### PR TITLE
VDP changed from msx_tms9918 to msx_ntsc for Daewoo MSX dpc200

### DIFF
--- a/src/mame/drivers/msx.cpp
+++ b/src/mame/drivers/msx.cpp
@@ -1921,7 +1921,7 @@ ROM_START (dpc200)
 	ROM_LOAD ("200han.rom",  0x8000, 0x4000, CRC(97478efb) SHA1(4421fa2504cbce18f7c84b5ea97f04e017007f07))
 ROM_END
 
-static MACHINE_CONFIG_DERIVED( dpc200, msx_tms9918 )
+static MACHINE_CONFIG_DERIVED( dpc200, msx_ntsc )
 	// AY8910/YM2149?
 	// FDC: None, 0 drives
 	// 2 Cartridge slots


### PR DESCRIPTION
Daewoo MSX dpc200 has strange configuration for TMS9918.
Most of MSX in Korea has msx_ntsc instead of msx_tms9918.
This difference makes an display error in SCREEN 2 mode,
It can be fixed by changing the value from msx_tms9918 to msx_ntsc