### PR TITLE
Soft resets no longer turn back clocks on devices

### DIFF
--- a/src/devices/machine/aicartc.cpp
+++ b/src/devices/machine/aicartc.cpp
@@ -54,40 +54,43 @@ void aicartc_device::device_start()
 {
 	m_clock_timer = timer_alloc();
 	m_clock_timer->adjust(attotime::from_hz(clock()), 0, attotime::from_hz(clock()));
+}
 
-	{
-		UINT32 current_time;
-		int year_count,cur_year,i;
-		const int month_to_day_conversion[12] = { 0, 31, 59, 90, 120, 151, 181, 212, 243, 273, 304, 334 };
-		system_time systime;
-		machine().base_datetime(systime);
 
-		/* put the seconds */
-		current_time = systime.local_time.second;
-		/* put the minutes */
-		current_time+= systime.local_time.minute*60;
-		/* put the hours */
-		current_time+= systime.local_time.hour*60*60;
-		/* put the days (note -1) */
-		current_time+= (systime.local_time.mday-1)*60*60*24;
-		/* take the current year here for calculating leaps */
-		cur_year = (systime.local_time.year);
+//-------------------------------------------------
+//  rtc_clock_updated -
+//-------------------------------------------------
 
-		/* take the months - despite popular beliefs, leap years aren't just evenly divisible by 4 */
-		if(((((cur_year % 4) == 0) && ((cur_year % 100) != 0)) || ((cur_year % 400) == 0)) && systime.local_time.month > 2)
-			current_time+= (month_to_day_conversion[systime.local_time.month]+1)*60*60*24;
-		else
-			current_time+= (month_to_day_conversion[systime.local_time.month])*60*60*24;
+void aicartc_device::rtc_clock_updated(int year, int month, int day, int day_of_week, int hour, int minute, int second)
+{
+	const int month_to_day_conversion[12] = { 0, 31, 59, 90, 120, 151, 181, 212, 243, 273, 304, 334 };
 
-		/* put the years */
-		year_count = (cur_year-1949);
+	// put the seconds
+	UINT32 current_time = second;
 
-		for(i=0;i<year_count-1;i++)
-			current_time += (((((i+1950) % 4) == 0) && (((i+1950) % 100) != 0)) || (((i+1950) % 400) == 0)) ? 60*60*24*366 : 60*60*24*365;
+	// put the minutes
+	current_time += minute * 60;
+	
+	// put the hours
+	current_time += hour * 60 * 60;
+	
+	// put the days (note -1) */
+	current_time += (day - 1) * 60 * 60 * 24;
 
-		m_rtc_reg_lo = current_time & 0x0000ffff;
-		m_rtc_reg_hi = (current_time & 0xffff0000) >> 16;
-	}
+	// take the months - despite popular beliefs, leap years aren't just evenly divisible by 4 */
+	if (((((year % 4) == 0) && ((year % 100) != 0)) || ((year % 400) == 0)) && month > 2)
+		current_time += (month_to_day_conversion[month - 1] + 1) * 60 * 60 * 24;
+	else
+		current_time += (month_to_day_conversion[month - 1]) * 60 * 60 * 24;
+
+	// put the years
+	int year_count = (year - 1949);
+
+	for (int i = 0; i < year_count - 1; i++)
+		current_time += (((((i+1950) % 4) == 0) && (((i+1950) % 100) != 0)) || (((i+1950) % 400) == 0)) ? 60*60*24*366 : 60*60*24*365;
+
+	m_rtc_reg_lo = current_time & 0x0000ffff;
+	m_rtc_reg_hi = (current_time & 0xffff0000) >> 16;
 }
 
 

--- a/src/devices/machine/aicartc.h
+++ b/src/devices/machine/aicartc.h
@@ -11,6 +11,7 @@ Template for skeleton device
 #ifndef __AICARTCDEV_H__
 #define __AICARTCDEV_H__
 
+#include "dirtc.h"
 
 
 //**************************************************************************
@@ -47,6 +48,11 @@ protected:
 	virtual void device_start() override;
 	virtual void device_reset() override;
 	virtual void device_timer(emu_timer &timer, device_timer_id id, int param, void *ptr) override;
