### PR TITLE
Re-add NetBSD support.

### DIFF
--- a/3rdparty/bgfx/src/renderer_null.cpp
+++ b/3rdparty/bgfx/src/renderer_null.cpp
@@ -33,7 +33,7 @@ namespace bgfx { namespace noop
 		{
 		}
 
-		void createIndexBuffer(IndexBufferHandle /*_handle*/, Memory* /*_mem*/, uint8_t /*_flags*/) BX_OVERRIDE
+		void createIndexBuffer(IndexBufferHandle /*_handle*/, Memory* /*_mem*/, uint16_t /*_flags*/) BX_OVERRIDE
 		{
 		}
 
@@ -49,7 +49,7 @@ namespace bgfx { namespace noop
 		{
 		}
 
-		void createVertexBuffer(VertexBufferHandle /*_handle*/, Memory* /*_mem*/, VertexDeclHandle /*_declHandle*/, uint8_t /*_flags*/) BX_OVERRIDE
+		void createVertexBuffer(VertexBufferHandle /*_handle*/, Memory* /*_mem*/, VertexDeclHandle /*_declHandle*/, uint16_t /*_flags*/) BX_OVERRIDE
 		{
 		}
 
@@ -57,7 +57,7 @@ namespace bgfx { namespace noop
 		{
 		}
 
-		void createDynamicIndexBuffer(IndexBufferHandle /*_handle*/, uint32_t /*_size*/, uint8_t /*_flags*/) BX_OVERRIDE
+		void createDynamicIndexBuffer(IndexBufferHandle /*_handle*/, uint32_t /*_size*/, uint16_t /*_flags*/) BX_OVERRIDE
 		{
 		}
 
@@ -69,7 +69,7 @@ namespace bgfx { namespace noop
 		{
 		}
 
-		void createDynamicVertexBuffer(VertexBufferHandle /*_handle*/, uint32_t /*_size*/, uint8_t /*_flags*/) BX_OVERRIDE
+		void createDynamicVertexBuffer(VertexBufferHandle /*_handle*/, uint32_t /*_size*/, uint16_t /*_flags*/) BX_OVERRIDE
 		{
 		}
 

--- a/3rdparty/bx/include/bx/os.h
+++ b/3rdparty/bx/include/bx/os.h
@@ -17,11 +17,12 @@
 	|| BX_PLATFORM_IOS \
 	|| BX_PLATFORM_LINUX \
 	|| BX_PLATFORM_NACL \
+	|| BX_PLATFORM_NETBSD \
 	|| BX_PLATFORM_OSX \
 	|| BX_PLATFORM_RPI
 
 #	include <sched.h> // sched_yield
-#	if BX_PLATFORM_FREEBSD || BX_PLATFORM_IOS || BX_PLATFORM_NACL || BX_PLATFORM_OSX
+#	if BX_PLATFORM_FREEBSD || BX_PLATFORM_IOS || BX_PLATFORM_NACL || BX_PLATFORM_NETBSD || BX_PLATFORM_OSX
 #		include <pthread.h> // mach_port_t
 #	endif // BX_PLATFORM_IOS || BX_PLATFORM_OSX || BX_PLATFORM_NACL
 
@@ -93,7 +94,7 @@ namespace bx
 		return (pid_t)::syscall(SYS_gettid);
 #elif BX_PLATFORM_IOS || BX_PLATFORM_OSX
 		return (mach_port_t)::pthread_mach_thread_np(pthread_self() );
-#elif BX_PLATFORM_FREEBSD || BX_PLATFORM_NACL
+#elif BX_PLATFORM_FREEBSD || BX_PLATFORM_NACL || BX_PLATFORM_NETBSD
 		// Casting __nc_basic_thread_data*... need better way to do this.
 		return *(uint32_t*)::pthread_self();
 #else

--- a/3rdparty/bx/include/bx/platform.h
+++ b/3rdparty/bx/include/bx/platform.h
@@ -18,6 +18,7 @@
 #define BX_PLATFORM_IOS        0
 #define BX_PLATFORM_LINUX      0
 #define BX_PLATFORM_NACL       0
+#define BX_PLATFORM_NETBSD     0
 #define BX_PLATFORM_OSX        0
 #define BX_PLATFORM_PS4        0
 #define BX_PLATFORM_QNX        0
@@ -187,6 +188,9 @@
 #elif defined(__FreeBSD__)
 #	undef  BX_PLATFORM_FREEBSD
 #	define BX_PLATFORM_FREEBSD 1
+#elif defined(__NetBSD__)
+#	undef  BX_PLATFORM_NETBSD
+#	define BX_PLATFORM_NETBSD 1
 #else
 #	error "BX_PLATFORM_* is not defined!"
 #endif //
@@ -198,6 +202,7 @@
 						|| BX_PLATFORM_IOS \
 						|| BX_PLATFORM_LINUX \
 						|| BX_PLATFORM_NACL \
+						|| BX_PLATFORM_NETBSD \
 						|| BX_PLATFORM_OSX \
 						|| BX_PLATFORM_QNX \
 						|| BX_PLATFORM_RPI \
@@ -250,6 +255,8 @@
 #elif BX_PLATFORM_NACL
 #	define BX_PLATFORM_NAME "NaCl " \
 				BX_STRINGIZE(BX_PLATFORM_NACL)
+#elif BX_PLATFORM_NETBSD
+#	define BX_PLATFORM_NAME "NetBSD"
 #elif BX_PLATFORM_OSX
 #	define BX_PLATFORM_NAME "OSX"
 #elif BX_PLATFORM_PS4

--- a/3rdparty/portmidi/porttime/ptlinux.c
+++ b/3rdparty/portmidi/porttime/ptlinux.c
@@ -38,7 +38,7 @@ CHANGE LOG
 #define FALSE 0
 
 static int time_started_flag = FALSE;
-static struct timeb time_offset = {0, 0, 0, 0};
+static struct timeval time_offset = {0, 0};
 static pthread_t pt_thread_pid;
 static int pt_thread_created = FALSE;
 
@@ -79,7 +79,7 @@ static void *Pt_CallbackProc(void *p)
 PtError Pt_Start(int resolution, PtCallback *callback, void *userData)
 {
     if (time_started_flag) return ptNoError;
-    ftime(&time_offset); /* need this set before process runs */
+    gettimeofday(&time_offset, NULL); /* need this set before process runs */
     if (callback) {
         int res;
         pt_callback_parameters *parms = (pt_callback_parameters *) 
@@ -121,10 +121,10 @@ int Pt_Started()
 PtTimestamp Pt_Time()
 {
     long seconds, milliseconds;
-    struct timeb now;
-    ftime(&now);
-    seconds = now.time - time_offset.time;
-    milliseconds = now.millitm - time_offset.millitm;
+    struct timeval now;
+    gettimeofday(&now, NULL);
+    seconds = now.tv_sec - time_offset.tv_sec;
+    milliseconds = now.tv_usec - time_offset.tv_usec;
     return seconds * 1000 + milliseconds;
 }
 

--- a/makefile
+++ b/makefile
@@ -296,6 +296,10 @@ ifeq ($(TARGETOS),freebsd)
 OSD := sdl
 endif
 
+ifeq ($(TARGETOS),netbsd)
+OSD := sdl
+endif
+
 ifeq ($(TARGETOS),solaris)
 OSD := sdl
 endif
@@ -1002,6 +1006,26 @@ freebsd: freebsd_x86
 .PHONY: freebsd_x86
 freebsd_x86: generate $(PROJECTDIR)/gmake-freebsd/Makefile
 	$(SILENT) $(MAKE) -C $(PROJECTDIR)/gmake-freebsd config=$(CONFIG)32
+
+
+#-------------------------------------------------
+# gmake-netbsd
+#-------------------------------------------------
+
+
+$(PROJECTDIR)/gmake-netbsd/Makefile: makefile $(SCRIPTS) $(GENIE)
+	$(SILENT) $(GENIE) $(PARAMS) --gcc=netbsd --gcc_version=$(GCC_VERSION) gmake
+
+.PHONY: netbsd_x64
+netbsd_x64: generate $(PROJECTDIR)/gmake-netbsd/Makefile
+	$(SILENT) $(MAKE) -C $(PROJECTDIR)/gmake-netbsd config=$(CONFIG)64
+
+.PHONY: netbsd
+netbsd: netbsd_x86
+
+.PHONY: netbsd_x86
+netbsd_x86: generate $(PROJECTDIR)/gmake-netbsd/Makefile
+	$(SILENT) $(MAKE) -C $(PROJECTDIR)/gmake-netbsd config=$(CONFIG)32
 
 
 #-------------------------------------------------

--- a/scripts/src/3rdparty.lua
+++ b/scripts/src/3rdparty.lua
@@ -534,6 +534,13 @@ project "portmidi"
 			MAME_DIR .. "3rdparty/portmidi/porttime/ptlinux.c",
 		}
 	end
+	if _OPTIONS["targetos"]=="netbsd" then
+		files {
+			MAME_DIR .. "3rdparty/portmidi/pm_linux/pmlinux.c",
+			MAME_DIR .. "3rdparty/portmidi/pm_linux/finddefault.c",
+			MAME_DIR .. "3rdparty/portmidi/porttime/ptlinux.c",
+		}
+	end
 	if _OPTIONS["targetos"]=="macosx" then
 		files {
 			MAME_DIR .. "3rdparty/portmidi/pm_mac/pmmac.c",
@@ -587,6 +594,11 @@ project "bgfx"
 		}
 		
 	configuration { "freebsd" }
+		includedirs {
+			MAME_DIR .. "3rdparty/bx/include/compat/freebsd",
+		}
+
+	configuration { "netbsd" }
 		includedirs {
 			MAME_DIR .. "3rdparty/bx/include/compat/freebsd",
 		}

--- a/scripts/toolchain.lua
+++ b/scripts/toolchain.lua
@@ -24,6 +24,7 @@ newoption {
 		{ "mingw-clang",   "MinGW (clang compiler)" },
 		{ "nacl",          "Native Client"          },
 		{ "nacl-arm",      "Native Client - ARM"    },
+		{ "netbsd",        "NetBSD"                },
 		{ "osx",           "OSX (GCC compiler)"     },
 		{ "osx-clang",     "OSX (Clang compiler)"   },
 		{ "pnacl",         "Native Client - PNaCl"  },
@@ -145,6 +146,10 @@ function toolchain(_buildDir, _subDir)
 
 		if "freebsd" == _OPTIONS["gcc"] then
 			location (_buildDir .. "projects/" .. _subDir .. "/".. _ACTION .. "-freebsd")
+		end
+
+		if "netbsd" == _OPTIONS["gcc"] then
+			location (_buildDir .. "projects/" .. _subDir .. "/".. _ACTION .. "-netbsd")
 		end
 
 		if "ios-arm" == _OPTIONS["gcc"] then
@@ -590,7 +595,29 @@ function toolchain(_buildDir, _subDir)
 	
 	configuration { "freebsd", "x64", "Debug" }
 		targetdir (_buildDir .. "freebsd" .. "/bin/x64/Debug")
-		
+
+	configuration { "netbsd", "x32" }
+		objdir (_buildDir .. "netbsd" .. "/obj")
+		buildoptions {
+			"-m32",
+		}
+	configuration { "netbsd", "x32", "Release" }
+		targetdir (_buildDir .. "netbsd" .. "/bin/x32/Release")
+
+	configuration { "netbsd", "x32", "Debug" }
+		targetdir (_buildDir .. "netbsd" .. "/bin/x32/Debug")
+
+	configuration { "netbsd", "x64" }
+		objdir (_buildDir .. "netbsd" .. "/obj")
+		buildoptions {
+			"-m64",
+		}
+	configuration { "netbsd", "x64", "Release" }
+		targetdir (_buildDir .. "netbsd" .. "/bin/x64/Release")
+
+	configuration { "netbsd", "x64", "Debug" }
+		targetdir (_buildDir .. "netbsd" .. "/bin/x64/Debug")
+
 	configuration { "android-*" }
 		includedirs {
 			"$(ANDROID_NDK_ROOT)/sources/cxx-stl/gnu-libstdc++/4.8/include",

--- a/src/osd/osdmini/minifile.c
+++ b/src/osd/osdmini/minifile.c
@@ -113,7 +113,7 @@ file_error osd_truncate(osd_file *file, UINT64 offset)
 		return FILERR_FAILURE;
 
 	result = ftruncate(fileno((FILE *)file), offset);
-	if (!result)
+	if (result)
 		return FILERR_FAILURE;
 
 	return FILERR_NONE;

--- a/src/osd/osdmini/minifile.c
+++ b/src/osd/osdmini/minifile.c
@@ -102,6 +102,25 @@ file_error osd_write(osd_file *file, const void *buffer, UINT64 offset, UINT32 l
 
 
 //============================================================
+//  osd_truncate
+//============================================================
+
+file_error osd_truncate(osd_file *file, UINT64 offset)
+{
+	UINT32 result;
+
+	if (!file)
+		return FILERR_FAILURE;
+
+	result = ftruncate(fileno((FILE *)file), offset);
+	if (!result)
+		return FILERR_FAILURE;
+
+	return FILERR_NONE;
+}
+
+
+//============================================================
 //  osd_rmfile
 //============================================================
 


### PR DESCRIPTION
Due to the change in the build system and additional bx/bgfx libraries, mame didn't build on NetBSD any longer.
The patches in this pull request fix this. Please take as much as possible, though I would understand that you want to avoid changing 3rdparty code.
In that case, let me know how to prepare the changes so you can take what you want as easily as possible.
Thanks.