### PR TITLE
Implement new option to hold down inputs when machine boots

### DIFF
--- a/src/emu/emuopts.cpp
+++ b/src/emu/emuopts.cpp
@@ -150,6 +150,8 @@ const options_entry emu_options::s_option_entries[] =
 	{ OPTION_NATURAL_KEYBOARD ";nat",                    "0",         OPTION_BOOLEAN,    "specifies whether to use a natural keyboard or not" },
 	{ OPTION_JOYSTICK_CONTRADICTORY ";joy_contradictory","0",         OPTION_BOOLEAN,    "enable contradictory direction digital joystick input at the same time" },
 	{ OPTION_COIN_IMPULSE,                               "0",         OPTION_INTEGER,    "set coin impulse time (n<0 disable impulse, n==0 obey driver, 0<n set time n)" },
+	{ OPTION_BOOT_PRESSED,                               nullptr,     OPTION_STRING,     "inputs to be automatically pressed for a short time after booting machine" },
+	{ OPTION_BOOT_PRESSED_TIME,                          "750",       OPTION_INTEGER,    "time to keep inputs pressed after booting (in milliseconds)" },
 
 	// input autoenable options
 	{ nullptr,                                              nullptr,        OPTION_HEADER,     "CORE INPUT AUTOMATIC ENABLE OPTIONS" },

--- a/src/emu/emuopts.h
+++ b/src/emu/emuopts.h
@@ -136,6 +136,8 @@
 #define OPTION_NATURAL_KEYBOARD     "natural"
 #define OPTION_JOYSTICK_CONTRADICTORY   "joystick_contradictory"
 #define OPTION_COIN_IMPULSE         "coin_impulse"
+#define OPTION_BOOT_PRESSED         "boot_pressed"
+#define OPTION_BOOT_PRESSED_TIME    "boot_pressed_time"
 
 // input autoenable options
 #define OPTION_PADDLE_DEVICE        "paddle_device"
@@ -325,6 +327,8 @@ public:
 	bool natural_keyboard() const { return bool_value(OPTION_NATURAL_KEYBOARD); }
 	bool joystick_contradictory() const { return m_joystick_contradictory; }
 	int coin_impulse() const { return m_coin_impulse; }
+	const char *boot_pressed() const { return value(OPTION_BOOT_PRESSED); }
+	int boot_pressed_time() const { return int_value(OPTION_BOOT_PRESSED_TIME); }
 
 	// core debugging options
 	bool log() const { return bool_value(OPTION_LOG); }

--- a/src/emu/ioport.cpp
+++ b/src/emu/ioport.cpp
@@ -96,7 +96,6 @@
 #include "xmlfile.h"
 #include "profiler.h"
 #include "ui/uimain.h"
-#include "uiinput.h"
 
 #include "osdepend.h"
 
@@ -1516,7 +1515,7 @@ ioport_field::~ioport_field()
 
 //-------------------------------------------------
 //  name - return the field name for a given input
-//  field
+//  field (this must never return nullptr)
 //-------------------------------------------------
 
 const char *ioport_field::name() const
