### PR TITLE
Update h8_adc.c

### DIFF
--- a/src/emu/cpu/h8/h8_adc.c
+++ b/src/emu/cpu/h8/h8_adc.c
@@ -496,4 +496,5 @@ void h8_adc_2655_device::do_buffering(int buffer)
 int h8_adc_2655_device::get_channel_index(int count)
 {
 	abort();
+	return 0;
 }


### PR DESCRIPTION
Fixes this on MSVC2010:

src\emu\cpu\h8\h8_adc.c(499) : error C4716: 'h8_adc_2655_device::get_channel_index' : must return a value
make: **\* [obj/vwindowsd/emu/cpu/h8/h8_adc.o] Error 2
