### PR TITLE
Consolidated implementations of device_image_interface::call_softlist_load()

### DIFF
--- a/src/devices/bus/a7800/a78_slot.cpp
+++ b/src/devices/bus/a7800/a78_slot.cpp
@@ -495,16 +495,6 @@ void a78_cart_slot_device::call_unload()
 
 
 /*-------------------------------------------------
- call softlist load
- -------------------------------------------------*/
-
-bool a78_cart_slot_device::call_softlist_load(software_list_device &swlist, const char *swname, const rom_entry *start_entry)
-{
-	machine().rom_load().load_software_part_region(*this, swlist, swname, start_entry);
-	return TRUE;
-}
-
-/*-------------------------------------------------
  verify_header - check the image (from fullpath)
  has an admissible header
  -------------------------------------------------*/

--- a/src/devices/bus/a7800/a78_slot.h
+++ b/src/devices/bus/a7800/a78_slot.h
@@ -96,7 +96,7 @@ public:
 	// image-level overrides
 	virtual bool call_load() override;
 	virtual void call_unload() override;
-	virtual bool call_softlist_load(software_list_device &swlist, const char *swname, const rom_entry *start_entry) override;
+	virtual softlist_type get_softlist_type() const override { return softlist_type::ROM; }
 
 	int get_cart_type() { return m_type; };
 	bool has_cart() { return m_cart != nullptr; }

--- a/src/devices/bus/a7800/a78_slot.h
+++ b/src/devices/bus/a7800/a78_slot.h
@@ -96,7 +96,7 @@ public:
 	// image-level overrides
 	virtual bool call_load() override;
 	virtual void call_unload() override;
-	virtual softlist_type get_softlist_type() const override { return softlist_type::ROM; }
+	virtual const software_list_loader &get_software_list_loader() const override { return rom_software_list_loader::instance(); }
 
 	int get_cart_type() { return m_type; };
 	bool has_cart() { return m_cart != nullptr; }

--- a/src/devices/bus/a800/a800_slot.cpp
+++ b/src/devices/bus/a800/a800_slot.cpp
@@ -304,16 +304,6 @@ void a800_cart_slot_device::call_unload()
 }
 
 /*-------------------------------------------------
- call softlist load
- -------------------------------------------------*/
-
-bool a800_cart_slot_device::call_softlist_load(software_list_device &swlist, const char *swname, const rom_entry *start_entry)
-{
-	machine().rom_load().load_software_part_region(*this, swlist, swname, start_entry);
-	return TRUE;
-}
-
-/*-------------------------------------------------
  identify_cart_type - code to detect cart type from
  fullpath
  -------------------------------------------------*/

--- a/src/devices/bus/a800/a800_slot.h
+++ b/src/devices/bus/a800/a800_slot.h
@@ -96,7 +96,7 @@ public:
 	// image-level overrides
 	virtual bool call_load() override;
 	virtual void call_unload() override;
-	virtual bool call_softlist_load(software_list_device &swlist, const char *swname, const rom_entry *start_entry) override;
+	virtual softlist_type get_softlist_type() const override { return softlist_type::ROM; }
 
 	int get_cart_type() { return m_type; };
 	int identify_cart_type(UINT8 *header);

--- a/src/devices/bus/a800/a800_slot.h
+++ b/src/devices/bus/a800/a800_slot.h
@@ -96,7 +96,7 @@ public:
 	// image-level overrides
 	virtual bool call_load() override;
 	virtual void call_unload() override;
-	virtual softlist_type get_softlist_type() const override { return softlist_type::ROM; }
+	virtual const software_list_loader &get_software_list_loader() const override { return rom_software_list_loader::instance(); }
 
 	int get_cart_type() { return m_type; };
 	int identify_cart_type(UINT8 *header);

--- a/src/devices/bus/adam/exp.cpp
+++ b/src/devices/bus/adam/exp.cpp
@@ -109,18 +109,6 @@ bool adam_expansion_slot_device::call_load()
 
 
 //-------------------------------------------------
-//  call_softlist_load -
-//-------------------------------------------------
-
-bool adam_expansion_slot_device::call_softlist_load(software_list_device &swlist, const char *swname, const rom_entry *start_entry)
-{
-	machine().rom_load().load_software_part_region(*this, swlist, swname, start_entry);
-
-	return true;
-}
-
-
-//-------------------------------------------------
 //  get_default_card_software -
 //-------------------------------------------------
 

--- a/src/devices/bus/adam/exp.h
+++ b/src/devices/bus/adam/exp.h
@@ -73,7 +73,7 @@ protected:
 
 	// image-level overrides
 	virtual bool call_load() override;
-	virtual bool call_softlist_load(software_list_device &swlist, const char *swname, const rom_entry *start_entry) override;
+	virtual softlist_type get_softlist_type() const override { return softlist_type::ROM; }
 
 	virtual iodevice_t image_type() const override { return IO_CARTSLOT; }
 

--- a/src/devices/bus/adam/exp.h
+++ b/src/devices/bus/adam/exp.h
@@ -73,7 +73,7 @@ protected:
 
 	// image-level overrides
 	virtual bool call_load() override;
-	virtual softlist_type get_softlist_type() const override { return softlist_type::ROM; }
+	virtual const software_list_loader &get_software_list_loader() const override { return rom_software_list_loader::instance(); }
 
 	virtual iodevice_t image_type() const override { return IO_CARTSLOT; }
 

--- a/src/devices/bus/apf/slot.cpp
+++ b/src/devices/bus/apf/slot.cpp
@@ -207,17 +207,6 @@ bool apf_cart_slot_device::call_load()
 
 
 /*-------------------------------------------------
- call softlist load
- -------------------------------------------------*/
-
-bool apf_cart_slot_device::call_softlist_load(software_list_device &swlist, const char *swname, const rom_entry *start_entry)
-{
-	machine().rom_load().load_software_part_region(*this, swlist, swname, start_entry);
-	return TRUE;
-}
-
-
-/*-------------------------------------------------
  get default card software
  -------------------------------------------------*/
 

--- a/src/devices/bus/apf/slot.h
+++ b/src/devices/bus/apf/slot.h
@@ -67,7 +67,7 @@ public:
 	// image-level overrides
 	virtual bool call_load() override;
 	virtual void call_unload() override {}
-	virtual bool call_softlist_load(software_list_device &swlist, const char *swname, const rom_entry *start_entry) override;
+	virtual softlist_type get_softlist_type() const override { return softlist_type::ROM; }
 
 	int get_type() { return m_type; }
 

--- a/src/devices/bus/apf/slot.h
+++ b/src/devices/bus/apf/slot.h
@@ -67,7 +67,7 @@ public:
 	// image-level overrides
 	virtual bool call_load() override;
 	virtual void call_unload() override {}
-	virtual softlist_type get_softlist_type() const override { return softlist_type::ROM; }
+	virtual const software_list_loader &get_software_list_loader() const override { return rom_software_list_loader::instance(); }
 
 	int get_type() { return m_type; }
 

--- a/src/devices/bus/arcadia/slot.cpp
+++ b/src/devices/bus/arcadia/slot.cpp
@@ -215,18 +215,6 @@ bool arcadia_cart_slot_device::call_load()
 
 
 /*-------------------------------------------------
- call softlist load
- -------------------------------------------------*/
-
-bool arcadia_cart_slot_device::call_softlist_load(software_list_device &swlist, const char *swname, const rom_entry *start_entry)
-{
-	machine().rom_load().load_software_part_region(*this, swlist, swname, start_entry);
-	return TRUE;
-}
-
-
-
-/*-------------------------------------------------
  get default card software
  -------------------------------------------------*/
 

--- a/src/devices/bus/arcadia/slot.h
+++ b/src/devices/bus/arcadia/slot.h
@@ -58,7 +58,7 @@ public:
 	// image-level overrides
 	virtual bool call_load() override;
 	virtual void call_unload() override {}
-	virtual softlist_type get_softlist_type() const override { return softlist_type::ROM; }
+	virtual const software_list_loader &get_software_list_loader() const override { return rom_software_list_loader::instance(); }
 
 	int get_type() { return m_type; }
 

--- a/src/devices/bus/arcadia/slot.h
+++ b/src/devices/bus/arcadia/slot.h
@@ -58,7 +58,7 @@ public:
 	// image-level overrides
 	virtual bool call_load() override;
 	virtual void call_unload() override {}
-	virtual bool call_softlist_load(software_list_device &swlist, const char *swname, const rom_entry *start_entry) override;
+	virtual softlist_type get_softlist_type() const override { return softlist_type::ROM; }
 
 	int get_type() { return m_type; }
 

--- a/src/devices/bus/astrocde/slot.cpp
+++ b/src/devices/bus/astrocde/slot.cpp
@@ -184,17 +184,6 @@ bool astrocade_cart_slot_device::call_load()
 
 
 /*-------------------------------------------------
- call softlist load
- -------------------------------------------------*/
-
-bool astrocade_cart_slot_device::call_softlist_load(software_list_device &swlist, const char *swname, const rom_entry *start_entry)
-{
-	machine().rom_load().load_software_part_region(*this, swlist, swname, start_entry);
-	return TRUE;
-}
-
-
-/*-------------------------------------------------
  get default card software
  -------------------------------------------------*/
 

--- a/src/devices/bus/astrocde/slot.h
+++ b/src/devices/bus/astrocde/slot.h
@@ -58,7 +58,7 @@ public:
 	// image-level overrides
 	virtual bool call_load() override;
 	virtual void call_unload() override {}
-	virtual softlist_type get_softlist_type() const override { return softlist_type::ROM; }
+	virtual const software_list_loader &get_software_list_loader() const override { return rom_software_list_loader::instance(); }
 
 	int get_type() { return m_type; }
 

--- a/src/devices/bus/astrocde/slot.h
+++ b/src/devices/bus/astrocde/slot.h
@@ -58,7 +58,7 @@ public:
 	// image-level overrides
 	virtual bool call_load() override;
 	virtual void call_unload() override {}
-	virtual bool call_softlist_load(software_list_device &swlist, const char *swname, const rom_entry *start_entry) override;
+	virtual softlist_type get_softlist_type() const override { return softlist_type::ROM; }
 
 	int get_type() { return m_type; }
 

--- a/src/devices/bus/c64/exp.cpp
+++ b/src/devices/bus/c64/exp.cpp
@@ -202,18 +202,6 @@ bool c64_expansion_slot_device::call_load()
 
 
 //-------------------------------------------------
-//  call_softlist_load -
-//-------------------------------------------------
-
-bool c64_expansion_slot_device::call_softlist_load(software_list_device &swlist, const char *swname, const rom_entry *start_entry)
-{
-	machine().rom_load().load_software_part_region(*this, swlist, swname, start_entry);
-
-	return true;
-}
-
-
-//-------------------------------------------------
 //  get_default_card_software -
 //-------------------------------------------------
 

--- a/src/devices/bus/c64/exp.h
+++ b/src/devices/bus/c64/exp.h
@@ -135,7 +135,7 @@ protected:
 
 	// image-level overrides
 	virtual bool call_load() override;
-	virtual softlist_type get_softlist_type() const override { return softlist_type::ROM; }
+	virtual const software_list_loader &get_software_list_loader() const override { return rom_software_list_loader::instance(); }
 
 	virtual iodevice_t image_type() const override { return IO_CARTSLOT; }
 

--- a/src/devices/bus/c64/exp.h
+++ b/src/devices/bus/c64/exp.h
@@ -135,7 +135,7 @@ protected:
 
 	// image-level overrides
 	virtual bool call_load() override;
-	virtual bool call_softlist_load(software_list_device &swlist, const char *swname, const rom_entry *start_entry) override;
+	virtual softlist_type get_softlist_type() const override { return softlist_type::ROM; }
 
 	virtual iodevice_t image_type() const override { return IO_CARTSLOT; }
 

--- a/src/devices/bus/cbm2/exp.cpp
+++ b/src/devices/bus/cbm2/exp.cpp
@@ -140,18 +140,6 @@ bool cbm2_expansion_slot_device::call_load()
 
 
 //-------------------------------------------------
-//  call_softlist_load -
-//-------------------------------------------------
-
-bool cbm2_expansion_slot_device::call_softlist_load(software_list_device &swlist, const char *swname, const rom_entry *start_entry)
-{
-	machine().rom_load().load_software_part_region(*this, swlist, swname, start_entry);
-
-	return true;
-}
-
-
-//-------------------------------------------------
 //  get_default_card_software -
 //-------------------------------------------------
 

--- a/src/devices/bus/cbm2/exp.h
+++ b/src/devices/bus/cbm2/exp.h
@@ -82,7 +82,7 @@ protected:
 
 	// image-level overrides
 	virtual bool call_load() override;
