### PR TITLE
Input documentation and COP tweaks based on M68000 and V30 code

### DIFF
--- a/src/mame/drivers/goal92.cpp
+++ b/src/mame/drivers/goal92.cpp
@@ -335,7 +335,7 @@ MACHINE_CONFIG_END
 
 /*
 
-Goal '92 (bootleg of Seibu Cup Soccer)
+Goal '92 (bootleg of Olympic Soccer '92 on non-Seibu board)
 
 
 PCB Layout
@@ -373,7 +373,7 @@ Z80 clock: 2.51MHz
 */
 
 ROM_START( goal92 )
-	ROM_REGION( 0x100000, "maincpu", 0 ) /* 68000 Code */
+	ROM_REGION( 0x100000, "maincpu", 0 ) /* 68000 Code - first 0x20000 bytes are a heavily patched copy of olysoc92a */
 	ROM_LOAD16_BYTE( "2.bin", 0x00000, 0x80000, CRC(db0a6c7c) SHA1(b609db7806b99bc921806d8b3e5e515b4651c375) )
 	ROM_LOAD16_BYTE( "3.bin", 0x00001, 0x80000, CRC(e4c45dee) SHA1(542749bd1ff51220a151fe66acdadac83df8f0ee) )
 

--- a/src/mame/drivers/legionna.cpp
+++ b/src/mame/drivers/legionna.cpp
@@ -15,6 +15,15 @@ hardware. It has a graphics banking facility, which doubles the 0xfff
 different tiles available for use in the foreground layer.
 
 
+Board names displayed on test mode menu:
+    SYS68C2 BOARD       Seibu Cup Soccer
+    SYS68C3 BOARD       SD Gundam Sangokushi Rainbow Tairiku Senki
+    Denden Makamaka     Denjin Makai
+    (none)              Godzilla
+
+Heated Barrel includes only the I/O test, and Legionnaire only has a DSW
+display. These can be accessed by holding down the P1 joystick at reset.
+
 
 TODO
 ----
@@ -102,7 +111,7 @@ static ADDRESS_MAP_START( legionna_cop_mem, AS_PROGRAM, 16, legionna_state )
 
 	AM_RANGE(0x100420, 0x100421) AM_DEVWRITE("raiden2cop", raiden2cop_device, cop_itoa_low_w)
 	AM_RANGE(0x100422, 0x100423) AM_DEVWRITE("raiden2cop", raiden2cop_device, cop_itoa_high_w)
-	AM_RANGE(0x100424, 0x100425) AM_DEVWRITE("raiden2cop", raiden2cop_device, cop_itoa_digit_count_w)
+	AM_RANGE(0x100424, 0x100425) AM_DEVWRITE("raiden2cop", raiden2cop_device, cop_itoa_mode_w)
 	AM_RANGE(0x100428, 0x100429) AM_DEVWRITE("raiden2cop", raiden2cop_device, cop_dma_v1_w)
 	AM_RANGE(0x10042a, 0x10042b) AM_DEVWRITE("raiden2cop", raiden2cop_device, cop_dma_v2_w)
 	AM_RANGE(0x10042c, 0x10042d) AM_DEVREADWRITE("raiden2cop", raiden2cop_device, cop_prng_maxvalue_r, cop_prng_maxvalue_w)
@@ -115,10 +124,12 @@ static ADDRESS_MAP_START( legionna_cop_mem, AS_PROGRAM, 16, legionna_state )
 	AM_RANGE(0x10043c, 0x10043d) AM_DEVWRITE("raiden2cop", raiden2cop_device, cop_pgm_trigger_w)
 	//AM_RANGE(0x10043e, 0x10043f) AM_DEVWRITE("raiden2cop", raiden2cop_device,)    /*  0 in all 68k based games,   0xffff in raiden2 / raidendx,   0x2000 in zeroteam / xsedae , it's always set up just before the 0x474 register */
 
