### PR TITLE
XAudio2 Bug fix - forgot to initialize buffers and no need to init COM

### DIFF
--- a/src/osd/modules/sound/xaudio2_sound.cpp
+++ b/src/osd/modules/sound/xaudio2_sound.cpp
@@ -306,8 +306,6 @@ int sound_xaudio2::init(osd_options const &options)
 {
     HRESULT result = S_OK;
 
-    HR_IGNORE(CoInitializeEx(NULL, COINITBASE_MULTITHREADED));
-
     // Create the IXAudio2 object
     IXAudio2 *temp_xaudio2 = nullptr;
     HR_RET1(xaudio2_create(&temp_xaudio2));
@@ -330,6 +328,9 @@ int sound_xaudio2::init(osd_options const &options)
     debugConfig.LogFunctionName = TRUE;
     m_xAudio2->SetDebugConfiguration(&debugConfig);
 #endif
+
+    // Create the buffers
+    create_buffers(format);
 
     // Initialize our events
     m_hEventBufferCompleted = CreateEvent(NULL, FALSE, FALSE, NULL);


### PR DESCRIPTION
When refactoring this code in the last pull request, I created a new method to initialize the buffers I forgot to call.  Additionally, there isn't any need to initialize COM before calling XAudio2Create in XAudio2 2.8