### PR TITLE
Return std::string objects by value rather than pass by reference

### DIFF
--- a/src/devices/bus/a7800/a78_slot.cpp
+++ b/src/devices/bus/a7800/a78_slot.cpp
@@ -528,7 +528,7 @@ int a78_cart_slot_device::verify_header(char *header)
  get default card software
  -------------------------------------------------*/
 
-void a78_cart_slot_device::get_default_card_software(std::string &result)
+std::string a78_cart_slot_device::get_default_card_software()
 {
 	if (open_image_file(mconfig().options()))
 	{
@@ -586,10 +586,10 @@ void a78_cart_slot_device::get_default_card_software(std::string &result)
 
 		clear();
 
-		result.assign(slot_string);
+		return std::string(slot_string);
 	}
 	else
-		software_get_default_slot(result, "a78_rom");
+		return software_get_default_slot("a78_rom");
 }
 
 

--- a/src/devices/bus/a7800/a78_slot.h
+++ b/src/devices/bus/a7800/a78_slot.h
@@ -113,7 +113,7 @@ public:
 	virtual device_image_partialhash_func get_partial_hash() const override { return &a78_partialhash; }
 
 	// slot interface overrides
-	virtual void get_default_card_software(std::string &result) override;
+	virtual std::string get_default_card_software() override;
 
 	// reading and writing
 	virtual DECLARE_READ8_MEMBER(read_04xx);

--- a/src/devices/bus/a800/a800_slot.cpp
+++ b/src/devices/bus/a800/a800_slot.cpp
@@ -406,7 +406,7 @@ int a800_cart_slot_device::identify_cart_type(UINT8 *header)
  get default card software
  -------------------------------------------------*/
 
-void a800_cart_slot_device::get_default_card_software(std::string &result)
+std::string a800_cart_slot_device::get_default_card_software()
 {
 	if (open_image_file(mconfig().options()))
 	{
@@ -436,14 +436,14 @@ void a800_cart_slot_device::get_default_card_software(std::string &result)
 
 		clear();
 
-		result.assign(slot_string);
+		return std::string(slot_string);
 	}
 	else
-		software_get_default_slot(result, "a800_8k");
+		return software_get_default_slot("a800_8k");
 }
 
 
-void a5200_cart_slot_device::get_default_card_software(std::string &result)
+std::string a5200_cart_slot_device::get_default_card_software()
 {
 	if (open_image_file(mconfig().options()))
 	{
@@ -469,14 +469,14 @@ void a5200_cart_slot_device::get_default_card_software(std::string &result)
 
 		clear();
 
-		result.assign(slot_string);
+		return std::string(slot_string);
 	}
 	else
-		software_get_default_slot(result, "a5200");
+		return software_get_default_slot("a5200");
 }
 
 
-void xegs_cart_slot_device::get_default_card_software(std::string &result)
+std::string xegs_cart_slot_device::get_default_card_software()
 {
 	if (open_image_file(mconfig().options()))
 	{
@@ -504,10 +504,10 @@ void xegs_cart_slot_device::get_default_card_software(std::string &result)
 
 		clear();
 
-		result.assign(slot_string);
+		return std::string(slot_string);
 	}
 	else
-		software_get_default_slot(result, "xegs");
+		return software_get_default_slot("xegs");
 }
 
 

--- a/src/devices/bus/a800/a800_slot.h
+++ b/src/devices/bus/a800/a800_slot.h
@@ -113,7 +113,7 @@ public:
 	virtual const char *file_extensions() const override { return "bin,rom,car"; }
 
 	// slot interface overrides
-	virtual void get_default_card_software(std::string &result) override;
+	virtual std::string get_default_card_software() override;
 
 	// reading and writing
 	virtual DECLARE_READ8_MEMBER(read_80xx);
@@ -142,7 +142,7 @@ public:
 	virtual const char *file_extensions() const override { return "bin,rom,car,a52"; }
 
 	// slot interface overrides
-	virtual void get_default_card_software(std::string &result) override;
+	virtual std::string get_default_card_software() override;
 };
 
 // ======================> xegs_cart_slot_device
@@ -157,7 +157,7 @@ public:
 	virtual const char *file_extensions() const override { return "bin,rom,car"; }
 
 	// slot interface overrides
-	virtual void get_default_card_software(std::string &result) override;
+	virtual std::string get_default_card_software() override;
 };
 
 // device type definition

--- a/src/devices/bus/adam/exp.cpp
+++ b/src/devices/bus/adam/exp.cpp
@@ -124,9 +124,9 @@ bool adam_expansion_slot_device::call_softlist_load(software_list_device &swlist
 //  get_default_card_software -
 //-------------------------------------------------
 
-void adam_expansion_slot_device::get_default_card_software(std::string &result)
+std::string adam_expansion_slot_device::get_default_card_software()
 {
-	software_get_default_slot(result, "standard");
+	return software_get_default_slot("standard");
 }
 
 

--- a/src/devices/bus/adam/exp.h
+++ b/src/devices/bus/adam/exp.h
@@ -87,7 +87,7 @@ protected:
 	virtual const option_guide *create_option_guide() const override { return nullptr; }
 
 	// slot interface overrides
-	virtual void get_default_card_software(std::string &result) override;
+	virtual std::string get_default_card_software() override;
 
 	devcb_write_line   m_write_irq;
 

--- a/src/devices/bus/apf/slot.cpp
+++ b/src/devices/bus/apf/slot.cpp
@@ -221,7 +221,7 @@ bool apf_cart_slot_device::call_softlist_load(software_list_device &swlist, cons
  get default card software
  -------------------------------------------------*/
 
-void apf_cart_slot_device::get_default_card_software(std::string &result)
+std::string apf_cart_slot_device::get_default_card_software()
 {
 	if (open_image_file(mconfig().options()))
 	{
@@ -240,11 +240,10 @@ void apf_cart_slot_device::get_default_card_software(std::string &result)
 		//printf("type: %s\n", slot_string);
 		clear();
 
-		result.assign(slot_string);
-		return;
+		return std::string(slot_string);
 	}
 
-	software_get_default_slot(result, "std");
+	return software_get_default_slot("std");
 }
 
 /*-------------------------------------------------

--- a/src/devices/bus/apf/slot.h
+++ b/src/devices/bus/apf/slot.h
@@ -84,7 +84,7 @@ public:
 	virtual const char *file_extensions() const override { return "bin"; }
 
 	// slot interface overrides
-	virtual void get_default_card_software(std::string &result) override;
+	virtual std::string get_default_card_software() override;
 
 	// reading and writing
 	virtual DECLARE_READ8_MEMBER(read_rom);

--- a/src/devices/bus/arcadia/slot.cpp
+++ b/src/devices/bus/arcadia/slot.cpp
@@ -230,9 +230,9 @@ bool arcadia_cart_slot_device::call_softlist_load(software_list_device &swlist, 
  get default card software
  -------------------------------------------------*/
 
-void arcadia_cart_slot_device::get_default_card_software(std::string &result)
+std::string arcadia_cart_slot_device::get_default_card_software()
 {
-	software_get_default_slot(result, "std");
+	return software_get_default_slot("std");
 }
 
 /*-------------------------------------------------

--- a/src/devices/bus/arcadia/slot.h
+++ b/src/devices/bus/arcadia/slot.h
@@ -73,7 +73,7 @@ public:
 	virtual const char *file_extensions() const override { return "bin"; }
 
 	// slot interface overrides
-	virtual void get_default_card_software(std::string &result) override;
+	virtual std::string get_default_card_software() override;
 
 	// reading and writing
 	virtual DECLARE_READ8_MEMBER(read_rom);

--- a/src/devices/bus/astrocde/slot.cpp
+++ b/src/devices/bus/astrocde/slot.cpp
@@ -198,7 +198,7 @@ bool astrocade_cart_slot_device::call_softlist_load(software_list_device &swlist
  get default card software
  -------------------------------------------------*/
 
-void astrocade_cart_slot_device::get_default_card_software(std::string &result)
+std::string astrocade_cart_slot_device::get_default_card_software()
 {
 	if (open_image_file(mconfig().options()))
 	{
@@ -216,11 +216,10 @@ void astrocade_cart_slot_device::get_default_card_software(std::string &result)
 		//printf("type: %s\n", slot_string);
 		clear();
 
-		result.assign(slot_string);
-		return;
+		return std::string(slot_string);
 	}
 
-	software_get_default_slot(result, "rom");
+	return software_get_default_slot("rom");
 }
 
 /*-------------------------------------------------

--- a/src/devices/bus/astrocde/slot.h
+++ b/src/devices/bus/astrocde/slot.h
@@ -73,7 +73,7 @@ public:
 	virtual const char *file_extensions() const override { return "bin"; }
 
 	// slot interface overrides
-	virtual void get_default_card_software(std::string &result) override;
+	virtual std::string get_default_card_software() override;
 
 	// reading and writing
 	virtual DECLARE_READ8_MEMBER(read_rom);

--- a/src/devices/bus/c64/exp.cpp
+++ b/src/devices/bus/c64/exp.cpp
@@ -217,20 +217,17 @@ bool c64_expansion_slot_device::call_softlist_load(software_list_device &swlist,
 //  get_default_card_software -
 //-------------------------------------------------
 
-void c64_expansion_slot_device::get_default_card_software(std::string &result)
+std::string c64_expansion_slot_device::get_default_card_software()
 {
 	if (open_image_file(mconfig().options()))
 	{
 		if (!core_stricmp(filetype(), "crt"))
-		{
-			cbm_crt_get_card(result, m_file);
-			return;
-		}
+			return cbm_crt_get_card(m_file);
 
 		clear();
 	}
 
-	software_get_default_slot(result, "standard");
+	return software_get_default_slot("standard");
 }
 
 

--- a/src/devices/bus/c64/exp.h
+++ b/src/devices/bus/c64/exp.h
@@ -149,7 +149,7 @@ protected:
 	virtual const option_guide *create_option_guide() const override { return nullptr; }
 
 	// slot interface overrides
-	virtual void get_default_card_software(std::string &result) override;
+	virtual std::string get_default_card_software() override;
 
 	devcb_read8        m_read_dma_cd;
 	devcb_write8       m_write_dma_cd;

--- a/src/devices/bus/cbm2/exp.cpp
+++ b/src/devices/bus/cbm2/exp.cpp
@@ -155,9 +155,9 @@ bool cbm2_expansion_slot_device::call_softlist_load(software_list_device &swlist
 //  get_default_card_software -
 //-------------------------------------------------
 
-void cbm2_expansion_slot_device::get_default_card_software(std::string &result)
+std::string cbm2_expansion_slot_device::get_default_card_software()
 {
-	software_get_default_slot(result, "standard");
+	return software_get_default_slot("standard");
 }
 
 

--- a/src/devices/bus/cbm2/exp.h
+++ b/src/devices/bus/cbm2/exp.h
@@ -96,7 +96,7 @@ protected:
 	virtual const option_guide *create_option_guide() const override { return nullptr; }
 
 	// slot interface overrides
-	virtual void get_default_card_software(std::string &result) override;
+	virtual std::string get_default_card_software() override;
 
 	device_cbm2_expansion_card_interface *m_card;
 };

--- a/src/devices/bus/chanf/slot.cpp
+++ b/src/devices/bus/chanf/slot.cpp
@@ -217,7 +217,7 @@ bool channelf_cart_slot_device::call_softlist_load(software_list_device &swlist,
  get default card software
  -------------------------------------------------*/
 
-void channelf_cart_slot_device::get_default_card_software(std::string &result)
+std::string channelf_cart_slot_device::get_default_card_software()
 {
 	if (open_image_file(mconfig().options()))
 	{
@@ -235,10 +235,9 @@ void channelf_cart_slot_device::get_default_card_software(std::string &result)
 		//printf("type: %s\n", slot_string);
 		clear();
 
-		result.assign(slot_string);
-		return;
+		return std::string(slot_string);
 	}
-	software_get_default_slot(result, "chess");
+	return software_get_default_slot("chess");
 }
 
 /*-------------------------------------------------

--- a/src/devices/bus/chanf/slot.h
+++ b/src/devices/bus/chanf/slot.h
@@ -87,7 +87,7 @@ public:
 	virtual const char *file_extensions() const override { return "bin,chf"; }
 
 	// slot interface overrides
-	virtual void get_default_card_software(std::string &result) override;
+	virtual std::string get_default_card_software() override;
 
 	// reading and writing
 	virtual DECLARE_READ8_MEMBER(read_rom);

--- a/src/devices/bus/coco/cococart.cpp
+++ b/src/devices/bus/coco/cococart.cpp
@@ -364,9 +364,9 @@ bool cococart_slot_device::call_softlist_load(software_list_device &swlist, cons
 //  get_default_card_software
 //-------------------------------------------------
 
-void cococart_slot_device::get_default_card_software(std::string &result)
+std::string cococart_slot_device::get_default_card_software()
 {
-	software_get_default_slot(result, "pak");
+	return software_get_default_slot("pak");
 }
 
 

--- a/src/devices/bus/coco/cococart.h
+++ b/src/devices/bus/coco/cococart.h
@@ -102,7 +102,7 @@ public:
 	virtual const option_guide *create_option_guide() const override { return nullptr; }
 
 	// slot interface overrides
-	virtual void get_default_card_software(std::string &result) override;
+	virtual std::string get_default_card_software() override;
 
 	// reading and writing to $FF40-$FF7F
 	DECLARE_READ8_MEMBER(read);

--- a/src/devices/bus/coleco/exp.cpp
+++ b/src/devices/bus/coleco/exp.cpp
@@ -112,18 +112,15 @@ bool colecovision_cartridge_slot_device::call_softlist_load(software_list_device
 //  get_default_card_software -
 //-------------------------------------------------
 
-void colecovision_cartridge_slot_device::get_default_card_software(std::string &result)
+std::string colecovision_cartridge_slot_device::get_default_card_software()
 {
 	if (open_image_file(mconfig().options()))
 	{
 		UINT32 length = core_fsize(m_file);
 		if (length == 0x100000 || length == 0x200000)
-		{
-			software_get_default_slot(result, "xin1");
-			return;
-		}
+			return software_get_default_slot("xin1");
 	}
-	software_get_default_slot(result, "standard");
+	return software_get_default_slot("standard");
 }
 
 

--- a/src/devices/bus/coleco/exp.h
+++ b/src/devices/bus/coleco/exp.h
@@ -93,7 +93,7 @@ protected:
 	virtual const option_guide *create_option_guide() const override { return nullptr; }
 
 	// slot interface overrides
-	virtual void get_default_card_software(std::string &result) override;
+	virtual std::string get_default_card_software() override;
 
 	device_colecovision_cartridge_interface *m_card;
 };

--- a/src/devices/bus/crvision/slot.cpp
+++ b/src/devices/bus/crvision/slot.cpp
@@ -229,7 +229,7 @@ bool crvision_cart_slot_device::call_softlist_load(software_list_device &swlist,
  get default card software
  -------------------------------------------------*/
 
-void crvision_cart_slot_device::get_default_card_software(std::string &result)
+std::string crvision_cart_slot_device::get_default_card_software()
 {
 	if (open_image_file(mconfig().options()))
 	{
@@ -267,11 +267,10 @@ void crvision_cart_slot_device::get_default_card_software(std::string &result)
 		//printf("type: %s\n", slot_string);
 		clear();
 
-		result.assign(slot_string);
-		return;
+		return std::string(slot_string);
 	}
 
-	software_get_default_slot(result, "crv_rom4k");
+	return software_get_default_slot("crv_rom4k");
 }
 
 /*-------------------------------------------------

--- a/src/devices/bus/crvision/slot.h
+++ b/src/devices/bus/crvision/slot.h
@@ -78,7 +78,7 @@ public:
 	virtual const char *file_extensions() const override { return "bin,rom"; }
 
 	// slot interface overrides
-	virtual void get_default_card_software(std::string &result) override;
+	virtual std::string get_default_card_software() override;
 
 	// reading and writing
 	virtual DECLARE_READ8_MEMBER(read_rom40);

--- a/src/devices/bus/gameboy/gb_slot.cpp
+++ b/src/devices/bus/gameboy/gb_slot.cpp
@@ -600,7 +600,7 @@ int base_gb_cart_slot_device::get_cart_type(UINT8 *ROM, UINT32 len)
  get default card software
  -------------------------------------------------*/
 
-void base_gb_cart_slot_device::get_default_card_software(std::string &result)
+std::string base_gb_cart_slot_device::get_default_card_software()
 {
 	if (open_image_file(mconfig().options()))
 	{
@@ -623,23 +623,19 @@ void base_gb_cart_slot_device::get_default_card_software(std::string &result)
 		//printf("type: %s\n", slot_string);
 		clear();
 
-		result.assign(slot_string);
-		return;
+		return std::string(slot_string);
 	}
 
-	software_get_default_slot(result, "rom");
+	return software_get_default_slot("rom");
 }
 
 
-void megaduck_cart_slot_device::get_default_card_software(std::string &result)
+std::string megaduck_cart_slot_device::get_default_card_software()
 {
 	if (open_image_file(mconfig().options()))
-	{
-		result.assign("rom");
-		return;
-	}
+		return std::string("rom");
 
-	software_get_default_slot(result, "rom");
+	return software_get_default_slot("rom");
 }
 
 

--- a/src/devices/bus/gameboy/gb_slot.h
+++ b/src/devices/bus/gameboy/gb_slot.h
@@ -141,7 +141,7 @@ public:
 	virtual const char *file_extensions() const override { return "bin,gb,gbc"; }
 
 	// slot interface overrides
-	virtual void get_default_card_software(std::string &result) override;
+	virtual std::string get_default_card_software() override;
 
 	// reading and writing
 	virtual DECLARE_READ8_MEMBER(read_rom);
@@ -182,7 +182,7 @@ public:
 	virtual const char *file_extensions() const override { return "bin"; }
 
 	// slot interface overrides
-	virtual void get_default_card_software(std::string &result) override;
+	virtual std::string get_default_card_software() override;
 };
 
 

--- a/src/devices/bus/gba/gba_slot.cpp
+++ b/src/devices/bus/gba/gba_slot.cpp
@@ -400,7 +400,7 @@ int gba_cart_slot_device::get_cart_type(UINT8 *ROM, UINT32 len)
  get default card software
  -------------------------------------------------*/
 
-void gba_cart_slot_device::get_default_card_software(std::string &result)
+std::string gba_cart_slot_device::get_default_card_software()
 {
 	if (open_image_file(mconfig().options()))
 	{
@@ -417,11 +417,10 @@ void gba_cart_slot_device::get_default_card_software(std::string &result)
 		//printf("type: %s\n", slot_string);
 		clear();
 
-		result.assign(slot_string);
-		return;
+		return std::string(slot_string);
 	}
 
-	software_get_default_slot(result, "gba_rom");
+	return software_get_default_slot("gba_rom");
 }
 
 /*-------------------------------------------------

--- a/src/devices/bus/gba/gba_slot.h
+++ b/src/devices/bus/gba/gba_slot.h
@@ -91,7 +91,7 @@ public:
 	virtual const char *file_extensions() const override { return "gba,bin"; }
 
 	// slot interface overrides
-	virtual void get_default_card_software(std::string &result) override;
+	virtual std::string get_default_card_software() override;
 
 	// reading and writing
 	virtual DECLARE_READ32_MEMBER(read_rom);

--- a/src/devices/bus/generic/slot.cpp
+++ b/src/devices/bus/generic/slot.cpp
@@ -179,9 +179,9 @@ bool generic_slot_device::call_softlist_load(software_list_device &swlist, const
  get default card software
  -------------------------------------------------*/
 
-void generic_slot_device::get_default_card_software(std::string &result)
+std::string generic_slot_device::get_default_card_software()
 {
-	software_get_default_slot(result, m_default_card);
+	return software_get_default_slot(m_default_card);
 }
 
 

--- a/src/devices/bus/generic/slot.h
+++ b/src/devices/bus/generic/slot.h
@@ -124,7 +124,7 @@ public:
 	virtual const char *file_extensions() const override { return m_extensions; }
 
 	// slot interface overrides
-	virtual void get_default_card_software(std::string &result) override;
+	virtual std::string get_default_card_software() override;
 
 	// reading and writing
 	virtual DECLARE_READ8_MEMBER(read_rom);

--- a/src/devices/bus/intv/slot.cpp
+++ b/src/devices/bus/intv/slot.cpp
@@ -459,7 +459,7 @@ bool intv_cart_slot_device::call_softlist_load(software_list_device &swlist, con
  get default card software
  -------------------------------------------------*/
 
-void intv_cart_slot_device::get_default_card_software(std::string &result)
+std::string intv_cart_slot_device::get_default_card_software()
 {
 	if (open_image_file(mconfig().options()))
 	{
@@ -503,10 +503,9 @@ void intv_cart_slot_device::get_default_card_software(std::string &result)
 		//printf("type: %s\n", slot_string);
 		clear();
 
-		result.assign(slot_string);
-		return;
+		return std::string(slot_string);
 	}
-	software_get_default_slot(result, "intv_rom");
+	return software_get_default_slot("intv_rom");
 }
 
 /*-------------------------------------------------

--- a/src/devices/bus/intv/slot.h
+++ b/src/devices/bus/intv/slot.h
@@ -120,7 +120,7 @@ public:
 	virtual const char *file_extensions() const override { return "bin,int,rom,itv"; }
 
 	// slot interface overrides
-	virtual void get_default_card_software(std::string &result) override;
+	virtual std::string get_default_card_software() override;
 
 	// reading and writing
 	virtual DECLARE_READ16_MEMBER(read_rom04) { if (m_cart) return m_cart->read_rom04(space, offset, mem_mask); else return 0xffff; }

--- a/src/devices/bus/iq151/iq151.cpp
+++ b/src/devices/bus/iq151/iq151.cpp
@@ -204,7 +204,7 @@ bool iq151cart_slot_device::call_softlist_load(software_list_device &swlist, con
     get default card software
 -------------------------------------------------*/
 
-void iq151cart_slot_device::get_default_card_software(std::string &result)
+std::string iq151cart_slot_device::get_default_card_software()
 {
-	software_get_default_slot(result, "basic6");
+	return software_get_default_slot("basic6");
 }

--- a/src/devices/bus/iq151/iq151.h
+++ b/src/devices/bus/iq151/iq151.h
@@ -106,7 +106,7 @@ public:
 	virtual const option_guide *create_option_guide() const override { return nullptr; }
 
 	// slot interface overrides
-	virtual void get_default_card_software(std::string &result) override;
+	virtual std::string get_default_card_software() override;
 
 	// reading and writing
 	virtual void read(offs_t offset, UINT8 &data);

--- a/src/devices/bus/kc/kc.cpp
+++ b/src/devices/bus/kc/kc.cpp
@@ -370,7 +370,7 @@ bool kccart_slot_device::call_softlist_load(software_list_device &swlist, const 
     get default card software
 -------------------------------------------------*/
 
-void kccart_slot_device::get_default_card_software(std::string &result)
+std::string kccart_slot_device::get_default_card_software()
 {
-	software_get_default_slot(result, "standard");
+	return software_get_default_slot("standard");
 }

--- a/src/devices/bus/kc/kc.h
+++ b/src/devices/bus/kc/kc.h
@@ -104,7 +104,7 @@ public:
 	virtual const option_guide *create_option_guide() const override { return nullptr; }
 
 	// slot interface overrides
-	virtual void get_default_card_software(std::string &result) override;
+	virtual std::string get_default_card_software() override;
 };
 
 // device type definition

--- a/src/devices/bus/megadrive/md_slot.cpp
+++ b/src/devices/bus/megadrive/md_slot.cpp
@@ -900,7 +900,7 @@ int base_md_cart_slot_device::get_cart_type(UINT8 *ROM, UINT32 len)
  get default card software
  -------------------------------------------------*/
 
-void base_md_cart_slot_device::get_default_card_software(std::string &result)
+std::string base_md_cart_slot_device::get_default_card_software()
 {
 	if (open_image_file(mconfig().options()))
 	{
@@ -919,10 +919,10 @@ void base_md_cart_slot_device::get_default_card_software(std::string &result)
 
 		clear();
 
-		result.assign(slot_string);
+		return std::string(slot_string);
 	}
 	else
-		software_get_default_slot(result, "rom");
+		return software_get_default_slot("rom");
 }
 
 

--- a/src/devices/bus/megadrive/md_slot.h
+++ b/src/devices/bus/megadrive/md_slot.h
@@ -161,7 +161,7 @@ public:
 	virtual const option_guide *create_option_guide() const override { return nullptr; }
 
 	// slot interface overrides
-	virtual void get_default_card_software(std::string &result) override;
+	virtual std::string get_default_card_software() override;
 
 	int get_type() { return m_type; }
 

--- a/src/devices/bus/msx_slot/cartridge.cpp
+++ b/src/devices/bus/msx_slot/cartridge.cpp
@@ -278,7 +278,7 @@ int msx_slot_cartridge_device::get_cart_type(UINT8 *rom, UINT32 length)
 }
 
 
-void msx_slot_cartridge_device::get_default_card_software(std::string &result)
+std::string msx_slot_cartridge_device::get_default_card_software()
 {
 	if (open_image_file(mconfig().options()))
 	{
@@ -337,10 +337,9 @@ void msx_slot_cartridge_device::get_default_card_software(std::string &result)
 			slot_string = msx_cart_get_slot_option(type);
 		}
 
-		result.assign(slot_string);
-		return;
+		return std::string(slot_string);
 	}
-	software_get_default_slot(result, "nomapper");
+	return software_get_default_slot("nomapper");
 }
 
 

--- a/src/devices/bus/msx_slot/cartridge.h
+++ b/src/devices/bus/msx_slot/cartridge.h
@@ -55,7 +55,7 @@ public:
 	virtual const char *file_extensions() const override { return "mx1,bin,rom"; }
 
 	// slot interface overrides
-	virtual void get_default_card_software(std::string &result) override;
+	virtual std::string get_default_card_software() override;
 
 	// msx_internal_slot-level overrides
 	virtual DECLARE_READ8_MEMBER(read) override;

