### PR TITLE
Scorpion4 7segment displays mostly fixed

### DIFF
--- a/src/mame/drivers/bfm_sc4.cpp
+++ b/src/mame/drivers/bfm_sc4.cpp
@@ -319,9 +319,33 @@ WRITE8_MEMBER(bfm_sc45_state::mux_output2_w)
 
 	// others drive 7-segs with it..  so rendering it there as well in our debug layouts
 
-	// todo: reorder properly!
-	UINT8 bf7segdata = BITSWAP8(data,7,6,5,4,3,2,1,0);
-	output().set_digit_value(offset, bf7segdata);
+	if (m_segment_34_encoding)
+	{
+		m_segment_34_cache[offset] = data;
+
+		UINT16 short_data;
+		UINT8 byte_data_first_segment;
+		UINT8 byte_data_second_segment;
+		for (int digit = 0; digit < 32; digit += 2) 
+		{
+			short_data = (m_segment_34_cache[digit + 1] << 8) | m_segment_34_cache[digit];
+			byte_data_first_segment = (short_data >> 1) & 15;
+			byte_data_second_segment = (short_data >> 6) & 15;
+			output().set_digit_value(digit, SEGMENT_34_ENCODING_LOOKUP[byte_data_first_segment]);
+			output().set_digit_value(digit + 1, SEGMENT_34_ENCODING_LOOKUP[byte_data_second_segment]);
+
+			if (digit == 0 || digit == 2)
+			{
+				byte_data_first_segment = (short_data >> 11) & 15;
+				output().set_digit_value((digit / 2) + 32, SEGMENT_34_ENCODING_LOOKUP[byte_data_first_segment]);
+			}
+		}
+	}
+	else
+	{
+		UINT8 bf7segdata = BITSWAP8(data,0,7,6,5,4,3,2,1);
+		output().set_digit_value(offset, bf7segdata);
+	}
 }
 
 WRITE16_MEMBER(sc4_state::sc4_mem_w)
@@ -35665,6 +35689,8 @@ GAMEL( 200?, sc4dndcse   ,sc4dndcs,  sc4, sc4dndcs5, sc4_state, sc4dndcs, ROT0, 
 
 DRIVER_INIT_MEMBER(sc4_state,sc4dndbb)
 {
+	m_segment_34_encoding = true;
+
 	DRIVER_INIT_CALL(sc4mbus);
 }
 
@@ -36337,6 +36363,8 @@ GAMEL( 200?, sc4dndrae   ,sc4dndra,  sc4_5reel_alt, sc4dndra70, sc4_state, sc4dn
 
 DRIVER_INIT_MEMBER(sc4_state,sc4dndbd)
 {
+	m_segment_34_encoding = true;
+
 	DRIVER_INIT_CALL(sc4mbus);
 }
 
@@ -36528,6 +36556,8 @@ GAMEL( 200?, sc4dndbrg   ,sc4dndbr,  sc4_5reel_alt, sc4dndbr70, sc4_state, sc4dn
 
 DRIVER_INIT_MEMBER(sc4_state,sc4dndcc)
 {
+	m_segment_34_encoding = true;
+
 	DRIVER_INIT_CALL(sc4mbus);
 }
 
@@ -36812,6 +36842,8 @@ GAMEL( 200?, sc4dnddfe   ,sc4dnddf,  sc4_200_alt, sc4dnddf70, sc4_state, sc4dndd
 
 DRIVER_INIT_MEMBER(sc4_state,sc4dndpg)
 {
+	m_segment_34_encoding = true;
+
 	DRIVER_INIT_CALL(sc4mbus);
 }
 
@@ -37451,6 +37483,8 @@ GAMEL( 200?, sc4dndben   ,sc4dndbe,  sc4_5reel_alt, sc4dndbe35, sc4_state, sc4dn
 
 DRIVER_INIT_MEMBER(sc4_state,sc4dndbc)
 {
+	m_segment_34_encoding = true;
+
 	DRIVER_INIT_CALL(sc4mbus);
 }
 

--- a/src/mame/includes/bfm_sc4.h
+++ b/src/mame/includes/bfm_sc4.h
@@ -59,6 +59,26 @@
 
 #define SC45_BUTTON_MATRIX_20_0 IPT_SERVICE1 // green / test
 
+static const UINT8 SEGMENT_34_ENCODING_LOOKUP[16] = 
+{
+	63,	// 0
+	6,	// 1
+	91,	// 2
+	79,	// 3
+	102,// 4
+	109,// 5
+	125,// 6
+	7,	// 7
+	127,// 8
+	103,// 9
+	0,	// 10
+	121,// 11
+	121,// 12
+	121,// 13
+	121,// 14
+	121,// 15
+};
+
 // common base class for things shared between sc4 and sc5
 class bfm_sc45_state : public driver_device
 {
@@ -85,6 +105,10 @@ public:
 
 	UINT8 vfd_ser_value;
 	int vfd_ser_count;
+
+	// 34 segment custom encoding used by some sc4/5 machines such as Box Clever, Break The Bank, The Big Deal, The Crazy Chair, The Perfect Game
+	bool m_segment_34_encoding;
+	UINT8 m_segment_34_cache[32];
 
 	DECLARE_WRITE8_MEMBER(mux_output_w);
 	DECLARE_WRITE8_MEMBER(mux_output2_w);


### PR DESCRIPTION
Unscramble the output for the 7segment displays in most Scorpion4 machines.