### PR TITLE
Fixing wrong title name

### DIFF
--- a/hash/apple2.xml
+++ b/hash/apple2.xml
@@ -570,7 +570,7 @@
 	</software>
 
 	<software name="aklabeth">
-		<description>Aklabeth</description>
+		<description>Akalabeth - World of Doom</description>
 		<year>19??</year>
 		<publisher>California Pacific Computer</publisher>
 


### PR DESCRIPTION
The name of the software is "Akalabeth - World of Doom" and not "Aklabeth" as in software-list