### PR TITLE
Version info for OSX binaries

### DIFF
--- a/makefile
+++ b/makefile
@@ -943,14 +943,14 @@ else
 EMULATOROBJ = $(EMULATOROBJLIST)
 endif
 
-$(EMULATOR): $(EMULATOROBJ)
+$(EMULATOR): $(EMULATOROBJ) $(SRC)/version.c
 	$(CC) $(CDEFS) $(CFLAGS) -c $(SRC)/version.c -o $(VERSIONOBJ)
 	@echo Linking $@...
 ifeq ($(TARGETOS),emscripten)
 # Emscripten's linker seems to be stricter about the ordering of files
-	$(LD) $(LDFLAGS) $(LDFLAGSEMULATOR) $(VERSIONOBJ) -Wl,--start-group $^ -Wl,--end-group $(LIBS) -o $@
+	$(LD) $(LDFLAGS) $(LDFLAGSEMULATOR) $(VERSIONOBJ) -Wl,--start-group $(EMULATOROBJ) -Wl,--end-group $(LIBS) -o $@
 else
-	$(LD) $(LDFLAGS) $(LDFLAGSEMULATOR) $(VERSIONOBJ) $^ $(LIBS) -o $@
+	$(LD) $(LDFLAGS) $(LDFLAGSEMULATOR) $(VERSIONOBJ) $(EMULATOROBJ) $(LIBS) -o $@
 endif
 ifeq ($(TARGETOS),win32)
 ifdef SYMBOLS

--- a/src/build/verinfo.py
+++ b/src/build/verinfo.py
@@ -2,48 +2,71 @@
 
 from __future__ import with_statement
 
-import sys
 import os
+import re
+import sys
 
-def usage():
-    sys.stderr.write('Usage: verinfo.py [-b mame|mess|ume] <filename>\n')
-    return 0
-	
-build = "mame"
 
-if (len(sys.argv)==1):
-   usage()
-   sys.exit(1)
+def parse_args():
+    def usage():
+        sys.stderr.write('Usage: verinfo.py [-b mame|mess|ume] [-r|-p] <filename>\n')
+        sys.exit(1)
 
-if (sys.argv[1]=='-b'):
-    if (sys.argv[2]=='mame'):
-        build = "mame"
-    elif (sys.argv[2]=='mess'):
-        build = "mess"
-    elif (sys.argv[2]=='ume'):
-        build = "ume"
-    else :
-		usage()
-		sys.exit(1)
+    flags = True
+    target = 'mame'
+    input = None
+    output = 'rc'
+    i = 1
+    while i < len(sys.argv):
+        if flags and (sys.argv[i] == '-r'):
+            output = 'rc'
+        elif flags and (sys.argv[i] == '-p'):
+            output = 'plist'
+        elif flags and (sys.argv[i] == '-b'):
+            i += 1;
+            if (i >= len(sys.argv)) or (sys.argv[i] not in ('mame', 'mess', 'ume')):
+                usage()
+            else:
+                target = sys.argv[i]
+        elif flags and (sys.argv[i] == '--'):
+            flags = False
+        elif flags and sys.argv[i].startswith('-'):
+            usage()
+        elif input is not None:
+            usage()
+        else:
+            input = sys.argv[i]
+        i += 1
+    if input is None:
+        usage()
+    return target, input, output
 
-srcfile = sys.argv[len(sys.argv)-1]
+
+def extract_version(input):
+    pattern = re.compile('\s+BARE_BUILD_VERSION\s+"(([^."]+)\.([^."]+))"')
+    for line in input.readlines():
+        match = pattern.search(line)
+        if match:
+            return match.group(1), match.group(2), match.group(3)
+    return None, None, None
+
+
+build, srcfile, outfmt = parse_args()
+
 try:
-	fp = open(srcfile, 'rb')
+    fp = open(srcfile, 'rb')
 except IOError:
-	sys.stderr.write("Unable to open source file '%s'" % srcfile)
-	sys.exit(1)
+    sys.stderr.write("Unable to open source file '%s'\n" % srcfile)
+    sys.exit(1)
 
-for line in fp.readlines():
-    if line.find("BARE_BUILD_VERSION")!=-1 and line.find('"')!=-1 and line.find('.')!=-1:
-        version_string = line[line.find('"')+1:]
-        version_string = version_string[0:version_string.find('"')]
-        break
-
-version_major = version_string[0:version_string.find('.')]
-version_minor = version_string[version_string.find('.')+1:]
+version_string, version_major, version_minor = extract_version(fp)
 version_build = "0"
 version_subbuild = "0"
-if (build == "mess") :
+if not version_string:
+    sys.stderr.write("Unable to extract version from source file '%s'\n" % srcfile)
+    sys.exit(1)
+
+if build == "mess":
     # MESS
     author = "MESS Team";
     comments = "Multi Emulation Super System";
