### PR TITLE
Show color values in palette viewer

### DIFF
--- a/src/emu/emupal.cpp
+++ b/src/emu/emupal.cpp
@@ -301,14 +301,10 @@ inline void palette_device::update_for_write(offs_t byte_offset, int bytes_modif
 	offs_t base = byte_offset / bpe;
 	for (int index = 0; index < count; index++)
 	{
-		UINT32 data = m_paletteram.read(base + index);
-		if (m_paletteram_ext.base() != nullptr)
-			data |= m_paletteram_ext.read(base + index) << (8 * bpe);
-
 		if (indirect)
-			set_indirect_color(base + index, m_raw_to_rgb(data));
+			set_indirect_color(base + index, m_raw_to_rgb(read_entry(base + index)));
 		else
-			m_palette->entry_set_color(base + index, m_raw_to_rgb(data));
+			m_palette->entry_set_color(base + index, m_raw_to_rgb(read_entry(base + index)));
 	}
 }
 

--- a/src/emu/emupal.h
+++ b/src/emu/emupal.h
@@ -392,6 +392,15 @@ public:
 	bool shadows_enabled() { return m_enable_shadows; }
 	bool hilights_enabled() { return m_enable_hilights; }
 
+	// raw entry reading
+	UINT32 read_entry(pen_t pen) const
+	{
+		UINT32 data = m_paletteram.read(pen);
+		if (m_paletteram_ext.base() != nullptr)
+			data |= m_paletteram_ext.read(pen) << (8 * m_paletteram.bytes_per_entry());
+		return data;
+	}
+
 	// setters
 	void set_pen_color(pen_t pen, rgb_t rgb) { m_palette->entry_set_color(pen, rgb); }
 	void set_pen_red_level(pen_t pen, UINT8 level) { m_palette->entry_set_red_level(pen, level); }

--- a/src/emu/memarray.cpp
+++ b/src/emu/memarray.cpp
@@ -125,22 +125,22 @@ void memory_array::set_endianness(endianness_t endianness)
 //  heleprs for 1 byte-per-entry
 //-------------------------------------------------
 
-UINT32 memory_array::read8_from_8(int index) { return reinterpret_cast<UINT8 *>(m_base)[index]; }
+UINT32 memory_array::read8_from_8(int index) const { return reinterpret_cast<UINT8 *>(m_base)[index]; }
 void memory_array::write8_to_8(int index, UINT32 data) { reinterpret_cast<UINT8 *>(m_base)[index] = data; }
 
-UINT32 memory_array::read8_from_16le(int index) { return reinterpret_cast<UINT8 *>(m_base)[BYTE_XOR_LE(index)]; }
+UINT32 memory_array::read8_from_16le(int index) const { return reinterpret_cast<UINT8 *>(m_base)[BYTE_XOR_LE(index)]; }
 void memory_array::write8_to_16le(int index, UINT32 data) { reinterpret_cast<UINT8 *>(m_base)[BYTE_XOR_LE(index)] = data; }
-UINT32 memory_array::read8_from_16be(int index) { return reinterpret_cast<UINT8 *>(m_base)[BYTE_XOR_BE(index)]; }
+UINT32 memory_array::read8_from_16be(int index) const { return reinterpret_cast<UINT8 *>(m_base)[BYTE_XOR_BE(index)]; }
 void memory_array::write8_to_16be(int index, UINT32 data) { reinterpret_cast<UINT8 *>(m_base)[BYTE_XOR_BE(index)] = data; }
 
-UINT32 memory_array::read8_from_32le(int index) { return reinterpret_cast<UINT8 *>(m_base)[BYTE4_XOR_LE(index)]; }
+UINT32 memory_array::read8_from_32le(int index) const { return reinterpret_cast<UINT8 *>(m_base)[BYTE4_XOR_LE(index)]; }
 void memory_array::write8_to_32le(int index, UINT32 data) { reinterpret_cast<UINT8 *>(m_base)[BYTE4_XOR_LE(index)] = data; }
