### PR TITLE
(1942p) [unconfirmed] XTALs (spcwarp) seperate memory map, add more info

### DIFF
--- a/src/mame/drivers/1942.c
+++ b/src/mame/drivers/1942.c
@@ -64,6 +64,10 @@ correctly.
 #define MAIN_CPU_CLOCK      (XTAL_12MHz/3) /* 12MHz is the only OSC on the PCB */
 #define SOUND_CPU_CLOCK     (XTAL_12MHz/4) /* 12MHz is the only OSC on the PCB */
 #define AUDIO_CLOCK     (XTAL_12MHz/8) /* 12MHz is the only OSC on the PCB */
+/* this is a wild guess but according to a pcb video it has a similar crystal */
+#define MAIN_CPU_CLOCK_1942P      (XTAL_12_432MHz/3)
+#define SOUND_CPU_CLOCK_1942P     (XTAL_12_432MHz/4)
+#define AUDIO_CLOCK_1942P     (XTAL_12_432MHz/10)
 
 #include "emu.h"
 #include "cpu/z80/z80.h"
@@ -620,11 +624,11 @@ MACHINE_CONFIG_END
 static MACHINE_CONFIG_START( 1942p, _1942_state )
 
 	/* basic machine hardware */
-	MCFG_CPU_ADD("maincpu", Z80, MAIN_CPU_CLOCK)    /* 4 MHz ??? */
+	MCFG_CPU_ADD("maincpu", Z80, MAIN_CPU_CLOCK_1942P)    /* ??? */
 	MCFG_CPU_PROGRAM_MAP(c1942p_map)
 	MCFG_CPU_VBLANK_INT_DRIVER("screen", _1942_state,  irq0_line_hold) // note, powerups won't move down the screen with the original '1942' logic.
 
-	MCFG_CPU_ADD("audiocpu", Z80, SOUND_CPU_CLOCK)  /* 3 MHz ??? */
+	MCFG_CPU_ADD("audiocpu", Z80, SOUND_CPU_CLOCK_1942P)  /* ??? */
 	MCFG_CPU_PROGRAM_MAP(c1942p_sound_map)
 	MCFG_CPU_IO_MAP(c1942p_sound_io)
 	MCFG_CPU_PERIODIC_INT_DRIVER(_1942_state, irq0_line_hold, 4*60)
@@ -650,9 +654,9 @@ static MACHINE_CONFIG_START( 1942p, _1942_state )
 	/* sound hardware */
 	MCFG_SPEAKER_STANDARD_MONO("mono")
 
-	MCFG_SOUND_ADD("ay1", AY8910, AUDIO_CLOCK)  /* 1.5 MHz */
+	MCFG_SOUND_ADD("ay1", AY8910, AUDIO_CLOCK_1942P) /* unconfirmed but matches PCB video */
 	MCFG_SOUND_ROUTE(ALL_OUTPUTS, "mono", 0.25)
-	MCFG_SOUND_ADD("ay2", AY8910, AUDIO_CLOCK)  /* 1.5 MHz */
+	MCFG_SOUND_ADD("ay2", AY8910, AUDIO_CLOCK_1942P) /* unconfirmed but matches PCB video */
 	MCFG_SOUND_ROUTE(ALL_OUTPUTS, "mono", 0.25)
 MACHINE_CONFIG_END
 

--- a/src/mame/drivers/galaxold.c
+++ b/src/mame/drivers/galaxold.c
@@ -3489,13 +3489,15 @@ ROM_START( hunchbkg )
 ROM_END
 
 ROM_START( spcwarp )
+	// unknown Century Electronics space shooter which involves shooting down enemy ships to use them yourself for increasing rate of fire
+	// came out of an undumped ROMS collection - we have no idea if this is Space Warp but it's a unique dump compared to everything else.
 	ROM_REGION( 0x8000, "maincpu", 0 )
 	ROM_LOAD( "swarpt7f.bin", 0x0000, 0x1000, CRC(04d744e3) SHA1(db8218510052a05670cb0b722b73d3f10464788c) )
 	ROM_LOAD( "swarpt7h.bin", 0x2000, 0x1000, CRC(34a36536) SHA1(bc438515618683b2a7c29637871ee00ed95ad7f8) )
 	/* missing rom at $4000? todo: check valid calls */
 	ROM_LOAD( "swarpt7m.bin", 0x6000, 0x1000, BAD_DUMP CRC(a2dff6c8) SHA1(d1c72848450dc5ff386dc94a26e4bf704ccc7121) ) /* ROMCMP reports "BADADDR            xxxxxx-xxxxx".  Observed data sequence repeated every 32 bytes */
 
