### PR TITLE
Update file2str.py

### DIFF
--- a/src/build/file2str.py
+++ b/src/build/file2str.py
@@ -40,7 +40,10 @@ try:
             chunk = src.read(16)
             if chunk:
                 for b in chunk:
-                    dst.write('0x%02x' % ord(b))
+                    # For Python 2.x compatibility.
+                    if isinstance(b, str):
+                        b = ord(b)
+                    dst.write('0x%02x' % b)
                     offs = offs + 1
                     if offs != byteCount:
                         dst.write(',')


### PR DESCRIPTION
Sorry about my previous recommendation that broke Python 2. It's been so long that I forgot that Python 2 open 'rb' returns a string representation of bytes. The above code will properly handle type conversion for Python 2.