### PR TITLE
Adding new string conversion overloads

### DIFF
--- a/src/osd/modules/debugger/win/consolewininfo.cpp
+++ b/src/osd/modules/debugger/win/consolewininfo.cpp
@@ -43,7 +43,7 @@ consolewin_info::consolewin_info(debugger_windows_interface &debugger) :
 			m_devices_menu = CreatePopupMenu();
 			for (device_image_interface &img : iter)
 			{
-				auto tc_buf = tstring_from_utf8(string_format("%s : %s", img.device().name(), img.exists() ? img.filename() : "[no image]").c_str());
+				tstring tc_buf = tstring_from_utf8(string_format("%s : %s", img.device().name(), img.exists() ? img.filename() : "[no image]"));
 				AppendMenu(m_devices_menu, MF_ENABLED, 0, tc_buf.c_str());
 			}
 			AppendMenu(GetMenu(window()), MF_ENABLED | MF_POPUP, (UINT_PTR)m_devices_menu, TEXT("Images"));
@@ -189,7 +189,7 @@ void consolewin_info::update_menu()
 				AppendMenu(devicesubmenu, flags_for_exists, new_item + DEVOPTION_CASSETTE_FASTFORWARD, TEXT("Fast Forward"));
 			}
 
-			auto tc_buf = tstring_from_utf8(string_format("%s :%s", img.device().name(), img.exists() ? img.filename() : "[empty slot]").c_str());
+			tstring tc_buf = tstring_from_utf8(string_format("%s :%s", img.device().name(), img.exists() ? img.filename() : "[empty slot]"));
 			ModifyMenu(m_devices_menu, cnt, MF_BYPOSITION | MF_POPUP, (UINT_PTR)devicesubmenu, tc_buf.c_str());
 
 			cnt++;
