### PR TITLE
Cherrypick portability fixes for 3rdparty modules

### DIFF
--- a/3rdparty/bx/include/bx/os.h
+++ b/3rdparty/bx/include/bx/os.h
@@ -16,6 +16,7 @@
 #elif  BX_PLATFORM_ANDROID \
 	|| BX_PLATFORM_EMSCRIPTEN \
 	|| BX_PLATFORM_BSD \
+	|| BX_PLATFORM_HURD \
 	|| BX_PLATFORM_IOS \
 	|| BX_PLATFORM_LINUX \
 	|| BX_PLATFORM_NACL \
@@ -51,6 +52,8 @@
 #		include <sys/syscall.h>
 #	elif BX_PLATFORM_OSX
 #		include <mach/mach.h> // mach_task_basic_info
+#	elif BX_PLATFORM_HURD
+#		include <pthread/pthread.h> // pthread_self
 #	elif BX_PLATFORM_ANDROID
 #		include "debug.h" // getTid is not implemented...
 #	endif // BX_PLATFORM_ANDROID
@@ -110,6 +113,8 @@ namespace bx
 #elif BX_PLATFORM_BSD || BX_PLATFORM_NACL
 		// Casting __nc_basic_thread_data*... need better way to do this.
 		return *(uint32_t*)::pthread_self();
+#elif BX_PLATFORM_HURD
+		return (pthread_t)::pthread_self();
 #else
 //#	pragma message "not implemented."
 		debugOutput("getTid is not implemented"); debugBreak();
@@ -122,7 +127,7 @@ namespace bx
 #if BX_PLATFORM_ANDROID
 		struct mallinfo mi = mallinfo();
 		return mi.uordblks;