-	ROM_REGION( 0x1000, "gfx1", 0 ) // gfx are very similar to 'cosmos' so I think it's a converion of that to Galaxian HW, maybe under the title Space Warp.
+	ROM_REGION( 0x1000, "gfx1", 0 ) // gfx are very similar to 'cosmos'
 	ROM_LOAD( "swarpb1h.bin", 0x0000, 0x0800, CRC(6ee3b5f7) SHA1(8150f2ecd59d3a165c0541b550664c56d049edd5) )
 	ROM_LOAD( "swarpb1k.bin", 0x0800, 0x0800, CRC(da4cee6b) SHA1(28b91381658f598fa62049489beee443232825c6) )
 

--- a/src/mame/drivers/galaxold.c
+++ b/src/mame/drivers/galaxold.c
@@ -361,7 +361,6 @@ Stephh's notes (based on the games Z80 code and some tests) for other games :
     to 0x00, so routine at 0x042a ALWAYS thinks that you've pressed COIN2,
     and as a consequence, it ALWAYS adds 1 credit (even when you are playing) !
 
-
 ***************************************************************************/
 
 #include "emu.h"
@@ -898,6 +897,36 @@ static ADDRESS_MAP_START( hunchbkg, AS_PROGRAM, 8, galaxold_state )
 	AM_RANGE(0x1800, 0x1bff) AM_MIRROR(0x6000) AM_WRITE(galaxold_videoram_w) AM_SHARE("videoram")
 	AM_RANGE(0x1c00, 0x1fff) AM_MIRROR(0x6000) AM_RAM
 	AM_RANGE(0x2000, 0x2fff) AM_ROM
+	AM_RANGE(0x4000, 0x4fff) AM_ROM
+	AM_RANGE(0x6000, 0x6fff) AM_ROM
+ADDRESS_MAP_END
+
+/* wrong but similar style to hunchbkg */
+static ADDRESS_MAP_START( spcwarp, AS_PROGRAM, 8, galaxold_state )
+	AM_RANGE(0x0000, 0x0fff) AM_ROM
+	AM_RANGE(0x1480, 0x14bf) AM_MIRROR(0x6000) AM_RAM_WRITE(galaxold_attributesram_w) AM_SHARE("attributesram")
+	AM_RANGE(0x14c0, 0x14ff) AM_MIRROR(0x6000) AM_WRITEONLY AM_SHARE("spriteram")
+	AM_RANGE(0x1500, 0x1500) AM_MIRROR(0x6000) AM_READ_PORT("IN0")
+	AM_RANGE(0x1500, 0x1501) AM_MIRROR(0x6000) AM_WRITE(galaxold_leds_w)            /* not connected ... */
+	AM_RANGE(0x1502, 0x1502) AM_MIRROR(0x6000) AM_WRITE(galaxold_coin_lockout_w)    /* not connected ... */
+	AM_RANGE(0x1503, 0x1503) AM_MIRROR(0x6000) AM_WRITE(galaxold_coin_counter_w)
+	AM_RANGE(0x1504, 0x1507) AM_MIRROR(0x6000) AM_DEVWRITE("cust", galaxian_sound_device, lfo_freq_w)
+	AM_RANGE(0x1580, 0x1580) AM_MIRROR(0x6000) AM_READ_PORT("IN1")
+	AM_RANGE(0x1580, 0x1587) AM_MIRROR(0x6000) AM_DEVWRITE("cust", galaxian_sound_device, sound_w)
+	AM_RANGE(0x1583, 0x1583) AM_MIRROR(0x6000) AM_DEVWRITE("cust", galaxian_sound_device, noise_enable_w)
+	AM_RANGE(0x1585, 0x1585) AM_MIRROR(0x6000) AM_DEVWRITE("cust", galaxian_sound_device, fire_enable_w)
+	AM_RANGE(0x1586, 0x1587) AM_MIRROR(0x6000) AM_DEVWRITE("cust", galaxian_sound_device, vol_w)
+	AM_RANGE(0x1600, 0x1600) AM_MIRROR(0x6000) AM_READ_PORT("DSW0")
+	AM_RANGE(0x1601, 0x1601) AM_MIRROR(0x6000) AM_WRITE(galaxold_nmi_enable_w)
+	AM_RANGE(0x1604, 0x1604) AM_MIRROR(0x6000) AM_WRITE(galaxold_stars_enable_w)
+	AM_RANGE(0x1606, 0x1606) AM_MIRROR(0x6000) AM_WRITE(galaxold_flip_screen_x_w)
+	AM_RANGE(0x1607, 0x1607) AM_MIRROR(0x6000) AM_WRITE(galaxold_flip_screen_y_w)
+	AM_RANGE(0x1680, 0x1680) AM_MIRROR(0x6000) AM_READ(watchdog_reset_r) AM_DEVWRITE("cust", galaxian_sound_device, pitch_w)
+	AM_RANGE(0x1700, 0x1701) AM_MIRROR(0x6000) AM_WRITENOP /* ??? this was in the error log */
+	AM_RANGE(0x1800, 0x1bff) AM_MIRROR(0x6000) AM_WRITE(galaxold_videoram_w) AM_SHARE("videoram")
+	AM_RANGE(0x1c00, 0x1fff) AM_MIRROR(0x6000) AM_RAM
+	AM_RANGE(0x2000, 0x2fff) AM_ROM
+	AM_RANGE(0x3700, 0x3701) AM_MIRROR(0x6000) AM_WRITENOP /* ??? this was in the error log */
 	AM_RANGE(0x4000, 0x4fff) AM_ROM
 	AM_RANGE(0x6000, 0x6fff) AM_ROM
 ADDRESS_MAP_END
