### PR TITLE
add lua console support back in

### DIFF
--- a/src/emu/emuopts.cpp
+++ b/src/emu/emuopts.cpp
@@ -185,6 +185,7 @@ const options_entry emu_options::s_option_entries[] =
 	{ OPTION_AUTOBOOT_COMMAND ";ab",                     nullptr,        OPTION_STRING,     "command to execute after machine boot" },
 	{ OPTION_AUTOBOOT_DELAY,                             "2",         OPTION_INTEGER,    "timer delay in sec to trigger command execution on autoboot" },
 	{ OPTION_AUTOBOOT_SCRIPT ";script",                  nullptr,        OPTION_STRING,     "lua script to execute after machine boot" },
+	{ OPTION_CONSOLE,                                    "0",         OPTION_BOOLEAN,    "enable emulator LUA console" },
 	{ nullptr }
 };
 

--- a/src/emu/emuopts.h
+++ b/src/emu/emuopts.h
@@ -189,6 +189,8 @@ enum
 #define OPTION_AUTOBOOT_DELAY       "autoboot_delay"
 #define OPTION_AUTOBOOT_SCRIPT      "autoboot_script"
 
+#define OPTION_CONSOLE              "console"
+
 //**************************************************************************
 //  TYPE DEFINITIONS
 //**************************************************************************
@@ -360,6 +362,8 @@ public:
 	const char *autoboot_command() const { return value(OPTION_AUTOBOOT_COMMAND); }
 	int autoboot_delay() const { return int_value(OPTION_AUTOBOOT_DELAY); }
 	const char *autoboot_script() const { return value(OPTION_AUTOBOOT_SCRIPT); }
+
+	bool console() const { return bool_value(OPTION_CONSOLE); }
 
 	// FIXME: Couriersud: This should be in image_device_exit
 	void remove_device_options();

--- a/src/emu/luaengine.cpp
+++ b/src/emu/luaengine.cpp
@@ -9,6 +9,7 @@
 ***************************************************************************/
 
 #include <limits>
+#include <thread>
 #include "lua.hpp"
 #include "luabridge/Source/LuaBridge/LuaBridge.h"
 #include <signal.h>
@@ -860,14 +861,12 @@ void lua_engine::serve_lua()
 	} while (1);
 }
 
-/*
 static void *serve_lua(void *param)
 {
     lua_engine *engine = (lua_engine *)param;
     engine->serve_lua();
     return NULL;
 }
-*/
 
 //-------------------------------------------------
 //  lua_engine - constructor
@@ -1024,6 +1023,8 @@ void lua_engine::initialize()
 
 void lua_engine::start_console()
 {
+	std::thread th(::serve_lua, this);
+	th.detach();
 }
 
 //-------------------------------------------------

--- a/src/emu/mame.cpp
+++ b/src/emu/mame.cpp
@@ -167,6 +167,9 @@ int machine_manager::execute()
 	int error = MAMERR_NONE;
 
 	m_lua->initialize();
+	if (m_options.console()) {
+		m_lua->start_console();
+	}
 	while (error == MAMERR_NONE && !exit_pending)
 	{
 		m_new_driver_pending = nullptr;


### PR DESCRIPTION
Originally removed by @mmicko when mongoose was axed in b6707c3bb53c931e9ec3c5c6630149b7121bbcf5.
Since C++14 I'm assuming using std::thread is ok.
