### PR TITLE
Ignore invalid default slot options in software lists

### DIFF
--- a/src/emu/emuopts.cpp
+++ b/src/emu/emuopts.cpp
@@ -262,7 +262,7 @@ bool emu_options::add_slot_options(const software_part *swpart)
 		{
 			std::string featurename = std::string(name).append("_default");
 			const char *value = swpart->feature(featurename.c_str());
-			if (value != nullptr)
+			if (value != nullptr && (*value == '\0' || slot->option(value) != nullptr))
 				set_default_value(name, value);
 		}
 	}


### PR DESCRIPTION
This prevents software lists from (e.g.) trying to put a Zapper into ctrl1 on the Famicom.