### PR TITLE
to fix flip sprites in toypop.

### DIFF
--- a/src/mame/drivers/toypop.cpp
+++ b/src/mame/drivers/toypop.cpp
@@ -253,7 +253,7 @@ void namcos16_state::legacy_obj_draw(bitmap_ind16 &bitmap,const rectangle &clipr
 		{
 			for(int xi=0;xi<width;xi++)
 			{
-				UINT16 sprite_offs = tile + xi + yi * 2;
+				UINT16 sprite_offs = tile + (xi ^ ((width - 1) & fx)) + yi * 2;
 				gfx_1->transmask(bitmap,cliprect,sprite_offs,color,fx,fy,x + xi*16,y + yi *16,m_palette->transpen_mask(*gfx_1, color, 0xff));
 			}
 		}


### PR DESCRIPTION
![sprite](https://cloud.githubusercontent.com/assets/11985559/14131366/63ea4442-f675-11e5-8839-1cc02b1130b7.jpg)
