### PR TITLE
Trs80 coco audio fixes

### DIFF
--- a/src/mess/includes/coco.h
+++ b/src/mess/includes/coco.h
@@ -208,7 +208,6 @@ private:
 	bool is_joystick_hires(int joystick_index);
 
 	soundmux_status_t soundmux_status(void);
-	UINT8 sound_value(void);
 	void update_sound(void);
 	bool joyin(void);
 	void poll_joystick(bool *joyin, UINT8 *buttons);

--- a/src/mess/includes/coco.h
+++ b/src/mess/includes/coco.h
@@ -153,8 +153,8 @@ protected:
 	void recalculate_firq(void);
 
 	// changed handlers
-	virtual void pia1_pa_changed(void);
-	virtual void pia1_pb_changed(void);
+	virtual void pia1_pa_changed(UINT8 data);
+	virtual void pia1_pb_changed(UINT8 data);
 
 	// miscellaneous
 	virtual void update_keyboard_input(UINT8 value, UINT8 z);

--- a/src/mess/includes/coco.h
+++ b/src/mess/includes/coco.h
@@ -243,6 +243,10 @@ private:
 	// DAC output
 	UINT8 m_dac_output;
 
+	// remember the last audio sample level from the analog sources (DAC, cart, cassette) so that we don't
+	// introduce step changes when the audio output is enabled/disabled via PIA1 CB2
+	UINT8 m_analog_audio_level;
+
 	// hires interface
 	emu_timer *m_hiresjoy_transition_timer[2];
 	bool m_hiresjoy_ca;

--- a/src/mess/includes/coco12.h
+++ b/src/mess/includes/coco12.h
@@ -56,7 +56,7 @@ protected:
 	virtual void update_cart_base(UINT8 *cart_base);
 
 	/* PIA1 */
-	virtual void pia1_pb_changed(void);
+	virtual void pia1_pb_changed(UINT8 data);
 
 private:
 

--- a/src/mess/includes/dragon.h
+++ b/src/mess/includes/dragon.h
@@ -45,7 +45,7 @@ public:
 	required_device<printer_image_device> m_printer;
 
 protected:
-	virtual void pia1_pa_changed(void);
+	virtual void pia1_pa_changed(UINT8 data);
 };
 
 
@@ -65,7 +65,7 @@ protected:
 	virtual DECLARE_READ8_MEMBER( ff00_read );
 	virtual DECLARE_WRITE8_MEMBER( ff00_write );
 
-	virtual void pia1_pb_changed(void);
+	virtual void pia1_pb_changed(UINT8 data);
 	void page_rom(bool romswitch);
 };
 

--- a/src/mess/machine/coco.c
+++ b/src/mess/machine/coco.c
@@ -457,6 +457,8 @@ WRITE8_MEMBER( coco_state::ff20_write )
 
 READ8_MEMBER( coco_state::pia1_pa_r )
 {
+	// Port A: we need to specify the values of all the lines, regardless of whether
+	// they are in input or output mode in the DDR
 	return (m_cassette->input() >= 0 ? 0x01 : 0x00)
 		| (dac_output() << 2);
 }
