### PR TITLE
Fix digitalker speed

### DIFF
--- a/src/devices/sound/digitalk.c
+++ b/src/devices/sound/digitalk.c
@@ -516,6 +516,7 @@ void digitalker_device::digitalker_step()
 				return;
 			}
 		} else if(m_stop_after == 1) {
+			digitalker_set_intr(1);
 			m_bpos = 0xffff;
 			m_zero_count = 81920;
 			m_stop_after = 2;
@@ -525,7 +526,6 @@ void digitalker_device::digitalker_step()
 			m_repeats = 0;
 		} else {
 			m_stop_after = 0;
-			digitalker_set_intr(1);
 		}
 	}
 


### PR DESCRIPTION
The interrupt command was triggered at the end of the post-sample blank instead of at the start. It's a tight guess but is on par with real hardware footage of Scorpion...