### PR TITLE
m6809: Improve debugging support for 6809/6309 cpus

### DIFF
--- a/src/devices/cpu/m6809/6309dasm.cpp
+++ b/src/devices/cpu/m6809/6309dasm.cpp
@@ -693,7 +693,7 @@ CPU_DISASSEMBLE( hd6309 )
 			if (pb & 0x40)
 				buffer += sprintf(buffer, "%s%s", (pb&0x3f)?",":"", (opcode==0x35)?"U":"S");
 			if (pb & 0x80)
-				buffer += sprintf(buffer, "%sPC ; (PUL? PC=RTS)", (pb&0x7f)?",":"");
+				buffer += sprintf(buffer, "%sPC", (pb&0x7f)?",":"");
 			break;
 		default:
 			// No operands
@@ -707,7 +707,7 @@ CPU_DISASSEMBLE( hd6309 )
 		break;
 
 	case DIR_IM:
-		buffer += sprintf(buffer, "#$%02X,", operandarray[0]);
+		buffer += sprintf(buffer, "#$%02X;", operandarray[0]);
 		buffer += sprintf(buffer, "$%02X", operandarray[1]);
 		break;
 
@@ -739,7 +739,7 @@ CPU_DISASSEMBLE( hd6309 )
 	case IND:
 		if (numoperands == 2)
 		{
-			buffer += sprintf(buffer, "#$%02X,", operandarray[0]);
+			buffer += sprintf(buffer, "#$%02X;", operandarray[0]);
 			pb = operandarray[1];
 		}
 		else

--- a/src/devices/cpu/m6809/6809dasm.cpp
+++ b/src/devices/cpu/m6809/6809dasm.cpp
@@ -453,7 +453,7 @@ CPU_DISASSEMBLE( m6809 )
 			if (pb & 0x40)
 				buffer += sprintf(buffer, "%s%s", (pb&0x3f)?",":"", (opcode==0x35)?"U":"S");
 			if (pb & 0x80)
-				buffer += sprintf(buffer, "%sPC ; (PUL? PC=RTS)", (pb&0x7f)?",":"");
+				buffer += sprintf(buffer, "%sPC", (pb&0x7f)?",":"");
 			break;
 		default:
 			// No operands

--- a/src/devices/cpu/m6809/base6x09.ops
+++ b/src/devices/cpu/m6809/base6x09.ops
@@ -356,7 +356,7 @@ ANDCC:
 	return;
 
 SEX:
-	m_d.w = set_flags<UINT16>(CC_NZ, (INT8) m_d.b.l);
+	m_q.r.d = set_flags<UINT16>(CC_NZ, (INT8) m_q.r.b);
 	eat(hd6309_native_mode() ? 0 : 1);
 	return;
 
@@ -400,7 +400,7 @@ JSR:
 GOTO_SUBROUTINE:
 	@write_memory(--m_s.w, m_pc.b.l);
 	@write_memory(--m_s.w, m_pc.b.h);
-	m_pc = m_ea;
+	m_pc.w = m_ea.w;
 	return;
 
 RTS:
@@ -410,7 +410,7 @@ RTS:
 	goto PULL_REGISTERS;
 
 ABX:
-	m_x.w += m_d.b.l;
+	m_x.w += m_q.r.b;
 	eat(hd6309_native_mode() ? 0 : 2);
 	return;
 

--- a/src/devices/cpu/m6809/hd6309.cpp
+++ b/src/devices/cpu/m6809/hd6309.cpp
@@ -26,7 +26,11 @@
                             machine must be twos complement
 
     History:
-
+ 
+July 2016 ErikGav: 
+    Unify with 6809 pairs and quads (A+B=D, E+F=W, D+W=Q)
+    Initialize V register to $FFFF at startup
+ 
 March 2013 NPW:
     Rewrite of 6809/6309/Konami CPU; attempted to make cycle exact.
 
