### PR TITLE
Refactored device_disasm_interface::disassemble() and dasm_override_delegate to take string buffers as std::string

### DIFF
--- a/src/devices/cpu/8x300/8x300.cpp
+++ b/src/devices/cpu/8x300/8x300.cpp
@@ -581,8 +581,8 @@ void n8x300_cpu_device::execute_run()
 	} while (m_icount > 0);
 }
 
-offs_t n8x300_cpu_device::disasm_disassemble(char *buffer, offs_t pc, const uint8_t *oprom, const uint8_t *opram, uint32_t options)
+offs_t n8x300_cpu_device::disasm_disassemble(std::ostream &stream, offs_t pc, const uint8_t *oprom, const uint8_t *opram, uint32_t options)
 {
 	extern CPU_DISASSEMBLE( n8x300 );
-	return CPU_DISASSEMBLE_NAME(n8x300)(this, buffer, pc, oprom, opram, options);
+	return CPU_DISASSEMBLE_NAME(n8x300)(this, stream, pc, oprom, opram, options);
 }

--- a/src/devices/cpu/8x300/8x300.h
+++ b/src/devices/cpu/8x300/8x300.h
@@ -73,7 +73,7 @@ protected:
 	// device_disasm_interface overrides
 	virtual uint32_t disasm_min_opcode_bytes() const override { return 2; }
 	virtual uint32_t disasm_max_opcode_bytes() const override { return 2; }
-	virtual offs_t disasm_disassemble(char *buffer, offs_t pc, const uint8_t *oprom, const uint8_t *opram, uint32_t options) override;
+	virtual offs_t disasm_disassemble(std::ostream &stream, offs_t pc, const u8 *oprom, const u8 *opram, u32 options) override;
 
 	address_space_config m_program_config;
 	address_space_config m_io_config;

--- a/src/devices/cpu/8x300/8x300dasm.cpp
+++ b/src/devices/cpu/8x300/8x300dasm.cpp
@@ -41,7 +41,7 @@ static inline bool is_src_rot(uint16_t opcode)
 		return true;
 }
 
-static offs_t internal_disasm_n8x300(cpu_device *device, std::ostream &stream, offs_t pc, const uint8_t *oprom, const uint8_t *opram, int options)
+CPU_DISASSEMBLE(n8x300)
 {
 	unsigned startpc = pc;
 	uint16_t opcode = (oprom[pc - startpc] << 8) | oprom[pc+1 - startpc];
@@ -128,14 +128,4 @@ static offs_t internal_disasm_n8x300(cpu_device *device, std::ostream &stream, o
 
 
 	return (pc - startpc);
-}
-
-
-CPU_DISASSEMBLE(n8x300)
-{
-	std::ostringstream stream;
-	offs_t result = internal_disasm_n8x300(device, stream, pc, oprom, opram, options);
-	std::string stream_str = stream.str();
-	strcpy(buffer, stream_str.c_str());
-	return result;
 }

--- a/src/devices/cpu/adsp2100/2100dasm.cpp
+++ b/src/devices/cpu/adsp2100/2100dasm.cpp
@@ -233,7 +233,7 @@ static void aluconst(std::ostream &stream, int dest, int op)
 
 
 /* execute instructions on this CPU until icount expires */
-static offs_t internal_disasm_adsp21xx(cpu_device *device, std::ostream &stream, offs_t pc, const uint8_t *oprom, const uint8_t *opram, int options)
+CPU_DISASSEMBLE(adsp21xx)
 {
 	unsigned int op = oprom[0] | (oprom[1] << 8) | (oprom[2] << 16);
 	unsigned dasmflags = 0;
@@ -551,14 +551,3 @@ static offs_t internal_disasm_adsp21xx(cpu_device *device, std::ostream &stream,
 
 	return 1 | dasmflags | DASMFLAG_SUPPORTED;
 }
-
-
-CPU_DISASSEMBLE(adsp21xx)
-{
-	std::ostringstream stream;
-	offs_t result = internal_disasm_adsp21xx(device, stream, pc, oprom, opram, options);
-	std::string stream_str = stream.str();
-	strcpy(buffer, stream_str.c_str());
-	return result;
-}
-

--- a/src/devices/cpu/adsp2100/adsp2100.cpp
+++ b/src/devices/cpu/adsp2100/adsp2100.cpp
@@ -774,10 +774,10 @@ uint32_t adsp21xx_device::disasm_max_opcode_bytes() const
 //  helper function
 //-------------------------------------------------
 
-offs_t adsp21xx_device::disasm_disassemble(char *buffer, offs_t pc, const uint8_t *oprom, const uint8_t *opram, uint32_t options)
+offs_t adsp21xx_device::disasm_disassemble(std::ostream &stream, offs_t pc, const uint8_t *oprom, const uint8_t *opram, uint32_t options)
 {
 	extern CPU_DISASSEMBLE( adsp21xx );
-	return CPU_DISASSEMBLE_NAME(adsp21xx)(this, buffer, pc, oprom, opram, options);
+	return CPU_DISASSEMBLE_NAME(adsp21xx)(this, stream, pc, oprom, opram, options);
 }
 
 

--- a/src/devices/cpu/adsp2100/adsp2100.h
+++ b/src/devices/cpu/adsp2100/adsp2100.h
@@ -243,7 +243,7 @@ protected:
 	// device_disasm_interface overrides
 	virtual uint32_t disasm_min_opcode_bytes() const override;
 	virtual uint32_t disasm_max_opcode_bytes() const override;
-	virtual offs_t disasm_disassemble(char *buffer, offs_t pc, const uint8_t *oprom, const uint8_t *opram, uint32_t options) override;
+	virtual offs_t disasm_disassemble(std::ostream &stream, offs_t pc, const uint8_t *oprom, const uint8_t *opram, uint32_t options) override;
 
 	// helpers
 	void create_tables();

--- a/src/devices/cpu/alph8201/8201dasm.cpp
+++ b/src/devices/cpu/alph8201/8201dasm.cpp
@@ -349,7 +349,7 @@ static void InitDasm8201(void)
 	OpInizialized = 1;
 }
 
-static offs_t internal_disasm_alpha8201(cpu_device *device, std::ostream &stream, offs_t pc, const uint8_t *oprom, const uint8_t *opram, int options)
+CPU_DISASSEMBLE(alpha8201)
 {
 	offs_t dasmflags = 0;
 	int i;
@@ -412,13 +412,4 @@ static offs_t internal_disasm_alpha8201(cpu_device *device, std::ostream &stream
 	}
 
 	return cnt | dasmflags | DASMFLAG_SUPPORTED;
-}
-
-CPU_DISASSEMBLE(alpha8201)
-{
-	std::ostringstream stream;
-	offs_t result = internal_disasm_alpha8201(device, stream, pc, oprom, opram, options);
-	std::string stream_str = stream.str();
-	strcpy(buffer, stream_str.c_str());
-	return result;
 }

--- a/src/devices/cpu/alph8201/alph8201.cpp
+++ b/src/devices/cpu/alph8201/alph8201.cpp
@@ -688,8 +688,8 @@ void alpha8201_cpu_device::execute_set_input(int inputnum, int state)
 }
 
 
-offs_t alpha8201_cpu_device::disasm_disassemble(char *buffer, offs_t pc, const uint8_t *oprom, const uint8_t *opram, uint32_t options)
+offs_t alpha8201_cpu_device::disasm_disassemble(std::ostream &stream, offs_t pc, const uint8_t *oprom, const uint8_t *opram, uint32_t options)
 {
 	extern CPU_DISASSEMBLE( alpha8201 );
-	return CPU_DISASSEMBLE_NAME(alpha8201)(this, buffer, pc, oprom, opram, options);
+	return CPU_DISASSEMBLE_NAME(alpha8201)(this, stream, pc, oprom, opram, options);
 }

--- a/src/devices/cpu/alph8201/alph8201.h
+++ b/src/devices/cpu/alph8201/alph8201.h
@@ -76,7 +76,7 @@ protected:
 	// device_disasm_interface overrides
 	virtual uint32_t disasm_min_opcode_bytes() const override { return 1; }
 	virtual uint32_t disasm_max_opcode_bytes() const override { return 4; }
-	virtual offs_t disasm_disassemble(char *buffer, offs_t pc, const uint8_t *oprom, const uint8_t *opram, uint32_t options) override;
+	virtual offs_t disasm_disassemble(std::ostream &stream, offs_t pc, const uint8_t *oprom, const uint8_t *opram, uint32_t options) override;
 
 	uint8_t M_RDMEM(uint16_t A) { return m_program->read_byte(A); }
 	void M_WRMEM(uint16_t A,uint8_t V) { m_program->write_byte(A, V); }

--- a/src/devices/cpu/alto2/alto2cpu.h
+++ b/src/devices/cpu/alto2/alto2cpu.h
@@ -238,7 +238,7 @@ protected:
 	//! device_disasm_interface overrides
 	virtual uint32_t disasm_min_opcode_bytes() const override { return 4; }
 	virtual uint32_t disasm_max_opcode_bytes() const override { return 4; }
-	virtual offs_t disasm_disassemble(char *buffer, offs_t pc, const uint8_t *oprom, const uint8_t *opram, uint32_t options) override;
+	virtual offs_t disasm_disassemble(std::ostream &stream, offs_t pc, const uint8_t *oprom, const uint8_t *opram, uint32_t options) override;
 
 private:
 
@@ -912,8 +912,6 @@ private:
 	void wrtram();                                  //!< write the microcode RAM from M register and ALU
 
 	uint8_t m_ether_id;                               //!< configured Ethernet ID for this machine
-
-	offs_t disasm_disassemble(std::ostream &stream, offs_t pc, const uint8_t *oprom, const uint8_t *opram, uint32_t options);
 
 //*******************************************
 // inline the sub-devices

--- a/src/devices/cpu/alto2/alto2dsm.cpp
+++ b/src/devices/cpu/alto2/alto2dsm.cpp
@@ -394,13 +394,3 @@ offs_t alto2_cpu_device::disasm_disassemble(std::ostream &main_stream, offs_t pc
 
 	return result;
 }
-
-
-offs_t alto2_cpu_device::disasm_disassemble(char *buffer, offs_t pc, const uint8_t *oprom, const uint8_t *opram, uint32_t options)
-{
-	std::ostringstream stream;
-	offs_t result = disasm_disassemble(stream, pc, oprom, opram, options);
-	std::string stream_str = stream.str();
-	strcpy(buffer, stream_str.c_str());
-	return result;
-}

--- a/src/devices/cpu/am29000/am29000.cpp
+++ b/src/devices/cpu/am29000/am29000.cpp
@@ -695,8 +695,8 @@ void am29000_cpu_device::execute_set_input(int inputnum, int state)
 }
 
 
-offs_t am29000_cpu_device::disasm_disassemble(char *buffer, offs_t pc, const uint8_t *oprom, const uint8_t *opram, uint32_t options)
+offs_t am29000_cpu_device::disasm_disassemble(std::ostream &stream, offs_t pc, const uint8_t *oprom, const uint8_t *opram, uint32_t options)
 {
 	extern CPU_DISASSEMBLE( am29000 );
-	return CPU_DISASSEMBLE_NAME(am29000)(this, buffer, pc, oprom, opram, options);
+	return CPU_DISASSEMBLE_NAME(am29000)(this, stream, pc, oprom, opram, options);
 }

--- a/src/devices/cpu/am29000/am29000.h
+++ b/src/devices/cpu/am29000/am29000.h
@@ -468,7 +468,7 @@ protected:
 	// device_disasm_interface overrides
 	virtual uint32_t disasm_min_opcode_bytes() const override { return 4; }
 	virtual uint32_t disasm_max_opcode_bytes() const override { return 4; }
-	virtual offs_t disasm_disassemble(char *buffer, offs_t pc, const uint8_t *oprom, const uint8_t *opram, uint32_t options) override;
+	virtual offs_t disasm_disassemble(std::ostream &stream, offs_t pc, const uint8_t *oprom, const uint8_t *opram, uint32_t options) override;
 
 	void signal_exception(uint32_t type);
 	void external_irq_check();

--- a/src/devices/cpu/am29000/am29dasm.cpp
+++ b/src/devices/cpu/am29000/am29dasm.cpp
@@ -117,7 +117,7 @@ static const char* get_spr(int spid)
 	}
 }
 
-static offs_t internal_disasm_am29000(cpu_device *device, std::ostream &stream, offs_t pc, const uint8_t *oprom, const uint8_t *opram, int options)
+CPU_DISASSEMBLE(am29000)
 {
 	uint32_t op = (oprom[0] << 24) | (oprom[1] << 16) | (oprom[2] << 8) | oprom[3];
 	uint32_t flags = 0;
@@ -229,13 +229,4 @@ static offs_t internal_disasm_am29000(cpu_device *device, std::ostream &stream, 
 	}
 
 	return 4 | flags | DASMFLAG_SUPPORTED;
-}
-
-CPU_DISASSEMBLE(am29000)
-{
-	std::ostringstream stream;
-	offs_t result = internal_disasm_am29000(device, stream, pc, oprom, opram, options);
-	std::string stream_str = stream.str();
-	strcpy(buffer, stream_str.c_str());
-	return result;
 }

--- a/src/devices/cpu/amis2000/amis2000.cpp
+++ b/src/devices/cpu/amis2000/amis2000.cpp
@@ -89,10 +89,10 @@ void amis2000_base_device::state_string_export(const device_state_entry &entry, 
 	}
 }
 
-offs_t amis2000_base_device::disasm_disassemble(char *buffer, offs_t pc, const uint8_t *oprom, const uint8_t *opram, uint32_t options)
+offs_t amis2000_base_device::disasm_disassemble(std::ostream &stream, offs_t pc, const uint8_t *oprom, const uint8_t *opram, uint32_t options)
 {
 	extern CPU_DISASSEMBLE(amis2000);
-	return CPU_DISASSEMBLE_NAME(amis2000)(this, buffer, pc, oprom, opram, options);
+	return CPU_DISASSEMBLE_NAME(amis2000)(this, stream, pc, oprom, opram, options);
 }
 
 

--- a/src/devices/cpu/amis2000/amis2000.h
+++ b/src/devices/cpu/amis2000/amis2000.h
@@ -88,7 +88,7 @@ protected:
 	// device_disasm_interface overrides
 	virtual uint32_t disasm_min_opcode_bytes() const override { return 1; }
 	virtual uint32_t disasm_max_opcode_bytes() const override { return 1; }
-	virtual offs_t disasm_disassemble(char *buffer, offs_t pc, const uint8_t *oprom, const uint8_t *opram, uint32_t options) override;
+	virtual offs_t disasm_disassemble(std::ostream &stream, offs_t pc, const uint8_t *oprom, const uint8_t *opram, uint32_t options) override;
 
 	// device_state_interface overrides
 	virtual void state_string_export(const device_state_entry &entry, std::string &str) const override;

--- a/src/devices/cpu/amis2000/amis2000d.cpp
+++ b/src/devices/cpu/amis2000/amis2000d.cpp
@@ -100,7 +100,7 @@ static const uint8_t s2000_mnemonic[0x100] =
 
 
 
-static offs_t internal_disasm_amis2000(cpu_device *device, std::ostream &stream, offs_t pc, const uint8_t *oprom, const uint8_t *opram, int options)
+CPU_DISASSEMBLE(amis2000)
 {
 	int pos = 0;
 	uint8_t op = oprom[pos++];
@@ -129,14 +129,4 @@ static offs_t internal_disasm_amis2000(cpu_device *device, std::ostream &stream,
 	}
 
 	return pos | s_flags[instr] | DASMFLAG_SUPPORTED;
-}
-
-
-CPU_DISASSEMBLE(amis2000)
-{
-	std::ostringstream stream;
-	offs_t result = internal_disasm_amis2000(device, stream, pc, oprom, opram, options);
-	std::string stream_str = stream.str();
-	strcpy(buffer, stream_str.c_str());
-	return result;
 }

--- a/src/devices/cpu/apexc/apexc.cpp
+++ b/src/devices/cpu/apexc/apexc.cpp
@@ -848,8 +848,8 @@ void apexc_cpu_device::execute_run()
 }
 
 
-offs_t apexc_cpu_device::disasm_disassemble(char *buffer, offs_t pc, const uint8_t *oprom, const uint8_t *opram, uint32_t options)
+offs_t apexc_cpu_device::disasm_disassemble(std::ostream &stream, offs_t pc, const uint8_t *oprom, const uint8_t *opram, uint32_t options)
 {
 	extern CPU_DISASSEMBLE( apexc );
-	return CPU_DISASSEMBLE_NAME(apexc)(this, buffer, pc, oprom, opram, options);
+	return CPU_DISASSEMBLE_NAME(apexc)(this, stream, pc, oprom, opram, options);
 }

--- a/src/devices/cpu/apexc/apexc.h
+++ b/src/devices/cpu/apexc/apexc.h
@@ -42,7 +42,7 @@ protected:
 	// device_disasm_interface overrides
 	virtual uint32_t disasm_min_opcode_bytes() const override { return 4; }
 	virtual uint32_t disasm_max_opcode_bytes() const override { return 4; }
-	virtual offs_t disasm_disassemble(char *buffer, offs_t pc, const uint8_t *oprom, const uint8_t *opram, uint32_t options) override;
+	virtual offs_t disasm_disassemble(std::ostream &stream, offs_t pc, const uint8_t *oprom, const uint8_t *opram, uint32_t options) override;
 
 	inline uint32_t apexc_readmem(uint32_t address) { return m_program->read_dword((address)<<2); }
 	inline void apexc_writemem(uint32_t address, uint32_t data) { m_program->write_dword((address)<<2, (data)); }

--- a/src/devices/cpu/apexc/apexcdsm.cpp
+++ b/src/devices/cpu/apexc/apexcdsm.cpp
@@ -83,7 +83,7 @@ static const instr_desc instructions[16] =
 	{ "A",      store },        { "S",      swap }
 };
 
-static offs_t internal_disasm_apexc(cpu_device *device, std::ostream &stream, offs_t pc, const uint8_t *oprom, const uint8_t *opram, int options)
+CPU_DISASSEMBLE(apexc)
 {
 	uint32_t instruction;         /* 32-bit machine instruction */
 	int x, y, function, c6, vector; /* instruction fields */
@@ -179,16 +179,5 @@ static offs_t internal_disasm_apexc(cpu_device *device, std::ostream &stream, of
 
 	/* print Y address */
 	util::stream_format(stream, "%03X(%02d/%02d)", y<<2, (y >> 5) & 0x1f, y & 0x1f);  /* 7 chars */
-
 	return 4;
-}
-
-
-CPU_DISASSEMBLE(apexc)
-{
-	std::ostringstream stream;
-	offs_t result = internal_disasm_apexc(device, stream, pc, oprom, opram, options);
-	std::string stream_str = stream.str();
-	strcpy(buffer, stream_str.c_str());
-	return result;
 }

--- a/src/devices/cpu/arc/arc.cpp
+++ b/src/devices/cpu/arc/arc.cpp
@@ -25,10 +25,10 @@ arc_device::arc_device(const machine_config &mconfig, const char *tag, device_t 
 }
 
 
-offs_t arc_device::disasm_disassemble(char *buffer, offs_t pc, const uint8_t *oprom, const uint8_t *opram, uint32_t options)
+offs_t arc_device::disasm_disassemble(std::ostream &stream, offs_t pc, const uint8_t *oprom, const uint8_t *opram, uint32_t options)
 {
 	extern CPU_DISASSEMBLE( arc );
-	return CPU_DISASSEMBLE_NAME(arc)(this, buffer, pc, oprom, opram, options);
+	return CPU_DISASSEMBLE_NAME(arc)(this, stream, pc, oprom, opram, options);
 }
 
 

--- a/src/devices/cpu/arc/arc.h
+++ b/src/devices/cpu/arc/arc.h
@@ -45,7 +45,7 @@ protected:
 	// device_disasm_interface overrides
 	virtual uint32_t disasm_min_opcode_bytes() const override { return 4; }
 	virtual uint32_t disasm_max_opcode_bytes() const override { return 4; }
-	virtual offs_t disasm_disassemble(char *buffer, offs_t pc, const uint8_t *oprom, const uint8_t *opram, uint32_t options) override;
+	virtual offs_t disasm_disassemble(std::ostream &stream, offs_t pc, const uint8_t *oprom, const uint8_t *opram, uint32_t options) override;
 
 private:
 	address_space_config m_program_config;

--- a/src/devices/cpu/arc/arcdasm.cpp
+++ b/src/devices/cpu/arc/arcdasm.cpp
@@ -180,7 +180,7 @@ static const char *regnames[0x40] =
 #define ARC_REGOP_SHIMM     ((op & 0x000001ff) >> 0  ) // aka D
 
 
-static offs_t internal_disasm_arc(cpu_device *device, std::ostream &stream, offs_t pc, const uint8_t *oprom, const uint8_t *opram, int options)
+CPU_DISASSEMBLE(arc) 
 {
 	uint32_t op = oprom[0] | (oprom[1] << 8) | (oprom[2] << 16) | (oprom[3] << 24);
 	op = big_endianize_int32(op);
@@ -207,14 +207,3 @@ static offs_t internal_disasm_arc(cpu_device *device, std::ostream &stream, offs
 
 	return 4 | DASMFLAG_SUPPORTED;
 }
-
-
-CPU_DISASSEMBLE(arc)
-{
-	std::ostringstream stream;
-	offs_t result = internal_disasm_arc(device, stream, pc, oprom, opram, options);
-	std::string stream_str = stream.str();
-	strcpy(buffer, stream_str.c_str());
-	return result;
-}
-

--- a/src/devices/cpu/arcompact/arcompact.cpp
+++ b/src/devices/cpu/arcompact/arcompact.cpp
@@ -58,10 +58,10 @@ arcompact_device::arcompact_device(const machine_config &mconfig, const char *ta
 }
 
 
-offs_t arcompact_device::disasm_disassemble(char *buffer, offs_t pc, const uint8_t *oprom, const uint8_t *opram, uint32_t options)
+offs_t arcompact_device::disasm_disassemble(std::ostream &stream, offs_t pc, const uint8_t *oprom, const uint8_t *opram, uint32_t options)
 {
 	extern CPU_DISASSEMBLE( arcompact );
-	return CPU_DISASSEMBLE_NAME(arcompact)(this, buffer, pc, oprom, opram, options);
+	return CPU_DISASSEMBLE_NAME(arcompact)(this, stream, pc, oprom, opram, options);
 }
 
 

--- a/src/devices/cpu/arcompact/arcompact.h
+++ b/src/devices/cpu/arcompact/arcompact.h
@@ -104,7 +104,7 @@ protected:
 	// device_disasm_interface overrides
 	virtual uint32_t disasm_min_opcode_bytes() const override { return 2; }
 	virtual uint32_t disasm_max_opcode_bytes() const override { return 8; }
-	virtual offs_t disasm_disassemble(char *buffer, offs_t pc, const uint8_t *oprom, const uint8_t *opram, uint32_t options) override;
+	virtual offs_t disasm_disassemble(std::ostream &stream, offs_t pc, const uint8_t *oprom, const uint8_t *opram, uint32_t options) override;
 
 
 

--- a/src/devices/cpu/arcompact/arcompactdasm.cpp
+++ b/src/devices/cpu/arcompact/arcompactdasm.cpp
@@ -22,7 +22,7 @@
 
 #define ARCOMPACT_OPERATION ((op & 0xf800) >> 11)
 
-static offs_t internal_disasm_arcompact(cpu_device *device, std::ostream &stream, offs_t pc, const uint8_t *oprom, const uint8_t *opram, int options)
+CPU_DISASSEMBLE(arcompact)
 {
 	int size;
 
@@ -86,14 +86,4 @@ static offs_t internal_disasm_arcompact(cpu_device *device, std::ostream &stream
 	}
 
 	return size | DASMFLAG_SUPPORTED;
-}
-
-
-CPU_DISASSEMBLE(arcompact)
-{
-	std::ostringstream stream;
-	offs_t result = internal_disasm_arcompact(device, stream, pc, oprom, opram, options);
-	std::string stream_str = stream.str();
-	strcpy(buffer, stream_str.c_str());
-	return result;
 }

--- a/src/devices/cpu/arm/arm.cpp
+++ b/src/devices/cpu/arm/arm.cpp
@@ -1553,15 +1553,15 @@ void arm_cpu_device::HandleCoPro( uint32_t insn )
 }
 
 
-offs_t arm_cpu_device::disasm_disassemble(char *buffer, offs_t pc, const uint8_t *oprom, const uint8_t *opram, uint32_t options)
+offs_t arm_cpu_device::disasm_disassemble(std::ostream &stream, offs_t pc, const uint8_t *oprom, const uint8_t *opram, uint32_t options)
 {
 	extern CPU_DISASSEMBLE( arm );
-	return CPU_DISASSEMBLE_NAME(arm)(this, buffer, pc, oprom, opram, options);
+	return CPU_DISASSEMBLE_NAME(arm)(this, stream, pc, oprom, opram, options);
 }
 
 
-offs_t arm_be_cpu_device::disasm_disassemble(char *buffer, offs_t pc, const uint8_t *oprom, const uint8_t *opram, uint32_t options)
+offs_t arm_be_cpu_device::disasm_disassemble(std::ostream &stream, offs_t pc, const uint8_t *oprom, const uint8_t *opram, uint32_t options)
 {
 	extern CPU_DISASSEMBLE( arm_be );
-	return CPU_DISASSEMBLE_NAME(arm_be)(this, buffer, pc, oprom, opram, options);
+	return CPU_DISASSEMBLE_NAME(arm_be)(this, stream, pc, oprom, opram, options);
 }

--- a/src/devices/cpu/arm/arm.h
+++ b/src/devices/cpu/arm/arm.h
@@ -66,7 +66,7 @@ protected:
 	// device_disasm_interface overrides
 	virtual uint32_t disasm_min_opcode_bytes() const override { return 4; }
 	virtual uint32_t disasm_max_opcode_bytes() const override { return 4; }
-	virtual offs_t disasm_disassemble(char *buffer, offs_t pc, const uint8_t *oprom, const uint8_t *opram, uint32_t options) override;
+	virtual offs_t disasm_disassemble(std::ostream &stream, offs_t pc, const uint8_t *oprom, const uint8_t *opram, uint32_t options) override;
 
 	address_space_config m_program_config;
 
@@ -113,7 +113,7 @@ public:
 	arm_be_cpu_device(const machine_config &mconfig, const char *tag, device_t *owner, uint32_t clock);
 
 protected:
-	virtual offs_t disasm_disassemble(char *buffer, offs_t pc, const uint8_t *oprom, const uint8_t *opram, uint32_t options) override;
+	virtual offs_t disasm_disassemble(std::ostream &stream, offs_t pc, const uint8_t *oprom, const uint8_t *opram, uint32_t options) override;
 };
 
 

--- a/src/devices/cpu/arm/armdasm.cpp
+++ b/src/devices/cpu/arm/armdasm.cpp
@@ -390,23 +390,14 @@ static uint32_t arm_disasm( std::ostream &stream, uint32_t pc, uint32_t opcode )
 	return dasmflags | DASMFLAG_SUPPORTED;
 }
 
-static uint32_t arm_disasm(char *buffer, uint32_t pc, uint32_t opcode)
-{
-	std::ostringstream stream;
-	uint32_t result = arm_disasm(stream, pc, opcode);
-	std::string stream_str = stream.str();
-	strcpy(buffer, stream_str.c_str());
-	return result;
-}
-
 CPU_DISASSEMBLE( arm )
 {
 	uint32_t opcode = oprom[0] | (oprom[1] << 8) | (oprom[2] << 16) | (oprom[3] << 24);
-	return 4 | arm_disasm(buffer, pc, opcode);
+	return 4 | arm_disasm(stream, pc, opcode);
 }
 
 CPU_DISASSEMBLE( arm_be )
 {
 	uint32_t opcode = oprom[3] | (oprom[2] << 8) | (oprom[1] << 16) | (oprom[0] << 24);
-	return 4 | arm_disasm(buffer, pc, opcode);
+	return 4 | arm_disasm(stream, pc, opcode);
 }

--- a/src/devices/cpu/arm7/arm7.cpp
+++ b/src/devices/cpu/arm7/arm7.cpp
@@ -764,7 +764,7 @@ void arm7_cpu_device::execute_set_input(int irqline, int state)
 }
 
 
-offs_t arm7_cpu_device::disasm_disassemble(char *buffer, offs_t pc, const uint8_t *oprom, const uint8_t *opram, uint32_t options)
+offs_t arm7_cpu_device::disasm_disassemble(std::ostream &stream, offs_t pc, const uint8_t *oprom, const uint8_t *opram, uint32_t options)
 {
 	extern CPU_DISASSEMBLE( arm7arm );
 	extern CPU_DISASSEMBLE( arm7thumb );
@@ -774,16 +774,16 @@ offs_t arm7_cpu_device::disasm_disassemble(char *buffer, offs_t pc, const uint8_
 	if (T_IS_SET(m_r[eCPSR]))
 	{
 		if ( m_endian == ENDIANNESS_BIG )
-			return CPU_DISASSEMBLE_NAME(arm7thumb_be)(this, buffer, pc, oprom, opram, options);
+			return CPU_DISASSEMBLE_NAME(arm7thumb_be)(this, stream, pc, oprom, opram, options);
 		else
-			return CPU_DISASSEMBLE_NAME(arm7thumb)(this, buffer, pc, oprom, opram, options);
+			return CPU_DISASSEMBLE_NAME(arm7thumb)(this, stream, pc, oprom, opram, options);
 	}
 	else
 	{
 		if ( m_endian == ENDIANNESS_BIG )
-			return CPU_DISASSEMBLE_NAME(arm7arm_be)(this, buffer, pc, oprom, opram, options);
+			return CPU_DISASSEMBLE_NAME(arm7arm_be)(this, stream, pc, oprom, opram, options);
 		else
-			return CPU_DISASSEMBLE_NAME(arm7arm)(this, buffer, pc, oprom, opram, options);
+			return CPU_DISASSEMBLE_NAME(arm7arm)(this, stream, pc, oprom, opram, options);
 	}
 }
 

--- a/src/devices/cpu/arm7/arm7.h
+++ b/src/devices/cpu/arm7/arm7.h
@@ -76,7 +76,7 @@ protected:
 	// device_disasm_interface overrides
 	virtual uint32_t disasm_min_opcode_bytes() const override { return 2; }
 	virtual uint32_t disasm_max_opcode_bytes() const override { return 4; }
-	virtual offs_t disasm_disassemble(char *buffer, offs_t pc, const uint8_t *oprom, const uint8_t *opram, uint32_t options) override;
+	virtual offs_t disasm_disassemble(std::ostream &stream, offs_t pc, const uint8_t *oprom, const uint8_t *opram, uint32_t options) override;
 
 	address_space_config m_program_config;
 

--- a/src/devices/cpu/arm7/arm7dasm.cpp
+++ b/src/devices/cpu/arm7/arm7dasm.cpp
@@ -1300,40 +1300,22 @@ static uint32_t thumb_disasm(std::ostream &stream, uint32_t pc, uint16_t opcode)
 	return dasmflags | DASMFLAG_SUPPORTED;
 }
 
-static uint32_t arm7_disasm(char *buffer, uint32_t pc, uint32_t opcode)
-{
-	std::ostringstream stream;
-	uint32_t result = arm7_disasm(stream, pc, opcode);
-	std::string stream_str = stream.str();
-	strcpy(buffer, stream_str.c_str());
-	return result;
-}
-
-static uint32_t thumb_disasm(char *buffer, uint32_t pc, uint16_t opcode)
-{
-	std::ostringstream stream;
-	uint32_t result = thumb_disasm(stream, pc, opcode);
-	std::string stream_str = stream.str();
-	strcpy(buffer, stream_str.c_str());
-	return result;
-}
-
 CPU_DISASSEMBLE( arm7arm )
 {
-	return arm7_disasm(buffer, pc, oprom[0] | (oprom[1] << 8) | (oprom[2] << 16) | (oprom[3] << 24)) | 4;
+	return arm7_disasm(stream, pc, oprom[0] | (oprom[1] << 8) | (oprom[2] << 16) | (oprom[3] << 24)) | 4;
 }
 
 CPU_DISASSEMBLE( arm7arm_be )
 {
-	return arm7_disasm(buffer, pc, oprom[3] | (oprom[2] << 8) | (oprom[1] << 16) | (oprom[0] << 24)) | 4;
+	return arm7_disasm(stream, pc, oprom[3] | (oprom[2] << 8) | (oprom[1] << 16) | (oprom[0] << 24)) | 4;
 }
 
 CPU_DISASSEMBLE( arm7thumb )
 {
-	return thumb_disasm(buffer, pc, oprom[0] | (oprom[1] << 8)) | 2;
+	return thumb_disasm(stream, pc, oprom[0] | (oprom[1] << 8)) | 2;
 }
 
 CPU_DISASSEMBLE( arm7thumb_be )
 {
-	return thumb_disasm(buffer, pc, oprom[1] | (oprom[0] << 8)) | 2;
+	return thumb_disasm(stream, pc, oprom[1] | (oprom[0] << 8)) | 2;
 }

--- a/src/devices/cpu/asap/asap.cpp
+++ b/src/devices/cpu/asap/asap.cpp
@@ -324,10 +324,10 @@ uint32_t asap_device::disasm_max_opcode_bytes() const
 //  helper function
 //-------------------------------------------------
 
-offs_t asap_device::disasm_disassemble(char *buffer, offs_t pc, const uint8_t *oprom, const uint8_t *opram, uint32_t options)
+offs_t asap_device::disasm_disassemble(std::ostream &stream, offs_t pc, const uint8_t *oprom, const uint8_t *opram, uint32_t options)
 {
 	extern CPU_DISASSEMBLE( asap );
-	return CPU_DISASSEMBLE_NAME(asap)(this, buffer, pc, oprom, opram, options);
+	return CPU_DISASSEMBLE_NAME(asap)(this, stream, pc, oprom, opram, options);
 }
 
 

--- a/src/devices/cpu/asap/asap.h
+++ b/src/devices/cpu/asap/asap.h
@@ -53,7 +53,7 @@ protected:
 	// device_disasm_interface overrides
 	virtual uint32_t disasm_min_opcode_bytes() const override;
 	virtual uint32_t disasm_max_opcode_bytes() const override;
-	virtual offs_t disasm_disassemble(char *buffer, offs_t pc, const uint8_t *oprom, const uint8_t *opram, uint32_t options) override;
+	virtual offs_t disasm_disassemble(std::ostream &stream, offs_t pc, const uint8_t *oprom, const uint8_t *opram, uint32_t options) override;
 
 	// helpers
 	inline uint32_t readop(offs_t pc);

--- a/src/devices/cpu/asap/asapdasm.cpp
+++ b/src/devices/cpu/asap/asapdasm.cpp
@@ -45,7 +45,7 @@ static inline char *src2(uint32_t op, int scale)
 	return temp;
 }
 
-static offs_t internal_disasm_asap(cpu_device *device, std::ostream &stream, offs_t pc, const uint8_t *oprom, const uint8_t *opram, int options)
+CPU_DISASSEMBLE(asap)
 {
 	uint32_t op = oprom[0] | (oprom[1] << 8) | (oprom[2] << 16) | (oprom[3] << 24);
 	int opcode = op >> 27;
@@ -141,16 +141,6 @@ static offs_t internal_disasm_asap(cpu_device *device, std::ostream &stream, off
 						util::stream_format(stream, "jmp%s  %s[%s]", setcond[cond], reg[rsrc1], src2(op,2));
 			break;
 		case 0x1f:  util::stream_format(stream, "trap   $1f"); flags = DASMFLAG_STEP_OVER;                              break;
-	}
+	}	
 	return 4 | flags | DASMFLAG_SUPPORTED;
-}
-
-
-CPU_DISASSEMBLE(asap)
-{
-	std::ostringstream stream;
-	offs_t result = internal_disasm_asap(device, stream, pc, oprom, opram, options);
-	std::string stream_str = stream.str();
-	strcpy(buffer, stream_str.c_str());
-	return result;
 }

--- a/src/devices/cpu/avr8/avr8.cpp
+++ b/src/devices/cpu/avr8/avr8.cpp
@@ -949,10 +949,10 @@ uint32_t avr8_device::disasm_max_opcode_bytes() const
 //  helper function
 //-------------------------------------------------
 
-offs_t avr8_device::disasm_disassemble(char *buffer, offs_t pc, const uint8_t *oprom, const uint8_t *opram, uint32_t options)
+offs_t avr8_device::disasm_disassemble(std::ostream &stream, offs_t pc, const uint8_t *oprom, const uint8_t *opram, uint32_t options)
 {
 	extern CPU_DISASSEMBLE( avr8 );
-	return CPU_DISASSEMBLE_NAME(avr8)(this, buffer, pc, oprom, opram, options);
+	return CPU_DISASSEMBLE_NAME(avr8)(this, stream, pc, oprom, opram, options);
 }
 
 

--- a/src/devices/cpu/avr8/avr8.h
+++ b/src/devices/cpu/avr8/avr8.h
@@ -128,7 +128,7 @@ protected:
 	// device_disasm_interface overrides
 	virtual uint32_t disasm_min_opcode_bytes() const override;
 	virtual uint32_t disasm_max_opcode_bytes() const override;
-	virtual offs_t disasm_disassemble(char *buffer, offs_t pc, const uint8_t *oprom, const uint8_t *opram, uint32_t options) override;
+	virtual offs_t disasm_disassemble(std::ostream &stream, offs_t pc, const uint8_t *oprom, const uint8_t *opram, uint32_t options) override;
 
 	// device_state_interface overrides
 	virtual void state_string_export(const device_state_entry &entry, std::string &str) const override;

--- a/src/devices/cpu/avr8/avr8dasm.cpp
+++ b/src/devices/cpu/avr8/avr8dasm.cpp
@@ -25,7 +25,7 @@
 #define ACONST6(op)     ((((op) >> 5) & 0x0030) | ((op) & 0x000f))
 #define MULCONST2(op)   ((((op) >> 6) & 0x0002) | (((op) >> 3) & 0x0001))
 
-static offs_t internal_disasm_avr8(cpu_device *device, std::ostream &stream, offs_t pc, const uint8_t *oprom, const uint8_t *opram, int options)
+CPU_DISASSEMBLE(avr8)
 {
 	int pos = 0;
 	uint32_t op = oprom[pos++];
@@ -670,14 +670,4 @@ static offs_t internal_disasm_avr8(cpu_device *device, std::ostream &stream, off
 	}
 
 	return pos | DASMFLAG_SUPPORTED;
-}
-
-
-CPU_DISASSEMBLE(avr8)
-{
-	std::ostringstream stream;
-	offs_t result = internal_disasm_avr8(device, stream, pc, oprom, opram, options);
-	std::string stream_str = stream.str();
-	strcpy(buffer, stream_str.c_str());
-	return result;
 }

--- a/src/devices/cpu/ccpu/ccpu.cpp
+++ b/src/devices/cpu/ccpu/ccpu.cpp
@@ -687,8 +687,8 @@ void ccpu_cpu_device::execute_run()
 }
 
 
-offs_t ccpu_cpu_device::disasm_disassemble(char *buffer, offs_t pc, const uint8_t *oprom, const uint8_t *opram, uint32_t options)
+offs_t ccpu_cpu_device::disasm_disassemble(std::ostream &stream, offs_t pc, const uint8_t *oprom, const uint8_t *opram, uint32_t options)
 {
 	extern CPU_DISASSEMBLE( ccpu );
-	return CPU_DISASSEMBLE_NAME(ccpu)(this, buffer, pc, oprom, opram, options);
+	return CPU_DISASSEMBLE_NAME(ccpu)(this, stream, pc, oprom, opram, options);
 }

--- a/src/devices/cpu/ccpu/ccpu.h
+++ b/src/devices/cpu/ccpu/ccpu.h
@@ -87,7 +87,7 @@ protected:
 	// device_disasm_interface overrides
 	virtual uint32_t disasm_min_opcode_bytes() const override { return 1; }
 	virtual uint32_t disasm_max_opcode_bytes() const override { return 3; }
-	virtual offs_t disasm_disassemble(char *buffer, offs_t pc, const uint8_t *oprom, const uint8_t *opram, uint32_t options) override;
+	virtual offs_t disasm_disassemble(std::ostream &stream, offs_t pc, const uint8_t *oprom, const uint8_t *opram, uint32_t options) override;
 
 	address_space_config m_program_config;
 	address_space_config m_data_config;

--- a/src/devices/cpu/ccpu/ccpudasm.cpp
+++ b/src/devices/cpu/ccpu/ccpudasm.cpp
@@ -14,7 +14,7 @@
 #include "ccpu.h"
 
 
-static offs_t internal_disasm_ccpu(cpu_device *device, std::ostream &stream, offs_t pc, const uint8_t *oprom, const uint8_t *opram, int options)
+CPU_DISASSEMBLE(ccpu)
 {
 	unsigned startpc = pc;
 	uint8_t opcode = oprom[pc++ - startpc];
@@ -327,14 +327,4 @@ static offs_t internal_disasm_ccpu(cpu_device *device, std::ostream &stream, off
 	}
 
 	return (pc - startpc) | DASMFLAG_SUPPORTED;
-}
-
-
-CPU_DISASSEMBLE(ccpu)
-{
-	std::ostringstream stream;
-	offs_t result = internal_disasm_ccpu(device, stream, pc, oprom, opram, options);
-	std::string stream_str = stream.str();
-	strcpy(buffer, stream_str.c_str());
-	return result;
 }

--- a/src/devices/cpu/cop400/cop400.cpp
+++ b/src/devices/cpu/cop400/cop400.cpp
@@ -1171,7 +1171,7 @@ void cop400_cpu_device::state_string_export(const device_state_entry &entry, std
 }
 
 
-offs_t cop400_cpu_device::disasm_disassemble(char *buffer, offs_t pc, const uint8_t *oprom, const uint8_t *opram, uint32_t options)
+offs_t cop400_cpu_device::disasm_disassemble(std::ostream &stream, offs_t pc, const uint8_t *oprom, const uint8_t *opram, uint32_t options)
 {
 	extern CPU_DISASSEMBLE( cop410 );
 	extern CPU_DISASSEMBLE( cop420 );
@@ -1179,15 +1179,15 @@ offs_t cop400_cpu_device::disasm_disassemble(char *buffer, offs_t pc, const uint
 
 	if ( m_featuremask & COP444_FEATURE )
 	{
-		return CPU_DISASSEMBLE_NAME(cop444)(this, buffer, pc, oprom, opram, options);
+		return CPU_DISASSEMBLE_NAME(cop444)(this, stream, pc, oprom, opram, options);
 	}
 
 	if ( m_featuremask & COP420_FEATURE )
 	{
-		return CPU_DISASSEMBLE_NAME(cop420)(this, buffer, pc, oprom, opram, options);
+		return CPU_DISASSEMBLE_NAME(cop420)(this, stream, pc, oprom, opram, options);
 	}
 
-	return CPU_DISASSEMBLE_NAME(cop410)(this, buffer, pc, oprom, opram, options);
+	return CPU_DISASSEMBLE_NAME(cop410)(this, stream, pc, oprom, opram, options);
 }
 
 READ8_MEMBER( cop400_cpu_device::microbus_rd )

--- a/src/devices/cpu/cop400/cop400.h
+++ b/src/devices/cpu/cop400/cop400.h
@@ -169,7 +169,7 @@ protected:
 	// device_disasm_interface overrides
 	virtual uint32_t disasm_min_opcode_bytes() const override { return 1; }
 	virtual uint32_t disasm_max_opcode_bytes() const override { return 2; }
-	virtual offs_t disasm_disassemble(char *buffer, offs_t pc, const uint8_t *oprom, const uint8_t *opram, uint32_t options) override;
+	virtual offs_t disasm_disassemble(std::ostream &stream, offs_t pc, const uint8_t *oprom, const uint8_t *opram, uint32_t options) override;
 
 	address_space_config m_program_config;
 	address_space_config m_data_config;

--- a/src/devices/cpu/cop400/cop410ds.cpp
+++ b/src/devices/cpu/cop400/cop410ds.cpp
@@ -10,7 +10,7 @@
 
 #include "emu.h"
 
-static offs_t internal_disasm_cop410(cpu_device *device, std::ostream &stream, offs_t pc, const uint8_t *oprom, const uint8_t *opram, int options)
+CPU_DISASSEMBLE(cop410)
 {
 	uint8_t opcode = oprom[0];
 	uint8_t next_opcode = oprom[1];
@@ -347,14 +347,4 @@ static offs_t internal_disasm_cop410(cpu_device *device, std::ostream &stream, o
 	}
 
 	return bytes | flags | DASMFLAG_SUPPORTED;
-}
-
-
-CPU_DISASSEMBLE(cop410)
-{
-	std::ostringstream stream;
-	offs_t result = internal_disasm_cop410(device, stream, pc, oprom, opram, options);
-	std::string stream_str = stream.str();
-	strcpy(buffer, stream_str.c_str());
-	return result;
 }

--- a/src/devices/cpu/cop400/cop420ds.cpp
+++ b/src/devices/cpu/cop400/cop420ds.cpp
@@ -10,7 +10,7 @@
 
 #include "emu.h"
 
-static offs_t internal_disasm_cop420(cpu_device *device, std::ostream &stream, offs_t pc, const uint8_t *oprom, const uint8_t *opram, int options)
+CPU_DISASSEMBLE(cop420)
 {
 	uint8_t opcode = oprom[0];
 	uint8_t next_opcode = oprom[1];
@@ -395,14 +395,4 @@ static offs_t internal_disasm_cop420(cpu_device *device, std::ostream &stream, o
 	}
 
 	return bytes | flags | DASMFLAG_SUPPORTED;
-}
-
-
-CPU_DISASSEMBLE(cop420)
-{
-	std::ostringstream stream;
-	offs_t result = internal_disasm_cop420(device, stream, pc, oprom, opram, options);
-	std::string stream_str = stream.str();
-	strcpy(buffer, stream_str.c_str());
-	return result;
 }

--- a/src/devices/cpu/cop400/cop440ds.cpp
+++ b/src/devices/cpu/cop400/cop440ds.cpp
@@ -10,7 +10,7 @@
 
 #include "emu.h"
 
-static offs_t internal_disasm_cop444(cpu_device *device, std::ostream &stream, offs_t pc, const uint8_t *oprom, const uint8_t *opram, int options)
+CPU_DISASSEMBLE(cop444)
 {
 	uint8_t opcode = oprom[0];
 	uint8_t next_opcode = oprom[1];
@@ -412,14 +412,4 @@ static offs_t internal_disasm_cop444(cpu_device *device, std::ostream &stream, o
 	}
 
 	return bytes | flags | DASMFLAG_SUPPORTED;
-}
-
-
-CPU_DISASSEMBLE(cop444)
-{
-	std::ostringstream stream;
-	offs_t result = internal_disasm_cop444(device, stream, pc, oprom, opram, options);
-	std::string stream_str = stream.str();
-	strcpy(buffer, stream_str.c_str());
-	return result;
 }

--- a/src/devices/cpu/cosmac/cosdasm.cpp
+++ b/src/devices/cpu/cosmac/cosdasm.cpp
@@ -185,23 +185,13 @@ static uint32_t disassemble(device_t *device, std::ostream &stream, offs_t pc, c
 }
 
 
-static uint32_t disassemble(device_t *device, char *buffer, offs_t pc, const uint8_t *oprom, const uint8_t *opram, uint32_t variant)
-{
-	std::ostringstream stream;
-	uint32_t result = disassemble(device, stream, pc, oprom, opram, variant);
-	std::string stream_str = stream.str();
-	strcpy(buffer, stream_str.c_str());
-	return result;
-}
-
-
 CPU_DISASSEMBLE( cdp1801 )
 {
-	return disassemble(device, buffer, pc, oprom, opram, TYPE_1801);
+	return disassemble(device, stream, pc, oprom, opram, TYPE_1801);
 }
 
 
 CPU_DISASSEMBLE( cdp1802 )
 {
-	return disassemble(device, buffer, pc, oprom, opram, TYPE_1802);
+	return disassemble(device, stream, pc, oprom, opram, TYPE_1802);
 }

--- a/src/devices/cpu/cosmac/cosmac.cpp
+++ b/src/devices/cpu/cosmac/cosmac.cpp
@@ -512,16 +512,16 @@ uint32_t cosmac_device::disasm_max_opcode_bytes() const
 //  helper function
 //-------------------------------------------------
 
-offs_t cdp1801_device::disasm_disassemble(char *buffer, offs_t pc, const uint8_t *oprom, const uint8_t *opram, uint32_t options)
+offs_t cdp1801_device::disasm_disassemble(std::ostream &stream, offs_t pc, const uint8_t *oprom, const uint8_t *opram, uint32_t options)
 {
 	extern CPU_DISASSEMBLE( cdp1801 );
-	return CPU_DISASSEMBLE_NAME( cdp1801 )(this, buffer, pc, oprom, opram, options);
+	return CPU_DISASSEMBLE_NAME( cdp1801 )(this, stream, pc, oprom, opram, options);
 }
 
-offs_t cdp1802_device::disasm_disassemble(char *buffer, offs_t pc, const uint8_t *oprom, const uint8_t *opram, uint32_t options)
+offs_t cdp1802_device::disasm_disassemble(std::ostream &stream, offs_t pc, const uint8_t *oprom, const uint8_t *opram, uint32_t options)
 {
 	extern CPU_DISASSEMBLE( cdp1802 );
-	return CPU_DISASSEMBLE_NAME( cdp1802 )(this, buffer, pc, oprom, opram, options);
+	return CPU_DISASSEMBLE_NAME( cdp1802 )(this, stream, pc, oprom, opram, options);
 }
 
 

--- a/src/devices/cpu/cosmac/cosmac.h
+++ b/src/devices/cpu/cosmac/cosmac.h
@@ -451,7 +451,7 @@ public:
 
 protected:
 	// device_disasm_interface overrides
-	virtual offs_t disasm_disassemble(char *buffer, offs_t pc, const uint8_t *oprom, const uint8_t *opram, uint32_t options) override;
+	virtual offs_t disasm_disassemble(std::ostream &stream, offs_t pc, const uint8_t *oprom, const uint8_t *opram, uint32_t options) override;
 
 	virtual cosmac_device::ophandler get_ophandler(uint8_t opcode) override;
 
@@ -469,7 +469,7 @@ public:
 
 protected:
 	// device_disasm_interface overrides
-	virtual offs_t disasm_disassemble(char *buffer, offs_t pc, const uint8_t *oprom, const uint8_t *opram, uint32_t options) override;
+	virtual offs_t disasm_disassemble(std::ostream &stream, offs_t pc, const uint8_t *oprom, const uint8_t *opram, uint32_t options) override;
 
 	virtual cosmac_device::ophandler get_ophandler(uint8_t opcode) override;
 

--- a/src/devices/cpu/cp1610/1610dasm.cpp
+++ b/src/devices/cpu/cp1610/1610dasm.cpp
@@ -4,7 +4,7 @@
 #include "debugger.h"
 #include "cp1610.h"
 
-static offs_t internal_disasm_cp1610(cpu_device *device, std::ostream &stream, offs_t pc, const uint8_t *oprom, const uint8_t *opram, int options)
+CPU_DISASSEMBLE(cp1610)
 {
 	uint16_t oprom16[4]={ static_cast<uint16_t>((oprom[0] << 8) | oprom[1]), static_cast<uint16_t>((oprom[2] << 8) | oprom[3]), static_cast<uint16_t>((oprom[4] << 8) | oprom[5]), static_cast<uint16_t>((oprom[6] << 8) | oprom[7]) };
 	uint16_t op = oprom16[0]; uint16_t subop;
@@ -1487,14 +1487,4 @@ static offs_t internal_disasm_cp1610(cpu_device *device, std::ostream &stream, o
 	}
 
 	return size;
-}
-
-
-CPU_DISASSEMBLE(cp1610)
-{
-	std::ostringstream stream;
-	offs_t result = internal_disasm_cp1610(device, stream, pc, oprom, opram, options);
-	std::string stream_str = stream.str();
-	strcpy(buffer, stream_str.c_str());
-	return result;
 }

--- a/src/devices/cpu/cp1610/cp1610.cpp
+++ b/src/devices/cpu/cp1610/cp1610.cpp
@@ -3417,8 +3417,8 @@ void cp1610_cpu_device::state_string_export(const device_state_entry &entry, std
 }
 
 
-offs_t cp1610_cpu_device::disasm_disassemble(char *buffer, offs_t pc, const uint8_t *oprom, const uint8_t *opram, uint32_t options)
+offs_t cp1610_cpu_device::disasm_disassemble(std::ostream &stream, offs_t pc, const uint8_t *oprom, const uint8_t *opram, uint32_t options)
 {
 	extern CPU_DISASSEMBLE( cp1610 );
-	return CPU_DISASSEMBLE_NAME(cp1610)(this, buffer, pc, oprom, opram, options);
+	return CPU_DISASSEMBLE_NAME(cp1610)(this, stream, pc, oprom, opram, options);
 }

--- a/src/devices/cpu/cp1610/cp1610.h
+++ b/src/devices/cpu/cp1610/cp1610.h
@@ -61,7 +61,7 @@ protected:
 	// device_disasm_interface overrides
 	virtual uint32_t disasm_min_opcode_bytes() const override { return 2; }
 	virtual uint32_t disasm_max_opcode_bytes() const override { return 8; }
-	virtual offs_t disasm_disassemble(char *buffer, offs_t pc, const uint8_t *oprom, const uint8_t *opram, uint32_t options) override;
+	virtual offs_t disasm_disassemble(std::ostream &stream, offs_t pc, const uint8_t *oprom, const uint8_t *opram, uint32_t options) override;
 
 private:
 	address_space_config m_program_config;

--- a/src/devices/cpu/cubeqcpu/cubedasm.cpp
+++ b/src/devices/cpu/cubeqcpu/cubedasm.cpp
@@ -58,7 +58,7 @@ static const char *const dst[] =
     SOUND DISASSEMBLY HOOK
 ***************************************************************************/
 
-static offs_t internal_disasm_cquestsnd(cpu_device *device, std::ostream &stream, offs_t pc, const uint8_t *oprom, const uint8_t *opram, int options)
+CPU_DISASSEMBLE(cquestsnd)
 {
 	static const char *const jmps[] =
 	{
@@ -125,21 +125,11 @@ static offs_t internal_disasm_cquestsnd(cpu_device *device, std::ostream &stream
 }
 
 
-CPU_DISASSEMBLE(cquestsnd)
-{
-	std::ostringstream stream;
-	offs_t result = internal_disasm_cquestsnd(device, stream, pc, oprom, opram, options);
-	std::string stream_str = stream.str();
-	strcpy(buffer, stream_str.c_str());
-	return result;
-}
-
-
 /***************************************************************************
     ROTATE DISASSEMBLY HOOK
 ***************************************************************************/
 
-static offs_t internal_disasm_cquestrot(cpu_device *device, std::ostream &stream, offs_t pc, const uint8_t *oprom, const uint8_t *opram, int options)
+CPU_DISASSEMBLE(cquestrot)
 {
 	static const char *const jmps[] =
 	{
@@ -231,21 +221,11 @@ static offs_t internal_disasm_cquestrot(cpu_device *device, std::ostream &stream
 }
 
 
-CPU_DISASSEMBLE(cquestrot)
-{
-	std::ostringstream stream;
-	offs_t result = internal_disasm_cquestrot(device, stream, pc, oprom, opram, options);
-	std::string stream_str = stream.str();
-	strcpy(buffer, stream_str.c_str());
-	return result;
-}
-
-
 /***************************************************************************
     LINE DRAWER DISASSEMBLY HOOK
 ***************************************************************************/
 
-static offs_t internal_disasm_cquestlin(cpu_device *device, std::ostream &stream, offs_t pc, const uint8_t *oprom, const uint8_t *opram, int options)
+CPU_DISASSEMBLE(cquestlin)
 {
 	static const char *const jmps[] =
 	{
@@ -324,14 +304,4 @@ static offs_t internal_disasm_cquestlin(cpu_device *device, std::ostream &stream
 			spfs[spf]);
 
 	return 1 | DASMFLAG_SUPPORTED;
-}
-
-
-CPU_DISASSEMBLE(cquestlin)
-{
-	std::ostringstream stream;
-	offs_t result = internal_disasm_cquestlin(device, stream, pc, oprom, opram, options);
-	std::string stream_str = stream.str();
-	strcpy(buffer, stream_str.c_str());
-	return result;
 }

--- a/src/devices/cpu/cubeqcpu/cubeqcpu.cpp
+++ b/src/devices/cpu/cubeqcpu/cubeqcpu.cpp
@@ -84,10 +84,10 @@ cquestsnd_cpu_device::cquestsnd_cpu_device(const machine_config &mconfig, const 
 }
 
 
-offs_t cquestsnd_cpu_device::disasm_disassemble(char *buffer, offs_t pc, const uint8_t *oprom, const uint8_t *opram, uint32_t options)
+offs_t cquestsnd_cpu_device::disasm_disassemble(std::ostream &stream, offs_t pc, const uint8_t *oprom, const uint8_t *opram, uint32_t options)
 {
 	extern CPU_DISASSEMBLE( cquestsnd );
-	return CPU_DISASSEMBLE_NAME(cquestsnd)(this, buffer, pc, oprom, opram, options);
+	return CPU_DISASSEMBLE_NAME(cquestsnd)(this, stream, pc, oprom, opram, options);
 }
 
 
@@ -105,10 +105,10 @@ READ16_MEMBER( cquestrot_cpu_device::linedata_r )
 }
 
 
-offs_t cquestrot_cpu_device::disasm_disassemble(char *buffer, offs_t pc, const uint8_t *oprom, const uint8_t *opram, uint32_t options)
+offs_t cquestrot_cpu_device::disasm_disassemble(std::ostream &stream, offs_t pc, const uint8_t *oprom, const uint8_t *opram, uint32_t options)
 {
 	extern CPU_DISASSEMBLE( cquestrot );
-	return CPU_DISASSEMBLE_NAME(cquestrot)(this, buffer, pc, oprom, opram, options);
+	return CPU_DISASSEMBLE_NAME(cquestrot)(this, stream, pc, oprom, opram, options);
 }
 
 
@@ -122,10 +122,10 @@ cquestlin_cpu_device::cquestlin_cpu_device(const machine_config &mconfig, const 
 }
 
 
-offs_t cquestlin_cpu_device::disasm_disassemble(char *buffer, offs_t pc, const uint8_t *oprom, const uint8_t *opram, uint32_t options)
+offs_t cquestlin_cpu_device::disasm_disassemble(std::ostream &stream, offs_t pc, const uint8_t *oprom, const uint8_t *opram, uint32_t options)
 {
 	extern CPU_DISASSEMBLE( cquestlin );
-	return CPU_DISASSEMBLE_NAME(cquestlin)(this, buffer, pc, oprom, opram, options);
+	return CPU_DISASSEMBLE_NAME(cquestlin)(this, stream, pc, oprom, opram, options);
 }
 
 

--- a/src/devices/cpu/cubeqcpu/cubeqcpu.h
+++ b/src/devices/cpu/cubeqcpu/cubeqcpu.h
@@ -166,7 +166,7 @@ protected:
 	// device_disasm_interface overrides
 	virtual uint32_t disasm_min_opcode_bytes() const override { return 8; }
 	virtual uint32_t disasm_max_opcode_bytes() const override { return 8; }
-	virtual offs_t disasm_disassemble(char *buffer, offs_t pc, const uint8_t *oprom, const uint8_t *opram, uint32_t options) override;
+	virtual offs_t disasm_disassemble(std::ostream &stream, offs_t pc, const uint8_t *oprom, const uint8_t *opram, uint32_t options) override;
 
 private:
 	address_space_config m_program_config;
@@ -237,7 +237,7 @@ protected:
 	// device_disasm_interface overrides
 	virtual uint32_t disasm_min_opcode_bytes() const override { return 8; }
 	virtual uint32_t disasm_max_opcode_bytes() const override { return 8; }
-	virtual offs_t disasm_disassemble(char *buffer, offs_t pc, const uint8_t *oprom, const uint8_t *opram, uint32_t options) override;
+	virtual offs_t disasm_disassemble(std::ostream &stream, offs_t pc, const uint8_t *oprom, const uint8_t *opram, uint32_t options) override;
 
 private:
 	address_space_config m_program_config;
@@ -321,7 +321,7 @@ protected:
 	// device_disasm_interface overrides
 	virtual uint32_t disasm_min_opcode_bytes() const override { return 8; }
 	virtual uint32_t disasm_max_opcode_bytes() const override { return 8; }
-	virtual offs_t disasm_disassemble(char *buffer, offs_t pc, const uint8_t *oprom, const uint8_t *opram, uint32_t options) override;
+	virtual offs_t disasm_disassemble(std::ostream &stream, offs_t pc, const uint8_t *oprom, const uint8_t *opram, uint32_t options) override;
 
 private:
 	address_space_config m_program_config;

--- a/src/devices/cpu/dsp16/dsp16.cpp
+++ b/src/devices/cpu/dsp16/dsp16.cpp
@@ -348,10 +348,10 @@ uint32_t dsp16_device::disasm_max_opcode_bytes() const
 //  helper function
 //-------------------------------------------------
 
-offs_t dsp16_device::disasm_disassemble(char *buffer, offs_t pc, const uint8_t *oprom, const uint8_t *opram, uint32_t options)
+offs_t dsp16_device::disasm_disassemble(std::ostream &stream, offs_t pc, const uint8_t *oprom, const uint8_t *opram, uint32_t options)
 {
 	extern CPU_DISASSEMBLE( dsp16a );
-	return CPU_DISASSEMBLE_NAME(dsp16a)(this, buffer, pc, oprom, opram, options);
+	return CPU_DISASSEMBLE_NAME(dsp16a)(this, stream, pc, oprom, opram, options);
 }
 
 

--- a/src/devices/cpu/dsp16/dsp16.h
+++ b/src/devices/cpu/dsp16/dsp16.h
@@ -51,7 +51,7 @@ protected:
 	// device_disasm_interface overrides
 	virtual uint32_t disasm_min_opcode_bytes() const override;
 	virtual uint32_t disasm_max_opcode_bytes() const override;
-	virtual offs_t disasm_disassemble(char *buffer, offs_t pc, const uint8_t *oprom, const uint8_t *opram, uint32_t options) override;
+	virtual offs_t disasm_disassemble(std::ostream &stream, offs_t pc, const uint8_t *oprom, const uint8_t *opram, uint32_t options) override;
 
 	// address spaces
 	const address_space_config m_program_config;

--- a/src/devices/cpu/dsp16/dsp16dis.cpp
+++ b/src/devices/cpu/dsp16/dsp16dis.cpp
@@ -248,7 +248,7 @@ bool disasmSIField(const uint8_t& SI)
 }
 
 
-static offs_t internal_disasm_dsp16a(cpu_device *device, std::ostream &stream, offs_t pc, const uint8_t *oprom, const uint8_t *opram, int options)
+CPU_DISASSEMBLE(dsp16a)
 {
 	uint8_t opSize = 1;
 	uint32_t dasmflags = 0;
@@ -583,14 +583,4 @@ static offs_t internal_disasm_dsp16a(cpu_device *device, std::ostream &stream, o
 	}
 
 	return opSize | dasmflags | DASMFLAG_SUPPORTED;
-}
-
-
-CPU_DISASSEMBLE(dsp16a)
-{
-	std::ostringstream stream;
-	offs_t result = internal_disasm_dsp16a(device, stream, pc, oprom, opram, options);
-	std::string stream_str = stream.str();
-	strcpy(buffer, stream_str.c_str());
-	return result;
 }

--- a/src/devices/cpu/dsp32/dsp32.cpp
+++ b/src/devices/cpu/dsp32/dsp32.cpp
@@ -421,10 +421,10 @@ uint32_t dsp32c_device::disasm_max_opcode_bytes() const
 //  helper function
 //-------------------------------------------------
 
-offs_t dsp32c_device::disasm_disassemble(char *buffer, offs_t pc, const uint8_t *oprom, const uint8_t *opram, uint32_t options)
+offs_t dsp32c_device::disasm_disassemble(std::ostream &stream, offs_t pc, const uint8_t *oprom, const uint8_t *opram, uint32_t options)
 {
 	extern CPU_DISASSEMBLE( dsp32c );
-	return CPU_DISASSEMBLE_NAME(dsp32c)(this, buffer, pc, oprom, opram, options);
+	return CPU_DISASSEMBLE_NAME(dsp32c)(this, stream, pc, oprom, opram, options);
 }
 
 

--- a/src/devices/cpu/dsp32/dsp32.h
+++ b/src/devices/cpu/dsp32/dsp32.h
@@ -128,7 +128,7 @@ protected:
 	// device_disasm_interface overrides
 	virtual uint32_t disasm_min_opcode_bytes() const override;
 	virtual uint32_t disasm_max_opcode_bytes() const override;
-	virtual offs_t disasm_disassemble(char *buffer, offs_t pc, const uint8_t *oprom, const uint8_t *opram, uint32_t options) override;
+	virtual offs_t disasm_disassemble(std::ostream &stream, offs_t pc, const uint8_t *oprom, const uint8_t *opram, uint32_t options) override;
 
 	// memory accessors
 	uint32_t ROPCODE(offs_t pc);

--- a/src/devices/cpu/dsp32/dsp32dis.cpp
+++ b/src/devices/cpu/dsp32/dsp32dis.cpp
@@ -694,21 +694,11 @@ static unsigned dasm_dsp32(std::ostream &stream, unsigned pc, uint32_t op)
 }
 
 
-static unsigned dasm_dsp32(char *buffer, unsigned pc, uint32_t op)
-{
-	std::ostringstream stream;
-	unsigned result = dasm_dsp32(stream, pc, op);
-	std::string stream_str = stream.str();
-	strcpy(buffer, stream_str.c_str());
-	return result;
-}
-
-
 /***************************************************************************
     DISASSEMBLY HOOK
 ***************************************************************************/
 
 CPU_DISASSEMBLE( dsp32c )
 {
-	return dasm_dsp32(buffer, pc, oprom[0] | (oprom[1] << 8) | (oprom[2] << 16) | (oprom[3] << 24));
+	return dasm_dsp32(stream, pc, oprom[0] | (oprom[1] << 8) | (oprom[2] << 16) | (oprom[3] << 24));
 }

--- a/src/devices/cpu/dsp56k/dsp56dsm.cpp
+++ b/src/devices/cpu/dsp56k/dsp56dsm.cpp
@@ -16,7 +16,7 @@
 /*****************************/
 /* Main disassembly function */
 /*****************************/
-static offs_t internal_disasm_dsp56k(cpu_device *device, std::ostream &stream, offs_t pc, const uint8_t *oprom, const uint8_t *opram, int options)
+CPU_DISASSEMBLE(dsp56k)
 {
 	const uint16_t w0 = oprom[0] | (oprom[1] << 8);
 	const uint16_t w1 = oprom[2] | (oprom[3] << 8);
@@ -27,14 +27,4 @@ static offs_t internal_disasm_dsp56k(cpu_device *device, std::ostream &stream, o
 
 	const unsigned size = op.size();
 	return (size | DASMFLAG_SUPPORTED);
-}
-
-
-CPU_DISASSEMBLE(dsp56k)
-{
-	std::ostringstream stream;
-	offs_t result = internal_disasm_dsp56k(device, stream, pc, oprom, opram, options);
-	std::string stream_str = stream.str();
-	strcpy(buffer, stream_str.c_str());
-	return result;
 }

--- a/src/devices/cpu/dsp56k/dsp56k.cpp
+++ b/src/devices/cpu/dsp56k/dsp56k.cpp
@@ -494,8 +494,8 @@ void dsp56k_device::execute_run()
 }
 
 
-offs_t dsp56k_device::disasm_disassemble(char *buffer, offs_t pc, const uint8_t *oprom, const uint8_t *opram, uint32_t options)
+offs_t dsp56k_device::disasm_disassemble(std::ostream &stream, offs_t pc, const uint8_t *oprom, const uint8_t *opram, uint32_t options)
 {
 	extern CPU_DISASSEMBLE( dsp56k );
-	return CPU_DISASSEMBLE_NAME(dsp56k)(this, buffer, pc, oprom, opram, options);
+	return CPU_DISASSEMBLE_NAME(dsp56k)(this, stream, pc, oprom, opram, options);
 }

--- a/src/devices/cpu/dsp56k/dsp56k.h
+++ b/src/devices/cpu/dsp56k/dsp56k.h
@@ -236,7 +236,7 @@ protected:
 	// device_disasm_interface overrides
 	virtual uint32_t disasm_min_opcode_bytes() const override { return 2; }
 	virtual uint32_t disasm_max_opcode_bytes() const override { return 4; }
-	virtual offs_t disasm_disassemble(char *buffer, offs_t pc, const uint8_t *oprom, const uint8_t *opram, uint32_t options) override;
+	virtual offs_t disasm_disassemble(std::ostream &stream, offs_t pc, const uint8_t *oprom, const uint8_t *opram, uint32_t options) override;
 
 private:
 	address_space_config m_program_config;

--- a/src/devices/cpu/e0c6200/e0c6200.cpp
+++ b/src/devices/cpu/e0c6200/e0c6200.cpp
@@ -40,10 +40,10 @@ void e0c6200_cpu_device::state_string_export(const device_state_entry &entry, st
 	}
 }
 
-offs_t e0c6200_cpu_device::disasm_disassemble(char *buffer, offs_t pc, const uint8_t *oprom, const uint8_t *opram, uint32_t options)
+offs_t e0c6200_cpu_device::disasm_disassemble(std::ostream &stream, offs_t pc, const uint8_t *oprom, const uint8_t *opram, uint32_t options)
 {
 	extern CPU_DISASSEMBLE(e0c6200);
-	return CPU_DISASSEMBLE_NAME(e0c6200)(this, buffer, pc, oprom, opram, options);
+	return CPU_DISASSEMBLE_NAME(e0c6200)(this, stream, pc, oprom, opram, options);
 }
 
 

--- a/src/devices/cpu/e0c6200/e0c6200.h
+++ b/src/devices/cpu/e0c6200/e0c6200.h
@@ -43,7 +43,7 @@ protected:
 	// device_disasm_interface overrides
 	virtual uint32_t disasm_min_opcode_bytes() const override { return 2; }
 	virtual uint32_t disasm_max_opcode_bytes() const override { return 2; }
-	virtual offs_t disasm_disassemble(char *buffer, offs_t pc, const uint8_t *oprom, const uint8_t *opram, uint32_t options) override;
+	virtual offs_t disasm_disassemble(std::ostream &stream, offs_t pc, const uint8_t *oprom, const uint8_t *opram, uint32_t options) override;
 	virtual void state_string_export(const device_state_entry &entry, std::string &str) const override;
 
 	address_space_config m_program_config;

--- a/src/devices/cpu/e0c6200/e0c6200d.cpp
+++ b/src/devices/cpu/e0c6200/e0c6200d.cpp
@@ -110,7 +110,7 @@ static char* decode_param(uint16_t opcode, int param, char* buffer)
 }
 
 
-static offs_t internal_disasm_e0c6200(cpu_device *device, std::ostream &stream, offs_t pc, const uint8_t *oprom, const uint8_t *opram, int options)
+CPU_DISASSEMBLE(e0c6200)
 {
 	uint16_t op = (oprom[1] | oprom[0] << 8) & 0xfff;
 
@@ -704,14 +704,4 @@ static offs_t internal_disasm_e0c6200(cpu_device *device, std::ostream &stream, 
 	}
 
 	return 1 | em_flags[m] | DASMFLAG_SUPPORTED;
-}
-
-
-CPU_DISASSEMBLE(e0c6200)
-{
-	std::ostringstream stream;
-	offs_t result = internal_disasm_e0c6200(device, stream, pc, oprom, opram, options);
-	std::string stream_str = stream.str();
-	strcpy(buffer, stream_str.c_str());
-	return result;
 }

--- a/src/devices/cpu/e132xs/32xsdasm.cpp
+++ b/src/devices/cpu/e132xs/32xsdasm.cpp
@@ -2136,16 +2136,7 @@ unsigned dasm_hyperstone(std::ostream &stream, unsigned pc, const uint8_t *oprom
 	return size | flags | DASMFLAG_SUPPORTED;
 }
 
-static unsigned dasm_hyperstone(char *buffer, unsigned pc, const uint8_t *oprom, unsigned h_flag, int private_fp)
-{
-	std::ostringstream stream;
-	unsigned result = dasm_hyperstone(stream, pc, oprom, h_flag, private_fp);
-	std::string stream_str = stream.str();
-	strcpy(buffer, stream_str.c_str());
-	return result;
-}
-
 CPU_DISASSEMBLE( hyperstone_generic )
 {
-	return dasm_hyperstone( buffer, pc, oprom, 0, 0 );
+	return dasm_hyperstone( stream, pc, oprom, 0, 0 );
 }

--- a/src/devices/cpu/e132xs/e132xs.cpp
+++ b/src/devices/cpu/e132xs/e132xs.cpp
@@ -1907,7 +1907,7 @@ uint32_t hyperstone_device::disasm_max_opcode_bytes() const
 offs_t hyperstone_device::disasm_disassemble(std::ostream &stream, offs_t pc, const uint8_t *oprom, const uint8_t *opram, uint32_t options)
 {
 	extern CPU_DISASSEMBLE( hyperstone );
-	return dasm_hyperstone(stream, pc, oprom, GET_H, GET_FP );
+	return dasm_hyperstone(stream, pc, oprom, GET_H, GET_FP);
 }
 
 /* Opcodes */

--- a/src/devices/cpu/e132xs/e132xs.cpp
+++ b/src/devices/cpu/e132xs/e132xs.cpp
@@ -1904,13 +1904,10 @@ uint32_t hyperstone_device::disasm_max_opcode_bytes() const
 //  helper function
 //-------------------------------------------------
 
-offs_t hyperstone_device::disasm_disassemble(char *buffer, offs_t pc, const uint8_t *oprom, const uint8_t *opram, uint32_t options)
+offs_t hyperstone_device::disasm_disassemble(std::ostream &stream, offs_t pc, const uint8_t *oprom, const uint8_t *opram, uint32_t options)
 {
-	std::ostringstream stream;
-	offs_t result = dasm_hyperstone(stream, pc, oprom, GET_H, GET_FP);
-	std::string stream_str = stream.str();
-	strcpy(buffer, stream_str.c_str());
-	return result;
+	extern CPU_DISASSEMBLE( hyperstone );
+	return dasm_hyperstone(stream, pc, oprom, GET_H, GET_FP );
 }
 
 /* Opcodes */

--- a/src/devices/cpu/e132xs/e132xs.h
+++ b/src/devices/cpu/e132xs/e132xs.h
@@ -238,7 +238,7 @@ protected:
 	// device_disasm_interface overrides
 	virtual uint32_t disasm_min_opcode_bytes() const override;
 	virtual uint32_t disasm_max_opcode_bytes() const override;
-	virtual offs_t disasm_disassemble(char *buffer, offs_t pc, const uint8_t *oprom, const uint8_t *opram, uint32_t options) override;
+	virtual offs_t disasm_disassemble(std::ostream &stream, offs_t pc, const uint8_t *oprom, const uint8_t *opram, uint32_t options) override;
 
 	// device_state_interface overrides
 	virtual void state_string_export(const device_state_entry &entry, std::string &str) const override;

--- a/src/devices/cpu/es5510/es5510.cpp
+++ b/src/devices/cpu/es5510/es5510.cpp
@@ -933,7 +933,7 @@ uint32_t es5510_device::disasm_max_opcode_bytes() const
 	return 6;
 }
 
-offs_t es5510_device::disasm_disassemble(char *buffer, offs_t pc, const uint8_t *oprom, const uint8_t *opram, uint32_t options)
+offs_t es5510_device::disasm_disassemble(std::ostream &stream, offs_t pc, const uint8_t *oprom, const uint8_t *opram, uint32_t options)
 {
 	return pc;
 }

--- a/src/devices/cpu/es5510/es5510.h
+++ b/src/devices/cpu/es5510/es5510.h
@@ -134,7 +134,7 @@ protected:
 	virtual void execute_run() override;
 	virtual uint32_t disasm_min_opcode_bytes() const override;
 	virtual uint32_t disasm_max_opcode_bytes() const override;
-	virtual offs_t disasm_disassemble(char *buffer, offs_t pc, const uint8_t *oprom, const uint8_t *opram, uint32_t options) override;
+	virtual offs_t disasm_disassemble(std::ostream &stream, offs_t pc, const uint8_t *oprom, const uint8_t *opram, uint32_t options) override;
 	virtual void execute_set_input(int linenum, int state) override;
 
 	int32_t alu_operation(uint8_t op, int32_t aValue, int32_t bValue, uint8_t &flags);

--- a/src/devices/cpu/esrip/esrip.cpp
+++ b/src/devices/cpu/esrip/esrip.cpp
@@ -398,10 +398,10 @@ uint32_t esrip_device::disasm_max_opcode_bytes() const
 //  helper function
 //-------------------------------------------------
 
-offs_t esrip_device::disasm_disassemble(char *buffer, offs_t pc, const uint8_t *oprom, const uint8_t *opram, uint32_t options)
+offs_t esrip_device::disasm_disassemble(std::ostream &stream, offs_t pc, const uint8_t *oprom, const uint8_t *opram, uint32_t options)
 {
 	extern CPU_DISASSEMBLE( esrip );
-	return CPU_DISASSEMBLE_NAME(esrip)(this, buffer, pc, oprom, opram, options);
+	return CPU_DISASSEMBLE_NAME(esrip)(this, stream, pc, oprom, opram, options);
 }
 
 

--- a/src/devices/cpu/esrip/esrip.h
+++ b/src/devices/cpu/esrip/esrip.h
@@ -149,7 +149,7 @@ protected:
 	// device_disasm_interface overrides
 	virtual uint32_t disasm_min_opcode_bytes() const override;
 	virtual uint32_t disasm_max_opcode_bytes() const override;
-	virtual offs_t disasm_disassemble(char *buffer, offs_t pc, const uint8_t *oprom, const uint8_t *opram, uint32_t options) override;
+	virtual offs_t disasm_disassemble(std::ostream &stream, offs_t pc, const uint8_t *oprom, const uint8_t *opram, uint32_t options) override;
 
 	// device_state_interface overrides
 	virtual void state_string_export(const device_state_entry &entry, std::string &str) const override;

--- a/src/devices/cpu/esrip/esripdsm.cpp
+++ b/src/devices/cpu/esrip/esripdsm.cpp
@@ -17,7 +17,7 @@
     DISASSEMBLY HOOK (TODO: FINISH)
 ***************************************************************************/
 
-static offs_t internal_disasm_esrip(cpu_device *device, std::ostream &stream, offs_t pc, const uint8_t *oprom, const uint8_t *opram, int options)
+CPU_DISASSEMBLE(esrip)
 {
 #if 0
 	static const char* const jmp_types[] =
@@ -92,14 +92,4 @@ static offs_t internal_disasm_esrip(cpu_device *device, std::ostream &stream, of
 			);
 
 	return 1 | DASMFLAG_SUPPORTED;
-}
-
-
-CPU_DISASSEMBLE(esrip)
-{
-	std::ostringstream stream;
-	offs_t result = internal_disasm_esrip(device, stream, pc, oprom, opram, options);
-	std::string stream_str = stream.str();
-	strcpy(buffer, stream_str.c_str());
-	return result;
 }

--- a/src/devices/cpu/f8/f8.cpp
+++ b/src/devices/cpu/f8/f8.cpp
@@ -2062,10 +2062,10 @@ void f8_cpu_device::state_string_export(const device_state_entry &entry, std::st
 }
 
 
-offs_t f8_cpu_device::disasm_disassemble(char *buffer, offs_t pc, const uint8_t *oprom, const uint8_t *opram, uint32_t options)
+offs_t f8_cpu_device::disasm_disassemble(std::ostream &stream, offs_t pc, const uint8_t *oprom, const uint8_t *opram, uint32_t options)
 {
 	extern CPU_DISASSEMBLE( f8 );
-	return CPU_DISASSEMBLE_NAME(f8)(this, buffer, pc, oprom, opram, options);
+	return CPU_DISASSEMBLE_NAME(f8)(this, stream, pc, oprom, opram, options);
 }
 
 

--- a/src/devices/cpu/f8/f8.h
+++ b/src/devices/cpu/f8/f8.h
@@ -56,7 +56,7 @@ protected:
 	// device_disasm_interface overrides
 	virtual uint32_t disasm_min_opcode_bytes() const override { return 1; }
 	virtual uint32_t disasm_max_opcode_bytes() const override { return 3; }
-	virtual offs_t disasm_disassemble(char *buffer, offs_t pc, const uint8_t *oprom, const uint8_t *opram, uint32_t options) override;
+	virtual offs_t disasm_disassemble(std::ostream &stream, offs_t pc, const uint8_t *oprom, const uint8_t *opram, uint32_t options) override;
 
 private:
 	address_space_config m_program_config;

--- a/src/devices/cpu/f8/f8dasm.cpp
+++ b/src/devices/cpu/f8/f8dasm.cpp
@@ -9,7 +9,7 @@ static const char *const rname[16] = {
 	"R8", "J",  "HU", "HL", "KU", "KL", "QU", "QL"
 };
 
-static offs_t internal_disasm_f8(cpu_device *device, std::ostream &stream, offs_t pc, const uint8_t *oprom, const uint8_t *opram, int options)
+CPU_DISASSEMBLE(f8)
 {
 	unsigned size = 0;
 	uint8_t op = oprom[size++];
@@ -531,14 +531,4 @@ static offs_t internal_disasm_f8(cpu_device *device, std::ostream &stream, offs_
 	}
 
 	return size;
-}
-
-
-CPU_DISASSEMBLE(f8)
-{
-	std::ostringstream stream;
-	offs_t result = internal_disasm_f8(device, stream, pc, oprom, opram, options);
-	std::string stream_str = stream.str();
-	strcpy(buffer, stream_str.c_str());
-	return result;
 }

--- a/src/devices/cpu/g65816/g65816.cpp
+++ b/src/devices/cpu/g65816/g65816.cpp
@@ -759,14 +759,14 @@ void g65816_device::execute_set_input(int line, int state)
 #include "g65816ds.h"
 
 
-offs_t g65816_device::disasm_disassemble(char *buffer, offs_t pc, const uint8_t *oprom, const uint8_t *opram, uint32_t options)
+offs_t g65816_device::disasm_disassemble(std::ostream &stream, offs_t pc, const uint8_t *oprom, const uint8_t *opram, uint32_t options)
 {
-	return g65816_disassemble(buffer, (pc & 0x00ffff), (pc & 0xff0000) >> 16, oprom, FLAG_M, FLAG_X);
+	return g65816_disassemble(stream, (pc & 0x00ffff), (pc & 0xff0000) >> 16, oprom, FLAG_M, FLAG_X);
 }
 
 CPU_DISASSEMBLE( g65816 )
 {
-	return g65816_disassemble(buffer, (pc & 0x00ffff), (pc & 0xff0000) >> 16, oprom, 0/*FLAG_M*/, 0/*FLAG_X*/);
+	return g65816_disassemble(stream, (pc & 0x00ffff), (pc & 0xff0000) >> 16, oprom, 0/*FLAG_M*/, 0/*FLAG_X*/);
 }
 
 void g65816_device::g65816_restore_state()

--- a/src/devices/cpu/g65816/g65816.h
+++ b/src/devices/cpu/g65816/g65816.h
@@ -87,7 +87,7 @@ protected:
 	// device_disasm_interface overrides
 	virtual uint32_t disasm_min_opcode_bytes() const override { return 1; }
 	virtual uint32_t disasm_max_opcode_bytes() const override { return 4; }
-	virtual offs_t disasm_disassemble(char *buffer, offs_t pc, const uint8_t *oprom, const uint8_t *opram, uint32_t options) override;
+	virtual offs_t disasm_disassemble(std::ostream &stream, offs_t pc, const uint8_t *oprom, const uint8_t *opram, uint32_t options) override;
 
 	address_space_config m_program_config;
 

--- a/src/devices/cpu/g65816/g65816ds.cpp
+++ b/src/devices/cpu/g65816/g65816ds.cpp
@@ -382,16 +382,7 @@ unsigned g65816_disassemble(std::ostream &stream, unsigned int pc, unsigned int 
 	return length | DASMFLAG_SUPPORTED | dasm_flags;
 }
 
-unsigned g65816_disassemble(char *buffer, unsigned int pc, unsigned int pb, const uint8_t *oprom, int m_flag, int x_flag)
-{
-	std::ostringstream stream;
-	unsigned result = g65816_disassemble(stream, pc, pb, oprom, m_flag, x_flag);
-	std::string stream_str = stream.str();
-	strcpy(buffer, stream_str.c_str());
-	return result;
-}
-
 CPU_DISASSEMBLE( g65816_generic )
 {
-	return g65816_disassemble(buffer, (pc & 0x00ffff), (pc & 0xff0000) >> 16, oprom, 0, 0);
+	return g65816_disassemble(stream, (pc & 0x00ffff), (pc & 0xff0000) >> 16, oprom, 0, 0);
 }

--- a/src/devices/cpu/g65816/g65816ds.h
+++ b/src/devices/cpu/g65816/g65816ds.h
@@ -17,7 +17,6 @@ All rights reserved.
 */
 
 unsigned g65816_disassemble(std::ostream &stream, unsigned int pc, unsigned int pb, const uint8_t *oprom, int m_flag, int x_flag);
-unsigned g65816_disassemble(char *buffer, unsigned int pc, unsigned int pb, const uint8_t *oprom, int m_flag, int x_flag);
 
 
 #endif /* __G65816DS_H__ */

--- a/src/devices/cpu/h6280/6280dasm.cpp
+++ b/src/devices/cpu/h6280/6280dasm.cpp
@@ -144,7 +144,7 @@ static const unsigned char op6280[512]=
 /*****************************************************************************
  *  Disassemble a single command and return the number of bytes it uses.
  *****************************************************************************/
-static offs_t internal_disasm_h6280(cpu_device *device, std::ostream &stream, offs_t pc, const uint8_t *oprom, const uint8_t *opram, int options)
+CPU_DISASSEMBLE(h6280)
 {
 	uint32_t flags = 0;
 	int PC, OP, opc, arg;
@@ -249,16 +249,6 @@ static offs_t internal_disasm_h6280(cpu_device *device, std::ostream &stream, of
 
 		default:
 			util::stream_format(stream, "%-5s$%02X", token[opc], OP >> 1);
-	}
+	}	
 	return (PC - pc) | flags | DASMFLAG_SUPPORTED;
-}
-
-
-CPU_DISASSEMBLE(h6280)
-{
-	std::ostringstream stream;
-	offs_t result = internal_disasm_h6280(device, stream, pc, oprom, opram, options);
-	std::string stream_str = stream.str();
-	strcpy(buffer, stream_str.c_str());
-	return result;
 }

--- a/src/devices/cpu/h6280/h6280.cpp
+++ b/src/devices/cpu/h6280/h6280.cpp
@@ -2238,10 +2238,10 @@ uint32_t h6280_device::disasm_max_opcode_bytes() const
 //  helper function
 //-------------------------------------------------
 
-offs_t h6280_device::disasm_disassemble(char *buffer, offs_t pc, const uint8_t *oprom, const uint8_t *opram, uint32_t options)
+offs_t h6280_device::disasm_disassemble(std::ostream &stream, offs_t pc, const uint8_t *oprom, const uint8_t *opram, uint32_t options)
 {
 	extern CPU_DISASSEMBLE( h6280 );
-	return CPU_DISASSEMBLE_NAME(h6280)(this, buffer, pc, oprom, opram, options);
+	return CPU_DISASSEMBLE_NAME(h6280)(this, stream, pc, oprom, opram, options);
 }
 
 

--- a/src/devices/cpu/h6280/h6280.h
+++ b/src/devices/cpu/h6280/h6280.h
@@ -95,7 +95,7 @@ protected:
 	// device_disasm_interface overrides
 	virtual uint32_t disasm_min_opcode_bytes() const override;
 	virtual uint32_t disasm_max_opcode_bytes() const override;
-	virtual offs_t disasm_disassemble(char *buffer, offs_t pc, const uint8_t *oprom, const uint8_t *opram, uint32_t options) override;
+	virtual offs_t disasm_disassemble(std::ostream &stream, offs_t pc, const uint8_t *oprom, const uint8_t *opram, uint32_t options) override;
 
 	// device_state_interface overrides
 	virtual void state_string_export(const device_state_entry &entry, std::string &str) const override;

--- a/src/devices/cpu/h8/h8.cpp
+++ b/src/devices/cpu/h8/h8.cpp
@@ -568,18 +568,9 @@ offs_t h8_device::disassemble_generic(std::ostream &stream, offs_t pc, const uin
 	return e.flags | DASMFLAG_SUPPORTED;
 }
 
-offs_t h8_device::disassemble_generic(char *buffer, offs_t pc, const uint8_t *oprom, const uint8_t *opram, uint32_t options, const disasm_entry *table)
+offs_t h8_device::disasm_disassemble(std::ostream &stream, offs_t pc, const uint8_t *oprom, const uint8_t *opram, uint32_t options)
 {
-	std::ostringstream stream;
-	offs_t result = disassemble_generic(stream, pc, oprom, opram, options, table);
-	std::string stream_str = stream.str();
-	strcpy(buffer, stream_str.c_str());
-	return result;
-}
-
-offs_t h8_device::disasm_disassemble(char *buffer, offs_t pc, const uint8_t *oprom, const uint8_t *opram, uint32_t options)
-{
-	return disassemble_generic(buffer, pc, oprom, opram, options, disasm_entries);
+	return disassemble_generic(stream, pc, oprom, opram, options, disasm_entries);
 }
 
 uint16_t h8_device::read16i(uint32_t adr)

--- a/src/devices/cpu/h8/h8.h
+++ b/src/devices/cpu/h8/h8.h
@@ -175,7 +175,7 @@ protected:
 	// device_disasm_interface overrides
 	virtual uint32_t disasm_min_opcode_bytes() const override;
 	virtual uint32_t disasm_max_opcode_bytes() const override;
-	virtual offs_t disasm_disassemble(char *buffer, offs_t pc, const uint8_t *oprom, const uint8_t *opram, uint32_t options) override;
+	virtual offs_t disasm_disassemble(std::ostream &stream, offs_t pc, const uint8_t *oprom, const uint8_t *opram, uint32_t options) override;
 
 	address_space_config program_config, io_config;
 	address_space *program, *io;
@@ -209,7 +209,6 @@ protected:
 	static const disasm_entry disasm_entries[];
 
 	offs_t disassemble_generic(std::ostream &stream, offs_t pc, const uint8_t *oprom, const uint8_t *opram, uint32_t options, const disasm_entry *table);
-	offs_t disassemble_generic(char *buffer, offs_t pc, const uint8_t *oprom, const uint8_t *opram, uint32_t options, const disasm_entry *table);
 	void disassemble_am(std::ostream &stream, int am, offs_t pc, const uint8_t *oprom, uint32_t opcode, int slot, int offset);
 
 	virtual void do_exec_full();

--- a/src/devices/cpu/h8/h8h.cpp
+++ b/src/devices/cpu/h8/h8h.cpp
@@ -10,9 +10,9 @@ h8h_device::h8h_device(const machine_config &mconfig, device_type type, const ch
 	mode_advanced = true;
 }
 
-offs_t h8h_device::disasm_disassemble(char *buffer, offs_t pc, const uint8_t *oprom, const uint8_t *opram, uint32_t options)
+offs_t h8h_device::disasm_disassemble(std::ostream &stream, offs_t pc, const uint8_t *oprom, const uint8_t *opram, uint32_t options)
 {
-	return disassemble_generic(buffer, pc, oprom, opram, options, disasm_entries);
+	return disassemble_generic(stream, pc, oprom, opram, options, disasm_entries);
 }
 
 #include "cpu/h8/h8h.hxx"

--- a/src/devices/cpu/h8/h8h.h
+++ b/src/devices/cpu/h8/h8h.h
@@ -23,7 +23,7 @@ public:
 protected:
 	static const disasm_entry disasm_entries[];
 
-	virtual offs_t disasm_disassemble(char *buffer, offs_t pc, const uint8_t *oprom, const uint8_t *opram, uint32_t options) override;
+	virtual offs_t disasm_disassemble(std::ostream &stream, offs_t pc, const uint8_t *oprom, const uint8_t *opram, uint32_t options) override;
 
 	virtual void do_exec_full() override;
 	virtual void do_exec_partial() override;

--- a/src/devices/cpu/h8/h8s2000.cpp
+++ b/src/devices/cpu/h8/h8s2000.cpp
@@ -9,9 +9,9 @@ h8s2000_device::h8s2000_device(const machine_config &mconfig, device_type type, 
 	has_exr = true;
 }
 
-offs_t h8s2000_device::disasm_disassemble(char *buffer, offs_t pc, const uint8_t *oprom, const uint8_t *opram, uint32_t options)
+offs_t h8s2000_device::disasm_disassemble(std::ostream &stream, offs_t pc, const uint8_t *oprom, const uint8_t *opram, uint32_t options)
 {
-	return disassemble_generic(buffer, pc, oprom, opram, options, disasm_entries);
+	return disassemble_generic(stream, pc, oprom, opram, options, disasm_entries);
 }
 
 #include "cpu/h8/h8s2000.hxx"

--- a/src/devices/cpu/h8/h8s2000.h
+++ b/src/devices/cpu/h8/h8s2000.h
@@ -25,7 +25,7 @@ public:
 protected:
 	static const disasm_entry disasm_entries[];
 
-	virtual offs_t disasm_disassemble(char *buffer, offs_t pc, const uint8_t *oprom, const uint8_t *opram, uint32_t options) override;
+	virtual offs_t disasm_disassemble(std::ostream &stream, offs_t pc, const uint8_t *oprom, const uint8_t *opram, uint32_t options) override;
 
 	virtual void do_exec_full() override;
 	virtual void do_exec_partial() override;

--- a/src/devices/cpu/h8/h8s2600.cpp
+++ b/src/devices/cpu/h8/h8s2600.cpp
@@ -8,9 +8,9 @@ h8s2600_device::h8s2600_device(const machine_config &mconfig, device_type type, 
 {
 }
 
-offs_t h8s2600_device::disasm_disassemble(char *buffer, offs_t pc, const uint8_t *oprom, const uint8_t *opram, uint32_t options)
+offs_t h8s2600_device::disasm_disassemble(std::ostream &stream, offs_t pc, const uint8_t *oprom, const uint8_t *opram, uint32_t options)
 {
-	return disassemble_generic(buffer, pc, oprom, opram, options, disasm_entries);
+	return disassemble_generic(stream, pc, oprom, opram, options, disasm_entries);
 }
 
 #include "cpu/h8/h8s2600.hxx"

--- a/src/devices/cpu/h8/h8s2600.h
+++ b/src/devices/cpu/h8/h8s2600.h
@@ -23,7 +23,7 @@ public:
 protected:
 	static const disasm_entry disasm_entries[];
 
-	virtual offs_t disasm_disassemble(char *buffer, offs_t pc, const uint8_t *oprom, const uint8_t *opram, uint32_t options) override;
+	virtual offs_t disasm_disassemble(std::ostream &stream, offs_t pc, const uint8_t *oprom, const uint8_t *opram, uint32_t options) override;
 
 	virtual void do_exec_full() override;
 	virtual void do_exec_partial() override;

--- a/src/devices/cpu/hcd62121/hcd62121.cpp
+++ b/src/devices/cpu/hcd62121/hcd62121.cpp
@@ -525,8 +525,8 @@ void hcd62121_cpu_device::execute_run()
 }
 
 
-offs_t hcd62121_cpu_device::disasm_disassemble(char *buffer, offs_t pc, const uint8_t *oprom, const uint8_t *opram, uint32_t options)
+offs_t hcd62121_cpu_device::disasm_disassemble(std::ostream &stream, offs_t pc, const uint8_t *oprom, const uint8_t *opram, uint32_t options)
 {
 	extern CPU_DISASSEMBLE( hcd62121 );
-	return CPU_DISASSEMBLE_NAME(hcd62121)(this, buffer, pc, oprom, opram, options);
+	return CPU_DISASSEMBLE_NAME(hcd62121)(this, stream, pc, oprom, opram, options);
 }

--- a/src/devices/cpu/hcd62121/hcd62121.h
+++ b/src/devices/cpu/hcd62121/hcd62121.h
@@ -59,7 +59,7 @@ protected:
 	// device_disasm_interface overrides
 	virtual uint32_t disasm_min_opcode_bytes() const override { return 1; }
 	virtual uint32_t disasm_max_opcode_bytes() const override { return 18; }
-	virtual offs_t disasm_disassemble(char *buffer, offs_t pc, const uint8_t *oprom, const uint8_t *opram, uint32_t options) override;
+	virtual offs_t disasm_disassemble(std::ostream &stream, offs_t pc, const uint8_t *oprom, const uint8_t *opram, uint32_t options) override;
 
 	uint8_t read_op();
 	uint8_t datasize( uint8_t op );

--- a/src/devices/cpu/hcd62121/hcd62121d.cpp
+++ b/src/devices/cpu/hcd62121/hcd62121d.cpp
@@ -129,7 +129,7 @@ static const hcd62121_dasm hcd62121_ops[256] =
 };
 
 
-static offs_t internal_disasm_hcd62121(cpu_device *device, std::ostream &stream, offs_t pc, const uint8_t *oprom, const uint8_t *opram, int options)
+CPU_DISASSEMBLE(hcd62121)
 {
 	uint8_t op;
 	uint8_t op1;
@@ -357,12 +357,3 @@ static offs_t internal_disasm_hcd62121(cpu_device *device, std::ostream &stream,
 	return pos | DASMFLAG_SUPPORTED;
 }
 
-
-CPU_DISASSEMBLE(hcd62121)
-{
-	std::ostringstream stream;
-	offs_t result = internal_disasm_hcd62121(device, stream, pc, oprom, opram, options);
-	std::string stream_str = stream.str();
-	strcpy(buffer, stream_str.c_str());
-	return result;
-}

--- a/src/devices/cpu/hd61700/hd61700.cpp
+++ b/src/devices/cpu/hd61700/hd61700.cpp
@@ -292,10 +292,10 @@ void hd61700_cpu_device::state_string_export(const device_state_entry &entry, st
 //  helper function
 //-------------------------------------------------
 
-offs_t hd61700_cpu_device::disasm_disassemble(char *buffer, offs_t pc, const uint8_t *oprom, const uint8_t *opram, uint32_t options)
+offs_t hd61700_cpu_device::disasm_disassemble(std::ostream &stream, offs_t pc, const uint8_t *oprom, const uint8_t *opram, uint32_t options)
 {
 	extern CPU_DISASSEMBLE( hd61700 );
-	return CPU_DISASSEMBLE_NAME(hd61700)(this, buffer, pc, oprom, opram, options);
+	return CPU_DISASSEMBLE_NAME(hd61700)(this, stream, pc, oprom, opram, options);
 }
 
 

--- a/src/devices/cpu/hd61700/hd61700.h
+++ b/src/devices/cpu/hd61700/hd61700.h
@@ -100,7 +100,7 @@ protected:
 	// device_disasm_interface overrides
 	virtual uint32_t disasm_min_opcode_bytes() const override { return 1; }
 	virtual uint32_t disasm_max_opcode_bytes() const override { return 16; }
-	virtual offs_t disasm_disassemble(char *buffer, offs_t pc, const uint8_t *oprom, const uint8_t *opram, uint32_t options) override;
+	virtual offs_t disasm_disassemble(std::ostream &stream, offs_t pc, const uint8_t *oprom, const uint8_t *opram, uint32_t options) override;
 
 	// interrupts
 	bool check_irqs(void);

--- a/src/devices/cpu/hd61700/hd61700d.cpp
+++ b/src/devices/cpu/hd61700/hd61700d.cpp
@@ -392,7 +392,7 @@ uint32_t get_dasmflags(uint8_t op)
 }
 
 
-static offs_t internal_disasm_hd61700(cpu_device *device, std::ostream &stream, offs_t pc, const uint8_t *oprom, const uint8_t *opram, int options)
+CPU_DISASSEMBLE(hd61700)
 {
 	const hd61700_dasm *inst;
 	uint32_t dasmflags;
@@ -432,14 +432,4 @@ static offs_t internal_disasm_hd61700(cpu_device *device, std::ostream &stream, 
 	if (pos&1) INC_POS;
 
 	return (pos>>1) | dasmflags | DASMFLAG_SUPPORTED;
-}
-
-
-CPU_DISASSEMBLE(hd61700)
-{
-	std::ostringstream stream;
-	offs_t result = internal_disasm_hd61700(device, stream, pc, oprom, opram, options);
-	std::string stream_str = stream.str();
-	strcpy(buffer, stream_str.c_str());
-	return result;
 }

--- a/src/devices/cpu/hmcs40/hmcs40.cpp
+++ b/src/devices/cpu/hmcs40/hmcs40.cpp
@@ -148,10 +148,10 @@ void hmcs40_cpu_device::state_string_export(const device_state_entry &entry, std
 	}
 }
 
-offs_t hmcs40_cpu_device::disasm_disassemble(char *buffer, offs_t pc, const uint8_t *oprom, const uint8_t *opram, uint32_t options)
+offs_t hmcs40_cpu_device::disasm_disassemble(std::ostream &stream, offs_t pc, const uint8_t *oprom, const uint8_t *opram, uint32_t options)
 {
 	extern CPU_DISASSEMBLE(hmcs40);
-	return CPU_DISASSEMBLE_NAME(hmcs40)(this, buffer, pc, oprom, opram, options);
+	return CPU_DISASSEMBLE_NAME(hmcs40)(this, stream, pc, oprom, opram, options);
 }
 
 

--- a/src/devices/cpu/hmcs40/hmcs40.h
+++ b/src/devices/cpu/hmcs40/hmcs40.h
@@ -174,7 +174,7 @@ protected:
 	// device_disasm_interface overrides
 	virtual uint32_t disasm_min_opcode_bytes() const override { return 2; }
 	virtual uint32_t disasm_max_opcode_bytes() const override { return 2; }
-	virtual offs_t disasm_disassemble(char *buffer, offs_t pc, const uint8_t *oprom, const uint8_t *opram, uint32_t options) override;
+	virtual offs_t disasm_disassemble(std::ostream &stream, offs_t pc, const uint8_t *oprom, const uint8_t *opram, uint32_t options) override;
 	virtual void state_string_export(const device_state_entry &entry, std::string &str) const override;
 
 	address_space_config m_program_config;

--- a/src/devices/cpu/hmcs40/hmcs40d.cpp
+++ b/src/devices/cpu/hmcs40/hmcs40d.cpp
@@ -184,7 +184,7 @@ static const uint8_t hmcs40_mnemonic[0x400] =
 
 
 
-static offs_t internal_disasm_hmcs40(cpu_device *device, std::ostream &stream, offs_t pc, const uint8_t *oprom, const uint8_t *opram, int options)
+CPU_DISASSEMBLE(hmcs40)
 {
 	uint16_t op = (oprom[0] | oprom[1] << 8) & 0x3ff;
 	uint8_t instr = hmcs40_mnemonic[op];
@@ -228,14 +228,4 @@ static offs_t internal_disasm_hmcs40(cpu_device *device, std::ostream &stream, o
 
 	int pos = s_next_pc[pc & 0x3f] & DASMFLAG_LENGTHMASK;
 	return pos | s_flags[instr] | DASMFLAG_SUPPORTED;
-}
-
-
-CPU_DISASSEMBLE(hmcs40)
-{
-	std::ostringstream stream;
-	offs_t result = internal_disasm_hmcs40(device, stream, pc, oprom, opram, options);
-	std::string stream_str = stream.str();
-	strcpy(buffer, stream_str.c_str());
-	return result;
 }

--- a/src/devices/cpu/hphybrid/hphybrid.cpp
+++ b/src/devices/cpu/hphybrid/hphybrid.cpp
@@ -675,10 +675,10 @@ void hp_hybrid_cpu_device::state_string_export(const device_state_entry &entry, 
 	}
 }
 
-offs_t hp_hybrid_cpu_device::disasm_disassemble(char *buffer, offs_t pc, const uint8_t *oprom, const uint8_t *opram, uint32_t options)
+offs_t hp_hybrid_cpu_device::disasm_disassemble(std::ostream &stream, offs_t pc, const uint8_t *oprom, const uint8_t *opram, uint32_t options)
 {
 				extern CPU_DISASSEMBLE(hp_hybrid);
-				return CPU_DISASSEMBLE_NAME(hp_hybrid)(this, buffer, pc, oprom, opram, options);
+				return CPU_DISASSEMBLE_NAME(hp_hybrid)(this, stream, pc, oprom, opram, options);
 }
 
 uint16_t hp_hybrid_cpu_device::remove_mae(uint32_t addr)
@@ -1536,10 +1536,10 @@ uint16_t hp_5061_3001_cpu_device::execute_no_bpc_ioc(uint16_t opcode)
 		return m_reg_P + 1;
 }
 
-offs_t hp_5061_3001_cpu_device::disasm_disassemble(char *buffer, offs_t pc, const uint8_t *oprom, const uint8_t *opram, uint32_t options)
+offs_t hp_5061_3001_cpu_device::disasm_disassemble(std::ostream &stream, offs_t pc, const uint8_t *oprom, const uint8_t *opram, uint32_t options)
 {
-		extern CPU_DISASSEMBLE(hp_5061_3001);
-		return CPU_DISASSEMBLE_NAME(hp_5061_3001)(this, buffer, pc, oprom, opram, options);
+	extern CPU_DISASSEMBLE(hp_5061_3001);
+	return CPU_DISASSEMBLE_NAME(hp_5061_3001)(this, stream, pc, oprom, opram, options);
 }
 
 uint32_t hp_5061_3001_cpu_device::add_mae(aec_cases_t aec_case , uint16_t addr)

--- a/src/devices/cpu/hphybrid/hphybrid.h
+++ b/src/devices/cpu/hphybrid/hphybrid.h
@@ -119,7 +119,7 @@ protected:
 				// device_disasm_interface overrides
 				virtual uint32_t disasm_min_opcode_bytes() const override { return 2; }
 				virtual uint32_t disasm_max_opcode_bytes() const override { return 2; }
-				virtual offs_t disasm_disassemble(char *buffer, offs_t pc, const uint8_t *oprom, const uint8_t *opram, uint32_t options) override;
+				virtual offs_t disasm_disassemble(std::ostream &stream, offs_t pc, const uint8_t *oprom, const uint8_t *opram, uint32_t options) override;
 
 		// Different cases of memory access
 		// See patent @ pg 361
@@ -213,8 +213,8 @@ protected:
 		void do_mpy(void);
 
 		virtual uint16_t execute_no_bpc_ioc(uint16_t opcode) override;
-		virtual offs_t disasm_disassemble(char *buffer, offs_t pc, const uint8_t *oprom, const uint8_t *opram, uint32_t options) override;
-		virtual uint32_t add_mae(aec_cases_t aec_case , uint16_t addr) override;
+		virtual offs_t disasm_disassemble(std::ostream &stream, offs_t pc, const uint8_t *oprom, const uint8_t *opram, uint32_t options) override;
+		virtual uint32_t add_mae(aec_cases_t aec_case, uint16_t addr) override;
 		virtual uint16_t read_non_common_reg(uint16_t addr) override;
 		virtual void write_non_common_reg(uint16_t addr , uint16_t v) override;
 

--- a/src/devices/cpu/hphybrid/hphybrid_dasm.cpp
+++ b/src/devices/cpu/hphybrid/hphybrid_dasm.cpp
@@ -371,7 +371,7 @@ static offs_t disassemble_table(uint16_t opcode , offs_t pc , const dis_entry_t 
 	return 0;
 }
 
-static offs_t internal_disasm_hp_hybrid(cpu_device *device, std::ostream &stream, offs_t pc, const uint8_t *oprom, const uint8_t *opram, int options)
+CPU_DISASSEMBLE(hp_hybrid)
 {
 	uint16_t opcode = ((uint16_t)oprom[ 0 ] << 8) | oprom[ 1 ];
 	offs_t res;
@@ -388,16 +388,7 @@ static offs_t internal_disasm_hp_hybrid(cpu_device *device, std::ostream &stream
 	return res;
 }
 
-CPU_DISASSEMBLE(hp_hybrid)
-{
-	std::ostringstream stream;
-	offs_t result = internal_disasm_hp_hybrid(device, stream, pc, oprom, opram, options);
-	std::string stream_str = stream.str();
-	strcpy(buffer, stream_str.c_str());
-	return result;
-}
-
-static offs_t internal_disasm_hp_5061_3001(cpu_device *device, std::ostream &stream, offs_t pc, const uint8_t *oprom, const uint8_t *opram, int options)
+CPU_DISASSEMBLE(hp_5061_3001)
 {
 	uint16_t opcode = ((uint16_t)oprom[ 0 ] << 8) | oprom[ 1 ];
 	offs_t res;
@@ -417,14 +408,4 @@ static offs_t internal_disasm_hp_5061_3001(cpu_device *device, std::ostream &str
 	}
 
 	return res;
-}
-
-
-CPU_DISASSEMBLE(hp_5061_3001)
-{
-	std::ostringstream stream;
-	offs_t result = internal_disasm_hp_5061_3001(device, stream, pc, oprom, opram, options);
-	std::string stream_str = stream.str();
-	strcpy(buffer, stream_str.c_str());
-	return result;
 }

--- a/src/devices/cpu/i386/i386.cpp
+++ b/src/devices/cpu/i386/i386.cpp
@@ -3989,13 +3989,9 @@ bool i386_device::memory_translate(address_spacenum spacenum, int intention, off
 	return ret;
 }
 
-offs_t i386_device::disasm_disassemble(char *buffer, offs_t pc, const uint8_t *oprom, const uint8_t *opram, uint32_t options)
+offs_t i386_device::disasm_disassemble(std::ostream &stream, offs_t pc, const uint8_t *oprom, const uint8_t *opram, uint32_t options)
 {
-	std::ostringstream stream;
-	offs_t result = i386_dasm_one(stream, pc, oprom, m_sreg[CS].d ? 32 : 16);
-	std::string stream_str = stream.str();
-	strcpy(buffer, stream_str.c_str());
-	return result;
+	return i386_dasm_one(stream, pc, oprom, m_sreg[CS].d ? 32 : 16);
 }
 
 

--- a/src/devices/cpu/i386/i386.h
+++ b/src/devices/cpu/i386/i386.h
@@ -64,7 +64,7 @@ protected:
 	// device_disasm_interface overrides
 	virtual uint32_t disasm_min_opcode_bytes() const override { return 1; }
 	virtual uint32_t disasm_max_opcode_bytes() const override { return 15; }
-	virtual offs_t disasm_disassemble(char *buffer, offs_t pc, const uint8_t *oprom, const uint8_t *opram, uint32_t options) override;
+	virtual offs_t disasm_disassemble(std::ostream &stream, offs_t pc, const uint8_t *oprom, const uint8_t *opram, uint32_t options) override;
 
 	address_space_config m_program_config;
 	address_space_config m_io_config;

--- a/src/devices/cpu/i386/i386dasm.cpp
+++ b/src/devices/cpu/i386/i386dasm.cpp
@@ -3115,26 +3115,17 @@ int i386_dasm_one(std::ostream &stream, offs_t eip, const uint8_t *oprom, int mo
 	return i386_dasm_one_ex(stream, eip, oprom, mode);
 }
 
-static int i386_dasm_one_ex(char *buffer, uint64_t eip, const uint8_t *oprom, int mode)
-{
-	std::ostringstream stream;
-	int result = i386_dasm_one_ex(stream, eip, oprom, mode);
-	std::string stream_str = stream.str();
-	strcpy(buffer, stream_str.c_str());
-	return result;
-}
-
 CPU_DISASSEMBLE( x86_16 )
 {
-	return i386_dasm_one_ex(buffer, pc, oprom, 16);
+	return i386_dasm_one_ex(stream, pc, oprom, 16);
 }
 
 CPU_DISASSEMBLE( x86_32 )
 {
-	return i386_dasm_one_ex(buffer, pc, oprom, 32);
+	return i386_dasm_one_ex(stream, pc, oprom, 32);
 }
 
 CPU_DISASSEMBLE( x86_64 )
 {
-	return i386_dasm_one_ex(buffer, pc, oprom, 64);
+	return i386_dasm_one_ex(stream, pc, oprom, 64);
 }

--- a/src/devices/cpu/i4004/4004dasm.cpp
+++ b/src/devices/cpu/i4004/4004dasm.cpp
@@ -13,7 +13,7 @@
 #define OP(A)   oprom[(A) - PC]
 #define ARG(A)  opram[(A) - PC]
 
-static offs_t internal_disasm_i4004(cpu_device *device, std::ostream &stream, offs_t pc, const uint8_t *oprom, const uint8_t *opram, int options)
+CPU_DISASSEMBLE(i4004)
 {
 	uint32_t flags = 0;
 	uint8_t op;
@@ -130,14 +130,4 @@ static offs_t internal_disasm_i4004(cpu_device *device, std::ostream &stream, of
 		default : util::stream_format(stream, "illegal"); break;
 	}
 	return (pc - PC) | flags | DASMFLAG_SUPPORTED;
-}
-
-
-CPU_DISASSEMBLE(i4004)
-{
-	std::ostringstream stream;
-	offs_t result = internal_disasm_i4004(device, stream, pc, oprom, opram, options);
-	std::string stream_str = stream.str();
-	strcpy(buffer, stream_str.c_str());
-	return result;
 }

--- a/src/devices/cpu/i4004/i4004.cpp
+++ b/src/devices/cpu/i4004/i4004.cpp
@@ -522,8 +522,8 @@ void i4004_cpu_device::state_string_export(const device_state_entry &entry, std:
 	}
 }
 
-offs_t i4004_cpu_device::disasm_disassemble(char *buffer, offs_t pc, const uint8_t *oprom, const uint8_t *opram, uint32_t options)
+offs_t i4004_cpu_device::disasm_disassemble(std::ostream &stream, offs_t pc, const uint8_t *oprom, const uint8_t *opram, uint32_t options)
 {
 	extern CPU_DISASSEMBLE( i4004 );
-	return CPU_DISASSEMBLE_NAME(i4004)(this, buffer, pc, oprom, opram, options);
+	return CPU_DISASSEMBLE_NAME(i4004)(this, stream, pc, oprom, opram, options);
 }

--- a/src/devices/cpu/i4004/i4004.h
+++ b/src/devices/cpu/i4004/i4004.h
@@ -59,7 +59,7 @@ protected:
 	// device_disasm_interface overrides
 	virtual uint32_t disasm_min_opcode_bytes() const override { return 1; }
 	virtual uint32_t disasm_max_opcode_bytes() const override { return 2; }
-	virtual offs_t disasm_disassemble(char *buffer, offs_t pc, const uint8_t *oprom, const uint8_t *opram, uint32_t options) override;
+	virtual offs_t disasm_disassemble(std::ostream &stream, offs_t pc, const uint8_t *oprom, const uint8_t *opram, uint32_t options) override;
 
 	uint8_t ROP();
 	uint8_t READ_ROM();

--- a/src/devices/cpu/i8008/8008dasm.cpp
+++ b/src/devices/cpu/i8008/8008dasm.cpp
@@ -16,7 +16,7 @@
 static const char reg[] = { 'a', 'b', 'c', 'd', 'e', 'h', 'l', 'm' };
 static const char flag_names[] = { 'c', 'z', 's', 'p' };
 
-static offs_t internal_disasm_i8008(cpu_device *device, std::ostream &stream, offs_t pc, const uint8_t *oprom, const uint8_t *opram, int options)
+CPU_DISASSEMBLE(i8008)
 {
 	uint32_t flags = 0;
 	unsigned PC = pc;
@@ -112,14 +112,4 @@ static offs_t internal_disasm_i8008(cpu_device *device, std::ostream &stream, of
 					break;
 	}
 	return (pc - PC) | flags | DASMFLAG_SUPPORTED;
-}
-
-
-CPU_DISASSEMBLE(i8008)
-{
-	std::ostringstream stream;
-	offs_t result = internal_disasm_i8008(device, stream, pc, oprom, opram, options);
-	std::string stream_str = stream.str();
-	strcpy(buffer, stream_str.c_str());
-	return result;
 }

--- a/src/devices/cpu/i8008/i8008.cpp
+++ b/src/devices/cpu/i8008/i8008.cpp
@@ -226,10 +226,10 @@ uint32_t i8008_device::disasm_max_opcode_bytes() const
 //  helper function
 //-------------------------------------------------
 
-offs_t i8008_device::disasm_disassemble(char *buffer, offs_t pc, const uint8_t *oprom, const uint8_t *opram, uint32_t options)
+offs_t i8008_device::disasm_disassemble(std::ostream &stream, offs_t pc, const uint8_t *oprom, const uint8_t *opram, uint32_t options)
 {
 	extern CPU_DISASSEMBLE( i8008 );
-	return CPU_DISASSEMBLE_NAME(i8008)(this, buffer, pc, oprom, opram, options);
+	return CPU_DISASSEMBLE_NAME(i8008)(this, stream, pc, oprom, opram, options);
 }
 
 //**************************************************************************

--- a/src/devices/cpu/i8008/i8008.h
+++ b/src/devices/cpu/i8008/i8008.h
@@ -50,7 +50,7 @@ protected:
 	// device_disasm_interface overrides
 	virtual uint32_t disasm_min_opcode_bytes() const override;
 	virtual uint32_t disasm_max_opcode_bytes() const override;
-	virtual offs_t disasm_disassemble(char *buffer, offs_t pc, const uint8_t *oprom, const uint8_t *opram, uint32_t options) override;
+	virtual offs_t disasm_disassemble(std::ostream &stream, offs_t pc, const uint8_t *oprom, const uint8_t *opram, uint32_t options) override;
 
 	virtual void execute_one(int opcode);
 

--- a/src/devices/cpu/i8085/8085dasm.cpp
+++ b/src/devices/cpu/i8085/8085dasm.cpp
@@ -18,7 +18,7 @@
 #define ARG(A)  opram[(A) - PC]
 #define ARGW(A) (opram[(A) - PC] | (opram[(A) + 1 - PC] << 8))
 
-static offs_t internal_disasm_i8085(cpu_device *device, std::ostream &stream, offs_t pc, const uint8_t *oprom, const uint8_t *opram, int options)
+CPU_DISASSEMBLE(i8085)
 {
 	uint32_t flags = 0;
 	uint8_t op;
@@ -542,14 +542,4 @@ static offs_t internal_disasm_i8085(cpu_device *device, std::ostream &stream, of
 #endif
 	}
 	return (pc - PC) | flags | DASMFLAG_SUPPORTED;
-}
-
-
-CPU_DISASSEMBLE(i8085)
-{
-	std::ostringstream stream;
-	offs_t result = internal_disasm_i8085(device, stream, pc, oprom, opram, options);
-	std::string stream_str = stream.str();
-	strcpy(buffer, stream_str.c_str());
-	return result;
 }

--- a/src/devices/cpu/i8085/i8085.cpp
+++ b/src/devices/cpu/i8085/i8085.cpp
@@ -1094,8 +1094,8 @@ void i8085a_cpu_device::execute_set_input(int irqline, int state)
 }
 
 
-offs_t i8085a_cpu_device::disasm_disassemble(char *buffer, offs_t pc, const uint8_t *oprom, const uint8_t *opram, uint32_t options)
+offs_t i8085a_cpu_device::disasm_disassemble(std::ostream &stream, offs_t pc, const uint8_t *oprom, const uint8_t *opram, uint32_t options)
 {
 	extern CPU_DISASSEMBLE( i8085 );
-	return CPU_DISASSEMBLE_NAME(i8085)(this, buffer, pc, oprom, opram, options);
+	return CPU_DISASSEMBLE_NAME(i8085)(this, stream, pc, oprom, opram, options);
 }

--- a/src/devices/cpu/i8085/i8085.h
+++ b/src/devices/cpu/i8085/i8085.h
@@ -88,7 +88,7 @@ protected:
 	// device_disasm_interface overrides
 	virtual uint32_t disasm_min_opcode_bytes() const override { return 1; }
 	virtual uint32_t disasm_max_opcode_bytes() const override { return 3; }
-	virtual offs_t disasm_disassemble(char *buffer, offs_t pc, const uint8_t *oprom, const uint8_t *opram, uint32_t options) override;
+	virtual offs_t disasm_disassemble(std::ostream &stream, offs_t pc, const uint8_t *oprom, const uint8_t *opram, uint32_t options) override;
 
 private:
 	address_space_config m_program_config;

--- a/src/devices/cpu/i8089/i8089.cpp
+++ b/src/devices/cpu/i8089/i8089.cpp
@@ -148,10 +148,10 @@ const address_space_config *i8089_device::memory_space_config(address_spacenum s
 //  disasm_disassemble - disassembler
 //-------------------------------------------------
 
-offs_t i8089_device::disasm_disassemble(char *buffer, offs_t pc, const uint8_t *oprom, const uint8_t *opram, uint32_t options)
+offs_t i8089_device::disasm_disassemble(std::ostream &stream, offs_t pc, const uint8_t *oprom, const uint8_t *opram, uint32_t options)
 {
 	extern CPU_DISASSEMBLE(i8089);
-	return CPU_DISASSEMBLE_NAME(i8089)(this, buffer, pc, oprom, opram, options);
+	return CPU_DISASSEMBLE_NAME(i8089)(this, stream, pc, oprom, opram, options);
 }
 
 //-------------------------------------------------

--- a/src/devices/cpu/i8089/i8089.h
+++ b/src/devices/cpu/i8089/i8089.h
@@ -85,7 +85,7 @@ protected:
 	// device_disasm_interface overrides
 	virtual uint32_t disasm_min_opcode_bytes() const override { return 1; }
 	virtual uint32_t disasm_max_opcode_bytes() const override { return 7; }
-	virtual offs_t disasm_disassemble(char *buffer, offs_t pc, const uint8_t *oprom, const uint8_t *opram, uint32_t options) override;
+	virtual offs_t disasm_disassemble(std::ostream &stream, offs_t pc, const uint8_t *oprom, const uint8_t *opram, uint32_t options) override;
 
 	// device_state_interface overrides
 	virtual void state_string_export(const device_state_entry &entry, std::string &str) const override;

--- a/src/devices/cpu/i8089/i8089_dasm.cpp
+++ b/src/devices/cpu/i8089/i8089_dasm.cpp
@@ -437,20 +437,10 @@ const char *i8089_instruction::m_reg[] =
 	"ga", "gb", "gc", "bc", "tp", "ix", "cc", "mc"
 };
 
-static offs_t internal_disasm_i8089(cpu_device *device, std::ostream &stream, offs_t pc, const uint8_t *oprom, const uint8_t *opram, int options)
+CPU_DISASSEMBLE(i8089)
 {
 	std::unique_ptr<i8089_instruction> i = std::make_unique<i8089_instruction>(pc, oprom);
 	stream << i->buffer();
 	offs_t result = i->length() | i->flags();
-	return result;
-}
-
-
-CPU_DISASSEMBLE(i8089)
-{
-	std::ostringstream stream;
-	offs_t result = internal_disasm_i8089(device, stream, pc, oprom, opram, options);
-	std::string stream_str = stream.str();
-	strcpy(buffer, stream_str.c_str());
 	return result;
 }

--- a/src/devices/cpu/i86/i86.cpp
+++ b/src/devices/cpu/i86/i86.cpp
@@ -508,14 +508,10 @@ void i8086_common_cpu_device::execute_set_input( int inptnum, int state )
 	}
 }
 
-offs_t i8086_common_cpu_device::disasm_disassemble(char *buffer, offs_t pc, const uint8_t *oprom, const uint8_t *opram, uint32_t options)
+offs_t i8086_common_cpu_device::disasm_disassemble(std::ostream &stream, offs_t pc, const uint8_t *oprom, const uint8_t *opram, uint32_t options)
 {
 	extern int i386_dasm_one(std::ostream &stream, offs_t eip, const uint8_t *oprom, int mode);
-	std::ostringstream stream;
-	offs_t result = i386_dasm_one(stream, pc, oprom, 1);
-	std::string stream_str = stream.str();
-	strcpy(buffer, stream_str.c_str());
-	return result;
+	return i386_dasm_one(stream, pc, oprom, 1);
 }
 
 uint8_t i8086_common_cpu_device::read_port_byte(uint16_t port)

--- a/src/devices/cpu/i86/i86.h
+++ b/src/devices/cpu/i86/i86.h
@@ -124,7 +124,7 @@ protected:
 	// device_disasm_interface overrides
 	virtual uint32_t disasm_min_opcode_bytes() const override { return 1; }
 	virtual uint32_t disasm_max_opcode_bytes() const override { return 8; }
-	virtual offs_t disasm_disassemble(char *buffer, offs_t pc, const uint8_t *oprom, const uint8_t *opram, uint32_t options) override;
+	virtual offs_t disasm_disassemble(std::ostream &stream, offs_t pc, const uint8_t *oprom, const uint8_t *opram, uint32_t options) override;
 
 	// device_state_interface overrides
 	virtual void state_string_export(const device_state_entry &entry, std::string &str) const override;

--- a/src/devices/cpu/i860/i860.cpp
+++ b/src/devices/cpu/i860/i860.cpp
@@ -225,10 +225,10 @@ void i860_cpu_device::device_reset()
 }
 
 
-offs_t i860_cpu_device::disasm_disassemble(char *buffer, offs_t pc, const uint8_t *oprom, const uint8_t *opram, uint32_t options)
+offs_t i860_cpu_device::disasm_disassemble(std::ostream &stream, offs_t pc, const uint8_t *oprom, const uint8_t *opram, uint32_t options)
 {
 	extern CPU_DISASSEMBLE( i860 );
-	return CPU_DISASSEMBLE_NAME(i860)(this, buffer, pc, oprom, opram, options);
+	return CPU_DISASSEMBLE_NAME(i860)(this, stream, pc, oprom, opram, options);
 }
 
 

--- a/src/devices/cpu/i860/i860.h
+++ b/src/devices/cpu/i860/i860.h
@@ -82,7 +82,7 @@ protected:
 	// device_disasm_interface overrides
 	virtual uint32_t disasm_min_opcode_bytes() const override { return 4; }
 	virtual uint32_t disasm_max_opcode_bytes() const override { return 4; }
-	virtual offs_t disasm_disassemble(char *buffer, offs_t pc, const uint8_t *oprom, const uint8_t *opram, uint32_t options) override;
+	virtual offs_t disasm_disassemble(std::ostream &stream, offs_t pc, const uint8_t *oprom, const uint8_t *opram, uint32_t options) override;
 
 private:
 	address_space_config m_program_config;

--- a/src/devices/cpu/i860/i860dis.cpp
+++ b/src/devices/cpu/i860/i860dis.cpp
@@ -694,9 +694,5 @@ static offs_t internal_disasm_i860(cpu_device *device, std::ostream &main_stream
 
 CPU_DISASSEMBLE(i860)
 {
-	std::ostringstream stream;
-	offs_t result = internal_disasm_i860(device, stream, pc, oprom, opram, options);
-	std::string stream_str = stream.str();
-	strcpy(buffer, stream_str.c_str());
-	return result;
+	return internal_disasm_i860(device, stream, pc, oprom, opram, options);
 }

--- a/src/devices/cpu/i960/i960.cpp
+++ b/src/devices/cpu/i960/i960.cpp
@@ -2117,8 +2117,8 @@ void i960_cpu_device::device_reset()
 }
 
 
-offs_t i960_cpu_device::disasm_disassemble(char *buffer, offs_t pc, const uint8_t *oprom, const uint8_t *opram, uint32_t options)
+offs_t i960_cpu_device::disasm_disassemble(std::ostream &stream, offs_t pc, const uint8_t *oprom, const uint8_t *opram, uint32_t options)
 {
 	extern CPU_DISASSEMBLE( i960 );
-	return CPU_DISASSEMBLE_NAME(i960)(this, buffer, pc, oprom, opram, options);
+	return CPU_DISASSEMBLE_NAME(i960)(this, stream, pc, oprom, opram, options);
 }

--- a/src/devices/cpu/i960/i960.h
+++ b/src/devices/cpu/i960/i960.h
@@ -100,7 +100,7 @@ protected:
 	// device_disasm_interface overrides
 	virtual uint32_t disasm_min_opcode_bytes() const override { return 4; }
 	virtual uint32_t disasm_max_opcode_bytes() const override { return 8; }
-	virtual offs_t disasm_disassemble(char *buffer, offs_t pc, const uint8_t *oprom, const uint8_t *opram, uint32_t options) override;
+	virtual offs_t disasm_disassemble(std::ostream &stream, offs_t pc, const uint8_t *oprom, const uint8_t *opram, uint32_t options) override;
 
 private:
 	address_space_config m_program_config;

--- a/src/devices/cpu/i960/i960dis.cpp
+++ b/src/devices/cpu/i960/i960dis.cpp
@@ -293,21 +293,11 @@ static void i960_disassemble(disassemble_t *diss)
 
 
 
-static offs_t internal_disasm_i960(cpu_device *device, std::ostream &stream, offs_t pc, const uint8_t *oprom, const uint8_t *opram, int options)
+CPU_DISASSEMBLE(i960)
 {
 	disassemble_t dis(stream, pc, oprom);
 
 	i960_disassemble(&dis);
 
 	return dis.IPinc | dis.disflags | DASMFLAG_SUPPORTED;
-}
-
-
-CPU_DISASSEMBLE(i960)
-{
-	std::ostringstream stream;
-	offs_t result = internal_disasm_i960(device, stream, pc, oprom, opram, options);
-	std::string stream_str = stream.str();
-	strcpy(buffer, stream_str.c_str());
-	return result;
 }

--- a/src/devices/cpu/ie15/ie15.cpp
+++ b/src/devices/cpu/ie15/ie15.cpp
@@ -171,10 +171,10 @@ uint32_t ie15_device::disasm_max_opcode_bytes() const
 //  helper function
 //-------------------------------------------------
 
-offs_t ie15_device::disasm_disassemble(char *buffer, offs_t pc, const uint8_t *oprom, const uint8_t *opram, uint32_t options)
+offs_t ie15_device::disasm_disassemble(std::ostream &stream, offs_t pc, const uint8_t *oprom, const uint8_t *opram, uint32_t options)
 {
 	extern CPU_DISASSEMBLE( ie15 );
-	return CPU_DISASSEMBLE_NAME(ie15)(nullptr, buffer, pc, oprom, opram, 0);
+	return CPU_DISASSEMBLE_NAME(ie15)(nullptr, stream, pc, oprom, opram, 0);
 }
 
 //**************************************************************************

--- a/src/devices/cpu/ie15/ie15.h
+++ b/src/devices/cpu/ie15/ie15.h
@@ -50,7 +50,7 @@ protected:
 	// device_disasm_interface overrides
 	virtual uint32_t disasm_min_opcode_bytes() const override;
 	virtual uint32_t disasm_max_opcode_bytes() const override;
-	virtual offs_t disasm_disassemble(char *buffer, offs_t pc, const uint8_t *oprom, const uint8_t *opram, uint32_t options) override;
+	virtual offs_t disasm_disassemble(std::ostream &stream, offs_t pc, const uint8_t *oprom, const uint8_t *opram, uint32_t options) override;
 
 	virtual void execute_one(int opcode);
 

--- a/src/devices/cpu/ie15/ie15dasm.cpp
+++ b/src/devices/cpu/ie15/ie15dasm.cpp
@@ -5,7 +5,7 @@
 #define OP(A)   oprom[(A) - PC]
 #define ARG(A)  opram[(A) - PC]
 
-static offs_t internal_disasm_ie15(cpu_device *device, std::ostream &stream, offs_t pc, const uint8_t *oprom, const uint8_t *opram, int options)
+CPU_DISASSEMBLE(ie15)
 {
 	uint32_t flags = 0;
 	uint8_t op;
@@ -122,15 +122,6 @@ static offs_t internal_disasm_ie15(cpu_device *device, std::ostream &stream, off
 			util::stream_format(stream, "ota  #$%02x", op & 0x0f);
 			break;
 	}
+
 	return (pc - PC) | flags | DASMFLAG_SUPPORTED;
-}
-
-
-CPU_DISASSEMBLE(ie15)
-{
-	std::ostringstream stream;
-	offs_t result = internal_disasm_ie15(device, stream, pc, oprom, opram, options);
-	std::string stream_str = stream.str();
-	strcpy(buffer, stream_str.c_str());
-	return result;
 }

--- a/src/devices/cpu/jaguar/jagdasm.cpp
+++ b/src/devices/cpu/jaguar/jagdasm.cpp
@@ -182,24 +182,16 @@ static unsigned dasmjag(int variant, std::ostream &stream, unsigned pc, const ui
 					util::stream_format(stream, "addqmod $%x,r%d", convert_zero[reg1], reg2);
 					break;
 	}
-	return size | flags | DASMFLAG_SUPPORTED;
-}
 
-static unsigned dasmjag(int variant, char *buffer, unsigned pc, const uint8_t *oprom)
-{
-	std::ostringstream stream;
-	unsigned result = dasmjag(variant, stream, pc, oprom);
-	std::string stream_str = stream.str();
-	strcpy(buffer, stream_str.c_str());
-	return result;
+	return size | flags | DASMFLAG_SUPPORTED;
 }
 
 CPU_DISASSEMBLE( jaguargpu )
 {
-	return dasmjag(JAGUAR_VARIANT_GPU, buffer, pc, oprom);
+	return dasmjag(JAGUAR_VARIANT_GPU, stream, pc, oprom);
 }
 
 CPU_DISASSEMBLE( jaguardsp )
 {
-	return dasmjag(JAGUAR_VARIANT_DSP, buffer, pc, oprom);
+	return dasmjag(JAGUAR_VARIANT_DSP, stream, pc, oprom);
 }

--- a/src/devices/cpu/jaguar/jaguar.cpp
+++ b/src/devices/cpu/jaguar/jaguar.cpp
@@ -1430,15 +1430,15 @@ WRITE32_MEMBER( jaguardsp_cpu_device::ctrl_w )
 }
 
 
-offs_t jaguargpu_cpu_device::disasm_disassemble(char *buffer, offs_t pc, const uint8_t *oprom, const uint8_t *opram, uint32_t options)
+offs_t jaguargpu_cpu_device::disasm_disassemble(std::ostream &stream, offs_t pc, const uint8_t *oprom, const uint8_t *opram, uint32_t options)
 {
 	extern CPU_DISASSEMBLE( jaguargpu );
-	return CPU_DISASSEMBLE_NAME(jaguargpu)(this, buffer, pc, oprom, opram, options);
+	return CPU_DISASSEMBLE_NAME(jaguargpu)(this, stream, pc, oprom, opram, options);
 }
 
 
-offs_t jaguardsp_cpu_device::disasm_disassemble(char *buffer, offs_t pc, const uint8_t *oprom, const uint8_t *opram, uint32_t options)
+offs_t jaguardsp_cpu_device::disasm_disassemble(std::ostream &stream, offs_t pc, const uint8_t *oprom, const uint8_t *opram, uint32_t options)
 {
 	extern CPU_DISASSEMBLE( jaguardsp );
-	return CPU_DISASSEMBLE_NAME(jaguardsp)(this, buffer, pc, oprom, opram, options);
+	return CPU_DISASSEMBLE_NAME(jaguardsp)(this, stream, pc, oprom, opram, options);
 }

--- a/src/devices/cpu/jaguar/jaguar.h
+++ b/src/devices/cpu/jaguar/jaguar.h
@@ -258,7 +258,7 @@ public:
 
 protected:
 	virtual void execute_run() override;
-	virtual offs_t disasm_disassemble(char *buffer, offs_t pc, const uint8_t *oprom, const uint8_t *opram, uint32_t options) override;
+	virtual offs_t disasm_disassemble(std::ostream &stream, offs_t pc, const uint8_t *oprom, const uint8_t *opram, uint32_t options) override;
 };
 
 
@@ -275,7 +275,7 @@ protected:
 	virtual uint32_t execute_input_lines() const override { return 6; }
 	virtual void execute_run() override;
 
-	virtual offs_t disasm_disassemble(char *buffer, offs_t pc, const uint8_t *oprom, const uint8_t *opram, uint32_t options) override;
+	virtual offs_t disasm_disassemble(std::ostream &stream, offs_t pc, const uint8_t *oprom, const uint8_t *opram, uint32_t options) override;
 };
 
 

--- a/src/devices/cpu/lc8670/lc8670.h
+++ b/src/devices/cpu/lc8670/lc8670.h
@@ -118,7 +118,7 @@ protected:
 	// device_disasm_interface overrides
 	virtual uint32_t disasm_min_opcode_bytes() const override { return 1; }
 	virtual uint32_t disasm_max_opcode_bytes() const override { return 4; }
-	virtual offs_t disasm_disassemble(char *buffer, offs_t pc, const uint8_t *oprom, const uint8_t *opram, uint32_t options) override;
+	virtual offs_t disasm_disassemble(std::ostream &stream, offs_t pc, const uint8_t *oprom, const uint8_t *opram, uint32_t options) override;
 
 private:
 	// helpers
@@ -259,8 +259,6 @@ private:
 		OP_D9B3,
 		OP_RII8
 	};
-
-	offs_t disasm_disassemble(std::ostream &stream, offs_t pc, const uint8_t *oprom, const uint8_t *opram, uint32_t options);
 
 	// disasm table
 	struct dasm_entry

--- a/src/devices/cpu/lc8670/lc8670dsm.cpp
+++ b/src/devices/cpu/lc8670/lc8670dsm.cpp
@@ -173,17 +173,3 @@ offs_t lc8670_cpu_device::disasm_disassemble(std::ostream &stream, offs_t pc, co
 
 	return pos;
 }
-
-//-------------------------------------------------
-//  disasm_disassemble - call the disassembly
-//  helper function
-//-------------------------------------------------
-
-offs_t lc8670_cpu_device::disasm_disassemble(char *buffer, offs_t pc, const uint8_t *oprom, const uint8_t *opram, uint32_t options)
-{
-	std::ostringstream stream;
-	offs_t result = disasm_disassemble(stream, pc, oprom, opram, options);
-	std::string stream_str = stream.str();
-	strcpy(buffer, stream_str.c_str());
-	return result;
-}

--- a/src/devices/cpu/lh5801/5801dasm.cpp
+++ b/src/devices/cpu/lh5801/5801dasm.cpp
@@ -663,7 +663,7 @@ const Entry Entry::table_fd[0x100]={
 } // anonymous namespace
 
 
-static offs_t internal_disasm_lh5801(cpu_device *device, std::ostream &stream, offs_t pc, const uint8_t *oprom, const uint8_t *opram, int options)
+CPU_DISASSEMBLE(lh5801)
 {
 	int pos = 0;
 	int oper;
@@ -746,14 +746,4 @@ static offs_t internal_disasm_lh5801(cpu_device *device, std::ostream &stream, o
 	}
 
 	return pos;
-}
-
-
-CPU_DISASSEMBLE(lh5801)
-{
-	std::ostringstream stream;
-	offs_t result = internal_disasm_lh5801(device, stream, pc, oprom, opram, options);
-	std::string stream_str = stream.str();
-	strcpy(buffer, stream_str.c_str());
-	return result;
 }

--- a/src/devices/cpu/lh5801/lh5801.cpp
+++ b/src/devices/cpu/lh5801/lh5801.cpp
@@ -248,8 +248,8 @@ void lh5801_cpu_device::execute_set_input(int irqline, int state)
 	}
 }
 
-offs_t lh5801_cpu_device::disasm_disassemble(char *buffer, offs_t pc, const uint8_t *oprom, const uint8_t *opram, uint32_t options)
+offs_t lh5801_cpu_device::disasm_disassemble(std::ostream &stream, offs_t pc, const uint8_t *oprom, const uint8_t *opram, uint32_t options)
 {
 	extern CPU_DISASSEMBLE( lh5801 );
-	return CPU_DISASSEMBLE_NAME(lh5801)(this, buffer, pc, oprom, opram, options);
+	return CPU_DISASSEMBLE_NAME(lh5801)(this, stream, pc, oprom, opram, options);
 }

--- a/src/devices/cpu/lh5801/lh5801.h
+++ b/src/devices/cpu/lh5801/lh5801.h
@@ -95,7 +95,7 @@ protected:
 	// device_disasm_interface overrides
 	virtual uint32_t disasm_min_opcode_bytes() const override { return 1; }
 	virtual uint32_t disasm_max_opcode_bytes() const override { return 5; }
-	virtual offs_t disasm_disassemble(char *buffer, offs_t pc, const uint8_t *oprom, const uint8_t *opram, uint32_t options) override;
+	virtual offs_t disasm_disassemble(std::ostream &stream, offs_t pc, const uint8_t *oprom, const uint8_t *opram, uint32_t options) override;
 
 private:
 	address_space_config m_program_config;

--- a/src/devices/cpu/lr35902/lr35902.cpp
+++ b/src/devices/cpu/lr35902/lr35902.cpp
@@ -226,10 +226,10 @@ void lr35902_cpu_device::device_reset()
 }
 
 
-offs_t lr35902_cpu_device::disasm_disassemble(char *buffer, offs_t pc, const uint8_t *oprom, const uint8_t *opram, uint32_t options)
+offs_t lr35902_cpu_device::disasm_disassemble(std::ostream &stream, offs_t pc, const uint8_t *oprom, const uint8_t *opram, uint32_t options)
 {
 	extern CPU_DISASSEMBLE( lr35902 );
-	return CPU_DISASSEMBLE_NAME(lr35902)(this, buffer, pc, oprom, opram, options);
+	return CPU_DISASSEMBLE_NAME(lr35902)(this, stream, pc, oprom, opram, options);
 }
 
 

--- a/src/devices/cpu/lr35902/lr35902.h
+++ b/src/devices/cpu/lr35902/lr35902.h
@@ -91,7 +91,7 @@ protected:
 	// device_disasm_interface overrides
 	virtual uint32_t disasm_min_opcode_bytes() const override { return 1; }
 	virtual uint32_t disasm_max_opcode_bytes() const override { return 4; }
-	virtual offs_t disasm_disassemble(char *buffer, offs_t pc, const uint8_t *oprom, const uint8_t *opram, uint32_t options) override;
+	virtual offs_t disasm_disassemble(std::ostream &stream, offs_t pc, const uint8_t *oprom, const uint8_t *opram, uint32_t options) override;
 
 	inline void cycles_passed(uint8_t cycles);
 	inline uint8_t mem_read_byte(uint16_t addr);

--- a/src/devices/cpu/lr35902/lr35902d.cpp
+++ b/src/devices/cpu/lr35902/lr35902d.cpp
@@ -190,7 +190,7 @@ static const lr35902dasm mnemonic_main[256]= {
  * Disassemble opcode at PC and return number of bytes it takes
  ****************************************************************************/
 
-static offs_t internal_disasm_lr35902(cpu_device *device, std::ostream &stream, offs_t pc, const uint8_t *oprom, const uint8_t *opram, int options)
+CPU_DISASSEMBLE(lr35902)
 {
 	const lr35902dasm *d;
 	const char /* *symbol,*/ *src;
@@ -272,14 +272,4 @@ static offs_t internal_disasm_lr35902(cpu_device *device, std::ostream &stream, 
 	}
 
 	return pos | s_flags[d->mnemonic] | DASMFLAG_SUPPORTED;
-}
-
-
-CPU_DISASSEMBLE(lr35902)
-{
-	std::ostringstream stream;
-	offs_t result = internal_disasm_lr35902(device, stream, pc, oprom, opram, options);
-	std::string stream_str = stream.str();
-	strcpy(buffer, stream_str.c_str());
-	return result;
 }

--- a/src/devices/cpu/m37710/m37710.cpp
+++ b/src/devices/cpu/m37710/m37710.cpp
@@ -939,13 +939,13 @@ void m37710_cpu_device::m37710_set_irq_line(int line, int state)
 
 CPU_DISASSEMBLE( m37710 )
 {
-	return m7700_disassemble(buffer, (pc&0xffff), pc>>16, oprom, 0, 0);
+	return m7700_disassemble(stream, (pc&0xffff), pc>>16, oprom, 0, 0);
 }
 
 
-offs_t m37710_cpu_device::disasm_disassemble(char *buffer, offs_t pc, const uint8_t *oprom, const uint8_t *opram, uint32_t options)
+offs_t m37710_cpu_device::disasm_disassemble(std::ostream &stream, offs_t pc, const uint8_t *oprom, const uint8_t *opram, uint32_t options)
 {
-	return m7700_disassemble(buffer, (pc&0xffff), pc>>16, oprom, FLAG_M, FLAG_X);
+	return m7700_disassemble(stream, (pc&0xffff), pc>>16, oprom, FLAG_M, FLAG_X);
 }
 
 

--- a/src/devices/cpu/m37710/m37710.h
+++ b/src/devices/cpu/m37710/m37710.h
@@ -122,7 +122,7 @@ protected:
 	// device_disasm_interface overrides
 	virtual uint32_t disasm_min_opcode_bytes() const override { return 1; }
 	virtual uint32_t disasm_max_opcode_bytes() const override { return 6; }
-	virtual offs_t disasm_disassemble(char *buffer, offs_t pc, const uint8_t *oprom, const uint8_t *opram, uint32_t options) override;
+	virtual offs_t disasm_disassemble(std::ostream &stream, offs_t pc, const uint8_t *oprom, const uint8_t *opram, uint32_t options) override;
 
 private:
 	address_space_config m_program_config;

--- a/src/devices/cpu/m37710/m7700ds.cpp
+++ b/src/devices/cpu/m37710/m7700ds.cpp
@@ -636,26 +636,7 @@ int m7700_disassemble(std::ostream &stream, unsigned int pc, unsigned int pb, co
 	return length | flags | DASMFLAG_SUPPORTED;
 }
 
-int m7700_disassemble(char *buffer, unsigned int pc, unsigned int pb, const uint8_t *oprom, int m_flag, int x_flag)
-{
-	std::ostringstream stream;
-	offs_t result = m7700_disassemble(stream, pc, pb, oprom, m_flag, x_flag);
-	std::string stream_str = stream.str();
-	strcpy(buffer, stream_str.c_str());
-	return result;
-}
-
-static offs_t internal_disasm_m37710_generic(cpu_device *device, std::ostream &stream, offs_t pc, const uint8_t *oprom, const uint8_t *opram, int options)
-{
-	return m7700_disassemble(stream, (pc&0xffff), pc>>16, oprom, 0, 0);
-}
-
-
 CPU_DISASSEMBLE(m37710_generic)
 {
-	std::ostringstream stream;
-	offs_t result = internal_disasm_m37710_generic(device, stream, pc, oprom, opram, options);
-	std::string stream_str = stream.str();
-	strcpy(buffer, stream_str.c_str());
-	return result;
+	return m7700_disassemble(stream, (pc&0xffff), pc>>16, oprom, 0, 0);
 }

--- a/src/devices/cpu/m37710/m7700ds.h
+++ b/src/devices/cpu/m37710/m7700ds.h
@@ -19,7 +19,5 @@ All rights reserved.
 */
 
 int m7700_disassemble(std::ostream &stream, unsigned int pc, unsigned int pb, const uint8_t *oprom, int m_flag, int x_flag);
-int m7700_disassemble(char* buff, unsigned int pc, unsigned int pb, const uint8_t *oprom, int m_flag, int x_flag);
-int m7700_disassemble(std::ostream &stream, unsigned int pc, unsigned int pb, const uint8_t *oprom, int m_flag, int x_flag);
 
 #endif /* __M7700DS_H__ */

--- a/src/devices/cpu/m37710/m7700ds.h
+++ b/src/devices/cpu/m37710/m7700ds.h
@@ -20,5 +20,6 @@ All rights reserved.
 
 int m7700_disassemble(std::ostream &stream, unsigned int pc, unsigned int pb, const uint8_t *oprom, int m_flag, int x_flag);
 int m7700_disassemble(char* buff, unsigned int pc, unsigned int pb, const uint8_t *oprom, int m_flag, int x_flag);
+int m7700_disassemble(std::ostream &stream, unsigned int pc, unsigned int pb, const uint8_t *oprom, int m_flag, int x_flag);
 
 #endif /* __M7700DS_H__ */

--- a/src/devices/cpu/m6502/deco16.cpp
+++ b/src/devices/cpu/m6502/deco16.cpp
@@ -22,9 +22,9 @@ deco16_device::deco16_device(const machine_config &mconfig, const char *tag, dev
 {
 }
 
-offs_t deco16_device::disasm_disassemble(char *buffer, offs_t pc, const uint8_t *oprom, const uint8_t *opram, uint32_t options)
+offs_t deco16_device::disasm_disassemble(std::ostream &stream, offs_t pc, const uint8_t *oprom, const uint8_t *opram, uint32_t options)
 {
-	return disassemble_generic(buffer, pc, oprom, opram, options, disasm_entries);
+	return disassemble_generic(stream, pc, oprom, opram, options, disasm_entries);
 }
 
 

--- a/src/devices/cpu/m6502/deco16.h
+++ b/src/devices/cpu/m6502/deco16.h
@@ -19,7 +19,7 @@ public:
 
 	static const disasm_entry disasm_entries[0x100];
 
-	virtual offs_t disasm_disassemble(char *buffer, offs_t pc, const uint8_t *oprom, const uint8_t *opram, uint32_t options) override;
+	virtual offs_t disasm_disassemble(std::ostream &stream, offs_t pc, const uint8_t *oprom, const uint8_t *opram, uint32_t options) override;
 	virtual void do_exec_full() override;
 	virtual void do_exec_partial() override;
 

--- a/src/devices/cpu/m6502/m4510.cpp
+++ b/src/devices/cpu/m6502/m4510.cpp
@@ -26,9 +26,9 @@ m4510_device::m4510_device(const machine_config &mconfig, const char *tag, devic
 	sprogram_config.m_page_shift = 13;
 }
 
-offs_t m4510_device::disasm_disassemble(char *buffer, offs_t pc, const uint8_t *oprom, const uint8_t *opram, uint32_t options)
+offs_t m4510_device::disasm_disassemble(std::ostream &stream, offs_t pc, const uint8_t *oprom, const uint8_t *opram, uint32_t options)
 {
-	return disassemble_generic(buffer, pc, oprom, opram, options, disasm_entries);
+	return disassemble_generic(stream, pc, oprom, opram, options, disasm_entries);
 }
 
 void m4510_device::device_start()

--- a/src/devices/cpu/m6502/m4510.h
+++ b/src/devices/cpu/m6502/m4510.h
@@ -19,7 +19,7 @@ public:
 
 	static const disasm_entry disasm_entries[0x100];
 
-	virtual offs_t disasm_disassemble(char *buffer, offs_t pc, const uint8_t *oprom, const uint8_t *opram, uint32_t options) override;
+	virtual offs_t disasm_disassemble(std::ostream &stream, offs_t pc, const uint8_t *oprom, const uint8_t *opram, uint32_t options) override;
 	virtual void do_exec_full() override;
 	virtual void do_exec_partial() override;
 

--- a/src/devices/cpu/m6502/m6502.cpp
+++ b/src/devices/cpu/m6502/m6502.cpp
@@ -628,15 +628,6 @@ offs_t m6502_device::disassemble_generic(std::ostream &stream, offs_t pc, const 
 	return flags;
 }
 
-offs_t m6502_device::disassemble_generic(char *buffer, offs_t pc, const uint8_t *oprom, const uint8_t *opram, uint32_t options, const disasm_entry *table)
-{
-	std::ostringstream stream;
-	offs_t result = disassemble_generic(stream, pc, oprom, opram, options, table);
-	std::string stream_str = stream.str();
-	strcpy(buffer, stream_str.c_str());
-	return result;
-}
-
 void m6502_device::prefetch()
 {
 	sync = true;
@@ -673,9 +664,9 @@ void m6502_device::set_nz(uint8_t v)
 		P |= F_Z;
 }
 
-offs_t m6502_device::disasm_disassemble(char *buffer, offs_t pc, const uint8_t *oprom, const uint8_t *opram, uint32_t options)
+offs_t m6502_device::disasm_disassemble(std::ostream &stream, offs_t pc, const uint8_t *oprom, const uint8_t *opram, uint32_t options)
 {
-	return disassemble_generic(buffer, pc, oprom, opram, options, disasm_entries);
+	return disassemble_generic(stream, pc, oprom, opram, options, disasm_entries);
 }
 
 

--- a/src/devices/cpu/m6502/m6502.h
+++ b/src/devices/cpu/m6502/m6502.h
@@ -146,7 +146,7 @@ protected:
 	// device_disasm_interface overrides
 	virtual uint32_t disasm_min_opcode_bytes() const override;
 	virtual uint32_t disasm_max_opcode_bytes() const override;
-	virtual offs_t disasm_disassemble(char *buffer, offs_t pc, const uint8_t *oprom, const uint8_t *opram, uint32_t options) override;
+	virtual offs_t disasm_disassemble(std::ostream &stream, offs_t pc, const uint8_t *oprom, const uint8_t *opram, uint32_t options) override;
 
 	address_space_config program_config, sprogram_config;
 
@@ -172,7 +172,6 @@ protected:
 	static const disasm_entry disasm_entries[0x100];
 
 	offs_t disassemble_generic(std::ostream &stream, offs_t pc, const uint8_t *oprom, const uint8_t *opram, uint32_t options, const disasm_entry *table);
-	offs_t disassemble_generic(char *buffer, offs_t pc, const uint8_t *oprom, const uint8_t *opram, uint32_t options, const disasm_entry *table);
 	uint8_t read(uint16_t adr) { return mintf->read(adr); }
 	uint8_t read_9(uint16_t adr) { return mintf->read_9(adr); }
 	void write(uint16_t adr, uint8_t val) { mintf->write(adr, val); }

--- a/src/devices/cpu/m6502/m6509.cpp
+++ b/src/devices/cpu/m6502/m6509.cpp
@@ -54,9 +54,9 @@ void m6509_device::state_export(const device_state_entry &entry)
 	}
 }
 
-offs_t m6509_device::disasm_disassemble(char *buffer, offs_t pc, const uint8_t *oprom, const uint8_t *opram, uint32_t options)
+offs_t m6509_device::disasm_disassemble(std::ostream &stream, offs_t pc, const uint8_t *oprom, const uint8_t *opram, uint32_t options)
 {
-	return disassemble_generic(buffer, pc, oprom, opram, options, disasm_entries);
+	return disassemble_generic(stream, pc, oprom, opram, options, disasm_entries);
 }
 
 

--- a/src/devices/cpu/m6502/m6509.h
+++ b/src/devices/cpu/m6502/m6509.h
@@ -19,7 +19,7 @@ public:
 
 	static const disasm_entry disasm_entries[0x100];
 
-	virtual offs_t disasm_disassemble(char *buffer, offs_t pc, const uint8_t *oprom, const uint8_t *opram, uint32_t options) override;
+	virtual offs_t disasm_disassemble(std::ostream &stream, offs_t pc, const uint8_t *oprom, const uint8_t *opram, uint32_t options) override;
 	virtual void do_exec_full() override;
 	virtual void do_exec_partial() override;
 

--- a/src/devices/cpu/m6502/m6510.cpp
+++ b/src/devices/cpu/m6502/m6510.cpp
@@ -37,9 +37,9 @@ void m6510_device::set_pulls(uint8_t _pullup, uint8_t _floating)
 	floating = _floating;
 }
 
-offs_t m6510_device::disasm_disassemble(char *buffer, offs_t pc, const uint8_t *oprom, const uint8_t *opram, uint32_t options)
+offs_t m6510_device::disasm_disassemble(std::ostream &stream, offs_t pc, const uint8_t *oprom, const uint8_t *opram, uint32_t options)
 {
-	return disassemble_generic(buffer, pc, oprom, opram, options, disasm_entries);
+	return disassemble_generic(stream, pc, oprom, opram, options, disasm_entries);
 }
 
 void m6510_device::device_start()

--- a/src/devices/cpu/m6502/m6510.h
+++ b/src/devices/cpu/m6502/m6510.h
@@ -34,7 +34,7 @@ public:
 
 	static const disasm_entry disasm_entries[0x100];
 
-	virtual offs_t disasm_disassemble(char *buffer, offs_t pc, const uint8_t *oprom, const uint8_t *opram, uint32_t options) override;
+	virtual offs_t disasm_disassemble(std::ostream &stream, offs_t pc, const uint8_t *oprom, const uint8_t *opram, uint32_t options) override;
 	virtual void do_exec_full() override;
 	virtual void do_exec_partial() override;
 

--- a/src/devices/cpu/m6502/m65c02.cpp
+++ b/src/devices/cpu/m6502/m65c02.cpp
@@ -24,9 +24,9 @@ m65c02_device::m65c02_device(const machine_config &mconfig, device_type type, co
 {
 }
 
-offs_t m65c02_device::disasm_disassemble(char *buffer, offs_t pc, const uint8_t *oprom, const uint8_t *opram, uint32_t options)
+offs_t m65c02_device::disasm_disassemble(std::ostream &stream, offs_t pc, const uint8_t *oprom, const uint8_t *opram, uint32_t options)
 {
-	return disassemble_generic(buffer, pc, oprom, opram, options, disasm_entries);
+	return disassemble_generic(stream, pc, oprom, opram, options, disasm_entries);
 }
 
 #include "cpu/m6502/m65c02.hxx"

--- a/src/devices/cpu/m6502/m65c02.h
+++ b/src/devices/cpu/m6502/m65c02.h
@@ -21,7 +21,7 @@ public:
 
 	static const disasm_entry disasm_entries[0x100];
 
-	virtual offs_t disasm_disassemble(char *buffer, offs_t pc, const uint8_t *oprom, const uint8_t *opram, uint32_t options) override;
+	virtual offs_t disasm_disassemble(std::ostream &stream, offs_t pc, const uint8_t *oprom, const uint8_t *opram, uint32_t options) override;
 	virtual void do_exec_full() override;
 	virtual void do_exec_partial() override;
 

--- a/src/devices/cpu/m6502/m65ce02.cpp
+++ b/src/devices/cpu/m6502/m65ce02.cpp
@@ -23,9 +23,9 @@ m65ce02_device::m65ce02_device(const machine_config &mconfig, device_type type, 
 {
 }
 
-offs_t m65ce02_device::disasm_disassemble(char *buffer, offs_t pc, const uint8_t *oprom, const uint8_t *opram, uint32_t options)
+offs_t m65ce02_device::disasm_disassemble(std::ostream &stream, offs_t pc, const uint8_t *oprom, const uint8_t *opram, uint32_t options)
 {
-	return disassemble_generic(buffer, pc, oprom, opram, options, disasm_entries);
+	return disassemble_generic(stream, pc, oprom, opram, options, disasm_entries);
 }
 
 void m65ce02_device::init()

--- a/src/devices/cpu/m6502/m65ce02.h
+++ b/src/devices/cpu/m6502/m65ce02.h
@@ -20,7 +20,7 @@ public:
 
 	static const disasm_entry disasm_entries[0x100];
 
-	virtual offs_t disasm_disassemble(char *buffer, offs_t pc, const uint8_t *oprom, const uint8_t *opram, uint32_t options) override;
+	virtual offs_t disasm_disassemble(std::ostream &stream, offs_t pc, const uint8_t *oprom, const uint8_t *opram, uint32_t options) override;
 	virtual void do_exec_full() override;
 	virtual void do_exec_partial() override;
 

--- a/src/devices/cpu/m6502/m740.cpp
+++ b/src/devices/cpu/m6502/m740.cpp
@@ -23,9 +23,9 @@ m740_device::m740_device(const machine_config &mconfig, device_type type, const 
 {
 }
 
-offs_t m740_device::disasm_disassemble(char *buffer, offs_t pc, const uint8_t *oprom, const uint8_t *opram, uint32_t options)
+offs_t m740_device::disasm_disassemble(std::ostream &stream, offs_t pc, const uint8_t *oprom, const uint8_t *opram, uint32_t options)
 {
-	return disassemble_generic(buffer, pc, oprom, opram, options, disasm_entries);
+	return disassemble_generic(stream, pc, oprom, opram, options, disasm_entries);
 }
 
 void m740_device::device_start()

--- a/src/devices/cpu/m6502/m740.h
+++ b/src/devices/cpu/m6502/m740.h
@@ -46,7 +46,7 @@ public:
 
 		virtual void state_string_export(const device_state_entry &entry, std::string &str) const override;
 
-		virtual offs_t disasm_disassemble(char *buffer, offs_t pc, const uint8_t *oprom, const uint8_t *opram, uint32_t options) override;
+		virtual offs_t disasm_disassemble(std::ostream &stream, offs_t pc, const uint8_t *oprom, const uint8_t *opram, uint32_t options) override;
 		virtual void do_exec_full() override;
 		virtual void do_exec_partial() override;
 		virtual void execute_set_input(int inputnum, int state) override;

--- a/src/devices/cpu/m6502/n2a03.cpp
+++ b/src/devices/cpu/m6502/n2a03.cpp
@@ -56,9 +56,9 @@ n2a03_device::n2a03_device(const machine_config &mconfig, const char *tag, devic
 {
 }
 
-offs_t n2a03_device::disasm_disassemble(char *buffer, offs_t pc, const uint8_t *oprom, const uint8_t *opram, uint32_t options)
+offs_t n2a03_device::disasm_disassemble(std::ostream &stream, offs_t pc, const uint8_t *oprom, const uint8_t *opram, uint32_t options)
 {
-	return disassemble_generic(buffer, pc, oprom, opram, options, disasm_entries);
+	return disassemble_generic(stream, pc, oprom, opram, options, disasm_entries);
 }
 
 void n2a03_device::device_start()

--- a/src/devices/cpu/m6502/n2a03.h
+++ b/src/devices/cpu/m6502/n2a03.h
@@ -22,7 +22,7 @@ public:
 
 	static const disasm_entry disasm_entries[0x100];
 
-	virtual offs_t disasm_disassemble(char *buffer, offs_t pc, const uint8_t *oprom, const uint8_t *opram, uint32_t options) override;
+	virtual offs_t disasm_disassemble(std::ostream &stream, offs_t pc, const uint8_t *oprom, const uint8_t *opram, uint32_t options) override;
 	virtual void do_exec_full() override;
 	virtual void do_exec_partial() override;
 	virtual void device_clock_changed() override;

--- a/src/devices/cpu/m6502/r65c02.cpp
+++ b/src/devices/cpu/m6502/r65c02.cpp
@@ -23,9 +23,9 @@ r65c02_device::r65c02_device(const machine_config &mconfig, device_type type, co
 {
 }
 
-offs_t r65c02_device::disasm_disassemble(char *buffer, offs_t pc, const uint8_t *oprom, const uint8_t *opram, uint32_t options)
+offs_t r65c02_device::disasm_disassemble(std::ostream &stream, offs_t pc, const uint8_t *oprom, const uint8_t *opram, uint32_t options)
 {
-	return disassemble_generic(buffer, pc, oprom, opram, options, disasm_entries);
+	return disassemble_generic(stream, pc, oprom, opram, options, disasm_entries);
 }
 
 #include "cpu/m6502/r65c02.hxx"

--- a/src/devices/cpu/m6502/r65c02.h
+++ b/src/devices/cpu/m6502/r65c02.h
@@ -20,7 +20,7 @@ public:
 
 	static const disasm_entry disasm_entries[0x100];
 
-	virtual offs_t disasm_disassemble(char *buffer, offs_t pc, const uint8_t *oprom, const uint8_t *opram, uint32_t options) override;
+	virtual offs_t disasm_disassemble(std::ostream &stream, offs_t pc, const uint8_t *oprom, const uint8_t *opram, uint32_t options) override;
 	virtual void do_exec_full() override;
 	virtual void do_exec_partial() override;
 };

--- a/src/devices/cpu/m6800/6800dasm.cpp
+++ b/src/devices/cpu/m6800/6800dasm.cpp
@@ -249,51 +249,42 @@ static unsigned Dasm680x (int subtype, std::ostream &stream, unsigned pc, const 
 	}
 }
 
-static unsigned Dasm680x(int subtype, char *buffer, unsigned pc, const uint8_t *oprom, const uint8_t *opram)
-{
-	std::ostringstream stream;
-	unsigned result = Dasm680x(subtype, stream, pc, oprom, opram);
-	std::string stream_str = stream.str();
-	strcpy(buffer, stream_str.c_str());
-	return result;
-}
-
 CPU_DISASSEMBLE( m6800 )
 {
-	return Dasm680x(6800,buffer,pc,oprom,opram);
+	return Dasm680x(6800,stream,pc,oprom,opram);
 }
 
 CPU_DISASSEMBLE( m6801 )
 {
-	return Dasm680x(6801,buffer,pc,oprom,opram);
+	return Dasm680x(6801,stream,pc,oprom,opram);
 }
 
 CPU_DISASSEMBLE( m6802 )
 {
-	return Dasm680x(6802,buffer,pc,oprom,opram);
+	return Dasm680x(6802,stream,pc,oprom,opram);
 }
 
 CPU_DISASSEMBLE( m6803 )
 {
-	return Dasm680x(6803,buffer,pc,oprom,opram);
+	return Dasm680x(6803,stream,pc,oprom,opram);
 }
 
 CPU_DISASSEMBLE( m6808 )
 {
-	return Dasm680x(6808,buffer,pc,oprom,opram);
+	return Dasm680x(6808,stream,pc,oprom,opram);
 }
 
 CPU_DISASSEMBLE( hd6301 )
 {
-	return Dasm680x(6301,buffer,pc,oprom,opram);
+	return Dasm680x(6301,stream,pc,oprom,opram);
 }
 
 CPU_DISASSEMBLE( hd63701 )
 {
-	return Dasm680x(63701,buffer,pc,oprom,opram);
+	return Dasm680x(63701,stream,pc,oprom,opram);
 }
 
 CPU_DISASSEMBLE( nsc8105 )
 {
-	return Dasm680x(8105,buffer,pc,oprom,opram);
+	return Dasm680x(8105,stream,pc,oprom,opram);
 }

--- a/src/devices/cpu/m6800/m6800.cpp
+++ b/src/devices/cpu/m6800/m6800.cpp
@@ -1752,57 +1752,57 @@ void m6801_cpu_device::m6801_clock_serial()
 	}
 }
 
-offs_t m6800_cpu_device::disasm_disassemble(char *buffer, offs_t pc, const uint8_t *oprom, const uint8_t *opram, uint32_t options)
+offs_t m6800_cpu_device::disasm_disassemble(std::ostream &stream, offs_t pc, const uint8_t *oprom, const uint8_t *opram, uint32_t options)
 {
 	extern CPU_DISASSEMBLE( m6800 );
-	return CPU_DISASSEMBLE_NAME(m6800)(this, buffer, pc, oprom, opram, options);
+	return CPU_DISASSEMBLE_NAME(m6800)(this, stream, pc, oprom, opram, options);
 }
 
 
-offs_t m6801_cpu_device::disasm_disassemble(char *buffer, offs_t pc, const uint8_t *oprom, const uint8_t *opram, uint32_t options)
+offs_t m6801_cpu_device::disasm_disassemble(std::ostream &stream, offs_t pc, const uint8_t *oprom, const uint8_t *opram, uint32_t options)
 {
 	extern CPU_DISASSEMBLE( m6801 );
-	return CPU_DISASSEMBLE_NAME(m6801)(this, buffer, pc, oprom, opram, options);
+	return CPU_DISASSEMBLE_NAME(m6801)(this, stream, pc, oprom, opram, options);
 }
 
 
-offs_t m6802_cpu_device::disasm_disassemble(char *buffer, offs_t pc, const uint8_t *oprom, const uint8_t *opram, uint32_t options)
+offs_t m6802_cpu_device::disasm_disassemble(std::ostream &stream, offs_t pc, const uint8_t *oprom, const uint8_t *opram, uint32_t options)
 {
 	extern CPU_DISASSEMBLE( m6802 );
-	return CPU_DISASSEMBLE_NAME(m6802)(this, buffer, pc, oprom, opram, options);
+	return CPU_DISASSEMBLE_NAME(m6802)(this, stream, pc, oprom, opram, options);
 }
 
 
-offs_t m6803_cpu_device::disasm_disassemble(char *buffer, offs_t pc, const uint8_t *oprom, const uint8_t *opram, uint32_t options)
+offs_t m6803_cpu_device::disasm_disassemble(std::ostream &stream, offs_t pc, const uint8_t *oprom, const uint8_t *opram, uint32_t options)
 {
 	extern CPU_DISASSEMBLE( m6803 );
-	return CPU_DISASSEMBLE_NAME(m6803)(this, buffer, pc, oprom, opram, options);
+	return CPU_DISASSEMBLE_NAME(m6803)(this, stream, pc, oprom, opram, options);
 }
 
 
-offs_t m6808_cpu_device::disasm_disassemble(char *buffer, offs_t pc, const uint8_t *oprom, const uint8_t *opram, uint32_t options)
+offs_t m6808_cpu_device::disasm_disassemble(std::ostream &stream, offs_t pc, const uint8_t *oprom, const uint8_t *opram, uint32_t options)
 {
 	extern CPU_DISASSEMBLE( m6808 );
-	return CPU_DISASSEMBLE_NAME(m6808)(this, buffer, pc, oprom, opram, options);
+	return CPU_DISASSEMBLE_NAME(m6808)(this, stream, pc, oprom, opram, options);
 }
 
 
-offs_t hd6301_cpu_device::disasm_disassemble(char *buffer, offs_t pc, const uint8_t *oprom, const uint8_t *opram, uint32_t options)
+offs_t hd6301_cpu_device::disasm_disassemble(std::ostream &stream, offs_t pc, const uint8_t *oprom, const uint8_t *opram, uint32_t options)
 {
 	extern CPU_DISASSEMBLE( hd6301 );
-	return CPU_DISASSEMBLE_NAME(hd6301)(this, buffer, pc, oprom, opram, options);
+	return CPU_DISASSEMBLE_NAME(hd6301)(this, stream, pc, oprom, opram, options);
 }
 
 
-offs_t hd63701_cpu_device::disasm_disassemble(char *buffer, offs_t pc, const uint8_t *oprom, const uint8_t *opram, uint32_t options)
+offs_t hd63701_cpu_device::disasm_disassemble(std::ostream &stream, offs_t pc, const uint8_t *oprom, const uint8_t *opram, uint32_t options)
 {
 	extern CPU_DISASSEMBLE( hd63701 );
-	return CPU_DISASSEMBLE_NAME(hd63701)(this, buffer, pc, oprom, opram, options);
+	return CPU_DISASSEMBLE_NAME(hd63701)(this, stream, pc, oprom, opram, options);
 }
 
 
-offs_t nsc8105_cpu_device::disasm_disassemble(char *buffer, offs_t pc, const uint8_t *oprom, const uint8_t *opram, uint32_t options)
+offs_t nsc8105_cpu_device::disasm_disassemble(std::ostream &stream, offs_t pc, const uint8_t *oprom, const uint8_t *opram, uint32_t options)
 {
 	extern CPU_DISASSEMBLE( nsc8105 );
-	return CPU_DISASSEMBLE_NAME(nsc8105)(this, buffer, pc, oprom, opram, options);
+	return CPU_DISASSEMBLE_NAME(nsc8105)(this, stream, pc, oprom, opram, options);
 }

--- a/src/devices/cpu/m6800/m6800.h
+++ b/src/devices/cpu/m6800/m6800.h
@@ -109,7 +109,7 @@ protected:
 	// device_disasm_interface overrides
 	virtual uint32_t disasm_min_opcode_bytes() const override { return 1; }
 	virtual uint32_t disasm_max_opcode_bytes() const override { return 4; }
-	virtual offs_t disasm_disassemble(char *buffer, offs_t pc, const uint8_t *oprom, const uint8_t *opram, uint32_t options) override;
+	virtual offs_t disasm_disassemble(std::ostream &stream, offs_t pc, const uint8_t *oprom, const uint8_t *opram, uint32_t options) override;
 
 	address_space_config m_program_config;
 	address_space_config m_decrypted_opcodes_config;
@@ -459,7 +459,7 @@ public:
 protected:
 	virtual uint64_t execute_clocks_to_cycles(uint64_t clocks) const override { return (clocks + 4 - 1) / 4; }
 	virtual uint64_t execute_cycles_to_clocks(uint64_t cycles) const override { return (cycles * 4); }
-	virtual offs_t disasm_disassemble(char *buffer, offs_t pc, const uint8_t *oprom, const uint8_t *opram, uint32_t options) override;
+	virtual offs_t disasm_disassemble(std::ostream &stream, offs_t pc, const uint8_t *oprom, const uint8_t *opram, uint32_t options) override;
 };
 
 
@@ -472,7 +472,7 @@ public:
 protected:
 	virtual uint64_t execute_clocks_to_cycles(uint64_t clocks) const override { return (clocks + 4 - 1) / 4; }
 	virtual uint64_t execute_cycles_to_clocks(uint64_t cycles) const override { return (cycles * 4); }
-	virtual offs_t disasm_disassemble(char *buffer, offs_t pc, const uint8_t *oprom, const uint8_t *opram, uint32_t options) override;
+	virtual offs_t disasm_disassemble(std::ostream &stream, offs_t pc, const uint8_t *oprom, const uint8_t *opram, uint32_t options) override;
 };
 
 
@@ -482,7 +482,7 @@ public:
 	m6803_cpu_device(const machine_config &mconfig, const char *tag, device_t *owner, uint32_t clock);
 
 protected:
-	virtual offs_t disasm_disassemble(char *buffer, offs_t pc, const uint8_t *oprom, const uint8_t *opram, uint32_t options) override;
+	virtual offs_t disasm_disassemble(std::ostream &stream, offs_t pc, const uint8_t *oprom, const uint8_t *opram, uint32_t options) override;
 };
 
 
@@ -492,7 +492,7 @@ public:
 	m6808_cpu_device(const machine_config &mconfig, const char *tag, device_t *owner, uint32_t clock);
 
 protected:
-	virtual offs_t disasm_disassemble(char *buffer, offs_t pc, const uint8_t *oprom, const uint8_t *opram, uint32_t options) override;
+	virtual offs_t disasm_disassemble(std::ostream &stream, offs_t pc, const uint8_t *oprom, const uint8_t *opram, uint32_t options) override;
 };
 
 
@@ -503,7 +503,7 @@ public:
 	hd6301_cpu_device(const machine_config &mconfig, device_type type, const char *name, const char *tag, device_t *owner, uint32_t clock, const char *shortname, const char *source);
 
 protected:
-	virtual offs_t disasm_disassemble(char *buffer, offs_t pc, const uint8_t *oprom, const uint8_t *opram, uint32_t options) override;
+	virtual offs_t disasm_disassemble(std::ostream &stream, offs_t pc, const uint8_t *oprom, const uint8_t *opram, uint32_t options) override;
 };
 
 
@@ -513,7 +513,7 @@ public:
 	hd63701_cpu_device(const machine_config &mconfig, const char *tag, device_t *owner, uint32_t clock);
 
 protected:
-	virtual offs_t disasm_disassemble(char *buffer, offs_t pc, const uint8_t *oprom, const uint8_t *opram, uint32_t options) override;
+	virtual offs_t disasm_disassemble(std::ostream &stream, offs_t pc, const uint8_t *oprom, const uint8_t *opram, uint32_t options) override;
 };
 
 
@@ -523,7 +523,7 @@ public:
 	nsc8105_cpu_device(const machine_config &mconfig, const char *tag, device_t *owner, uint32_t clock);
 
 protected:
-	virtual offs_t disasm_disassemble(char *buffer, offs_t pc, const uint8_t *oprom, const uint8_t *opram, uint32_t options) override;
+	virtual offs_t disasm_disassemble(std::ostream &stream, offs_t pc, const uint8_t *oprom, const uint8_t *opram, uint32_t options) override;
 };
 
 

--- a/src/devices/cpu/m68000/m68000.h
+++ b/src/devices/cpu/m68000/m68000.h
@@ -110,7 +110,6 @@ enum
 };
 
 unsigned int m68k_disassemble_raw(std::ostream &stream, unsigned int pc, const unsigned char* opdata, const unsigned char* argdata, unsigned int cpu_type);
-unsigned int m68k_disassemble_raw(char* str_buff, unsigned int pc, const unsigned char* opdata, const unsigned char* argdata, unsigned int cpu_type);
 
 class m68000_base_device;
 
@@ -137,7 +136,7 @@ public:
 
 	virtual uint32_t disasm_min_opcode_bytes() const override { return 2; };
 	virtual uint32_t disasm_max_opcode_bytes() const override { return 10; };
-	virtual offs_t disasm_disassemble(char *buffer, offs_t pc, const uint8_t *oprom, const uint8_t *opram, uint32_t options) override;
+	virtual offs_t disasm_disassemble(std::ostream &stream, offs_t pc, const uint8_t *oprom, const uint8_t *opram, uint32_t options) override;
 
 
 
@@ -413,7 +412,7 @@ public:
 
 	virtual uint32_t disasm_min_opcode_bytes() const override { return 2; };
 	virtual uint32_t disasm_max_opcode_bytes() const override { return 10; };
-	virtual offs_t disasm_disassemble(char *buffer, offs_t pc, const uint8_t *oprom, const uint8_t *opram, uint32_t options) override;
+	virtual offs_t disasm_disassemble(std::ostream &stream, offs_t pc, const uint8_t *oprom, const uint8_t *opram, uint32_t options) override;
 
 	virtual uint32_t execute_min_cycles() const override { return 4; };
 	virtual uint32_t execute_max_cycles() const override { return 158; };
@@ -432,7 +431,7 @@ public:
 
 	virtual uint32_t disasm_min_opcode_bytes() const override { return 2; };
 	virtual uint32_t disasm_max_opcode_bytes() const override { return 10; };
-	virtual offs_t disasm_disassemble(char *buffer, offs_t pc, const uint8_t *oprom, const uint8_t *opram, uint32_t options) override;
+	virtual offs_t disasm_disassemble(std::ostream &stream, offs_t pc, const uint8_t *oprom, const uint8_t *opram, uint32_t options) override;
 
 	virtual uint32_t execute_min_cycles() const override { return 4; };
 	virtual uint32_t execute_max_cycles() const override { return 158; };
@@ -454,7 +453,7 @@ public:
 
 	virtual uint32_t disasm_min_opcode_bytes() const override { return 2; };
 	virtual uint32_t disasm_max_opcode_bytes() const override { return 10; };
-	virtual offs_t disasm_disassemble(char *buffer, offs_t pc, const uint8_t *oprom, const uint8_t *opram, uint32_t options) override;
+	virtual offs_t disasm_disassemble(std::ostream &stream, offs_t pc, const uint8_t *oprom, const uint8_t *opram, uint32_t options) override;
 
 	virtual uint32_t execute_min_cycles() const override { return 4; };
 	virtual uint32_t execute_max_cycles() const override { return 158; };
@@ -473,7 +472,7 @@ public:
 
 	virtual uint32_t disasm_min_opcode_bytes() const override { return 2; };
 	virtual uint32_t disasm_max_opcode_bytes() const override { return 10; };
-	virtual offs_t disasm_disassemble(char *buffer, offs_t pc, const uint8_t *oprom, const uint8_t *opram, uint32_t options) override;
+	virtual offs_t disasm_disassemble(std::ostream &stream, offs_t pc, const uint8_t *oprom, const uint8_t *opram, uint32_t options) override;
 
 	virtual uint32_t execute_min_cycles() const override { return 4; };
 	virtual uint32_t execute_max_cycles() const override { return 158; };
@@ -492,7 +491,7 @@ public:
 
 	virtual uint32_t disasm_min_opcode_bytes() const override { return 2; };
 	virtual uint32_t disasm_max_opcode_bytes() const override { return 10; };
-	virtual offs_t disasm_disassemble(char *buffer, offs_t pc, const uint8_t *oprom, const uint8_t *opram, uint32_t options) override;
+	virtual offs_t disasm_disassemble(std::ostream &stream, offs_t pc, const uint8_t *oprom, const uint8_t *opram, uint32_t options) override;
 
 	virtual uint32_t execute_min_cycles() const override { return 4; };
 	virtual uint32_t execute_max_cycles() const override { return 158; };
@@ -511,7 +510,7 @@ public:
 
 	virtual uint32_t disasm_min_opcode_bytes() const override { return 2; };
 	virtual uint32_t disasm_max_opcode_bytes() const override { return 20; };
-	virtual offs_t disasm_disassemble(char *buffer, offs_t pc, const uint8_t *oprom, const uint8_t *opram, uint32_t options) override;
+	virtual offs_t disasm_disassemble(std::ostream &stream, offs_t pc, const uint8_t *oprom, const uint8_t *opram, uint32_t options) override;
 
 	virtual uint32_t execute_min_cycles() const override { return 2; };
 	virtual uint32_t execute_max_cycles() const override { return 158; };
@@ -530,7 +529,7 @@ public:
 
 	virtual uint32_t disasm_min_opcode_bytes() const override { return 2; };
 	virtual uint32_t disasm_max_opcode_bytes() const override { return 20; };
-	virtual offs_t disasm_disassemble(char *buffer, offs_t pc, const uint8_t *oprom, const uint8_t *opram, uint32_t options) override;
+	virtual offs_t disasm_disassemble(std::ostream &stream, offs_t pc, const uint8_t *oprom, const uint8_t *opram, uint32_t options) override;
 
 	virtual uint32_t execute_min_cycles() const override { return 2; };
 	virtual uint32_t execute_max_cycles() const override { return 158; };
@@ -549,7 +548,7 @@ public:
 
 	virtual uint32_t disasm_min_opcode_bytes() const override { return 2; };
 	virtual uint32_t disasm_max_opcode_bytes() const override { return 20; };
-	virtual offs_t disasm_disassemble(char *buffer, offs_t pc, const uint8_t *oprom, const uint8_t *opram, uint32_t options) override;
+	virtual offs_t disasm_disassemble(std::ostream &stream, offs_t pc, const uint8_t *oprom, const uint8_t *opram, uint32_t options) override;
 
 	virtual uint32_t execute_min_cycles() const override { return 2; };
 	virtual uint32_t execute_max_cycles() const override { return 158; };
@@ -568,7 +567,7 @@ public:
 
 	virtual uint32_t disasm_min_opcode_bytes() const override { return 2; };
 	virtual uint32_t disasm_max_opcode_bytes() const override { return 20; };
-	virtual offs_t disasm_disassemble(char *buffer, offs_t pc, const uint8_t *oprom, const uint8_t *opram, uint32_t options) override;
+	virtual offs_t disasm_disassemble(std::ostream &stream, offs_t pc, const uint8_t *oprom, const uint8_t *opram, uint32_t options) override;
 
 	virtual uint32_t execute_min_cycles() const override { return 2; };
 	virtual uint32_t execute_max_cycles() const override { return 158; };
@@ -587,7 +586,7 @@ public:
 
 	virtual uint32_t disasm_min_opcode_bytes() const override { return 2; };
 	virtual uint32_t disasm_max_opcode_bytes() const override { return 20; };
-	virtual offs_t disasm_disassemble(char *buffer, offs_t pc, const uint8_t *oprom, const uint8_t *opram, uint32_t options) override;
+	virtual offs_t disasm_disassemble(std::ostream &stream, offs_t pc, const uint8_t *oprom, const uint8_t *opram, uint32_t options) override;
 
 	virtual uint32_t execute_min_cycles() const override { return 2; };
 	virtual uint32_t execute_max_cycles() const override { return 158; };
@@ -608,7 +607,7 @@ public:
 
 	virtual uint32_t disasm_min_opcode_bytes() const override { return 2; };
 	virtual uint32_t disasm_max_opcode_bytes() const override { return 20; };
-	virtual offs_t disasm_disassemble(char *buffer, offs_t pc, const uint8_t *oprom, const uint8_t *opram, uint32_t options) override;
+	virtual offs_t disasm_disassemble(std::ostream &stream, offs_t pc, const uint8_t *oprom, const uint8_t *opram, uint32_t options) override;
 
 	virtual uint32_t execute_min_cycles() const override { return 2; };
 	virtual uint32_t execute_max_cycles() const override { return 158; };
@@ -627,7 +626,7 @@ public:
 
 	virtual uint32_t disasm_min_opcode_bytes() const override { return 2; };
 	virtual uint32_t disasm_max_opcode_bytes() const override { return 20; };
-	virtual offs_t disasm_disassemble(char *buffer, offs_t pc, const uint8_t *oprom, const uint8_t *opram, uint32_t options) override;
+	virtual offs_t disasm_disassemble(std::ostream &stream, offs_t pc, const uint8_t *oprom, const uint8_t *opram, uint32_t options) override;
 
 	virtual uint32_t execute_min_cycles() const override { return 2; };
 	virtual uint32_t execute_max_cycles() const override { return 158; };
@@ -646,7 +645,7 @@ public:
 
 	virtual uint32_t disasm_min_opcode_bytes() const override { return 2; };
 	virtual uint32_t disasm_max_opcode_bytes() const override { return 20; };
-	virtual offs_t disasm_disassemble(char *buffer, offs_t pc, const uint8_t *oprom, const uint8_t *opram, uint32_t options) override;
+	virtual offs_t disasm_disassemble(std::ostream &stream, offs_t pc, const uint8_t *oprom, const uint8_t *opram, uint32_t options) override;
 
 	virtual uint32_t execute_min_cycles() const override { return 2; };
 	virtual uint32_t execute_max_cycles() const override { return 158; };
@@ -665,7 +664,7 @@ public:
 
 	virtual uint32_t disasm_min_opcode_bytes() const override { return 2; };
 	virtual uint32_t disasm_max_opcode_bytes() const override { return 20; };
-	virtual offs_t disasm_disassemble(char *buffer, offs_t pc, const uint8_t *oprom, const uint8_t *opram, uint32_t options) override;
+	virtual offs_t disasm_disassemble(std::ostream &stream, offs_t pc, const uint8_t *oprom, const uint8_t *opram, uint32_t options) override;
 
 	virtual uint32_t execute_min_cycles() const override { return 2; };
 	virtual uint32_t execute_max_cycles() const override { return 158; };
@@ -684,7 +683,7 @@ public:
 
 	virtual uint32_t disasm_min_opcode_bytes() const override { return 2; };
 	virtual uint32_t disasm_max_opcode_bytes() const override { return 20; };
-	virtual offs_t disasm_disassemble(char *buffer, offs_t pc, const uint8_t *oprom, const uint8_t *opram, uint32_t options) override;
+	virtual offs_t disasm_disassemble(std::ostream &stream, offs_t pc, const uint8_t *oprom, const uint8_t *opram, uint32_t options) override;
 
 	virtual uint32_t execute_min_cycles() const override { return 2; };
 	virtual uint32_t execute_max_cycles() const override { return 158; };
@@ -703,7 +702,7 @@ public:
 
 	virtual uint32_t disasm_min_opcode_bytes() const override { return 2; };
 	virtual uint32_t disasm_max_opcode_bytes() const override { return 10; };
-	virtual offs_t disasm_disassemble(char *buffer, offs_t pc, const uint8_t *oprom, const uint8_t *opram, uint32_t options) override;
+	virtual offs_t disasm_disassemble(std::ostream &stream, offs_t pc, const uint8_t *oprom, const uint8_t *opram, uint32_t options) override;
 
 	virtual uint32_t execute_min_cycles() const override { return 4; };
 	virtual uint32_t execute_max_cycles() const override { return 158; };
@@ -728,7 +727,7 @@ public:
 
 	virtual uint32_t disasm_min_opcode_bytes() const override { return 2; };
 	virtual uint32_t disasm_max_opcode_bytes() const override { return 20; };
-	virtual offs_t disasm_disassemble(char *buffer, offs_t pc, const uint8_t *oprom, const uint8_t *opram, uint32_t options) override;
+	virtual offs_t disasm_disassemble(std::ostream &stream, offs_t pc, const uint8_t *oprom, const uint8_t *opram, uint32_t options) override;
 
 	virtual uint32_t execute_min_cycles() const override { return 2; };
 	virtual uint32_t execute_max_cycles() const override { return 158; };
@@ -749,7 +748,7 @@ public:
 
 	virtual uint32_t disasm_min_opcode_bytes() const override { return 2; };
 	virtual uint32_t disasm_max_opcode_bytes() const override { return 20; };
-	virtual offs_t disasm_disassemble(char *buffer, offs_t pc, const uint8_t *oprom, const uint8_t *opram, uint32_t options) override;
+	virtual offs_t disasm_disassemble(std::ostream &stream, offs_t pc, const uint8_t *oprom, const uint8_t *opram, uint32_t options) override;
 
 	virtual uint32_t execute_min_cycles() const override { return 2; };
 	virtual uint32_t execute_max_cycles() const override { return 158; };

--- a/src/devices/cpu/m68000/m68kcpu.cpp
+++ b/src/devices/cpu/m68000/m68kcpu.cpp
@@ -2135,78 +2135,78 @@ void m68000_base_device::init_cpu_coldfire(void)
 
 CPU_DISASSEMBLE( dasm_m68000 )
 {
-	return m68k_disassemble_raw(buffer, pc, oprom, opram, M68K_CPU_TYPE_68000);
+	return m68k_disassemble_raw(stream, pc, oprom, opram, M68K_CPU_TYPE_68000);
 }
 
 CPU_DISASSEMBLE( dasm_m68008 )
 {
-	return m68k_disassemble_raw(buffer, pc, oprom, opram, M68K_CPU_TYPE_68008);
+	return m68k_disassemble_raw(stream, pc, oprom, opram, M68K_CPU_TYPE_68008);
 }
 
 CPU_DISASSEMBLE( dasm_m68010 )
 {
-	return m68k_disassemble_raw(buffer, pc, oprom, opram, M68K_CPU_TYPE_68010);
+	return m68k_disassemble_raw(stream, pc, oprom, opram, M68K_CPU_TYPE_68010);
 }
 
 CPU_DISASSEMBLE( dasm_m68020 )
 {
-	return m68k_disassemble_raw(buffer, pc, oprom, opram, M68K_CPU_TYPE_68020);
+	return m68k_disassemble_raw(stream, pc, oprom, opram, M68K_CPU_TYPE_68020);
 }
 
 CPU_DISASSEMBLE( dasm_m68030 )
 {
-	return m68k_disassemble_raw(buffer, pc, oprom, opram, M68K_CPU_TYPE_68030);
+	return m68k_disassemble_raw(stream, pc, oprom, opram, M68K_CPU_TYPE_68030);
 }
 
 CPU_DISASSEMBLE( dasm_m68ec030 )
 {
-	return m68k_disassemble_raw(buffer, pc, oprom, opram, M68K_CPU_TYPE_68EC030);
+	return m68k_disassemble_raw(stream, pc, oprom, opram, M68K_CPU_TYPE_68EC030);
 }
 
 CPU_DISASSEMBLE( dasm_m68040 )
 {
-	return m68k_disassemble_raw(buffer, pc, oprom, opram, M68K_CPU_TYPE_68040);
+	return m68k_disassemble_raw(stream, pc, oprom, opram, M68K_CPU_TYPE_68040);
 }
 
 CPU_DISASSEMBLE( dasm_m68ec040 )
 {
-	return m68k_disassemble_raw(buffer, pc, oprom, opram, M68K_CPU_TYPE_68EC040);
+	return m68k_disassemble_raw(stream, pc, oprom, opram, M68K_CPU_TYPE_68EC040);
 }
 
 CPU_DISASSEMBLE( dasm_m68lc040 )
 {
-	return m68k_disassemble_raw(buffer, pc, oprom, opram, M68K_CPU_TYPE_68LC040);
+	return m68k_disassemble_raw(stream, pc, oprom, opram, M68K_CPU_TYPE_68LC040);
 }
 
 CPU_DISASSEMBLE( dasm_fscpu32 )
 {
-	return m68k_disassemble_raw(buffer, pc, oprom, opram, M68K_CPU_TYPE_FSCPU32);
+	return m68k_disassemble_raw(stream, pc, oprom, opram, M68K_CPU_TYPE_FSCPU32);
 }
 
 CPU_DISASSEMBLE( dasm_coldfire )
 {
-	return m68k_disassemble_raw(buffer, pc, oprom, opram, M68K_CPU_TYPE_COLDFIRE);
+	return m68k_disassemble_raw(stream, pc, oprom, opram, M68K_CPU_TYPE_COLDFIRE);
 }
 
-offs_t m68000_base_device::disasm_disassemble(char *buffer, offs_t pc, const uint8_t *oprom, const uint8_t *opram, uint32_t options) { return CPU_DISASSEMBLE_NAME(dasm_m68000)(this, buffer, pc, oprom, opram, options); }
-offs_t m68000_device::disasm_disassemble(char *buffer, offs_t pc, const uint8_t *oprom, const uint8_t *opram, uint32_t options) { return CPU_DISASSEMBLE_NAME(dasm_m68000)(this, buffer, pc, oprom, opram, options); }
-offs_t m68301_device::disasm_disassemble(char *buffer, offs_t pc, const uint8_t *oprom, const uint8_t *opram, uint32_t options) { return CPU_DISASSEMBLE_NAME(dasm_m68000)(this, buffer, pc, oprom, opram, options); }
-offs_t m68008_device::disasm_disassemble(char *buffer, offs_t pc, const uint8_t *oprom, const uint8_t *opram, uint32_t options) { return CPU_DISASSEMBLE_NAME(dasm_m68008)(this, buffer, pc, oprom, opram, options); }
-offs_t m68008plcc_device::disasm_disassemble(char *buffer, offs_t pc, const uint8_t *oprom, const uint8_t *opram, uint32_t options) { return CPU_DISASSEMBLE_NAME(dasm_m68008)(this, buffer, pc, oprom, opram, options); }
-offs_t m68010_device::disasm_disassemble(char *buffer, offs_t pc, const uint8_t *oprom, const uint8_t *opram, uint32_t options) { return CPU_DISASSEMBLE_NAME(dasm_m68010)(this, buffer, pc, oprom, opram, options); }
-offs_t m68ec020_device::disasm_disassemble(char *buffer, offs_t pc, const uint8_t *oprom, const uint8_t *opram, uint32_t options) { return CPU_DISASSEMBLE_NAME(dasm_m68020)(this, buffer, pc, oprom, opram, options); }
-offs_t m68020_device::disasm_disassemble(char *buffer, offs_t pc, const uint8_t *oprom, const uint8_t *opram, uint32_t options) { return CPU_DISASSEMBLE_NAME(dasm_m68020)(this, buffer, pc, oprom, opram, options); }
-offs_t m68020fpu_device::disasm_disassemble(char *buffer, offs_t pc, const uint8_t *oprom, const uint8_t *opram, uint32_t options) { return CPU_DISASSEMBLE_NAME(dasm_m68020)(this, buffer, pc, oprom, opram, options); }
-offs_t m68020pmmu_device::disasm_disassemble(char *buffer, offs_t pc, const uint8_t *oprom, const uint8_t *opram, uint32_t options) { return CPU_DISASSEMBLE_NAME(dasm_m68020)(this, buffer, pc, oprom, opram, options); }
-offs_t m68020hmmu_device::disasm_disassemble(char *buffer, offs_t pc, const uint8_t *oprom, const uint8_t *opram, uint32_t options) { return CPU_DISASSEMBLE_NAME(dasm_m68020)(this, buffer, pc, oprom, opram, options); }
-offs_t m68ec030_device::disasm_disassemble(char *buffer, offs_t pc, const uint8_t *oprom, const uint8_t *opram, uint32_t options) { return CPU_DISASSEMBLE_NAME(dasm_m68ec030)(this, buffer, pc, oprom, opram, options); }
-offs_t m68030_device::disasm_disassemble(char *buffer, offs_t pc, const uint8_t *oprom, const uint8_t *opram, uint32_t options) { return CPU_DISASSEMBLE_NAME(dasm_m68030)(this, buffer, pc, oprom, opram, options); }
-offs_t m68ec040_device::disasm_disassemble(char *buffer, offs_t pc, const uint8_t *oprom, const uint8_t *opram, uint32_t options) { return CPU_DISASSEMBLE_NAME(dasm_m68ec040)(this, buffer, pc, oprom, opram, options); }
-offs_t m68lc040_device::disasm_disassemble(char *buffer, offs_t pc, const uint8_t *oprom, const uint8_t *opram, uint32_t options) { return CPU_DISASSEMBLE_NAME(dasm_m68lc040)(this, buffer, pc, oprom, opram, options); }
-offs_t m68040_device::disasm_disassemble(char *buffer, offs_t pc, const uint8_t *oprom, const uint8_t *opram, uint32_t options) { return CPU_DISASSEMBLE_NAME(dasm_m68040)(this, buffer, pc, oprom, opram, options); }
-offs_t scc68070_device::disasm_disassemble(char *buffer, offs_t pc, const uint8_t *oprom, const uint8_t *opram, uint32_t options) { return CPU_DISASSEMBLE_NAME(dasm_m68000)(this, buffer, pc, oprom, opram, options); }
-offs_t fscpu32_device::disasm_disassemble(char *buffer, offs_t pc, const uint8_t *oprom, const uint8_t *opram, uint32_t options) { return CPU_DISASSEMBLE_NAME(dasm_fscpu32)(this, buffer, pc, oprom, opram, options); }
-offs_t mcf5206e_device::disasm_disassemble(char *buffer, offs_t pc, const uint8_t *oprom, const uint8_t *opram, uint32_t options) { return CPU_DISASSEMBLE_NAME(dasm_coldfire)(this, buffer, pc, oprom, opram, options); }
+offs_t m68000_base_device::disasm_disassemble(std::ostream &stream, offs_t pc, const uint8_t *oprom, const uint8_t *opram, uint32_t options) { return CPU_DISASSEMBLE_NAME(dasm_m68000)(this, stream, pc, oprom, opram, options); }
+offs_t m68000_device::disasm_disassemble(std::ostream &stream, offs_t pc, const uint8_t *oprom, const uint8_t *opram, uint32_t options) { return CPU_DISASSEMBLE_NAME(dasm_m68000)(this, stream, pc, oprom, opram, options); }
+offs_t m68301_device::disasm_disassemble(std::ostream &stream, offs_t pc, const uint8_t *oprom, const uint8_t *opram, uint32_t options) { return CPU_DISASSEMBLE_NAME(dasm_m68000)(this, stream, pc, oprom, opram, options); }
+offs_t m68008_device::disasm_disassemble(std::ostream &stream, offs_t pc, const uint8_t *oprom, const uint8_t *opram, uint32_t options) { return CPU_DISASSEMBLE_NAME(dasm_m68008)(this, stream, pc, oprom, opram, options); }
+offs_t m68008plcc_device::disasm_disassemble(std::ostream &stream, offs_t pc, const uint8_t *oprom, const uint8_t *opram, uint32_t options) { return CPU_DISASSEMBLE_NAME(dasm_m68008)(this, stream, pc, oprom, opram, options); }
+offs_t m68010_device::disasm_disassemble(std::ostream &stream, offs_t pc, const uint8_t *oprom, const uint8_t *opram, uint32_t options) { return CPU_DISASSEMBLE_NAME(dasm_m68010)(this, stream, pc, oprom, opram, options); }
+offs_t m68ec020_device::disasm_disassemble(std::ostream &stream, offs_t pc, const uint8_t *oprom, const uint8_t *opram, uint32_t options) { return CPU_DISASSEMBLE_NAME(dasm_m68020)(this, stream, pc, oprom, opram, options); }
+offs_t m68020_device::disasm_disassemble(std::ostream &stream, offs_t pc, const uint8_t *oprom, const uint8_t *opram, uint32_t options) { return CPU_DISASSEMBLE_NAME(dasm_m68020)(this, stream, pc, oprom, opram, options); }
+offs_t m68020fpu_device::disasm_disassemble(std::ostream &stream, offs_t pc, const uint8_t *oprom, const uint8_t *opram, uint32_t options) { return CPU_DISASSEMBLE_NAME(dasm_m68020)(this, stream, pc, oprom, opram, options); }
+offs_t m68020pmmu_device::disasm_disassemble(std::ostream &stream, offs_t pc, const uint8_t *oprom, const uint8_t *opram, uint32_t options) { return CPU_DISASSEMBLE_NAME(dasm_m68020)(this, stream, pc, oprom, opram, options); }
+offs_t m68020hmmu_device::disasm_disassemble(std::ostream &stream, offs_t pc, const uint8_t *oprom, const uint8_t *opram, uint32_t options) { return CPU_DISASSEMBLE_NAME(dasm_m68020)(this, stream, pc, oprom, opram, options); }
+offs_t m68ec030_device::disasm_disassemble(std::ostream &stream, offs_t pc, const uint8_t *oprom, const uint8_t *opram, uint32_t options) { return CPU_DISASSEMBLE_NAME(dasm_m68ec030)(this, stream, pc, oprom, opram, options); }
+offs_t m68030_device::disasm_disassemble(std::ostream &stream, offs_t pc, const uint8_t *oprom, const uint8_t *opram, uint32_t options) { return CPU_DISASSEMBLE_NAME(dasm_m68030)(this, stream, pc, oprom, opram, options); }
+offs_t m68ec040_device::disasm_disassemble(std::ostream &stream, offs_t pc, const uint8_t *oprom, const uint8_t *opram, uint32_t options) { return CPU_DISASSEMBLE_NAME(dasm_m68ec040)(this, stream, pc, oprom, opram, options); }
+offs_t m68lc040_device::disasm_disassemble(std::ostream &stream, offs_t pc, const uint8_t *oprom, const uint8_t *opram, uint32_t options) { return CPU_DISASSEMBLE_NAME(dasm_m68lc040)(this, stream, pc, oprom, opram, options); }
+offs_t m68040_device::disasm_disassemble(std::ostream &stream, offs_t pc, const uint8_t *oprom, const uint8_t *opram, uint32_t options) { return CPU_DISASSEMBLE_NAME(dasm_m68040)(this, stream, pc, oprom, opram, options); }
+offs_t scc68070_device::disasm_disassemble(std::ostream &stream, offs_t pc, const uint8_t *oprom, const uint8_t *opram, uint32_t options) { return CPU_DISASSEMBLE_NAME(dasm_m68000)(this, stream, pc, oprom, opram, options); }
+offs_t fscpu32_device::disasm_disassemble(std::ostream &stream, offs_t pc, const uint8_t *oprom, const uint8_t *opram, uint32_t options) { return CPU_DISASSEMBLE_NAME(dasm_fscpu32)(this, stream, pc, oprom, opram, options); }
+offs_t mcf5206e_device::disasm_disassemble(std::ostream &stream, offs_t pc, const uint8_t *oprom, const uint8_t *opram, uint32_t options) { return CPU_DISASSEMBLE_NAME(dasm_coldfire)(this, stream, pc, oprom, opram, options); }
 
 
 /* Service an interrupt request and start exception processing */

--- a/src/devices/cpu/m68000/m68kdasm.cpp
+++ b/src/devices/cpu/m68000/m68kdasm.cpp
@@ -3900,15 +3900,6 @@ unsigned int m68k_disassemble_raw(std::ostream &stream, unsigned int pc, const u
 	return result;
 }
 
-unsigned int m68k_disassemble_raw(char* str_buff, unsigned int pc, const unsigned char* opdata, const unsigned char* argdata, unsigned int cpu_type)
-{
-	std::ostringstream stream;
-	unsigned int result = m68k_disassemble_raw(stream, pc, opdata, argdata, cpu_type);
-	std::string stream_str = stream.str();
-	strcpy(str_buff, stream_str.c_str());
-	return result;
-}
-
 #ifdef UNUSED_FUNCTION
 /* Check if the instruction is a valid one */
 unsigned int m68k_is_valid_instruction(unsigned int instruction, unsigned int cpu_type)
@@ -4123,42 +4114,42 @@ unsigned int m68k_is_valid_instruction(unsigned int instruction, unsigned int cp
 
 CPU_DISASSEMBLE( m68000 )
 {
-	return m68k_disassemble_raw(buffer, pc, oprom, opram, M68K_CPU_TYPE_68000);
+	return m68k_disassemble_raw(stream, pc, oprom, opram, M68K_CPU_TYPE_68000);
 }
 
 CPU_DISASSEMBLE( m68008 )
 {
-	return m68k_disassemble_raw(buffer, pc, oprom, opram, M68K_CPU_TYPE_68008);
+	return m68k_disassemble_raw(stream, pc, oprom, opram, M68K_CPU_TYPE_68008);
 }
 
 CPU_DISASSEMBLE( m68010 )
 {
-	return m68k_disassemble_raw(buffer, pc, oprom, opram, M68K_CPU_TYPE_68010);
+	return m68k_disassemble_raw(stream, pc, oprom, opram, M68K_CPU_TYPE_68010);
 }
 
 CPU_DISASSEMBLE( m68020 )
 {
-	return m68k_disassemble_raw(buffer, pc, oprom, opram, M68K_CPU_TYPE_68020);
+	return m68k_disassemble_raw(stream, pc, oprom, opram, M68K_CPU_TYPE_68020);
 }
 
 CPU_DISASSEMBLE( m68030 )
 {
-	return m68k_disassemble_raw(buffer, pc, oprom, opram, M68K_CPU_TYPE_68030);
+	return m68k_disassemble_raw(stream, pc, oprom, opram, M68K_CPU_TYPE_68030);
 }
 
 CPU_DISASSEMBLE( m68040 )
 {
-	return m68k_disassemble_raw(buffer, pc, oprom, opram, M68K_CPU_TYPE_68040);
+	return m68k_disassemble_raw(stream, pc, oprom, opram, M68K_CPU_TYPE_68040);
 }
 
 CPU_DISASSEMBLE( m68340 )
 {
-	return m68k_disassemble_raw(buffer, pc, oprom, opram, M68K_CPU_TYPE_FSCPU32);
+	return m68k_disassemble_raw(stream, pc, oprom, opram, M68K_CPU_TYPE_FSCPU32);
 }
 
 CPU_DISASSEMBLE( coldfire )
 {
-	return m68k_disassemble_raw(buffer, pc, oprom, opram, M68K_CPU_TYPE_COLDFIRE);
+	return m68k_disassemble_raw(stream, pc, oprom, opram, M68K_CPU_TYPE_COLDFIRE);
 }
 
 /* ======================================================================== */

--- a/src/devices/cpu/m6805/6805dasm.cpp
+++ b/src/devices/cpu/m6805/6805dasm.cpp
@@ -160,7 +160,7 @@ static const char *const opcode_strings[0x0100] =
 };
 #endif
 
-static offs_t internal_disasm_m6805(cpu_device *device, std::ostream &stream, offs_t pc, const uint8_t *oprom, const uint8_t *opram, int options)
+CPU_DISASSEMBLE(m6805)
 {
 	int code, bit;
 	uint16_t ea;
@@ -222,15 +222,5 @@ static offs_t internal_disasm_m6805(cpu_device *device, std::ostream &stream, of
 		result = 1 | flags | DASMFLAG_SUPPORTED;
 		break;
 	}
-	return result;
-}
-
-
-CPU_DISASSEMBLE(m6805)
-{
-	std::ostringstream stream;
-	offs_t result = internal_disasm_m6805(device, stream, pc, oprom, opram, options);
-	std::string stream_str = stream.str();
-	strcpy(buffer, stream_str.c_str());
 	return result;
 }

--- a/src/devices/cpu/m6805/m6805.cpp
+++ b/src/devices/cpu/m6805/m6805.cpp
@@ -540,10 +540,10 @@ uint32_t m6805_base_device::disasm_max_opcode_bytes() const
 //  helper function
 //-------------------------------------------------
 
-offs_t m6805_base_device::disasm_disassemble(char *buffer, offs_t pc, const uint8_t *oprom, const uint8_t *opram, uint32_t options)
+offs_t m6805_base_device::disasm_disassemble(std::ostream &stream, offs_t pc, const uint8_t *oprom, const uint8_t *opram, uint32_t options)
 {
 	extern CPU_DISASSEMBLE( m6805 );
-	return CPU_DISASSEMBLE_NAME(m6805)(this, buffer, pc, oprom, opram, options);
+	return CPU_DISASSEMBLE_NAME(m6805)(this, stream, pc, oprom, opram, options);
 }
 
 

--- a/src/devices/cpu/m6805/m6805.h
+++ b/src/devices/cpu/m6805/m6805.h
@@ -48,7 +48,7 @@ protected:
 	// device_disasm_interface overrides
 	virtual uint32_t disasm_min_opcode_bytes() const override;
 	virtual uint32_t disasm_max_opcode_bytes() const override;
-	virtual offs_t disasm_disassemble(char *buffer, offs_t pc, const uint8_t *oprom, const uint8_t *opram, uint32_t options) override;
+	virtual offs_t disasm_disassemble(std::ostream &stream, offs_t pc, const uint8_t *oprom, const uint8_t *opram, uint32_t options) override;
 
 	// device_state_interface overrides
 	virtual void state_string_export(const device_state_entry &entry, std::string &str) const override;

--- a/src/devices/cpu/m6809/6x09dasm.cpp
+++ b/src/devices/cpu/m6809/6x09dasm.cpp
@@ -108,7 +108,6 @@ namespace
 		}
 
 		offs_t disassemble(std::ostream &stream, offs_t pc, const uint8_t *oprom, const uint8_t *opram);
-		offs_t disassemble(char *buffer, offs_t pc, const uint8_t *oprom, const uint8_t *opram);
 
 	protected:
 		virtual void indirect(std::ostream &stream, uint8_t pb, const uint8_t *opram, int &p) = 0;
@@ -173,20 +172,6 @@ const opcodeinfo *m6x09_disassembler_base::fetch_opcode(const uint8_t *oprom, in
 		op = nullptr;
 
 	return op;
-}
-
-
-//-------------------------------------------------
-//  disassemble - core of the disassembler
-//-------------------------------------------------
-
-offs_t m6x09_disassembler_base::disassemble(char *buffer, offs_t pc, const uint8_t *oprom, const uint8_t *opram)
-{
-	std::ostringstream stream;
-	offs_t result = disassemble(stream, pc, oprom, opram);
-	std::string stream_str = stream.str();
-	strcpy(buffer, stream_str.c_str());
-	return result;
 }
 
 
@@ -1098,7 +1083,7 @@ CPU_DISASSEMBLE(m6809)
 		"A", "B", "CC", "DP", "inv", "inv", "inv", "inv"
 	};
 	m6x09_disassembler disasm(M6x09_GENERAL, m6809_teregs);
-	return disasm.disassemble(buffer, pc, oprom, opram);
+	return disasm.disassemble(stream, pc, oprom, opram);
 }
 
 
@@ -1114,7 +1099,7 @@ CPU_DISASSEMBLE(hd6309)
 		"A", "B", "CC", "DP", "0",  "0", "E", "F"
 	};
 	m6x09_disassembler disasm(HD6309_EXCLUSIVE, hd6309_teregs);
-	return disasm.disassemble(buffer, pc, oprom, opram);
+	return disasm.disassemble(stream, pc, oprom, opram);
 }
 
 
@@ -1562,5 +1547,5 @@ void konami_disassembler::register_register(std::ostream &stream, uint8_t pb)
 CPU_DISASSEMBLE(konami)
 {
 	konami_disassembler disasm;
-	return disasm.disassemble(buffer, pc, oprom, opram);
+	return disasm.disassemble(stream, pc, oprom, opram);
 }

--- a/src/devices/cpu/m6809/hd6309.cpp
+++ b/src/devices/cpu/m6809/hd6309.cpp
@@ -313,10 +313,10 @@ uint32_t hd6309_device::disasm_max_opcode_bytes() const
 //  helper function
 //-------------------------------------------------
 
-offs_t hd6309_device::disasm_disassemble(char *buffer, offs_t pc, const uint8_t *oprom, const uint8_t *opram, uint32_t options)
+offs_t hd6309_device::disasm_disassemble(std::ostream &stream, offs_t pc, const uint8_t *oprom, const uint8_t *opram, uint32_t options)
 {
 	extern CPU_DISASSEMBLE( hd6309 );
-	return CPU_DISASSEMBLE_NAME(hd6309)(this, buffer, pc, oprom, opram, options);
+	return CPU_DISASSEMBLE_NAME(hd6309)(this, stream, pc, oprom, opram, options);
 }
 
 

--- a/src/devices/cpu/m6809/hd6309.h
+++ b/src/devices/cpu/m6809/hd6309.h
@@ -44,7 +44,7 @@ protected:
 	// device_disasm_interface overrides
 	virtual uint32_t disasm_min_opcode_bytes() const override;
 	virtual uint32_t disasm_max_opcode_bytes() const override;
-	virtual offs_t disasm_disassemble(char *buffer, offs_t pc, const uint8_t *oprom, const uint8_t *opram, uint32_t options) override;
+	virtual offs_t disasm_disassemble(std::ostream &stream, offs_t pc, const uint8_t *oprom, const uint8_t *opram, uint32_t options) override;
 
 	virtual bool is_6809() override { return false; };
 

--- a/src/devices/cpu/m6809/konami.cpp
+++ b/src/devices/cpu/m6809/konami.cpp
@@ -109,10 +109,10 @@ void konami_cpu_device::device_start()
 //  helper function
 //-------------------------------------------------
 
-offs_t konami_cpu_device::disasm_disassemble(char *buffer, offs_t pc, const uint8_t *oprom, const uint8_t *opram, uint32_t options)
+offs_t konami_cpu_device::disasm_disassemble(std::ostream &stream, offs_t pc, const uint8_t *oprom, const uint8_t *opram, uint32_t options)
 {
 	extern CPU_DISASSEMBLE( konami );
-	return CPU_DISASSEMBLE_NAME(konami)(this, buffer, pc, oprom, opram, options);
+	return CPU_DISASSEMBLE_NAME(konami)(this, stream, pc, oprom, opram, options);
 }
 
 

--- a/src/devices/cpu/m6809/konami.h
+++ b/src/devices/cpu/m6809/konami.h
@@ -46,7 +46,7 @@ protected:
 	virtual void execute_run() override;
 
 	// device_disasm_interface overrides
-	virtual offs_t disasm_disassemble(char *buffer, offs_t pc, const uint8_t *oprom, const uint8_t *opram, uint32_t options) override;
+	virtual offs_t disasm_disassemble(std::ostream &stream, offs_t pc, const uint8_t *oprom, const uint8_t *opram, uint32_t options) override;
 
 private:
 	typedef m6809_base_device super;

--- a/src/devices/cpu/m6809/m6809.cpp
+++ b/src/devices/cpu/m6809/m6809.cpp
@@ -373,10 +373,10 @@ uint32_t m6809_base_device::disasm_max_opcode_bytes() const
 //  helper function
 //-------------------------------------------------
 
-offs_t m6809_base_device::disasm_disassemble(char *buffer, offs_t pc, const uint8_t *oprom, const uint8_t *opram, uint32_t options)
+offs_t m6809_base_device::disasm_disassemble(std::ostream &stream, offs_t pc, const uint8_t *oprom, const uint8_t *opram, uint32_t options)
 {
 	extern CPU_DISASSEMBLE( m6809 );
-	return CPU_DISASSEMBLE_NAME(m6809)(this, buffer, pc, oprom, opram, options);
+	return CPU_DISASSEMBLE_NAME(m6809)(this, stream, pc, oprom, opram, options);
 }
 
 

--- a/src/devices/cpu/m6809/m6809.h
+++ b/src/devices/cpu/m6809/m6809.h
@@ -77,7 +77,7 @@ protected:
 	// device_disasm_interface overrides
 	virtual uint32_t disasm_min_opcode_bytes() const override;
 	virtual uint32_t disasm_max_opcode_bytes() const override;
-	virtual offs_t disasm_disassemble(char *buffer, offs_t pc, const uint8_t *oprom, const uint8_t *opram, uint32_t options) override;
+	virtual offs_t disasm_disassemble(std::ostream &stream, offs_t pc, const uint8_t *oprom, const uint8_t *opram, uint32_t options) override;
 
 	// device_state_interface overrides
 	virtual void state_import(const device_state_entry &entry) override;

--- a/src/devices/cpu/mb86233/mb86233.cpp
+++ b/src/devices/cpu/mb86233/mb86233.cpp
@@ -37,10 +37,10 @@ mb86233_cpu_device::mb86233_cpu_device(const machine_config &mconfig, const char
 }
 
 
-offs_t mb86233_cpu_device::disasm_disassemble(char *buffer, offs_t pc, const uint8_t *oprom, const uint8_t *opram, uint32_t options)
+offs_t mb86233_cpu_device::disasm_disassemble(std::ostream &stream, offs_t pc, const uint8_t *oprom, const uint8_t *opram, uint32_t options)
 {
 	extern CPU_DISASSEMBLE( mb86233 );
-	return CPU_DISASSEMBLE_NAME(mb86233)(this, buffer, pc, oprom, opram, options);
+	return CPU_DISASSEMBLE_NAME(mb86233)(this, stream, pc, oprom, opram, options);
 }
 
 

--- a/src/devices/cpu/mb86233/mb86233.h
+++ b/src/devices/cpu/mb86233/mb86233.h
@@ -79,7 +79,7 @@ protected:
 	// device_disasm_interface overrides
 	virtual uint32_t disasm_min_opcode_bytes() const override { return 4; }
 	virtual uint32_t disasm_max_opcode_bytes() const override { return 4; }
-	virtual offs_t disasm_disassemble(char *buffer, offs_t pc, const uint8_t *oprom, const uint8_t *opram, uint32_t options) override;
+	virtual offs_t disasm_disassemble(std::ostream &stream, offs_t pc, const uint8_t *oprom, const uint8_t *opram, uint32_t options) override;
 
 private:
 	address_space_config m_program_config;

--- a/src/devices/cpu/mb86233/mb86233d.cpp
+++ b/src/devices/cpu/mb86233/mb86233d.cpp
@@ -750,18 +750,9 @@ static unsigned dasm_mb86233(std::ostream &stream, uint32_t opcode )
 	return (1 | DASMFLAG_SUPPORTED);
 }
 
-static offs_t internal_disasm_mb86233(cpu_device *device, std::ostream &stream, offs_t pc, const uint8_t *oprom, const uint8_t *opram, int options)
+CPU_DISASSEMBLE(mb86233)
 {
 	uint32_t op = *(uint32_t *)oprom;
 	op = little_endianize_int32(op);
 	return dasm_mb86233(stream, op);
-}
-
-CPU_DISASSEMBLE(mb86233)
-{
-	std::ostringstream stream;
-	offs_t result = internal_disasm_mb86233(device, stream, pc, oprom, opram, options);
-	std::string stream_str = stream.str();
-	strcpy(buffer, stream_str.c_str());
-	return result;
 }

--- a/src/devices/cpu/mb86235/mb86235.cpp
+++ b/src/devices/cpu/mb86235/mb86235.cpp
@@ -123,8 +123,8 @@ void mb86235_cpu_device::state_string_export(const device_state_entry &entry, st
 	}
 }
 
-offs_t mb86235_cpu_device::disasm_disassemble(char *buffer, offs_t pc, const uint8_t *oprom, const uint8_t *opram, uint32_t options)
+offs_t mb86235_cpu_device::disasm_disassemble(std::ostream &stream, offs_t pc, const uint8_t *oprom, const uint8_t *opram, uint32_t options)
 {
 	extern CPU_DISASSEMBLE( mb86235 );
-	return CPU_DISASSEMBLE_NAME(mb86235)(this, buffer, pc, oprom, opram, options);
+	return CPU_DISASSEMBLE_NAME(mb86235)(this, stream, pc, oprom, opram, options);
 }

--- a/src/devices/cpu/mb86235/mb86235.h
+++ b/src/devices/cpu/mb86235/mb86235.h
@@ -47,7 +47,7 @@ protected:
 	// device_disasm_interface overrides
 	virtual uint32_t disasm_min_opcode_bytes() const override { return 8; }
 	virtual uint32_t disasm_max_opcode_bytes() const override { return 8; }
-	virtual offs_t disasm_disassemble(char *buffer, offs_t pc, const uint8_t *oprom, const uint8_t *opram, uint32_t options) override;
+	virtual offs_t disasm_disassemble(std::ostream &stream, offs_t pc, const uint8_t *oprom, const uint8_t *opram, uint32_t options) override;
 
 private:
 	address_space_config m_program_config;

--- a/src/devices/cpu/mb86235/mb86235d.cpp
+++ b/src/devices/cpu/mb86235/mb86235d.cpp
@@ -825,21 +825,10 @@ static unsigned dasm_mb86235(std::ostream &stream, uint32_t pc, uint64_t opcode)
 }
 
 
-
-static offs_t internal_disasm_mb86235(cpu_device *device, std::ostream &stream, offs_t pc, const uint8_t *oprom, const uint8_t *opram, int options)
+CPU_DISASSEMBLE(mb86235)
 {
 	uint64_t op = *(uint64_t*)oprom;
 	op = little_endianize_int64(op);
 
 	return dasm_mb86235(stream, pc, op);
-}
-
-
-CPU_DISASSEMBLE(mb86235)
-{
-	std::ostringstream stream;
-	offs_t result = internal_disasm_mb86235(device, stream, pc, oprom, opram, options);
-	std::string stream_str = stream.str();
-	strcpy(buffer, stream_str.c_str());
-	return result;
 }

--- a/src/devices/cpu/mb88xx/mb88dasm.cpp
+++ b/src/devices/cpu/mb88xx/mb88dasm.cpp
@@ -13,7 +13,7 @@
 #include "mb88xx.h"
 
 
-static offs_t internal_disasm_mb88(cpu_device *device, std::ostream &stream, offs_t pc, const uint8_t *oprom, const uint8_t *opram, int options)
+CPU_DISASSEMBLE(mb88)
 {
 	unsigned startpc = pc;
 	uint8_t op = oprom[pc++ - startpc];
@@ -221,14 +221,4 @@ static offs_t internal_disasm_mb88(cpu_device *device, std::ostream &stream, off
 	}
 
 	return (pc - startpc) | DASMFLAG_SUPPORTED;
-}
-
-
-CPU_DISASSEMBLE(mb88)
-{
-	std::ostringstream stream;
-	offs_t result = internal_disasm_mb88(device, stream, pc, oprom, opram, options);
-	std::string stream_str = stream.str();
-	strcpy(buffer, stream_str.c_str());
-	return result;
 }

--- a/src/devices/cpu/mb88xx/mb88xx.cpp
+++ b/src/devices/cpu/mb88xx/mb88xx.cpp
@@ -163,10 +163,10 @@ mb8844_cpu_device::mb8844_cpu_device(const machine_config &mconfig, const char *
 }
 
 
-offs_t mb88_cpu_device::disasm_disassemble(char *buffer, offs_t pc, const uint8_t *oprom, const uint8_t *opram, uint32_t options)
+offs_t mb88_cpu_device::disasm_disassemble(std::ostream &stream, offs_t pc, const uint8_t *oprom, const uint8_t *opram, uint32_t options)
 {
 	extern CPU_DISASSEMBLE( mb88 );
-	return CPU_DISASSEMBLE_NAME(mb88)(this, buffer, pc, oprom, opram, options);
+	return CPU_DISASSEMBLE_NAME(mb88)(this, stream, pc, oprom, opram, options);
 }
 
 

--- a/src/devices/cpu/mb88xx/mb88xx.h
+++ b/src/devices/cpu/mb88xx/mb88xx.h
@@ -97,7 +97,7 @@ protected:
 	// device_disasm_interface overrides
 	virtual uint32_t disasm_min_opcode_bytes() const override { return 1; }
 	virtual uint32_t disasm_max_opcode_bytes() const override { return 2; }
-	virtual offs_t disasm_disassemble(char *buffer, offs_t pc, const uint8_t *oprom, const uint8_t *opram, uint32_t options) override;
+	virtual offs_t disasm_disassemble(std::ostream &stream, offs_t pc, const uint8_t *oprom, const uint8_t *opram, uint32_t options) override;
 
 private:
 	address_space_config m_program_config;

--- a/src/devices/cpu/mc68hc11/hc11dasm.cpp
+++ b/src/devices/cpu/mc68hc11/hc11dasm.cpp
@@ -1274,7 +1274,7 @@ static uint32_t decode_opcode(std::ostream &stream, uint32_t pc, const M68HC11_O
 	return flags;
 }
 
-static offs_t internal_disasm_hc11(cpu_device *device, std::ostream &stream, offs_t pc, const uint8_t *oprom, const uint8_t *opram, int options)
+CPU_DISASSEMBLE(hc11)
 {
 	uint32_t flags;
 	uint8_t opcode;
@@ -1285,14 +1285,4 @@ static offs_t internal_disasm_hc11(cpu_device *device, std::ostream &stream, off
 	flags = decode_opcode(stream, pc, &opcode_table[opcode]);
 
 	return (rombase-oprom) | flags | DASMFLAG_SUPPORTED;
-}
-
-
-CPU_DISASSEMBLE(hc11)
-{
-	std::ostringstream stream;
-	offs_t result = internal_disasm_hc11(device, stream, pc, oprom, opram, options);
-	std::string stream_str = stream.str();
-	strcpy(buffer, stream_str.c_str());
-	return result;
 }

--- a/src/devices/cpu/mc68hc11/mc68hc11.cpp
+++ b/src/devices/cpu/mc68hc11/mc68hc11.cpp
@@ -54,10 +54,10 @@ mc68hc11_cpu_device::mc68hc11_cpu_device(const machine_config &mconfig, const ch
 }
 
 
-offs_t mc68hc11_cpu_device::disasm_disassemble(char *buffer, offs_t pc, const uint8_t *oprom, const uint8_t *opram, uint32_t options)
+offs_t mc68hc11_cpu_device::disasm_disassemble(std::ostream &stream, offs_t pc, const uint8_t *oprom, const uint8_t *opram, uint32_t options)
 {
 	extern CPU_DISASSEMBLE( hc11 );
-	return CPU_DISASSEMBLE_NAME(hc11)(this, buffer, pc, oprom, opram, options);
+	return CPU_DISASSEMBLE_NAME(hc11)(this, stream, pc, oprom, opram, options);
 }
 
 

--- a/src/devices/cpu/mc68hc11/mc68hc11.h
+++ b/src/devices/cpu/mc68hc11/mc68hc11.h
@@ -75,7 +75,7 @@ protected:
 	// device_disasm_interface overrides
 	virtual uint32_t disasm_min_opcode_bytes() const override { return 1; }
 	virtual uint32_t disasm_max_opcode_bytes() const override { return 5; }
-	virtual offs_t disasm_disassemble(char *buffer, offs_t pc, const uint8_t *oprom, const uint8_t *opram, uint32_t options) override;
+	virtual offs_t disasm_disassemble(std::ostream &stream, offs_t pc, const uint8_t *oprom, const uint8_t *opram, uint32_t options) override;
 
 private:
 	address_space_config m_program_config;

--- a/src/devices/cpu/mcs48/mcs48.cpp
+++ b/src/devices/cpu/mcs48/mcs48.cpp
@@ -324,17 +324,17 @@ i8742_device::i8742_device(const machine_config &mconfig, const char *tag, devic
 }
 
 
-offs_t mcs48_cpu_device::disasm_disassemble(char *buffer, offs_t pc, const uint8_t *oprom, const uint8_t *opram, uint32_t options)
+offs_t mcs48_cpu_device::disasm_disassemble(std::ostream &stream, offs_t pc, const uint8_t *oprom, const uint8_t *opram, uint32_t options)
 {
 	extern CPU_DISASSEMBLE( mcs48 );
-	return CPU_DISASSEMBLE_NAME(mcs48)(this, buffer, pc, oprom, opram, options);
+	return CPU_DISASSEMBLE_NAME(mcs48)(this, stream, pc, oprom, opram, options);
 }
 
 
-offs_t upi41_cpu_device::disasm_disassemble(char *buffer, offs_t pc, const uint8_t *oprom, const uint8_t *opram, uint32_t options)
+offs_t upi41_cpu_device::disasm_disassemble(std::ostream &stream, offs_t pc, const uint8_t *oprom, const uint8_t *opram, uint32_t options)
 {
 	extern CPU_DISASSEMBLE( upi41 );
-	return CPU_DISASSEMBLE_NAME(upi41)(this, buffer, pc, oprom, opram, options);
+	return CPU_DISASSEMBLE_NAME(upi41)(this, stream, pc, oprom, opram, options);
 }
 
 /***************************************************************************

--- a/src/devices/cpu/mcs48/mcs48.h
+++ b/src/devices/cpu/mcs48/mcs48.h
@@ -152,7 +152,7 @@ protected:
 	// device_disasm_interface overrides
 	virtual uint32_t disasm_min_opcode_bytes() const override { return 1; }
 	virtual uint32_t disasm_max_opcode_bytes() const override { return 2; }
-	virtual offs_t disasm_disassemble(char *buffer, offs_t pc, const uint8_t *oprom, const uint8_t *opram, uint32_t options) override;
+	virtual offs_t disasm_disassemble(std::ostream &stream, offs_t pc, const uint8_t *oprom, const uint8_t *opram, uint32_t options) override;
 
 protected:
 	address_space_config m_program_config;
@@ -594,7 +594,7 @@ public:
 	DECLARE_WRITE8_MEMBER(upi41_master_w);
 
 protected:
-	virtual offs_t disasm_disassemble(char *buffer, offs_t pc, const uint8_t *oprom, const uint8_t *opram, uint32_t options) override;
+	virtual offs_t disasm_disassemble(std::ostream &stream, offs_t pc, const uint8_t *oprom, const uint8_t *opram, uint32_t options) override;
 
 	TIMER_CALLBACK_MEMBER( master_callback );
 };

--- a/src/devices/cpu/mcs48/mcs48dsm.cpp
+++ b/src/devices/cpu/mcs48/mcs48dsm.cpp
@@ -315,23 +315,13 @@ static uint32_t common_dasm(device_t *device, std::ostream &stream, offs_t pc, c
 }
 
 
-static uint32_t common_dasm(device_t *device, char *buffer, offs_t pc, const uint8_t *oprom, const uint8_t *opram, bool upi41)
-{
-	std::ostringstream stream;
-	offs_t result = common_dasm(device, stream, pc, oprom, opram, upi41);
-	std::string stream_str = stream.str();
-	strcpy(buffer, stream_str.c_str());
-	return result;
-}
-
-
 CPU_DISASSEMBLE( mcs48 )
 {
-	return common_dasm(device, buffer, pc, oprom, opram, false);
+	return common_dasm(device, stream, pc, oprom, opram, false);
 }
 
 
 CPU_DISASSEMBLE( upi41 )
 {
-	return common_dasm(device, buffer, pc, oprom, opram, true);
+	return common_dasm(device, stream, pc, oprom, opram, true);
 }

--- a/src/devices/cpu/mcs51/mcs51.cpp
+++ b/src/devices/cpu/mcs51/mcs51.cpp
@@ -2462,43 +2462,43 @@ uint8_t ds5002fp_device::sfr_read(size_t offset)
 }
 
 
-offs_t mcs51_cpu_device::disasm_disassemble(char *buffer, offs_t pc, const uint8_t *oprom, const uint8_t *opram, uint32_t options)
+offs_t mcs51_cpu_device::disasm_disassemble(std::ostream &stream, offs_t pc, const uint8_t *oprom, const uint8_t *opram, uint32_t options)
 {
 	extern CPU_DISASSEMBLE( i8051 );
-	return CPU_DISASSEMBLE_NAME(i8051)(this, buffer, pc, oprom, opram, options);
+	return CPU_DISASSEMBLE_NAME(i8051)(this, stream, pc, oprom, opram, options);
 }
 
 
-offs_t i8052_device::disasm_disassemble(char *buffer, offs_t pc, const uint8_t *oprom, const uint8_t *opram, uint32_t options)
+offs_t i8052_device::disasm_disassemble(std::ostream &stream, offs_t pc, const uint8_t *oprom, const uint8_t *opram, uint32_t options)
 {
 	extern CPU_DISASSEMBLE( i8052 );
-	return CPU_DISASSEMBLE_NAME(i8052)(this, buffer, pc, oprom, opram, options);
+	return CPU_DISASSEMBLE_NAME(i8052)(this, stream, pc, oprom, opram, options);
 }
 
 
-offs_t i80c31_device::disasm_disassemble(char *buffer, offs_t pc, const uint8_t *oprom, const uint8_t *opram, uint32_t options)
+offs_t i80c31_device::disasm_disassemble(std::ostream &stream, offs_t pc, const uint8_t *oprom, const uint8_t *opram, uint32_t options)
 {
 	extern CPU_DISASSEMBLE( i80c51 );
-	return CPU_DISASSEMBLE_NAME(i80c51)(this, buffer, pc, oprom, opram, options);
+	return CPU_DISASSEMBLE_NAME(i80c51)(this, stream, pc, oprom, opram, options);
 }
 
 
-offs_t i80c51_device::disasm_disassemble(char *buffer, offs_t pc, const uint8_t *oprom, const uint8_t *opram, uint32_t options)
+offs_t i80c51_device::disasm_disassemble(std::ostream &stream, offs_t pc, const uint8_t *oprom, const uint8_t *opram, uint32_t options)
 {
 	extern CPU_DISASSEMBLE( i80c51 );
-	return CPU_DISASSEMBLE_NAME(i80c51)(this, buffer, pc, oprom, opram, options);
+	return CPU_DISASSEMBLE_NAME(i80c51)(this, stream, pc, oprom, opram, options);
 }
 
 
-offs_t i80c52_device::disasm_disassemble(char *buffer, offs_t pc, const uint8_t *oprom, const uint8_t *opram, uint32_t options)
+offs_t i80c52_device::disasm_disassemble(std::ostream &stream, offs_t pc, const uint8_t *oprom, const uint8_t *opram, uint32_t options)
 {
 	extern CPU_DISASSEMBLE( i80c52 );
-	return CPU_DISASSEMBLE_NAME(i80c52)(this, buffer, pc, oprom, opram, options);
+	return CPU_DISASSEMBLE_NAME(i80c52)(this, stream, pc, oprom, opram, options);
 }
 
 
-offs_t ds5002fp_device::disasm_disassemble(char *buffer, offs_t pc, const uint8_t *oprom, const uint8_t *opram, uint32_t options)
+offs_t ds5002fp_device::disasm_disassemble(std::ostream &stream, offs_t pc, const uint8_t *oprom, const uint8_t *opram, uint32_t options)
 {
 	extern CPU_DISASSEMBLE( ds5002fp );
-	return CPU_DISASSEMBLE_NAME(ds5002fp)(this, buffer, pc, oprom, opram, options);
+	return CPU_DISASSEMBLE_NAME(ds5002fp)(this, stream, pc, oprom, opram, options);
 }

--- a/src/devices/cpu/mcs51/mcs51.h
+++ b/src/devices/cpu/mcs51/mcs51.h
@@ -120,7 +120,7 @@ protected:
 	// device_disasm_interface overrides
 	virtual uint32_t disasm_min_opcode_bytes() const override { return 1; }
 	virtual uint32_t disasm_max_opcode_bytes() const override { return 5; }
-	virtual offs_t disasm_disassemble(char *buffer, offs_t pc, const uint8_t *oprom, const uint8_t *opram, uint32_t options) override;
+	virtual offs_t disasm_disassemble(std::ostream &stream, offs_t pc, const uint8_t *oprom, const uint8_t *opram, uint32_t options) override;
 
 protected:
 	address_space_config m_program_config;
@@ -393,7 +393,7 @@ public:
 	i8052_device(const machine_config &mconfig, device_type type, const char *name, const char *tag, device_t *owner, uint32_t clock, const char *shortname, int program_width, int data_width, uint8_t features = 0);
 
 protected:
-	virtual offs_t disasm_disassemble(char *buffer, offs_t pc, const uint8_t *oprom, const uint8_t *opram, uint32_t options) override;
+	virtual offs_t disasm_disassemble(std::ostream &stream, offs_t pc, const uint8_t *oprom, const uint8_t *opram, uint32_t options) override;
 
 	/* SFR Callbacks */
 	virtual void sfr_write(size_t offset, uint8_t data) override;
@@ -421,7 +421,7 @@ public:
 	i80c31_device(const machine_config &mconfig, const char *tag, device_t *owner, uint32_t clock);
 
 protected:
-	virtual offs_t disasm_disassemble(char *buffer, offs_t pc, const uint8_t *oprom, const uint8_t *opram, uint32_t options) override;
+	virtual offs_t disasm_disassemble(std::ostream &stream, offs_t pc, const uint8_t *oprom, const uint8_t *opram, uint32_t options) override;
 };
 
 
@@ -433,7 +433,7 @@ public:
 	i80c51_device(const machine_config &mconfig, device_type type, const char *name, const char *tag, device_t *owner, uint32_t clock, const char *shortname, int program_width, int data_width, uint8_t features = 0);
 
 protected:
-	virtual offs_t disasm_disassemble(char *buffer, offs_t pc, const uint8_t *oprom, const uint8_t *opram, uint32_t options) override;
+	virtual offs_t disasm_disassemble(std::ostream &stream, offs_t pc, const uint8_t *oprom, const uint8_t *opram, uint32_t options) override;
 };
 
 class i87c51_device : public i80c51_device
@@ -452,7 +452,7 @@ public:
 	i80c52_device(const machine_config &mconfig, device_type type, const char *name, const char *tag, device_t *owner, uint32_t clock, const char *shortname, int program_width, int data_width, uint8_t features = 0);
 
 protected:
-	virtual offs_t disasm_disassemble(char *buffer, offs_t pc, const uint8_t *oprom, const uint8_t *opram, uint32_t options) override;
+	virtual offs_t disasm_disassemble(std::ostream &stream, offs_t pc, const uint8_t *oprom, const uint8_t *opram, uint32_t options) override;
 
 	/* SFR Callbacks */
 	virtual void sfr_write(size_t offset, uint8_t data) override;
@@ -512,7 +512,7 @@ public:
 	static void set_crc(device_t &device, uint8_t crc) { downcast<ds5002fp_device &>(device).m_ds5002fp.crc = crc; }
 
 protected:
-	virtual offs_t disasm_disassemble(char *buffer, offs_t pc, const uint8_t *oprom, const uint8_t *opram, uint32_t options) override;
+	virtual offs_t disasm_disassemble(std::ostream &stream, offs_t pc, const uint8_t *oprom, const uint8_t *opram, uint32_t options) override;
 
 	/* SFR Callbacks */
 	virtual void sfr_write(size_t offset, uint8_t data) override;

--- a/src/devices/cpu/mcs51/mcs51dasm.cpp
+++ b/src/devices/cpu/mcs51/mcs51dasm.cpp
@@ -1147,15 +1147,6 @@ static offs_t mcs51_dasm( const char **mem_names, std::ostream &stream, offs_t p
 	return (PC - pc) | flags | DASMFLAG_SUPPORTED;
 }
 
-static offs_t mcs51_dasm(const char **mem_names, char *dst, offs_t pc, const uint8_t *oprom, const uint8_t *opram)
-{
-	std::ostringstream stream;
-	offs_t result = mcs51_dasm(mem_names, stream, pc, oprom, opram);
-	std::string stream_str = stream.str();
-	strcpy(dst, stream_str.c_str());
-	return result;
-}
-
 CPU_DISASSEMBLE( i8051 )
 {
 	static const char *mem_names[0x200];
@@ -1166,7 +1157,7 @@ CPU_DISASSEMBLE( i8051 )
 		init_mem_names( FEATURE_NONE, mem_names);
 		mem_names_initialized = 1;
 	}
-	return mcs51_dasm(mem_names, buffer, pc, oprom, opram);
+	return mcs51_dasm(mem_names, stream, pc, oprom, opram);
 }
 
 CPU_DISASSEMBLE( i8052 )
@@ -1179,7 +1170,7 @@ CPU_DISASSEMBLE( i8052 )
 		init_mem_names( FEATURE_I8052, mem_names);
 		mem_names_initialized = 1;
 	}
-	return mcs51_dasm(mem_names, buffer, pc, oprom, opram);
+	return mcs51_dasm(mem_names, stream, pc, oprom, opram);
 }
 
 CPU_DISASSEMBLE( i80c51 )
@@ -1192,7 +1183,7 @@ CPU_DISASSEMBLE( i80c51 )
 		init_mem_names( FEATURE_CMOS, mem_names);
 		mem_names_initialized = 1;
 	}
-	return mcs51_dasm(mem_names, buffer, pc, oprom, opram);
+	return mcs51_dasm(mem_names, stream, pc, oprom, opram);
 }
 
 CPU_DISASSEMBLE( i80c52 )
@@ -1205,7 +1196,7 @@ CPU_DISASSEMBLE( i80c52 )
 		init_mem_names( FEATURE_I8052 | FEATURE_CMOS | FEATURE_I80C52, mem_names);
 		mem_names_initialized = 1;
 	}
-	return mcs51_dasm(mem_names, buffer, pc, oprom, opram);
+	return mcs51_dasm(mem_names, stream, pc, oprom, opram);
 }
 
 CPU_DISASSEMBLE( ds5002fp )
@@ -1218,5 +1209,5 @@ CPU_DISASSEMBLE( ds5002fp )
 		init_mem_names( FEATURE_DS5002FP | FEATURE_CMOS, mem_names);
 		mem_names_initialized = 1;
 	}
-	return mcs51_dasm(mem_names, buffer, pc, oprom, opram);
+	return mcs51_dasm(mem_names, stream, pc, oprom, opram);
 }

--- a/src/devices/cpu/mcs96/i8x9x.cpp
+++ b/src/devices/cpu/mcs96/i8x9x.cpp
@@ -18,9 +18,9 @@ i8x9x_device::i8x9x_device(const machine_config &mconfig, device_type type, cons
 {
 }
 
-offs_t i8x9x_device::disasm_disassemble(char *buffer, offs_t pc, const uint8_t *oprom, const uint8_t *opram, uint32_t options)
+offs_t i8x9x_device::disasm_disassemble(std::ostream &stream, offs_t pc, const uint8_t *oprom, const uint8_t *opram, uint32_t options)
 {
-	return disasm_generic(buffer, pc, oprom, opram, options, disasm_entries);
+	return disasm_generic(stream, pc, oprom, opram, options, disasm_entries);
 }
 
 const address_space_config *i8x9x_device::memory_space_config(address_spacenum spacenum) const

--- a/src/devices/cpu/mcs96/i8x9x.h
+++ b/src/devices/cpu/mcs96/i8x9x.h
@@ -32,7 +32,7 @@ protected:
 
 	static const disasm_entry disasm_entries[0x100];
 
-	virtual offs_t disasm_disassemble(char *buffer, offs_t pc, const uint8_t *oprom, const uint8_t *opram, uint32_t options) override;
+	virtual offs_t disasm_disassemble(std::ostream &stream, offs_t pc, const uint8_t *oprom, const uint8_t *opram, uint32_t options) override;
 	virtual void do_exec_full() override;
 	virtual void do_exec_partial() override;
 	virtual void internal_update(uint64_t current_time) override;

--- a/src/devices/cpu/mcs96/i8xc196.cpp
+++ b/src/devices/cpu/mcs96/i8xc196.cpp
@@ -16,9 +16,9 @@ i8xc196_device::i8xc196_device(const machine_config &mconfig, device_type type, 
 {
 }
 
-offs_t i8xc196_device::disasm_disassemble(char *buffer, offs_t pc, const uint8_t *oprom, const uint8_t *opram, uint32_t options)
+offs_t i8xc196_device::disasm_disassemble(std::ostream &stream, offs_t pc, const uint8_t *oprom, const uint8_t *opram, uint32_t options)
 {
-	return disasm_generic(buffer, pc, oprom, opram, options, disasm_entries);
+	return disasm_generic(stream, pc, oprom, opram, options, disasm_entries);
 }
 
 void i8xc196_device::io_w8(uint8_t adr, uint8_t data)

--- a/src/devices/cpu/mcs96/i8xc196.h
+++ b/src/devices/cpu/mcs96/i8xc196.h
@@ -19,7 +19,7 @@ public:
 
 	static const disasm_entry disasm_entries[0x100];
 
-	virtual offs_t disasm_disassemble(char *buffer, offs_t pc, const uint8_t *oprom, const uint8_t *opram, uint32_t options) override;
+	virtual offs_t disasm_disassemble(std::ostream &stream, offs_t pc, const uint8_t *oprom, const uint8_t *opram, uint32_t options) override;
 	virtual void do_exec_full() override;
 	virtual void do_exec_partial() override;
 

--- a/src/devices/cpu/mcs96/mcs96.h
+++ b/src/devices/cpu/mcs96/mcs96.h
@@ -90,14 +90,7 @@ protected:
 	// device_disasm_interface overrides
 	virtual uint32_t disasm_min_opcode_bytes() const override;
 	virtual uint32_t disasm_max_opcode_bytes() const override;
-	virtual offs_t disasm_generic(char *buffer, offs_t pc, const uint8_t *oprom, const uint8_t *opram, uint32_t options, const disasm_entry *entries)
-	{
-		std::ostringstream stream;
-		offs_t result = disasm_generic(stream, pc, oprom, opram, options, entries);
-		std::string stream_str = stream.str();
-		strcpy(buffer, stream_str.c_str());
-		return result;
-	}
+	virtual offs_t disasm_generic(std::ostream &stream, offs_t pc, const uint8_t *oprom, const uint8_t *opram, uint32_t options, const disasm_entry *entries);
 
 	address_space_config program_config;
 	address_space *program;
@@ -252,9 +245,6 @@ protected:
 	O(fetch_noirq);
 
 #undef O
-
-private:
-	offs_t disasm_generic(std::ostream &stream, offs_t pc, const uint8_t *oprom, const uint8_t *opram, uint32_t options, const disasm_entry *entries);
 };
 
 enum {

--- a/src/devices/cpu/melps4/m58846.cpp
+++ b/src/devices/cpu/melps4/m58846.cpp
@@ -30,10 +30,10 @@ m58846_device::m58846_device(const machine_config &mconfig, const char *tag, dev
 
 
 // disasm
-offs_t m58846_device::disasm_disassemble(char *buffer, offs_t pc, const uint8_t *oprom, const uint8_t *opram, uint32_t options)
+offs_t m58846_device::disasm_disassemble(std::ostream &stream, offs_t pc, const uint8_t *oprom, const uint8_t *opram, uint32_t options)
 {
 	extern CPU_DISASSEMBLE(m58846);
-	return CPU_DISASSEMBLE_NAME(m58846)(this, buffer, pc, oprom, opram, options);
+	return CPU_DISASSEMBLE_NAME(m58846)(this, stream, pc, oprom, opram, options);
 }
 
 

--- a/src/devices/cpu/melps4/m58846.h
+++ b/src/devices/cpu/melps4/m58846.h
@@ -28,7 +28,7 @@ protected:
 	virtual void execute_one() override;
 
 	// device_disasm_interface overrides
-	virtual offs_t disasm_disassemble(char *buffer, offs_t pc, const uint8_t *oprom, const uint8_t *opram, uint32_t options) override;
+	virtual offs_t disasm_disassemble(std::ostream &stream, offs_t pc, const uint8_t *oprom, const uint8_t *opram, uint32_t options) override;
 
 	// timers
 	virtual void device_timer(emu_timer &timer, device_timer_id id, int param, void *ptr) override;

--- a/src/devices/cpu/melps4/melps4d.cpp
+++ b/src/devices/cpu/melps4/melps4d.cpp
@@ -100,7 +100,7 @@ static const uint8_t m58846_opmap[0xc0] =
 	em_LA,   em_LA,   em_LA,   em_LA,   em_LA,   em_LA,   em_LA,   em_LA,   em_LA,   em_LA,   em_LA,   em_LA,   em_LA,   em_LA,   em_LA,   em_LA    // Bx
 };
 
-static offs_t internal_disasm_m58846(cpu_device *device, std::ostream &stream, offs_t pc, const uint8_t *oprom, const uint8_t *opram, int options)
+CPU_DISASSEMBLE(m58846)
 {
 	uint16_t op = (oprom[0] | oprom[1] << 8) & 0x1ff;
 
@@ -137,14 +137,4 @@ static offs_t internal_disasm_m58846(cpu_device *device, std::ostream &stream, o
 	}
 
 	return 1 | em_flags[instr] | DASMFLAG_SUPPORTED;
-}
-
-
-CPU_DISASSEMBLE(m58846)
-{
-	std::ostringstream stream;
-	offs_t result = internal_disasm_m58846(device, stream, pc, oprom, opram, options);
-	std::string stream_str = stream.str();
-	strcpy(buffer, stream_str.c_str());
-	return result;
 }

--- a/src/devices/cpu/minx/minx.cpp
+++ b/src/devices/cpu/minx/minx.cpp
@@ -228,8 +228,8 @@ void minx_cpu_device::execute_set_input(int inputnum, int state)
 }
 
 
-offs_t minx_cpu_device::disasm_disassemble(char *buffer, offs_t pc, const uint8_t *oprom, const uint8_t *opram, uint32_t options)
+offs_t minx_cpu_device::disasm_disassemble(std::ostream &stream, offs_t pc, const uint8_t *oprom, const uint8_t *opram, uint32_t options)
 {
 	extern CPU_DISASSEMBLE( minx );
-	return CPU_DISASSEMBLE_NAME(minx)(this, buffer, pc, oprom, opram, options);
+	return CPU_DISASSEMBLE_NAME(minx)(this, stream, pc, oprom, opram, options);
 }

--- a/src/devices/cpu/minx/minx.h
+++ b/src/devices/cpu/minx/minx.h
@@ -41,7 +41,7 @@ protected:
 	// device_disasm_interface overrides
 	virtual uint32_t disasm_min_opcode_bytes() const override { return 1; }
 	virtual uint32_t disasm_max_opcode_bytes() const override { return 5; }
-	virtual offs_t disasm_disassemble(char *buffer, offs_t pc, const uint8_t *oprom, const uint8_t *opram, uint32_t options) override;
+	virtual offs_t disasm_disassemble(std::ostream &stream, offs_t pc, const uint8_t *oprom, const uint8_t *opram, uint32_t options) override;
 
 private:
 	address_space_config m_program_config;

--- a/src/devices/cpu/minx/minxd.cpp
+++ b/src/devices/cpu/minx/minxd.cpp
@@ -420,7 +420,7 @@ case M_HL:  util::stream_format(stream, "%c[HL]", fill); break;       \
 case OP:    util::stream_format(stream, "%c$%02X", fill, op); break;      \
 case OP1:   util::stream_format(stream, "%c$%02X", fill, op1); break;
 
-static offs_t internal_disasm_minx(cpu_device *device, std::ostream &stream, offs_t pc, const uint8_t *oprom, const uint8_t *opram, int options)
+CPU_DISASSEMBLE(minx)
 {
 	const minxdasm *instr;
 	uint8_t op, op1;
@@ -461,14 +461,4 @@ static offs_t internal_disasm_minx(cpu_device *device, std::ostream &stream, off
 		}
 	}
 	return pos | s_flags[instr->mnemonic] | DASMFLAG_SUPPORTED;
-}
-
-
-CPU_DISASSEMBLE(minx)
-{
-	std::ostringstream stream;
-	offs_t result = internal_disasm_minx(device, stream, pc, oprom, opram, options);
-	std::string stream_str = stream.str();
-	strcpy(buffer, stream_str.c_str());
-	return result;
 }

--- a/src/devices/cpu/mips/mips3.cpp
+++ b/src/devices/cpu/mips/mips3.cpp
@@ -963,14 +963,14 @@ bool mips3_device::memory_translate(address_spacenum spacenum, int intention, of
 }
 
 
-offs_t mips3_device::disasm_disassemble(char *buffer, offs_t pc, const uint8_t *oprom, const uint8_t *opram, uint32_t options)
+offs_t mips3_device::disasm_disassemble(std::ostream &stream, offs_t pc, const uint8_t *oprom, const uint8_t *opram, uint32_t options)
 {
 	uint32_t op = *(uint32_t *)oprom;
 	if (m_bigendian)
 		op = big_endianize_int32(op);
 	else
 		op = little_endianize_int32(op);
-	return dasmmips3(buffer, pc, op);
+	return dasmmips3(stream, pc, op);
 }
 
 

--- a/src/devices/cpu/mips/mips3.h
+++ b/src/devices/cpu/mips/mips3.h
@@ -771,7 +771,6 @@ private:
 ***************************************************************************/
 
 unsigned dasmmips3(std::ostream &stream, unsigned pc, uint32_t op);
-unsigned dasmmips3(char *buffer, unsigned pc, uint32_t op);
 
 
 #endif /* __MIPS3_H__ */

--- a/src/devices/cpu/mips/mips3.h
+++ b/src/devices/cpu/mips/mips3.h
@@ -308,7 +308,7 @@ protected:
 	// device_disasm_interface overrides
 	virtual uint32_t disasm_min_opcode_bytes() const override { return 4; }
 	virtual uint32_t disasm_max_opcode_bytes() const override { return 4; }
-	virtual offs_t disasm_disassemble(char *buffer, offs_t pc, const uint8_t *oprom, const uint8_t *opram, uint32_t options) override;
+	virtual offs_t disasm_disassemble(std::ostream &stream, offs_t pc, const uint8_t *oprom, const uint8_t *opram, uint32_t options) override;
 
 
 private:

--- a/src/devices/cpu/mips/mips3drc.cpp
+++ b/src/devices/cpu/mips/mips3drc.cpp
@@ -3947,9 +3947,10 @@ void mips3_device::log_add_disasm_comment(drcuml_block *block, uint32_t pc, uint
 {
 	if (m_drcuml->logging())
 	{
-		char buffer[100];
-		dasmmips3(buffer, pc, op);
-		block->append_comment("%08X: %s", pc, buffer);                                  // comment
+		std::ostringstream stream;
+		dasmmips3(stream, pc, op);
+		const std::string stream_string = stream.str();
+		block->append_comment("%08X: %s", pc, stream_string.c_str());                                  // comment
 	}
 }
 
@@ -4077,19 +4078,21 @@ void mips3_device::log_opcode_desc(drcuml_state *drcuml, const opcode_desc *desc
 	/* output each descriptor */
 	for ( ; desclist != nullptr; desclist = desclist->next())
 	{
-		char buffer[100];
+		std::ostringstream buffer;
 
 		/* disassemle the current instruction and output it to the log */
 		if (drcuml->logging() || drcuml->logging_native())
 		{
 			if (desclist->flags & OPFLAG_VIRTUAL_NOOP)
-				strcpy(buffer, "<virtual nop>");
+				buffer << "<virtual nop>";
 			else
 				dasmmips3(buffer, desclist->pc, desclist->opptr.l[0]);
 		}
 		else
-			strcpy(buffer, "???");
-		drcuml->log_printf("%08X [%08X] t:%08X f:%s: %-30s", desclist->pc, desclist->physpc, desclist->targetpc, log_desc_flags_to_string(desclist->flags), buffer);
+			buffer << "???";
+		
+		const std::string buffer_string = buffer.str();
+		drcuml->log_printf("%08X [%08X] t:%08X f:%s: %-30s", desclist->pc, desclist->physpc, desclist->targetpc, log_desc_flags_to_string(desclist->flags), buffer_string.c_str());
 
 		/* output register states */
 		log_register_list(drcuml, "use", desclist->regin, nullptr);

--- a/src/devices/cpu/mips/mips3dsm.cpp
+++ b/src/devices/cpu/mips/mips3dsm.cpp
@@ -536,21 +536,11 @@ unsigned dasmmips3(std::ostream &stream, unsigned pc, uint32_t op)
 }
 
 
-unsigned dasmmips3(char *buffer, unsigned pc, uint32_t op)
-{
-	std::ostringstream stream;
-	unsigned result = dasmmips3(stream, pc, op);
-	std::string stream_str = stream.str();
-	strcpy(buffer, stream_str.c_str());
-	return result;
-}
-
-
 CPU_DISASSEMBLE( mips3be )
 {
 	uint32_t op = *(uint32_t *)oprom;
 	op = big_endianize_int32(op);
-	return dasmmips3(buffer, pc, op);
+	return dasmmips3(stream, pc, op);
 }
 
 
@@ -558,5 +548,5 @@ CPU_DISASSEMBLE( mips3le )
 {
 	uint32_t op = *(uint32_t *)oprom;
 	op = little_endianize_int32(op);
-	return dasmmips3(buffer, pc, op);
+	return dasmmips3(stream, pc, op);
 }

--- a/src/devices/cpu/mips/r3000.cpp
+++ b/src/devices/cpu/mips/r3000.cpp
@@ -480,15 +480,15 @@ uint32_t r3000_device::disasm_max_opcode_bytes() const
 //  helper function
 //-------------------------------------------------
 
-offs_t r3000_device::disasm_disassemble(char *buffer, offs_t pc, const uint8_t *oprom, const uint8_t *opram, uint32_t options)
+offs_t r3000_device::disasm_disassemble(std::ostream &stream, offs_t pc, const uint8_t *oprom, const uint8_t *opram, uint32_t options)
 {
 	extern CPU_DISASSEMBLE( r3000le );
 	extern CPU_DISASSEMBLE( r3000be );
 
 	if (m_endianness == ENDIANNESS_BIG)
-		return CPU_DISASSEMBLE_NAME(r3000be)(this, buffer, pc, oprom, opram, options);
+		return CPU_DISASSEMBLE_NAME(r3000be)(this, stream, pc, oprom, opram, options);
 	else
-		return CPU_DISASSEMBLE_NAME(r3000le)(this, buffer, pc, oprom, opram, options);
+		return CPU_DISASSEMBLE_NAME(r3000le)(this, stream, pc, oprom, opram, options);
 }
 
 

--- a/src/devices/cpu/mips/r3000.h
+++ b/src/devices/cpu/mips/r3000.h
@@ -131,7 +131,7 @@ protected:
 	// device_disasm_interface overrides
 	virtual uint32_t disasm_min_opcode_bytes() const override;
 	virtual uint32_t disasm_max_opcode_bytes() const override;
-	virtual offs_t disasm_disassemble(char *buffer, offs_t pc, const uint8_t *oprom, const uint8_t *opram, uint32_t options) override;
+	virtual offs_t disasm_disassemble(std::ostream &stream, offs_t pc, const uint8_t *oprom, const uint8_t *opram, uint32_t options) override;
 
 	// memory accessors
 	struct r3000_data_accessors

--- a/src/devices/cpu/mips/r3kdasm.cpp
+++ b/src/devices/cpu/mips/r3kdasm.cpp
@@ -378,21 +378,11 @@ static unsigned dasmr3k(std::ostream &stream, unsigned pc, uint32_t op)
 }
 
 
-static unsigned dasmr3k(char *buffer, unsigned pc, uint32_t op)
-{
-	std::ostringstream stream;
-	unsigned result = dasmr3k(stream, pc, op);
-	std::string stream_str = stream.str();
-	strcpy(buffer, stream_str.c_str());
-	return result;
-}
-
-
 CPU_DISASSEMBLE( r3000be )
 {
 	uint32_t op = *(uint32_t *)oprom;
 	op = big_endianize_int32(op);
-	return dasmr3k(buffer, pc, op);
+	return dasmr3k(stream, pc, op);
 }
 
 
@@ -400,5 +390,5 @@ CPU_DISASSEMBLE( r3000le )
 {
 	uint32_t op = *(uint32_t *)oprom;
 	op = little_endianize_int32(op);
-	return dasmr3k(buffer, pc, op);
+	return dasmr3k(stream, pc, op);
 }

--- a/src/devices/cpu/mn10200/mn10200.cpp
+++ b/src/devices/cpu/mn10200/mn10200.cpp
@@ -72,10 +72,10 @@ void mn10200_device::state_string_export(const device_state_entry &entry, std::s
 	}
 }
 
-offs_t mn10200_device::disasm_disassemble(char *buffer, offs_t pc, const uint8_t *oprom, const uint8_t *opram, uint32_t options)
+offs_t mn10200_device::disasm_disassemble(std::ostream &stream, offs_t pc, const uint8_t *oprom, const uint8_t *opram, uint32_t options)
 {
 	extern CPU_DISASSEMBLE( mn10200 );
-	return CPU_DISASSEMBLE_NAME(mn10200)(this, buffer, pc, oprom, opram, options);
+	return CPU_DISASSEMBLE_NAME(mn10200)(this, stream, pc, oprom, opram, options);
 }
 
 

--- a/src/devices/cpu/mn10200/mn10200.h
+++ b/src/devices/cpu/mn10200/mn10200.h
@@ -93,7 +93,7 @@ protected:
 	// device_disasm_interface overrides
 	virtual uint32_t disasm_min_opcode_bytes() const override { return 1; }
 	virtual uint32_t disasm_max_opcode_bytes() const override { return 7; }
-	virtual offs_t disasm_disassemble(char *buffer, offs_t pc, const uint8_t *oprom, const uint8_t *opram, uint32_t options) override;
+	virtual offs_t disasm_disassemble(std::ostream &stream, offs_t pc, const uint8_t *oprom, const uint8_t *opram, uint32_t options) override;
 
 private:
 	address_space_config m_program_config;

--- a/src/devices/cpu/mn10200/mn102dis.cpp
+++ b/src/devices/cpu/mn10200/mn102dis.cpp
@@ -1034,9 +1034,5 @@ static int mn102_disassemble(std::ostream &stream, uint32_t pc, const uint8_t *o
 
 CPU_DISASSEMBLE( mn10200 )
 {
-	std::ostringstream stream;
-	offs_t result = mn102_disassemble(stream, pc, oprom);
-	std::string stream_str = stream.str();
-	strcpy(buffer, stream_str.c_str());
-	return result;
+	return mn102_disassemble(stream, pc, oprom);
 }

--- a/src/devices/cpu/nanoprocessor/nanoprocessor.cpp
+++ b/src/devices/cpu/nanoprocessor/nanoprocessor.cpp
@@ -159,10 +159,10 @@ void hp_nanoprocessor_device::state_string_export(const device_state_entry &entr
 
 }
 
-offs_t hp_nanoprocessor_device::disasm_disassemble(char *buffer, offs_t pc, const uint8_t *oprom, const uint8_t *opram, uint32_t options)
+offs_t hp_nanoprocessor_device::disasm_disassemble(std::ostream &stream, offs_t pc, const uint8_t *oprom, const uint8_t *opram, uint32_t options)
 {
 	extern CPU_DISASSEMBLE(hp_nanoprocessor);
-	return CPU_DISASSEMBLE_NAME(hp_nanoprocessor)(this , buffer , pc , oprom , opram , options);
+	return CPU_DISASSEMBLE_NAME(hp_nanoprocessor)(this , stream , pc , oprom , opram , options);
 }
 
 void hp_nanoprocessor_device::execute_one(uint8_t opcode)

--- a/src/devices/cpu/nanoprocessor/nanoprocessor.h
+++ b/src/devices/cpu/nanoprocessor/nanoprocessor.h
@@ -102,7 +102,7 @@ public:
 	// device_disasm_interface overrides
 	virtual uint32_t disasm_min_opcode_bytes() const override { return 1; }
 	virtual uint32_t disasm_max_opcode_bytes() const override { return 2; }
-	virtual offs_t disasm_disassemble(char *buffer, offs_t pc, const uint8_t *oprom, const uint8_t *opram, uint32_t options) override;
+	virtual offs_t disasm_disassemble(std::ostream &stream, offs_t pc, const uint8_t *oprom, const uint8_t *opram, uint32_t options) override;
 
 private:
 	devcb_write8 m_dc_changed_func;

--- a/src/devices/cpu/nanoprocessor/nanoprocessor_dasm.cpp
+++ b/src/devices/cpu/nanoprocessor/nanoprocessor_dasm.cpp
@@ -114,7 +114,6 @@ static const dis_entry_t dis_table[] = {
 
 CPU_DISASSEMBLE(hp_nanoprocessor)
 {
-    std::ostringstream stream;
     const uint8_t opcode = *oprom;
 
     opram++;
@@ -125,8 +124,6 @@ CPU_DISASSEMBLE(hp_nanoprocessor)
 			if (ent.m_param_fn != nullptr) {
 				ent.m_param_fn(stream , opcode , opram);
 			}
-			std::string stream_str = stream.str();
-			strcpy(buffer, stream_str.c_str());
 			return ent.m_dasm_flags | DASMFLAG_SUPPORTED;
 		}
 	}

--- a/src/devices/cpu/nec/nec.cpp
+++ b/src/devices/cpu/nec/nec.cpp
@@ -161,10 +161,10 @@ v33a_device::v33a_device(const machine_config &mconfig, const char *tag, device_
 }
 
 
-offs_t nec_common_device::disasm_disassemble(char *buffer, offs_t pc, const uint8_t *oprom, const uint8_t *opram, uint32_t options)
+offs_t nec_common_device::disasm_disassemble(std::ostream &stream, offs_t pc, const uint8_t *oprom, const uint8_t *opram, uint32_t options)
 {
 	extern CPU_DISASSEMBLE( nec );
-	return CPU_DISASSEMBLE_NAME(nec)(this, buffer, pc, oprom, opram, options);
+	return CPU_DISASSEMBLE_NAME(nec)(this, stream, pc, oprom, opram, options);
 }
 
 

--- a/src/devices/cpu/nec/nec.h
+++ b/src/devices/cpu/nec/nec.h
@@ -49,7 +49,7 @@ protected:
 	// device_disasm_interface overrides
 	virtual uint32_t disasm_min_opcode_bytes() const override { return 1; }
 	virtual uint32_t disasm_max_opcode_bytes() const override { return 8; }
-	virtual offs_t disasm_disassemble(char *buffer, offs_t pc, const uint8_t *oprom, const uint8_t *opram, uint32_t options) override;
+	virtual offs_t disasm_disassemble(std::ostream &stream, offs_t pc, const uint8_t *oprom, const uint8_t *opram, uint32_t options) override;
 
 private:
 	address_space_config m_program_config;

--- a/src/devices/cpu/nec/necdasm.cpp
+++ b/src/devices/cpu/nec/necdasm.cpp
@@ -1596,16 +1596,7 @@ int necv_dasm_one(std::ostream &stream, uint32_t eip, const uint8_t *oprom, cons
 	return (pc-eip) | dasm_flags | DASMFLAG_SUPPORTED;
 }
 
-int necv_dasm_one(char *buffer, uint32_t eip, const uint8_t *oprom, const uint8_t *decryption_table)
-{
-	std::ostringstream stream;
-	int result = necv_dasm_one(stream, eip, oprom, decryption_table);
-	std::string stream_str = stream.str();
-	strcpy(buffer, stream_str.c_str());
-	return result;
-}
-
 CPU_DISASSEMBLE( nec )
 {
-	return necv_dasm_one(buffer, pc, oprom, nullptr);
+	return necv_dasm_one(stream, pc, oprom, nullptr);
 }

--- a/src/devices/cpu/nec/v25.cpp
+++ b/src/devices/cpu/nec/v25.cpp
@@ -412,9 +412,9 @@ void v25_common_device::execute_set_input(int irqline, int state)
 	}
 }
 
-offs_t v25_common_device::disasm_disassemble(char *buffer, offs_t pc, const uint8_t *oprom, const uint8_t *opram, uint32_t options)
+offs_t v25_common_device::disasm_disassemble(std::ostream &stream, offs_t pc, const uint8_t *oprom, const uint8_t *opram, uint32_t options)
 {
-	return necv_dasm_one(buffer, pc, oprom, m_v25v35_decryptiontable);
+	return necv_dasm_one(stream, pc, oprom, m_v25v35_decryptiontable);
 }
 
 void v25_common_device::device_start()

--- a/src/devices/cpu/nec/v25.h
+++ b/src/devices/cpu/nec/v25.h
@@ -92,7 +92,7 @@ protected:
 	// device_disasm_interface overrides
 	virtual uint32_t disasm_min_opcode_bytes() const override { return 1; }
 	virtual uint32_t disasm_max_opcode_bytes() const override { return 8; }
-	virtual offs_t disasm_disassemble(char *buffer, offs_t pc, const uint8_t *oprom, const uint8_t *opram, uint32_t options) override;
+	virtual offs_t disasm_disassemble(std::ostream &stream, offs_t pc, const uint8_t *oprom, const uint8_t *opram, uint32_t options) override;
 
 private:
 	address_space_config m_program_config;

--- a/src/devices/cpu/patinhofeio/patinho_feio.cpp
+++ b/src/devices/cpu/patinhofeio/patinho_feio.cpp
@@ -775,8 +775,8 @@ void patinho_feio_cpu_device::execute_instruction()
 	printf("unimplemented opcode: 0x%02X\n", m_opcode);
 }
 
-offs_t patinho_feio_cpu_device::disasm_disassemble(char *buffer, offs_t pc, const uint8_t *oprom, const uint8_t *opram, uint32_t options)
+offs_t patinho_feio_cpu_device::disasm_disassemble(std::ostream &stream, offs_t pc, const uint8_t *oprom, const uint8_t *opram, uint32_t options)
 {
 	extern CPU_DISASSEMBLE( patinho_feio );
-	return CPU_DISASSEMBLE_NAME(patinho_feio)(this, buffer, pc, oprom, opram, options);
+	return CPU_DISASSEMBLE_NAME(patinho_feio)(this, stream, pc, oprom, opram, options);
 }

--- a/src/devices/cpu/patinhofeio/patinho_feio_dasm.cpp
+++ b/src/devices/cpu/patinhofeio/patinho_feio_dasm.cpp
@@ -3,7 +3,7 @@
 #include "emu.h"
 #include "cpu/patinhofeio/patinhofeio_cpu.h"
 
-static offs_t internal_disasm_patinho_feio(cpu_device *device, std::ostream &stream, offs_t pc, const uint8_t *oprom, const uint8_t *opram, int options)
+CPU_DISASSEMBLE(patinho_feio)
 {
 	int addr, value, n, f;
 
@@ -160,14 +160,4 @@ static offs_t internal_disasm_patinho_feio(cpu_device *device, std::ostream &str
 
 	util::stream_format(stream, "illegal instruction");
 	return 1;
-}
-
-
-CPU_DISASSEMBLE(patinho_feio)
-{
-	std::ostringstream stream;
-	offs_t result = internal_disasm_patinho_feio(device, stream, pc, oprom, opram, options);
-	std::string stream_str = stream.str();
-	strcpy(buffer, stream_str.c_str());
-	return result;
 }

--- a/src/devices/cpu/patinhofeio/patinhofeio_cpu.h
+++ b/src/devices/cpu/patinhofeio/patinhofeio_cpu.h
@@ -66,7 +66,7 @@ public:
 protected:
 
 	virtual void execute_run() override;
-	virtual offs_t disasm_disassemble(char *buffer, offs_t pc, const uint8_t *oprom, const uint8_t *opram, uint32_t options) override;
+	virtual offs_t disasm_disassemble(std::ostream &stream, offs_t pc, const uint8_t *oprom, const uint8_t *opram, uint32_t options) override;
 
 	address_space_config m_program_config;
 

--- a/src/devices/cpu/pdp1/pdp1.cpp
+++ b/src/devices/cpu/pdp1/pdp1.cpp
@@ -412,10 +412,10 @@ void pdp1_device::device_config_complete()
 }
 
 
-offs_t pdp1_device::disasm_disassemble(char *buffer, offs_t pc, const uint8_t *oprom, const uint8_t *opram, uint32_t options)
+offs_t pdp1_device::disasm_disassemble(std::ostream &stream, offs_t pc, const uint8_t *oprom, const uint8_t *opram, uint32_t options)
 {
 	extern CPU_DISASSEMBLE( pdp1 );
-	return CPU_DISASSEMBLE_NAME(pdp1)(this, buffer, pc, oprom, opram, options);
+	return CPU_DISASSEMBLE_NAME(pdp1)(this, stream, pc, oprom, opram, options);
 }
 
 

--- a/src/devices/cpu/pdp1/pdp1.h
+++ b/src/devices/cpu/pdp1/pdp1.h
@@ -114,7 +114,7 @@ protected:
 	// device_disasm_interface overrides
 	virtual uint32_t disasm_min_opcode_bytes() const override { return 4; }
 	virtual uint32_t disasm_max_opcode_bytes() const override { return 4; }
-	virtual offs_t disasm_disassemble(char *buffer, offs_t pc, const uint8_t *oprom, const uint8_t *opram, uint32_t options) override;
+	virtual offs_t disasm_disassemble(std::ostream &stream, offs_t pc, const uint8_t *oprom, const uint8_t *opram, uint32_t options) override;
 
 private:
 	address_space_config m_program_config;

--- a/src/devices/cpu/pdp1/pdp1dasm.cpp
+++ b/src/devices/cpu/pdp1/pdp1dasm.cpp
@@ -20,7 +20,7 @@ static inline void ea (void)
 
 #define IN if (ib) util::stream_format(stream, " i")
 
-static offs_t internal_disasm_pdp1(cpu_device *device, std::ostream &stream, offs_t pc, const uint8_t *oprom, const uint8_t *opram, int options)
+CPU_DISASSEMBLE(pdp1)
 {
 	int md;
 	//int etime = 0;
@@ -289,14 +289,4 @@ static offs_t internal_disasm_pdp1(cpu_device *device, std::ostream &stream, off
 		break;
 	}
 	return 4;
-}
-
-
-CPU_DISASSEMBLE(pdp1)
-{
-	std::ostringstream stream;
-	offs_t result = internal_disasm_pdp1(device, stream, pc, oprom, opram, options);
-	std::string stream_str = stream.str();
-	strcpy(buffer, stream_str.c_str());
-	return result;
 }

--- a/src/devices/cpu/pdp1/tx0.cpp
+++ b/src/devices/cpu/pdp1/tx0.cpp
@@ -1068,15 +1068,15 @@ void tx0_device::io_complete()
 }
 
 
-offs_t tx0_8kw_device::disasm_disassemble(char *buffer, offs_t pc, const uint8_t *oprom, const uint8_t *opram, uint32_t options)
+offs_t tx0_8kw_device::disasm_disassemble(std::ostream &stream, offs_t pc, const uint8_t *oprom, const uint8_t *opram, uint32_t options)
 {
 	extern CPU_DISASSEMBLE( tx0_8kw );
-	return CPU_DISASSEMBLE_NAME(tx0_8kw)(this, buffer, pc, oprom, opram, options);
+	return CPU_DISASSEMBLE_NAME(tx0_8kw)(this, stream, pc, oprom, opram, options);
 }
 
 
-offs_t tx0_64kw_device::disasm_disassemble(char *buffer, offs_t pc, const uint8_t *oprom, const uint8_t *opram, uint32_t options)
+offs_t tx0_64kw_device::disasm_disassemble(std::ostream &stream, offs_t pc, const uint8_t *oprom, const uint8_t *opram, uint32_t options)
 {
 	extern CPU_DISASSEMBLE( tx0_64kw );
-	return CPU_DISASSEMBLE_NAME(tx0_64kw)(this, buffer, pc, oprom, opram, options);
+	return CPU_DISASSEMBLE_NAME(tx0_64kw)(this, stream, pc, oprom, opram, options);
 }

--- a/src/devices/cpu/pdp1/tx0.h
+++ b/src/devices/cpu/pdp1/tx0.h
@@ -151,7 +151,7 @@ public:
 
 protected:
 	virtual void execute_run() override;
-	virtual offs_t disasm_disassemble(char *buffer, offs_t pc, const uint8_t *oprom, const uint8_t *opram, uint32_t options) override;
+	virtual offs_t disasm_disassemble(std::ostream &stream, offs_t pc, const uint8_t *oprom, const uint8_t *opram, uint32_t options) override;
 
 private:
 	void execute_instruction_8kw();
@@ -166,7 +166,7 @@ public:
 
 protected:
 	virtual void execute_run() override;
-	virtual offs_t disasm_disassemble(char *buffer, offs_t pc, const uint8_t *oprom, const uint8_t *opram, uint32_t options) override;
+	virtual offs_t disasm_disassemble(std::ostream &stream, offs_t pc, const uint8_t *oprom, const uint8_t *opram, uint32_t options) override;
 
 private:
 	void execute_instruction_64kw();

--- a/src/devices/cpu/pdp1/tx0dasm.cpp
+++ b/src/devices/cpu/pdp1/tx0dasm.cpp
@@ -3,7 +3,7 @@
 #include "emu.h"
 #include "cpu/pdp1/tx0.h"
 
-static offs_t internal_disasm_tx0_64kw(cpu_device *device, std::ostream &stream, offs_t pc, const uint8_t *oprom, const uint8_t *opram, int options)
+CPU_DISASSEMBLE(tx0_64kw)
 {
 	int md;
 	int x;
@@ -29,16 +29,7 @@ static offs_t internal_disasm_tx0_64kw(cpu_device *device, std::ostream &stream,
 	return 1;
 }
 
-CPU_DISASSEMBLE(tx0_64kw)
-{
-	std::ostringstream stream;
-	offs_t result = internal_disasm_tx0_64kw(device, stream, pc, oprom, opram, options);
-	std::string stream_str = stream.str();
-	strcpy(buffer, stream_str.c_str());
-	return result;
-}
-
-static offs_t internal_disasm_tx0_8kw(cpu_device *device, std::ostream &stream, offs_t pc, const uint8_t *oprom, const uint8_t *opram, int options)
+CPU_DISASSEMBLE(tx0_8kw)
 {
 	int md;
 	int x;
@@ -129,13 +120,4 @@ static offs_t internal_disasm_tx0_8kw(cpu_device *device, std::ostream &stream, 
 		break;
 	}
 	return 1;
-}
-
-CPU_DISASSEMBLE(tx0_8kw)
-{
-	std::ostringstream stream;
-	offs_t result = internal_disasm_tx0_8kw(device, stream, pc, oprom, opram, options);
-	std::string stream_str = stream.str();
-	strcpy(buffer, stream_str.c_str());
-	return result;
 }

--- a/src/devices/cpu/pdp8/pdp8.cpp
+++ b/src/devices/cpu/pdp8/pdp8.cpp
@@ -174,10 +174,10 @@ uint32_t pdp8_device::disasm_max_opcode_bytes() const
 //  helper function
 //-------------------------------------------------
 
-offs_t pdp8_device::disasm_disassemble(char *buffer, offs_t pc, const uint8_t *oprom, const uint8_t *opram, uint32_t options)
+offs_t pdp8_device::disasm_disassemble(std::ostream &stream, offs_t pc, const uint8_t *oprom, const uint8_t *opram, uint32_t options)
 {
 	extern CPU_DISASSEMBLE( pdp8 );
-	return CPU_DISASSEMBLE_NAME(pdp8)(this, buffer, pc, oprom, opram, options);
+	return CPU_DISASSEMBLE_NAME(pdp8)(this, stream, pc, oprom, opram, options);
 }
 
 

--- a/src/devices/cpu/pdp8/pdp8.h
+++ b/src/devices/cpu/pdp8/pdp8.h
@@ -42,7 +42,7 @@ public:
 	// device_disasm_interface overrides
 	virtual uint32_t disasm_min_opcode_bytes() const override;
 	virtual uint32_t disasm_max_opcode_bytes() const override;
-	virtual offs_t disasm_disassemble(char *buffer, offs_t pc, const uint8_t *oprom, const uint8_t *opram, uint32_t options) override;
+	virtual offs_t disasm_disassemble(std::ostream &stream, offs_t pc, const uint8_t *oprom, const uint8_t *opram, uint32_t options) override;
 
 	// device_state_interface overrides
 	virtual void state_string_export(const device_state_entry &entry, std::string &str) const override;

--- a/src/devices/cpu/pdp8/pdp8dasm.cpp
+++ b/src/devices/cpu/pdp8/pdp8dasm.cpp
@@ -160,14 +160,6 @@ static offs_t pdp8_dasm_one(std::ostream &stream, offs_t pc, uint16_t op)
 	return 2 | DASMFLAG_SUPPORTED;
 }
 
-static offs_t pdp8_dasm_one(char *buffer, offs_t pc, uint16_t op)
-{
-	std::ostringstream stream;
-	offs_t result = pdp8_dasm_one(stream, pc, op);
-	std::string stream_str = stream.str();
-	strcpy(buffer, stream_str.c_str());
-	return result;
-}
 
 /*****************************************************************************/
 
@@ -175,5 +167,5 @@ CPU_DISASSEMBLE( pdp8 )
 {
 	uint16_t op = (*(uint8_t *)(opram + 0) << 8) |
 				(*(uint8_t *)(opram + 1) << 0);
-	return pdp8_dasm_one(buffer, pc, op);
+	return pdp8_dasm_one(stream, pc, op);
 }

--- a/src/devices/cpu/pic16c5x/16c5xdsm.cpp
+++ b/src/devices/cpu/pic16c5x/16c5xdsm.cpp
@@ -149,7 +149,7 @@ static void InitDasm16C5x(void)
 	OpInizialized = 1;
 }
 
-static offs_t internal_disasm_pic16c5x(cpu_device *device, std::ostream &stream, offs_t pc, const uint8_t *oprom, const uint8_t *opram, int options)
+CPU_DISASSEMBLE(pic16c5x)
 {
 	int a, b, d, f, k;  /* these can all be filled in by parsing an instruction */
 	int i;
@@ -249,14 +249,4 @@ static offs_t internal_disasm_pic16c5x(cpu_device *device, std::ostream &stream,
 		}
 	}
 	return cnt | flags | DASMFLAG_SUPPORTED;
-}
-
-
-CPU_DISASSEMBLE(pic16c5x)
-{
-	std::ostringstream stream;
-	offs_t result = internal_disasm_pic16c5x(device, stream, pc, oprom, opram, options);
-	std::string stream_str = stream.str();
-	strcpy(buffer, stream_str.c_str());
-	return result;
 }

--- a/src/devices/cpu/pic16c5x/pic16c5x.cpp
+++ b/src/devices/cpu/pic16c5x/pic16c5x.cpp
@@ -153,10 +153,10 @@ pic16c58_device::pic16c58_device(const machine_config &mconfig, const char *tag,
 }
 
 
-offs_t pic16c5x_device::disasm_disassemble(char *buffer, offs_t pc, const uint8_t *oprom, const uint8_t *opram, uint32_t options)
+offs_t pic16c5x_device::disasm_disassemble(std::ostream &stream, offs_t pc, const uint8_t *oprom, const uint8_t *opram, uint32_t options)
 {
 	extern CPU_DISASSEMBLE( pic16c5x );
-	return CPU_DISASSEMBLE_NAME(pic16c5x)(this, buffer, pc, oprom, opram, options);
+	return CPU_DISASSEMBLE_NAME(pic16c5x)(this, stream, pc, oprom, opram, options);
 }
 
 

--- a/src/devices/cpu/pic16c5x/pic16c5x.h
+++ b/src/devices/cpu/pic16c5x/pic16c5x.h
@@ -122,7 +122,7 @@ protected:
 	// device_disasm_interface overrides
 	virtual uint32_t disasm_min_opcode_bytes() const override { return 2; }
 	virtual uint32_t disasm_max_opcode_bytes() const override { return 2; }
-	virtual offs_t disasm_disassemble(char *buffer, offs_t pc, const uint8_t *oprom, const uint8_t *opram, uint32_t options) override;
+	virtual offs_t disasm_disassemble(std::ostream &stream, offs_t pc, const uint8_t *oprom, const uint8_t *opram, uint32_t options) override;
 
 private:
 	address_space_config m_program_config;

--- a/src/devices/cpu/pic16c62x/16c62xdsm.cpp
+++ b/src/devices/cpu/pic16c62x/16c62xdsm.cpp
@@ -160,7 +160,7 @@ static void InitDasm16C5x(void)
 	OpInizialized = 1;
 }
 
-static offs_t internal_disasm_pic16c62x(cpu_device *device, std::ostream &stream, offs_t pc, const uint8_t *oprom, const uint8_t *opram, int options)
+CPU_DISASSEMBLE(pic16c62x)
 {
 	int a, b, d, f, k;  /* these can all be filled in by parsing an instruction */
 	int i;
@@ -260,14 +260,4 @@ static offs_t internal_disasm_pic16c62x(cpu_device *device, std::ostream &stream
 		}
 	}
 	return cnt | flags | DASMFLAG_SUPPORTED;
-}
-
-
-CPU_DISASSEMBLE(pic16c62x)
-{
-	std::ostringstream stream;
-	offs_t result = internal_disasm_pic16c62x(device, stream, pc, oprom, opram, options);
-	std::string stream_str = stream.str();
-	strcpy(buffer, stream_str.c_str());
-	return result;
 }

--- a/src/devices/cpu/pic16c62x/pic16c62x.cpp
+++ b/src/devices/cpu/pic16c62x/pic16c62x.cpp
@@ -158,10 +158,10 @@ pic16c622a_device::pic16c622a_device(const machine_config &mconfig, const char *
 }
 
 
-offs_t pic16c62x_device::disasm_disassemble(char *buffer, offs_t pc, const uint8_t *oprom, const uint8_t *opram, uint32_t options)
+offs_t pic16c62x_device::disasm_disassemble(std::ostream &stream, offs_t pc, const uint8_t *oprom, const uint8_t *opram, uint32_t options)
 {
 	extern CPU_DISASSEMBLE( pic16c62x );
-	return CPU_DISASSEMBLE_NAME(pic16c62x)(this, buffer, pc, oprom, opram, options);
+	return CPU_DISASSEMBLE_NAME(pic16c62x)(this, stream, pc, oprom, opram, options);
 }
 
 

--- a/src/devices/cpu/pic16c62x/pic16c62x.h
+++ b/src/devices/cpu/pic16c62x/pic16c62x.h
@@ -84,7 +84,7 @@ protected:
 	// device_disasm_interface overrides
 	virtual uint32_t disasm_min_opcode_bytes() const override { return 2; }
 	virtual uint32_t disasm_max_opcode_bytes() const override { return 2; }
-	virtual offs_t disasm_disassemble(char *buffer, offs_t pc, const uint8_t *oprom, const uint8_t *opram, uint32_t options) override;
+	virtual offs_t disasm_disassemble(std::ostream &stream, offs_t pc, const uint8_t *oprom, const uint8_t *opram, uint32_t options) override;
 
 private:
 	address_space_config m_program_config;

--- a/src/devices/cpu/powerpc/ppc.h
+++ b/src/devices/cpu/powerpc/ppc.h
@@ -269,7 +269,7 @@ protected:
 	// device_disasm_interface overrides
 	virtual uint32_t disasm_min_opcode_bytes() const override { return 4; }
 	virtual uint32_t disasm_max_opcode_bytes() const override { return 4; }
-	virtual offs_t disasm_disassemble(char *buffer, offs_t pc, const uint8_t *oprom, const uint8_t *opram, uint32_t options) override;
+	virtual offs_t disasm_disassemble(std::ostream &stream, offs_t pc, const uint8_t *oprom, const uint8_t *opram, uint32_t options) override;
 
 	/* exception types */
 	enum

--- a/src/devices/cpu/powerpc/ppc_dasm.cpp
+++ b/src/devices/cpu/powerpc/ppc_dasm.cpp
@@ -1169,18 +1169,10 @@ offs_t ppc_dasm_one(std::ostream &stream, uint32_t pc, uint32_t op)
 	return 4 | flags;
 }
 
-offs_t ppc_dasm_one(char *buffer, uint32_t pc, uint32_t op)
-{
-	std::ostringstream stream;
-	offs_t result = ppc_dasm_one(stream, pc, op);
-	std::string stream_str = stream.str();
-	strcpy(buffer, stream_str.c_str());
-	return result;
-}
 
 CPU_DISASSEMBLE( powerpc )
 {
 	uint32_t op = *(uint32_t *)oprom;
 	op = big_endianize_int32(op);
-	return ppc_dasm_one(buffer, pc, op);
+	return ppc_dasm_one(stream, pc, op);
 }

--- a/src/devices/cpu/powerpc/ppc_dasm.cpp
+++ b/src/devices/cpu/powerpc/ppc_dasm.cpp
@@ -1170,15 +1170,6 @@ offs_t ppc_dasm_one(std::ostream &stream, uint32_t pc, uint32_t op)
 }
 
 
-offs_t ppc_dasm_one(std::string &string, uint32_t pc, uint32_t op)
-{
-	std::ostringstream stream;
-	offs_t result = ppc_dasm_one(stream, pc, op);
-	string = stream.str();
-	return result;
-}
-
-
 CPU_DISASSEMBLE( powerpc )
 {
 	uint32_t op = *(uint32_t *)oprom;

--- a/src/devices/cpu/powerpc/ppc_dasm.cpp
+++ b/src/devices/cpu/powerpc/ppc_dasm.cpp
@@ -1170,6 +1170,15 @@ offs_t ppc_dasm_one(std::ostream &stream, uint32_t pc, uint32_t op)
 }
 
 
+offs_t ppc_dasm_one(std::string &string, uint32_t pc, uint32_t op)
+{
+	std::ostringstream stream;
+	offs_t result = ppc_dasm_one(stream, pc, op);
+	string = stream.str();
+	return result;
+}
+
+
 CPU_DISASSEMBLE( powerpc )
 {
 	uint32_t op = *(uint32_t *)oprom;

--- a/src/devices/cpu/powerpc/ppccom.cpp
+++ b/src/devices/cpu/powerpc/ppccom.cpp
@@ -1232,11 +1232,11 @@ void ppc_device::device_reset()
     CPU
 -------------------------------------------------*/
 
-offs_t ppc_device::disasm_disassemble(char *buffer, offs_t pc, const uint8_t *oprom, const uint8_t *opram, uint32_t options)
+offs_t ppc_device::disasm_disassemble(std::ostream &stream, offs_t pc, const uint8_t *oprom, const uint8_t *opram, uint32_t options)
 {
 	uint32_t op = *(uint32_t *)oprom;
 	op = big_endianize_int32(op);
-	return ppc_dasm_one(buffer, pc, op);
+	return ppc_dasm_one(stream, pc, op);
 }
 
 

--- a/src/devices/cpu/powerpc/ppccom.h
+++ b/src/devices/cpu/powerpc/ppccom.h
@@ -476,7 +476,7 @@ enum
 #define G_XO(op)            ((op & M_XO) >> (31 - 30))
 
 extern offs_t ppc_dasm_one(std::ostream &stream, uint32_t pc, uint32_t op);
-extern offs_t ppc_dasm_one(char *buffer, uint32_t pc, uint32_t op);
+extern offs_t ppc_dasm_one(std::string &string, uint32_t pc, uint32_t op);
 
 
 

--- a/src/devices/cpu/powerpc/ppccom.h
+++ b/src/devices/cpu/powerpc/ppccom.h
@@ -476,7 +476,6 @@ enum
 #define G_XO(op)            ((op & M_XO) >> (31 - 30))
 
 extern offs_t ppc_dasm_one(std::ostream &stream, uint32_t pc, uint32_t op);
-extern offs_t ppc_dasm_one(std::string &string, uint32_t pc, uint32_t op);
 
 
 

--- a/src/devices/cpu/powerpc/ppcdrc.cpp
+++ b/src/devices/cpu/powerpc/ppcdrc.cpp
@@ -3919,6 +3919,8 @@ void ppc_device::log_register_list(drcuml_state *drcuml, const char *string, con
 
 void ppc_device::log_opcode_desc(drcuml_state *drcuml, const opcode_desc *desclist, int indent)
 {
+	util::ovectorstream buffer;
+
 	/* open the file, creating it if necessary */
 	if (indent == 0)
 		drcuml->log_printf("\nDescriptor list @ %08X\n", desclist->pc);
@@ -3926,20 +3928,22 @@ void ppc_device::log_opcode_desc(drcuml_state *drcuml, const opcode_desc *descli
 	/* output each descriptor */
 	for ( ; desclist != nullptr; desclist = desclist->next())
 	{
-		std::string buffer;
+		buffer.clear();
+		buffer.seekp(0);
 
 		/* disassemble the current instruction and output it to the log */
 		if (drcuml->logging() || drcuml->logging_native())
 		{
 			if (desclist->flags & OPFLAG_VIRTUAL_NOOP)
-				buffer = "<virtual nop>";
+				buffer << "<virtual nop>";
 			else
 				ppc_dasm_one(buffer, desclist->pc, desclist->opptr.l[0]);
 		}
 		else
-			buffer = "???";
+			buffer << "???";
 
-		drcuml->log_printf("%08X [%08X] t:%08X f:%s: %-30s", desclist->pc, desclist->physpc, desclist->targetpc, log_desc_flags_to_string(desclist->flags), buffer.c_str());
+		buffer.put('\0');
+		drcuml->log_printf("%08X [%08X] t:%08X f:%s: %-30s", desclist->pc, desclist->physpc, desclist->targetpc, log_desc_flags_to_string(desclist->flags), buffer.vec());
 
 		/* output register states */
 		log_register_list(drcuml, "use", desclist->regin, nullptr);

--- a/src/devices/cpu/powerpc/ppcdrc.cpp
+++ b/src/devices/cpu/powerpc/ppcdrc.cpp
@@ -3745,11 +3745,12 @@ bool ppc_device::generate_instruction_3f(drcuml_block *block, compiler_state *co
 
 void ppc_device::log_add_disasm_comment(drcuml_block *block, uint32_t pc, uint32_t op)
 {
-	std::string buffer;
 	if (m_drcuml->logging())
 	{
-		ppc_dasm_one(buffer, pc, op);
-		block->append_comment("%08X: %s", pc, buffer.c_str());                                  // comment
+		util::ovectorstream stream;
+		ppc_dasm_one(stream, pc, op);
+		stream.put('\0');
+		block->append_comment("%08X: %s", pc, &stream.vec()[0]);                                  // comment
 	}
 }
 

--- a/src/devices/cpu/powerpc/ppcdrc.cpp
+++ b/src/devices/cpu/powerpc/ppcdrc.cpp
@@ -3745,11 +3745,11 @@ bool ppc_device::generate_instruction_3f(drcuml_block *block, compiler_state *co
 
 void ppc_device::log_add_disasm_comment(drcuml_block *block, uint32_t pc, uint32_t op)
 {
-	char buffer[100];
+	std::string buffer;
 	if (m_drcuml->logging())
 	{
 		ppc_dasm_one(buffer, pc, op);
-		block->append_comment("%08X: %s", pc, buffer);                                  // comment
+		block->append_comment("%08X: %s", pc, buffer.c_str());                                  // comment
 	}
 }
 
@@ -3926,20 +3926,20 @@ void ppc_device::log_opcode_desc(drcuml_state *drcuml, const opcode_desc *descli
 	/* output each descriptor */
 	for ( ; desclist != nullptr; desclist = desclist->next())
 	{
-		char buffer[100];
+		std::string buffer;
 
-		/* disassemle the current instruction and output it to the log */
+		/* disassemble the current instruction and output it to the log */
 		if (drcuml->logging() || drcuml->logging_native())
 		{
 			if (desclist->flags & OPFLAG_VIRTUAL_NOOP)
-				strcpy(buffer, "<virtual nop>");
+				buffer = "<virtual nop>";
 			else
 				ppc_dasm_one(buffer, desclist->pc, desclist->opptr.l[0]);
 		}
 		else
-			strcpy(buffer, "???");
+			buffer = "???";
 
-		drcuml->log_printf("%08X [%08X] t:%08X f:%s: %-30s", desclist->pc, desclist->physpc, desclist->targetpc, log_desc_flags_to_string(desclist->flags), buffer);
+		drcuml->log_printf("%08X [%08X] t:%08X f:%s: %-30s", desclist->pc, desclist->physpc, desclist->targetpc, log_desc_flags_to_string(desclist->flags), buffer.c_str());
 
 		/* output register states */
 		log_register_list(drcuml, "use", desclist->regin, nullptr);

--- a/src/devices/cpu/powerpc/ppcdrc.cpp
+++ b/src/devices/cpu/powerpc/ppcdrc.cpp
@@ -3943,7 +3943,7 @@ void ppc_device::log_opcode_desc(drcuml_state *drcuml, const opcode_desc *descli
 			buffer << "???";
 
 		buffer.put('\0');
-		drcuml->log_printf("%08X [%08X] t:%08X f:%s: %-30s", desclist->pc, desclist->physpc, desclist->targetpc, log_desc_flags_to_string(desclist->flags), buffer.vec());
+		drcuml->log_printf("%08X [%08X] t:%08X f:%s: %-30s", desclist->pc, desclist->physpc, desclist->targetpc, log_desc_flags_to_string(desclist->flags), &buffer.vec()[0]);
 
 		/* output register states */
 		log_register_list(drcuml, "use", desclist->regin, nullptr);

--- a/src/devices/cpu/pps4/pps4.cpp
+++ b/src/devices/cpu/pps4/pps4.cpp
@@ -100,10 +100,10 @@ void pps4_device::W(uint8_t data)
 	m_SAG = 0;
 }
 
-offs_t pps4_device::disasm_disassemble(char *buffer, offs_t pc, const uint8_t *oprom, const uint8_t *opram, uint32_t options)
+offs_t pps4_device::disasm_disassemble(std::ostream &stream, offs_t pc, const uint8_t *oprom, const uint8_t *opram, uint32_t options)
 {
 	extern CPU_DISASSEMBLE( pps4 );
-	return CPU_DISASSEMBLE_NAME(pps4)(this, buffer, pc, oprom, opram, options);
+	return CPU_DISASSEMBLE_NAME(pps4)(this, stream, pc, oprom, opram, options);
 }
 
 /**

--- a/src/devices/cpu/pps4/pps4.h
+++ b/src/devices/cpu/pps4/pps4.h
@@ -64,7 +64,7 @@ protected:
 	// device_disasm_interface overrides
 	virtual uint32_t disasm_min_opcode_bytes() const override { return 1; }
 	virtual uint32_t disasm_max_opcode_bytes() const override { return 2; }
-	virtual offs_t disasm_disassemble(char *buffer, offs_t pc, const uint8_t *oprom, const uint8_t *opram, uint32_t options) override;
+	virtual offs_t disasm_disassemble(std::ostream &stream, offs_t pc, const uint8_t *oprom, const uint8_t *opram, uint32_t options) override;
 
 private:
 	address_space_config m_program_config;

--- a/src/devices/cpu/pps4/pps4dasm.cpp
+++ b/src/devices/cpu/pps4/pps4dasm.cpp
@@ -367,7 +367,7 @@ static const uint16_t table[] = {
 /* ff */ t_TM | t_I6i | t_OVER
 };
 
-static offs_t internal_disasm_pps4(cpu_device *device, std::ostream &stream, offs_t pc, const uint8_t *oprom, const uint8_t *opram, int options)
+CPU_DISASSEMBLE(pps4)
 {
 	uint32_t flags = 0;
 	unsigned PC = pc;
@@ -439,13 +439,4 @@ static offs_t internal_disasm_pps4(cpu_device *device, std::ostream &stream, off
 			flags |= DASMFLAG_STEP_OUT;
 
 	return (pc - PC) | flags | DASMFLAG_SUPPORTED;
-}
-
-CPU_DISASSEMBLE(pps4)
-{
-	std::ostringstream stream;
-	offs_t result = internal_disasm_pps4(device, stream, pc, oprom, opram, options);
-	std::string stream_str = stream.str();
-	strcpy(buffer, stream_str.c_str());
-	return result;
 }

--- a/src/devices/cpu/psx/psx.cpp
+++ b/src/devices/cpu/psx/psx.cpp
@@ -2052,9 +2052,9 @@ void psxcpu_device::state_string_export( const device_state_entry &entry, std::s
 //  helper function
 //-------------------------------------------------
 
-offs_t psxcpu_device::disasm_disassemble( char *buffer, offs_t pc, const uint8_t *oprom, const uint8_t *opram, uint32_t options )
+offs_t psxcpu_device::disasm_disassemble( std::ostream &stream, offs_t pc, const uint8_t *oprom, const uint8_t *opram, uint32_t options )
 {
-	return DasmPSXCPU( this, buffer, pc, opram );
+	return DasmPSXCPU( this, stream, pc, opram );
 }
 
 

--- a/src/devices/cpu/psx/psx.h
+++ b/src/devices/cpu/psx/psx.h
@@ -227,7 +227,7 @@ protected:
 	// device_disasm_interface overrides
 	virtual uint32_t disasm_min_opcode_bytes() const override { return 4; }
 	virtual uint32_t disasm_max_opcode_bytes() const override { return 8; }
-	virtual offs_t disasm_disassemble(char *buffer, offs_t pc, const uint8_t *oprom, const uint8_t *opram, uint32_t options) override;
+	virtual offs_t disasm_disassemble(std::ostream &stream, offs_t pc, const uint8_t *oprom, const uint8_t *opram, uint32_t options) override;
 
 	// CPU registers
 	uint32_t m_pc;
@@ -522,7 +522,6 @@ extern const device_type CXD8606CQ;
 #define CF_TLBP ( 8 )
 #define CF_RFE ( 16 )
 
-extern unsigned DasmPSXCPU( psxcpu_state *state, std::ostream &stream, uint32_t pc, const uint8_t *opram);
-extern unsigned DasmPSXCPU( psxcpu_state *state, char *buffer, uint32_t pc, const uint8_t *opram );
+extern unsigned DasmPSXCPU(psxcpu_state *state, std::ostream &stream, uint32_t pc, const uint8_t *opram);
 
 #endif /* __PSXCPU_H__ */

--- a/src/devices/cpu/psx/psxdasm.cpp
+++ b/src/devices/cpu/psx/psxdasm.cpp
@@ -683,16 +683,8 @@ unsigned DasmPSXCPU( psxcpu_state *state, std::ostream &stream, uint32_t pc, con
 	return ( opram - oldopram ) | flags | DASMFLAG_SUPPORTED;
 }
 
-unsigned DasmPSXCPU(psxcpu_state *state, char *buffer, uint32_t pc, const uint8_t *opram)
-{
-	std::ostringstream stream;
-	unsigned result = DasmPSXCPU(state, stream, pc, opram);
-	std::string stream_str = stream.str();
-	strcpy(buffer, stream_str.c_str());
-	return result;
-}
 
 CPU_DISASSEMBLE( psxcpu_generic )
 {
-	return DasmPSXCPU( nullptr, buffer, pc, opram );
+	return DasmPSXCPU( nullptr, stream, pc, opram );
 }

--- a/src/devices/cpu/rsp/rsp.cpp
+++ b/src/devices/cpu/rsp/rsp.cpp
@@ -308,9 +308,10 @@ void rsp_device::unimplemented_opcode(uint32_t op)
 {
 	if ((machine().debug_flags & DEBUG_FLAG_ENABLED) != 0)
 	{
-		std::string string;
+		util::ovectorstream string;
 		rsp_dasm_one(string, m_ppc, op);
-		osd_printf_debug("%08X: %s\n", m_ppc, string.c_str());
+		string.put('\0');
+		osd_printf_debug("%08X: %s\n", m_ppc, &string.vec()[0]);
 	}
 
 #if SAVE_DISASM
@@ -734,12 +735,14 @@ void rsp_device::execute_run()
 		{
 			int i, l;
 			static uint32_t prev_regs[32];
-			std::string string;
+			
+			util::ovectorstream string;
 			rsp_dasm_one(string, m_ppc, op);
+			string.put('\0');
 
-			fprintf(m_exec_output, "%08X: %s", m_ppc, string.c_str());
+			fprintf(m_exec_output, "%08X: %s", m_ppc, &string.vec()[0]);
 
-			l = string.length();
+			l = string.vec().size() - 1;
 			if (l < 36)
 			{
 				for (i=l; i < 36; i++)

--- a/src/devices/cpu/rsp/rsp.cpp
+++ b/src/devices/cpu/rsp/rsp.cpp
@@ -139,10 +139,10 @@ rsp_device::rsp_device(const machine_config &mconfig, const char *tag, device_t 
 {
 }
 
-offs_t rsp_device::disasm_disassemble(char *buffer, offs_t pc, const uint8_t *oprom, const uint8_t *opram, uint32_t options)
+offs_t rsp_device::disasm_disassemble(std::ostream &stream, offs_t pc, const uint8_t *oprom, const uint8_t *opram, uint32_t options)
 {
 	extern CPU_DISASSEMBLE( rsp );
-	return CPU_DISASSEMBLE_NAME( rsp )(this, buffer, pc, oprom, opram, options);
+	return CPU_DISASSEMBLE_NAME( rsp )(this, stream, pc, oprom, opram, options);
 }
 
 void rsp_device::rsp_add_imem(uint32_t *base)

--- a/src/devices/cpu/rsp/rsp.cpp
+++ b/src/devices/cpu/rsp/rsp.cpp
@@ -308,9 +308,9 @@ void rsp_device::unimplemented_opcode(uint32_t op)
 {
 	if ((machine().debug_flags & DEBUG_FLAG_ENABLED) != 0)
 	{
-		char string[200];
+		std::string string;
 		rsp_dasm_one(string, m_ppc, op);
-		osd_printf_debug("%08X: %s\n", m_ppc, string);
+		osd_printf_debug("%08X: %s\n", m_ppc, string.c_str());
 	}
 
 #if SAVE_DISASM
@@ -734,12 +734,12 @@ void rsp_device::execute_run()
 		{
 			int i, l;
 			static uint32_t prev_regs[32];
-			char string[200];
+			std::string string;
 			rsp_dasm_one(string, m_ppc, op);
 
-			fprintf(m_exec_output, "%08X: %s", m_ppc, string);
+			fprintf(m_exec_output, "%08X: %s", m_ppc, string.c_str());
 
-			l = strlen(string);
+			l = string.length();
 			if (l < 36)
 			{
 				for (i=l; i < 36; i++)

--- a/src/devices/cpu/rsp/rsp.h
+++ b/src/devices/cpu/rsp/rsp.h
@@ -327,7 +327,7 @@ private:
 extern const device_type RSP;
 
 extern offs_t rsp_dasm_one(std::ostream &stream, offs_t pc, uint32_t op);
-extern offs_t rsp_dasm_one(char *buffer, offs_t pc, uint32_t op);
+extern offs_t rsp_dasm_one(std::string &string, offs_t pc, uint32_t op);
 
 
 #endif /* __RSP_H__ */

--- a/src/devices/cpu/rsp/rsp.h
+++ b/src/devices/cpu/rsp/rsp.h
@@ -327,7 +327,6 @@ private:
 extern const device_type RSP;
 
 extern offs_t rsp_dasm_one(std::ostream &stream, offs_t pc, uint32_t op);
-extern offs_t rsp_dasm_one(std::string &string, offs_t pc, uint32_t op);
 
 
 #endif /* __RSP_H__ */

--- a/src/devices/cpu/rsp/rsp.h
+++ b/src/devices/cpu/rsp/rsp.h
@@ -189,7 +189,7 @@ protected:
 	// device_disasm_interface overrides
 	virtual uint32_t disasm_min_opcode_bytes() const override { return 4; }
 	virtual uint32_t disasm_max_opcode_bytes() const override { return 4; }
-	virtual offs_t disasm_disassemble(char *buffer, offs_t pc, const uint8_t *oprom, const uint8_t *opram, uint32_t options) override;
+	virtual offs_t disasm_disassemble(std::ostream &stream, offs_t pc, const uint8_t *oprom, const uint8_t *opram, uint32_t options) override;
 
 	void unimplemented_opcode(uint32_t op);
 

--- a/src/devices/cpu/rsp/rsp_dasm.cpp
+++ b/src/devices/cpu/rsp/rsp_dasm.cpp
@@ -341,20 +341,11 @@ offs_t rsp_dasm_one(std::ostream &stream, offs_t pc, uint32_t op)
 	return 4 | flags | DASMFLAG_SUPPORTED;
 }
 
-offs_t rsp_dasm_one(char *buffer, offs_t pc, uint32_t op)
-{
-	std::ostringstream stream;
-	offs_t result = rsp_dasm_one(stream, pc, op);
-	std::string stream_str = stream.str();
-	strcpy(buffer, stream_str.c_str());
-	return result;
-}
-
 /*****************************************************************************/
 
 CPU_DISASSEMBLE( rsp )
 {
 	uint32_t op = *(uint32_t *)opram;
 	op = big_endianize_int32(op);
-	return rsp_dasm_one(buffer, pc, op);
+	return rsp_dasm_one(stream, pc, op);
 }

--- a/src/devices/cpu/rsp/rsp_dasm.cpp
+++ b/src/devices/cpu/rsp/rsp_dasm.cpp
@@ -341,14 +341,6 @@ offs_t rsp_dasm_one(std::ostream &stream, offs_t pc, uint32_t op)
 	return 4 | flags | DASMFLAG_SUPPORTED;
 }
 
-offs_t rsp_dasm_one(std::string &string, offs_t pc, uint32_t op)
-{
-	std::ostringstream stream;
-	offs_t result = rsp_dasm_one(stream, pc, op);
-	string = stream.str();
-	return result;
-}
-
 /*****************************************************************************/
 
 CPU_DISASSEMBLE( rsp )

--- a/src/devices/cpu/rsp/rsp_dasm.cpp
+++ b/src/devices/cpu/rsp/rsp_dasm.cpp
@@ -341,6 +341,14 @@ offs_t rsp_dasm_one(std::ostream &stream, offs_t pc, uint32_t op)
 	return 4 | flags | DASMFLAG_SUPPORTED;
 }
 
+offs_t rsp_dasm_one(std::string &string, offs_t pc, uint32_t op)
+{
+	std::ostringstream stream;
+	offs_t result = rsp_dasm_one(stream, pc, op);
+	string = stream.str();
+	return result;
+}
+
 /*****************************************************************************/
 
 CPU_DISASSEMBLE( rsp )

--- a/src/devices/cpu/rsp/rspcp2d.cpp
+++ b/src/devices/cpu/rsp/rspcp2d.cpp
@@ -133,9 +133,10 @@ void rsp_cop2_drc::cfunc_unimplemented_opcode()
 	const uint32_t ppc = m_rsp.m_ppc;
 	if ((m_machine.debug_flags & DEBUG_FLAG_ENABLED) != 0)
 	{
-		char string[200];
-		rsp_dasm_one(string, ppc, m_rspcop2_state->op);
-		osd_printf_debug("%08X: %s\n", ppc, string);
+		std::ostringstream stream;
+		rsp_dasm_one(stream, ppc, m_rspcop2_state->op);
+		const std::string stream_string = stream.str();
+		osd_printf_debug("%08X: %s\n", ppc, stream_string.c_str());
 	}
 	fatalerror("RSP: unknown opcode %02X (%08X) at %08X\n", m_rspcop2_state->op >> 26, m_rspcop2_state->op, ppc);
 }

--- a/src/devices/cpu/rsp/rspdrc.cpp
+++ b/src/devices/cpu/rsp/rspdrc.cpp
@@ -1283,8 +1283,8 @@ void rsp_device::log_add_disasm_comment(drcuml_block *block, uint32_t pc, uint32
 {
 	if (m_drcuml->logging())
 	{
-		char buffer[100];
+		std::string buffer;
 		rsp_dasm_one(buffer, pc, op);
-		block->append_comment("%08X: %s", pc, buffer);                                  // comment
+		block->append_comment("%08X: %s", pc, buffer.c_str());                                  // comment
 	}
 }

--- a/src/devices/cpu/rsp/rspdrc.cpp
+++ b/src/devices/cpu/rsp/rspdrc.cpp
@@ -1283,8 +1283,9 @@ void rsp_device::log_add_disasm_comment(drcuml_block *block, uint32_t pc, uint32
 {
 	if (m_drcuml->logging())
 	{
-		std::string buffer;
+		util::ovectorstream buffer;
 		rsp_dasm_one(buffer, pc, op);
-		block->append_comment("%08X: %s", pc, buffer.c_str());                                  // comment
+		buffer.put('\0');
+		block->append_comment("%08X: %s", pc, &buffer.vec()[0]);                                  // comment
 	}
 }

--- a/src/devices/cpu/s2650/2650dasm.cpp
+++ b/src/devices/cpu/s2650/2650dasm.cpp
@@ -221,7 +221,7 @@ static char *ADR(int pc)
 }
 
 /* disassemble one instruction at PC into buff. return byte size of instr */
-static offs_t internal_disasm_s2650(cpu_device *device, std::ostream &stream, offs_t pc, const uint8_t *oprom, const uint8_t *opram, int options)
+CPU_DISASSEMBLE(s2650)
 {
 	uint32_t flags = 0;
 	int PC = pc;
@@ -865,14 +865,4 @@ static offs_t internal_disasm_s2650(cpu_device *device, std::ostream &stream, of
 			break;
 	}
 	return (pc - PC) | flags | DASMFLAG_SUPPORTED;
-}
-
-
-CPU_DISASSEMBLE(s2650)
-{
-	std::ostringstream stream;
-	offs_t result = internal_disasm_s2650(device, stream, pc, oprom, opram, options);
-	std::string stream_str = stream.str();
-	strcpy(buffer, stream_str.c_str());
-	return result;
 }

--- a/src/devices/cpu/s2650/s2650.cpp
+++ b/src/devices/cpu/s2650/s2650.cpp
@@ -42,10 +42,10 @@ s2650_device::s2650_device(const machine_config &mconfig, const char *tag, devic
 }
 
 
-offs_t s2650_device::disasm_disassemble(char *buffer, offs_t pc, const uint8_t *oprom, const uint8_t *opram, uint32_t options)
+offs_t s2650_device::disasm_disassemble(std::ostream &stream, offs_t pc, const uint8_t *oprom, const uint8_t *opram, uint32_t options)
 {
 	extern CPU_DISASSEMBLE( s2650 );
-	return CPU_DISASSEMBLE_NAME(s2650)(this, buffer, pc, oprom, opram, options);
+	return CPU_DISASSEMBLE_NAME(s2650)(this, stream, pc, oprom, opram, options);
 }
 
 

--- a/src/devices/cpu/s2650/s2650.h
+++ b/src/devices/cpu/s2650/s2650.h
@@ -71,7 +71,7 @@ protected:
 	// device_disasm_interface overrides
 	virtual uint32_t disasm_min_opcode_bytes() const override { return 1; }
 	virtual uint32_t disasm_max_opcode_bytes() const override { return 3; }
-	virtual offs_t disasm_disassemble(char *buffer, offs_t pc, const uint8_t *oprom, const uint8_t *opram, uint32_t options) override;
+	virtual offs_t disasm_disassemble(std::ostream &stream, offs_t pc, const uint8_t *oprom, const uint8_t *opram, uint32_t options) override;
 
 private:
 	address_space_config m_program_config;

--- a/src/devices/cpu/saturn/saturn.cpp
+++ b/src/devices/cpu/saturn/saturn.cpp
@@ -58,10 +58,10 @@ saturn_device::saturn_device(const machine_config &mconfig, const char *tag, dev
 }
 
 
-offs_t saturn_device::disasm_disassemble(char *buffer, offs_t pc, const uint8_t *oprom, const uint8_t *opram, uint32_t options)
+offs_t saturn_device::disasm_disassemble(std::ostream &stream, offs_t pc, const uint8_t *oprom, const uint8_t *opram, uint32_t options)
 {
 	extern CPU_DISASSEMBLE( saturn );
-	return CPU_DISASSEMBLE_NAME(saturn)(this, buffer, pc, oprom, opram, options);
+	return CPU_DISASSEMBLE_NAME(saturn)(this, stream, pc, oprom, opram, options);
 }
 
 

--- a/src/devices/cpu/saturn/saturn.h
+++ b/src/devices/cpu/saturn/saturn.h
@@ -111,7 +111,7 @@ protected:
 	// device_disasm_interface overrides
 	virtual uint32_t disasm_min_opcode_bytes() const override { return 1; }
 	virtual uint32_t disasm_max_opcode_bytes() const override { return 20; }
-	virtual offs_t disasm_disassemble(char *buffer, offs_t pc, const uint8_t *oprom, const uint8_t *opram, uint32_t options) override;
+	virtual offs_t disasm_disassemble(std::ostream &stream, offs_t pc, const uint8_t *oprom, const uint8_t *opram, uint32_t options) override;
 
 private:
 	address_space_config m_program_config;

--- a/src/devices/cpu/saturn/saturnds.cpp
+++ b/src/devices/cpu/saturn/saturnds.cpp
@@ -1267,7 +1267,7 @@ static const int field_adr_a[]=
 static const int field_adr_b[]=
 { FieldP, FieldWP, FieldXS, FieldX, FieldS, FieldM, FieldB, FieldW };
 
-static offs_t internal_disasm_saturn(cpu_device *device, std::ostream &stream, offs_t pc, const uint8_t *oprom, const uint8_t *opram, int options)
+CPU_DISASSEMBLE(saturn)
 {
 	int adr=0;
 
@@ -1467,14 +1467,4 @@ static offs_t internal_disasm_saturn(cpu_device *device, std::ostream &stream, o
 	}
 
 	return pos;
-}
-
-
-CPU_DISASSEMBLE(saturn)
-{
-	std::ostringstream stream;
-	offs_t result = internal_disasm_saturn(device, stream, pc, oprom, opram, options);
-	std::string stream_str = stream.str();
-	strcpy(buffer, stream_str.c_str());
-	return result;
 }

--- a/src/devices/cpu/sc61860/sc61860.cpp
+++ b/src/devices/cpu/sc61860/sc61860.cpp
@@ -64,10 +64,10 @@ sc61860_device::sc61860_device(const machine_config &mconfig, const char *tag, d
 }
 
 
-offs_t sc61860_device::disasm_disassemble(char *buffer, offs_t pc, const uint8_t *oprom, const uint8_t *opram, uint32_t options)
+offs_t sc61860_device::disasm_disassemble(std::ostream &stream, offs_t pc, const uint8_t *oprom, const uint8_t *opram, uint32_t options)
 {
 	extern CPU_DISASSEMBLE( sc61860 );
-	return CPU_DISASSEMBLE_NAME(sc61860)(this, buffer, pc, oprom, opram, options);
+	return CPU_DISASSEMBLE_NAME(sc61860)(this, stream, pc, oprom, opram, options);
 }
 
 

--- a/src/devices/cpu/sc61860/sc61860.h
+++ b/src/devices/cpu/sc61860/sc61860.h
@@ -111,7 +111,7 @@ protected:
 	// device_disasm_interface overrides
 	virtual uint32_t disasm_min_opcode_bytes() const override { return 1; }
 	virtual uint32_t disasm_max_opcode_bytes() const override { return 4; }
-	virtual offs_t disasm_disassemble(char *buffer, offs_t pc, const uint8_t *oprom, const uint8_t *opram, uint32_t options) override;
+	virtual offs_t disasm_disassemble(std::ostream &stream, offs_t pc, const uint8_t *oprom, const uint8_t *opram, uint32_t options) override;
 
 private:
 	address_space_config m_program_config;

--- a/src/devices/cpu/sc61860/scdasm.cpp
+++ b/src/devices/cpu/sc61860/scdasm.cpp
@@ -152,7 +152,7 @@ static const struct { const char *mnemonic; Adr adr; } table[]={
 	{ nullptr }, { nullptr }, { nullptr }, { nullptr },  { nullptr }, { nullptr }, { nullptr }, { nullptr },
 };
 
-static offs_t internal_disasm_sc61860(cpu_device *device, std::ostream &stream, offs_t pc, const uint8_t *oprom, const uint8_t *opram, int options)
+CPU_DISASSEMBLE(sc61860)
 {
 	const uint8_t *base_oprom = oprom;
 	int oper=*(oprom++);
@@ -207,14 +207,4 @@ static offs_t internal_disasm_sc61860(cpu_device *device, std::ostream &stream, 
 		break;
 	}
 	return oprom - base_oprom;
-}
-
-
-CPU_DISASSEMBLE(sc61860)
-{
-	std::ostringstream stream;
-	offs_t result = internal_disasm_sc61860(device, stream, pc, oprom, opram, options);
-	std::string stream_str = stream.str();
-	strcpy(buffer, stream_str.c_str());
-	return result;
 }

--- a/src/devices/cpu/scmp/scmp.cpp
+++ b/src/devices/cpu/scmp/scmp.cpp
@@ -53,10 +53,10 @@ ins8060_device::ins8060_device(const machine_config &mconfig, const char *tag, d
 }
 
 
-offs_t scmp_device::disasm_disassemble(char *buffer, offs_t pc, const uint8_t *oprom, const uint8_t *opram, uint32_t options)
+offs_t scmp_device::disasm_disassemble(std::ostream &stream, offs_t pc, const uint8_t *oprom, const uint8_t *opram, uint32_t options)
 {
 	extern CPU_DISASSEMBLE( scmp );
-	return CPU_DISASSEMBLE_NAME(scmp)(this, buffer, pc, oprom, opram, options);
+	return CPU_DISASSEMBLE_NAME(scmp)(this, stream, pc, oprom, opram, options);
 }
 
 

--- a/src/devices/cpu/scmp/scmp.h
+++ b/src/devices/cpu/scmp/scmp.h
@@ -58,7 +58,7 @@ protected:
 	// device_disasm_interface overrides
 	virtual uint32_t disasm_min_opcode_bytes() const override { return 1; }
 	virtual uint32_t disasm_max_opcode_bytes() const override { return 2; }
-	virtual offs_t disasm_disassemble(char *buffer, offs_t pc, const uint8_t *oprom, const uint8_t *opram, uint32_t options) override;
+	virtual offs_t disasm_disassemble(std::ostream &stream, offs_t pc, const uint8_t *oprom, const uint8_t *opram, uint32_t options) override;
 
 private:
 	address_space_config m_program_config;

--- a/src/devices/cpu/scmp/scmpdasm.cpp
+++ b/src/devices/cpu/scmp/scmpdasm.cpp
@@ -13,7 +13,7 @@
 #define OP(A)   oprom[(A) - PC]
 #define ARG(A)  opram[(A) - PC]
 
-static offs_t internal_disasm_scmp(cpu_device *device, std::ostream &stream, offs_t pc, const uint8_t *oprom, const uint8_t *opram, int options)
+CPU_DISASSEMBLE(scmp)
 {
 	unsigned PC = pc;
 	uint8_t op = OP(pc++);
@@ -150,14 +150,4 @@ static offs_t internal_disasm_scmp(cpu_device *device, std::ostream &stream, off
 	}
 
 	return (pc - PC);
-}
-
-
-CPU_DISASSEMBLE(scmp)
-{
-	std::ostringstream stream;
-	offs_t result = internal_disasm_scmp(device, stream, pc, oprom, opram, options);
-	std::string stream_str = stream.str();
-	strcpy(buffer, stream_str.c_str());
-	return result;
 }

--- a/src/devices/cpu/score/score.h
+++ b/src/devices/cpu/score/score.h
@@ -55,14 +55,7 @@ protected:
 	// device_disasm_interface overrides
 	virtual uint32_t disasm_min_opcode_bytes() const override { return 2; }
 	virtual uint32_t disasm_max_opcode_bytes() const override { return 4; }
-	virtual offs_t disasm_disassemble(char *buffer, offs_t pc, const uint8_t *oprom, const uint8_t *opram, uint32_t options) override
-	{
-		std::ostringstream stream;
-		offs_t result = disasm_disassemble(stream, pc, oprom, opram, options);
-		std::string stream_str = stream.str();
-		strcpy(buffer, stream_str.c_str());
-		return result;
-	}
+	virtual offs_t disasm_disassemble(std::ostream &stream, offs_t pc, const uint8_t *oprom, const uint8_t *opram, uint32_t options) override;
 
 private:
 	// helpers
@@ -150,8 +143,6 @@ private:
 	static const char *const m_i1a_op[8];
 	static const char *const m_i1b_op[8];
 	static const char *const m_cr_op[2];
-
-	offs_t disasm_disassemble(std::ostream &stream, offs_t pc, const uint8_t *oprom, const uint8_t *opram, uint32_t options);
 };
 
 extern const device_type SCORE7;

--- a/src/devices/cpu/scudsp/scudsp.cpp
+++ b/src/devices/cpu/scudsp/scudsp.cpp
@@ -1033,8 +1033,8 @@ void scudsp_cpu_device::state_string_export(const device_state_entry &entry, std
 }
 
 
-offs_t scudsp_cpu_device::disasm_disassemble(char *buffer, offs_t pc, const uint8_t *oprom, const uint8_t *opram, uint32_t options)
+offs_t scudsp_cpu_device::disasm_disassemble(std::ostream &stream, offs_t pc, const uint8_t *oprom, const uint8_t *opram, uint32_t options)
 {
 	extern CPU_DISASSEMBLE( scudsp );
-	return CPU_DISASSEMBLE_NAME(scudsp)(this, buffer, pc, oprom, opram, options);
+	return CPU_DISASSEMBLE_NAME(scudsp)(this, stream, pc, oprom, opram, options);
 }

--- a/src/devices/cpu/scudsp/scudsp.h
+++ b/src/devices/cpu/scudsp/scudsp.h
@@ -101,7 +101,7 @@ protected:
 	// device_disasm_interface overrides
 	virtual uint32_t disasm_min_opcode_bytes() const override { return 4; }
 	virtual uint32_t disasm_max_opcode_bytes() const override { return 4; }
-	virtual offs_t disasm_disassemble(char *buffer, offs_t pc, const uint8_t *oprom, const uint8_t *opram, uint32_t options) override;
+	virtual offs_t disasm_disassemble(std::ostream &stream, offs_t pc, const uint8_t *oprom, const uint8_t *opram, uint32_t options) override;
 
 	devcb_write_line     m_out_irq_cb;
 	devcb_read16         m_in_dma_cb;

--- a/src/devices/cpu/scudsp/scudspdasm.cpp
+++ b/src/devices/cpu/scudsp/scudspdasm.cpp
@@ -237,7 +237,7 @@ static void scudsp_dasm_prefix( const char* format, char* buffer, uint32_t *data
 }
 
 
-static offs_t internal_disasm_scudsp(cpu_device *device, std::ostream &stream, offs_t pc, const uint8_t *oprom, const uint8_t *opram, int options)
+CPU_DISASSEMBLE(scudsp)
 {
 	uint32_t op = oprom[0]<<24|oprom[1]<<16|oprom[2]<<8|oprom[3]<<0;
 	unsigned size = 1;
@@ -360,14 +360,4 @@ static offs_t internal_disasm_scudsp(cpu_device *device, std::ostream &stream, o
 	}
 
 	return size;
-}
-
-
-CPU_DISASSEMBLE(scudsp)
-{
-	std::ostringstream stream;
-	offs_t result = internal_disasm_scudsp(device, stream, pc, oprom, opram, options);
-	std::string stream_str = stream.str();
-	strcpy(buffer, stream_str.c_str());
-	return result;
 }

--- a/src/devices/cpu/se3208/se3208.cpp
+++ b/src/devices/cpu/se3208/se3208.cpp
@@ -1838,8 +1838,8 @@ void se3208_device::execute_set_input( int line, int state )
 		m_IRQ=state;
 }
 
-offs_t se3208_device::disasm_disassemble(char *buffer, offs_t pc, const uint8_t *oprom, const uint8_t *opram, uint32_t options)
+offs_t se3208_device::disasm_disassemble(std::ostream &stream, offs_t pc, const uint8_t *oprom, const uint8_t *opram, uint32_t options)
 {
 	extern CPU_DISASSEMBLE( se3208 );
-	return CPU_DISASSEMBLE_NAME(se3208)(this, buffer, pc, oprom, opram, options);
+	return CPU_DISASSEMBLE_NAME(se3208)(this, stream, pc, oprom, opram, options);
 }

--- a/src/devices/cpu/se3208/se3208.h
+++ b/src/devices/cpu/se3208/se3208.h
@@ -37,7 +37,7 @@ protected:
 	// device_disasm_interface overrides
 	virtual uint32_t disasm_min_opcode_bytes() const override { return 2; }
 	virtual uint32_t disasm_max_opcode_bytes() const override { return 2; }
-	virtual offs_t disasm_disassemble(char *buffer, offs_t pc, const uint8_t *oprom, const uint8_t *opram, uint32_t options) override;
+	virtual offs_t disasm_disassemble(std::ostream &stream, offs_t pc, const uint8_t *oprom, const uint8_t *opram, uint32_t options) override;
 
 private:
 	address_space_config m_program_config;

--- a/src/devices/cpu/se3208/se3208dis.cpp
+++ b/src/devices/cpu/se3208/se3208dis.cpp
@@ -1400,7 +1400,7 @@ static _OP DecodeOp(uint16_t Opcode)
 }
 
 
-static offs_t internal_disasm_se3208(cpu_device *device, std::ostream &stream, offs_t pc, const uint8_t *oprom, const uint8_t *opram, int options)
+CPU_DISASSEMBLE(se3208)
 {
 	uint16_t Opcode;
 
@@ -1410,14 +1410,4 @@ static offs_t internal_disasm_se3208(cpu_device *device, std::ostream &stream, o
 	Context.PC=pc;
 	Opcode=oprom[0] | (oprom[1] << 8);
 	return 2 | ((*DecodeOp(Opcode))(Opcode, stream)) | DASMFLAG_SUPPORTED;
-}
-
-
-CPU_DISASSEMBLE(se3208)
-{
-	std::ostringstream stream;
-	offs_t result = internal_disasm_se3208(device, stream, pc, oprom, opram, options);
-	std::string stream_str = stream.str();
-	strcpy(buffer, stream_str.c_str());
-	return result;
 }

--- a/src/devices/cpu/sh2/sh2.cpp
+++ b/src/devices/cpu/sh2/sh2.cpp
@@ -248,10 +248,10 @@ const address_space_config *sh2_device::memory_space_config(address_spacenum spa
 	}
 }
 
-offs_t sh2_device::disasm_disassemble(char *buffer, offs_t pc, const uint8_t *oprom, const uint8_t *opram, uint32_t options)
+offs_t sh2_device::disasm_disassemble(std::ostream &stream, offs_t pc, const uint8_t *oprom, const uint8_t *opram, uint32_t options)
 {
 	extern CPU_DISASSEMBLE( sh2 );
-	return CPU_DISASSEMBLE_NAME( sh2 )(this, buffer, pc, oprom, opram, options);
+	return CPU_DISASSEMBLE_NAME( sh2 )(this, stream, pc, oprom, opram, options);
 }
 
 

--- a/src/devices/cpu/sh2/sh2.h
+++ b/src/devices/cpu/sh2/sh2.h
@@ -135,7 +135,7 @@ protected:
 	// device_disasm_interface overrides
 	virtual uint32_t disasm_min_opcode_bytes() const override { return 2; }
 	virtual uint32_t disasm_max_opcode_bytes() const override { return 2; }
-	virtual offs_t disasm_disassemble(char *buffer, offs_t pc, const uint8_t *oprom, const uint8_t *opram, uint32_t options) override;
+	virtual offs_t disasm_disassemble(std::ostream &stream, offs_t pc, const uint8_t *oprom, const uint8_t *opram, uint32_t options) override;
 	address_space *m_program, *m_decrypted_program;
 
 private:

--- a/src/devices/cpu/sh2/sh2dasm.cpp
+++ b/src/devices/cpu/sh2/sh2dasm.cpp
@@ -606,9 +606,5 @@ unsigned DasmSH2(std::ostream &stream, unsigned pc, uint16_t opcode)
 
 CPU_DISASSEMBLE(sh2)
 {
-	std::ostringstream stream;
-	offs_t result = DasmSH2(stream, pc, (oprom[0] << 8) | oprom[1]);
-	std::string stream_str = stream.str();
-	strcpy(buffer, stream_str.c_str());
-	return result;
+	return DasmSH2(stream, pc, (oprom[0] << 8) | oprom[1]);
 }

--- a/src/devices/cpu/sh4/sh4.cpp
+++ b/src/devices/cpu/sh4/sh4.cpp
@@ -151,27 +151,27 @@ sh4be_device::sh4be_device(const machine_config &mconfig, const char *tag, devic
 }
 
 
-offs_t sh34_base_device::disasm_disassemble(char *buffer, offs_t pc, const uint8_t *oprom, const uint8_t *opram, uint32_t options)
+offs_t sh34_base_device::disasm_disassemble(std::ostream &stream, offs_t pc, const uint8_t *oprom, const uint8_t *opram, uint32_t options)
 {
 	extern CPU_DISASSEMBLE( sh4 );
 
-	return CPU_DISASSEMBLE_NAME(sh4)(this, buffer, pc, oprom, opram, options);
+	return CPU_DISASSEMBLE_NAME(sh4)(this, stream, pc, oprom, opram, options);
 }
 
 
-offs_t sh3be_device::disasm_disassemble(char *buffer, offs_t pc, const uint8_t *oprom, const uint8_t *opram, uint32_t options)
+offs_t sh3be_device::disasm_disassemble(std::ostream &stream, offs_t pc, const uint8_t *oprom, const uint8_t *opram, uint32_t options)
 {
 	extern CPU_DISASSEMBLE( sh4be );
 
-	return CPU_DISASSEMBLE_NAME(sh4be)(this, buffer, pc, oprom, opram, options);
+	return CPU_DISASSEMBLE_NAME(sh4be)(this, stream, pc, oprom, opram, options);
 }
 
 
-offs_t sh4be_device::disasm_disassemble(char *buffer, offs_t pc, const uint8_t *oprom, const uint8_t *opram, uint32_t options)
+offs_t sh4be_device::disasm_disassemble(std::ostream &stream, offs_t pc, const uint8_t *oprom, const uint8_t *opram, uint32_t options)
 {
 	extern CPU_DISASSEMBLE( sh4be );
 
-	return CPU_DISASSEMBLE_NAME(sh4be)(this, buffer, pc, oprom, opram, options);
+	return CPU_DISASSEMBLE_NAME(sh4be)(this, stream, pc, oprom, opram, options);
 }
 
 

--- a/src/devices/cpu/sh4/sh4.h
+++ b/src/devices/cpu/sh4/sh4.h
@@ -225,7 +225,7 @@ protected:
 	// device_disasm_interface overrides
 	virtual uint32_t disasm_min_opcode_bytes() const override { return 2; }
 	virtual uint32_t disasm_max_opcode_bytes() const override { return 2; }
-	virtual offs_t disasm_disassemble(char *buffer, offs_t pc, const uint8_t *oprom, const uint8_t *opram, uint32_t options) override;
+	virtual offs_t disasm_disassemble(std::ostream &stream, offs_t pc, const uint8_t *oprom, const uint8_t *opram, uint32_t options) override;
 
 protected:
 	address_space_config m_program_config;
@@ -758,7 +758,7 @@ public:
 
 protected:
 	virtual void execute_run() override;
-	virtual offs_t disasm_disassemble(char *buffer, offs_t pc, const uint8_t *oprom, const uint8_t *opram, uint32_t options) override;
+	virtual offs_t disasm_disassemble(std::ostream &stream, offs_t pc, const uint8_t *oprom, const uint8_t *opram, uint32_t options) override;
 };
 
 
@@ -776,7 +776,7 @@ public:
 
 protected:
 	virtual void execute_run() override;
-	virtual offs_t disasm_disassemble(char *buffer, offs_t pc, const uint8_t *oprom, const uint8_t *opram, uint32_t options) override;
+	virtual offs_t disasm_disassemble(std::ostream &stream, offs_t pc, const uint8_t *oprom, const uint8_t *opram, uint32_t options) override;
 };
 
 

--- a/src/devices/cpu/sh4/sh4dasm.cpp
+++ b/src/devices/cpu/sh4/sh4dasm.cpp
@@ -896,18 +896,10 @@ unsigned DasmSH4(std::ostream &stream, unsigned pc, uint16_t opcode)
 
 CPU_DISASSEMBLE(sh4)
 {
-	std::ostringstream stream;
-	offs_t result = DasmSH4(stream, pc, (oprom[1] << 8) | oprom[0]);
-	std::string stream_str = stream.str();
-	strcpy(buffer, stream_str.c_str());
-	return result;
+	return DasmSH4(stream, pc, (oprom[1] << 8) | oprom[0]);
 }
 
 CPU_DISASSEMBLE(sh4be)
 {
-	std::ostringstream stream;
-	offs_t result = DasmSH4(stream, pc, (oprom[0] << 8) | oprom[1]);
-	std::string stream_str = stream.str();
-	strcpy(buffer, stream_str.c_str());
-	return result;
+	return DasmSH4(stream, pc, (oprom[0] << 8) | oprom[1]);
 }

--- a/src/devices/cpu/sharc/sharc.cpp
+++ b/src/devices/cpu/sharc/sharc.cpp
@@ -80,10 +80,10 @@ adsp21062_device::adsp21062_device(const machine_config &mconfig, const char *ta
 }
 
 
-offs_t adsp21062_device::disasm_disassemble(char *buffer, offs_t pc, const uint8_t *oprom, const uint8_t *opram, uint32_t options)
+offs_t adsp21062_device::disasm_disassemble(std::ostream &stream, offs_t pc, const uint8_t *oprom, const uint8_t *opram, uint32_t options)
 {
 	extern CPU_DISASSEMBLE( sharc );
-	return CPU_DISASSEMBLE_NAME(sharc)(this, buffer, pc, oprom, opram, options);
+	return CPU_DISASSEMBLE_NAME(sharc)(this, stream, pc, oprom, opram, options);
 }
 
 void adsp21062_device::enable_recompiler()

--- a/src/devices/cpu/sharc/sharc.h
+++ b/src/devices/cpu/sharc/sharc.h
@@ -263,7 +263,7 @@ protected:
 	// device_disasm_interface overrides
 	virtual uint32_t disasm_min_opcode_bytes() const override { return 6; }
 	virtual uint32_t disasm_max_opcode_bytes() const override { return 6; }
-	virtual offs_t disasm_disassemble(char *buffer, offs_t pc, const uint8_t *oprom, const uint8_t *opram, uint32_t options) override;
+	virtual offs_t disasm_disassemble(std::ostream &stream, offs_t pc, const uint8_t *oprom, const uint8_t *opram, uint32_t options) override;
 
 	direct_read_data *m_direct;
 

--- a/src/devices/cpu/sharc/sharcdsm.cpp
+++ b/src/devices/cpu/sharc/sharcdsm.cpp
@@ -1225,6 +1225,8 @@ CPU_DISASSEMBLE( sharc )
 			((uint64_t)oprom[2] << 16) | ((uint64_t)oprom[3] << 24) |
 			((uint64_t)oprom[4] << 32) | ((uint64_t)oprom[5] << 40);
 
+	char buffer[256];
 	flags = sharc_dasm_one(buffer, pc, op);
+	stream << buffer;
 	return 1 | flags | DASMFLAG_SUPPORTED;
 }

--- a/src/devices/cpu/sharc/sharcdsm.cpp
+++ b/src/devices/cpu/sharc/sharcdsm.cpp
@@ -1206,16 +1206,6 @@ static uint32_t sharc_dasm_one(std::ostream &stream, offs_t pc, uint64_t opcode)
 }
 
 
-static uint32_t sharc_dasm_one(char *buffer, offs_t pc, uint64_t opcode)
-{
-	std::ostringstream stream;
-	uint32_t result = sharc_dasm_one(stream, pc, opcode);
-	std::string stream_str = stream.str();
-	strcpy(buffer, stream_str.c_str());
-	return result;
-}
-
-
 CPU_DISASSEMBLE( sharc )
 {
 	uint64_t op;
@@ -1225,8 +1215,6 @@ CPU_DISASSEMBLE( sharc )
 			((uint64_t)oprom[2] << 16) | ((uint64_t)oprom[3] << 24) |
 			((uint64_t)oprom[4] << 32) | ((uint64_t)oprom[5] << 40);
 
-	char buffer[256];
-	flags = sharc_dasm_one(buffer, pc, op);
-	stream << buffer;
+	flags = sharc_dasm_one(stream, pc, op);
 	return 1 | flags | DASMFLAG_SUPPORTED;
 }

--- a/src/devices/cpu/sharc/sharcops.hxx
+++ b/src/devices/cpu/sharc/sharcops.hxx
@@ -2722,7 +2722,7 @@ void adsp21062_device::sharcop_idle()
 void adsp21062_device::sharcop_unimplemented()
 {
 	extern CPU_DISASSEMBLE(sharc);
-	std::stringstream dasm;
+	std::ostringstream dasm;
 	CPU_DISASSEMBLE_NAME(sharc)(nullptr, dasm, m_core->pc, nullptr, nullptr, 0);
 	osd_printf_debug("SHARC: %08X: %s\n", m_core->pc, dasm.str().c_str());
 	fatalerror("SHARC: Unimplemented opcode %04X%08X at %08X\n", (uint16_t)(m_core->opcode >> 32), (uint32_t)(m_core->opcode), m_core->pc);

--- a/src/devices/cpu/sharc/sharcops.hxx
+++ b/src/devices/cpu/sharc/sharcops.hxx
@@ -2722,8 +2722,8 @@ void adsp21062_device::sharcop_idle()
 void adsp21062_device::sharcop_unimplemented()
 {
 	extern CPU_DISASSEMBLE(sharc);
-	char dasm[1000];
+	std::stringstream dasm;
 	CPU_DISASSEMBLE_NAME(sharc)(nullptr, dasm, m_core->pc, nullptr, nullptr, 0);
-	osd_printf_debug("SHARC: %08X: %s\n", m_core->pc, dasm);
+	osd_printf_debug("SHARC: %08X: %s\n", m_core->pc, dasm.str().c_str());
 	fatalerror("SHARC: Unimplemented opcode %04X%08X at %08X\n", (uint16_t)(m_core->opcode >> 32), (uint32_t)(m_core->opcode), m_core->pc);
 }

--- a/src/devices/cpu/sm510/kb1013vk1-2.h
+++ b/src/devices/cpu/sm510/kb1013vk1-2.h
@@ -26,7 +26,7 @@ public:
 	kb1013vk12_device(const machine_config &mconfig, const char *tag, device_t *owner, uint32_t clock);
 
 protected:
-	virtual offs_t disasm_disassemble(char *buffer, offs_t pc, const uint8_t *oprom, const uint8_t *opram, uint32_t options) override;
+	virtual offs_t disasm_disassemble(std::ostream &stream, offs_t pc, const uint8_t *oprom, const uint8_t *opram, uint32_t options) override;
 	virtual void execute_one() override;
 
 	// opcode handlers

--- a/src/devices/cpu/sm510/kb1013vk1-2core.cpp
+++ b/src/devices/cpu/sm510/kb1013vk1-2core.cpp
@@ -34,10 +34,10 @@ kb1013vk12_device::kb1013vk12_device(const machine_config &mconfig, const char *
 
 
 // disasm
-offs_t kb1013vk12_device::disasm_disassemble(char *buffer, offs_t pc, const uint8_t *oprom, const uint8_t *opram, uint32_t options)
+offs_t kb1013vk12_device::disasm_disassemble(std::ostream &stream, offs_t pc, const uint8_t *oprom, const uint8_t *opram, uint32_t options)
 {
 	extern CPU_DISASSEMBLE(kb1013vk12);
-	return CPU_DISASSEMBLE_NAME(kb1013vk12)(this, buffer, pc, oprom, opram, options);
+	return CPU_DISASSEMBLE_NAME(kb1013vk12)(this, stream, pc, oprom, opram, options);
 }
 
 

--- a/src/devices/cpu/sm510/sm500.h
+++ b/src/devices/cpu/sm510/sm500.h
@@ -50,7 +50,7 @@ public:
 	sm500_device(const machine_config &mconfig, device_type type, const char *name, const char *tag, device_t *owner, uint32_t clock, int stack_levels, int prgwidth, address_map_constructor program, int datawidth, address_map_constructor data, const char *shortname, const char *source);
 
 protected:
-	virtual offs_t disasm_disassemble(char *buffer, offs_t pc, const uint8_t *oprom, const uint8_t *opram, uint32_t options) override;
+	virtual offs_t disasm_disassemble(std::ostream &stream, offs_t pc, const uint8_t *oprom, const uint8_t *opram, uint32_t options) override;
 	virtual void execute_one() override;
 	virtual void get_opcode_param() override;
 

--- a/src/devices/cpu/sm510/sm500core.cpp
+++ b/src/devices/cpu/sm510/sm500core.cpp
@@ -38,10 +38,10 @@ sm500_device::sm500_device(const machine_config &mconfig, device_type type, cons
 
 
 // disasm
-offs_t sm500_device::disasm_disassemble(char *buffer, offs_t pc, const uint8_t *oprom, const uint8_t *opram, uint32_t options)
+offs_t sm500_device::disasm_disassemble(std::ostream &stream, offs_t pc, const uint8_t *oprom, const uint8_t *opram, uint32_t options)
 {
 	extern CPU_DISASSEMBLE(sm500);
-	return CPU_DISASSEMBLE_NAME(sm500)(this, buffer, pc, oprom, opram, options);
+	return CPU_DISASSEMBLE_NAME(sm500)(this, stream, pc, oprom, opram, options);
 }
 
 

--- a/src/devices/cpu/sm510/sm510.h
+++ b/src/devices/cpu/sm510/sm510.h
@@ -298,7 +298,7 @@ public:
 	sm510_device(const machine_config &mconfig, const char *tag, device_t *owner, uint32_t clock);
 
 protected:
-	virtual offs_t disasm_disassemble(char *buffer, offs_t pc, const uint8_t *oprom, const uint8_t *opram, uint32_t options) override;
+	virtual offs_t disasm_disassemble(std::ostream &stream, offs_t pc, const uint8_t *oprom, const uint8_t *opram, uint32_t options) override;
 	virtual void execute_one() override;
 	virtual void get_opcode_param() override;
 
@@ -313,7 +313,7 @@ public:
 	sm511_device(const machine_config &mconfig, device_type type, const char *name, const char *tag, device_t *owner, uint32_t clock, int stack_levels, int prgwidth, address_map_constructor program, int datawidth, address_map_constructor data, const char *shortname, const char *source);
 
 protected:
-	virtual offs_t disasm_disassemble(char *buffer, offs_t pc, const uint8_t *oprom, const uint8_t *opram, uint32_t options) override;
+	virtual offs_t disasm_disassemble(std::ostream &stream, offs_t pc, const uint8_t *oprom, const uint8_t *opram, uint32_t options) override;
 	virtual void execute_one() override;
 	virtual void get_opcode_param() override;
 };

--- a/src/devices/cpu/sm510/sm510core.cpp
+++ b/src/devices/cpu/sm510/sm510core.cpp
@@ -36,10 +36,10 @@ sm510_device::sm510_device(const machine_config &mconfig, const char *tag, devic
 
 
 // disasm
-offs_t sm510_device::disasm_disassemble(char *buffer, offs_t pc, const uint8_t *oprom, const uint8_t *opram, uint32_t options)
+offs_t sm510_device::disasm_disassemble(std::ostream &stream, offs_t pc, const uint8_t *oprom, const uint8_t *opram, uint32_t options)
 {
 	extern CPU_DISASSEMBLE(sm510);
-	return CPU_DISASSEMBLE_NAME(sm510)(this, buffer, pc, oprom, opram, options);
+	return CPU_DISASSEMBLE_NAME(sm510)(this, stream, pc, oprom, opram, options);
 }
 
 

--- a/src/devices/cpu/sm510/sm510d.cpp
+++ b/src/devices/cpu/sm510/sm510d.cpp
@@ -192,15 +192,6 @@ static offs_t sm510_common_disasm(const uint8_t *lut_mnemonic, const uint8_t *lu
 	return len | s_flags[instr] | DASMFLAG_SUPPORTED;
 }
 
-static offs_t sm510_common_disasm(const uint8_t *lut_mnemonic, const uint8_t *lut_extended, char *buffer, offs_t pc, const uint8_t *oprom, const uint8_t *opram)
-{
-	std::ostringstream stream;
-	offs_t result = sm510_common_disasm(lut_mnemonic, lut_extended, stream, pc, oprom, opram);
-	std::string stream_str = stream.str();
-	strcpy(buffer, stream_str.c_str());
-	return result;
-}
-
 
 // SM510 disasm
 
@@ -230,7 +221,7 @@ static const uint8_t sm510_mnemonic[0x100] =
 
 CPU_DISASSEMBLE(sm510)
 {
-	return sm510_common_disasm(sm510_mnemonic, nullptr, buffer, pc, oprom, opram);
+	return sm510_common_disasm(sm510_mnemonic, nullptr, stream, pc, oprom, opram);
 }
 
 
@@ -272,7 +263,7 @@ CPU_DISASSEMBLE(sm511)
 	memset(ext, 0, 0x100);
 	memcpy(ext + 0x30, sm511_extended, 0x10);
 
-	return sm510_common_disasm(sm511_mnemonic, ext, buffer, pc, oprom, opram);
+	return sm510_common_disasm(sm511_mnemonic, ext, stream, pc, oprom, opram);
 }
 
 
@@ -314,7 +305,7 @@ CPU_DISASSEMBLE(sm500)
 	memset(ext, 0, 0x100);
 	memcpy(ext + 0x00, sm500_extended, 0x10);
 
-	return sm510_common_disasm(sm500_mnemonic, ext, buffer, pc, oprom, opram);
+	return sm510_common_disasm(sm500_mnemonic, ext, stream, pc, oprom, opram);
 }
 
 
@@ -356,5 +347,5 @@ CPU_DISASSEMBLE(kb1013vk12)
 	memset(ext, 0, 0x100);
 	memcpy(ext + 0x00, kb1013vk12_extended, 0x10);
 
-	return sm510_common_disasm(kb1013vk12_mnemonic, ext, buffer, pc, oprom, opram);
+	return sm510_common_disasm(kb1013vk12_mnemonic, ext, stream, pc, oprom, opram);
 }

--- a/src/devices/cpu/sm510/sm511core.cpp
+++ b/src/devices/cpu/sm510/sm511core.cpp
@@ -35,10 +35,10 @@ ADDRESS_MAP_END
 
 
 // disasm
-offs_t sm511_device::disasm_disassemble(char *buffer, offs_t pc, const uint8_t *oprom, const uint8_t *opram, uint32_t options)
+offs_t sm511_device::disasm_disassemble(std::ostream &stream, offs_t pc, const uint8_t *oprom, const uint8_t *opram, uint32_t options)
 {
 	extern CPU_DISASSEMBLE(sm511);
-	return CPU_DISASSEMBLE_NAME(sm511)(this, buffer, pc, oprom, opram, options);
+	return CPU_DISASSEMBLE_NAME(sm511)(this, stream, pc, oprom, opram, options);
 }
 
 

--- a/src/devices/cpu/sm8500/sm8500.cpp
+++ b/src/devices/cpu/sm8500/sm8500.cpp
@@ -341,10 +341,10 @@ void sm8500_cpu_device::process_interrupts()
 }
 
 
-offs_t sm8500_cpu_device::disasm_disassemble(char *buffer, offs_t pc, const uint8_t *oprom, const uint8_t *opram, uint32_t options)
+offs_t sm8500_cpu_device::disasm_disassemble(std::ostream &stream, offs_t pc, const uint8_t *oprom, const uint8_t *opram, uint32_t options)
 {
 	extern CPU_DISASSEMBLE( sm8500 );
-	return CPU_DISASSEMBLE_NAME(sm8500)(this, buffer, pc, oprom, opram, options);
+	return CPU_DISASSEMBLE_NAME(sm8500)(this, stream, pc, oprom, opram, options);
 }
 
 

--- a/src/devices/cpu/sm8500/sm8500.h
+++ b/src/devices/cpu/sm8500/sm8500.h
@@ -76,7 +76,7 @@ protected:
 	// device_disasm_interface overrides
 	virtual uint32_t disasm_min_opcode_bytes() const override { return 1; }
 	virtual uint32_t disasm_max_opcode_bytes() const override { return 5; }
-	virtual offs_t disasm_disassemble(char *buffer, offs_t pc, const uint8_t *oprom, const uint8_t *opram, uint32_t options) override;
+	virtual offs_t disasm_disassemble(std::ostream &stream, offs_t pc, const uint8_t *oprom, const uint8_t *opram, uint32_t options) override;
 
 	inline void get_sp();
 	uint8_t mem_readbyte(uint32_t offset) const;

--- a/src/devices/cpu/sm8500/sm8500d.cpp
+++ b/src/devices/cpu/sm8500/sm8500d.cpp
@@ -173,7 +173,7 @@ static const sm8500dasm mnemonic[256] = {
 
 };
 
-static offs_t internal_disasm_sm8500(cpu_device *device, std::ostream &stream, offs_t pc, const uint8_t *oprom, const uint8_t *opram, int options)
+CPU_DISASSEMBLE(sm8500)
 {
 	const sm8500dasm *instr;
 	uint8_t op;
@@ -578,14 +578,4 @@ static offs_t internal_disasm_sm8500(cpu_device *device, std::ostream &stream, o
 	}
 
 	return pos | s_flags[instr->mnemonic] | DASMFLAG_SUPPORTED;
-}
-
-
-CPU_DISASSEMBLE(sm8500)
-{
-	std::ostringstream stream;
-	offs_t result = internal_disasm_sm8500(device, stream, pc, oprom, opram, options);
-	std::string stream_str = stream.str();
-	strcpy(buffer, stream_str.c_str());
-	return result;
 }

--- a/src/devices/cpu/sparc/mb86901.cpp
+++ b/src/devices/cpu/sparc/mb86901.cpp
@@ -548,10 +548,10 @@ uint32_t mb86901_device::disasm_max_opcode_bytes() const
 //  helper function
 //-------------------------------------------------
 
-offs_t mb86901_device::disasm_disassemble(char *buffer, offs_t pc, const uint8_t *oprom, const uint8_t *opram, uint32_t options)
+offs_t mb86901_device::disasm_disassemble(std::ostream &stream, offs_t pc, const uint8_t *oprom, const uint8_t *opram, uint32_t options)
 {
 	uint32_t op = *reinterpret_cast<const uint32_t *>(oprom);
-	return m_dasm.dasm(buffer, pc, big_endianize_int32(op));
+	return m_dasm.dasm(stream, pc, big_endianize_int32(op));
 }
 
 

--- a/src/devices/cpu/sparc/sparc.h
+++ b/src/devices/cpu/sparc/sparc.h
@@ -45,7 +45,7 @@ public:
 	// device_disasm_interface overrides
 	virtual uint32_t disasm_min_opcode_bytes() const override;
 	virtual uint32_t disasm_max_opcode_bytes() const override;
-	virtual offs_t disasm_disassemble(char *buffer, offs_t pc, const uint8_t *oprom, const uint8_t *opram, uint32_t options) override;
+	virtual offs_t disasm_disassemble(std::ostream &stream, offs_t pc, const uint8_t *oprom, const uint8_t *opram, uint32_t options) override;
 
 	// device_state_interface overrides
 	virtual void state_string_export(const device_state_entry &entry, std::string &str) const override;

--- a/src/devices/cpu/sparc/sparcdasm.cpp
+++ b/src/devices/cpu/sparc/sparcdasm.cpp
@@ -1050,16 +1050,6 @@ offs_t sparc_disassembler::dasm(std::ostream &stream, offs_t pc, uint32_t op) co
 }
 
 
-offs_t sparc_disassembler::dasm(char *buf, offs_t pc, uint32_t op) const
-{
-	std::ostringstream stream;
-	const offs_t result(dasm(stream, pc, op));
-	const std::string stream_str(stream.str());
-	strcpy(buf, stream_str.c_str());
-	return result;
-}
-
-
 offs_t sparc_disassembler::dasm_invalid(std::ostream &stream, offs_t pc, uint32_t op) const
 {
 	util::stream_format(stream, "%-*s0x%08x ! ", m_op_field_width, ".word", op);

--- a/src/devices/cpu/sparc/sparcdasm.h
+++ b/src/devices/cpu/sparc/sparcdasm.h
@@ -107,7 +107,6 @@ public:
 	}
 
 	offs_t dasm(std::ostream &stream, offs_t pc, uint32_t op) const;
-	offs_t dasm(char *buf, offs_t pc, uint32_t op) const;
 
 private:
 	struct branch_desc

--- a/src/devices/cpu/spc700/spc700.cpp
+++ b/src/devices/cpu/spc700/spc700.cpp
@@ -1344,9 +1344,9 @@ void spc700_device::execute_set_input( int inptnum, int state )
 
 #include "spc700ds.h"
 
-offs_t spc700_device::disasm_disassemble(char *buffer, offs_t pc, const uint8_t *oprom, const uint8_t *opram, uint32_t options)
+offs_t spc700_device::disasm_disassemble(std::ostream &stream, offs_t pc, const uint8_t *oprom, const uint8_t *opram, uint32_t options)
 {
-	return CPU_DISASSEMBLE_NAME(spc700)(this, buffer, pc, oprom, opram, options);
+	return CPU_DISASSEMBLE_NAME(spc700)(this, stream, pc, oprom, opram, options);
 }
 
 //int dump_flag = 0;

--- a/src/devices/cpu/spc700/spc700.h
+++ b/src/devices/cpu/spc700/spc700.h
@@ -35,7 +35,7 @@ protected:
 	// device_disasm_interface overrides
 	virtual uint32_t disasm_min_opcode_bytes() const override { return 1; }
 	virtual uint32_t disasm_max_opcode_bytes() const override { return 3; }
-	virtual offs_t disasm_disassemble(char *buffer, offs_t pc, const uint8_t *oprom, const uint8_t *opram, uint32_t options) override;
+	virtual offs_t disasm_disassemble(std::ostream &stream, offs_t pc, const uint8_t *oprom, const uint8_t *opram, uint32_t options) override;
 
 private:
 	address_space_config m_program_config;

--- a/src/devices/cpu/spc700/spc700ds.cpp
+++ b/src/devices/cpu/spc700/spc700ds.cpp
@@ -337,7 +337,7 @@ static inline unsigned int read_16_immediate(void)
 	return result | (*rombase++ << 8);
 }
 
-static offs_t internal_disasm_spc700(cpu_device *device, std::ostream &stream, offs_t pc, const uint8_t *oprom, const uint8_t *opram, int options)
+CPU_DISASSEMBLE(spc700)
 {
 	const spc700_opcode_struct* opcode;
 	uint32_t flags = 0;
@@ -429,14 +429,4 @@ static offs_t internal_disasm_spc700(cpu_device *device, std::ostream &stream, o
 		}
 	}
 	return (g_pc - pc) | flags | DASMFLAG_SUPPORTED;
-}
-
-
-CPU_DISASSEMBLE(spc700)
-{
-	std::ostringstream stream;
-	offs_t result = internal_disasm_spc700(device, stream, pc, oprom, opram, options);
-	std::string stream_str = stream.str();
-	strcpy(buffer, stream_str.c_str());
-	return result;
 }

--- a/src/devices/cpu/ssem/ssem.cpp
+++ b/src/devices/cpu/ssem/ssem.cpp
@@ -188,10 +188,10 @@ uint32_t ssem_device::disasm_max_opcode_bytes() const
 //  helper function
 //-------------------------------------------------
 
-offs_t ssem_device::disasm_disassemble(char *buffer, offs_t pc, const uint8_t *oprom, const uint8_t *opram, uint32_t options)
+offs_t ssem_device::disasm_disassemble(std::ostream &stream, offs_t pc, const uint8_t *oprom, const uint8_t *opram, uint32_t options)
 {
 	extern CPU_DISASSEMBLE( ssem );
-	return CPU_DISASSEMBLE_NAME(ssem)(this, buffer, pc, oprom, opram, options);
+	return CPU_DISASSEMBLE_NAME(ssem)(this, stream, pc, oprom, opram, options);
 }
 
 

--- a/src/devices/cpu/ssem/ssem.h
+++ b/src/devices/cpu/ssem/ssem.h
@@ -42,7 +42,7 @@ public:
 	// device_disasm_interface overrides
 	virtual uint32_t disasm_min_opcode_bytes() const override;
 	virtual uint32_t disasm_max_opcode_bytes() const override;
-	virtual offs_t disasm_disassemble(char *buffer, offs_t pc, const uint8_t *oprom, const uint8_t *opram, uint32_t options) override;
+	virtual offs_t disasm_disassemble(std::ostream &stream, offs_t pc, const uint8_t *oprom, const uint8_t *opram, uint32_t options) override;
 
 	// device_state_interface overrides
 	virtual void state_string_export(const device_state_entry &entry, std::string &str) const override;

--- a/src/devices/cpu/ssem/ssemdasm.cpp
+++ b/src/devices/cpu/ssem/ssemdasm.cpp
@@ -62,17 +62,6 @@ static offs_t ssem_dasm_one(std::ostream &stream, offs_t pc, uint32_t op)
 	return 4 | DASMFLAG_SUPPORTED;
 }
 
-
-static offs_t ssem_dasm_one(char *buffer, offs_t pc, uint32_t op)
-{
-	std::ostringstream stream;
-	offs_t result = ssem_dasm_one(stream, pc, op);
-	std::string stream_str = stream.str();
-	strcpy(buffer, stream_str.c_str());
-	return result;
-}
-
-
 /*****************************************************************************/
 
 CPU_DISASSEMBLE( ssem )
@@ -81,5 +70,5 @@ CPU_DISASSEMBLE( ssem )
 				(*(uint8_t *)(opram + 1) << 16) |
 				(*(uint8_t *)(opram + 2) <<  8) |
 				(*(uint8_t *)(opram + 3) <<  0);
-	return ssem_dasm_one(buffer, pc, op);
+	return ssem_dasm_one(stream, pc, op);
 }

--- a/src/devices/cpu/ssp1601/ssp1601.cpp
+++ b/src/devices/cpu/ssp1601/ssp1601.cpp
@@ -200,10 +200,10 @@ ssp1601_device::ssp1601_device(const machine_config &mconfig, const char *tag, d
 }
 
 
-offs_t ssp1601_device::disasm_disassemble(char *buffer, offs_t pc, const uint8_t *oprom, const uint8_t *opram, uint32_t options)
+offs_t ssp1601_device::disasm_disassemble(std::ostream &stream, offs_t pc, const uint8_t *oprom, const uint8_t *opram, uint32_t options)
 {
 	extern CPU_DISASSEMBLE( ssp1601 );
-	return CPU_DISASSEMBLE_NAME(ssp1601)(this, buffer, pc, oprom, opram, options);
+	return CPU_DISASSEMBLE_NAME(ssp1601)(this, stream, pc, oprom, opram, options);
 }
 
 

--- a/src/devices/cpu/ssp1601/ssp1601.h
+++ b/src/devices/cpu/ssp1601/ssp1601.h
@@ -45,7 +45,7 @@ protected:
 	// device_disasm_interface overrides
 	virtual uint32_t disasm_min_opcode_bytes() const override { return 2; }
 	virtual uint32_t disasm_max_opcode_bytes() const override { return 4; }
-	virtual offs_t disasm_disassemble(char *buffer, offs_t pc, const uint8_t *oprom, const uint8_t *opram, uint32_t options) override;
+	virtual offs_t disasm_disassemble(std::ostream &stream, offs_t pc, const uint8_t *oprom, const uint8_t *opram, uint32_t options) override;
 
 private:
 	address_space_config m_program_config;

--- a/src/devices/cpu/ssp1601/ssp1601d.cpp
+++ b/src/devices/cpu/ssp1601/ssp1601d.cpp
@@ -288,20 +288,11 @@ static unsigned dasm_ssp1601(std::ostream &stream, unsigned pc, const uint8_t *o
 	return size | flags | DASMFLAG_SUPPORTED;
 }
 
-static unsigned dasm_ssp1601(char *buffer, unsigned pc, const uint8_t *oprom)
-{
-	std::ostringstream stream;
-	offs_t result = dasm_ssp1601(stream, pc, oprom);
-	std::string stream_str = stream.str();
-	strcpy(buffer, stream_str.c_str());
-	return result;
-}
-
 // vim:ts=4
 
 CPU_DISASSEMBLE( ssp1601 )
 {
 	//ssp1601_state_t *ssp1601_state = get_safe_token(device);
 
-	return dasm_ssp1601(buffer, pc, oprom);
+	return dasm_ssp1601(stream, pc, oprom);
 }

--- a/src/devices/cpu/superfx/superfx.cpp
+++ b/src/devices/cpu/superfx/superfx.cpp
@@ -1438,15 +1438,6 @@ void superfx_device::execute_run()
 	}
 }
 
-offs_t superfx_device::disasm_disassemble(char *buffer, offs_t pc, const uint8_t *oprom, const uint8_t *opram, uint32_t options)
-{
-	std::ostringstream stream;
-	offs_t result = disasm_disassemble(stream, pc, oprom, opram, options);
-	std::string stream_str = stream.str();
-	strcpy(buffer, stream_str.c_str());
-	return result;
-}
-
 offs_t superfx_device::disasm_disassemble(std::ostream &stream, offs_t pc, const uint8_t *oprom, const uint8_t *opram, uint32_t options)
 {
 	uint8_t  op = *(uint8_t *)(opram + 0);

--- a/src/devices/cpu/superfx/superfx.h
+++ b/src/devices/cpu/superfx/superfx.h
@@ -126,7 +126,7 @@ protected:
 	// device_disasm_interface overrides
 	virtual uint32_t disasm_min_opcode_bytes() const override { return 1; }
 	virtual uint32_t disasm_max_opcode_bytes() const override { return 3; }
-	virtual offs_t disasm_disassemble(char *buffer, offs_t pc, const uint8_t *oprom, const uint8_t *opram, uint32_t options) override;
+	virtual offs_t disasm_disassemble(std::ostream &stream, offs_t pc, const uint8_t *oprom, const uint8_t *opram, uint32_t options) override;
 
 private:
 	address_space_config m_program_config;
@@ -209,8 +209,6 @@ private:
 	inline void superfx_add_clocks_internal(uint32_t clocks);
 	void superfx_timing_reset();
 	inline void superfx_dreg_sfr_sz_update();
-
-	offs_t disasm_disassemble(std::ostream &stream, offs_t pc, const uint8_t *oprom, const uint8_t *opram, uint32_t options);
 };
 
 

--- a/src/devices/cpu/t11/t11.cpp
+++ b/src/devices/cpu/t11/t11.cpp
@@ -422,8 +422,8 @@ void t11_device::execute_run()
 }
 
 
-offs_t t11_device::disasm_disassemble(char *buffer, offs_t pc, const uint8_t *oprom, const uint8_t *opram, uint32_t options)
+offs_t t11_device::disasm_disassemble(std::ostream &stream, offs_t pc, const uint8_t *oprom, const uint8_t *opram, uint32_t options)
 {
 	extern CPU_DISASSEMBLE( t11 );
-	return CPU_DISASSEMBLE_NAME(t11)(this, buffer, pc, oprom, opram, options);
+	return CPU_DISASSEMBLE_NAME(t11)(this, stream, pc, oprom, opram, options);
 }

--- a/src/devices/cpu/t11/t11.h
+++ b/src/devices/cpu/t11/t11.h
@@ -67,7 +67,7 @@ protected:
 	// device_disasm_interface overrides
 	virtual uint32_t disasm_min_opcode_bytes() const override { return 2; }
 	virtual uint32_t disasm_max_opcode_bytes() const override { return 6; }
-	virtual offs_t disasm_disassemble(char *buffer, offs_t pc, const uint8_t *oprom, const uint8_t *opram, uint32_t options) override;
+	virtual offs_t disasm_disassemble(std::ostream &stream, offs_t pc, const uint8_t *oprom, const uint8_t *opram, uint32_t options) override;
 
 protected:
 	address_space_config m_program_config;

--- a/src/devices/cpu/t11/t11dasm.cpp
+++ b/src/devices/cpu/t11/t11dasm.cpp
@@ -84,7 +84,7 @@ static unsigned MakeEA (char *ea, int lo, unsigned pc, int width)
 }
 
 
-static offs_t internal_disasm_t11(cpu_device *device, std::ostream &stream, offs_t pc, const uint8_t *oprom, const uint8_t *opram, int options)
+CPU_DISASSEMBLE(t11)
 {
 	char ea1[32], ea2[32];
 	unsigned PC = pc;
@@ -515,14 +515,4 @@ static offs_t internal_disasm_t11(cpu_device *device, std::ostream &stream, offs
 	}
 
 	return (pc - PC) | flags | DASMFLAG_SUPPORTED;
-}
-
-
-CPU_DISASSEMBLE(t11)
-{
-	std::ostringstream stream;
-	offs_t result = internal_disasm_t11(device, stream, pc, oprom, opram, options);
-	std::string stream_str = stream.str();
-	strcpy(buffer, stream_str.c_str());
-	return result;
 }

--- a/src/devices/cpu/tlcs90/tlcs90.h
+++ b/src/devices/cpu/tlcs90/tlcs90.h
@@ -58,14 +58,7 @@ protected:
 	// device_disasm_interface overrides
 	virtual uint32_t disasm_min_opcode_bytes() const override { return 1; }
 	virtual uint32_t disasm_max_opcode_bytes() const override { return 6; }
-	virtual offs_t disasm_disassemble(char *buffer, offs_t pc, const uint8_t *oprom, const uint8_t *opram, uint32_t options) override
-	{
-		std::ostringstream stream;
-		offs_t result = disasm_disassemble(stream, pc, oprom, opram, options);
-		std::string stream_str = stream.str();
-		strcpy(buffer, stream_str.c_str());
-		return result;
-	}
+	virtual offs_t disasm_disassemble(std::ostream &stream, offs_t pc, const uint8_t *oprom, const uint8_t *opram, uint32_t options) override;
 
 private:
 	enum e_mode {
@@ -147,7 +140,6 @@ private:
 	void t90_stop_timer(int i);
 	void t90_stop_timer4();
 	void set_irq_line(int irq, int state);
-	offs_t disasm_disassemble(std::ostream &stream, offs_t pc, const uint8_t *oprom, const uint8_t *opram, uint32_t options);
 };
 
 

--- a/src/devices/cpu/tlcs900/dasm900.cpp
+++ b/src/devices/cpu/tlcs900/dasm900.cpp
@@ -1433,7 +1433,7 @@ static const char *const s_cond[16] =
 };
 
 
-static offs_t internal_disasm_tlcs900(cpu_device *device, std::ostream &stream, offs_t pc, const uint8_t *oprom, const uint8_t *opram, int options)
+CPU_DISASSEMBLE(tlcs900)
 {
 	const tlcs900inst *dasm;
 	std::string buf;
@@ -2255,14 +2255,4 @@ static offs_t internal_disasm_tlcs900(cpu_device *device, std::ostream &stream, 
 	}
 
 	return pos | flags | DASMFLAG_SUPPORTED;
-}
-
-
-CPU_DISASSEMBLE(tlcs900)
-{
-	std::ostringstream stream;
-	offs_t result = internal_disasm_tlcs900(device, stream, pc, oprom, opram, options);
-	std::string stream_str = stream.str();
-	strcpy(buffer, stream_str.c_str());
-	return result;
 }

--- a/src/devices/cpu/tlcs900/tlcs900.cpp
+++ b/src/devices/cpu/tlcs900/tlcs900.cpp
@@ -141,10 +141,10 @@ void tmp95c063_device::device_config_complete()
 }
 
 
-offs_t tlcs900h_device::disasm_disassemble(char *buffer, offs_t pc, const uint8_t *oprom, const uint8_t *opram, uint32_t options)
+offs_t tlcs900h_device::disasm_disassemble(std::ostream &stream, offs_t pc, const uint8_t *oprom, const uint8_t *opram, uint32_t options)
 {
 	extern CPU_DISASSEMBLE( tlcs900 );
-	return CPU_DISASSEMBLE_NAME(tlcs900)(this, buffer, pc, oprom, opram, options);
+	return CPU_DISASSEMBLE_NAME(tlcs900)(this, stream, pc, oprom, opram, options);
 }
 
 

--- a/src/devices/cpu/tlcs900/tlcs900.h
+++ b/src/devices/cpu/tlcs900/tlcs900.h
@@ -76,7 +76,7 @@ protected:
 	// device_disasm_interface overrides
 	virtual uint32_t disasm_min_opcode_bytes() const override { return 1; }
 	virtual uint32_t disasm_max_opcode_bytes() const override { return 7; } /* FIXME */
-	virtual offs_t disasm_disassemble(char *buffer, offs_t pc, const uint8_t *oprom, const uint8_t *opram, uint32_t options) override;
+	virtual offs_t disasm_disassemble(std::ostream &stream, offs_t pc, const uint8_t *oprom, const uint8_t *opram, uint32_t options) override;
 
 protected:
 	int m_am8_16;

--- a/src/devices/cpu/tms1000/tms0980.cpp
+++ b/src/devices/cpu/tms1000/tms0980.cpp
@@ -90,10 +90,10 @@ machine_config_constructor tms1980_cpu_device::device_mconfig_additions() const
 
 
 // disasm
-offs_t tms0980_cpu_device::disasm_disassemble(char *buffer, offs_t pc, const uint8_t *oprom, const uint8_t *opram, uint32_t options)
+offs_t tms0980_cpu_device::disasm_disassemble(std::ostream &stream, offs_t pc, const uint8_t *oprom, const uint8_t *opram, uint32_t options)
 {
 	extern CPU_DISASSEMBLE(tms0980);
-	return CPU_DISASSEMBLE_NAME(tms0980)(this, buffer, pc, oprom, opram, options);
+	return CPU_DISASSEMBLE_NAME(tms0980)(this, stream, pc, oprom, opram, options);
 }
 
 

--- a/src/devices/cpu/tms1000/tms0980.h
+++ b/src/devices/cpu/tms1000/tms0980.h
@@ -28,7 +28,7 @@ protected:
 
 	virtual uint32_t disasm_min_opcode_bytes() const override { return 2; }
 	virtual uint32_t disasm_max_opcode_bytes() const override { return 2; }
-	virtual offs_t disasm_disassemble(char *buffer, offs_t pc, const uint8_t *oprom, const uint8_t *opram, uint32_t options) override;
+	virtual offs_t disasm_disassemble(std::ostream &stream, offs_t pc, const uint8_t *oprom, const uint8_t *opram, uint32_t options) override;
 
 	virtual uint8_t read_k_input() override;
 	virtual void set_cki_bus() override;

--- a/src/devices/cpu/tms1000/tms1000.cpp
+++ b/src/devices/cpu/tms1000/tms1000.cpp
@@ -93,10 +93,10 @@ machine_config_constructor tms1000_cpu_device::device_mconfig_additions() const
 
 
 // disasm
-offs_t tms1000_cpu_device::disasm_disassemble(char *buffer, offs_t pc, const uint8_t *oprom, const uint8_t *opram, uint32_t options)
+offs_t tms1000_cpu_device::disasm_disassemble(std::ostream &stream, offs_t pc, const uint8_t *oprom, const uint8_t *opram, uint32_t options)
 {
 	extern CPU_DISASSEMBLE(tms1000);
-	return CPU_DISASSEMBLE_NAME(tms1000)(this, buffer, pc, oprom, opram, options);
+	return CPU_DISASSEMBLE_NAME(tms1000)(this, stream, pc, oprom, opram, options);
 }
 
 

--- a/src/devices/cpu/tms1000/tms1000.h
+++ b/src/devices/cpu/tms1000/tms1000.h
@@ -24,7 +24,7 @@ protected:
 	virtual machine_config_constructor device_mconfig_additions() const override;
 
 
-	virtual offs_t disasm_disassemble(char *buffer, offs_t pc, const uint8_t *oprom, const uint8_t *opram, uint32_t options) override;
+	virtual offs_t disasm_disassemble(std::ostream &stream, offs_t pc, const uint8_t *oprom, const uint8_t *opram, uint32_t options) override;
 };
 
 class tms1070_cpu_device : public tms1000_cpu_device

--- a/src/devices/cpu/tms1000/tms1100.cpp
+++ b/src/devices/cpu/tms1000/tms1100.cpp
@@ -49,10 +49,10 @@ tms1370_cpu_device::tms1370_cpu_device(const machine_config &mconfig, const char
 
 
 // disasm
-offs_t tms1100_cpu_device::disasm_disassemble(char *buffer, offs_t pc, const uint8_t *oprom, const uint8_t *opram, uint32_t options)
+offs_t tms1100_cpu_device::disasm_disassemble(std::ostream &stream, offs_t pc, const uint8_t *oprom, const uint8_t *opram, uint32_t options)
 {
 	extern CPU_DISASSEMBLE(tms1100);
-	return CPU_DISASSEMBLE_NAME(tms1100)(this, buffer, pc, oprom, opram, options);
+	return CPU_DISASSEMBLE_NAME(tms1100)(this, stream, pc, oprom, opram, options);
 }
 
 

--- a/src/devices/cpu/tms1000/tms1100.h
+++ b/src/devices/cpu/tms1000/tms1100.h
@@ -22,7 +22,7 @@ protected:
 	// overrides
 	virtual void device_reset() override;
 
-	virtual offs_t disasm_disassemble(char *buffer, offs_t pc, const uint8_t *oprom, const uint8_t *opram, uint32_t options) override;
+	virtual offs_t disasm_disassemble(std::ostream &stream, offs_t pc, const uint8_t *oprom, const uint8_t *opram, uint32_t options) override;
 
 	virtual void op_setr() override;
 	virtual void op_rstr() override;

--- a/src/devices/cpu/tms1000/tms1k_dasm.cpp
+++ b/src/devices/cpu/tms1000/tms1k_dasm.cpp
@@ -259,32 +259,23 @@ static offs_t tms1k_dasm(std::ostream &stream, const uint8_t *oprom, const uint8
 	return pos | s_flags[instr] | DASMFLAG_SUPPORTED;
 }
 
-static offs_t tms1k_dasm(char *buffer, const uint8_t *oprom, const uint8_t *lut_mnemonic, uint16_t opcode_mask)
-{
-	std::ostringstream stream;
-	offs_t result = tms1k_dasm(stream, oprom, lut_mnemonic, opcode_mask);
-	std::string stream_str = stream.str();
-	strcpy(buffer, stream_str.c_str());
-	return result;
-}
-
 
 CPU_DISASSEMBLE(tms1000)
 {
-	return tms1k_dasm(buffer, oprom, tms1000_mnemonic, 0xff);
+	return tms1k_dasm(stream, oprom, tms1000_mnemonic, 0xff);
 }
 
 CPU_DISASSEMBLE(tms1100)
 {
-	return tms1k_dasm(buffer, oprom, tms1100_mnemonic, 0xff);
+	return tms1k_dasm(stream, oprom, tms1100_mnemonic, 0xff);
 }
 
 CPU_DISASSEMBLE(tms0980)
 {
-	return tms1k_dasm(buffer, oprom, tms0980_mnemonic, 0x1ff);
+	return tms1k_dasm(stream, oprom, tms0980_mnemonic, 0x1ff);
 }
 
 CPU_DISASSEMBLE(tp0320)
 {
-	return tms1k_dasm(buffer, oprom, tp0320_mnemonic, 0x1ff);
+	return tms1k_dasm(stream, oprom, tp0320_mnemonic, 0x1ff);
 }

--- a/src/devices/cpu/tms1000/tp0320.cpp
+++ b/src/devices/cpu/tms1000/tp0320.cpp
@@ -58,10 +58,10 @@ machine_config_constructor tp0320_cpu_device::device_mconfig_additions() const
 
 
 // disasm
-offs_t tp0320_cpu_device::disasm_disassemble(char *buffer, offs_t pc, const uint8_t *oprom, const uint8_t *opram, uint32_t options)
+offs_t tp0320_cpu_device::disasm_disassemble(std::ostream &stream, offs_t pc, const uint8_t *oprom, const uint8_t *opram, uint32_t options)
 {
 	extern CPU_DISASSEMBLE(tp0320);
-	return CPU_DISASSEMBLE_NAME(tp0320)(this, buffer, pc, oprom, opram, options);
+	return CPU_DISASSEMBLE_NAME(tp0320)(this, stream, pc, oprom, opram, options);
 }
 
 

--- a/src/devices/cpu/tms1000/tp0320.h
+++ b/src/devices/cpu/tms1000/tp0320.h
@@ -24,7 +24,7 @@ protected:
 	virtual uint32_t decode_fixed(uint16_t op) override { return 0; } // not yet
 	virtual uint32_t decode_micro(uint8_t sel) override;
 	virtual void device_reset() override;
-	virtual offs_t disasm_disassemble(char *buffer, offs_t pc, const uint8_t *oprom, const uint8_t *opram, uint32_t options) override;
+	virtual offs_t disasm_disassemble(std::ostream &stream, offs_t pc, const uint8_t *oprom, const uint8_t *opram, uint32_t options) override;
 
 	virtual machine_config_constructor device_mconfig_additions() const override;
 };

--- a/src/devices/cpu/tms32010/32010dsm.cpp
+++ b/src/devices/cpu/tms32010/32010dsm.cpp
@@ -222,7 +222,7 @@ static void InitDasm32010(void)
 	OpInizialized = 1;
 }
 
-static offs_t internal_disasm_tms32010(cpu_device *device, std::ostream &stream, offs_t pc, const uint8_t *oprom, const uint8_t *opram, int options)
+CPU_DISASSEMBLE(tms32010)
 {
 	uint32_t flags = 0;
 	int a, b, d, k, m, n, p, r, s, w;   /* these can all be filled in by parsing an instruction */
@@ -331,14 +331,4 @@ static offs_t internal_disasm_tms32010(cpu_device *device, std::ostream &stream,
 		}
 	}
 	return cnt | flags | DASMFLAG_SUPPORTED;
-}
-
-
-CPU_DISASSEMBLE(tms32010)
-{
-	std::ostringstream stream;
-	offs_t result = internal_disasm_tms32010(device, stream, pc, oprom, opram, options);
-	std::string stream_str = stream.str();
-	strcpy(buffer, stream_str.c_str());
-	return result;
 }

--- a/src/devices/cpu/tms32010/tms32010.cpp
+++ b/src/devices/cpu/tms32010/tms32010.cpp
@@ -131,10 +131,10 @@ tms32016_device::tms32016_device(const machine_config &mconfig, const char *tag,
 }
 
 
-offs_t tms32010_device::disasm_disassemble(char *buffer, offs_t pc, const uint8_t *oprom, const uint8_t *opram, uint32_t options)
+offs_t tms32010_device::disasm_disassemble(std::ostream &stream, offs_t pc, const uint8_t *oprom, const uint8_t *opram, uint32_t options)
 {
 	extern CPU_DISASSEMBLE( tms32010 );
-	return CPU_DISASSEMBLE_NAME(tms32010)(this, buffer, pc, oprom, opram, options);
+	return CPU_DISASSEMBLE_NAME(tms32010)(this, stream, pc, oprom, opram, options);
 }
 
 

--- a/src/devices/cpu/tms32010/tms32010.h
+++ b/src/devices/cpu/tms32010/tms32010.h
@@ -72,7 +72,7 @@ protected:
 	// device_disasm_interface overrides
 	virtual uint32_t disasm_min_opcode_bytes() const override { return 2; }
 	virtual uint32_t disasm_max_opcode_bytes() const override { return 4; }
-	virtual offs_t disasm_disassemble(char *buffer, offs_t pc, const uint8_t *oprom, const uint8_t *opram, uint32_t options) override;
+	virtual offs_t disasm_disassemble(std::ostream &stream, offs_t pc, const uint8_t *oprom, const uint8_t *opram, uint32_t options) override;
 
 private:
 	address_space_config m_program_config;

--- a/src/devices/cpu/tms32025/32025dsm.cpp
+++ b/src/devices/cpu/tms32025/32025dsm.cpp
@@ -387,7 +387,7 @@ static void InitDasm32025(void)
 	OpInizialized = 1;
 }
 
-static offs_t internal_disasm_tms32025(cpu_device *device, std::ostream &stream, offs_t pc, const uint8_t *oprom, const uint8_t *opram, int options)
+CPU_DISASSEMBLE(tms32025)
 {
 	uint32_t flags = 0;
 	int a, b, c, d, k, m, n, p, r, s, t, w; /* these can all be filled in by parsing an instruction */
@@ -502,14 +502,4 @@ static offs_t internal_disasm_tms32025(cpu_device *device, std::ostream &stream,
 		}
 	}
 	return cnt | flags | DASMFLAG_SUPPORTED;
-}
-
-
-CPU_DISASSEMBLE(tms32025)
-{
-	std::ostringstream stream;
-	offs_t result = internal_disasm_tms32025(device, stream, pc, oprom, opram, options);
-	std::string stream_str = stream.str();
-	strcpy(buffer, stream_str.c_str());
-	return result;
 }

--- a/src/devices/cpu/tms32025/tms32025.cpp
+++ b/src/devices/cpu/tms32025/tms32025.cpp
@@ -242,10 +242,10 @@ tms32026_device::tms32026_device(const machine_config &mconfig, const char *tag,
 }
 
 
-offs_t tms32025_device::disasm_disassemble(char *buffer, offs_t pc, const uint8_t *oprom, const uint8_t *opram, uint32_t options)
+offs_t tms32025_device::disasm_disassemble(std::ostream &stream, offs_t pc, const uint8_t *oprom, const uint8_t *opram, uint32_t options)
 {
 	extern CPU_DISASSEMBLE( tms32025 );
-	return CPU_DISASSEMBLE_NAME(tms32025)(this, buffer, pc, oprom, opram, options);
+	return CPU_DISASSEMBLE_NAME(tms32025)(this, stream, pc, oprom, opram, options);
 }
 
 

--- a/src/devices/cpu/tms32025/tms32025.h
+++ b/src/devices/cpu/tms32025/tms32025.h
@@ -118,7 +118,7 @@ protected:
 	// device_disasm_interface overrides
 	virtual uint32_t disasm_min_opcode_bytes() const override { return 2; }
 	virtual uint32_t disasm_max_opcode_bytes() const override { return 4; }
-	virtual offs_t disasm_disassemble(char *buffer, offs_t pc, const uint8_t *oprom, const uint8_t *opram, uint32_t options) override;
+	virtual offs_t disasm_disassemble(std::ostream &stream, offs_t pc, const uint8_t *oprom, const uint8_t *opram, uint32_t options) override;
 
 private:
 	address_space_config m_program_config;

--- a/src/devices/cpu/tms32031/dis32031.cpp
+++ b/src/devices/cpu/tms32031/dis32031.cpp
@@ -724,18 +724,8 @@ static unsigned dasm_tms3203x(std::ostream &stream, unsigned pc, uint32_t op)
 }
 
 
-static unsigned dasm_tms3203x(char *buffer, unsigned pc, uint32_t op)
-{
-	std::ostringstream stream;
-	unsigned result = dasm_tms3203x(stream, pc, op);
-	std::string stream_str = stream.str();
-	strcpy(buffer, stream_str.c_str());
-	return result;
-}
-
-
 CPU_DISASSEMBLE( tms3203x )
 {
 	uint32_t op = oprom[0] | (oprom[1] << 8) | (oprom[2] << 16) | (oprom[3] << 24);
-	return dasm_tms3203x(buffer, pc, op);
+	return dasm_tms3203x(stream, pc, op);
 }

--- a/src/devices/cpu/tms32031/tms32031.cpp
+++ b/src/devices/cpu/tms32031/tms32031.cpp
@@ -589,10 +589,10 @@ uint32_t tms3203x_device::disasm_max_opcode_bytes() const
 //  helper function
 //-------------------------------------------------
 
-offs_t tms3203x_device::disasm_disassemble(char *buffer, offs_t pc, const uint8_t *oprom, const uint8_t *opram, uint32_t options)
+offs_t tms3203x_device::disasm_disassemble(std::ostream &stream, offs_t pc, const uint8_t *oprom, const uint8_t *opram, uint32_t options)
 {
 	extern CPU_DISASSEMBLE( tms3203x );
-	return CPU_DISASSEMBLE_NAME(tms3203x)(this, buffer, pc, oprom, opram, options);
+	return CPU_DISASSEMBLE_NAME(tms3203x)(this, stream, pc, oprom, opram, options);
 }
 
 

--- a/src/devices/cpu/tms32031/tms32031.h
+++ b/src/devices/cpu/tms32031/tms32031.h
@@ -184,7 +184,7 @@ protected:
 	// device_disasm_interface overrides
 	virtual uint32_t disasm_min_opcode_bytes() const override;
 	virtual uint32_t disasm_max_opcode_bytes() const override;
-	virtual offs_t disasm_disassemble(char *buffer, offs_t pc, const uint8_t *oprom, const uint8_t *opram, uint32_t options) override;
+	virtual offs_t disasm_disassemble(std::ostream &stream, offs_t pc, const uint8_t *oprom, const uint8_t *opram, uint32_t options) override;
 
 	// memory helpers
 	DECLARE_DIRECT_UPDATE_MEMBER(direct_handler);

--- a/src/devices/cpu/tms32051/dis32051.cpp
+++ b/src/devices/cpu/tms32051/dis32051.cpp
@@ -273,7 +273,7 @@ static void dasm_group_bf(uint16_t opcode)
 	}
 }
 
-static offs_t internal_disasm_tms32051(cpu_device *device, std::ostream &stream, offs_t pc, const uint8_t *oprom, const uint8_t *opram, int options)
+CPU_DISASSEMBLE(tms32051)
 {
 	uint32_t flags = 0;
 	uint16_t opcode;
@@ -582,14 +582,4 @@ static offs_t internal_disasm_tms32051(cpu_device *device, std::ostream &stream,
 	}
 
 	return (npc-pc) | flags | DASMFLAG_SUPPORTED;
-}
-
-
-CPU_DISASSEMBLE(tms32051)
-{
-	std::ostringstream stream;
-	offs_t result = internal_disasm_tms32051(device, stream, pc, oprom, opram, options);
-	std::string stream_str = stream.str();
-	strcpy(buffer, stream_str.c_str());
-	return result;
 }

--- a/src/devices/cpu/tms32051/tms32051.cpp
+++ b/src/devices/cpu/tms32051/tms32051.cpp
@@ -112,10 +112,10 @@ tms32053_device::tms32053_device(const machine_config &mconfig, const char *tag,
 }
 
 
-offs_t tms32051_device::disasm_disassemble(char *buffer, offs_t pc, const uint8_t *oprom, const uint8_t *opram, uint32_t options)
+offs_t tms32051_device::disasm_disassemble(std::ostream &stream, offs_t pc, const uint8_t *oprom, const uint8_t *opram, uint32_t options)
 {
 	extern CPU_DISASSEMBLE( tms32051 );
-	return CPU_DISASSEMBLE_NAME(tms32051)(this, buffer, pc, oprom, opram, options);
+	return CPU_DISASSEMBLE_NAME(tms32051)(this, stream, pc, oprom, opram, options);
 }
 
 

--- a/src/devices/cpu/tms32051/tms32051.h
+++ b/src/devices/cpu/tms32051/tms32051.h
@@ -82,7 +82,7 @@ protected:
 	// device_disasm_interface overrides
 	virtual uint32_t disasm_min_opcode_bytes() const override { return 2; }
 	virtual uint32_t disasm_max_opcode_bytes() const override { return 4; }
-	virtual offs_t disasm_disassemble(char *buffer, offs_t pc, const uint8_t *oprom, const uint8_t *opram, uint32_t options) override;
+	virtual offs_t disasm_disassemble(std::ostream &stream, offs_t pc, const uint8_t *oprom, const uint8_t *opram, uint32_t options) override;
 
 	address_space_config m_program_config;
 	address_space_config m_data_config;

--- a/src/devices/cpu/tms32082/dis_mp.cpp
+++ b/src/devices/cpu/tms32082/dis_mp.cpp
@@ -505,16 +505,7 @@ static offs_t tms32082_disasm_mp(std::ostream &stream, offs_t pc, const uint8_t 
 	return opbytes | flags | DASMFLAG_SUPPORTED;
 }
 
-static offs_t tms32082_disasm_mp(char *buffer, offs_t pc, const uint8_t *oprom)
-{
-	std::ostringstream stream;
-	offs_t result = tms32082_disasm_mp(stream, pc, oprom);
-	std::string stream_str = stream.str();
-	strcpy(buffer, stream_str.c_str());
-	return result;
-}
-
 CPU_DISASSEMBLE(tms32082_mp)
 {
-	return tms32082_disasm_mp(buffer, pc, oprom);
+	return tms32082_disasm_mp(stream, pc, oprom);
 }

--- a/src/devices/cpu/tms32082/dis_pp.cpp
+++ b/src/devices/cpu/tms32082/dis_pp.cpp
@@ -698,16 +698,7 @@ static offs_t tms32082_disasm_pp(std::ostream &stream, offs_t pc, const uint8_t 
 	return 8 | flags | DASMFLAG_SUPPORTED;
 }
 
-static offs_t tms32082_disasm_pp(char *buffer, offs_t pc, const uint8_t *oprom)
-{
-	std::ostringstream stream;
-	offs_t result = tms32082_disasm_pp(stream, pc, oprom);
-	std::string stream_str = stream.str();
-	strcpy(buffer, stream_str.c_str());
-	return result;
-}
-
 CPU_DISASSEMBLE(tms32082_pp)
 {
-	return tms32082_disasm_pp(buffer, pc, oprom);
+	return tms32082_disasm_pp(stream, pc, oprom);
 }

--- a/src/devices/cpu/tms32082/tms32082.cpp
+++ b/src/devices/cpu/tms32082/tms32082.cpp
@@ -51,9 +51,9 @@ tms32082_mp_device::tms32082_mp_device(const machine_config &mconfig, const char
 }
 
 
-offs_t tms32082_mp_device::disasm_disassemble(char *buffer, offs_t pc, const uint8_t *oprom, const uint8_t *opram, uint32_t options)
+offs_t tms32082_mp_device::disasm_disassemble(std::ostream &stream, offs_t pc, const uint8_t *oprom, const uint8_t *opram, uint32_t options)
 {
-	return CPU_DISASSEMBLE_NAME(tms32082_mp)(this, buffer, pc, oprom, opram, options);
+	return CPU_DISASSEMBLE_NAME(tms32082_mp)(this, stream, pc, oprom, opram, options);
 }
 
 
@@ -489,9 +489,9 @@ tms32082_pp_device::tms32082_pp_device(const machine_config &mconfig, const char
 }
 
 
-offs_t tms32082_pp_device::disasm_disassemble(char *buffer, offs_t pc, const uint8_t *oprom, const uint8_t *opram, uint32_t options)
+offs_t tms32082_pp_device::disasm_disassemble(std::ostream &stream, offs_t pc, const uint8_t *oprom, const uint8_t *opram, uint32_t options)
 {
-	return CPU_DISASSEMBLE_NAME(tms32082_pp)(this, buffer, pc, oprom, opram, options);
+	return CPU_DISASSEMBLE_NAME(tms32082_pp)(this, stream, pc, oprom, opram, options);
 }
 
 void tms32082_pp_device::device_start()

--- a/src/devices/cpu/tms32082/tms32082.h
+++ b/src/devices/cpu/tms32082/tms32082.h
@@ -102,7 +102,7 @@ protected:
 	// device_disasm_interface overrides
 	virtual uint32_t disasm_min_opcode_bytes() const override { return 4; }
 	virtual uint32_t disasm_max_opcode_bytes() const override { return 8; }
-	virtual offs_t disasm_disassemble(char *buffer, offs_t pc, const uint8_t *oprom, const uint8_t *opram, uint32_t options) override;
+	virtual offs_t disasm_disassemble(std::ostream &stream, offs_t pc, const uint8_t *oprom, const uint8_t *opram, uint32_t options) override;
 
 	address_space_config m_program_config;
 
@@ -197,7 +197,7 @@ protected:
 	// device_disasm_interface overrides
 	virtual uint32_t disasm_min_opcode_bytes() const override { return 8; }
 	virtual uint32_t disasm_max_opcode_bytes() const override { return 8; }
-	virtual offs_t disasm_disassemble(char *buffer, offs_t pc, const uint8_t *oprom, const uint8_t *opram, uint32_t options) override;
+	virtual offs_t disasm_disassemble(std::ostream &stream, offs_t pc, const uint8_t *oprom, const uint8_t *opram, uint32_t options) override;
 
 	address_space_config m_program_config;
 

--- a/src/devices/cpu/tms34010/34010dsm.cpp
+++ b/src/devices/cpu/tms34010/34010dsm.cpp
@@ -1717,21 +1717,12 @@ static unsigned Dasm340x0(std::ostream &stream, uint32_t pc, bool is_34020)
 	return (_pc - __pc) | flags | DASMFLAG_SUPPORTED;
 }
 
-static unsigned Dasm340x0(char *buff, uint32_t pc, bool is_34020)
-{
-	std::ostringstream stream;
-	unsigned result = Dasm340x0(stream, pc, is_34020);
-	std::string stream_str = stream.str();
-	strcpy(buff, stream_str.c_str());
-	return result;
-}
-
 CPU_DISASSEMBLE( tms34010 )
 {
 	rombase = oprom;
 	rambase = opram;
 	pcbase = pc;
-	return Dasm340x0(buffer, pc, false);
+	return Dasm340x0(stream, pc, false);
 }
 
 CPU_DISASSEMBLE( tms34020 )
@@ -1739,5 +1730,5 @@ CPU_DISASSEMBLE( tms34020 )
 	rombase = oprom;
 	rambase = opram;
 	pcbase = pc;
-	return Dasm340x0(buffer, pc, true);
+	return Dasm340x0(stream, pc, true);
 }

--- a/src/devices/cpu/tms34010/tms34010.cpp
+++ b/src/devices/cpu/tms34010/tms34010.cpp
@@ -1627,17 +1627,17 @@ void tms340x0_device::state_string_export(const device_state_entry &entry, std::
 }
 
 
-offs_t tms34010_device::disasm_disassemble(char *buffer, offs_t pc, const uint8_t *oprom, const uint8_t *opram, uint32_t options)
+offs_t tms34010_device::disasm_disassemble(std::ostream &stream, offs_t pc, const uint8_t *oprom, const uint8_t *opram, uint32_t options)
 {
 	extern CPU_DISASSEMBLE( tms34010 );
 
-	return CPU_DISASSEMBLE_NAME(tms34010)(this, buffer, pc, oprom, opram, options);
+	return CPU_DISASSEMBLE_NAME(tms34010)(this, stream, pc, oprom, opram, options);
 }
 
 
-offs_t tms34020_device::disasm_disassemble(char *buffer, offs_t pc, const uint8_t *oprom, const uint8_t *opram, uint32_t options)
+offs_t tms34020_device::disasm_disassemble(std::ostream &stream, offs_t pc, const uint8_t *oprom, const uint8_t *opram, uint32_t options)
 {
 	extern CPU_DISASSEMBLE( tms34020 );
 
-	return CPU_DISASSEMBLE_NAME(tms34020)(this, buffer, pc, oprom, opram, options);
+	return CPU_DISASSEMBLE_NAME(tms34020)(this, stream, pc, oprom, opram, options);
 }

--- a/src/devices/cpu/tms34010/tms34010.h
+++ b/src/devices/cpu/tms34010/tms34010.h
@@ -1029,7 +1029,7 @@ public:
 protected:
 	virtual uint64_t execute_clocks_to_cycles(uint64_t clocks) const override { return (clocks + 8 - 1) / 8; }
 	virtual uint64_t execute_cycles_to_clocks(uint64_t cycles) const override { return (cycles * 8); }
-	virtual offs_t disasm_disassemble(char *buffer, offs_t pc, const uint8_t *oprom, const uint8_t *opram, uint32_t options) override;
+	virtual offs_t disasm_disassemble(std::ostream &stream, offs_t pc, const uint8_t *oprom, const uint8_t *opram, uint32_t options) override;
 };
 
 extern const device_type TMS34010;
@@ -1046,7 +1046,7 @@ public:
 protected:
 	virtual uint64_t execute_clocks_to_cycles(uint64_t clocks) const override { return (clocks + 4 - 1) / 4; }
 	virtual uint64_t execute_cycles_to_clocks(uint64_t cycles) const override { return (cycles * 4); }
-	virtual offs_t disasm_disassemble(char *buffer, offs_t pc, const uint8_t *oprom, const uint8_t *opram, uint32_t options) override;
+	virtual offs_t disasm_disassemble(std::ostream &stream, offs_t pc, const uint8_t *oprom, const uint8_t *opram, uint32_t options) override;
 };
 
 extern const device_type TMS34020;

--- a/src/devices/cpu/tms57002/57002dsm.cpp
+++ b/src/devices/cpu/tms57002/57002dsm.cpp
@@ -31,7 +31,7 @@ static std::string get_memadr(uint32_t opcode, char type)
 }
 
 
-static offs_t internal_disasm_tms57002(cpu_device *device, std::ostream &stream, offs_t pc, const uint8_t *oprom, const uint8_t *opram, int options)
+CPU_DISASSEMBLE(tms57002)
 {
 	std::streampos original_pos = stream.tellp();
 	uint32_t opcode = opram[0] | (opram[1] << 8) | (opram[2] << 16);
@@ -82,14 +82,4 @@ static offs_t internal_disasm_tms57002(cpu_device *device, std::ostream &stream,
 	}
 
 	return 1;
-}
-
-
-CPU_DISASSEMBLE(tms57002)
-{
-	std::ostringstream stream;
-	offs_t result = internal_disasm_tms57002(device, stream, pc, oprom, opram, options);
-	std::string stream_str = stream.str();
-	strcpy(buffer, stream_str.c_str());
-	return result;
 }

--- a/src/devices/cpu/tms57002/tms57002.cpp
+++ b/src/devices/cpu/tms57002/tms57002.cpp
@@ -902,10 +902,10 @@ uint32_t tms57002_device::disasm_max_opcode_bytes() const
 	return 4;
 }
 
-offs_t tms57002_device::disasm_disassemble(char *buffer, offs_t pc, const uint8_t *oprom, const uint8_t *opram, uint32_t options)
+offs_t tms57002_device::disasm_disassemble(std::ostream &stream, offs_t pc, const uint8_t *oprom, const uint8_t *opram, uint32_t options)
 {
 	extern CPU_DISASSEMBLE( tms57002 );
-	return CPU_DISASSEMBLE_NAME(tms57002)(this, buffer, pc, oprom, opram, options);
+	return CPU_DISASSEMBLE_NAME(tms57002)(this, stream, pc, oprom, opram, options);
 }
 
 const address_space_config *tms57002_device::memory_space_config(address_spacenum spacenum) const

--- a/src/devices/cpu/tms57002/tms57002.h
+++ b/src/devices/cpu/tms57002/tms57002.h
@@ -37,7 +37,7 @@ protected:
 	virtual void execute_run() override;
 	virtual uint32_t disasm_min_opcode_bytes() const override;
 	virtual uint32_t disasm_max_opcode_bytes() const override;
-	virtual offs_t disasm_disassemble(char *buffer, offs_t pc, const uint8_t *oprom, const uint8_t *opram, uint32_t options) override;
+	virtual offs_t disasm_disassemble(std::ostream &stream, offs_t pc, const uint8_t *oprom, const uint8_t *opram, uint32_t options) override;
 
 private:
 	enum {

--- a/src/devices/cpu/tms57002/tms57kdec.cpp
+++ b/src/devices/cpu/tms57002/tms57kdec.cpp
@@ -72,7 +72,6 @@ inline int tms57002_device::sfma(uint32_t st1)
 
 void tms57002_device::decode_error(uint32_t opcode)
 {
-	char buf[256];
 	uint8_t opr[3];
 	if(unsupported_inst_warning)
 		return;
@@ -82,8 +81,9 @@ void tms57002_device::decode_error(uint32_t opcode)
 	opr[1] = opcode >> 8;
 	opr[2] = opcode >> 16;
 
-	disasm_disassemble(buf, pc, opr, opr, 0);
-	popmessage("tms57002: %s - Contact Mamedev", buf);
+	std::stringstream stream;
+	disasm_disassemble(stream, pc, opr, opr, 0);
+	popmessage("tms57002: %s - Contact Mamedev", stream.str());
 }
 
 void tms57002_device::decode_cat1(uint32_t opcode, unsigned short *op, cstate *cs)

--- a/src/devices/cpu/tms7000/7000dasm.cpp
+++ b/src/devices/cpu/tms7000/7000dasm.cpp
@@ -367,7 +367,7 @@ static const tms7000_opcodeinfo opcodes[] = {
 	{0x00, "NOP", 23, 0 }
 };
 
-static offs_t internal_disasm_tms7000(cpu_device *device, std::ostream &stream, offs_t pc, const uint8_t *oprom, const uint8_t *opram, int options)
+CPU_DISASSEMBLE(tms7000)
 {
 	int opcode, i/*, size = 1*/;
 	int pos = 0;
@@ -445,14 +445,4 @@ static offs_t internal_disasm_tms7000(cpu_device *device, std::ostream &stream, 
 	/* No Match */
 	stream << "Illegal Opcode";
 	return pos | DASMFLAG_SUPPORTED;
-}
-
-
-CPU_DISASSEMBLE(tms7000)
-{
-	std::ostringstream stream;
-	offs_t result = internal_disasm_tms7000(device, stream, pc, oprom, opram, options);
-	std::string stream_str = stream.str();
-	strcpy(buffer, stream_str.c_str());
-	return result;
 }

--- a/src/devices/cpu/tms7000/tms7000.cpp
+++ b/src/devices/cpu/tms7000/tms7000.cpp
@@ -267,10 +267,10 @@ void tms7000_device::state_string_export(const device_state_entry &entry, std::s
 	}
 }
 
-offs_t tms7000_device::disasm_disassemble(char *buffer, offs_t pc, const uint8_t *oprom, const uint8_t *opram, uint32_t options)
+offs_t tms7000_device::disasm_disassemble(std::ostream &stream, offs_t pc, const uint8_t *oprom, const uint8_t *opram, uint32_t options)
 {
 	extern CPU_DISASSEMBLE( tms7000 );
-	return CPU_DISASSEMBLE_NAME(tms7000)(this, buffer, pc, oprom, opram, options);
+	return CPU_DISASSEMBLE_NAME(tms7000)(this, stream, pc, oprom, opram, options);
 }
 
 

--- a/src/devices/cpu/tms7000/tms7000.h
+++ b/src/devices/cpu/tms7000/tms7000.h
@@ -85,7 +85,7 @@ protected:
 	// device_disasm_interface overrides
 	virtual uint32_t disasm_min_opcode_bytes() const override { return 1; }
 	virtual uint32_t disasm_max_opcode_bytes() const override { return 4; }
-	virtual offs_t disasm_disassemble(char *buffer, offs_t pc, const uint8_t *oprom, const uint8_t *opram, uint32_t options) override;
+	virtual offs_t disasm_disassemble(std::ostream &stream, offs_t pc, const uint8_t *oprom, const uint8_t *opram, uint32_t options) override;
 
 	virtual void execute_one(uint8_t op);
 

--- a/src/devices/cpu/tms9900/9900dasm.cpp
+++ b/src/devices/cpu/tms9900/9900dasm.cpp
@@ -784,26 +784,17 @@ static unsigned Dasm9900 (std::ostream &stream, unsigned pc, int model_id, const
 	return (PC - pc) | DASMFLAG_SUPPORTED | dasmflags;
 }
 
-static unsigned Dasm9900(char *buffer, unsigned pc, int model_id, const uint8_t *oprom, const uint8_t *opram)
-{
-	std::ostringstream stream;
-	unsigned result = Dasm9900(stream, pc, model_id, oprom, opram);
-	std::string stream_str = stream.str();
-	strcpy(buffer, stream_str.c_str());
-	return result;
-}
-
 CPU_DISASSEMBLE( tms9900 )
 {
-	return Dasm9900(buffer, pc, TMS9900_ID, oprom, opram);
+	return Dasm9900(stream, pc, TMS9900_ID, oprom, opram);
 }
 
 CPU_DISASSEMBLE( tms9980 )
 {
-	return Dasm9900(buffer, pc, TMS9980_ID, oprom, opram);
+	return Dasm9900(stream, pc, TMS9980_ID, oprom, opram);
 }
 
 CPU_DISASSEMBLE( tms9995 )
 {
-	return Dasm9900(buffer, pc, TMS9995_ID, oprom, opram);
+	return Dasm9900(stream, pc, TMS9995_ID, oprom, opram);
 }

--- a/src/devices/cpu/tms9900/ti990_10.cpp
+++ b/src/devices/cpu/tms9900/ti990_10.cpp
@@ -140,10 +140,10 @@ uint32_t ti990_10_device::disasm_max_opcode_bytes() const
 }
 
 // TODO: check 9900dasm
-offs_t ti990_10_device::disasm_disassemble(char *buffer, offs_t pc, const uint8_t *oprom, const uint8_t *opram, uint32_t options)
+offs_t ti990_10_device::disasm_disassemble(std::ostream &stream, offs_t pc, const uint8_t *oprom, const uint8_t *opram, uint32_t options)
 {
 	extern CPU_DISASSEMBLE( tms9900 );
-	return CPU_DISASSEMBLE_NAME(tms9900)(this, buffer, pc, oprom, opram, options);
+	return CPU_DISASSEMBLE_NAME(tms9900)(this, stream, pc, oprom, opram, options);
 }
 
 const device_type TI990_10 = &device_creator<ti990_10_device>;

--- a/src/devices/cpu/tms9900/ti990_10.h
+++ b/src/devices/cpu/tms9900/ti990_10.h
@@ -34,7 +34,7 @@ protected:
 	// device_disasm_interface overrides
 	uint32_t      disasm_min_opcode_bytes() const override;
 	uint32_t      disasm_max_opcode_bytes() const override;
-	offs_t      disasm_disassemble(char *buffer, offs_t pc, const uint8_t *oprom, const uint8_t *opram, uint32_t options) override;
+	offs_t      disasm_disassemble(std::ostream &stream, offs_t pc, const uint8_t *oprom, const uint8_t *opram, uint32_t options) override;
 
 	const address_space_config* memory_space_config(address_spacenum spacenum) const override;
 

--- a/src/devices/cpu/tms9900/tms9900.cpp
+++ b/src/devices/cpu/tms9900/tms9900.cpp
@@ -2761,10 +2761,10 @@ uint32_t tms99xx_device::disasm_max_opcode_bytes() const
 	return 6;
 }
 
-offs_t tms99xx_device::disasm_disassemble(char *buffer, offs_t pc, const uint8_t *oprom, const uint8_t *opram, uint32_t options)
+offs_t tms99xx_device::disasm_disassemble(std::ostream &stream, offs_t pc, const uint8_t *oprom, const uint8_t *opram, uint32_t options)
 {
 	extern CPU_DISASSEMBLE( tms9900 );
-	return CPU_DISASSEMBLE_NAME(tms9900)(this, buffer, pc, oprom, opram, options);
+	return CPU_DISASSEMBLE_NAME(tms9900)(this, stream, pc, oprom, opram, options);
 }
 
 

--- a/src/devices/cpu/tms9900/tms9900.h
+++ b/src/devices/cpu/tms9900/tms9900.h
@@ -83,7 +83,7 @@ protected:
 	// device_disasm_interface overrides
 	virtual uint32_t      disasm_min_opcode_bytes() const override;
 	virtual uint32_t      disasm_max_opcode_bytes() const override;
-	virtual offs_t      disasm_disassemble(char *buffer, offs_t pc, const uint8_t *oprom, const uint8_t *opram, uint32_t options) override;
+	virtual offs_t      disasm_disassemble(std::ostream &stream, offs_t pc, const uint8_t *oprom, const uint8_t *opram, uint32_t options) override;
 
 	const address_space_config* memory_space_config(address_spacenum spacenum) const override;
 

--- a/src/devices/cpu/tms9900/tms9980a.cpp
+++ b/src/devices/cpu/tms9900/tms9980a.cpp
@@ -290,10 +290,10 @@ uint32_t tms9980a_device::disasm_max_opcode_bytes() const
 	return 6;
 }
 
-offs_t tms9980a_device::disasm_disassemble(char *buffer, offs_t pc, const uint8_t *oprom, const uint8_t *opram, uint32_t options)
+offs_t tms9980a_device::disasm_disassemble(std::ostream &stream, offs_t pc, const uint8_t *oprom, const uint8_t *opram, uint32_t options)
 {
 	extern CPU_DISASSEMBLE( tms9980 );
-	return CPU_DISASSEMBLE_NAME(tms9980)(this, buffer, pc, oprom, opram, options);
+	return CPU_DISASSEMBLE_NAME(tms9980)(this, stream, pc, oprom, opram, options);
 }
 
 const device_type TMS9980A = &device_creator<tms9980a_device>;

--- a/src/devices/cpu/tms9900/tms9980a.h
+++ b/src/devices/cpu/tms9900/tms9980a.h
@@ -45,7 +45,7 @@ protected:
 
 	uint32_t      disasm_min_opcode_bytes() const override;
 	uint32_t      disasm_max_opcode_bytes() const override;
-	offs_t      disasm_disassemble(char *buffer, offs_t pc, const uint8_t *oprom, const uint8_t *opram, uint32_t options) override;
+	offs_t      disasm_disassemble(std::ostream &stream, offs_t pc, const uint8_t *oprom, const uint8_t *opram, uint32_t options) override;
 	address_space_config    m_program_config80;
 	address_space_config    m_io_config80;
 };

--- a/src/devices/cpu/tms9900/tms9995.cpp
+++ b/src/devices/cpu/tms9900/tms9995.cpp
@@ -3536,10 +3536,10 @@ uint32_t tms9995_device::disasm_max_opcode_bytes() const
 	return 6;
 }
 
-offs_t tms9995_device::disasm_disassemble(char *buffer, offs_t pc, const uint8_t *oprom, const uint8_t *opram, uint32_t options)
+offs_t tms9995_device::disasm_disassemble(std::ostream &stream, offs_t pc, const uint8_t *oprom, const uint8_t *opram, uint32_t options)
 {
 	extern CPU_DISASSEMBLE( tms9995 );
-	return CPU_DISASSEMBLE_NAME(tms9995)(this, buffer, pc, oprom, opram, options);
+	return CPU_DISASSEMBLE_NAME(tms9995)(this, stream, pc, oprom, opram, options);
 }
 
 

--- a/src/devices/cpu/tms9900/tms9995.h
+++ b/src/devices/cpu/tms9900/tms9995.h
@@ -94,7 +94,7 @@ protected:
 	// device_disasm_interface overrides
 	virtual uint32_t      disasm_min_opcode_bytes() const override;
 	virtual uint32_t      disasm_max_opcode_bytes() const override;
-	virtual offs_t      disasm_disassemble(char *buffer, offs_t pc, const uint8_t *oprom, const uint8_t *opram, uint32_t options) override;
+	virtual offs_t      disasm_disassemble(std::ostream &stream, offs_t pc, const uint8_t *oprom, const uint8_t *opram, uint32_t options) override;
 
 	const address_space_config* memory_space_config(address_spacenum spacenum) const override;
 

--- a/src/devices/cpu/ucom4/ucom4.cpp
+++ b/src/devices/cpu/ucom4/ucom4.cpp
@@ -95,10 +95,10 @@ void ucom4_cpu_device::state_string_export(const device_state_entry &entry, std:
 	}
 }
 
-offs_t ucom4_cpu_device::disasm_disassemble(char *buffer, offs_t pc, const uint8_t *oprom, const uint8_t *opram, uint32_t options)
+offs_t ucom4_cpu_device::disasm_disassemble(std::ostream &stream, offs_t pc, const uint8_t *oprom, const uint8_t *opram, uint32_t options)
 {
 	extern CPU_DISASSEMBLE(ucom4);
-	return CPU_DISASSEMBLE_NAME(ucom4)(this, buffer, pc, oprom, opram, options);
+	return CPU_DISASSEMBLE_NAME(ucom4)(this, stream, pc, oprom, opram, options);
 }
 
 

--- a/src/devices/cpu/ucom4/ucom4.h
+++ b/src/devices/cpu/ucom4/ucom4.h
@@ -155,7 +155,7 @@ protected:
 	// device_disasm_interface overrides
 	virtual uint32_t disasm_min_opcode_bytes() const override { return 1; }
 	virtual uint32_t disasm_max_opcode_bytes() const override { return 2; }
-	virtual offs_t disasm_disassemble(char *buffer, offs_t pc, const uint8_t *oprom, const uint8_t *opram, uint32_t options) override;
+	virtual offs_t disasm_disassemble(std::ostream &stream, offs_t pc, const uint8_t *oprom, const uint8_t *opram, uint32_t options) override;
 
 	// device_state_interface overrides
 	virtual void state_string_export(const device_state_entry &entry, std::string &str) const override;

--- a/src/devices/cpu/ucom4/ucom4d.cpp
+++ b/src/devices/cpu/ucom4/ucom4d.cpp
@@ -113,7 +113,7 @@ static const uint8_t ucom4_mnemonic[0x100] =
 
 
 
-static offs_t internal_disasm_ucom4(cpu_device *device, std::ostream &stream, offs_t pc, const uint8_t *oprom, const uint8_t *opram, int options)
+CPU_DISASSEMBLE(ucom4)
 {
 	int pos = 0;
 	uint8_t op = oprom[pos++];
@@ -149,14 +149,4 @@ static offs_t internal_disasm_ucom4(cpu_device *device, std::ostream &stream, of
 	}
 
 	return pos | s_flags[instr] | DASMFLAG_SUPPORTED;
-}
-
-
-CPU_DISASSEMBLE(ucom4)
-{
-	std::ostringstream stream;
-	offs_t result = internal_disasm_ucom4(device, stream, pc, oprom, opram, options);
-	std::string stream_str = stream.str();
-	strcpy(buffer, stream_str.c_str());
-	return result;
 }

--- a/src/devices/cpu/unsp/unsp.cpp
+++ b/src/devices/cpu/unsp/unsp.cpp
@@ -23,10 +23,10 @@ unsp_device::unsp_device(const machine_config &mconfig, const char *tag, device_
 }
 
 
-offs_t unsp_device::disasm_disassemble(char *buffer, offs_t pc, const uint8_t *oprom, const uint8_t *opram, uint32_t options)
+offs_t unsp_device::disasm_disassemble(std::ostream &stream, offs_t pc, const uint8_t *oprom, const uint8_t *opram, uint32_t options)
 {
 	extern CPU_DISASSEMBLE( unsp );
-	return CPU_DISASSEMBLE_NAME(unsp)(this, buffer, pc, oprom, opram, options);
+	return CPU_DISASSEMBLE_NAME(unsp)(this, stream, pc, oprom, opram, options);
 }
 
 

--- a/src/devices/cpu/unsp/unsp.h
+++ b/src/devices/cpu/unsp/unsp.h
@@ -77,7 +77,7 @@ protected:
 	// device_disasm_interface overrides
 	virtual uint32_t disasm_min_opcode_bytes() const override { return 2; }
 	virtual uint32_t disasm_max_opcode_bytes() const override { return 4; }
-	virtual offs_t disasm_disassemble(char *buffer, offs_t pc, const uint8_t *oprom, const uint8_t *opram, uint32_t options) override;
+	virtual offs_t disasm_disassemble(std::ostream &stream, offs_t pc, const uint8_t *oprom, const uint8_t *opram, uint32_t options) override;
 
 private:
 	address_space_config m_program_config;

--- a/src/devices/cpu/unsp/unspdasm.cpp
+++ b/src/devices/cpu/unsp/unspdasm.cpp
@@ -46,7 +46,7 @@ static const char *alu[] =
 
 #define UNSP_DASM_OK ((OP2X ? 2 : 1) | DASMFLAG_SUPPORTED)
 
-static offs_t internal_disasm_unsp(cpu_device *device, std::ostream &stream, offs_t pc, const uint8_t *oprom, const uint8_t *opram, int options)
+CPU_DISASSEMBLE(unsp)
 {
 	uint16_t op = *(uint16_t *)oprom;
 	uint16_t imm16 = *(uint16_t *)(oprom + 2);
@@ -257,14 +257,4 @@ static offs_t internal_disasm_unsp(cpu_device *device, std::ostream &stream, off
 	}
 	util::stream_format(stream, "<inv>");
 	return UNSP_DASM_OK;
-}
-
-
-CPU_DISASSEMBLE(unsp)
-{
-	std::ostringstream stream;
-	offs_t result = internal_disasm_unsp(device, stream, pc, oprom, opram, options);
-	std::string stream_str = stream.str();
-	strcpy(buffer, stream_str.c_str());
-	return result;
 }

--- a/src/devices/cpu/upd7725/dasm7725.cpp
+++ b/src/devices/cpu/upd7725/dasm7725.cpp
@@ -12,7 +12,7 @@
 #include "emu.h"
 #include "upd7725.h"
 
-static offs_t internal_disasm_upd7725(cpu_device *device, std::ostream &stream, offs_t pc, const uint8_t *oprom, const uint8_t *opram, int options)
+CPU_DISASSEMBLE(upd7725)
 {
 	uint32_t opcode = oprom[2] | (oprom[1] << 8) | (oprom[0] << 16);
 	uint32_t type = (opcode >> 22);
@@ -221,14 +221,4 @@ static offs_t internal_disasm_upd7725(cpu_device *device, std::ostream &stream, 
 	}
 
 	return 1 | DASMFLAG_SUPPORTED;
-}
-
-
-CPU_DISASSEMBLE(upd7725)
-{
-	std::ostringstream stream;
-	offs_t result = internal_disasm_upd7725(device, stream, pc, oprom, opram, options);
-	std::string stream_str = stream.str();
-	strcpy(buffer, stream_str.c_str());
-	return result;
 }

--- a/src/devices/cpu/upd7725/upd7725.cpp
+++ b/src/devices/cpu/upd7725/upd7725.cpp
@@ -308,10 +308,10 @@ uint32_t necdsp_device::disasm_max_opcode_bytes() const
 //  helper function
 //-------------------------------------------------
 
-offs_t necdsp_device::disasm_disassemble(char *buffer, offs_t pc, const uint8_t *oprom, const uint8_t *opram, uint32_t options)
+offs_t necdsp_device::disasm_disassemble(std::ostream &stream, offs_t pc, const uint8_t *oprom, const uint8_t *opram, uint32_t options)
 {
 	extern CPU_DISASSEMBLE( upd7725 );
-	return CPU_DISASSEMBLE_NAME(upd7725)(this, buffer, pc, oprom, opram, options);
+	return CPU_DISASSEMBLE_NAME(upd7725)(this, stream, pc, oprom, opram, options);
 }
 
 void necdsp_device::execute_run()

--- a/src/devices/cpu/upd7725/upd7725.h
+++ b/src/devices/cpu/upd7725/upd7725.h
@@ -115,7 +115,7 @@ protected:
 	// device_disasm_interface overrides
 	virtual uint32_t disasm_min_opcode_bytes() const override;
 	virtual uint32_t disasm_max_opcode_bytes() const override;
-	virtual offs_t disasm_disassemble(char *buffer, offs_t pc, const uint8_t *oprom, const uint8_t *opram, uint32_t options) override;
+	virtual offs_t disasm_disassemble(std::ostream &stream, offs_t pc, const uint8_t *oprom, const uint8_t *opram, uint32_t options) override;
 
 	// inline data
 	const address_space_config m_program_config, m_data_config;

--- a/src/devices/cpu/upd7810/upd7810.cpp
+++ b/src/devices/cpu/upd7810/upd7810.cpp
@@ -486,28 +486,28 @@ upd78c06_device::upd78c06_device(const machine_config &mconfig, const char *tag,
 	m_opXX = s_opXX_78c06;
 }
 
-offs_t upd7810_device::disasm_disassemble(char *buffer, offs_t pc, const uint8_t *oprom, const uint8_t *opram, uint32_t options)
+offs_t upd7810_device::disasm_disassemble(std::ostream &stream, offs_t pc, const uint8_t *oprom, const uint8_t *opram, uint32_t options)
 {
 	extern CPU_DISASSEMBLE( upd7810 );
-	return CPU_DISASSEMBLE_NAME(upd7810)(this, buffer, pc, oprom, opram, options);
+	return CPU_DISASSEMBLE_NAME(upd7810)(this, stream, pc, oprom, opram, options);
 }
 
-offs_t upd7807_device::disasm_disassemble(char *buffer, offs_t pc, const uint8_t *oprom, const uint8_t *opram, uint32_t options)
+offs_t upd7807_device::disasm_disassemble(std::ostream &stream, offs_t pc, const uint8_t *oprom, const uint8_t *opram, uint32_t options)
 {
 	extern CPU_DISASSEMBLE( upd7807 );
-	return CPU_DISASSEMBLE_NAME(upd7807)(this, buffer, pc, oprom, opram, options);
+	return CPU_DISASSEMBLE_NAME(upd7807)(this, stream, pc, oprom, opram, options);
 }
 
-offs_t upd7801_device::disasm_disassemble(char *buffer, offs_t pc, const uint8_t *oprom, const uint8_t *opram, uint32_t options)
+offs_t upd7801_device::disasm_disassemble(std::ostream &stream, offs_t pc, const uint8_t *oprom, const uint8_t *opram, uint32_t options)
 {
 	extern CPU_DISASSEMBLE( upd7801 );
-	return CPU_DISASSEMBLE_NAME(upd7801)(this, buffer, pc, oprom, opram, options);
+	return CPU_DISASSEMBLE_NAME(upd7801)(this, stream, pc, oprom, opram, options);
 }
 
-offs_t upd78c05_device::disasm_disassemble(char *buffer, offs_t pc, const uint8_t *oprom, const uint8_t *opram, uint32_t options)
+offs_t upd78c05_device::disasm_disassemble(std::ostream &stream, offs_t pc, const uint8_t *oprom, const uint8_t *opram, uint32_t options)
 {
 	extern CPU_DISASSEMBLE( upd78c05 );
-	return CPU_DISASSEMBLE_NAME(upd78c05)(this, buffer, pc, oprom, opram, options);
+	return CPU_DISASSEMBLE_NAME(upd78c05)(this, stream, pc, oprom, opram, options);
 }
 
 uint8_t upd7810_device::RP(offs_t port)

--- a/src/devices/cpu/upd7810/upd7810.h
+++ b/src/devices/cpu/upd7810/upd7810.h
@@ -175,7 +175,7 @@ protected:
 	// device_disasm_interface overrides
 	virtual uint32_t disasm_min_opcode_bytes() const override { return 1; }
 	virtual uint32_t disasm_max_opcode_bytes() const override { return 4; }
-	virtual offs_t disasm_disassemble(char *buffer, offs_t pc, const uint8_t *oprom, const uint8_t *opram, uint32_t options) override;
+	virtual offs_t disasm_disassemble(std::ostream &stream, offs_t pc, const uint8_t *oprom, const uint8_t *opram, uint32_t options) override;
 
 	virtual void handle_timers(int cycles);
 	virtual void upd7810_take_irq();
@@ -1376,7 +1376,7 @@ public:
 	upd7807_device(const machine_config &mconfig, const char *tag, device_t *owner, uint32_t clock);
 
 protected:
-	virtual offs_t disasm_disassemble(char *buffer, offs_t pc, const uint8_t *oprom, const uint8_t *opram, uint32_t options) override;
+	virtual offs_t disasm_disassemble(std::ostream &stream, offs_t pc, const uint8_t *oprom, const uint8_t *opram, uint32_t options) override;
 };
 
 
@@ -1389,7 +1389,7 @@ public:
 protected:
 	virtual void device_reset() override;
 	virtual void execute_set_input(int inputnum, int state) override;
-	virtual offs_t disasm_disassemble(char *buffer, offs_t pc, const uint8_t *oprom, const uint8_t *opram, uint32_t options) override;
+	virtual offs_t disasm_disassemble(std::ostream &stream, offs_t pc, const uint8_t *oprom, const uint8_t *opram, uint32_t options) override;
 	virtual void handle_timers(int cycles) override;
 	virtual void upd7810_take_irq() override;
 };
@@ -1407,7 +1407,7 @@ protected:
 	virtual void device_reset() override;
 	virtual uint64_t execute_clocks_to_cycles(uint64_t clocks) const override { return (clocks + 4 - 1) / 4; }
 	virtual uint64_t execute_cycles_to_clocks(uint64_t cycles) const override { return (cycles * 4); }
-	virtual offs_t disasm_disassemble(char *buffer, offs_t pc, const uint8_t *oprom, const uint8_t *opram, uint32_t options) override;
+	virtual offs_t disasm_disassemble(std::ostream &stream, offs_t pc, const uint8_t *oprom, const uint8_t *opram, uint32_t options) override;
 	virtual void handle_timers(int cycles) override;
 };
 

--- a/src/devices/cpu/upd7810/upd7810_dasm.cpp
+++ b/src/devices/cpu/upd7810/upd7810_dasm.cpp
@@ -5483,33 +5483,24 @@ offs_t Dasm( std::ostream &stream, offs_t pc, const dasm_s (&dasmXX)[256], const
 	return idx | flags | DASMFLAG_SUPPORTED;
 }
 
-offs_t Dasm(char *buffer, offs_t pc, const dasm_s(&dasmXX)[256], const uint8_t *oprom, const uint8_t *opram, bool is_7810)
-{
-	std::ostringstream stream;
-	offs_t result = Dasm(stream, pc, dasmXX, oprom, opram, is_7810);
-	std::string stream_str = stream.str();
-	strcpy(buffer, stream_str.c_str());
-	return result;
-}
-
 } // anonymous namespace
 
 CPU_DISASSEMBLE( upd7810 )
 {
-	return Dasm( buffer, pc, dasm_s::XX_7810, oprom, opram, true );
+	return Dasm( stream, pc, dasm_s::XX_7810, oprom, opram, true );
 }
 
 CPU_DISASSEMBLE( upd7807 )
 {
-	return Dasm( buffer, pc, dasm_s::XX_7807, oprom, opram, true );
+	return Dasm( stream, pc, dasm_s::XX_7807, oprom, opram, true );
 }
 
 CPU_DISASSEMBLE( upd7801 )
 {
-	return Dasm( buffer, pc, dasm_s::XX_7801, oprom, opram, false );
+	return Dasm( stream, pc, dasm_s::XX_7801, oprom, opram, false );
 }
 
 CPU_DISASSEMBLE( upd78c05 )
 {
-	return Dasm( buffer, pc, dasm_s::XX_78c05, oprom, opram, false );
+	return Dasm( stream, pc, dasm_s::XX_78c05, oprom, opram, false );
 }

--- a/src/devices/cpu/v30mz/v30mz.cpp
+++ b/src/devices/cpu/v30mz/v30mz.cpp
@@ -1296,10 +1296,10 @@ void v30mz_cpu_device::execute_set_input( int inptnum, int state )
 }
 
 
-offs_t v30mz_cpu_device::disasm_disassemble(char *buffer, offs_t pc, const uint8_t *oprom, const uint8_t *opram, uint32_t options)
+offs_t v30mz_cpu_device::disasm_disassemble(std::ostream &stream, offs_t pc, const uint8_t *oprom, const uint8_t *opram, uint32_t options)
 {
 	extern CPU_DISASSEMBLE( nec );
-	return CPU_DISASSEMBLE_NAME(nec)(this, buffer, pc, oprom, opram, options);
+	return CPU_DISASSEMBLE_NAME(nec)(this, stream, pc, oprom, opram, options);
 }
 
 

--- a/src/devices/cpu/v30mz/v30mz.h
+++ b/src/devices/cpu/v30mz/v30mz.h
@@ -49,7 +49,7 @@ protected:
 	// device_disasm_interface overrides
 	virtual uint32_t disasm_min_opcode_bytes() const override { return 1; }
 	virtual uint32_t disasm_max_opcode_bytes() const override { return 7; }
-	virtual offs_t disasm_disassemble(char *buffer, offs_t pc, const uint8_t *oprom, const uint8_t *opram, uint32_t options) override;
+	virtual offs_t disasm_disassemble(std::ostream &stream, offs_t pc, const uint8_t *oprom, const uint8_t *opram, uint32_t options) override;
 
 	void interrupt(int int_num);
 

--- a/src/devices/cpu/v60/v60.cpp
+++ b/src/devices/cpu/v60/v60.cpp
@@ -112,17 +112,17 @@ v70_device::v70_device(const machine_config &mconfig, const char *tag, device_t 
 }
 
 
-offs_t v60_device::disasm_disassemble(char *buffer, offs_t pc, const uint8_t *oprom, const uint8_t *opram, uint32_t options)
+offs_t v60_device::disasm_disassemble(std::ostream &stream, offs_t pc, const uint8_t *oprom, const uint8_t *opram, uint32_t options)
 {
 	extern CPU_DISASSEMBLE( v60 );
-	return CPU_DISASSEMBLE_NAME(v60)(this, buffer, pc, oprom, opram, options);
+	return CPU_DISASSEMBLE_NAME(v60)(this, stream, pc, oprom, opram, options);
 }
 
 
-offs_t v70_device::disasm_disassemble(char *buffer, offs_t pc, const uint8_t *oprom, const uint8_t *opram, uint32_t options)
+offs_t v70_device::disasm_disassemble(std::ostream &stream, offs_t pc, const uint8_t *oprom, const uint8_t *opram, uint32_t options)
 {
 	extern CPU_DISASSEMBLE( v70 );
-	return CPU_DISASSEMBLE_NAME(v70)(this, buffer, pc, oprom, opram, options);
+	return CPU_DISASSEMBLE_NAME(v70)(this, stream, pc, oprom, opram, options);
 }
 
 

--- a/src/devices/cpu/v60/v60.h
+++ b/src/devices/cpu/v60/v60.h
@@ -111,7 +111,7 @@ protected:
 	// device_disasm_interface overrides
 	virtual uint32_t disasm_min_opcode_bytes() const override { return 1; }
 	virtual uint32_t disasm_max_opcode_bytes() const override { return 22; }
-	virtual offs_t disasm_disassemble(char *buffer, offs_t pc, const uint8_t *oprom, const uint8_t *opram, uint32_t options) override;
+	virtual offs_t disasm_disassemble(std::ostream &stream, offs_t pc, const uint8_t *oprom, const uint8_t *opram, uint32_t options) override;
 
 private:
 	typedef uint32_t (v60_device::*am_func)();
@@ -778,7 +778,7 @@ public:
 	v70_device(const machine_config &mconfig, const char *tag, device_t *owner, uint32_t clock);
 
 protected:
-	virtual offs_t disasm_disassemble(char *buffer, offs_t pc, const uint8_t *oprom, const uint8_t *opram, uint32_t options) override;
+	virtual offs_t disasm_disassemble(std::ostream &stream, offs_t pc, const uint8_t *oprom, const uint8_t *opram, uint32_t options) override;
 };
 
 

--- a/src/devices/cpu/v60/v60d.cpp
+++ b/src/devices/cpu/v60/v60d.cpp
@@ -1484,23 +1484,7 @@ static int (*const dasm_optable[256])(unsigned ipc, unsigned pc, std::ostream &s
 	/* 0xFF */ dopCLRTLB
 };
 
-static offs_t internal_disasm_v60(cpu_device *device, std::ostream &stream, offs_t pc, const uint8_t *oprom, const uint8_t *opram, int options)
-{
-	rombase = oprom;
-	pcbase = pc;
-	return dasm_optable[oprom[0]](pc, pc+1, stream) | DASMFLAG_SUPPORTED;
-}
-
 CPU_DISASSEMBLE(v60)
-{
-	std::ostringstream stream;
-	offs_t result = internal_disasm_v60(device, stream, pc, oprom, opram, options);
-	std::string stream_str = stream.str();
-	strcpy(buffer, stream_str.c_str());
-	return result;
-}
-
-static offs_t internal_disasm_v70(cpu_device *device, std::ostream &stream, offs_t pc, const uint8_t *oprom, const uint8_t *opram, int options)
 {
 	rombase = oprom;
 	pcbase = pc;
@@ -1509,10 +1493,7 @@ static offs_t internal_disasm_v70(cpu_device *device, std::ostream &stream, offs
 
 CPU_DISASSEMBLE(v70)
 {
-	std::ostringstream stream;
-	offs_t result = internal_disasm_v70(device, stream, pc, oprom, opram, options);
-	std::string stream_str = stream.str();
-	strcpy(buffer, stream_str.c_str());
-	return result;
+	rombase = oprom;
+	pcbase = pc;
+	return dasm_optable[oprom[0]](pc, pc+1, stream) | DASMFLAG_SUPPORTED;
 }
-

--- a/src/devices/cpu/v810/v810.cpp
+++ b/src/devices/cpu/v810/v810.cpp
@@ -46,10 +46,10 @@ v810_device::v810_device(const machine_config &mconfig, const char *tag, device_
 }
 
 
-offs_t v810_device::disasm_disassemble(char *buffer, offs_t pc, const uint8_t *oprom, const uint8_t *opram, uint32_t options)
+offs_t v810_device::disasm_disassemble(std::ostream &stream, offs_t pc, const uint8_t *oprom, const uint8_t *opram, uint32_t options)
 {
 	extern CPU_DISASSEMBLE( v810 );
-	return CPU_DISASSEMBLE_NAME(v810)(this, buffer, pc, oprom, opram, options);
+	return CPU_DISASSEMBLE_NAME(v810)(this, stream, pc, oprom, opram, options);
 }
 
 

--- a/src/devices/cpu/v810/v810.h
+++ b/src/devices/cpu/v810/v810.h
@@ -106,7 +106,7 @@ protected:
 	// device_disasm_interface overrides
 	virtual uint32_t disasm_min_opcode_bytes() const override { return 2; }
 	virtual uint32_t disasm_max_opcode_bytes() const override { return 4; }
-	virtual offs_t disasm_disassemble(char *buffer, offs_t pc, const uint8_t *oprom, const uint8_t *opram, uint32_t options) override;
+	virtual offs_t disasm_disassemble(std::ostream &stream, offs_t pc, const uint8_t *oprom, const uint8_t *opram, uint32_t options) override;
 
 private:
 	typedef uint32_t (v810_device::*opcode_func)(uint32_t op);

--- a/src/devices/cpu/v810/v810dasm.cpp
+++ b/src/devices/cpu/v810/v810dasm.cpp
@@ -39,7 +39,7 @@ static const char *const dRegs[]=
 #define GET2s(opcode) dRegs[((opcode)>>5)&0x1f]
 #define GETRs(opcode) dRegs[32+((opcode)&0x1f)]
 
-static offs_t internal_disasm_v810(cpu_device *device, std::ostream &stream, offs_t pc, const uint8_t *oprom, const uint8_t *opram, int options)
+CPU_DISASSEMBLE(v810)
 {
 	uint32_t flags = 0;
 	uint32_t opc,opc2;
@@ -174,14 +174,4 @@ static offs_t internal_disasm_v810(cpu_device *device, std::ostream &stream, off
 		default : size=2;
 	}
 	return size | flags | DASMFLAG_SUPPORTED;
-}
-
-
-CPU_DISASSEMBLE(v810)
-{
-	std::ostringstream stream;
-	offs_t result = internal_disasm_v810(device, stream, pc, oprom, opram, options);
-	std::string stream_str = stream.str();
-	strcpy(buffer, stream_str.c_str());
-	return result;
 }

--- a/src/devices/cpu/z180/z180.cpp
+++ b/src/devices/cpu/z180/z180.cpp
@@ -91,10 +91,10 @@ z180_device::z180_device(const machine_config &mconfig, const char *tag, device_
 }
 
 
-offs_t z180_device::disasm_disassemble(char *buffer, offs_t pc, const uint8_t *oprom, const uint8_t *opram, uint32_t options)
+offs_t z180_device::disasm_disassemble(std::ostream &stream, offs_t pc, const uint8_t *oprom, const uint8_t *opram, uint32_t options)
 {
 	extern CPU_DISASSEMBLE( z180 );
-	return CPU_DISASSEMBLE_NAME(z180)(this, buffer, pc, oprom, opram, options);
+	return CPU_DISASSEMBLE_NAME(z180)(this, stream, pc, oprom, opram, options);
 }
 
 

--- a/src/devices/cpu/z180/z180.h
+++ b/src/devices/cpu/z180/z180.h
@@ -153,7 +153,7 @@ protected:
 	// device_disasm_interface overrides
 	virtual uint32_t disasm_min_opcode_bytes() const override { return 1; }
 	virtual uint32_t disasm_max_opcode_bytes() const override { return 4; }
-	virtual offs_t disasm_disassemble(char *buffer, offs_t pc, const uint8_t *oprom, const uint8_t *opram, uint32_t options) override;
+	virtual offs_t disasm_disassemble(std::ostream &stream, offs_t pc, const uint8_t *oprom, const uint8_t *opram, uint32_t options) override;
 
 private:
 	address_space_config m_program_config;

--- a/src/devices/cpu/z180/z180dasm.cpp
+++ b/src/devices/cpu/z180/z180dasm.cpp
@@ -391,7 +391,7 @@ static int offs(int8_t offset)
 /****************************************************************************
  * Disassemble opcode at PC and return number of bytes it takes
  ****************************************************************************/
-static offs_t internal_disasm_z180(cpu_device *device, std::ostream &stream, offs_t pc, const uint8_t *oprom, const uint8_t *opram, int options)
+CPU_DISASSEMBLE(z180)
 {
 	const z80dasm *d;
 	const char *src, *ixy;
@@ -512,14 +512,4 @@ static offs_t internal_disasm_z180(cpu_device *device, std::ostream &stream, off
 		flags = DASMFLAG_STEP_OUT;
 
 	return pos | flags | DASMFLAG_SUPPORTED;
-}
-
-
-CPU_DISASSEMBLE(z180)
-{
-	std::ostringstream stream;
-	offs_t result = internal_disasm_z180(device, stream, pc, oprom, opram, options);
-	std::string stream_str = stream.str();
-	strcpy(buffer, stream_str.c_str());
-	return result;
 }

--- a/src/devices/cpu/z8/z8.cpp
+++ b/src/devices/cpu/z8/z8.cpp
@@ -197,10 +197,10 @@ z8611_device::z8611_device(const machine_config &mconfig, const char *_tag, devi
 }
 
 
-offs_t z8_device::disasm_disassemble(char *buffer, offs_t pc, const uint8_t *oprom, const uint8_t *opram, uint32_t options)
+offs_t z8_device::disasm_disassemble(std::ostream &stream, offs_t pc, const uint8_t *oprom, const uint8_t *opram, uint32_t options)
 {
 	extern CPU_DISASSEMBLE( z8 );
-	return CPU_DISASSEMBLE_NAME(z8)(this, buffer, pc, oprom, opram, options);
+	return CPU_DISASSEMBLE_NAME(z8)(this, stream, pc, oprom, opram, options);
 }
 
 

--- a/src/devices/cpu/z8/z8.h
+++ b/src/devices/cpu/z8/z8.h
@@ -61,7 +61,7 @@ protected:
 	// device_disasm_interface overrides
 	virtual uint32_t disasm_min_opcode_bytes() const override { return 1; }
 	virtual uint32_t disasm_max_opcode_bytes() const override { return 3; }
-	virtual offs_t disasm_disassemble(char *buffer, offs_t pc, const uint8_t *oprom, const uint8_t *opram, uint32_t options) override;
+	virtual offs_t disasm_disassemble(std::ostream &stream, offs_t pc, const uint8_t *oprom, const uint8_t *opram, uint32_t options) override;
 
 
 private:

--- a/src/devices/cpu/z8/z8dasm.cpp
+++ b/src/devices/cpu/z8/z8dasm.cpp
@@ -82,7 +82,7 @@ static const char *const CONDITION_CODE[16] =
     DISASSEMBLER
 ***************************************************************************/
 
-static offs_t internal_disasm_z8(cpu_device *device, std::ostream &stream, offs_t pc, const uint8_t *oprom, const uint8_t *opram, int options)
+CPU_DISASSEMBLE(z8)
 {
 	const uint8_t *startrom = oprom;
 	uint32_t flags = 0;
@@ -376,14 +376,4 @@ static offs_t internal_disasm_z8(cpu_device *device, std::ostream &stream, offs_
 	}
 
 	return (oprom - startrom) | flags | DASMFLAG_SUPPORTED;
-}
-
-
-CPU_DISASSEMBLE(z8)
-{
-	std::ostringstream stream;
-	offs_t result = internal_disasm_z8(device, stream, pc, oprom, opram, options);
-	std::string stream_str = stream.str();
-	strcpy(buffer, stream_str.c_str());
-	return result;
 }

--- a/src/devices/cpu/z80/z80.cpp
+++ b/src/devices/cpu/z80/z80.cpp
@@ -3669,10 +3669,10 @@ void z80_device::state_string_export(const device_state_entry &entry, std::strin
 //  helper function
 //-------------------------------------------------
 
-offs_t z80_device::disasm_disassemble( char *buffer, offs_t pc, const uint8_t *oprom, const uint8_t *opram, uint32_t options )
+offs_t z80_device::disasm_disassemble( std::ostream &stream, offs_t pc, const uint8_t *oprom, const uint8_t *opram, uint32_t options )
 {
 	extern CPU_DISASSEMBLE( z80 );
-	return CPU_DISASSEMBLE_NAME(z80)(this, buffer, pc, oprom, opram, options);
+	return CPU_DISASSEMBLE_NAME(z80)(this, stream, pc, oprom, opram, options);
 }
 
 

--- a/src/devices/cpu/z80/z80.h
+++ b/src/devices/cpu/z80/z80.h
@@ -68,7 +68,7 @@ protected:
 	// device_disasm_interface overrides
 	virtual uint32_t disasm_min_opcode_bytes() const override { return 1; }
 	virtual uint32_t disasm_max_opcode_bytes() const override { return 4; }
-	virtual offs_t disasm_disassemble(char *buffer, offs_t pc, const uint8_t *oprom, const uint8_t *opram, uint32_t options) override;
+	virtual offs_t disasm_disassemble(std::ostream &stream, offs_t pc, const uint8_t *oprom, const uint8_t *opram, uint32_t options) override;
 
 #undef PROTOTYPES
 #define PROTOTYPES(prefix) \

--- a/src/devices/cpu/z80/z80dasm.cpp
+++ b/src/devices/cpu/z80/z80dasm.cpp
@@ -413,7 +413,7 @@ static int offs(int8_t offset)
 /****************************************************************************
  * Disassemble opcode at PC and return number of bytes it takes
  ****************************************************************************/
-static offs_t internal_disasm_z80(cpu_device *device, std::ostream &stream, offs_t pc, const uint8_t *oprom, const uint8_t *opram, int options)
+CPU_DISASSEMBLE(z80)
 {
 	const z80dasm *d;
 	const char *src, *ixy;
@@ -526,14 +526,4 @@ static offs_t internal_disasm_z80(cpu_device *device, std::ostream &stream, offs
 	}
 
 	return pos | s_flags[d->mnemonic] | DASMFLAG_SUPPORTED;
-}
-
-
-CPU_DISASSEMBLE(z80)
-{
-	std::ostringstream stream;
-	offs_t result = internal_disasm_z80(device, stream, pc, oprom, opram, options);
-	std::string stream_str = stream.str();
-	strcpy(buffer, stream_str.c_str());
-	return result;
 }

--- a/src/devices/cpu/z8000/8000dasm.cpp
+++ b/src/devices/cpu/z8000/8000dasm.cpp
@@ -48,7 +48,7 @@ static const char *const ints[4] = {
 int z8k_segm;                               /* Current disassembler mode: 0 - non-segmented, 1 - segmented */
 int z8k_segm_mode = Z8K_SEGM_MODE_AUTO;     /* User disassembler mode setting: segmented, non-segmented, auto */
 
-static offs_t internal_disasm_z8000(cpu_device *device, std::ostream &stream, offs_t pc, const uint8_t *oprom, const uint8_t *opram, int options)
+CPU_DISASSEMBLE(z8000)
 {
 	int new_pc = pc, i, j, tmp;
 	const char *src;
@@ -310,14 +310,4 @@ static offs_t internal_disasm_z8000(cpu_device *device, std::ostream &stream, of
 			break;
 	}
 	return (new_pc - pc) | flags | DASMFLAG_SUPPORTED;
-}
-
-
-CPU_DISASSEMBLE(z8000)
-{
-	std::ostringstream stream;
-	offs_t result = internal_disasm_z8000(device, stream, pc, oprom, opram, options);
-	std::string stream_str = stream.str();
-	strcpy(buffer, stream_str.c_str());
-	return result;
 }

--- a/src/devices/cpu/z8000/z8000.cpp
+++ b/src/devices/cpu/z8000/z8000.cpp
@@ -61,10 +61,10 @@ z8001_device::z8001_device(const machine_config &mconfig, const char *tag, devic
 }
 
 
-offs_t z8002_device::disasm_disassemble(char *buffer, offs_t pc, const uint8_t *oprom, const uint8_t *opram, uint32_t options)
+offs_t z8002_device::disasm_disassemble(std::ostream &stream, offs_t pc, const uint8_t *oprom, const uint8_t *opram, uint32_t options)
 {
 	extern CPU_DISASSEMBLE( z8000 );
-	return CPU_DISASSEMBLE_NAME(z8000)(this, buffer, pc, oprom, opram, options);
+	return CPU_DISASSEMBLE_NAME(z8000)(this, stream, pc, oprom, opram, options);
 }
 
 

--- a/src/devices/cpu/z8000/z8000.h
+++ b/src/devices/cpu/z8000/z8000.h
@@ -74,7 +74,7 @@ protected:
 	// device_disasm_interface overrides
 	virtual uint32_t disasm_min_opcode_bytes() const override { return 2; }
 	virtual uint32_t disasm_max_opcode_bytes() const override { return 6; }
-	virtual offs_t disasm_disassemble(char *buffer, offs_t pc, const uint8_t *oprom, const uint8_t *opram, uint32_t options) override;
+	virtual offs_t disasm_disassemble(std::ostream &stream, offs_t pc, const uint8_t *oprom, const uint8_t *opram, uint32_t options) override;
 
 	address_space_config m_program_config;
 	address_space_config m_io_config;

--- a/src/devices/machine/netlist.cpp
+++ b/src/devices/machine/netlist.cpp
@@ -535,7 +535,7 @@ ATTR_COLD uint64_t netlist_mame_cpu_device_t::execute_cycles_to_clocks(uint64_t 
 	return cycles;
 }
 
-ATTR_COLD offs_t netlist_mame_cpu_device_t::disasm_disassemble(char *buffer, offs_t pc, const uint8_t *oprom, const uint8_t *opram, uint32_t options)
+ATTR_COLD offs_t netlist_mame_cpu_device_t::disasm_disassemble(std::ostream &stream, offs_t pc, const uint8_t *oprom, const uint8_t *opram, uint32_t options)
 {
 	//char tmp[16];
 	unsigned startpc = pc;
@@ -544,11 +544,9 @@ ATTR_COLD offs_t netlist_mame_cpu_device_t::disasm_disassemble(char *buffer, off
 	{
 		int dpc = netlist().queue().size() - relpc - 1;
 		// FIXME: 50 below fixes crash in mame-debugger. It's based on try on error.
-		snprintf(buffer, 50, "%c %s @%10.7f", (relpc == 0) ? '*' : ' ', netlist().queue()[dpc].m_object->name().cstr(),
+		util::stream_format(stream, "%c %s @%10.7f", (relpc == 0) ? '*' : ' ', netlist().queue()[dpc].m_object->name().cstr(),
 				netlist().queue()[dpc].m_exec_time.as_double());
 	}
-	else
-		sprintf(buffer, "%s", "");
 
 	pc+=1;
 	return (pc - startpc);

--- a/src/devices/machine/netlist.h
+++ b/src/devices/machine/netlist.h
@@ -210,7 +210,7 @@ protected:
 	// device_disasm_interface overrides
 	ATTR_COLD virtual uint32_t disasm_min_opcode_bytes() const override { return 1; }
 	ATTR_COLD virtual uint32_t disasm_max_opcode_bytes() const override { return 1; }
-	ATTR_COLD virtual offs_t disasm_disassemble(char *buffer, offs_t pc, const uint8_t *oprom, const uint8_t *opram, uint32_t options) override;
+	ATTR_COLD virtual offs_t disasm_disassemble(std::ostream &stream, offs_t pc, const uint8_t *oprom, const uint8_t *opram, uint32_t options) override;
 
 	// device_memory_interface overrides
 

--- a/src/emu/debug/debugcmd.cpp
+++ b/src/emu/debug/debugcmd.cpp
@@ -2401,11 +2401,11 @@ void debugger_commands::execute_dasm(int ref, int params, const char *param[])
 
 	/* now write the data out */
 	util::ovectorstream output;
+	util::ovectorstream disasm;
 	output.reserve(512);
 	for (u64 i = 0; i < length; )
 	{
 		int pcbyte = space->address_to_byte(offset + i) & space->bytemask();
-		std::string disasm;
 		const char *comment;
 		offs_t tempaddr;
 		int numbytes = 0;
@@ -2429,6 +2429,8 @@ void debugger_commands::execute_dasm(int ref, int params, const char *param[])
 			}
 
 			/* disassemble the result */
+			disasm.clear();
+			disasm.seekp(0);
 			i += numbytes = dasmintf->disassemble(disasm, offset + i, opbuf, argbuf) & DASMFLAG_LENGTHMASK;
 		}
 
@@ -2445,7 +2447,8 @@ void debugger_commands::execute_dasm(int ref, int params, const char *param[])
 		}
 
 		/* add the disassembly */
-		stream_format(output, "%s", disasm);
+		disasm.put('\0');
+		stream_format(output, "%s", &disasm.vec()[0]);
 
 		/* attempt to add the comment */
 		comment = space->device().debug()->comment_text(tempaddr);
@@ -2604,10 +2607,11 @@ void debugger_commands::execute_history(int ref, int params, const char *param[]
 			argbuf[numbytes] = m_cpu.read_opcode(*space, pcbyte + numbytes, 1);
 		}
 
-		std::string buffer;
+		util::ovectorstream buffer;
 		dasmintf->disassemble(buffer, pc, opbuf, argbuf);
+		buffer.put('\0');
 
-		m_console.printf("%0*X: %s\n", space->logaddrchars(), pc, buffer.c_str());
+		m_console.printf("%0*X: %s\n", space->logaddrchars(), pc, &buffer.vec()[0]);
 	}
 }
 

--- a/src/emu/debug/debugcmd.cpp
+++ b/src/emu/debug/debugcmd.cpp
@@ -2405,7 +2405,7 @@ void debugger_commands::execute_dasm(int ref, int params, const char *param[])
 	for (u64 i = 0; i < length; )
 	{
 		int pcbyte = space->address_to_byte(offset + i) & space->bytemask();
-		char disasm[200];
+		std::string disasm;
 		const char *comment;
 		offs_t tempaddr;
 		int numbytes = 0;
@@ -2604,10 +2604,10 @@ void debugger_commands::execute_history(int ref, int params, const char *param[]
 			argbuf[numbytes] = m_cpu.read_opcode(*space, pcbyte + numbytes, 1);
 		}
 
-		char buffer[200];
+		std::string buffer;
 		dasmintf->disassemble(buffer, pc, opbuf, argbuf);
 
-		m_console.printf("%0*X: %s\n", space->logaddrchars(), pc, buffer);
+		m_console.printf("%0*X: %s\n", space->logaddrchars(), pc, buffer.c_str());
 	}
 }
 

--- a/src/emu/debug/debugcmd.cpp
+++ b/src/emu/debug/debugcmd.cpp
@@ -2411,6 +2411,8 @@ void debugger_commands::execute_dasm(int ref, int params, const char *param[])
 		int numbytes = 0;
 		output.clear();
 		output.rdbuf()->clear();
+		disasm.clear();
+		disasm.seekp(0);
 
 		/* print the address */
 		stream_format(output, "%0*X: ", space->logaddrchars(), u32(space->byte_to_address(pcbyte)));
@@ -2429,8 +2431,6 @@ void debugger_commands::execute_dasm(int ref, int params, const char *param[])
 			}
 
 			/* disassemble the result */
-			disasm.clear();
-			disasm.seekp(0);
 			i += numbytes = dasmintf->disassemble(disasm, offset + i, opbuf, argbuf) & DASMFLAG_LENGTHMASK;
 		}
 

--- a/src/emu/debug/debugcpu.cpp
+++ b/src/emu/debug/debugcpu.cpp
@@ -2627,8 +2627,7 @@ u32 device_debug::compute_opcode_crc32(offs_t pc) const
 	if (m_disasm != nullptr)
 	{
 		// disassemble to our buffer
-		char diasmbuf[200];
-		memset(diasmbuf, 0x00, 200);
+		std::string diasmbuf;
 		numbytes = m_disasm->disassemble(diasmbuf, pc, opbuf, argbuf) & DASMFLAG_LENGTHMASK;
 	}
 
@@ -3027,10 +3026,7 @@ u32 device_debug::dasm_wrapped(std::string &buffer, offs_t pc)
 	}
 
 	// disassemble to our buffer
-	char diasmbuf[200];
-	memset(diasmbuf, 0x00, 200);
-	u32 result = m_disasm->disassemble(diasmbuf, pc, opbuf, argbuf);
-	buffer.assign(diasmbuf);
+	uint32_t result = m_disasm->disassemble(buffer, pc, opbuf, argbuf);
 	return result;
 }
 

--- a/src/emu/debug/debugcpu.cpp
+++ b/src/emu/debug/debugcpu.cpp
@@ -2627,7 +2627,7 @@ u32 device_debug::compute_opcode_crc32(offs_t pc) const
 	if (m_disasm != nullptr)
 	{
 		// disassemble to our buffer
-		std::string diasmbuf;
+		std::ostringstream diasmbuf;
 		numbytes = m_disasm->disassemble(diasmbuf, pc, opbuf, argbuf) & DASMFLAG_LENGTHMASK;
 	}
 
@@ -3026,7 +3026,9 @@ u32 device_debug::dasm_wrapped(std::string &buffer, offs_t pc)
 	}
 
 	// disassemble to our buffer
-	uint32_t result = m_disasm->disassemble(buffer, pc, opbuf, argbuf);
+	std::ostringstream stream;
+	uint32_t result = m_disasm->disassemble(stream, pc, opbuf, argbuf);
+	buffer = stream.str();
 	return result;
 }
 

--- a/src/emu/debug/dvdisasm.cpp
+++ b/src/emu/debug/dvdisasm.cpp
@@ -271,7 +271,7 @@ offs_t debug_view_disasm::find_pc_backwards(offs_t targetpc, int numinstrs)
 			instlen = 1;
 			if (source.m_space.device().memory().translate(source.m_space.spacenum(), TRANSLATE_FETCH, physpcbyte))
 			{
-				char dasmbuffer[100];
+				std::string dasmbuffer;
 				instlen = source.m_disasmintf->disassemble(dasmbuffer, scanpc, &opbuf[1000 + scanpcbyte - targetpcbyte], &argbuf[1000 + scanpcbyte - targetpcbyte]) & DASMFLAG_LENGTHMASK;
 			}
 
@@ -392,7 +392,7 @@ bool debug_view_disasm::recompute(offs_t pc, int startline, int lines)
 			source.m_space.logaddrchars()/2*char_num, source.m_space.byte_to_address(pcbyte));
 
 		// make sure we can translate the address, and then disassemble the result
-		char buffer[100];
+		std::string buffer;
 		int numbytes = 0;
 		offs_t physpcbyte = pcbyte;
 		if (source.m_space.device().memory().translate(source.m_space.spacenum(), TRANSLATE_FETCH_DEBUG, physpcbyte))
@@ -410,7 +410,7 @@ bool debug_view_disasm::recompute(offs_t pc, int startline, int lines)
 			pc += numbytes = source.m_disasmintf->disassemble(buffer, pc & source.m_space.logaddrmask(), opbuf, argbuf) & DASMFLAG_LENGTHMASK;
 		}
 		else
-			strcpy(buffer, "<unmapped>");
+			buffer = "<unmapped>";
 
 		// append the disassembly to the buffer
 		util::stream_format(m_dasm.seekp(base + m_divider1 + 1), "%2$-*1$.*1$s  ", m_dasm_width, buffer);

--- a/src/emu/debug/dvdisasm.cpp
+++ b/src/emu/debug/dvdisasm.cpp
@@ -271,7 +271,7 @@ offs_t debug_view_disasm::find_pc_backwards(offs_t targetpc, int numinstrs)
 			instlen = 1;
 			if (source.m_space.device().memory().translate(source.m_space.spacenum(), TRANSLATE_FETCH, physpcbyte))
 			{
-				std::string dasmbuffer;
+				std::ostringstream dasmbuffer;
 				instlen = source.m_disasmintf->disassemble(dasmbuffer, scanpc, &opbuf[1000 + scanpcbyte - targetpcbyte], &argbuf[1000 + scanpcbyte - targetpcbyte]) & DASMFLAG_LENGTHMASK;
 			}
 
@@ -335,6 +335,7 @@ void debug_view_disasm::generate_bytes(offs_t pcbyte, int numbytes, int minbytes
 
 bool debug_view_disasm::recompute(offs_t pc, int startline, int lines)
 {
+	util::ovectorstream buffer;
 	bool changed = false;
 	const debug_view_disasm_source &source = downcast<const debug_view_disasm_source &>(*m_source);
 	const int char_num = source.m_space.is_octal() ? 3 : 2;
@@ -392,7 +393,8 @@ bool debug_view_disasm::recompute(offs_t pc, int startline, int lines)
 			source.m_space.logaddrchars()/2*char_num, source.m_space.byte_to_address(pcbyte));
 
 		// make sure we can translate the address, and then disassemble the result
-		std::string buffer;
+		buffer.clear();
+		buffer.seekp(0);
 		int numbytes = 0;
 		offs_t physpcbyte = pcbyte;
 		if (source.m_space.device().memory().translate(source.m_space.spacenum(), TRANSLATE_FETCH_DEBUG, physpcbyte))
@@ -410,10 +412,12 @@ bool debug_view_disasm::recompute(offs_t pc, int startline, int lines)
 			pc += numbytes = source.m_disasmintf->disassemble(buffer, pc & source.m_space.logaddrmask(), opbuf, argbuf) & DASMFLAG_LENGTHMASK;
 		}
 		else
-			buffer = "<unmapped>";
+			buffer << "<unmapped>";
+
+		buffer.put('\0');
 
 		// append the disassembly to the buffer
-		util::stream_format(m_dasm.seekp(base + m_divider1 + 1), "%2$-*1$.*1$s  ", m_dasm_width, buffer);
+		util::stream_format(m_dasm.seekp(base + m_divider1 + 1), "%2$-*1$.*1$s  ", m_dasm_width, &buffer.vec()[0]);
 
 		// output the right column
 		if (m_right_column == DASM_RIGHTCOL_RAW || m_right_column == DASM_RIGHTCOL_ENCRYPTED)

--- a/src/emu/devcpu.h
+++ b/src/emu/devcpu.h
@@ -54,8 +54,8 @@
 //**************************************************************************
 
 #define CPU_DISASSEMBLE_NAME(name)      cpu_disassemble_##name
-#define CPU_DISASSEMBLE(name)           offs_t CPU_DISASSEMBLE_NAME(name)(cpu_device *device, char *buffer, offs_t pc, const u8 *oprom, const u8 *opram, int options)
-#define CPU_DISASSEMBLE_CALL(name)      CPU_DISASSEMBLE_NAME(name)(device, buffer, pc, oprom, opram, options)
+#define CPU_DISASSEMBLE(name)           offs_t CPU_DISASSEMBLE_NAME(name)(cpu_device *device, std::ostream &stream, offs_t pc, const u8 *oprom, const u8 *opram, int options)
+#define CPU_DISASSEMBLE_CALL(name)      CPU_DISASSEMBLE_NAME(name)(device, stream, pc, oprom, opram, options)
 
 
 //**************************************************************************
@@ -88,7 +88,7 @@ private:
 };
 
 
-typedef offs_t (*cpu_disassemble_func)(cpu_device *device, char *buffer, offs_t pc, const u8 *oprom, const u8 *opram, int options);
+typedef offs_t (*cpu_disassemble_func)(cpu_device *device, std::ostream &stream, offs_t pc, const u8 *oprom, const u8 *opram, int options);
 
 
 #endif  /* MAME_EMU_DEVCPU_H */

--- a/src/emu/didisasm.cpp
+++ b/src/emu/didisasm.cpp
@@ -90,16 +90,3 @@ offs_t device_disasm_interface::disassemble(std::ostream &stream, offs_t pc, con
 
 	return result;
 }
-
-
-//-------------------------------------------------
-//  disassemble - interface for disassembly
-//-------------------------------------------------
-
-offs_t device_disasm_interface::disassemble(std::string &buffer, offs_t pc, const u8 *oprom, const u8 *opram, uint32_t options)
-{
-	std::stringstream stream;
-	offs_t result = disassemble(stream, pc, oprom, opram, options);
-	buffer = stream.str();
-	return result;
-}

--- a/src/emu/didisasm.cpp
+++ b/src/emu/didisasm.cpp
@@ -64,20 +64,15 @@ void device_disasm_interface::static_set_dasm_override(device_t &device, dasm_ov
 //  disassemble - interface for disassembly
 //-------------------------------------------------
 
-offs_t device_disasm_interface::disassemble(char *buffer, offs_t pc, const u8 *oprom, const u8 *opram, u32 options)
+offs_t device_disasm_interface::disassemble(std::ostream &stream, offs_t pc, const u8 *oprom, const u8 *opram, u32 options)
 {
 	offs_t result = 0;
 
 	// check for disassembler override
 	if (!m_dasm_override.isnull())
-	{
-		std::ostringstream stream;
 		result = m_dasm_override(device(), stream, pc, oprom, opram, options);
-		std::string stream_str = stream.str();
-		strcpy(buffer, stream_str.c_str());
-	}
 	if (result == 0)
-		result = disasm_disassemble(buffer, pc, oprom, opram, options);
+		result = disasm_disassemble(stream, pc, oprom, opram, options);
 
 	// make sure we get good results
 	assert((result & DASMFLAG_LENGTHMASK) != 0);
@@ -93,5 +88,18 @@ offs_t device_disasm_interface::disassemble(char *buffer, offs_t pc, const u8 *o
 	}
 #endif
 
+	return result;
+}
+
+
+//-------------------------------------------------
+//  disassemble - interface for disassembly
+//-------------------------------------------------
+
+offs_t device_disasm_interface::disassemble(std::string &buffer, offs_t pc, const u8 *oprom, const u8 *opram, uint32_t options)
+{
+	std::stringstream stream;
+	offs_t result = disassemble(stream, pc, oprom, opram, options);
+	buffer = stream.str();
 	return result;
 }

--- a/src/emu/didisasm.h
+++ b/src/emu/didisasm.h
@@ -74,7 +74,6 @@ public:
 
 	// interface for disassembly
 	offs_t disassemble(std::ostream &stream, offs_t pc, const u8 *oprom, const u8 *opram, u32 options = 0);
-	offs_t disassemble(std::string &buffer, offs_t pc, const u8 *oprom, const u8 *opram, u32 options = 0);
 
 protected:
 	// required operation overrides

--- a/src/emu/didisasm.h
+++ b/src/emu/didisasm.h
@@ -73,13 +73,14 @@ public:
 	static void static_set_dasm_override(device_t &device, dasm_override_delegate dasm_override);
 
 	// interface for disassembly
-	offs_t disassemble(char *buffer, offs_t pc, const u8 *oprom, const u8 *opram, u32 options = 0);
+	offs_t disassemble(std::ostream &stream, offs_t pc, const u8 *oprom, const u8 *opram, u32 options = 0);
+	offs_t disassemble(std::string &buffer, offs_t pc, const u8 *oprom, const u8 *opram, u32 options = 0);
 
 protected:
 	// required operation overrides
 	virtual u32 disasm_min_opcode_bytes() const = 0;
 	virtual u32 disasm_max_opcode_bytes() const = 0;
-	virtual offs_t disasm_disassemble(char *buffer, offs_t pc, const u8 *oprom, const u8 *opram, u32 options) = 0;
+	virtual offs_t disasm_disassemble(std::ostream &stream, offs_t pc, const u8 *oprom, const u8 *opram, u32 options) = 0;
 
 	// interface-level overrides
 	virtual void interface_pre_start() override;

--- a/src/mame/drivers/vgmplay.cpp
+++ b/src/mame/drivers/vgmplay.cpp
@@ -86,7 +86,6 @@ public:
 	virtual uint32_t disasm_min_opcode_bytes() const override;
 	virtual uint32_t disasm_max_opcode_bytes() const override;
 	virtual offs_t disasm_disassemble(std::ostream &stream, offs_t pc, const uint8_t *oprom, const uint8_t *opram, uint32_t options) override;
-	offs_t disasm_disassemble(char *buffer, offs_t pc, const uint8_t *oprom, const uint8_t *opram, uint32_t options);
 
 	READ8_MEMBER(segapcm_rom_r);
 	READ8_MEMBER(multipcma_rom_r);
@@ -568,99 +567,91 @@ uint32_t vgmplay_device::disasm_max_opcode_bytes() const
 
 offs_t vgmplay_device::disasm_disassemble(std::ostream &stream, offs_t pc, const uint8_t *oprom, const uint8_t *opram, uint32_t options)
 {
-	char buffer[256];
-	offs_t result = disasm_disassemble(buffer, pc, oprom, opram, options);
-	stream << buffer;
-	return result;	
-}
-
-offs_t vgmplay_device::disasm_disassemble(char *buffer, offs_t pc, const uint8_t *oprom, const uint8_t *opram, uint32_t options)
-{
 	switch(oprom[0]) {
 	case 0x4f:
-		sprintf(buffer, "psg r06 = %02x", oprom[1]);
+		util::stream_format(stream, "psg r06 = %02x", oprom[1]);
 		return 2 | DASMFLAG_SUPPORTED;
 
 	case 0x50:
-		sprintf(buffer, "psg write %02x", oprom[1]);
+		util::stream_format(stream, "psg write %02x", oprom[1]);
 		return 2 | DASMFLAG_SUPPORTED;
 
 	case 0x51:
-		sprintf(buffer, "ym2413 r%02x = %02x", oprom[1], oprom[2]);
+		util::stream_format(stream, "ym2413 r%02x = %02x", oprom[1], oprom[2]);
 		return 3 | DASMFLAG_SUPPORTED;
 
 	case 0x52:
-		sprintf(buffer, "ym2612.0 r%02x = %02x", oprom[1], oprom[2]);
+		util::stream_format(stream, "ym2612.0 r%02x = %02x", oprom[1], oprom[2]);
 		return 3 | DASMFLAG_SUPPORTED;
 
 	case 0x53:
-		sprintf(buffer, "ym2612.1 r%02x = %02x", oprom[1], oprom[2]);
+		util::stream_format(stream, "ym2612.1 r%02x = %02x", oprom[1], oprom[2]);
 		return 3 | DASMFLAG_SUPPORTED;
 
 	case 0x54:
-		sprintf(buffer, "ym2151 r%02x = %02x", oprom[1], oprom[2]);
+		util::stream_format(stream, "ym2151 r%02x = %02x", oprom[1], oprom[2]);
 		return 3 | DASMFLAG_SUPPORTED;
 
 	case 0x55:
-		sprintf(buffer, "ym2203a r%02x = %02x", oprom[1], oprom[2]);
+		util::stream_format(stream, "ym2203a r%02x = %02x", oprom[1], oprom[2]);
 		return 3 | DASMFLAG_SUPPORTED;
 
 	case 0x56:
-		sprintf(buffer, "ym2608.0 r%02x = %02x", oprom[1], oprom[2]);
+		util::stream_format(stream, "ym2608.0 r%02x = %02x", oprom[1], oprom[2]);
 		return 3 | DASMFLAG_SUPPORTED;
 
 	case 0x57:
-		sprintf(buffer, "ym2608.1 r%02x = %02x", oprom[1], oprom[2]);
+		util::stream_format(stream, "ym2608.1 r%02x = %02x", oprom[1], oprom[2]);
 		return 3 | DASMFLAG_SUPPORTED;
 
 	case 0x58:
-		sprintf(buffer, "ym2610.0 r%02x = %02x", oprom[1], oprom[2]);
+		util::stream_format(stream, "ym2610.0 r%02x = %02x", oprom[1], oprom[2]);
 		return 3 | DASMFLAG_SUPPORTED;
 
 	case 0x59:
-		sprintf(buffer, "ym2610.1 r%02x = %02x", oprom[1], oprom[2]);
+		util::stream_format(stream, "ym2610.1 r%02x = %02x", oprom[1], oprom[2]);
 		return 3 | DASMFLAG_SUPPORTED;
 
 	case 0x5a:
-		sprintf(buffer, "ym3812 r%02x = %02x", oprom[1], oprom[2]);
+		util::stream_format(stream, "ym3812 r%02x = %02x", oprom[1], oprom[2]);
 		return 3 | DASMFLAG_SUPPORTED;
 
 	case 0x5b:
-		sprintf(buffer, "ym3526 r%02x = %02x", oprom[1], oprom[2]);
+		util::stream_format(stream, "ym3526 r%02x = %02x", oprom[1], oprom[2]);
 		return 3 | DASMFLAG_SUPPORTED;
 
 	case 0x5c:
-		sprintf(buffer, "y8950 r%02x = %02x", oprom[1], oprom[2]);
+		util::stream_format(stream, "y8950 r%02x = %02x", oprom[1], oprom[2]);
 		return 3 | DASMFLAG_SUPPORTED;
 
 	case 0x5d:
-		sprintf(buffer, "ymz280b r%02x = %02x", oprom[1], oprom[2]);
+		util::stream_format(stream, "ymz280b r%02x = %02x", oprom[1], oprom[2]);
 		return 3 | DASMFLAG_SUPPORTED;
 
 	case 0x5e:
-		sprintf(buffer, "ymf262.0 r%02x = %02x", oprom[1], oprom[2]);
+		util::stream_format(stream, "ymf262.0 r%02x = %02x", oprom[1], oprom[2]);
 		return 3 | DASMFLAG_SUPPORTED;
 
 	case 0x5f:
-		sprintf(buffer, "ymf262.1 r%02x = %02x", oprom[1], oprom[2]);
+		util::stream_format(stream, "ymf262.1 r%02x = %02x", oprom[1], oprom[2]);
 		return 3 | DASMFLAG_SUPPORTED;
 
 	case 0x61: {
 		uint32_t duration = oprom[1] | (oprom[2] << 8);
-		sprintf(buffer, "wait %d", duration);
+		util::stream_format(stream, "wait %d", duration);
 		return 3 | DASMFLAG_SUPPORTED;
 	}
 
 	case 0x62:
-		sprintf(buffer, "wait 735");
+		util::stream_format(stream, "wait 735");
 		return 1 | DASMFLAG_SUPPORTED;
 
 	case 0x63:
-		sprintf(buffer, "wait 882");
+		util::stream_format(stream, "wait 882");
 		return 1 | DASMFLAG_SUPPORTED;
 
 	case 0x66:
-		sprintf(buffer, "end");
+		util::stream_format(stream, "end");
 		return 1 | DASMFLAG_SUPPORTED;
 
 	case 0x67: {
@@ -712,155 +703,155 @@ offs_t vgmplay_device::disasm_disassemble(char *buffer, offs_t pc, const uint8_t
 		uint8_t type = oprom[2];
 		uint32_t size = oprom[3] | (oprom[4] << 8) | (oprom[5] << 16) | (oprom[6] << 24);
 		if(type < 0x8)
-			sprintf(buffer, "data-block %x, %s", size, basic_types[type]);
+			util::stream_format(stream, "data-block %x, %s", size, basic_types[type]);
 		else if(type < 0x40)
-			sprintf(buffer, "data-block %x, %02x", size, type);
+			util::stream_format(stream, "data-block %x, %02x", size, type);
 		else if(type < 0x48)
-			sprintf(buffer, "data-block %x comp., %s", size, basic_types[type & 0x3f]);
+			util::stream_format(stream, "data-block %x comp., %s", size, basic_types[type & 0x3f]);
 		else if(type < 0x7f)
-			sprintf(buffer, "data-block %x comp., %02x", size, type & 0x3f);
+			util::stream_format(stream, "data-block %x comp., %02x", size, type & 0x3f);
 		else if(type < 0x80)
-			sprintf(buffer, "decomp-table %x, %02x/%02x", size, oprom[7], oprom[8]);
+			util::stream_format(stream, "decomp-table %x, %02x/%02x", size, oprom[7], oprom[8]);
 		else if(type < 0x94)
-			sprintf(buffer, "data-block %x, %s", size, rom_types[type & 0x7f]);
+			util::stream_format(stream, "data-block %x, %s", size, rom_types[type & 0x7f]);
 		else if(type < 0xc0)
-			sprintf(buffer, "data-block %x, rom %02x", size, type);
+			util::stream_format(stream, "data-block %x, rom %02x", size, type);
 		else if(type < 0xc3)
-			sprintf(buffer, "data-block %x, %s", size, ram_types[type & 0x1f]);
+			util::stream_format(stream, "data-block %x, %s", size, ram_types[type & 0x1f]);
 		else if(type < 0xe0)
-			sprintf(buffer, "data-block %x, ram %02x", size, type);
+			util::stream_format(stream, "data-block %x, ram %02x", size, type);
 		else if(type < 0xe2)
-			sprintf(buffer, "data-block %x, %s", size, ram2_types[type & 0x1f]);
+			util::stream_format(stream, "data-block %x, %s", size, ram2_types[type & 0x1f]);
 		else
-			sprintf(buffer, "data-block %x, ram %02x", size, type);
+			util::stream_format(stream, "data-block %x, ram %02x", size, type);
 		return (7+size) | DASMFLAG_SUPPORTED;
 	}
 
 	case 0x70: case 0x71: case 0x72: case 0x73: case 0x74: case 0x75: case 0x76: case 0x77:
 	case 0x78: case 0x79: case 0x7a: case 0x7b: case 0x7c: case 0x7d: case 0x7e: case 0x7f:
-		sprintf(buffer, "wait %d", 1+(oprom[0] & 0x0f));
+		util::stream_format(stream, "wait %d", 1+(oprom[0] & 0x0f));
 		return 1 | DASMFLAG_SUPPORTED;
 
 	case 0x80:
-		sprintf(buffer, "ym2612.0 r2a = rom++");
+		util::stream_format(stream, "ym2612.0 r2a = rom++");
 		return 1 | DASMFLAG_SUPPORTED;
 
 	case 0x81: case 0x82: case 0x83: case 0x84: case 0x85: case 0x86: case 0x87:
 	case 0x88: case 0x89: case 0x8a: case 0x8b: case 0x8c: case 0x8d: case 0x8e: case 0x8f:
-		sprintf(buffer, "ym2612.0 r2a = rom++; wait %d", oprom[0] & 0xf);
+		util::stream_format(stream, "ym2612.0 r2a = rom++; wait %d", oprom[0] & 0xf);
 		return 1 | DASMFLAG_SUPPORTED;
 
 	case 0xa0:
-		sprintf(buffer, "ay8910 r%02x = %02x", oprom[1], oprom[2]);
+		util::stream_format(stream, "ay8910 r%02x = %02x", oprom[1], oprom[2]);
 		return 3 | DASMFLAG_SUPPORTED;
 
 	case 0xa5:
-		sprintf(buffer, "ym2203b r%02x = %02x", oprom[1], oprom[2]);
+		util::stream_format(stream, "ym2203b r%02x = %02x", oprom[1], oprom[2]);
 		return 3 | DASMFLAG_SUPPORTED;
 
 	case 0xb0:
-		sprintf(buffer, "rf5c68 r%02x = %02x", oprom[1], oprom[2]);
+		util::stream_format(stream, "rf5c68 r%02x = %02x", oprom[1], oprom[2]);
 		return 3 | DASMFLAG_SUPPORTED;
 
 	case 0xb1:
-		sprintf(buffer, "rf5c164 r%02x = %02x", oprom[1], oprom[2]);
+		util::stream_format(stream, "rf5c164 r%02x = %02x", oprom[1], oprom[2]);
 		return 3 | DASMFLAG_SUPPORTED;
 
 	case 0xb2:
-		sprintf(buffer, "pwm r%x = %03x", oprom[1] >> 4, oprom[2] | ((oprom[1] & 0xf) << 8));
+		util::stream_format(stream, "pwm r%x = %03x", oprom[1] >> 4, oprom[2] | ((oprom[1] & 0xf) << 8));
 		return 3 | DASMFLAG_SUPPORTED;
 
 	case 0xb3:
-		sprintf(buffer, "dmg r%02x = %02x", oprom[1], oprom[2]);
+		util::stream_format(stream, "dmg r%02x = %02x", oprom[1], oprom[2]);
 		return 3 | DASMFLAG_SUPPORTED;
 
 	case 0xb4:
-		sprintf(buffer, "nesapu r%02x = %02x", oprom[1], oprom[2]);
+		util::stream_format(stream, "nesapu r%02x = %02x", oprom[1], oprom[2]);
 		return 3 | DASMFLAG_SUPPORTED;
 
 	case 0xb5:
-		sprintf(buffer, "multipcm r%02x = %02x", oprom[1], oprom[2]);
+		util::stream_format(stream, "multipcm r%02x = %02x", oprom[1], oprom[2]);
 		return 3 | DASMFLAG_SUPPORTED;
 
 	case 0xb6:
-		sprintf(buffer, "upd7759 r%02x = %02x", oprom[1], oprom[2]);
+		util::stream_format(stream, "upd7759 r%02x = %02x", oprom[1], oprom[2]);
 		return 3 | DASMFLAG_SUPPORTED;
 
 	case 0xb7:
-		sprintf(buffer, "okim6258 r%02x = %02x", oprom[1], oprom[2]);
+		util::stream_format(stream, "okim6258 r%02x = %02x", oprom[1], oprom[2]);
 		return 3 | DASMFLAG_SUPPORTED;
 
 	case 0xb8:
-		sprintf(buffer, "okim6295 r%02x = %02x", oprom[1], oprom[2]);
+		util::stream_format(stream, "okim6295 r%02x = %02x", oprom[1], oprom[2]);
 		return 3 | DASMFLAG_SUPPORTED;
 
 	case 0xb9:
-		sprintf(buffer, "huc6280 r%02x = %02x", oprom[1], oprom[2]);
+		util::stream_format(stream, "huc6280 r%02x = %02x", oprom[1], oprom[2]);
 		return 3 | DASMFLAG_SUPPORTED;
 
 	case 0xba:
-		sprintf(buffer, "k053260 r%02x = %02x", oprom[1], oprom[2]);
+		util::stream_format(stream, "k053260 r%02x = %02x", oprom[1], oprom[2]);
 		return 3 | DASMFLAG_SUPPORTED;
 
 	case 0xbb:
-		sprintf(buffer, "pokey r%02x = %02x", oprom[1], oprom[2]);
+		util::stream_format(stream, "pokey r%02x = %02x", oprom[1], oprom[2]);
 		return 3 | DASMFLAG_SUPPORTED;
 
 	case 0xc0:
-		sprintf(buffer, "segapcm %04x = %02x", oprom[1] | (oprom[2] << 8), oprom[3]);
+		util::stream_format(stream, "segapcm %04x = %02x", oprom[1] | (oprom[2] << 8), oprom[3]);
 		return 4 | DASMFLAG_SUPPORTED;
 
 	case 0xc1:
-		sprintf(buffer, "rf5c68 %04x = %02x", oprom[1] | (oprom[2] << 8), oprom[3]);
+		util::stream_format(stream, "rf5c68 %04x = %02x", oprom[1] | (oprom[2] << 8), oprom[3]);
 		return 4 | DASMFLAG_SUPPORTED;
 
 	case 0xc2:
-		sprintf(buffer, "rf5c163 %04x = %02x", oprom[1] | (oprom[2] << 8), oprom[3]);
+		util::stream_format(stream, "rf5c163 %04x = %02x", oprom[1] | (oprom[2] << 8), oprom[3]);
 		return 4 | DASMFLAG_SUPPORTED;
 
 	case 0xc3:
-		sprintf(buffer, "multipcm c%02x.off = %04x", oprom[1], oprom[2] | (oprom[3] << 8));
+		util::stream_format(stream, "multipcm c%02x.off = %04x", oprom[1], oprom[2] | (oprom[3] << 8));
 		return 4 | DASMFLAG_SUPPORTED;
 
 	case 0xc4:
-		sprintf(buffer, "qsound %02x = %04x", oprom[3], oprom[2] | (oprom[1] << 8));
+		util::stream_format(stream, "qsound %02x = %04x", oprom[3], oprom[2] | (oprom[1] << 8));
 		return 4 | DASMFLAG_SUPPORTED;
 
 	case 0xd0:
-		sprintf(buffer, "ymf278b r%02x.%02x = %02x", oprom[1], oprom[2], oprom[3]);
+		util::stream_format(stream, "ymf278b r%02x.%02x = %02x", oprom[1], oprom[2], oprom[3]);
 		return 4 | DASMFLAG_SUPPORTED;
 
 	case 0xd1:
-		sprintf(buffer, "ymf271 r%02x.%02x = %02x", oprom[1], oprom[2], oprom[3]);
+		util::stream_format(stream, "ymf271 r%02x.%02x = %02x", oprom[1], oprom[2], oprom[3]);
 		return 4 | DASMFLAG_SUPPORTED;
 
 	case 0xd2:
-		sprintf(buffer, "scc1 r%02x.%02x = %02x", oprom[1], oprom[2], oprom[3]);
+		util::stream_format(stream, "scc1 r%02x.%02x = %02x", oprom[1], oprom[2], oprom[3]);
 		return 4 | DASMFLAG_SUPPORTED;
 
 	case 0xd3:
-		sprintf(buffer, "k054539 r%02x.%02x = %02x", oprom[1], oprom[2], oprom[3]);
+		util::stream_format(stream, "k054539 r%02x.%02x = %02x", oprom[1], oprom[2], oprom[3]);
 		return 4 | DASMFLAG_SUPPORTED;
 
 	case 0xd4:
-		sprintf(buffer, "c140 r%02x.%02x = %02x", oprom[1], oprom[2], oprom[3]);
+		util::stream_format(stream, "c140 r%02x.%02x = %02x", oprom[1], oprom[2], oprom[3]);
 		return 4 | DASMFLAG_SUPPORTED;
 
 	case 0xe0: {
 		uint32_t off = oprom[1] | (oprom[2] << 8) | (oprom[3] << 16) | (oprom[4] << 24);
-		sprintf(buffer, "ym2612 offset = %x", off);
+		util::stream_format(stream, "ym2612 offset = %x", off);
 		return 5 | DASMFLAG_SUPPORTED;
 	}
 
 	case 0xe1: {
 		uint16_t addr = (oprom[1] << 8) | oprom[2];
 		uint16_t data = (oprom[3] << 8) | oprom[4];
-		sprintf(buffer, "c352 r%04x = %04x", addr, data);
+		util::stream_format(stream, "c352 r%04x = %04x", addr, data);
 		return 5 | DASMFLAG_SUPPORTED;
 	}
 
 	default:
-		sprintf(buffer, "?? %02x", oprom[0]);
+		util::stream_format(stream, "?? %02x", oprom[0]);
 		return 1 | DASMFLAG_SUPPORTED;
 	}
 }

--- a/src/mame/drivers/vgmplay.cpp
+++ b/src/mame/drivers/vgmplay.cpp
@@ -85,7 +85,8 @@ public:
 
 	virtual uint32_t disasm_min_opcode_bytes() const override;
 	virtual uint32_t disasm_max_opcode_bytes() const override;
-	virtual offs_t disasm_disassemble(char *buffer, offs_t pc, const uint8_t *oprom, const uint8_t *opram, uint32_t options) override;
+	virtual offs_t disasm_disassemble(std::ostream &stream, offs_t pc, const uint8_t *oprom, const uint8_t *opram, uint32_t options) override;
+	offs_t disasm_disassemble(char *buffer, offs_t pc, const uint8_t *oprom, const uint8_t *opram, uint32_t options);
 
 	READ8_MEMBER(segapcm_rom_r);
 	READ8_MEMBER(multipcma_rom_r);
@@ -563,6 +564,14 @@ uint32_t vgmplay_device::disasm_min_opcode_bytes() const
 uint32_t vgmplay_device::disasm_max_opcode_bytes() const
 {
 	return 9;
+}
+
+offs_t vgmplay_device::disasm_disassemble(std::ostream &stream, offs_t pc, const uint8_t *oprom, const uint8_t *opram, uint32_t options)
+{
+	char buffer[256];
+	offs_t result = disasm_disassemble(buffer, pc, oprom, opram, options);
+	stream << buffer;
+	return result;	
 }
 
 offs_t vgmplay_device::disasm_disassemble(char *buffer, offs_t pc, const uint8_t *oprom, const uint8_t *opram, uint32_t options)

--- a/src/mame/machine/apollo_dbg.cpp
+++ b/src/mame/machine/apollo_dbg.cpp
@@ -1061,7 +1061,10 @@ static const std::string &disassemble(m68000_base_device *m68k, offs_t pc, std::
 			return sb;
 		}
 	}
-	m68k->disassemble(sb, pc, oprom, opram, options);
+
+	std::ostringstream stream;
+	m68k->disassemble(stream, pc, oprom, opram, options);
+	sb = stream.str();
 
 	// restore previous bus error state
 	m68k->mmu_tmp_buserror_occurred = tmp_buserror_occurred;

--- a/src/mame/machine/apollo_dbg.cpp
+++ b/src/mame/machine/apollo_dbg.cpp
@@ -1033,7 +1033,7 @@ static const char* get_svc_call(m68000_base_device *m68k, int trap_no,
 	return sb;
 }
 
-static const char * disassemble(m68000_base_device *m68k, offs_t pc, char* sb)
+static const std::string &disassemble(m68000_base_device *m68k, offs_t pc, std::string& sb)
 {
 	uint8_t oprom[10];
 	uint8_t opram[10];
@@ -1052,7 +1052,7 @@ static const char * disassemble(m68000_base_device *m68k, offs_t pc, char* sb)
 		oprom[i] = opram[i] = m68k->read8(pc + i);
 		if (m68k->mmu_tmp_buserror_occurred)
 		{
-			sprintf(sb, "- (apollo_disassemble failed at %08x)", pc + i);
+			sb = string_format("- (apollo_disassemble failed at %08x)", pc + i);
 
 			// restore previous bus error state
 			m68k->mmu_tmp_buserror_occurred = tmp_buserror_occurred;
@@ -1130,7 +1130,7 @@ int apollo_debug_instruction_hook(m68000_base_device *device, offs_t curpc)
 		}
 		else if ((ir & 0xff00) == 0xf200 && (apollo_config( APOLLO_CONF_FPU_TRACE)))
 		{
-			char sb[256];
+			std::string sb;
 			DLOG(("%s sp=%08x FPU: %x %s", apollo_cpu_context(device->machine().firstcpu),
 					REG_A(m68k)[7], ir, disassemble(m68k, REG_PC(m68k), sb)));
 		}

--- a/src/tools/unidasm.cpp
+++ b/src/tools/unidasm.cpp
@@ -217,14 +217,14 @@ CPU_DISASSEMBLE( z8 );
 CPU_DISASSEMBLE( z80 );
 CPU_DISASSEMBLE( z8000 );
 
-CPU_DISASSEMBLE( sparcv7 )      { static sparc_disassembler dasm(nullptr, 7);                             return dasm.dasm(buffer, pc, big_endianize_int32(*reinterpret_cast<const uint32_t *>(oprom))); }
-CPU_DISASSEMBLE( sparcv8 )      { static sparc_disassembler dasm(nullptr, 8);                             return dasm.dasm(buffer, pc, big_endianize_int32(*reinterpret_cast<const uint32_t *>(oprom))); }
-CPU_DISASSEMBLE( sparcv9 )      { static sparc_disassembler dasm(nullptr, 9);                             return dasm.dasm(buffer, pc, big_endianize_int32(*reinterpret_cast<const uint32_t *>(oprom))); }
-CPU_DISASSEMBLE( sparcv9vis1 )  { static sparc_disassembler dasm(nullptr, 9, sparc_disassembler::vis_1);  return dasm.dasm(buffer, pc, big_endianize_int32(*reinterpret_cast<const uint32_t *>(oprom))); }
-CPU_DISASSEMBLE( sparcv9vis2 )  { static sparc_disassembler dasm(nullptr, 9, sparc_disassembler::vis_2);  return dasm.dasm(buffer, pc, big_endianize_int32(*reinterpret_cast<const uint32_t *>(oprom))); }
-CPU_DISASSEMBLE( sparcv9vis2p ) { static sparc_disassembler dasm(nullptr, 9, sparc_disassembler::vis_2p); return dasm.dasm(buffer, pc, big_endianize_int32(*reinterpret_cast<const uint32_t *>(oprom))); }
-CPU_DISASSEMBLE( sparcv9vis3 )  { static sparc_disassembler dasm(nullptr, 9, sparc_disassembler::vis_3);  return dasm.dasm(buffer, pc, big_endianize_int32(*reinterpret_cast<const uint32_t *>(oprom))); }
-CPU_DISASSEMBLE( sparcv9vis3b ) { static sparc_disassembler dasm(nullptr, 9, sparc_disassembler::vis_3b); return dasm.dasm(buffer, pc, big_endianize_int32(*reinterpret_cast<const uint32_t *>(oprom))); }
+CPU_DISASSEMBLE( sparcv7 )      { static sparc_disassembler dasm(nullptr, 7);                             return dasm.dasm(stream, pc, big_endianize_int32(*reinterpret_cast<const uint32_t *>(oprom))); }
+CPU_DISASSEMBLE( sparcv8 )      { static sparc_disassembler dasm(nullptr, 8);                             return dasm.dasm(stream, pc, big_endianize_int32(*reinterpret_cast<const uint32_t *>(oprom))); }
+CPU_DISASSEMBLE( sparcv9 )      { static sparc_disassembler dasm(nullptr, 9);                             return dasm.dasm(stream, pc, big_endianize_int32(*reinterpret_cast<const uint32_t *>(oprom))); }
+CPU_DISASSEMBLE( sparcv9vis1 )  { static sparc_disassembler dasm(nullptr, 9, sparc_disassembler::vis_1);  return dasm.dasm(stream, pc, big_endianize_int32(*reinterpret_cast<const uint32_t *>(oprom))); }
+CPU_DISASSEMBLE( sparcv9vis2 )  { static sparc_disassembler dasm(nullptr, 9, sparc_disassembler::vis_2);  return dasm.dasm(stream, pc, big_endianize_int32(*reinterpret_cast<const uint32_t *>(oprom))); }
+CPU_DISASSEMBLE( sparcv9vis2p ) { static sparc_disassembler dasm(nullptr, 9, sparc_disassembler::vis_2p); return dasm.dasm(stream, pc, big_endianize_int32(*reinterpret_cast<const uint32_t *>(oprom))); }
+CPU_DISASSEMBLE( sparcv9vis3 )  { static sparc_disassembler dasm(nullptr, 9, sparc_disassembler::vis_3);  return dasm.dasm(stream, pc, big_endianize_int32(*reinterpret_cast<const uint32_t *>(oprom))); }
+CPU_DISASSEMBLE( sparcv9vis3b ) { static sparc_disassembler dasm(nullptr, 9, sparc_disassembler::vis_3b); return dasm.dasm(stream, pc, big_endianize_int32(*reinterpret_cast<const uint32_t *>(oprom))); }
 
 
 static const dasm_table_entry dasm_table[] =
@@ -545,7 +545,6 @@ int main(int argc, char *argv[])
 	options opts;
 	int numbytes;
 	void *data;
-	char *p;
 	int result = 0;
 
 	// parse options first
@@ -578,15 +577,18 @@ int main(int argc, char *argv[])
 		if ((length > opts.count) && (opts.count != 0))
 			length = opts.count;
 		curpc = opts.basepc;
+
+		std::stringstream stream;
 		for (curbyte = 0; curbyte < length; curbyte += numbytes)
 		{
 			uint8_t *oprom = (uint8_t *)data + opts.skip + curbyte;
-			char buffer[1024];
 			uint32_t pcdelta;
 			int numchunks;
 
 			// disassemble
-			pcdelta = (*opts.dasm->func)(nullptr, buffer, curpc, oprom, oprom, opts.mode) & DASMFLAG_LENGTHMASK;
+			stream.str("");
+			pcdelta = (*opts.dasm->func)(nullptr, stream, curpc, oprom, oprom, opts.mode) & DASMFLAG_LENGTHMASK;
+			std::string buffer = stream.str();
 
 			if (opts.dasm->pcshift < 0)
 				numbytes = pcdelta << -opts.dasm->pcshift;
@@ -596,13 +598,19 @@ int main(int argc, char *argv[])
 			// force upper or lower
 			if (opts.lower)
 			{
-				for (p = buffer; *p != 0; p++)
-					*p = tolower((uint8_t)*p);
+				std::transform(
+					std::begin(buffer),
+					std::end(buffer),
+					std::begin(buffer),
+					[](char c) { return tolower(c); });
 			}
 			else if (opts.upper)
 			{
-				for (p = buffer; *p != 0; p++)
-					*p = toupper((uint8_t)*p);
+				std::transform(
+					std::begin(buffer),
+					std::end(buffer),
+					std::begin(buffer),
+					[](char c) { return toupper(c); });
 			}
 
 			// round to the nearest display chunk
@@ -635,7 +643,7 @@ int main(int argc, char *argv[])
 				}
 
 				// output the disassembly
-				printf("%s\n", buffer);
+				printf("%s\n", buffer.c_str());
 
 				// output additional raw bytes
 				if (!opts.norawbytes && numchunks > maxchunks)
@@ -661,7 +669,7 @@ int main(int argc, char *argv[])
 			else
 			{
 				// output the disassembly and address
-				printf("\t%-40s ; %08X", buffer, curpc);
+				printf("\t%-40s ; %08X", buffer.c_str(), curpc);
 
 				// output the raw bytes
 				if (!opts.norawbytes)


### PR DESCRIPTION
Also consolidated dasm_override_delegates for CoCo and Dragon Beta

Feel free to defer this until after the release
