### PR TITLE
Gameboy: Sachen MMC1/MMC2 update + small fixes

### DIFF
--- a/hash/gameboy.xml
+++ b/hash/gameboy.xml
@@ -23570,6 +23570,18 @@
 		</part>
 	</software>
 
+	<software name="4B-001_Color">
+		<description>Sachen 4B-001</description>
+		<year>20??</year>
+		<publisher>Sachen</publisher>
+		<part name="cart" interface="gameboy_cart">
+			<feature name="slot" value="rom_sachen2" />
+			<dataarea name="rom" size="524288">
+				<rom name="4B-001.gbc" size="524288" crc="42A2FDF8" sha1="79A4FADDFD1ACA397E56D7895E45B1BC12900DAB" offset="000000" />
+			</dataarea>
+		</part>
+	</software>
+
 	<!-- Below we list the ripped games from Sachen multicarts (I assumed they come from a 4-in-1 cart, but they could come as well from a 8-in-1 cart).
 	    They should be removed as soon as the carts are properly dumped and emulated -->
 	<software name="antsoldr" supported="partial">

--- a/hash/gbcolor.xml
+++ b/hash/gbcolor.xml
@@ -23615,7 +23615,17 @@ These were produced between 2000 and 2001 by Rocket Games, run by Datel Design
 		</part>
 	</software>
 
-
+	<software name="4B-001_Color">
+		<description>Sachen 4B-001</description>
+		<year>20??</year>
+		<publisher>Sachen</publisher>
+		<part name="cart" interface="gameboy_cart">
+			<feature name="slot" value="rom_sachen2" />
+			<dataarea name="rom" size="524288">
+				<rom name="4B-001.gbc" size="524288" crc="42A2FDF8" sha1="79A4FADDFD1ACA397E56D7895E45B1BC12900DAB" offset="000000" />
+			</dataarea>
+		</part>
+	</software>
 
 <!-- GOWIN games -->
 <!--

--- a/src/emu/bus/gameboy/mbc.c
+++ b/src/emu/bus/gameboy/mbc.c
@@ -399,7 +399,7 @@ WRITE8_MEMBER(gb_rom_mbc2_device::write_bank)
 READ8_MEMBER(gb_rom_mbc2_device::read_ram)
 {
 	if (!m_ram.empty() && m_ram_enable)
-		return m_ram[ram_bank_map[m_ram_bank] * 0x2000 + (offset & 0x1fff)];
+		return m_ram[ram_bank_map[m_ram_bank] * 0x2000 + (offset & 0x01ff)] | 0xF0;
 	else
 		return 0xff;
 }
@@ -407,7 +407,7 @@ READ8_MEMBER(gb_rom_mbc2_device::read_ram)
 WRITE8_MEMBER(gb_rom_mbc2_device::write_ram)
 {
 	if (!m_ram.empty() && m_ram_enable)
-		m_ram[ram_bank_map[m_ram_bank] * 0x2000 + (offset & 0x1fff)] = data;
+		m_ram[ram_bank_map[m_ram_bank] * 0x2000 + (offset & 0x01ff)] = data & 0x0F;
 }
 
 

