### PR TITLE
witch: Take the "Hopper Active" DSW value into proper account; no lon…

### DIFF
--- a/src/mame/machine/ticket.cpp
+++ b/src/mame/machine/ticket.cpp
@@ -98,6 +98,7 @@ void ticket_dispenser_device::static_set_senses(device_t &device, UINT8 motor_se
 
 //-------------------------------------------------
 //  read - read the status line via the active bit
+//  (legacy method)
 //-------------------------------------------------
 
 READ8_MEMBER( ticket_dispenser_device::read )
@@ -119,7 +120,7 @@ READ_LINE_MEMBER( ticket_dispenser_device::line_r )
 
 //-------------------------------------------------
 //  write - write the control line via the active
-//  bit
+//  bit (legacy method)
 //-------------------------------------------------
 
 WRITE8_MEMBER( ticket_dispenser_device::write )
@@ -147,6 +148,15 @@ WRITE8_MEMBER( ticket_dispenser_device::write )
 	}
 }
 
+//-------------------------------------------------
+//  motor_w - write the control line as a proper
+//  line
+//-------------------------------------------------
+
+WRITE_LINE_MEMBER( ticket_dispenser_device::motor_w )
+{
+	write(machine().driver_data()->generic_space(), 0, state ? m_active_bit : 0);
+}
 
 
 //**************************************************************************

--- a/src/mame/machine/ticket.h
+++ b/src/mame/machine/ticket.h
@@ -64,6 +64,7 @@ public:
 	DECLARE_READ8_MEMBER( read );
 	DECLARE_READ_LINE_MEMBER( line_r );
 	DECLARE_WRITE8_MEMBER( write );
+	DECLARE_WRITE_LINE_MEMBER( motor_w );
 
 protected:
 	// device-level overrides


### PR DESCRIPTION
…ger must it be low

Add ticket_dispenser_device::motor_w as a proper WRITE_LINE method, first step towards eliminating the m_active_bit=0x80 nonsense (nw) (#1485 please take note)