### PR TITLE
Remove 2nd joystick from omv1000

### DIFF
--- a/src/mame/drivers/sg1000.cpp
+++ b/src/mame/drivers/sg1000.cpp
@@ -691,7 +691,7 @@ ROM_END
     SYSTEM DRIVERS
 ***************************************************************************/
 
-/*    YEAR  NAME        PARENT      COMPAT      MACHINE     INPUT    INIT                       COMPANY             FULLNAME                                    FLAGS */
+/*    YEAR  NAME        PARENT      COMPAT      MACHINE     INPUT                     INIT      COMPANY             FULLNAME                                    FLAGS */
 CONS( 1983, sg1000,     0,          0,          sg1000,     sg1000,  driver_device,     0,      "Sega",             "SG-1000",                                  MACHINE_SUPPORTS_SAVE )
 CONS( 1984, sg1000m2,   sg1000,     0,          sc3000,     sc3000,  driver_device,     0,      "Sega",             "SG-1000 II",                               MACHINE_SUPPORTS_SAVE )
 COMP( 1983, sc3000,     0,          sg1000,     sc3000,     sc3000,  driver_device,     0,      "Sega",             "SC-3000",                                  MACHINE_SUPPORTS_SAVE )

--- a/src/mame/drivers/sg1000.cpp
+++ b/src/mame/drivers/sg1000.cpp
@@ -268,7 +268,7 @@ INPUT_PORTS_END
     INPUT_PORTS( omv )
 -------------------------------------------------*/
 
-static INPUT_PORTS_START( omv )
+static INPUT_PORTS_START( omv1000 )
 	PORT_START("C0")
 	PORT_BIT( 0x01, IP_ACTIVE_LOW, IPT_KEYPAD ) PORT_CODE(KEYCODE_1) PORT_CHAR('1')
 	PORT_BIT( 0x02, IP_ACTIVE_LOW, IPT_KEYPAD ) PORT_CODE(KEYCODE_2) PORT_CHAR('2')
@@ -309,7 +309,16 @@ static INPUT_PORTS_START( omv )
 	PORT_BIT( 0x40, IP_ACTIVE_LOW, IPT_JOYSTICK_UP ) PORT_PLAYER(2)
 	PORT_BIT( 0x80, IP_ACTIVE_LOW, IPT_JOYSTICK_DOWN ) PORT_PLAYER(2)
 
+	// The OMV FG-1000 has no 2nd joystick
+	// http://www.famitsu.com/image/29819/pEllnbNQfCJ58skZ25uB511N6eSFfAu6.jpg
 	PORT_START("C5")
+	PORT_BIT( 0xff, IP_ACTIVE_LOW, IPT_UNUSED )
+INPUT_PORTS_END
+
+static INPUT_PORTS_START( omv2000 )
+	PORT_INCLUDE( omv1000 )
+
+	PORT_MODIFY("C5")
 	PORT_BIT( 0x01, IP_ACTIVE_LOW, IPT_JOYSTICK_LEFT ) PORT_PLAYER(2)
 	PORT_BIT( 0x02, IP_ACTIVE_LOW, IPT_JOYSTICK_RIGHT ) PORT_PLAYER(2)
 	PORT_BIT( 0x04, IP_ACTIVE_LOW, IPT_BUTTON1 ) PORT_PLAYER(2)
@@ -682,11 +691,11 @@ ROM_END
     SYSTEM DRIVERS
 ***************************************************************************/
 
-/*    YEAR  NAME        PARENT      COMPAT      MACHINE     INPUT       INIT    COMPANY             FULLNAME                                    FLAGS */
-CONS( 1983, sg1000,     0,          0,          sg1000,     sg1000, driver_device,     0,      "Sega",             "SG-1000",                                  MACHINE_SUPPORTS_SAVE )
-CONS( 1984, sg1000m2,   sg1000,     0,          sc3000,     sc3000, driver_device,     0,      "Sega",             "SG-1000 II",                               MACHINE_SUPPORTS_SAVE )
-COMP( 1983, sc3000,     0,          sg1000,     sc3000,     sc3000, driver_device,     0,      "Sega",             "SC-3000",                                  MACHINE_SUPPORTS_SAVE )
-COMP( 1983, sc3000h,    sc3000,     0,          sc3000,     sc3000, driver_device,     0,      "Sega",             "SC-3000H",                                 MACHINE_SUPPORTS_SAVE )
-COMP( 1983, sf7000,     sc3000,     0,          sf7000,     sf7000, driver_device,     0,      "Sega",             "SC-3000/Super Control Station SF-7000",    MACHINE_SUPPORTS_SAVE )
-CONS( 1984, omv1000,    sg1000,     0,          omv,        omv,    driver_device,     0,      "Tsukuda Original", "Othello Multivision FG-1000",              MACHINE_SUPPORTS_SAVE )
-CONS( 1984, omv2000,    sg1000,     0,          omv,        omv,    driver_device,     0,      "Tsukuda Original", "Othello Multivision FG-2000",              MACHINE_SUPPORTS_SAVE )
+/*    YEAR  NAME        PARENT      COMPAT      MACHINE     INPUT    INIT                       COMPANY             FULLNAME                                    FLAGS */
+CONS( 1983, sg1000,     0,          0,          sg1000,     sg1000,  driver_device,     0,      "Sega",             "SG-1000",                                  MACHINE_SUPPORTS_SAVE )
+CONS( 1984, sg1000m2,   sg1000,     0,          sc3000,     sc3000,  driver_device,     0,      "Sega",             "SG-1000 II",                               MACHINE_SUPPORTS_SAVE )
+COMP( 1983, sc3000,     0,          sg1000,     sc3000,     sc3000,  driver_device,     0,      "Sega",             "SC-3000",                                  MACHINE_SUPPORTS_SAVE )
+COMP( 1983, sc3000h,    sc3000,     0,          sc3000,     sc3000,  driver_device,     0,      "Sega",             "SC-3000H",                                 MACHINE_SUPPORTS_SAVE )
+COMP( 1983, sf7000,     sc3000,     0,          sf7000,     sf7000,  driver_device,     0,      "Sega",             "SC-3000/Super Control Station SF-7000",    MACHINE_SUPPORTS_SAVE )
+CONS( 1984, omv1000,    sg1000,     0,          omv,        omv1000, driver_device,     0,      "Tsukuda Original", "Othello Multivision FG-1000",              MACHINE_SUPPORTS_SAVE )
+CONS( 1984, omv2000,    sg1000,     0,          omv,        omv2000, driver_device,     0,      "Tsukuda Original", "Othello Multivision FG-2000",              MACHINE_SUPPORTS_SAVE )


### PR DESCRIPTION
The Othello Multivision FG-1000 only has one built-in controller. The OMV FG-2000 removed this in favour of external controllers (which will need to be made into slot devices in the future).

OMV FG-1000: http://www.famitsu.com/image/29819/pEllnbNQfCJ58skZ25uB511N6eSFfAu6.jpg
OMV FG-2000: http://segaretro.org/images/6/60/OthelloMultivision_FG-2000_1.jpg

Misc: http://segaretro.org/Othello_Multivision