### PR TITLE
Fixes how the file selection dialog determines when to show [create]

### DIFF
--- a/src/frontend/mame/ui/filesel.cpp
+++ b/src/frontend/mame/ui/filesel.cpp
@@ -560,7 +560,7 @@ void menu_file_selector::populate()
 		append_entry(SELECTOR_ENTRY_TYPE_EMPTY, "", "");
 	}
 
-	if (m_has_create)
+	if (m_has_create && !util::zippath_is_zip(directory))
 	{
 		// add the "[create]" entry
 		append_entry(SELECTOR_ENTRY_TYPE_CREATE, "", "");

--- a/src/frontend/mame/ui/imgcntrl.cpp
+++ b/src/frontend/mame/ui/imgcntrl.cpp
@@ -177,16 +177,8 @@ void menu_control_device_image::handle()
 {
 	switch(state) {
 	case START_FILE: {
-		bool can_create = false;
-		if(image->is_creatable()) {
-			util::zippath_directory *directory = nullptr;
-			osd_file::error err = util::zippath_opendir(current_directory.c_str(), &directory);
-			can_create = err == osd_file::error::NONE && !util::zippath_is_zip(directory);
-			if(directory)
-				util::zippath_closedir(directory);
-		}
 		submenu_result = -1;
-		menu::stack_push<menu_file_selector>(ui(), container, image, current_directory, current_file, true, image->image_interface()!=nullptr, can_create, &submenu_result);
+		menu::stack_push<menu_file_selector>(ui(), container, image, current_directory, current_file, true, image->image_interface()!=nullptr, image->is_creatable(), &submenu_result);
 		state = SELECT_FILE;
 		break;
 	}


### PR DESCRIPTION
Previously, the calling code would make the determination and pass that to the file selector.  That was incorrect, because this determination wouldn't be remade if the user enters or exits an archive