### PR TITLE
Marywu improvements

### DIFF
--- a/src/mame/drivers/marywu.cpp
+++ b/src/mame/drivers/marywu.cpp
@@ -36,6 +36,7 @@ public:
     DECLARE_WRITE8_MEMBER(ay2_port_a_w);
     DECLARE_WRITE8_MEMBER(ay2_port_b_w);
     DECLARE_READ8_MEMBER(keyboard_r);
+    DECLARE_READ8_MEMBER(port_r);
 private:
     uint8_t m_selected_7seg_module;
 };
@@ -132,6 +133,17 @@ WRITE8_MEMBER( marywu_state::multiplex_7seg_w )
     m_selected_7seg_module = data;
 }
 
+READ8_MEMBER( marywu_state::port_r )
+{
+//TODO: figure out what each bit is mapped to in the 80c31 ports P1 and P3
+    switch(offset){
+        //case 1:
+	//	return (1 << 6);
+	default:
+		return 0x00;
+    }
+}
+
 READ8_MEMBER( marywu_state::keyboard_r )
 {
     switch(m_selected_7seg_module % 8){
@@ -165,7 +177,7 @@ static ADDRESS_MAP_START( io_map, AS_IO, 8, marywu_state )
     AM_RANGE(0x9002, 0x9002) AM_MIRROR(0x0ffc) AM_DEVWRITE("ay2", ay8910_device, data_address_w)
     AM_RANGE(0x9003, 0x9003) AM_MIRROR(0x0ffc) AM_DEVREADWRITE("ay2", ay8910_device, data_r, data_w)
     AM_RANGE(0xf000, 0xf000) AM_NOP /* TODO: Investigate this. There's something going on at this address range. */
-    AM_RANGE(MCS51_PORT_P0, MCS51_PORT_P3) AM_NOP /* FIX-ME! I am ignoring port accesses for a while. */
+    AM_RANGE(MCS51_PORT_P0, MCS51_PORT_P3) AM_READ(port_r)
 ADDRESS_MAP_END
 
 static MACHINE_CONFIG_START( marywu , marywu_state )

--- a/src/mame/drivers/marywu.cpp
+++ b/src/mame/drivers/marywu.cpp
@@ -10,7 +10,7 @@
 
   TODO:
   * Figure out where exactly all devices are mapped to (the devices are
-    2 sound chips, the KC8279 controller the 2kb SRAM, the 8bit dipswitches,
+    2 sound chips, the 2kb SRAM, the 8bit dipswitches,
     31 LEDs, 13 modules of double-digit 7-seg displays and 4 push-buttons).
   * we may also have user inputs from the coin slot and from the
     cabinet buttons, for making bets.
@@ -19,6 +19,7 @@
 #include "emu.h"
 #include "cpu/mcs51/mcs51.h"
 #include "sound/ay8910.h"
+#include "machine/i8279.h"
 
 class marywu_state : public driver_device
 {
@@ -26,7 +27,15 @@ public:
     marywu_state(const machine_config &mconfig, device_type type, const char *tag)
         : driver_device(mconfig, type, tag)
     { }
+
+    DECLARE_WRITE8_MEMBER(display_7seg_data_w);
 };
+
+WRITE8_MEMBER( marywu_state::display_7seg_data_w )
+{
+    output_set_digit_value(0, data & 0x0F);
+    output_set_digit_value(1, data & 0xF0);
+}
 
 static ADDRESS_MAP_START( program_map, AS_PROGRAM, 8, marywu_state )
     AM_RANGE(0x0000, 0x7fff) AM_ROM
@@ -34,7 +43,8 @@ ADDRESS_MAP_END
 
 static ADDRESS_MAP_START( io_map, AS_IO, 8, marywu_state )
     AM_RANGE(0x8000, 0x87ff) AM_RAM //HM6116: 2kbytes of Static RAM /* This is a guess. Maybe it is also mirrored? */
-    //AM_RANGE(0xB000, 0xB001) AM_NOP /*maybe this is where the keyboard/display "KC8279" controller is hooked up ? */
+    AM_RANGE(0xB000, 0xB000) AM_DEVREADWRITE("i8279", i8279_device, data_r, data_w)
+    AM_RANGE(0xB001, 0xB001) AM_DEVREADWRITE("i8279", i8279_device, status_r, cmd_w)
     AM_RANGE(0x9001, 0x9002) AM_DEVREADWRITE("ay1", ay8910_device, data_r, address_data_w) /* This is a guess */
     AM_RANGE(0x9003, 0x9004) AM_DEVREADWRITE("ay2", ay8910_device, data_r, address_data_w) /* This is a guess */
 ADDRESS_MAP_END
@@ -44,6 +54,12 @@ static MACHINE_CONFIG_START( marywu , marywu_state )
     MCFG_CPU_ADD("maincpu", I80C31, XTAL_10_738635MHz) //actual CPU is a Winbond w78c31b-24
     MCFG_CPU_PROGRAM_MAP(program_map)
     MCFG_CPU_IO_MAP(io_map)
+
+    /* Keyboard interface */
+    MCFG_DEVICE_ADD("i8279", I8279, XTAL_10_738635MHz) /* should it be perhaps a fraction of the XTAL clock ? */
+//    MCFG_I8279_OUT_SL_CB(WRITE8(marywu_state, marywu_scanlines_w))          // scan SL lines
+//    MCFG_I8279_IN_RL_CB(READ8(marywu_state, marywu_kbd_r))                  // kbd RL lines
+    MCFG_I8279_OUT_DISP_CB(WRITE8(marywu_state, display_7seg_data_w))
 
     /* sound hardware */
     MCFG_SPEAKER_STANDARD_MONO("mono")

--- a/src/mame/drivers/marywu.cpp
+++ b/src/mame/drivers/marywu.cpp
@@ -30,14 +30,22 @@ public:
     { }
 
     DECLARE_WRITE8_MEMBER(display_7seg_data_w);
+    DECLARE_WRITE8_MEMBER(multiplex_7seg_w);
+private:
+    uint8_t m_selected_7seg_module;
 };
+
+WRITE8_MEMBER( marywu_state::multiplex_7seg_w )
+{
+        m_selected_7seg_module = data;
+}
 
 WRITE8_MEMBER( marywu_state::display_7seg_data_w )
 {
     static const UINT8 patterns[16] = { 0x3f, 0x06, 0x5b, 0x4f, 0x66, 0x6d, 0x7c, 0x07, 0x7f, 0x67, 0, 0, 0, 0, 0, 0 }; // HEF4511BP (7 seg display driver)
 
-    output_set_digit_value(0, patterns[data & 0x0F]);
-    output_set_digit_value(1, patterns[(data >> 4) & 0x0F]);
+    output_set_digit_value(2 * m_selected_7seg_module + 0, patterns[data & 0x0F]);
+    output_set_digit_value(2 * m_selected_7seg_module + 1, patterns[(data >> 4) & 0x0F]);
 }
 
 static ADDRESS_MAP_START( program_map, AS_PROGRAM, 8, marywu_state )
@@ -60,7 +68,7 @@ static MACHINE_CONFIG_START( marywu , marywu_state )
 
     /* Keyboard & display interface */
     MCFG_DEVICE_ADD("i8279", I8279, XTAL_10_738635MHz) /* should it be perhaps a fraction of the XTAL clock ? */
-//    MCFG_I8279_OUT_SL_CB(WRITE8(marywu_state, marywu_scanlines_w))          // scan SL lines
+    MCFG_I8279_OUT_SL_CB(WRITE8(marywu_state, multiplex_7seg_w))          // select  block of 7seg modules by multiplexing the SL scan lines
 //    MCFG_I8279_IN_RL_CB(READ8(marywu_state, marywu_kbd_r))                  // kbd RL lines
     MCFG_I8279_OUT_DISP_CB(WRITE8(marywu_state, display_7seg_data_w))
 

--- a/src/mame/drivers/marywu.cpp
+++ b/src/mame/drivers/marywu.cpp
@@ -53,11 +53,14 @@ static ADDRESS_MAP_START( program_map, AS_PROGRAM, 8, marywu_state )
 ADDRESS_MAP_END
 
 static ADDRESS_MAP_START( io_map, AS_IO, 8, marywu_state )
-    AM_RANGE(0x8000, 0x87ff) AM_RAM //HM6116: 2kbytes of Static RAM /* This is a guess. Maybe it is also mirrored? */
-    AM_RANGE(0xB000, 0xB000) AM_DEVREADWRITE("i8279", i8279_device, data_r, data_w)
-    AM_RANGE(0xB001, 0xB001) AM_DEVREADWRITE("i8279", i8279_device, status_r, cmd_w)
-    AM_RANGE(0x9001, 0x9002) AM_DEVREADWRITE("ay1", ay8910_device, data_r, address_data_w) /* This is a guess */
-    AM_RANGE(0x9003, 0x9004) AM_DEVREADWRITE("ay2", ay8910_device, data_r, address_data_w) /* This is a guess */
+    AM_RANGE(0x8000, 0x87ff) AM_MIRROR(0x0100) AM_RAM /* HM6116: 2kbytes of Static RAM */
+    AM_RANGE(0xb000, 0xb000) AM_MIRROR(0x0ffe) AM_DEVREADWRITE("i8279", i8279_device, data_r, data_w)
+    AM_RANGE(0xb001, 0xb001) AM_MIRROR(0x0ffe) AM_DEVREADWRITE("i8279", i8279_device, status_r, cmd_w)
+    AM_RANGE(0x9000, 0x9000) AM_MIRROR(0x0ffc) AM_DEVWRITE("ay1", ay8910_device, data_address_w)
+    AM_RANGE(0x9001, 0x9001) AM_MIRROR(0x0ffc) AM_DEVREADWRITE("ay1", ay8910_device, data_r, data_w)
+    AM_RANGE(0x9002, 0x9002) AM_MIRROR(0x0ffc) AM_DEVWRITE("ay2", ay8910_device, data_address_w)
+    AM_RANGE(0x9003, 0x9003) AM_MIRROR(0x0ffc) AM_DEVREADWRITE("ay2", ay8910_device, data_r, data_w)
+    AM_RANGE(MCS51_PORT_P0, MCS51_PORT_P3) AM_NOP /* FIX-ME! I am ignoring port accesses for a while. */
 ADDRESS_MAP_END
 
 static MACHINE_CONFIG_START( marywu , marywu_state )

--- a/src/mame/drivers/marywu.cpp
+++ b/src/mame/drivers/marywu.cpp
@@ -31,13 +31,84 @@ public:
 
     DECLARE_WRITE8_MEMBER(display_7seg_data_w);
     DECLARE_WRITE8_MEMBER(multiplex_7seg_w);
+    DECLARE_READ8_MEMBER(keyboard_r);
 private:
     uint8_t m_selected_7seg_module;
 };
 
