### PR TITLE
Devfind revision phase 2 (nw)

### DIFF
--- a/src/devices/bus/coco/coco_dwsock.cpp
+++ b/src/devices/bus/coco/coco_dwsock.cpp
@@ -203,6 +203,6 @@ WRITE8_MEMBER(beckerport_device::write)
 void beckerport_device::update_port(void)
 {
 	device_stop();
-	m_dwtcpport = read_safe(m_dwconfigport, 65504);
+	m_dwtcpport = m_dwconfigport.read_safe(65504);
 	device_start();
 }

--- a/src/devices/bus/coco/coco_fdc.cpp
+++ b/src/devices/bus/coco/coco_fdc.cpp
@@ -116,7 +116,7 @@ SLOT_INTERFACE_END
 
 coco_rtc_type_t coco_fdc_device::real_time_clock()
 {
-	coco_rtc_type_t result = coco_rtc_type_t(read_safe(machine().root_device().ioport("real_time_clock"), RTC_NONE));
+	coco_rtc_type_t result = coco_rtc_type_t(m_rtc.read_safe(RTC_NONE));
 
 	/* check to make sure we don't have any invalid values */
 	if (((result == RTC_DISTO) && (m_disto_msm6242 == nullptr))
@@ -183,7 +183,8 @@ coco_fdc_device::coco_fdc_device(const machine_config &mconfig, device_type type
 		m_wd17xx(*this, WD_TAG),
 		m_wd2797(*this, WD2797_TAG),
 		m_ds1315(*this, CLOUD9_TAG),
-		m_disto_msm6242(*this, DISTO_TAG), m_msm6242_rtc_address(0)
+		m_disto_msm6242(*this, DISTO_TAG), m_msm6242_rtc_address(0),
+		m_rtc(*this, ":real_time_clock")
 {
 }
 
@@ -193,8 +194,9 @@ coco_fdc_device::coco_fdc_device(const machine_config &mconfig, const char *tag,
 		m_wd17xx(*this, WD_TAG),
 		m_wd2797(*this, WD2797_TAG),
 		m_ds1315(*this, CLOUD9_TAG),
-		m_disto_msm6242(*this, DISTO_TAG), m_msm6242_rtc_address(0)
-	{
+		m_disto_msm6242(*this, DISTO_TAG), m_msm6242_rtc_address(0),
+		m_rtc(*this, ":real_time_clock")
+{
 }
 
 //-------------------------------------------------

--- a/src/devices/bus/coco/coco_fdc.h
+++ b/src/devices/bus/coco/coco_fdc.h
@@ -76,6 +76,7 @@ protected:
 		optional_device<msm6242_device> m_disto_msm6242;        /* 6242 RTC on Disto interface */
 
 		offs_t m_msm6242_rtc_address;
+		optional_ioport m_rtc;
 };
 
 

--- a/src/devices/bus/coco/coco_pak.cpp
+++ b/src/devices/bus/coco/coco_pak.cpp
@@ -41,13 +41,15 @@ const device_type COCO_PAK = &device_creator<coco_pak_device>;
 //-------------------------------------------------
 coco_pak_device::coco_pak_device(const machine_config &mconfig, device_type type, const char *name, const char *tag, device_t *owner, UINT32 clock, const char *shortname, const char *source)
 	: device_t(mconfig, type, name, tag, owner, clock, shortname, source),
-		device_cococart_interface( mconfig, *this ), m_cart(nullptr), m_owner(nullptr)
+		device_cococart_interface( mconfig, *this ), m_cart(nullptr), m_owner(nullptr),
+		m_autostart(*this, ":" CART_AUTOSTART_TAG)
 {
 }
 
 coco_pak_device::coco_pak_device(const machine_config &mconfig, const char *tag, device_t *owner, UINT32 clock)
 		: device_t(mconfig, COCO_PAK, "CoCo Program PAK", tag, owner, clock, "cocopak", __FILE__),
-		device_cococart_interface( mconfig, *this ), m_cart(nullptr), m_owner(nullptr)
+		device_cococart_interface( mconfig, *this ), m_cart(nullptr), m_owner(nullptr),
+		m_autostart(*this, ":" CART_AUTOSTART_TAG)
 	{
 }
 
@@ -87,9 +89,7 @@ const rom_entry *coco_pak_device::device_rom_region() const
 void coco_pak_device::device_reset()
 {
 	if (m_cart->exists()) {
-		cococart_line_value cart_line;
-
-		cart_line = read_safe(machine().root_device().ioport(CART_AUTOSTART_TAG), 0x01)
+		cococart_line_value cart_line = m_autostart.read_safe(0x01)
 			? COCOCART_LINE_VALUE_Q
 			: COCOCART_LINE_VALUE_CLEAR;
 

--- a/src/devices/bus/coco/coco_pak.h
+++ b/src/devices/bus/coco/coco_pak.h
@@ -36,6 +36,8 @@ protected:
 		// internal state
 		device_image_interface *m_cart;
 		cococart_slot_device *m_owner;
+
+		optional_ioport m_autostart;
 };
 
 

--- a/src/devices/bus/megadrive/jcart.cpp
+++ b/src/devices/bus/megadrive/jcart.cpp
@@ -180,14 +180,14 @@ READ16_MEMBER(md_jcart_device::read)
 
 		if (m_jcart_io_data[0] & 0x40)
 		{
-			joy[0] = read_safe(m_jcart3, 0);
-			joy[1] = read_safe(m_jcart4, 0);
+			joy[0] = m_jcart3.read_safe(0);
+			joy[1] = m_jcart4.read_safe(0);
 			return (m_jcart_io_data[0] & 0x40) | joy[0] | (joy[1] << 8);
 		}
 		else
 		{
-			joy[0] = ((read_safe(m_jcart3, 0) & 0xc0) >> 2) | (read_safe(m_jcart3, 0) & 0x03);
-			joy[1] = ((read_safe(m_jcart4, 0) & 0xc0) >> 2) | (read_safe(m_jcart4, 0) & 0x03);
+			joy[0] = ((m_jcart3.read_safe(0) & 0xc0) >> 2) | (m_jcart3.read_safe(0) & 0x03);
+			joy[1] = ((m_jcart4.read_safe(0) & 0xc0) >> 2) | (m_jcart4.read_safe(0) & 0x03);
 			return (m_jcart_io_data[0] & 0x40) | joy[0] | (joy[1] << 8);
 		}
 	}
@@ -223,14 +223,14 @@ READ16_MEMBER(md_seprom_codemast_device::read)
 
 		if (m_jcart_io_data[0] & 0x40)
 		{
-			joy[0] = read_safe(m_jcart3, 0);
-			joy[1] = read_safe(m_jcart4, 0);
+			joy[0] = m_jcart3.read_safe(0);
+			joy[1] = m_jcart4.read_safe(0);
 			return (m_jcart_io_data[0] & 0x40) | joy[0] | (joy[1] << 8);
 		}
 		else
 		{
-			joy[0] = ((read_safe(m_jcart3, 0) & 0xc0) >> 2) | (read_safe(m_jcart3, 0) & 0x03);
-			joy[1] = ((read_safe(m_jcart4, 0) & 0xc0) >> 2) | (read_safe(m_jcart4, 0) & 0x03);
+			joy[0] = ((m_jcart3.read_safe(0) & 0xc0) >> 2) | (m_jcart3.read_safe(0) & 0x03);
+			joy[1] = ((m_jcart4.read_safe(0) & 0xc0) >> 2) | (m_jcart4.read_safe(0) & 0x03);
 			return (m_jcart_io_data[0] & 0x40) | joy[0] | (joy[1] << 8);
 		}
 	}

--- a/src/devices/bus/sg1000_exp/sk1100.cpp
+++ b/src/devices/bus/sg1000_exp/sk1100.cpp
@@ -104,6 +104,9 @@ static INPUT_PORTS_START( sk1100_keys )
 	PORT_BIT( 0x40, IP_ACTIVE_LOW, IPT_KEYBOARD ) PORT_NAME(UTF8_UP) PORT_CODE(KEYCODE_UP) PORT_CHAR(UCHAR_MAMEKEY(UP))
 	PORT_BIT( 0x80, IP_ACTIVE_LOW, IPT_UNUSED )
 
+	PORT_START("PA7")
+	PORT_BIT( 0xff, IP_ACTIVE_LOW, IPT_UNUSED ) // keyboard disabled
+
 	PORT_START("PB0")
 	PORT_BIT( 0x01, IP_ACTIVE_LOW, IPT_KEYBOARD ) PORT_CODE(KEYCODE_8) PORT_CHAR('8') PORT_CHAR('(')
 	PORT_BIT( 0x06, IP_ACTIVE_LOW, IPT_UNUSED )
@@ -134,6 +137,9 @@ static INPUT_PORTS_START( sk1100_keys )
 	PORT_BIT( 0x02, IP_ACTIVE_LOW, IPT_KEYBOARD ) PORT_NAME("GRAPH") PORT_CODE(KEYCODE_LALT) PORT_CHAR(UCHAR_MAMEKEY(LALT))
 	PORT_BIT( 0x04, IP_ACTIVE_LOW, IPT_KEYBOARD ) PORT_NAME("CTRL") PORT_CODE(KEYCODE_LCONTROL) PORT_CHAR(UCHAR_MAMEKEY(LCONTROL))
 	PORT_BIT( 0x08, IP_ACTIVE_LOW, IPT_KEYBOARD ) PORT_NAME("SHIFT") PORT_CODE(KEYCODE_LSHIFT) PORT_CODE(KEYCODE_RSHIFT) PORT_CHAR(UCHAR_SHIFT_1)
+
+	PORT_START("PB7")
+	PORT_BIT( 0x0f, IP_ACTIVE_LOW, IPT_UNUSED ) // keyboard disabled
 INPUT_PORTS_END
 
 
@@ -185,20 +191,8 @@ sega_sk1100_device::sega_sk1100_device(const machine_config &mconfig, const char
 	device_sg1000_expansion_slot_interface(mconfig, *this),
 	m_cassette(*this, "cassette"),
 	m_ppi(*this, UPD9255_0_TAG),
-	m_pa0(*this, "PA0"),
-	m_pa1(*this, "PA1"),
-	m_pa2(*this, "PA2"),
-	m_pa3(*this, "PA3"),
-	m_pa4(*this, "PA4"),
-	m_pa5(*this, "PA5"),
-	m_pa6(*this, "PA6"),
-	m_pb0(*this, "PB0"),
-	m_pb1(*this, "PB1"),
-	m_pb2(*this, "PB2"),
-	m_pb3(*this, "PB3"),
-	m_pb4(*this, "PB4"),
-	m_pb5(*this, "PB5"),
-	m_pb6(*this, "PB6"),
+	m_pa(*this, {"PA0", "PA1", "PA2", "PA3", "PA4", "PA5", "PA6", "PA7"}),
+	m_pb(*this, {"PB0", "PB1", "PB2", "PB3", "PB4", "PB5", "PB6", "PB7"}),
 	m_keylatch(0)
 {
 }
@@ -210,24 +204,6 @@ sega_sk1100_device::sega_sk1100_device(const machine_config &mconfig, const char
 
 void sega_sk1100_device::device_start()
 {
-	// find keyboard rows
-	m_key_row[0] = m_pa0;
-	m_key_row[1] = m_pa1;
-	m_key_row[2] = m_pa2;
-	m_key_row[3] = m_pa3;
-	m_key_row[4] = m_pa4;
-	m_key_row[5] = m_pa5;
-	m_key_row[6] = m_pa6;
-	m_key_row[7] = nullptr; // keyboard disabled
-	m_key_row[8] = m_pb0;
-	m_key_row[9] = m_pb1;
-	m_key_row[10] = m_pb2;
-	m_key_row[11] = m_pb3;
-	m_key_row[12] = m_pb4;
-	m_key_row[13] = m_pb5;
-	m_key_row[14] = m_pb6;
-	m_key_row[15] = nullptr; // keyboard disabled
-
 	/* register for state saving */
 	save_item(NAME(m_keylatch));
 }
@@ -278,7 +254,7 @@ READ8_MEMBER( sega_sk1100_device::ppi_pa_r )
 	    PA7     Keyboard input
 	*/
 
-	return m_key_row[m_keylatch]->read();
+	return m_pa[m_keylatch]->read();
 }
 
 READ8_MEMBER( sega_sk1100_device::ppi_pb_r )
@@ -297,7 +273,7 @@ READ8_MEMBER( sega_sk1100_device::ppi_pb_r )
 	*/
 
 	/* keyboard */
-	UINT8 data = m_key_row[m_keylatch + 8]->read();
+	UINT8 data = m_pb[m_keylatch]->read();
 
 	/* cartridge contact */
 	data |= 0x10;

--- a/src/devices/bus/sg1000_exp/sk1100.h
+++ b/src/devices/bus/sg1000_exp/sk1100.h
@@ -54,23 +54,10 @@ protected:
 	virtual bool is_readable(UINT8 offset) override;
 
 private:
-	ioport_port* m_key_row[16];
 	required_device<cassette_image_device> m_cassette;
 	required_device<i8255_device> m_ppi;
-	required_ioport m_pa0;
-	required_ioport m_pa1;
-	required_ioport m_pa2;
-	required_ioport m_pa3;
-	required_ioport m_pa4;
-	required_ioport m_pa5;
-	required_ioport m_pa6;
-	required_ioport m_pb0;
-	required_ioport m_pb1;
-	required_ioport m_pb2;
-	required_ioport m_pb3;
-	required_ioport m_pb4;
-	required_ioport m_pb5;
-	required_ioport m_pb6;
+	required_ioport_array<8> m_pa;
+	required_ioport_array<8> m_pb;
 
 	/* keyboard state */
 	UINT8 m_keylatch;

--- a/src/devices/machine/pckeybrd.cpp
+++ b/src/devices/machine/pckeybrd.cpp
@@ -528,39 +528,39 @@ UINT32 pc_keyboard_device::readport(int port)
 	switch(port)
 	{
 		case 0:
-			if(m_ioport_0)
+			if (m_ioport_0.found())
 				result = m_ioport_0->read();
 			break;
 		case 1:
-			if(m_ioport_1)
+			if (m_ioport_1.found())
 				result = m_ioport_1->read();
 			break;
 		case 2:
-			if(m_ioport_2)
+			if (m_ioport_2.found())
 				result = m_ioport_2->read();
 			break;
 		case 3:
-			if(m_ioport_3)
+			if (m_ioport_3.found())
 				result = m_ioport_3->read();
 			break;
 		case 4:
-			if(m_ioport_4)
+			if (m_ioport_4.found())
 				result = m_ioport_4->read();
 			break;
 		case 5:
-			if(m_ioport_5)
+			if (m_ioport_5.found())
 				result = m_ioport_5->read();
 			break;
 		case 6:
-			if(m_ioport_6)
+			if (m_ioport_6.found())
 				result = m_ioport_6->read();
 			break;
 		case 7:
-			if(m_ioport_7)
+			if (m_ioport_7.found())
 				result = m_ioport_7->read();
 			break;
 	}
-	return result;
+	return 0;
 }
 
 void pc_keyboard_device::polling(void)

--- a/src/devices/video/snes_ppu.cpp
+++ b/src/devices/video/snes_ppu.cpp
@@ -203,7 +203,12 @@ const device_type SNES_PPU = &device_creator<snes_ppu_device>;
 snes_ppu_device::snes_ppu_device(const machine_config &mconfig, const char *tag, device_t *owner, UINT32 clock)
 				: device_t(mconfig, SNES_PPU, "SNES PPU", tag, owner, clock, "snes_ppu", __FILE__),
 					device_video_interface(mconfig, *this),
-					m_openbus_cb(*this)
+					m_openbus_cb(*this),
+					m_options(*this, ":OPTIONS"),
+					m_debug1(*this, ":DEBUG1"),
+					m_debug2(*this, ":DEBUG2"),
+					m_debug3(*this, ":DEBUG3"),
+					m_debug4(*this, ":DEBUG4")
 {
 }
 
@@ -1819,7 +1824,7 @@ void snes_ppu_device::refresh_scanline( bitmap_rgb32 &bitmap, UINT16 curline )
 	struct SNES_SCANLINE *scanline1, *scanline2;
 	UINT16 c;
 	UINT16 prev_colour = 0;
-	int blurring = read_safe(machine().root_device().ioport("OPTIONS"), 0) & 0x01;
+	int blurring = m_options.read_safe(0) & 0x01;
 
 	g_profiler.start(PROFILER_VIDEO);
 
@@ -2831,13 +2836,13 @@ void snes_ppu_device::write(address_space &space, UINT32 offset, UINT8 data)
 UINT8 snes_ppu_device::dbg_video( UINT16 curline )
 {
 	int i;
-	UINT8 toggles = read_safe(machine().root_device().ioport("DEBUG1"), 0);
+	UINT8 toggles = m_debug1.read_safe(0);
 	m_debug_options.select_pri[SNES_BG1] = (toggles & 0x03);
 	m_debug_options.select_pri[SNES_BG2] = (toggles & 0x0c) >> 2;
 	m_debug_options.select_pri[SNES_BG3] = (toggles & 0x30) >> 4;
 	m_debug_options.select_pri[SNES_BG4] = (toggles & 0xc0) >> 6;
 
-	toggles = read_safe(machine().root_device().ioport("DEBUG2"), 0);
+	toggles = m_debug2.read_safe(0);
 	for (i = 0; i < 4; i++)
 		DEBUG_TOGGLE(i, m_debug_options.bg_disabled[i], ("Debug: Disabled BG%d.\n", i + 1), ("Debug: Enabled BG%d.\n", i + 1))
 	DEBUG_TOGGLE(4, m_debug_options.bg_disabled[SNES_OAM], ("Debug: Disabled OAM.\n"), ("Debug: Enabled OAM.\n"))
@@ -2845,11 +2850,11 @@ UINT8 snes_ppu_device::dbg_video( UINT16 curline )
 	DEBUG_TOGGLE(6, m_debug_options.colormath_disabled, ("Debug: Disabled Color Math.\n"), ("Debug: Enabled Color Math.\n"))
 	DEBUG_TOGGLE(7, m_debug_options.windows_disabled, ("Debug: Disabled Window Masks.\n"), ("Debug: Enabled Window Masks.\n"))
 
-	toggles = read_safe(machine().root_device().ioport("DEBUG4"), 0);
+	toggles = m_debug4.read_safe(0);
 	for (i = 0; i < 8; i++)
 		DEBUG_TOGGLE(i, m_debug_options.mode_disabled[i], ("Debug: Disabled Mode %d drawing.\n", i), ("Debug: Enabled Mode %d drawing.\n", i))
 
-	toggles = read_safe(machine().root_device().ioport("DEBUG3"), 0);
+	toggles = m_debug3.read_safe(0);
 	DEBUG_TOGGLE(2, m_debug_options.mosaic_disabled, ("Debug: Disabled Mosaic.\n"), ("Debug: Enabled Mosaic.\n"))
 	m_debug_options.sprite_reversed = BIT(toggles, 7);
 	m_debug_options.select_pri[SNES_OAM] = (toggles & 0x70) >> 4;

--- a/src/devices/video/snes_ppu.h
+++ b/src/devices/video/snes_ppu.h
@@ -278,6 +278,11 @@ protected:
 
 private:
 	devcb_read16  m_openbus_cb;
+	optional_ioport m_options;
+	optional_ioport m_debug1;
+	optional_ioport m_debug2;
+	optional_ioport m_debug3;
+	optional_ioport m_debug4;
 };
 
 

--- a/src/emu/ioport.h
+++ b/src/emu/ioport.h
@@ -1325,8 +1325,6 @@ private:
 	std::unique_ptr<ioport_port_live> m_live;      // live state of port (nullptr if not live)
 };
 
-inline ioport_value read_safe(ioport_port *port, ioport_value defval) { return (port == nullptr) ? defval : port->read(); }
-
 
 
 // ======================> analog_field

--- a/src/mame/audio/midway.cpp
+++ b/src/mame/audio/midway.cpp
@@ -53,6 +53,7 @@ midway_ssio_device::midway_ssio_device(const machine_config &mconfig, const char
 		m_cpu(*this, "cpu"),
 		m_ay0(*this, "ay0"),
 		m_ay1(*this, "ay1"),
+		m_ports(*this, {"IP0", "IP1", "IP2", "IP3", "IP4"}),
 		m_status(0),
 		m_14024_count(0),
 		m_mute(0)
@@ -113,8 +114,7 @@ WRITE_LINE_MEMBER(midway_ssio_device::reset_write)
 
 READ8_MEMBER(midway_ssio_device::ioport_read)
 {
-	static const char *const port[] = { "IP0", "IP1", "IP2", "IP3", "IP4" };
-	UINT8 result = read_safe(ioport(port[offset]), 0xff);
+	UINT8 result = m_ports[offset].read_safe(0xff);
 	if (!m_custom_input[offset].isnull())
 		result = (result & ~m_custom_input_mask[offset]) |
 					(m_custom_input[offset](space, offset, 0xff) & m_custom_input_mask[offset]);

--- a/src/mame/audio/midway.h
+++ b/src/mame/audio/midway.h
@@ -104,6 +104,9 @@ private:
 	required_device<ay8910_device> m_ay0;
 	required_device<ay8910_device> m_ay1;
 
+	// I/O ports
+	optional_ioport_array<5> m_ports;
+
 	// internal state
 	UINT8 m_data[4];
 	UINT8 m_status;

--- a/src/mame/drivers/8080bw.cpp
+++ b/src/mame/drivers/8080bw.cpp
@@ -2986,8 +2986,8 @@ INPUT_CHANGED_MEMBER(_8080bw_state::claybust_gun_trigger)
 		    ana  a
 		    rz
 		*/
-		UINT8 const gunx = read_safe(ioport("GUNX"), 0x00);
-		UINT8 const guny = read_safe(ioport("GUNY"), 0x20);
+		UINT8 const gunx = m_gunx.read_safe(0x00);
+		UINT8 const guny = m_guny.read_safe(0x20);
 		m_claybust_gun_pos = ((gunx >> 3) | (guny << 5)) + 2;
 		m_claybust_gun_on->adjust(attotime::from_msec(250)); // timing is a guess
 	}

--- a/src/mame/drivers/aces1.cpp
+++ b/src/mame/drivers/aces1.cpp
@@ -44,14 +44,7 @@ public:
 			m_reel1(*this, "reel1"),
 			m_reel2(*this, "reel2"),
 			m_reel3(*this, "reel3"),
-			m_io1_port(*this, "IO1"),
-			m_io2_port(*this, "IO2"),
-			m_io3_port(*this, "IO3"),
-			m_io4_port(*this, "IO4"),
-			m_io5_port(*this, "IO5"),
-			m_io6_port(*this, "IO6"),
-			m_io7_port(*this, "IO7"),
-			m_io8_port(*this, "IO8")
+			m_io_ports(*this, {"IO1", "IO2", "IO3", "IO4", "IO5", "IO6", "IO7", "IO8"})
 	{ }
 	int m_input_strobe;
 	int m_lamp_strobe;
@@ -197,9 +190,7 @@ public:
 
 	DECLARE_READ8_MEMBER( ic37_read_b )
 	{
-		ioport_port * portnames[] = { m_io1_port, m_io2_port, m_io3_port, m_io4_port, m_io5_port, m_io6_port, m_io7_port, m_io8_port,m_io1_port, m_io2_port, m_io3_port, m_io4_port, m_io5_port, m_io6_port, m_io7_port, m_io8_port };
-
-		return (portnames[m_input_strobe])->read();
+		return (m_io_ports[m_input_strobe & 7])->read();
 	}
 
 	DECLARE_READ8_MEMBER( ic37_read_c )
@@ -219,14 +210,7 @@ public:
 	required_device<stepper_device> m_reel1;
 	required_device<stepper_device> m_reel2;
 	required_device<stepper_device> m_reel3;
-	required_ioport m_io1_port;
-	required_ioport m_io2_port;
-	required_ioport m_io3_port;
-	required_ioport m_io4_port;
-	required_ioport m_io5_port;
-	required_ioport m_io6_port;
-	required_ioport m_io7_port;
-	required_ioport m_io8_port;
+	required_ioport_array<8> m_io_ports;
 
 	DECLARE_DRIVER_INIT(aces1);
 	virtual void machine_start() override;

--- a/src/mame/drivers/alg.cpp
+++ b/src/mame/drivers/alg.cpp
@@ -87,8 +87,8 @@ int alg_state::get_lightgun_pos(int player, int *x, int *y)
 {
 	const rectangle &visarea = m_screen->visible_area();
 
-	int xpos = (player == 0) ? m_gun1x->read() : (m_gun2x ? m_gun2x->read() : 0xffffffff);
-	int ypos = (player == 0) ? m_gun1y->read() : (m_gun2y ? m_gun2y->read() : 0xffffffff);
+	int xpos = (player == 0) ? m_gun1x->read() : m_gun2x.read_safe(0xffffffff);
+	int ypos = (player == 0) ? m_gun1y->read() : m_gun2y.read_safe(0xffffffff);
 
 	if (xpos == -1 || ypos == -1)
 		return FALSE;

--- a/src/mame/drivers/apple2.cpp
+++ b/src/mame/drivers/apple2.cpp
@@ -334,7 +334,7 @@ TIMER_DEVICE_CALLBACK_MEMBER(napple2_state::apple2_interrupt)
 		m_video->m_sysconfig = m_sysconfig->read();
 
 		// check reset
-		if (m_resetdip) // if reset DIP is present, use it
+		if (m_resetdip.found()) // if reset DIP is present, use it
 		{
 			if (m_resetdip->read() & 1)
 			{       // CTRL-RESET

--- a/src/mame/drivers/astrocde.cpp
+++ b/src/mame/drivers/astrocde.cpp
@@ -265,7 +265,7 @@ READ8_MEMBER(astrocde_state::spacezap_io_r)
 {
 	machine().bookkeeping().coin_counter_w(0, (offset >> 8) & 1);
 	machine().bookkeeping().coin_counter_w(1, (offset >> 9) & 1);
-	return m_p3handle ? m_p3handle->read() : 0xff;
+	return m_p3handle.read_safe(0xff);
 }
 
 

--- a/src/mame/drivers/astrof.cpp
+++ b/src/mame/drivers/astrof.cpp
@@ -198,7 +198,7 @@ void astrof_state::astrof_get_pens( pen_t *pens )
 {
 	offs_t i;
 	UINT8 bank = (m_astrof_palette_bank ? 0x10 : 0x00);
-	UINT8 config = read_safe(ioport("FAKE"), 0x00);
+	UINT8 config = m_fake_port.read_safe(0x00);
 	UINT8 *prom = memregion("proms")->base();
 
 	/* a common wire hack to the pcb causes the prom halves to be inverted */
@@ -234,7 +234,7 @@ void astrof_state::tomahawk_get_pens( pen_t *pens )
 {
 	offs_t i;
 	UINT8 *prom = memregion("proms")->base();
-	UINT8 config = read_safe(ioport("FAKE"), 0x00);
+	UINT8 config = m_fake_port.read_safe(0x00);
 
 	for (i = 0; i < TOMAHAWK_NUM_PENS; i++)
 	{

--- a/src/mame/drivers/atarist.cpp
+++ b/src/mame/drivers/atarist.cpp
@@ -566,7 +566,7 @@ READ8_MEMBER( st_state::ikbd_port2_r )
 
 	*/
 
-	UINT8 data = m_joy1 ? m_joy1->read() & 0x06 : 0x06;
+	UINT8 data = m_joy1.read_safe(0x06) & 0x06;
 
 	// serial receive
 	data |= m_ikbd_tx << 3;
@@ -653,7 +653,7 @@ READ8_MEMBER( st_state::ikbd_port4_r )
 
 	if (m_ikbd_joy) return 0xff;
 
-	UINT8 data = m_joy0 ? m_joy0->read() : 0xff;
+	UINT8 data = m_joy0.read_safe(0xff);
 
 	if ((m_config->read() & 0x01) == 0)
 	{
@@ -1941,7 +1941,8 @@ void st_state::machine_start()
 		m_maincpu->space(AS_PROGRAM).install_read_handler(0xfa0000, 0xfbffff, read16_delegate(FUNC(generic_slot_device::read16_rom),(generic_slot_device*)m_cart));
 
 	// allocate timers
-	if(m_mousex) {
+	if (m_mousex.found())
+	{
 		m_mouse_timer = timer_alloc(TIMER_MOUSE_TICK);
 		m_mouse_timer->adjust(attotime::zero, 0, attotime::from_hz(500));
 	}

--- a/src/mame/drivers/attache.cpp
+++ b/src/mame/drivers/attache.cpp
@@ -86,14 +86,7 @@ public:
 			m_palette(*this, "palette"),
 			m_floppy0(*this, "fdc:0:525dd"),
 			m_floppy1(*this, "fdc:1:525dd"),
-			m_kb_row0(*this, "row0"),
-			m_kb_row1(*this, "row1"),
-			m_kb_row2(*this, "row2"),
-			m_kb_row3(*this, "row3"),
-			m_kb_row4(*this, "row4"),
-			m_kb_row5(*this, "row5"),
-			m_kb_row6(*this, "row6"),
-			m_kb_row7(*this, "row7"),
+			m_kb_rows(*this, {"row0", "row1", "row2", "row3", "row4", "row5", "row6", "row7"}),
 			m_kb_mod(*this, "modifiers"),
 			m_membank1(*this, "bank1"),
 			m_membank2(*this, "bank2"),
@@ -183,14 +176,7 @@ private:
 	required_device<palette_device> m_palette;
 	required_device<floppy_image_device> m_floppy0;
 	required_device<floppy_image_device> m_floppy1;
-	required_ioport m_kb_row0;
-	required_ioport m_kb_row1;
-	required_ioport m_kb_row2;
-	required_ioport m_kb_row3;
-	required_ioport m_kb_row4;
-	required_ioport m_kb_row5;
-	required_ioport m_kb_row6;
-	required_ioport m_kb_row7;
+	required_ioport_array<8> m_kb_rows;
 	required_ioport m_kb_mod;
 	required_memory_bank m_membank1;
 	required_memory_bank m_membank2;
@@ -370,13 +356,12 @@ WRITE8_MEMBER(attache_state::rom_w)
 UINT16 attache_state::get_key()
 {
 	UINT8 row,bits,data;
-	ioport_port* keys[8] = { m_kb_row0, m_kb_row1, m_kb_row2, m_kb_row3, m_kb_row4, m_kb_row5, m_kb_row6, m_kb_row7 };
 	UINT8 res = 0;
 
 	// scan input ports
 	for(row=0;row<8;row++)
 	{
-		data = keys[row]->read();
+		data = m_kb_rows[row]->read();
 		for(bits=0;bits<8;bits++)
 		{
 			if(BIT(data,bits))

--- a/src/mame/drivers/bbc.cpp
+++ b/src/mame/drivers/bbc.cpp
@@ -659,14 +659,14 @@ INPUT_PORTS_END
 
 INPUT_CHANGED_MEMBER(bbc_state::monitor_changed)
 {
-	m_monitortype = read_safe(ioport("BBCCONFIG"), 0) &0x03;
+	m_monitortype = m_bbcconfig.read_safe(0) &0x03;
 }
 
 
 INPUT_CHANGED_MEMBER(bbc_state::speech_changed)
 {
 	// Switchable during runtime as some games (Hyper Sports, Space Fighter) are not compatible with Speech
-	m_Speech = read_safe(ioport("BBCCONFIG"), 0) & 0x04;
+	m_Speech = m_bbcconfig.read_safe(0) & 0x04;
 }
 
 

--- a/src/mame/drivers/bfm_sc4.cpp
+++ b/src/mame/drivers/bfm_sc4.cpp
@@ -110,13 +110,12 @@
 
 UINT8 sc4_state::read_input_matrix(int row)
 {
-	ioport_port* portnames[16] = { m_io1, m_io2, m_io3, m_io4, m_io5, m_io6, m_io7, m_io8, m_io9, m_io10, m_io11, m_io12 };
 	UINT8 value;
 
 	if (row<4)
-		value = (read_safe(portnames[row], 0x00) & 0x1f) + ((read_safe(portnames[row+8], 0x00) & 0x07) << 5);
+		value = (m_io_ports[row].read_safe(0x00) & 0x1f) + ((m_io_ports[row+8].read_safe(0x00) & 0x07) << 5);
 	else
-		value = (read_safe(portnames[row], 0x00) & 0x1f) + ((read_safe(portnames[row+4], 0x00) & 0x18) << 2);
+		value = (m_io_ports[row].read_safe(0x00) & 0x1f) + ((m_io_ports[row+4].read_safe(0x00) & 0x18) << 2);
 
 	return value;
 }

--- a/src/mame/drivers/bwidow.cpp
+++ b/src/mame/drivers/bwidow.cpp
@@ -264,9 +264,9 @@ READ8_MEMBER(bwidow_state::spacduel_IN3_r)
 	int res2;
 	int res3;
 
-	res1 = ioport("IN3")->read();
-	res2 = ioport("IN4")->read();
-	res3 = read_safe(ioport("DSW2"), 0);
+	res1 = m_in3->read();
+	res2 = m_in4->read();
+	res3 = m_dsw2.read_safe(0);
 	res = 0x00;
 
 	switch (offset & 0x07)
@@ -315,7 +315,7 @@ CUSTOM_INPUT_MEMBER(bwidow_state::clock_r)
 
 READ8_MEMBER(bwidow_state::bwidowp_in_r)
 {
-	return (ioport("IN4")->read() & 0x0f) | ((ioport("IN3")->read() & 0x0f) << 4);
+	return (m_in4->read() & 0x0f) | ((m_in3->read() & 0x0f) << 4);
 }
 
 /*************************************

--- a/src/mame/drivers/cdi.cpp
+++ b/src/mame/drivers/cdi.cpp
@@ -143,35 +143,35 @@ INPUT_CHANGED_MEMBER(cdi_state::mcu_input)
 	switch((FPTR)param)
 	{
 		case 0x39:
-			if(m_input1 && m_input1->read() & 0x01) send = true;
+			if (m_input1.read_safe(0) & 0x01) send = true;
 			break;
 		case 0x37:
-			if(m_input1 && m_input1->read() & 0x02) send = true;
+			if (m_input1.read_safe(0) & 0x02) send = true;
 			break;
 		case 0x31:
-			if(m_input1 && m_input1->read() & 0x04) send = true;
+			if (m_input1.read_safe(0) & 0x04) send = true;
 			break;
 		case 0x32:
-			if(m_input1 && m_input1->read() & 0x08) send = true;
+			if (m_input1.read_safe(0) & 0x08) send = true;
 			break;
 		case 0x33:
-			if(m_input1 && m_input1->read() & 0x10) send = true;
+			if (m_input1.read_safe(0) & 0x10) send = true;
 			break;
 
 		case 0x30:
-			if(m_input2 && m_input2->read() & 0x01) send = true;
+			if (m_input2.read_safe(0) & 0x01) send = true;
 			break;
 		case 0x38:
-			if(m_input2 && m_input2->read() & 0x02) send = true;
+			if (m_input2.read_safe(0) & 0x02) send = true;
 			break;
 		case 0x34:
-			if(m_input2 && m_input2->read() & 0x04) send = true;
+			if (m_input2.read_safe(0) & 0x04) send = true;
 			break;
 		case 0x35:
-			if(m_input2 && m_input2->read() & 0x08) send = true;
+			if (m_input2.read_safe(0) & 0x08) send = true;
 			break;
 		case 0x36:
-			if(m_input2 && m_input2->read() & 0x10) send = true;
+			if (m_input2.read_safe(0) & 0x10) send = true;
 			break;
 	}
 

--- a/src/mame/drivers/cinemat.cpp
+++ b/src/mame/drivers/cinemat.cpp
@@ -151,7 +151,7 @@ READ8_MEMBER(cinemat_state::joystick_read)
 	else
 	{
 		int const xval = INT16(m_maincpu->state_int(CCPU_X) << 4) >> 4;
-		return (read_safe(ioport(m_mux_select ? "ANALOGX" : "ANALOGY"), 0) - xval) < 0x800;
+		return ((m_mux_select ? m_analog_x : m_analog_y).read_safe(0) - xval) < 0x800;
 	}
 }
 

--- a/src/mame/drivers/cobra.cpp
+++ b/src/mame/drivers/cobra.cpp
@@ -504,12 +504,16 @@ protected:
 
 private:
 	int m_coin_counter[2];
+	optional_ioport m_test_port;
+	optional_ioport_array<2> m_player_ports;
 };
 
 const device_type COBRA_JVS = &device_creator<cobra_jvs>;
 
 cobra_jvs::cobra_jvs(const machine_config &mconfig, const char *tag, device_t *owner, UINT32 clock)
-	: jvs_device(mconfig, COBRA_JVS, "JVS (COBRA)", tag, owner, clock, "cobra_jvs", __FILE__)
+	: jvs_device(mconfig, COBRA_JVS, "JVS (COBRA)", tag, owner, clock, "cobra_jvs", __FILE__),
+		m_test_port(*this, ":TEST"),
+		m_player_ports(*this, {":P1", ":P2"})
 {
 	m_coin_counter[0] = 0;
 	m_coin_counter[1] = 0;
@@ -551,13 +555,11 @@ bool cobra_jvs::switches(UINT8 *&buf, UINT8 count_players, UINT8 bytes_per_switc
 	if (count_players > 2 || bytes_per_switch > 2)
 		return false;
 
-	static const char* player_ports[2] = { ":P1", ":P2" };
-
-	*buf++ = read_safe(ioport(":TEST"), 0);
+	*buf++ = m_test_port.read_safe(0);
 
 	for (int i=0; i < count_players; i++)
 	{
-		UINT32 pval = read_safe(ioport(player_ports[i]), 0);
+		UINT32 pval = m_player_ports[i].read_safe(0);
 		for (int j=0; j < bytes_per_switch; j++)
 		{
 			*buf++ = (UINT8)(pval >> ((1-j) * 8));

--- a/src/mame/drivers/coleco.cpp
+++ b/src/mame/drivers/coleco.cpp
@@ -231,18 +231,18 @@ READ8_MEMBER( coleco_state::cart_r )
 
 UINT8 coleco_state::coleco_scan_paddles(UINT8 *joy_status0, UINT8 *joy_status1)
 {
-	UINT8 ctrl_sel = (m_ctrlsel != nullptr) ? m_ctrlsel->read() : 0;
+	UINT8 ctrl_sel = m_ctrlsel.read_safe(0);
 
 	/* which controller shall we read? */
 	if ((ctrl_sel & 0x07) == 0x02)          // Super Action Controller P1
-		*joy_status0 = (m_sac_slide1 != nullptr) ? m_sac_slide1->read() : 0;
+		*joy_status0 = m_sac_slide1.read_safe(0);
 	else if ((ctrl_sel & 0x07) == 0x03)     // Driving Controller P1
-		*joy_status0 = (m_driv_wheel1 != nullptr) ? m_driv_wheel1->read() : 0;
+		*joy_status0 = m_driv_wheel1.read_safe(0);
 
 	if ((ctrl_sel & 0x70) == 0x20)          // Super Action Controller P2
-		*joy_status1 = (m_sac_slide2 != nullptr) ? m_sac_slide2->read() : 0;
+		*joy_status1 = m_sac_slide2.read_safe(0);
 	else if ((ctrl_sel & 0x70) == 0x30)     // Driving Controller P2
-		*joy_status1 = (m_driv_wheel2 != nullptr) ? m_driv_wheel2->read() : 0;
+		*joy_status1 = m_driv_wheel2.read_safe(0);
 
 	/* In principle, even if not supported by any game, I guess we could have two Super
 	   Action Controllers plugged into the Roller controller ports. Since I found no info
@@ -250,8 +250,8 @@ UINT8 coleco_state::coleco_scan_paddles(UINT8 *joy_status0, UINT8 *joy_status1)
 	   the Roller trackball inputs and actually use the latter ones, when both are selected. */
 	if (ctrl_sel & 0x80)                    // Roller controller
 	{
-		*joy_status0 = (m_roller_x != nullptr) ? m_roller_x->read() : 0;
-		*joy_status1 = (m_roller_y != nullptr) ? m_roller_y->read() : 0;
+		*joy_status0 = m_roller_x.read_safe(0);
+		*joy_status1 = m_roller_y.read_safe(0);
 	}
 
 	return *joy_status0 | *joy_status1;
@@ -260,7 +260,7 @@ UINT8 coleco_state::coleco_scan_paddles(UINT8 *joy_status0, UINT8 *joy_status1)
 
 UINT8 coleco_state::coleco_paddle_read(int port, int joy_mode, UINT8 joy_status)
 {
-	UINT8 ctrl_sel = (m_ctrlsel != nullptr ) ? m_ctrlsel->read() : 0;
+	UINT8 ctrl_sel = m_ctrlsel.read_safe(0);
 	UINT8 ctrl_extra = ctrl_sel & 0x80;
 	ctrl_sel = ctrl_sel >> (port*4) & 7;
 

--- a/src/mame/drivers/combatsc.cpp
+++ b/src/mame/drivers/combatsc.cpp
@@ -268,13 +268,12 @@ READ8_MEMBER(combatsc_state::trackball_r)
 	if (offset == 0)
 	{
 		int i, dir[4];
-		static const char *const tracknames[] = { "TRACK0_Y", "TRACK0_X", "TRACK1_Y", "TRACK1_X" };
 
 		for (i = 0; i < 4; i++)
 		{
 			UINT8 curr;
 
-			curr = read_safe(ioport(tracknames[i]), 0xff);
+			curr = m_track_ports[i].read_safe(0xff);
 
 			dir[i] = curr - m_pos[i];
 			m_sign[i] = dir[i] & 0x80;

--- a/src/mame/drivers/cosmic.cpp
+++ b/src/mame/drivers/cosmic.cpp
@@ -324,12 +324,12 @@ READ8_MEMBER(cosmic_state::cosmica_pixel_clock_r)
 READ8_MEMBER(cosmic_state::cosmicg_port_0_r)
 {
 	/* The top four address lines from the CRTC are bits 0-3 */
-	return (ioport("IN0")->read() & 0xf0) | ((m_screen->vpos() & 0xf0) >> 4);
+	return (m_in_ports[0]->read() & 0xf0) | ((m_screen->vpos() & 0xf0) >> 4);
 }
 
 READ8_MEMBER(cosmic_state::magspot_coinage_dip_r)
 {
-	return (read_safe(ioport("DSW"), 0) & (1 << (7 - offset))) ? 0 : 1;
+	return (m_dsw.read_safe(0) & (1 << (7 - offset))) ? 0 : 1;
 }
 
 
@@ -337,8 +337,8 @@ READ8_MEMBER(cosmic_state::magspot_coinage_dip_r)
 
 READ8_MEMBER(cosmic_state::nomnlnd_port_0_1_r)
 {
-	int control = ioport(offset ? "IN1" : "IN0")->read();
-	int fire = ioport("IN3")->read();
+	int control = m_in_ports[offset]->read();
+	int fire = m_in_ports[3]->read();
 
 	/* If firing - stop tank */
 	if ((fire & 0xc0) == 0) return 0xff;

--- a/src/mame/drivers/cosmicos.cpp
+++ b/src/mame/drivers/cosmicos.cpp
@@ -456,12 +456,6 @@ void cosmicos_state::machine_start()
 	/* initialize LED display */
 	m_led->rbi_w(1);
 
-	// find keyboard rows
-	m_key_row[0] = m_y1;
-	m_key_row[1] = m_y2;
-	m_key_row[2] = m_y3;
-	m_key_row[3] = m_y4;
-
 	/* register for state saving */
 	save_item(NAME(m_wait));
 	save_item(NAME(m_clear));

--- a/src/mame/drivers/cp1.cpp
+++ b/src/mame/drivers/cp1.cpp
@@ -28,11 +28,7 @@ public:
 		m_i8155(*this, "i8155"),
 		m_i8155_cp3(*this, "i8155_cp3"),
 		m_cassette(*this, "cassette"),
-		m_io_line0(*this, "LINE0"),
-		m_io_line1(*this, "LINE1"),
-		m_io_line2(*this, "LINE2"),
-		m_io_line3(*this, "LINE3"),
-		m_io_line4(*this, "LINE4"),
+		m_io_lines(*this, {"LINE0", "LINE1", "LINE2", "LINE3", "LINE4"}),
 		m_io_config(*this, "CONFIG")
 	{ }
 
@@ -40,11 +36,7 @@ public:
 	required_device<i8155_device> m_i8155;
 	required_device<i8155_device> m_i8155_cp3;
 	required_device<cassette_image_device> m_cassette;
-	required_ioport m_io_line0;
-	required_ioport m_io_line1;
-	required_ioport m_io_line2;
-	required_ioport m_io_line3;
-	required_ioport m_io_line4;
+	required_ioport_array<5> m_io_lines;
 	required_ioport m_io_config;
 
 	virtual void machine_reset() override;
@@ -99,12 +91,11 @@ READ8_MEMBER(cp1_state::port2_r)
 	// ---x ----   I8155 CE
 	// ---- xxxx   keyboard input
 
-	ioport_port* portnames[] = { m_io_line0, m_io_line1, m_io_line2, m_io_line3, m_io_line4 };
 	UINT8 data = 0;
 
 	for(int i=0; i<5; i++)
 		if (!(m_matrix & (1<<i)))
-			data |= portnames[i]->read();
+			data |= m_io_lines[i]->read();
 
 	return (data & 0x0f) | (m_port2 & 0xf0);
 }

--- a/src/mame/drivers/djmain.cpp
+++ b/src/mame/drivers/djmain.cpp
@@ -224,14 +224,13 @@ READ8_MEMBER(djmain_state::inp2_r)
 READ32_MEMBER(djmain_state::turntable_r)
 {
 	UINT32 result = 0;
-	static const char *const ttnames[] = { "TT1", "TT2" };
 
 	if (ACCESSING_BITS_8_15)
 	{
 		UINT8 pos;
 		int delta;
 
-		pos = read_safe(ioport(ttnames[m_turntable_select]), 0);
+		pos = m_turntable[m_turntable_select].read_safe(0);
 		delta = pos - m_turntable_last_pos[m_turntable_select];
 		if (delta < -128)
 			delta += 256;

--- a/src/mame/drivers/elwro800.cpp
+++ b/src/mame/drivers/elwro800.cpp
@@ -40,7 +40,7 @@ public:
 		m_i8251(*this, "i8251"),
 		m_i8255(*this, "ppi8255"),
 		m_centronics(*this, "centronics"),
-		m_io_line8(*this, "LINE8"),
+		m_io_ports(*this, {"LINE7", "LINE6", "LINE5", "LINE4", "LINE3", "LINE2", "LINE1", "LINE0", "LINE8"}),
 		m_io_line9(*this, "LINE9"),
 		m_io_network_id(*this, "NETWORK ID")
 	{
@@ -68,7 +68,7 @@ protected:
 	required_device<i8251_device> m_i8251;
 	required_device<i8255_device> m_i8255;
 	required_device<centronics_device> m_centronics;
-	required_ioport m_io_line8;
+	required_ioport_array<9> m_io_ports;
 	required_ioport m_io_line9;
 	required_ioport m_io_network_id;
 
@@ -234,7 +234,6 @@ READ8_MEMBER(elwro800_state::elwro800jr_io_r)
 		int mask = 0x8000;
 		int data = 0xff;
 		int i;
-		ioport_port *io_ports[9] = { m_io_line7, m_io_line6, m_io_line5, m_io_line4, m_io_line3, m_io_line2, m_io_line1, m_io_line0, m_io_line8 };
 
 		if ( !m_NR )
 		{
@@ -242,7 +241,7 @@ READ8_MEMBER(elwro800_state::elwro800jr_io_r)
 			{
 				if (!(offset & mask))
 				{
-					data &= io_ports[i]->read();
+					data &= m_io_ports[i]->read();
 				}
 			}
 

--- a/src/mame/drivers/fidel6502.cpp
+++ b/src/mame/drivers/fidel6502.cpp
@@ -743,7 +743,7 @@ WRITE8_MEMBER(fidel6502_state::fexcel_ttl_w)
 READ8_MEMBER(fidel6502_state::fexcel_ttl_r)
 {
 	// a0-a2,d6: from speech board: language switches and TSI BUSY line, otherwise tied to VCC
-	UINT8 d6 = (read_safe(m_inp_matrix[9], 0xff) >> offset & 1) ? 0x40 : 0;
+	UINT8 d6 = (m_inp_matrix[9].read_safe(0xff) >> offset & 1) ? 0x40 : 0;
 
 	// a0-a2,d7: multiplexed inputs (active low)
 	return d6 | ((read_inputs(9) >> offset & 1) ? 0 : 0x80);

--- a/src/mame/drivers/firetrk.cpp
+++ b/src/mame/drivers/firetrk.cpp
@@ -155,8 +155,8 @@ void firetrk_state::machine_reset()
 
 READ8_MEMBER(firetrk_state::firetrk_dip_r)
 {
-	UINT8 val0 = ioport("DIP_0")->read();
-	UINT8 val1 = ioport("DIP_1")->read();
+	UINT8 val0 = m_dips[0]->read();
+	UINT8 val1 = m_dips[1]->read();
 
 	if (val1 & (1 << (2 * offset + 0))) val0 |= 1;
 	if (val1 & (1 << (2 * offset + 1))) val0 |= 2;
@@ -167,8 +167,8 @@ READ8_MEMBER(firetrk_state::firetrk_dip_r)
 
 READ8_MEMBER(firetrk_state::montecar_dip_r)
 {
-	UINT8 val0 = ioport("DIP_0")->read();
-	UINT8 val1 = ioport("DIP_1")->read();
+	UINT8 val0 = m_dips[0]->read();
+	UINT8 val1 = m_dips[1]->read();
 
 	if (val1 & (1 << (3 - offset))) val0 |= 1;
 	if (val1 & (1 << (7 - offset))) val0 |= 2;
@@ -230,7 +230,7 @@ READ8_MEMBER(firetrk_state::firetrk_input_r)
 	/* update steering wheels */
 	for (i = 0; i < 2; i++)
 	{
-		UINT32 const new_dial = read_safe(ioport(i ? "STEER_2" : "STEER_1"), 0);
+		UINT32 const new_dial = m_steer[i].read_safe(0);
 		INT32 const delta = new_dial - m_dial[i];
 
 		if (delta != 0)
@@ -242,9 +242,9 @@ READ8_MEMBER(firetrk_state::firetrk_input_r)
 		}
 	}
 
-	return ((read_safe(ioport("BIT_0"), 0) & (1 << offset)) ? 0x01 : 0) |
-			((read_safe(ioport("BIT_6"), 0) & (1 << offset)) ? 0x40 : 0) |
-			((read_safe(ioport("BIT_7"), 0) & (1 << offset)) ? 0x80 : 0);
+	return ((m_bit_0.read_safe(0) & (1 << offset)) ? 0x01 : 0) |
+			((m_bit_6.read_safe(0) & (1 << offset)) ? 0x40 : 0) |
+			((m_bit_7.read_safe(0) & (1 << offset)) ? 0x80 : 0);
 }
 
 

--- a/src/mame/drivers/fm7.cpp
+++ b/src/mame/drivers/fm7.cpp
@@ -1288,7 +1288,6 @@ void fm7_state::key_press(UINT16 scancode)
 
 void fm7_state::fm7_keyboard_poll_scan()
 {
-	ioport_port* portnames[3] = { m_key1, m_key2, m_key3 };
 	int bit = 0;
 	int x,y;
 	UINT32 keys;
@@ -1297,7 +1296,7 @@ void fm7_state::fm7_keyboard_poll_scan()
 
 	for(x=0;x<3;x++)
 	{
-		keys = portnames[x]->read();
+		keys = m_kb_ports[x]->read();
 
 		for(y=0;y<32;y++)  // loop through each bit in the port
 		{
@@ -1333,14 +1332,13 @@ void fm7_state::fm7_keyboard_poll_scan()
 
 TIMER_CALLBACK_MEMBER(fm7_state::fm7_keyboard_poll)
 {
-	ioport_port* portnames[3] = { m_key1, m_key2, m_key3 };
 	int x,y;
 	int bit = 0;
 	int mod = 0;
 	UINT32 keys;
 	UINT32 modifiers = m_keymod->read();
 
-	if(m_key3->read() & 0x40000)
+	if (m_kb_ports[2]->read() & 0x40000)
 	{
 		m_break_flag = 1;
 		m_maincpu->set_input_line(M6809_FIRQ_LINE,ASSERT_LINE);
@@ -1369,7 +1367,7 @@ TIMER_CALLBACK_MEMBER(fm7_state::fm7_keyboard_poll)
 
 	for(x=0;x<3;x++)
 	{
-		keys = portnames[x]->read();
+		keys = m_kb_ports[x]->read();
 
 		for(y=0;y<32;y++)  // loop through each bit in the port
 		{

--- a/src/mame/drivers/fmtowns.cpp
+++ b/src/mame/drivers/fmtowns.cpp
@@ -661,21 +661,21 @@ void towns_state::kb_sendcode(UINT8 scancode, int release)
 		case 0:  // key press
 			m_towns_kb_output = 0x80;
 			m_towns_kb_extend = scancode & 0x7f;
-			if(m_key3->read() & 0x00080000)
+			if (m_kb_ports[2]->read() & 0x00080000)
 				m_towns_kb_output |= 0x04;
-			if(m_key3->read() & 0x00040000)
+			if (m_kb_ports[2]->read() & 0x00040000)
 				m_towns_kb_output |= 0x08;
-			if(m_key3->read() & 0x06400000)
+			if (m_kb_ports[2]->read() & 0x06400000)
 				m_towns_kb_output |= 0x20;
 			break;
 		case 1:  // key release
 			m_towns_kb_output = 0x90;
 			m_towns_kb_extend = scancode & 0x7f;
-			if(m_key3->read() & 0x00080000)
+			if (m_kb_ports[2]->read() & 0x00080000)
 				m_towns_kb_output |= 0x04;
-			if(m_key3->read() & 0x00040000)
+			if (m_kb_ports[2]->read() & 0x00040000)
 				m_towns_kb_output |= 0x08;
-			if(m_key3->read() & 0x06400000)
+			if (m_kb_ports[2]->read() & 0x06400000)
 				m_towns_kb_output |= 0x20;
 			break;
 		case 2:  // extended byte
@@ -694,7 +694,6 @@ void towns_state::kb_sendcode(UINT8 scancode, int release)
 
 void towns_state::poll_keyboard()
 {
-	ioport_port* kb_ports[4] = { m_key1, m_key2, m_key3, m_key4 };
 	int port,bit;
 	UINT8 scan;
 	UINT32 portval;
@@ -702,7 +701,7 @@ void towns_state::poll_keyboard()
 	scan = 0;
 	for(port=0;port<4;port++)
 	{
-		portval = kb_ports[port]->read();
+		portval = m_kb_ports[port]->read();
 		for(bit=0;bit<32;bit++)
 		{
 			if(((portval & (1<<bit))) != ((m_kb_prev[port] & (1<<bit))))

--- a/src/mame/drivers/gaelco3d.cpp
+++ b/src/mame/drivers/gaelco3d.cpp
@@ -430,10 +430,10 @@ WRITE16_MEMBER(gaelco3d_state::analog_port_latch_w)
 	{
 		if (!(data & 0xff))
 		{
-			m_analog_ports[0] = read_safe(ioport("ANALOG0"), 0);
-			m_analog_ports[1] = read_safe(ioport("ANALOG1"), 0);
-			m_analog_ports[2] = read_safe(ioport("ANALOG2"), 0);
-			m_analog_ports[3] = read_safe(ioport("ANALOG3"), 0);
+			m_analog_ports[0] = m_analog[0].read_safe(0);
+			m_analog_ports[1] = m_analog[1].read_safe(0);
+			m_analog_ports[2] = m_analog[2].read_safe(0);
+			m_analog_ports[3] = m_analog[3].read_safe(0);
 		}
 	}
 	else

--- a/src/mame/drivers/galaxian.cpp
+++ b/src/mame/drivers/galaxian.cpp
@@ -687,7 +687,7 @@ INTERRUPT_GEN_MEMBER(galaxian_state::fakechange_interrupt_gen)
 {
 	interrupt_gen(device);
 
-	if (read_safe(ioport("FAKE_SELECT"), 0x00))
+	if (m_fake_select.read_safe(0x00))
 	{
 		m_tenspot_current_game++;
 		m_tenspot_current_game%=10;
@@ -6589,9 +6589,10 @@ DRIVER_INIT_MEMBER(galaxian_state,pacmanbl)
 
 READ8_MEMBER(galaxian_state::tenspot_dsw_read)
 {
-	char tmp[64];
-	sprintf(tmp,"IN2_GAME%d", m_tenspot_current_game);
-	return read_safe(ioport(tmp), 0x00);
+	if (m_tenspot_current_game >= 0 && m_tenspot_current_game < 10)
+		return m_tenspot_game_dsw[m_tenspot_current_game]->read();
+	else
+		return 0x00;
 }
 
 

--- a/src/mame/drivers/gomoku.cpp
+++ b/src/mame/drivers/gomoku.cpp
@@ -32,11 +32,10 @@ todo:
 READ8_MEMBER(gomoku_state::input_port_r)
 {
 	int i, res;
-	static const char *const portnames[] = { "IN0", "IN1", "DSW", "UNUSED0", "UNUSED1", "UNUSED2", "UNUSED3", "UNUSED4" };
 
 	res = 0;
 	for (i = 0; i < 8; i++)
-		res |= ((read_safe(ioport(portnames[i]), 0xff) >> offset) & 1) << i;
+		res |= ((m_inputs[i].read_safe(0xff) >> offset) & 1) << i;
 
 	return res;
 }

--- a/src/mame/drivers/gottlieb.cpp
+++ b/src/mame/drivers/gottlieb.cpp
@@ -284,8 +284,8 @@ CUSTOM_INPUT_MEMBER(gottlieb_state::analog_delta_r)
 WRITE8_MEMBER(gottlieb_state::gottlieb_analog_reset_w)
 {
 	/* reset the trackball counters */
-	m_track[0] = read_safe(ioport("TRACKX"), 0);
-	m_track[1] = read_safe(ioport("TRACKY"), 0);
+	m_track[0] = m_track_x.read_safe(0);
+	m_track[1] = m_track_y.read_safe(0);
 }
 
 

--- a/src/mame/drivers/hornet.cpp
+++ b/src/mame/drivers/hornet.cpp
@@ -995,8 +995,8 @@ ADC12138_IPT_CONVERT_CB(hornet_state::adc12138_input_callback)
 	int value = 0;
 	switch (input)
 	{
-		case 0: value = (m_analog1) ? m_analog1->read() : 0; break;
-		case 1: value = (m_analog2) ? m_analog2->read() : 0; break;
+		case 0: value = m_analog1.read_safe(0); break;
+		case 1: value = m_analog2.read_safe(0); break;
 	}
 
 	return (double)(value) / 2047.0;

--- a/src/mame/drivers/huebler.cpp
+++ b/src/mame/drivers/huebler.cpp
@@ -278,24 +278,6 @@ static const z80_daisy_config amu880_daisy_chain[] =
 
 void amu880_state::machine_start()
 {
-	// find keyboard rows
-	m_key_row[0] = m_y0;
-	m_key_row[1] = m_y1;
-	m_key_row[2] = m_y2;
-	m_key_row[3] = m_y3;
-	m_key_row[4] = m_y4;
-	m_key_row[5] = m_y5;
-	m_key_row[6] = m_y6;
-	m_key_row[7] = m_y7;
-	m_key_row[8] = m_y8;
-	m_key_row[9] = m_y9;
-	m_key_row[10] = m_y10;
-	m_key_row[11] = m_y11;
-	m_key_row[12] = m_y12;
-	m_key_row[13] = m_y13;
-	m_key_row[14] = m_y14;
-	m_key_row[15] = m_y15;
-
 	/* register for state saving */
 	save_item(NAME(m_key_d6));
 	save_item(NAME(m_key_d7));

--- a/src/mame/drivers/jackal.cpp
+++ b/src/mame/drivers/jackal.cpp
@@ -87,7 +87,7 @@ Address          Dir Data     Description
 
 READ8_MEMBER(jackal_state::jackalr_rotary_r)
 {
-	return (1 << read_safe(ioport(offset ? "DIAL1" : "DIAL0"), 0x00)) ^ 0xff;
+	return (1 << m_dials[offset].read_safe(0x00)) ^ 0xff;
 }
 
 WRITE8_MEMBER(jackal_state::jackal_flipscreen_w)

--- a/src/mame/drivers/laserbat.cpp
+++ b/src/mame/drivers/laserbat.cpp
@@ -136,8 +136,7 @@ WRITE8_MEMBER(laserbat_state_base::ct_io_w)
 
 READ8_MEMBER(laserbat_state_base::rrowx_r)
 {
-	ioport_port *const mux_ports[] = { m_row0, m_row1, m_sw1, m_sw2 };
-	return (m_mpx_p_1_2 ? m_row2 : mux_ports[m_input_mux])->read();
+	return (m_mpx_p_1_2 ? m_row2 : m_mux_ports[m_input_mux])->read();
 }
 
 /*

--- a/src/mame/drivers/mac.cpp
+++ b/src/mame/drivers/mac.cpp
@@ -136,7 +136,7 @@ WRITE32_MEMBER( mac_state::rbv_ramdac_w )
 			if (m_model != MODEL_MAC_CLASSIC_II)
 			{
 				// Color Classic has no MONTYPE so the default gets us 512x384, which is right
-				if ((m_montype ? m_montype->read() : 2) == 1)
+				if (m_montype.read_safe(2) == 1)
 				{
 					m_palette->set_pen_color(m_rbv_clutoffs, rgb_t(m_rbv_colors[2], m_rbv_colors[2], m_rbv_colors[2]));
 					m_rbv_palette[m_rbv_clutoffs] = rgb_t(m_rbv_colors[2], m_rbv_colors[2], m_rbv_colors[2]);
@@ -172,7 +172,7 @@ WRITE32_MEMBER( mac_state::ariel_ramdac_w ) // this is for the "Ariel" style RAM
 			if (m_model != MODEL_MAC_CLASSIC_II)
 			{
 				// Color Classic has no MONTYPE so the default gets us 512x384, which is right
-				if ((m_montype ? m_montype->read() : 2) == 1)
+				if (m_montype.read_safe(2) == 1)
 				{
 					m_palette->set_pen_color(m_rbv_clutoffs, rgb_t(m_rbv_colors[2], m_rbv_colors[2], m_rbv_colors[2]));
 					m_rbv_palette[m_rbv_clutoffs] = rgb_t(m_rbv_colors[2], m_rbv_colors[2], m_rbv_colors[2]);
@@ -204,7 +204,7 @@ READ8_MEMBER( mac_state::mac_sonora_vctl_r )
 	if (offset == 2)
 	{
 //        printf("Sonora: read monitor ID at PC=%x\n", m_maincpu->pc());
-		return ((m_montype ? m_montype->read() : 6)<<4);
+		return (m_montype.read_safe(6)<<4);
 	}
 
 	return m_sonora_vctl[offset];
@@ -260,7 +260,7 @@ READ8_MEMBER ( mac_state::mac_rbv_r )
 		if (offset == 0x10)
 		{
 			data &= ~0x38;
-			data |= ((m_montype ? m_montype->read() : 2)<<3);
+			data |= (m_montype.read_safe(2)<<3);
 //            printf("rbv_r montype: %02x (PC %x)\n", data, space.cpu->safe_pc());
 		}
 

--- a/src/mame/drivers/maxaflex.cpp
+++ b/src/mame/drivers/maxaflex.cpp
@@ -389,12 +389,12 @@ INPUT_PORTS_END
 
 READ8_MEMBER(maxaflex_state::pia_pa_r)
 {
-	return atari_input_disabled() ? 0xff : read_safe(m_joy01, 0);
+	return atari_input_disabled() ? 0xff : m_joy01.read_safe(0);
 }
 
 READ8_MEMBER(maxaflex_state::pia_pb_r)
 {
-	return atari_input_disabled() ? 0xff : read_safe(m_joy23, 0);
+	return atari_input_disabled() ? 0xff : m_joy23.read_safe(0);
 }
 
 

--- a/src/mame/drivers/maygay1b.cpp
+++ b/src/mame/drivers/maygay1b.cpp
@@ -559,8 +559,7 @@ WRITE8_MEMBER( maygay1b_state::lamp_data_w )
 
 READ8_MEMBER( maygay1b_state::kbd_r )
 {
-	ioport_port * portnames[] = { m_sw1_port, m_s2_port, m_s3_port, m_s4_port, m_s5_port, m_s6_port, m_s7_port, m_sw2_port};
-	return (portnames[m_lamp_strobe&0x07])->read();
+	return (m_kbd_ports[m_lamp_strobe&0x07])->read();
 }
 
 WRITE8_MEMBER( maygay1b_state::lamp_data_2_w )

--- a/src/mame/drivers/megadriv.cpp
+++ b/src/mame/drivers/megadriv.cpp
@@ -356,7 +356,7 @@ MACHINE_RESET_MEMBER(md_cons_state, ms_megadriv)
 // same as screen_eof_megadriv but with addition of 32x and SegaCD/MegaCD pieces
 void md_cons_state::screen_eof_console(screen_device &screen, bool state)
 {
-	if (m_io_reset && (m_io_reset->read() & 0x01))
+	if (m_io_reset.read_safe(0) & 0x01)
 		m_maincpu->set_input_line(INPUT_LINE_RESET, PULSE_LINE);
 
 	// rising edge

--- a/src/mame/drivers/meyc8088.cpp
+++ b/src/mame/drivers/meyc8088.cpp
@@ -43,13 +43,16 @@ public:
 		m_maincpu(*this,"maincpu"),
 		m_vram(*this, "vram"),
 		m_heartbeat(*this, "heartbeat"),
-		m_dac(*this, "dac")
+		m_dac(*this, "dac"),
+		m_switches(*this, {"C0", "C1", "C2", "C3"})
 	{ }
 
 	required_device<cpu_device> m_maincpu;
 	required_shared_ptr<UINT8> m_vram;
 	required_device<timer_device> m_heartbeat;
 	required_device<dac_device> m_dac;
+
+	optional_ioport_array<4> m_switches;
 
 	UINT8 m_status;
 	UINT8 m_common;
@@ -231,10 +234,10 @@ READ8_MEMBER(meyc8088_state::meyc8088_input_r)
 	UINT8 ret = 0xff;
 
 	// multiplexed switch inputs
-	if (~m_common & 1) ret &= read_safe(ioport("C0"), 0); // bit switches
-	if (~m_common & 2) ret &= read_safe(ioport("C1"), 0); // control switches
-	if (~m_common & 4) ret &= read_safe(ioport("C2"), 0); // light switches
-	if (~m_common & 8) ret &= read_safe(ioport("C3"), 0); // light switches
+	if (~m_common & 1) ret &= m_switches[0].read_safe(0); // bit switches
+	if (~m_common & 2) ret &= m_switches[1].read_safe(0); // control switches
+	if (~m_common & 4) ret &= m_switches[2].read_safe(0); // light switches
+	if (~m_common & 8) ret &= m_switches[3].read_safe(0); // light switches
 
 	return ret;
 }

--- a/src/mame/drivers/midvunit.cpp
+++ b/src/mame/drivers/midvunit.cpp
@@ -135,14 +135,13 @@ READ32_MEMBER(midvunit_state::midvunit_adc_r)
 
 WRITE32_MEMBER(midvunit_state::midvunit_adc_w)
 {
-	static const char *const adcnames[] = { "WHEEL", "ACCEL", "BRAKE" };
-
 	if (!(m_control_data & 0x20))
 	{
 		int which = (data >> m_adc_shift) - 4;
 		if (which < 0 || which > 2)
 			logerror("adc_w: unexpected which = %02X\n", which + 4);
-		m_adc_data = read_safe(ioport(adcnames[which]), 0);
+		else
+			m_adc_data = m_adc_ports[which].read_safe(0);
 		timer_set(attotime::from_msec(1), TIMER_ADC_READY);
 	}
 	else

--- a/src/mame/drivers/model1.cpp
+++ b/src/mame/drivers/model1.cpp
@@ -638,11 +638,8 @@ Notes:
 
 READ16_MEMBER(model1_state::io_r)
 {
-	static const char *const analognames[] = { "AN.0", "AN.1", "AN.2", "AN.3", "AN.4", "AN.5", "AN.6", "AN.7" };
-	static const char *const inputnames[] = { "IN.0", "IN.1", "IN.2" };
-
 	if(offset < 0x8)
-		return read_safe(ioport(analognames[offset]), 0x00);
+		return m_analog_ports[offset].read_safe(0x00);
 
 	if(offset == 0x0f)
 		return m_lamp_state;
@@ -651,7 +648,7 @@ READ16_MEMBER(model1_state::io_r)
 	{
 		offset -= 0x8;
 		if(offset < 3)
-			return ioport(inputnames[offset])->read();
+			return m_digital_ports[offset]->read();
 		return 0xff;
 	}
 

--- a/src/mame/drivers/model2.cpp
+++ b/src/mame/drivers/model2.cpp
@@ -520,7 +520,7 @@ WRITE32_MEMBER(model2_state::videoctl_w)
 
 CUSTOM_INPUT_MEMBER(model2_state::_1c00000_r)
 {
-	UINT32 ret = ioport("IN0")->read();
+	UINT32 ret = m_in0->read();
 
 	if(m_ctrlmode == 0)
 	{
@@ -538,8 +538,7 @@ CUSTOM_INPUT_MEMBER(model2_state::_1c0001c_r)
 	UINT32 iptval = 0x00ff;
 	if(m_analog_channel < 4)
 	{
-		static const char *const ports[] = { "ANA0", "ANA1", "ANA2", "ANA3" };
-		iptval = read_safe(ioport(ports[m_analog_channel]), 0);
+		iptval = m_analog_ports[m_analog_channel].read_safe(0);
 		++m_analog_channel;
 	}
 	return iptval;
@@ -557,7 +556,7 @@ CUSTOM_INPUT_MEMBER(model2_state::_1c0001c_r)
 /* Used specifically by Sega Rally, others might be different */
 CUSTOM_INPUT_MEMBER(model2_state::srallyc_gearbox_r)
 {
-	UINT8 res = read_safe(ioport("GEARS"), 0);
+	UINT8 res = m_gears.read_safe(0);
 	int i;
 	const UINT8 gearvalue[5] = { 0, 2, 1, 6, 5 };
 
@@ -1054,21 +1053,20 @@ WRITE32_MEMBER(model2_state::geo_w)
 
 READ32_MEMBER(model2_state::hotd_lightgun_r)
 {
-	static const char *const ports[] = { "P1_Y", "P1_X", "P2_Y", "P2_X" };
 	UINT16 res = 0xffff;
 
 	if(m_lightgun_mux < 8)
-		res = (read_safe(ioport(ports[m_lightgun_mux >> 1]), 0) >> ((m_lightgun_mux & 1)*8)) & 0xff;
+		res = (m_lightgun_ports[m_lightgun_mux >> 1].read_safe(0) >> ((m_lightgun_mux & 1)*8)) & 0xff;
 	else
 	{
 		UINT16 p1x,p1y,p2x,p2y;
 
 		res = 0xfffc;
 
-		p1x = read_safe(ioport("P1_X"), 0);
-		p1y = read_safe(ioport("P1_Y"), 0);
-		p2x = read_safe(ioport("P2_X"), 0);
-		p2y = read_safe(ioport("P2_Y"), 0);
+		p1x = m_lightgun_ports[1].read_safe(0);
+		p1y = m_lightgun_ports[0].read_safe(0);
+		p2x = m_lightgun_ports[3].read_safe(0);
+		p2y = m_lightgun_ports[2].read_safe(0);
 
 		/* TODO: might be better, supposedly user has to calibrate guns in order to make these settings to work ... */
 		if(p1x <= 0x28 || p1x >= 0x3e0 || p1y <= 0x40 || p1y >= 0x3c0)
@@ -1479,10 +1477,9 @@ ADDRESS_MAP_END
 
 READ8_MEMBER(model2_state::virtuacop_lightgun_r)
 {
-	static const char *const ports[] = { "P1_Y", "P1_X", "P2_Y", "P2_X" };
 	UINT8 res;
 
-	res = (read_safe(ioport(ports[offset >> 1]), 0) >> ((offset & 1)*8)) & 0xff;
+	res = (m_lightgun_ports[offset >> 1].read_safe(0) >> ((offset & 1)*8)) & 0xff;
 
 	return res;
 }
@@ -1493,10 +1490,10 @@ READ8_MEMBER(model2_state::virtuacop_lightgun_offscreen_r)
 	UINT16 special_res = 0xfffc;
 	UINT16 p1x,p1y,p2x,p2y;
 
-	p1x = read_safe(ioport("P1_X"), 0);
-	p1y = read_safe(ioport("P1_Y"), 0);
-	p2x = read_safe(ioport("P2_X"), 0);
-	p2y = read_safe(ioport("P2_Y"), 0);
+	p1x = m_lightgun_ports[1].read_safe(0);
+	p1y = m_lightgun_ports[0].read_safe(0);
+	p2x = m_lightgun_ports[3].read_safe(0);
+	p2y = m_lightgun_ports[2].read_safe(0);
 
 	/* TODO: might be better, supposedly user has to calibrate guns in order to make these settings to work ... */
 	if(p1x <= 0x28 || p1x >= 0x3e0 || p1y <= 0x40 || p1y >= 0x3c0)

--- a/src/mame/drivers/model3.cpp
+++ b/src/mame/drivers/model3.cpp
@@ -1431,8 +1431,7 @@ READ64_MEMBER(model3_state::model3_ctrl_r)
 		case 7:
 			if (ACCESSING_BITS_24_31)       /* ADC Data read */
 			{
-				static const char *const adcnames[] = { "AN0", "AN1", "AN2", "AN3", "AN4", "AN5", "AN6", "AN7" };
-				const UINT8 adc_data = read_safe(ioport(adcnames[m_adc_channel]), 0);
+				const UINT8 adc_data = m_adc_ports[m_adc_channel].read_safe(0);
 				m_adc_channel++;
 				m_adc_channel &= 0x7;
 				return (UINT64)adc_data << 24;

--- a/src/mame/drivers/mpu4.cpp
+++ b/src/mame/drivers/mpu4.cpp
@@ -1255,14 +1255,12 @@ WRITE_LINE_MEMBER(mpu4_state::pia_ic7_cb2_w)
 /* IC8, Inputs, TRIACS, alpha clock */
 READ8_MEMBER(mpu4_state::pia_ic8_porta_r)
 {
-	ioport_port * portnames[] = { m_orange1_port, m_orange2_port, m_black1_port, m_black2_port, m_orange1_port, m_orange2_port, m_dil1_port, m_dil2_port };
-
 	LOG_IC8(("%s: IC8 PIA Read of Port A (MUX input data)\n", machine().describe_context()));
 /* The orange inputs are polled twice as often as the black ones, for reasons of efficiency.
    This is achieved via connecting every input line to an AND gate, thus allowing two strobes
    to represent each orange input bank (strobes are active low). */
 	m_pia5->cb1_w(m_aux2_port->read() & 0x80);
-	return (portnames[m_input_strobe])->read();
+	return (m_port_mux[m_input_strobe])->read();
 }
 
 

--- a/src/mame/drivers/multigam.cpp
+++ b/src/mame/drivers/multigam.cpp
@@ -118,10 +118,16 @@ public:
 	multigam_state(const machine_config &mconfig, device_type type, const char *tag)
 		: driver_device(mconfig, type, tag),
 		m_maincpu(*this, "maincpu"),
-		m_ppu(*this, "ppu") { }
+		m_ppu(*this, "ppu"),
+		m_p1(*this, "P1"),
+		m_p2(*this, "P2"),
+		m_dsw(*this, "DSW") { }
 
 	required_device<cpu_device> m_maincpu;
 	required_device<ppu2c0x_device> m_ppu;
+	required_ioport m_p1;
+	required_ioport m_p2;
+	optional_ioport m_dsw;
 
 	std::unique_ptr<UINT8[]> m_nt_ram;
 	std::unique_ptr<UINT8[]> m_vram;
@@ -313,11 +319,11 @@ WRITE8_MEMBER(multigam_state::multigam_IN0_w)
 	m_in_0_shift = 0;
 	m_in_1_shift = 0;
 
-	m_in_0 = ioport("P1")->read();
-	m_in_1 = ioport("P2")->read();
+	m_in_0 = m_p1->read();
+	m_in_1 = m_p2->read();
 
 	m_in_dsw_shift = 0;
-	m_in_dsw = read_safe(ioport("DSW"), 0);
+	m_in_dsw = m_dsw.read_safe(0);
 }
 
 READ8_MEMBER(multigam_state::multigam_IN1_r)

--- a/src/mame/drivers/mz2000.cpp
+++ b/src/mame/drivers/mz2000.cpp
@@ -55,21 +55,7 @@ public:
 		m_region_chargen(*this, "chargen"),
 		m_region_ipl(*this, "ipl"),
 		m_region_wram(*this, "wram"),
-		m_io_key0(*this, "KEY0"),
-		m_io_key1(*this, "KEY1"),
-		m_io_key2(*this, "KEY2"),
-		m_io_key3(*this, "KEY3"),
-		m_io_key4(*this, "KEY4"),
-		m_io_key5(*this, "KEY5"),
-		m_io_key6(*this, "KEY6"),
-		m_io_key7(*this, "KEY7"),
-		m_io_key8(*this, "KEY8"),
-		m_io_key9(*this, "KEY9"),
-		m_io_keya(*this, "KEYA"),
-		m_io_keyb(*this, "KEYB"),
-		m_io_keyc(*this, "KEYC"),
-		m_io_keyd(*this, "KEYD"),
-		m_io_unused(*this, "UNUSED"),
+		m_io_keys(*this, {"KEY0", "KEY1", "KEY2", "KEY3", "KEY4", "KEY5", "KEY6", "KEY7", "KEY8", "KEY9", "KEYA", "KEYB", "KEYC", "KEYD", "UNUSED", "UNUSED"}),
 		m_io_config(*this, "CONFIG"),
 		m_palette(*this, "palette")  { }
 
@@ -141,21 +127,7 @@ protected:
 	required_memory_region m_region_chargen;
 	required_memory_region m_region_ipl;
 	required_memory_region m_region_wram;
-	required_ioport m_io_key0;
-	required_ioport m_io_key1;
-	required_ioport m_io_key2;
-	required_ioport m_io_key3;
-	required_ioport m_io_key4;
-	required_ioport m_io_key5;
-	required_ioport m_io_key6;
-	required_ioport m_io_key7;
-	required_ioport m_io_key8;
-	required_ioport m_io_key9;
-	required_ioport m_io_keya;
-	required_ioport m_io_keyb;
-	required_ioport m_io_keyc;
-	required_ioport m_io_keyd;
-	required_ioport m_io_unused;
+	required_ioport_array<16> m_io_keys;
 	required_ioport m_io_config;
 	required_device<palette_device> m_palette;
 };
@@ -760,23 +732,18 @@ WRITE8_MEMBER(mz2000_state::mz2000_pio1_porta_w)
 
 READ8_MEMBER(mz2000_state::mz2000_pio1_portb_r)
 {
-	ioport_port* keynames[] = { m_io_key0, m_io_key1, m_io_key2, m_io_key3,
-								m_io_key4, m_io_key5, m_io_key6, m_io_key7,
-								m_io_key8, m_io_key9, m_io_keya, m_io_keyb,
-								m_io_keyc, m_io_keyd, m_io_unused, m_io_unused };
-
 	if(((m_key_mux & 0x10) == 0x00) || ((m_key_mux & 0x0f) == 0x0f)) //status read
 	{
 		int res,i;
 
 		res = 0xff;
 		for(i=0;i<0xe;i++)
-			res &= keynames[i]->read();
+			res &= m_io_keys[i]->read();
 
 		return res;
 	}
 
-	return keynames[m_key_mux & 0xf]->read();
+	return m_io_keys[m_key_mux & 0xf]->read();
 }
 
 READ8_MEMBER(mz2000_state::mz2000_pio1_porta_r)

--- a/src/mame/drivers/namcofl.cpp
+++ b/src/mame/drivers/namcofl.cpp
@@ -282,16 +282,16 @@ READ8_MEMBER(namcofl_state::port7_r)
 	switch (m_mcu_port6 & 0xf0)
 	{
 		case 0x00:
-			return ioport("IN0")->read();
+			return m_in0->read();
 
 		case 0x20:
-			return ioport("MISC")->read();
+			return m_misc->read();
 
 		case 0x40:
-			return ioport("IN1")->read();
+			return m_in1->read();
 
 		case 0x60:
-			return ioport("IN2")->read();
+			return m_in2->read();
 
 		default:
 			break;
@@ -302,17 +302,17 @@ READ8_MEMBER(namcofl_state::port7_r)
 
 READ8_MEMBER(namcofl_state::dac7_r)
 {
-	return read_safe(ioport("ACCEL"), 0xff);
+	return m_accel.read_safe(0xff);
 }
 
 READ8_MEMBER(namcofl_state::dac6_r)
 {
-	return read_safe(ioport("BRAKE"), 0xff);
+	return m_brake.read_safe(0xff);
 }
 
 READ8_MEMBER(namcofl_state::dac5_r)
 {
-	return read_safe(ioport("WHEEL"), 0xff);
+	return m_wheel.read_safe(0xff);
 }
 
 READ8_MEMBER(namcofl_state::dac4_r){ return 0xff; }

--- a/src/mame/drivers/namconb1.cpp
+++ b/src/mame/drivers/namconb1.cpp
@@ -639,10 +639,10 @@ READ32_MEMBER(namconb1_state::gunbulet_gun_r)
 
 	switch (offset)
 	{
-		case 0: case 1: result = (UINT8)(0x0f + ioport("LIGHT1_Y")->read() * 224/255); break; /* Y (p2) */
-		case 2: case 3: result = (UINT8)(0x26 + ioport("LIGHT1_X")->read() * 288/314); break; /* X (p2) */
-		case 4: case 5: result = (UINT8)(0x0f + ioport("LIGHT0_Y")->read() * 224/255); break; /* Y (p1) */
-		case 6: case 7: result = (UINT8)(0x26 + ioport("LIGHT0_X")->read() * 288/314); break; /* X (p1) */
+		case 0: case 1: result = (UINT8)(0x0f + m_light1_y->read() * 224/255); break; /* Y (p2) */
+		case 2: case 3: result = (UINT8)(0x26 + m_light1_x->read() * 288/314); break; /* X (p2) */
+		case 4: case 5: result = (UINT8)(0x0f + m_light0_y->read() * 224/255); break; /* Y (p1) */
+		case 6: case 7: result = (UINT8)(0x26 + m_light0_x->read() * 288/314); break; /* X (p1) */
 	}
 	return result<<24;
 } /* gunbulet_gun_r */
@@ -757,16 +757,16 @@ READ8_MEMBER(namconb1_state::port7_r)
 	switch (m_port6 & 0xf0)
 	{
 		case 0x00:
-			return read_safe(ioport("P4"), 0xff);
+			return m_p4.read_safe(0xff);
 
 		case 0x20:
-			return ioport("MISC")->read();
+			return m_misc->read();
 
 		case 0x40:
-			return ioport("P1")->read();
+			return m_p1->read();
 
 		case 0x60:
-			return ioport("P2")->read();
+			return m_p2->read();
 
 		default:
 			break;
@@ -780,42 +780,42 @@ READ8_MEMBER(namconb1_state::port7_r)
 // register full scale, so it works...
 READ8_MEMBER(namconb1_state::dac7_r)// bit 7
 {
-	return read_safe(ioport("P3"), 0xff)&0x80;
+	return m_p3.read_safe(0xff)&0x80;
 }
 
 READ8_MEMBER(namconb1_state::dac6_r)// bit 3
 {
-	return (read_safe(ioport("P3"), 0xff)<<1)&0x80;
+	return (m_p3.read_safe(0xff)<<1)&0x80;
 }
 
 READ8_MEMBER(namconb1_state::dac5_r)// bit 2
 {
-	return (read_safe(ioport("P3"), 0xff)<<2)&0x80;
+	return (m_p3.read_safe(0xff)<<2)&0x80;
 }
 
 READ8_MEMBER(namconb1_state::dac4_r)// bit 1
 {
-	return (read_safe(ioport("P3"), 0xff)<<3)&0x80;
+	return (m_p3.read_safe(0xff)<<3)&0x80;
 }
 
 READ8_MEMBER(namconb1_state::dac3_r)// bit 0
 {
-	return (read_safe(ioport("P3"), 0xff)<<4)&0x80;
+	return (m_p3.read_safe(0xff)<<4)&0x80;
 }
 
 READ8_MEMBER(namconb1_state::dac2_r)// bit 4
 {
-	return (read_safe(ioport("P3"), 0xff)<<5)&0x80;
+	return (m_p3.read_safe(0xff)<<5)&0x80;
 }
 
 READ8_MEMBER(namconb1_state::dac1_r)// bit 5
 {
-	return (read_safe(ioport("P3"), 0xff)<<6)&0x80;
+	return (m_p3.read_safe(0xff)<<6)&0x80;
 }
 
 READ8_MEMBER(namconb1_state::dac0_r)// bit 6
 {
-	return (read_safe(ioport("P3"), 0xff)<<7)&0x80;
+	return (m_p3.read_safe(0xff)<<7)&0x80;
 }
 
 static ADDRESS_MAP_START( namcoc75_io, AS_IO, 8, namconb1_state )

--- a/src/mame/drivers/namcos22.cpp
+++ b/src/mame/drivers/namcos22.cpp
@@ -1686,7 +1686,7 @@ READ16_MEMBER(namcos22_state::namcos22_portbit_r)
 
 WRITE16_MEMBER(namcos22_state::namcos22_portbit_w)
 {
-	m_portbits[offset] = read_safe(ioport((offset == 0) ? "P1" : "P2"), 0xffff);
+	m_portbits[offset] = ((offset == 0) ? m_p1 : m_p2).read_safe(0xffff);
 }
 
 READ16_MEMBER(namcos22_state::namcos22_dipswitch_r)
@@ -2760,9 +2760,9 @@ WRITE8_MEMBER(namcos22_state::mcu_port5_w)
 READ8_MEMBER(namcos22_state::mcu_port5_r)
 {
 	if (m_p4 & 8)
-		return read_safe(ioport("MCUP5A"), 0xff);
+		return m_mcup5a.read_safe(0xff);
 	else
-		return read_safe(ioport("MCUP5B"), 0xff);
+		return m_mcup5b.read_safe(0xff);
 }
 
 WRITE8_MEMBER(namcos22_state::mcu_port6_w)
@@ -2787,7 +2787,7 @@ READ8_MEMBER(namcos22_state::mcu_port7_r)
 
 READ8_MEMBER(namcos22_state::namcos22s_mcu_adc_r)
 {
-	UINT16 adc = read_safe(m_adc_ports[offset >> 1 & 7], 0) << 2;
+	UINT16 adc = m_adc_ports[offset >> 1 & 7].read_safe(0) << 2;
 	return (offset & 1) ? adc >> 8 : adc;
 }
 

--- a/src/mame/drivers/namcos23.cpp
+++ b/src/mame/drivers/namcos23.cpp
@@ -3129,7 +3129,7 @@ WRITE16_MEMBER(namcos23_state::iob_p6_w)
 
 READ16_MEMBER(namcos23_state::iob_analog_r)
 {
-	return read_safe(m_adc_ports[offset], 0);
+	return m_adc_ports[offset].read_safe(0);
 }
 
 

--- a/src/mame/drivers/nanos.cpp
+++ b/src/mame/drivers/nanos.cpp
@@ -39,13 +39,7 @@ public:
 	m_bank1(*this, "bank1"),
 	m_bank2(*this, "bank2"),
 	m_bank3(*this, "bank3"),
-	m_line0(*this, "LINE0"),
-	m_line1(*this, "LINE1"),
-	m_line2(*this, "LINE2"),
-	m_line3(*this, "LINE3"),
-	m_line4(*this, "LINE4"),
-	m_line5(*this, "LINE5"),
-	m_line6(*this, "LINE6"),
+	m_lines(*this, {"LINE0", "LINE1", "LINE2", "LINE3", "LINE4", "LINE5", "LINE6"}),
 	m_linec(*this, "LINEC")
 	{ }
 
@@ -84,13 +78,7 @@ protected:
 	required_memory_bank m_bank1;
 	required_memory_bank m_bank2;
 	required_memory_bank m_bank3;
-	required_ioport m_line0;
-	required_ioport m_line1;
-	required_ioport m_line2;
-	required_ioport m_line3;
-	required_ioport m_line4;
-	required_ioport m_line5;
-	required_ioport m_line6;
+	required_ioport_array<7> m_lines;
 	required_ioport m_linec;
 	UINT8 row_number(UINT8 code);
 };
@@ -343,8 +331,6 @@ UINT8 nanos_state::row_number(UINT8 code)
 
 TIMER_DEVICE_CALLBACK_MEMBER(nanos_state::keyboard_callback)
 {
-	ioport_port *io_ports[] = { m_line0, m_line1, m_line2, m_line3, m_line4, m_line5, m_line6 };
-
 	int i;
 	UINT8 code;
 	UINT8 key_code = 0;
@@ -353,7 +339,7 @@ TIMER_DEVICE_CALLBACK_MEMBER(nanos_state::keyboard_callback)
 	m_key_pressed = 0xff;
 	for(i = 0; i < 7; i++)
 	{
-		code = io_ports[i]->read();
+		code = m_lines[i]->read();
 		if (code != 0)
 		{
 			if (i==0 && shift==0) {

--- a/src/mame/drivers/pc6001.cpp
+++ b/src/mame/drivers/pc6001.cpp
@@ -155,9 +155,7 @@ public:
 		m_io_mode4_dsw(*this, "MODE4_DSW"),
 		m_io_p1(*this, "P1"),
 		m_io_p2(*this, "P2"),
-		m_io_key1(*this, "key1"),
-		m_io_key2(*this, "key2"),
-		m_io_key3(*this, "key3"),
+		m_io_keys(*this, {"key1", "key2", "key3"}),
 		m_io_key_modifiers(*this, "key_modifiers"),
 		m_bank1(*this, "bank1"),
 		m_bank2(*this, "bank2"),
@@ -278,9 +276,7 @@ protected:
 	required_ioport m_io_mode4_dsw;
 	required_ioport m_io_p1;
 	required_ioport m_io_p2;
-	required_ioport m_io_key1;
-	required_ioport m_io_key2;
-	required_ioport m_io_key3;
+	required_ioport_array<3> m_io_keys;
 	required_ioport m_io_key_modifiers;
 	required_memory_bank m_bank1;
 	optional_memory_bank m_bank2;
@@ -1903,7 +1899,6 @@ READ8_MEMBER(pc6001_state::pc6001_8255_portc_r)
 
 UINT8 pc6001_state::check_keyboard_press()
 {
-	ioport_port *ports[3] = { m_io_key1, m_io_key2, m_io_key3 };
 	int i,port_i,scancode;
 	UINT8 shift_pressed,caps_lock;
 	scancode = 0;
@@ -1915,7 +1910,7 @@ UINT8 pc6001_state::check_keyboard_press()
 	{
 		for(i=0;i<32;i++)
 		{
-			if((ports[port_i]->read()>>i) & 1)
+			if((m_io_keys[port_i]->read()>>i) & 1)
 			{
 				if((shift_pressed != caps_lock) && scancode >= 0x41 && scancode <= 0x5f)
 					scancode+=0x20;
@@ -1948,7 +1943,7 @@ UINT8 pc6001_state::check_joy_press()
 {
 	UINT8 p1_key = m_io_p1->read() ^ 0xff;
 	UINT8 shift_key = m_io_key_modifiers->read() & 0x02;
-	UINT8 space_key = m_io_key2->read() & 0x01;
+	UINT8 space_key = m_io_keys[1]->read() & 0x01;
 	UINT8 joy_press;
 
 		/*
@@ -2027,9 +2022,9 @@ TIMER_DEVICE_CALLBACK_MEMBER(pc6001_state::cassette_callback)
 
 TIMER_DEVICE_CALLBACK_MEMBER(pc6001_state::keyboard_callback)
 {
-	UINT32 key1 = m_io_key1->read();
-	UINT32 key2 = m_io_key2->read();
-	UINT32 key3 = m_io_key3->read();
+	UINT32 key1 = m_io_keys[0]->read();
+	UINT32 key2 = m_io_keys[1]->read();
+	UINT32 key3 = m_io_keys[2]->read();
 //  UINT8 p1_key = m_io_p1->read();
 
 	if(m_cas_switch == 0)

--- a/src/mame/drivers/segahang.cpp
+++ b/src/mame/drivers/segahang.cpp
@@ -177,10 +177,7 @@ READ16_MEMBER( segahang_state::hangon_io_r )
 			return m_i8255_2->read(space, offset & 3);
 
 		case 0x3020/2: // ADC0804 data output
-		{
-			static const char *const adcports[] = { "ADC0", "ADC1", "ADC2", "ADC3" };
-			return read_safe(ioport(adcports[m_adc_select]), 0);
-		}
+			return m_adc_ports[m_adc_select].read_safe(0);
 	}
 
 	//logerror("%06X:hangon_io_r - unknown read access to address %04X\n", m_maincpu->pc(), offset * 2);
@@ -238,10 +235,7 @@ READ16_MEMBER( segahang_state::sharrier_io_r )
 			return m_i8255_2->read(space, offset & 3);
 
 		case 0x0030/2: // ADC0804 data output
-		{
-			static const char *const adcports[] = { "ADC0", "ADC1", "ADC2", "ADC3" };
-			return read_safe(ioport(adcports[m_adc_select]), 0);
-		}
+			return m_adc_ports[m_adc_select].read_safe(0);
 	}
 
 	//logerror("%06X:sharrier_io_r - unknown read access to address %04X\n", m_maincpu->pc(), offset * 2);
@@ -391,7 +385,7 @@ void segahang_state::sharrier_i8751_sim()
 	m_workram[0x0f0/2] = 0;
 
 	// read I/O ports
-	m_workram[0x492/2] = (ioport("ADC0")->read() << 8) | ioport("ADC1")->read();
+	m_workram[0x492/2] = (m_adc_ports[0]->read() << 8) | m_adc_ports[1]->read();
 }
 
 

--- a/src/mame/drivers/segaorun.cpp
+++ b/src/mame/drivers/segaorun.cpp
@@ -695,7 +695,7 @@ READ16_MEMBER( segaorun_state::outrun_custom_io_r )
 
 		case 0x30/2:
 		{
-			return read_safe(m_adc_ports[m_adc_select], 0x0010);
+			return m_adc_ports[m_adc_select].read_safe(0x0010);
 		}
 
 		case 0x60/2:
@@ -781,7 +781,7 @@ READ16_MEMBER( segaorun_state::shangon_custom_io_r )
 
 		case 0x3020/2:
 		{
-			return read_safe(m_adc_ports[m_adc_select], 0x0010);
+			return m_adc_ports[m_adc_select].read_safe(0x0010);
 		}
 
 		default:

--- a/src/mame/drivers/segas16a.cpp
+++ b/src/mame/drivers/segas16a.cpp
@@ -917,19 +917,18 @@ READ16_MEMBER( segas16a_state::sdi_custom_io_r )
 
 READ16_MEMBER( segas16a_state::sjryuko_custom_io_r )
 {
-	static const char *const portname[] = { "MJ0", "MJ1", "MJ2", "MJ3", "MJ4", "MJ5" };
 	switch (offset & (0x3000/2))
 	{
 		case 0x1000/2:
 			switch (offset & 3)
 			{
 				case 1:
-					if (read_safe(ioport(portname[m_mj_input_num]), 0xff) != 0xff)
+					if (m_mj_inputs[m_mj_input_num].read_safe(0xff) != 0xff)
 						return 0xff & ~(1 << m_mj_input_num);
 					return 0xff;
 
 				case 2:
-					return read_safe(ioport(portname[m_mj_input_num]), 0xff);
+					return m_mj_inputs[m_mj_input_num].read_safe(0xff);
 			}
 			break;
 	}

--- a/src/mame/drivers/segas16b.cpp
+++ b/src/mame/drivers/segas16b.cpp
@@ -1590,14 +1590,30 @@ READ16_MEMBER( segas16b_state::hwchamp_custom_io_r )
 
 WRITE16_MEMBER( segas16b_state::hwchamp_custom_io_w )
 {
-	static const char *const portname[4] = { "MONITOR", "LEFT", "RIGHT", "DUMMY" };
 	switch (offset & (0x3000/2))
 	{
 		case 0x3000/2:
 			switch (offset & 0x30/2)
 			{
 				case 0x20/2:
-					m_hwc_input_value = read_safe(ioport(portname[offset & 3]), 0xff);
+					switch (offset & 3)
+					{
+						case 0:
+							m_hwc_input_value = m_hwc_monitor->read();
+							break;
+
+						case 1:
+							m_hwc_input_value = m_hwc_left->read();
+							break;
+
+						case 2:
+							m_hwc_input_value = m_hwc_right->read();
+							break;
+
+						default:
+							m_hwc_input_value = 0xff;
+							break;
+					}
 					break;
 
 				case 0x30/2:
@@ -1668,20 +1684,18 @@ READ16_MEMBER( segas16b_state::sdi_custom_io_r )
 
 READ16_MEMBER( segas16b_state::sjryuko_custom_io_r )
 {
-	static const char *const portname[] = { "MJ0", "MJ1", "MJ2", "MJ3", "MJ4", "MJ5" };
-
 	switch (offset & (0x3000/2))
 	{
 		case 0x1000/2:
 			switch (offset & 3)
 			{
 				case 1:
-					if (read_safe(ioport(portname[m_mj_input_num]), 0xff) != 0xff)
+					if (m_mj_inputs[m_mj_input_num].read_safe(0xff) != 0xff)
 						return 0xff & ~(1 << m_mj_input_num);
 					return 0xff;
 
 				case 2:
-					return read_safe(ioport(portname[m_mj_input_num]), 0xff);
+					return m_mj_inputs[m_mj_input_num].read_safe(0xff);
 			}
 			break;
 	}

--- a/src/mame/drivers/segas24.cpp
+++ b/src/mame/drivers/segas24.cpp
@@ -518,19 +518,19 @@ UINT8 segas24_state::hotrod_io_r(UINT8 port)
 	switch(port)
 	{
 	case 0:
-		return ioport("P1")->read();
+		return m_p1->read();
 	case 1:
-		return ioport("P2")->read();
+		return m_p2->read();
 	case 2:
-		return read_safe(ioport("P3"), 0xff);
+		return m_p3.read_safe(0xff);
 	case 3:
 		return 0xff;
 	case 4:
-		return ioport("SERVICE")->read();
+		return m_service->read();
 	case 5: // Dip switches
-		return ioport("COINAGE")->read();
+		return m_coinage->read();
 	case 6:
-		return ioport("DSW")->read();
+		return m_dsw->read();
 	case 7: // DAC
 		return 0xff;
 	}
@@ -544,20 +544,20 @@ UINT8 segas24_state::dcclub_io_r(UINT8 port)
 	case 0:
 	{
 		static const UINT8 pos[16] = { 0, 1, 3, 2, 6, 4, 12, 8, 9 };
-		return (ioport("P1")->read() & 0xf) | ((~pos[ioport("PADDLE")->read()>>4]<<4) & 0xf0);
+		return (m_p1->read() & 0xf) | ((~pos[m_paddle->read()>>4]<<4) & 0xf0);
 	}
 	case 1:
-		return ioport("P2")->read();
+		return m_p2->read();
 	case 2:
 		return 0xff;
 	case 3:
 		return 0xff;
 	case 4:
-		return ioport("SERVICE")->read();
+		return m_service->read();
 	case 5: // Dip switches
-		return ioport("COINAGE")->read();
+		return m_coinage->read();
 	case 6:
-		return ioport("DSW")->read();
+		return m_dsw->read();
 	case 7: // DAC
 		return 0xff;
 	}
@@ -567,8 +567,6 @@ UINT8 segas24_state::dcclub_io_r(UINT8 port)
 
 UINT8 segas24_state::mahmajn_io_r(UINT8 port)
 {
-	static const char *const keynames[] = { "MJ0", "MJ1", "MJ2", "MJ3", "MJ4", "MJ5", "P1", "P2" };
-
 	switch(port)
 	{
 	case 0:
@@ -576,15 +574,15 @@ UINT8 segas24_state::mahmajn_io_r(UINT8 port)
 	case 1:
 		return 0xff;
 	case 2:
-		return ioport(keynames[cur_input_line])->read();
+		return m_mj_inputs[cur_input_line].read_safe(0xff);
 	case 3:
 		return 0xff;
 	case 4:
-		return ioport("SERVICE")->read();
+		return m_service->read();
 	case 5: // Dip switches
-		return ioport("COINAGE")->read();
+		return m_coinage->read();
 	case 6:
-		return ioport("DSW")->read();
+		return m_dsw->read();
 	case 7: // DAC
 		return 0xff;
 	}
@@ -624,12 +622,10 @@ void segas24_state::hotrod_io_w(UINT8 port, UINT8 data)
 
 WRITE16_MEMBER( segas24_state::hotrod3_ctrl_w )
 {
-	static const char *const portnames[] = { "PEDAL1", "PEDAL2", "PEDAL3", "PEDAL4" };
-
 	if(ACCESSING_BITS_0_7)
 	{
 		data &= 3;
-		hotrod_ctrl_cur = read_safe(ioport(portnames[data]), 0);
+		hotrod_ctrl_cur = m_pedals[data].read_safe(0);
 	}
 }
 
@@ -641,21 +637,21 @@ READ16_MEMBER( segas24_state::hotrod3_ctrl_r )
 		{
 			// Steering dials
 			case 0:
-				return read_safe(ioport("DIAL1"), 0) & 0xff;
+				return m_dials[0].read_safe(0) & 0xff;
 			case 1:
-				return read_safe(ioport("DIAL1"), 0) >> 8;
+				return m_dials[0].read_safe(0) >> 8;
 			case 2:
-				return read_safe(ioport("DIAL2"), 0) & 0xff;
+				return m_dials[1].read_safe(0) & 0xff;
 			case 3:
-				return read_safe(ioport("DIAL2"), 0) >> 8;
+				return m_dials[1].read_safe(0) >> 8;
 			case 4:
-				return read_safe(ioport("DIAL3"), 0) & 0xff;
+				return m_dials[2].read_safe(0) & 0xff;
 			case 5:
-				return read_safe(ioport("DIAL3"), 0) >> 8;
+				return m_dials[2].read_safe(0) >> 8;
 			case 6:
-				return read_safe(ioport("DIAL4"), 0) & 0xff;
+				return m_dials[3].read_safe(0) & 0xff;
 			case 7:
-				return read_safe(ioport("DIAL4"), 0) >> 8;
+				return m_dials[3].read_safe(0) >> 8;
 
 			case 8:
 			{

--- a/src/mame/drivers/segaxbd.cpp
+++ b/src/mame/drivers/segaxbd.cpp
@@ -293,7 +293,9 @@ segaxbd_state::segaxbd_state(const machine_config &mconfig, const char *tag, dev
 			m_gprider_hack(false),
 			m_palette_entries(0),
 			m_screen(*this, "screen"),
-			m_palette(*this, "palette")
+			m_palette(*this, "palette"),
+			m_adc_ports(*this, {"ADC0", "ADC1", "ADC2", "ADC3", "ADC4", "ADC5", "ADC6", "ADC7"}),
+			m_mux_ports(*this, {"MUX0", "MUX1", "MUX2", "MUX3"})
 {
 	memset(m_adc_reverse, 0, sizeof(m_adc_reverse));
 	memset(m_iochip_regs, 0, sizeof(m_iochip_regs));
@@ -462,11 +464,9 @@ void segaxbd_state::sound_data_w(UINT8 data)
 
 READ16_MEMBER( segaxbd_state::adc_r )
 {
-	static const char *const ports[] = { "ADC0", "ADC1", "ADC2", "ADC3", "ADC4", "ADC5", "ADC6", "ADC7" };
-
 	// on the write, latch the selected input port and stash the value
 	int which = (m_iochip_regs[0][2] >> 2) & 7;
-	int value = read_safe(ioport(ports[which]), 0x0010);
+	int value = m_adc_ports[which].read_safe(0x0010);
 
 	// reverse some port values
 	if (m_adc_reverse[which])
@@ -926,8 +926,7 @@ void segaxbd_state::smgp_iochip0_motor_w(UINT8 data)
 
 UINT8 segaxbd_state::lastsurv_iochip1_port_r(UINT8 data)
 {
-	static const char * const port_names[] = { "MUX0", "MUX1", "MUX2", "MUX3" };
-	return read_safe(ioport(port_names[m_lastsurv_mux]), 0xff);
+	return m_mux_ports[m_lastsurv_mux].read_safe(0xff);
 }
 
 

--- a/src/mame/drivers/segaybd.cpp
+++ b/src/mame/drivers/segaybd.cpp
@@ -106,7 +106,7 @@ READ16_MEMBER( segaybd_state::analog_r )
 WRITE16_MEMBER( segaybd_state::analog_w )
 {
 	int selected = ((offset & 3) == 3) ? (3 + (m_misc_io_data[0x08/2] & 3)) : (offset & 3);
-	m_analog_data[offset & 3] = read_safe(m_adc_ports[selected], 0xff);
+	m_analog_data[offset & 3] = m_adc_ports[selected].read_safe(0xff);
 }
 
 

--- a/src/mame/drivers/seicross.cpp
+++ b/src/mame/drivers/seicross.cpp
@@ -79,7 +79,7 @@ void seicross_state::machine_reset()
 
 READ8_MEMBER(seicross_state::portB_r)
 {
-	return (m_portb & 0x9f) | (read_safe(ioport("DEBUG"), 0) & 0x60);
+	return (m_portb & 0x9f) | (m_debug_port.read_safe(0) & 0x60);
 }
 
 WRITE8_MEMBER(seicross_state::portB_w)

--- a/src/mame/drivers/seta.cpp
+++ b/src/mame/drivers/seta.cpp
@@ -1583,12 +1583,12 @@ READ16_MEMBER(seta_state::seta_dsw_r)
 
 READ8_MEMBER(seta_state::dsw1_r)
 {
-	return (ioport("DSW")->read() >> 8) & 0xff;
+	return (m_dsw->read() >> 8) & 0xff;
 }
 
 READ8_MEMBER(seta_state::dsw2_r)
 {
-	return (ioport("DSW")->read() >> 0) & 0xff;
+	return (m_dsw->read() >> 0) & 0xff;
 }
 
 
@@ -1683,15 +1683,15 @@ ADDRESS_MAP_END
 
 READ16_MEMBER(seta_state::calibr50_ip_r)
 {
-	int dir1 = ioport("ROT1")->read();  // analog port
-	int dir2 = ioport("ROT2")->read();  // analog port
+	int dir1 = m_rot[0]->read();  // analog port
+	int dir2 = m_rot[1]->read();  // analog port
 
 	switch (offset)
 	{
-		case 0x00/2:    return ioport("P1")->read();    // p1
-		case 0x02/2:    return ioport("P2")->read();    // p2
+		case 0x00/2:    return m_p1->read();        // p1
+		case 0x02/2:    return m_p2->read();        // p2
 
-		case 0x08/2:    return ioport("COINS")->read(); // Coins
+		case 0x08/2:    return m_coins->read();     // Coins
 
 		case 0x10/2:    return (dir1 & 0xff);       // lower 8 bits of p1 rotation
 		case 0x12/2:    return (dir1 >> 8);         // upper 4 bits of p1 rotation
@@ -1746,10 +1746,10 @@ READ16_MEMBER(seta_state::usclssic_dsw_r)
 {
 	switch (offset)
 	{
-		case 0/2:   return (ioport("DSW")->read() >>  8) & 0xf;
-		case 2/2:   return (ioport("DSW")->read() >> 12) & 0xf;
-		case 4/2:   return (ioport("DSW")->read() >>  0) & 0xf;
-		case 6/2:   return (ioport("DSW")->read() >>  4) & 0xf;
+		case 0/2:   return (m_dsw->read() >>  8) & 0xf;
+		case 2/2:   return (m_dsw->read() >> 12) & 0xf;
+		case 4/2:   return (m_dsw->read() >>  0) & 0xf;
+		case 6/2:   return (m_dsw->read() >>  4) & 0xf;
 	}
 	return 0;
 }
@@ -1963,7 +1963,7 @@ WRITE16_MEMBER(seta_state::zombraid_gun_w)
 
 READ16_MEMBER(seta_state::extra_r)
 {
-	return read_safe(ioport("EXTRA"), 0xff);
+	return m_extra_port.read_safe(0xff);
 }
 
 static ADDRESS_MAP_START( wrofaero_map, AS_PROGRAM, 16, seta_state )
@@ -2137,7 +2137,7 @@ READ16_MEMBER(seta_state::keroppi_protection_init_r)
 
 READ16_MEMBER(seta_state::keroppi_coin_r)
 {
-	UINT16 result = ioport("COINS")->read();
+	UINT16 result = m_coins->read();
 
 	if (m_keroppi_prize_hop == 2)
 	{
@@ -2548,10 +2548,10 @@ ADDRESS_MAP_END
 READ16_MEMBER(seta_state::krzybowl_input_r)
 {
 	// analog ports
-	int dir1x = ioport("TRACK1_X")->read() & 0xfff;
-	int dir1y = ioport("TRACK1_Y")->read() & 0xfff;
-	int dir2x = ioport("TRACK2_X")->read() & 0xfff;
-	int dir2y = ioport("TRACK2_Y")->read() & 0xfff;
+	int dir1x = m_track1_x->read() & 0xfff;
+	int dir1y = m_track1_y->read() & 0xfff;
+	int dir2x = m_track2_x->read() & 0xfff;
+	int dir2y = m_track2_y->read() & 0xfff;
 
 	switch (offset)
 	{
@@ -2724,7 +2724,7 @@ READ16_MEMBER(seta_state::kiwame_input_r)
 	{
 		case 0x00/2:    return ioport(keynames[i])->read();
 		case 0x02/2:    return 0xffff;
-		case 0x04/2:    return ioport("COINS")->read();
+		case 0x04/2:    return m_coins->read();
 //      case 0x06/2:
 		case 0x08/2:    return 0xffff;
 
@@ -2991,20 +2991,20 @@ ADDRESS_MAP_END
 READ16_MEMBER(seta_state::inttoote_dsw_r)
 {
 	int shift = offset * 4;
-	return  ((((ioport("DSW1")->read() >> shift)       & 0xf)) << 0) |
-			((((ioport("DSW2_3")->read() >> shift)     & 0xf)) << 4) |
-			((((ioport("DSW2_3")->read() >> (shift+8)) & 0xf)) << 8) ;
+	return  ((((m_dsw1->read() >> shift)       & 0xf)) << 0) |
+			((((m_dsw2_3->read() >> shift)     & 0xf)) << 4) |
+			((((m_dsw2_3->read() >> (shift+8)) & 0xf)) << 8) ;
 }
 
 READ16_MEMBER(seta_state::inttoote_key_r)
 {
 	switch( *m_inttoote_key_select )
 	{
-		case 0x08:  return ioport("BET0")->read();
-		case 0x10:  return ioport("BET1")->read();
-		case 0x20:  return ioport("BET2")->read();
-		case 0x40:  return ioport("BET3")->read();
-		case 0x80:  return ioport("BET4")->read();
+		case 0x08:  return m_bet[0]->read();
+		case 0x10:  return m_bet[1]->read();
+		case 0x20:  return m_bet[2]->read();
+		case 0x40:  return m_bet[3]->read();
+		case 0x80:  return m_bet[4]->read();
 	}
 
 	logerror("%06X: unknown read, select = %04x\n",space.device().safe_pc(), *m_inttoote_key_select);
@@ -3055,11 +3055,11 @@ READ16_MEMBER(seta_state::jockeyc_mux_r)
 {
 	switch( m_jockeyc_key_select )
 	{
-		case 0x08:  return ioport("BET0")->read();
-		case 0x10:  return ioport("BET1")->read();
-		case 0x20:  return ioport("BET2")->read();
-		case 0x40:  return ioport("BET3")->read();
-		case 0x80:  return ioport("BET4")->read();
+		case 0x08:  return m_bet[0]->read();
+		case 0x10:  return m_bet[1]->read();
+		case 0x20:  return m_bet[2]->read();
+		case 0x40:  return m_bet[3]->read();
+		case 0x80:  return m_bet[4]->read();
 	}
 
 	return 0xffff;

--- a/src/mame/drivers/sidearms.cpp
+++ b/src/mame/drivers/sidearms.cpp
@@ -70,7 +70,7 @@ READ8_MEMBER(sidearms_state::turtship_ports_r)
 {
 	int res = 0;
 	for (int i = 0; i < 5;i++)
-		res |= ((read_safe(m_ports[i], 0) >> offset) & 1) << i;
+		res |= ((m_ports[i].read_safe(0) >> offset) & 1) << i;
 
 	return res;
 }

--- a/src/mame/drivers/spectrum.cpp
+++ b/src/mame/drivers/spectrum.cpp
@@ -329,11 +329,11 @@ READ8_MEMBER(spectrum_state::spectrum_port_fe_r)
 	int lines = offset >> 8;
 	int data = 0xff;
 
-	int cs_extra1 = m_io_plus0 ? m_io_plus0->read() & 0x1f : 0x1f;
-	int cs_extra2 = m_io_plus1 ? m_io_plus1->read() & 0x1f : 0x1f;
-	int cs_extra3 = m_io_plus2 ? m_io_plus2->read() & 0x1f : 0x1f;
-	int ss_extra1 = m_io_plus3 ? m_io_plus3->read() & 0x1f : 0x1f;
-	int ss_extra2 = m_io_plus4 ? m_io_plus4->read() & 0x1f : 0x1f;
+	int cs_extra1 = m_io_plus0.read_safe(0x1f) & 0x1f;
+	int cs_extra2 = m_io_plus1.read_safe(0x1f) & 0x1f;
+	int cs_extra3 = m_io_plus2.read_safe(0x1f) & 0x1f;
+	int ss_extra1 = m_io_plus3.read_safe(0x1f) & 0x1f;
+	int ss_extra2 = m_io_plus4.read_safe(0x1f) & 0x1f;
 
 	/* Caps - V */
 	if ((lines & 1) == 0)

--- a/src/mame/drivers/ssv.cpp
+++ b/src/mame/drivers/ssv.cpp
@@ -444,9 +444,7 @@ ADDRESS_MAP_END
 
 READ16_MEMBER(ssv_state::gdfs_eeprom_r)
 {
-	ioport_port *gun[] = { m_io_gunx1, m_io_guny1, m_io_gunx2, m_io_guny2 };
-
-	return (((m_gdfs_lightgun_select & 1) ? 0 : 0xff) ^ gun[m_gdfs_lightgun_select]->read()) | (m_eeprom->do_read() << 8);
+	return (((m_gdfs_lightgun_select & 1) ? 0 : 0xff) ^ m_io_gun[m_gdfs_lightgun_select]->read()) | (m_eeprom->do_read() << 8);
 }
 
 WRITE16_MEMBER(ssv_state::gdfs_eeprom_w)
@@ -722,11 +720,7 @@ ADDRESS_MAP_END
 
 READ16_MEMBER(ssv_state::sxyreact_ballswitch_r)
 {
-	if ( m_io_service )
-	{
-		return m_io_service->read();
-	}
-	return 0;
+	return m_io_service.read_safe(0);
 }
 
 READ16_MEMBER(ssv_state::sxyreact_dial_r)
@@ -740,7 +734,7 @@ WRITE16_MEMBER(ssv_state::sxyreact_dial_w)
 	if (ACCESSING_BITS_0_7)
 	{
 		if (data & 0x20)
-			m_sxyreact_serial = ( m_io_paddle ? m_io_paddle->read() : 0 ) & 0xff;
+			m_sxyreact_serial = m_io_paddle.read_safe(0) & 0xff;
 
 		if ( (m_sxyreact_dial & 0x40) && !(data & 0x40) )   // $40 -> $00
 			m_sxyreact_serial <<= 1;                        // shift 1 bit

--- a/src/mame/drivers/starfire.cpp
+++ b/src/mame/drivers/starfire.cpp
@@ -320,7 +320,7 @@ static const char *const starfire_sample_names[] =
 INTERRUPT_GEN_MEMBER(starfire_state::vblank_int)
 {
 	// starfire has a jumper for disabling NMI, used to do a complete RAM test
-	if (read_safe(ioport("NMI"), 0x01))
+	if (m_nmi.read_safe(0x01))
 		device.execute().set_input_line(INPUT_LINE_NMI, PULSE_LINE);
 }
 

--- a/src/mame/drivers/svision.cpp
+++ b/src/mame/drivers/svision.cpp
@@ -29,7 +29,7 @@ TIMER_CALLBACK_MEMBER(svision_state::svision_pet_timer)
 	switch (m_pet.state)
 	{
 		case 0:
-			if ( m_joy2 )
+			if (m_joy2.found())
 			{
 				m_pet.input = m_joy2->read();
 			}

--- a/src/mame/drivers/taito_z.cpp
+++ b/src/mame/drivers/taito_z.cpp
@@ -1104,8 +1104,8 @@ WRITE16_MEMBER(taitoz_state::spacegun_output_bypass_w)
 CUSTOM_INPUT_MEMBER(taitoz_state::taitoz_pedal_r)
 {
 	static const UINT8 retval[8] = { 0,1,3,2,6,7,5,4 };
-	const char *tag = (const char *)param;
-	return retval[read_safe(ioport(tag), 0) & 7];
+	ioport_port *port = ioport((const char *)param);
+	return retval[port != nullptr ? port->read() & 7 : 0];
 }
 
 
@@ -1114,7 +1114,7 @@ READ8_MEMBER(taitoz_state::contcirc_input_bypass_r)
 	/* Bypass TC0220IOC controller for analog input */
 
 	UINT8 port = m_tc0220ioc->port_r(space, 0);   /* read port number */
-	UINT16 steer = 0xff80 + read_safe(ioport("STEER"), 0x80);
+	UINT16 steer = 0xff80 + m_steer.read_safe(0x80);
 
 	switch (port)
 	{
@@ -1135,7 +1135,7 @@ READ8_MEMBER(taitoz_state::chasehq_input_bypass_r)
 	/* Bypass TC0220IOC controller for extra inputs */
 
 	UINT8 port = m_tc0220ioc->port_r(space, 0);   /* read port number */
-	UINT16 steer = 0xff80 + read_safe(ioport("STEER"), 0x80);
+	UINT16 steer = 0xff80 + m_steer.read_safe(0x80);
 
 	switch (port)
 	{
@@ -1222,7 +1222,7 @@ WRITE16_MEMBER(taitoz_state::bshark_stick_w)
 
 READ16_MEMBER(taitoz_state::sci_steer_input_r)
 {
-	UINT16 steer = 0xff80 + read_safe(ioport("STEER"), 0x80);
+	UINT16 steer = 0xff80 + m_steer.read_safe(0x80);
 
 	switch (offset)
 	{
@@ -1293,7 +1293,7 @@ WRITE16_MEMBER(taitoz_state::spacegun_gun_output_w)
 
 READ16_MEMBER(taitoz_state::dblaxle_steer_input_r)
 {
-	UINT16 steer = 0xff80 + read_safe(ioport("STEER"), 0x80);
+	UINT16 steer = 0xff80 + m_steer.read_safe(0x80);
 
 	switch (offset)
 	{

--- a/src/mame/drivers/taitojc.cpp
+++ b/src/mame/drivers/taitojc.cpp
@@ -754,7 +754,7 @@ WRITE8_MEMBER(taitojc_state::hc11_output_w)
 
 READ8_MEMBER(taitojc_state::hc11_analog_r)
 {
-	return read_safe(m_analog_ports[offset], 0);
+	return m_analog_ports[offset].read_safe(0);
 }
 
 

--- a/src/mame/drivers/tmc1800.cpp
+++ b/src/mame/drivers/tmc1800.cpp
@@ -634,16 +634,6 @@ void tmc2000_state::machine_start()
 		m_colorram[addr] = machine().rand() & 0xff;
 	}
 
-	// find keyboard rows
-	m_key_row[0] = m_y0;
-	m_key_row[1] = m_y1;
-	m_key_row[2] = m_y2;
-	m_key_row[3] = m_y3;
-	m_key_row[4] = m_y4;
-	m_key_row[5] = m_y5;
-	m_key_row[6] = m_y6;
-	m_key_row[7] = m_y7;
-
 	// state saving
 	save_item(NAME(m_keylatch));
 	save_item(NAME(m_rac));

--- a/src/mame/drivers/tmc2000e.cpp
+++ b/src/mame/drivers/tmc2000e.cpp
@@ -258,16 +258,6 @@ WRITE8_MEMBER( tmc2000e_state::dma_w )
 
 void tmc2000e_state::machine_start()
 {
-	// find keyboard rows
-	m_key_row[0] = m_y0;
-	m_key_row[1] = m_y1;
-	m_key_row[2] = m_y2;
-	m_key_row[3] = m_y3;
-	m_key_row[4] = m_y4;
-	m_key_row[5] = m_y5;
-	m_key_row[6] = m_y6;
-	m_key_row[7] = m_y7;
-
 	/* register for state saving */
 	save_item(NAME(m_cdp1864_efx));
 	save_item(NAME(m_keylatch));

--- a/src/mame/drivers/tmc600.cpp
+++ b/src/mame/drivers/tmc600.cpp
@@ -236,16 +236,6 @@ void tmc600_state::machine_start()
 		break;
 	}
 
-	// find keyboard rows
-	m_key_row[0] = m_y0;
-	m_key_row[1] = m_y1;
-	m_key_row[2] = m_y2;
-	m_key_row[3] = m_y3;
-	m_key_row[4] = m_y4;
-	m_key_row[5] = m_y5;
-	m_key_row[6] = m_y6;
-	m_key_row[7] = m_y7;
-
 	/* register for state saving */
 	save_item(NAME(m_keylatch));
 }

--- a/src/mame/drivers/topspeed.cpp
+++ b/src/mame/drivers/topspeed.cpp
@@ -189,7 +189,7 @@ READ8_MEMBER(topspeed_state::input_bypass_r)
 {
 	// Read port number
 	UINT8 port = m_tc0220ioc->port_r(space, 0);
-	UINT16 steer = 0xff80 + read_safe(ioport("STEER"), 0);
+	UINT16 steer = 0xff80 + m_steer.read_safe(0);
 
 	switch (port)
 	{
@@ -207,8 +207,8 @@ READ8_MEMBER(topspeed_state::input_bypass_r)
 CUSTOM_INPUT_MEMBER(topspeed_state::pedal_r)
 {
 	static const UINT8 retval[8] = { 0,1,3,2,6,7,5,4 };
-	const char *tag = (const char *)param;
-	return retval[read_safe(ioport(tag), 0) & 7];
+	ioport_port *port = ioport((const char *)param);
+	return retval[port != nullptr ? port->read() & 7 : 0];
 }
 
 READ16_MEMBER(topspeed_state::motor_r)

--- a/src/mame/drivers/vegas.cpp
+++ b/src/mame/drivers/vegas.cpp
@@ -1484,7 +1484,7 @@ WRITE32_MEMBER( vegas_state::analog_port_w )
 {
 	if (data < 8 || data > 15)
 		logerror("%08X:Unexpected analog port select = %08X\n", safe_pc(), data);
-	m_pending_analog_read = m_io_analog[data & 7] ? m_io_analog[data & 7]->read() : 0;
+	m_pending_analog_read = m_io_analog[data & 7].read_safe(0);
 }
 
 

--- a/src/mame/drivers/vicdual.cpp
+++ b/src/mame/drivers/vicdual.cpp
@@ -191,7 +191,7 @@ CUSTOM_INPUT_MEMBER(vicdual_state::get_timer_value)
 
 int vicdual_state::is_cabinet_color()
 {
-	return ((m_color_bw ? m_color_bw->read() : 0) & 1) ? 0 : 1;
+	return (m_color_bw.read_safe(0) & 1) ? 0 : 1;
 }
 
 
@@ -1303,7 +1303,7 @@ CUSTOM_INPUT_MEMBER(vicdual_state::fake_lives_r)
 
 	/* and use d8 for the port */
 	int port = ((FPTR)param) >> 8 & 1;
-	return ((m_fake_lives[port] ? m_fake_lives[port]->read() : 0) & bit_mask) ? 0 : 1;
+	return (m_fake_lives[port].read_safe(0) & bit_mask) ? 0 : 1;
 }
 
 

--- a/src/mame/drivers/warpwarp.cpp
+++ b/src/mame/drivers/warpwarp.cpp
@@ -158,7 +158,7 @@ READ8_MEMBER(warpwarp_state::geebee_in_r)
 	int res;
 
 	offset &= 3;
-	res = m_ports[offset] ? m_ports[offset]->read() : 0;
+	res = m_ports[offset].read_safe(0);
 	if (offset == 3)
 	{
 		res = (flip_screen() & 1) ? m_in2->read() : m_in1->read();  // read player 2 input in cocktail mode

--- a/src/mame/drivers/wgp.cpp
+++ b/src/mame/drivers/wgp.cpp
@@ -517,12 +517,12 @@ WRITE16_MEMBER(wgp_state::rotate_port_w)
 READ16_MEMBER(wgp_state::wgp_adinput_r)
 {
 	int steer = 0x40;
-	int fake = m_fake ? m_fake->read() : 0;
+	int fake = m_fake.read_safe(0);
 
 	if (!(fake & 0x10)) /* Analogue steer (the real control method) */
 	{
 		/* Reduce span to 0x80 */
-		steer = ((m_steer ? m_steer->read() : 0) * 0x80) / 0x100;
+		steer = (m_steer.read_safe(0) * 0x80) / 0x100;
 	}
 	else    /* Digital steer */
 	{
@@ -567,7 +567,7 @@ READ16_MEMBER(wgp_state::wgp_adinput_r)
 		}
 
 		case 0x05:
-			return m_unknown ? m_unknown->read() : 0;   /* unknown */
+			return m_unknown.read_safe(0);   /* unknown */
 	}
 
 logerror("CPU #0 PC %06x: warning - read unmapped a/d input offset %06x\n",space.device().safe_pc(),offset);

--- a/src/mame/includes/8080bw.h
+++ b/src/mame/includes/8080bw.h
@@ -27,7 +27,9 @@ public:
 		m_eeprom(*this, "eeprom"),
 		m_sn(*this, "snsnd"),
 		m_screen(*this, "screen"),
-		m_palette(*this, "palette")
+		m_palette(*this, "palette"),
+		m_gunx(*this, "GUNX"),
+		m_guny(*this, "GUNY")
 	{ }
 
 	/* devices/memory pointers */
@@ -41,6 +43,8 @@ public:
 	optional_device<palette_device> m_palette;
 
 	/* misc game specific */
+	optional_ioport m_gunx;
+	optional_ioport m_guny;
 	UINT8 m_color_map;
 	UINT8 m_screen_red;
 	UINT8 m_fleet_step;

--- a/src/mame/includes/amiga.h
+++ b/src/mame/includes/amiga.h
@@ -347,8 +347,7 @@ public:
 	m_potgo_port(*this, "potgo"),
 	m_pot0dat_port(*this, "POT0DAT"),
 	m_pot1dat_port(*this, "POT1DAT"),
-	m_p1joy_port(*this, "p1_joy"),
-	m_p2joy_port(*this, "p2_joy"),
+	m_joy_ports(*this, {"p1_joy", "p2_joy"}),
 	m_p1_mouse_x(*this, "p1_mouse_x"),
 	m_p1_mouse_y(*this, "p1_mouse_y"),
 	m_p2_mouse_x(*this, "p2_mouse_x"),
@@ -576,8 +575,7 @@ protected:
 	optional_ioport m_potgo_port;
 	optional_ioport m_pot0dat_port;
 	optional_ioport m_pot1dat_port;
-	optional_ioport m_p1joy_port;
-	optional_ioport m_p2joy_port;
+	optional_ioport_array<2> m_joy_ports;
 	optional_ioport m_p1_mouse_x;
 	optional_ioport m_p1_mouse_y;
 	optional_ioport m_p2_mouse_x;

--- a/src/mame/includes/astrof.h
+++ b/src/mame/includes/astrof.h
@@ -17,6 +17,7 @@ public:
 		m_videoram(*this, "videoram"),
 		m_astrof_color(*this, "astrof_color"),
 		m_tomahawk_protection(*this, "tomahawk_prot"),
+		m_fake_port(*this, "FAKE"),
 		m_maincpu(*this, "maincpu"),
 		m_samples(*this, "samples"),
 		m_sn(*this, "snsnd"),
@@ -28,6 +29,7 @@ public:
 	std::unique_ptr<UINT8[]>    m_colorram;
 	required_shared_ptr<UINT8> m_astrof_color;
 	optional_shared_ptr<UINT8> m_tomahawk_protection;
+	optional_ioport m_fake_port;
 
 	UINT8      m_astrof_palette_bank;
 	UINT8      m_red_on;

--- a/src/mame/includes/bbc.h
+++ b/src/mame/includes/bbc.h
@@ -102,7 +102,8 @@ public:
 		m_via_system_irq(CLEAR_LINE),
 		m_via_user_irq(CLEAR_LINE),
 		m_acia_irq(CLEAR_LINE),
-		m_palette(*this, "palette")
+		m_palette(*this, "palette"),
+		m_bbcconfig(*this, "BBCCONFIG")
 	{ }
 
 	DECLARE_FLOPPY_FORMATS(floppy_formats_bbc);
@@ -445,6 +446,7 @@ public: // HACK FOR MC6845
 	void bbc_update_nmi();
 	unsigned int calculate_video_address(int ma,int ra);
 	required_device<palette_device> m_palette;
+	optional_ioport m_bbcconfig;
 };
 
 #endif /* BBC_H_ */

--- a/src/mame/includes/bfm_sc4.h
+++ b/src/mame/includes/bfm_sc4.h
@@ -133,18 +133,7 @@ public:
 			m_reel4(*this, "reel4"),
 			m_reel5(*this, "reel5"),
 			m_reel6(*this, "reel6"),
-			m_io1(*this, "IN-0"),
-			m_io2(*this, "IN-1"),
-			m_io3(*this, "IN-2"),
-			m_io4(*this, "IN-3"),
-			m_io5(*this, "IN-4"),
-			m_io6(*this, "IN-5"),
-			m_io7(*this, "IN-6"),
-			m_io8(*this, "IN-7"),
-			m_io9(*this, "IN-8"),
-			m_io10(*this, "IN-9"),
-			m_io11(*this, "IN-10"),
-			m_io12(*this, "IN-11")
+			m_io_ports(*this, {"IN-0", "IN-1", "IN-2", "IN-3", "IN-4", "IN-5", "IN-6", "IN-7", "IN-8", "IN-9", "IN-10", "IN-11"})
 	{
 		m_chk41addr = -1;
 		m_dochk41 = false;
@@ -630,18 +619,7 @@ public:
 
 
 protected:
-	required_ioport m_io1;
-	required_ioport m_io2;
-	required_ioport m_io3;
-	required_ioport m_io4;
-	required_ioport m_io5;
-	required_ioport m_io6;
-	required_ioport m_io7;
-	required_ioport m_io8;
-	required_ioport m_io9;
-	required_ioport m_io10;
-	required_ioport m_io11;
-	required_ioport m_io12;
+	optional_ioport_array<16> m_io_ports;
 };
 
 class sc4_adder4_state : public sc4_state

--- a/src/mame/includes/bwidow.h
+++ b/src/mame/includes/bwidow.h
@@ -13,7 +13,10 @@ class bwidow_state : public driver_device
 public:
 	bwidow_state(const machine_config &mconfig, device_type type, const char *tag)
 		: driver_device(mconfig, type, tag) ,
-		m_maincpu(*this, "maincpu") { }
+		m_maincpu(*this, "maincpu"),
+		m_in3(*this, "IN3"),
+		m_in4(*this, "IN4"),
+		m_dsw2(*this, "DSW2") { }
 
 	int m_lastdata;
 	DECLARE_READ8_MEMBER(spacduel_IN3_r);
@@ -23,6 +26,9 @@ public:
 	DECLARE_WRITE8_MEMBER(irq_ack_w);
 	DECLARE_CUSTOM_INPUT_MEMBER(clock_r);
 	required_device<cpu_device> m_maincpu;
+	optional_ioport m_in3;
+	optional_ioport m_in4;
+	optional_ioport m_dsw2;
 };
 
 

--- a/src/mame/includes/cinemat.h
+++ b/src/mame/includes/cinemat.h
@@ -20,7 +20,9 @@ public:
 		m_samples(*this, "samples"),
 		m_vector(*this, "vector"),
 		m_screen(*this, "screen"),
-		m_rambase(*this, "rambase") { }
+		m_rambase(*this, "rambase"),
+		m_analog_x(*this, "ANALOGX"),
+		m_analog_y(*this, "ANALOGY") { }
 
 	required_device<ccpu_cpu_device> m_maincpu;
 	optional_device<ay8910_device> m_ay1;
@@ -28,6 +30,9 @@ public:
 	required_device<vector_device> m_vector;
 	required_device<screen_device> m_screen;
 	optional_shared_ptr<UINT16> m_rambase;
+
+	optional_ioport m_analog_x;
+	optional_ioport m_analog_y;
 
 	typedef void (cinemat_state::*sound_func)(UINT8 sound_val, UINT8 bits_changed);
 

--- a/src/mame/includes/combatsc.h
+++ b/src/mame/includes/combatsc.h
@@ -24,7 +24,10 @@ public:
 		m_msm5205(*this, "msm5205"),
 		m_gfxdecode(*this, "gfxdecode"),
 		m_palette(*this, "palette"),
-		m_soundlatch(*this, "soundlatch") { }
+		m_soundlatch(*this, "soundlatch"),
+		m_track_ports(*this, {"TRACK0_Y", "TRACK0_X", "TRACK1_Y", "TRACK1_X"})
+	{
+	}
 
 	/* memory pointers */
 	UINT8 *    m_videoram;
@@ -62,6 +65,8 @@ public:
 	required_device<gfxdecode_device> m_gfxdecode;
 	required_device<palette_device> m_palette;
 	required_device<generic_latch_8_device> m_soundlatch;
+
+	optional_ioport_array<4> m_track_ports;
 
 	DECLARE_WRITE8_MEMBER(combatsc_vreg_w);
 	DECLARE_WRITE8_MEMBER(combatscb_sh_irqtrigger_w);

--- a/src/mame/includes/cosmic.h
+++ b/src/mame/includes/cosmic.h
@@ -20,6 +20,8 @@ public:
 		: driver_device(mconfig, type, tag),
 		m_videoram(*this, "videoram"),
 		m_spriteram(*this, "spriteram"),
+		m_in_ports(*this, {"IN0", "IN1", "IN2"}),
+		m_dsw(*this, "DSW"),
 		m_maincpu(*this, "maincpu"),
 		m_samples(*this, "samples"),
 		m_dac(*this, "dac"),
@@ -47,6 +49,8 @@ public:
 	/* misc */
 	UINT32         m_pixel_clock;
 	int            m_ic_state;   // for 9980
+	optional_ioport_array<4> m_in_ports;
+	optional_ioport m_dsw;
 
 	/* devices */
 	required_device<cpu_device> m_maincpu;

--- a/src/mame/includes/cosmicos.h
+++ b/src/mame/includes/cosmicos.h
@@ -50,10 +50,7 @@ public:
 			m_speaker(*this, "speaker"),
 			m_ram(*this, RAM_TAG),
 			m_rom(*this, CDP1802_TAG),
-			m_y1(*this, "Y1"),
-			m_y2(*this, "Y2"),
-			m_y3(*this, "Y3"),
-			m_y4(*this, "Y4"),
+			m_key_row(*this, {"Y1", "Y2", "Y3", "Y4"}),
 			m_io_data(*this, "DATA"),
 			m_special(*this, "SPECIAL"),
 			m_buttons(*this, "BUTTONS")
@@ -66,10 +63,7 @@ public:
 	required_device<speaker_sound_device> m_speaker;
 	required_device<ram_device> m_ram;
 	required_memory_region m_rom;
-	required_ioport m_y1;
-	required_ioport m_y2;
-	required_ioport m_y3;
-	required_ioport m_y4;
+	required_ioport_array<4> m_key_row;
 	required_ioport m_io_data;
 	required_ioport m_special;
 	required_ioport m_buttons;
@@ -127,7 +121,6 @@ public:
 	int m_ram_disable;
 
 	/* keyboard state */
-	ioport_port* m_key_row[4];
 	UINT8 m_keylatch;
 
 	/* display state */

--- a/src/mame/includes/djmain.h
+++ b/src/mame/includes/djmain.h
@@ -16,7 +16,8 @@ public:
 		m_k055555(*this, "k055555"),
 		m_ata(*this, "ata"),
 		m_gfxdecode(*this, "gfxdecode"),
-		m_palette(*this, "palette")
+		m_palette(*this, "palette"),
+		m_turntable(*this, {"TT1", "TT2"})
 	{
 	}
 
@@ -75,4 +76,5 @@ public:
 	required_device<gfxdecode_device> m_gfxdecode;
 	required_device<palette_device> m_palette;
 	K056832_CB_MEMBER(tile_callback);
+	optional_ioport_array<2> m_turntable;
 };

--- a/src/mame/includes/firetrk.h
+++ b/src/mame/includes/firetrk.h
@@ -52,7 +52,12 @@ public:
 		m_drone_rot(*this, "drone_rot"),
 		m_gfxdecode(*this, "gfxdecode"),
 		m_screen(*this, "screen"),
-		m_palette(*this, "palette")
+		m_palette(*this, "palette"),
+		m_bit_0(*this, "BIT_0"),
+		m_bit_6(*this, "BIT_6"),
+		m_bit_7(*this, "BIT_7"),
+		m_dips(*this, {"DIP_0", "DIP_1"}),
+		m_steer(*this, {"STEER_1", "STEER_2"})
 	{ }
 
 	required_device<cpu_device> m_maincpu;
@@ -70,6 +75,12 @@ public:
 	required_device<gfxdecode_device> m_gfxdecode;
 	required_device<screen_device> m_screen;
 	required_device<palette_device> m_palette;
+
+	optional_ioport m_bit_0;
+	optional_ioport m_bit_6;
+	optional_ioport m_bit_7;
+	required_ioport_array<2> m_dips;
+	optional_ioport_array<2> m_steer;
 
 	UINT8 m_in_service_mode;
 	UINT32 m_dial[2];

--- a/src/mame/includes/fm7.h
+++ b/src/mame/includes/fm7.h
@@ -140,9 +140,7 @@ public:
 		m_rom_ptr(*this, "init"),
 		m_basic_ptr(*this, "fbasic"),
 		m_kanji(*this, "kanji1"),
-		m_key1(*this, "key1"),
-		m_key2(*this, "key2"),
-		m_key3(*this, "key3"),
+		m_kb_ports(*this, {"key1", "key2", "key3"}),
 		m_keymod(*this, "key_modifiers"),
 		m_joy1(*this, "joy1"),
 		m_joy2(*this, "joy2"),
@@ -379,9 +377,7 @@ protected:
 	int m_centronics_perror;
 
 	optional_memory_region m_kanji;
-	required_ioport m_key1;
-	required_ioport m_key2;
-	required_ioport m_key3;
+	required_ioport_array<3> m_kb_ports;
 	required_ioport m_keymod;
 	required_ioport m_joy1;
 	required_ioport m_joy2;

--- a/src/mame/includes/fmtowns.h
+++ b/src/mame/includes/fmtowns.h
@@ -95,10 +95,7 @@ class towns_state : public driver_device
 			m_nvram(*this, "nvram"),
 			m_nvram16(*this, "nvram16"),
 			m_ctrltype(*this, "ctrltype"),
-			m_key1(*this, "key1"),
-			m_key2(*this, "key2"),
-			m_key3(*this, "key3"),
-			m_key4(*this, "key4"),
+			m_kb_ports(*this, {"key1", "key2", "key3", "key4"}),
 			m_joy1(*this, "joy1"),
 			m_joy2(*this, "joy2"),
 			m_joy1_ex(*this, "joy1_ex"),
@@ -283,10 +280,7 @@ class towns_state : public driver_device
 	UINT8 towns_cdrom_read_byte_software();
 
 	required_ioport m_ctrltype;
-	required_ioport m_key1;
-	required_ioport m_key2;
-	required_ioport m_key3;
-	required_ioport m_key4;
+	required_ioport_array<4> m_kb_ports;
 	required_ioport m_joy1;
 	required_ioport m_joy2;
 	required_ioport m_joy1_ex;

--- a/src/mame/includes/gaelco3d.h
+++ b/src/mame/includes/gaelco3d.h
@@ -69,7 +69,9 @@ public:
 		m_serial(*this, "serial"),
 		m_screen(*this, "screen"),
 		m_paletteram16(*this, "paletteram"),
-		m_paletteram32(*this, "paletteram") { }
+		m_paletteram32(*this, "paletteram"),
+		m_analog(*this, {"ANALOG0", "ANALOG1", "ANALOG2", "ANALOG3"})
+		{ }
 
 	required_shared_ptr<UINT32> m_adsp_ram_base;
 	required_shared_ptr<UINT16> m_m68k_ram_base;
@@ -84,6 +86,7 @@ public:
 	required_device<screen_device> m_screen;
 	optional_shared_ptr<UINT16> m_paletteram16;
 	optional_shared_ptr<UINT32> m_paletteram32;
+	optional_ioport_array<4> m_analog;
 
 	UINT16 m_sound_data;
 	UINT8 m_sound_status;

--- a/src/mame/includes/galaxian.h
+++ b/src/mame/includes/galaxian.h
@@ -55,6 +55,8 @@ public:
 			m_screen(*this, "screen"),
 			m_palette(*this, "palette"),
 			m_soundlatch(*this, "soundlatch"),
+			m_fake_select(*this, "FAKE_SELECT"),
+			m_tenspot_game_dsw(*this, {"IN2_GAME0", "IN2_GAME1", "IN2_GAME2", "IN2_GAME3", "IN2_GAME4", "IN2_GAME5", "IN2_GAME6", "IN2_GAME7", "IN2_GAME8", "IN2_GAME9"}),
 			m_spriteram(*this, "spriteram"),
 			m_videoram(*this, "videoram"),
 			m_decrypted_opcodes(*this, "decrypted_opcodes") { }
@@ -75,6 +77,9 @@ public:
 	required_device<screen_device> m_screen;
 	required_device<palette_device> m_palette;
 	optional_device<generic_latch_8_device> m_soundlatch;
+
+	optional_ioport m_fake_select;
+	optional_ioport_array<10> m_tenspot_game_dsw;
 
 	required_shared_ptr<UINT8> m_spriteram;
 	required_shared_ptr<UINT8> m_videoram;

--- a/src/mame/includes/gomoku.h
+++ b/src/mame/includes/gomoku.h
@@ -9,6 +9,7 @@ public:
 		m_videoram(*this, "videoram"),
 		m_colorram(*this, "colorram"),
 		m_bgram(*this, "bgram"),
+		m_inputs(*this, {"IN0", "IN1", "DSW", "UNUSED0", "UNUSED1", "UNUSED2", "UNUSED3", "UNUSED4"}),
 		m_maincpu(*this, "maincpu"),
 		m_gfxdecode(*this, "gfxdecode"),
 		m_screen(*this, "screen") { }
@@ -20,6 +21,7 @@ public:
 	int m_bg_dispsw;
 	tilemap_t *m_fg_tilemap;
 	bitmap_ind16 m_bg_bitmap;
+	optional_ioport_array<8> m_inputs;
 	DECLARE_READ8_MEMBER(input_port_r);
 	DECLARE_WRITE8_MEMBER(gomoku_videoram_w);
 	DECLARE_WRITE8_MEMBER(gomoku_colorram_w);

--- a/src/mame/includes/gottlieb.h
+++ b/src/mame/includes/gottlieb.h
@@ -49,7 +49,9 @@ public:
 			m_gfxdecode(*this, "gfxdecode"),
 			m_screen(*this, "screen"),
 			m_palette(*this, "palette"),
-			m_generic_paletteram_8(*this, "paletteram")
+			m_generic_paletteram_8(*this, "paletteram"),
+			m_track_x(*this, "TRACKX"),
+			m_track_y(*this, "TRACKY")
 	{ }
 
 	// devices
@@ -67,6 +69,9 @@ public:
 	required_device<screen_device> m_screen;
 	required_device<palette_device> m_palette;
 	required_shared_ptr<UINT8> m_generic_paletteram_8;
+
+	optional_ioport m_track_x;
+	optional_ioport m_track_y;
 
 	UINT8 m_knocker_prev;
 	UINT8 m_joystick_select;

--- a/src/mame/includes/huebler.h
+++ b/src/mame/includes/huebler.h
@@ -30,22 +30,7 @@ public:
 			m_kb_rom(*this, "keyboard"),
 			m_char_rom(*this, "chargen"),
 			m_video_ram(*this, "video_ram"),
-			m_y0(*this, "Y0"),
-			m_y1(*this, "Y1"),
-			m_y2(*this, "Y2"),
-			m_y3(*this, "Y3"),
-			m_y4(*this, "Y4"),
-			m_y5(*this, "Y5"),
-			m_y6(*this, "Y6"),
-			m_y7(*this, "Y7"),
-			m_y8(*this, "Y8"),
-			m_y9(*this, "Y9"),
-			m_y10(*this, "Y10"),
-			m_y11(*this, "Y11"),
-			m_y12(*this, "Y12"),
-			m_y13(*this, "Y13"),
-			m_y14(*this, "Y14"),
-			m_y15(*this, "Y15"),
+			m_key_row(*this, {"Y0", "Y1", "Y2", "Y3", "Y4", "Y5", "Y6", "Y7", "Y8", "Y9", "Y10", "Y11", "Y12", "Y13", "Y14", "Y15"}),
 			m_special(*this, "SPECIAL"),
 			m_key_d6(0),
 			m_key_d7(0),
@@ -58,22 +43,7 @@ public:
 	required_memory_region m_kb_rom;
 	required_memory_region m_char_rom;
 	required_shared_ptr<UINT8> m_video_ram;
-	required_ioport m_y0;
-	required_ioport m_y1;
-	required_ioport m_y2;
-	required_ioport m_y3;
-	required_ioport m_y4;
-	required_ioport m_y5;
-	required_ioport m_y6;
-	required_ioport m_y7;
-	required_ioport m_y8;
-	required_ioport m_y9;
-	required_ioport m_y10;
-	required_ioport m_y11;
-	required_ioport m_y12;
-	required_ioport m_y13;
-	required_ioport m_y14;
-	required_ioport m_y15;
+	required_ioport_array<16> m_key_row;
 	required_ioport m_special;
 
 	virtual void machine_start() override;
@@ -86,7 +56,6 @@ public:
 	void scan_keyboard();
 
 	// keyboard state
-	ioport_port* m_key_row[16];
 	int m_key_d6;
 	int m_key_d7;
 	int m_key_a4;

--- a/src/mame/includes/jackal.h
+++ b/src/mame/includes/jackal.h
@@ -13,6 +13,7 @@ public:
 	jackal_state(const machine_config &mconfig, device_type type, const char *tag)
 		: driver_device(mconfig, type, tag),
 		m_videoctrl(*this, "videoctrl"),
+		m_dials(*this, {"DIAL0", "DIAL1"}),
 		m_mastercpu(*this, "master"),
 		m_slavecpu(*this, "slave"),
 		m_gfxdecode(*this, "gfxdecode"),
@@ -29,6 +30,7 @@ public:
 	int      m_irq_enable;
 	UINT8    *m_rambank;
 	UINT8    *m_spritebank;
+	optional_ioport_array<2> m_dials;
 
 	/* devices */
 	required_device<cpu_device> m_mastercpu;

--- a/src/mame/includes/laserbat.h
+++ b/src/mame/includes/laserbat.h
@@ -23,11 +23,9 @@ public:
 
 	laserbat_state_base(const machine_config &mconfig, device_type type, const char *tag)
 		: driver_device(mconfig, type, tag)
-		, m_row0(*this, "ROW0")
+		, m_mux_ports(*this, {"ROW0", "ROW1", "SW1", "SW2"})
 		, m_row1(*this, "ROW1")
 		, m_row2(*this, "ROW2")
-		, m_sw1(*this, "SW1")
-		, m_sw2(*this, "SW2")
 		, m_maincpu(*this, "maincpu")
 		, m_screen(*this, "screen")
 		, m_palette(*this, "palette")
@@ -93,11 +91,9 @@ protected:
 	TIMER_CALLBACK_MEMBER(video_line);
 
 	// input lines
-	required_ioport m_row0;
+	required_ioport_array<4> m_mux_ports;
 	required_ioport m_row1;
 	required_ioport m_row2;
-	required_ioport m_sw1;
-	required_ioport m_sw2;
 
 	// main CPU device
 	required_device<cpu_device> m_maincpu;

--- a/src/mame/includes/mac.h
+++ b/src/mame/includes/mac.h
@@ -208,13 +208,7 @@ public:
 		m_mouse0(*this, "MOUSE0"),
 		m_mouse1(*this, "MOUSE1"),
 		m_mouse2(*this, "MOUSE2"),
-		m_key0(*this, "KEY0"),
-		m_key1(*this, "KEY1"),
-		m_key2(*this, "KEY2"),
-		m_key3(*this, "KEY3"),
-		m_key4(*this, "KEY4"),
-		m_key5(*this, "KEY5"),
-		m_key6(*this, "KEY6"),
+		m_keys(*this, {"KEY0", "KEY1", "KEY2", "KEY3", "KEY4", "KEY5", "KEY6"}),
 		m_montype(*this, "MONTYPE"),
 		m_vram(*this,"vram"),
 		m_vram16(*this,"vram16"),
@@ -239,8 +233,8 @@ public:
 	optional_device<rtc3430042_device> m_rtc;
 
 	required_ioport m_mouse0, m_mouse1, m_mouse2;
-	required_ioport m_key0, m_key1, m_key2, m_key3, m_key4, m_key5;
-	optional_ioport m_key6, m_montype;
+	optional_ioport_array<7> m_keys;
+	optional_ioport m_montype;
 
 	virtual void machine_start() override;
 	virtual void machine_reset() override;

--- a/src/mame/includes/maygay1b.h
+++ b/src/mame/includes/maygay1b.h
@@ -40,12 +40,7 @@ public:
 		m_duart68681(*this, "duart68681"),
 		m_sw1_port(*this, "SW1"),
 		m_sw2_port(*this, "SW2"),
-		m_s2_port(*this, "STROBE2"),
-		m_s3_port(*this, "STROBE3"),
-		m_s4_port(*this, "STROBE4"),
-		m_s5_port(*this, "STROBE5"),
-		m_s6_port(*this, "STROBE6"),
-		m_s7_port(*this, "STROBE7"),
+		m_kbd_ports(*this, {"SW1", "STROBE2", "STROBE3", "STROBE4", "STROBE5", "STROBE6", "STROBE7", "SW2"}),
 		m_bank1(*this, "bank1"),
 		m_reel0(*this, "reel0"),
 		m_reel1(*this, "reel1"),
@@ -66,12 +61,7 @@ public:
 	required_device<mc68681_device> m_duart68681;
 	required_ioport m_sw1_port;
 	required_ioport m_sw2_port;
-	required_ioport m_s2_port;
-	required_ioport m_s3_port;
-	required_ioport m_s4_port;
-	required_ioport m_s5_port;
-	required_ioport m_s6_port;
-	required_ioport m_s7_port;
+	required_ioport_array<8> m_kbd_ports;
 	required_memory_bank m_bank1;
 	required_device<stepper_device> m_reel0;
 	required_device<stepper_device> m_reel1;

--- a/src/mame/includes/megasys1.h
+++ b/src/mame/includes/megasys1.h
@@ -104,14 +104,12 @@ public:
 	DECLARE_WRITE16_MEMBER(protection_peekaboo_w);
 	DECLARE_READ16_MEMBER(megasys1A_mcu_hs_r);
 	DECLARE_WRITE16_MEMBER(megasys1A_mcu_hs_w);
-	DECLARE_READ16_MEMBER(edfbl_input_r);
 	DECLARE_READ16_MEMBER(iganinju_mcu_hs_r);
 	DECLARE_WRITE16_MEMBER(iganinju_mcu_hs_w);
 	DECLARE_READ16_MEMBER(soldamj_spriteram16_r);
 	DECLARE_WRITE16_MEMBER(soldamj_spriteram16_w);
 	DECLARE_READ16_MEMBER(stdragon_mcu_hs_r);
 	DECLARE_WRITE16_MEMBER(stdragon_mcu_hs_w);
-	DECLARE_READ16_MEMBER(monkelf_input_r);
 	DECLARE_WRITE16_MEMBER(megasys1_scrollram_0_w);
 	DECLARE_WRITE16_MEMBER(megasys1_scrollram_1_w);
 	DECLARE_WRITE16_MEMBER(megasys1_scrollram_2_w);

--- a/src/mame/includes/midvunit.h
+++ b/src/mame/includes/midvunit.h
@@ -57,6 +57,7 @@ public:
 			m_midvplus_misc(*this, "midvplus_misc"),
 			m_videoram(*this, "videoram", 32),
 			m_textureram(*this, "textureram") ,
+		m_adc_ports(*this, {"WHEEL", "ACCEL", "BRAKE"}),
 		m_maincpu(*this, "maincpu"),
 		m_watchdog(*this, "watchdog"),
 		m_screen(*this, "screen"),
@@ -74,6 +75,8 @@ public:
 	optional_shared_ptr<UINT32> m_midvplus_misc;
 	required_shared_ptr<UINT16> m_videoram;
 	required_shared_ptr<UINT32> m_textureram;
+
+	optional_ioport_array<3> m_adc_ports;
 
 	UINT8 m_cmos_protected;
 	UINT16 m_control_data;

--- a/src/mame/includes/model2.h
+++ b/src/mame/includes/model2.h
@@ -42,8 +42,11 @@ public:
 		m_palette(*this, "palette"),
 		m_scsp(*this, "scsp"),
 		m_cryptdevice(*this, "315_5881"),
-		m_0229crypt(*this, "317_0229")
-
+		m_0229crypt(*this, "317_0229"),
+		m_in0(*this, "IN0"),
+		m_gears(*this, "GEARS"),
+		m_analog_ports(*this, {"ANA0", "ANA1", "ANA2", "ANA3"}),
+		m_lightgun_ports(*this, {"P1_Y", "P1_X", "P2_Y", "P2_X"})
 		{ }
 
 	required_shared_ptr<UINT32> m_workram;
@@ -72,6 +75,11 @@ public:
 	optional_device<scsp_device> m_scsp;
 	optional_device<sega_315_5881_crypt_device> m_cryptdevice;
 	optional_device<sega_315_5838_comp_device> m_0229crypt;
+
+	required_ioport m_in0;
+	optional_ioport m_gears;
+	optional_ioport_array<4> m_analog_ports;
+	optional_ioport_array<4> m_lightgun_ports;
 
 	UINT32 m_intreq;
 	UINT32 m_intena;

--- a/src/mame/includes/model3.h
+++ b/src/mame/includes/model3.h
@@ -59,6 +59,7 @@ public:
 		m_scsp1(*this, "scsp1"),
 		m_eeprom(*this, "eeprom"),
 		m_screen(*this, "screen"),
+		m_adc_ports(*this, {"AN0", "AN1", "AN2", "AN3", "AN4", "AN5", "AN6", "AN7"}),
 		m_work_ram(*this, "work_ram"),
 		m_paletteram64(*this, "paletteram64"),
 		m_dsbz80(*this, DSBZ80_TAG),
@@ -77,6 +78,8 @@ public:
 	required_device<scsp_device> m_scsp1;
 	required_device<eeprom_serial_93cxx_device> m_eeprom;
 	required_device<screen_device> m_screen;
+
+	optional_ioport_array<8> m_adc_ports;
 
 	required_shared_ptr<UINT64> m_work_ram;
 	required_shared_ptr<UINT64> m_paletteram64;

--- a/src/mame/includes/mpu4.h
+++ b/src/mame/includes/mpu4.h
@@ -105,12 +105,7 @@ public:
 			m_pia6(*this, "pia_ic6"),
 			m_pia7(*this, "pia_ic7"),
 			m_pia8(*this, "pia_ic8"),
-			m_orange1_port(*this, "ORANGE1"),
-			m_orange2_port(*this, "ORANGE2"),
-			m_black1_port(*this, "BLACK1"),
-			m_black2_port(*this, "BLACK2"),
-			m_dil1_port(*this, "DIL1"),
-			m_dil2_port(*this, "DIL2"),
+			m_port_mux(*this, {"ORANGE1", "ORANGE2", "BLACK1", "BLACK2", "ORANGE1", "ORANGE2", "DIL1", "DIL2"}),
 			m_aux1_port(*this, "AUX1"),
 			m_aux2_port(*this, "AUX2"),
 			m_bank1(*this, "bank1"),
@@ -250,12 +245,7 @@ protected:
 	optional_device<pia6821_device> m_pia6;
 	optional_device<pia6821_device> m_pia7;
 	optional_device<pia6821_device> m_pia8;
-	required_ioport m_orange1_port;
-	required_ioport m_orange2_port;
-	required_ioport m_black1_port;
-	required_ioport m_black2_port;
-	required_ioport m_dil1_port;
-	required_ioport m_dil2_port;
+	required_ioport_array<8> m_port_mux;
 	required_ioport m_aux1_port;
 	required_ioport m_aux2_port;
 	optional_memory_bank m_bank1;

--- a/src/mame/includes/msx.h
+++ b/src/mame/includes/msx.h
@@ -131,12 +131,7 @@ public:
 		, m_io_dsw(*this, "DSW")
 		, m_io_mouse0(*this, "MOUSE0")
 		, m_io_mouse1(*this, "MOUSE1")
-		, m_io_key0(*this, "KEY0")
-		, m_io_key1(*this, "KEY1")
-		, m_io_key2(*this, "KEY2")
-		, m_io_key3(*this, "KEY3")
-		, m_io_key4(*this, "KEY4")
-		, m_io_key5(*this, "KEY5")
+		, m_io_key(*this, {"KEY0", "KEY1", "KEY2", "KEY3", "KEY4", "KEY5"})
 		, m_psg_b(0)
 		, m_rtc_latch(0)
 		, m_kanji_latch(0)
@@ -228,12 +223,7 @@ private:
 	required_ioport m_io_dsw;
 	required_ioport m_io_mouse0;
 	required_ioport m_io_mouse1;
-	required_ioport m_io_key0;
-	required_ioport m_io_key1;
-	required_ioport m_io_key2;
-	required_ioport m_io_key3;
-	required_ioport m_io_key4;
-	required_ioport m_io_key5;
+	required_ioport_array<6> m_io_key;
 
 	/* PSG */
 	int m_psg_b;

--- a/src/mame/includes/namcofl.h
+++ b/src/mame/includes/namcofl.h
@@ -26,11 +26,25 @@ public:
 		m_maincpu(*this,"maincpu"),
 		m_mcu(*this,"mcu"),
 		m_c116(*this,"c116"),
+		m_in0(*this, "IN0"),
+		m_in1(*this, "IN1"),
+		m_in2(*this, "IN2"),
+		m_misc(*this, "MISC"),
+		m_accel(*this, "ACCEL"),
+		m_brake(*this, "BRAKE"),
+		m_wheel(*this, "WHEEL"),
 		m_shareram(*this, "shareram") { }
 
 	required_device<cpu_device> m_maincpu;
 	required_device<cpu_device> m_mcu;
 	required_device<namco_c116_device> m_c116;
+	required_ioport m_in0;
+	required_ioport m_in1;
+	required_ioport m_in2;
+	required_ioport m_misc;
+	optional_ioport m_accel;
+	optional_ioport m_brake;
+	optional_ioport m_wheel;
 	emu_timer *m_raster_interrupt_timer;
 	std::unique_ptr<UINT32[]> m_workram;
 	required_shared_ptr<UINT16> m_shareram;

--- a/src/mame/includes/namconb1.h
+++ b/src/mame/includes/namconb1.h
@@ -34,6 +34,15 @@ public:
 		m_mcu(*this, "mcu"),
 		m_c116(*this, "c116"),
 		m_eeprom(*this, "eeprom"),
+		m_p1(*this, "P1"),
+		m_p2(*this, "P2"),
+		m_p3(*this, "P3"),
+		m_p4(*this, "P4"),
+		m_misc(*this, "MISC"),
+		m_light0_x(*this, "LIGHT0_X"),
+		m_light0_y(*this, "LIGHT0_Y"),
+		m_light1_x(*this, "LIGHT1_X"),
+		m_light1_y(*this, "LIGHT1_Y"),
 		m_spritebank32(*this, "spritebank32"),
 		m_tilebank32(*this, "tilebank32"),
 		m_namconb_shareram(*this, "namconb_share") { }
@@ -42,6 +51,15 @@ public:
 	required_device<cpu_device> m_mcu;
 	required_device<namco_c116_device> m_c116;
 	required_device<eeprom_parallel_28xx_device> m_eeprom;
+	required_ioport m_p1;
+	required_ioport m_p2;
+	optional_ioport m_p3;
+	optional_ioport m_p4;
+	required_ioport m_misc;
+	optional_ioport m_light0_x;
+	optional_ioport m_light0_y;
+	optional_ioport m_light1_x;
+	optional_ioport m_light1_y;
 	required_shared_ptr<UINT32> m_spritebank32;
 	optional_shared_ptr<UINT32> m_tilebank32;
 	required_shared_ptr<UINT16> m_namconb_shareram;

--- a/src/mame/includes/namcos22.h
+++ b/src/mame/includes/namcos22.h
@@ -199,7 +199,11 @@ public:
 		m_gfxdecode(*this, "gfxdecode"),
 		m_screen(*this, "screen"),
 		m_palette(*this, "palette"),
-		m_adc_ports(*this, "ADC")
+		m_adc_ports(*this, "ADC"),
+		m_p1(*this, "P1"),
+		m_p2(*this, "P2"),
+		m_mcup5a(*this, "MCUP5A"),
+		m_mcup5b(*this, "MCUP5B")
 	{ }
 
 	required_device<cpu_device> m_maincpu;
@@ -229,7 +233,10 @@ public:
 	required_device<screen_device> m_screen;
 	required_device<palette_device> m_palette;
 	optional_ioport_array<8> m_adc_ports;
-
+	optional_ioport m_p1;
+	optional_ioport m_p2;
+	optional_ioport m_mcup5a;
+	optional_ioport m_mcup5b;
 
 	UINT8 m_syscontrol[0x20];
 	bool m_dsp_irq_enabled;

--- a/src/mame/includes/segahang.h
+++ b/src/mame/includes/segahang.h
@@ -38,6 +38,7 @@ public:
 			m_workram(*this, "workram"),
 			m_sharrier_video(false),
 			m_adc_select(0),
+			m_adc_ports(*this, {"ADC0", "ADC1", "ADC2", "ADC3"}),
 			m_decrypted_opcodes(*this, "decrypted_opcodes")
 	{ }
 
@@ -109,6 +110,7 @@ protected:
 
 	// internal state
 	UINT8                   m_adc_select;
+	optional_ioport_array<4> m_adc_ports;
 	bool                    m_shadow;
 	optional_shared_ptr<UINT16> m_decrypted_opcodes;
 };

--- a/src/mame/includes/segas16a.h
+++ b/src/mame/includes/segas16a.h
@@ -50,7 +50,8 @@ public:
 			m_last_buttons1(0),
 			m_last_buttons2(0),
 			m_read_port(0),
-			m_mj_input_num(0)
+			m_mj_input_num(0),
+			m_mj_inputs(*this, {"MJ0", "MJ1", "MJ2", "MJ3", "MJ4", "MJ5"})
 	{ }
 
 	// PPI read/write callbacks
@@ -160,4 +161,5 @@ protected:
 	UINT8                   m_last_buttons2;
 	UINT8                   m_read_port;
 	UINT8                   m_mj_input_num;
+	optional_ioport_array<6> m_mj_inputs;
 };

--- a/src/mame/includes/segas16b.h
+++ b/src/mame/includes/segas16b.h
@@ -49,8 +49,12 @@ public:
 			m_atomicp_sound_divisor(0),
 			m_atomicp_sound_count(0),
 			m_hwc_input_value(0),
+			m_hwc_monitor(*this, "MONITOR"),
+			m_hwc_left(*this, "LEFT"),
+			m_hwc_right(*this, "RIGHT"),
 			m_mj_input_num(0),
 			m_mj_last_val(0),
+			m_mj_inputs(*this, {"MJ0", "MJ1", "MJ2", "MJ3", "MJ4", "MJ5"}),
 			m_spritepalbase(0x400),
 			m_gfxdecode(*this, "gfxdecode"),
 			m_sound_decrypted_opcodes(*this, "sound_decrypted_opcodes"),
@@ -216,8 +220,12 @@ protected:
 	// game-specific state
 	UINT8               m_atomicp_sound_count;
 	UINT8               m_hwc_input_value;
+	optional_ioport     m_hwc_monitor;
+	optional_ioport     m_hwc_left;
+	optional_ioport     m_hwc_right;
 	UINT8               m_mj_input_num;
 	UINT8               m_mj_last_val;
+	optional_ioport_array<6> m_mj_inputs;
 	int                 m_spritepalbase;
 
 	required_device<gfxdecode_device> m_gfxdecode;

--- a/src/mame/includes/segas24.h
+++ b/src/mame/includes/segas24.h
@@ -21,6 +21,16 @@ public:
 		, m_generic_paletteram_16(*this, "paletteram")
 		, m_romboard(*this, "romboard")
 		, m_gground_hack_timer(nullptr)
+		, m_p1(*this, "P1")
+		, m_p2(*this, "P2")
+		, m_p3(*this, "P3")
+		, m_service(*this, "SERVICE")
+		, m_coinage(*this, "COINAGE")
+		, m_dsw(*this, "DSW")
+		, m_paddle(*this, "PADDLE")
+		, m_dials(*this, {"DIAL1", "DIAL2", "DIAL3", "DIAL4"})
+		, m_pedals(*this, {"PEDAL1", "PEDAL2", "PEDAL3", "PEDAL4"})
+		, m_mj_inputs(*this, {"MJ0", "MJ1", "MJ2", "MJ3", "MJ4", "MJ5", "P1", "P2"})
 	{
 	}
 
@@ -147,4 +157,14 @@ public:
 	// game specific
 	TIMER_CALLBACK_MEMBER(gground_hack_timer_callback);
 	emu_timer *m_gground_hack_timer;
+	required_ioport m_p1;
+	required_ioport m_p2;
+	optional_ioport m_p3;
+	required_ioport m_service;
+	required_ioport m_coinage;
+	required_ioport m_dsw;
+	optional_ioport m_paddle;
+	optional_ioport_array<4> m_dials;
+	optional_ioport_array<4> m_pedals;
+	optional_ioport_array<8> m_mj_inputs;
 };

--- a/src/mame/includes/segas32.h
+++ b/src/mame/includes/segas32.h
@@ -25,6 +25,12 @@ public:
 	required_shared_ptr<UINT16> m_system32_spriteram;
 	optional_shared_ptr_array<UINT16, 2> m_system32_paletteram;
 
+	optional_ioport_array<8> m_ports_a;
+	optional_ioport_array<8> m_ports_b;
+	optional_ioport_array<8> m_analog_ports;
+	optional_ioport_array<4> m_extra_ports;
+	optional_ioport_array<6> m_track_ports;
+
 	required_device<cpu_device> m_maincpu;
 	required_device<cpu_device> m_soundcpu;
 	optional_device<multipcm_device> m_multipcm;

--- a/src/mame/includes/segaxbd.h
+++ b/src/mame/includes/segaxbd.h
@@ -138,6 +138,8 @@ protected:
 	UINT8       m_palette_hilight[32];      // RGB translations for hilighted pixels
 	required_device<screen_device> m_screen;
 	required_device<palette_device> m_palette;
+	optional_ioport_array<8> m_adc_ports;
+	optional_ioport_array<4> m_mux_ports;
 
 protected:
 	virtual void device_start() override;

--- a/src/mame/includes/seicross.h
+++ b/src/mame/includes/seicross.h
@@ -12,6 +12,7 @@ public:
 		m_nvram(*this, "nvram"),
 		m_gfxdecode(*this, "gfxdecode"),
 		m_palette(*this, "palette"),
+		m_debug_port(*this, "DEBUG"),
 		m_spriteram(*this, "spriteram"),
 		m_videoram(*this, "videoram"),
 		m_row_scroll(*this, "row_scroll"),
@@ -24,6 +25,8 @@ public:
 	optional_device<nvram_device> m_nvram;
 	required_device<gfxdecode_device> m_gfxdecode;
 	required_device<palette_device> m_palette;
+
+	optional_ioport m_debug_port;
 
 	required_shared_ptr<UINT8> m_spriteram;
 	required_shared_ptr<UINT8> m_videoram;

--- a/src/mame/includes/seta.h
+++ b/src/mame/includes/seta.h
@@ -41,6 +41,19 @@ public:
 		m_x1(*this, "x1snd"),
 		m_soundlatch(*this, "soundlatch"),
 		m_soundlatch2(*this, "soundlatch2"),
+		m_dsw(*this, "DSW"),
+		m_rot(*this, {"ROT1", "ROT2"}),
+		m_p1(*this, "P1"),
+		m_p2(*this, "P2"),
+		m_coins(*this, "COINS"),
+		m_extra_port(*this, "EXTRA"),
+		m_track1_x(*this, "TRACK1_X"),
+		m_track1_y(*this, "TRACK1_Y"),
+		m_track2_x(*this, "TRACK2_X"),
+		m_track2_y(*this, "TRACK2_Y"),
+		m_dsw1(*this, "DSW1"),
+		m_dsw2_3(*this, "DSW2_3"),
+		m_bet(*this, {"BET0", "BET1", "BET2", "BET3", "BET4"}),
 		m_sharedram(*this,"sharedram"),
 		m_workram(*this,"workram"),
 		m_vregs(*this,"vregs"),
@@ -63,6 +76,20 @@ public:
 	optional_device<x1_010_device> m_x1;
 	optional_device<generic_latch_8_device> m_soundlatch;
 	optional_device<generic_latch_8_device> m_soundlatch2;
+
+	optional_ioport m_dsw;
+	optional_ioport_array<2> m_rot;
+	optional_ioport m_p1;
+	optional_ioport m_p2;
+	optional_ioport m_coins;
+	optional_ioport m_extra_port;
+	optional_ioport m_track1_x;
+	optional_ioport m_track1_y;
+	optional_ioport m_track2_x;
+	optional_ioport m_track2_y;
+	optional_ioport m_dsw1;
+	optional_ioport m_dsw2_3;
+	optional_ioport_array<5> m_bet;
 
 	optional_shared_ptr<UINT8> m_sharedram;
 	optional_shared_ptr<UINT16> m_workram;

--- a/src/mame/includes/ssv.h
+++ b/src/mame/includes/ssv.h
@@ -22,10 +22,7 @@ public:
 		m_gdfs_tmapscroll(*this, "gdfs_tmapscroll"),
 		m_gdfs_st0020(*this, "st0020_spr"),
 		m_input_sel(*this, "input_sel"),
-		m_io_gunx1(*this, "GUNX1"),
-		m_io_guny1(*this, "GUNY1"),
-		m_io_gunx2(*this, "GUNX2"),
-		m_io_guny2(*this, "GUNY2"),
+		m_io_gun(*this, {"GUNX1", "GUNY1", "GUNX2", "GUNY2"}),
 		m_io_key0(*this, "KEY0"),
 		m_io_key1(*this, "KEY1"),
 		m_io_key2(*this, "KEY2"),
@@ -153,10 +150,7 @@ public:
 	void init_st010();
 
 protected:
-	optional_ioport m_io_gunx1;
-	optional_ioport m_io_guny1;
-	optional_ioport m_io_gunx2;
-	optional_ioport m_io_guny2;
+	optional_ioport_array<4> m_io_gun;
 	optional_ioport m_io_key0;
 	optional_ioport m_io_key1;
 	optional_ioport m_io_key2;

--- a/src/mame/includes/starfire.h
+++ b/src/mame/includes/starfire.h
@@ -29,12 +29,14 @@ public:
 		m_starfire_colorram(*this, "colorram"),
 		m_starfire_videoram(*this, "videoram"),
 		m_samples(*this, "samples"),
+		m_nmi(*this, "NMI"),
 		m_maincpu(*this, "maincpu"),
 		m_screen(*this, "screen") { }
 
 	required_shared_ptr<UINT8> m_starfire_colorram;
 	required_shared_ptr<UINT8> m_starfire_videoram;
 	optional_device<samples_device> m_samples;
+	optional_ioport m_nmi;
 
 	UINT8 m_prev_sound;
 	UINT8 m_fireone_select;

--- a/src/mame/includes/taito_z.h
+++ b/src/mame/includes/taito_z.h
@@ -40,7 +40,7 @@ public:
 		m_tc0510nio(*this, "tc0510nio"),
 		m_tc0140syt(*this, "tc0140syt"),
 		m_gfxdecode(*this, "gfxdecode"),
-		m_palette(*this, "palette") { }
+		m_steer(*this, "STEER") { }
 
 	/* memory pointers */
 	required_shared_ptr<UINT16> m_spriteram;
@@ -68,7 +68,7 @@ public:
 	optional_device<tc0510nio_device> m_tc0510nio;
 	optional_device<tc0140syt_device> m_tc0140syt;  // bshark & spacegun miss the CPUs which shall use TC0140
 	required_device<gfxdecode_device> m_gfxdecode;
-	required_device<palette_device> m_palette;
+	optional_ioport m_steer;
 
 	DECLARE_WRITE16_MEMBER(cpua_ctrl_w);
 	DECLARE_WRITE16_MEMBER(bshark_cpua_ctrl_w);

--- a/src/mame/includes/tmc1800.h
+++ b/src/mame/includes/tmc1800.h
@@ -111,26 +111,12 @@ public:
 		: tmc1800_base_state(mconfig, type, tag),
 			m_cti(*this, CDP1864_TAG),
 			m_colorram(*this, "color_ram"),
-			m_y0(*this, "Y0"),
-			m_y1(*this, "Y1"),
-			m_y2(*this, "Y2"),
-			m_y3(*this, "Y3"),
-			m_y4(*this, "Y4"),
-			m_y5(*this, "Y5"),
-			m_y6(*this, "Y6"),
-			m_y7(*this, "Y7")
+			m_key_row(*this, {"Y0", "Y1", "Y2", "Y3", "Y4", "Y5", "Y6", "Y7"})
 	{ }
 
 	required_device<cdp1864_device> m_cti;
 	optional_shared_ptr<UINT8> m_colorram;
-	required_ioport m_y0;
-	required_ioport m_y1;
-	required_ioport m_y2;
-	required_ioport m_y3;
-	required_ioport m_y4;
-	required_ioport m_y5;
-	required_ioport m_y6;
-	required_ioport m_y7;
+	required_ioport_array<8> m_key_row;
 
 	virtual void machine_start() override;
 	virtual void machine_reset() override;
@@ -157,7 +143,6 @@ public:
 	UINT8 m_color;
 
 	/* keyboard state */
-	ioport_port* m_key_row[8];
 	int m_keylatch;
 };
 

--- a/src/mame/includes/tmc2000e.h
+++ b/src/mame/includes/tmc2000e.h
@@ -28,14 +28,7 @@ public:
 			m_cti(*this, CDP1864_TAG),
 			m_cassette(*this, "cassette"),
 			m_colorram(*this, "colorram"),
-			m_y0(*this, "Y0"),
-			m_y1(*this, "Y1"),
-			m_y2(*this, "Y2"),
-			m_y3(*this, "Y3"),
-			m_y4(*this, "Y4"),
-			m_y5(*this, "Y5"),
-			m_y6(*this, "Y6"),
-			m_y7(*this, "Y7"),
+			m_key_row(*this, {"Y0", "Y1", "Y2", "Y3", "Y4", "Y5", "Y6", "Y7"}),
 			m_run(*this, "RUN")
 	{ }
 
@@ -43,14 +36,7 @@ public:
 	required_device<cdp1864_device> m_cti;
 	required_device<cassette_image_device> m_cassette;
 	required_shared_ptr<UINT8> m_colorram;
-	required_ioport m_y0;
-	required_ioport m_y1;
-	required_ioport m_y2;
-	required_ioport m_y3;
-	required_ioport m_y4;
-	required_ioport m_y5;
-	required_ioport m_y6;
-	required_ioport m_y7;
+	required_ioport_array<8> m_key_row;
 	required_ioport m_run;
 
 	virtual void machine_start() override;
@@ -79,7 +65,6 @@ public:
 	UINT8 m_color;
 
 	/* keyboard state */
-	ioport_port* m_key_row[8];
 	int m_keylatch;         /* key latch */
 	int m_reset;            /* reset activated */
 };

--- a/src/mame/includes/tmc600.h
+++ b/src/mame/includes/tmc600.h
@@ -36,14 +36,7 @@ public:
 			m_page_ram(*this, "page_ram"),
 			m_color_ram(*this, "color_ram"),
 			m_run(*this, "RUN"),
-			m_y0(*this, "Y0"),
-			m_y1(*this, "Y1"),
-			m_y2(*this, "Y2"),
-			m_y3(*this, "Y3"),
-			m_y4(*this, "Y4"),
-			m_y5(*this, "Y5"),
-			m_y6(*this, "Y6"),
-			m_y7(*this, "Y7")
+			m_key_row(*this, {"Y0", "Y1", "Y2", "Y3", "Y4", "Y5", "Y6", "Y7"})
 	{ }
 
 	required_device<cosmac_device> m_maincpu;
@@ -55,14 +48,7 @@ public:
 	required_shared_ptr<UINT8> m_page_ram;
 	optional_shared_ptr<UINT8> m_color_ram;
 	required_ioport m_run;
-	required_ioport m_y0;
-	required_ioport m_y1;
-	required_ioport m_y2;
-	required_ioport m_y3;
-	required_ioport m_y4;
-	required_ioport m_y5;
-	required_ioport m_y6;
-	required_ioport m_y7;
+	required_ioport_array<8> m_key_row;
 
 	virtual void machine_start() override;
 
@@ -86,7 +72,6 @@ public:
 	int m_blink;                // cursor blink
 
 	// keyboard state
-	ioport_port* m_key_row[8];
 	int m_keylatch;             // key latch
 
 	TIMER_DEVICE_CALLBACK_MEMBER(blink_tick);

--- a/src/mame/includes/topspeed.h
+++ b/src/mame/includes/topspeed.h
@@ -33,7 +33,7 @@ public:
 		m_filter2(*this, "filter2"),
 		m_filter3(*this, "filter3"),
 		m_gfxdecode(*this, "gfxdecode"),
-		m_palette(*this, "palette") { }
+		m_steer(*this, "STEER") { }
 
 	required_shared_ptr<UINT16> m_spritemap;
 	required_shared_ptr<UINT16> m_raster_ctrl;
@@ -53,7 +53,7 @@ public:
 	required_device<filter_volume_device> m_filter2;
 	required_device<filter_volume_device> m_filter3;
 	required_device<gfxdecode_device> m_gfxdecode;
-	required_device<palette_device> m_palette;
+	required_ioport m_steer;
 
 	// Misc
 	UINT16  m_cpua_ctrl;

--- a/src/mame/includes/vectrex.h
+++ b/src/mame/includes/vectrex.h
@@ -49,10 +49,7 @@ public:
 		m_ay8912(*this, "ay8912"),
 		m_vector(*this, "vector"),
 		m_cart(*this, "cartslot"),
-		m_io_contr1x(*this, "CONTR1X"),
-		m_io_contr1y(*this, "CONTR1Y"),
-		m_io_contr2x(*this, "CONTR2X"),
-		m_io_contr2y(*this, "CONTR2Y"),
+		m_io_contr(*this, {"CONTR1X", "CONTR1Y", "CONTR2X", "CONTR2Y"}),
 		m_io_buttons(*this, "BUTTONS"),
 		m_io_3dconf(*this, "3DCONF"),
 		m_io_lpenconf(*this, "LPENCONF"),
@@ -133,10 +130,7 @@ protected:
 	required_device<ay8910_device> m_ay8912;
 	required_device<vector_device> m_vector;
 	optional_device<vectrex_cart_slot_device> m_cart;
-	optional_ioport m_io_contr1x;
-	optional_ioport m_io_contr1y;
-	optional_ioport m_io_contr2x;
-	optional_ioport m_io_contr2y;
+	optional_ioport_array<4> m_io_contr;
 	required_ioport m_io_buttons;
 	required_ioport m_io_3dconf;
 	required_ioport m_io_lpenconf;

--- a/src/mame/machine/amiga.cpp
+++ b/src/mame/machine/amiga.cpp
@@ -262,7 +262,7 @@ TIMER_CALLBACK_MEMBER( amiga_state::scanline_callback )
 		m_cia_0->tod_w(0);
 	}
 
-	if (m_potgo_port)
+	if (m_potgo_port.found())
 	{
 		// pot counters (start counting at 7 (ntsc) or 8 (pal))
 		if (BIT(CUSTOM_REG(REG_POTGO), 0) && (scanline /2 ) > 7)
@@ -380,33 +380,23 @@ TIMER_CALLBACK_MEMBER( amiga_state::amiga_irq_proc )
 
 UINT16 amiga_state::joy0dat_r()
 {
-	if (m_input_device == nullptr)
-		return m_joy0dat_port ? m_joy0dat_port->read() : 0xffff;
-
-	if (m_input_device->read() & 0x10)
-		return m_joy0dat_port ? m_joy0dat_port->read() : 0xffff;
+	if (!m_input_device.found() || (m_input_device->read() & 0x10))
+		return m_joy0dat_port.read_safe(0xffff);
 	else
-		return ((m_p1_mouse_y ? m_p1_mouse_y->read() : 0xff) << 8) | (m_p1_mouse_x? m_p1_mouse_x->read() : 0xff);
+		return (m_p1_mouse_y.read_safe(0xff) << 8) | m_p1_mouse_x.read_safe(0xff);
 }
 
 UINT16 amiga_state::joy1dat_r()
 {
-	if (m_input_device == nullptr)
-		return m_joy1dat_port ? m_joy1dat_port->read() : 0xffff;
-
-	if (m_input_device->read() & 0x20)
-		return m_joy1dat_port ? m_joy1dat_port->read() : 0xffff;
+	if (!m_input_device.found() || m_input_device->read() & 0x20)
+		return m_joy1dat_port.read_safe(0xffff);
 	else
-		return ((m_p2_mouse_y ? m_p2_mouse_y->read() : 0xff) << 8) | (m_p2_mouse_x ? m_p2_mouse_x->read() : 0xff);
+		return (m_p2_mouse_y.read_safe(0xff) << 8) | m_p2_mouse_x.read_safe(0xff);
 }
 
 CUSTOM_INPUT_MEMBER( amiga_state::amiga_joystick_convert )
 {
-	ioport_port *ports[2] = { m_p1joy_port, m_p2joy_port };
-	UINT8 bits = 0xff;
-
-	if (ports[(int)(FPTR)param])
-		bits = ports[(int)(FPTR)param]->read();
+	UINT8 bits = m_joy_ports[(int)(FPTR)param].read_safe(0xff);
 
 	int up = (bits >> 0) & 1;
 	int down = (bits >> 1) & 1;
@@ -1186,21 +1176,18 @@ READ16_MEMBER( amiga_state::custom_chip_r )
 			return CUSTOM_REG(REG_SERDATR);
 
 		case REG_JOY0DAT:
-			if (m_joy0dat_port)
+			if (m_joy0dat_port.found())
 				return joy0dat_r();
 
 		case REG_JOY1DAT:
-			if (m_joy1dat_port)
+			if (m_joy1dat_port.found())
 				return joy1dat_r();
 
 		case REG_POTGOR:
-			if (m_potgo_port)
-				return m_potgo_port->read();
-			else
-				return 0x5500;
+			return m_potgo_port.read_safe(0x5500);
 
 		case REG_POT0DAT:
-			if (m_pot0dat_port)
+			if (m_pot0dat_port.found())
 			{
 				return m_pot0dat_port->read();
 			}
@@ -1215,7 +1202,7 @@ READ16_MEMBER( amiga_state::custom_chip_r )
 			}
 
 		case REG_POT1DAT:
-			if (m_pot1dat_port)
+			if (m_pot1dat_port.found())
 			{
 				return m_pot1dat_port->read();
 			}

--- a/src/mame/machine/amstrad.cpp
+++ b/src/mame/machine/amstrad.cpp
@@ -1860,7 +1860,7 @@ READ8_MEMBER(amstrad_state::amstrad_cpc_io_r)
 //  m6845_personality_t crtc_type;
 	int page;
 
-//  crtc_type = read_safe(ioport("crtc"), 0);
+//  crtc_type = m_crtc.read_safe(0);
 //  m6845_set_personality(crtc_type);
 
 	if(m_aleste_mode & 0x04)
@@ -2721,21 +2721,21 @@ READ8_MEMBER(amstrad_state::amstrad_psg_porta_read)
 		if(m_aleste_mode == 0x08 && ( m_ppi_port_outputs[amstrad_ppi_PortC] & 0x0F ) == 10)
 			return 0xff;
 
-		if (m_io_kbrow[m_ppi_port_outputs[amstrad_ppi_PortC] & 0x0F])
+		if (m_io_kbrow[m_ppi_port_outputs[amstrad_ppi_PortC] & 0x0F].found())
 		{
 			if(m_system_type != SYSTEM_GX4000)
 			{
-				if(m_io_ctrltype && (m_io_ctrltype->read() == 1) && (m_ppi_port_outputs[amstrad_ppi_PortC] & 0x0F) == 9)
+				if (m_io_ctrltype.read_safe(0) == 1 && (m_ppi_port_outputs[amstrad_ppi_PortC] & 0x0F) == 9)
 				{
 					return m_amx_mouse_data;
 				}
-				if(m_io_ctrltype && (m_io_ctrltype->read() == 2) && (m_ppi_port_outputs[amstrad_ppi_PortC] & 0x0F) == 9)
+				if (m_io_ctrltype.read_safe(0) == 2 && (m_ppi_port_outputs[amstrad_ppi_PortC] & 0x0F) == 9)
 				{
-					return (m_io_kbrow[m_ppi_port_outputs[amstrad_ppi_PortC] & 0x0F] ? m_io_kbrow[m_ppi_port_outputs[amstrad_ppi_PortC] & 0x0F]->read() & 0x80 : 0) | 0x7f;
+					return (m_io_kbrow[m_ppi_port_outputs[amstrad_ppi_PortC] & 0x0F].read_safe(0) & 0x80) | 0x7f;
 				}
 			}
 
-			return m_io_kbrow[m_ppi_port_outputs[amstrad_ppi_PortC] & 0x0F] ? m_io_kbrow[m_ppi_port_outputs[amstrad_ppi_PortC] & 0x0F]->read() : 0;
+			return m_io_kbrow[m_ppi_port_outputs[amstrad_ppi_PortC] & 0x0F].read_safe(0);
 		}
 		return 0xFF;
 	}
@@ -2770,14 +2770,14 @@ IRQ_CALLBACK_MEMBER(amstrad_state::amstrad_cpu_acknowledge_int)
 	if(m_system_type != SYSTEM_GX4000)
 		{
 			// update AMX mouse inputs (normally done every 1/300th of a second)
-			if(m_io_ctrltype && m_io_ctrltype->read() == 1)
+			if (m_io_ctrltype.read_safe(0) == 1)
 			{
 				static UINT8 prev_x,prev_y;
 				UINT8 data_x, data_y;
 
 				m_amx_mouse_data = 0x0f;
-				data_x = m_io_mouse1 ? m_io_mouse1->read() : 0;
-				data_y = m_io_mouse2 ? m_io_mouse2->read() : 0;
+				data_x = m_io_mouse1.read_safe(0);
+				data_y = m_io_mouse2.read_safe(0);
 
 				if(data_x > prev_x)
 					m_amx_mouse_data &= ~0x08;
@@ -2787,11 +2787,11 @@ IRQ_CALLBACK_MEMBER(amstrad_state::amstrad_cpu_acknowledge_int)
 					m_amx_mouse_data &= ~0x02;
 				if(data_y < prev_y)
 					m_amx_mouse_data &= ~0x01;
-				m_amx_mouse_data |= ((m_io_mouse3 ? m_io_mouse3->read() : 0) << 4);
+				m_amx_mouse_data |= (m_io_mouse3.read_safe(0) << 4);
 				prev_x = data_x;
 				prev_y = data_y;
 
-				m_amx_mouse_data |= ((m_io_kbrow[9] ? m_io_kbrow[9]->read() : 0) & 0x80);  // DEL key
+				m_amx_mouse_data |= (m_io_kbrow[9].read_safe(0) & 0x80);  // DEL key
 			}
 		}
 	return 0xFF;

--- a/src/mame/machine/apple2.cpp
+++ b/src/mame/machine/apple2.cpp
@@ -1308,8 +1308,8 @@ void apple2_state::machine_reset()
 
 int apple2_state::a2_no_ctrl_reset()
 {
-	return (((m_kbrepeat != nullptr) && (m_resetdip == nullptr)) ||
-			((m_resetdip != nullptr) && !m_resetdip->read()));
+	return ((m_kbrepeat.found() && !m_resetdip.found()) ||
+			(m_resetdip.found() && !m_resetdip->read()));
 }
 
 /* -----------------------------------------------------------------------
@@ -2438,8 +2438,8 @@ MACHINE_START_MEMBER(apple2_state,tk2000)
 
 int apple2_state::apple2_pressed_specialkey(UINT8 key)
 {
-	return ((m_kbspecial ? m_kbspecial->read() : 0) & key)
-		|| ((m_joybuttons ? m_joybuttons->read() : 0) & key);
+	return (m_kbspecial.read_safe(0) & key)
+		|| (m_joybuttons.read_safe(0) & key);
 }
 
 void apple2_state::apple2_refresh_delegates()

--- a/src/mame/machine/atari400.cpp
+++ b/src/mame/machine/atari400.cpp
@@ -98,15 +98,15 @@ POKEY_KEYBOARD_CB_MEMBER(atari_common_state::a800_keyboard)
 	{
 	case pokey_device::POK_KEY_BREAK:
 		/* special case ... */
-		ret |= ((m_keyboard[0] && m_keyboard[0]->read() & 0x08) ? 0x02 : 0x00);
+		ret |= ((m_keyboard[0].read_safe(0x00) & 0x08) ? 0x02 : 0x00);
 		break;
 	case pokey_device::POK_KEY_CTRL:
 		/* CTRL */
-		ret |= ((m_fake && m_fake->read() & 0x02) ? 0x02 : 0x00);
+		ret |= ((m_fake.read_safe(0x00) & 0x02) ? 0x02 : 0x00);
 		break;
 	case pokey_device::POK_KEY_SHIFT:
 		/* SHIFT */
-		ret |= ((m_fake && m_fake->read() & 0x01) ? 0x02 : 0x00);
+		ret |= ((m_fake.read_safe(0x00) & 0x01) ? 0x02 : 0x00);
 		break;
 	}
 
@@ -115,7 +115,7 @@ POKEY_KEYBOARD_CB_MEMBER(atari_common_state::a800_keyboard)
 		return ret;
 
 	/* decode regular key */
-	ipt = m_keyboard[k543210 >> 3] ? m_keyboard[k543210 >> 3]->read() : 0;
+	ipt = m_keyboard[k543210 >> 3].read_safe(0);
 
 	if (ipt & (1 << (k543210 & 0x07)))
 		ret |= 0x01;
@@ -162,7 +162,7 @@ POKEY_KEYBOARD_CB_MEMBER(atari_common_state::a5200_keypads)
 	{
 	case pokey_device::POK_KEY_BREAK:
 		/* special case ... */
-		ret |= ((m_keypad[0] && m_keypad[0]->read() & 0x01) ? 0x02 : 0x00);
+		ret |= ((m_keypad[0].read_safe(0x00) & 0x01) ? 0x02 : 0x00);
 		break;
 	case pokey_device::POK_KEY_CTRL:
 		break;
@@ -184,7 +184,7 @@ POKEY_KEYBOARD_CB_MEMBER(atari_common_state::a5200_keypads)
 	if (k543210 == 0)
 		return ret;
 
-	ipt = m_keypad[k543210 >> 2] ? m_keypad[k543210 >> 2]->read() : 0;
+	ipt = m_keypad[k543210 >> 2].read_safe(0);
 
 	if (ipt & (1 << (k543210 & 0x03)))
 		ret |= 0x01;

--- a/src/mame/machine/bbc.cpp
+++ b/src/mame/machine/bbc.cpp
@@ -1747,9 +1747,9 @@ MACHINE_START_MEMBER(bbc_state, bbca)
 
 MACHINE_RESET_MEMBER(bbc_state, bbca)
 {
-	m_monitortype = read_safe(ioport("BBCCONFIG"), 0) & 0x03;
-	m_Speech      = read_safe(ioport("BBCCONFIG"), 0) & 0x04;
-	m_SWRAMtype   = read_safe(ioport("BBCCONFIG"), 0) & 0x18;
+	m_monitortype = m_bbcconfig.read_safe(0) & 0x03;
+	m_Speech      = m_bbcconfig.read_safe(0) & 0x04;
+	m_SWRAMtype   = m_bbcconfig.read_safe(0) & 0x18;
 
 	UINT8 *RAM = m_region_maincpu->base();
 
@@ -1782,9 +1782,9 @@ MACHINE_START_MEMBER(bbc_state, bbcb)
 
 MACHINE_RESET_MEMBER(bbc_state, bbcb)
 {
-	m_monitortype = read_safe(ioport("BBCCONFIG"), 0) & 0x03;
-	m_Speech      = read_safe(ioport("BBCCONFIG"), 1) & 0x04;
-	m_SWRAMtype   = read_safe(ioport("BBCCONFIG"), 0) & 0x18;
+	m_monitortype = m_bbcconfig.read_safe(0) & 0x03;
+	m_Speech      = m_bbcconfig.read_safe(1) & 0x04;
+	m_SWRAMtype   = m_bbcconfig.read_safe(0) & 0x18;
 
 	UINT8 *RAM = m_region_maincpu->base();
 
@@ -1823,8 +1823,8 @@ MACHINE_START_MEMBER(bbc_state, bbcbp)
 
 MACHINE_RESET_MEMBER(bbc_state, bbcbp)
 {
-	m_monitortype = read_safe(ioport("BBCCONFIG"), 0) & 0x03;
-	m_Speech      = read_safe(ioport("BBCCONFIG"), 1) & 0x04;
+	m_monitortype = m_bbcconfig.read_safe(0) & 0x03;
+	m_Speech      = m_bbcconfig.read_safe(1) & 0x04;
 	m_SWRAMtype   = 0;
 
 	m_bank1->set_base(m_region_maincpu->base());
@@ -1855,7 +1855,7 @@ MACHINE_START_MEMBER(bbc_state, bbcm)
 
 MACHINE_RESET_MEMBER(bbc_state, bbcm)
 {
-	m_monitortype = read_safe(ioport("BBCCONFIG"), 0) & 0x03;
+	m_monitortype = m_bbcconfig.read_safe(0) & 0x03;
 	m_Speech      = 0;
 	m_SWRAMtype   = 0;
 

--- a/src/mame/machine/coco.cpp
+++ b/src/mame/machine/coco.cpp
@@ -1172,7 +1172,7 @@ WRITE8_MEMBER( coco_state::ff60_write )
 
 READ8_MEMBER( coco_state::ff40_read )
 {
-	if (offset >= 1 && offset <= 2 && m_beckerportconfig && m_beckerportconfig->read() == 1)
+	if (offset >= 1 && offset <= 2 && m_beckerportconfig.read_safe(0) == 1)
 	{
 		return m_beckerport->read(space, offset-1, mem_mask);
 	}
@@ -1188,7 +1188,7 @@ READ8_MEMBER( coco_state::ff40_read )
 
 WRITE8_MEMBER( coco_state::ff40_write )
 {
-	if (offset >= 1 && offset <= 2 && m_beckerportconfig && m_beckerportconfig->read() == 1)
+	if (offset >= 1 && offset <= 2 && m_beckerportconfig.read_safe(0) == 1)
 	{
 		return m_beckerport->write(space, offset-1, data, mem_mask);
 	}

--- a/src/mame/machine/cybiko.cpp
+++ b/src/mame/machine/cybiko.cpp
@@ -103,7 +103,7 @@ int cybiko_state::cybiko_key_r( offs_t offset, int mem_mask)
 	UINT16 data = 0xFFFF;
 	for (UINT8 i = 0; i < 15; i++)
 	{
-		if (m_input[i] && !BIT(offset, i))
+		if (m_input[i].found() && !BIT(offset, i))
 			data &= ~m_input[i]->read();
 	}
 	if (data != 0xFFFF)

--- a/src/mame/machine/harddriv.cpp
+++ b/src/mame/machine/harddriv.cpp
@@ -220,7 +220,7 @@ READ16_MEMBER( harddriv_state::hd68k_port0_r )
 	*/
 	screen_device &scr = m_gsp->screen();
 
-	int temp = ((m_sw1 ? m_sw1->read() : 0xff) << 8) | m_in0->read();
+	int temp = (m_sw1.read_safe(0xff) << 8) | m_in0->read();
 	if (get_hblank(scr)) temp ^= 0x0002;
 	temp ^= 0x0018;     /* both EOCs always high for now */
 	return temp;
@@ -270,7 +270,7 @@ READ16_MEMBER( harddriv_state::hda68k_port1_r )
 READ16_MEMBER( harddriv_state::hdc68k_wheel_r )
 {
 	/* grab the new wheel value and upconvert to 12 bits */
-	UINT16 new_wheel = (m_12badc[0] ? m_12badc[0]->read() : 0xffff) << 4;
+	UINT16 new_wheel = m_12badc[0].read_safe(0xffff) << 4;
 
 	/* hack to display the wheel position */
 	if (space.machine().input().code_pressed(KEYCODE_LSHIFT))
@@ -321,14 +321,14 @@ WRITE16_MEMBER( harddriv_state::hd68k_adc_control_w )
 	if (m_adc_control & 0x08)
 	{
 		m_adc8_select = m_adc_control & 0x07;
-		m_adc8_data = m_8badc[m_adc8_select] ? m_8badc[m_adc8_select]->read() : 0xffff;
+		m_adc8_data = m_8badc[m_adc8_select].read_safe(0xffff);
 	}
 
 	/* handle a write to the 12-bit ADC address select */
 	if (m_adc_control & 0x40)
 	{
 		m_adc12_select = (m_adc_control >> 4) & 0x03;
-		m_adc12_data = (m_12badc[m_adc12_select] ? m_12badc[m_adc12_select]->read() : 0xffff) << 4;
+		m_adc12_data = m_12badc[m_adc12_select].read_safe(0xffff) << 4;
 	}
 
 	/* bit 7 selects which byte of the 12 bit data to read */

--- a/src/mame/machine/mac.cpp
+++ b/src/mame/machine/mac.cpp
@@ -538,7 +538,6 @@ int mac_state::scan_keyboard()
 	int i, j;
 	int keybuf = 0;
 	int keycode;
-	ioport_port *ports[7] = { m_key0, m_key1, m_key2, m_key3, m_key4, m_key5, m_key6 };
 
 	if (m_keycode_buf_index)
 	{
@@ -547,7 +546,7 @@ int mac_state::scan_keyboard()
 
 	for (i=0; i<7; i++)
 	{
-		keybuf = ports[i]->read();
+		keybuf = m_keys[i]->read();
 
 		if (keybuf != m_key_matrix[i])
 		{

--- a/src/mame/machine/macadb.cpp
+++ b/src/mame/machine/macadb.cpp
@@ -78,14 +78,13 @@ static const char *const adb_statenames[4] = { "NEW", "EVEN", "ODD", "IDLE" };
 int mac_state::adb_pollkbd(int update)
 {
 	int i, j, keybuf, report, codes[2], result;
-	ioport_port *ports[6] = { m_key0, m_key1,   m_key2, m_key3, m_key4, m_key5 };
 
 	codes[0] = codes[1] = 0xff; // key up
 	report = result = 0;
 
 	for (i = 0; i < 6; i++)
 	{
-		keybuf = ports[i]->read();
+		keybuf = m_keys[i]->read();
 
 		// any changes in this row?
 		if ((keybuf != m_key_matrix[i]) && (report < 2))

--- a/src/mame/machine/megadriv.cpp
+++ b/src/mame/machine/megadriv.cpp
@@ -1066,7 +1066,7 @@ DRIVER_INIT_MEMBER(md_base_state, megadrie)
 
 void md_base_state::screen_eof_megadriv(screen_device &screen, bool state)
 {
-	if (m_io_reset && m_io_reset->read() & 0x01)
+	if (m_io_reset.read_safe(0) & 0x01)
 		m_maincpu->set_input_line(INPUT_LINE_RESET, PULSE_LINE);
 
 	// rising edge

--- a/src/mame/machine/micro3d.cpp
+++ b/src/mame/machine/micro3d.cpp
@@ -467,16 +467,16 @@ WRITE32_MEMBER(micro3d_state::micro3d_mac2_w)
 
 READ16_MEMBER(micro3d_state::micro3d_encoder_h_r)
 {
-	UINT16 x_encoder = m_joystick_x ? m_joystick_x->read() : 0;
-	UINT16 y_encoder = m_joystick_y ? m_joystick_y->read() : 0;
+	UINT16 x_encoder = m_joystick_x.read_safe(0);
+	UINT16 y_encoder = m_joystick_y.read_safe(0);
 
 	return (y_encoder & 0xf00) | ((x_encoder & 0xf00) >> 8);
 }
 
 READ16_MEMBER(micro3d_state::micro3d_encoder_l_r)
 {
-	UINT16 x_encoder = m_joystick_x ? m_joystick_x->read() : 0;
-	UINT16 y_encoder = m_joystick_y ? m_joystick_y->read() : 0;
+	UINT16 x_encoder = m_joystick_x.read_safe(0);
+	UINT16 y_encoder = m_joystick_y.read_safe(0);
 
 	return ((y_encoder & 0xff) << 8) | (x_encoder & 0xff);
 }
@@ -485,7 +485,7 @@ TIMER_CALLBACK_MEMBER(micro3d_state::adc_done_callback)
 {
 	switch (param)
 	{
-		case 0: m_adc_val = m_throttle ? m_throttle->read() : 0;
+		case 0: m_adc_val = m_throttle.read_safe(0);
 				break;
 		case 1: m_adc_val = (UINT8)((255.0/100.0) * m_volume->read() + 0.5);
 				break;

--- a/src/mame/machine/msx.cpp
+++ b/src/mame/machine/msx.cpp
@@ -361,12 +361,11 @@ READ8_MEMBER( msx_state::msx_ppi_port_b_r )
 {
 	UINT8 result = 0xff;
 	int row, data;
-	ioport_port *keynames[] = { m_io_key0, m_io_key1, m_io_key2, m_io_key3, m_io_key4, m_io_key5 };
 
 	row = m_keylatch;
 	if (row <= 10)
 	{
-		data = keynames[row / 2]->read();
+		data = m_io_key[row / 2]->read();
 
 		if (BIT(row, 0))
 			data >>= 8;

--- a/src/mame/machine/naomi.cpp
+++ b/src/mame/machine/naomi.cpp
@@ -228,7 +228,11 @@ CUSTOM_INPUT_MEMBER(naomi_state::naomi_mp_r)
 	for (int i = 0x80; i >= 0x08; i >>= 1)
 	{
 		if (m_mp_mux & i)
-			retval |= read_safe(ioport(tagptr), 0);
+		{
+			ioport_port *port = ioport(tagptr);
+			if (port != nullptr)
+				retval |= port->read();
+		}
 		tagptr += strlen(tagptr) + 1;
 	}
 	return retval;

--- a/src/mame/machine/sms.cpp
+++ b/src/mame/machine/sms.cpp
@@ -252,7 +252,7 @@ WRITE_LINE_MEMBER(sms_state::sms_pause_callback)
 
 WRITE_LINE_MEMBER(sms_state::sms_csync_callback)
 {
-	if ( m_port_rapid )
+	if (m_port_rapid.found())
 	{
 		UINT8 rapid_previous_mode = m_rapid_mode;
 
@@ -345,7 +345,7 @@ READ8_MEMBER(sms_state::sms_input_port_dc_r)
 		m_port_dc_reg &= ~0x20 | ((m_io_ctrl_reg & 0x10) << 1);
 	}
 
-	if ( m_port_rapid )
+	if (m_port_rapid.found())
 	{
 		// Check if Rapid Fire is enabled for Button 1
 		if (m_rapid_mode & 0x01)
@@ -391,7 +391,7 @@ READ8_MEMBER(sms_state::sms_input_port_dd_r)
 	}
 
 	// Reset Button
-	if ( m_port_reset )
+	if (m_port_reset.found())
 	{
 		m_port_dd_reg &= ~0x10 | (m_port_reset->read() & 0x01) << 4;
 	}
@@ -440,7 +440,7 @@ READ8_MEMBER(sms_state::sms_input_port_dd_r)
 		}
 	}
 
-	if ( m_port_rapid )
+	if (m_port_rapid.found())
 	{
 		// Check if Rapid Fire is enabled for Button 1
 		if (m_rapid_mode & 0x04)
@@ -1054,7 +1054,7 @@ MACHINE_START_MEMBER(sms_state,sms)
 		save_item(NAME(m_smsj_audio_control));
 	}
 
-	if (m_port_rapid)
+	if (m_port_rapid.found())
 	{
 		save_item(NAME(m_csync_counter));
 		save_item(NAME(m_rapid_mode));
@@ -1111,7 +1111,7 @@ MACHINE_RESET_MEMBER(sms_state,sms)
 		m_smsj_audio_control = 0x00;
 	}
 
-	if (m_port_rapid)
+	if (m_port_rapid.found())
 	{
 		m_csync_counter = 0;
 		m_rapid_mode = 0x00;

--- a/src/mame/machine/tnzs.cpp
+++ b/src/mame/machine/tnzs.cpp
@@ -84,8 +84,7 @@ READ8_MEMBER(tnzs_state::arknoid2_sh_f000_r)
 {
 //  logerror("PC %04x: read input %04x\n", space.device().safe_pc(), 0xf000 + offset);
 
-	ioport_port *port = (offset / 2) ? m_an2 : m_an1;
-	int val = port ? port->read() : 0;
+	int val = ((offset / 2) ? m_an2 : m_an1).read_safe(0);
 
 	if (offset & 1)
 		return ((val >> 8) & 0xff);

--- a/src/mame/machine/vectrex.cpp
+++ b/src/mame/machine/vectrex.cpp
@@ -183,10 +183,7 @@ WRITE_LINE_MEMBER(vectrex_state::vectrex_via_irq)
 
 READ8_MEMBER(vectrex_state::vectrex_via_pb_r)
 {
-	int pot;
-	ioport_port *io_port[4] = { m_io_contr1x, m_io_contr1y, m_io_contr2x, m_io_contr2y };
-
-	pot = io_port[(m_via_out[PORTB] & 0x6) >> 1]->read() - 0x80;
+	int pot = m_io_contr[(m_via_out[PORTB] & 0x6) >> 1]->read() - 0x80;
 
 	if (pot > (signed char)m_via_out[PORTA])
 		m_via_out[PORTB] |= 0x20;

--- a/src/mame/video/amiga.cpp
+++ b/src/mame/video/amiga.cpp
@@ -150,7 +150,7 @@ UINT32 amiga_state::amiga_gethvpos()
 {
 	amiga_state *state = this;
 	UINT32 hvpos = (m_last_scanline << 8) | (m_screen->hpos() >> 2);
-	UINT32 latchedpos = m_hvpos ? m_hvpos->read() : 0;
+	UINT32 latchedpos = m_hvpos.read_safe(0);
 
 	/* if there's no latched position, or if we are in the active display area */
 	/* but before the latching point, return the live HV position */

--- a/src/mame/video/antic.cpp
+++ b/src/mame/video/antic.cpp
@@ -1391,7 +1391,7 @@ void antic_device::render(address_space &space, int param1, int param2, int para
  ************************************************************************/
 UINT32 antic_device::screen_update(screen_device &screen, bitmap_ind16 &bitmap, const rectangle &cliprect)
 {
-	UINT32 new_tv_artifacts = m_artifacts ? m_artifacts->read() : 0;
+	UINT32 new_tv_artifacts = m_artifacts.read_safe(0);
 	copybitmap(bitmap, *m_bitmap, 0, 0, 0, 0, cliprect);
 
 	if (m_tv_artifacts != new_tv_artifacts)
@@ -2084,7 +2084,7 @@ void antic_device::generic_interrupt(int button_count)
 	if( m_scanline == VBL_START )
 	{
 		/* specify buttons relevant to this Atari variant */
-		m_gtia->button_interrupt(button_count, m_djoy_b ? m_djoy_b->read() : 0);
+		m_gtia->button_interrupt(button_count, m_djoy_b.read_safe(0));
 
 		/* do nothing new for the rest of the frame */
 		m_modelines = m_screen->height() - VBL_START;

--- a/src/mame/video/apple2.cpp
+++ b/src/mame/video/apple2.cpp
@@ -101,7 +101,7 @@ inline void apple2_state::apple2_plot_text_character(bitmap_ind16 &bitmap, int x
 	const UINT8 *chardata;
 	UINT16 color;
 
-	if (m_sysconfig != nullptr)
+	if (m_sysconfig.found())
 	{
 		switch (m_sysconfig->read() & 0x03)
 		{
@@ -289,12 +289,7 @@ void apple2_state::apple2_hires_draw(bitmap_ind16 &bitmap, const rectangle &clip
 	UINT16 *p;
 	UINT32 w;
 	UINT16 *artifact_map_ptr;
-	int mon_type = 0;
-
-	if (m_sysconfig != nullptr)
-	{
-		mon_type = m_sysconfig->read() & 0x03;
-	}
+	int mon_type = m_sysconfig.read_safe(0) & 0x03;
 
 	/* sanity checks */
 	if (beginrow < cliprect.min_y)

--- a/src/mame/video/astrocde.cpp
+++ b/src/mame/video/astrocde.cpp
@@ -490,51 +490,51 @@ READ8_MEMBER(astrocde_state::astrocade_data_chip_register_r)
 			break;
 
 		case 0x10:  /* player 1 handle */
-			result = m_p1handle? m_p1handle->read() : 0xff;
+			result = m_p1handle.read_safe(0xff);
 			break;
 
 		case 0x11:  /* player 2 handle */
-			result = m_p2handle? m_p2handle->read() : 0xff;
+			result = m_p2handle.read_safe(0xff);
 			break;
 
 		case 0x12:  /* player 3 handle */
-			result = m_p3handle? m_p3handle->read() : 0xff;
+			result = m_p3handle.read_safe(0xff);
 			break;
 
 		case 0x13:  /* player 4 handle */
-			result = m_p4handle? m_p4handle->read() : 0xff;
+			result = m_p4handle.read_safe(0xff);
 			break;
 
 		case 0x14:  /* keypad column 0 */
-			result = m_keypad0 ? m_keypad0->read() : 0xff;
+			result = m_keypad0.read_safe(0xff);
 			break;
 
 		case 0x15:  /* keypad column 1 */
-			result = m_keypad1 ? m_keypad1->read() : 0xff;
+			result = m_keypad1.read_safe(0xff);
 			break;
 
 		case 0x16:  /* keypad column 2 */
-			result = m_keypad2 ? m_keypad2->read() : 0xff;
+			result = m_keypad2.read_safe(0xff);
 			break;
 
 		case 0x17:  /* keypad column 3 */
-			result = m_keypad3 ? m_keypad3->read() : 0xff;
+			result = m_keypad3.read_safe(0xff);
 			break;
 
 		case 0x1c:  /* player 1 knob */
-			result = m_p1_knob ? m_p1_knob->read() : 0xff;
+			result = m_p1_knob.read_safe(0xff);
 			break;
 
 		case 0x1d:  /* player 2 knob */
-			result = m_p2_knob ? m_p2_knob->read() : 0xff;
+			result = m_p2_knob.read_safe(0xff);
 			break;
 
 		case 0x1e:  /* player 3 knob */
-			result = m_p3_knob ? m_p3_knob->read() : 0xff;
+			result = m_p3_knob.read_safe(0xff);
 			break;
 
 		case 0x1f:  /* player 4 knob */
-			result = m_p4_knob ? m_p4_knob->read() : 0xff;
+			result = m_p4_knob.read_safe(0xff);
 			break;
 	}
 

--- a/src/mame/video/itech8.cpp
+++ b/src/mame/video/itech8.cpp
@@ -436,7 +436,7 @@ READ8_MEMBER(itech8_state::blitter_r)
 
 	/* a read from offsets 12-15 return input port values */
 	if (offset >= 12 && offset <= 15)
-		result = m_an[offset - 12] ? m_an[offset - 12]->read() : 0;
+		result = m_an[offset - 12].read_safe(0);
 
 	return result;
 }

--- a/src/mame/video/lethalj.cpp
+++ b/src/mame/video/lethalj.cpp
@@ -30,13 +30,13 @@ inline void lethalj_state::get_crosshair_xy(int player, int *x, int *y)
 
 	if (player)
 	{
-		*x = (((m_light1_x ? m_light1_x->read() : 0) & 0xff) * width) / 255;
-		*y = (((m_light1_y ? m_light1_y->read() : 0) & 0xff) * height) / 255;
+		*x = ((m_light1_x.read_safe(0) & 0xff) * width) / 255;
+		*y = ((m_light1_y.read_safe(0) & 0xff) * height) / 255;
 	}
 	else
 	{
-		*x = (((m_light0_x ? m_light0_x->read() : 0) & 0xff) * width) / 255;
-		*y = (((m_light0_y ? m_light0_y->read() : 0) & 0xff) * height) / 255;
+		*x = ((m_light0_x.read_safe(0) & 0xff) * width) / 255;
+		*y = ((m_light0_y.read_safe(0) & 0xff) * height) / 255;
 	}
 }
 

--- a/src/mame/video/mac.cpp
+++ b/src/mame/video/mac.cpp
@@ -245,14 +245,8 @@ VIDEO_RESET_MEMBER(mac_state,macrbv)
 	visarea.min_x = 0;
 	visarea.min_y = 0;
 	view = 0;
-	if (m_montype)
-	{
-		m_rbv_montype = m_montype->read();
-	}
-	else
-	{
-		m_rbv_montype = 2;
-	}
+
+	m_rbv_montype = m_montype.read_safe(2);
 	switch (m_rbv_montype)
 	{
 		case 1: // 15" portrait display
@@ -309,7 +303,7 @@ VIDEO_RESET_MEMBER(mac_state,macsonora)
 	visarea.min_x = 0;
 	visarea.min_y = 0;
 
-	m_rbv_montype = m_montype ? m_montype->read() : 2;
+	m_rbv_montype = m_montype.read_safe(2);
 	switch (m_rbv_montype)
 	{
 		case 1: // 15" portrait display


### PR DESCRIPTION
- Eliminate read_safe as a global function and make it a method of optional_ioport (and required_ioport, for which it makes less sense).
- New constructor for optional_ioport_array and required_ioport_array using std::initializer_list to specify tag list
- Remove pointer/reference conversion operators for required_ioport and optional_ioport. Explicit getters like found() and target() are now required when dereferencing isn't wanted. Many drivers have been changed to use required_ioport_array and optional_ioport_array to make this cleaner.
- Update numerous drivers that were using read_safe to use I/O port finders generally. Port names have been kept the same as far as possible to avoid breaking saves.(Some of the optional finders should probably be required.)
- Give edfbl and monkelf their own memory maps so hacky input reading routines can be removed.
- Clean up some legacy static handlers in amiga.cpp and cubo.cpp.