### PR TITLE
Get .ini file default path makefile variable back.

### DIFF
--- a/scripts/src/osd/sdl_cfg.lua
+++ b/scripts/src/osd/sdl_cfg.lua
@@ -18,6 +18,11 @@ if _OPTIONS["NO_OPENGL"]~="1" and _OPTIONS["USE_DISPATCH_GL"]~="1" and _OPTIONS[
 	}
 end
 
+if _OPTIONS["SDL_INI_PATH"]~=nil then
+    defines {
+        "'INI_PATH=\"" .. _OPTIONS["SDL_INI_PATH"] .. "\"'",
+    }
+end
 
 if _OPTIONS["NO_X11"]=="1" then
 	defines {


### PR DESCRIPTION
Get SDL_INI_PATH back in the source tree. This makefile variable helps giving an arbitrary default value to the inipath entry in mame.ini. Useful for linux packagers.

Please consider merging, thank you.