### PR TITLE
machine type attribute added in the xml

### DIFF
--- a/src/emu/emuopts.c
+++ b/src/emu/emuopts.c
@@ -421,13 +421,13 @@ void emu_options::parse_standard_inis(std::string &error_string)
 		parse_one_ini("horizont", OPTION_PRIORITY_ORIENTATION_INI, &error_string);
 
 	if (cursystem->flags & GAME_TYPE_ARCADE)
-		parse_one_ini("arcade", OPTION_PRIORITY_SYSTYPE_INI, &error_string);
+		parse_one_ini(GAME_TYPE_STRING_ARCADE, OPTION_PRIORITY_SYSTYPE_INI, &error_string);
 	else if (cursystem->flags & GAME_TYPE_CONSOLE)
-		parse_one_ini("console", OPTION_PRIORITY_SYSTYPE_INI, &error_string);
+		parse_one_ini(GAME_TYPE_STRING_CONSOLE, OPTION_PRIORITY_SYSTYPE_INI, &error_string);
 	else if (cursystem->flags & GAME_TYPE_COMPUTER)
-		parse_one_ini("computer", OPTION_PRIORITY_SYSTYPE_INI, &error_string);
+		parse_one_ini(GAME_TYPE_STRING_COMPUTER, OPTION_PRIORITY_SYSTYPE_INI, &error_string);
 	else if (cursystem->flags & GAME_TYPE_OTHER)
-		parse_one_ini("othersys", OPTION_PRIORITY_SYSTYPE_INI, &error_string);
+		parse_one_ini(GAME_TYPE_STRING_OTHER, OPTION_PRIORITY_SYSTYPE_INI, &error_string);
 
 	// parse "vector.ini" for vector games
 	{

--- a/src/emu/gamedrv.h
+++ b/src/emu/gamedrv.h
@@ -49,7 +49,11 @@ const UINT32 GAME_CLICKABLE_ARTWORK         = 0x00800000;   // marking that artw
 const UINT32 GAME_IS_SKELETON               = GAME_NO_SOUND | GAME_NOT_WORKING; // mask for skelly games
 const UINT32 GAME_IS_SKELETON_MECHANICAL    = GAME_IS_SKELETON | GAME_MECHANICAL | GAME_REQUIRES_ARTWORK; // mask for skelly mechanical games
 
-
+// machine type string
+#define GAME_TYPE_STRING_ARCADE             "arcade"
+#define GAME_TYPE_STRING_CONSOLE            "console"
+#define GAME_TYPE_STRING_COMPUTER           "computer"
+#define GAME_TYPE_STRING_OTHER              "othersys"
 
 //**************************************************************************
 //  TYPE DEFINITIONS

--- a/src/emu/info.c
+++ b/src/emu/info.c
@@ -39,6 +39,7 @@ const char info_xml_creator::s_dtd_string[] =
 "\t\t<!ATTLIST __XML_TOP__ cloneof CDATA #IMPLIED>\n"
 "\t\t<!ATTLIST __XML_TOP__ romof CDATA #IMPLIED>\n"
 "\t\t<!ATTLIST __XML_TOP__ sampleof CDATA #IMPLIED>\n"
+"\t\t<!ATTLIST __XML_TOP__ type CDATA #IMPLIED>\n"
 "\t\t<!ELEMENT description (#PCDATA)>\n"
 "\t\t<!ELEMENT year (#PCDATA)>\n"
 "\t\t<!ELEMENT manufacturer (#PCDATA)>\n"
@@ -273,6 +274,15 @@ void info_xml_creator::output_one()
 
 	// display sample information and close the game tag
 	output_sampleof();
+	// machine type indicator
+	if (driver.flags & GAME_TYPE_ARCADE)
+		fprintf(m_output, " type=\"%s\"", GAME_TYPE_STRING_ARCADE);
+	else if (driver.flags & GAME_TYPE_CONSOLE)
+		fprintf(m_output, " type=\"%s\"", GAME_TYPE_STRING_CONSOLE);
+	else if (driver.flags & GAME_TYPE_COMPUTER)
+		fprintf(m_output, " type=\"%s\"", GAME_TYPE_STRING_COMPUTER);
+	else if (driver.flags & GAME_TYPE_OTHER)
+		fprintf(m_output, " type=\"%s\"", GAME_TYPE_STRING_OTHER);
 	fprintf(m_output, ">\n");
 
 	// output game description


### PR DESCRIPTION
Hello MAME project team.

MAME and MESS combined are happy events.
But, It have problem in the listxml.
The xml can't indicate machine type are arcade(MAME) or console/system(MESS).
I propose to add type attribute in the xml.
It is easy way to add filtering in the custom front-end.
If no filter needs, the attribute can ignore.
I'm tested binary in the clrmamepro after attribute added.
it is no error occured.

thank you.