+static INPUT_PORTS_START( marywu )
+    PORT_START("KEYS1")
+    PORT_BIT(0x80, IP_ACTIVE_HIGH, IPT_KEYBOARD) PORT_CODE(KEYCODE_1)
+    PORT_BIT(0x40, IP_ACTIVE_HIGH, IPT_KEYBOARD) PORT_CODE(KEYCODE_2)
+    PORT_BIT(0x20, IP_ACTIVE_HIGH, IPT_KEYBOARD) PORT_CODE(KEYCODE_3)
+    PORT_BIT(0x10, IP_ACTIVE_HIGH, IPT_KEYBOARD) PORT_CODE(KEYCODE_4)
+    PORT_BIT(0x08, IP_ACTIVE_HIGH, IPT_KEYBOARD) PORT_CODE(KEYCODE_5)
+    PORT_BIT(0x04, IP_ACTIVE_HIGH, IPT_KEYBOARD) PORT_CODE(KEYCODE_6)
+    PORT_BIT(0x02, IP_ACTIVE_HIGH, IPT_KEYBOARD) PORT_CODE(KEYCODE_7)
+    PORT_BIT(0x01, IP_ACTIVE_HIGH, IPT_KEYBOARD) PORT_CODE(KEYCODE_8)
+
+    PORT_START("KEYS2")
+    PORT_BIT(0x80, IP_ACTIVE_HIGH, IPT_KEYBOARD) PORT_CODE(KEYCODE_Q)
+    PORT_BIT(0x40, IP_ACTIVE_HIGH, IPT_KEYBOARD) PORT_CODE(KEYCODE_W)
+    PORT_BIT(0x20, IP_ACTIVE_HIGH, IPT_KEYBOARD) PORT_CODE(KEYCODE_E)
+    PORT_BIT(0x10, IP_ACTIVE_HIGH, IPT_KEYBOARD) PORT_CODE(KEYCODE_R)
+    PORT_BIT(0x08, IP_ACTIVE_HIGH, IPT_KEYBOARD) PORT_CODE(KEYCODE_T)
+    PORT_BIT(0x04, IP_ACTIVE_HIGH, IPT_KEYBOARD) PORT_CODE(KEYCODE_Y)
+    PORT_BIT(0x02, IP_ACTIVE_HIGH, IPT_KEYBOARD) PORT_CODE(KEYCODE_U)
+    PORT_BIT(0x01, IP_ACTIVE_HIGH, IPT_KEYBOARD) PORT_CODE(KEYCODE_I)
+
+    PORT_START("DSW")
+    PORT_DIPNAME( 0x01, 0x01, "Unknown bit #0" )    PORT_DIPLOCATION("DSW:0")
+        PORT_DIPSETTING(0x01, DEF_STR( On ) )
+        PORT_DIPSETTING(0x00, DEF_STR( Off ) )
+    PORT_DIPNAME( 0x02, 0x02, "Unknown bit #1" )    PORT_DIPLOCATION("DSW:1")
+        PORT_DIPSETTING(0x02, DEF_STR( On ) )
+        PORT_DIPSETTING(0x00, DEF_STR( Off ) )
+    PORT_DIPNAME( 0x04, 0x04, "Unknown bit #2" )    PORT_DIPLOCATION("DSW:2")
+        PORT_DIPSETTING(0x04, DEF_STR( On ) )
+        PORT_DIPSETTING(0x00, DEF_STR( Off ) )
+    PORT_DIPNAME( 0x08, 0x08, "Unknown bit #3" )    PORT_DIPLOCATION("DSW:3")
+        PORT_DIPSETTING(0x08, DEF_STR( On ) )
+        PORT_DIPSETTING(0x00, DEF_STR( Off ) )
+    PORT_DIPNAME( 0x10, 0x10, "Unknown bit #4" )    PORT_DIPLOCATION("DSW:4")
+        PORT_DIPSETTING(0x10, DEF_STR( On ) )
+        PORT_DIPSETTING(0x00, DEF_STR( Off ) )
+    PORT_DIPNAME( 0x20, 0x20, "Unknown bit #5" )    PORT_DIPLOCATION("DSW:5")
+        PORT_DIPSETTING(0x20, DEF_STR( On ) )
+        PORT_DIPSETTING(0x00, DEF_STR( Off ) )
+    PORT_DIPNAME( 0x40, 0x40, "Unknown bit #6" )    PORT_DIPLOCATION("DSW:6")
+        PORT_DIPSETTING(0x40, DEF_STR( On ) )
+        PORT_DIPSETTING(0x00, DEF_STR( Off ) )
+    PORT_DIPNAME( 0x80, 0x80, "Unknown bit #7" )    PORT_DIPLOCATION("DSW:7")
+        PORT_DIPSETTING(0x80, DEF_STR( On ) )
+        PORT_DIPSETTING(0x00, DEF_STR( Off ) )
+
+    PORT_START("PUSHBUTTONS")
+    PORT_BIT(0x80, IP_ACTIVE_HIGH, IPT_UNUSED )
+    PORT_BIT(0x40, IP_ACTIVE_HIGH, IPT_UNUSED )
+    PORT_BIT(0x20, IP_ACTIVE_HIGH, IPT_UNUSED )
+    PORT_BIT(0x10, IP_ACTIVE_HIGH, IPT_UNUSED )
+    PORT_BIT(0x08, IP_ACTIVE_HIGH, IPT_KEYBOARD) PORT_CODE(KEYCODE_A)
+    PORT_BIT(0x04, IP_ACTIVE_HIGH, IPT_KEYBOARD) PORT_CODE(KEYCODE_S)
+    PORT_BIT(0x02, IP_ACTIVE_HIGH, IPT_KEYBOARD) PORT_CODE(KEYCODE_D)
+    PORT_BIT(0x01, IP_ACTIVE_HIGH, IPT_KEYBOARD) PORT_CODE(KEYCODE_F)
+INPUT_PORTS_END
+
 WRITE8_MEMBER( marywu_state::multiplex_7seg_w )
 {
-        m_selected_7seg_module = data;
+    m_selected_7seg_module = data;
+}
+
+READ8_MEMBER( marywu_state::keyboard_r )
+{
+    switch(m_selected_7seg_module % 8){
+	case 0: return ioport("KEYS1")->read();
+        case 1: return ioport("KEYS2")->read();
+        case 2: return ioport("DSW")->read();
+        case 3: return ioport("PUSHBUTTONS")->read();
+	default:
+            return 0x00;
+    }
 }
 
 WRITE8_MEMBER( marywu_state::display_7seg_data_w )
