### PR TITLE
New Phoenix clone

### DIFF
--- a/src/mame/drivers/phoenix.cpp
+++ b/src/mame/drivers/phoenix.cpp
@@ -559,6 +559,30 @@ ROM_START( phoenix )
 	ROM_LOAD( "mmi6301.ic41",   0x0100, 0x0100, CRC(e176b768) SHA1(e2184dd495ed579f10b6da0b78379e02d7a6229f) )  /* palette high bits */
 ROM_END
 
+ROM_START( phoenix2 )
+	ROM_REGION( 0x10000, "maincpu", 0 )
+	ROM_LOAD( "ic45-pg1.1a",  0x0000, 0x0800, CRC(5b8c55a8) SHA1(839c1ca9766f730ec3accd48db70f6429a9c3362) )
+	ROM_LOAD( "ic46-pg2.2a",  0x0800, 0x0800, CRC(273a4a82) SHA1(6f3019a074e73ff50ceb92f655fcf15659f34919) )
+	ROM_LOAD( "ic47-pg3.3a",  0x1000, 0x0800, CRC(cbbb8839) SHA1(b7f449374cac111081559e39646f973e7e99fd64) )
+	ROM_LOAD( "ic48-pg4.4a",  0x1800, 0x0800, CRC(cb5d9915) SHA1(49bcf55a5721cfcc02c3b811a4b601e35ea576db) )
+	ROM_LOAD( "ic49-pg5.5a",  0x2000, 0x0800, CRC(73bcd2e1) SHA1(773acb7317531572cb2b81c7375e0fe52127fa0a) )
+	ROM_LOAD( "ic50-pg6.6a",  0x2800, 0x0800, CRC(ac5e9ec1) SHA1(0402e5241d99759d804291998efd43f37ce99917) )
+	ROM_LOAD( "ic51-pg7.7a",  0x3000, 0x0800, CRC(2eab35b4) SHA1(849bf8273317cc869bdd67e50c68399ee8ece81d) )
+	ROM_LOAD( "ic52-pg8.8a",  0x3800, 0x0800, CRC(aff8e9c5) SHA1(e4164f85ec12d4d9bcbffba27ab1f51b3599f6d0) )
+
+	ROM_REGION( 0x1000, "bgtiles", 0 )
+	ROM_LOAD( "ic23-cg1.3d",  0x0000, 0x0800, CRC(3c7e623f) SHA1(e7ff5fc371664af44785c079e92eeb2d8530187b) )
+	ROM_LOAD( "ic24-cg2.4d",  0x0800, 0x0800, CRC(59916d3b) SHA1(71aec70a8e096ed1f0c2297b3ae7dca1b8ecc38d) )
+
+	ROM_REGION( 0x1000, "fgtiles", 0 )
+	ROM_LOAD( "ic39-cg3.3b",  0x0000, 0x0800, CRC(53413e8f) SHA1(d772358505b973b10da840d204afb210c0c746ec) )
+	ROM_LOAD( "ic40-cg4.4b",  0x0800, 0x0800, CRC(0be2ba91) SHA1(af9243ee23377b632b9b7d0b84d341d06bf22480) )
+
+	ROM_REGION( 0x0200, "proms", 0 )
+	ROM_LOAD( "mmi6301.ic40",   0x0000, 0x0100, CRC(79350b25) SHA1(57411be4c1d89677f7919ae295446da90612c8a8) )  /* palette low bits */
+	ROM_LOAD( "mmi6301.ic41",   0x0100, 0x0100, CRC(e176b768) SHA1(e2184dd495ed579f10b6da0b78379e02d7a6229f) )  /* palette high bits */
+ROM_END
+
 ROM_START( phoenixa )
 	ROM_REGION( 0x10000, "maincpu", 0 )
 	ROM_LOAD( "1-ic45.1a",    0x0000, 0x0800, CRC(c7a9b499) SHA1(cda61de47956b3603ff6e48556ce528b5f45deab) )
@@ -1383,7 +1407,8 @@ DRIVER_INIT_MEMBER(phoenix_state,vautourza)
 }
 
 /*** Phoenix (& clones) ***/
