### PR TITLE
Improvements to almost all games in skylncr.cpp

### DIFF
--- a/src/devices/cpu/z80/z80.cpp
+++ b/src/devices/cpu/z80/z80.cpp
@@ -1948,8 +1948,8 @@ OP(xycb,fe) { wm(m_ea, set(7, rm(m_ea)));        } /* SET  7,(XY+o)    */
 OP(xycb,ff) { A = set(7, rm(m_ea)); wm(m_ea, A); } /* SET  7,A=(XY+o)  */
 
 OP(illegal,1) {
-	logerror("Z80 '%s' ill. opcode $%02x $%02x\n",
-			tag(), m_decrypted_opcodes_direct->read_byte((PCD-1)&0xffff), m_decrypted_opcodes_direct->read_byte(PCD));
+	logerror("Z80 ill. opcode $%02x $%02x ($%04x)\n",
+			m_decrypted_opcodes_direct->read_byte((PCD-1)&0xffff), m_decrypted_opcodes_direct->read_byte(PCD), PCD-1);
 }
 
 /**********************************************************

--- a/src/emu/emumem.h
+++ b/src/emu/emumem.h
@@ -475,6 +475,33 @@ private:
 };
 
 
+// ======================> address_space_debug_wrapper
+
+// wrapper for temporarily setting the debug flag on a memory space (especially one being accessed through another space)
+class address_space_debug_wrapper
+{
+public:
+	// construction
+	address_space_debug_wrapper(address_space &space, bool debugger_access)
+		: m_target(space)
+		, m_prev_debugger_access(space.debugger_access())
+	{
+		space.set_debugger_access(debugger_access);
+	}
+
+	// destruction
+	~address_space_debug_wrapper() { m_target.set_debugger_access(m_prev_debugger_access); }
+
+	// getter
+	address_space &space() const { return m_target; }
+
+private:
+	// internal state
+	address_space &m_target;
+	const bool m_prev_debugger_access;
+};
+
+
 // ======================> memory_block
 
 // a memory block is a chunk of RAM associated with a range of memory in a device's address space

--- a/src/mame/drivers/skylncr.cpp
+++ b/src/mame/drivers/skylncr.cpp
@@ -488,7 +488,8 @@ READ_LINE_MEMBER(skylncr_state::mbutrfly_prot_r)
 
 READ8_MEMBER(skylncr_state::bdream97_opcode_r)
 {
-	return m_maincpu->space(AS_PROGRAM).read_byte(offset) ^ 0x80;
+	address_space_debug_wrapper program(m_maincpu->space(AS_PROGRAM), space.debugger_access());
+	return program.space().read_byte(offset) ^ 0x80;
 }
 
 


### PR DESCRIPTION
- Use standard input mappings in all games except Sonik Fighter
- Add working hopper outputs and payout buttons
- Promote mbutrfly to WORKING after solving the protection (the code wasn't encrypted) and add the button lamps internally associated with it
- Decrypt bdream97, which is almost working now with obvious graphical glitches and some apparent input problems

Slight error logging elaboration for illegal Z80 instructions (nw)