@@ -52,7 +75,8 @@ if (build == "mess") :
     internal_name = "MESS";
     original_filename = "MESS";
     product_name = "MESS";
-elif (build == "ume") :
+    bundle_identifier = "org.mamedev.mess"
+elif build == "ume":
     # UME
     author = "MAME and MESS Team"
     comments = "Universal Machine Emulator"
@@ -61,7 +85,8 @@ elif (build == "ume") :
     internal_name = "UME"
     original_filename = "UME"
     product_name = "UME"
-else : 
+    bundle_identifier = "org.mamedev.ume"
+else:
     # MAME
     author = "Nicola Salmoria and the MAME Team"
     comments = "Multiple Arcade Machine Emulator"
@@ -70,47 +95,66 @@ else :
     internal_name = "MAME"
     original_filename = "MAME"
     product_name = "MAME"
+    bundle_identifier = "org.mamedev.mame"
 
 legal_copyright = "Copyright Nicola Salmoria and the MAME team"
 
-print("VS_VERSION_INFO VERSIONINFO")
-print("\tFILEVERSION %s,%s,%s,%s" % (version_major, version_minor, version_build, version_subbuild))
-print("\tPRODUCTVERSION %s,%s,%s,%s" % (version_major, version_minor, version_build, version_subbuild))
-print("\tFILEFLAGSMASK 0x3fL")
-if (version_build == 0) :
-    print("\tFILEFLAGS 0x0L")
-else :
-    print("\tFILEFLAGS VS_FF_PRERELEASE")
-print("\tFILEOS VOS_NT_WINDOWS32")
-print("\tFILETYPE VFT_APP")
-print("\tFILESUBTYPE VFT2_UNKNOWN")
-print("BEGIN")
-print("\tBLOCK \"StringFileInfo\"")
-print("\tBEGIN")
-print("#ifdef UNICODE")
-print("\t\tBLOCK \"040904b0\"")
-print("#else")
-print("\t\tBLOCK \"040904E4\"")
-print("#endif")
-print("\t\tBEGIN")
-print("\t\t\tVALUE \"Author\", \"%s\\0\"" % author)
-print("\t\t\tVALUE \"Comments\", \"%s\\0\"" % comments)
-print("\t\t\tVALUE \"CompanyName\", \"%s\\0\"" % company_name)
-print("\t\t\tVALUE \"FileDescription\", \"%s\\0\"" % file_description)
-print("\t\t\tVALUE \"FileVersion\", \"%s, %s, %s, %s\\0\"" % (version_major, version_minor, version_build, version_subbuild))
-print("\t\t\tVALUE \"InternalName\", \"%s\\0\"" % internal_name)
-print("\t\t\tVALUE \"LegalCopyright\", \"%s\\0\"" % legal_copyright)
-print("\t\t\tVALUE \"OriginalFilename\", \"%s\\0\"" % original_filename)
-print("\t\t\tVALUE \"ProductName\", \"%s\\0\"" % product_name)
-print("\t\t\tVALUE \"ProductVersion\", \"%s\\0\"" % version_string)
-print("\t\tEND")
-print("\tEND")
-print("\tBLOCK \"VarFileInfo\"")
-print("\tBEGIN")
-print("#ifdef UNICODE")
-print("\t\tVALUE \"Translation\", 0x409, 1200")
-print("#else")
-print("\t\tVALUE \"Translation\", 0x409, 1252")
-print("#endif")
-print("\tEND")
-print("END")
+if outfmt == 'rc':
+    print("VS_VERSION_INFO VERSIONINFO")
+    print("\tFILEVERSION %s,%s,%s,%s" % (version_major, version_minor, version_build, version_subbuild))
+    print("\tPRODUCTVERSION %s,%s,%s,%s" % (version_major, version_minor, version_build, version_subbuild))
+    print("\tFILEFLAGSMASK 0x3fL")
+    if (version_build == 0) :
+        print("\tFILEFLAGS 0x0L")
+    else :
+        print("\tFILEFLAGS VS_FF_PRERELEASE")
+    print("\tFILEOS VOS_NT_WINDOWS32")
+    print("\tFILETYPE VFT_APP")
+    print("\tFILESUBTYPE VFT2_UNKNOWN")
+    print("BEGIN")
+    print("\tBLOCK \"StringFileInfo\"")
+    print("\tBEGIN")
+    print("#ifdef UNICODE")
+    print("\t\tBLOCK \"040904b0\"")
+    print("#else")
+    print("\t\tBLOCK \"040904E4\"")
+    print("#endif")
+    print("\t\tBEGIN")
+    print("\t\t\tVALUE \"Author\", \"%s\\0\"" % author)
+    print("\t\t\tVALUE \"Comments\", \"%s\\0\"" % comments)
+    print("\t\t\tVALUE \"CompanyName\", \"%s\\0\"" % company_name)
+    print("\t\t\tVALUE \"FileDescription\", \"%s\\0\"" % file_description)
+    print("\t\t\tVALUE \"FileVersion\", \"%s, %s, %s, %s\\0\"" % (version_major, version_minor, version_build, version_subbuild))
+    print("\t\t\tVALUE \"InternalName\", \"%s\\0\"" % internal_name)
+    print("\t\t\tVALUE \"LegalCopyright\", \"%s\\0\"" % legal_copyright)
+    print("\t\t\tVALUE \"OriginalFilename\", \"%s\\0\"" % original_filename)
+    print("\t\t\tVALUE \"ProductName\", \"%s\\0\"" % product_name)
+    print("\t\t\tVALUE \"ProductVersion\", \"%s\\0\"" % version_string)
+    print("\t\tEND")
+    print("\tEND")
+    print("\tBLOCK \"VarFileInfo\"")
+    print("\tBEGIN")
+    print("#ifdef UNICODE")
+    print("\t\tVALUE \"Translation\", 0x409, 1200")
+    print("#else")
+    print("\t\tVALUE \"Translation\", 0x409, 1252")
+    print("#endif")
+    print("\tEND")
+    print("END")
+elif outfmt == 'plist':
+    print('<?xml version="1.0" encoding="UTF-8"?>')
+    print('<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">')
+    print('<plist version="1.0">')
+    print('<dict>')
+    print('\t<key>CFBundleDisplayName</key>')
+    print('\t<string>%s</string>' % product_name)
+    print('\t<key>CFBundleIdentifier</key>')
+    print('\t<string>%s</string>' % bundle_identifier)
+    print('\t<key>CFBundleInfoDictionaryVersion</key>')
+    print('\t<string>6.0</string>')
+    print('\t<key>CFBundleName</key>')
+    print('\t<string>%s</string>' % product_name)
+    print('\t<key>CFBundleShortVersionString</key>')
+    print('\t<string>%s.%s.%s</string>' % (version_major, version_minor, version_build))
+    print('</dict>')
+    print('</plist>')

