### PR TITLE
Allow mame -validate -verbose to capture verbose messages

### DIFF
--- a/src/emu/clifront.cpp
+++ b/src/emu/clifront.cpp
@@ -1612,7 +1612,7 @@ void cli_frontend::execute_commands(const char *exename)
 		validity_checker valid(m_options);
 		bool result = valid.check_all();
 		if (!result)
-			throw emu_fatalerror(MAMERR_FAILED_VALIDITY, "Validity check failed!\n");
+			throw emu_fatalerror(MAMERR_FAILED_VALIDITY, "Validity check failed (%d errors, %d warnings in total)\n", valid.errors(), valid.warnings());
 		return;
 	}
 

--- a/src/emu/mame.cpp
+++ b/src/emu/mame.cpp
@@ -194,6 +194,7 @@ int machine_manager::execute()
 		if (system != nullptr)
 		{
 			validity_checker valid(m_options);
+			valid.set_verbose(false);
 			valid.check_shared_source(*system);
 		}
 

--- a/src/emu/validity.h
+++ b/src/emu/validity.h
@@ -84,6 +84,7 @@ private:
 	// output helpers
 	void build_output_prefix(std::string &str);
 	void output_via_delegate(osd_output_channel channel, const char *format, ...) ATTR_PRINTF(3,4);
+	void output_indented_errors(std::string &text, const char *header);
 
 	// internal driver list
 	driver_enumerator       m_drivlist;

--- a/src/emu/validity.h
+++ b/src/emu/validity.h
@@ -40,6 +40,9 @@ public:
 	int errors() const { return m_errors; }
 	int warnings() const { return m_warnings; }
 
+	// setter
+	void set_verbose(bool verbose) { m_print_verbose = verbose; }
+
 	// operations
 	void check_driver(const game_driver &driver);
 	void check_shared_source(const game_driver &driver);
@@ -88,8 +91,10 @@ private:
 	// error tracking
 	int                     m_errors;
 	int                     m_warnings;
+	bool                    m_print_verbose;
 	std::string             m_error_text;
 	std::string             m_warning_text;
+	std::string             m_verbose_text;
 
 	// maps for finding duplicates
 	game_driver_map         m_names_map;

--- a/src/lib/util/corealloc.h
+++ b/src/lib/util/corealloc.h
@@ -87,15 +87,12 @@ extern const zeromem_t zeromem;
 #ifndef NO_MEM_TRACKING
 // re-route classic malloc-style allocations
 #undef malloc
+#undef realloc
 #undef free
 
 #define malloc(x)       malloc_file_line(x, __FILE__, __LINE__, true, false, false)
-#define free(x)         free_file_line(x, __FILE__, __LINE__, true)
-
-#if !defined(__APPLE__) // avoid conflicts with some 3rd-party #includes
-#undef realloc
 #define realloc(x,y)    __error_realloc_is_dangerous__
-#endif
+#define free(x)         free_file_line(x, __FILE__, __LINE__, true)
 
 #if !defined(_MSC_VER) || _MSC_VER < 1900 // < VS2015
 #undef calloc

--- a/src/lib/util/corealloc.h
+++ b/src/lib/util/corealloc.h
@@ -87,12 +87,15 @@ extern const zeromem_t zeromem;
 #ifndef NO_MEM_TRACKING
 // re-route classic malloc-style allocations
 #undef malloc
-#undef realloc
 #undef free
 
 #define malloc(x)       malloc_file_line(x, __FILE__, __LINE__, true, false, false)
-#define realloc(x,y)    __error_realloc_is_dangerous__
 #define free(x)         free_file_line(x, __FILE__, __LINE__, true)
+
+#if !defined(__APPLE__) // avoid conflicts with some 3rd-party #includes
+#undef realloc
+#define realloc(x,y)    __error_realloc_is_dangerous__
+#endif
 
 #if !defined(_MSC_VER) || _MSC_VER < 1900 // < VS2015
 #undef calloc

--- a/src/osd/modules/lib/osdobj_common.cpp
+++ b/src/osd/modules/lib/osdobj_common.cpp
@@ -13,8 +13,6 @@
 #include "osdepend.h"
 #include "modules/lib/osdobj_common.h"
 
