### PR TITLE
GNU/kFreeBSD support

### DIFF
--- a/3rdparty/bx/include/bx/platform.h
+++ b/3rdparty/bx/include/bx/platform.h
@@ -6,12 +6,37 @@
 #ifndef BX_PLATFORM_H_HEADER_GUARD
 #define BX_PLATFORM_H_HEADER_GUARD
 
+// Architecture
+#define BX_ARCH_32BIT 0
+#define BX_ARCH_64BIT 0
+
+// Compiler
 #define BX_COMPILER_CLANG           0
 #define BX_COMPILER_CLANG_ANALYZER  0
 #define BX_COMPILER_GCC             0
 #define BX_COMPILER_MSVC            0
-#define BX_COMPILER_MSVC_COMPATIBLE 0
+#define BX_COMPILER_MSVC_COMPATIBLE (BX_CRT_MSVC)
 
+// Endianess
+#define BX_CPU_ENDIAN_BIG    0
+#define BX_CPU_ENDIAN_LITTLE 0
+
+// CPU
+#define BX_CPU_ARM   0
+#define BX_CPU_JIT   0
+#define BX_CPU_MIPS  0
+#define BX_CPU_PPC   0
+#define BX_CPU_RISCV 0
+#define BX_CPU_X86   0
+
+// C Runtime
+#define BX_CRT_MSVC   0
+#define BX_CRT_GLIBC  0
+#define BX_CRT_NEWLIB 0
+#define BX_CRT_MINGW  0
+#define BX_CRT_MUSL   0
+
+// Platform
 #define BX_PLATFORM_ANDROID    0
 #define BX_PLATFORM_EMSCRIPTEN 0
 #define BX_PLATFORM_BSD        0
@@ -28,19 +53,6 @@
 #define BX_PLATFORM_XBOX360    0
 #define BX_PLATFORM_XBOXONE    0
 
-#define BX_CPU_ARM   0
-#define BX_CPU_JIT   0
-#define BX_CPU_MIPS  0
-#define BX_CPU_PPC   0
-#define BX_CPU_RISCV 0
-#define BX_CPU_X86   0
-
-#define BX_ARCH_32BIT 0
-#define BX_ARCH_64BIT 0
-
-#define BX_CPU_ENDIAN_BIG    0
-#define BX_CPU_ENDIAN_LITTLE 0
-
 // http://sourceforge.net/apps/mediawiki/predef/index.php?title=Compilers
 #if defined(__clang__)
 // clang defines __GNUC__ or _MSC_VER
@@ -51,17 +63,27 @@
 #		define BX_COMPILER_CLANG_ANALYZER 1
 #	endif // defined(__clang_analyzer__)
 #	if defined(_MSC_VER)
-#		undef  BX_COMPILER_MSVC_COMPATIBLE
-#		define BX_COMPILER_MSVC_COMPATIBLE _MSC_VER
-#	endif // defined(_MSC_VER)
+#		undef  BX_CRT_MSVC
+#		define BX_CRT_MSVC 1
+#	elif defined(__GLIBC__)
+#		undef  BX_CRT_GLIBC
+#		define BX_CRT_GLIBC (__GLIBC__ * 10000 + __GLIBC_MINOR__ * 100)
+#	endif // defined(__GLIBC__)
 #elif defined(_MSC_VER)
 #	undef  BX_COMPILER_MSVC
 #	define BX_COMPILER_MSVC _MSC_VER
-#	undef  BX_COMPILER_MSVC_COMPATIBLE
-#	define BX_COMPILER_MSVC_COMPATIBLE _MSC_VER
+#	undef  BX_CRT_MSVC
+#	define BX_CRT_MSVC 1
 #elif defined(__GNUC__)
 #	undef  BX_COMPILER_GCC
 #	define BX_COMPILER_GCC (__GNUC__ * 10000 + __GNUC_MINOR__ * 100 + __GNUC_PATCHLEVEL__)
+#	if defined(__GLIBC__)
+#		undef  BX_CRT_GLIBC
+#		define BX_CRT_GLIBC (__GLIBC__ * 10000 + __GLIBC_MINOR__ * 100)
+#	elif defined(__MINGW32__) || defined(__MINGW64__)
+#		undef  BX_CRT_MINGW
+#		define BX_CRT_MINGW 1
+#	endif //
 #else
 #	error "BX_COMPILER_* is not defined!"
 #endif //

--- a/3rdparty/bx/include/bx/thread.h
+++ b/3rdparty/bx/include/bx/thread.h
@@ -8,12 +8,13 @@
 
 #if BX_PLATFORM_POSIX
 #	include <pthread.h>
