### PR TITLE
Update unzip.cpp to work with bigger files

### DIFF
--- a/src/lib/util/unzip.cpp
+++ b/src/lib/util/unzip.cpp
@@ -81,7 +81,7 @@ namespace {
 
 #define FBOVERF         0x0ffffffff // 4 byte offset fields are set to this when the 8 bit offset should be used
 #define EBPLSIG         0x080001    // eight byte payload signature (for extra_field)
-#define EBPLO           0x04        // offset to eight byte offset (in "eight byte payload" type of extra_field)#define Z64_PK12        0x02014B50  // central directory record signature ("PK12")
+#define EBPLO           0x04        // offset to eight byte offset (in "eight byte payload" type of extra_field)
 #define Z64_PK12        0x02014B50  // central directory record signature ("PK12")
 #define Z64_PK66        0x06064B50  // zip64 end of central directory record signature ("PK66")
 #define Z64_PK67        0x07064B50  // zip64 end of central directory locator signature ("PK67")


### PR DESCRIPTION
Re: issue https://github.com/mamedev/mame/pull/785
Enables the ui to be able to read 4GB+ zip files, in case the users choose to zip up entire folders for convenience.

Lines 82-90: Added some defines
Line 158: Have the initialize() function use the 8 byte offset instead of the 4 byte offset.
Line 245: Added extra_field definition to file header structure.
Line 263: Added 8 byte offset field to ecd structure.
Lines 356-370: Added new inline function read_qword().
Line 461: Added code to load the extra_field in the search() function.
Lines 603-647: Changes to load_ecd() to detect zip64, and populate the 8 byte offset when zip64 is present.
Lines 684-699: Main code changes.