### PR TITLE
New stretching options (as suggested by Jeeze)

### DIFF
--- a/src/emu/emuopts.cpp
+++ b/src/emu/emuopts.cpp
@@ -87,6 +87,7 @@ const options_entry emu_options::s_option_entries[] =
 	{ OPTION_KEEPASPECT ";ka",                           "1",         OPTION_BOOLEAN,    "constrain to the proper aspect ratio" },
 	{ OPTION_UNEVENSTRETCH ";ues",                       "1",         OPTION_BOOLEAN,    "allow non-integer stretch factors" },
 	{ OPTION_UNEVENSTRETCHX ";uesx",                     "0",         OPTION_BOOLEAN,    "allow non-integer stretch factors only on horizontal axis"},
+	{ OPTION_UNEVENSTRETCHY ";uesy",                     "0",         OPTION_BOOLEAN,    "allow non-integer stretch factors only on vertical axis"},
 	{ OPTION_INTOVERSCAN ";ios",                         "0",         OPTION_BOOLEAN,    "allow overscan on integer scaled targets"},
 	{ OPTION_INTSCALEX ";sx",                            "0",         OPTION_INTEGER,    "set horizontal integer scale factor."},
 	{ OPTION_INTSCALEY ";sy",                            "0",         OPTION_INTEGER,    "set vertical integer scale."},

--- a/src/emu/emuopts.cpp
+++ b/src/emu/emuopts.cpp
@@ -88,6 +88,7 @@ const options_entry emu_options::s_option_entries[] =
 	{ OPTION_UNEVENSTRETCH ";ues",                       "1",         OPTION_BOOLEAN,    "allow non-integer stretch factors" },
 	{ OPTION_UNEVENSTRETCHX ";uesx",                     "0",         OPTION_BOOLEAN,    "allow non-integer stretch factors only on horizontal axis"},
 	{ OPTION_UNEVENSTRETCHY ";uesy",                     "0",         OPTION_BOOLEAN,    "allow non-integer stretch factors only on vertical axis"},
+	{ OPTION_AUTOSTRETCHXY ";asxy",                      "0",         OPTION_BOOLEAN,    "automatically apply -unevenstretchx/y based on source native orientation"},
 	{ OPTION_INTOVERSCAN ";ios",                         "0",         OPTION_BOOLEAN,    "allow overscan on integer scaled targets"},
 	{ OPTION_INTSCALEX ";sx",                            "0",         OPTION_INTEGER,    "set horizontal integer scale factor."},
 	{ OPTION_INTSCALEY ";sy",                            "0",         OPTION_INTEGER,    "set vertical integer scale."},

--- a/src/emu/emuopts.h
+++ b/src/emu/emuopts.h
@@ -80,6 +80,7 @@
 #define OPTION_UNEVENSTRETCH        "unevenstretch"
 #define OPTION_UNEVENSTRETCHX       "unevenstretchx"
 #define OPTION_UNEVENSTRETCHY       "unevenstretchy"
+#define OPTION_AUTOSTRETCHXY        "autostretchxy"
 #define OPTION_INTOVERSCAN          "intoverscan"
 #define OPTION_INTSCALEX            "intscalex"
 #define OPTION_INTSCALEY            "intscaley"
@@ -267,6 +268,7 @@ public:
 	bool uneven_stretch() const { return bool_value(OPTION_UNEVENSTRETCH); }
 	bool uneven_stretch_x() const { return bool_value(OPTION_UNEVENSTRETCHX); }
 	bool uneven_stretch_y() const { return bool_value(OPTION_UNEVENSTRETCHY); }
+	bool auto_stretch_xy() const { return bool_value(OPTION_AUTOSTRETCHXY); }
 	bool int_overscan() const { return bool_value(OPTION_INTOVERSCAN); }
 	int int_scale_x() const { return int_value(OPTION_INTSCALEX); }
 	int int_scale_y() const { return int_value(OPTION_INTSCALEY); }

--- a/src/emu/emuopts.h
+++ b/src/emu/emuopts.h
@@ -79,6 +79,7 @@
 #define OPTION_KEEPASPECT           "keepaspect"
 #define OPTION_UNEVENSTRETCH        "unevenstretch"
 #define OPTION_UNEVENSTRETCHX       "unevenstretchx"
+#define OPTION_UNEVENSTRETCHY       "unevenstretchy"
 #define OPTION_INTOVERSCAN          "intoverscan"
 #define OPTION_INTSCALEX            "intscalex"
 #define OPTION_INTSCALEY            "intscaley"
