### PR TITLE
Export SDL_SendKeyboardKey function to allow scancode injection in Emscripten build

### DIFF
--- a/scripts/resources/emscripten/emscripten_post.js
+++ b/scripts/resources/emscripten/emscripten_post.js
@@ -7,4 +7,5 @@ JSMAME.ui_set_show_fps = Module.cwrap('_ZN15mame_ui_manager12set_show_fpsEb', ''
 JSMAME.ui_get_show_fps = Module.cwrap('_ZNK15mame_ui_manager8show_fpsEv', 'number', ['number']);
 JSMAME.sound_manager_mute = Module.cwrap('_ZN13sound_manager4muteEbh', '', ['number', 'number', 'number']);
 JSMAME.sdl_pauseaudio = Module.cwrap('SDL_PauseAudio', '', ['number']);
+JSMAME.sdl_sendkeyboardkey = Module.cwrap('SDL_SendKeyboardKey', '', ['number', 'number']);
 var JSMESS = JSMAME;

--- a/scripts/src/main.lua
+++ b/scripts/src/main.lua
@@ -123,7 +123,7 @@ end
 			emccopts = emccopts .. " -s TOTAL_MEMORY=268435456"
 			emccopts = emccopts .. " -s DISABLE_EXCEPTION_CATCHING=2"
 			emccopts = emccopts .. " -s EXCEPTION_CATCHING_WHITELIST='[\"__ZN15running_machine17start_all_devicesEv\",\"__ZN12cli_frontend7executeEiPPc\"]'"
-			emccopts = emccopts .. " -s EXPORTED_FUNCTIONS=\"['_main', '_malloc', '__Z14js_get_machinev', '__Z9js_get_uiv', '__Z12js_get_soundv', '__ZN15mame_ui_manager12set_show_fpsEb', '__ZNK15mame_ui_manager8show_fpsEv', '__ZN13sound_manager4muteEbh', '_SDL_PauseAudio']\""
+			emccopts = emccopts .. " -s EXPORTED_FUNCTIONS=\"['_main', '_malloc', '__Z14js_get_machinev', '__Z9js_get_uiv', '__Z12js_get_soundv', '__ZN15mame_ui_manager12set_show_fpsEb', '__ZNK15mame_ui_manager8show_fpsEv', '__ZN13sound_manager4muteEbh', '_SDL_PauseAudio', '_SDL_SendKeyboardKey']\""
 			emccopts = emccopts .. " --pre-js " .. _MAKE.esc(MAME_DIR) .. "src/osd/modules/sound/js_sound.js"
 			emccopts = emccopts .. " --post-js " .. _MAKE.esc(MAME_DIR) .. "scripts/resources/emscripten/emscripten_post.js"
 			emccopts = emccopts .. " --embed-file " .. _MAKE.esc(MAME_DIR) .. "bgfx/chains@bgfx/chains"


### PR DESCRIPTION
This change is specifically for the Emscripten build, it allows the containing website to access the SDL_SendKeyboardKey function directly, which is useful for linking webpage UI elements with the running emulator instance.