### PR TITLE
This should fix a regression incurred from the rom_entry changes identified by MASH

### DIFF
--- a/src/frontend/mame/info.cpp
+++ b/src/frontend/mame/info.cpp
@@ -579,8 +579,7 @@ void info_xml_creator::output_rom(device_t &device)
 				if (!is_disk && is_bios)
 				{
 					// scan backwards through the ROM entries
-					auto entries = rom_build_entries(m_drivlist.driver().rom);
-					for (const rom_entry *brom = entries.data(); !ROMENTRY_ISEND(brom); brom++)
+					for (const rom_entry *brom = rom - 1; brom != device.rom_region(); brom--)
 						if (ROMENTRY_ISSYSTEM_BIOS(brom))
 						{
 							strcpy(bios_name, ROM_GETNAME(brom));


### PR DESCRIPTION
On pull request #1200, MASH identfied a regression caused by recent changes to rom_entry handling.  That said, I disagreed with his proposed fix because the code did a backwards scan for ROMENTRY_ISEND.  I don't think this is correct; ROMENTRY_ISEND should only work for forward scans, and it probably worked by accident simply because rom_entry structures were likely allocated back to back.

As far as I can tell, my proposed change seems to work but I'm somewhat fuzzy on the interactions between BIOS ROMs and devices, and it is possible that I'm neglecting a use case.