-#elif BX_PLATFORM_LINUX
+#elif BX_PLATFORM_LINUX || BX_PLATFORM_HURD
 		FILE* file = fopen("/proc/self/statm", "r");
 		if (NULL == file)
 		{

--- a/3rdparty/bx/include/bx/platform.h
+++ b/3rdparty/bx/include/bx/platform.h
@@ -40,6 +40,7 @@
 #define BX_PLATFORM_ANDROID    0
 #define BX_PLATFORM_EMSCRIPTEN 0
 #define BX_PLATFORM_BSD        0
+#define BX_PLATFORM_HURD       0
 #define BX_PLATFORM_IOS        0
 #define BX_PLATFORM_LINUX      0
 #define BX_PLATFORM_NACL       0
@@ -228,6 +229,9 @@
 #elif defined(__FreeBSD__) || defined(__FreeBSD_kernel__) || defined(__NetBSD__) || defined(__OpenBSD__) || defined(__DragonFly__)
 #	undef  BX_PLATFORM_BSD
 #	define BX_PLATFORM_BSD 1
+#elif defined(__GNU__)
+#	undef  BX_PLATFORM_HURD
+#	define BX_PLATFORM_HURD 1
 #else
 #	error "BX_PLATFORM_* is not defined!"
 #endif //
@@ -236,6 +240,7 @@
 						|| BX_PLATFORM_ANDROID \
 						|| BX_PLATFORM_EMSCRIPTEN \
 						|| BX_PLATFORM_BSD \
+						|| BX_PLATFORM_HURD \
 						|| BX_PLATFORM_IOS \
 						|| BX_PLATFORM_LINUX \
 						|| BX_PLATFORM_NACL \
@@ -286,6 +291,8 @@
 				BX_STRINGIZE(__EMSCRIPTEN_tiny__)
 #elif BX_PLATFORM_BSD
 #	define BX_PLATFORM_NAME "BSD"
+#elif BX_PLATFORM_HURD
+#	define BX_PLATFORM_NAME "Hurd"
 #elif BX_PLATFORM_IOS
 #	define BX_PLATFORM_NAME "iOS"
 #elif BX_PLATFORM_LINUX

--- a/3rdparty/bx/include/bx/process.h
+++ b/3rdparty/bx/include/bx/process.h
@@ -9,16 +9,16 @@
 #include "string.h"
 #include "uint32_t.h"
 
-#if BX_PLATFORM_LINUX
+#if BX_PLATFORM_LINUX || BX_PLATFORM_HURD
 #	include <unistd.h>
-#endif // BX_PLATFORM_LINUX
+#endif // BX_PLATFORM_LINUX || BX_PLATFORM_HURD
 
 namespace bx
 {
 	///
 	inline void* exec(const char* const* _argv)
 	{
-#if BX_PLATFORM_LINUX
+#if BX_PLATFORM_LINUX || BX_PLATFORM_HURD
 		pid_t pid = fork();
 
 		if (0 == pid)
@@ -72,7 +72,7 @@ namespace bx
 		return NULL;
 #else
 		return NULL;
-#endif // BX_PLATFORM_LINUX
+#endif // BX_PLATFORM_LINUX || BX_PLATFORM_HURD
 	}
 
 } // namespace bx

--- a/3rdparty/bx/include/bx/thread.h
+++ b/3rdparty/bx/include/bx/thread.h
@@ -157,7 +157,7 @@ namespace bx
 		{
 #if BX_PLATFORM_OSX || BX_PLATFORM_IOS
 			pthread_setname_np(_name);
-#elif (BX_CRT_GLIBC >= 21200)
+#elif (BX_CRT_GLIBC >= 21200) && ! BX_PLATFORM_HURD
 			pthread_setname_np(m_handle, _name);
 #elif BX_PLATFORM_LINUX
 			prctl(PR_SET_NAME,_name, 0, 0, 0);

--- a/3rdparty/bx/makefile
+++ b/3rdparty/bx/makefile
@@ -181,7 +181,7 @@ clean:
 SILENT ?= @
 
 UNAME := $(shell uname)
-ifeq ($(UNAME),$(filter $(UNAME),Linux Darwin))
+ifeq ($(UNAME),$(filter $(UNAME),Linux GNU Darwin))
 ifeq ($(UNAME),$(filter $(UNAME),Darwin))
 OS=darwin
 BUILD_PROJECT_DIR=gmake-osx

--- a/3rdparty/genie/makefile
+++ b/3rdparty/genie/makefile
@@ -4,7 +4,7 @@
 #
 
 UNAME := $(shell uname)
-ifeq ($(UNAME),$(filter $(UNAME),Linux Darwin SunOS FreeBSD GNU/kFreeBSD NetBSD OpenBSD))
+ifeq ($(UNAME),$(filter $(UNAME),Linux Darwin SunOS FreeBSD GNU/kFreeBSD NetBSD OpenBSD GNU))
 ifeq ($(UNAME),$(filter $(UNAME),Darwin))
 OS=darwin
 else

--- a/3rdparty/genie/src/host/premake.h
+++ b/3rdparty/genie/src/host/premake.h
@@ -12,7 +12,7 @@
 
 /* Identify the current platform I'm not sure how to reliably detect
  * Windows but since it is the most common I use it as the default */
-#if defined(__linux__)
+#if defined(__linux__) || defined(__GNU__)
 #define PLATFORM_LINUX    (1)
 #define PLATFORM_STRING   "linux"
 #elif defined(__FreeBSD__) || defined(__FreeBSD_kernel__) || defined(__NetBSD__) || defined(__OpenBSD__) || defined(__DragonFly__)

--- a/3rdparty/luafilesystem/src/lfs.c
+++ b/3rdparty/luafilesystem/src/lfs.c
@@ -60,6 +60,12 @@
 #include <utime.h>
 #endif
 
+#ifdef __GNU__
+#ifndef MAXPATHLEN
+#define MAXPATHLEN 1024
+#endif
+#endif
+
 #include <lua.h>
 #include <lauxlib.h>
 #include <lualib.h>


### PR DESCRIPTION
Cherrypick fixes that improve portability on GNU/Hurd and GNU/kFreeBSD for genie, bx and luafilesystem.