-UINT32 memory_array::read8_from_32be(int index) { return reinterpret_cast<UINT8 *>(m_base)[BYTE4_XOR_BE(index)]; }
+UINT32 memory_array::read8_from_32be(int index) const { return reinterpret_cast<UINT8 *>(m_base)[BYTE4_XOR_BE(index)]; }
 void memory_array::write8_to_32be(int index, UINT32 data) { reinterpret_cast<UINT8 *>(m_base)[BYTE4_XOR_BE(index)] = data; }
 
-UINT32 memory_array::read8_from_64le(int index) { return reinterpret_cast<UINT8 *>(m_base)[BYTE8_XOR_BE(index)]; }
+UINT32 memory_array::read8_from_64le(int index) const { return reinterpret_cast<UINT8 *>(m_base)[BYTE8_XOR_BE(index)]; }
 void memory_array::write8_to_64le(int index, UINT32 data) { reinterpret_cast<UINT8 *>(m_base)[BYTE8_XOR_BE(index)] = data; }
-UINT32 memory_array::read8_from_64be(int index) { return reinterpret_cast<UINT8 *>(m_base)[BYTE8_XOR_BE(index)]; }
+UINT32 memory_array::read8_from_64be(int index) const { return reinterpret_cast<UINT8 *>(m_base)[BYTE8_XOR_BE(index)]; }
 void memory_array::write8_to_64be(int index, UINT32 data) { reinterpret_cast<UINT8 *>(m_base)[BYTE8_XOR_BE(index)] = data; }
 
 
