### PR TITLE
Prevent NaN errors by initializing variable in ui::text_layout (nw)

### DIFF
--- a/src/devices/sound/ay8910.cpp
+++ b/src/devices/sound/ay8910.cpp
@@ -603,10 +603,8 @@ void ay8910_device::ay8910_write_reg(int r, int v)
 			/* No action required */
 			break;
 		case AY_ECOARSE:
-			#ifdef MAME_DEBUG
 			if ( (v & 0x0f) > 0)
-				popmessage("ECoarse");
-			#endif
+				osd_printf_verbose("ECoarse\n");
 			/* No action required */
 			break;
 		case AY_ENABLE:
@@ -628,10 +626,8 @@ void ay8910_device::ay8910_write_reg(int r, int v)
 			m_last_enable = m_regs[AY_ENABLE];
 			break;
 		case AY_ESHAPE:
-			#ifdef MAME_DEBUG
 			if ( (v & 0x0f) > 0)
-				popmessage("EShape");
-			#endif
+				osd_printf_verbose("EShape\n");
 			m_attack = (m_regs[AY_ESHAPE] & 0x04) ? m_env_step_mask : 0x00;
 			if ((m_regs[AY_ESHAPE] & 0x08) == 0)
 			{

--- a/src/emu/render.cpp
+++ b/src/emu/render.cpp
@@ -772,6 +772,11 @@ render_container::item &render_container::add_generic(UINT8 type, float x0, floa
 {
 	item *newitem = m_item_allocator.alloc();
 
+	assert(x0 == x0);
+	assert(x1 == x1);
+	assert(y0 == y0);
+	assert(y1 == y1);
+
 	// copy the data into the new item
 	newitem->m_type = type;
 	newitem->m_bounds.x0 = x0;

--- a/src/frontend/mame/ui/text.cpp
+++ b/src/frontend/mame/ui/text.cpp
@@ -78,7 +78,7 @@ CORE IMPLEMENTATION
 //-------------------------------------------------
 
 text_layout::text_layout(render_font &font, float xscale, float yscale, float width, text_layout::text_justify justify, text_layout::word_wrapping wrap)
-	: m_font(font), m_xscale(xscale), m_yscale(yscale), m_width(width), m_justify(justify), m_wrap(wrap), m_current_line(nullptr), m_last_break(0), m_text_position(0), m_truncating(false)
+	: m_font(font), m_xscale(xscale), m_yscale(yscale), m_width(width), m_maximum_line_width(0.0f), m_justify(justify), m_wrap(wrap), m_current_line(nullptr), m_last_break(0), m_text_position(0), m_truncating(false)
 
 {
 }
@@ -89,7 +89,7 @@ text_layout::text_layout(render_font &font, float xscale, float yscale, float wi
 //-------------------------------------------------
 
 text_layout::text_layout(text_layout &&that)
-	: m_font(that.m_font), m_xscale(that.m_xscale), m_yscale(that.m_yscale), m_width(that.m_width), m_justify(that.m_justify), m_wrap(that.m_wrap), m_lines(std::move(that.m_lines)),
+	: m_font(that.m_font), m_xscale(that.m_xscale), m_yscale(that.m_yscale), m_width(that.m_width), m_maximum_line_width(that.m_maximum_line_width), m_justify(that.m_justify), m_wrap(that.m_wrap), m_lines(std::move(that.m_lines)),
 	  m_current_line(that.m_current_line), m_last_break(that.m_last_break), m_text_position(that.m_text_position), m_truncating(false)
 {
 }


### PR DESCRIPTION
Use osd_printf_verbose instead of popmessage in ay8910 (too annoying even for debug build)