### PR TITLE
Fix build with Xcode 7

### DIFF
--- a/makefile
+++ b/makefile
@@ -718,19 +718,17 @@ CHECK_CLANG      :=
 else
 GCC_VERSION      := $(shell $(subst @,,$(CC)) -dumpversion 2> /dev/null)
 ifneq ($(OS),solaris)
-CLANG_VERSION    := $(shell clang --version  2> /dev/null | head -n 1 | grep '[0-9]\.[0-9]' -o | tail -n 1)
+CLANG_VERSION    := $(shell clang --version  2> /dev/null | head -n 1 | grep -e 'version [0-9]\.[0-9]\(\.[0-9]\)\?' -o | grep -e '[0-9]\.[0-9]\(\.[0-9]\)\?' -o | tail -n 1)
 endif
 PYTHON_AVAILABLE := $(shell $(PYTHON) --version > /dev/null 2>&1 && echo python)
 CHECK_CLANG      := $(shell gcc --version  2> /dev/null | grep 'clang' | head -n 1)
 endif
 
 ifeq ($(TARGETOS),macosx)
-ifneq (,$(findstring 3.,$(CLANG_VERSION)))
 ifeq ($(ARCHITECTURE),_x64)
 ARCHITECTURE := _x64_clang
 else
 ARCHITECTURE := _x86_clang
-endif
 endif
 endif
 

--- a/scripts/genie.lua
+++ b/scripts/genie.lua
@@ -1000,6 +1000,11 @@ end
 					"-Wno-extern-c-compat",
 				}
 			end
+      if (version >= 70000) then
+        buildoptions {
+          "-Wno-tautological-undefined-compare",
+        }
+      end
 		else
 			if (version == 40201) then
 				buildoptions {

--- a/src/osd/modules/debugger/osx/debugview.m
+++ b/src/osd/modules/debugger/osx/debugview.m
@@ -404,7 +404,7 @@ static void debugwin_view_update(debug_view &view, void *osdprivate)
 	[text addAttribute:NSFontAttributeName value:font range:run];
 	NSPasteboard *const board = [NSPasteboard generalPasteboard];
 	[board declareTypes:[NSArray arrayWithObject:NSRTFPboardType] owner:nil];
-	[board setData:[text RTFFromRange:run documentAttributes:nil] forType:NSRTFPboardType];
+	[board setData:[text RTFFromRange:run documentAttributes:@{}] forType:NSRTFPboardType];
 	[text deleteCharactersInRange:run];
 }
 

--- a/src/osd/modules/debugger/osx/pointsviewer.m
+++ b/src/osd/modules/debugger/osx/pointsviewer.m
@@ -74,7 +74,7 @@
 	[breakScroll setBorderType:NSNoBorder];
 	[breakScroll setDocumentView:breakView];
 	[breakView release];
-	breakTab = [[NSTabViewItem alloc] initWithIdentifier:nil];
+	breakTab = [[NSTabViewItem alloc] initWithIdentifier:@""];
 	[breakTab setView:breakScroll];
 	[breakScroll release];
 
@@ -89,7 +89,7 @@
 	[watchScroll setBorderType:NSNoBorder];
 	[watchScroll setDocumentView:watchView];
 	[watchView release];
-	watchTab = [[NSTabViewItem alloc] initWithIdentifier:nil];
+	watchTab = [[NSTabViewItem alloc] initWithIdentifier:@""];
 	[watchTab setView:watchScroll];
 	[watchScroll release];
 


### PR DESCRIPTION
Xcode 7 changes Clang version numbering to 7.0.0. Apple has also added additional null-checking, and the documentation for those calls has not yet been updated. This allows for clean build on 10.11 with Xcode 7.

I am not certain about the purpose of https://github.com/mamedev/mame/pull/332/files#diff-cd5dbf3629c558b0104ba8f0937d6816L728 , which looks for 3. in the Clang version number. This doesn't work anymore because Clang is now version 7.0.0.