--- a/src/emu/bus/gameboy/mbc.c
+++ b/src/emu/bus/gameboy/mbc.c
@@ -314,18 +314,18 @@ WRITE8_MEMBER(gb_rom_mbc_device::write_ram)
 
 READ8_MEMBER(gb_rom_mbc1_device::read_rom)
 {
-	if (offset < 0x4000)
-	{
+	if (offset & 0x4000) /* RB1 */
+		return m_rom[rom_bank_map[(m_ram_bank << (5 + m_shift)) | m_latch_bank2] * 0x4000 + (offset & 0x3fff)];
+	else
+	{                    /* RB0 */
 		int bank = (m_mode == MODE_4M_256k) ? (m_ram_bank << (5 + m_shift)) : 0;
 		return m_rom[rom_bank_map[bank] * 0x4000 + (offset & 0x3fff)];
 	}
-	else
-		return m_rom[rom_bank_map[(m_ram_bank << (5 + m_shift)) | m_latch_bank2] * 0x4000 + (offset & 0x3fff)];
 }
 
 WRITE8_MEMBER(gb_rom_mbc1_device::write_bank)
 {
-	// the mapper only uses inputs A13-A15
+	// the mapper only uses inputs A15..A13
 	switch (offset & 0xe000)
 	{
 		case 0x0000:    // RAM Enable Register

--- a/src/emu/bus/gameboy/mbc.c
+++ b/src/emu/bus/gameboy/mbc.c
@@ -665,6 +665,14 @@ WRITE8_MEMBER(gb_rom_m161_device::write_bank)
 
 // MMM01
 // This mmm01 implementation is mostly guess work, no clue how correct it all is
+/* TODO: This implementation is wrong. Tauwasser
+ * 
+ * Register 0: Map Latch, AA Mask, RAM Enable
+ * Register 1: EA1..EA0, RA18..RA14
+ * Register 2: ??, AA18..AA15, AA14..AA13
+ * Register 3: AA Multiplex, RA Mask, ???, MBC1 Mode
+ * 
+ */
 
 READ8_MEMBER(gb_rom_mmm01_device::read_rom)
 {

--- a/src/emu/bus/gameboy/mbc.c
+++ b/src/emu/bus/gameboy/mbc.c
@@ -27,7 +27,7 @@ const device_type GB_ROM_MBC7 = &device_creator<gb_rom_mbc7_device>;
 const device_type GB_ROM_M161_M12 = &device_creator<gb_rom_m161_device>;
 const device_type GB_ROM_MMM01 = &device_creator<gb_rom_mmm01_device>;
 const device_type GB_ROM_SACHEN1 = &device_creator<gb_rom_sachen_mmc1_device>;
-const device_type GB_ROM_SACHEN2 = &device_creator<gb_rom_sachen_mmc1_device>;  // Just a placeholder for the moment...
+const device_type GB_ROM_SACHEN2 = &device_creator<gb_rom_sachen_mmc2_device>;
 const device_type GB_ROM_188IN1 = &device_creator<gb_rom_188in1_device>;
 const device_type GB_ROM_SINTAX = &device_creator<gb_rom_sintax_device>;
 const device_type GB_ROM_CHONGWU = &device_creator<gb_rom_chongwu_device>;
@@ -99,6 +99,16 @@ gb_rom_mmm01_device::gb_rom_mmm01_device(const machine_config &mconfig, const ch
 
 gb_rom_sachen_mmc1_device::gb_rom_sachen_mmc1_device(const machine_config &mconfig, const char *tag, device_t *owner, UINT32 clock)
 					: gb_rom_mbc_device(mconfig, GB_ROM_SACHEN1, "GB Sachen MMC1 Carts", tag, owner, clock, "gb_rom_sachen1", __FILE__)
+{
+}
+
+gb_rom_sachen_mmc1_device::gb_rom_sachen_mmc1_device(const machine_config &mconfig, device_type type, const char *name, const char *tag, device_t *owner, UINT32 clock, const char *shortname, const char *source)
+					: gb_rom_mbc_device(mconfig, type, name, tag, owner, clock, shortname, source)
+{
+}
+
+gb_rom_sachen_mmc2_device::gb_rom_sachen_mmc2_device(const machine_config &mconfig, const char *tag, device_t *owner, UINT32 clock)
+					: gb_rom_sachen_mmc1_device(mconfig, GB_ROM_SACHEN2, "GB Sachen MMC2 Carts", tag, owner, clock, "gb_rom_sachen2", __FILE__)
 {
 }
 
@@ -248,6 +258,24 @@ void gb_rom_sachen_mmc1_device::device_reset()
 	m_base_bank = 0x00;
 	m_mask = 0x00;
 	m_mode = MODE_LOCKED;
+	m_unlock_cnt = 0x00;
+}
+
+void gb_rom_sachen_mmc2_device::device_start()
+{
+	shared_start();
+	save_item(NAME(m_base_bank));
+	save_item(NAME(m_mask));
+	save_item(NAME(m_mode));
+	save_item(NAME(m_unlock_cnt));
+}
+
+void gb_rom_sachen_mmc2_device::device_reset()
+{
+	shared_reset();
+	m_base_bank = 0x00;
+	m_mask = 0x00;
+	m_mode = MODE_LOCKED_DMG;
 	m_unlock_cnt = 0x00;
 }
 
@@ -716,7 +744,6 @@ WRITE8_MEMBER(gb_rom_mmm01_device::write_bank)
 	}
 }
 
-
 // Sachen MMC1
 
 READ8_MEMBER(gb_rom_sachen_mmc1_device::read_rom)
@@ -724,7 +751,7 @@ READ8_MEMBER(gb_rom_sachen_mmc1_device::read_rom)
 
 	UINT16 off_edit = offset;
 
-	/* Wait for 0x31 transitions of A15, i.e. ROM accesses; A15 = HI while in bootstrap */
+	/* Wait for 0x31 transitions of A15 (hi -> lo), i.e. ROM accesses; A15 = HI while in bootstrap */
 	/* This is 0x31 transitions, because we increment counter _after_ checking it */
 	if (m_unlock_cnt == 0x30)
 		m_mode = MODE_UNLOCKED;
@@ -789,6 +816,68 @@ WRITE8_MEMBER(gb_rom_sachen_mmc1_device::write_bank)
 			/* did not extensively test other unlikely ranges */
 			break;
 	}
+}
+
+// Sachen MMC2
+
+READ8_MEMBER(gb_rom_sachen_mmc2_device::read_rom)
+{
+
+	UINT16 off_edit = offset;
+
+	/* Wait for 0x30 transitions of A15 (lo -> hi), i.e. ROM accesses; A15 = HI while in bootstrap */
+	/* This is 0x30 transitions, because we increment counter _after_ checking it, but A15 lo -> hi*/
+	/* transition means first read (hi -> lo transition) must not count */
+	
+	if (m_unlock_cnt == 0x30 && m_mode == MODE_LOCKED_DMG) {
+		m_mode = MODE_LOCKED_CGB;
+		m_unlock_cnt = 0x00;
+	} else if (m_unlock_cnt == 0x30 && m_mode == MODE_LOCKED_CGB) {
+		m_mode = MODE_UNLOCKED;
+	}
+	
+	if (m_unlock_cnt != 0x30)
+		m_unlock_cnt++;
+	
+	/* Logo Switch */
+	if (m_mode == MODE_LOCKED_CGB)
+		off_edit |= 0x80;
+		
+	/* Header Un-Scramble */
+	if ((off_edit & 0xFF00) == 0x0100) {
+		off_edit &= 0xFFAC;
+		off_edit |= ((offset >> 6) & 0x01) << 0;
+		off_edit |= ((offset >> 4) & 0x01) << 1;
+		off_edit |= ((offset >> 1) & 0x01) << 4;
+		off_edit |= ((offset >> 0) & 0x01) << 6;
+	}
+	//logerror("read from %04X (%04X) cnt: %02X\n", offset, off_edit, m_unlock_cnt);
+	
+	if (offset & 0x4000) /* RB1 */
+		return m_rom[rom_bank_map[(m_base_bank & m_mask) | (m_latch_bank2 & ~m_mask)] * 0x4000 + (offset & 0x3fff)];
+	else                 /* RB0 */
+		return m_rom[rom_bank_map[(m_base_bank & m_mask) | (m_latch_bank & ~m_mask)] * 0x4000 + (off_edit & 0x3fff)];
+}
+
+READ8_MEMBER(gb_rom_sachen_mmc2_device::read_ram)
+{
+
+	if (m_mode == MODE_LOCKED_DMG) {
+		m_unlock_cnt = 0x00;
+		m_mode = MODE_LOCKED_CGB;
+	}
+	return 0xFF;
+
+}
+
+WRITE8_MEMBER(gb_rom_sachen_mmc2_device::write_ram)
+{
+
+	if (m_mode == MODE_LOCKED_DMG) {
+		m_unlock_cnt = 0x00;
+		m_mode = MODE_LOCKED_CGB;
+	}
+
 }
 
 

