### PR TITLE
This fixes issues where softlist items (that were not for floppies) were loaded from the software list menu

### DIFF
--- a/src/emu/diimage.cpp
+++ b/src/emu/diimage.cpp
@@ -1370,6 +1370,10 @@ bool device_image_interface::load_software_part(const char *path, const software
 		return false;
 	}
 
+	// I'm not sure what m_init_phase is all about; but for now I'm preserving this behavior
+	if (is_reset_on_load())
+		set_init_phase();
+
 	// Load the software part
 	software_list_device &swlist = swpart->info().list();
 	const char *swname = swpart->info().shortname().c_str();

--- a/src/frontend/mame/ui/floppycntrl.cpp
+++ b/src/frontend/mame/ui/floppycntrl.cpp
@@ -61,16 +61,8 @@ void menu_control_floppy_image::do_load_create()
 	}
 }
 
-void menu_control_floppy_image::hook_load(const std::string &filename, bool softlist)
+void menu_control_floppy_image::hook_load(const std::string &filename)
 {
-	if (softlist)
-	{
-		machine().popmessage("When loaded from software list, the disk is Read-only.\n");
-		m_image.load_software(filename);
-		stack_pop();
-		return;
-	}
-
 	input_filename = filename;
 	input_format = static_cast<floppy_image_device &>(m_image).identify(filename);
 

--- a/src/frontend/mame/ui/floppycntrl.h
+++ b/src/frontend/mame/ui/floppycntrl.h
@@ -33,7 +33,7 @@ private:
 	virtual void handle() override;
 
 	void do_load_create();
-	virtual void hook_load(const std::string &filename, bool softlist) override;
+	virtual void hook_load(const std::string &filename) override;
 };
 
 } // namespace ui

--- a/src/frontend/mame/ui/imgcntrl.cpp
+++ b/src/frontend/mame/ui/imgcntrl.cpp
@@ -140,7 +140,10 @@ void menu_control_device_image::load_software_part()
 	media_auditor::summary summary = auditor.audit_software(m_sld->list_name(), (software_info *)m_swi, AUDIT_VALIDATE_FAST);
 	// if everything looks good, load software
 	if (summary == media_auditor::CORRECT || summary == media_auditor::BEST_AVAILABLE || summary == media_auditor::NONE_NEEDED)
-		hook_load(temp_name, true);
+	{
+		m_image.load_software(temp_name);
+		stack_pop();
+	}
 	else
 	{
 		machine().popmessage(_("The software selected is missing one or more required ROM or CHD images. Please select a different one."));
@@ -153,7 +156,7 @@ void menu_control_device_image::load_software_part()
 //  hook_load
 //-------------------------------------------------
 
-void menu_control_device_image::hook_load(const std::string &name, bool softlist)
+void menu_control_device_image::hook_load(const std::string &name)
 {
 	if (m_image.is_reset_on_load()) m_image.set_init_phase();
 	m_image.load(name);
@@ -276,7 +279,7 @@ void menu_control_device_image::handle()
 			break;
 
 		case menu_file_selector::result::FILE:
-			hook_load(m_current_file, false);
+			hook_load(m_current_file);
 			break;
 
 		case menu_file_selector::result::CREATE:

--- a/src/frontend/mame/ui/imgcntrl.h
+++ b/src/frontend/mame/ui/imgcntrl.h
@@ -53,7 +53,7 @@ protected:
 	bool                            m_create_ok;
 
 	// methods
-	virtual void hook_load(const std::string &filename, bool softlist);
+	virtual void hook_load(const std::string &filename);
 	virtual void handle() override;
 
 private:


### PR DESCRIPTION
I'm still not 100% satisfied with this patch.  While I got rid of the weird path when hook_proc() was called for a software list item, I still don't like the whole m_init_phase infrastructure in devices, which seems to be an arbitrary piece of state.  Baby steps...