### PR TITLE
New Ms. Pac-Man clone

### DIFF
--- a/src/mame/drivers/pacman.cpp
+++ b/src/mame/drivers/pacman.cpp
@@ -4996,6 +4996,29 @@ ROM_START( mspacmab )
 ROM_END
 
 
+ROM_START( mspacmab2 )
+	ROM_REGION( 0x10000, "maincpu", 0 )
+	ROM_LOAD( "2764_a.a",       0x0000, 0x2000, CRC(39ae7b16) SHA1(8ed2a01877d7b32894bd932f6a292ef21a2876ab) )
+	ROM_LOAD( "2764_b.b",       0x2000, 0x2000, CRC(09d86ef8) SHA1(c373d34250f29778be45122db666c4522e44e3a6) )
+	ROM_LOAD( "2764_c.c",       0x8000, 0x2000, CRC(9921d46f) SHA1(8ed2bfdde3d1d1558532e2b9411535a5b5ff37cd) )
+
+	ROM_REGION( 0x2000, "gfx1", 0 )
+	ROM_LOAD( "2732_e.5e",      0x0000, 0x1000, CRC(5c281d01) SHA1(5e8b472b615f12efca3fe792410c23619f067845) )
+	ROM_LOAD( "2732_f.5f",      0x1000, 0x1000, CRC(615af909) SHA1(fd6a1dde780b39aea76bf1c4befa5882573c2ef4) )
+
+	ROM_REGION( 0x0120, "proms", 0 )
+	ROM_LOAD( "tbp18s030_p1.7f", 0x0000, 0x0020, CRC(2fc650bd) SHA1(8d0268dee78e47c712202b0ec4f1f51109b1f2a5) )
+	ROM_LOAD( "pac.4a",          0x0020, 0x0100, CRC(3eb3a8e4) SHA1(19097b5f60d1030f8b82d9f1d3a241f93e5c75d6) )
+
+	ROM_REGION( 0x0200, "namco", 0 )    /* sound PROMs */
+	ROM_LOAD( "82s126.1m",    0x0000, 0x0100, CRC(a9cc86bf) SHA1(bbcec0570aeceb582ff8238a4bc8546a23430081) )
+	ROM_LOAD( "63s141.3m",    0x0100, 0x0100, CRC(77245b66) SHA1(0c4d0bee858b97632411c440bea6948a74759746) )    /* timing - not used */
+
+	ROM_REGION( 0x0100, "plds", 0 )
+	ROM_LOAD( "82s153.d",     0x0000, 0x00eb, CRC(0294d8bc) SHA1(7b66d39c464ee2a3f7a659bf066d2ebb487605fd) )
+ROM_END
+
+
 ROM_START( mspacmbe )
 	ROM_REGION( 0x10000, "maincpu", 0 )
 	ROM_LOAD( "boot1",        0x0000, 0x1000, CRC(d16b31b7) SHA1(bc2247ec946b639dd1f00bfc603fa157d0baaa97) )
@@ -7203,7 +7226,8 @@ GAME( 1981, mspacmat, mspacman, mspacman, mspacman, pacman_state,  mspacman, ROT
 GAME( 1989, msheartb, mspacman, mspacman, mspacman, pacman_state,  mspacman, ROT90,  "hack (Two-Bit Score)", "Ms. Pac-Man Heart Burn", MACHINE_SUPPORTS_SAVE )
 GAME( 1981, pacgal2,  mspacman, mspacman, mspacman, pacman_state,  mspacman, ROT90,  "bootleg", "Pac-Gal (set 2)", MACHINE_SUPPORTS_SAVE )
 GAME( 1981, mspacmancr,mspacman,mspacman, mspacman, pacman_state,  mspacman, ROT90,  "bootleg", "Ms. Pac-Man (bootleg on Crush Roller Hardware)", MACHINE_SUPPORTS_SAVE )
-GAME( 1981, mspacmab, mspacman, woodpek,  mspacman, driver_device, 0,        ROT90,  "bootleg", "Ms. Pac-Man (bootleg)", MACHINE_SUPPORTS_SAVE )
+GAME( 1981, mspacmab, mspacman, woodpek,  mspacman, driver_device, 0,        ROT90,  "bootleg", "Ms. Pac-Man (bootleg, set 1)", MACHINE_SUPPORTS_SAVE )
+GAME( 1981, mspacmab2,mspacman, woodpek,  mspacman, driver_device, 0,        ROT90,  "bootleg", "Ms. Pac-Man (bootleg, set 2)", MACHINE_SUPPORTS_SAVE )
 GAME( 1981, mspacmbe, mspacman, woodpek,  mspacman, pacman_state,  mspacmbe, ROT90,  "bootleg", "Ms. Pac-Man (bootleg, encrypted)", MACHINE_SUPPORTS_SAVE )
 GAME( 1981, mspacii,  mspacman, woodpek,  mspacman, pacman_state,  mspacii,  ROT90,  "bootleg (Orca)", "Ms. Pac-Man II (Orca bootleg set 1)", MACHINE_SUPPORTS_SAVE )
 GAME( 1981, mspacii2, mspacman, woodpek,  mspacman, pacman_state,  mspacii,  ROT90,  "bootleg (Orca)", "Ms. Pac-Man II (Orca bootleg set 2)", MACHINE_SUPPORTS_SAVE )

--- a/src/mame/mame.lst
+++ b/src/mame/mame.lst
@@ -29248,6 +29248,7 @@ msheartb                        // hack
 mspacii                         // bootleg
 mspacii2                        // bootleg
 mspacmab                        // bootleg
+mspacmab2                       // bootleg
 mspacman                        // (c) 1981 Midway  // made by General Computer
 mspacmanbcc                     // bootleg
 mspacmanbg                      // bootleg


### PR DESCRIPTION
New clone added
---------------------------------------------
Ms. Pac-Man (bootleg, set 2) [Siftware, MASH]

Siftware: multi Pac? (pac.zip)

* Added IC type and sticker letter from the info text to the roms. 
* gfx1 roms pac.5e and pac.5f have identical halves, but the checksum for the first
  halves are 93933d1d and 22b0188a and these are the original mspacman gfx1 roms.
* Rom pac.3m and pac.4a have wrong length and are 8bit dumps, but they
  are MAME's mspacman roms 82s126.3m and 82s126.4a.
* Sound rom 82s126.1m is missing, but all mspacman versions use the same one.
* Converted rom pac.d with jedutil to 82s153.d.

I have compared all Ms. Pac-Man versions with this dump and the
program is like clone Ms. Pac-Man (bootleg).
The differences are:

269E: 32 03 4E      ld   ($4E03),a  // Note: Like in pacgal
.
.
.
3000: 21 34 12      ld   hl,$1234   // This routine is in no other version
3003: 11 CC 2A      ld   de,$2ACC
3006: 19            add  hl,de
3007: 3E C9         ld   a,$C9
3009: 77            ld   (hl),a
300A: AF            xor  a
300B: 26 3D         ld   h,$3D
300D: 2E 00         ld   l,$00
300F: 7E            ld   a,(hl)
3010: 21 2B 0A      ld   hl,$0A2B
3013: BE            cp   (hl)
3014: C3 BD 30      jp   $30BD
3017: 76            halt
3018: C3 00 30      jp   $3000
301B: 76            halt
.
3020: FE 40         cp   $40
.
.
30F0: C3 74 31      jp   $3174


Program ends at $9800 like mspacpls. mspacmab has extra code from $9800-$9FFF.

--