### PR TITLE
Make Techno Drive working, fix H8 ADC inputs.

### DIFF
--- a/src/devices/cpu/h8/h8_adc.cpp
+++ b/src/devices/cpu/h8/h8_adc.cpp
@@ -33,7 +33,7 @@ void h8_adc_device::set_info(const char *_intc_tag, int _intc_vector)
 READ8_MEMBER(h8_adc_device::addr8_r)
 {
 	if(V>=1) logerror("addr8_r %d %03x\n", offset, addr[offset >> 1]);
-	return offset & 1 ? addr[offset >> 1] >> 2 : addr[offset >> 1] << 6;
+	return offset & 1 ? addr[offset >> 1] << 6 : addr[offset >> 1] >> 2;
 }
 
 READ16_MEMBER(h8_adc_device::addr16_r)

--- a/src/mame/drivers/namcos12.cpp
+++ b/src/mame/drivers/namcos12.cpp
@@ -1153,6 +1153,7 @@ public:
 
 	DECLARE_DRIVER_INIT(namcos12);
 	DECLARE_DRIVER_INIT(ptblank2);
+	DECLARE_DRIVER_INIT(technodr);
 	inline void ATTR_PRINTF(3,4) verboselog( int n_level, const char *s_fmt, ... );
 	void namcos12_rom_read( UINT32 *p_n_psxram, UINT32 n_address, INT32 n_size );
 	void namcos12_sub_irq( screen_device &screen, bool vblank_state );
@@ -1654,6 +1655,14 @@ DRIVER_INIT_MEMBER(namcos12_state,ptblank2)
 	*( (UINT32 *)( memregion( "maincpu:rom" )->base() + 0x331c4 ) ) = 0;
 }
 
+DRIVER_INIT_MEMBER(namcos12_state,technodr)
+{
+	DRIVER_INIT_CALL(namcos12);
+
+	// HACK: patch H8 to fix COIN ERROR
+	*( (UINT32 *)( memregion( "sub" )->base() + 0x14b6 ) ) = 0;
+}
+
 static MACHINE_CONFIG_START( coh700, namcos12_state )
 
 	/* basic machine hardware */
@@ -1996,13 +2005,13 @@ static INPUT_PORTS_START( technodr )
 	PORT_BIT( 0x01, IP_ACTIVE_LOW, IPT_SERVICE1 )  // service coin
 
 	PORT_START("GAS")
-	PORT_BIT( 0x3ff, 0x0200, IPT_PEDAL )  PORT_SENSITIVITY(100) PORT_KEYDELTA(10) PORT_NAME("Gas Pedal")
+	PORT_BIT( 0x3ff, 0x0200, IPT_PEDAL )  PORT_SENSITIVITY(100) PORT_KEYDELTA(10) PORT_NAME("Gas Pedal") PORT_REVERSE
 
 	PORT_START("BRAKE")
-	PORT_BIT( 0x3ff, 0x0200, IPT_PEDAL2 ) PORT_SENSITIVITY(100) PORT_KEYDELTA(10) PORT_NAME("Brake Pedal")
+	PORT_BIT( 0x3ff, 0x0200, IPT_PEDAL2 ) PORT_SENSITIVITY(100) PORT_KEYDELTA(10) PORT_NAME("Brake Pedal") PORT_REVERSE
 
 	PORT_START("STEER")
-	PORT_BIT( 0x3ff, 0x0200, IPT_PADDLE ) PORT_SENSITIVITY(100) PORT_KEYDELTA(10) PORT_NAME("Steering Wheel")
+	PORT_BIT( 0x3ff, 0x0200, IPT_PADDLE ) PORT_SENSITIVITY(100) PORT_KEYDELTA(10) PORT_NAME("Steering Wheel") PORT_REVERSE
 INPUT_PORTS_END
 
 static INPUT_PORTS_START( aplarail )
@@ -3109,8 +3118,8 @@ ROM_START( technodr )
 	ROM_LOAD16_BYTE( "th1rom0u.9",   0x0000001, 0x400000, CRC(260ae0c5) SHA1(2ecb82e069fa64b9d3f63d6193befae02f3140e4) )
 	ROM_LOAD16_BYTE( "th1rom1l.7",   0x0800000, 0x400000, CRC(56d9b477) SHA1(101b5acfbe5d292418f7fd8db642187f2b571d0b) )
 	ROM_LOAD16_BYTE( "th1rom1u.10",  0x0800001, 0x400000, CRC(a45d337e) SHA1(10e230b61ab4c6aa386c68463badef0c4ba58f0e) )
