### PR TITLE
A little change to device_image_interface::call_display to better decouple UI fronted and image devices

### DIFF
--- a/src/devices/imagedev/cassette.h
+++ b/src/devices/imagedev/cassette.h
@@ -58,7 +58,7 @@ public:
 	virtual bool call_load() override;
 	virtual bool call_create(int format_type, option_resolution *format_options) override;
 	virtual void call_unload() override;
-	virtual void call_display() override;
+	virtual int call_display(std::string& s) override;
 	virtual bool call_softlist_load(software_list_device &swlist, const char *swname, const rom_entry *start_entry) override { return load_software(swlist, swname, start_entry); }
 
 	virtual iodevice_t image_type() const override { return IO_CASSETTE; }

--- a/src/devices/machine/hp_taco.cpp
+++ b/src/devices/machine/hp_taco.cpp
@@ -1686,42 +1686,38 @@ void hp_taco_device::call_unload()
 		set_tape_present(false);
 }
 
-void hp_taco_device::call_display()
+int hp_taco_device::call_display(std::string& s)
 {
-/*
-        // Mostly lifted from cassette_image_device::call_display ;)
+	// Mostly lifted from cassette_image_device::call_display ;)
 
-        // Do not show anything if image not loaded or tape not moving
-        if (!exists() || m_start_time.is_never()) {
-                return;
-        }
+	// Do not show anything if image not loaded or tape not moving
+	if (!exists() || m_start_time.is_never()) {
+		return -1;
+	}
 
-        char buffer[ 64 ];
+	char buffer[ 64 ];
 
-        char track = BIT(m_status_reg , STATUS_TRACKB_BIT) ? 'B' : 'A';
-        char r_w = m_tape_wr ? 'W' : 'R';
-        char m1;
-        char m2;
+	char track = BIT(m_status_reg , STATUS_TRACKB_BIT) ? 'B' : 'A';
+	char r_w = m_tape_wr ? 'W' : 'R';
+	char m1;
+	char m2;
 
-        if (m_tape_fwd) {
-                m1 = '>';
-                m2 = m_tape_fast ? '>' : ' ';
-        } else {
-                m1 = '<';
-                m2 = m_tape_fast ? '<' : ' ';
-        }
+	if (m_tape_fwd) {
+		m1 = '>';
+		m2 = m_tape_fast ? '>' : ' ';
+	} else {
+		m1 = '<';
+		m2 = m_tape_fast ? '<' : ' ';
+	}
 
-        int pos_in = current_tape_pos() / ONE_INCH_POS;
+	int pos_in = current_tape_pos() / ONE_INCH_POS;
 
-        snprintf(buffer , sizeof(buffer) , "%c %c %c%c [%04d/1824]" , track , r_w , m1 , m2 , pos_in);
+	snprintf(buffer , sizeof(buffer) , "%c %c %c%c [%04d/1824]" , track , r_w , m1 , m2 , pos_in);
 
-    float x, y;
-    x = 0.2f;
-    y = 0.5f;
-    y *= device().machine().ui().get_line_height() + 2.0f * UI_BOX_TB_BORDER;
+	s = buffer;
 
-    device().machine().ui().draw_text_box(&device().machine().render().ui_container(), buffer, JUSTIFY_LEFT, x, y, UI_BACKGROUND_COLOR);
-    */
+	// Not correct when there are 2 or more instances of TACO
+	return 0;
 }
 
 const char *hp_taco_device::file_extensions() const

--- a/src/devices/machine/hp_taco.h
+++ b/src/devices/machine/hp_taco.h
@@ -47,7 +47,7 @@ public:
 	virtual bool call_load() override;
 	virtual bool call_create(int format_type, option_resolution *format_options) override;
 	virtual void call_unload() override;
-	virtual void call_display() override;
+	virtual int call_display(std::string& s) override;
 	virtual iodevice_t image_type() const override { return IO_MAGTAPE; }
 	virtual bool is_readable() const override { return true; }
 	virtual bool is_writeable() const override { return true; }

--- a/src/emu/diimage.h
+++ b/src/emu/diimage.h
@@ -152,7 +152,7 @@ public:
 	virtual bool call_softlist_load(software_list_device &swlist, const char *swname, const rom_entry *start_entry) { return FALSE; }
 	virtual bool call_create(int format_type, option_resolution *format_options) { return FALSE; }
 	virtual void call_unload() { }
-	virtual void call_display() { }
+	virtual int call_display(std::string& s) { return -1; }
 	virtual device_image_partialhash_func get_partial_hash() const { return nullptr; }
 	virtual bool core_opens_image_file() const { return TRUE; }
 	virtual iodevice_t image_type()  const = 0;

