### PR TITLE
Fixed an issue that caused softlist device descriptions to be blank

### DIFF
--- a/src/emu/softlist.cpp
+++ b/src/emu/softlist.cpp
@@ -166,12 +166,13 @@ bool software_info::has_multiple_parts(const char *interface) const
 //  softlist_parser - constructor
 //-------------------------------------------------
 
-softlist_parser::softlist_parser(util::core_file &file, const std::string &filename, std::list<software_info> &infolist, std::ostringstream &errors)
+softlist_parser::softlist_parser(util::core_file &file, const std::string &filename, std::string &description, std::list<software_info> &infolist, std::ostringstream &errors)
 		: m_file(file),
 		m_filename(filename),
 		m_infolist(infolist),
 		m_errors(errors),
 		m_done(false),
+		m_description(description),
 		m_data_accum_expected(false),
 		m_current_info(nullptr),
 		m_current_part(nullptr),

--- a/src/emu/softlist.h
+++ b/src/emu/softlist.h
@@ -148,7 +148,7 @@ class softlist_parser
 {
 public:
 	// construction (== execution)
-	softlist_parser(util::core_file &file, const std::string &filename, std::list<software_info> &infolist, std::ostringstream &errors);
+	softlist_parser(util::core_file &file, const std::string &filename, std::string &description, std::list<software_info> &infolist, std::ostringstream &errors);
 
 private:
 	enum parse_position
@@ -191,12 +191,12 @@ private:
 
 	// internal parsing state
 	util::core_file &					m_file;
-	const std::string &			m_filename;
+	std::string 						m_filename;
 	std::list<software_info> &	m_infolist;
 	std::ostringstream &		m_errors;
 	struct XML_ParserStruct *	m_parser;
 	bool						m_done;
-	std::string					m_description;
+	std::string &				m_description;
 	bool                    m_data_accum_expected;
 	std::string             m_data_accum;
 	software_info *         m_current_info;

--- a/src/emu/softlist_dev.cpp
+++ b/src/emu/softlist_dev.cpp
@@ -229,9 +229,9 @@ void software_list_device::display_matches(const machine_config &config, const c
 		{
 			// different output depending on original system or compatible
 			if (swlistdev.list_type() == SOFTWARE_LIST_ORIGINAL_SYSTEM)
-				osd_printf_error("* Software list \"%s\" (%s) matches: \n", swlistdev.list_name().c_str(), swlistdev.description());
+				osd_printf_error("* Software list \"%s\" (%s) matches: \n", swlistdev.list_name().c_str(), swlistdev.description().c_str());
 			else
-				osd_printf_error("* Compatible software list \"%s\" (%s) matches: \n", swlistdev.list_name().c_str(), swlistdev.description());
+				osd_printf_error("* Compatible software list \"%s\" (%s) matches: \n", swlistdev.list_name().c_str(), swlistdev.description().c_str());
 
 			// print them out
 			for (auto &match : matches)
@@ -297,7 +297,7 @@ void software_list_device::parse()
 	{
 		// parse if no error
 		std::ostringstream errs;
-		softlist_parser parser(m_file, m_description, m_infolist, errs);
+		softlist_parser parser(m_file, m_file.filename(), m_description, m_infolist, errs);
 		m_file.close();
 		m_errors = errs.str();
 	}

--- a/src/emu/softlist_dev.h
+++ b/src/emu/softlist_dev.h
@@ -145,7 +145,7 @@ public:
 	const char *filename() { return m_file.filename(); }
 
 	// getters that may trigger a parse
-	const char *description() { if (!m_parsed) parse(); return m_description.c_str(); }
+	const std::string &description() { if (!m_parsed) parse(); return m_description; }
 	bool valid() { if (!m_parsed) parse(); return !m_infolist.empty(); }
 	const char *errors_string() { if (!m_parsed) parse(); return m_errors.c_str(); }
 	const std::list<software_info> &get_info() { if (!m_parsed) parse(); return m_infolist; }

--- a/src/frontend/mame/clifront.cpp
+++ b/src/frontend/mame/clifront.cpp
@@ -1387,7 +1387,7 @@ void cli_frontend::verifysamples(const char *gamename)
 
 void cli_frontend::output_single_softlist(FILE *out, software_list_device &swlistdev)
 {
-	fprintf(out, "\t<softwarelist name=\"%s\" description=\"%s\">\n", swlistdev.list_name().c_str(), xml_normalize_string(swlistdev.description()));
+	fprintf(out, "\t<softwarelist name=\"%s\" description=\"%s\">\n", swlistdev.list_name().c_str(), xml_normalize_string(swlistdev.description().c_str()));
 	for (const software_info &swinfo : swlistdev.get_info())
 	{
 		fprintf(out, "\t\t<software name=\"%s\"", swinfo.shortname().c_str());


### PR DESCRIPTION
This also fixes a likely undiscovered issue where the filename in softlist XML parse error messages was also blank