### PR TITLE
Fix audio distortion with -refreshspeed and -sound xaudio2 (MT 06199)

### DIFF
--- a/src/osd/modules/sound/xaudio2_sound.cpp
+++ b/src/osd/modules/sound/xaudio2_sound.cpp
@@ -45,6 +45,7 @@
 
 #define INITIAL_BUFFER_COUNT 4
 #define SUBMIT_FREQUENCY_TARGET_MS 20
+#define RESAMPLE_TOLERANCE 1.20f
 
 //============================================================
 //  Macros
@@ -494,7 +495,7 @@ void sound_xaudio2::create_buffers(const WAVEFORMATEX &format)
 	// buffer size is equal to the bytes we need to hold in memory per X tenths of a second where X is audio_latency
 	float audio_latency_in_seconds = m_audio_latency / 10.0f;
 	UINT32 format_bytes_per_second = format.nSamplesPerSec * format.nBlockAlign;
-	UINT32 total_buffer_size = format_bytes_per_second * audio_latency_in_seconds;
+	UINT32 total_buffer_size = format_bytes_per_second * audio_latency_in_seconds * RESAMPLE_TOLERANCE;
 
 	// We want to be able to submit buffers every X milliseconds
 	// I want to divide these up into "packets" so figure out how many buffers we need
@@ -594,10 +595,6 @@ void sound_xaudio2::submit_needed()
 {
 	XAUDIO2_VOICE_STATE state;
 	m_sourceVoice->GetState(&state, XAUDIO2_VOICE_NOSAMPLESPLAYED);
-
-	// If we have a buffer on the queue, no reason to submit
-	if (state.BuffersQueued >= 1)
-		return;
 
 	std::lock_guard<std::mutex> lock(m_buffer_lock);
 


### PR DESCRIPTION
This fixes the audio distortion when using -refreshspeed or -speed in combination with -sound xaudio2.  Currently the xaudio2 module expects an exact number of samples per update, otherwise audio glitches are introduced. When using -refreshspeed or -speed, the sound output is resampled by the core sound manager to meet the new speed factor. This causes a different number of samples to be sent to xaudio2, which causes the mentioned glitches. While the module seems to be designed to allow this circunstance, there are two issues preventing correct behaviour:

1.- New sound buffers are not submitted if there's currently a buffer on the queue.  Maybe there was a good reason for this, but removing this code restores correct audio for the most part.

2.- In case of a speed factor lower than 1.0, the resampling creates more data so it overflows the buffer. Increasing its size by a reasonable factor (RESAMPLE_TOLERANCE) prevents the buffer overflow. This extra size is only used in case it's needed, so it shouldn't add any latency in normal use.

There might still exist minor audio glitches during machine start but nothing comparable with current situation. Just sending this as a pull request so audio pros can check it.