@@ -149,22 +149,22 @@ void memory_array::write8_to_64be(int index, UINT32 data) { reinterpret_cast<UIN
 //  heleprs for 2 bytes-per-entry
 //-------------------------------------------------
 
-UINT32 memory_array::read16_from_8le(int index) { return read8_from_8(index*2) | (read8_from_8(index*2+1) << 8); }
+UINT32 memory_array::read16_from_8le(int index) const { return read8_from_8(index*2) | (read8_from_8(index*2+1) << 8); }
 void memory_array::write16_to_8le(int index, UINT32 data) { write8_to_8(index*2, data); write8_to_8(index*2+1, data >> 8); }
-UINT32 memory_array::read16_from_8be(int index) { return (read8_from_8(index*2) << 8) | read8_from_8(index*2+1); }
+UINT32 memory_array::read16_from_8be(int index) const { return (read8_from_8(index*2) << 8) | read8_from_8(index*2+1); }
 void memory_array::write16_to_8be(int index, UINT32 data) { write8_to_8(index*2, data >> 8); write8_to_8(index*2+1, data); }
 
-UINT32 memory_array::read16_from_16(int index) { return reinterpret_cast<UINT16 *>(m_base)[index]; }
+UINT32 memory_array::read16_from_16(int index) const { return reinterpret_cast<UINT16 *>(m_base)[index]; }
 void memory_array::write16_to_16(int index, UINT32 data) { reinterpret_cast<UINT16 *>(m_base)[index] = data; }
 
-UINT32 memory_array::read16_from_32le(int index) { return reinterpret_cast<UINT16 *>(m_base)[BYTE_XOR_LE(index)]; }
+UINT32 memory_array::read16_from_32le(int index) const { return reinterpret_cast<UINT16 *>(m_base)[BYTE_XOR_LE(index)]; }
 void memory_array::write16_to_32le(int index, UINT32 data) { reinterpret_cast<UINT16 *>(m_base)[BYTE_XOR_LE(index)] = data; }
-UINT32 memory_array::read16_from_32be(int index) { return reinterpret_cast<UINT16 *>(m_base)[BYTE_XOR_BE(index)]; }
+UINT32 memory_array::read16_from_32be(int index) const { return reinterpret_cast<UINT16 *>(m_base)[BYTE_XOR_BE(index)]; }
 void memory_array::write16_to_32be(int index, UINT32 data) { reinterpret_cast<UINT16 *>(m_base)[BYTE_XOR_BE(index)] = data; }
 
-UINT32 memory_array::read16_from_64le(int index) { return reinterpret_cast<UINT16 *>(m_base)[BYTE4_XOR_LE(index)]; }
+UINT32 memory_array::read16_from_64le(int index) const { return reinterpret_cast<UINT16 *>(m_base)[BYTE4_XOR_LE(index)]; }
 void memory_array::write16_to_64le(int index, UINT32 data) { reinterpret_cast<UINT16 *>(m_base)[BYTE4_XOR_LE(index)] = data; }
-UINT32 memory_array::read16_from_64be(int index) { return reinterpret_cast<UINT16 *>(m_base)[BYTE4_XOR_BE(index)]; }
+UINT32 memory_array::read16_from_64be(int index) const { return reinterpret_cast<UINT16 *>(m_base)[BYTE4_XOR_BE(index)]; }
 void memory_array::write16_to_64be(int index, UINT32 data) { reinterpret_cast<UINT16 *>(m_base)[BYTE4_XOR_BE(index)] = data; }
 
 
@@ -173,20 +173,20 @@ void memory_array::write16_to_64be(int index, UINT32 data) { reinterpret_cast<UI
 //  heleprs for 4 bytes-per-entry
 //-------------------------------------------------
 
-UINT32 memory_array::read32_from_8le(int index) { return read16_from_8le(index*2) | (read16_from_8le(index*2+1) << 16); }
+UINT32 memory_array::read32_from_8le(int index) const { return read16_from_8le(index*2) | (read16_from_8le(index*2+1) << 16); }
 void memory_array::write32_to_8le(int index, UINT32 data) { write16_to_8le(index*2, data); write16_to_8le(index*2+1, data >> 16); }
-UINT32 memory_array::read32_from_8be(int index) { return (read16_from_8be(index*2) << 16) | read16_from_8be(index*2+1); }
+UINT32 memory_array::read32_from_8be(int index) const { return (read16_from_8be(index*2) << 16) | read16_from_8be(index*2+1); }
 void memory_array::write32_to_8be(int index, UINT32 data) { write16_to_8be(index*2, data >> 16); write16_to_8be(index*2+1, data); }
 
-UINT32 memory_array::read32_from_16le(int index) { return read16_from_16(index*2) | (read16_from_16(index*2+1) << 16); }
+UINT32 memory_array::read32_from_16le(int index) const { return read16_from_16(index*2) | (read16_from_16(index*2+1) << 16); }
 void memory_array::write32_to_16le(int index, UINT32 data) { write16_to_16(index*2, data); write16_to_16(index*2+1, data >> 16); }
-UINT32 memory_array::read32_from_16be(int index) { return (read16_from_16(index*2) << 16) | read16_from_16(index*2+1); }
+UINT32 memory_array::read32_from_16be(int index) const { return (read16_from_16(index*2) << 16) | read16_from_16(index*2+1); }
 void memory_array::write32_to_16be(int index, UINT32 data) { write16_to_16(index*2, data >> 16); write16_to_16(index*2+1, data); }
 
-UINT32 memory_array::read32_from_32(int index) { return reinterpret_cast<UINT32 *>(m_base)[index]; }
+UINT32 memory_array::read32_from_32(int index) const { return reinterpret_cast<UINT32 *>(m_base)[index]; }
 void memory_array::write32_to_32(int index, UINT32 data) { reinterpret_cast<UINT32 *>(m_base)[index] = data; }
 
-UINT32 memory_array::read32_from_64le(int index) { return reinterpret_cast<UINT32 *>(m_base)[BYTE_XOR_LE(index)]; }
+UINT32 memory_array::read32_from_64le(int index) const { return reinterpret_cast<UINT32 *>(m_base)[BYTE_XOR_LE(index)]; }
 void memory_array::write32_to_64le(int index, UINT32 data) { reinterpret_cast<UINT32 *>(m_base)[BYTE_XOR_LE(index)] = data; }
-UINT32 memory_array::read32_from_64be(int index) { return reinterpret_cast<UINT32 *>(m_base)[BYTE_XOR_BE(index)]; }
+UINT32 memory_array::read32_from_64be(int index) const { return reinterpret_cast<UINT32 *>(m_base)[BYTE_XOR_BE(index)]; }
 void memory_array::write32_to_64be(int index, UINT32 data) { reinterpret_cast<UINT32 *>(m_base)[BYTE_XOR_BE(index)] = data; }

--- a/src/emu/memarray.h
+++ b/src/emu/memarray.h
@@ -69,14 +69,14 @@ public:
 	int bytes_per_entry() const { return m_bytes_per_entry; }
 
 	// entry-level readers and writers
-	UINT32 read(int index) { return (this->*m_read_entry)(index); }
+	UINT32 read(int index) const { return (this->*m_read_entry)(index); }
 	void write(int index, UINT32 data) { (this->*m_write_entry)(index, data); }
 
 	// byte/word/dword-level readers and writers
-	UINT8 read8(offs_t offset) { return reinterpret_cast<UINT8 *>(m_base)[offset]; }
-	UINT16 read16(offs_t offset) { return reinterpret_cast<UINT16 *>(m_base)[offset]; }
-	UINT32 read32(offs_t offset) { return reinterpret_cast<UINT32 *>(m_base)[offset]; }
-	UINT64 read64(offs_t offset) { return reinterpret_cast<UINT64 *>(m_base)[offset]; }
+	UINT8 read8(offs_t offset) const { return reinterpret_cast<UINT8 *>(m_base)[offset]; }
+	UINT16 read16(offs_t offset) const { return reinterpret_cast<UINT16 *>(m_base)[offset]; }
+	UINT32 read32(offs_t offset) const { return reinterpret_cast<UINT32 *>(m_base)[offset]; }
+	UINT64 read64(offs_t offset) const { return reinterpret_cast<UINT64 *>(m_base)[offset]; }
 	void write8(offs_t offset, UINT8 data) { reinterpret_cast<UINT8 *>(m_base)[offset] = data; }
 	void write16(offs_t offset, UINT16 data, UINT16 mem_mask = 0xffff) { COMBINE_DATA(&reinterpret_cast<UINT16 *>(m_base)[offset]); }
 	void write32(offs_t offset, UINT32 data, UINT32 mem_mask = 0xffffffff) { COMBINE_DATA(&reinterpret_cast<UINT32 *>(m_base)[offset]); }
@@ -84,31 +84,31 @@ public:
 
 private:
 	// internal read/write helpers for 1 byte entries
-	UINT32 read8_from_8(int index);     void write8_to_8(int index, UINT32 data);
-	UINT32 read8_from_16le(int index);  void write8_to_16le(int index, UINT32 data);
-	UINT32 read8_from_16be(int index);  void write8_to_16be(int index, UINT32 data);
-	UINT32 read8_from_32le(int index);  void write8_to_32le(int index, UINT32 data);
-	UINT32 read8_from_32be(int index);  void write8_to_32be(int index, UINT32 data);
-	UINT32 read8_from_64le(int index);  void write8_to_64le(int index, UINT32 data);
-	UINT32 read8_from_64be(int index);  void write8_to_64be(int index, UINT32 data);
+	UINT32 read8_from_8(int index) const;     void write8_to_8(int index, UINT32 data);
+	UINT32 read8_from_16le(int index) const;  void write8_to_16le(int index, UINT32 data);
+	UINT32 read8_from_16be(int index) const;  void write8_to_16be(int index, UINT32 data);
+	UINT32 read8_from_32le(int index) const;  void write8_to_32le(int index, UINT32 data);
+	UINT32 read8_from_32be(int index) const;  void write8_to_32be(int index, UINT32 data);
+	UINT32 read8_from_64le(int index) const;  void write8_to_64le(int index, UINT32 data);
+	UINT32 read8_from_64be(int index) const;  void write8_to_64be(int index, UINT32 data);
 
 	// internal read/write helpers for 2 byte entries
-	UINT32 read16_from_8le(int index);  void write16_to_8le(int index, UINT32 data);
-	UINT32 read16_from_8be(int index);  void write16_to_8be(int index, UINT32 data);
-	UINT32 read16_from_16(int index);   void write16_to_16(int index, UINT32 data);
-	UINT32 read16_from_32le(int index); void write16_to_32le(int index, UINT32 data);
-	UINT32 read16_from_32be(int index); void write16_to_32be(int index, UINT32 data);
-	UINT32 read16_from_64le(int index); void write16_to_64le(int index, UINT32 data);
-	UINT32 read16_from_64be(int index); void write16_to_64be(int index, UINT32 data);
+	UINT32 read16_from_8le(int index) const;  void write16_to_8le(int index, UINT32 data);
+	UINT32 read16_from_8be(int index) const;  void write16_to_8be(int index, UINT32 data);
+	UINT32 read16_from_16(int index) const;   void write16_to_16(int index, UINT32 data);
+	UINT32 read16_from_32le(int index) const; void write16_to_32le(int index, UINT32 data);
+	UINT32 read16_from_32be(int index) const; void write16_to_32be(int index, UINT32 data);
+	UINT32 read16_from_64le(int index) const; void write16_to_64le(int index, UINT32 data);
+	UINT32 read16_from_64be(int index) const; void write16_to_64be(int index, UINT32 data);
 
 	// internal read/write helpers for 4 byte entries
-	UINT32 read32_from_8le(int index);  void write32_to_8le(int index, UINT32 data);
-	UINT32 read32_from_8be(int index);  void write32_to_8be(int index, UINT32 data);
-	UINT32 read32_from_16le(int index); void write32_to_16le(int index, UINT32 data);
-	UINT32 read32_from_16be(int index); void write32_to_16be(int index, UINT32 data);
-	UINT32 read32_from_32(int index);   void write32_to_32(int index, UINT32 data);
-	UINT32 read32_from_64le(int index); void write32_to_64le(int index, UINT32 data);
-	UINT32 read32_from_64be(int index); void write32_to_64be(int index, UINT32 data);
+	UINT32 read32_from_8le(int index) const;  void write32_to_8le(int index, UINT32 data);
+	UINT32 read32_from_8be(int index) const;  void write32_to_8be(int index, UINT32 data);
+	UINT32 read32_from_16le(int index) const; void write32_to_16le(int index, UINT32 data);
+	UINT32 read32_from_16be(int index) const; void write32_to_16be(int index, UINT32 data);
+	UINT32 read32_from_32(int index) const;   void write32_to_32(int index, UINT32 data);
+	UINT32 read32_from_64le(int index) const; void write32_to_64le(int index, UINT32 data);
+	UINT32 read32_from_64be(int index) const; void write32_to_64be(int index, UINT32 data);
 
 	// internal state
 	void *              m_base;
@@ -116,7 +116,7 @@ private:
 	int                 m_membits;
 	endianness_t        m_endianness;
 	int                 m_bytes_per_entry;
-	UINT32 (memory_array::*m_read_entry)(int);
+	UINT32 (memory_array::*m_read_entry)(int) const;
 	void (memory_array::*m_write_entry)(int, UINT32);
 };
 

--- a/src/frontend/mame/ui/viewgfx.cpp
+++ b/src/frontend/mame/ui/viewgfx.cpp
@@ -347,14 +347,12 @@ static void palette_handler(mame_ui_manager &mui, render_container &container, u
 	int total = state.palette.which ? palette->indirect_entries() : palette->entries();
 	const rgb_t *raw_color = palette->palette()->entry_list_raw();
 	render_font *ui_font = mui.get_font();
-	float cellwidth, cellheight;
 	float chwidth, chheight;
 	float titlewidth;
 	float x0, y0;
 	render_bounds cellboxbounds;
 	render_bounds boxbounds;
 	int x, y, skip;
-	char title[100];
 
 	// add a half character padding for the box
 	chheight = mui.get_line_height();
@@ -377,10 +375,42 @@ static void palette_handler(mame_ui_manager &mui, render_container &container, u
 	// add space on the top for a title, a half line of padding, a header, and another half line
 	cellboxbounds.y0 += 3.0f * chheight;
 
-	// figure out the title and expand the outer box to fit
-	const char *suffix = palette->indirect_entries() == 0 ? "" : state.palette.which ? _(" COLORS") : _(" PENS");
-	sprintf(title, "'%s'%s", palette->tag(), suffix);
-	titlewidth = ui_font->string_width(chheight, mui.machine().render().ui_aspect(), title);
+	// compute the cell size
+	float cellwidth = (cellboxbounds.x1 - cellboxbounds.x0) / (float)state.palette.columns;
+	float cellheight = (cellboxbounds.y1 - cellboxbounds.y0) / (float)state.palette.columns;
+
+	// figure out the title
+	std::ostringstream title_buf;
+	util::stream_format(title_buf, "'%s'", palette->tag());
+	if (palette->indirect_entries() > 0)
+		title_buf << (state.palette.which ? _(" COLORS") : _(" PENS"));
+
+	// if the mouse pointer is over one of our cells, add some info about the corresponding palette entry
+	INT32 mouse_target_x, mouse_target_y;
+	bool mouse_button;
+	float mouse_x, mouse_y;
+	render_target *mouse_target = mui.machine().ui_input().find_mouse(&mouse_target_x, &mouse_target_y, &mouse_button);
+	if (mouse_target != nullptr && mouse_target->map_point_container(mouse_target_x, mouse_target_y, container, mouse_x, mouse_y)
+		&& cellboxbounds.x0 <= mouse_x && cellboxbounds.x1 > mouse_x
+		&& cellboxbounds.y0 <= mouse_y && cellboxbounds.y1 > mouse_y)
+	{
+		int index = state.palette.offset + int((mouse_x - cellboxbounds.x0) / cellwidth) + int((mouse_y - cellboxbounds.y0) / cellheight) * state.palette.columns;
+		if (index < total)
+		{
+			util::stream_format(title_buf, " #%X", index);
+			if (palette->indirect_entries() > 0 && !state.palette.which)
+				util::stream_format(title_buf, " => %X", palette->pen_indirect(index));
+			else if (palette->basemem().base() != nullptr)
+				util::stream_format(title_buf, " = %X", palette->read_entry(index));
+
+			rgb_t col = state.palette.which ? palette->indirect_color(index) : raw_color[index];
+			util::stream_format(title_buf, " (R:%X G:%X B:%X)", col.r(), col.g(), col.b());
+		}
+	}
+
+	// expand the outer box to fit the title
+	const std::string title = title_buf.str();
+	titlewidth = ui_font->string_width(chheight, mui.machine().render().ui_aspect(), title.c_str());
 	x0 = 0.0f;
 	if (boxbounds.x1 - boxbounds.x0 < titlewidth + chwidth)
 		x0 = boxbounds.x0 - (0.5f - 0.5f * (titlewidth + chwidth));
@@ -391,15 +421,11 @@ static void palette_handler(mame_ui_manager &mui, render_container &container, u
 	// draw the title
 	x0 = 0.5f - 0.5f * titlewidth;
 	y0 = boxbounds.y0 + 0.5f * chheight;
-	for (x = 0; title[x] != 0; x++)
+	for (auto ch : title)
 	{
-		container.add_char(x0, y0, chheight, mui.machine().render().ui_aspect(), rgb_t::white, *ui_font, title[x]);
-		x0 += ui_font->char_width(chheight, mui.machine().render().ui_aspect(), title[x]);
+		container.add_char(x0, y0, chheight, mui.machine().render().ui_aspect(), rgb_t::white, *ui_font, ch);
+		x0 += ui_font->char_width(chheight, mui.machine().render().ui_aspect(), ch);
 	}
-
-	// compute the cell size
-	cellwidth = (cellboxbounds.x1 - cellboxbounds.x0) / (float)state.palette.columns;
-	cellheight = (cellboxbounds.y1 - cellboxbounds.y0) / (float)state.palette.columns;
 
 	// draw the top column headers
 	skip = (int)(chwidth / cellwidth);
@@ -559,7 +585,6 @@ static void gfxset_handler(mame_ui_manager &mui, render_container &container, ui
 	float cellwidth, cellheight;
 	float chwidth, chheight;
 	float titlewidth;
-	//float cellaspect;
 	float x0, y0;
 	render_bounds cellboxbounds;
 	render_bounds boxbounds;
@@ -570,7 +595,6 @@ static void gfxset_handler(mame_ui_manager &mui, render_container &container, ui
 	int xcells, ycells;
 	int pixelscale = 0;
 	int x, y, skip;
-	char title[100];
 
 	// add a half character padding for the box
 	chheight = mui.get_line_height();
@@ -638,12 +662,12 @@ static void gfxset_handler(mame_ui_manager &mui, render_container &container, ui
 	boxbounds.y1 = boxbounds.y0 + fullheight;
 
 	// figure out the title and expand the outer box to fit
-	sprintf(title, "'%s' %d/%d %dx%d COLOR %X",
+	const std::string title = string_format("'%s' %d/%d %dx%d COLOR %X",
 					interface.device().tag(),
 					set, info.setcount - 1,
 					gfx.width(), gfx.height(),
 					info.color[set]);
-	titlewidth = ui_font->string_width(chheight, mui.machine().render().ui_aspect(), title);
+	titlewidth = ui_font->string_width(chheight, mui.machine().render().ui_aspect(), title.c_str());
 	x0 = 0.0f;
 	if (boxbounds.x1 - boxbounds.x0 < titlewidth + chwidth)
 		x0 = boxbounds.x0 - (0.5f - 0.5f * (titlewidth + chwidth));
@@ -654,10 +678,10 @@ static void gfxset_handler(mame_ui_manager &mui, render_container &container, ui
 	// draw the title
 	x0 = 0.5f - 0.5f * titlewidth;
 	y0 = boxbounds.y0 + 0.5f * chheight;
-	for (x = 0; title[x] != 0; x++)
+	for (auto ch : title)
 	{
-		container.add_char(x0, y0, chheight, mui.machine().render().ui_aspect(), rgb_t::white, *ui_font, title[x]);
-		x0 += ui_font->char_width(chheight, mui.machine().render().ui_aspect(), title[x]);
+		container.add_char(x0, y0, chheight, mui.machine().render().ui_aspect(), rgb_t::white, *ui_font, ch);
+		x0 += ui_font->char_width(chheight, mui.machine().render().ui_aspect(), ch);
 	}
 
 	// draw the top column headers
@@ -960,8 +984,6 @@ static void tilemap_handler(mame_ui_manager &mui, render_container &container, u
 	int mapboxwidth, mapboxheight;
 	int maxxscale, maxyscale;
 	UINT32 mapwidth, mapheight;
-	int x, pixelscale;
-	char title[100];
 
 	// get the size of the tilemap itself
 	tilemap_t *tilemap = mui.machine().tilemap().find(state.tilemap.which);
@@ -993,7 +1015,7 @@ static void tilemap_handler(mame_ui_manager &mui, render_container &container, u
 	mapboxheight = (mapboxbounds.y1 - mapboxbounds.y0) * (float)targheight;
 
 	// determine the maximum integral scaling factor
-	pixelscale = state.tilemap.zoom;
+	int pixelscale = state.tilemap.zoom;
 	if (pixelscale == 0)
 	{
 		for (maxxscale = 1; mapwidth * (maxxscale + 1) < mapboxwidth; maxxscale++) { }
@@ -1018,8 +1040,8 @@ static void tilemap_handler(mame_ui_manager &mui, render_container &container, u
 	boxbounds.y1 = mapboxbounds.y1 + 0.5f * chheight;
 
 	// figure out the title and expand the outer box to fit
-	sprintf(title, "TILEMAP %d/%d %dx%d OFFS %d,%d", state.tilemap.which, mui.machine().tilemap().count() - 1, mapwidth, mapheight, state.tilemap.xoffs, state.tilemap.yoffs);
-	titlewidth = ui_font->string_width(chheight, mui.machine().render().ui_aspect(), title);
+	const std::string title = string_format("TILEMAP %d/%d %dx%d OFFS %d,%d", state.tilemap.which, mui.machine().tilemap().count() - 1, mapwidth, mapheight, state.tilemap.xoffs, state.tilemap.yoffs);
+	titlewidth = ui_font->string_width(chheight, mui.machine().render().ui_aspect(), title.c_str());
 	if (boxbounds.x1 - boxbounds.x0 < titlewidth + chwidth)
 	{
 		boxbounds.x0 = 0.5f - 0.5f * (titlewidth + chwidth);
@@ -1032,10 +1054,10 @@ static void tilemap_handler(mame_ui_manager &mui, render_container &container, u
 	// draw the title
 	x0 = 0.5f - 0.5f * titlewidth;
 	y0 = boxbounds.y0 + 0.5f * chheight;
-	for (x = 0; title[x] != 0; x++)
+	for (auto ch : title)
 	{
-		container.add_char(x0, y0, chheight, mui.machine().render().ui_aspect(), rgb_t::white, *ui_font, title[x]);
-		x0 += ui_font->char_width(chheight, mui.machine().render().ui_aspect(), title[x]);
+		container.add_char(x0, y0, chheight, mui.machine().render().ui_aspect(), rgb_t::white, *ui_font, ch);
+		x0 += ui_font->char_width(chheight, mui.machine().render().ui_aspect(), ch);
 	}
 
 	// update the bitmap

--- a/src/mame/video/seibuspi.cpp
+++ b/src/mame/video/seibuspi.cpp
@@ -751,6 +751,8 @@ void seibuspi_state::video_start()
 	m_palette_ram = make_unique_clear<UINT32[]>(m_palette_ram_size/4);
 	m_sprite_ram = make_unique_clear<UINT32[]>(m_sprite_ram_size/4);
 
+	m_palette->basemem().set(&m_palette_ram[0], m_palette_ram_size, 32, ENDIANNESS_LITTLE, 2);
+
 	m_text_layer = &machine().tilemap().create(*m_gfxdecode, tilemap_get_info_delegate(FUNC(seibuspi_state::get_text_tile_info),this), TILEMAP_SCAN_ROWS, 8, 8, 64,32);
 	m_back_layer = &machine().tilemap().create(*m_gfxdecode, tilemap_get_info_delegate(FUNC(seibuspi_state::get_back_tile_info),this), TILEMAP_SCAN_COLS, 16,16,32,32);
 	m_midl_layer = &machine().tilemap().create(*m_gfxdecode, tilemap_get_info_delegate(FUNC(seibuspi_state::get_midl_tile_info),this), TILEMAP_SCAN_COLS, 16,16,32,32);
@@ -812,6 +814,8 @@ VIDEO_START_MEMBER(seibuspi_state,sys386f)
 	m_tilemap_ram = nullptr;
 	m_palette_ram = make_unique_clear<UINT32[]>(m_palette_ram_size/4);
 	m_sprite_ram = make_unique_clear<UINT32[]>(m_sprite_ram_size/4);
+
+	m_palette->basemem().set(&m_palette_ram[0], m_palette_ram_size, 32, ENDIANNESS_LITTLE, 2);
 
 	memset(m_alpha_table, 0, 0x2000); // no alpha blending
 


### PR DESCRIPTION
- On the UI graphics viewer's palette screen, moving the mouse over a color rectangle will show the index of the entry and its RGB values in hexadecimal.
- For indirect pens, the index of the corresponding color will also be shown.
- For colors in normal RAM-based palettes, the raw (i.e. undecoded) value stored in memory will also be shown. This does not currently work with most buffered palettes (though the Seibu SPI driver has been updated for this purpose), and is totally incompatible with PROM-based or RAMDAC-based palettes.

(nw) The changes made to the core while implementing this feature may look more substantial than they really are. A whole batch of read methods have been made const, and palette_device now has a generic read_entry function that is used both internally and externally.