### PR TITLE
VI timing period is now set dynamically from the VI registers.

### DIFF
--- a/src/mame/video/n64.c
+++ b/src/mame/video/n64.c
@@ -212,11 +212,11 @@ void n64_periphs::video_update16(bitmap_rgb32 &bitmap)
 		return;
 	}
 
-	if (hres > 640) // Needed by Top Gear Overdrive (E)
-	{
-		invisiblewidth += (hres - 640);
-		hres = 640;
-	}
+	//if (hres > 640) // Needed by Top Gear Overdrive (E)
+	//{
+	//	invisiblewidth += (hres - 640);
+	//	hres = 640;
+	//}
 
 	if (vres > bitmap.height()) // makes Perfect Dark boot w/o crashing
 	{
@@ -241,7 +241,7 @@ void n64_periphs::video_update16(bitmap_rgb32 &bitmap)
 				d[i] = (r << 16) | (g << 8) | b;
 				pixels++;
 			}
-			pixels +=invisiblewidth;
+			pixels += invisiblewidth;
 		}
 	}
 }
@@ -268,11 +268,11 @@ void n64_periphs::video_update32(bitmap_rgb32 &bitmap)
 		return;
 	}
 
-	if (hres > 640) // Needed by Top Gear Overdrive (E)
-	{
-		invisiblewidth += (hres - 640);
-		hres = 640;
-	}
+	//if (hres > 640) // Needed by Top Gear Overdrive (E)
+	//{
+	//	invisiblewidth += (hres - 640);
+	//	hres = 640;
+	//}
 
 	if (frame_buffer32)
 	{

--- a/src/mess/drivers/n64.c
+++ b/src/mess/drivers/n64.c
@@ -411,10 +411,12 @@ static MACHINE_CONFIG_START( n64, n64_mess_state )
 
 	/* video hardware */
 	MCFG_SCREEN_ADD("screen", RASTER)
-	MCFG_SCREEN_REFRESH_RATE(60)
+	/* Video DACRATE is for quarter pixels, so the horizontal is also given in quarter pixels.  However, the horizontal and vertical timing and sizing is adjustable by register and will be reset when the registers are written. */
+	MCFG_SCREEN_RAW_PARAMS(DACRATE_NTSC,3093,0,3093,525,0,525)
+	//MCFG_SCREEN_REFRESH_RATE(60)
 	//MCFG_SCREEN_VBLANK_TIME(ATTOSECONDS_IN_USEC(0))
-	MCFG_SCREEN_SIZE(640, 525)
-	MCFG_SCREEN_VISIBLE_AREA(0, 639, 0, 479)
+	//MCFG_SCREEN_SIZE(640, 525)
+	//MCFG_SCREEN_VISIBLE_AREA(0, 639, 0, 479)
 	MCFG_SCREEN_UPDATE_DRIVER(n64_state, screen_update_n64)
 	MCFG_SCREEN_VBLANK_DRIVER(n64_state, screen_eof_n64)
 


### PR DESCRIPTION
VI timing should now be accurate (for NTSC)