### PR TITLE
Document 3 diagnostic menu bugs in the Vii's BIOS

### DIFF
--- a/src/mame/drivers/vii.cpp
+++ b/src/mame/drivers/vii.cpp
@@ -66,6 +66,9 @@ Detailed list of bugs:
 -- Smart Dart, black screen
 -- Happy Tennis, controls are haywire
 -- Bowling, freezes at the high score screen
+-- The "EEPROM TEST" option in the diagnostic menu (accessible by holding 1+2 or A+B during startup) freezes when selected
+-- The "MOTOR" option in the diagnostic menu does nothing when selected
+-- The input for the gyroscopic sensor tests in the "KEYBOARD + G-SENSOR" sub-menu goes haywire
 
 
 *******************************************************************************/


### PR DESCRIPTION
Add documentation for 3 bugs in the Vii's recently discovered diagnostic menu (from https://tcrf.net/Vii):

-- The "EEPROM TEST" option in the diagnostic menu (accessible by holding 1+2 or A+B during startup) freezes when selected
-- The "MOTOR" option in the diagnostic menu does nothing when selected
-- The input for the gyroscopic sensor tests in the "KEYBOARD + G-SENSOR" sub-menu goes haywire