### PR TITLE
Fix GAME_NO_SOUND in emudummy

### DIFF
--- a/src/emu/drivers/emudummy.c
+++ b/src/emu/drivers/emudummy.c
@@ -33,4 +33,4 @@ ROM_START( __dummy )
 ROM_END
 
 
-GAME( 1900, __dummy, 0, __dummy, 0, driver_device, 0, ROT0, "(none)", "Dummy", GAME_NO_SOUND )
+GAME( 1900, __dummy, 0, __dummy, 0, driver_device, 0, ROT0, "(none)", "Dummy", MACHINE_NO_SOUND )


### PR DESCRIPTION
While all other uses of `GAME_*` have been changed to `MACHINE_*`, there is one left behind. Not sure if it's really used, but seems to prevent building `TOOLS`.