@@ -2733,6 +2762,24 @@ static MACHINE_CONFIG_DERIVED( hunchbkg, galaxold_base )
 MACHINE_CONFIG_END
 
 
+static MACHINE_CONFIG_DERIVED( spcwarp, galaxold_base )
+	/* hunchbkg but with different banking? */
+	/* basic machine hardware */
+	MCFG_CPU_REPLACE("maincpu", S2650, PIXEL_CLOCK / 4)
+
+	MCFG_CPU_PROGRAM_MAP(spcwarp)
+	MCFG_CPU_IO_MAP(hunchbkg_io)
+	MCFG_CPU_IRQ_ACKNOWLEDGE_DRIVER(galaxold_state,hunchbkg_irq_callback)
+
+	MCFG_DEVICE_MODIFY("7474_9m_1")
+	MCFG_7474_COMP_OUTPUT_CB(DEVWRITELINE("maincpu", s2650_device, write_sense))
+
+	MCFG_MACHINE_RESET_OVERRIDE(galaxold_state,hunchbkg)
+
+	MCFG_FRAGMENT_ADD(galaxian_audio)
+MACHINE_CONFIG_END
+
+
 static MACHINE_CONFIG_DERIVED( tazzmang, galaxian )
 
 	/* basic machine hardware */
@@ -3445,9 +3492,10 @@ ROM_START( spcwarp )
 	ROM_REGION( 0x8000, "maincpu", 0 )
 	ROM_LOAD( "swarpt7f.bin", 0x0000, 0x1000, CRC(04d744e3) SHA1(db8218510052a05670cb0b722b73d3f10464788c) )
 	ROM_LOAD( "swarpt7h.bin", 0x2000, 0x1000, CRC(34a36536) SHA1(bc438515618683b2a7c29637871ee00ed95ad7f8) )
+	/* missing rom at $4000? todo: check valid calls */
 	ROM_LOAD( "swarpt7m.bin", 0x6000, 0x1000, BAD_DUMP CRC(a2dff6c8) SHA1(d1c72848450dc5ff386dc94a26e4bf704ccc7121) ) /* ROMCMP reports "BADADDR            xxxxxx-xxxxx".  Observed data sequence repeated every 32 bytes */
 
-	ROM_REGION( 0x1000, "gfx1", 0 ) // gfx are very similar to 'cosmos' so I think it's a converion of that to Galaxian HW, maybe under hthe title Space Warp.
+	ROM_REGION( 0x1000, "gfx1", 0 ) // gfx are very similar to 'cosmos' so I think it's a converion of that to Galaxian HW, maybe under the title Space Warp.
 	ROM_LOAD( "swarpb1h.bin", 0x0000, 0x0800, CRC(6ee3b5f7) SHA1(8150f2ecd59d3a165c0541b550664c56d049edd5) )
 	ROM_LOAD( "swarpb1k.bin", 0x0800, 0x0800, CRC(da4cee6b) SHA1(28b91381658f598fa62049489beee443232825c6) )
 
