### PR TITLE
Python 3 compatibility fix (nw)

### DIFF
--- a/scripts/build/complay.py
+++ b/scripts/build/complay.py
@@ -42,7 +42,8 @@ try:
                 compsize = len(compchunk)
                 for b in compchunk:
                     # For Python 2.x compatibility.
-                    b = ord(b)
+                    if sys.hexversion < 0x03000000:
+                        b = ord(b)
                     dst.write('%d' % b)
                     offs += 1
                     if offs != compsize:


### PR DESCRIPTION
    Traceback (most recent call last):
      File "scripts/build/complay.py", line 45, in <module>
        b = ord(b)
    TypeError: ord() expected string of length 1, but int found