### PR TITLE
Added 'jumpingi' / correct date

### DIFF
--- a/src/mame/arcade.lst
+++ b/src/mame/arcade.lst
@@ -2109,7 +2109,8 @@ rbisland        // B22 (c) 1987 Taito Corporation
 rbislando       // B22 (c) 1987 Taito Corporation
 rbislande       // B39 (c) 1988 Taito Corporation
 jumping         // bootleg
-jumpinga        // bootleg
+jumpinga        // bootleg (Seyutu)
+jumpingi        // bootleg (Seyutu / Imnoe)
 arkanoid        // A75 (c) 1986 Taito Corporation Japan (World)
 arkanoidu       // A75 (c) 1986 Taito America Corporation + Romstar license (US)
 arkanoiduo      // A75 (c) 1986 Taito America Corporation + Romstar license (US)

--- a/src/mame/drivers/rainbow.c
+++ b/src/mame/drivers/rainbow.c
@@ -894,7 +894,49 @@ ROM_START( jumpinga )
 	ROM_LOAD( "pal16l8a.ic51.bin",               0x000, 0x104, CRC(c1e6cb8f) SHA1(9908e62bb9b806047b7a344bb62334bd696b9fc8) ) // z80 address decoder?
 ROM_END
 
+/* red 'Imnoe' PCB */
+ROM_START( jumpingi )
+        ROM_REGION( 0xa0000, "maincpu", 0 )
+        ROM_LOAD16_BYTE( "05.IC3",         0x00000, 0x20000, CRC(69ac4af4) SHA1(39055573e412e2591f7a68f9fee5919528529544) )
+        ROM_LOAD16_BYTE( "03.IC6",         0x00001, 0x20000, CRC(38975cdc) SHA1(23c02a4574a95904805d5f458c06c77c14d11c14) )
+        ROM_LOAD16_BYTE( "06.IC2",         0x40000, 0x20000, CRC(3ebb0fb8) SHA1(1b41b305623d121255eb70cb992e4d9da13abd82) ) // b22-03.23
+        ROM_LOAD16_BYTE( "04.IC5",         0x40001, 0x20000, CRC(91625e7f) SHA1(765afd973d9b82bb496b04beca284bf2769d6e6f) ) // b22-04.24
+        ROM_LOAD16_BYTE( "02",             0x80001, 0x10000, CRC(0810d327) SHA1(fe91ac02e617bde413dc8a20b7cbcaf3e20aeb28) ) /* c-chip substitute */
 