+	AM_RANGE(0x100440, 0x100441) AM_DEVWRITE("raiden2cop", raiden2cop_device, cop_unk_param_a_w)
+	AM_RANGE(0x100442, 0x100443) AM_DEVWRITE("raiden2cop", raiden2cop_device, cop_unk_param_b_w)
 	AM_RANGE(0x100444, 0x100445) AM_DEVWRITE("raiden2cop", raiden2cop_device, cop_scale_w)
-	AM_RANGE(0x100446, 0x100447) AM_DEVWRITE("raiden2cop", raiden2cop_device, cop_rom_addr_unk_w) // 68k
-	AM_RANGE(0x100448, 0x100449) AM_DEVWRITE("raiden2cop", raiden2cop_device, cop_rom_addr_lo_w) // 68k
-	AM_RANGE(0x10044a, 0x10044b) AM_DEVWRITE("raiden2cop", raiden2cop_device, cop_rom_addr_hi_w) // 68k
+	AM_RANGE(0x100446, 0x100447) AM_DEVWRITE("raiden2cop", raiden2cop_device, cop_rom_addr_hi_w) // cupsoc
+	AM_RANGE(0x100448, 0x100449) AM_DEVWRITE("raiden2cop", raiden2cop_device, cop_rom_addr_lo_w) // cupsoc
+	AM_RANGE(0x10044a, 0x10044b) AM_DEVWRITE("raiden2cop", raiden2cop_device, cop_precmd_w) // cupsoc
 
 	AM_RANGE(0x100450, 0x100451) AM_DEVWRITE("raiden2cop", raiden2cop_device, cop_sort_ram_addr_hi_w)
 	AM_RANGE(0x100452, 0x100453) AM_DEVWRITE("raiden2cop", raiden2cop_device, cop_sort_ram_addr_lo_w)
@@ -169,7 +180,7 @@ static ADDRESS_MAP_START( legionna_map, AS_PROGRAM, 16, legionna_state )
 	AM_RANGE(0x100000, 0x1003ff) AM_RAM
 	AM_RANGE(0x100470, 0x100471) AM_WRITENOP // toggles 0x2000 / 0x0000, tile bank on some games
 	AM_RANGE(0x100600, 0x10063f) AM_DEVREADWRITE("crtc", seibu_crtc_device, read, write)
-	AM_RANGE(0x100680, 0x100681) AM_WRITENOP // writes 0x0000
+	AM_RANGE(0x100680, 0x100681) AM_WRITENOP // D0 written on every update
 	AM_RANGE(0x100700, 0x10071f) AM_READWRITE(sound_comms_r,sound_comms_w)
 	AM_RANGE(0x100740, 0x100741) AM_READ_PORT("DSW1")
 	AM_RANGE(0x100744, 0x100745) AM_READ_PORT("PLAYERS12")
@@ -191,6 +202,7 @@ static ADDRESS_MAP_START( heatbrl_map, AS_PROGRAM, 16, legionna_state )
 	AM_RANGE(0x000000, 0x07ffff) AM_ROM
 	AM_RANGE(0x100000, 0x1003ff) AM_RAM
 	AM_RANGE(0x100470, 0x100471) AM_WRITE(heatbrl_setgfxbank)
+	AM_RANGE(0x100600, 0x100601) AM_WRITENOP // 0xffff written on every update
 	AM_RANGE(0x100640, 0x10068f) AM_DEVREADWRITE("crtc", seibu_crtc_device, read, write)
 	AM_RANGE(0x100740, 0x100741) AM_READ_PORT("DSW1")
 	AM_RANGE(0x100744, 0x100745) AM_READ_PORT("PLAYERS12")
@@ -212,6 +224,7 @@ static ADDRESS_MAP_START( godzilla_map, AS_PROGRAM, 16, legionna_state )
 	AM_RANGE(0x100000, 0x1003ff) AM_RAM
 	AM_RANGE(0x100470, 0x100471) AM_WRITE(denjinmk_setgfxbank)
 	AM_RANGE(0x100600, 0x10063f) AM_DEVREADWRITE("crtc", seibu_crtc_device, read, write)
