### PR TITLE
add Fighting Vipers 2 key

### DIFF
--- a/src/mame/drivers/naomi.c
+++ b/src/mame/drivers/naomi.c
@@ -332,7 +332,7 @@ Mars TV                                         840-0025C    22993   15 (64Mb)  
 OutTrigger                                      840-0017C    22163   19 (64Mb)   ?           315-6213  317-0266-COM   requires regular 837-13551 and 837-13938 rotary JVS boards, and special panel
 Power Stone                                     841-0001C    21597    8 (64Mb)   present     315-6213  317-5046-COM   joystick + 3 buttons
 Power Stone 2                                   841-0008C    23127    9 (64Mb)   present     315-6213  317-5054-COM   joystick + 3 buttons
-Puyo Puyo Da!                                   841-0006C    22206   20 (64Mb)   ?           315-6213  ?
+Puyo Puyo Da!                                   841-0006C    22206   20 (64Mb)   ?           315-6213  317-5052-COM
 Ring Out 4x4                                    840-0004C    21779   10 (64Mb)   present     315-6213  317-0250-COM   requires 2 JVS boards
 Samba de Amigo (Rev B)                          840-0020C    22966B  16 (64Mb)   present     315-6213  317-0270-COM   will boot but requires special controller to play it
 Sega Marine Fishing                             840-0027C    22221   10 (64Mb)   ?           315-6213  not present    ROM 3&4 not present. Requires 837-13844 JVS IO with all DIPSW Off and fishing controller
@@ -341,7 +341,7 @@ Sega Strike Fighter (Rev A, set 2)              840-0035C    23786A  20 (64Mb)  
 Sega Tetris                                     840-0018C    22909    6 (64Mb)   present     315-6213  317-0268-COM
 Slashout                                        840-0041C    23341   17 (64Mb)   ?           315-6213  317-0286-COM   joystick + 4 buttons
 Spawn In the Demon's Hand (Rev B)               841-0005C    22977B  10 (64Mb)   ?           315-6213  317-5051-COM   joystick + 4 buttons
-Super Major League '99                          840-0012C    22059   21 (64Mb)   ?           315-6213  ?
+Super Major League '99                          840-0012C    22059   21 (64Mb)   ?           315-6213  317-0259-COM
 The Typing of the Dead (Rev A)                  840-0026C    23021A  20 (64Mb)   present     315-6213  not present
 Touch de UNO! / Unou Nouryoku Check Machine     840-0008C    22073    4 (64Mb)   present     315-6213  317-0255-JPN   requires 837-13844 JVS IO with DIPSW 5 On, ELO AccuTouch-compatible touch screen controller and special printer.
 Toy Fighter / Waffupu                           840-0011C    22035   10 (64Mb)   present     315-6212  317-0257-COM   joystick + 3 buttons
@@ -512,7 +512,7 @@ Derby Owners Club II (Rev B)                    840-0083C  22306B  11 (128Mb)  3
 Derby Owners Club World Edition (Rev C)         840-0088C  22336C   7 (128Mb)  315-6319A  315-6213  not present
 Derby Owners Club World Edition (Rev D)         840-0088C  22336D   7 (128Mb)  315-6319A  315-6213  not present   2 MaskROM are different from Rev C
 Giga Wing 2                                     841-0014C  22270    5 (128Mb)  315-6319A  315-6213  317-5064-COM
-Mobile Suit Gundam: Federation Vs. Zeon         841-0017C  23638   10 (128Mb)  315-6319A  315-6213  ?
+Mobile Suit Gundam: Federation Vs. Zeon         841-0017C  23638   10 (128Mb)  315-6319A  315-6213  317-5070-COM
 Moero Justice Gakuen / Project Justice (Rev A)  841-0015C  23548A  11 (128Mb)  315-6319A  315-6213  317-5065-COM
 MushiKing - The King Of Beetle 2K5 1ST          840-0158C  24286    7 (128Mb)  315-6319A  315-6213  not present   requires 610-0669 barcode reader
 Oinori-daimyoujin Matsuri                       840-0126B  24053    5 (128Mb)  315-6319A  315-6213  not present   requires 837-14274 "G2 EXPANSION BD" (similar to hopper 837-14381 but with ARC NET chip)
