### PR TITLE
Hp9845: added support for graphic video

### DIFF
--- a/src/devices/cpu/hphybrid/hphybrid.cpp
+++ b/src/devices/cpu/hphybrid/hphybrid.cpp
@@ -1092,12 +1092,7 @@ void hp_hybrid_cpu_device::handle_dma(void)
 								m_icount -= 9;
 				}
 
-				// This is the one of the biggest question marks: is the DMA automatically disabled on TC?
-				// Here we assume it is. After all it would make no difference because there is no way
-				// to read the DMA enable flag back, so each time the DMA is needed it has to be enabled again.
-				if (tc) {
-								BIT_CLR(m_flags , HPHYBRID_DMAEN_BIT);
-				}
+                                // Mystery solved: DMA is not automatically disabled at TC
 }
 
 UINT16 hp_hybrid_cpu_device::RIO(UINT8 pa , UINT8 ic)
@@ -1559,7 +1554,7 @@ UINT32 hp_5061_3001_cpu_device::add_mae(aec_cases_t aec_case , UINT16 addr)
 				break;
 
 		case AEC_CASE_D:
-				bsc_reg = HP_REG_R37_ADDR;
+				bsc_reg = top_half ? HP_REG_R32_ADDR : HP_REG_R37_ADDR;
 				break;
 
 				case AEC_CASE_I:

--- a/src/devices/cpu/hphybrid/hphybrid.cpp
+++ b/src/devices/cpu/hphybrid/hphybrid.cpp
@@ -1092,7 +1092,7 @@ void hp_hybrid_cpu_device::handle_dma(void)
 								m_icount -= 9;
 				}
 
-                                // Mystery solved: DMA is not automatically disabled at TC
+                                // Mystery solved: DMA is not automatically disabled at TC (test of 9845's graphic memory relies on this to work)
 }
 
 UINT16 hp_hybrid_cpu_device::RIO(UINT8 pa , UINT8 ic)

--- a/src/devices/cpu/hphybrid/hphybrid.cpp
+++ b/src/devices/cpu/hphybrid/hphybrid.cpp
@@ -131,6 +131,11 @@ WRITE_LINE_MEMBER(hp_hybrid_cpu_device::flag_w)
 		}
 }
 
+UINT8 hp_hybrid_cpu_device::pa_r(void) const
+{
+        return CURRENT_PA;
+}
+
 hp_hybrid_cpu_device::hp_hybrid_cpu_device(const machine_config &mconfig, device_type type, const char *name, const char *tag, device_t *owner, UINT32 clock, const char *shortname , UINT8 addrwidth)
 		: cpu_device(mconfig, type, name, tag, owner, clock, shortname, __FILE__),
 			m_pa_changed_func(*this),

--- a/src/devices/cpu/hphybrid/hphybrid.h
+++ b/src/devices/cpu/hphybrid/hphybrid.h
@@ -87,6 +87,8 @@ public:
 				DECLARE_WRITE_LINE_MEMBER(status_w);
 				DECLARE_WRITE_LINE_MEMBER(flag_w);
 
+        UINT8 pa_r(void) const;
+
 		template<class _Object> static devcb_base &set_pa_changed_func(device_t &device, _Object object) { return downcast<hp_hybrid_cpu_device &>(device).m_pa_changed_func.set_callback(object); }
 
 protected:

--- a/src/mame/drivers/hp9845.cpp
+++ b/src/mame/drivers/hp9845.cpp
@@ -692,8 +692,11 @@ void hp9845b_state::advance_gv_fsm(bool ds , bool trigger)
 
                 switch (m_gv_fsm_state) {
                 case GV_STAT_WAIT_DS_0:
-                        // Wait for data strobe (r/w on r4 or r6)
-                        if (ds) {
+                        if ((m_gv_cmd & 0xc) == 0xc) {
+                                // Read command (11xx)
+                                m_gv_fsm_state = GV_STAT_WAIT_MEM_0;
+                        } else if (ds) {
+                                // Wait for data strobe (r/w on r4 or r6)
                                 m_gv_fsm_state = GV_STAT_WAIT_TRIG_0;
                         } else {
                                 get_out = true;
@@ -707,13 +710,8 @@ void hp9845b_state::advance_gv_fsm(bool ds , bool trigger)
                                         // Not a cursor command
                                         // Load memory address
                                         m_gv_io_counter = ~m_gv_data_w & GVIDEO_ADDR_MASK;
-                                        if (BIT(m_gv_cmd , 2)) {
-                                                // Read command (11xx)
-                                                m_gv_fsm_state = GV_STAT_WAIT_MEM_0;
-                                        } else {
-                                                // Write commands (10xx)
-                                                m_gv_fsm_state = GV_STAT_WAIT_DS_2;
-                                        }
+                                        // Write commands (10xx)
+                                        m_gv_fsm_state = GV_STAT_WAIT_DS_2;
                                 } else {
                                         // Cursor command (0xxx)
                                         if (BIT(m_gv_cmd , 2)) {


### PR DESCRIPTION
Hi,
I pushed a set of changes to hp9845b driver to support graphic video. If you want something very basic to try, type in this program:
10 PLOTTER IS "GRAPHICS"
20 GRAPHICS
30 FRAME
40 END
and RUN it: it should show a rectangle on the border of the screen (wasn't BASIC fun??).
Don't forget that you need to load the "graphics" optional ROM, I'm attaching the image. It can be loaded in any of the optrom slots through the software list facility.
Thanks.
-- F.Ulivi


[graphics.zip](https://github.com/mamedev/mame/files/266172/graphics.zip)
