### PR TITLE
Fix linking for Windows SDL cross-compilations

### DIFF
--- a/src/osd/sdl/sdl.mak
+++ b/src/osd/sdl/sdl.mak
@@ -657,8 +657,8 @@ MOC = @moc
 endif
 
 ifeq ($(SDL_LIBVER),sdl2)
-LIBS += -lSDL2 -lImm32 -lversion -lole32 -loleaut32 -static
-BASELIBS += -lImm32 -lversion -lole32 -loleaut32 -static
+LIBS += -lSDL2 -limm32 -lversion -lole32 -loleaut32 -lws2_32 -static
+BASELIBS += -limm32 -lversion -lole32 -loleaut32 -lws2_32 -static
 else
 LIBS += -lSDL -static
 endif


### PR DESCRIPTION
- Library names must be lower-case when cross-compiling from Linux (-limm32 instead of -lImm32)
- ntohl() needs -lws2_32