-	virtual bool call_softlist_load(software_list_device &swlist, const char *swname, const rom_entry *start_entry) override;
+	virtual softlist_type get_softlist_type() const override { return softlist_type::ROM; }
 
 	virtual iodevice_t image_type() const override { return IO_CARTSLOT; }
 

--- a/src/devices/bus/cbm2/exp.h
+++ b/src/devices/bus/cbm2/exp.h
@@ -82,7 +82,7 @@ protected:
 
 	// image-level overrides
 	virtual bool call_load() override;
-	virtual softlist_type get_softlist_type() const override { return softlist_type::ROM; }
+	virtual const software_list_loader &get_software_list_loader() const override { return rom_software_list_loader::instance(); }
 
 	virtual iodevice_t image_type() const override { return IO_CARTSLOT; }
 

--- a/src/devices/bus/chanf/slot.cpp
+++ b/src/devices/bus/chanf/slot.cpp
@@ -202,18 +202,6 @@ bool channelf_cart_slot_device::call_load()
 
 
 /*-------------------------------------------------
- call softlist load
- -------------------------------------------------*/
-
-bool channelf_cart_slot_device::call_softlist_load(software_list_device &swlist, const char *swname, const rom_entry *start_entry)
-{
-	machine().rom_load().load_software_part_region(*this, swlist, swname, start_entry);
-	return TRUE;
-}
-
-
-
-/*-------------------------------------------------
  get default card software
  -------------------------------------------------*/
 

--- a/src/devices/bus/chanf/slot.h
+++ b/src/devices/bus/chanf/slot.h
@@ -70,7 +70,7 @@ public:
 	// image-level overrides
 	virtual bool call_load() override;
 	virtual void call_unload() override {}
-	virtual bool call_softlist_load(software_list_device &swlist, const char *swname, const rom_entry *start_entry) override;
+	virtual softlist_type get_softlist_type() const override { return softlist_type::ROM; }
 
 	int get_type() { return m_type; }
 

--- a/src/devices/bus/chanf/slot.h
+++ b/src/devices/bus/chanf/slot.h
@@ -70,7 +70,7 @@ public:
 	// image-level overrides
 	virtual bool call_load() override;
 	virtual void call_unload() override {}
-	virtual softlist_type get_softlist_type() const override { return softlist_type::ROM; }
+	virtual const software_list_loader &get_software_list_loader() const override { return rom_software_list_loader::instance(); }
 
 	int get_type() { return m_type; }
 

--- a/src/devices/bus/coco/cococart.cpp
+++ b/src/devices/bus/coco/cococart.cpp
@@ -348,18 +348,6 @@ bool cococart_slot_device::call_load()
 
 
 //-------------------------------------------------
-//  call_softlist_load
-//-------------------------------------------------
-
-bool cococart_slot_device::call_softlist_load(software_list_device &swlist, const char *swname, const rom_entry *start_entry)
-{
-	machine().rom_load().load_software_part_region(*this, swlist, swname, start_entry );
-	return TRUE;
-}
-
-
-
-//-------------------------------------------------
 //  get_default_card_software
 //-------------------------------------------------
 

--- a/src/devices/bus/coco/cococart.h
+++ b/src/devices/bus/coco/cococart.h
@@ -88,7 +88,7 @@ public:
 
 	// image-level overrides
 	virtual bool call_load() override;
-	virtual softlist_type get_softlist_type() const override { return softlist_type::ROM; }
+	virtual const software_list_loader &get_software_list_loader() const override { return rom_software_list_loader::instance(); }
 
 	virtual iodevice_t image_type() const override { return IO_CARTSLOT; }
 

--- a/src/devices/bus/coco/cococart.h
+++ b/src/devices/bus/coco/cococart.h
@@ -88,7 +88,7 @@ public:
 
 	// image-level overrides
 	virtual bool call_load() override;
-	virtual bool call_softlist_load(software_list_device &swlist, const char *swname, const rom_entry *start_entry) override;
+	virtual softlist_type get_softlist_type() const override { return softlist_type::ROM; }
 
 	virtual iodevice_t image_type() const override { return IO_CARTSLOT; }
 

--- a/src/devices/bus/coleco/exp.cpp
+++ b/src/devices/bus/coleco/exp.cpp
@@ -97,18 +97,6 @@ bool colecovision_cartridge_slot_device::call_load()
 
 
 //-------------------------------------------------
-//  call_softlist_load -
-//-------------------------------------------------
-
-bool colecovision_cartridge_slot_device::call_softlist_load(software_list_device &swlist, const char *swname, const rom_entry *start_entry)
-{
-	machine().rom_load().load_software_part_region(*this, swlist, swname, start_entry);
-
-	return true;
-}
-
-
-//-------------------------------------------------
 //  get_default_card_software -
 //-------------------------------------------------
 

--- a/src/devices/bus/coleco/exp.h
+++ b/src/devices/bus/coleco/exp.h
@@ -79,7 +79,7 @@ protected:
 
 	// image-level overrides
 	virtual bool call_load() override;
-	virtual bool call_softlist_load(software_list_device &swlist, const char *swname, const rom_entry *start_entry) override;
+	virtual softlist_type get_softlist_type() const override { return softlist_type::ROM; }
 
 	virtual iodevice_t image_type() const override { return IO_CARTSLOT; }
 

--- a/src/devices/bus/coleco/exp.h
+++ b/src/devices/bus/coleco/exp.h
@@ -79,7 +79,7 @@ protected:
 
 	// image-level overrides
 	virtual bool call_load() override;
-	virtual softlist_type get_softlist_type() const override { return softlist_type::ROM; }
+	virtual const software_list_loader &get_software_list_loader() const override { return rom_software_list_loader::instance(); }
 
 	virtual iodevice_t image_type() const override { return IO_CARTSLOT; }
 

--- a/src/devices/bus/crvision/slot.cpp
+++ b/src/devices/bus/crvision/slot.cpp
@@ -215,17 +215,6 @@ bool crvision_cart_slot_device::call_load()
 
 
 /*-------------------------------------------------
- call softlist load
- -------------------------------------------------*/
-
-bool crvision_cart_slot_device::call_softlist_load(software_list_device &swlist, const char *swname, const rom_entry *start_entry)
-{
-	machine().rom_load().load_software_part_region(*this, swlist, swname, start_entry);
-	return TRUE;
-}
-
-
-/*-------------------------------------------------
  get default card software
  -------------------------------------------------*/
 

--- a/src/devices/bus/crvision/slot.h
+++ b/src/devices/bus/crvision/slot.h
@@ -63,7 +63,7 @@ public:
 	// image-level overrides
 	virtual bool call_load() override;
 	virtual void call_unload() override {}
-	virtual softlist_type get_softlist_type() const override { return softlist_type::ROM; }
+	virtual const software_list_loader &get_software_list_loader() const override { return rom_software_list_loader::instance(); }
 
 	int get_type() { return m_type; }
 

--- a/src/devices/bus/crvision/slot.h
+++ b/src/devices/bus/crvision/slot.h
@@ -63,7 +63,7 @@ public:
 	// image-level overrides
 	virtual bool call_load() override;
 	virtual void call_unload() override {}
-	virtual bool call_softlist_load(software_list_device &swlist, const char *swname, const rom_entry *start_entry) override;
+	virtual softlist_type get_softlist_type() const override { return softlist_type::ROM; }
 
 	int get_type() { return m_type; }
 

--- a/src/devices/bus/gameboy/gb_slot.cpp
+++ b/src/devices/bus/gameboy/gb_slot.cpp
@@ -451,16 +451,6 @@ void base_gb_cart_slot_device::setup_ram(UINT8 banks)
 
 
 
-/*-------------------------------------------------
- call softlist load
- -------------------------------------------------*/
-
-bool base_gb_cart_slot_device::call_softlist_load(software_list_device &swlist, const char *swname, const rom_entry *start_entry)
-{
-	machine().rom_load().load_software_part_region(*this, swlist, swname, start_entry);
-	return true;
-}
-
 // This fails to catch Mani 4-in-1 carts... even when they match this, then they have MBC1/3 in the internal header instead of MMM01...
 bool base_gb_cart_slot_device::get_mmm01_candidate(UINT8 *ROM, UINT32 len)
 {

--- a/src/devices/bus/gameboy/gb_slot.h
+++ b/src/devices/bus/gameboy/gb_slot.h
@@ -118,7 +118,7 @@ public:
 	// image-level overrides
 	virtual bool call_load() override;
 	virtual void call_unload() override;
-	virtual bool call_softlist_load(software_list_device &swlist, const char *swname, const rom_entry *start_entry) override;
+	virtual softlist_type get_softlist_type() const override { return softlist_type::ROM; }
 
 	int get_type() { return m_type; }
 	int get_cart_type(UINT8 *ROM, UINT32 len);

--- a/src/devices/bus/gameboy/gb_slot.h
+++ b/src/devices/bus/gameboy/gb_slot.h
@@ -118,7 +118,7 @@ public:
 	// image-level overrides
 	virtual bool call_load() override;
 	virtual void call_unload() override;
-	virtual softlist_type get_softlist_type() const override { return softlist_type::ROM; }
+	virtual const software_list_loader &get_software_list_loader() const override { return rom_software_list_loader::instance(); }
 
 	int get_type() { return m_type; }
 	int get_cart_type(UINT8 *ROM, UINT32 len);

--- a/src/devices/bus/gba/gba_slot.cpp
+++ b/src/devices/bus/gba/gba_slot.cpp
@@ -255,18 +255,6 @@ void gba_cart_slot_device::call_unload()
 
 
 /*-------------------------------------------------
- call softlist load
- -------------------------------------------------*/
-
-bool gba_cart_slot_device::call_softlist_load(software_list_device &swlist, const char *swname, const rom_entry *start_entry)
-{
-	machine().rom_load().load_software_part_region(*this, swlist, swname, start_entry);
-	return TRUE;
-}
-
-
-
-/*-------------------------------------------------
  get_cart_type - code to detect NVRAM type from
  fullpath
  -------------------------------------------------*/

--- a/src/devices/bus/gba/gba_slot.h
+++ b/src/devices/bus/gba/gba_slot.h
@@ -87,7 +87,7 @@ public:
 	// image-level overrides
 	virtual bool call_load() override;
 	virtual void call_unload() override;
-	virtual bool call_softlist_load(software_list_device &swlist, const char *swname, const rom_entry *start_entry) override;
+	virtual softlist_type get_softlist_type() const override { return softlist_type::ROM; }
 
 	int get_type() { return m_type; }
 	int get_cart_type(UINT8 *ROM, UINT32 len);

--- a/src/devices/bus/gba/gba_slot.h
+++ b/src/devices/bus/gba/gba_slot.h
@@ -87,7 +87,7 @@ public:
 	// image-level overrides
 	virtual bool call_load() override;
 	virtual void call_unload() override;
-	virtual softlist_type get_softlist_type() const override { return softlist_type::ROM; }
+	virtual const software_list_loader &get_software_list_loader() const override { return rom_software_list_loader::instance(); }
 
 	int get_type() { return m_type; }
 	int get_cart_type(UINT8 *ROM, UINT32 len);

--- a/src/devices/bus/generic/slot.cpp
+++ b/src/devices/bus/generic/slot.cpp
@@ -165,18 +165,6 @@ void generic_slot_device::call_unload()
 
 
 /*-------------------------------------------------
- call softlist load
- -------------------------------------------------*/
-
-bool generic_slot_device::call_softlist_load(software_list_device &swlist, const char *swname, const rom_entry *start_entry)
-{
-	machine().rom_load().load_software_part_region(*this, swlist, swname, start_entry);
-	return TRUE;
-}
-
-
-
-/*-------------------------------------------------
  get default card software
  -------------------------------------------------*/
 

--- a/src/devices/bus/generic/slot.h
+++ b/src/devices/bus/generic/slot.h
@@ -114,7 +114,7 @@ public:
 	// image-level overrides
 	virtual bool call_load() override;
 	virtual void call_unload() override;
-	virtual bool call_softlist_load(software_list_device &swlist, const char *swname, const rom_entry *start_entry) override;
+	virtual softlist_type get_softlist_type() const override { return softlist_type::ROM; }
 
 	UINT32 common_get_size(const char *region);
 	void common_load_rom(UINT8 *ROM, UINT32 len, const char *region);

--- a/src/devices/bus/generic/slot.h
+++ b/src/devices/bus/generic/slot.h
@@ -114,7 +114,7 @@ public:
 	// image-level overrides
 	virtual bool call_load() override;
 	virtual void call_unload() override;
-	virtual softlist_type get_softlist_type() const override { return softlist_type::ROM; }
+	virtual const software_list_loader &get_software_list_loader() const override { return rom_software_list_loader::instance(); }
 
 	UINT32 common_get_size(const char *region);
 	void common_load_rom(UINT8 *ROM, UINT32 len, const char *region);

--- a/src/devices/bus/hp_optroms/hp_optrom.cpp
+++ b/src/devices/bus/hp_optroms/hp_optrom.cpp
@@ -126,13 +126,6 @@ void hp_optrom_slot_device::call_unload()
 		}
 }
 
