### PR TITLE
New Nibbler clone

### DIFF
--- a/src/mame/drivers/snk6502.cpp
+++ b/src/mame/drivers/snk6502.cpp
@@ -1526,6 +1526,32 @@ ROM_START( nibbler6 ) /* revision 6 */
 	ROM_LOAD( "g-0959-45.ic53", 0x1000, 0x0800, CRC(33189917) SHA1(01a1b1693db0172609780daeb60430fa0c8bcec2) )
 ROM_END
 
+ROM_START( nibblera ) /* revision ??? */
+	ROM_REGION( 0x10000, "maincpu", 0 )
+	ROM_LOAD( "2732.ic12", 0x3000, 0x1000, CRC(e569937b) SHA1(6ee9aa528cc3f0685153b3170f41b9a665d358e0) )
+	ROM_LOAD( "2732.ic07", 0x4000, 0x1000, CRC(7f9d715c) SHA1(59fbdbb55dceaa86235911589395fa5243e44afe) )
+	ROM_LOAD( "2732.ic08", 0x5000, 0x1000, CRC(e46eb1c9) SHA1(b70a14085985096eb6650f3d06343a20d75e61b5) )
+	ROM_LOAD( "2732.ic09", 0x6000, 0x1000, CRC(a599df10) SHA1(68ee8b5199ec24409fcbb40c887a1eec44c68dcf) )
+	ROM_LOAD( "2732.ic10", 0x7000, 0x1000, BAD_DUMP CRC(746e94cd) SHA1(284696722857900760d35f1f8ef53290deddac20) )  // FIXED BITS (xxx1xxxx)
+	ROM_LOAD( "2732.ic14", 0x8000, 0x1000, CRC(48ec4af0) SHA1(9b4b80c288d5ade998c0bbcfc3868c9dcd438707) )
+	ROM_RELOAD(                 0xf000, 0x1000 )    /* for the reset and interrupt vectors */
+	ROM_LOAD( "2732.ic15", 0x9000, 0x1000, CRC(7205fb8d) SHA1(bc341bc11a383aa8b8dd7b2be851907a3ec56f8b) )
+	ROM_LOAD( "2732.ic16", 0xa000, 0x1000, CRC(4bb39815) SHA1(1755c28d7d300524ab839aedcc744254544e9c19) )
+	ROM_LOAD( "2732.ic17", 0xb000, 0x1000, CRC(ed680f19) SHA1(b44203585f32ebe2a3bf0597eac7c0faa7e81a92) )
+
+	ROM_REGION( 0x2000, "gfx1", 0 )
+	ROM_LOAD( "2732.ic50", 0x0000, 0x1000, CRC(01d4d0c2) SHA1(5a8026210a872351ce4e39e27f6479d3ca0689e2) )
+	ROM_LOAD( "2732.ic51", 0x1000, 0x1000, CRC(feff7faf) SHA1(50005502578a4ea9b9c8f36998670b787d2d0b20) )
+
+	ROM_REGION( 0x0040, "proms", 0 )
+	ROM_LOAD( "g-0708-05.ic7",  0x0000, 0x0020, CRC(a5709ff3) SHA1(fbd07b756235f2d03aea3d777ca741ade54be200) ) /* foreground colors */
+	ROM_LOAD( "g-0708-04.ic6",  0x0020, 0x0020, CRC(dacd592d) SHA1(c7709c680e2764885a40bc256d07dffc9e827cd6) ) /* background colors */
+
+	ROM_REGION( 0x1800, "snk6502", ROMREGION_ERASEFF )  /* sound ROMs */
+	ROM_LOAD( "2732.ic52", 0x0800, 0x0800, CRC(cabe6c34) SHA1(664ab47555d4c05189d797836f34045f00ac119e) )
+	ROM_LOAD( "2732.ic53", 0x1000, 0x0800, CRC(33189917) SHA1(01a1b1693db0172609780daeb60430fa0c8bcec2) ) // missing in set
+ROM_END
+
 ROM_START( nibblerp ) /* revision 6 + extra soundrom */
 	ROM_REGION( 0x10000, "maincpu", 0 )
 	ROM_LOAD( "ic12",           0x3000, 0x1000, CRC(ac6a802b) SHA1(ac1072e30994f13097663dc24d9d1dc35a95d874) )