@@ -60,6 +131,7 @@ static ADDRESS_MAP_START( io_map, AS_IO, 8, marywu_state )
     AM_RANGE(0x9001, 0x9001) AM_MIRROR(0x0ffc) AM_DEVREADWRITE("ay1", ay8910_device, data_r, data_w)
     AM_RANGE(0x9002, 0x9002) AM_MIRROR(0x0ffc) AM_DEVWRITE("ay2", ay8910_device, data_address_w)
     AM_RANGE(0x9003, 0x9003) AM_MIRROR(0x0ffc) AM_DEVREADWRITE("ay2", ay8910_device, data_r, data_w)
+    AM_RANGE(0xf000, 0xf000) AM_NOP /* TODO: Investigate this. There's something going on at this address range. */
     AM_RANGE(MCS51_PORT_P0, MCS51_PORT_P3) AM_NOP /* FIX-ME! I am ignoring port accesses for a while. */
 ADDRESS_MAP_END
 
@@ -72,7 +144,7 @@ static MACHINE_CONFIG_START( marywu , marywu_state )
     /* Keyboard & display interface */
     MCFG_DEVICE_ADD("i8279", I8279, XTAL_10_738635MHz) /* should it be perhaps a fraction of the XTAL clock ? */
     MCFG_I8279_OUT_SL_CB(WRITE8(marywu_state, multiplex_7seg_w))          // select  block of 7seg modules by multiplexing the SL scan lines