+
+	// device_rtc_interface overrides
+	virtual bool rtc_feature_y2k() const override { return true; }
+	virtual bool rtc_feature_leap_year() const override { return true; }
+	virtual void rtc_clock_updated(int year, int month, int day, int day_of_week, int hour, int minute, int second) override;
 
 private:
 	emu_timer *m_clock_timer;

--- a/src/devices/machine/ds1302.cpp
+++ b/src/devices/machine/ds1302.cpp
@@ -113,8 +113,6 @@ void ds1302_device::device_start()
 
 void ds1302_device::device_reset()
 {
-	set_current_time(machine());
-
 	m_clk = 0;
 	m_ce = 0;
 	m_state = STATE_COMMAND;

--- a/src/devices/machine/ds1302.h
+++ b/src/devices/machine/ds1302.h
@@ -18,7 +18,7 @@
 #ifndef __DS1302_H__
 #define __DS1302_H__
 
-#include "emu.h"
+#include "dirtc.h"
 
 
 
@@ -63,7 +63,7 @@ protected:
 
 	// device_rtc_interface overrides
 	virtual void rtc_clock_updated(int year, int month, int day, int day_of_week, int hour, int minute, int second) override;
-	virtual bool rtc_feature_leap_year() override { return true; }
+	virtual bool rtc_feature_leap_year() const override { return true; }
 
 private:
 	void load_shift_register();

--- a/src/devices/machine/e0516.cpp
+++ b/src/devices/machine/e0516.cpp
@@ -68,16 +68,6 @@ void e0516_device::device_start()
 
 
 //-------------------------------------------------
-//  device_reset - device-specific reset
-//-------------------------------------------------
-
-void e0516_device::device_reset()
-{
-	set_current_time(machine());
-}
-
-
-//-------------------------------------------------
 //  device_timer - handler timer events
 //-------------------------------------------------
 
@@ -195,4 +185,13 @@ WRITE_LINE_MEMBER( e0516_device::dio_w )
 READ_LINE_MEMBER( e0516_device::dio_r )
 {
 	return m_dio;
+}
+
+
+//-------------------------------------------------
+//  rtc_clock_updated -
+//-------------------------------------------------
+
+void e0516_device::rtc_clock_updated(int year, int month, int day, int day_of_week, int hour, int minute, int second)
+{
 }

--- a/src/devices/machine/e0516.h
+++ b/src/devices/machine/e0516.h
@@ -22,7 +22,7 @@
 #ifndef __E0516__
 #define __E0516__
 
-#include "emu.h"
+#include "dirtc.h"
 
 
 
@@ -56,8 +56,10 @@ public:
 protected:
 	// device-level overrides
 	virtual void device_start() override;
-	virtual void device_reset() override;
 	virtual void device_timer(emu_timer &timer, device_timer_id id, int param, void *ptr) override;
+
+	// device_rtc_interface overrides
+	virtual void rtc_clock_updated(int year, int month, int day, int day_of_week, int hour, int minute, int second) override;
 
 private:
 	int m_cs;                       // chip select

--- a/src/devices/machine/hd64610.cpp
+++ b/src/devices/machine/hd64610.cpp
@@ -183,16 +183,6 @@ void hd64610_device::device_start()
 
 
 //-------------------------------------------------
-//  device_start - device-specific reset
-//-------------------------------------------------
-
-void hd64610_device::device_reset()
-{
-	set_current_time(machine());
-}
-
-
-//-------------------------------------------------
 //  device_timer - handler timer events
 //-------------------------------------------------
 

--- a/src/devices/machine/hd64610.h
+++ b/src/devices/machine/hd64610.h
@@ -26,7 +26,7 @@
 #ifndef __HD64610__
 #define __HD64610__
 
-#include "emu.h"
+#include "dirtc.h"
 
 
 
@@ -67,7 +67,6 @@ public:
 protected:
 	// device-level overrides
 	virtual void device_start() override;
-	virtual void device_reset() override;
 	virtual void device_timer(emu_timer &timer, device_timer_id id, int param, void *ptr) override;
 
 	// device_rtc_interface overrides

--- a/src/devices/machine/mccs1850.cpp
+++ b/src/devices/machine/mccs1850.cpp
@@ -299,13 +299,17 @@ mccs1850_device::mccs1850_device(const machine_config &mconfig, const char *tag,
 
 
 //-------------------------------------------------
-//  set_counter - set the counter at startup time
+//  rtc_clock_changed -
 //-------------------------------------------------
 
-void mccs1850_device::set_counter(UINT32 value)
+void mccs1850_device::rtc_clock_updated(int year, int month, int day, int day_of_week, int hour, int minute, int second)
 {
-	m_counter = value;
+	// FIXME: implement this properly
+	system_time systime;
+	machine().base_datetime(systime);
+	m_counter = systime.time;
 }
+
 
 //-------------------------------------------------
 //  device_start - device-specific startup

--- a/src/devices/machine/mccs1850.h
+++ b/src/devices/machine/mccs1850.h
@@ -22,7 +22,7 @@
 #ifndef __MCCS1850__
 #define __MCCS1850__
 
-#include "emu.h"
+#include "dirtc.h"
 
 
 
@@ -67,9 +67,6 @@ public:
 	DECLARE_WRITE_LINE_MEMBER( por_w );
 	DECLARE_WRITE_LINE_MEMBER( test_w );
 
-	// For setting the time at startup
-	void set_counter(UINT32 value);
-
 protected:
 	// device-level overrides
 	virtual void device_start() override;
@@ -80,6 +77,9 @@ protected:
 	virtual void nvram_default() override;
 	virtual void nvram_read(emu_file &file) override;
 	virtual void nvram_write(emu_file &file) override;
+
+	// device_rtc_interface overrides
+	virtual void rtc_clock_updated(int year, int month, int day, int day_of_week, int hour, int minute, int second) override;
 
 private:
 	inline void check_interrupt();

--- a/src/devices/machine/mm58167.cpp
+++ b/src/devices/machine/mm58167.cpp
@@ -83,8 +83,6 @@ void mm58167_device::device_start()
 
 void mm58167_device::device_reset()
 {
-	set_current_time(machine());
-
 	m_regs[R_CTL_STATUS] = 0;   // not busy
 	m_regs[R_CTL_IRQSTATUS] = 0;
 	m_regs[R_CTL_IRQCONTROL] = 0;

--- a/src/devices/machine/mm58167.h
+++ b/src/devices/machine/mm58167.h
@@ -11,7 +11,7 @@
 #ifndef __MM58167_H__
 #define __MM58167_H__
 
-#include "emu.h"
+#include "dirtc.h"
 
 
 //**************************************************************************
@@ -50,7 +50,7 @@ protected:
 
 	// device_rtc_interface overrides
 	virtual void rtc_clock_updated(int year, int month, int day, int day_of_week, int hour, int minute, int second) override;
-	virtual bool rtc_feature_leap_year() override { return true; }
+	virtual bool rtc_feature_leap_year() const override { return true; }
 
 	void set_irq(int bit);
 	void update_rtc();

--- a/src/devices/machine/msm5832.cpp
+++ b/src/devices/machine/msm5832.cpp
@@ -122,16 +122,6 @@ void msm5832_device::device_start()
 
 
 //-------------------------------------------------
-//  device_reset - device-specific reset
-//-------------------------------------------------
-
-void msm5832_device::device_reset()
-{
-	set_current_time(machine());
-}
-
-
-//-------------------------------------------------
 //  device_timer - handler timer events
 //-------------------------------------------------
 

--- a/src/devices/machine/msm5832.h
+++ b/src/devices/machine/msm5832.h
@@ -23,7 +23,7 @@
 #ifndef __MSM5832__
 #define __MSM5832__
 
-#include "emu.h"
+#include "dirtc.h"
 
 
 
@@ -65,7 +65,6 @@ public:
 protected:
 	// device-level overrides
 	virtual void device_start() override;
-	virtual void device_reset() override;
 	virtual void device_timer(emu_timer &timer, device_timer_id id, int param, void *ptr) override;
 
 	// device_rtc_interface overrides

--- a/src/devices/machine/msm58321.cpp
+++ b/src/devices/machine/msm58321.cpp
@@ -243,10 +243,6 @@ void msm58321_device::device_start()
 	save_item(NAME(m_cs1));
 	save_item(NAME(m_address));
 	save_item(NAME(m_reg));
-
-	set_current_time(machine());
-
-	update_output();
 }
 
 

--- a/src/devices/machine/msm58321.h
+++ b/src/devices/machine/msm58321.h
@@ -22,7 +22,7 @@
 #ifndef __MSM58321__
 #define __MSM58321__
 
-#include "emu.h"
+#include "dirtc.h"
 
 
 
@@ -89,7 +89,7 @@ protected:
 
 	// device_rtc_interface overrides
 	virtual void rtc_clock_updated(int year, int month, int day, int day_of_week, int hour, int minute, int second) override;
-	virtual bool rtc_feature_y2k() override { return m_year0 != 0; }
+	virtual bool rtc_feature_y2k() const override { return m_year0 != 0; }
 
 	// device_nvram_interface overrides
 	virtual void nvram_default() override;

--- a/src/devices/machine/msm6242.cpp
+++ b/src/devices/machine/msm6242.cpp
@@ -86,9 +86,6 @@ void msm6242_device::device_start()
 	m_timer = timer_alloc(TIMER_RTC_CALLBACK);
 	m_timer->adjust(attotime::zero);
 
-	// get real time from system
-	set_current_time(machine());
-
 	// set up registers
 	m_tick = 0;
 	m_irq_flag = 0;

--- a/src/devices/machine/msm6242.h
+++ b/src/devices/machine/msm6242.h
@@ -11,7 +11,7 @@
 #ifndef __MSM6242DEV_H__
 #define __MSM6242DEV_H__
 
-#include "emu.h"
+#include "dirtc.h"
 
 
 #define MCFG_MSM6242_OUT_INT_HANDLER(_devcb) \

--- a/src/devices/machine/pcf8593.h
+++ b/src/devices/machine/pcf8593.h
@@ -11,7 +11,7 @@
 #ifndef __PCF8593_H__
 #define __PCF8593_H__
 
-#include "emu.h"
+#include "dirtc.h"
 
 
 //**************************************************************************
@@ -45,7 +45,7 @@ protected:
 	virtual void device_timer(emu_timer &timer, device_timer_id id, int param, void *ptr) override;
 
 	// device_rtc_interface overrides
-	virtual bool rtc_feature_y2k() override { return true; }
+	virtual bool rtc_feature_y2k() const override { return true; }
 	virtual void rtc_clock_updated(int year, int month, int day, int day_of_week, int hour, int minute, int second) override;
 
 	// device_nvram_interface overrides

--- a/src/devices/machine/rp5c01.cpp
+++ b/src/devices/machine/rp5c01.cpp
@@ -224,9 +224,6 @@ void rp5c01_device::device_reset()
 
 	// 24 hour mode
 	m_reg[MODE01][REGISTER_12_24_SELECT] = 1;
-
-	if (m_battery_backed && clock() > 0)
-		set_current_time(machine());
 }
 
 

--- a/src/devices/machine/rp5c01.h
+++ b/src/devices/machine/rp5c01.h
@@ -23,7 +23,7 @@
 #ifndef __RP5C01__
 #define __RP5C01__
 
-#include "emu.h"
+#include "dirtc.h"
 
 
 
@@ -68,7 +68,8 @@ protected:
 	virtual void device_timer(emu_timer &timer, device_timer_id id, int param, void *ptr) override;
 
 	// device_rtc_interface overrides
-	virtual bool rtc_feature_leap_year() override { return true; }
+	virtual bool rtc_feature_leap_year() const override { return true; }
+	virtual bool rtc_battery_backed() const override { return m_battery_backed; }
 	virtual void rtc_clock_updated(int year, int month, int day, int day_of_week, int hour, int minute, int second) override;
 
 	// device_nvram_interface overrides

--- a/src/devices/machine/rp5c15.cpp
+++ b/src/devices/machine/rp5c15.cpp
@@ -238,16 +238,6 @@ void rp5c15_device::device_start()
 
 
 //-------------------------------------------------
-//  device_reset - device-specific reset
-//-------------------------------------------------
-
-void rp5c15_device::device_reset()
-{
-	set_current_time(machine());
-}
-
-
-//-------------------------------------------------
 //  device_timer - handler timer events
 //-------------------------------------------------
 

--- a/src/devices/machine/rp5c15.h
+++ b/src/devices/machine/rp5c15.h
@@ -23,7 +23,7 @@
 #ifndef __RP5C15__
 #define __RP5C15__
 
-#include "emu.h"
+#include "dirtc.h"
 
 
 
@@ -59,11 +59,10 @@ public:
 protected:
 	// device-level overrides
 	virtual void device_start() override;
-	virtual void device_reset() override;
 	virtual void device_timer(emu_timer &timer, device_timer_id id, int param, void *ptr) override;
 
 	// device_rtc_interface overrides
-	virtual bool rtc_feature_leap_year() override { return true; }
+	virtual bool rtc_feature_leap_year() const override { return true; }
 	virtual void rtc_clock_updated(int year, int month, int day, int day_of_week, int hour, int minute, int second) override;
 
 private:

--- a/src/devices/machine/rtc4543.cpp
+++ b/src/devices/machine/rtc4543.cpp
@@ -89,8 +89,6 @@ void rtc4543_device::device_start()
 
 void rtc4543_device::device_reset()
 {
-	set_current_time(machine());
-
 	m_ce = 0;
 	m_wr = 0;
 	m_clk = 0;

--- a/src/devices/machine/rtc4543.h
+++ b/src/devices/machine/rtc4543.h
@@ -12,7 +12,7 @@
 #ifndef __RTC4543_H__
 #define __RTC4543_H__
 
-#include "emu.h"
+#include "dirtc.h"
 
 
 
@@ -63,7 +63,7 @@ protected:
 
 	// device_rtc_interface overrides
 	virtual void rtc_clock_updated(int year, int month, int day, int day_of_week, int hour, int minute, int second) override;
-	virtual bool rtc_feature_leap_year() override { return true; }
+	virtual bool rtc_feature_leap_year() const override { return true; }
 
 	// helpers
 	virtual void ce_rising();

--- a/src/devices/machine/upd1990a.cpp
+++ b/src/devices/machine/upd1990a.cpp
@@ -83,9 +83,6 @@ void upd1990a_device::device_start()
 	m_write_data.resolve_safe();
 	m_write_tp.resolve_safe();
 
-	// initialize
-	set_current_time(machine());
-
 	for (auto & elem : m_shift_reg)
 		elem = 0;
 

--- a/src/devices/machine/upd1990a.h
+++ b/src/devices/machine/upd1990a.h
@@ -21,7 +21,7 @@
 #ifndef __UPD1990A__
 #define __UPD1990A__
 
-#include "emu.h"
+#include "dirtc.h"
 
 
 

--- a/src/devices/machine/upd4992.cpp
+++ b/src/devices/machine/upd4992.cpp
@@ -61,16 +61,6 @@ void upd4992_device::device_start()
 }
 
 
-//-------------------------------------------------
-//  device_reset - device-specific reset
-//-------------------------------------------------
-
-void upd4992_device::device_reset()
-{
-	set_current_time(machine());
-}
-
-
 void upd4992_device::device_timer(emu_timer &timer, device_timer_id id, int param, void *ptr)
 {
 	switch (id)

--- a/src/devices/machine/upd4992.h
+++ b/src/devices/machine/upd4992.h
@@ -11,6 +11,7 @@
 #ifndef __UPD4992DEV_H__
 #define __UPD4992DEV_H__
 
+#include "dirtc.h"
 
 
 //**************************************************************************
@@ -41,7 +42,6 @@ protected:
 	// device-level overrides
 	virtual void device_validity_check(validity_checker &valid) const override;
 	virtual void device_start() override;
-	virtual void device_reset() override;
 	virtual void device_timer(emu_timer &timer, device_timer_id id, int param, void *ptr) override;
 	virtual void rtc_clock_updated(int year, int month, int day, int day_of_week, int hour, int minute, int second) override;
 

--- a/src/emu/dirtc.cpp
+++ b/src/emu/dirtc.cpp
@@ -9,7 +9,7 @@
 ***************************************************************************/
 
 #include "emu.h"
-
+#include "dirtc.h"
 
 
 //**************************************************************************
@@ -76,11 +76,8 @@ void device_rtc_interface::set_time(bool update, int year, int month, int day, i
 //  to the current system time
 //-------------------------------------------------
 
-void device_rtc_interface::set_current_time(running_machine &machine)
+void device_rtc_interface::set_current_time(const system_time &systime)
 {
-	system_time systime;
-	machine.base_datetime(systime);
-
 	set_time(true, systime.local_time.year, systime.local_time.month + 1, systime.local_time.mday, systime.local_time.weekday + 1,
 		systime.local_time.hour, systime.local_time.minute, systime.local_time.second);
 }

--- a/src/emu/dirtc.h
+++ b/src/emu/dirtc.h
@@ -10,10 +10,6 @@
 
 #pragma once
 
-#ifndef __EMU_H__
-#error Dont include this file directly; include emu.h instead.
-#endif
-
 #ifndef __DIRTC_H__
 #define __DIRTC_H__
 
@@ -52,7 +48,9 @@ public:
 	virtual ~device_rtc_interface();
 
 	void set_time(bool update, int year, int month, int day, int day_of_week, int hour, int minute, int second);
-	void set_current_time(running_machine &machine);
+	void set_current_time(const system_time &systime);
+
+	bool has_battery() const { return rtc_battery_backed(); }
 
 protected:
 	static UINT8 convert_to_bcd(int val);
@@ -68,12 +66,16 @@ protected:
 	void adjust_seconds();
 
 	// derived class overrides
-	virtual bool rtc_feature_y2k() { return false; }
-	virtual bool rtc_feature_leap_year() { return false; }
-	virtual void rtc_clock_updated(int year, int month, int day, int day_of_week, int hour, int minute, int second) { }
+	virtual bool rtc_feature_y2k() const { return false; }
+	virtual bool rtc_feature_leap_year() const { return false; }
+	virtual bool rtc_battery_backed() const { return true; }
+	virtual void rtc_clock_updated(int year, int month, int day, int day_of_week, int hour, int minute, int second) = 0;
 
 	int m_register[7];
 };
+
+// iterator
+typedef device_interface_iterator<device_rtc_interface> rtc_interface_iterator;
 
 
 #endif  /* __DIRTC_H__ */

--- a/src/emu/emu.h
+++ b/src/emu/emu.h
@@ -78,7 +78,6 @@ typedef device_t * (*machine_config_constructor)(machine_config &config, device_
 #include "disound.h"
 #include "divideo.h"
 #include "dinvram.h"
-#include "dirtc.h"
 #include "didisasm.h"
 #include "schedule.h"
 #include "timer.h"

--- a/src/emu/machine.h
+++ b/src/emu/machine.h
@@ -107,6 +107,7 @@ class system_time
 {
 public:
 	system_time();
+	explicit system_time(time_t t);
 	void set(time_t t);
 
 	struct full_time
@@ -226,6 +227,7 @@ public:
 	// date & time
 	void base_datetime(system_time &systime);
 	void current_datetime(system_time &systime);
+	void set_rtc_datetime(const system_time &systime);
 
 	// misc
 	void popmessage() const { popmessage(static_cast<char const *>(nullptr)); }

--- a/src/mame/drivers/next.cpp
+++ b/src/mame/drivers/next.cpp
@@ -874,10 +874,6 @@ void next_state::machine_start()
 	}
 
 	timer_tm = timer_alloc(0);
-
-	system_time systime;
-	machine().base_datetime(systime);
-	rtc->set_counter(systime.time);
 }
 
 void next_state::machine_reset()

--- a/src/mame/machine/macrtc.cpp
+++ b/src/mame/machine/macrtc.cpp
@@ -62,8 +62,6 @@ void rtc3430042_device::device_start()
 
 void rtc3430042_device::device_reset()
 {
-	set_current_time(machine());
-
 	m_rtc_rTCEnb = 0;
 	m_rtc_rTCClk = 0;
 	m_rtc_bit_count = 0;

--- a/src/mame/machine/macrtc.h
+++ b/src/mame/machine/macrtc.h
@@ -12,7 +12,7 @@
 #ifndef __RTC3430042_H__
 #define __RTC3430042_H__
 
-#include "emu.h"
+#include "dirtc.h"
 
 
 //**************************************************************************
@@ -51,7 +51,7 @@ protected:
 
 	// device_rtc_interface overrides
 	virtual void rtc_clock_updated(int year, int month, int day, int day_of_week, int hour, int minute, int second) override;
-	virtual bool rtc_feature_leap_year() override { return true; }
+	virtual bool rtc_feature_leap_year() const override { return true; }
 
 	// device_nvram_interface overrides
 	virtual void nvram_default() override;


### PR DESCRIPTION
device_rtc_interface: Cleanups and refinements (nw)
- Give RTCs their own phase of machine initialization, right after NVRAM loading
- Make RTC feature flag overrides const, including one new one
- Make rtc_clock_updated a required override