-GAME( 1980, phoenix,  0,        phoenix,  phoenix, driver_device,  0,        ROT90, "Amstar",                            "Phoenix (Amstar)", MACHINE_SUPPORTS_SAVE )
+GAME( 1980, phoenix,  0,        phoenix,  phoenix, driver_device,  0,        ROT90, "Amstar",                            "Phoenix (Amstar, set 1)", MACHINE_SUPPORTS_SAVE )
+GAME( 1980, phoenix2, phoenix,  phoenix,  phoenix, driver_device,  0,        ROT90, "Amstar",                            "Phoenix (Amstar, set 2)", MACHINE_SUPPORTS_SAVE )
 GAME( 1980, phoenixa, phoenix,  phoenix,  phoenixa, driver_device, 0,        ROT90, "Amstar (Centuri license)",          "Phoenix (Centuri, set 1)", MACHINE_SUPPORTS_SAVE )
 GAME( 1980, phoenixb, phoenix,  phoenix,  phoenixa, driver_device, 0,        ROT90, "Amstar (Centuri license)",          "Phoenix (Centuri, set 2)", MACHINE_SUPPORTS_SAVE )
 GAME( 1980, phoenixt, phoenix,  phoenix,  phoenixt, driver_device, 0,        ROT90, "Amstar (Taito license)",            "Phoenix (Taito)", MACHINE_SUPPORTS_SAVE )

--- a/src/mame/mame.lst
+++ b/src/mame/mame.lst
@@ -30331,6 +30331,7 @@ fenix                           // bootleg
 griffon                         // bootleg (Videotron)
 nextfase                        // bootleg
 phoenix                         // (c) 1980 Amstar
+phoenix2                        // (c) 1980 Amstar
 phoenix3                        // bootleg
 phoenixa                        // (c) 1980 Amstar + Centuri license
 phoenixass                      // bootleg (Assa)


### PR DESCRIPTION
New clone added
------------------------------
Phoenix (Amstar, set 2) [MASH]


Romset: Amstar/Phoenix.zip (53kb)
The ZIP file includes 4x Phoenix versions (40files). Three of them are in MAME.
Here i list only the important files:

IC23-CG1.3D  2048  1289  1996-01-28 21:05  3C7E623F
IC24-CG2.4D  2048   555  1996-01-28 21:06  59916D3B
IC39-CG3.3B  2048  1218  1996-01-28 21:07  53413E8F
IC40-CG4.4B  2048   795  1996-01-28 21:07  0BE2BA91
IC45-PGl.1A  2048  1496  1996-01-28 21:08  5B8C55A8
IC46-PG2.2A  2048  1494  1996-01-28 21:09  273A4A82
IC47-PG3.3A  2048  1122  1996-01-28 21:09  CBBB8839
IC48-PG4.4A  2048  1139  1996-01-28 21:10  CB5D9915
IC49-PG5.5A  2048  1660  1996-01-28 21:10  73BCD2E1
IC50-PG6.6A  2048   835  1996-01-28 21:11  AC5E9EC1
IC51-PG7.7A  2048  1482  1996-01-28 21:11  2EAB35B4
IC52-PG8.8A  2048  1549  1996-01-28 21:12  AFF8E9C5


README
======
Centuri Phoenix

All parts are 2716 or 2516 

Note: it is not known whether these ROM images came from a working board

                        WORKING BOARD
loc   label  cksm       LABEL               
----  -----  ----       ---------         
ic23  B3     3dda       CH2         THERE MAY BE MULTIPLE VERSIONS
ic24  B4     bb03       CH3         OR CLONES
ic39  B1     1e7a       CH0
ic40  B2     17ea       CH1
ic45  H1     42f0       1
ic46  H2     f6e0       2
ic47  H3     0916       3
ic48  H4     6348       4
ic49  H5     b05e       R5
ic50  H6     1ec4       R6
ic51  H7     5873       R7
ic52  H8     2c7f       A8

THE CHIPS ARE CODED    IC##            - PG OR CG       .A,B,D#
                       -----           ----------       ---------
                   IC # ON BOARD      TAG ON CHIP       POSITION ON BOARD

