### PR TITLE
Crosshair refactoring (nw)

### DIFF
--- a/src/emu/crsshair.cpp
+++ b/src/emu/crsshair.cpp
@@ -95,6 +95,183 @@ static const rgb_t crosshair_colors[] =
 	rgb_t(0xff,0xff,0xff)
 };
 
+
+//**************************************************************************
+//  RENDER CROSSHAIR
+//**************************************************************************
+
+//-------------------------------------------------
+//  render_crosshair - constructor
+//-------------------------------------------------
+
+render_crosshair::render_crosshair(running_machine &machine, int player)
+	: m_machine(machine)
+	, m_player(player)
+	, m_used(false)
+	, m_mode(CROSSHAIR_VISIBILITY_OFF)
+	, m_visible(false)
+	, m_texture(nullptr)
+	, m_x(0.0f)
+	, m_y(0.0f)
+	, m_last_x(0.0f)
+	, m_last_y(0.0f)
+	, m_time(0)
+{
+	// for now, use the main screen
+	m_screen = machine.first_screen();
+}
+
+
+//-------------------------------------------------
+//  render_crosshair - destructor
+//-------------------------------------------------
+
+render_crosshair::~render_crosshair()
+{
+	m_machine.render().texture_free(m_texture);
+}
+
+
+//-------------------------------------------------
+//  set_bitmap_name - change the bitmap name
+//-------------------------------------------------
+
+void render_crosshair::set_bitmap_name(const char *name)
+{
+	// update bitmap if name has changed
+	bool changed = name != m_name;
+	m_name = name;
+	if (changed)
+		create_bitmap();
+}
+
+
+//-------------------------------------------------
+//  set_default_bitmap - reset to default bitmap
+//-------------------------------------------------
+
+void render_crosshair::set_default_bitmap()
+{
+	// update bitmap if name has changed
+	bool changed = !m_name.empty();
+	m_name.clear();
+	if (changed || m_bitmap == nullptr)
+		create_bitmap();
+}
+
+
+//-------------------------------------------------
+//  create_bitmap - create the rendering
+//  structures for the given player
+//-------------------------------------------------
+
+void render_crosshair::create_bitmap()
+{
+	int x, y;
+	rgb_t color = m_player < ARRAY_LENGTH(crosshair_colors) ? crosshair_colors[m_player] : rgb_t::white;
+
+	// if we have a bitmap and texture for this player, kill it
+	if (m_bitmap == nullptr)
+	{
+		m_bitmap = std::make_unique<bitmap_argb32>();
+		m_texture = m_machine.render().texture_alloc(render_texture::hq_scale);
+	}
+
+	emu_file crossfile(m_machine.options().crosshair_path(), OPEN_FLAG_READ);
+	if (!m_name.empty())
+	{
+		// look for user specified file
+		std::string filename = m_name + ".png";
+		render_load_png(*m_bitmap, crossfile, nullptr, filename.c_str());
+	}
+	else
+	{
+		// look for default cross?.png in crsshair/game dir
+		std::string filename = string_format("cross%d.png", m_player + 1);
+		render_load_png(*m_bitmap, crossfile, m_machine.system().name, filename.c_str());
+
+		// look for default cross?.png in crsshair dir
+		if (!m_bitmap->valid())
+			render_load_png(*m_bitmap, crossfile, nullptr, filename.c_str());
+	}
+
+	/* if that didn't work, use the built-in one */
+	if (!m_bitmap->valid())
+	{
+		/* allocate a blank bitmap to start with */
+		m_bitmap->allocate(CROSSHAIR_RAW_SIZE, CROSSHAIR_RAW_SIZE);
+		m_bitmap->fill(rgb_t(0x00,0xff,0xff,0xff));
+
+		/* extract the raw source data to it */
+		for (y = 0; y < CROSSHAIR_RAW_SIZE / 2; y++)
+		{
+			/* assume it is mirrored vertically */
+			UINT32 *dest0 = &m_bitmap->pix32(y);
+			UINT32 *dest1 = &m_bitmap->pix32(CROSSHAIR_RAW_SIZE - 1 - y);
+
+			/* extract to two rows simultaneously */
+			for (x = 0; x < CROSSHAIR_RAW_SIZE; x++)
+				if ((crosshair_raw_top[y * CROSSHAIR_RAW_ROWBYTES + x / 8] << (x % 8)) & 0x80)
+					dest0[x] = dest1[x] = rgb_t(0xff,0x00,0x00,0x00) | color;
+		}
+	}
+
+	/* reference the new bitmap */
+	m_texture->set_bitmap(*m_bitmap, m_bitmap->cliprect(), TEXFORMAT_ARGB32);
+}
+
+
+//-------------------------------------------------
+//  animate - update the crosshair state
+//-------------------------------------------------
+
+void render_crosshair::animate(UINT16 auto_time)
+{
+	// read all the port values
+	if (m_used)
+		m_machine.ioport().crosshair_position(m_player, m_x, m_y);
+
+	// auto visibility
+	if (m_mode == CROSSHAIR_VISIBILITY_AUTO)
+	{
+		if ((m_x != m_last_x) || (m_y != m_last_y))
+		{
+			// crosshair has moved, keep crosshair visible
+			m_visible = true;
+			m_last_x = m_x;
+			m_last_y = m_y;
+			m_time = 0;
+		}
+		else
+		{
+			// see if the player has been motionless for time specified
+			// slightly confusing formula, but the effect is:
+			// auto_time = 0 makes the crosshair barely visible while moved
+			// every increment in auto_time is about .2s at 60Hz
+			if (m_time > auto_time * 12 + 2)
+				// time exceeded so turn crosshair invisible
+				m_visible = false;
+
+			// increment player visibility time
+			m_time++;
+		}
+	}
+}
+
+
+//-------------------------------------------------
+//  draw - render the crosshair to the container
+//-------------------------------------------------
+
+void render_crosshair::draw(render_container &container, UINT8 fade)
+{
+	// add a quad assuming a 4:3 screen (this is not perfect)
+	container.add_quad(m_x - 0.03f, m_y - 0.04f, m_x + 0.03f, m_y + 0.04f,
+						rgb_t(0xc0, fade, fade, fade),
+						m_texture, PRIMFLAG_BLENDMODE(BLENDMODE_ALPHA));
+}
+
+
 //**************************************************************************
 //  CROSSHAIR MANAGER
 //**************************************************************************
