### PR TITLE
Some more validity checking improvements:

### DIFF
--- a/src/emu/clifront.cpp
+++ b/src/emu/clifront.cpp
@@ -1595,7 +1595,8 @@ void cli_frontend::execute_commands(const char *exename)
 	if (strcmp(m_options.command(), CLICOMMAND_VALIDATE) == 0)
 	{
 		validity_checker valid(m_options);
-		bool result = valid.check_all();
+		const char *sysname = m_options.system_name();
+		bool result = valid.check_all_matching((sysname[0] == 0) ? "*" : sysname);
 		if (!result)
 			throw emu_fatalerror(MAMERR_FAILED_VALIDITY, "Validity check failed (%d errors, %d warnings in total)\n", valid.errors(), valid.warnings());
 		return;

--- a/src/emu/validity.cpp
+++ b/src/emu/validity.cpp
@@ -184,10 +184,11 @@ void validity_checker::check_shared_source(const game_driver &driver)
 
 
 //-------------------------------------------------
-//  check_all - check all drivers
+//  check_all_matching - check all drivers whose
+//  names match the given string
 //-------------------------------------------------
 
-bool validity_checker::check_all()
+bool validity_checker::check_all_matching(const char *string)
 {
 	// start by checking core stuff
 	validate_begin();
@@ -210,7 +211,8 @@ bool validity_checker::check_all()
 	// then iterate over all drivers and check them
 	m_drivlist.reset();
 	while (m_drivlist.next())
-		validate_one(m_drivlist.driver());
+		if (m_drivlist.matches(string, m_drivlist.driver().name))
+			validate_one(m_drivlist.driver());
 
 	// cleanup
 	validate_end();
@@ -968,15 +970,11 @@ void validity_checker::validate_devices()
 	device_iterator iter_find(m_current_config->root_device());
 	for (const device_t *device = iter_find.first(); device != nullptr; device = iter_find.next())
 	{
-		device->findit(true);
-	}
-
-	// iterate over devices
-	device_iterator iter(m_current_config->root_device());
-	for (const device_t *device = iter.first(); device != nullptr; device = iter.next())
-	{
 		// track the current device
 		m_current_device = device;
+
+		// validate auto-finders
+		device->findit(true);
 
 		// validate the device tag
 		validate_tag(device->basetag());

--- a/src/emu/validity.h
+++ b/src/emu/validity.h
@@ -46,7 +46,7 @@ public:
 	// operations
 	void check_driver(const game_driver &driver);
 	void check_shared_source(const game_driver &driver);
-	bool check_all();
+	bool check_all_matching(const char *string = "*");
 
 	// helpers for devices
 	void validate_tag(const char *tag);


### PR DESCRIPTION
- The -validate command now accepts an optional string, validating only matching drivers.
  This has proven useful for debugging. The default is to validate all drivers as usual.
- Devices' names are tracked when validating their auto-finders.