### PR TITLE
Sord m5: bug fixes

### DIFF
--- a/hash/m5_cart.xml
+++ b/hash/m5_cart.xml
@@ -667,8 +667,8 @@ come from... they might be eventually removed -->
 
   <!-- Brno mod ROMs -->
 
-	<software name="brnoboot" supported="no">
-		<description>Boot for Brno ramdisk</description>
+	<software name="brno_boot" supported="no">
+		<description>Boot for Brno ramdisk [console version]</description>
 		<year>1989</year>
 		<publisher>&lt;Pavel Brychta a spol.&gt;</publisher>
 		<part name="cart" interface="m5_cart">
@@ -679,7 +679,7 @@ come from... they might be eventually removed -->
 	</software>
 
 	<software name="brno_win" supported="no">
-		<description>Brno windows boot</description>
+		<description>Boot for Brno ramdisk [windows version]</description>
 		<year>1989</year>
 		<publisher>&lt;Ladislav Novak&gt;</publisher>
 		<part name="cart" interface="m5_cart">

--- a/hash/m5_flop.xml
+++ b/hash/m5_flop.xml
@@ -6,7 +6,7 @@
 		<description>Booting diskette for CP/M.[Brno mod]</description>
 		<year>1989</year>
 		<publisher></publisher>
-		<part name="flop1" interface="floppy_5_25">
+		<part name="flop1" interface="floppy_3_5">
 			<dataarea name="flop" size="860416">
 				<rom name="brno_boot_cpm.dsk" size="860416" crc="9484f399" sha1="efd1e664d5f4b80a7d49078cc80d187f72f4bc2f" offset="0" />
 			</dataarea>


### PR DESCRIPTION
fixed bug: crash if rom card was only cart
fixed bug: when em-5 selected monitor rom wasn't paged in
brno mod: windowed boot as default rom
brno mod: fixed bug: tape command in menu now works