### PR TITLE
Split "widgets" code out of ui::menu::global_state into a separate module

### DIFF
--- a/scripts/src/mame/frontend.lua
+++ b/scripts/src/mame/frontend.lua
@@ -160,4 +160,6 @@ files {
 	MAME_DIR .. "src/frontend/mame/ui/toolbar.h",
 	MAME_DIR .. "src/frontend/mame/ui/utils.cpp",
 	MAME_DIR .. "src/frontend/mame/ui/utils.h",
+	MAME_DIR .. "src/frontend/mame/ui/widgets.cpp",
+	MAME_DIR .. "src/frontend/mame/ui/widgets.h",
 }

--- a/src/frontend/mame/ui/menu.cpp
+++ b/src/frontend/mame/ui/menu.cpp
@@ -82,61 +82,12 @@ bool menu::exclusive_input_pressed(int &iptkey, int key, int repeat)
 ***************************************************************************/
 
 menu::global_state::global_state(running_machine &machine, ui_options const &options)
-	: m_machine(machine)
+	: widgets_manager(machine, options)
+	, m_machine(machine)
 	, m_cleanup_callbacks()
-	, m_hilight_bitmap(std::make_unique<bitmap_argb32>(256, 1))
-	, m_hilight_texture()
-	, m_hilight_main_bitmap(std::make_unique<bitmap_argb32>(1, 128))
-	, m_hilight_main_texture()
-	, m_bgrnd_bitmap()
-	, m_bgrnd_texture()
 	, m_stack()
 	, m_free()
 {
-	render_manager &render(machine.render());
-	auto const texture_free([&render](render_texture *texture) { render.texture_free(texture); });
-
-	// create a texture for hilighting items
-	for (unsigned x = 0; x < 256; ++x)
-	{
-		unsigned const alpha((x < 25) ? (0xff * x / 25) : (x > (256 - 25)) ? (0xff * (255 - x) / 25) : 0xff);
-		m_hilight_bitmap->pix32(0, x) = rgb_t(alpha, 0xff, 0xff, 0xff);
-	}
-	m_hilight_texture = texture_ptr(render.texture_alloc(), texture_free);
-	m_hilight_texture->set_bitmap(*m_hilight_bitmap, m_hilight_bitmap->cliprect(), TEXFORMAT_ARGB32);
-
-	// create a texture for hilighting items in main menu
-	for (unsigned y = 0; y < 128; ++y)
-	{
-		constexpr unsigned r1(0), g1(169), b1 = (255); // any start color
-		constexpr unsigned r2(0), g2(39), b2 = (130); // any stop color
-		unsigned const r = r1 + (y * (r2 - r1) / 128);
-		unsigned const g = g1 + (y * (g2 - g1) / 128);
-		unsigned const b = b1 + (y * (b2 - b1) / 128);
-		m_hilight_main_bitmap->pix32(y, 0) = rgb_t(r, g, b);
-	}
-	m_hilight_main_texture = texture_ptr(render.texture_alloc(), texture_free);
-	m_hilight_main_texture->set_bitmap(*m_hilight_main_bitmap, m_hilight_main_bitmap->cliprect(), TEXFORMAT_ARGB32);
-
-	// create a texture for arrow icons
-	m_arrow_texture = texture_ptr(render.texture_alloc(render_triangle), texture_free);
-
-	// create a texture for main menu background
-	m_bgrnd_texture = texture_ptr(render.texture_alloc(render_texture::hq_scale), texture_free);
-	if (options.use_background_image() && (&machine.system() == &GAME_NAME(___empty)))
-	{
-		m_bgrnd_bitmap = std::make_unique<bitmap_argb32>(0, 0);
-		emu_file backgroundfile(".", OPEN_FLAG_READ);
-		render_load_jpeg(*m_bgrnd_bitmap, backgroundfile, nullptr, "background.jpg");
-
-		if (!m_bgrnd_bitmap->valid())
-			render_load_png(*m_bgrnd_bitmap, backgroundfile, nullptr, "background.png");
-
-		if (m_bgrnd_bitmap->valid())
-			m_bgrnd_texture->set_bitmap(*m_bgrnd_bitmap, m_bgrnd_bitmap->cliprect(), TEXFORMAT_ARGB32);
-		else
-			m_bgrnd_bitmap->reset();
-	}
 }
 
 
