### PR TITLE
i8251: RTS and DTR outputs now use negative logic (0 = active)

### DIFF
--- a/src/devices/bus/rs232/null_modem.cpp
+++ b/src/devices/bus/rs232/null_modem.cpp
@@ -16,7 +16,7 @@ null_modem_device::null_modem_device(const machine_config &mconfig, const char *
 	m_input_count(0),
 	m_input_index(0),
 	m_timer_poll(nullptr),
-	m_rts(ASSERT_LINE)
+	m_rts(0)
 {
 }
 
@@ -70,7 +70,7 @@ WRITE_LINE_MEMBER(null_modem_device::update_serial)
 	output_dsr(0);
 	output_cts(0);
 
-	m_rts = ASSERT_LINE;
+	m_rts = 0;
 }
 
 void null_modem_device::device_reset()
@@ -102,7 +102,7 @@ void null_modem_device::queue()
 			m_input_count = m_stream->input(m_input_buffer, sizeof(m_input_buffer));
 		}
 
-		if (m_input_count != 0 && m_rts == ASSERT_LINE)
+		if (m_input_count != 0 && m_rts == 0)
 		{
 			transmit_register_setup(m_input_buffer[m_input_index++]);
 

--- a/src/devices/bus/rs232/null_modem.h
+++ b/src/devices/bus/rs232/null_modem.h
@@ -15,7 +15,7 @@ public:
 	virtual machine_config_constructor device_mconfig_additions() const override;
 
 	virtual WRITE_LINE_MEMBER( input_txd ) override { device_serial_interface::rx_w(state); }
-	virtual WRITE_LINE_MEMBER( input_rts ) override { m_rts = (line_state) state; }
+	virtual WRITE_LINE_MEMBER( input_rts ) override { m_rts = state; }
 
 	DECLARE_WRITE_LINE_MEMBER(update_serial);
 
@@ -47,7 +47,7 @@ private:
 	UINT32 m_input_count;
 	UINT32 m_input_index;
 	emu_timer *m_timer_poll;
-	line_state m_rts;
+	int m_rts;
 };
 
 extern const device_type NULL_MODEM;

--- a/src/devices/machine/i8251.cpp
+++ b/src/devices/machine/i8251.cpp
@@ -416,8 +416,8 @@ WRITE8_MEMBER(i8251_device::command_w)
 	        1 = transmit enable
 	*/
 
-	m_rts_handler(BIT(data, 5));
-	m_dtr_handler(BIT(data, 1));
+	m_rts_handler(!BIT(data, 5));
+	m_dtr_handler(!BIT(data, 1));
 
 	if (data & (1<<4))
 	{


### PR DESCRIPTION
Hi,
this is an attempt to fix the problem I described here:
[MESS forum post](http://forums.bannister.org/ubbthreads.php?ubb=showflat&Number=106520#Post106520)
I think this is the solution with the least impact on the current code.
Thanks.
--F.Ulivi