### PR TITLE
(MESS) ti85: improve support for the TI-84 Plus

### DIFF
--- a/src/mess/drivers/ti85.c
+++ b/src/mess/drivers/ti85.c
@@ -1,5 +1,6 @@
 /***************************************************************************
 TI-85 and TI-86 drivers by Krzysztof Strzecha
+TI-83 Plus, TI-84 Plus, and Siliver Edition support by Jon Sturm
 
 Notes:
 1. After start TI-85 waits for ON key interrupt, so press ON key to start
@@ -339,6 +340,12 @@ ADDRESS_MAP_END
 
 static ADDRESS_MAP_START( ti83pse_banked_mem , AS_PROGRAM, 8, ti85_state )
 	AM_RANGE(0x0000, 0x1fffff) AM_DEVREADWRITE("flash", intelfsh8_device, read, write)
+	AM_RANGE(0x200000, 0x21BFFF) AM_RAM AM_SHARE("nvram")
+ADDRESS_MAP_END
+
+
+static ADDRESS_MAP_START( ti84p_banked_mem , AS_PROGRAM, 8, ti85_state )
+	AM_RANGE(0x0000, 0xfffff) AM_DEVREADWRITE("flash", intelfsh8_device, read, write)
 	AM_RANGE(0x200000, 0x21BFFF) AM_RAM AM_SHARE("nvram")
 ADDRESS_MAP_END
 
@@ -730,17 +737,31 @@ static MACHINE_CONFIG_DERIVED( ti83pse, ti83p )
 	MCFG_DEVICE_PROGRAM_MAP(ti83pse_banked_mem)
 
 	MCFG_MACHINE_START_OVERRIDE(ti85_state, ti83pse )
-	MCFG_MACHINE_RESET_OVERRIDE(ti85_state, ti83pse )
 	MCFG_DEVICE_REPLACE("flash", FUJITSU_29F160T, 0)
 
 	//MCFG_TI83PSERIAL_ADD( "tiserial" )
 MACHINE_CONFIG_END
 
 static MACHINE_CONFIG_DERIVED( ti84p, ti83pse )
-	MCFG_DEVICE_REPLACE("flash", AMD_29F800T , 0)
-	//MCFG_TI83PSERIAL_ADD( "tiserial" )
+    MCFG_DEVICE_MODIFY("membank1")
+	MCFG_DEVICE_PROGRAM_MAP(ti84p_banked_mem)
+
+	MCFG_DEVICE_MODIFY("membank2")
+	MCFG_DEVICE_PROGRAM_MAP(ti84p_banked_mem)
+
+	MCFG_DEVICE_MODIFY("membank3")
+	MCFG_DEVICE_PROGRAM_MAP(ti84p_banked_mem)
+
+	MCFG_DEVICE_MODIFY("membank4")
+	MCFG_DEVICE_PROGRAM_MAP(ti84p_banked_mem)
+
+	MCFG_MACHINE_START_OVERRIDE(ti85_state, ti84p )
+    MCFG_DEVICE_REPLACE("flash", AMD_29F800T , 0)
 MACHINE_CONFIG_END
 
+static MACHINE_CONFIG_DERIVED( ti84pse, ti83pse )
+	MCFG_MACHINE_START_OVERRIDE(ti85_state, ti84pse )
+MACHINE_CONFIG_END
 
 static MACHINE_CONFIG_DERIVED( ti73, ti83p )
 	//MCFG_DEVICE_REMOVE( "tiserial" )
@@ -888,12 +909,11 @@ ROM_START (ti84pse)
 ROM_END
 
 ROM_START (ti84p)
-	ROM_REGION (0x100000, "flash",0)
-	ROM_DEFAULT_BIOS("v241")
-	ROM_SYSTEM_BIOS( 0, "v241", "V 2.41" )
-	ROMX_LOAD( "ti84v241.bin", 0x00000, 0x100000, CRC(5758db36) SHA1(7daa4f22e9b5dc8a1cc8fd31bceece9fa8b43515), ROM_BIOS(1) )
+    ROM_REGION (0x100000, "flash",0)
+    ROM_DEFAULT_BIOS("b100v255mp")
+    ROM_SYSTEM_BIOS( 0, "b100v255mp", "Boot 1.00 OS V 2.55MP" )
+    ROMX_LOAD( "ti84pb100v255mp.bin", 0x00000, 0x100000, CRC(4AF31251) SHA1(8F67269346644B87E7CD0F353F5F4030E787CF57), ROM_BIOS(1) )
 ROM_END
-
 
 /*    YEAR  NAME        PARENT  COMPAT  MACHINE INPUT   INIT   COMPANY                 FULLNAME                        FLAGS */
 COMP( 1990, ti81,       0,      0,      ti81,   ti81, driver_device,   0,     "Texas Instruments",    "TI-81",                        GAME_NO_SOUND )