@@ -265,6 +266,7 @@ public:
 	bool keep_aspect() const { return bool_value(OPTION_KEEPASPECT); }
 	bool uneven_stretch() const { return bool_value(OPTION_UNEVENSTRETCH); }
 	bool uneven_stretch_x() const { return bool_value(OPTION_UNEVENSTRETCHX); }
+	bool uneven_stretch_y() const { return bool_value(OPTION_UNEVENSTRETCHY); }
 	bool int_overscan() const { return bool_value(OPTION_INTOVERSCAN); }
 	int int_scale_x() const { return int_value(OPTION_INTSCALEX); }
 	int int_scale_y() const { return int_value(OPTION_INTSCALEY); }

--- a/src/emu/render.cpp
+++ b/src/emu/render.cpp
@@ -935,10 +935,14 @@ render_target::render_target(render_manager &manager, const internal_layout *lay
 	m_int_overscan = manager.machine().options().int_overscan();
 	m_int_scale_x = manager.machine().options().int_scale_x();
 	m_int_scale_y = manager.machine().options().int_scale_y();
-	if (manager.machine().options().uneven_stretch() && !manager.machine().options().uneven_stretch_x())
+	if (manager.machine().options().uneven_stretch_x())
+		m_scale_mode = SCALE_FRACTIONAL_X;
+	else if (manager.machine().options().uneven_stretch_y())
+		m_scale_mode = SCALE_FRACTIONAL_Y;
+	else if (manager.machine().options().uneven_stretch())
 		m_scale_mode = SCALE_FRACTIONAL;
 	else
-		m_scale_mode = manager.machine().options().uneven_stretch_x() ? SCALE_FRACTIONAL_X : SCALE_INTEGER;
+		m_scale_mode = SCALE_INTEGER;
 
 	// determine the base orientation based on options
 	if (!manager.machine().options().rotate())
@@ -1195,6 +1199,7 @@ void render_target::compute_visible_area(INT32 target_width, INT32 target_height
 		}
 
 		case SCALE_FRACTIONAL_X:
+		case SCALE_FRACTIONAL_Y:
 		case SCALE_INTEGER:
 		{
 			// get source size and aspect
@@ -1210,8 +1215,8 @@ void render_target::compute_visible_area(INT32 target_width, INT32 target_height
 			float target_aspect = (float)target_width / (float)target_height * target_pixel_aspect;
 
 			// determine the scale mode for each axis
-			bool x_is_integer = !(target_aspect >= 1.0f && m_scale_mode == SCALE_FRACTIONAL_X);
-			bool y_is_integer = !(target_aspect < 1.0f && m_scale_mode == SCALE_FRACTIONAL_X);
+			bool x_is_integer = !((target_aspect >= 1.0f && m_scale_mode == SCALE_FRACTIONAL_X) || (target_aspect < 1.0f && m_scale_mode == SCALE_FRACTIONAL_Y));
+			bool y_is_integer = !((target_aspect < 1.0f && m_scale_mode == SCALE_FRACTIONAL_X) || (target_aspect >= 1.0f && m_scale_mode == SCALE_FRACTIONAL_Y));
 
 			// first compute scale factors to fit the screen
 			float xscale = (float)target_width / src_width;

--- a/src/emu/render.cpp
+++ b/src/emu/render.cpp
@@ -1240,8 +1240,10 @@ void render_target::compute_visible_area(INT32 target_width, INT32 target_height
 			if (y_is_integer) yscale = std::min(maxyscale, std::max(1.0f, render_round_nearest(yscale)));
 
 			// check if we have user defined scale factors, if so use them instead
-			xscale = m_int_scale_x > 0 ? m_int_scale_x : xscale;
-			yscale = m_int_scale_y > 0 ? m_int_scale_y : yscale;
+			int user_scale_x = target_is_portrait? m_int_scale_y : m_int_scale_x;
+			int user_scale_y = target_is_portrait? m_int_scale_x : m_int_scale_y;
+			xscale = user_scale_x > 0 ? user_scale_x : xscale;
+			yscale = user_scale_y > 0 ? user_scale_y : yscale;
 
 			// set the final width/height
 			visible_width = render_round_nearest(src_width * xscale);

--- a/src/emu/render.cpp
+++ b/src/emu/render.cpp
@@ -935,7 +935,9 @@ render_target::render_target(render_manager &manager, const internal_layout *lay
 	m_int_overscan = manager.machine().options().int_overscan();
 	m_int_scale_x = manager.machine().options().int_scale_x();
 	m_int_scale_y = manager.machine().options().int_scale_y();
-	if (manager.machine().options().uneven_stretch_x())
+	if (m_manager.machine().options().auto_stretch_xy())
+		m_scale_mode = SCALE_FRACTIONAL_AUTO;
+	else if (manager.machine().options().uneven_stretch_x())
 		m_scale_mode = SCALE_FRACTIONAL_X;
 	else if (manager.machine().options().uneven_stretch_y())
 		m_scale_mode = SCALE_FRACTIONAL_Y;
@@ -1198,9 +1200,7 @@ void render_target::compute_visible_area(INT32 target_width, INT32 target_height
 			break;
 		}
 
-		case SCALE_FRACTIONAL_X:
-		case SCALE_FRACTIONAL_Y:
-		case SCALE_INTEGER:
+		default:
 		{
 			// get source size and aspect
 			INT32 src_width, src_height;
@@ -1213,10 +1213,19 @@ void render_target::compute_visible_area(INT32 target_width, INT32 target_height
 
 			// get target aspect
 			float target_aspect = (float)target_width / (float)target_height * target_pixel_aspect;
+			bool target_is_portrait = (target_aspect < 1.0f);
+
+			// apply automatic axial stretching if required
+			int scale_mode = m_scale_mode;
+			if (m_scale_mode == SCALE_FRACTIONAL_AUTO)
+			{
+				bool is_rotated = (m_manager.machine().system().flags & ORIENTATION_SWAP_XY) ^ (target_orientation & ORIENTATION_SWAP_XY);
+				scale_mode = is_rotated ^ target_is_portrait ? SCALE_FRACTIONAL_Y : SCALE_FRACTIONAL_X;
+			}
 
 			// determine the scale mode for each axis
-			bool x_is_integer = !((target_aspect >= 1.0f && m_scale_mode == SCALE_FRACTIONAL_X) || (target_aspect < 1.0f && m_scale_mode == SCALE_FRACTIONAL_Y));
-			bool y_is_integer = !((target_aspect < 1.0f && m_scale_mode == SCALE_FRACTIONAL_X) || (target_aspect >= 1.0f && m_scale_mode == SCALE_FRACTIONAL_Y));
+			bool x_is_integer = !((!target_is_portrait && scale_mode == SCALE_FRACTIONAL_X) || (target_is_portrait && scale_mode == SCALE_FRACTIONAL_Y));
+			bool y_is_integer = !((target_is_portrait && scale_mode == SCALE_FRACTIONAL_X) || (!target_is_portrait && scale_mode == SCALE_FRACTIONAL_Y));
 
 			// first compute scale factors to fit the screen
 			float xscale = (float)target_width / src_width;

--- a/src/emu/render.h
+++ b/src/emu/render.h
@@ -87,6 +87,7 @@ enum
 	SCALE_FRACTIONAL = 0,                               // compute fractional scaling factors for both axes
 	SCALE_FRACTIONAL_X,                                 // compute fractional scaling factor for x-axis, and integer factor for y-axis
 	SCALE_FRACTIONAL_Y,                                 // compute fractional scaling factor for y-axis, and integer factor for x-axis
+	SCALE_FRACTIONAL_AUTO,                              // automatically compute fractional scaling for x/y-axes based on source native orientation
 	SCALE_INTEGER                                       // compute integer scaling factors for both axes, based on target dimensions
 };
 

--- a/src/emu/render.h
+++ b/src/emu/render.h
@@ -86,6 +86,7 @@ enum
 {
 	SCALE_FRACTIONAL = 0,                               // compute fractional scaling factors for both axes
 	SCALE_FRACTIONAL_X,                                 // compute fractional scaling factor for x-axis, and integer factor for y-axis
+	SCALE_FRACTIONAL_Y,                                 // compute fractional scaling factor for y-axis, and integer factor for x-axis
 	SCALE_INTEGER                                       // compute integer scaling factors for both axes, based on target dimensions
 };
 


### PR DESCRIPTION
New stretching options:
- New option -unevenstretchy (complementary to -unevenstretchx)
- New option -autostretchxy, to automatically apply -unevenstretchx or -unevenstretchy based on source native orientation.

The purpose of -autostretchxy is to achieve evenly spaced scanlines when using filters on LCD monitors, by applying fractional scaling only on direction of the source scanlines.

Note: in options -unevenstretchx/unevenstretchy and -intscalex/intscaley, the x/y axes consistenly correspond to:
- x: long dimension of target monitor
- y: short dimension of target monitor

