### PR TITLE
Changes rom_entry from a struct to a class, storing its strings as stdd::string and separated the declaration into a new header

### DIFF
--- a/scripts/src/emu.lua
+++ b/scripts/src/emu.lua
@@ -149,6 +149,7 @@ files {
 	MAME_DIR .. "src/emu/rendutil.h",
 	MAME_DIR .. "src/emu/romload.cpp",
 	MAME_DIR .. "src/emu/romload.h",
+	MAME_DIR .. "src/emu/romentry.h",
 	MAME_DIR .. "src/emu/save.cpp",
 	MAME_DIR .. "src/emu/save.h",
 	MAME_DIR .. "src/emu/schedule.cpp",

--- a/src/emu/device.h
+++ b/src/emu/device.h
@@ -69,7 +69,7 @@ class device_execute_interface;
 class device_memory_interface;
 class device_state_interface;
 class validity_checker;
-struct rom_entry;
+class rom_entry;
 class machine_config;
 class emu_timer;
 struct input_device_default;

--- a/src/emu/romentry.h
+++ b/src/emu/romentry.h
@@ -132,6 +132,10 @@ public:
 		, m_offset(offset)
 		, m_length(length)
 		, m_flags(flags) {}
+	rom_entry(rom_entry const &) = default;
+	rom_entry(rom_entry &&) = default;
+	rom_entry &operator=(rom_entry const &) = default;
+	rom_entry &operator=(rom_entry &&) = default;
 
 	// accessors
 	const std::string &name() const { return m_name; }
@@ -139,7 +143,7 @@ public:
 	UINT32 offset() const { return m_offset; }
 	UINT32 length() const { return m_length; }
 	UINT32 flags() const { return m_flags; }
-	UINT32 &flags() { return m_flags; }
+	void set_flags(UINT32 flags) { m_flags = flags; }
 
 private:
 	std::string		m_name;

--- a/src/emu/romentry.h
+++ b/src/emu/romentry.h
@@ -1,0 +1,153 @@
+// license:BSD-3-Clause
+// copyright-holders:Nicola Salmoria,Aaron Giles
+/*********************************************************************
+
+	romentry.h
+
+	ROM loading functions.
+
+*********************************************************************/
+
+#ifndef MAME_EMU_ROMENTRY_H_
+#define MAME_EMU_ROMENTRY_H_
+
+#include <string>
+
+#include "osdcomm.h"
+
+/***************************************************************************
+CONSTANTS
+***************************************************************************/
+
+/* ----- type constants ----- */
+#define ROMENTRY_TYPEMASK           0x0000000f          /* type of entry */
+enum
+{
+	ROMENTRYTYPE_ROM = 0,       /* this entry is an actual ROM definition */
+	ROMENTRYTYPE_REGION,        /* this entry marks the start of a region */
+	ROMENTRYTYPE_END,           /* this entry marks the end of a region */
+	ROMENTRYTYPE_RELOAD,        /* this entry reloads the previous ROM */
+	ROMENTRYTYPE_CONTINUE,      /* this entry continues loading the previous ROM */
+	ROMENTRYTYPE_FILL,          /* this entry fills an area with a constant value */
+	ROMENTRYTYPE_COPY,          /* this entry copies data from another region/offset */
+	ROMENTRYTYPE_CARTRIDGE,     /* this entry specifies a cartridge (MESS) */
+	ROMENTRYTYPE_IGNORE,        /* this entry continues loading the previous ROM but throws the data away */
+	ROMENTRYTYPE_SYSTEM_BIOS,   /* this entry specifies a bios */
+	ROMENTRYTYPE_DEFAULT_BIOS,  /* this entry specifies a default bios */
+	ROMENTRYTYPE_PARAMETER,     /* this entry specifies a per-game parameter */
+	ROMENTRYTYPE_COUNT
+};
+
+/* ----- per-region constants ----- */
+#define ROMREGION_WIDTHMASK         0x00000300          /* native width of region, as power of 2 */
+#define     ROMREGION_8BIT          0x00000000          /*    (non-CPU regions only) */
+#define     ROMREGION_16BIT         0x00000100
+#define     ROMREGION_32BIT         0x00000200
+#define     ROMREGION_64BIT         0x00000300
+
+#define ROMREGION_ENDIANMASK        0x00000400          /* endianness of the region */
+#define     ROMREGION_LE            0x00000000          /*    (non-CPU regions only) */
+#define     ROMREGION_BE            0x00000400
+
+#define ROMREGION_INVERTMASK        0x00000800          /* invert the bits of the region */
+#define     ROMREGION_NOINVERT      0x00000000
+#define     ROMREGION_INVERT        0x00000800
+
+#define ROMREGION_ERASEMASK         0x00002000          /* erase the region before loading */
+#define     ROMREGION_NOERASE       0x00000000
+#define     ROMREGION_ERASE         0x00002000
+
+#define ROMREGION_DATATYPEMASK      0x00004000          /* type of region (ROM versus disk) */
+#define     ROMREGION_DATATYPEROM   0x00000000
+#define     ROMREGION_DATATYPEDISK  0x00004000
+
+#define ROMREGION_ERASEVALMASK      0x00ff0000          /* value to erase the region to */
+#define     ROMREGION_ERASEVAL(x)   ((((x) & 0xff) << 16) | ROMREGION_ERASE)
+#define     ROMREGION_ERASE00       ROMREGION_ERASEVAL(0)
+#define     ROMREGION_ERASEFF       ROMREGION_ERASEVAL(0xff)
+
+
+	/* ----- per-ROM constants ----- */
+#define DISK_READONLYMASK           0x00000010          /* is the disk read-only? */
+#define     DISK_READWRITE          0x00000000
+#define     DISK_READONLY           0x00000010
+
+#define ROM_OPTIONALMASK            0x00000020          /* optional - won't hurt if it's not there */
+#define     ROM_REQUIRED            0x00000000
+#define     ROM_OPTIONAL            0x00000020
+
+#define ROM_REVERSEMASK             0x00000040          /* reverse the byte order within a group */
+#define     ROM_NOREVERSE           0x00000000
+#define     ROM_REVERSE             0x00000040
+
+#define ROM_INHERITFLAGSMASK        0x00000080          /* inherit all flags from previous definition */
+#define     ROM_INHERITFLAGS        0x00000080
+
+#define ROM_GROUPMASK               0x00000f00          /* load data in groups of this size + 1 */
+#define     ROM_GROUPSIZE(n)        ((((n) - 1) & 15) << 8)
+#define     ROM_GROUPBYTE           ROM_GROUPSIZE(1)
+#define     ROM_GROUPWORD           ROM_GROUPSIZE(2)
+#define     ROM_GROUPDWORD          ROM_GROUPSIZE(4)
+
+#define ROM_SKIPMASK                0x0000f000          /* skip this many bytes after each group */
+#define     ROM_SKIP(n)             (((n) & 15) << 12)
+#define     ROM_NOSKIP              ROM_SKIP(0)
+
+#define ROM_BITWIDTHMASK            0x000f0000          /* width of data in bits */
+#define     ROM_BITWIDTH(n)         (((n) & 15) << 16)
+#define     ROM_NIBBLE              ROM_BITWIDTH(4)
+#define     ROM_FULLBYTE            ROM_BITWIDTH(8)
+
+#define ROM_BITSHIFTMASK            0x00f00000          /* left-shift count for the bits */
+#define     ROM_BITSHIFT(n)         (((n) & 15) << 20)
+#define     ROM_NOSHIFT             ROM_BITSHIFT(0)
+#define     ROM_SHIFT_NIBBLE_LO     ROM_BITSHIFT(0)
+#define     ROM_SHIFT_NIBBLE_HI     ROM_BITSHIFT(4)
+
+#define ROM_BIOSFLAGSMASK           0xff000000          /* only loaded if value matches global bios value */
+#define     ROM_BIOS(n)             (((n) & 255) << 24)
+
+#define ROM_INHERITEDFLAGS          (ROM_GROUPMASK | ROM_SKIPMASK | ROM_REVERSEMASK | ROM_BITWIDTHMASK | ROM_BITSHIFTMASK | ROM_BIOSFLAGSMASK)
+
+
+
+//**************************************************************************
+//  TYPE DEFINITIONS
+//**************************************************************************
+
+// ======================> rom_entry
+
+class rom_entry
+{
+public:
+	rom_entry(const char *name, const char *hashdata, UINT32 offset, UINT32 length, UINT32 flags)
+		: m_name(name != nullptr ? name : "")
+		, m_hashdata(hashdata != nullptr ? hashdata : "")
+		, m_offset(offset)
+		, m_length(length)
+		, m_flags(flags) {}
+	rom_entry(std::string &&name, std::string &&hashdata, UINT32 offset, UINT32 length, UINT32 flags)
+		: m_name(std::move(name))
+		, m_hashdata(std::move(hashdata))
+		, m_offset(offset)
+		, m_length(length)
+		, m_flags(flags) {}
+
+	// accessors
+	const std::string &name() const { return m_name; }
+	const std::string &hashdata() const { return m_hashdata; }
+	UINT32 offset() const { return m_offset; }
+	UINT32 length() const { return m_length; }
+	UINT32 flags() const { return m_flags; }
+	UINT32 &flags() { return m_flags; }
+
+private:
+	std::string		m_name;
+	std::string		m_hashdata;
+	UINT32			m_offset;
+	UINT32			m_length;
+	UINT32			m_flags;
+};
+
+
+#endif // MAME_EMU_ROMENTRY_H_

--- a/src/emu/romload.cpp
+++ b/src/emu/romload.cpp
@@ -914,7 +914,7 @@ void rom_load_manager::process_rom_entries(const char *regiontag, const rom_entr
 					if (!ROM_INHERITSFLAGS(&modified_romp))
 						lastflags = modified_romp.flags();
 					else
-						modified_romp.flags() = (modified_romp.flags() & ~ROM_INHERITEDFLAGS) | lastflags;
+						modified_romp.set_flags((modified_romp.flags() & ~ROM_INHERITEDFLAGS) | lastflags);
 
 					explength += ROM_GETLENGTH(&modified_romp);
 

--- a/src/emu/romload.cpp
+++ b/src/emu/romload.cpp
@@ -164,7 +164,7 @@ std::string rom_region_name(const device_t &device, const rom_entry *romp)
 
 std::string rom_parameter_name(const device_t &device, const rom_entry *romp)
 {
-	return device.subtag(romp->_name);
+	return device.subtag(romp->name().c_str());
 }
 
 
@@ -175,7 +175,7 @@ std::string rom_parameter_name(const device_t &device, const rom_entry *romp)
 
 std::string rom_parameter_value(const rom_entry *romp)
 {
-	return std::string(romp->_hashdata);
+	return romp->hashdata();
 }
 
 
@@ -832,7 +832,7 @@ void rom_load_manager::copy_rom_data(const rom_entry *romp)
 	UINT8 *base = m_region->base() + ROM_GETOFFSET(romp);
 	const char *srcrgntag = ROM_GETNAME(romp);
 	UINT32 numbytes = ROM_GETLENGTH(romp);
-	UINT32 srcoffs = (FPTR)ROM_GETHASHDATA(romp);  /* srcoffset in place of hashdata */
+	UINT32 srcoffs = (UINT32) strtol(ROM_GETHASHDATA(romp), nullptr, 0);  /* srcoffset in place of hashdata */
 
 	/* make sure we copy within the region space */
 	if (ROM_GETOFFSET(romp) + numbytes > m_region->bytes())
@@ -912,9 +912,9 @@ void rom_load_manager::process_rom_entries(const char *regiontag, const rom_entr
 
 					/* handle flag inheritance */
 					if (!ROM_INHERITSFLAGS(&modified_romp))
-						lastflags = modified_romp._flags;
+						lastflags = modified_romp.flags();
 					else
-						modified_romp._flags = (modified_romp._flags & ~ROM_INHERITEDFLAGS) | lastflags;
+						modified_romp.flags() = (modified_romp.flags() & ~ROM_INHERITEDFLAGS) | lastflags;
 
 					explength += ROM_GETLENGTH(&modified_romp);
 
@@ -1113,7 +1113,7 @@ chd_error rom_load_manager::open_disk_diff(emu_options &options, const rom_entry
 	/* try to open the diff */
 	LOG(("Opening differencing image file: %s\n", fname.c_str()));
 	emu_file diff_file(options.diff_directory(), OPEN_FLAG_READ | OPEN_FLAG_WRITE);
-	osd_file::error filerr = diff_file.open(fname);
+	osd_file::error filerr = diff_file.open(fname.c_str());
 	if (filerr == osd_file::error::NONE)
 	{
 		std::string fullpath(diff_file.fullpath());
@@ -1126,7 +1126,7 @@ chd_error rom_load_manager::open_disk_diff(emu_options &options, const rom_entry
 	/* didn't work; try creating it instead */
 	LOG(("Creating differencing image: %s\n", fname.c_str()));
 	diff_file.set_openflags(OPEN_FLAG_READ | OPEN_FLAG_WRITE | OPEN_FLAG_CREATE | OPEN_FLAG_CREATE_PATHS);
-	filerr = diff_file.open(fname);
+	filerr = diff_file.open(fname.c_str());
 	if (filerr == osd_file::error::NONE)
 	{
 		std::string fullpath(diff_file.fullpath());

--- a/src/emu/romload.h
+++ b/src/emu/romload.h
@@ -17,101 +17,7 @@
 #define MAME_EMU_ROMLOAD_H
 
 #include "chd.h"
-
-/***************************************************************************
-    CONSTANTS
-***************************************************************************/
-
-/* ----- type constants ----- */
-#define ROMENTRY_TYPEMASK           0x0000000f          /* type of entry */
-enum
-{
-	ROMENTRYTYPE_ROM = 0,       /* this entry is an actual ROM definition */
-	ROMENTRYTYPE_REGION,        /* this entry marks the start of a region */
-	ROMENTRYTYPE_END,           /* this entry marks the end of a region */
-	ROMENTRYTYPE_RELOAD,        /* this entry reloads the previous ROM */
-	ROMENTRYTYPE_CONTINUE,      /* this entry continues loading the previous ROM */
-	ROMENTRYTYPE_FILL,          /* this entry fills an area with a constant value */
-	ROMENTRYTYPE_COPY,          /* this entry copies data from another region/offset */
-	ROMENTRYTYPE_CARTRIDGE,     /* this entry specifies a cartridge (MESS) */
-	ROMENTRYTYPE_IGNORE,        /* this entry continues loading the previous ROM but throws the data away */
-	ROMENTRYTYPE_SYSTEM_BIOS,   /* this entry specifies a bios */
-	ROMENTRYTYPE_DEFAULT_BIOS,  /* this entry specifies a default bios */
-	ROMENTRYTYPE_PARAMETER,     /* this entry specifies a per-game parameter */
-	ROMENTRYTYPE_COUNT
-};
-
-/* ----- per-region constants ----- */
-#define ROMREGION_WIDTHMASK         0x00000300          /* native width of region, as power of 2 */
-#define     ROMREGION_8BIT          0x00000000          /*    (non-CPU regions only) */
-#define     ROMREGION_16BIT         0x00000100
-#define     ROMREGION_32BIT         0x00000200
-#define     ROMREGION_64BIT         0x00000300
-
-#define ROMREGION_ENDIANMASK        0x00000400          /* endianness of the region */
-#define     ROMREGION_LE            0x00000000          /*    (non-CPU regions only) */
-#define     ROMREGION_BE            0x00000400
-
-#define ROMREGION_INVERTMASK        0x00000800          /* invert the bits of the region */
-#define     ROMREGION_NOINVERT      0x00000000
-#define     ROMREGION_INVERT        0x00000800
-
-#define ROMREGION_ERASEMASK         0x00002000          /* erase the region before loading */
-#define     ROMREGION_NOERASE       0x00000000
-#define     ROMREGION_ERASE         0x00002000
-
-#define ROMREGION_DATATYPEMASK      0x00004000          /* type of region (ROM versus disk) */
-#define     ROMREGION_DATATYPEROM   0x00000000
-#define     ROMREGION_DATATYPEDISK  0x00004000
-
-#define ROMREGION_ERASEVALMASK      0x00ff0000          /* value to erase the region to */
-#define     ROMREGION_ERASEVAL(x)   ((((x) & 0xff) << 16) | ROMREGION_ERASE)
-#define     ROMREGION_ERASE00       ROMREGION_ERASEVAL(0)
-#define     ROMREGION_ERASEFF       ROMREGION_ERASEVAL(0xff)
-
-
-/* ----- per-ROM constants ----- */
-#define DISK_READONLYMASK           0x00000010          /* is the disk read-only? */
-#define     DISK_READWRITE          0x00000000
-#define     DISK_READONLY           0x00000010
-
-#define ROM_OPTIONALMASK            0x00000020          /* optional - won't hurt if it's not there */
-#define     ROM_REQUIRED            0x00000000
-#define     ROM_OPTIONAL            0x00000020
-
-#define ROM_REVERSEMASK             0x00000040          /* reverse the byte order within a group */
-#define     ROM_NOREVERSE           0x00000000
-#define     ROM_REVERSE             0x00000040
-
-#define ROM_INHERITFLAGSMASK        0x00000080          /* inherit all flags from previous definition */
-#define     ROM_INHERITFLAGS        0x00000080
-
-#define ROM_GROUPMASK               0x00000f00          /* load data in groups of this size + 1 */
-#define     ROM_GROUPSIZE(n)        ((((n) - 1) & 15) << 8)
-#define     ROM_GROUPBYTE           ROM_GROUPSIZE(1)
-#define     ROM_GROUPWORD           ROM_GROUPSIZE(2)
-#define     ROM_GROUPDWORD          ROM_GROUPSIZE(4)
-
-#define ROM_SKIPMASK                0x0000f000          /* skip this many bytes after each group */
-#define     ROM_SKIP(n)             (((n) & 15) << 12)
-#define     ROM_NOSKIP              ROM_SKIP(0)
-
-#define ROM_BITWIDTHMASK            0x000f0000          /* width of data in bits */
-#define     ROM_BITWIDTH(n)         (((n) & 15) << 16)
-#define     ROM_NIBBLE              ROM_BITWIDTH(4)
-#define     ROM_FULLBYTE            ROM_BITWIDTH(8)
-
-#define ROM_BITSHIFTMASK            0x00f00000          /* left-shift count for the bits */
-#define     ROM_BITSHIFT(n)         (((n) & 15) << 20)
-#define     ROM_NOSHIFT             ROM_BITSHIFT(0)
-#define     ROM_SHIFT_NIBBLE_LO     ROM_BITSHIFT(0)
-#define     ROM_SHIFT_NIBBLE_HI     ROM_BITSHIFT(4)
-
-#define ROM_BIOSFLAGSMASK           0xff000000          /* only loaded if value matches global bios value */
-#define     ROM_BIOS(n)             (((n) & 255) << 24)
-
-#define ROM_INHERITEDFLAGS          (ROM_GROUPMASK | ROM_SKIPMASK | ROM_REVERSEMASK | ROM_BITWIDTHMASK | ROM_BITSHIFTMASK | ROM_BIOSFLAGSMASK)
-
+#include "romentry.h"
 
 
 /***************************************************************************
@@ -123,15 +29,6 @@ class emu_options;
 class chd_file;
 class software_list_device;
 
-struct rom_entry
-{
-	const char *    _name;              /* name of the file to load */
-	const char *    _hashdata;          /* hashing informations (checksums) */
-	UINT32          _offset;            /* offset to load it to */
-	UINT32          _length;            /* length of the file */
-	UINT32          _flags;             /* flags */
-};
-
 
 
 /***************************************************************************
@@ -139,7 +36,7 @@ struct rom_entry
 ***************************************************************************/
 
 /* ----- per-entry macros ----- */
-#define ROMENTRY_GETTYPE(r)         ((r)->_flags & ROMENTRY_TYPEMASK)
+#define ROMENTRY_GETTYPE(r)         ((r)->flags() & ROMENTRY_TYPEMASK)
 #define ROMENTRY_ISSPECIAL(r)       (ROMENTRY_GETTYPE(r) != ROMENTRYTYPE_ROM)
 #define ROMENTRY_ISFILE(r)          (ROMENTRY_GETTYPE(r) == ROMENTRYTYPE_ROM)
 #define ROMENTRY_ISREGION(r)        (ROMENTRY_GETTYPE(r) == ROMENTRYTYPE_REGION)
@@ -155,9 +52,9 @@ struct rom_entry
 #define ROMENTRY_ISREGIONEND(r)     (ROMENTRY_ISREGION(r) || ROMENTRY_ISPARAMETER(r) || ROMENTRY_ISEND(r))
 
 /* ----- per-region macros ----- */
-#define ROMREGION_GETTAG(r)         ((r)->_name)
-#define ROMREGION_GETLENGTH(r)      ((r)->_length)
-#define ROMREGION_GETFLAGS(r)       ((r)->_flags)
+#define ROMREGION_GETTAG(r)         ((r)->name().c_str())
+#define ROMREGION_GETLENGTH(r)      ((r)->length())
+#define ROMREGION_GETFLAGS(r)       ((r)->flags())
 #define ROMREGION_GETWIDTH(r)       (8 << ((ROMREGION_GETFLAGS(r) & ROMREGION_WIDTHMASK) >> 8))
 #define ROMREGION_ISLITTLEENDIAN(r) ((ROMREGION_GETFLAGS(r) & ROMREGION_ENDIANMASK) == ROMREGION_LE)
 #define ROMREGION_ISBIGENDIAN(r)    ((ROMREGION_GETFLAGS(r) & ROMREGION_ENDIANMASK) == ROMREGION_BE)
@@ -170,12 +67,12 @@ struct rom_entry
 
 
 /* ----- per-ROM macros ----- */
-#define ROM_GETNAME(r)              ((r)->_name)
+#define ROM_GETNAME(r)              ((r)->name().c_str())
 #define ROM_SAFEGETNAME(r)          (ROMENTRY_ISFILL(r) ? "fill" : ROMENTRY_ISCOPY(r) ? "copy" : ROM_GETNAME(r))
-#define ROM_GETOFFSET(r)            ((r)->_offset)
-#define ROM_GETLENGTH(r)            ((r)->_length)
-#define ROM_GETFLAGS(r)             ((r)->_flags)
-#define ROM_GETHASHDATA(r)          ((r)->_hashdata)
+#define ROM_GETOFFSET(r)            ((r)->offset())
+#define ROM_GETLENGTH(r)            ((r)->length())
+#define ROM_GETFLAGS(r)             ((r)->flags())
+#define ROM_GETHASHDATA(r)          ((r)->hashdata().c_str())
 #define ROM_ISOPTIONAL(r)           ((ROM_GETFLAGS(r) & ROM_OPTIONALMASK) == ROM_OPTIONAL)
 #define ROM_GETGROUPSIZE(r)         (((ROM_GETFLAGS(r) & ROM_GROUPMASK) >> 8) + 1)
 #define ROM_GETSKIPCOUNT(r)         ((ROM_GETFLAGS(r) & ROM_SKIPMASK) >> 12)
@@ -187,7 +84,7 @@ struct rom_entry
 
 
 /* ----- per-disk macros ----- */
-#define DISK_GETINDEX(r)            ((r)->_offset)
+#define DISK_GETINDEX(r)            ((r)->offset())
 #define DISK_ISREADONLY(r)          ((ROM_GETFLAGS(r) & DISK_READONLYMASK) == DISK_READONLY)
 
 
@@ -235,9 +132,9 @@ struct rom_entry
 /* ----- additional ROM-related macros ----- */
 #define ROM_CONTINUE(offset,length)                 { nullptr, nullptr, offset, length, ROMENTRYTYPE_CONTINUE | ROM_INHERITFLAGS },
 #define ROM_IGNORE(length)                          { nullptr, nullptr, 0,      length, ROMENTRYTYPE_IGNORE | ROM_INHERITFLAGS },
-#define ROM_FILL(offset,length,value)               { nullptr, (const char *)value, offset, length, ROMENTRYTYPE_FILL },
-#define ROMX_FILL(offset,length,value,flags)        { nullptr, (const char *)value, offset, length, ROMENTRYTYPE_FILL | flags },
-#define ROM_COPY(srctag,srcoffs,offset,length)      { srctag, (const char *)srcoffs, offset, length, ROMENTRYTYPE_COPY },
+#define ROM_FILL(offset,length,value)               { nullptr, #value, offset, length, ROMENTRYTYPE_FILL },
+#define ROMX_FILL(offset,length,value,flags)        { nullptr, #value, offset, length, ROMENTRYTYPE_FILL | flags },
+#define ROM_COPY(srctag,srcoffs,offset,length)      { srctag, #srcoffs, offset, length, ROMENTRYTYPE_COPY },
 
 
 /* ----- system BIOS macros ----- */

--- a/src/emu/softlist.cpp
+++ b/src/emu/softlist.cpp
@@ -57,7 +57,7 @@ private:
 	// internal helpers
 	template <typename T> std::vector<std::string> parse_attributes(const char **attributes, const T &attrlist);
 	bool parse_name_and_value(const char **attributes, std::string &name, std::string &value);
-	void add_rom_entry(const char *name, const char *hashdata, UINT32 offset, UINT32 length, UINT32 flags);
+	void add_rom_entry(std::string &&name, std::string &&hashdata, UINT32 offset, UINT32 length, UINT32 flags);
 
 	// expat callbacks
 	static void start_handler(void *data, const char *tagname, const char **attributes);
@@ -733,15 +733,6 @@ void software_list_device::internal_validity_check(validity_checker &valid)
 
 			if (!part_names.insert(std::make_pair(part.name(), &swinfo)).second)
 				osd_printf_error("%s: %s has a part (%s) whose name is duplicate\n", filename(), swinfo.shortname().c_str(), part.name().c_str());
-
-			for (const rom_entry *data = part.romdata(); data->_name != nullptr; data++)
-				if (data->_hashdata != nullptr)
-				{
-					// make sure the hash is valid
-					util::hash_collection hashes;
-					if (!hashes.from_internal_string(data->_hashdata))
-						osd_printf_error("%s: %s has rom '%s' with an invalid hash string '%s'\n", filename(), swinfo.shortname().c_str(), data->_name, data->_hashdata);
-				}
 		}
 	}
 
@@ -892,7 +883,7 @@ bool softlist_parser::parse_name_and_value(const char **attributes, std::string 
 //  current part's list
 //-------------------------------------------------
 
-void softlist_parser::add_rom_entry(const char *name, const char *hashdata, UINT32 offset, UINT32 length, UINT32 flags)
+void softlist_parser::add_rom_entry(std::string &&name, std::string &&hashdata, UINT32 offset, UINT32 length, UINT32 flags)
 {
 	// get the current part
 	if (m_current_part == nullptr)
@@ -902,20 +893,18 @@ void softlist_parser::add_rom_entry(const char *name, const char *hashdata, UINT
 	}
 
 	// make sure we don't add duplicate regions
-	if (name != nullptr && (flags & ROMENTRY_TYPEMASK) == ROMENTRYTYPE_REGION)
+	if (!name.empty() && (flags & ROMENTRY_TYPEMASK) == ROMENTRYTYPE_REGION)
 		for (auto &elem : m_current_part->m_romdata)
-			if (elem._name != nullptr && strcmp(elem._name, name) == 0)
+			if (!elem.name().empty() && elem.name() == name)
 				parse_error("Duplicated dataarea %s in software %s", name, infoname());
 
 	// create the new entry and append it
-	rom_entry entry;
-	entry._name = m_list.add_string(name);
-	entry._hashdata = m_list.add_string(hashdata);
-	entry._offset = offset;
-	entry._length = length;
-	entry._flags = flags;
-
-	m_current_part->m_romdata.push_back(entry);
+	m_current_part->m_romdata.emplace_back(
+		std::move(name),
+		std::move(hashdata),
+		offset,
+		length,
+		flags);
 }
 
 
@@ -1147,7 +1136,7 @@ void softlist_parser::parse_part_start(const char *tagname, const char **attribu
 	if (strcmp(tagname, "dataarea") == 0)
 	{
 		static const char *attrnames[] = { "name", "size", "width", "endianness" };
-		const auto attrvalues = parse_attributes(attributes, attrnames);
+		auto attrvalues = parse_attributes(attributes, attrnames);
 
 		if (!attrvalues[0].empty() && !attrvalues[1].empty())
 		{
@@ -1179,7 +1168,7 @@ void softlist_parser::parse_part_start(const char *tagname, const char **attribu
 					parse_error("Invalid dataarea endianness");
 			}
 
-			add_rom_entry(attrvalues[0].c_str(), nullptr, 0, strtol(attrvalues[1].c_str(), nullptr, 0), regionflags);
+			add_rom_entry(std::move(attrvalues[0]), "", 0, strtol(attrvalues[1].c_str(), nullptr, 0), regionflags);
 		}
 		else
 			parse_error("Incomplete dataarea definition");
@@ -1189,10 +1178,10 @@ void softlist_parser::parse_part_start(const char *tagname, const char **attribu
 	else if (strcmp(tagname, "diskarea") == 0)
 	{
 		static const char *attrnames[] = { "name" };
-		const auto attrvalues = parse_attributes(attributes, attrnames);
+		auto attrvalues = parse_attributes(attributes, attrnames);
 
 		if (!attrvalues[0].empty())
-			add_rom_entry(attrvalues[0].c_str(), nullptr, 0, 1, ROMENTRYTYPE_REGION | ROMREGION_DATATYPEDISK);
+			add_rom_entry(std::move(attrvalues[0]), "", 0, 1, ROMENTRYTYPE_REGION | ROMREGION_DATATYPEDISK);
 		else
 			parse_error("Incomplete diskarea definition");
 	}
@@ -1234,14 +1223,14 @@ void softlist_parser::parse_data_start(const char *tagname, const char **attribu
 	if (strcmp(tagname, "rom") == 0)
 	{
 		static const char *attrnames[] = { "name", "size", "crc", "sha1", "offset", "value", "status", "loadflag" };
-		const auto attrvalues = parse_attributes(attributes, attrnames);
+		auto attrvalues = parse_attributes(attributes, attrnames);
 
-		const std::string &name = attrvalues[0];
+		std::string &name = attrvalues[0];
 		const std::string &sizestr = attrvalues[1];
 		const std::string &crc = attrvalues[2];
 		const std::string &sha1 = attrvalues[3];
 		const std::string &offsetstr = attrvalues[4];
-		const std::string &value = attrvalues[5];
+		std::string &value = attrvalues[5];
 		const std::string &status = attrvalues[6];
 		const std::string &loadflag = attrvalues[7];
 		if (!sizestr.empty() && !offsetstr.empty())
@@ -1250,13 +1239,13 @@ void softlist_parser::parse_data_start(const char *tagname, const char **attribu
 			UINT32 offset = strtol(offsetstr.c_str(), nullptr, 0);
 
 			if (loadflag == "reload")
-				add_rom_entry(nullptr, nullptr, offset, length, ROMENTRYTYPE_RELOAD | ROM_INHERITFLAGS);
+				add_rom_entry("", "", offset, length, ROMENTRYTYPE_RELOAD | ROM_INHERITFLAGS);
 			else if (loadflag == "reload_plain")
-				add_rom_entry(nullptr, nullptr, offset, length, ROMENTRYTYPE_RELOAD);
+				add_rom_entry("", "", offset, length, ROMENTRYTYPE_RELOAD);
 			else if (loadflag == "continue")
-				add_rom_entry(nullptr, nullptr, offset, length, ROMENTRYTYPE_CONTINUE | ROM_INHERITFLAGS);
+				add_rom_entry("", "", offset, length, ROMENTRYTYPE_CONTINUE | ROM_INHERITFLAGS);
 			else if (loadflag == "fill")
-				add_rom_entry(nullptr, (const char *)(FPTR)(strtol(value.c_str(), nullptr, 0) & 0xff), offset, length, ROMENTRYTYPE_FILL);
+				add_rom_entry("", std::move(value), offset, length, ROMENTRYTYPE_FILL);
 			else if (!name.empty())
 			{
 				bool baddump = (status == "baddump");
@@ -1290,7 +1279,7 @@ void softlist_parser::parse_data_start(const char *tagname, const char **attribu
 				else if (loadflag == "load32_byte")
 					romflags = ROM_SKIP(3);
 
-				add_rom_entry(name.c_str(), hashdata.c_str(), offset, length, ROMENTRYTYPE_ROM | romflags);
+				add_rom_entry(std::move(name), std::move(hashdata), offset, length, ROMENTRYTYPE_ROM | romflags);
 			}
 			else
 				parse_error("Rom name missing");
@@ -1298,7 +1287,7 @@ void softlist_parser::parse_data_start(const char *tagname, const char **attribu
 		else if (!sizestr.empty() && !loadflag.empty() && loadflag == "ignore")
 		{
 			UINT32 length = strtol(sizestr.c_str(), nullptr, 0);
-			add_rom_entry(nullptr, nullptr, 0, length, ROMENTRYTYPE_IGNORE | ROM_INHERITFLAGS);
+			add_rom_entry("", "", 0, length, ROMENTRYTYPE_IGNORE | ROM_INHERITFLAGS);
 		}
 		else
 			parse_error("Incomplete rom definition");
@@ -1308,9 +1297,9 @@ void softlist_parser::parse_data_start(const char *tagname, const char **attribu
 	else if (strcmp(tagname, "disk") == 0)
 	{
 		static const char *attrnames[] = { "name", "sha1", "status", "writeable" };
-		const auto attrvalues = parse_attributes(attributes, attrnames);
+		auto attrvalues = parse_attributes(attributes, attrnames);
 
-		const std::string &name = attrvalues[0];
+		std::string &name = attrvalues[0];
 		const std::string &sha1 = attrvalues[1];
 		const std::string &status = attrvalues[2];
 		const std::string &writeablestr = attrvalues[3];
@@ -1321,7 +1310,7 @@ void softlist_parser::parse_data_start(const char *tagname, const char **attribu
 			const bool writeable = (writeablestr == "yes");
 			std::string hashdata = string_format("%c%s%s", util::hash_collection::HASH_SHA1, sha1, (nodump ? NO_DUMP : (baddump ? BAD_DUMP : "")));
 
-			add_rom_entry(name.c_str(), hashdata.c_str(), 0, 0, ROMENTRYTYPE_ROM | (writeable ? DISK_READWRITE : DISK_READONLY));
+			add_rom_entry(std::move(name), std::move(hashdata), 0, 0, ROMENTRYTYPE_ROM | (writeable ? DISK_READWRITE : DISK_READONLY));
 		}
 		else if (status.empty() || (status == "nodump")) // a no_dump chd is not an incomplete entry
 			parse_error("Incomplete disk definition");
@@ -1366,7 +1355,7 @@ void softlist_parser::parse_soft_end(const char *tagname)
 
 		// was any dataarea/rom information encountered? if so, add a terminator
 		if (m_current_part->romdata() != nullptr)
-			add_rom_entry(nullptr, nullptr, 0, 0, ROMENTRYTYPE_END);
+			add_rom_entry("", "", 0, 0, ROMENTRYTYPE_END);
 
 		// get the info; if present, copy shared data (we assume name/value strings live
 		// in the string pool and don't need to be reallocated)

--- a/src/emu/softlist.h
+++ b/src/emu/softlist.h
@@ -73,7 +73,7 @@ enum software_compatibility
 //  TYPE DEFINITIONS
 //**************************************************************************
 
-struct rom_entry;
+class rom_entry;
 class software_info;
 class device_image_interface;
 class software_list_device;


### PR DESCRIPTION
This should really be followed up by further changes to eliminate the usage of the weird accessor macros in favor of conventional C++ accessors