### PR TITLE
Modernize x86log.h and x86log.cpp

### DIFF
--- a/src/devices/cpu/x86log.cpp
+++ b/src/devices/cpu/x86log.cpp
@@ -8,9 +8,9 @@
 
 ***************************************************************************/
 
+#include <cstdint>
 #include "emu.h"
 #include "x86log.h"
-
 
 
 /***************************************************************************
@@ -18,10 +18,9 @@
 ***************************************************************************/
 
 /* comment parameters */
-#define MAX_COMMENTS        4000
-#define MAX_DATA_RANGES     1000
-#define COMMENT_POOL_SIZE   (MAX_COMMENTS * 40)
-
+constexpr std::size_t MAX_COMMENTS{4000};
+constexpr std::size_t MAX_DATA_RANGES{1000};
+constexpr std::size_t COMMENT_POOL_SIZE{MAX_COMMENTS * 40};
 
 
 /***************************************************************************
@@ -67,7 +66,7 @@ struct x86log_context
     FUNCTION PROTOTYPES
 ***************************************************************************/
 
-static void reset_log(x86log_context *log);
+static void reset_log(x86log_context *log) noexcept;
 extern int i386_dasm_one_ex(char *buffer, UINT64 eip, const UINT8 *oprom, int mode);
 
 
@@ -100,7 +99,7 @@ x86log_context *x86log_create_context(const char *filename)
     x86log_free_context - release a context
 -------------------------------------------------*/
 