@@ -214,7 +214,7 @@ bool consolewin_info::handle_command(WPARAM wparam, LPARAM lparam)
 					std::string filter;
 					build_generic_filter(img, false, filter);
 					{
-						auto t_filter = tstring_from_utf8(filter.c_str());
+						tstring t_filter = tstring_from_utf8(filter);
 
 						// convert a pipe-char delimited string into a NUL delimited string
 						for (int i = 0; t_filter[i] != '\0'; i++)
@@ -252,7 +252,7 @@ bool consolewin_info::handle_command(WPARAM wparam, LPARAM lparam)
 					std::string filter;
 					build_generic_filter(img, true, filter);
 					{
-						auto t_filter = tstring_from_utf8(filter.c_str());
+						tstring t_filter = tstring_from_utf8(filter);
 						// convert a pipe-char delimited string into a NUL delimited string
 						for (int i = 0; t_filter[i] != '\0'; i++)
 						{

--- a/src/osd/modules/debugger/win/consolewininfo.cpp
+++ b/src/osd/modules/debugger/win/consolewininfo.cpp
@@ -43,7 +43,7 @@ consolewin_info::consolewin_info(debugger_windows_interface &debugger) :
 			m_devices_menu = CreatePopupMenu();
 			for (device_image_interface &img : iter)
 			{
-				tstring tc_buf = tstring_from_utf8(string_format("%s : %s", img.device().name(), img.exists() ? img.filename() : "[no image]"));
+				osd::text::tstring tc_buf = osd::text::to_tstring(string_format("%s : %s", img.device().name(), img.exists() ? img.filename() : "[no image]"));
 				AppendMenu(m_devices_menu, MF_ENABLED, 0, tc_buf.c_str());
 			}
 			AppendMenu(GetMenu(window()), MF_ENABLED | MF_POPUP, (UINT_PTR)m_devices_menu, TEXT("Images"));
@@ -189,7 +189,7 @@ void consolewin_info::update_menu()
 				AppendMenu(devicesubmenu, flags_for_exists, new_item + DEVOPTION_CASSETTE_FASTFORWARD, TEXT("Fast Forward"));
 			}
 
-			tstring tc_buf = tstring_from_utf8(string_format("%s :%s", img.device().name(), img.exists() ? img.filename() : "[empty slot]"));
+			osd::text::tstring tc_buf = osd::text::to_tstring(string_format("%s :%s", img.device().name(), img.exists() ? img.filename() : "[empty slot]"));
 			ModifyMenu(m_devices_menu, cnt, MF_BYPOSITION | MF_POPUP, (UINT_PTR)devicesubmenu, tc_buf.c_str());
 
 			cnt++;
@@ -214,7 +214,7 @@ bool consolewin_info::handle_command(WPARAM wparam, LPARAM lparam)
 					std::string filter;
 					build_generic_filter(img, false, filter);
 					{
-						tstring t_filter = tstring_from_utf8(filter);
+						osd::text::tstring t_filter = osd::text::to_tstring(filter);
 
 						// convert a pipe-char delimited string into a NUL delimited string
 						for (int i = 0; t_filter[i] != '\0'; i++)
@@ -241,7 +241,7 @@ bool consolewin_info::handle_command(WPARAM wparam, LPARAM lparam)
 
 						if (GetOpenFileName(&ofn))
 						{
-							auto utf8_buf = utf8_from_tstring(selectedFilename);
+							auto utf8_buf = osd::text::from_tstring(selectedFilename);
 							img->load(utf8_buf.c_str());
 						}
 					}
@@ -252,7 +252,7 @@ bool consolewin_info::handle_command(WPARAM wparam, LPARAM lparam)
 					std::string filter;
 					build_generic_filter(img, true, filter);
 					{
-						tstring t_filter = tstring_from_utf8(filter);
+						osd::text::tstring t_filter = osd::text::to_tstring(filter);
 						// convert a pipe-char delimited string into a NUL delimited string
 						for (int i = 0; t_filter[i] != '\0'; i++)
 						{
@@ -278,7 +278,7 @@ bool consolewin_info::handle_command(WPARAM wparam, LPARAM lparam)
 
 						if (GetSaveFileName(&ofn))
 						{
-							auto utf8_buf = utf8_from_tstring(selectedFilename);
+							auto utf8_buf = osd::text::from_tstring(selectedFilename);
 							img->create(utf8_buf.c_str(), img->device_get_indexed_creatable_format(0), nullptr);
 						}
 					}

--- a/src/osd/modules/debugger/win/debugviewinfo.cpp
+++ b/src/osd/modules/debugger/win/debugviewinfo.cpp
@@ -268,7 +268,7 @@ HWND debugview_info::create_source_combobox(HWND parent, LONG_PTR userdata)
 		int const length = strlen(source->name());
 		if (length > maxlength)
 			maxlength = length;
-		auto t_name = tstring_from_utf8(source->name());
+		auto t_name = osd::text::to_tstring(source->name());
 		SendMessage(result, CB_ADDSTRING, 0, (LPARAM)t_name.c_str());
 	}
 	if (cursource != nullptr)

--- a/src/osd/modules/debugger/win/editwininfo.cpp
+++ b/src/osd/modules/debugger/win/editwininfo.cpp
@@ -79,7 +79,7 @@ void editwin_info::set_editwnd_bounds(RECT const &bounds)
 
 void editwin_info::set_editwnd_text(char const *text)
 {
-	auto tc_buffer = tstring_from_utf8(text);
+	auto tc_buffer = osd::text::to_tstring(text);
 	SendMessage(m_editwnd, WM_SETTEXT, (WPARAM)0, (LPARAM)tc_buffer.c_str());
 }
 
@@ -187,7 +187,7 @@ LRESULT editwin_info::edit_proc(UINT message, WPARAM wparam, LPARAM lparam)
 
 						// process
 						{
-							auto utf8_buffer = utf8_from_tstring(buffer);
+							auto utf8_buffer = osd::text::from_tstring(buffer);
 							process_string(utf8_buffer.c_str());
 						}
 						break;

--- a/src/osd/modules/debugger/win/uimetrics.cpp
+++ b/src/osd/modules/debugger/win/uimetrics.cpp
@@ -27,7 +27,7 @@ ui_metrics::ui_metrics(osd_options const &options) :
 		char const *const face = options.debugger_font();
 
 		// create a standard font
-		auto t_face = tstring_from_utf8((!*face || !strcmp(OSDOPTVAL_AUTO, face)) ? "Lucida Console" : face);
+		auto t_face = osd::text::to_tstring((!*face || !strcmp(OSDOPTVAL_AUTO, face)) ? "Lucida Console" : face);
 		m_debug_font = CreateFont(-MulDiv((size <= 0) ? 9 : size, GetDeviceCaps(temp_dc, LOGPIXELSY), 72), 0, 0, 0, FW_MEDIUM, FALSE, FALSE, FALSE,
 					ANSI_CHARSET, OUT_DEFAULT_PRECIS, CLIP_DEFAULT_PRECIS, DEFAULT_QUALITY, FIXED_PITCH, t_face.c_str());
 

--- a/src/osd/modules/file/windir.cpp
+++ b/src/osd/modules/file/windir.cpp
@@ -91,7 +91,7 @@ const directory::entry *win_directory::read()
 	m_is_first = false;
 
 	// extract the data
-	utf8_from_tstring(m_name, m_data.cFileName);
+	osd::text::from_tstring(m_name, m_data.cFileName);
 	m_entry.name = m_name.c_str();
 	m_entry.type = win_attributes_to_entry_type(m_data.dwFileAttributes);
 	m_entry.size = m_data.nFileSizeLow | (std::uint64_t(m_data.nFileSizeHigh) << 32);
@@ -112,7 +112,7 @@ bool win_directory::open_impl(std::string const &dirname)
 	std::string dirfilter = string_format("%s\\*.*", dirname);
 
 	// convert the path to TCHARs
-	tstring t_dirfilter = tstring_from_utf8(dirfilter);
+	osd::text::tstring t_dirfilter = osd::text::to_tstring(dirfilter);
 
 	// attempt to find the first file
 	m_find = FindFirstFileEx(t_dirfilter.c_str(), FindExInfoStandard, &m_data, FindExSearchNameMatch, nullptr, 0);

--- a/src/osd/modules/file/windir.cpp
+++ b/src/osd/modules/file/windir.cpp
@@ -112,7 +112,7 @@ bool win_directory::open_impl(std::string const &dirname)
 	std::string dirfilter = string_format("%s\\*.*", dirname);
 
 	// convert the path to TCHARs
-	auto t_dirfilter = tstring_from_utf8(dirfilter.c_str());
+	tstring t_dirfilter = tstring_from_utf8(dirfilter);
 
 	// attempt to find the first file
 	m_find = FindFirstFileEx(t_dirfilter.c_str(), FindExInfoStandard, &m_data, FindExSearchNameMatch, nullptr, 0);

--- a/src/osd/modules/file/winfile.cpp
+++ b/src/osd/modules/file/winfile.cpp
@@ -173,7 +173,7 @@ osd_file::error osd_file::open(std::string const &orig_path, UINT32 openflags, p
 		return win_open_ptty(path, openflags, file, filesize);
 
 	// convert path to TCHAR
-	tstring t_path = tstring_from_utf8(path);
+	osd::text::tstring t_path = osd::text::to_tstring(path);
 
 	// convert the path into something Windows compatible (the actual interesting part appears
 	// to have been commented out???)
@@ -274,7 +274,7 @@ osd_file::error osd_file::openpty(ptr &file, std::string &name)
 
 osd_file::error osd_file::remove(std::string const &filename)
 {
-	tstring tempstr = tstring_from_utf8(filename);
+	osd::text::tstring tempstr = osd::text::to_tstring(filename);
 
 	error filerr = error::NONE;
 	if (!DeleteFile(tempstr.c_str()))
@@ -301,7 +301,7 @@ int osd_get_physical_drive_geometry(const char *filename, UINT32 *cylinders, UIN
 		return FALSE;
 
 	// do a create file on the drive
-	auto t_filename = tstring_from_utf8(filename);
+	auto t_filename = osd::text::to_tstring(filename);
 	file = CreateFile(t_filename.c_str(), GENERIC_READ, FILE_SHARE_WRITE, nullptr, OPEN_EXISTING, FILE_FLAG_NO_BUFFERING, nullptr);
 	if (file == INVALID_HANDLE_VALUE)
 		return FALSE;
@@ -338,7 +338,7 @@ int osd_get_physical_drive_geometry(const char *filename, UINT32 *cylinders, UIN
 std::unique_ptr<osd::directory::entry> osd_stat(const std::string &path)
 {
 	// convert the path to TCHARs
-	tstring t_path = tstring_from_utf8(path);
+	osd::text::tstring t_path = osd::text::to_tstring(path);
 
 	// is this path a root directory (e.g. - C:)?
 	WIN32_FIND_DATA find_data;
@@ -382,7 +382,7 @@ std::unique_ptr<osd::directory::entry> osd_stat(const std::string &path)
 osd_file::error osd_get_full_path(std::string &dst, std::string const &path)
 {
 	// convert the path to TCHARs
-	tstring t_path = tstring_from_utf8(path);
+	osd::text::tstring t_path = osd::text::to_tstring(path);
 
 	// cannonicalize the path
 	TCHAR buffer[MAX_PATH];
@@ -390,7 +390,7 @@ osd_file::error osd_get_full_path(std::string &dst, std::string const &path)
 		return win_error_to_file_error(GetLastError());
 
 	// convert the result back to UTF-8
-	utf8_from_tstring(dst, buffer);
+	osd::text::from_tstring(dst, buffer);
 	return osd_file::error::NONE;
 }
 
@@ -402,7 +402,7 @@ osd_file::error osd_get_full_path(std::string &dst, std::string const &path)
 
 bool osd_is_absolute_path(std::string const &path)
 {
-	tstring t_path = tstring_from_utf8(path);
+	osd::text::tstring t_path = osd::text::to_tstring(path);
 	return !PathIsRelative(t_path.c_str());
 }
 

--- a/src/osd/modules/file/winfile.cpp
+++ b/src/osd/modules/file/winfile.cpp
@@ -173,7 +173,7 @@ osd_file::error osd_file::open(std::string const &orig_path, UINT32 openflags, p
 		return win_open_ptty(path, openflags, file, filesize);
 
 	// convert path to TCHAR
-	auto t_path = tstring_from_utf8(path.c_str());
+	tstring t_path = tstring_from_utf8(path);
 
 	// convert the path into something Windows compatible (the actual interesting part appears
 	// to have been commented out???)
@@ -274,7 +274,7 @@ osd_file::error osd_file::openpty(ptr &file, std::string &name)
 
 osd_file::error osd_file::remove(std::string const &filename)
 {
-	auto tempstr = tstring_from_utf8(filename.c_str());
+	tstring tempstr = tstring_from_utf8(filename);
 
 	error filerr = error::NONE;
 	if (!DeleteFile(tempstr.c_str()))
@@ -338,7 +338,7 @@ int osd_get_physical_drive_geometry(const char *filename, UINT32 *cylinders, UIN
 std::unique_ptr<osd::directory::entry> osd_stat(const std::string &path)
 {
 	// convert the path to TCHARs
-	auto t_path = tstring_from_utf8(path.c_str());
+	tstring t_path = tstring_from_utf8(path);
 
 	// is this path a root directory (e.g. - C:)?
 	WIN32_FIND_DATA find_data;
@@ -382,7 +382,7 @@ std::unique_ptr<osd::directory::entry> osd_stat(const std::string &path)
 osd_file::error osd_get_full_path(std::string &dst, std::string const &path)
 {
 	// convert the path to TCHARs
-	auto t_path = tstring_from_utf8(path.c_str());
+	tstring t_path = tstring_from_utf8(path);
 
 	// cannonicalize the path
 	TCHAR buffer[MAX_PATH];
@@ -402,7 +402,7 @@ osd_file::error osd_get_full_path(std::string &dst, std::string const &path)
 
 bool osd_is_absolute_path(std::string const &path)
 {
-	auto t_path = tstring_from_utf8(path.c_str());
+	tstring t_path = tstring_from_utf8(path);
 	return !PathIsRelative(t_path.c_str());
 }
 

--- a/src/osd/modules/file/winptty.cpp
+++ b/src/osd/modules/file/winptty.cpp
@@ -87,7 +87,7 @@ bool win_check_ptty_path(std::string const &path)
 
 osd_file::error win_open_ptty(std::string const &path, std::uint32_t openflags, osd_file::ptr &file, std::uint64_t &filesize)
 {
-	auto t_name = tstring_from_utf8(path.c_str());
+	tstring t_name = tstring_from_utf8(path);
 
 	HANDLE pipe = CreateNamedPipe(t_name.c_str(), PIPE_ACCESS_DUPLEX, PIPE_TYPE_BYTE | PIPE_READMODE_BYTE | PIPE_NOWAIT, 1, 32, 32, 0, nullptr);
 

--- a/src/osd/modules/file/winptty.cpp
+++ b/src/osd/modules/file/winptty.cpp
@@ -87,7 +87,7 @@ bool win_check_ptty_path(std::string const &path)
 
 osd_file::error win_open_ptty(std::string const &path, std::uint32_t openflags, osd_file::ptr &file, std::uint64_t &filesize)
 {
-	tstring t_name = tstring_from_utf8(path);
+	osd::text::tstring t_name = osd::text::to_tstring(path);
 
 	HANDLE pipe = CreateNamedPipe(t_name.c_str(), PIPE_ACCESS_DUPLEX, PIPE_TYPE_BYTE | PIPE_READMODE_BYTE | PIPE_NOWAIT, 1, 32, 32, 0, nullptr);
 

--- a/src/osd/modules/font/font_dwrite.cpp
+++ b/src/osd/modules/font/font_dwrite.cpp
@@ -362,7 +362,7 @@ public:
 		bool italic = (strreplace(name, "[I]", "") + strreplace(name, "[i]", "") > 0);
 
 		// convert the face name
-		std::wstring familyName = wstring_from_utf8(name.c_str());
+		std::wstring familyName = osd::text::to_wstring(name.c_str());
 
 		// find the font
 		HR_RET0(find_font(
@@ -757,7 +757,7 @@ public:
 			std::unique_ptr<WCHAR[]> name = nullptr;
 			HR_RET0(get_localized_familyname(names, name));
 
-			std::string utf8_name = utf8_from_wstring(name.get());
+			std::string utf8_name = osd::text::from_wstring(name.get());
 			name.reset();
 
 			// Review: should the config name, be unlocalized?

--- a/src/osd/modules/font/font_windows.cpp
+++ b/src/osd/modules/font/font_windows.cpp
@@ -85,7 +85,7 @@ bool osd_font_windows::open(std::string const &font_path, std::string const &_na
 	logfont.lfPitchAndFamily = DEFAULT_PITCH | FF_DONTCARE;
 
 	// copy in the face name
-	std::basic_string<TCHAR> face = tstring_from_utf8(name.c_str());
+	tstring face = tstring_from_utf8(name);
 	_tcsncpy(logfont.lfFaceName, face.c_str(), ARRAY_LENGTH(logfont.lfFaceName));
 	logfont.lfFaceName[sizeof(logfont.lfFaceName) / sizeof(TCHAR)-1] = 0;
 

--- a/src/osd/modules/font/font_windows.cpp
+++ b/src/osd/modules/font/font_windows.cpp
@@ -85,7 +85,7 @@ bool osd_font_windows::open(std::string const &font_path, std::string const &_na
 	logfont.lfPitchAndFamily = DEFAULT_PITCH | FF_DONTCARE;
 
 	// copy in the face name
-	tstring face = tstring_from_utf8(name);
+	osd::text::tstring face = osd::text::to_tstring(name);
 	_tcsncpy(logfont.lfFaceName, face.c_str(), ARRAY_LENGTH(logfont.lfFaceName));
 	logfont.lfFaceName[sizeof(logfont.lfFaceName) / sizeof(TCHAR)-1] = 0;
 
@@ -110,7 +110,7 @@ bool osd_font_windows::open(std::string const &font_path, std::string const &_na
 	}
 
 	// if it doesn't match our request, fail
-	std::string utf = utf8_from_tstring(&realname[0]);
+	std::string utf = osd::text::from_tstring(&realname[0]);
 	int result = core_stricmp(utf.c_str(), name.c_str());
 
 	// if we didn't match, nuke our font and fall back
@@ -300,7 +300,7 @@ private:
 	static int CALLBACK font_family_callback(LOGFONT const *lpelfe, TEXTMETRIC const *lpntme, DWORD FontType, LPARAM lParam)
 	{
 		auto &result = *reinterpret_cast<std::vector<std::pair<std::string, std::string> > *>(lParam);
-		std::string face = utf8_from_tstring(lpelfe->lfFaceName);
+		std::string face = osd::text::from_tstring(lpelfe->lfFaceName);
 		if ((face[0] != '@') && (result.empty() || (result.back().first != face))) result.emplace_back(face, face);
 		return TRUE;
 	}

--- a/src/osd/modules/input/input_dinput.cpp
+++ b/src/osd/modules/input/input_dinput.cpp
@@ -262,14 +262,14 @@ public:
 		}
 
 		// convert the name to utf8
-		std::string namestring = utf8_from_tstring(instance.tszName);
+		std::string namestring = osd::text::from_tstring(instance.tszName);
 
 		// if no suffix, return as-is
 		if (suffix == nullptr)
 			return namestring;
 
 		// convert the suffix to utf8
-		std::string suffix_utf8 = utf8_from_tstring(suffix);
+		std::string suffix_utf8 = osd::text::from_tstring(suffix);
 
 		// Concat the name and suffix
 		return namestring + " " + suffix_utf8;

--- a/src/osd/modules/input/input_dinput.h
+++ b/src/osd/modules/input/input_dinput.h
@@ -79,7 +79,7 @@ public:
 		HRESULT result;
 
 		// convert instance name to utf8
-		std::string utf8_instance_name = utf8_from_tstring(instance->tszInstanceName);
+		std::string utf8_instance_name = osd::text::from_tstring(instance->tszInstanceName);
 
 		// set device id to name
 		std::string utf8_instance_id = utf8_instance_name;

--- a/src/osd/modules/input/input_rawinput.cpp
+++ b/src/osd/modules/input/input_rawinput.cpp
@@ -573,10 +573,10 @@ protected:
 		std::wstring name = rawinput_device_improve_name(tname.get());
 
 		// convert name to utf8
-		std::string utf8_name = utf8_from_wstring(name.c_str());
+		std::string utf8_name = osd::text::from_wstring(name.c_str());
 
 		// set device id to raw input name
-		std::string utf8_id = utf8_from_wstring(tname.get());
+		std::string utf8_id = osd::text::from_wstring(tname.get());
 
 		devinfo = devicelist()->create_device<TDevice>(machine, utf8_name.c_str(), utf8_id.c_str(), *this);
 
@@ -679,7 +679,7 @@ protected:
 			// generate the name
 			if (GetKeyNameText(((keynum & 0x7f) << 16) | ((keynum & 0x80) << 17), keyname, ARRAY_LENGTH(keyname)) == 0)
 				_sntprintf(keyname, ARRAY_LENGTH(keyname), TEXT("Scan%03d"), keynum);
-			std::string name = utf8_from_tstring(keyname);
+			std::string name = osd::text::from_tstring(keyname);
 
 			// add the item to the device
 			devinfo->device()->add_item(name.c_str(), itemid, generic_button_get_state<std::uint8_t>, &devinfo->keyboard.state[keynum]);

--- a/src/osd/modules/lib/osdlib_win32.cpp
+++ b/src/osd/modules/lib/osdlib_win32.cpp
@@ -367,7 +367,7 @@ protected:
 
 		for (auto const &library : m_libraries)
 		{
-			auto tempstr = tstring_from_utf8(library.c_str());
+			tstring tempstr = tstring_from_utf8(library);
 			HMODULE module = load_library(tempstr.c_str());
 
 			if (module != nullptr)

--- a/src/osd/modules/lib/osdlib_win32.cpp
+++ b/src/osd/modules/lib/osdlib_win32.cpp
@@ -297,7 +297,7 @@ static char *get_clipboard_text_by_format(UINT format, std::string (*convert)(LP
 
 static std::string convert_wide(LPCVOID data)
 {
-	return utf8_from_wstring((LPCWSTR) data);
+	return osd::text::from_wstring((LPCWSTR) data);
 }
 
 //============================================================
@@ -306,7 +306,7 @@ static std::string convert_wide(LPCVOID data)
 
 static std::string convert_ansi(LPCVOID data)
 {
-	return utf8_from_astring((LPCSTR) data);
+	return osd::text::from_astring((LPCSTR) data);
 }
 
 //============================================================
@@ -367,7 +367,7 @@ protected:
 
 		for (auto const &library : m_libraries)
 		{
-			tstring tempstr = tstring_from_utf8(library);
+			osd::text::tstring tempstr = osd::text::to_tstring(library);
 			HMODULE module = load_library(tempstr.c_str());
 
 			if (module != nullptr)

--- a/src/osd/modules/monitor/monitor_dxgi.cpp
+++ b/src/osd/modules/monitor/monitor_dxgi.cpp
@@ -46,7 +46,7 @@ public:
 		m_output->GetDesc(&desc);
 
 		// fetch the latest info about the monitor
-		m_name = utf8_from_wstring(desc.DeviceName);
+		m_name = osd::text::from_wstring(desc.DeviceName);
 
 		m_pos_size = RECT_to_osd_rect(desc.DesktopCoordinates);
 		m_usuable_pos_size = RECT_to_osd_rect(desc.DesktopCoordinates);
@@ -139,7 +139,7 @@ protected:
 				float aspect = float(coords->right - coords->left) / float(coords->bottom - coords->top);
 
 				// allocate a new monitor info
-				std::string devicename = utf8_from_wstring(desc.DeviceName);
+				std::string devicename = osd::text::from_wstring(desc.DeviceName);
 
 				// allocate a new monitor info
 				auto monitor = std::make_shared<dxgi_monitor_info>(*this, desc.Monitor, devicename.c_str(), aspect, output);

--- a/src/osd/modules/monitor/monitor_win32.cpp
+++ b/src/osd/modules/monitor/monitor_win32.cpp
@@ -45,7 +45,7 @@ public:
 		result = GetMonitorInfo(reinterpret_cast<HMONITOR>(oshandle()), static_cast<LPMONITORINFO>(&m_info));
 		assert(result);
 
-		m_name = utf8_from_tstring(m_info.szDevice);
+		m_name = osd::text::from_tstring(m_info.szDevice);
 
 		m_pos_size = RECT_to_osd_rect(m_info.rcMonitor);
 		m_usuable_pos_size = RECT_to_osd_rect(m_info.rcWork);
@@ -122,7 +122,7 @@ private:
 		float aspect = static_cast<float>(info.rcMonitor.right - info.rcMonitor.left) / static_cast<float>(info.rcMonitor.bottom - info.rcMonitor.top);
 
 		// allocate a new monitor info
-		auto temp = utf8_from_tstring(info.szDevice);
+		auto temp = osd::text::from_tstring(info.szDevice);
 
 		// copy in the data
 		auto monitor = std::make_shared<win32_monitor_info>(*self, handle, temp.c_str(), aspect);

--- a/src/osd/modules/render/d3d/d3dhlsl.cpp
+++ b/src/osd/modules/render/d3d/d3dhlsl.cpp
@@ -2589,7 +2589,7 @@ effect::effect(shaders *shadersys, IDirect3DDevice9 *dev, const char *name, cons
 
 	char name_cstr[1024];
 	sprintf(name_cstr, "%s\\%s", path, name);
-	auto effect_name = tstring_from_utf8(name_cstr);
+	auto effect_name = osd::text::to_tstring(name_cstr);
 
 	HRESULT hr = (*shadersys->d3dx_create_effect_from_file_ptr)(dev, effect_name.c_str(), nullptr, nullptr, 0, nullptr, &m_effect, &buffer_errors);
 	if (FAILED(hr))

--- a/src/osd/strconv.cpp
+++ b/src/osd/strconv.cpp
@@ -43,6 +43,9 @@ namespace
 	};
 };
 
+namespace osd {
+namespace text {
+
 //============================================================
 //  mbstring_from_wstring
 //============================================================
@@ -74,13 +77,13 @@ static std::wstring &wstring_from_mbstring(std::wstring &dst, const string_sourc
 
 
 //============================================================
-//  astring_from_utf8
+//  to_astring
 //============================================================
 
-std::string &astring_from_utf8(std::string &dst, const std::string &s)
+std::string &to_astring(std::string &dst, const std::string &s)
 {
 	// convert MAME string (UTF-8) to UTF-16
-	std::wstring wstring = wstring_from_utf8(s);
+	std::wstring wstring = to_wstring(s);
 
 	// convert UTF-16 to "ANSI code page" string
 	return mbstring_from_wstring(dst, CP_ACP, string_source<wchar_t>(wstring));
@@ -89,13 +92,13 @@ std::string &astring_from_utf8(std::string &dst, const std::string &s)
 
 
 //============================================================
-//  astring_from_utf8
+//  to_astring
 //============================================================
 
-std::string &astring_from_utf8(std::string &dst, const char *s)
+std::string &to_astring(std::string &dst, const char *s)
 {
 	// convert MAME string (UTF-8) to UTF-16
-	std::wstring wstring = wstring_from_utf8(s);
+	std::wstring wstring = to_wstring(s);
 
 	// convert UTF-16 to "ANSI code page" string
 	return mbstring_from_wstring(dst, CP_ACP, string_source<wchar_t>(wstring));
@@ -103,88 +106,88 @@ std::string &astring_from_utf8(std::string &dst, const char *s)
 
 
 //============================================================
-//  astring_from_utf8
+//  to_astring
 //============================================================
 
-std::string astring_from_utf8(const std::string &s)
+std::string to_astring(const std::string &s)
 {
 	std::string result;
-	astring_from_utf8(result, s);
+	to_astring(result, s);
 	return result;
 }
 
 
 //============================================================
-//  astring_from_utf8
+//  to_astring
 //============================================================
 
-std::string astring_from_utf8(const char *s)
+std::string to_astring(const char *s)
 {
 	std::string result;
-	astring_from_utf8(result, s);
+	to_astring(result, s);
 	return result;
 }
 
 
 //============================================================
-//  utf8_from_astring
+//  from_astring
 //============================================================
 
-std::string &utf8_from_astring(std::string &dst, const std::string &s)
+std::string &from_astring(std::string &dst, const std::string &s)
 {
 	// convert "ANSI code page" string to UTF-16
 	std::wstring wstring;
 	wstring_from_mbstring(wstring, string_source<char>(s), CP_ACP);
 
 	// convert UTF-16 to MAME string (UTF-8)
-	return utf8_from_wstring(dst, wstring);
+	return from_wstring(dst, wstring);
 }
 
 
 //============================================================
-//  utf8_from_astring
+//  from_astring
 //============================================================
 
-std::string &utf8_from_astring(std::string &dst, const CHAR *s)
+std::string &from_astring(std::string &dst, const CHAR *s)
 {
 	// convert "ANSI code page" string to UTF-16
 	std::wstring wstring;
 	wstring_from_mbstring(wstring, string_source<char>(s), CP_ACP);
 
 	// convert UTF-16 to MAME string (UTF-8)
-	return utf8_from_wstring(dst, wstring);
+	return from_wstring(dst, wstring);
 }
 
 
 //============================================================
-//  utf8_from_astring
+//  from_astring
 //============================================================
 
-std::string utf8_from_astring(const std::string &s)
+std::string from_astring(const std::string &s)
 {
 	std::string result;
-	utf8_from_astring(result, s);
+	from_astring(result, s);
 	return result;
 }
 
 
 //============================================================
-//  utf8_from_astring
+//  from_astring
 //============================================================
 
-std::string utf8_from_astring(const CHAR *s)
+std::string from_astring(const CHAR *s)
 {
 	std::string result;
-	utf8_from_astring(result, s);
+	from_astring(result, s);
 	return result;
 }
 
 
 //============================================================
-//  wstring_from_utf8
+//  to_wstring
 //============================================================
 
-std::wstring &wstring_from_utf8(std::wstring &dst, const std::string &s)
+std::wstring &to_wstring(std::wstring &dst, const std::string &s)
 {
 	// convert MAME string (UTF-8) to UTF-16
 	return wstring_from_mbstring(dst, string_source<char>(s), CP_UTF8);
@@ -192,10 +195,10 @@ std::wstring &wstring_from_utf8(std::wstring &dst, const std::string &s)
 
 
 //============================================================
-//  wstring_from_utf8
+//  to_wstring
 //============================================================
 
-std::wstring &wstring_from_utf8(std::wstring &dst, const char *s)
+std::wstring &to_wstring(std::wstring &dst, const char *s)
 {
 	// convert MAME string (UTF-8) to UTF-16
 	return wstring_from_mbstring(dst, string_source<char>(s), CP_UTF8);
@@ -203,34 +206,34 @@ std::wstring &wstring_from_utf8(std::wstring &dst, const char *s)
 
 
 //============================================================
-//  wstring_from_utf8
+//  to_wstring
 //============================================================
 
-std::wstring wstring_from_utf8(const std::string &s)
+std::wstring to_wstring(const std::string &s)
 {
 	std::wstring result;
-	wstring_from_utf8(result, s);
+	to_wstring(result, s);
 	return result;
 }
 
 
 //============================================================
-//  wstring_from_utf8
+//  to_wstring
 //============================================================
 
-std::wstring wstring_from_utf8(const char *s)
+std::wstring to_wstring(const char *s)
 {
 	std::wstring result;
-	wstring_from_utf8(result, s);
+	to_wstring(result, s);
 	return result;
 }
 
 
 //============================================================
-//  utf8_from_wstring
+//  from_wstring
 //============================================================
 
-std::string &utf8_from_wstring(std::string &dst, const std::wstring &s)
+std::string &from_wstring(std::string &dst, const std::wstring &s)
 {
 	// convert UTF-16 to MAME string (UTF-8)
 	return mbstring_from_wstring(dst, CP_UTF8, string_source<wchar_t>(s));
@@ -238,10 +241,10 @@ std::string &utf8_from_wstring(std::string &dst, const std::wstring &s)
 
 
 //============================================================
-//  utf8_from_wstring
+//  from_wstring
 //============================================================
 
-std::string &utf8_from_wstring(std::string &dst, const WCHAR *s)
+std::string &from_wstring(std::string &dst, const WCHAR *s)
 {
 	// convert UTF-16 to MAME string (UTF-8)
 	return mbstring_from_wstring(dst, CP_UTF8, string_source<wchar_t>(s));
@@ -249,27 +252,30 @@ std::string &utf8_from_wstring(std::string &dst, const WCHAR *s)
 
 
 //============================================================
-//  utf8_from_wstring
+//  from_wstring
 //============================================================
 
-std::string utf8_from_wstring(const std::wstring &s)
+std::string from_wstring(const std::wstring &s)
 {
 	std::string result;
-	utf8_from_wstring(result, s);
+	from_wstring(result, s);
 	return result;
 }
 
 
 //============================================================
-//  utf8_from_wstring
+//  from_wstring
 //============================================================
 
-std::string utf8_from_wstring(const WCHAR *s)
+std::string from_wstring(const WCHAR *s)
 {
 	std::string result;
-	utf8_from_wstring(result, s);
+	from_wstring(result, s);
 	return result;
 }
+
+}; // namespace text
+}; // namespace osd
 
 
 //============================================================
@@ -297,6 +303,7 @@ error:
 	*uchar = 0;
 	return static_cast<int>(count);
 }
+
 
 #else
 #include "unicode.h"

--- a/src/osd/strconv.cpp
+++ b/src/osd/strconv.cpp
@@ -25,8 +25,18 @@ namespace
 	class string_source
 	{
 	public:
-		virtual const T *string() const = 0;	// returns pointer to actual characters
-		virtual int char_count() const = 0;		// returns the character count (including NUL terminater), or -1 if NUL terminated
+		const T *string() const { return m_str;	};	// returns pointer to actual characters
+		virtual int char_count() const { return m_char_count; }		// returns the character count (including NUL terminater), or -1 if NUL terminated
+
+	protected:
+		string_source(const T *str, int char_count) : m_str(str), m_char_count(char_count)
+		{
+			assert(str != nullptr);
+		}
+
+	private:
+		const T *m_str;
+		int m_char_count;
 	};
 
 	// implementation of string_source for NUL-terminated strings
@@ -34,16 +44,9 @@ namespace
 	class null_terminated_string_source : public string_source<T>
 	{
 	public:
-		null_terminated_string_source(const T *str) : m_str(str)
+		null_terminated_string_source(const T *str) : string_source<T>(str, -1)
 		{
-			assert(str != nullptr);
 		}
-
-		virtual const T *string() const override { return m_str; }
-		virtual int char_count() const override { return -1; }
-
-	private:
-		const T *m_str;
 	};
 
 	// implementation of string_source for std::[w]string
@@ -51,15 +54,9 @@ namespace
 	class basic_string_source : public string_source<T>
 	{
 	public:
-		basic_string_source(const std::basic_string<T> &str) : m_str(str)
+		basic_string_source(const std::basic_string<T> &str) : string_source<T>(str.c_str(), (int)str.size() + 1)
 		{
 		}
-
-		virtual const T *string() const override { return m_str.c_str(); }
-		virtual int char_count() const override { return (int) m_str.size() + 1; }
-
-	private:
-		const std::basic_string<T> &m_str;
 	};
 };
 

--- a/src/osd/strconv.cpp
+++ b/src/osd/strconv.cpp
@@ -17,20 +17,58 @@
 
 #if defined(SDLMAME_WIN32) || defined(OSD_WINDOWS)
 //============================================================
+//  astring_from_wstring
+//============================================================
+
+static std::string &astring_from_wstring(std::string &dst, const std::wstring &wstring)
+{
+	// convert UTF-16 to "ANSI code page" string
+	int char_count = WideCharToMultiByte(CP_ACP, 0, wstring.c_str(), wstring.size() + 1, nullptr, 0, nullptr, nullptr);
+	dst.resize(char_count - 1);
+	WideCharToMultiByte(CP_ACP, 0, wstring.c_str(), wstring.size(), &dst[0], char_count, nullptr, nullptr);
+
+	return dst;
+}
+
+
+//============================================================
+//  astring_from_utf8
+//============================================================
+
+std::string &astring_from_utf8(std::string &dst, const std::string &s)
+{
+	// convert MAME string (UTF-8) to UTF-16
+	std::wstring wstring = wstring_from_utf8(s);
+
+	// convert UTF-16 to "ANSI code page" string
+	return astring_from_wstring(dst, wstring);
+}
+
+
+
+//============================================================
 //  astring_from_utf8
 //============================================================
 
 std::string &astring_from_utf8(std::string &dst, const char *s)
 {
 	// convert MAME string (UTF-8) to UTF-16
-	std::basic_string<WCHAR> wstring = wstring_from_utf8(s);
+	std::wstring wstring = wstring_from_utf8(s);
 
 	// convert UTF-16 to "ANSI code page" string
-	int char_count = WideCharToMultiByte(CP_ACP, 0, wstring.c_str(), wstring.size(), nullptr, 0, nullptr, nullptr);
-	dst.resize(char_count);
-	WideCharToMultiByte(CP_ACP, 0, wstring.c_str(), wstring.size(), &dst[0], char_count, nullptr, nullptr);
+	return astring_from_wstring(dst, wstring);
+}
 
-	return dst;
+
+//============================================================
+//  astring_from_utf8
+//============================================================
+
+std::string astring_from_utf8(const std::string &s)
+{
+	std::string result;
+	astring_from_utf8(result, s);
+	return result;
 }
 
 
@@ -50,6 +88,22 @@ std::string astring_from_utf8(const char *s)
 //  utf8_from_astring
 //============================================================
 
+std::string &utf8_from_astring(std::string &dst, const std::string &s)
+{
+	// convert "ANSI code page" string to UTF-16
+	int char_count = MultiByteToWideChar(CP_ACP, 0, s.c_str(), s.size() + 1, nullptr, 0);
+	std::wstring wstring(char_count - 1, 0);
+	MultiByteToWideChar(CP_ACP, 0, s.c_str(), s.size() + 1, &wstring[0], char_count - 1);
+
+	// convert UTF-16 to MAME string (UTF-8)
+	return utf8_from_wstring(dst, wstring);
+}
+
+
+//============================================================
+//  utf8_from_astring
+//============================================================
+
 std::string &utf8_from_astring(std::string &dst, const CHAR *s)
 {
 	// convert "ANSI code page" string to UTF-16
@@ -58,7 +112,19 @@ std::string &utf8_from_astring(std::string &dst, const CHAR *s)
 	MultiByteToWideChar(CP_ACP, 0, s, -1, &wstring[0], char_count - 1);
 
 	// convert UTF-16 to MAME string (UTF-8)
-	return utf8_from_wstring(dst, wstring.c_str());
+	return utf8_from_wstring(dst, wstring);
+}
+
+
+//============================================================
+//  utf8_from_astring
+//============================================================
+
+std::string utf8_from_astring(const std::string &s)
+{
+	std::string result;
+	utf8_from_astring(result, s);
+	return result;
 }
 
 
@@ -71,6 +137,21 @@ std::string utf8_from_astring(const CHAR *s)
 	std::string result;
 	utf8_from_astring(result, s);
 	return result;
+}
+
+
+//============================================================
+//  wstring_from_utf8
+//============================================================
+
+std::wstring &wstring_from_utf8(std::wstring &dst, const std::string &s)
+{
+	// convert MAME string (UTF-8) to UTF-16
+	int char_count = MultiByteToWideChar(CP_UTF8, 0, s.c_str(), s.size() + 1, nullptr, 0);
+	dst.resize(char_count - 1);
+	MultiByteToWideChar(CP_UTF8, 0, s.c_str(), s.size() + 1, &dst[0], char_count - 1);
+
+	return dst;
 }
 
 
@@ -93,11 +174,38 @@ std::wstring &wstring_from_utf8(std::wstring &dst, const char *s)
 //  wstring_from_utf8
 //============================================================
 
+std::wstring wstring_from_utf8(const std::string &s)
+{
+	std::wstring result;
+	wstring_from_utf8(result, s);
+	return result;
+}
+
+
+//============================================================
+//  wstring_from_utf8
+//============================================================
+
 std::wstring wstring_from_utf8(const char *s)
 {
 	std::wstring result;
 	wstring_from_utf8(result, s);
 	return result;
+}
+
+
+//============================================================
+//  utf8_from_wstring
+//============================================================
+
+std::string &utf8_from_wstring(std::string &dst, const std::wstring &s)
+{
+	// convert UTF-16 to MAME string (UTF-8)
+	int char_count = WideCharToMultiByte(CP_UTF8, 0, s.c_str(), s.size() + 1, nullptr, 0, nullptr, nullptr);
+	dst.resize(char_count - 1);
+	WideCharToMultiByte(CP_UTF8, 0, s.c_str(), -1, &dst[0], char_count - 1, nullptr, nullptr);
+
+	return dst;
 }
 
 
@@ -113,6 +221,18 @@ std::string &utf8_from_wstring(std::string &dst, const WCHAR *s)
 	WideCharToMultiByte(CP_UTF8, 0, s, -1, &dst[0], char_count - 1, nullptr, nullptr);
 
 	return dst;
+}
+
+
+//============================================================
+//  utf8_from_wstring
+//============================================================
+
+std::string utf8_from_wstring(const std::wstring &s)
+{
+	std::string result;
+	utf8_from_wstring(result, s);
+	return result;
 }
 
 

--- a/src/osd/strconv.h
+++ b/src/osd/strconv.h
@@ -25,22 +25,30 @@
 
 #include <windows.h>
 
-// the result of these functions has to be released with osd_free()
-
+std::string astring_from_utf8(const std::string &s);
 std::string astring_from_utf8(const char *s);
+std::string &astring_from_utf8(std::string &dst, std::string &s);
 std::string &astring_from_utf8(std::string &dst, const char *s);
+std::string utf8_from_astring(const std::string &s);
 std::string utf8_from_astring(const CHAR *s);
+std::string &utf8_from_astring(std::string &dst, const std::string &s);
 std::string &utf8_from_astring(std::string &dst, const CHAR *s);
 
+std::wstring wstring_from_utf8(const std::string &s);
 std::wstring wstring_from_utf8(const char *s);
+std::wstring &wstring_from_utf8(std::wstring &dst, std::string &s);
 std::wstring &wstring_from_utf8(std::wstring &dst, const char *s);
+std::string utf8_from_wstring(const std::wstring &s);
 std::string utf8_from_wstring(const WCHAR *s);
+std::string &utf8_from_wstring(std::string &dst, const std::wstring &s);
 std::string &utf8_from_wstring(std::string &dst, const WCHAR *s);
 
 #ifdef UNICODE
+typedef std::wstring tstring;
 #define tstring_from_utf8   wstring_from_utf8
 #define utf8_from_tstring   utf8_from_wstring
 #else // !UNICODE
+typedef std::string tstring;
 #define tstring_from_utf8   astring_from_utf8
 #define utf8_from_tstring   utf8_from_astring
 #endif // UNICODE

--- a/src/osd/strconv.h
+++ b/src/osd/strconv.h
@@ -25,33 +25,40 @@
 
 #include <windows.h>
 
-std::string astring_from_utf8(const std::string &s);
-std::string astring_from_utf8(const char *s);
-std::string &astring_from_utf8(std::string &dst, const std::string &s);
-std::string &astring_from_utf8(std::string &dst, const char *s);
-std::string utf8_from_astring(const std::string &s);
-std::string utf8_from_astring(const CHAR *s);
-std::string &utf8_from_astring(std::string &dst, const std::string &s);
-std::string &utf8_from_astring(std::string &dst, const CHAR *s);
+namespace osd
+{
+	namespace text
+	{
+		std::string to_astring(const std::string &s);
+		std::string to_astring(const char *s);
+		std::string &to_astring(std::string &dst, const std::string &s);
+		std::string &to_astring(std::string &dst, const char *s);
+		std::string from_astring(const std::string &s);
+		std::string from_astring(const CHAR *s);
+		std::string &from_astring(std::string &dst, const std::string &s);
+		std::string &from_astring(std::string &dst, const CHAR *s);
 
-std::wstring wstring_from_utf8(const std::string &s);
-std::wstring wstring_from_utf8(const char *s);
-std::wstring &wstring_from_utf8(std::wstring &dst, const std::string &s);
-std::wstring &wstring_from_utf8(std::wstring &dst, const char *s);
-std::string utf8_from_wstring(const std::wstring &s);
-std::string utf8_from_wstring(const WCHAR *s);
-std::string &utf8_from_wstring(std::string &dst, const std::wstring &s);
-std::string &utf8_from_wstring(std::string &dst, const WCHAR *s);
+		std::wstring to_wstring(const std::string &s);
+		std::wstring to_wstring(const char *s);
+		std::wstring &to_wstring(std::wstring &dst, const std::string &s);
+		std::wstring &to_wstring(std::wstring &dst, const char *s);
+		std::string from_wstring(const std::wstring &s);
+		std::string from_wstring(const WCHAR *s);
+		std::string &from_wstring(std::string &dst, const std::wstring &s);
+		std::string &from_wstring(std::string &dst, const WCHAR *s);
 
 #ifdef UNICODE
 typedef std::wstring tstring;
-#define tstring_from_utf8   wstring_from_utf8
-#define utf8_from_tstring   utf8_from_wstring
+#define to_tstring   to_wstring
+#define from_tstring   from_wstring
 #else // !UNICODE
 typedef std::string tstring;
-#define tstring_from_utf8   astring_from_utf8
-#define utf8_from_tstring   utf8_from_astring
+#define to_tstring   to_astring
+#define from_tstring   from_astring
 #endif // UNICODE
+
+	}
+}
 
 #endif // defined(WIN32)
 

--- a/src/osd/strconv.h
+++ b/src/osd/strconv.h
@@ -27,7 +27,7 @@
 
 std::string astring_from_utf8(const std::string &s);
 std::string astring_from_utf8(const char *s);
-std::string &astring_from_utf8(std::string &dst, std::string &s);
+std::string &astring_from_utf8(std::string &dst, const std::string &s);
 std::string &astring_from_utf8(std::string &dst, const char *s);
 std::string utf8_from_astring(const std::string &s);
 std::string utf8_from_astring(const CHAR *s);
@@ -36,7 +36,7 @@ std::string &utf8_from_astring(std::string &dst, const CHAR *s);
 
 std::wstring wstring_from_utf8(const std::string &s);
 std::wstring wstring_from_utf8(const char *s);
-std::wstring &wstring_from_utf8(std::wstring &dst, std::string &s);
+std::wstring &wstring_from_utf8(std::wstring &dst, const std::string &s);
 std::wstring &wstring_from_utf8(std::wstring &dst, const char *s);
 std::string utf8_from_wstring(const std::wstring &s);
 std::string utf8_from_wstring(const WCHAR *s);

--- a/src/osd/windows/main.cpp
+++ b/src/osd/windows/main.cpp
@@ -36,7 +36,7 @@ extern "C" int _tmain(int argc, TCHAR **argv)
 	// convert arguments to UTF-8
 	for (i = 0; i < argc; i++)
 	{
-		argv_vectors[i] = utf8_from_tstring(argv[i]);
+		argv_vectors[i] = osd::text::from_tstring(argv[i]);
 		utf8_argv[i] = (char *) argv_vectors[i].c_str();
 	}
 

--- a/src/osd/windows/winmain.cpp
+++ b/src/osd/windows/winmain.cpp
@@ -99,8 +99,8 @@ public:
 			char buffer[1024];
 			vsnprintf(buffer, ARRAY_LENGTH(buffer), msg, args);
 
-			osd_unique_wstr wcbuffer(wstring_from_utf8(buffer));
-			osd_unique_wstr wcappname(wstring_from_utf8(emulator_info::get_appname()));
+			osd_unique_wstr wcbuffer(osd::text::to_wstring(buffer));
+			osd_unique_wstr wcappname(osd::text::to_wstring(emulator_info::get_appname()));
 
 			auto dlg = ref new MessageDialog(ref new Platform::String(wcbuffer.get()), ref new Platform::String(wcappname.get()));
 			dlg->ShowAsync();

--- a/src/osd/windows/winutf8.cpp
+++ b/src/osd/windows/winutf8.cpp
@@ -23,7 +23,7 @@
 
 void win_output_debug_string_utf8(const char *string)
 {
-	auto t_string = tstring_from_utf8(string);
+	auto t_string = osd::text::to_tstring(string);
 	OutputDebugString(t_string.c_str());
 }
 
@@ -42,13 +42,13 @@ int win_message_box_utf8(HWND window, const char *text, const char *caption, UIN
 
 	if (text)
 	{
-		ts_text = tstring_from_utf8(text);
+		ts_text = osd::text::to_tstring(text);
 		t_text = ts_text.c_str();
 	}
 
 	if (caption)
 	{
-		ts_caption = tstring_from_utf8(caption);
+		ts_caption = osd::text::to_tstring(caption);
 		t_caption = ts_caption.c_str();
 	}
 
@@ -69,7 +69,7 @@ BOOL win_set_window_text_utf8(HWND window, const char *text)
 
 	if (text)
 	{
-		ts_text = tstring_from_utf8(text);
+		ts_text = osd::text::to_tstring(text);
 		t_text = ts_text.c_str();
 	}
 
@@ -100,14 +100,14 @@ std::string win_get_window_text_utf8(HWND window)
 
 		TCHAR *buffer = (TCHAR *) alloca((length + 1) * sizeof(TCHAR));
 		GetWindowText(window, buffer, length + 1);
-		return utf8_from_tstring(buffer);
+		return osd::text::from_tstring(buffer);
 	}
 #else
 	{
 		TCHAR t_buffer[256];
 		auto title = Windows::UI::ViewManagement::ApplicationView::GetForCurrentView()->Title;
 		wcsncpy(t_buffer, title->Data(), ARRAY_LENGTH(t_buffer));
-		return utf8_from_tstring(t_buffer);
+		return osd::text::from_tstring(t_buffer);
 	}
 #endif
 }
@@ -122,13 +122,13 @@ HWND win_create_window_ex_utf8(DWORD exstyle, const char* classname, const char*
 								int x, int y, int width, int height, HWND parent, HMENU menu,
 								HINSTANCE instance, void* param)
 {
-	std::basic_string<TCHAR> ts_classname = tstring_from_utf8(classname);
+	std::basic_string<TCHAR> ts_classname = osd::text::to_tstring(classname);
 
 	LPCTSTR t_windowname = nullptr;
 	std::basic_string<TCHAR> ts_windowname;
 	if (windowname != nullptr)
 	{
-		ts_windowname = tstring_from_utf8(windowname);
+		ts_windowname = osd::text::to_tstring(windowname);
 		t_windowname = ts_windowname.c_str();
 	}
 

--- a/src/osd/windows/winutil.cpp
+++ b/src/osd/windows/winutil.cpp
@@ -106,9 +106,9 @@ void osd_subst_env(std::string &dst, const std::string &src)
 {
 	TCHAR buffer[MAX_PATH];
 
-	tstring t_src = tstring_from_utf8(src);
+	osd::text::tstring t_src = osd::text::to_tstring(src);
 	ExpandEnvironmentStrings(t_src.c_str(), buffer, ARRAY_LENGTH(buffer));
-	utf8_from_tstring(dst, buffer);
+	osd::text::from_tstring(dst, buffer);
 }
 
 //-------------------------------------------------

--- a/src/osd/windows/winutil.cpp
+++ b/src/osd/windows/winutil.cpp
@@ -106,7 +106,7 @@ void osd_subst_env(std::string &dst, const std::string &src)
 {
 	TCHAR buffer[MAX_PATH];
 
-	auto t_src = tstring_from_utf8(src.c_str());
+	tstring t_src = tstring_from_utf8(src);
 	ExpandEnvironmentStrings(t_src.c_str(), buffer, ARRAY_LENGTH(buffer));
 	utf8_from_tstring(dst, buffer);
 }


### PR DESCRIPTION
[a|w|t|utf8]_from_[a|w|t|utf8_]string(xyz.c_str()) seems to be common enough to justify overloads.  Also, I'm explicitly assuming that it is legal to override the NUL pointer within a C++ basic_string (e.g. - s[s.size()] = '\0').  As far as I can tell, this seems to be legal - please don't shoot if I am wrong.