### PR TITLE
Stop PIA from spamming debug console by default

### DIFF
--- a/src/devices/machine/6821pia.cpp
+++ b/src/devices/machine/6821pia.cpp
@@ -14,7 +14,7 @@
 //  MACROS
 //**************************************************************************
 
-#define VERBOSE 1
+#define VERBOSE 0
 
 #define LOG(x)  do { if (VERBOSE) logerror x; } while (0)
 


### PR DESCRIPTION
I guess it wasn't intentional to leave it in VERBOSE?