### PR TITLE
fix compile (nw)

### DIFF
--- a/src/lib/util/aviio.cpp
+++ b/src/lib/util/aviio.cpp
@@ -1297,7 +1297,7 @@ avi_error avi_read_sound_samples(avi_file *file, int channel, UINT32 firstsample
 	UINT32 bytes_per_sample;
 	file_error filerr;
 	avi_stream *stream;
-	int offset;
+	int offset = 0;
 
 	/* get the audio stream */
 	stream = get_audio_stream(file, channel, &offset);


### PR DESCRIPTION
GCC 5.3.1 on Fedora 22

    src/lib/util/aviio.cpp:1378:57: error: ‘offset’ may be used uninitialized in this function [-Werror=maybe-uninitialized]