### PR TITLE
*nix: Fixed linking tools against system libraries

### DIFF
--- a/makefile
+++ b/makefile
@@ -756,6 +756,7 @@ INCPATH += -I$(3RDPARTY)/zlib
 ZLIB = $(OBJ)/libz.a
 else
 LIBS += -lz
+BASELIBS += -lz
 ZLIB =
 endif
 
@@ -766,6 +767,7 @@ FLAC_LIB = $(OBJ)/libflac.a
 # $(OBJ)/libflac++.a
 else
 LIBS += -lFLAC
+BASELIBS += -lFLAC
 FLAC_LIB =
 endif
 


### PR DESCRIPTION
Useful for distro packager, this adds proper references to zlib and flac in the reduced set of libraries (BASELIBS).