@@ -3739,7 +3787,7 @@ GAME( 1981, froggerv,  frogger,  videotron, froggerv,  driver_device,  0,       
 /* S2650 games */
 //    YEAR  NAME       PARENT    MACHINE    INPUT      INIT                       ROT     COMPANY, FULLNAME, FLAGS, LAYOUT
 GAME( 1983, hunchbkg,  hunchbak, hunchbkg,  hunchbkg,  driver_device,  0,         ROT90,  "Century Electronics", "Hunchback (Galaxian hardware)", MACHINE_SUPPORTS_SAVE )
-GAME( 1983, spcwarp,   0,        hunchbkg,  hunchbkg,  driver_device,  0,         ROT90,  "Century Electronics", "Space Warp?",  MACHINE_NOT_WORKING | MACHINE_SUPPORTS_SAVE ) // bad dump
+GAME( 1983, spcwarp,   0,        spcwarp,  hunchbkg,  driver_device,  0,         ROT90,  "Century Electronics", "Space Warp?",  MACHINE_NOT_WORKING | MACHINE_SUPPORTS_SAVE | MACHINE_WRONG_COLORS ) // bad dump
 GAME( 1984, drivfrcg,  drivfrcp, drivfrcg,  drivfrcg,  driver_device,  0,         ROT90,  "Shinkai Inc. (Magic Electronics USA license)", "Driving Force (Galaxian conversion)", MACHINE_SUPPORTS_SAVE )
 GAME( 1984, drivfrct,  drivfrcp, drivfrcg,  drivfrcg,  driver_device,  0,         ROT90,  "bootleg (EMT Germany)", "Top Racer (bootleg of Driving Force)", MACHINE_SUPPORTS_SAVE ) // Video Klein PCB
 GAME( 1985, drivfrcb,  drivfrcp, drivfrcg,  drivfrcg,  driver_device,  0,         ROT90,  "bootleg (Elsys Software)", "Driving Force (Galaxian conversion bootleg)", MACHINE_SUPPORTS_SAVE )

--- a/src/mame/drivers/galaxold.c
+++ b/src/mame/drivers/galaxold.c
@@ -3787,7 +3787,7 @@ GAME( 1981, froggerv,  frogger,  videotron, froggerv,  driver_device,  0,       
 /* S2650 games */
 //    YEAR  NAME       PARENT    MACHINE    INPUT      INIT                       ROT     COMPANY, FULLNAME, FLAGS, LAYOUT
 GAME( 1983, hunchbkg,  hunchbak, hunchbkg,  hunchbkg,  driver_device,  0,         ROT90,  "Century Electronics", "Hunchback (Galaxian hardware)", MACHINE_SUPPORTS_SAVE )
-GAME( 1983, spcwarp,   0,        spcwarp,  hunchbkg,  driver_device,  0,         ROT90,  "Century Electronics", "Space Warp?",  MACHINE_NOT_WORKING | MACHINE_SUPPORTS_SAVE | MACHINE_WRONG_COLORS ) // bad dump
+GAME( 1983, spcwarp,   0,        spcwarp,   hunchbkg,  driver_device,  0,         ROT90,  "Century Electronics", "Space Warp?",  MACHINE_NOT_WORKING | MACHINE_SUPPORTS_SAVE | MACHINE_WRONG_COLORS ) // bad dump
 GAME( 1984, drivfrcg,  drivfrcp, drivfrcg,  drivfrcg,  driver_device,  0,         ROT90,  "Shinkai Inc. (Magic Electronics USA license)", "Driving Force (Galaxian conversion)", MACHINE_SUPPORTS_SAVE )
 GAME( 1984, drivfrct,  drivfrcp, drivfrcg,  drivfrcg,  driver_device,  0,         ROT90,  "bootleg (EMT Germany)", "Top Racer (bootleg of Driving Force)", MACHINE_SUPPORTS_SAVE ) // Video Klein PCB
 GAME( 1985, drivfrcb,  drivfrcp, drivfrcg,  drivfrcg,  driver_device,  0,         ROT90,  "bootleg (Elsys Software)", "Driving Force (Galaxian conversion bootleg)", MACHINE_SUPPORTS_SAVE )


### PR DESCRIPTION
1942p:
crystals and divider guessed from this video https://www.youtube.com/watch?v=xFCDIZ3MI4c

spcwarp:
seperated memory map due to different write locations that hunchbkg doesn't use. added more info and cleared up some statements according to the barebones wikipedia article.