-//    MCFG_I8279_IN_RL_CB(READ8(marywu_state, marywu_kbd_r))                  // kbd RL lines
+    MCFG_I8279_IN_RL_CB(READ8(marywu_state, keyboard_r))                  // keyboard Return Lines
     MCFG_I8279_OUT_DISP_CB(WRITE8(marywu_state, display_7seg_data_w))
 
     /* Video */
@@ -93,4 +165,4 @@ ROM_START( marywu )
 ROM_END
 
 /*    YEAR  NAME       PARENT   MACHINE   INPUT     STATE          INIT   ROT    COMPANY       FULLNAME          FLAGS  */
-GAME( ????, marywu,    0,       marywu,   0,        driver_device, 0,     ROT0, "<unknown>", "<unknown> Labeled 'WU- MARY-1A' Music by: SunKiss Chen", MACHINE_NOT_WORKING )
+GAME( ????, marywu,    0,       marywu,   marywu,   driver_device, 0,     ROT0, "<unknown>", "<unknown> Labeled 'WU- MARY-1A' Music by: SunKiss Chen", MACHINE_NOT_WORKING )

--- a/src/mame/drivers/marywu.cpp
+++ b/src/mame/drivers/marywu.cpp
@@ -31,6 +31,10 @@ public:
 
     DECLARE_WRITE8_MEMBER(display_7seg_data_w);
     DECLARE_WRITE8_MEMBER(multiplex_7seg_w);
+    DECLARE_WRITE8_MEMBER(ay1_port_a_w);
+    DECLARE_WRITE8_MEMBER(ay1_port_b_w);
+    DECLARE_WRITE8_MEMBER(ay2_port_a_w);
+    DECLARE_WRITE8_MEMBER(ay2_port_b_w);
     DECLARE_READ8_MEMBER(keyboard_r);
 private:
     uint8_t m_selected_7seg_module;
