### PR TITLE
Now setting m_filetype for images loaded from softlists

### DIFF
--- a/src/devices/imagedev/cassette.h
+++ b/src/devices/imagedev/cassette.h
@@ -96,6 +96,7 @@ protected:
 	// device-level overrides
 	virtual void device_config_complete() override;
 	virtual void device_start() override;
+	virtual const bool use_software_list_file_extension_for_filetype() const override { return true; }
 
 private:
 	cassette_image  *m_cassette;

--- a/src/emu/diimage.cpp
+++ b/src/emu/diimage.cpp
@@ -1052,7 +1052,7 @@ image_init_result device_image_interface::load_software(const std::string &softl
 	m_image_name = m_full_software_name;
 	m_basename = m_full_software_name;
 	m_basename_noext = m_full_software_name;
-	m_filetype = m_mame_file != nullptr
+	m_filetype = use_software_list_file_extension_for_filetype() && m_mame_file != nullptr
 		? core_filename_extract_extension(m_mame_file->filename(), true)
 		: "";
 

--- a/src/emu/diimage.cpp
+++ b/src/emu/diimage.cpp
@@ -1052,7 +1052,9 @@ image_init_result device_image_interface::load_software(const std::string &softl
 	m_image_name = m_full_software_name;
 	m_basename = m_full_software_name;
 	m_basename_noext = m_full_software_name;
-	m_filetype = "";
+	m_filetype = m_mame_file != nullptr
+		? core_filename_extract_extension(m_mame_file->filename(), true)
+		: "";
 
 	// check if image should be read-only
 	const char *read_only = get_feature("read_only");

--- a/src/emu/diimage.h
+++ b/src/emu/diimage.h
@@ -250,6 +250,7 @@ public:
 
 protected:
 	virtual const software_list_loader &get_software_list_loader() const;
+	virtual const bool use_software_list_file_extension_for_filetype() const { return false; }
 
 	image_init_result load_internal(const std::string &path, bool is_create, int create_format, util::option_resolution *create_args, bool just_load);
 	image_error_t load_image_by_path(UINT32 open_flags, const std::string &path);


### PR DESCRIPTION
Tafoid reported that 'bbcb exile' failed in the tip, but succeeded in MAME 0.176.  I've identified the issue.

`
In MAME 0.176, cassette.cpp had the following code:

	const char *extension;

	...

	if (software_entry()==nullptr) {
		extension = filetype();
	} else {
		fname = m_mame_file->filename();
		int loc = fname.find_last_of('.');
		if (loc!=-1) {
			extension = fname.substr(loc + 1,fname.length()-loc).c_str();
		} else {
			extension = "";
		}
	}
`

The implication of this hack is that filetype() shouldn't be trusted for cassettes loaded by softlists.  The fact that this relied on the return value of c_str() invoked on an rvalue implies that this worked by accident, but that is a separate issue.

This hack was (IMHO correctly) completely unwound in my softlist changes.  The fix to make sure that filetype() works is in my opinion, the correct way to go.

It seems much safer to make it so that filetype() returns the right thing for items loaded from software lists.