### PR TITLE
S11paradise

### DIFF
--- a/src/mame/arcade.lst
+++ b/src/mame/arcade.lst
@@ -9482,7 +9482,9 @@ skybump         // (c) 1982 Venture Line
 suprridr        // (c) 1983 Venture Line + Taito license
 
 // Yun Sung games
-paradise        // (c) >1994 Yun Sung
+paradise        // (c) 1994 Yun Sung
+paradisea	// (c) 1994 Yun Sung
+paradisee	// (c) 1994 Yun Sung (Escape license)
 paradlx         // (c) >1994 Yun Sung
 para2dx         // (c) >1994 Yun Sung
 penky           // (c) 1995 Yun Sung

--- a/src/mame/drivers/paradise.c
+++ b/src/mame/drivers/paradise.c
@@ -14,8 +14,8 @@ Sound Chips  :  2 x AR17961 (OKI M6295) (only 1 in Torus)
 ---------------------------------------------------------------------------
 Year + Game          Board#
 ---------------------------------------------------------------------------
-94+ Paradise         YS-1600
-94+ Paradise Deluxe  YS-1604
+94  Paradise         YS-1600
+94  Paradise Deluxe  YS-1604
 95  Target Ball      YS-2002
 96  Penky            YS951004
 96  Torus            YS-0402? Looks identical
@@ -27,8 +27,6 @@ Notes:
 paradise: I'm not sure it's working correctly:
 
 - The high scores table can't be entered !?
-- The chance to play a bonus game is very slim. I think I got to play
-  a couple in total. Is there a way to trigger them !?
 
 penky: we need to delay the irqs at startup or it won't boot. Either one of
        ports 0x2003.r or 0x2005.w starts up the irq timer (confirmed via trojan)
@@ -80,6 +78,11 @@ DIPSW-B
        TV Test        |    Game    |                           |off|*
     (Slide Show)      |    Test    |                           |on |
 --------------------------------------------------------------------
+
+2015/06/03 - System11
+Amended above comments - bonus round is triggered by percentage when you
+beat a stage.  Added 2 clones.  Amended date to 1994 based on Distributor
+sticker from Jan 95 and factory sticker 94*41.
 
 ***************************************************************************/
 
@@ -802,8 +805,10 @@ YS-1604
 |                                                         |
 |---------------------------------------------------------|
 
-The year is not shown but must be >= 1994, since the development system
-(cross compiler?) they used left a "1994.8-1989" in the rom
+Year is assumed to be 1994 based on 94*41 factory sticker and 19/1/95 
+operator sticker on a revised version PCB.  The year is not shown but
+must be >= 1994, since the development system (cross compiler?) they
+used left a "1994.8-1989" in the rom
 
 ***************************************************************************/
 
@@ -831,6 +836,67 @@ ROM_START( paradise )
 
 	ROM_REGION( 0x80000, "oki2", 0 )    /* Samples (banked) */
 	ROM_LOAD( "u113", 0x00000, 0x80000, CRC(53de6025) SHA1(c94b3778b57ff7f46ce4cff661841019fb187d5d) )
