### PR TITLE
Fix an SDL compile bug

### DIFF
--- a/src/osd/sdl/sdlfile.cpp
+++ b/src/osd/sdl/sdlfile.cpp
@@ -383,7 +383,7 @@ file_error osd_fflush(osd_file *file)
 	switch (file->type)
 	{
 		case SDLFILE_FILE:
-			result = fflush(file->handle, offset);
+			result = fflush(file->handle);
 			if (result == EOF)
 				return error_to_file_error(errno);
 			return FILERR_NONE;


### PR DESCRIPTION
Apparently, somebody thought fflush() had two arguments... This caused a compile error on my system.