### PR TITLE
luaengine: add HUD-like capabilities

### DIFF
--- a/src/emu/luaengine.h
+++ b/src/emu/luaengine.h
@@ -35,6 +35,7 @@ public:
 
 	void serve_lua();
 	void periodic_check();
+	bool frame_hook();
 
 	void resume(lua_State *L, int nparam = 0, lua_State *root = NULL);
 	void set_machine(running_machine *machine) { m_machine = machine; update_machine(); }
@@ -60,6 +61,8 @@ private:
 	hook hook_output_cb;
 	bool output_notifier_set;
 
+	hook frame_hook_cb;
+
 	static lua_engine*  luaThis;
 
 	std::map<lua_State *, std::pair<lua_State *, int> > thread_registry;
@@ -74,6 +77,7 @@ private:
 	int emu_after(lua_State *L);
 	int emu_wait(lua_State *L);
 	void emu_hook_output(lua_State *L);
+	void emu_hook_frame(lua_State *L);
 
 	static int l_ioport_write(lua_State *L);
 
@@ -91,6 +95,7 @@ private:
 	static int l_emu_start(lua_State *L);
 	static int l_emu_pause(lua_State *L);
 	static int l_emu_unpause(lua_State *L);
+	static int l_emu_hook_frame(lua_State *L);
 
 	// "gui" namespace
 	static int l_gui_screen_width(lua_State *L);

--- a/src/emu/video.c
+++ b/src/emu/video.c
@@ -655,6 +655,9 @@ bool video_manager::finish_screen_updates()
 		if (screen->update_quads())
 			anything_changed = true;
 
+	// draw HUD from LUA callback (if any)
+	anything_changed |= machine().manager().lua()->frame_hook();
+
 	// update our movie recording and burn-in state
 	if (!machine().paused())
 	{


### PR DESCRIPTION
These commits add several methods to let LUA scripts register a callback
to be invoked before rendering each frame.
This callback typically makes use of the provided gui.\* methods to draw
custom graphics on top of each frame.

The idea is to let LUA script provide HUD-like features, mostly used for 
trainings and TAS runs development.

Signed-off-by: Luca Bruno lucab@debian.org