+ROM_END
+
+/* No board ID, some tracks which are wire hacked on the YS board are
+   corrected on this variant - for example red on the edge connector,
+   would assume this is a later version.  All ROMs have A-19 stickers
+   on them, this could be a bootleg set, hard to say since Yun-Sung
+   often made boards with no labels at all...  Probably original code
+   since the same Microtek compiler was used*/
+ROM_START( paradisea )
+        ROM_REGION( 0x40000, "maincpu", 0 )     /* Z80 Code */
+        ROM_LOAD( "A-19.U128", 0x00000, 0x40000, CRC(d47ecb7e) SHA1(74e7a33f2fc4c7c830c53c50541c3d0efd152e98) )
+
+        ROM_REGION( 0x80000, "gfx1", ROMREGION_INVERT)  /* 16x16x8 Sprites */
+        ROM_LOAD( "u114", 0x00000, 0x40000, CRC(c748ba3b) SHA1(ad23bda4e001ca539f849c1ca256de5daf7c233b) )
+        ROM_LOAD( "u115", 0x40000, 0x40000, CRC(0d517bbb) SHA1(5bf7c5036f3d660901e26f14baaea1a3c0327dfe) )
+
+        ROM_REGION( 0x20000, "gfx2", ROMREGION_INVERT)  /* 8x8x4 Background */
+        ROM_LOAD( "u94", 0x00000, 0x20000, CRC(e3a99209) SHA1(5db79dc1a38d93b458b043499a58516285c65aa8) )
+
+        ROM_REGION( 0x100000, "gfx3", ROMREGION_INVERT) /* 8x8x8 Foreground */
+        ROM_LOAD( "u92", 0x00000, 0x80000, CRC(633d24f0) SHA1(26b25ec1014fba1a3d0d2bdba0c867c57034647d) )
+        ROM_LOAD( "u93", 0x80000, 0x80000, CRC(bbf5c632) SHA1(9d31e136f014c2dd7dd988c3aee0adfcfea91bc9) )
+
+        ROM_REGION( 0x40000, "gfx4", ROMREGION_INVERT)  /* 8x8x8 Midground */
+        ROM_LOAD( "u110", 0x00000, 0x20000, CRC(9807a7e6) SHA1(30e2a741a93954cfe672c61c93a990d0c3b25145) )
+        ROM_LOAD( "u111", 0x20000, 0x20000, CRC(bc9f93f0) SHA1(dd4cfc849a0c0f918ac0dfeb7f00a67aae5a1c13) )
+
+        ROM_REGION( 0x40000, "oki1", 0 )    /* Samples */
+        ROM_LOAD( "u85", 0x00000, 0x40000, CRC(bf3c3065) SHA1(54dd7ffea2fb3f31ed575e982b82691cddc2581a) )
+
+        ROM_REGION( 0x80000, "oki2", 0 )    /* Samples (banked) */
+        ROM_LOAD( "u113", 0x00000, 0x80000, CRC(53de6025) SHA1(c94b3778b57ff7f46ce4cff661841019fb187d5d) )
+ROM_END
+
+/* Same board ID as main set, Escape labels on all ROMs
+   Suspect this is actually the newest revision due to improved slot
+   machine animation on 'girl select' compared to other sets */
+ROM_START( paradisee )
+        ROM_REGION( 0x40000, "maincpu", 0 )     /* Z80 Code */
+        ROM_LOAD( "Escape.U128", 0x00000, 0x40000, CRC(19b4e854) SHA1(7d7292017df67b7ed3a3e0059334866890c58b83) )
+
+        ROM_REGION( 0x80000, "gfx1", ROMREGION_INVERT)  /* 16x16x8 Sprites */
+        ROM_LOAD( "u114", 0x00000, 0x40000, CRC(c748ba3b) SHA1(ad23bda4e001ca539f849c1ca256de5daf7c233b) )
+        ROM_LOAD( "u115", 0x40000, 0x40000, CRC(0d517bbb) SHA1(5bf7c5036f3d660901e26f14baaea1a3c0327dfe) )
+
+        ROM_REGION( 0x20000, "gfx2", ROMREGION_INVERT)  /* 8x8x4 Background */
+        ROM_LOAD( "u94", 0x00000, 0x20000, CRC(e3a99209) SHA1(5db79dc1a38d93b458b043499a58516285c65aa8) )
+
+        ROM_REGION( 0x100000, "gfx3", ROMREGION_INVERT) /* 8x8x8 Foreground */
+        ROM_LOAD( "u92", 0x00000, 0x80000, CRC(633d24f0) SHA1(26b25ec1014fba1a3d0d2bdba0c867c57034647d) )
+        ROM_LOAD( "u93", 0x80000, 0x80000, CRC(bbf5c632) SHA1(9d31e136f014c2dd7dd988c3aee0adfcfea91bc9) )
+
+        ROM_REGION( 0x40000, "gfx4", ROMREGION_INVERT)  /* 8x8x8 Midground */
+        ROM_LOAD( "u110", 0x00000, 0x20000, CRC(9807a7e6) SHA1(30e2a741a93954cfe672c61c93a990d0c3b25145) )
+        ROM_LOAD( "u111", 0x20000, 0x20000, CRC(bc9f93f0) SHA1(dd4cfc849a0c0f918ac0dfeb7f00a67aae5a1c13) )
+
+        ROM_REGION( 0x40000, "oki1", 0 )    /* Samples */
+        ROM_LOAD( "u85", 0x00000, 0x40000, CRC(bf3c3065) SHA1(54dd7ffea2fb3f31ed575e982b82691cddc2581a) )
+
+        ROM_REGION( 0x80000, "oki2", 0 )    /* Samples (banked) */
+        ROM_LOAD( "u113", 0x00000, 0x80000, CRC(53de6025) SHA1(c94b3778b57ff7f46ce4cff661841019fb187d5d) )
 ROM_END
 
 ROM_START( paradlx )
