### PR TITLE
namconb1: forgot speaker rearrangement for NB2

### DIFF
--- a/src/mame/drivers/namconb1.cpp
+++ b/src/mame/drivers/namconb1.cpp
@@ -1183,10 +1183,10 @@ static MACHINE_CONFIG_START( namconb2, namconb1_state )
 
 	MCFG_SPEAKER_STANDARD_STEREO("lspeaker", "rspeaker")
 	MCFG_C352_ADD("c352", MASTER_CLOCK/2, 288)
-	MCFG_SOUND_ROUTE(0, "rspeaker", 1.00)
-	MCFG_SOUND_ROUTE(1, "lspeaker", 1.00)
-	MCFG_SOUND_ROUTE(2, "rspeaker", 1.00)
-	MCFG_SOUND_ROUTE(3, "lspeaker", 1.00)
+	MCFG_SOUND_ROUTE(0, "lspeaker", 1.00)
+	MCFG_SOUND_ROUTE(1, "rspeaker", 1.00)
+	//MCFG_SOUND_ROUTE(2, "lspeaker", 1.00) // Second DAC not present.
+	//MCFG_SOUND_ROUTE(3, "rspeaker", 1.00)
 MACHINE_CONFIG_END
 
 


### PR DESCRIPTION
Also we can probably get rid of the MACHINE_IMPERFECT_SOUND flag for the C352 games now, but that will be for another pull request.