### PR TITLE
Fix .hi file load and write

### DIFF
--- a/plugins/hiscore/init.lua
+++ b/plugins/hiscore/init.lua
@@ -24,16 +24,38 @@ function hiscore.startplugin()
 
 	local hiscoredata_path = hiscore_plugin_path .. "/hiscore.dat";
 	local hiscore_path = hiscore_plugin_path .. "/hi";
-
+    	local config_path = manager:options().entries.inipath:value():match("[^;]+") .. "/hiscore.ini";
+	config_path = config_path:gsub("%$(%w+)", os.getenv);
+	
 	local current_checksum = 0;
 	local default_checksum = 0;
 
+	local config_read = false;
 	local scores_have_been_read = false;
 	local mem_check_passed = false;
 	local found_hiscore_entry = false;
 
 	local positions = {};
-
+	-- Configuration file will be searched in the first path defined
+	-- in mame inipath option.
+    	local function read_config()
+	  if config_read then return true end;
+	  local file = io.open( config_path, "r" );
+	  if file then
+		file:close()
+		emu.print_verbose( "hiscore: config found" );
+		local _conf = {}
+		for line in io.lines(config_path) do
+		  token, value = string.match(line, '([^ ]+) ([^ ]+)');
+		  _conf[token] = value:gsub("%$(%w+)", os.getenv);
+		end
+		hiscore_path = _conf["hi_path"];
+		-- hiscoredata_path = _conf["dat_path"]; -- don't know if I should do it, but wathever
+		return true
+	  end
+	  return false
+	end
+	
 	local function parse_table ( dsting )
 	  local _table = {};
 	  for line in string.gmatch(dsting, '([^\n]+)') do
@@ -244,6 +266,7 @@ function hiscore.startplugin()
 	   	scores_have_been_read = false;
 		last_write_time = -10
 	  	emu.print_verbose("Starting " .. emu.gamename())
+	  	config_read = read_config();
 		local dat = read_hiscore_dat()
 		if dat and dat ~= "" then
 			emu.print_verbose( "hiscore: found hiscore.dat entry for " .. emu.romname() );

--- a/plugins/hiscore/init.lua
+++ b/plugins/hiscore/init.lua
@@ -22,8 +22,8 @@ end
 
 function hiscore.startplugin()
 
-	local hiscoredata_path = "hiscore.dat";
-	local hiscore_path = "hi";
+	local hiscoredata_path = hiscore_plugin_path .. "/hiscore.dat";
+	local hiscore_path = hiscore_plugin_path .. "/hi";
 
 	local current_checksum = 0;
 	local default_checksum = 0;
@@ -65,9 +65,6 @@ function hiscore.startplugin()
 	local function read_hiscore_dat ()
 	  local file = io.open( hiscoredata_path, "r" );
 	  local rm_match;
-	  if not file then
-		file = io.open( hiscore_plugin_path .. "/hiscore.dat", "r" );
-	  end
 	  if emu.softname() ~= "" then
 		rm_match = '^' .. emu.romname() .. ',' .. emu.softname() .. ':';
 	  else

--- a/plugins/hiscore/init.lua
+++ b/plugins/hiscore/init.lua
@@ -22,8 +22,8 @@ end
 
 function hiscore.startplugin()
 
-	local hiscoredata_path = hiscore_plugin_path .. "/hiscore.dat";
-	local hiscore_path = hiscore_plugin_path .. "/hi";
+	local hiscoredata_path = "hiscore.dat";
+	local hiscore_path = "hi";
     	local config_path = manager:options().entries.inipath:value():match("[^;]+") .. "/hiscore.ini";
 	config_path = config_path:gsub("%$(%w+)", os.getenv);
 	
@@ -87,6 +87,9 @@ function hiscore.startplugin()
 	local function read_hiscore_dat ()
 	  local file = io.open( hiscoredata_path, "r" );
 	  local rm_match;
+	  if not file then
+		file = io.open( hiscore_plugin_path .. "/hiscore.dat", "r" );
+	  end
 	  if emu.softname() ~= "" then
 		rm_match = '^' .. emu.romname() .. ',' .. emu.softname() .. ':';
 	  else


### PR DESCRIPTION
hiscore.dat and hi folder path were not resolved as expected (their path was relative to mame executable, not to the plugin folder). Explicitly writing them as absolute paths gives the desired behavior.