### PR TITLE
Don't error out on an incorrect CRC for the GUI

### DIFF
--- a/src/emu/audit.c
+++ b/src/emu/audit.c
@@ -382,6 +382,7 @@ media_auditor::summary media_auditor::summarize(const char *name, astring *strin
 					else
 						string->catprintf("NOT FOUND (%s)\n", shared_device->shortname());
 				}
+				best_new_status = NOTFOUND;
 				break;
 
 			case audit_record::SUBSTATUS_NOT_FOUND_NODUMP:

--- a/src/emu/ui/selgame.c
+++ b/src/emu/ui/selgame.c
@@ -157,7 +157,7 @@ void ui_menu_select_game::inkey_select(const ui_menu_event *menu_event)
 		media_auditor::summary summary = auditor.audit_media(AUDIT_VALIDATE_FAST);
 
 		// if everything looks good, schedule the new driver
-		if (summary == media_auditor::CORRECT || summary == media_auditor::BEST_AVAILABLE || summary == media_auditor::NONE_NEEDED)
+		if (summary == media_auditor::CORRECT || summary == media_auditor::BEST_AVAILABLE || summary == media_auditor::NONE_NEEDED || summary == media_auditor::INCORRECT)
 		{
 			machine().manager().schedule_new_driver(*driver);
 			machine().schedule_hard_reset();


### PR DESCRIPTION
There's no reason for the GUI to bail on an incorrect CRC (especially with a misleading error message!), and the auditor should actually return NOTFOUND instead of INCORRECT when a ROM is not found.