### PR TITLE
World rev of Crime Fighters now default, Penfan girls set minor rev

### DIFF
--- a/src/mame/drivers/crimfght.cpp
+++ b/src/mame/drivers/crimfght.cpp
@@ -134,8 +134,8 @@ static INPUT_PORTS_START( crimfght )
 	PORT_DIPSETTING(   0x0b, DEF_STR( 1C_5C ))
 	PORT_DIPSETTING(   0x0a, DEF_STR( 1C_6C ))
 	PORT_DIPSETTING(   0x09, DEF_STR( 1C_7C ))
-	PORT_DIPSETTING(   0x00, "Void")
-	PORT_DIPNAME(0xf0, 0x00, "Coin B (unused)") PORT_DIPLOCATION("SW1:5,6,7,8")
+	PORT_DIPSETTING(   0x00, DEF_STR( Free_Play ))
+	PORT_DIPNAME(0xf0, 0xf0, "Coin B") PORT_DIPLOCATION("SW1:5,6,7,8")
 	PORT_DIPSETTING(   0x20, DEF_STR( 4C_1C ))
 	PORT_DIPSETTING(   0x50, DEF_STR( 3C_1C ))
 	PORT_DIPSETTING(   0x80, DEF_STR( 2C_1C ))
@@ -151,11 +151,14 @@ static INPUT_PORTS_START( crimfght )
 	PORT_DIPSETTING(   0xb0, DEF_STR( 1C_5C ))
 	PORT_DIPSETTING(   0xa0, DEF_STR( 1C_6C ))
 	PORT_DIPSETTING(   0x90, DEF_STR( 1C_7C ))
-	PORT_DIPSETTING(   0x00, "Void")
+	PORT_DIPSETTING(   0x00, DEF_STR( Unused ))
 
 	PORT_START("DSW2")
-	PORT_DIPUNUSED_DIPLOC(0x01, 0x01, "SW2:1")
-	PORT_DIPUNUSED_DIPLOC(0x02, 0x02, "SW2:2")
+	PORT_DIPNAME( 0x03, 0x02, DEF_STR( Lives ) ) PORT_DIPLOCATION("SW2:1,2")
+        PORT_DIPSETTING(    0x03, "1" )
+        PORT_DIPSETTING(    0x02, "2" )
+        PORT_DIPSETTING(    0x01, "3" )
+        PORT_DIPSETTING(    0x00, "4" )
 	PORT_DIPUNUSED_DIPLOC(0x04, 0x04, "SW2:3")
 	PORT_DIPUNUSED_DIPLOC(0x08, 0x08, "SW2:4")
 	PORT_DIPUNUSED_DIPLOC(0x10, 0x10, "SW2:5")
@@ -178,61 +181,72 @@ static INPUT_PORTS_START( crimfght )
 	PORT_BIT(0xf0, IP_ACTIVE_HIGH, IPT_SPECIAL) PORT_CUSTOM_MEMBER(DEVICE_SELF, crimfght_state, system_r, NULL)
 
 	PORT_START("P1")
-	KONAMI8_B12_UNK(1)
+	KONAMI8_B123_START(1)
 
 	PORT_START("P2")
-	KONAMI8_B12_UNK(2)
+	KONAMI8_B123_START(2)
 
 	PORT_START("P3")
-	KONAMI8_B12_UNK(3)
+	PORT_BIT( 0xff, IP_ACTIVE_LOW, IPT_UNKNOWN )
 
 	PORT_START("P4")
-	KONAMI8_B12_UNK(4)
+	PORT_BIT( 0xff, IP_ACTIVE_LOW, IPT_UNKNOWN )
 
 	PORT_START("SYSTEM")
 	PORT_BIT(0x01, IP_ACTIVE_LOW, IPT_COIN1)
 	PORT_BIT(0x02, IP_ACTIVE_LOW, IPT_COIN2)
