### PR TITLE
poly.h: Avoid std::min() for comaptibility

### DIFF
--- a/src/devices/video/poly.h
+++ b/src/devices/video/poly.h
@@ -224,7 +224,8 @@ private:
 	// internal array types
 	typedef poly_array<polygon_info, _MaxPolys> polygon_array;
 	typedef poly_array<_ObjectData, _MaxPolys + 1> objectdata_array;
-	typedef poly_array<work_unit, std::min(_MaxPolys * UNITS_PER_POLY, 65535)> unit_array;
+	typedef poly_array<work_unit, (_MaxPolys * UNITS_PER_POLY) < 65535 ?
+		_MaxPolys * UNITS_PER_POLY : 65535> unit_array;
 
 	// round in a cross-platform consistent manner
 	inline INT32 round_coordinate(_BaseType value)


### PR DESCRIPTION
With gcc 4.9.3 and its libstdc++ headers using std::min() here gives
an error, see: http://sprunge.us/TOgG
Using the conditional operator solves the issue for me.