### PR TITLE
Drop NO_SDL_GLEXT define on OSX

### DIFF
--- a/scripts/src/osd/sdl_cfg.lua
+++ b/scripts/src/osd/sdl_cfg.lua
@@ -79,7 +79,6 @@ if BASE_TARGETOS=="unix" then
 			}
 		else
 			defines {
-				"NO_SDL_GLEXT",
 				"MACOSX_USE_LIBSDL",
 			}
 			buildoptions {


### PR DESCRIPTION
This will help me to build latest MAME with homebrew.

I think OSX can use GLEXT with native OpenGL library.