### PR TITLE
fix build for VS 2013 and earlier.

### DIFF
--- a/src/lib/formats/cassimg.cpp
+++ b/src/lib/formats/cassimg.cpp
@@ -279,7 +279,9 @@ void cassette_close(cassette_image *cassette)
 		if ((cassette->flags & CASSETTE_FLAG_DIRTY) && (cassette->flags & CASSETTE_FLAG_SAVEONEXIT))
 			cassette_save(cassette);
 		for (auto & elem : cassette->blocks)
+		{
 			global_free(elem);
+		}
 		global_free(cassette);
 	}
 }


### PR DESCRIPTION
reference http://stackoverflow.com/questions/22212737/strange-syntax-error-reported-in-a-range-based-for-loop