### PR TITLE
Critical fixes (nw)

### DIFF
--- a/src/devices/cpu/z80/tmpz84c015.cpp
+++ b/src/devices/cpu/z80/tmpz84c015.cpp
@@ -155,7 +155,7 @@ WRITE8_MEMBER(tmpz84c015_device::irq_priority_w)
 			{ 1, 2, 0 }  // 5: sio -> pio -> ctc -> ext
 		};
 
-		// reconfigure first 3 entries in daisy chain
+		// reconfigure daisy chain
 		const z80_daisy_config daisy_chain[] =
 		{
 			{ dev[prio[data][0]] },
@@ -163,6 +163,8 @@ WRITE8_MEMBER(tmpz84c015_device::irq_priority_w)
 			{ dev[prio[data][2]] },
 			{ nullptr }
 		};
+
+		// insert these 3 entries in order before any externally linked devices
 		daisy_init(daisy_chain);
 
 		m_irq_priority = data;

--- a/src/devices/cpu/z80/tmpz84c015.h
+++ b/src/devices/cpu/z80/tmpz84c015.h
@@ -23,9 +23,6 @@
     DEVICE CONFIGURATION MACROS
 ***************************************************************************/
 
-// If an external daisy chain is used, insert this before your own device tags:
-#define TMPZ84C015_DAISY_INTERNAL { "tmpz84c015_ctc" }, { "tmpz84c015_sio" }, { "tmpz84c015_pio" }
-
 // SIO callbacks
 #define MCFG_TMPZ84C015_OUT_TXDA_CB(_devcb) \
 	devcb = &tmpz84c015_device::set_out_txda_callback(*device, DEVCB_##_devcb);

--- a/src/devices/cpu/z80/z80daisy.h
+++ b/src/devices/cpu/z80/z80daisy.h
@@ -85,6 +85,7 @@ public:
 
 	// getters
 	bool daisy_chain_present() const { return (m_chain != nullptr); }
+	std::string daisy_show_chain() const;
 
 protected:
 	// interface-level overrides

--- a/src/mame/drivers/pve500.cpp
+++ b/src/mame/drivers/pve500.cpp
@@ -102,7 +102,6 @@ WRITE_LINE_MEMBER( pve500_state::external_monitor_w )
 
 static const z80_daisy_config maincpu_daisy_chain[] =
 {
-	TMPZ84C015_DAISY_INTERNAL,
 	{ "external_ctc" },
 	{ "external_sio" },
 	{ nullptr }

--- a/src/mame/drivers/system1.cpp
+++ b/src/mame/drivers/system1.cpp
@@ -2222,15 +2222,13 @@ MACHINE_CONFIG_END
 	MCFG_CPU_PROGRAM_MAP(system1_map) \
 	MCFG_CPU_DECRYPTED_OPCODES_MAP(decrypted_opcodes_map) \
 	MCFG_CPU_IO_MAP(system1_ppi_io_map) \
-	MCFG_CPU_VBLANK_INT_DRIVER("screen", system1_state, irq0_line_hold) \
-	MCFG_SEGAZ80_SET_DECRYPTED_TAG(":decrypted_opcodes")
+	MCFG_CPU_VBLANK_INT_DRIVER("screen", system1_state, irq0_line_hold)
 
 #define ENCRYPTED_SYS1PIO_MAPS \
 	MCFG_CPU_PROGRAM_MAP(system1_map) \
 	MCFG_CPU_DECRYPTED_OPCODES_MAP(decrypted_opcodes_map) \
 	MCFG_CPU_IO_MAP(system1_pio_io_map) \
-	MCFG_CPU_VBLANK_INT_DRIVER("screen", system1_state, irq0_line_hold) \
-	MCFG_SEGAZ80_SET_DECRYPTED_TAG(":decrypted_opcodes")
+	MCFG_CPU_VBLANK_INT_DRIVER("screen", system1_state, irq0_line_hold)
 
 
 static MACHINE_CONFIG_DERIVED( sys1ppix_315_5178, sys1ppi )


### PR DESCRIPTION
- Prevent tmpz84c015_device::irq_priority_w from crashing or corrupting the daisy chain
- Eliminate the need for TMPZ84C015_DAISY_INTERNAL by not overwriting elements in the daisy list
- Removed leftover MCFG_SEGAZ80_SET_DECRYPTED_TAG from macros in system1.cpp, which lets all drivers validate without crashing