@@ -134,7 +138,6 @@ hd6309_device::hd6309_device(const machine_config &mconfig, const char *tag, dev
 {
 }
 
-
 //-------------------------------------------------
 //  device_start - device-specific startup
 //-------------------------------------------------
@@ -144,20 +147,27 @@ void hd6309_device::device_start()
 	super::device_start();
 
 	// register our state for the debugger
-	state_add(HD6309_E,         "E",            m_w.b.h).mask(0xff);
-	state_add(HD6309_F,         "F",            m_w.b.l).mask(0xff);
-	state_add(HD6309_W,         "W",            m_w.w).mask(0xffff);
-	state_add(HD6309_V,         "V",            m_v.w).mask(0xffff);
-	state_add(HD6309_MD,        "MD",           m_md).mask(0xff);
+	state_add(HD6309_MD,    "MD",   m_md).mask(0xff);
+	state_add(HD6309_V,     "V",    m_v.w).mask(0xffff);
+	state_add(HD6309_A,     "A",    m_q.r.a).mask(0xff);
+	state_add(HD6309_B,     "B",    m_q.r.b).mask(0xff);
+	state_add(HD6309_D,     "D",    m_q.r.d).mask(0xffff);
+	state_add(HD6309_E,     "E",    m_q.r.e).mask(0xff);
+	state_add(HD6309_F,     "F",    m_q.r.f).mask(0xff);
+	state_add(HD6309_W,     "W",    m_q.r.w).mask(0xffff);
+	state_add(HD6309_Q,     "Q",    m_q.q).mask(0xffffffff);
+	state_add(HD6309_X,     "X",    m_x.w).mask(0xffff);
+	state_add(HD6309_Y,     "Y",    m_y.w).mask(0xffff);
+	state_add(HD6309_U,     "U",    m_u.w).mask(0xffff);
 
 	// initialize variables
-	m_w.w = 0x0000;
-	m_v.w = 0x0000;
+	m_q.q = 0x00000000;
+	m_v.w = 0xffff; // v is initialized to $ffff at reset
 	m_md = 0x00;
 	m_temp_im = 0x00;
 
 	// setup regtable
-	save_item(NAME(m_w.w));
+	save_item(NAME(m_q.r.w));
 	save_item(NAME(m_v.w));
 	save_item(NAME(m_md));
 	save_item(NAME(m_temp_im));
@@ -184,22 +194,22 @@ void hd6309_device::device_reset()
 
 void hd6309_device::device_pre_save()
 {
-	if      (m_reg8 == &m_d.b.h)    m_reg = HD6309_A;
-	else if (m_reg8 == &m_d.b.l)    m_reg = HD6309_B;
-	else if (m_reg8 == &m_w.b.h)    m_reg = HD6309_E;
-	else if (m_reg8 == &m_w.b.l)    m_reg = HD6309_F;
+	if      (m_reg8 == &m_q.r.a)    m_reg = HD6309_A;
+	else if (m_reg8 == &m_q.r.b)    m_reg = HD6309_B;
+	else if (m_reg8 == &m_q.r.e)    m_reg = HD6309_E;
+	else if (m_reg8 == &m_q.r.f)    m_reg = HD6309_F;
 	else if (m_reg8 == &m_cc)       m_reg = HD6309_CC;
 	else if (m_reg8 == &m_dp)       m_reg = HD6309_DP;
 	else if (m_reg8 == &m_md)       m_reg = HD6309_MD;
 	else if (m_reg8 == &m_temp.b.l) m_reg = HD6309_ZERO_BYTE;
 
-	else if (m_reg16 == &m_d)       m_reg = HD6309_D;
+	else if (m_reg16 == &m_q.p.d)   m_reg = HD6309_D;
 	else if (m_reg16 == &m_x)       m_reg = HD6309_X;
 	else if (m_reg16 == &m_y)       m_reg = HD6309_Y;
 	else if (m_reg16 == &m_u)       m_reg = HD6309_U;
 	else if (m_reg16 == &m_s)       m_reg = HD6309_S;
 	else if (m_reg16 == &m_pc)      m_reg = HD6309_PC;
-	else if (m_reg16 == &m_w)       m_reg = HD6309_W;
+	else if (m_reg16 == &m_q.p.w)   m_reg = HD6309_W;
 	else if (m_reg16 == &m_v)       m_reg = HD6309_V;
 	else if (m_reg16 == &m_temp)    m_reg = HD6309_ZERO_WORD;
 	else
@@ -219,16 +229,16 @@ void hd6309_device::device_post_load()
 	switch(m_reg)
 	{
 		case HD6309_A:
-			set_regop8(m_d.b.h);
+			set_regop8(m_q.r.a);
 			break;
 		case HD6309_B:
-			set_regop8(m_d.b.l);
+			set_regop8(m_q.r.b);
 			break;
 		case HD6309_E:
-			set_regop8(m_w.b.h);
+			set_regop8(m_q.r.e);
 			break;
 		case HD6309_F:
-			set_regop8(m_w.b.l);
+			set_regop8(m_q.r.f);
 			break;
 		case HD6309_CC:
 			set_regop8(m_cc);
@@ -244,7 +254,7 @@ void hd6309_device::device_post_load()
 			break;
 
 		case HD6309_D:
-			set_regop16(m_d);
+			set_regop16(m_q.p.d);
 			break;
 		case HD6309_X:
 			set_regop16(m_x);
@@ -262,7 +272,7 @@ void hd6309_device::device_post_load()
 			set_regop16(m_pc);
 			break;
 		case HD6309_W:
-			set_regop16(m_w);
+			set_regop16(m_q.p.w);
 			break;
 		case HD6309_V:
 			set_regop16(m_v);
@@ -321,10 +331,10 @@ inline UINT8 hd6309_device::read_operand()
 	{
 		case ADDRESSING_MODE_EA:            return read_memory(m_ea.w);
 		case ADDRESSING_MODE_IMMEDIATE:     return read_opcode_arg();
-		case ADDRESSING_MODE_REGISTER_A:    return m_d.b.h;
-		case ADDRESSING_MODE_REGISTER_B:    return m_d.b.l;
-		case ADDRESSING_MODE_REGISTER_E:    return m_w.b.h;
-		case ADDRESSING_MODE_REGISTER_F:    return m_w.b.l;
+		case ADDRESSING_MODE_REGISTER_A:    return m_q.r.a;
+		case ADDRESSING_MODE_REGISTER_B:    return m_q.r.b;
+		case ADDRESSING_MODE_REGISTER_E:    return m_q.r.e;
+		case ADDRESSING_MODE_REGISTER_F:    return m_q.r.f;
 		default:                            fatalerror("Unexpected");
 	}
 }
@@ -340,8 +350,8 @@ inline UINT8 hd6309_device::read_operand(int ordinal)
 	{
 		case ADDRESSING_MODE_EA:            return read_memory(m_ea.w + ordinal);
 		case ADDRESSING_MODE_IMMEDIATE:     return read_opcode_arg();
-		case ADDRESSING_MODE_REGISTER_D:    return (ordinal & 1) ? m_d.b.l : m_d.b.h;
-		case ADDRESSING_MODE_REGISTER_W:    return (ordinal & 1) ? m_w.b.l : m_w.b.h;
+		case ADDRESSING_MODE_REGISTER_D:    return (ordinal & 1) ? m_q.r.b : m_q.r.a;
+		case ADDRESSING_MODE_REGISTER_W:    return (ordinal & 1) ? m_q.r.f : m_q.r.e;
 		case ADDRESSING_MODE_REGISTER_X:    return (ordinal & 1) ? m_x.b.l : m_x.b.h;
 		case ADDRESSING_MODE_REGISTER_Y:    return (ordinal & 1) ? m_y.b.l : m_y.b.h;
 		case ADDRESSING_MODE_REGISTER_U:    return (ordinal & 1) ? m_u.b.l : m_u.b.h;
@@ -363,10 +373,10 @@ inline void hd6309_device::write_operand(UINT8 data)
 	switch(m_addressing_mode)
 	{
 		case ADDRESSING_MODE_EA:            write_memory(m_ea.w, data);     break;
-		case ADDRESSING_MODE_REGISTER_A:    m_d.b.h = data;                 break;
-		case ADDRESSING_MODE_REGISTER_B:    m_d.b.l = data;                 break;
-		case ADDRESSING_MODE_REGISTER_E:    m_w.b.h = data;                 break;
-		case ADDRESSING_MODE_REGISTER_F:    m_w.b.l = data;                 break;
+		case ADDRESSING_MODE_REGISTER_A:    m_q.r.a = data;                 break;
+		case ADDRESSING_MODE_REGISTER_B:    m_q.r.b = data;                 break;
+		case ADDRESSING_MODE_REGISTER_E:    m_q.r.e = data;                 break;
+		case ADDRESSING_MODE_REGISTER_F:    m_q.r.f = data;                 break;
 		case ADDRESSING_MODE_ZERO:                                          break;
 		default:                            fatalerror("Unexpected");
 	}
@@ -382,8 +392,8 @@ inline void hd6309_device::write_operand(int ordinal, UINT8 data)
 	switch(m_addressing_mode)
 	{
 		case ADDRESSING_MODE_EA:            write_memory(m_ea.w + ordinal, data);               break;
-		case ADDRESSING_MODE_REGISTER_D:    *((ordinal & 1) ? &m_d.b.l : &m_d.b.h) = data;      break;
-		case ADDRESSING_MODE_REGISTER_W:    *((ordinal & 1) ? &m_w.b.l : &m_w.b.h) = data;      break;
+		case ADDRESSING_MODE_REGISTER_D:    *((ordinal & 1) ? &m_q.r.b : &m_q.r.a) = data;      break;
+		case ADDRESSING_MODE_REGISTER_W:    *((ordinal & 1) ? &m_q.r.f : &m_q.r.e) = data;      break;
 		case ADDRESSING_MODE_REGISTER_X:    *((ordinal & 1) ? &m_x.b.l : &m_x.b.h) = data;      break;
 		case ADDRESSING_MODE_REGISTER_Y:    *((ordinal & 1) ? &m_y.b.l : &m_y.b.h) = data;      break;
 		case ADDRESSING_MODE_REGISTER_U:    *((ordinal & 1) ? &m_u.b.l : &m_u.b.h) = data;      break;
@@ -405,8 +415,8 @@ inline UINT8 &hd6309_device::bittest_register()
 	switch(m_temp_im & 0xC0)
 	{
 		case 0x00:  return m_cc;
-		case 0x40:  return m_d.b.h;
-		case 0x80:  return m_d.b.l;
+		case 0x40:  return m_q.r.a;
+		case 0x80:  return m_q.r.b;
 		default:    return m_temp.b.l;
 	}
 }
@@ -456,22 +466,22 @@ inline m6809_base_device::exgtfr_register hd6309_device::read_exgtfr_register(UI
 
 	switch(reg & 0x0F)
 	{
-		case  0: value = m_d.w;                             break;  // D
+		case  0: value = m_q.r.d;                           break;  // D
 		case  1: value = m_x.w;                             break;  // X
 		case  2: value = m_y.w;                             break;  // Y
 		case  3: value = m_u.w;                             break;  // U
 		case  4: value = m_s.w;                             break;  // S
 		case  5: value = m_pc.w;                            break;  // PC
-		case  6: value = m_w.w;                             break;  // W
+		case  6: value = m_q.r.w;                           break;  // W
 		case  7: value = m_v.w;                             break;  // V
-		case  8: value = ((UINT16) m_d.b.h) << 8 | m_d.b.h; break;  // A
-		case  9: value = ((UINT16) m_d.b.l) << 8 | m_d.b.l; break;  // B
+		case  8: value = ((UINT16) m_q.r.a) << 8 | m_q.r.a; break;  // A
+		case  9: value = ((UINT16) m_q.r.b) << 8 | m_q.r.b; break;  // B
 		case 10: value = ((UINT16) m_cc) << 8 | m_cc;       break;  // CC
 		case 11: value = ((UINT16) m_dp) << 8 | m_dp;       break;  // DP
 		case 12: value = 0;                                 break;  // 0
 		case 13: value = 0;                                 break;  // 0
-		case 14: value = ((UINT16) m_w.b.h) << 8 | m_w.b.h; break;  // E
-		case 15: value = ((UINT16) m_w.b.l) << 8 | m_w.b.l; break;  // F
+		case 14: value = ((UINT16) m_q.r.e) << 8 | m_q.r.e; break;  // E
+		case 15: value = ((UINT16) m_q.r.f) << 8 | m_q.r.f; break;  // F
 		default:
 			fatalerror("Should not reach here");
 	}
@@ -492,22 +502,22 @@ inline void hd6309_device::write_exgtfr_register(UINT8 reg, m6809_base_device::e
 {
 	switch(reg & 0x0F)
 	{
-		case  0: m_d.w   = value.word_value;                break;  // D
+		case  0: m_q.r.d = value.word_value;                break;  // D
 		case  1: m_x.w   = value.word_value;                break;  // X
 		case  2: m_y.w   = value.word_value;                break;  // Y
 		case  3: m_u.w   = value.word_value;                break;  // U
 		case  4: m_s.w   = value.word_value;                break;  // S
 		case  5: m_pc.w  = value.word_value;                break;  // PC
-		case  6: m_w.w   = value.word_value;                break;  // W
+		case  6: m_q.r.w = value.word_value;                break;  // W
 		case  7: m_v.w   = value.word_value;                break;  // V
-		case  8: m_d.b.h = (UINT8) (value.word_value >> 8); break;  // A
-		case  9: m_d.b.l = (UINT8) (value.word_value >> 0); break;  // B
+		case  8: m_q.r.a = (UINT8) (value.word_value >> 8); break;  // A
+		case  9: m_q.r.b = (UINT8) (value.word_value >> 0); break;  // B
 		case 10: m_cc    = (UINT8) (value.word_value >> 0); break;  // CC
 		case 11: m_dp    = (UINT8) (value.word_value >> 8); break;  // DP
 		case 12:                                            break;  // 0
 		case 13:                                            break;  // 0
-		case 14: m_w.b.h = (UINT8) (value.word_value >> 8); break;  // E
-		case 15: m_w.b.l = (UINT8) (value.word_value >> 0); break;  // F
+		case 14: m_q.r.e = (UINT8) (value.word_value >> 8); break;  // E
+		case 15: m_q.r.f = (UINT8) (value.word_value >> 0); break;  // F
 		default:
 			fatalerror("Should not reach here");
 	}
@@ -525,7 +535,7 @@ inline bool hd6309_device::tfr_read(UINT8 opcode, UINT8 arg, UINT8 &data)
 
 	switch(arg & 0xF0)
 	{
-		case 0x00:      reg = &m_d; break;
+		case 0x00:      reg = &m_q.p.d; break;
 		case 0x10:      reg = &m_x; break;
 		case 0x20:      reg = &m_y; break;
 		case 0x30:      reg = &m_u; break;
@@ -558,7 +568,7 @@ inline bool hd6309_device::tfr_write(UINT8 opcode, UINT8 arg, UINT8 data)
 
 	switch(arg & 0x0F)
 	{
-		case 0x00:      reg = &m_d; break;
+		case 0x00:      reg = &m_q.p.d; break;
 		case 0x01:      reg = &m_x; break;
 		case 0x02:      reg = &m_y; break;
 		case 0x03:      reg = &m_u; break;
@@ -598,22 +608,22 @@ void hd6309_device::register_register_op()
 	// set destination
 	switch((operand >> 0) & 0x0F)
 	{
-		case  0: set_regop16(m_d);                                                  break;  // D
+		case  0: set_regop16(m_q.p.d);                                              break;  // D
 		case  1: set_regop16(m_x);                                                  break;  // X
 		case  2: set_regop16(m_y);                                                  break;  // Y
 		case  3: set_regop16(m_u);                                                  break;  // U
 		case  4: set_regop16(m_s);                                                  break;  // S
 		case  5: set_regop16(m_pc);                                                 break;  // PC
-		case  6: set_regop16(m_w);                                                  break;  // W
+		case  6: set_regop16(m_q.p.w);                                              break;  // W
 		case  7: set_regop16(m_v);                                                  break;  // V
-		case  8: if (promote) set_regop16(m_d);     else set_regop8(m_d.b.h);       break;  // A
-		case  9: if (promote) set_regop16(m_d);     else set_regop8(m_d.b.l);       break;  // B
+		case  8: if (promote) set_regop16(m_q.p.d); else set_regop8(m_q.r.a);       break;  // A
+		case  9: if (promote) set_regop16(m_q.p.d); else set_regop8(m_q.r.b);       break;  // B
 		case 10: if (promote) set_regop16(m_temp);  else set_regop8(m_cc);          break;  // CC
 		case 11: if (promote) set_regop16(m_temp);  else set_regop8(m_dp);          break;  // DP
 		case 12: if (promote) set_regop16(m_temp);  else set_regop8(m_temp.b.l);    break;  // 0
 		case 13: if (promote) set_regop16(m_temp);  else set_regop8(m_temp.b.l);    break;  // 0
-		case 14: if (promote) set_regop16(m_w);     else set_regop8(m_w.b.h);       break;  // E
-		case 15: if (promote) set_regop16(m_w);     else set_regop8(m_w.b.l);       break;  // F
+		case 14: if (promote) set_regop16(m_q.p.w); else set_regop8(m_q.r.e);       break;  // E
+		case 15: if (promote) set_regop16(m_q.p.w); else set_regop8(m_q.r.f);       break;  // F
 		default:
 			fatalerror("Should not reach here");
 	}
@@ -645,33 +655,6 @@ void hd6309_device::register_register_op()
 	eat(1);
 }
 
-
-//-------------------------------------------------
-//  get_q
-//-------------------------------------------------
-
-UINT32 hd6309_device::get_q()
-{
-	PAIR result;
-	result.w.h = m_d.w;
-	result.w.l = m_w.w;
-	return result.d;
-}
-
-
-//-------------------------------------------------
-//  put_q
-//-------------------------------------------------
-
-void hd6309_device::put_q(UINT32 value)
-{
-	PAIR pair;
-	pair.d = value;
-	m_d.w = pair.w.h;
-	m_w.w = pair.w.l;
-}
-
-
 //-------------------------------------------------
 //  muld - (Q := D * operand)
 //-------------------------------------------------
@@ -679,8 +662,8 @@ void hd6309_device::put_q(UINT32 value)
 void hd6309_device::muld()
 {
 	UINT32 result;
-	result = ((INT16) m_d.w) * ((INT16) m_temp.w);
-	put_q(set_flags<UINT32>(CC_NZ, result));
+	result = ((INT16) m_q.r.d) * ((INT16) m_temp.w);
+	m_q.q = (set_flags<UINT32>(CC_NZ, result));
 	m_cc &= ~CC_VC;
 }
 
@@ -697,18 +680,18 @@ bool hd6309_device::divq()
 	if (m_temp.w == 0)
 		return false;
 
-	INT32 q = get_q();
+	INT32 q = m_q.q;
 	INT32 old_q = q;
 
 	// do the divide/modulo
 	result = q / (INT16) m_temp.w;
-	m_d.w = q % (INT16) m_temp.w;
+	m_q.r.d = q % (INT16) m_temp.w;
 
 	// set NZ condition codes
-	m_w.w = set_flags<UINT16>(CC_NZ, result);
+	m_q.r.w = set_flags<UINT16>(CC_NZ, result);
 
 	// set C condition code
-	if (m_w.w & 0x0001)
+	if (m_q.r.w & 0x0001)
 		m_cc |= CC_C;
 	else
 		m_cc &= ~CC_C;
@@ -726,7 +709,7 @@ bool hd6309_device::divq()
 			else if (old_q == 0 )
 				m_cc |= CC_Z;
 
-			put_q(old_q);
+			m_q.q = old_q;
 		}
 	}
 	else
@@ -749,18 +732,18 @@ bool hd6309_device::divd()
 	if (m_temp.b.l == 0)
 		return false;
 
-	INT16 old_d = m_d.w;
+	INT16 old_d = m_q.r.d;
 	INT16 result;
 
 	// do the divide/modulo
-	result = ((INT16) m_d.w) / (INT8) m_temp.b.l;
-	m_d.b.h = ((INT16) m_d.w) % (INT8) m_temp.b.l;
+	result = ((INT16) m_q.r.d) / (INT8) m_temp.b.l;
+	m_q.r.a = ((INT16) m_q.r.d) % (INT8) m_temp.b.l;
 
 	// set NZ condition codes
-	m_d.b.l = set_flags<UINT8>(CC_NZ, result);
+	m_q.r.b = set_flags<UINT8>(CC_NZ, result);
 
 	// set C condition code
-	if (m_d.b.l & 0x01)
+	if (m_q.r.b & 0x01)
 		m_cc |= CC_C;
 	else
 		m_cc &= ~CC_C;
@@ -774,7 +757,7 @@ bool hd6309_device::divd()
 		{
 			// hard overflow - division is aborted
 			set_flags<UINT16>(CC_NZ, old_d);
-			m_d.w = abs(old_d);
+			m_q.r.d = abs(old_d);
 		}
 	}
 	else
@@ -812,3 +795,4 @@ void hd6309_device::execute_run()
 		execute_one();
 	} while(m_icount > 0);
 }
+

--- a/src/devices/cpu/m6809/hd6309.h
+++ b/src/devices/cpu/m6809/hd6309.h
@@ -46,6 +46,8 @@ protected:
 	virtual UINT32 disasm_max_opcode_bytes() const override;
 	virtual offs_t disasm_disassemble(char *buffer, offs_t pc, const UINT8 *oprom, const UINT8 *opram, UINT32 options) override;
 
+	virtual bool is_6809() override { return false; };
+
 private:
 	typedef m6809_base_device super;
 
@@ -73,7 +75,6 @@ private:
 	};
 
 	// CPU registers
-	PAIR16  m_w;
 	PAIR16  m_v;
 	UINT8   m_md;
 
@@ -100,10 +101,6 @@ private:
 	void muld();
 	bool divq();
 	bool divd();
-
-	// the Q register
-	UINT32 get_q();
-	void put_q(UINT32 value);
 
 	// miscellaneous
 	void set_e()                                    { m_addressing_mode = ADDRESSING_MODE_REGISTER_E; }
@@ -136,6 +133,7 @@ enum
 	HD6309_E = 1000,
 	HD6309_F,
 	HD6309_W,
+	HD6309_Q,
 	HD6309_V,
 	HD6309_MD,
 	HD6309_ZERO_BYTE,

--- a/src/devices/cpu/m6809/hd6309.ops
+++ b/src/devices/cpu/m6809/hd6309.ops
@@ -140,135 +140,135 @@ MAIN:
 		case 0x7E:										%EXTENDED;	%JMP;		return;
 		case 0x7F:										%EXTENDED;	%CLR8;		return;
 
-		case 0x80:				set_regop8(m_d.b.h);	set_imm();	%SUB8;		return;
-		case 0x81:				set_regop8(m_d.b.h);	set_imm();	%CMP8;		return;
-		case 0x82:				set_regop8(m_d.b.h);	set_imm();	%SBC8;		return;
-		case 0x83:				set_regop16(m_d);		set_imm();	%SUB16;		return;
-		case 0x84:				set_regop8(m_d.b.h);	set_imm();	%AND8;		return;
-		case 0x85:				set_regop8(m_d.b.h);	set_imm();	%BIT8;		return;
-		case 0x86:				set_regop8(m_d.b.h);	set_imm();	%LD8;		return;
-		case 0x88:				set_regop8(m_d.b.h);	set_imm();	%EOR8;		return;
-		case 0x89:				set_regop8(m_d.b.h);	set_imm();	%ADC8;		return;
-		case 0x8A:				set_regop8(m_d.b.h);	set_imm();	%OR8;		return;
-		case 0x8B:				set_regop8(m_d.b.h);	set_imm();	%ADD8;		return;
+		case 0x80:				set_regop8(m_q.r.a);	set_imm();	%SUB8;		return;
+		case 0x81:				set_regop8(m_q.r.a);	set_imm();	%CMP8;		return;
+		case 0x82:				set_regop8(m_q.r.a);	set_imm();	%SBC8;		return;
+		case 0x83:				set_regop16(m_q.p.d);	set_imm();	%SUB16;		return;
+		case 0x84:				set_regop8(m_q.r.a);	set_imm();	%AND8;		return;
+		case 0x85:				set_regop8(m_q.r.a);	set_imm();	%BIT8;		return;
+		case 0x86:				set_regop8(m_q.r.a);	set_imm();	%LD8;		return;
+		case 0x88:				set_regop8(m_q.r.a);	set_imm();	%EOR8;		return;
+		case 0x89:				set_regop8(m_q.r.a);	set_imm();	%ADC8;		return;
+		case 0x8A:				set_regop8(m_q.r.a);	set_imm();	%OR8;		return;
+		case 0x8B:				set_regop8(m_q.r.a);	set_imm();	%ADD8;		return;
 		case 0x8C:				set_regop16(m_x);		set_imm();	%CMP16;		return;
 		case 0x8D:													%BSR;		return;
 		case 0x8E:				set_regop16(m_x);		set_imm();	%LD16;		return;
 
-		case 0x90:				set_regop8(m_d.b.h);	%DIRECT;	%SUB8;		return;
-		case 0x91:				set_regop8(m_d.b.h);	%DIRECT;	%CMP8;		return;
-		case 0x92:				set_regop8(m_d.b.h);	%DIRECT;	%SBC8;		return;
-		case 0x93:				set_regop16(m_d);		%DIRECT;	%SUB16;		return;
-		case 0x94:				set_regop8(m_d.b.h);	%DIRECT;	%AND8;		return;
-		case 0x95:				set_regop8(m_d.b.h);	%DIRECT;	%BIT8;		return;
-		case 0x96:				set_regop8(m_d.b.h);	%DIRECT;	%LD8;		return;
-		case 0x97:				set_regop8(m_d.b.h);	%DIRECT;	%ST8;		return;
-		case 0x98:				set_regop8(m_d.b.h);	%DIRECT;	%EOR8;		return;
-		case 0x99:				set_regop8(m_d.b.h);	%DIRECT;	%ADC8;		return;
-		case 0x9A:				set_regop8(m_d.b.h);	%DIRECT;	%OR8;		return;
-		case 0x9B:				set_regop8(m_d.b.h);	%DIRECT;	%ADD8;		return;
+		case 0x90:				set_regop8(m_q.r.a);	%DIRECT;	%SUB8;		return;
+		case 0x91:				set_regop8(m_q.r.a);	%DIRECT;	%CMP8;		return;
+		case 0x92:				set_regop8(m_q.r.a);	%DIRECT;	%SBC8;		return;
+		case 0x93:				set_regop16(m_q.p.d);	%DIRECT;	%SUB16;		return;
+		case 0x94:				set_regop8(m_q.r.a);	%DIRECT;	%AND8;		return;
+		case 0x95:				set_regop8(m_q.r.a);	%DIRECT;	%BIT8;		return;
+		case 0x96:				set_regop8(m_q.r.a);	%DIRECT;	%LD8;		return;
+		case 0x97:				set_regop8(m_q.r.a);	%DIRECT;	%ST8;		return;
+		case 0x98:				set_regop8(m_q.r.a);	%DIRECT;	%EOR8;		return;
+		case 0x99:				set_regop8(m_q.r.a);	%DIRECT;	%ADC8;		return;
+		case 0x9A:				set_regop8(m_q.r.a);	%DIRECT;	%OR8;		return;
+		case 0x9B:				set_regop8(m_q.r.a);	%DIRECT;	%ADD8;		return;
 		case 0x9C:				set_regop16(m_x);		%DIRECT;	%CMP16;		return;
 		case 0x9D:										%DIRECT;	%JSR;		return;
 		case 0x9E:				set_regop16(m_x);		%DIRECT;	%LD16;		return;
 		case 0x9F:				set_regop16(m_x);		%DIRECT;	%ST16;		return;
 
-		case 0xA0:				set_regop8(m_d.b.h);	%INDEXED;	%SUB8;		return;
-		case 0xA1:				set_regop8(m_d.b.h);	%INDEXED;	%CMP8;		return;
-		case 0xA2:				set_regop8(m_d.b.h);	%INDEXED;	%SBC8;		return;
-		case 0xA3:				set_regop16(m_d);		%INDEXED;	%SUB16;		return;
-		case 0xA4:				set_regop8(m_d.b.h);	%INDEXED;	%AND8;		return;
-		case 0xA5:				set_regop8(m_d.b.h);	%INDEXED;	%BIT8;		return;
-		case 0xA6:				set_regop8(m_d.b.h);	%INDEXED;	%LD8;		return;
-		case 0xA7:				set_regop8(m_d.b.h);	%INDEXED;	%ST8;		return;
-		case 0xA8:				set_regop8(m_d.b.h);	%INDEXED;	%EOR8;		return;
-		case 0xA9:				set_regop8(m_d.b.h);	%INDEXED;	%ADC8;		return;
-		case 0xAA:				set_regop8(m_d.b.h);	%INDEXED;	%OR8;		return;
-		case 0xAB:				set_regop8(m_d.b.h);	%INDEXED;	%ADD8;		return;
+		case 0xA0:				set_regop8(m_q.r.a);	%INDEXED;	%SUB8;		return;
+		case 0xA1:				set_regop8(m_q.r.a);	%INDEXED;	%CMP8;		return;
+		case 0xA2:				set_regop8(m_q.r.a);	%INDEXED;	%SBC8;		return;
+		case 0xA3:				set_regop16(m_q.p.d);	%INDEXED;	%SUB16;		return;
+		case 0xA4:				set_regop8(m_q.r.a);	%INDEXED;	%AND8;		return;
+		case 0xA5:				set_regop8(m_q.r.a);	%INDEXED;	%BIT8;		return;
+		case 0xA6:				set_regop8(m_q.r.a);	%INDEXED;	%LD8;		return;
+		case 0xA7:				set_regop8(m_q.r.a);	%INDEXED;	%ST8;		return;
+		case 0xA8:				set_regop8(m_q.r.a);	%INDEXED;	%EOR8;		return;
+		case 0xA9:				set_regop8(m_q.r.a);	%INDEXED;	%ADC8;		return;
+		case 0xAA:				set_regop8(m_q.r.a);	%INDEXED;	%OR8;		return;
+		case 0xAB:				set_regop8(m_q.r.a);	%INDEXED;	%ADD8;		return;
 		case 0xAC:				set_regop16(m_x);		%INDEXED;	%CMP16;		return;
 		case 0xAD:										%INDEXED;	%JSR_ind;	return;
 		case 0xAE:				set_regop16(m_x);		%INDEXED;	%LD16;		return;
 		case 0xAF:				set_regop16(m_x);		%INDEXED;	%ST16;		return;
 
-		case 0xB0:				set_regop8(m_d.b.h);	%EXTENDED;	%SUB8;		return;
-		case 0xB1:				set_regop8(m_d.b.h);	%EXTENDED;	%CMP8;		return;
-		case 0xB2:				set_regop8(m_d.b.h);	%EXTENDED;	%SBC8;		return;
-		case 0xB3:				set_regop16(m_d);		%EXTENDED;	%SUB16;		return;
-		case 0xB4:				set_regop8(m_d.b.h);	%EXTENDED;	%AND8;		return;
-		case 0xB5:				set_regop8(m_d.b.h);	%EXTENDED;	%BIT8;		return;
-		case 0xB6:				set_regop8(m_d.b.h);	%EXTENDED;	%LD8;		return;
-		case 0xB7:				set_regop8(m_d.b.h);	%EXTENDED;	%ST8;		return;
-		case 0xB8:				set_regop8(m_d.b.h);	%EXTENDED;	%EOR8;		return;
-		case 0xB9:				set_regop8(m_d.b.h);	%EXTENDED;	%ADC8;		return;
-		case 0xBA:				set_regop8(m_d.b.h);	%EXTENDED;	%OR8;		return;
-		case 0xBB:				set_regop8(m_d.b.h);	%EXTENDED;	%ADD8;		return;
+		case 0xB0:				set_regop8(m_q.r.a);	%EXTENDED;	%SUB8;		return;
+		case 0xB1:				set_regop8(m_q.r.a);	%EXTENDED;	%CMP8;		return;
+		case 0xB2:				set_regop8(m_q.r.a);	%EXTENDED;	%SBC8;		return;
+		case 0xB3:				set_regop16(m_q.p.d);	%EXTENDED;	%SUB16;		return;
+		case 0xB4:				set_regop8(m_q.r.a);	%EXTENDED;	%AND8;		return;
+		case 0xB5:				set_regop8(m_q.r.a);	%EXTENDED;	%BIT8;		return;
+		case 0xB6:				set_regop8(m_q.r.a);	%EXTENDED;	%LD8;		return;
+		case 0xB7:				set_regop8(m_q.r.a);	%EXTENDED;	%ST8;		return;
+		case 0xB8:				set_regop8(m_q.r.a);	%EXTENDED;	%EOR8;		return;
+		case 0xB9:				set_regop8(m_q.r.a);	%EXTENDED;	%ADC8;		return;
+		case 0xBA:				set_regop8(m_q.r.a);	%EXTENDED;	%OR8;		return;
+		case 0xBB:				set_regop8(m_q.r.a);	%EXTENDED;	%ADD8;		return;
 		case 0xBC:				set_regop16(m_x);		%EXTENDED;	%CMP16;		return;
 		case 0xBD:										%EXTENDED;	%JSR;		return;
 		case 0xBE:				set_regop16(m_x);		%EXTENDED;	%LD16;		return;
 		case 0xBF:				set_regop16(m_x);		%EXTENDED;	%ST16;		return;
 
-		case 0xC0:				set_regop8(m_d.b.l);	set_imm();	%SUB8;		return;
-		case 0xC1:				set_regop8(m_d.b.l);	set_imm();	%CMP8;		return;
-		case 0xC2:				set_regop8(m_d.b.l);	set_imm();	%SBC8;		return;
-		case 0xC3:				set_regop16(m_d);		set_imm();	%ADD16;		return;
-		case 0xC4:				set_regop8(m_d.b.l);	set_imm();	%AND8;		return;
-		case 0xC5:				set_regop8(m_d.b.l);	set_imm();	%BIT8;		return;
-		case 0xC6:				set_regop8(m_d.b.l);	set_imm();	%LD8;		return;
-		case 0xC8:				set_regop8(m_d.b.l);	set_imm();	%EOR8;		return;
-		case 0xC9:				set_regop8(m_d.b.l);	set_imm();	%ADC8;		return;
-		case 0xCA:				set_regop8(m_d.b.l);	set_imm();	%OR8;		return;
-		case 0xCB:				set_regop8(m_d.b.l);	set_imm();	%ADD8;		return;
-		case 0xCC:				set_regop16(m_d);		set_imm();	%LD16;		return;
+		case 0xC0:				set_regop8(m_q.r.b);	set_imm();	%SUB8;		return;
+		case 0xC1:				set_regop8(m_q.r.b);	set_imm();	%CMP8;		return;
+		case 0xC2:				set_regop8(m_q.r.b);	set_imm();	%SBC8;		return;
+		case 0xC3:				set_regop16(m_q.p.d);	set_imm();	%ADD16;		return;
+		case 0xC4:				set_regop8(m_q.r.b);	set_imm();	%AND8;		return;
+		case 0xC5:				set_regop8(m_q.r.b);	set_imm();	%BIT8;		return;
+		case 0xC6:				set_regop8(m_q.r.b);	set_imm();	%LD8;		return;
+		case 0xC8:				set_regop8(m_q.r.b);	set_imm();	%EOR8;		return;
+		case 0xC9:				set_regop8(m_q.r.b);	set_imm();	%ADC8;		return;
+		case 0xCA:				set_regop8(m_q.r.b);	set_imm();	%OR8;		return;
+		case 0xCB:				set_regop8(m_q.r.b);	set_imm();	%ADD8;		return;
+		case 0xCC:				set_regop16(m_q.p.d);	set_imm();	%LD16;		return;
 		case 0xCD:										set_imm();	%LDQ;		return;
 		case 0xCE:				set_regop16(m_u);		set_imm();	%LD16;		return;
 
-		case 0xD0:				set_regop8(m_d.b.l);	%DIRECT;	%SUB8;		return;
-		case 0xD1:				set_regop8(m_d.b.l);	%DIRECT;	%CMP8;		return;
-		case 0xD2:				set_regop8(m_d.b.l);	%DIRECT;	%SBC8;		return;
-		case 0xD3:				set_regop16(m_d);		%DIRECT;	%ADD16;		return;
-		case 0xD4:				set_regop8(m_d.b.l);	%DIRECT;	%AND8;		return;
-		case 0xD5:				set_regop8(m_d.b.l);	%DIRECT;	%BIT8;		return;
-		case 0xD6:				set_regop8(m_d.b.l);	%DIRECT;	%LD8;		return;
-		case 0xD7:				set_regop8(m_d.b.l);	%DIRECT;	%ST8;		return;
-		case 0xD8:				set_regop8(m_d.b.l);	%DIRECT;	%EOR8;		return;
-		case 0xD9:				set_regop8(m_d.b.l);	%DIRECT;	%ADC8;		return;
-		case 0xDA:				set_regop8(m_d.b.l);	%DIRECT;	%OR8;		return;
-		case 0xDB:				set_regop8(m_d.b.l);	%DIRECT;	%ADD8;		return;
-		case 0xDC:				set_regop16(m_d);		%DIRECT;	%LD16;		return;
-		case 0xDD:				set_regop16(m_d);		%DIRECT;	%ST16;		return;
+		case 0xD0:				set_regop8(m_q.r.b);	%DIRECT;	%SUB8;		return;
+		case 0xD1:				set_regop8(m_q.r.b);	%DIRECT;	%CMP8;		return;
+		case 0xD2:				set_regop8(m_q.r.b);	%DIRECT;	%SBC8;		return;
+		case 0xD3:				set_regop16(m_q.p.d);	%DIRECT;	%ADD16;		return;
+		case 0xD4:				set_regop8(m_q.r.b);	%DIRECT;	%AND8;		return;
+		case 0xD5:				set_regop8(m_q.r.b);	%DIRECT;	%BIT8;		return;
+		case 0xD6:				set_regop8(m_q.r.b);	%DIRECT;	%LD8;		return;
+		case 0xD7:				set_regop8(m_q.r.b);	%DIRECT;	%ST8;		return;
+		case 0xD8:				set_regop8(m_q.r.b);	%DIRECT;	%EOR8;		return;
+		case 0xD9:				set_regop8(m_q.r.b);	%DIRECT;	%ADC8;		return;
+		case 0xDA:				set_regop8(m_q.r.b);	%DIRECT;	%OR8;		return;
+		case 0xDB:				set_regop8(m_q.r.b);	%DIRECT;	%ADD8;		return;
+		case 0xDC:				set_regop16(m_q.p.d);	%DIRECT;	%LD16;		return;
+		case 0xDD:				set_regop16(m_q.p.d);	%DIRECT;	%ST16;		return;
 		case 0xDE:				set_regop16(m_u);		%DIRECT;	%LD16;		return;
 		case 0xDF:				set_regop16(m_u);		%DIRECT;	%ST16;		return;
 
-		case 0xE0:				set_regop8(m_d.b.l);	%INDEXED;	%SUB8;		return;
-		case 0xE1:				set_regop8(m_d.b.l);	%INDEXED;	%CMP8;		return;
-		case 0xE2:				set_regop8(m_d.b.l);	%INDEXED;	%SBC8;		return;
-		case 0xE3:				set_regop16(m_d);		%INDEXED;	%ADD16;		return;
-		case 0xE4:				set_regop8(m_d.b.l);	%INDEXED;	%AND8;		return;
-		case 0xE5:				set_regop8(m_d.b.l);	%INDEXED;	%BIT8;		return;
-		case 0xE6:				set_regop8(m_d.b.l);	%INDEXED;	%LD8;		return;
-		case 0xE7:				set_regop8(m_d.b.l);	%INDEXED;	%ST8;		return;
-		case 0xE8:				set_regop8(m_d.b.l);	%INDEXED;	%EOR8;		return;
-		case 0xE9:				set_regop8(m_d.b.l);	%INDEXED;	%ADC8;		return;
-		case 0xEA:				set_regop8(m_d.b.l);	%INDEXED;	%OR8;		return;
-		case 0xEB:				set_regop8(m_d.b.l);	%INDEXED;	%ADD8;		return;
-		case 0xEC:				set_regop16(m_d);		%INDEXED;	%LD16;		return;
-		case 0xED:				set_regop16(m_d);		%INDEXED;	%ST16;		return;
+		case 0xE0:				set_regop8(m_q.r.b);	%INDEXED;	%SUB8;		return;
+		case 0xE1:				set_regop8(m_q.r.b);	%INDEXED;	%CMP8;		return;
+		case 0xE2:				set_regop8(m_q.r.b);	%INDEXED;	%SBC8;		return;
+		case 0xE3:				set_regop16(m_q.p.d);	%INDEXED;	%ADD16;		return;
+		case 0xE4:				set_regop8(m_q.r.b);	%INDEXED;	%AND8;		return;
+		case 0xE5:				set_regop8(m_q.r.b);	%INDEXED;	%BIT8;		return;
+		case 0xE6:				set_regop8(m_q.r.b);	%INDEXED;	%LD8;		return;
+		case 0xE7:				set_regop8(m_q.r.b);	%INDEXED;	%ST8;		return;
+		case 0xE8:				set_regop8(m_q.r.b);	%INDEXED;	%EOR8;		return;
+		case 0xE9:				set_regop8(m_q.r.b);	%INDEXED;	%ADC8;		return;
+		case 0xEA:				set_regop8(m_q.r.b);	%INDEXED;	%OR8;		return;
+		case 0xEB:				set_regop8(m_q.r.b);	%INDEXED;	%ADD8;		return;
+		case 0xEC:				set_regop16(m_q.p.d);	%INDEXED;	%LD16;		return;
+		case 0xED:				set_regop16(m_q.p.d);	%INDEXED;	%ST16;		return;
 		case 0xEE:				set_regop16(m_u);		%INDEXED;	%LD16;		return;
 		case 0xEF:				set_regop16(m_u);		%INDEXED;	%ST16;		return;
 
-		case 0xF0:				set_regop8(m_d.b.l);	%EXTENDED;	%SUB8;		return;
-		case 0xF1:				set_regop8(m_d.b.l);	%EXTENDED;	%CMP8;		return;
-		case 0xF2:				set_regop8(m_d.b.l);	%EXTENDED;	%SBC8;		return;
-		case 0xF3:				set_regop16(m_d);		%EXTENDED;	%ADD16;		return;
-		case 0xF4:				set_regop8(m_d.b.l);	%EXTENDED;	%AND8;		return;
-		case 0xF5:				set_regop8(m_d.b.l);	%EXTENDED;	%BIT8;		return;
-		case 0xF6:				set_regop8(m_d.b.l);	%EXTENDED;	%LD8;		return;
-		case 0xF7:				set_regop8(m_d.b.l);	%EXTENDED;	%ST8;		return;
-		case 0xF8:				set_regop8(m_d.b.l);	%EXTENDED;	%EOR8;		return;
-		case 0xF9:				set_regop8(m_d.b.l);	%EXTENDED;	%ADC8;		return;
-		case 0xFA:				set_regop8(m_d.b.l);	%EXTENDED;	%OR8;		return;
-		case 0xFB:				set_regop8(m_d.b.l);	%EXTENDED;	%ADD8;		return;
-		case 0xFC:				set_regop16(m_d);		%EXTENDED;	%LD16;		return;
-		case 0xFD:				set_regop16(m_d);		%EXTENDED;	%ST16;		return;
+		case 0xF0:				set_regop8(m_q.r.b);	%EXTENDED;	%SUB8;		return;
+		case 0xF1:				set_regop8(m_q.r.b);	%EXTENDED;	%CMP8;		return;
+		case 0xF2:				set_regop8(m_q.r.b);	%EXTENDED;	%SBC8;		return;
+		case 0xF3:				set_regop16(m_q.p.d);	%EXTENDED;	%ADD16;		return;
+		case 0xF4:				set_regop8(m_q.r.b);	%EXTENDED;	%AND8;		return;
+		case 0xF5:				set_regop8(m_q.r.b);	%EXTENDED;	%BIT8;		return;
+		case 0xF6:				set_regop8(m_q.r.b);	%EXTENDED;	%LD8;		return;
+		case 0xF7:				set_regop8(m_q.r.b);	%EXTENDED;	%ST8;		return;
+		case 0xF8:				set_regop8(m_q.r.b);	%EXTENDED;	%EOR8;		return;
+		case 0xF9:				set_regop8(m_q.r.b);	%EXTENDED;	%ADC8;		return;
+		case 0xFA:				set_regop8(m_q.r.b);	%EXTENDED;	%OR8;		return;
+		case 0xFB:				set_regop8(m_q.r.b);	%EXTENDED;	%ADD8;		return;
+		case 0xFC:				set_regop16(m_q.p.d);	%EXTENDED;	%LD16;		return;
+		case 0xFD:				set_regop16(m_q.p.d);	%EXTENDED;	%ST16;		return;
 		case 0xFE:				set_regop16(m_u);		%EXTENDED;	%LD16;		return;
 		case 0xFF:				set_regop16(m_u);		%EXTENDED;	%ST16;		return;
 		default:													%ILLEGAL;	return;			
@@ -334,64 +334,64 @@ DISPATCH10:
 		case 0x5D:									set_w();		%TST16;		return;
 		case 0x5F:									set_w();		%CLR16;		return;
 
-		case 0x80:				set_regop16(m_w);	set_imm();		%SUB16;		return;
-		case 0x81:				set_regop16(m_w);	set_imm();		%CMP16;		return;
-		case 0x82:				set_regop16(m_d);	set_imm();		%SBC16;		return;
-		case 0x83:				set_regop16(m_d);	set_imm();		%CMP16;		return;
-		case 0x84:				set_regop16(m_d);	set_imm();		%AND16;		return;
-		case 0x85:				set_regop16(m_d);	set_imm();		%BIT16;		return;
-		case 0x86:				set_regop16(m_w);	set_imm();		%LD16;		return;
-		case 0x88:				set_regop16(m_d);	set_imm();		%EOR16;		return;
-		case 0x89:				set_regop16(m_d);	set_imm();		%ADC16;		return;
-		case 0x8A:				set_regop16(m_d);	set_imm();		%OR16;		return;
-		case 0x8B:				set_regop16(m_w);	set_imm();		%ADD16;		return;
+		case 0x80:				set_regop16(m_q.p.w);	set_imm();		%SUB16;		return;
+		case 0x81:				set_regop16(m_q.p.w);	set_imm();		%CMP16;		return;
+		case 0x82:				set_regop16(m_q.p.d);	set_imm();		%SBC16;		return;
+		case 0x83:				set_regop16(m_q.p.d);	set_imm();		%CMP16;		return;
+		case 0x84:				set_regop16(m_q.p.d);	set_imm();		%AND16;		return;
+		case 0x85:				set_regop16(m_q.p.d);	set_imm();		%BIT16;		return;
+		case 0x86:				set_regop16(m_q.p.w);	set_imm();		%LD16;		return;
+		case 0x88:				set_regop16(m_q.p.d);	set_imm();		%EOR16;		return;
+		case 0x89:				set_regop16(m_q.p.d);	set_imm();		%ADC16;		return;
+		case 0x8A:				set_regop16(m_q.p.d);	set_imm();		%OR16;		return;
+		case 0x8B:				set_regop16(m_q.p.w);	set_imm();		%ADD16;		return;
 		case 0x8C:				set_regop16(m_y);	set_imm();		%CMP16;		return;
 		case 0x8E:				set_regop16(m_y);	set_imm();		%LD16;		return;
 
-		case 0x90:				set_regop16(m_w);	%DIRECT;		%SUB16;		return;
-		case 0x91:				set_regop16(m_w);	%DIRECT;		%CMP16;		return;
-		case 0x92:				set_regop16(m_d);	%DIRECT;		%SBC16;		return;
-		case 0x93:				set_regop16(m_d);	%DIRECT;		%CMP16;		return;
-		case 0x94:				set_regop16(m_d);	%DIRECT;		%AND16;		return;
-		case 0x95:				set_regop16(m_d);	%DIRECT;		%BIT16;		return;
-		case 0x96:				set_regop16(m_w);	%DIRECT;		%LD16;		return;
-		case 0x97:				set_regop16(m_w);	%DIRECT;		%ST16;		return;
-		case 0x98:				set_regop16(m_d);	%DIRECT;		%EOR16;		return;
-		case 0x99:				set_regop16(m_d);	%DIRECT;		%ADC16;		return;
-		case 0x9A:				set_regop16(m_d);	%DIRECT;		%OR16;		return;
-		case 0x9B:				set_regop16(m_w);	%DIRECT;		%ADD16;		return;
+		case 0x90:				set_regop16(m_q.p.w);	%DIRECT;		%SUB16;		return;
+		case 0x91:				set_regop16(m_q.p.w);	%DIRECT;		%CMP16;		return;
+		case 0x92:				set_regop16(m_q.p.d);	%DIRECT;		%SBC16;		return;
+		case 0x93:				set_regop16(m_q.p.d);	%DIRECT;		%CMP16;		return;
+		case 0x94:				set_regop16(m_q.p.d);	%DIRECT;		%AND16;		return;
+		case 0x95:				set_regop16(m_q.p.d);	%DIRECT;		%BIT16;		return;
+		case 0x96:				set_regop16(m_q.p.w);	%DIRECT;		%LD16;		return;
+		case 0x97:				set_regop16(m_q.p.w);	%DIRECT;		%ST16;		return;
+		case 0x98:				set_regop16(m_q.p.d);	%DIRECT;		%EOR16;		return;
+		case 0x99:				set_regop16(m_q.p.d);	%DIRECT;		%ADC16;		return;
+		case 0x9A:				set_regop16(m_q.p.d);	%DIRECT;		%OR16;		return;
+		case 0x9B:				set_regop16(m_q.p.w);	%DIRECT;		%ADD16;		return;
 		case 0x9C:				set_regop16(m_y);	%DIRECT;		%CMP16;		return;
 		case 0x9E:				set_regop16(m_y);	%DIRECT;		%LD16;		return;
 		case 0x9F:				set_regop16(m_y);	%DIRECT;		%ST16;		return;
 
-		case 0xA0:				set_regop16(m_w);	%INDEXED;		%SUB16;		return;
-		case 0xA1:				set_regop16(m_w);	%INDEXED;		%CMP16;		return;
-		case 0xA2:				set_regop16(m_d);	%INDEXED;		%SBC16;		return;
-		case 0xA3:				set_regop16(m_d);	%INDEXED;		%CMP16;		return;
-		case 0xA4:				set_regop16(m_d);	%INDEXED;		%AND16;		return;
-		case 0xA5:				set_regop16(m_d);	%INDEXED;		%BIT16;		return;
-		case 0xA6:				set_regop16(m_w);	%INDEXED;		%LD16;		return;
-		case 0xA7:				set_regop16(m_w);	%INDEXED;		%ST16;		return;
-		case 0xA8:				set_regop16(m_d);	%INDEXED;		%EOR16;		return;
-		case 0xA9:				set_regop16(m_d);	%INDEXED;		%ADC16;		return;
-		case 0xAA:				set_regop16(m_d);	%INDEXED;		%OR16;		return;
-		case 0xAB:				set_regop16(m_w);	%INDEXED;		%ADD16;		return;
+		case 0xA0:				set_regop16(m_q.p.w);	%INDEXED;		%SUB16;		return;
+		case 0xA1:				set_regop16(m_q.p.w);	%INDEXED;		%CMP16;		return;
+		case 0xA2:				set_regop16(m_q.p.d);	%INDEXED;		%SBC16;		return;
+		case 0xA3:				set_regop16(m_q.p.d);	%INDEXED;		%CMP16;		return;
+		case 0xA4:				set_regop16(m_q.p.d);	%INDEXED;		%AND16;		return;
+		case 0xA5:				set_regop16(m_q.p.d);	%INDEXED;		%BIT16;		return;
+		case 0xA6:				set_regop16(m_q.p.w);	%INDEXED;		%LD16;		return;
+		case 0xA7:				set_regop16(m_q.p.w);	%INDEXED;		%ST16;		return;
+		case 0xA8:				set_regop16(m_q.p.d);	%INDEXED;		%EOR16;		return;
+		case 0xA9:				set_regop16(m_q.p.d);	%INDEXED;		%ADC16;		return;
+		case 0xAA:				set_regop16(m_q.p.d);	%INDEXED;		%OR16;		return;
+		case 0xAB:				set_regop16(m_q.p.w);	%INDEXED;		%ADD16;		return;
 		case 0xAC:				set_regop16(m_y);	%INDEXED;		%CMP16;		return;
 		case 0xAE:				set_regop16(m_y);	%INDEXED;		%LD16;		return;
 		case 0xAF:				set_regop16(m_y);	%INDEXED;		%ST16;		return;
 
-		case 0xB0:				set_regop16(m_w);	%EXTENDED;		%SUB16;		return;
-		case 0xB1:				set_regop16(m_w);	%EXTENDED;		%CMP16;		return;
-		case 0xB2:				set_regop16(m_d);	%EXTENDED;		%SBC16;		return;
-		case 0xB3:				set_regop16(m_d);	%EXTENDED;		%CMP16;		return;
-		case 0xB4:				set_regop16(m_d);	%EXTENDED;		%AND16;		return;
-		case 0xB5:				set_regop16(m_d);	%EXTENDED;		%BIT16;		return;
-		case 0xB6:				set_regop16(m_w);	%EXTENDED;		%LD16;		return;
-		case 0xB7:				set_regop16(m_w);	%EXTENDED;		%ST16;		return;
-		case 0xB8:				set_regop16(m_d);	%EXTENDED;		%EOR16;		return;
-		case 0xB9:				set_regop16(m_d);	%EXTENDED;		%ADC16;		return;
-		case 0xBA:				set_regop16(m_d);	%EXTENDED;		%OR16;		return;
-		case 0xBB:				set_regop16(m_w);	%EXTENDED;		%ADD16;		return;
+		case 0xB0:				set_regop16(m_q.p.w);	%EXTENDED;		%SUB16;		return;
+		case 0xB1:				set_regop16(m_q.p.w);	%EXTENDED;		%CMP16;		return;
+		case 0xB2:				set_regop16(m_q.p.d);	%EXTENDED;		%SBC16;		return;
+		case 0xB3:				set_regop16(m_q.p.d);	%EXTENDED;		%CMP16;		return;
+		case 0xB4:				set_regop16(m_q.p.d);	%EXTENDED;		%AND16;		return;
+		case 0xB5:				set_regop16(m_q.p.d);	%EXTENDED;		%BIT16;		return;
+		case 0xB6:				set_regop16(m_q.p.w);	%EXTENDED;		%LD16;		return;
+		case 0xB7:				set_regop16(m_q.p.w);	%EXTENDED;		%ST16;		return;
+		case 0xB8:				set_regop16(m_q.p.d);	%EXTENDED;		%EOR16;		return;
+		case 0xB9:				set_regop16(m_q.p.d);	%EXTENDED;		%ADC16;		return;
+		case 0xBA:				set_regop16(m_q.p.d);	%EXTENDED;		%OR16;		return;
+		case 0xBB:				set_regop16(m_q.p.w);	%EXTENDED;		%ADD16;		return;
 		case 0xBC:				set_regop16(m_y);	%EXTENDED;		%CMP16;		return;
 		case 0xBE:				set_regop16(m_y);	%EXTENDED;		%LD16;		return;
 		case 0xBF:				set_regop16(m_y);	%EXTENDED;		%ST16;		return;
@@ -446,71 +446,71 @@ DISPATCH11:
 		case 0x5D:									set_f();		%TST8;		return;
 		case 0x5F:									set_f();		%CLR8;		return;
 
-		case 0x80:				set_regop8(m_w.b.h);	set_imm();		%SUB8;		return;
-		case 0x81:				set_regop8(m_w.b.h);	set_imm();		%CMP8;		return;
+		case 0x80:				set_regop8(m_q.r.e);	set_imm();		%SUB8;		return;
+		case 0x81:				set_regop8(m_q.r.e);	set_imm();		%CMP8;		return;
 		case 0x83:				set_regop16(m_u);		set_imm();		%CMP16;		return;
-		case 0x86:				set_regop8(m_w.b.h);	set_imm();		%LD8;		return;
-		case 0x8B:				set_regop8(m_w.b.h);	set_imm();		%ADD8;		return;
+		case 0x86:				set_regop8(m_q.r.e);	set_imm();		%LD8;		return;
+		case 0x8B:				set_regop8(m_q.r.e);	set_imm();		%ADD8;		return;
 		case 0x8C:				set_regop16(m_s);		set_imm();		%CMP16;		return;
 		case 0x8D:										set_imm();		%DIVD;		return;
 		case 0x8E:										set_imm();		%DIVQ;		return;
 		case 0x8F:										set_imm();		%MULD;		return;
 
-		case 0x90:				set_regop8(m_w.b.h);	%DIRECT;		%SUB8;		return;
-		case 0x91:				set_regop8(m_w.b.h);	%DIRECT;		%CMP8;		return;
+		case 0x90:				set_regop8(m_q.r.e);	%DIRECT;		%SUB8;		return;
+		case 0x91:				set_regop8(m_q.r.e);	%DIRECT;		%CMP8;		return;
 		case 0x93:				set_regop16(m_u);		%DIRECT;		%CMP16;		return;
-		case 0x96:				set_regop8(m_w.b.h);	%DIRECT;		%LD8;		return;
-		case 0x97:				set_regop8(m_w.b.h);	%DIRECT;		%ST8;		return;
-		case 0x9B:				set_regop8(m_w.b.h);	%DIRECT;		%ADD8;		return;
+		case 0x96:				set_regop8(m_q.r.e);	%DIRECT;		%LD8;		return;
+		case 0x97:				set_regop8(m_q.r.e);	%DIRECT;		%ST8;		return;
+		case 0x9B:				set_regop8(m_q.r.e);	%DIRECT;		%ADD8;		return;
 		case 0x9C:				set_regop16(m_s);		%DIRECT;		%CMP16;		return;
 		case 0x9D:										%DIRECT;		%DIVD;		return;
 		case 0x9E:										%DIRECT;		%DIVQ;		return;
 		case 0x9F:										%DIRECT;		%MULD;		return;
 
-		case 0xA0:				set_regop8(m_w.b.h);	%INDEXED;		%SUB8;		return;
-		case 0xA1:				set_regop8(m_w.b.h);	%INDEXED;		%CMP8;		return;
+		case 0xA0:				set_regop8(m_q.r.e);	%INDEXED;		%SUB8;		return;
+		case 0xA1:				set_regop8(m_q.r.e);	%INDEXED;		%CMP8;		return;
 		case 0xA3:				set_regop16(m_u);		%INDEXED;		%CMP16;		return;
-		case 0xA6:				set_regop8(m_w.b.h);	%INDEXED;		%LD8;		return;
-		case 0xA7:				set_regop8(m_w.b.h);	%INDEXED;		%ST8;		return;
-		case 0xAB:				set_regop8(m_w.b.h);	%INDEXED;		%ADD8;		return;
+		case 0xA6:				set_regop8(m_q.r.e);	%INDEXED;		%LD8;		return;
+		case 0xA7:				set_regop8(m_q.r.e);	%INDEXED;		%ST8;		return;
+		case 0xAB:				set_regop8(m_q.r.e);	%INDEXED;		%ADD8;		return;
 		case 0xAC:				set_regop16(m_s);		%INDEXED;		%CMP16;		return;
 		case 0xAD:										%INDEXED;		%DIVD;		return;
 		case 0xAE:										%INDEXED;		%DIVQ;		return;
 		case 0xAF:										%INDEXED;		%MULD;		return;
 
-		case 0xB0:				set_regop8(m_w.b.h);	%EXTENDED;		%SUB8;		return;
-		case 0xB1:				set_regop8(m_w.b.h);	%EXTENDED;		%CMP8;		return;
+		case 0xB0:				set_regop8(m_q.r.e);	%EXTENDED;		%SUB8;		return;
+		case 0xB1:				set_regop8(m_q.r.e);	%EXTENDED;		%CMP8;		return;
 		case 0xB3:				set_regop16(m_u);		%EXTENDED;		%CMP16;		return;
-		case 0xB6:				set_regop8(m_w.b.h);	%EXTENDED;		%LD8;		return;
-		case 0xB7:				set_regop8(m_w.b.h);	%EXTENDED;		%ST8;		return;
-		case 0xBB:				set_regop8(m_w.b.h);	%EXTENDED;		%ADD8;		return;
+		case 0xB6:				set_regop8(m_q.r.e);	%EXTENDED;		%LD8;		return;
+		case 0xB7:				set_regop8(m_q.r.e);	%EXTENDED;		%ST8;		return;
+		case 0xBB:				set_regop8(m_q.r.e);	%EXTENDED;		%ADD8;		return;
 		case 0xBC:				set_regop16(m_s);		%EXTENDED;		%CMP16;		return;
 		case 0xBD:										%EXTENDED;		%DIVD;		return;
 		case 0xBE:										%EXTENDED;		%DIVQ;		return;
 		case 0xBF:										%EXTENDED;		%MULD;		return;
 
-		case 0xC0:				set_regop8(m_w.b.l);	set_imm();		%SUB8;		return;
-		case 0xC1:				set_regop8(m_w.b.l);	set_imm();		%CMP8;		return;
-		case 0xC6:				set_regop8(m_w.b.l);	set_imm();		%LD8;		return;
-		case 0xCB:				set_regop8(m_w.b.l);	set_imm();		%ADD8;		return;
+		case 0xC0:				set_regop8(m_q.r.f);	set_imm();		%SUB8;		return;
+		case 0xC1:				set_regop8(m_q.r.f);	set_imm();		%CMP8;		return;
+		case 0xC6:				set_regop8(m_q.r.f);	set_imm();		%LD8;		return;
+		case 0xCB:				set_regop8(m_q.r.f);	set_imm();		%ADD8;		return;
 
-		case 0xD0:				set_regop8(m_w.b.l);	%DIRECT;		%SUB8;		return;
-		case 0xD1:				set_regop8(m_w.b.l);	%DIRECT;		%CMP8;		return;
-		case 0xD6:				set_regop8(m_w.b.l);	%DIRECT;		%LD8;		return;
-		case 0xD7:				set_regop8(m_w.b.l);	%DIRECT;		%ST8;		return;
-		case 0xDB:				set_regop8(m_w.b.l);	%DIRECT;		%ADD8;		return;
+		case 0xD0:				set_regop8(m_q.r.f);	%DIRECT;		%SUB8;		return;
+		case 0xD1:				set_regop8(m_q.r.f);	%DIRECT;		%CMP8;		return;
+		case 0xD6:				set_regop8(m_q.r.f);	%DIRECT;		%LD8;		return;
+		case 0xD7:				set_regop8(m_q.r.f);	%DIRECT;		%ST8;		return;
+		case 0xDB:				set_regop8(m_q.r.f);	%DIRECT;		%ADD8;		return;
 
-		case 0xE0:				set_regop8(m_w.b.l);	%INDEXED;		%SUB8;		return;
-		case 0xE1:				set_regop8(m_w.b.l);	%INDEXED;		%CMP8;		return;
-		case 0xE6:				set_regop8(m_w.b.l);	%INDEXED;		%LD8;		return;
-		case 0xE7:				set_regop8(m_w.b.l);	%INDEXED;		%ST8;		return;
-		case 0xEB:				set_regop8(m_w.b.l);	%INDEXED;		%ADD8;		return;
+		case 0xE0:				set_regop8(m_q.r.f);	%INDEXED;		%SUB8;		return;
+		case 0xE1:				set_regop8(m_q.r.f);	%INDEXED;		%CMP8;		return;
+		case 0xE6:				set_regop8(m_q.r.f);	%INDEXED;		%LD8;		return;
+		case 0xE7:				set_regop8(m_q.r.f);	%INDEXED;		%ST8;		return;
+		case 0xEB:				set_regop8(m_q.r.f);	%INDEXED;		%ADD8;		return;
 
-		case 0xF0:				set_regop8(m_w.b.l);	%EXTENDED;		%SUB8;		return;
-		case 0xF1:				set_regop8(m_w.b.l);	%EXTENDED;		%CMP8;		return;
-		case 0xF6:				set_regop8(m_w.b.l);	%EXTENDED;		%LD8;		return;
-		case 0xF7:				set_regop8(m_w.b.l);	%EXTENDED;		%ST8;		return;
-		case 0xFB:				set_regop8(m_w.b.l);	%EXTENDED;		%ADD8;		return;
+		case 0xF0:				set_regop8(m_q.r.f);	%EXTENDED;		%SUB8;		return;
+		case 0xF1:				set_regop8(m_q.r.f);	%EXTENDED;		%CMP8;		return;
+		case 0xF6:				set_regop8(m_q.r.f);	%EXTENDED;		%LD8;		return;
+		case 0xF7:				set_regop8(m_q.r.f);	%EXTENDED;		%ST8;		return;
+		case 0xFB:				set_regop8(m_q.r.f);	%EXTENDED;		%ADD8;		return;
 
 		default:														%ILLEGAL;	return;			
 	}
