### PR TITLE
Added extra bit as delay between bytes to make 1 stop bit work

### DIFF
--- a/src/emu/diserial.cpp
+++ b/src/emu/diserial.cpp
@@ -425,8 +425,8 @@ void device_serial_interface::transmit_register_setup(UINT8 data_byte)
 		transmit_register_add_bit(parity);
 	}
 
-	/* stop bit(s) */
-	for (i=0; i<m_df_stop_bit_count; i++)
+	/* stop bit(s) + 1 extra bit as delay between bytes, needed to get 1 stop bit to work.  */
+	for (i=0; i<=m_df_stop_bit_count; i++)
 	{
 		transmit_register_add_bit(1);
 	}


### PR DESCRIPTION
I had to add this fix to make 1 stop bit work with the serial terminal device. Apparantly diserial sended bytes back to back which is not normal, there is always a small delay between bytes on a serial line.

The real fix may be to add a device_serial_interface callback to allow for an arbitrary delay and also implement the 1.5 stop bits but I am not brave enough to mess with core classes yet.