### PR TITLE
GameBoy: fix MBC1 code and merge MBC1 Multi-Game (Bomberman/Momotarou Collection etc.) code

### DIFF
--- a/hash/gbcolor.xml
+++ b/hash/gbcolor.xml
@@ -5584,7 +5584,7 @@ List of unconfirmed retail cartridge roms
 	<software name="bombmsel">
 		<!-- Notes: GBC only -->
 		<description>Bomberman Selection (Kor)</description>
-		<year>1996?</year>
+		<year>2003</year>
 		<publisher>Hudson Soft</publisher>
 		<info name="serial" value="CGB-B2CK-KOR"/>
 		<part name="cart" interface="gameboy_cart">

--- a/src/emu/bus/gameboy/gb_slot.h
+++ b/src/emu/bus/gameboy/gb_slot.h
@@ -22,7 +22,8 @@ enum
 	GB_MBC_MBC6,         /*    ?? ROM,  32KB SRAM                         */
 	GB_MBC_MBC7,         /*    ?? ROM,    ?? RAM                          */
 	GB_MBC_WISDOM,       /*    ?? ROM,    ?? RAM - Wisdom tree controller */
-	GB_MBC_MBC1_COL,     /*   1MB ROM,    ?? RAM - MBC1 variant for multigame carts    */
+	GB_MBC_MBC1_COL,     /*   1MB ROM,  32KB RAM - workaround for MBC1 on */
+	                     /*   PCB that maps rom address lines differently */
 	GB_MBC_YONGYONG,     /*    ?? ROM,    ?? RAM - Appears in Sonic 3D Blast 5 pirate */
 	GB_MBC_LASAMA,       /*    ?? ROM,    ?? RAM - Appears in La Sa Ma */
 	GB_MBC_ATVRACIN,

--- a/src/emu/bus/gameboy/mbc.h
+++ b/src/emu/bus/gameboy/mbc.h
@@ -26,44 +26,34 @@ public:
 	virtual DECLARE_WRITE8_MEMBER(write_ram);
 
 	UINT8 m_ram_enable;
-	UINT8 m_mode;
 };
 
 // ======================> gb_rom_mbc1_device
 
+template <UINT8 ra_mask, INT8 aa_shift>
 class gb_rom_mbc1_device : public gb_rom_mbc_device
 {
 public:
+
+	enum {
+		MODE_16M_8k  = 0x00u, /// 16Mbit ROM, 8kBit RAM
+		MODE_4M_256k = 0x01u, /// 4Mbit ROM, 256kBit RAM
+	};
+
 	// construction/destruction
 	gb_rom_mbc1_device(const machine_config &mconfig, device_type type, const char *name, const char *tag, device_t *owner, UINT32 clock, const char *shortname, const char *source);
 	gb_rom_mbc1_device(const machine_config &mconfig, const char *tag, device_t *owner, UINT32 clock);
 
 	// device-level overrides
-	virtual void device_start() { shared_start(); };
-	virtual void device_reset() { shared_reset(); };
+	virtual void device_start() { shared_start(); save_item(NAME(m_mode)); };
+	virtual void device_reset() { shared_reset(); m_mode = MODE_16M_8k; };
 
 	virtual DECLARE_READ8_MEMBER(read_rom);
 	virtual DECLARE_WRITE8_MEMBER(write_bank);
 	virtual DECLARE_READ8_MEMBER(read_ram);
 	virtual DECLARE_WRITE8_MEMBER(write_ram);
-};
 
-// ======================> gb_rom_mbc1col_device
-
-class gb_rom_mbc1col_device : public gb_rom_mbc_device
-{
-public:
-	// construction/destruction
-	gb_rom_mbc1col_device(const machine_config &mconfig, const char *tag, device_t *owner, UINT32 clock);
-
-	// device-level overrides
-	virtual void device_start() { shared_start(); };
-	virtual void device_reset() { shared_reset(); };
-
-	virtual DECLARE_READ8_MEMBER(read_rom);
-	virtual DECLARE_WRITE8_MEMBER(write_bank);
-	virtual DECLARE_READ8_MEMBER(read_ram);
-	virtual DECLARE_WRITE8_MEMBER(write_ram);
+	UINT8 m_mode;
 };
 
 // ======================> gb_rom_mbc2_device
@@ -178,7 +168,7 @@ public:
 };
 
 // ======================> gb_rom_188in1_device
-class gb_rom_188in1_device : public gb_rom_mbc1_device
+class gb_rom_188in1_device : public gb_rom_mbc1_device<0x1Fu, 0x00u>
 {
 public:
 	// construction/destruction
@@ -298,7 +288,7 @@ public:
 	virtual DECLARE_WRITE8_MEMBER(write_bank);
 	virtual DECLARE_READ8_MEMBER(read_ram);
 	virtual DECLARE_WRITE8_MEMBER(write_ram);
-	UINT8 m_bank_mask, m_bank, m_reg;
+	UINT8 m_bank_mask, m_bank, m_reg, m_mode;
 };
 
 


### PR DESCRIPTION
MBC1 addressing mode mapping was all over the place and broke on mode switch: 

- start in mode 0 (16Mbit ROM / 64kBit RAM)
- write XX (non-zero) to RAM bank register (0x4000-0x5FFF)
- switch modes to mode 1 (4Mbit ROM / 256kBit RAM)
- 0x0000-0x3FFF still maps to 0x000000-0x003FFF instead of 0xXX0000-0xXX3FFF

I've just reconfirmed that the current code is buggy on hardware.
There is no "special" Korean MBC1 or MBC1 collection mapper. There is simply the good old MBC1 on PCBs (DMG-M-BFAN, DMG-MC-DFCN) that route the ROM address lines differently.

Using the aforementioned fix, I've implemented masking/shifting using templates and merged mbc1col with mbc1, which is good enough for all commercial titles.

Signed-off-by: Tauwasser <tauwasser@tauwasser.eu>