### PR TITLE
Fix clock regression with RP5C01 (nw)

### DIFF
--- a/src/devices/machine/rp5c01.cpp
+++ b/src/devices/machine/rp5c01.cpp
@@ -201,6 +201,12 @@ void rp5c01_device::device_start()
 		m_16hz_timer->adjust(attotime::from_hz(clock() / 1024), 0, attotime::from_hz(clock() / 1024));
 	}
 
+	memset(m_reg, 0, sizeof(m_reg));
+	memset(m_ram, 0, sizeof(m_ram));
+
+	// 24 hour mode
+	m_reg[MODE01][REGISTER_12_24_SELECT] = 1;
+
 	// state saving
 	save_item(NAME(m_reg[MODE00]));
 	save_item(NAME(m_reg[MODE01]));
@@ -210,20 +216,6 @@ void rp5c01_device::device_start()
 	save_item(NAME(m_alarm_on));
 	save_item(NAME(m_1hz));
 	save_item(NAME(m_16hz));
-}
-
-
-//-------------------------------------------------
-//  device_reset - device-specific reset
-//-------------------------------------------------
-
-void rp5c01_device::device_reset()
-{
-	memset(m_reg, 0, sizeof(m_reg));
-	memset(m_ram, 0, sizeof(m_ram));
-
-	// 24 hour mode
-	m_reg[MODE01][REGISTER_12_24_SELECT] = 1;
 }
 
 

--- a/src/devices/machine/rp5c01.h
+++ b/src/devices/machine/rp5c01.h
@@ -64,7 +64,6 @@ public:
 protected:
 	// device-level overrides
 	virtual void device_start() override;
-	virtual void device_reset() override;
 	virtual void device_timer(emu_timer &timer, device_timer_id id, int param, void *ptr) override;
 
 	// device_rtc_interface overrides


### PR DESCRIPTION
This also makes the RP5C01's NVRAM actually non-volatile (previously it would be cleared upon reset after being loaded).

The RP5C01 has a power supply line but no reset signal input, so device_reset doesn't seem to make sense here.