### PR TITLE
Output vectors to a DAC device on the serial port.

### DIFF
--- a/scripts/target/mame/vector.lua
+++ b/scripts/target/mame/vector.lua
@@ -1,0 +1,392 @@
+-- license:BSD-3-Clause
+-- copyright-holders:MAMEdev Team
+
+---------------------------------------------------------------------------
+--
+--   vector.lua
+--
+--   Small driver-specific example makefile
+--   Use make SUBTARGET=vector to build
+--
+---------------------------------------------------------------------------
+
+
+--------------------------------------------------
+-- Specify all the CPU cores necessary for the
+-- drivers referenced in vector.lst.
+--------------------------------------------------
+
+CPUS["Z80"] = true
+CPUS["M6502"] = true
+CPUS["MCS48"] = true
+CPUS["MCS51"] = true
+CPUS["M6800"] = true
+CPUS["M6809"] = true
+CPUS["M680X0"] = true
+CPUS["TMS9900"] = true
+CPUS["TMS32010"] = true
+CPUS["TMS32025"] = true
+CPUS["TMS32031"] = true
+CPUS["TMS32051"] = true
+CPUS["TMS32082"] = true
+CPUS["TMS57002"] = true
+CPUS["COP400"] = true
+
+--------------------------------------------------
+-- Specify all the sound cores necessary for the
+-- drivers referenced in vector.lst.
+--------------------------------------------------
+
+SOUNDS["SAMPLES"] = true
+SOUNDS["DAC"] = true
+SOUNDS["DISCRETE"] = true
+SOUNDS["AY8910"] = true
+SOUNDS["YM2151"] = true
+SOUNDS["ASTROCADE"] = true
+SOUNDS["TMS5220"] = true
+SOUNDS["OKIM6295"] = true
+SOUNDS["HC55516"] = true
+SOUNDS["YM3812"] = true
+SOUNDS["CEM3394"] = true
+SOUNDS["VOTRAX"] = true
+SOUNDS["POKEY"] = true
+
+--------------------------------------------------
+-- specify available video cores
+--------------------------------------------------
+
+--------------------------------------------------
+-- specify available machine cores
+--------------------------------------------------
+
+MACHINES["6821PIA"] = true
+MACHINES["TTL74148"] = true
+MACHINES["TTL74153"] = true
+MACHINES["TTL7474"] = true
+MACHINES["TIMEKPR"] = true
+MACHINES["RIOT6532"] = true
+MACHINES["PIT8253"] = true
+MACHINES["Z80CTC"] = true
+MACHINES["68681"] = true
+MACHINES["BANKDEV"] = true
+MACHINES["X2212"] = true
+
+
+--------------------------------------------------
+-- specify available bus cores
+--------------------------------------------------
+
+BUSES["CENTRONICS"] = true
+BUSES["GENERIC"] = true
+
+--------------------------------------------------
+-- This is the list of files that are necessary
+-- for building all of the drivers referenced
+-- in vector.lst
+--------------------------------------------------
+
+function createProjects_mame_vector(_target, _subtarget)
+	project ("mame_vector")
+	targetsubdir(_target .."_" .. _subtarget)
+	kind (LIBTYPE)
+	uuid (os.uuid("drv-mame-vector"))
+	
+	includedirs {
+		MAME_DIR .. "src/osd",
+		MAME_DIR .. "src/emu",
+		MAME_DIR .. "src/devices",
+		MAME_DIR .. "src/mame",
+		MAME_DIR .. "src/lib",
+		MAME_DIR .. "src/lib/util",
+		MAME_DIR .. "src/lib/netlist",
+		MAME_DIR .. "3rdparty",
+		GEN_DIR  .. "mame/layout",
+	}
+
+files {
+	MAME_DIR .. "src/mame/video/avgdvg.cpp",
+	MAME_DIR .. "src/mame/video/avgdvg.h",
+
+	MAME_DIR .. "src/mame/drivers/arcadecl.cpp",
+	MAME_DIR .. "src/mame/includes/arcadecl.h",
+	MAME_DIR .. "src/mame/video/arcadecl.cpp",
+	MAME_DIR .. "src/mame/drivers/asteroid.cpp",
+	MAME_DIR .. "src/mame/includes/asteroid.h",
+	MAME_DIR .. "src/mame/machine/asteroid.cpp",
+	MAME_DIR .. "src/mame/audio/asteroid.cpp",
+	MAME_DIR .. "src/mame/audio/llander.cpp",
+	MAME_DIR .. "src/mame/drivers/atarifb.cpp",
+	MAME_DIR .. "src/mame/includes/atarifb.h",
+	MAME_DIR .. "src/mame/machine/atarifb.cpp",
+	MAME_DIR .. "src/mame/audio/atarifb.cpp",
+	MAME_DIR .. "src/mame/video/atarifb.cpp",
+	MAME_DIR .. "src/mame/drivers/atarig1.cpp",
+	MAME_DIR .. "src/mame/includes/atarig1.h",
+	MAME_DIR .. "src/mame/video/atarig1.cpp",
+	MAME_DIR .. "src/mame/includes/slapstic.h",
+	MAME_DIR .. "src/mame/drivers/atarig42.cpp",
+	MAME_DIR .. "src/mame/includes/atarig42.h",
+	MAME_DIR .. "src/mame/video/atarig42.cpp",
+	MAME_DIR .. "src/mame/drivers/atarigt.cpp",
+	MAME_DIR .. "src/mame/includes/atarigt.h",
+	MAME_DIR .. "src/mame/video/atarigt.cpp",
+	MAME_DIR .. "src/mame/drivers/atarigx2.cpp",
+	MAME_DIR .. "src/mame/includes/atarigx2.h",
+	MAME_DIR .. "src/mame/video/atarigx2.cpp",
+	MAME_DIR .. "src/mame/drivers/atarisy1.cpp",
+	MAME_DIR .. "src/mame/includes/atarisy1.h",
+	MAME_DIR .. "src/mame/video/atarisy1.cpp",
+	MAME_DIR .. "src/mame/drivers/atarisy2.cpp",
+	MAME_DIR .. "src/mame/includes/atarisy2.h",
+	MAME_DIR .. "src/mame/video/atarisy2.cpp",
+	MAME_DIR .. "src/mame/drivers/atarisy4.cpp",
+	MAME_DIR .. "src/mame/drivers/atarittl.cpp",
+	--MAME_DIR .. "src/mame/drivers/atetris.cpp",
+	--MAME_DIR .. "src/mame/includes/atetris.h",
+	--MAME_DIR .. "src/mame/video/atetris.cpp",
+	MAME_DIR .. "src/mame/drivers/avalnche.cpp",
+	MAME_DIR .. "src/mame/includes/avalnche.h",
+	MAME_DIR .. "src/mame/audio/avalnche.cpp",
+	--MAME_DIR .. "src/mame/drivers/badlands.cpp",
+	--MAME_DIR .. "src/mame/includes/badlands.h",
+	--MAME_DIR .. "src/mame/video/badlands.cpp",
+	--MAME_DIR .. "src/mame/drivers/bartop52.cpp",
+	--MAME_DIR .. "src/mame/drivers/batman.cpp",
+	--MAME_DIR .. "src/mame/includes/batman.h",
+	--MAME_DIR .. "src/mame/video/batman.cpp",
+	--MAME_DIR .. "src/mame/drivers/beathead.cpp",
+	--MAME_DIR .. "src/mame/includes/beathead.h",
+	--MAME_DIR .. "src/mame/video/beathead.cpp",
+	--MAME_DIR .. "src/mame/drivers/blstroid.cpp",
+	--MAME_DIR .. "src/mame/includes/blstroid.h",
+	--MAME_DIR .. "src/mame/video/blstroid.cpp",
+	--MAME_DIR .. "src/mame/drivers/boxer.cpp",
+	--MAME_DIR .. "src/mame/drivers/bsktball.cpp",
+	--MAME_DIR .. "src/mame/includes/bsktball.h",
+	--MAME_DIR .. "src/mame/machine/bsktball.cpp",
+	--MAME_DIR .. "src/mame/audio/bsktball.cpp",
+	--MAME_DIR .. "src/mame/video/bsktball.cpp",
+	MAME_DIR .. "src/mame/drivers/bwidow.cpp",
+	MAME_DIR .. "src/mame/includes/bwidow.h",
+	MAME_DIR .. "src/mame/audio/bwidow.cpp",
+	MAME_DIR .. "src/mame/drivers/bzone.cpp",
+	MAME_DIR .. "src/mame/includes/bzone.h",
+	MAME_DIR .. "src/mame/audio/bzone.cpp",
+	--MAME_DIR .. "src/mame/drivers/canyon.cpp",
+	--MAME_DIR .. "src/mame/includes/canyon.h",
+	--MAME_DIR .. "src/mame/audio/canyon.cpp",
+	--MAME_DIR .. "src/mame/video/canyon.cpp",
+	--MAME_DIR .. "src/mame/drivers/cball.cpp",
+	--MAME_DIR .. "src/mame/drivers/ccastles.cpp",
+	--MAME_DIR .. "src/mame/includes/ccastles.h",
+	--MAME_DIR .. "src/mame/video/ccastles.cpp",
+	--MAME_DIR .. "src/mame/drivers/centiped.cpp",
+	--MAME_DIR .. "src/mame/includes/centiped.h",
+	--MAME_DIR .. "src/mame/video/centiped.cpp",
+	--MAME_DIR .. "src/mame/drivers/cloak.cpp",
+	--MAME_DIR .. "src/mame/includes/cloak.h",
+	--MAME_DIR .. "src/mame/video/cloak.cpp",
+	--MAME_DIR .. "src/mame/drivers/cloud9.cpp",
+	--MAME_DIR .. "src/mame/includes/cloud9.h",
+	--MAME_DIR .. "src/mame/video/cloud9.cpp",
+	--MAME_DIR .. "src/mame/drivers/cmmb.cpp",
+	--MAME_DIR .. "src/mame/drivers/cops.cpp",
+	--MAME_DIR .. "src/mame/drivers/copsnrob.cpp",
+	--MAME_DIR .. "src/mame/includes/copsnrob.h",
+	--MAME_DIR .. "src/mame/audio/copsnrob.cpp",
+	--MAME_DIR .. "src/mame/video/copsnrob.cpp",
+	--MAME_DIR .. "src/mame/drivers/cyberbal.cpp",
+	--MAME_DIR .. "src/mame/includes/cyberbal.h",
+	--MAME_DIR .. "src/mame/audio/cyberbal.cpp",
+	--MAME_DIR .. "src/mame/video/cyberbal.cpp",
+	--MAME_DIR .. "src/mame/drivers/destroyr.cpp",
+	--MAME_DIR .. "src/mame/drivers/dragrace.cpp",
+	--MAME_DIR .. "src/mame/includes/dragrace.h",
+	--MAME_DIR .. "src/mame/audio/dragrace.cpp",
+	--MAME_DIR .. "src/mame/video/dragrace.cpp",
+	MAME_DIR .. "src/mame/drivers/eprom.cpp",
+	MAME_DIR .. "src/mame/includes/eprom.h",
+	MAME_DIR .. "src/mame/video/eprom.cpp",
+	--MAME_DIR .. "src/mame/drivers/firefox.cpp",
+	--MAME_DIR .. "src/mame/drivers/firetrk.cpp",
+	--MAME_DIR .. "src/mame/includes/firetrk.h",
+	--MAME_DIR .. "src/mame/audio/firetrk.cpp",
+	--MAME_DIR .. "src/mame/video/firetrk.cpp",
+	--MAME_DIR .. "src/mame/drivers/flyball.cpp",
+	--MAME_DIR .. "src/mame/drivers/foodf.cpp",
+	--MAME_DIR .. "src/mame/includes/foodf.h",
+	--MAME_DIR .. "src/mame/video/foodf.cpp",
+	--MAME_DIR .. "src/mame/drivers/gauntlet.cpp",
+	--MAME_DIR .. "src/mame/includes/gauntlet.h",
+	--MAME_DIR .. "src/mame/video/gauntlet.cpp",
+	--MAME_DIR .. "src/mame/drivers/harddriv.cpp",
+	--MAME_DIR .. "src/mame/includes/harddriv.h",
+	--MAME_DIR .. "src/mame/machine/harddriv.cpp",
+	--MAME_DIR .. "src/mame/audio/harddriv.cpp",
+	--MAME_DIR .. "src/mame/video/harddriv.cpp",
+	--MAME_DIR .. "src/mame/drivers/irobot.cpp",
+	--MAME_DIR .. "src/mame/includes/irobot.h",
+	--MAME_DIR .. "src/mame/machine/irobot.cpp",
+	--MAME_DIR .. "src/mame/video/irobot.cpp",
+	--MAME_DIR .. "src/mame/drivers/jaguar.cpp",
+	--MAME_DIR .. "src/mame/includes/jaguar.h",
+	--MAME_DIR .. "src/mame/audio/jaguar.cpp",
+	--MAME_DIR .. "src/mame/video/jaguar.cpp",
+	--MAME_DIR .. "src/mame/video/jagblit.h",
+	--MAME_DIR .. "src/mame/video/jagblit.inc",
+	--MAME_DIR .. "src/mame/video/jagobj.inc",
+	MAME_DIR .. "src/mame/drivers/jedi.cpp",
+	MAME_DIR .. "src/mame/includes/jedi.h",
+	MAME_DIR .. "src/mame/audio/jedi.cpp",
+	MAME_DIR .. "src/mame/video/jedi.cpp",
+	--MAME_DIR .. "src/mame/drivers/klax.cpp",
+	--MAME_DIR .. "src/mame/includes/klax.h",
+	--MAME_DIR .. "src/mame/video/klax.cpp",
+	--MAME_DIR .. "src/mame/drivers/liberatr.cpp",
+	--MAME_DIR .. "src/mame/includes/liberatr.h",
+	--MAME_DIR .. "src/mame/video/liberatr.cpp",
+	--MAME_DIR .. "src/mame/drivers/mediagx.cpp",
+	--MAME_DIR .. "src/mame/drivers/metalmx.cpp",
+	--MAME_DIR .. "src/mame/includes/metalmx.h",
+	--MAME_DIR .. "src/mame/drivers/mgolf.cpp",
+	MAME_DIR .. "src/mame/drivers/mhavoc.cpp",
+	MAME_DIR .. "src/mame/includes/mhavoc.h",
+	MAME_DIR .. "src/mame/machine/mhavoc.cpp",
+	--MAME_DIR .. "src/mame/drivers/missile.cpp",
+	--MAME_DIR .. "src/mame/drivers/nitedrvr.cpp",
+	--MAME_DIR .. "src/mame/includes/nitedrvr.h",
+	--MAME_DIR .. "src/mame/machine/nitedrvr.cpp",
+	--MAME_DIR .. "src/mame/audio/nitedrvr.cpp",
+	--MAME_DIR .. "src/mame/video/nitedrvr.cpp",
+	--MAME_DIR .. "src/mame/drivers/offtwall.cpp",
+	--MAME_DIR .. "src/mame/includes/offtwall.h",
+	--MAME_DIR .. "src/mame/video/offtwall.cpp",
+	--MAME_DIR .. "src/mame/drivers/orbit.cpp",
+	--MAME_DIR .. "src/mame/includes/orbit.h",
+	--MAME_DIR .. "src/mame/audio/orbit.cpp",
+	--MAME_DIR .. "src/mame/video/orbit.cpp",
+	--MAME_DIR .. "src/mame/drivers/pong.cpp",
+	--MAME_DIR .. "src/mame/drivers/nl_pong.cpp",
+	--MAME_DIR .. "src/mame/drivers/nl_pongd.cpp",
+	--MAME_DIR .. "src/mame/drivers/nl_breakout.cpp",
+	--MAME_DIR .. "src/mame/drivers/poolshrk.cpp",
+	--MAME_DIR .. "src/mame/includes/poolshrk.h",
+	--MAME_DIR .. "src/mame/audio/poolshrk.cpp",
+	--MAME_DIR .. "src/mame/video/poolshrk.cpp",
+	MAME_DIR .. "src/mame/drivers/quantum.cpp",
+	--MAME_DIR .. "src/mame/drivers/quizshow.cpp",
+	--MAME_DIR .. "src/mame/drivers/rampart.cpp",
+	--MAME_DIR .. "src/mame/includes/rampart.h",
+	--MAME_DIR .. "src/mame/video/rampart.cpp",
+	--MAME_DIR .. "src/mame/drivers/relief.cpp",
+	--MAME_DIR .. "src/mame/includes/relief.h",
+	--MAME_DIR .. "src/mame/video/relief.cpp",
+	--MAME_DIR .. "src/mame/drivers/runaway.cpp",
+	--MAME_DIR .. "src/mame/includes/runaway.h",
+	--MAME_DIR .. "src/mame/video/runaway.cpp",
+	--MAME_DIR .. "src/mame/drivers/sbrkout.cpp",
+	--MAME_DIR .. "src/mame/drivers/shuuz.cpp",
+	--MAME_DIR .. "src/mame/includes/shuuz.h",
+	--MAME_DIR .. "src/mame/video/shuuz.cpp",
+	--MAME_DIR .. "src/mame/drivers/skullxbo.cpp",
+	--MAME_DIR .. "src/mame/includes/skullxbo.h",
+	--MAME_DIR .. "src/mame/video/skullxbo.cpp",
+	--MAME_DIR .. "src/mame/drivers/skydiver.cpp",
+	--MAME_DIR .. "src/mame/includes/skydiver.h",
+	--MAME_DIR .. "src/mame/audio/skydiver.cpp",
+	--MAME_DIR .. "src/mame/video/skydiver.cpp",
+	--MAME_DIR .. "src/mame/drivers/skyraid.cpp",
+	--MAME_DIR .. "src/mame/includes/skyraid.h",
+	--MAME_DIR .. "src/mame/audio/skyraid.cpp",
+	--MAME_DIR .. "src/mame/video/skyraid.cpp",
+	--MAME_DIR .. "src/mame/drivers/sprint2.cpp",
+	--MAME_DIR .. "src/mame/includes/sprint2.h",
+	--MAME_DIR .. "src/mame/audio/sprint2.cpp",
+	--MAME_DIR .. "src/mame/video/sprint2.cpp",
+	--MAME_DIR .. "src/mame/drivers/sprint4.cpp",
+	--MAME_DIR .. "src/mame/includes/sprint4.h",
+	--MAME_DIR .. "src/mame/video/sprint4.cpp",
+	--MAME_DIR .. "src/mame/audio/sprint4.cpp",
+	--MAME_DIR .. "src/mame/audio/sprint4.h",
+	--MAME_DIR .. "src/mame/drivers/sprint8.cpp",
+	--MAME_DIR .. "src/mame/includes/sprint8.h",
+	--MAME_DIR .. "src/mame/audio/sprint8.cpp",
+	--MAME_DIR .. "src/mame/video/sprint8.cpp",
+	--MAME_DIR .. "src/mame/drivers/starshp1.cpp",
+	--MAME_DIR .. "src/mame/includes/starshp1.h",
+	--MAME_DIR .. "src/mame/audio/starshp1.cpp",
+	--MAME_DIR .. "src/mame/video/starshp1.cpp",
+	MAME_DIR .. "src/mame/drivers/starwars.cpp",
+	MAME_DIR .. "src/mame/includes/starwars.h",
+	MAME_DIR .. "src/mame/machine/starwars.cpp",
+	MAME_DIR .. "src/mame/audio/starwars.cpp",
+	--MAME_DIR .. "src/mame/drivers/subs.cpp",
+	--MAME_DIR .. "src/mame/includes/subs.h",
+	--MAME_DIR .. "src/mame/machine/subs.cpp",
+	--MAME_DIR .. "src/mame/audio/subs.cpp",
+	--MAME_DIR .. "src/mame/video/subs.cpp",
+	--MAME_DIR .. "src/mame/drivers/tank8.cpp",
+	--MAME_DIR .. "src/mame/includes/tank8.h",
+	--MAME_DIR .. "src/mame/audio/tank8.cpp",
+	--MAME_DIR .. "src/mame/video/tank8.cpp",
+	MAME_DIR .. "src/mame/drivers/tempest.cpp",
+	--MAME_DIR .. "src/mame/drivers/thunderj.cpp",
+	--MAME_DIR .. "src/mame/includes/thunderj.h",
+	--MAME_DIR .. "src/mame/video/thunderj.cpp",
+	MAME_DIR .. "src/mame/drivers/tomcat.cpp",
+	--MAME_DIR .. "src/mame/drivers/toobin.cpp",
+	--MAME_DIR .. "src/mame/includes/toobin.h",
+	--MAME_DIR .. "src/mame/video/toobin.cpp",
+	--MAME_DIR .. "src/mame/drivers/tourtabl.cpp",
+	--MAME_DIR .. "src/mame/video/tia.cpp",
+	--MAME_DIR .. "src/mame/video/tia.h",
+	--MAME_DIR .. "src/mame/drivers/triplhnt.cpp",
+	--MAME_DIR .. "src/mame/includes/triplhnt.h",
+	--MAME_DIR .. "src/mame/audio/triplhnt.cpp",
+	--MAME_DIR .. "src/mame/video/triplhnt.cpp",
+	--MAME_DIR .. "src/mame/drivers/tunhunt.cpp",
+	--MAME_DIR .. "src/mame/includes/tunhunt.h",
+	--MAME_DIR .. "src/mame/video/tunhunt.cpp",
+	--MAME_DIR .. "src/mame/drivers/ultratnk.cpp",
+	--MAME_DIR .. "src/mame/includes/ultratnk.h",
+	--MAME_DIR .. "src/mame/video/ultratnk.cpp",
+	--MAME_DIR .. "src/mame/drivers/videopin.cpp",
+	--MAME_DIR .. "src/mame/includes/videopin.h",
+	--MAME_DIR .. "src/mame/audio/videopin.cpp",
+	--MAME_DIR .. "src/mame/video/videopin.cpp",
+	--MAME_DIR .. "src/mame/drivers/vindictr.cpp",
+	--MAME_DIR .. "src/mame/includes/vindictr.h",
+	--MAME_DIR .. "src/mame/video/vindictr.cpp",
+	--MAME_DIR .. "src/mame/drivers/wolfpack.cpp",
+	--MAME_DIR .. "src/mame/includes/wolfpack.h",
+	--MAME_DIR .. "src/mame/video/wolfpack.cpp",
+	--MAME_DIR .. "src/mame/drivers/xybots.cpp",
+	--MAME_DIR .. "src/mame/includes/xybots.h",
+	--MAME_DIR .. "src/mame/video/xybots.cpp",
+	MAME_DIR .. "src/mame/machine/asic65.cpp",
+	MAME_DIR .. "src/mame/machine/asic65.h",
+	MAME_DIR .. "src/mame/machine/atari_vg.cpp",
+	MAME_DIR .. "src/mame/machine/atari_vg.h",
+	MAME_DIR .. "src/mame/machine/atarigen.cpp",
+	MAME_DIR .. "src/mame/machine/atarigen.h",
+	MAME_DIR .. "src/mame/machine/mathbox.cpp",
+	MAME_DIR .. "src/mame/machine/mathbox.h",
+	MAME_DIR .. "src/mame/machine/slapstic.cpp",
+	MAME_DIR .. "src/mame/audio/atarijsa.cpp",
+	MAME_DIR .. "src/mame/audio/atarijsa.h",
+	MAME_DIR .. "src/mame/audio/cage.cpp",
+	MAME_DIR .. "src/mame/audio/cage.h",
+	MAME_DIR .. "src/mame/audio/redbaron.cpp",
+	MAME_DIR .. "src/mame/audio/redbaron.h",
+	MAME_DIR .. "src/mame/video/atarimo.cpp",
+	MAME_DIR .. "src/mame/video/atarimo.h",
+	MAME_DIR .. "src/mame/video/atarirle.cpp",
+	MAME_DIR .. "src/mame/video/atarirle.h",
+}
+end
+
+function linkProjects_mame_vector(_target, _subtarget)
+	links {
+		"mame_vector",
+	}
+end

