### PR TITLE
Update German strings.po file

### DIFF
--- a/language/German/strings.po
+++ b/language/German/strings.po
@@ -9,7 +9,7 @@ msgstr ""
 "Project-Id-Version: MAME\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2016-03-22 13:51+1100\n"
-"PO-Revision-Date: 2016-03-09 15:19+0100\n"
+"PO-Revision-Date: 2016-03-23 13:50+0100\n"
 "Last-Translator: Lothar Serra Mari <scummvm@rootfather.de>\n"
 "Language-Team: MAME Language Team\n"
 "Language: de\n"
@@ -553,7 +553,7 @@ msgstr "Gegen"
 
 #: src/emu/ui/dirmenu.cpp:58 src/emu/ui/menu.cpp:59
 msgid "Covers"
-msgstr ""
+msgstr "Cover"
 
 #: src/emu/ui/dirmenu.cpp:116 src/emu/ui/dirmenu.cpp:136
 msgid "Folders Setup"


### PR DESCRIPTION
This PR only adds a translation for the string "Covers". All the other changes are only changes in the line breaks, thanks to poEdit.

I translated the string "Covers" with "Cover" - it's a well-known term in German and any translation would sound quite silly. I'm open for discussions regarding the plurals form - according to the Duden, "Cover" as well as "Covers" is accepted as a plural form, but I think "Cover" is more known to the public...