+	AM_RANGE(0x100680, 0x100681) AM_WRITENOP // D0 written on every update
 	AM_RANGE(0x100700, 0x10071f) AM_READWRITE(sound_comms_r,sound_comms_w)
 	AM_RANGE(0x100740, 0x100741) AM_READ_PORT("DSW1")
 	AM_RANGE(0x100744, 0x100745) AM_READ_PORT("PLAYERS12")
@@ -246,6 +259,7 @@ static ADDRESS_MAP_START( denjinmk_map, AS_PROGRAM, 16, legionna_state )
 	AM_RANGE(0x100000, 0x1003ff) AM_RAM
 	AM_RANGE(0x100470, 0x100471) AM_WRITE(denjinmk_setgfxbank)
 	AM_RANGE(0x100600, 0x10063f) AM_DEVREADWRITE("crtc", seibu_crtc_device, read, write)
+	AM_RANGE(0x100680, 0x100681) AM_WRITENOP // D0 written on every update
 	AM_RANGE(0x100700, 0x10071f) AM_READWRITE(sound_comms_r,sound_comms_w)
 	AM_RANGE(0x100740, 0x100741) AM_READ_PORT("DSW1")
 	AM_RANGE(0x100744, 0x100745) AM_READ_PORT("PLAYERS12")
@@ -269,7 +283,9 @@ static ADDRESS_MAP_START( grainbow_map, AS_PROGRAM, 16, legionna_state )
 	AM_IMPORT_FROM( legionna_cop_mem )
 	AM_RANGE(0x000000, 0x0fffff) AM_ROM
 	AM_RANGE(0x100000, 0x1003ff) AM_RAM
+	AM_RANGE(0x100480, 0x100487) AM_WRITE(grainbow_layer_config_w) // probably a COP feature
 	AM_RANGE(0x100600, 0x10063f) AM_DEVREADWRITE("crtc", seibu_crtc_device, read, write)
+	AM_RANGE(0x100680, 0x100681) AM_WRITENOP // D0 written on every update
 	AM_RANGE(0x100700, 0x10071f) AM_READWRITE(sound_comms_r,sound_comms_w)
 	AM_RANGE(0x100740, 0x100741) AM_READ_PORT("DSW1")
 	AM_RANGE(0x100744, 0x100745) AM_READ_PORT("PLAYERS12")
@@ -293,6 +309,7 @@ static ADDRESS_MAP_START( cupsoc_mem, AS_PROGRAM, 16, legionna_state )
 	AM_RANGE(0x000000, 0x0fffff) AM_ROM
 	AM_RANGE(0x100000, 0x1003ff) AM_RAM
 	AM_RANGE(0x100600, 0x10063f) AM_DEVREADWRITE("crtc", seibu_crtc_device, read, write)
+	AM_RANGE(0x100680, 0x100681) AM_WRITENOP // D0 written on every update
 	AM_RANGE(0x100700, 0x10071f) AM_READWRITE(sound_comms_r,sound_comms_w)
 	AM_RANGE(0x100740, 0x100741) AM_READ_PORT("DSW1")
 	AM_RANGE(0x100744, 0x100745) AM_READ_PORT("PLAYERS12")
@@ -320,6 +337,7 @@ static ADDRESS_MAP_START( cupsocs_mem, AS_PROGRAM, 16, legionna_state )
 	AM_RANGE(0x100000, 0x1003ff) AM_RAM
 	AM_RANGE(0x100600, 0x10060f) AM_DEVREADWRITE("crtc", seibu_crtc_device, read, write)//?
 	AM_RANGE(0x100640, 0x10067f) AM_DEVREADWRITE("crtc", seibu_crtc_device, read, write)
+	AM_RANGE(0x100680, 0x100681) AM_WRITENOP // D0 written on every update
 	AM_RANGE(0x100700, 0x100701) AM_READ_PORT("DSW1")
 	AM_RANGE(0x100704, 0x100705) AM_READ_PORT("PLAYERS12")
 	AM_RANGE(0x100708, 0x100709) AM_READ_PORT("PLAYERS34")
