### PR TITLE
fix ksl shift bits in OPL chips

### DIFF
--- a/src/devices/sound/fmopl.cpp
+++ b/src/devices/sound/fmopl.cpp
@@ -390,7 +390,7 @@ static const UINT32 ksl_tab[8*16]=
 #undef DV
 
 /* 0 / 3.0 / 1.5 / 6.0 dB/OCT */
-static const UINT32 ksl_shift[4] = { 31, 1, 2, 0 };
+static const UINT32 ksl_shift[4] = { 31, 2, 1, 0 };
 
 
 /* sustain level table (3dB per step) */

--- a/src/devices/sound/ymf262.cpp
+++ b/src/devices/sound/ymf262.cpp
@@ -343,7 +343,7 @@ static const UINT32 ksl_tab[8*16]=
 #undef DV
 
 /* 0 / 3.0 / 1.5 / 6.0 dB/OCT */
-static const UINT32 ksl_shift[4] = { 31, 1, 2, 0 };
+static const UINT32 ksl_shift[4] = { 31, 2, 1, 0 };
 
 
 /* sustain level table (3dB per step) */


### PR DESCRIPTION
3.0 and 1.5 dB/OCT were reversed around according to opl3 on the OPL reverse engineering forum.