### PR TITLE
Fix reversion for PI.  PI transfers round length up, not down.

### DIFF
--- a/src/mame/includes/n64.h
+++ b/src/mame/includes/n64.h
@@ -117,6 +117,7 @@ public:
 	UINT32 vi_leap;
 	UINT32 vi_intr;
 	UINT32 vi_vburst;
+	UINT8 field;
 
 	/* nvram-specific for MESS */
 	device_t *m_nvram_image;

--- a/src/mame/machine/n64.c
+++ b/src/mame/machine/n64.c
@@ -1057,10 +1057,6 @@ void n64_periphs::vi_recalculate_resolution()
 	if (height > 480)
 		height = 480;
 
-	if(vi_control & 0x40) /* Interlace */
-	{
-	}
-
 	visarea.max_x = width - 1;
 	visarea.max_y = height - 1;
 	m_screen->configure((vi_hsync & 0x00000fff)>>2, (vi_vsync & 0x00000fff), visarea, period);
@@ -1088,7 +1084,7 @@ READ32_MEMBER( n64_periphs::vi_reg_r )
 			break;
 
 		case 0x10/4:        // VI_CURRENT_REG
-			ret = (m_screen->vpos() & 0x3FE); // << 1);
+			ret = (m_screen->vpos() & 0x3FE) + field; // << 1);
 			break;
 
 		case 0x14/4:        // VI_BURST_REG
@@ -1461,7 +1457,7 @@ void n64_periphs::pi_dma_tick()
 
 	if(pi_dma_dir == 1)
 	{
-		UINT32 dma_length = pi_wr_len + 1;
+		UINT32 dma_length = pi_wr_len + 1 + 1; //Round Up Nearest 2
 		//logerror("PI Write, %X, %X, %X\n", pi_cart_addr, pi_dram_addr, pi_wr_len);
 
 		if (pi_dram_addr != 0xffffffff)
@@ -1477,7 +1473,7 @@ void n64_periphs::pi_dma_tick()
 	}
 	else
 	{
-		UINT32 dma_length = pi_rd_len + 1;
+		UINT32 dma_length = pi_rd_len + 1 + 1; //Round Up Nearest 2
 		//logerror("PI Read, %X, %X, %X\n", pi_cart_addr, pi_dram_addr, pi_rd_len);
 
 		if (pi_dram_addr != 0xffffffff)

--- a/src/mame/video/n64.c
+++ b/src/mame/video/n64.c
@@ -168,6 +168,15 @@ void n64_state::screen_eof_n64(screen_device &screen, bool state)
 
 void n64_periphs::video_update(bitmap_rgb32 &bitmap)
 {
+	if(vi_control & 0x40) /* Interlace */
+	{
+		field ^= 1;
+	}
+	else
+	{
+		field = 1;
+	}
+
 	switch(vi_control & 0x3)
 	{
 		case PIXEL_SIZE_16BIT:


### PR DESCRIPTION
Add field for VI interlaced modes.  Display of interlaced video still needs work.