### PR TITLE
In SDL version command line, don't look for depth in -resolution

### DIFF
--- a/src/osd/sdl/video.c
+++ b/src/osd/sdl/video.c
@@ -756,6 +756,6 @@ static void get_resolution(const char *defdata, const char *data, osd_window_con
 		data = defdata;
 	}
 
-	if (sscanf(data, "%dx%dx%d@%d", &config->width, &config->height, &config->depth, &config->refresh) < 2 && report_error)
+	if (sscanf(data, "%dx%d@%d", &config->width, &config->height, &config->refresh) < 2 && report_error)
 		osd_printf_error("Illegal resolution value = %s\n", data);
 }

--- a/src/osd/sdl/video.c
+++ b/src/osd/sdl/video.c
@@ -756,6 +756,11 @@ static void get_resolution(const char *defdata, const char *data, osd_window_con
 		data = defdata;
 	}
 
-	if (sscanf(data, "%dx%d@%d", &config->width, &config->height, &config->refresh) < 2 && report_error)
+	if (sscanf(data, "%dx%dx%d", &config->width, &config->height, &config->depth) < 2 && report_error)
 		osd_printf_error("Illegal resolution value = %s\n", data);
+
+	const char * at_pos = strchr(data, '@');
+	if (at_pos)
+		if (sscanf(at_pos + 1, "%d", &config->refresh) < 1 && report_error)
+			osd_printf_error("Illegal refresh rate in resolution value = %s\n", data);
 }

--- a/src/osd/windows/video.c
+++ b/src/osd/windows/video.c
@@ -508,6 +508,12 @@ static void get_resolution(const char *defdata, const char *data, osd_window_con
 			return;
 		data = defdata;
 	}
-	if (sscanf(data, "%dx%d@%d", &config->width, &config->height, &config->refresh) < 2 && report_error)
+
+	if (sscanf(data, "%dx%dx%d", &config->width, &config->height, &config->depth) < 2 && report_error)
 		osd_printf_error("Illegal resolution value = %s\n", data);
+
+	const char * at_pos = strchr(data, '@');
+	if (at_pos)
+		if (sscanf(at_pos + 1, "%d", &config->refresh) < 1 && report_error)
+			osd_printf_error("Illegal refresh rate in resolution value = %s\n", data);
 }


### PR DESCRIPTION
-showusage says, and the Windows version looks for,
"\<width>x\<height>[@\<refreshrate>]", but the SDL version was scanning for
"\<width>x\<height>[x\<depth>][@\<refreshrate>]", with the effect of
silently ignoring refreshrate if depth was omitted. And if given, the
depth didn't appear to be used anywhere anyway.

If you want to test this, I suggest doing something like
./mame64 shinobi -switchres -resolution0 800x600@60 -verbose
and looking at the verbose output to see the scores it gave to the modes, instead of asking your monitor what refresh rate it's actually switched to, as there's another bug to do with SDL and mode switching which I'm going to make another PR for shortly.