### PR TITLE
bbc: clones, floppy formats, softlists, and cleanups.

### DIFF
--- a/hash/bbcb_cass.xml
+++ b/hash/bbcb_cass.xml
@@ -3324,13 +3324,13 @@
 		<publisher>Visions</publisher>
 		<info name="usage" value="Load with *RUN" />
 		<part name="cass1" interface="bbc_cass">
-			<dataarea name="cass" size="9339">
-				<rom name="demolator_infinitelives_run(visions).uef" size="9339" crc="8c638151" sha1="85aced0345aec14e7750c5daa290f1cb642b1961" offset="0" />
+			<dataarea name="cass" size="9319">
+				<rom name="demolator_run(visions).uef" size="9319" crc="5dc43e5b" sha1="d7d88ca1b651926104c0833e257e967e0d47dfc2" offset="0" />
 			</dataarea>
 		</part>
 		<part name="cass2" interface="bbc_cass">
-			<dataarea name="cass" size="9319">
-				<rom name="demolator_run(visions).uef" size="9319" crc="5dc43e5b" sha1="d7d88ca1b651926104c0833e257e967e0d47dfc2" offset="0" />
+			<dataarea name="cass" size="9339">
+				<rom name="demolator_infinitelives_run(visions).uef" size="9339" crc="8c638151" sha1="85aced0345aec14e7750c5daa290f1cb642b1961" offset="0" />
 			</dataarea>
 		</part>
 	</software>
@@ -5710,17 +5710,6 @@
 		</part>
 	</software>
 
-	<software name="hopperg" cloneof="hopper">
-		<description>Hopper (Ger)</description>
-		<year>1983</year>
-		<publisher>Acornsoft</publisher>
-		<part name="cass" interface="bbc_cass">
-			<dataarea name="cass" size="8112">
-				<rom name="hopper-german(1983)(acornsoft)(g23).uef" size="8112" crc="3972b897" sha1="b5f7897dcad92b758d0473ac840f2b41e8049ef4" offset="0" />
-			</dataarea>
-		</part>
-	</software>
-
 	<software name="hopper21" cloneof="hopper">
 		<description>Hopper v2.1</description>
 		<year>1983</year>
@@ -7430,17 +7419,6 @@
 		</part>
 	</software>
 
-	<software name="meteorsg" cloneof="meteors">
-		<description>Meteors (Ger)</description>
-		<year>1982</year>
-		<publisher>Acornsoft</publisher>
-		<part name="cass" interface="bbc_cass">
-			<dataarea name="cass" size="6610">
-				<rom name="meteors-german(1982)(acornsoft)(g13).uef" size="6610" crc="0bb65e55" sha1="238ba733b0094942dd477ca49754249284741c40" offset="0" />
-			</dataarea>
-		</part>
-	</software>
-
 	<software name="meteorssc" cloneof="meteors">
 		<description>Meteors (The Acornsoft Hits Vol.2)</description>
 		<year>1987</year>
@@ -7741,17 +7719,6 @@
 		<part name="cass" interface="bbc_cass">
 			<dataarea name="cass" size="14572">
 				<rom name="monopoly(1985)(leisuregenius).uef" size="14572" crc="b96f7f88" sha1="acb1760b51310f02eccab9620924e53f637b91ac" offset="0" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="monstersg" cloneof="monsters">
-		<description>Monsters (Ger)</description>
-		<year>1982</year>
-		<publisher>Acornsoft</publisher>
-		<part name="cass" interface="bbc_cass">
-			<dataarea name="cass" size="7890">
-				<rom name="monsters-german(1982)(acornsoft)(g03).uef" size="7890" crc="37838358" sha1="c3c698a8174d0b67d6ee563bcecb9a42354ae3fc" offset="0" />
 			</dataarea>
 		</part>
 	</software>
@@ -8889,17 +8856,6 @@
 		</part>
 	</software>
 
-	<software name="planetoidg" cloneof="plantoid">
-		<description>Planetoid (Ger)</description>
-		<year>1982</year>
-		<publisher>Acornsoft</publisher>
-		<part name="cass" interface="bbc_cass">
-			<dataarea name="cass" size="8515">
-				<rom name="planetoid-german(1982)(acornsoft)(g15).uef" size="8515" crc="bfaa94f8" sha1="fc8cb246c19cd717f7684074979ea5cb6d98e4fb" offset="0" />
-			</dataarea>
-		</part>
-	</software>
-
 	<software name="plantoidsc" cloneof="plantoid">
 		<description>Planetoid (The Acornsoft Hits Vol.1)</description>
 		<year>1987</year>
@@ -9828,17 +9784,6 @@
 		</part>
 	</software>
 
-	<software name="rocketrag" cloneof="rocketra">
-		<description>Rocket Raid (Ger)</description>
-		<year>1982</year>
-		<publisher>Acornsoft</publisher>
-		<part name="cass" interface="bbc_cass">
-			<dataarea name="cass" size="7747">
-				<rom name="rocketraid-german(1982)(acornsoft)(g05).uef" size="7747" crc="3a6ccbd0" sha1="afd7318589bb419606b25b575c7488369acf2c9b" offset="0" />
-			</dataarea>
-		</part>
-	</software>
-
 	<software name="rocketrasc" cloneof="rocketra">
 		<description>Rocket Raid (The Acornsoft Hits Vol.1)</description>
 		<year>1987</year>
@@ -10717,17 +10662,6 @@
 		<part name="cass" interface="bbc_cass">
 			<dataarea name="cass" size="2367">
 				<rom name="snakepit(postern).uef" size="2367" crc="e9aebd0e" sha1="f383fe71bafe0b093547abcba3987667a69fbf4d" offset="0" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="snapperg" cloneof="snapper">
-		<description>Snapper (Ger)</description>
-		<year>1982</year>
-		<publisher>Acornsoft</publisher>
-		<part name="cass" interface="bbc_cass">
-			<dataarea name="cass" size="7174">
-				<rom name="snapper-german(1982)(acornsoft)(g04).uef" size="7174" crc="6ffbe578" sha1="0cc295dba1b771475ae8e71340b6ce4f885040e9" offset="0" />
 			</dataarea>
 		</part>
 	</software>
@@ -11898,17 +11832,6 @@
 		<part name="cass" interface="bbc_cass">
 			<dataarea name="cass" size="8105">
 				<rom name="superhangman(ijk).uef" size="8105" crc="0dec33af" sha1="aa514fcb9548e198d9672f9af7b67a5385086813" offset="0" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="superinvg" cloneof="superinv">
-		<description>Super Invaders (Ger)</description>
-		<year>1982</year>
-		<publisher>Acornsoft</publisher>
-		<part name="cass" interface="bbc_cass">
-			<dataarea name="cass" size="7812">
-				<rom name="superinvaders-german(1982)(acornsoft)(g16).uef" size="7812" crc="382b3412" sha1="4361fba1203b07fb05f62273ac02db403a3f38ce" offset="0" />
 			</dataarea>
 		</part>
 	</software>
@@ -13494,17 +13417,6 @@
 		</part>
 	</software>
 
-	<software name="welcomeg" cloneof="welcome">
-		<description>Welcome (Ger)</description>
-		<year>1981</year>
-		<publisher>BBC Soft</publisher>
-		<part name="cass" interface="bbc_cass">
-			<dataarea name="cass" size="48009">
-				<rom name="welcome-german(1981)(bbc).uef" size="48009" crc="a2d78451" sha1="b0ff9fd8a51412dee878e763fe0aa54deef2c962" offset="0" />
-			</dataarea>
-		</part>
-	</software>
-
 	<software name="welcome">
 		<description>Welcome</description>
 		<year>1981</year>
@@ -14095,17 +14007,6 @@
 		<part name="cass" interface="bbc_cass">
 			<dataarea name="cass" size="6233">
 				<rom name="datafile(1985)(kansas).uef" size="6233" crc="c9fcb24d" sha1="459786fceab265834edf9b72ffe23efa82e06adf" offset="0" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="dskdiaryg" cloneof="dskdiary">
-		<description>Desk Diary (Ger)</description>
-		<year>198?</year>
-		<publisher>Acornsoft</publisher>
-		<part name="cass" interface="bbc_cass">
-			<dataarea name="cass" size="9739">
-				<rom name="deskdiary-german(198x)(acornsoft)(b01).uef" size="9739" crc="7ef32892" sha1="ec3910be9c7b5c1729586ba88a88173d08dcf34b" offset="0" />
 			</dataarea>
 		</part>
 	</software>
@@ -14753,17 +14654,6 @@
 		</part>
 	</software>
 
-	<software name="numberbag" cloneof="numberba">
-		<description>Number Balance (Ger)</description>
-		<year>198?</year>
-		<publisher>Acornsoft/ESM</publisher>
-		<part name="cass" interface="bbc_cass">
-			<dataarea name="cass" size="7727">
-				<rom name="numberbalance-german(acornsoftesm).uef" size="7727" crc="2461e7a8" sha1="7b2ce801a3213fcac582b173d65aaa347555a2c4" offset="0" />
-			</dataarea>
-		</part>
-	</software>
-
 	<software name="numberba">
 		<description>Number Balance</description>
 		<year>198?</year>
@@ -14848,17 +14738,6 @@
 		<part name="cass" interface="bbc_cass">
 			<dataarea name="cass" size="15699">
 				<rom name="science1(1985)(shards).uef" size="15699" crc="23a70afc" sha1="c9c15955612e50169ac5a8030b50489c0be8c57c" offset="0" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="sentseqg" cloneof="sentseq">
-		<description>Sentence Sequencing (Ger)</description>
-		<year>198?</year>
-		<publisher>Acornsoft</publisher>
-		<part name="cass" interface="bbc_cass">
-			<dataarea name="cass" size="10769">
-				<rom name="sentencesequencing-german(198x)(acornsoft)(e07).uef" size="10769" crc="28955bf7" sha1="f6422764589cbe5d1acefca2d90f288b95e84280" offset="0" />
 			</dataarea>
 		</part>
 	</software>
@@ -14967,17 +14846,6 @@
 		</part>
 	</software>
 
-	<software name="treeknowg" cloneof="treeknow">
-		<description>Tree Of Knowledge (Ger)</description>
-		<year>198?</year>
-		<publisher>Acornsoft</publisher>
-		<part name="cass" interface="bbc_cass">
-			<dataarea name="cass" size="11319">
-				<rom name="treeofknowledge-german(198x)(acornsoft)(e04).uef" size="11319" crc="c1b66b33" sha1="53bd97ccc48c5b00a1e57728800e786b6a9d30d9" offset="0" />
-			</dataarea>
-		</part>
-	</software>
-
 	<software name="treeknow">
 		<description>Tree Of Knowledge</description>
 		<year>198?</year>
@@ -15073,17 +14941,6 @@
 		<part name="cass" interface="bbc_cass">
 			<dataarea name="cass" size="8377">
 				<rom name="worldwise(bourne).uef" size="8377" crc="c1e2ec64" sha1="e98121d7cb8d3ef7406a151ce4523db41a431699" offset="0" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="jars">
-		<description>Jars (Ger)</description>
-		<year>198?</year>
-		<publisher>Acornsoft</publisher>
-		<part name="cass" interface="bbc_cass">
-			<dataarea name="cass" size="8325">
-				<rom name="jars-german(198x)(acornsoft)(e15).uef" size="8325" crc="943ba245" sha1="5a911796040eb708926d5c9e1aecb3d0e7ea546b" offset="0" />
 			</dataarea>
 		</part>
 	</software>

--- a/hash/bbcb_de_cass.xml
+++ b/hash/bbcb_de_cass.xml
@@ -1,0 +1,166 @@
+<?xml version="1.0"?>
+<!DOCTYPE softwarelist SYSTEM "softwarelist.dtd">
+
+<!-- BBC Micro Model B (German) Tapes -->
+
+<!-- I believe all the Cassette images here are original, so some require the manuals for additional copy protection -->
+
+<!-- Loading Instructions:
+
+      If the system has a disk drive (which the BBC Model B does by default in MESS) you must type *TAPE, then use the relevant command to load the software, usually CHAIN"" or *RUN, though some earlier titles from Micro Power require *LOAD.
+
+      To start/stop the tape you must use the MESS menus, so you'll have to turn full keyboard mode off with Scroll Lock, then navigate the menus, turning Scroll Lock back on when you're finished.
+-->
+
+<softwarelist name="bbcb_de_cass" description="BBC Micro Model B (German) cassettes">
+
+	<!-- Games -->
+
+	<software name="hopperg">
+		<description>Hopper (Ger)</description>
+		<year>1983</year>
+		<publisher>Acornsoft</publisher>
+		<part name="cass" interface="bbc_cass">
+			<dataarea name="cass" size="8112">
+				<rom name="hopper-german(1983)(acornsoft)(g23).uef" size="8112" crc="3972b897" sha1="b5f7897dcad92b758d0473ac840f2b41e8049ef4" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+	<software name="meteorsg">
+		<description>Meteors (Ger)</description>
+		<year>1982</year>
+		<publisher>Acornsoft</publisher>
+		<part name="cass" interface="bbc_cass">
+			<dataarea name="cass" size="6610">
+				<rom name="meteors-german(1982)(acornsoft)(g13).uef" size="6610" crc="0bb65e55" sha1="238ba733b0094942dd477ca49754249284741c40" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+	<software name="monstersg">
+		<description>Monsters (Ger)</description>
+		<year>1982</year>
+		<publisher>Acornsoft</publisher>
+		<part name="cass" interface="bbc_cass">
+			<dataarea name="cass" size="7890">
+				<rom name="monsters-german(1982)(acornsoft)(g03).uef" size="7890" crc="37838358" sha1="c3c698a8174d0b67d6ee563bcecb9a42354ae3fc" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+	<software name="planetoidg">
+		<description>Planetoid (Ger)</description>
+		<year>1982</year>
+		<publisher>Acornsoft</publisher>
+		<part name="cass" interface="bbc_cass">
+			<dataarea name="cass" size="8515">
+				<rom name="planetoid-german(1982)(acornsoft)(g15).uef" size="8515" crc="bfaa94f8" sha1="fc8cb246c19cd717f7684074979ea5cb6d98e4fb" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+	<software name="rocketrag">
+		<description>Rocket Raid (Ger)</description>
+		<year>1982</year>
+		<publisher>Acornsoft</publisher>
+		<part name="cass" interface="bbc_cass">
+			<dataarea name="cass" size="7747">
+				<rom name="rocketraid-german(1982)(acornsoft)(g05).uef" size="7747" crc="3a6ccbd0" sha1="afd7318589bb419606b25b575c7488369acf2c9b" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+	<software name="snapperg">
+		<description>Snapper (Ger)</description>
+		<year>1982</year>
+		<publisher>Acornsoft</publisher>
+		<part name="cass" interface="bbc_cass">
+			<dataarea name="cass" size="7174">
+				<rom name="snapper-german(1982)(acornsoft)(g04).uef" size="7174" crc="6ffbe578" sha1="0cc295dba1b771475ae8e71340b6ce4f885040e9" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+	<software name="superinvg">
+		<description>Super Invaders (Ger)</description>
+		<year>1982</year>
+		<publisher>Acornsoft</publisher>
+		<part name="cass" interface="bbc_cass">
+			<dataarea name="cass" size="7812">
+				<rom name="superinvaders-german(1982)(acornsoft)(g16).uef" size="7812" crc="382b3412" sha1="4361fba1203b07fb05f62273ac02db403a3f38ce" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+	<software name="welcomeg">
+		<description>Welcome (Ger)</description>
+		<year>1981</year>
+		<publisher>BBC Soft</publisher>
+		<part name="cass" interface="bbc_cass">
+			<dataarea name="cass" size="48009">
+				<rom name="welcome-german(1981)(bbc).uef" size="48009" crc="a2d78451" sha1="b0ff9fd8a51412dee878e763fe0aa54deef2c962" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+	<!-- Business -->
+
+	<software name="dskdiaryg">
+		<description>Desk Diary (Ger)</description>
+		<year>198?</year>
+		<publisher>Acornsoft</publisher>
+		<part name="cass" interface="bbc_cass">
+			<dataarea name="cass" size="9739">
+				<rom name="deskdiary-german(198x)(acornsoft)(b01).uef" size="9739" crc="7ef32892" sha1="ec3910be9c7b5c1729586ba88a88173d08dcf34b" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+	<!-- Educational -->
+
+	<software name="numberbag">
+		<description>Number Balance (Ger)</description>
+		<year>198?</year>
+		<publisher>Acornsoft/ESM</publisher>
+		<part name="cass" interface="bbc_cass">
+			<dataarea name="cass" size="7727">
+				<rom name="numberbalance-german(acornsoftesm).uef" size="7727" crc="2461e7a8" sha1="7b2ce801a3213fcac582b173d65aaa347555a2c4" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+	<software name="sentseqg">
+		<description>Sentence Sequencing (Ger)</description>
+		<year>198?</year>
+		<publisher>Acornsoft</publisher>
+		<part name="cass" interface="bbc_cass">
+			<dataarea name="cass" size="10769">
+				<rom name="sentencesequencing-german(198x)(acornsoft)(e07).uef" size="10769" crc="28955bf7" sha1="f6422764589cbe5d1acefca2d90f288b95e84280" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+	<software name="treeknowg">
+		<description>Tree Of Knowledge (Ger)</description>
+		<year>198?</year>
+		<publisher>Acornsoft</publisher>
+		<part name="cass" interface="bbc_cass">
+			<dataarea name="cass" size="11319">
+				<rom name="treeofknowledge-german(198x)(acornsoft)(e04).uef" size="11319" crc="c1b66b33" sha1="53bd97ccc48c5b00a1e57728800e786b6a9d30d9" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+	<software name="jars">
+		<description>Jars (Ger)</description>
+		<year>198?</year>
+		<publisher>Acornsoft</publisher>
+		<part name="cass" interface="bbc_cass">
+			<dataarea name="cass" size="8325">
+				<rom name="jars-german(198x)(acornsoft)(e15).uef" size="8325" crc="943ba245" sha1="5a911796040eb708926d5c9e1aecb3d0e7ea546b" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+</softwarelist>

--- a/hash/bbcb_us_flop.xml
+++ b/hash/bbcb_us_flop.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE softwarelist SYSTEM "softwarelist.dtd">
+
+<!-- BBC Micro Model B (US) Disks -->
+
+<!-- Loading Instructions:
+
+      Hold down the SHIFT key and press and release the BREAK key.
+-->
+
+<softwarelist name="bbcb_us_flop" description="BBC Micro Model B (US) disks">
+
+	<software name="intrutil">
+		<description>Introductory and Utilities Disk</description>
+		<year>1983</year>
+		<publisher>Acorn</publisher>
+		<info name="protection" value="none" />
+		<part name="flop1" interface="floppy_5_25">
+			<dataarea name="flop" size="204800">
+				<rom name="introductory_utils(1983)(acorn).ssd" size="204800" crc="60612fc2" sha1="037f7c3499547d5ac5f88e812d7765ccaf27d6e1" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+</softwarelist>

--- a/hash/bbcmc_flop.xml
+++ b/hash/bbcmc_flop.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE softwarelist SYSTEM "softwarelist.dtd">
+
+<!-- BBC Master Compact Disks -->
+
+<!-- Loading Instructions:
+
+      Hold down the SHIFT key and press and release the BREAK key.
+-->
+
+<softwarelist name="bbcmc_flop" description="BBC Master Compact disks">
+
+	<software name="welcome">
+		<description>BBC Master Compact Welcome Disc</description>
+		<year>1986</year>
+		<publisher>Acorn</publisher>
+		<info name="protection" value="none" />
+		<part name="flop1" interface="floppy_3_5">
+			<dataarea name="flop" size="655360">
+				<rom name="welcome_compact.adl" size="655360" crc="9d747205" sha1="04cfd6d1e08e8f695befb2948e27d63fd7842b8f" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+</softwarelist>

