### PR TITLE
Fix cross compile (nw)

### DIFF
--- a/src/osd/modules/input/input_dinput.cpp
+++ b/src/osd/modules/input/input_dinput.cpp
@@ -15,7 +15,7 @@
 #define WIN32_LEAN_AND_MEAN
 #include <windows.h>
 #include <tchar.h>
-#include <wrl\client.h>
+#include <wrl/client.h>
 
 // undef WINNT for dinput.h to prevent duplicate definition
 #undef WINNT


### PR DESCRIPTION
Note: recent ComPtr change requires Mingw64 HEAD (post 5.0-rc1 commits) for wrl support. Should be good to go in 5.0-rc2.