### PR TITLE
fix build (nw)

### DIFF
--- a/src/mame/drivers/wmg.cpp
+++ b/src/mame/drivers/wmg.cpp
@@ -68,6 +68,7 @@ of save-state is also needed.
 
 ***********************************************************************************************************/
 
+#include "emu.h"
 #include "includes/williams.h"
 #include "cpu/m6800/m6800.h"
 #include "machine/nvram.h"


### PR DESCRIPTION
    In file included from ../../../../../src/mame/includes/williams.h:10:0,
                 from ../../../../../src/mame/drivers/wmg.cpp:71:
    ../../../../../src/devices/cpu/m6809/m6809.h:25:14: error: 'device_type' does not name a type
     extern const device_type M6809;
                  ^