### PR TITLE
Gameshark is a clone of Action Replay

### DIFF
--- a/hash/n64.xml
+++ b/hash/n64.xml
@@ -11754,7 +11754,7 @@ patched out (+ a fix for internal checksum)
 		</part>
 	</software>
 
-	<software name="gsharka" cloneof="gshark" supported="no">
+	<software name="gsharka" cloneof="arp64" supported="no">
 		<description>GameShark Pro (USA, v2.0)</description>
 		<year>19??</year>
 		<publisher>&lt;unknown&gt;</publisher>
@@ -11765,7 +11765,7 @@ patched out (+ a fix for internal checksum)
 		</part>
 	</software>
 
-	<software name="gshark" supported="no">
+	<software name="gshark" cloneof="arp64" supported="no">
 		<description>GameShark Pro (USA, v3.3)</description>
 		<year>19??</year>
 		<publisher>&lt;unknown&gt;</publisher>


### PR DESCRIPTION
http://doc.kodewerx.org/hacking_n64.html#devices_gspro
http://www.gamewinners.com/device/misc/blgameshark.htm

Gameshark and Action Replay for N64 are the exact same device with different names. Action Replay was originally developed by Datel in the UK It was then sold by Interact with the Gameshark label in the U.S. Madcatz now owns that label. They're also called GameBuster in Germany.