### PR TITLE
Fix various typos and spelling mistakes

### DIFF
--- a/docs/m6502.txt
+++ b/docs/m6502.txt
@@ -170,7 +170,7 @@ An opcode description is a series of lines starting by an opcode entry
 by itself and followed by a series of indented lines with code
 executing the opcode.
 
-For instance the asl <absolute adress> opcode looks like this:
+For instance the asl <absolute address> opcode looks like this:
 
 asl_aba
     TMP = read_pc();

--- a/src/emu/bus/a2bus/a2arcadebd.c
+++ b/src/emu/bus/a2bus/a2arcadebd.c
@@ -2,7 +2,7 @@
 
     a2arcadeboard.c
 
-    Implementation of the Third Millenium Engineering Arcade Board
+    Implementation of the Third Millennium Engineering Arcade Board
 
     TODO:
         - VDPTEST program seems to want more than 16K of RAM, but docs/ads/press releases say 16k, period
@@ -56,7 +56,7 @@ machine_config_constructor a2bus_arcboard_device::device_mconfig_additions() con
 //**************************************************************************
 
 a2bus_arcboard_device::a2bus_arcboard_device(const machine_config &mconfig, const char *tag, device_t *owner, UINT32 clock) :
-	device_t(mconfig, A2BUS_ARCADEBOARD, "Third Millenium Engineering Arcade Board", tag, owner, clock, "a2arcbd", __FILE__),
+	device_t(mconfig, A2BUS_ARCADEBOARD, "Third Millennium Engineering Arcade Board", tag, owner, clock, "a2arcbd", __FILE__),
 	device_a2bus_card_interface(mconfig, *this),
 	m_tms(*this, TMS_TAG),
 	m_ay(*this, AY_TAG)

--- a/src/emu/bus/a2bus/a2arcadebd.c
+++ b/src/emu/bus/a2bus/a2arcadebd.c
@@ -2,7 +2,7 @@
 
     a2arcadeboard.c
 
-    Implementation of the Third Millennium Engineering Arcade Board
+    Implementation of the Third Millenium Engineering Arcade Board
 
     TODO:
         - VDPTEST program seems to want more than 16K of RAM, but docs/ads/press releases say 16k, period
@@ -56,7 +56,7 @@ machine_config_constructor a2bus_arcboard_device::device_mconfig_additions() con
 //**************************************************************************
 
 a2bus_arcboard_device::a2bus_arcboard_device(const machine_config &mconfig, const char *tag, device_t *owner, UINT32 clock) :
-	device_t(mconfig, A2BUS_ARCADEBOARD, "Third Millennium Engineering Arcade Board", tag, owner, clock, "a2arcbd", __FILE__),
+	device_t(mconfig, A2BUS_ARCADEBOARD, "Third Millenium Engineering Arcade Board", tag, owner, clock, "a2arcbd", __FILE__),
 	device_a2bus_card_interface(mconfig, *this),
 	m_tms(*this, TMS_TAG),
 	m_ay(*this, AY_TAG)

--- a/src/emu/bus/a2bus/a2arcadebd.h
+++ b/src/emu/bus/a2bus/a2arcadebd.h
@@ -2,7 +2,7 @@
 
     a2arcadebd.h
 
-    Third Millenium Engineering Arcade Board
+    Third Millennium Engineering Arcade Board
 
 *********************************************************************/
 

--- a/src/emu/bus/a2bus/a2arcadebd.h
+++ b/src/emu/bus/a2bus/a2arcadebd.h
@@ -2,7 +2,7 @@
 
     a2arcadebd.h
 
-    Third Millennium Engineering Arcade Board
+    Third Millenium Engineering Arcade Board
 
 *********************************************************************/
 

