### PR TITLE
spectum.c: tiny update [MetalliC]

### DIFF
--- a/src/mess/drivers/pentagon.c
+++ b/src/mess/drivers/pentagon.c
@@ -234,6 +234,14 @@ static MACHINE_CONFIG_DERIVED_CLASS( pentagon, spectrum_128, pentagon_state )
 	MCFG_BETA_DISK_ADD(BETA_DISK_TAG)
 	MCFG_GFXDECODE_MODIFY("gfxdecode", pentagon)
 
+	MCFG_SPEAKER_STANDARD_STEREO("lspeaker", "rspeaker")
+
+	MCFG_SOUND_REPLACE("ay8912", AY8912, XTAL_14MHz / 8)
+	MCFG_SOUND_ROUTE(0, "lspeaker", 0.50)
+	MCFG_SOUND_ROUTE(1, "lspeaker", 0.25)
+	MCFG_SOUND_ROUTE(1, "rspeaker", 0.25)
+	MCFG_SOUND_ROUTE(2, "rspeaker", 0.50)
+
 	MCFG_SOFTWARE_LIST_ADD("cass_list_pen","pentagon_cass")
 MACHINE_CONFIG_END
 

--- a/src/mess/video/spectrum.c
+++ b/src/mess/video/spectrum.c
@@ -197,22 +197,17 @@ void spectrum_state::spectrum_UpdateBorderBitmap()
 
 		do
 		{
-			if (m_previous_border_y < height)
-			{
-				UINT16* bm = &m_border_bitmap.pix16(m_previous_border_y);
-
-				if (m_previous_border_x < width)
-					bm[m_previous_border_x] = colour;
-			}
+			UINT16* bm = &m_border_bitmap.pix16(m_previous_border_y);
+			bm[m_previous_border_x] = colour;
 
 			m_previous_border_x += 1;
 
-			if (m_previous_border_x > width)
+			if (m_previous_border_x >= width)
 			{
 				m_previous_border_x = 0;
 				m_previous_border_y += 1;
 
-				if (m_previous_border_y > height)
+				if (m_previous_border_y >= height)
 				{
 					m_previous_border_y = 0;
 				}


### PR DESCRIPTION
spectum.c: remove weird loop range at border drawing, make Pentagon stereo, correct its AY clock
