### PR TITLE
gameboy: MBC1: fix byte/bit confusion

### DIFF
--- a/src/emu/bus/gameboy/mbc.c
+++ b/src/emu/bus/gameboy/mbc.c
@@ -398,31 +398,29 @@ WRITE8_MEMBER(gb_rom_mbc1_device::write_ram)
 
 READ8_MEMBER(gb_rom_mbc2_device::read_rom)
 {
-	if (offset < 0x4000)
-		return m_rom[rom_bank_map[m_latch_bank] * 0x4000 + (offset & 0x3fff)];
-	else
+	if (offset & 0x4000) /* RB1 */
 		return m_rom[rom_bank_map[m_latch_bank2] * 0x4000 + (offset & 0x3fff)];
+	else                 /* RB0 */
+		return m_rom[rom_bank_map[m_latch_bank] * 0x4000 + (offset & 0x3fff)];
 }
 
 WRITE8_MEMBER(gb_rom_mbc2_device::write_bank)
 {
-	if (offset < 0x2000)
-		m_ram_enable = ((data & 0x0f) == 0x0a) ? 1 : 0;
-	else if (offset < 0x4000)
-	{
-		// 4bits only
-		data &= 0x0f;
-		// bank = 0 => bank = 1
-		if (data == 0)
-			data = 1;
+	// the mapper only has data lines D3..D0
+	data &= 0x0f;
 
-		// The least significant bit of the upper address byte must be 1
-		if (offset & 0x0100)
-			m_latch_bank2 = (m_latch_bank2 & 0x100) | data;
+	// the mapper only uses inputs A15..A14, A8 for register accesses
+	switch (offset & 0xc100)
+	{
+		case 0x0000:    // RAM Enable Register
+			m_ram_enable = (data == 0x0a) ? 1 : 0;
+			break;
+		case 0x0100:    // ROM Bank Register
+			m_latch_bank2 = (data == 0x00) ? 0x01 : data;
+			break;
 	}
 }
 
-// 1 bank only??
 READ8_MEMBER(gb_rom_mbc2_device::read_ram)
 {
 	if (!m_ram.empty() && m_ram_enable)

--- a/src/emu/bus/gameboy/mbc.c
+++ b/src/emu/bus/gameboy/mbc.c
@@ -368,7 +368,6 @@ WRITE8_MEMBER(gb_rom_mbc1_device::write_bank)
 			m_ram_bank = data & 0x3;
 			break;
 		case 0x6000:    // MBC1 Mode Register
-		default:
 			m_mode = (data & 0x1) ? MODE_4M_256k : MODE_16M_64k;
 			break;
 	}

--- a/src/emu/bus/gameboy/mbc.c
+++ b/src/emu/bus/gameboy/mbc.c
@@ -369,7 +369,7 @@ WRITE8_MEMBER(gb_rom_mbc1_device::write_bank)
 			break;
 		case 0x6000:    // MBC1 Mode Register
 		default:
-			m_mode = (data & 0x1) ? MODE_4M_256k : MODE_16M_8k;
+			m_mode = (data & 0x1) ? MODE_4M_256k : MODE_16M_64k;
 			break;
 	}
 }

--- a/src/emu/bus/gameboy/mbc.h
+++ b/src/emu/bus/gameboy/mbc.h
@@ -37,7 +37,7 @@ class gb_rom_mbc1_device : public gb_rom_mbc_device
 public:
 
 	enum {
-		MODE_16M_8k  = 0, /// 16Mbit ROM, 8kBit RAM
+		MODE_16M_64k = 0, /// 16Mbit ROM, 64kBit RAM
 		MODE_4M_256k = 1, /// 4Mbit ROM, 256kBit RAM
 	};
 
@@ -47,7 +47,7 @@ public:
 
 	// device-level overrides
 	virtual void device_start() { shared_start(); save_item(NAME(m_mode)); };
-	virtual void device_reset() { shared_reset(); m_mode = MODE_16M_8k; };
+	virtual void device_reset() { shared_reset(); m_mode = MODE_16M_64k; };
 	virtual void set_additional_wirings(UINT8 mask, int shift) { m_mask = mask; m_shift = shift; }  // these get set at cart loading
 
 	virtual DECLARE_READ8_MEMBER(read_rom);


### PR DESCRIPTION
When I contributed my changes to MBC1, I accidentally mixed up 8 kByte with 8 kbit. It's 64 kbit, so fix the enum.

Signed-off-by: Tauwasser <tauwasser@tauwasser.eu>