--- a/hash/pro128_cart.xml
+++ b/hash/pro128_cart.xml
@@ -1,0 +1,55 @@
+<?xml version="1.0"?>
+<!DOCTYPE softwarelist SYSTEM "softwarelist.dtd">
+<softwarelist name="pro128_cart" description="Prodest PC 128 cartridges">
+
+
+	<software name="agenda">
+		<description>Agenda</description>
+		<year>1984</year>
+		<publisher>Answare</publisher>
+
+		<part name="cart" interface="mo5_cart">
+			<dataarea name="rom" size="16384">
+				<rom name="agenda (1984)(answare)(fr).m5" size="16384" crc="a4460761" sha1="5a77e3709b90f430c0b4c2c282916095e60ee22b" offset="0x0000" />
+			</dataarea>
+		</part>
+	</software>
+
+	<software name="clrpaint">
+		<description>Colorpaint</description>
+		<year>1985</year>
+		<publisher>Thomson</publisher>
+
+		<part name="cart" interface="mo5_cart">
+			<dataarea name="rom" size="32768">
+				<rom name="colorpaint (1985)(thomson)(it).m5" size="32768" crc="8fa1493b" sha1="d27c6db21adb29dc76df33d7a3855f8532d8cc57" offset="0x0000" />
+			</dataarea>
+		</part>
+	</software>
+
+	<software name="logo">
+		<description>LOGO v1.0</description>
+		<year>1984</year>
+		<publisher>Soli</publisher>
+
+		<part name="cart" interface="mo5_cart">
+			<dataarea name="rom" size="16384">
+				<rom name="logo v1.0 (1984)(soli)(fr).m5" size="16384" crc="6e997494" sha1="039f460f00973da9e192691061b37b493028bc35" offset="0x0000" />
+			</dataarea>
+		</part>
+	</software>
+
+	<software name="scriptor">
+		<description>Scriptor</description>
+		<year>1986</year>
+		<publisher>To Tek</publisher>
+
+		<part name="cart" interface="mo5_cart">
+			<dataarea name="rom" size="16384">
+				<rom name="scriptor (1986)(to tek)(it).m5" size="16384" crc="3bb553c9" sha1="b8b4b7618684e0c9331e8759fe13b07d22340fbe" offset="0x0000" />
+			</dataarea>
+		</part>
+	</software>
+
+
+</softwarelist>

--- a/src/lib/formats/bbc_dsk.c
+++ b/src/lib/formats/bbc_dsk.c
@@ -1,53 +1,229 @@
 // license:GPL-2.0+
-// copyright-holders:Dirk Best
+// copyright-holders:Dirk Best, Nigel Barnes
 /***************************************************************************
 
     BBC Micro
 
-    Disk image format
+    Disk image formats
 
 ***************************************************************************/
 
 #include "bbc_dsk.h"
+#include "basicdsk.h"
 
-bbc_format::bbc_format() : wd177x_format(formats)
+LEGACY_FLOPPY_OPTIONS_START(bbc)
+	LEGACY_FLOPPY_OPTION( ssd40, "bbc,img,ssd", "BBC 40t SSD disk image", basicdsk_identify_default, basicdsk_construct_default, NULL,
+		HEADS([1])
+		TRACKS([40])
+		SECTORS([10])
+		SECTOR_LENGTH([256])
+		FIRST_SECTOR_ID([0]))
+	LEGACY_FLOPPY_OPTION( ssd80, "bbc,img,ssd", "BBC 80t SSD disk image", basicdsk_identify_default, basicdsk_construct_default, NULL,
+		HEADS([1])
+		TRACKS([80])
+		SECTORS([10])
+		SECTOR_LENGTH([256])
+		FIRST_SECTOR_ID([0]))
+	LEGACY_FLOPPY_OPTION( dsd40, "dsd", "BBC 40t DSD disk image", basicdsk_identify_default, basicdsk_construct_default, NULL,
+		HEADS([2])
+		TRACKS([40])
+		SECTORS([10])
+		SECTOR_LENGTH([256])
+		INTERLEAVE([0])
+		FIRST_SECTOR_ID([0]))
+	LEGACY_FLOPPY_OPTION( dsd80, "dsd", "BBC 80t DSD disk image", basicdsk_identify_default, basicdsk_construct_default, NULL,
+		HEADS([2])
+		TRACKS([80])
+		SECTORS([10])
+		SECTOR_LENGTH([256])
+		INTERLEAVE([0])
+		FIRST_SECTOR_ID([0]))
+LEGACY_FLOPPY_OPTIONS_END
+
+/********************************************************************/
+
+bbc_ssd_525_format::bbc_ssd_525_format() : wd177x_format(formats)
 {
 }
 
-const char *bbc_format::name() const
+const char *bbc_ssd_525_format::name() const
 {
-	return "bbc";
+	return "ssd";
 }
 
-const char *bbc_format::description() const
+const char *bbc_ssd_525_format::description() const
 {
-	return "BBC Micro disk image";
+	return "BBC Micro 5.25\" disk image";
 }
 
-const char *bbc_format::extensions() const
+const char *bbc_ssd_525_format::extensions() const
 {
-	return "bbc,img,ssd,dsd";
+	return "bbc,img,ssd";
 }
 
