### PR TITLE
Load save state menu

### DIFF
--- a/scripts/src/mame/frontend.lua
+++ b/scripts/src/mame/frontend.lua
@@ -153,6 +153,8 @@ files {
 	MAME_DIR .. "src/frontend/mame/ui/sndmenu.cpp",
 	MAME_DIR .. "src/frontend/mame/ui/sndmenu.h",
 	MAME_DIR .. "src/frontend/mame/ui/starimg.h",
+	MAME_DIR .. "src/frontend/mame/ui/state.cpp",
+	MAME_DIR .. "src/frontend/mame/ui/state.h",
 	MAME_DIR .. "src/frontend/mame/ui/toolbar.h",
 	MAME_DIR .. "src/frontend/mame/ui/utils.cpp",
 	MAME_DIR .. "src/frontend/mame/ui/utils.h",

--- a/src/emu/fileio.cpp
+++ b/src/emu/fileio.cpp
@@ -30,6 +30,7 @@ path_iterator::path_iterator(const char *rawsearchpath)
 		m_current(m_base),
 		m_index(0)
 {
+	assert(rawsearchpath != nullptr);
 }
 
 

--- a/src/emu/machine.h
+++ b/src/emu/machine.h
@@ -234,6 +234,8 @@ public:
 	void strlog(const char *str) const;
 	UINT32 rand();
 	const char *describe_context();
+	std::string compose_saveload_filename(const char *base_filename, const char **searchpath = nullptr);
+	std::time_t get_save_state_modified_time(const char *filename);
 
 	// CPU information
 	cpu_device *            firstcpu;           // first CPU

--- a/src/frontend/mame/ui/state.cpp
+++ b/src/frontend/mame/ui/state.cpp
@@ -1,0 +1,232 @@
+// license:BSD-3-Clause
+// copyright-holders:Nathan Woods
+/***************************************************************************
+
+	ui/state.cpp
+
+	Menus for saving and loading state
+
+***************************************************************************/
+
+#include "emu.h"
+#include "ui/state.h"
+
+
+namespace ui {
+
+/***************************************************************************
+	BASE CLASS FOR LOAD AND SAVE
+***************************************************************************/
+
+int menu_load_save_state_base::s_last_slot_selected;
+
+//-------------------------------------------------
+//  ctor
+//-------------------------------------------------
+
+menu_load_save_state_base::menu_load_save_state_base(mame_ui_manager &mui, render_container *container, const char *header, bool disable_not_found_items)
+	: menu(mui, container),
+		m_header(header),
+		m_disable_not_found_items(disable_not_found_items),
+		m_enabled_mask(0)
+{
+}
+
+
+//-------------------------------------------------
+//  dtor
+//-------------------------------------------------
+
+menu_load_save_state_base::~menu_load_save_state_base()
+{
+}
+
+
+//-------------------------------------------------
+//  itemref_from_slot_number
+//-------------------------------------------------
+
+void *menu_load_save_state_base::itemref_from_slot_number(int slot)
+{
+	return (void *)(size_t)slot;
+}
+
+
+//-------------------------------------------------
+//  populate
+//-------------------------------------------------
+
+void menu_load_save_state_base::populate()
+{
+	m_enabled_mask = 0;
+
+	// populate all slots
+	for (int i = 0; i < SLOT_COUNT; i++)
+	{
+		// name the save state
+		std::string name = string_format("%d", i);
+
+		// compose the filename
+		std::string file_name = machine().compose_saveload_filename(name.c_str());
+
+		// get the last modified time
+		std::time_t last_modified = machine().get_save_state_modified_time(file_name.c_str());
+
+		// is the file present?
+		bool file_present = last_modified != (std::time_t) -1;
+
+		// get the time as a local time string
+		char time_string[128];
+		if (file_present)
+			std::strftime(time_string, sizeof(time_string), "%A %c", std::localtime(&last_modified));
+		else
+			snprintf(time_string, ARRAY_LENGTH(time_string), "---");
+
+		// create the menu text and flags
+		std::string text = string_format("%s: %s", name.c_str(), time_string);
+
+		// is this item enabled?
+		bool enabled = file_present || !m_disable_not_found_items;
+
+		// if enabled, set the bit field
+		if (enabled)
+			m_enabled_mask |= 1 << i;
+
+		// append the menu item
+		item_append(
+			text.c_str(),
+			"",
+			enabled ? 0 : FLAG_DISABLE,
+			itemref_from_slot_number(i));
+	}
+
+	// select the most recently used slot
+	if (s_last_slot_selected >= 0
+		&& s_last_slot_selected < SLOT_COUNT
+		&& ((m_enabled_mask & (1 << s_last_slot_selected)) != 0))
+	{
+		auto itemref = itemref_from_slot_number(s_last_slot_selected);
+		set_selection(itemref);
+	}
+
+	// set up custom render proc
+	customtop = ui().get_line_height() + 3.0f * UI_BOX_TB_BORDER;
+
+	// pause if appropriate
+	m_was_paused = machine().paused();
+	if (!m_was_paused)
+		machine().pause();
+}
+
+
+//-------------------------------------------------
+//  handle
+//-------------------------------------------------
+
+void menu_load_save_state_base::handle()
+{
+	// process the menu
+	const event *event = process(0);
+
+	// process the event
+	if ((event != nullptr) && (event->iptkey == IPT_UI_SELECT))
+	{
+		// user selected one of the entries
+		slot_selected((int)(size_t)event->itemref);
+	}
+	else if ((event != nullptr) && (event->iptkey == IPT_SPECIAL)
+		&& (event->unichar >= '0') && (event->unichar < '0' + SLOT_COUNT))
+	{
+		// user pressed a shortcut key
+		int slot = event->unichar - '0';
+		if (m_enabled_mask && 1 << slot)
+			slot_selected(slot);
+	}
+}
+
+
+//-------------------------------------------------
+//  slot_selected
+//-------------------------------------------------
+
+void menu_load_save_state_base::slot_selected(int slot)
+{
+	// name the save state
+	std::string name = string_format("%d", slot);
+
+	// handle it
+	process_file(name);
+
+	// record the last slot touched
+	s_last_slot_selected = slot;
+
+	// no matter what, pop out
+	menu::stack_pop(machine());
+
+	// resume if appropriate
+	if (!m_was_paused)
+		machine().resume();
+}
+
+
+//-------------------------------------------------
+//  custom_render - perform our special rendering
+//-------------------------------------------------
+
+void menu_load_save_state_base::custom_render(void *selectedref, float top, float bottom, float origx1, float origy1, float origx2, float origy2)
+{
+	extra_text_render(top, bottom, origx1, origy1, origx2, origy2,
+		m_header,
+		nullptr);
+}
+
+
+/***************************************************************************
+	LOAD STATE
+***************************************************************************/
+
+//-------------------------------------------------
+//  ctor
+//-------------------------------------------------
+
+menu_load_state::menu_load_state(mame_ui_manager &mui, render_container *container)
+	: menu_load_save_state_base(mui, container, _("Load State"), true)
+{
+}
+
+
+//-------------------------------------------------
+//  process_file
+//-------------------------------------------------
+
+void menu_load_state::process_file(const std::string &file_name)
+{
+	machine().schedule_load(file_name.c_str());
+}
+
+
+/***************************************************************************
+	SAVE STATE
+***************************************************************************/
+
+//-------------------------------------------------
+//  ctor
+//-------------------------------------------------
+
+menu_save_state::menu_save_state(mame_ui_manager &mui, render_container *container)
+	: menu_load_save_state_base(mui, container, _("Save State"), false)
+{
+}
+
+
+//-------------------------------------------------
+//  process_file
+//-------------------------------------------------
+
+void menu_save_state::process_file(const std::string &file_name)
+{
+	machine().schedule_save(file_name.c_str());
+}
+
+
+} // namespace ui

--- a/src/frontend/mame/ui/state.h
+++ b/src/frontend/mame/ui/state.h
@@ -1,0 +1,71 @@
+// license:BSD-3-Clause
+// copyright-holders:Nathan Woods
+/***************************************************************************
+
+	ui/state.h
+
+	Menus for saving and loading state
+
+***************************************************************************/
+
+#pragma once
+
+#ifndef MAME_FRONTEND_UI_STATE_H
+#define MAME_FRONTEND_UI_STATE_H
+
+#include "ui/menu.h"
+
+namespace ui {
+
+// ======================> menu_load_save_state_base
+
+class menu_load_save_state_base : public menu
+{
+public:
+	virtual ~menu_load_save_state_base() override;
+	virtual void populate() override;
+	virtual void handle() override;
+	virtual void custom_render(void *selectedref, float top, float bottom, float x, float y, float x2, float y2) override;
+
+protected:
+	menu_load_save_state_base(mame_ui_manager &mui, render_container *container, const char *header, bool disable_not_found_items);
+	virtual void process_file(const std::string &file_name) = 0;
+
+private:
+	const int SLOT_COUNT = 10;
+	static int s_last_slot_selected;
+
+	const char *m_header;
+	bool m_disable_not_found_items;
+	bool m_was_paused;
+	UINT32 m_enabled_mask;
+
+	void slot_selected(int slot);
+	static void *itemref_from_slot_number(int slot);
+};
+
+// ======================> menu_load_state
+
+class menu_load_state : public menu_load_save_state_base
+{
+public:
+	menu_load_state(mame_ui_manager &mui, render_container *container);
+
+protected:
+	virtual void process_file(const std::string &file_name) override;
+};
+
+// ======================> menu_save_state
+
+class menu_save_state : public menu_load_save_state_base
+{
+public:
+	menu_save_state(mame_ui_manager &mui, render_container *container);
+
+protected:
+	virtual void process_file(const std::string &file_name) override;
+};
+
+}
+
+#endif // MAME_FRONTEND_UI_STATE_H

--- a/src/frontend/mame/ui/ui.cpp
+++ b/src/frontend/mame/ui/ui.cpp
@@ -1210,6 +1210,30 @@ void mame_ui_manager::draw_profiler(render_container *container)
 
 
 //-------------------------------------------------
+//  start_save_state
+//-------------------------------------------------
+
+void mame_ui_manager::start_save_state()
+{
+	machine().pause();
+	m_load_save_hold = true;
+	set_handler(UI_CALLBACK_TYPE_GENERAL, &mame_ui_manager::handler_load_save, (UINT32)LOADSAVE_SAVE);
+}
+
+
+//-------------------------------------------------
+//  start_load_state
+//-------------------------------------------------
+
+void mame_ui_manager::start_load_state()
+{
+	machine().pause();
+	m_load_save_hold = true;
+	set_handler(UI_CALLBACK_TYPE_GENERAL, &mame_ui_manager::handler_load_save, (UINT32)LOADSAVE_LOAD);
+}
+
+
+//-------------------------------------------------
 //  image_handler_ingame - execute display
 //  callback function for each image device
 //-------------------------------------------------
@@ -1386,18 +1410,14 @@ UINT32 mame_ui_manager::handler_ingame(render_container *container)
 	// handle a save state request
 	if (machine().ui_input().pressed(IPT_UI_SAVE_STATE))
 	{
-		machine().pause();
-		m_load_save_hold = true;
-		set_handler(UI_CALLBACK_TYPE_GENERAL, &mame_ui_manager::handler_load_save, (UINT32)LOADSAVE_SAVE);
+		start_save_state();
 		return LOADSAVE_SAVE;
 	}
 
 	// handle a load state request
 	if (machine().ui_input().pressed(IPT_UI_LOAD_STATE))
 	{
-		machine().pause();
-		m_load_save_hold = true;
-		set_handler(UI_CALLBACK_TYPE_GENERAL, &mame_ui_manager::handler_load_save, (UINT32)LOADSAVE_LOAD);
+		start_load_state();
 		return LOADSAVE_LOAD;
 	}
 

--- a/src/frontend/mame/ui/ui.cpp
+++ b/src/frontend/mame/ui/ui.cpp
@@ -25,6 +25,7 @@
 #include "ui/mainmenu.h"
 #include "ui/filemngr.h"
 #include "ui/sliders.h"
+#include "ui/state.h"
 #include "ui/viewgfx.h"
 #include "imagedev/cassette.h"
 #include "image.h"
@@ -181,8 +182,7 @@ mame_ui_manager::mame_ui_manager(running_machine &machine)
 		m_show_profiler(false),
 		m_popup_text_end(0),
 		m_mouse_arrow_texture(nullptr),
-		m_mouse_show(false),
-		m_load_save_hold(false)
+		m_mouse_show(false)
 {
 }
 
@@ -1215,9 +1215,8 @@ void mame_ui_manager::draw_profiler(render_container *container)
 
 void mame_ui_manager::start_save_state()
 {
-	machine().pause();
-	m_load_save_hold = true;
-	set_handler(UI_CALLBACK_TYPE_GENERAL, &mame_ui_manager::handler_load_save, (UINT32)LOADSAVE_SAVE);
+	show_menu();
+	ui::menu::stack_push<ui::menu_save_state>(*this, &machine().render().ui_container());
 }
 
 
@@ -1227,9 +1226,8 @@ void mame_ui_manager::start_save_state()
 
 void mame_ui_manager::start_load_state()
 {
-	machine().pause();
-	m_load_save_hold = true;
-	set_handler(UI_CALLBACK_TYPE_GENERAL, &mame_ui_manager::handler_load_save, (UINT32)LOADSAVE_LOAD);
+	show_menu();
+	ui::menu::stack_push<ui::menu_load_state>(*this, &machine().render().ui_container());
 }
 
 
@@ -1491,110 +1489,6 @@ UINT32 mame_ui_manager::handler_ingame(render_container *container)
 	return 0;
 }
 
