### PR TITLE
Small fixes.

### DIFF
--- a/src/frontend/mame/ui/mainmenu.cpp
+++ b/src/frontend/mame/ui/mainmenu.cpp
@@ -129,7 +129,7 @@ void menu_main::populate()
 		item_append(_("Plugin Options"), "", 0, (void *)PLUGINS);
 
 	// add dats menu
-	if (ui().options().enabled_dats() && mame_machine_manager::instance()->lua()->call_plugin("", "data_list"))
+	if (mame_machine_manager::instance()->lua()->call_plugin("", "data_list"))
 		item_append(_("External DAT View"), "", 0, (void *)EXTERNAL_DATS);
 
 	item_append(menu_item_type::SEPARATOR);

--- a/src/frontend/mame/ui/moptions.cpp
+++ b/src/frontend/mame/ui/moptions.cpp
@@ -44,7 +44,6 @@ const options_entry ui_options::s_option_entries[] =
 
 	// misc options
 	{ nullptr,                              nullptr,    OPTION_HEADER,      "UI MISC OPTIONS" },
-	{ OPTION_DATS_ENABLED,                  "1",        OPTION_BOOLEAN,     "enable DATs support" },
 	{ OPTION_REMEMBER_LAST,                 "1",        OPTION_BOOLEAN,     "reselect in main menu last played game" },
 	{ OPTION_ENLARGE_SNAPS,                 "1",        OPTION_BOOLEAN,     "enlarge arts (snapshot, title, etc...) in right panel (keeping aspect ratio)" },
 	{ OPTION_FORCED4X3,                     "1",        OPTION_BOOLEAN,     "force the appearance of the snapshot in the list software to 4:3" },

--- a/src/frontend/mame/ui/moptions.h
+++ b/src/frontend/mame/ui/moptions.h
@@ -38,7 +38,6 @@
 #define OPTION_UI_PATH                "ui_path"
 
 // core misc options
-#define OPTION_DATS_ENABLED           "dats_enabled"
 #define OPTION_REMEMBER_LAST          "remember_last"
 #define OPTION_ENLARGE_SNAPS          "enlarge_snaps"
 #define OPTION_FORCED4X3              "forced4x3"
@@ -102,7 +101,6 @@ public:
 	const char *ui_path() const { return value(OPTION_UI_PATH); }
 
 	// Misc options
-	bool enabled_dats() const { return bool_value(OPTION_DATS_ENABLED); }
 	bool remember_last() const { return bool_value(OPTION_REMEMBER_LAST); }
 	bool enlarge_snaps() const { return bool_value(OPTION_ENLARGE_SNAPS); }
 	bool forced_4x3_snapshot() const { return bool_value(OPTION_FORCED4X3); }

--- a/src/frontend/mame/ui/selgame.cpp
+++ b/src/frontend/mame/ui/selgame.cpp
@@ -139,11 +139,15 @@ menu_select_game::~menu_select_game()
 	game_driver const *const driver(isfavorite() ? nullptr : reinterpret_cast<game_driver const *>(get_selection_ref()));
 	ui_software_info *const swinfo(isfavorite() ? reinterpret_cast<ui_software_info *>(get_selection_ref()) : nullptr);
 
-	if ((FPTR)driver > skip_main_items)
+	if (reinterpret_cast<FPTR>(driver) > skip_main_items)
 		last_driver = driver->name;
+	else if (driver && m_prev_selected)
+		last_driver = reinterpret_cast<game_driver const *>(m_prev_selected)->name;
 
-	if ((FPTR)swinfo > skip_main_items)
+	if (reinterpret_cast<FPTR>(swinfo) > skip_main_items)
 		last_driver = swinfo->shortname;
+	else if (swinfo && m_prev_selected)
+		last_driver = reinterpret_cast<ui_software_info *>(m_prev_selected)->shortname;
 
 	std::string filter(main_filters::text[main_filters::actual]);
 	if (main_filters::actual == FILTER_MANUFACTURER)
@@ -168,7 +172,6 @@ void menu_select_game::handle()
 		m_prev_selected = item[0].ref;
 
 	bool check_filter = false;
-	bool enabled_dats = ui().options().enabled_dats();
 
 	// if i have to load datfile, performe an hard reset
 	if (ui_globals::reset)
@@ -339,7 +342,7 @@ void menu_select_game::handle()
 			m_search[0] = '\0';
 			reset(reset_options::SELECT_FIRST);
 		}
-		else if (menu_event->iptkey == IPT_UI_DATS && enabled_dats)
+		else if (menu_event->iptkey == IPT_UI_DATS && mame_machine_manager::instance()->lua()->call_plugin("", "data_list"))
 		{
 			// handle UI_DATS
 			if (!isfavorite())
@@ -501,7 +504,7 @@ void menu_select_game::populate()
 	if (!isfavorite())
 	{
 		// if search is not empty, find approximate matches
-		if (m_search[0] != 0 && !isfavorite())
+		if (m_search[0] != 0)
 			populate_search();
 		else
 		{

--- a/src/frontend/mame/ui/selsoft.cpp
+++ b/src/frontend/mame/ui/selsoft.cpp
@@ -242,7 +242,7 @@ void menu_select_software::handle()
 			// handle UI_DOWN_FILTER
 			highlight++;
 		}
-		else if (menu_event->iptkey == IPT_UI_DATS && ui().options().enabled_dats())
+		else if (menu_event->iptkey == IPT_UI_DATS && mame_machine_manager::instance()->lua()->call_plugin("", "data_list"))
 		{
 			// handle UI_DATS
 			ui_software_info *ui_swinfo = (ui_software_info *)menu_event->itemref;

--- a/src/frontend/mame/ui/submenu.cpp
+++ b/src/frontend/mame/ui/submenu.cpp
@@ -22,7 +22,6 @@ std::vector<submenu::option> const submenu::misc_options = {
 	{ submenu::option_type::HEAD, __("Miscellaneous Options") },
 	{ submenu::option_type::UI,   __("Re-select last machine played"),           OPTION_REMEMBER_LAST },
 	{ submenu::option_type::UI,   __("Enlarge images in the right panel"),       OPTION_ENLARGE_SNAPS },
-	{ submenu::option_type::UI,   __("DATs info"),                               OPTION_DATS_ENABLED },
 	{ submenu::option_type::EMU,  __("Cheats"),                                  OPTION_CHEAT },
 	{ submenu::option_type::EMU,  __("Show mouse pointer"),                      OPTION_UI_MOUSE },
 	{ submenu::option_type::EMU,  __("Confirm quit from machines"),              OPTION_CONFIRM_QUIT },


### PR DESCRIPTION
removed enable_dats() option, no longer needed after the switch to lua plugin. (nw)
fixed the failure to select the last used machine if quit with the focus in another part of the main menu. (nw)