-bool hp_optrom_slot_device::call_softlist_load(software_list_device &swlist, const char *swname, const rom_entry *start_entry)
-{
-		logerror("hp_optrom: call_softlist_load\n");
-		machine().rom_load().load_software_part_region(*this, swlist, swname, start_entry);
-		return TRUE;
-}
-
 std::string hp_optrom_slot_device::get_default_card_software()
 {
 		return software_get_default_slot("rom");

--- a/src/devices/bus/hp_optroms/hp_optrom.h
+++ b/src/devices/bus/hp_optroms/hp_optrom.h
@@ -43,7 +43,7 @@ public:
 		// image-level overrides
 		virtual bool call_load() override;
 		virtual void call_unload() override;
-		virtual softlist_type get_softlist_type() const override { return softlist_type::ROM; }
+		virtual const software_list_loader &get_software_list_loader() const override { return rom_software_list_loader::instance(); }
 
 		virtual iodevice_t image_type() const override { return IO_CARTSLOT; }
 		virtual bool is_readable()  const override { return true; }

--- a/src/devices/bus/hp_optroms/hp_optrom.h
+++ b/src/devices/bus/hp_optroms/hp_optrom.h
@@ -43,7 +43,7 @@ public:
 		// image-level overrides
 		virtual bool call_load() override;
 		virtual void call_unload() override;
-		virtual bool call_softlist_load(software_list_device &swlist, const char *swname, const rom_entry *start_entry) override;
+		virtual softlist_type get_softlist_type() const override { return softlist_type::ROM; }
 
 		virtual iodevice_t image_type() const override { return IO_CARTSLOT; }
 		virtual bool is_readable()  const override { return true; }

--- a/src/devices/bus/intv/slot.cpp
+++ b/src/devices/bus/intv/slot.cpp
@@ -445,17 +445,6 @@ bool intv_cart_slot_device::call_load()
 
 
 /*-------------------------------------------------
- call softlist load
- -------------------------------------------------*/
-
-bool intv_cart_slot_device::call_softlist_load(software_list_device &swlist, const char *swname, const rom_entry *start_entry)
-{
-	machine().rom_load().load_software_part_region(*this, swlist, swname, start_entry);
-	return TRUE;
-}
-
-
-/*-------------------------------------------------
  get default card software
  -------------------------------------------------*/
 

--- a/src/devices/bus/intv/slot.h
+++ b/src/devices/bus/intv/slot.h
@@ -102,7 +102,7 @@ public:
 	// image-level overrides
 	virtual bool call_load() override;
 	virtual void call_unload() override {}
-	virtual bool call_softlist_load(software_list_device &swlist, const char *swname, const rom_entry *start_entry) override;
+	virtual softlist_type get_softlist_type() const override { return softlist_type::ROM; }
 
 	int get_type() { return m_type; }
 	int load_fullpath();

--- a/src/devices/bus/intv/slot.h
+++ b/src/devices/bus/intv/slot.h
@@ -102,7 +102,7 @@ public:
 	// image-level overrides
 	virtual bool call_load() override;
 	virtual void call_unload() override {}
-	virtual softlist_type get_softlist_type() const override { return softlist_type::ROM; }
+	virtual const software_list_loader &get_software_list_loader() const override { return rom_software_list_loader::instance(); }
 
 	int get_type() { return m_type; }
 	int load_fullpath();

--- a/src/devices/bus/iq151/iq151.cpp
+++ b/src/devices/bus/iq151/iq151.cpp
@@ -190,16 +190,6 @@ bool iq151cart_slot_device::call_load()
 }
 
 /*-------------------------------------------------
-    call softlist load
--------------------------------------------------*/
-
-bool iq151cart_slot_device::call_softlist_load(software_list_device &swlist, const char *swname, const rom_entry *start_entry)
-{
-	machine().rom_load().load_software_part_region(*this, swlist, swname, start_entry );
-	return TRUE;
-}
-
-/*-------------------------------------------------
     get default card software
 -------------------------------------------------*/
 

--- a/src/devices/bus/iq151/iq151.h
+++ b/src/devices/bus/iq151/iq151.h
@@ -93,7 +93,7 @@ public:
 
 	// image-level overrides
 	virtual bool call_load() override;
-	virtual bool call_softlist_load(software_list_device &swlist, const char *swname, const rom_entry *start_entry) override;
+	virtual softlist_type get_softlist_type() const override { return softlist_type::ROM; }
 
 	virtual iodevice_t image_type() const override { return IO_CARTSLOT; }
 	virtual bool is_readable()  const override { return 1; }

--- a/src/devices/bus/iq151/iq151.h
+++ b/src/devices/bus/iq151/iq151.h
@@ -93,7 +93,7 @@ public:
 
 	// image-level overrides
 	virtual bool call_load() override;
-	virtual softlist_type get_softlist_type() const override { return softlist_type::ROM; }
+	virtual const software_list_loader &get_software_list_loader() const override { return rom_software_list_loader::instance(); }
 
 	virtual iodevice_t image_type() const override { return IO_CARTSLOT; }
 	virtual bool is_readable()  const override { return 1; }

--- a/src/devices/bus/isa/sc499.h
+++ b/src/devices/bus/isa/sc499.h
@@ -30,7 +30,7 @@ public:
 
 	// image-level overrides
 	virtual bool call_load() override;
-	virtual softlist_type get_softlist_type() const override { return softlist_type::SOFTWARE; }
+	virtual const software_list_loader &get_software_list_loader() const override { return image_software_list_loader::instance(); }
 	virtual void call_unload() override;
 	virtual iodevice_t image_type() const override { return IO_MAGTAPE; }
 

--- a/src/devices/bus/isa/sc499.h
+++ b/src/devices/bus/isa/sc499.h
@@ -30,7 +30,7 @@ public:
 
 	// image-level overrides
 	virtual bool call_load() override;
-	virtual bool call_softlist_load(software_list_device &swlist, const char *swname, const rom_entry *start_entry) override { return load_software(swlist, swname, start_entry); }
+	virtual softlist_type get_softlist_type() const override { return softlist_type::SOFTWARE; }
 	virtual void call_unload() override;
 	virtual iodevice_t image_type() const override { return IO_MAGTAPE; }
 

--- a/src/devices/bus/kc/kc.cpp
+++ b/src/devices/bus/kc/kc.cpp
@@ -356,16 +356,6 @@ bool kccart_slot_device::call_load()
 }
 
 /*-------------------------------------------------
-    call softlist load
--------------------------------------------------*/
-
-bool kccart_slot_device::call_softlist_load(software_list_device &swlist, const char *swname, const rom_entry *start_entry)
-{
-	machine().rom_load().load_software_part_region(*this, swlist, swname, start_entry );
-	return TRUE;
-}
-
-/*-------------------------------------------------
     get default card software
 -------------------------------------------------*/
 

--- a/src/devices/bus/kc/kc.h
+++ b/src/devices/bus/kc/kc.h
@@ -91,7 +91,7 @@ public:
 
 	// image-level overrides
 	virtual bool call_load() override;
-	virtual bool call_softlist_load(software_list_device &swlist, const char *swname, const rom_entry *start_entry) override;
+	virtual softlist_type get_softlist_type() const override { return softlist_type::ROM; }
 
 	virtual iodevice_t image_type() const override { return IO_CARTSLOT; }
 	virtual bool is_readable()  const override { return 1; }

--- a/src/devices/bus/kc/kc.h
+++ b/src/devices/bus/kc/kc.h
@@ -91,7 +91,7 @@ public:
 
 	// image-level overrides
 	virtual bool call_load() override;
-	virtual softlist_type get_softlist_type() const override { return softlist_type::ROM; }
+	virtual const software_list_loader &get_software_list_loader() const override { return rom_software_list_loader::instance(); }
 
 	virtual iodevice_t image_type() const override { return IO_CARTSLOT; }
 	virtual bool is_readable()  const override { return 1; }

--- a/src/devices/bus/m5/slot.cpp
+++ b/src/devices/bus/m5/slot.cpp
@@ -204,17 +204,6 @@ bool m5_cart_slot_device::call_load()
 
 
 /*-------------------------------------------------
- call softlist load
- -------------------------------------------------*/
-
-bool m5_cart_slot_device::call_softlist_load(software_list_device &swlist, const char *swname, const rom_entry *start_entry)
-{
-	machine().rom_load().load_software_part_region(*this, swlist, swname, start_entry);
-	return TRUE;
-}
-
-
-/*-------------------------------------------------
  get default card software
  -------------------------------------------------*/
 

--- a/src/devices/bus/m5/slot.h
+++ b/src/devices/bus/m5/slot.h
@@ -70,7 +70,7 @@ public:
 	// image-level overrides
 	virtual bool call_load() override;
 	virtual void call_unload() override {}
-	virtual bool call_softlist_load(software_list_device &swlist, const char *swname, const rom_entry *start_entry) override;
+	virtual softlist_type get_softlist_type() const override { return softlist_type::ROM; }
 
 	int get_type() { return m_type; }
 

--- a/src/devices/bus/m5/slot.h
+++ b/src/devices/bus/m5/slot.h
@@ -70,7 +70,7 @@ public:
 	// image-level overrides
 	virtual bool call_load() override;
 	virtual void call_unload() override {}
-	virtual softlist_type get_softlist_type() const override { return softlist_type::ROM; }
+	virtual const software_list_loader &get_software_list_loader() const override { return rom_software_list_loader::instance(); }
 
 	int get_type() { return m_type; }
 

--- a/src/devices/bus/megadrive/md_slot.cpp
+++ b/src/devices/bus/megadrive/md_slot.cpp
@@ -683,16 +683,6 @@ void base_md_cart_slot_device::setup_nvram()
 
 
 
-/*-------------------------------------------------
- call softlist load
- -------------------------------------------------*/
-
-bool base_md_cart_slot_device::call_softlist_load(software_list_device &swlist, const char *swname, const rom_entry *start_entry)
-{
-	machine().rom_load().load_software_part_region(*this, swlist, swname, start_entry);
-	return TRUE;
-}
-
 int base_md_cart_slot_device::get_cart_type(UINT8 *ROM, UINT32 len)
 {
 	int type = SEGA_STD;

--- a/src/devices/bus/megadrive/md_slot.h
+++ b/src/devices/bus/megadrive/md_slot.h
@@ -153,7 +153,7 @@ public:
 	// image-level overrides
 	virtual bool call_load() override;
 	virtual void call_unload() override;
-	virtual bool call_softlist_load(software_list_device &swlist, const char *swname, const rom_entry *start_entry) override;
+	virtual softlist_type get_softlist_type() const override { return softlist_type::ROM; }
 
 	virtual iodevice_t image_type() const override { return IO_CARTSLOT; }
 	virtual bool is_readable()  const override { return 1; }

--- a/src/devices/bus/megadrive/md_slot.h
+++ b/src/devices/bus/megadrive/md_slot.h
@@ -153,7 +153,7 @@ public:
 	// image-level overrides
 	virtual bool call_load() override;
 	virtual void call_unload() override;
-	virtual softlist_type get_softlist_type() const override { return softlist_type::ROM; }
+	virtual const software_list_loader &get_software_list_loader() const override { return rom_software_list_loader::instance(); }
 
 	virtual iodevice_t image_type() const override { return IO_CARTSLOT; }
 	virtual bool is_readable()  const override { return 1; }

--- a/src/devices/bus/msx_slot/cartridge.cpp
+++ b/src/devices/bus/msx_slot/cartridge.cpp
@@ -198,13 +198,6 @@ void msx_slot_cartridge_device::call_unload()
 }
 
 
