### PR TITLE
Add arch defines for Linux alpha and mips64el.

### DIFF
--- a/makefile
+++ b/makefile
@@ -140,6 +140,12 @@ endif
 ifneq ($(filter %86,$(UNAME_P)),)
 PLATFORM := x86
 endif 
+ifneq ($(filter alpha,$(UNAME_M)),)
+PLATFORM := alpha
+endif
+ifneq ($(filter alpha,$(UNAME_P)),)
+PLATFORM := alpha
+endif
 ifneq ($(filter arm%,$(UNAME_M)),)
 PLATFORM := arm
 endif 
@@ -155,6 +161,11 @@ endif
 ifneq ($(filter powerpc,$(UNAME_P)),)
 PLATFORM := powerpc
 endif 
+ifneq ($(filter mips64%,$(UNAME_M)),)
+ifeq ($(shell getconf LONG_BIT),64)
+PLATFORM := mips64
+endif
+endif
 ifeq ($(firstword $(filter Linux,$(UNAME))),Linux)
 OS := linux
 endif

--- a/scripts/genie.lua
+++ b/scripts/genie.lua
@@ -982,6 +982,12 @@ end
 		end
 	end
 
+if (_OPTIONS["PLATFORM"]=="alpha") then
+	defines {
+		"PTR64=1",
+	}
+end
+
 if (_OPTIONS["PLATFORM"]=="arm") then
 	buildoptions {
 		"-Wno-cast-align",
@@ -992,6 +998,12 @@ if (_OPTIONS["PLATFORM"]=="arm64") then
 	buildoptions {
 		"-Wno-cast-align",
 	}
+	defines {
+		"PTR64=1",
+	}
+end
+
+if (_OPTIONS["PLATFORM"]=="mips64") then
 	defines {
 		"PTR64=1",
 	}


### PR DESCRIPTION
Add detection for Linux architectures alpha and mips64el, to avoid
using gcc -m64, which isn't available on them.