### PR TITLE
luaengine: add romname() and pause()/unpause()

### DIFF
--- a/src/emu/luaengine.c
+++ b/src/emu/luaengine.c
@@ -217,6 +217,22 @@ int lua_engine::l_emu_romname(lua_State *L)
 }
 
 //-------------------------------------------------
+//  emu_pause/emu_unpause - pause/unpause game
+//-------------------------------------------------
+
+int lua_engine::l_emu_pause(lua_State *L)
+{
+	luaThis->machine().pause();
+	return 0;
+}
+
+int lua_engine::l_emu_unpause(lua_State *L)
+{
+	luaThis->machine().resume();
+	return 0;
+}
+
+//-------------------------------------------------
 //  emu_keypost - post keys to natural keyboard
 //-------------------------------------------------
 
@@ -514,6 +530,8 @@ void lua_engine::initialize()
 			.addCFunction ("after",       l_emu_after )
 			.addCFunction ("exit",        l_emu_exit )
 			.addCFunction ("start",       l_emu_start )
+			.addCFunction ("pause",       l_emu_pause )
+			.addCFunction ("unpause",     l_emu_unpause )
 			.beginClass <machine_manager> ("manager")
 				.addFunction ("machine", &machine_manager::machine)
 				.addFunction ("options", &machine_manager::options)

--- a/src/emu/luaengine.h
+++ b/src/emu/luaengine.h
@@ -84,6 +84,8 @@ private:
 	static int l_emu_hook_output(lua_State *L);
 	static int l_emu_exit(lua_State *L);
 	static int l_emu_start(lua_State *L);
+	static int l_emu_pause(lua_State *L);
+	static int l_emu_unpause(lua_State *L);
 
 	void resume(void *L, INT32 param);
 	void report_errors(int status);


### PR DESCRIPTION
Hi,
this is a really small PR to add the following methods to MAME lua API:
- emu.romname()
- emu.pause()
- emu.unpause()

These are mostly being added here in order to start closing the gap with [mame-rr lua interface](https://code.google.com/p/mame-rr/wiki/LuaScriptingFunctions).

Signed-off-by: Luca Bruno lucab@debian.org
