### PR TITLE
Pass and return palette devices by reference, not as pointers

### DIFF
--- a/src/devices/cpu/alto2/a2disp.cpp
+++ b/src/devices/cpu/alto2/a2disp.cpp
@@ -581,8 +581,8 @@ void alto2_cpu_device::reset_disp()
 UINT32 alto2_cpu_device::screen_update(screen_device &screen, bitmap_ind16 &bitmap, const rectangle &cliprect)
 {
 	pen_t palette_bw[2];
-	palette_bw[0] = screen.palette()->white_pen();
-	palette_bw[1] = screen.palette()->black_pen();
+	palette_bw[0] = screen.palette().white_pen();
+	palette_bw[1] = screen.palette().black_pen();
 	// copy even or odd field
 	for (int y = m_dsp.odd_frame ? 0 : 1; y < ALTO2_DISPLAY_HEIGHT; y += 2)
 		draw_scanline8(*m_dsp.bitmap, 0, y, ALTO2_DISPLAY_WIDTH, m_dsp.scanline[y], palette_bw);

--- a/src/devices/cpu/tms34010/tms34010.cpp
+++ b/src/devices/cpu/tms34010/tms34010.cpp
@@ -1004,7 +1004,7 @@ void tms340x0_device::get_display_params(tms34010_display_params *params)
 
 UINT32 tms340x0_device::tms340x0_ind16(screen_device &screen, bitmap_ind16 &bitmap, const rectangle &cliprect)
 {
-	pen_t blackpen = screen.palette()->black_pen();
+	pen_t blackpen = screen.palette().black_pen();
 	tms34010_display_params params;
 	int x;
 

--- a/src/emu/digfx.cpp
+++ b/src/emu/digfx.cpp
@@ -276,7 +276,7 @@ void device_gfx_interface::decode_gfx(const gfx_decode_entry *gfxdecodeinfo)
 		}
 
 		// allocate the graphics
-		m_gfx[curgfx] = std::make_unique<gfx_element>(m_palette, glcopy, (region_base != nullptr) ? region_base + gfx.start : nullptr, xormask, gfx.total_color_codes, gfx.color_codes_start);
+		m_gfx[curgfx] = std::make_unique<gfx_element>(*m_palette, glcopy, (region_base != nullptr) ? region_base + gfx.start : nullptr, xormask, gfx.total_color_codes, gfx.color_codes_start);
 	}
 
 	m_decoded = true;

--- a/src/emu/digfx.h
+++ b/src/emu/digfx.h
@@ -199,7 +199,7 @@ public:
 	static void static_set_palette(device_t &device, const char *tag);
 
 	// getters
-	palette_device *palette() const { return m_palette; }
+	palette_device &palette() const { return *m_palette; }
 	gfx_element *gfx(int index) const { assert(index < MAX_GFX_ELEMENTS); return m_gfx[index].get(); }
 
 	// decoding
@@ -214,10 +214,10 @@ protected:
 	virtual void interface_pre_start() override;
 	virtual void interface_post_start() override;
 
+private:
 	palette_device *            m_palette;                  // pointer to the palette device
 	std::unique_ptr<gfx_element>  m_gfx[MAX_GFX_ELEMENTS];    // array of pointers to graphic sets
 
-private:
 	// configuration
 	const gfx_decode_entry *    m_gfxdecodeinfo;        // pointer to array of gfx decode information
 	const char *                m_palette_tag;          // configured tag for palette device