-const bbc_format::format bbc_format::formats[] =
+int bbc_ssd_525_format::find_size(io_generic *io, UINT32 form_factor)
 {
-	{   // 100k single sided single density
+	char cat[8];
+	io_generic_read(io, cat, 256, 8);
+	UINT64 sectors = ((cat[6] & 3) << 8) + cat[7]; // sector count from catalogue
+	UINT64 size = io_generic_size(io);
+	for(int i=0; formats[i].form_factor; i++) {
+		const format &f = formats[i];
+		if(form_factor != floppy_image::FF_UNKNOWN && form_factor != f.form_factor)
+			continue;
+
+		if((size <= (UINT64)compute_track_size(f) * f.track_count * f.head_count) && (sectors == f.track_count * f.sector_count))
+			return i;
+	}
+	return -1;
+}
+
+const bbc_ssd_525_format::format bbc_ssd_525_format::formats[] =
+{
+	{ // 100k 40 track single sided single density
 		floppy_image::FF_525, floppy_image::SSSD, floppy_image::FM,
-		4000, 10, 40, 1, 256, {}, 0, {}, 16, 11, 19
+		4000, 10, 40, 1, 256, {}, 0, {}, 40, 10, 10
 	},
-	{   // 200k double sided single density
-		floppy_image::FF_525, floppy_image::DSSD, floppy_image::FM,
-		4000, 10, 40, 2, 256, {}, 0, {}, 16, 11, 19
-	},
-	{   // 200k single sided double density
+	{ // 200k 80 track single sided single density
 		floppy_image::FF_525, floppy_image::SSQD, floppy_image::FM,
-		4000, 10, 80, 1, 256, {}, 0, {}, 16, 11, 19
+		4000, 10, 80, 1, 256, {}, 0, {}, 40, 10, 10
 	},
-	{   // 400k double sided double density
+	{ // 200k 40 track double sided single density
+		floppy_image::FF_525, floppy_image::DSSD, floppy_image::FM,
+		4000, 10, 40, 2, 256, {}, 0, {}, 40, 10, 10
+	},
+	{ // 400k 80 track double sided single density
 		floppy_image::FF_525, floppy_image::DSQD, floppy_image::FM,
-		4000, 10, 80, 2, 256, {}, 0, {}, 16, 11, 19
+		4000, 10, 80, 2, 256, {}, 0, {}, 40, 10, 10
 	},
 	{}
 };
 
-const floppy_format_type FLOPPY_BBC_FORMAT = &floppy_image_format_creator<bbc_format>;
+
+bbc_dsd_525_format::bbc_dsd_525_format() : wd177x_format(formats)
+{
+}
+
+const char *bbc_dsd_525_format::name() const
+{
+	return "dsd";
+}
+
+const char *bbc_dsd_525_format::description() const
+{
+	return "BBC Micro 5.25\" disk image";
+}
+
+const char *bbc_dsd_525_format::extensions() const
+{
+	return "dsd";
+}
+
+int bbc_dsd_525_format::find_size(io_generic *io, UINT32 form_factor)
+{
+	char cat[8];
+	io_generic_read(io, cat, 256, 8);
+	UINT64 sectors = ((cat[6] & 3) << 8) + cat[7]; // sector count from catalogue
+	UINT64 size = io_generic_size(io);
+	for(int i=0; formats[i].form_factor; i++) {
+		const format &f = formats[i];
+		if(form_factor != floppy_image::FF_UNKNOWN && form_factor != f.form_factor)
+			continue;
+
+		if((size <= (UINT64)compute_track_size(f) * f.track_count * f.head_count) && (sectors == f.track_count * f.sector_count))
+			return i;
+	}
+	return -1;
+}
+
+const bbc_dsd_525_format::format bbc_dsd_525_format::formats[] =
+{
+	{ // 200k 40 track double sided single density
+		floppy_image::FF_525, floppy_image::DSQD, floppy_image::FM,
+		4000, 10, 40, 2, 256, {}, -1, { 0,1,2,3,4,5,6,7,8,9 }, 40, 10, 10
+	},
+	{ // 400k 80 track double sided single density
+		floppy_image::FF_525, floppy_image::DSQD, floppy_image::FM,
+		4000, 10, 80, 2, 256, {}, -1, { 0,1,2,3,4,5,6,7,8,9 }, 40, 10, 10
+	},
+	{}
+};
+
+
+bbc_adf_525_format::bbc_adf_525_format() : wd177x_format(formats)
+{
+}
+
+const char *bbc_adf_525_format::name() const
+{
+	return "adf";
+}
+
+const char *bbc_adf_525_format::description() const
+{
+	return "BBC Micro 5.25\" ADFS disk image";
+}
+
+const char *bbc_adf_525_format::extensions() const
+{
+	return "adf,ads,adm,adl,img";
+}
+
+const bbc_adf_525_format::format bbc_adf_525_format::formats[] =
+{
+	{ // 160K 40 track single sided double density
+		floppy_image::FF_525, floppy_image::SSDD, floppy_image::MFM,
+		2000, 16, 40, 1, 256, {}, 0, {}, 60, 22, 43
+	},
+	{ // 320K 80 track single sided double density
+		floppy_image::FF_525, floppy_image::SSDD, floppy_image::MFM,
+		2000, 16, 80, 1, 256, {}, 0, {}, 60, 22, 43
+	},
+	{ // 640K 80 track double sided double density
+		floppy_image::FF_525, floppy_image::DSDD, floppy_image::MFM,
+		2000, 16, 80, 2, 256, {}, -1, { 0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15 }, 60, 22, 43
+	},
+	{}
+};
+
+
+bbc_adf_35_format::bbc_adf_35_format() : wd177x_format(formats)
+{
+}
+
+const char *bbc_adf_35_format::name() const
+{
+	return "adf";
+}
+
+const char *bbc_adf_35_format::description() const
+{
+	return "BBC Micro 3.5\" ADFS disk image";
+}
+
+const char *bbc_adf_35_format::extensions() const
+{
+	return "adf,ads,adm,adl,img";
+}
+
+const bbc_adf_35_format::format bbc_adf_35_format::formats[] = {
+	{ // 160K 3 1/2 inch 40 track single sided double density
+		floppy_image::FF_35, floppy_image::SSDD, floppy_image::MFM,
+		2000, 16, 40, 1, 256, {}, 0, {}, 60, 22, 43
+	},
+	{ // 320K 3 1/2 inch 80 track single sided double density
+		floppy_image::FF_35, floppy_image::SSQD, floppy_image::MFM,
+		2000, 16, 80, 1, 256, {}, 0, {}, 60, 22, 43
+	},
+	{ // 640K 3 1/2 inch 80 track double sided double density
+		floppy_image::FF_35, floppy_image::DSQD, floppy_image::MFM,
+		2000, 16, 80, 2, 256, {}, -1, { 0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15 }, 60, 22, 43
+	},
+	{}
+};
+
+
+const floppy_format_type FLOPPY_BBC_SSD_525_FORMAT = &floppy_image_format_creator<bbc_ssd_525_format>;
+const floppy_format_type FLOPPY_BBC_DSD_525_FORMAT = &floppy_image_format_creator<bbc_dsd_525_format>;
+const floppy_format_type FLOPPY_BBC_ADF_525_FORMAT = &floppy_image_format_creator<bbc_adf_525_format>;
+const floppy_format_type FLOPPY_BBC_ADF_35_FORMAT = &floppy_image_format_creator<bbc_adf_35_format>;

--- a/src/lib/formats/bbc_dsk.h
+++ b/src/lib/formats/bbc_dsk.h
@@ -1,10 +1,10 @@
 // license:GPL-2.0+
-// copyright-holders:Dirk Best
+// copyright-holders:Dirk Best, Nigel Barnes
 /***************************************************************************
 
     BBC Micro
 
-    Disk image format
+    Disk image formats
 
 ***************************************************************************/
 
@@ -13,12 +13,47 @@
 #ifndef __BBC_DSK_H__
 #define __BBC_DSK_H__
 
+#include "flopimg.h"
 #include "wd177x_dsk.h"
 
-class bbc_format : public wd177x_format
+/**************************************************************************/
+
+LEGACY_FLOPPY_OPTIONS_EXTERN(bbc);
+
+/**************************************************************************/
+
+class bbc_ssd_525_format : public wd177x_format
 {
 public:
-	bbc_format();
+	bbc_ssd_525_format();
+
+	virtual int find_size(io_generic *io, UINT32 form_factor);
+	virtual const char *name() const;
+	virtual const char *description() const;
+	virtual const char *extensions() const;
+
+private:
+	static const format formats[];
+};
+
+class bbc_dsd_525_format : public wd177x_format
+{
+public:
+	bbc_dsd_525_format();
+
+	virtual int find_size(io_generic *io, UINT32 form_factor);
+	virtual const char *name() const;
+	virtual const char *description() const;
+	virtual const char *extensions() const;
+
+private:
+	static const format formats[];
+};
+
+class bbc_adf_525_format : public wd177x_format
+{
+public:
+	bbc_adf_525_format();
 
 	virtual const char *name() const;
 	virtual const char *description() const;
@@ -28,6 +63,23 @@ private:
 	static const format formats[];
 };
 
-extern const floppy_format_type FLOPPY_BBC_FORMAT;
+class bbc_adf_35_format : public wd177x_format
+{
+public:
+	bbc_adf_35_format();
+
+	virtual const char *name() const;
+	virtual const char *description() const;
+	virtual const char *extensions() const;
+
+private:
+	static const format formats[];
+};
+
+
+extern const floppy_format_type FLOPPY_BBC_SSD_525_FORMAT;
+extern const floppy_format_type FLOPPY_BBC_DSD_525_FORMAT;
+extern const floppy_format_type FLOPPY_BBC_ADF_525_FORMAT;
+extern const floppy_format_type FLOPPY_BBC_ADF_35_FORMAT;
 
 #endif // __BBC_DSK_H__

--- a/src/mame/mess.lst
+++ b/src/mame/mess.lst
@@ -342,12 +342,17 @@ atomeb    // 1979 Acorn Atom
 atombb    // 1979 Acorn Atom
 //prophet2
 bbca      // 1981 BBC Micro Model A
-bbcb      // 1981 BBC Micro Model B
+bbcb      // 1981 BBC Micro Model B w/8271 FDC
 bbcb_de   // 1981 BBC Micro Model B (German)
-bbcb_us   // 1981 BBC Micro Model B (US)
+bbcb_us   // 1983 BBC Micro Model B (US)
 electron  // 1983 Acorn Electron
+bbcb1770  // 1985 BBC Micro Model B w/1770 FDC
 bbcbp     // 1985 BBC Micro Model B+ 64K
 bbcbp128  // 1985 BBC Micro Model B+ 128K
+abc110    // 1985 ABC 110
+abc210    // 1985 ABC 210/Cambridge Workstation
+abc310    // 1985 ABC 310
+reutapm   // 1985 Reuters APM Board
 bbcm      // 1986 BBC Master 128
 bbcmt     // 1986 BBC Master Turbo
 bbcmaiv   // 1986 BBC Master AIV
@@ -355,7 +360,8 @@ bbcmet    // 1986 BBC Master ET
 bbcm512   // 1986 BBC Master 512
 bbcmarm   // 1986 ARM Evaluation System
 bbcmc     // 1986 BBC Master Compact
-bbcmc_ar  // 1986 BBC Master Comapact (Arabic)
+bbcmc_ar  // 1986 BBC Master Compact (Arabic)
+pro128s   // 1987 Olivetti Prodest PC 128S
 bbcbc     // 1985 BBC Bridge Companion
 a310      // 1988 Acorn Archimedes 310
 a3010     // 1988 Acorn Archimedes 3010

--- a/src/mess/drivers/bbc.c
+++ b/src/mess/drivers/bbc.c
@@ -48,7 +48,6 @@
 #include "cpu/m6502/m6502.h"
 #include "cpu/m6502/m65sc02.h"
 #include "machine/6522via.h"
-#include "machine/mc146818.h"       /* RTC & CMOS RAM */
 #include "bus/centronics/ctronics.h"
 #include "bus/econet/econet.h"
 #include "sound/tms5220.h"          /* Speech */
@@ -58,7 +57,6 @@
 /* Devices */
 #include "imagedev/flopdrv.h"
 #include "formats/bbc_dsk.h"
-#include "formats/basicdsk.h"
 #include "imagedev/cassette.h"
 #include "formats/uef_cas.h"
 #include "formats/csw_cas.h"
@@ -138,119 +136,119 @@ READ8_MEMBER(bbc_state::bbc_fe_r)
 }
 
 static ADDRESS_MAP_START( bbca_mem, AS_PROGRAM, 8, bbc_state )
-	ADDRESS_MAP_UNMAP_HIGH                                                                      /*  Hardware marked with a # is not present in a Model A        */
+	ADDRESS_MAP_UNMAP_HIGH                                                                                      /*  Hardware marked with a # is not present in a Model A        */
 
-	AM_RANGE(0x0000, 0x3fff) AM_READ_BANK("bank1") AM_WRITE(bbc_memorya1_w)                     /*    0000-3fff                 Regular Ram                     */
-	AM_RANGE(0x4000, 0x7fff) AM_READ_BANK("bank3") AM_WRITE(bbc_memoryb3_w)                     /*    4000-7fff                 Repeat of the Regular Ram       */
-	AM_RANGE(0x8000, 0xbfff) AM_READ_BANK("bank4")                                              /*    8000-bfff                 Paged ROM                       */
-	AM_RANGE(0xc000, 0xfbff) AM_READ_BANK("bank7")                                              /*    c000-fbff                 OS ROM                          */
-	AM_RANGE(0xfc00, 0xfdff) AM_NOP                                                             /*    fc00-fdff                 FRED & JIM Pages                */
-																								/*    fe00-feff                 Shiela Address Page             */
-	AM_RANGE(0xfe00, 0xfe07) AM_READWRITE(bbc_6845_r, bbc_6845_w)                               /*    fe00-fe07  6845 CRTC      Video controller                */
-	AM_RANGE(0xfe08, 0xfe08) AM_MIRROR(0x06) AM_DEVREADWRITE("acia6850", acia6850_device, status_r, control_w)
+	AM_RANGE(0x0000, 0x3fff) AM_READ_BANK("bank1") AM_WRITE(bbc_memorya1_w)                                     /*    0000-3fff                 Regular Ram                     */
+	AM_RANGE(0x4000, 0x7fff) AM_READ_BANK("bank3") AM_WRITE(bbc_memoryb3_w)                                     /*    4000-7fff                 Repeat of the Regular Ram       */
+	AM_RANGE(0x8000, 0xbfff) AM_READ_BANK("bank4") AM_WRITE(bbc_memoryb4_w)                                     /*    8000-bfff                 Paged ROM                       */
+	AM_RANGE(0xc000, 0xfbff) AM_READ_BANK("bank7")                                                              /*    c000-fbff                 OS ROM                          */
+	AM_RANGE(0xfc00, 0xfdff) AM_NOP                                                                             /*    fc00-fdff                 FRED & JIM Pages                */
+	                                                                                                            /*    fe00-feff                 SHEILA Address Page             */
+	AM_RANGE(0xfe00, 0xfe00) AM_MIRROR(0x06) AM_DEVREADWRITE("mc6845", mc6845_device, status_r, address_w)      /*    fe00-fe07  6845 CRTC      Video controller                */
+	AM_RANGE(0xfe01, 0xfe01) AM_MIRROR(0x06) AM_DEVREADWRITE("mc6845", mc6845_device, register_r, register_w)
+	AM_RANGE(0xfe08, 0xfe08) AM_MIRROR(0x06) AM_DEVREADWRITE("acia6850", acia6850_device, status_r, control_w)  /*    fe08-fe0F  6850 ACIA      Serial controller               */
 	AM_RANGE(0xfe09, 0xfe09) AM_MIRROR(0x06) AM_DEVREADWRITE("acia6850", acia6850_device, data_r, data_w)
-	AM_RANGE(0xfe10, 0xfe17) AM_READWRITE(bbc_fe_r, bbc_SerialULA_w)                            /*    fe10-fe17  Serial ULA     Serial system chip              */
-	AM_RANGE(0xfe18, 0xfe1f) AM_NOP                                                             /*    fe18-fe1f  INTOFF/STATID  # ECONET Interrupt Off / ID No. */
-	AM_RANGE(0xfe20, 0xfe2f) AM_WRITE(bbc_videoULA_w)                                           /* R: fe20-fe2f  INTON          # ECONET Interrupt On           */
-																								/* W: fe20-fe2f  Video ULA      Video system chip               */
-	AM_RANGE(0xfe30, 0xfe3f) AM_READWRITE(bbc_fe_r, bbc_page_selecta_w)                         /* R: fe30-fe3f  NC             Not Connected                   */
-																								/* W: fe30-fe3f  84LS161        Paged ROM selector              */
-	AM_RANGE(0xfe40, 0xfe5f) AM_DEVREADWRITE("via6522_0", via6522_device, read, write)          /*    fe40-fe5f  6522 VIA       SYSTEM VIA                      */
-	AM_RANGE(0xfe60, 0xfe7f) AM_NOP                                                             /*    fe60-fe7f  6522 VIA       # USER VIA                      */
-	AM_RANGE(0xfe80, 0xfe9f) AM_NOP                                                             /*    fe80-fe9f  8271/1770 FDC  # Floppy disc controller        */
-	AM_RANGE(0xfea0, 0xfebf) AM_READ(bbc_fe_r)                                                  /*    fea0-febf  68B54 ADLC     # ECONET controller             */
-	AM_RANGE(0xfec0, 0xfedf) AM_NOP                                                             /*    fec0-fedf  uPD7002        # Analogue to digital converter */
-	AM_RANGE(0xfee0, 0xfeff) AM_READ(bbc_fe_r)                                                  /*    fee0-feff  Tube ULA       # Tube system interface         */
-	AM_RANGE(0xff00, 0xffff) AM_ROM AM_REGION("os", 0x3f00)                                 /*    ff00-ffff                 OS Rom (continued)              */
+	AM_RANGE(0xfe10, 0xfe17) AM_READWRITE(bbc_fe_r, bbc_SerialULA_w)                                            /*    fe10-fe17  Serial ULA     Serial system chip              */
+	AM_RANGE(0xfe18, 0xfe1f) AM_NOP                                                                             /*    fe18-fe1f  INTOFF/STATID  # ECONET Interrupt Off / ID No. */
+	AM_RANGE(0xfe20, 0xfe2f) AM_WRITE(bbc_videoULA_w)                                                           /* R: fe20-fe2f  INTON          # ECONET Interrupt On           */
+	                                                                                                            /* W: fe20-fe2f  Video ULA      Video system chip               */
+	AM_RANGE(0xfe30, 0xfe3f) AM_READWRITE(bbc_fe_r, bbc_page_selecta_w)                                         /* R: fe30-fe3f  NC             Not Connected                   */
+	                                                                                                            /* W: fe30-fe3f  84LS161        Paged ROM selector              */
+	AM_RANGE(0xfe40, 0xfe5f) AM_DEVREADWRITE("via6522_0", via6522_device, read, write)                          /*    fe40-fe5f  6522 VIA       SYSTEM VIA                      */
+	AM_RANGE(0xfe60, 0xfe7f) AM_NOP                                                                             /*    fe60-fe7f  6522 VIA       # USER VIA                      */
+	AM_RANGE(0xfe80, 0xfe9f) AM_NOP                                                                             /*    fe80-fe9f  8271/1770 FDC  # Floppy disc controller        */
+	AM_RANGE(0xfea0, 0xfebf) AM_READ(bbc_fe_r)                                                                  /*    fea0-febf  68B54 ADLC     # ECONET controller             */
+	AM_RANGE(0xfec0, 0xfedf) AM_NOP                                                                             /*    fec0-fedf  uPD7002        # Analogue to digital converter */
+	AM_RANGE(0xfee0, 0xfeff) AM_READ(bbc_fe_r)                                                                  /*    fee0-feff  Tube ULA       # Tube system interface         */
+	AM_RANGE(0xff00, 0xffff) AM_ROM AM_REGION("os", 0x3f00)                                                     /*    ff00-ffff                 OS Rom (continued)              */
+ADDRESS_MAP_END
+
+
+static ADDRESS_MAP_START( bbc_base, AS_PROGRAM, 8, bbc_state )
+	ADDRESS_MAP_UNMAP_HIGH
+
+	AM_RANGE(0xc000, 0xfbff) AM_READ_BANK("bank7")                                                              /*    c000-fbff                 OS ROM                          */
+	AM_RANGE(0xfc00, 0xfdff) AM_NOP                                                                             /*    fc00-fdff                 FRED & JIM Pages                */
+	                                                                                                            /*    fe00-feff                 SHEILA Address Page             */
+	AM_RANGE(0xfe00, 0xfe00) AM_MIRROR(0x06) AM_DEVREADWRITE("mc6845", mc6845_device, status_r, address_w)      /*    fe00-fe07  6845 CRTC      Video controller                */
+	AM_RANGE(0xfe01, 0xfe01) AM_MIRROR(0x06) AM_DEVREADWRITE("mc6845", mc6845_device, register_r, register_w)
+	AM_RANGE(0xfe08, 0xfe08) AM_MIRROR(0x06) AM_DEVREADWRITE("acia6850", acia6850_device, status_r, control_w)  /*    fe08-fe0F  6850 ACIA      Serial controller               */
+	AM_RANGE(0xfe09, 0xfe09) AM_MIRROR(0x06) AM_DEVREADWRITE("acia6850", acia6850_device, data_r, data_w)
+	AM_RANGE(0xfe10, 0xfe17) AM_READWRITE(bbc_fe_r, bbc_SerialULA_w)                                            /*    fe10-fe17  Serial ULA     Serial system chip              */
+	AM_RANGE(0xfe18, 0xfe1f) AM_READ_PORT("S11")                                                                /*    fe18-fe1f  INTOFF/STATID  ECONET Interrupt Off / ID No.   */
+	AM_RANGE(0xfe20, 0xfe2f) AM_WRITE(bbc_videoULA_w)                                                           /* R: fe20-fe2f  INTON          ECONET Interrupt On             */
+	                                                                                                            /* W: fe20-fe2f  Video ULA      Video system chip               */
+	AM_RANGE(0xfe40, 0xfe5f) AM_DEVREADWRITE("via6522_0", via6522_device, read, write)                          /*    fe40-fe5f  6522 VIA       SYSTEM VIA                      */
+	AM_RANGE(0xfe60, 0xfe7f) AM_DEVREADWRITE("via6522_1", via6522_device, read, write)                          /*    fe60-fe7f  6522 VIA       USER VIA                        */
+	                                                                                                            /*    fe80-fe9f  FDC            Floppy disc controller          */
+	AM_RANGE(0xfea0, 0xfebf) AM_READ(bbc_fe_r)                                                                  /*    fea0-febf  68B54 ADLC     ECONET controller               */
+	AM_RANGE(0xfec0, 0xfedf) AM_DEVREADWRITE("upd7002", upd7002_device, read, write)                            /*    fec0-fedf  uPD7002        Analogue to digital converter   */
+	AM_RANGE(0xfee0, 0xfeff) AM_READ(bbc_fe_r)                                                                  /*    fee0-feff  Tube ULA       Tube system interface           */
+	AM_RANGE(0xff00, 0xffff) AM_ROM AM_REGION("os", 0x3f00)                                                     /*    ff00-ffff                 OS ROM (continued)              */
 ADDRESS_MAP_END
 
 
 static ADDRESS_MAP_START( bbcb_mem, AS_PROGRAM, 8, bbc_state )
-	ADDRESS_MAP_UNMAP_HIGH
-
 	AM_RANGE(0x0000, 0x3fff) AM_READ_BANK("bank1") AM_WRITE(bbc_memorya1_w)                     /*    0000-3fff                 Regular Ram                     */
-	AM_RANGE(0x4000, 0x7fff) AM_READ_BANK("bank3") AM_WRITE(bbc_memoryb3_w)                     /*    4000-7fff                 Repeat of the Regular Ram       */
+	AM_RANGE(0x4000, 0x7fff) AM_READ_BANK("bank3") AM_WRITE(bbc_memoryb3_w)                     /*    4000-7fff                 Regular Ram                     */
 	AM_RANGE(0x8000, 0xbfff) AM_READ_BANK("bank4") AM_WRITE(bbc_memoryb4_w)                     /*    8000-bfff                 Paged ROM                       */
-	AM_RANGE(0xc000, 0xfbff) AM_READ_BANK("bank7")                                              /*    c000-fbff                 OS ROM                          */
-	AM_RANGE(0xfc00, 0xfdff) AM_READWRITE(bbc_opus_read, bbc_opus_write)                        /*    fc00-fdff                 OPUS Disc Controller            */
-																								/*    fe00-feff                 Shiela Address Page             */
-	AM_RANGE(0xfe00, 0xfe07) AM_READWRITE(bbc_6845_r, bbc_6845_w)                               /*    fe00-fe07  6845 CRTC      Video controller                */
-	AM_RANGE(0xfe08, 0xfe08) AM_MIRROR(0x06) AM_DEVREADWRITE("acia6850", acia6850_device, status_r, control_w)
-	AM_RANGE(0xfe09, 0xfe09) AM_MIRROR(0x06) AM_DEVREADWRITE("acia6850", acia6850_device, data_r, data_w)
-	AM_RANGE(0xfe10, 0xfe17) AM_READWRITE(bbc_fe_r, bbc_SerialULA_w)                            /*    fe10-fe17  Serial ULA     Serial system chip              */
-	AM_RANGE(0xfe18, 0xfe1f) AM_NOP                                                             /*    fe18-fe1f  INTOFF/STATID  ECONET Interrupt Off / ID No.   */
-	AM_RANGE(0xfe20, 0xfe2f) AM_WRITE(bbc_videoULA_w)                                           /* R: fe20-fe2f  INTON          ECONET Interrupt On             */
-																								/* W: fe20-fe2f  Video ULA      Video system chip               */
 	AM_RANGE(0xfe30, 0xfe3f) AM_READWRITE(bbc_fe_r, bbc_page_selectb_w)                         /* R: fe30-fe3f  NC             Not Connected                   */
-																								/* W: fe30-fe3f  84LS161        Paged ROM selector              */
-	AM_RANGE(0xfe40, 0xfe5f) AM_DEVREADWRITE("via6522_0", via6522_device, read, write)          /*    fe40-fe5f  6522 VIA       SYSTEM VIA                      */
-	AM_RANGE(0xfe60, 0xfe7f) AM_DEVREADWRITE("via6522_1", via6522_device, read, write)          /*    fe60-fe7f  6522 VIA       USER VIA                        */
-	AM_RANGE(0xfe80, 0xfe9f) AM_READWRITE(bbc_disc_r, bbc_disc_w)                               /*    fe80-fe9f  8271 FDC       Floppy disc controller          */
-	AM_RANGE(0xfea0, 0xfebf) AM_READ(bbc_fe_r)                                                  /*    fea0-febf  68B54 ADLC     ECONET controller               */
-	AM_RANGE(0xfec0, 0xfedf) AM_DEVREADWRITE("upd7002", upd7002_device, read, write)            /*    fec0-fedf  uPD7002        Analogue to digital converter   */
-	AM_RANGE(0xfee0, 0xfeff) AM_READ(bbc_fe_r)                                                  /*    fee0-feff  Tube ULA       Tube system interface           */
-	AM_RANGE(0xff00, 0xffff) AM_ROM AM_REGION("os", 0x3f00)                                 /*    ff00-ffff                 OS Rom (continued)              */
+	                                                                                            /* W: fe30-fe3f  84LS161        Paged ROM selector              */
+	AM_RANGE(0xfe80, 0xfe83) AM_DEVREADWRITE("i8271", i8271_device, read, write)                /*    fe80-fe9f  8271 FDC       Floppy disc controller          */
+	AM_RANGE(0xfe84, 0xfe9f) AM_DEVREADWRITE("i8271", i8271_device, dack_r, dack_w)             /*    fe80-fe9f  8271 FDC       Floppy disc controller          */
+	AM_IMPORT_FROM(bbc_base)
+ADDRESS_MAP_END
+
+
+static ADDRESS_MAP_START(bbcb1770_mem, AS_PROGRAM, 8, bbc_state)
+	AM_RANGE(0x0000, 0x3fff) AM_READ_BANK("bank1") AM_WRITE(bbc_memorya1_w)                     /*    0000-3fff                 Regular Ram                     */
+	AM_RANGE(0x4000, 0x7fff) AM_READ_BANK("bank3") AM_WRITE(bbc_memoryb3_w)                     /*    4000-7fff                 Regular Ram                     */
+	AM_RANGE(0x8000, 0xbfff) AM_READ_BANK("bank4") AM_WRITE(bbc_memoryb4_w)                     /*    8000-bfff                 Paged ROM                       */
+	AM_RANGE(0xfe30, 0xfe3f) AM_READWRITE(bbc_fe_r, bbc_page_selectb_w)                         /* R: fe30-fe3f  NC             Not Connected                   */
+	                                                                                            /* W: fe30-fe3f  84LS161        Paged ROM selector              */
+	AM_RANGE(0xfe80, 0xfe83) AM_WRITE(bbc_wd1770_status_w)                                      /*    fe80-fe83  1770 FDC       Drive control register          */
+	AM_RANGE(0xfe84, 0xfe9f) AM_DEVREADWRITE("wd1770", wd1770_t, read, write)                   /*    fe84-fe9f  1770 FDC       Floppy disc controller          */
+	AM_IMPORT_FROM(bbc_base)
 ADDRESS_MAP_END
 
 
 static ADDRESS_MAP_START( bbcbp_mem, AS_PROGRAM, 8, bbc_state )
-	ADDRESS_MAP_UNMAP_HIGH
-
 	AM_RANGE(0x0000, 0x2fff) AM_READ_BANK("bank1") AM_WRITE(bbc_memorybp1_w)                    /*    0000-2fff                 Regular Ram                     */
 	AM_RANGE(0x3000, 0x7fff) AM_READ_BANK("bank2") AM_WRITE(bbc_memorybp2_w)                    /*    3000-7fff                 Video/Shadow Ram                */
 	AM_RANGE(0x8000, 0xafff) AM_READ_BANK("bank4") AM_WRITE(bbc_memorybp4_w)                    /*    8000-afff                 Paged ROM or 12K of SWRAM       */
 	AM_RANGE(0xb000, 0xbfff) AM_READ_BANK("bank6")                                              /*    b000-bfff                 Rest of paged ROM area          */
-	AM_RANGE(0xc000, 0xfbff) AM_READ_BANK("bank7")                                              /*    c000-fbff                 OS ROM                          */
-	AM_RANGE(0xfc00, 0xfdff) AM_NOP                                                             /*    fc00-fdff                 FRED & JIM Pages                */
-																								/*    fe00-feff                 Shiela Address Page             */
-	AM_RANGE(0xfe00, 0xfe07) AM_READWRITE(bbc_6845_r, bbc_6845_w)                               /*    fe00-fe07  6845 CRTC      Video controller                */
-	AM_RANGE(0xfe08, 0xfe08) AM_MIRROR(0x06) AM_DEVREADWRITE("acia6850", acia6850_device, status_r, control_w)
-	AM_RANGE(0xfe09, 0xfe09) AM_MIRROR(0x06) AM_DEVREADWRITE("acia6850", acia6850_device, data_r, data_w)
-	AM_RANGE(0xfe10, 0xfe17) AM_READWRITE(bbc_fe_r, bbc_SerialULA_w)                            /*    fe10-fe17  Serial ULA     Serial system chip              */
-	AM_RANGE(0xfe18, 0xfe1f) AM_NOP                                                             /*    fe18-fe1f  INTOFF/STATID  ECONET Interrupt Off / ID No.   */
-	AM_RANGE(0xfe20, 0xfe2f) AM_WRITE(bbc_videoULA_w)                                           /* R: fe20-fe2f  INTON          ECONET Interrupt On             */
-																								/* W: fe20-fe2f  Video ULA      Video system chip               */
 	AM_RANGE(0xfe30, 0xfe3f) AM_READWRITE(bbc_fe_r, bbc_page_selectbp_w)                        /* R: fe30-fe3f  NC             Not Connected                   */
-																								/* W: fe30-fe3f  84LS161        Paged ROM selector              */
-	AM_RANGE(0xfe40, 0xfe5f) AM_DEVREADWRITE("via6522_0", via6522_device, read, write)          /*    fe40-fe5f  6522 VIA       SYSTEM VIA                      */
-	AM_RANGE(0xfe60, 0xfe7f) AM_DEVREADWRITE("via6522_1", via6522_device, read, write)          /*    fe60-fe7f  6522 VIA       USER VIA                        */
-	AM_RANGE(0xfe80, 0xfe9f) AM_READWRITE(bbc_wd1770_read, bbc_wd1770_write)                    /*    fe80-fe9f  1770 FDC       Floppy disc controller          */
-	AM_RANGE(0xfea0, 0xfebf) AM_READ(bbc_fe_r)                                                  /*    fea0-febf  68B54 ADLC     ECONET controller               */
-	AM_RANGE(0xfec0, 0xfedf) AM_DEVREADWRITE("upd7002", upd7002_device, read, write)            /*    fec0-fedf  uPD7002        Analogue to digital converter   */
-	AM_RANGE(0xfee0, 0xfeff) AM_READ(bbc_fe_r)                                                  /*    fee0-feff  Tube ULA       Tube system interface           */
-	AM_RANGE(0xff00, 0xffff) AM_ROM AM_REGION("os", 0x3f00)                                 /*    ff00-ffff                 OS Rom (continued)              */
+	                                                                                            /* W: fe30-fe3f  84LS161        Paged ROM selector              */
+	AM_RANGE(0xfe80, 0xfe83) AM_WRITE(bbc_wd1770_status_w)                                      /*    fe80-fe83  1770 FDC       Drive control register          */
+	AM_RANGE(0xfe84, 0xfe9f) AM_DEVREADWRITE("wd1770", wd1770_t, read, write)                   /*    fe84-fe9f  1770 FDC       Floppy disc controller          */
+	AM_IMPORT_FROM(bbc_base)
 ADDRESS_MAP_END
 
 
 static ADDRESS_MAP_START( bbcbp128_mem, AS_PROGRAM, 8, bbc_state )
-	ADDRESS_MAP_UNMAP_HIGH
-
 	AM_RANGE(0x0000, 0x2fff) AM_READ_BANK("bank1") AM_WRITE(bbc_memorybp1_w)                    /*    0000-2fff                 Regular Ram                     */
 	AM_RANGE(0x3000, 0x7fff) AM_READ_BANK("bank2") AM_WRITE(bbc_memorybp2_w)                    /*    3000-7fff                 Video/Shadow Ram                */
 	AM_RANGE(0x8000, 0xafff) AM_READ_BANK("bank4") AM_WRITE(bbc_memorybp4_128_w)                /*    8000-afff                 Paged ROM or 12K of SWRAM       */
 	AM_RANGE(0xb000, 0xbfff) AM_READ_BANK("bank6") AM_WRITE(bbc_memorybp6_128_w)                /*    b000-bfff                 Rest of paged ROM area          */
-	AM_RANGE(0xc000, 0xfbff) AM_READ_BANK("bank7")                                              /*    c000-fbff                 OS ROM                          */
-	AM_RANGE(0xfc00, 0xfdff) AM_NOP                                                             /*    fc00-fdff                 FRED & JIM Pages                */
-																								/*    fe00-feff                 Shiela Address Page             */
-	AM_RANGE(0xfe00, 0xfe07) AM_READWRITE(bbc_6845_r, bbc_6845_w)                               /*    fe00-fe07  6845 CRTC      Video controller                */
-	AM_RANGE(0xfe08, 0xfe08) AM_MIRROR(0x06) AM_DEVREADWRITE("acia6850", acia6850_device, status_r, control_w)
-	AM_RANGE(0xfe09, 0xfe09) AM_MIRROR(0x06) AM_DEVREADWRITE("acia6850", acia6850_device, data_r, data_w)
-	AM_RANGE(0xfe10, 0xfe17) AM_READWRITE(bbc_fe_r, bbc_SerialULA_w)                            /*    fe10-fe17  Serial ULA     Serial system chip              */
-	AM_RANGE(0xfe10, 0xfe17) AM_NOP                                                             /*    fe10-fe17  Serial ULA     Serial system chip              */
-	AM_RANGE(0xfe18, 0xfe1f) AM_NOP                                                             /*    fe18-fe1f  INTOFF/STATID  ECONET Interrupt Off / ID No.   */
-	AM_RANGE(0xfe20, 0xfe2f) AM_WRITE(bbc_videoULA_w)                                           /* R: fe20-fe2f  INTON          ECONET Interrupt On             */
-																								/* W: fe20-fe2f  Video ULA      Video system chip               */
 	AM_RANGE(0xfe30, 0xfe3f) AM_READWRITE(bbc_fe_r, bbc_page_selectbp_w)                        /* R: fe30-fe3f  NC             Not Connected                   */
-																								/* W: fe30-fe3f  84LS161        Paged ROM selector              */
-	AM_RANGE(0xfe40, 0xfe5f) AM_DEVREADWRITE("via6522_0", via6522_device, read, write)          /*    fe40-fe5f  6522 VIA       SYSTEM VIA                      */
-	AM_RANGE(0xfe60, 0xfe7f) AM_DEVREADWRITE("via6522_1", via6522_device, read, write)          /*    fe60-fe7f  6522 VIA       USER VIA                        */
-	AM_RANGE(0xfe80, 0xfe9f) AM_READWRITE(bbc_wd1770_read, bbc_wd1770_write)                    /*    fe80-fe9f  1770 FDC       Floppy disc controller          */
-	AM_RANGE(0xfea0, 0xfebf) AM_READ(bbc_fe_r)                                                  /*    fea0-febf  68B54 ADLC     ECONET controller               */
-	AM_RANGE(0xfec0, 0xfedf) AM_DEVREADWRITE("upd7002", upd7002_device, read, write)            /*    fec0-fedf  uPD7002        Analogue to digital converter   */
-	AM_RANGE(0xfee0, 0xfeff) AM_READ(bbc_fe_r)                                                  /*    fee0-feff  Tube ULA       Tube system interface           */
-	AM_RANGE(0xff00, 0xffff) AM_ROM AM_REGION("os", 0x3f00)                                 /*    ff00-ffff                 OS Rom (continued)              */
+	                                                                                            /* W: fe30-fe3f  84LS161        Paged ROM selector              */
+	AM_RANGE(0xfe80, 0xfe83) AM_WRITE(bbc_wd1770_status_w)                                      /*    fe80-fe83  1770 FDC       Drive control register          */
+	AM_RANGE(0xfe84, 0xfe9f) AM_DEVREADWRITE("wd1770", wd1770_t, read, write)                   /*    fe84-fe9f  1770 FDC       Floppy disc controller          */
+	AM_IMPORT_FROM(bbc_base)
 ADDRESS_MAP_END
 
+
+static ADDRESS_MAP_START( reutapm_mem, AS_PROGRAM, 8, bbc_state )
+	AM_RANGE(0x0000, 0x2fff) AM_READ_BANK("bank1") AM_WRITE(bbc_memorybp1_w)                    /*    0000-2fff                 Regular Ram                     */
+	AM_RANGE(0x3000, 0x7fff) AM_READ_BANK("bank2") AM_WRITE(bbc_memorybp2_w)                    /*    3000-7fff                 Video/Shadow Ram                */
+	AM_RANGE(0x8000, 0xafff) AM_READ_BANK("bank4") AM_WRITE(bbc_memorybp4_w)                    /*    8000-afff                 Paged ROM or 12K of SWRAM       */
+	AM_RANGE(0xb000, 0xbfff) AM_READ_BANK("bank6")                                              /*    b000-bfff                 Rest of paged ROM area          */
+	AM_RANGE(0xfe30, 0xfe3f) AM_READWRITE(bbc_fe_r, bbc_page_selectbp_w)                        /* R: fe30-fe3f  NC             Not Connected                   */
+	                                                                                            /* W: fe30-fe3f  84LS161        Paged ROM selector              */
+	AM_RANGE(0xfe80, 0xfe83) AM_NOP                                                             /*    fe80-fe83  1770 FDC       Drive control register          */
+	AM_RANGE(0xfe84, 0xfe9f) AM_NOP                                                             /*    fe84-fe9f  1770 FDC       Floppy disc controller          */
+	AM_IMPORT_FROM(bbc_base)
+ADDRESS_MAP_END
 
 /******************************************************************************
 &FC00-&FCFF FRED
@@ -263,7 +261,7 @@ ADDRESS_MAP_END
 
 &20-&23 Video ULA       -                       Video system chip        4 ( 2 bytes x  2 )
 &24-&27 FDC Latch       1770 Control latch      1770 Control latch       4 ( 1 byte  x  4 )
-&28-&2F 1770 registers  1770 Disc Controller    1170 Disc Controller     8 ( 4 bytes x  2 )
+&28-&2F 1770 registers  1770 Disc Controller    1770 Disc Controller     8 ( 4 bytes x  2 )
 &30-&33 ROMSEL          -                       ROM Select               4 ( 1 byte  x  4 )
 &34-&37 ACCCON          ACCCON select reg.      ACCCON select reg        4 ( 1 byte  x  4 )
 &38-&3F NC              -                       -
@@ -282,9 +280,9 @@ static ADDRESS_MAP_START(bbcm_mem, AS_PROGRAM, 8, bbc_state )
 	AM_RANGE(0x8000, 0x8fff) AM_READ_BANK("bank4") AM_WRITE(bbc_memorybm4_w)                    /*    8000-8fff                 Paged ROM/RAM or 4K of RAM ANDY */
 	AM_RANGE(0x9000, 0xbfff) AM_READ_BANK("bank5") AM_WRITE(bbc_memorybm5_w)                    /*    9000-bfff                 Rest of paged ROM/RAM area      */
 	AM_RANGE(0xc000, 0xdfff) AM_READ_BANK("bank7") AM_WRITE(bbc_memorybm7_w)                    /*    c000-dfff                 OS ROM or 8K of RAM       HAZEL */
-	AM_RANGE(0xe000, 0xfbff) AM_ROM AM_REGION("os", 0x2000)                                 /*    e000-fbff                 OS ROM                          */
-	AM_RANGE(0xfc00, 0xfeff) AM_READ_BANK("bank8") AM_WRITE(bbcm_w)                             /*    this is now processed directly because it can be ROM or hardware */
-	AM_RANGE(0xff00, 0xffff) AM_ROM AM_REGION("os", 0x3f00)                                 /*    ff00-ffff                 OS ROM (continued)              */
+	AM_RANGE(0xe000, 0xfbff) AM_ROM AM_REGION("os", 0x2000)                                     /*    e000-fbff                 OS ROM                          */
+	AM_RANGE(0xfc00, 0xfeff) AM_READ_BANK("bank8") AM_WRITE(bbcm_w)                             /*    processed directly because it can be ROM or hardware      */
+	AM_RANGE(0xff00, 0xffff) AM_ROM AM_REGION("os", 0x3f00)                                     /*    ff00-ffff                 OS ROM (continued)              */
 ADDRESS_MAP_END
 
 
@@ -464,44 +462,102 @@ INPUT_PORTS_END
 
 static INPUT_PORTS_START(bbc_dipswitch)
 	PORT_MODIFY("COL2")
-	PORT_DIPNAME(0x01, 0x01, "DIP 8 (Default File System)")
+	PORT_DIPNAME(0x01, 0x01, "Default File System") PORT_DIPLOCATION("KBD:1")
 	PORT_DIPSETTING(   0x00, "NFS" )
 	PORT_DIPSETTING(   0x01, "DFS" )
 
 	PORT_MODIFY("COL3")
-	PORT_DIPNAME(0x01, 0x01, "DIP 7 (Not Used)")
+	PORT_DIPNAME(0x01, 0x01, "Not Used") PORT_DIPLOCATION("KBD:2")
 	PORT_DIPSETTING(   0x00, DEF_STR( Off ))
 	PORT_DIPSETTING(   0x01, DEF_STR( On ))
 
 	PORT_MODIFY("COL4")
-	PORT_DIPNAME(0x01, 0x01, "DIP 6 (Disc Timings)")
+	PORT_DIPNAME(0x01, 0x01, "Disc Timings") PORT_DIPLOCATION("KBD:3")
 	PORT_DIPSETTING(   0x00, DEF_STR( Off ))
 	PORT_DIPSETTING(   0x01, DEF_STR( On ))
 
 	PORT_MODIFY("COL5")
-	PORT_DIPNAME(0x01, 0x01, "DIP 5 (Disc Timings)")
+	PORT_DIPNAME(0x01, 0x01, "Disc Timings") PORT_DIPLOCATION("KBD:4")
 	PORT_DIPSETTING(   0x00, DEF_STR( Off ))
 	PORT_DIPSETTING(   0x01, DEF_STR( On ))
 
 	PORT_MODIFY("COL6")
-	PORT_DIPNAME(0x01, 0x01, "DIP 4 (Boot)")
+	PORT_DIPNAME(0x01, 0x01, "Boot") PORT_DIPLOCATION("KBD:5")
 	PORT_DIPSETTING(   0x00, "SHIFT" )
 	PORT_DIPSETTING(   0x01, "SHIFT-BREAK" )
 
 	PORT_MODIFY("COL7")
-	PORT_DIPNAME(0x01, 0x01, "DIP 3 (Screen Mode)")
+	PORT_DIPNAME(0x01, 0x01, "Screen Mode") PORT_DIPLOCATION("KBD:6")
 	PORT_DIPSETTING(   0x00, "+0" )
 	PORT_DIPSETTING(   0x01, "+4" )
-
+	
 	PORT_MODIFY("COL8")
-	PORT_DIPNAME(0x01, 0x01, "DIP 2 (Screen Mode)")
+	PORT_DIPNAME(0x01, 0x01, "Screen Mode") PORT_DIPLOCATION("KBD:7")
 	PORT_DIPSETTING(   0x00, "+0" )
 	PORT_DIPSETTING(   0x01, "+2" )
 
 	PORT_MODIFY("COL9")
-	PORT_DIPNAME(0x01, 0x01, "DIP 1 (Screen Mode)")
+	PORT_DIPNAME(0x01, 0x01, "Screen Mode") PORT_DIPLOCATION("KBD:8")
 	PORT_DIPSETTING(   0x00, "+0" )
 	PORT_DIPSETTING(   0x01, "+1" )
+INPUT_PORTS_END
+
+
+static INPUT_PORTS_START(bbc_links)
+	PORT_START("S11")
+	PORT_DIPNAME(0xff, 0xfe, "Econet ID") PORT_DIPLOCATION("S11:1,2,3,4,5,6,7,8")
+	PORT_DIPSETTING(   0x00,   "0" )	PORT_DIPSETTING(   0x01,   "1" )	PORT_DIPSETTING(   0x02,   "2" )	PORT_DIPSETTING(   0x03,   "3" )	PORT_DIPSETTING(   0x04,   "4" )
+	PORT_DIPSETTING(   0x05,   "5" )	PORT_DIPSETTING(   0x06,   "6" )	PORT_DIPSETTING(   0x07,   "7" )	PORT_DIPSETTING(   0x08,   "8" )	PORT_DIPSETTING(   0x09,   "9" )
+	PORT_DIPSETTING(   0x0a,  "10" )	PORT_DIPSETTING(   0x0b,  "11" )	PORT_DIPSETTING(   0x0c,  "12" )	PORT_DIPSETTING(   0x0d,  "13" )	PORT_DIPSETTING(   0x0e,  "14" )
+	PORT_DIPSETTING(   0x0f,  "15" )	PORT_DIPSETTING(   0x10,  "16" )	PORT_DIPSETTING(   0x11,  "17" )	PORT_DIPSETTING(   0x12,  "18" )	PORT_DIPSETTING(   0x13,  "19" )
+	PORT_DIPSETTING(   0x14,  "20" )	PORT_DIPSETTING(   0x15,  "21" )	PORT_DIPSETTING(   0x16,  "22" )	PORT_DIPSETTING(   0x17,  "23" )	PORT_DIPSETTING(   0x18,  "24" )
+	PORT_DIPSETTING(   0x19,  "25" )	PORT_DIPSETTING(   0x1a,  "26" )	PORT_DIPSETTING(   0x1b,  "27" )	PORT_DIPSETTING(   0x1c,  "28" )	PORT_DIPSETTING(   0x1d,  "29" )
+	PORT_DIPSETTING(   0x1e,  "30" )	PORT_DIPSETTING(   0x1f,  "31" )	PORT_DIPSETTING(   0x20,  "32" )	PORT_DIPSETTING(   0x21,  "33" )	PORT_DIPSETTING(   0x22,  "34" )
+	PORT_DIPSETTING(   0x23,  "35" )	PORT_DIPSETTING(   0x24,  "36" )	PORT_DIPSETTING(   0x25,  "37" )	PORT_DIPSETTING(   0x26,  "38" )	PORT_DIPSETTING(   0x27,  "39" )
+	PORT_DIPSETTING(   0x28,  "40" )	PORT_DIPSETTING(   0x29,  "41" )	PORT_DIPSETTING(   0x2a,  "42" )	PORT_DIPSETTING(   0x2b,  "43" )	PORT_DIPSETTING(   0x2c,  "44" )
+	PORT_DIPSETTING(   0x2d,  "45" )	PORT_DIPSETTING(   0x2e,  "46" )	PORT_DIPSETTING(   0x2f,  "47" )	PORT_DIPSETTING(   0x30,  "48" )	PORT_DIPSETTING(   0x31,  "49" )
+	PORT_DIPSETTING(   0x32,  "50" )	PORT_DIPSETTING(   0x33,  "51" )	PORT_DIPSETTING(   0x34,  "52" )	PORT_DIPSETTING(   0x35,  "53" )	PORT_DIPSETTING(   0x36,  "54" )
+	PORT_DIPSETTING(   0x37,  "15" )	PORT_DIPSETTING(   0x38,  "56" )	PORT_DIPSETTING(   0x39,  "57" )	PORT_DIPSETTING(   0x3a,  "58" )	PORT_DIPSETTING(   0x3b,  "59" )
+	PORT_DIPSETTING(   0x3c,  "60" )	PORT_DIPSETTING(   0x3d,  "61" )	PORT_DIPSETTING(   0x3e,  "62" )	PORT_DIPSETTING(   0x3f,  "63" )	PORT_DIPSETTING(   0x40,  "64" )
+	PORT_DIPSETTING(   0x41,  "65" )	PORT_DIPSETTING(   0x42,  "66" )	PORT_DIPSETTING(   0x43,  "67" )	PORT_DIPSETTING(   0x44,  "68" )	PORT_DIPSETTING(   0x45,  "69" )
+	PORT_DIPSETTING(   0x46,  "70" )	PORT_DIPSETTING(   0x47,  "71" )	PORT_DIPSETTING(   0x48,  "72" )	PORT_DIPSETTING(   0x49,  "73" )	PORT_DIPSETTING(   0x4a,  "74" )
+	PORT_DIPSETTING(   0x4b,  "75" )	PORT_DIPSETTING(   0x4c,  "76" )	PORT_DIPSETTING(   0x4d,  "77" )	PORT_DIPSETTING(   0x4e,  "78" )	PORT_DIPSETTING(   0x4f,  "79" )
+	PORT_DIPSETTING(   0x50,  "80" )	PORT_DIPSETTING(   0x51,  "81" )	PORT_DIPSETTING(   0x52,  "82" )	PORT_DIPSETTING(   0x53,  "83" )	PORT_DIPSETTING(   0x54,  "84" )
+	PORT_DIPSETTING(   0x55,  "85" )	PORT_DIPSETTING(   0x56,  "86" )	PORT_DIPSETTING(   0x57,  "87" )	PORT_DIPSETTING(   0x58,  "88" )	PORT_DIPSETTING(   0x59,  "89" )
+	PORT_DIPSETTING(   0x5a,  "90" )	PORT_DIPSETTING(   0x5b,  "91" )	PORT_DIPSETTING(   0x5c,  "92" )	PORT_DIPSETTING(   0x5d,  "93" )	PORT_DIPSETTING(   0x5e,  "94" )
+	PORT_DIPSETTING(   0x5f,  "95" )	PORT_DIPSETTING(   0x60,  "96" )	PORT_DIPSETTING(   0x61,  "97" )	PORT_DIPSETTING(   0x62,  "98" )	PORT_DIPSETTING(   0x63,  "99" )
+	PORT_DIPSETTING(   0x64, "100" )	PORT_DIPSETTING(   0x65, "101" )	PORT_DIPSETTING(   0x66, "102" )	PORT_DIPSETTING(   0x67, "103" )	PORT_DIPSETTING(   0x68, "104" )
+	PORT_DIPSETTING(   0x69, "105" )	PORT_DIPSETTING(   0x6a, "106" )	PORT_DIPSETTING(   0x6b, "107" )	PORT_DIPSETTING(   0x6c, "108" )	PORT_DIPSETTING(   0x6d, "109" )
+	PORT_DIPSETTING(   0x6e, "110" )	PORT_DIPSETTING(   0x6f, "111" )	PORT_DIPSETTING(   0x70, "112" )	PORT_DIPSETTING(   0x71, "113" )	PORT_DIPSETTING(   0x72, "114" )
+	PORT_DIPSETTING(   0x73, "115" )	PORT_DIPSETTING(   0x74, "116" )	PORT_DIPSETTING(   0x75, "117" )	PORT_DIPSETTING(   0x76, "118" )	PORT_DIPSETTING(   0x77, "119" )
+	PORT_DIPSETTING(   0x78, "120" )	PORT_DIPSETTING(   0x79, "121" )	PORT_DIPSETTING(   0x7a, "122" )	PORT_DIPSETTING(   0x7b, "123" )	PORT_DIPSETTING(   0x7c, "124" )
+	PORT_DIPSETTING(   0x7d, "125" )	PORT_DIPSETTING(   0x7e, "126" )	PORT_DIPSETTING(   0x7f, "127" )	PORT_DIPSETTING(   0x80, "128" )	PORT_DIPSETTING(   0x81, "129" )
+	PORT_DIPSETTING(   0x82, "130" )	PORT_DIPSETTING(   0x83, "131" )	PORT_DIPSETTING(   0x84, "132" )	PORT_DIPSETTING(   0x85, "133" )	PORT_DIPSETTING(   0x86, "134" )
+	PORT_DIPSETTING(   0x87, "135" )	PORT_DIPSETTING(   0x88, "136" )	PORT_DIPSETTING(   0x89, "137" )	PORT_DIPSETTING(   0x8a, "138" )	PORT_DIPSETTING(   0x8b, "139" )
+	PORT_DIPSETTING(   0x8c, "140" )	PORT_DIPSETTING(   0x8d, "141" )	PORT_DIPSETTING(   0x8e, "142" )	PORT_DIPSETTING(   0x8f, "143" )	PORT_DIPSETTING(   0x90, "144" )
+	PORT_DIPSETTING(   0x91, "145" )	PORT_DIPSETTING(   0x92, "146" )	PORT_DIPSETTING(   0x93, "147" )	PORT_DIPSETTING(   0x94, "148" )	PORT_DIPSETTING(   0x95, "149" )
+	PORT_DIPSETTING(   0x96, "150" )	PORT_DIPSETTING(   0x97, "151" )	PORT_DIPSETTING(   0x98, "152" )	PORT_DIPSETTING(   0x99, "153" )	PORT_DIPSETTING(   0x9a, "154" )
+	PORT_DIPSETTING(   0x9b, "155" )	PORT_DIPSETTING(   0x9c, "156" )	PORT_DIPSETTING(   0x9d, "157" )	PORT_DIPSETTING(   0x9e, "158" )	PORT_DIPSETTING(   0x9f, "159" )
+	PORT_DIPSETTING(   0xa0, "160" )	PORT_DIPSETTING(   0xa1, "161" )	PORT_DIPSETTING(   0xa2, "162" )	PORT_DIPSETTING(   0xa3, "163" )	PORT_DIPSETTING(   0xa4, "164" )
+	PORT_DIPSETTING(   0xa5, "165" )	PORT_DIPSETTING(   0xa6, "166" )	PORT_DIPSETTING(   0xa7, "167" )	PORT_DIPSETTING(   0xa8, "168" )	PORT_DIPSETTING(   0xa9, "169" )
+	PORT_DIPSETTING(   0xaa, "170" )	PORT_DIPSETTING(   0xab, "171" )	PORT_DIPSETTING(   0xac, "172" )	PORT_DIPSETTING(   0xad, "173" )	PORT_DIPSETTING(   0xae, "174" )
+	PORT_DIPSETTING(   0xaf, "175" )	PORT_DIPSETTING(   0xb0, "176" )	PORT_DIPSETTING(   0xb1, "177" )	PORT_DIPSETTING(   0xb2, "178" )	PORT_DIPSETTING(   0xb3, "179" )
+	PORT_DIPSETTING(   0xb4, "180" )	PORT_DIPSETTING(   0xb5, "181" )	PORT_DIPSETTING(   0xb6, "182" )	PORT_DIPSETTING(   0xb7, "183" )	PORT_DIPSETTING(   0xb8, "184" )
+	PORT_DIPSETTING(   0xb9, "185" )	PORT_DIPSETTING(   0xba, "186" )	PORT_DIPSETTING(   0xbb, "187" )	PORT_DIPSETTING(   0xbc, "188" )	PORT_DIPSETTING(   0xbd, "189" )
+	PORT_DIPSETTING(   0xbe, "190" )	PORT_DIPSETTING(   0xbf, "191" )	PORT_DIPSETTING(   0xc0, "192" )	PORT_DIPSETTING(   0xc1, "193" )	PORT_DIPSETTING(   0xc2, "194" )
+	PORT_DIPSETTING(   0xc3, "195" )	PORT_DIPSETTING(   0xc4, "196" )	PORT_DIPSETTING(   0xc5, "197" )	PORT_DIPSETTING(   0xc6, "198" )	PORT_DIPSETTING(   0xc7, "199" )
+	PORT_DIPSETTING(   0xc8, "200" )	PORT_DIPSETTING(   0xc9, "201" )	PORT_DIPSETTING(   0xca, "202" )	PORT_DIPSETTING(   0xcb, "203" )	PORT_DIPSETTING(   0xcc, "204" )
+	PORT_DIPSETTING(   0xcd, "205" )	PORT_DIPSETTING(   0xce, "206" )	PORT_DIPSETTING(   0xcf, "207" )	PORT_DIPSETTING(   0xd0, "208" )	PORT_DIPSETTING(   0xd1, "209" )
+	PORT_DIPSETTING(   0xd2, "210" )	PORT_DIPSETTING(   0xd3, "211" )	PORT_DIPSETTING(   0xd4, "212" )	PORT_DIPSETTING(   0xd5, "213" )	PORT_DIPSETTING(   0xd6, "214" )
+	PORT_DIPSETTING(   0xd7, "215" )	PORT_DIPSETTING(   0xd8, "216" )	PORT_DIPSETTING(   0xd9, "217" )	PORT_DIPSETTING(   0xda, "218" )	PORT_DIPSETTING(   0xdb, "219" )
+	PORT_DIPSETTING(   0xdc, "220" )	PORT_DIPSETTING(   0xdd, "221" )	PORT_DIPSETTING(   0xde, "222" )	PORT_DIPSETTING(   0xdf, "223" )	PORT_DIPSETTING(   0xe0, "224" )
+	PORT_DIPSETTING(   0xe1, "225" )	PORT_DIPSETTING(   0xe2, "226" )	PORT_DIPSETTING(   0xe3, "227" )	PORT_DIPSETTING(   0xe4, "228" )	PORT_DIPSETTING(   0xe5, "229" )
+	PORT_DIPSETTING(   0xe6, "230" )	PORT_DIPSETTING(   0xe7, "231" )	PORT_DIPSETTING(   0xe8, "232" )	PORT_DIPSETTING(   0xe9, "233" )	PORT_DIPSETTING(   0xea, "234" )
+	PORT_DIPSETTING(   0xeb, "235" )	PORT_DIPSETTING(   0xec, "236" )	PORT_DIPSETTING(   0xed, "237" )	PORT_DIPSETTING(   0xee, "238" )	PORT_DIPSETTING(   0xef, "239" )
+	PORT_DIPSETTING(   0xf0, "240" )	PORT_DIPSETTING(   0xf1, "241" )	PORT_DIPSETTING(   0xf2, "242" )	PORT_DIPSETTING(   0xf3, "243" )	PORT_DIPSETTING(   0xf4, "244" )
+	PORT_DIPSETTING(   0xf5, "245" )	PORT_DIPSETTING(   0xf6, "246" )	PORT_DIPSETTING(   0xf7, "247" )	PORT_DIPSETTING(   0xf8, "248" )	PORT_DIPSETTING(   0xf9, "249" )
+	PORT_DIPSETTING(   0xfa, "250" )	PORT_DIPSETTING(   0xfb, "251" )	PORT_DIPSETTING(   0xfc, "252" )	PORT_DIPSETTING(   0xfd, "253" )	PORT_DIPSETTING(   0xfe, "254" )
+	PORT_DIPSETTING(   0xff, "255" )
 INPUT_PORTS_END
 
 
@@ -523,19 +579,9 @@ INPUT_PORTS_END
 static INPUT_PORTS_START(bbc_config)
 	PORT_START("BBCCONFIG")
 
-//  PORT_CONFNAME( 0x01, 0x00, "Speech Upgrade" )
-//  PORT_CONFSETTING(    0x00, DEF_STR( On ) )
-//  PORT_CONFSETTING(    0x01, DEF_STR( Off ) )
-
-	PORT_CONFNAME( 0x07, 0x00, "DFS Select" )
-	PORT_CONFSETTING(    0x00, "Acorn DFS 0.90 (read only)"  )
-	PORT_CONFSETTING(    0x01, "Acorn DNFS 1.20 (read only)" )
-	PORT_CONFSETTING(    0x02, "Watford DFS 1.44 (read only)" )
-	PORT_CONFSETTING(    0x03, "Acorn DFS E00 (hack / read only)" )
-	PORT_CONFSETTING(    0x04, "Acorn DDFS" )
-	PORT_CONFSETTING(    0x05, "Watford DDFS (not working)" )
-	PORT_CONFSETTING(    0x06, "Opus Challenger 512K (RAM drive only)" )
-	PORT_CONFSETTING(    0x07, DEF_STR( None ) )
+	PORT_CONFNAME( 0x01, 0x00, "Speech Upgrade" )
+	PORT_CONFSETTING(    0x00, DEF_STR( On ) )
+	PORT_CONFSETTING(    0x01, DEF_STR( Off ) )
 
 	PORT_CONFNAME( 0x18, 0x00, "Sideways RAM Type" )
 	PORT_CONFSETTING(    0x00, DEF_STR( None ) )
@@ -554,6 +600,15 @@ static INPUT_PORTS_START(bbcb)
 	PORT_INCLUDE(bbc_config)
 	PORT_INCLUDE(bbc_keyboard)
 	PORT_INCLUDE(bbc_dipswitch)
+	PORT_INCLUDE(bbc_links)
+	PORT_INCLUDE(bbc_joy)
+INPUT_PORTS_END
+
+static INPUT_PORTS_START(abc)
+	PORT_INCLUDE(bbc_keyboard)
+	PORT_INCLUDE(bbc_keypad)
+	PORT_INCLUDE(bbc_dipswitch)
+	PORT_INCLUDE(bbc_links)
 	PORT_INCLUDE(bbc_joy)
 INPUT_PORTS_END
 
@@ -572,15 +627,6 @@ INTERRUPT_GEN_MEMBER(bbc_state::bbcb_vsync)
 }
 
 
-//static const struct TMS5220interface tms5220_interface =
-//{
-//  680000L,
-//  50,
-//  bbc_TMSint
-//};
-
-
-
 WRITE_LINE_MEMBER(bbc_state::bbcb_acia6850_irq_w)
 {
 	m_acia_irq = state;
@@ -588,20 +634,6 @@ WRITE_LINE_MEMBER(bbc_state::bbcb_acia6850_irq_w)
 	check_interrupts();
 }
 
-static LEGACY_FLOPPY_OPTIONS_START(bbc)
-	LEGACY_FLOPPY_OPTION( ssd80, "bbc,img,ssd", "BBC SSD disk image", basicdsk_identify_default, basicdsk_construct_default, NULL,
-		HEADS([1])
-		TRACKS([80])
-		SECTORS([10])
-		SECTOR_LENGTH([256])
-		FIRST_SECTOR_ID([0]))
-	LEGACY_FLOPPY_OPTION( dsd80, "dsd", "BBC DSD disk image", basicdsk_identify_default, basicdsk_construct_default, NULL,
-		HEADS([2])
-		TRACKS([80])
-		SECTORS([10])
-		SECTOR_LENGTH([256])
-		FIRST_SECTOR_ID([0]))
-LEGACY_FLOPPY_OPTIONS_END
 
 static const floppy_interface bbc_floppy_interface =
 {
@@ -610,17 +642,32 @@ static const floppy_interface bbc_floppy_interface =
 	"floppy_5_25"
 };
 
-FLOPPY_FORMATS_MEMBER( bbc_state::floppy_formats )
-	FLOPPY_BBC_FORMAT
+FLOPPY_FORMATS_MEMBER( bbc_state::floppy_formats_525sd )
+	FLOPPY_BBC_SSD_525_FORMAT,
+	FLOPPY_BBC_DSD_525_FORMAT
 FLOPPY_FORMATS_END
 
-static SLOT_INTERFACE_START( bbc_floppies )
+FLOPPY_FORMATS_MEMBER( bbc_state::floppy_formats_525dd )
+	FLOPPY_BBC_SSD_525_FORMAT,
+	FLOPPY_BBC_DSD_525_FORMAT,
+	FLOPPY_BBC_ADF_525_FORMAT
+FLOPPY_FORMATS_END
+
+FLOPPY_FORMATS_MEMBER( bbc_state::floppy_formats_35dd )
+	FLOPPY_BBC_ADF_35_FORMAT
+FLOPPY_FORMATS_END
+
+static SLOT_INTERFACE_START( bbc_floppies_525 )
 	SLOT_INTERFACE("sssd", FLOPPY_525_SSSD)
 	SLOT_INTERFACE("sd",   FLOPPY_525_SD)
 	SLOT_INTERFACE("ssdd", FLOPPY_525_SSDD)
 	SLOT_INTERFACE("dd",   FLOPPY_525_DD)
 	SLOT_INTERFACE("ssqd", FLOPPY_525_SSQD)
 	SLOT_INTERFACE("qd",   FLOPPY_525_QD)
+SLOT_INTERFACE_END
+
+static SLOT_INTERFACE_START( bbc_floppies_35 )
+	SLOT_INTERFACE("qd",   FLOPPY_35_DD)
 SLOT_INTERFACE_END
 
 WRITE_LINE_MEMBER(bbc_state::econet_clk_w)
@@ -647,6 +694,13 @@ static MACHINE_CONFIG_FRAGMENT( bbc_eprom_sockets )
 	MCFG_GENERIC_EXTENSIONS("bin,rom")
 	MCFG_GENERIC_LOAD(bbc_state, exp4_load)
 MACHINE_CONFIG_END
+
+
+/***************************************************************************
+
+    BBC Micro
+
+****************************************************************************/
 
 
 static MACHINE_CONFIG_START( bbca, bbc_state )
@@ -747,8 +801,9 @@ static MACHINE_CONFIG_DERIVED( bbcb, bbca )
 	MCFG_RAM_DEFAULT_VALUE(0x00)
 
 	/* speech hardware */
-//  MCFG_SOUND_ADD("tms5220", TMS5220, 640000)
-//  MCFG_TMS52XX_SPEECHROM("vsm")
+	MCFG_DEVICE_ADD("vsm", SPEECHROM, 0)
+	MCFG_SOUND_ADD("tms5220", TMS5220, 640000)
+	MCFG_TMS52XX_SPEECHROM("vsm")
 
 	/* user via */
 	MCFG_DEVICE_ADD("via6522_1", VIA6522, 1000000)
@@ -766,7 +821,6 @@ static MACHINE_CONFIG_DERIVED( bbcb, bbca )
 	/* printer */
 	MCFG_CENTRONICS_ADD("centronics", centronics_devices, "printer")
 	MCFG_CENTRONICS_ACK_HANDLER(DEVWRITELINE("via6522_1", via6522_device, write_ca1)) MCFG_DEVCB_INVERT /* ack seems to be inverted? */
-
 	MCFG_CENTRONICS_OUTPUT_LATCH_ADD("cent_data_out", "centronics")
 
 	/* fdc */
@@ -776,13 +830,6 @@ static MACHINE_CONFIG_DERIVED( bbcb, bbca )
 
 	MCFG_LEGACY_FLOPPY_2_DRIVES_ADD(bbc_floppy_interface)
 
-	MCFG_WD1770_ADD("wd177x", XTAL_16MHz / 2)
-	MCFG_WD_FDC_INTRQ_CALLBACK(WRITELINE(bbc_state, bbc_wd177x_intrq_w))
-	MCFG_WD_FDC_DRQ_CALLBACK(WRITELINE(bbc_state, bbc_wd177x_drq_w))
-
-	MCFG_FLOPPY_DRIVE_ADD("wd177x:0", bbc_floppies, "qd", bbc_state::floppy_formats)
-	MCFG_FLOPPY_DRIVE_ADD("wd177x:1", bbc_floppies, "qd", bbc_state::floppy_formats)
-
 	/* software lists */
 	MCFG_DEVICE_REMOVE("cass_ls_a")
 	MCFG_SOFTWARE_LIST_ADD("cass_ls_b", "bbcb_cass")
@@ -790,71 +837,50 @@ static MACHINE_CONFIG_DERIVED( bbcb, bbca )
 MACHINE_CONFIG_END
 
 
-static MACHINE_CONFIG_DERIVED( bbcb_us, bbca )
+static MACHINE_CONFIG_DERIVED(bbcb1770, bbcb)
 	/* basic machine hardware */
-	MCFG_CPU_MODIFY( "maincpu" )
-	MCFG_CPU_PROGRAM_MAP(bbcb_mem)
+	MCFG_CPU_MODIFY("maincpu")
+	MCFG_CPU_PROGRAM_MAP(bbcb1770_mem)
 
-	MCFG_MACHINE_START_OVERRIDE(bbc_state, bbcb )
-	MCFG_MACHINE_RESET_OVERRIDE(bbc_state, bbcb )
-	MCFG_VIDEO_START_OVERRIDE(bbc_state, bbcb )
+	/* fdc */
+	MCFG_DEVICE_REMOVE("i8271")
+	MCFG_DEVICE_REMOVE(FLOPPY_0)
+	MCFG_DEVICE_REMOVE(FLOPPY_1)
 
-	/* internal ram */
-	MCFG_RAM_MODIFY(RAM_TAG)
-	MCFG_RAM_DEFAULT_SIZE("32K")
-	MCFG_RAM_DEFAULT_VALUE(0x00)
+	MCFG_WD1770_ADD("wd1770", XTAL_16MHz / 2)
+	MCFG_WD_FDC_INTRQ_CALLBACK(WRITELINE(bbc_state, bbc_wd177x_intrq_w))
+	MCFG_WD_FDC_DRQ_CALLBACK(WRITELINE(bbc_state, bbc_wd177x_drq_w))
 
-	/* speech hardware */
-//  MCFG_SOUND_ADD("tms5220", TMS5220, 640000)
-//  MCFG_TMS52XX_SPEECHROM("vsm")
+	MCFG_FLOPPY_DRIVE_ADD("wd1770:0", bbc_floppies_525, "qd", bbc_state::floppy_formats_525dd)
+	MCFG_FLOPPY_DRIVE_SOUND(true)
+	MCFG_FLOPPY_DRIVE_ADD("wd1770:1", bbc_floppies_525, "qd", bbc_state::floppy_formats_525dd)
+	MCFG_FLOPPY_DRIVE_SOUND(true)
+MACHINE_CONFIG_END
 
+
+static MACHINE_CONFIG_DERIVED( bbcb_de, bbcb )
+	/* software lists */
+	MCFG_DEVICE_REMOVE("cass_ls_b")
+	MCFG_SOFTWARE_LIST_ADD("flop_ls_b_de", "bbcb_de_cass")
+	MCFG_SOFTWARE_LIST_COMPATIBLE_ADD("cass_ls_b", "bbcb_cass")
+MACHINE_CONFIG_END
+
+
+static MACHINE_CONFIG_DERIVED( bbcb_us, bbcb )
 	/* video hardware */
 	MCFG_SCREEN_MODIFY("screen")
 	MCFG_SCREEN_SIZE(640, 200)
 	MCFG_SCREEN_VISIBLE_AREA(0, 640-1, 0, 200-1)
 	MCFG_SCREEN_REFRESH_RATE(60)
 
-	/* system via */
-	MCFG_DEVICE_ADD("via6522_1", VIA6522, 1000000)
-	MCFG_VIA6522_READPB_HANDLER(READ8(bbc_state, bbcb_via_user_read_portb))
-	MCFG_VIA6522_WRITEPA_HANDLER(DEVWRITE8("cent_data_out", output_latch_device, write))
-	MCFG_VIA6522_WRITEPB_HANDLER(WRITE8(bbc_state, bbcb_via_user_write_portb))
-	MCFG_VIA6522_CA2_HANDLER(DEVWRITELINE("centronics", centronics_device, write_strobe))
-	MCFG_VIA6522_IRQ_HANDLER(WRITELINE(bbc_state, bbcb_via_user_irq_w))
-
-	/* adc */
-	MCFG_DEVICE_ADD("upd7002", UPD7002, 0)
-	MCFG_UPD7002_GET_ANALOGUE_CB(bbc_state, BBC_get_analogue_input)
-	MCFG_UPD7002_EOC_CB(bbc_state, BBC_uPD7002_EOC)
-
-	/* printer */
-	MCFG_CENTRONICS_ADD("centronics", centronics_devices, "printer")
-	MCFG_CENTRONICS_ACK_HANDLER(DEVWRITELINE("via6522_1", via6522_device, write_ca1)) MCFG_DEVCB_INVERT /* ack seems to be inverted? */
-
-	MCFG_CENTRONICS_OUTPUT_LATCH_ADD("cent_data_out", "centronics")
-
-	/* fdc */
-	MCFG_DEVICE_ADD("i8271", I8271, 0)
-	MCFG_I8271_IRQ_CALLBACK(WRITELINE(bbc_state, bbc_i8271_interrupt))
-	MCFG_I8271_FLOPPIES(FLOPPY_0, FLOPPY_1)
-
-	MCFG_LEGACY_FLOPPY_2_DRIVES_ADD(bbc_floppy_interface)
-
-	MCFG_WD1770_ADD("wd177x", XTAL_16MHz / 2)
-	MCFG_WD_FDC_INTRQ_CALLBACK(WRITELINE(bbc_state, bbc_wd177x_intrq_w))
-	MCFG_WD_FDC_DRQ_CALLBACK(WRITELINE(bbc_state, bbc_wd177x_drq_w))
-
-	MCFG_FLOPPY_DRIVE_ADD("wd177x:0", bbc_floppies, "qd", bbc_state::floppy_formats)
-	MCFG_FLOPPY_DRIVE_ADD("wd177x:1", bbc_floppies, "qd", bbc_state::floppy_formats)
-
 	/* software lists */
-	MCFG_DEVICE_REMOVE("cass_ls_a")
-	MCFG_SOFTWARE_LIST_ADD("cass_ls_b", "bbcb_cass")
-	MCFG_SOFTWARE_LIST_COMPATIBLE_ADD("cass_ls_a", "bbca_cass")
+	MCFG_DEVICE_REMOVE("cass_ls_b")
+	MCFG_SOFTWARE_LIST_ADD("flop_ls_b_us", "bbcb_us_flop")
+	MCFG_SOFTWARE_LIST_COMPATIBLE_ADD("cass_ls_b", "bbcb_cass")
 MACHINE_CONFIG_END
 
 
-static MACHINE_CONFIG_DERIVED( bbcbp, bbcb )
+static MACHINE_CONFIG_DERIVED( bbcbp, bbcb1770 )
 	/* basic machine hardware */
 	MCFG_CPU_MODIFY( "maincpu" )  /* M6512 */
 	MCFG_CPU_PROGRAM_MAP(bbcbp_mem)
@@ -867,18 +893,14 @@ static MACHINE_CONFIG_DERIVED( bbcbp, bbcb )
 	MCFG_RAM_MODIFY(RAM_TAG)
 	MCFG_RAM_DEFAULT_SIZE("64K")
 	MCFG_RAM_DEFAULT_VALUE(0x00)
-
-	/* fdc */
-	MCFG_DEVICE_REMOVE("i8271")
-	MCFG_DEVICE_REMOVE(FLOPPY_0)
-	MCFG_DEVICE_REMOVE(FLOPPY_1)
 MACHINE_CONFIG_END
 
 
-static MACHINE_CONFIG_DERIVED( bbcbp128, bbcbp )
+static MACHINE_CONFIG_DERIVED( bbcbp128, bbcb1770 )
 	/* basic machine hardware */
 	MCFG_CPU_MODIFY( "maincpu" )  /* M6512 */
 	MCFG_CPU_PROGRAM_MAP(bbcbp128_mem)
+
 	MCFG_MACHINE_START_OVERRIDE(bbc_state, bbcbp)
 	MCFG_MACHINE_RESET_OVERRIDE(bbc_state, bbcbp)
 	MCFG_VIDEO_START_OVERRIDE(bbc_state, bbcbp)
@@ -890,7 +912,90 @@ static MACHINE_CONFIG_DERIVED( bbcbp128, bbcbp )
 MACHINE_CONFIG_END
 
 
-/* BBC Master Series */
+/***************************************************************************
+
+    Acorn Business Computers
+
+****************************************************************************/
+
+
+static MACHINE_CONFIG_DERIVED( abc110, bbcbp )
+	/* fdc */
+	MCFG_DEVICE_REMOVE("wd1770:1")
+
+	/* Add Z80 co-processor */
+
+	/* Add ADAPTEC ACB-4000 Winchester Disc Controller */
+
+	/* Add 10MB ST-412 Winchester */
+
+MACHINE_CONFIG_END
+
+
+static MACHINE_CONFIG_DERIVED( abc210, bbcbp )
+	/* fdc */
+	MCFG_DEVICE_REMOVE("wd1770:1")
+
+	/* Add 32016 co-processor */
+
+	/* Add ADAPTEC ACB-4000 Winchester Disc Controller */
+
+	/* Add 10MB ST-412 Winchester ABC210 */
+
+	/* Add 20MB ST-412 Winchester Cambridge */
+
+MACHINE_CONFIG_END
+
+
+static MACHINE_CONFIG_DERIVED( abc310, bbcbp )
+	/* fdc */
+	MCFG_DEVICE_REMOVE("wd1770:1")
+
+	/* Add 80286 co-processor */
+
+	/* Add ADAPTEC ACB-4000 Winchester Disc Controller */
+
+	/* Add 10MB ST-412 Winchester */
+
+MACHINE_CONFIG_END
+
+
+/***************************************************************************
+
+    Reuters APM Board (Application Processor Module)
+
+****************************************************************************/
+
+
+static MACHINE_CONFIG_DERIVED( reutapm, bbcbp )
+	/* basic machine hardware */
+	MCFG_CPU_MODIFY( "maincpu" )  /* M6512 */
+	MCFG_CPU_PROGRAM_MAP(reutapm_mem)
+
+	/* sound hardware */
+	MCFG_DEVICE_REMOVE("mono")
+  MCFG_DEVICE_REMOVE("sn76489")
+	MCFG_DEVICE_REMOVE("vsm")
+	MCFG_DEVICE_REMOVE("tms5220")
+
+	/* cassette */
+	MCFG_DEVICE_REMOVE( "cassette" )
+
+	/* fdc */
+	MCFG_DEVICE_REMOVE("wd1770")
+
+	/* software lists */
+	MCFG_DEVICE_REMOVE("cass_ls_a")
+	MCFG_DEVICE_REMOVE("cass_ls_b")
+MACHINE_CONFIG_END
+
+
+/***************************************************************************
+
+    BBC Master Series
+
+****************************************************************************/
+
 
 static MACHINE_CONFIG_START( bbcm, bbc_state )
 	/* basic machine hardware */
@@ -943,7 +1048,6 @@ static MACHINE_CONFIG_START( bbcm, bbc_state )
 	/* printer */
 	MCFG_CENTRONICS_ADD("centronics", centronics_devices, "printer")
 	MCFG_CENTRONICS_ACK_HANDLER(DEVWRITELINE("via6522_1", via6522_device, write_ca1)) MCFG_DEVCB_INVERT /* ack seems to be inverted? */
-
 	MCFG_CENTRONICS_OUTPUT_LATCH_ADD("cent_data_out", "centronics")
 
 	/* cassette */
@@ -1001,12 +1105,14 @@ static MACHINE_CONFIG_START( bbcm, bbc_state )
 	MCFG_VIA6522_IRQ_HANDLER(WRITELINE(bbc_state, bbcb_via_user_irq_w))
 
 	/* fdc */
-	MCFG_WD1770_ADD("wd177x", XTAL_16MHz / 2)
+	MCFG_WD1770_ADD("wd1770", XTAL_16MHz / 2)
 	MCFG_WD_FDC_INTRQ_CALLBACK(WRITELINE(bbc_state, bbc_wd177x_intrq_w))
 	MCFG_WD_FDC_DRQ_CALLBACK(WRITELINE(bbc_state, bbc_wd177x_drq_w))
 
-	MCFG_FLOPPY_DRIVE_ADD("wd177x:0", bbc_floppies, "qd", bbc_state::floppy_formats)
-	MCFG_FLOPPY_DRIVE_ADD("wd177x:1", bbc_floppies, "qd", bbc_state::floppy_formats)
+	MCFG_FLOPPY_DRIVE_ADD("wd1770:0", bbc_floppies_525, "qd", bbc_state::floppy_formats_525dd)
+	MCFG_FLOPPY_DRIVE_SOUND(true)
+	MCFG_FLOPPY_DRIVE_ADD("wd1770:1", bbc_floppies_525, "qd", bbc_state::floppy_formats_525dd)
+	MCFG_FLOPPY_DRIVE_SOUND(true)
 
 	/* econet */
 	MCFG_DEVICE_ADD("mc6854", MC6854, 0)
@@ -1037,15 +1143,12 @@ MACHINE_CONFIG_END
 
 
 static MACHINE_CONFIG_DERIVED( bbcmet, bbcm )
-
-	/* Remove all devices not present in this model */
-
 	/* sound hardware */
-//  MCFG_DEVICE_REMOVE("mono")
-//  MCFG_DEVICE_REMOVE("sn76489")
+	MCFG_DEVICE_REMOVE("mono")
+	MCFG_DEVICE_REMOVE("sn76489")
 
 	/* printer */
-//  MCFG_DEVICE_REMOVE("centronics")
+	MCFG_DEVICE_REMOVE("centronics")
 
 	/* cassette */
 	MCFG_DEVICE_REMOVE("cassette")
@@ -1056,15 +1159,16 @@ static MACHINE_CONFIG_DERIVED( bbcmet, bbcm )
 	MCFG_SOFTWARE_LIST_REMOVE("cass_ls_b")
 
 	/* acia */
-//  MCFG_DEVICE_REMOVE("acia6850")
+	MCFG_DEVICE_REMOVE("acia6850")
 	MCFG_DEVICE_REMOVE(RS232_TAG)
+	MCFG_DEVICE_REMOVE("acia_clock")
 
 	/* devices */
-//  MCFG_DEVICE_REMOVE("upd7002")
-//  MCFG_DEVICE_REMOVE("via6522_1")
+	MCFG_DEVICE_REMOVE("upd7002")
+	MCFG_DEVICE_REMOVE("via6522_1")
 
 	/* fdc */
-//  MCFG_DEVICE_REMOVE("wd177x")
+	MCFG_DEVICE_REMOVE("wd1770")
 MACHINE_CONFIG_END
 
 
@@ -1082,24 +1186,46 @@ static MACHINE_CONFIG_DERIVED( bbcmarm, bbcm )
 MACHINE_CONFIG_END
 
 
-static MACHINE_CONFIG_DERIVED( bbcmc, bbcm )
+/***************************************************************************
 
-//  MCFG_DEVICE_REMOVE("rtc")
+    BBC Master Compact
+
+****************************************************************************/
+
+
+static MACHINE_CONFIG_DERIVED( bbcmc, bbcm )
+	/* cassette */
+	MCFG_DEVICE_REMOVE("cassette")
 
 	/* fdc */
-	MCFG_DEVICE_REMOVE("wd177x")
+	MCFG_DEVICE_REMOVE("wd1770")
 
-//  MCFG_WD1772_ADD("wd177x", XTAL_16MHz / 2)
-	MCFG_WD1770_ADD("wd177x", XTAL_16MHz / 2)
+	MCFG_WD1772_ADD("wd1772", XTAL_16MHz / 2)
 	MCFG_WD_FDC_INTRQ_CALLBACK(WRITELINE(bbc_state, bbc_wd177x_intrq_w))
 	MCFG_WD_FDC_DRQ_CALLBACK(WRITELINE(bbc_state, bbc_wd177x_drq_w))
 
-	MCFG_FLOPPY_DRIVE_ADD("wd177x:0", bbc_floppies, "qd", bbc_state::floppy_formats)
-	MCFG_FLOPPY_DRIVE_ADD("wd177x:1", bbc_floppies, "qd", bbc_state::floppy_formats)
+	MCFG_FLOPPY_DRIVE_ADD("wd1772:0", bbc_floppies_35, "qd", bbc_state::floppy_formats_35dd)
+	MCFG_FLOPPY_DRIVE_SOUND(true)
+	MCFG_FLOPPY_DRIVE_ADD("wd1772:1", bbc_floppies_35, NULL, bbc_state::floppy_formats_35dd)
+	MCFG_FLOPPY_DRIVE_SOUND(true)
+
+	/* eeprom pcd8572 */
+	//MCFG_DEVICE_REMOVE("rtc")
 
 	/* software lists */
+	MCFG_SOFTWARE_LIST_REMOVE("cass_ls_m")
+	MCFG_SOFTWARE_LIST_REMOVE("cass_ls_a")
+	MCFG_SOFTWARE_LIST_REMOVE("cass_ls_b")
 	MCFG_SOFTWARE_LIST_REMOVE("cart_ls_m")
 	MCFG_SOFTWARE_LIST_ADD("flop_ls_mc", "bbcmc_flop")
+MACHINE_CONFIG_END
+
+
+static MACHINE_CONFIG_DERIVED(pro128s, bbcmc)
+	/* software lists */
+	MCFG_SOFTWARE_LIST_REMOVE("flop_ls_mc")
+	MCFG_SOFTWARE_LIST_ADD("flop_ls_pro128s", "pro128s_flop")
+	MCFG_SOFTWARE_LIST_COMPATIBLE_ADD("flop_ls_mc", "bbcmc_flop")
 MACHINE_CONFIG_END
 
 
@@ -1111,9 +1237,9 @@ ROM_START(bbca)
 	ROM_REGION(0x08000,"maincpu",ROMREGION_ERASEFF) /* RAM */
 
 	ROM_REGION(0x14000,"option",0) /* ROM */
-	/* rom page 0  00000 */
-	/* rom page 1  04000 */
-	/* rom page 2  08000 */
+	/* rom page 0  00000 SPARE SOCKET */
+	/* rom page 1  04000 SPARE SOCKET */
+	/* rom page 2  08000 SPARE SOCKET */
 	/* rom page 3  0c000 BASIC */
 	ROM_DEFAULT_BIOS("os12b2")
 	ROM_SYSTEM_BIOS( 0, "os12b2", "OS 1.20 / BASIC2" )
@@ -1128,6 +1254,7 @@ ROM_START(bbca)
 	ROM_SYSTEM_BIOS( 3, "os10b1", "OS 1.00 / BASIC1" )
 	ROMX_LOAD("os10.rom",   0x10000, 0x4000, CRC(9679b8f8) SHA1(d35f6723132aabe3c4d00fc16fd9ecc6768df753), ROM_BIOS(4)) /* os */
 	ROMX_LOAD("basic1.rom", 0x0c000, 0x4000, CRC(b3364108) SHA1(890f6e3e7fab3340f75b85e93ff29332bc9ecb2e), ROM_BIOS(4)) /* rom page 3  0c000 */
+	/* OS0.1 does not support rom paging, load BASIC into all pages */
 	ROM_SYSTEM_BIOS( 4, "os01b2", "OS 0.10 / BASIC2" )
 	ROMX_LOAD("os01.rom",   0x10000, 0x4000, CRC(45ee0980) SHA1(4b0ece6dc139d5d3f4fabd023716fb6f25149b80), ROM_BIOS(5)) /* os */
 	ROMX_LOAD("basic2.rom", 0x00000, 0x4000, CRC(79434781) SHA1(4a7393f3a45ea309f744441c16723e2ef447a281), ROM_BIOS(5)) /* rom page 0  00000 */
@@ -1144,7 +1271,6 @@ ROM_START(bbca)
 	ROM_REGION(0x4000, "os", 0)
 	ROM_COPY("option", 0x10000, 0, 0x4000)
 ROM_END
-
 
 
 /*  0000- 7fff  ram */
@@ -1168,9 +1294,9 @@ ROM_START(bbcb)
 	/* rom page 9  24000 */
 	/* rom page 10 28000 */
 	/* rom page 11 2c000 */
-	/* rom page 12 30000 */
-	/* rom page 13 34000 */
-	/* rom page 14 38000 */
+	/* rom page 12 30000 SPARE SOCKET */
+	/* rom page 13 34000 SPARE SOCKET */
+	/* rom page 14 38000 DFS */
 	/* rom page 15 3c000 BASIC */
 	ROM_DEFAULT_BIOS("os12b2")
 	ROM_SYSTEM_BIOS( 0, "os12b2", "OS 1.20 / BASIC2" )
@@ -1186,28 +1312,59 @@ ROM_START(bbcb)
 	ROMX_LOAD("os10.rom",   0x40000, 0x4000, CRC(9679b8f8) SHA1(d35f6723132aabe3c4d00fc16fd9ecc6768df753), ROM_BIOS(4)) /* os */
 	ROMX_LOAD("basic1.rom", 0x3c000, 0x4000, CRC(b3364108) SHA1(890f6e3e7fab3340f75b85e93ff29332bc9ecb2e), ROM_BIOS(4)) /* rom page 15 3c000 */
 
+	ROM_LOAD("dnfs.rom",    0x38000, 0x4000, CRC(8ccd2157) SHA1(7e3c536baeae84d6498a14e8405319e01ee78232))
+
 	ROM_REGION(0x4000, "os", 0)
 	ROM_COPY("option", 0x40000, 0, 0x4000)
 
-	ROM_REGION(0x20000,"dfs",0) /* DFS ROMS */
-	ROM_LOAD("dfs09.rom",    0x00000, 0x2000, CRC(3ce609cf) SHA1(5cc0f14b8f46855c70eaa653cca4ad079b458732))
-	ROM_RELOAD(              0x02000, 0x2000                )
-	ROM_LOAD("dnfs.rom",     0x04000, 0x4000, CRC(8ccd2157) SHA1(7e3c536baeae84d6498a14e8405319e01ee78232))
-	ROM_LOAD("dfs144.rom",   0x08000, 0x4000, CRC(9fb8d13f) SHA1(387d2468c6e1360f5b531784ce95d5f71a50c2b5))
-	ROM_LOAD("zdfs-0.90.rom",0x0C000, 0x2000, CRC(ea579d4d) SHA1(59ad2a8994f4bddad6687891f1a2bc29f2fd32b8))
-	ROM_LOAD("ddfs223.rom",  0x10000, 0x4000, CRC(7891f9b7) SHA1(0d7ed0b0b3852cb61970ada1993244f2896896aa))
-	ROM_LOAD("ddfs-1.53.rom",0x14000, 0x4000, CRC(e1be4ee4) SHA1(6719dc958f2631e6dc8f045429797b289bfe649a))
-	ROM_LOAD("ch103.rom",    0x18000, 0x4000, CRC(98367cf4) SHA1(eca3631aa420691f96b72bfdf2e9c2b613e1bf33))
-	/*NONE*/
-	ROM_REGION(0x80000, "disks", ROMREGION_ERASEFF) /* Opus Ram Disc Space */
-
-	//ROM_REGION(0x2000, "torch", 0)
-	//ROM_LOAD("torchz80_094.bin", 0x0000, 0x2000, CRC(49989bd4) SHA1(62b57c858a3baa4ff943c31f77d331c414772a61))
-	//ROM_LOAD("torchz80_102.bin", 0x0000, 0x2000, CRC(2eb40a21) SHA1(e6ee738e5f2f8556002b79d18caa8ef21f14e08d))
-
-	//ROM_REGION(0x8000, "vsm", 0) /* system speech PHROM */
-	//ROM_LOAD("phroma.bin", 0x0000, 0x4000, CRC(98e1bf9e) SHA1(b369809275cb67dfd8a749265e91adb2d2558ae6))
+	ROM_REGION(0x8000, "vsm", 0) /* system speech PHROM */
+	ROM_LOAD("phroma.bin", 0x0000, 0x4000, CRC(98e1bf9e) SHA1(b369809275cb67dfd8a749265e91adb2d2558ae6))
 ROM_END
+
+
+ROM_START(bbcb1770)
+	ROM_REGION(0x08000,"maincpu",ROMREGION_ERASEFF) /* RAM */
+
+	ROM_REGION(0x44000,"option",0) /* ROM */
+	/* rom page 0  00000 */
+	/* rom page 1  04000 */
+	/* rom page 2  08000 */
+	/* rom page 3  0c000 */
+	/* rom page 4  10000 */
+	/* rom page 5  14000 */
+	/* rom page 6  18000 */
+	/* rom page 7  1c000 */
+	/* rom page 8  20000 */
+	/* rom page 9  24000 */
+	/* rom page 10 28000 */
+	/* rom page 11 2c000 */
+	/* rom page 12 30000 SPARE SOCKET */
+	/* rom page 13 34000 SPARE SOCKET */
+	/* rom page 14 38000 DDFS */
+	/* rom page 15 3c000 BASIC */
+	ROM_DEFAULT_BIOS("os12b2")
+	ROM_SYSTEM_BIOS( 0, "os12b2", "OS 1.20 / BASIC2" )
+	ROMX_LOAD("os12.rom",   0x40000, 0x4000, CRC(3c14fc70) SHA1(0d9bcaf6a393c9ce2359ed700ddb53c232c2c45d), ROM_BIOS(1)) /* os */
+	ROMX_LOAD("basic2.rom", 0x3c000, 0x4000, CRC(79434781) SHA1(4a7393f3a45ea309f744441c16723e2ef447a281), ROM_BIOS(1)) /* rom page 15 3c000 */
+	ROM_SYSTEM_BIOS( 1, "os12b1", "OS 1.20 / BASIC1" )
+	ROMX_LOAD("os12.rom",   0x40000, 0x4000, CRC(3c14fc70) SHA1(0d9bcaf6a393c9ce2359ed700ddb53c232c2c45d), ROM_BIOS(2)) /* os */
+	ROMX_LOAD("basic1.rom", 0x3c000, 0x4000, CRC(b3364108) SHA1(890f6e3e7fab3340f75b85e93ff29332bc9ecb2e), ROM_BIOS(2)) /* rom page 15 3c000 */
+	ROM_SYSTEM_BIOS( 2, "os10b2", "OS 1.00 / BASIC2" )
+	ROMX_LOAD("os10.rom",   0x40000, 0x4000, CRC(9679b8f8) SHA1(d35f6723132aabe3c4d00fc16fd9ecc6768df753), ROM_BIOS(3)) /* os */
+	ROMX_LOAD("basic2.rom", 0x3c000, 0x4000, CRC(79434781) SHA1(4a7393f3a45ea309f744441c16723e2ef447a281), ROM_BIOS(3)) /* rom page 15 3c000 */
+	ROM_SYSTEM_BIOS( 3, "os10b1", "OS 1.00 / BASIC1" )
+	ROMX_LOAD("os10.rom",   0x40000, 0x4000, CRC(9679b8f8) SHA1(d35f6723132aabe3c4d00fc16fd9ecc6768df753), ROM_BIOS(4)) /* os */
+	ROMX_LOAD("basic1.rom", 0x3c000, 0x4000, CRC(b3364108) SHA1(890f6e3e7fab3340f75b85e93ff29332bc9ecb2e), ROM_BIOS(4)) /* rom page 15 3c000 */
+
+	ROM_LOAD("ddfs223.rom", 0x38000, 0x4000, CRC(7891f9b7) SHA1(0d7ed0b0b3852cb61970ada1993244f2896896aa))
+
+	ROM_REGION(0x4000, "os", 0)
+	ROM_COPY("option", 0x40000, 0, 0x4000)
+
+	ROM_REGION(0x8000, "vsm", 0) /* system speech PHROM */
+	ROM_LOAD("phroma.bin", 0x0000, 0x4000, CRC(98e1bf9e) SHA1(b369809275cb67dfd8a749265e91adb2d2558ae6))
+ROM_END
+
 
 ROM_START(bbcb_de)
 	ROM_REGION(0x08000,"maincpu",ROMREGION_ERASEFF) /* RAM */
@@ -1225,31 +1382,24 @@ ROM_START(bbcb_de)
 	/* rom page 9  24000 */
 	/* rom page 10 28000 */
 	/* rom page 11 2c000 */
-	/* rom page 12 30000 */
-	/* rom page 13 34000 */
-	/* rom page 14 38000 */
+	/* rom page 12 30000 SPARE SOCKET */
+	/* rom page 13 34000 SPARE SOCKET */
+	/* rom page 14 38000 DFS */
 	/* rom page 15 3c000 BASIC */
 	ROM_DEFAULT_BIOS("os12")
 	ROM_SYSTEM_BIOS( 0, "os12", "OS 1.20 / BASIC2" )
 	ROMX_LOAD("os_de.rom",   0x40000, 0x4000, CRC(b7262caf) SHA1(aadf90338ee9d1c85dfa73beba50e930c2a38f10), ROM_BIOS(1))
 	ROMX_LOAD("basic2.rom",  0x3c000, 0x4000, CRC(79434781) SHA1(4a7393f3a45ea309f744441c16723e2ef447a281), ROM_BIOS(1)) /* rom page 15 3c000 */
 
+	ROM_LOAD("dfs10.rom",    0x38000, 0x4000, CRC(7e367e8c) SHA1(161f585dc45665ea77433c84afd2f95049f7f5a0))
+
 	ROM_REGION(0x4000, "os", 0)
 	ROM_COPY("option", 0x40000, 0, 0x4000)
 
-	ROM_REGION(0x20000,"dfs",0) /* DFS ROMS */
-	ROM_LOAD("dfs09.rom",    0x00000, 0x2000, CRC(3ce609cf) SHA1(5cc0f14b8f46855c70eaa653cca4ad079b458732))
-	ROM_RELOAD(              0x02000, 0x2000                )
-
-	ROM_LOAD("dnfs.rom",     0x04000, 0x4000, CRC(8ccd2157) SHA1(7e3c536baeae84d6498a14e8405319e01ee78232))
-	ROM_LOAD("dfs144.rom",   0x08000, 0x4000, CRC(9fb8d13f) SHA1(387d2468c6e1360f5b531784ce95d5f71a50c2b5))
-	ROM_LOAD("zdfs-0.90.rom",0x0C000, 0x2000, CRC(ea579d4d) SHA1(59ad2a8994f4bddad6687891f1a2bc29f2fd32b8))
-	ROM_LOAD("ddfs223.rom",  0x10000, 0x4000, CRC(7891f9b7) SHA1(0d7ed0b0b3852cb61970ada1993244f2896896aa))
-	ROM_LOAD("ddfs-1.53.rom",0x14000, 0x4000, CRC(e1be4ee4) SHA1(6719dc958f2631e6dc8f045429797b289bfe649a))
-	ROM_LOAD("ch103.rom",    0x18000, 0x4000, CRC(98367cf4) SHA1(eca3631aa420691f96b72bfdf2e9c2b613e1bf33))
-	/*NONE*/
-	ROM_REGION(0x80000, "disks", ROMREGION_ERASEFF) /* Opus Ram Disc Space */
+	ROM_REGION(0x8000, "vsm", 0) /* system speech PHROM */
+	ROM_LOAD("phroma.bin", 0x0000, 0x4000, CRC(98e1bf9e) SHA1(b369809275cb67dfd8a749265e91adb2d2558ae6))
 ROM_END
+
 
 ROM_START(bbcb_us)
 	ROM_REGION(0x08000,"maincpu",ROMREGION_ERASEFF) /* RAM */
@@ -1267,34 +1417,24 @@ ROM_START(bbcb_us)
 	/* rom page 9  24000 */
 	/* rom page 10 28000 */
 	/* rom page 11 2c000 */
-	/* rom page 12 30000 */
-	/* rom page 13 34000 */
-	/* rom page 14 38000 */
+	/* rom page 12 30000 SPARE SOCKET */
+	/* rom page 13 34000 SPARE SOCKET */
+	/* rom page 14 38000 DFS */
 	/* rom page 15 3c000 BASIC */
 	ROM_DEFAULT_BIOS("os10b3")
 	ROM_SYSTEM_BIOS( 0, "os10b3", "OS A1.0 / BASIC3" )
 	ROMX_LOAD("os10_us.rom", 0x40000, 0x4000, CRC(c8e946a9) SHA1(83d91d089dca092d2c8b7c3650ff8143c9069b89), ROM_BIOS(1))
 	ROMX_LOAD("basic3.rom",  0x3c000, 0x4000, CRC(161b9539) SHA1(b39014610a968789afd7695aa04d1277d874405c), ROM_BIOS(1)) /* rom page 15 3c000 */
 
+	ROM_LOAD("dfs10.rom",    0x38000, 0x4000, CRC(7e367e8c) SHA1(161f585dc45665ea77433c84afd2f95049f7f5a0))
+
 	ROM_REGION(0x4000, "os", 0)
 	ROM_COPY("option", 0x40000, 0, 0x4000)
-
-	ROM_REGION(0x20000,"dfs",0) /* DFS ROMS */
-	ROM_LOAD("dfs09.rom",    0x00000, 0x2000, CRC(3ce609cf) SHA1(5cc0f14b8f46855c70eaa653cca4ad079b458732))
-	ROM_RELOAD(              0x02000, 0x2000                )
-
-	ROM_LOAD("dnfs.rom",     0x04000, 0x4000, CRC(8ccd2157) SHA1(7e3c536baeae84d6498a14e8405319e01ee78232))
-	ROM_LOAD("dfs144.rom",   0x08000, 0x4000, CRC(9fb8d13f) SHA1(387d2468c6e1360f5b531784ce95d5f71a50c2b5))
-	ROM_LOAD("zdfs-0.90.rom",0x0C000, 0x2000, CRC(ea579d4d) SHA1(59ad2a8994f4bddad6687891f1a2bc29f2fd32b8))
-	ROM_LOAD("ddfs223.rom",  0x10000, 0x4000, CRC(7891f9b7) SHA1(0d7ed0b0b3852cb61970ada1993244f2896896aa))
-	ROM_LOAD("ddfs-1.53.rom",0x14000, 0x4000, CRC(e1be4ee4) SHA1(6719dc958f2631e6dc8f045429797b289bfe649a))
-	ROM_LOAD("ch103.rom",    0x18000, 0x4000, CRC(98367cf4) SHA1(eca3631aa420691f96b72bfdf2e9c2b613e1bf33))
-	/*NONE*/
-	ROM_REGION(0x80000, "disks", ROMREGION_ERASEFF) /* Opus Ram Disc Space */
 
 	ROM_REGION(0x8000, "vsm", 0) /* system speech PHROM */
 	ROM_LOAD("phrom_us.bin", 0x0000, 0x4000, CRC(bf4b3b64) SHA1(66876702d1d95eecc034d20f25047f893a27cde5))
 ROM_END
+
 
 ROM_START(bbcbp)
 	ROM_REGION(0x10000,"maincpu",ROMREGION_ERASEFF) /* ROM MEMORY */
@@ -1309,7 +1449,7 @@ ROM_START(bbcbp)
 	/* rom page 2  08000  32K IN PAGE 3 */
 	/* rom page 3  0c000  SPARE SOCKET */
 	/* rom page 4  10000  32K IN PAGE 5 */
-	/* rom page 5  14000  SPARE SOCKET */
+	/* rom page 5  14000  ADFS */
 	/* rom page 6  18000  32K IN PAGE 7 */
 	/* rom page 7  1c000  DDFS */
 	/* rom page 8  20000  32K IN PAGE 9 */
@@ -1320,11 +1460,14 @@ ROM_START(bbcbp)
 	/* rom page 13 34000 */
 	/* rom page 14 38000  32K IN PAGE 15 */
 	/* rom page 15 3C000  BASIC */
-	/* ddfs 2.23 this is acorns 1770 disc controller Double density disc filing system */
+	ROM_LOAD("adfs130.rom", 0x14000, 0x4000, CRC(d3855588) SHA1(301fd05c475a629c4bec70510d4507256a5b00d8))
 	ROM_LOAD("ddfs223.rom", 0x1c000, 0x4000, CRC(7891f9b7) SHA1(0d7ed0b0b3852cb61970ada1993244f2896896aa))
 
 	ROM_REGION(0x4000, "os", 0)
 	ROM_COPY("option", 0x40000, 0, 0x4000)
+
+	ROM_REGION(0x8000, "vsm", 0) /* system speech PHROM */
+	ROM_LOAD("phroma.bin", 0x0000, 0x4000, CRC(98e1bf9e) SHA1(b369809275cb67dfd8a749265e91adb2d2558ae6))
 ROM_END
 
 
@@ -1341,7 +1484,7 @@ ROM_START(bbcbp128)
 	/* rom page 2  08000  32K IN PAGE 3 */
 	/* rom page 3  0c000  SPARE SOCKET */
 	/* rom page 4  10000  32K IN PAGE 5 */
-	/* rom page 5  14000  SPARE SOCKET */
+	/* rom page 5  14000  ADFS */
 	/* rom page 6  18000  32K IN PAGE 7 */
 	/* rom page 7  1c000  DDFS */
 	/* rom page 8  20000  32K IN PAGE 9 */
@@ -1352,11 +1495,159 @@ ROM_START(bbcbp128)
 	/* rom page 13 34000 */
 	/* rom page 14 38000  32K IN PAGE 15 */
 	/* rom page 15 3C000  BASIC */
-	/* ddfs 2.23 this is acorns 1770 disc controller Double density disc filing system */
+	ROM_LOAD("adfs130.rom", 0x14000, 0x4000, CRC(d3855588) SHA1(301fd05c475a629c4bec70510d4507256a5b00d8))
 	ROM_LOAD("ddfs223.rom", 0x1c000, 0x4000, CRC(7891f9b7) SHA1(0d7ed0b0b3852cb61970ada1993244f2896896aa))
 
 	ROM_REGION(0x4000, "os", 0)
 	ROM_COPY("option", 0x40000, 0, 0x4000)
+
+	ROM_REGION(0x8000, "vsm", 0) /* system speech PHROM */
+	ROM_LOAD("phroma.bin", 0x0000, 0x4000, CRC(98e1bf9e) SHA1(b369809275cb67dfd8a749265e91adb2d2558ae6))
+ROM_END
+
+
+ROM_START(abc110)
+	ROM_REGION(0x10000,"maincpu",ROMREGION_ERASEFF) /* ROM MEMORY */
+
+	ROM_REGION(0x44000,"option",0) /* ROM */
+	ROM_DEFAULT_BIOS("mos200")
+	ROM_SYSTEM_BIOS( 0, "mos200", "MOS2.00" )
+	ROMX_LOAD("mos200.rom", 0x40000, 0x4000, CRC(5e88f994) SHA1(76235ff15d736f5def338f73ac7497c41b916505), ROM_BIOS(1))
+	ROM_SYSTEM_BIOS( 1, "mos123", "MOS1.23" )
+	ROMX_LOAD("mos123.rom", 0x40000, 0x4000, CRC(90d31d08) SHA1(42a01892cf8bd2ada4db1c8b36aff80c85eb5dcb), ROM_BIOS(2))
+	ROM_SYSTEM_BIOS( 2, "mos120", "MOS1.20" )
+	ROMX_LOAD("mos120.rom", 0x40000, 0x4000, CRC(0a1e83a0) SHA1(21dc3a94eef7c003b194686730fb461779f44925), ROM_BIOS(3))
+	/* rom page 0  00000 */
+	/* rom page 1  04000 */
+	/* rom page 2  08000  32K IN PAGE 3 */
+	/* rom page 3  0c000  SPARE SOCKET */
+	/* rom page 4  10000  32K IN PAGE 5 */
+	/* rom page 5  14000  DDFS */
+	/* rom page 6  18000  32K IN PAGE 7 */
+	/* rom page 7  1c000  ADFS */
+	/* rom page 8  20000  32K IN PAGE 9 */
+	/* rom page 9  24000  SPARE SOCKET */
+	/* rom page 10 28000  32K IN PAGE 11 */
+	/* rom page 11 2c000  SPARE SOCKET */
+	/* rom page 12 30000 */
+	/* rom page 13 34000 */
+	/* rom page 14 38000  32K IN PAGE 15 */
+	/* rom page 15 3C000  BASIC */
+	ROM_LOAD("ddfs223.rom", 0x14000, 0x4000, CRC(7891f9b7) SHA1(0d7ed0b0b3852cb61970ada1993244f2896896aa))
+	ROM_LOAD("adfs130.rom", 0x1c000, 0x4000, CRC(d3855588) SHA1(301fd05c475a629c4bec70510d4507256a5b00d8))
+	ROM_LOAD("basic200.rom", 0x3c000, 0x4000, CRC(79434781) SHA1(4a7393f3a45ea309f744441c16723e2ef447a281))
+
+	ROM_REGION(0x4000, "os", 0)
+	ROM_COPY("option", 0x40000, 0, 0x4000)
+
+	ROM_REGION(0x8000, "vsm", 0) /* system speech PHROM */
+	ROM_LOAD("phroma.bin", 0x0000, 0x4000, CRC(98e1bf9e) SHA1(b369809275cb67dfd8a749265e91adb2d2558ae6))
+ROM_END
+
+
+ROM_START(abc210)
+	ROM_REGION(0x10000,"maincpu",ROMREGION_ERASEFF) /* ROM MEMORY */
+
+	ROM_REGION(0x44000,"option",0) /* ROM */
+	ROM_DEFAULT_BIOS("mos200")
+	ROM_SYSTEM_BIOS( 0, "mos200", "MOS2.00" )
+	ROMX_LOAD("mos200.rom", 0x40000, 0x4000, CRC(5e88f994) SHA1(76235ff15d736f5def338f73ac7497c41b916505), ROM_BIOS(1))
+	ROM_SYSTEM_BIOS( 1, "mos123", "MOS1.23" )
+	ROMX_LOAD("mos123.rom", 0x40000, 0x4000, CRC(90d31d08) SHA1(42a01892cf8bd2ada4db1c8b36aff80c85eb5dcb), ROM_BIOS(2))
+	ROM_SYSTEM_BIOS( 2, "mos120", "MOS1.20" )
+	ROMX_LOAD("mos120.rom", 0x40000, 0x4000, CRC(0a1e83a0) SHA1(21dc3a94eef7c003b194686730fb461779f44925), ROM_BIOS(3))
+	/* rom page 0  00000 */
+	/* rom page 1  04000 */
+	/* rom page 2  08000  32K IN PAGE 3 */
+	/* rom page 3  0c000  SPARE SOCKET */
+	/* rom page 4  10000  32K IN PAGE 5 */
+	/* rom page 5  14000  DDFS */
+	/* rom page 6  18000  32K IN PAGE 7 */
+	/* rom page 7  1c000  ADFS */
+	/* rom page 8  20000  32K IN PAGE 9 */
+	/* rom page 9  24000  SPARE SOCKET */
+	/* rom page 10 28000  32K IN PAGE 11 */
+	/* rom page 11 2c000  SPARE SOCKET */
+	/* rom page 12 30000 */
+	/* rom page 13 34000 */
+	/* rom page 14 38000  32K IN PAGE 15 */
+	/* rom page 15 3C000  BASIC */
+	ROM_LOAD("ddfs223.rom",  0x14000, 0x4000, CRC(7891f9b7) SHA1(0d7ed0b0b3852cb61970ada1993244f2896896aa))
+	ROM_LOAD("adfs130.rom",  0x1c000, 0x4000, CRC(d3855588) SHA1(301fd05c475a629c4bec70510d4507256a5b00d8))
+	ROM_LOAD("basic200.rom", 0x3c000, 0x4000, CRC(79434781) SHA1(4a7393f3a45ea309f744441c16723e2ef447a281))
+
+	ROM_REGION(0x4000, "os", 0)
+	ROM_COPY("option", 0x40000, 0, 0x4000)
+
+	ROM_REGION(0x8000, "vsm", 0) /* system speech PHROM */
+	ROM_LOAD("phroma.bin", 0x0000, 0x4000, CRC(98e1bf9e) SHA1(b369809275cb67dfd8a749265e91adb2d2558ae6))
+ROM_END
+
+
+ROM_START(abc310)
+	ROM_REGION(0x10000,"maincpu",ROMREGION_ERASEFF) /* ROM MEMORY */
+
+	ROM_REGION(0x44000,"option",0) /* ROM */
+	ROM_DEFAULT_BIOS("mos200")
+	ROM_SYSTEM_BIOS( 0, "mos200", "MOS2.00" )
+	ROMX_LOAD("mos200.rom", 0x40000, 0x4000, CRC(5e88f994) SHA1(76235ff15d736f5def338f73ac7497c41b916505), ROM_BIOS(1))
+	ROM_SYSTEM_BIOS( 1, "mos123", "MOS1.23" )
+	ROMX_LOAD("mos123.rom", 0x40000, 0x4000, CRC(90d31d08) SHA1(42a01892cf8bd2ada4db1c8b36aff80c85eb5dcb), ROM_BIOS(2))
+	ROM_SYSTEM_BIOS( 2, "mos120", "MOS1.20" )
+	ROMX_LOAD("mos120.rom", 0x40000, 0x4000, CRC(0a1e83a0) SHA1(21dc3a94eef7c003b194686730fb461779f44925), ROM_BIOS(3))
+	/* rom page 0  00000 */
+	/* rom page 1  04000 */
+	/* rom page 2  08000  32K IN PAGE 3 */
+	/* rom page 3  0c000  SPARE SOCKET */
+	/* rom page 4  10000  32K IN PAGE 5 */
+	/* rom page 5  14000  DDFS */
+	/* rom page 6  18000  32K IN PAGE 7 */
+	/* rom page 7  1c000  ADFS */
+	/* rom page 8  20000  32K IN PAGE 9 */
+	/* rom page 9  24000  SPARE SOCKET */
+	/* rom page 10 28000  32K IN PAGE 11 */
+	/* rom page 11 2c000  SPARE SOCKET */
+	/* rom page 12 30000 */
+	/* rom page 13 34000 */
+	/* rom page 14 38000  32K IN PAGE 15 */
+	/* rom page 15 3C000  BASIC */
+	ROM_LOAD("ddfs223.rom",  0x14000, 0x4000, CRC(7891f9b7) SHA1(0d7ed0b0b3852cb61970ada1993244f2896896aa))
+	ROM_LOAD("adfs130.rom",  0x1c000, 0x4000, CRC(d3855588) SHA1(301fd05c475a629c4bec70510d4507256a5b00d8))
+	ROM_LOAD("basic200.rom", 0x3c000, 0x4000, CRC(79434781) SHA1(4a7393f3a45ea309f744441c16723e2ef447a281))
+
+	ROM_REGION(0x4000, "os", 0)
+	ROM_COPY("option", 0x40000, 0, 0x4000)
+
+	ROM_REGION(0x8000, "vsm", 0) /* system speech PHROM */
+	ROM_LOAD("phroma.bin", 0x0000, 0x4000, CRC(98e1bf9e) SHA1(b369809275cb67dfd8a749265e91adb2d2558ae6))
+ROM_END
+
+
+ROM_START(reutapm)
+	ROM_REGION(0x10000,"maincpu",ROMREGION_ERASEFF) /* ROM MEMORY */
+
+	ROM_REGION(0x44000,"option",0) /* ROM */
+	/* rom page 0  00000 */
+	/* rom page 1  04000 */
+	/* rom page 2  08000  32K IN PAGE 3 */
+	/* rom page 3  0c000  SPARE SOCKET */
+	/* rom page 4  10000  32K IN PAGE 5 */
+	/* rom page 5  14000  SPARE SOCKET */
+	/* rom page 6  18000  32K IN PAGE 7 */
+	/* rom page 7  1c000  SPARE SOCKET */
+	/* rom page 8  20000  32K IN PAGE 9 */
+	/* rom page 9  24000  SPARE SOCKET */
+	/* rom page 10 28000  32K IN PAGE 11 */
+	/* rom page 11 2c000  SPARE SOCKET */
+	/* rom page 12 30000 */
+	/* rom page 13 34000 */
+	/* rom page 14 38000  32K IN PAGE 15 */
+	/* rom page 15 3C000  SPARE SOCKET */
+	ROM_LOAD("reutera100.rom", 0x1c000, 0x4000, CRC(98ebabfb) SHA1(a7887e1e5c206203491e1e06682b9508b0fef49d))
+	ROM_LOAD("reuterb.rom",    0x2c000, 0x4000, CRC(9e02f59b) SHA1(1e63aa3bf4b37bf9ba41e454f95db05c3d15bfbf))
+
+	ROM_REGION(0x4000, "os", 0)
+	ROM_LOAD("mos_r030.rom", 0x0000, 0x4000, CRC(8b652337) SHA1(6a5c7ace255c8ac96c983d5ba67084fbd71ff61e))
 ROM_END
 
 
@@ -1480,10 +1771,10 @@ ROM_START(bbcmet)
 	ROM_REGION(0x44000,"option",0) /* ROM */
 	ROM_DEFAULT_BIOS("mos400")
 	ROM_SYSTEM_BIOS( 0, "mos400", "Econet MOS 4.00" )
-	ROMX_LOAD("mos400.ic24", 0x20000, 0x10000, BAD_DUMP CRC(81729034) SHA1(d4bc2c7f5e66b5298786138f395908e70c772971), ROM_BIOS(1)) /* Merged individual ROM bank dumps */
-	ROM_COPY("option", 0x24000, 0x34000, 0xC000) /* Mirror */
-	ROM_COPY("option", 0x20000, 0x40000, 0x4000) /* Move loaded roms into place */
-	ROM_FILL(0x20000, 0x4000, 0xFFFF)
+	ROMX_LOAD("mos400.ic24", 0x30000, 0x10000, BAD_DUMP CRC(81729034) SHA1(d4bc2c7f5e66b5298786138f395908e70c772971), ROM_BIOS(1)) /* Merged individual ROM bank dumps */
+	ROM_COPY("option", 0x34000, 0x24000, 0xC000) /* Mirror */
+	ROM_COPY("option", 0x30000, 0x40000, 0x4000) /* Move loaded roms into place */
+	ROM_FILL(0x30000, 0x4000, 0xFFFF)
 	/* 00000 rom 0   Rear Cartridge bottom 16K */
 	/* 04000 rom 1   Rear Cartridge top 16K */
 	/* 08000 rom 2   Front Cartridge bottom 16K */
@@ -1659,18 +1950,58 @@ ROM_START(bbcmc_ar)
 ROM_END
 
 
-/*     YEAR  NAME      PARENT    COMPAT MACHINE   INPUT CLASS        INIT     COMPANY  FULLNAME */
-COMP ( 1981, bbcb,     0,        bbca,  bbcb,     bbcb, bbc_state,   bbc,     "Acorn", "BBC Micro Model B", 0)
-COMP ( 1981, bbca,     bbcb,     0,     bbca,     bbca, bbc_state,   bbc,     "Acorn", "BBC Micro Model A", 0)
-COMP ( 1981, bbcb_us,  bbcb,     0,     bbcb_us,  bbcb, bbc_state,   bbc,     "Acorn", "Acorn Proton (US)", 0)
-COMP ( 1981, bbcb_de,  bbcb,     0,     bbcb,     bbcb, bbc_state,   bbc,     "Acorn", "BBC Micro Model B (German)", 0)
-COMP ( 1985, bbcbp,    0,        bbcb,  bbcbp,    bbcb, bbc_state,   bbc,     "Acorn", "BBC Micro Model B+ 64K", 0)
-COMP ( 1985, bbcbp128, bbcbp,    0,     bbcbp128, bbcb, bbc_state,   bbc,     "Acorn", "BBC Micro Model B+ 128K", 0)
-COMP ( 1986, bbcm,     0,        bbcb,  bbcm,     bbcm, bbc_state,   bbcm,    "Acorn", "BBC Master 128", 0)
-COMP ( 1986, bbcmt,    bbcm,     0,     bbcmt,    bbcm, bbc_state,   bbcm,    "Acorn", "BBC Master Turbo", MACHINE_NOT_WORKING)
-COMP ( 1986, bbcmaiv,  bbcm,     0,     bbcmaiv,  bbcm, bbc_state,   bbcm,    "Acorn", "BBC Master AIV", MACHINE_NOT_WORKING)
-COMP ( 1986, bbcmet,   bbcm,     0,     bbcmet,   bbcm, bbc_state,   bbcm,    "Acorn", "BBC Master ET", 0)
-COMP ( 1986, bbcm512,  bbcm,     0,     bbcm512,  bbcm, bbc_state,   bbcm,    "Acorn", "BBC Master 512", MACHINE_NOT_WORKING)
-COMP ( 1986, bbcmarm,  bbcm,     0,     bbcmarm,  bbcm, bbc_state,   bbcm,    "Acorn", "ARM Evaluation System", MACHINE_NOT_WORKING)
-COMP ( 1986, bbcmc,    0,        bbcm,  bbcmc,    bbcm, bbc_state,   bbcm,    "Acorn", "BBC Master Compact", 0)
-COMP ( 1986, bbcmc_ar, bbcmc,    0,     bbcmc,    bbcm, bbc_state,   bbcm,    "Acorn", "BBC Master Compact (Arabic)", 0)
+ROM_START(pro128s)
+	ROM_REGION(0x10000, "maincpu", ROMREGION_ERASEFF) /* ROM MEMORY */
+
+	ROM_REGION(0x44000, "option", 0) /* ROM */
+	ROM_DEFAULT_BIOS("mos510o")
+	ROM_SYSTEM_BIOS(0, "mos510o", "Olivetti MOS 5.10")
+	ROMX_LOAD("mos510o.ic49", 0x30000, 0x10000, CRC(c16858d3) SHA1(ad231ed21a55e493b553703285530d1cacd3de7a), ROM_BIOS(1))
+	ROM_COPY("option", 0x30000, 0x40000, 0x4000) /* Move loaded roms into place */
+	ROM_FILL(0x30000, 0x4000, 0xFFFF)
+	/* 00000 rom 0   EXTERNAL */
+	/* 04000 rom 1   EXTERNAL */
+	/* 08000 rom 2   SPARE SOCKET */
+	/* 0c000 rom 3   SPARE SOCKET */
+	/* 10000 rom 4   SWRAM */
+	/* 14000 rom 5   SWRAM */
+	/* 18000 rom 6   SWRAM */
+	/* 1c000 rom 7   SWRAM */
+	/* 20000 rom 8   SPARE SOCKET */
+	/* 24000 rom 9   UNUSED */
+	/* 28000 rom 10  UNUSED */
+	/* 2c000 rom 11  UNUSED */
+	/* 30000 rom 12  UNUSED */
+	/* 34000 rom 13  ADFS */
+	/* 38000 rom 14  BASIC */
+	/* 3c000 rom 15  Utils */
+
+	ROM_REGION(0x4000, "os", 0)
+	ROM_COPY("option", 0x40000, 0, 0x4000)
+
+	//  ROM_REGION(0x80,"eeprom",0) /* pcd8572 */
+	/* Factory defaulted EEPROM, sets default language ROM, etc. */
+	//  ROM_LOAD("mos510o.epr", 0x00, 0x80, CRC(d8458039) SHA1(72c056d493e74ceca41f48936012b012b496a226))
+ROM_END
+
+/*     YEAR  NAME      PARENT    COMPAT MACHINE   INPUT  CLASS        INIT     COMPANY     FULLNAME                         FLAGS */
+COMP ( 1981, bbcb,     0,        bbca,  bbcb,     bbcb,  bbc_state,   bbc,     "Acorn",    "BBC Micro Model B w/8271 FDC",  MACHINE_IMPERFECT_GRAPHICS)
+COMP ( 1981, bbca,     bbcb,     0,     bbca,     bbca,  bbc_state,   bbc,     "Acorn",    "BBC Micro Model A",             MACHINE_IMPERFECT_GRAPHICS)
+COMP ( 1981, bbcb_de,  bbcb,     0,     bbcb_de,  bbcb,  bbc_state,   bbc,     "Acorn",    "BBC Micro Model B (German)",    MACHINE_IMPERFECT_GRAPHICS)
+COMP ( 1983, bbcb_us,  bbcb,     0,     bbcb_us,  bbcb,  bbc_state,   bbc,     "Acorn",    "BBC Micro Model B (US)",        MACHINE_IMPERFECT_GRAPHICS)
+COMP ( 1985, bbcb1770, bbcb,     0,     bbcb1770, bbcb,  bbc_state,   bbc,     "Acorn",    "BBC Micro Model B w/1770 FDC",  MACHINE_IMPERFECT_GRAPHICS)
+COMP ( 1985, bbcbp,    0,        bbcb,  bbcbp,    bbcb,  bbc_state,   bbc,     "Acorn",    "BBC Micro Model B+ 64K",        MACHINE_IMPERFECT_GRAPHICS)
+COMP ( 1985, bbcbp128, bbcbp,    0,     bbcbp128, bbcb,  bbc_state,   bbc,     "Acorn",    "BBC Micro Model B+ 128K",       MACHINE_IMPERFECT_GRAPHICS)
+COMP ( 1985, abc110,   abc210,   0,     abc110,   abc,   bbc_state,   bbc,     "Acorn",    "ABC 110",                       MACHINE_NOT_WORKING)
+COMP ( 1985, abc210,   0,        0,     abc210,   abc,   bbc_state,   bbc,     "Acorn",    "ABC 210/Cambridge Workstation", MACHINE_NOT_WORKING)
+COMP ( 1985, abc310,   abc210,   0,     abc310,   abc,   bbc_state,   bbc,     "Acorn",    "ABC 310",                       MACHINE_NOT_WORKING)
+COMP ( 1985, reutapm,  0,        0,     reutapm,  bbcb,  bbc_state,   bbc,     "Acorn",    "Reuters APM",                   MACHINE_NO_SOUND | MACHINE_NOT_WORKING)
+COMP ( 1986, bbcm,     0,        bbcb,  bbcm,     bbcm,  bbc_state,   bbc,     "Acorn",    "BBC Master 128",                MACHINE_IMPERFECT_GRAPHICS)
+COMP ( 1986, bbcmt,    bbcm,     0,     bbcmt,    bbcm,  bbc_state,   bbc,     "Acorn",    "BBC Master Turbo",              MACHINE_NOT_WORKING)
+COMP ( 1986, bbcmaiv,  bbcm,     0,     bbcmaiv,  bbcm,  bbc_state,   bbc,     "Acorn",    "BBC Master AIV",                MACHINE_NOT_WORKING)
+COMP ( 1986, bbcmet,   bbcm,     0,     bbcmet,   bbcm,  bbc_state,   bbc,     "Acorn",    "BBC Master ET",                 MACHINE_NO_SOUND | MACHINE_IMPERFECT_GRAPHICS)
+COMP ( 1986, bbcm512,  bbcm,     0,     bbcm512,  bbcm,  bbc_state,   bbc,     "Acorn",    "BBC Master 512",                MACHINE_NOT_WORKING)
+COMP ( 1986, bbcmarm,  bbcm,     0,     bbcmarm,  bbcm,  bbc_state,   bbc,     "Acorn",    "ARM Evaluation System",         MACHINE_NOT_WORKING)
+COMP ( 1986, bbcmc,    0,        bbcm,  bbcmc,    bbcm,  bbc_state,   bbc,     "Acorn",    "BBC Master Compact",            MACHINE_IMPERFECT_GRAPHICS)
+COMP ( 1986, bbcmc_ar, bbcmc,    0,     bbcmc,    bbcm,  bbc_state,   bbc,     "Acorn",    "BBC Master Compact (Arabic)",   MACHINE_IMPERFECT_GRAPHICS)
+COMP ( 1987, pro128s,  bbcmc,    0,     pro128s,  bbcm,  bbc_state,   bbc,     "Olivetti", "Prodest PC 128S",               MACHINE_IMPERFECT_GRAPHICS)

--- a/src/mess/video/bbc.c
+++ b/src/mess/video/bbc.c
@@ -99,8 +99,7 @@ static const int width_of_cursor_set[8]={ 0,0,1,2,1,0,2,4 };
    this is used by the palette lookup in the video ULA */
 void bbc_state::set_pixel_lookup()
 {
-	int i;
-	for (i=0; i<256; i++)
+	for (int i=0; i<256; i++)
 	{
 		m_pixel_bits[i] = (((i>>7)&1)<<3) | (((i>>5)&1)<<2) | (((i>>3)&1)<<1) | (((i>>1)&1)<<0);
 	}
@@ -254,37 +253,6 @@ WRITE_LINE_MEMBER(bbc_state::bbc_vsync)
 	m_trom->dew_w(state);
 }
 
-/************************************************************************
- * memory interface to BBC's 6845
- ************************************************************************/
-
-WRITE8_MEMBER(bbc_state::bbc_6845_w)
-{
-	switch(offset & 1)
-	{
-		case 0 :
-			m_mc6845->address_w(space,0,data);
-			break;
-		case 1 :
-			m_mc6845->register_w(space,0,data);
-			break;
-	}
-	return;
-}
-
-READ8_MEMBER(bbc_state::bbc_6845_r)
-{
-	switch (offset&1)
-	{
-		case 0: return m_mc6845->status_r(space,0);
-		case 1: return m_mc6845->register_r(space,0);
-	}
-	return 0;
-}
-
-
-
-
 
 /**** BBC B+ Shadow Ram change ****/
 
@@ -319,7 +287,7 @@ void bbc_state::common_init(int memorySize)
 
 VIDEO_START_MEMBER(bbc_state,bbca)
 {
-	common_init(16);
+	common_init(m_ram->size()/1024);
 }
 
 VIDEO_START_MEMBER(bbc_state,bbcb)


### PR DESCRIPTION
- Added clone bbcb1770, bbcb now 8271 only.
- Added clone pro128s, Olivetti Prodest PC 128S.
- Added clones Acorn Business Computers and Cambridge Workstation.
- Added clone reutapm, Reuters APM board.
- Improved floppy formats, added dsd and double density formats for ADFS.
- Added speech PHROMs, not yet hooked up correctly.
- Added softlists bbcb_de_cass, bbcb_us_flop and bbcmc_flop.
- Added S11 links (dipswitch) to specify Econet ID.
- Address map cleanups.