@@ -906,4 +926,4 @@ COMP( 1998, ti73,       0,      0,      ti73,   ti82, driver_device,   0,     "T
 COMP( 1999, ti83p,      0,      0,      ti83p,  ti82, driver_device,   0,     "Texas Instruments",    "TI-83 Plus",                   GAME_NO_SOUND )
 COMP( 2001, ti83pse,    0,      0,      ti83pse,   ti82, driver_device,   0,     "Texas Instruments",    "TI-83 Plus Silver Edition", GAME_NO_SOUND )
 COMP( 2004, ti84p,      0,      0,      ti84p,   ti82, driver_device,   0,   "Texas Instruments",    "TI-84 Plus",                    GAME_NO_SOUND )
-COMP( 2004, ti84pse,    0,      0,      ti83pse,   ti82, driver_device,   0,     "Texas Instruments",    "TI-84 Plus Silver Edition", GAME_NO_SOUND )
+COMP( 2004, ti84pse,    0,      0,      ti84pse,   ti82, driver_device,   0,     "Texas Instruments",    "TI-84 Plus Silver Edition", GAME_NO_SOUND )

--- a/src/mess/includes/ti85.h
+++ b/src/mess/includes/ti85.h
@@ -16,7 +16,7 @@
 
 
 /* model */
-typedef enum {
+enum ti85_model {
 	TI81,
 	TI81v2,
 	TI82,
@@ -27,7 +27,7 @@ typedef enum {
 	TI83PSE,
 	TI84P,
 	TI84PSE
-} ti85_models;
+};
 
 typedef struct
 {
@@ -73,6 +73,8 @@ public:
 	optional_device<address_map_bank_device> m_membank2;
 	optional_device<address_map_bank_device> m_membank3;
 	optional_device<address_map_bank_device> m_membank4;
+
+	ti85_model m_model;
 
 	UINT8 m_LCD_memory_base;
 	UINT8 m_LCD_contrast;
@@ -167,11 +169,14 @@ public:
 	DECLARE_PALETTE_INIT(ti85);
 	DECLARE_MACHINE_RESET(ti85);
 	DECLARE_MACHINE_RESET(ti83p);
-	DECLARE_MACHINE_RESET(ti83pse);
 	DECLARE_PALETTE_INIT(ti82);
 	DECLARE_MACHINE_START(ti86);
 	DECLARE_MACHINE_START(ti83p);
 	DECLARE_MACHINE_START(ti83pse);
+	DECLARE_MACHINE_START(ti84pse);
+	DECLARE_MACHINE_START(ti84p);
+	void ti8xpse_init_common();
+
 	UINT32 screen_update_ti85(screen_device &screen, bitmap_ind16 &bitmap, const rectangle &cliprect);
 	TIMER_CALLBACK_MEMBER(ti85_timer_callback);
 	TIMER_CALLBACK_MEMBER(ti83_timer1_callback);

--- a/src/mess/mess.lst
+++ b/src/mess/mess.lst
@@ -1067,8 +1067,9 @@ ti83      // 1996 TI-83 (Z80 6 MHz)
 ti86      // 1997 TI-86 (Z80 6 MHz)
 ti83p    // 1999 TI-83 Plus (Z80 6 MHz)
 ti83pse   // 2001 TI-83 Plus Silver Edition
-//ti84p  // 2004 TI-84 Plus
+ti84p  // 2004 TI-84 Plus
 ti84pse   // 2004 TI-84 Plus Silver Edition
+//ti84cse // 2013 TI-84 Plus C Silver Edition (color screen)
 ti89      // 1998 TI-89
 ti92      // 1995 TI-92
 ti92p    // 1999 TI-92 Plus


### PR DESCRIPTION
Adds known dump of TI-84 Plus which has been sent to a mess dev and supports
enough asic functionality that it boots and runs.

Fixed up model enum to match style from the apple2 and used it to add support
for where the ti84p differs from the ti84pse.

Consolidated code for the 15Mhz calculators so there is less duplicated code
between the ti83pse, ti84pse and ti84 support code.