@@ -471,6 +473,8 @@ READ8_MEMBER( coco_state::pia1_pa_r )
 
 READ8_MEMBER( coco_state::pia1_pb_r )
 {
+	// Port B: lines in output mode are handled automatically by the PIA object.
+	// We only need to specify the input lines here
 	UINT32 ram_size = m_ram->size();
 
 	//  For the CoCo 1, the logic has been changed to only select 64K rams
@@ -480,7 +484,7 @@ READ8_MEMBER( coco_state::pia1_pb_r )
 	//  to access 32K of ram, and also allows the cocoe driver to access
 	//  the full 64K, as this uses Color Basic 1.2, which can configure 64K rams
 	bool memory_sense = (ram_size >= 0x4000 && ram_size <= 0x7FFF)
-		|| (ram_size >= 0x8000 && (m_pia_0->b_output() & 0x80));
+		|| (ram_size >= 0x8000 && (m_pia_0->b_output() & 0x40));
 
 	// serial in (PB0)
 	bool serial_in = (m_rs232 != NULL) && (m_rs232->rxd_r() ? true : false);

--- a/src/mess/machine/coco.c
+++ b/src/mess/machine/coco.c
@@ -502,7 +502,7 @@ READ8_MEMBER( coco_state::pia1_pb_r )
 
 WRITE8_MEMBER( coco_state::pia1_pa_w )
 {
-	pia1_pa_changed();
+	pia1_pa_changed(data);
 }
 
 
@@ -513,7 +513,7 @@ WRITE8_MEMBER( coco_state::pia1_pa_w )
 
 WRITE8_MEMBER( coco_state::pia1_pb_w )
 {
-	pia1_pb_changed();
+	pia1_pb_changed(data);
 }
 
 
@@ -998,12 +998,12 @@ void coco_state::update_prinout(bool prinout)
 //  pia1_pa_changed - called when PIA1 PA changes
 //-------------------------------------------------
 
-void coco_state::pia1_pa_changed(void)
+void coco_state::pia1_pa_changed(UINT8 data)
 {
 	update_sound();     // DAC is connected to PIA1 PA2-PA7
 	poll_keyboard();
 	update_cassout(dac_output());
-	update_prinout(m_pia_1->a_output() & 0x02 ? true : false);
+	update_prinout(data & 0x02 ? true : false);
 }
 
 
@@ -1012,7 +1012,7 @@ void coco_state::pia1_pa_changed(void)
 //  pia1_pb_changed - called when PIA1 PB changes
 //-------------------------------------------------
 
-void coco_state::pia1_pb_changed(void)
+void coco_state::pia1_pb_changed(UINT8 data)
 {
 	update_sound();     // singe_bit_sound is connected to PIA1 PB1
 }

--- a/src/mess/machine/coco.c
+++ b/src/mess/machine/coco.c
@@ -538,7 +538,6 @@ WRITE_LINE_MEMBER( coco_state::pia1_ca2_w )
 WRITE_LINE_MEMBER( coco_state::pia1_cb2_w )
 {
 	update_sound();     // SOUND_ENABLE is connected to PIA1 CB2
-	poll_keyboard();
 }
 
 

--- a/src/mess/machine/coco12.c
+++ b/src/mess/machine/coco12.c
@@ -94,12 +94,11 @@ READ8_MEMBER( coco12_state::sam_read )
 //  pia1_pb_changed
 //-------------------------------------------------
 
-void coco12_state::pia1_pb_changed(void)
+void coco12_state::pia1_pb_changed(UINT8 data)
 {
 	/* call inherited function */
-	coco_state::pia1_pb_changed();
+	coco_state::pia1_pb_changed(data);
 
-	UINT8 data = m_pia_1->b_output();
 	m_vdg->css_w(data & 0x08);
 	m_vdg->intext_w(data & 0x10);
 	m_vdg->gm0_w(data & 0x10);

--- a/src/mess/machine/dragon.c
+++ b/src/mess/machine/dragon.c
@@ -48,13 +48,13 @@ easier to manage.
 //  pia1_pa_changed - called when PIA1 PA changes
 //-------------------------------------------------
 
-void dragon_state::pia1_pa_changed(void)
+void dragon_state::pia1_pa_changed(UINT8 data)
 {
 	/* call inherited function */
-	coco12_state::pia1_pa_changed();
+	coco12_state::pia1_pa_changed(data);
 
 	/* if strobe bit is high send data from pia0 port b to dragon parallel printer */
-	if (m_pia_1->a_output() & 0x02)
+	if (data & 0x02)
 	{
 		UINT8 output = m_pia_1->b_output();
 		m_printer->output(output);
@@ -113,9 +113,9 @@ WRITE8_MEMBER( dragon64_state::ff00_write )
 //  pia1_pb_changed
 //-------------------------------------------------
 
-void dragon64_state::pia1_pb_changed(void)
+void dragon64_state::pia1_pb_changed(UINT8 data)
 {
-	dragon_state::pia1_pb_changed();
+	dragon_state::pia1_pb_changed(data);
 
 	UINT8 ddr = ~m_pia_1->port_b_z_mask();
 
@@ -125,7 +125,7 @@ void dragon64_state::pia1_pb_changed(void)
 	/* always be high (enabling 32k basic rom) */
 	if (ddr & 0x04)
 	{
-		page_rom(m_pia_1->b_output() & 0x04 ? true : false);
+		page_rom(data & 0x04 ? true : false);
 		logerror("pia1_pb_changed\n");
 	}
 }


### PR DESCRIPTION
Emulation accuracy improvements and fixes for TRS-80 Color Computer audio/PIA hardware.

This fixes audio artifacts in Sock Master's Donkey Kong and Tandy's Androne games.

I spent quite a bit of time diagnosing and trying to resolve the issue with the 'buzzing' sound in the Tandy/Datasoft Popcorn game, as mentioned in an earlier code comment, until I played it on a real Coco and realized that this sound is supposed to be in the game.  I think it is supposed to be the sound of the conveyer belt moving.

I tested quite a few Coco 2 and Coco 3 cartridge game to test for regressions and didn't find any.