@@ -1584,7 +1583,7 @@ const input_seq &ioport_field::defseq(input_seq_type seqtype) const
 ioport_type_class ioport_field::type_class() const
 {
 	ioport_group group = manager().type_group(m_type, m_player);
-	if (group >= IPG_PLAYER1 && group <= IPG_PLAYER8)
+	if (group >= IPG_PLAYER1 && group <= IPG_PLAYER10)
 		return INPUT_CLASS_CONTROLLER;
 
 	if (m_type == IPT_KEYPAD || m_type == IPT_KEYBOARD)
@@ -1843,7 +1842,7 @@ void ioport_field::select_next_setting()
 //  digital field
 //-------------------------------------------------
 
-void ioport_field::frame_update(ioport_value &result, bool mouse_down)
+void ioport_field::frame_update(ioport_value &result)
 {
 	// skip if not enabled
 	if (!enabled())
@@ -1861,14 +1860,15 @@ void ioport_field::frame_update(ioport_value &result, bool mouse_down)
 		return;
 
 	// if the state changed, look for switch down/switch up
-	bool curstate = mouse_down || machine().input().seq_pressed(seq()) || m_digital_value;
-	if (m_live->autofire && !machine().ioport().get_autofire_toggle())
+	bool special_press = manager().is_specially_pressed(*this);
+	bool curstate = special_press || machine().input().seq_pressed(seq()) || m_digital_value;
+	if (m_live->autofire && !manager().get_autofire_toggle())
 	{
 		if (curstate)
 		{
-			if (m_live->autopressed > machine().ioport().get_autofire_delay())
+			if (m_live->autopressed > manager().get_autofire_delay())
 				m_live->autopressed = 0;
-			else if (m_live->autopressed > machine().ioport().get_autofire_delay() / 2)
+			else if (m_live->autopressed > manager().get_autofire_delay() / 2)
 				curstate = false;
 			m_live->autopressed++;
 		}
@@ -1928,7 +1928,7 @@ void ioport_field::frame_update(ioport_value &result, bool mouse_down)
 		curstate = false;
 
 	// additional logic to restrict digital joysticks
-	if (curstate && !m_digital_value && !mouse_down && m_live->joystick != nullptr && m_way != 16 && !machine().options().joystick_contradictory())
+	if (curstate && !m_digital_value && !special_press && m_live->joystick != nullptr && m_way != 16 && !machine().options().joystick_contradictory())
 	{
 		UINT8 mask = (m_way == 4) ? m_live->joystick->current4way() : m_live->joystick->current();
 		if (!(mask & (1 << m_live->joydir)))
@@ -2273,14 +2273,14 @@ void ioport_port::write(ioport_value data, ioport_value mem_mask)
 //  frame_update - once/frame update
 //-------------------------------------------------
 
-void ioport_port::frame_update(ioport_field *mouse_field)
+void ioport_port::frame_update()
 {
 	// start with 0 values for the digital bits
 	m_live->digital = 0;
 
 	// now loop back and modify based on the inputs
 	for (ioport_field &field : fields())
-		field.frame_update(m_live->digital, &field == mouse_field);
+		field.frame_update(m_live->digital);
 
 	// hook for MESS's natural keyboard support
 	manager().natkeyboard().frame_update(*this, m_live->digital);
@@ -2372,6 +2372,24 @@ void ioport_port::init_live_state()
 }
 
 
+//-------------------------------------------------
+//  update_defaults - force an update to the input
+//  port values based on current conditions
+//-------------------------------------------------
+
+void ioport_port::update_defaults(bool flush_defaults)
+{
+	// only clear on the first pass
+	if (flush_defaults)
+		m_live->defvalue = 0;
+
+	// recompute the default value for the entire port
+	for (ioport_field &field : m_fieldlist)
+		if (field.enabled())
+			m_live->defvalue = (m_live->defvalue & ~field.mask()) | (field.live().value & field.mask());
+}
+
+
 
 //**************************************************************************
 //  I/O PORT LIVE STATE
@@ -2420,6 +2438,7 @@ ioport_port_live::ioport_port_live(ioport_port &port)
 ioport_manager::ioport_manager(running_machine &machine)
 	: m_machine(machine),
 		m_safe_to_read(false),
+		m_mouse_field(nullptr),
 		m_natkeyboard(machine),
 		m_last_frame_time(attotime::zero),
 		m_last_delta_nsec(0),
@@ -2451,6 +2470,9 @@ time_t ioport_manager::initialize()
 	// add an exit callback and a frame callback
 	machine().add_notifier(MACHINE_NOTIFY_EXIT, machine_notify_delegate(FUNC(ioport_manager::exit), this));
 	machine().add_notifier(MACHINE_NOTIFY_FRAME, machine_notify_delegate(FUNC(ioport_manager::frame_update_callback), this));
+
+	// add a reset callback
+	machine().add_notifier(MACHINE_NOTIFY_RESET, machine_notify_delegate(FUNC(ioport_manager::reset_callback), this));
 
 	// initialize the default port info from the OSD
 	init_port_types();
@@ -2510,6 +2532,8 @@ time_t ioport_manager::initialize()
 					break;
 				}
 
+	m_boot_pressed_timer = machine().scheduler().timer_alloc(timer_expired_delegate(FUNC(ioport_manager::boot_presses_expired), this));
+	init_boot_presses();
 	m_natkeyboard.initialize();
 	// register callbacks for when we load configurations
 	machine().configuration().config_register("input", config_saveload_delegate(FUNC(ioport_manager::load_config), this), config_saveload_delegate(FUNC(ioport_manager::save_config), this));
@@ -2626,6 +2650,69 @@ void ioport_manager::init_autoselect_devices(int type1, int type2, int type3, co
 
 
 //-------------------------------------------------
+//  init_boot_presses - prepare the list of fields
+//  to be kept pressed at boot time
+//-------------------------------------------------
+
+void ioport_manager::init_boot_presses()
+{
+	const char *pressed_codes = machine().options().boot_pressed();
+
+	m_pressed_fields.clear();
+
+	while (*pressed_codes != '\0')
+	{
+		// copy up to the next comma
+		const char *comma = strchr(pressed_codes, ',');
+		if (comma == nullptr)
+			comma = pressed_codes + strlen(pressed_codes);
+		std::string token(pressed_codes, comma - pressed_codes);
+		pressed_codes = (*comma == '\0') ? comma : comma + 1;
+
+		// eliminate any leading space
+		if (token.length() > 1 && token[0] == ' ')
+			token.erase(0, 1);
+
+		int player;
+		ioport_type type = token_to_input_type(token.c_str(), player);
+
+		// go through the ports and fields defined by the machine
+		bool found = false;
+		for (ioport_port &port : m_portlist)
+		{
+			for (ioport_field &field : port.fields())
+			{
+				// search by input type if we have one
+				// otherwise, try to match on field name (generic or specific)
+				if ((type != IPT_UNKNOWN)
+					? (field.type() == type && field.player() == player)
+					: (token == field.name()))
+				{
+					found = true;
+					m_pressed_fields.push_back(&field);
+				}
+			}
+		}
+
+		if (!found)
+			osd_printf_warning("Could not press %s: field not found\n", token.c_str());
+	}
+}
+
+
+//-------------------------------------------------
+//  boot_presses_expired - remove the boot presses
+//  after a short time
+//-------------------------------------------------
+
+void ioport_manager::boot_presses_expired(void *ptr, INT32 param)
+{
+	m_pressed_fields.clear();
+	machine().options().set_default_value(OPTION_BOOT_PRESSED, "");
+}
+
+
+//-------------------------------------------------
 //  exit - exit callback to ensure we clean up
 //  and close our files
 //-------------------------------------------------
@@ -2648,10 +2735,10 @@ const char *ioport_manager::type_name(ioport_type type, UINT8 player)
 {
 	// if we have a machine, use the live state and quick lookup
 	input_type_entry *entry = m_type_to_entry[type][player];
-	if (entry != nullptr)
+	if (entry != nullptr && entry->name() != nullptr)
 		return entry->name();
 
-	// if we find nothing, return an invalid group
+	// if we find nothing, return a default string (nullptr is not acceptable)
 	return "???";
 }
 
@@ -2796,32 +2883,6 @@ bool ioport_manager::crosshair_position(int player, float &x, float &y)
 
 
 //-------------------------------------------------
-//  update_defaults - force an update to the input
-//  port values based on current conditions
-//-------------------------------------------------
-
-void ioport_manager::update_defaults()
-{
-	// two passes to catch conditionals properly
-	for (int loopnum = 0; loopnum < 2; loopnum++)
-	{
-		// loop over all input ports
-		for (ioport_port &port : m_portlist)
-		{
-			// only clear on the first pass
-			if (loopnum == 0)
-				port.live().defvalue = 0;
-
-			// first compute the default value for the entire port
-			for (ioport_field &field : port.fields())
-				if (field.enabled())
-					port.live().defvalue = (port.live().defvalue & ~field.mask()) | (field.live().value & field.mask());
-		}
-	}
-}
-
-
-//-------------------------------------------------
 //  frame_update - core logic for per-frame input
 //  port updating
 //-------------------------------------------------
@@ -2835,6 +2896,40 @@ digital_joystick &ioport_manager::digjoystick(int player, int number)
 
 	// create a new one
 	return m_joystick_list.append(*global_alloc(digital_joystick(player, number)));
+}
+
+
+//-------------------------------------------------
+//  is_specially_pressed - return true if the
+//  given field is being held down by some special
+//  input that is not specifically bound to it
+//-------------------------------------------------
+
+bool ioport_manager::is_specially_pressed(ioport_field &field)
+{
+	// mouse hit testing
+	if (&field == m_mouse_field)
+		return true;
+
+	// force certain fields to be pressed down
+	for (ioport_field *fieldptr : m_pressed_fields)
+		if (fieldptr == &field)
+			return true;
+
+	// not specially pressed
+	return false;
+}
+
+
+//-------------------------------------------------
+//  reset_callback - callback for machine reset
+//-------------------------------------------------
+
+void ioport_manager::reset_callback()
+{
+	// delay this until reset since timers are time-sensitive
+	if (!m_pressed_fields.empty())
+		m_boot_pressed_timer->adjust(attotime::from_msec(machine().options().boot_pressed_time()));
 }
 
 
@@ -2873,31 +2968,16 @@ g_profiler.start(PROFILER_INPUT);
 		joystick.frame_update();
 
 	// compute default values for all the ports
-	update_defaults();
-
-	// perform mouse hit testing
-	INT32 mouse_target_x, mouse_target_y;
-	bool mouse_button;
-	render_target *mouse_target = machine().ui_input().find_mouse(&mouse_target_x, &mouse_target_y, &mouse_button);
-
-	// if the button is pressed, map the point and determine what was hit
-	ioport_field *mouse_field = nullptr;
-	if (mouse_button && mouse_target != nullptr)
-	{
-		ioport_port *port = nullptr;
-		ioport_value mask;
-		float x, y;
-		if (mouse_target->map_point_input(mouse_target_x, mouse_target_y, port, mask, x, y))
-		{
-			if (port != nullptr)
-				mouse_field = port->field(mask);
-		}
-	}
+	// two passes to catch conditionals properly
+	for (ioport_port &port : m_portlist)
+		port.update_defaults(true);
+	for (ioport_port &port : m_portlist)
+		port.update_defaults(false);
 
 	// loop over all input ports
 	for (ioport_port &port : m_portlist)
 	{
-		port.frame_update(mouse_field);
+		port.frame_update();
 
 		// handle playback/record
 		playback_port(port);

--- a/src/emu/ioport.h
+++ b/src/emu/ioport.h
@@ -1499,8 +1499,8 @@ public:
 	INT32 frame_interpolate(INT32 oldval, INT32 newval);
 	ioport_type token_to_input_type(const char *string, int &player) const;
 	std::string input_type_to_token(ioport_type type, int player);
-	bool is_specially_pressed(ioport_field &field);
 	void set_mouse_field(ioport_field *field) { m_mouse_field = field; }
+	ioport_field *mouse_field() const { return m_mouse_field; }
 
 	// autofire
 	bool get_autofire_toggle() { return m_autofire_toggle; }

--- a/src/emu/ioport.h
+++ b/src/emu/ioport.h
@@ -1171,7 +1171,7 @@ public:
 	void select_next_setting();
 	void crosshair_position(float &x, float &y, bool &gotx, bool &goty);
 	void init_live_state(analog_field *analog);
-	void frame_update(ioport_value &result, bool mouse_down);
+	void frame_update(ioport_value &result);
 	void reduce_mask(ioport_value bits_to_remove) { m_mask &= ~bits_to_remove; }
 
 	// user-controllable settings for a field
@@ -1308,8 +1308,9 @@ public:
 	// other operations
 	ioport_field *field(ioport_value mask) const;
 	void collapse_fields(std::string &errorbuf);
-	void frame_update(ioport_field *mouse_field);
+	void frame_update();
 	void init_live_state();
+	void update_defaults(bool flush_defaults);
 
 private:
 	void insert_field(ioport_field &newfield, ioport_value &disallowedbits, std::string &errorbuf);
@@ -1498,6 +1499,8 @@ public:
 	INT32 frame_interpolate(INT32 oldval, INT32 newval);
 	ioport_type token_to_input_type(const char *string, int &player) const;
 	std::string input_type_to_token(ioport_type type, int player);
+	bool is_specially_pressed(ioport_field &field);
+	void set_mouse_field(ioport_field *field) { m_mouse_field = field; }
 
 	// autofire
 	bool get_autofire_toggle() { return m_autofire_toggle; }
@@ -1509,14 +1512,16 @@ private:
 	// internal helpers
 	void init_port_types();
 	void init_autoselect_devices(int type1, int type2, int type3, const char *option, const char *ananame);
+	void init_boot_presses();
+	void boot_presses_expired(void *ptr, INT32 param);
 
+	void reset_callback();
 	void frame_update_callback();
 	void frame_update();
 
 	ioport_port *port(const char *tag) const { return m_portlist.find(tag); }
 	void exit();
 	input_seq_type token_to_seq_type(const char *string);
-	void update_defaults();
 
 	void load_config(config_type cfg_type, xml_data_node *parentnode);
 	void load_remap_table(xml_data_node *parentnode);
@@ -1549,6 +1554,11 @@ private:
 	running_machine &       m_machine;              // reference to owning machine
 	bool                    m_safe_to_read;         // clear at start; set after state is loaded
 	ioport_list             m_portlist;             // list of input port configurations
+
+	// special fields
+	ioport_field *          m_mouse_field;          // field that is currently being pressed by the mouse
+	std::vector<ioport_field *> m_pressed_fields;   // fields to be automatically held down
+	emu_timer *             m_boot_pressed_timer;
 
 	// types
 	simple_list<input_type_entry> m_typelist;       // list of live type states

--- a/src/emu/machine.cpp
+++ b/src/emu/machine.cpp
@@ -202,7 +202,7 @@ void running_machine::start()
 	// allocate a soft_reset timer
 	m_soft_reset_timer = m_scheduler.timer_alloc(timer_expired_delegate(FUNC(running_machine::soft_reset), this));
 
-	// intialize UI input
+	// initialize UI input
 	m_ui_input = make_unique_clear<ui_input_manager>(*this);
 
 	// init the osd layer

--- a/src/emu/uiinput.cpp
+++ b/src/emu/uiinput.cpp
@@ -68,6 +68,21 @@ void ui_input_manager::frame_update()
 		if (!pressed || m_seqpressed[code] != SEQ_PRESSED_RESET)
 			m_seqpressed[code] = pressed;
 	}
+
+	// if the mouse button is pressed, map the point and determine what was hit
+	ioport_field *mouse_field = nullptr;
+	if (m_current_mouse_down && m_current_mouse_target != nullptr)
+	{
+		ioport_port *port = nullptr;
+		ioport_value mask;
+		float x, y;
+		if (m_current_mouse_target->map_point_input(m_current_mouse_x, m_current_mouse_y, port, mask, x, y))
+		{
+			if (port != nullptr)
+				mouse_field = port->field(mask);
+		}
+	}
+	machine().ioport().set_mouse_field(mouse_field);
 }
 
 

--- a/src/emu/uiinput.h
+++ b/src/emu/uiinput.h
@@ -12,7 +12,7 @@
 #ifndef __UIINPUT_H__
 #define __UIINPUT_H__
 
-#include "render.h"
+class render_target;
 
 
 /***************************************************************************

--- a/src/emu/validity.cpp
+++ b/src/emu/validity.cpp
@@ -872,12 +872,20 @@ void validity_checker::validate_inputs()
 				// verify dip switches
 				if (field.type() == IPT_DIPSWITCH)
 				{
-					// dip switch fields must have a name
-					if (field.name() == nullptr)
-						osd_printf_error("DIP switch has a nullptr name\n");
+					// dip switch fields must have a specific name
+					if (field.specific_name() == nullptr)
+						osd_printf_error("DIP switch has no specific name\n");
 
 					// verify the settings list
 					validate_dip_settings(field);
+				}
+
+				// verify config settings
+				if (field.type() == IPT_CONFIG)
+				{
+					// config fields must have a specific name
+					if (field.specific_name() == nullptr)
+						osd_printf_error("Config switch has no specific name\n");
 				}
 
 				// verify names

--- a/src/frontend/mame/luaengine.cpp
+++ b/src/frontend/mame/luaengine.cpp
@@ -664,7 +664,7 @@ luabridge::LuaRef lua_engine::l_ioports_port_get_fields(const ioport_port *i)
 	luabridge::LuaRef f_table = luabridge::LuaRef::newTable(L);
 
 	for (ioport_field &field : p->fields()) {
-		if(field.name())
+		if (field.type_class() != INPUT_CLASS_INTERNAL)
 			f_table[field.name()] = &field;
 	}
 
@@ -1985,7 +1985,7 @@ void lua_engine::update_machine()
 		{
 			for (ioport_field &field : port.fields())
 			{
-				if (field.name())
+				if (field.type_class() != INPUT_CLASS_INTERNAL)
 				{
 					push(m_lua_state, &field, tname_ioport);
 					lua_setfield(m_lua_state, -2, field.name());

--- a/src/frontend/mame/ui/cheatopt.cpp
+++ b/src/frontend/mame/ui/cheatopt.cpp
@@ -263,7 +263,7 @@ void ui_menu_autofire::populate()
 		bool is_first_button = true;
 		for (ioport_field &field : port.fields())
 		{
-			if ((field.name()) && ((field.type() >= IPT_BUTTON1 && field.type() <= IPT_BUTTON16))) // IPT_BUTTON1 + 15)))
+			if (field.type() >= IPT_BUTTON1 && field.type() <= IPT_BUTTON16)
 			{
 				menu_items++;
 				ioport_field::user_settings settings;

--- a/src/frontend/mame/ui/inputmap.cpp
+++ b/src/frontend/mame/ui/inputmap.cpp
@@ -167,20 +167,19 @@ void ui_menu_input_specific::populate()
 		port_count++;
 		for (ioport_field &field : port.fields())
 		{
-			const char *name = field.name();
+			ioport_type_class type_class = field.type_class();
 
 			/* add if we match the group and we have a valid name */
-			if (name != nullptr && field.enabled() &&
-				((field.type() == IPT_OTHER && field.name() != nullptr) || machine().ioport().type_group(field.type(), field.player()) != IPG_INVALID))
+			if (field.enabled() && (type_class == INPUT_CLASS_CONTROLLER || type_class == INPUT_CLASS_MISC))
 			{
 				input_seq_type seqtype;
 				UINT32 sortorder;
 
 				/* determine the sorting order */
-				if (field.type() >= IPT_START1 && field.type() < IPT_ANALOG_LAST)
+				if (type_class == INPUT_CLASS_CONTROLLER)
 				{
 					sortorder = (field.type() << 2) | (field.player() << 12);
-					if (strcmp(field.device().tag(), ":"))
+					if (field.device().owner() != nullptr)
 						sortorder |= (port_count & 0xfff) * 0x10000;
 				}
 				else
@@ -200,7 +199,7 @@ void ui_menu_input_specific::populate()
 					item->defseq = &field.defseq(seqtype);
 					item->sortorder = sortorder + suborder[seqtype];
 					item->type = field.is_analog() ? (INPUT_TYPE_ANALOG + seqtype) : INPUT_TYPE_DIGITAL;
-					item->name = name;
+					item->name = field.name();
 					item->owner_name = field.device().tag();
 					item->next = itemlist;
 					itemlist = item;

--- a/src/osd/modules/debugger/debugimgui.cpp
+++ b/src/osd/modules/debugger/debugimgui.cpp
@@ -4,6 +4,7 @@
 
 #include "emu.h"
 #include "imgui/imgui.h"
+#include "render.h"
 #include "uiinput.h"
 
 #include "debug/debugvw.h"

--- a/src/osd/sdl/window.h
+++ b/src/osd/sdl/window.h
@@ -11,6 +11,8 @@
 #ifndef __SDLWINDOW__
 #define __SDLWINDOW__
 
+#include "render.h"
+
 #include "osdsdl.h"
 #include "video.h"
 


### PR DESCRIPTION
New -boot-pressed option allows a number of I/O fields to be specified on the command line. These buttons will be held down for some milliseconds (configurable, default to 750) after resetting the machine, after which the presses are permanently cleared.

Disallow ioport_field::name() from returning nullptr; there are too many places in the core that don't check for it and shouldn't have to. Use type_class instead to determine if a field is an anonymous internal input. (nw)

Move mouse hit targeting into uiinput.cpp, eliminating another dependency. (nw)