-
-//-------------------------------------------------
-//  handler_load_save - leads the user through
-//  specifying a game to save or load
-//-------------------------------------------------
-
-UINT32 mame_ui_manager::handler_load_save(render_container *container, UINT32 state)
-{
-	char filename[20];
-	char file = 0;
-
-	// if we're not in the middle of anything, skip
-	if (state == LOADSAVE_NONE)
-		return 0;
-
-	// okay, we're waiting for a key to select a slot; display a message
-	if (state == LOADSAVE_SAVE)
-		draw_message_window(container, _("Select position to save to"));
-	else
-		draw_message_window(container, _("Select position to load from"));
-
-	// if load/save state sequence is still being pressed, do not read the filename yet
-	if (m_load_save_hold) {
-		bool seq_in_progress = false;
-		const input_seq &load_save_seq = state == LOADSAVE_SAVE ?
-			machine().ioport().type_seq(IPT_UI_SAVE_STATE) :
-			machine().ioport().type_seq(IPT_UI_LOAD_STATE);
-
-		for (int i = 0; i < load_save_seq.length(); i++)
-			if (machine().input().code_pressed_once(load_save_seq[i]))
-				seq_in_progress = true;
-
-		if (seq_in_progress)
-			return state;
-		else
-			m_load_save_hold = false;
-	}
-
-	// check for cancel key
-	if (machine().ui_input().pressed(IPT_UI_CANCEL))
-	{
-		// display a popup indicating things were cancelled
-		if (state == LOADSAVE_SAVE)
-			machine().popmessage(_("Save cancelled"));
-		else
-			machine().popmessage(_("Load cancelled"));
-
-		// reset the state
-		machine().resume();
-		return UI_HANDLER_CANCEL;
-	}
-
-	// check for A-Z or 0-9
-	for (input_item_id id = ITEM_ID_A; id <= ITEM_ID_Z; ++id)
-		if (machine().input().code_pressed_once(input_code(DEVICE_CLASS_KEYBOARD, 0, ITEM_CLASS_SWITCH, ITEM_MODIFIER_NONE, id)))
-			file = id - ITEM_ID_A + 'a';
-	if (file == 0)
-		for (input_item_id id = ITEM_ID_0; id <= ITEM_ID_9; ++id)
-			if (machine().input().code_pressed_once(input_code(DEVICE_CLASS_KEYBOARD, 0, ITEM_CLASS_SWITCH, ITEM_MODIFIER_NONE, id)))
-				file = id - ITEM_ID_0 + '0';
-	if (file == 0)
-		for (input_item_id id = ITEM_ID_0_PAD; id <= ITEM_ID_9_PAD; ++id)
-			if (machine().input().code_pressed_once(input_code(DEVICE_CLASS_KEYBOARD, 0, ITEM_CLASS_SWITCH, ITEM_MODIFIER_NONE, id)))
-				file = id - ITEM_ID_0_PAD + '0';
-	if (file == 0)
-	{
-		bool found = false;
-
-		for (int joy_index = 0; joy_index <= MAX_SAVED_STATE_JOYSTICK; joy_index++)
-			for (input_item_id id = ITEM_ID_BUTTON1; id <= ITEM_ID_BUTTON32; ++id)
-				if (machine().input().code_pressed_once(input_code(DEVICE_CLASS_JOYSTICK, joy_index, ITEM_CLASS_SWITCH, ITEM_MODIFIER_NONE, id)))
-				{
-					snprintf(filename, sizeof(filename), "joy%i-%i", joy_index, id - ITEM_ID_BUTTON1 + 1);
-					found = true;
-					break;
-				}
-
-		if (!found)
-			return state;
-	}
-	else
-	{
-		sprintf(filename, "%c", file);
-	}
-
-	// display a popup indicating that the save will proceed
-	if (state == LOADSAVE_SAVE)
-	{
-		machine().popmessage(_("Save to position %s"), filename);
-		machine().schedule_save(filename);
-	}
-	else
-	{
-		machine().popmessage(_("Load from position %s"), filename);
-		machine().schedule_load(filename);
-	}
-
-	// avoid handling the name of the save state slot as a seperate input
-	machine().ui_input().mark_all_as_pressed();
-
-	// remove the pause and reset the state
-	machine().resume();
-	return UI_HANDLER_CANCEL;
-}
 
 
 //-------------------------------------------------

