### PR TITLE
Correct JRC6355E implementation to agree with NJU6355 datasheet

### DIFF
--- a/src/devices/machine/rtc4543.h
+++ b/src/devices/machine/rtc4543.h
@@ -66,11 +66,14 @@ protected:
 	virtual bool rtc_feature_leap_year() override { return true; }
 
 	// helpers
+	virtual void ce_rising();
+	virtual void ce_falling();
 	virtual void clk_rising();
 	virtual void clk_falling();
 	void load_bit(int reg);
 	void store_bit(int reg);
 	void advance_bit();
+	void update_effective();
 
 	devcb_write_line data_cb;
 
@@ -97,6 +100,8 @@ public:
 
 protected:
 	// rtc4543 overrides
+	virtual void ce_rising() override;
+	virtual void ce_falling() override;
 	virtual void clk_rising() override;
 	virtual void clk_falling() override;
 };

--- a/src/mame/drivers/feversoc.cpp
+++ b/src/mame/drivers/feversoc.cpp
@@ -9,7 +9,6 @@ A down-grade of the Seibu SPI Hardware with SH-2 as main cpu.
 driver by Angelo Salese & Nicola Salmoria
 
 TODO:
-- Make RTC writes actually go through (SH2 interrupt/timing issue?)
 - Determine what buttons 5-7 actually do
 - Find out where the NVRAM maps to
 - Layout including lamps


### PR DESCRIPTION
RTC writes and reads in feversoc both fully work now.