--- a/src/emu/bus/gameboy/mbc.h
+++ b/src/emu/bus/gameboy/mbc.h
@@ -191,7 +191,7 @@ public:
 	UINT8 m_bank_mask, m_bank, m_reg;
 };
 
-// ======================> gb_rom_sachen1_device
+// ======================> gb_rom_sachen_mmc1_device
 
 class gb_rom_sachen_mmc1_device : public gb_rom_mbc_device
 {
@@ -204,6 +204,7 @@ public:
 
 	// construction/destruction
 	gb_rom_sachen_mmc1_device(const machine_config &mconfig, const char *tag, device_t *owner, UINT32 clock);
+	gb_rom_sachen_mmc1_device(const machine_config &mconfig, device_type type, const char *name, const char *tag, device_t *owner, UINT32 clock, const char *shortname, const char *source);
 
 	// device-level overrides
 	virtual void device_start();
@@ -215,6 +216,31 @@ public:
 	virtual DECLARE_WRITE8_MEMBER(write_ram) { }
 
 	UINT8 m_base_bank, m_mask, m_mode, m_unlock_cnt;
+};
+
+// ======================> gb_rom_sachen_mmc2_device
+
+class gb_rom_sachen_mmc2_device : public gb_rom_sachen_mmc1_device
+{
+public:
+
+	enum {
+		MODE_LOCKED_DMG,
+		MODE_LOCKED_CGB,
+		MODE_UNLOCKED
+	};
+
+	// construction/destruction
+	gb_rom_sachen_mmc2_device(const machine_config &mconfig, const char *tag, device_t *owner, UINT32 clock);
+
+	// device-level overrides
+	virtual void device_start();
+	virtual void device_reset();
+
+	virtual DECLARE_READ8_MEMBER(read_rom);
+	virtual DECLARE_READ8_MEMBER(read_ram);
+	virtual DECLARE_WRITE8_MEMBER(write_ram);
+
 };
 
 // ======================> gb_rom_188in1_device