@@ -550,22 +550,22 @@ PUSH_REGISTERS:
 	}
 	if (m_temp.w & 0x200)
 	{
-		@write_memory(--regop16().w, m_w.b.l);
+		@write_memory(--regop16().w, m_q.r.f);
 		nop();
 	}
 	if (m_temp.w & 0x100)
 	{
-		@write_memory(--regop16().w, m_w.b.h);
+		@write_memory(--regop16().w, m_q.r.e);
 		nop();
 	}
 	if (m_temp.w & 0x04)
 	{
-		@write_memory(--regop16().w, m_d.b.l);
+		@write_memory(--regop16().w, m_q.r.b);
 		nop();
 	}
 	if (m_temp.w & 0x02)
 	{
-		@write_memory(--regop16().w, m_d.b.h);
+		@write_memory(--regop16().w, m_q.r.a);
 		nop();
 	}
 	if (m_temp.w & 0x01)
@@ -583,22 +583,22 @@ PULL_REGISTERS:
 	}
 	if (m_temp.w & 0x02)
 	{
-		@m_d.b.h = read_memory(regop16().w++);
+		@m_q.r.a = read_memory(regop16().w++);
 		nop();
 	}
 	if (m_temp.w & 0x04)
 	{
-		@m_d.b.l = read_memory(regop16().w++);
+		@m_q.r.b = read_memory(regop16().w++);
 		nop();
 	}
 	if (m_temp.w & 0x100)
 	{
-		@m_w.b.h = read_memory(regop16().w++);
+		@m_q.r.e = read_memory(regop16().w++);
 		nop();
 	}
 	if (m_temp.w & 0x200)
 	{
-		@m_w.b.l = read_memory(regop16().w++);
+		@m_q.r.f = read_memory(regop16().w++);
 		nop();
 	}
 	if (m_temp.w & 0x08)
