### PR TITLE
Do not check gl_lib() without OpenGL support

### DIFF
--- a/src/osd/sdl/draw13.c
+++ b/src/osd/sdl/draw13.c
@@ -479,8 +479,12 @@ int drawsdl2_init(running_machine &machine, sdl_draw_info *callbacks)
 
 	expand_copy_info(blit_info_default);
 
+#if USE_OPENGL
 	// Load the GL library now - else MT will fail
 	stemp = downcast<sdl_options &>(machine.options()).gl_lib();
+#else
+	stemp = NULL;
+#endif
 	if (stemp != NULL && strcmp(stemp, SDLOPTVAL_AUTO) == 0)
 		stemp = NULL;
 


### PR DESCRIPTION
The gl_lib() function is not defined if we do not #USE_OPENGL,
as can be seen in osdsdl.h. Building with NO_OPENGL=1 then
breaks, unless we add this conditional #ifdef.

Signed-off-by: Tarnyko tarnyko@tarnyko.net