--- a/src/emu/ui/uimain.h
+++ b/src/emu/ui/uimain.h
@@ -41,8 +41,6 @@ public:
 
 	virtual void popup_time_string(int seconds, std::string message) { }
 
-	virtual void image_display(const device_type &type, device_image_interface *image) { }
-
 	virtual void menu_reset() { }
 
 	template <typename Format, typename... Params> void popup_time(int seconds, Format &&fmt, Params &&... args);

--- a/src/frontend/mame/ui/ui.cpp
+++ b/src/frontend/mame/ui/ui.cpp
@@ -1401,59 +1401,20 @@ void mame_ui_manager::paste()
 void mame_ui_manager::image_handler_ingame()
 {
 	// run display routine for devices
-	if (machine().phase() == MACHINE_PHASE_RUNNING)
-		for (device_image_interface &image : image_interface_iterator(machine().root_device()))
-			image.call_display();
-}
+    if (machine().phase() == MACHINE_PHASE_RUNNING)
+		for (device_image_interface &image : image_interface_iterator(machine().root_device())) {
+			std::string str;
+			int idx = image.call_display(str);
+			if (idx >= 0) {
+				float x, y;
+				/* choose a location on the screen */
+				x = 0.2f;
+				y = 0.5f + idx;
+				y *= get_line_height() + 2.0f * UI_BOX_TB_BORDER;
 
-
-#define ANIMATION_FPS       1
-#define ANIMATION_FRAMES    4
-
-void mame_ui_manager::image_display(const device_type &type, device_image_interface *image)
-{
-	if (type == CASSETTE)
-	{
-		cassette_image_device *cass = dynamic_cast<cassette_image_device *>(image);
-		if (cass != nullptr)
-		{
-			char buf[65];
-			float x, y;
-			int n;
-			double position, length;
-			cassette_state uistate;
-			static const UINT8 shapes[8] = { 0x2d, 0x5c, 0x7c, 0x2f, 0x2d, 0x20, 0x20, 0x20 };
-
-			/* figure out where we are in the cassette */
-			position = cass->get_position();
-			length = cass->get_length();
-			uistate = (cassette_state)(cass->get_state() & CASSETTE_MASK_UISTATE);
-
-			/* choose a location on the screen */
-			x = 0.2f;
-			y = 0.5f;
-
-			y += cassette_device_iterator(machine().root_device()).indexof(*cass);
-
-			y *= get_line_height() + 2.0f * UI_BOX_TB_BORDER;
-			/* choose which frame of the animation we are at */
-			n = ((int)position / ANIMATION_FPS) % ANIMATION_FRAMES;
-			/* Since you can have anything in a BDF file, we will use crude ascii characters instead */
-			snprintf(buf, ARRAY_LENGTH(buf), "%c%c %c %02d:%02d (%04d) [%02d:%02d (%04d)]",
-				shapes[n],                  /* cassette icon left */
-				shapes[n | 4],                    /* cassette icon right */
-				(uistate == CASSETTE_PLAY) ? 0x50 : 0x52,   /* play (P) or record (R) */
-				((int)position / 60),
-				((int)position % 60),
-				(int)position,
-				((int)length / 60),
-				((int)length % 60),
-				(int)length);
-
-			// draw the cassette
-			draw_text_box(&machine().render().ui_container(), buf, JUSTIFY_LEFT, x, y, UI_BACKGROUND_COLOR);
+				draw_text_box(&machine().render().ui_container(), str.c_str(), JUSTIFY_LEFT, x, y, UI_BACKGROUND_COLOR);
+			}
 		}
-	}
 }
 
 //-------------------------------------------------

--- a/src/frontend/mame/ui/ui.h
+++ b/src/frontend/mame/ui/ui.h
@@ -264,8 +264,6 @@ public:
 	void draw_textured_box(render_container *container, float x0, float y0, float x1, float y1, rgb_t backcolor, rgb_t linecolor, render_texture *texture = nullptr, UINT32 flags = PRIMFLAG_BLENDMODE(BLENDMODE_ALPHA));
 	virtual void popup_time_string(int seconds, std::string message) override;
 
-	virtual void image_display(const device_type &type, device_image_interface *image) override;
-
 	virtual void menu_reset() override;
 
 private:


### PR DESCRIPTION
Hi,
I've made a small change to call_display so that UI frontend is better de-coupled from image devices. Basically the UI periodically calls this function to retrieve the string that should be displayed as status of the image device. The function itself doesn't display it anymore.
As of now this way of providing visual feedback is only used by the cassette image device and the HP TACO driver I wrote for HP9845b system. If I kept the previous way of interfacing image devices and UI, whenever the UI fronted was built it also required the taco driver to be compiled as well in order to link successfully. With this approach building the UI is independent from the device building.
Let me know if these changes are ok for you.
Thanks.
--F.Ulivi