-	ROM_LOAD16_BYTE( "th1fl3l.12",   0x1000000, 0x200000, CRC(cd4422c0) SHA1(97a9788cf0c589477f77c5403cc715ce4980a7bd) )
-	ROM_LOAD16_BYTE( "th1fl3u.13",   0x1000001, 0x200000, CRC(c330116f) SHA1(b12de5a82d6ebb5f893882b578e02af732231512) )
+	ROM_LOAD16_BYTE( "th1fl3l.12",   0x1800000, 0x200000, CRC(c330116f) SHA1(b12de5a82d6ebb5f893882b578e02af732231512) )
+	ROM_LOAD16_BYTE( "th1fl3u.13",   0x1800001, 0x200000, CRC(cd4422c0) SHA1(97a9788cf0c589477f77c5403cc715ce4980a7bd) )
 
 	ROM_REGION( 0x0080000, "sub", 0 ) /* sound prg */
 	ROM_LOAD16_WORD_SWAP( "th1verb.11s",  0x000000, 0x080000, CRC(85806e2e) SHA1(9e0a7e6924b72e7b5b1d0e72eeec10045984dd4b) )
@@ -3173,7 +3182,7 @@ GAME( 1998, ehrgeizja, ehrgeiz,  coh700,   namcos12, namcos12_state, namcos12, R
 GAME( 1998, mdhorse,   0,        coh700,   namcos12, namcos12_state, namcos12, ROT0, "MOSS / Namco",    "Derby Quiz My Dream Horse (Japan, MDH1/VER.A2)", MACHINE_IMPERFECT_GRAPHICS | MACHINE_NOT_WORKING ) /* KC035 */
 GAME( 1998, aplarail,  0,        aplarail, aplarail, namcos12_state, namcos12, ROT0, "Namco / Tomy",    "Attack Pla Rail (Japan, AP1/VER.A)", MACHINE_IMPERFECT_GRAPHICS ) /* KC032 */
 GAME( 1998, sws98,     0,        coh700,   namcos12, namcos12_state, namcos12, ROT0, "Namco",           "Super World Stadium '98 (Japan, SS81/VER.A)", MACHINE_IMPERFECT_GRAPHICS ) /* KC0?? */
-GAME( 1998, technodr,  0,        technodr, technodr, namcos12_state, namcos12, ROT0, "Namco",           "Techno Drive (Japan, TD2/VER.B)", MACHINE_IMPERFECT_GRAPHICS | MACHINE_NOT_WORKING ) /* KC056 */
+GAME( 1998, technodr,  0,        technodr, technodr, namcos12_state, technodr, ROT0, "Namco",           "Techno Drive (Japan, TD2/VER.B)", MACHINE_IMPERFECT_GRAPHICS ) /* KC056 */
 GAME( 1998, tenkomor,  0,        coh700,   namcos12, namcos12_state, namcos12, ROT90,"Namco",           "Tenkomori Shooting (Asia, TKM2/VER.A1)", MACHINE_IMPERFECT_GRAPHICS ) /* KC036 */
 GAME( 1998, tenkomorja,tenkomor, coh700,   namcos12, namcos12_state, namcos12, ROT90,"Namco",           "Tenkomori Shooting (Japan, TKM1/VER.A1)", MACHINE_IMPERFECT_GRAPHICS ) /* KC036 */
 GAME( 1998, fgtlayer,  0,        coh700,   namcos12, namcos12_state, namcos12, ROT0, "Arika / Namco",   "Fighting Layer (Japan, FTL1/VER.A)", MACHINE_IMPERFECT_GRAPHICS ) /* KC037 */


### PR DESCRIPTION
Techno Drive previously displayed a 'COIN ERROR' at bootup. Fixed this by
patching the sub CPU program (not the best fix maybe but I hope it will
work for now).

The contents of 'th1fl3l.12' and 'th1fl3u.13' appeared to have been
swapped. Swapped the filenames and placed them at the proper memory
location (0x1800000) and the game no longer crashes at the Namco logo.

Played through the game a few times and it seems to be fully working
now.