### PR TITLE
Added overlooked factor of 2 to VI timing to account for vertical res…

### DIFF
--- a/src/devices/cpu/rsp/rsp_dasm.c
+++ b/src/devices/cpu/rsp/rsp_dasm.c
@@ -8,12 +8,21 @@
 
 #include "emu.h"
 
-static const char *const reg[32] =
+/*static const char *const reg[32] =
 {
 	"0",    "r1",   "r2",   "r3",   "r4",   "r5",   "r6",   "r7",
 	"r8",   "r9",   "r10",  "r11",  "r12",  "r13",  "r14",  "r15",
 	"r16",  "r17",  "r18",  "r19",  "r20",  "r21",  "r22",  "r23",
 	"r24",  "r25",  "r26",  "r27",  "r28",  "r29",  "r30",  "r31"
+};
+*/
+
+static const char *const reg[32] =
+{
+	"$0",   "$at",  "$v0",  "$v1",  "$a0",  "$a1",  "$a2",  "$a3",
+	"$t0",  "$t1",  "$t2",  "$t3",  "$t4",  "$t5",  "$t6",  "$t7",
+	"$s0",  "$s1",  "$s2",  "$s3",  "$s4",  "$s5",  "$s6",  "$s7",
+	"$t8",  "$t9",  "$k0",  "$k1",  "$gp",  "$sp",  "$fp",  "$ra"
 };
 
 static const char *const vreg[32] =

--- a/src/mame/includes/n64.h
+++ b/src/mame/includes/n64.h
@@ -311,6 +311,7 @@ extern const device_type N64PERIPH;
 #define DP_STATUS_XBUS_DMA      0x01
 #define DP_STATUS_FREEZE        0x02
 #define DP_STATUS_FLUSH         0x04
+#define DP_STATUS_START_VALID	0x400
 
 #define DD_ASIC_STATUS_DISK_CHANGE   0x00010000
 #define DD_ASIC_STATUS_MECHA_ERR     0x00020000

--- a/src/mess/drivers/n64.c
+++ b/src/mess/drivers/n64.c
@@ -406,13 +406,13 @@ static MACHINE_CONFIG_START( n64, n64_mess_state )
 	MCFG_RSP_SP_SET_STATUS_CB(DEVWRITE32("rcp",n64_periphs, sp_set_status))
 	MCFG_CPU_PROGRAM_MAP(rsp_map)
 
-	//MCFG_QUANTUM_TIME(attotime::from_hz(1000000))
-	MCFG_QUANTUM_TIME(attotime::from_hz(1200))
+	MCFG_QUANTUM_TIME(attotime::from_hz(1000000))
+	//MCFG_QUANTUM_TIME(attotime::from_hz(1200))
 
 	/* video hardware */
 	MCFG_SCREEN_ADD("screen", RASTER)
 	/* Video DACRATE is for quarter pixels, so the horizontal is also given in quarter pixels.  However, the horizontal and vertical timing and sizing is adjustable by register and will be reset when the registers are written. */
-	MCFG_SCREEN_RAW_PARAMS(DACRATE_NTSC,3093,0,3093,525,0,525)
+	MCFG_SCREEN_RAW_PARAMS(DACRATE_NTSC*2,3093,0,3093,525,0,525)
 	//MCFG_SCREEN_REFRESH_RATE(60)
 	//MCFG_SCREEN_VBLANK_TIME(ATTOSECONDS_IN_USEC(0))
 	//MCFG_SCREEN_SIZE(640, 525)


### PR DESCRIPTION
…olution being set in half-lines.

Changed rsp disassembly to use MIPS ABI names for registers.
Implemented 'start valid' bit in RDP status register.
Increased scheduler quantum time to allow for better r4300 <-> RSP signaling.