### PR TITLE
Iterate over devices C++11 style

### DIFF
--- a/src/devices/bus/abcbus/abc890.cpp
+++ b/src/devices/bus/abcbus/abc890.cpp
@@ -252,11 +252,9 @@ void abc890_t::device_reset()
 
 void abc890_t::abcbus_cs(UINT8 data)
 {
-	abcbus_slot_device_iterator iter(*this);
-
-	for (abcbus_slot_t *slot = iter.first(); slot != nullptr; slot = iter.next())
+	for (abcbus_slot_t &slot : abcbus_slot_device_iterator(*this))
 	{
-		slot->cs_w(data);
+		slot.cs_w(data);
 	}
 }
 
@@ -269,11 +267,9 @@ UINT8 abc890_t::abcbus_inp()
 {
 	UINT8 data = 0xff;
 
-	abcbus_slot_device_iterator iter(*this);
-
-	for (abcbus_slot_t *slot = iter.first(); slot != nullptr; slot = iter.next())
+	for (abcbus_slot_t &slot : abcbus_slot_device_iterator(*this))
 	{
-		data &= slot->inp_r();
+		data &= slot.inp_r();
 	}
 
 	return data;
@@ -286,11 +282,9 @@ UINT8 abc890_t::abcbus_inp()
 
 void abc890_t::abcbus_out(UINT8 data)
 {
-	abcbus_slot_device_iterator iter(*this);
-
-	for (abcbus_slot_t *slot = iter.first(); slot != nullptr; slot = iter.next())
+	for (abcbus_slot_t &slot : abcbus_slot_device_iterator(*this))
 	{
-		slot->out_w(data);
+		slot.out_w(data);
 	}
 }
 
@@ -303,11 +297,9 @@ UINT8 abc890_t::abcbus_stat()
 {
 	UINT8 data = 0xff;
 
-	abcbus_slot_device_iterator iter(*this);
-
-	for (abcbus_slot_t *slot = iter.first(); slot != nullptr; slot = iter.next())
+	for (abcbus_slot_t &slot : abcbus_slot_device_iterator(*this))
 	{
-		data &= slot->stat_r();
+		data &= slot.stat_r();
 	}
 
 	return data;
@@ -320,11 +312,9 @@ UINT8 abc890_t::abcbus_stat()
 
 void abc890_t::abcbus_c1(UINT8 data)
 {
-	abcbus_slot_device_iterator iter(*this);
-
-	for (abcbus_slot_t *slot = iter.first(); slot != nullptr; slot = iter.next())
+	for (abcbus_slot_t &slot : abcbus_slot_device_iterator(*this))
 	{
-		slot->c1_w(data);
+		slot.c1_w(data);
 	}
 }
 
@@ -335,11 +325,9 @@ void abc890_t::abcbus_c1(UINT8 data)
 
 void abc890_t::abcbus_c2(UINT8 data)
 {
-	abcbus_slot_device_iterator iter(*this);
-
-	for (abcbus_slot_t *slot = iter.first(); slot != nullptr; slot = iter.next())
+	for (abcbus_slot_t &slot : abcbus_slot_device_iterator(*this))
 	{
-		slot->c2_w(data);
+		slot.c2_w(data);
 	}
 }
 
@@ -350,11 +338,9 @@ void abc890_t::abcbus_c2(UINT8 data)
 
 void abc890_t::abcbus_c3(UINT8 data)
 {
-	abcbus_slot_device_iterator iter(*this);
-
-	for (abcbus_slot_t *slot = iter.first(); slot != nullptr; slot = iter.next())
+	for (abcbus_slot_t &slot : abcbus_slot_device_iterator(*this))
 	{
-		slot->c3_w(data);
+		slot.c3_w(data);
 	}
 }
 
@@ -365,11 +351,9 @@ void abc890_t::abcbus_c3(UINT8 data)
 
 void abc890_t::abcbus_c4(UINT8 data)
 {
-	abcbus_slot_device_iterator iter(*this);
-
-	for (abcbus_slot_t *slot = iter.first(); slot != nullptr; slot = iter.next())
+	for (abcbus_slot_t &slot : abcbus_slot_device_iterator(*this))
 	{
-		slot->c4_w(data);
+		slot.c4_w(data);
 	}
 }
 
@@ -382,11 +366,9 @@ UINT8 abc890_t::abcbus_xmemfl(offs_t offset)
 {
 	UINT8 data = 0xff;
 
-	abcbus_slot_device_iterator iter(*this);
-
-	for (abcbus_slot_t *slot = iter.first(); slot != nullptr; slot = iter.next())
+	for (abcbus_slot_t &slot : abcbus_slot_device_iterator(*this))
 	{
-		data &= slot->xmemfl_r(offset);
+		data &= slot.xmemfl_r(offset);
 	}
 
 	return data;
@@ -399,10 +381,8 @@ UINT8 abc890_t::abcbus_xmemfl(offs_t offset)
 
 void abc890_t::abcbus_xmemw(offs_t offset, UINT8 data)
 {
-	abcbus_slot_device_iterator iter(*this);
-
-	for (abcbus_slot_t *slot = iter.first(); slot != nullptr; slot = iter.next())
+	for (abcbus_slot_t &slot : abcbus_slot_device_iterator(*this))
 	{
-		slot->xmemw_w(offset, data);
+		slot.xmemw_w(offset, data);
 	}
 }

--- a/src/devices/bus/c64/bn1541.cpp
+++ b/src/devices/bus/c64/bn1541.cpp
@@ -74,17 +74,13 @@ c64_bn1541_device::c64_bn1541_device(const machine_config &mconfig, const char *
 
 void c64_bn1541_device::device_start()
 {
-	device_iterator iter(machine().root_device());
-
-	for (device_t *device = iter.first(); device != nullptr; device = iter.next())
+	for (device_t &device : device_iterator(machine().root_device()))
 	{
-		device_iterator subiter(*device);
-
-		for (device_t *subdevice = subiter.first(); subdevice != nullptr; subdevice = iter.next())
+		for (device_t &subdevice : device_iterator(device))
 		{
-			if (subdevice->interface(m_other) && subdevice != this)
+			if (subdevice.interface(m_other) && &subdevice != this)
 			{
-				if (LOG) logerror("Parallel device %s\n", subdevice->tag());
+				if (LOG) logerror("Parallel device %s\n", subdevice.tag());
 
 				// grab the first 1541/1571 and run to the hills
 				m_other->m_other = this;

--- a/src/devices/imagedev/cassette.cpp
+++ b/src/devices/imagedev/cassette.cpp
@@ -372,7 +372,6 @@ void cassette_image_device::call_display()
 	int n;
 	double position, length;
 	cassette_state uistate;
-	cassette_image_device *dev;
 	static const UINT8 shapes[8] = { 0x2d, 0x5c, 0x7c, 0x2f, 0x2d, 0x20, 0x20, 0x20 };
 
 	/* abort if we should not be showing the image */
@@ -390,9 +389,7 @@ void cassette_image_device::call_display()
 	x = 0.2f;
 	y = 0.5f;
 
-	cassette_device_iterator iter(device().machine().root_device());
-	for (dev = iter.first(); dev != nullptr && strcmp( dev->tag(), device().tag() ); dev = iter.next())
-		y += 1;
+	y += cassette_device_iterator(device().machine().root_device()).indexof(*this);
 
 	y *= device().machine().ui().get_line_height() + 2.0f * UI_BOX_TB_BORDER;
 	/* choose which frame of the animation we are at */

--- a/src/devices/video/voodoo.cpp
+++ b/src/devices/video/voodoo.cpp
@@ -5010,12 +5010,11 @@ void voodoo_device::common_start_voodoo(UINT8 type)
 	}
 
 	/* set the type, and initialize the chip mask */
-	device_iterator iter(machine().root_device());
 	index = 0;
-	for (device_t *scan = iter.first(); scan != nullptr; scan = iter.next())
-		if (scan->type() == this->type())
+	for (device_t &scan : device_iterator(machine().root_device()))
+		if (scan.type() == this->type())
 		{
-			if (scan == this)
+			if (&scan == this)
 				break;
 			index++;
 		}

--- a/src/emu/addrmap.cpp
+++ b/src/emu/addrmap.cpp
@@ -696,11 +696,10 @@ void address_map::map_validity_check(validity_checker &valid, const device_t &de
 			std::string entry_region = entry.m_devbase.subtag(entry.m_region);
 
 			// look for the region
-			device_iterator deviter(device.mconfig().root_device());
-			for (device_t *dev = deviter.first(); dev != nullptr; dev = deviter.next())
-				for (const rom_entry *romp = rom_first_region(*dev); romp != nullptr && !found; romp = rom_next_region(romp))
+			for (device_t &dev : device_iterator(device.mconfig().root_device()))
+				for (const rom_entry *romp = rom_first_region(dev); romp != nullptr && !found; romp = rom_next_region(romp))
 				{
-					if (rom_region_name(*dev, romp) == entry_region)
+					if (rom_region_name(dev, romp) == entry_region)
 					{
 						// verify the address range is within the region's bounds
 						offs_t length = ROMREGION_GETLENGTH(romp);

--- a/src/emu/audit.cpp
+++ b/src/emu/audit.cpp
@@ -54,26 +54,25 @@ const char *driverpath = m_enumerator.config().root_device().searchpath();
 	int shared_required = 0;
 
 	// iterate over devices and regions
-	device_iterator deviter(m_enumerator.config().root_device());
-	for (device_t *device = deviter.first(); device != nullptr; device = deviter.next())
+	for (device_t &device : device_iterator(m_enumerator.config().root_device()))
 	{
 		// determine the search path for this source and iterate through the regions
-		m_searchpath = device->searchpath();
+		m_searchpath = device.searchpath();
 
 		// now iterate over regions and ROMs within
-		for (const rom_entry *region = rom_first_region(*device); region != nullptr; region = rom_next_region(region))
+		for (const rom_entry *region = rom_first_region(device); region != nullptr; region = rom_next_region(region))
 		{
 // temporary hack: add the driver path & region name
-std::string combinedpath = std::string(device->searchpath()).append(";").append(driverpath);
-if (device->shortname())
-	combinedpath.append(";").append(device->shortname());
+std::string combinedpath = std::string(device.searchpath()).append(";").append(driverpath);
+if (device.shortname())
+	combinedpath.append(";").append(device.shortname());
 m_searchpath = combinedpath.c_str();
 
 			for (const rom_entry *rom = rom_first_file(region); rom; rom = rom_next_file(rom))
 			{
 				const char *name = ROM_GETNAME(rom);
 				hash_collection hashes(ROM_GETHASHDATA(rom));
-				device_t *shared_device = find_shared_device(*device, name, hashes, ROM_GETLENGTH(rom));
+				device_t *shared_device = find_shared_device(device, name, hashes, ROM_GETLENGTH(rom));
 
 				// count the number of files with hashes
 				if (!hashes.flag(hash_collection::FLAG_NO_DUMP) && !ROM_ISOPTIONAL(rom))
@@ -95,7 +94,7 @@ m_searchpath = combinedpath.c_str();
 				if (record != nullptr)
 				{
 					// count the number of files that are found.
-					if (record->status() == audit_record::STATUS_GOOD || (record->status() == audit_record::STATUS_FOUND_INVALID && find_shared_device(*device, name, record->actual_hashes(), record->actual_length()) == nullptr))
+					if (record->status() == audit_record::STATUS_GOOD || (record->status() == audit_record::STATUS_FOUND_INVALID && find_shared_device(device, name, record->actual_hashes(), record->actual_length()) == nullptr))
 					{
 						found++;
 						if (shared_device != nullptr)
@@ -124,20 +123,20 @@ m_searchpath = combinedpath.c_str();
 //  audit_device - audit the device
 //-------------------------------------------------
 
-media_auditor::summary media_auditor::audit_device(device_t *device, const char *validation)
+media_auditor::summary media_auditor::audit_device(device_t &device, const char *validation)
 {
 	// start fresh
 	m_record_list.reset();
 
 	// store validation for later
 	m_validation = validation;
-	m_searchpath = device->shortname();
+	m_searchpath = device.shortname();
 
 	int found = 0;
 	int required = 0;
 
 	// now iterate over regions and ROMs within
-	for (const rom_entry *region = rom_first_region(*device); region != nullptr; region = rom_next_region(region))
+	for (const rom_entry *region = rom_first_region(device); region != nullptr; region = rom_next_region(region))
 	{
 		for (const rom_entry *rom = rom_first_file(region); rom; rom = rom_next_file(rom))
 		{
@@ -173,7 +172,7 @@ media_auditor::summary media_auditor::audit_device(device_t *device, const char 
 	}
 
 	// return a summary
-	return summarize(device->shortname());
+	return summarize(device.shortname());
 }
 
 
@@ -270,14 +269,13 @@ media_auditor::summary media_auditor::audit_samples()
 	int found = 0;
 
 	// iterate over sample entries
-	samples_device_iterator iterator(m_enumerator.config().root_device());
-	for (samples_device *device = iterator.first(); device != nullptr; device = iterator.next())
+	for (samples_device &device : samples_device_iterator(m_enumerator.config().root_device()))
 	{
 		// by default we just search using the driver name
 		std::string searchpath(m_enumerator.driver().name);
 
 		// add the alternate path if present
-		samples_iterator iter(*device);
+		samples_iterator iter(device);
 		if (iter.altbasename() != nullptr)
 			searchpath.append(";").append(iter.altbasename());
 
@@ -560,15 +558,14 @@ device_t *media_auditor::find_shared_device(device_t &device, const char *name, 
 		// iterate up the parent chain
 		for (int drvindex = m_enumerator.find(m_enumerator.driver().parent); drvindex != -1; drvindex = m_enumerator.find(m_enumerator.driver(drvindex).parent))
 		{
-			device_iterator deviter(m_enumerator.config(drvindex).root_device());
-			for (device_t *scandevice = deviter.first(); scandevice != nullptr; scandevice = deviter.next())
-				for (const rom_entry *region = rom_first_region(*scandevice); region; region = rom_next_region(region))
+			for (device_t &scandevice : device_iterator(m_enumerator.config(drvindex).root_device()))
+				for (const rom_entry *region = rom_first_region(scandevice); region; region = rom_next_region(region))
 					for (const rom_entry *rom = rom_first_file(region); rom; rom = rom_next_file(rom))
 						if (ROM_GETLENGTH(rom) == romlength)
 						{
 							hash_collection hashes(ROM_GETHASHDATA(rom));
 							if ((dumped && hashes == romhashes) || (!dumped && ROM_GETNAME(rom) == name))
-								highest_device = scandevice;
+								highest_device = &scandevice;
 						}
 		}
 	}

--- a/src/emu/audit.h
+++ b/src/emu/audit.h
@@ -145,7 +145,7 @@ public:
 
 	// audit operations
 	summary audit_media(const char *validation = AUDIT_VALIDATE_FULL);
-	summary audit_device(device_t *device, const char *validation = AUDIT_VALIDATE_FULL);
+	summary audit_device(device_t &device, const char *validation = AUDIT_VALIDATE_FULL);
 	summary audit_software(const char *list_name, software_info *swinfo, const char *validation = AUDIT_VALIDATE_FULL);
 	summary audit_samples();
 	summary summarize(const char *name,std::string *output = nullptr);

--- a/src/emu/cheat.cpp
+++ b/src/emu/cheat.cpp
@@ -1141,22 +1141,21 @@ void cheat_manager::reload()
 
 	// load the cheat file, if it's a system that has a software list then try softlist_name/shortname.xml first,
 	// if it fails to load then try to load via crc32 - basename/crc32.xml ( eg. 01234567.xml )
-	image_interface_iterator iter(machine().root_device());
-	for (device_image_interface *image = iter.first(); image != nullptr; image = iter.next())
-		if (image->exists())
+	for (device_image_interface &image : image_interface_iterator(machine().root_device()))
+		if (image.exists())
 		{
 			// if we are loading through a software list, try to load softlist_name/shortname.xml
 			// this allows the coexistence of arcade cheats with cheats for home conversions which
 			// have the same shortname
-			if (image->software_entry() != nullptr)
+			if (image.software_entry() != nullptr)
 			{
-				load_cheats(string_format("%s%s%s", image->software_list_name(), PATH_SEPARATOR, image->basename()).c_str());
+				load_cheats(string_format("%s%s%s", image.software_list_name(), PATH_SEPARATOR, image.basename()).c_str());
 				break;
 			}
 			// else we are loading outside the software list, try to load machine_basename/crc32.xml
 			else
 			{
-				UINT32 crc = image->crc();
+				UINT32 crc = image.crc();
 				if (crc != 0)
 				{
 					load_cheats(string_format("%s%s%08X", machine().basename(), PATH_SEPARATOR, crc).c_str());

--- a/src/emu/clifront.cpp
+++ b/src/emu/clifront.cpp
@@ -123,37 +123,36 @@ int cli_frontend::execute(int argc, char **argv)
 				throw emu_fatalerror(MAMERR_FATALERROR, "Error: unknown option: %s\n", m_options.software_name());
 
 			bool found = false;
-			for (software_list_device *swlistdev = iter.first(); swlistdev != nullptr; swlistdev = iter.next())
+			for (software_list_device &swlistdev : iter)
 			{
-				software_info *swinfo = swlistdev->find(m_options.software_name());
+				software_info *swinfo = swlistdev.find(m_options.software_name());
 				if (swinfo != nullptr)
 				{
 					// loop through all parts
 					for (software_part &swpart : swinfo->parts())
 					{
 						const char *mount = swpart.feature("automount");
-						if (swpart.is_compatible(*swlistdev))
+						if (swpart.is_compatible(swlistdev))
 						{
 							if (mount == nullptr || strcmp(mount,"no") != 0)
 							{
 								// search for an image device with the right interface
-								image_interface_iterator imgiter(config.root_device());
-								for (device_image_interface *image = imgiter.first(); image != nullptr; image = imgiter.next())
+								for (device_image_interface &image : image_interface_iterator(config.root_device()))
 								{
-									const char *interface = image->image_interface();
+									const char *interface = image.image_interface();
 									if (interface != nullptr)
 									{
 										if (swpart.matches_interface(interface))
 										{
-											const char *option = m_options.value(image->brief_instance_name());
+											const char *option = m_options.value(image.brief_instance_name());
 
 											// mount only if not already mounted
 											if (*option == 0)
 											{
-												std::string val = string_format("%s:%s:%s", swlistdev->list_name(), m_options.software_name(), swpart.name());
+												std::string val = string_format("%s:%s:%s", swlistdev.list_name(), m_options.software_name(), swpart.name());
 
 												// call this in order to set slot devices according to mounting
-												m_options.parse_slot_devices(argc, argv, option_errors, image->instance_name(), val.c_str(), &swpart);
+												m_options.parse_slot_devices(argc, argv, option_errors, image.instance_name(), val.c_str(), &swpart);
 												break;
 											}
 										}
@@ -434,15 +433,14 @@ void cli_frontend::listcrc(const char *gamename)
 	// iterate through matches, and then through ROMs
 	while (drivlist.next())
 	{
-		device_iterator deviter(drivlist.config().root_device());
-		for (device_t *device = deviter.first(); device != nullptr; device = deviter.next())
-			for (const rom_entry *region = rom_first_region(*device); region; region = rom_next_region(region))
+		for (device_t &device : device_iterator(drivlist.config().root_device()))
+			for (const rom_entry *region = rom_first_region(device); region; region = rom_next_region(region))
 				for (const rom_entry *rom = rom_first_file(region); rom; rom = rom_next_file(rom))
 				{
 					// if we have a CRC, display it
 					UINT32 crc;
 					if (hash_collection(ROM_GETHASHDATA(rom)).crc(crc))
-						osd_printf_info("%08x %-16s \t %-8s \t %s\n", crc, ROM_GETNAME(rom), device->shortname(), device->name());
+						osd_printf_info("%08x %-16s \t %-8s \t %s\n", crc, ROM_GETNAME(rom), device.shortname(), device.name());
 				}
 	}
 }
@@ -472,9 +470,8 @@ void cli_frontend::listroms(const char *gamename)
 				"Name                    Size Checksum\n", drivlist.driver().name);
 
 		// iterate through roms
-		device_iterator deviter(drivlist.config().root_device());
-		for (device_t *device = deviter.first(); device != nullptr; device = deviter.next())
-			for (const rom_entry *region = rom_first_region(*device); region; region = rom_next_region(region))
+		for (device_t &device : device_iterator(drivlist.config().root_device()))
+			for (const rom_entry *region = rom_first_region(device); region; region = rom_next_region(region))
 				for (const rom_entry *rom = rom_first_file(region); rom; rom = rom_next_file(rom))
 				{
 					// accumulate the total length of all chunks
@@ -538,9 +535,9 @@ void cli_frontend::listsamples(const char *gamename)
 		osd_printf_info("Samples required for driver \"%s\".\n", drivlist.driver().name);
 
 		// iterate over samples devices and print the samples from each one
-		for (samples_device *device = iter.first(); device != nullptr; device = iter.next())
+		for (samples_device &device : iter)
 		{
-			samples_iterator sampiter(*device);
+			samples_iterator sampiter(device);
 			for (const char *samplename = sampiter.first(); samplename != nullptr; samplename = sampiter.next())
 				osd_printf_info("%s\n", samplename);
 		}
@@ -578,10 +575,9 @@ void cli_frontend::listdevices(const char *gamename)
 		printf("Driver %s (%s):\n", drivlist.driver().name, drivlist.driver().description);
 
 		// build a list of devices
-		device_iterator iter(drivlist.config().root_device());
 		std::vector<device_t *> device_list;
-		for (device_t *device = iter.first(); device != nullptr; device = iter.next())
-			device_list.push_back(device);
+		for (device_t &device : device_iterator(drivlist.config().root_device()))
+			device_list.push_back(&device);
 
 		// sort them by tag
 		qsort(&device_list[0], device_list.size(), sizeof(device_list[0]), compare_devices);
@@ -649,18 +645,17 @@ void cli_frontend::listslots(const char *gamename)
 	while (drivlist.next())
 	{
 		// iterate
-		slot_interface_iterator iter(drivlist.config().root_device());
 		bool first = true;
-		for (const device_slot_interface *slot = iter.first(); slot != nullptr; slot = iter.next())
+		for (const device_slot_interface &slot : slot_interface_iterator(drivlist.config().root_device()))
 		{
-			if (slot->fixed()) continue;
+			if (slot.fixed()) continue;
 			// output the line, up to the list of extensions
-			printf("%-13s%-10s   ", first ? drivlist.driver().name : "", slot->device().tag()+1);
+			printf("%-13s%-10s   ", first ? drivlist.driver().name : "", slot.device().tag()+1);
 
 			bool first_option = true;
 
 			// get the options and print them
-			for (const device_slot_option &option : slot->option_list())
+			for (const device_slot_option &option : slot.option_list())
 			{
 				if (option.selectable())
 				{
@@ -710,21 +705,20 @@ void cli_frontend::listmedia(const char *gamename)
 	while (drivlist.next())
 	{
 		// iterate
-		image_interface_iterator iter(drivlist.config().root_device());
 		bool first = true;
-		for (const device_image_interface *imagedev = iter.first(); imagedev != nullptr; imagedev = iter.next())
+		for (const device_image_interface &imagedev : image_interface_iterator(drivlist.config().root_device()))
 		{
-            if (!imagedev->user_loadable())
-                continue;
-            
+			if (!imagedev.user_loadable())
+				continue;
+
 			// extract the shortname with parentheses
-			std::string paren_shortname = string_format("(%s)", imagedev->brief_instance_name());
+			std::string paren_shortname = string_format("(%s)", imagedev.brief_instance_name());
 
 			// output the line, up to the list of extensions
-			printf("%-13s%-12s%-8s   ", first ? drivlist.driver().name : "", imagedev->instance_name(), paren_shortname.c_str());
+			printf("%-13s%-12s%-8s   ", first ? drivlist.driver().name : "", imagedev.instance_name(), paren_shortname.c_str());
 
 			// get the extensions and print them
-			std::string extensions(imagedev->file_extensions());
+			std::string extensions(imagedev.file_extensions());
 			for (int start = 0, end = extensions.find_first_of(',');; start = end + 1, end = extensions.find_first_of(',', start))
 			{
 				std::string curext(extensions, start, (end == -1) ? extensions.length() - start : end - start);
@@ -817,11 +811,10 @@ void cli_frontend::verifyroms(const char *gamename)
 		while (dummy_drivlist.next())
 		{
 			machine_config &config = dummy_drivlist.config();
-			device_iterator iter(config.root_device());
-			for (device_t *dev = iter.first(); dev != nullptr; dev = iter.next())
+			for (device_t &dev : device_iterator(config.root_device()))
 			{
-				if (dev->owner() != nullptr && (*(dev->shortname()) != 0) && dev->rom_region() != nullptr && (device_map.insert(dev->shortname()).second)) {
-					if (core_strwildcmp(gamename, dev->shortname()) == 0)
+				if (dev.owner() != nullptr && (*(dev.shortname()) != 0) && dev.rom_region() != nullptr && (device_map.insert(dev.shortname()).second)) {
+					if (core_strwildcmp(gamename, dev.shortname()) == 0)
 					{
 						matched++;
 
@@ -836,11 +829,11 @@ void cli_frontend::verifyroms(const char *gamename)
 						{
 							// output the summary of the audit
 							std::string summary_string;
-							auditor.summarize(dev->shortname(),&summary_string);
+							auditor.summarize(dev.shortname(),&summary_string);
 							osd_printf_info("%s", summary_string.c_str());
 
 							// display information about what we discovered
-							osd_printf_info("romset %s ", dev->shortname());
+							osd_printf_info("romset %s ", dev.shortname());
 
 							// switch off of the result
 							switch (summary)
@@ -868,20 +861,18 @@ void cli_frontend::verifyroms(const char *gamename)
 				}
 			}
 
-			slot_interface_iterator slotiter(config.root_device());
-			for (const device_slot_interface *slot = slotiter.first(); slot != nullptr; slot = slotiter.next())
+			for (const device_slot_interface &slot : slot_interface_iterator(config.root_device()))
 			{
-				for (const device_slot_option &option : slot->option_list())
+				for (const device_slot_option &option : slot.option_list())
 				{
 					std::string temptag("_");
 					temptag.append(option.name());
 					device_t *dev = const_cast<machine_config &>(config).device_add(&config.root_device(), temptag.c_str(), option.devtype(), 0);
 
 					// notify this device and all its subdevices that they are now configured
-					device_iterator subiter(*dev);
-					for (device_t *device = subiter.first(); device != nullptr; device = subiter.next())
-						if (!device->configured())
-							device->config_complete();
+					for (device_t &device : device_iterator(*dev))
+						if (!device.configured())
+							device.config_complete();
 
 					if (device_map.insert(dev->shortname()).second) {
 						if (core_strwildcmp(gamename, dev->shortname()) == 0)
@@ -890,7 +881,7 @@ void cli_frontend::verifyroms(const char *gamename)
 							if (dev->rom_region() != nullptr)
 							{
 								// audit the ROMs in this set
-								media_auditor::summary summary = auditor.audit_device(dev, AUDIT_VALIDATE_FAST);
+								media_auditor::summary summary = auditor.audit_device(*dev, AUDIT_VALIDATE_FAST);
 
 								// if not found, count that and leave it at that
 								if (summary == media_auditor::NOTFOUND)
@@ -933,17 +924,15 @@ void cli_frontend::verifyroms(const char *gamename)
 						}
 					} else {
 						// check for subdevices with ROMs (a few devices are missed otherwise, e.g. MPU401)
-						device_iterator subiter(*dev);
-						for (device_t *device = subiter.first(); device != nullptr; device = subiter.next())
+						for (device_t &device : device_iterator(*dev))
 						{
-							device_iterator subsubiter(*device);
-							for (device_t *subdev = subsubiter.first(); subdev != nullptr; subdev = subsubiter.next())
+							for (device_t &subdev : device_iterator(device))
 							{
-								if (subdev->owner() == device && subdev->rom_region() != nullptr && subdev->shortname() != nullptr && subdev->shortname()[0] != '\0')
+								if (subdev.owner() == &device && subdev.rom_region() != nullptr && subdev.shortname() != nullptr && subdev.shortname()[0] != '\0')
 								{
-									if (device_map.insert(subdev->shortname()).second)
+									if (device_map.insert(subdev.shortname()).second)
 									{
-										if (core_strwildcmp(gamename, subdev->shortname()) == 0)
+										if (core_strwildcmp(gamename, subdev.shortname()) == 0)
 										{
 											matched++;
 
@@ -959,11 +948,11 @@ void cli_frontend::verifyroms(const char *gamename)
 											{
 												// output the summary of the audit
 												std::string summary_string;
-												auditor.summarize(subdev->shortname(),&summary_string);
+												auditor.summarize(subdev.shortname(),&summary_string);
 												osd_printf_info("%s", summary_string.c_str());
 
 												// display information about what we discovered
-												osd_printf_info("romset %s ", subdev->shortname());
+												osd_printf_info("romset %s ", subdev.shortname());
 
 												// switch off of the result
 												switch (summary)
@@ -1311,13 +1300,12 @@ void cli_frontend::listsoftware(const char *gamename)
 
 	while (drivlist.next())
 	{
-		software_list_device_iterator iter(drivlist.config().root_device());
-		for (software_list_device *swlistdev = iter.first(); swlistdev != nullptr; swlistdev = iter.next())
-			if (list_map.insert(swlistdev->list_name()).second)
-				if (!swlistdev->get_info().empty())
+		for (software_list_device &swlistdev : software_list_device_iterator(drivlist.config().root_device()))
+			if (list_map.insert(swlistdev.list_name()).second)
+				if (!swlistdev.get_info().empty())
 				{
 					if (isfirst) { fprintf(out, SOFTLIST_XML_BEGIN); isfirst = false; }
-					output_single_softlist(out, *swlistdev);
+					output_single_softlist(out, swlistdev);
 				}
 	}
 
@@ -1354,16 +1342,15 @@ void cli_frontend::verifysoftware(const char *gamename)
 	{
 		matched++;
 
-		software_list_device_iterator iter(drivlist.config().root_device());
-		for (software_list_device *swlistdev = iter.first(); swlistdev != nullptr; swlistdev = iter.next())
-			if (swlistdev->list_type() == SOFTWARE_LIST_ORIGINAL_SYSTEM)
-				if (list_map.insert(swlistdev->list_name()).second)
-					if (!swlistdev->get_info().empty())
+		for (software_list_device &swlistdev : software_list_device_iterator(drivlist.config().root_device()))
+			if (swlistdev.list_type() == SOFTWARE_LIST_ORIGINAL_SYSTEM)
+				if (list_map.insert(swlistdev.list_name()).second)
+					if (!swlistdev.get_info().empty())
 					{
 						nrlists++;
-						for (software_info &swinfo : swlistdev->get_info())
+						for (software_info &swinfo : swlistdev.get_info())
 						{
-							media_auditor::summary summary = auditor.audit_software(swlistdev->list_name(), &swinfo, AUDIT_VALIDATE_FAST);
+							media_auditor::summary summary = auditor.audit_software(swlistdev.list_name(), &swinfo, AUDIT_VALIDATE_FAST);
 
 							// if not found, count that and leave it at that
 							if (summary == media_auditor::NOTFOUND)
@@ -1379,7 +1366,7 @@ void cli_frontend::verifysoftware(const char *gamename)
 								osd_printf_info("%s", summary_string.c_str());
 
 								// display information about what we discovered
-								osd_printf_info("romset %s:%s ", swlistdev->list_name(), swinfo.shortname());
+								osd_printf_info("romset %s:%s ", swlistdev.list_name(), swinfo.shortname());
 
 								// switch off of the result
 								switch (summary)
@@ -1442,13 +1429,12 @@ void cli_frontend::getsoftlist(const char *gamename)
 	driver_enumerator drivlist(m_options);
 	while (drivlist.next())
 	{
-		software_list_device_iterator iter(drivlist.config().root_device());
-		for (software_list_device *swlistdev = iter.first(); swlistdev != nullptr; swlistdev = iter.next())
-			if (core_strwildcmp(gamename, swlistdev->list_name()) == 0 && list_map.insert(swlistdev->list_name()).second)
-				if (!swlistdev->get_info().empty())
+		for (software_list_device &swlistdev : software_list_device_iterator(drivlist.config().root_device()))
+			if (core_strwildcmp(gamename, swlistdev.list_name()) == 0 && list_map.insert(swlistdev.list_name()).second)
+				if (!swlistdev.get_info().empty())
 				{
 					if (isfirst) { fprintf( out, SOFTLIST_XML_BEGIN); isfirst = FALSE; }
-					output_single_softlist(out, *swlistdev);
+					output_single_softlist(out, swlistdev);
 				}
 	}
 
@@ -1475,17 +1461,16 @@ void cli_frontend::verifysoftlist(const char *gamename)
 
 	while (drivlist.next())
 	{
-		software_list_device_iterator iter(drivlist.config().root_device());
-		for (software_list_device *swlistdev = iter.first(); swlistdev != nullptr; swlistdev = iter.next())
-			if (core_strwildcmp(gamename, swlistdev->list_name()) == 0 && list_map.insert(swlistdev->list_name()).second)
-				if (!swlistdev->get_info().empty())
+		for (software_list_device &swlistdev : software_list_device_iterator(drivlist.config().root_device()))
+			if (core_strwildcmp(gamename, swlistdev.list_name()) == 0 && list_map.insert(swlistdev.list_name()).second)
+				if (!swlistdev.get_info().empty())
 				{
 					matched++;
 
 					// Get the actual software list contents
-					for (software_info &swinfo : swlistdev->get_info())
+					for (software_info &swinfo : swlistdev.get_info())
 					{
-						media_auditor::summary summary = auditor.audit_software(swlistdev->list_name(), &swinfo, AUDIT_VALIDATE_FAST);
+						media_auditor::summary summary = auditor.audit_software(swlistdev.list_name(), &swinfo, AUDIT_VALIDATE_FAST);
 
 						// if not found, count that and leave it at that
 						if (summary == media_auditor::NOTFOUND)
@@ -1501,7 +1486,7 @@ void cli_frontend::verifysoftlist(const char *gamename)
 							osd_printf_info("%s", summary_string.c_str());
 
 							// display information about what we discovered
-							osd_printf_info("romset %s:%s ", swlistdev->list_name(), swinfo.shortname());
+							osd_printf_info("romset %s:%s ", swlistdev.list_name(), swinfo.shortname());
 
 							// switch off of the result
 							switch (summary)
@@ -1937,13 +1922,12 @@ int media_identifier::find_by_hash(const hash_collection &hashes, int length)
 	m_drivlist.reset();
 	while (m_drivlist.next())
 	{
-		// iterate over devices, regions and files within the region */
-		device_iterator deviter(m_drivlist.config().root_device());
-		for (device_t *device = deviter.first(); device != nullptr; device = deviter.next())
+		// iterate over devices, regions and files within the region
+		for (device_t &device : device_iterator(m_drivlist.config().root_device()))
 		{
-			if (shortnames.insert(device->shortname()).second)
+			if (shortnames.insert(device.shortname()).second)
 			{
-				for (const rom_entry *region = rom_first_region(*device); region != nullptr; region = rom_next_region(region))
+				for (const rom_entry *region = rom_first_region(device); region != nullptr; region = rom_next_region(region))
 					for (const rom_entry *rom = rom_first_file(region); rom != nullptr; rom = rom_next_file(rom))
 					{
 						hash_collection romhashes(ROM_GETHASHDATA(rom));
@@ -1962,12 +1946,11 @@ int media_identifier::find_by_hash(const hash_collection &hashes, int length)
 		}
 
 		// next iterate over softlists
-		software_list_device_iterator iter(m_drivlist.config().root_device());
-		for (software_list_device *swlistdev = iter.first(); swlistdev != nullptr; swlistdev = iter.next())
+		for (software_list_device &swlistdev : software_list_device_iterator(m_drivlist.config().root_device()))
 		{
-			if (listnames.insert(swlistdev->list_name()).second)
+			if (listnames.insert(swlistdev.list_name()).second)
 			{
-				for (software_info &swinfo : swlistdev->get_info())
+				for (software_info &swinfo : swlistdev.get_info())
 					for (software_part &part : swinfo.parts())
 						for (const rom_entry *region = part.romdata(); region != nullptr; region = rom_next_region(region))
 							for (const rom_entry *rom = rom_first_file(region); rom != nullptr; rom = rom_next_file(rom))
@@ -1980,7 +1963,7 @@ int media_identifier::find_by_hash(const hash_collection &hashes, int length)
 									// output information about the match
 									if (found)
 										osd_printf_info("                    ");
-									osd_printf_info("= %s%-20s  %s:%s %s\n", baddump ? "(BAD) " : "", ROM_GETNAME(rom), swlistdev->list_name(), swinfo.shortname(), swinfo.longname());
+									osd_printf_info("= %s%-20s  %s:%s %s\n", baddump ? "(BAD) " : "", ROM_GETNAME(rom), swlistdev.list_name(), swinfo.shortname(), swinfo.longname());
 									found++;
 								}
 							}

--- a/src/emu/debug/debugcpu.cpp
+++ b/src/emu/debug/debugcpu.cpp
@@ -172,10 +172,9 @@ void debug_cpu_flush_traces(running_machine &machine)
 {
 	/* this can be called on exit even when no debugging is enabled, so
 	 make sure the devdebug is valid before proceeding */
-	device_iterator iter(machine.root_device());
-	for (device_t *device = iter.first(); device != nullptr; device = iter.next())
-		if (device->debug() != nullptr)
-			device->debug()->trace_flush();
+	for (device_t &device : device_iterator(machine.root_device()))
+		if (device.debug() != nullptr)
+			device.debug()->trace_flush();
 }
 
 
@@ -311,19 +310,18 @@ bool debug_comment_save(running_machine &machine)
 		xml_set_attribute(systemnode, "name", machine.system().name);
 
 		// for each device
-		device_iterator iter(machine.root_device());
 		bool found_comments = false;
-		for (device_t *device = iter.first(); device != nullptr; device = iter.next())
-			if (device->debug() && device->debug()->comment_count() > 0)
+		for (device_t &device : device_iterator(machine.root_device()))
+			if (device.debug() && device.debug()->comment_count() > 0)
 			{
 				// create a node for this device
 				xml_data_node *curnode = xml_add_child(systemnode, "cpu", nullptr);
 				if (curnode == nullptr)
 					throw emu_exception();
-				xml_set_attribute(curnode, "tag", device->tag());
+				xml_set_attribute(curnode, "tag", device.tag());
 
 				// export the comments
-				if (!device->debug()->comment_export(*curnode))
+				if (!device.debug()->comment_export(*curnode))
 					throw emu_exception();
 				found_comments = true;
 			}
@@ -1049,9 +1047,8 @@ static void on_vblank(running_machine &machine, screen_device &device, bool vbla
 static void reset_transient_flags(running_machine &machine)
 {
 	/* loop over CPUs and reset the transient flags */
-	device_iterator iter(machine.root_device());
-	for (device_t *device = iter.first(); device != nullptr; device = iter.next())
-		device->debug()->reset_transient_flag();
+	for (device_t &device : device_iterator(machine.root_device()))
+		device.debug()->reset_transient_flag();
 	machine.debugcpu_data->m_stop_when_not_device = nullptr;
 }
 

--- a/src/emu/debug/dvbpoints.cpp
+++ b/src/emu/debug/dvbpoints.cpp
@@ -132,12 +132,11 @@ void debug_view_breakpoints::enumerate_sources()
 	m_source_list.reset();
 
 	// iterate over devices with disassembly interfaces
-	disasm_interface_iterator iter(machine().root_device());
-	for (device_disasm_interface *dasm = iter.first(); dasm != nullptr; dasm = iter.next())
+	for (device_disasm_interface &dasm : disasm_interface_iterator(machine().root_device()))
 	{
 		std::string name;
-		name = string_format("%s '%s'", dasm->device().name(), dasm->device().tag());
-		m_source_list.append(*global_alloc(debug_view_source(name.c_str(), &dasm->device())));
+		name = string_format("%s '%s'", dasm.device().name(), dasm.device().tag());
+		m_source_list.append(*global_alloc(debug_view_source(name.c_str(), &dasm.device())));
 	}
 
 	// reset the source to a known good entry

--- a/src/emu/debug/dvdisasm.cpp
+++ b/src/emu/debug/dvdisasm.cpp
@@ -98,13 +98,12 @@ void debug_view_disasm::enumerate_sources()
 	m_source_list.reset();
 
 	// iterate over devices with disassembly interfaces
-	disasm_interface_iterator iter(machine().root_device());
 	std::string name;
-	for (device_disasm_interface *dasm = iter.first(); dasm != nullptr; dasm = iter.next())
+	for (device_disasm_interface &dasm : disasm_interface_iterator(machine().root_device()))
 	{
-		name = string_format("%s '%s'", dasm->device().name(), dasm->device().tag());
-		if (dasm->device().memory().space_config(AS_PROGRAM)!=nullptr)
-			m_source_list.append(*global_alloc(debug_view_disasm_source(name.c_str(), dasm->device())));
+		name = string_format("%s '%s'", dasm.device().name(), dasm.device().tag());
+		if (dasm.device().memory().space_config(AS_PROGRAM)!=nullptr)
+			m_source_list.append(*global_alloc(debug_view_disasm_source(name.c_str(), dasm.device())));
 	}
 
 	// reset the source to a known good entry

--- a/src/emu/debug/dvmemory.cpp
+++ b/src/emu/debug/dvmemory.cpp
@@ -135,14 +135,13 @@ void debug_view_memory::enumerate_sources()
 	std::string name;
 
 	// first add all the devices' address spaces
-	memory_interface_iterator iter(machine().root_device());
-	for (device_memory_interface *memintf = iter.first(); memintf != nullptr; memintf = iter.next())
-		if (&memintf->device() != &machine().root_device())
+	for (device_memory_interface &memintf : memory_interface_iterator(machine().root_device()))
+		if (&memintf.device() != &machine().root_device())
 			for (address_spacenum spacenum = AS_0; spacenum < ADDRESS_SPACES; ++spacenum)
-				if (memintf->has_space(spacenum))
+				if (memintf.has_space(spacenum))
 				{
-					address_space &space = memintf->space(spacenum);
-					name = string_format("%s '%s' %s space memory", memintf->device().name(), memintf->device().tag(), space.name());
+					address_space &space = memintf.space(spacenum);
+					name = string_format("%s '%s' %s space memory", memintf.device().name(), memintf.device().tag(), space.name());
 					m_source_list.append(*global_alloc(debug_view_memory_source(name.c_str(), space)));
 				}
 

--- a/src/emu/debug/dvstate.cpp
+++ b/src/emu/debug/dvstate.cpp
@@ -74,12 +74,11 @@ void debug_view_state::enumerate_sources()
 	m_source_list.reset();
 
 	// iterate over devices that have state interfaces
-	state_interface_iterator iter(machine().root_device());
 	std::string name;
-	for (device_state_interface *state = iter.first(); state != nullptr; state = iter.next())
+	for (device_state_interface &state : state_interface_iterator(machine().root_device()))
 	{
-		name = string_format("%s '%s'", state->device().name(), state->device().tag());
-		m_source_list.append(*global_alloc(debug_view_state_source(name.c_str(), state->device())));
+		name = string_format("%s '%s'", state.device().name(), state.device().tag());
+		m_source_list.append(*global_alloc(debug_view_state_source(name.c_str(), state.device())));
 	}
 
 	// reset the source to a known good entry

--- a/src/emu/debug/dvwpoints.cpp
+++ b/src/emu/debug/dvwpoints.cpp
@@ -153,12 +153,11 @@ void debug_view_watchpoints::enumerate_sources()
 	m_source_list.reset();
 
 	// iterate over devices with disassembly interfaces
-	disasm_interface_iterator iter(machine().root_device());
-	for (device_disasm_interface *dasm = iter.first(); dasm != nullptr; dasm = iter.next())
+	for (device_disasm_interface &dasm : disasm_interface_iterator(machine().root_device()))
 	{
 		std::string name;
-		name = string_format("%s '%s'", dasm->device().name(), dasm->device().tag());
-		m_source_list.append(*global_alloc(debug_view_source(name.c_str(), &dasm->device())));
+		name = string_format("%s '%s'", dasm.device().name(), dasm.device().tag());
+		m_source_list.append(*global_alloc(debug_view_source(name.c_str(), &dasm.device())));
 	}
 
 	// reset the source to a known good entry

--- a/src/emu/devfind.cpp
+++ b/src/emu/devfind.cpp
@@ -86,16 +86,19 @@ bool finder_base::validate_memregion(size_t bytes, bool required) const
 	std::string region_fulltag = m_base.subtag(m_tag);
 
 	// look for the region
-	device_iterator deviter(m_base.mconfig().root_device());
-	for (device_t *dev = deviter.first(); dev != nullptr && bytes_found == 0; dev = deviter.next())
-		for (const rom_entry *romp = rom_first_region(*dev); romp != nullptr; romp = rom_next_region(romp))
+	for (device_t &dev : device_iterator(m_base.mconfig().root_device()))
+	{
+		for (const rom_entry *romp = rom_first_region(dev); romp != nullptr; romp = rom_next_region(romp))
 		{
-			if (rom_region_name(*dev, romp) == region_fulltag)
+			if (rom_region_name(dev, romp) == region_fulltag)
 			{
 				bytes_found = ROMREGION_GETLENGTH(romp);
 				break;
 			}
 		}
+		if (bytes_found != 0)
+			break;
+	}
 
 	if (bytes_found != 0)
 	{

--- a/src/emu/diexec.cpp
+++ b/src/emu/diexec.cpp
@@ -476,8 +476,7 @@ void device_execute_interface::interface_pre_start()
 	m_driver_irq.bind_relative_to(*device().owner());
 
 	// fill in the initial states
-	device_iterator iter(device().machine().root_device());
-	int index = iter.indexof(*this);
+	int index = device_iterator(device().machine().root_device()).indexof(*this);
 	m_suspend = SUSPEND_REASON_RESET;
 	m_profiler = profile_type(index + PROFILER_DEVICE_FIRST);
 	m_inttrigger = index + TRIGGER_INT;

--- a/src/emu/divideo.cpp
+++ b/src/emu/divideo.cpp
@@ -81,7 +81,7 @@ void device_video_interface::interface_validity_check(validity_checker &valid) c
 		{
 			screen_device_iterator iter(device().mconfig().root_device());
 			screen = iter.first();
-			if (iter.next() != nullptr)
+			if (iter.count() > 1)
 				osd_printf_error("No screen specified for device '%s', but multiple screens found\n", device().tag());
 		}
 	}
@@ -115,7 +115,7 @@ void device_video_interface::interface_pre_start()
 		{
 			screen_device_iterator iter(device().machine().root_device());
 			m_screen = iter.first();
-			if (iter.next() != nullptr)
+			if (iter.count() > 1)
 				throw emu_fatalerror("No screen specified for device '%s', but multiple screens found", device().tag());
 		}
 	}

--- a/src/emu/drivenum.cpp
+++ b/src/emu/drivenum.cpp
@@ -404,7 +404,6 @@ void driver_enumerator::release_current() const
 		return;
 
 	// iterate over software lists in this entry and reset
-	software_list_device_iterator deviter(m_config[m_current]->root_device());
-	for (software_list_device *swlistdev = deviter.first(); swlistdev != nullptr; swlistdev = deviter.next())
-		swlistdev->release();
+	for (software_list_device &swlistdev : software_list_device_iterator(m_config[m_current]->root_device()))
+		swlistdev.release();
 }

--- a/src/emu/driver.cpp
+++ b/src/emu/driver.cpp
@@ -201,9 +201,8 @@ ioport_constructor driver_device::device_input_ports() const
 void driver_device::device_start()
 {
 	// reschedule ourselves to be last
-	device_iterator iter(*this);
-	for (device_t *test = iter.first(); test != nullptr; test = iter.next())
-		if (test != this && !test->started())
+	for (device_t &test : device_iterator(*this))
+		if (&test != this && !test.started())
 			throw device_missing_dependencies();
 
 	// call the game-specific init

--- a/src/emu/emumem.cpp
+++ b/src/emu/emumem.cpp
@@ -1549,13 +1549,13 @@ void memory_manager::initialize()
 {
 	// loop over devices and spaces within each device
 	memory_interface_iterator iter(machine().root_device());
-	for (device_memory_interface *memory = iter.first(); memory != nullptr; memory = iter.next())
+	for (device_memory_interface &memory : iter)
 		for (address_spacenum spacenum = AS_0; spacenum < ADDRESS_SPACES; ++spacenum)
 		{
 			// if there is a configuration for this space, we need an address space
-			const address_space_config *spaceconfig = memory->space_config(spacenum);
+			const address_space_config *spaceconfig = memory.space_config(spacenum);
 			if (spaceconfig != nullptr)
-				m_spacelist.append(address_space::allocate(*this, *spaceconfig, *memory, spacenum));
+				m_spacelist.append(address_space::allocate(*this, *spaceconfig, memory, spacenum));
 		}
 
 	// construct and preprocess the address_map for each space

--- a/src/emu/emuopts.cpp
+++ b/src/emu/emuopts.cpp
@@ -249,15 +249,14 @@ bool emu_options::add_slot_options(const software_part *swpart)
 
 	// iterate through all slot devices
 	int starting_count = options_count();
-	slot_interface_iterator iter(config.root_device());
-	for (const device_slot_interface *slot = iter.first(); slot != nullptr; slot = iter.next())
+	for (const device_slot_interface &slot : slot_interface_iterator(config.root_device()))
 	{
 		// skip fixed slots
-		if (slot->fixed())
+		if (slot.fixed())
 			continue;
 
 		// retrieve info about the device instance
-		const char *name = slot->device().tag() + 1;
+		const char *name = slot.device().tag() + 1;
 		if (!exists(name))
 		{
 			// first device? add the header as to be pretty
@@ -265,7 +264,7 @@ bool emu_options::add_slot_options(const software_part *swpart)
 				add_entry(nullptr, "SLOT DEVICES", OPTION_HEADER | OPTION_FLAG_DEVICE);
 
 			// add the option
-			add_entry(name, nullptr, OPTION_STRING | OPTION_FLAG_DEVICE, slot->default_option(), true);
+			add_entry(name, nullptr, OPTION_STRING | OPTION_FLAG_DEVICE, slot.default_option(), true);
 		}
 
 		// allow software lists to supply their own defaults
@@ -273,7 +272,7 @@ bool emu_options::add_slot_options(const software_part *swpart)
 		{
 			std::string featurename = std::string(name).append("_default");
 			const char *value = swpart->feature(featurename.c_str());
-			if (value != nullptr && (*value == '\0' || slot->option(value) != nullptr))
+			if (value != nullptr && (*value == '\0' || slot.option(value) != nullptr))
 			{
 				// set priority above INIs but below actual command line
 				std::string error;
@@ -299,14 +298,13 @@ void emu_options::update_slot_options(const software_part *swpart)
 	machine_config config(*cursystem, *this);
 
 	// iterate through all slot devices
-	slot_interface_iterator iter(config.root_device());
-	for (device_slot_interface *slot = iter.first(); slot != nullptr; slot = iter.next())
+	for (device_slot_interface &slot : slot_interface_iterator(config.root_device()))
 	{
 		// retrieve info about the device instance
-		const char *name = slot->device().tag() + 1;
-		if (exists(name) && !slot->option_list().empty())
+		const char *name = slot.device().tag() + 1;
+		if (exists(name) && !slot.option_list().empty())
 		{
-			std::string defvalue = slot->get_default_card_software();
+			std::string defvalue = slot.get_default_card_software();
 			if (defvalue.empty())
 			{
 				// keep any non-default setting
@@ -314,13 +312,13 @@ void emu_options::update_slot_options(const software_part *swpart)
 					continue;
 
 				// reinstate the actual default value as configured
-				if (slot->default_option() != nullptr)
-					defvalue.assign(slot->default_option());
+				if (slot.default_option() != nullptr)
+					defvalue.assign(slot.default_option());
 			}
 
 			// set the value and hide the option if not selectable
 			set_default_value(name, defvalue.c_str());
-			const device_slot_option *option = slot->option(defvalue.c_str());
+			const device_slot_option *option = slot.option(defvalue.c_str());
 			set_flag(name, ~OPTION_FLAG_INTERNAL, (option != nullptr && !option->selectable()) ? OPTION_FLAG_INTERNAL : 0);
 		}
 	}
@@ -343,20 +341,19 @@ void emu_options::add_device_options()
 	machine_config config(*cursystem, *this);
 
 	// iterate through all image devices
-	image_interface_iterator iter(config.root_device());
-	for (const device_image_interface *image = iter.first(); image != nullptr; image = iter.next())
+	for (const device_image_interface &image : image_interface_iterator(config.root_device()))
 	{
-        if (!image->user_loadable())
-            continue;
+		if (!image.user_loadable())
+			continue;
 
         // retrieve info about the device instance
 		std::ostringstream option_name;
-		util::stream_format(option_name, "%s;%s", image->instance_name(), image->brief_instance_name());
-		if (strcmp(image->device_typename(image->image_type()), image->instance_name()) == 0)
-			util::stream_format(option_name, ";%s1;%s1", image->instance_name(), image->brief_instance_name());
+		util::stream_format(option_name, "%s;%s", image.instance_name(), image.brief_instance_name());
+		if (strcmp(image.device_typename(image.image_type()), image.instance_name()) == 0)
+			util::stream_format(option_name, ";%s1;%s1", image.instance_name(), image.brief_instance_name());
 
 		// add the option
-		if (!exists(image->instance_name()))
+		if (!exists(image.instance_name()))
 		{
 			// first device? add the header as to be pretty
 			if (m_device_options++ == 0)
@@ -486,23 +483,22 @@ void emu_options::parse_standard_inis(std::string &error_string, const game_driv
 		parse_one_ini("othersys", OPTION_PRIORITY_SYSTYPE_INI, &error_string);
 
 	machine_config config(*cursystem, *this);
-	screen_device_iterator iter(config.root_device());
-	for (const screen_device *device = iter.first(); device != nullptr; device = iter.next())
+	for (const screen_device &device : screen_device_iterator(config.root_device()))
 	{
 		// parse "raster.ini" for raster games
-		if (device->screen_type() == SCREEN_TYPE_RASTER)
+		if (device.screen_type() == SCREEN_TYPE_RASTER)
 		{
 			parse_one_ini("raster", OPTION_PRIORITY_SCREEN_INI, &error_string);
 			break;
 		}
 		// parse "vector.ini" for vector games
-		if (device->screen_type() == SCREEN_TYPE_VECTOR)
+		if (device.screen_type() == SCREEN_TYPE_VECTOR)
 		{
 			parse_one_ini("vector", OPTION_PRIORITY_SCREEN_INI, &error_string);
 			break;
 		}
 		// parse "lcd.ini" for lcd games
-		if (device->screen_type() == SCREEN_TYPE_LCD)
+		if (device.screen_type() == SCREEN_TYPE_LCD)
 		{
 			parse_one_ini("lcd", OPTION_PRIORITY_SCREEN_INI, &error_string);
 			break;

--- a/src/emu/image.cpp
+++ b/src/emu/image.cpp
@@ -27,38 +27,34 @@
 image_manager::image_manager(running_machine &machine)
 	: m_machine(machine)
 {
-	const char *image_name;
-
 	/* make sure that any required devices have been allocated */
-	image_interface_iterator iter(machine.root_device());
-	for (device_image_interface *image = iter.first(); image != nullptr; image = iter.next())
+	for (device_image_interface &image : image_interface_iterator(machine.root_device()))
 	{
 		/* is an image specified for this image */
-		image_name = machine.options().value(image->instance_name());
-
-        if (!image->user_loadable())
-            continue;
+		const char *image_name = machine.options().value(image.instance_name());
+		if (!image.user_loadable())
+			continue;
 
 		if ((image_name != nullptr) && (image_name[0] != '\0'))
 		{
 			/* mark init state */
-			image->set_init_phase();
+			image.set_init_phase();
 
 			/* try to load this image */
-			bool result = image->load(image_name);
+			bool result = image.load(image_name);
 
 			/* did the image load fail? */
 			if (result)
 			{
 				/* retrieve image error message */
-				std::string image_err = std::string(image->error());
+				std::string image_err = std::string(image.error());
 				std::string image_basename(image_name);
 
 				/* unload all images */
 				unload_all();
 
 				fatalerror_exitcode(machine, MAMERR_DEVICE, "Device %s load (%s) failed: %s",
-					image->device().name(),
+					image.device().name(),
 					image_basename.c_str(),
 					image_err.c_str());
 			}
@@ -77,11 +73,10 @@ void image_manager::unload_all()
 	// extract the options
 	options_extract();
 
-	image_interface_iterator iter(machine().root_device());
-	for (device_image_interface *image = iter.first(); image != nullptr; image = iter.next())
+	for (device_image_interface &image : image_interface_iterator(machine().root_device()))
 	{
 		// unload this image
-		image->unload();
+		image.unload();
 	}
 }
 
@@ -99,13 +94,12 @@ void image_manager::config_load(config_type cfg_type, xml_data_node *parentnode)
 
 			if ((dev_instance != nullptr) && (dev_instance[0] != '\0'))
 			{
-				image_interface_iterator iter(machine().root_device());
-				for (device_image_interface *image = iter.first(); image != nullptr; image = iter.next())
+				for (device_image_interface &image : image_interface_iterator(machine().root_device()))
 				{
-					if (!strcmp(dev_instance, image->instance_name())) {
+					if (!strcmp(dev_instance, image.instance_name())) {
 						working_directory = xml_get_attribute_string(node, "directory", nullptr);
 						if (working_directory != nullptr)
-							image->set_working_directory(working_directory);
+							image.set_working_directory(working_directory);
 					}
 				}
 			}
@@ -126,16 +120,15 @@ void image_manager::config_save(config_type cfg_type, xml_data_node *parentnode)
 	/* only care about game-specific data */
 	if (cfg_type == config_type::CONFIG_TYPE_GAME)
 	{
-		image_interface_iterator iter(machine().root_device());
-		for (device_image_interface *image = iter.first(); image != nullptr; image = iter.next())
+		for (device_image_interface &image : image_interface_iterator(machine().root_device()))
 		{
-			dev_instance = image->instance_name();
+			dev_instance = image.instance_name();
 
 			node = xml_add_child(parentnode, "device", nullptr);
 			if (node != nullptr)
 			{
 				xml_set_attribute(node, "instance", dev_instance);
-				xml_set_attribute(node, "directory", image->working_directory());
+				xml_set_attribute(node, "directory", image.working_directory());
 			}
 		}
 	}
@@ -180,14 +173,13 @@ void image_manager::options_extract()
 	{
 		int index = 0;
 
-		image_interface_iterator iter(machine().root_device());
-		for (device_image_interface *image = iter.first(); image != nullptr; image = iter.next())
+		for (device_image_interface &image : image_interface_iterator(machine().root_device()))
 		{
-			const char *filename = image->filename();
+			const char *filename = image.filename();
 
 			/* and set the option */
 			std::string error;
-			machine().options().set_value(image->instance_name(), filename ? filename : "", OPTION_PRIORITY_CMDLINE, error);
+			machine().options().set_value(image.instance_name(), filename ? filename : "", OPTION_PRIORITY_CMDLINE, error);
 
 			index++;
 		}
@@ -208,11 +200,10 @@ std::string &image_manager::mandatory_scan(std::string &mandatory)
 {
 	mandatory.clear();
 	// make sure that any required image has a mounted file
-	image_interface_iterator iter(machine().root_device());
-	for (device_image_interface *image = iter.first(); image != nullptr; image = iter.next())
+	for (device_image_interface &image : image_interface_iterator(machine().root_device()))
 	{
-		if (image->filename() == nullptr && image->must_be_loaded())
-			mandatory.append("\"").append(image->instance_name()).append("\", ");
+		if (image.filename() == nullptr && image.must_be_loaded())
+			mandatory.append("\"").append(image.instance_name()).append("\", ");
 	}
 	return mandatory;
 }
@@ -225,24 +216,23 @@ std::string &image_manager::mandatory_scan(std::string &mandatory)
 void image_manager::postdevice_init()
 {
 	/* make sure that any required devices have been allocated */
-	image_interface_iterator iter(machine().root_device());
-	for (device_image_interface *image = iter.first(); image != nullptr; image = iter.next())
+	for (device_image_interface &image : image_interface_iterator(machine().root_device()))
 	{
-			int result = image->finish_load();
+		int result = image.finish_load();
 
-			/* did the image load fail? */
-			if (result)
-			{
-				/* retrieve image error message */
-				std::string image_err = std::string(image->error());
+		/* did the image load fail? */
+		if (result)
+		{
+			/* retrieve image error message */
+			std::string image_err = std::string(image.error());
 
-				/* unload all images */
-				unload_all();
+			/* unload all images */
+			unload_all();
 
-				fatalerror_exitcode(machine(), MAMERR_DEVICE, "Device %s load failed: %s",
-					image->device().name(),
-					image_err.c_str());
-			}
+			fatalerror_exitcode(machine(), MAMERR_DEVICE, "Device %s load failed: %s",
+				image.device().name(),
+				image_err.c_str());
+		}
 	}
 	/* add a callback for when we shut down */
 	machine().add_notifier(MACHINE_NOTIFY_EXIT, machine_notify_delegate(FUNC(image_manager::unload_all), this));

--- a/src/emu/ioport.cpp
+++ b/src/emu/ioport.cpp
@@ -2457,22 +2457,22 @@ time_t ioport_manager::initialize()
 
 	// if we have a token list, proceed
 	device_iterator iter(machine().root_device());
-	for (device_t *device = iter.first(); device != nullptr; device = iter.next())
+	for (device_t &device : iter)
 	{
 		std::string errors;
-		m_portlist.append(*device, errors);
+		m_portlist.append(device, errors);
 		if (!errors.empty())
 			osd_printf_error("Input port errors:\n%s", errors.c_str());
 	}
 
 	// renumber player numbers for controller ports
 	int player_offset = 0;
-	for (device_t *device = iter.first(); device != nullptr; device = iter.next())
+	for (device_t &device : iter)
 	{
 		int players = 0;
 		for (ioport_port &port : m_portlist)
 		{
-			if (&port.device() == device)
+			if (&port.device() == &device)
 			{
 				for (ioport_field &field : port.fields())
 					if (field.type_class()==INPUT_CLASS_CONTROLLER)
@@ -2532,10 +2532,9 @@ time_t ioport_manager::initialize()
 				if (field.is_analog())
 					m_has_analog = true;
 			}
-		device_iterator deviter(machine().root_device());
-		for (device_t *device = deviter.first(); device != nullptr; device = deviter.next())
-			if (device->rom_region())
-				for (const rom_entry *rom = device->rom_region(); !ROMENTRY_ISEND(rom); rom++)
+		for (device_t &device : device_iterator(machine().root_device()))
+			if (device.rom_region())
+				for (const rom_entry *rom = device.rom_region(); !ROMENTRY_ISEND(rom); rom++)
 					if (ROMENTRY_ISSYSTEM_BIOS(rom)) { m_has_bioses= true; break; }
 	}
 

--- a/src/emu/luaengine.cpp
+++ b/src/emu/luaengine.cpp
@@ -547,10 +547,10 @@ luabridge::LuaRef lua_engine::l_machine_get_images(const running_machine *r)
 	lua_State *L = luaThis->m_lua_state;
 	luabridge::LuaRef image_table = luabridge::LuaRef::newTable(L);
 
-	image_interface_iterator iter(r->root_device());
-	for (device_image_interface *image = iter.first(); image != nullptr; image = iter.next()) {
-		image_table[image->brief_instance_name()] = image;
-		image_table[image->instance_name()] = image;
+	for (device_image_interface &image : image_interface_iterator(r->root_device()))
+	{
+		image_table[image.brief_instance_name()] = &image;
+		image_table[image.instance_name()] = &image;
 	}
 
 	return image_table;

--- a/src/emu/mconfig.cpp
+++ b/src/emu/mconfig.cpp
@@ -34,20 +34,20 @@ machine_config::machine_config(const game_driver &gamedrv, emu_options &options)
 
 	bool is_selected_driver = core_stricmp(gamedrv.name,options.system_name())==0;
 	// intialize slot devices - make sure that any required devices have been allocated
-	slot_interface_iterator slotiter(root_device());
-	for (device_slot_interface *slot = slotiter.first(); slot != nullptr; slot = slotiter.next())
+	
+	for (device_slot_interface &slot : slot_interface_iterator(root_device()))
 	{
-		device_t &owner = slot->device();
+		device_t &owner = slot.device();
 		std::string selval;
 		bool isdefault = (options.priority(owner.tag()+1)==OPTION_PRIORITY_DEFAULT);
 		if (is_selected_driver && options.exists(owner.tag()+1))
 			selval = options.main_value(owner.tag()+1);
-		else if (slot->default_option() != nullptr)
-			selval.assign(slot->default_option());
+		else if (slot.default_option() != nullptr)
+			selval.assign(slot.default_option());
 
 		if (!selval.empty())
 		{
-			const device_slot_option *option = slot->option(selval.c_str());
+			const device_slot_option *option = slot.option(selval.c_str());
 
 			if (option && (isdefault || option->selectable()))
 			{
@@ -74,10 +74,9 @@ machine_config::machine_config(const game_driver &gamedrv, emu_options &options)
 	driver_device::static_set_game(*m_root_device, gamedrv);
 
 	// then notify all devices that their configuration is complete
-	device_iterator iter(root_device());
-	for (device_t *device = iter.first(); device != nullptr; device = iter.next())
-		if (!device->configured())
-			device->config_complete();
+	for (device_t &device : device_iterator(root_device()))
+		if (!device.configured())
+			device.config_complete();
 }
 
 
@@ -97,8 +96,7 @@ machine_config::~machine_config()
 
 screen_device *machine_config::first_screen() const
 {
-	screen_device_iterator iter(root_device());
-	return iter.first();
+	return screen_device_iterator(root_device()).first();
 }
 
 
@@ -235,9 +233,8 @@ device_t *machine_config::device_find(device_t *owner, const char *tag)
 void machine_config::remove_references(ATTR_UNUSED device_t &device)
 {
 	// iterate over all devices and remove any references
-	device_iterator iter(root_device());
-	for (device_t *scan = iter.first(); scan != nullptr; scan = iter.next())
-		scan->subdevices().m_tagmap.clear(); //remove(&device);
+	for (device_t &scan : device_iterator(root_device()))
+		scan.subdevices().m_tagmap.clear(); //remove(&device);
 }
 
 

--- a/src/emu/network.cpp
+++ b/src/emu/network.cpp
@@ -43,19 +43,18 @@ void network_manager::config_load(config_type cfg_type, xml_data_node *parentnod
 
 			if ((tag != nullptr) && (tag[0] != '\0'))
 			{
-				network_interface_iterator iter(machine().root_device());
-				for (device_network_interface *network = iter.first(); network != nullptr; network = iter.next())
+				for (device_network_interface &network : network_interface_iterator(machine().root_device()))
 				{
-					if (!strcmp(tag, network->device().tag())) {
+					if (!strcmp(tag, network.device().tag())) {
 						int interface = xml_get_attribute_int(node, "interface", 0);
-						network->set_interface(interface);
+						network.set_interface(interface);
 						const char *mac_addr = xml_get_attribute_string(node, "mac", nullptr);
 						if (mac_addr != nullptr && strlen(mac_addr) == 17) {
 							char mac[7];
 							unsigned int mac_num[6];
 							sscanf(mac_addr, "%02x:%02x:%02x:%02x:%02x:%02x", &mac_num[0], &mac_num[1], &mac_num[2], &mac_num[3], &mac_num[4], &mac_num[5]);
 							for (int i = 0; i<6; i++) mac[i] = mac_num[i];
-							network->set_mac(mac);
+							network.set_mac(mac);
 						}
 
 					}
@@ -76,15 +75,14 @@ void network_manager::config_save(config_type cfg_type, xml_data_node *parentnod
 	/* only care about game-specific data */
 	if (cfg_type == config_type::CONFIG_TYPE_GAME)
 	{
-		network_interface_iterator iter(machine().root_device());
-		for (device_network_interface *network = iter.first(); network != nullptr; network = iter.next())
+		for (device_network_interface &network : network_interface_iterator(machine().root_device()))
 		{
 			node = xml_add_child(parentnode, "device", nullptr);
 			if (node != nullptr)
 			{
-				xml_set_attribute(node, "tag", network->device().tag());
-				xml_set_attribute_int(node, "interface", network->get_interface());
-				const char *mac = network->get_mac();
+				xml_set_attribute(node, "tag", network.device().tag());
+				xml_set_attribute_int(node, "interface", network.get_interface());
+				const char *mac = network.get_mac();
 				char mac_addr[6 * 3];
 				sprintf(mac_addr, "%02x:%02x:%02x:%02x:%02x:%02x", (UINT8)mac[0], (UINT8)mac[1], (UINT8)mac[2], (UINT8)mac[3], (UINT8)mac[4], (UINT8)mac[5]);
 				xml_set_attribute(node, "mac", mac_addr);

--- a/src/emu/render.cpp
+++ b/src/emu/render.cpp
@@ -1103,11 +1103,14 @@ int render_target::configured_view(const char *viewname, int targetindex, int nu
 					break;
 				if (viewscreens.count() >= scrcount)
 				{
-					screen_device *screen;
-					for (screen = iter.first(); screen != nullptr; screen = iter.next())
-						if (!viewscreens.contains(*screen))
+					bool has_screen = false;
+					for (screen_device &screen : iter)
+						if (!viewscreens.contains(screen))
+						{
+							has_screen = true;
 							break;
-					if (screen == nullptr)
+						}
+					if (!has_screen)
 						break;
 				}
 			}
@@ -2567,9 +2570,8 @@ render_manager::render_manager(running_machine &machine)
 	machine.configuration().config_register("video", config_saveload_delegate(FUNC(render_manager::config_load), this), config_saveload_delegate(FUNC(render_manager::config_save), this));
 
 	// create one container per screen
-	screen_device_iterator iter(machine.root_device());
-	for (screen_device *screen = iter.first(); screen != nullptr; screen = iter.next())
-		screen->set_container(*container_alloc(screen));
+	for (screen_device &screen : screen_device_iterator(machine.root_device()))
+		screen.set_container(*container_alloc(&screen));
 }
 
 

--- a/src/emu/rendlay.cpp
+++ b/src/emu/rendlay.cpp
@@ -164,16 +164,15 @@ static int get_variable_value(running_machine &machine, const char *string, char
 	char temp[100];
 
 	// screen 0 parameters
-	screen_device_iterator iter(machine.root_device());
 	int scrnum = 0;
-	for (const screen_device *device = iter.first(); device != nullptr; device = iter.next(), scrnum++)
+	for (const screen_device &device : screen_device_iterator(machine.root_device()))
 	{
 		// native X aspect factor
 		sprintf(temp, "~scr%dnativexaspect~", scrnum);
 		if (!strncmp(string, temp, strlen(temp)))
 		{
-			int num = device->visible_area().width();
-			int den = device->visible_area().height();
+			int num = device.visible_area().width();
+			int den = device.visible_area().height();
 			reduce_fraction(num, den);
 			*outputptr += sprintf(*outputptr, "%d", num);
 			return strlen(temp);
@@ -183,8 +182,8 @@ static int get_variable_value(running_machine &machine, const char *string, char
 		sprintf(temp, "~scr%dnativeyaspect~", scrnum);
 		if (!strncmp(string, temp, strlen(temp)))
 		{
-			int num = device->visible_area().width();
-			int den = device->visible_area().height();
+			int num = device.visible_area().width();
+			int den = device.visible_area().height();
 			reduce_fraction(num, den);
 			*outputptr += sprintf(*outputptr, "%d", den);
 			return strlen(temp);
@@ -194,7 +193,7 @@ static int get_variable_value(running_machine &machine, const char *string, char
 		sprintf(temp, "~scr%dwidth~", scrnum);
 		if (!strncmp(string, temp, strlen(temp)))
 		{
-			*outputptr += sprintf(*outputptr, "%d", device->visible_area().width());
+			*outputptr += sprintf(*outputptr, "%d", device.visible_area().width());
 			return strlen(temp);
 		}
 
@@ -202,9 +201,12 @@ static int get_variable_value(running_machine &machine, const char *string, char
 		sprintf(temp, "~scr%dheight~", scrnum);
 		if (!strncmp(string, temp, strlen(temp)))
 		{
-			*outputptr += sprintf(*outputptr, "%d", device->visible_area().height());
+			*outputptr += sprintf(*outputptr, "%d", device.visible_area().height());
 			return strlen(temp);
 		}
+
+		// keep count
+		scrnum++;
 	}
 
 	// default: copy the first character and continue
@@ -2401,10 +2403,7 @@ layout_view::item::item(running_machine &machine, xml_data_node &itemnode, simpl
 	// fetch common data
 	int index = xml_get_attribute_int_with_subst(machine, itemnode, "index", -1);
 	if (index != -1)
-	{
-		screen_device_iterator iter(machine.root_device());
-		m_screen = iter.byindex(index);
-	}
+		m_screen = screen_device_iterator(machine.root_device()).byindex(index);
 	m_input_mask = xml_get_attribute_int_with_subst(machine, itemnode, "inputmask", 0);
 	if (m_output_name[0] != 0 && m_element != nullptr)
 		machine.output().set_value(m_output_name.c_str(), m_element->default_state());

--- a/src/emu/romload.h
+++ b/src/emu/romload.h
@@ -305,7 +305,7 @@ public:
 	void load_software_part_region(device_t &device, software_list_device &swlist, const char *swname, const rom_entry *start_region);
 
 private:
-	void determine_bios_rom(device_t *device, const char *specbios);
+	void determine_bios_rom(device_t &device, const char *specbios);
 	void count_roms();
 	void fill_random(UINT8 *base, UINT32 length);
 	void handle_missing_file(const rom_entry *romp, std::string tried_file_names, chd_error chderr);

--- a/src/emu/schedule.cpp
+++ b/src/emu/schedule.cpp
@@ -781,20 +781,19 @@ void device_scheduler::rebuild_execute_list()
 	device_execute_interface **suspend_tailptr = &suspend_list;
 
 	// iterate over all devices
-	execute_interface_iterator iter(machine().root_device());
-	for (device_execute_interface *exec = iter.first(); exec != nullptr; exec = iter.next())
+	for (device_execute_interface &exec : execute_interface_iterator(machine().root_device()))
 	{
 		// append to the appropriate list
-		exec->m_nextexec = nullptr;
-		if (exec->m_suspend == 0)
+		exec.m_nextexec = nullptr;
+		if (exec.m_suspend == 0)
 		{
-			*active_tailptr = exec;
-			active_tailptr = &exec->m_nextexec;
+			*active_tailptr = &exec;
+			active_tailptr = &exec.m_nextexec;
 		}
 		else
 		{
-			*suspend_tailptr = exec;
-			suspend_tailptr = &exec->m_nextexec;
+			*suspend_tailptr = &exec;
+			suspend_tailptr = &exec.m_nextexec;
 		}
 	}
 

--- a/src/emu/softlist.cpp
+++ b/src/emu/softlist.cpp
@@ -391,10 +391,9 @@ void software_list_device::release()
 software_list_device *software_list_device::find_by_name(const machine_config &config, const char *name)
 {
 	// iterate over each device in the system and find a match
-	software_list_device_iterator deviter(config.root_device());
-	for (software_list_device *swlistdev = deviter.first(); swlistdev != nullptr; swlistdev = deviter.next())
-		if (strcmp(swlistdev->list_name(), name) == 0)
-			return swlistdev;
+	for (software_list_device &swlistdev : software_list_device_iterator(config.root_device()))
+		if (strcmp(swlistdev.list_name(), name) == 0)
+			return &swlistdev;
 	return nullptr;
 }
 
@@ -409,25 +408,25 @@ void software_list_device::display_matches(const machine_config &config, const c
 {
 	// check if there is at least one software list
 	software_list_device_iterator deviter(config.root_device());
-	if (deviter.first())
+	if (deviter.first() != nullptr)
 		osd_printf_error("\n\"%s\" approximately matches the following\n"
 							"supported software items (best match first):\n\n", name);
 
 	// iterate through lists
-	for (software_list_device *swlistdev = deviter.first(); swlistdev != nullptr; swlistdev = deviter.next())
+	for (software_list_device &swlistdev : deviter)
 	{
 		// get the top 16 approximate matches for the selected device interface (i.e. only carts for cartslot, etc.)
 		software_info *matches[16] = { nullptr };
-		swlistdev->find_approx_matches(name, ARRAY_LENGTH(matches), matches, interface);
+		swlistdev.find_approx_matches(name, ARRAY_LENGTH(matches), matches, interface);
 
 		// if we found some, print them
 		if (matches[0] != nullptr)
 		{
 			// different output depending on original system or compatible
-			if (swlistdev->list_type() == SOFTWARE_LIST_ORIGINAL_SYSTEM)
-				osd_printf_error("* Software list \"%s\" (%s) matches: \n", swlistdev->list_name(), swlistdev->description());
+			if (swlistdev.list_type() == SOFTWARE_LIST_ORIGINAL_SYSTEM)
+				osd_printf_error("* Software list \"%s\" (%s) matches: \n", swlistdev.list_name(), swlistdev.description());
 			else
-				osd_printf_error("* Compatible software list \"%s\" (%s) matches: \n", swlistdev->list_name(), swlistdev->description());
+				osd_printf_error("* Compatible software list \"%s\" (%s) matches: \n", swlistdev.list_name(), swlistdev.description());
 
 			// print them out
 			for (auto & matche : matches)

--- a/src/emu/sound.cpp
+++ b/src/emu/sound.cpp
@@ -899,19 +899,20 @@ void sound_manager::set_attenuation(int attenuation)
 bool sound_manager::indexed_mixer_input(int index, mixer_input &info) const
 {
 	// scan through the mixers until we find the indexed input
-	mixer_interface_iterator iter(machine().root_device());
-	for (info.mixer = iter.first(); info.mixer != nullptr; info.mixer = iter.next())
+	for (device_mixer_interface &mixer : mixer_interface_iterator(machine().root_device()))
 	{
-		if (index < info.mixer->inputs())
+		if (index < mixer.inputs())
 		{
-			info.stream = info.mixer->input_to_stream_input(index, info.inputnum);
+			info.mixer = &mixer;
+			info.stream = mixer.input_to_stream_input(index, info.inputnum);
 			assert(info.stream != nullptr);
 			return true;
 		}
-		index -= info.mixer->inputs();
+		index -= mixer.inputs();
 	}
 
 	// didn't locate
+	info.mixer = nullptr;
 	return false;
 }
 
@@ -937,9 +938,8 @@ void sound_manager::mute(bool mute, UINT8 reason)
 void sound_manager::reset()
 {
 	// reset all the sound chips
-	sound_interface_iterator iter(machine().root_device());
-	for (device_sound_interface *sound = iter.first(); sound != nullptr; sound = iter.next())
-		sound->device().reset();
+	for (device_sound_interface &sound : sound_interface_iterator(machine().root_device()))
+		sound.device().reset();
 }
 
 
@@ -1039,9 +1039,8 @@ void sound_manager::update(void *ptr, int param)
 
 	// force all the speaker streams to generate the proper number of samples
 	int samples_this_update = 0;
-	speaker_device_iterator iter(machine().root_device());
-	for (speaker_device *speaker = iter.first(); speaker != nullptr; speaker = iter.next())
-		speaker->mix(&m_leftmix[0], &m_rightmix[0], samples_this_update, (m_muted & MUTE_REASON_SYSTEM));
+	for (speaker_device &speaker : speaker_device_iterator(machine().root_device()))
+		speaker.mix(&m_leftmix[0], &m_rightmix[0], samples_this_update, (m_muted & MUTE_REASON_SYSTEM));
 
 	// now downmix the final result
 	UINT32 finalmix_step = machine().video().speed_factor();

--- a/src/emu/ui/cheatopt.cpp
+++ b/src/emu/ui/cheatopt.cpp
@@ -158,8 +158,7 @@ ui_menu_cheat::~ui_menu_cheat()
 
 ui_menu_autofire::ui_menu_autofire(running_machine &machine, render_container *container) : ui_menu(machine, container)
 {
-	screen_device_iterator iter(machine.root_device());
-	const screen_device *screen = iter.first();
+	const screen_device *screen = machine.first_screen();
 
 	if (screen == nullptr)
 	{

--- a/src/emu/ui/datmenu.cpp
+++ b/src/emu/ui/datmenu.cpp
@@ -29,15 +29,14 @@ ui_menu_dats_view::ui_menu_dats_view(running_machine &machine, render_container 
 	, m_issoft(false)
 
 {
-	image_interface_iterator iter(machine.root_device());
-	for (device_image_interface *image = iter.first(); image != nullptr; image = iter.next())
+	for (device_image_interface &image : image_interface_iterator(machine.root_device()))
 	{
-		if (image->filename())
+		if (image.filename())
 		{
-			m_list = strensure(image->software_list_name());
-			m_short = strensure(image->software_entry()->shortname());
-			m_long = strensure(image->software_entry()->longname());
-			m_parent = strensure(image->software_entry()->parentname());
+			m_list = strensure(image.software_list_name());
+			m_short = strensure(image.software_entry()->shortname());
+			m_long = strensure(image.software_entry()->longname());
+			m_parent = strensure(image.software_entry()->parentname());
 		}
 	}
 

--- a/src/emu/ui/filemngr.cpp
+++ b/src/emu/ui/filemngr.cpp
@@ -113,28 +113,26 @@ void ui_menu_file_manager::populate()
 	}
 
 	// cycle through all devices for this system
-	device_iterator iter(machine().root_device());
 	std::unordered_set<std::string> devtags;
-	for (device_t *dev = iter.first(); dev != nullptr; dev = iter.next())
+	for (device_t &dev : device_iterator(machine().root_device()))
 	{
 		bool tag_appended = false;
-		if (!devtags.insert(dev->tag()).second)
+		if (!devtags.insert(dev.tag()).second)
 			continue;
 
 		// check whether it owns an image interface
-		image_interface_iterator subiter(*dev);
-		if (subiter.count() > 0)
+		image_interface_iterator subiter(dev);
+		if (subiter.first() != nullptr)
 		{
 			// if so, cycle through all its image interfaces
-			image_interface_iterator subiterator(*dev);
-			for (device_image_interface *scan = subiterator.first(); scan != nullptr; scan = subiterator.next())
+			for (device_image_interface &scan : subiter)
 			{
-                if (!scan->user_loadable())
-                    continue;
-                
+				if (!scan.user_loadable())
+					continue;
+
 				// if it is a children device, and not something further down the device tree, we want it in the menu!
-				if (strcmp(scan->device().owner()->tag(), dev->tag()) == 0)
-					if (devtags.insert(scan->device().tag()).second)
+				if (strcmp(scan.device().owner()->tag(), dev.tag()) == 0)
+					if (devtags.insert(scan.device().tag()).second)
 					{
 						// check whether we already had some devices with the same owner: if not, output the owner tag!
 						if (!tag_appended)
@@ -143,12 +141,12 @@ void ui_menu_file_manager::populate()
 								first_entry = false;
 							else
 								item_append(ui_menu_item_type::SEPARATOR);
-							item_append(string_format("[root%s]", dev->tag()).c_str(), nullptr, 0, nullptr);
+							item_append(string_format("[root%s]", dev.tag()).c_str(), nullptr, 0, nullptr);
 							tag_appended = true;
 						}
 						// finally, append the image interface to the menu
-						fill_image_line(scan, tmp_inst, tmp_name);
-						item_append(tmp_inst.c_str(), tmp_name.c_str(), 0, (void *)scan);
+						fill_image_line(&scan, tmp_inst, tmp_name);
+						item_append(tmp_inst.c_str(), tmp_name.c_str(), 0, (void *)&scan);
 					}
 			}
 		}

--- a/src/emu/ui/imgcntrl.cpp
+++ b/src/emu/ui/imgcntrl.cpp
@@ -36,14 +36,10 @@ ui_menu_control_device_image::ui_menu_control_device_image(running_machine &mach
 {
 	image = _image;
 
-	sld = nullptr;
-	if (image->software_list_name()) {
-		software_list_device_iterator iter(machine.config().root_device());
-		for (software_list_device *swlist = iter.first(); swlist != nullptr; swlist = iter.next())
-		{
-			if (strcmp(swlist->list_name(),image->software_list_name())==0) sld = swlist;
-		}
-	}
+	if (image->software_list_name())
+		sld = software_list_device::find_by_name(machine.config(), image->software_list_name());
+	else
+		sld = nullptr;
 	swi = image->software_entry();
 	swp = image->part_entry();
 

--- a/src/emu/ui/info.cpp
+++ b/src/emu/ui/info.cpp
@@ -58,9 +58,8 @@ void ui_menu_image_info::populate()
 	item_append(machine().system().description, nullptr, MENU_FLAG_DISABLE, nullptr);
 	item_append("", nullptr, MENU_FLAG_DISABLE, nullptr);
 
-	image_interface_iterator iter(machine().root_device());
-	for (device_image_interface *image = iter.first(); image != nullptr; image = iter.next())
-			image_info(image);
+	for (device_image_interface &image : image_interface_iterator(machine().root_device()))
+		image_info(&image);
 }
 
 void ui_menu_image_info::handle()

--- a/src/emu/ui/info_pty.cpp
+++ b/src/emu/ui/info_pty.cpp
@@ -26,14 +26,13 @@ void ui_menu_pty_info::populate()
 	item_append(_("Pseudo terminals"), nullptr, MENU_FLAG_DISABLE, nullptr);
 	item_append("", nullptr, MENU_FLAG_DISABLE, nullptr);
 
-	pty_interface_iterator iter(machine().root_device());
-	for (device_pty_interface *pty = iter.first(); pty != nullptr; pty = iter.next()) {
-		const char *port_name = pty->device().owner()->tag() + 1;
-		if (pty->is_open()) {
-			item_append(port_name , pty->slave_name() , MENU_FLAG_DISABLE , nullptr);
-		} else {
-			item_append(port_name , _("[failed]") , MENU_FLAG_DISABLE , nullptr);
-		}
+	for (device_pty_interface &pty : pty_interface_iterator(machine().root_device()))
+	{
+		const char *port_name = pty.device().owner()->tag() + 1;
+		if (pty.is_open())
+			item_append(port_name, pty.slave_name(), MENU_FLAG_DISABLE, nullptr);
+		else
+			item_append(port_name, _("[failed]"), MENU_FLAG_DISABLE, nullptr);
 		item_append("", nullptr, MENU_FLAG_DISABLE, nullptr);
 	}
 }

--- a/src/emu/ui/inifile.cpp
+++ b/src/emu/ui/inifile.cpp
@@ -207,30 +207,29 @@ void favorite_manager::add_favorite_game()
 	}
 
 	bool software_avail = false;
-	image_interface_iterator iter(machine().root_device());
-	for (device_image_interface *image = iter.first(); image != nullptr; image = iter.next())
+	for (device_image_interface &image : image_interface_iterator(machine().root_device()))
 	{
-		if (image->exists() && image->software_entry())
+		if (image.exists() && image.software_entry())
 		{
-			const software_info *swinfo = image->software_entry();
-			const software_part *part = image->part_entry();
+			const software_info *swinfo = image.software_entry();
+			const software_part *part = image.part_entry();
 			ui_software_info tmpmatches;
 			tmpmatches.shortname = strensure(swinfo->shortname());
-			tmpmatches.longname = strensure(image->longname());
+			tmpmatches.longname = strensure(image.longname());
 			tmpmatches.parentname = strensure(swinfo->parentname());
-			tmpmatches.year = strensure(image->year());
-			tmpmatches.publisher = strensure(image->manufacturer());
-			tmpmatches.supported = image->supported();
+			tmpmatches.year = strensure(image.year());
+			tmpmatches.publisher = strensure(image.manufacturer());
+			tmpmatches.supported = image.supported();
 			tmpmatches.part = strensure(part->name());
 			tmpmatches.driver = &machine().system();
-			tmpmatches.listname = strensure(image->software_list_name());
+			tmpmatches.listname = strensure(image.software_list_name());
 			tmpmatches.interface = strensure(part->interface());
-			tmpmatches.instance = strensure(image->instance_name());
+			tmpmatches.instance = strensure(image.instance_name());
 			tmpmatches.startempty = 0;
 			tmpmatches.parentlongname.clear();
 			if (swinfo->parentname())
 			{
-				software_list_device *swlist = software_list_device::find_by_name(machine().config(), image->software_list_name());
+				software_list_device *swlist = software_list_device::find_by_name(machine().config(), image.software_list_name());
 				for (software_info &c_swinfo : swlist->get_info())
 				{
 					std::string c_parent(c_swinfo.parentname());
@@ -247,7 +246,7 @@ void favorite_manager::add_favorite_game()
 				if (!strcmp(flist.name(), "usage"))
 					tmpmatches.usage = flist.value();
 
-			tmpmatches.devicetype = strensure(image->image_type_name());
+			tmpmatches.devicetype = strensure(image.image_type_name());
 			tmpmatches.available = true;
 			software_avail = true;
 			m_list.push_back(tmpmatches);
@@ -288,18 +287,17 @@ bool favorite_manager::isgame_favorite()
 	if ((machine().system().flags & MACHINE_TYPE_ARCADE) != 0)
 		return isgame_favorite(&machine().system());
 
-	image_interface_iterator iter(machine().root_device());
 	bool image_loaded = false;
 
-	for (device_image_interface *image = iter.first(); image != nullptr; image = iter.next())
+	for (device_image_interface &image : image_interface_iterator(machine().root_device()))
 	{
-		const software_info *swinfo = image->software_entry();
-		if (image->exists() && swinfo != nullptr)
+		const software_info *swinfo = image.software_entry();
+		if (image.exists() && swinfo != nullptr)
 		{
 			image_loaded = true;
 			for (size_t current = 0; current < m_list.size(); current++)
 				if (m_list[current].shortname == swinfo->shortname() &&
-					m_list[current].listname == image->software_list_name())
+					m_list[current].listname == image.software_list_name())
 				{
 					m_current = current;
 					return true;

--- a/src/emu/ui/mainmenu.cpp
+++ b/src/emu/ui/mainmenu.cpp
@@ -71,46 +71,40 @@ void ui_menu_main::populate()
 	/* add game info menu */
 	item_append(_("Machine Information"), nullptr, 0, (void *)GAME_INFO);
 
-	image_interface_iterator imgiter(machine().root_device());
-    for (device_image_interface *image = imgiter.first(); image != nullptr; image = imgiter.next())
-    {
-        if (image->user_loadable())
-        {
-            /* add image info menu */
-            item_append(_("Image Information"), nullptr, 0, (void *)IMAGE_MENU_IMAGE_INFO);
-            
-            /* add file manager menu */
-            item_append(_("File Manager"), nullptr, 0, (void *)IMAGE_MENU_FILE_MANAGER);
-            
-            break;
-        }
-    }
+	for (device_image_interface &image : image_interface_iterator(machine().root_device()))
+	{
+		if (image.user_loadable())
+		{
+			/* add image info menu */
+			item_append(_("Image Information"), nullptr, 0, (void *)IMAGE_MENU_IMAGE_INFO);
 
-    /* add tape control menu */
-    cassette_device_iterator cassiter(machine().root_device());
-    if (cassiter.first() != nullptr)
-        item_append(_("Tape Control"), nullptr, 0, (void *)TAPE_CONTROL);
+			/* add file manager menu */
+			item_append(_("File Manager"), nullptr, 0, (void *)IMAGE_MENU_FILE_MANAGER);
 
-    pty_interface_iterator ptyiter(machine().root_device());
-    if (ptyiter.first() != nullptr)
-        item_append(_("Pseudo terminals"), nullptr, 0, (void *)PTY_INFO);
+			break;
+		}
+	}
 
-    if (machine().ioport().has_bioses())
+	/* add tape control menu */
+	if (cassette_device_iterator(machine().root_device()).first() != nullptr)
+		item_append(_("Tape Control"), nullptr, 0, (void *)TAPE_CONTROL);
+
+	if (pty_interface_iterator(machine().root_device()).first() != nullptr)
+		item_append(_("Pseudo terminals"), nullptr, 0, (void *)PTY_INFO);
+
+	if (machine().ioport().has_bioses())
 		item_append(_("Bios Selection"), nullptr, 0, (void *)BIOS_SELECTION);
 
-    /* add slot info menu */
-	slot_interface_iterator slotiter(machine().root_device());
-	if (slotiter.first() != nullptr)
+	/* add slot info menu */
+	if (slot_interface_iterator(machine().root_device()).first() != nullptr)
 		item_append(_("Slot Devices"), nullptr, 0, (void *)SLOT_DEVICES);
 
-    /* add Barcode reader menu */
-	barcode_reader_device_iterator bcriter(machine().root_device());
-	if (bcriter.first() != nullptr)
+	/* add Barcode reader menu */
+	if (barcode_reader_device_iterator(machine().root_device()).first() != nullptr)
 		item_append(_("Barcode Reader"), nullptr, 0, (void *)BARCODE_READ);
 
-    /* add network info menu */
-	network_interface_iterator netiter(machine().root_device());
-	if (netiter.first() != nullptr)
+	/* add network info menu */
+	if (network_interface_iterator(machine().root_device()).first() != nullptr)
 		item_append(_("Network Devices"), nullptr, 0, (void*)NETWORK_DEVICES);
 
 	/* add keyboard mode menu */

--- a/src/emu/ui/miscmenu.cpp
+++ b/src/emu/ui/miscmenu.cpp
@@ -72,19 +72,19 @@ ui_menu_bios_selection::ui_menu_bios_selection(running_machine &machine, render_
 void ui_menu_bios_selection::populate()
 {
 	/* cycle through all devices for this system */
-	device_iterator deviter(machine().root_device());
-	for (device_t *device = deviter.first(); device != nullptr; device = deviter.next())
+	for (device_t &device : device_iterator(machine().root_device()))
 	{
-		if (device->rom_region()) {
+		if (device.rom_region())
+		{
 			const char *val = "default";
-			for (const rom_entry *rom = device->rom_region(); !ROMENTRY_ISEND(rom); rom++)
+			for (const rom_entry *rom = device.rom_region(); !ROMENTRY_ISEND(rom); rom++)
 			{
-				if (ROMENTRY_ISSYSTEM_BIOS(rom) && ROM_GETBIOSFLAGS(rom)==device->system_bios())
+				if (ROMENTRY_ISSYSTEM_BIOS(rom) && ROM_GETBIOSFLAGS(rom) == device.system_bios())
 				{
 					val = ROM_GETHASHDATA(rom);
 				}
 			}
-			item_append(strcmp(device->tag(),":")==0 ? "driver" : device->tag()+1, val, MENU_FLAG_LEFT_ARROW | MENU_FLAG_RIGHT_ARROW, (void *)device);
+			item_append(device.owner() == nullptr ? "driver" : device.tag()+1, val, MENU_FLAG_LEFT_ARROW | MENU_FLAG_RIGHT_ARROW, (void *)&device);
 		}
 	}
 
@@ -154,10 +154,9 @@ ui_menu_network_devices::~ui_menu_network_devices()
 void ui_menu_network_devices::populate()
 {
 	/* cycle through all devices for this system */
-	network_interface_iterator iter(machine().root_device());
-	for (device_network_interface *network = iter.first(); network != nullptr; network = iter.next())
+	for (device_network_interface &network : network_interface_iterator(machine().root_device()))
 	{
-		int curr = network->get_interface();
+		int curr = network.get_interface();
 		const char *title = nullptr;
 		const osd_netdev::entry_t *entry = netdev_first();
 		while(entry) {
@@ -168,7 +167,7 @@ void ui_menu_network_devices::populate()
 			entry = entry->m_next;
 		}
 
-		item_append(network->device().tag(),  (title) ? title : "------", MENU_FLAG_LEFT_ARROW | MENU_FLAG_RIGHT_ARROW, (void *)network);
+		item_append(network.device().tag(),  (title) ? title : "------", MENU_FLAG_LEFT_ARROW | MENU_FLAG_RIGHT_ARROW, (void *)network);
 	}
 }
 

--- a/src/emu/ui/selgame.cpp
+++ b/src/emu/ui/selgame.cpp
@@ -1048,9 +1048,8 @@ void ui_menu_select_game::inkey_select(const ui_menu_event *m_event)
 		{
 			if ((driver->flags & MACHINE_TYPE_ARCADE) == 0)
 			{
-				software_list_device_iterator iter(enumerator.config().root_device());
-				for (software_list_device *swlistdev = iter.first(); swlistdev != nullptr; swlistdev = iter.next())
-					if (!swlistdev->get_info().empty())
+				for (software_list_device &swlistdev : software_list_device_iterator(enumerator.config().root_device()))
+					if (!swlistdev.get_info().empty())
 					{
 						ui_menu::stack_push(global_alloc_clear<ui_menu_select_software>(machine(), container, driver));
 						return;

--- a/src/emu/ui/selsoft.cpp
+++ b/src/emu/ui/selsoft.cpp
@@ -430,9 +430,8 @@ void ui_menu_select_software::populate()
 	int old_software = -1;
 
 	machine_config config(*m_driver, machine().options());
-	image_interface_iterator iter(config.root_device());
-	for (device_image_interface *image = iter.first(); image != nullptr; image = iter.next())
-		if (image->filename() == nullptr && image->must_be_loaded())
+	for (device_image_interface &image : image_interface_iterator(config.root_device()))
+		if (image.filename() == nullptr && image.must_be_loaded())
 		{
 			m_has_empty_start = false;
 			break;
@@ -528,32 +527,30 @@ void ui_menu_select_software::build_software_list()
 	m_swinfo.emplace_back(m_driver->name, m_driver->description, "", "", "", 0, "", m_driver, "", "", "", 1, "", "", "", true);
 
 	machine_config config(*m_driver, machine().options());
-	software_list_device_iterator deviter(config.root_device());
 
 	// iterate thru all software lists
-	for (software_list_device *swlist = deviter.first(); swlist != nullptr; swlist = deviter.next())
+	for (software_list_device &swlist : software_list_device_iterator(config.root_device()))
 	{
-		m_filter.swlist.name.push_back(swlist->list_name());
-		m_filter.swlist.description.push_back(swlist->description());
-		for (software_info &swinfo : swlist->get_info())
+		m_filter.swlist.name.push_back(swlist.list_name());
+		m_filter.swlist.description.push_back(swlist.description());
+		for (software_info &swinfo : swlist.get_info())
 		{
 			software_part *part = swinfo.first_part();
-			if (part->is_compatible(*swlist))
+			if (part->is_compatible(swlist))
 			{
 				const char *instance_name = nullptr;
 				const char *type_name = nullptr;
 				ui_software_info tmpmatches;
-				image_interface_iterator imgiter(config.root_device());
-				for (device_image_interface *image = imgiter.first(); image != nullptr; image = imgiter.next())
+				for (device_image_interface &image : image_interface_iterator(config.root_device()))
 				{
-					const char *interface = image->image_interface();
+					const char *interface = image.image_interface();
 					if (interface != nullptr && part->matches_interface(interface))
 					{
-						instance_name = image->instance_name();
+						instance_name = image.instance_name();
 						if (instance_name != nullptr)
-							tmpmatches.instance = image->instance_name();
+							tmpmatches.instance = image.instance_name();
 
-						type_name = image->image_type_name();
+						type_name = image.image_type_name();
 						if (type_name != nullptr)
 							tmpmatches.devicetype = type_name;
 						break;
@@ -571,7 +568,7 @@ void ui_menu_select_software::build_software_list()
 				tmpmatches.supported = swinfo.supported();
 				tmpmatches.part = strensure(part->name());
 				tmpmatches.driver = m_driver;
-				tmpmatches.listname = strensure(swlist->list_name());
+				tmpmatches.listname = strensure(swlist.list_name());
 				tmpmatches.interface = strensure(part->interface());
 				tmpmatches.startempty = 0;
 				tmpmatches.parentlongname.clear();

--- a/src/emu/ui/slotopt.cpp
+++ b/src/emu/ui/slotopt.cpp
@@ -19,33 +19,33 @@
 /*-------------------------------------------------
     ui_slot_get_current_option - returns
 -------------------------------------------------*/
-device_slot_option *ui_menu_slot_devices::slot_get_current_option(device_slot_interface *slot)
+device_slot_option *ui_menu_slot_devices::slot_get_current_option(device_slot_interface &slot)
 {
 	std::string current;
-	if (slot->fixed())
+	if (slot.fixed())
 	{
-		if (slot->default_option() == nullptr) return nullptr;
-		current.assign(slot->default_option());
+		if (slot.default_option() == nullptr) return nullptr;
+		current.assign(slot.default_option());
 	}
 	else
 	{
-		current = machine().options().main_value(slot->device().tag() + 1);
+		current = machine().options().main_value(slot.device().tag() + 1);
 	}
 
-	return slot->option(current.c_str());
+	return slot.option(current.c_str());
 }
 
 /*-------------------------------------------------
     ui_slot_get_current_index - returns
 -------------------------------------------------*/
-int ui_menu_slot_devices::slot_get_current_index(device_slot_interface *slot)
+int ui_menu_slot_devices::slot_get_current_index(device_slot_interface &slot)
 {
 	const device_slot_option *current = slot_get_current_option(slot);
 
 	if (current != nullptr)
 	{
 		int val = 0;
-		for (const device_slot_option &option : slot->option_list())
+		for (const device_slot_option &option : slot.option_list())
 		{
 			if (&option == current)
 				return val;
@@ -61,10 +61,10 @@ int ui_menu_slot_devices::slot_get_current_index(device_slot_interface *slot)
 /*-------------------------------------------------
     ui_slot_get_length - returns
 -------------------------------------------------*/
-int ui_menu_slot_devices::slot_get_length(device_slot_interface *slot)
+int ui_menu_slot_devices::slot_get_length(device_slot_interface &slot)
 {
 	int val = 0;
-	for (const device_slot_option &option : slot->option_list())
+	for (const device_slot_option &option : slot.option_list())
 		if (option.selectable())
 			val++;
 
@@ -74,7 +74,7 @@ int ui_menu_slot_devices::slot_get_length(device_slot_interface *slot)
 /*-------------------------------------------------
     ui_slot_get_next - returns
 -------------------------------------------------*/
-const char *ui_menu_slot_devices::slot_get_next(device_slot_interface *slot)
+const char *ui_menu_slot_devices::slot_get_next(device_slot_interface &slot)
 {
 	int idx = slot_get_current_index(slot);
 	if (idx < 0)
@@ -91,7 +91,7 @@ const char *ui_menu_slot_devices::slot_get_next(device_slot_interface *slot)
 /*-------------------------------------------------
     ui_slot_get_prev - returns
 -------------------------------------------------*/
-const char *ui_menu_slot_devices::slot_get_prev(device_slot_interface *slot)
+const char *ui_menu_slot_devices::slot_get_prev(device_slot_interface &slot)
 {
 	int idx = slot_get_current_index(slot);
 	if (idx < 0)
@@ -108,12 +108,12 @@ const char *ui_menu_slot_devices::slot_get_prev(device_slot_interface *slot)
 /*-------------------------------------------------
     ui_slot_get_option - returns
 -------------------------------------------------*/
-const char *ui_menu_slot_devices::slot_get_option(device_slot_interface *slot, int index)
+const char *ui_menu_slot_devices::slot_get_option(device_slot_interface &slot, int index)
 {
 	if (index >= 0)
 	{
 		int val = 0;
-		for (const device_slot_option &option : slot->option_list())
+		for (const device_slot_option &option : slot.option_list())
 		{
 			if (val == index)
 				return option.name();
@@ -132,10 +132,10 @@ const char *ui_menu_slot_devices::slot_get_option(device_slot_interface *slot, i
     whether the natural keyboard is active
 -------------------------------------------------*/
 
-void ui_menu_slot_devices::set_slot_device(device_slot_interface *slot, const char *val)
+void ui_menu_slot_devices::set_slot_device(device_slot_interface &slot, const char *val)
 {
 	std::string error;
-	machine().options().set_value(slot->device().tag()+1, val, OPTION_PRIORITY_CMDLINE, error);
+	machine().options().set_value(slot.device().tag()+1, val, OPTION_PRIORITY_CMDLINE, error);
 	assert(error.empty());
 }
 
@@ -151,8 +151,7 @@ ui_menu_slot_devices::ui_menu_slot_devices(running_machine &machine, render_cont
 void ui_menu_slot_devices::populate()
 {
 	/* cycle through all devices for this system */
-	slot_interface_iterator iter(machine().root_device());
-	for (device_slot_interface *slot = iter.first(); slot != nullptr; slot = iter.next())
+	for (device_slot_interface &slot : slot_interface_iterator(machine().root_device()))
 	{
 		/* record the menu item */
 		const device_slot_option *option = slot_get_current_option(slot);
@@ -162,11 +161,11 @@ void ui_menu_slot_devices::populate()
 		else
 		{
 			opt_name.assign(option->name());
-			if (slot->fixed() || slot_get_length(slot) == 0)
+			if (slot.fixed() || slot_get_length(slot) == 0)
 				opt_name.append(_(" [internal]"));
 		}
 
-		item_append(slot->device().tag() + 1, opt_name.c_str(), (slot->fixed() || slot_get_length(slot) == 0) ? 0 : (MENU_FLAG_LEFT_ARROW | MENU_FLAG_RIGHT_ARROW), (void *)slot);
+		item_append(slot.device().tag() + 1, opt_name.c_str(), (slot.fixed() || slot_get_length(slot) == 0) ? 0 : (MENU_FLAG_LEFT_ARROW | MENU_FLAG_RIGHT_ARROW), (void *)&slot);
 	}
 	item_append(ui_menu_item_type::SEPARATOR);
 	item_append(_("Reset"),  nullptr, 0, (void *)1);
@@ -195,14 +194,14 @@ void ui_menu_slot_devices::handle()
 		else if (menu_event->iptkey == IPT_UI_LEFT || menu_event->iptkey == IPT_UI_RIGHT)
 		{
 			device_slot_interface *slot = (device_slot_interface *)menu_event->itemref;
-			const char *val = (menu_event->iptkey == IPT_UI_LEFT) ? slot_get_prev(slot) : slot_get_next(slot);
-			set_slot_device(slot, val);
+			const char *val = (menu_event->iptkey == IPT_UI_LEFT) ? slot_get_prev(*slot) : slot_get_next(*slot);
+			set_slot_device(*slot, val);
 			reset(UI_MENU_RESET_REMEMBER_REF);
 		}
 		else if (menu_event->iptkey == IPT_UI_SELECT)
 		{
 			device_slot_interface *slot = (device_slot_interface *)menu_event->itemref;
-			device_slot_option *option = slot_get_current_option(slot);
+			device_slot_option *option = slot_get_current_option(*slot);
 			if (option)
 				ui_menu::stack_push(global_alloc_clear<ui_menu_device_config>(machine(), container, slot, option));
 		}

--- a/src/emu/ui/slotopt.h
+++ b/src/emu/ui/slotopt.h
@@ -23,13 +23,13 @@ public:
 	virtual void handle() override;
 
 private:
-	device_slot_option *slot_get_current_option(device_slot_interface *slot);
-	int slot_get_current_index(device_slot_interface *slot);
-	int slot_get_length(device_slot_interface *slot);
-	const char *slot_get_next(device_slot_interface *slot);
-	const char *slot_get_prev(device_slot_interface *slot);
-	const char *slot_get_option(device_slot_interface *slot, int index);
-	void set_slot_device(device_slot_interface *slot, const char *val);
+	device_slot_option *slot_get_current_option(device_slot_interface &slot);
+	int slot_get_current_index(device_slot_interface &slot);
+	int slot_get_length(device_slot_interface &slot);
+	const char *slot_get_next(device_slot_interface &slot);
+	const char *slot_get_prev(device_slot_interface &slot);
+	const char *slot_get_option(device_slot_interface &slot, int index);
+	void set_slot_device(device_slot_interface &slot, const char *val);
 };
 
 #endif  /* __UI_SLOTOPT_H__ */

--- a/src/emu/ui/swlist.cpp
+++ b/src/emu/ui/swlist.cpp
@@ -409,32 +409,32 @@ void ui_menu_software::populate()
 
 	// Add original software lists for this system
 	software_list_device_iterator iter(machine().config().root_device());
-	for (software_list_device *swlistdev = iter.first(); swlistdev != nullptr; swlistdev = iter.next())
-		if (swlistdev->list_type() == SOFTWARE_LIST_ORIGINAL_SYSTEM)
-			if (!swlistdev->get_info().empty() && m_interface != nullptr)
+	for (software_list_device &swlistdev : iter)
+		if (swlistdev.list_type() == SOFTWARE_LIST_ORIGINAL_SYSTEM)
+			if (!swlistdev.get_info().empty() && m_interface != nullptr)
 			{
 				bool found = false;
-				for (const software_info &swinfo : swlistdev->get_info())
+				for (const software_info &swinfo : swlistdev.get_info())
 					if (swinfo.first_part()->matches_interface(m_interface))
 						found = true;
 				if (found)
-					item_append(swlistdev->description(), nullptr, 0, (void *)swlistdev);
+					item_append(swlistdev.description(), nullptr, 0, (void *)&swlistdev);
 			}
 
 	// add compatible software lists for this system
-	for (software_list_device *swlistdev = iter.first(); swlistdev != nullptr; swlistdev = iter.next())
-		if (swlistdev->list_type() == SOFTWARE_LIST_COMPATIBLE_SYSTEM)
-			if (!swlistdev->get_info().empty() && m_interface != nullptr)
+	for (software_list_device &swlistdev : iter)
+		if (swlistdev.list_type() == SOFTWARE_LIST_COMPATIBLE_SYSTEM)
+			if (!swlistdev.get_info().empty() && m_interface != nullptr)
 			{
 				bool found = false;
-				for (const software_info &swinfo : swlistdev->get_info())
+				for (const software_info &swinfo : swlistdev.get_info())
 					if (swinfo.first_part()->matches_interface(m_interface))
 						found = true;
 				if (found)
 				{
 					if (!have_compatible)
 						item_append(_("[compatible lists]"), nullptr, MENU_FLAG_DISABLE, nullptr);
-					item_append(swlistdev->description(), nullptr, 0, (void *)swlistdev);
+					item_append(swlistdev.description(), nullptr, 0, (void *)&swlistdev);
 				}
 				have_compatible = true;
 			}

--- a/src/emu/ui/ui.cpp
+++ b/src/emu/ui/ui.cpp
@@ -1188,21 +1188,20 @@ std::string &ui_manager::game_info_astring(std::string &str)
 	// loop over all CPUs
 	execute_interface_iterator execiter(machine().root_device());
 	std::unordered_set<std::string> exectags;
-	for (device_execute_interface *exec = execiter.first(); exec != nullptr; exec = execiter.next())
+	for (device_execute_interface &exec : execiter)
 	{
-		if (!exectags.insert(exec->device().tag()).second)
+		if (!exectags.insert(exec.device().tag()).second)
 			continue;
 		// get cpu specific clock that takes internal multiplier/dividers into account
-		int clock = exec->device().clock();
+		int clock = exec.device().clock();
 
 		// count how many identical CPUs we have
 		int count = 1;
-		const char *name = exec->device().name();
-		execute_interface_iterator execinneriter(machine().root_device());
-		for (device_execute_interface *scan = execinneriter.first(); scan != nullptr; scan = execinneriter.next())
+		const char *name = exec.device().name();
+		for (device_execute_interface &scan : execiter)
 		{
-			if (exec->device().type() == scan->device().type() && strcmp(name, scan->device().name()) == 0 && exec->device().clock() == scan->device().clock())
-				if (exectags.insert(scan->device().tag()).second)
+			if (exec.device().type() == scan.device().type() && strcmp(name, scan.device().name()) == 0 && exec.device().clock() == scan.device().clock())
+				if (exectags.insert(scan.device().tag()).second)
 					count++;
 		}
 
@@ -1222,9 +1221,9 @@ std::string &ui_manager::game_info_astring(std::string &str)
 	sound_interface_iterator snditer(machine().root_device());
 	std::unordered_set<std::string> soundtags;
 	bool found_sound = false;
-	for (device_sound_interface *sound = snditer.first(); sound != nullptr; sound = snditer.next())
+	for (device_sound_interface &sound : snditer)
 	{
-		if (!soundtags.insert(sound->device().tag()).second)
+		if (!soundtags.insert(sound.device().tag()).second)
 			continue;
 
 		// append the Sound: string
@@ -1234,23 +1233,22 @@ std::string &ui_manager::game_info_astring(std::string &str)
 
 		// count how many identical sound chips we have
 		int count = 1;
-		sound_interface_iterator sndinneriter(machine().root_device());
-		for (device_sound_interface *scan = sndinneriter.first(); scan != nullptr; scan = sndinneriter.next())
+		for (device_sound_interface &scan : snditer)
 		{
-			if (sound->device().type() == scan->device().type() && sound->device().clock() == scan->device().clock())
-				if (soundtags.insert(scan->device().tag()).second)
+			if (sound.device().type() == scan.device().type() && sound.device().clock() == scan.device().clock())
+				if (soundtags.insert(scan.device().tag()).second)
 					count++;
 		}
 
 		// if more than one, prepend a #x in front of the CPU name
 		// display clock in kHz or MHz
-		int clock = sound->device().clock();
+		int clock = sound.device().clock();
 		util::stream_format(buf,
 				(count > 1)
 					? ((clock != 0) ? "%1$d" UTF8_MULTIPLY "%2$s %3$d.%4$0*5$d%6$s\n" : "%1$d" UTF8_MULTIPLY "%2$s\n")
 					: ((clock != 0) ? "%2$s %3$d.%4$0*5$d%6$s\n" : "%2$s\n"),
 				count,
-				sound->device().name(),
+				sound.device().name(),
 				(clock >= 1000000) ? (clock / 1000000) : (clock / 1000),
 				(clock >= 1000000) ? (clock % 1000000) : (clock % 1000),
 				(clock >= 1000000) ? 6 : 3,
@@ -1265,23 +1263,23 @@ std::string &ui_manager::game_info_astring(std::string &str)
 		buf << _("None\n");
 	else
 	{
-		for (screen_device *screen = scriter.first(); screen != nullptr; screen = scriter.next())
+		for (screen_device &screen : scriter)
 		{
 			std::string detail;
-			if (screen->screen_type() == SCREEN_TYPE_VECTOR)
+			if (screen.screen_type() == SCREEN_TYPE_VECTOR)
 				detail = _("Vector");
 			else
 			{
-				const rectangle &visarea = screen->visible_area();
+				const rectangle &visarea = screen.visible_area();
 				detail = string_format("%d " UTF8_MULTIPLY " %d (%s) %f" UTF8_NBSP "Hz",
 						visarea.width(), visarea.height(),
 						(machine().system().flags & ORIENTATION_SWAP_XY) ? "V" : "H",
-						ATTOSECONDS_TO_HZ(screen->frame_period().attoseconds()));
+						ATTOSECONDS_TO_HZ(screen.frame_period().attoseconds()));
 			}
 
 			util::stream_format(buf,
 					(scrcount > 1) ? _("%1$s: %2$s\n") : _("%2$s\n"),
-					slider_get_screen_desc(*screen), detail);
+					slider_get_screen_desc(screen), detail);
 		}
 	}
 
@@ -1467,11 +1465,8 @@ void ui_manager::image_handler_ingame()
 {
 	// run display routine for devices
 	if (machine().phase() == MACHINE_PHASE_RUNNING)
-	{
-		image_interface_iterator iter(machine().root_device());
-		for (device_image_interface *image = iter.first(); image != nullptr; image = iter.next())
-			image->call_display();
-	}
+		for (device_image_interface &image : image_interface_iterator(machine().root_device()))
+			image.call_display();
 }
 
 
@@ -1605,19 +1600,17 @@ UINT32 ui_manager::handler_ingame(running_machine &machine, render_container *co
 	// handle a tape control key
 	if (machine.ui_input().pressed(IPT_UI_TAPE_START))
 	{
-		cassette_device_iterator cassiter(machine.root_device());
-		for (cassette_image_device *cass = cassiter.first(); cass != nullptr; cass = cassiter.next())
+		for (cassette_image_device &cass : cassette_device_iterator(machine.root_device()))
 		{
-			cass->change_state(CASSETTE_PLAY, CASSETTE_MASK_UISTATE);
+			cass.change_state(CASSETTE_PLAY, CASSETTE_MASK_UISTATE);
 			return 0;
 		}
 	}
 	if (machine.ui_input().pressed(IPT_UI_TAPE_STOP))
 	{
-		cassette_device_iterator cassiter(machine.root_device());
-		for (cassette_image_device *cass = cassiter.first(); cass != nullptr; cass = cassiter.next())
+		for (cassette_image_device &cass : cassette_device_iterator(machine.root_device()))
 		{
-			cass->change_state(CASSETTE_STOPPED, CASSETTE_MASK_UISTATE);
+			cass.change_state(CASSETTE_STOPPED, CASSETTE_MASK_UISTATE);
 			return 0;
 		}
 	}
@@ -1939,25 +1932,24 @@ std::vector<ui_menu_item> ui_manager::slider_init(running_machine &machine)
 	// add CPU overclocking (cheat only)
 	if (machine.options().cheat())
 	{
-		execute_interface_iterator iter(machine.root_device());
-		for (device_execute_interface *exec = iter.first(); exec != nullptr; exec = iter.next())
+		for (device_execute_interface &exec : execute_interface_iterator(machine.root_device()))
 		{
-			void *param = (void *)&exec->device();
-			std::string str = string_format(_("Overclock CPU %1$s"), exec->device().tag());
+			void *param = (void *)&exec.device();
+			std::string str = string_format(_("Overclock CPU %1$s"), exec.device().tag());
 			sliders.push_back(slider_alloc(machine, str.c_str(), 10, 1000, 2000, 1, slider_overclock, param));
 		}
 	}
 
 	// add screen parameters
 	screen_device_iterator scriter(machine.root_device());
-	for (screen_device *screen = scriter.first(); screen != nullptr; screen = scriter.next())
+	for (screen_device &screen : scriter)
 	{
-		int defxscale = floor(screen->xscale() * 1000.0f + 0.5f);
-		int defyscale = floor(screen->yscale() * 1000.0f + 0.5f);
-		int defxoffset = floor(screen->xoffset() * 1000.0f + 0.5f);
-		int defyoffset = floor(screen->yoffset() * 1000.0f + 0.5f);
-		void *param = (void *)screen;
-		std::string screen_desc = slider_get_screen_desc(*screen);
+		int defxscale = floor(screen.xscale() * 1000.0f + 0.5f);
+		int defyscale = floor(screen.yscale() * 1000.0f + 0.5f);
+		int defxoffset = floor(screen.xoffset() * 1000.0f + 0.5f);
+		int defyoffset = floor(screen.yoffset() * 1000.0f + 0.5f);
+		void *param = (void *)&screen;
+		std::string screen_desc = slider_get_screen_desc(screen);
 
 		// add refresh rate tweaker
 		if (machine.options().cheat())
@@ -1985,34 +1977,33 @@ std::vector<ui_menu_item> ui_manager::slider_init(running_machine &machine)
 		sliders.push_back(slider_alloc(machine, str.c_str(), -500, defyoffset, 500, 2, slider_yoffset, param));
 	}
 
-	laserdisc_device_iterator lditer(machine.root_device());
-	for (laserdisc_device *laserdisc = lditer.first(); laserdisc != nullptr; laserdisc = lditer.next())
+	for (laserdisc_device &laserdisc : laserdisc_device_iterator(machine.root_device()))
 	{
-		if (laserdisc->overlay_configured())
+		if (laserdisc.overlay_configured())
 		{
 			laserdisc_overlay_config config;
-			laserdisc->get_overlay_config(config);
+			laserdisc.get_overlay_config(config);
 			int defxscale = floor(config.m_overscalex * 1000.0f + 0.5f);
 			int defyscale = floor(config.m_overscaley * 1000.0f + 0.5f);
 			int defxoffset = floor(config.m_overposx * 1000.0f + 0.5f);
 			int defyoffset = floor(config.m_overposy * 1000.0f + 0.5f);
-			void *param = (void *)laserdisc;
+			void *param = (void *)&laserdisc;
 
 			// add scale and offset controls per-overlay
-			std::string str = string_format(_("Laserdisc '%1$s' Horiz Stretch"), laserdisc->tag());
+			std::string str = string_format(_("Laserdisc '%1$s' Horiz Stretch"), laserdisc.tag());
 			sliders.push_back(slider_alloc(machine, str.c_str(), 500, (defxscale == 0) ? 1000 : defxscale, 1500, 2, slider_overxscale, param));
-			str = string_format(_("Laserdisc '%1$s' Horiz Position"), laserdisc->tag());
+			str = string_format(_("Laserdisc '%1$s' Horiz Position"), laserdisc.tag());
 			sliders.push_back(slider_alloc(machine, str.c_str(), -500, defxoffset, 500, 2, slider_overxoffset, param));
-			str = string_format(_("Laserdisc '%1$s' Vert Stretch"), laserdisc->tag());
+			str = string_format(_("Laserdisc '%1$s' Vert Stretch"), laserdisc.tag());
 			sliders.push_back(slider_alloc(machine, str.c_str(), 500, (defyscale == 0) ? 1000 : defyscale, 1500, 2, slider_overyscale, param));
-			str = string_format(_("Laserdisc '%1$s' Vert Position"), laserdisc->tag());
+			str = string_format(_("Laserdisc '%1$s' Vert Position"), laserdisc.tag());
 			sliders.push_back(slider_alloc(machine, str.c_str(), -500, defyoffset, 500, 2, slider_overyoffset, param));
 		}
 	}
 
-	for (screen_device *screen = scriter.first(); screen != nullptr; screen = scriter.next())
+	for (screen_device &screen : scriter)
 	{
-		if (screen->screen_type() == SCREEN_TYPE_VECTOR)
+		if (screen.screen_type() == SCREEN_TYPE_VECTOR)
 		{
 			// add vector control
 			sliders.push_back(slider_alloc(machine, _("Vector Flicker"), 0, 0, 1000, 10, slider_flicker, nullptr));
@@ -2462,10 +2453,7 @@ static INT32 slider_beam_intensity_weight(running_machine &machine, void *arg, i
 
 static std::string slider_get_screen_desc(screen_device &screen)
 {
-	screen_device_iterator iter(screen.machine().root_device());
-	int scrcount = iter.count();
-
-	if (scrcount > 1)
+	if (screen_device_iterator(screen.machine().root_device()).count() > 1)
 		return string_format(_("Screen '%1$s'"), screen.tag());
 	else
 		return _("Screen");

--- a/src/mame/machine/atarigen.cpp
+++ b/src/mame/machine/atarigen.cpp
@@ -970,17 +970,15 @@ atarigen_state::atarigen_state(const machine_config &mconfig, device_type type, 
 
 void atarigen_state::machine_start()
 {
-	screen_device *screen;
-	int i;
-
 	// allocate timers for all screens
-	screen_device_iterator iter(*this);
-	assert(iter.count() <= ARRAY_LENGTH(m_screen_timer));
-	for (i = 0, screen = iter.first(); screen != nullptr; i++, screen = iter.next())
+	int i = 0;
+	for (screen_device &screen : screen_device_iterator(*this))
 	{
-		m_screen_timer[i].screen = screen;
-		m_screen_timer[i].scanline_interrupt_timer = timer_alloc(TID_SCANLINE_INTERRUPT, (void *)screen);
-		m_screen_timer[i].scanline_timer = timer_alloc(TID_SCANLINE_TIMER, (void *)screen);
+		assert(i <= ARRAY_LENGTH(m_screen_timer));
+		m_screen_timer[i].screen = &screen;
+		m_screen_timer[i].scanline_interrupt_timer = timer_alloc(TID_SCANLINE_INTERRUPT, (void *)&screen);
+		m_screen_timer[i].scanline_timer = timer_alloc(TID_SCANLINE_TIMER, (void *)&screen);
+		i++;
 	}
 
 	save_item(NAME(m_scanline_int_state));

--- a/src/mame/video/cyberbal.cpp
+++ b/src/mame/video/cyberbal.cpp
@@ -130,12 +130,9 @@ VIDEO_START_MEMBER(cyberbal_state,cyberbal2p)
 
 void cyberbal_state::scanline_update(screen_device &screen, int scanline)
 {
-	int i;
-	screen_device *update_screen;
-
 	/* loop over screens */
-	screen_device_iterator iter(*this);
-	for (i = 0, update_screen = iter.first(); update_screen != nullptr; i++, update_screen = iter.next())
+	int i = 0;
+	for (screen_device &update_screen : screen_device_iterator(*this))
 	{
 		/* need explicit target() because one is optional_device and other is required_device */
 		tilemap_t *curplayfield = i ? m_playfield2_tilemap.target() : m_playfield_tilemap.target();
@@ -155,7 +152,7 @@ void cyberbal_state::scanline_update(screen_device &screen, int scanline)
 			if (((word >> 1) & 7) != m_playfield_palette_bank[i])
 			{
 				if (scanline > 0)
-					update_screen->update_partial(scanline - 1);
+					update_screen.update_partial(scanline - 1);
 				m_playfield_palette_bank[i] = (word >> 1) & 7;
 				curplayfield->set_palette_offset(m_playfield_palette_bank[i] << 8);
 			}
@@ -167,7 +164,7 @@ void cyberbal_state::scanline_update(screen_device &screen, int scanline)
 			if (newscroll != m_playfield_xscroll[i])
 			{
 				if (scanline > 0)
-					update_screen->update_partial(scanline - 1);
+					update_screen.update_partial(scanline - 1);
 				curplayfield->set_scrollx(0, newscroll);
 				m_playfield_xscroll[i] = newscroll;
 			}
@@ -180,7 +177,7 @@ void cyberbal_state::scanline_update(screen_device &screen, int scanline)
 			if (newscroll != m_playfield_yscroll[i])
 			{
 				if (scanline > 0)
-					update_screen->update_partial(scanline - 1);
+					update_screen.update_partial(scanline - 1);
 				curplayfield->set_scrolly(0, newscroll);
 				m_playfield_yscroll[i] = newscroll;
 			}
@@ -191,10 +188,11 @@ void cyberbal_state::scanline_update(screen_device &screen, int scanline)
 			if (m_current_slip[i] != word)
 			{
 				if (scanline > 0)
-					update_screen->update_partial(scanline - 1);
+					update_screen.update_partial(scanline - 1);
 				m_current_slip[i] = word;
 			}
 		}
+		i++;
 	}
 }
 

--- a/src/osd/modules/debugger/qt/deviceswindow.cpp
+++ b/src/osd/modules/debugger/qt/deviceswindow.cpp
@@ -91,14 +91,7 @@ int DevicesWindowModel::rowCount(const QModelIndex &parent) const
 		return 1;
 
 	device_t *dparent = static_cast<device_t *>(parent.internalPointer());
-	int count = 0;
-	for (device_t &child : dparent->subdevices()) 
-	{
-		(void)child;
-		count++;
-	}
-
-	return count;
+	return dparent->subdevices().count();
 }
 
 int DevicesWindowModel::columnCount(const QModelIndex &parent) const

--- a/src/osd/modules/debugger/qt/mainwindow.cpp
+++ b/src/osd/modules/debugger/qt/mainwindow.cpp
@@ -469,13 +469,12 @@ void MainWindow::createImagesMenu()
 	QMenu* imagesMenu = menuBar()->addMenu("&Images");
 
 	int interfaceIndex = 0;
-	image_interface_iterator iter(m_machine->root_device());
-	for (device_image_interface *img = iter.first(); img != NULL; img = iter.next())
+	for (device_image_interface &img : image_interface_iterator(m_machine->root_device()))
 	{
-		std::string menuName = string_format("%s : %s", img->device().name(), img->exists() ? img->filename() : "[empty slot]");
+		std::string menuName = string_format("%s : %s", img.device().name(), img.exists() ? img.filename() : "[empty slot]");
 
 		QMenu* interfaceMenu = imagesMenu->addMenu(menuName.c_str());
-		interfaceMenu->setObjectName(img->device().name());
+		interfaceMenu->setObjectName(img.device().name());
 
 		QAction* mountAct = new QAction("Mount...", interfaceMenu);
 		QAction* unmountAct = new QAction("Unmount", interfaceMenu);
@@ -486,7 +485,7 @@ void MainWindow::createImagesMenu()
 		connect(mountAct, &QAction::triggered, this, &MainWindow::mountImage);
 		connect(unmountAct, &QAction::triggered, this, &MainWindow::unmountImage);
 
-		if (!img->exists())
+		if (!img.exists())
 			unmountAct->setEnabled(false);
 
 		interfaceMenu->addAction(mountAct);

--- a/src/osd/modules/debugger/win/consolewininfo.cpp
+++ b/src/osd/modules/debugger/win/consolewininfo.cpp
@@ -37,13 +37,12 @@ consolewin_info::consolewin_info(debugger_windows_interface &debugger) :
 	{
 		// Add image menu only if image devices exist
 		image_interface_iterator iter(machine().root_device());
-		device_image_interface *img = iter.first();
-		if (img != NULL)
+		if (iter.first() != nullptr)
 		{
 			m_devices_menu = CreatePopupMenu();
-			for ( ; img != NULL; img = iter.next())
+			for (device_image_interface &img : iter)
 			{
-				TCHAR *tc_buf = tstring_from_utf8(string_format("%s : %s", img->device().name(), img->exists() ? img->filename() : "[no image]").c_str());
+				TCHAR *tc_buf = tstring_from_utf8(string_format("%s : %s", img.device().name(), img.exists() ? img.filename() : "[no image]").c_str());
 				if (tc_buf != NULL)
 				{
 					AppendMenu(m_devices_menu, MF_ENABLED, 0, tc_buf);
@@ -163,32 +162,30 @@ void consolewin_info::update_menu()
 	if (m_devices_menu != NULL)
 	{
 		// create the image menu
-		image_interface_iterator iter(machine().root_device());
-		device_image_interface *img;
-		UINT32 cnt;
-		for (img = iter.first(), cnt = 0; img != NULL; img = iter.next(), cnt++)
+		UINT32 cnt = 0;
+		for (device_image_interface &img : image_interface_iterator(machine().root_device()))
 		{
 			HMENU const devicesubmenu = CreatePopupMenu();
 
 			UINT_PTR const new_item = ID_DEVICE_OPTIONS + (cnt * DEVOPTION_MAX);
 
 			UINT flags_for_exists = MF_ENABLED | MF_STRING;
-			if (!img->exists())
+			if (!img.exists())
 				flags_for_exists |= MF_GRAYED;
 
 			UINT flags_for_writing = flags_for_exists;
-			if (img->is_readonly())
+			if (img.is_readonly())
 				flags_for_writing |= MF_GRAYED;
 
 			AppendMenu(devicesubmenu, MF_STRING, new_item + DEVOPTION_OPEN, TEXT("Mount..."));
 
-			//if (img->is_creatable())
+			//if (img.is_creatable())
 				//AppendMenu(devicesubmenu, MF_STRING, new_item + DEVOPTION_CREATE, TEXT("Create..."));
 			AppendMenu(devicesubmenu, flags_for_exists, new_item + DEVOPTION_CLOSE, TEXT("Unmount"));
 
-			if (img->device().type() == CASSETTE)
+			if (img.device().type() == CASSETTE)
 			{
-				cassette_state const state = (cassette_state)(img->exists() ? (downcast<cassette_image_device *>(&img->device())->get_state() & CASSETTE_MASK_UISTATE) : CASSETTE_STOPPED);
+				cassette_state const state = (cassette_state)(img.exists() ? (downcast<cassette_image_device *>(&img.device())->get_state() & CASSETTE_MASK_UISTATE) : CASSETTE_STOPPED);
 				AppendMenu(devicesubmenu, MF_SEPARATOR, 0, NULL);
 				AppendMenu(devicesubmenu, flags_for_exists | ((state == CASSETTE_STOPPED) ? MF_CHECKED : 0), new_item + DEVOPTION_CASSETTE_STOPPAUSE, TEXT("Pause/Stop"));
 				AppendMenu(devicesubmenu, flags_for_exists | ((state == CASSETTE_PLAY) ? MF_CHECKED : 0), new_item + DEVOPTION_CASSETTE_PLAY, TEXT("Play"));
@@ -197,12 +194,14 @@ void consolewin_info::update_menu()
 				AppendMenu(devicesubmenu, flags_for_exists, new_item + DEVOPTION_CASSETTE_FASTFORWARD, TEXT("Fast Forward"));
 			}
 
-			TCHAR *tc_buf = tstring_from_utf8(string_format("%s :%s", img->device().name(), img->exists() ? img->filename() : "[empty slot]").c_str());
+			TCHAR *tc_buf = tstring_from_utf8(string_format("%s :%s", img.device().name(), img.exists() ? img.filename() : "[empty slot]").c_str());
 			if (tc_buf != NULL)
 			{
 				ModifyMenu(m_devices_menu, cnt, MF_BYPOSITION | MF_POPUP, (UINT_PTR)devicesubmenu, tc_buf);
 				osd_free(tc_buf);
 			}
+
+			cnt++;
 		}
 	}
 }

--- a/src/osd/modules/render/d3d/d3dhlsl.cpp
+++ b/src/osd/modules/render/d3d/d3dhlsl.cpp
@@ -1372,11 +1372,7 @@ int shaders::post_pass(d3d_render_target *rt, int source_index, poly_info *poly,
 	int next_index = source_index;
 
 	screen_device_iterator screen_iterator(machine->root_device());
-	screen_device *screen = screen_iterator.first();
-	for (int i = 0; i < curr_screen; i++)
-	{
-		screen = screen_iterator.next();
-	}
+	screen_device *screen = screen_iterator.byindex(curr_screen);
 	render_container &screen_container = screen->container();
 
 	float xscale = screen_container.xscale();

--- a/src/osd/sdl/window.cpp
+++ b/src/osd/sdl/window.cpp
@@ -1073,22 +1073,8 @@ OSDWORK_CALLBACK( sdl_window_info::draw_video_contents_wt )
 
 	{
 #if 1
-		int scrnum = 0;
-		int is_vector = 0;
-		screen_device_iterator iter(window->machine().root_device());
-		for (const screen_device *screen = iter.first(); screen != nullptr; screen = iter.next())
-		{
-			if (scrnum == window->m_index)
-			{
-				is_vector = (screen->screen_type() == SCREEN_TYPE_VECTOR) ? 1 : 0;
-				break;
-			}
-			else
-			{
-				scrnum++;
-			}
-		}
-		if (is_vector)
+		const screen_device *screen = screen_device_iterator(window->machine().root_device()).byindex(window->m_index);
+		if ((screen != nullptr) && (screen->screen_type() == SCREEN_TYPE_VECTOR))
 			window->renderer().set_flags(osd_renderer::FLAG_HAS_VECTOR_SCREEN);
 		else
 			window->renderer().clear_flags(osd_renderer::FLAG_HAS_VECTOR_SCREEN);


### PR DESCRIPTION
Replace the old device_iterator and its specialized versions with functionally equivalent classes that use standard operators to yield references to devices/interfaces rather than pointers. With range-based for loops, they no longer have to be stored in named variables, though they can also be reused concurrently since the iteration state is now maintained by a subclass.

Add a few more typical getters to device_t::subdevice_list.