### PR TITLE
Added layout for California Speed

### DIFF
--- a/src/mame/drivers/seattle.cpp
+++ b/src/mame/drivers/seattle.cpp
@@ -195,6 +195,7 @@
 #include "video/voodoo.h"
 #include "machine/nvram.h"
 #include "calspeed.lh"
+#include "vaportrx.lh"
 #include "hyprdriv.lh"
 
 
@@ -3277,8 +3278,8 @@ GAMEL( 1998, calspeedb,calspeed, calspeed,          calspeed, seattle_state, cal
 
 
 
-GAME( 1998, vaportrx, 0,        vaportrx,          vaportrx, seattle_state, vaportrx, ROT0, "Atari Games",  "Vapor TRX", MACHINE_SUPPORTS_SAVE )
-GAME( 1998, vaportrxp,vaportrx, vaportrx,          vaportrx, seattle_state, vaportrx, ROT0, "Atari Games",  "Vapor TRX (prototype)", MACHINE_SUPPORTS_SAVE )
+GAMEL( 1998, vaportrx, 0,        vaportrx,          vaportrx, seattle_state, vaportrx, ROT0, "Atari Games",  "Vapor TRX", MACHINE_SUPPORTS_SAVE, layout_vaportrx )
+GAMEL( 1998, vaportrxp,vaportrx, vaportrx,          vaportrx, seattle_state, vaportrx, ROT0, "Atari Games",  "Vapor TRX (prototype)", MACHINE_SUPPORTS_SAVE, layout_vaportrx )
 
 /* Midway */
 GAME( 1997, biofreak, 0,        biofreak,          biofreak, seattle_state, biofreak, ROT0, "Midway Games", "BioFreaks (prototype)", MACHINE_SUPPORTS_SAVE )

--- a/src/mame/drivers/seattle.cpp
+++ b/src/mame/drivers/seattle.cpp
@@ -195,6 +195,7 @@
 #include "video/voodoo.h"
 #include "machine/nvram.h"
 #include "calspeed.lh"
+#include "hyprdriv.lh"
 
 
 
@@ -1580,11 +1581,11 @@ READ32_MEMBER(seattle_state::output_r)
 WRITE32_MEMBER(seattle_state::output_w)
 {
 	UINT8 bit;
-	UINT8 op = (data >> 8) & 0xFF;
+	UINT8 op = (data >> 8) & 0x0F;
 	UINT8 arg = data & 0xFF;
 	switch (op) {
-		case 0xF7: m_output_mode = arg; break;
-		case 0xFB:
+		case 0x07: m_output_mode = arg; break;
+		case 0x0B:
 		switch (m_output_mode) {
 			case 0x04: output().set_value("wheel", arg); break; //wheel motor delta. signed byte.
 			case 0x05: for (bit = 0; bit < 8; bit++) output().set_lamp_value(bit, (arg >> bit) & 0x1); break;
@@ -3288,4 +3289,4 @@ GAME( 1998, blitz99a, blitz99,  blitz99,           blitz99, seattle_state,  blit
 GAME( 1999, blitz2k,  0,        blitz2k,           blitz99, seattle_state,  blitz2k,  ROT0, "Midway Games", "NFL Blitz 2000 Gold Edition (ver 1.2, Sep 22 1999)", MACHINE_SUPPORTS_SAVE )
 GAME( 1998, carnevil, 0,        carnevil,          carnevil, seattle_state, carnevil, ROT0, "Midway Games", "CarnEvil (v1.0.3)", MACHINE_SUPPORTS_SAVE )
 GAME( 1998, carnevil1,carnevil, carnevil,          carnevil, seattle_state, carnevil, ROT0, "Midway Games", "CarnEvil (v1.0.1)", MACHINE_SUPPORTS_SAVE )
-GAME( 1998, hyprdriv, 0,        hyprdriv,          hyprdriv, seattle_state, hyprdriv, ROT0, "Midway Games", "Hyperdrive", MACHINE_SUPPORTS_SAVE )
+GAMEL( 1998, hyprdriv, 0,        hyprdriv,          hyprdriv, seattle_state, hyprdriv, ROT0, "Midway Games", "Hyperdrive", MACHINE_SUPPORTS_SAVE, layout_hyprdriv )

--- a/src/mame/drivers/seattle.cpp
+++ b/src/mame/drivers/seattle.cpp
@@ -1587,9 +1587,10 @@ WRITE32_MEMBER(seattle_state::output_w)
 	switch (op)
 	{
 		default:
-			if (LOG_WIDGET)
-				logerror("Output (%02X) = %02X\n", op, arg);
+			logerror("Unknown output (%02X) = %02X\n", op, arg);
 			break;
+			
+		case 0xF: break; // sync/security wrapper commands. arg matches the wrapped command.
 		
 		case 0x7:
 			m_output_mode = arg;
@@ -1599,12 +1600,11 @@ WRITE32_MEMBER(seattle_state::output_w)
 			switch (m_output_mode)
 			{
 				default:
-					if (LOG_WIDGET)
-						logerror("Output Mode (%02X) = %02X\n", m_output_mode, arg);
+					logerror("Unknown output with mode (%02X) = %02X\n", m_output_mode, arg);
 					break;
 				
 				case 0x04:
-					output().set_value("wheel", arg); //wheel motor delta. signed byte.
+					output().set_value("wheel", arg); // wheel motor delta. signed byte.
 					break;
 					
 				case 0x05:

--- a/src/mame/drivers/seattle.cpp
+++ b/src/mame/drivers/seattle.cpp
@@ -1581,17 +1581,38 @@ READ32_MEMBER(seattle_state::output_r)
 
 WRITE32_MEMBER(seattle_state::output_w)
 {
-	UINT8 bit;
-	UINT8 op = (data >> 8) & 0x0F;
+	UINT8 op = (data >> 8) & 0xF;
 	UINT8 arg = data & 0xFF;
-	switch (op) {
-		case 0x07: m_output_mode = arg; break;
-		case 0x0B:
-		switch (m_output_mode) {
-			case 0x04: output().set_value("wheel", arg); break; //wheel motor delta. signed byte.
-			case 0x05: for (bit = 0; bit < 8; bit++) output().set_lamp_value(bit, (arg >> bit) & 0x1); break;
-		}
-		break;
+	
+	switch (op)
+	{
+		default:
+			if (LOG_WIDGET)
+				logerror("Output (%02X) = %02X\n", op, arg);
+			break;
+		
+		case 0x7:
+			m_output_mode = arg;
+			break;
+			
+		case 0xB:
+			switch (m_output_mode)
+			{
+				default:
+					if (LOG_WIDGET)
+						logerror("Output Mode (%02X) = %02X\n", m_output_mode, arg);
+					break;
+				
+				case 0x04:
+					output().set_value("wheel", arg); //wheel motor delta. signed byte.
+					break;
+					
+				case 0x05:
+					for (UINT8 bit = 0; bit < 8; bit++)
+						output().set_lamp_value(bit, (arg >> bit) & 0x1);
+					break;
+			}
+			break;
 	}
 }
 

--- a/src/mame/drivers/seattle.cpp
+++ b/src/mame/drivers/seattle.cpp
@@ -194,6 +194,7 @@
 #include "machine/smc91c9x.h"
 #include "video/voodoo.h"
 #include "machine/nvram.h"
+#include "calspeed.lh"
 
 
 
@@ -368,6 +369,7 @@
 /* Widget registers */
 #define WREG_ETHER_ADDR     (0x00/4)
 #define WREG_INTERRUPT      (0x04/4)
+#define WREG_OUTPUT         (0x0C/4)
 #define WREG_ANALOG         (0x10/4)
 #define WREG_ETHER_DATA     (0x14/4)
 
@@ -469,6 +471,8 @@ public:
 	UINT8 m_pending_analog_read;
 	UINT8 m_status_leds;
 	UINT32 m_cmos_write_enabled;
+	UINT32 m_output;
+	UINT8 m_output_mode;
 	DECLARE_READ32_MEMBER(interrupt_state_r);
 	DECLARE_READ32_MEMBER(interrupt_state2_r);
 	DECLARE_WRITE32_MEMBER(interrupt_config_w);
@@ -492,6 +496,8 @@ public:
 	DECLARE_WRITE32_MEMBER(status_leds_w);
 	DECLARE_READ32_MEMBER(ethernet_r);
 	DECLARE_WRITE32_MEMBER(ethernet_w);
+	DECLARE_READ32_MEMBER(output_r);
+	DECLARE_WRITE32_MEMBER(output_w);
 	DECLARE_READ32_MEMBER(widget_r);
 	DECLARE_WRITE32_MEMBER(widget_w);
 	DECLARE_READ32_MEMBER(seattle_ide_r);
@@ -599,6 +605,8 @@ void seattle_state::machine_start()
 	save_item(NAME(m_pending_analog_read));
 	save_item(NAME(m_status_leds));
 	save_item(NAME(m_cmos_write_enabled));
+	save_item(NAME(m_output));
+	save_item(NAME(m_output_mode));
 }
 
 
@@ -1563,6 +1571,29 @@ void seattle_state::update_widget_irq()
 }
 
 
+READ32_MEMBER(seattle_state::output_r)
+{
+	return m_output;
+}
+
+
+WRITE32_MEMBER(seattle_state::output_w)
+{
+	UINT8 bit;
+	UINT8 op = (data >> 8) & 0xFF;
+	UINT8 arg = data & 0xFF;
+	switch (op) {
+		case 0xF7: m_output_mode = arg; break;
+		case 0xFB:
+		switch (m_output_mode) {
+			case 0x04: output().set_value("wheel", arg); break; //wheel motor delta. signed byte.
+			case 0x05: for (bit = 0; bit < 8; bit++) output().set_lamp_value(bit, (arg >> bit) & 0x1); break;
+		}
+		break;
+	}
+}
+
+
 READ32_MEMBER(seattle_state::widget_r)
 {
 	UINT32 result = ~0;
@@ -1576,6 +1607,10 @@ READ32_MEMBER(seattle_state::widget_r)
 		case WREG_INTERRUPT:
 			result = m_ethernet_irq_state << WINT_ETHERNET_SHIFT;
 			result = ~result;
+			break;
+			
+		case WREG_OUTPUT:
+			result = output_r(m_maincpu->space(AS_PROGRAM), 0, mem_mask);
 			break;
 
 		case WREG_ANALOG:
@@ -1607,6 +1642,10 @@ WRITE32_MEMBER(seattle_state::widget_w)
 		case WREG_INTERRUPT:
 			m_widget.irq_mask = data;
 			update_widget_irq();
+			break;
+			
+		case WREG_OUTPUT:
+			output_w(m_maincpu->space(AS_PROGRAM), 0, data, mem_mask);
 			break;
 
 		case WREG_ANALOG:
@@ -3231,9 +3270,9 @@ GAME( 1996, mace,     0,        mace,              mace, seattle_state,     mace
 GAME( 1997, macea,    mace,     mace,              mace, seattle_state,     mace,     ROT0, "Atari Games",  "Mace: The Dark Age (HDD 1.0a)", MACHINE_SUPPORTS_SAVE )
 GAME( 1996, sfrush,   0,        sfrush,            sfrush, seattle_state,   sfrush,   ROT0, "Atari Games",  "San Francisco Rush", MACHINE_SUPPORTS_SAVE )
 GAME( 1996, sfrushrk, 0,        sfrushrk,          sfrushrk, seattle_state, sfrushrk, ROT0, "Atari Games",  "San Francisco Rush: The Rock", MACHINE_NOT_WORKING | MACHINE_SUPPORTS_SAVE )
-GAME( 1998, calspeed, 0,        calspeed,          calspeed, seattle_state, calspeed, ROT0, "Atari Games",  "California Speed (Version 2.1a Apr 17 1998, GUTS 1.25 Apr 17 1998 / MAIN Apr 17 1998)", MACHINE_SUPPORTS_SAVE )
-GAME( 1998, calspeeda,calspeed, calspeed,          calspeed, seattle_state, calspeed, ROT0, "Atari Games",  "California Speed (Version 1.0r8 Mar 10 1998, GUTS Mar 10 1998 / MAIN Mar 10 1998)", MACHINE_SUPPORTS_SAVE )
-GAME( 1998, calspeedb,calspeed, calspeed,          calspeed, seattle_state, calspeed, ROT0, "Atari Games",  "California Speed (Version 1.0r7a Mar 4 1998, GUTS Mar 3 1998 / MAIN Jan 19 1998)", MACHINE_SUPPORTS_SAVE )
+GAMEL( 1998, calspeed, 0,        calspeed,          calspeed, seattle_state, calspeed, ROT0, "Atari Games",  "California Speed (Version 2.1a Apr 17 1998, GUTS 1.25 Apr 17 1998 / MAIN Apr 17 1998)", MACHINE_SUPPORTS_SAVE, layout_calspeed )
+GAMEL( 1998, calspeeda,calspeed, calspeed,          calspeed, seattle_state, calspeed, ROT0, "Atari Games",  "California Speed (Version 1.0r8 Mar 10 1998, GUTS Mar 10 1998 / MAIN Mar 10 1998)", MACHINE_SUPPORTS_SAVE, layout_calspeed )
+GAMEL( 1998, calspeedb,calspeed, calspeed,          calspeed, seattle_state, calspeed, ROT0, "Atari Games",  "California Speed (Version 1.0r7a Mar 4 1998, GUTS Mar 3 1998 / MAIN Jan 19 1998)", MACHINE_SUPPORTS_SAVE, layout_calspeed )
 
 
 

--- a/src/mame/layout/calspeed.lay
+++ b/src/mame/layout/calspeed.lay
@@ -1,0 +1,117 @@
+<?xml version="1.0"?>
+<mamelayout version="2">
+	<element name="lamp" defstate="0">
+		<rect state="0">
+			<color red="0.1" green="0.1" blue="0.0" />
+			<bounds x="0.0" y="0.0" width="1.0" height="1.0" />
+		</rect>
+		<rect state="1">
+			<color red="1.0" green="1.0" blue="0.0" />
+			<bounds x="0.0" y="0.0" width="1.0" height="1.0" />
+		</rect>
+	</element>
+
+	<element name="start" defstate="0">
+		<disk state="0">
+			<bounds x="0" y="0" width="2.0" height="2.0" />
+			<color red="0.0" green="0.1" blue="0.061" />
+		</disk>
+		<disk state="1">
+			<bounds x="0" y="0" width="2.0" height="2.0" />
+			<color red="0.0" green="1.0" blue="0.61" />
+		</disk>
+		<text string="START">
+			<color red="0.0" green="0.0" blue="0.0" />
+			<bounds x="0.25" y="0.5" width="1.5" height="1.0" />
+		</text>
+	</element>
+
+	<element name="view1" defstate="0">
+		<disk state="0">
+			<bounds x="0.0" y="0.0" width="170.0" height="90.0" />
+			<color red="0.1" green="0.01137" blue="0.02314" />
+		</disk>
+		<disk state="1">
+			<bounds x="0.0" y="0.0" width="170.0" height="90.0" />
+			<color red="1.0" green="0.1137" blue="0.2314" />
+		</disk>
+		<text string="ROAD CAM">
+			<color red="0.0" green="0.0" blue="0.0" />
+			<bounds x="10.0" y="10.0" width="150.0" height="70.0" />
+		</text>
+	</element>
+
+	<element name="view2" defstate="0">
+		<disk state="0">
+			<bounds x="0.0" y="0.0" width="170.0" height="90.0" />
+			<color red="0.1" green="0.09294" blue="0.00078" />
+		</disk>
+		<disk state="1">
+			<bounds x="0.0" y="0.0" width="170.0" height="90.0" />
+			<color red="1.0" green="0.9294" blue="0.0078" />
+		</disk>
+		<text string="TAILGATE CAM">
+			<color red="0.0" green="0.0" blue="0.0" />
+			<bounds x="10.0" y="10.0" width="150.0" height="70.0" />
+		</text>
+	</element>
+
+	<element name="view3" defstate="0">
+		<disk state="0">
+			<bounds x="0.0" y="0.0" width="170.0" height="90.0" />
+			<color red="0.0" green="0.1" blue="0.03686" />
+		</disk>
+		<disk state="1">
+			<bounds x="0.0" y="0.0" width="170.0" height="90.0" />
+			<color red="0.0" green="1.0" blue="0.3686" />
+		</disk>
+		<text string="SKY CAM">
+			<color red="0.0" green="0.0" blue="0.0" />
+			<bounds x="10.0" y="10.0" width="150.0" height="70.0" />
+		</text>
+	</element>
+	
+	<element name="counter" defstate="0">
+		<simplecounter digits="3">
+			<color red="1.0" green="1.0" blue="1.0" />
+		</simplecounter>
+	</element>
+
+	<view name="Simple LEDs">
+		<bounds left="0" top="0" right="4" bottom="3.472" />
+
+		<screen index="0">
+			<bounds left="0" top="0" right="4" bottom="3" />
+		</screen>
+
+		<bezel name="lamp0" element="start">
+			<bounds x="3.60" y="3.1" width="0.3" height="0.3" />
+		</bezel>
+		<bezel name="lamp1" element="view1">
+			<bounds x="0.025" y="3.025" width="0.472" height="0.125" />
+		</bezel>
+		<bezel name="lamp2" element="view2">
+			<bounds x="0.025" y="3.175" width="0.472" height="0.125" />
+		</bezel>
+		<bezel name="lamp3" element="view3">
+			<bounds x="0.025" y="3.325" width="0.472" height="0.125" />
+		</bezel>
+		
+		<bezel name="lamp4" element="lamp">
+			<bounds x="1.785" y="3.2" width="0.1" height="0.1" />
+		</bezel>
+		<bezel name="lamp5" element="lamp">
+			<bounds x="1.895" y="3.2" width="0.1" height="0.1" />
+		</bezel>
+		<bezel name="lamp6" element="lamp">
+			<bounds x="2.005" y="3.2" width="0.1" height="0.1" />
+		</bezel>
+		<bezel name="lamp7" element="lamp">
+			<bounds x="2.115" y="3.2" width="0.1" height="0.1" />
+		</bezel>
+		
+		<bezel name="wheel" element="counter">
+			<bounds x="1.9" y="3.0" width="0.2" height="0.1" />
+		</bezel>
+	</view>
+</mamelayout>

--- a/src/mame/layout/hyprdriv.lay
+++ b/src/mame/layout/hyprdriv.lay
@@ -1,0 +1,117 @@
+<?xml version="1.0"?>
+<mamelayout version="2">
+	<element name="lamp" defstate="0">
+		<rect state="0">
+			<color red="0.1" green="0.1" blue="0.0" />
+			<bounds x="0.0" y="0.0" width="1.0" height="1.0" />
+		</rect>
+		<rect state="1">
+			<color red="1.0" green="1.0" blue="0.0" />
+			<bounds x="0.0" y="0.0" width="1.0" height="1.0" />
+		</rect>
+	</element>
+
+	<element name="start" defstate="0">
+		<disk state="0">
+			<bounds x="0" y="0" width="2.0" height="2.0" />
+			<color red="0.0" green="0.1" blue="0.061" />
+		</disk>
+		<disk state="1">
+			<bounds x="0" y="0" width="2.0" height="2.0" />
+			<color red="0.0" green="1.0" blue="0.61" />
+		</disk>
+		<text string="START">
+			<color red="0.0" green="0.0" blue="0.0" />
+			<bounds x="0.25" y="0.5" width="1.5" height="1.0" />
+		</text>
+	</element>
+
+	<element name="view1" defstate="0">
+		<disk state="0">
+			<bounds x="0.0" y="0.0" width="1.0" height="1.0" />
+			<color red="0.0" green="0.064" blue="0.1" />
+		</disk>
+		<disk state="1">
+			<bounds x="0.0" y="0.0" width="1.0" height="1.0" />
+			<color red="0.0" green="0.64" blue="1.0" />
+		</disk>
+		<text string="1">
+			<color red="0.0" green="1.0" blue="1.0" />
+			<bounds x="0.0" y="0.0" width="1.0" height="1.0" />
+		</text>
+	</element>
+
+	<element name="view2" defstate="0">
+		<disk state="0">
+			<bounds x="0.0" y="0.0" width="1.0" height="1.0" />
+			<color red="0.0" green="0.064" blue="0.1" />
+		</disk>
+		<disk state="1">
+			<bounds x="0.0" y="0.0" width="1.0" height="1.0" />
+			<color red="0.0" green="0.64" blue="1.0" />
+		</disk>
+		<text string="2">
+			<color red="0.0" green="1.0" blue="1.0" />
+			<bounds x="0.0" y="0.0" width="1.0" height="1.0" />
+		</text>
+	</element>
+
+	<element name="view3" defstate="0">
+		<disk state="0">
+			<bounds x="0.0" y="0.0" width="1.0" height="1.0" />
+			<color red="0.0" green="0.064" blue="0.1" />
+		</disk>
+		<disk state="1">
+			<bounds x="0.0" y="0.0" width="1.0" height="1.0" />
+			<color red="0.0" green="0.64" blue="1.0" />
+		</disk>
+		<text string="3">
+			<color red="0.0" green="1.0" blue="1.0" />
+			<bounds x="0.0" y="0.0" width="1.0" height="1.0" />
+		</text>
+	</element>
+	
+	<element name="counter" defstate="0">
+		<simplecounter digits="3">
+			<color red="1.0" green="1.0" blue="1.0" />
+		</simplecounter>
+	</element>
+
+	<view name="Simple LEDs">
+		<bounds left="0" top="0" right="4" bottom="3.472" />
+
+		<screen index="0">
+			<bounds left="0" top="0" right="4" bottom="3" />
+		</screen>
+
+		<bezel name="lamp0" element="start">
+			<bounds x="3.60" y="3.1" width="0.3" height="0.3" />
+		</bezel>
+		<bezel name="lamp2" element="view1">
+			<bounds x="0.025" y="3.025" width="0.125" height="0.125" />
+		</bezel>
+		<bezel name="lamp1" element="view2">
+			<bounds x="0.025" y="3.175" width="0.125" height="0.125" />
+		</bezel>
+		<bezel name="lamp3" element="view3">
+			<bounds x="0.025" y="3.325" width="0.125" height="0.125" />
+		</bezel>
+		
+		<bezel name="lamp4" element="lamp">
+			<bounds x="1.785" y="3.2" width="0.1" height="0.1" />
+		</bezel>
+		<bezel name="lamp5" element="lamp">
+			<bounds x="1.895" y="3.2" width="0.1" height="0.1" />
+		</bezel>
+		<bezel name="lamp6" element="lamp">
+			<bounds x="2.005" y="3.2" width="0.1" height="0.1" />
+		</bezel>
+		<bezel name="lamp7" element="lamp">
+			<bounds x="2.115" y="3.2" width="0.1" height="0.1" />
+		</bezel>
+		
+		<bezel name="wheel" element="counter">
+			<bounds x="1.9" y="3.0" width="0.2" height="0.1" />
+		</bezel>
+	</view>
+</mamelayout>

--- a/src/mame/layout/vaportrx.lay
+++ b/src/mame/layout/vaportrx.lay
@@ -1,0 +1,62 @@
+<?xml version="1.0"?>
+<mamelayout version="2">
+	<element name="lamp" defstate="0">
+		<rect state="0">
+			<color red="0.25" green="0.0" blue="0.0" />
+			<bounds x="0.0" y="0.0" width="1.0" height="2.0" />
+		</rect>
+		<rect state="1">
+			<color red="1.0" green="0.0" blue="0.0" />
+			<bounds x="0.0" y="0.0" width="1.0" height="2.0" />
+		</rect>
+		<rect>
+			<color red="0.1" green="0.0" blue="0.0" />
+			<bounds x="0.1" y="0.1" width="0.8" height="0.85" />
+		</rect>
+		<rect>
+			<color red="0.1" green="0.0" blue="0.0" />
+			<bounds x="0.1" y="1.05" width="0.8" height="0.85" />
+		</rect>
+		<text string="START" state="0">
+			<color red="0.25" green="0.0" blue="0.0" />
+			<bounds x="0.15" y="0.1" width="0.7" height="0.85" />
+		</text>
+		<text string="VIEW" state="0">
+			<color red="0.25" green="0.0" blue="0.0" />
+			<bounds x="0.15" y="1.05" width="0.7" height="0.85" />
+		</text>
+		<text string="START" state="1">
+			<color red="1.0" green="0.0" blue="0.0" />
+			<bounds x="0.15" y="0.1" width="0.7" height="0.85" />
+		</text>
+		<text string="VIEW" state="1">
+			<color red="1.0" green="0.0" blue="0.0" />
+			<bounds x="0.15" y="1.05" width="0.7" height="0.85" />
+		</text>
+	</element>
+	
+	<element name="counter" defstate="0">
+		<simplecounter digits="3">
+			<color red="1.0" green="1.0" blue="1.0" />
+		</simplecounter>
+	</element>
+
+	<view name="Simple LEDs">
+		<bounds left="0" top="0" right="4" bottom="3.472" />
+
+		<screen index="0">
+			<bounds left="0" top="0" right="4" bottom="3" />
+		</screen>
+
+		<bezel name="lamp0" element="lamp">
+			<bounds x="3.75" y="3.05" width="0.2" height="0.4" />
+		</bezel>
+		<bezel name="lamp1" element="lamp">
+			<bounds x="0.05" y="3.05" width="0.2" height="0.4" />
+		</bezel>
+		
+		<bezel name="wheel" element="counter">
+			<bounds x="1.9" y="3.0" width="0.2" height="0.1" />
+		</bezel>
+	</view>
+</mamelayout>


### PR DESCRIPTION
Surprise. it's the same output system as the Midway V Unit. Would expect to find more stuff in there. Couldn't crack what San Francisco Rush was doing with its outputs so couldn't include it. Perhaps some other games with the Widget board uses same system as well, but I'm not sure about the Flagstaff board.

EDIT: Hyperdrive confirmed my suspicions about Widget board. Just needed a small fix.