### PR TITLE
Maygay - fix input strobe order bug

### DIFF
--- a/src/mame/drivers/maygay1b.cpp
+++ b/src/mame/drivers/maygay1b.cpp
@@ -635,7 +635,7 @@ WRITE8_MEMBER( maygay1b_state::lamp_data_w )
 
 READ8_MEMBER( maygay1b_state::kbd_r )
 {
-	return (m_kbd_ports[m_lamp_strobe&0x07])->read();
+	return (m_kbd_ports[(m_lamp_strobe&0x07)^4])->read();
 }
 
 WRITE8_MEMBER( maygay1b_state::scanlines_2_w )

--- a/src/mame/includes/maygay1b.h
+++ b/src/mame/includes/maygay1b.h
@@ -41,7 +41,7 @@ public:
 		m_duart68681(*this, "duart68681"),
 		m_sw1_port(*this, "SW1"),
 		m_sw2_port(*this, "SW2"),
-		m_kbd_ports(*this, {"SW1", "STROBE2", "STROBE3", "STROBE4", "STROBE5", "STROBE6", "STROBE7", "SW2"}),
+		m_kbd_ports(*this, { "SW1", "SW2", "STROBE2", "STROBE3", "STROBE4", "STROBE5", "STROBE6", "STROBE7", }),
 		m_bank1(*this, "bank1"),
 		m_reel0(*this, "reel0"),
 		m_reel1(*this, "reel1"),


### PR DESCRIPTION
m_kbd_ports array order was wrong, strobe needed the same ^4 bit twiddle as the lamps