@@ -1204,61 +1155,6 @@ UINT32 menu::ui_handler(render_container &container, mame_ui_manager &mui)
 /***************************************************************************
     MENU HELPERS
 ***************************************************************************/
-
-//-------------------------------------------------
-//  render_triangle - render a triangle that
-//  is used for up/down arrows and left/right
-//  indicators
-//-------------------------------------------------
-
-void menu::render_triangle(bitmap_argb32 &dest, bitmap_argb32 &source, const rectangle &sbounds, void *param)
-{
-	int halfwidth = dest.width() / 2;
-	int height = dest.height();
-	int x, y;
-
-	// start with all-transparent
-	dest.fill(rgb_t(0x00,0x00,0x00,0x00));
-
-	// render from the tip to the bottom
-	for (y = 0; y < height; y++)
-	{
-		int linewidth = (y * (halfwidth - 1) + (height / 2)) * 255 * 2 / height;
-		UINT32 *target = &dest.pix32(y, halfwidth);
-
-		// don't antialias if height < 12
-		if (dest.height() < 12)
-		{
-			int pixels = (linewidth + 254) / 255;
-			if (pixels % 2 == 0) pixels++;
-			linewidth = pixels * 255;
-		}
-
-		// loop while we still have data to generate
-		for (x = 0; linewidth > 0; x++)
-		{
-			int dalpha;
-
-			// first column we only consume one pixel
-			if (x == 0)
-			{
-				dalpha = MIN(0xff, linewidth);
-				target[x] = rgb_t(dalpha,0xff,0xff,0xff);
-			}
-
-			// remaining columns consume two pixels, one on each side
-			else
-			{
-				dalpha = MIN(0x1fe, linewidth);
-				target[x] = target[-x] = rgb_t(dalpha/2,0xff,0xff,0xff);
-			}
-
-			// account for the weight we consumed */
-			linewidth -= dalpha;
-		}
-	}
-}
-
 
 //-------------------------------------------------
 //  highlight

--- a/src/frontend/mame/ui/menu.h
+++ b/src/frontend/mame/ui/menu.h
@@ -15,6 +15,7 @@
 
 #include "ui/ui.h"
 #include "ui/menuitem.h"
+#include "ui/widgets.h"
 
 #include "language.h"
 #include "render.h"
@@ -98,8 +99,6 @@ private:
 	virtual void draw(UINT32 flags);
 	void draw_text_box();
 
-	static void render_triangle(bitmap_argb32 &dest, bitmap_argb32 &source, const rectangle &sbounds, void *param);
-
 public:
 	void *m_prev_selected;
 
@@ -111,8 +110,8 @@ public:
 
 protected:
 	using cleanup_callback = std::function<void(running_machine &)>;
-	using bitmap_ptr = std::unique_ptr<bitmap_argb32>;
-	using texture_ptr = std::unique_ptr<render_texture, std::function<void(render_texture *)> >;
+	using bitmap_ptr = widgets_manager::bitmap_ptr;
+	using texture_ptr = widgets_manager::texture_ptr;
 
 	// flags to pass to process
 	enum
@@ -257,7 +256,7 @@ protected:
 	int right_visible_lines;  // right box lines
 
 private:
