### PR TITLE
Make -verifyroms verify sub-devices like mpu401 and c2040fdc

### DIFF
--- a/src/emu/clifront.cpp
+++ b/src/emu/clifront.cpp
@@ -939,6 +939,67 @@ void cli_frontend::verifyroms(const char *gamename)
 								}
 							}
 						}
+					} else {
+						// check for subdevices with ROMs (a few devices are missed otherwise, e.g. MPU401)
+						device_iterator subiter(*dev);
+						for (device_t *device = subiter.first(); device != nullptr; device = subiter.next())
+						{
+							device_iterator subsubiter(*device);
+							for (device_t *subdev = subsubiter.first(); subdev != nullptr; subdev = subsubiter.next())
+							{
+								if (subdev->owner() == device && subdev->rom_region() != nullptr && subdev->shortname() != nullptr && subdev->shortname()[0] != '\0')
+								{
+									if (device_map.insert(subdev->shortname()).second)
+									{
+										if (core_strwildcmp(gamename, subdev->shortname()) == 0)
+										{
+											matched++;
+
+											// audit the ROMs in this set
+											media_auditor::summary summary = auditor.audit_device(subdev, AUDIT_VALIDATE_FAST);
+
+											// if not found, count that and leave it at that
+											if (summary == media_auditor::NOTFOUND)
+												notfound++;
+
+											// else display information about what we discovered
+											else if (summary != media_auditor::NONE_NEEDED)
+											{
+												// output the summary of the audit
+												std::string summary_string;
+												auditor.summarize(subdev->shortname(),&summary_string);
+												osd_printf_info("%s", summary_string.c_str());
+
+												// display information about what we discovered
+												osd_printf_info("romset %s ", subdev->shortname());
+
+												// switch off of the result
+												switch (summary)
+												{
+													case media_auditor::INCORRECT:
+														osd_printf_info("is bad\n");
+														incorrect++;
+														break;
+
+													case media_auditor::CORRECT:
+														osd_printf_info("is good\n");
+														correct++;
+														break;
+
+													case media_auditor::BEST_AVAILABLE:
+														osd_printf_info("is best available\n");
+														correct++;
+														break;
+
+													default:
+														break;
+												}
+											}
+										}
+									}
+								}
+							}
+						}
 					}
 
 					const_cast<machine_config &>(config).device_remove(&config.root_device(), temptag.c_str());


### PR DESCRIPTION
-verifyroms doesn't verify sub-(sub-)devices like mpu401 and c2040fdc. This change enables it.