### PR TITLE
Change warning flags for Clang build (nw)

### DIFF
--- a/scripts/genie.lua
+++ b/scripts/genie.lua
@@ -958,23 +958,15 @@ end
 			buildoptions {
 				"-Wno-cast-align",
 				"-Wno-tautological-compare",
-				"-Wno-dynamic-class-memaccess",
 				"-Wno-unused-value",
-				"-Wno-inline-new-delete",
 				"-Wno-constant-logical-operand",
-				"-Wno-deprecated-register",
+				"-Wno-missing-braces", -- clang is not as permissive as GCC about std::array initialization
 				"-fdiagnostics-show-note-include-stack",
 			}
 			if (version >= 30500) then
 				buildoptions {
-					"-Wno-absolute-value",
 					"-Wno-unknown-warning-option",
 					"-Wno-extern-c-compat",
-				}
-			end
-			if (version >= 70000) then
-				buildoptions {
-					"-Wno-tautological-undefined-compare",
 				}
 			end
 		else

--- a/src/emu/render.cpp
+++ b/src/emu/render.cpp
@@ -1756,8 +1756,8 @@ void render_target::add_container_primitives(render_primitive_list &list, const 
 	cliprect.y1 = xform.yoffs + xform.yscale;
 	sect_render_bounds(&cliprect, &m_bounds);
 
-	float root_xoffs = root_xform.xoffs + abs(root_xform.xscale - xform.xscale) * 0.5f;
-	float root_yoffs = root_xform.yoffs + abs(root_xform.yscale - xform.yscale) * 0.5f;
+	float root_xoffs = root_xform.xoffs + fabsf(root_xform.xscale - xform.xscale) * 0.5f;
+	float root_yoffs = root_xform.yoffs + fabsf(root_xform.yscale - xform.yscale) * 0.5f;
 
 	render_bounds root_cliprect;
 	root_cliprect.x0 = root_xoffs;


### PR DESCRIPTION
-Wno-missing-braces is unfortunately now necessary to avoid errors on almost every single use of the std::array initializer in devfind.h. (Apparently C++14 does make double braces optional for std::array initializers, but clang and GCC's -Wmissing-braces never took that into proper account, which is why GCC may still have it disabled by default.)

Several other Clang-specific warnings have been undisabled; some might perhaps need to be locally reenabled if legacy 3rdparty code or sundry OSD includes happen to disagree with them. The only warning to require any code changes was -Wabsolute-value, which seems to have caught a minor render bug (and nothing more).