### PR TITLE
decocass: Fix positioning of object sprite

### DIFF
--- a/src/mame/video/decocass.cpp
+++ b/src/mame/video/decocass.cpp
@@ -244,12 +244,10 @@ void decocass_state::draw_object(bitmap_ind16 &bitmap, const rectangle &cliprect
 
 	color = (m_color_center_bot >> 4) & 15;
 
-	sy = 192 - (m_part_v_shift & 0x7f);
-
-	if (m_part_h_shift & 0x80)
-		sx = (m_part_h_shift & 0x7f) + 1;
-	else
-		sx = 91 - (m_part_h_shift & 0x7f);
+	sy = 64 - m_part_v_shift + 1;
+	if (sy < 0)
+		sy += 256;
+	sx = m_part_h_shift - 128;
 
 	m_gfxdecode->gfx(3)->transpen(bitmap,cliprect, 0, color, 0, 0, sx + 64, sy, 0);
 	m_gfxdecode->gfx(3)->transpen(bitmap,cliprect, 1, color, 0, 0, sx, sy, 0);
@@ -455,7 +453,7 @@ WRITE8_MEMBER(decocass_state::decocass_back_vr_shift_w )
 
 WRITE8_MEMBER(decocass_state::decocass_part_h_shift_w )
 {
-	if (data == m_part_v_shift )
+	if (data == m_part_h_shift )
 		return;
 	LOG(1,("decocass_part_h_shift_w: $%02x\n", data));
 	m_part_h_shift = data;


### PR DESCRIPTION
This stops the headlight in chwy from bouncing all over the screen and makes the shadow stick to cskater's toe.

Reference videos show that color is still 100% wrong.