### PR TITLE
Changed the backing representation of OPTION_UI from being a string t…

### DIFF
--- a/src/emu/emuopts.cpp
+++ b/src/emu/emuopts.cpp
@@ -219,6 +219,7 @@ emu_options::emu_options()
 , m_joystick_contradictory(false)
 , m_sleep(true)
 , m_refresh_speed(false)
+, m_ui(UI_CABINET)
 {
 	add_entries(emu_options::s_option_entries);
 }
@@ -263,4 +264,10 @@ void emu_options::update_cached_options()
 	m_joystick_contradictory = bool_value(OPTION_JOYSTICK_CONTRADICTORY);
 	m_sleep = bool_value(OPTION_SLEEP);
 	m_refresh_speed = bool_value(OPTION_REFRESHSPEED);
+
+	auto ui_option_string = value(OPTION_UI);
+	if (!strcmp(ui_option_string, "simple"))
+		m_ui = UI_SIMPLE;
+	else
+		m_ui = UI_CABINET;
 }

--- a/src/emu/emuopts.h
+++ b/src/emu/emuopts.h
@@ -194,6 +194,12 @@
 class emu_options : public core_options
 {
 public:
+	enum ui_option
+	{
+		UI_CABINET,
+		UI_SIMPLE
+	};
+	
 	// construction/destruction
 	emu_options();
 
@@ -343,7 +349,7 @@ public:
 	bool cheat() const { return bool_value(OPTION_CHEAT); }
 	bool skip_gameinfo() const { return bool_value(OPTION_SKIP_GAMEINFO); }
 	const char *ui_font() const { return value(OPTION_UI_FONT); }
-	const char *ui() const { return value(OPTION_UI); }
+	ui_option ui() const { return m_ui; }
 	const char *ram_size() const { return value(OPTION_RAMSIZE); }
 
 	// core comm options
@@ -382,6 +388,7 @@ private:
 	bool m_joystick_contradictory;
 	bool m_sleep;
 	bool m_refresh_speed;
+	ui_option m_ui;
 };
 
 

--- a/src/frontend/mame/mame.cpp
+++ b/src/frontend/mame/mame.cpp
@@ -313,7 +313,7 @@ void emulator_info::display_ui_chooser(running_machine& machine)
 	// force the UI to show the game select screen
 	mame_ui_manager &mui = mame_machine_manager::instance()->ui();
 	render_container *container = &machine.render().ui_container();
-	if (strcmp(machine.options().ui(), "simple") == 0)
+	if (machine.options().ui() == emu_options::UI_SIMPLE)
 		ui::simple_menu_select_game::force_game_select(mui, container);
 	else
 		ui::menu_select_game::force_game_select(mui, container);

--- a/src/frontend/mame/ui/mainmenu.cpp
+++ b/src/frontend/mame/ui/mainmenu.cpp
@@ -244,7 +244,7 @@ void menu_main::handle()
 			break;
 
 		case SELECT_GAME:
-			if (strcmp(machine().options().ui(),"simple")==0)
+			if (machine().options().ui() == emu_options::UI_SIMPLE)
 				menu::stack_push<simple_menu_select_game>(ui(), container, nullptr);
 			else
 				menu::stack_push<menu_select_game>(ui(), container, nullptr);

--- a/src/frontend/mame/ui/menu.cpp
+++ b/src/frontend/mame/ui/menu.cpp
@@ -266,14 +266,14 @@ void menu::reset(reset_options options)
 	}
 	else if (m_parent->is_special_main_menu())
 	{
-		if (strcmp(machine().options().ui(), "simple") == 0)
+		if (machine().options().ui() == emu_options::UI_SIMPLE)
 			item_append(_("Exit"), nullptr, 0, nullptr);
 		else
 			item_append(_("Exit"), nullptr, FLAG_UI | FLAG_LEFT_ARROW | FLAG_RIGHT_ARROW, nullptr);
 	}
 	else
 	{
-		if (strcmp(machine().options().ui(), "simple") != 0 && menu::stack_has_special_main_menu())
+		if (machine().options().ui() != emu_options::UI_SIMPLE && menu::stack_has_special_main_menu())
 			item_append(_("Return to Previous Menu"), nullptr, FLAG_UI | FLAG_LEFT_ARROW | FLAG_RIGHT_ARROW, nullptr);
 		else
 			item_append(_("Return to Previous Menu"), nullptr, 0, nullptr);

--- a/src/frontend/mame/ui/optsmenu.cpp
+++ b/src/frontend/mame/ui/optsmenu.cpp
@@ -59,7 +59,7 @@ void menu_game_options::handle()
 
 	// process the menu
 	const event *menu_event;
-	if (strcmp(machine().options().ui(), "simple") == 0)
+	if (machine().options().ui() == emu_options::UI_SIMPLE)
 	{
 		menu_event = process(PROCESS_LR_REPEAT);
 	}
@@ -223,7 +223,7 @@ void menu_game_options::handle()
 
 void menu_game_options::populate()
 {
-	if (strcmp(machine().options().ui(),"simple")!=0)
+	if (machine().options().ui() != emu_options::UI_SIMPLE)
 	{
 		// set filter arrow
 		std::string fbuff;


### PR DESCRIPTION
Currently, emu_options.ui() returns a string (const char *).  Clients are invoking strcmp() to check its value.  This change makes this an enumerated type, and centralizes the string comparisons.