--- a/src/osd/sdl/sdl.mak
+++ b/src/osd/sdl/sdl.mak
@@ -539,6 +539,24 @@ ifeq ($(TARGETOS),macosx)
 OSDCOREOBJS += $(SDLOBJ)/osxutils.o
 SDLOS_TARGETOS = macosx
 
+ifeq ($(TARGET),mame)
+MACOSX_EMBED_INFO_PLIST = 1
+endif
+ifeq ($(TARGET),mess)
+MACOSX_EMBED_INFO_PLIST = 1
+endif
+ifeq ($(TARGET),ume)
+MACOSX_EMBED_INFO_PLIST = 1
+endif
+ifdef MACOSX_EMBED_INFO_PLIST
+INFOPLIST = $(SDLOBJ)/$(TARGET)-Info.plist
+LDFLAGSEMULATOR += -sectcreate __TEXT __info_plist $(INFOPLIST)
+$(EMULATOR): $(INFOPLIST)
+$(INFOPLIST): $(SRC)/build/verinfo.py $(SRC)/version.c
+	@echo Emitting $@...
+	$(PYTHON) $(SRC)/build/verinfo.py -b $(TARGET) -p $(SRC)/version.c > $@
+endif
+
 ifndef MACOSX_USE_LIBSDL
 # Compile using framework (compile using libSDL is the exception)
 ifeq ($(SDL_LIBVER),sdl2)


### PR DESCRIPTION
The ultimate purpose of this is to get version information into MAME/MESS/UME on OSX that will show in Finder info windows and the applications' about boxes.  There are three parts to the change.
* First commit adds functionality to verinfo.py for generating Info.plist files for OSX.  By default it still generates a Windows resource script.  This meant adding slightly sophisticated command-line argument parsing to it.  I also changed the hand-rolled string matching to use Python's regular expression module.
* The second commit marks the emulator binary as depending on the version source file and decouples the dependencies from the linker inputs.  Editing src/version.c doesn't cause the emulator to be re-linked if nothing else has changed, this changes that.
* The third change embeds version info for emulators on OSX.  I realise it's a bit ugly, but I couldn't think of a cleaner way to make it only attempt to generate/embed the resource in MAME, MESS and UME, and not try doing it for things like ldplayer that it doesn't know how to generate a property list for.  This obviously depends on verinfo.py being able to create the property lists, but it also depends on the emulator's dependencies being decoupled from its linker inputs because of the way you tell the linker to embed the property list.