@@ -347,6 +365,7 @@ static ADDRESS_MAP_START( cupsocbl_mem, AS_PROGRAM, 16, legionna_state )
 	//AM_RANGE(0x100000, 0x1003ff) AM_RAM
 	AM_RANGE(0x100600, 0x10060f) AM_DEVREADWRITE("crtc", seibu_crtc_device, read, write)//?
 	AM_RANGE(0x100640, 0x10067f) AM_DEVREADWRITE("crtc", seibu_crtc_device, read, write)
+	AM_RANGE(0x100680, 0x100681) AM_WRITENOP // D0 written on every update
 	AM_RANGE(0x100700, 0x100701) AM_READ_PORT("DSW1")
 	AM_RANGE(0x100704, 0x100705) AM_READ_PORT("PLAYERS12")
 	AM_RANGE(0x100708, 0x100709) AM_READ_PORT("PLAYERS34")
@@ -402,22 +421,22 @@ static INPUT_PORTS_START( legionna )
 	PORT_BIT( 0xff00, IP_ACTIVE_LOW, IPT_UNKNOWN )
 
 	PORT_START("PLAYERS12")
-	PORT_BIT( 0x0001, IP_ACTIVE_LOW,  IPT_JOYSTICK_UP ) PORT_8WAY
-	PORT_BIT( 0x0002, IP_ACTIVE_LOW,  IPT_JOYSTICK_DOWN ) PORT_8WAY
-	PORT_BIT( 0x0004, IP_ACTIVE_LOW,  IPT_JOYSTICK_LEFT ) PORT_8WAY
-	PORT_BIT( 0x0008, IP_ACTIVE_LOW,  IPT_JOYSTICK_RIGHT ) PORT_8WAY
-	PORT_BIT( 0x0010, IP_ACTIVE_LOW,  IPT_BUTTON1 )
-	PORT_BIT( 0x0020, IP_ACTIVE_LOW,  IPT_BUTTON2 )
-	PORT_BIT( 0x0040, IP_ACTIVE_LOW,  IPT_UNKNOWN )
-	PORT_BIT( 0x0080, IP_ACTIVE_LOW,  IPT_UNKNOWN )
-	PORT_BIT( 0x0100, IP_ACTIVE_LOW,  IPT_JOYSTICK_UP ) PORT_8WAY PORT_COCKTAIL
-	PORT_BIT( 0x0200, IP_ACTIVE_LOW,  IPT_JOYSTICK_DOWN ) PORT_8WAY PORT_COCKTAIL
-	PORT_BIT( 0x0400, IP_ACTIVE_LOW,  IPT_JOYSTICK_LEFT ) PORT_8WAY PORT_COCKTAIL
-	PORT_BIT( 0x0800, IP_ACTIVE_LOW,  IPT_JOYSTICK_RIGHT ) PORT_8WAY PORT_COCKTAIL
-	PORT_BIT( 0x1000, IP_ACTIVE_LOW,  IPT_BUTTON1 ) PORT_COCKTAIL
-	PORT_BIT( 0x2000, IP_ACTIVE_LOW,  IPT_BUTTON2 ) PORT_COCKTAIL
-	PORT_BIT( 0x4000, IP_ACTIVE_LOW,  IPT_UNKNOWN )
-	PORT_BIT( 0x8000, IP_ACTIVE_LOW,  IPT_UNKNOWN )
+	PORT_BIT( 0x0001, IP_ACTIVE_LOW,  IPT_JOYSTICK_UP ) PORT_8WAY PORT_PLAYER(1)
+	PORT_BIT( 0x0002, IP_ACTIVE_LOW,  IPT_JOYSTICK_DOWN ) PORT_8WAY PORT_PLAYER(1)
+	PORT_BIT( 0x0004, IP_ACTIVE_LOW,  IPT_JOYSTICK_LEFT ) PORT_8WAY PORT_PLAYER(1)
+	PORT_BIT( 0x0008, IP_ACTIVE_LOW,  IPT_JOYSTICK_RIGHT ) PORT_8WAY PORT_PLAYER(1)
+	PORT_BIT( 0x0010, IP_ACTIVE_LOW,  IPT_BUTTON1 ) PORT_PLAYER(1)
+	PORT_BIT( 0x0020, IP_ACTIVE_LOW,  IPT_BUTTON2 ) PORT_PLAYER(1)
+	PORT_BIT( 0x0040, IP_ACTIVE_LOW,  IPT_UNKNOWN ) // ???
+	PORT_BIT( 0x0080, IP_ACTIVE_LOW,  IPT_UNKNOWN ) // ???
+	PORT_BIT( 0x0100, IP_ACTIVE_LOW,  IPT_JOYSTICK_UP ) PORT_8WAY PORT_PLAYER(2)
+	PORT_BIT( 0x0200, IP_ACTIVE_LOW,  IPT_JOYSTICK_DOWN ) PORT_8WAY PORT_PLAYER(2)
+	PORT_BIT( 0x0400, IP_ACTIVE_LOW,  IPT_JOYSTICK_LEFT ) PORT_8WAY PORT_PLAYER(2)
+	PORT_BIT( 0x0800, IP_ACTIVE_LOW,  IPT_JOYSTICK_RIGHT ) PORT_8WAY PORT_PLAYER(2)
+	PORT_BIT( 0x1000, IP_ACTIVE_LOW,  IPT_BUTTON1 ) PORT_PLAYER(2)
+	PORT_BIT( 0x2000, IP_ACTIVE_LOW,  IPT_BUTTON2 ) PORT_PLAYER(2)
+	PORT_BIT( 0x4000, IP_ACTIVE_LOW,  IPT_UNKNOWN ) // ???
+	PORT_BIT( 0x8000, IP_ACTIVE_LOW,  IPT_UNKNOWN ) // ???
 
 	PORT_START("DSW1")
 	PORT_DIPNAME( 0x001f, 0x001f, DEF_STR( Coinage ) )
