### PR TITLE
Update vtvideo.cpp

### DIFF
--- a/src/mame/video/vtvideo.cpp
+++ b/src/mame/video/vtvideo.cpp
@@ -283,6 +283,7 @@ WRITE8_MEMBER(vt100_video_device::dc012_w)
 			// PDF: reverse field OFF 
 			// SETUP: dark screen selected 
 			m_reverse_field = 1; 
+			break;
 
 			//  Writing a 11XX bit combination clears the blink-flip flop (valid for 0x0C - 0x0F):
 		case 0x0c:

--- a/src/mame/video/vtvideo.cpp
+++ b/src/mame/video/vtvideo.cpp
@@ -236,20 +236,18 @@ WRITE8_MEMBER(vt100_video_device::dc012_w)
 {
 	// Writes to [10C] and [0C] are treated differently
 	// - see 3.1.3.9.5 DC012 Programming Information (PC-100 spec)
-	if ((offset & 0x100) && (data == 0) ) // MHFU is disabled by writing 00 to port 010C.
+	if ((offset & 0x100) ) // MHFU is disabled by writing a value to port 010C.
 	{
-		if (MHFU_FLAG == true)
-						printf("MHFU  *** DISABLED *** \n");
+//		if (MHFU_FLAG == true)
+//						printf("MHFU  *** DISABLED *** \n");
 		MHFU_FLAG = false;
-		MHFU_counter = 0; // ?
 	}
 	else
 	{
-		if (MHFU_FLAG == false)
-			printf("MHFU  ___ENABLED___ %05x \n", space.device().safe_pc());
-
+//		if (MHFU_FLAG == false)
+//			printf("MHFU  ___ENABLED___ %05x \n", space.device().safe_pc());
 		MHFU_FLAG = true;
-		MHFU_counter = 0;
+		MHFU_counter = 0;  // TEST-DEBUG ***********
 	}
 
 	if (!(data & 0x08))
@@ -835,49 +833,40 @@ void rainbow_video_device::video_blanking(bitmap_ind16 &bitmap, const rectangle 
 	bitmap.fill(((m_reverse_field ^ m_basic_attribute) ? 1 : 0), cliprect);
 }
 
-
+#define MHFU_IS_ENABLED 1
+#define MHFU_COUNT -1
+#define MHFU_VALUE -2
+#define MHFU_RESET_and_ENABLE   -100
+#define MHFU_RESET_and_DISABLE  -200
+#define MHFU_RESET              -250
 
 int rainbow_video_device::MHFU(int ASK)
 {
 	switch (ASK)
 	{
-	case 1:         // "true": RETURN BOOLEAN (MHFU disabled or enabled?)
+	case MHFU_IS_ENABLED:		// "true": RETURN BOOLEAN (MHFU disabled or enabled?)
 		return MHFU_FLAG;
 
-	case -1:        // -1: increment IF ENABLED, return counter value (=> Rainbow.c)
-		//if (MHFU_FLAG == true)
-			if (MHFU_counter < 255)
+	case MHFU_COUNT:		// -1: increment IF ENABLED, return counter value (=> Rainbow.c)
+		if (MHFU_FLAG == true)
+			if (MHFU_counter < 254)
 				MHFU_counter++;
 
-	case -2:
+	case MHFU_VALUE:
 		return MHFU_counter;
 
-	case -250:          // -250 : RESET counter (NOTHING ELSE!)
+	case MHFU_RESET:		// -250 : RESET counter (NOTHING ELSE!)
 		MHFU_counter = 0;
 		return MHFU_FLAG;
 
-	case -100:          // -100 : RESET and ENABLE MHFU counter
+	case MHFU_RESET_and_ENABLE:	// -100 : RESET and ENABLE MHFU counter
 		MHFU_counter = 0;
-		if(0) //if (VERBOSE)
-			printf("-100 MHFU  * reset and ENABLE * \n");
-
-		if(0) // if (VERBOSE)
-		{
-			if (MHFU_FLAG == false)
-				printf("-100 MHFU  ___ENABLED___\n");
-		}
 		MHFU_FLAG = true;
 
 		return -100;
 
-	case -200:          // -200 : RESET and DISABLE MHFU
+	case MHFU_RESET_and_DISABLE:	// -200 : RESET and DISABLE MHFU
 		MHFU_counter = 0;
-
-		if(0) //if (VERBOSE)
-		{
-			if (MHFU_FLAG == true)
-				printf("MHFU  *** DISABLED ***xxx \n");
-		}
 		MHFU_FLAG = false;
 
 		return -200;

--- a/src/mame/video/vtvideo.cpp
+++ b/src/mame/video/vtvideo.cpp
@@ -247,7 +247,7 @@ WRITE8_MEMBER(vt100_video_device::dc012_w)
 //		if (MHFU_FLAG == false)
 //			printf("MHFU  ___ENABLED___ %05x \n", space.device().safe_pc());
 		MHFU_FLAG = true;
-		MHFU_counter = 0;  // TEST-DEBUG ***********
+		MHFU_counter = 0;  
 	}
 
 	if (!(data & 0x08))
@@ -276,13 +276,13 @@ WRITE8_MEMBER(vt100_video_device::dc012_w)
 			m_write_clear_video_interrupt(0);
 			break;
 		case 0x0a:
-			// set reverse field on
-			m_reverse_field = 1;
-			break;
-		case 0x0b:
-			// set reverse field off
+			// PDF: reverse field ON
 			m_reverse_field = 0;
 			break;
+		case 0x0b: 			
+			// PDF: reverse field OFF 
+			// SETUP: dark screen selected 
+			m_reverse_field = 1; 
 
 			//  Writing a 11XX bit combination clears the blink-flip flop (valid for 0x0C - 0x0F):
 		case 0x0c:


### PR DESCRIPTION
Changes to get the internal watchdog up and running. Documentation states that 0x00 must be written to 0x10C (to disable foulup detection). Contrary to that claim, sane values should be poked (handled by the same logic as $0C). The offset makes the difference.