### PR TITLE
coco3: improve palettes and support alternate composite mode

### DIFF
--- a/src/mame/video/gime.h
+++ b/src/mame/video/gime.h
@@ -176,6 +176,7 @@ private:
 	UINT8                       m_firq;
 	UINT16                      m_timer_value;
 	bool                        m_is_blinking;
+	bool                        m_composite_phase_invert;
 
 	// video state
 	bool                        m_legacy_video;
@@ -262,6 +263,8 @@ private:
 	// video
 	bool update_screen(bitmap_rgb32 &bitmap, const rectangle &cliprect, const pixel_t *palette);
 	void update_geometry(void);
+	void update_rgb_palette(void);
+	void update_composite_palette(void);
 	void update_border(UINT16 physical_scanline);
 	pixel_t get_composite_color(int color);
 	pixel_t get_rgb_color(int color);


### PR DESCRIPTION
This patch updates the CoCo 3 composite mode palettes. It replaces the crudely modeled ones with sampled values. It also adds support for a secondary set of composite palettes that kick in when the $FF98 color phase bit is set. This mode is used in SockMaster's "Donkey Kong Remixed." SockMaster was the source of the original modeling code and he supplied the updated palette values and assisted in testing.