-extern bool g_print_verbose;
-
 const options_entry osd_options::s_option_entries[] =
 {
 	{ NULL,                                   NULL,             OPTION_HEADER,    "OSD KEYBOARD MAPPING OPTIONS" },
@@ -155,6 +153,7 @@ osd_options::osd_options()
 osd_common_t::osd_common_t(osd_options &options)
 	: osd_output(), m_machine(NULL),
 		m_options(options),
+		m_print_verbose(false),
 		m_sound(NULL),
 		m_debugger(NULL)
 {
@@ -278,9 +277,11 @@ void osd_common_t::output_callback(osd_output_channel channel, const char *msg, 
 			vfprintf(stderr, msg, args);
 			break;
 		case OSD_OUTPUT_CHANNEL_INFO:
-		case OSD_OUTPUT_CHANNEL_VERBOSE:
 		case OSD_OUTPUT_CHANNEL_LOG:
 			vfprintf(stdout, msg, args);
+			break;
+		case OSD_OUTPUT_CHANNEL_VERBOSE:
+			if (verbose()) vfprintf(stdout, msg, args);
 			break;
 		case OSD_OUTPUT_CHANNEL_DEBUG:
 #ifdef MAME_DEBUG
@@ -333,7 +334,7 @@ void osd_common_t::init(running_machine &machine)
 	osd_options &options = downcast<osd_options &>(machine.options());
 	// extract the verbose printing option
 	if (options.verbose())
-		g_print_verbose = true;
+		set_verbose(true);
 
 	// ensure we get called on the way out
 	machine.add_notifier(MACHINE_NOTIFY_EXIT, machine_notify_delegate(FUNC(osd_common_t::osd_exit), this));

--- a/src/osd/modules/lib/osdobj_common.h
+++ b/src/osd/modules/lib/osdobj_common.h
@@ -202,7 +202,6 @@ public:
 	// getters
 	running_machine &machine() { assert(m_machine != nullptr); return *m_machine; }
 
-
 	virtual void debugger_update();
 
 	virtual void init_subsystems();
@@ -228,6 +227,8 @@ public:
 
 	// osd_output interface ...
 	virtual void output_callback(osd_output_channel channel, const char *msg, va_list args)  override;
+	bool verbose() const { return m_print_verbose; }
+	void set_verbose(bool print_verbose) { m_print_verbose = print_verbose; }
 
 protected:
 	virtual bool input_init();
@@ -237,6 +238,8 @@ private:
 	// internal state
 	running_machine *   m_machine;
 	osd_options& m_options;
+
+	bool m_print_verbose;
 
 	osd_module_manager m_mod_man;
 	font_module *m_font_module;

--- a/src/osd/osdcore.cpp
+++ b/src/osd/osdcore.cpp
@@ -3,8 +3,6 @@
 
 #include "osdcore.h"
 
-bool g_print_verbose = false;
-
 static const int MAXSTACK = 10;
 static osd_output *m_stack[MAXSTACK];
 static int m_ptr = -1;
@@ -103,10 +101,6 @@ void CLIB_DECL osd_printf_info(const char *format, ...)
 void CLIB_DECL osd_printf_verbose(const char *format, ...)
 {
 	va_list argptr;
-
-	/* if we're not verbose, skip it */
-	if (!g_print_verbose)
-		return;
 
 	/* do the output */
 	va_start(argptr, format);


### PR DESCRIPTION
* Verbose messages can be enabled by option for the -validate command. They are displayed through the same channel as errors and warnings encountered during validation but are not counted as either, and are printed separately for each driver if produced. Verbose output is entirely disabled for pre-run validation to spare users from spurious error pop-ups.
* osd_printf_verbose is no longer enabled or disabled by a global variable; instead, osd_output objects should make the decision whether or not to allow verbose messages, as is now done within both osd_common_t and validity_checker.
* Messages printed by the validity checker no longer have superfluous indentation following the last newline.
* The validity checker now tracks and tags devices slightly differently, omitting the leading colons from the output for conciseness, and tracking devices properly when validating their object finders.