### PR TITLE
Update 315_5124.c

### DIFF
--- a/src/emu/video/315_5124.c
+++ b/src/emu/video/315_5124.c
@@ -110,23 +110,24 @@ PALETTE_INIT_MEMBER(sega315_5124_device, sega315_5124)
 		int b = (i & 0x30) >> 4;
 		palette.set_pen_color(i, pal2bit(r), pal2bit(g), pal2bit(b));
 	}
-	/* TMS9918 palette */
-	palette.set_pen_color(64+ 0,   0,   0,   0);
-	palette.set_pen_color(64+ 1,   0,   0,   0);
-	palette.set_pen_color(64+ 2,  33, 200,  66);
-	palette.set_pen_color(64+ 3,  94, 220, 120);
-	palette.set_pen_color(64+ 4,  84,  85, 237);
-	palette.set_pen_color(64+ 5, 125, 118, 252);
-	palette.set_pen_color(64+ 6, 212,  82,  77);
-	palette.set_pen_color(64+ 7,  66, 235, 245);
-	palette.set_pen_color(64+ 8, 252,  85,  84);
-	palette.set_pen_color(64+ 9, 255, 121, 120);
-	palette.set_pen_color(64+10, 212, 193,  84);
-	palette.set_pen_color(64+11, 230, 206, 128);
-	palette.set_pen_color(64+12,  33, 176,  59);
-	palette.set_pen_color(64+13, 201,  91, 186);
-	palette.set_pen_color(64+14, 204, 204, 204);
-	palette.set_pen_color(64+15, 255, 255, 255);
+	/* sms and sg1000-mark3 uses a different palette for modes 0 to 3 - see http://www.smspower.org/Development/Palette */
+	/* TMS9918 palette */ 
+	palette.set_pen_color(64+ 0,   0,   0,   0); // palette.set_pen_color(64+ 0,   0,   0,   0);
+	palette.set_pen_color(64+ 1,   0,   0,   0); // palette.set_pen_color(64+ 1,   0,   0,   0);
+	palette.set_pen_color(64+ 2,   0, 170,   0); // palette.set_pen_color(64+ 2,  33, 200,  66);
+	palette.set_pen_color(64+ 3,   0, 255,   0); // palette.set_pen_color(64+ 3,  94, 220, 120);
+	palette.set_pen_color(64+ 4,   0,   0,  85); // palette.set_pen_color(64+ 4,  84,  85, 237);
+	palette.set_pen_color(64+ 5,   0,   0, 255); // palette.set_pen_color(64+ 5, 125, 118, 252);
+	palette.set_pen_color(64+ 6,  85,   0,   0); // palette.set_pen_color(64+ 6, 212,  82,  77);
+	palette.set_pen_color(64+ 7,   0, 255, 255); // palette.set_pen_color(64+ 7,  66, 235, 245);
+	palette.set_pen_color(64+ 8, 170,   0,   0); // palette.set_pen_color(64+ 8, 252,  85,  84);
+	palette.set_pen_color(64+ 9, 255,   0,   0); // palette.set_pen_color(64+ 9, 255, 121, 120);
+	palette.set_pen_color(64+10,  85,  85,   0); // palette.set_pen_color(64+10, 212, 193,  84);
+	palette.set_pen_color(64+11, 255, 255,   0); // palette.set_pen_color(64+11, 230, 206, 128);
+	palette.set_pen_color(64+12,   0,  85,   0); // palette.set_pen_color(64+12,  33, 176,  59);
+	palette.set_pen_color(64+13, 255,   0, 255); // palette.set_pen_color(64+13, 201,  91, 186);
+	palette.set_pen_color(64+14,  85,  85,  85); // palette.set_pen_color(64+14, 204, 204, 204);
+	palette.set_pen_color(64+15,   0,   0,   0); // palette.set_pen_color(64+15, 255, 255, 255);
 }
 
 


### PR DESCRIPTION
sms and sg1000-mark3 uses a different palette for modes 0 to 3

besides the colour space got posterized into 4 levels (2 bits), that was "designed" from people that didn't care about using the closest colours, which results in a darker picture, and somehow different from what sg1000 mark1 and mark2 games displays

http://www.smspower.org/Development/Palette has more information about