### PR TITLE
Pass explicit -qt5 to all moc and qmake calls.

### DIFF
--- a/scripts/src/osd/modules.lua
+++ b/scripts/src/osd/modules.lua
@@ -286,14 +286,14 @@ function qtdebuggerbuild()
 			MOC = "moc"
 		else
 			if _OPTIONS["QT_HOME"]~=nil then
-				QMAKETST = backtick(_OPTIONS["QT_HOME"] .. "/bin/qmake --version 2>/dev/null")
+				QMAKETST = backtick(_OPTIONS["QT_HOME"] .. "/bin/qmake -qt5 --version 2>/dev/null")
 				if (QMAKETST=='') then
 					print("Qt's Meta Object Compiler (moc) wasn't found!")
 					os.exit(1)
 				end
-				MOC = _OPTIONS["QT_HOME"] .. "/bin/moc"
+				MOC = _OPTIONS["QT_HOME"] .. "/bin/moc -qt5"
 			else
-				MOCTST = backtick("which moc-qt5 2>/dev/null")
+				MOCTST = backtick("which moc 2>/dev/null")
 				if (MOCTST=='') then
 					MOCTST = backtick("which moc 2>/dev/null")
 				end
@@ -301,7 +301,7 @@ function qtdebuggerbuild()
 					print("Qt's Meta Object Compiler (moc) wasn't found!")
 					os.exit(1)
 				end
-				MOC = MOCTST
+				MOC = MOCTST .. " -qt5"
 			end
 		end
 
@@ -322,17 +322,17 @@ function qtdebuggerbuild()
 		if _OPTIONS["targetos"]=="windows" then
 			configuration { "mingw*" }
 				buildoptions {
-					"-I$(shell qmake -query QT_INSTALL_HEADERS)",
+					"-I$(shell qmake -qt5 -query QT_INSTALL_HEADERS)",
 				}
 			configuration { }
 		elseif _OPTIONS["targetos"]=="macosx" then
 			buildoptions {
-				"-F" .. backtick("qmake -query QT_INSTALL_LIBS"),
+				"-F" .. backtick("qmake -qt5 -query QT_INSTALL_LIBS"),
 			}
 		else
 			if _OPTIONS["QT_HOME"]~=nil then
 				buildoptions {
-					"-I" .. backtick(_OPTIONS["QT_HOME"] .. "/bin/qmake -query QT_INSTALL_HEADERS"),
+					"-I" .. backtick(_OPTIONS["QT_HOME"] .. "/bin/qmake -qt5 -query QT_INSTALL_HEADERS"),
 				}
 			else
 				buildoptions {
@@ -384,7 +384,7 @@ function osdmodulestargetconf()
 	if _OPTIONS["USE_QTDEBUG"]=="1" then
 		if _OPTIONS["targetos"]=="windows" then
 			linkoptions {
-				"-L$(shell qmake -query QT_INSTALL_LIBS)",
+				"-L$(shell qmake -qt5 -query QT_INSTALL_LIBS)",
 			}
 			links {
 				"qtmain",
@@ -394,7 +394,7 @@ function osdmodulestargetconf()
 			}
 		elseif _OPTIONS["targetos"]=="macosx" then
 			linkoptions {
-				"-F" .. backtick("qmake -query QT_INSTALL_LIBS"),
+				"-F" .. backtick("qmake -qt5 -query QT_INSTALL_LIBS"),
 			}
 			links {
 				"Qt5Core.framework",
@@ -404,7 +404,7 @@ function osdmodulestargetconf()
 		else
 			if _OPTIONS["QT_HOME"]~=nil then
 				linkoptions {
-					"-L" .. backtick(_OPTIONS["QT_HOME"] .. "/bin/qmake -query QT_INSTALL_LIBS"),
+					"-L" .. backtick(_OPTIONS["QT_HOME"] .. "/bin/qmake -qt5 -query QT_INSTALL_LIBS"),
 				}
 				links {
 					"Qt5Core",


### PR DESCRIPTION
Some systems like Debian, Ubuntu and other derivatives, expect qtchooser
will be used to select the appropriate Qt version, as Qt5 and Qt4 can
co-exist.

As MAME's build system does calls to moc and qmake directly, and Qt5 is
now the required version for the debugger, pass -qt5 to all moc and qmake
calls to avoid the build fail.