### PR TITLE
Allow sound output if 8253 is never programmed, i.e. all output is done ...

### DIFF
--- a/src/emu/bus/lpci/southbridge.c
+++ b/src/emu/bus/lpci/southbridge.c
@@ -203,7 +203,7 @@ void southbridge_device::device_start()
 void southbridge_device::device_reset()
 {
 	m_at_spkrdata = 0;
-	m_pit_out2 = 0;
+	m_pit_out2 = 1;
 	m_dma_channel = -1;
 	m_cur_eop = false;
 	m_nmi_enabled = 0;

--- a/src/mame/drivers/pcxt.c
+++ b/src/mame/drivers/pcxt.c
@@ -685,7 +685,7 @@ void pcxt_state::machine_reset()
 	m_lastvalue = -1;
 
 	m_pc_spkrdata = 0;
-	m_pit_out2 = 0;
+	m_pit_out2 = 1;
 	m_wss2_data = 0;
 	m_speaker->level_w(0);
 }

--- a/src/mess/drivers/pasogo.c
+++ b/src/mess/drivers/pasogo.c
@@ -688,7 +688,7 @@ void pasogo_state::machine_reset()
 	m_u73_q2 = 0;
 	m_out1 = 2; // initial state of pit output is undefined
 	m_pc_spkrdata = 0;
-	m_pit_out2 = 0;
+	m_pit_out2 = 1;
 	m_dma_channel = -1;
 	m_cur_eop = false;
 }

--- a/src/mess/drivers/pc1512.c
+++ b/src/mess/drivers/pc1512.c
@@ -1131,6 +1131,7 @@ void pc1512_state::machine_reset()
 	m_nmi_enable = 0;
 	m_toggle = 0;
 	m_kb_bits = 0;
+	m_pit2 = 1;
 
 	m_lpen = 0;
 	m_blink = 0;

--- a/src/mess/machine/at.c
+++ b/src/mess/machine/at.c
@@ -300,7 +300,7 @@ MACHINE_START_MEMBER(at_state,at)
 MACHINE_RESET_MEMBER(at_state,at)
 {
 	m_at_spkrdata = 0;
-	m_pit_out2 = 0;
+	m_pit_out2 = 1;
 	m_dma_channel = -1;
 	m_cur_eop = false;
 }

--- a/src/mess/machine/genpc.c
+++ b/src/mess/machine/genpc.c
@@ -572,7 +572,7 @@ void ibm5160_mb_device::device_reset()
 	m_u73_q2 = 0;
 	m_out1 = 2; // initial state of pit output is undefined
 	m_pc_spkrdata = 0;
-	m_pit_out2 = 0;
+	m_pit_out2 = 1;
 	m_dma_channel = -1;
 	m_cur_eop = false;
 	memset(m_dma_offset,0,sizeof(m_dma_offset));


### PR DESCRIPTION
...by modulating speaker output line.   This was done earlier (but only in src/mess/machine/pc.c) to fix sound in Arkanoid.
