### PR TITLE
[Imgtool] Changed the create/open callbacks to take 'imgtool::stream &&'

### DIFF
--- a/src/tools/imgtool/iflopimg.cpp
+++ b/src/tools/imgtool/iflopimg.cpp
@@ -105,7 +105,7 @@ struct imgtool_floppy_image
 static imgtoolerr_t imgtool_floppy_open_internal(imgtool::image *image, imgtool::stream::ptr &&stream, int noclose)
 {
 	floperr_t ferr;
-	imgtoolerr_t err;
+	imgtoolerr_t err = IMGTOOLERR_SUCCESS;
 	imgtool::stream *f = nullptr;
 	struct imgtool_floppy_image *fimg;
 	const imgtool_class *imgclass;
@@ -126,7 +126,7 @@ static imgtoolerr_t imgtool_floppy_open_internal(imgtool::image *image, imgtool:
 	if (ferr)
 	{
 		err = imgtool_floppy_error(ferr);
-		return err;
+		goto done;
 	}
 	f = nullptr;	// the floppy object has the stream now
 
@@ -134,10 +134,13 @@ static imgtoolerr_t imgtool_floppy_open_internal(imgtool::image *image, imgtool:
 	{
 		err = open(image, nullptr);
 		if (err)
-			return err;
+			goto done;
 	}
 
-	return IMGTOOLERR_SUCCESS;
+done:
+	if (f)
+		delete f;
+	return err;
 }
 
 

--- a/src/tools/imgtool/iflopimg.cpp
+++ b/src/tools/imgtool/iflopimg.cpp
@@ -102,10 +102,11 @@ struct imgtool_floppy_image
 
 
 
-static imgtoolerr_t imgtool_floppy_open_internal(imgtool::image *image, imgtool::stream &f, int noclose)
+static imgtoolerr_t imgtool_floppy_open_internal(imgtool::image *image, imgtool::stream::ptr &&stream, int noclose)
 {
 	floperr_t ferr;
 	imgtoolerr_t err;
+	imgtool::stream *f = nullptr;
 	struct imgtool_floppy_image *fimg;
 	const imgtool_class *imgclass;
 	const struct FloppyFormat *format;
@@ -116,14 +117,18 @@ static imgtoolerr_t imgtool_floppy_open_internal(imgtool::image *image, imgtool:
 	format = (const struct FloppyFormat *) imgclass->derived_param;
 	open = (imgtoolerr_t (*)(imgtool::image *, imgtool::stream *)) imgtool_get_info_ptr(imgclass, IMGTOOLINFO_PTR_FLOPPY_OPEN);
 
-	/* open up the floppy */
-	ferr = floppy_open(&f, noclose ? &imgtool_noclose_ioprocs : &imgtool_ioprocs,
+	// extract the pointer
+	f = stream.release();
+
+	// open up the floppy
+	ferr = floppy_open(f, noclose ? &imgtool_noclose_ioprocs : &imgtool_ioprocs,
 		"", format, FLOPPY_FLAGS_READWRITE, &fimg->floppy);
 	if (ferr)
 	{
 		err = imgtool_floppy_error(ferr);
 		return err;
 	}
+	f = nullptr;	// the floppy object has the stream now
 
 	if (open)
 	{
@@ -137,17 +142,18 @@ static imgtoolerr_t imgtool_floppy_open_internal(imgtool::image *image, imgtool:
 
 
 
-static imgtoolerr_t imgtool_floppy_open(imgtool::image *image, imgtool::stream &f)
+static imgtoolerr_t imgtool_floppy_open(imgtool::image *image, imgtool::stream::ptr &&stream)
 {
-	return imgtool_floppy_open_internal(image, f, FALSE);
+	return imgtool_floppy_open_internal(image, std::move(stream), FALSE);
 }
 
 
 
-static imgtoolerr_t imgtool_floppy_create(imgtool::image *image, imgtool::stream &f, util::option_resolution *opts)
+static imgtoolerr_t imgtool_floppy_create(imgtool::image *image, imgtool::stream::ptr &&stream, util::option_resolution *opts)
 {
 	floperr_t ferr;
 	imgtoolerr_t err = IMGTOOLERR_SUCCESS;
+	imgtool::stream *f = nullptr;
 	struct imgtool_floppy_image *fimg;
 	const imgtool_class *imgclass;
 	const struct FloppyFormat *format;
@@ -160,15 +166,19 @@ static imgtoolerr_t imgtool_floppy_create(imgtool::image *image, imgtool::stream
 	create = (imgtoolerr_t (*)(imgtool::image *, imgtool::stream *, util::option_resolution *)) imgtool_get_info_ptr(imgclass, IMGTOOLINFO_PTR_FLOPPY_CREATE);
 	open = (imgtoolerr_t (*)(imgtool::image *, imgtool::stream *)) imgtool_get_info_ptr(imgclass, IMGTOOLINFO_PTR_FLOPPY_OPEN);
 
-	/* open up the floppy */
-	ferr = floppy_create(&f, &imgtool_ioprocs, format, opts, &fimg->floppy);
+	// extract the pointer
+	f = stream.release();
+
+	// open up the floppy
+	ferr = floppy_create(f, &imgtool_ioprocs, format, opts, &fimg->floppy);
 	if (ferr)
 	{
 		err = imgtool_floppy_error(ferr);
 		goto done;
 	}
+	f = nullptr;	// the floppy object has the stream now
 
-	/* do we have to do extra stuff when creating the image? */
+	// do we have to do extra stuff when creating the image?
 	if (create)
 	{
 		err = create(image, nullptr, opts);
@@ -176,7 +186,7 @@ static imgtoolerr_t imgtool_floppy_create(imgtool::image *image, imgtool::stream
 			goto done;
 	}
 
-	/* do we have to do extra stuff when opening the image? */
+	// do we have to do extra stuff when opening the image?
 	if (open)
 	{
 		err = open(image, nullptr);
@@ -185,6 +195,8 @@ static imgtoolerr_t imgtool_floppy_create(imgtool::image *image, imgtool::stream
 	}
 
 done:
+	if (f)
+		delete f;
 	return err;
 }
 

--- a/src/tools/imgtool/imghd.cpp
+++ b/src/tools/imgtool/imghd.cpp
@@ -218,7 +218,7 @@ const hard_disk_info *imghd_get_header(struct mess_hard_disk_file *disk)
 }
 
 
-static imgtoolerr_t mess_hd_image_create(imgtool::image *image, imgtool::stream &f, util::option_resolution *createoptions);
+static imgtoolerr_t mess_hd_image_create(imgtool::image *image, imgtool::stream::ptr &&stream, util::option_resolution *createoptions);
 
 enum
 {
@@ -257,7 +257,7 @@ void hd_get_info(const imgtool_class *imgclass, UINT32 state, union imgtoolinfo 
 
 
 
-static imgtoolerr_t mess_hd_image_create(imgtool::image *image, imgtool::stream &f, util::option_resolution *createoptions)
+static imgtoolerr_t mess_hd_image_create(imgtool::image *image, imgtool::stream::ptr &&stream, util::option_resolution *createoptions)
 {
 	UINT32  blocksize, cylinders, heads, sectors, seclen;
 
@@ -268,5 +268,5 @@ static imgtoolerr_t mess_hd_image_create(imgtool::image *image, imgtool::stream 
 	sectors = createoptions->lookup_int(mess_hd_createopts_sectors);
 	seclen = createoptions->lookup_int(mess_hd_createopts_seclen);
 
-	return imghd_create(f, blocksize, cylinders, heads, sectors, seclen);
+	return imghd_create(*stream.get(), blocksize, cylinders, heads, sectors, seclen);
 }

--- a/src/tools/imgtool/library.cpp
+++ b/src/tools/imgtool/library.cpp
@@ -69,8 +69,8 @@ void library::add_class(const imgtool_class *imgclass)
 	module->tracks_are_called_cylinders = imgtool_get_info_int(imgclass, IMGTOOLINFO_INT_TRACKS_ARE_CALLED_CYLINDERS) ? 1 : 0;
 	module->writing_untested            = imgtool_get_info_int(imgclass, IMGTOOLINFO_INT_WRITING_UNTESTED) ? 1 : 0;
 	module->creation_untested           = imgtool_get_info_int(imgclass, IMGTOOLINFO_INT_CREATION_UNTESTED) ? 1 : 0;
-	module->open                        = (imgtoolerr_t (*)(imgtool::image *, imgtool::stream *)) imgtool_get_info_fct(imgclass, IMGTOOLINFO_PTR_OPEN);
-	module->create                      = (imgtoolerr_t (*)(imgtool::image *, imgtool::stream *, util::option_resolution *)) imgtool_get_info_fct(imgclass, IMGTOOLINFO_PTR_CREATE);
+	module->open                        = (imgtoolerr_t (*)(imgtool::image *, imgtool::stream::ptr &&)) imgtool_get_info_fct(imgclass, IMGTOOLINFO_PTR_OPEN);
+	module->create                      = (imgtoolerr_t (*)(imgtool::image *, imgtool::stream::ptr &&, util::option_resolution *)) imgtool_get_info_fct(imgclass, IMGTOOLINFO_PTR_CREATE);
 	module->close                       = (void (*)(imgtool::image *)) imgtool_get_info_fct(imgclass, IMGTOOLINFO_PTR_CLOSE);
 	module->info                        = (void (*)(imgtool::image *, char *, size_t)) imgtool_get_info_fct(imgclass, IMGTOOLINFO_PTR_INFO);
 	module->read_sector                 = (imgtoolerr_t (*)(imgtool::image *, UINT32, UINT32, UINT32, std::vector<UINT8> &)) imgtool_get_info_fct(imgclass, IMGTOOLINFO_PTR_READ_SECTOR);

--- a/src/tools/imgtool/library.h
+++ b/src/tools/imgtool/library.h
@@ -254,9 +254,9 @@ union imgtoolinfo
 	void *  f;                                          /* generic function pointers */
 	char *  s;                                          /* generic strings */
 
-	imgtoolerr_t    (*open)             (imgtool::image *image, imgtool::stream &stream);
+	imgtoolerr_t    (*open)             (imgtool::image *image, imgtool::stream::ptr &&stream);
 	void            (*close)            (imgtool::image *image);
-	imgtoolerr_t    (*create)           (imgtool::image *image, imgtool::stream &stream, util::option_resolution *opts);
+	imgtoolerr_t    (*create)           (imgtool::image *image, imgtool::stream::ptr &&stream, util::option_resolution *opts);
 	imgtoolerr_t    (*create_partition) (imgtool::image *image, UINT64 first_block, UINT64 block_count);
 	void            (*info)             (imgtool::image *image, char *string, size_t len);
 	imgtoolerr_t    (*begin_enum)       (imgtool::directory *enumeration, const char *path);
@@ -347,10 +347,10 @@ struct imgtool_module
 	unsigned int writing_untested : 1;              /* used when we support writing, but not in main build */
 	unsigned int creation_untested : 1;             /* used when we support creation, but not in main build */
 
-	imgtoolerr_t    (*open)         (imgtool::image *image, imgtool::stream *f);
+	imgtoolerr_t    (*open)         (imgtool::image *image, imgtool::stream::ptr &&stream);
 	void            (*close)        (imgtool::image *image);
 	void            (*info)         (imgtool::image *image, char *string, size_t len);
-	imgtoolerr_t    (*create)       (imgtool::image *image, imgtool::stream *f, util::option_resolution *opts);
+	imgtoolerr_t    (*create)       (imgtool::image *image, imgtool::stream::ptr &&stream, util::option_resolution *opts);
 	imgtoolerr_t    (*get_geometry) (imgtool::image *image, UINT32 *track, UINT32 *heads, UINT32 *sectors);
 	imgtoolerr_t    (*read_sector)  (imgtool::image *image, UINT32 track, UINT32 head, UINT32 sector, std::vector<UINT8> &buffer);
 	imgtoolerr_t    (*write_sector) (imgtool::image *image, UINT32 track, UINT32 head, UINT32 sector, const void *buffer, size_t len);

--- a/src/tools/imgtool/modules/bml3.cpp
+++ b/src/tools/imgtool/modules/bml3.cpp
@@ -498,7 +498,7 @@ static imgtoolerr_t prepare_dirent(UINT8 variant, struct bml3_dirent *ent, const
 
 
 
-static imgtoolerr_t bml3_diskimage_open(imgtool::image *image, imgtool::stream &stream)
+static imgtoolerr_t bml3_diskimage_open(imgtool::image *image, imgtool::stream::ptr &&dummy)
 {
 	// imgtoolerr_t err;
 	floperr_t ferr;

--- a/src/tools/imgtool/modules/concept.cpp
+++ b/src/tools/imgtool/modules/concept.cpp
@@ -126,7 +126,7 @@ struct concept_iterator
 };
 
 
-static imgtoolerr_t concept_image_init(imgtool::image *img, imgtool::stream &f);
+static imgtoolerr_t concept_image_init(imgtool::image *img, imgtool::stream::ptr &&stream);
 static void concept_image_exit(imgtool::image *img);
 static void concept_image_info(imgtool::image *img, char *string, size_t len);
 static imgtoolerr_t concept_image_beginenum(imgtool::directory *enumeration, const char *path);
@@ -260,19 +260,17 @@ static int get_catalog_entry(concept_image *image, const unsigned char *filename
 /*
     Open a file as a concept_image.
 */
-static imgtoolerr_t concept_image_init(imgtool::image *img, imgtool::stream &f)
+static imgtoolerr_t concept_image_init(imgtool::image *img, imgtool::stream::ptr &&stream)
 {
 	concept_image *image = (concept_image *) img->extra_bytes();
 	int reply;
 	int i;
 	unsigned totphysrecs;
 
-	image->file_handle = &f;
-
 	/* read device directory */
 	for (i=0; i<4; i++)
 	{
-		reply = read_physical_record(f, i+2, ((char *) & image->dev_dir)+i*512);
+		reply = read_physical_record(*stream, i+2, ((char *) & image->dev_dir)+i*512);
 		if (reply)
 			return IMGTOOLERR_READERROR;
 	}
@@ -289,6 +287,7 @@ static imgtoolerr_t concept_image_init(imgtool::image *img, imgtool::stream &f)
 		return IMGTOOLERR_CORRUPTIMAGE;
 	}
 
+	image->file_handle = stream.release();
 	return IMGTOOLERR_SUCCESS;
 }
 

--- a/src/tools/imgtool/modules/cybikoxt.cpp
+++ b/src/tools/imgtool/modules/cybikoxt.cpp
@@ -260,9 +260,9 @@ static bool cfs_verify(cybiko_file_system &cfs)
 	return true;
 }
 
-static bool cfs_init(cybiko_file_system &cfs, imgtool::stream &stream)
+static bool cfs_init(cybiko_file_system &cfs, imgtool::stream::ptr &&stream)
 {
-	cfs.stream = &stream;
+	cfs.stream = stream.release();
 	cfs.page_count = 2005;
 	cfs.page_size = 258;
 	cfs.block_count_boot = 5;
@@ -319,11 +319,11 @@ static UINT32 cfs_calc_free_space( cybiko_file_system *cfs, UINT16 blocks)
 	return free_space;
 }
 
-static imgtoolerr_t cybiko_image_open(imgtool::image *image, imgtool::stream &stream)
+static imgtoolerr_t cybiko_image_open(imgtool::image *image, imgtool::stream::ptr &&stream)
 {
 	cybiko_file_system *cfs = (cybiko_file_system*)image->extra_bytes();
 	// init
-	if (!cfs_init(*cfs, stream)) return IMGTOOLERR_CORRUPTIMAGE;
+	if (!cfs_init(*cfs, std::move(stream))) return IMGTOOLERR_CORRUPTIMAGE;
 	// verify
 	if (!cfs_verify(*cfs)) return IMGTOOLERR_CORRUPTIMAGE;
 	// ok
@@ -336,11 +336,11 @@ static void cybiko_image_close(imgtool::image *image)
 	delete cfs->stream;
 }
 
-static imgtoolerr_t cybiko_image_create(imgtool::image *image, imgtool::stream &stream, util::option_resolution *opts)
+static imgtoolerr_t cybiko_image_create(imgtool::image *image, imgtool::stream::ptr &&stream, util::option_resolution *opts)
 {
 	cybiko_file_system *cfs = (cybiko_file_system*)image->extra_bytes();
 	// init
-	if (!cfs_init(*cfs, stream)) return IMGTOOLERR_CORRUPTIMAGE;
+	if (!cfs_init(*cfs, std::move(stream))) return IMGTOOLERR_CORRUPTIMAGE;
 	// format
 	if (!cfs_format(cfs)) return IMGTOOLERR_CORRUPTIMAGE;
 	// ok

--- a/src/tools/imgtool/modules/hp9845_tape.cpp
+++ b/src/tools/imgtool/modules/hp9845_tape.cpp
@@ -1042,22 +1042,27 @@ static tape_image_t& get_tape_image(tape_state_t& ts)
 /********************************************************************************
  * Imgtool functions
  ********************************************************************************/
-static imgtoolerr_t hp9845_tape_open(imgtool::image *image, imgtool::stream &stream)
+static imgtoolerr_t hp9845_tape_open(imgtool::image *image, imgtool::stream::ptr &&stream)
 {
 	tape_state_t& state = get_tape_state(image);
 
-	state.stream = &stream;
+	state.stream = stream.get();
 
 	tape_image_t& tape_image = get_tape_image(state);
 
-	return tape_image.load_from_file(&stream);
+	imgtoolerr_t err = tape_image.load_from_file(state.stream);
+	if (err)
+		return err;
+
+	state.stream = stream.release();
+	return IMGTOOLERR_SUCCESS;
 }
 
-static imgtoolerr_t hp9845_tape_create(imgtool::image *image, imgtool::stream &stream, util::option_resolution *opts)
+static imgtoolerr_t hp9845_tape_create(imgtool::image *image, imgtool::stream::ptr &&stream, util::option_resolution *opts)
 {
 	tape_state_t& state = get_tape_state(image);
 
-	state.stream = &stream;
+	state.stream = stream.release();
 
 	tape_image_t& tape_image = get_tape_image(state);
 

--- a/src/tools/imgtool/modules/mac.cpp
+++ b/src/tools/imgtool/modules/mac.cpp
@@ -1542,7 +1542,7 @@ struct mfs_dirref
 
 
 
-static imgtoolerr_t mfs_image_create(imgtool::image *image, imgtool::stream &stream, util::option_resolution *opts)
+static imgtoolerr_t mfs_image_create(imgtool::image *image, imgtool::stream::ptr &&dummy, util::option_resolution *opts)
 {
 	imgtoolerr_t err;
 	UINT8 buffer[512];
@@ -1606,7 +1606,7 @@ static imgtoolerr_t mfs_image_create(imgtool::image *image, imgtool::stream &str
 
     Return imgtool error code
 */
-static imgtoolerr_t mfs_image_open(imgtool::image *image, imgtool::stream &stream)
+static imgtoolerr_t mfs_image_open(imgtool::image *image, imgtool::stream::ptr &&dummy)
 {
 	imgtoolerr_t err;
 	struct mac_l2_imgref *l2_img;
@@ -3033,7 +3033,7 @@ static int hfs_catKey_compare(const void *p1, const void *p2)
 
     Return imgtool error code
 */
-static imgtoolerr_t hfs_image_open(imgtool::image *image, imgtool::stream &stream)
+static imgtoolerr_t hfs_image_open(imgtool::image *image, imgtool::stream::ptr &&stream)
 {
 	imgtoolerr_t err;
 	struct mac_l2_imgref *l2_img;

--- a/src/tools/imgtool/modules/os9.cpp
+++ b/src/tools/imgtool/modules/os9.cpp
@@ -622,7 +622,7 @@ done:
 
 
 
-static imgtoolerr_t os9_diskimage_open(imgtool::image *image, imgtool::stream &stream)
+static imgtoolerr_t os9_diskimage_open(imgtool::image *image, imgtool::stream::ptr &&dummy)
 {
 	imgtoolerr_t err;
 	floperr_t ferr;
@@ -710,7 +710,7 @@ static imgtoolerr_t os9_diskimage_open(imgtool::image *image, imgtool::stream &s
 
 
 
-static imgtoolerr_t os9_diskimage_create(imgtool::image *img, imgtool::stream &stream, util::option_resolution *opts)
+static imgtoolerr_t os9_diskimage_create(imgtool::image *img, imgtool::stream::ptr &&stream, util::option_resolution *opts)
 {
 	imgtoolerr_t err;
 	dynamic_buffer header;

--- a/src/tools/imgtool/modules/pc_flop.cpp
+++ b/src/tools/imgtool/modules/pc_flop.cpp
@@ -17,7 +17,7 @@
 #define FAT_SECLEN              512
 
 
-static imgtoolerr_t fat_image_create(imgtool::image *image, imgtool::stream &stream, util::option_resolution *opts)
+static imgtoolerr_t fat_image_create(imgtool::image *image, imgtool::stream::ptr &&stream, util::option_resolution *opts)
 {
 	imgtoolerr_t err;
 	UINT32 tracks, heads, sectors;

--- a/src/tools/imgtool/modules/pc_hard.cpp
+++ b/src/tools/imgtool/modules/pc_hard.cpp
@@ -232,7 +232,7 @@ static imgtoolerr_t pc_chd_read_partition_header(imgtool::image &image)
 
 
 
-static imgtoolerr_t pc_chd_image_create(imgtool::image *image, imgtool::stream &f, util::option_resolution *opts)
+static imgtoolerr_t pc_chd_image_create(imgtool::image *image, imgtool::stream::ptr &&stream, util::option_resolution *opts)
 {
 	imgtoolerr_t err;
 	UINT32 cylinders, heads, sectors;
@@ -246,11 +246,11 @@ static imgtoolerr_t pc_chd_image_create(imgtool::image *image, imgtool::stream &
 	info = pc_chd_get_image_info(*image);
 
 	/* create the hard disk image */
-	err = imghd_create(f, 0, cylinders, heads, sectors, FAT_SECLEN);
+	err = imghd_create(*stream, 0, cylinders, heads, sectors, FAT_SECLEN);
 	if (err)
 		goto done;
 
-	err = imghd_open(f, &info->hard_disk);
+	err = imghd_open(*stream, &info->hard_disk);
 	if (err)
 		goto done;
 
@@ -278,7 +278,7 @@ done:
 
 
 
-static imgtoolerr_t pc_chd_image_open(imgtool::image *image, imgtool::stream &stream)
+static imgtoolerr_t pc_chd_image_open(imgtool::image *image, imgtool::stream::ptr &&stream)
 {
 	imgtoolerr_t err;
 	pc_chd_image_info *info;
@@ -286,7 +286,7 @@ static imgtoolerr_t pc_chd_image_open(imgtool::image *image, imgtool::stream &st
 	info = pc_chd_get_image_info(*image);
 
 	/* open the hard drive */
-	err = imghd_open(stream, &info->hard_disk);
+	err = imghd_open(*stream, &info->hard_disk);
 	if (err)
 		return err;
 

--- a/src/tools/imgtool/modules/prodos.cpp
+++ b/src/tools/imgtool/modules/prodos.cpp
@@ -502,7 +502,7 @@ static imgtoolerr_t prodos_diskimage_open(imgtool::image *image)
 
 
 
-static imgtoolerr_t prodos_diskimage_open_525(imgtool::image *image, imgtool::stream &stream)
+static imgtoolerr_t prodos_diskimage_open_525(imgtool::image *image, imgtool::stream::ptr &&dummy)
 {
 	prodos_setprocs_525(image);
 	return prodos_diskimage_open(image);
@@ -510,7 +510,7 @@ static imgtoolerr_t prodos_diskimage_open_525(imgtool::image *image, imgtool::st
 
 
 
-static imgtoolerr_t prodos_diskimage_open_35(imgtool::image *image, imgtool::stream &stream)
+static imgtoolerr_t prodos_diskimage_open_35(imgtool::image *image, imgtool::stream::ptr &&dummy)
 {
 	prodos_setprocs_35(image);
 	return prodos_diskimage_open(image);
@@ -702,7 +702,7 @@ static imgtoolerr_t prodos_diskimage_create(imgtool::image *image, util::option_
 
 
 
-static imgtoolerr_t prodos_diskimage_create_525(imgtool::image *image, imgtool::stream &stream, util::option_resolution *opts)
+static imgtoolerr_t prodos_diskimage_create_525(imgtool::image *image, imgtool::stream::ptr &&dummy, util::option_resolution *opts)
 {
 	prodos_setprocs_525(image);
 	return prodos_diskimage_create(image, opts);
@@ -710,7 +710,7 @@ static imgtoolerr_t prodos_diskimage_create_525(imgtool::image *image, imgtool::
 
 
 
-static imgtoolerr_t prodos_diskimage_create_35(imgtool::image *image, imgtool::stream &stream, util::option_resolution *opts)
+static imgtoolerr_t prodos_diskimage_create_35(imgtool::image *image, imgtool::stream::ptr &&dummy, util::option_resolution *opts)
 {
 	prodos_setprocs_35(image);
 	return prodos_diskimage_create(image, opts);

--- a/src/tools/imgtool/modules/ti99.cpp
+++ b/src/tools/imgtool/modules/ti99.cpp
@@ -966,21 +966,19 @@ static int read_image_vib_no_geometry(imgtool::stream &file_handle, ti99_img_for
 
     Return imgtool error code
 */
-static imgtoolerr_t open_image_lvl1(imgtool::stream &file_handle, ti99_img_format img_format, ti99_lvl1_imgref *l1_img, dsk_vib *vib)
+static imgtoolerr_t open_image_lvl1(imgtool::stream::ptr &&file_handle, ti99_img_format img_format, ti99_lvl1_imgref *l1_img, dsk_vib *vib)
 {
 	imgtoolerr_t err;
 	int reply;
 	UINT16 totphysrecs;
 
-
 	l1_img->img_format = img_format;
-	l1_img->file_handle = &file_handle;
 
 	if (img_format == if_harddisk)
 	{
 		const hard_disk_info *info;
 
-		err = imghd_open(file_handle, &l1_img->harddisk_handle);
+		err = imghd_open(*file_handle, &l1_img->harddisk_handle);
 		if (err)
 			return err;
 
@@ -1004,7 +1002,7 @@ static imgtoolerr_t open_image_lvl1(imgtool::stream &file_handle, ti99_img_forma
 	else
 	{
 		/* read vib */
-		reply = read_image_vib_no_geometry(file_handle, img_format, vib);
+		reply = read_image_vib_no_geometry(*file_handle, img_format, vib);
 		if (reply)
 			return (imgtoolerr_t)reply;
 
@@ -1032,7 +1030,7 @@ static imgtoolerr_t open_image_lvl1(imgtool::stream &file_handle, ti99_img_forma
 				|| (totphysrecs < 2)
 				|| memcmp(vib->id, "DSK", 3) || (! strchr(" P", vib->protection))
 				|| (((img_format == if_mess) || (img_format == if_v9t9))
-					&& (file_handle.size() != totphysrecs*256U)))
+					&& (file_handle->size() != totphysrecs*256U)))
 			return (imgtoolerr_t)IMGTOOLERR_CORRUPTIMAGE;
 
 		if ((img_format == if_pc99_fm) || (img_format == if_pc99_mfm))
@@ -1040,7 +1038,7 @@ static imgtoolerr_t open_image_lvl1(imgtool::stream &file_handle, ti99_img_forma
 			l1_img->pc99_data_offset_array = (UINT32*)malloc(sizeof(*l1_img->pc99_data_offset_array)*totphysrecs);
 			if (! l1_img->pc99_data_offset_array)
 				return IMGTOOLERR_OUTOFMEMORY;
-			reply = parse_pc99_image(file_handle, img_format == if_pc99_fm, 1, NULL, & l1_img->geometry, l1_img->pc99_data_offset_array, &l1_img->pc99_track_len);
+			reply = parse_pc99_image(*file_handle, img_format == if_pc99_fm, 1, NULL, & l1_img->geometry, l1_img->pc99_data_offset_array, &l1_img->pc99_track_len);
 			if (reply)
 			{
 				free(l1_img->pc99_data_offset_array);
@@ -1048,6 +1046,8 @@ static imgtoolerr_t open_image_lvl1(imgtool::stream &file_handle, ti99_img_forma
 			}
 		}
 	}
+
+	l1_img->file_handle = file_handle.release();	// we can only do this when we're sure we're successful
 
 	return (imgtoolerr_t)0;
 }
@@ -3848,11 +3848,11 @@ struct win_iterator
 };
 
 
-static imgtoolerr_t dsk_image_init_mess(imgtool::image *image, imgtool::stream &f);
-static imgtoolerr_t dsk_image_init_v9t9(imgtool::image *image, imgtool::stream &f);
-static imgtoolerr_t dsk_image_init_pc99_fm(imgtool::image *image, imgtool::stream &f);
-static imgtoolerr_t dsk_image_init_pc99_mfm(imgtool::image *image, imgtool::stream &f);
-static imgtoolerr_t win_image_init(imgtool::image *image, imgtool::stream &f);
+static imgtoolerr_t dsk_image_init_mess(imgtool::image *image, imgtool::stream::ptr &&stream);
+static imgtoolerr_t dsk_image_init_v9t9(imgtool::image *image, imgtool::stream::ptr &&stream);
+static imgtoolerr_t dsk_image_init_pc99_fm(imgtool::image *image, imgtool::stream::ptr &&stream);
+static imgtoolerr_t dsk_image_init_pc99_mfm(imgtool::image *image, imgtool::stream::ptr &&stream);
+static imgtoolerr_t win_image_init(imgtool::image *image, imgtool::stream::ptr &&stream);
 static void ti99_image_exit(imgtool::image *img);
 static void ti99_image_info(imgtool::image *img, char *string, size_t len);
 static imgtoolerr_t dsk_image_beginenum(imgtool::directory *enumeration, const char *path);
@@ -3864,8 +3864,8 @@ static imgtoolerr_t ti99_image_readfile(imgtool::partition *partition, const cha
 static imgtoolerr_t ti99_image_writefile(imgtool::partition *partition, const char *fpath, const char *fork, imgtool::stream &sourcef, util::option_resolution *writeoptions);
 static imgtoolerr_t dsk_image_deletefile(imgtool::partition *partition, const char *fpath);
 static imgtoolerr_t win_image_deletefile(imgtool::partition *partition, const char *fpath);
-static imgtoolerr_t dsk_image_create_mess(imgtool::image *image, imgtool::stream &f, util::option_resolution *createoptions);
-static imgtoolerr_t dsk_image_create_v9t9(imgtool::image *image, imgtool::stream &f, util::option_resolution *createoptions);
+static imgtoolerr_t dsk_image_create_mess(imgtool::image *image, imgtool::stream::ptr &&stream, util::option_resolution *createoptions);
+static imgtoolerr_t dsk_image_create_v9t9(imgtool::image *image, imgtool::stream::ptr &&stream, util::option_resolution *createoptions);
 
 enum
 {
@@ -3995,17 +3995,17 @@ void ti99_ti99hd_get_info(const imgtool_class *imgclass, UINT32 state, union img
 /*
     Open a file as a ti99_image (common code).
 */
-static int dsk_image_init(imgtool::image *img, imgtool::stream &f, ti99_img_format img_format)
+static imgtoolerr_t dsk_image_init(imgtool::image *img, imgtool::stream::ptr &&stream, ti99_img_format img_format)
 {
 	struct ti99_lvl2_imgref *image = (struct ti99_lvl2_imgref *) img->extra_bytes();
 	dsk_vib vib;
-	int reply;
+	imgtoolerr_t reply;
 	int totphysrecs;
 	unsigned fdir_aphysrec;
 	int i;
 
 	/* open disk image at level 1 */
-	reply = open_image_lvl1(f, img_format, &image->l1_img, &vib);
+	reply = open_image_lvl1(std::move(stream), img_format, &image->l1_img, &vib);
 	if (reply)
 		return reply;
 
@@ -4029,7 +4029,7 @@ static int dsk_image_init(imgtool::image *img, imgtool::stream &f, ti99_img_form
 	image->dsk.totphysrecs = get_UINT16BE(vib.totphysrecs);
 
 	/* read and check main volume catalog */
-	reply = dsk_read_catalog(image, 1, &image->dsk.catalogs[0]);
+	reply = (imgtoolerr_t)dsk_read_catalog(image, 1, &image->dsk.catalogs[0]);
 	if (reply)
 		return reply;
 
@@ -4072,7 +4072,7 @@ static int dsk_image_init(imgtool::image *img, imgtool::stream &f, ti99_img_form
 			image->dsk.fdir_aphysrec[image->dsk.catalogs[0].num_subdirs+1] = fdir_aphysrec;
 			/*image->dsk.catalogs[0].subdirs[image->dsk.catalogs[0].num_subdirs].dir_ptr = fdir_aphysrec;*/
 			memcpy(image->dsk.catalogs[0].subdirs[image->dsk.catalogs[0].num_subdirs].name, vib.subdir[i].name, 10);
-			reply = dsk_read_catalog(image, fdir_aphysrec, &image->dsk.catalogs[image->dsk.catalogs[0].num_subdirs+1]);
+			reply = (imgtoolerr_t) dsk_read_catalog(image, fdir_aphysrec, &image->dsk.catalogs[image->dsk.catalogs[0].num_subdirs+1]);
 			if (reply)
 			{
 				/* error: invalid fdir */
@@ -4090,45 +4090,45 @@ static int dsk_image_init(imgtool::image *img, imgtool::stream &f, ti99_img_form
 	/* initialize default data_offset */
 	image->data_offset = 32+2;
 
-	return 0;
+	return (imgtoolerr_t)0;
 }
 
 /*
     Open a file as a ti99_image (MESS format).
 */
-static imgtoolerr_t dsk_image_init_mess(imgtool::image *image, imgtool::stream &f)
+static imgtoolerr_t dsk_image_init_mess(imgtool::image *image, imgtool::stream::ptr &&stream)
 {
-	return (imgtoolerr_t)dsk_image_init(image, f, if_mess);
+	return dsk_image_init(image, std::move(stream), if_mess);
 }
 
 /*
     Open a file as a ti99_image (V9T9 format).
 */
-static imgtoolerr_t dsk_image_init_v9t9(imgtool::image *image, imgtool::stream &f)
+static imgtoolerr_t dsk_image_init_v9t9(imgtool::image *image, imgtool::stream::ptr &&stream)
 {
-	return (imgtoolerr_t)dsk_image_init(image, f, if_v9t9);
+	return dsk_image_init(image, std::move(stream), if_v9t9);
 }
 
 /*
     Open a file as a ti99_image (PC99 FM format).
 */
-static imgtoolerr_t dsk_image_init_pc99_fm(imgtool::image *image, imgtool::stream &f)
+static imgtoolerr_t dsk_image_init_pc99_fm(imgtool::image *image, imgtool::stream::ptr &&stream)
 {
-	return (imgtoolerr_t)dsk_image_init(image, f, if_pc99_fm);
+	return dsk_image_init(image, std::move(stream), if_pc99_fm);
 }
 
 /*
     Open a file as a ti99_image (PC99 MFM format).
 */
-static imgtoolerr_t dsk_image_init_pc99_mfm(imgtool::image *image, imgtool::stream &f)
+static imgtoolerr_t dsk_image_init_pc99_mfm(imgtool::image *image, imgtool::stream::ptr &&stream)
 {
-	return (imgtoolerr_t)dsk_image_init(image, f, if_pc99_mfm);
+	return dsk_image_init(image, std::move(stream), if_pc99_mfm);
 }
 
 /*
     Open a file as a ti99_image (harddisk format).
 */
-static imgtoolerr_t win_image_init(imgtool::image *img, imgtool::stream &f)
+static imgtoolerr_t win_image_init(imgtool::image *img, imgtool::stream::ptr &&stream)
 {
 	struct ti99_lvl2_imgref *image = (struct ti99_lvl2_imgref *) img->extra_bytes();
 	win_vib_ddr vib;
@@ -4136,7 +4136,7 @@ static imgtoolerr_t win_image_init(imgtool::image *img, imgtool::stream &f)
 	int i;
 
 	/* open disk image at level 1 */
-	reply = open_image_lvl1(f, if_harddisk, & image->l1_img, NULL);
+	reply = open_image_lvl1(std::move(stream), if_harddisk, & image->l1_img, NULL);
 	if (reply)
 		return (imgtoolerr_t)reply;
 
@@ -5226,7 +5226,7 @@ static imgtoolerr_t win_image_deletefile(imgtool::partition *partition, const ch
 
     Supports MESS and V9T9 formats only
 */
-static imgtoolerr_t dsk_image_create(imgtool::image *image, imgtool::stream &f, util::option_resolution *createoptions, ti99_img_format img_format)
+static imgtoolerr_t dsk_image_create(imgtool::image *image, imgtool::stream::ptr &&stream, util::option_resolution *createoptions, ti99_img_format img_format)
 {
 	const char *volname;
 	int density;
@@ -5241,7 +5241,7 @@ static imgtoolerr_t dsk_image_create(imgtool::image *image, imgtool::stream &f, 
 	int i;
 
 	l1_img.img_format = img_format;
-	l1_img.file_handle = &f;
+	l1_img.file_handle = stream.get();	// can't release here
 
 	/* read options */
 	volname = createoptions->lookup_string(dsk_createopts_volname).c_str();
@@ -5328,7 +5328,7 @@ static imgtoolerr_t dsk_image_create(imgtool::image *image, imgtool::stream &f, 
 	vib.abm[0] |= (physrecsperAU == 1) ? 3 : 1;
 
 	/* write aphysrec 0 */
-	if (write_absolute_physrec(& l1_img, 0, &vib))
+	if (write_absolute_physrec(&l1_img, 0, &vib))
 		return IMGTOOLERR_WRITEERROR;
 
 
@@ -5340,21 +5340,21 @@ static imgtoolerr_t dsk_image_create(imgtool::image *image, imgtool::stream &f, 
 			return IMGTOOLERR_WRITEERROR;
 
 
-	return (imgtoolerr_t)dsk_image_init(image, f, img_format);
+	return dsk_image_init(image, std::move(stream), img_format);
 }
 
 /*
     Create a blank ti99_image (MESS format).
 */
-static imgtoolerr_t dsk_image_create_mess(imgtool::image *image, imgtool::stream &f, util::option_resolution *createoptions)
+static imgtoolerr_t dsk_image_create_mess(imgtool::image *image, imgtool::stream::ptr &&stream, util::option_resolution *createoptions)
 {
-	return dsk_image_create(image, f, createoptions, if_mess);
+	return dsk_image_create(image, std::move(stream), createoptions, if_mess);
 }
 
 /*
     Create a blank ti99_image (V9T9 format).
 */
-static imgtoolerr_t dsk_image_create_v9t9(imgtool::image *image, imgtool::stream &f, util::option_resolution *createoptions)
+static imgtoolerr_t dsk_image_create_v9t9(imgtool::image *image, imgtool::stream::ptr &&stream, util::option_resolution *createoptions)
 {
-	return dsk_image_create(image, f, createoptions, if_v9t9);
+	return dsk_image_create(image, std::move(stream), createoptions, if_v9t9);
 }

--- a/src/tools/imgtool/modules/vzdos.cpp
+++ b/src/tools/imgtool/modules/vzdos.cpp
@@ -789,7 +789,7 @@ static imgtoolerr_t vzdos_diskimage_suggesttransfer(imgtool::partition *partitio
 	return IMGTOOLERR_SUCCESS;
 }
 
-static imgtoolerr_t vzdos_diskimage_create(imgtool::image *img, imgtool::stream &stream, util::option_resolution *opts)
+static imgtoolerr_t vzdos_diskimage_create(imgtool::image *img, imgtool::stream::ptr &&dummy, util::option_resolution *opts)
 {
 	imgtoolerr_t ret;
 	int track, sector;


### PR DESCRIPTION
They always took ownership of the stream; this just makes it official.  Because the ownership would only traditionally happen if the open() or create() succeeded, I had to do a clumsy pattern where I call get() at the beginning of the callback to get the stream, but later on release() immediately prior to succeeding.