### PR TITLE
Allows devices to indicate whether image creation should be supported at the command line

### DIFF
--- a/src/emu/diimage.cpp
+++ b/src/emu/diimage.cpp
@@ -539,6 +539,34 @@ UINT32 device_image_interface::crc()
 	return crc;
 }
 
+
+//-------------------------------------------------
+//  support_command_line_image_creation - do we
+//	want to support image creation from the front
+//	end command line?
+//-------------------------------------------------
+
+bool device_image_interface::support_command_line_image_creation() const
+{
+	bool result;
+	switch (image_type())
+	{
+	case IO_PRINTER:
+	case IO_SERIAL:
+	case IO_PARALLEL:
+		// going by the assumption that these device image types should support this
+		// behavior; ideally we'd get rid of IO_* and just push this to the specific
+		// devices
+		result = true;
+		break;
+	default:
+		result = false;
+		break;
+	}
+	return result;
+}
+
+
 // ****************************************************************************
 // Battery functions
 //
@@ -1155,6 +1183,16 @@ image_init_result device_image_interface::finish_load()
 	m_create_args = nullptr;
 	m_init_phase = false;
 	return err;
+}
+
+
+//-------------------------------------------------
+//  create - create a image
+//-------------------------------------------------
+
+image_init_result device_image_interface::create(const std::string &path)
+{
+	return create(path, nullptr, nullptr);
 }
 
 

--- a/src/emu/diimage.h
+++ b/src/emu/diimage.h
@@ -158,6 +158,7 @@ public:
 	virtual bool is_creatable() const = 0;
 	virtual bool must_be_loaded() const = 0;
 	virtual bool is_reset_on_load() const = 0;
+	virtual bool support_command_line_image_creation() const;
 	virtual const char *image_interface() const { return nullptr; }
 	virtual const char *file_extensions() const = 0;
 	virtual const option_guide *create_option_guide() const { return nullptr; }
@@ -235,6 +236,7 @@ public:
 	image_init_result finish_load();
 	void unload();
 	image_init_result create(const std::string &path, const image_device_format *create_format, util::option_resolution *create_args);
+	image_init_result create(const std::string &path);
 	bool load_software(software_list_device &swlist, const char *swname, const rom_entry *entry);
 	int reopen_for_write(const std::string &path);
 

--- a/src/emu/image.cpp
+++ b/src/emu/image.cpp
@@ -55,6 +55,10 @@ image_manager::image_manager(running_machine &machine)
 			if (result != image_init_result::PASS)
 				result = image.load(image_name);
 
+			// failing that, try creating it (if appropriate)
+			if (result != image_init_result::PASS && image.support_command_line_image_creation())
+				result = image.create(image_name);
+
 			// did the image load fail?
 			if (result != image_init_result::PASS)
 			{


### PR DESCRIPTION
This addresses MT bug #6372.  The prior issue is that creating serial and/or printer output relied on how image_load() would create images that were not there.  This behavior was not universally desirable (the consensus was that it was wrong for disk images, up in the air for cassettes etc).  This change makes it possible for devices to control this behavior.

Currently I have it associated with image_type(); this might not be the ideal fix.