-bool msx_slot_cartridge_device::call_softlist_load(software_list_device &swlist, const char *swname, const rom_entry *start_entry)
-{
-	machine().rom_load().load_software_part_region(*this, swlist, swname, start_entry);
-	return true;
-}
-
-
 WRITE_LINE_MEMBER(msx_slot_cartridge_device::irq_out)
 {
 	m_irq_handler(state);

--- a/src/devices/bus/msx_slot/cartridge.h
+++ b/src/devices/bus/msx_slot/cartridge.h
@@ -43,7 +43,7 @@ public:
 	// image-level overrides
 	virtual bool call_load() override;
 	virtual void call_unload() override;
-	virtual softlist_type get_softlist_type() const override { return softlist_type::ROM; }
+	virtual const software_list_loader &get_software_list_loader() const override { return rom_software_list_loader::instance(); }
 	virtual iodevice_t image_type() const override { return IO_CARTSLOT; }
 	virtual bool is_readable()  const override { return true; }
 	virtual bool is_writeable() const override { return false; }

--- a/src/devices/bus/msx_slot/cartridge.h
+++ b/src/devices/bus/msx_slot/cartridge.h
@@ -43,7 +43,7 @@ public:
 	// image-level overrides
 	virtual bool call_load() override;
 	virtual void call_unload() override;
-	virtual bool call_softlist_load(software_list_device &swlist, const char *swname, const rom_entry *start_entry) override;
+	virtual softlist_type get_softlist_type() const override { return softlist_type::ROM; }
 	virtual iodevice_t image_type() const override { return IO_CARTSLOT; }
 	virtual bool is_readable()  const override { return true; }
 	virtual bool is_writeable() const override { return false; }

--- a/src/devices/bus/neogeo/slot.cpp
+++ b/src/devices/bus/neogeo/slot.cpp
@@ -331,17 +331,6 @@ void neogeo_cart_slot_device::call_unload()
 }
 
 /*-------------------------------------------------
- call softlist load
- -------------------------------------------------*/
-
-bool neogeo_cart_slot_device::call_softlist_load(software_list_device &swlist, const char *swname, const rom_entry *start_entry)
-{
-	machine().rom_load().load_software_part_region(*this, swlist, swname, start_entry );
-	return TRUE;
-}
-
-
-/*-------------------------------------------------
  get default card software
  -------------------------------------------------*/
 

--- a/src/devices/bus/neogeo/slot.h
+++ b/src/devices/bus/neogeo/slot.h
@@ -195,7 +195,7 @@ public:
 	// image-level overrides
 	virtual bool call_load() override;
 	virtual void call_unload() override;
-	virtual bool call_softlist_load(software_list_device &swlist, const char *swname, const rom_entry *start_entry) override;
+	virtual softlist_type get_softlist_type() const override { return softlist_type::ROM; }
 
 	virtual iodevice_t image_type() const override { return IO_CARTSLOT; }
 	virtual bool is_readable()  const override { return 1; }

--- a/src/devices/bus/neogeo/slot.h
+++ b/src/devices/bus/neogeo/slot.h
@@ -195,7 +195,7 @@ public:
 	// image-level overrides
 	virtual bool call_load() override;
 	virtual void call_unload() override;
-	virtual softlist_type get_softlist_type() const override { return softlist_type::ROM; }
+	virtual const software_list_loader &get_software_list_loader() const override { return rom_software_list_loader::instance(); }
 
 	virtual iodevice_t image_type() const override { return IO_CARTSLOT; }
 	virtual bool is_readable()  const override { return 1; }

--- a/src/devices/bus/nes/aladdin.cpp
+++ b/src/devices/bus/nes/aladdin.cpp
@@ -136,12 +136,6 @@ bool nes_aladdin_slot_device::call_load()
 }
 
 
-bool nes_aladdin_slot_device::call_softlist_load(software_list_device &swlist, const char *swname, const rom_entry *start_entry)
-{
-	machine().rom_load().load_software_part_region(*this, swlist, swname, start_entry );
-	return TRUE;
-}
-
 std::string nes_aladdin_slot_device::get_default_card_software()
 {
 	if (open_image_file(mconfig().options()))

--- a/src/devices/bus/nes/aladdin.h
+++ b/src/devices/bus/nes/aladdin.h
@@ -52,7 +52,7 @@ public:
 
 	// image-level overrides
 	virtual bool call_load() override;
-	virtual bool call_softlist_load(software_list_device &swlist, const char *swname, const rom_entry *start_entry) override;
+	virtual softlist_type get_softlist_type() const override { return softlist_type::ROM; }
 
 	virtual iodevice_t image_type() const override { return IO_CARTSLOT; }
 	virtual bool is_readable()  const override { return 1; }

--- a/src/devices/bus/nes/aladdin.h
+++ b/src/devices/bus/nes/aladdin.h
@@ -52,7 +52,7 @@ public:
 
 	// image-level overrides
 	virtual bool call_load() override;
-	virtual softlist_type get_softlist_type() const override { return softlist_type::ROM; }
+	virtual const software_list_loader &get_software_list_loader() const override { return rom_software_list_loader::instance(); }
 
 	virtual iodevice_t image_type() const override { return IO_CARTSLOT; }
 	virtual bool is_readable()  const override { return 1; }

--- a/src/devices/bus/nes/datach.cpp
+++ b/src/devices/bus/nes/datach.cpp
@@ -137,12 +137,6 @@ bool nes_datach_slot_device::call_load()
 }
 
 
-bool nes_datach_slot_device::call_softlist_load(software_list_device &swlist, const char *swname, const rom_entry *start_entry)
-{
-	machine().rom_load().load_software_part_region(*this, swlist, swname, start_entry );
-	return TRUE;
-}
-
 std::string nes_datach_slot_device::get_default_card_software()
 {
 	// any way to detect the game with X24C01?

--- a/src/devices/bus/nes/datach.h
+++ b/src/devices/bus/nes/datach.h
@@ -54,7 +54,7 @@ public:
 
 	// image-level overrides
 	virtual bool call_load() override;
-	virtual softlist_type get_softlist_type() const override { return softlist_type::ROM; }
+	virtual const software_list_loader &get_software_list_loader() const override { return rom_software_list_loader::instance(); }
 
 	virtual iodevice_t image_type() const override { return IO_CARTSLOT; }
 	virtual bool is_readable()  const override { return 1; }

--- a/src/devices/bus/nes/datach.h
+++ b/src/devices/bus/nes/datach.h
@@ -54,7 +54,7 @@ public:
 
 	// image-level overrides
 	virtual bool call_load() override;
-	virtual bool call_softlist_load(software_list_device &swlist, const char *swname, const rom_entry *start_entry) override;
+	virtual softlist_type get_softlist_type() const override { return softlist_type::ROM; }
 
 	virtual iodevice_t image_type() const override { return IO_CARTSLOT; }
 	virtual bool is_readable()  const override { return 1; }

--- a/src/devices/bus/nes/karastudio.cpp
+++ b/src/devices/bus/nes/karastudio.cpp
@@ -126,12 +126,6 @@ bool nes_kstudio_slot_device::call_load()
 }
 
 
-bool nes_kstudio_slot_device::call_softlist_load(software_list_device &swlist, const char *swname, const rom_entry *start_entry)
-{
-	machine().rom_load().load_software_part_region(*this, swlist, swname, start_entry );
-	return TRUE;
-}
-
 std::string nes_kstudio_slot_device::get_default_card_software()
 {
 	return software_get_default_slot("ks_exp");

--- a/src/devices/bus/nes/karastudio.h
+++ b/src/devices/bus/nes/karastudio.h
@@ -51,7 +51,7 @@ public:
 
 	// image-level overrides
 	virtual bool call_load() override;
-	virtual softlist_type get_softlist_type() const override { return softlist_type::ROM; }
+	virtual const software_list_loader &get_software_list_loader() const override { return rom_software_list_loader::instance(); }
 
 	virtual iodevice_t image_type() const override { return IO_CARTSLOT; }
 	virtual bool is_readable()  const override { return 1; }

--- a/src/devices/bus/nes/karastudio.h
+++ b/src/devices/bus/nes/karastudio.h
@@ -51,7 +51,7 @@ public:
 
 	// image-level overrides
 	virtual bool call_load() override;
-	virtual bool call_softlist_load(software_list_device &swlist, const char *swname, const rom_entry *start_entry) override;
+	virtual softlist_type get_softlist_type() const override { return softlist_type::ROM; }
 
 	virtual iodevice_t image_type() const override { return IO_CARTSLOT; }
 	virtual bool is_readable()  const override { return 1; }

--- a/src/devices/bus/nes/nes_slot.cpp
+++ b/src/devices/bus/nes/nes_slot.cpp
@@ -899,16 +899,6 @@ void nes_cart_slot_device::call_unload()
 
 
 /*-------------------------------------------------
- call softlist load
- -------------------------------------------------*/
-
-bool nes_cart_slot_device::call_softlist_load(software_list_device &swlist, const char *swname, const rom_entry *start_entry)
-{
-	machine().rom_load().load_software_part_region(*this, swlist, swname, start_entry);
-	return TRUE;
-}
-
-/*-------------------------------------------------
  get default card software
  -------------------------------------------------*/
 

--- a/src/devices/bus/nes/nes_slot.h
+++ b/src/devices/bus/nes/nes_slot.h
@@ -346,7 +346,7 @@ public:
 	// image-level overrides
 	virtual bool call_load() override;
 	virtual void call_unload() override;
-	virtual softlist_type get_softlist_type() const override { return softlist_type::ROM; }
+	virtual const software_list_loader &get_software_list_loader() const override { return rom_software_list_loader::instance(); }
 
 	void call_load_ines();
 	void call_load_unif();

--- a/src/devices/bus/nes/nes_slot.h
+++ b/src/devices/bus/nes/nes_slot.h
@@ -346,7 +346,7 @@ public:
 	// image-level overrides
 	virtual bool call_load() override;
 	virtual void call_unload() override;
-	virtual bool call_softlist_load(software_list_device &swlist, const char *swname, const rom_entry *start_entry) override;
+	virtual softlist_type get_softlist_type() const override { return softlist_type::ROM; }
 
 	void call_load_ines();
 	void call_load_unif();

--- a/src/devices/bus/nes/sunsoft_dcs.cpp
+++ b/src/devices/bus/nes/sunsoft_dcs.cpp
@@ -105,12 +105,6 @@ bool nes_ntb_slot_device::call_load()
 }
 
 
