### PR TITLE
Update upd7220.c

### DIFF
--- a/src/emu/video/upd7220.c
+++ b/src/emu/video/upd7220.c
@@ -1587,7 +1587,7 @@ void upd7220_device::update_graphics(bitmap_rgb32 &bitmap, const rectangle &clip
 				addr = ((sad << 1) & 0x3ffff) + (y * m_pitch * 2);
 
 				if (!m_display_cb.isnull())
-					draw_graphics_line(bitmap, addr, y + (bsy >> !im), wd);
+					draw_graphics_line(bitmap, addr, y + (bsy >> (int)(!im)), wd);
 			}
 		}
 		else


### PR DESCRIPTION
src\emu\video\upd7220.c(1590) : error C2220: warning treated as error - no 'object' file generated
src\emu\video\upd7220.c(1590) : warning C4804: '>>' : unsafe use of type 'bool' in operation
make: **\* [obj/vwindowsd/emu/video/upd7220.o] Error 2

Just added a cast, something better obviously needs to be done?