--- a/scripts/toolchain.lua
+++ b/scripts/toolchain.lua
@@ -858,6 +858,7 @@ function toolchain(_buildDir, _subDir)
 		objdir (_buildDir .. "osx_clang" .. "/obj")
 		buildoptions {
 			"-m64",
+			"-Wno-constant-logical-operand",
 		}
 
 	configuration { "osx*", "x64", "Release" }

--- a/src/devices/sound/samples.cpp
+++ b/src/devices/sound/samples.cpp
@@ -571,7 +571,7 @@ bool samples_device::read_flac_sample(emu_file &file, sample_t &sample)
 	file.seek(0, SEEK_SET);
 
 	// create the FLAC decoder and fill in the sample data
-	flac_decoder decoder(file);
+	flac_decoder decoder((core_file&) file);
 	sample.frequency = decoder.sample_rate();
 
 	// error if more than 1 channel or not 16bpp

--- a/src/emu/emuopts.cpp
+++ b/src/emu/emuopts.cpp
@@ -557,7 +557,7 @@ bool emu_options::parse_one_ini(const char *basename, int priority, std::string 
 	// parse the file
 	osd_printf_verbose("Parsing %s.ini\n", basename);
 	std::string error;
-	bool result = parse_ini_file(file, priority, OPTION_PRIORITY_DRIVER_INI, error);
+	bool result = parse_ini_file((core_file&)file, priority, OPTION_PRIORITY_DRIVER_INI, error);
 
 	// append errors if requested
 	if (!error.empty() && error_string != NULL)

--- a/src/emu/emuopts.cpp
+++ b/src/emu/emuopts.cpp
@@ -116,6 +116,10 @@ const options_entry emu_options::s_option_entries[] =
 	{ OPTION_BEAM_WIDTH_MAX,                             "1.0",       OPTION_FLOAT,      "set vector beam width maximum" },
 	{ OPTION_BEAM_INTENSITY_WEIGHT,                      "0",         OPTION_FLOAT,      "set vector beam intensity weight " },
 	{ OPTION_FLICKER,                                    "0",         OPTION_FLOAT,      "set vector flicker effect" },
+	{ OPTION_VECTOR_SERIAL,                              "",          OPTION_STRING,      "set vector serial device" },
+	{ OPTION_VECTOR_SCALE,                               "1.0",       OPTION_FLOAT,      "set vector serial output scale" },
+	{ OPTION_VECTOR_ROTATE,                              "0",         OPTION_INTEGER,    "set vector serial rotation (0,1,2,3)" },
+	{ OPTION_VECTOR_BRIGHT,                              "200",       OPTION_INTEGER,    "set vector threshold for bright lines (0-255)" },
 
 	// sound options
 	{ NULL,                                              NULL,        OPTION_HEADER,     "CORE SOUND OPTIONS" },
@@ -557,7 +561,7 @@ bool emu_options::parse_one_ini(const char *basename, int priority, std::string 
 	// parse the file
 	osd_printf_verbose("Parsing %s.ini\n", basename);
 	std::string error;
-	bool result = parse_ini_file((core_file&)file, priority, OPTION_PRIORITY_DRIVER_INI, error);
+	bool result = parse_ini_file((core_file&) file, priority, OPTION_PRIORITY_DRIVER_INI, error);
 
 	// append errors if requested
 	if (!error.empty() && error_string != NULL)

--- a/src/emu/emuopts.h
+++ b/src/emu/emuopts.h
@@ -123,6 +123,10 @@ enum
 #define OPTION_BEAM_WIDTH_MAX       "beam_width_max"
 #define OPTION_BEAM_INTENSITY_WEIGHT   "beam_intensity_weight"
 #define OPTION_FLICKER              "flicker"
+#define OPTION_VECTOR_SERIAL        "vector_serial"
+#define OPTION_VECTOR_ROTATE        "vector_rotate"
+#define OPTION_VECTOR_BRIGHT        "vector_bright"
+#define OPTION_VECTOR_SCALE         "vector_scale"
 
 // core sound options
 #define OPTION_SAMPLERATE           "samplerate"
@@ -297,6 +301,10 @@ public:
 	float beam_width_max() const { return float_value(OPTION_BEAM_WIDTH_MAX); }
 	float beam_intensity_weight() const { return float_value(OPTION_BEAM_INTENSITY_WEIGHT); }
 	float flicker() const { return float_value(OPTION_FLICKER); }
+	float vector_scale() const { return float_value(OPTION_VECTOR_SCALE); }
+	const char * vector_serial() const { return value(OPTION_VECTOR_SERIAL); }
+	int vector_rotate() const { return int_value(OPTION_VECTOR_ROTATE); }
+	int vector_bright() const { return int_value(OPTION_VECTOR_BRIGHT); }
 
 	// core sound options
 	int sample_rate() const { return int_value(OPTION_SAMPLERATE); }

--- a/src/emu/video/vector.cpp
+++ b/src/emu/video/vector.cpp
@@ -317,7 +317,7 @@ void vector_device::serial_send()
 
 	size_t offset = 0;
 
-	printf("%zu vectors: off=%zu on=%zu bright=%zu%s\n",
+	printf("%zu vectors: off=%u on=%u bright=%u%s\n",
 		m_serial_offset/3,
 		m_vector_transit[0],
 		m_vector_transit[1],

--- a/src/emu/video/vector.cpp
+++ b/src/emu/video/vector.cpp
@@ -34,6 +34,17 @@
 #include "rendutil.h"
 #include "vector.h"
 
+// Serial port related includes
+#include <sys/types.h>
+#include <sys/stat.h>
+#include <fcntl.h>
+#include <unistd.h>
+#include <termios.h>
+#include <errno.h>
+
+#include <inttypes.h>
+#include <sys/time.h>
+ 
 
 #define FLT_EPSILON 1E-5
 
@@ -152,6 +163,195 @@ float vector_device::m_beam_width_max = 0.0f;
 float vector_device::m_beam_intensity_weight = 0.0f;
 int vector_device::m_vector_index;
 
+int
+serial_open(
+        const char * const dev
+)
+{
+        const int fd = open(dev, O_RDWR | O_NONBLOCK | O_NOCTTY, 0666);
+        if (fd < 0)
+                return -1;
+
+        // Disable modem control signals
+        struct termios attr;
+        tcgetattr(fd, &attr);
+        attr.c_cflag |= CLOCAL | CREAD;
+        attr.c_oflag &= ~OPOST;
+        tcsetattr(fd, TCSANOW, &attr);
+
+        return fd;
+}
+
+void vector_device::serial_draw_point(
+	unsigned x,
+	unsigned y,
+	int intensity
+)
+{
+	// always flip the Y, since the vectorscope measures
+	// 0,0 at the bottom left corner, but this coord uses
+	// the top left corner.
+	y = 2047 - y;
+
+	// make sure that we are in range; should always be
+	// due to clipping on the window, but just in case
+	if (x < 0) x = 0;
+	if (y < 0) y = 0;
+
+	if (x > 2047) x = 2047;
+	if (y > 2047) y = 2047;
+
+	unsigned bright;
+	if (intensity > m_serial_bright)
+		bright = 3;
+	else
+	if (intensity > 0)
+		bright = 2;
+	else
+		bright = 1;
+
+	if (m_serial_rotate == 1)
+	{
+		// +90
+		unsigned tmp = x;
+		x = 2047 - y;
+		y = tmp;
+	} else
+	if (m_serial_rotate == 2)
+	{
+		// +180
+		x = 2047 - x;
+		y = 2047 - y;
+	} else
+	if (m_serial_rotate == 3)
+	{
+		// -90
+		unsigned t = x;
+		x = y;
+		y = 2047 - t;
+	}
+
+	uint32_t cmd = 0
+		| (bright << 22)
+		| (x & 0x7FF) << 11
+		| (y & 0x7FF) <<  0
+		;
+
+	m_serial_buf[m_serial_offset++] = cmd >> 16;
+	m_serial_buf[m_serial_offset++] = cmd >>  8;
+	m_serial_buf[m_serial_offset++] = cmd >>  0;
+
+	// todo: check for overflow;
+	// should always have enough points
+}
+
+
+void vector_device::serial_draw_line(
+	float xf0,
+	float yf0,
+	float xf1,
+	float yf1,
+	int intensity
+)
+{
+	if (m_serial_fd < 0)
+		return;
+
+	static int last_x;
+	static int last_y;
+
+	const int x0 = (xf0 * 2048 - 1024) * m_serial_scale + 1024;
+	const int y0 = (yf0 * 2048 - 1024) * m_serial_scale + 1024;
+	const int x1 = (xf1 * 2048 - 1024) * m_serial_scale + 1024;
+	const int y1 = (yf1 * 2048 - 1024) * m_serial_scale + 1024;
+
+	// if this is not a continuous segment,
+	// we must add a transit command
+	if (last_x != x0 || last_y != y0)
+	{
+		serial_draw_point(x0, y0, 0);
+		int dx = x0 - last_x;
+		int dy = y0 - last_y;
+		m_vector_transit[0] += sqrt(dx*dx + dy*dy);
+	}
+
+	// transit to the new point
+	int dx = x1 - x0;
+	int dy = y1 - y0;
+	int dist = sqrt(dx*dx + dy*dy);
+
+	serial_draw_point(x1, y1, intensity);
+	if (intensity > m_serial_bright)
+		m_vector_transit[2] += dist;
+	else
+		m_vector_transit[1] += dist;
+
+	last_x = x1;
+	last_y = y1;
+}
+
+
+void vector_device::serial_reset()
+{
+	m_serial_offset = 0;
+	m_serial_buf[m_serial_offset++] = 0;
+	m_serial_buf[m_serial_offset++] = 0;
+	m_serial_buf[m_serial_offset++] = 0;
+	m_serial_buf[m_serial_offset++] = 0;
+
+	m_vector_transit[0] = 0;
+	m_vector_transit[1] = 0;
+	m_vector_transit[2] = 0;
+}
+
+
+void vector_device::serial_send()
+{
+	if (m_serial_fd < 0)
+		return;
+
+	// add the "done" command to the message
+	m_serial_buf[m_serial_offset++] = 1;
+	m_serial_buf[m_serial_offset++] = 1;
+	m_serial_buf[m_serial_offset++] = 1;
+
+	size_t offset = 0;
+
+	printf("%zu vectors: off=%zu on=%zu bright=%zu%s\n",
+		m_serial_offset/3,
+		m_vector_transit[0],
+		m_vector_transit[1],
+		m_vector_transit[2],
+		m_serial_drop_frame ? " !" : ""
+	);
+
+	if (m_serial_drop_frame)
+	{
+		// we skipped a frame, don't skip the next one
+		m_serial_drop_frame = 0;
+	} else
+	while (offset < m_serial_offset)
+	{
+		ssize_t rc = write(m_serial_fd, m_serial_buf + offset, m_serial_offset - offset);
+		if (rc <= 0)
+		{
+			m_serial_drop_frame = 1;
+			if (errno == EAGAIN)
+				continue;
+			perror(m_serial);
+			close(m_serial_fd);
+			m_serial_fd = -1;
+			break;
+		}
+
+		offset += rc;
+	}
+
+	serial_reset();
+}
+
+
+
 void vector_device::device_start()
 {
 	/* Grab the settings for this session */
@@ -164,6 +364,31 @@ void vector_device::device_start()
 
 	/* allocate memory for tables */
 	m_vector_list = auto_alloc_array_clear(machine(), point, MAX_POINTS);
+
+	/* Setup the serial output of the XY coords if configured */
+	m_serial = machine().options().vector_serial();
+	m_serial_scale = machine().options().vector_scale();
+	m_serial_rotate = machine().options().vector_rotate();
+	m_serial_bright = machine().options().vector_bright();
+	m_serial_drop_frame = 0;
+
+	// allocate enough buffer space, although we should never use this much
+	m_serial_buf = auto_alloc_array_clear(machine(), unsigned char, (MAX_POINTS+2) * 3);
+	if (!m_serial_buf)
+	{
+		// todo: how to signal an error?
+	}
+
+	serial_reset();
+
+	if (!m_serial || strcmp(m_serial,"") == 0)
+	{
+		fprintf(stderr, "no serial vector display configured\n");
+		m_serial_fd = -1;
+	} else {
+		m_serial_fd = serial_open(m_serial);
+		fprintf(stderr, "serial dev='%s' fd=%d\n", m_serial, m_serial_fd);
+	}
 }
 
 void vector_device::set_flicker(float newval)
@@ -367,6 +592,11 @@ UINT32 vector_device::screen_update(screen_device &screen, bitmap_rgb32 &bitmap,
 					beam_width,
 					(curpoint->intensity << 24) | (curpoint->col & 0xffffff),
 					flags);
+
+				serial_draw_line(
+					coords.x0, coords.y0,
+					coords.x1, coords.y1,
+					curpoint->intensity);
 			}
 
 			lastx = curpoint->x;
@@ -375,6 +605,8 @@ UINT32 vector_device::screen_update(screen_device &screen, bitmap_rgb32 &bitmap,
 
 		curpoint++;
 	}
+
+	serial_send();
 
 	return 0;
 }

--- a/src/emu/video/vector.h
+++ b/src/emu/video/vector.h
@@ -70,6 +70,38 @@ private:
 	int m_min_intensity;
 	int m_max_intensity;
 
+	// Serial output option for driving vector display hardware
+	const char * m_serial;
+	int m_serial_fd;
+	float m_serial_scale;
+	int m_serial_rotate;
+	int m_serial_bright;
+	int m_serial_drop_frame;
+	unsigned m_vector_transit[3];
+	unsigned char * m_serial_buf;
+	size_t m_serial_offset;
+
+	void serial_reset();
+
+	void
+	serial_draw_point(
+		unsigned x,
+		unsigned y,
+		int intensity
+	);
+
+	void
+	serial_draw_line(
+		float x0,
+		float y0,
+		float x1,
+		float y1,
+		int intensity
+	);
+
+	void
+	serial_send();
+
 	float normalized_sigmoid(float n, float k);
 };
 

--- a/src/mame/vector.lst
+++ b/src/mame/vector.lst
@@ -1,0 +1,66 @@
+// license:BSD-3-Clause
+// copyright-holders:Aaron Giles
+/******************************************************************************
+
+    arcade.lst
+
+    List of all enabled drivers in the system. This file is parsed by
+    makelist.exe, sorted, and output as C code describing the drivers.
+
+******************************************************************************/
+
+
+// Atari vector games
+llander         // 0345xx           no copyright notice
+llander1        // 0345xx           no copyright notice
+llandert        // (test)           no copyright notice
+asteroid        // 035127-035145    (c) 1979
+asteroid2       // 035127-035145    (c) 1979
+asteroid1       // 035127-035145    no copyright notice
+asteroidb       // (bootleg)
+aerolitos       // Rodmar Elec. bootleg
+asterock        // Sidam bootleg    (c) 1979
+asterockv       // Videotron bootleg(c) 1979
+hyperspc        // Rumiano bootleg  (c) 1979
+meteorts        // VCC bootleg      (c) 1979
+meteorho        // Hoei? bootleg    (c) 1980
+astdelux        // 0351xx           (c) 1980
+astdelux2       // 0351xx           (c) 1980
+astdelux1       // 0351xx           (c) 1980
+bzone           // 0364xx           (c) 1980
+bzonea          // 0364xx           (c) 1980
+bzonec          // 0364xx           (c) 1980
+bradley         //     ??           (c) 1980
+redbaron        // 036995-037007    (c) 1980
+redbarona       // 036995-037007    (c) 1980
+tempest         // 136002           (c) 1980
+tempest3        // 136002           (c) 1980
+tempest2        // 136002           (c) 1980
+tempest1        // 136002           (c) 1980
+tempest1r       // 136002           (c) 1980
+temptube        // (hack)
+spacduel        // 136006           (c) 1980
+spacduel1       // 136006           (c) 1980
+spacduel0       // 136006           (c) 1980
+gravitar        // 136010           (c) 1982
+gravitar2       // 136010           (c) 1982
+gravitar1       // 136010           (c) 1982
+lunarbat        // (proto)          (c) 1982
+lunarba1        // (proto)          (c) 1982
+quantum         // 136016           (c) 1982        // made by Gencomp
+quantum1        // 136016           (c) 1982        // made by Gencomp
+quantump        // 136016           (c) 1982        // made by Gencomp
+bwidow          // 136017           (c) 1982
+bwidowp         // (proto)          (c) 1982
+starwars        // 136021           (c) 1983
+starwars1       // 136021           (c) 1983
+starwarso       // 136021           (c) 1983
+tomcatsw        // (proto)          (c) 1983
+mhavoc          // 136025           (c) 1983
+mhavoc2         // 136025           (c) 1983
+mhavocp         // 136025           (c) 1983
+mhavocrv        // (hack)
+alphaone        // (proto)          (c) 1983
+alphaonea       // (proto)          (c) 1983
+esb             // 136031           (c) 1985
+tomcat          // (proto)          (c) 1985


### PR DESCRIPTION
This patch adds output of the vector line segments to the serial port in a format that the v.st vector display board will parse.  This allows display of the emulated games on real vector hardware like oscilloscopes, vectorscopes and slower XY monitors like the Vectrex.  It adds runtime options to set the serial port, the scaling and the rotation of the display.  More info: https://trmm.net/MAME

This patch also adds a `SUBTARGET=vector` to build just the vector games and CPUs, which shortens the build time from hours to a few minutes.

![Starwars on a vectorscope and a Vectrex](https://49.media.tumblr.com/e4f2586dd94cd36beee271fd90e8a9cc/tumblr_nxgs3gqcMc1s6w6q7o1_500.gif)