### PR TITLE
Fix builds on x32 platform.

### DIFF
--- a/3rdparty/rapidjson/include/rapidjson/rapidjson.h
+++ b/3rdparty/rapidjson/include/rapidjson/rapidjson.h
@@ -250,7 +250,7 @@
 
 //! Whether using 64-bit architecture
 #ifndef RAPIDJSON_64BIT
-#if defined(__LP64__) || defined(_WIN64) || defined(__EMSCRIPTEN__)
+#if defined(__LP64__) || (defined(__x86_64__) && defined(__ILP32__)) || defined(_WIN64) || defined(__EMSCRIPTEN__)
 #define RAPIDJSON_64BIT 1
 #else
 #define RAPIDJSON_64BIT 0


### PR DESCRIPTION
From the Debian wiki: https://wiki.debian.org/X32Port

X32 is an ABI for amd64/x86_64 CPUs using 32-bit integers, longs
and pointers. The idea is to combine the smaller memory and cache
footprint from 32-bit data types with the larger register set of
x86_64. The 64-bit registers can make computation more efficient,
and with 8 additional registers available, there is less pressure
compared to i386/i686.

rapidjson makes an incorrect assumption in a check for 64 bit platforms,
and uses __LP64__ exclusively. This fix adds an additional check for
__x86_64__ && __ILP32__ defines, as a very conservative fix. However, the
usage of __LP64__ would be a problem for other "mixed" applications like
ARM ILP32, so a better detection scheme might be needed in the future.