### PR TITLE
Eliminated device_image_interface::m_readonly

### DIFF
--- a/src/devices/imagedev/cassette.cpp
+++ b/src/devices/imagedev/cassette.cpp
@@ -285,10 +285,6 @@ image_init_result cassette_image_device::internal_load(bool is_create)
 			cassette_flags = is_writable ? (CASSETTE_FLAG_READWRITE|CASSETTE_FLAG_SAVEONEXIT) : CASSETTE_FLAG_READONLY;
 			std::string fname;
 			err = cassette_open_choices((void *)image, &image_ioprocs, filetype().c_str(), m_formats, cassette_flags, &m_cassette);
-
-			/* this is kind of a hack */
-			if (err && is_writable)
-				make_readonly();
 		}
 		while(err && is_writable);
 

--- a/src/emu/diimage.h
+++ b/src/emu/diimage.h
@@ -179,8 +179,7 @@ public:
 	bool is_open() const { return bool(m_file); }
 	util::core_file &image_core_file() const { return *m_file; }
 	UINT64 length() { check_for_file(); return m_file->size(); }
-	bool is_readonly() const { return m_readonly; }
-	void make_readonly() { m_readonly = true; }
+	bool is_readonly() const { return m_file.get() != nullptr && !m_file->write_access(); }
 	UINT32 fread(void *buffer, UINT32 length) { check_for_file(); return m_file->read(buffer, length); }
 	UINT32 fread(optional_shared_ptr<UINT8> &ptr, UINT32 length) { ptr.allocate(length); return fread(ptr.target(), length); }
 	UINT32 fread(optional_shared_ptr<UINT8> &ptr, UINT32 length, offs_t offset) { ptr.allocate(length); return fread(ptr + offset, length - offset); }
@@ -320,7 +319,6 @@ private:
 	UINT32  m_supported;
 
 	// flags
-	bool m_readonly;
 	bool m_created;
 	bool m_init_phase;
 

--- a/src/lib/util/corefile.cpp
+++ b/src/lib/util/corefile.cpp
@@ -162,6 +162,8 @@ public:
 	virtual osd_file::error truncate(std::uint64_t offset) override { return m_file.truncate(offset); }
 
 	virtual osd_file::error flush() override { return m_file.flush(); }
+	virtual bool read_access() const override { return m_file.read_access(); }
+	virtual bool write_access() const override { return m_file.write_access(); }
 
 private:
 	core_file &m_file;
@@ -197,8 +199,8 @@ protected:
 	{
 	}
 
-	bool read_access() const { return 0U != (m_openflags & OPEN_FLAG_READ); }
-	bool write_access() const { return 0U != (m_openflags & OPEN_FLAG_WRITE); }
+	virtual bool read_access() const override { return 0U != (m_openflags & OPEN_FLAG_READ); }
+	virtual bool write_access() const override { return 0U != (m_openflags & OPEN_FLAG_WRITE); }
 	bool no_bom() const { return 0U != (m_openflags & OPEN_FLAG_NO_BOM); }
 
 	bool has_putback() const { return m_back_char_head != m_back_char_tail; }

--- a/src/lib/util/corefile.h
+++ b/src/lib/util/corefile.h
@@ -125,6 +125,10 @@ public:
 	// flush file buffers
 	virtual osd_file::error flush() = 0;
 
+	// file access types
+	virtual bool read_access() const = 0;
+	virtual bool write_access() const = 0;
+
 
 protected:
 	core_file();


### PR DESCRIPTION
…getting the same information through exposed methods on core_file

m_readonly looked like a holdover from when core file objects had less state, and we couldn't necessarily figure out whether a file was in fact readonly.

Take note that I eliminated make_readonly(); here is why I think the calls were unnecessary:
  1.  All image loads through softlists are done through common_process_file(), and thus going to be readonly anyways
  2.  The cassette.cpp call to make_readonly() seems to be a residual hack, if a failure occurs the image will be unloaded anyways