### PR TITLE
Update file2str.py

### DIFF
--- a/src/build/file2str.py
+++ b/src/build/file2str.py
@@ -40,7 +40,7 @@ try:
             chunk = src.read(16)
             if chunk:
                 for b in chunk:
-                    dst.write('0x%02x' % ord(b))
+                    dst.write('0x%02x' % b)
                     offs = offs + 1
                     if offs != bytes:
                         dst.write(',')


### PR DESCRIPTION
On line 43, wouldn't "ord(b)" simply be "b" since each iteration through "chunk", which is of type "bytes", return an "int"? In Python 3.x, the "ord" function expects type "str" so passing an "int" causes a "TypeError" exception. You might also consider changing your "bytes" label to something else, since it's in conflict with the pre-existing class.