### PR TITLE
Changed win_get_window_text_utf8() to return std::string

### DIFF
--- a/src/osd/modules/debugger/win/consolewininfo.cpp
+++ b/src/osd/modules/debugger/win/consolewininfo.cpp
@@ -99,11 +99,9 @@ void consolewin_info::set_cpu(device_t &device)
 	m_views[1]->set_source_for_device(device);
 
 	// then update the caption
-	char curtitle[256];
-
 	std::string title = string_format("Debug: %s - %s '%s'", device.machine().system().name, device.name(), device.tag());
-	win_get_window_text_utf8(window(), curtitle, ARRAY_LENGTH(curtitle));
-	if (title.compare(curtitle) != 0)
+	std::string curtitle = win_get_window_text_utf8(window());
+	if (title != curtitle)
 		win_set_window_text_utf8(window(), title.c_str());
 
 	// and recompute the children

--- a/src/osd/windows/winutf8.h
+++ b/src/osd/windows/winutf8.h
@@ -17,7 +17,7 @@ void win_output_debug_string_utf8(const char *string);
 // wrappers for user32.dll
 int win_message_box_utf8(HWND window, const char *text, const char *caption, UINT type);
 BOOL win_set_window_text_utf8(HWND window, const char *text);
-int win_get_window_text_utf8(HWND window, char *buffer, size_t buffer_size);
+std::string win_get_window_text_utf8(HWND window);
 HWND win_create_window_ex_utf8(DWORD exstyle, const char* classname, const char* windowname, DWORD style,
 								int x, int y, int width, int height, HWND wndparent, HMENU menu,
 								HINSTANCE instance, void* param);


### PR DESCRIPTION
This eliminated an unnecessary conversion step.

Also, I have no idea what this WINAPI_FAMILY_PARTITION(WINAPI_PARTITION_DESKTOP) stuff is; it is hard to understand how it could possibly be correct because it ignores the 'window' parameter