### PR TITLE
Code Enhancements

### DIFF
--- a/src/emu/machine.c
+++ b/src/emu/machine.c
@@ -1351,12 +1351,12 @@ void system_time::full_time::set(struct tm &t)
 
 static running_machine * jsmess_machine;
 
-void js_main_loop() {
-	device_scheduler * scheduler;
-	scheduler = &(jsmess_machine->scheduler());
-	attotime stoptime = scheduler->time() + attotime(0,HZ_TO_ATTOSECONDS(60));
-	while (scheduler->time() < stoptime) {
-		scheduler->timeslice();
+void js_main_loop()
+{
+	attotime stoptime(jsmess_machine->scheduler().time() + attotime(0,HZ_TO_ATTOSECONDS(60)));
+	while (jsmess_machine->scheduler().time()) < stoptime)
+	{
+		jsmess_machine->scheduler().timeslice();
 	}
 }
 

--- a/src/emu/schedule.c
+++ b/src/emu/schedule.c
@@ -434,7 +434,7 @@ void device_scheduler::timeslice()
 	while (m_basetime < m_timer_list->m_expire)
 	{
 		// by default, assume our target is the end of the next quantum
-		attotime target = m_basetime + attotime(0, m_quantum_list.first()->m_actual);
+		attotime target(m_basetime + attotime(0, m_quantum_list.first()->m_actual));
 
 		// however, if the next timer is going to fire before then, override
 		if (m_timer_list->m_expire < target)


### PR DESCRIPTION
No real need for an extra pointer here "device_scheduler * scheduler", only makes the code more cryptic with no real gain in performance.
Removed the assignment steps by initializing the objects with the values intended, at "attotime stoptime" and "attotime target".