### PR TITLE
Eliminated device_image_interface::make_readonly()

### DIFF
--- a/src/devices/imagedev/cassette.cpp
+++ b/src/devices/imagedev/cassette.cpp
@@ -285,10 +285,6 @@ image_init_result cassette_image_device::internal_load(bool is_create)
 			cassette_flags = is_writable ? (CASSETTE_FLAG_READWRITE|CASSETTE_FLAG_SAVEONEXIT) : CASSETTE_FLAG_READONLY;
 			std::string fname;
 			err = cassette_open_choices((void *)image, &image_ioprocs, filetype().c_str(), m_formats, cassette_flags, &m_cassette);
-
-			/* this is kind of a hack */
-			if (err && is_writable)
-				make_readonly();
 		}
 		while(err && is_writable);
 

--- a/src/emu/diimage.cpp
+++ b/src/emu/diimage.cpp
@@ -510,7 +510,7 @@ void device_image_interface::image_checkhash()
 
 	// only calculate CRC if it hasn't been calculated, and the open_mode is read only
 	UINT32 crcval;
-	if (!m_hash.crc(crcval) && m_readonly && !m_created)
+	if (!m_hash.crc(crcval) && is_readonly() && !m_created)
 	{
 		// do not cause a linear read of 600 megs please
 		// TODO: use SHA1 in the CHD header as the hash
@@ -1060,8 +1060,6 @@ image_init_result device_image_interface::load_software(const std::string &softl
 	const char *read_only = get_feature("read_only");
 	if (read_only && !strcmp(read_only, "true"))
 	{
-		make_readonly();
-
 		// Copy some image information when we have been loaded through a software list
 		if (m_software_info_ptr)
 		{

--- a/src/emu/diimage.h
+++ b/src/emu/diimage.h
@@ -180,7 +180,6 @@ public:
 	util::core_file &image_core_file() const { return *m_file; }
 	UINT64 length() { check_for_file(); return m_file->size(); }
 	bool is_readonly() const { return m_readonly; }
-	void make_readonly() { m_readonly = true; }
 	UINT32 fread(void *buffer, UINT32 length) { check_for_file(); return m_file->read(buffer, length); }
 	UINT32 fread(optional_shared_ptr<UINT8> &ptr, UINT32 length) { ptr.allocate(length); return fread(ptr.target(), length); }
 	UINT32 fread(optional_shared_ptr<UINT8> &ptr, UINT32 length, offs_t offset) { ptr.allocate(length); return fread(ptr + offset, length - offset); }


### PR DESCRIPTION
Take note that I eliminated make_readonly(); here is why I think the calls were unnecessary:
1.  All image loads through softlists are done through common_process_file(), and thus going to be readonly anyways
2.  The cassette.cpp call to make_readonly() seems to be a residual hack, if a failure occurs the image will be unloaded anyways