### PR TITLE
luaengine: minor bugfixes and enhancements

### DIFF
--- a/docs/luaengine.md
+++ b/docs/luaengine.md
@@ -112,6 +112,9 @@ your hook to be called on every frame repaint:
 > emu.sethook(draw_hud, "frame")
 ```
 
+All colors are expected in ARGB format (32b unsigned), while screen origin (0,0)
+normally corresponds to the top-left corner.
+
 Similarly to screens, you can inspect all the devices attached to a
 machine:
 ```

--- a/src/emu/luaengine.c
+++ b/src/emu/luaengine.c
@@ -707,6 +707,7 @@ int lua_engine::lua_screen::l_draw_text(lua_State *L)
 	luaL_argcheck(L, lua_isnumber(L, 2), 2, "x (integer) expected");
 	luaL_argcheck(L, lua_isnumber(L, 3), 3, "y (integer) expected");
 	luaL_argcheck(L, lua_isstring(L, 4), 4, "message (string) expected");
+	luaL_argcheck(L, lua_isinteger(L, 5) || lua_isnone(L, 5), 5, "optional argument: text color, integer expected (default: 0xffffffff)");
 
 	// retrieve all parameters
 	int sc_width = sc->visible_area().width();
@@ -714,13 +715,16 @@ int lua_engine::lua_screen::l_draw_text(lua_State *L)
 	float x = MIN(MAX(0, lua_tonumber(L, 2)), sc_width-1) / static_cast<float>(sc_width);
 	float y = MIN(MAX(0, lua_tonumber(L, 3)), sc_height-1) / static_cast<float>(sc_height);
 	const char *msg = luaL_checkstring(L,4);
-	// TODO: add optional parameters (colors, etc.)
+	rgb_t textcolor = UI_TEXT_COLOR;
+	if (!lua_isnone(L, 5)) {
+		textcolor = rgb_t(lua_tounsigned(L, 5));
+	}
 
 	// draw the text
 	render_container &rc = sc->container();
 	ui_manager &ui = sc->machine().ui();
 	ui.draw_text_full(&rc, msg, x, y , (1.0f - x),
-						JUSTIFY_LEFT, WRAP_WORD, DRAW_NORMAL, UI_TEXT_COLOR,
+						JUSTIFY_LEFT, WRAP_WORD, DRAW_NORMAL, textcolor,
 						UI_TEXT_BG_COLOR, NULL, NULL);
 
 	return 0;

--- a/src/emu/luaengine.c
+++ b/src/emu/luaengine.c
@@ -642,10 +642,10 @@ int lua_engine::lua_screen::l_draw_box(lua_State *L)
 	int sc_width = sc->visible_area().width();
 	int sc_height = sc->visible_area().height();
 	float x1, y1, x2, y2;
-	x1 = MIN(MAX(0, lua_tointeger(L, 2)), sc_width-1) / static_cast<float>(sc_width);
-	y1 = MIN(MAX(0, lua_tointeger(L, 3)), sc_height-1) / static_cast<float>(sc_height);
-	x2 = MIN(MAX(0, lua_tointeger(L, 4)), sc_width-1) / static_cast<float>(sc_width);
-	y2 = MIN(MAX(0, lua_tointeger(L, 5)), sc_height-1) / static_cast<float>(sc_height);
+	x1 = MIN(MAX(0, lua_tonumber(L, 2)), sc_width-1) / static_cast<float>(sc_width);
+	y1 = MIN(MAX(0, lua_tonumber(L, 3)), sc_height-1) / static_cast<float>(sc_height);
+	x2 = MIN(MAX(0, lua_tonumber(L, 4)), sc_width-1) / static_cast<float>(sc_width);
+	y2 = MIN(MAX(0, lua_tonumber(L, 5)), sc_height-1) / static_cast<float>(sc_height);
 	UINT32 bgcolor = lua_tounsigned(L, 6);
 	UINT32 fgcolor = lua_tounsigned(L, 7);
 
@@ -680,10 +680,10 @@ int lua_engine::lua_screen::l_draw_line(lua_State *L)
 	int sc_width = sc->visible_area().width();
 	int sc_height = sc->visible_area().height();
 	float x1, y1, x2, y2;
-	x1 = MIN(MAX(0, lua_tointeger(L, 2)), sc_width-1) / static_cast<float>(sc_width);
-	y1 = MIN(MAX(0, lua_tointeger(L, 3)), sc_height-1) / static_cast<float>(sc_height);
-	x2 = MIN(MAX(0, lua_tointeger(L, 4)), sc_width-1) / static_cast<float>(sc_width);
-	y2 = MIN(MAX(0, lua_tointeger(L, 5)), sc_height-1) / static_cast<float>(sc_height);
+	x1 = MIN(MAX(0, lua_tonumber(L, 2)), sc_width-1) / static_cast<float>(sc_width);
+	y1 = MIN(MAX(0, lua_tonumber(L, 3)), sc_height-1) / static_cast<float>(sc_height);
+	x2 = MIN(MAX(0, lua_tonumber(L, 4)), sc_width-1) / static_cast<float>(sc_width);
+	y2 = MIN(MAX(0, lua_tonumber(L, 5)), sc_height-1) / static_cast<float>(sc_height);
 	UINT32 color = lua_tounsigned(L, 6);
 
 	// draw the line
@@ -711,8 +711,8 @@ int lua_engine::lua_screen::l_draw_text(lua_State *L)
 	// retrieve all parameters
 	int sc_width = sc->visible_area().width();
 	int sc_height = sc->visible_area().height();
-	float x = MIN(MAX(0, lua_tointeger(L, 2)), sc_width-1) / static_cast<float>(sc_width);
-	float y = MIN(MAX(0, lua_tointeger(L, 3)), sc_height-1) / static_cast<float>(sc_height);
+	float x = MIN(MAX(0, lua_tonumber(L, 2)), sc_width-1) / static_cast<float>(sc_width);
+	float y = MIN(MAX(0, lua_tonumber(L, 3)), sc_height-1) / static_cast<float>(sc_height);
 	const char *msg = luaL_checkstring(L,4);
 	// TODO: add optional parameters (colors, etc.)
 

--- a/src/emu/ui/ui.c
+++ b/src/emu/ui/ui.c
@@ -694,6 +694,9 @@ void ui_manager::draw_text_full(render_container *container, const char *origs, 
 						break;
 
 					curwidth -= get_font()->char_width(lineheight, aspect, schar);
+					// if back to 0, there is no space to draw even a single char
+					if (curwidth <= 0)
+						break;
 				}
 			}
 


### PR DESCRIPTION
This PR contains minor bugfixes/enhancements related to luaengine.
In particular it:
 * fixes a pre-existing infinite loop condition in ui, triggerable via `draw_text()`
 * introduces an (optional) text color parameter to `draw_text()`
 * fixes a type confusion (float/int) in all drawing methods
 * specify color format and screen origin in docs