### PR TITLE
rungun.cpp: Implemented bread and butter dual screen drawing setup.

### DIFF
--- a/src/mame/drivers/rungun.cpp
+++ b/src/mame/drivers/rungun.cpp
@@ -28,16 +28,11 @@
      - missing sprites and priority
 
    Known Issues:
-     - no dual monitor support
-     - games seem to think they're in dual-monitor mode when they're not
-     - speed in some sets is incorrect (for dual monitors I'm guessing it should
-       output alternate frames to alternate monitors, but due to other bugs it
-       just causes the game to run twice as fast as it should?)
-     - synchronization and other oddities (rungunu doesn't show attract mode)
-     - swapped P12 and P34 controls in 4-player mode team selectet (real puzzler)
-     - P3 and P4 coin chutes not working in 4-player mode
-     - sprite palettes are not entirely right
-
+     - CRTC and video registers needs syncronization with current video draw state, it's very noticeable if for example scroll values are in very different states between screens.
+	 - Current draw state could be improved optimization-wise (for example by supporting it in the core in some way).
+	 - sprite palettes are not entirely right
+	 
+	 
 *************************************************************************/
 
 #include "emu.h"
@@ -164,7 +159,8 @@ READ16_MEMBER(rungun_state::sound_status_msb_r)
 
 INTERRUPT_GEN_MEMBER(rungun_state::rng_interrupt)
 {
-	// TODO: in screen update causes sprites to desync badly ...
+	// send to sprite device current state (i.e. bread & butter sprite DMA)
+	// TODO: firing this in screen update causes sprites to desync badly ...
 	address_space &space = m_maincpu->space(AS_PROGRAM);
 
 	for(int i=0;i<0x1000;i+=2)
@@ -219,7 +215,6 @@ static ADDRESS_MAP_START( rungun_map, AS_PROGRAM, 16, rungun_state )
 	AM_RANGE(0x5c0000, 0x5c000f) AM_DEVREAD("k055673", k055673_device, k055673_rom_word_r)                       // 246A ROM readback window
 	AM_RANGE(0x5c0010, 0x5c001f) AM_DEVWRITE("k055673", k055673_device, k055673_reg_word_w)
 	AM_RANGE(0x600000, 0x601fff) AM_RAMBANK("spriteram_bank")                                        	     // OBJ RAM 
-//	AM_RANGE(0x602000, 0x603fff) AM_DEVWRITE("k055673", k055673_device, k053247_word_w)
 	AM_RANGE(0x640000, 0x640007) AM_DEVWRITE("k055673", k055673_device, k053246_word_w)                      // '246A registers
 	AM_RANGE(0x680000, 0x68001f) AM_DEVWRITE("k053936", k053936_device, ctrl_w)          // '936 registers
 	AM_RANGE(0x6c0000, 0x6cffff) AM_READWRITE(rng_psac2_videoram_r,rng_psac2_videoram_w) // PSAC2 ('936) RAM (34v + 35v)

--- a/src/mame/drivers/rungun.cpp
+++ b/src/mame/drivers/rungun.cpp
@@ -423,6 +423,7 @@ static MACHINE_CONFIG_START( rng, rungun_state )
 	MCFG_SCREEN_VISIBLE_AREA(88, 88+384-1, 24, 24+224-1)
 	MCFG_SCREEN_UPDATE_DRIVER(rungun_state, screen_update_rng)
 	MCFG_SCREEN_PALETTE("palette")
+	MCFG_SCREEN_VIDEO_ATTRIBUTES(VIDEO_ALWAYS_UPDATE)
 
 	MCFG_PALETTE_ADD("palette", 1024)
 	MCFG_PALETTE_FORMAT(xBBBBBGGGGGRRRRR)
@@ -443,6 +444,28 @@ static MACHINE_CONFIG_START( rng, rungun_state )
 	MCFG_K053252_OFFSETS(9*8, 24)
 	MCFG_VIDEO_SET_SCREEN("screen")
 
+	MCFG_SCREEN_ADD("demultiplex1", RASTER)
+	MCFG_SCREEN_VIDEO_ATTRIBUTES(VIDEO_UPDATE_BEFORE_VBLANK)
+	MCFG_SCREEN_REFRESH_RATE(59.185606)
+	MCFG_SCREEN_VBLANK_TIME(ATTOSECONDS_IN_USEC(0))
+	MCFG_SCREEN_SIZE(64*8, 32*8)
+	MCFG_SCREEN_VISIBLE_AREA(88, 88+384-1, 24, 24+224-1)
+	MCFG_SCREEN_UPDATE_DRIVER(rungun_state, screen_update_rng_dual_left)
+	MCFG_SCREEN_PALETTE("palette")
+
+	MCFG_PALETTE_ADD("palette2", 1024)
+	MCFG_PALETTE_FORMAT(xBBBBBGGGGGRRRRR)
+	MCFG_PALETTE_ENABLE_SHADOWS()
+	MCFG_PALETTE_ENABLE_HILIGHTS()
+	
+	MCFG_SCREEN_ADD("demultiplex2", RASTER)
+	MCFG_SCREEN_VIDEO_ATTRIBUTES(VIDEO_UPDATE_BEFORE_VBLANK)
+	MCFG_SCREEN_REFRESH_RATE(59.185606)
+	MCFG_SCREEN_VBLANK_TIME(ATTOSECONDS_IN_USEC(0))
+	MCFG_SCREEN_SIZE(64*8, 32*8)
+	MCFG_SCREEN_VISIBLE_AREA(88, 88+384-1, 24, 24+224-1)
+	MCFG_SCREEN_UPDATE_DRIVER(rungun_state, screen_update_rng_dual_right)
+	MCFG_SCREEN_PALETTE("palette2")
 	/* sound hardware */
 	MCFG_SPEAKER_STANDARD_STEREO("lspeaker", "rspeaker")
 
@@ -461,33 +484,7 @@ MACHINE_CONFIG_END
 // for dual-screen output Run and Gun requires the video de-multiplexer board connected to the Jamma output, this gives you 2 Jamma connectors, one for each screen.
 // this means when operated as a single dedicated cabinet the game runs at 60fps, and has smoother animations than when operated as a twin setup where each
 // screen only gets an update every other frame.
-static MACHINE_CONFIG_DERIVED( rng_dual, rng )
-	MCFG_SCREEN_MODIFY("screen") // this needs to always render as we demux from the output of it
-	MCFG_SCREEN_VIDEO_ATTRIBUTES(VIDEO_ALWAYS_UPDATE)
 
-	MCFG_SCREEN_ADD("demultiplex1", RASTER)
-	MCFG_SCREEN_VIDEO_ATTRIBUTES(VIDEO_UPDATE_BEFORE_VBLANK)
-	MCFG_SCREEN_REFRESH_RATE(60)
-	MCFG_SCREEN_VBLANK_TIME(ATTOSECONDS_IN_USEC(0))
-	MCFG_SCREEN_SIZE(64*8, 32*8)
-	MCFG_SCREEN_VISIBLE_AREA(88, 88+384-1, 24, 24+224-1)
-	MCFG_SCREEN_UPDATE_DRIVER(rungun_state, screen_update_rng_dual_left)
-	MCFG_SCREEN_PALETTE("palette")
-
-	MCFG_PALETTE_ADD("palette2", 1024)
-	MCFG_PALETTE_FORMAT(xBBBBBGGGGGRRRRR)
-	MCFG_PALETTE_ENABLE_SHADOWS()
-	MCFG_PALETTE_ENABLE_HILIGHTS()
-	
-	MCFG_SCREEN_ADD("demultiplex2", RASTER)
-	MCFG_SCREEN_VIDEO_ATTRIBUTES(VIDEO_UPDATE_BEFORE_VBLANK)
-	MCFG_SCREEN_REFRESH_RATE(60)
-	MCFG_SCREEN_VBLANK_TIME(ATTOSECONDS_IN_USEC(0))
-	MCFG_SCREEN_SIZE(64*8, 32*8)
-	MCFG_SCREEN_VISIBLE_AREA(88, 88+384-1, 24, 24+224-1)
-	MCFG_SCREEN_UPDATE_DRIVER(rungun_state, screen_update_rng_dual_right)
-	MCFG_SCREEN_PALETTE("palette2")
-MACHINE_CONFIG_END
 
 // Older non-US 53936/A13 roms were all returning bad from the mask ROM check. Using the US ROM on non-US reports good therefore I guess that data matches for that
 // across all sets.
@@ -747,11 +744,11 @@ ROM_END
 
 
 // these sets operate as single screen / dual screen depending on if you have the video de-multiplexer plugged in, and the dipswitch set to 1 or 2 monitors
-GAME( 1993, rungun,   0,      rng, rng, driver_device, 0, ROT0, "Konami", "Run and Gun (ver EAA 1993 10.8)", MACHINE_IMPERFECT_GRAPHICS | MACHINE_IMPERFECT_COLORS | MACHINE_IMPERFECT_SOUND | MACHINE_SUPPORTS_SAVE )
-GAME( 1993, runguna,  rungun, rng, rng, driver_device, 0, ROT0, "Konami", "Run and Gun (ver EAA 1993 10.4)", MACHINE_IMPERFECT_GRAPHICS | MACHINE_IMPERFECT_COLORS | MACHINE_IMPERFECT_SOUND | MACHINE_SUPPORTS_SAVE )
-GAME( 1993, rungunb,  rungun, rng, rng, driver_device, 0, ROT0, "Konami", "Run and Gun (ver EAA 1993 9.10, prototype?)", MACHINE_IMPERFECT_GRAPHICS | MACHINE_IMPERFECT_COLORS | MACHINE_IMPERFECT_SOUND | MACHINE_SUPPORTS_SAVE )
-GAME( 1993, rungunua, rungun, rng, rng, driver_device, 0, ROT0, "Konami", "Run and Gun (ver UBA 1993 10.8)", MACHINE_IMPERFECT_GRAPHICS | MACHINE_IMPERFECT_COLORS | MACHINE_IMPERFECT_SOUND | MACHINE_SUPPORTS_SAVE | MACHINE_NOT_WORKING )
-GAME( 1993, slmdunkj, rungun, rng, rng, driver_device, 0, ROT0, "Konami", "Slam Dunk (ver JAA 1993 10.8)", MACHINE_IMPERFECT_GRAPHICS | MACHINE_IMPERFECT_COLORS | MACHINE_IMPERFECT_SOUND | MACHINE_SUPPORTS_SAVE )
+GAMEL( 1993, rungun,   0,      rng, rng, driver_device, 0, ROT0, "Konami", "Run and Gun (ver EAA 1993 10.8)", MACHINE_IMPERFECT_GRAPHICS | MACHINE_IMPERFECT_COLORS | MACHINE_IMPERFECT_SOUND, layout_rungun_dual )
+GAMEL( 1993, runguna,  rungun, rng, rng, driver_device, 0, ROT0, "Konami", "Run and Gun (ver EAA 1993 10.4)", MACHINE_IMPERFECT_GRAPHICS | MACHINE_IMPERFECT_COLORS | MACHINE_IMPERFECT_SOUND, layout_rungun_dual )
+GAMEL( 1993, rungunb,  rungun, rng, rng, driver_device, 0, ROT0, "Konami", "Run and Gun (ver EAA 1993 9.10, prototype?)", MACHINE_IMPERFECT_GRAPHICS | MACHINE_IMPERFECT_COLORS | MACHINE_IMPERFECT_SOUND, layout_rungun_dual )
+GAMEL( 1993, rungunua, rungun, rng, rng, driver_device, 0, ROT0, "Konami", "Run and Gun (ver UBA 1993 10.8)", MACHINE_IMPERFECT_GRAPHICS | MACHINE_IMPERFECT_COLORS | MACHINE_IMPERFECT_SOUND, layout_rungun_dual )
+GAMEL( 1993, slmdunkj, rungun, rng, rng, driver_device, 0, ROT0, "Konami", "Slam Dunk (ver JAA 1993 10.8)", MACHINE_IMPERFECT_GRAPHICS | MACHINE_IMPERFECT_COLORS | MACHINE_IMPERFECT_SOUND, layout_rungun_dual )
 
 // this set has no dipswitches to select single screen mode (they're not even displayed in test menu) it's twin cabinet ONLY
-GAMEL( 1993, rungunu,  rungun, rng_dual, rng, driver_device, 0, ROT0, "Konami", "Run and Gun (ver UAB 1993 10.12, dedicated twin cabinet)", MACHINE_IMPERFECT_GRAPHICS | MACHINE_IMPERFECT_COLORS | MACHINE_IMPERFECT_SOUND | MACHINE_SUPPORTS_SAVE | MACHINE_NOT_WORKING, layout_rungun_dual ) 
+GAMEL( 1993, rungunu,  rungun, rng, rng, driver_device, 0, ROT0, "Konami", "Run and Gun (ver UAB 1993 10.12, dedicated twin cabinet)", MACHINE_IMPERFECT_GRAPHICS | MACHINE_IMPERFECT_COLORS | MACHINE_IMPERFECT_SOUND, layout_rungun_dual ) 

--- a/src/mame/drivers/rungun.cpp
+++ b/src/mame/drivers/rungun.cpp
@@ -60,22 +60,11 @@ READ16_MEMBER(rungun_state::rng_sysregs_r)
 	switch (offset)
 	{
 		case 0x00/2:
-			if (ioport("DSW")->read() & 0x20)
-				return (ioport("P1")->read() | ioport("P3")->read() << 8);
-			else
-			{
-				data = ioport("P1")->read() & ioport("P3")->read();
-				return (data << 8 | data);
-			}
+			return (ioport("P1")->read() | ioport("P3")->read() << 8);
 
 		case 0x02/2:
-			if (ioport("DSW")->read() & 0x20)
-				return (ioport("P2")->read() | ioport("P4")->read() << 8);
-			else
-			{
-				data = ioport("P2")->read() & ioport("P4")->read();
-				return (data << 8 | data);
-			}
+			return (ioport("P2")->read() | ioport("P4")->read() << 8);
+
 
 		case 0x04/2:
 			/*

--- a/src/mame/includes/rungun.h
+++ b/src/mame/includes/rungun.h
@@ -52,6 +52,7 @@ public:
 	tilemap_t   *m_936_tilemap;
 	UINT16		*m_psac2_vram;
 	UINT16      *m_ttl_vram;
+	UINT16		*m_pal_ram;
 	UINT8		m_current_frame_number;
 	int         m_ttl_gfx_index;
 	int         m_sprite_colorbase;

--- a/src/mame/includes/rungun.h
+++ b/src/mame/includes/rungun.h
@@ -27,6 +27,7 @@ public:
 		m_936_videoram(*this, "936_videoram"),
 		m_gfxdecode(*this, "gfxdecode"),
 		m_palette(*this, "palette"),
+		m_palette2(*this, "palette2"),
 		m_screen(*this, "screen")
 	{ }
 
@@ -45,12 +46,14 @@ public:
 
 	required_device<gfxdecode_device> m_gfxdecode;
 	required_device<palette_device> m_palette;
+	optional_device<palette_device> m_palette2;
 	required_device<screen_device> m_screen;
 
 	/* video-related */
 	tilemap_t   *m_ttl_tilemap;
 	tilemap_t   *m_936_tilemap;
-	UINT16      m_ttl_vram[0x1000];
+	UINT16      *m_ttl_vram;
+	UINT8		m_current_frame_number;
 	int         m_ttl_gfx_index;
 	int         m_sprite_colorbase;
 
@@ -65,6 +68,7 @@ public:
 	bool		m_video_priority_mode;
 	UINT16		*m_banked_ram;
 	bool		m_single_screen_mode;
+	UINT8		m_video_mux_bank;
 	
 	DECLARE_READ16_MEMBER(rng_sysregs_r);
 	DECLARE_WRITE16_MEMBER(rng_sysregs_w);
@@ -81,6 +85,10 @@ public:
 	TILE_GET_INFO_MEMBER(ttl_get_tile_info);
 	TILE_GET_INFO_MEMBER(get_rng_936_tile_info);
 	DECLARE_WRITE_LINE_MEMBER(k054539_nmi_gen);
+	DECLARE_READ16_MEMBER(palette_read);
+	DECLARE_WRITE16_MEMBER(palette_write);
+
+	
 	K055673_CB_MEMBER(sprite_callback);
 
 	virtual void machine_start();

--- a/src/mame/includes/rungun.h
+++ b/src/mame/includes/rungun.h
@@ -24,7 +24,6 @@ public:
 		m_k055673(*this, "k055673"),
 		m_k053252(*this, "k053252"),
 		m_sysreg(*this, "sysreg"),
-		m_936_videoram(*this, "936_videoram"),
 		m_gfxdecode(*this, "gfxdecode"),
 		m_palette(*this, "palette"),
 		m_palette2(*this, "palette2"),
@@ -42,7 +41,6 @@ public:
 
 	/* memory pointers */
 	required_shared_ptr<UINT16> m_sysreg;
-	required_shared_ptr<UINT16> m_936_videoram;
 
 	required_device<gfxdecode_device> m_gfxdecode;
 	required_device<palette_device> m_palette;
@@ -52,6 +50,7 @@ public:
 	/* video-related */
 	tilemap_t   *m_ttl_tilemap;
 	tilemap_t   *m_936_tilemap;
+	UINT16		*m_psac2_vram;
 	UINT16      *m_ttl_vram;
 	UINT8		m_current_frame_number;
 	int         m_ttl_gfx_index;
@@ -80,7 +79,8 @@ public:
 	DECLARE_WRITE8_MEMBER(sound_ctrl_w);
 	DECLARE_READ16_MEMBER(rng_ttl_ram_r);
 	DECLARE_WRITE16_MEMBER(rng_ttl_ram_w);
-	DECLARE_WRITE16_MEMBER(rng_936_videoram_w);
+	DECLARE_READ16_MEMBER(rng_psac2_videoram_r);
+	DECLARE_WRITE16_MEMBER(rng_psac2_videoram_w);
 	DECLARE_READ8_MEMBER(rng_53936_rom_r);
 	TILE_GET_INFO_MEMBER(ttl_get_tile_info);
 	TILE_GET_INFO_MEMBER(get_rng_936_tile_info);

--- a/src/mame/video/rungun.cpp
+++ b/src/mame/video/rungun.cpp
@@ -119,7 +119,6 @@ UINT32 rungun_state::screen_update_rng(screen_device &screen, bitmap_ind16 &bitm
 		m_936_tilemap->mark_all_dirty();
 
 	}	
-	//	AM_RANGE(0x600000, 0x600fff) AM_DEVREADWRITE("k055673", k055673_device, k053247_word_r, k053247_word_w)  // OBJ RAM
 
 
 	if(m_video_priority_mode == false)
@@ -137,7 +136,7 @@ UINT32 rungun_state::screen_update_rng(screen_device &screen, bitmap_ind16 &bitm
 
 	// copy frame output to temp buffers so we can demultiplex it for the dual screen output
 	// (really only need to do this for dual setup)
-	if (machine().first_screen()->frame_number() & 1)
+	if (m_current_frame_number)
 	{
 		copybitmap(m_rng_dual_demultiplex_right_temp, bitmap, 0, 0, 0, 0, cliprect);
 	}

--- a/src/mame/video/rungun.cpp
+++ b/src/mame/video/rungun.cpp
@@ -117,7 +117,6 @@ UINT32 rungun_state::screen_update_rng(screen_device &screen, bitmap_ind16 &bitm
 	{
 		m_ttl_tilemap->mark_all_dirty();
 		m_936_tilemap->mark_all_dirty();
-
 	}	
 
 


### PR DESCRIPTION
This patch takes into accout current multiplexer frame for drawing and palette updates. 
Makes dual screen 4p support to happen for all games in the driver. 

I'm not directly merging because I would like to know if anybody has a costructive criticism, if any.