-#	if defined(BX_PLATFORM_BSD) && !defined(__GLIBC__)
+#	if defined(__GLIBC__)
+#		if !( (__GLIBC__ > 2) || ( (__GLIBC__ == 2) && (__GLIBC_MINOR__ >= 12) ) )
+#			include <sys/prctl.h>
+#		endif
+#	elif defined(BX_PLATFORM_BSD)
 #		include <pthread_np.h>
 #	endif
-#	if defined(__GLIBC__) && !( (__GLIBC__ > 2) || ( (__GLIBC__ == 2) && (__GLIBC_MINOR__ >= 12) ) )
-#		include <sys/prctl.h>
-#	endif // defined(__GLIBC__) ...
 #elif BX_PLATFORM_WINRT
 using namespace Platform;
 using namespace Windows::Foundation;

--- a/3rdparty/bx/include/bx/thread.h
+++ b/3rdparty/bx/include/bx/thread.h
@@ -6,12 +6,19 @@
 #ifndef BX_THREAD_H_HEADER_GUARD
 #define BX_THREAD_H_HEADER_GUARD
 
+#define BX_USE_GLIBC_PTHREAD_SETNAME_NP 0
+#if defined(__GLIBC__)
+#	if ( (__GLIBC__ > 2) || ( (__GLIBC__ == 2) && (__GLIBC_MINOR__ >= 12) ) )
+#		define BX_USE_GLIBC_PTHREAD_SETNAME_NP 1
+#	endif
+#endif
+
 #if BX_PLATFORM_POSIX
 #	include <pthread.h>
-#	if defined(__GLIBC__)
-#		if !( (__GLIBC__ > 2) || ( (__GLIBC__ == 2) && (__GLIBC_MINOR__ >= 12) ) )
-#			include <sys/prctl.h>
-#		endif
+#	if BX_USE_GLIBC_PTHREAD_SETNAME_NP
+/* pthread.h provides pthread_setname_np */
+#	elif defined(BX_PLATFORM_LINUX)
+#		include <sys/prctl.h>
 #	elif defined(BX_PLATFORM_BSD)
 #		include <pthread_np.h>
 #	endif
