### PR TITLE
Techno Drive improvements

### DIFF
--- a/src/devices/cpu/h8/h8_sci.cpp
+++ b/src/devices/cpu/h8/h8_sci.cpp
@@ -141,12 +141,17 @@ READ8_MEMBER(h8_sci_device::tdr_r)
 
 WRITE8_MEMBER(h8_sci_device::ssr_w)
 {
+	cpu->synchronize();
+	
 	if(!(scr & SCR_TE)) {
 		data |= SSR_TDRE;
 		ssr |= SSR_TDRE;
 	}
 	if((ssr & SSR_TDRE) && !(data & SSR_TDRE))
+	{
 		ssr &= ~SSR_TEND;
+		scr &= ~SCR_TIE;
+	}
 	ssr = ((ssr & ~SSR_MPBT) | (data & SSR_MPBT)) & (data | (SSR_TEND|SSR_MPB|SSR_MPBT));
 	if(V>=2) logerror("ssr_w %02x -> %02x (%06x)\n", data, ssr, cpu->pc());
 
@@ -606,7 +611,7 @@ void h8_sci_device::tx_dropped_edge()
 		tx_bit = 0;
 		clock_stop(CLK_TX);
 		tx_cb(1);
-		ssr |= SSR_TEND;
+		ssr |= SSR_TEND|SSR_TDRE;
 		if(scr & SCR_TEIE)
 			intc->internal_interrupt(tei_int);
 		break;

--- a/src/mame/drivers/namcos12.cpp
+++ b/src/mame/drivers/namcos12.cpp
@@ -22,8 +22,8 @@
       which is called by the routine at 3FEA.  It is not clear how execution is intended to get to 3FEA - there are no direct
       branches to that location, and the bytes 3F EA don't appear at all in the program.
 	  
-	- technodr: printer not emulated. To play the game, press F2 to enter the test menu, navigate to GAME OPTIONS and disable
-	  the printer by setting "PRINTER" to OFF.
+    - technodr: printer not emulated. To play the game, press F2 to enter the test menu, navigate to GAME OPTIONS and disable
+      the printer by setting "PRINTER" to OFF.
 
 Namco System 12 - Arcade Playstation-based Hardware
 ===================================================

--- a/src/mame/drivers/namcos12.cpp
+++ b/src/mame/drivers/namcos12.cpp
@@ -9,6 +9,9 @@
   H8/3002 and Golgo13 support by R. Belmont based on work by The_Author and DynaChicken
   JVS Support by R. Belmont
 
+  Notes:
+    - technodr: Calibrate controls by turning on the service mode switch (F2) while holdign service coin (9).
+  
   Issues:
     not all games work due to either banking, dma or protection issues.
     graphics are glitchy in some games.
@@ -18,7 +21,9 @@
     - truckk doesn't boot: the H8/3002 never enters InitJVSBoards @ 1DE2.  1DE2 is referenced in a table of commands at 4032,
       which is called by the routine at 3FEA.  It is not clear how execution is intended to get to 3FEA - there are no direct
       branches to that location, and the bytes 3F EA don't appear at all in the program.
-
+	  
+	- technodr: printer not emulated. To play the game, press F2 to enter the test menu, navigate to GAME OPTIONS and disable
+	  the printer by setting "PRINTER" to OFF.
 
 Namco System 12 - Arcade Playstation-based Hardware
 ===================================================


### PR DESCRIPTION
Sub CPU seems to expect certain H8 SCI behavior (especially after starting a transmission by clearing the TDRE flag), otherwise it locks up after a few minutes making controls unresponsive.

Also added notes to namcos12.cpp regarding input calibration and initial setup.