### PR TITLE
Fix compile failure in netlist code (linux, GCC)

### DIFF
--- a/scripts/src/netlist.lua
+++ b/scripts/src/netlist.lua
@@ -9,6 +9,11 @@ project "netlist"
 		"ForceCPP",
 	}
 
+        configuration { "linux-gcc" }
+                buildoptions {
+                        "-Wno-maybe-uninitialized",
+                }
+
 	includedirs {
 		MAME_DIR .. "src/emu/netlist",
 		MAME_DIR .. "src/osd",

--- a/scripts/src/netlist.lua
+++ b/scripts/src/netlist.lua
@@ -9,10 +9,10 @@ project "netlist"
 		"ForceCPP",
 	}
 
-        configuration { "linux-gcc" }
-                buildoptions {
-                        "-Wno-maybe-uninitialized",
-                }
+	configuration { "linux-gcc" }
+		buildoptions {
+			"-Wno-maybe-uninitialized",
+		}
 
 	includedirs {
 		MAME_DIR .. "src/emu/netlist",


### PR DESCRIPTION
Added -Wno-maybe-uninitialized for linux-gcc builds to stop build failure on post-4.8 GCC