### PR TITLE
Improve Ensoniq 5503DOC Swap Mode

### DIFF
--- a/src/emu/sound/es5503.c
+++ b/src/emu/sound/es5503.c
@@ -128,9 +128,10 @@ void es5503_device::halt_osc(int onum, int type, UINT32 *accumulator, int resshi
 
 		*accumulator = altram << resshift;
 	}
+	int omode = (pPartner->control>>1) & 3;
 
 	// if swap mode, start the partner
-	if (mode == MODE_SWAP)
+	if ((mode == MODE_SWAP) || (omode == MODE_SWAP))
 	{
 		pPartner->control &= ~1;    // clear the halt bit
 		pPartner->accumulator = 0;  // and make sure it starts from the top (does this also need phase preservation?)


### PR DESCRIPTION
If one oscillator is in swap mode, its partner should be treated as
being in swap mode, even if it is set to one shot. This behavior is
undocumented in literature from Ensoniq, but exploited by software
developers. See: https://groups.google.com/forum/#!original/comp.sys.apple2/TrB4IN10Qiw/j46LHuQvFbYJ

This change allows Ninjaforce's NinjaTracker to correctly play looped
instruments. NinjaTracker, along with it's source code, can be obtained from the following link: http://www.ninjaforce.com/html/products_ninjatracker.html

The included demo song 'conrad' exhibits the looping bug with some instruments that this patch addresses. Output accuracy was also verified with a real ROM 01 Apple IIgs.