### PR TITLE
Use consistent logical ID for joystick registration log

### DIFF
--- a/src/osd/sdl/input.c
+++ b/src/osd/sdl/input.c
@@ -757,7 +757,7 @@ static void sdlinput_register_joysticks(running_machine &machine)
 
 		osd_printf_verbose("Joystick: %s\n", devinfo->name.cstr());
 		osd_printf_verbose("Joystick:   ...  %d axes, %d buttons %d hats %d balls\n", SDL_JoystickNumAxes(joy), SDL_JoystickNumButtons(joy), SDL_JoystickNumHats(joy), SDL_JoystickNumBalls(joy));
-		osd_printf_verbose("Joystick:   ...  Physical id %d mapped to logical id %d\n", physical_stick, stick);
+		osd_printf_verbose("Joystick:   ...  Physical id %d mapped to logical id %d\n", physical_stick, stick + 1);
 
 		// loop over all axes
 		for (axis = 0; axis < SDL_JoystickNumAxes(joy); axis++)


### PR DESCRIPTION
Just came across with an inconsistent numbering of logical IDs showed up for joystick registration log. It would be trivial but still confusing.

```
Joystick mapping: Logical id 1: USB,2-axis 8-button gamepad
Joystick mapping: Logical id 2: STICK A
Joystick: Start initialization
Input: Adding Joy #0: USB,2-axis 8-button gamepad
Joystick: USB,2-axis 8-button gamepad
Joystick:   ...  2 axes, 8 buttons 0 hats 0 balls
Joystick:   ...  Physical id 0 mapped to logical id 0
Input: Adding Joy #1: STICK A
Joystick: STICK A
Joystick:   ...  4 axes, 13 buttons 1 hats 0 balls
Joystick:   ...  Physical id 1 mapped to logical id 1
```

It's found while reporting [another SDL issue](https://bugzilla.libsdl.org/show_bug.cgi?id=2822) about registering joysticks on OS X.
