### PR TITLE
Fixed listxml sample output.

### DIFF
--- a/src/emu/info.cpp
+++ b/src/emu/info.cpp
@@ -620,7 +620,7 @@ void info_xml_creator::output_sample(device_t &device)
 		for (const char *samplename = iter.first(); samplename != nullptr; samplename = iter.next())
 		{
 			// filter out duplicates
-			if (already_printed.insert(samplename).second)
+			if (!(already_printed.insert(samplename)).second)
 				continue;
 
 			// output the sample name


### PR DESCRIPTION
The listxml dosn't output the game samples.
This fixed commit: tagmap_t to std::unordered_map or std::unordered_set where applicable… 
https://github.com/mamedev/mame/commit/3414b0166e77c5353373d655e3def0251571722d