### PR TITLE
Changed how ROM_COPY and ROM_FILL are represented in tiny_rom_entry to be more how they were in the past

### DIFF
--- a/scripts/src/emu.lua
+++ b/scripts/src/emu.lua
@@ -150,6 +150,7 @@ files {
 	MAME_DIR .. "src/emu/romload.cpp",
 	MAME_DIR .. "src/emu/romload.h",
 	MAME_DIR .. "src/emu/romentry.h",
+	MAME_DIR .. "src/emu/romentry.cpp",
 	MAME_DIR .. "src/emu/save.cpp",
 	MAME_DIR .. "src/emu/save.h",
 	MAME_DIR .. "src/emu/schedule.cpp",

--- a/src/emu/romentry.cpp
+++ b/src/emu/romentry.cpp
@@ -1,0 +1,74 @@
+// license:BSD-3-Clause
+// copyright-holders:Nicola Salmoria,Aaron Giles
+/*********************************************************************
+
+	romentry.cpp
+
+	ROM loading functions.
+
+*********************************************************************/
+
+#include "romentry.h"
+#include "strformat.h"
+
+
+/***************************************************************************
+	HELPERS
+***************************************************************************/
+
+//-------------------------------------------------
+//  hashdata_from_tiny_rom_entry - calculates the
+//	proper hashdata string from the value in the
+//	tiny_rom_entry
+//-------------------------------------------------
+
+static std::string hashdata_from_tiny_rom_entry(const tiny_rom_entry &ent)
+{
+	std::string result;
+	switch (ent.flags & ROMENTRY_TYPEMASK)
+	{
+	case ROMENTRYTYPE_FILL:
+	case ROMENTRYTYPE_COPY:
+		// for these types, tiny_rom_entry::hashdata is an integer typecasted to a pointer 
+		result = string_format("0x%x", (unsigned)(FPTR)ent.hashdata);
+		break;
+
+	default:
+		if (ent.hashdata != nullptr)
+			result.assign(ent.hashdata);
+		break;
+	}
+	return result;
+}
+
+
+/***************************************************************************
+	ROM ENTRY
+***************************************************************************/
+
+//-------------------------------------------------
+//  ctor (with move constructors)
+//-------------------------------------------------
+
+rom_entry::rom_entry(std::string &&name, std::string &&hashdata, UINT32 offset, UINT32 length, UINT32 flags)
+	: m_name(std::move(name))
+	, m_hashdata(std::move(hashdata))
+	, m_offset(offset)
+	, m_length(length)
+	, m_flags(flags)
+{
+}
+
+
+//-------------------------------------------------
+//  ctor (with tiny_rom_entry)
+//-------------------------------------------------
+
+rom_entry::rom_entry(const tiny_rom_entry &ent)
+	: m_name(ent.name != nullptr ? ent.name : "")
+	, m_hashdata(hashdata_from_tiny_rom_entry(ent))
+	, m_offset(ent.offset)
+	, m_length(ent.length)
+	, m_flags(ent.flags)
+{
+}

--- a/src/emu/romentry.h
+++ b/src/emu/romentry.h
@@ -132,18 +132,8 @@ struct tiny_rom_entry
 class rom_entry
 {
 public:
-	rom_entry(const tiny_rom_entry &ent)
-		: m_name(ent.name != nullptr ? ent.name : "")
-		, m_hashdata(ent.hashdata != nullptr ? ent.hashdata : "")
-		, m_offset(ent.offset)
-		, m_length(ent.length)
-		, m_flags(ent.flags) {}
-	rom_entry(std::string &&name, std::string &&hashdata, UINT32 offset, UINT32 length, UINT32 flags)
-		: m_name(std::move(name))
-		, m_hashdata(std::move(hashdata))
-		, m_offset(offset)
-		, m_length(length)
-		, m_flags(flags) {}
+	rom_entry(const tiny_rom_entry &ent);
+	rom_entry(std::string &&name, std::string &&hashdata, UINT32 offset, UINT32 length, UINT32 flags);
 	rom_entry(rom_entry const &) = default;
 	rom_entry(rom_entry &&) = default;
 	rom_entry &operator=(rom_entry const &) = default;

--- a/src/emu/romload.h
+++ b/src/emu/romload.h
@@ -132,9 +132,9 @@ class software_list_device;
 /* ----- additional ROM-related macros ----- */
 #define ROM_CONTINUE(offset,length)                 { nullptr, nullptr, offset, length, ROMENTRYTYPE_CONTINUE | ROM_INHERITFLAGS },
 #define ROM_IGNORE(length)                          { nullptr, nullptr, 0,      length, ROMENTRYTYPE_IGNORE | ROM_INHERITFLAGS },
-#define ROM_FILL(offset,length,value)               { nullptr, #value, offset, length, ROMENTRYTYPE_FILL },
-#define ROMX_FILL(offset,length,value,flags)        { nullptr, #value, offset, length, ROMENTRYTYPE_FILL | flags },
-#define ROM_COPY(srctag,srcoffs,offset,length)      { srctag, #srcoffs, offset, length, ROMENTRYTYPE_COPY },
+#define ROM_FILL(offset,length,value)               { nullptr, (const char *)value, offset, length, ROMENTRYTYPE_FILL },
+#define ROMX_FILL(offset,length,value,flags)        { nullptr, (const char *)value, offset, length, ROMENTRYTYPE_FILL | flags },
+#define ROM_COPY(srctag,srcoffs,offset,length)      { srctag, (const char *)srcoffs, offset, length, ROMENTRYTYPE_COPY },
 
 
 /* ----- system BIOS macros ----- */

--- a/src/emu/romload.h
+++ b/src/emu/romload.h
@@ -130,11 +130,11 @@ class software_list_device;
 #define ROM_RELOAD_PLAIN(offset,length)                 { nullptr, nullptr, offset, length, ROMENTRYTYPE_RELOAD },
 
 /* ----- additional ROM-related macros ----- */
-#define ROM_CONTINUE(offset,length)                 { nullptr, nullptr, offset, length, ROMENTRYTYPE_CONTINUE | ROM_INHERITFLAGS },
-#define ROM_IGNORE(length)                          { nullptr, nullptr, 0,      length, ROMENTRYTYPE_IGNORE | ROM_INHERITFLAGS },
-#define ROM_FILL(offset,length,value)               { nullptr, (const char *)value, offset, length, ROMENTRYTYPE_FILL },
-#define ROMX_FILL(offset,length,value,flags)        { nullptr, (const char *)value, offset, length, ROMENTRYTYPE_FILL | flags },
-#define ROM_COPY(srctag,srcoffs,offset,length)      { srctag, (const char *)srcoffs, offset, length, ROMENTRYTYPE_COPY },
+#define ROM_CONTINUE(offset,length)                 { nullptr, nullptr, (offset), (length), ROMENTRYTYPE_CONTINUE | ROM_INHERITFLAGS },
+#define ROM_IGNORE(length)                          { nullptr, nullptr, 0,      (length), ROMENTRYTYPE_IGNORE | ROM_INHERITFLAGS },
+#define ROM_FILL(offset,length,value)               { nullptr, (const char *)(value), (offset), (length), ROMENTRYTYPE_FILL },
+#define ROMX_FILL(offset,length,value,flags)        { nullptr, (const char *)(value), (offset), (length), ROMENTRYTYPE_FILL | flags },
+#define ROM_COPY(srctag,srcoffs,offset,length)      { (srctag), (const char *)(srcoffs), (offset), (length), ROMENTRYTYPE_COPY },
 
 
 /* ----- system BIOS macros ----- */


### PR DESCRIPTION
turbosub had a ROM_COPY declaration with an expression ('ROM_COPY( "main_code", 0x18000 + 0x2000,...) and this simply did not work with the new model.  This required changing ROM_* declarations to more resemble how they used to be and to perform the conversion on load.