@@ -105,12 +282,15 @@ static const rgb_t crosshair_colors[] =
 
 crosshair_manager::crosshair_manager(running_machine &machine)
 	: m_machine(machine)
+	, m_usage(false)
+	, m_animation_counter(0)
+	, m_auto_time(CROSSHAIR_VISIBILITY_AUTOTIME_DEFAULT)
 {
 	/* request a callback upon exiting */
 	machine.add_notifier(MACHINE_NOTIFY_EXIT, machine_notify_delegate(FUNC(crosshair_manager::exit), this));
 
-	/* setup the default auto visibility time */
-	m_auto_time = CROSSHAIR_VISIBILITY_AUTOTIME_DEFAULT;
+	for (int player = 0; player < MAX_PLAYERS; player++)
+		m_crosshair[player] = std::make_unique<render_crosshair>(machine, player);
 
 	/* determine who needs crosshairs */
 	for (auto &port : machine.ioport().ports())
@@ -122,15 +302,11 @@ crosshair_manager::crosshair_manager(running_machine &machine)
 				assert(player < MAX_PLAYERS);
 
 				/* mark as used and set the default visibility and mode */
-				m_usage = TRUE;
-				m_used[player] = TRUE;
-				m_mode[player] = CROSSHAIR_VISIBILITY_DEFAULT;
-				m_visible[player] = (CROSSHAIR_VISIBILITY_DEFAULT == CROSSHAIR_VISIBILITY_OFF) ? FALSE : TRUE;
-
-				/* for now, use the main screen */
-				m_screen[player] = machine.first_screen();
-
-				create_bitmap(player);
+				m_usage = true;
+				m_crosshair[player]->set_used(true);
+				m_crosshair[player]->set_mode(CROSSHAIR_VISIBILITY_DEFAULT);
+				m_crosshair[player]->set_visible(CROSSHAIR_VISIBILITY_DEFAULT != CROSSHAIR_VISIBILITY_OFF);
+				m_crosshair[player]->set_default_bitmap();
 			}
 
 	/* register callbacks for when we load/save configurations */
