### PR TITLE
Imgtool:  Changed the read_sector apparatus to use std::vector

### DIFF
--- a/src/tools/imgtool/iflopimg.cpp
+++ b/src/tools/imgtool/iflopimg.cpp
@@ -208,7 +208,8 @@ static imgtoolerr_t imgtool_floppy_read_sector(imgtool_image *image, UINT32 trac
 		return imgtool_floppy_error(ferr);
 
 	// resize the buffer accordingly
-	buffer.resize(sector_size);
+	try { buffer.resize(sector_size); }
+	catch (std::bad_alloc& b) { return IMGTOOLERR_OUTOFMEMORY; }
 
 	// and read the sector
 	ferr = floppy_read_sector(imgtool_floppy(image), head, track, sector, 0, &buffer[0], sector_size);

--- a/src/tools/imgtool/iflopimg.cpp
+++ b/src/tools/imgtool/iflopimg.cpp
@@ -118,7 +118,7 @@ static imgtoolerr_t imgtool_floppy_open_internal(imgtool_image *image, imgtool_s
 
 	/* open up the floppy */
 	ferr = floppy_open(f, noclose ? &imgtool_noclose_ioprocs : &imgtool_ioprocs,
-		nullptr, format, FLOPPY_FLAGS_READWRITE, &fimg->floppy);
+		"", format, FLOPPY_FLAGS_READWRITE, &fimg->floppy);
 	if (ferr)
 	{
 		err = imgtool_floppy_error(ferr);
@@ -197,24 +197,21 @@ static void imgtool_floppy_close(imgtool_image *img)
 
 
 
-static imgtoolerr_t imgtool_floppy_get_sector_size(imgtool_image *image, UINT32 track, UINT32 head, UINT32 sector, UINT32 *sector_size)
+static imgtoolerr_t imgtool_floppy_read_sector(imgtool_image *image, UINT32 track, UINT32 head, UINT32 sector, std::vector<UINT8> &buffer)
 {
 	floperr_t ferr;
+	UINT32 sector_size;
 
-	ferr = floppy_get_sector_length(imgtool_floppy(image), head, track, sector, sector_size);
+	// get the sector length
+	ferr = floppy_get_sector_length(imgtool_floppy(image), head, track, sector, &sector_size);
 	if (ferr)
 		return imgtool_floppy_error(ferr);
 
-	return IMGTOOLERR_SUCCESS;
-}
+	// resize the buffer accordingly
+	buffer.resize(sector_size);
 
-
-
-static imgtoolerr_t imgtool_floppy_read_sector(imgtool_image *image, UINT32 track, UINT32 head, UINT32 sector, void *buffer, size_t len)
-{
-	floperr_t ferr;
-
-	ferr = floppy_read_sector(imgtool_floppy(image), head, track, sector, 0, buffer, len);
+	// and read the sector
+	ferr = floppy_read_sector(imgtool_floppy(image), head, track, sector, 0, &buffer[0], sector_size);
 	if (ferr)
 		return imgtool_floppy_error(ferr);
 
@@ -270,7 +267,6 @@ static void imgtool_floppy_get_info(const imgtool_class *imgclass, UINT32 state,
 		case IMGTOOLINFO_PTR_CREATE:                info->create = imgtool_floppy_create; break;
 		case IMGTOOLINFO_PTR_CLOSE:                 info->close = imgtool_floppy_close; break;
 		case IMGTOOLINFO_PTR_CREATEIMAGE_OPTGUIDE:  info->createimage_optguide = format->param_guidelines ? &floppy_option_guide : nullptr; break;
-		case IMGTOOLINFO_PTR_GET_SECTOR_SIZE:       info->get_sector_size = imgtool_floppy_get_sector_size; break;
 		case IMGTOOLINFO_PTR_READ_SECTOR:           info->read_sector = imgtool_floppy_read_sector; break;
 		case IMGTOOLINFO_PTR_WRITE_SECTOR:          info->write_sector = imgtool_floppy_write_sector; break;
 

--- a/src/tools/imgtool/iflopimg.cpp
+++ b/src/tools/imgtool/iflopimg.cpp
@@ -209,7 +209,7 @@ static imgtoolerr_t imgtool_floppy_read_sector(imgtool_image *image, UINT32 trac
 
 	// resize the buffer accordingly
 	try { buffer.resize(sector_size); }
-	catch (std::bad_alloc& b) { return IMGTOOLERR_OUTOFMEMORY; }
+	catch (std::bad_alloc const &) { return IMGTOOLERR_OUTOFMEMORY; }
 
 	// and read the sector
 	ferr = floppy_read_sector(imgtool_floppy(image), head, track, sector, 0, &buffer[0], sector_size);

--- a/src/tools/imgtool/imgtool.cpp
+++ b/src/tools/imgtool/imgtool.cpp
@@ -462,23 +462,6 @@ done:
 
 
 /*-------------------------------------------------
-    imgtool_image_get_sector_size - gets the size
-    of a particular sector on an image
--------------------------------------------------*/
-
-imgtoolerr_t imgtool_image_get_sector_size(imgtool_image *image, UINT32 track, UINT32 head,
-	UINT32 sector, UINT32 *length)
-{
-	/* implemented? */
-	if (!image->module->get_sector_size)
-		return (imgtoolerr_t )(IMGTOOLERR_UNIMPLEMENTED | IMGTOOLERR_SRC_FUNCTIONALITY);
-
-	return image->module->get_sector_size(image, track, head, sector, length);
-}
-
-
-
-/*-------------------------------------------------
     imgtool_image_get_geometry - gets the geometry
     of an image; note that this may disagree with
     particular sectors; this is a common copy
@@ -514,13 +497,13 @@ imgtoolerr_t imgtool_image_get_geometry(imgtool_image *image, UINT32 *tracks, UI
 -------------------------------------------------*/
 
 imgtoolerr_t imgtool_image_read_sector(imgtool_image *image, UINT32 track, UINT32 head,
-	UINT32 sector, void *buffer, size_t len)
+	UINT32 sector, std::vector<UINT8> &buffer)
 {
 	/* implemented? */
 	if (!image->module->read_sector)
 		return (imgtoolerr_t)(IMGTOOLERR_UNIMPLEMENTED | IMGTOOLERR_SRC_FUNCTIONALITY);
 
-	return image->module->read_sector(image, track, head, sector, buffer, len);
+	return image->module->read_sector(image, track, head, sector, buffer);
 }
 
 
@@ -990,18 +973,6 @@ int imgtool_validitychecks(void)
 			}
 		}
 #endif
-
-		/* sanity checks on sector operations */
-		if (module->read_sector && !module->get_sector_size)
-		{
-			printf("imgtool module %s implements read_sector without supporting get_sector_size\n", module->name);
-			error = 1;
-		}
-		if (module->write_sector && !module->get_sector_size)
-		{
-			printf("imgtool module %s implements write_sector without supporting get_sector_size\n", module->name);
-			error = 1;
-		}
 
 		/* sanity checks on creation options */
 		if (module->createimage_optguide || module->createimage_optspec)

--- a/src/tools/imgtool/imgtool.h
+++ b/src/tools/imgtool/imgtool.h
@@ -94,9 +94,8 @@ imgtoolerr_t imgtool_image_create(const imgtool_module *module, const char *fnam
 imgtoolerr_t imgtool_image_create_byname(const char *modulename, const char *fname, util::option_resolution *opts, imgtool_image **image);
 void imgtool_image_close(imgtool_image *image);
 imgtoolerr_t imgtool_image_info(imgtool_image *image, char *string, size_t len);
-imgtoolerr_t imgtool_image_get_sector_size(imgtool_image *image, UINT32 track, UINT32 head, UINT32 sector, UINT32 *length);
 imgtoolerr_t imgtool_image_get_geometry(imgtool_image *image, UINT32 *tracks, UINT32 *heads, UINT32 *sectors);
-imgtoolerr_t imgtool_image_read_sector(imgtool_image *image, UINT32 track, UINT32 head, UINT32 sector, void *buffer, size_t len);
+imgtoolerr_t imgtool_image_read_sector(imgtool_image *image, UINT32 track, UINT32 head, UINT32 sector, std::vector<UINT8> &buffer);
 imgtoolerr_t imgtool_image_write_sector(imgtool_image *image, UINT32 track, UINT32 head, UINT32 sector, const void *buffer, size_t len);
 imgtoolerr_t imgtool_image_get_block_size(imgtool_image *image, UINT32 *length);
 imgtoolerr_t imgtool_image_read_block(imgtool_image *image, UINT64 block, void *buffer);

--- a/src/tools/imgtool/library.cpp
+++ b/src/tools/imgtool/library.cpp
@@ -73,10 +73,9 @@ void library::add_class(const imgtool_class *imgclass)
 	module->create                      = (imgtoolerr_t (*)(imgtool_image *, imgtool_stream *, util::option_resolution *)) imgtool_get_info_fct(imgclass, IMGTOOLINFO_PTR_CREATE);
 	module->close                       = (void (*)(imgtool_image *)) imgtool_get_info_fct(imgclass, IMGTOOLINFO_PTR_CLOSE);
 	module->info                        = (void (*)(imgtool_image *, char *, size_t)) imgtool_get_info_fct(imgclass, IMGTOOLINFO_PTR_INFO);
-	module->read_sector                 = (imgtoolerr_t (*)(imgtool_image *, UINT32, UINT32, UINT32, void *, size_t)) imgtool_get_info_fct(imgclass, IMGTOOLINFO_PTR_READ_SECTOR);
+	module->read_sector                 = (imgtoolerr_t (*)(imgtool_image *, UINT32, UINT32, UINT32, std::vector<UINT8> &)) imgtool_get_info_fct(imgclass, IMGTOOLINFO_PTR_READ_SECTOR);
 	module->write_sector                = (imgtoolerr_t (*)(imgtool_image *, UINT32, UINT32, UINT32, const void *, size_t)) imgtool_get_info_fct(imgclass, IMGTOOLINFO_PTR_WRITE_SECTOR);
 	module->get_geometry                = (imgtoolerr_t (*)(imgtool_image *, UINT32 *, UINT32 *, UINT32 *))imgtool_get_info_fct(imgclass, IMGTOOLINFO_PTR_GET_GEOMETRY);
-	module->get_sector_size             = (imgtoolerr_t (*)(imgtool_image *, UINT32, UINT32, UINT32, UINT32 *))imgtool_get_info_fct(imgclass, IMGTOOLINFO_PTR_GET_SECTOR_SIZE);
 	module->read_block                  = (imgtoolerr_t (*)(imgtool_image *, void *, UINT64)) imgtool_get_info_fct(imgclass, IMGTOOLINFO_PTR_READ_BLOCK);
 	module->write_block                 = (imgtoolerr_t (*)(imgtool_image *, const void *, UINT64)) imgtool_get_info_fct(imgclass, IMGTOOLINFO_PTR_WRITE_BLOCK);
 	module->list_partitions             = (imgtoolerr_t (*)(imgtool_image *, imgtool_partition_info *, size_t)) imgtool_get_info_fct(imgclass, IMGTOOLINFO_PTR_LIST_PARTITIONS);

--- a/src/tools/imgtool/library.h
+++ b/src/tools/imgtool/library.h
@@ -193,7 +193,6 @@ enum
 	IMGTOOLINFO_PTR_GET_ICON_INFO,
 	IMGTOOLINFO_PTR_SUGGEST_TRANSFER,
 	IMGTOOLINFO_PTR_GET_CHAIN,
-	IMGTOOLINFO_PTR_GET_SECTOR_SIZE,
 	IMGTOOLINFO_PTR_GET_GEOMETRY,
 	IMGTOOLINFO_PTR_READ_SECTOR,
 	IMGTOOLINFO_PTR_WRITE_SECTOR,
@@ -276,9 +275,8 @@ union imgtoolinfo
 	imgtoolerr_t    (*get_iconinfo)     (imgtool_partition *partition, const char *path, imgtool_iconinfo *iconinfo);
 	imgtoolerr_t    (*suggest_transfer) (imgtool_partition *partition, const char *path, imgtool_transfer_suggestion *suggestions, size_t suggestions_length);
 	imgtoolerr_t    (*get_chain)        (imgtool_partition *partition, const char *path, imgtool_chainent *chain, size_t chain_size);
-	imgtoolerr_t    (*get_sector_size)  (imgtool_image *image, UINT32 track, UINT32 head, UINT32 sector, UINT32 *sector_size);
 	imgtoolerr_t    (*get_geometry)     (imgtool_image *image, UINT32 *tracks, UINT32 *heads, UINT32 *sectors);
-	imgtoolerr_t    (*read_sector)      (imgtool_image *image, UINT32 track, UINT32 head, UINT32 sector, void *buffer, size_t len);
+	imgtoolerr_t    (*read_sector)      (imgtool_image *image, UINT32 track, UINT32 head, UINT32 sector, std::vector<UINT8> &buffer);
 	imgtoolerr_t    (*write_sector)     (imgtool_image *image, UINT32 track, UINT32 head, UINT32 sector, const void *buffer, size_t len, int ddam);
 	imgtoolerr_t    (*read_block)       (imgtool_image *image, void *buffer, UINT64 block);
 	imgtoolerr_t    (*write_block)      (imgtool_image *image, const void *buffer, UINT64 block);
@@ -351,9 +349,8 @@ struct imgtool_module
 	void            (*close)        (imgtool_image *image);
 	void            (*info)         (imgtool_image *image, char *string, size_t len);
 	imgtoolerr_t    (*create)       (imgtool_image *image, imgtool_stream *f, util::option_resolution *opts);
-	imgtoolerr_t    (*get_sector_size)(imgtool_image *image, UINT32 track, UINT32 head, UINT32 sector, UINT32 *sector_size);
 	imgtoolerr_t    (*get_geometry) (imgtool_image *image, UINT32 *track, UINT32 *heads, UINT32 *sectors);
-	imgtoolerr_t    (*read_sector)  (imgtool_image *image, UINT32 track, UINT32 head, UINT32 sector, void *buffer, size_t len);
+	imgtoolerr_t    (*read_sector)  (imgtool_image *image, UINT32 track, UINT32 head, UINT32 sector, std::vector<UINT8> &buffer);
 	imgtoolerr_t    (*write_sector) (imgtool_image *image, UINT32 track, UINT32 head, UINT32 sector, const void *buffer, size_t len);
 	imgtoolerr_t    (*read_block)   (imgtool_image *image, void *buffer, UINT64 block);
 	imgtoolerr_t    (*write_block)  (imgtool_image *image, const void *buffer, UINT64 block);

--- a/src/tools/imgtool/main.cpp
+++ b/src/tools/imgtool/main.cpp
@@ -619,8 +619,8 @@ static int cmd_readsector(const struct command *c, int argc, char *argv[])
 	imgtoolerr_t err;
 	imgtool_image *img;
 	imgtool_stream *stream = nullptr;
-	dynamic_buffer buffer;
-	UINT32 size, track, head, sector;
+	std::vector<UINT8> buffer;
+	UINT32 track, head, sector;
 
 	/* attempt to open image */
 	err = imgtool_image_open_byname(argv[0], argv[1], OSD_FOPEN_READ, &img);
@@ -631,16 +631,9 @@ static int cmd_readsector(const struct command *c, int argc, char *argv[])
 	head = atoi(argv[3]);
 	sector = atoi(argv[4]);
 
-	err = imgtool_image_get_sector_size(img, track, head, sector, &size);
+	err = imgtool_image_read_sector(img, track, head, sector, buffer);
 	if (err)
 		goto done;
-
-	buffer.resize(size);
-
-	err = imgtool_image_read_sector(img, track, head, sector, &buffer[0], size);
-	if (err)
-		goto done;
-
 
 	stream = stream_open(argv[5], OSD_FOPEN_WRITE);
 	if (!stream)
@@ -649,7 +642,7 @@ static int cmd_readsector(const struct command *c, int argc, char *argv[])
 		goto done;
 	}
 
-	stream_write(stream, &buffer[0], size);
+	stream_write(stream, &buffer[0], buffer.size());
 
 done:
 	if (stream)

--- a/src/tools/imgtool/modules/amiga.cpp
+++ b/src/tools/imgtool/modules/amiga.cpp
@@ -1818,7 +1818,9 @@ static imgtoolerr_t amiga_image_read_sector(imgtool_image* img, UINT32 track, UI
 static imgtoolerr_t amiga_image_read_sector(imgtool_image* img,
 	UINT32 track, UINT32 head, UINT32 sector, std::vector<UINT8> &buffer)
 {
-	buffer.resize(BSIZE);
+	try { buffer.resize(BSIZE); }
+	catch (std::bad_alloc& b) { return IMGTOOLERR_OUTOFMEMORY; }
+
 	return amiga_image_read_sector(img, track, head, sector, &buffer[0], buffer.size());
 }
 

--- a/src/tools/imgtool/modules/amiga.cpp
+++ b/src/tools/imgtool/modules/amiga.cpp
@@ -232,6 +232,8 @@ struct amiga_iterator
 
 static imgtoolerr_t amiga_image_read_sector(imgtool_image* img,
 	UINT32 track, UINT32 head, UINT32 sector, void *buf, size_t len);
+static imgtoolerr_t amiga_image_read_sector(imgtool_image* img,
+	UINT32 track, UINT32 head, UINT32 sector, std::vector<UINT8> &buffer);
 static imgtoolerr_t amiga_image_write_sector(imgtool_image* img,
 	UINT32 track, UINT32 head, UINT32 sector, const void *buf, size_t len, int ddam);
 
@@ -1813,6 +1815,14 @@ static imgtoolerr_t amiga_image_read_sector(imgtool_image* img, UINT32 track, UI
 }
 
 
+static imgtoolerr_t amiga_image_read_sector(imgtool_image* img,
+	UINT32 track, UINT32 head, UINT32 sector, std::vector<UINT8> &buffer)
+{
+	buffer.resize(BSIZE);
+	return amiga_image_read_sector(img, track, head, sector, &buffer[0], buffer.size());
+}
+
+
 static imgtoolerr_t amiga_image_write_sector(imgtool_image* img, UINT32 track, UINT32 head, UINT32 sector, const void *buf, size_t len, int ddam)
 {
 	amiga_floppy *f = (amiga_floppy *) imgtool_image_extra_bytes(img);
@@ -1829,13 +1839,6 @@ static imgtoolerr_t amiga_image_write_sector(imgtool_image* img, UINT32 track, U
 	/* reset stream */
 	stream_seek(f->stream, 0, 0);
 
-	return IMGTOOLERR_SUCCESS;
-}
-
-
-static imgtoolerr_t amiga_image_get_sector_size(imgtool_image* img, UINT32 track, UINT32 head, UINT32 sector, UINT32 *sector_size)
-{
-	*sector_size = BSIZE;
 	return IMGTOOLERR_SUCCESS;
 }
 
@@ -2391,7 +2394,6 @@ void amiga_floppy_get_info(const imgtool_class *imgclass, UINT32 state, union im
 		case IMGTOOLINFO_PTR_CLOSE:                      info->close = amiga_image_exit; break;
 		case IMGTOOLINFO_PTR_READ_SECTOR:                info->read_sector = amiga_image_read_sector; break;
 		case IMGTOOLINFO_PTR_WRITE_SECTOR:               info->write_sector = amiga_image_write_sector; break;
-		case IMGTOOLINFO_PTR_GET_SECTOR_SIZE:            info->get_sector_size = amiga_image_get_sector_size; break;
 		case IMGTOOLINFO_PTR_CREATE:                     info->create = amiga_image_create; break;
 		case IMGTOOLINFO_PTR_INFO:                       info->info = amiga_image_info; break;
 		case IMGTOOLINFO_PTR_BEGIN_ENUM:                 info->begin_enum = amiga_image_beginenum; break;

--- a/src/tools/imgtool/modules/amiga.cpp
+++ b/src/tools/imgtool/modules/amiga.cpp
@@ -1819,7 +1819,7 @@ static imgtoolerr_t amiga_image_read_sector(imgtool_image* img,
 	UINT32 track, UINT32 head, UINT32 sector, std::vector<UINT8> &buffer)
 {
 	try { buffer.resize(BSIZE); }
-	catch (std::bad_alloc& b) { return IMGTOOLERR_OUTOFMEMORY; }
+	catch (std::bad_alloc const &) { return IMGTOOLERR_OUTOFMEMORY; }
 
 	return amiga_image_read_sector(img, track, head, sector, &buffer[0], buffer.size());
 }

--- a/src/tools/imgtool/modules/pc_hard.cpp
+++ b/src/tools/imgtool/modules/pc_hard.cpp
@@ -324,16 +324,6 @@ static imgtoolerr_t pc_chd_image_get_geometry(imgtool_image *image, UINT32 *trac
 
 
 
-static imgtoolerr_t pc_chd_image_getsectorsize(imgtool_image *image, UINT32 track, UINT32 head, UINT32 sector, UINT32 *sector_size)
-{
-	pc_chd_image_info *info;
-	info = pc_chd_get_image_info(image);
-	*sector_size = imghd_get_header(&info->hard_disk)->sectorbytes;
-	return IMGTOOLERR_SUCCESS;
-}
-
-
-
 static UINT32 pc_chd_calc_lbasector(pc_chd_image_info *info, UINT32 track, UINT32 head, UINT32 sector)
 {
 	UINT32 lbasector;
@@ -350,13 +340,18 @@ static UINT32 pc_chd_calc_lbasector(pc_chd_image_info *info, UINT32 track, UINT3
 
 
 
-static imgtoolerr_t pc_chd_image_readsector(imgtool_image *image, UINT32 track, UINT32 head, UINT32 sector, void *buffer, size_t len)
+static imgtoolerr_t pc_chd_image_readsector(imgtool_image *image, UINT32 track, UINT32 head, UINT32 sector, std::vector<UINT8> &buffer)
 {
-	pc_chd_image_info *info;
-	info = pc_chd_get_image_info(image);
+	pc_chd_image_info *info = pc_chd_get_image_info(image);
+
+	// get the sector size and resize the buffer
+	UINT32 sector_size = imghd_get_header(&info->hard_disk)->sectorbytes;
+	buffer.resize(sector_size);
+
+	// read the data
 	return imghd_read(&info->hard_disk,
 		pc_chd_calc_lbasector(info, track, head, sector),
-		buffer);
+		&buffer[0]);
 }
 
 
@@ -462,7 +457,6 @@ void pc_chd_get_info(const imgtool_class *imgclass, UINT32 state, union imgtooli
 		case IMGTOOLINFO_PTR_WRITE_SECTOR:                  info->write_sector = pc_chd_image_writesector; break;
 		case IMGTOOLINFO_PTR_READ_BLOCK:                    info->read_block = pc_chd_image_readblock; break;
 		case IMGTOOLINFO_PTR_WRITE_BLOCK:                   info->write_block = pc_chd_image_writeblock; break;
-		case IMGTOOLINFO_PTR_GET_SECTOR_SIZE:               info->get_sector_size = pc_chd_image_getsectorsize; break;
 		case IMGTOOLINFO_PTR_CREATEIMAGE_OPTGUIDE:          info->createimage_optguide = &pc_chd_create_optionguide; break;
 		case IMGTOOLINFO_PTR_GET_GEOMETRY:                  info->get_geometry = pc_chd_image_get_geometry; break;
 		case IMGTOOLINFO_PTR_LIST_PARTITIONS:               info->list_partitions = pc_chd_list_partitions; break;

--- a/src/tools/imgtool/modules/pc_hard.cpp
+++ b/src/tools/imgtool/modules/pc_hard.cpp
@@ -347,7 +347,7 @@ static imgtoolerr_t pc_chd_image_readsector(imgtool_image *image, UINT32 track, 
 	// get the sector size and resize the buffer
 	UINT32 sector_size = imghd_get_header(&info->hard_disk)->sectorbytes;
 	try { buffer.resize(sector_size); }
-	catch (std::bad_alloc& b) { return IMGTOOLERR_OUTOFMEMORY; }
+	catch (std::bad_alloc const &) { return IMGTOOLERR_OUTOFMEMORY; }
 
 	// read the data
 	return imghd_read(&info->hard_disk,

--- a/src/tools/imgtool/modules/pc_hard.cpp
+++ b/src/tools/imgtool/modules/pc_hard.cpp
@@ -346,7 +346,8 @@ static imgtoolerr_t pc_chd_image_readsector(imgtool_image *image, UINT32 track, 
 
 	// get the sector size and resize the buffer
 	UINT32 sector_size = imghd_get_header(&info->hard_disk)->sectorbytes;
-	buffer.resize(sector_size);
+	try { buffer.resize(sector_size); }
+	catch (std::bad_alloc& b) { return IMGTOOLERR_OUTOFMEMORY; }
 
 	// read the data
 	return imghd_read(&info->hard_disk,

--- a/src/tools/imgtool/modules/thomson.cpp
+++ b/src/tools/imgtool/modules/thomson.cpp
@@ -812,7 +812,7 @@ static imgtoolerr_t thom_read_sector(imgtool_image* img, UINT32 track,
 
 	// resize the buffer
 	try { buffer.resize(f->sector_size); }
-	catch (std::bad_alloc& b) { return IMGTOOLERR_OUTOFMEMORY; }
+	catch (std::bad_alloc const &) { return IMGTOOLERR_OUTOFMEMORY; }
 
 	memcpy( &buffer[0], thom_get_sector( f, head, track, sector ), f->sector_size);
 	return IMGTOOLERR_SUCCESS;

--- a/src/tools/imgtool/modules/thomson.cpp
+++ b/src/tools/imgtool/modules/thomson.cpp
@@ -793,20 +793,6 @@ static void thom_put_file(thom_floppy* f, unsigned head,
 
 /********************** module functions ***********************/
 
-static imgtoolerr_t thom_get_sector_size(imgtool_image* img, UINT32 track,
-						UINT32 head, UINT32 sector,
-						UINT32 *sector_size)
-{
-	thom_floppy* f = (thom_floppy*) imgtool_image_extra_bytes( img );
-
-	if ( head >= f->heads || sector < 1 || sector > 16 || track >= f->tracks ) {
-	if ( sector_size ) *sector_size = 0;
-	return IMGTOOLERR_SEEKERROR;
-	}
-	if ( sector_size ) *sector_size = f->sector_size;
-	return IMGTOOLERR_SUCCESS;
-}
-
 static imgtoolerr_t thom_get_geometry(imgtool_image* img, UINT32* tracks,
 						UINT32* heads, UINT32* sectors)
 {
@@ -818,14 +804,16 @@ static imgtoolerr_t thom_get_geometry(imgtool_image* img, UINT32* tracks,
 }
 
 static imgtoolerr_t thom_read_sector(imgtool_image* img, UINT32 track,
-						UINT32 head, UINT32 sector, void *buf,
-						size_t len)
+						UINT32 head, UINT32 sector, std::vector<UINT8> &buffer)
 {
 	thom_floppy* f = (thom_floppy*) imgtool_image_extra_bytes( img );
 	if ( head >= f->heads || sector < 1 || sector > 16 || track >= f->tracks )
-	return IMGTOOLERR_SEEKERROR;
-	if ( len > f->sector_size) return IMGTOOLERR_READERROR;
-	memcpy( buf, thom_get_sector( f, head, track, sector ), len );
+		return IMGTOOLERR_SEEKERROR;
+
+	// resize the buffer
+	buffer.resize(f->sector_size);
+
+	memcpy( &buffer[0], thom_get_sector( f, head, track, sector ), f->sector_size);
 	return IMGTOOLERR_SUCCESS;
 }
 
@@ -1590,8 +1578,6 @@ static void thom_basic_get_info(const imgtool_class *clas,
 	info->delete_file = thom_delete_file; break;
 	case IMGTOOLINFO_PTR_FREE_SPACE:
 	info->free_space = thom_free_space; break;
-	case IMGTOOLINFO_PTR_GET_SECTOR_SIZE:
-	info->get_sector_size = thom_get_sector_size; break;
 	case IMGTOOLINFO_PTR_GET_GEOMETRY:
 	info->get_geometry = thom_get_geometry; break;
 	case IMGTOOLINFO_PTR_INFO:

--- a/src/tools/imgtool/modules/thomson.cpp
+++ b/src/tools/imgtool/modules/thomson.cpp
@@ -811,7 +811,8 @@ static imgtoolerr_t thom_read_sector(imgtool_image* img, UINT32 track,
 		return IMGTOOLERR_SEEKERROR;
 
 	// resize the buffer
-	buffer.resize(f->sector_size);
+	try { buffer.resize(f->sector_size); }
+	catch (std::bad_alloc& b) { return IMGTOOLERR_OUTOFMEMORY; }
 
 	memcpy( &buffer[0], thom_get_sector( f, head, track, sector ), f->sector_size);
 	return IMGTOOLERR_SUCCESS;


### PR DESCRIPTION
This also eliminated the need for get_sector_size

The asute reviewer will note that a side effect of this change is that in scenarios where we once returned IMGTOOLERR_OUTOFMEMORY, we now throw std::bad_alloc.  This is deliberate.  Having an error code for out of memory conditions no longer makes sense with MAME's embrace of the C++ way of doing things.  It is highly likely that I will follow up this change with one that eliminates IMGTOOLERR_OUTOFMEMORY in favor of throwing std::bad_alloc.

This commit also fixes a recent regression in which we passed nullptr to an std::string ctor