### PR TITLE
luaengine: fix font aspect-ratio in multi-screens games

### DIFF
--- a/src/emu/render.c
+++ b/src/emu/render.c
@@ -2574,26 +2574,41 @@ render_target *render_manager::target_by_index(int index) const
 //  fonts
 //-------------------------------------------------
 
-float render_manager::ui_aspect()
+float render_manager::ui_aspect(render_container *rc)
 {
-	int orient = orientation_add(m_ui_target->orientation(), m_ui_container->orientation());
+	int orient = 0;
+	float aspect = 1.0f;
 
-	// based on the orientation of the target, compute height/width or width/height
-	float aspect;
-	if (!(orient & ORIENTATION_SWAP_XY))
-		aspect = (float)m_ui_target->height() / (float)m_ui_target->width();
-	else
-		aspect = (float)m_ui_target->width() / (float)m_ui_target->height();
+	if (rc == m_ui_container || rc == NULL) {
+		// ui container, aggregated multi-screen target
 
-	// if we have a valid pixel aspect, apply that and return
-	if (m_ui_target->pixel_aspect() != 0.0f)
-		return aspect / m_ui_target->pixel_aspect();
+		orient = orientation_add(m_ui_target->orientation(), m_ui_container->orientation());
+		// based on the orientation of the target, compute height/width or width/height
+		if (!(orient & ORIENTATION_SWAP_XY))
+			   aspect = (float)m_ui_target->height() / (float)m_ui_target->width();
+		else
+			   aspect = (float)m_ui_target->width() / (float)m_ui_target->height();
 
-	// if not, clamp for extreme proportions
+		// if we have a valid pixel aspect, apply that and return
+		if (m_ui_target->pixel_aspect() != 0.0f)
+			   return (aspect / m_ui_target->pixel_aspect());
+	} else {
+		// single screen container
+
+		orient = rc->orientation();
+		// based on the orientation of the target, compute height/width or width/height
+		if (!(orient & ORIENTATION_SWAP_XY))
+			aspect = (float)rc->screen()->visible_area().height() / (float)rc->screen()->visible_area().width();
+		else
+			aspect = (float)rc->screen()->visible_area().width() / (float)rc->screen()->visible_area().height();
+	}
+
+	// clamp for extreme proportions
 	if (aspect < 0.66f)
 		aspect = 0.66f;
 	if (aspect > 1.5f)
 		aspect = 1.5f;
+
 	return aspect;
 }
 

--- a/src/emu/render.h
+++ b/src/emu/render.h
@@ -775,7 +775,7 @@ public:
 	// UI targets
 	render_target &ui_target() const { assert(m_ui_target != NULL); return *m_ui_target; }
 	void set_ui_target(render_target &target) { m_ui_target = &target; }
-	float ui_aspect();
+	float ui_aspect(render_container *rc = NULL);
 
 	// UI containers
 	render_container &ui_container() const { assert(m_ui_container != NULL); return *m_ui_container; }

--- a/src/emu/ui/ui.c
+++ b/src/emu/ui/ui.c
@@ -456,7 +456,7 @@ void ui_manager::update_and_render(render_container *container)
 		{
 			float mouse_y=-1,mouse_x=-1;
 			if (mouse_target->map_point_container(mouse_target_x, mouse_target_y, *container, mouse_x, mouse_y)) {
-				container->add_quad(mouse_x,mouse_y,mouse_x + 0.05*container->manager().ui_aspect(),mouse_y + 0.05,UI_TEXT_COLOR,m_mouse_arrow_texture,PRIMFLAG_BLENDMODE(BLENDMODE_ALPHA));
+				container->add_quad(mouse_x,mouse_y,mouse_x + 0.05*container->manager().ui_aspect(container),mouse_y + 0.05,UI_TEXT_COLOR,m_mouse_arrow_texture,PRIMFLAG_BLENDMODE(BLENDMODE_ALPHA));
 			}
 		}
 	}
@@ -600,7 +600,7 @@ void ui_manager::draw_text_full(render_container *container, const char *origs, 
 	const char *linestart;
 	float cury = y;
 	float maxwidth = 0;
-	float aspect = machine().render().ui_aspect();
+	float aspect = machine().render().ui_aspect(container);
 
 	// if we don't want wrapping, guarantee a huge wrapwidth
 	if (wrap == WRAP_NEVER)


### PR DESCRIPTION
Do not assume ui-container aspect when drawing on other containers.
This fixes LUA draw_text() in multi-screens game, where the font
aspect for each screen is wrongly computed on the aggregated target.

Signed-off-by: Luca Bruno <lucab@debian.org>