### PR TITLE
Fix typo in 8530scc.cpp

### DIFF
--- a/src/devices/machine/8530scc.cpp
+++ b/src/devices/machine/8530scc.cpp
@@ -530,7 +530,7 @@ void scc8530_t::write_reg(int offset, UINT8 data)
 		case 0: /* Channel B (Printer Port) Control */
 		case 1: /* Channel A (Modem Port) Control */
 		{
-			int chan = ((offset == 2) ? 1 : 0);
+			int chan = ((offset == 0) ? 1 : 0);
 			if (mode == 0)
 			{
 				if((data & 0xf0) == 0)  // not a reset command


### PR DESCRIPTION
This patch fixes a typo in 8530scc.cpp. This typo was causing the Mac emulator from being able to boot System 7 without locking up during the boot process. With this patch, 7.5.3 Rev. 2 is able to boot normally.