@@ -474,7 +493,11 @@ static INPUT_PORTS_START( legionna )
 	PORT_DIPSETTING(      0x8000, DEF_STR( On ) )
 
 	PORT_START("PLAYERS34")
-	PORT_BIT( 0xffff, IP_ACTIVE_LOW, IPT_UNKNOWN )
+	PORT_BIT( 0x000f, IP_ACTIVE_LOW, IPT_UNKNOWN )
+	PORT_BIT( 0x00f0, IP_ACTIVE_LOW, IPT_UNKNOWN ) // Some sort of rotational input?
+	PORT_BIT( 0x0100, IP_ACTIVE_LOW, IPT_UNKNOWN ) // ???
+	PORT_BIT( 0x0200, IP_ACTIVE_LOW, IPT_UNKNOWN ) // Also read but not used
+	PORT_BIT( 0xfc00, IP_ACTIVE_LOW, IPT_UNKNOWN )
 INPUT_PORTS_END
 
 
@@ -726,12 +749,11 @@ static INPUT_PORTS_START( grainbow )
 	PORT_DIPSETTING(      0x0003, "3")
 	PORT_DIPSETTING(      0x0000, "5")
 	PORT_DIPSETTING(      0x0001, "4")
-	PORT_DIPNAME( 0x0004, 0x0004, DEF_STR( Unknown ) )
-	PORT_DIPSETTING(      0x0004, DEF_STR( Off ) )
-	PORT_DIPSETTING(      0x0000, DEF_STR( On ) )
-	PORT_DIPNAME( 0x0008, 0x0008, DEF_STR( Unknown ) )
-	PORT_DIPSETTING(      0x0008, DEF_STR( Off ) )
-	PORT_DIPSETTING(      0x0000, DEF_STR( On ) )
+	PORT_DIPNAME( 0x000c, 0x000c, DEF_STR( Difficulty ) ) // ???
+	PORT_DIPSETTING(      0x000c, "2" ) // Internal value stored at 0x1086cc and often used as table offset
+	PORT_DIPSETTING(      0x0008, "0" )
+	PORT_DIPSETTING(      0x0004, "4" )
+	//PORT_DIPSETTING(      0x0000, "4" ) // Was one of these settings intended to be 6?
 	PORT_DIPNAME( 0x00f0, 0x00f0, DEF_STR( Coin_A ) )
 	PORT_DIPSETTING(      0x0000, DEF_STR( Free_Play ) )
 	PORT_DIPSETTING(      0x00a0, DEF_STR( 6C_1C ) )