-void x86log_free_context(x86log_context *log)
+void x86log_free_context(x86log_context *log) noexcept
 {
 	/* close any open files */
 	if (log->file != nullptr)
@@ -112,46 +111,11 @@ void x86log_free_context(x86log_context *log)
 
 
 /*-------------------------------------------------
-    x86log_add_comment - add a comment associated
-    with a given code pointer
--------------------------------------------------*/
-
-void x86log_add_comment(x86log_context *log, x86code *base, const char *format, ...)
-{
-	char *string = log->comment_pool_next;
-	log_comment *comment;
-	va_list va;
-
-	assert(log->comment_count < MAX_COMMENTS);
-	assert(log->comment_pool_next + strlen(format) + 256 < log->comment_pool + COMMENT_POOL_SIZE);
-
-	/* we assume comments are registered in order; enforce this */
-	assert(log->comment_count == 0 || base >= log->comment_list[log->comment_count - 1].base);
-
-	/* if we exceed the maxima, skip it */
-	if (log->comment_count >= MAX_COMMENTS)
-		return;
-	if (log->comment_pool_next + strlen(format) + 256 >= log->comment_pool + COMMENT_POOL_SIZE)
-		return;
-
-	/* do the printf to the string pool */
-	va_start(va, format);
-	log->comment_pool_next += vsprintf(log->comment_pool_next, format, va) + 1;
-	va_end(va);
-
-	/* fill in the new comment */
-	comment = &log->comment_list[log->comment_count++];
-	comment->base = base;
-	comment->string = string;
-}
-
-
-/*-------------------------------------------------
     x86log_mark_as_data - mark a given range as
     data for logging purposes
 -------------------------------------------------*/
 
-void x86log_mark_as_data(x86log_context *log, x86code *base, x86code *end, int size)
+void x86log_mark_as_data(x86log_context *log, x86code *base, x86code *end, int size) noexcept
 {
 	data_range_t *data;
 
@@ -258,31 +222,6 @@ void x86log_disasm_code_range(x86log_context *log, const char *label, x86code *s
 }
 
 
-/*-------------------------------------------------
-    x86log_printf - manually printf information to
-    the log file
--------------------------------------------------*/
-
-void x86log_printf(x86log_context *log, const char *format, ...)
-{
-	va_list va;
-
-	/* open the file, creating it if necessary */
-	if (log->file == nullptr)
-		log->file = fopen(log->filename.c_str(), "w");
-	if (log->file == nullptr)
-		return;
-
-	/* do the printf */
-	va_start(va, format);
-	vfprintf(log->file, format, va);
-	va_end(va);
-
-	/* flush the file */
-	fflush(log->file);
-}
-
-
 
 /***************************************************************************
     LOCAL FUNCTIONS
@@ -292,7 +231,7 @@ void x86log_printf(x86log_context *log, const char *format, ...)
     reset_log - reset the state of the log
 -------------------------------------------------*/
 
-static void reset_log(x86log_context *log)
+static void reset_log(x86log_context *log) noexcept
 {
 	log->data_range_count = 0;
 	log->comment_count = 0;

--- a/src/devices/cpu/x86log.h
+++ b/src/devices/cpu/x86log.h
@@ -32,19 +32,80 @@ struct x86log_context;
 x86log_context *x86log_create_context(const char *filename);
 
 /* release a context */
-void x86log_free_context(x86log_context *log);
+void x86log_free_context(x86log_context *log) noexcept;
 
 /* add a comment associated with a given code pointer */
-void x86log_add_comment(x86log_context *log, x86code *base, const char *format, ...) ATTR_PRINTF(3,4);
+template<typename... Ts>
+inline void x86log_add_comment(x86log_context *log, x86code *base, const char *format, Ts&&... xs);
 
 /* mark a given range as data for logging purposes */
-void x86log_mark_as_data(x86log_context *log, x86code *base, x86code *end, int size);
+void x86log_mark_as_data(x86log_context *log, x86code *base, x86code *end, int size) noexcept;
 
 /* disassemble a range of code and reset accumulated information */
 void x86log_disasm_code_range(x86log_context *log, const char *label, x86code *start, x86code *stop);
 
 /* manually printf information to the log file */
-void x86log_printf(x86log_context *log, const char *format, ...) ATTR_PRINTF(2,3);
+template<typename... Ts>
+inline void x86log_printf(x86log_context *log, const char *format, Ts&&... xs);
 
+
+/*-------------------------------------------------
+    x86log_add_comment - add a comment associated
+    with a given code pointer
+-------------------------------------------------*/
+
+template<typename... Ts>
+inline void x86log_add_comment(x86log_context *log, x86code *base, const char *format, Ts&&... xs)
+{
+	char *string = log->comment_pool_next;
+	log_comment *comment;
+
+	assert(log->comment_count < MAX_COMMENTS);
+	assert(log->comment_pool_next + strlen(format) + 256 < log->comment_pool + COMMENT_POOL_SIZE);
+
+	/* we assume comments are registered in order; enforce this */
+	assert(log->comment_count == 0 || base >= log->comment_list[log->comment_count - 1].base);
+
+	/* if we exceed the maxima, skip it */
+	if (log->comment_count >= MAX_COMMENTS)
+		return;
+	if (log->comment_pool_next + strlen(format) + 256 >= log->comment_pool + COMMENT_POOL_SIZE)
+		return;
+
+	/* do the printf to the string pool */
+	log->comment_pool_next += sprintf(log->comment_pool_next, format, std::forward<Ts>(xs)...) + 1;
+
+	/* fill in the new comment */
+	comment = &log->comment_list[log->comment_count++];
+	comment->base = base;
+	comment->string = string;
+}
+
+
+/*-------------------------------------------------
+    x86log_printf - manually printf information to
+    the log file
+-------------------------------------------------*/
+
+template<typename... Ts>
+inline void x86log_printf(x86log_context *log, const char *format, Ts&&... xs)
+{
+	/* open the file, creating it if necessary */
+	if (log->file == nullptr)
+	{
+		log->file = fopen(log->filename.c_str(), "w");
+		
+		if (log->file == nullptr)
+			return;
+	}
+
+	assert(log->file != nullptr);
+
+	/* do the printf */
+	fprintf(log->file, format, std::forward<Ts>(xs)...);
+
+	/* flush the file */
+	fflush(log->file);
+}
 
 #endif  /* __X86LOG_H__ */

--- a/src/lib/util/coretmpl.h
+++ b/src/lib/util/coretmpl.h
@@ -62,25 +62,25 @@ inline std::unique_ptr<T> make_unique_clear()
 // a simple_list is a singly-linked list whose 'next' pointer is owned
 // by the object
 template<class _ElementType>
-class simple_list
+class simple_list final
 {
-	// we don't support deep copying
-	simple_list(const simple_list &);
-	simple_list &operator=(const simple_list &);
-
 public:
+	// we don't support deep copying
+	simple_list(const simple_list &) = delete;
+	simple_list &operator=(const simple_list &) = delete;
+
 	// construction/destruction
-	simple_list()
+	simple_list() noexcept
 		: m_head(nullptr),
 			m_tail(nullptr),
 			m_count(0) { }
 
-	virtual ~simple_list() { reset(); }
+	~simple_list() noexcept { reset(); }
 
 	// simple getters
-	_ElementType *first() const { return m_head; }
-	_ElementType *last() const { return m_tail; }
-	int count() const { return m_count; }
+	_ElementType *first() const noexcept { return m_head; }
+	_ElementType *last() const noexcept { return m_tail; }
+	int count() const noexcept { return m_count; }
 
 	// remove (free) all objects in the list, leaving an empty list
 	void reset()
@@ -101,7 +101,7 @@ public:
 	}
 
 	// add the given list to the head of the list
-	void prepend_list(simple_list<_ElementType> &list)
+	void prepend_list(simple_list<_ElementType> &list) noexcept
 	{
 		int count = list.count();
 		if (count == 0)
@@ -116,7 +116,7 @@ public:
 	}
 
 	// add the given object to the tail of the list
-	_ElementType &append(_ElementType &object)
+	_ElementType &append(_ElementType &object) noexcept
 	{
 		object.m_next = nullptr;
 		if (m_tail != nullptr)
@@ -128,7 +128,7 @@ public:
 	}
 
 	// add the given list to the tail of the list
-	void append_list(simple_list<_ElementType> &list)
+	void append_list(simple_list<_ElementType> &list) noexcept
 	{
 		int count = list.count();
 		if (count == 0)
@@ -144,7 +144,7 @@ public:
 	}
 
 	// insert the given object after a particular object (NULL means prepend)
-	_ElementType &insert_after(_ElementType &object, _ElementType *insert_after)
+	_ElementType &insert_after(_ElementType &object, _ElementType *insert_after) noexcept
 	{
 		if (insert_after == nullptr)
 			return prepend(object);
@@ -157,7 +157,7 @@ public:
 	}
 
 	// insert the given object before a particular object (NULL means append)
-	_ElementType &insert_before(_ElementType &object, _ElementType *insert_before)
+	_ElementType &insert_before(_ElementType &object, _ElementType *insert_before) noexcept
 	{
 		if (insert_before == nullptr)
 			return append(object);
@@ -175,7 +175,7 @@ public:
 	}
 
 	// replace an item in the list at the same location, and remove it
-	_ElementType &replace_and_remove(_ElementType &object, _ElementType &toreplace)
+	_ElementType &replace_and_remove(_ElementType &object, _ElementType &toreplace) noexcept
 	{
 		_ElementType *prev = nullptr;
 		for (_ElementType *cur = m_head; cur != nullptr; prev = cur, cur = cur->m_next)
@@ -195,7 +195,7 @@ public:
 	}
 
 	// detach the head item from the list, but don't free its memory
-	_ElementType *detach_head()
+	_ElementType *detach_head() noexcept
 	{
 		_ElementType *result = m_head;
 		if (result != nullptr)
@@ -209,7 +209,7 @@ public:
 	}
 
 	// detach the given item from the list, but don't free its memory
-	_ElementType &detach(_ElementType &object)
+	_ElementType &detach(_ElementType &object) noexcept
 	{
 		_ElementType *prev = nullptr;
 		for (_ElementType *cur = m_head; cur != nullptr; prev = cur, cur = cur->m_next)
@@ -228,7 +228,7 @@ public:
 	}
 
 	// deatch the entire list, returning the head, but don't free memory
-	_ElementType *detach_all()
+	_ElementType *detach_all() noexcept
 	{
 		_ElementType *result = m_head;
 		m_head = m_tail = nullptr;
@@ -237,13 +237,13 @@ public:
 	}
 
 	// remove the given object and free its memory
-	void remove(_ElementType &object)
+	void remove(_ElementType &object) noexcept
 	{
 		global_free(&detach(object));
 	}
 
 	// find an object by index in the list
-	_ElementType *find(int index) const
+	_ElementType *find(int index) const noexcept
 	{
 		for (_ElementType *cur = m_head; cur != nullptr; cur = cur->m_next)
 			if (index-- == 0)
@@ -252,7 +252,7 @@ public:
 	}
 
 	// return the index of the given object in the list
-	int indexof(const _ElementType &object) const
+	int indexof(const _ElementType &object) const noexcept
 	{
 		int index = 0;
 		for (_ElementType *cur = m_head; cur != nullptr; cur = cur->m_next)


### PR DESCRIPTION
* Use variadic template functions instead of `va_list`
    * In `x86log_mark_as_data` and `x86log_printf`
* Add `noexcept` where appropriate/safe
* Use `constexpr std::size_t` instead of macros for constants
* Nest `nullptr` check to prevent useless check, add assertion
    * In `x86log_printf`

*(Hope variadic templates are OK!)*