@@ -673,13 +673,13 @@ INDEXED:
 
 			case 0x05: case 0x25: case 0x45: case 0x65:
 			case 0x15: case 0x35: case 0x55: case 0x75:
-				m_temp.w = ireg() + (INT8) m_d.b.l;
+				m_temp.w = ireg() + (INT8) m_q.r.b;
 				eat(2);
 				break;
 
 			case 0x06: case 0x26: case 0x46: case 0x66:
 			case 0x16: case 0x36: case 0x56: case 0x76:
-				m_temp.w = ireg() + (INT8) m_d.b.h;
+				m_temp.w = ireg() + (INT8) m_q.r.a;
 				eat(2);
 				break;
 
@@ -699,7 +699,7 @@ INDEXED:
 
 			case 0x0B: case 0x2B: case 0x4B: case 0x6B:
 			case 0x1B: case 0x3B: case 0x5B: case 0x7B:
-				m_temp.w = ireg() + m_d.w;
+				m_temp.w = ireg() + m_q.r.d;
 				eat((hd6309_native_mode() && !(m_opcode & 0x10)) ? 3 : 5);
 				break;
 
@@ -727,27 +727,27 @@ INDEXED:
 			case 0x07: case 0x27: case 0x47: case 0x67:
 			case 0x17: case 0x37: case 0x57: case 0x77:
 				// 6309 specific mode
