### PR TITLE
bbcbc: Input overhaul and machine/software list corrections

### DIFF
--- a/hash/bbcbc.xml
+++ b/hash/bbcbc.xml
@@ -5,7 +5,7 @@
 	<software name="advbidng">
 		<description>Advanced Bidding</description>
 		<year>198?</year>
-		<publisher>BBC</publisher>
+		<publisher>Unicard</publisher>
 		<part name="cart" interface="bbcbc_cart">
 			<dataarea name="rom" size="32768">
 				<rom name="masc_03a.bin" size="32768" crc="cbec2471" sha1="770ab06b1fcc35da08ce8453b754b8f62520cdd0" offset="0" />
@@ -16,7 +16,7 @@
 	<software name="advdefnc">
 		<description>Advanced Defence</description>
 		<year>198?</year>
-		<publisher>BBC</publisher>
+		<publisher>Unicard</publisher>
 		<part name="cart" interface="bbcbc_cart">
 			<dataarea name="rom" size="32768">
 				<rom name="advco4a.bin" size="32768" crc="e5ff9113" sha1="262f6f72bd0b63531102e8d4da0345b39ca3ea2f" offset="0" />
@@ -26,8 +26,8 @@
 
 	<software name="bbuilder">
 		<description>Bridge Builder</description>
-		<year>198?</year>
-		<publisher>BBC</publisher>
+		<year>1985</year>
+		<publisher>Unicard</publisher>
 		<part name="cart" interface="bbcbc_cart">
 			<dataarea name="rom" size="32768">
 				<rom name="bbc2_1.bin" size="8192" crc="ee348134" sha1="0528f7c935549f5fe7c033f1f5e58cba8a03736b" offset="0" />
@@ -40,8 +40,8 @@
 
 	<software name="bbuildera" cloneof="bbuilder">
 		<description>Bridge Builder (Alt)</description>
-		<year>198?</year>
-		<publisher>BBC</publisher>
+		<year>1985</year>
+		<publisher>Unicard</publisher>
 		<part name="cart" interface="bbcbc_cart">
 			<dataarea name="rom" size="32768">
 				<rom name="bbc4a.0" size="16384" crc="d1f20bc0" sha1="368fa3ff5affea6ca355b09b4f00917299fa6a8e" offset="0" />
@@ -52,8 +52,8 @@
 
 	<software name="cplay1">
 		<description>Club Play 1</description>
-		<year>198?</year>
-		<publisher>BBC</publisher>
+		<year>1985</year>
+		<publisher>Unicard</publisher>
 		<part name="cart" interface="bbcbc_cart">
 			<dataarea name="rom" size="24576">
 				<rom name="cpc_2_1.bin" size="8192" crc="1efd1481" sha1="d0483da7ae3abff4a1141a89d066e2b5879a52c1" offset="0" />
@@ -66,7 +66,7 @@
 	<software name="cplay2">
 		<description>Club Play 2</description>
 		<year>198?</year>
-		<publisher>BBC</publisher>
+		<publisher>Unicard</publisher>
 		<part name="cart" interface="bbcbc_cart">
 			<dataarea name="rom" size="32768">
 				<rom name="2cp1_1.bin" size="16384" crc="5e18577d" sha1="b22858fb42231453e80fa994a7431e9853b4a2eb" offset="0" />
@@ -78,7 +78,7 @@
 	<software name="cplay2a" cloneof="cplay2">
 		<description>Club Play 2 (Alt)</description>
 		<year>198?</year>
-		<publisher>BBC</publisher>
+		<publisher>Unicard</publisher>
 		<part name="cart" interface="bbcbc_cart">
 			<dataarea name="rom" size="32768">
 				<rom name="club_play_2.bin" size="32768" crc="2867fc62" sha1="ef519def0ad37882da81a9c16371cf2b1d8919ee" offset="0" />
@@ -89,7 +89,7 @@
 	<software name="cplay3">
 		<description>Club Play 3</description>
 		<year>198?</year>
-		<publisher>BBC</publisher>
+		<publisher>Unicard</publisher>
 		<part name="cart" interface="bbcbc_cart">
 			<dataarea name="rom" size="32768">
 				<rom name="cp3.bin" size="32768" crc="a17569d8" sha1="151256d1d0957e3c6c07e2b0150c679384ce195d" offset="0" />
@@ -100,7 +100,7 @@
 	<software name="convent1">
 		<description>Conventions 1</description>
 		<year>198?</year>
-		<publisher>BBC</publisher>
+		<publisher>Unicard</publisher>
 		<part name="cart" interface="bbcbc_cart">
 			<dataarea name="rom" size="32768">
 				<rom name="conc019.bin" size="32768" crc="968179b3" sha1="eb23cd6506a2afea3ff72535be18102036723f94" offset="0" />
@@ -111,7 +111,7 @@
 	<software name="duplict1">
 		<description>Duplicate 1</description>
 		<year>198?</year>
