### PR TITLE
Convert to UTF-8.

### DIFF
--- a/hash/vsmile_cd.xml
+++ b/hash/vsmile_cd.xml
@@ -17,8 +17,8 @@ Language:
 ********7 = Spain
 
 80-093000(US)   | The Crystal Ball Adventures
-80-093004(GE)   | Das zauberhafte Märchenabenteuer
-80-093005(FR)   | L'aventure enchantée
+80-093004(GE)   | Das zauberhafte MÃ¤rchenabenteuer
+80-093005(FR)   | L'aventure enchantÃ©e
 80-093007(SP)   | El Castillo de las Princesas
 -
 80-093020(US)   | The Incredibles - Mission Incredible
@@ -31,7 +31,7 @@ Language:
 -
 80-093060(US)   | The Amazing Spider-Man - Countdown to Doom
 80-093064(GE)   | Spiderman - Angriff der Superschurken
-80-093065(FR)   | Spider-Man - Course-poursuite à Manhattan
+80-093065(FR)   | Spider-Man - Course-poursuite Ã  Manhattan
 80-093067(SP)   | El Asombroso Spider-Man - Persecucion en la Cuidad
 -
 80-093080(US)   | Scooby-Doo! - Ancient Adventure
@@ -41,12 +41,12 @@ Language:
 80-093087(SP)   | Scooby-Doo - Viaje al Pasdao
 -
 80-093100(US)   | Cars - In The Fast Lane
-80-093104(GE)   | Cars - Auf der Überholspur
+80-093104(GE)   | Cars - Auf der Ãœberholspur
 80-093105(FR)   | Cars - A Fond la Caisse!
 80-093107(SP)   | Cars - El Carril Rapido
 -
 80-093120(US)   | Wacky Race on Jumpin' Bean Island
-80-093124(GE)   | Das verrückte Rennen auf der Hüpf-Bohnen-Insel
+80-093124(GE)   | Das verrÃ¼ckte Rennen auf der HÃ¼pf-Bohnen-Insel
 80-093127(SP)   | Carrera Loca - En La Isla de las Vainas Fritas  (real# unknown)
 -
 80-093140(US)   | Shrek The Third - The Search for Arthur


### PR DESCRIPTION
The comments are not valid ISO-8559-1, which makes this file fail with strict parsers.