-				m_temp.w = ireg() + (INT8) m_w.b.h;
+				m_temp.w = ireg() + (INT8) m_q.r.e;
 				eat(2);
 				break;
 
 			case 0x0A: case 0x2A: case 0x4A: case 0x6A:
 			case 0x1A: case 0x3A: case 0x5A: case 0x7A:
 				// 6309 specific mode
-				m_temp.w = ireg() + (INT8) m_w.b.l;
+				m_temp.w = ireg() + (INT8) m_q.r.f;
 				eat(2);
 				break;
 
 			case 0x0E: case 0x2E: case 0x4E: case 0x6E:
 			case 0x1E: case 0x3E: case 0x5E: case 0x7E:
 				// 6309 specific mode
-				m_temp.w = ireg() + m_w.w;
+				m_temp.w = ireg() + m_q.r.w;
 				eat((hd6309_native_mode() && !(m_opcode & 0x10)) ? 2 : 5);
 				break;
 
 			case 0x0F:
 				// 6309 specific mode
-				m_temp.w = m_w.w;
+				m_temp.w = m_q.r.w;
 				eat(1);
 				break;
 
@@ -755,21 +755,21 @@ INDEXED:
 				// 6309 specific mode
 				@m_temp.b.h = read_opcode_arg();
 				@m_temp.b.l = read_opcode_arg();
-				m_temp.w = m_w.w + m_temp.w;
+				m_temp.w = m_q.r.w + m_temp.w;
 				eat(hd6309_native_mode() ? 1 : 5);
 				break;
 
 			case 0x4F:
 				// 6309 specific mode
-				m_temp.w = m_w.w;
-				m_w.w += 2;
+				m_temp.w = m_q.r.w;
+				m_q.r.w += 2;
 				eat((hd6309_native_mode() && !(m_opcode & 0x10)) ? 2 : 4);
 				break;
 
 			case 0x6F:
 				// 6309 specific mode
-				m_w.w -= 2;
-				m_temp.w = m_w.w;
+				m_q.r.w -= 2;
+				m_temp.w = m_q.r.w;
 				eat((hd6309_native_mode() && !(m_opcode & 0x10)) ? 2 : 4);
 				break;
 
@@ -835,19 +835,19 @@ JSR_ind:
 	goto JSR;
 
 LDQ:
-	@m_d.b.h = read_operand(0);
-	@m_d.b.l = read_operand(1);
-	@m_w.b.h = read_operand(2);
-	@m_w.b.l = read_operand(3);
-	set_flags<UINT32>(CC_NZV, get_q());
+	@m_q.r.a = read_operand(0);
+	@m_q.r.b = read_operand(1);
+	@m_q.r.e = read_operand(2);
+	@m_q.r.f = read_operand(3);
+	set_flags<UINT32>(CC_NZV, m_q.q);
 	return;
 
 STQ:
-	@write_operand(0, m_d.b.h);
-	@write_operand(1, m_d.b.l);
-	@write_operand(2, m_w.b.h);
-	@write_operand(3, m_w.b.l);
-	set_flags<UINT32>(CC_NZV, get_q());
+	@write_operand(0, m_q.r.a);
+	@write_operand(1, m_q.r.b);
+	@write_operand(2, m_q.r.e);
+	@write_operand(3, m_q.r.f);
+	set_flags<UINT32>(CC_NZV, m_q.q);
 	return;
 
 OIM:
@@ -897,7 +897,7 @@ TFM:
 	// here; the timings of the reads and writes are really just a guess.
 	@m_temp.b.l = read_opcode_arg();
 
-	while (m_w.w != 0x0000)
+	while (m_q.r.w != 0x0000)
 	{
 		// TFM is abortable - we need to check for a pending interrupt
 		if (get_pending_interrupt() != 0)
@@ -914,7 +914,7 @@ TFM:
 			goto ILLEGAL;
 		@eat(1);
 
-		m_w.w--;
+		m_q.r.w--;
 	}
 
 	// Not sure if this sub instruction timing is accurate either
@@ -1079,8 +1079,8 @@ DIVD:
 	return;
 
 SEXW:
-	m_d.w = set_flags<UINT16>(CC_N, (m_w.w & 0x8000) ? 0xFFFF : 0x0000);
-	if ((m_d.w == 0x0000) && (m_w.w == 0x0000))
+	m_q.r.d = set_flags<UINT16>(CC_N, (m_q.r.w & 0x8000) ? 0xFFFF : 0x0000);
+	if ((m_q.r.d == 0x0000) && (m_q.r.w == 0x0000))
 		m_cc |= CC_Z;
 	else
 		m_cc &= ~CC_Z;

--- a/src/devices/cpu/m6809/konami.cpp
+++ b/src/devices/cpu/m6809/konami.cpp
@@ -136,7 +136,7 @@ inline UINT8 konami_cpu_device::read_operand(int ordinal)
 	{
 		case ADDRESSING_MODE_EA:            return read_memory(m_ea.w + ordinal);
 		case ADDRESSING_MODE_IMMEDIATE:     return read_opcode_arg();
-		case ADDRESSING_MODE_REGISTER_D:    return (ordinal & 1) ? m_d.b.l : m_d.b.h;
+		case ADDRESSING_MODE_REGISTER_D:    return (ordinal & 1) ? m_q.r.b : m_q.r.a;
 		default:                            fatalerror("Unexpected");
 	}
 }
@@ -163,7 +163,7 @@ inline void konami_cpu_device::write_operand(int ordinal, UINT8 data)
 	{
 		case ADDRESSING_MODE_IMMEDIATE:     /* do nothing */                                break;
 		case ADDRESSING_MODE_EA:            write_memory(m_ea.w + ordinal, data);           break;
-		case ADDRESSING_MODE_REGISTER_D:    *((ordinal & 1) ? &m_d.b.l : &m_d.b.h) = data;  break;
+		case ADDRESSING_MODE_REGISTER_D:    *((ordinal & 1) ? &m_q.r.b : &m_q.r.a) = data;  break;
 		default:                            fatalerror("Unexpected");
 	}
 }
