### PR TITLE
Changing finder_base::DUMMY_TAG from constexpr ==> const

### DIFF
--- a/src/emu/devfind.cpp
+++ b/src/emu/devfind.cpp
@@ -36,7 +36,7 @@ template class ioport_finder<true>;
 //  BASE FINDER CLASS
 //**************************************************************************
 
-constexpr char finder_base::DUMMY_TAG[];
+const char finder_base::DUMMY_TAG[] = "finder_dummy_tag";
 
 
 //-------------------------------------------------

--- a/src/emu/devfind.h
+++ b/src/emu/devfind.h
@@ -154,7 +154,7 @@ public:
 	void set_tag(const char *tag) { m_tag = tag; }
 
 	/// \brief Dummy tag always treated as not found
-	constexpr static char DUMMY_TAG[] = "finder_dummy_tag";
+	static const char DUMMY_TAG[];
 
 protected:
 	/// \brief Designated constructor


### PR DESCRIPTION
MSVC2015 (for whaver reason) doesn't like the constexpr declaration