-bool nes_ntb_slot_device::call_softlist_load(software_list_device &swlist, const char *swname, const rom_entry *start_entry)
-{
-	machine().rom_load().load_software_part_region(*this, swlist, swname, start_entry );
-	return TRUE;
-}
-
 std::string nes_ntb_slot_device::get_default_card_software()
 {
 	return software_get_default_slot("ntbrom");

--- a/src/devices/bus/nes/sunsoft_dcs.h
+++ b/src/devices/bus/nes/sunsoft_dcs.h
@@ -48,7 +48,7 @@ public:
 
 	// image-level overrides
 	virtual bool call_load() override;
-	virtual bool call_softlist_load(software_list_device &swlist, const char *swname, const rom_entry *start_entry) override;
+	virtual softlist_type get_softlist_type() const override { return softlist_type::ROM; }
 
 	virtual iodevice_t image_type() const override { return IO_CARTSLOT; }
 	virtual bool is_readable()  const override { return 1; }

--- a/src/devices/bus/nes/sunsoft_dcs.h
+++ b/src/devices/bus/nes/sunsoft_dcs.h
@@ -48,7 +48,7 @@ public:
 
 	// image-level overrides
 	virtual bool call_load() override;
-	virtual softlist_type get_softlist_type() const override { return softlist_type::ROM; }
+	virtual const software_list_loader &get_software_list_loader() const override { return rom_software_list_loader::instance(); }
 
 	virtual iodevice_t image_type() const override { return IO_CARTSLOT; }
 	virtual bool is_readable()  const override { return 1; }

--- a/src/devices/bus/odyssey2/slot.cpp
+++ b/src/devices/bus/odyssey2/slot.cpp
@@ -195,17 +195,6 @@ bool o2_cart_slot_device::call_load()
 
 
 /*-------------------------------------------------
- call softlist load
- -------------------------------------------------*/
-
-bool o2_cart_slot_device::call_softlist_load(software_list_device &swlist, const char *swname, const rom_entry *start_entry)
-{
-	machine().rom_load().load_software_part_region(*this, swlist, swname, start_entry);
-	return TRUE;
-}
-
-
-/*-------------------------------------------------
  get default card software
  -------------------------------------------------*/
 

--- a/src/devices/bus/odyssey2/slot.h
+++ b/src/devices/bus/odyssey2/slot.h
@@ -69,7 +69,7 @@ public:
 	// image-level overrides
 	virtual bool call_load() override;
 	virtual void call_unload() override {}
-	virtual bool call_softlist_load(software_list_device &swlist, const char *swname, const rom_entry *start_entry) override;
+	virtual softlist_type get_softlist_type() const override { return softlist_type::ROM; }
 
 	int get_type() { return m_type; }
 

--- a/src/devices/bus/odyssey2/slot.h
+++ b/src/devices/bus/odyssey2/slot.h
@@ -69,7 +69,7 @@ public:
 	// image-level overrides
 	virtual bool call_load() override;
 	virtual void call_unload() override {}
-	virtual softlist_type get_softlist_type() const override { return softlist_type::ROM; }
+	virtual const software_list_loader &get_software_list_loader() const override { return rom_software_list_loader::instance(); }
 
 	int get_type() { return m_type; }
 

--- a/src/devices/bus/pce/pce_slot.cpp
+++ b/src/devices/bus/pce/pce_slot.cpp
@@ -295,18 +295,6 @@ void pce_cart_slot_device::call_unload()
 
 
 /*-------------------------------------------------
- call softlist load
- -------------------------------------------------*/
-
-bool pce_cart_slot_device::call_softlist_load(software_list_device &swlist, const char *swname, const rom_entry *start_entry)
-{
-	machine().rom_load().load_software_part_region(*this, swlist, swname, start_entry);
-	return TRUE;
-}
-
-
-
-/*-------------------------------------------------
  get_cart_type - code to detect NVRAM type from
  fullpath
  -------------------------------------------------*/

--- a/src/devices/bus/pce/pce_slot.h
+++ b/src/devices/bus/pce/pce_slot.h
@@ -68,7 +68,7 @@ public:
 	// image-level overrides
 	virtual bool call_load() override;
 	virtual void call_unload() override;
-	virtual softlist_type get_softlist_type() const override { return softlist_type::ROM; }
+	virtual const software_list_loader &get_software_list_loader() const override { return rom_software_list_loader::instance(); }
 
 	int get_type() { return m_type; }
 	int get_cart_type(UINT8 *ROM, UINT32 len);

--- a/src/devices/bus/pce/pce_slot.h
+++ b/src/devices/bus/pce/pce_slot.h
@@ -68,7 +68,7 @@ public:
 	// image-level overrides
 	virtual bool call_load() override;
 	virtual void call_unload() override;
-	virtual bool call_softlist_load(software_list_device &swlist, const char *swname, const rom_entry *start_entry) override;
+	virtual softlist_type get_softlist_type() const override { return softlist_type::ROM; }
 
 	int get_type() { return m_type; }
 	int get_cart_type(UINT8 *ROM, UINT32 len);

--- a/src/devices/bus/plus4/exp.cpp
+++ b/src/devices/bus/plus4/exp.cpp
@@ -142,18 +142,6 @@ bool plus4_expansion_slot_device::call_load()
 
 
 //-------------------------------------------------
-//  call_softlist_load -
-//-------------------------------------------------
-
-bool plus4_expansion_slot_device::call_softlist_load(software_list_device &swlist, const char *swname, const rom_entry *start_entry)
-{
-	machine().rom_load().load_software_part_region(*this, swlist, swname, start_entry);
-
-	return true;
-}
-
-
-//-------------------------------------------------
 //  get_default_card_software -
 //-------------------------------------------------
 

--- a/src/devices/bus/plus4/exp.h
+++ b/src/devices/bus/plus4/exp.h
@@ -121,7 +121,7 @@ protected:
 
 	// image-level overrides
 	virtual bool call_load() override;
-	virtual bool call_softlist_load(software_list_device &swlist, const char *swname, const rom_entry *start_entry) override;
+	virtual softlist_type get_softlist_type() const override { return softlist_type::ROM; }
 
 	virtual iodevice_t image_type() const override { return IO_CARTSLOT; }
 

--- a/src/devices/bus/plus4/exp.h
+++ b/src/devices/bus/plus4/exp.h
@@ -121,7 +121,7 @@ protected:
 
 	// image-level overrides
 	virtual bool call_load() override;
-	virtual softlist_type get_softlist_type() const override { return softlist_type::ROM; }
+	virtual const software_list_loader &get_software_list_loader() const override { return rom_software_list_loader::instance(); }
 
 	virtual iodevice_t image_type() const override { return IO_CARTSLOT; }
 

--- a/src/devices/bus/ql/rom.cpp
+++ b/src/devices/bus/ql/rom.cpp
@@ -99,18 +99,6 @@ bool ql_rom_cartridge_slot_t::call_load()
 
 
 //-------------------------------------------------
-//  call_softlist_load -
-//-------------------------------------------------
-
-bool ql_rom_cartridge_slot_t::call_softlist_load(software_list_device &swlist, const char *swname, const rom_entry *start_entry)
-{
-	machine().rom_load().load_software_part_region(*this, swlist, swname, start_entry);
-
-	return true;
-}
-
-
-//-------------------------------------------------
 //  get_default_card_software -
 //-------------------------------------------------
 

--- a/src/devices/bus/ql/rom.h
+++ b/src/devices/bus/ql/rom.h
@@ -96,7 +96,7 @@ protected:
 
 	// image-level overrides
 	virtual bool call_load() override;
-	virtual bool call_softlist_load(software_list_device &swlist, const char *swname, const rom_entry *start_entry) override;
+	virtual softlist_type get_softlist_type() const override { return softlist_type::ROM; }
 
 	virtual iodevice_t image_type() const override { return IO_CARTSLOT; }
 

--- a/src/devices/bus/ql/rom.h
+++ b/src/devices/bus/ql/rom.h
@@ -96,7 +96,7 @@ protected:
 
 	// image-level overrides
 	virtual bool call_load() override;
-	virtual softlist_type get_softlist_type() const override { return softlist_type::ROM; }
+	virtual const software_list_loader &get_software_list_loader() const override { return rom_software_list_loader::instance(); }
 
 	virtual iodevice_t image_type() const override { return IO_CARTSLOT; }
 

--- a/src/devices/bus/saturn/sat_slot.cpp
+++ b/src/devices/bus/saturn/sat_slot.cpp
@@ -205,17 +205,6 @@ void sat_cart_slot_device::call_unload()
 
 
 /*-------------------------------------------------
- call softlist load
- -------------------------------------------------*/
-
-bool sat_cart_slot_device::call_softlist_load(software_list_device &swlist, const char *swname, const rom_entry *start_entry)
-{
-	machine().rom_load().load_software_part_region(*this, swlist, swname, start_entry);
-	return TRUE;
-}
-
-
-/*-------------------------------------------------
  get default card software
  -------------------------------------------------*/
 

--- a/src/devices/bus/saturn/sat_slot.h
+++ b/src/devices/bus/saturn/sat_slot.h
@@ -74,7 +74,7 @@ public:
 	// image-level overrides
 	virtual bool call_load() override;
 	virtual void call_unload() override;
-	virtual softlist_type get_softlist_type() const override { return softlist_type::ROM; }
+	virtual const software_list_loader &get_software_list_loader() const override { return rom_software_list_loader::instance(); }
 
 	int get_cart_type();
 

--- a/src/devices/bus/saturn/sat_slot.h
+++ b/src/devices/bus/saturn/sat_slot.h
@@ -74,7 +74,7 @@ public:
 	// image-level overrides
 	virtual bool call_load() override;
 	virtual void call_unload() override;
-	virtual bool call_softlist_load(software_list_device &swlist, const char *swname, const rom_entry *start_entry) override;
+	virtual softlist_type get_softlist_type() const override { return softlist_type::ROM; }
 
 	int get_cart_type();
 

--- a/src/devices/bus/scv/slot.cpp
+++ b/src/devices/bus/scv/slot.cpp
@@ -211,18 +211,6 @@ bool scv_cart_slot_device::call_load()
 
 
 /*-------------------------------------------------
- call softlist load
- -------------------------------------------------*/
-
-bool scv_cart_slot_device::call_softlist_load(software_list_device &swlist, const char *swname, const rom_entry *start_entry)
-{
-	machine().rom_load().load_software_part_region(*this, swlist, swname, start_entry);
-	return TRUE;
-}
-
-
-
-/*-------------------------------------------------
  get_cart_type - code to detect NVRAM type from
  fullpath
  -------------------------------------------------*/

--- a/src/devices/bus/scv/slot.h
+++ b/src/devices/bus/scv/slot.h
@@ -70,7 +70,7 @@ public:
 	// image-level overrides
 	virtual bool call_load() override;
 	virtual void call_unload() override {}
-	virtual bool call_softlist_load(software_list_device &swlist, const char *swname, const rom_entry *start_entry) override;
+	virtual softlist_type get_softlist_type() const override { return softlist_type::ROM; }
 
 	int get_type() { return m_type; }
 	int get_cart_type(UINT8 *ROM, UINT32 len);

--- a/src/devices/bus/scv/slot.h
+++ b/src/devices/bus/scv/slot.h
@@ -70,7 +70,7 @@ public:
 	// image-level overrides
 	virtual bool call_load() override;
 	virtual void call_unload() override {}
-	virtual softlist_type get_softlist_type() const override { return softlist_type::ROM; }
+	virtual const software_list_loader &get_software_list_loader() const override { return rom_software_list_loader::instance(); }
 
 	int get_type() { return m_type; }
 	int get_cart_type(UINT8 *ROM, UINT32 len);

--- a/src/devices/bus/sega8/sega8_slot.cpp
+++ b/src/devices/bus/sega8/sega8_slot.cpp
@@ -415,17 +415,6 @@ void sega8_cart_slot_device::call_unload()
 }
 
 
-/*-------------------------------------------------
- call softlist load
- -------------------------------------------------*/
-
-bool sega8_cart_slot_device::call_softlist_load(software_list_device &swlist, const char *swname, const rom_entry *start_entry)
-{
-	machine().rom_load().load_software_part_region(*this, swlist, swname, start_entry);
-	return TRUE;
-}
-
-
 #ifdef UNUSED_FUNCTION
 // For the moment we switch to a different detection routine which allows to detect
 // in a single run Codemasters mapper, Korean mapper (including Jang Pung 3 which

--- a/src/devices/bus/sega8/sega8_slot.h
+++ b/src/devices/bus/sega8/sega8_slot.h
@@ -110,7 +110,7 @@ public:
 	// image-level overrides
 	virtual bool call_load() override;
 	virtual void call_unload() override;
-	virtual softlist_type get_softlist_type() const override { return softlist_type::ROM; }
+	virtual const software_list_loader &get_software_list_loader() const override { return rom_software_list_loader::instance(); }
 
 	int get_type() { return m_type; }
 	int get_cart_type(UINT8 *ROM, UINT32 len);

--- a/src/devices/bus/sega8/sega8_slot.h
+++ b/src/devices/bus/sega8/sega8_slot.h
@@ -110,7 +110,7 @@ public:
 	// image-level overrides
 	virtual bool call_load() override;
 	virtual void call_unload() override;
-	virtual bool call_softlist_load(software_list_device &swlist, const char *swname, const rom_entry *start_entry) override;
+	virtual softlist_type get_softlist_type() const override { return softlist_type::ROM; }
 
 	int get_type() { return m_type; }
 	int get_cart_type(UINT8 *ROM, UINT32 len);

--- a/src/devices/bus/snes/snes_slot.cpp
+++ b/src/devices/bus/snes/snes_slot.cpp
@@ -880,16 +880,6 @@ void base_sns_cart_slot_device::setup_nvram()
 
 
 
-/*-------------------------------------------------
- call softlist load
- -------------------------------------------------*/
-
-bool base_sns_cart_slot_device::call_softlist_load(software_list_device &swlist, const char *swname, const rom_entry *start_entry)
-{
-	machine().rom_load().load_software_part_region(*this, swlist, swname, start_entry );
-	return TRUE;
-}
-
 void base_sns_cart_slot_device::get_cart_type_addon(UINT8 *ROM, UINT32 len, int &type, int &addon)
 {
 	// First, look if the cart is HiROM or LoROM (and set snes_cart accordingly)

--- a/src/devices/bus/snes/snes_slot.h
+++ b/src/devices/bus/snes/snes_slot.h
@@ -159,7 +159,7 @@ public:
 	// image-level overrides
 	virtual bool call_load() override;
 	virtual void call_unload() override;
-	virtual bool call_softlist_load(software_list_device &swlist, const char *swname, const rom_entry *start_entry) override;
+	virtual softlist_type get_softlist_type() const override { return softlist_type::ROM; }
 
 	void get_cart_type_addon(UINT8 *ROM, UINT32 len, int &type, int &addon);
 	UINT32 snes_skip_header(UINT8 *ROM, UINT32 snes_rom_size);

--- a/src/devices/bus/snes/snes_slot.h
+++ b/src/devices/bus/snes/snes_slot.h
@@ -159,7 +159,7 @@ public:
 	// image-level overrides
 	virtual bool call_load() override;
 	virtual void call_unload() override;
-	virtual softlist_type get_softlist_type() const override { return softlist_type::ROM; }
+	virtual const software_list_loader &get_software_list_loader() const override { return rom_software_list_loader::instance(); }
 
 	void get_cart_type_addon(UINT8 *ROM, UINT32 len, int &type, int &addon);
 	UINT32 snes_skip_header(UINT8 *ROM, UINT32 snes_rom_size);

--- a/src/devices/bus/ti99x/gromport.cpp
+++ b/src/devices/bus/ti99x/gromport.cpp
@@ -1417,13 +1417,11 @@ void ti99_cartridge_device::set_slot(int i)
 	m_slot = i;
 }
 
