### PR TITLE
3rdparty/mongoose: Fix build on NetBSD and possibly Solaris.

### DIFF
--- a/3rdparty/mongoose/mongoose.c
+++ b/3rdparty/mongoose/mongoose.c
@@ -48,7 +48,9 @@
 #define _INTEGRAL_MAX_BITS 64   // Enable _stati64() on Windows
 #define _CRT_SECURE_NO_WARNINGS // Disable deprecation warning in VS2005+
 #undef WIN32_LEAN_AND_MEAN      // Let windows.h always include winsock2.h
+#ifdef __Linux__
 #define _XOPEN_SOURCE 600       // For flockfile() on Linux
+#endif
 #define __STDC_FORMAT_MACROS    // <inttypes.h> wants this for C++
 #define __STDC_LIMIT_MACROS     // C++ wants that for INT64_MAX
 #ifndef _LARGEFILE_SOURCE


### PR DESCRIPTION
If _XOPEN_SOURCE is defined to 600, NetBSD does not provide strtoll
and other stuff.
Sent upstream as
https://github.com/cesanta/mongoose/pull/466
and committed as
https://github.com/cesanta/mongoose/commit/bef3f85ba88f3b2067f4b00c4cc4d290149957df

Signed-off-by: Thomas Klausner <wiz@NetBSD.org>