### PR TITLE
Show MAME's program name lowercase in help output.

### DIFF
--- a/src/emu/clifront.cpp
+++ b/src/emu/clifront.cpp
@@ -1713,14 +1713,14 @@ void cli_frontend::display_help()
 	osd_printf_info("This software reproduces, more or less faithfully, the behaviour of a wide range\n"
 					"of machines. But hardware is useless without software, so images of the ROMs and\n"
 					"other media which run on that hardware are also required.\n\n");
-	osd_printf_info("Usage:  %s [machine] [media] [software] [options]",emulator_info::get_appname());
+	osd_printf_info("Usage:  %s [machine] [media] [software] [options]",emulator_info::get_appname_lower());
 	osd_printf_info("\n\n"
 			"        %s -showusage    for a brief list of options\n"
 			"        %s -showconfig   for a list of configuration options\n"
 			"        %s -listmedia    for a full list of supported media\n"
 			"        %s -createconfig to create a %s.ini\n\n"
-			"For usage instructions, please consult the files config.txt and windows.txt.\n",emulator_info::get_appname(),
-			emulator_info::get_appname(),emulator_info::get_appname(),emulator_info::get_appname(),emulator_info::get_configname());
+			"For usage instructions, please consult the files config.txt and windows.txt.\n",emulator_info::get_appname_lower(),
+			emulator_info::get_appname_lower(),emulator_info::get_appname_lower(),emulator_info::get_appname_lower(),emulator_info::get_configname());
 }
 
 

--- a/src/emu/clifront.cpp
+++ b/src/emu/clifront.cpp
@@ -1586,7 +1586,7 @@ void cli_frontend::execute_commands(const char *exename)
 	// help?
 	if (strcmp(m_options.command(), CLICOMMAND_HELP) == 0)
 	{
-		display_help();
+		display_help(exename);
 		return;
 	}
 
@@ -1707,20 +1707,20 @@ void cli_frontend::execute_commands(const char *exename)
 //  output
 //-------------------------------------------------
 
-void cli_frontend::display_help()
+void cli_frontend::display_help(const char *exename)
 {
 	osd_printf_info("%s v%s\n%s\n\n", emulator_info::get_appname(),build_version,emulator_info::get_copyright_info());
 	osd_printf_info("This software reproduces, more or less faithfully, the behaviour of a wide range\n"
 					"of machines. But hardware is useless without software, so images of the ROMs and\n"
 					"other media which run on that hardware are also required.\n\n");
-	osd_printf_info("Usage:  %s [machine] [media] [software] [options]",emulator_info::get_appname_lower());
+	osd_printf_info("Usage:  %s [machine] [media] [software] [options]",exename);
 	osd_printf_info("\n\n"
 			"        %s -showusage    for a brief list of options\n"
 			"        %s -showconfig   for a list of configuration options\n"
 			"        %s -listmedia    for a full list of supported media\n"
 			"        %s -createconfig to create a %s.ini\n\n"
-			"For usage instructions, please consult the files config.txt and windows.txt.\n",emulator_info::get_appname_lower(),
-			emulator_info::get_appname_lower(),emulator_info::get_appname_lower(),emulator_info::get_appname_lower(),emulator_info::get_configname());
+			"For usage instructions, please consult the files config.txt and windows.txt.\n",exename,
+			exename,exename,exename,emulator_info::get_configname());
 }
 
 

--- a/src/emu/clifront.h
+++ b/src/emu/clifront.h
@@ -59,7 +59,7 @@ public:
 private:
 	// internal helpers
 	void execute_commands(const char *exename);
-	void display_help();
+	void display_help(const char *exename);
 	void display_suggestions(const char *gamename);
 	void output_single_softlist(FILE *out, software_list_device &swlist);
 


### PR DESCRIPTION
As the name of the binary is normally installed lowercase, the help
output should also reflect this.