### PR TITLE
Modernize sound volume setting code in various Atari drivers

### DIFF
--- a/src/mame/drivers/arcadecl.cpp
+++ b/src/mame/drivers/arcadecl.cpp
@@ -131,7 +131,7 @@ WRITE16_MEMBER(arcadecl_state::latch_w)
 	if (ACCESSING_BITS_0_7)
 	{
 		m_oki->set_bank_base((data & 0x80) ? 0x40000 : 0x00000);
-		set_oki6295_volume((data & 0x001f) * 100 / 0x1f);
+		m_oki->set_output_gain(ALL_OUTPUTS, (data & 0x001f) / 31.0f);
 	}
 }
 

--- a/src/mame/drivers/rampart.cpp
+++ b/src/mame/drivers/rampart.cpp
@@ -105,12 +105,12 @@ WRITE16_MEMBER(rampart_state::latch_w)
 	/* lower byte being modified? */
 	if (ACCESSING_BITS_0_7)
 	{
-		set_oki6295_volume((data & 0x0020) ? 100 : 0);
+		m_oki->set_output_gain(ALL_OUTPUTS, (data & 0x0020) ? 1.0f : 0.0f);
 		if (!(data & 0x0010))
 			m_oki->reset();
-		set_ym2413_volume(((data >> 1) & 7) * 100 / 7);
+		m_ym2413->set_output_gain(ALL_OUTPUTS, ((data >> 1) & 7) / 7.0f);
 		if (!(data & 0x0001))
-			machine().device("ymsnd")->reset();
+			m_ym2413->reset();
 	}
 }
 

--- a/src/mame/drivers/relief.cpp
+++ b/src/mame/drivers/relief.cpp
@@ -84,7 +84,7 @@ WRITE16_MEMBER(relief_state::audio_control_w)
 	if (ACCESSING_BITS_0_7)
 	{
 		m_ym2413_volume = (data >> 1) & 15;
-		set_ym2413_volume((m_ym2413_volume * m_overall_volume * 100) / (127 * 15));
+		m_ym2413->set_output_gain(ALL_OUTPUTS, (m_ym2413_volume * m_overall_volume) / (127.0f * 15.0f));
 		m_adpcm_bank = ((data >> 6) & 3) | (m_adpcm_bank & 4);
 	}
 	if (ACCESSING_BITS_8_15)
@@ -99,8 +99,8 @@ WRITE16_MEMBER(relief_state::audio_volume_w)
 	if (ACCESSING_BITS_0_7)
 	{
 		m_overall_volume = data & 127;
-		set_ym2413_volume((m_ym2413_volume * m_overall_volume * 100) / (127 * 15));
-		set_oki6295_volume(m_overall_volume * 100 / 127);
+		m_ym2413->set_output_gain(ALL_OUTPUTS, (m_ym2413_volume * m_overall_volume) / (127.0f * 15.0f));
+		m_oki->set_output_gain(ALL_OUTPUTS, m_overall_volume / 127.0f);
 	}
 }
 

--- a/src/mame/includes/arcadecl.h
+++ b/src/mame/includes/arcadecl.h
@@ -8,15 +8,18 @@
 
 #include "machine/atarigen.h"
 #include "video/atarimo.h"
