### PR TITLE
upd7810: use intermediate flip flops for extended timer/event counter

### DIFF
--- a/src/emu/cpu/upd7810/upd7810.h
+++ b/src/emu/cpu/upd7810/upd7810.h
@@ -24,7 +24,8 @@ enum
 	UPD7810_ANM, UPD7810_MKL, UPD7810_MKH, UPD7810_ZCM,
 	UPD7810_TXB, UPD7810_RXB, UPD7810_CR0, UPD7810_CR1, UPD7810_CR2, UPD7810_CR3,
 	UPD7810_AN0, UPD7810_AN1, UPD7810_AN2, UPD7810_AN3, UPD7810_AN4, UPD7810_AN5, UPD7810_AN6, UPD7810_AN7,
-	UPD7810_TXD, UPD7810_RXD, UPD7810_SCK, UPD7810_TI, UPD7810_TO, UPD7810_CI, UPD7810_CO0, UPD7810_CO1
+	UPD7810_TXD, UPD7810_RXD, UPD7810_SCK, UPD7810_TI, UPD7810_TO, UPD7810_CI, UPD7810_CO0, UPD7810_CO1,
+	UPD7810_LV0, UPD7810_LV1
 };
 
 /* port numbers for PA,PB,PC,PD and PF */
@@ -180,6 +181,9 @@ protected:
 	void upd7810_handle_timer0(int cycles, int clkdiv);
 	void upd7810_handle_timer1(int cycles, int clkdiv);
 
+	void upd7810_co0_output_change();
+	void upd7810_co1_output_change();
+
 	devcb_write_line  m_to_func;
 	devcb_write_line  m_co0_func;
 	devcb_write_line  m_co1_func;
@@ -300,6 +304,8 @@ protected:
 	UINT8   m_ti;
 	UINT8   m_to;
 	UINT8   m_ci;
+	UINT8   m_lv0;    /* level flip flop for co0 */
+	UINT8   m_lv1;    /* level flip flop for co1 */
 	UINT8   m_co0;
 	UINT8   m_co1;
 	UINT16  m_irr;    /* interrupt request register */

--- a/src/emu/cpu/upd7810/upd7810_macros.h
+++ b/src/emu/cpu/upd7810/upd7810_macros.h
@@ -89,6 +89,8 @@
 #define TI      m_ti
 #define TO      m_to
 #define CI      m_ci
+#define LV0     m_lv0
+#define LV1     m_lv1
 #define CO0     m_co0
 #define CO1     m_co1
 


### PR DESCRIPTION
The extended timer/event counter uses intermediate flip flops (LV0 and
LV1) before writing the output to CO0 and CO1.

The introduction of LV0/LV1 addresses three issues:
- Level inversion occurs after the flip flop is output, not before;
- The intermediate flip flop can be altered without affecting the
  output of CO0/CO1;
- upd7810_write_EOM() didn't work properly when the level inversion
  bit was set along other bits.
