### PR TITLE
Check software parts for incompatibility as well as compatibility

### DIFF
--- a/hash/megadriv.xml
+++ b/hash/megadriv.xml
@@ -3800,6 +3800,7 @@ Info on Sega chip labels (from Sunbeam / Digital Corruption)
 		<description>Ishido - The Way of Stones (USA)</description>
 		<year>1990</year>
 		<publisher>Accolade</publisher>
+		<sharedfeat name="incompatibility" value="TMSS"/>
 		<part name="cart" interface="megadriv_cart">
 			<feature name="pcb" value="ACBWPC1190"/>
 			<feature name="ic1" value="MB834200A 2M5 BA 9044 T03 ISS0890"/>
@@ -11942,6 +11943,7 @@ but dumps still have to be confirmed.
 		<description>Budokan - The Martial Spirit (USA)</description>
 		<year>1990</year>
 		<publisher>Electronic Arts</publisher>
+		<sharedfeat name="incompatibility" value="TMSS"/>
 		<part name="cart" interface="megadriv_cart">
 			<dataarea name="rom" width="16" endianness="big" size="524288">
 				<rom name="budokan - the martial spirit (usa).bin" size="524288" crc="acd9f5fc" sha1="93bc8242106bc9b2e0a8a974a3f65b559dd2941d" offset="0x000000"/>
@@ -20522,6 +20524,7 @@ Notice that these are not working on real hardware due to bugged code with VDP i
 		<description>Onslaught (Euro, USA)</description>
 		<year>1991</year>
 		<publisher>Ballistic</publisher>
+		<sharedfeat name="incompatibility" value="TMSS"/>
 		<part name="cart" interface="megadriv_cart">
 			<dataarea name="rom" width="16" endianness="big" size="524288">
 				<rom name="onslaught (euro, usa).bin" size="524288" crc="9f19d6df" sha1="dc542ddfa878f2aed3a7fcedc4b0f8d503eb5d70" offset="0x000000"/>
@@ -21578,6 +21581,7 @@ Notice that these are not working on real hardware due to bugged code with VDP i
 		<description>Populous (USA)</description>
 		<year>1991</year>
 		<publisher>Sega</publisher>
+		<sharedfeat name="incompatibility" value="TMSS"/>
 		<part name="cart" interface="megadriv_cart">
 			<dataarea name="rom" width="16" endianness="big" size="524288">
 				<rom name="populous (usa).bin" size="524288" crc="bd74b31e" sha1="89907c4ba4fd9db4e8ef2271c0253bb0e4b6d52d" offset="0x000000"/>
@@ -29417,6 +29421,7 @@ Notice that these are not working on real hardware due to bugged code with VDP i
 		<description>Zany Golf (Euro, USA)</description>
 		<year>1990</year>
 		<publisher>Electronic Arts</publisher>
+		<sharedfeat name="incompatibility" value="TMSS"/>
 		<part name="cart" interface="megadriv_cart">
 			<dataarea name="rom" width="16" endianness="big" size="524288">
 				<rom name="zany golf (euro, usa).bin" size="524288" crc="ed5d12ea" sha1="4f9bea2d8f489bfbc963718a8dca212e033fb5a2" offset="0x000000"/>

--- a/src/emu/softlist.h
+++ b/src/emu/softlist.h
@@ -29,6 +29,12 @@ enum softlist_type
 	SOFTWARE_LIST_COMPATIBLE_SYSTEM
 };
 
+enum software_compatibility
+{
+	SOFTWARE_IS_COMPATIBLE,
+	SOFTWARE_IS_INCOMPATIBLE,
+	SOFTWARE_NOT_COMPATIBLE
+};
 
 
 //**************************************************************************
@@ -115,9 +121,10 @@ public:
 	rom_entry *romdata(unsigned int index = 0) { return (index < m_romdata.size()) ? &m_romdata[index] : nullptr; }
 
 	// helpers
-	bool is_compatible(const software_list_device &swlist) const;
+	software_compatibility is_compatible(const software_list_device &swlist) const;
 	bool matches_interface(const char *interface) const;
 	const char *feature(const char *feature_name) const;
+	device_image_interface *find_mountable_image(const machine_config &mconfig) const;
 
 private:
 	// internal state

--- a/src/frontend/mame/ui/selsoft.cpp
+++ b/src/frontend/mame/ui/selsoft.cpp
@@ -538,7 +538,7 @@ void ui_menu_select_software::build_software_list()
 		for (software_info &swinfo : swlist.get_info())
 		{
 			software_part *part = swinfo.first_part();
-			if (part->is_compatible(swlist))
+			if (part->is_compatible(swlist) == SOFTWARE_IS_COMPATIBLE)
 			{
 				const char *instance_name = nullptr;
 				const char *type_name = nullptr;

--- a/src/frontend/mame/ui/swlist.cpp
+++ b/src/frontend/mame/ui/swlist.cpp
@@ -191,7 +191,7 @@ ui_menu_software_list::entry_info *ui_menu_software_list::append_software_entry(
 	// check if at least one of the parts has the correct interface and add a menu entry only in this case
 	for (const software_part &swpart : swinfo.parts())
 	{
-		if (swpart.matches_interface(m_interface) && swpart.is_compatible(*m_swlist))
+		if (swpart.matches_interface(m_interface) && swpart.is_compatible(*m_swlist) == SOFTWARE_IS_COMPATIBLE)
 		{
 			entry_updated = TRUE;
 			// allocate a new entry

--- a/src/mame/drivers/megadriv.cpp
+++ b/src/mame/drivers/megadriv.cpp
@@ -406,6 +406,9 @@ static MACHINE_CONFIG_START( ms_megadpal, md_cons_state )
 	MCFG_SOFTWARE_LIST_ADD("cart_list","megadriv")
 MACHINE_CONFIG_END
 
+static MACHINE_CONFIG_DERIVED( genesis_tmss, ms_megadriv )
+	MCFG_SOFTWARE_LIST_FILTER("cart_list","TMSS")
+MACHINE_CONFIG_END
 
 
 
@@ -1058,7 +1061,7 @@ CONS( 1990, megadriv,   genesis,   0,      ms_megadpal,     md, md_cons_state,  
 CONS( 1988, megadrij,   genesis,   0,      ms_megadriv,     md, md_cons_state,     md_jpn,    "Sega",   "Mega Drive (Japan, NTSC)", MACHINE_SUPPORTS_SAVE )
 
 // 1990+ models had the TMSS security chip, leave this as a clone, it reduces compatibility and nothing more.
-CONS( 1990, genesis_tmss, genesis, 0,      ms_megadriv,     md, md_cons_state,     genesis,   "Sega",   "Genesis (USA, NTSC, with TMSS chip)",  MACHINE_SUPPORTS_SAVE )
+CONS( 1990, genesis_tmss, genesis, 0,      genesis_tmss,    md, md_cons_state,     genesis,   "Sega",   "Genesis (USA, NTSC, with TMSS chip)",  MACHINE_SUPPORTS_SAVE )
 
 
 // the 32X plugged in the cart slot, games plugged into the 32x.  Maybe it should be handled as an expansion device?


### PR DESCRIPTION
This new softlist feature is now used by genesis_tmss to exclude several entries from megadriv.xml.

- Use popmessage instead of osd_printf_warning for incompatibility warnings
- Unify some common software loading code, which reduces indentation levels in clifront.cpp