@@ -201,8 +201,8 @@ inline m6809_base_device::exgtfr_register konami_cpu_device::read_exgtfr_registe
 
 	switch(reg & 0x07)
 	{
-		case  0: result.word_value = m_d.b.h;   break;  // A
-		case  1: result.word_value = m_d.b.l;   break;  // B
+		case  0: result.word_value = m_q.r.a;   break;  // A
+		case  1: result.word_value = m_q.r.b;   break;  // B
 		case  2: result.word_value = m_x.w;     break;  // X
 		case  3: result.word_value = m_y.w;     break;  // Y
 		case  4: result.word_value = m_s.w;     break;  // S
@@ -221,8 +221,8 @@ inline void konami_cpu_device::write_exgtfr_register(UINT8 reg, m6809_base_devic
 {
 	switch(reg & 0x07)
 	{
-		case  0: m_d.b.h = value.byte_value;    break;  // A
-		case  1: m_d.b.l = value.byte_value;    break;  // B
+		case  0: m_q.r.a = value.byte_value;    break;  // A
+		case  1: m_q.r.b = value.byte_value;    break;  // B
 		case  2: m_x.w   = value.word_value;    break;  // X
 		case  3: m_y.w   = value.word_value;    break;  // Y
 		case  4: m_s.w   = value.word_value;    break;  // S
@@ -318,10 +318,10 @@ inline void konami_cpu_device::divx()
 	UINT16 result;
 	UINT8 remainder;
 
-	if (m_d.b.l != 0)
+	if (m_q.r.b != 0)
 	{
-		result = m_x.w / m_d.b.l;
-		remainder = m_x.w % m_d.b.l;
+		result = m_x.w / m_q.r.b;
+		remainder = m_x.w % m_q.r.b;
 	}
 	else
 	{
@@ -332,7 +332,7 @@ inline void konami_cpu_device::divx()
 
 	// set results and Z flag
 	m_x.w = set_flags<UINT16>(CC_Z, result);
-	m_d.b.l = remainder;
+	m_q.r.b = remainder;
 
 	// set C flag
 	if (result & 0x0080)

--- a/src/devices/cpu/m6809/konami.ops
+++ b/src/devices/cpu/m6809/konami.ops
@@ -28,59 +28,59 @@ MAIN:
 		case 0x0E:													%PULS;		return;
 		case 0x0F:													%PULU;		return;
 
-		case 0x10:				set_regop8(m_d.b.h);	set_imm();	%LD8;		return;
-		case 0x11:				set_regop8(m_d.b.l);	set_imm();	%LD8;		return;
-		case 0x12:				set_regop8(m_d.b.h);	%INDEXED;	%LD8;		return;
-		case 0x13:				set_regop8(m_d.b.l);	%INDEXED;	%LD8;		return;
-		case 0x14:				set_regop8(m_d.b.h);	set_imm();	%ADD8;		return;
-		case 0x15:				set_regop8(m_d.b.l);	set_imm();	%ADD8;		return;
-		case 0x16:				set_regop8(m_d.b.h);	%INDEXED;	%ADD8;		return;
-		case 0x17:				set_regop8(m_d.b.l);	%INDEXED;	%ADD8;		return;
-		case 0x18:				set_regop8(m_d.b.h);	set_imm();	%ADC8;		return;
-		case 0x19:				set_regop8(m_d.b.l);	set_imm();	%ADC8;		return;
-		case 0x1A:				set_regop8(m_d.b.h);	%INDEXED;	%ADC8;		return;
-		case 0x1B:				set_regop8(m_d.b.l);	%INDEXED;	%ADC8;		return;
-		case 0x1C:				set_regop8(m_d.b.h);	set_imm();	%SUB8;		return;
-		case 0x1D:				set_regop8(m_d.b.l);	set_imm();	%SUB8;		return;
-		case 0x1E:				set_regop8(m_d.b.h);	%INDEXED;	%SUB8;		return;
-		case 0x1F:				set_regop8(m_d.b.l);	%INDEXED;	%SUB8;		return;
+		case 0x10:				set_regop8(m_q.r.a);	set_imm();	%LD8;		return;
+		case 0x11:				set_regop8(m_q.r.b);	set_imm();	%LD8;		return;
+		case 0x12:				set_regop8(m_q.r.a);	%INDEXED;	%LD8;		return;
+		case 0x13:				set_regop8(m_q.r.b);	%INDEXED;	%LD8;		return;
+		case 0x14:				set_regop8(m_q.r.a);	set_imm();	%ADD8;		return;
+		case 0x15:				set_regop8(m_q.r.b);	set_imm();	%ADD8;		return;
+		case 0x16:				set_regop8(m_q.r.a);	%INDEXED;	%ADD8;		return;
+		case 0x17:				set_regop8(m_q.r.b);	%INDEXED;	%ADD8;		return;
+		case 0x18:				set_regop8(m_q.r.a);	set_imm();	%ADC8;		return;
+		case 0x19:				set_regop8(m_q.r.b);	set_imm();	%ADC8;		return;
+		case 0x1A:				set_regop8(m_q.r.a);	%INDEXED;	%ADC8;		return;
+		case 0x1B:				set_regop8(m_q.r.b);	%INDEXED;	%ADC8;		return;
+		case 0x1C:				set_regop8(m_q.r.a);	set_imm();	%SUB8;		return;
+		case 0x1D:				set_regop8(m_q.r.b);	set_imm();	%SUB8;		return;
+		case 0x1E:				set_regop8(m_q.r.a);	%INDEXED;	%SUB8;		return;
+		case 0x1F:				set_regop8(m_q.r.b);	%INDEXED;	%SUB8;		return;
 
-		case 0x20:				set_regop8(m_d.b.h);	set_imm();	%SBC8;		return;
-		case 0x21:				set_regop8(m_d.b.l);	set_imm();	%SBC8;		return;
-		case 0x22:				set_regop8(m_d.b.h);	%INDEXED;	%SBC8;		return;
-		case 0x23:				set_regop8(m_d.b.l);	%INDEXED;	%SBC8;		return;
-		case 0x24:				set_regop8(m_d.b.h);	set_imm();	%AND8;		return;
-		case 0x25:				set_regop8(m_d.b.l);	set_imm();	%AND8;		return;
-		case 0x26:				set_regop8(m_d.b.h);	%INDEXED;	%AND8;		return;
-		case 0x27:				set_regop8(m_d.b.l);	%INDEXED;	%AND8;		return;
-		case 0x28:				set_regop8(m_d.b.h);	set_imm();	%BIT8;		return;
-		case 0x29:				set_regop8(m_d.b.l);	set_imm();	%BIT8;		return;
-		case 0x2A:				set_regop8(m_d.b.h);	%INDEXED;	%BIT8;		return;
-		case 0x2B:				set_regop8(m_d.b.l);	%INDEXED;	%BIT8;		return;
-		case 0x2C:				set_regop8(m_d.b.h);	set_imm();	%EOR8;		return;
-		case 0x2D:				set_regop8(m_d.b.l);	set_imm();	%EOR8;		return;
-		case 0x2E:				set_regop8(m_d.b.h);	%INDEXED;	%EOR8;		return;
-		case 0x2F:				set_regop8(m_d.b.l);	%INDEXED;	%EOR8;		return;
+		case 0x20:				set_regop8(m_q.r.a);	set_imm();	%SBC8;		return;
+		case 0x21:				set_regop8(m_q.r.b);	set_imm();	%SBC8;		return;
+		case 0x22:				set_regop8(m_q.r.a);	%INDEXED;	%SBC8;		return;
+		case 0x23:				set_regop8(m_q.r.b);	%INDEXED;	%SBC8;		return;
+		case 0x24:				set_regop8(m_q.r.a);	set_imm();	%AND8;		return;
+		case 0x25:				set_regop8(m_q.r.b);	set_imm();	%AND8;		return;
+		case 0x26:				set_regop8(m_q.r.a);	%INDEXED;	%AND8;		return;
+		case 0x27:				set_regop8(m_q.r.b);	%INDEXED;	%AND8;		return;
+		case 0x28:				set_regop8(m_q.r.a);	set_imm();	%BIT8;		return;
+		case 0x29:				set_regop8(m_q.r.b);	set_imm();	%BIT8;		return;
+		case 0x2A:				set_regop8(m_q.r.a);	%INDEXED;	%BIT8;		return;
+		case 0x2B:				set_regop8(m_q.r.b);	%INDEXED;	%BIT8;		return;
+		case 0x2C:				set_regop8(m_q.r.a);	set_imm();	%EOR8;		return;
+		case 0x2D:				set_regop8(m_q.r.b);	set_imm();	%EOR8;		return;
+		case 0x2E:				set_regop8(m_q.r.a);	%INDEXED;	%EOR8;		return;
+		case 0x2F:				set_regop8(m_q.r.b);	%INDEXED;	%EOR8;		return;
 
-		case 0x30:				set_regop8(m_d.b.h);	set_imm();	%OR8;		return;
-		case 0x31:				set_regop8(m_d.b.l);	set_imm();	%OR8;		return;
-		case 0x32:				set_regop8(m_d.b.h);	%INDEXED;	%OR8;		return;
-		case 0x33:				set_regop8(m_d.b.l);	%INDEXED;	%OR8;		return;
-		case 0x34:				set_regop8(m_d.b.h);	set_imm();	%CMP8;		return;
-		case 0x35:				set_regop8(m_d.b.l);	set_imm();	%CMP8;		return;
-		case 0x36:				set_regop8(m_d.b.h);	%INDEXED;	%CMP8;		return;
-		case 0x37:				set_regop8(m_d.b.l);	%INDEXED;	%CMP8;		return;
+		case 0x30:				set_regop8(m_q.r.a);	set_imm();	%OR8;		return;
+		case 0x31:				set_regop8(m_q.r.b);	set_imm();	%OR8;		return;
+		case 0x32:				set_regop8(m_q.r.a);	%INDEXED;	%OR8;		return;
+		case 0x33:				set_regop8(m_q.r.b);	%INDEXED;	%OR8;		return;
+		case 0x34:				set_regop8(m_q.r.a);	set_imm();	%CMP8;		return;
+		case 0x35:				set_regop8(m_q.r.b);	set_imm();	%CMP8;		return;
+		case 0x36:				set_regop8(m_q.r.a);	%INDEXED;	%CMP8;		return;
+		case 0x37:				set_regop8(m_q.r.b);	%INDEXED;	%CMP8;		return;
 		case 0x38:										set_imm();	%SETLINE;	return;
 		case 0x39:										%INDEXED;	%SETLINE;	return;
-		case 0x3A:				set_regop8(m_d.b.h);	%INDEXED;	%ST8;		return;
-		case 0x3B:				set_regop8(m_d.b.l);	%INDEXED;	%ST8;		return;
+		case 0x3A:				set_regop8(m_q.r.a);	%INDEXED;	%ST8;		return;
+		case 0x3B:				set_regop8(m_q.r.b);	%INDEXED;	%ST8;		return;
 		case 0x3C:				set_imm();							%ANDCC;		return;
 		case 0x3D:				set_imm();							%ORCC;		return;
 		case 0x3E:													%EXG;		return;
 		case 0x3F:													%TFR;		return;
 
-		case 0x40:				set_regop16(m_d);		set_imm();	%LD16;		return;
-		case 0x41:				set_regop16(m_d);		%INDEXED;	%LD16;		return;
+		case 0x40:				set_regop16(m_q.p.d);	set_imm();	%LD16;		return;
+		case 0x41:				set_regop16(m_q.p.d);	%INDEXED;	%LD16;		return;
 		case 0x42:				set_regop16(m_x);		set_imm();	%LD16;		return;
 		case 0x43:				set_regop16(m_x);		%INDEXED;	%LD16;		return;
 		case 0x44:				set_regop16(m_y);		set_imm();	%LD16;		return;
@@ -89,8 +89,8 @@ MAIN:
 		case 0x47:				set_regop16(m_u);		%INDEXED;	%LD16;		return;
 		case 0x48:				set_regop16(m_s);		set_imm();	%LD16;		return;
 		case 0x49:				set_regop16(m_s);		%INDEXED;	%LD16;		return;
-		case 0x4A:				set_regop16(m_d);		set_imm();	%CMP16;		return;
-		case 0x4B:				set_regop16(m_d);		%INDEXED;	%CMP16;		return;
+		case 0x4A:				set_regop16(m_q.p.d);	set_imm();	%CMP16;		return;
+		case 0x4B:				set_regop16(m_q.p.d);	%INDEXED;	%CMP16;		return;
 		case 0x4C:				set_regop16(m_x);		set_imm();	%CMP16;		return;
 		case 0x4D:				set_regop16(m_x);		%INDEXED;	%CMP16;		return;
 		case 0x4E:				set_regop16(m_y);		set_imm();	%CMP16;		return;
@@ -100,11 +100,11 @@ MAIN:
 		case 0x51:				set_regop16(m_u);		%INDEXED;	%CMP16;		return;
 		case 0x52:				set_regop16(m_s);		set_imm();	%CMP16;		return;
 		case 0x53:				set_regop16(m_s);		%INDEXED;	%CMP16;		return;
-		case 0x54:				set_regop16(m_d);		set_imm();	%ADD16;		return;
-		case 0x55:				set_regop16(m_d);		%INDEXED;	%ADD16;		return;
-		case 0x56:				set_regop16(m_d);		set_imm();	%SUB16;		return;
-		case 0x57:				set_regop16(m_d);		%INDEXED;	%SUB16;		return;
-		case 0x58:				set_regop16(m_d);		%INDEXED;	%ST16;		return;
+		case 0x54:				set_regop16(m_q.p.d);	set_imm();	%ADD16;		return;
+		case 0x55:				set_regop16(m_q.p.d);	%INDEXED;	%ADD16;		return;
+		case 0x56:				set_regop16(m_q.p.d);	set_imm();	%SUB16;		return;
+		case 0x57:				set_regop16(m_q.p.d);	%INDEXED;	%SUB16;		return;
+		case 0x58:				set_regop16(m_q.p.d);	%INDEXED;	%ST16;		return;
 		case 0x59:				set_regop16(m_x);		%INDEXED;	%ST16;		return;
 		case 0x5A:				set_regop16(m_y);		%INDEXED;	%ST16;		return;
 		case 0x5B:				set_regop16(m_u);		%INDEXED;	%ST16;		return;
@@ -267,12 +267,12 @@ PUSH_REGISTERS:
 	}
 	if (m_temp.w & 0x04)
 	{
-		@write_memory(--regop16().w, m_d.b.l);
+		@write_memory(--regop16().w, m_q.r.b);
 		nop();
 	}
 	if (m_temp.w & 0x02)
 	{
-		@write_memory(--regop16().w, m_d.b.h);
+		@write_memory(--regop16().w, m_q.r.a);
 		nop();
 	}
 	if (m_temp.w & 0x01)
@@ -290,12 +290,12 @@ PULL_REGISTERS:
 	}
 	if (m_temp.w & 0x02)
 	{
-		@m_d.b.h = read_memory(regop16().w++);
+		@m_q.r.a = read_memory(regop16().w++);
 		nop();
 	}
 	if (m_temp.w & 0x04)
 	{
-		@m_d.b.l = read_memory(regop16().w++);
+		@m_q.r.b = read_memory(regop16().w++);
 		nop();
 	}
 	if (m_temp.w & 0x08)
@@ -397,19 +397,19 @@ INDEXED:
 
 		case 0xA0: case 0xB0: case 0xD0: case 0xE0: case 0xF0:
 			// relative to register A
-			m_temp.w = ireg() + (INT8) m_d.b.h;
+			m_temp.w = ireg() + (INT8) m_q.r.a;
 			@eat(1);
 			break;
 
 		case 0xA1: case 0xB1: case 0xD1: case 0xE1: case 0xF1:
 			// relative to register B
-			m_temp.w = ireg() + (INT8) m_d.b.l;
+			m_temp.w = ireg() + (INT8) m_q.r.b;
 			@eat(1);
 			break;
 
 		case 0xA7: case 0xB7: case 0xD7: case 0xE7: case 0xF7:
 			// relative to register D
-			m_temp.w = ireg() + (INT16) m_d.w;
+			m_temp.w = ireg() + (INT16) m_q.r.d;
 			@eat(4);
 			break;
 
@@ -480,7 +480,7 @@ BSET:
 	while(m_u.w != 0)
 	{
 		@eat(1);
-		@write_memory(m_x.w++, m_d.b.h);
+		@write_memory(m_x.w++, m_q.r.a);
 		m_u.w--;
 	}
 	return;
@@ -491,8 +491,8 @@ BSET2:
 	while(m_u.w != 0)
 	{
 		@eat(1);
-		@write_memory(m_x.w++, m_d.b.h);
-		@write_memory(m_x.w++, m_d.b.l);
+		@write_memory(m_x.w++, m_q.r.a);
+		@write_memory(m_x.w++, m_q.r.b);
 		m_u.w--;
 	}
 	return;
@@ -506,7 +506,7 @@ DECXJNZ:
 
 DECBJNZ:
 	// not sure if this affects V?
-	m_d.b.l = set_flags<UINT8>(CC_NZV, m_d.b.l, 1, m_d.b.l - 1);
+	m_q.r.b = set_flags<UINT8>(CC_NZV, m_q.r.b, 1, m_q.r.b - 1);
 	@eat(1);
 	set_cond(cond_ne());
 	goto BRANCH;
@@ -516,12 +516,12 @@ LSRD:
 	if (m_temp.b.l != 0x00)
 	{
 		// set C condition code
-		if (m_d.w & safe_shift_left(1, m_temp.b.l))
+		if (m_q.r.d & safe_shift_left(1, m_temp.b.l))
 			m_cc |= CC_C;
 		else
 			m_cc &= ~CC_C;
 
-		m_d.w = set_flags<UINT16>(CC_NZ, safe_shift_right_unsigned<UINT16>(m_d.w, m_temp.b.l));
+		m_q.r.d = set_flags<UINT16>(CC_NZ, safe_shift_right_unsigned<UINT16>(m_q.r.d, m_temp.b.l));
 	}
 	eat(1);
 	return;
@@ -531,12 +531,12 @@ ASLD:
 	if (m_temp.b.l != 0x00)
 	{
 		// set C condition code
-		if (m_d.w & safe_shift_right(0x10000, m_temp.b.l))
+		if (m_q.r.d & safe_shift_right(0x10000, m_temp.b.l))
 			m_cc |= CC_C;
 		else
 			m_cc &= ~CC_C;
 
-		m_d.w = set_flags<UINT16>(CC_NZV, safe_shift_left<INT16>(m_d.w, m_temp.b.l));
+		m_q.r.d = set_flags<UINT16>(CC_NZV, safe_shift_left<INT16>(m_q.r.d, m_temp.b.l));
 	}
 	eat(1);
 	return;
@@ -546,12 +546,12 @@ ASRD:
 	if (m_temp.b.l != 0x00)
 	{
 		// set C condition code
-		if (m_d.w & safe_shift_left(1, m_temp.b.l))
+		if (m_q.r.d & safe_shift_left(1, m_temp.b.l))
 			m_cc |= CC_C;
 		else
 			m_cc &= ~CC_C;
 
-		m_d.w = set_flags<UINT16>(CC_NZ, safe_shift_right<INT16>(m_d.w, m_temp.b.l));
+		m_q.r.d = set_flags<UINT16>(CC_NZ, safe_shift_right<INT16>(m_q.r.d, m_temp.b.l));
 	}
 	eat(1);
 	return;

--- a/src/devices/cpu/m6809/m6809.h
+++ b/src/devices/cpu/m6809/m6809.h
@@ -82,6 +82,8 @@ protected:
 	// device_state_interface overrides
 	virtual void state_string_export(const device_state_entry &entry, std::string &str) const override;
 
+	virtual bool is_6809() { return true; };
+
 	// addressing modes
 	enum
 	{
@@ -136,13 +138,33 @@ protected:
 		VECTOR_RESET_FFFE   = 0xFFFE
 	};
 
+	union M6809Q
+	{
+		#ifdef LSB_FIRST
+			union 
+			{
+				struct { UINT8 f, e, b, a; };
+				struct { UINT16 w, d; };
+			} r;
+			struct { PAIR16 w, d; } p;
+		#else
+			union 
+			{
+				struct { UINT8 a, b, e, f; };
+				struct { UINT16 d, w; };
+			} r;
+			struct { PAIR16 d, w; } p;
+		#endif
+		UINT32 q;
+	};
+
 	// Memory interface
 	memory_interface *          m_mintf;
 
 	// CPU registers
 	PAIR16                      m_pc;               // program counter
 	PAIR16                      m_ppc;              // previous program counter
-	PAIR16                      m_d;                // accumulator a and b
+	M6809Q                      m_q;                // accumulator a and b (plus e and f on 6309)
 	PAIR16                      m_x, m_y;           // index registers
 	PAIR16                      m_u, m_s;           // stack pointers
 	UINT8                       m_dp;               // direct page register

--- a/src/devices/cpu/m6809/m6809.ops
+++ b/src/devices/cpu/m6809/m6809.ops
@@ -131,139 +131,139 @@ MAIN:
 		case 0x7E:										%EXTENDED;	%JMP;		return;
 		case 0x7F:										%EXTENDED;	%CLR8;		return;
 
-		case 0x80:				set_regop8(m_d.b.h);	set_imm();	%SUB8;		return;
-		case 0x81:				set_regop8(m_d.b.h);	set_imm();	%CMP8;		return;
-		case 0x82:				set_regop8(m_d.b.h);	set_imm();	%SBC8;		return;
-		case 0x83:				set_regop16(m_d);		set_imm();	%SUB16;		return;
-		case 0x84:				set_regop8(m_d.b.h);	set_imm();	%AND8;		return;
-		case 0x85:				set_regop8(m_d.b.h);	set_imm();	%BIT8;		return;
-		case 0x86:				set_regop8(m_d.b.h);	set_imm();	%LD8;		return;
-		case 0x87:				set_regop8(m_d.b.h);	set_imm();	%ST8;		return;
-		case 0x88:				set_regop8(m_d.b.h);	set_imm();	%EOR8;		return;
-		case 0x89:				set_regop8(m_d.b.h);	set_imm();	%ADC8;		return;
-		case 0x8A:				set_regop8(m_d.b.h);	set_imm();	%OR8;		return;
-		case 0x8B:				set_regop8(m_d.b.h);	set_imm();	%ADD8;		return;
+		case 0x80:				set_regop8(m_q.r.a);	set_imm();	%SUB8;		return;
+		case 0x81:				set_regop8(m_q.r.a);	set_imm();	%CMP8;		return;
+		case 0x82:				set_regop8(m_q.r.a);	set_imm();	%SBC8;		return;
+		case 0x83:				set_regop16(m_q.p.d);	set_imm();	%SUB16;		return;
+		case 0x84:				set_regop8(m_q.r.a);	set_imm();	%AND8;		return;
+		case 0x85:				set_regop8(m_q.r.a);	set_imm();	%BIT8;		return;
+		case 0x86:				set_regop8(m_q.r.a);	set_imm();	%LD8;		return;
+		case 0x87:				set_regop8(m_q.r.a);	set_imm();	%ST8;		return;
+		case 0x88:				set_regop8(m_q.r.a);	set_imm();	%EOR8;		return;
+		case 0x89:				set_regop8(m_q.r.a);	set_imm();	%ADC8;		return;
+		case 0x8A:				set_regop8(m_q.r.a);	set_imm();	%OR8;		return;
+		case 0x8B:				set_regop8(m_q.r.a);	set_imm();	%ADD8;		return;
 		case 0x8C:				set_regop16(m_x);		set_imm();	%CMP16;		return;
 		case 0x8D:													%BSR;		return;
 		case 0x8E:				set_regop16(m_x);		set_imm();	%LD16;		return;
 		case 0x8F:				set_regop16(m_x);		set_imm();	%ST16;		return;
 
-		case 0x90:				set_regop8(m_d.b.h);	%DIRECT;	%SUB8;		return;
-		case 0x91:				set_regop8(m_d.b.h);	%DIRECT;	%CMP8;		return;
-		case 0x92:				set_regop8(m_d.b.h);	%DIRECT;	%SBC8;		return;
-		case 0x93:				set_regop16(m_d);		%DIRECT;	%SUB16;		return;
-		case 0x94:				set_regop8(m_d.b.h);	%DIRECT;	%AND8;		return;
-		case 0x95:				set_regop8(m_d.b.h);	%DIRECT;	%BIT8;		return;
-		case 0x96:				set_regop8(m_d.b.h);	%DIRECT;	%LD8;		return;
-		case 0x97:				set_regop8(m_d.b.h);	%DIRECT;	%ST8;		return;
-		case 0x98:				set_regop8(m_d.b.h);	%DIRECT;	%EOR8;		return;
-		case 0x99:				set_regop8(m_d.b.h);	%DIRECT;	%ADC8;		return;
-		case 0x9A:				set_regop8(m_d.b.h);	%DIRECT;	%OR8;		return;
-		case 0x9B:				set_regop8(m_d.b.h);	%DIRECT;	%ADD8;		return;
+		case 0x90:				set_regop8(m_q.r.a);	%DIRECT;	%SUB8;		return;
+		case 0x91:				set_regop8(m_q.r.a);	%DIRECT;	%CMP8;		return;
+		case 0x92:				set_regop8(m_q.r.a);	%DIRECT;	%SBC8;		return;
+		case 0x93:				set_regop16(m_q.p.d);	%DIRECT;	%SUB16;		return;
+		case 0x94:				set_regop8(m_q.r.a);	%DIRECT;	%AND8;		return;
+		case 0x95:				set_regop8(m_q.r.a);	%DIRECT;	%BIT8;		return;
+		case 0x96:				set_regop8(m_q.r.a);	%DIRECT;	%LD8;		return;
+		case 0x97:				set_regop8(m_q.r.a);	%DIRECT;	%ST8;		return;
+		case 0x98:				set_regop8(m_q.r.a);	%DIRECT;	%EOR8;		return;
+		case 0x99:				set_regop8(m_q.r.a);	%DIRECT;	%ADC8;		return;
+		case 0x9A:				set_regop8(m_q.r.a);	%DIRECT;	%OR8;		return;
+		case 0x9B:				set_regop8(m_q.r.a);	%DIRECT;	%ADD8;		return;
 		case 0x9C:				set_regop16(m_x);		%DIRECT;	%CMP16;		return;
 		case 0x9D:										%DIRECT;	%JSR;		return;
 		case 0x9E:				set_regop16(m_x);		%DIRECT;	%LD16;		return;
 		case 0x9F:				set_regop16(m_x);		%DIRECT;	%ST16;		return;
 
-		case 0xA0:				set_regop8(m_d.b.h);	%INDEXED;	%SUB8;		return;
-		case 0xA1:				set_regop8(m_d.b.h);	%INDEXED;	%CMP8;		return;
-		case 0xA2:				set_regop8(m_d.b.h);	%INDEXED;	%SBC8;		return;
-		case 0xA3:				set_regop16(m_d);		%INDEXED;	%SUB16;		return;
-		case 0xA4:				set_regop8(m_d.b.h);	%INDEXED;	%AND8;		return;
-		case 0xA5:				set_regop8(m_d.b.h);	%INDEXED;	%BIT8;		return;
-		case 0xA6:				set_regop8(m_d.b.h);	%INDEXED;	%LD8;		return;
-		case 0xA7:				set_regop8(m_d.b.h);	%INDEXED;	%ST8;		return;
-		case 0xA8:				set_regop8(m_d.b.h);	%INDEXED;	%EOR8;		return;
-		case 0xA9:				set_regop8(m_d.b.h);	%INDEXED;	%ADC8;		return;
-		case 0xAA:				set_regop8(m_d.b.h);	%INDEXED;	%OR8;		return;
-		case 0xAB:				set_regop8(m_d.b.h);	%INDEXED;	%ADD8;		return;
+		case 0xA0:				set_regop8(m_q.r.a);	%INDEXED;	%SUB8;		return;
+		case 0xA1:				set_regop8(m_q.r.a);	%INDEXED;	%CMP8;		return;
+		case 0xA2:				set_regop8(m_q.r.a);	%INDEXED;	%SBC8;		return;
+		case 0xA3:				set_regop16(m_q.p.d);	%INDEXED;	%SUB16;		return;
+		case 0xA4:				set_regop8(m_q.r.a);	%INDEXED;	%AND8;		return;
+		case 0xA5:				set_regop8(m_q.r.a);	%INDEXED;	%BIT8;		return;
+		case 0xA6:				set_regop8(m_q.r.a);	%INDEXED;	%LD8;		return;
+		case 0xA7:				set_regop8(m_q.r.a);	%INDEXED;	%ST8;		return;
+		case 0xA8:				set_regop8(m_q.r.a);	%INDEXED;	%EOR8;		return;
+		case 0xA9:				set_regop8(m_q.r.a);	%INDEXED;	%ADC8;		return;
+		case 0xAA:				set_regop8(m_q.r.a);	%INDEXED;	%OR8;		return;
+		case 0xAB:				set_regop8(m_q.r.a);	%INDEXED;	%ADD8;		return;
 		case 0xAC:				set_regop16(m_x);		%INDEXED;	%CMP16;		return;
 		case 0xAD:										%INDEXED;	%JSR;		return;
 		case 0xAE:				set_regop16(m_x);		%INDEXED;	%LD16;		return;
 		case 0xAF:				set_regop16(m_x);		%INDEXED;	%ST16;		return;
 
-		case 0xB0:				set_regop8(m_d.b.h);	%EXTENDED;	%SUB8;		return;
-		case 0xB1:				set_regop8(m_d.b.h);	%EXTENDED;	%CMP8;		return;
-		case 0xB2:				set_regop8(m_d.b.h);	%EXTENDED;	%SBC8;		return;
-		case 0xB3:				set_regop16(m_d);		%EXTENDED;	%SUB16;		return;
-		case 0xB4:				set_regop8(m_d.b.h);	%EXTENDED;	%AND8;		return;
-		case 0xB5:				set_regop8(m_d.b.h);	%EXTENDED;	%BIT8;		return;
-		case 0xB6:				set_regop8(m_d.b.h);	%EXTENDED;	%LD8;		return;
-		case 0xB7:				set_regop8(m_d.b.h);	%EXTENDED;	%ST8;		return;
-		case 0xB8:				set_regop8(m_d.b.h);	%EXTENDED;	%EOR8;		return;
-		case 0xB9:				set_regop8(m_d.b.h);	%EXTENDED;	%ADC8;		return;
-		case 0xBA:				set_regop8(m_d.b.h);	%EXTENDED;	%OR8;		return;
-		case 0xBB:				set_regop8(m_d.b.h);	%EXTENDED;	%ADD8;		return;
+		case 0xB0:				set_regop8(m_q.r.a);	%EXTENDED;	%SUB8;		return;
+		case 0xB1:				set_regop8(m_q.r.a);	%EXTENDED;	%CMP8;		return;
+		case 0xB2:				set_regop8(m_q.r.a);	%EXTENDED;	%SBC8;		return;
+		case 0xB3:				set_regop16(m_q.p.d);	%EXTENDED;	%SUB16;		return;
+		case 0xB4:				set_regop8(m_q.r.a);	%EXTENDED;	%AND8;		return;
+		case 0xB5:				set_regop8(m_q.r.a);	%EXTENDED;	%BIT8;		return;
+		case 0xB6:				set_regop8(m_q.r.a);	%EXTENDED;	%LD8;		return;
+		case 0xB7:				set_regop8(m_q.r.a);	%EXTENDED;	%ST8;		return;
+		case 0xB8:				set_regop8(m_q.r.a);	%EXTENDED;	%EOR8;		return;
+		case 0xB9:				set_regop8(m_q.r.a);	%EXTENDED;	%ADC8;		return;
+		case 0xBA:				set_regop8(m_q.r.a);	%EXTENDED;	%OR8;		return;
+		case 0xBB:				set_regop8(m_q.r.a);	%EXTENDED;	%ADD8;		return;
 		case 0xBC:				set_regop16(m_x);		%EXTENDED;	%CMP16;		return;
 		case 0xBD:										%EXTENDED;	%JSR;		return;
 		case 0xBE:				set_regop16(m_x);		%EXTENDED;	%LD16;		return;
 		case 0xBF:				set_regop16(m_x);		%EXTENDED;	%ST16;		return;
 
-		case 0xC0:				set_regop8(m_d.b.l);	set_imm();	%SUB8;		return;
-		case 0xC1:				set_regop8(m_d.b.l);	set_imm();	%CMP8;		return;
-		case 0xC2:				set_regop8(m_d.b.l);	set_imm();	%SBC8;		return;
-		case 0xC3:				set_regop16(m_d);		set_imm();	%ADD16;		return;
-		case 0xC4:				set_regop8(m_d.b.l);	set_imm();	%AND8;		return;
-		case 0xC5:				set_regop8(m_d.b.l);	set_imm();	%BIT8;		return;
-		case 0xC6:				set_regop8(m_d.b.l);	set_imm();	%LD8;		return;
-		case 0xC7:				set_regop8(m_d.b.l);	set_imm();	%ST8;		return;
-		case 0xC8:				set_regop8(m_d.b.l);	set_imm();	%EOR8;		return;
-		case 0xC9:				set_regop8(m_d.b.l);	set_imm();	%ADC8;		return;
-		case 0xCA:				set_regop8(m_d.b.l);	set_imm();	%OR8;		return;
-		case 0xCB:				set_regop8(m_d.b.l);	set_imm();	%ADD8;		return;
-		case 0xCC:				set_regop16(m_d);		set_imm();	%LD16;		return;
-		case 0xCD:				set_regop16(m_d);		set_imm();	%ST16;		return;
+		case 0xC0:				set_regop8(m_q.r.b);	set_imm();	%SUB8;		return;
+		case 0xC1:				set_regop8(m_q.r.b);	set_imm();	%CMP8;		return;
+		case 0xC2:				set_regop8(m_q.r.b);	set_imm();	%SBC8;		return;
+		case 0xC3:				set_regop16(m_q.p.d);	set_imm();	%ADD16;		return;
+		case 0xC4:				set_regop8(m_q.r.b);	set_imm();	%AND8;		return;
+		case 0xC5:				set_regop8(m_q.r.b);	set_imm();	%BIT8;		return;
+		case 0xC6:				set_regop8(m_q.r.b);	set_imm();	%LD8;		return;
+		case 0xC7:				set_regop8(m_q.r.b);	set_imm();	%ST8;		return;
+		case 0xC8:				set_regop8(m_q.r.b);	set_imm();	%EOR8;		return;
+		case 0xC9:				set_regop8(m_q.r.b);	set_imm();	%ADC8;		return;
+		case 0xCA:				set_regop8(m_q.r.b);	set_imm();	%OR8;		return;
+		case 0xCB:				set_regop8(m_q.r.b);	set_imm();	%ADD8;		return;
+		case 0xCC:				set_regop16(m_q.p.d);	set_imm();	%LD16;		return;
+		case 0xCD:				set_regop16(m_q.p.d);	set_imm();	%ST16;		return;
 		case 0xCE:				set_regop16(m_u);		set_imm();	%LD16;		return;
 		case 0xCF:				set_regop16(m_u);		set_imm();	%ST16;		return;
 
-		case 0xD0:				set_regop8(m_d.b.l);	%DIRECT;	%SUB8;		return;
-		case 0xD1:				set_regop8(m_d.b.l);	%DIRECT;	%CMP8;		return;
-		case 0xD2:				set_regop8(m_d.b.l);	%DIRECT;	%SBC8;		return;
-		case 0xD3:				set_regop16(m_d);		%DIRECT;	%ADD16;		return;
-		case 0xD4:				set_regop8(m_d.b.l);	%DIRECT;	%AND8;		return;
-		case 0xD5:				set_regop8(m_d.b.l);	%DIRECT;	%BIT8;		return;
-		case 0xD6:				set_regop8(m_d.b.l);	%DIRECT;	%LD8;		return;
-		case 0xD7:				set_regop8(m_d.b.l);	%DIRECT;	%ST8;		return;
-		case 0xD8:				set_regop8(m_d.b.l);	%DIRECT;	%EOR8;		return;
-		case 0xD9:				set_regop8(m_d.b.l);	%DIRECT;	%ADC8;		return;
-		case 0xDA:				set_regop8(m_d.b.l);	%DIRECT;	%OR8;		return;
-		case 0xDB:				set_regop8(m_d.b.l);	%DIRECT;	%ADD8;		return;
-		case 0xDC:				set_regop16(m_d);		%DIRECT;	%LD16;		return;
-		case 0xDD:				set_regop16(m_d);		%DIRECT;	%ST16;		return;
+		case 0xD0:				set_regop8(m_q.r.b);	%DIRECT;	%SUB8;		return;
+		case 0xD1:				set_regop8(m_q.r.b);	%DIRECT;	%CMP8;		return;
+		case 0xD2:				set_regop8(m_q.r.b);	%DIRECT;	%SBC8;		return;
+		case 0xD3:				set_regop16(m_q.p.d);	%DIRECT;	%ADD16;		return;
+		case 0xD4:				set_regop8(m_q.r.b);	%DIRECT;	%AND8;		return;
+		case 0xD5:				set_regop8(m_q.r.b);	%DIRECT;	%BIT8;		return;
+		case 0xD6:				set_regop8(m_q.r.b);	%DIRECT;	%LD8;		return;
+		case 0xD7:				set_regop8(m_q.r.b);	%DIRECT;	%ST8;		return;
+		case 0xD8:				set_regop8(m_q.r.b);	%DIRECT;	%EOR8;		return;
+		case 0xD9:				set_regop8(m_q.r.b);	%DIRECT;	%ADC8;		return;
+		case 0xDA:				set_regop8(m_q.r.b);	%DIRECT;	%OR8;		return;
+		case 0xDB:				set_regop8(m_q.r.b);	%DIRECT;	%ADD8;		return;
+		case 0xDC:				set_regop16(m_q.p.d);	%DIRECT;	%LD16;		return;
+		case 0xDD:				set_regop16(m_q.p.d);	%DIRECT;	%ST16;		return;
 		case 0xDE:				set_regop16(m_u);		%DIRECT;	%LD16;		return;
 		case 0xDF:				set_regop16(m_u);		%DIRECT;	%ST16;		return;
 
-		case 0xE0:				set_regop8(m_d.b.l);	%INDEXED;	%SUB8;		return;
-		case 0xE1:				set_regop8(m_d.b.l);	%INDEXED;	%CMP8;		return;
-		case 0xE2:				set_regop8(m_d.b.l);	%INDEXED;	%SBC8;		return;
-		case 0xE3:				set_regop16(m_d);		%INDEXED;	%ADD16;		return;
-		case 0xE4:				set_regop8(m_d.b.l);	%INDEXED;	%AND8;		return;
-		case 0xE5:				set_regop8(m_d.b.l);	%INDEXED;	%BIT8;		return;
-		case 0xE6:				set_regop8(m_d.b.l);	%INDEXED;	%LD8;		return;
-		case 0xE7:				set_regop8(m_d.b.l);	%INDEXED;	%ST8;		return;
-		case 0xE8:				set_regop8(m_d.b.l);	%INDEXED;	%EOR8;		return;
-		case 0xE9:				set_regop8(m_d.b.l);	%INDEXED;	%ADC8;		return;
-		case 0xEA:				set_regop8(m_d.b.l);	%INDEXED;	%OR8;		return;
-		case 0xEB:				set_regop8(m_d.b.l);	%INDEXED;	%ADD8;		return;
-		case 0xEC:				set_regop16(m_d);		%INDEXED;	%LD16;		return;
-		case 0xED:				set_regop16(m_d);		%INDEXED;	%ST16;		return;
+		case 0xE0:				set_regop8(m_q.r.b);	%INDEXED;	%SUB8;		return;
+		case 0xE1:				set_regop8(m_q.r.b);	%INDEXED;	%CMP8;		return;
+		case 0xE2:				set_regop8(m_q.r.b);	%INDEXED;	%SBC8;		return;
+		case 0xE3:				set_regop16(m_q.p.d);	%INDEXED;	%ADD16;		return;
+		case 0xE4:				set_regop8(m_q.r.b);	%INDEXED;	%AND8;		return;
+		case 0xE5:				set_regop8(m_q.r.b);	%INDEXED;	%BIT8;		return;
+		case 0xE6:				set_regop8(m_q.r.b);	%INDEXED;	%LD8;		return;
+		case 0xE7:				set_regop8(m_q.r.b);	%INDEXED;	%ST8;		return;
+		case 0xE8:				set_regop8(m_q.r.b);	%INDEXED;	%EOR8;		return;
+		case 0xE9:				set_regop8(m_q.r.b);	%INDEXED;	%ADC8;		return;
+		case 0xEA:				set_regop8(m_q.r.b);	%INDEXED;	%OR8;		return;
+		case 0xEB:				set_regop8(m_q.r.b);	%INDEXED;	%ADD8;		return;
+		case 0xEC:				set_regop16(m_q.p.d);	%INDEXED;	%LD16;		return;
+		case 0xED:				set_regop16(m_q.p.d);	%INDEXED;	%ST16;		return;
 		case 0xEE:				set_regop16(m_u);		%INDEXED;	%LD16;		return;
 		case 0xEF:				set_regop16(m_u);		%INDEXED;	%ST16;		return;
 
-		case 0xF0:				set_regop8(m_d.b.l);	%EXTENDED;	%SUB8;		return;
-		case 0xF1:				set_regop8(m_d.b.l);	%EXTENDED;	%CMP8;		return;
-		case 0xF2:				set_regop8(m_d.b.l);	%EXTENDED;	%SBC8;		return;
-		case 0xF3:				set_regop16(m_d);		%EXTENDED;	%ADD16;		return;
-		case 0xF4:				set_regop8(m_d.b.l);	%EXTENDED;	%AND8;		return;
-		case 0xF5:				set_regop8(m_d.b.l);	%EXTENDED;	%BIT8;		return;
-		case 0xF6:				set_regop8(m_d.b.l);	%EXTENDED;	%LD8;		return;
-		case 0xF7:				set_regop8(m_d.b.l);	%EXTENDED;	%ST8;		return;
-		case 0xF8:				set_regop8(m_d.b.l);	%EXTENDED;	%EOR8;		return;
-		case 0xF9:				set_regop8(m_d.b.l);	%EXTENDED;	%ADC8;		return;
-		case 0xFA:				set_regop8(m_d.b.l);	%EXTENDED;	%OR8;		return;
-		case 0xFB:				set_regop8(m_d.b.l);	%EXTENDED;	%ADD8;		return;
-		case 0xFC:				set_regop16(m_d);		%EXTENDED;	%LD16;		return;
-		case 0xFD:				set_regop16(m_d);		%EXTENDED;	%ST16;		return;
+		case 0xF0:				set_regop8(m_q.r.b);	%EXTENDED;	%SUB8;		return;
+		case 0xF1:				set_regop8(m_q.r.b);	%EXTENDED;	%CMP8;		return;
+		case 0xF2:				set_regop8(m_q.r.b);	%EXTENDED;	%SBC8;		return;
+		case 0xF3:				set_regop16(m_q.p.d);	%EXTENDED;	%ADD16;		return;
+		case 0xF4:				set_regop8(m_q.r.b);	%EXTENDED;	%AND8;		return;
+		case 0xF5:				set_regop8(m_q.r.b);	%EXTENDED;	%BIT8;		return;
+		case 0xF6:				set_regop8(m_q.r.b);	%EXTENDED;	%LD8;		return;
+		case 0xF7:				set_regop8(m_q.r.b);	%EXTENDED;	%ST8;		return;
+		case 0xF8:				set_regop8(m_q.r.b);	%EXTENDED;	%EOR8;		return;
+		case 0xF9:				set_regop8(m_q.r.b);	%EXTENDED;	%ADC8;		return;
+		case 0xFA:				set_regop8(m_q.r.b);	%EXTENDED;	%OR8;		return;
+		case 0xFB:				set_regop8(m_q.r.b);	%EXTENDED;	%ADD8;		return;
+		case 0xFC:				set_regop16(m_q.p.d);	%EXTENDED;	%LD16;		return;
+		case 0xFD:				set_regop16(m_q.p.d);	%EXTENDED;	%ST16;		return;
 		case 0xFE:				set_regop16(m_u);		%EXTENDED;	%LD16;		return;
 		case 0xFF:				set_regop16(m_u);		%EXTENDED;	%ST16;		return;
 		default:													%ILLEGAL;	return;			
@@ -293,19 +293,19 @@ DISPATCH10:
 
 		case 0x3F:													%SWI2;		return;
 
-		case 0x83:				set_regop16(m_d);	set_imm();		%CMP16;		return;
+		case 0x83:				set_regop16(m_q.p.d);	set_imm();		%CMP16;		return;
 		case 0x8C:				set_regop16(m_y);	set_imm();		%CMP16;		return;
 		case 0x8E:				set_regop16(m_y);	set_imm();		%LD16;		return;
 		case 0x8F:				set_regop16(m_y);	set_imm();		%ST16;		return;
-		case 0x93:				set_regop16(m_d);	%DIRECT;		%CMP16;		return;
+		case 0x93:				set_regop16(m_q.p.d);	%DIRECT;		%CMP16;		return;
 		case 0x9C:				set_regop16(m_y);	%DIRECT;		%CMP16;		return;
 		case 0x9E:				set_regop16(m_y);	%DIRECT;		%LD16;		return;
 		case 0x9F:				set_regop16(m_y);	%DIRECT;		%ST16;		return;
-		case 0xA3:				set_regop16(m_d);	%INDEXED;		%CMP16;		return;
+		case 0xA3:				set_regop16(m_q.p.d);	%INDEXED;		%CMP16;		return;
 		case 0xAC:				set_regop16(m_y);	%INDEXED;		%CMP16;		return;
 		case 0xAE:				set_regop16(m_y);	%INDEXED;		%LD16;		return;
 		case 0xAF:				set_regop16(m_y);	%INDEXED;		%ST16;		return;
-		case 0xB3:				set_regop16(m_d);	%EXTENDED;		%CMP16;		return;
+		case 0xB3:				set_regop16(m_q.p.d);	%EXTENDED;		%CMP16;		return;
 		case 0xBC:				set_regop16(m_y);	%EXTENDED;		%CMP16;		return;
 		case 0xBE:				set_regop16(m_y);	%EXTENDED;		%LD16;		return;
 		case 0xBF:				set_regop16(m_y);	%EXTENDED;		%ST16;		return;
@@ -336,7 +336,6 @@ DISPATCH11:
 		case 0xAC:				set_regop16(m_s);	%INDEXED;		%CMP16;		return;
 		case 0xB3:				set_regop16(m_u);	%EXTENDED;		%CMP16;		return;
 		case 0xBC:				set_regop16(m_s);	%EXTENDED;		%CMP16;		return;
-
 		default:													%ILLEGAL;	return;			
 	}
 	return;
@@ -375,12 +374,12 @@ PUSH_REGISTERS:
 	}
 	if (m_temp.w & 0x04)
 	{
-		@write_memory(--regop16().w, m_d.b.l);
+		@write_memory(--regop16().w, m_q.r.b);
 		nop();
 	}
 	if (m_temp.w & 0x02)
 	{
-		@write_memory(--regop16().w, m_d.b.h);
+		@write_memory(--regop16().w, m_q.r.a);
 		nop();
 	}
 	if (m_temp.w & 0x01)
@@ -398,12 +397,12 @@ PULL_REGISTERS:
 	}
 	if (m_temp.w & 0x02)
 	{
-		@m_d.b.h = read_memory(regop16().w++);
+		@m_q.r.a = read_memory(regop16().w++);
 		nop();
 	}
 	if (m_temp.w & 0x04)
 	{
-		@m_d.b.l = read_memory(regop16().w++);
+		@m_q.r.b = read_memory(regop16().w++);
 		nop();
 	}
 	if (m_temp.w & 0x08)