--- a/src/emu/bus/gameboy/mbc.h
+++ b/src/emu/bus/gameboy/mbc.h
@@ -193,12 +193,17 @@ public:
 
 // ======================> gb_rom_sachen1_device
 
-class gb_rom_sachen1_device : public gb_rom_mbc1_device
+class gb_rom_sachen_mmc1_device : public gb_rom_mbc_device
 {
 public:
 
+	enum {
+		MODE_LOCKED,
+		MODE_UNLOCKED
+	};
+
 	// construction/destruction
-	gb_rom_sachen1_device(const machine_config &mconfig, const char *tag, device_t *owner, UINT32 clock);
+	gb_rom_sachen_mmc1_device(const machine_config &mconfig, const char *tag, device_t *owner, UINT32 clock);
 
 	// device-level overrides
 	virtual void device_start();
@@ -209,7 +214,7 @@ public:
 	virtual DECLARE_READ8_MEMBER(read_ram) { return 0xff; }
 	virtual DECLARE_WRITE8_MEMBER(write_ram) { }
 
-	UINT8 m_base_bank, m_mask;
+	UINT8 m_base_bank, m_mask, m_mode, m_unlock_cnt;
 };
 
 // ======================> gb_rom_188in1_device


### PR DESCRIPTION
Some more changes from me:

* fixed some MBC1, MBC2 things
* added MMM01 notes on registers; emulation is totally bogus right now (but works)
* fixed Sachen MMC1 implementation
  * logo switch works now
  * header de-scramble works now as well

I also added Sachen MMC2 emulation, which works 100% on DMG now. Due to the way RAM accesses are emulated, CGB mode does not currently work, because cartridges don't see WRAM accesses ATM.

However, you can trivially replace rom_sachen2 with rom_sachen1 in gbcolor.xml and play these games already. It's just not proper to do so :P I might look into command-line switches for the integrated MMC2+ROM COB (start ROM bank and masking), but pointers are appreciated.

I feel I kept most of the established style, except for switch case vs. if-else address comparisons, because I feel the former is clearer and etabeta merged previous MBC1 changes in switch-case style into master.

cYa,

Tauwasser