@@ -151,109 +327,7 @@ void crosshair_manager::exit()
 {
 	/* free bitmaps and textures for each player */
 	for (int player = 0; player < MAX_PLAYERS; player++)
-	{
-		machine().render().texture_free(m_texture[player]);
-		m_texture[player] = nullptr;
-		m_bitmap[player] = nullptr;
-	}
-}
-
-/*-------------------------------------------------
-    create_bitmap - create the rendering
-    structures for the given player
--------------------------------------------------*/
-
-void crosshair_manager::create_bitmap(int player)
-{
-	int x, y;
-	char filename[20];
-	rgb_t color = crosshair_colors[player];
-
-	/* if we have a bitmap and texture for this player, kill it */
-	if (m_bitmap[player] == nullptr) {
-		m_bitmap[player] = std::make_unique<bitmap_argb32>();
-		m_texture[player] = machine().render().texture_alloc(render_texture::hq_scale);
-	}
-
-	emu_file crossfile(machine().options().crosshair_path(), OPEN_FLAG_READ);
-	if (m_name[player][0] != 0)
-	{
-		/* look for user specified file */
-		sprintf(filename, "%s.png", m_name[player]);
-		render_load_png(*m_bitmap[player], crossfile, nullptr, filename);
-	}
-	else
-	{
-		/* look for default cross?.png in crsshair\game dir */
-		sprintf(filename, "cross%d.png", player + 1);
-		render_load_png(*m_bitmap[player], crossfile, machine().system().name, filename);
-
-		/* look for default cross?.png in crsshair dir */
-		if (!m_bitmap[player]->valid())
-			render_load_png(*m_bitmap[player], crossfile, nullptr, filename);
-	}
-
-	/* if that didn't work, use the built-in one */
-	if (!m_bitmap[player]->valid())
-	{
-		/* allocate a blank bitmap to start with */
-		m_bitmap[player]->allocate(CROSSHAIR_RAW_SIZE, CROSSHAIR_RAW_SIZE);
-		m_bitmap[player]->fill(rgb_t(0x00,0xff,0xff,0xff));
-
-		/* extract the raw source data to it */
-		for (y = 0; y < CROSSHAIR_RAW_SIZE / 2; y++)
-		{
-			/* assume it is mirrored vertically */
-			UINT32 *dest0 = &m_bitmap[player]->pix32(y);
-			UINT32 *dest1 = &m_bitmap[player]->pix32(CROSSHAIR_RAW_SIZE - 1 - y);
-
-			/* extract to two rows simultaneously */
-			for (x = 0; x < CROSSHAIR_RAW_SIZE; x++)
-				if ((crosshair_raw_top[y * CROSSHAIR_RAW_ROWBYTES + x / 8] << (x % 8)) & 0x80)
-					dest0[x] = dest1[x] = rgb_t(0xff,0x00,0x00,0x00) | color;
-		}
-	}
-
-	/* reference the new bitmap */
-	m_texture[player]->set_bitmap(*m_bitmap[player], m_bitmap[player]->cliprect(), TEXFORMAT_ARGB32);
-}
-
-/*-------------------------------------------------
-    get_user_settings - return the
-    current crosshair settings for a player
-    Note: auto_time is common for all players
--------------------------------------------------*/
-
-void crosshair_manager::get_user_settings(UINT8 player, crosshair_user_settings *settings)
-{
-	settings->auto_time = m_auto_time;
-	settings->used = m_used[player];
-	settings->mode = m_mode[player];
-	strcpy(settings->name, m_name[player]);
-}
-
-
-/*-------------------------------------------------
-    set_user_settings - modify the
-    current crosshair settings for a player
-    Note: auto_time is common for all players
--------------------------------------------------*/
-
-void crosshair_manager::set_user_settings(UINT8 player, crosshair_user_settings *settings)
-{
-	m_auto_time = settings->auto_time;
-	m_used[player] = settings->used;
-	m_mode[player] = settings->mode;
-
-	/* set visibility as specified by mode */
-	/* auto mode starts with visibility off */
-	m_visible[player] = (settings->mode == CROSSHAIR_VISIBILITY_ON) ? TRUE : FALSE;
-
-	/* update bitmap if name has changed */
-	int changed = strcmp(settings->name, m_name[player]);
-	strcpy(m_name[player], settings->name);
-	if (changed != 0)
-		create_bitmap(player);
+		m_crosshair[player] = nullptr;
 }
 
 