--- a/src/devices/bus/neogeo/neogeo_slot.cpp
+++ b/src/devices/bus/neogeo/neogeo_slot.cpp
@@ -204,9 +204,9 @@ bool neogeo_cart_slot_device::call_softlist_load(software_list_device &swlist, c
  get default card software
  -------------------------------------------------*/
 
-void neogeo_cart_slot_device::get_default_card_software(std::string &result)
+std::string neogeo_cart_slot_device::get_default_card_software()
 {
-	software_get_default_slot(result, "rom");
+	return software_get_default_slot("rom");
 }
 
 /*-------------------------------------------------

--- a/src/devices/bus/neogeo/neogeo_slot.h
+++ b/src/devices/bus/neogeo/neogeo_slot.h
@@ -41,7 +41,7 @@ public:
 	virtual const char *file_extensions() const override { return "bin"; }
 
 	// slot interface overrides
-	virtual void get_default_card_software(std::string &result) override;
+	virtual std::string get_default_card_software() override;
 
 	// reading and writing
 	virtual DECLARE_READ16_MEMBER(read_rom);

--- a/src/devices/bus/nes/aladdin.cpp
+++ b/src/devices/bus/nes/aladdin.cpp
@@ -142,7 +142,7 @@ bool nes_aladdin_slot_device::call_softlist_load(software_list_device &swlist, c
 	return TRUE;
 }
 
-void nes_aladdin_slot_device::get_default_card_software(std::string &result)
+std::string nes_aladdin_slot_device::get_default_card_software()
 {
 	if (open_image_file(mconfig().options()))
 	{
@@ -163,10 +163,10 @@ void nes_aladdin_slot_device::get_default_card_software(std::string &result)
 
 		clear();
 
-		result.assign(slot_string);
+		return std::string(slot_string);
 	}
 	else
-		software_get_default_slot(result, "algn");
+		return software_get_default_slot("algn");
 }
 
 

--- a/src/devices/bus/nes/aladdin.h
+++ b/src/devices/bus/nes/aladdin.h
@@ -65,7 +65,7 @@ public:
 	virtual const option_guide *create_option_guide() const override { return nullptr; }
 
 	// slot interface overrides
-	virtual void get_default_card_software(std::string &result) override;
+	virtual std::string get_default_card_software() override;
 
 	virtual DECLARE_READ8_MEMBER(read);
 	void write_prg(UINT32 offset, UINT8 data) { if (m_cart) m_cart->write_prg(offset, data); }

--- a/src/devices/bus/nes/datach.cpp
+++ b/src/devices/bus/nes/datach.cpp
@@ -143,10 +143,10 @@ bool nes_datach_slot_device::call_softlist_load(software_list_device &swlist, co
 	return TRUE;
 }
 
-void nes_datach_slot_device::get_default_card_software(std::string &result)
+std::string nes_datach_slot_device::get_default_card_software()
 {
 	// any way to detect the game with X24C01?
-	software_get_default_slot(result, "datach_rom");
+	return software_get_default_slot("datach_rom");
 }
 
 

--- a/src/devices/bus/nes/datach.h
+++ b/src/devices/bus/nes/datach.h
@@ -67,7 +67,7 @@ public:
 	virtual const option_guide *create_option_guide() const override { return nullptr; }
 
 	// slot interface overrides
-	virtual void get_default_card_software(std::string &result) override;
+	virtual std::string get_default_card_software() override;
 
 	virtual DECLARE_READ8_MEMBER(read);
 	void write_prg_bank(UINT8 bank) { if (m_cart) m_cart->write_prg_bank(bank); }

--- a/src/devices/bus/nes/karastudio.cpp
+++ b/src/devices/bus/nes/karastudio.cpp
@@ -132,9 +132,9 @@ bool nes_kstudio_slot_device::call_softlist_load(software_list_device &swlist, c
 	return TRUE;
 }
 
-void nes_kstudio_slot_device::get_default_card_software(std::string &result)
+std::string nes_kstudio_slot_device::get_default_card_software()
 {
-	software_get_default_slot(result, "ks_exp");
+	return software_get_default_slot("ks_exp");
 }
 
 

--- a/src/devices/bus/nes/karastudio.h
+++ b/src/devices/bus/nes/karastudio.h
@@ -64,7 +64,7 @@ public:
 	virtual const option_guide *create_option_guide() const override { return nullptr; }
 
 	// slot interface overrides
-	virtual void get_default_card_software(std::string &result) override;
+	virtual std::string get_default_card_software() override;
 
 	virtual DECLARE_READ8_MEMBER(read);
 	void write_prg_bank(UINT8 bank) { if (m_cart) m_cart->write_prg_bank(bank); }

--- a/src/devices/bus/nes/nes_slot.cpp
+++ b/src/devices/bus/nes/nes_slot.cpp
@@ -912,7 +912,7 @@ bool nes_cart_slot_device::call_softlist_load(software_list_device &swlist, cons
  get default card software
  -------------------------------------------------*/
 
-void nes_cart_slot_device::get_default_card_software(std::string &result)
+std::string nes_cart_slot_device::get_default_card_software()
 {
 	if (open_image_file(mconfig().options()))
 	{
@@ -930,10 +930,10 @@ void nes_cart_slot_device::get_default_card_software(std::string &result)
 
 		clear();
 
-		result.assign(slot_string);
+		return std::string(slot_string);
 	}
 	else
-		software_get_default_slot(result, "nrom");
+		return software_get_default_slot("nrom");
 }
 
 

--- a/src/devices/bus/nes/nes_slot.h
+++ b/src/devices/bus/nes/nes_slot.h
@@ -363,7 +363,7 @@ public:
 	virtual device_image_partialhash_func get_partial_hash() const override { return &nes_partialhash; }
 
 	// slot interface overrides
-	virtual void get_default_card_software(std::string &result) override;
+	virtual std::string get_default_card_software() override;
 	const char * get_default_card_ines(UINT8 *ROM, UINT32 len);
 	const char * get_default_card_unif(UINT8 *ROM, UINT32 len);
 	const char * nes_get_slot(int pcb_id);

--- a/src/devices/bus/nes/sunsoft_dcs.cpp
+++ b/src/devices/bus/nes/sunsoft_dcs.cpp
@@ -111,9 +111,9 @@ bool nes_ntb_slot_device::call_softlist_load(software_list_device &swlist, const
 	return TRUE;
 }
 
-void nes_ntb_slot_device::get_default_card_software(std::string &result)
+std::string nes_ntb_slot_device::get_default_card_software()
 {
-	software_get_default_slot(result, "ntbrom");
+	return software_get_default_slot("ntbrom");
 }
 
 //-----------------------------------------------

--- a/src/devices/bus/nes/sunsoft_dcs.h
+++ b/src/devices/bus/nes/sunsoft_dcs.h
@@ -61,7 +61,7 @@ public:
 	virtual const option_guide *create_option_guide() const override { return nullptr; }
 
 	// slot interface overrides
-	virtual void get_default_card_software(std::string &result) override;
+	virtual std::string get_default_card_software() override;
 
 	virtual DECLARE_READ8_MEMBER(read);
 

--- a/src/devices/bus/odyssey2/slot.cpp
+++ b/src/devices/bus/odyssey2/slot.cpp
@@ -209,7 +209,7 @@ bool o2_cart_slot_device::call_softlist_load(software_list_device &swlist, const
  get default card software
  -------------------------------------------------*/
 
-void o2_cart_slot_device::get_default_card_software(std::string &result)
+std::string o2_cart_slot_device::get_default_card_software()
 {
 	if (open_image_file(mconfig().options()))
 	{
@@ -227,11 +227,10 @@ void o2_cart_slot_device::get_default_card_software(std::string &result)
 		//printf("type: %s\n", slot_string);
 		clear();
 
-		result.assign(slot_string);
-		return;
+		return std::string(slot_string);
 	}
 
-	software_get_default_slot(result, "o2_rom");
+	return software_get_default_slot("o2_rom");
 }
 
 /*-------------------------------------------------

--- a/src/devices/bus/odyssey2/slot.h
+++ b/src/devices/bus/odyssey2/slot.h
@@ -84,7 +84,7 @@ public:
 	virtual const char *file_extensions() const override { return "bin,rom"; }
 
 	// slot interface overrides
-	virtual void get_default_card_software(std::string &result) override;
+	virtual std::string get_default_card_software() override;
 
 	// reading and writing
 	virtual DECLARE_READ8_MEMBER(read_rom04);

--- a/src/devices/bus/pce/pce_slot.cpp
+++ b/src/devices/bus/pce/pce_slot.cpp
@@ -339,7 +339,7 @@ int pce_cart_slot_device::get_cart_type(UINT8 *ROM, UINT32 len)
  get default card software
  -------------------------------------------------*/
 
-void pce_cart_slot_device::get_default_card_software(std::string &result)
+std::string pce_cart_slot_device::get_default_card_software()
 {
 	if (open_image_file(mconfig().options()))
 	{
@@ -356,11 +356,10 @@ void pce_cart_slot_device::get_default_card_software(std::string &result)
 		//printf("type: %s\n", slot_string);
 		clear();
 
-		result.assign(slot_string);
-		return;
+		return std::string(slot_string);
 	}
 
-	software_get_default_slot(result, "rom");
+	return software_get_default_slot("rom");
 }
 
 /*-------------------------------------------------

--- a/src/devices/bus/pce/pce_slot.h
+++ b/src/devices/bus/pce/pce_slot.h
@@ -88,7 +88,7 @@ public:
 	virtual const char *file_extensions() const override { return "pce,bin"; }
 
 	// slot interface overrides
-	virtual void get_default_card_software(std::string &result) override;
+	virtual std::string get_default_card_software() override;
 
 	// reading and writing
 	virtual DECLARE_READ8_MEMBER(read_cart);

--- a/src/devices/bus/plus4/exp.cpp
+++ b/src/devices/bus/plus4/exp.cpp
@@ -157,9 +157,9 @@ bool plus4_expansion_slot_device::call_softlist_load(software_list_device &swlis
 //  get_default_card_software -
 //-------------------------------------------------
 
-void plus4_expansion_slot_device::get_default_card_software(std::string &result)
+std::string plus4_expansion_slot_device::get_default_card_software()
 {
-	software_get_default_slot(result, "standard");
+	return software_get_default_slot("standard");
 }
 
 

--- a/src/devices/bus/plus4/exp.h
+++ b/src/devices/bus/plus4/exp.h
@@ -135,7 +135,7 @@ protected:
 	virtual const option_guide *create_option_guide() const override { return nullptr; }
 
 	// slot interface overrides
-	virtual void get_default_card_software(std::string &result) override;
+	virtual std::string get_default_card_software() override;
 
 	devcb_write_line   m_write_irq;
 	devcb_read8        m_read_dma_cd;

--- a/src/devices/bus/ql/rom.cpp
+++ b/src/devices/bus/ql/rom.cpp
@@ -114,9 +114,9 @@ bool ql_rom_cartridge_slot_t::call_softlist_load(software_list_device &swlist, c
 //  get_default_card_software -
 //-------------------------------------------------
 
-void ql_rom_cartridge_slot_t::get_default_card_software(std::string &result)
+std::string ql_rom_cartridge_slot_t::get_default_card_software()
 {
-	software_get_default_slot(result, "standard");
+	return software_get_default_slot("standard");
 }
 
 

--- a/src/devices/bus/ql/rom.h
+++ b/src/devices/bus/ql/rom.h
@@ -110,7 +110,7 @@ protected:
 	virtual const option_guide *create_option_guide() const override { return nullptr; }
 
 	// slot interface overrides
-	virtual void get_default_card_software(std::string &result) override;
+	virtual std::string get_default_card_software() override;
 
 	device_ql_rom_cartridge_card_interface *m_card;
 };

--- a/src/devices/bus/saturn/sat_slot.cpp
+++ b/src/devices/bus/saturn/sat_slot.cpp
@@ -219,9 +219,9 @@ bool sat_cart_slot_device::call_softlist_load(software_list_device &swlist, cons
  get default card software
  -------------------------------------------------*/
 
-void sat_cart_slot_device::get_default_card_software(std::string &result)
+std::string sat_cart_slot_device::get_default_card_software()
 {
-	software_get_default_slot(result, "rom");
+	return software_get_default_slot("rom");
 }
 
 

--- a/src/devices/bus/saturn/sat_slot.h
+++ b/src/devices/bus/saturn/sat_slot.h
@@ -89,7 +89,7 @@ public:
 	virtual const char *file_extensions() const override { return "bin"; }
 
 	// slot interface overrides
-	virtual void get_default_card_software(std::string &result) override;
+	virtual std::string get_default_card_software() override;
 
 	// reading and writing
 	virtual DECLARE_READ32_MEMBER(read_rom);

--- a/src/devices/bus/scv/slot.cpp
+++ b/src/devices/bus/scv/slot.cpp
@@ -259,7 +259,7 @@ int scv_cart_slot_device::get_cart_type(UINT8 *ROM, UINT32 len)
  get default card software
  -------------------------------------------------*/
 
-void scv_cart_slot_device::get_default_card_software(std::string &result)
+std::string scv_cart_slot_device::get_default_card_software()
 {
 	if (open_image_file(mconfig().options()))
 	{
@@ -276,11 +276,10 @@ void scv_cart_slot_device::get_default_card_software(std::string &result)
 		//printf("type: %s\n", slot_string);
 		clear();
 
-		result.assign(slot_string);
-		return;
+		return std::string(slot_string);
 	}
 
-	software_get_default_slot(result, "rom8k");
+	return software_get_default_slot("rom8k");
 }
 
 /*-------------------------------------------------

--- a/src/devices/bus/scv/slot.h
+++ b/src/devices/bus/scv/slot.h
@@ -88,7 +88,7 @@ public:
 	virtual const char *file_extensions() const override { return "bin"; }
 
 	// slot interface overrides
-	virtual void get_default_card_software(std::string &result) override;
+	virtual std::string get_default_card_software() override;
 
 	// reading and writing
 	virtual DECLARE_READ8_MEMBER(read_cart);

--- a/src/devices/bus/sega8/sega8_slot.cpp
+++ b/src/devices/bus/sega8/sega8_slot.cpp
@@ -603,7 +603,7 @@ int sega8_cart_slot_device::get_cart_type(UINT8 *ROM, UINT32 len)
  get default card software
  -------------------------------------------------*/
 
-void sega8_cart_slot_device::get_default_card_software(std::string &result)
+std::string sega8_cart_slot_device::get_default_card_software()
 {
 	if (open_image_file(mconfig().options()))
 	{
@@ -623,11 +623,10 @@ void sega8_cart_slot_device::get_default_card_software(std::string &result)
 		//printf("type: %s\n", slot_string);
 		clear();
 
-		result.assign(slot_string);
-		return;
+		return std::string(slot_string);
 	}
 
-	software_get_default_slot(result, "rom");
+	return software_get_default_slot("rom");
 }
 
 

--- a/src/devices/bus/sega8/sega8_slot.h
+++ b/src/devices/bus/sega8/sega8_slot.h
@@ -137,7 +137,7 @@ public:
 	virtual const char *file_extensions() const override { return m_extensions; }
 
 	// slot interface overrides
-	virtual void get_default_card_software(std::string &result) override;
+	virtual std::string get_default_card_software() override;
 
 	// reading and writing
 	virtual DECLARE_READ8_MEMBER(read_cart);

--- a/src/devices/bus/snes/snes_slot.cpp
+++ b/src/devices/bus/snes/snes_slot.cpp
@@ -999,7 +999,7 @@ void base_sns_cart_slot_device::get_cart_type_addon(UINT8 *ROM, UINT32 len, int 
  get default card software
  -------------------------------------------------*/
 
-void base_sns_cart_slot_device::get_default_card_software(std::string &result)
+std::string base_sns_cart_slot_device::get_default_card_software()
 {
 	bool fullpath = open_image_file(mconfig().options());
 
@@ -1058,11 +1058,10 @@ void base_sns_cart_slot_device::get_default_card_software(std::string &result)
 
 		clear();
 
-		result.assign(slot_string);
-		return;
+		return std::string(slot_string);
 	}
 
-	software_get_default_slot(result, "lorom");
+	return software_get_default_slot("lorom");
 }
 
 

--- a/src/devices/bus/snes/snes_slot.h
+++ b/src/devices/bus/snes/snes_slot.h
@@ -180,7 +180,7 @@ public:
 	virtual const option_guide *create_option_guide() const override { return nullptr; }
 
 	// slot interface overrides
-	virtual void get_default_card_software(std::string &result) override;
+	virtual std::string get_default_card_software() override;
 
 	// reading and writing
 	virtual DECLARE_READ8_MEMBER(read_l);

--- a/src/devices/bus/vboy/slot.cpp
+++ b/src/devices/bus/vboy/slot.cpp
@@ -233,9 +233,9 @@ bool vboy_cart_slot_device::call_softlist_load(software_list_device &swlist, con
  get default card software
  -------------------------------------------------*/
 
-void vboy_cart_slot_device::get_default_card_software(std::string &result)
+std::string vboy_cart_slot_device::get_default_card_software()
 {
-	software_get_default_slot(result, "vb_rom");
+	return software_get_default_slot("vb_rom");
 }
 
 /*-------------------------------------------------

--- a/src/devices/bus/vboy/slot.h
+++ b/src/devices/bus/vboy/slot.h
@@ -83,7 +83,7 @@ public:
 	virtual const char *file_extensions() const override { return "vb,bin"; }
 
 	// slot interface overrides
-	virtual void get_default_card_software(std::string &result) override;
+	virtual std::string get_default_card_software() override;
 
 	// reading and writing
 	virtual DECLARE_READ32_MEMBER(read_cart);

--- a/src/devices/bus/vc4000/slot.cpp
+++ b/src/devices/bus/vc4000/slot.cpp
@@ -235,7 +235,7 @@ bool vc4000_cart_slot_device::call_softlist_load(software_list_device &swlist, c
  get default card software
  -------------------------------------------------*/
 
-void vc4000_cart_slot_device::get_default_card_software(std::string &result)
+std::string vc4000_cart_slot_device::get_default_card_software()
 {
 	if (open_image_file(mconfig().options()))
 	{
@@ -254,11 +254,10 @@ void vc4000_cart_slot_device::get_default_card_software(std::string &result)
 		//printf("type: %s\n", slot_string);
 		clear();
 
-		result.assign(slot_string);
-		return;
+		return std::string(slot_string);
 	}
 
-	software_get_default_slot(result, "std");
+	return software_get_default_slot("std");
 }
 
 /*-------------------------------------------------

--- a/src/devices/bus/vc4000/slot.h
+++ b/src/devices/bus/vc4000/slot.h
@@ -85,7 +85,7 @@ public:
 	virtual const char *file_extensions() const override { return "bin,rom"; }
 
 	// slot interface overrides
-	virtual void get_default_card_software(std::string &result) override;
+	virtual std::string get_default_card_software() override;
 
 	// reading and writing
 	virtual DECLARE_READ8_MEMBER(read_rom);

--- a/src/devices/bus/vcs/vcs_slot.cpp
+++ b/src/devices/bus/vcs/vcs_slot.cpp
@@ -781,7 +781,7 @@ int vcs_cart_slot_device::identify_cart_type(UINT8 *ROM, UINT32 len)
  get default card software
  -------------------------------------------------*/
 
-void vcs_cart_slot_device::get_default_card_software(std::string &result)
+std::string vcs_cart_slot_device::get_default_card_software()
 {
 	if (open_image_file(mconfig().options()))
 	{
@@ -797,10 +797,10 @@ void vcs_cart_slot_device::get_default_card_software(std::string &result)
 
 		clear();
 
-		result.assign(slot_string);
+		return std::string(slot_string);
 	}
 	else
-		software_get_default_slot(result, "a26_4k");
+		return software_get_default_slot("a26_4k");
 }
 
 

--- a/src/devices/bus/vcs/vcs_slot.h
+++ b/src/devices/bus/vcs/vcs_slot.h
@@ -112,7 +112,7 @@ public:
 	virtual const char *file_extensions() const override { return "bin,a26"; }
 
 	// slot interface overrides
-	virtual void get_default_card_software(std::string &result) override;
+	virtual std::string get_default_card_software() override;
 
 	// reading and writing
 	virtual DECLARE_READ8_MEMBER(read_rom);

--- a/src/devices/bus/vectrex/slot.cpp
+++ b/src/devices/bus/vectrex/slot.cpp
@@ -217,7 +217,7 @@ bool vectrex_cart_slot_device::call_softlist_load(software_list_device &swlist, 
  get default card software
  -------------------------------------------------*/
 
-void vectrex_cart_slot_device::get_default_card_software(std::string &result)
+std::string vectrex_cart_slot_device::get_default_card_software()
 {
 	if (open_image_file(mconfig().options()))
 	{
@@ -238,11 +238,10 @@ void vectrex_cart_slot_device::get_default_card_software(std::string &result)
 		//printf("type: %s\n", slot_string);
 		clear();
 
-		result.assign(slot_string);
-		return;
+		return std::string(slot_string);
 	}
 
-	software_get_default_slot(result, "vec_rom");
+	return software_get_default_slot("vec_rom");
 }
 
 /*-------------------------------------------------

--- a/src/devices/bus/vectrex/slot.h
+++ b/src/devices/bus/vectrex/slot.h
@@ -84,7 +84,7 @@ public:
 	virtual const char *file_extensions() const override { return "bin,gam,vec"; }
 
 	// slot interface overrides
-	virtual void get_default_card_software(std::string &result) override;
+	virtual std::string get_default_card_software() override;
 
 	// reading and writing
 	virtual DECLARE_READ8_MEMBER(read_rom);

--- a/src/devices/bus/vic10/exp.cpp
+++ b/src/devices/bus/vic10/exp.cpp
@@ -182,20 +182,17 @@ bool vic10_expansion_slot_device::call_softlist_load(software_list_device &swlis
 //  get_default_card_software -
 //-------------------------------------------------
 
-void vic10_expansion_slot_device::get_default_card_software(std::string &result)
+std::string vic10_expansion_slot_device::get_default_card_software()
 {
 	if (open_image_file(mconfig().options()))
 	{
 		if (!core_stricmp(filetype(), "crt"))
-		{
-			cbm_crt_get_card(result, m_file);
-			return;
-		}
+			return cbm_crt_get_card(m_file);
 
 		clear();
 	}
 
-	software_get_default_slot(result, "standard");
+	return software_get_default_slot("standard");
 }
 
 

--- a/src/devices/bus/vic10/exp.h
+++ b/src/devices/bus/vic10/exp.h
@@ -134,7 +134,7 @@ protected:
 	virtual const option_guide *create_option_guide() const override { return nullptr; }
 
 	// slot interface overrides
-	virtual void get_default_card_software(std::string &result) override;
+	virtual std::string get_default_card_software() override;
 
 	devcb_write_line   m_write_irq;
 	devcb_write_line   m_write_res;

--- a/src/devices/bus/vic20/exp.cpp
+++ b/src/devices/bus/vic20/exp.cpp
@@ -167,9 +167,9 @@ bool vic20_expansion_slot_device::call_softlist_load(software_list_device &swlis
 //  get_default_card_software -
 //-------------------------------------------------
 
-void vic20_expansion_slot_device::get_default_card_software(std::string &result)
+std::string vic20_expansion_slot_device::get_default_card_software()
 {
-	software_get_default_slot(result, "standard");
+	return software_get_default_slot("standard");
 }
 
 

--- a/src/devices/bus/vic20/exp.h
+++ b/src/devices/bus/vic20/exp.h
@@ -125,7 +125,7 @@ protected:
 	virtual const option_guide *create_option_guide() const override { return nullptr; }
 
 	// slot interface overrides
-	virtual void get_default_card_software(std::string &result) override;
+	virtual std::string get_default_card_software() override;
 
 	devcb_write_line   m_write_irq;
 	devcb_write_line   m_write_nmi;

--- a/src/devices/bus/vidbrain/exp.cpp
+++ b/src/devices/bus/vidbrain/exp.cpp
@@ -154,9 +154,9 @@ bool videobrain_expansion_slot_device::call_softlist_load(software_list_device &
 //  get_default_card_software -
 //-------------------------------------------------
 
-void videobrain_expansion_slot_device::get_default_card_software(std::string &result)
+std::string videobrain_expansion_slot_device::get_default_card_software()
 {
-	software_get_default_slot(result, "standard");
+	return software_get_default_slot("standard");
 }
 
 

--- a/src/devices/bus/vidbrain/exp.h
+++ b/src/devices/bus/vidbrain/exp.h
@@ -150,7 +150,7 @@ protected:
 	virtual const option_guide *create_option_guide() const override { return nullptr; }
 
 	// slot interface overrides
-	virtual void get_default_card_software(std::string &result) override;
+	virtual std::string get_default_card_software() override;
 
 	devcb_write_line   m_write_extres;
 

--- a/src/devices/bus/wswan/slot.cpp
+++ b/src/devices/bus/wswan/slot.cpp
@@ -306,7 +306,7 @@ int ws_cart_slot_device::get_cart_type(UINT8 *ROM, UINT32 len, UINT32 &nvram_len
  get default card software
  -------------------------------------------------*/
 
-void ws_cart_slot_device::get_default_card_software(std::string &result)
+std::string ws_cart_slot_device::get_default_card_software()
 {
 	if (open_image_file(mconfig().options()))
 	{
@@ -325,11 +325,10 @@ void ws_cart_slot_device::get_default_card_software(std::string &result)
 		//printf("type: %s\n", slot_string);
 		clear();
 
-		result.assign(slot_string);
-		return;
+		return std::string(slot_string);
 	}
 
-	software_get_default_slot(result, "ws_rom");
+	return software_get_default_slot("ws_rom");
 }
 
 /*-------------------------------------------------

--- a/src/devices/bus/wswan/slot.h
+++ b/src/devices/bus/wswan/slot.h
@@ -96,7 +96,7 @@ public:
 	virtual const char *file_extensions() const override { return "ws,wsc,bin"; }
 
 	// slot interface overrides
-	virtual void get_default_card_software(std::string &result) override;
+	virtual std::string get_default_card_software() override;
 
 	// reading and writing
 	virtual DECLARE_READ8_MEMBER(read_rom20);

--- a/src/devices/bus/z88/z88.cpp
+++ b/src/devices/bus/z88/z88.cpp
@@ -182,9 +182,9 @@ bool z88cart_slot_device::call_softlist_load(software_list_device &swlist, const
     get default card software
 -------------------------------------------------*/
 
-void z88cart_slot_device::get_default_card_software(std::string &result)
+std::string z88cart_slot_device::get_default_card_software()
 {
-	software_get_default_slot(result, "128krom");
+	return software_get_default_slot("128krom");
 }
 
 

--- a/src/devices/bus/z88/z88.h
+++ b/src/devices/bus/z88/z88.h
@@ -109,7 +109,7 @@ public:
 	virtual const option_guide *create_option_guide() const override { return nullptr; }
 
 	// slot interface overrides
-	virtual void get_default_card_software(std::string &result) override;
+	virtual std::string get_default_card_software() override;
 
 	// reading and writing
 	virtual DECLARE_READ8_MEMBER(read);

--- a/src/devices/cpu/8x300/8x300.cpp
+++ b/src/devices/cpu/8x300/8x300.cpp
@@ -145,7 +145,7 @@ void n8x300_cpu_device::device_start()
 	m_icountptr = &m_icount;
 }
 
-void n8x300_cpu_device::state_string_export(const device_state_entry &entry, std::string &str)
+void n8x300_cpu_device::state_string_export(const device_state_entry &entry, std::string &str) const
 {
 	switch (entry.index())
 	{

--- a/src/devices/cpu/8x300/8x300.h
+++ b/src/devices/cpu/8x300/8x300.h
@@ -66,7 +66,7 @@ protected:
 	}
 
 	// device_state_interface overrides
-	void state_string_export(const device_state_entry &entry, std::string &str) override;
+	virtual void state_string_export(const device_state_entry &entry, std::string &str) const override;
 
 	// device_disasm_interface overrides
 	virtual UINT32 disasm_min_opcode_bytes() const override { return 2; }

--- a/src/devices/cpu/adsp2100/adsp2100.cpp
+++ b/src/devices/cpu/adsp2100/adsp2100.cpp
@@ -544,15 +544,14 @@ void adsp21xx_device::device_start()
 	state_add(ADSP2100_SR0_SEC, "SR0_SEC",   m_alt.sr.srx.sr0.u);
 	state_add(ADSP2100_SR1_SEC, "SR1_SEC",   m_alt.sr.srx.sr1.u);
 
-	std::string tempstring;
 	for (int ireg = 0; ireg < 8; ireg++)
-		state_add(ADSP2100_I0 + ireg, strformat(tempstring, "I%d", ireg).c_str(), m_i[ireg]).mask(0x3fff).callimport();
+		state_add(ADSP2100_I0 + ireg, strformat("I%d", ireg).c_str(), m_i[ireg]).mask(0x3fff).callimport();
 
 	for (int lreg = 0; lreg < 8; lreg++)
-		state_add(ADSP2100_L0 + lreg, strformat(tempstring, "L%d", lreg).c_str(), m_l[lreg]).mask(0x3fff).callimport();
+		state_add(ADSP2100_L0 + lreg, strformat("L%d", lreg).c_str(), m_l[lreg]).mask(0x3fff).callimport();
 
 	for (int mreg = 0; mreg < 8; mreg++)
-		state_add(ADSP2100_M0 + mreg, strformat(tempstring, "M%d", mreg).c_str(), m_m[mreg]).signed_mask(0x3fff);
+		state_add(ADSP2100_M0 + mreg, strformat("M%d", mreg).c_str(), m_m[mreg]).signed_mask(0x3fff);
 
 	state_add(ADSP2100_PX,      "PX",        m_px);
 	state_add(ADSP2100_CNTR,    "CNTR",      m_cntr).mask(0x3fff);
@@ -571,7 +570,7 @@ void adsp21xx_device::device_start()
 
 	for (int irqnum = 0; irqnum < 4; irqnum++)
 		if (irqnum < 4 || m_chip_type == CHIP_TYPE_ADSP2100)
-			state_add(ADSP2100_IRQSTATE0 + irqnum, strformat(tempstring, "IRQ%d", irqnum).c_str(), m_irq_state[irqnum]).mask(1).callimport();
+			state_add(ADSP2100_IRQSTATE0 + irqnum, strformat("IRQ%d", irqnum).c_str(), m_irq_state[irqnum]).mask(1).callimport();
 
 	state_add(ADSP2100_FLAGIN,  "FLAGIN",    m_flagin).mask(1);
 	state_add(ADSP2100_FLAGOUT, "FLAGOUT",   m_flagout).mask(1);
@@ -720,7 +719,7 @@ void adsp21xx_device::state_import(const device_state_entry &entry)
 //  for the debugger
 //-------------------------------------------------
 
-void adsp21xx_device::state_string_export(const device_state_entry &entry, std::string &str)
+void adsp21xx_device::state_string_export(const device_state_entry &entry, std::string &str) const
 {
 	switch (entry.index())
 	{

--- a/src/devices/cpu/adsp2100/adsp2100.h
+++ b/src/devices/cpu/adsp2100/adsp2100.h
@@ -237,7 +237,7 @@ protected:
 
 	// device_state_interface overrides
 	virtual void state_import(const device_state_entry &entry) override;
-	virtual void state_string_export(const device_state_entry &entry, std::string &str) override;
+	virtual void state_string_export(const device_state_entry &entry, std::string &str) const override;
 
 	// device_disasm_interface overrides
 	virtual UINT32 disasm_min_opcode_bytes() const override;

--- a/src/devices/cpu/alph8201/alph8201.cpp
+++ b/src/devices/cpu/alph8201/alph8201.cpp
@@ -527,7 +527,7 @@ void alpha8201_cpu_device::state_export(const device_state_entry &entry)
 }
 
 
-void alpha8201_cpu_device::state_string_export(const device_state_entry &entry, std::string &str)
+void alpha8201_cpu_device::state_string_export(const device_state_entry &entry, std::string &str) const
 {
 	switch (entry.index())
 	{

--- a/src/devices/cpu/alph8201/alph8201.h
+++ b/src/devices/cpu/alph8201/alph8201.h
@@ -75,7 +75,7 @@ protected:
 	// device_state_interface overrides
 	virtual void state_import(const device_state_entry &entry) override;
 	virtual void state_export(const device_state_entry &entry) override;
-	void state_string_export(const device_state_entry &entry, std::string &str) override;
+	virtual void state_string_export(const device_state_entry &entry, std::string &str) const override;
 
 	// device_disasm_interface overrides
 	virtual UINT32 disasm_min_opcode_bytes() const override { return 1; }

--- a/src/devices/cpu/alto2/alto2cpu.cpp
+++ b/src/devices/cpu/alto2/alto2cpu.cpp
@@ -1002,7 +1002,7 @@ void alto2_cpu_device::device_start()
 //  for the debugger
 //-------------------------------------------------
 
-void alto2_cpu_device::state_string_export(const device_state_entry &entry, std::string &str)
+void alto2_cpu_device::state_string_export(const device_state_entry &entry, std::string &str) const
 {
 	switch (entry.index())
 	{

--- a/src/devices/cpu/alto2/alto2cpu.h
+++ b/src/devices/cpu/alto2/alto2cpu.h
@@ -213,7 +213,7 @@ protected:
 	//! device (P)ROMs
 	virtual const rom_entry *device_rom_region() const override;
 	//! device_state_interface overrides
-	void state_string_export(const device_state_entry &entry, std::string &str) override;
+	void state_string_export(const device_state_entry &entry, std::string &str) const override;
 
 	//! device_disasm_interface overrides
 	virtual UINT32 disasm_min_opcode_bytes() const override { return 4; }

--- a/src/devices/cpu/am29000/am29000.cpp
+++ b/src/devices/cpu/am29000/am29000.cpp
@@ -404,7 +404,7 @@ void am29000_cpu_device::device_start()
 }
 
 
-void am29000_cpu_device::state_string_export(const device_state_entry &entry, std::string &str)
+void am29000_cpu_device::state_string_export(const device_state_entry &entry, std::string &str) const
 {
 	switch (entry.index())
 	{

--- a/src/devices/cpu/am29000/am29000.h
+++ b/src/devices/cpu/am29000/am29000.h
@@ -462,7 +462,7 @@ protected:
 	}
 
 	// device_state_interface overrides
-	void state_string_export(const device_state_entry &entry, std::string &str) override;
+	void state_string_export(const device_state_entry &entry, std::string &str) const override;
 
 	// device_disasm_interface overrides
 	virtual UINT32 disasm_min_opcode_bytes() const override { return 4; }

--- a/src/devices/cpu/amis2000/amis2000.cpp
+++ b/src/devices/cpu/amis2000/amis2000.cpp
@@ -70,7 +70,7 @@ amis2152_cpu_device::amis2152_cpu_device(const machine_config &mconfig, const ch
 
 
 // disasm
-void amis2000_base_device::state_string_export(const device_state_entry &entry, std::string &str)
+void amis2000_base_device::state_string_export(const device_state_entry &entry, std::string &str) const
 {
 	switch (entry.index())
 	{

--- a/src/devices/cpu/amis2000/amis2000.h
+++ b/src/devices/cpu/amis2000/amis2000.h
@@ -89,7 +89,7 @@ protected:
 	virtual UINT32 disasm_min_opcode_bytes() const override { return 1; }
 	virtual UINT32 disasm_max_opcode_bytes() const override { return 1; }
 	virtual offs_t disasm_disassemble(char *buffer, offs_t pc, const UINT8 *oprom, const UINT8 *opram, UINT32 options) override;
-	void state_string_export(const device_state_entry &entry, std::string &str) override;
+	virtual void state_string_export(const device_state_entry &entry, std::string &str) const override;
 
 	address_space_config m_program_config;
 	address_space_config m_data_config;

--- a/src/devices/cpu/apexc/apexc.cpp
+++ b/src/devices/cpu/apexc/apexc.cpp
@@ -814,7 +814,7 @@ void apexc_cpu_device::state_export(const device_state_entry &entry)
 }
 
 
-void apexc_cpu_device::state_string_export(const device_state_entry &entry, std::string &str)
+void apexc_cpu_device::state_string_export(const device_state_entry &entry, std::string &str) const
 {
 	switch (entry.index())
 	{

--- a/src/devices/cpu/apexc/apexc.h
+++ b/src/devices/cpu/apexc/apexc.h
@@ -44,7 +44,7 @@ protected:
 	// device_state_interface overrides
 	virtual void state_import(const device_state_entry &entry) override;
 	virtual void state_export(const device_state_entry &entry) override;
-	void state_string_export(const device_state_entry &entry, std::string &str) override;
+	virtual void state_string_export(const device_state_entry &entry, std::string &str) const override;
 
 	// device_disasm_interface overrides
 	virtual UINT32 disasm_min_opcode_bytes() const override { return 4; }

--- a/src/devices/cpu/arm/arm.cpp
+++ b/src/devices/cpu/arm/arm.cpp
@@ -552,7 +552,7 @@ void arm_cpu_device::device_start()
 }
 
 
-void arm_cpu_device::state_string_export(const device_state_entry &entry, std::string &str)
+void arm_cpu_device::state_string_export(const device_state_entry &entry, std::string &str) const
 {
 	static const char *s[4] = { "USER", "FIRQ", "IRQ ", "SVC " };
 

--- a/src/devices/cpu/arm/arm.h
+++ b/src/devices/cpu/arm/arm.h
@@ -61,7 +61,7 @@ protected:
 	virtual const address_space_config *memory_space_config(address_spacenum spacenum = AS_0) const override { return (spacenum == AS_PROGRAM) ? &m_program_config : nullptr; }
 
 	// device_state_interface overrides
-	void state_string_export(const device_state_entry &entry, std::string &str) override;
+	virtual void state_string_export(const device_state_entry &entry, std::string &str) const override;
 
 	// device_disasm_interface overrides
 	virtual UINT32 disasm_min_opcode_bytes() const override { return 4; }

--- a/src/devices/cpu/arm7/arm7.cpp
+++ b/src/devices/cpu/arm7/arm7.cpp
@@ -564,7 +564,7 @@ void arm7_cpu_device::state_export(const device_state_entry &entry)
 }
 
 
-void arm7_cpu_device::state_string_export(const device_state_entry &entry, std::string &str)
+void arm7_cpu_device::state_string_export(const device_state_entry &entry, std::string &str) const
 {
 	switch (entry.index())
 	{

--- a/src/devices/cpu/arm7/arm7.h
+++ b/src/devices/cpu/arm7/arm7.h
@@ -71,7 +71,7 @@ protected:
 
 	// device_state_interface overrides
 	virtual void state_export(const device_state_entry &entry) override;
-	void state_string_export(const device_state_entry &entry, std::string &str) override;
+	virtual void state_string_export(const device_state_entry &entry, std::string &str) const override;
 
 	// device_disasm_interface overrides
 	virtual UINT32 disasm_min_opcode_bytes() const override { return 2; }

--- a/src/devices/cpu/asap/asap.cpp
+++ b/src/devices/cpu/asap/asap.cpp
@@ -186,7 +186,6 @@ void asap_device::device_start()
 	m_direct = &m_program->direct();
 
 	// register our state for the debugger
-	std::string tempstr;
 	state_add(STATE_GENPC,     "GENPC",     m_pc).noshow();
 	state_add(STATE_GENPCBASE, "GENPCBASE", m_ppc).noshow();
 	state_add(STATE_GENSP,     "GENSP",     m_src2val[REGBASE + 31]).noshow();
@@ -194,7 +193,7 @@ void asap_device::device_start()
 	state_add(ASAP_PC,         "PC",        m_pc);
 	state_add(ASAP_PS,         "PS",        m_flagsio).callimport().callexport();
 	for (int regnum = 0; regnum < 32; regnum++)
-		state_add(ASAP_R0 + regnum, strformat(tempstr, "R%d", regnum).c_str(), m_src2val[REGBASE + regnum]);
+		state_add(ASAP_R0 + regnum, strformat("R%d", regnum).c_str(), m_src2val[REGBASE + regnum]);
 
 	// register our state for saving
 	save_item(NAME(m_pc));
@@ -281,7 +280,7 @@ void asap_device::state_export(const device_state_entry &entry)
 //  for the debugger
 //-------------------------------------------------
 
-void asap_device::state_string_export(const device_state_entry &entry, std::string &str)
+void asap_device::state_string_export(const device_state_entry &entry, std::string &str) const
 {
 	switch (entry.index())
 	{

--- a/src/devices/cpu/asap/asap.h
+++ b/src/devices/cpu/asap/asap.h
@@ -48,7 +48,7 @@ protected:
 	// device_state_interface overrides
 	virtual void state_import(const device_state_entry &entry) override;
 	virtual void state_export(const device_state_entry &entry) override;
-	virtual void state_string_export(const device_state_entry &entry, std::string &str) override;
+	virtual void state_string_export(const device_state_entry &entry, std::string &str) const override;
 
 	// device_disasm_interface overrides
 	virtual UINT32 disasm_min_opcode_bytes() const override;

--- a/src/devices/cpu/avr8/avr8.cpp
+++ b/src/devices/cpu/avr8/avr8.cpp
@@ -905,7 +905,7 @@ const address_space_config *avr8_device::memory_space_config(address_spacenum sp
 //  for the debugger
 //-------------------------------------------------
 
-void avr8_device::state_string_export(const device_state_entry &entry, std::string &str)
+void avr8_device::state_string_export(const device_state_entry &entry, std::string &str) const
 {
 	switch (entry.index())
 	{

--- a/src/devices/cpu/avr8/avr8.h
+++ b/src/devices/cpu/avr8/avr8.h
@@ -131,7 +131,7 @@ protected:
 	virtual offs_t disasm_disassemble(char *buffer, offs_t pc, const UINT8 *oprom, const UINT8 *opram, UINT32 options) override;
 
 	// device_state_interface overrides
-	virtual void state_string_export(const device_state_entry &entry, std::string &str) override;
+	virtual void state_string_export(const device_state_entry &entry, std::string &str) const override;
 
 	// address spaces
 	const address_space_config m_program_config;

--- a/src/devices/cpu/ccpu/ccpu.cpp
+++ b/src/devices/cpu/ccpu/ccpu.cpp
@@ -139,7 +139,7 @@ void ccpu_cpu_device::device_start()
 }
 
 
-void ccpu_cpu_device::state_string_export(const device_state_entry &entry, std::string &str)
+void ccpu_cpu_device::state_string_export(const device_state_entry &entry, std::string &str) const
 {
 	switch (entry.index())
 	{

--- a/src/devices/cpu/ccpu/ccpu.h
+++ b/src/devices/cpu/ccpu/ccpu.h
@@ -82,7 +82,7 @@ protected:
 	}
 
 	// device_state_interface overrides
-	void state_string_export(const device_state_entry &entry, std::string &str) override;
+	virtual void state_string_export(const device_state_entry &entry, std::string &str) const override;
 
 	// device_disasm_interface overrides
 	virtual UINT32 disasm_min_opcode_bytes() const override { return 1; }

--- a/src/devices/cpu/cop400/cop400.cpp
+++ b/src/devices/cpu/cop400/cop400.cpp
@@ -1205,7 +1205,7 @@ void cop400_cpu_device::state_export(const device_state_entry &entry)
 	}
 }
 
-void cop400_cpu_device::state_string_export(const device_state_entry &entry, std::string &str)
+void cop400_cpu_device::state_string_export(const device_state_entry &entry, std::string &str) const
 {
 	switch (entry.index())
 	{

--- a/src/devices/cpu/cop400/cop400.h
+++ b/src/devices/cpu/cop400/cop400.h
@@ -170,7 +170,7 @@ protected:
 	// device_state_interface overrides
 	virtual void state_import(const device_state_entry &entry) override;
 	virtual void state_export(const device_state_entry &entry) override;
-	void state_string_export(const device_state_entry &entry, std::string &str) override;
+	virtual void state_string_export(const device_state_entry &entry, std::string &str) const override;
 
 	// device_disasm_interface overrides
 	virtual UINT32 disasm_min_opcode_bytes() const override { return 1; }

--- a/src/devices/cpu/cosmac/cosmac.cpp
+++ b/src/devices/cpu/cosmac/cosmac.cpp
@@ -353,9 +353,8 @@ void cosmac_device::device_start()
 	state_add(COSMAC_I,     "I",    m_i).mask(0xf);
 	state_add(COSMAC_N,     "N",    m_n).mask(0xf);
 
-	std::string tempstr;
 	for (int regnum = 0; regnum < 16; regnum++)
-		state_add(COSMAC_R0 + regnum, strformat(tempstr, "R%x", regnum).c_str(), m_r[regnum]);
+		state_add(COSMAC_R0 + regnum, strformat("R%x", regnum).c_str(), m_r[regnum]);
 
 	state_add(COSMAC_DF,    "DF",   m_df).mask(0x1).noshow();
 	state_add(COSMAC_IE,    "IE",   m_ie).mask(0x1).noshow();
@@ -469,7 +468,7 @@ void cosmac_device::state_export(const device_state_entry &entry)
 //  for the debugger
 //-------------------------------------------------
 
-void cosmac_device::state_string_export(const device_state_entry &entry, std::string &str)
+void cosmac_device::state_string_export(const device_state_entry &entry, std::string &str) const
 {
 	switch (entry.index())
 	{

--- a/src/devices/cpu/cosmac/cosmac.h
+++ b/src/devices/cpu/cosmac/cosmac.h
@@ -232,7 +232,7 @@ protected:
 	// device_state_interface overrides
 	virtual void state_import(const device_state_entry &entry) override;
 	virtual void state_export(const device_state_entry &entry) override;
-	virtual void state_string_export(const device_state_entry &entry, std::string &str) override;
+	virtual void state_string_export(const device_state_entry &entry, std::string &str) const override;
 
 	// device_disasm_interface overrides
 	virtual UINT32 disasm_min_opcode_bytes() const override;

--- a/src/devices/cpu/cp1610/cp1610.cpp
+++ b/src/devices/cpu/cp1610/cp1610.cpp
@@ -3401,7 +3401,7 @@ cp1610_cpu_device::cp1610_cpu_device(const machine_config &mconfig, const char *
 }
 
 
-void cp1610_cpu_device::state_string_export(const device_state_entry &entry, std::string &str)
+void cp1610_cpu_device::state_string_export(const device_state_entry &entry, std::string &str) const
 {
 	switch (entry.index())
 	{

--- a/src/devices/cpu/cp1610/cp1610.h
+++ b/src/devices/cpu/cp1610/cp1610.h
@@ -56,7 +56,7 @@ protected:
 	virtual const address_space_config *memory_space_config(address_spacenum spacenum = AS_0) const override { return (spacenum == AS_PROGRAM) ? &m_program_config : nullptr; }
 
 	// device_state_interface overrides
-	void state_string_export(const device_state_entry &entry, std::string &str) override;
+	void state_string_export(const device_state_entry &entry, std::string &str) const override;
 
 	// device_disasm_interface overrides
 	virtual UINT32 disasm_min_opcode_bytes() const override { return 2; }

--- a/src/devices/cpu/cubeqcpu/cubeqcpu.cpp
+++ b/src/devices/cpu/cubeqcpu/cubeqcpu.cpp
@@ -347,7 +347,7 @@ void cquestrot_cpu_device::device_reset()
 }
 
 
-void cquestrot_cpu_device::state_string_export(const device_state_entry &entry, std::string &str)
+void cquestrot_cpu_device::state_string_export(const device_state_entry &entry, std::string &str) const
 {
 	switch (entry.index())
 	{
@@ -471,7 +471,7 @@ void cquestlin_cpu_device::device_reset()
 }
 
 
-void cquestlin_cpu_device::state_string_export(const device_state_entry &entry, std::string &str)
+void cquestlin_cpu_device::state_string_export(const device_state_entry &entry, std::string &str) const
 {
 	switch (entry.index())
 	{

--- a/src/devices/cpu/cubeqcpu/cubeqcpu.h
+++ b/src/devices/cpu/cubeqcpu/cubeqcpu.h
@@ -232,7 +232,7 @@ protected:
 	virtual const address_space_config *memory_space_config(address_spacenum spacenum = AS_0) const override { return (spacenum == AS_PROGRAM) ? &m_program_config : nullptr; }
 
 	// device_state_interface overrides
-	void state_string_export(const device_state_entry &entry, std::string &str) override;
+	virtual void state_string_export(const device_state_entry &entry, std::string &str) const override;
 
 	// device_disasm_interface overrides
 	virtual UINT32 disasm_min_opcode_bytes() const override { return 8; }
@@ -316,7 +316,7 @@ protected:
 	virtual const address_space_config *memory_space_config(address_spacenum spacenum = AS_0) const override { return (spacenum == AS_PROGRAM) ? &m_program_config : nullptr; }
 
 	// device_state_interface overrides
-	void state_string_export(const device_state_entry &entry, std::string &str) override;
+	virtual void state_string_export(const device_state_entry &entry, std::string &str) const override;
 
 	// device_disasm_interface overrides
 	virtual UINT32 disasm_min_opcode_bytes() const override { return 8; }

--- a/src/devices/cpu/drcbex64.cpp
+++ b/src/devices/cpu/drcbex64.cpp
@@ -787,7 +787,6 @@ void drcbe_x64::generate(drcuml_block &block, const instruction *instlist, UINT3
 	x86code *dst = base;
 
 	// generate code
-	std::string tempstring;
 	const char *blockname = nullptr;
 	for (int inum = 0; inum < numinst; inum++)
 	{
@@ -797,8 +796,7 @@ void drcbe_x64::generate(drcuml_block &block, const instruction *instlist, UINT3
 		// add a comment
 		if (m_log != nullptr)
 		{
-			std::string dasm;
-			inst.disasm(dasm, &m_drcuml);
+			std::string dasm = inst.disasm(&m_drcuml);
 			x86log_add_comment(m_log, dst, "%s", dasm.c_str());
 		}
 
@@ -808,7 +806,7 @@ void drcbe_x64::generate(drcuml_block &block, const instruction *instlist, UINT3
 			if (inst.opcode() == OP_HANDLE)
 				blockname = inst.param(0).handle().string();
 			else if (inst.opcode() == OP_HASH)
-				blockname = strformat(tempstring, "Code: mode=%d PC=%08X", (UINT32)inst.param(0).immediate(), (offs_t)inst.param(1).immediate()).c_str();
+				blockname = strformat("Code: mode=%d PC=%08X", (UINT32)inst.param(0).immediate(), (offs_t)inst.param(1).immediate()).c_str();
 		}
 
 		// generate code

--- a/src/devices/cpu/drcbex86.cpp
+++ b/src/devices/cpu/drcbex86.cpp
@@ -770,7 +770,6 @@ void drcbe_x86::generate(drcuml_block &block, const instruction *instlist, UINT3
 	x86code *dst = base;
 
 	// generate code
-	std::string tempstring;
 	const char *blockname = nullptr;
 	for (int inum = 0; inum < numinst; inum++)
 	{
@@ -780,8 +779,7 @@ void drcbe_x86::generate(drcuml_block &block, const instruction *instlist, UINT3
 		// add a comment
 		if (m_log != nullptr)
 		{
-			std::string dasm;
-			inst.disasm(dasm, &m_drcuml);
+			std::string dasm = inst.disasm(&m_drcuml);
 			x86log_add_comment(m_log, dst, "%s", dasm.c_str());
 		}
 
@@ -791,7 +789,7 @@ void drcbe_x86::generate(drcuml_block &block, const instruction *instlist, UINT3
 			if (inst.opcode() == OP_HANDLE)
 				blockname = inst.param(0).handle().string();
 			else if (inst.opcode() == OP_HASH)
-				blockname = strformat(tempstring, "Code: mode=%d PC=%08X", (UINT32)inst.param(0).immediate(), (offs_t)inst.param(1).immediate()).c_str();
+				blockname = strformat("Code: mode=%d PC=%08X", (UINT32)inst.param(0).immediate(), (offs_t)inst.param(1).immediate()).c_str();
 		}
 
 		// generate code

--- a/src/devices/cpu/drcuml.cpp
+++ b/src/devices/cpu/drcuml.cpp
@@ -456,7 +456,6 @@ void drcuml_block::optimize()
 void drcuml_block::disassemble()
 {
 	std::string comment;
-	std::string dasm;
 
 	// iterate over instructions and output
 	int firstcomment = -1;
@@ -483,7 +482,7 @@ void drcuml_block::disassemble()
 		// indent everything else with a tab
 		else
 		{
-			m_inst[instnum].disasm(dasm, &m_drcuml);
+			std::string dasm = m_inst[instnum].disasm(&m_drcuml);
 
 			// include the first accumulated comment with this line
 			if (firstcomment != -1)
@@ -1119,16 +1118,14 @@ static int bevalidate_verify_state(drcuml_state *drcuml, const drcuml_machine_st
 	// output the error if we have one
 	if (errend != errorbuf)
 	{
-		char disasm[256];
-
 		// disassemble the test instruction
-		testinst->disasm(disasm, drcuml);
+		std::string disasm = testinst->disasm(drcuml);
 
 		// output a description of what went wrong
 		printf("\n");
 		printf("----------------------------------------------\n");
 		printf("Backend validation error:\n");
-		printf("   %s\n", disasm);
+		printf("   %s\n", disasm.c_str());
 		printf("\n");
 		printf("Errors:\n");
 		printf("%s\n", errorbuf);

--- a/src/devices/cpu/dsp16/dsp16.cpp
+++ b/src/devices/cpu/dsp16/dsp16.cpp
@@ -214,7 +214,7 @@ const address_space_config *dsp16_device::memory_space_config(address_spacenum s
 //  for the debugger
 //-------------------------------------------------
 
-void dsp16_device::state_string_export(const device_state_entry &entry, std::string &str)
+void dsp16_device::state_string_export(const device_state_entry &entry, std::string &str) const
 {
 	switch (entry.index())
 	{

--- a/src/devices/cpu/dsp16/dsp16.h
+++ b/src/devices/cpu/dsp16/dsp16.h
@@ -46,7 +46,7 @@ protected:
 	virtual const address_space_config *memory_space_config(address_spacenum spacenum = AS_0) const override;
 
 	// device_state_interface overrides
-	virtual void state_string_export(const device_state_entry &entry, std::string &str) override;
+	virtual void state_string_export(const device_state_entry &entry, std::string &str) const override;
 
 	// device_disasm_interface overrides
 	virtual UINT32 disasm_min_opcode_bytes() const override;

--- a/src/devices/cpu/dsp32/dsp32.cpp
+++ b/src/devices/cpu/dsp32/dsp32.cpp
@@ -194,14 +194,13 @@ void dsp32c_device::device_start()
 	m_direct = &m_program->direct();
 
 	// register our state for the debugger
-	std::string tempstr;
 	state_add(STATE_GENPC,     "GENPC",     m_r[15]).noshow();
 	state_add(STATE_GENPCBASE, "GENPCBASE", m_ppc).noshow();
 	state_add(STATE_GENSP,     "GENSP",     m_r[21]).noshow();
 	state_add(STATE_GENFLAGS,  "GENFLAGS",  m_iotemp).callimport().callexport().formatstr("%6s").noshow();
 	state_add(DSP32_PC,        "PC",        m_r[15]).mask(0xffffff);
 	for (int regnum = 0; regnum <= 14; regnum++)
-		state_add(DSP32_R0 + regnum, strformat(tempstr, "R%d", regnum).c_str(), m_r[regnum]).mask(0xffffff);
+		state_add(DSP32_R0 + regnum, strformat("R%d", regnum).c_str(), m_r[regnum]).mask(0xffffff);
 	state_add(DSP32_R15,       "R15",       m_r[17]).mask(0xffffff);
 	state_add(DSP32_R16,       "R16",       m_r[18]).mask(0xffffff);
 	state_add(DSP32_R17,       "R17",       m_r[19]).mask(0xffffff);
@@ -369,7 +368,7 @@ void dsp32c_device::state_export(const device_state_entry &entry)
 //  for the debugger
 //-------------------------------------------------
 
-void dsp32c_device::state_string_export(const device_state_entry &entry, std::string &str)
+void dsp32c_device::state_string_export(const device_state_entry &entry, std::string &str) const
 {
 	switch (entry.index())
 	{

--- a/src/devices/cpu/dsp32/dsp32.h
+++ b/src/devices/cpu/dsp32/dsp32.h
@@ -123,7 +123,7 @@ protected:
 	// device_state_interface overrides
 	virtual void state_import(const device_state_entry &entry) override;
 	virtual void state_export(const device_state_entry &entry) override;
-	virtual void state_string_export(const device_state_entry &entry, std::string &str) override;
+	virtual void state_string_export(const device_state_entry &entry, std::string &str) const override;
 
 	// device_disasm_interface overrides
 	virtual UINT32 disasm_min_opcode_bytes() const override;

--- a/src/devices/cpu/dsp56k/dsp56k.cpp
+++ b/src/devices/cpu/dsp56k/dsp56k.cpp
@@ -340,9 +340,9 @@ void dsp56k_device::device_start()
 }
 
 
-void dsp56k_device::state_string_export(const device_state_entry &entry, std::string &str)
+void dsp56k_device::state_string_export(const device_state_entry &entry, std::string &str) const
 {
-	dsp56k_core *cpustate = &m_dsp56k_core;
+	const dsp56k_core *cpustate = &m_dsp56k_core;
 
 	switch (entry.index())
 	{

--- a/src/devices/cpu/dsp56k/dsp56k.h
+++ b/src/devices/cpu/dsp56k/dsp56k.h
@@ -231,7 +231,7 @@ protected:
 	virtual const address_space_config *memory_space_config(address_spacenum spacenum = AS_0) const override { return (spacenum == AS_PROGRAM) ? &m_program_config : ((spacenum == AS_DATA) ? &m_data_config : nullptr ); }
 
 	// device_state_interface overrides
-	void state_string_export(const device_state_entry &entry, std::string &str) override;
+	virtual void state_string_export(const device_state_entry &entry, std::string &str) const override;
 
 	// device_disasm_interface overrides
 	virtual UINT32 disasm_min_opcode_bytes() const override { return 2; }

--- a/src/devices/cpu/dsp56k/dsp56pcu.cpp
+++ b/src/devices/cpu/dsp56k/dsp56pcu.cpp
@@ -14,18 +14,18 @@ namespace DSP56K
 /* |-------------------------------------| |-------------------------------| */
 /*                                                                           */
 /* ************************************************************************* */
-UINT8 LF_bit(dsp56k_core* cpustate) { return (SR & 0x8000) >> 15; }
-UINT8 FV_bit(dsp56k_core* cpustate) { return (SR & 0x4000) >> 14; }
-// UINT8 S_bits(dsp56k_core* cpustate) { return (SR & 0x0c00) >> 10; }
-UINT8 I_bits(dsp56k_core* cpustate) { return (SR & 0x0300) >> 8;  }
-UINT8 S_bit (dsp56k_core* cpustate) { return (SR & 0x0080) >> 7;  }
-UINT8 L_bit (dsp56k_core* cpustate) { return (SR & 0x0040) >> 6;  }
-UINT8 E_bit (dsp56k_core* cpustate) { return (SR & 0x0020) >> 5;  }
-UINT8 U_bit (dsp56k_core* cpustate) { return (SR & 0x0010) >> 4;  }
-UINT8 N_bit (dsp56k_core* cpustate) { return (SR & 0x0008) >> 3;  }
-UINT8 Z_bit (dsp56k_core* cpustate) { return (SR & 0x0004) >> 2;  }
-UINT8 V_bit (dsp56k_core* cpustate) { return (SR & 0x0002) >> 1;  }
-UINT8 C_bit (dsp56k_core* cpustate) { return (SR & 0x0001) >> 0;  }
+UINT8 LF_bit(const dsp56k_core* cpustate) { return (SR & 0x8000) >> 15; }
+UINT8 FV_bit(const dsp56k_core* cpustate) { return (SR & 0x4000) >> 14; }
+// UINT8 S_bits(const dsp56k_core* cpustate) { return (SR & 0x0c00) >> 10; }
+UINT8 I_bits(const dsp56k_core* cpustate) { return (SR & 0x0300) >> 8;  }
+UINT8 S_bit (const dsp56k_core* cpustate) { return (SR & 0x0080) >> 7;  }
+UINT8 L_bit (const dsp56k_core* cpustate) { return (SR & 0x0040) >> 6;  }
+UINT8 E_bit (const dsp56k_core* cpustate) { return (SR & 0x0020) >> 5;  }
+UINT8 U_bit (const dsp56k_core* cpustate) { return (SR & 0x0010) >> 4;  }
+UINT8 N_bit (const dsp56k_core* cpustate) { return (SR & 0x0008) >> 3;  }
+UINT8 Z_bit (const dsp56k_core* cpustate) { return (SR & 0x0004) >> 2;  }
+UINT8 V_bit (const dsp56k_core* cpustate) { return (SR & 0x0002) >> 1;  }
+UINT8 C_bit (const dsp56k_core* cpustate) { return (SR & 0x0001) >> 0;  }
 
 /* MR setters */
 void LF_bit_set(dsp56k_core* cpustate, UINT8 value) { if (value) (SR |= 0x8000); else (SR &= (~0x8000)); }
@@ -54,13 +54,13 @@ void C_bit_set(dsp56k_core* cpustate, UINT8 value) { if (value) (SR |= 0x0001); 
 /*  |---------------------------------------------------------------------|  */
 /*                                                                           */
 /* ************************************************************************* */
-// UINT8 CD_bit(dsp56k_core* cpustate) { return ((OMR & 0x0080) != 0); }
-// UINT8 SD_bit(dsp56k_core* cpustate) { return ((OMR & 0x0040) != 0); }
-// UINT8  R_bit(dsp56k_core* cpustate) { return ((OMR & 0x0020) != 0); }
-// UINT8 SA_bit(dsp56k_core* cpustate) { return ((OMR & 0x0010) != 0); }
-// UINT8 MC_bit(dsp56k_core* cpustate) { return ((OMR & 0x0004) != 0); }
-UINT8 MB_bit(dsp56k_core* cpustate) { return ((OMR & 0x0002) != 0); }
-UINT8 MA_bit(dsp56k_core* cpustate) { return ((OMR & 0x0001) != 0); }
+// UINT8 CD_bit(const dsp56k_core* cpustate) { return ((OMR & 0x0080) != 0); }
+// UINT8 SD_bit(const dsp56k_core* cpustate) { return ((OMR & 0x0040) != 0); }
+// UINT8  R_bit(const dsp56k_core* cpustate) { return ((OMR & 0x0020) != 0); }
+// UINT8 SA_bit(const dsp56k_core* cpustate) { return ((OMR & 0x0010) != 0); }
+// UINT8 MC_bit(const dsp56k_core* cpustate) { return ((OMR & 0x0004) != 0); }
+UINT8 MB_bit(const dsp56k_core* cpustate) { return ((OMR & 0x0002) != 0); }
+UINT8 MA_bit(const dsp56k_core* cpustate) { return ((OMR & 0x0001) != 0); }
 
 void CD_bit_set(dsp56k_core* cpustate, UINT8 value) { if (value) (OMR |= 0x0080); else (OMR &= (~0x0080)); }
 void SD_bit_set(dsp56k_core* cpustate, UINT8 value) { if (value) (OMR |= 0x0040); else (OMR &= (~0x0040)); }
@@ -70,7 +70,7 @@ void MC_bit_set(dsp56k_core* cpustate, UINT8 value) { if (value) (OMR |= 0x0004)
 void MB_bit_set(dsp56k_core* cpustate, UINT8 value) { if (value) (OMR |= 0x0002); else (OMR &= (~0x0002)); }
 void MA_bit_set(dsp56k_core* cpustate, UINT8 value) { if (value) (OMR |= 0x0001); else (OMR &= (~0x0001)); }
 
-UINT8 dsp56k_operating_mode(dsp56k_core* cpustate)
+UINT8 dsp56k_operating_mode(const dsp56k_core* cpustate)
 {
 	return ((MB_bit(cpustate) << 1) | MA_bit(cpustate));
 }
@@ -86,8 +86,8 @@ UINT8 dsp56k_operating_mode(dsp56k_core* cpustate)
 /*  |---------------------------------------------------------------------|  */
 /*                                                                           */
 /* ************************************************************************* */
-UINT8 UF_bit(dsp56k_core* cpustate) { return ((SP & 0x0020) != 0); }
-UINT8 SE_bit(dsp56k_core* cpustate) { return ((SP & 0x0010) != 0); }
+UINT8 UF_bit(const dsp56k_core* cpustate) { return ((SP & 0x0020) != 0); }
+UINT8 SE_bit(const dsp56k_core* cpustate) { return ((SP & 0x0010) != 0); }
 
 //void UF_bit_set(dsp56k_core* cpustate, UINT8 value) {};
 //void SE_bit_set(dsp56k_core* cpustate, UINT8 value) {};

--- a/src/devices/cpu/dsp56k/dsp56pcu.h
+++ b/src/devices/cpu/dsp56k/dsp56pcu.h
@@ -42,28 +42,28 @@ void pcu_init(dsp56k_core* cpustate, device_t *device);
 
 /* STATUS REGISTER (SR) BITS (1-25) */
 /* MR */
-UINT8 LF_bit(dsp56k_core* cpustate);
-UINT8 FV_bit(dsp56k_core* cpustate);
-//UINT8 S_bits(dsp56k_core* cpustate);
-UINT8 I_bits(dsp56k_core* cpustate);
+UINT8 LF_bit(const dsp56k_core* cpustate);
+UINT8 FV_bit(const dsp56k_core* cpustate);
+//UINT8 S_bits(const dsp56k_core* cpustate);
+UINT8 I_bits(const dsp56k_core* cpustate);
 
 /* CCR - with macros for easy access */
 #define S() (S_bit(cpustate))
-UINT8 S_bit(dsp56k_core* cpustate);
+UINT8 S_bit(const dsp56k_core* cpustate);
 #define L() (L_bit(cpustate))
-UINT8 L_bit(dsp56k_core* cpustate);
+UINT8 L_bit(const dsp56k_core* cpustate);
 #define E() (E_bit(cpustate))
-UINT8 E_bit(dsp56k_core* cpustate);
+UINT8 E_bit(const dsp56k_core* cpustate);
 #define U() (U_bit(cpustate))
-UINT8 U_bit(dsp56k_core* cpustate);
+UINT8 U_bit(const dsp56k_core* cpustate);
 #define N() (N_bit(cpustate))
-UINT8 N_bit(dsp56k_core* cpustate);
+UINT8 N_bit(const dsp56k_core* cpustate);
 #define Z() (Z_bit(cpustate))
-UINT8 Z_bit(dsp56k_core* cpustate);
+UINT8 Z_bit(const dsp56k_core* cpustate);
 #define V() (V_bit(cpustate))
-UINT8 V_bit(dsp56k_core* cpustate);
+UINT8 V_bit(const dsp56k_core* cpustate);
 #define C() (C_bit(cpustate))
-UINT8 C_bit(dsp56k_core* cpustate);
+UINT8 C_bit(const dsp56k_core* cpustate);
 
 /* MR setters */
 void LF_bit_set(dsp56k_core* cpustate, UINT8 value);
@@ -101,13 +101,13 @@ void C_bit_set(dsp56k_core* cpustate, UINT8 value);
 
 
 /* 1-28 OPERATING MODE REGISTER (OMR) BITS */
-//UINT8 CD_bit(dsp56k_core* cpustate);
-//UINT8 SD_bit(dsp56k_core* cpustate);
-//UINT8 R_bit(dsp56k_core* cpustate);
-//UINT8 SA_bit(dsp56k_core* cpustate);
-//UINT8 MC_bit(dsp56k_core* cpustate);
-UINT8 MB_bit(dsp56k_core* cpustate);
-UINT8 MA_bit(dsp56k_core* cpustate);
+//UINT8 CD_bit(const dsp56k_core* cpustate);
+//UINT8 SD_bit(const dsp56k_core* cpustate);
+//UINT8 R_bit(const dsp56k_core* cpustate);
+//UINT8 SA_bit(const dsp56k_core* cpustate);
+//UINT8 MC_bit(const dsp56k_core* cpustate);
+UINT8 MB_bit(const dsp56k_core* cpustate);
+UINT8 MA_bit(const dsp56k_core* cpustate);
 
 void CD_bit_set(dsp56k_core* cpustate, UINT8 value);
 void SD_bit_set(dsp56k_core* cpustate, UINT8 value);
@@ -118,8 +118,8 @@ void MB_bit_set(dsp56k_core* cpustate, UINT8 value);
 void MA_bit_set(dsp56k_core* cpustate, UINT8 value);
 
 /* 1-27 STACK POINTER (SP) BITS */
-UINT8 UF_bit(dsp56k_core* cpustate);
-UINT8 SE_bit(dsp56k_core* cpustate);
+UINT8 UF_bit(const dsp56k_core* cpustate);
+UINT8 SE_bit(const dsp56k_core* cpustate);
 
 //void UF_bit_set(dsp56k_core* cpustate, UINT8 value) {};
 //void SE_bit_set(dsp56k_core* cpustate, UINT8 value) {};

--- a/src/devices/cpu/e0c6200/e0c6200.cpp
+++ b/src/devices/cpu/e0c6200/e0c6200.cpp
@@ -25,7 +25,7 @@
 
 
 // disasm
-void e0c6200_cpu_device::state_string_export(const device_state_entry &entry, std::string &str)
+void e0c6200_cpu_device::state_string_export(const device_state_entry &entry, std::string &str) const
 {
 	switch (entry.index())
 	{

--- a/src/devices/cpu/e0c6200/e0c6200.h
+++ b/src/devices/cpu/e0c6200/e0c6200.h
@@ -44,7 +44,7 @@ protected:
 	virtual UINT32 disasm_min_opcode_bytes() const override { return 2; }
 	virtual UINT32 disasm_max_opcode_bytes() const override { return 2; }
 	virtual offs_t disasm_disassemble(char *buffer, offs_t pc, const UINT8 *oprom, const UINT8 *opram, UINT32 options) override;
-	virtual void state_string_export(const device_state_entry &entry, std::string &str) override;
+	virtual void state_string_export(const device_state_entry &entry, std::string &str) const override;
 
 	address_space_config m_program_config;
 	address_space_config m_data_config;

--- a/src/devices/cpu/e132xs/e132xs.cpp
+++ b/src/devices/cpu/e132xs/e132xs.cpp
@@ -1848,7 +1848,7 @@ const address_space_config *hyperstone_device::memory_space_config(address_space
 //  for the debugger
 //-------------------------------------------------
 
-void hyperstone_device::state_string_export(const device_state_entry &entry, std::string &str)
+void hyperstone_device::state_string_export(const device_state_entry &entry, std::string &str) const
 {
 	switch (entry.index())
 	{

--- a/src/devices/cpu/e132xs/e132xs.h
+++ b/src/devices/cpu/e132xs/e132xs.h
@@ -241,7 +241,7 @@ protected:
 	virtual offs_t disasm_disassemble(char *buffer, offs_t pc, const UINT8 *oprom, const UINT8 *opram, UINT32 options) override;
 
 	// device_state_interface overrides
-	virtual void state_string_export(const device_state_entry &entry, std::string &str) override;
+	virtual void state_string_export(const device_state_entry &entry, std::string &str) const override;
 
 	// address spaces
 	const address_space_config m_program_config;

--- a/src/devices/cpu/esrip/esrip.cpp
+++ b/src/devices/cpu/esrip/esrip.cpp
@@ -350,7 +350,7 @@ const address_space_config *esrip_device::memory_space_config(address_spacenum s
 //  for the debugger
 //-------------------------------------------------
 
-void esrip_device::state_string_export(const device_state_entry &entry, std::string &str)
+void esrip_device::state_string_export(const device_state_entry &entry, std::string &str) const
 {
 	switch (entry.index())
 	{
@@ -408,13 +408,13 @@ offs_t esrip_device::disasm_disassemble(char *buffer, offs_t pc, const UINT8 *op
     PRIVATE FUNCTIONS
 ***************************************************************************/
 
-int esrip_device::get_hblank()
+int esrip_device::get_hblank() const
 {
 	return machine().first_screen()->hblank();
 }
 
 /* Return the state of the LBRM line (Y-scaling related) */
-int esrip_device::get_lbrm()
+int esrip_device::get_lbrm() const
 {
 	int addr = ((m_y_scale & 0x3f) << 3) | ((m_line_latch >> 3) & 7);
 	int sel = (m_line_latch & 7);
@@ -424,7 +424,7 @@ int esrip_device::get_lbrm()
 	return (val >> sel) & 1;
 }
 
-int esrip_device::check_jmp(UINT8 jmp_ctrl)
+int esrip_device::check_jmp(UINT8 jmp_ctrl) const
 {
 	int ret = 0;
 

--- a/src/devices/cpu/esrip/esrip.h
+++ b/src/devices/cpu/esrip/esrip.h
@@ -152,7 +152,7 @@ protected:
 	virtual offs_t disasm_disassemble(char *buffer, offs_t pc, const UINT8 *oprom, const UINT8 *opram, UINT32 options) override;
 
 	// device_state_interface overrides
-	virtual void state_string_export(const device_state_entry &entry, std::string &str) override;
+	virtual void state_string_export(const device_state_entry &entry, std::string &str) const override;
 
 	// address spaces
 	const address_space_config m_program_config;
@@ -223,9 +223,9 @@ protected:
 	static const ophandler s_opcodetable[24];
 
 private:
-	int get_hblank();
-	int get_lbrm();
-	int check_jmp(UINT8 jmp_ctrl);
+	int get_hblank() const;
+	int get_lbrm() const;
+	int check_jmp(UINT8 jmp_ctrl) const;
 
 	// flags
 	void calc_z_flag(UINT16 res);

--- a/src/devices/cpu/f8/f8.cpp
+++ b/src/devices/cpu/f8/f8.cpp
@@ -2045,7 +2045,7 @@ void f8_cpu_device::device_start()
 }
 
 
-void f8_cpu_device::state_string_export(const device_state_entry &entry, std::string &str)
+void f8_cpu_device::state_string_export(const device_state_entry &entry, std::string &str) const
 {
 	switch (entry.index())
 	{

--- a/src/devices/cpu/f8/f8.h
+++ b/src/devices/cpu/f8/f8.h
@@ -51,7 +51,7 @@ protected:
 	virtual const address_space_config *memory_space_config(address_spacenum spacenum = AS_0) const override { return (spacenum == AS_PROGRAM) ? &m_program_config : ( (spacenum == AS_IO) ? &m_io_config : nullptr ); }
 
 	// device_state_interface overrides
-	void state_string_export(const device_state_entry &entry, std::string &str) override;
+	virtual void state_string_export(const device_state_entry &entry, std::string &str) const override;
 
 	// device_disasm_interface overrides
 	virtual UINT32 disasm_min_opcode_bytes() const override { return 1; }

--- a/src/devices/cpu/g65816/g65816.cpp
+++ b/src/devices/cpu/g65816/g65816.cpp
@@ -952,7 +952,7 @@ void g65816_device::state_export(const device_state_entry &entry)
 	}
 }
 
-void g65816_device::state_string_export(const device_state_entry &entry, std::string &str)
+void g65816_device::state_string_export(const device_state_entry &entry, std::string &str) const
 {
 	switch (entry.index())
 	{

--- a/src/devices/cpu/g65816/g65816.h
+++ b/src/devices/cpu/g65816/g65816.h
@@ -82,7 +82,7 @@ protected:
 	// device_state_interface overrides
 	virtual void state_import(const device_state_entry &entry) override;
 	virtual void state_export(const device_state_entry &entry) override;
-	virtual void state_string_export(const device_state_entry &entry, std::string &str) override;
+	virtual void state_string_export(const device_state_entry &entry, std::string &str) const override;
 
 	// device_disasm_interface overrides
 	virtual UINT32 disasm_min_opcode_bytes() const override { return 1; }

--- a/src/devices/cpu/h6280/h6280.cpp
+++ b/src/devices/cpu/h6280/h6280.cpp
@@ -2191,7 +2191,7 @@ OP(op,ff) { h6280_cycles(4); bbs(7, rd_zpg());         } // 6/8 BBS7 ZPG,REL
 //  for the debugger
 //-------------------------------------------------
 
-void h6280_device::state_string_export(const device_state_entry &entry, std::string &str)
+void h6280_device::state_string_export(const device_state_entry &entry, std::string &str) const
 {
 	switch (entry.index())
 	{

--- a/src/devices/cpu/h6280/h6280.h
+++ b/src/devices/cpu/h6280/h6280.h
@@ -98,7 +98,7 @@ protected:
 	virtual offs_t disasm_disassemble(char *buffer, offs_t pc, const UINT8 *oprom, const UINT8 *opram, UINT32 options) override;
 
 	// device_state_interface overrides
-	virtual void state_string_export(const device_state_entry &entry, std::string &str) override;
+	virtual void state_string_export(const device_state_entry &entry, std::string &str) const override;
 
 	// opcode accessors
 	UINT8 program_read8(offs_t addr);

--- a/src/devices/cpu/h8/h8.cpp
+++ b/src/devices/cpu/h8/h8.cpp
@@ -216,7 +216,7 @@ void h8_device::state_export(const device_state_entry &entry)
 {
 }
 
-void h8_device::state_string_export(const device_state_entry &entry, std::string &str)
+void h8_device::state_string_export(const device_state_entry &entry, std::string &str) const
 {
 	switch(entry.index()) {
 	case STATE_GENFLAGS:

--- a/src/devices/cpu/h8/h8.h
+++ b/src/devices/cpu/h8/h8.h
@@ -157,7 +157,7 @@ protected:
 	// device_state_interface overrides
 	virtual void state_import(const device_state_entry &entry) override;
 	virtual void state_export(const device_state_entry &entry) override;
-	virtual void state_string_export(const device_state_entry &entry, std::string &str) override;
+	virtual void state_string_export(const device_state_entry &entry, std::string &str) const override;
 
 	// device_disasm_interface overrides
 	virtual UINT32 disasm_min_opcode_bytes() const override;

--- a/src/devices/cpu/hcd62121/hcd62121.cpp
+++ b/src/devices/cpu/hcd62121/hcd62121.cpp
@@ -363,7 +363,7 @@ void hcd62121_cpu_device::device_start()
 }
 
 
-void hcd62121_cpu_device::state_string_export(const device_state_entry &entry, std::string &str)
+void hcd62121_cpu_device::state_string_export(const device_state_entry &entry, std::string &str) const
 {
 	switch (entry.index())
 	{

--- a/src/devices/cpu/hcd62121/hcd62121.h
+++ b/src/devices/cpu/hcd62121/hcd62121.h
@@ -54,7 +54,7 @@ protected:
 	virtual const address_space_config *memory_space_config(address_spacenum spacenum = AS_0) const override { return (spacenum == AS_PROGRAM) ? &m_program_config : ( (spacenum == AS_IO) ? &m_io_config : nullptr ); }
 
 	// device_state_interface overrides
-	void state_string_export(const device_state_entry &entry, std::string &str) override;
+	virtual void state_string_export(const device_state_entry &entry, std::string &str) const override;
 
 	// device_disasm_interface overrides
 	virtual UINT32 disasm_min_opcode_bytes() const override { return 1; }

--- a/src/devices/cpu/hd61700/hd61700.cpp
+++ b/src/devices/cpu/hd61700/hd61700.cpp
@@ -183,8 +183,7 @@ void hd61700_cpu_device::device_start()
 
 	for (int ireg=0; ireg<32; ireg++)
 	{
-		std::string tmpstr;
-		state_add(HD61700_MAINREG + ireg, strformat(tmpstr, "R%d", ireg).c_str(), m_regmain[ireg]).callimport().callexport().formatstr("%02X");
+		state_add(HD61700_MAINREG + ireg, strformat("R%d", ireg).c_str(), m_regmain[ireg]).callimport().callexport().formatstr("%02X");
 	}
 
 	state_add(STATE_GENPC, "curpc", m_curpc).callimport().callexport().formatstr("%8s").noshow();
@@ -271,7 +270,7 @@ void hd61700_cpu_device::state_import(const device_state_entry &entry)
 //  for the debugger
 //-------------------------------------------------
 
-void hd61700_cpu_device::state_string_export(const device_state_entry &entry, std::string &str)
+void hd61700_cpu_device::state_string_export(const device_state_entry &entry, std::string &str) const
 {
 	switch (entry.index())
 	{

--- a/src/devices/cpu/hd61700/hd61700.h
+++ b/src/devices/cpu/hd61700/hd61700.h
@@ -92,7 +92,7 @@ protected:
 
 	// device_state_interface overrides
 	virtual void state_import(const device_state_entry &entry) override;
-	void state_string_export(const device_state_entry &entry, std::string &str) override;
+	void state_string_export(const device_state_entry &entry, std::string &str) const override;
 
 	// device_memory_interface overrides
 	virtual const address_space_config *memory_space_config(address_spacenum spacenum = AS_0) const override { return (spacenum == AS_PROGRAM) ? &m_program_config : nullptr; }

--- a/src/devices/cpu/hmcs40/hmcs40.cpp
+++ b/src/devices/cpu/hmcs40/hmcs40.cpp
@@ -133,7 +133,7 @@ hd44828_device::hd44828_device(const machine_config &mconfig, const char *tag, d
 
 
 // disasm
-void hmcs40_cpu_device::state_string_export(const device_state_entry &entry, std::string &str)
+void hmcs40_cpu_device::state_string_export(const device_state_entry &entry, std::string &str) const
 {
 	switch (entry.index())
 	{

--- a/src/devices/cpu/hmcs40/hmcs40.h
+++ b/src/devices/cpu/hmcs40/hmcs40.h
@@ -175,7 +175,7 @@ protected:
 	virtual UINT32 disasm_min_opcode_bytes() const override { return 2; }
 	virtual UINT32 disasm_max_opcode_bytes() const override { return 2; }
 	virtual offs_t disasm_disassemble(char *buffer, offs_t pc, const UINT8 *oprom, const UINT8 *opram, UINT32 options) override;
-	void state_string_export(const device_state_entry &entry, std::string &str) override;
+	virtual void state_string_export(const device_state_entry &entry, std::string &str) const override;
 
 	address_space_config m_program_config;
 	address_space_config m_data_config;

--- a/src/devices/cpu/hphybrid/hphybrid.cpp
+++ b/src/devices/cpu/hphybrid/hphybrid.cpp
@@ -616,15 +616,15 @@ UINT16 hp_hybrid_cpu_device::execute_one_sub(UINT16 opcode)
 				return m_reg_P + 1;
 }
 
-void hp_hybrid_cpu_device::state_string_export(const device_state_entry &entry, std::string &str)
+void hp_hybrid_cpu_device::state_string_export(const device_state_entry &entry, std::string &str) const
 {
-				if (entry.index() == STATE_GENFLAGS) {
-								strprintf(str, "%s %s %c %c",
-														BIT(m_flags , HPHYBRID_DB_BIT) ? "Db":"..",
-														BIT(m_flags , HPHYBRID_CB_BIT) ? "Cb":"..",
-														BIT(m_flags , HPHYBRID_O_BIT) ? 'O':'.',
-														BIT(m_flags , HPHYBRID_C_BIT) ? 'E':'.');
-				}
+	if (entry.index() == STATE_GENFLAGS) {
+		strprintf(str, "%s %s %c %c",
+					BIT(m_flags , HPHYBRID_DB_BIT) ? "Db":"..",
+					BIT(m_flags , HPHYBRID_CB_BIT) ? "Cb":"..",
+					BIT(m_flags , HPHYBRID_O_BIT) ? 'O':'.',
+					BIT(m_flags , HPHYBRID_C_BIT) ? 'E':'.');
+	}
 }
 
 offs_t hp_hybrid_cpu_device::disasm_disassemble(char *buffer, offs_t pc, const UINT8 *oprom, const UINT8 *opram, UINT32 options)

--- a/src/devices/cpu/hphybrid/hphybrid.h
+++ b/src/devices/cpu/hphybrid/hphybrid.h
@@ -112,7 +112,7 @@ protected:
                 virtual const address_space_config *memory_space_config(address_spacenum spacenum = AS_0) const override { return (spacenum == AS_PROGRAM) ? &m_program_config : ( (spacenum == AS_IO) ? &m_io_config : NULL ); }
 
                 // device_state_interface overrides
-                void state_string_export(const device_state_entry &entry, std::string &str) override;
+                void state_string_export(const device_state_entry &entry, std::string &str) const override;
 
                 // device_disasm_interface overrides
                 virtual UINT32 disasm_min_opcode_bytes() const override { return 2; }

--- a/src/devices/cpu/i386/i386.cpp
+++ b/src/devices/cpu/i386/i386.cpp
@@ -275,7 +275,7 @@ UINT32 i386_device::i386_get_stack_ptr(UINT8 privilege)
 	return ret;
 }
 
-UINT32 i386_device::get_flags()
+UINT32 i386_device::get_flags() const
 {
 	UINT32 f = 0x2;
 	f |= m_CF;
@@ -3465,7 +3465,7 @@ void i386_device::state_export(const device_state_entry &entry)
 	}
 }
 
-void i386_device::state_string_export(const device_state_entry &entry, std::string &str)
+void i386_device::state_string_export(const device_state_entry &entry, std::string &str) const
 {
 	switch (entry.index())
 	{

--- a/src/devices/cpu/i386/i386.h
+++ b/src/devices/cpu/i386/i386.h
@@ -59,7 +59,7 @@ protected:
 	// device_state_interface overrides
 	virtual void state_import(const device_state_entry &entry) override;
 	virtual void state_export(const device_state_entry &entry) override;
-	virtual void state_string_export(const device_state_entry &entry, std::string &str) override;
+	virtual void state_string_export(const device_state_entry &entry, std::string &str) const override;
 
 	// device_disasm_interface overrides
 	virtual UINT32 disasm_min_opcode_bytes() const override { return 1; }
@@ -362,7 +362,7 @@ struct I386_CALL_GATE
 	void i386_load_segment_descriptor(int segment );
 	UINT32 i386_get_stack_segment(UINT8 privilege);
 	UINT32 i386_get_stack_ptr(UINT8 privilege);
-	UINT32 get_flags();
+	UINT32 get_flags() const;
 	void set_flags(UINT32 f );
 	void sib_byte(UINT8 mod, UINT32* out_ea, UINT8* out_segment);
 	void modrm_to_EA(UINT8 mod_rm, UINT32* out_ea, UINT8* out_segment);

--- a/src/devices/cpu/i4004/i4004.cpp
+++ b/src/devices/cpu/i4004/i4004.cpp
@@ -419,15 +419,14 @@ void i4004_cpu_device::device_start()
 		state_add(STATE_GENFLAGS, "GENFLAGS", m_flags).mask(0x0f).callimport().callexport().noshow().formatstr("%4s");
 		state_add(I4004_A,     "A",     m_A).mask(0x0f);
 
-		std::string tempstr;
 		for (int regnum = 0; regnum < 8; regnum++)
 		{
-			state_add(I4004_R01 + regnum, strformat(tempstr, "R%X%X", regnum * 2, regnum * 2 + 1).c_str(), m_R[regnum]);
+			state_add(I4004_R01 + regnum, strformat("R%X%X", regnum * 2, regnum * 2 + 1).c_str(), m_R[regnum]);
 		}
 
 		for (int addrnum = 0; addrnum < 4; addrnum++)
 		{
-			state_add(I4004_ADDR1 + addrnum, strformat(tempstr, "ADDR%d", addrnum + 1).c_str(), m_ADDR[addrnum].w.l).mask(0xfff);
+			state_add(I4004_ADDR1 + addrnum, strformat("ADDR%d", addrnum + 1).c_str(), m_ADDR[addrnum].w.l).mask(0xfff);
 		}
 
 		state_add(I4004_RAM,   "RAM",   m_RAM.w.l).mask(0x0fff);
@@ -507,7 +506,7 @@ void i4004_cpu_device::state_export(const device_state_entry &entry)
 	}
 }
 
-void i4004_cpu_device::state_string_export(const device_state_entry &entry, std::string &str)
+void i4004_cpu_device::state_string_export(const device_state_entry &entry, std::string &str) const
 {
 	switch (entry.index())
 	{

--- a/src/devices/cpu/i4004/i4004.h
+++ b/src/devices/cpu/i4004/i4004.h
@@ -57,7 +57,7 @@ protected:
 	// device_state_interface overrides
 	virtual void state_import(const device_state_entry &entry) override;
 	virtual void state_export(const device_state_entry &entry) override;
-	virtual void state_string_export(const device_state_entry &entry, std::string &str) override;
+	virtual void state_string_export(const device_state_entry &entry, std::string &str) const override;
 
 	// device_disasm_interface overrides
 	virtual UINT32 disasm_min_opcode_bytes() const override { return 1; }

--- a/src/devices/cpu/i8008/i8008.cpp
+++ b/src/devices/cpu/i8008/i8008.cpp
@@ -92,9 +92,8 @@ void i8008_device::device_start()
 	state_add(I8008_H,        "H",        m_H);
 	state_add(I8008_L,        "L",        m_L);
 
-	std::string tempstr;
 	for (int addrnum = 0; addrnum < 8; addrnum++)
-		state_add(I8008_ADDR1 + addrnum, strformat(tempstr, "ADDR%d", addrnum + 1).c_str(), m_ADDR[addrnum].w.l).mask(0xfff);
+		state_add(I8008_ADDR1 + addrnum, strformat("ADDR%d", addrnum + 1).c_str(), m_ADDR[addrnum].w.l).mask(0xfff);
 
 	init_tables();
 }
@@ -187,7 +186,7 @@ void i8008_device::state_export(const device_state_entry &entry)
 //  for the debugger
 //-------------------------------------------------
 
-void i8008_device::state_string_export(const device_state_entry &entry, std::string &str)
+void i8008_device::state_string_export(const device_state_entry &entry, std::string &str) const
 {
 	switch (entry.index())
 	{

--- a/src/devices/cpu/i8008/i8008.h
+++ b/src/devices/cpu/i8008/i8008.h
@@ -48,7 +48,7 @@ protected:
 	// device_state_interface overrides
 	virtual void state_import(const device_state_entry &entry) override;
 	virtual void state_export(const device_state_entry &entry) override;
-	virtual void state_string_export(const device_state_entry &entry, std::string &str) override;
+	virtual void state_string_export(const device_state_entry &entry, std::string &str) const override;
 
 
 	// device_disasm_interface overrides

--- a/src/devices/cpu/i8085/i8085.cpp
+++ b/src/devices/cpu/i8085/i8085.cpp
@@ -1048,7 +1048,7 @@ void i8085a_cpu_device::state_export(const device_state_entry &entry)
 	}
 }
 
-void i8085a_cpu_device::state_string_export(const device_state_entry &entry, std::string &str)
+void i8085a_cpu_device::state_string_export(const device_state_entry &entry, std::string &str) const
 {
 	switch (entry.index())
 	{

--- a/src/devices/cpu/i8085/i8085.h
+++ b/src/devices/cpu/i8085/i8085.h
@@ -85,9 +85,9 @@ protected:
 	virtual const address_space_config *memory_space_config(address_spacenum spacenum = AS_0) const override { return (spacenum == AS_PROGRAM) ? &m_program_config : ( (spacenum == AS_IO) ? &m_io_config : nullptr ); }
 
 	// device_state_interface overrides
-	void state_string_export(const device_state_entry &entry, std::string &str) override;
-	void state_export(const device_state_entry &entry) override;
-	void state_import(const device_state_entry &entry) override;
+	virtual void state_string_export(const device_state_entry &entry, std::string &str) const override;
+	virtual void state_export(const device_state_entry &entry) override;
+	virtual void state_import(const device_state_entry &entry) override;
 
 	// device_disasm_interface overrides
 	virtual UINT32 disasm_min_opcode_bytes() const override { return 1; }

--- a/src/devices/cpu/i8089/i8089.cpp
+++ b/src/devices/cpu/i8089/i8089.cpp
@@ -158,9 +158,9 @@ offs_t i8089_device::disasm_disassemble(char *buffer, offs_t pc, const UINT8 *op
 //  for the debugger
 //-------------------------------------------------
 
-void i8089_device::state_string_export(const device_state_entry &entry, std::string &str)
+void i8089_device::state_string_export(const device_state_entry &entry, std::string &str) const
 {
-	i8089_channel *ch = m_ch1;
+	const i8089_channel *ch = m_ch1;
 
 	if (entry.index() >= CH2_GA && entry.index() <= CH2_PSW)
 		ch = m_ch2;

--- a/src/devices/cpu/i8089/i8089.h
+++ b/src/devices/cpu/i8089/i8089.h
@@ -88,15 +88,15 @@ protected:
 	virtual offs_t disasm_disassemble(char *buffer, offs_t pc, const UINT8 *oprom, const UINT8 *opram, UINT32 options) override;
 
 	// device_state_interface overrides
-	virtual void state_string_export(const device_state_entry &entry, std::string &str) override;
+	virtual void state_string_export(const device_state_entry &entry, std::string &str) const override;
 
 	// optional information overrides
 	virtual machine_config_constructor device_mconfig_additions() const override;
 
 private:
-	bool sysbus_width() { return BIT(m_sysbus, 0); }
-	bool remotebus_width() { return BIT(m_soc, 0); }
-	bool request_grant() { return BIT(m_soc, 1); }
+	bool sysbus_width() const { return BIT(m_sysbus, 0); }
+	bool remotebus_width() const { return BIT(m_soc, 0); }
+	bool request_grant() const { return BIT(m_soc, 1); }
 
 	UINT8 read_byte(bool space, offs_t address);
 	UINT16 read_word(bool space, offs_t address);

--- a/src/devices/cpu/i86/i286.cpp
+++ b/src/devices/cpu/i86/i286.cpp
@@ -277,12 +277,12 @@ void i80286_cpu_device::device_start()
 	m_out_shutdown_func.resolve_safe();
 }
 
-void i80286_cpu_device::state_string_export(const device_state_entry &entry, std::string &str)
+void i80286_cpu_device::state_string_export(const device_state_entry &entry, std::string &str) const
 {
 	switch (entry.index())
 	{
 		case STATE_GENPC:
-			strprintf(str, "%08X", pc());
+			strprintf(str, "%08X", m_base[CS] + m_ip);
 			break;
 
 		case STATE_GENFLAGS:

--- a/src/devices/cpu/i86/i286.h
+++ b/src/devices/cpu/i86/i286.h
@@ -77,7 +77,7 @@ protected:
 	virtual void execute_run() override;
 	virtual void device_reset() override;
 	virtual void device_start() override;
-	virtual void state_string_export(const device_state_entry &entry, std::string &str) override;
+	virtual void state_string_export(const device_state_entry &entry, std::string &str) const override;
 	virtual UINT32 execute_input_lines() const override { return 1; }
 	virtual void execute_set_input(int inputnum, int state) override;
 	bool memory_translate(address_spacenum spacenum, int intention, offs_t &address) override;

--- a/src/devices/cpu/i86/i86.cpp
+++ b/src/devices/cpu/i86/i86.cpp
@@ -314,12 +314,12 @@ i8086_common_cpu_device::i8086_common_cpu_device(const machine_config &mconfig, 
 	memset(m_sregs, 0x00, sizeof(m_sregs));
 }
 
-void i8086_common_cpu_device::state_string_export(const device_state_entry &entry, std::string &str)
+void i8086_common_cpu_device::state_string_export(const device_state_entry &entry, std::string &str) const
 {
 	switch (entry.index())
 	{
 		case STATE_GENPC:
-			strprintf(str, "%08X", pc());
+			strprintf(str, "%08X", (m_sregs[CS] << 4) + m_ip);
 			break;
 
 		case STATE_GENFLAGS:

--- a/src/devices/cpu/i86/i86.h
+++ b/src/devices/cpu/i86/i86.h
@@ -127,7 +127,7 @@ protected:
 	virtual offs_t disasm_disassemble(char *buffer, offs_t pc, const UINT8 *oprom, const UINT8 *opram, UINT32 options) override;
 
 	// device_state_interface overrides
-	virtual void state_string_export(const device_state_entry &entry, std::string &str) override;
+	virtual void state_string_export(const device_state_entry &entry, std::string &str) const override;
 
 	virtual void interrupt(int int_num, int trap = 1);
 	bool common_op(UINT8 op);
@@ -192,7 +192,7 @@ protected:
 	inline void set_OFB_Add(UINT32 x,UINT32 y,UINT32 z);
 	inline void set_OFW_Sub(UINT32 x,UINT32 y,UINT32 z);
 	inline void set_OFB_Sub(UINT32 x,UINT32 y,UINT32 z);
-	inline UINT16 CompressFlags();
+	inline UINT16 CompressFlags() const;
 	inline void ExpandFlags(UINT16 f);
 
 	// rep instructions

--- a/src/devices/cpu/i86/i86inline.h
+++ b/src/devices/cpu/i86/i86inline.h
@@ -504,7 +504,7 @@ inline void i8086_common_cpu_device::set_OFB_Sub(UINT32 x,UINT32 y,UINT32 z)
 }
 
 
-inline UINT16 i8086_common_cpu_device::CompressFlags()
+inline UINT16 i8086_common_cpu_device::CompressFlags() const
 {
 	return (CF ? 1 : 0)
 		| (1 << 1)

--- a/src/devices/cpu/i960/i960.cpp
+++ b/src/devices/cpu/i960/i960.cpp
@@ -2081,7 +2081,7 @@ void i960_cpu_device::device_start()
 	m_icountptr = &m_icount;
 }
 
-void i960_cpu_device::state_string_export(const device_state_entry &entry, std::string &str)
+void i960_cpu_device::state_string_export(const device_state_entry &entry, std::string &str) const
 {
 	static const char *const conditions[8] =
 	{

--- a/src/devices/cpu/i960/i960.h
+++ b/src/devices/cpu/i960/i960.h
@@ -95,7 +95,7 @@ protected:
 	virtual const address_space_config *memory_space_config(address_spacenum spacenum = AS_0) const override { return (spacenum == AS_PROGRAM) ? &m_program_config : nullptr; }
 
 	// device_state_interface overrides
-	void state_string_export(const device_state_entry &entry, std::string &str) override;
+	virtual void state_string_export(const device_state_entry &entry, std::string &str) const override;
 
 	// device_disasm_interface overrides
 	virtual UINT32 disasm_min_opcode_bytes() const override { return 4; }

--- a/src/devices/cpu/ie15/ie15.cpp
+++ b/src/devices/cpu/ie15/ie15.cpp
@@ -64,9 +64,8 @@ void ie15_device::device_start()
 	state_add(STATE_GENFLAGS,"GENFLAGS", m_flags).mask(0x0f).callimport().callexport().noshow().formatstr("%4s");
 	state_add(IE15_A,        "A",        m_A);
 
-	std::string tempstring;
 	for (int ireg = 0; ireg < 32; ireg++)
-		state_add(IE15_R0 + ireg, strformat(tempstring, "R%d", ireg).c_str(), m_REGS[ireg]);
+		state_add(IE15_R0 + ireg, strformat("R%d", ireg).c_str(), m_REGS[ireg]);
 }
 
 //-------------------------------------------------
@@ -133,7 +132,7 @@ void ie15_device::state_export(const device_state_entry &entry)
 //  for the debugger
 //-------------------------------------------------
 
-void ie15_device::state_string_export(const device_state_entry &entry, std::string &str)
+void ie15_device::state_string_export(const device_state_entry &entry, std::string &str) const
 {
 	switch (entry.index())
 	{

--- a/src/devices/cpu/ie15/ie15.h
+++ b/src/devices/cpu/ie15/ie15.h
@@ -48,7 +48,7 @@ protected:
 	// device_state_interface overrides
 	virtual void state_import(const device_state_entry &entry) override;
 	virtual void state_export(const device_state_entry &entry) override;
-	virtual void state_string_export(const device_state_entry &entry, std::string &str) override;
+	virtual void state_string_export(const device_state_entry &entry, std::string &str) const override;
 
 	// device_disasm_interface overrides
 	virtual UINT32 disasm_min_opcode_bytes() const override;

--- a/src/devices/cpu/jaguar/jaguar.cpp
+++ b/src/devices/cpu/jaguar/jaguar.cpp
@@ -400,7 +400,7 @@ void jaguar_cpu_device::device_start()
 }
 
 
-void jaguar_cpu_device::state_string_export(const device_state_entry &entry, std::string &str)
+void jaguar_cpu_device::state_string_export(const device_state_entry &entry, std::string &str) const
 {
 	switch (entry.index())
 	{

--- a/src/devices/cpu/jaguar/jaguar.h
+++ b/src/devices/cpu/jaguar/jaguar.h
@@ -127,7 +127,7 @@ protected:
 	virtual const address_space_config *memory_space_config(address_spacenum spacenum = AS_0) const override { return (spacenum == AS_PROGRAM) ? &m_program_config : nullptr; }
 
 	// device_state_interface overrides
-	void state_string_export(const device_state_entry &entry, std::string &str) override;
+	void state_string_export(const device_state_entry &entry, std::string &str) const override;
 
 	// device_disasm_interface overrides
 	virtual UINT32 disasm_min_opcode_bytes() const override { return 2; }

--- a/src/devices/cpu/lc8670/lc8670.cpp
+++ b/src/devices/cpu/lc8670/lc8670.cpp
@@ -369,7 +369,7 @@ void lc8670_cpu_device::state_import(const device_state_entry &entry)
 //  for the debugger
 //-------------------------------------------------
 
-void lc8670_cpu_device::state_string_export(const device_state_entry &entry, std::string &str)
+void lc8670_cpu_device::state_string_export(const device_state_entry &entry, std::string &str) const
 {
 	switch (entry.index())
 	{

--- a/src/devices/cpu/lc8670/lc8670.h
+++ b/src/devices/cpu/lc8670/lc8670.h
@@ -110,7 +110,7 @@ protected:
 
 	// device_state_interface overrides
 	virtual void state_import(const device_state_entry &entry) override;
-	void state_string_export(const device_state_entry &entry, std::string &str) override;
+	virtual void state_string_export(const device_state_entry &entry, std::string &str) const override;
 
 	// device_memory_interface overrides
 	virtual const address_space_config *memory_space_config(address_spacenum spacenum = AS_0) const override;

--- a/src/devices/cpu/lh5801/lh5801.cpp
+++ b/src/devices/cpu/lh5801/lh5801.cpp
@@ -142,7 +142,7 @@ void lh5801_cpu_device::device_start()
 	m_icountptr = &m_icount;
 }
 
-void lh5801_cpu_device::state_string_export(const device_state_entry &entry, std::string &str)
+void lh5801_cpu_device::state_string_export(const device_state_entry &entry, std::string &str) const
 {
 	switch (entry.index())
 	{

--- a/src/devices/cpu/lh5801/lh5801.h
+++ b/src/devices/cpu/lh5801/lh5801.h
@@ -90,7 +90,7 @@ protected:
 	virtual const address_space_config *memory_space_config(address_spacenum spacenum = AS_0) const override { return (spacenum == AS_PROGRAM) ? &m_program_config : ( (spacenum == AS_IO) ? &m_io_config : nullptr ); }
 
 	// device_state_interface overrides
-	void state_string_export(const device_state_entry &entry, std::string &str) override;
+	virtual void state_string_export(const device_state_entry &entry, std::string &str) const override;
 
 	// device_disasm_interface overrides
 	virtual UINT32 disasm_min_opcode_bytes() const override { return 1; }

--- a/src/devices/cpu/lr35902/lr35902.cpp
+++ b/src/devices/cpu/lr35902/lr35902.cpp
@@ -180,7 +180,7 @@ void lr35902_cpu_device::device_start()
 }
 
 
-void lr35902_cpu_device::state_string_export(const device_state_entry &entry, std::string &str)
+void lr35902_cpu_device::state_string_export(const device_state_entry &entry, std::string &str) const
 {
 	switch (entry.index())
 	{

--- a/src/devices/cpu/lr35902/lr35902.h
+++ b/src/devices/cpu/lr35902/lr35902.h
@@ -70,7 +70,7 @@ protected:
 	virtual const address_space_config *memory_space_config(address_spacenum spacenum = AS_0) const override { return (spacenum == AS_PROGRAM) ? &m_program_config : nullptr; }
 
 	// device_state_interface overrides
-	void state_string_export(const device_state_entry &entry, std::string &str) override;
+	virtual void state_string_export(const device_state_entry &entry, std::string &str) const override;
 
 	// device_disasm_interface overrides
 	virtual UINT32 disasm_min_opcode_bytes() const override { return 1; }

--- a/src/devices/cpu/m37710/m37710.cpp
+++ b/src/devices/cpu/m37710/m37710.cpp
@@ -1136,7 +1136,7 @@ void m37710_cpu_device::state_export(const device_state_entry &entry)
 }
 
 
-void m37710_cpu_device::state_string_export(const device_state_entry &entry, std::string &str)
+void m37710_cpu_device::state_string_export(const device_state_entry &entry, std::string &str) const
 {
 	switch (entry.index())
 	{

--- a/src/devices/cpu/m37710/m37710.h
+++ b/src/devices/cpu/m37710/m37710.h
@@ -117,7 +117,7 @@ protected:
 	// device_state_interface overrides
 	virtual void state_import(const device_state_entry &entry) override;
 	virtual void state_export(const device_state_entry &entry) override;
-	void state_string_export(const device_state_entry &entry, std::string &str) override;
+	virtual void state_string_export(const device_state_entry &entry, std::string &str) const override;
 
 	// device_disasm_interface overrides
 	virtual UINT32 disasm_min_opcode_bytes() const override { return 1; }

--- a/src/devices/cpu/m6502/m6502.cpp
+++ b/src/devices/cpu/m6502/m6502.cpp
@@ -439,7 +439,7 @@ void m6502_device::state_export(const device_state_entry &entry)
 {
 }
 
-void m6502_device::state_string_export(const device_state_entry &entry, std::string &str)
+void m6502_device::state_string_export(const device_state_entry &entry, std::string &str) const
 {
 	switch(entry.index()) {
 	case STATE_GENFLAGS:

--- a/src/devices/cpu/m6502/m6502.h
+++ b/src/devices/cpu/m6502/m6502.h
@@ -144,7 +144,7 @@ protected:
 	// device_state_interface overrides
 	virtual void state_import(const device_state_entry &entry) override;
 	virtual void state_export(const device_state_entry &entry) override;
-	virtual void state_string_export(const device_state_entry &entry, std::string &str) override;
+	virtual void state_string_export(const device_state_entry &entry, std::string &str) const override;
 
 	// device_disasm_interface overrides
 	virtual UINT32 disasm_min_opcode_bytes() const override;

--- a/src/devices/cpu/m6502/m65ce02.cpp
+++ b/src/devices/cpu/m6502/m65ce02.cpp
@@ -75,7 +75,7 @@ void m65ce02_device::state_export(const device_state_entry &entry)
 {
 }
 
-void m65ce02_device::state_string_export(const device_state_entry &entry, std::string &str)
+void m65ce02_device::state_string_export(const device_state_entry &entry, std::string &str) const
 {
 	switch(entry.index()) {
 	case STATE_GENFLAGS:

--- a/src/devices/cpu/m6502/m65ce02.h
+++ b/src/devices/cpu/m6502/m65ce02.h
@@ -34,7 +34,7 @@ protected:
 	virtual void device_reset() override;
 	virtual void state_import(const device_state_entry &entry) override;
 	virtual void state_export(const device_state_entry &entry) override;
-	virtual void state_string_export(const device_state_entry &entry, std::string &str) override;
+	virtual void state_string_export(const device_state_entry &entry, std::string &str) const override;
 
 	inline void dec_SP_ce() { if(P & F_E) SP = set_l(SP, SP-1); else SP--; }
 	inline void inc_SP_ce() { if(P & F_E) SP = set_l(SP, SP+1); else SP++; }

--- a/src/devices/cpu/m6502/m740.cpp
+++ b/src/devices/cpu/m6502/m740.cpp
@@ -53,7 +53,7 @@ void m740_device::device_reset()
 	SP = 0x00ff;
 }
 
-void m740_device::state_string_export(const device_state_entry &entry, std::string &str)
+void m740_device::state_string_export(const device_state_entry &entry, std::string &str) const
 {
 	switch(entry.index()) {
 	case STATE_GENFLAGS:

--- a/src/devices/cpu/m6502/m740.h
+++ b/src/devices/cpu/m6502/m740.h
@@ -44,7 +44,7 @@ public:
 
 		static const disasm_entry disasm_entries[0x200];
 
-		virtual void state_string_export(const device_state_entry &entry, std::string &str) override;
+		virtual void state_string_export(const device_state_entry &entry, std::string &str) const override;
 
 		virtual offs_t disasm_disassemble(char *buffer, offs_t pc, const UINT8 *oprom, const UINT8 *opram, UINT32 options) override;
 		virtual void do_exec_full() override;

--- a/src/devices/cpu/m6800/m6800.cpp
+++ b/src/devices/cpu/m6800/m6800.cpp
@@ -1140,7 +1140,7 @@ void m6800_cpu_device::device_start()
 	m_icountptr = &m_icount;
 }
 
-void m6800_cpu_device::state_string_export(const device_state_entry &entry, std::string &str)
+void m6800_cpu_device::state_string_export(const device_state_entry &entry, std::string &str) const
 {
 	switch (entry.index())
 	{

--- a/src/devices/cpu/m6800/m6800.h
+++ b/src/devices/cpu/m6800/m6800.h
@@ -87,7 +87,7 @@ protected:
 	virtual const address_space_config *memory_space_config(address_spacenum spacenum = AS_0) const override;
 
 	// device_state_interface overrides
-	void state_string_export(const device_state_entry &entry, std::string &str) override;
+	void state_string_export(const device_state_entry &entry, std::string &str) const override;
 
 	// device_disasm_interface overrides
 	virtual UINT32 disasm_min_opcode_bytes() const override { return 1; }

--- a/src/devices/cpu/m68000/m68000.h
+++ b/src/devices/cpu/m68000/m68000.h
@@ -396,7 +396,7 @@ public:
 	// device_state_interface overrides
 	virtual void state_import(const device_state_entry &entry) override;
 	virtual void state_export(const device_state_entry &entry) override;
-	virtual void state_string_export(const device_state_entry &entry, std::string &str) override;
+	virtual void state_string_export(const device_state_entry &entry, std::string &str) const override;
 
 	// device_memory_interface overrides
 	virtual bool memory_translate(address_spacenum space, int intention, offs_t &address) override;

--- a/src/devices/cpu/m68000/m68kcpu.cpp
+++ b/src/devices/cpu/m68000/m68kcpu.cpp
@@ -1166,7 +1166,7 @@ void m68000_base_device::state_export(const device_state_entry &entry)
 	}
 }
 
-void m68000_base_device::state_string_export(const device_state_entry &entry, std::string &str)
+void m68000_base_device::state_string_export(const device_state_entry &entry, std::string &str) const
 {
 	UINT16 sr;
 
@@ -1734,14 +1734,11 @@ void m68000_base_device::define_state(void)
 	if (cpu_type & MASK_020_OR_LATER)
 		state_add(M68K_MSP,    "MSP",       iotemp).callimport().callexport();
 
-	std::string tempstr;
 	for (int regnum = 0; regnum < 8; regnum++) {
-		strprintf(tempstr,"D%d", regnum);
-		state_add(M68K_D0 + regnum, tempstr.c_str(), dar[regnum]);
+		state_add(M68K_D0 + regnum, strformat("D%d", regnum).c_str(), dar[regnum]);
 	}
 	for (int regnum = 0; regnum < 8; regnum++) {
-		strprintf(tempstr,"A%d", regnum);
-		state_add(M68K_A0 + regnum, tempstr.c_str(), dar[8 + regnum]);
+		state_add(M68K_A0 + regnum, strformat("A%d", regnum).c_str(), dar[8 + regnum]);
 	}
 
 	state_add(M68K_PREF_ADDR,  "PREF_ADDR", pref_addr).mask(addrmask);
@@ -1763,8 +1760,7 @@ void m68000_base_device::define_state(void)
 	if (cpu_type & MASK_030_OR_LATER)
 	{
 		for (int regnum = 0; regnum < 8; regnum++) {
-			strprintf(tempstr,"FP%d", regnum);
-			state_add(M68K_FP0 + regnum, tempstr.c_str(), iotemp).callimport().callexport().formatstr("%10s");
+			state_add(M68K_FP0 + regnum, strformat("FP%d", regnum).c_str(), iotemp).callimport().callexport().formatstr("%10s");
 		}
 		state_add(M68K_FPSR, "FPSR", fpsr);
 		state_add(M68K_FPCR, "FPCR", fpcr);

--- a/src/devices/cpu/m6805/m6805.cpp
+++ b/src/devices/cpu/m6805/m6805.cpp
@@ -493,7 +493,7 @@ const address_space_config *m6805_base_device::memory_space_config(address_space
 //  for the debugger
 //-------------------------------------------------
 
-void m6805_base_device::state_string_export(const device_state_entry &entry, std::string &str)
+void m6805_base_device::state_string_export(const device_state_entry &entry, std::string &str) const
 {
 	switch (entry.index())
 	{

--- a/src/devices/cpu/m6805/m6805.h
+++ b/src/devices/cpu/m6805/m6805.h
@@ -51,7 +51,7 @@ protected:
 	virtual offs_t disasm_disassemble(char *buffer, offs_t pc, const UINT8 *oprom, const UINT8 *opram, UINT32 options) override;
 
 	// device_state_interface overrides
-	virtual void state_string_export(const device_state_entry &entry, std::string &str) override;
+	virtual void state_string_export(const device_state_entry &entry, std::string &str) const override;
 
 private:
 	// opcode/condition tables

--- a/src/devices/cpu/m6809/m6809.cpp
+++ b/src/devices/cpu/m6809/m6809.cpp
@@ -302,7 +302,7 @@ const address_space_config *m6809_base_device::memory_space_config(address_space
 //  for the debugger
 //-------------------------------------------------
 
-void m6809_base_device::state_string_export(const device_state_entry &entry, std::string &str)
+void m6809_base_device::state_string_export(const device_state_entry &entry, std::string &str) const
 {
 	switch (entry.index())
 	{

--- a/src/devices/cpu/m6809/m6809.h
+++ b/src/devices/cpu/m6809/m6809.h
@@ -84,7 +84,7 @@ protected:
 	virtual offs_t disasm_disassemble(char *buffer, offs_t pc, const UINT8 *oprom, const UINT8 *opram, UINT32 options) override;
 
 	// device_state_interface overrides
-	virtual void state_string_export(const device_state_entry &entry, std::string &str) override;
+	virtual void state_string_export(const device_state_entry &entry, std::string &str) const override;
 
 	// addressing modes
 	enum

--- a/src/devices/cpu/mb86233/mb86233.cpp
+++ b/src/devices/cpu/mb86233/mb86233.cpp
@@ -161,7 +161,7 @@ void mb86233_cpu_device::device_start()
 }
 
 
-void mb86233_cpu_device::state_string_export(const device_state_entry &entry, std::string &str)
+void mb86233_cpu_device::state_string_export(const device_state_entry &entry, std::string &str) const
 {
 	switch (entry.index())
 	{

--- a/src/devices/cpu/mb86233/mb86233.h
+++ b/src/devices/cpu/mb86233/mb86233.h
@@ -74,7 +74,7 @@ protected:
 	virtual const address_space_config *memory_space_config(address_spacenum spacenum = AS_0) const override { return (spacenum == AS_PROGRAM) ? &m_program_config : ( (spacenum == AS_DATA) ? &m_data_config :  nullptr ); }
 
 	// device_state_interface overrides
-	void state_string_export(const device_state_entry &entry, std::string &str) override;
+	void state_string_export(const device_state_entry &entry, std::string &str) const override;
 
 	// device_disasm_interface overrides
 	virtual UINT32 disasm_min_opcode_bytes() const override { return 4; }

--- a/src/devices/cpu/mb86235/mb86235.cpp
+++ b/src/devices/cpu/mb86235/mb86235.cpp
@@ -108,7 +108,7 @@ mb86235_cpu_device::mb86235_cpu_device(const machine_config &mconfig, const char
 }
 
 
-void mb86235_cpu_device::state_string_export(const device_state_entry &entry, std::string &str)
+void mb86235_cpu_device::state_string_export(const device_state_entry &entry, std::string &str) const
 {
 	switch (entry.index())
 	{

--- a/src/devices/cpu/mb86235/mb86235.h
+++ b/src/devices/cpu/mb86235/mb86235.h
@@ -42,7 +42,7 @@ protected:
 	virtual const address_space_config *memory_space_config(address_spacenum spacenum = AS_0) const override { return (spacenum == AS_PROGRAM) ? &m_program_config : nullptr; }
 
 	// device_state_interface overrides
-	void state_string_export(const device_state_entry &entry, std::string &str) override;
+	virtual void state_string_export(const device_state_entry &entry, std::string &str) const override;
 
 	// device_disasm_interface overrides
 	virtual UINT32 disasm_min_opcode_bytes() const override { return 8; }

--- a/src/devices/cpu/mb88xx/mb88xx.cpp
+++ b/src/devices/cpu/mb88xx/mb88xx.cpp
@@ -269,7 +269,7 @@ void mb88_cpu_device::state_export(const device_state_entry &entry)
 }
 
 
-void mb88_cpu_device::state_string_export(const device_state_entry &entry, std::string &str)
+void mb88_cpu_device::state_string_export(const device_state_entry &entry, std::string &str) const
 {
 	switch (entry.index())
 	{

--- a/src/devices/cpu/mb88xx/mb88xx.h
+++ b/src/devices/cpu/mb88xx/mb88xx.h
@@ -90,9 +90,9 @@ protected:
 	virtual const address_space_config *memory_space_config(address_spacenum spacenum = AS_0) const override { return (spacenum == AS_PROGRAM) ? &m_program_config : ( (spacenum == AS_DATA) ? &m_data_config : ( (spacenum == AS_IO) ? &m_io_config : nullptr ) ); }
 
 	// device_state_interface overrides
-	void state_string_export(const device_state_entry &entry, std::string &str) override;
-	void state_import(const device_state_entry &entry) override;
-	void state_export(const device_state_entry &entry) override;
+	virtual void state_string_export(const device_state_entry &entry, std::string &str) const override;
+	virtual void state_import(const device_state_entry &entry) override;
+	virtual void state_export(const device_state_entry &entry) override;
 
 	// device_disasm_interface overrides
 	virtual UINT32 disasm_min_opcode_bytes() const override { return 1; }

--- a/src/devices/cpu/mc68hc11/mc68hc11.cpp
+++ b/src/devices/cpu/mc68hc11/mc68hc11.cpp
@@ -448,7 +448,7 @@ void mc68hc11_cpu_device::device_start()
 }
 
 
-void mc68hc11_cpu_device::state_string_export(const device_state_entry &entry, std::string &str)
+void mc68hc11_cpu_device::state_string_export(const device_state_entry &entry, std::string &str) const
 {
 	switch (entry.index())
 	{

--- a/src/devices/cpu/mc68hc11/mc68hc11.h
+++ b/src/devices/cpu/mc68hc11/mc68hc11.h
@@ -70,7 +70,7 @@ protected:
 	}
 
 	// device_state_interface overrides
-	void state_string_export(const device_state_entry &entry, std::string &str) override;
+	virtual void state_string_export(const device_state_entry &entry, std::string &str) const override;
 
 	// device_disasm_interface overrides
 	virtual UINT32 disasm_min_opcode_bytes() const override { return 1; }

--- a/src/devices/cpu/mcs48/mcs48.cpp
+++ b/src/devices/cpu/mcs48/mcs48.cpp
@@ -978,10 +978,8 @@ void mcs48_cpu_device::device_start()
 		state_add(MCS48_P1,        "P1",        m_p1);
 		state_add(MCS48_P2,        "P2",        m_p2);
 
-		std::string tempstr;
 		for (int regnum = 0; regnum < 8; regnum++) {
-			strprintf(tempstr, "R%d", regnum);
-			state_add(MCS48_R0 + regnum, tempstr.c_str(), m_rtemp).callimport().callexport();
+			state_add(MCS48_R0 + regnum, strformat("R%d", regnum).c_str(), m_rtemp).callimport().callexport();
 		}
 		state_add(MCS48_EA,        "EA",        m_ea).mask(0x1);
 
@@ -1298,7 +1296,7 @@ void mcs48_cpu_device::state_export(const device_state_entry &entry)
 	}
 }
 
-void mcs48_cpu_device::state_string_export(const device_state_entry &entry, std::string &str)
+void mcs48_cpu_device::state_string_export(const device_state_entry &entry, std::string &str) const
 {
 	switch (entry.index())
 	{

--- a/src/devices/cpu/mcs48/mcs48.h
+++ b/src/devices/cpu/mcs48/mcs48.h
@@ -152,7 +152,7 @@ protected:
 	// device_state_interface overrides
 	virtual void state_import(const device_state_entry &entry) override;
 	virtual void state_export(const device_state_entry &entry) override;
-	void state_string_export(const device_state_entry &entry, std::string &str) override;
+	virtual void state_string_export(const device_state_entry &entry, std::string &str) const override;
 
 	// device_disasm_interface overrides
 	virtual UINT32 disasm_min_opcode_bytes() const override { return 1; }

--- a/src/devices/cpu/mcs51/mcs51.cpp
+++ b/src/devices/cpu/mcs51/mcs51.cpp
@@ -2213,7 +2213,7 @@ void mcs51_cpu_device::state_export(const device_state_entry &entry)
 	}
 }
 
-void mcs51_cpu_device::state_string_export(const device_state_entry &entry, std::string &str)
+void mcs51_cpu_device::state_string_export(const device_state_entry &entry, std::string &str) const
 {
 	switch (entry.index())
 	{

--- a/src/devices/cpu/mcs51/mcs51.h
+++ b/src/devices/cpu/mcs51/mcs51.h
@@ -109,7 +109,7 @@ protected:
 	// device_state_interface overrides
 	virtual void state_import(const device_state_entry &entry) override;
 	virtual void state_export(const device_state_entry &entry) override;
-	void state_string_export(const device_state_entry &entry, std::string &str) override;
+	virtual void state_string_export(const device_state_entry &entry, std::string &str) const override;
 
 	// device_disasm_interface overrides
 	virtual UINT32 disasm_min_opcode_bytes() const override { return 1; }

--- a/src/devices/cpu/mcs96/mcs96.cpp
+++ b/src/devices/cpu/mcs96/mcs96.cpp
@@ -128,7 +128,7 @@ void mcs96_device::state_export(const device_state_entry &entry)
 {
 }
 
-void mcs96_device::state_string_export(const device_state_entry &entry, std::string &str)
+void mcs96_device::state_string_export(const device_state_entry &entry, std::string &str) const
 {
 	switch(entry.index()) {
 	case STATE_GENFLAGS:

--- a/src/devices/cpu/mcs96/mcs96.h
+++ b/src/devices/cpu/mcs96/mcs96.h
@@ -85,7 +85,7 @@ protected:
 	// device_state_interface overrides
 	virtual void state_import(const device_state_entry &entry) override;
 	virtual void state_export(const device_state_entry &entry) override;
-	virtual void state_string_export(const device_state_entry &entry, std::string &str) override;
+	virtual void state_string_export(const device_state_entry &entry, std::string &str) const override;
 
 	// device_disasm_interface overrides
 	virtual UINT32 disasm_min_opcode_bytes() const override;

--- a/src/devices/cpu/melps4/melps4.cpp
+++ b/src/devices/cpu/melps4/melps4.cpp
@@ -42,7 +42,7 @@
 
 
 // disasm
-void melps4_cpu_device::state_string_export(const device_state_entry &entry, std::string &str)
+void melps4_cpu_device::state_string_export(const device_state_entry &entry, std::string &str) const
 {
 	switch (entry.index())
 	{

--- a/src/devices/cpu/melps4/melps4.h
+++ b/src/devices/cpu/melps4/melps4.h
@@ -160,7 +160,7 @@ protected:
 	// device_disasm_interface overrides
 	virtual UINT32 disasm_min_opcode_bytes() const override { return 2; }
 	virtual UINT32 disasm_max_opcode_bytes() const override { return 2; }
-	virtual void state_string_export(const device_state_entry &entry, std::string &str) override;
+	virtual void state_string_export(const device_state_entry &entry, std::string &str) const override;
 
 	address_space_config m_program_config;
 	address_space_config m_data_config;

--- a/src/devices/cpu/minx/minx.cpp
+++ b/src/devices/cpu/minx/minx.cpp
@@ -121,7 +121,7 @@ void minx_cpu_device::device_start()
 }
 
 
-void minx_cpu_device::state_string_export(const device_state_entry &entry, std::string &str)
+void minx_cpu_device::state_string_export(const device_state_entry &entry, std::string &str) const
 {
 	switch (entry.index())
 	{

--- a/src/devices/cpu/minx/minx.h
+++ b/src/devices/cpu/minx/minx.h
@@ -36,7 +36,7 @@ protected:
 	virtual const address_space_config *memory_space_config(address_spacenum spacenum = AS_0) const override { return (spacenum == AS_PROGRAM) ? &m_program_config : nullptr; }
 
 	// device_state_interface overrides
-	void state_string_export(const device_state_entry &entry, std::string &str) override;
+	virtual void state_string_export(const device_state_entry &entry, std::string &str) const override;
 
 	// device_disasm_interface overrides
 	virtual UINT32 disasm_min_opcode_bytes() const override { return 1; }

--- a/src/devices/cpu/mips/mips3.cpp
+++ b/src/devices/cpu/mips/mips3.cpp
@@ -659,7 +659,7 @@ void mips3_device::state_export(const device_state_entry &entry)
 }
 
 
-void mips3_device::state_string_export(const device_state_entry &entry, std::string &str)
+void mips3_device::state_string_export(const device_state_entry &entry, std::string &str) const
 {
 	switch (entry.index())
 	{

--- a/src/devices/cpu/mips/mips3.h
+++ b/src/devices/cpu/mips/mips3.h
@@ -303,7 +303,7 @@ protected:
 
 	// device_state_interface overrides
 	virtual void state_export(const device_state_entry &entry) override;
-	void state_string_export(const device_state_entry &entry, std::string &str) override;
+	virtual void state_string_export(const device_state_entry &entry, std::string &str) const override;
 
 	// device_disasm_interface overrides
 	virtual UINT32 disasm_min_opcode_bytes() const override { return 4; }

--- a/src/devices/cpu/mips/r3000.cpp
+++ b/src/devices/cpu/mips/r3000.cpp
@@ -443,7 +443,7 @@ void r3000_device::state_export(const device_state_entry &entry)
 //  for the debugger
 //-------------------------------------------------
 
-void r3000_device::state_string_export(const device_state_entry &entry, std::string &str)
+void r3000_device::state_string_export(const device_state_entry &entry, std::string &str) const
 {
 	switch (entry.index())
 	{

--- a/src/devices/cpu/mips/r3000.h
+++ b/src/devices/cpu/mips/r3000.h
@@ -126,7 +126,7 @@ protected:
 	// device_state_interface overrides
 	virtual void state_import(const device_state_entry &entry) override;
 	virtual void state_export(const device_state_entry &entry) override;
-	virtual void state_string_export(const device_state_entry &entry, std::string &str) override;
+	virtual void state_string_export(const device_state_entry &entry, std::string &str) const override;
 
 	// device_disasm_interface overrides
 	virtual UINT32 disasm_min_opcode_bytes() const override;

--- a/src/devices/cpu/mn10200/mn10200.cpp
+++ b/src/devices/cpu/mn10200/mn10200.cpp
@@ -51,7 +51,7 @@ mn1020012a_device::mn1020012a_device(const machine_config &mconfig, const char *
 
 
 // disasm
-void mn10200_device::state_string_export(const device_state_entry &entry, std::string &str)
+void mn10200_device::state_string_export(const device_state_entry &entry, std::string &str) const
 {
 	switch (entry.index())
 	{

--- a/src/devices/cpu/mn10200/mn10200.h
+++ b/src/devices/cpu/mn10200/mn10200.h
@@ -88,7 +88,7 @@ protected:
 	virtual const address_space_config *memory_space_config(address_spacenum spacenum = AS_0) const override { return (spacenum == AS_PROGRAM) ? &m_program_config : nullptr; }
 
 	// device_state_interface overrides
-	void state_string_export(const device_state_entry &entry, std::string &str) override;
+	virtual void state_string_export(const device_state_entry &entry, std::string &str) const override;
 
 	// device_disasm_interface overrides
 	virtual UINT32 disasm_min_opcode_bytes() const override { return 1; }

--- a/src/devices/cpu/nec/nec.cpp
+++ b/src/devices/cpu/nec/nec.cpp
@@ -437,7 +437,7 @@ void nec_common_device::device_start()
 	m_icountptr = &m_icount;
 }
 
-void nec_common_device::state_string_export(const device_state_entry &entry, std::string &str)
+void nec_common_device::state_string_export(const device_state_entry &entry, std::string &str) const
 {
 	UINT16 flags = CompressFlags();
 

--- a/src/devices/cpu/nec/nec.h
+++ b/src/devices/cpu/nec/nec.h
@@ -42,7 +42,7 @@ protected:
 	virtual const address_space_config *memory_space_config(address_spacenum spacenum = AS_0) const override { return (spacenum == AS_PROGRAM) ? &m_program_config : ( (spacenum == AS_IO) ? &m_io_config : nullptr); }
 
 	// device_state_interface overrides
-	void state_string_export(const device_state_entry &entry, std::string &str) override;
+	virtual void state_string_export(const device_state_entry &entry, std::string &str) const override;
 	virtual void state_import(const device_state_entry &entry) override;
 	virtual void state_export(const device_state_entry &entry) override;
 

--- a/src/devices/cpu/nec/v25.cpp
+++ b/src/devices/cpu/nec/v25.cpp
@@ -525,7 +525,7 @@ void v25_common_device::device_start()
 }
 
 
-void v25_common_device::state_string_export(const device_state_entry &entry, std::string &str)
+void v25_common_device::state_string_export(const device_state_entry &entry, std::string &str) const
 {
 	UINT16 flags = CompressFlags();
 

--- a/src/devices/cpu/nec/v25.h
+++ b/src/devices/cpu/nec/v25.h
@@ -59,7 +59,7 @@ protected:
 	virtual const address_space_config *memory_space_config(address_spacenum spacenum = AS_0) const override { return (spacenum == AS_PROGRAM) ? &m_program_config : ( (spacenum == AS_IO) ? &m_io_config : nullptr); }
 
 	// device_state_interface overrides
-	void state_string_export(const device_state_entry &entry, std::string &str) override;
+	virtual void state_string_export(const device_state_entry &entry, std::string &str) const override;
 	virtual void state_import(const device_state_entry &entry) override;
 	virtual void state_export(const device_state_entry &entry) override;
 

--- a/src/devices/cpu/pdp1/pdp1.cpp
+++ b/src/devices/cpu/pdp1/pdp1.cpp
@@ -737,7 +737,7 @@ void pdp1_device::state_export(const device_state_entry &entry)
 }
 
 
-void pdp1_device::state_string_export(const device_state_entry &entry, std::string &str)
+void pdp1_device::state_string_export(const device_state_entry &entry, std::string &str) const
 {
 	switch (entry.index())
 	{

--- a/src/devices/cpu/pdp1/pdp1.h
+++ b/src/devices/cpu/pdp1/pdp1.h
@@ -107,7 +107,7 @@ protected:
 	// device_state_interface overrides
 	virtual void state_import(const device_state_entry &entry) override;
 	virtual void state_export(const device_state_entry &entry) override;
-	void state_string_export(const device_state_entry &entry, std::string &str) override;
+	virtual void state_string_export(const device_state_entry &entry, std::string &str) const override;
 
 	// device_disasm_interface overrides
 	virtual UINT32 disasm_min_opcode_bytes() const override { return 4; }

--- a/src/devices/cpu/pdp8/pdp8.cpp
+++ b/src/devices/cpu/pdp8/pdp8.cpp
@@ -72,7 +72,6 @@ void pdp8_device::device_start()
 	m_program = &space(AS_PROGRAM);
 
 	// register our state for the debugger
-	std::string tempstr;
 	state_add(STATE_GENPC,     "GENPC",     m_pc).noshow();
 	state_add(STATE_GENFLAGS,  "GENFLAGS",  m_l).callimport().callexport().formatstr("%1s").noshow();
 	state_add(PDP8_PC,         "PC",        m_pc).mask(0xfff);
@@ -136,7 +135,7 @@ const address_space_config *pdp8_device::memory_space_config(address_spacenum sp
 //  for the debugger
 //-------------------------------------------------
 
-void pdp8_device::state_string_export(const device_state_entry &entry, std::string &str)
+void pdp8_device::state_string_export(const device_state_entry &entry, std::string &str) const
 {
 	switch (entry.index())
 	{

--- a/src/devices/cpu/pdp8/pdp8.h
+++ b/src/devices/cpu/pdp8/pdp8.h
@@ -45,7 +45,7 @@ public:
 	virtual offs_t disasm_disassemble(char *buffer, offs_t pc, const UINT8 *oprom, const UINT8 *opram, UINT32 options) override;
 
 	// device_state_interface overrides
-	virtual void state_string_export(const device_state_entry &entry, std::string &str) override;
+	virtual void state_string_export(const device_state_entry &entry, std::string &str) const override;
 
 	// address spaces
 	const address_space_config m_program_config;

--- a/src/devices/cpu/pic16c5x/pic16c5x.cpp
+++ b/src/devices/cpu/pic16c5x/pic16c5x.cpp
@@ -923,7 +923,7 @@ void pic16c5x_device::state_export(const device_state_entry &entry)
 	}
 }
 
-void pic16c5x_device::state_string_export(const device_state_entry &entry, std::string &str)
+void pic16c5x_device::state_string_export(const device_state_entry &entry, std::string &str) const
 {
 	switch (entry.index())
 	{

--- a/src/devices/cpu/pic16c5x/pic16c5x.h
+++ b/src/devices/cpu/pic16c5x/pic16c5x.h
@@ -117,7 +117,7 @@ protected:
 	// device_state_interface overrides
 	virtual void state_import(const device_state_entry &entry) override;
 	virtual void state_export(const device_state_entry &entry) override;
-	void state_string_export(const device_state_entry &entry, std::string &str) override;
+	void state_string_export(const device_state_entry &entry, std::string &str) const override;
 
 	// device_disasm_interface overrides
 	virtual UINT32 disasm_min_opcode_bytes() const override { return 2; }

--- a/src/devices/cpu/pic16c62x/pic16c62x.cpp
+++ b/src/devices/cpu/pic16c62x/pic16c62x.cpp
@@ -990,7 +990,7 @@ void pic16c62x_device::state_export(const device_state_entry &entry)
 	}
 }
 
-void pic16c62x_device::state_string_export(const device_state_entry &entry, std::string &str)
+void pic16c62x_device::state_string_export(const device_state_entry &entry, std::string &str) const
 {
 	switch (entry.index())
 	{

--- a/src/devices/cpu/pic16c62x/pic16c62x.h
+++ b/src/devices/cpu/pic16c62x/pic16c62x.h
@@ -79,7 +79,7 @@ protected:
 	// device_state_interface overrides
 	virtual void state_import(const device_state_entry &entry) override;
 	virtual void state_export(const device_state_entry &entry) override;
-	void state_string_export(const device_state_entry &entry, std::string &str) override;
+	virtual void state_string_export(const device_state_entry &entry, std::string &str) const override;
 
 	// device_disasm_interface overrides
 	virtual UINT32 disasm_min_opcode_bytes() const override { return 2; }

--- a/src/devices/cpu/powerpc/ppc.h
+++ b/src/devices/cpu/powerpc/ppc.h
@@ -264,7 +264,7 @@ protected:
 	// device_state_interface overrides
 	virtual void state_export(const device_state_entry &entry) override;
 	virtual void state_import(const device_state_entry &entry) override;
-	virtual void state_string_export(const device_state_entry &entry, std::string &str) override;
+	virtual void state_string_export(const device_state_entry &entry, std::string &str) const override;
 
 	// device_disasm_interface overrides
 	virtual UINT32 disasm_min_opcode_bytes() const override { return 4; }

--- a/src/devices/cpu/powerpc/ppccom.cpp
+++ b/src/devices/cpu/powerpc/ppccom.cpp
@@ -1007,7 +1007,7 @@ void ppc_device::state_import(const device_state_entry &entry)
 }
 
 
-void ppc_device::state_string_export(const device_state_entry &entry, std::string &str)
+void ppc_device::state_string_export(const device_state_entry &entry, std::string &str) const
 {
 	switch (entry.index())
 	{

--- a/src/devices/cpu/pps4/pps4.cpp
+++ b/src/devices/cpu/pps4/pps4.cpp
@@ -1552,7 +1552,7 @@ void pps4_device::device_start()
 	m_icountptr = &m_icount;
 }
 
-void pps4_device::state_string_export(const device_state_entry &entry, std::string &str)
+void pps4_device::state_string_export(const device_state_entry &entry, std::string &str) const
 {
 	switch (entry.index())
 	{

--- a/src/devices/cpu/pps4/pps4.h
+++ b/src/devices/cpu/pps4/pps4.h
@@ -62,7 +62,7 @@ protected:
 	}
 
 	// device_state_interface overrides
-	void state_string_export(const device_state_entry &entry, std::string &str) override;
+	virtual void state_string_export(const device_state_entry &entry, std::string &str) const override;
 
 	// device_disasm_interface overrides
 	virtual UINT32 disasm_min_opcode_bytes() const override { return 1; }

--- a/src/devices/cpu/psx/psx.cpp
+++ b/src/devices/cpu/psx/psx.cpp
@@ -2026,7 +2026,7 @@ void psxcpu_device::state_import( const device_state_entry &entry )
 //  for the debugger
 //-------------------------------------------------
 
-void psxcpu_device::state_string_export( const device_state_entry &entry, std::string &str )
+void psxcpu_device::state_string_export( const device_state_entry &entry, std::string &str ) const
 {
 	switch( entry.index() )
 	{

--- a/src/devices/cpu/psx/psx.h
+++ b/src/devices/cpu/psx/psx.h
@@ -222,7 +222,7 @@ protected:
 
 	// device_state_interface overrides
 	virtual void state_import(const device_state_entry &entry) override;
-	virtual void state_string_export(const device_state_entry &entry, std::string &str) override;
+	virtual void state_string_export(const device_state_entry &entry, std::string &str) const override;
 
 	// device_disasm_interface overrides
 	virtual UINT32 disasm_min_opcode_bytes() const override { return 4; }

--- a/src/devices/cpu/rsp/rsp.cpp
+++ b/src/devices/cpu/rsp/rsp.cpp
@@ -539,7 +539,7 @@ void rsp_device::state_export(const device_state_entry &entry)
 	}
 }
 
-void rsp_device::state_string_export(const device_state_entry &entry, std::string &str)
+void rsp_device::state_string_export(const device_state_entry &entry, std::string &str) const
 {
 	const int index = entry.index();
 	if (index >= RSP_V0 && index <= RSP_V31)

--- a/src/devices/cpu/rsp/rsp.h
+++ b/src/devices/cpu/rsp/rsp.h
@@ -184,7 +184,7 @@ protected:
 	// device_state_interface overrides
 	virtual void state_import(const device_state_entry &entry) override;
 	virtual void state_export(const device_state_entry &entry) override;
-	void state_string_export(const device_state_entry &entry, std::string &str) override;
+	virtual void state_string_export(const device_state_entry &entry, std::string &str) const override;
 
 	// device_disasm_interface overrides
 	virtual UINT32 disasm_min_opcode_bytes() const override { return 4; }

--- a/src/devices/cpu/rsp/rspcp2.cpp
+++ b/src/devices/cpu/rsp/rspcp2.cpp
@@ -746,7 +746,7 @@ void rsp_cop2::start()
 	}
 }
 
-void rsp_cop2::state_string_export(const int index, std::string &str)
+void rsp_cop2::state_string_export(const int index, std::string &str) const
 {
 	switch (index)
 	{

--- a/src/devices/cpu/rsp/rspcp2.h
+++ b/src/devices/cpu/rsp/rspcp2.h
@@ -89,7 +89,7 @@ protected:
 	virtual int generate_lwc2(drcuml_block *block, rsp_device::compiler_state *compiler, const opcode_desc *desc) { return TRUE; }
 	virtual int generate_swc2(drcuml_block *block, rsp_device::compiler_state *compiler, const opcode_desc *desc) { return TRUE; }
 
-	virtual void state_string_export(const int index, std::string &str);
+	virtual void state_string_export(const int index, std::string &str) const;
 
 public:
 	virtual ~rsp_cop2();

--- a/src/devices/cpu/rsp/rspcp2d.cpp
+++ b/src/devices/cpu/rsp/rspcp2d.cpp
@@ -147,7 +147,7 @@ static void unimplemented_opcode(void *param)
 	((rsp_cop2 *)param)->cfunc_unimplemented_opcode();
 }
 
-void rsp_cop2_drc::state_string_export(const int index, std::string &str)
+void rsp_cop2_drc::state_string_export(const int index, std::string &str) const
 {
 	switch (index)
 	{

--- a/src/devices/cpu/rsp/rspcp2d.h
+++ b/src/devices/cpu/rsp/rspcp2d.h
@@ -28,7 +28,7 @@ private:
 	virtual int generate_lwc2(drcuml_block *block, rsp_device::compiler_state *compiler, const opcode_desc *desc) override;
 	virtual int generate_swc2(drcuml_block *block, rsp_device::compiler_state *compiler, const opcode_desc *desc) override;
 
-	virtual void state_string_export(const int index, std::string &str) override;
+	virtual void state_string_export(const int index, std::string &str) const override;
 
 	void cfunc_unimplemented_opcode() override;
 

--- a/src/devices/cpu/s2650/s2650.cpp
+++ b/src/devices/cpu/s2650/s2650.cpp
@@ -876,7 +876,7 @@ void s2650_device::state_export(const device_state_entry &entry)
 	}
 }
 
-void s2650_device::state_string_export(const device_state_entry &entry, std::string &str)
+void s2650_device::state_string_export(const device_state_entry &entry, std::string &str) const
 {
 	switch (entry.index())
 	{

--- a/src/devices/cpu/s2650/s2650.h
+++ b/src/devices/cpu/s2650/s2650.h
@@ -66,7 +66,7 @@ protected:
 	// device_state_interface overrides
 	virtual void state_import(const device_state_entry &entry) override;
 	virtual void state_export(const device_state_entry &entry) override;
-	void state_string_export(const device_state_entry &entry, std::string &str) override;
+	virtual void state_string_export(const device_state_entry &entry, std::string &str) const override;
 
 	// device_disasm_interface overrides
 	virtual UINT32 disasm_min_opcode_bytes() const override { return 1; }

--- a/src/devices/cpu/saturn/saturn.cpp
+++ b/src/devices/cpu/saturn/saturn.cpp
@@ -169,7 +169,7 @@ void saturn_device::device_start()
 	m_icountptr = &m_icount;
 }
 
-void saturn_device::state_string_export(const device_state_entry &entry, std::string &str)
+void saturn_device::state_string_export(const device_state_entry &entry, std::string &str) const
 {
 #define Reg64Data(s) s[15],s[14],s[13],s[12],s[11],s[10],s[9],s[8],s[7],s[6],s[5],s[4],s[3],s[2],s[1],s[0]
 #define Reg64Format "%x %x%x%x%x%x%x%x %x%x%x %x%x%x%x%x"

--- a/src/devices/cpu/saturn/saturn.h
+++ b/src/devices/cpu/saturn/saturn.h
@@ -104,7 +104,7 @@ protected:
 	virtual const address_space_config *memory_space_config(address_spacenum spacenum = AS_0) const override { return (spacenum == AS_PROGRAM) ? &m_program_config : nullptr; }
 
 	// device_state_interface overrides
-	void state_string_export(const device_state_entry &entry, std::string &str) override;
+	virtual void state_string_export(const device_state_entry &entry, std::string &str) const override;
 	virtual void state_import(const device_state_entry &entry) override;
 	virtual void state_export(const device_state_entry &entry) override;
 

--- a/src/devices/cpu/sc61860/sc61860.cpp
+++ b/src/devices/cpu/sc61860/sc61860.cpp
@@ -171,7 +171,7 @@ void sc61860_device::device_start()
 }
 
 
-void sc61860_device::state_string_export(const device_state_entry &entry, std::string &str)
+void sc61860_device::state_string_export(const device_state_entry &entry, std::string &str) const
 {
 	switch (entry.index())
 	{

--- a/src/devices/cpu/sc61860/sc61860.h
+++ b/src/devices/cpu/sc61860/sc61860.h
@@ -106,7 +106,7 @@ protected:
 	// device_state_interface overrides
 	virtual void state_import(const device_state_entry &entry) override;
 	virtual void state_export(const device_state_entry &entry) override;
-	void state_string_export(const device_state_entry &entry, std::string &str) override;
+	virtual void state_string_export(const device_state_entry &entry, std::string &str) const override;
 
 	// device_disasm_interface overrides
 	virtual UINT32 disasm_min_opcode_bytes() const override { return 1; }

--- a/src/devices/cpu/scmp/scmp.cpp
+++ b/src/devices/cpu/scmp/scmp.cpp
@@ -547,7 +547,7 @@ void scmp_device::device_reset()
     COMMON STATE IMPORT/EXPORT
 ***************************************************************************/
 
-void scmp_device::state_string_export(const device_state_entry &entry, std::string &str)
+void scmp_device::state_string_export(const device_state_entry &entry, std::string &str) const
 {
 	switch (entry.index())
 	{

--- a/src/devices/cpu/scmp/scmp.h
+++ b/src/devices/cpu/scmp/scmp.h
@@ -56,7 +56,7 @@ protected:
 	virtual const address_space_config *memory_space_config(address_spacenum spacenum = AS_0) const override { return (spacenum == AS_PROGRAM) ? &m_program_config : nullptr; }
 
 	// device_state_interface overrides
-	void state_string_export(const device_state_entry &entry, std::string &str) override;
+	void state_string_export(const device_state_entry &entry, std::string &str) const override;
 
 	// device_disasm_interface overrides
 	virtual UINT32 disasm_min_opcode_bytes() const override { return 1; }

--- a/src/devices/cpu/score/score.cpp
+++ b/src/devices/cpu/score/score.cpp
@@ -80,16 +80,14 @@ void score7_cpu_device::device_start()
 	// register state for debugger
 	state_add(SCORE_PC  , "PC"  , m_pc).callimport().callexport().formatstr("%08X");
 
-	std::string tmp_string;
+	for(int i=0; i<0x20; i++)
+		state_add(SCORE_GPR + i, strformat("r%d", i).c_str(), m_gpr[i]).callimport().callexport().formatstr("%08X");
 
 	for(int i=0; i<0x20; i++)
-		state_add(SCORE_GPR + i, strformat(tmp_string, "r%d", i).c_str(), m_gpr[i]).callimport().callexport().formatstr("%08X");
-
-	for(int i=0; i<0x20; i++)
-		state_add(SCORE_CR + i, strformat(tmp_string, "cr%d", i).c_str(), m_cr[i]).callimport().callexport().formatstr("%08X");
+		state_add(SCORE_CR + i, strformat("cr%d", i).c_str(), m_cr[i]).callimport().callexport().formatstr("%08X");
 
 	for(int i=0; i<3; i++)
-		state_add(SCORE_SR + i, strformat(tmp_string, "sr%d", i).c_str(), m_sr[i]).callimport().callexport().formatstr("%08X");
+		state_add(SCORE_SR + i, strformat("sr%d", i).c_str(), m_sr[i]).callimport().callexport().formatstr("%08X");
 
 	state_add(SCORE_CEH, "ceh", REG_CEH).callimport().callexport().formatstr("%08X");
 	state_add(SCORE_CEL, "cel", REG_CEL).callimport().callexport().formatstr("%08X");
@@ -132,7 +130,7 @@ void score7_cpu_device::device_reset()
 //  for the debugger
 //-------------------------------------------------
 
-void score7_cpu_device::state_string_export(const device_state_entry &entry, std::string &str)
+void score7_cpu_device::state_string_export(const device_state_entry &entry, std::string &str) const
 {
 	switch (entry.index())
 	{

--- a/src/devices/cpu/score/score.h
+++ b/src/devices/cpu/score/score.h
@@ -47,7 +47,7 @@ protected:
 	virtual void execute_set_input(int inputnum, int state) override;
 
 	// device_state_interface overrides
-	void state_string_export(const device_state_entry &entry, std::string &str) override;
+	virtual void state_string_export(const device_state_entry &entry, std::string &str) const override;
 
 	// device_memory_interface overrides
 	virtual const address_space_config *memory_space_config(address_spacenum spacenum = AS_0) const override;

--- a/src/devices/cpu/scudsp/scudsp.cpp
+++ b/src/devices/cpu/scudsp/scudsp.cpp
@@ -1010,7 +1010,7 @@ scudsp_cpu_device::scudsp_cpu_device(const machine_config &mconfig, const char *
 }
 
 
-void scudsp_cpu_device::state_string_export(const device_state_entry &entry, std::string &str)
+void scudsp_cpu_device::state_string_export(const device_state_entry &entry, std::string &str) const
 {
 	switch (entry.index())
 	{

--- a/src/devices/cpu/scudsp/scudsp.h
+++ b/src/devices/cpu/scudsp/scudsp.h
@@ -96,7 +96,7 @@ protected:
 	virtual const address_space_config *memory_space_config(address_spacenum spacenum = AS_0) const override { return (spacenum == AS_PROGRAM) ? &m_program_config : ( (spacenum == AS_DATA) ? &m_data_config : nullptr ); }
 
 	// device_state_interface overrides
-	void state_string_export(const device_state_entry &entry, std::string &str) override;
+	void state_string_export(const device_state_entry &entry, std::string &str) const override;
 
 	// device_disasm_interface overrides
 	virtual UINT32 disasm_min_opcode_bytes() const override { return 4; }

--- a/src/devices/cpu/se3208/se3208.cpp
+++ b/src/devices/cpu/se3208/se3208.cpp
@@ -1821,7 +1821,7 @@ void se3208_device::device_start()
 }
 
 
-void se3208_device::state_string_export(const device_state_entry &entry, std::string &str)
+void se3208_device::state_string_export(const device_state_entry &entry, std::string &str) const
 {
 	switch (entry.index())
 	{

--- a/src/devices/cpu/se3208/se3208.h
+++ b/src/devices/cpu/se3208/se3208.h
@@ -32,7 +32,7 @@ protected:
 	virtual const address_space_config *memory_space_config(address_spacenum spacenum = AS_0) const override { return (spacenum == AS_PROGRAM) ? &m_program_config : nullptr; }
 
 	// device_state_interface overrides
-	void state_string_export(const device_state_entry &entry, std::string &str) override;
+	virtual void state_string_export(const device_state_entry &entry, std::string &str) const override;
 
 	// device_disasm_interface overrides
 	virtual UINT32 disasm_min_opcode_bytes() const override { return 2; }

--- a/src/devices/cpu/sh2/sh2.cpp
+++ b/src/devices/cpu/sh2/sh2.cpp
@@ -2583,7 +2583,7 @@ void sh2_device::device_start()
 }
 
 
-void sh2_device::state_string_export(const device_state_entry &entry, std::string &str)
+void sh2_device::state_string_export(const device_state_entry &entry, std::string &str) const
 {
 	switch (entry.index())
 	{

--- a/src/devices/cpu/sh2/sh2.h
+++ b/src/devices/cpu/sh2/sh2.h
@@ -131,7 +131,7 @@ protected:
 	// device_state_interface overrides
 	virtual void state_import(const device_state_entry &entry) override;
 	virtual void state_export(const device_state_entry &entry) override;
-	void state_string_export(const device_state_entry &entry, std::string &str) override;
+	virtual void state_string_export(const device_state_entry &entry, std::string &str) const override;
 
 	// device_disasm_interface overrides
 	virtual UINT32 disasm_min_opcode_bytes() const override { return 2; }

--- a/src/devices/cpu/sh4/sh4.cpp
+++ b/src/devices/cpu/sh4/sh4.cpp
@@ -4447,7 +4447,7 @@ void sh34_base_device::state_export(const device_state_entry &entry)
 	}
 }
 
-void sh34_base_device::state_string_export(const device_state_entry &entry, std::string &str)
+void sh34_base_device::state_string_export(const device_state_entry &entry, std::string &str) const
 {
 #ifdef LSB_FIRST
 	UINT8 fpu_xor = m_fpu_pr;

--- a/src/devices/cpu/sh4/sh4.h
+++ b/src/devices/cpu/sh4/sh4.h
@@ -220,7 +220,7 @@ protected:
 	// device_state_interface overrides
 	virtual void state_import(const device_state_entry &entry) override;
 	virtual void state_export(const device_state_entry &entry) override;
-	virtual void state_string_export(const device_state_entry &entry, std::string &str) override;
+	virtual void state_string_export(const device_state_entry &entry, std::string &str) const override;
 
 	// device_disasm_interface overrides
 	virtual UINT32 disasm_min_opcode_bytes() const override { return 2; }

--- a/src/devices/cpu/sm8500/sm8500.cpp
+++ b/src/devices/cpu/sm8500/sm8500.cpp
@@ -53,7 +53,7 @@ void sm8500_cpu_device::get_sp()
 }
 
 
-UINT8 sm8500_cpu_device::mem_readbyte( UINT32 offset )
+UINT8 sm8500_cpu_device::mem_readbyte( UINT32 offset ) const
 {
 	offset &= 0xffff;
 	if ( offset < 0x10)
@@ -141,7 +141,7 @@ void sm8500_cpu_device::device_start()
 }
 
 
-void sm8500_cpu_device::state_string_export(const device_state_entry &entry, std::string &str)
+void sm8500_cpu_device::state_string_export(const device_state_entry &entry, std::string &str) const
 {
 	switch (entry.index())
 	{

--- a/src/devices/cpu/sm8500/sm8500.h
+++ b/src/devices/cpu/sm8500/sm8500.h
@@ -71,7 +71,7 @@ protected:
 	virtual const address_space_config *memory_space_config(address_spacenum spacenum = AS_0) const override { return (spacenum == AS_PROGRAM) ? &m_program_config : nullptr; }
 
 	// device_state_interface overrides
-	void state_string_export(const device_state_entry &entry, std::string &str) override;
+	virtual void state_string_export(const device_state_entry &entry, std::string &str) const override;
 
 	// device_disasm_interface overrides
 	virtual UINT32 disasm_min_opcode_bytes() const override { return 1; }
@@ -79,9 +79,9 @@ protected:
 	virtual offs_t disasm_disassemble(char *buffer, offs_t pc, const UINT8 *oprom, const UINT8 *opram, UINT32 options) override;
 
 	inline void get_sp();
-	UINT8 mem_readbyte(UINT32 offset);
+	UINT8 mem_readbyte(UINT32 offset) const;
 	void mem_writebyte(UINT32 offset, UINT8 data);
-	inline UINT16 mem_readword(UINT32 address) { return (mem_readbyte(address ) << 8) | (mem_readbyte(address+1)); }
+	inline UINT16 mem_readword(UINT32 address) const { return (mem_readbyte(address ) << 8) | (mem_readbyte(address+1)); }
 	inline void mem_writeword(UINT32 address, UINT16 value) { mem_writebyte(address, value >> 8); mem_writebyte(address+1, value); }
 	inline void take_interrupt(UINT16 vector);
 	void process_interrupts();

--- a/src/devices/cpu/spc700/spc700.cpp
+++ b/src/devices/cpu/spc700/spc700.cpp
@@ -1244,7 +1244,7 @@ void spc700_device::device_start()
 }
 
 
-void spc700_device::state_string_export(const device_state_entry &entry, std::string &str)
+void spc700_device::state_string_export(const device_state_entry &entry, std::string &str) const
 {
 	switch (entry.index())
 	{

--- a/src/devices/cpu/spc700/spc700.h
+++ b/src/devices/cpu/spc700/spc700.h
@@ -30,7 +30,7 @@ protected:
 	// device_state_interface overrides
 	virtual void state_import(const device_state_entry &entry) override;
 	virtual void state_export(const device_state_entry &entry) override;
-	void state_string_export(const device_state_entry &entry, std::string &str) override;
+	virtual void state_string_export(const device_state_entry &entry, std::string &str) const override;
 
 	// device_disasm_interface overrides
 	virtual UINT32 disasm_min_opcode_bytes() const override { return 1; }

--- a/src/devices/cpu/ssem/ssem.cpp
+++ b/src/devices/cpu/ssem/ssem.cpp
@@ -149,7 +149,7 @@ const address_space_config *ssem_device::memory_space_config(address_spacenum sp
 //  for the debugger
 //-------------------------------------------------
 
-void ssem_device::state_string_export(const device_state_entry &entry, std::string &str)
+void ssem_device::state_string_export(const device_state_entry &entry, std::string &str) const
 {
 	switch (entry.index())
 	{

--- a/src/devices/cpu/ssem/ssem.h
+++ b/src/devices/cpu/ssem/ssem.h
@@ -45,7 +45,7 @@ public:
 	virtual offs_t disasm_disassemble(char *buffer, offs_t pc, const UINT8 *oprom, const UINT8 *opram, UINT32 options) override;
 
 	// device_state_interface overrides
-	virtual void state_string_export(const device_state_entry &entry, std::string &str) override;
+	virtual void state_string_export(const device_state_entry &entry, std::string &str) const override;
 
 	// address spaces
 	const address_space_config m_program_config;

--- a/src/devices/cpu/ssp1601/ssp1601.cpp
+++ b/src/devices/cpu/ssp1601/ssp1601.cpp
@@ -547,7 +547,7 @@ void ssp1601_device::device_start()
 }
 
 
-void ssp1601_device::state_string_export(const device_state_entry &entry, std::string &str)
+void ssp1601_device::state_string_export(const device_state_entry &entry, std::string &str) const
 {
 	switch (entry.index())
 	{

--- a/src/devices/cpu/ssp1601/ssp1601.h
+++ b/src/devices/cpu/ssp1601/ssp1601.h
@@ -40,7 +40,7 @@ protected:
 	virtual const address_space_config *memory_space_config(address_spacenum spacenum = AS_0) const override { return (spacenum == AS_PROGRAM) ? &m_program_config : ((spacenum == AS_IO) ? &m_io_config : nullptr); }
 
 	// device_state_interface overrides
-	void state_string_export(const device_state_entry &entry, std::string &str) override;
+	virtual void state_string_export(const device_state_entry &entry, std::string &str) const override;
 
 	// device_disasm_interface overrides
 	virtual UINT32 disasm_min_opcode_bytes() const override { return 2; }

--- a/src/devices/cpu/t11/t11.cpp
+++ b/src/devices/cpu/t11/t11.cpp
@@ -291,7 +291,7 @@ void t11_device::device_start()
 	m_icountptr = &m_icount;
 }
 
-void t11_device::state_string_export(const device_state_entry &entry, std::string &str)
+void t11_device::state_string_export(const device_state_entry &entry, std::string &str) const
 {
 	switch (entry.index())
 	{
@@ -310,7 +310,7 @@ void t11_device::state_string_export(const device_state_entry &entry, std::strin
 	}
 }
 
-void k1801vm2_device::state_string_export(const device_state_entry &entry, std::string &str)
+void k1801vm2_device::state_string_export(const device_state_entry &entry, std::string &str) const
 {
 	switch (entry.index())
 	{

--- a/src/devices/cpu/t11/t11.h
+++ b/src/devices/cpu/t11/t11.h
@@ -59,7 +59,7 @@ protected:
 	virtual const address_space_config *memory_space_config(address_spacenum spacenum = AS_0) const override { return (spacenum == AS_PROGRAM) ? &m_program_config : nullptr; }
 
 	// device_state_interface overrides
-	void state_string_export(const device_state_entry &entry, std::string &str) override;
+	virtual void state_string_export(const device_state_entry &entry, std::string &str) const override;
 
 	// device_disasm_interface overrides
 	virtual UINT32 disasm_min_opcode_bytes() const override { return 2; }
@@ -1145,7 +1145,7 @@ protected:
 	virtual void device_reset() override;
 
 	// device_state_interface overrides
-	void state_string_export(const device_state_entry &entry, std::string &str) override;
+	virtual void state_string_export(const device_state_entry &entry, std::string &str) const override;
 };
 
 

--- a/src/devices/cpu/tlcs90/tlcs90.cpp
+++ b/src/devices/cpu/tlcs90/tlcs90.cpp
@@ -2766,7 +2766,7 @@ void tlcs90_device::device_start()
 }
 
 
-void tlcs90_device::state_string_export(const device_state_entry &entry, std::string &str)
+void tlcs90_device::state_string_export(const device_state_entry &entry, std::string &str) const
 {
 	switch (entry.index())
 	{

--- a/src/devices/cpu/tlcs90/tlcs90.h
+++ b/src/devices/cpu/tlcs90/tlcs90.h
@@ -51,7 +51,7 @@ protected:
 	virtual const address_space_config *memory_space_config(address_spacenum spacenum = AS_0) const override { return (spacenum == AS_PROGRAM) ? &m_program_config : ( (spacenum == AS_IO) ? &m_io_config : nullptr ); }
 
 	// device_state_interface overrides
-	void state_string_export(const device_state_entry &entry, std::string &str) override;
+	virtual void state_string_export(const device_state_entry &entry, std::string &str) const override;
 
 	// device_disasm_interface overrides
 	virtual UINT32 disasm_min_opcode_bytes() const override { return 1; }

--- a/src/devices/cpu/tlcs900/tlcs900.cpp
+++ b/src/devices/cpu/tlcs900/tlcs900.cpp
@@ -384,7 +384,7 @@ void tlcs900h_device::device_start()
 }
 
 
-void tlcs900h_device::state_string_export(const device_state_entry &entry, std::string &str)
+void tlcs900h_device::state_string_export(const device_state_entry &entry, std::string &str) const
 {
 	switch (entry.index())
 	{

--- a/src/devices/cpu/tlcs900/tlcs900.h
+++ b/src/devices/cpu/tlcs900/tlcs900.h
@@ -71,7 +71,7 @@ protected:
 	}
 
 	// device_state_interface overrides
-	void state_string_export(const device_state_entry &entry, std::string &str) override;
+	virtual void state_string_export(const device_state_entry &entry, std::string &str) const override;
 
 	// device_disasm_interface overrides
 	virtual UINT32 disasm_min_opcode_bytes() const override { return 1; }

--- a/src/devices/cpu/tms0980/tms0980.cpp
+++ b/src/devices/cpu/tms0980/tms0980.cpp
@@ -475,7 +475,7 @@ offs_t tms0980_cpu_device::disasm_disassemble(char *buffer, offs_t pc, const UIN
 	return CPU_DISASSEMBLE_NAME(tms0980)(this, buffer, pc, oprom, opram, options);
 }
 
-void tms1xxx_cpu_device::state_string_export(const device_state_entry &entry, std::string &str)
+void tms1xxx_cpu_device::state_string_export(const device_state_entry &entry, std::string &str) const
 {
 	switch (entry.index())
 	{

--- a/src/devices/cpu/tms0980/tms0980.h
+++ b/src/devices/cpu/tms0980/tms0980.h
@@ -137,7 +137,8 @@ protected:
 	virtual UINT32 disasm_min_opcode_bytes() const override { return 1; }
 	virtual UINT32 disasm_max_opcode_bytes() const override { return 1; }
 
-	void state_string_export(const device_state_entry &entry, std::string &str) override;
+	// device_state_interface overrides
+	virtual void state_string_export(const device_state_entry &entry, std::string &str) const override;
 
 	void next_pc();
 

--- a/src/devices/cpu/tms32010/tms32010.cpp
+++ b/src/devices/cpu/tms32010/tms32010.cpp
@@ -895,7 +895,7 @@ void tms32010_device::device_reset()
 }
 
 
-void tms32010_device::state_string_export(const device_state_entry &entry, std::string &str)
+void tms32010_device::state_string_export(const device_state_entry &entry, std::string &str) const
 {
 	switch (entry.index())
 	{

--- a/src/devices/cpu/tms32010/tms32010.h
+++ b/src/devices/cpu/tms32010/tms32010.h
@@ -72,7 +72,7 @@ protected:
 	virtual const address_space_config *memory_space_config(address_spacenum spacenum = AS_0) const override { return (spacenum == AS_PROGRAM) ? &m_program_config : ( (spacenum == AS_IO) ? &m_io_config : ( (spacenum == AS_DATA) ? &m_data_config : nullptr ) ); }
 
 	// device_state_interface overrides
-	void state_string_export(const device_state_entry &entry, std::string &str) override;
+	virtual void state_string_export(const device_state_entry &entry, std::string &str) const override;
 
 	// device_disasm_interface overrides
 	virtual UINT32 disasm_min_opcode_bytes() const override { return 2; }

--- a/src/devices/cpu/tms32025/tms32025.cpp
+++ b/src/devices/cpu/tms32025/tms32025.cpp
@@ -1801,7 +1801,7 @@ void tms32025_device::state_export(const device_state_entry &entry)
 }
 
 
-void tms32025_device::state_string_export(const device_state_entry &entry, std::string &str)
+void tms32025_device::state_string_export(const device_state_entry &entry, std::string &str) const
 {
 	switch (entry.index())
 	{

--- a/src/devices/cpu/tms32025/tms32025.h
+++ b/src/devices/cpu/tms32025/tms32025.h
@@ -97,7 +97,7 @@ protected:
 	// device_state_interface overrides
 	virtual void state_import(const device_state_entry &entry) override;
 	virtual void state_export(const device_state_entry &entry) override;
-	void state_string_export(const device_state_entry &entry, std::string &str) override;
+	virtual void state_string_export(const device_state_entry &entry, std::string &str) const override;
 
 	// device_disasm_interface overrides
 	virtual UINT32 disasm_min_opcode_bytes() const override { return 2; }

--- a/src/devices/cpu/tms32031/tms32031.cpp
+++ b/src/devices/cpu/tms32031/tms32031.cpp
@@ -529,7 +529,7 @@ void tms3203x_device::state_export(const device_state_entry &entry)
 //  for the debugger
 //-------------------------------------------------
 
-void tms3203x_device::state_string_export(const device_state_entry &entry, std::string &str)
+void tms3203x_device::state_string_export(const device_state_entry &entry, std::string &str) const
 {
 	switch (entry.index())
 	{

--- a/src/devices/cpu/tms32031/tms32031.h
+++ b/src/devices/cpu/tms32031/tms32031.h
@@ -179,7 +179,7 @@ protected:
 	// device_state_interface overrides
 	virtual void state_import(const device_state_entry &entry) override;
 	virtual void state_export(const device_state_entry &entry) override;
-	virtual void state_string_export(const device_state_entry &entry, std::string &str) override;
+	virtual void state_string_export(const device_state_entry &entry, std::string &str) const override;
 
 	// device_disasm_interface overrides
 	virtual UINT32 disasm_min_opcode_bytes() const override;

--- a/src/devices/cpu/tms32082/tms32082.cpp
+++ b/src/devices/cpu/tms32082/tms32082.cpp
@@ -214,7 +214,7 @@ void tms32082_mp_device::device_start()
 	m_icountptr = &m_icount;
 }
 
-void tms32082_mp_device::state_string_export(const device_state_entry &entry, std::string &str)
+void tms32082_mp_device::state_string_export(const device_state_entry &entry, std::string &str) const
 {
 	switch (entry.index())
 	{
@@ -511,7 +511,7 @@ void tms32082_pp_device::device_start()
 	m_icountptr = &m_icount;
 }
 
-void tms32082_pp_device::state_string_export(const device_state_entry &entry, std::string &str)
+void tms32082_pp_device::state_string_export(const device_state_entry &entry, std::string &str) const
 {
 	switch (entry.index())
 	{

--- a/src/devices/cpu/tms32082/tms32082.h
+++ b/src/devices/cpu/tms32082/tms32082.h
@@ -97,7 +97,7 @@ protected:
 	}
 
 	// device_state_interface overrides
-	void state_string_export(const device_state_entry &entry, std::string &str) override;
+	virtual void state_string_export(const device_state_entry &entry, std::string &str) const override;
 
 	// device_disasm_interface overrides
 	virtual UINT32 disasm_min_opcode_bytes() const override { return 4; }
@@ -192,7 +192,7 @@ protected:
 	}
 
 	// device_state_interface overrides
-	void state_string_export(const device_state_entry &entry, std::string &str) override;
+	virtual void state_string_export(const device_state_entry &entry, std::string &str) const override;
 
 	// device_disasm_interface overrides
 	virtual UINT32 disasm_min_opcode_bytes() const override { return 8; }

--- a/src/devices/cpu/tms34010/tms34010.cpp
+++ b/src/devices/cpu/tms34010/tms34010.cpp
@@ -592,14 +592,13 @@ void tms340x0_device::device_start()
 		state_add(TMS34010_ST,     "ST",        m_st);
 		state_add(STATE_GENFLAGS,  "GENFLAGS",  m_st).noshow().formatstr("%18s");
 
-		std::string tempstr;
 		for (int regnum = 0; regnum < 15; regnum++)
 		{
-			state_add(TMS34010_A0 + regnum, strformat(tempstr, "A%d", regnum).c_str(), m_regs[regnum].reg);
+			state_add(TMS34010_A0 + regnum, strformat("A%d", regnum).c_str(), m_regs[regnum].reg);
 		}
 		for (int regnum = 0; regnum < 15; regnum++)
 		{
-			state_add(TMS34010_B0 + regnum, strformat(tempstr, "B%d", regnum).c_str(), m_regs[30 - regnum].reg);
+			state_add(TMS34010_B0 + regnum, strformat("B%d", regnum).c_str(), m_regs[30 - regnum].reg);
 		}
 	}
 
@@ -1599,7 +1598,7 @@ READ16_MEMBER( tms340x0_device::host_r )
 }
 
 
-void tms340x0_device::state_string_export(const device_state_entry &entry, std::string &str)
+void tms340x0_device::state_string_export(const device_state_entry &entry, std::string &str) const
 {
 	switch (entry.index())
 	{

--- a/src/devices/cpu/tms34010/tms34010.h
+++ b/src/devices/cpu/tms34010/tms34010.h
@@ -282,7 +282,7 @@ protected:
 	virtual const address_space_config *memory_space_config(address_spacenum spacenum = AS_0) const override { return (spacenum == AS_PROGRAM) ? &m_program_config : nullptr; }
 
 	// device_state_interface overrides
-	virtual void state_string_export(const device_state_entry &entry, std::string &str) override;
+	virtual void state_string_export(const device_state_entry &entry, std::string &str) const override;
 
 	// device_disasm_interface overrides
 	virtual UINT32 disasm_min_opcode_bytes() const override { return 2; }

--- a/src/devices/cpu/tms7000/tms7000.cpp
+++ b/src/devices/cpu/tms7000/tms7000.cpp
@@ -257,7 +257,7 @@ void tms7000_device::device_start()
 	state_add(STATE_GENFLAGS, "GENFLAGS", m_sr).formatstr("%8s").noshow();
 }
 
-void tms7000_device::state_string_export(const device_state_entry &entry, std::string &str)
+void tms7000_device::state_string_export(const device_state_entry &entry, std::string &str) const
 {
 	switch (entry.index())
 	{

--- a/src/devices/cpu/tms7000/tms7000.h
+++ b/src/devices/cpu/tms7000/tms7000.h
@@ -80,7 +80,7 @@ protected:
 	virtual const address_space_config *memory_space_config(address_spacenum spacenum = AS_0) const override { return (spacenum == AS_PROGRAM) ? &m_program_config : ( (spacenum == AS_IO) ? &m_io_config : nullptr ); }
 
 	// device_state_interface overrides
-	void state_string_export(const device_state_entry &entry, std::string &str) override;
+	virtual void state_string_export(const device_state_entry &entry, std::string &str) const override;
 
 	// device_disasm_interface overrides
 	virtual UINT32 disasm_min_opcode_bytes() const override { return 1; }

--- a/src/devices/cpu/tms9900/tms9900.cpp
+++ b/src/devices/cpu/tms9900/tms9900.cpp
@@ -349,11 +349,11 @@ void tms99xx_device::state_export(const device_state_entry &entry)
 /*
     state_string_export - export state as a string for the debugger
 */
-void tms99xx_device::state_string_export(const device_state_entry &entry, std::string &str)
+void tms99xx_device::state_string_export(const device_state_entry &entry, std::string &str) const
 {
 	static const char *statestr = "LAECOPX-----IIII";
 	char flags[17];
-	memset(flags, 0x00, ARRAY_LENGTH(flags));
+	for (auto &flag : flags) flag = 0x00;
 	UINT16 val = 0x8000;
 	if (entry.index()==STATE_GENFLAGS)
 	{

--- a/src/devices/cpu/tms9900/tms9900.h
+++ b/src/devices/cpu/tms9900/tms9900.h
@@ -224,9 +224,9 @@ private:
 	// State / debug management
 	UINT16  m_state_any;
 	static const char* s_statename[];
-	void    state_import(const device_state_entry &entry) override;
-	void    state_export(const device_state_entry &entry) override;
-	void    state_string_export(const device_state_entry &entry, std::string &str) override;
+	virtual void state_import(const device_state_entry &entry) override;
+	virtual void state_export(const device_state_entry &entry) override;
+	virtual void state_string_export(const device_state_entry &entry, std::string &str) const override;
 
 	// Interrupt handling
 	void service_interrupt();

--- a/src/devices/cpu/tms9900/tms9995.cpp
+++ b/src/devices/cpu/tms9900/tms9995.cpp
@@ -372,7 +372,7 @@ void tms9995_device::state_export(const device_state_entry &entry)
 /*
     state_string_export - export state as a string for the debugger
 */
-void tms9995_device::state_string_export(const device_state_entry &entry, std::string &str)
+void tms9995_device::state_string_export(const device_state_entry &entry, std::string &str) const
 {
 	static const char *statestr = "LAECOPX-----IIII";
 	char flags[17];

--- a/src/devices/cpu/tms9900/tms9995.h
+++ b/src/devices/cpu/tms9900/tms9995.h
@@ -106,7 +106,7 @@ private:
 	static const char* s_statename[];
 	void    state_import(const device_state_entry &entry) override;
 	void    state_export(const device_state_entry &entry) override;
-	void    state_string_export(const device_state_entry &entry, std::string &str) override;
+	void    state_string_export(const device_state_entry &entry, std::string &str) const override;
 	UINT16  read_workspace_register_debug(int reg);
 	void    write_workspace_register_debug(int reg, UINT16 data);
 

--- a/src/devices/cpu/ucom4/ucom4.cpp
+++ b/src/devices/cpu/ucom4/ucom4.cpp
@@ -76,7 +76,7 @@ upd552_cpu_device::upd552_cpu_device(const machine_config &mconfig, const char *
 
 
 // disasm
-void ucom4_cpu_device::state_string_export(const device_state_entry &entry, std::string &str)
+void ucom4_cpu_device::state_string_export(const device_state_entry &entry, std::string &str) const
 {
 	switch (entry.index())
 	{

--- a/src/devices/cpu/ucom4/ucom4.h
+++ b/src/devices/cpu/ucom4/ucom4.h
@@ -157,7 +157,8 @@ protected:
 	virtual UINT32 disasm_max_opcode_bytes() const override { return 2; }
 	virtual offs_t disasm_disassemble(char *buffer, offs_t pc, const UINT8 *oprom, const UINT8 *opram, UINT32 options) override;
 
-	void state_string_export(const device_state_entry &entry, std::string &str) override;
+	// device_state_interface overrides
+	virtual void state_string_export(const device_state_entry &entry, std::string &str) const override;
 
 	address_space_config m_program_config;
 	address_space_config m_data_config;

--- a/src/devices/cpu/uml.cpp
+++ b/src/devices/cpu/uml.cpp
@@ -739,9 +739,8 @@ void uml::instruction::simplify()
 	/*
 	    if (LOG_SIMPLIFICATIONS && memcmp(&orig, inst, sizeof(orig)) != 0)
 	    {
-	        std::string disasm1, disasm2;
-	        orig.disasm(disasm1, block->drcuml);
-	        inst->disasm(disasm2, block->drcuml);
+	        std::string disasm1 = orig.disasm(block->drcuml);
+	        std::string disasm2 = inst->disasm(block->drcuml);
 	        osd_printf_debug("Simplified: %-50.50s -> %s\n", disasm1.c_str(), disasm2.c_str());
 	    }
 	*/
@@ -854,7 +853,7 @@ UINT8 uml::instruction::modified_flags() const
 //  given buffer
 //-------------------------------------------------
 
-const char *uml::instruction::disasm(std::string &buffer, drcuml_state *drcuml) const
+std::string uml::instruction::disasm(drcuml_state *drcuml) const
 {
 	static const char *const conditions[] = { "z", "nz", "s", "ns", "c", "nc", "v", "nv", "u", "nu", "a", "be", "g", "le", "l", "ge" };
 	static const char *const pound_size[] = { "?", "?", "?", "?", "s", "?", "?", "?", "d" };
@@ -868,7 +867,7 @@ const char *uml::instruction::disasm(std::string &buffer, drcuml_state *drcuml) 
 	assert(m_opcode != OP_INVALID && m_opcode < OP_MAX);
 
 	// start with the raw mnemonic and substitute sizes
-	buffer.clear();
+	std::string buffer;
 	for (const char *opsrc = opinfo.mnemonic; *opsrc != 0; opsrc++)
 		if (*opsrc == '!')
 			strcatprintf(buffer, "%s", bang_size[m_size]);
@@ -1025,5 +1024,5 @@ const char *uml::instruction::disasm(std::string &buffer, drcuml_state *drcuml) 
 		if (m_flags & FLAG_C)
 			buffer.push_back('C');
 	}
-	return buffer.c_str();
+	return buffer;
 }

--- a/src/devices/cpu/uml.h
+++ b/src/devices/cpu/uml.h
@@ -409,7 +409,7 @@ namespace uml
 		void set_mapvar(int paramnum, UINT32 value) { assert(paramnum < m_numparams); assert(m_param[paramnum].is_mapvar()); m_param[paramnum] = value; }
 
 		// misc
-		const char *disasm(std::string &str, drcuml_state *drcuml = nullptr) const;
+		std::string disasm(drcuml_state *drcuml = nullptr) const;
 		UINT8 input_flags() const;
 		UINT8 output_flags() const;
 		UINT8 modified_flags() const;

--- a/src/devices/cpu/upd7725/upd7725.cpp
+++ b/src/devices/cpu/upd7725/upd7725.cpp
@@ -202,7 +202,7 @@ void necdsp_device::state_export(const device_state_entry &entry)
 //  for the debugger
 //-------------------------------------------------
 
-void necdsp_device::state_string_export(const device_state_entry &entry, std::string &str)
+void necdsp_device::state_string_export(const device_state_entry &entry, std::string &str) const
 {
 	switch (entry.index())
 	{

--- a/src/devices/cpu/upd7725/upd7725.h
+++ b/src/devices/cpu/upd7725/upd7725.h
@@ -110,7 +110,7 @@ protected:
 	// device_state_interface overrides
 	virtual void state_import(const device_state_entry &entry) override;
 	virtual void state_export(const device_state_entry &entry) override;
-	virtual void state_string_export(const device_state_entry &entry, std::string &str) override;
+	virtual void state_string_export(const device_state_entry &entry, std::string &str) const override;
 
 	// device_disasm_interface overrides
 	virtual UINT32 disasm_min_opcode_bytes() const override;

--- a/src/devices/cpu/upd7810/upd7810.cpp
+++ b/src/devices/cpu/upd7810/upd7810.cpp
@@ -1696,7 +1696,7 @@ void upd78c05_device::device_start()
 
 }
 
-void upd7810_device::state_string_export(const device_state_entry &entry, std::string &str)
+void upd7810_device::state_string_export(const device_state_entry &entry, std::string &str) const
 {
 	switch (entry.index())
 	{

--- a/src/devices/cpu/upd7810/upd7810.h
+++ b/src/devices/cpu/upd7810/upd7810.h
@@ -170,7 +170,7 @@ protected:
 	virtual const address_space_config *memory_space_config(address_spacenum spacenum = AS_0) const override { return (spacenum == AS_PROGRAM) ? &m_program_config : ( (spacenum == AS_IO) ? &m_io_config : nullptr ); }
 
 	// device_state_interface overrides
-	void state_string_export(const device_state_entry &entry, std::string &str) override;
+	virtual void state_string_export(const device_state_entry &entry, std::string &str) const override;
 
 	// device_disasm_interface overrides
 	virtual UINT32 disasm_min_opcode_bytes() const override { return 1; }

--- a/src/devices/cpu/v30mz/v30mz.cpp
+++ b/src/devices/cpu/v30mz/v30mz.cpp
@@ -185,12 +185,12 @@ void v30mz_cpu_device::device_start()
 }
 
 
-void v30mz_cpu_device::state_string_export(const device_state_entry &entry, std::string &str)
+void v30mz_cpu_device::state_string_export(const device_state_entry &entry, std::string &str) const
 {
 	switch (entry.index())
 	{
 		case STATE_GENPC:
-			strprintf(str, "%08X", pc());
+			strprintf(str, "%08X", ( m_sregs[CS] << 4 ) + m_ip);
 			break;
 
 		case STATE_GENFLAGS:
@@ -781,7 +781,7 @@ inline void v30mz_cpu_device::set_OFB_Sub(UINT32 x,UINT32 y,UINT32 z)
 }
 
 
-inline UINT16 v30mz_cpu_device::CompressFlags()
+inline UINT16 v30mz_cpu_device::CompressFlags() const
 {
 	return (CF ? 1 : 0)
 		| (PF ? 4 : 0)

--- a/src/devices/cpu/v30mz/v30mz.h
+++ b/src/devices/cpu/v30mz/v30mz.h
@@ -44,7 +44,7 @@ protected:
 	virtual const address_space_config *memory_space_config(address_spacenum spacenum = AS_0) const override { return (spacenum == AS_PROGRAM) ? &m_program_config : ( (spacenum == AS_IO) ? &m_io_config : nullptr ); }
 
 	// device_state_interface overrides
-	void state_string_export(const device_state_entry &entry, std::string &str) override;
+	virtual void state_string_export(const device_state_entry &entry, std::string &str) const override;
 
 	// device_disasm_interface overrides
 	virtual UINT32 disasm_min_opcode_bytes() const override { return 1; }
@@ -112,7 +112,7 @@ protected:
 	inline void set_OFB_Add(UINT32 x,UINT32 y,UINT32 z);
 	inline void set_OFW_Sub(UINT32 x,UINT32 y,UINT32 z);
 	inline void set_OFB_Sub(UINT32 x,UINT32 y,UINT32 z);
-	inline UINT16 CompressFlags();
+	inline UINT16 CompressFlags() const;
 	inline void ExpandFlags(UINT16 f);
 
 	// rep instructions

--- a/src/devices/cpu/v810/v810.cpp
+++ b/src/devices/cpu/v810/v810.cpp
@@ -1314,7 +1314,7 @@ void v810_device::device_start()
 	m_icountptr = &m_icount;
 }
 
-void v810_device::state_string_export(const device_state_entry &entry, std::string &str)
+void v810_device::state_string_export(const device_state_entry &entry, std::string &str) const
 {
 	switch (entry.index())
 	{

--- a/src/devices/cpu/v810/v810.h
+++ b/src/devices/cpu/v810/v810.h
@@ -101,7 +101,7 @@ protected:
 	virtual const address_space_config *memory_space_config(address_spacenum spacenum = AS_0) const override { return (spacenum == AS_PROGRAM) ? &m_program_config : ((spacenum == AS_IO) ? &m_io_config : nullptr); }
 
 	// device_state_interface overrides
-	void state_string_export(const device_state_entry &entry, std::string &str) override;
+	virtual void state_string_export(const device_state_entry &entry, std::string &str) const override;
 
 	// device_disasm_interface overrides
 	virtual UINT32 disasm_min_opcode_bytes() const override { return 2; }

--- a/src/devices/cpu/z180/z180.cpp
+++ b/src/devices/cpu/z180/z180.cpp
@@ -2560,7 +2560,7 @@ void z180_device::state_export(const device_state_entry &entry)
 	}
 }
 
-void z180_device::state_string_export(const device_state_entry &entry, std::string &str)
+void z180_device::state_string_export(const device_state_entry &entry, std::string &str) const
 {
 	switch (entry.index())
 	{

--- a/src/devices/cpu/z180/z180.h
+++ b/src/devices/cpu/z180/z180.h
@@ -152,7 +152,7 @@ protected:
 	// device_state_interface overrides
 	virtual void state_import(const device_state_entry &entry) override;
 	virtual void state_export(const device_state_entry &entry) override;
-	void state_string_export(const device_state_entry &entry, std::string &str) override;
+	virtual void state_string_export(const device_state_entry &entry, std::string &str) const override;
 
 	// device_disasm_interface overrides
 	virtual UINT32 disasm_min_opcode_bytes() const override { return 1; }

--- a/src/devices/cpu/z8/z8.cpp
+++ b/src/devices/cpu/z8/z8.cpp
@@ -677,9 +677,8 @@ void z8_device::device_start()
 		state_add(Z8_T1,         "T1",        m_t1);
 		state_add(STATE_GENFLAGS, "GENFLAGS", m_r[Z8_REGISTER_FLAGS]).noshow().formatstr("%6s");
 
-		std::string tempstr;
 		for (int regnum = 0; regnum < 16; regnum++)
-			state_add(Z8_R0 + regnum, strformat(tempstr, "R%d", regnum).c_str(), m_fake_r[regnum]).callimport().callexport();
+			state_add(Z8_R0 + regnum, strformat("R%d", regnum).c_str(), m_fake_r[regnum]).callimport().callexport();
 	}
 
 	/* find address spaces */
@@ -806,7 +805,7 @@ void z8_device::state_export(const device_state_entry &entry)
 	}
 }
 
-void z8_device::state_string_export(const device_state_entry &entry, std::string &str)
+void z8_device::state_string_export(const device_state_entry &entry, std::string &str) const
 {
 	switch (entry.index())
 	{

--- a/src/devices/cpu/z8/z8.h
+++ b/src/devices/cpu/z8/z8.h
@@ -59,7 +59,7 @@ protected:
 	// device_state_interface overrides
 	virtual void state_import(const device_state_entry &entry) override;
 	virtual void state_export(const device_state_entry &entry) override;
-	void state_string_export(const device_state_entry &entry, std::string &str) override;
+	virtual void state_string_export(const device_state_entry &entry, std::string &str) const override;
 
 	// device_disasm_interface overrides
 	virtual UINT32 disasm_min_opcode_bytes() const override { return 1; }

--- a/src/devices/cpu/z80/z80.cpp
+++ b/src/devices/cpu/z80/z80.cpp
@@ -3666,7 +3666,7 @@ void z80_device::state_export( const device_state_entry &entry )
 	}
 }
 
-void z80_device::state_string_export(const device_state_entry &entry, std::string &str)
+void z80_device::state_string_export(const device_state_entry &entry, std::string &str) const
 {
 	switch (entry.index())
 	{

--- a/src/devices/cpu/z80/z80.h
+++ b/src/devices/cpu/z80/z80.h
@@ -68,7 +68,7 @@ protected:
 	// device_state_interface overrides
 	virtual void state_import(const device_state_entry &entry) override;
 	virtual void state_export(const device_state_entry &entry) override;
-	virtual void state_string_export(const device_state_entry &entry, std::string &str) override;
+	virtual void state_string_export(const device_state_entry &entry, std::string &str) const override;
 
 	// device_disasm_interface overrides
 	virtual UINT32 disasm_min_opcode_bytes() const override { return 1; }

--- a/src/devices/cpu/z8000/z8000.cpp
+++ b/src/devices/cpu/z8000/z8000.cpp
@@ -616,7 +616,7 @@ void z8002_device::register_debug_state()
 	state_add( STATE_GENSP, "GENSP", m_nspoff ).noshow();
 }
 
-void z8002_device::state_string_export(const device_state_entry &entry, std::string &str)
+void z8002_device::state_string_export(const device_state_entry &entry, std::string &str) const
 {
 	switch (entry.index())
 	{

--- a/src/devices/cpu/z8000/z8000.h
+++ b/src/devices/cpu/z8000/z8000.h
@@ -67,7 +67,7 @@ protected:
 	}
 
 	// device_state_interface overrides
-	void state_string_export(const device_state_entry &entry, std::string &str) override;
+	virtual void state_string_export(const device_state_entry &entry, std::string &str) const override;
 
 	// device_disasm_interface overrides
 	virtual UINT32 disasm_min_opcode_bytes() const override { return 2; }

--- a/src/devices/machine/netlist.h
+++ b/src/devices/machine/netlist.h
@@ -220,7 +220,7 @@ protected:
 
 	//  device_state_interface overrides
 
-	virtual void state_string_export(const device_state_entry &entry, std::string &str) override
+	virtual void state_string_export(const device_state_entry &entry, std::string &str) const override
 	{
 		if (entry.index() >= 0)
 		{

--- a/src/emu/audit.cpp
+++ b/src/emu/audit.cpp
@@ -369,10 +369,9 @@ media_auditor::summary media_auditor::summarize(const char *name, std::string *o
 			case audit_record::SUBSTATUS_FOUND_BAD_CHECKSUM:
 				if (output != nullptr)
 				{
-					std::string tempstr;
 					strcatprintf(*output,"INCORRECT CHECKSUM:\n");
-					strcatprintf(*output,"EXPECTED: %s\n", record->expected_hashes().macro_string(tempstr));
-					strcatprintf(*output,"   FOUND: %s\n", record->actual_hashes().macro_string(tempstr));
+					strcatprintf(*output,"EXPECTED: %s\n", record->expected_hashes().macro_string().c_str());
+					strcatprintf(*output,"   FOUND: %s\n", record->actual_hashes().macro_string().c_str());
 				}
 				break;
 

--- a/src/emu/cheat.cpp
+++ b/src/emu/cheat.cpp
@@ -102,28 +102,23 @@
 //  the format
 //-------------------------------------------------
 
-inline const char *number_and_format::format(std::string &str) const
+inline std::string number_and_format::format() const
 {
 	switch (m_format)
 	{
 		default:
 		case XML_INT_FORMAT_DECIMAL:
-			strprintf(str, "%d", (UINT32)m_value);
-			break;
+			return strformat("%d", (UINT32)m_value);
 
 		case XML_INT_FORMAT_DECIMAL_POUND:
-			strprintf(str, "#%d", (UINT32)m_value);
-			break;
+			return strformat("#%d", (UINT32)m_value);
 
 		case XML_INT_FORMAT_HEX_DOLLAR:
-			strprintf(str, "$%X", (UINT32)m_value);
-			break;
+			return strformat("$%X", (UINT32)m_value);
 
 		case XML_INT_FORMAT_HEX_C:
-			strprintf(str, "0x%X", (UINT32)m_value);
-			break;
+			return strformat("0x%X", (UINT32)m_value);
 	}
-	return str.c_str();
 }
 
 
@@ -206,15 +201,14 @@ void cheat_parameter::save(emu_file &cheatfile) const
 	cheatfile.printf("\t\t<parameter");
 
 	// if no items, just output min/max/step
-	std::string str;
 	if (!has_itemlist())
 	{
 		if (m_minval != 0)
-			cheatfile.printf(" min=\"%s\"", m_minval.format(str));
+			cheatfile.printf(" min=\"%s\"", m_minval.format().c_str());
 		if (m_maxval != 0)
-			cheatfile.printf(" max=\"%s\"", m_maxval.format(str));
+			cheatfile.printf(" max=\"%s\"", m_maxval.format().c_str());
 		if (m_stepval != 1)
-			cheatfile.printf(" step=\"%s\"", m_stepval.format(str));
+			cheatfile.printf(" step=\"%s\"", m_stepval.format().c_str());
 		cheatfile.printf("/>\n");
 	}
 
@@ -222,7 +216,7 @@ void cheat_parameter::save(emu_file &cheatfile) const
 	else
 	{
 		for (const item *curitem = m_itemlist.first(); curitem != nullptr; curitem = curitem->next())
-			cheatfile.printf("\t\t\t<item value=\"%s\">%s</item>\n", curitem->value().format(str), curitem->text());
+			cheatfile.printf("\t\t\t<item value=\"%s\">%s</item>\n", curitem->value().format().c_str(), curitem->text());
 		cheatfile.printf("\t\t</parameter>\n");
 	}
 }
@@ -527,15 +521,13 @@ void cheat_script::script_entry::execute(cheat_manager &manager, UINT64 &arginde
 
 void cheat_script::script_entry::save(emu_file &cheatfile) const
 {
-	std::string tempstring;
-
 	// output an action
 	if (m_format.empty())
 	{
 		cheatfile.printf("\t\t\t<action");
 		if (!m_condition.is_empty())
-			cheatfile.printf(" condition=\"%s\"", cheat_manager::quote_expression(tempstring, m_condition));
-		cheatfile.printf(">%s</action>\n", cheat_manager::quote_expression(tempstring, m_expression));
+			cheatfile.printf(" condition=\"%s\"", cheat_manager::quote_expression(m_condition).c_str());
+		cheatfile.printf(">%s</action>\n", cheat_manager::quote_expression(m_expression).c_str());
 	}
 
 	// output an output
@@ -543,7 +535,7 @@ void cheat_script::script_entry::save(emu_file &cheatfile) const
 	{
 		cheatfile.printf("\t\t\t<output format=\"%s\"", m_format.c_str());
 		if (!m_condition.is_empty())
-			cheatfile.printf(" condition=\"%s\"", cheat_manager::quote_expression(tempstring, m_condition));
+			cheatfile.printf(" condition=\"%s\"", cheat_manager::quote_expression(m_condition).c_str());
 		if (m_line != 0)
 			cheatfile.printf(" line=\"%d\"", m_line);
 		if (m_justify == JUSTIFY_CENTER)
@@ -661,12 +653,10 @@ int cheat_script::script_entry::output_argument::values(UINT64 &argindex, UINT64
 
 void cheat_script::script_entry::output_argument::save(emu_file &cheatfile) const
 {
-	std::string tempstring;
-
 	cheatfile.printf("\t\t\t\t<argument");
 	if (m_count != 1)
 		cheatfile.printf(" count=\"%d\"", (int)m_count);
-	cheatfile.printf(">%s</argument>\n", cheat_manager::quote_expression(tempstring, m_expression));
+	cheatfile.printf(">%s</argument>\n", cheat_manager::quote_expression(m_expression).c_str());
 }
 
 
@@ -706,10 +696,8 @@ cheat_entry::cheat_entry(cheat_manager &manager, symbol_table &globaltable, cons
 
 		// create the symbol table
 		m_symbols.add("argindex", symbol_table::READ_ONLY, &m_argindex);
-		std::string tempname;
 		for (int curtemp = 0; curtemp < tempcount; curtemp++) {
-			strprintf(tempname,"temp%d", curtemp);
-			m_symbols.add(tempname.c_str(), symbol_table::READ_WRITE);
+			m_symbols.add(strformat("temp%d", curtemp).c_str(), symbol_table::READ_WRITE);
 		}
 
 		// read the first comment node
@@ -1267,9 +1255,9 @@ std::string &cheat_manager::get_output_astring(int row, int justify)
 //  document
 //-------------------------------------------------
 
-const char *cheat_manager::quote_expression(std::string &str, const parsed_expression &expression)
+std::string cheat_manager::quote_expression(const parsed_expression &expression)
 {
-	str.assign(expression.original_string());
+	std::string str = expression.original_string();
 
 	strreplace(str, " && ", " and ");
 	strreplace(str, " &&", " and ");
@@ -1296,7 +1284,7 @@ const char *cheat_manager::quote_expression(std::string &str, const parsed_expre
 	strreplace(str, "<< ", " lshift ");
 	strreplace(str, "<<", " lshift ");
 
-	return str.c_str();
+	return str;
 }
 
 

--- a/src/emu/cheat.h
+++ b/src/emu/cheat.h
@@ -56,7 +56,7 @@ public:
 	operator const UINT64 &() const { return m_value; }
 
 	// format the number according to its format
-	const char *format(std::string &str) const;
+	std::string format() const;
 
 private:
 	// internal state
@@ -308,7 +308,7 @@ public:
 	std::string &get_output_astring(int row, int justify);
 
 	// global helpers
-	static const char *quote_expression(std::string &str, const parsed_expression &expression);
+	static std::string quote_expression(const parsed_expression &expression);
 	static UINT64 execute_frombcd(symbol_table &table, void *ref, int params, const UINT64 *param);
 	static UINT64 execute_tobcd(symbol_table &table, void *ref, int params, const UINT64 *param);
 

--- a/src/emu/clifront.cpp
+++ b/src/emu/clifront.cpp
@@ -184,8 +184,7 @@ int cli_frontend::execute(int argc, char **argv)
 			osd_printf_error("Error in command line:\n%s\n", strtrimspace(option_errors).c_str());
 
 		// determine the base name of the EXE
-		std::string exename;
-		core_filename_extract_base(exename, argv[0], true);
+		std::string exename = core_filename_extract_base(argv[0], true);
 
 		// if we have a command, execute that
 		if (*(m_options.command()) != 0)
@@ -321,9 +320,8 @@ void cli_frontend::listsource(const char *gamename)
 		throw emu_fatalerror(MAMERR_NO_SUCH_GAME, "No matching games found for '%s'", gamename);
 
 	// iterate through drivers and output the info
-	std::string filename;
 	while (drivlist.next())
-		osd_printf_info("%-16s %s\n", drivlist.driver().name, core_filename_extract_base(filename, drivlist.driver().source_file).c_str());
+		osd_printf_info("%-16s %s\n", drivlist.driver().name, core_filename_extract_base(drivlist.driver().source_file).c_str());
 }
 
 
@@ -409,11 +407,10 @@ void cli_frontend::listbrothers(const char *gamename)
 
 	// output the entries found
 	drivlist.reset();
-	std::string filename;
 	while (drivlist.next())
 	{
 		int clone_of = drivlist.clone();
-		osd_printf_info("%-16s %-16s %-16s\n", core_filename_extract_base(filename, drivlist.driver().source_file).c_str(), drivlist.driver().name, (clone_of == -1 ? "" : drivlist.driver(clone_of).name));
+		osd_printf_info("%-16s %-16s %-16s\n", core_filename_extract_base(drivlist.driver().source_file).c_str(), drivlist.driver().name, (clone_of == -1 ? "" : drivlist.driver(clone_of).name));
 	}
 }
 
@@ -460,7 +457,6 @@ void cli_frontend::listroms(const char *gamename)
 		throw emu_fatalerror(MAMERR_NO_SUCH_GAME, "No matching games found for '%s'", gamename);
 
 	// iterate through matches
-	std::string tempstr;
 	bool first = true;
 	while (drivlist.next())
 	{
@@ -498,7 +494,7 @@ void cli_frontend::listroms(const char *gamename)
 					{
 						if (hashes.flag(hash_collection::FLAG_BAD_DUMP))
 							osd_printf_info(" BAD");
-						osd_printf_info(" %s", hashes.macro_string(tempstr));
+						osd_printf_info(" %s", hashes.macro_string().c_str());
 					}
 					else
 						osd_printf_info(" NO GOOD DUMP KNOWN");
@@ -1174,8 +1170,6 @@ void cli_frontend::verifysamples(const char *gamename)
 
 void cli_frontend::output_single_softlist(FILE *out, software_list_device &swlistdev)
 {
-	std::string tempstr;
-
 	fprintf(out, "\t<softwarelist name=\"%s\" description=\"%s\">\n", swlistdev.list_name(), xml_normalize_string(swlistdev.description()));
 	for (software_info *swinfo = swlistdev.first_software_info(); swinfo != nullptr; swinfo = swinfo->next())
 	{
@@ -1227,7 +1221,7 @@ void cli_frontend::output_single_softlist(FILE *out, software_list_device &swlis
 						/* dump checksum information only if there is a known dump */
 						hash_collection hashes(ROM_GETHASHDATA(rom));
 						if ( !hashes.flag(hash_collection::FLAG_NO_DUMP) )
-							fprintf( out, " %s", hashes.attribute_string(tempstr) );
+							fprintf( out, " %s", hashes.attribute_string().c_str() );
 						else
 							fprintf( out, " status=\"nodump\"" );
 
@@ -1592,9 +1586,8 @@ void cli_frontend::execute_commands(const char *exename)
 	// showusage?
 	if (strcmp(m_options.command(), CLICOMMAND_SHOWUSAGE) == 0)
 	{
-		std::string helpstring;
 		emulator_info::printf_usage(exename, emulator_info::get_gamenoun());
-		osd_printf_info("\n\nOptions:\n%s", m_options.output_help(helpstring));
+		osd_printf_info("\n\nOptions:\n%s", m_options.output_help().c_str());
 		return;
 	}
 
@@ -1623,8 +1616,7 @@ void cli_frontend::execute_commands(const char *exename)
 			throw emu_fatalerror("Unable to create file %s.ini\n",emulator_info::get_configname());
 
 		// generate the updated INI
-		std::string initext;
-		file.puts(m_options.output_ini(initext));
+		file.puts(m_options.output_ini().c_str());
 		return;
 	}
 
@@ -1632,8 +1624,7 @@ void cli_frontend::execute_commands(const char *exename)
 	if (strcmp(m_options.command(), CLICOMMAND_SHOWCONFIG) == 0)
 	{
 		// print the INI text
-		std::string initext;
-		printf("%s\n", m_options.output_ini(initext));
+		printf("%s\n", m_options.output_ini().c_str());
 		return;
 	}
 
@@ -1834,8 +1825,7 @@ void media_identifier::identify_file(const char *name)
 	if (core_filename_ends_with(name, ".chd"))
 	{
 		// output the name
-		std::string basename;
-		osd_printf_info("%-20s", core_filename_extract_base(basename, name).c_str());
+		osd_printf_info("%-20s", core_filename_extract_base(name).c_str());
 		m_total++;
 
 		// attempt to open as a CHD; fail if not
@@ -1910,8 +1900,7 @@ void media_identifier::identify_data(const char *name, const UINT8 *data, int le
 
 	// output the name
 	m_total++;
-	std::string basename;
-	osd_printf_info("%-20s", core_filename_extract_base(basename, name).c_str());
+	osd_printf_info("%-20s", core_filename_extract_base(name).c_str());
 
 	// see if we can find a match in the ROMs
 	int found = find_by_hash(hashes, length);

--- a/src/emu/debug/dvstate.cpp
+++ b/src/emu/debug/dvstate.cpp
@@ -276,7 +276,7 @@ void debug_view_state::view_update()
 				if (m_last_update != total_cycles)
 					curitem->m_lastval = curitem->m_currval;
 				curitem->m_currval = source.m_stateintf->state_int(curitem->m_index);
-				source.m_stateintf->state_string(curitem->m_index, valstr);
+				valstr = source.m_stateintf->state_string(curitem->m_index);
 			}
 
 			// see if we changed

--- a/src/emu/devcb.h
+++ b/src/emu/devcb.h
@@ -295,8 +295,8 @@ class devcb_read_line : public devcb_read_base
 {
 public:
 	devcb_read_line(device_t &device) : devcb_read_base(device, 0xff) { }
-	int operator()() { return (this->*m_adapter)(*m_space, 0, U64(0xff)) & 1; }
-	int operator()(address_space &space) { return (this->*m_adapter)((m_space_tag != nullptr) ? *m_space : space, 0, U64(0xff)) & 1; }
+	int operator()() const { return (this->*m_adapter)(*m_space, 0, U64(0xff)) & 1; }
+	int operator()(address_space &space) const { return (this->*m_adapter)((m_space_tag != nullptr) ? *m_space : space, 0, U64(0xff)) & 1; }
 };
 
 
@@ -306,8 +306,8 @@ class devcb_read8 : public devcb_read_base
 {
 public:
 	devcb_read8(device_t &device) : devcb_read_base(device, 0xff) { }
-	UINT8 operator()(offs_t offset = 0, UINT8 mask = 0xff) { return (this->*m_adapter)(*m_space, offset, mask) & mask; }
-	UINT8 operator()(address_space &space, offs_t offset = 0, UINT8 mask = 0xff) { return (this->*m_adapter)((m_space_tag != nullptr) ? *m_space : space, offset, mask) & mask; }
+	UINT8 operator()(offs_t offset = 0, UINT8 mask = 0xff) const { return (this->*m_adapter)(*m_space, offset, mask) & mask; }
+	UINT8 operator()(address_space &space, offs_t offset = 0, UINT8 mask = 0xff) const { return (this->*m_adapter)((m_space_tag != nullptr) ? *m_space : space, offset, mask) & mask; }
 };
 
 
@@ -317,8 +317,8 @@ class devcb_read16 : public devcb_read_base
 {
 public:
 	devcb_read16(device_t &device) : devcb_read_base(device, 0xffff) { }
-	UINT16 operator()(offs_t offset = 0, UINT16 mask = 0xffff) { return (this->*m_adapter)(*m_space, offset, mask) & mask; }
-	UINT16 operator()(address_space &space, offs_t offset = 0, UINT16 mask = 0xffff) { return (this->*m_adapter)((m_space_tag != nullptr) ? *m_space : space, offset, mask) & mask; }
+	UINT16 operator()(offs_t offset = 0, UINT16 mask = 0xffff) const { return (this->*m_adapter)(*m_space, offset, mask) & mask; }
+	UINT16 operator()(address_space &space, offs_t offset = 0, UINT16 mask = 0xffff) const { return (this->*m_adapter)((m_space_tag != nullptr) ? *m_space : space, offset, mask) & mask; }
 };
 
 
@@ -328,8 +328,8 @@ class devcb_read32 : public devcb_read_base
 {
 public:
 	devcb_read32(device_t &device) : devcb_read_base(device, 0xffffffff) { }
-	UINT32 operator()(offs_t offset = 0, UINT32 mask = 0xffffffff) { return (this->*m_adapter)(*m_space, offset, mask) & mask; }
-	UINT32 operator()(address_space &space, offs_t offset = 0, UINT32 mask = 0xffffffff) { return (this->*m_adapter)((m_space_tag != nullptr) ? *m_space : space, offset, mask) & mask; }
+	UINT32 operator()(offs_t offset = 0, UINT32 mask = 0xffffffff) const { return (this->*m_adapter)(*m_space, offset, mask) & mask; }
+	UINT32 operator()(address_space &space, offs_t offset = 0, UINT32 mask = 0xffffffff) const { return (this->*m_adapter)((m_space_tag != nullptr) ? *m_space : space, offset, mask) & mask; }
 };
 
 
@@ -339,8 +339,8 @@ class devcb_read64 : public devcb_read_base
 {
 public:
 	devcb_read64(device_t &device) : devcb_read_base(device, U64(0xffffffffffffffff)) { }
-	UINT64 operator()(offs_t offset = 0, UINT64 mask = U64(0xffffffffffffffff)) { return (this->*m_adapter)(*m_space, offset, mask) & mask; }
-	UINT64 operator()(address_space &space, offs_t offset = 0, UINT64 mask = U64(0xffffffffffffffff)) { return (this->*m_adapter)((m_space_tag != nullptr) ? *m_space : space, offset, mask) & mask; }
+	UINT64 operator()(offs_t offset = 0, UINT64 mask = U64(0xffffffffffffffff)) const { return (this->*m_adapter)(*m_space, offset, mask) & mask; }
+	UINT64 operator()(address_space &space, offs_t offset = 0, UINT64 mask = U64(0xffffffffffffffff)) const { return (this->*m_adapter)((m_space_tag != nullptr) ? *m_space : space, offset, mask) & mask; }
 };
 
 

--- a/src/emu/devfind.h
+++ b/src/emu/devfind.h
@@ -270,7 +270,7 @@ public:
 	{
 		for (int index = 0; index < _Count; index++)
 		{
-			strformat(m_tag[index], "%s.%d", basetag, index);
+			strprintf(m_tag[index], "%s.%d", basetag, index);
 			m_array[index] = std::make_unique<ioport_finder_type>(base, m_tag[index].c_str());
 		}
 	}
@@ -441,7 +441,7 @@ public:
 	{
 		for (int index = 0; index < _Count; index++)
 		{
-			strformat(m_tag[index],"%s.%d", basetag, index);
+			strprintf(m_tag[index],"%s.%d", basetag, index);
 			m_array[index] = std::make_unique<shared_ptr_type>(base, m_tag[index].c_str(), width);
 		}
 	}

--- a/src/emu/diimage.cpp
+++ b/src/emu/diimage.cpp
@@ -711,9 +711,8 @@ void device_image_interface::determine_open_plan(int is_create, UINT32 *open_pla
 
 static void dump_wrong_and_correct_checksums(const hash_collection &hashes, const hash_collection &acthashes)
 {
-	std::string tempstr;
-	osd_printf_error("    EXPECTED: %s\n", hashes.macro_string(tempstr));
-	osd_printf_error("       FOUND: %s\n", acthashes.macro_string(tempstr));
+	osd_printf_error("    EXPECTED: %s\n", hashes.macro_string().c_str());
+	osd_printf_error("       FOUND: %s\n", acthashes.macro_string().c_str());
 }
 
 /*-------------------------------------------------
@@ -735,8 +734,7 @@ static int verify_length_and_hash(emu_file *file, const char *name, UINT32 exple
 	}
 
 	/* If there is no good dump known, write it */
-	std::string tempstr;
-	hash_collection &acthashes = file->hashes(hashes.hash_types(tempstr));
+	hash_collection &acthashes = file->hashes(hashes.hash_types().c_str());
 	if (hashes.flag(hash_collection::FLAG_NO_DUMP))
 	{
 		osd_printf_error("%s NO GOOD DUMP KNOWN\n", name);
@@ -1209,7 +1207,7 @@ void device_image_interface::software_name_split(const char *swlist_swname, std:
 }
 
 
-software_part *device_image_interface::find_software_item(const char *path, bool restrict_to_interface)
+software_part *device_image_interface::find_software_item(const char *path, bool restrict_to_interface) const
 {
 	// split full software name into software list name and short software name
 	std::string swlist_name, swinfo_name, swpart_name;
@@ -1307,7 +1305,7 @@ bool device_image_interface::load_software_part(const char *path, software_part 
 					{
 						const char *option = device().mconfig().options().value(req_image->brief_instance_name());
 						// mount only if not already mounted
-						if (strlen(option) == 0 && !req_image->filename())
+						if (*option == '\0' && !req_image->filename())
 						{
 							req_image->set_init_phase();
 							req_image->load(requirement);
@@ -1325,11 +1323,11 @@ bool device_image_interface::load_software_part(const char *path, software_part 
 //  software_get_default_slot
 //-------------------------------------------------
 
-void device_image_interface::software_get_default_slot(std::string &result, const char *default_card_slot)
+std::string device_image_interface::software_get_default_slot(const char *default_card_slot) const
 {
 	const char *path = device().mconfig().options().value(instance_name());
-	result.clear();
-	if (strlen(path) > 0)
+	std::string result;
+	if (*path != '\0')
 	{
 		result.assign(default_card_slot);
 		software_part *swpart = find_software_item(path, true);
@@ -1340,6 +1338,7 @@ void device_image_interface::software_get_default_slot(std::string &result, cons
 				result.assign(slot);
 		}
 	}
+	return result;
 }
 
 /*-------------------------------------------------

--- a/src/emu/diimage.h
+++ b/src/emu/diimage.h
@@ -257,9 +257,9 @@ protected:
 	void image_checkhash();
 	void update_names(const device_type device_type = nullptr, const char *inst = nullptr, const char *brief = nullptr);
 
-	software_part *find_software_item(const char *path, bool restrict_to_interface);
+	software_part *find_software_item(const char *path, bool restrict_to_interface) const;
 	bool load_software_part(const char *path, software_part *&swpart);
-	void software_get_default_slot(std::string &result, const char *default_card_slot);
+	std::string software_get_default_slot(const char *default_card_slot) const;
 
 	// derived class overrides
 

--- a/src/emu/dislot.cpp
+++ b/src/emu/dislot.cpp
@@ -63,17 +63,15 @@ device_slot_option *device_slot_interface::static_option(device_t &device, const
 
 device_t* device_slot_interface::get_card_device()
 {
-	const char *subtag;
+	std::string subtag;
 	device_t *dev = nullptr;
-	std::string temp;
-	if (!device().mconfig().options().exists(device().tag()+1)) {
-		subtag = m_default_option;
-	} else {
-		subtag = device().mconfig().options().main_value(temp,device().tag()+1);
-	}
-	if (subtag && *subtag != 0) {
+	if (device().mconfig().options().exists(device().tag()+1))
+		subtag = device().mconfig().options().main_value(device().tag()+1);
+	else if (m_default_option != nullptr)
+		subtag.assign(m_default_option);
+	if (!subtag.empty()) {
 		device_slot_card_interface *intf = nullptr;
-		dev = device().subdevice(subtag);
+		dev = device().subdevice(subtag.c_str());
 		if (dev!=nullptr && !dev->interface(intf))
 			throw emu_fatalerror("get_card_device called for device '%s' with no slot card interface", dev->tag());
 	}

--- a/src/emu/dislot.h
+++ b/src/emu/dislot.h
@@ -116,7 +116,7 @@ public:
 	const char *default_option() const { return m_default_option; }
 	device_slot_option *first_option() const { return m_options.first(); }
 	device_slot_option *option(const char *name) const { if (name) return m_options.find(name); return nullptr; }
-	virtual void get_default_card_software(std::string &result) { result.clear(); }
+	virtual std::string get_default_card_software() { return std::string(); }
 	device_t *get_card_device();
 
 private:

--- a/src/emu/distate.cpp
+++ b/src/emu/distate.cpp
@@ -113,8 +113,7 @@ device_state_entry &device_state_entry::formatstr(const char *_format)
 
 	// set the DSF_CUSTOM_STRING flag by formatting with a NULL string
 	m_flags &= ~DSF_CUSTOM_STRING;
-	std::string dummy;
-	format(dummy, nullptr);
+	format(nullptr);
 
 	return *this;
 }
@@ -164,8 +163,9 @@ UINT64 device_state_entry::value() const
 //  pieces of indexed state as a string
 //-------------------------------------------------
 
-std::string &device_state_entry::format(std::string &dest, const char *string, bool maxout) const
+std::string device_state_entry::format(const char *string, bool maxout) const
 {
+	std::string dest;
 	UINT64 result = value();
 
 	// parse the format
@@ -436,12 +436,12 @@ UINT64 device_state_interface::state_int(int index)
 //  pieces of indexed state as a string
 //-------------------------------------------------
 
-std::string &device_state_interface::state_string(int index, std::string &dest)
+std::string device_state_interface::state_string(int index) const
 {
 	// NULL or out-of-range entry returns bogus string
 	const device_state_entry *entry = state_find_entry(index);
 	if (entry == nullptr)
-		return dest.assign("???");
+		return std::string("???");
 
 	// get the custom string if needed
 	std::string custom;
@@ -449,7 +449,7 @@ std::string &device_state_interface::state_string(int index, std::string &dest)
 		state_string_export(*entry, custom);
 
 	// ask the entry to format itself
-	return entry->format(dest, custom.c_str());
+	return entry->format(custom.c_str());
 }
 
 
@@ -466,8 +466,7 @@ int device_state_interface::state_string_max_length(int index)
 		return 3;
 
 	// ask the entry to format itself maximally
-	std::string tempstring;
-	return entry->format(tempstring, "", true).length();
+	return entry->format("", true).length();
 }
 
 
@@ -591,7 +590,7 @@ void device_state_interface::state_string_import(const device_state_entry &entry
 //  written to perform any post-processing
 //-------------------------------------------------
 
-void device_state_interface::state_string_export(const device_state_entry &entry, std::string &str)
+void device_state_interface::state_string_export(const device_state_entry &entry, std::string &str) const
 {
 	// do nothing by default
 }
@@ -615,7 +614,7 @@ void device_state_interface::interface_post_start()
 //  state entry for the given index
 //-------------------------------------------------
 
-const device_state_entry *device_state_interface::state_find_entry(int index)
+const device_state_entry *device_state_interface::state_find_entry(int index) const
 {
 	// use fast lookup if possible
 	if (index >= FAST_STATE_MIN && index <= FAST_STATE_MAX)

--- a/src/emu/distate.h
+++ b/src/emu/distate.h
@@ -87,7 +87,7 @@ protected:
 	// return the current value -- only for our friends who handle export
 	bool needs_export() const { return ((m_flags & DSF_EXPORT) != 0); }
 	UINT64 value() const;
-	std::string &format(std::string &dest, const char *string, bool maxout = false) const;
+	std::string format(const char *string, bool maxout = false) const;
 
 	// set the current value -- only for our friends who handle import
 	bool needs_import() const { return ((m_flags & DSF_IMPORT) != 0); }
@@ -128,7 +128,7 @@ public:
 
 	// state getters
 	UINT64 state_int(int index);
-	std::string &state_string(int index, std::string &dest);
+	std::string state_string(int index) const;
 	int state_string_max_length(int index);
 	offs_t pc() { return state_int(STATE_GENPC); }
 	offs_t pcbase() { return state_int(STATE_GENPCBASE); }
@@ -163,13 +163,13 @@ protected:
 	virtual void state_import(const device_state_entry &entry);
 	virtual void state_export(const device_state_entry &entry);
 	virtual void state_string_import(const device_state_entry &entry, std::string &str);
-	virtual void state_string_export(const device_state_entry &entry, std::string &str);
+	virtual void state_string_export(const device_state_entry &entry, std::string &str) const;
 
 	// internal operation overrides
 	virtual void interface_post_start() override;
 
 	// find the entry for a given index
-	const device_state_entry *state_find_entry(int index);
+	const device_state_entry *state_find_entry(int index) const;
 
 	// constants
 	static const int FAST_STATE_MIN = -4;                           // range for fast state

--- a/src/emu/emuopts.cpp
+++ b/src/emu/emuopts.cpp
@@ -281,8 +281,7 @@ void emu_options::update_slot_options()
 		const char *name = slot->device().tag() + 1;
 		if (exists(name) && slot->first_option() != nullptr)
 		{
-			std::string defvalue;
-			slot->get_default_card_software(defvalue);
+			std::string defvalue = slot->get_default_card_software();
 			if (defvalue.length() > 0)
 			{
 				set_default_value(name, defvalue.c_str());
@@ -470,11 +469,10 @@ void emu_options::parse_standard_inis(std::string &error_string)
 	}
 
 	// next parse "source/<sourcefile>.ini"; if that doesn't exist, try <sourcefile>.ini
-	std::string sourcename;
-	core_filename_extract_base(sourcename, cursystem->source_file, true).insert(0, "source" PATH_SEPARATOR);
+	std::string sourcename = core_filename_extract_base(cursystem->source_file, true).insert(0, "source" PATH_SEPARATOR);
 	if (!parse_one_ini(sourcename.c_str(), OPTION_PRIORITY_SOURCE_INI, &error_string))
 	{
-		core_filename_extract_base(sourcename, cursystem->source_file, true);
+		sourcename = core_filename_extract_base(cursystem->source_file, true);
 		parse_one_ini(sourcename.c_str(), OPTION_PRIORITY_SOURCE_INI, &error_string);
 	}
 
@@ -501,8 +499,7 @@ void emu_options::parse_standard_inis(std::string &error_string)
 
 const game_driver *emu_options::system() const
 {
-	std::string tempstr;
-	int index = driver_list::find(core_filename_extract_base(tempstr, system_name(), true).c_str());
+	int index = driver_list::find(core_filename_extract_base(system_name(), true).c_str());
 	return (index != -1) ? &driver_list::driver(index) : nullptr;
 }
 
@@ -568,19 +565,19 @@ bool emu_options::parse_one_ini(const char *basename, int priority, std::string 
 }
 
 
-const char *emu_options::main_value(std::string &buffer, const char *name) const
+std::string emu_options::main_value(const char *name) const
 {
-	buffer = value(name);
+	std::string buffer = value(name);
 	int pos = buffer.find_first_of(',');
 	if (pos != -1)
 		buffer = buffer.substr(0, pos);
-	return buffer.c_str();
+	return buffer;
 }
 
-const char *emu_options::sub_value(std::string &buffer, const char *name, const char *subname) const
+std::string emu_options::sub_value(const char *name, const char *subname) const
 {
 	std::string tmp = std::string(",").append(subname).append("=");
-	buffer = value(name);
+	std::string buffer = value(name);
 	int pos = buffer.find(tmp);
 	if (pos != -1)
 	{
@@ -591,7 +588,7 @@ const char *emu_options::sub_value(std::string &buffer, const char *name, const 
 	}
 	else
 		buffer.clear();
-	return buffer.c_str();
+	return buffer;
 }
 
 

--- a/src/emu/emuopts.h
+++ b/src/emu/emuopts.h
@@ -368,8 +368,8 @@ public:
 	// FIXME: Couriersud: This should be in image_device_exit
 	void remove_device_options();
 
-	const char *main_value(std::string &buffer, const char *option) const;
-	const char *sub_value(std::string &buffer, const char *name, const char *subname) const;
+	std::string main_value(const char *option) const;
+	std::string sub_value(const char *name, const char *subname) const;
 	bool add_slot_options(bool isfirst);
 
 private:

--- a/src/emu/fileio.cpp
+++ b/src/emu/fileio.cpp
@@ -219,8 +219,7 @@ emu_file::operator core_file &()
 hash_collection &emu_file::hashes(const char *types)
 {
 	// determine the hashes we already have
-	std::string already_have;
-	m_hashes.hash_types(already_have);
+	std::string already_have = m_hashes.hash_types();
 
 	// determine which hashes we need
 	std::string needed;

--- a/src/emu/hash.cpp
+++ b/src/emu/hash.cpp
@@ -115,14 +115,14 @@ bool hash_collection::operator==(const hash_collection &rhs) const
 //  a string
 //-------------------------------------------------
 
-const char *hash_collection::hash_types(std::string &buffer) const
+std::string hash_collection::hash_types() const
 {
-	buffer.clear();
+	std::string buffer;
 	if (m_has_crc32)
 		buffer.push_back(HASH_CRC);
 	if (m_has_sha1)
 		buffer.push_back(HASH_SHA1);
-	return buffer.c_str();
+	return buffer;
 }
 
 
@@ -190,24 +190,24 @@ bool hash_collection::remove(char type)
 //  format
 //-------------------------------------------------
 
-const char *hash_collection::internal_string(std::string &buffer) const
+std::string hash_collection::internal_string() const
 {
-	buffer.clear();
+	std::string buffer;
 
 	// handle CRCs
-	std::string temp;
 	if (m_has_crc32) {
 		buffer.push_back(HASH_CRC);
-		buffer.append(m_crc32.as_string(temp));
+		buffer.append(m_crc32.as_string());
 	}
 	// handle SHA1s
 	if (m_has_sha1) {
 		buffer.push_back(HASH_SHA1);
-		buffer.append(m_sha1.as_string(temp));
+		buffer.append(m_sha1.as_string());
 	}
 
 	// append flags
-	return buffer.append(m_flags).c_str();
+	buffer.append(m_flags);
+	return buffer;
 }
 
 
@@ -216,18 +216,17 @@ const char *hash_collection::internal_string(std::string &buffer) const
 //  flags to a string in the macroized format
 //-------------------------------------------------
 
-const char *hash_collection::macro_string(std::string &buffer) const
+std::string hash_collection::macro_string() const
 {
-	buffer.clear();
+	std::string buffer;
 
 	// handle CRCs
-	std::string temp;
 	if (m_has_crc32)
-		buffer.append("CRC(").append(m_crc32.as_string(temp)).append(") ");
+		buffer.append("CRC(").append(m_crc32.as_string()).append(") ");
 
 	// handle SHA1s
 	if (m_has_sha1)
-		buffer.append("SHA1(").append(m_sha1.as_string(temp)).append(") ");
+		buffer.append("SHA1(").append(m_sha1.as_string()).append(") ");
 
 	// append flags
 	if (flag(FLAG_NO_DUMP))
@@ -235,7 +234,7 @@ const char *hash_collection::macro_string(std::string &buffer) const
 	if (flag(FLAG_BAD_DUMP))
 		buffer.append("BAD_DUMP ");
 	strtrimspace(buffer);
-	return buffer.c_str();
+	return buffer;
 }
 
 
@@ -244,18 +243,17 @@ const char *hash_collection::macro_string(std::string &buffer) const
 //  flags to a string in XML attribute format
 //-------------------------------------------------
 
-const char *hash_collection::attribute_string(std::string &buffer) const
+std::string hash_collection::attribute_string() const
 {
-	buffer.clear();
+	std::string buffer;
 
 	// handle CRCs
-	std::string temp;
 	if (m_has_crc32)
-		buffer.append("crc=\"").append(m_crc32.as_string(temp)).append("\" ");
+		buffer.append("crc=\"").append(m_crc32.as_string()).append("\" ");
 
 	// handle SHA1s
 	if (m_has_sha1)
-		buffer.append("sha1=\"").append(m_sha1.as_string(temp)).append("\" ");
+		buffer.append("sha1=\"").append(m_sha1.as_string()).append("\" ");
 
 	// append flags
 	if (flag(FLAG_NO_DUMP))
@@ -263,7 +261,7 @@ const char *hash_collection::attribute_string(std::string &buffer) const
 	if (flag(FLAG_BAD_DUMP))
 		buffer.append("status=\"baddump\"");
 	strtrimspace(buffer);
-	return buffer.c_str();
+	return buffer;
 }
 
 

--- a/src/emu/hash.h
+++ b/src/emu/hash.h
@@ -67,7 +67,7 @@ public:
 
 	// getters
 	bool flag(char flag) const { return (m_flags.find_first_of(flag) != std::string::npos); }
-	const char *hash_types(std::string &buffer) const;
+	std::string hash_types() const;
 
 	// hash manipulators
 	void reset();
@@ -83,9 +83,9 @@ public:
 	void add_sha1(sha1_t sha1) { m_has_sha1 = true; m_sha1 = sha1; }
 
 	// string conversion
-	const char *internal_string(std::string &buffer) const;
-	const char *macro_string(std::string &buffer) const;
-	const char *attribute_string(std::string &buffer) const;
+	std::string internal_string() const;
+	std::string macro_string() const;
+	std::string attribute_string() const;
 	bool from_internal_string(const char *string);
 
 	// creation

--- a/src/emu/image.cpp
+++ b/src/emu/image.cpp
@@ -141,8 +141,7 @@ static int write_config(emu_options &options, const char *filename, const game_d
 	file_error filerr = file.open(filename);
 	if (filerr == FILERR_NONE)
 	{
-		std::string inistring;
-		options.output_ini(inistring);
+		std::string inistring = options.output_ini();
 		file.puts(inistring.c_str());
 		retval = 0;
 	}

--- a/src/emu/info.cpp
+++ b/src/emu/info.cpp
@@ -572,8 +572,7 @@ void info_xml_creator::output_rom(device_t &device)
 				if (!hashes.flag(hash_collection::FLAG_NO_DUMP))
 				{
 					// iterate over hash function types and print m_output their values
-					std::string tempstr;
-					strcatprintf(output," %s", hashes.attribute_string(tempstr));
+					output.append(" ").append(hashes.attribute_string());
 				}
 				else
 					output.append(" status=\"nodump\"");
@@ -1306,11 +1305,8 @@ void info_xml_creator::output_slots(device_t &device, const char *root_tag)
 					fprintf(m_output, "\t\t\t<slotoption");
 					fprintf(m_output, " name=\"%s\"", xml_normalize_string(option->name()));
 					fprintf(m_output, " devname=\"%s\"", xml_normalize_string(dev->shortname()));
-					if (slot->default_option())
-					{
-						if (strcmp(slot->default_option(),option->name())==0)
-							fprintf(m_output, " default=\"yes\"");
-					}
+					if (slot->default_option() != nullptr && strcmp(slot->default_option(),option->name())==0)
+						fprintf(m_output, " default=\"yes\"");
 					fprintf(m_output, "/>\n");
 					const_cast<machine_config &>(m_drivlist.config()).device_remove(&m_drivlist.config().root_device(), "dummy");
 				}

--- a/src/emu/input.h
+++ b/src/emu/input.h
@@ -365,7 +365,7 @@ public:
 	bool parse(const char *mapstring);
 
 	// create a friendly string
-	const char *to_string(std::string &str) const;
+	std::string to_string() const;
 
 	// update the state of a live map
 	UINT8 update(INT32 xaxisval, INT32 yaxisval);
@@ -654,8 +654,8 @@ public:
 	input_device *device_from_code(input_code code) const;
 	input_device_item *item_from_code(input_code code) const;
 	input_code code_from_itemid(input_item_id itemid) const;
-	const char *code_name(std::string &str, input_code code) const;
-	const char *code_to_token(std::string &str, input_code code) const;
+	std::string code_name(input_code code) const;
+	std::string code_to_token(input_code code) const;
 	input_code code_from_token(const char *_token);
 
 	// input sequence readers
@@ -668,8 +668,8 @@ public:
 	const input_seq &seq_poll_final() const { return m_poll_seq; }
 
 	// input sequence helpers
-	const char *seq_name(std::string &str, const input_seq &seq) const;
-	const char *seq_to_tokens(std::string &str, const input_seq &seq) const;
+	std::string seq_name(const input_seq &seq) const;
+	std::string seq_to_tokens(const input_seq &seq) const;
 	void seq_from_tokens(input_seq &seq, const char *_token);
 
 	// misc

--- a/src/emu/ioport.h
+++ b/src/emu/ioport.h
@@ -830,7 +830,7 @@ public:
 	void post_coded(const char *text, size_t length = 0, const attotime &rate = attotime::zero);
 
 	void frame_update(ioport_port &port, ioport_value &digital);
-	const char *key_name(std::string &str, unicode_char ch);
+	std::string key_name(unicode_char ch) const;
 
 	// debugging
 	std::string dump();
@@ -850,7 +850,7 @@ private:
 	attotime choose_delay(unicode_char ch);
 	void internal_post(unicode_char ch);
 	void timer(void *ptr, int param);
-	const char *unicode_to_string(std::string &buffer, unicode_char ch);
+	std::string unicode_to_string(unicode_char ch);
 	const keycode_map_entry *find_code(unicode_char ch) const;
 
 	// internal state
@@ -1396,7 +1396,7 @@ public:
 	bool has_keyboard() const;
 	INT32 frame_interpolate(INT32 oldval, INT32 newval);
 	ioport_type token_to_input_type(const char *string, int &player) const;
-	const char *input_type_to_token(std::string &str, ioport_type type, int player);
+	std::string input_type_to_token(ioport_type type, int player);
 
 private:
 	// internal helpers

--- a/src/emu/machine.h
+++ b/src/emu/machine.h
@@ -246,13 +246,12 @@ private:
 	// internal helpers
 	void start();
 	void set_saveload_filename(const char *filename);
-	std::string get_statename(const char *statename_opt);
+	std::string get_statename(const char *statename_opt) const;
 	void handle_saveload();
 	void soft_reset(void *ptr = nullptr, INT32 param = 0);
 	void watchdog_fired(void *ptr = nullptr, INT32 param = 0);
 	void watchdog_vblank(screen_device &screen, bool vblank_state);
-	const char *image_parent_basename(device_t *device);
-	std::string &nvram_filename(std::string &result, device_t &device);
+	std::string nvram_filename(device_t &device) const;
 	void nvram_load();
 	void nvram_save();
 

--- a/src/emu/mconfig.cpp
+++ b/src/emu/mconfig.cpp
@@ -39,15 +39,16 @@ machine_config::machine_config(const game_driver &gamedrv, emu_options &options)
 	for (device_slot_interface *slot = slotiter.first(); slot != nullptr; slot = slotiter.next())
 	{
 		device_t &owner = slot->device();
-		std::string temp;
-		const char *selval = options.main_value(temp, owner.tag()+1);
+		std::string selval;
 		bool isdefault = (options.priority(owner.tag()+1)==OPTION_PRIORITY_DEFAULT);
-		if (!is_selected_driver || !options.exists(owner.tag()+1))
-			selval = slot->default_option();
+		if (is_selected_driver && options.exists(owner.tag()+1))
+			selval = options.main_value(owner.tag()+1);
+		else if (slot->default_option() != nullptr)
+			selval.assign(slot->default_option());
 
-		if (selval != nullptr && *selval != 0)
+		if (!selval.empty())
 		{
-			const device_slot_option *option = slot->option(selval);
+			const device_slot_option *option = slot->option(selval.c_str());
 
 			if (option && (isdefault || option->selectable()))
 			{
@@ -66,7 +67,7 @@ machine_config::machine_config(const game_driver &gamedrv, emu_options &options)
 					device_t::static_set_input_default(*new_dev, input_device_defaults);
 			}
 			else
-				throw emu_fatalerror("Unknown slot option '%s' in slot '%s'", selval, owner.tag()+1);
+				throw emu_fatalerror("Unknown slot option '%s' in slot '%s'", selval.c_str(), owner.tag()+1);
 		}
 	}
 

--- a/src/emu/romload.cpp
+++ b/src/emu/romload.cpp
@@ -474,9 +474,8 @@ static void handle_missing_file(romload_private *romdata, const rom_entry *romp,
 
 static void dump_wrong_and_correct_checksums(romload_private *romdata, const hash_collection &hashes, const hash_collection &acthashes)
 {
-	std::string tempstr;
-	strcatprintf(romdata->errorstring, "    EXPECTED: %s\n", hashes.macro_string(tempstr));
-	strcatprintf(romdata->errorstring, "       FOUND: %s\n", acthashes.macro_string(tempstr));
+	strcatprintf(romdata->errorstring, "    EXPECTED: %s\n", hashes.macro_string().c_str());
+	strcatprintf(romdata->errorstring, "       FOUND: %s\n", acthashes.macro_string().c_str());
 }
 
 
@@ -500,8 +499,7 @@ static void verify_length_and_hash(romload_private *romdata, const char *name, U
 	}
 
 	/* If there is no good dump known, write it */
-	std::string tempstr;
-	hash_collection &acthashes = romdata->file->hashes(hashes.hash_types(tempstr));
+	hash_collection &acthashes = romdata->file->hashes(hashes.hash_types().c_str());
 	if (hashes.flag(hash_collection::FLAG_NO_DUMP))
 	{
 		strcatprintf(romdata->errorstring, "%s NO GOOD DUMP KNOWN\n", name);
@@ -1538,17 +1536,16 @@ void rom_init(running_machine &machine)
 	device_iterator deviter(romdata->machine().config().root_device());
 	for (device_t *device = deviter.first(); device != nullptr; device = deviter.next()) {
 		if (device->rom_region()) {
-			const char *specbios;
-			std::string temp;
-			if (strcmp(device->tag(),":")==0) {
-				specbios = romdata->machine().options().bios();
+			std::string specbios;
+			if (device->owner() == nullptr) {
+				specbios.assign(romdata->machine().options().bios());
 			} else {
-				specbios = romdata->machine().options().sub_value(temp,device->owner()->tag()+1,"bios");
-				if (strlen(specbios) == 0) {
-					specbios = device->default_bios_tag().c_str();
+				specbios = romdata->machine().options().sub_value(device->owner()->tag()+1,"bios");
+				if (specbios.empty()) {
+					specbios = device->default_bios_tag();
 				}
 			}
-			determine_bios_rom(romdata, device, specbios);
+			determine_bios_rom(romdata, device, specbios.c_str());
 		}
 	}
 

--- a/src/emu/ui/inputmap.cpp
+++ b/src/emu/ui/inputmap.cpp
@@ -434,7 +434,7 @@ void ui_menu_input::populate_and_sort(input_item_data *itemlist)
 		/* otherwise, generate the sequence name and invert it if different from the default */
 		else
 		{
-			machine().input().seq_name(subtext, item->seq);
+			subtext = machine().input().seq_name(item->seq);
 			flags |= (item->seq != *item->defseq) ? MENU_FLAG_INVERT : 0;
 		}
 

--- a/src/emu/ui/miscmenu.cpp
+++ b/src/emu/ui/miscmenu.cpp
@@ -124,9 +124,8 @@ void ui_menu_bios_selection::handle()
 				assert(error.empty());
 			} else {
 				std::string error;
-				std::string value;
-				std::string temp;
-				strprintf(value,"%s,bios=%d",machine().options().main_value(temp,dev->owner()->tag()+1),val-1);
+				std::string value = machine().options().main_value(dev->owner()->tag()+1);
+				strcatprintf(value,",bios=%d",val-1);
 				machine().options().set_value(dev->owner()->tag()+1, value.c_str(), OPTION_PRIORITY_CMDLINE, error);
 				assert(error.empty());
 			}

--- a/src/emu/ui/selgame.cpp
+++ b/src/emu/ui/selgame.cpp
@@ -325,7 +325,7 @@ void ui_menu_select_game::custom_render(void *selectedref, float top, float bott
 		strprintf(tempbuf[1], "%s, %-.100s", driver->year, driver->manufacturer);
 
 		// next line source path
-		strprintf(tempbuf[2],"Driver: %-.100s", core_filename_extract_base(tempbuf[3], driver->source_file).c_str());
+		strprintf(tempbuf[2],"Driver: %-.100s", core_filename_extract_base(driver->source_file).c_str());
 
 		// next line is overall driver status
 		if (driver->flags & MACHINE_NOT_WORKING)

--- a/src/emu/ui/slotopt.cpp
+++ b/src/emu/ui/slotopt.cpp
@@ -21,18 +21,18 @@
 -------------------------------------------------*/
 device_slot_option *ui_menu_slot_devices::slot_get_current_option(device_slot_interface *slot)
 {
-	const char *current;
+	std::string current;
 	if (slot->fixed())
 	{
-		current = slot->default_option();
+		if (slot->default_option() == nullptr) return nullptr;
+		current.assign(slot->default_option());
 	}
 	else
 	{
-		std::string temp;
-		current = machine().options().main_value(temp, slot->device().tag() + 1);
+		current = machine().options().main_value(slot->device().tag() + 1);
 	}
 
-	return slot->option(current);
+	return slot->option(current.c_str());
 }
 
 /*-------------------------------------------------

--- a/src/emu/ui/ui.cpp
+++ b/src/emu/ui/ui.cpp
@@ -1153,8 +1153,7 @@ std::string &ui_manager::warnings_string(std::string &str)
 std::string &ui_manager::game_info_astring(std::string &str)
 {
 	// print description, manufacturer, and CPU:
-	std::string tempstr;
-	strprintf(str, "%s\n%s %s\nDriver: %s\n\nCPU:\n", machine().system().description, machine().system().year, machine().system().manufacturer, core_filename_extract_base(tempstr, machine().system().source_file).c_str());
+	strprintf(str, "%s\n%s %s\nDriver: %s\n\nCPU:\n", machine().system().description, machine().system().year, machine().system().manufacturer, core_filename_extract_base(machine().system().source_file).c_str());
 
 	// loop over all CPUs
 	execute_interface_iterator execiter(machine().root_device());
@@ -1489,7 +1488,7 @@ UINT32 ui_manager::handler_ingame(running_machine &machine, render_container *co
 	if (machine.ui().show_fps_counter())
 	{
 		std::string tempstring;
-		machine.ui().draw_text_full(container, machine.video().speed_text(tempstring).c_str(), 0.0f, 0.0f, 1.0f,
+		machine.ui().draw_text_full(container, machine.video().speed_text().c_str(), 0.0f, 0.0f, 1.0f,
 					JUSTIFY_RIGHT, WRAP_WORD, DRAW_OPAQUE, ARGB_WHITE, ARGB_BLACK, nullptr, nullptr);
 	}
 
@@ -1767,17 +1766,13 @@ void ui_manager::request_quit()
 UINT32 ui_manager::handler_confirm_quit(running_machine &machine, render_container *container, UINT32 state)
 {
 	// get the text for 'UI Select'
-	std::string ui_select_text;
-	machine.input().seq_name(ui_select_text, machine.ioport().type_seq(IPT_UI_SELECT, 0, SEQ_TYPE_STANDARD));
+	std::string ui_select_text = machine.input().seq_name(machine.ioport().type_seq(IPT_UI_SELECT, 0, SEQ_TYPE_STANDARD));
 
 	// get the text for 'UI Cancel'
-	std::string ui_cancel_text;
-	machine.input().seq_name(ui_cancel_text, machine.ioport().type_seq(IPT_UI_CANCEL, 0, SEQ_TYPE_STANDARD));
+	std::string ui_cancel_text = machine.input().seq_name(machine.ioport().type_seq(IPT_UI_CANCEL, 0, SEQ_TYPE_STANDARD));
 
 	// assemble the quit message
-	std::string quit_message;
-	strprintf(quit_message,
-		"Are you sure you want to quit?\n\n"
+	std::string quit_message = strformat("Are you sure you want to quit?\n\n"
 		"Press ''%s'' to quit,\n"
 		"Press ''%s'' to return to emulation.",
 		ui_select_text.c_str(),

--- a/src/emu/validity.cpp
+++ b/src/emu/validity.cpp
@@ -295,8 +295,7 @@ void validity_checker::validate_one(const game_driver &driver)
 	// if we had warnings or errors, output
 	if (m_errors > start_errors || m_warnings > start_warnings || !m_verbose_text.empty())
 	{
-		std::string tempstr;
-		output_via_delegate(OSD_OUTPUT_CHANNEL_ERROR, "Driver %s (file %s): %d errors, %d warnings\n", driver.name, core_filename_extract_base(tempstr, driver.source_file).c_str(), m_errors - start_errors, m_warnings - start_warnings);
+		output_via_delegate(OSD_OUTPUT_CHANNEL_ERROR, "Driver %s (file %s): %d errors, %d warnings\n", driver.name, core_filename_extract_base(driver.source_file).c_str(), m_errors - start_errors, m_warnings - start_warnings);
 		if (m_errors > start_errors)
 			output_indented_errors(m_error_text, "Errors");
 		if (m_warnings > start_warnings)
@@ -524,18 +523,17 @@ void validity_checker::validate_inlines()
 void validity_checker::validate_driver()
 {
 	// check for duplicate names
-	std::string tempstr;
 	if (!m_names_map.insert(std::make_pair(m_current_driver->name, m_current_driver)).second)
 	{
 		const game_driver *match = m_names_map.find(m_current_driver->name)->second;
-		osd_printf_error("Driver name is a duplicate of %s(%s)\n", core_filename_extract_base(tempstr, match->source_file).c_str(), match->name);
+		osd_printf_error("Driver name is a duplicate of %s(%s)\n", core_filename_extract_base(match->source_file).c_str(), match->name);
 	}
 
 	// check for duplicate descriptions
 	if (!m_descriptions_map.insert(std::make_pair(m_current_driver->description, m_current_driver)).second)
 	{
 		const game_driver *match = m_descriptions_map.find(m_current_driver->description)->second;
-		osd_printf_error("Driver description is a duplicate of %s(%s)\n", core_filename_extract_base(tempstr, match->source_file).c_str(), match->name);
+		osd_printf_error("Driver description is a duplicate of %s(%s)\n", core_filename_extract_base(match->source_file).c_str(), match->name);
 	}
 
 	// determine if we are a clone

--- a/src/emu/video.cpp
+++ b/src/emu/video.cpp
@@ -258,9 +258,9 @@ void video_manager::frame_update(bool debug)
 //  into a string buffer
 //-------------------------------------------------
 
-std::string &video_manager::speed_text(std::string &str)
+std::string video_manager::speed_text()
 {
-	str.clear();
+	std::string str;
 
 	// if we're paused, just display Paused
 	bool paused = machine().paused();

--- a/src/emu/video.h
+++ b/src/emu/video.h
@@ -81,7 +81,7 @@ public:
 	void frame_update(bool debug = false);
 
 	// current speed helpers
-	std::string &speed_text(std::string &str);
+	std::string speed_text();
 	double speed_percent() const { return m_speed_percent; }
 
 	// snapshots

--- a/src/lib/formats/cbm_crt.cpp
+++ b/src/lib/formats/cbm_crt.cpp
@@ -122,7 +122,7 @@ static const char * CRT_C64_SLOT_NAMES[_CRT_C64_COUNT] =
 //  cbm_crt_get_card - get slot interface card
 //-------------------------------------------------
 
-void cbm_crt_get_card(std::string &result, core_file *file)
+std::string cbm_crt_get_card(core_file *file)
 {
 	// read the header
 	cbm_crt_header header;
@@ -132,11 +132,10 @@ void cbm_crt_get_card(std::string &result, core_file *file)
 	{
 		UINT16 hardware = pick_integer_be(header.hardware, 0, 2);
 
-		result.assign(CRT_C64_SLOT_NAMES[hardware]);
-		return;
+		return std::string(CRT_C64_SLOT_NAMES[hardware]);
 	}
 
-	result.clear();
+	return std::string();
 }
 
 

--- a/src/lib/formats/cbm_crt.h
+++ b/src/lib/formats/cbm_crt.h
@@ -135,7 +135,7 @@ struct cbm_crt_chip
 //  FUNCTION PROTOTYPES
 //**************************************************************************
 
-void cbm_crt_get_card(std::string &result, core_file *file);
+std::string cbm_crt_get_card(core_file *file);
 bool cbm_crt_read_header(core_file* file, size_t *roml_size, size_t *romh_size, int *exrom, int *game);
 bool cbm_crt_read_data(core_file* file, UINT8 *roml, UINT8 *romh);
 

--- a/src/lib/util/corefile.cpp
+++ b/src/lib/util/corefile.cpp
@@ -909,7 +909,7 @@ file_error core_truncate(core_file *f, UINT64 offset)
     assumptions about path separators
 -------------------------------------------------*/
 
-std::string &core_filename_extract_base(std::string &result, const char *name, bool strip_extension)
+std::string core_filename_extract_base(const char *name, bool strip_extension)
 {
 	/* find the start of the name */
 	const char *start = name + strlen(name);
@@ -917,7 +917,7 @@ std::string &core_filename_extract_base(std::string &result, const char *name, b
 		start--;
 
 	/* copy the rest into an astring */
-	result.assign(start);
+	std::string result(start);
 
 	/* chop the extension if present */
 	if (strip_extension)

--- a/src/lib/util/corefile.h
+++ b/src/lib/util/corefile.h
@@ -125,7 +125,7 @@ file_error core_truncate(core_file *f, UINT64 offset);
 /* ----- filename utilities ----- */
 
 /* extract the base part of a filename (remove extensions and paths) */
-std::string &core_filename_extract_base(std::string &result, const char *name, bool strip_extension = false);
+std::string core_filename_extract_base(const char *name, bool strip_extension = false);
 
 /* true if the given filename ends with a particular extension */
 int core_filename_ends_with(const char *filename, const char *extension);

--- a/src/lib/util/corestr.cpp
+++ b/src/lib/util/corestr.cpp
@@ -217,14 +217,13 @@ int strprintf(std::string &str, const char *format, ...)
 	return retVal;
 }
 
-std::string strformat(std::string &str, const char *format, ...)
+std::string strformat(const char *format, ...)
 {
 	std::string retVal;
 	va_list ap;
 	va_start(ap, format);
-	strvprintf(str, format, ap);
+	strvprintf(retVal, format, ap);
 	va_end(ap);
-	retVal.assign(str);
 	return retVal;
 }
 

--- a/src/lib/util/corestr.h
+++ b/src/lib/util/corestr.h
@@ -68,7 +68,7 @@ int strvprintf(std::string &str, const char *format, va_list args);
 int strcatvprintf(std::string &str, const char *format, va_list args);
 int strprintf(std::string &str, const char *format, ...) ATTR_PRINTF(2, 3);
 int strcatprintf(std::string &str, const char *format, ...) ATTR_PRINTF(2, 3);
-std::string strformat(std::string &str, const char *format, ...) ATTR_PRINTF(2, 3);
+std::string strformat(const char *format, ...) ATTR_PRINTF(1, 2);
 
 void strdelchr(std::string& str, char chr);
 void strreplacechr(std::string& str, char ch, char newch);

--- a/src/lib/util/hashing.cpp
+++ b/src/lib/util/hashing.cpp
@@ -79,12 +79,12 @@ bool sha1_t::from_string(const char *string, int length)
 //  as_string - convert to a string
 //-------------------------------------------------
 
-const char *sha1_t::as_string(std::string &buffer) const
+std::string sha1_t::as_string() const
 {
-	buffer.clear();
+	std::string buffer;
 	for (auto & elem : m_raw)
 		strcatprintf(buffer, "%02x", elem);
-	return buffer.c_str();
+	return buffer;
 }
 
 
@@ -122,12 +122,12 @@ bool md5_t::from_string(const char *string, int length)
 //  as_string - convert to a string
 //-------------------------------------------------
 
-const char *md5_t::as_string(std::string &buffer) const
+std::string md5_t::as_string() const
 {
-	buffer.clear();
+	std::string buffer;
 	for (auto & elem : m_raw)
 		strcatprintf(buffer, "%02x", elem);
-	return buffer.c_str();
+	return buffer;
 }
 
 
@@ -166,10 +166,9 @@ bool crc32_t::from_string(const char *string, int length)
 //  as_string - convert to a string
 //-------------------------------------------------
 
-const char *crc32_t::as_string(std::string &buffer) const
+std::string crc32_t::as_string() const
 {
-	strprintf(buffer, "%08x", m_raw);
-	return buffer.c_str();
+	return strformat("%08x", m_raw);
 }
 
 
@@ -215,21 +214,18 @@ bool crc16_t::from_string(const char *string, int length)
 }
 
 /**
- * @fn  const char *crc16_t::as_string(std::string &buffer) const
+ * @fn  std::string crc16_t::as_string() const
  *
  * @brief   -------------------------------------------------
  *            as_string - convert to a string
  *          -------------------------------------------------.
  *
- * @param [in,out]  buffer  The buffer.
- *
- * @return  null if it fails, else a char*.
+ * @return  a std::string.
  */
 
-const char *crc16_t::as_string(std::string &buffer) const
+std::string crc16_t::as_string() const
 {
-	strprintf(buffer, "%04x", m_raw);
-	return buffer.c_str();
+	return strformat("%04x", m_raw);
 }
 
 /**

--- a/src/lib/util/hashing.h
+++ b/src/lib/util/hashing.h
@@ -34,7 +34,7 @@ struct sha1_t
 	bool operator!=(const sha1_t &rhs) const { return memcmp(m_raw, rhs.m_raw, sizeof(m_raw)) != 0; }
 	operator UINT8 *() { return m_raw; }
 	bool from_string(const char *string, int length = -1);
-	const char *as_string(std::string &buffer) const;
+	std::string as_string() const;
 	UINT8 m_raw[20];
 	static const sha1_t null;
 };
@@ -85,7 +85,7 @@ struct md5_t
 	bool operator!=(const md5_t &rhs) const { return memcmp(m_raw, rhs.m_raw, sizeof(m_raw)) != 0; }
 	operator UINT8 *() { return m_raw; }
 	bool from_string(const char *string, int length = -1);
-	const char *as_string(std::string &buffer) const;
+	std::string as_string() const;
 	UINT8 m_raw[16];
 	static const md5_t null;
 };
@@ -136,7 +136,7 @@ struct crc32_t
 	crc32_t &operator=(const UINT32 crc) { m_raw = crc; return *this; }
 	operator UINT32() const { return m_raw; }
 	bool from_string(const char *string, int length = -1);
-	const char *as_string(std::string &buffer) const;
+	std::string as_string() const;
 	UINT32 m_raw;
 	static const crc32_t null;
 };
@@ -182,7 +182,7 @@ struct crc16_t
 	crc16_t &operator=(const UINT16 crc) { m_raw = crc; return *this; }
 	operator UINT16() const { return m_raw; }
 	bool from_string(const char *string, int length = -1);
-	const char *as_string(std::string &buffer) const;
+	std::string as_string() const;
 	UINT16 m_raw;
 	static const crc16_t null;
 };

--- a/src/lib/util/options.cpp
+++ b/src/lib/util/options.cpp
@@ -478,10 +478,10 @@ void core_options::revert(int priority)
 //  the optional diff
 //-------------------------------------------------
 
-const char *core_options::output_ini(std::string &buffer, const core_options *diff)
+std::string core_options::output_ini(const core_options *diff) const
 {
 	// INI files are complete, so always start with a blank buffer
-	buffer.clear();
+	std::string buffer;
 
 	int num_valid_headers = 0;
 	int unadorned_index = 0;
@@ -534,7 +534,7 @@ const char *core_options::output_ini(std::string &buffer, const core_options *di
 			}
 		}
 	}
-	return buffer.c_str();
+	return buffer;
 }
 
 
@@ -542,10 +542,10 @@ const char *core_options::output_ini(std::string &buffer, const core_options *di
 //  output_help - output option help to a string
 //-------------------------------------------------
 
-const char *core_options::output_help(std::string &buffer)
+std::string core_options::output_help() const
 {
 	// start empty
-	buffer.clear();
+	std::string buffer;
 
 	// loop over all items
 	for (entry *curentry = m_entrylist.first(); curentry != nullptr; curentry = curentry->next())
@@ -558,7 +558,7 @@ const char *core_options::output_help(std::string &buffer)
 		else if (curentry->description() != nullptr)
 			strcatprintf(buffer,"-%-20s%s\n", curentry->name(), curentry->description());
 	}
-	return buffer.c_str();
+	return buffer;
 }
 
 
@@ -634,15 +634,13 @@ bool core_options::set_value(const char *name, const char *value, int priority, 
 
 bool core_options::set_value(const char *name, int value, int priority, std::string &error_string)
 {
-	std::string tempstr;
-	strprintf(tempstr,"%d", value);
+	std::string tempstr = strformat("%d", value);
 	return set_value(name, tempstr.c_str(), priority, error_string);
 }
 
 bool core_options::set_value(const char *name, float value, int priority, std::string &error_string)
 {
-	std::string tempstr;
-	strprintf(tempstr, "%f", (double) value);
+	std::string tempstr = strformat("%f", (double)value);
 	return set_value(name, tempstr.c_str(), priority, error_string);
 }
 

--- a/src/lib/util/options.h
+++ b/src/lib/util/options.h
@@ -145,8 +145,8 @@ public:
 	void revert(int priority = OPTION_PRIORITY_MAXIMUM);
 
 	// output
-	const char *output_ini(std::string &buffer, const core_options *diff = nullptr);
-	const char *output_help(std::string &buffer);
+	std::string output_ini(const core_options *diff = nullptr) const;
+	std::string output_help() const;
 
 	// reading
 	const char *value(const char *option) const;

--- a/src/mame/drivers/bfm_sc45_helper.cpp
+++ b/src/mame/drivers/bfm_sc45_helper.cpp
@@ -155,10 +155,7 @@ int find_input_strings(running_machine &machine)
 	{
 		for (int j = 0; j < 16; j++)
 		{
-			char tempstr[32];
-			sprintf(tempstr, "IN%d-%d", i, j);
-
-			sc4inputs[i][j].name = tempstr;
+			sc4inputs[i][j].name = strformat("IN%d-%d", i, j);
 			sc4inputs[i][j].used = false;
 		}
 	}

--- a/src/mame/drivers/cps3.cpp
+++ b/src/mame/drivers/cps3.cpp
@@ -772,10 +772,9 @@ void cps3_state::cps3_decrypt_bios()
 void cps3_state::init_common(void)
 {
 	// flash roms
-	std::string tempstr;
 	for (int simmnum = 0; simmnum < 7; simmnum++)
 		for (int chipnum = 0; chipnum < 8; chipnum++)
-			m_simm[simmnum][chipnum] = machine().device<fujitsu_29f016a_device>(strformat(tempstr,"simm%d.%d", simmnum + 1, chipnum).c_str());
+			m_simm[simmnum][chipnum] = machine().device<fujitsu_29f016a_device>(strformat("simm%d.%d", simmnum + 1, chipnum).c_str());
 
 	m_eeprom = std::make_unique<UINT32[]>(0x400/4);
 	machine().device<nvram_device>("eeprom")->set_base(m_eeprom.get(), 0x400);

--- a/src/mame/etc/template_cpu.cpp
+++ b/src/mame/etc/template_cpu.cpp
@@ -107,7 +107,7 @@ xxx_cpu_device::xxx_cpu_device(const machine_config &mconfig, const char *tag, d
 }
 
 
-void xxx_cpu_device::state_string_export(const device_state_entry &entry, std::string &str)
+void xxx_cpu_device::state_string_export(const device_state_entry &entry, std::string &str) const
 {
 	switch (entry.index())
 	{

--- a/src/mame/etc/template_cpu.h
+++ b/src/mame/etc/template_cpu.h
@@ -28,26 +28,26 @@ public:
 
 protected:
 	// device-level overrides
-	virtual void device_start();
-	virtual void device_reset();
+	virtual void device_start() override;
+	virtual void device_reset() override;
 
 	// device_execute_interface overrides
-	virtual UINT32 execute_min_cycles() const { return 1; }
-	virtual UINT32 execute_max_cycles() const { return 7; }
-	virtual UINT32 execute_input_lines() const { return 0; }
-	virtual void execute_run();
-	virtual void execute_set_input(int inputnum, int state);
+	virtual UINT32 execute_min_cycles() const override { return 1; }
+	virtual UINT32 execute_max_cycles() const override { return 7; }
+	virtual UINT32 execute_input_lines() const override { return 0; }
+	virtual void execute_run() override;
+	virtual void execute_set_input(int inputnum, int state) override;
 
 	// device_memory_interface overrides
-	virtual const address_space_config *memory_space_config(address_spacenum spacenum = AS_0) const { return (spacenum == AS_PROGRAM) ? &m_program_config : ( (spacenum == AS_DATA) ? &m_data_config : NULL ); }
+	virtual const address_space_config *memory_space_config(address_spacenum spacenum = AS_0) const override { return (spacenum == AS_PROGRAM) ? &m_program_config : ( (spacenum == AS_DATA) ? &m_data_config : NULL ); }
 
 	// device_state_interface overrides
-	void state_string_export(const device_state_entry &entry, std::string &str);
+	virtual void state_string_export(const device_state_entry &entry, std::string &str) const override;
 
 	// device_disasm_interface overrides
-	virtual UINT32 disasm_min_opcode_bytes() const { return 4; }
-	virtual UINT32 disasm_max_opcode_bytes() const { return 4; }
-	virtual offs_t disasm_disassemble(char *buffer, offs_t pc, const UINT8 *oprom, const UINT8 *opram, UINT32 options);
+	virtual UINT32 disasm_min_opcode_bytes() const override { return 4; }
+	virtual UINT32 disasm_max_opcode_bytes() const override { return 4; }
+	virtual offs_t disasm_disassemble(char *buffer, offs_t pc, const UINT8 *oprom, const UINT8 *opram, UINT32 options) override;
 
 private:
 	address_space_config m_program_config;

--- a/src/osd/sdl/osdsdl.h
+++ b/src/osd/sdl/osdsdl.h
@@ -119,12 +119,12 @@ public:
 	const char *keymap_file() const { return value(SDLOPTION_KEYMAP_FILE); }
 
 	// joystick mapping
-	const char *joy_index(int index) const { std::string temp; return value(strformat(temp, "%s%d", SDLOPTION_JOYINDEX, index).c_str()); }
+	const char *joy_index(int index) const { return value(strformat("%s%d", SDLOPTION_JOYINDEX, index).c_str()); }
 	bool sixaxis() const { return bool_value(SDLOPTION_SIXAXIS); }
 
 #if (SDLMAME_SDL2)
-	const char *mouse_index(int index) const { std::string temp; return value(strformat(temp, "%s%d", SDLOPTION_MOUSEINDEX, index).c_str()); }
-	const char *keyboard_index(int index) const { std::string temp; return value(strformat(temp, "%s%d", SDLOPTION_KEYBINDEX, index).c_str()); }
+	const char *mouse_index(int index) const { return value(strformat("%s%d", SDLOPTION_MOUSEINDEX, index).c_str()); }
+	const char *keyboard_index(int index) const { return value(strformat("%s%d", SDLOPTION_KEYBINDEX, index).c_str()); }
 #endif
 
 	const char *video_driver() const { return value(SDLOPTION_VIDEODRIVER); }

--- a/src/tools/chdman.cpp
+++ b/src/tools/chdman.cpp
@@ -2406,14 +2406,13 @@ static void do_extract_cd(parameters_t &params)
 
 			// output the metadata about the track to the TOC file
 			const cdrom_track_info &trackinfo = toc->tracks[tracknum];
-			std::string temp;
 			if (mode == MODE_GDI)
 			{
-				output_track_metadata(mode, output_toc_file, tracknum, trackinfo, core_filename_extract_base(temp, trackbin_name.c_str()).c_str(), discoffs, outputoffs);
+				output_track_metadata(mode, output_toc_file, tracknum, trackinfo, core_filename_extract_base(trackbin_name.c_str()).c_str(), discoffs, outputoffs);
 			}
 			else
 			{
-				output_track_metadata(mode, output_toc_file, tracknum, trackinfo, core_filename_extract_base(temp, output_bin_file_str->c_str()).c_str(), discoffs, outputoffs);
+				output_track_metadata(mode, output_toc_file, tracknum, trackinfo, core_filename_extract_base(output_bin_file_str->c_str()).c_str(), discoffs, outputoffs);
 			}
 
 			// If this is bin/cue output and the CHD contains subdata, warn the user and don't include


### PR DESCRIPTION
- strprintf is unaltered, but strformat now takes one fewer argument
- state_string_export still fills a buffer, but has been made const
- get_default_card_software now takes no arguments but returns a string