### PR TITLE
luaengine: add HUD-like capabilities

### DIFF
--- a/src/emu/luaengine.h
+++ b/src/emu/luaengine.h
@@ -44,6 +44,7 @@ public:
 
 	void serve_lua();
 	void periodic_check();
+	bool frame_hook();
 
 	void resume(lua_State *L, int nparam = 0, lua_State *root = NULL);
 	void set_machine(running_machine *machine) { m_machine = machine; update_machine(); }
@@ -68,6 +69,8 @@ private:
 	hook hook_output_cb;
 	bool output_notifier_set;
 
+	hook hook_frame_cb;
+
 	static lua_engine*  luaThis;
 
 	std::map<lua_State *, std::pair<lua_State *, int> > thread_registry;
@@ -82,6 +85,7 @@ private:
 	int emu_after(lua_State *L);
 	int emu_wait(lua_State *L);
 	void emu_hook_output(lua_State *L);
+	void emu_set_hook(lua_State *L);
 
 	static int l_ioport_write(lua_State *L);
 	static int l_emu_after(lua_State *L);
@@ -97,6 +101,7 @@ private:
 	static int l_emu_start(lua_State *L);
 	static int l_emu_pause(lua_State *L);
 	static int l_emu_unpause(lua_State *L);
+	static int l_emu_set_hook(lua_State *L);
 
 	// "emu.machine" namespace
 	static luabridge::LuaRef l_machine_get_devices(const running_machine *r);

--- a/src/emu/luaengine.h
+++ b/src/emu/luaengine.h
@@ -105,6 +105,12 @@ private:
 	struct lua_addr_space {
 		template<typename T> int l_mem_read(lua_State *L);
 	};
+	static luabridge::LuaRef l_machine_get_screens(const running_machine *r);
+	struct lua_screen {
+		int l_draw_box(lua_State *L);
+		int l_draw_line(lua_State *L);
+		int l_draw_text(lua_State *L);
+	};
 
 	void resume(void *L, INT32 param);
 	void report_errors(int status);

--- a/src/emu/video.c
+++ b/src/emu/video.c
@@ -655,6 +655,9 @@ bool video_manager::finish_screen_updates()
 		if (screen->update_quads())
 			anything_changed = true;
 
+	// draw HUD from LUA callback (if any)
+	anything_changed |= machine().manager().lua()->frame_hook();
+
 	// update our movie recording and burn-in state
 	if (!machine().paused())
 	{


### PR DESCRIPTION
These commits add a way to let LUA scripts register a callback
to be invoked before rendering each frame.
This callback typically makes use of other provided methods to draw
custom graphics on top of each frame.

The idea is to let LUA script provide HUD-like features, mostly used for
trainings and TAS runs development.

Signed-off-by: Luca Bruno lucab@debian.org