### PR TITLE
GBA: Fix VBlank timing

### DIFF
--- a/src/mess/drivers/gba.c
+++ b/src/mess/drivers/gba.c
@@ -2012,7 +2012,7 @@ TIMER_CALLBACK_MEMBER(gba_state::perform_scan)
 	}
 
 	// exiting VBL, handle interrupts and DMA triggers
-	if (scanline == 224)
+	if (scanline == 160)
 	{
 		// FIXME: some games are very picky with this trigger!
 		// * Mario & Luigi SuperStar Saga loses pieces of gfx for 225-227.


### PR DESCRIPTION
According to the mGBA author, VBlank IRQs happen on line 160. Confirmed to fix Pokemon Ruby's title screen.