### PR TITLE
Take pkg-config path from env if defined

### DIFF
--- a/scripts/src/osd/modules.lua
+++ b/scripts/src/osd/modules.lua
@@ -35,6 +35,14 @@ function addoptionsfromstring(str)
 	end
 end
 
+function pkgconfigcmd()
+	local pkgconfig = os.getenv("PKG_CONFIG")
+	if pkgconfig == nil then 
+		return "pkg-config" 
+	end
+	return pkgconfig
+end
+
 function osdmodulesbuild()
 
 	removeflags {
@@ -343,7 +351,7 @@ function qtdebuggerbuild()
 				}
 			else
 				buildoptions {
-					backtick("pkg-config --cflags Qt5Widgets"),
+					backtick(pkgconfigcmd() .. " --cflags Qt5Widgets"),
 				}
 			end
 		end
@@ -378,7 +386,7 @@ function osdmodulestargetconf()
 
 	if _OPTIONS["NO_USE_MIDI"]~="1" then
 		if _OPTIONS["targetos"]=="linux" then
-			local str = backtick("pkg-config --libs alsa")
+			local str = backtick(pkgconfigcmd() .. " --libs alsa")
 			addlibfromstring(str)
 			addoptionsfromstring(str)
 		elseif _OPTIONS["targetos"]=="macosx" then
@@ -419,7 +427,7 @@ function osdmodulestargetconf()
 					"Qt5Widgets",
 				}
 			else
-				local str = backtick("pkg-config --libs Qt5Widgets")
+				local str = backtick(pkgconfigcmd() .. " --libs Qt5Widgets")
 				addlibfromstring(str)
 				addoptionsfromstring(str)
 			end

--- a/scripts/src/osd/sdl.lua
+++ b/scripts/src/osd/sdl.lua
@@ -42,7 +42,7 @@ function maintargetosdoptions(_target,_subtarget)
 		links {
 			"SDL2_ttf",
 		}
-		local str = backtick("pkg-config --libs fontconfig")
+		local str = backtick(pkgconfigcmd() .. " --libs fontconfig")
 		addlibfromstring(str)
 		addoptionsfromstring(str)
 	end
@@ -132,7 +132,7 @@ function sdlconfigcmd()
 	if _OPTIONS["targetos"]=="asmjs" then
 		return "sdl2-config"
 	elseif not _OPTIONS["SDL_INSTALL_ROOT"] then
-		return _OPTIONS['TOOLCHAIN'] .. "pkg-config sdl2"
+		return pkgconfigcmd() .. " sdl2"
 	else
 		return path.join(_OPTIONS["SDL_INSTALL_ROOT"],"bin","sdl2") .. "-config"
 	end

--- a/scripts/src/osd/sdl_cfg.lua
+++ b/scripts/src/osd/sdl_cfg.lua
@@ -1,6 +1,8 @@
 -- license:BSD-3-Clause
 -- copyright-holders:MAMEdev Team
 
+dofile('modules.lua')
+
 forcedincludes {
 	MAME_DIR .. "src/osd/sdl/sdlprefix.h"
 }
@@ -52,7 +54,7 @@ end
 
 if _OPTIONS["NO_USE_MIDI"]~="1" and _OPTIONS["targetos"]=="linux" then
 	buildoptions {
-		backtick("pkg-config --cflags alsa"),
+		backtick(pkgconfigcmd() .. " --cflags alsa"),
 	}
 end
 
@@ -94,7 +96,7 @@ if BASE_TARGETOS=="unix" then
 		}
 		if _OPTIONS["targetos"]~="asmjs" then
 			buildoptions {
-				backtick("pkg-config --cflags fontconfig"),
+				backtick(pkgconfigcmd() .. " --cflags fontconfig"),
 			}
 		end
 	end
@@ -121,7 +123,7 @@ elseif _OPTIONS["targetos"]=="linux" then
 		}
 	else
 		buildoptions {
-			backtick("pkg-config --cflags Qt5Widgets"),
+			backtick(pkgconfigcmd() .. " --cflags Qt5Widgets"),
 		}
 	end
 elseif _OPTIONS["targetos"]=="macosx" then


### PR DESCRIPTION
On some systems pkg-config is not available under that name, but for example a prefixed variant. Those systems set the PKG_CONFIG environment variable to define which binary should be called for pkg-config.

While this works for all makefiles etc., the lua osd scripts don't respect that variable.

The attached patch implements that behaviour for the osd build scripts, falling back to "pkg-config" if the variable is nil.