-	PORT_BIT(0x04, IP_ACTIVE_LOW, IPT_COIN3)
-	PORT_BIT(0x08, IP_ACTIVE_LOW, IPT_COIN4)
+	PORT_BIT(0x04, IP_ACTIVE_LOW, IPT_UNKNOWN)
+	PORT_BIT(0x08, IP_ACTIVE_LOW, IPT_UNKNOWN)
 	PORT_BIT(0x10, IP_ACTIVE_LOW, IPT_SERVICE1)
 	PORT_BIT(0x20, IP_ACTIVE_LOW, IPT_SERVICE2)
-	PORT_BIT(0x40, IP_ACTIVE_LOW, IPT_SERVICE3)
-	PORT_BIT(0x80, IP_ACTIVE_LOW, IPT_SERVICE4)
+	PORT_BIT(0x40, IP_ACTIVE_LOW, IPT_UNKNOWN)
+	PORT_BIT(0x80, IP_ACTIVE_LOW, IPT_UNKNOWN)
 INPUT_PORTS_END
 
-static INPUT_PORTS_START( crimfghtj )
+static INPUT_PORTS_START( crimfghtu )
 	PORT_INCLUDE( crimfght )
 
 	PORT_MODIFY("DSW1")
-	KONAMI_COINAGE_LOC(DEF_STR( Free_Play ), "No Coin B", SW1)
-	/* "No Coin B" = coins produce sound, but no effect on coin counter */
+	PORT_DIPNAME(0xf0, 0x00, "Coin B (Unused)") PORT_DIPLOCATION("SW1:5,6,7,8")
+        PORT_DIPSETTING(   0x20, DEF_STR( 4C_1C ))
+        PORT_DIPSETTING(   0x50, DEF_STR( 3C_1C ))
+        PORT_DIPSETTING(   0x80, DEF_STR( 2C_1C ))
+        PORT_DIPSETTING(   0x40, DEF_STR( 3C_2C ))
+        PORT_DIPSETTING(   0x10, DEF_STR( 4C_3C ))
+        PORT_DIPSETTING(   0xf0, DEF_STR( 1C_1C ))
+        PORT_DIPSETTING(   0x30, DEF_STR( 3C_4C ))
+        PORT_DIPSETTING(   0x70, DEF_STR( 2C_3C ))
+        PORT_DIPSETTING(   0xe0, DEF_STR( 1C_2C ))
+        PORT_DIPSETTING(   0x60, DEF_STR( 2C_5C ))
+        PORT_DIPSETTING(   0xd0, DEF_STR( 1C_3C ))
+        PORT_DIPSETTING(   0xc0, DEF_STR( 1C_4C ))
+        PORT_DIPSETTING(   0xb0, DEF_STR( 1C_5C ))
+        PORT_DIPSETTING(   0xa0, DEF_STR( 1C_6C ))
+        PORT_DIPSETTING(   0x90, DEF_STR( 1C_7C ))
+        PORT_DIPSETTING(   0x00, DEF_STR( Unused ))
 
 	PORT_MODIFY("DSW2")
-	PORT_DIPNAME( 0x03, 0x02, DEF_STR( Lives ) ) PORT_DIPLOCATION("SW2:1,2")
-	PORT_DIPSETTING(    0x03, "1" )
-	PORT_DIPSETTING(    0x02, "2" )
-	PORT_DIPSETTING(    0x01, "3" )
-	PORT_DIPSETTING(    0x00, "4" )
+        PORT_DIPUNUSED_DIPLOC(0x01, 0x01, "SW2:1")
+        PORT_DIPUNUSED_DIPLOC(0x02, 0x02, "SW2:2")
 
-	PORT_MODIFY("P1")
-	KONAMI8_B123_START(1)
+        PORT_MODIFY("P1")
+        KONAMI8_B12_UNK(1)
 
-	PORT_MODIFY("P2")
-	KONAMI8_B123_START(2)
+        PORT_MODIFY("P2")
+        KONAMI8_B12_UNK(2)
 
-	PORT_MODIFY("P3")
-	PORT_BIT( 0xff, IP_ACTIVE_LOW, IPT_UNKNOWN )
+        PORT_MODIFY("P3")
+        KONAMI8_B12_UNK(3)
 
-	PORT_MODIFY("P4")
-	PORT_BIT( 0xff, IP_ACTIVE_LOW, IPT_UNKNOWN )
+        PORT_MODIFY("P4")
+        KONAMI8_B12_UNK(4)
 
 	PORT_MODIFY("SYSTEM")