--- a/src/emu/drawgfx.cpp
+++ b/src/emu/drawgfx.cpp
@@ -86,6 +86,7 @@ gfxdecode_device::gfxdecode_device(const machine_config &mconfig, const char *ta
 //  gfx_element - constructor
 //-------------------------------------------------
 
+#ifdef UNUSED_FUNCTION
 gfx_element::gfx_element()
 	: m_palette(nullptr),
 		m_width(0),
@@ -110,9 +111,10 @@ gfx_element::gfx_element()
 		m_layout_charincrement(0)
 {
 }
+#endif
 
-gfx_element::gfx_element(palette_device *palette, UINT8 *base, UINT32 width, UINT32 height, UINT32 rowbytes, UINT32 total_colors, UINT32 color_base, UINT32 color_granularity)
-	: m_palette(palette),
+gfx_element::gfx_element(palette_device &palette, UINT8 *base, UINT32 width, UINT32 height, UINT32 rowbytes, UINT32 total_colors, UINT32 color_base, UINT32 color_granularity)
+	: m_palette(&palette),
 		m_width(width),
 		m_height(height),
 		m_startx(0),
@@ -136,8 +138,8 @@ gfx_element::gfx_element(palette_device *palette, UINT8 *base, UINT32 width, UIN
 {
 }
 
-gfx_element::gfx_element(palette_device *palette, const gfx_layout &gl, const UINT8 *srcdata, UINT32 xormask, UINT32 total_colors, UINT32 color_base)
-	: m_palette(palette),
+gfx_element::gfx_element(palette_device &palette, const gfx_layout &gl, const UINT8 *srcdata, UINT32 xormask, UINT32 total_colors, UINT32 color_base)
+	: m_palette(&palette),
 		m_width(0),
 		m_height(0),
 		m_startx(0),

--- a/src/emu/drawgfx.h
+++ b/src/emu/drawgfx.h
@@ -148,12 +148,14 @@ class gfx_element
 {
 public:
 	// construction/destruction
+#ifdef UNUSED_FUNCTION
 	gfx_element();
-	gfx_element(palette_device *palette, const gfx_layout &gl, const UINT8 *srcdata, UINT32 xormask, UINT32 total_colors, UINT32 color_base);
-	gfx_element(palette_device *palette, UINT8 *base, UINT32 width, UINT32 height, UINT32 rowbytes, UINT32 total_colors, UINT32 color_base, UINT32 color_granularity);
+#endif
+	gfx_element(palette_device &palette, const gfx_layout &gl, const UINT8 *srcdata, UINT32 xormask, UINT32 total_colors, UINT32 color_base);
+	gfx_element(palette_device &palette, UINT8 *base, UINT32 width, UINT32 height, UINT32 rowbytes, UINT32 total_colors, UINT32 color_base, UINT32 color_granularity);
 
 	// getters
-	palette_device *palette() const { return m_palette; }
+	palette_device &palette() const { return *m_palette; }
 	UINT16 width() const { return m_width; }
 	UINT16 height() const { return m_height; }
 	UINT32 elements() const { return m_total_elements; }
@@ -173,7 +175,7 @@ public:
 	void set_source(const UINT8 *source);
 	void set_source_and_total(const UINT8 *source, UINT32 total);
 	void set_xormask(UINT32 xormask) { m_layout_xormask = xormask; }
-	void set_palette(palette_device *palette) { m_palette = palette; }
+	void set_palette(palette_device &palette) { m_palette = &palette; }
 	void set_colors(UINT32 colors) { m_total_colors = colors; }
 	void set_colorbase(UINT16 colorbase) { m_color_base = colorbase; }
 	void set_granularity(UINT16 granularity) { m_color_granularity = granularity; }

--- a/src/emu/screen.h
+++ b/src/emu/screen.h
@@ -197,7 +197,8 @@ public:
 	// information getters
 	render_container &container() const { assert(m_container != nullptr); return *m_container; }
 	bitmap_ind8 &priority() { return m_priority; }
-	palette_device *palette() { return m_palette; }
+	palette_device &palette() const { assert(m_palette.found()); return *m_palette; }
+	bool has_palette() const { return m_palette.found(); }
 
 	// dynamic configuration
 	void configure(int width, int height, const rectangle &visarea, attoseconds_t frame_period);

--- a/src/emu/tilemap.cpp
+++ b/src/emu/tilemap.cpp
@@ -348,7 +348,7 @@ tilemap_t &tilemap_t::init(tilemap_manager &manager, device_gfx_interface &decod
 	// populate managers and devices
 	m_manager = &manager;
 	m_device = dynamic_cast<tilemap_device *>(this);
-	m_palette = decoder.palette();
+	m_palette = &decoder.palette();
 	m_next = nullptr;
 	m_user_data = nullptr;
 

--- a/src/emu/tilemap.h
+++ b/src/emu/tilemap.h
@@ -497,7 +497,7 @@ public:
 	// getters
 	running_machine &machine() const;
 	tilemap_device *device() const { return m_device; }
-	palette_device *palette() const { return m_palette; }
+	palette_device &palette() const { return *m_palette; }
 	tilemap_t *next() const { return m_next; }
 	void *user_data() const { return m_user_data; }
 	memory_array &basemem() { return m_basemem; }
@@ -518,7 +518,7 @@ public:
 	// setters
 	void enable(bool enable = true) { m_enable = enable; }
 	void set_user_data(void *user_data) { m_user_data = user_data; }
-	void set_palette(palette_device *palette) { m_palette = palette; }
+	void set_palette(palette_device &palette) { m_palette = &palette; }
 	void set_palette_offset(UINT32 offset) { m_palette_offset = offset; }
 	void set_scrolldx(int dx, int dx_flipped) { m_dx = dx; m_dx_flipped = dx_flipped; }
 	void set_scrolldy(int dy, int dy_flipped) { m_dy = dy; m_dy_flipped = dy_flipped; }

--- a/src/emu/ui/viewgfx.cpp
+++ b/src/emu/ui/viewgfx.cpp
@@ -904,7 +904,7 @@ static void gfxset_draw_item(running_machine &machine, gfx_element &gfx, int ind
 {
 	int width = (rotate & ORIENTATION_SWAP_XY) ? gfx.height() : gfx.width();
 	int height = (rotate & ORIENTATION_SWAP_XY) ? gfx.width() : gfx.height();
-	const rgb_t *palette = gfx.palette()->palette()->entry_list_raw() + gfx.colorbase() + color * gfx.granularity();
+	const rgb_t *palette = gfx.palette().palette()->entry_list_raw() + gfx.colorbase() + color * gfx.granularity();
 	int x, y;
 
 	// loop over rows in the cell

--- a/src/emu/video.cpp
+++ b/src/emu/video.cpp
@@ -247,8 +247,9 @@ void video_manager::frame_update(bool debug)
 	if (phase == MACHINE_PHASE_RUNNING)
 	{
 		// reset partial updates if we're paused or if the debugger is active
-		if (machine().first_screen() != nullptr && (machine().paused() || debug || debugger_within_instruction_hook(machine())))
-			machine().first_screen()->reset_partial_updates();
+		screen_device *screen = machine().first_screen();
+		if (screen != nullptr && (machine().paused() || debug || debugger_within_instruction_hook(machine())))
+			screen->reset_partial_updates();
 	}
 }
 
@@ -316,8 +317,8 @@ void video_manager::save_snapshot(screen_device *screen, emu_file &file)
 	png_add_text(&pnginfo, "System", text2.c_str());
 
 	// now do the actual work
-	const rgb_t *palette = (screen !=nullptr && screen->palette() != nullptr) ? screen->palette()->palette()->entry_list_adjusted() : nullptr;
-	int entries = (screen !=nullptr && screen->palette() != nullptr) ? screen->palette()->entries() : 0;
+	const rgb_t *palette = (screen != nullptr && screen->has_palette()) ? screen->palette().palette()->entry_list_adjusted() : nullptr;
+	int entries = (screen != nullptr && screen->has_palette()) ? screen->palette().entries() : 0;
 	png_error error = png_write_bitmap(file, &pnginfo, m_snap_bitmap, entries, palette);
 	if (error != PNGERR_NONE)
 		osd_printf_error("Error generating PNG for snapshot: png_error = %d\n", error);
@@ -380,9 +381,10 @@ void video_manager::begin_recording(const char *name, movie_format format)
 		m_avi_next_frame_time = machine().time();
 
 		// build up information about this new movie
+		screen_device *screen = machine().first_screen();
 		avi_movie_info info;
 		info.video_format = 0;
-		info.video_timescale = 1000 * ((machine().first_screen() != nullptr) ? ATTOSECONDS_TO_HZ(machine().first_screen()->frame_period().attoseconds()) : screen_device::DEFAULT_FRAME_RATE);
+		info.video_timescale = 1000 * ((screen != nullptr) ? ATTOSECONDS_TO_HZ(screen->frame_period().attoseconds()) : screen_device::DEFAULT_FRAME_RATE);
 		info.video_sampletime = 1000;
 		info.video_numsamples = 0;
 		info.video_width = m_snap_bitmap.width();
@@ -448,7 +450,8 @@ void video_manager::begin_recording(const char *name, movie_format format)
 		if (filerr == FILERR_NONE)
 		{
 			// start the capture
-			int rate = (machine().first_screen() != nullptr) ? ATTOSECONDS_TO_HZ(machine().first_screen()->frame_period().attoseconds()) : screen_device::DEFAULT_FRAME_RATE;
+			screen_device *screen = machine().first_screen();
+			int rate = (screen != nullptr) ? ATTOSECONDS_TO_HZ(screen->frame_period().attoseconds()) : screen_device::DEFAULT_FRAME_RATE;
 			png_error pngerr = mng_capture_start(*m_mng_file, m_snap_bitmap, rate);
 			if (pngerr != PNGERR_NONE)
 			{
@@ -1037,13 +1040,14 @@ void video_manager::recompute_speed(const attotime &emutime)
 	// if we're past the "time-to-execute" requested, signal an exit
 	if (m_seconds_to_run != 0 && emutime.seconds() >= m_seconds_to_run)
 	{
-		if (machine().first_screen() != nullptr)
+		screen_device *screen = machine().first_screen();
+		if (screen != nullptr)
 		{
 			// create a final screenshot
 			emu_file file(machine().options().snapshot_directory(), OPEN_FLAG_WRITE | OPEN_FLAG_CREATE | OPEN_FLAG_CREATE_PATHS);
 			file_error filerr = file.open(machine().basename(), PATH_SEPARATOR "final.png");
 			if (filerr == FILERR_NONE)
-				save_snapshot(machine().first_screen(), file);
+				save_snapshot(screen, file);
 		}
 		//printf("Scheduled exit at %f\n", emutime.as_double());
 		// schedule our demise
@@ -1279,8 +1283,9 @@ void video_manager::record_frame()
 			}
 
 			// write the next frame
-			const rgb_t *palette = (machine().first_screen() !=nullptr && machine().first_screen()->palette() != nullptr) ? machine().first_screen()->palette()->palette()->entry_list_adjusted() : nullptr;
-			int entries = (machine().first_screen() !=nullptr && machine().first_screen()->palette() != nullptr) ? machine().first_screen()->palette()->entries() : 0;
+			screen_device *screen = machine().first_screen();
+			const rgb_t *palette = (screen != nullptr && screen->has_palette()) ? screen->palette().palette()->entry_list_adjusted() : nullptr;
+			int entries = (screen != nullptr && screen->has_palette()) ? screen->palette().entries() : 0;
 			png_error error = mng_capture_frame(*m_mng_file, &pnginfo, m_snap_bitmap, entries, palette);
 			png_free(&pnginfo);
 			if (error != PNGERR_NONE)

--- a/src/mame/drivers/batman.cpp
+++ b/src/mame/drivers/batman.cpp
@@ -76,7 +76,7 @@ WRITE16_MEMBER(batman_state::latch_w)
 	if ((oldword ^ m_latch_data) & 0x7000)
 	{
 		m_screen->update_partial(m_screen->vpos());
-		m_vad->alpha()->mark_all_dirty();
+		m_vad->alpha().mark_all_dirty();
 		m_alpha_tile_bank = (m_latch_data >> 12) & 7;
 	}
 }

--- a/src/mame/drivers/peoplepc.cpp
+++ b/src/mame/drivers/peoplepc.cpp
@@ -176,7 +176,7 @@ void peoplepc_state::machine_reset()
 
 void peoplepc_state::machine_start()
 {
-	m_gfxdecode->set_gfx(0, std::make_unique<gfx_element>(machine().device<palette_device>("palette"), peoplepc_charlayout, &m_charram[0], 0, 1, 0));
+	m_gfxdecode->set_gfx(0, std::make_unique<gfx_element>(*m_palette, peoplepc_charlayout, &m_charram[0], 0, 1, 0));
 	m_dma0pg = 0;
 
 	// FIXME: cheat as there no docs about how or obvious ports that set to control the motor

--- a/src/mame/drivers/rungun.cpp
+++ b/src/mame/drivers/rungun.cpp
@@ -182,7 +182,7 @@ READ16_MEMBER(rungun_state::palette_read)
 
 WRITE16_MEMBER(rungun_state::palette_write)
 {
-	palette_device *cur_paldevice = m_video_mux_bank == 0 ? m_palette : static_cast<palette_device *>(m_palette2);
+	palette_device &cur_paldevice = m_video_mux_bank == 0 ? *m_palette : *m_palette2;
 	UINT32 addr = offset + m_video_mux_bank*0x800/2;
 	COMBINE_DATA(&m_pal_ram[addr]);
 
@@ -192,7 +192,7 @@ WRITE16_MEMBER(rungun_state::palette_write)
 	g = (m_pal_ram[addr] & 0x3e0) >> 5;
 	b = (m_pal_ram[addr] & 0x7e00) >> 10;
 
-	cur_paldevice->set_pen_color(offset,pal5bit(r),pal5bit(g),pal5bit(b));
+	cur_paldevice.set_pen_color(offset,pal5bit(r),pal5bit(g),pal5bit(b));
 }
 
 static ADDRESS_MAP_START( rungun_map, AS_PROGRAM, 16, rungun_state )

--- a/src/mame/drivers/thunderj.cpp
+++ b/src/mame/drivers/thunderj.cpp
@@ -100,7 +100,7 @@ WRITE16_MEMBER(thunderj_state::latch_w)
 		if (m_alpha_tile_bank != ((data >> 2) & 7))
 		{
 			m_screen->update_partial(m_screen->vpos());
-			m_vad->alpha()->mark_all_dirty();
+			m_vad->alpha().mark_all_dirty();
 			m_alpha_tile_bank = (data >> 2) & 7;
 		}
 	}

--- a/src/mame/includes/kaneko16.h
+++ b/src/mame/includes/kaneko16.h
@@ -96,7 +96,7 @@ public:
 	TIMER_DEVICE_CALLBACK_MEMBER(shogwarr_interrupt);
 
 	template<class _BitmapClass>
-	void kaneko16_fill_bitmap(palette_device* palette, _BitmapClass &bitmap, const rectangle &cliprect);
+	void kaneko16_fill_bitmap(_BitmapClass &bitmap, const rectangle &cliprect);
 
 	void kaneko16_common_oki_bank_w(  const char *bankname, const char* tag, int bank, size_t fixedsize, size_t bankedsize );
 	void kaneko16_unscramble_tiles(const char *region);

--- a/src/mame/machine/atarigen.h
+++ b/src/mame/machine/atarigen.h
@@ -188,10 +188,10 @@ public:
 	template<class _Object> static devcb_base &static_set_scanline_int_cb(device_t &device, _Object object) { return downcast<atari_vad_device &>(device).m_scanline_int_cb.set_callback(object); }
 
 	// getters
-	tilemap_device *alpha() const { return m_alpha_tilemap; }
-	tilemap_device *playfield() const { return m_playfield_tilemap; }
-	tilemap_device *playfield2() const { return m_playfield2_tilemap; }
-	atari_motion_objects_device *mob() const { return m_mob; }
+	tilemap_device &alpha() const { return *m_alpha_tilemap; }
+	tilemap_device &playfield() const { return *m_playfield_tilemap; }
+	tilemap_device &playfield2() const { return *m_playfield2_tilemap; }
+	atari_motion_objects_device &mob() const { return *m_mob; }
 
 	// read/write handlers
 	DECLARE_READ16_MEMBER(control_read);

--- a/src/mame/machine/megacd.cpp
+++ b/src/mame/machine/megacd.cpp
@@ -911,23 +911,23 @@ WRITE16_MEMBER( sega_segacd_device::scd_a12006_hint_register_w )
 
 void sega_segacd_device::segacd_mark_tiles_dirty(int offset)
 {
-	m_gfx[0]->mark_dirty((offset*2)/(SEGACD_BYTES_PER_TILE16));
-	m_gfx[1]->mark_dirty((offset*2)/(SEGACD_BYTES_PER_TILE16));
-	m_gfx[2]->mark_dirty((offset*2)/(SEGACD_BYTES_PER_TILE16));
-	m_gfx[3]->mark_dirty((offset*2)/(SEGACD_BYTES_PER_TILE16));
-	m_gfx[4]->mark_dirty((offset*2)/(SEGACD_BYTES_PER_TILE16));
-	m_gfx[5]->mark_dirty((offset*2)/(SEGACD_BYTES_PER_TILE16));
-	m_gfx[6]->mark_dirty((offset*2)/(SEGACD_BYTES_PER_TILE16));
-	m_gfx[7]->mark_dirty((offset*2)/(SEGACD_BYTES_PER_TILE16));
+	gfx(0)->mark_dirty((offset*2)/(SEGACD_BYTES_PER_TILE16));
+	gfx(1)->mark_dirty((offset*2)/(SEGACD_BYTES_PER_TILE16));
+	gfx(2)->mark_dirty((offset*2)/(SEGACD_BYTES_PER_TILE16));
+	gfx(3)->mark_dirty((offset*2)/(SEGACD_BYTES_PER_TILE16));
+	gfx(4)->mark_dirty((offset*2)/(SEGACD_BYTES_PER_TILE16));
+	gfx(5)->mark_dirty((offset*2)/(SEGACD_BYTES_PER_TILE16));
+	gfx(6)->mark_dirty((offset*2)/(SEGACD_BYTES_PER_TILE16));
+	gfx(7)->mark_dirty((offset*2)/(SEGACD_BYTES_PER_TILE16));
 
-	m_gfx[8]->mark_dirty((offset*2)/(SEGACD_BYTES_PER_TILE32));
-	m_gfx[9]->mark_dirty((offset*2)/(SEGACD_BYTES_PER_TILE32));
-	m_gfx[10]->mark_dirty((offset*2)/(SEGACD_BYTES_PER_TILE32));
-	m_gfx[11]->mark_dirty((offset*2)/(SEGACD_BYTES_PER_TILE32));
-	m_gfx[12]->mark_dirty((offset*2)/(SEGACD_BYTES_PER_TILE32));
-	m_gfx[13]->mark_dirty((offset*2)/(SEGACD_BYTES_PER_TILE32));
-	m_gfx[14]->mark_dirty((offset*2)/(SEGACD_BYTES_PER_TILE32));
-	m_gfx[15]->mark_dirty((offset*2)/(SEGACD_BYTES_PER_TILE32));
+	gfx(8)->mark_dirty((offset*2)/(SEGACD_BYTES_PER_TILE32));
+	gfx(9)->mark_dirty((offset*2)/(SEGACD_BYTES_PER_TILE32));
+	gfx(10)->mark_dirty((offset*2)/(SEGACD_BYTES_PER_TILE32));
+	gfx(11)->mark_dirty((offset*2)/(SEGACD_BYTES_PER_TILE32));
+	gfx(12)->mark_dirty((offset*2)/(SEGACD_BYTES_PER_TILE32));
+	gfx(13)->mark_dirty((offset*2)/(SEGACD_BYTES_PER_TILE32));
+	gfx(14)->mark_dirty((offset*2)/(SEGACD_BYTES_PER_TILE32));
+	gfx(15)->mark_dirty((offset*2)/(SEGACD_BYTES_PER_TILE32));
 }
 
 
@@ -1062,11 +1062,11 @@ inline UINT8 sega_segacd_device::get_stampmap_16x16_1x1_tile_info_pixel(int xpos
 	int tile_region, tileno;
 	SCD_GET_TILE_INFO_16x16_1x1(tile_region,tileno,(int)tile_index);
 
-	tileno %= m_gfx[tile_region]->elements();
+	tileno %= gfx(tile_region)->elements();
 
 	if (tileno==0) return 0x00;
 
-	const UINT8* srcdata = m_gfx[tile_region]->get_data(tileno);
+	const UINT8* srcdata = gfx(tile_region)->get_data(tileno);
 	return srcdata[((ypos&((1<<tilesize)-1))*(1<<tilesize))+(xpos&((1<<tilesize)-1))];
 }
 
@@ -1100,11 +1100,11 @@ inline UINT8 sega_segacd_device::get_stampmap_32x32_1x1_tile_info_pixel(int xpos
 	int tile_region, tileno;
 	SCD_GET_TILE_INFO_32x32_1x1(tile_region,tileno,(int)tile_index);
 
-	tileno %= m_gfx[tile_region]->elements();
+	tileno %= gfx(tile_region)->elements();
 
 	if (tileno==0) return 0x00; // does this apply in this mode?
 
-	const UINT8* srcdata = m_gfx[tile_region]->get_data(tileno);
+	const UINT8* srcdata = gfx(tile_region)->get_data(tileno);
 	return srcdata[((ypos&((1<<tilesize)-1))*(1<<tilesize))+(xpos&((1<<tilesize)-1))];
 }
 
@@ -1138,11 +1138,11 @@ inline UINT8 sega_segacd_device::get_stampmap_16x16_16x16_tile_info_pixel(int xp
 	int tile_region, tileno;
 	SCD_GET_TILE_INFO_16x16_16x16(tile_region,tileno,(int)tile_index);
 
-	tileno %= m_gfx[tile_region]->elements();
+	tileno %= gfx(tile_region)->elements();
 
 	if (tileno==0) return 0x00; // does this apply in this mode
 
-	const UINT8* srcdata = m_gfx[tile_region]->get_data(tileno);
+	const UINT8* srcdata = gfx(tile_region)->get_data(tileno);
 	return srcdata[((ypos&((1<<tilesize)-1))*(1<<tilesize))+(xpos&((1<<tilesize)-1))];
 }
 
@@ -1176,11 +1176,11 @@ inline UINT8 sega_segacd_device::get_stampmap_32x32_16x16_tile_info_pixel(int xp
 	int tile_region, tileno;
 	SCD_GET_TILE_INFO_32x32_16x16(tile_region,tileno,(int)tile_index);
 
-	tileno %= m_gfx[tile_region]->elements();
+	tileno %= gfx(tile_region)->elements();
 
 	if (tileno==0) return 0x00;
 
-	const UINT8* srcdata = m_gfx[tile_region]->get_data(tileno);
+	const UINT8* srcdata = gfx(tile_region)->get_data(tileno);
 	return srcdata[((ypos&((1<<tilesize)-1))*(1<<tilesize))+(xpos&((1<<tilesize)-1))];
 }
 

--- a/src/mame/video/atari.cpp
+++ b/src/mame/video/atari.cpp
@@ -23,10 +23,10 @@
 
 void atari_common_state::video_start()
 {
-	palette_device *m_palette = machine().first_screen()->palette();
+	palette_device &palette = machine().first_screen()->palette();
 
 	for (int i = 0; i < 256; i++)
-		m_gtia->set_color_lookup(i, (m_palette->pen(0) << 8) + m_palette->pen(0));
+		m_gtia->set_color_lookup(i, (palette.pen(0) << 8) + palette.pen(0));
 }
 
 

--- a/src/mame/video/batman.cpp
+++ b/src/mame/video/batman.cpp
@@ -105,23 +105,23 @@ VIDEO_START_MEMBER(batman_state,batman)
 UINT32 batman_state::screen_update_batman(screen_device &screen, bitmap_ind16 &bitmap, const rectangle &cliprect)
 {
 	// start drawing
-	m_vad->mob()->draw_async(cliprect);
+	m_vad->mob().draw_async(cliprect);
 
 	/* draw the playfield */
 	bitmap_ind8 &priority_bitmap = screen.priority();
 	priority_bitmap.fill(0, cliprect);
-	m_vad->playfield()->draw(screen, bitmap, cliprect, 0, 0x00);
-	m_vad->playfield()->draw(screen, bitmap, cliprect, 1, 0x01);
-	m_vad->playfield()->draw(screen, bitmap, cliprect, 2, 0x02);
-	m_vad->playfield()->draw(screen, bitmap, cliprect, 3, 0x03);
-	m_vad->playfield2()->draw(screen, bitmap, cliprect, 0, 0x80);
-	m_vad->playfield2()->draw(screen, bitmap, cliprect, 1, 0x84);
-	m_vad->playfield2()->draw(screen, bitmap, cliprect, 2, 0x88);
-	m_vad->playfield2()->draw(screen, bitmap, cliprect, 3, 0x8c);
+	m_vad->playfield().draw(screen, bitmap, cliprect, 0, 0x00);
+	m_vad->playfield().draw(screen, bitmap, cliprect, 1, 0x01);
+	m_vad->playfield().draw(screen, bitmap, cliprect, 2, 0x02);
+	m_vad->playfield().draw(screen, bitmap, cliprect, 3, 0x03);
+	m_vad->playfield2().draw(screen, bitmap, cliprect, 0, 0x80);
+	m_vad->playfield2().draw(screen, bitmap, cliprect, 1, 0x84);
+	m_vad->playfield2().draw(screen, bitmap, cliprect, 2, 0x88);
+	m_vad->playfield2().draw(screen, bitmap, cliprect, 3, 0x8c);
 
 	// draw and merge the MO
-	bitmap_ind16 &mobitmap = m_vad->mob()->bitmap();
-	for (const sparse_dirty_rect *rect = m_vad->mob()->first_dirty_rect(cliprect); rect != nullptr; rect = rect->next())
+	bitmap_ind16 &mobitmap = m_vad->mob().bitmap();
+	for (const sparse_dirty_rect *rect = m_vad->mob().first_dirty_rect(cliprect); rect != nullptr; rect = rect->next())
 		for (int y = rect->min_y; y <= rect->max_y; y++)
 		{
 			UINT16 *mo = &mobitmap.pix16(y);
@@ -190,10 +190,10 @@ UINT32 batman_state::screen_update_batman(screen_device &screen, bitmap_ind16 &b
 		}
 
 	/* add the alpha on top */
-	m_vad->alpha()->draw(screen, bitmap, cliprect, 0, 0);
+	m_vad->alpha().draw(screen, bitmap, cliprect, 0, 0);
 
 	/* now go back and process the upper bit of MO priority */
-	for (const sparse_dirty_rect *rect = m_vad->mob()->first_dirty_rect(cliprect); rect != nullptr; rect = rect->next())
+	for (const sparse_dirty_rect *rect = m_vad->mob().first_dirty_rect(cliprect); rect != nullptr; rect = rect->next())
 		for (int y = rect->min_y; y <= rect->max_y; y++)
 		{
 			UINT16 *mo = &mobitmap.pix16(y);
@@ -208,7 +208,7 @@ UINT32 batman_state::screen_update_batman(screen_device &screen, bitmap_ind16 &b
 					{
 						/* if bit 2 is set, start setting high palette bits */
 						if (mo[x] & 2)
-							m_vad->mob()->apply_stain(bitmap, pf, mo, x, y);
+							m_vad->mob().apply_stain(bitmap, pf, mo, x, y);
 					}
 				}
 		}

--- a/src/mame/video/c116.cpp
+++ b/src/mame/video/c116.cpp
@@ -156,7 +156,7 @@ WRITE8_MEMBER(namco_c116_device::write)
 	}
 	int color = ((offset & 0x6000) >> 2) | (offset & 0x7ff);
 	RAM[color] = data;
-	m_palette->set_pen_color(color,m_ram_r[color],m_ram_g[color],m_ram_b[color]);
+	palette().set_pen_color(color,m_ram_r[color],m_ram_g[color],m_ram_b[color]);
 }
 
 

--- a/src/mame/video/c45.cpp
+++ b/src/mame/video/c45.cpp
@@ -133,7 +133,7 @@ WRITE16_MEMBER( namco_c45_road_device::tilemap_w )
 WRITE16_MEMBER( namco_c45_road_device::tileram_w )
 {
 	COMBINE_DATA(&m_tileram[offset]);
-	m_gfx[0]->mark_dirty(offset / WORDS_PER_ROAD_TILE);
+	gfx(0)->mark_dirty(offset / WORDS_PER_ROAD_TILE);
 }
 
 
@@ -200,7 +200,7 @@ void namco_c45_road_device::draw(bitmap_ind16 &bitmap, const rectangle &cliprect
 			while (numpixels-- > 0)
 			{
 				int pen = source_gfx[sourcex >> 16];
-				if (m_palette->pen_indirect(pen) != m_transparent_color)
+				if (palette().pen_indirect(pen) != m_transparent_color)
 				{
 					if (m_clut != nullptr)
 						pen = (pen & ~0xff) | m_clut[pen & 0xff];

--- a/src/mame/video/cyberbal.cpp
+++ b/src/mame/video/cyberbal.cpp
@@ -85,8 +85,8 @@ void cyberbal_state::video_start_common(int screens)
 	if (screens == 2)
 	{
 		palette_device *rpalette = subdevice<palette_device>("rpalette");
-		m_playfield2_tilemap->set_palette(rpalette);
-		m_alpha2_tilemap->set_palette(rpalette);
+		m_playfield2_tilemap->set_palette(*rpalette);
+		m_alpha2_tilemap->set_palette(*rpalette);
 	}
 
 	/* initialize the motion objects */

--- a/src/mame/video/flkatck.cpp
+++ b/src/mame/video/flkatck.cpp
@@ -162,7 +162,7 @@ UINT32 flkatck_state::screen_update_flkatck(screen_device &screen, bitmap_ind16 
 
 	/* draw the graphics */
 	m_k007121_tilemap[0]->draw(screen, bitmap, clip[0], 0, 0);
-	m_k007121->sprites_draw(bitmap, cliprect, m_gfxdecode->gfx(0), nullptr, &m_k007121_ram[0x1000], 0, 40, 0, screen.priority(), (UINT32)-1);
+	m_k007121->sprites_draw(bitmap, cliprect, m_gfxdecode->gfx(0), m_gfxdecode->palette(), &m_k007121_ram[0x1000], 0, 40, 0, screen.priority(), (UINT32)-1, true);
 	m_k007121_tilemap[1]->draw(screen, bitmap, clip[1], 0, 0);
 	return 0;
 }

--- a/src/mame/video/fromanc2.cpp
+++ b/src/mame/video/fromanc2.cpp
@@ -283,7 +283,7 @@ VIDEO_START_MEMBER(fromanc2_state,fromanc2)
 
 	for (int screen = 0; screen < 2; screen++)
 	{
-		palette_device *palette = (screen == 0 ? m_lpalette : m_rpalette);
+		palette_device &palette = (screen == 0 ? *m_lpalette : *m_rpalette);
 		for (int tmap = 0; tmap < 4; tmap++)
 		{
 			m_videoram[screen][tmap] = std::make_unique<UINT16[]>((64 * 64));
@@ -321,7 +321,7 @@ VIDEO_START_MEMBER(fromanc2_state,fromancr)
 
 	for (int screen = 0; screen < 2; screen++)
 	{
-		palette_device *palette = (screen == 0 ? m_lpalette : m_rpalette);
+		palette_device &palette = (screen == 0 ? *m_lpalette : *m_rpalette);
 		for (int tmap = 0; tmap < 3; tmap++)
 		{
 			m_videoram[screen][tmap] = std::make_unique<UINT16[]>((64 * 64));
@@ -357,7 +357,7 @@ VIDEO_START_MEMBER(fromanc2_state,fromanc4)
 
 	for (int screen = 0; screen < 2; screen++)
 	{
-		palette_device *palette = (screen == 0 ? m_lpalette : m_rpalette);
+		palette_device &palette = (screen == 0 ? *m_lpalette : *m_rpalette);
 		for (int tmap = 0; tmap < 3; tmap++)
 		{
 			m_videoram[screen][tmap] = std::make_unique<UINT16[]>((256 * 64));

--- a/src/mame/video/gp9001.cpp
+++ b/src/mame/video/gp9001.cpp
@@ -681,9 +681,9 @@ void gp9001vdp_device::draw_sprites( bitmap_ind16 &bitmap, const rectangle &clip
 	UINT16 *source;
 
 	if (sp.use_sprite_buffer) source = sp.vram16_buffer.get();
-	else source = m_spriteram;
-	int total_elements = m_gfx[1]->elements();
-	int total_colors = m_gfx[1]->colors();
+	else source = &m_spriteram[0];
+	int total_elements = gfx(1)->elements();
+	int total_colors = gfx(1)->colors();
 
 	int old_x = (-(sp.scrollx)) & 0x1ff;
 	int old_y = (-(sp.scrolly)) & 0x1ff;
@@ -784,10 +784,10 @@ void gp9001vdp_device::draw_sprites( bitmap_ind16 &bitmap, const rectangle &clip
 					*/
 					sprite %= total_elements;
 					color %= total_colors;
-					const pen_t *paldata = &m_palette->pen(color * 16);
+					const pen_t *paldata = &palette().pen(color * 16);
 					{
 						int yy, xx;
-						const UINT8* srcdata = m_gfx[1]->get_data(sprite);
+						const UINT8* srcdata = gfx(1)->get_data(sprite);
 						int count = 0;
 						int ystart, yend, yinc;
 						int xstart, xend, xinc;

--- a/src/mame/video/k007121.cpp
+++ b/src/mame/video/k007121.cpp
@@ -229,13 +229,12 @@ WRITE8_MEMBER( k007121_device::ctrl_w )
  *
  */
 
-void k007121_device::sprites_draw( bitmap_ind16 &bitmap, const rectangle &cliprect, gfx_element *gfx, palette_device *palette,
-							const UINT8 *source, int base_color, int global_x_offset, int bank_base, bitmap_ind8 &priority_bitmap, UINT32 pri_mask )
+void k007121_device::sprites_draw( bitmap_ind16 &bitmap, const rectangle &cliprect, gfx_element *gfx, palette_device &palette,
+							const UINT8 *source, int base_color, int global_x_offset, int bank_base, bitmap_ind8 &priority_bitmap, UINT32 pri_mask, bool is_flakatck )
 {
 	//  gfx_element *gfx = gfxs[chip];
 	int flipscreen = m_flipscreen;
 	int i, num, inc, offs[5];
-	int is_flakatck = (palette == nullptr);
 
 	if (is_flakatck)
 	{
@@ -296,7 +295,7 @@ void k007121_device::sprites_draw( bitmap_ind16 &bitmap, const rectangle &clipre
 		if (is_flakatck)
 			transparent_mask = 1 << 0;
 		else
-			transparent_mask = palette->transpen_mask(*gfx, color, 0);
+			transparent_mask = palette.transpen_mask(*gfx, color, 0);
 
 		if (!is_flakatck || source[0x00])   /* Flak Attack needs this */
 		{

--- a/src/mame/video/k007121.h
+++ b/src/mame/video/k007121.h
@@ -17,7 +17,7 @@ public:
 
 	/* shall we move source in the interface? */
 	/* also notice that now we directly pass *gfx[chip] instead of **gfx !! */
-	void sprites_draw( bitmap_ind16 &bitmap, const rectangle &cliprect, gfx_element *gfx, palette_device *palette, const UINT8 *source, int base_color, int global_x_offset, int bank_base, bitmap_ind8 &priority_bitmap, UINT32 pri_mask );
+	void sprites_draw( bitmap_ind16 &bitmap, const rectangle &cliprect, gfx_element *gfx, palette_device &palette, const UINT8 *source, int base_color, int global_x_offset, int bank_base, bitmap_ind8 &priority_bitmap, UINT32 pri_mask, bool is_flakatck = false );
 
 protected:
 	// device-level overrides

--- a/src/mame/video/k051316.cpp
+++ b/src/mame/video/k051316.cpp
@@ -159,7 +159,7 @@ void k051316_device::device_start()
 	}
 
 	decode_gfx();
-	m_gfx[0]->set_colors(m_palette->entries() / m_gfx[0]->depth());
+	gfx(0)->set_colors(palette().entries() / gfx(0)->depth());
 
 	m_tmap = &machine().tilemap().create(*this, tilemap_get_info_delegate(FUNC(k051316_device::get_tile_info),this), TILEMAP_SCAN_ROWS, 16, 16, 32, 32);
 	m_ram.resize(0x800);

--- a/src/mame/video/k051316.h
+++ b/src/mame/video/k051316.h
@@ -70,7 +70,7 @@ public:
 	void zoom_draw(screen_device &screen, bitmap_ind16 &bitmap,const rectangle &cliprect,int flags,UINT32 priority);
 	void wraparound_enable(int status);
 
-	void mark_gfx_dirty(offs_t byteoffset) { m_gfx[0]->mark_dirty(byteoffset * m_pixels_per_byte / (16 * 16)); }
+	void mark_gfx_dirty(offs_t byteoffset) { gfx(0)->mark_dirty(byteoffset * m_pixels_per_byte / (16 * 16)); }
 	void mark_tmap_dirty() { m_tmap->mark_all_dirty(); }
 
 protected:

--- a/src/mame/video/k051960.cpp
+++ b/src/mame/video/k051960.cpp
@@ -196,9 +196,9 @@ void k051960_device::device_start()
 	m_sprite_size = region()->bytes();
 
 	decode_gfx();
-	m_gfx[0]->set_colors(m_palette->entries() / m_gfx[0]->depth());
+	gfx(0)->set_colors(palette().entries() / gfx(0)->depth());
 
-	if (VERBOSE && !(m_palette->shadows_enabled()))
+	if (VERBOSE && !(palette().shadows_enabled()))
 		popmessage("driver should use VIDEO_HAS_SHADOWS");
 
 	m_ram = make_unique_clear<UINT8[]>(0x400);
@@ -466,7 +466,7 @@ void k051960_device::k051960_sprites_draw( bitmap_ind16 &bitmap, const rectangle
 			flipy = !flipy;
 		}
 
-		drawmode_table[m_gfx[0]->granularity() - 1] = shadow ? DRAWMODE_SHADOW : DRAWMODE_SOURCE;
+		drawmode_table[gfx(0)->granularity() - 1] = shadow ? DRAWMODE_SHADOW : DRAWMODE_SOURCE;
 
 		if (zoomx == 0x10000 && zoomy == 0x10000)
 		{
@@ -492,14 +492,14 @@ void k051960_device::k051960_sprites_draw( bitmap_ind16 &bitmap, const rectangle
 						c += yoffset[y];
 
 					if (max_priority == -1)
-						m_gfx[0]->prio_transtable(bitmap,cliprect,
+						gfx(0)->prio_transtable(bitmap,cliprect,
 								c,color,
 								flipx,flipy,
 								sx & 0x1ff,sy,
 								priority_bitmap,pri,
 								drawmode_table);
 					else
-						m_gfx[0]->transtable(bitmap,cliprect,
+						gfx(0)->transtable(bitmap,cliprect,
 								c,color,
 								flipx,flipy,
 								sx & 0x1ff,sy,
@@ -533,7 +533,7 @@ void k051960_device::k051960_sprites_draw( bitmap_ind16 &bitmap, const rectangle
 						c += yoffset[y];
 
 					if (max_priority == -1)
-						m_gfx[0]->prio_zoom_transtable(bitmap,cliprect,
+						gfx(0)->prio_zoom_transtable(bitmap,cliprect,
 								c,color,
 								flipx,flipy,
 								sx & 0x1ff,sy,
@@ -541,7 +541,7 @@ void k051960_device::k051960_sprites_draw( bitmap_ind16 &bitmap, const rectangle
 								priority_bitmap,pri,
 								drawmode_table);
 					else
-						m_gfx[0]->zoom_transtable(bitmap,cliprect,
+						gfx(0)->zoom_transtable(bitmap,cliprect,
 								c,color,
 								flipx,flipy,
 								sx & 0x1ff,sy,

--- a/src/mame/video/k052109.cpp
+++ b/src/mame/video/k052109.cpp
@@ -223,7 +223,7 @@ void k052109_device::device_start()
 	}
 
 	decode_gfx();
-	m_gfx[0]->set_colors(m_palette->entries() / m_gfx[0]->depth());
+	gfx(0)->set_colors(palette().entries() / gfx(0)->depth());
 
 	m_ram = make_unique_clear<UINT8[]>(0x6000);
 

--- a/src/mame/video/k053244_k053245.cpp
+++ b/src/mame/video/k053244_k053245.cpp
@@ -123,9 +123,9 @@ void k05324x_device::device_start()
 
 	/* decode the graphics */
 	decode_gfx();
-	m_gfx[0]->set_colors(m_palette->entries() / m_gfx[0]->depth());
+	gfx(0)->set_colors(palette().entries() / gfx(0)->depth());
 
-	if (VERBOSE && !(m_palette->shadows_enabled()))
+	if (VERBOSE && !(palette().shadows_enabled()))
 		popmessage("driver should use VIDEO_HAS_SHADOWS");
 
 	m_ramsize = 0x800;
@@ -458,7 +458,7 @@ void k05324x_device::sprites_draw( bitmap_ind16 &bitmap, const rectangle &clipre
 		ox -= (zoomx * w) >> 13;
 		oy -= (zoomy * h) >> 13;
 
-		drawmode_table[m_gfx[0]->granularity() - 1] = shadow ? DRAWMODE_SHADOW : DRAWMODE_SOURCE;
+		drawmode_table[gfx(0)->granularity() - 1] = shadow ? DRAWMODE_SHADOW : DRAWMODE_SOURCE;
 
 		for (y = 0; y < h; y++)
 		{
@@ -522,7 +522,7 @@ void k05324x_device::sprites_draw( bitmap_ind16 &bitmap, const rectangle &clipre
 
 				if (zoomx == 0x10000 && zoomy == 0x10000)
 				{
-					m_gfx[0]->prio_transtable(bitmap,cliprect,
+					gfx(0)->prio_transtable(bitmap,cliprect,
 							c,color,
 							fx,fy,
 							sx,sy,
@@ -531,7 +531,7 @@ void k05324x_device::sprites_draw( bitmap_ind16 &bitmap, const rectangle &clipre
 				}
 				else
 				{
-					m_gfx[0]->prio_zoom_transtable(bitmap,cliprect,
+					gfx(0)->prio_zoom_transtable(bitmap,cliprect,
 							c,color,
 							fx,fy,
 							sx,sy,

--- a/src/mame/video/k053250.cpp
+++ b/src/mame/video/k053250.cpp
@@ -353,7 +353,7 @@ void k053250_device::draw( bitmap_rgb32 &bitmap, const rectangle &cliprect, int 
 	linedata_offs += line_start * linedata_adv;     // pre-advance line info offset for the clipped region
 
 	// load physical palette base
-	pal_base = m_palette->pens() + (colorbase << 4) % m_palette->entries();
+	pal_base = palette().pens() + (colorbase << 4) % palette().entries();
 
 	// walk the target bitmap within the visible area vertically or horizontally, one line at a time
 	for (line_pos=line_start; line_pos <= line_end; linedata_offs += linedata_adv, line_pos++)

--- a/src/mame/video/k053936.cpp
+++ b/src/mame/video/k053936.cpp
@@ -436,7 +436,7 @@ static inline void K053936GP_copyroz32clip( running_machine &machine,
 		bitmap_rgb32 &dst_bitmap, bitmap_ind16 &src_bitmap,
 		const rectangle &dst_cliprect, const rectangle &src_cliprect,
 		UINT32 _startx,UINT32 _starty,int _incxx,int _incxy,int _incyx,int _incyy,
-		int tilebpp, int blend, int alpha, int clip, int pixeldouble_output, palette_device *palette )
+		int tilebpp, int blend, int alpha, int clip, int pixeldouble_output, palette_device &palette )
 {
 	static const int colormask[8]={1,3,7,0xf,0x1f,0x3f,0x7f,0xff};
 	int cy, cx;
@@ -484,7 +484,7 @@ static inline void K053936GP_copyroz32clip( running_machine &machine,
 	ecx = tx = -tx;
 
 	tilebpp = (tilebpp-1) & 7;
-	pal_base = palette->pens();
+	pal_base = palette.pens();
 	cmask = colormask[tilebpp];
 
 	src_pitch = src_bitmap.rowpixels();
@@ -590,7 +590,7 @@ static inline void K053936GP_copyroz32clip( running_machine &machine,
 static void K053936GP_zoom_draw(running_machine &machine,
 		int chip, UINT16 *ctrl, UINT16 *linectrl,
 		bitmap_rgb32 &bitmap, const rectangle &cliprect, tilemap_t *tmap,
-		int tilebpp, int blend, int alpha, int pixeldouble_output, palette_device *palette)
+		int tilebpp, int blend, int alpha, int pixeldouble_output, palette_device &palette)
 {
 	UINT16 *lineaddr;
 
@@ -658,7 +658,7 @@ static void K053936GP_zoom_draw(running_machine &machine,
 }
 
 void K053936GP_0_zoom_draw(running_machine &machine, bitmap_rgb32 &bitmap, const rectangle &cliprect,
-		tilemap_t *tmap, int tilebpp, int blend, int alpha, int pixeldouble_output, UINT16* temp_m_k053936_0_ctrl_16, UINT16* temp_m_k053936_0_linectrl_16,UINT16* temp_m_k053936_0_ctrl, UINT16* temp_m_k053936_0_linectrl, palette_device *palette)
+		tilemap_t *tmap, int tilebpp, int blend, int alpha, int pixeldouble_output, UINT16* temp_m_k053936_0_ctrl_16, UINT16* temp_m_k053936_0_linectrl_16,UINT16* temp_m_k053936_0_ctrl, UINT16* temp_m_k053936_0_linectrl, palette_device &palette)
 {
 	if (temp_m_k053936_0_ctrl_16)
 	{

--- a/src/mame/video/k053936.h
+++ b/src/mame/video/k053936.h
@@ -13,7 +13,7 @@ void K053936_set_offset(int chip, int xoffs, int yoffs);
 void K053936GP_set_offset(int chip, int xoffs, int yoffs);
 void K053936GP_clip_enable(int chip, int status);
 void K053936GP_set_cliprect(int chip, int minx, int maxx, int miny, int maxy);
-void K053936GP_0_zoom_draw(running_machine &machine, bitmap_rgb32 &bitmap, const rectangle &cliprect, tilemap_t *tmap, int tilebpp, int blend, int alpha, int pixeldouble_output, UINT16* temp_m_k053936_0_ctrl_16, UINT16* temp_m_k053936_0_linectrl_16, UINT16* temp_m_k053936_0_ctrl, UINT16* temp_m_k053936_0_linectrl, palette_device *palette);
+void K053936GP_0_zoom_draw(running_machine &machine, bitmap_rgb32 &bitmap, const rectangle &cliprect, tilemap_t *tmap, int tilebpp, int blend, int alpha, int pixeldouble_output, UINT16* temp_m_k053936_0_ctrl_16, UINT16* temp_m_k053936_0_linectrl_16, UINT16* temp_m_k053936_0_ctrl, UINT16* temp_m_k053936_0_linectrl, palette_device &palette);
 
 
 class k053936_device : public device_t

--- a/src/mame/video/k054338.cpp
+++ b/src/mame/video/k054338.cpp
@@ -74,7 +74,7 @@ int  k054338_device::register_r( int reg )
 	return m_regs[reg];
 }
 
-void k054338_device::update_all_shadows( int rushingheroes_hack, palette_device *palette )
+void k054338_device::update_all_shadows( int rushingheroes_hack, palette_device &palette )
 {
 	int i, d;
 	int noclip = m_regs[K338_REG_CONTROL] & K338_CTL_CLIPSL;
@@ -89,15 +89,15 @@ void k054338_device::update_all_shadows( int rushingheroes_hack, palette_device 
 
 	if (!rushingheroes_hack)
 	{
-		palette->set_shadow_dRGB32(0, m_shd_rgb[0], m_shd_rgb[1], m_shd_rgb[2], noclip);
-		palette->set_shadow_dRGB32(1, m_shd_rgb[3], m_shd_rgb[4], m_shd_rgb[5], noclip);
-		palette->set_shadow_dRGB32(2, m_shd_rgb[6], m_shd_rgb[7], m_shd_rgb[8], noclip);
+		palette.set_shadow_dRGB32(0, m_shd_rgb[0], m_shd_rgb[1], m_shd_rgb[2], noclip);
+		palette.set_shadow_dRGB32(1, m_shd_rgb[3], m_shd_rgb[4], m_shd_rgb[5], noclip);
+		palette.set_shadow_dRGB32(2, m_shd_rgb[6], m_shd_rgb[7], m_shd_rgb[8], noclip);
 	}
 	else // rushing heroes seems to specify shadows in another format, or it's not being interpreted properly.
 	{
-		palette->set_shadow_dRGB32(0, -80, -80, -80, 0);
-		palette->set_shadow_dRGB32(1, -80, -80, -80, 0);
-		palette->set_shadow_dRGB32(2, -80, -80, -80, 0);
+		palette.set_shadow_dRGB32(0, -80, -80, -80, 0);
+		palette.set_shadow_dRGB32(1, -80, -80, -80, 0);
+		palette.set_shadow_dRGB32(2, -80, -80, -80, 0);
 	}
 }
 

--- a/src/mame/video/k054338.h
+++ b/src/mame/video/k054338.h
@@ -38,7 +38,7 @@ public:
 	DECLARE_READ16_MEMBER( word_r );        // CLTC
 
 	int register_r(int reg);
-	void update_all_shadows(int rushingheroes_hack, palette_device *palette);          // called at the beginning of SCREEN_UPDATE()
+	void update_all_shadows(int rushingheroes_hack, palette_device &palette);          // called at the beginning of SCREEN_UPDATE()
 	void fill_solid_bg(bitmap_rgb32 &bitmap, const rectangle &cliprect);             // solid backcolor fill
 	void fill_backcolor(bitmap_rgb32 &bitmap, const rectangle &cliprect, const pen_t *pal_ptr, int mode);  // solid or gradient fill using k055555
 	int  set_alpha_level(int pblend);                         // blend style 0-2

--- a/src/mame/video/kaneko16.cpp
+++ b/src/mame/video/kaneko16.cpp
@@ -29,11 +29,11 @@ VIDEO_START_MEMBER(kaneko16_state,kaneko16)
    the times. To do it right, each pixel should be drawn with pen 0
    of the bottomost tile that covers it (which is pretty tricky to do) */
 template<class _BitmapClass>
-void kaneko16_state::kaneko16_fill_bitmap(palette_device* palette, _BitmapClass &bitmap, const rectangle &cliprect)
+void kaneko16_state::kaneko16_fill_bitmap(_BitmapClass &bitmap, const rectangle &cliprect)
 {
 	int pen = 0;
 
-	if (m_kaneko_spr)
+	if (m_kaneko_spr.found())
 	{
 		if (m_kaneko_spr->get_sprite_type() == 1)
 		{
@@ -49,7 +49,7 @@ void kaneko16_state::kaneko16_fill_bitmap(palette_device* palette, _BitmapClass 
 	}
 	else
 	{
-		const pen_t *pal = palette->pens();
+		const pen_t *pal = m_palette->pens();
 		bitmap.fill(pal[pen], cliprect);
 	}
 }
@@ -82,7 +82,7 @@ UINT32 kaneko16_state::screen_update_common(screen_device &screen, _BitmapClass 
 
 UINT32 kaneko16_state::screen_update_kaneko16(screen_device &screen, bitmap_ind16 &bitmap, const rectangle &cliprect)
 {
-	kaneko16_fill_bitmap(m_palette, bitmap,cliprect);
+	kaneko16_fill_bitmap(bitmap,cliprect);
 
 	// if the display is disabled, do nothing?
 	if (!m_disp_enable) return 0;

--- a/src/mame/video/kaneko_spr.cpp
+++ b/src/mame/video/kaneko_spr.cpp
@@ -308,7 +308,7 @@ void kaneko16_sprite_device::kaneko16_draw_sprites_custom(_BitmapClass &dest_bmp
 			if (sizeof(*dest) == 2) rgb = 0;
 			else rgb = 1;
 
-			const pen_t *pal = gfx->palette()->pens();
+			const pen_t *pal = gfx->palette().pens();
 
 			for (int y = sy; y < ey; y++)
 			{
@@ -575,7 +575,7 @@ void kaneko16_sprite_device::kaneko16_copybitmap(bitmap_ind16 &bitmap, const rec
 
 void kaneko16_sprite_device::kaneko16_copybitmap(bitmap_rgb32 &bitmap, const rectangle &cliprect)
 {
-	const pen_t *pal = m_gfxdecode->gfx(0)->palette()->pens();
+	const pen_t *pal = m_gfxdecode->gfx(0)->palette().pens();
 	UINT16* srcbitmap;
 	UINT32* dstbitmap;
 

--- a/src/mame/video/konami_helper.cpp
+++ b/src/mame/video/konami_helper.cpp
@@ -11,7 +11,7 @@ void konami_decode_gfx(running_machine &machine, gfxdecode_device * gfxdecode, p
 
 	memcpy(&gl, layout, sizeof(gl));
 	gl.total = total;
-	gfxdecode->set_gfx(gfx_index, std::make_unique<gfx_element>(&palette, gl, data, 0, palette.entries() >> bpp, 0));
+	gfxdecode->set_gfx(gfx_index, std::make_unique<gfx_element>(palette, gl, data, 0, palette.entries() >> bpp, 0));
 }
 
 

--- a/src/mame/video/offtwall.cpp
+++ b/src/mame/video/offtwall.cpp
@@ -84,14 +84,14 @@ VIDEO_START_MEMBER(offtwall_state,offtwall)
 UINT32 offtwall_state::screen_update_offtwall(screen_device &screen, bitmap_ind16 &bitmap, const rectangle &cliprect)
 {
 	// start drawing
-	m_vad->mob()->draw_async(cliprect);
+	m_vad->mob().draw_async(cliprect);
 
 	/* draw the playfield */
-	m_vad->playfield()->draw(screen, bitmap, cliprect, 0, 0);
+	m_vad->playfield().draw(screen, bitmap, cliprect, 0, 0);
 
 	// draw and merge the MO
-	bitmap_ind16 &mobitmap = m_vad->mob()->bitmap();
-	for (const sparse_dirty_rect *rect = m_vad->mob()->first_dirty_rect(cliprect); rect != nullptr; rect = rect->next())
+	bitmap_ind16 &mobitmap = m_vad->mob().bitmap();
+	for (const sparse_dirty_rect *rect = m_vad->mob().first_dirty_rect(cliprect); rect != nullptr; rect = rect->next())
 		for (int y = rect->min_y; y <= rect->max_y; y++)
 		{
 			UINT16 *mo = &mobitmap.pix16(y);

--- a/src/mame/video/relief.cpp
+++ b/src/mame/video/relief.cpp
@@ -96,17 +96,17 @@ VIDEO_START_MEMBER(relief_state,relief)
 UINT32 relief_state::screen_update_relief(screen_device &screen, bitmap_ind16 &bitmap, const rectangle &cliprect)
 {
 	// start drawing
-	m_vad->mob()->draw_async(cliprect);
+	m_vad->mob().draw_async(cliprect);
 
 	/* draw the playfield */
 	bitmap_ind8 &priority_bitmap = screen.priority();
 	priority_bitmap.fill(0, cliprect);
-	m_vad->playfield()->draw(screen, bitmap, cliprect, 0, 0);
-	m_vad->playfield2()->draw(screen, bitmap, cliprect, 0, 1);
+	m_vad->playfield().draw(screen, bitmap, cliprect, 0, 0);
+	m_vad->playfield2().draw(screen, bitmap, cliprect, 0, 1);
 
 	// draw and merge the MO
-	bitmap_ind16 &mobitmap = m_vad->mob()->bitmap();
-	for (const sparse_dirty_rect *rect = m_vad->mob()->first_dirty_rect(cliprect); rect != nullptr; rect = rect->next())
+	bitmap_ind16 &mobitmap = m_vad->mob().bitmap();
+	for (const sparse_dirty_rect *rect = m_vad->mob().first_dirty_rect(cliprect); rect != nullptr; rect = rect->next())
 		for (int y = rect->min_y; y <= rect->max_y; y++)
 		{
 			UINT16 *mo = &mobitmap.pix16(y);

--- a/src/mame/video/shuuz.cpp
+++ b/src/mame/video/shuuz.cpp
@@ -78,14 +78,14 @@ const atari_motion_objects_config shuuz_state::s_mob_config =
 UINT32 shuuz_state::screen_update(screen_device &screen, bitmap_ind16 &bitmap, const rectangle &cliprect)
 {
 	// start drawing
-	m_vad->mob()->draw_async(cliprect);
+	m_vad->mob().draw_async(cliprect);
 
 	/* draw the playfield */
-	m_vad->playfield()->draw(screen, bitmap, cliprect, 0, 0);
+	m_vad->playfield().draw(screen, bitmap, cliprect, 0, 0);
 
 	// draw and merge the MO
-	bitmap_ind16 &mobitmap = m_vad->mob()->bitmap();
-	for (const sparse_dirty_rect *rect = m_vad->mob()->first_dirty_rect(cliprect); rect != nullptr; rect = rect->next())
+	bitmap_ind16 &mobitmap = m_vad->mob().bitmap();
+	for (const sparse_dirty_rect *rect = m_vad->mob().first_dirty_rect(cliprect); rect != nullptr; rect = rect->next())
 		for (int y = rect->min_y; y <= rect->max_y; y++)
 		{
 			UINT16 *mo = &mobitmap.pix16(y);

--- a/src/mame/video/tecmo_mix.cpp
+++ b/src/mame/video/tecmo_mix.cpp
@@ -90,13 +90,13 @@ void tecmo_mix_device::set_bgpen(device_t &device, int bgpen)
 }
 
 
-void tecmo_mix_device::mix_bitmaps(screen_device &screen, bitmap_rgb32 &bitmap, const rectangle &cliprect, palette_device* palette, bitmap_ind16* bitmap_bg, bitmap_ind16* bitmap_fg, bitmap_ind16* bitmap_tx, bitmap_ind16* bitmap_sp)
+void tecmo_mix_device::mix_bitmaps(screen_device &screen, bitmap_rgb32 &bitmap, const rectangle &cliprect, palette_device &palette, bitmap_ind16* bitmap_bg, bitmap_ind16* bitmap_fg, bitmap_ind16* bitmap_tx, bitmap_ind16* bitmap_sp)
 {
 	//int frame = (screen.frame_number()) & 1;
 	// note this game has no tx layer, comments relate to other drivers
 
 	int y, x;
-	const pen_t *paldata = palette->pens();
+	const pen_t *paldata = palette.pens();
 
 	for (y = cliprect.min_y; y <= cliprect.max_y; y++)
 	{

--- a/src/mame/video/tecmo_mix.h
+++ b/src/mame/video/tecmo_mix.h
@@ -10,7 +10,7 @@ class tecmo_mix_device : public device_t,
 public:
 	tecmo_mix_device(const machine_config &mconfig, const char *tag, device_t *owner, UINT32 clock);
 
-	void mix_bitmaps(screen_device &screen, bitmap_rgb32 &bitmap, const rectangle &cliprect, palette_device* palette, bitmap_ind16* bitmap_bg, bitmap_ind16* bitmap_fg, bitmap_ind16* bitmap_tx, bitmap_ind16* bitmap_sp);
+	void mix_bitmaps(screen_device &screen, bitmap_rgb32 &bitmap, const rectangle &cliprect, palette_device &palette, bitmap_ind16* bitmap_bg, bitmap_ind16* bitmap_fg, bitmap_ind16* bitmap_tx, bitmap_ind16* bitmap_sp);
 	static void set_mixer_shifts(device_t &device, int sprpri_shift, int sprbln_shift, int sprcol_shift);
 	static void set_blendcols(device_t &device, int bgblend_comp, int fgblend_comp, int txblend_comp, int spblend_comp);
 	static void set_regularcols(device_t &device, int bgregular_comp, int fgregular_comp, int txregular_comp, int spregular_comp);

--- a/src/mame/video/thunderj.cpp
+++ b/src/mame/video/thunderj.cpp
@@ -106,23 +106,23 @@ VIDEO_START_MEMBER(thunderj_state,thunderj)
 UINT32 thunderj_state::screen_update_thunderj(screen_device &screen, bitmap_ind16 &bitmap, const rectangle &cliprect)
 {
 	// start drawing
-	m_vad->mob()->draw_async(cliprect);
+	m_vad->mob().draw_async(cliprect);
 
 	/* draw the playfield */
 	bitmap_ind8 &priority_bitmap = screen.priority();
 	priority_bitmap.fill(0, cliprect);
-	m_vad->playfield()->draw(screen, bitmap, cliprect, 0, 0x00);
-	m_vad->playfield()->draw(screen, bitmap, cliprect, 1, 0x01);
-	m_vad->playfield()->draw(screen, bitmap, cliprect, 2, 0x02);
-	m_vad->playfield()->draw(screen, bitmap, cliprect, 3, 0x03);
-	m_vad->playfield2()->draw(screen, bitmap, cliprect, 0, 0x80);
-	m_vad->playfield2()->draw(screen, bitmap, cliprect, 1, 0x84);
-	m_vad->playfield2()->draw(screen, bitmap, cliprect, 2, 0x88);
-	m_vad->playfield2()->draw(screen, bitmap, cliprect, 3, 0x8c);
+	m_vad->playfield().draw(screen, bitmap, cliprect, 0, 0x00);
+	m_vad->playfield().draw(screen, bitmap, cliprect, 1, 0x01);
+	m_vad->playfield().draw(screen, bitmap, cliprect, 2, 0x02);
+	m_vad->playfield().draw(screen, bitmap, cliprect, 3, 0x03);
+	m_vad->playfield2().draw(screen, bitmap, cliprect, 0, 0x80);
+	m_vad->playfield2().draw(screen, bitmap, cliprect, 1, 0x84);
+	m_vad->playfield2().draw(screen, bitmap, cliprect, 2, 0x88);
+	m_vad->playfield2().draw(screen, bitmap, cliprect, 3, 0x8c);
 
 	// draw and merge the MO
-	bitmap_ind16 &mobitmap = m_vad->mob()->bitmap();
-	for (const sparse_dirty_rect *rect = m_vad->mob()->first_dirty_rect(cliprect); rect != nullptr; rect = rect->next())
+	bitmap_ind16 &mobitmap = m_vad->mob().bitmap();
+	for (const sparse_dirty_rect *rect = m_vad->mob().first_dirty_rect(cliprect); rect != nullptr; rect = rect->next())
 		for (int y = rect->min_y; y <= rect->max_y; y++)
 		{
 			UINT16 *mo = &mobitmap.pix16(y);
@@ -217,10 +217,10 @@ UINT32 thunderj_state::screen_update_thunderj(screen_device &screen, bitmap_ind1
 		}
 
 	/* add the alpha on top */
-	m_vad->alpha()->draw(screen, bitmap, cliprect, 0, 0);
+	m_vad->alpha().draw(screen, bitmap, cliprect, 0, 0);
 
 	/* now go back and process the upper bit of MO priority */
-	for (const sparse_dirty_rect *rect = m_vad->mob()->first_dirty_rect(cliprect); rect != nullptr; rect = rect->next())
+	for (const sparse_dirty_rect *rect = m_vad->mob().first_dirty_rect(cliprect); rect != nullptr; rect = rect->next())
 		for (int y = rect->min_y; y <= rect->max_y; y++)
 		{
 			UINT16 *mo = &mobitmap.pix16(y);
@@ -235,7 +235,7 @@ UINT32 thunderj_state::screen_update_thunderj(screen_device &screen, bitmap_ind1
 					{
 						/* if bit 2 is set, start setting high palette bits */
 						if (mo[x] & 2)
-							m_vad->mob()->apply_stain(bitmap, pf, mo, x, y);
+							m_vad->mob().apply_stain(bitmap, pf, mo, x, y);
 					}
 				}
 		}

--- a/src/mame/video/toaplan_scu.cpp
+++ b/src/mame/video/toaplan_scu.cpp
@@ -85,7 +85,7 @@ void toaplan_scu_device::draw_sprites_to_tempbitmap(const rectangle &cliprect, U
 			if (flipx) sx -= m_xoffs_flipped;
 
 			flipy = attribute & 0x200;
-			m_gfx[0]->transpen_raw(m_temp_spritebitmap,cliprect,
+			gfx(0)->transpen_raw(m_temp_spritebitmap,cliprect,
 				sprite,
 				color << 4 /* << 4 because using _raw */ ,
 				flipx,flipy,
@@ -103,7 +103,7 @@ void toaplan_scu_device::draw_sprites_to_tempbitmap(const rectangle &cliprect, U
 void toaplan_scu_device::copy_sprites_from_tempbitmap(bitmap_ind16 &bitmap, const rectangle &cliprect, int priority)
 {
 	int y, x;
-	int colourbase = m_gfx[0]->colorbase();
+	int colourbase = gfx(0)->colorbase();
 
 	for (y=cliprect.min_y;y<=cliprect.max_y;y++)
 	{


### PR DESCRIPTION
- Add screen_device::has_palette()
- Require device_gfx_interface::gfx() and palette() to access members
- Getters for atari_vad_device return devices as references, not pointers
- Pass is_flakatck to k007121::sprites_draw as a parameter of its own