### PR TITLE
In SDL version, fix refresh rate setting in fullscreen

### DIFF
--- a/src/osd/sdl/window.c
+++ b/src/osd/sdl/window.c
@@ -1168,8 +1168,7 @@ OSDWORK_CALLBACK( sdl_window_info::complete_create_wt )
 
 	// create the SDL window
 	// soft driver also used | SDL_WINDOW_INPUT_GRABBED | SDL_WINDOW_MOUSE_FOCUS
-	window->m_extra_flags |= (window->fullscreen() ?
-			/*SDL_WINDOW_BORDERLESS |*/ SDL_WINDOW_INPUT_FOCUS | SDL_WINDOW_FULLSCREEN : SDL_WINDOW_RESIZABLE);
+	window->m_extra_flags |= SDL_WINDOW_RESIZABLE;
 
 #if defined(SDLMAME_WIN32)
 	SDL_SetHint(SDL_HINT_VIDEO_MINIMIZE_ON_FOCUS_LOSS, "0");
@@ -1201,7 +1200,10 @@ OSDWORK_CALLBACK( sdl_window_info::complete_create_wt )
 		if (window->m_win_config.refresh)
 			mode.refresh_rate = window->m_win_config.refresh;
 
-		SDL_SetWindowDisplayMode(window->sdl_window(), &mode);    // Try to set mode
+		// Set the mode we want SDL to use for this window while fullscreen
+		SDL_SetWindowDisplayMode(window->sdl_window(), &mode);
+		// Now actually go fullscreen
+		SDL_SetWindowFullscreen(window->sdl_window(), SDL_WINDOW_INPUT_FOCUS | SDL_WINDOW_FULLSCREEN);
 #ifndef SDLMAME_WIN32
 		/* FIXME: Warp the mouse to 0,0 in case a virtual desktop resolution
 		 * is in place after the mode switch - which will most likely be the case


### PR DESCRIPTION
The SDL version is used on so many different systems, and the SDL documentation is vague enough, that any argument for this change can only really be a "works for me". Let me ramble a bit anyway on how this does work for me.

The change is confined to the file src/osd/sdl/window.c. This file contains code for both SDL 1 and SDL 2 ("#if (SDLMAME_SDL2)"). My change relates to the SDL 2 code only.

Using a command line such as "./mame64 shinobi -resolution 800x600@60 -switchres", I've observed the following when single-stepping through the original code with gdb:

([Line 1178](https://github.com/mamedev/mame/blob/e1e0e9edbd0e857997c4725703e562f715c9589b/src/osd/sdl/window.c#L1178)) SDL_CreateWindow() is called with arguments that include the desired width, height and an SDL_WINDOW_FULLSCREEN flag (the function does not have a refresh rate parameter). If this width and height is the same as what's already in effect on your desktop, SDL doesn't touch the video mode, it just opens a borderless window covering the whole screen area. But if either width or height is different, SDL now triggers a mode switch to those dimensions, at some refresh rate that is close to what was previously in effect on the desktop (presumably the closest available out of the modes that are defined by your system).

Shortly after, ([line 1204](https://github.com/mamedev/mame/blob/e1e0e9edbd0e857997c4725703e562f715c9589b/src/osd/sdl/window.c#L1204)) SDL_SetWindowDisplayMode() is called with the previously created window, the desired width and height again, and the desired refresh rate. It would be good if this now caused the monitor to switch mode to the desired refresh rate, but unfortunately nothing happens.

To fix this, I find that if you create the window without the SDL_WINDOW_FULLSCREEN flag to begin with, then call SDL_SetWindowDisplayMode() to specify the desired width/height/refresh - the video mode is still not changed at this point - then finally call SDL_SetWindowFullscreen() - now, the video mode changes, the window goes borderless, and you have both the size and refresh rate you wanted.

Now, I'd love to link to some note or example in the SDL docs where this pattern of usage is demonstrated, but unfortunately their docs are pretty thin altogether. Here's [SDL_SetWindowDisplayMode()](https://wiki.libsdl.org/SDL_SetWindowDisplayMode): "Use this function to set the display mode to use when a window is visible at fullscreen". It's not wrong, but for starters, I wish they'd have said a bit more to clarify the general philosophy of how screen modes are handled in SDL 2. By observation and joining the dots, I think it's like this: in the [data structure that SDL uses to represent a window](http://hg.libsdl.org/SDL/file/704a0bfecf75/src/video/SDL_sysvideo.h#l71) there is a member ('fullscreen_mode') with width/height/refresh of the video mode that should be used if and when that window is called upon to be fullscreen, and a flag (in 'flags') which indicates whether that window should indeed be shown in fullscreen or not. SDL actively manages the video mode when windows gain or lose focus - if you alt+tab away from an SDL fullscreen window back to your desktop, SDL automatically changes the video mode back to the original desktop mode; if you alt+tab back to the fullscreen window, it automatically switches back to the window's configured mode for fullscreen situations.

There is no function in SDL 2 to directly activate a particular video mode, on a particular monitor (not from a quick perusal [here](https://wiki.libsdl.org/CategoryAPI), anyway. In SDL 1, [SDL_SetVideoMode()](https://www.libsdl.org/release/SDL-1.2.15/docs/html/sdlsetvideomode.html) might have been that function but I only had a quick peek, don't take my word for it).

Getting back to the point, if you google around you can find [other](http://www.gamedev.net/topic/664182-sdl-setwindowdisplaymode-problem/) people [saying](http://www.freeorion.org/forum/viewtopic.php?f=9&t=9109) that SDL_SetWindowDisplayMode() doesn't "work" if the window is already fullscreen. Looking at the [source of the function](http://hg.libsdl.org/SDL/file/704a0bfecf75/src/video/SDL_video.c#l1012) it does seem like it does no more than just set a field in a structure. There are also suggestions in the above-linked forum threads that perhaps this behaviour has been fixed in the latest SDL. Lo and behold, if you look at the [head revision of the function](http://hg.libsdl.org/SDL/file/e9738a3ac057/src/video/SDL_video.c#l1031), there is additional code which seems like it might be effecting an actual mode change (I haven't tried it). However, it doesn't seem like they're in much of a hurry to put out a new release. The current 'stable' SDL, without the added code, is 2.0.3 - released 15 months ago.

Short of actually talking to the SDL devs and getting them to clarify their current design and future direction (which I admit I don't really have the patience for, I'm not much interested in SDL beyond MAME's usage of it), I think it's reasonable to expect that the sequence of actions
- create window non-fullscreen
- specify desired fullscreen mode
- turn on fullscreen

will not be less likely to work fully, in the future or in other SDL ports, than

- create window fullscreen
- change to another fullscreen mode

It may be less stress on the monitor too, since you're only changing mode once rather than possibly forcing it through two.

I also tried alt+enter to go out of fullscreen and back in again. With the current sdlmame, on return to fullscreen it restores the incorrect refresh rate (the one related to your desktop rather than the desired rate given on the command line). With the change from this pull request, it all seems to work correctly.

All my investigations have turned out identically between sdlmame on Arch Linux and sdlmame on Windows 7. That is, the gdb stepping, various command-line options, and alt+enter'ing - all give me the same failures or successes for the old or new sdlmame on both OS'es. (I am using the same machine for both, but it is a dual boot - I'm not going through Virtualbox or anything like that). I'm unable to test on Mac, though.