@@ -752,7 +774,7 @@ static INPUT_PORTS_START( grainbow )
 	PORT_DIPNAME( 0x0100, 0x0100, DEF_STR( Flip_Screen ) )
 	PORT_DIPSETTING(      0x0100, DEF_STR( Off ) )
 	PORT_DIPSETTING(      0x0000, DEF_STR( On ) )
-	PORT_DIPNAME( 0x0200, 0x0200, DEF_STR( Unknown ) )
+	PORT_DIPNAME( 0x0200, 0x0200, DEF_STR( Unknown ) ) // Dead code?
 	PORT_DIPSETTING(      0x0200, DEF_STR( Off ) )
 	PORT_DIPSETTING(      0x0000, DEF_STR( On ) )
 	PORT_DIPNAME( 0x0400, 0x0400, DEF_STR( Unknown ) )

--- a/src/mame/drivers/r2dx_v33.cpp
+++ b/src/mame/drivers/r2dx_v33.cpp
@@ -17,7 +17,8 @@ Then it puts settings at 0x9e08 and 0x9e0a (bp 91acb)
      - EEPROM contains high scores, but they don't get restored? (original bug?)
 
     New Zero Team
-     - 2 Player only? Service mode only shows 2 Players and I don't see a switch
+     - 2 Player only. Service mode only shows 2 Players, and the code confirms that the options
+       for three and four players have been removed from this version.
      - Stages 3 and 1 are swapped, this is correct.
 
     Raiden 2 New / Raiden DX
@@ -635,6 +636,8 @@ static INPUT_PORTS_START( nzerotea )
 	PORT_DIPNAME( 0x8000, 0x8000, DEF_STR( Unknown ) )
 	PORT_DIPSETTING(      0x8000, DEF_STR( Off ) )
 	PORT_DIPSETTING(      0x0000, DEF_STR( On ) )
+
+	// The P3_P4 port is never read in this version
 
 	PORT_START("DSW") // taken from zeroteam, except last dip is service mode
 	PORT_DIPNAME( 0x0007, 0x0007, DEF_STR( Coin_A ) ) PORT_DIPLOCATION("SW1:!1,!2,!3")

--- a/src/mame/includes/legionna.h
+++ b/src/mame/includes/legionna.h
@@ -34,6 +34,7 @@ public:
 	std::unique_ptr<UINT16[]> m_textram;
 	std::unique_ptr<UINT16[]> m_scrollram16;
 	UINT16 m_layer_disable;
+	std::unique_ptr<UINT16[]> m_layer_config;
 	int m_sprite_xoffs;
 	int m_sprite_yoffs;
 	tilemap_t *m_background_layer;
@@ -61,6 +62,7 @@ public:
 	DECLARE_WRITE16_MEMBER(sound_comms_w);
 	DECLARE_WRITE16_MEMBER(denjinmk_setgfxbank);
 	DECLARE_WRITE16_MEMBER(heatbrl_setgfxbank);
+	DECLARE_WRITE16_MEMBER(grainbow_layer_config_w);
 
 	DECLARE_DRIVER_INIT(legiongfx);
 	DECLARE_DRIVER_INIT(cupsoc_debug);