@@ -279,37 +353,7 @@ void crosshair_manager::animate(screen_device &device, bool vblank_state)
 		m_fade = 0xa0 + (0x60 * (~m_animation_counter & 0x7f) / 0x80);
 
 	for (player = 0; player < MAX_PLAYERS; player++)
-	{
-		/* read all the lightgun values */
-		if (m_used[player])
-			device.machine().ioport().crosshair_position(player, m_x[player], m_y[player]);
-
-		/* auto visibility */
-		if (m_mode[player] == CROSSHAIR_VISIBILITY_AUTO)
-		{
-			if ((m_x[player] != m_last_x[player]) || (m_y[player] != m_last_y[player]))
-			{
-				/* crosshair has moved, keep crosshair visible */
-				m_visible[player] = TRUE;
-				m_last_x[player] = m_x[player];
-				m_last_y[player] = m_y[player];
-				m_time[player] = 0;
-			}
-			else
-			{
-				/* see if the player has been motionless for time specified */
-				/* slightly confusing formula, but the effect is: */
-				/* auto_time = 0 makes the crosshair barely visible while moved */
-				/* every increment in auto_time is about .2s at 60Hz */
-				if (m_time[player] > m_auto_time * 12 + 2)
-					/* time exceeded so turn crosshair invisible */
-					m_visible[player] = FALSE;
-
-				/* increment player visibility time */
-				m_time[player]++;
-			}
-		}
-	}
+		m_crosshair[player]->animate(m_auto_time);
 }
 
 
@@ -323,16 +367,13 @@ void crosshair_manager::render(screen_device &screen)
 	int player;
 
 	for (player = 0; player < MAX_PLAYERS; player++)
