### PR TITLE
Software list entries can now supply slot option defaults

### DIFF
--- a/src/emu/clifront.cpp
+++ b/src/emu/clifront.cpp
@@ -148,7 +148,7 @@ int cli_frontend::execute(int argc, char **argv)
 												strprintf(val, "%s:%s:%s", swlistdev->list_name(), m_options.software_name(), swpart->name());
 
 												// call this in order to set slot devices according to mounting
-												m_options.parse_slot_devices(argc, argv, option_errors, image->instance_name(), val.c_str());
+												m_options.parse_slot_devices(argc, argv, option_errors, image->instance_name(), val.c_str(), swpart);
 												break;
 											}
 										}

--- a/src/emu/emuopts.h
+++ b/src/emu/emuopts.h
@@ -197,6 +197,7 @@ enum
 
 // forward references
 struct game_driver;
+class software_part;
 
 
 class emu_options : public core_options
@@ -210,7 +211,7 @@ public:
 	// parsing wrappers
 	bool parse_command_line(int argc, char *argv[], std::string &error_string);
 	void parse_standard_inis(std::string &error_string);
-	bool parse_slot_devices(int argc, char *argv[], std::string &error_string, const char *name, const char *value);
+	bool parse_slot_devices(int argc, char *argv[], std::string &error_string, const char *name = nullptr, const char *value = nullptr, const software_part *swpart = nullptr);
 
 	// core options
 	const char *system_name() const { return value(OPTION_SYSTEMNAME); }
@@ -370,12 +371,12 @@ public:
 
 	std::string main_value(const char *option) const;
 	std::string sub_value(const char *name, const char *subname) const;
-	bool add_slot_options(bool isfirst);
+	bool add_slot_options(const software_part *swpart = nullptr);
 
 private:
 	// device-specific option handling
-	void add_device_options(bool isfirst);
-	void update_slot_options();
+	void add_device_options();
+	void update_slot_options(const software_part *swpart = nullptr);
 
 	// INI parsing helper
 	bool parse_one_ini(const char *basename, int priority, std::string *error_string = nullptr);
@@ -390,6 +391,8 @@ private:
 	bool m_joystick_contradictory;
 	bool m_sleep;
 	bool m_refresh_speed;
+	int m_slot_options;
+	int m_device_options;
 };
 
 

--- a/src/emu/ui/slotopt.cpp
+++ b/src/emu/ui/slotopt.cpp
@@ -189,7 +189,7 @@ void ui_menu_slot_devices::handle()
 	{
 		if ((FPTR)menu_event->itemref == 1 && menu_event->iptkey == IPT_UI_SELECT)
 		{
-			machine().options().add_slot_options(false);
+			machine().options().add_slot_options();
 			machine().schedule_hard_reset();
 		}
 		else if (menu_event->iptkey == IPT_UI_LEFT || menu_event->iptkey == IPT_UI_RIGHT)


### PR DESCRIPTION
This feature is enabled when executing 'mame driver software'. After the specified software is found in the software list and attached to an appropriate image device, the software part's feature list is examined for any feature whose name is that of a slot device with _default appended. The feature's value field becomes the slot's default option, which overrides any driver-specified default and can be overridden by user-specified options.

No software lists have been updated to use this feature at the moment.