### PR TITLE
Add makefile switch to choose linking against bundled OR system expat…

### DIFF
--- a/makefile
+++ b/makefile
@@ -53,6 +53,8 @@
 # ARCHOPTS =
 # LDOPTS =
 
+# USE_SYSTEM_LIB_EXPAT = 1
+
 # MESA_INSTALL_ROOT = /opt/mesa
 # SDL_INSTALL_ROOT = /opt/sdl2
 # SDL_FRAMEWORK_PATH = $(HOME)/Library/Frameworks
@@ -285,6 +287,13 @@ OSD := sdl
 endif
 endif
 
+#-------------------------------------------------
+# which 3rdparty library to build;
+#  link against system (common) library otherwise
+#-------------------------------------------------
+ifndef USE_SYSTEM_LIB_EXPAT
+PARAMS += --with-bundled-expat
+endif
 
 #-------------------------------------------------
 # distribution may change things

--- a/scripts/genie.lua
+++ b/scripts/genie.lua
@@ -89,6 +89,11 @@ newoption {
 }
 
 newoption {
+    trigger = 'with-bundled-expat',
+    description = 'Build bundled Expat library',
+}
+
+newoption {
 	trigger = "distro",
 	description = "Choose distribution",
 	allowed = {

--- a/scripts/src/3rdparty.lua
+++ b/scripts/src/3rdparty.lua
@@ -5,6 +5,7 @@
 -- expat library objects
 --------------------------------------------------
 
+if _OPTIONS["with-bundled-expat"] then
 project "expat"
 	uuid "f4cd40b1-c37c-452d-9785-640f26f0bf54"
 	kind "StaticLib"
@@ -23,6 +24,11 @@ project "expat"
 			"-Wshadow"
 		}
 	end
+else
+links {
+	"expat",
+}
+end
 
 --------------------------------------------------
 -- zlib library objects
@@ -84,8 +90,12 @@ project "softfloat"
 		MAME_DIR .. "src/lib",
 		MAME_DIR .. "src/lib/util",
 		MAME_DIR .. "3rdparty",
-		MAME_DIR .. "3rdparty/expat/lib/",
 	}
+	if _OPTIONS["with-bundled-expat"] then
+	    includedirs {
+			MAME_DIR .. "3rdparty/expat/lib/",
+		}
+	end
 	
 	files {
 		MAME_DIR .. "3rdparty/softfloat/softfloat.c",

--- a/scripts/src/emu.lua
+++ b/scripts/src/emu.lua
@@ -14,12 +14,16 @@ includedirs {
 	MAME_DIR .. "src/lib",
 	MAME_DIR .. "src/lib/util",
 	MAME_DIR .. "3rdparty",
-	MAME_DIR .. "3rdparty/expat/lib",
 	MAME_DIR .. "3rdparty/lua/src",
 	MAME_DIR .. "3rdparty/zlib",
 	GEN_DIR  .. "emu",
 	GEN_DIR  .. "emu/layout",
 }
+if _OPTIONS["with-bundled-expat"] then
+	includedirs {
+		MAME_DIR .. "3rdparty/expat/lib",
+	}
+end
 
 files {
 	MAME_DIR .. "src/emu/emu.h",
@@ -368,13 +372,17 @@ function emuProject(_target, _subtarget)
 		MAME_DIR .. "src/lib",
 		MAME_DIR .. "src/lib/util",
 		MAME_DIR .. "3rdparty",
-		MAME_DIR .. "3rdparty/expat/lib",
 		MAME_DIR .. "3rdparty/lua/src",
 		MAME_DIR .. "3rdparty/zlib",
 		GEN_DIR  .. "emu",
 		GEN_DIR  .. "emu/layout",
 		MAME_DIR .. "src/emu/cpu/m68000",
 	}
+	if _OPTIONS["with-bundled-expat"] then
+		includedirs {
+			MAME_DIR .. "3rdparty/expat/lib",
+		}
+	end
 	
 	dofile(path.join("src", "cpu.lua"))
 
@@ -402,7 +410,6 @@ function emuProject(_target, _subtarget)
 		MAME_DIR .. "src/lib",
 		MAME_DIR .. "src/lib/util",
 		MAME_DIR .. "3rdparty",
-		MAME_DIR .. "3rdparty/expat/lib",
 		MAME_DIR .. "3rdparty/lua/src",
 		MAME_DIR .. "3rdparty/zlib",
 		MAME_DIR .. "src/mess", -- some mess bus devices need this
@@ -410,6 +417,11 @@ function emuProject(_target, _subtarget)
 		GEN_DIR  .. "emu",
 		GEN_DIR  .. "emu/layout",
 	}
+	if _OPTIONS["with-bundled-expat"] then
+		includedirs {
+			MAME_DIR .. "3rdparty/expat/lib",
+		}
+	end
 
 	dofile(path.join("src", "bus.lua"))
 	
@@ -428,11 +440,15 @@ function emuProject(_target, _subtarget)
 		MAME_DIR .. "src/lib",
 		MAME_DIR .. "src/lib/util",
 		MAME_DIR .. "3rdparty",
-		MAME_DIR .. "3rdparty/expat/lib",
 		MAME_DIR .. "3rdparty/lua/src",
 		MAME_DIR .. "3rdparty/zlib",
 		GEN_DIR  .. "emu",
 	}
+	if _OPTIONS["with-bundled-expat"] then
+		includedirs {
+			MAME_DIR .. "3rdparty/expat/lib",
+		}
+	end
 	
 	files {
 		disasm_files

--- a/scripts/src/lib.lua
+++ b/scripts/src/lib.lua
@@ -13,9 +13,13 @@ project "utils"
 		MAME_DIR .. "src/osd",
 		MAME_DIR .. "src/lib/util",
 		MAME_DIR .. "3rdparty",
-		MAME_DIR .. "3rdparty/expat/lib",
 		MAME_DIR .. "3rdparty/zlib",
 	}
+	if _OPTIONS["with-bundled-expat"] then
+		includedirs {
+			MAME_DIR .. "3rdparty/expat/lib",
+		}
+	end
 
 	files {
 		MAME_DIR .. "src/lib/util/bitstream.h",


### PR DESCRIPTION
This adds a new switch variable to makefile, to choose between building and statically linking the bundled libraries or dinamically linking the common (system) ones.

Though tested and working, this is a preliminary patch, limited to the expat library only. Please review it and give me your feedbacks. Should you feel this is appropriate, I'll write and contribute code for a new switch series USE_SYSTEM_LIB_* wherever applicable for the 3rdparty dir.

Thanks!
Cesare