--- a/src/emu/bus/a2bus/corvfdc02.c
+++ b/src/emu/bus/a2bus/corvfdc02.c
@@ -257,7 +257,7 @@ WRITE_LINE_MEMBER(a2bus_corvfdc02_device::intrq_w)
 {
 	if (state)
 	{
-		m_fdc_local_status &= ~2;   // indicate IRQ occured
+		m_fdc_local_status &= ~2;   // indicate IRQ occurred
 		if (m_fdc_local_command & 0x20)
 		{
 			raise_slot_irq();

--- a/src/emu/bus/isa/ega.c
+++ b/src/emu/bus/isa/ega.c
@@ -51,7 +51,7 @@ TODO - Write documentation
           | | +------------ input from FEAT0 on the feature connector
           | +-------------- input from FEAT1 on the feature connector
           +---------------- CRT Interrupt
-                            0 = vertical retrace if occuring
+                            0 = vertical retrace if occurring
                             1 = video is being displayed
 
 

--- a/src/emu/bus/isa/gus.c
+++ b/src/emu/bus/isa/gus.c
@@ -734,7 +734,7 @@ WRITE8_MEMBER(gf1_device::global_reg_data_w)
  * bit 2 - DMA channel width (0=8-bit, 1=16-bit)
  * bits 3,4 - DMA rate divider
  * bit 5 - DMA terminal count IRQ enable
- * bit 6 - DMA terminal count IRQ pending (read), Data size (write, 0=8bit, 1=16-bit, independant of channel size)
+ * bit 6 - DMA terminal count IRQ pending (read), Data size (write, 0=8bit, 1=16-bit, independent of channel size)
  * bit 7 - Invert MSB of data
  */
 		if(offset == 1)

--- a/src/emu/bus/isa/vga_ati.c
+++ b/src/emu/bus/isa/vga_ati.c
@@ -32,7 +32,7 @@ ROM_START( gfxultrp )
 	ROM_SYSTEM_BIOS( 0, "isa", "ISA BIOS 112-18900-100" )
 	ROMX_LOAD("gfxultrapro.bin", 0x00000, 0x8000, CRC(4e5effd7) SHA1(84ad3abf7653e4734bf39f5d5c8b88e74527e8ce), ROM_BIOS(1) )
 
-	// We can seperate out this BIOS once a proper VLB bus emulation is available
+	// We can separate out this BIOS once a proper VLB bus emulation is available
 	ROM_SYSTEM_BIOS( 1, "vlb", "VLB BIOS 113-19500-100" )
 	ROMX_LOAD("gfxultrapro_vlb.bin", 0x00000, 0x8000, CRC(5018f71e) SHA1(61321dfecf1bcdd8043836fabbe41786dbf3001b), ROM_BIOS(2) )
 ROM_END
@@ -43,7 +43,7 @@ ROM_START( mach64 )
 	ROM_SYSTEM_BIOS( 0, "isa", "ISA BIOS 112-28122-101" )
 	ROMX_LOAD("mach64.bin", 0x00000, 0x8000, CRC(1300aa8f) SHA1(dfc7f817900f125b89b0bda16fcb205f066a47fc), ROM_BIOS(1) )
 
-	// We can seperate out these BIOSes once a proper PCI and VLB bus emulation is available
+	// We can separate out these BIOSes once a proper PCI and VLB bus emulation is available
 	ROM_SYSTEM_BIOS( 1, "vlb_d", "VLB DRAM BIOS 113-27803-102" )
 	ROMX_LOAD("mach64_vlb_dram.bin", 0x00000, 0x8000, CRC(f2a24699) SHA1(580401a8bdfc379180a8d7d77305fc529b2a8374), ROM_BIOS(2) )
 

--- a/src/emu/bus/nes_ctrl/miracle.c
+++ b/src/emu/bus/nes_ctrl/miracle.c
@@ -179,7 +179,7 @@ void nes_miracle_device::write(UINT8 data)
 
 			if (m_strobe_clock < 66 && data == 0)
 			{
-				// short delay is recieve mode
+				// short delay is receive mode
 				m_midi_mode = MIRACLE_MIDI_RECEIVE;
 				strobe_timer->reset();
 				m_strobe_on = 0;

--- a/src/emu/bus/snes/rom.c
+++ b/src/emu/bus/snes/rom.c
@@ -312,7 +312,7 @@ WRITE8_MEMBER( sns_rom_pokemon_device::chip_write )
 // Tekken 2: It accesses the protection in a very strange way, always reading/writing the same data $f0 times,
 // because each access must be repeated a couple of times to be registered (typically around 7-30 times)
 // They probably used a microcontroller here.
-// The protection itself is accessed in banks $80-$bf. Accessing (read/write, doesn't matter) adress lines
+// The protection itself is accessed in banks $80-$bf. Accessing (read/write, doesn't matter) address lines
 // A8,A9,A10 in these banks in a certain sequence makes the mc return a 4bit value. [d4s]
 // Details on a possible algorythm behind the sequence of accesses were provided by nocash. Thanks!
 void sns_rom_tekken2_device::update_prot(UINT32 offset)

--- a/src/emu/bus/snes_ctrl/miracle.c
+++ b/src/emu/bus/snes_ctrl/miracle.c
@@ -173,7 +173,7 @@ void snes_miracle_device::write_strobe(UINT8 data)
 
 			if (m_strobe_clock < 500 && data == 0)
 			{
-				// short delay is recieve mode
+				// short delay is receive mode
 				m_midi_mode = MIRACLE_MIDI_RECEIVE;
 				strobe_timer->reset();
 				m_strobe_on = 0;

--- a/src/emu/cpu/alto2/a2ether.c
+++ b/src/emu/cpu/alto2/a2ether.c
@@ -435,9 +435,9 @@ void alto2_cpu_device::eth_wakeup()
  * 'F401 is not in the data path, but only monitors the message. The
  * Error output becomes valid after the last check bit has been entered
  * into the 'F401 by a HIGH-to-LOW transition of CP'. If no detectable
- * errors have occured during the transmission, the resultant internal
+ * errors have occurred during the transmission, the resultant internal
  * register bits are all LOW and the Error Output (ER) is LOW.
- * If a detectable error has occured, ER is HIGH.
+ * If a detectable error has occurred, ER is HIGH.
  *
  * A HIGH on the Master Reset input (MR) asynchronously clears the
  * register. A LOW on the Preset input (P') asynchronously sets the

--- a/src/emu/cpu/alto2/a2mem.c
+++ b/src/emu/cpu/alto2/a2mem.c
@@ -487,7 +487,7 @@ UINT32 alto2_cpu_device::hamming_code(int write, UINT32 dw_addr, UINT32 dw_data)
  *
  * This register is a 'shadow MAR'; it holds the address of the
  * first error since the error status was last reset. If no error
- * has occured, MEAR reports the address of the most recent
+ * has occurred, MEAR reports the address of the most recent
  * memory access. Note that MEAR is set whenever an error of
  * _any kind_ (single-bit or double-bit) is detected.
  */
@@ -504,7 +504,7 @@ READ16_MEMBER( alto2_cpu_device::mear_r )
  * @brief memory error status register read
  *
  * This register reports specifics of the first error that
- * occured since MESR was last reset. Storing anything into
+ * occurred since MESR was last reset. Storing anything into
  * this register resets the error logic and enables it to
  * detect a new error. Bits are "low true", i.e. if the bit
  * is 0, the conidition is true.
@@ -513,7 +513,7 @@ READ16_MEMBER( alto2_cpu_device::mear_r )
  * MESR[6]  Parity error
  * MESR[7]  Memory parity bit
  * MESR[8-13]   Syndrome bits
- * MESR[14-15]  Bank number in which error occured
+ * MESR[14-15]  Bank number in which error occurred
  * </PRE>
  */
 READ16_MEMBER( alto2_cpu_device::mesr_r )
@@ -551,7 +551,7 @@ WRITE16_MEMBER( alto2_cpu_device::mesr_w )
  * the memory error logic. This register is set to all ones
  * (disable all interrupts) when the alto is bootstrapped
  * and when the parity error task first detects an error.
- * When an error has occured, MEAR and MESR should be read
+ * When an error has occurred, MEAR and MESR should be read
  * before setting MECR. Bits are "low true", i.e. a 0 bit
  * enables the condition.
  *

--- a/src/emu/cpu/apexc/apexcdsm.c
+++ b/src/emu/cpu/apexc/apexcdsm.c
@@ -86,7 +86,7 @@ CPU_DISASSEMBLE( apexc )
 	UINT32 instruction;         /* 32-bit machine instruction */
 	int x, y, function, c6, vector; /* instruction fields */
 	int n;                      /* 'friendly', instruction-dependant interpretation of C6 */
-	const instr_desc *the_desc; /* pointer to the revelant entry in the instructions array */
+	const instr_desc *the_desc; /* pointer to the relevant entry in the instructions array */
 	char mnemonic[9];           /* storage for generated mnemonic */
 
 	/* read the instruction to disassemble */
@@ -99,7 +99,7 @@ CPU_DISASSEMBLE( apexc )
 	c6 = (instruction >> 1) & 0x3F;
 	vector = instruction & 1;
 
-	/* get the revelant entry in instructions */
+	/* get the relevant entry in instructions */
 	the_desc = & instructions[function >> 1];
 
 	/* generate mnemonic : append a 'v' to the basic mnemonic if it is a vector instruction */

--- a/src/emu/cpu/dsp16/dsp16.h
+++ b/src/emu/cpu/dsp16/dsp16.h
@@ -91,12 +91,12 @@ protected:
 	UINT16 m_sdx;
 	UINT16 m_pioc;
 	UINT16 m_pdx0;  // pdx0 & pdx1 refer to the same physical register (page 6-1)
-	UINT16 m_pdx1;  // but we keep them seperate for logic's sake.
+	UINT16 m_pdx1;  // but we keep them separate for logic's sake.
 
 	// internal stuff
 	UINT16 m_ppc;
 
-	// This CPU core handles the cache as more of a loop than 15 seperate memory elements.
+	// This CPU core handles the cache as more of a loop than 15 separate memory elements.
 	// It's a bit of a hack, but it's easier this way (for now).
 	UINT16 m_cacheStart;
 	UINT16 m_cacheEnd;

--- a/src/emu/cpu/m68000/m68kcpu.h
+++ b/src/emu/cpu/m68000/m68kcpu.h
@@ -698,7 +698,7 @@ INLINE UINT32 m68ki_ic_readimm16(m68000_base_device *m68k, UINT32 address)
 
 //              printf("m68k: doing cache fill at %08x (tag %08x idx %d)\n", address, tag, idx);
 
-				// if no buserror occured, validate the tag
+				// if no buserror occurred, validate the tag
 				if (!m68k->mmu_tmp_buserror_occurred)
 				{
 					m68k->ic_address[idx] = tag;

--- a/src/emu/cpu/mcs51/mcs51.c
+++ b/src/emu/cpu/mcs51/mcs51.c
@@ -124,7 +124,7 @@
  * - Fix limenko.c videopkr.c : Issue with core allocation of ram (duplicate savestate)
  * - Handle internal ram better (debugger visible)
  *  - Fixed port reading
- *  - Rewrote Macros for better readibility
+ *  - Rewrote Macros for better readability
  *  - Fixed and rewrote Interrupt handling
  *  - Now returns INTERNAL_DIVIDER, adjusted cycle counts
  *  - Remove unnecessary and duplicated code

--- a/src/emu/cpu/mn10200/mn10200.c
+++ b/src/emu/cpu/mn10200/mn10200.c
@@ -394,7 +394,7 @@ TIMER_CALLBACK_MEMBER( mn10200_device::simple_timer_cb )
 
 	// handle our expiring and also tick our cascaded children
 	if (timer_tick_simple(tmr) == 2)
-		m_simple_timer[tmr].cur = 0xff; // cascaded and no underflow occured
+		m_simple_timer[tmr].cur = 0xff; // cascaded and no underflow occurred
 	else
 		m_simple_timer[tmr].cur = m_simple_timer[tmr].base;
 

--- a/src/emu/cpu/pdp1/pdp1.c
+++ b/src/emu/cpu/pdp1/pdp1.c
@@ -441,7 +441,7 @@ void pdp1_device::field_interrupt()
 	/* current_irq: 1 bit for each active pending interrupt request
 	Pending interrupts are in b3 (simulated by (m_irq_state & m_b1) | m_b2)), but they
 	are only honored if no higher priority interrupt routine is in execution (one bit set in b4
-	for each routine in execution).  The revelant mask is created with (m_b4 | (- m_b4)),
+	for each routine in execution).  The relevant mask is created with (m_b4 | (- m_b4)),
 	as the carry chain (remember that -b4 = (~ b4) + 1) does precisely what we want.
 	b4:    0001001001000
 	-b4:   1110110111000
@@ -833,7 +833,7 @@ void pdp1_device::execute_run()
 					else if ((IR == DIO) || (IR == DAC))    /* dio or dac instruction ? */
 					{   /* there is a discrepancy: the pdp1 handbook tells that only dio should be used,
                         but the lisp tape uses the dac instruction instead */
-						/* Yet maintainance manual p. 6-25 states clearly that the data is located
+						/* Yet maintenance manual p. 6-25 states clearly that the data is located
 						in IO and transfered to MB, so DAC is likely to be a mistake. */
 						m_rim_step = 2;
 					}
@@ -881,7 +881,7 @@ void pdp1_device::execute_run()
 			/* yes, interrupt can occur in the midst of an instruction (impressing, huh?) */
 			/* Note that break cannot occur during a one-cycle jump that is deferred only once,
 			or another break cycle.  Also, it cannot interrupt the long cycle 1 of automatic
-			multiply/divide.  (maintainance manual 6-19) */
+			multiply/divide.  (maintenance manual 6-19) */
 			if (m_sbs_request && (! m_no_sequence_break) && (! m_brk_ctr))
 			{   /* begin sequence break */
 				m_brk_ctr = 1;
@@ -900,7 +900,7 @@ void pdp1_device::execute_run()
 					MA = m_sbs_level << 2;  /* always 0 with standard sequence break system */
 					MB = AC;            /* save AC to MB */
 					AC = (OV << 17) | (EXD << 16) | PC; /* save OV/EXD/PC to AC */
-					EXD = OV = 0;       /* according to maintainance manual p. 8-17 and ?-?? */
+					EXD = OV = 0;       /* according to maintenance manual p. 8-17 and ?-?? */
 					m_cycle = m_defer = m_exc = 0;  /* mere guess */
 					WRITE_PDP_18BIT(MA, MB);    /* save former AC to memory */
 					INCREMENT_MA;
@@ -954,7 +954,7 @@ void pdp1_device::execute_run()
 									m_b4 &= ~(1 << level);
 									field_interrupt();
 									if (m_extend_support)
-										EXD = 1;    /* according to maintainance manual p. 6-33 */
+										EXD = 1;    /* according to maintenance manual p. 6-33 */
 									m_sbs_restore = 1;
 								}
 							}
@@ -990,7 +990,7 @@ void pdp1_device::execute_run()
 						m_exc = 0;
 
 						if (m_sbs_restore)
-						{   /* interrupt return: according to maintainance manual p. 6-33 */
+						{   /* interrupt return: according to maintenance manual p. 6-33 */
 							if (m_extend_support)
 								EXD = (MB >> 16) & 1;
 							OV = (MB >> 17) & 1;
@@ -1119,7 +1119,7 @@ void pdp1_device::execute_instruction()
 			break;
 		}
 	case SUB:       /* Subtract */
-		{   /* maintainance manual 7-14 seems to imply that substract does not test for -0.
+		{   /* maintenance manual 7-14 seems to imply that substract does not test for -0.
               The sim 2.3 source says so explicitely, though they do not give a reference.
               It sounds a bit weird, but the reason is probably that doing so would
               require additionnal logic that does not exist. */
@@ -1230,7 +1230,7 @@ void pdp1_device::execute_instruction()
 		}
 		else
 		{   /* MUS */
-			/* should we check for -0??? (Maintainance manual 7-14 seems to imply we should not:
+			/* should we check for -0??? (Maintenance manual 7-14 seems to imply we should not:
 			as a matter of fact, since the MUS instruction is supposed to have positive operands,
 			there is no need to check for -0, therefore such a simplification does not sound
 			absurd.) */
@@ -1777,8 +1777,8 @@ void pdp1_device::pdp1_type_20_sbs_iot(int op2, int nac, int mb, int *io, int ac
 void pdp1_device::pulse_start_clear()
 {
 	/* processor registers */
-	PC = 0;         /* according to maintainance manual p. 6-17 */
-	IR = 0;         /* according to maintainance manual p. 6-13 */
+	PC = 0;         /* according to maintenance manual p. 6-17 */
+	IR = 0;         /* according to maintenance manual p. 6-13 */
 	/*MB = 0;*/     /* ??? */
 	/*MA = 0;*/     /* ??? */
 	/*AC = 0;*/     /* ??? */
@@ -1790,14 +1790,14 @@ void pdp1_device::pulse_start_clear()
 	m_cycle = 0;        /* mere guess */
 	m_defer = 0;        /* mere guess */
 	m_brk_ctr = 0;  /* mere guess */
-	m_ov = 0;       /* according to maintainance manual p. 7-18 */
+	m_ov = 0;       /* according to maintenance manual p. 7-18 */
 	m_rim = 0;      /* ??? */
 	m_sbm = 0;      /* ??? */
-	EXD = 0;            /* according to maintainance manual p. 8-16 */
-	m_exc = 0;      /* according to maintainance manual p. 8-16 */
-	m_ioc = 1;      /* according to maintainance manual p. 6-10 */
-	m_ioh = 0;      /* according to maintainance manual p. 6-10 */
-	m_ios = 0;      /* according to maintainance manual p. 6-10 */
+	EXD = 0;            /* according to maintenance manual p. 8-16 */
+	m_exc = 0;      /* according to maintenance manual p. 8-16 */
+	m_ioc = 1;      /* according to maintenance manual p. 6-10 */
+	m_ioh = 0;      /* according to maintenance manual p. 6-10 */
+	m_ios = 0;      /* according to maintenance manual p. 6-10 */
 
 	m_b1 = m_type_20_sbs ? 0 : 1;   /* mere guess */
 	m_b2 = 0;       /* mere guess */

--- a/src/emu/cpu/pps4/pps4.c
+++ b/src/emu/cpu/pps4/pps4.c
@@ -571,7 +571,7 @@ void pps4_device::iEXD()
  * The 4-bit contents, immediate field I(4:1),
  * of the instruction are placed in the accumulator.
  *
- * Note: Only the first occurence of an LDI in a consecutive
+ * Note: Only the first occurrence of an LDI in a consecutive
  * string of LDIs will be executed. The program will ignore
  * remaining LDIs and execute next valid instruction.
  *
@@ -815,7 +815,7 @@ void pps4_device::iCYS()
  * This instruction takes two cycles to execute but occupies
  * only one ROM word. (Automatic return)
  *
- * Only the first occurence of an LB or LBL instruction in a
+ * Only the first occurrence of an LB or LBL instruction in a
  * consecutive string of LB or LBL will be executed. The
  * program will ignore the remaining LB or LBL and execute
  * the next valid instruction. Within subroutines the LB
@@ -858,7 +858,7 @@ void pps4_device::iLB()
  * bits of the B register. The four most significant bits
  * of B (BU) will be loaded with zeroes.
  *
- * Only the first occurence of an LB or LBL instruction in a
+ * Only the first occurrence of an LB or LBL instruction in a
  * consecutive string of LB or LBL will be executed. The
  * program will ignore the remaining LB or LBL and execute
  * the next valid instruction.

--- a/src/emu/cpu/tms32025/tms32025.c
+++ b/src/emu/cpu/tms32025/tms32025.c
@@ -1102,7 +1102,7 @@ void tms32025_device::macd()          /** RAM blocks B0,B1,B2 may be important !
 	CALCULATE_ADD_OVERFLOW(m_ALU.d);
 	CALCULATE_ADD_CARRY();
 	GETDATA(0, 0);
-	if ( (m_opcode.b.l & 0x80) || m_init_load_addr ) {  /* No writing during repitition, or DMA mode */
+	if ( (m_opcode.b.l & 0x80) || m_init_load_addr ) {  /* No writing during repetition, or DMA mode */
 		M_WRTRAM((m_memaccess+1), m_ALU.w.l);
 	}
 	m_Treg = m_ALU.w.l;

--- a/src/emu/cpu/tms9900/99xxcore.h
+++ b/src/emu/cpu/tms9900/99xxcore.h
@@ -787,7 +787,7 @@ WRITE8_HANDLER(tms9995_internal2_w)
 #elif (TMS99XX_MODEL == TMS9900_ID) || (TMS99XX_MODEL == TMS9940_ID)
 	/*16-bit data bus, 16-bit address bus (internal bus in the case of TMS9940)*/
 	/*Note that tms9900 actually never accesses a single byte : when performing byte operations,
-	it reads a 16-bit word, changes the revelant byte, then write a complete word.  You should
+	it reads a 16-bit word, changes the relevant byte, then write a complete word.  You should
 	remember this when writing memory handlers.*/
 	/*This does not apply to tms9995 and tms99xxx, but does apply to tms9980 (see below).*/
 
@@ -2342,7 +2342,7 @@ static void tms99xx_set_irq_line(tms99xx_state *cpustate, int irqline, int state
 /*
  * field_interrupt
  *
- * Determines whether if an interrupt is pending, and sets the revelant flag.
+ * Determines whether if an interrupt is pending, and sets the relevant flag.
  *
  * Called when an interrupt pin (LOAD*, INTREQ*, IC0-IC3) is changed, and when the interrupt mask
  * is modified.
@@ -2959,9 +2959,9 @@ static void contextswitch(tms99xx_state *cpustate, UINT16 addr)
 
 #if HAS_MAPPING || HAS_PRIVILEGE
 
-/* priviledged context switch, that occurs after a reset, interrupt or XOP:
-we enter priviledged mode and select map file 0 before doing the context switch */
-/* For CPU that have no priviledge support, contextswitchX would behave
+/* privileged context switch, that occurs after a reset, interrupt or XOP:
+we enter privileged mode and select map file 0 before doing the context switch */
+/* For CPU that have no privilege support, contextswitchX would behave
 identically to contextswitch, so we can call contextswitch in all cases. */
 static void contextswitchX(tms99xx_state *cpustate, UINT16 addr)
 {
@@ -2973,7 +2973,7 @@ static void contextswitchX(tms99xx_state *cpustate, UINT16 addr)
 	setstat(cpustate);
 	oldST = cpustate->STATUS;
 
-	/* enter priviledged mode and select map file 0 */
+	/* enter privileged mode and select map file 0 */
 	#if HAS_PRIVILEGE
 		cpustate->STATUS &= ~ ST_PR;
 	#endif
@@ -4951,7 +4951,7 @@ static void h4000b(tms99xx_state *cpustate, UINT16 opcode)
 		setst_byte_laep(cpustate, value);
 		#if (TMS99XX_MODEL <= TMS9985_ID)
 			/* On ti990/10 and tms9900, MOVB needs to read destination, because it cannot actually
-			  read one single byte.  It reads a word, replaces the revelant byte, then write
+			  read one single byte.  It reads a word, replaces the relevant byte, then write
 			  the result.  A tms9980 should not need to do so, but still does, because it is just
 			  a tms9900 with a 16 to 8 bit multiplexer (instead of a new chip design, like tms9995). */
 			(void)readbyteX(cpustate, dest, dst_map);

--- a/src/emu/cpu/tms9900/tms9995.c
+++ b/src/emu/cpu/tms9900/tms9995.c
@@ -1467,7 +1467,7 @@ void tms9995_device::int_prefetch_and_decode()
 				if (m_idle_state)
 				{
 					m_idle_state = false;
-					if (TRACE_INT) logerror("tms9995: Interrupt occured, terminate IDLE state\n");
+					if (TRACE_INT) logerror("tms9995: Interrupt occurred, terminate IDLE state\n");
 				}
 				PC = PC + 2;        // PC must be advanced (see flow chart), but no prefetch
 				if (TRACE_INT) logerror("tms9995: Interrupts pending; no prefetch; advance PC to %04x\n", PC);

--- a/src/emu/diserial.h
+++ b/src/emu/diserial.h
@@ -68,7 +68,7 @@ public:
 						/*                               end is ready to accept it */
 		DSR = 0x0004, /* Data Set ready.      (INPUT)  Other end of connection has data */
 		DTR = 0x0008, /* Data terminal Ready. (OUTPUT) TX contains new data. */
-		RX  = 0x0010, /* Recieve data.        (INPUT)  */
+		RX  = 0x0010, /* Receive data.        (INPUT)  */
 		TX  = 0x0020  /* TX = Transmit data.  (OUTPUT) */
 	};
 

--- a/src/emu/machine/hdc9234.c
+++ b/src/emu/machine/hdc9234.c
@@ -627,7 +627,7 @@ void hdc9234_device::read_id(int& cont, bool implied_seek, bool wait_seek_comple
 			break;
 
 		case READ_ID1:
-			// If an error occured (no IDAM found), terminate the command
+			// If an error occurred (no IDAM found), terminate the command
 			if ((m_register_r[CHIP_STATUS] & CS_SYNCERR) != 0)
 			{
 				if (TRACE_FAIL) logerror("%s: READ_ID failed to find any IDAM\n", tag());
@@ -735,7 +735,7 @@ void hdc9234_device::verify(int& cont, bool verify_all)
 
 			if (TRACE_VERIFY && TRACE_SUBSTATES) logerror("%s: substate VERIFY\n", tag());
 
-			// If an error occured (no IDAM found), terminate the command
+			// If an error occurred (no IDAM found), terminate the command
 			// (This test is only relevant when we did not have a seek phase before)
 			if ((m_register_r[CHIP_STATUS] & CS_SYNCERR) != 0)
 			{
@@ -1757,7 +1757,7 @@ void hdc9234_device::write_sectors()
     state machine attempts to find marks on the track, starting from the current
     position. When found, it waits for the machine to catch up. When an event
     happens in the meantime, the state machine is rolled back, and the actions
-    are replayed until the position where the event occured.
+    are replayed until the position where the event occurred.
 
     Lots of code is taken from wd_fdc, with some minor restructuring and renaming.
     Same ideas, though. More comments.

--- a/src/emu/machine/mb89352.h
+++ b/src/emu/machine/mb89352.h
@@ -63,7 +63,7 @@ public:
 	template<class _Object> static devcb_base &set_irq_callback(device_t &device, _Object object) { return downcast<mb89352_device &>(device).m_irq_cb.set_callback(object); }
 	template<class _Object> static devcb_base &set_drq_callback(device_t &device, _Object object) { return downcast<mb89352_device &>(device).m_drq_cb.set_callback(object); }
 
-	// any publically accessible interfaces needed for runtime
+	// any publicly accessible interfaces needed for runtime
 	DECLARE_READ8_MEMBER( mb89352_r );
 	DECLARE_WRITE8_MEMBER( mb89352_w );
 

--- a/src/emu/machine/mb89352.h
+++ b/src/emu/machine/mb89352.h
@@ -63,7 +63,7 @@ public:
 	template<class _Object> static devcb_base &set_irq_callback(device_t &device, _Object object) { return downcast<mb89352_device &>(device).m_irq_cb.set_callback(object); }
 	template<class _Object> static devcb_base &set_drq_callback(device_t &device, _Object object) { return downcast<mb89352_device &>(device).m_drq_cb.set_callback(object); }
 
-	// any publicly accessible interfaces needed for runtime
+	// any publically accessible interfaces needed for runtime
 	DECLARE_READ8_MEMBER( mb89352_r );
 	DECLARE_WRITE8_MEMBER( mb89352_w );
 

--- a/src/emu/machine/ncr5380n.h
+++ b/src/emu/machine/ncr5380n.h
@@ -127,7 +127,7 @@ private:
 		ARB_TIMEOUT_ABORT,
 		ARB_DESKEW_WAIT,
 
-		// Send/recieve byte
+		// Send/receive byte
 		SEND_WAIT_SETTLE,
 		SEND_WAIT_REQ_0,
 		RECV_WAIT_REQ_1,

--- a/src/emu/machine/ncr5390.h
+++ b/src/emu/machine/ncr5390.h
@@ -119,7 +119,7 @@ private:
 		ARB_TIMEOUT_ABORT,
 		ARB_DESKEW_WAIT,
 
-		// Send/recieve byte
+		// Send/receive byte
 		SEND_WAIT_SETTLE,
 		SEND_WAIT_REQ_0,
 		RECV_WAIT_REQ_1,

--- a/src/emu/machine/spchrom.c
+++ b/src/emu/machine/spchrom.c
@@ -11,7 +11,7 @@
     Interfacing it with the tms5110 would make sense, too.
 
     TODO:
-        Create seperate devices for TMS6100 & TMS6125
+        Create separate devices for TMS6100 & TMS6125
         Implement the serial protocol
 */
 

--- a/src/emu/sound/msm5205.c
+++ b/src/emu/sound/msm5205.c
@@ -28,7 +28,7 @@
 
     Data is streamed from a CPU by means of a clock generated on the chip.
 
-    A reset signal is set high or low to determine whether playback (and interrupts) are occuring.
+    A reset signal is set high or low to determine whether playback (and interrupts) are occurring.
 
   MSM6585: is an upgraded MSM5205 voice synth IC.
    Improvements:

--- a/src/emu/video/315_5124.c
+++ b/src/emu/video/315_5124.c
@@ -562,7 +562,7 @@ void sega315_5124_device::check_pending_flags()
 	/* A timer ensures that this function will run at least at end of each line.
 	   When this function runs through a CPU instruction executed when the timer
 	   was about to fire, the time added in the CPU timeslice may make hpos()
-	   return some position in the begining of next line. To ensure the instruction
+	   return some position in the beginning of next line. To ensure the instruction
 	   will get updated status, here a maximum hpos is set if the timer reports no
 	   remaining time, what could also occur due to the ahead time of the timeslice. */
 	if (m_pending_flags_timer->remaining() == attotime::zero)
@@ -712,7 +712,7 @@ WRITE8_MEMBER( sega315_5124_device::register_write )
 				//
 				// For VINT disabling through register 01:
 				// When running eagles5 on the smskr driver the irq_state is 1 because of some
-				// previos HINTs that occured. eagles5 sets register 01 to 0x02 and expects
+				// previos HINTs that occurred. eagles5 sets register 01 to 0x02 and expects
 				// the irq state to be cleared after that.
 				// The following bit of code takes care of that.
 				//

--- a/src/emu/video/epic12.c
+++ b/src/emu/video/epic12.c
@@ -96,7 +96,7 @@ UINT64 epic12_device_blit_delay;
 
 inline UINT16 epic12_device::READ_NEXT_WORD(offs_t *addr)
 {
-//  UINT16 data = space.read_word(*addr); // going through the memory system is 'more correct' but noticably slower
+//  UINT16 data = space.read_word(*addr); // going through the memory system is 'more correct' but noticeably slower
 	UINT16 data = m_use_ram[((*addr & m_main_rammask) >> 1) ^ NATIVE_ENDIAN_VALUE_LE_BE(3, 0)];
 
 	*addr += 2;
@@ -107,7 +107,7 @@ inline UINT16 epic12_device::READ_NEXT_WORD(offs_t *addr)
 
 inline UINT16 epic12_device::COPY_NEXT_WORD(address_space &space, offs_t *addr)
 {
-//  UINT16 data = space.read_word(*addr); // going through the memory system is 'more correct' but noticably slower
+//  UINT16 data = space.read_word(*addr); // going through the memory system is 'more correct' but noticeably slower
 	UINT16 data = m_ram16[((*addr & m_main_rammask) >> 1) ^ NATIVE_ENDIAN_VALUE_LE_BE(3, 0)];
 	m_ram16_copy[((*addr & m_main_rammask) >> 1) ^ NATIVE_ENDIAN_VALUE_LE_BE(3, 0)] = data;
 

--- a/src/emu/video/v9938.c
+++ b/src/emu/video/v9938.c
@@ -3240,7 +3240,7 @@ UINT8 v99x8_device::command_unit_w(UINT8 Op)
 	// Start execution if we still have time slices
 	if(m_vdp_engine&&(m_vdp_ops_count>0)) (this->*m_vdp_engine)();
 
-	// Operation successfull initiated
+	// Operation successfully initiated
 	return(1);
 }
 

--- a/src/lib/util/chd.c
+++ b/src/lib/util/chd.c
@@ -2669,12 +2669,12 @@ void chd_file_compressor::async_read()
 	}
 	catch (chd_error& err)
 	{
-		fprintf(stderr, "CHD error occured: %s\n", chd_file::error_string(err));
+		fprintf(stderr, "CHD error occurred: %s\n", chd_file::error_string(err));
 		m_read_error = true;
 	}
 	catch (std::exception& ex)
 	{
-		fprintf(stderr, "exception occured: %s\n", ex.what());
+		fprintf(stderr, "exception occurred: %s\n", ex.what());
 		m_read_error = true;
 	}
 }

--- a/src/mame/drivers/40love.c
+++ b/src/mame/drivers/40love.c
@@ -33,7 +33,7 @@ One GFX ROM is bad though.
 See A30-26.u23\A30-26.txt for details about the bad ROM.
 To summarise:
   Dumps from GFX ROM A30-26.u23 were inconsistent. Reads with checksums
-  41A3 and 415F occured a couple of times, and the difference is one byte
+  41A3 and 415F occurred a couple of times, and the difference is one byte
   at offset $0004 (data $CC or $88). Maybe one of these reads is correct
   or closest to the real ROM. We are using the one with checksum 415F,
   the other one makes one sprite looks worse.

--- a/src/mame/drivers/chance32.c
+++ b/src/mame/drivers/chance32.c
@@ -202,7 +202,7 @@ ADDRESS_MAP_END
 
 static ADDRESS_MAP_START( chance32_portmap, AS_IO, 8, chance32_state )
 	ADDRESS_MAP_GLOBAL_MASK(0xff)
-	AM_RANGE(0x10, 0x10) AM_WRITENOP        // writting bit3 constantly... watchdog?
+	AM_RANGE(0x10, 0x10) AM_WRITENOP        // writing bit3 constantly... watchdog?
 	AM_RANGE(0x13, 0x13) AM_WRITE(mux_w)
 	AM_RANGE(0x20, 0x20) AM_READ_PORT("DSW0")
 	AM_RANGE(0x21, 0x21) AM_READ_PORT("DSW1")

--- a/src/mame/drivers/cocoloco.c
+++ b/src/mame/drivers/cocoloco.c
@@ -387,7 +387,7 @@ static ADDRESS_MAP_START( cocoloco_map, AS_PROGRAM, 8, cocoloco_state )
 ADDRESS_MAP_END
 
 /*
-  1800-3fff: RW  --> code inits reading and writting the whole range.
+  1800-3fff: RW  --> code inits reading and writing the whole range.
 
   All 3 instances of A005 reads (d07e, d355 and dca8),
   discard the read in a non-sense way....

--- a/src/mame/drivers/coinmstr.c
+++ b/src/mame/drivers/coinmstr.c
@@ -112,7 +112,7 @@
   (keep pressing HOLD 4, and press HIGH and LOW to set the stake limit
   between 10-100).
 
-  Pressing DEAL/START, you can get the winning hands, occurence of
+  Pressing DEAL/START, you can get the winning hands, occurrence of
   spades, diamonds, clubs and hearts. also number of jokers dealt.
 
   With DIP switch #8 ON, you can enter a sort of test mode, where you

--- a/src/mame/drivers/coolridr.c
+++ b/src/mame/drivers/coolridr.c
@@ -2195,7 +2195,7 @@ void coolridr_state::blit_current_sprite(address_space &space)
 			//
 			// all other cliprect blits seem to be written after mode 50, so this hack just prevents
 			// writes with a higher value than the last one from taking effect, fixing the ending...
-			// especially noticable with 'LoveMachine'
+			// especially noticeable with 'LoveMachine'
 			// (mode 4f) unknown sprite list type 1 - 0054 0105 0059 0198 (00540105 0060019f 00000007)
 			// (mode 50) unknown sprite list type 1 - 0000 017f 0000 01f0 (0000017f 000701f7 00000007)
 			// said ending also ends up drawing a red bar under the image, which isn't clipped out and

--- a/src/mame/drivers/dday.c
+++ b/src/mame/drivers/dday.c
@@ -8,7 +8,7 @@ driver by Zsolt Vasvari
 Convention: "sl" stands for "searchlight"
 
 Note: This game doesn't seem to support cocktail mode, which is not too
-      suprising for a gun game.
+      surprising for a gun game.
 
 0000-3fff ROM
 5000-53ff Text layer videoram

--- a/src/mame/drivers/decocass.c
+++ b/src/mame/drivers/decocass.c
@@ -1108,7 +1108,7 @@ ROM_START( clocknch )
 ROM_END
 
 /* 13 */
-/* Photo of Dongle shows DP-1130B (the "B" is in a seperate white box then the DP-1130 label) */
+/* Photo of Dongle shows DP-1130B (the "B" is in a separate white box then the DP-1130 label) */
 ROM_START( cprogolf ) // version 9-B-0
 	DECOCASS_BIOS_B_ROMS
 
@@ -1152,7 +1152,7 @@ ROM_START( cdsteljn ) // version 4-A-3
 ROM_END
 
 /* 15 Lucky Poker */
-/* Photo of Dongle shows DP-1150B (the "B" is in a seperate white box then the DP-1150 label) */
+/* Photo of Dongle shows DP-1150B (the "B" is in a separate white box then the DP-1150 label) */
 ROM_START( cluckypo )
 	DECOCASS_BIOS_B_ROMS
 
@@ -1213,7 +1213,7 @@ ROM_START( ctisland3 )
 ROM_END
 
 /* 18 Explorer */
-/* Photo of Dongle shows DP-1180B (the "B" is in a seperate white box then the DP-1180 label) */
+/* Photo of Dongle shows DP-1180B (the "B" is in a separate white box then the DP-1180 label) */
 ROM_START( cexplore )
 	DECOCASS_BIOS_B_ROMS
 
@@ -1233,7 +1233,7 @@ ROM_END
 
 /* 19 Disco No.1 / Sweet Heart */
 ROM_START( cdiscon1 )
-/* Photo of Dongle shows DP-1190B (the "B" is in a seperate white box then the DP-1190 label) */
+/* Photo of Dongle shows DP-1190B (the "B" is in a separate white box then the DP-1190 label) */
 	DECOCASS_BIOS_B_ROMS
 
 	ROM_REGION( 0x00800, "dongle", 0 )    /* dongle data */
@@ -1265,7 +1265,7 @@ ROM_START( ctornado )
 ROM_END
 
 /* 21 Mission-X */
-/* Photo of Dongle shows DP-121B with Cassette DT-1213B (the "3B" is in a seperate white box then the DP-121 label) */
+/* Photo of Dongle shows DP-121B with Cassette DT-1213B (the "3B" is in a separate white box then the DP-121 label) */
 ROM_START( cmissnx )
 	DECOCASS_BIOS_B_ROMS
 
@@ -1314,7 +1314,7 @@ ROM_END
 
 
 /* 26 Hamburger / Burger Time */
-/* Photo of Dongle shows DP-126B with Cassette DT-1267B (the "7B" is in a seperate white box then the DP-126 label) */
+/* Photo of Dongle shows DP-126B with Cassette DT-1267B (the "7B" is in a separate white box then the DP-126 label) */
 ROM_START( cbtime ) // version 7-B-0
 	DECOCASS_BIOS_B_ROMS
 
@@ -1336,7 +1336,7 @@ ROM_START( chamburger ) // version 0-A-0
 ROM_END
 
 /* 27 Burnin' Rubber / Bump 'n' Jump */
-/* Photo of Dongle shows DP-127B with Cassette DP-1275B (the "5B" is in a seperate white box then the DP-127 label) */
+/* Photo of Dongle shows DP-127B with Cassette DP-1275B (the "5B" is in a separate white box then the DP-127 label) */
 ROM_START( cburnrub )
 	DECOCASS_BIOS_B_ROMS
 

--- a/src/mame/drivers/gei.c
+++ b/src/mame/drivers/gei.c
@@ -64,7 +64,7 @@ U.S.A. Trivia              New Sports                 General Facts
  or alt: Adult Sex 2        or alt: Adult Sex 3        or alt: Gay Times
 
 NOTE: Trivia Question rom names are the internal names used. IE: read from the file with
-      a Hex Editor. Any "_alt" extention is used to seperate different roms with the same
+      a Hex Editor. Any "_alt" extention is used to separate different roms with the same
       label or internal name.
 
 */

--- a/src/mame/drivers/hikaru.c
+++ b/src/mame/drivers/hikaru.c
@@ -373,7 +373,7 @@ Notes:
     subroutines, after all.)
 
   - the serial device at 0080000(A|C) is not an EEPROM; it's likely some
-    weird device that is used to query the heirarchy of the attached
+    weird device that is used to query the hierarchy of the attached
     input/output devices. Probably the naomi has something similar, I
     haven't looked into it yet.
 

--- a/src/mame/drivers/jubilee.c
+++ b/src/mame/drivers/jubilee.c
@@ -570,7 +570,7 @@ ADDRESS_MAP_END
 
 /* I/O byte R/W
 
-   0x080  R    ; Input port? polled once at begining.
+   0x080  R    ; Input port? Polled once at beginning.
    0x0C8  R    ; Input port.
 
    Can't see more inputs. There is a multiplexion with the following offsets as selectors:

--- a/src/mame/drivers/kas89.c
+++ b/src/mame/drivers/kas89.c
@@ -282,7 +282,7 @@ WRITE8_MEMBER(kas89_state::mux_w)
     7654 3210
     xxxx xxxx   Input selector.
 
-    Writes: 1-2-4-8-10-20-40-3f. Only 80 (for DSW) at very begining...
+    Writes: 1-2-4-8-10-20-40-3f. Only 80 (for DSW) at very beginning...
 */
 
 	m_mux_data = data;

--- a/src/mame/drivers/maygaysw.c
+++ b/src/mame/drivers/maygaysw.c
@@ -271,7 +271,7 @@ MAYGAY M2 - London Underground SWP game
 Dumped by Andy Welburn on a sunny morning 10/03/07
 
 *************************************************
-**Do not seperate this text file from the roms.**
+**Do not separate this text file from the roms.**
 *************************************************
 
 filename:   label:          location    type

--- a/src/mame/drivers/merit.c
+++ b/src/mame/drivers/merit.c
@@ -1796,7 +1796,7 @@ ROM_START( tictac )
 	ROM_LOAD( "merit.u40",    0x00000, 0x2000, CRC(ab0088eb) SHA1(23a05a4dc11a8497f4fc7e4a76085af15ff89cea) )
 
 	ROM_REGION( 0xa0000, "user1", ROMREGION_ERASEFF ) /* questions */
-	ROM_LOAD( "spo-004_01a.1", 0x08000, 0x8000, CRC(71b398a9) SHA1(5ea07c409afd52c7d08592b30ff0ff3b72c3f8c3) ) /* Trivia catagories are: */
+	ROM_LOAD( "spo-004_01a.1", 0x08000, 0x8000, CRC(71b398a9) SHA1(5ea07c409afd52c7d08592b30ff0ff3b72c3f8c3) ) /* Trivia categories are: */
 	ROM_LOAD( "spo-004_02a.2", 0x18000, 0x8000, CRC(eb34672f) SHA1(c472fc4445fc434029a2740dfc1d9ab9b1ef9f87) ) /* Sports, Entertainment, General Interest & Sex Trivia III */
 	ROM_LOAD( "spo-004_03a.3", 0x28000, 0x8000, CRC(8eea30b9) SHA1(fe1d0332106631f56bc6c57a888da9e4e63fa52f) )
 	ROM_LOAD( "ent-004_01.4",  0x38000, 0x8000, CRC(3f45064d) SHA1(de109ac0b19fd1cd7f0020cc174c2da21708108c) )
@@ -1821,7 +1821,7 @@ ROM_START( tictacv )
 	ROM_LOAD( "ttts_u-40.u40", 0x00000, 0x2000, CRC(c7071c98) SHA1(88e1b26f198cfbbd86b492356f60fc1b81b38d97) )
 
 	ROM_REGION( 0xa0000, "user1", ROMREGION_ERASEFF ) /* questions */
-	ROM_LOAD( "spo-004_01a.1", 0x08000, 0x8000, CRC(71b398a9) SHA1(5ea07c409afd52c7d08592b30ff0ff3b72c3f8c3) ) /* Trivia catagories are: */
+	ROM_LOAD( "spo-004_01a.1", 0x08000, 0x8000, CRC(71b398a9) SHA1(5ea07c409afd52c7d08592b30ff0ff3b72c3f8c3) ) /* Trivia categories are: */
 	ROM_LOAD( "spo-004_02a.2", 0x18000, 0x8000, CRC(eb34672f) SHA1(c472fc4445fc434029a2740dfc1d9ab9b1ef9f87) ) /* Sports, Entertainment, General Interest & Sex Trivia III */
 	ROM_LOAD( "spo-004_03a.3", 0x28000, 0x8000, CRC(8eea30b9) SHA1(fe1d0332106631f56bc6c57a888da9e4e63fa52f) )
 	ROM_LOAD( "ent-004_01.4",  0x38000, 0x8000, CRC(3f45064d) SHA1(de109ac0b19fd1cd7f0020cc174c2da21708108c) )

--- a/src/mame/drivers/namcos10.c
+++ b/src/mame/drivers/namcos10.c
@@ -28,7 +28,7 @@ Kotoba no Puzzle Mojipittan (KPM1 Ver.A)         (C) Namco, 2001
 Mr Driller 2 (DR21 Ver.A)                        (C) Namco, 2000
 Mr Driller 2 (DR22 Ver.A)                        (C) Namco, 2000
 Mr Driller G (DRG1 Ver.A)                        (C) Namco, 2001
-NFL Classic Football (NCF3 Ver.A)                (C) Namco, 2003 - Has a noticable red dot the right right of the version printed on PCB.  Something to determine region?
+NFL Classic Football (NCF3 Ver.A)                (C) Namco, 2003 - Has a noticeable red dot on the right of the version printed on PCB.  Something to determine region?
 Panicuru Panekuru (PPA1 Ver.A)                   (C) Namco, 2001
 *Photo Battole                                   (C) Namco, 2001
 Point Blank 3 / Gunbalina (GNN2 Ver. A)          (C) Namco, 2000

--- a/src/mame/drivers/naomi.c
+++ b/src/mame/drivers/naomi.c
@@ -67,7 +67,7 @@ TODO (general):
     * Shootout Pool Medal
     * Shootout Pool Prize
 
-    - "com error occured between Naomi BD and I/O BD"
+    - "com error occurred between Naomi BD and I/O BD"
     * Samba de Amigo
     * Samba de Amigo (prototype)
     * Samba de Amigo Ver. 2000
@@ -595,7 +595,7 @@ Mushiking - The King Of Beetles II ENG (Ver. 1.001) 840-0164C  not present  2 (5
 Mushiking - The King Of Beetles II ENG (Ver. 2.001) 840-0164C  24357        2 (512Mb)   present  317-0437-COM  present  IC4# is marked "18"
 Poka Suka Ghost                                     840-0170C  not present  5 (512Mb)   present  317-0461-COM  present  requires 837-14672 sensor board (SH4 based)
 Radirgy Noa                                         841-0062C  not present  4 (512Mb)   present  317-5138-JPN  present  IC2# is labeled "VER.2" - IC4# is marked "8A"
-Rythm Tengoku                                       841-0177C  not present  4 (512Mb)   present  317-0503-JPN  present  IC2# is labeled "VER.2" - IC4# is marked "8A"
+Rhythm Tengoku                                      841-0177C  not present  4 (512Mb)   present  317-0503-JPN  present  IC2# is labeled "VER.2" - IC4# is marked "8A"
 Star Horse Progress Returns (satellite)             840-0186C  not present  2 (512Mb)   present  not present   present  IC2# is labeled "VER.2", requires 837-13785 ARCNET&IO BD
 Shooting Love 2007                                  841-0057C  not present  4 (512Mb)   present  317-5129-JPN  present  IC2# is labeled "VER.2"
 Touch De Zunou (Rev A)                              840-0166C  not present  2 (512Mb)   present  317-0435-JPN  present  IC4# is marked "18", requires 837-14672 sensor board (SH4 based)

--- a/src/mame/drivers/pgm2.c
+++ b/src/mame/drivers/pgm2.c
@@ -25,7 +25,7 @@
      IGS037(GFX PROCESSOR)
      YMZ774-S(SOUND)
      R5F21256SN(extra MCU for protection and ICcard communication)
-      - Appears to be refered to by the games as MPU
+      - Appears to be referred to by the games as MPU
 
     Cartridges
      IGS036 (MAIN CPU) (differs per game, internal code)

--- a/src/mame/drivers/playmark.c
+++ b/src/mame/drivers/playmark.c
@@ -54,7 +54,7 @@ TODO:
   ROM is currently missing.
 - Lucky Boom has some minor colour issue with the background - see the title screen. The
   game selects the wrong colour for some tiles. The tiles should be colour 0x01 not 0x02.
-  Affects the backgrounds in game however it's barely noticable.
+  Affects the backgrounds in game however it's barely noticeable.
 
 ***************************************************************************/
 

--- a/src/mame/drivers/psikyosh.c
+++ b/src/mame/drivers/psikyosh.c
@@ -108,7 +108,7 @@ TAKO-8
 
 --- Gunbarich ---
 
-0-2-9-2-0 Maintainance Mode
+0-2-9-2-0 Maintenance Mode
 0-2-9-1-0 All Data Initialised
 1-2-3-4-5 Best Score Erased
 

--- a/src/mame/drivers/sfbonus.c
+++ b/src/mame/drivers/sfbonus.c
@@ -462,7 +462,7 @@ public:
 	TILE_GET_INFO_MEMBER(get_sfbonus_reel4_tile_info);
 	virtual void machine_reset();
 	virtual void video_start();
-	void draw_reel_layer(screen_device &screen, bitmap_ind16 &bitmap, const rectangle &cliprect, int catagory);
+	void draw_reel_layer(screen_device &screen, bitmap_ind16 &bitmap, const rectangle &cliprect, int category);
 	UINT32 screen_update_sfbonus(screen_device &screen, bitmap_ind16 &bitmap, const rectangle &cliprect);
 };
 
@@ -929,7 +929,7 @@ void sfbonus_state::video_start()
 
 }
 
-void sfbonus_state::draw_reel_layer(screen_device &screen, bitmap_ind16 &bitmap, const rectangle &cliprect, int catagory)
+void sfbonus_state::draw_reel_layer(screen_device &screen, bitmap_ind16 &bitmap, const rectangle &cliprect, int category)
 {
 	int zz;
 	int i;
@@ -1021,38 +1021,38 @@ void sfbonus_state::draw_reel_layer(screen_device &screen, bitmap_ind16 &bitmap,
 
 		if (rowenable2==0)
 		{
-			m_reel_tilemap->draw(screen, *m_temp_reel_bitmap, clip, TILEMAP_DRAW_CATEGORY(catagory),3);
+			m_reel_tilemap->draw(screen, *m_temp_reel_bitmap, clip, TILEMAP_DRAW_CATEGORY(category),3);
 		}
 		if (rowenable==0)
 		{
-			m_reel_tilemap->draw(screen, *m_temp_reel_bitmap, clip, TILEMAP_DRAW_CATEGORY(catagory),3);
+			m_reel_tilemap->draw(screen, *m_temp_reel_bitmap, clip, TILEMAP_DRAW_CATEGORY(category),3);
 		}
 
 		if (rowenable2==0x1)
 		{
-			m_reel2_tilemap->draw(screen, *m_temp_reel_bitmap, clip, TILEMAP_DRAW_CATEGORY(catagory),2);
+			m_reel2_tilemap->draw(screen, *m_temp_reel_bitmap, clip, TILEMAP_DRAW_CATEGORY(category),2);
 		}
 		if (rowenable==0x1)
 		{
-			m_reel2_tilemap->draw(screen, *m_temp_reel_bitmap, clip, TILEMAP_DRAW_CATEGORY(catagory),2);
+			m_reel2_tilemap->draw(screen, *m_temp_reel_bitmap, clip, TILEMAP_DRAW_CATEGORY(category),2);
 		}
 
 		if (rowenable2==0x2)
 		{
-			m_reel3_tilemap->draw(screen, *m_temp_reel_bitmap, clip, TILEMAP_DRAW_CATEGORY(catagory),1);
+			m_reel3_tilemap->draw(screen, *m_temp_reel_bitmap, clip, TILEMAP_DRAW_CATEGORY(category),1);
 		}
 		if (rowenable==0x2)
 		{
-			m_reel3_tilemap->draw(screen, *m_temp_reel_bitmap, clip, TILEMAP_DRAW_CATEGORY(catagory),1);
+			m_reel3_tilemap->draw(screen, *m_temp_reel_bitmap, clip, TILEMAP_DRAW_CATEGORY(category),1);
 		}
 
 		if (rowenable2==0x3)
 		{
-			m_reel4_tilemap->draw(screen, *m_temp_reel_bitmap, clip, TILEMAP_DRAW_CATEGORY(catagory),4);
+			m_reel4_tilemap->draw(screen, *m_temp_reel_bitmap, clip, TILEMAP_DRAW_CATEGORY(category),4);
 		}
 		if (rowenable==0x3)
 		{
-			m_reel4_tilemap->draw(screen, *m_temp_reel_bitmap, clip, TILEMAP_DRAW_CATEGORY(catagory),4);
+			m_reel4_tilemap->draw(screen, *m_temp_reel_bitmap, clip, TILEMAP_DRAW_CATEGORY(category),4);
 		}
 
 

--- a/src/mame/drivers/sfbonus.c
+++ b/src/mame/drivers/sfbonus.c
@@ -462,7 +462,7 @@ public:
 	TILE_GET_INFO_MEMBER(get_sfbonus_reel4_tile_info);
 	virtual void machine_reset();
 	virtual void video_start();
-	void draw_reel_layer(screen_device &screen, bitmap_ind16 &bitmap, const rectangle &cliprect, int category);
+	void draw_reel_layer(screen_device &screen, bitmap_ind16 &bitmap, const rectangle &cliprect, int catagory);
 	UINT32 screen_update_sfbonus(screen_device &screen, bitmap_ind16 &bitmap, const rectangle &cliprect);
 };
 
@@ -929,7 +929,7 @@ void sfbonus_state::video_start()
 
 }
 
-void sfbonus_state::draw_reel_layer(screen_device &screen, bitmap_ind16 &bitmap, const rectangle &cliprect, int category)
+void sfbonus_state::draw_reel_layer(screen_device &screen, bitmap_ind16 &bitmap, const rectangle &cliprect, int catagory)
 {
 	int zz;
 	int i;
@@ -1021,38 +1021,38 @@ void sfbonus_state::draw_reel_layer(screen_device &screen, bitmap_ind16 &bitmap,
 
 		if (rowenable2==0)
 		{
-			m_reel_tilemap->draw(screen, *m_temp_reel_bitmap, clip, TILEMAP_DRAW_CATEGORY(category),3);
+			m_reel_tilemap->draw(screen, *m_temp_reel_bitmap, clip, TILEMAP_DRAW_CATEGORY(catagory),3);
 		}
 		if (rowenable==0)
 		{
-			m_reel_tilemap->draw(screen, *m_temp_reel_bitmap, clip, TILEMAP_DRAW_CATEGORY(category),3);
+			m_reel_tilemap->draw(screen, *m_temp_reel_bitmap, clip, TILEMAP_DRAW_CATEGORY(catagory),3);
 		}
 
 		if (rowenable2==0x1)
 		{
-			m_reel2_tilemap->draw(screen, *m_temp_reel_bitmap, clip, TILEMAP_DRAW_CATEGORY(category),2);
+			m_reel2_tilemap->draw(screen, *m_temp_reel_bitmap, clip, TILEMAP_DRAW_CATEGORY(catagory),2);
 		}
 		if (rowenable==0x1)
 		{
-			m_reel2_tilemap->draw(screen, *m_temp_reel_bitmap, clip, TILEMAP_DRAW_CATEGORY(category),2);
+			m_reel2_tilemap->draw(screen, *m_temp_reel_bitmap, clip, TILEMAP_DRAW_CATEGORY(catagory),2);
 		}
 
 		if (rowenable2==0x2)
 		{
-			m_reel3_tilemap->draw(screen, *m_temp_reel_bitmap, clip, TILEMAP_DRAW_CATEGORY(category),1);
+			m_reel3_tilemap->draw(screen, *m_temp_reel_bitmap, clip, TILEMAP_DRAW_CATEGORY(catagory),1);
 		}
 		if (rowenable==0x2)
 		{
-			m_reel3_tilemap->draw(screen, *m_temp_reel_bitmap, clip, TILEMAP_DRAW_CATEGORY(category),1);
+			m_reel3_tilemap->draw(screen, *m_temp_reel_bitmap, clip, TILEMAP_DRAW_CATEGORY(catagory),1);
 		}
 
 		if (rowenable2==0x3)
 		{
-			m_reel4_tilemap->draw(screen, *m_temp_reel_bitmap, clip, TILEMAP_DRAW_CATEGORY(category),4);
+			m_reel4_tilemap->draw(screen, *m_temp_reel_bitmap, clip, TILEMAP_DRAW_CATEGORY(catagory),4);
 		}
 		if (rowenable==0x3)
 		{
-			m_reel4_tilemap->draw(screen, *m_temp_reel_bitmap, clip, TILEMAP_DRAW_CATEGORY(category),4);
+			m_reel4_tilemap->draw(screen, *m_temp_reel_bitmap, clip, TILEMAP_DRAW_CATEGORY(catagory),4);
 		}
 
 

--- a/src/mame/drivers/snowbros.c
+++ b/src/mame/drivers/snowbros.c
@@ -53,7 +53,7 @@ Cookie & Bibi 3
 This game is quite buggy.  The test mode is incomplete and displays garbage
 on the 'Dipswitch settings' screens, and during some of the attract mode
 scenes the credit counter is not updated when you insert coins until the next
-scene.  Both these bugs are verified as occuring on the original hardware.
+scene.  Both these bugs are verified as occurring on the original hardware.
 
 Honey Doll / Twin Adventure
 

--- a/src/mame/drivers/stfight.c
+++ b/src/mame/drivers/stfight.c
@@ -54,7 +54,7 @@ RST 10,the main IRQ, is to be triggered each time the screen is refreshed.
 RST 08 must be triggered in order to make the game work properly. I haven't
 ascertained the exact frequency of this interrupt yet, though the game
 appears to run at the correct speed with RST08 at 30Hz. Curiously a trace
-on the interrupt pin shows two interrupts occuring at 60Hz, obviously the
+on the interrupt pin shows two interrupts occurring at 60Hz, obviously the
 VBlank interrupt followed by a second interrupt some 3.3ms later. At some
 stage I'll get around to probing the data lines to find the interrupt
 vector addresses.

--- a/src/mame/drivers/vlc.c
+++ b/src/mame/drivers/vlc.c
@@ -29,7 +29,7 @@ PRINTER communication (Star Printer )
 ******************************************************
 SECURITY SYSTEM
 
-ADRESS A40000..A40001
+ADDRESS A40000..A40001
 U35 PAL16R8  SECURITY
 PAL is connect on the BUS D15..D8
 Write Clock 8 bits in D15..D8
@@ -204,7 +204,7 @@ need further test on PAL16R8 (FlipFlop Trick with other bits ?)
 this DUMP is done writing 0 to 255 and reading output (probably not the good way.)
 
 PAL is connected on the UPPER byte D15..D8
-Adress A40000..A40001
+Address A40000..A40001
 2 Type of PAL (one for game, the other is to set game to fabric default)
 
 there is a 74LS173 on the LOWER byte that used bit D3..D0
@@ -469,7 +469,7 @@ U40 MC68681 PIN38 IP5  from U51 DS1260 smart Battery POWER FAIL FLAG
 U40 MC68681 Pin12 OP1  JCM Bill Acceptor  (Enable Comm. U34)
 U40 MC68681 Pin27 OP4  JCM Bill Acceptor  (J4-6, J4-7 Control)
 
-// missing adress for :
+// missing address for :
 // external I/O board communication via PAL23
 
     A23 A22 A21 A20  | A19 A18 A17 A16 | A15 A14 A13 A12 | A11 A10 A9 A8 | A7 A6 A5 A4 | A3 A2 A1 xx
@@ -487,11 +487,11 @@ U40 MC68681 Pin27 OP4  JCM Bill Acceptor  (J4-6, J4-7 Control)
     00014001
     00020001
     00024001
-    00900001 6845  CS  CRTC U8  RS=LOW   ADRESS REGISTER    (A15 ON RS)  Data bus on D7..D0
+    00900001 6845  CS  CRTC U8  RS=LOW   ADDRESS REGISTER   (A15 ON RS)  Data bus on D7..D0
     00980001 6845  CS  CRTC U8  RS=HIGH  DATA   REGISTER    (A15 ON RS)
     00A00001           I/O Board Communication
     00A08001           I/O Board Communication
-    00A10000 WDT    STROBE DS1232 WatchDog Controller (this adress reset Strobe of Ds1232)
+    00A10000 WDT    STROBE DS1232 WatchDog Controller (this address reset Strobe of Ds1232)
     00A20001 AY8912 BDIR  AUDIO  Data bus on D7..D0
     00A28001 AY8912 BC1   AUDIO
     00A300x1 6242  CS  RTC  U41 A0..A3   (A4..A7 ON A0..A3)  Data bus on D3..D0

--- a/src/mame/layout/hankin.lay
+++ b/src/mame/layout/hankin.lay
@@ -1,7 +1,7 @@
 <!-- Hankin copied from gp_1.lay -->
 
 <!-- 2014-08-14: Initial version.  [Robbbert] -->
-<!-- 2014-08-18: Changed to flourescent vacuum display.  [Robbbert] -->
+<!-- 2014-08-18: Changed to fluorescent vacuum display.  [Robbbert] -->
 
 <mamelayout version="2">
 

--- a/src/mame/layout/nsm.lay
+++ b/src/mame/layout/nsm.lay
@@ -30,7 +30,7 @@
 			<bounds left="0" top="20" right="362" bottom="394" />
 		</backdrop>
 
-		<!-- Flourescent Displays -->
+		<!-- Fluorescent Displays -->
 
 		<!-- Player 1 Score -->
 

--- a/src/mame/layout/wico.lay
+++ b/src/mame/layout/wico.lay
@@ -36,7 +36,7 @@
 			<bounds left="0" top="20" right="318" bottom="394" />
 		</backdrop>
 
-		<!-- Flourescent Displays -->
+		<!-- Fluorescent Displays -->
 
 		<!-- Player 1 Score -->
 

--- a/src/mame/machine/iteagle_fpga.c
+++ b/src/mame/machine/iteagle_fpga.c
@@ -56,8 +56,8 @@ void iteagle_fpga_device::device_reset()
 	m_ctrl_regs[0x10/4] =  0x00000000; // 0xFFFFFFFF causes a write of 0xFFFEFFFF then 0xFFFFFFFF  // Not sure
 	// 0x00&0x2 == 1 for boot
 	m_fpga_regs[0x00/4] =  0xC0000002; // 0xCF000002;// byte 3 is voltage sensor? high = 0x40 good = 0xC0 0xF0 0xFF; //0x80 0x30 0x00FF = voltage low
-	//m_fpga_regs[0x308/4]=0x0000ffff; // Low 16 bits gets read alot?
-	m_fpga_regs[0x08/4]=0x00000000; // Low 16 bits gets read alot?
+	//m_fpga_regs[0x308/4]=0x0000ffff; // Low 16 bits get read a lot?
+	m_fpga_regs[0x08/4]=0x00000000; // Low 16 bits get read a lot?
 	m_prev_reg = 0;
 }
 

--- a/src/mame/video/tc0480scp.c
+++ b/src/mame/video/tc0480scp.c
@@ -690,7 +690,7 @@ Historical Issues
    TC0480SCP_ctrl_word_write.
 
 4) Zoom movement was jagged: improved by bringing in scroll delta
-   values... but the results are noticably imperfect.
+   values... but the results are noticeably imperfect.
 
 **********************************************************************/
 

--- a/src/mame/video/tia.c
+++ b/src/mame/video/tia.c
@@ -481,7 +481,7 @@ void tia_video_device::draw_sprite_helper(UINT8* p, UINT8 *col, struct player_gf
 
 
 void tia_video_device::draw_missile_helper(UINT8* p, UINT8* col, int horz, int skipdelay, int latch, int start,
-	UINT8 RESMP, UINT8 ENAM, UINT8 NUSIZ, UINT8 COLUM)
+	UINT8 RESMP, UINT8 ENAM, UINT8 NUSIZ, UINT8 COLUMN)
 {
 	int num = nusiz[NUSIZ & 7][0];
 	int skp = nusiz[NUSIZ & 7][2];
@@ -508,27 +508,27 @@ void tia_video_device::draw_missile_helper(UINT8* p, UINT8* col, int horz, int s
 							if ( horz >= 0 )
 							{
 								if ( horz < 156 ) {
-									p[(horz + 1) % 160] = COLUM >> 1;
-									col[(horz + 1) % 160] = COLUM >> 1;
+									p[(horz + 1) % 160] = COLUMN >> 1;
+									col[(horz + 1) % 160] = COLUMN >> 1;
 								}
-								p[horz % 160] = COLUM >> 1;
-								col[horz % 160] = COLUM >> 1;
+								p[horz % 160] = COLUMN >> 1;
+								col[horz % 160] = COLUMN >> 1;
 							}
 							break;
 						case 2:
 						case 3:
 							if ( horz >= 0 )
 							{
-								p[horz % 160] = COLUM >> 1;
-								col[horz % 160] = COLUM >> 1;
+								p[horz % 160] = COLUMN >> 1;
+								col[horz % 160] = COLUMN >> 1;
 							}
 							break;
 						}
 					} else {
 						if ( horz >= 0 )
 						{
-							p[horz % 160] = COLUM >> 1;
-							col[horz % 160] = COLUM >> 1;
+							p[horz % 160] = COLUMN >> 1;
+							col[horz % 160] = COLUMN >> 1;
 						}
 					}
 				}

--- a/src/mame/video/tia.c
+++ b/src/mame/video/tia.c
@@ -481,7 +481,7 @@ void tia_video_device::draw_sprite_helper(UINT8* p, UINT8 *col, struct player_gf
 
 
 void tia_video_device::draw_missile_helper(UINT8* p, UINT8* col, int horz, int skipdelay, int latch, int start,
-	UINT8 RESMP, UINT8 ENAM, UINT8 NUSIZ, UINT8 COLUMN)
+	UINT8 RESMP, UINT8 ENAM, UINT8 NUSIZ, UINT8 COLUM)
 {
 	int num = nusiz[NUSIZ & 7][0];
 	int skp = nusiz[NUSIZ & 7][2];
@@ -508,27 +508,27 @@ void tia_video_device::draw_missile_helper(UINT8* p, UINT8* col, int horz, int s
 							if ( horz >= 0 )
 							{
 								if ( horz < 156 ) {
-									p[(horz + 1) % 160] = COLUMN >> 1;
-									col[(horz + 1) % 160] = COLUMN >> 1;
+									p[(horz + 1) % 160] = COLUM >> 1;
+									col[(horz + 1) % 160] = COLUM >> 1;
 								}
-								p[horz % 160] = COLUMN >> 1;
-								col[horz % 160] = COLUMN >> 1;
+								p[horz % 160] = COLUM >> 1;
+								col[horz % 160] = COLUM >> 1;
 							}
 							break;
 						case 2:
 						case 3:
 							if ( horz >= 0 )
 							{
-								p[horz % 160] = COLUMN >> 1;
-								col[horz % 160] = COLUMN >> 1;
+								p[horz % 160] = COLUM >> 1;
+								col[horz % 160] = COLUM >> 1;
 							}
 							break;
 						}
 					} else {
 						if ( horz >= 0 )
 						{
-							p[horz % 160] = COLUMN >> 1;
-							col[horz % 160] = COLUMN >> 1;
+							p[horz % 160] = COLUM >> 1;
+							col[horz % 160] = COLUM >> 1;
 						}
 					}
 				}

--- a/src/mame/video/tia.h
+++ b/src/mame/video/tia.h
@@ -66,7 +66,7 @@ protected:
 	virtual void device_reset();
 
 	void draw_sprite_helper(UINT8* p, UINT8 *col, struct player_gfx *gfx, UINT8 GRP, UINT8 COLUP, UINT8 REFP);
-	void draw_missile_helper(UINT8* p, UINT8* col, int horz, int skipdelay, int latch, int start, UINT8 RESMP, UINT8 ENAM, UINT8 NUSIZ, UINT8 COLUMN);
+	void draw_missile_helper(UINT8* p, UINT8* col, int horz, int skipdelay, int latch, int start, UINT8 RESMP, UINT8 ENAM, UINT8 NUSIZ, UINT8 COLUM);
 	void draw_playfield_helper(UINT8* p, UINT8* col, int horz, UINT8 COLU, UINT8 REFPF);
 	void draw_ball_helper(UINT8* p, UINT8* col, int horz, UINT8 ENAB);
 	void drawS0(UINT8* p, UINT8* col);

--- a/src/mame/video/tia.h
+++ b/src/mame/video/tia.h
@@ -66,7 +66,7 @@ protected:
 	virtual void device_reset();
 
 	void draw_sprite_helper(UINT8* p, UINT8 *col, struct player_gfx *gfx, UINT8 GRP, UINT8 COLUP, UINT8 REFP);
-	void draw_missile_helper(UINT8* p, UINT8* col, int horz, int skipdelay, int latch, int start, UINT8 RESMP, UINT8 ENAM, UINT8 NUSIZ, UINT8 COLUM);
+	void draw_missile_helper(UINT8* p, UINT8* col, int horz, int skipdelay, int latch, int start, UINT8 RESMP, UINT8 ENAM, UINT8 NUSIZ, UINT8 COLUMN);
 	void draw_playfield_helper(UINT8* p, UINT8* col, int horz, UINT8 COLU, UINT8 REFPF);
 	void draw_ball_helper(UINT8* p, UINT8* col, int horz, UINT8 ENAB);
 	void drawS0(UINT8* p, UINT8* col);

--- a/src/mess/drivers/apple2.c
+++ b/src/mess/drivers/apple2.c
@@ -1212,7 +1212,7 @@ static SLOT_INTERFACE_START(apple2_cards)
 	SLOT_INTERFACE("ap16alt", A2BUS_IBSAP16ALT)    /* IBS AP16 (German VideoTerm clone), alternate revision */
 	SLOT_INTERFACE("vtc1", A2BUS_VTC1)    /* Unknown VideoTerm clone #1 */
 	SLOT_INTERFACE("vtc2", A2BUS_VTC2)    /* Unknown VideoTerm clone #2 */
-	SLOT_INTERFACE("arcbd", A2BUS_ARCADEBOARD)    /* Third Millenium Engineering Arcade Board */
+	SLOT_INTERFACE("arcbd", A2BUS_ARCADEBOARD)    /* Third Millennium Engineering Arcade Board */
 	SLOT_INTERFACE("midi", A2BUS_MIDI)  /* Generic 6840+6850 MIDI board */
 	SLOT_INTERFACE("zipdrive", A2BUS_ZIPDRIVE)  /* ZIP Technologies IDE card */
 	SLOT_INTERFACE("echoiiplus", A2BUS_ECHOPLUS)    /* Street Electronics Echo Plus (Echo II + Mockingboard clone) */

--- a/src/mess/drivers/apple2.c
+++ b/src/mess/drivers/apple2.c
@@ -1212,7 +1212,7 @@ static SLOT_INTERFACE_START(apple2_cards)
 	SLOT_INTERFACE("ap16alt", A2BUS_IBSAP16ALT)    /* IBS AP16 (German VideoTerm clone), alternate revision */
 	SLOT_INTERFACE("vtc1", A2BUS_VTC1)    /* Unknown VideoTerm clone #1 */
 	SLOT_INTERFACE("vtc2", A2BUS_VTC2)    /* Unknown VideoTerm clone #2 */
-	SLOT_INTERFACE("arcbd", A2BUS_ARCADEBOARD)    /* Third Millennium Engineering Arcade Board */
+	SLOT_INTERFACE("arcbd", A2BUS_ARCADEBOARD)    /* Third Millenium Engineering Arcade Board */
 	SLOT_INTERFACE("midi", A2BUS_MIDI)  /* Generic 6840+6850 MIDI board */
 	SLOT_INTERFACE("zipdrive", A2BUS_ZIPDRIVE)  /* ZIP Technologies IDE card */
 	SLOT_INTERFACE("echoiiplus", A2BUS_ECHOPLUS)    /* Street Electronics Echo Plus (Echo II + Mockingboard clone) */

--- a/src/mess/drivers/apple2e.c
+++ b/src/mess/drivers/apple2e.c
@@ -3019,7 +3019,7 @@ static SLOT_INTERFACE_START(apple2_cards)
 	SLOT_INTERFACE("ap16alt", A2BUS_IBSAP16ALT)    /* IBS AP16 (German VideoTerm clone), alternate revision */
 	SLOT_INTERFACE("vtc1", A2BUS_VTC1)    /* Unknown VideoTerm clone #1 */
 	SLOT_INTERFACE("vtc2", A2BUS_VTC2)    /* Unknown VideoTerm clone #2 */
-	SLOT_INTERFACE("arcbd", A2BUS_ARCADEBOARD)    /* Third Millenium Engineering Arcade Board */
+	SLOT_INTERFACE("arcbd", A2BUS_ARCADEBOARD)    /* Third Millennium Engineering Arcade Board */
 	SLOT_INTERFACE("midi", A2BUS_MIDI)  /* Generic 6840+6850 MIDI board */
 	SLOT_INTERFACE("zipdrive", A2BUS_ZIPDRIVE)  /* ZIP Technologies IDE card */
 	SLOT_INTERFACE("echoiiplus", A2BUS_ECHOPLUS)    /* Street Electronics Echo Plus (Echo II + Mockingboard clone) */

--- a/src/mess/drivers/apple2gs.c
+++ b/src/mess/drivers/apple2gs.c
@@ -288,7 +288,7 @@ static SLOT_INTERFACE_START(apple2_cards)
 	SLOT_INTERFACE("sam", A2BUS_SAM)    /* SAM Software Automated Mouth (8-bit DAC + speaker) */
 	SLOT_INTERFACE("alfam2", A2BUS_ALFAM2)    /* ALF Apple Music II */
 	SLOT_INTERFACE("echoii", A2BUS_ECHOII)    /* Street Electronics Echo II */
-	SLOT_INTERFACE("arcbd", A2BUS_ARCADEBOARD)    /* Third Millenium Engineering Arcade Board */
+	SLOT_INTERFACE("arcbd", A2BUS_ARCADEBOARD)    /* Third Millennium Engineering Arcade Board */
 	SLOT_INTERFACE("midi", A2BUS_MIDI)  /* Generic 6840+6850 MIDI board */
 	SLOT_INTERFACE("vulcan", A2BUS_VULCAN)  /* AE Vulcan IDE card */
 	SLOT_INTERFACE("vulcangold", A2BUS_VULCANGOLD)  /* AE Vulcan Gold IDE card */

--- a/src/mess/drivers/attache.c
+++ b/src/mess/drivers/attache.c
@@ -40,7 +40,7 @@
  *  cchsV - Read a sector from disk (cc = cylinder, h = head [bit 0=drive, bit 2=side], s = sector)
  *  cchsW - Write a sector from disk
  *  nnnnmmmmX - I/O port transmit (nnnn = number of bytes to transmit, mmmm = start of data to transmit)
- *  nnnnY - I/O port recieve (nnnn = address of data loaded)
+ *  nnnnY - I/O port receive (nnnn = address of data loaded)
  *  Z - Auto Disk Test (1Z for drive B)
  *
  *

--- a/src/mess/drivers/microvsn.c
+++ b/src/mess/drivers/microvsn.c
@@ -200,7 +200,7 @@ MACHINE_RESET_MEMBER(microvision_state, microvision)
 					break;
 
 				case RC_TYPE_100PF_23_2K:
-				case RC_TYPE_UNKNOWN:   // Default to most occuring setting
+				case RC_TYPE_UNKNOWN:   // Default to most occurring setting
 					static_set_clock( m_tms1100, 500000 );
 					break;
 

--- a/src/mess/drivers/pdp1.c
+++ b/src/mess/drivers/pdp1.c
@@ -405,7 +405,7 @@ static void iot_cks(device_t *device, int op2, int nac, int mb, int *io, int ac)
 
 
 /*
-    devices which are known to generate a completion pulse (source: maintainance manual 9-??,
+    devices which are known to generate a completion pulse (source: maintenance manual 9-??,
     and 9-20, 9-21):
     emulated:
     * perforated tape reader
@@ -451,8 +451,8 @@ static pdp1_reset_param_t pdp1_reset_param =
 {
 	{   /* external iot handlers.  NULL means that the iot is unimplemented, unless there are
         parentheses around the iot name, in which case the iot is internal to the cpu core. */
-		/* I put a ? when the source is the handbook, since a) I have used the maintainance manual
-		as the primary source (as it goes more into details) b) the handbook and the maintainance
+		/* I put a ? when the source is the handbook, since a) I have used the maintenance manual
+		as the primary source (as it goes more into details) b) the handbook and the maintenance
 		manual occasionnally contradict each other. */
 		/* dia, dba, dcc, dra are documented in MIT PDP-1 COMPUTER MODIFICATION
 		BULLETIN no. 2 (drumInstrWriteup.bin/drumInstrWriteup.txt), and are
@@ -1303,7 +1303,7 @@ static void iot_tyo(device_t *device, int op2, int nac, int mb, int *io, int ac)
 	state->typewriter_out(ch);
 	state->m_io_status &= ~io_st_tyo;
 
-	/* compute completion delay (source: maintainance manual 9-12, 9-13 and 9-14) */
+	/* compute completion delay (source: maintenance manual 9-12, 9-13 and 9-14) */
 	switch (ch)
 	{
 	case 072:   /* lower-case */

--- a/src/mess/drivers/socrates.c
+++ b/src/mess/drivers/socrates.c
@@ -500,7 +500,7 @@ WRITE8_MEMBER(socrates_state::speech_command) // write 0x4x
    does not have the rom read mode, which the socrates definitely uses! */
 /* Commands (tc8802):
 SEL 5 4 3 2 1 0
-    0 0 n n n n -  ADLD - ADress LoaD - writes one nybble to the address
+    0 0 n n n n -  ADLD - ADdress LoaD - writes one nybble to the address
                           of vsm rom selected (internal or external) starting
                           from the low 4 bits; each subsequent write writes to
                           the next higher 4 bits; resetting the chip resets

--- a/src/mess/drivers/ti99_4x.c
+++ b/src/mess/drivers/ti99_4x.c
@@ -435,7 +435,7 @@ WRITE8_MEMBER( ti99_4x_state::external_operation )
 
     When an interrupt line is set (and the corresponding bit in the interrupt mask is set),
     a level 1 interrupt is requested from the TMS9900.  This interrupt request lasts as long as
-    the interrupt pin and the revelant bit in the interrupt mask are set.
+    the interrupt pin and the relevant bit in the interrupt mask are set.
 
 ***************************************************************************/
 

--- a/src/mess/drivers/vk100.c
+++ b/src/mess/drivers/vk100.c
@@ -616,9 +616,9 @@ READ8_MEMBER(vk100_state::SYSTAT_A)
 /* port 0x48: "SYSTAT B"; NOT documented in the tech manual at all.
  * when in loopback/test mode, SYSTAT_B is read and expected the following, around 0x606:
  * reset 8751, modewrite of 0x5E
- * write command -> 0x20 (normal, normal, /RTS is 0, normal, normal, recieve off, /DTR is 1, transmit off)
+ * write command -> 0x20 (normal, normal, /RTS is 0, normal, normal, receive off, /DTR is 1, transmit off)
  * read SYSTAT B (and xor with 0xe), expect d7 to be CLEAR or jump to error
- * write command -> 0x05 (normal, normal, /RTS is 1, normal, normal, recieve ON, /DTR is 0, transmit off)
+ * write command -> 0x05 (normal, normal, /RTS is 1, normal, normal, receive ON, /DTR is 0, transmit off)
  * read SYSTAT B (and xor with 0xe), expect d7 to be SET or jump to error
  * after this it does something and waits for an rxrdy interrupt
 

--- a/src/mess/drivers/zexall.c
+++ b/src/mess/drivers/zexall.c
@@ -35,7 +35,7 @@
 Ram 0000-FFFF (preloaded with binary)
 Special calls take place for three ram values (this interface was designed by kevtris):
 FFFD - 'ack' - shared ram with output device; z80 reads from here and considers the byte at FFFF read if this value incremented
-FFFE - 'req' - shared ram with output device; z80 writes an incrementing value to FFFE to indicate that there is a byte waiting at FFFF and hence requesting the output device on the other end do something about it, until FFFD is incremented by the output device to acknowledge reciept
+FFFE - 'req' - shared ram with output device; z80 writes an incrementing value to FFFE to indicate that there is a byte waiting at FFFF and hence requesting the output device on the other end do something about it, until FFFD is incremented by the output device to acknowledge receipt
 FFFF - 'data' - shared ram with output device; z80 writes the data to be sent to output device here
 One i/o port is used:
 0001 - bit 0 controls whether interrupt timer is enabled (1) or not (0), this is a holdover from a project of kevtris' and can be ignored.

--- a/src/mess/includes/mac.h
+++ b/src/mess/includes/mac.h
@@ -29,7 +29,7 @@
 #define MAC_539X_2_TAG "539x_2"
 #define MACKBD_TAG "mackbd"
 
-// uncomment to run i8021 keyboard in orignal Mac/512(e)/Plus
+// uncomment to run i8021 keyboard in original Mac/512(e)/Plus
 //#define MAC_USE_EMULATED_KBD (1)
 
 // model helpers

--- a/src/mess/machine/dragon.c
+++ b/src/mess/machine/dragon.c
@@ -25,9 +25,9 @@ this is set to toggle at 1Hz, this seems to be good enough to trigger the
 cartline, but is so slow in real terms that it should have very little
 impact on the emulation speed.
 
-Re-factored the code common to all machines, and seperated the code different,
+Re-factored the code common to all machines, and separated the code different,
 into callbacks/functions unique to the machines, in preperation for splitting
-the code for individual machine types into seperate files, I have preposed, that
+the code for individual machine types into separate files, I have preposed, that
 the CoCo 1/2 should stay in coco.c, and that the coco3 and dragon specifc code
 should go into coco3.c and dragon.c which should (hopefully) make the code
 easier to manage.

--- a/src/mess/machine/esqvfd.c
+++ b/src/mess/machine/esqvfd.c
@@ -1,5 +1,5 @@
 /*
-    Ensoniq Vacuum Flourescent Displays (VFDs)
+    Ensoniq Vacuum Fluorescent Displays (VFDs)
     Emulation by R. Belmont
 */
 

--- a/src/mess/machine/fm_scsi.h
+++ b/src/mess/machine/fm_scsi.h
@@ -48,7 +48,7 @@ public:
 	template<class _Object> static devcb_base &set_irq_handler(device_t &device, _Object object) { return downcast<fmscsi_device &>(device).m_irq_handler.set_callback(object); }
 	template<class _Object> static devcb_base &set_drq_handler(device_t &device, _Object object) { return downcast<fmscsi_device &>(device).m_drq_handler.set_callback(object); }
 
-	// any publicly accessible interfaces needed for runtime
+	// any publically accessible interfaces needed for runtime
 	UINT8 fmscsi_data_r(void);
 	void fmscsi_data_w(UINT8 data);
 	UINT8 fmscsi_status_r(void);

--- a/src/mess/machine/fm_scsi.h
+++ b/src/mess/machine/fm_scsi.h
@@ -48,7 +48,7 @@ public:
 	template<class _Object> static devcb_base &set_irq_handler(device_t &device, _Object object) { return downcast<fmscsi_device &>(device).m_irq_handler.set_callback(object); }
 	template<class _Object> static devcb_base &set_drq_handler(device_t &device, _Object object) { return downcast<fmscsi_device &>(device).m_drq_handler.set_callback(object); }
 
-	// any publically accessible interfaces needed for runtime
+	// any publicly accessible interfaces needed for runtime
 	UINT8 fmscsi_data_r(void);
 	void fmscsi_data_w(UINT8 data);
 	UINT8 fmscsi_status_r(void);

--- a/src/mess/machine/lisa.c
+++ b/src/mess/machine/lisa.c
@@ -805,7 +805,7 @@ DIRECT_UPDATE_HANDLER (lisa_OPbaseoverride)
 	{
 		int seg_offset = address & 0x01ffff;
 
-		/* add revelant origin -> address */
+		/* add relevant origin -> address */
 		offs_t mapped_address = (m_mmu_regs[the_seg][segment].sorg + seg_offset) & 0x1fffff;
 
 		switch ((mmu_entry_t)m_mmu_regs[the_seg][segment].type)
@@ -1331,7 +1331,7 @@ READ16_MEMBER(lisa_state::lisa_r)
 		/* offset in segment */
 		int seg_offset = (offset & 0x00ffff) << 1;
 
-		/* add revelant origin -> address */
+		/* add relevant origin -> address */
 		offs_t address = (m_mmu_regs[the_seg][segment].sorg + seg_offset) & 0x1fffff;
 
 		/*logerror("read, logical address%lX\n", offset);
@@ -1537,7 +1537,7 @@ WRITE16_MEMBER(lisa_state::lisa_w)
 		/* offset in segment */
 		int seg_offset = (offset & 0x00ffff) << 1;
 
-		/* add revelant origin -> address */
+		/* add relevant origin -> address */
 		offs_t address = (m_mmu_regs[the_seg][segment].sorg + seg_offset) & 0x1fffff;
 
 		switch (m_mmu_regs[the_seg][segment].type)

--- a/src/mess/machine/swtpc09.c
+++ b/src/mess/machine/swtpc09.c
@@ -525,7 +525,7 @@ WRITE8_MEMBER( swtpc09_state::piaide_b_w )
 /* DAT ram write handler (Dynamic Address Translator)    */
 /* This creates the address map when a page is mapped in */
 /* memory map is created based on system_type flag       */
-/* this is accomodate the different cards installed      */
+/* this is accommodate the different cards installed     */
 
 WRITE8_MEMBER(swtpc09_state::dat_w)
 {

--- a/src/mess/machine/ti85.c
+++ b/src/mess/machine/ti85.c
@@ -154,7 +154,7 @@ void ti85_state::update_ti83p_memory ()
 {
 	//address_space &space = m_maincpu->space(AS_PROGRAM);
 
-	m_membank1->set_bank(m_booting ? 0x1f : 0); //Always flash page 0, well allmost
+	m_membank1->set_bank(m_booting ? 0x1f : 0); //Always flash page 0, well almost
 
 	if (m_ti83p_port4 & 1)
 	{

--- a/src/mess/machine/ti99/gromport.c
+++ b/src/mess/machine/ti99/gromport.c
@@ -321,7 +321,7 @@ machine_config_constructor single_conn_device::device_mconfig_additions() const
     The multi-cartridge extender
 
     This is a somewhat mythical device which was never available for the normal
-    customer, but there are reports of the existance of such a device
+    customer, but there are reports of the existence of such a device
     in development labs or demonstrations.
 
     The interesting thing about this is that the OS of the console

--- a/src/mess/tools/imgtool/modules/hp48.c
+++ b/src/mess/tools/imgtool/modules/hp48.c
@@ -108,7 +108,7 @@ struct hp48_card
 
 struct hp48_partition
 {
-		/* pointer to the begining of the partition inside the hp48_card */
+		/* pointer to the beginning of the partition inside the hp48_card */
 		UINT8* data;
 
 		/* size, in bytes (128 KB or less) */

--- a/src/mess/tools/imgtool/modules/ti99.c
+++ b/src/mess/tools/imgtool/modules/ti99.c
@@ -496,7 +496,7 @@ struct dsk_subdir
 /*
     DSK VIB record
 
-    Most fields in this record are only revelant to level 2 routines, but level
+    Most fields in this record are only relevant to level 2 routines, but level
     1 routines need the disk geometry information extracted from the VIB.
 */
 struct dsk_vib

--- a/src/mess/video/733_asr.c
+++ b/src/mess/video/733_asr.c
@@ -8,7 +8,7 @@
     emulated).  The ASR is attached to the computer with a serial interface.
 
     References:
-    945401-9701 Model 990/4 Computer System Field Maintainance Manual p. C-1,
+    945401-9701 Model 990/4 Computer System Field Maintenance Manual p. C-1,
     945250-9701 990 Computer Family Systems Handbook pp. 5-9 through 5-16,
     0943442-9701 Model 990 Computer Reference Manual Preliminary pp. 3-13
     through 3-21 and 3-39 through 3-44.

--- a/src/mess/video/rmnimbus.c
+++ b/src/mess/video/rmnimbus.c
@@ -9,7 +9,7 @@
     video system.
 
     On the real machine, the Video chip has a block of 64K of memory which is
-    completely seperate from the main 80186 memory.
+    completely separate from the main 80186 memory.
 
     The main CPU write to the video chip via a series of registers in the
     0x0000 to 0x002F reigon, the video chip then manages all video memory

--- a/src/tools/chdman.c
+++ b/src/tools/chdman.c
@@ -2930,12 +2930,12 @@ int CLIB_DECL main(int argc, char *argv[])
 			}
 			catch (chd_error &err)
 			{
-				fprintf(stderr, "CHD error occured (main): %s\n", chd_file::error_string(err));
+				fprintf(stderr, "CHD error occurred (main): %s\n", chd_file::error_string(err));
 				return 1;
 			}
 			catch (fatal_error &err)
 			{
-				fprintf(stderr, "Fatal error occured: %d\n", err.error());
+				fprintf(stderr, "Fatal error occurred: %d\n", err.error());
 				return err.error();
 			}
 			catch (std::exception& ex)

--- a/src/tools/jedutil.c
+++ b/src/tools/jedutil.c
@@ -127,8 +127,8 @@
 #define OUTPUT_COMBINATORIAL          0x00000004
 #define OUTPUT_REGISTERED             0x00000008
 #define OUTPUT_FEEDBACK_OUTPUT        0x00000010 /* Feedback state depends on output enable */
-#define OUTPUT_FEEDBACK_COMBINATORIAL 0x00000020 /* Feedback state independant of output enable */
-#define OUTPUT_FEEDBACK_REGISTERED    0x00000040 /* Feedback state independant of output enable */
+#define OUTPUT_FEEDBACK_COMBINATORIAL 0x00000020 /* Feedback state independent of output enable */
+#define OUTPUT_FEEDBACK_REGISTERED    0x00000040 /* Feedback state independent of output enable */
 #define OUTPUT_FEEDBACK_NONE          0x00000080 /* Feedback not available */
 
 /*

--- a/src/tools/pngcmp.c
+++ b/src/tools/pngcmp.c
@@ -55,7 +55,7 @@ int main(int argc, char *argv[])
 	}
 	catch(...)
 	{
-		printf("Exception occured");
+		printf("Exception occurred");
 		return 1000;
 	}
 }


### PR DESCRIPTION
I'm purposefully leaving /src/emu/bus/cbmiec/c1541.c's kernal.bin
as it is, as this particular spelling mistake was originally made
by Robert Russell, therefore is canon.  See
http://en.wikipedia.org/wiki/KERNAL for details.

I'm also leaving /src/emu/machine/nscsi_bus.c's RECIEVE as I don't
want to break anything, but it's worth someone looking into.

I renamed some variables in /src/mame/drivers/sfbonus.c,
/src/mame/video/tia.c and /src/mame/video/tia.h, so if anyone wants
to verify I didn't break anything, that would be nice.