-bool ti99_cartridge_device::call_softlist_load(software_list_device &swlist, const char *swname, const rom_entry *start_entry)
+void ti99_cartridge_device::loaded_through_softlist()
 {
-	if (TRACE_CONFIG) logerror("swlist = %s, swname = %s\n", swlist.list_name(), swname);
-	machine().rom_load().load_software_part_region(*this, swlist, swname, start_entry);
+	// TI99 cartridge seems to be the only reason we need loaded_through_softlist()... why?
 	m_softlist = true;
 	m_rpk = nullptr;
-	return true;
 }
 
 READ8Z_MEMBER(ti99_cartridge_device::readz)

--- a/src/devices/bus/ti99x/gromport.h
+++ b/src/devices/bus/ti99x/gromport.h
@@ -108,7 +108,7 @@ protected:
 	// Image handling: implementation of methods which are abstract in the parent
 	bool call_load() override;
 	void call_unload() override;
-	virtual softlist_type get_softlist_type() const override { return softlist_type::ROM; }
+	virtual const software_list_loader &get_software_list_loader() const override { return rom_software_list_loader::instance(); }
 	virtual void loaded_through_softlist() override;
 
 	void prepare_cartridge();

--- a/src/devices/bus/ti99x/gromport.h
+++ b/src/devices/bus/ti99x/gromport.h
@@ -108,7 +108,8 @@ protected:
 	// Image handling: implementation of methods which are abstract in the parent
 	bool call_load() override;
 	void call_unload() override;
-	bool call_softlist_load(software_list_device &swlist, const char *swname, const rom_entry *start_entry) override;
+	virtual softlist_type get_softlist_type() const override { return softlist_type::ROM; }
+	virtual void loaded_through_softlist() override;
 
 	void prepare_cartridge();
 

--- a/src/devices/bus/vboy/slot.cpp
+++ b/src/devices/bus/vboy/slot.cpp
@@ -218,18 +218,6 @@ void vboy_cart_slot_device::call_unload()
 }
 
 /*-------------------------------------------------
- call softlist load
- -------------------------------------------------*/
-
-bool vboy_cart_slot_device::call_softlist_load(software_list_device &swlist, const char *swname, const rom_entry *start_entry)
-{
-	machine().rom_load().load_software_part_region(*this, swlist, swname, start_entry);
-	return TRUE;
-}
-
-
-
-/*-------------------------------------------------
  get default card software
  -------------------------------------------------*/
 

--- a/src/devices/bus/vboy/slot.h
+++ b/src/devices/bus/vboy/slot.h
@@ -66,7 +66,7 @@ public:
 	// image-level overrides
 	virtual bool call_load() override;
 	virtual void call_unload() override;
-	virtual softlist_type get_softlist_type() const override { return softlist_type::ROM; }
+	virtual const software_list_loader &get_software_list_loader() const override { return rom_software_list_loader::instance(); }
 
 	int get_type() { return m_type; }
 

--- a/src/devices/bus/vboy/slot.h
+++ b/src/devices/bus/vboy/slot.h
@@ -66,7 +66,7 @@ public:
 	// image-level overrides
 	virtual bool call_load() override;
 	virtual void call_unload() override;
-	virtual bool call_softlist_load(software_list_device &swlist, const char *swname, const rom_entry *start_entry) override;
+	virtual softlist_type get_softlist_type() const override { return softlist_type::ROM; }
 
 	int get_type() { return m_type; }
 

--- a/src/devices/bus/vc4000/slot.cpp
+++ b/src/devices/bus/vc4000/slot.cpp
@@ -221,17 +221,6 @@ bool vc4000_cart_slot_device::call_load()
 
 
 /*-------------------------------------------------
- call softlist load
- -------------------------------------------------*/
-
-bool vc4000_cart_slot_device::call_softlist_load(software_list_device &swlist, const char *swname, const rom_entry *start_entry)
-{
-	machine().rom_load().load_software_part_region(*this, swlist, swname, start_entry);
-	return TRUE;
-}
-
-
-/*-------------------------------------------------
  get default card software
  -------------------------------------------------*/
 

--- a/src/devices/bus/vc4000/slot.h
+++ b/src/devices/bus/vc4000/slot.h
@@ -68,7 +68,7 @@ public:
 	// image-level overrides
 	virtual bool call_load() override;
 	virtual void call_unload() override {}
-	virtual softlist_type get_softlist_type() const override { return softlist_type::ROM; }
+	virtual const software_list_loader &get_software_list_loader() const override { return rom_software_list_loader::instance(); }
 
 	int get_type() { return m_type; }
 

--- a/src/devices/bus/vc4000/slot.h
+++ b/src/devices/bus/vc4000/slot.h
@@ -68,7 +68,7 @@ public:
 	// image-level overrides
 	virtual bool call_load() override;
 	virtual void call_unload() override {}
-	virtual bool call_softlist_load(software_list_device &swlist, const char *swname, const rom_entry *start_entry) override;
+	virtual softlist_type get_softlist_type() const override { return softlist_type::ROM; }
 
 	int get_type() { return m_type; }
 

--- a/src/devices/bus/vcs/vcs_slot.cpp
+++ b/src/devices/bus/vcs/vcs_slot.cpp
@@ -328,17 +328,6 @@ void vcs_cart_slot_device::call_unload()
 
 
 /*-------------------------------------------------
- call softlist load
- -------------------------------------------------*/
-
-bool vcs_cart_slot_device::call_softlist_load(software_list_device &swlist, const char *swname, const rom_entry *start_entry)
-{
-	machine().rom_load().load_software_part_region(*this, swlist, swname, start_entry );
-	return TRUE;
-}
-
-
-/*-------------------------------------------------
   detection helper routines
  -------------------------------------------------*/
 

--- a/src/devices/bus/vcs/vcs_slot.h
+++ b/src/devices/bus/vcs/vcs_slot.h
@@ -96,7 +96,7 @@ public:
 	// image-level overrides
 	virtual bool call_load() override;
 	virtual void call_unload() override;
-	virtual softlist_type get_softlist_type() const override { return softlist_type::ROM; }
+	virtual const software_list_loader &get_software_list_loader() const override { return rom_software_list_loader::instance(); }
 
 	int get_cart_type() { return m_type; };
 	int identify_cart_type(UINT8 *ROM, UINT32 len);

--- a/src/devices/bus/vcs/vcs_slot.h
+++ b/src/devices/bus/vcs/vcs_slot.h
@@ -96,7 +96,7 @@ public:
 	// image-level overrides
 	virtual bool call_load() override;
 	virtual void call_unload() override;
-	virtual bool call_softlist_load(software_list_device &swlist, const char *swname, const rom_entry *start_entry) override;
+	virtual softlist_type get_softlist_type() const override { return softlist_type::ROM; }
 
 	int get_cart_type() { return m_type; };
 	int identify_cart_type(UINT8 *ROM, UINT32 len);

--- a/src/devices/bus/vectrex/slot.cpp
+++ b/src/devices/bus/vectrex/slot.cpp
@@ -203,17 +203,6 @@ bool vectrex_cart_slot_device::call_load()
 
 
 /*-------------------------------------------------
- call softlist load
- -------------------------------------------------*/
-
-bool vectrex_cart_slot_device::call_softlist_load(software_list_device &swlist, const char *swname, const rom_entry *start_entry)
-{
-	machine().rom_load().load_software_part_region(*this, swlist, swname, start_entry);
-	return TRUE;
-}
-
-
-/*-------------------------------------------------
  get default card software
  -------------------------------------------------*/
 

--- a/src/devices/bus/vectrex/slot.h
+++ b/src/devices/bus/vectrex/slot.h
@@ -68,7 +68,7 @@ public:
 	// image-level overrides
 	virtual bool call_load() override;
 	virtual void call_unload() override {}
-	virtual softlist_type get_softlist_type() const override { return softlist_type::ROM; }
+	virtual const software_list_loader &get_software_list_loader() const override { return rom_software_list_loader::instance(); }
 
 	int get_type() { return m_type; }
 	int get_vec3d() { return m_vec3d; }

--- a/src/devices/bus/vectrex/slot.h
+++ b/src/devices/bus/vectrex/slot.h
@@ -68,7 +68,7 @@ public:
 	// image-level overrides
 	virtual bool call_load() override;
 	virtual void call_unload() override {}
-	virtual bool call_softlist_load(software_list_device &swlist, const char *swname, const rom_entry *start_entry) override;
+	virtual softlist_type get_softlist_type() const override { return softlist_type::ROM; }
 
 	int get_type() { return m_type; }
 	int get_vec3d() { return m_vec3d; }

--- a/src/devices/bus/vic10/exp.cpp
+++ b/src/devices/bus/vic10/exp.cpp
@@ -167,18 +167,6 @@ bool vic10_expansion_slot_device::call_load()
 
 
 //-------------------------------------------------
-//  call_softlist_load -
-//-------------------------------------------------
-
-bool vic10_expansion_slot_device::call_softlist_load(software_list_device &swlist, const char *swname, const rom_entry *start_entry)
-{
-	machine().rom_load().load_software_part_region(*this, swlist, swname, start_entry);
-
-	return true;
-}
-
-
-//-------------------------------------------------
 //  get_default_card_software -
 //-------------------------------------------------
 

--- a/src/devices/bus/vic10/exp.h
+++ b/src/devices/bus/vic10/exp.h
@@ -120,7 +120,7 @@ protected:
 
 	// image-level overrides
 	virtual bool call_load() override;
-	virtual bool call_softlist_load(software_list_device &swlist, const char *swname, const rom_entry *start_entry) override;
+	virtual softlist_type get_softlist_type() const override { return softlist_type::ROM; }
 
 	virtual iodevice_t image_type() const override { return IO_CARTSLOT; }
 

--- a/src/devices/bus/vic10/exp.h
+++ b/src/devices/bus/vic10/exp.h
@@ -120,7 +120,7 @@ protected:
 
 	// image-level overrides
 	virtual bool call_load() override;
-	virtual softlist_type get_softlist_type() const override { return softlist_type::ROM; }
+	virtual const software_list_loader &get_software_list_loader() const override { return rom_software_list_loader::instance(); }
 
 	virtual iodevice_t image_type() const override { return IO_CARTSLOT; }
 

--- a/src/devices/bus/vic20/exp.cpp
+++ b/src/devices/bus/vic20/exp.cpp
@@ -152,18 +152,6 @@ bool vic20_expansion_slot_device::call_load()
 
 
 //-------------------------------------------------
-//  call_softlist_load -
-//-------------------------------------------------
-
-bool vic20_expansion_slot_device::call_softlist_load(software_list_device &swlist, const char *swname, const rom_entry *start_entry)
-{
-	machine().rom_load().load_software_part_region(*this, swlist, swname, start_entry);
-
-	return true;
-}
-
-
-//-------------------------------------------------
 //  get_default_card_software -
 //-------------------------------------------------
 

--- a/src/devices/bus/vic20/exp.h
+++ b/src/devices/bus/vic20/exp.h
@@ -111,7 +111,7 @@ protected:
 
 	// image-level overrides
 	virtual bool call_load() override;
-	virtual softlist_type get_softlist_type() const override { return softlist_type::ROM; }
+	virtual const software_list_loader &get_software_list_loader() const override { return rom_software_list_loader::instance(); }
 
 	virtual iodevice_t image_type() const override { return IO_CARTSLOT; }
 

--- a/src/devices/bus/vic20/exp.h
+++ b/src/devices/bus/vic20/exp.h
@@ -111,7 +111,7 @@ protected:
 
 	// image-level overrides
 	virtual bool call_load() override;
-	virtual bool call_softlist_load(software_list_device &swlist, const char *swname, const rom_entry *start_entry) override;
+	virtual softlist_type get_softlist_type() const override { return softlist_type::ROM; }
 
 	virtual iodevice_t image_type() const override { return IO_CARTSLOT; }
 

--- a/src/devices/bus/vidbrain/exp.cpp
+++ b/src/devices/bus/vidbrain/exp.cpp
@@ -139,18 +139,6 @@ bool videobrain_expansion_slot_device::call_load()
 
 
 //-------------------------------------------------
