### PR TITLE
Tiny fix for coleco_cart region so it doesn't crash MAME when used in the debugger

### DIFF
--- a/src/devices/bus/coleco/exp.cpp
+++ b/src/devices/bus/coleco/exp.cpp
@@ -38,7 +38,7 @@ void device_colecovision_cartridge_interface::rom_alloc(size_t size)
 {
 	if (m_rom == nullptr)
 	{
-		m_rom = device().machine().memory().region_alloc("coleco_cart:rom", size, 1, ENDIANNESS_LITTLE)->base();
+		m_rom = device().machine().memory().region_alloc(":coleco_cart:rom", size, 1, ENDIANNESS_LITTLE)->base();
 		m_rom_size = size;
 	}
 }

--- a/src/devices/bus/coleco/exp.h
+++ b/src/devices/bus/coleco/exp.h
@@ -88,7 +88,7 @@ protected:
 	virtual bool is_creatable() const override { return 0; }
 	virtual bool must_be_loaded() const override { return 0; }
 	virtual bool is_reset_on_load() const override { return 1; }
-	virtual const char *image_interface() const override { return "coleco_cart"; }
+	virtual const char *image_interface() const override { return ":coleco_cart"; }
 	virtual const char *file_extensions() const override { return "rom,col,bin"; }
 	virtual const option_guide *create_option_guide() const override { return nullptr; }
 


### PR DESCRIPTION
Fix the coleco_cart:rom so that it doesn't crash MAME when used in the debugger:-
eg.
print coleco_cart:rom.mb@0