@@ -158,7 +165,7 @@ namespace bx
 		{
 #if BX_PLATFORM_OSX || BX_PLATFORM_IOS
 			pthread_setname_np(_name);
-#elif defined(__GLIBC__) && (__GLIBC__ > 2) || ( (__GLIBC__ == 2) && (__GLIBC_MINOR__ >= 12) )
+#elif BX_USE_GLIBC_PTHREAD_SETNAME_NP
 			pthread_setname_np(m_handle, _name);
 #elif BX_PLATFORM_LINUX
 			prctl(PR_SET_NAME,_name, 0, 0, 0);

--- a/3rdparty/bx/include/bx/thread.h
+++ b/3rdparty/bx/include/bx/thread.h
@@ -6,27 +6,19 @@
 #ifndef BX_THREAD_H_HEADER_GUARD
 #define BX_THREAD_H_HEADER_GUARD
 
-#define BX_USE_GLIBC_PTHREAD_SETNAME_NP 0
-#if defined(__GLIBC__)
-#	if ( (__GLIBC__ > 2) || ( (__GLIBC__ == 2) && (__GLIBC_MINOR__ >= 12) ) )
-#		define BX_USE_GLIBC_PTHREAD_SETNAME_NP 1
-#	endif
-#endif
-
 #if BX_PLATFORM_POSIX
 #	include <pthread.h>
-#	if BX_USE_GLIBC_PTHREAD_SETNAME_NP
-/* pthread.h provides pthread_setname_np */
-#	elif defined(BX_PLATFORM_LINUX)
-#		include <sys/prctl.h>
-#	elif defined(BX_PLATFORM_BSD)
+#	if defined(__FreeBSD__)
 #		include <pthread_np.h>
 #	endif
+#	if BX_PLATFORM_LINUX && (BX_CRT_GLIBC < 21200)
+#		include <sys/prctl.h>
+#	endif // BX_PLATFORM_
 #elif BX_PLATFORM_WINRT
 using namespace Platform;
 using namespace Windows::Foundation;
 using namespace Windows::System::Threading;
-#endif
+#endif // BX_PLATFORM_
 
 #include "sem.h"
 
@@ -165,16 +157,16 @@ namespace bx
 		{
 #if BX_PLATFORM_OSX || BX_PLATFORM_IOS
 			pthread_setname_np(_name);
-#elif BX_USE_GLIBC_PTHREAD_SETNAME_NP
+#elif (BX_CRT_GLIBC >= 21200)
 			pthread_setname_np(m_handle, _name);
 #elif BX_PLATFORM_LINUX
 			prctl(PR_SET_NAME,_name, 0, 0, 0);
 #elif BX_PLATFORM_BSD
-#ifdef __NetBSD__
-			pthread_setname_np(m_handle, "%s", (void *)_name);
-#else
+#	ifdef __NetBSD__
+			pthread_setname_np(m_handle, "%s", (void*)_name);
+#	else
 			pthread_set_name_np(m_handle, _name);
-#endif
+#	endif // __NetBSD__
 #elif BX_PLATFORM_WINDOWS && BX_COMPILER_MSVC
 #	pragma pack(push, 8)
 			struct ThreadName

--- a/3rdparty/bx/include/bx/thread.h
+++ b/3rdparty/bx/include/bx/thread.h
@@ -8,7 +8,7 @@
 
 #if BX_PLATFORM_POSIX
 #	include <pthread.h>
-#	if BX_PLATFORM_BSD
+#	if defined(BX_PLATFORM_BSD) && !defined(__GLIBC__)
 #		include <pthread_np.h>
 #	endif
 #	if defined(__GLIBC__) && !( (__GLIBC__ > 2) || ( (__GLIBC__ == 2) && (__GLIBC_MINOR__ >= 12) ) )
@@ -157,12 +157,10 @@ namespace bx
 		{
 #if BX_PLATFORM_OSX || BX_PLATFORM_IOS
 			pthread_setname_np(_name);
-#elif BX_PLATFORM_LINUX
-#	if defined(__GLIBC__) && (__GLIBC__ > 2) || ( (__GLIBC__ == 2) && (__GLIBC_MINOR__ >= 12) )
+#elif defined(__GLIBC__) && (__GLIBC__ > 2) || ( (__GLIBC__ == 2) && (__GLIBC_MINOR__ >= 12) )
 			pthread_setname_np(m_handle, _name);
-#	else
+#elif BX_PLATFORM_LINUX
 			prctl(PR_SET_NAME,_name, 0, 0, 0);
-#	endif // defined(__GLIBC__) ...
 #elif BX_PLATFORM_BSD
 #ifdef __NetBSD__
 			pthread_setname_np(m_handle, "%s", (void *)_name);

--- a/3rdparty/bx/include/compat/freebsd/alloca.h
+++ b/3rdparty/bx/include/compat/freebsd/alloca.h
@@ -1,5 +1,5 @@
-#ifdef __GLIBC__
-#include_next <alloca.h>
+#if defined(__GLIBC__)
+#	include_next <alloca.h>
 #else
-#include <stdlib.h>
+#	include <stdlib.h>
 #endif

--- a/3rdparty/bx/include/compat/freebsd/alloca.h
+++ b/3rdparty/bx/include/compat/freebsd/alloca.h
@@ -1,1 +1,5 @@
+#ifdef __GLIBC__
+#include_next <alloca.h>
+#else
 #include <stdlib.h>
+#endif

--- a/3rdparty/bx/include/compat/freebsd/signal.h
+++ b/3rdparty/bx/include/compat/freebsd/signal.h
@@ -1,5 +1,5 @@
-#ifdef __GLIBC__
-#include_next <signal.h>
+#if defined(__GLIBC__)
+#	include_next <signal.h>
 #else
-#include <sys/signal.h>
+#	include <sys/signal.h>
 #endif

--- a/3rdparty/bx/include/compat/freebsd/signal.h
+++ b/3rdparty/bx/include/compat/freebsd/signal.h
@@ -1,1 +1,5 @@
+#ifdef __GLIBC__
+#include_next <signal.h>
+#else
 #include <sys/signal.h>
+#endif

--- a/scripts/src/osd/sdl.lua
+++ b/scripts/src/osd/sdl.lua
@@ -340,7 +340,7 @@ project ("qtdbg_" .. _OPTIONS["osd"])
 		MAME_DIR .. "src/osd/modules/render",
 		MAME_DIR .. "3rdparty",
 	}
-	configuration { "linux-*" }
+	configuration { "linux-* or freebsd" }
 		buildoptions {
 			"-fPIC",
 		}

--- a/src/osd/modules/file/posixptty.cpp
+++ b/src/osd/modules/file/posixptty.cpp
@@ -19,7 +19,7 @@
 #include <unistd.h>
 #include <stdlib.h>
 
-#if defined(__FreeBSD__) || defined(__DragonFly__)
+#if defined(__FreeBSD_kernel__) || defined(__DragonFly__)
 #include <termios.h>
 #include <libutil.h>
 #elif defined(__NetBSD__) || defined(__OpenBSD__) || defined(__APPLE__) || defined(__ANDROID__)


### PR DESCRIPTION
Hi!

This series of patches fixes the current issues building mame on Debian GNU/kFreeBSD.  There were some assumptions in code that glibc (its headers and functions) is not available when building on a BSD platform.

Thanks!