@@ -480,13 +479,13 @@ INDEXED:
 
 			case 0x05: case 0x25: case 0x45: case 0x65:
 			case 0x15: case 0x35: case 0x55: case 0x75:
-				m_temp.w = ireg() + (INT8) m_d.b.l;
+				m_temp.w = ireg() + (INT8) m_q.r.b;
 				eat(2);
 				break;
 
 			case 0x06: case 0x26: case 0x46: case 0x66:
 			case 0x16: case 0x36: case 0x56: case 0x76:
-				m_temp.w = ireg() + (INT8) m_d.b.h;
+				m_temp.w = ireg() + (INT8) m_q.r.a;
 				eat(2);
 				break;
 
@@ -506,7 +505,7 @@ INDEXED:
 
 			case 0x0B: case 0x2B: case 0x4B: case 0x6B:
 			case 0x1B: case 0x3B: case 0x5B: case 0x7B:
-				m_temp.w = ireg() + m_d.w;
+				m_temp.w = ireg() + m_q.r.d;
 				eat(5);
 				break;
 

--- a/src/devices/cpu/m6809/m6809inl.h
+++ b/src/devices/cpu/m6809/m6809inl.h
@@ -71,8 +71,8 @@ inline ATTR_FORCE_INLINE UINT8 m6809_base_device::read_operand()
 	{
 		case ADDRESSING_MODE_EA:            return read_memory(m_ea.w);
 		case ADDRESSING_MODE_IMMEDIATE:     return read_opcode_arg();
-		case ADDRESSING_MODE_REGISTER_A:    return m_d.b.h;
-		case ADDRESSING_MODE_REGISTER_B:    return m_d.b.l;
+		case ADDRESSING_MODE_REGISTER_A:    return m_q.r.a;
+		case ADDRESSING_MODE_REGISTER_B:    return m_q.r.b;
 		default:                            fatalerror("Unexpected");   return 0x00;
 	}
 }