@@ -521,7 +521,7 @@ Star Horse (big screens)                        840-0054C  23625    4 (128Mb)  3
 Star Horse (satellite)                          840-0056C  23627    6 (128Mb)* 315-6319   315-6213  not present   * +1 (64Mb), requires 837-13785 ARCNET&IO BD
 Star Horse Progress (satellite) (Rev A)         840-0123C  24122A   7 (128Mb)  315-6319A  315-6213  not present   requires 837-13785 ARCNET&IO BD
 The King of Route 66 (Rev A)                    840-0087C  23819A  10 (128Mb)  315-6319A  315-6213  not present
-Virtua Fighter 4                                840-0080C  23785   11 (128Mb)  ?          ?         ?
+Virtua Fighter 4                                840-0080C  23785   11 (128Mb)  ?          ?         317-0324-COM
 Virtua Striker 3                                840-0061C  23663   11 (128Mb)  315-6319A  315-6213  317-0310-COM
 Virtua Striker 3 (Rev B)                        840-0061C  23663B  11 (128Mb)  315-6319A  315-6213  317-0310-COM
 Wave Runner GP                                  840-0064C  24059    6 (128Mb)  315-6319A  315-6213  not present

--- a/src/mame/machine/315-5881_helper.c
+++ b/src/mame/machine/315-5881_helper.c
@@ -137,13 +137,12 @@ static const struct game_keys keys_table[] =
 
 	{ "von2",            0x092a0e97 }, //             ????     317-0234-COM   Model 3
 	{ "von254g",         0x092a0e97 }, //             ????     317-0234-COM   Model 3
-	{ "fvipers2",        -1         }, //             ????     317-0235-COM   Model 3
+	{ "fvipers2",        0x09260e96 }, //             ????     317-0235-COM   Model 3
 	{ "vs298",           0x09234e96 }, //             ????     317-0237-COM   Model 3
 	{ "dirtdvls",        0x09290f17 }, //             ????     317-0238-COM   Model 3
 	{ "dirtdvlsa",       0x09290f17 }, //             ????     317-0238-COM   Model 3
 	{ "daytona2",        0x09250e16 }, //             ????     317-0239-COM   Model 3
 	{ "spikeout",        0x092f2b04 }, //             ????     317-0240-COM   Model 3
-	{ "spikeofe",        0x09236fc8 }, //             ????     317-0247-COM   Model 3
 	{ "swtrilgy",        0x11272a01 }, //             ????     317-0241-COM   Model 3
 	{ "swtrilgya",       0x11272a01 }, //             ????     317-0241-COM   Model 3
 	{ "oceanhun",        0x092b6a01 }, //             ????     317-0242-COM   Model 3
@@ -153,6 +152,7 @@ static const struct game_keys keys_table[] =
 	{ "vs2v991",         0x09222ac8 }, //             ????     317-0245-COM   Model 3
 	{ "vs299b",          0x09222ac8 }, //             ????     317-0245-COM   Model 3
 	{ "vs299a",          0x09222ac8 }, //             ????     317-0245-COM   Model 3
+	{ "spikeofe",        0x09236fc8 }, //             ????     317-0247-COM   Model 3
 	{ "eca",             0x0923aa91 }, //             ????     317-0265-COM   Model 3
 	{ "ecax",            0x0923aa91 }, //             ????     317-0265-COM   Model 3
 	{ "ecap",            0x0923aa91 }, //             ????     317-0265-COM   Model 3


### PR DESCRIPTION
note: it seems old security data feeding routines can be removed from model3.c now