### PR TITLE
Small code cleanup

### DIFF
--- a/src/emu/debug/debugcmd.cpp
+++ b/src/emu/debug/debugcmd.cpp
@@ -2381,11 +2381,12 @@ static void execute_find(running_machine &machine, int ref, int params, const ch
 	for (int i = 2; i < params; i++)
 	{
 		const char *pdata = param[i];
+		size_t pdatalen = strlen(pdata) - 1;
 
 		/* check for a string */
-		if (pdata[0] == '"' && pdata[strlen(pdata) - 1] == '"')
+		if (pdata[0] == '"' && pdata[pdatalen] == '"')
 		{
-			for (j = 1; j < strlen(pdata) - 1; j++)
+			for (j = 1; j < pdatalen; j++)
 			{
 				data_to_find[data_count] = pdata[j];
 				data_size[data_count++] = 1;

--- a/src/emu/debug/textbuf.cpp
+++ b/src/emu/debug/textbuf.cpp
@@ -86,12 +86,12 @@ text_buffer *text_buffer_alloc(UINT32 bytes, UINT32 lines)
 	text_buffer *text;
 
 	/* allocate memory for the text buffer object */
-	text = (text_buffer *)global_alloc(text_buffer);
+	text = global_alloc_nothrow(text_buffer);
 	if (!text)
 		return nullptr;
 
 	/* allocate memory for the buffer itself */
-	text->buffer = (char *)global_alloc_array(char, bytes);
+	text->buffer = global_alloc_array_nothrow(char, bytes);
 	if (!text->buffer)
 	{
 		global_free(text);
@@ -99,7 +99,7 @@ text_buffer *text_buffer_alloc(UINT32 bytes, UINT32 lines)
 	}
 
 	/* allocate memory for the lines array */
-	text->lineoffs = (INT32 *)global_alloc_array(INT32, lines);
+	text->lineoffs = global_alloc_array_nothrow(INT32, lines);
 	if (!text->lineoffs)
 	{
 		global_free_array(text->buffer);

--- a/src/emu/diimage.cpp
+++ b/src/emu/diimage.cpp
@@ -161,29 +161,27 @@ image_error_t device_image_interface::set_image_filename(const char *filename)
 	zippath_parent(m_working_directory, filename);
 	m_basename.assign(m_image_name);
 
-	int loc1 = m_image_name.find_last_of('\\');
-	int loc2 = m_image_name.find_last_of('/');
-	int loc3 = m_image_name.find_last_of(':');
-	int loc = MAX(loc1,MAX(loc2,loc3));
-	if (loc!=-1) {
+	size_t loc1 = m_image_name.find_last_of('\\');
+	size_t loc2 = m_image_name.find_last_of('/');
+	size_t loc3 = m_image_name.find_last_of(':');
+	size_t loc = MAX(loc1,MAX(loc2, loc3));
+	if (loc != -1) {
 		if (loc == loc3)
 		{
 			// temp workaround for softlists now that m_image_name contains the part name too (e.g. list:gamename:cart)
 			m_basename = m_basename.substr(0, loc);
-			std::string tmpstr = std::string(m_basename);
-			int tmploc = tmpstr.find_last_of(':');
-			m_basename = m_basename.substr(tmploc + 1,loc-tmploc);
+			size_t tmploc = m_basename.find_last_of(':');
+			m_basename = m_basename.substr(tmploc + 1, loc - tmploc);
 		}
 		else
-			m_basename = m_basename.substr(loc + 1, m_basename.length() - loc);
+			m_basename = m_basename.substr(loc + 1);
 	}
-	m_basename_noext = m_basename.assign(m_basename);
+	m_basename_noext = m_basename;
 	m_filetype = "";
 	loc = m_basename_noext.find_last_of('.');
-	if (loc!=-1) {
-		m_basename_noext = m_basename_noext.substr(0,loc);
-		m_filetype = m_basename.assign(m_basename);
-		m_filetype = m_filetype.substr(loc + 1, m_filetype.length() - loc);
+	if (loc != -1) {
+		m_basename_noext = m_basename_noext.substr(0, loc);
+		m_filetype = m_basename.substr(loc + 1);
 	}
 
 	return IMAGE_ERROR_SUCCESS;

--- a/src/emu/luaengine.cpp
+++ b/src/emu/luaengine.cpp
@@ -1049,7 +1049,7 @@ void lua_engine::periodic_check()
 	osd_lock_acquire(lock);
 	if (msg.ready == 1) {
 	lua_settop(m_lua_state, 0);
-	int status = luaL_loadbuffer(m_lua_state, msg.text.c_str(), strlen(msg.text.c_str()), "=stdin");
+	int status = luaL_loadbuffer(m_lua_state, msg.text.c_str(), msg.text.length(), "=stdin");
 	if (incomplete(status)==0)  /* cannot try to add lines? */
 	{
 		if (status == LUA_OK) status = docall(0, LUA_MULTRET);

--- a/src/emu/render.cpp
+++ b/src/emu/render.cpp
@@ -1055,8 +1055,9 @@ int render_target::configured_view(const char *viewname, int targetindex, int nu
 	if (strcmp(viewname, "auto") != 0)
 	{
 		// scan for a matching view name
+		size_t viewlen = strlen(viewname);
 		for (view = view_by_index(viewindex = 0); view != nullptr; view = view_by_index(++viewindex))
-			if (core_strnicmp(view->name(), viewname, strlen(viewname)) == 0)
+			if (core_strnicmp(view->name(), viewname, viewlen) == 0)
 				break;
 	}
 

--- a/src/emu/sound/wavwrite.cpp
+++ b/src/emu/sound/wavwrite.cpp
@@ -18,7 +18,7 @@ wav_file *wav_open(const char *filename, int sample_rate, int channels)
 	UINT16 align, temp16;
 
 	/* allocate memory for the wav struct */
-	wav = (wav_file *) global_alloc(wav_file);
+	wav = global_alloc(wav_file);
 	if (!wav)
 		return nullptr;
 

--- a/src/emu/sound/wavwrite.cpp
+++ b/src/emu/sound/wavwrite.cpp
@@ -18,7 +18,7 @@ wav_file *wav_open(const char *filename, int sample_rate, int channels)
 	UINT16 align, temp16;
 
 	/* allocate memory for the wav struct */
-	wav = global_alloc(wav_file);
+	wav = global_alloc_nothrow(wav_file);
 	if (!wav)
 		return nullptr;
 

--- a/src/emu/ui/miscmenu.cpp
+++ b/src/emu/ui/miscmenu.cpp
@@ -434,9 +434,9 @@ void ui_menu_crosshair::populate()
 			file_enumerator path(machine().options().crosshair_path());
 			const osd_directory_entry *dir;
 			/* reset search flags */
-			int using_default = false;
-			int finished = false;
-			int found = false;
+			bool using_default = false;
+			bool finished = false;
+			bool found = false;
 
 			/* if we are using the default, then we just need to find the first in the list */
 			if (*(settings.name) == 0)

--- a/src/emu/ui/selgame.h
+++ b/src/emu/ui/selgame.h
@@ -31,7 +31,7 @@ private:
 	// internal state
 	enum { VISIBLE_GAMES_IN_LIST = 15 };
 	UINT8                   m_error;
-	UINT8                   m_rerandomize;
+	bool                    m_rerandomize;
 	char                    m_search[40];
 	int                     m_matchlist[VISIBLE_GAMES_IN_LIST];
 	std::vector<const game_driver *> m_driverlist;

--- a/src/emu/ui/ui.cpp
+++ b/src/emu/ui/ui.cpp
@@ -236,7 +236,7 @@ ui_manager::ui_manager(running_machine &machine)
 	m_handler_param = 0;
 	m_single_step = false;
 	m_showfps = false;
-	m_showfps_end = false;
+	m_showfps_end = 0;
 	m_show_profiler = false;
 	m_popup_text_end = 0;
 	m_use_natural_keyboard = false;
@@ -1503,7 +1503,6 @@ UINT32 ui_manager::handler_ingame(running_machine &machine, render_container *co
 	// first draw the FPS counter
 	if (machine.ui().show_fps_counter())
 	{
-		std::string tempstring;
 		machine.ui().draw_text_full(container, machine.video().speed_text().c_str(), 0.0f, 0.0f, 1.0f,
 					JUSTIFY_RIGHT, WRAP_WORD, DRAW_OPAQUE, ARGB_WHITE, ARGB_BLACK, nullptr, nullptr);
 	}

--- a/src/emu/video.cpp
+++ b/src/emu/video.cpp
@@ -584,7 +584,7 @@ void video_manager::postload()
 //  forward
 //-------------------------------------------------
 
-inline int video_manager::effective_autoframeskip() const
+inline bool video_manager::effective_autoframeskip() const
 {
 	// if we're fast forwarding or paused, autoframeskip is disabled
 	if (m_fastforward || machine().paused())

--- a/src/emu/video.h
+++ b/src/emu/video.h
@@ -100,7 +100,7 @@ private:
 	void postload();
 
 	// effective value helpers
-	int effective_autoframeskip() const;
+	bool effective_autoframeskip() const;
 	int effective_frameskip() const;
 	bool effective_throttle() const;
 

--- a/src/lib/util/corealloc.h
+++ b/src/lib/util/corealloc.h
@@ -27,7 +27,9 @@
 
 // global allocation helpers -- use these instead of new and delete
 #define global_alloc(_type)                         new _type
+#define global_alloc_nothrow(_type)                 new (std::nothrow) _type
 #define global_alloc_array(_type, _num)             new _type[_num]
+#define global_alloc_array_nothrow(_type, _num)     new (std::nothrow) _type[_num]
 #define global_free(_ptr)                           do { delete _ptr; } while (0)
 #define global_free_array(_ptr)                     do { delete[] _ptr; } while (0)
 


### PR DESCRIPTION
- corealloc.h: added macro definition for global_alloc (nothrow) memory allocation.
- textbuf.cpp / wavwrite.cpp: removed pointless cast.
- debugcmd.cpp / luaengine.cpp / render.cpp: avoid strlen calls in a loop.
- diimage.cpp: simplified "device_image_interface::set_image_filename" function.
- miscmenu.cpp / selgame.h / video.cpp(h): replaced int with bool where applicable.
- ui.cpp: removed unused code.