### PR TITLE
added output so artwork can display current gear settings

### DIFF
--- a/src/mame/drivers/firetrk.c
+++ b/src/mame/drivers/firetrk.c
@@ -42,7 +42,10 @@ INPUT_CHANGED_MEMBER(firetrk_state::firetrk_horn_changed)
 INPUT_CHANGED_MEMBER(firetrk_state::gear_changed)
 {
 	if (newval)
+	{
 		m_gear = (FPTR)param;
+		output_set_value("P1gear", m_gear+1);
+	}
 }
 
 


### PR DESCRIPTION
m_gear+1 is so output of gears will start at 1 instead of 0, to be consistent with other Atari 4-speed shifter games (drag race & sprint series).  Internally gear still starts at 0 (though perhaps that should be changed).