-		/* draw if visible and the right screen */
-		if (m_visible[player] &&
-			((m_screen[player] == &screen) || (m_screen[player] == CROSSHAIR_SCREEN_ALL)))
-		{
-			/* add a quad assuming a 4:3 screen (this is not perfect) */
-			screen.container().add_quad(m_x[player] - 0.03f, m_y[player] - 0.04f,
-										m_x[player] + 0.03f, m_y[player] + 0.04f,
-										rgb_t(0xc0, m_fade, m_fade, m_fade),
-										m_texture[player], PRIMFLAG_BLENDMODE(BLENDMODE_ALPHA));
-		}
+	{
+		render_crosshair &crosshair = *m_crosshair[player];
+
+		// draw if visible and the right screen
+		if (crosshair.is_visible() && ((crosshair.screen() == &screen) || (crosshair.screen() == CROSSHAIR_SCREEN_ALL)))
+			crosshair.draw(screen.container(), m_fade);
+	}
 }
 
 /*-------------------------------------------------
@@ -362,24 +403,26 @@ void crosshair_manager::config_load(config_type cfg_type, xml_data_node *parentn
 
 		player = xml_get_attribute_int(crosshairnode, "player", -1);
 
-		/* check to make sure we have a valid player */
-		/* also check if the player really uses a crosshair */
-		if (player >=0 && player < MAX_PLAYERS && m_used[player])
+		// check to make sure we have a valid player
+		if (player >= 0 && player < MAX_PLAYERS)
 		{
-			/* get, check, and store visibility mode */
-			mode = xml_get_attribute_int(crosshairnode, "mode", CROSSHAIR_VISIBILITY_DEFAULT);
-			if (mode >= CROSSHAIR_VISIBILITY_OFF && mode <= CROSSHAIR_VISIBILITY_AUTO)
+			// check if the player really uses a crosshair
+			render_crosshair &crosshair = *m_crosshair[player];
+			if (crosshair.is_used())
 			{
-				m_mode[player] = (UINT8)mode;
-				/* set visibility as specified by mode */
-				/* auto mode starts with visibility off */
-				m_visible[player] = (mode == CROSSHAIR_VISIBILITY_ON) ? TRUE : FALSE;
-			}
+				// get, check, and store visibility mode
+				mode = xml_get_attribute_int(crosshairnode, "mode", CROSSHAIR_VISIBILITY_DEFAULT);
+				if (mode >= CROSSHAIR_VISIBILITY_OFF && mode <= CROSSHAIR_VISIBILITY_AUTO)
+				{
+					crosshair.set_mode((UINT8)mode);
+					/* set visibility as specified by mode */
+					/* auto mode starts with visibility off */
+					crosshair.set_visible(mode == CROSSHAIR_VISIBILITY_ON);
+				}
 
-			/* get and store crosshair pic name, truncate name to max length */
-			strncpy(m_name[player], xml_get_attribute_string(crosshairnode, "pic", ""), CROSSHAIR_PIC_NAME_LENGTH);
-			/* update bitmap */
-			create_bitmap(player);
+				// get and store crosshair pic name
+				crosshair.set_bitmap_name(xml_get_attribute_string(crosshairnode, "pic", ""));
+			}
 		}
 	}
 
