### PR TITLE
Fix for MAMETESTER bug #6005

### DIFF
--- a/src/mame/drivers/taito_x.c
+++ b/src/mame/drivers/taito_x.c
@@ -965,7 +965,7 @@ static MACHINE_CONFIG_START( ballbros, taitox_state )
 	MCFG_PALETTE_ADD("palette", 2048)
 	MCFG_PALETTE_FORMAT(xRRRRRGGGGGBBBBB)
 
-	MCFG_VIDEO_START_OVERRIDE(taitox_state,seta_no_layers)
+	MCFG_VIDEO_START_OVERRIDE(taitox_state, kyustrkr_no_layers)
 
 	/* sound hardware */
 	MCFG_SPEAKER_STANDARD_STEREO("lspeaker", "rspeaker")

--- a/src/mame/includes/seta.h
+++ b/src/mame/includes/seta.h
@@ -193,6 +193,7 @@ public:
 	TILE_GET_INFO_MEMBER(get_tile_info_2);
 	TILE_GET_INFO_MEMBER(get_tile_info_3);
 	DECLARE_VIDEO_START(seta_no_layers);
+	DECLARE_VIDEO_START(kyustrkr_no_layers);
 	DECLARE_VIDEO_START(twineagl_1_layer);
 	DECLARE_VIDEO_START(setaroul_1_layer);
 	DECLARE_VIDEO_START(seta_1_layer);

--- a/src/mame/video/seta.c
+++ b/src/mame/video/seta.c
@@ -556,6 +556,15 @@ VIDEO_START_MEMBER(seta_state,seta_no_layers)
 	m_seta001->set_bg_yoffsets( 0x1, -0x1 );
 }
 
+VIDEO_START_MEMBER(seta_state,kyustrkr_no_layers)
+{
+	VIDEO_START_CALL_MEMBER(seta_no_layers);
+
+	// position kludges
+	m_seta001->set_fg_yoffsets( -0x0a, 0x0e );
+	m_seta001->set_bg_yoffsets( 0x1, -0x1 );
+}
+
 
 
 /***************************************************************************


### PR DESCRIPTION
A quick fix for the only (it seems) game which requires different foreground y offsets. 