### PR TITLE
fix for FM-Towns clock, minor fixes

### DIFF
--- a/src/emu/machine.c
+++ b/src/emu/machine.c
@@ -339,7 +339,7 @@ int running_machine::run(bool firstrun)
 		m_current_phase = MACHINE_PHASE_INIT;
 
 		// if we have a logfile, set up the callback
-		if (options().log())
+		if (options().log() && &system() != &GAME_NAME(___empty))
 		{
 			m_logfile.reset(global_alloc(emu_file(OPEN_FLAG_WRITE | OPEN_FLAG_CREATE | OPEN_FLAG_CREATE_PATHS)));
 			file_error filerr = m_logfile->open("error.log");

--- a/src/emu/sound.c
+++ b/src/emu/sound.c
@@ -835,7 +835,7 @@ sound_manager::sound_manager(running_machine &machine)
 #endif
 
 	// open the output WAV file if specified
-	if (wavfile[0] != 0)
+	if (wavfile[0] != 0 && &machine.system() != &GAME_NAME(___empty))
 		m_wavfile = wav_open(wavfile, machine.sample_rate(), 2);
 
 	// register callbacks

--- a/src/mame/drivers/xorworld.c
+++ b/src/mame/drivers/xorworld.c
@@ -171,8 +171,11 @@ static MACHINE_CONFIG_START( xorworld, xorworld_state )
 	// basic machine hardware
 	MCFG_CPU_ADD("maincpu", M68000, 10000000)   // 10 MHz
 	MCFG_CPU_PROGRAM_MAP(xorworld_map)
-	MCFG_CPU_VBLANK_INT_DRIVER("screen", xorworld_state, irq6_line_assert) // irq 4 or 6
-	MCFG_CPU_PERIODIC_INT_DRIVER(xorworld_state, irq2_line_assert, 3*60) //timed irq, unknown timing
+	//MCFG_CPU_VBLANK_INT_DRIVER("screen", xorworld_state, irq6_line_assert) // irq 4 or 6
+	//MCFG_CPU_PERIODIC_INT_DRIVER(xorworld_state, irq2_line_assert, 3*60) //timed irq, unknown timing
+	// Simple fix - but this sounds good!! -Valley Bell
+	MCFG_CPU_VBLANK_INT_DRIVER("screen", xorworld_state, irq2_line_assert) // irq 4 or 6
+	MCFG_CPU_PERIODIC_INT_DRIVER(xorworld_state, irq6_line_assert, 3*60) //timed irq, unknown timing
 
 	MCFG_QUANTUM_TIME(attotime::from_hz(60))
 

--- a/src/mess/drivers/fmtowns.c
+++ b/src/mess/drivers/fmtowns.c
@@ -2696,11 +2696,11 @@ static MACHINE_CONFIG_FRAGMENT( towns_base )
 
 	/* sound hardware */
 	MCFG_SPEAKER_STANDARD_MONO("mono")
-	MCFG_SOUND_ADD("fm", YM3438, 53693100 / 7) // actual clock speed unknown
+	MCFG_SOUND_ADD("fm", YM3438, 16000000 / 2) // actual clock speed unknown
 	MCFG_YM2612_IRQ_HANDLER(WRITELINE(towns_state, towns_fm_irq))
 	MCFG_SOUND_ROUTE(ALL_OUTPUTS, "mono", 0.50)
 
-	MCFG_RF5C68_ADD("pcm", 53693100 / 7)  // actual clock speed unknown
+	MCFG_RF5C68_ADD("pcm", 16000000 / 2)  // actual clock speed unknown
 	MCFG_RF5C68_SAMPLE_END_CB(towns_state, towns_pcm_irq)
 	MCFG_SOUND_ROUTE(ALL_OUTPUTS, "mono", 1.50)
 	MCFG_SOUND_ADD("cdda",CDDA,0)


### PR DESCRIPTION
repost of parts of an earlier pull request
- There is a small fix for the FM-Towns clock posted by the people on the vgmrips forum. (The original code used the Sega MegaCD clock.)
- The interrupts for Xor World are pure guesswork, but it makes the game run at a playable speed (instead of insanely fast) and the music/sfx aren't way too slow anymore.
- I added a few checks to prevent MAME's main menu from overwriting wavelog + error.log.