-	class global_state
+	class global_state : public widgets_manager
 	{
 	public:
 		global_state(running_machine &machine, ui_options const &options);
@@ -266,12 +265,6 @@ private:
 		~global_state();
 
 		void add_cleanup_callback(cleanup_callback &&callback);
-
-		render_texture *hilight_texture() { return m_hilight_texture.get(); }
-		render_texture *hilight_main_texture() { return m_hilight_main_texture.get(); }
-		render_texture *arrow_texture() { return m_arrow_texture.get(); }
-		bitmap_argb32 *bgrnd_bitmap() { return m_bgrnd_bitmap.get(); }
-		render_texture * bgrnd_texture() { return m_bgrnd_texture.get(); }
 
 		void reset_topmost(reset_options options) { if (m_stack) m_stack->reset(options); }
 
@@ -289,14 +282,6 @@ private:
 
 		running_machine         &m_machine;
 		cleanup_callback_vector m_cleanup_callbacks;
-
-		bitmap_ptr              m_hilight_bitmap;
-		texture_ptr             m_hilight_texture;
-		bitmap_ptr              m_hilight_main_bitmap;
-		texture_ptr             m_hilight_main_texture;
-		texture_ptr             m_arrow_texture;
-		bitmap_ptr              m_bgrnd_bitmap;
-		texture_ptr             m_bgrnd_texture;
 
 		std::unique_ptr<menu>   m_stack;
 		std::unique_ptr<menu>   m_free;

--- a/src/frontend/mame/ui/menu.h
+++ b/src/frontend/mame/ui/menu.h
@@ -266,6 +266,9 @@ private:
 
 		void add_cleanup_callback(cleanup_callback &&callback);
 
+		bitmap_argb32 *bgrnd_bitmap() { return m_bgrnd_bitmap.get(); }
+		render_texture * bgrnd_texture() { return m_bgrnd_texture.get(); }
+
 		void reset_topmost(reset_options options) { if (m_stack) m_stack->reset(options); }
 
 		template <typename T>
@@ -282,6 +285,9 @@ private:
 
 		running_machine         &m_machine;
 		cleanup_callback_vector m_cleanup_callbacks;
+
+		bitmap_ptr              m_bgrnd_bitmap;
+		texture_ptr             m_bgrnd_texture;
 
 		std::unique_ptr<menu>   m_stack;
 		std::unique_ptr<menu>   m_free;

--- a/src/frontend/mame/ui/widgets.cpp
+++ b/src/frontend/mame/ui/widgets.cpp
@@ -1,0 +1,133 @@
+// license:BSD-3-Clause
+// copyright-holders:Nicola Salmoria, Aaron Giles, Nathan Woods
+/*********************************************************************
+
+	ui/widgets.cpp
+
+	Internal MAME widgets for the user interface.
+
+*********************************************************************/
+
+#include "widgets.h"
+#include "rendutil.h"
+#include "drivenum.h"
+
+namespace ui {
+/***************************************************************************
+	WIDGETS
+***************************************************************************/
+
+//-------------------------------------------------
+//  ctor
+//-------------------------------------------------
+
+widgets_manager::widgets_manager(running_machine &machine, ui_options const &options)
+	: m_hilight_bitmap(std::make_unique<bitmap_argb32>(256, 1))
+	, m_hilight_texture()
+	, m_hilight_main_bitmap(std::make_unique<bitmap_argb32>(1, 128))
+	, m_hilight_main_texture()
+	, m_bgrnd_bitmap()
+	, m_bgrnd_texture()
+{
+	render_manager &render(machine.render());
+	auto const texture_free([&render](render_texture *texture) { render.texture_free(texture); });
+
+	// create a texture for hilighting items
+	for (unsigned x = 0; x < 256; ++x)
+	{
+		unsigned const alpha((x < 25) ? (0xff * x / 25) : (x >(256 - 25)) ? (0xff * (255 - x) / 25) : 0xff);
+		m_hilight_bitmap->pix32(0, x) = rgb_t(alpha, 0xff, 0xff, 0xff);
+	}
+	m_hilight_texture = texture_ptr(render.texture_alloc(), texture_free);
+	m_hilight_texture->set_bitmap(*m_hilight_bitmap, m_hilight_bitmap->cliprect(), TEXFORMAT_ARGB32);
+
+	// create a texture for hilighting items in main menu
+	for (unsigned y = 0; y < 128; ++y)
+	{
+		constexpr unsigned r1(0), g1(169), b1 = (255); // any start color
+		constexpr unsigned r2(0), g2(39), b2 = (130); // any stop color
+		unsigned const r = r1 + (y * (r2 - r1) / 128);
+		unsigned const g = g1 + (y * (g2 - g1) / 128);
+		unsigned const b = b1 + (y * (b2 - b1) / 128);
+		m_hilight_main_bitmap->pix32(y, 0) = rgb_t(r, g, b);
+	}
+	m_hilight_main_texture = texture_ptr(render.texture_alloc(), texture_free);
+	m_hilight_main_texture->set_bitmap(*m_hilight_main_bitmap, m_hilight_main_bitmap->cliprect(), TEXFORMAT_ARGB32);
+
+	// create a texture for arrow icons
+	m_arrow_texture = texture_ptr(render.texture_alloc(render_triangle), texture_free);
+
+	// create a texture for main menu background
+	m_bgrnd_texture = texture_ptr(render.texture_alloc(render_texture::hq_scale), texture_free);
+	if (options.use_background_image() && (&machine.system() == &GAME_NAME(___empty)))
+	{
+		m_bgrnd_bitmap = std::make_unique<bitmap_argb32>(0, 0);
+		emu_file backgroundfile(".", OPEN_FLAG_READ);
+		render_load_jpeg(*m_bgrnd_bitmap, backgroundfile, nullptr, "background.jpg");
+
+		if (!m_bgrnd_bitmap->valid())
+			render_load_png(*m_bgrnd_bitmap, backgroundfile, nullptr, "background.png");
+
+		if (m_bgrnd_bitmap->valid())
+			m_bgrnd_texture->set_bitmap(*m_bgrnd_bitmap, m_bgrnd_bitmap->cliprect(), TEXFORMAT_ARGB32);
+		else
+			m_bgrnd_bitmap->reset();
+	}
+}
+
+
+//-------------------------------------------------
+//  render_triangle - render a triangle that
+//  is used for up/down arrows and left/right
+//  indicators
+//-------------------------------------------------
+
+void widgets_manager::render_triangle(bitmap_argb32 &dest, bitmap_argb32 &source, const rectangle &sbounds, void *param)
+{
+	int halfwidth = dest.width() / 2;
+	int height = dest.height();
+	int x, y;
+
+	// start with all-transparent
+	dest.fill(rgb_t(0x00, 0x00, 0x00, 0x00));
+
+	// render from the tip to the bottom
+	for (y = 0; y < height; y++)
+	{
+		int linewidth = (y * (halfwidth - 1) + (height / 2)) * 255 * 2 / height;
+		UINT32 *target = &dest.pix32(y, halfwidth);
+
+		// don't antialias if height < 12
+		if (dest.height() < 12)
+		{
+			int pixels = (linewidth + 254) / 255;
+			if (pixels % 2 == 0) pixels++;
+			linewidth = pixels * 255;
+		}
+
+		// loop while we still have data to generate
+		for (x = 0; linewidth > 0; x++)
+		{
+			int dalpha;
+
+			// first column we only consume one pixel
+			if (x == 0)
+			{
+				dalpha = MIN(0xff, linewidth);
+				target[x] = rgb_t(dalpha, 0xff, 0xff, 0xff);
+			}
+
+			// remaining columns consume two pixels, one on each side
+			else
+			{
+				dalpha = MIN(0x1fe, linewidth);
+				target[x] = target[-x] = rgb_t(dalpha / 2, 0xff, 0xff, 0xff);
+			}
+
+			// account for the weight we consumed */
+			linewidth -= dalpha;
+		}
+	}
+}
+
+} // namespace ui

--- a/src/frontend/mame/ui/widgets.cpp
+++ b/src/frontend/mame/ui/widgets.cpp
@@ -21,12 +21,11 @@ namespace ui {
 //  ctor
 //-------------------------------------------------
 
-widgets_manager::widgets_manager(running_machine &machine, ui_options const &options)
+widgets_manager::widgets_manager(running_machine &machine)
 	: m_hilight_bitmap(std::make_unique<bitmap_argb32>(256, 1))
 	, m_hilight_texture()
 	, m_hilight_main_bitmap(std::make_unique<bitmap_argb32>(1, 128))
 	, m_hilight_main_texture()
-	, m_bgrnd_bitmap()
 	, m_bgrnd_texture()
 {
 	render_manager &render(machine.render());
@@ -56,23 +55,6 @@ widgets_manager::widgets_manager(running_machine &machine, ui_options const &opt
 
 	// create a texture for arrow icons
 	m_arrow_texture = texture_ptr(render.texture_alloc(render_triangle), texture_free);
-
-	// create a texture for main menu background
-	m_bgrnd_texture = texture_ptr(render.texture_alloc(render_texture::hq_scale), texture_free);
-	if (options.use_background_image() && (&machine.system() == &GAME_NAME(___empty)))
-	{
-		m_bgrnd_bitmap = std::make_unique<bitmap_argb32>(0, 0);
-		emu_file backgroundfile(".", OPEN_FLAG_READ);
-		render_load_jpeg(*m_bgrnd_bitmap, backgroundfile, nullptr, "background.jpg");
-
-		if (!m_bgrnd_bitmap->valid())
-			render_load_png(*m_bgrnd_bitmap, backgroundfile, nullptr, "background.png");
-
-		if (m_bgrnd_bitmap->valid())
-			m_bgrnd_texture->set_bitmap(*m_bgrnd_bitmap, m_bgrnd_bitmap->cliprect(), TEXFORMAT_ARGB32);
-		else
-			m_bgrnd_bitmap->reset();
-	}
 }
 
 

--- a/src/frontend/mame/ui/widgets.h
+++ b/src/frontend/mame/ui/widgets.h
@@ -13,7 +13,12 @@
 
 #pragma once
 
+#include <memory>
+#include <functional>
+
 #include "ui/ui.h"
+#include "bitmap.h"
+#include "render.h"
 
 namespace ui {
 /***************************************************************************

--- a/src/frontend/mame/ui/widgets.h
+++ b/src/frontend/mame/ui/widgets.h
@@ -28,12 +28,11 @@ TYPE DEFINITIONS
 class widgets_manager
 {
 public:
-	widgets_manager(running_machine &machine, ui_options const &options);
+	widgets_manager(running_machine &machine);
 
 	render_texture *hilight_texture() { return m_hilight_texture.get(); }
 	render_texture *hilight_main_texture() { return m_hilight_main_texture.get(); }
 	render_texture *arrow_texture() { return m_arrow_texture.get(); }
-	bitmap_argb32 *bgrnd_bitmap() { return m_bgrnd_bitmap.get(); }
 	render_texture * bgrnd_texture() { return m_bgrnd_texture.get(); }
 
 	using bitmap_ptr = std::unique_ptr<bitmap_argb32>;
@@ -45,7 +44,6 @@ private:
 	bitmap_ptr              m_hilight_main_bitmap;
 	texture_ptr             m_hilight_main_texture;
 	texture_ptr             m_arrow_texture;
-	bitmap_ptr              m_bgrnd_bitmap;
 	texture_ptr             m_bgrnd_texture;
 
 	static void render_triangle(bitmap_argb32 &dest, bitmap_argb32 &source, const rectangle &sbounds, void *param);

--- a/src/frontend/mame/ui/widgets.h
+++ b/src/frontend/mame/ui/widgets.h
@@ -1,0 +1,51 @@
+// license:BSD-3-Clause
+// copyright-holders:Nicola Salmoria, Aaron Giles, Nathan Woods
+/***************************************************************************
+
+	ui/widgets.h
+
+	Internal MAME widgets for the user interface.
+
+***************************************************************************/
+
+#ifndef MAME_FRONTEND_UI_WIDGETS_H
+#define MAME_FRONTEND_UI_WIDGETS_H
+
+#pragma once
+
+#include "ui/ui.h"
+
+namespace ui {
+/***************************************************************************
+TYPE DEFINITIONS
+***************************************************************************/
+
+class widgets_manager
+{
+public:
+	widgets_manager(running_machine &machine, ui_options const &options);
+
+	render_texture *hilight_texture() { return m_hilight_texture.get(); }
+	render_texture *hilight_main_texture() { return m_hilight_main_texture.get(); }
+	render_texture *arrow_texture() { return m_arrow_texture.get(); }
+	bitmap_argb32 *bgrnd_bitmap() { return m_bgrnd_bitmap.get(); }
+	render_texture * bgrnd_texture() { return m_bgrnd_texture.get(); }
+
+	using bitmap_ptr = std::unique_ptr<bitmap_argb32>;
+	using texture_ptr = std::unique_ptr<render_texture, std::function<void(render_texture *)> >;
+
+private:
+	bitmap_ptr              m_hilight_bitmap;
+	texture_ptr             m_hilight_texture;
+	bitmap_ptr              m_hilight_main_bitmap;
+	texture_ptr             m_hilight_main_texture;
+	texture_ptr             m_arrow_texture;
+	bitmap_ptr              m_bgrnd_bitmap;
+	texture_ptr             m_bgrnd_texture;
+
+	static void render_triangle(bitmap_argb32 &dest, bitmap_argb32 &source, const rectangle &sbounds, void *param);
+};
+
+} // namespace ui
+
+#endif  // MAME_FRONTEND_UI_WIDGETS_H


### PR DESCRIPTION
Ultimately this code should be structured so that highlighting, arrows etc is completely decoupled from the menu code