+        ROM_REGION( 0x14000, "audiocpu", 0 )
+        ROM_LOAD( "01.IC53",              0x00000, 0x8000, CRC(8527c00e) SHA1(86e3824caca39aca4ca4df63bb4474adacfc4c53) )
+        ROM_CONTINUE(                     0x10000, 0x4000 )
+        ROM_CONTINUE(                     0x0c000, 0x4000 )
+
+        ROM_REGION( 0x80000, "gfx1", 0 )
+        ROM_LOAD( "13.IC8",              0x00000, 0x10000, CRC(65b76309) SHA1(1e345726e137f4c56d4bf239651c986fd53a16c3) )  /* tiles */
+        ROM_LOAD( "14.IC7",              0x10000, 0x10000, CRC(43a94283) SHA1(d6a05cbc7b996a8e7f1520563f6fada9a59021a4) )
+        ROM_LOAD( "11.IC10",             0x20000, 0x10000, CRC(e61933fb) SHA1(02bc0e1a7a3ce9e15fb83b28ce8fafb0b8d80ebd) )
+        ROM_LOAD( "12.IC9",              0x30000, 0x10000, CRC(ed031eb2) SHA1(905be4d890ff7bb8a4d8ad85b2a11483fb4d67eb) )
+        ROM_LOAD( "09.IC12",             0x40000, 0x10000, CRC(312700ca) SHA1(c79edc9c25f364d0afd79aaa21cfe2fe46044314) )
+        ROM_LOAD( "10.IC11",             0x50000, 0x10000, CRC(de3b0b88) SHA1(14b8871821e4c0abbb9967c5aa282cf4e67884fe) )
+        ROM_LOAD( "07.IC14",             0x60000, 0x10000, CRC(9fdc6c8e) SHA1(ff4e1a98dc982bce2f9d235cac62c7166f477f64) )
+        ROM_LOAD( "08.IC13",             0x70000, 0x10000, CRC(06226492) SHA1(834280ec49e61a0c9c6b6fe2033e1b20bd1bffbf) )
+
+        ROM_REGION( 0xa0000, "gfx2", ROMREGION_INVERT )
+        ROM_LOAD( "15.IC62",             0x00000, 0x10000, CRC(8548db6c) SHA1(675cd301259d5ed16098a38ac58b27b5ccd91264) )  /* sprites */
+        ROM_LOAD( "19.IC61",             0x10000, 0x10000, CRC(89b3d8ee) SHA1(8491de6e8292e58b9a8696be15827bcb1ea42845) ) 
+        ROM_LOAD( "23.IC60",             0x20000, 0x08000, CRC(662a2f1e) SHA1(1c5e8b1f0623e64faf9cd60f9653fc5957191a9b) )
+        ROM_LOAD( "16.IC78",             0x28000, 0x10000, CRC(925865e1) SHA1(457de50bc03e8b949ac7d46ae4188201e87574a8) )
+        ROM_LOAD( "20.IC77",             0x38000, 0x10000, CRC(b09695d1) SHA1(e6d315f9befb7b47f42668d573a1102e52d78aea) )
+        ROM_LOAD( "24.IC76",             0x48000, 0x08000, CRC(41937743) SHA1(890c832a7cf87e6fe749d4824b02d57e10872bdf) )
+        ROM_LOAD( "17.IC93",             0x50000, 0x10000, CRC(f644eeab) SHA1(9d45e9dfb08e8c90b4b10f5dc383fa4732161a81) )
+        ROM_LOAD( "21.IC92",             0x60000, 0x10000, CRC(16e1b0ff) SHA1(1467a317d07a447d01113e6b6b9f5aca30cb0dcb) )
+        ROM_LOAD( "25.IC91",             0x70000, 0x08000, CRC(d886c014) SHA1(9327c332c98a81451e9e0624344d2601ef06e490) )
+        ROM_LOAD( "18.IC121",            0x78000, 0x10000, CRC(93df1e4d) SHA1(b100d265b973254ec9cd44b6c32f62b4bac3b732) )
+        ROM_LOAD( "22.IC120",            0x88000, 0x10000, CRC(7c4e893b) SHA1(eceecb38554157ee24d228a2c722dad750a6a07d) )
+        ROM_LOAD( "26.IC119",            0x98000, 0x08000, CRC(7e1d58d8) SHA1(d586a018c3ec3e6e6a39992170d324361e03c68a) )
+
+        ROM_REGION( 0x200, "pals", 0 )
+        ROM_LOAD( "JP2.IC56",            0x000, 0x104, CRC(12e9a7b8) SHA1(a0ce8b6083c9adfcb4bdbca87f63a01f292525f3) ) // PAL16R6A-2CN
+        ROM_LOAD( "JP1.IC13",            0x000, 0x144, CRC(76944f81) SHA1(ab78e4e157ffdc13aea5dc360268b2640e60d19c) ) // PAL20L8A-2CNS
+        ROM_LOAD( "JP3.IC51",            0x000, 0x104, CRC(c1e6cb8f) SHA1(9908e62bb9b806047b7a344bb62334bd696b9fc8) ) // PAL16L8A-2CN z80 address decoder?
+ROM_END
 
 DRIVER_INIT_MEMBER(rbisland_state,rbisland)
 {
@@ -925,4 +967,5 @@ GAME( 1987, rbisland,  0,        rbisland, rbisland, rbisland_state, rbisland,  
 GAME( 1987, rbislando, rbisland, rbisland, rbisland, rbisland_state, rbisland,  ROT0, "Taito Corporation", "Rainbow Islands (old version)", GAME_SUPPORTS_SAVE )
 GAME( 1988, rbislande, rbisland, rbisland, rbisland, rbisland_state, rbislande, ROT0, "Taito Corporation", "Rainbow Islands (Extra)", GAME_SUPPORTS_SAVE )
 GAME( 1989, jumping,   rbisland, jumping,  jumping, rbisland_state,  jumping,   ROT0, "bootleg",          "Jumping (set 1)", GAME_SUPPORTS_SAVE )
-GAME( 1989, jumpinga,  rbisland, jumping,  jumping, rbisland_state,  jumping,   ROT0, "bootleg (Seyutu)", "Jumping (set 2)", GAME_SUPPORTS_SAVE )
+GAME( 1988, jumpinga,  rbisland, jumping,  jumping, rbisland_state,  jumping,   ROT0, "bootleg (Seyutu)", "Jumping (set 2)", GAME_SUPPORTS_SAVE )
+GAME( 1988, jumpingi,  rbisland, jumping,  jumping, rbisland_state,  jumping,   ROT0, "bootleg (Seyutu)", "Jumping (set 3, Imnoe PCB)", GAME_SUPPORTS_SAVE )


### PR DESCRIPTION
jumpingi from a red 'Imnoe' PCB which was the source for the recent clock timing fixes.  Board has unsplit code ROMs, based on (or parent of) jumpinga set.

Corrected date to 1988 for jumpinga

http://www.system11.org/temp/ROMs/S11jumping.zip
