### PR TITLE
Misc. fixes (nw)

### DIFF
--- a/src/emu/digfx.h
+++ b/src/emu/digfx.h
@@ -200,7 +200,7 @@ public:
 	static void static_set_palette(device_t &device, const char *tag);
 
 	// getters
-	palette_device &palette() const { return *m_palette; }
+	palette_device &palette() const { assert(m_palette != nullptr); return *m_palette; }
 	gfx_element *gfx(int index) const { assert(index < MAX_GFX_ELEMENTS); return m_gfx[index].get(); }
 
 	// decoding

--- a/src/mame/drivers/barni.cpp
+++ b/src/mame/drivers/barni.cpp
@@ -49,7 +49,7 @@ static ADDRESS_MAP_START( subcpu_map, AS_PROGRAM, 8, barni_state )
 	AM_RANGE(0xe000, 0xffff) AM_ROM
 ADDRESS_MAP_END
 
-static ADDRESS_MAP_START( audiocpu_map, AS_IO, 8, barni_state )
+static ADDRESS_MAP_START( audiocpu_map, AS_PROGRAM, 8, barni_state )
 	AM_RANGE(0x0000, 0x007f) AM_RAM
 	AM_RANGE(0xc000, 0xffff) AM_ROM
 ADDRESS_MAP_END

--- a/src/mame/drivers/stfight.cpp
+++ b/src/mame/drivers/stfight.cpp
@@ -1070,4 +1070,4 @@ GAME( 1986, stfighta, empcity, stfight, stfight, stfight_state, stfight, ROT0,  
 GAME( 1986, stfightgb,empcity, stfight, stfight, stfight_state, stfight, ROT0,   "Seibu Kaihatsu (Tuning license)",          "Street Fight (Germany - Benelux)", MACHINE_IMPERFECT_SOUND | MACHINE_SUPPORTS_SAVE )
 
 /* Cross Shooter uses the same base board, but different video board */
-GAME( 1987, cshootert,  airraid,      cshooter, cshooter, stfight_state, cshooter, ROT270, "Seibu Kaihatsu (Taito license)",           "Cross Shooter (2 PCB Stack)", MACHINE_NOT_WORKING | MACHINE_SUPPORTS_SAVE )
+GAME( 1987, cshootert,  airraid,      cshooter, cshooter, stfight_state, cshooter, ROT270, "Seibu Kaihatsu (Taito license)",           "Cross Shooter (2 PCB Stack)", MACHINE_NOT_WORKING | MACHINE_IMPERFECT_SOUND | MACHINE_SUPPORTS_SAVE )

--- a/src/mame/video/airraid_dev.cpp
+++ b/src/mame/video/airraid_dev.cpp
@@ -80,6 +80,9 @@ machine_config_constructor airraid_video_device::device_mconfig_additions() cons
 
 void airraid_video_device::device_start()
 {
+	if (!m_gfxdecode->started())
+		throw device_missing_dependencies();
+
 	save_item(NAME(m_hw));
 
 	// there might actually be 4 banks of 2048 x 16 tilemaps in here as the upper scroll bits are with the rom banking.


### PR DESCRIPTION
- Correct address space number for audiocpu_map in barni.cpp
- Add missing_dependencies check to airraid_dev (fixes segfault in tilemap viewer; yes, I know these tiles are 100% garbage)
- Add assert to device_gfx_interface::palette() to help catch dependency mistakes like the above
- Add MACHINE_IMPERFECT_SOUND to cshootert (music desyncs a lot)