--- a/src/frontend/mame/ui/ui.h
+++ b/src/frontend/mame/ui/ui.h
@@ -236,6 +236,8 @@ public:
 	void draw_timecode_counter(render_container *container);
 	void draw_timecode_total(render_container *container);
 	void draw_profiler(render_container *container);
+	void start_save_state();
+	void start_load_state();
 
 	// print the game info string into a buffer
 	std::string &game_info_astring(std::string &str);

--- a/src/frontend/mame/ui/ui.h
+++ b/src/frontend/mame/ui/ui.h
@@ -272,7 +272,6 @@ private:
 	std::unique_ptr<UINT8[]> m_non_char_keys_down;
 	render_texture *        m_mouse_arrow_texture;
 	bool                    m_mouse_show;
-	bool                    m_load_save_hold;
 	ui_options              m_ui_options;
 
 	// static variables

--- a/src/lib/util/corefile.cpp
+++ b/src/lib/util/corefile.cpp
@@ -313,6 +313,7 @@ public:
 	virtual std::uint32_t write(void const *buffer, std::uint32_t length) override;
 	virtual osd_file::error truncate(std::uint64_t offset) override;
 	virtual osd_file::error flush() override;
+	virtual std::time_t get_last_modified_time() override;
 
 protected:
 
@@ -963,6 +964,19 @@ osd_file::error core_osd_file::flush()
 
 
 /*-------------------------------------------------
+	get_last_modified_time
+-------------------------------------------------*/
+
+std::time_t core_osd_file::get_last_modified_time()
+{
+	std::time_t last_modified_time;
+	return m_file->get_last_modified_time(last_modified_time) == osd_file::error::NONE
+		? last_modified_time
+		: (std::time_t) - 1;
+}
+
+
+/*-------------------------------------------------
     osd_or_zlib_read - wrapper for osd_read that
     handles zlib-compressed data
 -------------------------------------------------*/