-	PORT_BIT( 0x04, IP_ACTIVE_LOW, IPT_UNKNOWN )
-	PORT_BIT( 0x08, IP_ACTIVE_LOW, IPT_UNKNOWN )
-	PORT_BIT( 0x40, IP_ACTIVE_LOW, IPT_UNKNOWN )
-	PORT_BIT( 0x80, IP_ACTIVE_LOW, IPT_UNKNOWN )
+	PORT_BIT( 0x04, IP_ACTIVE_LOW, IPT_COIN3 )
+	PORT_BIT( 0x08, IP_ACTIVE_LOW, IPT_COIN4 )
+	PORT_BIT( 0x40, IP_ACTIVE_LOW, IPT_SERVICE3 )
+	PORT_BIT( 0x80, IP_ACTIVE_LOW, IPT_SERVICE4 )
 INPUT_PORTS_END
-
 
 
 /***************************************************************************
@@ -344,7 +358,7 @@ MACHINE_CONFIG_END
 
 ROM_START( crimfght )
 	ROM_REGION( 0x20000, "maincpu", 0 ) /* code + banked roms */
-	ROM_LOAD( "821l02.f24", 0x00000, 0x20000, CRC(588e7da6) SHA1(285febb3bcca31f82b34af3695a59eafae01cd30) )
+	ROM_LOAD( "821r02.f24", 0x00000, 0x20000, CRC(4ecdd923) SHA1(78e5260c4bb9b18d7818fb6300d7e1d3a577fb63) )
 
 	ROM_REGION( 0x10000, "audiocpu", 0 ) /* 64k for the sound CPU */
 	ROM_LOAD( "821l01.h4",  0x0000, 0x8000, CRC(0faca89e) SHA1(21c9c6d736b398a29e8709e1187c5bf3cacdc99d) )
@@ -386,9 +400,9 @@ ROM_START( crimfghtj )
 	ROM_LOAD( "821k03.e5",  0x00000, 0x40000, CRC(fef8505a) SHA1(5c5121609f69001838963e961cb227d6b64e4f5f) )
 ROM_END
 
-ROM_START( crimfght2 )
+ROM_START( crimfghtu )
 	ROM_REGION( 0x20000, "maincpu", 0 ) /* code + banked roms */
-	ROM_LOAD( "821r02.f24", 0x00000, 0x20000, CRC(4ecdd923) SHA1(78e5260c4bb9b18d7818fb6300d7e1d3a577fb63) )
+        ROM_LOAD( "821l02.f24", 0x00000, 0x20000, CRC(588e7da6) SHA1(285febb3bcca31f82b34af3695a59eafae01cd30) )
 
 	ROM_REGION( 0x10000, "audiocpu", 0 ) /* 64k for the sound CPU */
 	ROM_LOAD( "821l01.h4",  0x0000, 0x8000, CRC(0faca89e) SHA1(21c9c6d736b398a29e8709e1187c5bf3cacdc99d) )
@@ -414,6 +428,6 @@ ROM_END
 
 ***************************************************************************/
 
-GAME( 1989, crimfght,  0,        crimfght, crimfght, driver_device, 0, ROT0, "Konami", "Crime Fighters (US 4 players)", MACHINE_SUPPORTS_SAVE )
-GAME( 1989, crimfght2, crimfght, crimfght, crimfghtj, driver_device,0, ROT0, "Konami", "Crime Fighters (World 2 Players)", MACHINE_SUPPORTS_SAVE )
-GAME( 1989, crimfghtj, crimfght, crimfght, crimfghtj, driver_device,0, ROT0, "Konami", "Crime Fighters (Japan 2 Players)", MACHINE_SUPPORTS_SAVE )
+GAME( 1989, crimfght,  0,        crimfght, crimfght, driver_device, 0, ROT0, "Konami", "Crime Fighters (World 2 players)", MACHINE_SUPPORTS_SAVE )
+GAME( 1989, crimfghtu, crimfght, crimfght, crimfghtu, driver_device,0, ROT0, "Konami", "Crime Fighters (US 4 Players)", MACHINE_SUPPORTS_SAVE )
+GAME( 1989, crimfghtj, crimfght, crimfght, crimfght, driver_device,0, ROT0, "Konami", "Crime Fighters (Japan 2 Players)", MACHINE_SUPPORTS_SAVE )

