### PR TITLE
Update phozons manufacturer (nw)

### DIFF
--- a/src/mame/drivers/mappy.c
+++ b/src/mame/drivers/mappy.c
@@ -2462,7 +2462,7 @@ GAME( 1984, grobda3,  grobda,   grobda,   grobda, mappy_state,   grobda,   ROT90
 
 /* 3x6809, static tilemap, 2bpp sprites (Gaplus type) */
 GAME( 1983, phozon,   0,        phozon,   phozon, mappy_state,   phozon,        ROT90, "Namco", "Phozon (Japan)", GAME_SUPPORTS_SAVE )
-GAME( 1983, phozons,  phozon,   phozon,   phozon, mappy_state,   phozon,        ROT90, "bootleg? (Sidam)", "Phozon (Sidam)", GAME_SUPPORTS_SAVE )
+GAME( 1983, phozons,  phozon,   phozon,   phozon, mappy_state,   phozon,        ROT90, "Namco (Sidam license)", "Phozon (Sidam)", GAME_SUPPORTS_SAVE )
 
 /* 2x6809, scroling tilemap, 4bpp sprites (Super Pacman type) */
 GAME( 1983, mappy,    0,        mappy,    mappy, mappy_state,   mappy,        ROT90, "Namco", "Mappy (US)", GAME_SUPPORTS_SAVE )


### PR DESCRIPTION
According to tilt.it (http://www.tilt.it/deb/sidam-en.html), this one was licensed. Claim holds up given that there's a Super Pac-Man licensed to Bally France that was manufactured by Sidam (http://www.gamoover.net/Forums/index.php?topic=29916.0)