+#include "sound/okim6295.h"
 
 class arcadecl_state : public atarigen_state
 {
 public:
 	arcadecl_state(const machine_config &mconfig, device_type type, const char *tag)
 		: atarigen_state(mconfig, type, tag),
+			m_oki(*this, "oki"),
 			m_mob(*this, "mob"),
 			m_bitmap(*this, "bitmap") { }
 
+	required_device<okim6295_device> m_oki;
 	optional_device<atari_motion_objects_device> m_mob;
 	required_shared_ptr<UINT16> m_bitmap;
 

--- a/src/mame/includes/atarisy1.h
+++ b/src/mame/includes/atarisy1.h
@@ -15,6 +15,8 @@ class atarisy1_state : public atarigen_state
 public:
 	atarisy1_state(const machine_config &mconfig, device_type type, const char *tag)
 		: atarigen_state(mconfig, type, tag),
+			m_audiocpu(*this, "audiocpu"),
+			m_soundcomm(*this, "soundcomm"),
 			m_bankselect(*this, "bankselect"),
 			m_mob(*this, "mob"),
 			m_joystick_timer(*this, "joystick_timer"),
@@ -24,6 +26,9 @@ public:
 			m_scanline_timer(*this, "scan_timer"),
 			m_int3off_timer(*this, "int3off_timer"),
 			m_tms(*this, "tms") { }
+
+	required_device<cpu_device> m_audiocpu;
+	required_device<atari_sound_comm_device> m_soundcomm;
 
 	required_shared_ptr<UINT16> m_bankselect;
 	required_device<atari_motion_objects_device> m_mob;

--- a/src/mame/includes/atarisy2.h
+++ b/src/mame/includes/atarisy2.h
@@ -10,6 +10,9 @@
 #include "video/atarimo.h"
 #include "cpu/m6502/m6502.h"
 #include "cpu/t11/t11.h"
+#include "sound/2151intf.h"
+#include "sound/pokey.h"
+#include "sound/tms5220.h"
 #include "slapstic.h"
 
 class atarisy2_state : public atarigen_state
@@ -23,6 +26,11 @@ public:
 			m_slapstic_base(*this, "slapstic_base"),
 			m_playfield_tilemap(*this, "playfield"),
 			m_alpha_tilemap(*this, "alpha"),
+			m_soundcomm(*this, "soundcomm"),
+			m_ym2151(*this, "ymsnd"),
+			m_pokey1(*this, "pokey1"),
+			m_pokey2(*this, "pokey2"),
+			m_tms5220(*this, "tms"),
 			m_rombank1(*this, "rombank1"),
 			m_rombank2(*this, "rombank2"),
 			m_slapstic(*this, "slapstic")
@@ -40,7 +48,11 @@ public:
 
 	INT8            m_pedal_count;
 
-	UINT8           m_has_tms5220;
+	required_device<atari_sound_comm_device> m_soundcomm;
+	required_device<ym2151_device> m_ym2151;
+	required_device<pokey_device> m_pokey1;
+	required_device<pokey_device> m_pokey2;
+	optional_device<tms5220_device> m_tms5220;
 
 	UINT8           m_which_adc;
 

--- a/src/mame/includes/badlands.h
+++ b/src/mame/includes/badlands.h
@@ -14,8 +14,13 @@ class badlands_state : public atarigen_state
 public:
 	badlands_state(const machine_config &mconfig, device_type type, const char *tag)
 		: atarigen_state(mconfig, type, tag),
+			m_audiocpu(*this, "audiocpu"),
+			m_soundcomm(*this, "soundcomm"),
 			m_playfield_tilemap(*this, "playfield"),
 			m_mob(*this, "mob") { }
+
+	optional_device<cpu_device> m_audiocpu;
+	optional_device<atari_sound_comm_device> m_soundcomm;
 
 	required_device<tilemap_device> m_playfield_tilemap;
 	required_device<atari_motion_objects_device> m_mob;

--- a/src/mame/includes/cyberbal.h
+++ b/src/mame/includes/cyberbal.h
@@ -24,6 +24,7 @@ public:
 			m_daccpu(*this, "dac"),
 			m_dac1(*this, "dac1"),
 			m_dac2(*this, "dac2"),
+			m_soundcomm(*this, "soundcomm"),
 			m_jsa(*this, "jsa"),
 			m_playfield_tilemap(*this, "playfield"),
 			m_alpha_tilemap(*this, "alpha"),
@@ -40,6 +41,7 @@ public:
 	optional_device<cpu_device> m_daccpu;
 	optional_device<dac_device> m_dac1;
 	optional_device<dac_device> m_dac2;
+	optional_device<atari_sound_comm_device> m_soundcomm;
 	optional_device<atari_jsa_ii_device> m_jsa;
 	required_device<tilemap_device> m_playfield_tilemap;
 	required_device<tilemap_device> m_alpha_tilemap;

--- a/src/mame/includes/gauntlet.h
+++ b/src/mame/includes/gauntlet.h
@@ -8,15 +8,29 @@
 
 #include "machine/atarigen.h"
 #include "video/atarimo.h"
+#include "sound/2151intf.h"
+#include "sound/pokey.h"
+#include "sound/tms5220.h"
 
 class gauntlet_state : public atarigen_state
 {
 public:
 	gauntlet_state(const machine_config &mconfig, device_type type, const char *tag)
 		: atarigen_state(mconfig, type, tag),
+			m_audiocpu(*this, "audiocpu"),
+			m_soundcomm(*this, "soundcomm"),
+			m_ym2151(*this, "ymsnd"),
+			m_pokey(*this, "pokey"),
+			m_tms5220(*this, "tms"),
 			m_playfield_tilemap(*this, "playfield"),
 			m_alpha_tilemap(*this, "alpha"),
 			m_mob(*this, "mob")  { }
+
+	required_device<cpu_device> m_audiocpu;
+	required_device<atari_sound_comm_device> m_soundcomm;
+	required_device<ym2151_device> m_ym2151;
+	required_device<pokey_device> m_pokey;
+	required_device<tms5220_device> m_tms5220;
 
 	required_device<tilemap_device> m_playfield_tilemap;
 	required_device<tilemap_device> m_alpha_tilemap;

--- a/src/mame/includes/rampart.h
+++ b/src/mame/includes/rampart.h
@@ -8,6 +8,7 @@
 
 #include "machine/atarigen.h"
 #include "sound/okim6295.h"
+#include "sound/2413intf.h"
 #include "video/atarimo.h"
 
 class rampart_state : public atarigen_state
@@ -17,10 +18,12 @@ public:
 		: atarigen_state(mconfig, type, tag),
 			m_mob(*this, "mob"),
 			m_oki(*this, "oki"),
+			m_ym2413(*this, "ymsnd"),
 			m_bitmap(*this, "bitmap") { }
 
 	required_device<atari_motion_objects_device> m_mob;
 	required_device<okim6295_device> m_oki;
+	required_device<ym2413_device> m_ym2413;
 
 	required_shared_ptr<UINT16> m_bitmap;
 

--- a/src/mame/includes/relief.h
+++ b/src/mame/includes/relief.h
@@ -8,6 +8,8 @@
 
 #include "machine/atarigen.h"
 #include "video/atarimo.h"
+#include "sound/okim6295.h"
+#include "sound/2413intf.h"
 
 class relief_state : public atarigen_state
 {
@@ -15,10 +17,14 @@ public:
 	relief_state(const machine_config &mconfig, device_type type, const char *tag)
 		: atarigen_state(mconfig, type, tag),
 			m_vad(*this, "vad"),
+			m_oki(*this, "oki"),
+			m_ym2413(*this, "ymsnd"),
 			m_okibank(*this, "okibank")
 			{ }
 
 	required_device<atari_vad_device> m_vad;
+	required_device<okim6295_device> m_oki;
+	required_device<ym2413_device> m_ym2413;
 	required_memory_bank m_okibank;
 
 	UINT8           m_ym2413_volume;

--- a/src/mame/machine/atarigen.cpp
+++ b/src/mame/machine/atarigen.cpp
@@ -10,11 +10,6 @@
 
 #include "emu.h"
 #include "cpu/m6502/m6502.h"
-#include "sound/2151intf.h"
-#include "sound/2413intf.h"
-#include "sound/tms5220.h"
-#include "sound/okim6295.h"
-#include "sound/pokey.h"
 #include "video/atarimo.h"
 #include "atarigen.h"
 
@@ -965,9 +960,6 @@ atarigen_state::atarigen_state(const machine_config &mconfig, device_type type, 
 		m_slapstic_mirror(0),
 		m_scanlines_per_callback(0),
 		m_maincpu(*this, "maincpu"),
-		m_audiocpu(*this, "audiocpu"),
-		m_oki(*this, "oki"),
-		m_soundcomm(*this, "soundcomm"),
 		m_gfxdecode(*this, "gfxdecode"),
 		m_screen(*this, "screen"),
 		m_palette(*this, "palette"),
@@ -1287,57 +1279,6 @@ READ16_MEMBER(atarigen_state::slapstic_r)
 	// then determine the new one
 	slapstic_update_bank(m_slapstic_device->slapstic_tweak(space, offset));
 	return result;
-}
-
-
-
-/***************************************************************************
-    SOUND HELPERS
-***************************************************************************/
-
-//-------------------------------------------------
-//  set_volume_by_type: Scans for a particular
-//  sound chip and changes the volume on all
-//  channels associated with it.
-//-------------------------------------------------
-
-void atarigen_state::set_volume_by_type(int volume, device_type type)
-{
-	sound_interface_iterator iter(*this);
-	for (device_sound_interface *sound = iter.first(); sound != nullptr; sound = iter.next())
-		if (sound->device().type() == type)
-			sound->set_output_gain(ALL_OUTPUTS, volume / 100.0);
-}
-
-
-//-------------------------------------------------
-//  set_XXXXX_volume: Sets the volume for a given
-//  type of chip.
-//-------------------------------------------------
-
-void atarigen_state::set_ym2151_volume(int volume)
-{
-	set_volume_by_type(volume, YM2151);
-}
-
-void atarigen_state::set_ym2413_volume(int volume)
-{
-	set_volume_by_type(volume, YM2413);
-}
-
-void atarigen_state::set_pokey_volume(int volume)
-{
-	set_volume_by_type(volume, POKEY);
-}
-
-void atarigen_state::set_tms5220_volume(int volume)
-{
-	set_volume_by_type(volume, TMS5220);
-}
-
-void atarigen_state::set_oki6295_volume(int volume)
-{
-	set_volume_by_type(volume, OKIM6295);
 }
 
 

--- a/src/mame/machine/atarigen.h
+++ b/src/mame/machine/atarigen.h
@@ -14,7 +14,6 @@
 #include "machine/eeprompar.h"
 #include "video/atarimo.h"
 #include "cpu/m6502/m6502.h"
-#include "sound/okim6295.h"
 #include "includes/slapstic.h"
 
 
@@ -362,14 +361,6 @@ public:
 	DECLARE_WRITE16_MEMBER(slapstic_w);
 	DECLARE_READ16_MEMBER(slapstic_r);
 
-	// sound helpers
-	void set_volume_by_type(int volume, device_type type);
-	void set_ym2151_volume(int volume);
-	void set_ym2413_volume(int volume);
-	void set_pokey_volume(int volume);
-	void set_tms5220_volume(int volume);
-	void set_oki6295_volume(int volume);
-
 	// scanline timing
 	void scanline_timer_reset(screen_device &screen, int frequency);
 	void scanline_timer(emu_timer &timer, screen_device &screen, int scanline);
@@ -412,10 +403,7 @@ public:
 
 	atarigen_screen_timer   m_screen_timer[2];
 	required_device<cpu_device> m_maincpu;
-	optional_device<cpu_device> m_audiocpu;
-	optional_device<okim6295_device> m_oki;
 
-	optional_device<atari_sound_comm_device> m_soundcomm;
 	optional_device<gfxdecode_device> m_gfxdecode;
 	optional_device<screen_device> m_screen;
 	optional_device<palette_device> m_palette;


### PR DESCRIPTION
This lets atarigen.cpp shed legacy sound routines using the archaic
method of looking up sound devices by types rather than tags (which
until 0.126u2 they weren't required to provide and often didn't have).