@@ -1245,6 +1259,16 @@ osd_file::error core_file::load(std::string const &filename, dynamic_buffer &dat
 
 	// close the file and return data
 	return osd_file::error::NONE;
+}
+
+
+/*-------------------------------------------------
+	get_last_modified_time
+-------------------------------------------------*/
+
+std::time_t core_file::get_last_modified_time()
+{
+	return (std::time_t) -1;
 }
 
 

--- a/src/lib/util/corefile.h
+++ b/src/lib/util/corefile.h
@@ -125,6 +125,9 @@ public:
 	// flush file buffers
 	virtual osd_file::error flush() = 0;
 
+	// last modified
+	virtual std::time_t get_last_modified_time();
+
 
 protected:
 	core_file();

--- a/src/osd/osdcore.cpp
+++ b/src/osd/osdcore.cpp
@@ -13,6 +13,17 @@ static osd_output *m_stack[MAXSTACK];
 static int m_ptr = -1;
 
 /*-------------------------------------------------
+osd_file::get_last_modified_time
+-------------------------------------------------*/
+
+osd_file::error osd_file::get_last_modified_time(std::time_t &last_modified_time)
+{
+	last_modified_time = (std::time_t) -1;
+	return error::FAILURE;
+}
+
+
+/*-------------------------------------------------
     osd_output
 -------------------------------------------------*/
 

--- a/src/osd/osdcore.h
+++ b/src/osd/osdcore.h
@@ -25,6 +25,7 @@
 #include <cstdint>
 #include <memory>
 #include <string>
+#include <ctime>
 
 
 /***************************************************************************
@@ -224,6 +225,20 @@ public:
 	        the file, or FILERR_NONE if no error occurred
 	-----------------------------------------------------------------------------*/
 	static error remove(std::string const &filename);
+
+	/*-----------------------------------------------------------------------------
+		osd_file::get_last_modified_time: gets the last modified time
+	
+	Parameters:
+
+		last_modified_time - last modified time
+
+	Return value:
+
+		a file_error describing any error that occurred while deleting
+		the file, or FILERR_NONE if no error occurred
+	-----------------------------------------------------------------------------*/
+	virtual error get_last_modified_time(std::time_t &last_modified_time);
 };
 
 


### PR DESCRIPTION
This implements a bonafide menu around loading and saving machine states.  I made sure to preserve existing keyboard shortcuts.

Note that I had to add support for querying last modified times to the OSD layer; I only did this for windows.  Help implementing this for other platforms would be appreciated.