@@ -94,6 +98,35 @@ static INPUT_PORTS_START( marywu )
     PORT_BIT(0x01, IP_ACTIVE_HIGH, IPT_KEYBOARD) PORT_CODE(KEYCODE_F)
 INPUT_PORTS_END
 
+WRITE8_MEMBER( marywu_state::ay1_port_a_w )
+{
+    for (uint8_t i=0; i<8; i++){
+        output_set_led_value(i, (data & (1 << i)) ? 1 : 0);
+    }
+}
+
+WRITE8_MEMBER( marywu_state::ay1_port_b_w )
+{
+    for (uint8_t i=0; i<8; i++){
+        output_set_led_value(i+8, (data & (1 << i)) ? 1 : 0);
+    }
+}
+
+WRITE8_MEMBER( marywu_state::ay2_port_a_w )
+{
+    for (uint8_t i=0; i<8; i++){
+        output_set_led_value(i+16, (data & (1 << i)) ? 1 : 0);
+    }
+}
+
+WRITE8_MEMBER( marywu_state::ay2_port_b_w )
+{
+    for (uint8_t i=0; i<6; i++){
+        /* we only have 30 LEDs. The last 2 bits in this port are unused.  */
+        output_set_led_value(i+24, (data & (1 << i)) ? 1 : 0);
+    }
+}
+
 WRITE8_MEMBER( marywu_state::multiplex_7seg_w )
 {
     m_selected_7seg_module = data;
@@ -154,9 +187,13 @@ static MACHINE_CONFIG_START( marywu , marywu_state )
     MCFG_SPEAKER_STANDARD_MONO("mono")
     MCFG_SOUND_ADD("ay1", AY8910, XTAL_10_738635MHz) /* should it be perhaps a fraction of the XTAL clock ? */
     MCFG_SOUND_ROUTE(ALL_OUTPUTS, "mono", 0.50)
+    MCFG_AY8910_PORT_A_WRITE_CB(WRITE8(marywu_state, ay1_port_a_w))
+    MCFG_AY8910_PORT_B_WRITE_CB(WRITE8(marywu_state, ay1_port_b_w))
     
     MCFG_SOUND_ADD("ay2", AY8910, XTAL_10_738635MHz) /* should it be perhaps a fraction of the XTAL clock ? */
     MCFG_SOUND_ROUTE(ALL_OUTPUTS, "mono", 0.50)
+    MCFG_AY8910_PORT_A_WRITE_CB(WRITE8(marywu_state, ay2_port_a_w))
+    MCFG_AY8910_PORT_B_WRITE_CB(WRITE8(marywu_state, ay2_port_b_w))
 MACHINE_CONFIG_END
 
 ROM_START( marywu )

--- a/src/mame/layout/marywu.lay
+++ b/src/mame/layout/marywu.lay
@@ -1,3 +1,4 @@
+<?xml version="1.0"?>
 <!-- marywu.lay -->
 
 <mamelayout version="2">
@@ -7,6 +8,18 @@
 			<color red="1.0" green="0.0" blue="0.0" />
 		</led7seg>
 	</element>
+
+        <element name="led" defstate="0">
+                <text string=""></text>
+                <disk state="0">
+                        <color red="0.1" green="0.025" blue="0.028" />
+                        <bounds x="0.25" y="0.25" width="0.5" height="0.5" />
+                </disk>
+                <disk state="1">
+                        <color red="1.0" green="0.25" blue="0.28" />
+                        <bounds x="0.25" y="0.25" width="0.5" height="0.5" />
+                </disk>
+        </element>
 
 	<element name="background">
 		<rect>
@@ -19,10 +32,49 @@
 
 		<!-- Background -->
 		<backdrop element="background">
-			<bounds left="0" top="20" right="798" bottom="394" />
+			<bounds left="0" top="20" right="798" bottom="770" />
 		</backdrop>
 
+                <!-- LEDs -->
 
+                <bezel name="led4"  element="led"><bounds x="199" y="160" width="40" height="40" /></bezel>
+                <bezel name="led5"  element="led"><bounds x="249" y="160" width="40" height="40" /></bezel>
+                <bezel name="led6"  element="led"><bounds x="324" y="160" width="40" height="40" /></bezel>
+                <bezel name="led7"  element="led"><bounds x="399" y="160" width="40" height="40" /></bezel>
+                <bezel name="led8"  element="led"><bounds x="474" y="160" width="40" height="40" /></bezel>
+                <bezel name="led9"  element="led"><bounds x="549" y="160" width="40" height="40" /></bezel>
+                <bezel name="led10" element="led"><bounds x="599" y="160" width="40" height="40" /></bezel>
+
+                <bezel name="led3"  element="led"><bounds x="199" y="210" width="40" height="40" /></bezel>
+                <bezel name="led11" element="led"><bounds x="599" y="210" width="40" height="40" /></bezel>
+
+                <bezel name="led2"  element="led"><bounds x="199" y="285" width="40" height="40" /></bezel>
+                <bezel name="led12" element="led"><bounds x="599" y="285" width="40" height="40" /></bezel>
+
+                <bezel name="led1"  element="led"><bounds x="199" y="360" width="40" height="40" /></bezel>
+                <bezel name="led30" element="led"><bounds x="399" y="360" width="40" height="40" /></bezel>
+                <bezel name="led13" element="led"><bounds x="599" y="360" width="40" height="40" /></bezel>
+
+                <bezel name="led0"  element="led"><bounds x="199" y="435" width="40" height="40" /></bezel>
+                <bezel name="led14" element="led"><bounds x="599" y="435" width="40" height="40" /></bezel>
+
+                <bezel name="led23" element="led"><bounds x="199" y="510" width="40" height="40" /></bezel>
+                <bezel name="led15" element="led"><bounds x="599" y="510" width="40" height="40" /></bezel>
+
+                <bezel name="led22" element="led"><bounds x="199" y="560" width="40" height="40" /></bezel>
+                <bezel name="led21" element="led"><bounds x="249" y="560" width="40" height="40" /></bezel>
+                <bezel name="led20" element="led"><bounds x="324" y="560" width="40" height="40" /></bezel>
+                <bezel name="led19" element="led"><bounds x="399" y="560" width="40" height="40" /></bezel>
+                <bezel name="led18" element="led"><bounds x="474" y="560" width="40" height="40" /></bezel>
+                <bezel name="led17" element="led"><bounds x="549" y="560" width="40" height="40" /></bezel>
+                <bezel name="led16" element="led"><bounds x="599" y="560" width="40" height="40" /></bezel>
+
+                <bezel name="led29" element="led"><bounds x="199" y="660" width="40" height="40" /></bezel>
+                <bezel name="led28" element="led"><bounds x="279" y="660" width="40" height="40" /></bezel>
+                <bezel name="led27" element="led"><bounds x="359" y="660" width="40" height="40" /></bezel>
+                <bezel name="led26" element="led"><bounds x="439" y="660" width="40" height="40" /></bezel>
+                <bezel name="led25" element="led"><bounds x="519" y="660" width="40" height="40" /></bezel>
+                <bezel name="led24" element="led"><bounds x="599" y="660" width="40" height="40" /></bezel>
 
                 <!-- Top 7seg display modules -->
 
@@ -58,10 +110,10 @@
                 <!-- Middle 7seg display module -->
 
                 <bezel name="digit25" element="digit">
-                        <bounds left="355" top="105" right="389" bottom="144" />
+                        <bounds left="355" top="421" right="389" bottom="460" />
                 </bezel>
                 <bezel name="digit24" element="digit">
-                        <bounds left="399" top="105" right="433" bottom="144" />
+                        <bounds left="399" top="421" right="433" bottom="460" />
                 </bezel>
 
 
@@ -69,52 +121,52 @@
                 <!-- Bottom 7seg display modules -->
 
 		<bezel name="digit15" element="digit">
-			<bounds left="10" top="165" right="44" bottom="204" />
+			<bounds left="10" top="721" right="44" bottom="760" />
 		</bezel>
 		<bezel name="digit14" element="digit">
-			<bounds left="54" top="165" right="88" bottom="204" />
+			<bounds left="54" top="721" right="88" bottom="760" />
 		</bezel>
 		<bezel name="digit13" element="digit">
-			<bounds left="110" top="165" right="144" bottom="204" />
+			<bounds left="110" top="721" right="144" bottom="760" />
 		</bezel>
 		<bezel name="digit12" element="digit">
-			<bounds left="154" top="165" right="188" bottom="204" />
+			<bounds left="154" top="721" right="188" bottom="760" />
 		</bezel>
 		<bezel name="digit11" element="digit">
-			<bounds left="210" top="165" right="244" bottom="204" />
+			<bounds left="210" top="721" right="244" bottom="760" />
 		</bezel>
 		<bezel name="digit10" element="digit">
-			<bounds left="254" top="165" right="288" bottom="204" />
+			<bounds left="254" top="721" right="288" bottom="760" />
 		</bezel>
 		<bezel name="digit9" element="digit">
-			<bounds left="310" top="165" right="344" bottom="204" /> <!-- 144 -->
+			<bounds left="310" top="721" right="344" bottom="760" />
 		</bezel>
 		<bezel name="digit8" element="digit">
-			<bounds left="354" top="165" right="388" bottom="204" />
+			<bounds left="354" top="721" right="388" bottom="760" />
 		</bezel>
 		<bezel name="digit7" element="digit">
-			<bounds left="410" top="165" right="444" bottom="204" />
+			<bounds left="410" top="721" right="444" bottom="760" />
 		</bezel>
 		<bezel name="digit6" element="digit">
-			<bounds left="454" top="165" right="488" bottom="204" />
+			<bounds left="454" top="721" right="488" bottom="760" />
 		</bezel>
 		<bezel name="digit5" element="digit">
-			<bounds left="510" top="165" right="544" bottom="204" />
+			<bounds left="510" top="721" right="544" bottom="760" />
 		</bezel>
 		<bezel name="digit4" element="digit">
-			<bounds left="554" top="165" right="588" bottom="204" />
+			<bounds left="554" top="721" right="588" bottom="760" />
 		</bezel>
 		<bezel name="digit3" element="digit">
-			<bounds left="610" top="165" right="644" bottom="204" />
+			<bounds left="610" top="721" right="644" bottom="760" />
 		</bezel>
 		<bezel name="digit2" element="digit">
-			<bounds left="654" top="165" right="688" bottom="204" />
+			<bounds left="654" top="721" right="688" bottom="760" />
 		</bezel>
 		<bezel name="digit1" element="digit">
-			<bounds left="710" top="165" right="744" bottom="204" />
+			<bounds left="710" top="721" right="744" bottom="760" />
 		</bezel>
 		<bezel name="digit0" element="digit">
-			<bounds left="754" top="165" right="788" bottom="204" />
+			<bounds left="754" top="721" right="788" bottom="760" />
 		</bezel>
 	</view>
 </mamelayout>

--- a/src/mame/layout/marywu.lay
+++ b/src/mame/layout/marywu.lay
@@ -19,60 +19,102 @@
 
 		<!-- Background -->
 		<backdrop element="background">
-			<bounds left="0" top="20" right="274" bottom="394" />
+			<bounds left="0" top="20" right="798" bottom="394" />
 		</backdrop>
 
-		<!-- LEDs -->
 
-		<bezel name="digit4" element="digit">
-			<bounds left="10" top="45" right="44" bottom="84" />
-		</bezel>
-		<bezel name="digit5" element="digit">
-			<bounds left="54" top="45" right="88" bottom="84" />
-		</bezel>
-		<bezel name="digit2" element="digit">
-			<bounds left="98" top="45" right="132" bottom="84" />
-		</bezel>
-		<bezel name="digit3" element="digit">
-			<bounds left="142" top="45" right="176" bottom="84" />
-		</bezel>
-		<bezel name="digit0" element="digit">
-			<bounds left="186" top="45" right="220" bottom="84" />
-		</bezel>
-		<bezel name="digit1" element="digit">
-			<bounds left="230" top="45" right="264" bottom="84" />
-		</bezel>
 
-		<bezel name="digit10" element="digit">
-			<bounds left="10" top="105" right="44" bottom="144" />
-		</bezel>
-		<bezel name="digit11" element="digit">
-			<bounds left="54" top="105" right="88" bottom="144" />
-		</bezel>
-		<bezel name="digit8" element="digit">
-			<bounds left="98" top="105" right="132" bottom="144" />
-		</bezel>
-		<bezel name="digit9" element="digit">
-			<bounds left="142" top="105" right="176" bottom="144" />
-		</bezel>
-		<bezel name="digit6" element="digit">
-			<bounds left="186" top="105" right="220" bottom="144" />
-		</bezel>
-		<bezel name="digit7" element="digit">
-			<bounds left="230" top="105" right="264" bottom="144" />
-		</bezel>
+                <!-- Top 7seg display modules -->
 
-		<bezel name="digit14" element="digit">
-			<bounds left="98" top="165" right="132" bottom="204" />
-		</bezel>
+                <bezel name="digit23" element="digit">
+                        <bounds left="200" top="45" right="234" bottom="84" />
+                </bezel>
+                <bezel name="digit22" element="digit">
+                        <bounds left="244" top="45" right="278" bottom="84" />
+                </bezel>
+                <bezel name="digit21" element="digit">
+                        <bounds left="288" top="45" right="322" bottom="84" />
+                </bezel>
+                <bezel name="digit20" element="digit">
+                        <bounds left="332" top="45" right="366" bottom="84" />
+                </bezel>
+
+
+                <bezel name="digit19" element="digit">
+                        <bounds left="432" top="45" right="466" bottom="84" />
+                </bezel>
+                <bezel name="digit18" element="digit">
+                        <bounds left="476" top="45" right="510" bottom="84" />
+                </bezel>
+                <bezel name="digit17" element="digit">
+                        <bounds left="520" top="45" right="554" bottom="84" />
+                </bezel>
+                <bezel name="digit16" element="digit">
+                        <bounds left="564" top="45" right="598" bottom="84" />
+                </bezel>
+
+
+
+                <!-- Middle 7seg display module -->
+
+                <bezel name="digit25" element="digit">
+                        <bounds left="355" top="105" right="389" bottom="144" />
+                </bezel>
+                <bezel name="digit24" element="digit">
+                        <bounds left="399" top="105" right="433" bottom="144" />
+                </bezel>
+
+
+
+                <!-- Bottom 7seg display modules -->
+
 		<bezel name="digit15" element="digit">
-			<bounds left="142" top="165" right="176" bottom="204" />
+			<bounds left="10" top="165" right="44" bottom="204" />
 		</bezel>
-		<bezel name="digit12" element="digit">
-			<bounds left="186" top="165" right="220" bottom="204" />
+		<bezel name="digit14" element="digit">
+			<bounds left="54" top="165" right="88" bottom="204" />
 		</bezel>
 		<bezel name="digit13" element="digit">
-			<bounds left="230" top="165" right="264" bottom="204" />
+			<bounds left="110" top="165" right="144" bottom="204" />
+		</bezel>
+		<bezel name="digit12" element="digit">
+			<bounds left="154" top="165" right="188" bottom="204" />
+		</bezel>
+		<bezel name="digit11" element="digit">
+			<bounds left="210" top="165" right="244" bottom="204" />
+		</bezel>
+		<bezel name="digit10" element="digit">
+			<bounds left="254" top="165" right="288" bottom="204" />
+		</bezel>
+		<bezel name="digit9" element="digit">
+			<bounds left="310" top="165" right="344" bottom="204" /> <!-- 144 -->
+		</bezel>
+		<bezel name="digit8" element="digit">
+			<bounds left="354" top="165" right="388" bottom="204" />
+		</bezel>
+		<bezel name="digit7" element="digit">
+			<bounds left="410" top="165" right="444" bottom="204" />
+		</bezel>
+		<bezel name="digit6" element="digit">
+			<bounds left="454" top="165" right="488" bottom="204" />
+		</bezel>
+		<bezel name="digit5" element="digit">
+			<bounds left="510" top="165" right="544" bottom="204" />
+		</bezel>
+		<bezel name="digit4" element="digit">
+			<bounds left="554" top="165" right="588" bottom="204" />
+		</bezel>
+		<bezel name="digit3" element="digit">
+			<bounds left="610" top="165" right="644" bottom="204" />
+		</bezel>
+		<bezel name="digit2" element="digit">
+			<bounds left="654" top="165" right="688" bottom="204" />
+		</bezel>
+		<bezel name="digit1" element="digit">
+			<bounds left="710" top="165" right="744" bottom="204" />
+		</bezel>
+		<bezel name="digit0" element="digit">
+			<bounds left="754" top="165" right="788" bottom="204" />
 		</bezel>
 	</view>
 </mamelayout>

--- a/src/mame/layout/marywu.lay
+++ b/src/mame/layout/marywu.lay
@@ -1,0 +1,78 @@
+<!-- marywu.lay -->
+
+<mamelayout version="2">
+
+	<element name="digit" defstate="0">
+		<led7seg>
+			<color red="1.0" green="0.0" blue="0.0" />
+		</led7seg>
+	</element>
+
+	<element name="background">
+		<rect>
+			<bounds left="0" top="0" right="1" bottom="1" />
+			<color red="0.0" green="0.0" blue="0.0" />
+		</rect>
+	</element>
+
+	<view name="Default Layout">
+
+		<!-- Background -->
+		<backdrop element="background">
+			<bounds left="0" top="20" right="274" bottom="394" />
+		</backdrop>
+
+		<!-- LEDs -->
+
+		<bezel name="digit4" element="digit">
+			<bounds left="10" top="45" right="44" bottom="84" />
+		</bezel>
+		<bezel name="digit5" element="digit">
+			<bounds left="54" top="45" right="88" bottom="84" />
+		</bezel>
+		<bezel name="digit2" element="digit">
+			<bounds left="98" top="45" right="132" bottom="84" />
+		</bezel>
+		<bezel name="digit3" element="digit">
+			<bounds left="142" top="45" right="176" bottom="84" />
+		</bezel>
+		<bezel name="digit0" element="digit">
+			<bounds left="186" top="45" right="220" bottom="84" />
+		</bezel>
+		<bezel name="digit1" element="digit">
+			<bounds left="230" top="45" right="264" bottom="84" />
+		</bezel>
+
+		<bezel name="digit10" element="digit">
+			<bounds left="10" top="105" right="44" bottom="144" />
+		</bezel>
+		<bezel name="digit11" element="digit">
+			<bounds left="54" top="105" right="88" bottom="144" />
+		</bezel>
+		<bezel name="digit8" element="digit">
+			<bounds left="98" top="105" right="132" bottom="144" />
+		</bezel>
+		<bezel name="digit9" element="digit">
+			<bounds left="142" top="105" right="176" bottom="144" />
+		</bezel>
+		<bezel name="digit6" element="digit">
+			<bounds left="186" top="105" right="220" bottom="144" />
+		</bezel>
+		<bezel name="digit7" element="digit">
+			<bounds left="230" top="105" right="264" bottom="144" />
+		</bezel>
+
+		<bezel name="digit14" element="digit">
+			<bounds left="98" top="165" right="132" bottom="204" />
+		</bezel>
+		<bezel name="digit15" element="digit">
+			<bounds left="142" top="165" right="176" bottom="204" />
+		</bezel>
+		<bezel name="digit12" element="digit">
+			<bounds left="186" top="165" right="220" bottom="204" />
+		</bezel>
+		<bezel name="digit13" element="digit">
+			<bounds left="230" top="165" right="264" bottom="204" />
+		</bezel>
+	</view>
+</mamelayout>


### PR DESCRIPTION
Most of the hardware has been mapped by analysing the pcb tracks. This set of commits include:

* a video layout with all 30 LEDs 13 double-digit 7seg modules
* an improved memory map hooking up the couple AY8910-3 chips, 2kb of Static RAM and the keyboard/display controller (an i8279 clone)
* multiplexing signals for the 7seg displays
* LEDs being controlled by the IO ports of the 2 AY8910-3 chips
* 8-bit set of DIP-Switches, a 2x16 keyboard and 4 push buttons mapped to the i8279 scanlines and return lines

The device still does not play music because it apparently fails to detect auxiliar hardware (it tries to do something with port bits P1.0 and P1.6 a few dozen of times and then enters an infinite-loop). In this case, the display is frozen with a number 1 displayed in the top right corner and with all LEDs turned on, expect for the one right in the middle of the board.