@@ -103,8 +103,8 @@ inline ATTR_FORCE_INLINE void m6809_base_device::write_operand(UINT8 data)
 	{
 		case ADDRESSING_MODE_IMMEDIATE:     /* do nothing */                break;
 		case ADDRESSING_MODE_EA:            write_memory(m_ea.w, data);     break;
-		case ADDRESSING_MODE_REGISTER_A:    m_d.b.h = data;                 break;
-		case ADDRESSING_MODE_REGISTER_B:    m_d.b.l = data;                 break;
+		case ADDRESSING_MODE_REGISTER_A:    m_q.r.a = data;                 break;
+		case ADDRESSING_MODE_REGISTER_B:    m_q.r.b = data;                 break;
 		default:                            fatalerror("Unexpected");       break;
 	}
 }
@@ -132,8 +132,8 @@ inline ATTR_FORCE_INLINE void m6809_base_device::write_operand(int ordinal, UINT
 inline ATTR_FORCE_INLINE void m6809_base_device::daa()
 {
 	UINT16 t, cf = 0;
-	UINT8 msn = m_d.b.h & 0xF0;
-	UINT8 lsn = m_d.b.h & 0x0F;
+	UINT8 msn = m_q.r.a & 0xF0;
+	UINT8 lsn = m_q.r.a & 0x0F;
 
 	// compute the carry
 	if (lsn > 0x09 || m_cc & CC_H)  cf |= 0x06;
@@ -141,14 +141,14 @@ inline ATTR_FORCE_INLINE void m6809_base_device::daa()
 	if (msn > 0x90 || m_cc & CC_C)  cf |= 0x60;
 
 	// calculate the result
-	t = m_d.b.h + cf;
+	t = m_q.r.a + cf;
 
 	m_cc &= ~CC_V;
 	if (t & 0x0100)     // keep carry from previous operation
 		m_cc |= CC_C;
 
 	// and put it back into A
-	m_d.b.h = set_flags(CC_NZ, (UINT8) t);
+	m_q.r.a = set_flags(CC_NZ, (UINT8) t);
 }
 
 
@@ -159,13 +159,13 @@ inline ATTR_FORCE_INLINE void m6809_base_device::daa()
 inline ATTR_FORCE_INLINE void m6809_base_device::mul()
 {
 	// perform multiply
-	UINT16 result = ((UINT16) m_d.b.h) * ((UINT16) m_d.b.l);
+	UINT16 result = ((UINT16) m_q.r.a) * ((UINT16) m_q.r.b);
 
 	// set result and Z flag
-	m_d.w = set_flags(CC_Z, result);
+	m_q.r.d = set_flags(CC_Z, result);
 
 	// set C flag
-	if (m_d.w & 0x0080)
+	if (m_q.r.d & 0x0080)
 		m_cc |= CC_C;
 	else
 		m_cc &= ~CC_C;


### PR DESCRIPTION
Apologies in advance to whomever has to review this PR. Changes are repetitive but were scripted (not manual) then hand-verified and tested. If it makes you feel any better, I've been coding this micro for 30+ years.

The 6809 has 8-bit A and B registers that become a 16-bit D register. The 6309 adds an E and F register that becomes a W. And then D and W combine to form a 32-bit Q.

Although that's the architecture of the chip, the emulation code wandered from it. It made the debugger very difficult to use as register values were duplicated and out of order.

This PR unifies the 6309 emulation to be structured like the original 6809 emulation, with unions of larger registers giving way to smaller ones. As a result some special-casing around the Q register disappears.

Per docs, the V register now initalizes to $FFFF. Previously it was 0.


