### PR TITLE
Corrected viewable as per 05991

### DIFF
--- a/src/mame/drivers/snk.c
+++ b/src/mame/drivers/snk.c
@@ -3979,12 +3979,6 @@ static MACHINE_CONFIG_DERIVED( chopper1, bermudat )
 	MCFG_CPU_MODIFY("audiocpu")
 	MCFG_CPU_PROGRAM_MAP(YM3812_Y8950_sound_map)
 
-	/* video hardware */
-	MCFG_SCREEN_MODIFY("screen")
-	// this visible area matches the flyer
-	MCFG_SCREEN_SIZE(51*8, 28*8)
-	MCFG_SCREEN_VISIBLE_AREA(1*8, 50*8-1, 0*8, 28*8-1)
-
 	/* sound hardware */
 	MCFG_SOUND_REPLACE("ym1", YM3812, 4000000)
 	MCFG_YM3812_IRQ_HANDLER(WRITELINE(snk_state, ymirq_callback_1))


### PR DESCRIPTION
Previously using flyer evidence - often WIP/incorrect images used on those.