@@ -412,28 +455,30 @@ void crosshair_manager::config_save(config_type cfg_type, xml_data_node *parentn
 
 	for (player = 0; player < MAX_PLAYERS; player++)
 	{
-		if (m_used[player])
+		const render_crosshair &crosshair = *m_crosshair[player];
+
+		if (crosshair.is_used())
 		{
 			/* create a node */
 			crosshairnode = xml_add_child(parentnode, "crosshair", nullptr);
 
 			if (crosshairnode != nullptr)
 			{
-				int changed = FALSE;
+				bool changed = false;
 
 				xml_set_attribute_int(crosshairnode, "player", player);
 
-				if (m_visible[player] != CROSSHAIR_VISIBILITY_DEFAULT)
+				if (crosshair.mode() != CROSSHAIR_VISIBILITY_DEFAULT)
 				{
-					xml_set_attribute_int(crosshairnode, "mode", m_mode[player]);
-					changed = TRUE;
+					xml_set_attribute_int(crosshairnode, "mode", crosshair.mode());
+					changed = true;
 				}
 
-				/* the default graphic name is "", so only save if not */
-				if (*(m_name[player]) != 0)
+				// only save graphic name if not the default
+				if (*crosshair.bitmap_name() != '\0')
 				{
-					xml_set_attribute(crosshairnode, "pic", m_name[player]);
-					changed = TRUE;
+					xml_set_attribute(crosshairnode, "pic", crosshair.bitmap_name());
+					changed = true;
 				}
 
 				/* if nothing changed, kill the node */

--- a/src/emu/crsshair.h
+++ b/src/emu/crsshair.h
@@ -31,22 +31,64 @@
 #define CROSSHAIR_VISIBILITY_AUTOTIME_MAX           50
 #define CROSSHAIR_VISIBILITY_AUTOTIME_DEFAULT       15
 
-/* maximum crosshair pic filename size */
-#define CROSSHAIR_PIC_NAME_LENGTH               12
-
 
 
 /***************************************************************************
     TYPE DEFINITIONS
 ***************************************************************************/
 
-/* user-controllable settings for a player */
-struct crosshair_user_settings
+// ======================> render_crosshair
+
+class render_crosshair
 {
-	UINT8           used;       /* is used */
-	UINT8           mode;       /* visibility mode */
-	UINT8           auto_time;  /* time in seconds to blank crosshair if no movement */
-	char            name[CROSSHAIR_PIC_NAME_LENGTH + 1];        /* bitmap name */
+public:
+	// construction/destruction
+	render_crosshair(running_machine &machine, int player);
+	~render_crosshair();
+
+	// getters
+	running_machine &machine() const { return m_machine; }
+	int player() const { return m_player; }
+	bool is_used() const { return m_used; }
+	UINT8 mode() const { return m_mode; }
+	bool is_visible() const { return m_visible; }
+	screen_device *screen() const { return m_screen; }
+	float x() const { return m_x; }
+	float y() const { return m_y; }
+	const char *bitmap_name() const { return m_name.c_str(); }
+
+	// setters
+	void set_used(bool used) { m_used = used; }
+	void set_mode(UINT8 mode) { m_mode = mode; }
+	void set_visible(bool visible) { m_visible = visible; }
+	void set_screen(screen_device *screen) { m_screen = screen; }
+	//void setxy(float x, float y);
+	void set_bitmap_name(const char *name);
+	void set_default_bitmap();
+
+	// updates
+	void animate(UINT16 auto_time);
+	void draw(render_container &container, UINT8 fade);
+
+private:
+	// private helpers
+	void create_bitmap();
+
+	// private state
+	running_machine &   m_machine;  // reference to our machine
+	int                 m_player;   // player number
+	bool                m_used;     // usage for this crosshair
+	UINT8               m_mode;     // visibility mode for this crosshair
+	bool                m_visible;  // visibility for this crosshair
+	std::unique_ptr<bitmap_argb32>  m_bitmap;    // bitmap for this crosshair
+	render_texture *    m_texture;  // texture for this crosshair
+	screen_device *     m_screen;   // the screen on which this crosshair is drawn
+	float               m_x;        // current X position
+	float               m_y;        // current Y position
+	float               m_last_x;   // last X position
+	float               m_last_y;   // last Y position
+	UINT16              m_time;     // time since last movement
+	std::string         m_name;     // name of png file
 };
 
 
@@ -61,21 +103,16 @@ public:
 	/* draws crosshair(s) in a given screen, if necessary */
 	void render(screen_device &screen);
 
-	/* sets the screen(s) for a given player's crosshair */
-	void set_screen(int player, screen_device *screen) { m_screen[player] = screen; }
+	// return true if any crosshairs are used
+	bool get_usage() const { return m_usage; }
 
-	/* return TRUE if any crosshairs are used */
-	int get_usage() const { return m_usage; }
-
-	/* return the current crosshair settings for the given player */
-	void get_user_settings(UINT8 player, crosshair_user_settings *settings);
-
-	/* modify the current crosshair settings for the given player */
-	void set_user_settings(UINT8 player, crosshair_user_settings *settings);
 	// getters
 	running_machine &machine() const { return m_machine; }
+	render_crosshair &get_crosshair(int player) const { assert(player >= 0 && player < MAX_PLAYERS); assert(m_crosshair[player] != nullptr); return *m_crosshair[player]; }
+	UINT16 auto_time() const { return m_auto_time; }
+	void set_auto_time(UINT16 auto_time) { m_auto_time = auto_time; }
+
 private:
-	void create_bitmap(int player);
 	void exit();
 	void animate(screen_device &device, bool vblank_state);
 
@@ -85,22 +122,11 @@ private:
 	// internal state
 	running_machine &   m_machine;                  // reference to our machine
 
-	UINT8               m_usage;                  /* true if any crosshairs are used */
-	UINT8               m_used[MAX_PLAYERS];      /* usage per player */
-	UINT8               m_mode[MAX_PLAYERS];      /* visibility mode per player */
-	UINT8               m_visible[MAX_PLAYERS];   /* visibility per player */
-	std::unique_ptr<bitmap_argb32>  m_bitmap[MAX_PLAYERS];    /* bitmap per player */
-	render_texture *    m_texture[MAX_PLAYERS];   /* texture per player */
-	screen_device *     m_screen[MAX_PLAYERS];    /* the screen on which this player's crosshair is drawn */
-	float               m_x[MAX_PLAYERS];         /* current X position */
-	float               m_y[MAX_PLAYERS];         /* current Y position */
-	float               m_last_x[MAX_PLAYERS];    /* last X position */
-	float               m_last_y[MAX_PLAYERS];    /* last Y position */
-	UINT8               m_fade;                   /* color fading factor */
-	UINT8               m_animation_counter;      /* animation frame index */
-	UINT16              m_auto_time;              /* time in seconds to turn invisible */
-	UINT16              m_time[MAX_PLAYERS];      /* time since last movement */
-	char                m_name[MAX_PLAYERS][CROSSHAIR_PIC_NAME_LENGTH + 1];   /* name of crosshair png file */
+	bool                m_usage;                    // true if any crosshairs are used
+	std::unique_ptr<render_crosshair> m_crosshair[MAX_PLAYERS]; // per-player crosshair state
+	UINT8               m_fade;                     // color fading factor
+	UINT8               m_animation_counter;        // animation frame index
+	UINT16              m_auto_time;                // time in seconds to turn invisible
 };
 
 #endif  /* __CRSSHAIR_H__ */

--- a/src/frontend/mame/ui/miscmenu.h
+++ b/src/frontend/mame/ui/miscmenu.h
@@ -69,6 +69,9 @@ private:
 		CROSSHAIR_ITEM_AUTO_TIME
 	};
 
+	// FIXME: use std::string instead of fixed-length arrays
+	constexpr static int CROSSHAIR_PIC_NAME_LENGTH = 12;
+
 	/* internal crosshair menu item data */
 	struct crosshair_item_data
 	{

--- a/src/mame/machine/sms.cpp
+++ b/src/mame/machine/sms.cpp
@@ -1324,7 +1324,7 @@ VIDEO_START_MEMBER(sms_state,sms1)
 	save_item(NAME(m_frame_sscope_state));
 
 	// Allow sscope screens to have crosshair, useful for the game missil3d
-	machine().crosshair().set_screen(0, CROSSHAIR_SCREEN_ALL);
+	machine().crosshair().get_crosshair(0).set_screen(CROSSHAIR_SCREEN_ALL);
 }
 
 

--- a/src/mame/video/cave.cpp
+++ b/src/mame/video/cave.cpp
@@ -1715,11 +1715,11 @@ UINT32 cave_state::screen_update_ppsatan_top(screen_device &screen, bitmap_rgb32
 }
 UINT32 cave_state::screen_update_ppsatan_left(screen_device &screen, bitmap_rgb32 &bitmap, const rectangle &cliprect)
 {
-	machine().crosshair().set_screen(1, &screen);
+	machine().crosshair().get_crosshair(1).set_screen(&screen);
 	return screen_update_ppsatan_core(screen, bitmap, cliprect, 1);
 }
 UINT32 cave_state::screen_update_ppsatan_right(screen_device &screen, bitmap_rgb32 &bitmap, const rectangle &cliprect)
 {
-	machine().crosshair().set_screen(0, &screen);
+	machine().crosshair().get_crosshair(0).set_screen(&screen);
 	return screen_update_ppsatan_core(screen, bitmap, cliprect, 2);
 }


### PR DESCRIPTION
- Individual crosshairs are now first-class objects, rather than bits of state scattered across half a dozen arrays. The class is named render_crosshair with a view towards incorporating crosshairs into layouts in the future, rather than managing them separately as crosshair_manager still does now.
- Removed the old crosshair_user_settings interface for adjusting crosshair settings, since the UI can access the new crosshair objects directly.