USES 8085 CPU
THERE ARE SEVERAL SETS    ANOTHER SET
--------------------------------------
IC23           SAME       CG1
IC24           SAME       CG2
IC39           SAME       CG3
IC40           SAME       CG4
IC45                      PG1-45
IC46           SAME       PG2
IC47                      PG3-47
IC48           SAME       PG4
IC49                      PG5-49
IC50           SAME       PG6
IC51           SAME       PG7 
IC52           SAME       PG8



IC23-CH2
IC24-CH3
IC39-CH0
IC40-CH1
IC45-1
IC46-2
IC47-3
IC48-4
IC49-R4
IC50-R5
IC51-R6
IC52-A7


IC23-CG1 3D
IC24-CG2 4D
IC39-CG3 3B
IC40-CG4 4B
IC45-PG1 1A
IC46-PG2 2A
IC47-PG3 3A
IC48-PG4 4A
IC49-PG5 5A
IC50-PG6 6A
IC51-PG7 7A
IC52-PG8 8A

-

I compare this version with all MAME's versions and they are all different.
DASMs from all Phoenix sets can be download here:
http://www.mameworld.info/mameinfo/download/Phoenix-Sets-DASM.zip
To compare the DASMs use WDiff: http://www.csitte.at/wdiff/wdiff150.zip


DASM phoenix                 |  phoenix2
----------------------------------------------------------
0039: CD E0 17   call $17e0  |  0039: 3A 8F 43   ldax $438f
-----------------------------|-------------------------------
009D: 2E 8F      mvi  l,$8f  |  009D: 06 01      mvi  b,$01
009F: 7E         mov  a,m    |  009F: CD BB 00   call $00bb
00A0: FE 09      cpi  $09    |  
-----------------------------|-------------------------------
00A3: D2 00 00   jnc  $0000  |  00A3: 2E 8F      mvi  l,$8f
00A6: 06 01      mvi  b,$01  |  00A5: 7E         mov  a,m
00A8: CD BB 00   call $00bb  |  00A6: FE 99      cpi  $99
00AB: C8         rz          |  00A8: C8         rz
00AC: 2E 8F      mvi  l,$8f  |  00A9: 01 01 00   lxi  b,$0001
00AE: 34         inr  m      |  00AC: CD 20 02   call $0220
00AF: 7E         mov  a,m    |  00AF: 11 42 41   lxi  d,$4142
00B0: C6 20      adi  $20    |  00B2: 06 02      mvi  b,$02
00B2: 32 42 41   stax $4142  |  00B4: CD C4 00   call $00c4
00B5: C9         ret         |  
00B6: 00         nop         |  
-----------------------------|-------------------------------
01CA: C3 E0 14   jmp  $14e0  |  01CA: C9         ret
01CD: C2 C0 01   jnz  $01c0  |  01CB: 01 0D C2   lxi  b,$c20d
01D0: 56         mov  d,m    |  01CE: C0         rnz
01D1: 2C         inr  l      |  01CF: 01 56 2C   lxi  b,$2c56
-----------------------------|-------------------------------
0295: CD E0 17   call $17e0  |  0295: 3A 8F 43   ldax $438f
-----------------------------|-------------------------------
02D8: 3A 00 78   ldax $7800  |  02D8: 2C         inr  l
02DB: E6 10      ani  $10    |  02D9: 36 00      mvi  m,$00
02DD: CA E3 02   jz   $02e3  |  02DB: 06 00      mvi  b,$00
02E0: 79         mov  a,c    |  02DD: 2E 8F      mvi  l,$8f
02E1: 07         rlc         |  02DF: CD 36 02   call $0236
02E2: 4F         mov  c,a    |  02E2: 2E 8F      mvi  l,$8f
02E3: 2E 8F      mvi  l,$8f  |  02E4: 11 42 41   lxi  d,$4142
02E5: 7E         mov  a,m    |  02E7: 06 02      mvi  b,$02
02E6: 91         sub  c      |  02E9: CD C4 00   call $00c4
02E7: 77         mov  m,a    |  02EC: C9         ret
02E8: C6 20      adi  $20    |  02ED: FF         rst  7
02EA: 32 42 41   stax $4142  |  
02ED: C9         ret         |  
-----------------------------|-------------------------------
14E0: 47         mov  b,a    |  14E0: FF         rst  7
14E1: 3A 00 78   ldax $7800  |  14E1: FF         rst  7
14E4: E6 10      ani  $10    |  14E2: FF         rst  7
14E6: C8         rz          |  14E3: FF         rst  7
14E7: EB         xchg        |  14E4: FF         rst  7
14E8: 7A         mov  a,d    |  14E5: FF         rst  7
14E9: FE 18      cpi  $18    |  14E6: FF         rst  7
14EB: C0         rnz         |  14E7: FF         rst  7
14EC: 7B         mov  a,e    |  14E8: FF         rst  7
14ED: FE 95      cpi  $95    |  14E9: FF         rst  7
14EF: 36 22      mvi  m,$22  |  14EA: FF         rst  7
14F1: C8         rz          |  14EB: FF         rst  7
14F2: FE 9A      cpi  $9a    |  14EC: FF         rst  7
14F4: 36 13      mvi  m,$13  |  14ED: FF         rst  7
14F6: C8         rz          |  14EE: FF         rst  7
14F7: FE B5      cpi  $b5    |  14EF: FF         rst  7
14F9: 36 24      mvi  m,$24  |  14F0: FF         rst  7
14FB: C8         rz          |  14F1: FF         rst  7
14FC: 70         mov  m,b    |  14F2: FF         rst  7
14FD: C9         ret         |  14F3: FF         rst  7
                             |  14F4: FF         rst  7
                             |  14F5: FF         rst  7
                             |  14F6: FF         rst  7
                             |  14F7: FF         rst  7
                             |  14F8: FF         rst  7
                             |  14F9: FF         rst  7
                             |  14FA: FF         rst  7
                             |  14FB: FF         rst  7
                             |  14FC: FF         rst  7
                             |  14FD: FF         rst  7
