### PR TITLE
Filter for Hp9845 data files added to imgtool

### DIFF
--- a/src/tools/imgtool/filter.cpp
+++ b/src/tools/imgtool/filter.cpp
@@ -61,6 +61,7 @@ const filter_getinfoproc filters[] =
 	filter_thombas128_getinfo,
 	filter_thomcrypt_getinfo,
 	filter_bml3bas_getinfo,
+        filter_hp9845data_getinfo,
 	nullptr
 };
 

--- a/src/tools/imgtool/filter.h
+++ b/src/tools/imgtool/filter.h
@@ -61,6 +61,6 @@ extern void filter_thombas7_getinfo(UINT32 state, union filterinfo *info);
 extern void filter_thombas128_getinfo(UINT32 state, union filterinfo *info);
 extern void filter_thomcrypt_getinfo(UINT32 state, union filterinfo *info);
 extern void filter_bml3bas_getinfo(UINT32 state, union filterinfo *info);
-
+extern void filter_hp9845data_getinfo(UINT32 state, union filterinfo *info);
 
 #endif /* FILTER_H */

--- a/src/tools/imgtool/stream.cpp
+++ b/src/tools/imgtool/stream.cpp
@@ -266,8 +266,7 @@ UINT32 stream_write(imgtool_stream *s, const void *buf, UINT32 sz)
 				if (s->filesize < s->position + sz)
 				{
 					/* try to expand the buffer */
-					if (s->buffer) free(s->buffer);
-					new_buffer = malloc(s->position + sz);
+					new_buffer = realloc(s->buffer , s->position + sz);
 					if (new_buffer)
 					{
 						s->buffer = (UINT8*)new_buffer;


### PR DESCRIPTION
Hi everyone,

I've just pushed a new filter ("9845data") in imgtool to translate DATA files of HP9845 system to and from text files.
In HP9845 systems DATA files are a kind of files with a generic record-based format. They are used, among other things, to store BASIC programs in text (non-tokenized) form. My filter translates this record-base text into plain text files (and viceversa).
Thanks.
--F.Ulivi