--- a/src/mame/machine/raiden2cop.h
+++ b/src/mame/machine/raiden2cop.h
@@ -16,9 +16,6 @@
 #define MCFG_RAIDEN2COP_VIDEORAM_OUT_CB(_devcb) \
 	devcb = &raiden2cop_device::set_m_videoramout_cb(*device, DEVCB_##_devcb);
 
-#define MCFG_ITOA_UNUSED_DIGIT_VALUE(value) \
-	raiden2cop_device::set_itoa_unused_digit_value(*device, value);
-
 #define MCFG_CPU_IS_68K(value) \
 	raiden2cop_device::set_cpu_is_68k(*device, value);
 
@@ -87,15 +84,12 @@ public:
 
 	DECLARE_WRITE16_MEMBER( cop_itoa_low_w );
 	DECLARE_WRITE16_MEMBER( cop_itoa_high_w );
-	DECLARE_WRITE16_MEMBER( cop_itoa_digit_count_w );
+	DECLARE_WRITE16_MEMBER( cop_itoa_mode_w );
 	DECLARE_READ16_MEMBER ( cop_itoa_digits_r );
 
 	UINT32 cop_itoa;
-	UINT16 cop_itoa_digit_count;
+	UINT16 cop_itoa_mode;
 	UINT8 cop_itoa_digits[10];
-	UINT8 m_cop_itoa_unused_digit_value;
-
-	static void set_itoa_unused_digit_value(device_t &device, int value) { downcast<raiden2cop_device &>(device).m_cop_itoa_unused_digit_value = value; }
 
 	// Main COP functionality
 
@@ -228,8 +222,12 @@ public:
 	int m_cop_sprite_dma_size;
 
 	// misc 68k
-	UINT16 m_cop_rom_addr_lo,m_cop_rom_addr_hi,m_cop_rom_addr_unk;
-	DECLARE_WRITE16_MEMBER(cop_rom_addr_unk_w);
+	UINT16 m_cop_unk_param_a,m_cop_unk_param_b;
+	DECLARE_WRITE16_MEMBER(cop_unk_param_a_w);
+	DECLARE_WRITE16_MEMBER(cop_unk_param_b_w);
+
+	UINT16 m_cop_rom_addr_lo,m_cop_rom_addr_hi,m_cop_precmd;
+	DECLARE_WRITE16_MEMBER(cop_precmd_w);
 	DECLARE_WRITE16_MEMBER(cop_rom_addr_lo_w);
 	DECLARE_WRITE16_MEMBER(cop_rom_addr_hi_w);
 

--- a/src/mame/video/legionna.cpp
+++ b/src/mame/video/legionna.cpp
@@ -106,6 +106,12 @@ WRITE16_MEMBER(legionna_state::videowrite_cb_w)
 	}
 }
 
+WRITE16_MEMBER(legionna_state::grainbow_layer_config_w)
+{
+	// (0x8000|0x1ff), 0x200, 0x1ff, 0x200 written in sequence at startup
+	COMBINE_DATA(&m_layer_config[offset]);
+}
+
 WRITE16_MEMBER(legionna_state::legionna_background_w)
 {
 	COMBINE_DATA(&m_back_data[offset]);
@@ -291,6 +297,8 @@ VIDEO_START_MEMBER(legionna_state,grainbow)
 
 	m_has_extended_banking = 0;
 	m_has_extended_priority = 1;
+
+	m_layer_config = std::make_unique<UINT16[]>(0x8/2);
 }
 
 VIDEO_START_MEMBER(legionna_state,godzilla)
@@ -299,7 +307,6 @@ VIDEO_START_MEMBER(legionna_state,godzilla)
 
 	m_has_extended_banking = 1;
 	m_has_extended_priority = 0;
-
 }
 
 /*************************************************************************


### PR DESCRIPTION
- grainbow: Correct score and credits display
- heatbrl: Suppress "divide by zero?" message since code actually checks for it (no, still not working)
- legionna: 2P inputs now designated as such
- zeroteam: Hook up PRNG (definitely used in this game)