### PR TITLE
relicense SVP/SSP1601 code (nw)

### DIFF
--- a/src/devices/bus/megadrive/svp.cpp
+++ b/src/devices/bus/megadrive/svp.cpp
@@ -1,4 +1,4 @@
-// license:???
+// license:BSD-3-Clause
 // copyright-holders:Fabio Priuli,Pierpaolo Prazzoli,Grazvydas Ignotas
 /****************************************** SVP related *****************************************/
 

--- a/src/devices/bus/megadrive/svp.h
+++ b/src/devices/bus/megadrive/svp.h
@@ -1,4 +1,4 @@
-// license:???
+// license:BSD-3-Clause
 // copyright-holders:Fabio Priuli,Pierpaolo Prazzoli,Grazvydas Ignotas
 #ifndef __MD_SVP_H
 #define __MD_SVP_H

--- a/src/devices/cpu/ssp1601/ssp1601.cpp
+++ b/src/devices/cpu/ssp1601/ssp1601.cpp
@@ -1,4 +1,4 @@
-// license:???
+// license:BSD-3-Clause
 // copyright-holders:Pierpaolo Prazzoli,Grazvydas Ignotas
 /*
  * Samsung SSP1601 DSP emulator

--- a/src/devices/cpu/ssp1601/ssp1601d.cpp
+++ b/src/devices/cpu/ssp1601/ssp1601d.cpp
@@ -1,5 +1,5 @@
 // license:BSD-3-Clause
-// copyright-holders:Pierpaolo Prazzoli
+// copyright-holders:Pierpaolo Prazzoli,Grazvydas Ignotas
 /*
 
  SSP1601 disassembler


### PR DESCRIPTION
notes:
9f1788f65c243208e1ea386bc476dfb71f89bcb7 already removed MAME license
notice without bothering with permission
00b76c70c3a437d5bd9d988e43782df5931964ac claims Pierpaolo Prazzoli chose
BSD3 too
3360feb244452ca0a0c2f4f0a4dae59327b49567 claims the same about
Fabio Priuli