### PR TITLE
Cleanups for device_image_interface (nw)

### DIFF
--- a/src/devices/bus/hp_optroms/hp_optrom.cpp
+++ b/src/devices/bus/hp_optroms/hp_optrom.cpp
@@ -60,7 +60,7 @@ void hp_optrom_slot_device::device_config_complete()
 bool hp_optrom_slot_device::call_load()
 {
 		logerror("hp_optrom: call_load\n");
-		if (m_cart == nullptr || !m_from_swlist) {
+		if (m_cart == nullptr || !loaded_through_softlist()) {
 				logerror("hp_optrom: must be loaded from sw list\n");
 				return IMAGE_INIT_FAIL;
 		}

--- a/src/devices/bus/ti99x/gromport.h
+++ b/src/devices/bus/ti99x/gromport.h
@@ -109,7 +109,6 @@ protected:
 	bool call_load() override;
 	void call_unload() override;
 	virtual const software_list_loader &get_software_list_loader() const override { return rom_software_list_loader::instance(); }
-	virtual void loaded_through_softlist() override;
 
 	void prepare_cartridge();
 
@@ -125,7 +124,6 @@ protected:
 
 private:
 	bool    m_readrom;
-	bool    m_softlist;
 	int     m_pcbtype;
 	int     m_slot;
 	int     get_index_from_tagname();

--- a/src/emu/diimage.h
+++ b/src/emu/diimage.h
@@ -205,6 +205,7 @@ public:
 	const software_info *software_entry() const { return m_software_info_ptr; }
 	const software_part *part_entry() const { return m_software_part_ptr; }
 	const char *software_list_name() const { return m_software_list_name.c_str(); }
+	bool loaded_through_softlist() const { return m_software_info_ptr != nullptr; }
 
 	void set_working_directory(const char *working_directory) { m_working_directory = working_directory; }
 	const char * working_directory();
@@ -249,7 +250,6 @@ public:
 
 protected:
 	virtual const software_list_loader &get_software_list_loader() const { return false_software_list_loader::instance(); }
-	virtual void loaded_through_softlist() { }
 
 	bool load_internal(const char *path, bool is_create, int create_format, util::option_resolution *create_args, bool just_load);
 	void determine_open_plan(int is_create, UINT32 *open_plan);
@@ -311,7 +311,6 @@ protected:
 	bool m_readonly;
 	bool m_created;
 	bool m_init_phase;
-	bool m_from_swlist;
 
 	/* special - used when creating */
 	int m_create_format;
@@ -330,9 +329,6 @@ protected:
 	bool m_user_loadable;
 
 	bool m_is_loading;
-
-private:
-	bool call_softlist_load(software_list_device &swlist, const char *swname, const rom_entry *start_entry);
 };
 
 // iterator


### PR DESCRIPTION
- Remove the loaded_through_softlist virtual method and add a boolean getter with the same name, replacing a few variables that provided similar but redundant flags.
- Remove call_softlist_load, which the previous change reduces to a simple, unnecessary wrapper.

N.B. This conflicts with pull request #1137.