### PR TITLE
Sun475 sccbug

### DIFF
--- a/src/devices/bus/rs232/sparckbd.cpp
+++ b/src/devices/bus/rs232/sparckbd.cpp
@@ -366,7 +366,7 @@ void sparc_keyboard_device::device_reset()
 
 	// configure device_serial_interface
 	set_data_frame(1, 8, PARITY_NONE, STOP_BITS_1);
-	set_rate(9'600); // FIXME: should be 1'200 but the z80scc Baud rate generator is broken
+	set_rate(1200); 
 	receive_register_reset();
 	transmit_register_reset();
 

--- a/src/devices/machine/z80scc.cpp
+++ b/src/devices/machine/z80scc.cpp
@@ -79,9 +79,11 @@ DONE (x) (p=partly)         NMOS         CMOS       ESCC      EMSCC
 // printf("TAG %lld %s%s Data:%d\n", machine().firstcpu->total_cycles(), __PRETTY_FUNCTION__, m_owner->tag(), data);
 
 #define VERBOSE 0
-
-#define LOG(x) do { if (VERBOSE) logerror x; } while (0)
+#define LOGPRINT(x) do { if (VERBOSE) logerror x; } while (0) 
+#define LOG(x) LOGPRINT(x)
 #define LOGR(x)
+#define LOGSETUP(x) LOGPRINT(x)
+#define LOGRCV(x) LOGPRINT(x)
 #if VERBOSE == 2
 #define logerror printf
 #endif
@@ -981,6 +983,7 @@ void z80scc_channel::rcv_callback()
 {
 	if (m_wr3 & WR3_RX_ENABLE)
 	{
+		LOG((LLFORMAT " %s() \"%s \"Channel %c receive data bit %d m_wr3:%02x\n", machine().firstcpu->total_cycles(), FUNCNAME, m_owner->tag(), 'A' + m_index, m_rxd, m_wr3));
 		receive_register_update_bit(m_rxd);
 	}
 #if 1
@@ -1785,6 +1788,7 @@ void z80scc_channel::do_sccreg_wr12(UINT8 data)
 {
 	// TODO: Check if BRG enabled already and restart timer with new value in case advice above is not followed by ROM
 	m_wr12 = data;
+	update_serial();
 	LOG(("\"%s\": %c : %s  %02x Low byte of Time Constant for Baudrate generator\n", m_owner->tag(), 'A' + m_index, FUNCNAME, data));
 }
 
@@ -1793,6 +1797,7 @@ void z80scc_channel::do_sccreg_wr13(UINT8 data)
 {
 	// TODO: Check if BRG enabled already and restart timer with new value in case advice above is not followed by ROM
 	m_wr13 = data;
+	update_serial();
 	LOG(("\"%s\": %c : %s  %02x  High byte of Time Constant for Baudrate generator\n", m_owner->tag(), 'A' + m_index, FUNCNAME, data));
 }
 
@@ -1859,7 +1864,7 @@ void z80scc_channel::do_sccreg_wr14(UINT8 data)
 	/* Based on baudrate code from 8530scc.cpp */
 	if ( !(m_wr14 & WR14_BRG_ENABLE) && (data & WR14_BRG_ENABLE) ) // baud rate generator beeing enabled?
 	{
-		LOG(("\"%s\": %c : %s Mics Control Bits Baudrate generator enabled with \n", m_owner->tag(), 'A' + m_index, FUNCNAME));
+		LOG(("\"%s\": %c : %s Mics Control Bits Baudrate generator enabled with ", m_owner->tag(), 'A' + m_index, FUNCNAME));
 		m_brg_const = 2 + (m_wr13 << 8 | m_wr12);
 		if (data & WR14_BRG_SOURCE) // Do we use the PCLK as baudrate source
 		{
@@ -1948,6 +1953,7 @@ void z80scc_channel::control_write(UINT8 data)
 	}
 
 	//LOG(("\n%s(%02x) reg %02x, regmask %02x\n", FUNCNAME, data, reg, regmask));
+	LOGSETUP((" * %s %c Reg %02x <- %02x  \n", m_owner->tag(), 'A' + m_index, reg, data));
 
 	/* TODO. Sort out 80X30 & other SCC variants limitations in register access */
 	switch (reg)
@@ -2117,7 +2123,7 @@ void z80scc_channel::receive_data(UINT8 data)
 	{
 		// receive overrun error detected
 		m_rx_error_fifo[m_rx_fifo_wp] |= RR1_RX_OVERRUN_ERROR; // = m_rx_error;
-		logerror("Receive_data() Error %02x\n", m_rr1 & (RR1_CRC_FRAMING_ERROR | RR1_RX_OVERRUN_ERROR | RR1_PARITY_ERROR));
+		logerror("Receive_data() Error %02x\n", m_rx_error_fifo[m_rx_fifo_wp] & (RR1_CRC_FRAMING_ERROR | RR1_RX_OVERRUN_ERROR | RR1_PARITY_ERROR));
 	}
 	else
 	{
@@ -2453,6 +2459,7 @@ WRITE_LINE_MEMBER(z80scc_channel::write_rx)
 	}
 #endif
 
+	LOGRCV(("%s(%d)\n", FUNCNAME, state));
 	m_rxd = state;
 	//only use rx_w when self-clocked
 	if(m_rxc != 0 || m_brg_rate != 0)

--- a/src/mame/drivers/sun4.cpp
+++ b/src/mame/drivers/sun4.cpp
@@ -1853,6 +1853,59 @@ ROM_START( sun4_65 )
 ROM_END
 
 // SPARCstation 2 (Sun 4/75)
+/* SCC init 1 for the keyboard
+ *----------------------------
+ * :scc1 A Reg 09 <- c0 Master Interrupt Control - Device reset  c0 A&B: RTS=1 DTR=1 INT=0
+ * :scc1 int: 0
+ * :scc1 A Reg 04 <- 46 Setting up asynchronous frame format and clock, Parity Enable=0, Even Parity, Stop Bits 1, Clock Mode 16X                                     * :scc1 A Reg 03 <- c0 Setting up the receiver, Receiver Enable 0, Auto Enables 0, Receiver Bits/Character 8
+ * :scc1 A Reg 05 <- e2 Setting up the transmitter, Transmitter Enable 0, Transmitter Bits/Character 8, Send Break 0, RTS=1 DTR=1
+ * :scc1 A Reg 09 <- 02 Master Interrupt Control - No reset  02 A&B: RTS=1 DTR=1 INT=0
+ * :scc1 A Reg 0b <- 55 Clock Mode Control 55 Clock type TTL level on RTxC pin, RCV CLK=BRG, TRA CLK=BRG, TRxC pin is Output, TRxC CLK=TRA CLK - not_implemented
+ * :scc1 A Reg 0c <- 7e Low byte of Time Constant for Baudrate generator
+ * :scc1 A Reg 0d <- 00 High byte of Time Constant for Baudrate generator
+ * :scc1 A Reg 0e <- 82 Misc Control Bits Baudrate Generator Input DPLL Command - not implemented
+ * :scc1 A Reg 03 <- c1 Setting up the receiver, Receiver Enable 1, Auto Enables 0, Receiver Bits/Character 8
+ * :scc1 A Reg 05 <- ea Setting up the transmitter, Transmitter Enable 1, Transmitter Bits/Character 8, Send Break 0, RTS=1, DTR=1
+ * :scc1 A Reg 0e <- 83 Misc Control Bits DPLL SRC=BRG Command - not implemented, BRG enabled SRC=PCLK, BRG SRC bps=38400=PCLK 4915200/128, BRG OUT 1200=38400/16
+ * :scc1 A Reg 00 <- 10 Reset External/Status Interrupt
+ * :scc1 A Reg 00 <- 10 Reset External/Status Interrupt
+
+ * SCC init 2 for the keyboard
+ * -------------------------------
+ * :scc1 A Reg 09 <- c0 Master Interrupt Control - Device reset  c0 A&B: RTS=1 DTR=1 INT=0
+scc1 int: 0
+ * :scc1 A Reg 04 <- 46 Setting up asynchronous frame format and clock, Parity Enable=0, Even Parity, Stop Bits 1, Clock Mode 16X
+ * :scc1 A Reg 03 <- c0 Setting up the receiver, Receiver Enable 0, Auto Enables 0, Receiver Bits/Character 8
+ * :scc1 A Reg 05 <- e2 Setting up the transmitter, Transmitter Enable 0, Transmitter Bits/Character 8, Send Break 0, RTS=1 DTR=1
+ * :scc1 A Reg 09 <- 02 Master Interrupt Control - No reset  02 A&B: RTS=1 DTR=1 INT=0
+ * :scc1 A Reg 0b <- 55 Clock Mode Control 55 Clock type TTL level on RTxC pin, RCV CLK=BRG, TRA CLK=BRG, TRxC pin is Output, TRxC CLK=TRA CLK - not_implemented
+ * :scc1 A Reg 0c <- 7e Low byte of Time Constant for Baudrate generator
+ * :scc1 A Reg 0d <- 00 High byte of Time Constant for Baudrate generator
+ * :scc1 A Reg 0e <- 82 Misc Control Bits Baudrate Generator Input DPLL Command - not implemented
+ * :scc1 A Reg 03 <- c1 Setting up the receiver, Receiver Enable 1, Auto Enables 0, Receiver Bits/Character 8
+ * :scc1 A Reg 05 <- ea Setting up the transmitter, Transmitter Enable 1, Transmitter Bits/Character 8, Send Break 0, RTS=1, DTR=1
+ * :scc1 A Reg 0e <- 83 Misc Control Bits DPLL SRC=BRG Command - not implemented, BRG enabled SRC=PCLK, BRG SRC bps=38400=PCLK 4915200/128, BRG OUT 1200=38400/16
+ * :scc1 A Reg 00 <- 10 Reset External/Status Interrupt
+ * :scc1 A Reg 00 <- 10 Reset External/Status Interrupt
+
+ * SCC init 3 for the keyboard - tricky one that reprogramms the baudrate constant as the last step.
+ * -------------------------------------------------------------------------------------------------
+ * :scc1 A Reg 09 <- 02 Master Interrupt Control - No Reset, No vector
+ * :scc1 A Reg 04 <- 44 Setting up asynchronous frame format and clock, Parity Enable=0, Even Odd, Stop Bits 1, Clock Mode 16X
+ * :scc1 A Reg 03 <- c0 Setting up the receiver, Receiver Enable 0, Auto Enables 0, Receiver Bits/Character 8
+ * :scc1 A Reg 05 <- 60 Setting up the transmitter, Transmitter Enable 0, Transmitter Bits/Character 8, Send Break 0, RTS=0 DTR=0
+ * :scc1 A Reg 0e <- 82 Misc Control Bits Baudrate Generator Input DPLL Command - not implemented
+ * :scc1 A Reg 0b <- 55 Clock Mode Control 55 Clock type TTL level on RTxC pin, RCV CLK=BRG, TRA CLK=BRG, TRxC pin is Output, TRxC CLK=TRA CLK - not_implemented
+ * :scc1 A Reg 0c <- 0e Low byte of Time Constant for Baudrate generator  -> 9600 baud
+ * :scc1 A Reg 0d <- 00 High byte of Time Constant for Baudrate generator
+ * :scc1 A Reg 03 <- c1 Setting up the receiver, Receiver Enable 1, Auto Enables 0, Receiver Bits/Character 8
+ * :scc1 A Reg 05 <- 68 Setting up the transmitter, Transmitter Enable 1, Transmitter Bits/Character 8, Send Break 0, RTS=0, DTR=0
+ * :scc1 A Reg 0e <- 83 Misc Control Bits DPLL SRC=BRG Command - not implemented, BRG enabled SRC=PCLK, BRG SRC bps=307200=PCLK 4915200/16, BRG OUT 9600=307200/16
+ * :scc1 A Reg 00 <- 10 Reset External/Status Interrupt
+ * :scc1 A Reg 00 <- 10 Reset External/Status Interrupt
+ * :scc1 A Reg 0c <- 7e Low byte of Time Constant for Baudrate generator -> 1200 baud
+
+*/
 ROM_START( sun4_75 )
 	ROM_REGION32_BE( 0x80000, "user1", ROMREGION_ERASEFF )
 	ROM_LOAD( "ss2-29.rom", 0x0000, 0x40000, CRC(d04132b3) SHA1(ef26afafa2800b8e2e5e994b3a76ca17ce1314b1))


### PR DESCRIPTION
Added support for changing the baudrate constant with enabled Rx/Tx. There are also related patches for removing the workaround in the Sparc keyboard driver and a commentary the sun4 driver, that can be omitted if they are not wanted/needed.