### PR TITLE
[COCO] Changed to use required_ioport_array and optional_ioport

### DIFF
--- a/src/emu/devfind.h
+++ b/src/emu/devfind.h
@@ -115,6 +115,9 @@ public:
 	/// \param [in] index Index of desired element (zero-based).
 	/// \return Reference to element at specified index.
 	T &operator[](unsigned index) { assert(index < Count); return m_array[index]; }
+
+	/// \brief Returns the count
+	unsigned size() const { return Count; }
 };
 
 

--- a/src/emu/devfind.h
+++ b/src/emu/devfind.h
@@ -116,8 +116,11 @@ public:
 	/// \return Reference to element at specified index.
 	T &operator[](unsigned index) { assert(index < Count); return m_array[index]; }
 
-	/// \brief Returns the count
-	unsigned size() const { return Count; }
+	/// \brief Get array size
+	///
+	/// Returns number of objects in array (compile-time constant).
+	/// \return The size of the array.
+	constexpr unsigned size() const { return Count; }
 };
 
 

--- a/src/mame/includes/coco.h
+++ b/src/mame/includes/coco.h
@@ -233,9 +233,9 @@ private:
 	UINT8 floating_bus_read(void);
 
 	// input ports
-	ioport_port *m_keyboard[7];
-	ioport_port *m_joystick_type_control;
-	ioport_port *m_joystick_hires_control;
+	required_ioport_array<7> m_keyboard;
+	optional_ioport m_joystick_type_control;
+	optional_ioport m_joystick_hires_control;
 	analog_input_t m_joystick;
 	analog_input_t m_rat_mouse;
 	analog_input_t m_diecom_lightgun;

--- a/src/mame/machine/coco.cpp
+++ b/src/mame/machine/coco.cpp
@@ -2,7 +2,7 @@
 // copyright-holders:Nathan Woods
 /***************************************************************************
 
-    coco.c
+    coco.cpp
 
     TRS-80 Radio Shack Color Computer Family
 
@@ -93,7 +93,7 @@ coco_state::coco_state(const machine_config &mconfig, device_type type, const ch
 	m_vhd_1(*this, VHD1_TAG),
 	m_beckerport(*this, DWSOCK_TAG),
 	m_beckerportconfig(*this, BECKERPORT_TAG),
-	m_keyboard(*this, { "row0", "row1", "row2", "row3", "row4", "row5", "row6" }),
+	m_keyboard(*this, "row%u", 0),
 	m_joystick_type_control(*this, CTRL_SEL_TAG),
 	m_joystick_hires_control(*this, HIRES_INTF_TAG)
 {
@@ -857,7 +857,7 @@ void coco_state::poll_keyboard(void)
 	UINT8 pia0_pa_z = 0x7F;
 
 	/* poll the keyboard, and update PA6-PA0 accordingly*/
-	for (int i = 0; i < m_keyboard.size(); i++)
+	for (unsigned i = 0; i < m_keyboard.size(); i++)
 	{
 		int value = m_keyboard[i]->read();
 		if ((value | pia0_pb) != 0xFF)

--- a/src/mame/machine/coco.cpp
+++ b/src/mame/machine/coco.cpp
@@ -92,7 +92,10 @@ coco_state::coco_state(const machine_config &mconfig, device_type type, const ch
 	m_vhd_0(*this, VHD0_TAG),
 	m_vhd_1(*this, VHD1_TAG),
 	m_beckerport(*this, DWSOCK_TAG),
-	m_beckerportconfig(*this, BECKERPORT_TAG)
+	m_beckerportconfig(*this, BECKERPORT_TAG),
+	m_keyboard(*this, { "row0", "row1", "row2", "row3", "row4", "row5", "row6" }),
+	m_joystick_type_control(*this, CTRL_SEL_TAG),
+	m_joystick_hires_control(*this, HIRES_INTF_TAG)
 {
 }
 
@@ -121,14 +124,6 @@ void coco_state::device_start()
 	/* call base device_start */
 	driver_device::device_start();
 
-	/* look up keyboard ports */
-	for (int i = 0; i < ARRAY_LENGTH(m_keyboard); i++)
-	{
-		char name[32];
-		snprintf(name, ARRAY_LENGTH(name), "row%d", i);
-		m_keyboard[i] =  ioport(name);
-	}
-
 	/* look up analog ports */
 	analog_port_start(&m_joystick, JOYSTICK_RX_TAG, JOYSTICK_RY_TAG,
 		JOYSTICK_LX_TAG, JOYSTICK_LY_TAG, JOYSTICK_BUTTONS_TAG);
@@ -136,10 +131,6 @@ void coco_state::device_start()
 		RAT_MOUSE_LX_TAG, RAT_MOUSE_LY_TAG, RAT_MOUSE_BUTTONS_TAG);
 	analog_port_start(&m_diecom_lightgun, DIECOM_LIGHTGUN_RX_TAG, DIECOM_LIGHTGUN_RY_TAG,
 		DIECOM_LIGHTGUN_LX_TAG, DIECOM_LIGHTGUN_LY_TAG, DIECOM_LIGHTGUN_BUTTONS_TAG);
-
-	/* look up miscellaneous controls */
-	m_joystick_type_control =  ioport(CTRL_SEL_TAG);
-	m_joystick_hires_control =  ioport(HIRES_INTF_TAG);
 
 	/* timers */
 	m_hiresjoy_transition_timer[0] = timer_alloc(TIMER_HIRES_JOYSTICK_X);
@@ -723,7 +714,7 @@ void coco_state::update_sound(void)
 coco_state::joystick_type_t coco_state::joystick_type(int index)
 {
 	assert((index == 0) || (index == 1));
-	return (m_joystick_type_control != nullptr)
+	return m_joystick_type_control
 		? (joystick_type_t) ((m_joystick_type_control->read() >> (index * 4)) & 0x0F)
 		: JOYSTICK_NONE;
 }
@@ -736,7 +727,7 @@ coco_state::joystick_type_t coco_state::joystick_type(int index)
 
 coco_state::hires_type_t coco_state::hires_interface_type(void)
 {
-	return (m_joystick_hires_control != nullptr)
+	return m_joystick_hires_control
 		? (hires_type_t) m_joystick_hires_control->read()
 		: HIRES_NONE;
 }
@@ -866,7 +857,7 @@ void coco_state::poll_keyboard(void)
 	UINT8 pia0_pa_z = 0x7F;
 
 	/* poll the keyboard, and update PA6-PA0 accordingly*/
-	for (int i = 0; i < ARRAY_LENGTH(m_keyboard); i++)
+	for (int i = 0; i < m_keyboard.size(); i++)
 	{
 		int value = m_keyboard[i]->read();
 		if ((value | pia0_pb) != 0xFF)


### PR DESCRIPTION
Also, I added a size() accessor to object_array_finder.  If there is a better way to do this, let me know.