-----------------------------|-------------------------------
17E0: 3A 00 78   ldax $7800  |  17E0: FF         rst  7
17E3: E6 10      ani  $10    |  17E1: FF         rst  7
17E5: 3A 8F 43   ldax $438f  |  17E2: FF         rst  7
17E8: C8         rz          |  17E3: FF         rst  7
17E9: 0F         rrc         |  17E4: FF         rst  7
17EA: E6 0F      ani  $0f    |  17E5: FF         rst  7
17EC: C9         ret         |  17E6: FF         rst  7
                             |  17E7: FF         rst  7
                             |  17E8: FF         rst  7
                             |  17E9: FF         rst  7
                             |  17EA: FF         rst  7
                             |  17EB: FF         rst  7
                             |  17EC: FF         rst  7
-----------------------------|-------------------------------
2725: 3A A4 43   ldax $43a4  |  2725: 1A         ldax d
2728: FE 06      cpi  $06    |  2726: A7         ana  a
272A: C2 39 27   jnz  $2739  |  2727: CA 35 27   jz   $2735
272D: 1A         ldax d      |  272A: 47         mov  b,a
272E: 47         mov  b,a    |  272B: 0E 00      mvi  c,$00
272F: 0E 00      mvi  c,$00  |  272D: CD 20 02   call $0220
2731: CD 20 02   call $0220  |  2730: AF         xra  a
2734: AF         xra  a      |  2731: 12         stax d
2735: 12         stax d      |  2732: 32 97 43   stax $4397
2736: 32 97 43   stax $4397  |  2735: 3A 97 43   ldax $4397
2739: 3A 97 43   ldax $4397  |  2738: A7         ana  a
273C: A7         ana  a      |  2739: CC 68 27   cz   $2768
273D: CC 68 27   cz   $2768  |  273C: CD A8 27   call $27a8
2740: CD A8 27   call $27a8  |  273F: C3 10 3A   jmp  $3a10
2743: C3 10 3A   jmp  $3a10  |  2742: C3 BD 27   jmp  $27bd
                             |  2745: FF         rst  7


-