@@ -1244,7 +1310,9 @@ DRIVER_INIT_MEMBER(paradise_state,torus)
 
 ***************************************************************************/
 
-GAME( 199?,  paradise, 0,       paradise, paradise, paradise_state, paradise, ROT90, "Yun Sung", "Paradise", GAME_SUPPORTS_SAVE )   // year not shown, but should be >=1994
+GAME( 1994,  paradise, 0,       paradise, paradise, paradise_state, paradise, ROT90, "Yun Sung", "Paradise", GAME_SUPPORTS_SAVE )
+GAME( 1994,  paradisea, paradise,       paradise, paradise, paradise_state, paradise, ROT90, "Yun Sung", "Paradise (set 2)", GAME_SUPPORTS_SAVE )
+GAME( 1994,  paradisee, paradise,       paradise, paradise, paradise_state, paradise, ROT90, "Yun Sung", "Paradise (Escape)", GAME_SUPPORTS_SAVE )
 GAME( 199?,  paradlx,  0,       paradise, paradise, paradise_state, paradise, ROT90, "Yun Sung", "Paradise Deluxe", GAME_IMPERFECT_GRAPHICS | GAME_SUPPORTS_SAVE )      // "
 GAME( 199?,  para2dx,  0,       paradise, para2dx, paradise_state,  paradise, ROT90, "Yun Sung", "Paradise 2 Deluxe", GAME_IMPERFECT_GRAPHICS | GAME_SUPPORTS_SAVE )    // "
 GAME( 1995,  tgtball,  0,       tgtball,  tgtball, paradise_state,  tgtball,  ROT0,  "Yun Sung", "Target Ball (Nude)", GAME_SUPPORTS_SAVE )

--- a/src/mame/drivers/sidearms.c
+++ b/src/mame/drivers/sidearms.c
@@ -14,8 +14,8 @@ MAY-2015 System11
 
 - added turtshipko and turtshipkn.
 - amended comments for T-5 instances, A14 is tied high on the PCBs hence the need to load the higher half of the ROM only
-- order of age is guessed - turtshipko has grey bullets and is the only revision to have these, probably fixed based on feedback before it was licensed to Sharp Image and Pacific Games - differences between US/JP/Korea versions previously in MAME are minimal.
-- turtshipkn I assume is newer, the level order has changed and the disclaimer is in pure Korean however the orange bullets are retained.  Given the 88/9 release date from the startup screen it would seem unlikely that this came out first, then got grey bullets and back to orange in time for it to still be a 1988 game in other countries.
+- order of age is guessed - turtshipko has grey bullets and a different level order, 3x horizontal and then 3x vertical (as far as tested).  Bullets probably fixed based on feedback before it was licensed to Sharp Image and Pacific Games - differences between US/JP/Korea versions previously in MAME are minimal.
+- turtshipkn I assume is newer, the disclaimer is in pure Korean and the orange bullets are retained.  Given the 88/9 release date from the startup screen it would seem unlikely that this came out first, then got grey bullets and back to orange in time for it to still be a 1988 game in other countries.
 
 JUL-2003 AAT
 


### PR DESCRIPTION
added paradisea - alt version of Paradise
added paradisee - Escape license of Paradise
corrected year for Paradise versions to 1994 based on evidence from one of the PCBs
removed comment about bugged bonus round chance + explanation
corrected comments in sidearms.c from my previous commits

ROMs and photos of PCBs for new clones:
http://www.system11.org/temp/ROMs/S11paradise.zip