-//  call_softlist_load -
-//-------------------------------------------------
-
-bool videobrain_expansion_slot_device::call_softlist_load(software_list_device &swlist, const char *swname, const rom_entry *start_entry)
-{
-	machine().rom_load().load_software_part_region(*this, swlist, swname, start_entry);
-
-	return true;
-}
-
-
-//-------------------------------------------------
 //  get_default_card_software -
 //-------------------------------------------------
 

--- a/src/devices/bus/vidbrain/exp.h
+++ b/src/devices/bus/vidbrain/exp.h
@@ -136,7 +136,7 @@ protected:
 
 	// image-level overrides
 	virtual bool call_load() override;
-	virtual bool call_softlist_load(software_list_device &swlist, const char *swname, const rom_entry *start_entry) override;
+	virtual softlist_type get_softlist_type() const override { return softlist_type::ROM; }
 
 	virtual iodevice_t image_type() const override { return IO_CARTSLOT; }
 

--- a/src/devices/bus/vidbrain/exp.h
+++ b/src/devices/bus/vidbrain/exp.h
@@ -136,7 +136,7 @@ protected:
 
 	// image-level overrides
 	virtual bool call_load() override;
-	virtual softlist_type get_softlist_type() const override { return softlist_type::ROM; }
+	virtual const software_list_loader &get_software_list_loader() const override { return rom_software_list_loader::instance(); }
 
 	virtual iodevice_t image_type() const override { return IO_CARTSLOT; }
 

--- a/src/devices/bus/wswan/slot.cpp
+++ b/src/devices/bus/wswan/slot.cpp
@@ -238,17 +238,6 @@ void ws_cart_slot_device::call_unload()
 
 
 /*-------------------------------------------------
- call softlist load
- -------------------------------------------------*/
-
-bool ws_cart_slot_device::call_softlist_load(software_list_device &swlist, const char *swname, const rom_entry *start_entry)
-{
-	machine().rom_load().load_software_part_region(*this, swlist, swname, start_entry);
-	return TRUE;
-}
-
-
-/*-------------------------------------------------
  get cart type from cart file
  -------------------------------------------------*/
 

--- a/src/devices/bus/wswan/slot.h
+++ b/src/devices/bus/wswan/slot.h
@@ -76,7 +76,7 @@ public:
 	// image-level overrides
 	virtual bool call_load() override;
 	virtual void call_unload() override;
-	virtual bool call_softlist_load(software_list_device &swlist, const char *swname, const rom_entry *start_entry) override;
+	virtual softlist_type get_softlist_type() const override { return softlist_type::ROM; }
 
 	int get_type() { return m_type; }
 	int get_is_rotated() { return m_cart->get_is_rotated(); }

--- a/src/devices/bus/wswan/slot.h
+++ b/src/devices/bus/wswan/slot.h
@@ -76,7 +76,7 @@ public:
 	// image-level overrides
 	virtual bool call_load() override;
 	virtual void call_unload() override;
-	virtual softlist_type get_softlist_type() const override { return softlist_type::ROM; }
+	virtual const software_list_loader &get_software_list_loader() const override { return rom_software_list_loader::instance(); }
 
 	int get_type() { return m_type; }
 	int get_is_rotated() { return m_cart->get_is_rotated(); }

--- a/src/devices/bus/z88/z88.cpp
+++ b/src/devices/bus/z88/z88.cpp
@@ -172,16 +172,6 @@ void z88cart_slot_device::call_unload()
 
 
 /*-------------------------------------------------
-    call softlist load
--------------------------------------------------*/
-
-bool z88cart_slot_device::call_softlist_load(software_list_device &swlist, const char *swname, const rom_entry *start_entry)
-{
-	machine().rom_load().load_software_part_region(*this, swlist, swname, start_entry );
-	return TRUE;
-}
-
-/*-------------------------------------------------
     get default card software
 -------------------------------------------------*/
 

--- a/src/devices/bus/z88/z88.h
+++ b/src/devices/bus/z88/z88.h
@@ -96,7 +96,7 @@ public:
 	// image-level overrides
 	virtual bool call_load() override;
 	virtual void call_unload() override;
-	virtual bool call_softlist_load(software_list_device &swlist, const char *swname, const rom_entry *start_entry) override;
+	virtual softlist_type get_softlist_type() const override { return softlist_type::ROM; }
 
 	virtual iodevice_t image_type() const override { return IO_CARTSLOT; }
 	virtual bool is_readable()  const override { return 1; }

--- a/src/devices/bus/z88/z88.h
+++ b/src/devices/bus/z88/z88.h
@@ -96,7 +96,7 @@ public:
 	// image-level overrides
 	virtual bool call_load() override;
 	virtual void call_unload() override;
-	virtual softlist_type get_softlist_type() const override { return softlist_type::ROM; }
+	virtual const software_list_loader &get_software_list_loader() const override { return rom_software_list_loader::instance(); }
 
 	virtual iodevice_t image_type() const override { return IO_CARTSLOT; }
 	virtual bool is_readable()  const override { return 1; }

--- a/src/devices/imagedev/cassette.h
+++ b/src/devices/imagedev/cassette.h
@@ -59,7 +59,7 @@ public:
 	virtual bool call_create(int format_type, util::option_resolution *format_options) override;
 	virtual void call_unload() override;
 	virtual std::string call_display() override;
-	virtual bool call_softlist_load(software_list_device &swlist, const char *swname, const rom_entry *start_entry) override { return load_software(swlist, swname, start_entry); }
+	virtual softlist_type get_softlist_type() const override { return softlist_type::SOFTWARE; }
 
 	virtual iodevice_t image_type() const override { return IO_CASSETTE; }
 

--- a/src/devices/imagedev/cassette.h
+++ b/src/devices/imagedev/cassette.h
@@ -59,7 +59,7 @@ public:
 	virtual bool call_create(int format_type, util::option_resolution *format_options) override;
 	virtual void call_unload() override;
 	virtual std::string call_display() override;
-	virtual softlist_type get_softlist_type() const override { return softlist_type::SOFTWARE; }
+	virtual const software_list_loader &get_software_list_loader() const override { return image_software_list_loader::instance(); }
 
 	virtual iodevice_t image_type() const override { return IO_CASSETTE; }
 

--- a/src/devices/imagedev/chd_cd.h
+++ b/src/devices/imagedev/chd_cd.h
@@ -33,7 +33,7 @@ public:
 	// image-level overrides
 	virtual bool call_load() override;
 	virtual void call_unload() override;
-	virtual bool call_softlist_load(software_list_device &swlist, const char *swname, const rom_entry *start_entry) override { machine().rom_load().load_software_part_region(*this, swlist, swname, start_entry ); return TRUE; }
+	virtual softlist_type get_softlist_type() const override { return softlist_type::ROM; }
 
 	virtual iodevice_t image_type() const override { return IO_CDROM; }
 

--- a/src/devices/imagedev/chd_cd.h
+++ b/src/devices/imagedev/chd_cd.h
@@ -33,7 +33,7 @@ public:
 	// image-level overrides
 	virtual bool call_load() override;
 	virtual void call_unload() override;
-	virtual softlist_type get_softlist_type() const override { return softlist_type::ROM; }
+	virtual const software_list_loader &get_software_list_loader() const override { return rom_software_list_loader::instance(); }
 
 	virtual iodevice_t image_type() const override { return IO_CDROM; }
 

--- a/src/devices/imagedev/diablo.h
+++ b/src/devices/imagedev/diablo.h
@@ -33,7 +33,7 @@ public:
 	virtual bool call_load() override;
 	virtual bool call_create(int create_format, util::option_resolution *create_args) override;
 	virtual void call_unload() override;
-	virtual bool call_softlist_load(software_list_device &swlist, const char *swname, const rom_entry *start_entry) override { device().machine().rom_load().load_software_part_region(*this, swlist, swname, start_entry ); return TRUE; }
+	virtual softlist_type get_softlist_type() const override { return softlist_type::ROM; }
 
 	virtual iodevice_t image_type() const override { return IO_HARDDISK; }
 

--- a/src/devices/imagedev/diablo.h
+++ b/src/devices/imagedev/diablo.h
@@ -33,7 +33,7 @@ public:
 	virtual bool call_load() override;
 	virtual bool call_create(int create_format, util::option_resolution *create_args) override;
 	virtual void call_unload() override;
-	virtual softlist_type get_softlist_type() const override { return softlist_type::ROM; }
+	virtual const software_list_loader &get_software_list_loader() const override { return rom_software_list_loader::instance(); }
 
 	virtual iodevice_t image_type() const override { return IO_HARDDISK; }
 

--- a/src/devices/imagedev/flopdrv.h
+++ b/src/devices/imagedev/flopdrv.h
@@ -100,7 +100,7 @@ public:
 	template<class _Object> static devcb_base &set_out_idx_func(device_t &device, _Object object) { return downcast<legacy_floppy_image_device &>(device).m_out_idx_func.set_callback(object); }
 
 	virtual bool call_load() override;
-	virtual softlist_type get_softlist_type() const override { return softlist_type::SOFTWARE; }
+	virtual const software_list_loader &get_software_list_loader() const override { return image_software_list_loader::instance(); }
 	virtual bool call_create(int format_type, util::option_resolution *format_options) override;
 	virtual void call_unload() override;
 

--- a/src/devices/imagedev/flopdrv.h
+++ b/src/devices/imagedev/flopdrv.h
@@ -100,7 +100,7 @@ public:
 	template<class _Object> static devcb_base &set_out_idx_func(device_t &device, _Object object) { return downcast<legacy_floppy_image_device &>(device).m_out_idx_func.set_callback(object); }
 
 	virtual bool call_load() override;
-	virtual bool call_softlist_load(software_list_device &swlist, const char *swname, const rom_entry *start_entry) override {   return load_software(swlist, swname, start_entry); }
+	virtual softlist_type get_softlist_type() const override { return softlist_type::SOFTWARE; }
 	virtual bool call_create(int format_type, util::option_resolution *format_options) override;
 	virtual void call_unload() override;
 

--- a/src/devices/imagedev/floppy.h
+++ b/src/devices/imagedev/floppy.h
@@ -83,7 +83,7 @@ public:
 	virtual bool call_load() override;
 	virtual void call_unload() override;
 	virtual bool call_create(int format_type, util::option_resolution *format_options) override;
-	virtual bool call_softlist_load(software_list_device &swlist, const char *swname, const rom_entry *start_entry) override { return load_software(swlist, swname, start_entry); }
+	virtual softlist_type get_softlist_type() const override { return softlist_type::SOFTWARE; }
 	virtual const char *image_interface() const override = 0;
 	virtual iodevice_t image_type() const override { return IO_FLOPPY; }
 

--- a/src/devices/imagedev/floppy.h
+++ b/src/devices/imagedev/floppy.h
@@ -83,7 +83,7 @@ public:
 	virtual bool call_load() override;
 	virtual void call_unload() override;
 	virtual bool call_create(int format_type, util::option_resolution *format_options) override;
-	virtual softlist_type get_softlist_type() const override { return softlist_type::SOFTWARE; }
+	virtual const software_list_loader &get_software_list_loader() const override { return image_software_list_loader::instance(); }
 	virtual const char *image_interface() const override = 0;
 	virtual iodevice_t image_type() const override { return IO_FLOPPY; }
 

--- a/src/devices/imagedev/harddriv.h
+++ b/src/devices/imagedev/harddriv.h
@@ -35,7 +35,7 @@ public:
 	virtual bool call_load() override;
 	virtual bool call_create(int create_format, util::option_resolution *create_args) override;
 	virtual void call_unload() override;
-	virtual softlist_type get_softlist_type() const override { return softlist_type::ROM; }
+	virtual const software_list_loader &get_software_list_loader() const override { return rom_software_list_loader::instance(); }
 
 	virtual iodevice_t image_type() const override { return IO_HARDDISK; }
 

--- a/src/devices/imagedev/harddriv.h
+++ b/src/devices/imagedev/harddriv.h
@@ -35,7 +35,7 @@ public:
 	virtual bool call_load() override;
 	virtual bool call_create(int create_format, util::option_resolution *create_args) override;
 	virtual void call_unload() override;
-	virtual bool call_softlist_load(software_list_device &swlist, const char *swname, const rom_entry *start_entry) override { machine().rom_load().load_software_part_region(*this, swlist, swname, start_entry ); return TRUE; }
+	virtual softlist_type get_softlist_type() const override { return softlist_type::ROM; }
 
 	virtual iodevice_t image_type() const override { return IO_HARDDISK; }
 

--- a/src/devices/imagedev/snapquik.h
+++ b/src/devices/imagedev/snapquik.h
@@ -27,7 +27,7 @@ public:
 
 	// image-level overrides
 	virtual bool call_load() override;