--- a/src/mame/drivers/eolith.cpp
+++ b/src/mame/drivers/eolith.cpp
@@ -36,7 +36,8 @@
   1999 - Land Breaker (pcb ver 3.03) (MCU internal flash dump is missing)
   1999 - Land Breaker (pcb ver 3.02)
   1999 - New Hidden Catch (pcb ver 3.02)
-  1999 - Penfan Girls
+  1999 - Penfan Girls (set 1, pcb ver 3.03)
+  1999 - Penfan Girls (set 2, pcb ver 3.03P)
   2000 - Hidden Catch 3 (v. 1.00 / pcb ver 3.05)
   2001 - Fortress 2 Blue Arcade (v. 1.01 / pcb ver 3.05)
   2001 - Fortress 2 Blue Arcade (v. 1.00 / pcb ver 3.05)
@@ -1199,8 +1200,9 @@ ROM_START( penfana )
 	ROM_LOAD32_WORD_SWAP( "11.u11", 0x1400002, 0x200000, CRC(ddcd2bae) SHA1(c4fa5ebbaf801a7f06222150658033955966fe1b) )
 	ROM_LOAD32_WORD_SWAP( "12.u17", 0x1800000, 0x200000, CRC(2eed0f64) SHA1(3b9e65e41d8699a93ea74225ba12a3f66ecba11d) )
 	ROM_LOAD32_WORD_SWAP( "13.u12", 0x1800002, 0x200000, CRC(cc3068a8) SHA1(0022fad5a4d36678d35e99092c870f2b99d3d8d4) )
-	ROM_LOAD32_WORD_SWAP( "14.u18", 0x1c00000, 0x200000, CRC(20a9a08e) SHA1(fe4071cdf78d362bccaee92cdc70c66f7e30f817) ) // not checked by rom check
-	ROM_LOAD32_WORD_SWAP( "15.u13", 0x1c00002, 0x200000, CRC(872fa9c4) SHA1(4902faa97c9a3a9671cfefc6a711cfcd25f2d6bc) ) // not checked by rom check
+	// The 3.03P version doesn't even have these populated
+	//ROM_LOAD32_WORD_SWAP( "14.u18", 0x1c00000, 0x200000, CRC(20a9a08e) SHA1(fe4071cdf78d362bccaee92cdc70c66f7e30f817) ) // not checked by rom check
+	//ROM_LOAD32_WORD_SWAP( "15.u13", 0x1c00002, 0x200000, CRC(872fa9c4) SHA1(4902faa97c9a3a9671cfefc6a711cfcd25f2d6bc) ) // not checked by rom check
 
 	ROM_REGION( 0x008000, "soundcpu", 0 ) /* Sound (80c301) CPU Code */
 	ROM_LOAD( "pfg.u111", 0x0000, 0x8000, CRC(79012474) SHA1(09a2d5705d7bc52cc2d1644c87c1e31ee44813ef) )

--- a/src/mame/mame.lst
+++ b/src/mame/mame.lst
@@ -9935,8 +9935,8 @@ crgolfc                         // (c) 1984 Nasco Japan
 crgolfhi                        // (c) 1984 Nasco Japan
 
 @source:crimfght.cpp
-crimfght                        // GX821 (c) 1989 (US)
-crimfght2                       // GX821 (c) 1989 (World)
+crimfght                        // GX821 (c) 1989 (World)
+crimfghtu                       // GX821 (c) 1989 (US)
 crimfghtj                       // GX821 (c) 1989 (Japan)
 
 @source:crospang.cpp


### PR DESCRIPTION
4P Crime Fighters was made specifically for the US market, World rev should be default - ROMs and driver corrected for this.  No longer loading unused ROMs in one version of Penfan girls since that board physically doesn't have the chips.

New ROM sets:
http://www.system11.org/temp/ROMs/S11pencrim.zip