### PR TITLE
New @ driver specifier; improved -listclones; add -lcs, -listtree

### DIFF
--- a/src/emu/validity.cpp
+++ b/src/emu/validity.cpp
@@ -199,7 +199,7 @@ bool validity_checker::check_all_matching(const char *string)
 	// then iterate over all drivers and check them
 	m_drivlist.reset();
 	while (m_drivlist.next())
-		if (m_drivlist.matches(string, m_drivlist.driver().name))
+		if (m_drivlist.matches(string, m_drivlist.driver()))
 			validate_one(m_drivlist.driver());
 
 	// cleanup

--- a/src/frontend/mame/clifront.h
+++ b/src/frontend/mame/clifront.h
@@ -40,7 +40,9 @@ public:
 	void listfull(const char *gamename = "*");
 	void listsource(const char *gamename = "*");
 	void listclones(const char *gamename = "*");
+	void listclonesource(const char *gamename = "*");
 	void listbrothers(const char *gamename = "*");
+	void listtree(const char *gamename = "*");
 	void listcrc(const char *gamename = "*");
 	void listroms(const char *gamename = "*");
 	void listsamples(const char *gamename = "*");


### PR DESCRIPTION
The @source.cpp specifier, which matches on the exact basename of the source file, is now accepted by all commands that do driver enumeration.

The -listclones command has been altered to include the parent sets; -listclones pacman and -listclones puckman now produce identical output.

The new -listclonesource (-lcs) command works like -listclones, but also prints the source file of each driver. Unlike -listclones, the parent sets are included in the listing.

The new -listtree command tabulates matching drivers by source file in a human-readable tree format, with the names of clones indented under their parents and drivers indented under their respective BIOS roots.

Fix include_all counting error causing assert to fail in find_approximate_matches (nw)