@@ -1602,5 +1628,6 @@ GAME( 1982, pballoonr,pballoon, pballoon, pballoon, driver_device, 0, ROT90, "SN
 GAME( 1982, nibbler,  0,        nibbler,  nibbler, driver_device,  0, ROT90, "Rock-Ola", "Nibbler (rev 9)", MACHINE_SUPPORTS_SAVE )
 GAME( 1982, nibbler8, nibbler,  nibbler,  nibbler8, driver_device, 0, ROT90, "Rock-Ola", "Nibbler (rev 8)", MACHINE_SUPPORTS_SAVE )
 GAME( 1982, nibbler6, nibbler,  nibbler,  nibbler6, driver_device, 0, ROT90, "Rock-Ola", "Nibbler (rev 6)", MACHINE_SUPPORTS_SAVE )
+GAME( 1982, nibblera, nibbler,  nibbler,  nibbler, driver_device,  0, ROT90, "Rock-Ola", "Nibbler (rev ?)", MACHINE_SUPPORTS_SAVE )
 GAME( 1982, nibblerp, nibbler,  nibbler,  nibbler6, driver_device, 0, ROT90, "Rock-Ola", "Nibbler (Pioneer Balloon conversion)", MACHINE_SUPPORTS_SAVE )
 GAME( 1983, nibblero, nibbler,  nibbler,  nibbler8, driver_device, 0, ROT90, "Rock-Ola (Olympia license)", "Nibbler (Olympia - rev 8)", MACHINE_SUPPORTS_SAVE )

--- a/src/mame/mame.lst
+++ b/src/mame/mame.lst
@@ -33552,6 +33552,7 @@ fantasyu                        // (c) 1981 Rock-Ola
 nibbler                         // (c) 1982 Rock-ola (version 9)
 nibbler6                        // (c) 1982 Rock-ola (vresion 6)
 nibbler8                        // (c) 1982 Rock-ola (version 8)
+nibblera                        // (c) 1982 Rock-ola (version ?)
 nibblero                        // (c) 1983 Olympia/Rock-Ola (version 8)
 nibblerp                        // (c) 1982 Rock-ola (pballoon conversion)
 pballoon                        // (c) 1982 SNK


### PR DESCRIPTION
New clone added
-----------------------
Nibbler (rev ?) [MASH]

Romset: Nibbler/nibbler.zip (18kb)

IC07        4096  2706  1994-06-14 22:37  7F9D715C
IC08        4096  2579  1994-06-14 22:37  E46EB1C9
IC09        4096  1159  1994-06-14 22:37  A599DF10
IC10        4096  1660  1994-06-14 22:37  E2652C11
IC12        4096  2586  1994-06-14 22:38  E569937B
IC14        4096  1174  1994-06-14 22:38  48EC4AF0
IC15        4096   883  1994-06-14 22:39  7205FB8D
IC16        4096  1705  1994-06-14 22:39  4BB39815
1C17        4096   806  1994-06-14 22:39  ED680F19
IC50        4096   639  1994-06-14 22:41  01D4D0C2
IC51        4096   303  1994-06-14 22:40  FEFF7FAF
IC52        2048   286  1994-06-14 22:40  CABE6C34
README.TXT   643   329  1994-06-14 22:42  B31C0466


First time i start the game, IC10 failed the ROM TEST. I compared it with
rom g-0960-51.ic10 from nibbler.zip and saw that the first 67 bytes have a *bad* bit4.
I replaced them and the ROM TEST shows OK.
I also compared the DASM with all MAME versions and the romset is very
different to the others.


README
========
NIBBLER (Rock-Ola, 1983)

Two smallish PCBs, SK-7A and SK-8A, connected by two 50-pin ribbon cables.
SK-7A is the "top" board (with the 44-pin edge connector and ROMs)
SK-8A is the "bottom" board (no edge connectors, some 2114s)

All ROMs are numbered "ICxx", as marked on the PCBs.

File  Sum   Board (type)
----  ----  -------------
ic07  f24b  Top (2732)
ic08  9d92  Top (2732)
ic09  e21b  Top (2732)
ic10  4b27  Top (2732)
ic12  0fd5  Top (2732)
ic14  473a  Top (2732)
ic15  da5c  Top (2732)
ic16  efae  Top (2732)
ic17  3044  Top (2732)
ic50  5b3f  Bottom (2732)
ic51  8422  Bottom (2732)
ic52  90aa  Top (2716)

-