-	virtual softlist_type get_softlist_type() const override { return softlist_type::SOFTWARE; }
+	virtual const software_list_loader &get_software_list_loader() const override { return image_software_list_loader::instance(); }
 	virtual iodevice_t image_type() const override { return IO_SNAPSHOT; }
 
 	virtual bool is_readable()  const override { return 1; }

--- a/src/devices/imagedev/snapquik.h
+++ b/src/devices/imagedev/snapquik.h
@@ -27,7 +27,7 @@ public:
 
 	// image-level overrides
 	virtual bool call_load() override;
-	virtual bool call_softlist_load(software_list_device &swlist, const char *swname, const rom_entry *start_entry) override { return load_software(swlist, swname, start_entry); }
+	virtual softlist_type get_softlist_type() const override { return softlist_type::SOFTWARE; }
 	virtual iodevice_t image_type() const override { return IO_SNAPSHOT; }
 
 	virtual bool is_readable()  const override { return 1; }

--- a/src/devices/machine/smartmed.h
+++ b/src/devices/machine/smartmed.h
@@ -216,7 +216,7 @@ public:
 
 	virtual bool call_load() override;
 	virtual void call_unload() override;
-	virtual bool call_softlist_load(software_list_device &swlist, const char *swname, const rom_entry *start_entry) override { return load_software(swlist, swname, start_entry); }
+	virtual softlist_type get_softlist_type() const override { return softlist_type::SOFTWARE; }
 
 protected:
 	// device-level overrides

--- a/src/devices/machine/smartmed.h
+++ b/src/devices/machine/smartmed.h
@@ -216,7 +216,7 @@ public:
 
 	virtual bool call_load() override;
 	virtual void call_unload() override;
-	virtual softlist_type get_softlist_type() const override { return softlist_type::SOFTWARE; }
+	virtual const software_list_loader &get_software_list_loader() const override { return image_software_list_loader::instance(); }
 
 protected:
 	// device-level overrides

--- a/src/emu/diimage.cpp
+++ b/src/emu/diimage.cpp
@@ -1332,23 +1332,8 @@ const software_part *device_image_interface::find_software_item(const char *path
 
 bool device_image_interface::call_softlist_load(software_list_device &swlist, const char *swname, const rom_entry *start_entry)
 {
-	bool result = false;
-	switch (get_softlist_type())
-	{
-	case softlist_type::ROM:
-		device().machine().rom_load().load_software_part_region(*this, swlist, swname, start_entry);
-		result = true;
-		break;
-
-	case softlist_type::SOFTWARE:
-		result = load_software(swlist, swname, start_entry);
-		break;
-
-	case softlist_type::NONE:
-	default:
-		result = false;
-		break;		
-	}
+	const software_list_loader &loader = get_software_list_loader();
+	bool result = loader.load_software(*this, swlist, swname, start_entry);
 
 	// this is a hook that seems to only be used by TI99
 	if (result)

--- a/src/emu/diimage.cpp
+++ b/src/emu/diimage.cpp
@@ -1327,6 +1327,38 @@ const software_part *device_image_interface::find_software_item(const char *path
 
 
 //-------------------------------------------------
+//	call_softlist_load
+//-------------------------------------------------
+
+bool device_image_interface::call_softlist_load(software_list_device &swlist, const char *swname, const rom_entry *start_entry)
+{
+	bool result = false;
+	switch (get_softlist_type())
+	{
+	case softlist_type::ROM:
+		device().machine().rom_load().load_software_part_region(*this, swlist, swname, start_entry);
+		result = true;
+		break;
+
+	case softlist_type::SOFTWARE:
+		result = load_software(swlist, swname, start_entry);
+		break;
+
+	case softlist_type::NONE:
+	default:
+		result = false;
+		break;		
+	}
+
+	// this is a hook that seems to only be used by TI99
+	if (result)
+		loaded_through_softlist();
+
+	return result;
+}
+
+
+//-------------------------------------------------
 //  load_software_part
 //
 //  Load a software part for a device. The part to

--- a/src/emu/diimage.h
+++ b/src/emu/diimage.h
@@ -137,6 +137,13 @@ class device_image_interface : public device_interface
 public:
 	typedef std::vector<std::unique_ptr<image_device_format>> formatlist_type;
 
+	enum class softlist_type
+	{
+		NONE,
+		ROM,
+		SOFTWARE
+	};
+
 	// construction/destruction
 	device_image_interface(const machine_config &mconfig, device_t &device);
 	virtual ~device_image_interface();
@@ -148,7 +155,6 @@ public:
 	virtual void device_compute_hash(hash_collection &hashes, const void *data, size_t length, const char *types) const;
 
 	virtual bool call_load() { return FALSE; }
-	virtual bool call_softlist_load(software_list_device &swlist, const char *swname, const rom_entry *start_entry) { return FALSE; }
 	virtual bool call_create(int format_type, util::option_resolution *format_options) { return FALSE; }
 	virtual void call_unload() { }
 	virtual std::string call_display() { return std::string(); }
@@ -247,6 +253,9 @@ public:
 	bool user_loadable() const { return m_user_loadable; }
 
 protected:
+	virtual softlist_type get_softlist_type() const { return softlist_type::NONE; }
+	virtual void loaded_through_softlist() { }
+
 	bool load_internal(const char *path, bool is_create, int create_format, util::option_resolution *create_args, bool just_load);
 	void determine_open_plan(int is_create, UINT32 *open_plan);
 	image_error_t load_image_by_path(UINT32 open_flags, const char *path);
@@ -326,6 +335,9 @@ protected:
 	bool m_user_loadable;
 
 	bool m_is_loading;
+
+private:
+	bool call_softlist_load(software_list_device &swlist, const char *swname, const rom_entry *start_entry);
 };
 
 // iterator

--- a/src/emu/diimage.h
+++ b/src/emu/diimage.h
@@ -21,6 +21,8 @@
 #include <string>
 #include <vector>
 
+#include "softlist.h"
+
 
 //**************************************************************************
 //  TYPE DEFINITIONS
@@ -137,13 +139,6 @@ class device_image_interface : public device_interface
 public:
 	typedef std::vector<std::unique_ptr<image_device_format>> formatlist_type;
 
-	enum class softlist_type
-	{
-		NONE,
-		ROM,
-		SOFTWARE
-	};
-
 	// construction/destruction
 	device_image_interface(const machine_config &mconfig, device_t &device);
 	virtual ~device_image_interface();
@@ -253,7 +248,7 @@ public:
 	bool user_loadable() const { return m_user_loadable; }
 
 protected:
-	virtual softlist_type get_softlist_type() const { return softlist_type::NONE; }
+	virtual const software_list_loader &get_software_list_loader() const { return false_software_list_loader::instance(); }
 	virtual void loaded_through_softlist() { }
 
 	bool load_internal(const char *path, bool is_create, int create_format, util::option_resolution *create_args, bool just_load);

--- a/src/emu/softlist.cpp
+++ b/src/emu/softlist.cpp
@@ -91,7 +91,45 @@ private:
 
 // device type definition
 const device_type SOFTWARE_LIST = &device_creator<software_list_device>;
+false_software_list_loader false_software_list_loader::s_instance;
+rom_software_list_loader rom_software_list_loader::s_instance;
+image_software_list_loader image_software_list_loader::s_instance;
 
+
+
+//**************************************************************************
+//  SOFTWARE LIST LOADER
+//**************************************************************************
+
+//-------------------------------------------------
+//  false_software_list_loader::load_software
+//-------------------------------------------------
+
+bool false_software_list_loader::load_software(device_image_interface &device, software_list_device &swlist, const char *swname, const rom_entry *start_entry) const
+{
+	return false;
+}
+
+
+//-------------------------------------------------
+//  rom_software_list_loader::load_software
+//-------------------------------------------------
+
+bool rom_software_list_loader::load_software(device_image_interface &device, software_list_device &swlist, const char *swname, const rom_entry *start_entry) const
+{
+	swlist.machine().rom_load().load_software_part_region(device, swlist, swname, start_entry);
+	return true;
+}
+
+
+//-------------------------------------------------
+//  image_software_list_loader::load_software
+//-------------------------------------------------
+
+bool image_software_list_loader::load_software(device_image_interface &device, software_list_device &swlist, const char *swname, const rom_entry *start_entry) const
+{
+	return device.load_software(swlist, swname, start_entry);
+}
 
 
 //**************************************************************************

--- a/src/emu/softlist.h
+++ b/src/emu/softlist.h
@@ -73,6 +73,59 @@ enum software_compatibility
 //  TYPE DEFINITIONS
 //**************************************************************************
 
+struct rom_entry;
+class software_info;
+class device_image_interface;
+class software_list_device;
+
+// ======================> software_list_loader
+
+class software_list_loader
+{
+public:
+	virtual bool load_software(device_image_interface &device, software_list_device &swlist, const char *swname, const rom_entry *start_entry) const = 0;
+};
+
+
+// ======================> false_software_list_loader
+
+class false_software_list_loader : public software_list_loader
+{
+public:
+	virtual bool load_software(device_image_interface &device, software_list_device &swlist, const char *swname, const rom_entry *start_entry) const override;
+	static const software_list_loader &instance() { return s_instance; }
+
+private:
+	static false_software_list_loader s_instance;
+};
+
+
+// ======================> rom_software_list_loader
+
+class rom_software_list_loader : public software_list_loader
+{
+public:
+	virtual bool load_software(device_image_interface &device, software_list_device &swlist, const char *swname, const rom_entry *start_entry) const override;
+	static const software_list_loader &instance() { return s_instance; }
+
+private:
+	static rom_software_list_loader s_instance;
+};
+
+
+// ======================> image_software_list_loader
+
+class image_software_list_loader : public software_list_loader
+{
+public:
+	virtual bool load_software(device_image_interface &device, software_list_device &swlist, const char *swname, const rom_entry *start_entry) const override;
+	static const software_list_loader &instance() { return s_instance; }
+
+private:
+	static image_software_list_loader s_instance;
+};
+
+
 // ======================> feature_list_item
 
 // an item in a list of name/value pairs

--- a/src/mame/machine/microdrv.h
+++ b/src/mame/machine/microdrv.h
@@ -50,7 +50,7 @@ public:
 	// image-level overrides
 	virtual bool call_load() override;
 	virtual void call_unload() override;
-	virtual bool call_softlist_load(software_list_device &swlist, const char *swname, const rom_entry *start_entry) override { return load_software(swlist, swname, start_entry); }
+	virtual softlist_type get_softlist_type() const override { return softlist_type::SOFTWARE; }
 
 	virtual iodevice_t image_type() const override { return IO_CASSETTE; }
 

--- a/src/mame/machine/microdrv.h
+++ b/src/mame/machine/microdrv.h
@@ -50,7 +50,7 @@ public:
 	// image-level overrides
 	virtual bool call_load() override;
 	virtual void call_unload() override;
-	virtual softlist_type get_softlist_type() const override { return softlist_type::SOFTWARE; }
+	virtual const software_list_loader &get_software_list_loader() const override { return image_software_list_loader::instance(); }
 
 	virtual iodevice_t image_type() const override { return IO_CASSETTE; }
 

--- a/src/mame/machine/psion_pack.h
+++ b/src/mame/machine/psion_pack.h
@@ -28,7 +28,7 @@ public:
 	virtual bool call_load() override;
 	virtual void call_unload() override;
 	virtual bool call_create(int format_type, util::option_resolution *create_args) override;
-	virtual bool call_softlist_load(software_list_device &swlist, const char *swname, const rom_entry *start_entry) override { return load_software(swlist, swname, start_entry); }
+	virtual softlist_type get_softlist_type() const override { return softlist_type::SOFTWARE; }
 
 	virtual iodevice_t image_type() const override { return IO_CARTSLOT; }
 	virtual bool is_readable()  const override { return 1; }

--- a/src/mame/machine/psion_pack.h
+++ b/src/mame/machine/psion_pack.h
@@ -28,7 +28,7 @@ public:
 	virtual bool call_load() override;
 	virtual void call_unload() override;
 	virtual bool call_create(int format_type, util::option_resolution *create_args) override;
-	virtual softlist_type get_softlist_type() const override { return softlist_type::SOFTWARE; }
+	virtual const software_list_loader &get_software_list_loader() const override { return image_software_list_loader::instance(); }
 
 	virtual iodevice_t image_type() const override { return IO_CARTSLOT; }
 	virtual bool is_readable()  const override { return 1; }


### PR DESCRIPTION
device_image_interface::call_softlist_load() was a virtual function where every implementation was one of two copy-and-paste jobs.  This change consolidates all of these implementations, replacing that virtual function with a mere hook that chooses which technique to perform