### PR TITLE
Modernize x86log.h and x86log.cpp:

### DIFF
--- a/src/devices/cpu/drcbex64.cpp
+++ b/src/devices/cpu/drcbex64.cpp
@@ -680,7 +680,7 @@ void drcbe_x64::reset()
 {
 	// output a note to the log
 	if (m_log != nullptr)
-		x86log_printf(m_log, "\n\n===========\nCACHE RESET\n===========\n\n");
+		x86log_printf(m_log, "%s", "\n\n===========\nCACHE RESET\n===========\n\n");
 
 	// generate a little bit of glue code to set up the environment
 	drccodeptr *cachetop = m_cache.begin_codegen(500);

--- a/src/devices/cpu/drcbex86.cpp
+++ b/src/devices/cpu/drcbex86.cpp
@@ -594,7 +594,7 @@ void drcbe_x86::reset()
 {
 	// output a note to the log
 	if (m_log != nullptr)
-		x86log_printf(m_log, "\n\n===========\nCACHE RESET\n===========\n\n");
+		x86log_printf(m_log, "%s", "\n\n===========\nCACHE RESET\n===========\n\n");
 
 	// generate a little bit of glue code to set up the environment
 	drccodeptr *cachetop = m_cache.begin_codegen(500);

--- a/src/devices/cpu/x86log.h
+++ b/src/devices/cpu/x86log.h
@@ -13,14 +13,57 @@
 #ifndef __X86LOG_H__
 #define __X86LOG_H__
 
+#include <cstdint>
+#include <cassert>
 #include "x86emit.h"
+
+
+/***************************************************************************
+    CONSTANTS
+***************************************************************************/
+
+/* comment parameters */
+constexpr int MAX_COMMENTS{4000};
+constexpr int MAX_DATA_RANGES{1000};
+constexpr int COMMENT_POOL_SIZE{MAX_COMMENTS * 40};
 
 
 /***************************************************************************
     TYPE DEFINITIONS
 ***************************************************************************/
 
-struct x86log_context;
+/* code logging info */
+struct log_comment
+{
+    x86code* base;
+    const char* string;
+};
+
+
+/* data ranges */
+struct data_range_t
+{
+    x86code* base;
+    x86code* end;
+    int size;
+};
+
+
+/* the code logging context */
+struct x86log_context
+{
+    std::string filename; /* name of the file */
+    FILE* file;           /* file we are logging to */
+
+    data_range_t data_range[MAX_DATA_RANGES]; /* list of data ranges */
+    int data_range_count;                     /* number of data ranges */
+
+    log_comment comment_list[MAX_COMMENTS]; /* list of comments */
+    int comment_count;                      /* number of live comments */
+
+    char comment_pool[COMMENT_POOL_SIZE]; /* string pool to hold comments */
+    char* comment_pool_next; /* pointer to next string pool location */
+};
 
 
 
@@ -29,22 +72,89 @@ struct x86log_context;
 ***************************************************************************/
 
 /* create a new context */
-x86log_context *x86log_create_context(const char *filename);
+x86log_context* x86log_create_context(const char* filename);
 
 /* release a context */
-void x86log_free_context(x86log_context *log);
+void x86log_free_context(x86log_context* log) noexcept;
 
 /* add a comment associated with a given code pointer */
-void x86log_add_comment(x86log_context *log, x86code *base, const char *format, ...) ATTR_PRINTF(3,4);
+template <typename... Ts>
+inline void x86log_add_comment(
+    x86log_context* log, x86code* base, const char* format, Ts&&... xs);
 
 /* mark a given range as data for logging purposes */
-void x86log_mark_as_data(x86log_context *log, x86code *base, x86code *end, int size);
+void x86log_mark_as_data(
+    x86log_context* log, x86code* base, x86code* end, int size) noexcept;
 
 /* disassemble a range of code and reset accumulated information */
-void x86log_disasm_code_range(x86log_context *log, const char *label, x86code *start, x86code *stop);
+void x86log_disasm_code_range(
+    x86log_context* log, const char* label, x86code* start, x86code* stop);
 
 /* manually printf information to the log file */
-void x86log_printf(x86log_context *log, const char *format, ...) ATTR_PRINTF(2,3);
+template <typename... Ts>
+inline void x86log_printf(x86log_context* log, const char* format, Ts&&... xs);
 
 
-#endif  /* __X86LOG_H__ */
+/*-------------------------------------------------
+    x86log_add_comment - add a comment associated
+    with a given code pointer
+-------------------------------------------------*/
+
+template <typename... Ts>
+inline void x86log_add_comment(
+    x86log_context* log, x86code* base, const char* format, Ts&&... xs)
+{
+    char* string = log->comment_pool_next;
+    log_comment* comment;
+
+    assert(log->comment_count < MAX_COMMENTS);
+    assert(log->comment_pool_next + strlen(format) + 256 <
+           log->comment_pool + COMMENT_POOL_SIZE);
+
+    /* we assume comments are registered in order; enforce this */
+    assert(log->comment_count == 0 ||
+           base >= log->comment_list[log->comment_count - 1].base);
+
+    /* if we exceed the maxima, skip it */
+    if(log->comment_count >= MAX_COMMENTS) return;
+    if(log->comment_pool_next + strlen(format) + 256 >=
+        log->comment_pool + COMMENT_POOL_SIZE)
+        return;
+
+    /* do the printf to the string pool */
+    log->comment_pool_next +=
+        sprintf(log->comment_pool_next, format, std::forward<Ts>(xs)...) + 1;
+
+    /* fill in the new comment */
+    comment = &log->comment_list[log->comment_count++];
+    comment->base = base;
+    comment->string = string;
+}
+
+
+/*-------------------------------------------------
+    x86log_printf - manually printf information to
+    the log file
+-------------------------------------------------*/
+
+template <typename... Ts>
+inline void x86log_printf(x86log_context* log, const char* format, Ts&&... xs)
+{
+    /* open the file, creating it if necessary */
+    if(log->file == nullptr)
+    {
+        log->file = fopen(log->filename.c_str(), "w");
+
+        if(log->file == nullptr) return;
+    }
+
+    assert(log->file != nullptr);
+
+    /* do the printf */
+    fprintf(log->file, format, std::forward<Ts>(xs)...);
+
+    /* flush the file */
+    fflush(log->file);
+}
+
+#endif /* __X86LOG_H__ */


### PR DESCRIPTION
* Use variadic template functions instead of `va_list`
    * In `x86log_mark_as_data` and `x86log_printf`
* Add `noexcept` where appropriate/safe
* Use `constexpr std::size_t` instead of macros for constants
* Nest `nullptr` check to prevent useless check, add assertion
    * In `x86log_printf`
* Move definitions of `log_comment`, `data_range_t`, `x86log_context` to `x86_log.h` from `x86_log.cpp`
* Adapt usages of `x86log_printf` in `drcbex64.cpp` and `drcbex86.cpp`