-		<publisher>BBC</publisher>
+		<publisher>Unicard</publisher>
 		<part name="cart" interface="bbcbc_cart">
 			<dataarea name="rom" size="32768">
 				<rom name="dupc04a.bin" size="32768" crc="83d55b90" sha1="61a01c0ccb19f01b3e875db467886969b8284259" offset="0" />
@@ -121,8 +121,8 @@
 
 	<software name="mplay1">
 		<description>Master Play 1</description>
-		<year>198?</year>
-		<publisher>BBC</publisher>
+		<year>1985</year>
+		<publisher>Unicard</publisher>
 		<part name="cart" interface="bbcbc_cart">
 			<dataarea name="rom" size="32768">
 				<rom name="mp_1_1.bin" size="16384" crc="d28d9995" sha1="4288eae32eaabbe489b549a30e4eb35a4e671ae7" offset="0" />

--- a/scripts/target/mame/mess.lua
+++ b/scripts/target/mame/mess.lua
@@ -883,6 +883,7 @@ function linkProjects_mame_mess(_target, _subtarget)
 		"trs",
 		"ultimachine",
 		"ultratec",
+		"unicard",
 		"unisonic",
 		"unisys",
 		"usp",
@@ -1106,7 +1107,6 @@ files {
 	MAME_DIR .. "src/mame/includes/bbc.h",
 	MAME_DIR .. "src/mame/machine/bbc.cpp",
 	MAME_DIR .. "src/mame/video/bbc.cpp",
-	MAME_DIR .. "src/mame/drivers/bbcbc.cpp",
 	MAME_DIR .. "src/mame/drivers/electron.cpp",
 	MAME_DIR .. "src/mame/includes/electron.h",
 	MAME_DIR .. "src/mame/machine/electron.cpp",
@@ -2885,6 +2885,11 @@ files {
 createMESSProjects(_target, _subtarget, "ultratec")
 files {
 	MAME_DIR .. "src/mame/drivers/minicom.cpp",
+}
+
+createMESSProjects(_target, _subtarget, "unicard")
+files {
+	MAME_DIR .. "src/mame/drivers/bbcbc.cpp",
 }
 
 createMESSProjects(_target, _subtarget, "unisonic")

--- a/src/devices/machine/z80pio.cpp
+++ b/src/devices/machine/z80pio.cpp
@@ -131,7 +131,7 @@ int z80pio_device::z80daisy_irq_ack()
 
 		if (port.m_ip)
 		{
-			if (LOG) logerror("Z80PIO '%s' Port %c Interrupt Acknowledge\n", tag(), 'A' + index);
+			if (LOG) logerror("Z80PIO Port %c Interrupt Acknowledge\n", 'A' + index);
 
 			// clear interrupt pending flag
 			port.m_ip = false;
@@ -164,7 +164,7 @@ void z80pio_device::z80daisy_irq_reti()
 
 		if (port.m_ius)
 		{
-			if (LOG) logerror("Z80PIO '%s' Port %c Return from Interrupt\n", tag(), 'A' + index);
+			if (LOG) logerror("Z80PIO Port %c Return from Interrupt\n", 'A' + index);
 
 			// clear interrupt under service flag
 			port.m_ius = false;
@@ -251,7 +251,7 @@ void z80pio_device::check_interrupts()
 
 	for (int index = PORT_A; index < PORT_COUNT; index++)
 	{
-		if (LOG) logerror("Z80PIO '%s' Port %c IE %s IP %s IUS %s\n", tag(), 'A' + index, m_port[index].m_ie ? "1":"0", m_port[index].m_ip ? "1":"0", m_port[index].m_ius ? "1":"0");
+		if (LOG) logerror("Z80PIO Port %c IE %s IP %s IUS %s\n", 'A' + index, m_port[index].m_ie ? "1":"0", m_port[index].m_ip ? "1":"0", m_port[index].m_ius ? "1":"0");
 
 		if (!ius && m_port[index].m_ie && m_port[index].m_ip)
 		{
@@ -259,7 +259,7 @@ void z80pio_device::check_interrupts()
 		}
 	}
 
-	if (LOG) logerror("Z80PIO '%s' INT %u\n", tag(), state);
+	if (LOG) logerror("Z80PIO INT %u\n", state);
 
 	m_out_int_cb(state);
 }
@@ -360,7 +360,7 @@ void z80pio_device::pio_port::reset()
 void z80pio_device::pio_port::trigger_interrupt()
 {
 	m_ip = true;
-	if (LOG) m_device->logerror("Z80PIO '%s' Port %c Transfer Mode Interrupt Pending\n", m_device->tag(), 'A' + m_index);
+	if (LOG) m_device->logerror("Z80PIO Port %c Transfer Mode Interrupt Pending\n", 'A' + m_index);
 
 	check_interrupts();
 }
@@ -374,7 +374,7 @@ void z80pio_device::pio_port::set_rdy(bool state)
 {
 	if (m_rdy == state) return;
 
-	if (LOG) m_device->logerror("Z80PIO '%s' Port %c Ready: %u\n", m_device->tag(), 'A' + m_index, state);
+	if (LOG) m_device->logerror("Z80PIO Port %c Ready: %u\n", 'A' + m_index, state);
 
 	m_rdy = state;
 	if (m_index == PORT_A)
@@ -390,11 +390,11 @@ void z80pio_device::pio_port::set_rdy(bool state)
 
 void z80pio_device::pio_port::set_mode(int mode)
 {
-	if (LOG) m_device->logerror("Z80PIO '%s' Port %c Mode: %u\n", m_device->tag(), 'A' + m_index, mode);
-
 	switch (mode)
 	{
 	case MODE_OUTPUT:
+		if (LOG) m_device->logerror("Z80PIO Port %c Mode: Output\n", 'A' + m_index);
+
 		// enable data output
 		if (m_index == PORT_A)
 			m_device->m_out_pa_cb((offs_t)0, m_output);
@@ -409,6 +409,8 @@ void z80pio_device::pio_port::set_mode(int mode)
 		break;
 
 	case MODE_INPUT:
+		if (LOG) m_device->logerror("Z80PIO Port %c Mode: Input\n", 'A' + m_index);
+
 		// set mode register
 		m_mode = mode;
 		break;
@@ -416,16 +418,19 @@ void z80pio_device::pio_port::set_mode(int mode)
 	case MODE_BIDIRECTIONAL:
 		if (m_index == PORT_B)
 		{
-			m_device->logerror("Z80PIO '%s' Port %c Invalid Mode: %u!\n", m_device->tag(), 'A' + m_index, mode);
+			m_device->logerror("Z80PIO Port %c Invalid Mode: %u!\n", 'A' + m_index, mode);
 		}
 		else
 		{
+			if (LOG) m_device->logerror("Z80PIO Port %c Mode: Bidirectional\n", 'A' + m_index);
 			// set mode register
 			m_mode = mode;
 		}
 		break;
 
 	case MODE_BIT_CONTROL:
+		if (LOG) m_device->logerror("Z80PIO Port %c Mode: Bit Control\n", 'A' + m_index);
+
 		if ((m_index == PORT_A) || (m_device->m_port[PORT_A].m_mode != MODE_BIDIRECTIONAL))
 		{
 			// clear ready line
@@ -455,7 +460,7 @@ void z80pio_device::pio_port::set_mode(int mode)
 
 void z80pio_device::pio_port::strobe(bool state)
 {
-	if (LOG) m_device->logerror("Z80PIO '%s' Port %c Strobe: %u\n", m_device->tag(), 'A' + m_index, state);
+	if (LOG) m_device->logerror("Z80PIO Port %c Strobe: %u\n", 'A' + m_index, state);
 
 	if (m_device->m_port[PORT_A].m_mode == MODE_BIDIRECTIONAL)
 	{
@@ -573,7 +578,7 @@ void z80pio_device::pio_port::write(UINT8 data)
 		{
 			// trigger interrupt
 			m_ip = true;
-			if (LOG) m_device->logerror("Z80PIO '%s' Port %c Bit Control Mode Interrupt Pending\n", m_device->tag(), 'A' + m_index);
+			if (LOG) m_device->logerror("Z80PIO Port %c Bit Control Mode Interrupt Pending\n", 'A' + m_index);
 		}
 
 		m_match = match;
@@ -596,7 +601,7 @@ void z80pio_device::pio_port::control_write(UINT8 data)
 		{
 			// load interrupt vector
 			m_vector = data;
-			if (LOG) m_device->logerror("Z80PIO '%s' Port %c Interrupt Vector: %02x\n", m_device->tag(), 'A' + m_index, data);
+			if (LOG) m_device->logerror("Z80PIO Port %c Interrupt Vector: %02x\n", 'A' + m_index, data);
 
 			// set interrupt enable
 			m_icw |= ICW_ENABLE_INT;
@@ -616,10 +621,10 @@ void z80pio_device::pio_port::control_write(UINT8 data)
 
 				if (LOG)
 				{
-					m_device->logerror("Z80PIO '%s' Port %c Interrupt Enable: %u\n", m_device->tag(), 'A' + m_index, BIT(data, 7));
-					m_device->logerror("Z80PIO '%s' Port %c Logic: %s\n", m_device->tag(), 'A' + m_index, BIT(data, 6) ? "AND" : "OR");
-					m_device->logerror("Z80PIO '%s' Port %c Active %s\n", m_device->tag(), 'A' + m_index, BIT(data, 5) ? "High" : "Low");
-					m_device->logerror("Z80PIO '%s' Port %c Mask Follows: %u\n", m_device->tag(), 'A' + m_index, BIT(data, 4));
+					m_device->logerror("Z80PIO Port %c Interrupt Enable: %u\n", 'A' + m_index, BIT(data, 7));
+					m_device->logerror("Z80PIO Port %c Logic: %s\n", 'A' + m_index, BIT(data, 6) ? "AND" : "OR");
+					m_device->logerror("Z80PIO Port %c Active %s\n", 'A' + m_index, BIT(data, 5) ? "High" : "Low");
+					m_device->logerror("Z80PIO Port %c Mask Follows: %u\n", 'A' + m_index, BIT(data, 4));
 				}
 
 				if (m_icw & ICW_MASK_FOLLOWS)
@@ -647,7 +652,7 @@ void z80pio_device::pio_port::control_write(UINT8 data)
 
 			case 0x03: // set interrupt enable flip-flop
 				m_icw = (data & 0x80) | (m_icw & 0x7f);
-				if (LOG) m_device->logerror("Z80PIO '%s' Port %c Interrupt Enable: %u\n", m_device->tag(), 'A' + m_index, BIT(data, 7));
+				if (LOG) m_device->logerror("Z80PIO Port %c Interrupt Enable: %u\n", 'A' + m_index, BIT(data, 7));
 
 				// set interrupt enable
 				m_ie = BIT(m_icw, 7) ? true : false;
@@ -655,14 +660,14 @@ void z80pio_device::pio_port::control_write(UINT8 data)
 				break;
 
 			default:
-				m_device->logerror("Z80PIO '%s' Port %c Invalid Control Word: %02x!\n", m_device->tag(), 'A' + m_index, data);
+				m_device->logerror("Z80PIO Port %c Invalid Control Word: %02x!\n", 'A' + m_index, data);
 			}
 		}
 		break;
 
 	case IOR: // data direction register
 		m_ior = data;
-		if (LOG) m_device->logerror("Z80PIO '%s' Port %c IOR: %02x\n", m_device->tag(), 'A' + m_index, data);
+		if (LOG) m_device->logerror("Z80PIO Port %c IOR: %02x\n", 'A' + m_index, data);
 
 		// set interrupt enable
 		m_ie = BIT(m_icw, 7) ? true : false;
@@ -674,7 +679,7 @@ void z80pio_device::pio_port::control_write(UINT8 data)
 
 	case MASK: // interrupt mask
 		m_mask = data;
-		if (LOG) m_device->logerror("Z80PIO '%s' Port %c Mask: %02x\n", m_device->tag(), 'A' + m_index, data);
+		if (LOG) m_device->logerror("Z80PIO Port %c Mask: %02x\n", 'A' + m_index, data);
 
 		// set interrupt enable
 		m_ie = BIT(m_icw, 7) ? true : false;
@@ -709,6 +714,7 @@ UINT8 z80pio_device::pio_port::data_read()
 				m_input = m_device->m_in_pa_cb(0);
 			else
 				m_input = m_device->m_in_pb_cb(0);
+			if (LOG) m_device->logerror("Z80PIO Port %c In: %02x\n", 'A' + m_index, m_input);
 		}
 
 		data = m_input;
@@ -736,6 +742,7 @@ UINT8 z80pio_device::pio_port::data_read()
 			m_input = m_device->m_in_pa_cb(0);
 		else
 			m_input = m_device->m_in_pb_cb(0);
+		if (LOG) m_device->logerror("Z80PIO Port %c In: %02x & %02x\n", 'A' + m_index, m_input, m_ior);
 
 		data = (m_input & m_ior) | (m_output & (m_ior ^ 0xff));
 		break;
@@ -759,6 +766,7 @@ void z80pio_device::pio_port::data_write(UINT8 data)
 
 		// latch output data
 		m_output = data;
+		if (LOG) m_device->logerror("Z80PIO Port %c Out: %02x\n", 'A' + m_index, m_output);
 
 		// output data to port
 		if (m_index == PORT_A)
@@ -784,6 +792,8 @@ void z80pio_device::pio_port::data_write(UINT8 data)
 
 		if (!m_stb)
 		{
+			if (LOG) m_device->logerror("Z80PIO Port %c Out: %02x\n", 'A' + m_index, m_output);
+
 			// output data to port
 			if (m_index == PORT_A)
 				m_device->m_out_pa_cb((offs_t)0, data);
@@ -798,6 +808,7 @@ void z80pio_device::pio_port::data_write(UINT8 data)
 	case MODE_BIT_CONTROL:
 		// latch output data
 		m_output = data;
+		if (LOG) m_device->logerror("Z80PIO Port %c Out: %02x | %02x\n", 'A' + m_index, m_output, m_ior);
 
 		// output data to port
 		if (m_index == PORT_A)

--- a/src/mame/drivers/bbcbc.cpp
+++ b/src/mame/drivers/bbcbc.cpp
@@ -43,17 +43,19 @@ public:
 		: driver_device(mconfig, type, tag),
 		m_maincpu(*this, "maincpu"),
 		m_pio(*this, "z80pio"),
-		m_cart(*this, "cartslot")
+		m_cart(*this, "cartslot"),
+		m_buttons(*this, "BUTTONS")
 	{ }
 
 	required_device<cpu_device> m_maincpu;
 	required_device<z80pio_device> m_pio;
 	required_device<generic_slot_device> m_cart;
+	required_ioport_array<3> m_buttons;
 
 	UINT8 m_input_select;
 
-	void machine_start() override;
-	void machine_reset() override;
+	virtual void machine_start() override;
+	virtual void machine_reset() override;
 
 	DECLARE_READ8_MEMBER(pio_r);
 	DECLARE_WRITE8_MEMBER(pio_w);
@@ -90,21 +92,21 @@ ADDRESS_MAP_END
 
 // Input bits are read through the PIO four at a time, then stored individually in RAM at E030-E03B
 static INPUT_PORTS_START( bbcbc )
-	PORT_START("BUTTONS1")
+	PORT_START("BUTTONS.0")
 	PORT_BIT(0x01, IP_ACTIVE_LOW, IPT_KEYPAD) PORT_NAME("Pass") PORT_CODE(KEYCODE_A) // Grey button
 	PORT_BIT(0x02, IP_ACTIVE_LOW, IPT_KEYPAD) PORT_NAME("Spades") PORT_CODE(KEYCODE_Z) // Grey button
 	PORT_BIT(0x04, IP_ACTIVE_LOW, IPT_KEYPAD) PORT_NAME("Clubs") PORT_CODE(KEYCODE_V) // Grey button
 	PORT_BIT(0x08, IP_ACTIVE_LOW, IPT_KEYPAD) PORT_NAME("Rdbl") PORT_CODE(KEYCODE_F) // Grey button
 	PORT_BIT(0xf0, IP_ACTIVE_LOW, IPT_UNUSED)
 
-	PORT_START("BUTTONS2")
+	PORT_START("BUTTONS.1")
 	PORT_BIT(0x01, IP_ACTIVE_LOW, IPT_KEYPAD) PORT_NAME("NT") PORT_CODE(KEYCODE_S) // Grey button
 	PORT_BIT(0x02, IP_ACTIVE_LOW, IPT_KEYPAD) PORT_NAME("Hearts, Up") PORT_CODE(KEYCODE_X) // Grey button
 	PORT_BIT(0x04, IP_ACTIVE_LOW, IPT_BUTTON1) PORT_NAME("Play, Yes") // Yellow button
 	PORT_BIT(0x08, IP_ACTIVE_LOW, IPT_SELECT) PORT_NAME("Back") // Red button
 	PORT_BIT(0xf0, IP_ACTIVE_LOW, IPT_UNUSED)
 
-	PORT_START("BUTTONS3")
+	PORT_START("BUTTONS.2")
 	PORT_BIT(0x01, IP_ACTIVE_LOW, IPT_KEYPAD) PORT_NAME("Dbl") PORT_CODE(KEYCODE_D) // Grey button
 	PORT_BIT(0x02, IP_ACTIVE_LOW, IPT_KEYPAD) PORT_NAME("Diamonds, Down") PORT_CODE(KEYCODE_C) // Grey button
 	PORT_BIT(0x04, IP_ACTIVE_LOW, IPT_START) PORT_NAME("Start") // Red button
@@ -159,11 +161,11 @@ READ8_MEMBER(bbcbc_state::input_r)
 	switch (m_input_select)
 	{
 		case 0xef:
-			return ioport("BUTTONS1")->read();
+			return m_buttons[0]->read();
 		case 0xdf:
-			return ioport("BUTTONS2")->read();
+			return m_buttons[1]->read();
 		case 0xbf:
-			return ioport("BUTTONS3")->read();
+			return m_buttons[2]->read();
 	}
 	logerror("Unknown input select: %02x\n", m_input_select);
 	return 0xff;

--- a/src/mame/drivers/bbcbc.cpp
+++ b/src/mame/drivers/bbcbc.cpp
@@ -23,7 +23,7 @@
 
     (C) 1985 Unicard Ltd.
 
-    The title BBC Bridge is under license from BBC Enterprises Ltd.
+    The title BBC Bridge is under licence from BBC Enterprises Ltd.
 
 ***************************************************************************/
 
@@ -176,7 +176,7 @@ WRITE8_MEMBER(bbcbc_state::input_select_w)
 
 
 ROM_START( bbcbc )
-	ROM_REGION( 0x10000, "maincpu", ROMREGION_ERASEFF )
+	ROM_REGION( 0x4000, "maincpu", ROMREGION_ERASEFF )
 	ROM_LOAD("br_4_1.ic3", 0x0000, 0x2000, CRC(7c880d75) SHA1(954db096bd9e8edfef72946637a12f1083841fb0))
 	ROM_LOAD("br_4_2.ic4", 0x2000, 0x2000, CRC(16a33aef) SHA1(9529f9f792718a3715af2063b91a5fb18f741226))
 ROM_END

--- a/src/mame/drivers/bbcbc.cpp
+++ b/src/mame/drivers/bbcbc.cpp
@@ -9,6 +9,22 @@
   Inputs hooked up - 2009-03-14 - Robbbert
   Clock Freq added - 2009-05-18 - incog
 
+  From the Operations Manual, Page 1:
+
+    The BBC BRIDGE COMPANION and its associated family of
+    Cartridges are distributed in the U.K. by:
+
+    CONTEMPORARY CHESS COMPUTERS
+    2/3 Noble Corner
+    Great West Road
+    HOUNSLOW
+    Middlesex
+    TW5 0PA
+
+    (C) 1985 Unicard Ltd.
+
+    The title BBC Bridge is under license from BBC Enterprises Ltd.
+
 ***************************************************************************/
 
 #include "emu.h"
@@ -26,81 +42,74 @@ public:
 	bbcbc_state(const machine_config &mconfig, device_type type, const char *tag)
 		: driver_device(mconfig, type, tag),
 		m_maincpu(*this, "maincpu"),
+		m_pio(*this, "z80pio"),
 		m_cart(*this, "cartslot")
 	{ }
 
 	required_device<cpu_device> m_maincpu;
+	required_device<z80pio_device> m_pio;
 	required_device<generic_slot_device> m_cart;
-	virtual void machine_start() override;
-	virtual void machine_reset() override;
+
+	UINT8 m_input_select;
+
+	void machine_start() override;
+	void machine_reset() override;
+
+	DECLARE_READ8_MEMBER(pio_r);
+	DECLARE_WRITE8_MEMBER(pio_w);
+	DECLARE_READ8_MEMBER(input_r);
+	DECLARE_WRITE8_MEMBER(input_select_w);
 };
 
 
 #define MAIN_CLOCK XTAL_4_433619MHz
 
 
+READ8_MEMBER(bbcbc_state::pio_r)
+{
+	return m_pio->read(space, offset >> 5, mem_mask);
+}
+
+WRITE8_MEMBER(bbcbc_state::pio_w)
+{
+	m_pio->write(space, offset >> 5, data, mem_mask);
+}
+
 static ADDRESS_MAP_START( bbcbc_prg, AS_PROGRAM, 8, bbcbc_state )
 	AM_RANGE(0x0000, 0x3fff) AM_ROM
-	//AM_RANGE(0x4000, 0xbfff)  // mapped by the cartslot
-	AM_RANGE(0xe000, 0xe02f) AM_RAM
-	AM_RANGE(0xe030, 0xe030) AM_READ_PORT("LINE01")
-	AM_RANGE(0xe031, 0xe031) AM_READ_PORT("LINE02")
-	AM_RANGE(0xe032, 0xe032) AM_READ_PORT("LINE03")
-	AM_RANGE(0xe033, 0xe033) AM_READ_PORT("LINE04")
-	AM_RANGE(0xe034, 0xe034) AM_READ_PORT("LINE05")
-	AM_RANGE(0xe035, 0xe035) AM_READ_PORT("LINE06")
-	AM_RANGE(0xe036, 0xe036) AM_READ_PORT("LINE07")
-	AM_RANGE(0xe037, 0xe037) AM_READ_PORT("LINE08")
-	AM_RANGE(0xe038, 0xe038) AM_READ_PORT("LINE09")
-	AM_RANGE(0xe039, 0xe039) AM_READ_PORT("LINE10")
-	AM_RANGE(0xe03a, 0xe03a) AM_READ_PORT("LINE11")
-	AM_RANGE(0xe03b, 0xe03b) AM_READ_PORT("LINE12")
-	AM_RANGE(0xe03c, 0xe7ff) AM_RAM
+	AM_RANGE(0x4000, 0xbfff) AM_DEVREAD("cartslot", generic_slot_device, read_rom)
+	AM_RANGE(0xe000, 0xe7ff) AM_RAM
 ADDRESS_MAP_END
 
 static ADDRESS_MAP_START( bbcbc_io, AS_IO, 8, bbcbc_state )
 	ADDRESS_MAP_GLOBAL_MASK(0xff)
-	AM_RANGE(0x40, 0x43) AM_DEVREADWRITE("z80pio", z80pio_device, read, write)
+	AM_RANGE(0x00, 0x7f) AM_READWRITE(pio_r, pio_w) // actually only $00, $20, $40, $60
 	AM_RANGE(0x80, 0x80) AM_DEVREADWRITE("tms9129", tms9129_device, vram_read, vram_write)
 	AM_RANGE(0x81, 0x81) AM_DEVREADWRITE("tms9129", tms9129_device, register_read, register_write)
 ADDRESS_MAP_END
 
+// Input bits are read through the PIO four at a time, then stored individually in RAM at E030-E03B
 static INPUT_PORTS_START( bbcbc )
-	PORT_START("LINE01")
-	PORT_BIT(0x01, IP_ACTIVE_HIGH, IPT_KEYBOARD) PORT_NAME("Pass") PORT_CODE(KEYCODE_W) PORT_IMPULSE(1)
+	PORT_START("BUTTONS1")
+	PORT_BIT(0x01, IP_ACTIVE_LOW, IPT_KEYPAD) PORT_NAME("Pass") PORT_CODE(KEYCODE_A) // Grey button
+	PORT_BIT(0x02, IP_ACTIVE_LOW, IPT_KEYPAD) PORT_NAME("Spades") PORT_CODE(KEYCODE_Z) // Grey button
+	PORT_BIT(0x04, IP_ACTIVE_LOW, IPT_KEYPAD) PORT_NAME("Clubs") PORT_CODE(KEYCODE_V) // Grey button
+	PORT_BIT(0x08, IP_ACTIVE_LOW, IPT_KEYPAD) PORT_NAME("Rdbl") PORT_CODE(KEYCODE_F) // Grey button
+	PORT_BIT(0xf0, IP_ACTIVE_LOW, IPT_UNUSED)
 
-	PORT_START("LINE02")
-	PORT_BIT(0x01, IP_ACTIVE_HIGH, IPT_KEYBOARD) PORT_NAME("Clubs") PORT_CODE(KEYCODE_G) PORT_IMPULSE(1)
+	PORT_START("BUTTONS2")
+	PORT_BIT(0x01, IP_ACTIVE_LOW, IPT_KEYPAD) PORT_NAME("NT") PORT_CODE(KEYCODE_S) // Grey button
+	PORT_BIT(0x02, IP_ACTIVE_LOW, IPT_KEYPAD) PORT_NAME("Hearts, Up") PORT_CODE(KEYCODE_X) // Grey button
+	PORT_BIT(0x04, IP_ACTIVE_LOW, IPT_BUTTON1) PORT_NAME("Play, Yes") // Yellow button
+	PORT_BIT(0x08, IP_ACTIVE_LOW, IPT_SELECT) PORT_NAME("Back") // Red button
+	PORT_BIT(0xf0, IP_ACTIVE_LOW, IPT_UNUSED)
 
-	PORT_START("LINE03")
-	PORT_BIT(0x01, IP_ACTIVE_HIGH, IPT_KEYBOARD) PORT_NAME("Spades") PORT_CODE(KEYCODE_D) PORT_IMPULSE(1)
-
-	PORT_START("LINE04")
-	PORT_BIT(0x01, IP_ACTIVE_HIGH, IPT_KEYBOARD) PORT_NAME("Rdbl") PORT_CODE(KEYCODE_T) PORT_IMPULSE(1)
-
-	PORT_START("LINE05")
-	PORT_BIT(0x01, IP_ACTIVE_HIGH, IPT_KEYBOARD) PORT_NAME("NT") PORT_CODE(KEYCODE_E) PORT_IMPULSE(1)
-
-	PORT_START("LINE06")
-	PORT_BIT(0x01, IP_ACTIVE_HIGH, IPT_KEYBOARD) PORT_NAME("Hearts, Up") PORT_CODE(KEYCODE_S) PORT_IMPULSE(1)
-
-	PORT_START("LINE07")
-	PORT_BIT(0x01, IP_ACTIVE_HIGH, IPT_KEYBOARD) PORT_NAME("Play, Yes") PORT_CODE(KEYCODE_X) PORT_IMPULSE(1)
-
-	PORT_START("LINE08")
-	PORT_BIT(0x01, IP_ACTIVE_HIGH, IPT_KEYBOARD) PORT_NAME("Back") PORT_CODE(KEYCODE_A) PORT_IMPULSE(1)
-
-	PORT_START("LINE09")
-	PORT_BIT(0x01, IP_ACTIVE_HIGH, IPT_KEYBOARD) PORT_NAME("Dbl") PORT_CODE(KEYCODE_R) PORT_IMPULSE(1)
-
-	PORT_START("LINE10")
-	PORT_BIT(0x01, IP_ACTIVE_HIGH, IPT_KEYBOARD) PORT_NAME("Diamonds, Down") PORT_CODE(KEYCODE_F) PORT_IMPULSE(1)
-
-	PORT_START("LINE11")
-	PORT_BIT(0x01, IP_ACTIVE_HIGH, IPT_KEYBOARD) PORT_NAME("Start") PORT_CODE(KEYCODE_Q) PORT_IMPULSE(1)
-
-	PORT_START("LINE12")
-	PORT_BIT(0x01, IP_ACTIVE_HIGH, IPT_KEYBOARD) PORT_NAME("Play, No") PORT_CODE(KEYCODE_B) PORT_IMPULSE(1)
+	PORT_START("BUTTONS3")
+	PORT_BIT(0x01, IP_ACTIVE_LOW, IPT_KEYPAD) PORT_NAME("Dbl") PORT_CODE(KEYCODE_D) // Grey button
+	PORT_BIT(0x02, IP_ACTIVE_LOW, IPT_KEYPAD) PORT_NAME("Diamonds, Down") PORT_CODE(KEYCODE_C) // Grey button
+	PORT_BIT(0x04, IP_ACTIVE_LOW, IPT_START) PORT_NAME("Start") // Red button
+	PORT_BIT(0x08, IP_ACTIVE_LOW, IPT_BUTTON2) PORT_NAME("Play, No") // Yellow button
+	PORT_BIT(0xf0, IP_ACTIVE_LOW, IPT_UNUSED)
 INPUT_PORTS_END
 
 
@@ -111,24 +120,17 @@ static const z80_daisy_config bbcbc_daisy_chain[] =
 };
 
 
-void bbcbc_state::machine_start()
-{
-	if (m_cart->exists())
-		m_maincpu->space(AS_PROGRAM).install_read_handler(0x4000, 0xbfff, read8_delegate(FUNC(generic_slot_device::read_rom),(generic_slot_device*)m_cart));
-}
-
-void bbcbc_state::machine_reset()
-{
-}
-
-
 static MACHINE_CONFIG_START( bbcbc, bbcbc_state )
 	MCFG_CPU_ADD( "maincpu", Z80, MAIN_CLOCK / 8 )
-	MCFG_CPU_PROGRAM_MAP( bbcbc_prg)
-	MCFG_CPU_IO_MAP( bbcbc_io)
+	MCFG_CPU_PROGRAM_MAP(bbcbc_prg)
+	MCFG_CPU_IO_MAP(bbcbc_io)
 	MCFG_Z80_DAISY_CHAIN(bbcbc_daisy_chain)
 
 	MCFG_DEVICE_ADD("z80pio", Z80PIO, MAIN_CLOCK/8)
+	//MCFG_Z80PIO_OUT_PA_CB(???)
+	//MCFG_Z80PIO_IN_STROBE_CB(???)
+	MCFG_Z80PIO_IN_PB_CB(READ8(bbcbc_state, input_r))
+	MCFG_Z80PIO_OUT_PB_CB(WRITE8(bbcbc_state, input_select_w))
 
 	MCFG_DEVICE_ADD( "tms9129", TMS9129, XTAL_10_738635MHz / 2 )
 	MCFG_TMS9928A_VRAM_SIZE(0x4000)
@@ -136,11 +138,41 @@ static MACHINE_CONFIG_START( bbcbc, bbcbc_state )
 	MCFG_TMS9928A_SCREEN_ADD_PAL( "screen" )
 	MCFG_SCREEN_UPDATE_DEVICE( "tms9129", tms9928a_device, screen_update )
 
+	// Software on ROM cartridges
 	MCFG_GENERIC_CARTSLOT_ADD("cartslot", generic_plain_slot, "bbcbc_cart")
-
-	/* Software lists */
 	MCFG_SOFTWARE_LIST_ADD("cart_list","bbcbc")
 MACHINE_CONFIG_END
+
+
+void bbcbc_state::machine_start()
+{
+	save_item(NAME(m_input_select));
+}
+
+void bbcbc_state::machine_reset()
+{
+	m_input_select = 0xff;
+}
+
+READ8_MEMBER(bbcbc_state::input_r)
+{
+	switch (m_input_select)
+	{
+		case 0xef:
+			return ioport("BUTTONS1")->read();
+		case 0xdf:
+			return ioport("BUTTONS2")->read();
+		case 0xbf:
+			return ioport("BUTTONS3")->read();
+	}
+	logerror("Unknown input select: %02x\n", m_input_select);
+	return 0xff;
+}
+
+WRITE8_MEMBER(bbcbc_state::input_select_w)
+{
+	m_input_select = data;
+}
 
 
 ROM_START( bbcbc )
@@ -156,4 +188,4 @@ ROM_END
 ***************************************************************************/
 
 /*   YEAR  NAME   PARENT  COMPAT  MACHINE INPUT  CLASS          INIT  COMPANY                 FULLNAME            FLAGS */
-CONS(1985, bbcbc, 0,      0,      bbcbc,  bbcbc, driver_device, 0,    "BBC Enterprises Ltd.", "Bridge Companion", MACHINE_NO_SOUND_HW )
+CONS(1985, bbcbc, 0,      0,      bbcbc,  bbcbc, driver_device, 0,    "Unicard", "BBC Bridge Companion", MACHINE_NO_SOUND_HW | MACHINE_SUPPORTS_SAVE)


### PR DESCRIPTION
- Button mappings completely reworked: grey bidding/suit selection buttons classified as keypad inputs and put in correct order, and other buttons as console-standard Start, Select, Button 1-2
- Inputs now read through PIO instead of RAM addresses, making them less hypersensitive
- Manufacturer/publisher is Unicard, as manuals and system/cartridge labels clearly state
- Added release years for some common cartridges
- (nw) Link bbcbc in its own library rather than the unrelated libacorn ("make clean" strongly recommended)