### PR TITLE
Increase debug console maximum parameters in debugcon.h

### DIFF
--- a/src/emu/debug/debugcon.h
+++ b/src/emu/debug/debugcon.h
@@ -18,8 +18,8 @@
     CONSTANTS
 ***************************************************************************/
 
-#define MAX_COMMAND_LENGTH                  512
-#define MAX_COMMAND_PARAMS                  16
+#define MAX_COMMAND_LENGTH                  4096
+#define MAX_COMMAND_PARAMS                  128
 
 /* flags for command parsing */
 #define CMDFLAG_NONE                        (0x0000)


### PR DESCRIPTION
Increased MAX_COMMAND PARAMS and MAX_COMMAND_LENGTH to quadruple their previous size.  The previous values did not have the capacity to allow trace logging of all registers at the same time in some CPUS.  Setting the maximum to 128 should allow for capturing of systems with large symbolic lists (such as Playstation) if needed. 

For example, the following command would throw an error when trace logging a 68000 CPU because the maximum parameters (16) would be reached when attempting to capture all registers:

trace 68K.log,0,{tracelog "A0=%08X, A1=%08X, A2=%08X, A3=%08X, A4=%08X, A5=%08X, A6=%08X, A7=%08X, D0=%08X, D1=%08X, D2=%08X, D3=%08X, D4=%08X, D5=%08X, D6=%08X, D7=%08X ",a0,a1,a2,a3,a4,a5,a6,a7,d0,d1,d2,d3,d4,d5,d6,d7}