### PR TITLE
Fix hash errors in Sega CD softlist

### DIFF
--- a/hash/segacd.xml
+++ b/hash/segacd.xml
@@ -142,7 +142,6 @@ Dumps that are known to exist, but are lost in the aether:
 | Night Trap (Prototype)                                      |                                                                   |
 | The Adventures of Batman and Robin CD (Prototype)           |                                                                   |
 | The Amazing Spider-Man vs. The Kingpin (Prototype)          |                                                                   |
-| The Secret of Monkey Island                                 | Redump.org dump. http://redump.org/disc/36040/                    |
 | Tomcat Alley (Prototype)                                    |                                                                   |
 | Virtual VCR - Colors of Modern Rock (Prototype)             |                                                                   |
 +=============================================================+===================================================================+
@@ -822,13 +821,13 @@ See: http://rawdump.net/
 		<part name="cdrom1" interface="scd_cdrom">
 			<feature name="part_id" value="Disc 1" />
 			<diskarea name="cdrom">
-				<disk name="dracula unleashed (usa) (disc 1)" sha1="a622e34eece3b778be5db57e286f660dfa6eb24f"/>
+				<disk name="dracula unleashed (usa) (disc 1)" sha1="307c0779dace5d95f3e7a0ccee18c00356ca2362"/>
 			</diskarea>
 		</part>
 		<part name="cdrom2" interface="scd_cdrom">
 			<feature name="part_id" value="Disc 2" />
 			<diskarea name="cdrom">
-				<disk name="dracula unleashed (usa) (disc 2)" sha1="c47146684c86dd5fa393570abd8669b50a0426ba"/>
+				<disk name="dracula unleashed (usa) (disc 2)" sha1="e3adeebe60f32a3487e7d5afc86675b73057fba6"/>
 			</diskarea>
 		</part>
 	</software>
@@ -846,7 +845,7 @@ See: http://rawdump.net/
 		<info name="ring_code" value="SEGAT121015 R3D MFD BY JVC 13"/>
 		<part name="cdrom" interface="scd_cdrom">
 			<diskarea name="cdrom">
-				<disk name="dragon's lair (usa)" sha1="1008694a91ae7afafe6895063e59f69955ae1f3e"/>
+				<disk name="dragon's lair (usa)" sha1="724bc872d111ed67df10e95b134f8bf7fe2fcfe3"/>
 			</diskarea>
 		</part>
 	</software>
@@ -875,7 +874,7 @@ See: http://rawdump.net/
 		<info name="ring_code" value="JVC SEGA4657 R2E 0 0"/>
 		<part name="cdrom" interface="scd_cdrom">
 			<diskarea name="cdrom">
-				<disk name="dungeon explorer (usa)" sha1="bad39498e424ad995d258cf0cb128226eee1cba4"/>
+				<disk name="dungeon explorer (usa)" sha1="432897f1f19e8a053c8f7d783e2331e7fd0f0b1f"/>
 			</diskarea>
 		</part>
 	</software>
@@ -973,7 +972,7 @@ See: http://rawdump.net/
 		<info name="ring_code" value="SEGA4441 R2H"/>
 		<part name="cdrom" interface="scd_cdrom">
 			<diskarea name="cdrom">
-				<disk name="ecco - the tides of time (usa, alt)" sha1="e69a037b7fe122cbbf25b9106ad4f1057327212a"/>
+				<disk name="ecco - the tides of time (usa, alt)" sha1="9fb665727fdc629df195ef315eef17eae9661f4d"/>
 			</diskarea>
 		</part>
 	</software>
@@ -1009,7 +1008,7 @@ See: http://rawdump.net/
 		<info name="ring_code" value="CDAC-077600 1"/>
 		<part name="cdrom" interface="scd_cdrom">
 			<diskarea name="cdrom">
-				<disk name="espn sunday night nfl (usa)" sha1="b7eb5fc182ab3793897d858b5d2842dcef97d1c9"/>
+				<disk name="espn sunday night nfl (usa)" sha1="11504fbfcecc6ffdaa69960ba9e57d6cd343bd78"/>
 			</diskarea>
 		</part>
 	</software>
@@ -1079,7 +1078,7 @@ See: http://rawdump.net/
 		<info name="ring_code" value="SEGA4427RE R1J"/>
 		<part name="cdrom" interface="scd_cdrom">
 			<diskarea name="cdrom">
-				<disk name="eternal champions - challenge from the dark side (usa, alt)" sha1="d5bad2a096ce595c79c61d07284d4f5eb611ceab"/>
+				<disk name="eternal champions - challenge from the dark side (usa, alt)" sha1="9fb665727fdc629df195ef315eef17eae9661f4d"/>
 			</diskarea>
 		</part>
 	</software>
@@ -1152,7 +1151,7 @@ See: http://rawdump.net/
 		<info name="ring_code" value="CDAC-070100 2"/>
 		<part name="cdrom" interface="scd_cdrom">
 			<diskarea name="cdrom">
-				<disk name="eye of the beholder (usa)" sha1="a92a1a01dd6135e0e5ccd65a8294197129803349"/>
+				<disk name="eye of the beholder (usa)" sha1="8901e20ec6cb1cc8b8771b7bdac01d3220a067f5"/>
 			</diskarea>
 		</part>
 	</software>
@@ -1177,13 +1176,13 @@ See: http://rawdump.net/
 		<part name="cdrom1" interface="scd_cdrom">
 			<feature name="part_id" value="Sega CD / Disc 1 - Key Disc" />
 			<diskarea name="cdrom">
-				<disk name="fahrenheit (usa) (sega cd)" sha1="71c1139aae8da757c9c7d46838de48a7f5efc11b"/>
+				<disk name="fahrenheit (usa) (sega cd)" sha1="c53080012578fe291323197e6319842beb84ee9b"/>
 			</diskarea>
 		</part>
 		<part name="cdrom2" interface="scd_cdrom">
 			<feature name="part_id" value="32X CD / Disc 2 - Insert Key Disc 1 First" />
 			<diskarea name="cdrom">
-				<disk name="fahrenheit (usa) (32x cd)" sha1="6bb1beea70cd1f282029fb124c929891d56a264c"/>
+				<disk name="fahrenheit (usa) (32x cd)" sha1="f94ea9821ca030c3cc61eccc29eb9c692198415e"/>
 			</diskarea>
 		</part>
 	</software>
@@ -1245,7 +1244,7 @@ See: http://rawdump.net/
 		<info name="ring_code" value="CDAC-064000(9)1"/>
 		<part name="cdrom" interface="scd_cdrom">
 			<diskarea name="cdrom">
-				<disk name="fifa international soccer (usa)" sha1="374f3effa5bf0bbc88ca4a845e47b900c7cd9b17"/>
+				<disk name="fifa international soccer (usa)" sha1="3e32c3d5e99f5df103277aed209a59f888c06bec"/>
 			</diskarea>
 		</part>
 	</software>
@@ -1341,7 +1340,7 @@ See: http://rawdump.net/
 		<info name="ring_code" value="CDAC-063600 1"/>
 		<part name="cdrom" interface="scd_cdrom">
 			<diskarea name="cdrom">
-				<disk name="formula one world championship - beyond the limit (usa)" sha1="ba5ac10c8529c13791ad3831d1e8008e15c7b265"/>
+				<disk name="formula one world championship - beyond the limit (usa)" sha1="da0c0fd84af458744d6b045c3fb44b5ac5f89152"/>
 			</diskarea>
 		</part>
 	</software>
@@ -1364,14 +1363,14 @@ See: http://rawdump.net/
 		<part name="cdrom1" interface="scd_cdrom">
 			<feature name="part_id" value="Disc 1" />
 			<diskarea name="cdrom">
-				<disk name="ground zero texas (usa) (disc 1)" sha1="e2670636dd5aa323a1b7bd10e755eac933d47325"/>
+				<disk name="ground zero texas (usa) (disc 1)" sha1="226bef5c19446c6be18674941707b3baebc11223"/>
 			</diskarea>
 		</part>
 
 		<part name="cdrom2" interface="scd_cdrom">
 			<feature name="part_id" value="Disc 2" />
 			<diskarea name="cdrom">
-				<disk name="ground zero texas (usa) (disc 2)" sha1="45777568ff3e40f03c5d738259dfe996bd82c57b"/>
+				<disk name="ground zero texas (usa) (disc 2)" sha1="13c7cc77f2659155dec4deb4700d8ac8af95fb42"/>
 			</diskarea>
 		</part>
 	</software>
@@ -1468,7 +1467,7 @@ See: http://rawdump.net/
 		<info name="ring_code" value="SEGAT60105 R1D MFD BY JVC"/>
 		<part name="cdrom" interface="scd_cdrom">
 			<diskarea name="cdrom">
-				<disk name="heimdall (usa)" sha1="a9f6b312247d0157e8a450470b584ac6f8df0378"/>
+				<disk name="heimdall (usa)" sha1="986813f0d66eff9c163c19ccdbe6e055bf75043d"/>
 			</diskarea>
 		</part>
 	</software>
@@ -1506,7 +1505,7 @@ See: http://rawdump.net/
 		<info name="ring_code" value="CDAC-032400 4"/>
 		<part name="cdrom" interface="scd_cdrom">
 			<diskarea name="cdrom">
-				<disk name="hook (usa)" sha1="ce3463592a56ad97a72904848fcaefe801ffb469"/>
+				<disk name="hook (usa)" sha1="310b67fc0163da2dbae236b1276624b2170425b0"/>
 			</diskarea>
 		</part>
 	</software>
@@ -1544,7 +1543,7 @@ See: http://rawdump.net/
 		<info name="ring_code" value="CDAC-075900 3"/>
 		<part name="cdrom" interface="scd_cdrom">
 			<diskarea name="cdrom">
-				<disk name="jeopardy! (usa)" sha1="79215718f2ed53f084a494a6f94543ca0733b922"/>
+				<disk name="jeopardy! (usa)" sha1="6f159f64d3ea62bb8eff70e9a2f84d02bfb54688"/>
 			</diskarea>
 		</part>
 	</software>
@@ -1567,7 +1566,7 @@ See: http://rawdump.net/
 		<info name="ring_code" value="SEGA4201 R1C MFD BY JVC, SEGA4201RE R2C MFD BY JVC"/>
 		<part name="cdrom" interface="scd_cdrom">
 			<diskarea name="cdrom">
-				<disk name="joe montana's nfl football (usa)" sha1="19e43232acd7b99ba6c2205e0de1117f263661c8"/>
+				<disk name="joe montana's nfl football (usa)" sha1="a6c4dccb249c27d38846e204313446e5928c2b4d"/>
 			</diskarea>
 		</part>
 	</software>
@@ -1633,7 +1632,7 @@ See: http://rawdump.net/
 		<info name="ring_code" value="GW 03611 SRCR##02"/>
 		<part name="cdrom" interface="scd_cdrom">
 			<diskarea name="cdrom">
-				<disk name="kids on site (usa)" sha1="272ad4f8f6f058c704c2ab0b310cae6be794909c"/>
+				<disk name="kids on site (usa)" sha1="9a97c7c151cbe77121bb626954b50bd2223a9292"/>
 			</diskarea>
 		</part>
 	</software>
@@ -1714,7 +1713,7 @@ See: http://rawdump.net/
 		<info name="ring_code" value="T95015-U12 1"/>
 		<part name="cdrom" interface="scd_cdrom">
 			<diskarea name="cdrom">
-				<disk name="lethal enforcers (usa, alt)" sha1="c63c8f1f01bb0cc1ac72e43c28492afc41268122"/>
+				<disk name="lethal enforcers (usa, alt)" sha1="924fd382c6d23099200ef33eee358f768a0503b8"/>
 			</diskarea>
 		</part>
 	</software>
@@ -1754,7 +1753,7 @@ See: http://rawdump.net/
 		<info name="ring_code" value="T95025-U12 1"/>
 		<part name="cdrom" interface="scd_cdrom">
 			<diskarea name="cdrom">
-				<disk name="lethal enforcers ii - gun fighters (usa)" sha1="4280aa6895a98de5c4360e28a5bc78cd8bd76f68"/>
+				<disk name="lethal enforcers ii - gun fighters (usa)" sha1="7d63da6fa26441e31bd614474936d8c7adacd239"/>
 			</diskarea>
 		</part>
 	</software>
@@ -1772,7 +1771,7 @@ See: http://rawdump.net/
 		<info name="ring_code" value="SEGAT153015 R3J MFD BY JVC"/>
 		<part name="cdrom" interface="scd_cdrom">
 			<diskarea name="cdrom">
-				<disk name="loadstar - the legend of tully bodine (usa)" sha1="3fe14a9944c86246aa5a6a63b644c23ead50412d"/>
+				<disk name="loadstar - the legend of tully bodine (usa)" sha1="a9b4df4c8b3ed81d14cfa5506961c3815387194e"/>
 			</diskarea>
 		</part>
 	</software>
@@ -1809,7 +1808,7 @@ See: http://rawdump.net/
 		<info name="ring_code" value="SEGA4450 R1F"/>
 		<part name="cdrom" interface="scd_cdrom">
 			<diskarea name="cdrom">
-				<disk name="lords of thunder (usa)" sha1="d7fd1bb3f1e869b6bbb5fc30add6c7567d7a28f4"/>
+				<disk name="lords of thunder (usa)" sha1="c4be0138ac50ee190fb8df9839a2efb97e9f30c2"/>
 			</diskarea>
 		</part>
 	</software>
@@ -1896,7 +1895,7 @@ See: http://rawdump.net/
 		<info name="ring_code" value="SEGAT127045RE R1H"/>
 		<part name="cdrom" interface="scd_cdrom">
 			<diskarea name="cdrom">
-				<disk name="lunar - eternal blue (usa)" sha1="6c6eb7b999056ccdfc2fad2b30858a6bf83e3f7e"/>
+				<disk name="lunar - eternal blue (usa)" sha1="1cc95c2b91d6c52d561a4f70e96c52ddc3c10313"/>
 			</diskarea>
 		</part>
 	</software>
@@ -1919,7 +1918,7 @@ See: http://rawdump.net/
 		<info name="ring_code" value="SEGAT111015 R1D MFD BY JVC"/>
 		<part name="cdrom" interface="scd_cdrom">
 			<diskarea name="cdrom">
-				<disk name="mad dog mccree (usa)" sha1="6e46c47a198892e71f2ccc4320db39f313d8f683"/>
+				<disk name="mad dog mccree (usa)" sha1="244713e8c7c1d1ef38f5f9ba2232cb1a2b23a1f7"/>
 			</diskarea>
 		</part>
 	</software>
@@ -1963,7 +1962,7 @@ See: http://rawdump.net/
 		<info name="ring_code" value="CDAC-077800 1"/>
 		<part name="cdrom" interface="scd_cdrom">
 			<diskarea name="cdrom">
-				<disk name="mary shelley's frankenstein (usa)" sha1="b3ab787161481ea7a110a9ce320fb142523060d6"/>
+				<disk name="mary shelley's frankenstein (usa)" sha1="4d0d40a70d2a585e371d23d122ec98a6dce7b299"/>
 			</diskarea>
 		</part>
 	</software>
@@ -2008,7 +2007,7 @@ See: http://rawdump.net/
 		<info name="ring_code" value="CDAC-073600 1"/>
 		<part name="cdrom" interface="scd_cdrom">
 			<diskarea name="cdrom">
-				<disk name="mickey mania - timeless adventures of mickey mouse (usa)" sha1="fe66ef3cd4429671d5a50b7f95271542af7e138c"/>
+				<disk name="mickey mania - timeless adventures of mickey mouse (usa)" sha1="c98e204f92845b6e90ee0afce16d10501ded7ea2"/>
 			</diskarea>
 		</part>
 	</software>
@@ -2033,7 +2032,7 @@ See: http://rawdump.net/
 		<info name="ring_code" value="CDAC-055200 1"/>
 		<part name="cdrom" interface="scd_cdrom">
 			<diskarea name="cdrom">
-				<disk name="microcosm (usa)" sha1="12bc7832b9762d5d4d0fa1d7454667353dea9b5e"/>
+				<disk name="microcosm (usa)" sha1="bca8a59c2aa47d1207b0c2df1d2ff40cb5d11fb4"/>
 			</diskarea>
 		</part>
 	</software>
@@ -2051,7 +2050,7 @@ See: http://rawdump.net/
 		<info name="ring_code" value="SEGA4439 R1J MFD BY JVC"/>
 		<part name="cdrom" interface="scd_cdrom">
 			<diskarea name="cdrom">
-				<disk name="midnight raiders (usa)" sha1="eb65e2760227bd234f39c075a67c35f0112d7d9b"/>
+				<disk name="midnight raiders (usa)" sha1="83db51aee2ef658fa9d29e67acdc7d5774e69d3a"/>
 			</diskarea>
 		</part>
 	</software>
@@ -2115,7 +2114,7 @@ See: http://rawdump.net/
 		<info name="ring_code" value="CDAC-074200 4"/>
 		<part name="cdrom" interface="scd_cdrom">
 			<diskarea name="cdrom">
-				<disk name="nba jam (usa)" sha1="df754ad88c6a674e0a5eb7b02dc40b4fb9d08ec5"/>
+				<disk name="nba jam (usa)" sha1="48b0fdb2476ac795b303bfdc11b40abb8609511b"/>
 			</diskarea>
 		</part>
 	</software>
@@ -2134,7 +2133,7 @@ See: http://rawdump.net/
 		<info name="ring_code" value="CDAC-054500 4"/>
 		<part name="cdrom" interface="scd_cdrom">
 			<diskarea name="cdrom">
-				<disk name="nfl's greatest - san francisco vs dallas 1978-1993 (usa)" sha1="1d5383630e3814832468b138aa541169711e0277"/>
+				<disk name="nfl's greatest - san francisco vs dallas 1978-1993 (usa)" sha1="20fc574d1912b92dd9d6c248734a8e897501b3ea"/>
 			</diskarea>
 		</part>
 	</software>
@@ -2315,7 +2314,7 @@ See: http://rawdump.net/
 		<part name="cdrom1" interface="scd_cdrom">
 			<feature name="part_id" value="Disc 1" />
 			<diskarea name="cdrom">
-				<disk name="night trap (usa, alt) (disc 1)" sha1="69e634002fad8a1e77e5d996c08c5d2320744a4e"/>
+				<disk name="night trap (usa, alt) (disc 1)" sha1="d5d21d92798661d67ab7247acc41ea6602721a0b"/>
 			</diskarea>
 		</part>
 
@@ -2350,7 +2349,7 @@ See: http://rawdump.net/
 		<sharedfeat name="requirement" value="megadriv -psolar"/>
 		<part name="cdrom" interface="scd_cdrom">
 			<diskarea name="cdrom">
-				<disk name="pier solar and the great architects enhanced soundtrack disc (world)" sha1="a880a449bb7a0cbab7625e24b31a7a79c8fa4723"/>
+				<disk name="pier solar and the great architects enhanced soundtrack disc (world)" sha1="1f26cce723ef044f449d87cdb624a2937f40f5d9"/>
 			</diskarea>
 		</part>
 	</software>
@@ -2410,7 +2409,7 @@ See: http://rawdump.net/
 		<info name="ring_code" value="SEGAT127035RE R1J MFD BY JVC"/>
 		<part name="cdrom" interface="scd_cdrom">
 			<diskarea name="cdrom">
-				<disk name="popful mail (usa)" sha1="a1c748d9b3c087ff172c945ed3fa7e276b26e377"/>
+				<disk name="popful mail (usa)" sha1="459853983b1e01fe297ffd6287502eab1678e8e4"/>
 			</diskarea>
 		</part>
 	</software>
@@ -2518,7 +2517,7 @@ See: http://rawdump.net/
 		<info name="ring_code" value="CDAC-055000 1"/>
 		<part name="cdrom" interface="scd_cdrom">
 			<diskarea name="cdrom">
-				<disk name="racing aces (usa)" sha1="9fc4882208dad3f8e4cb4c040573661c86dcd3e9"/>
+				<disk name="racing aces (usa)" sha1="a2038d4de56b75d61db6ad757919cca00cc91c95"/>
 			</diskarea>
 		</part>
 	</software>
@@ -2541,7 +2540,7 @@ See: http://rawdump.net/
 		<info name="ring_code" value="SEGAT86025 R1F MFD BY JVC"/>
 		<part name="cdrom" interface="scd_cdrom">
 			<diskarea name="cdrom">
-				<disk name="rdf - global conflict (usa)" sha1="19a3a857bff0ea658f7475e4cba55fd3cf002e91"/>
+				<disk name="rdf - global conflict (usa)" sha1="32cf1e068598e385962db8de493eb191aab7716b"/>
 			</diskarea>
 		</part>
 	</software>
@@ -2626,7 +2625,7 @@ See: http://rawdump.net/
 		<info name="ring_code" value="SEGA6207 R1D MFD BY JVC"/>
 		<part name="cdrom" interface="scd_cdrom">
 			<diskarea name="cdrom">
-				<disk name="road avenger (usa)" sha1="28e2f7cf2e3972c54bff3826095084bd19e49fa9"/>
+				<disk name="road avenger (usa)" sha1="05fa6ae67687aacdf99fe939b0f04ce13b6d527b"/>
 			</diskarea>
 		</part>
 	</software>
@@ -2645,7 +2644,7 @@ See: http://rawdump.net/
 		<info name="ring_code" value="SEGA4442 R1J"/>
 		<part name="cdrom" interface="scd_cdrom">
 			<diskarea name="cdrom">
-				<disk name="saban's mighty morphin power rangers (usa)" sha1="2566cacaee3bae9b16775687029a351c94634765"/>
+				<disk name="saban's mighty morphin power rangers (usa)" sha1="fffd902d4ab06d946c47b7eaa40cc5ddd9963299"/>
 			</diskarea>
 		</part>
 	</software>
@@ -2674,7 +2673,7 @@ See: http://rawdump.net/
 		<info name="ring_code" value="SEGA4126RE R1D MFD BY JVC"/>
 		<part name="cdrom" interface="scd_cdrom">
 			<diskarea name="cdrom">
-				<disk name="sega classics arcade collection (usa, 4 in 1, alt)" sha1="8d6ea92f4a5e1d10d63d80996043b68907a34275"/>
+				<disk name="sega classics arcade collection (usa, 4 in 1, alt)" sha1="c587085ec1b3a2cea0575a5bf90abfd3789c3779"/>
 			</diskarea>
 		</part>
 	</software>
@@ -2702,7 +2701,7 @@ See: http://rawdump.net/
 		<info name="ring_code" value="CDAC-056800 2"/>
 		<part name="cdrom" interface="scd_cdrom">
 			<diskarea name="cdrom">
-				<disk name="sega classics arcade collection (usa, 5 in 1)" sha1="cb83a3499793a41d78ee7ae1000137aec3604eb5"/>
+				<disk name="sega classics arcade collection (usa, 5 in 1)" sha1="9f4bdadabba7d8998b701a3becd2520d4d2a037d"/>
 			</diskarea>
 		</part>
 	</software>
@@ -2720,7 +2719,7 @@ See: http://rawdump.net/
 		<info name="ring_code" value="CDRM-1033200 1"/>
 		<part name="cdrom" interface="scd_cdrom">
 			<diskarea name="cdrom">
-				<disk name="sewer shark (usa)" sha1="49d3ca6742e979b1df059b24fc8af422d0e647d3"/>
+				<disk name="sewer shark (usa)" sha1="65eb30fa88be9de6a7ceb980b4016241c5aafe0f"/>
 			</diskarea>
 		</part>
 	</software>
@@ -2777,7 +2776,7 @@ See: http://rawdump.net/
 		<info name="ring_code" value="CDRM-1095270 1"/>
 		<part name="cdrom" interface="scd_cdrom">
 			<diskarea name="cdrom">
-				<disk name="sewer shark (usa, rev. b, alt)" sha1="d8ed9b17e1a3a476db3cae4a114180f243d74252"/>
+				<disk name="sewer shark (usa, rev. b, alt)" sha1="9229f299de538d02ebf6d8e8a44c0066bc879077"/>
 			</diskarea>
 		</part>
 	</software>
@@ -2816,7 +2815,7 @@ See: http://rawdump.net/
 		<info name="ring_code" value="CDAC-031300 1, CDAC-031300 2"/>
 		<part name="cdrom" interface="scd_cdrom">
 			<diskarea name="cdrom">
-				<disk name="sherlock holmes - consulting detective vol. i (usa)" sha1="288bca13a125e4104325088fa010767784be0cdd"/>
+				<disk name="sherlock holmes - consulting detective vol. i (usa)" sha1="32d2f47f459927cd162376e46d6a02430572a82a"/>
 			</diskarea>
 		</part>
 	</software>
@@ -3005,25 +3004,25 @@ See: http://rawdump.net/
 		<part name="cdrom1" interface="scd_cdrom">
 			<feature name="part_id" value="Disc 1 - Fingers" />
 			<diskarea name="cdrom1">
-				<disk name="slam city with scottie pippen (usa, alt) (disc 1)" sha1="2baee1ae3b6101d979128252e822617f5e1ed00d"/>
+				<disk name="slam city with scottie pippen (usa, alt) (disc 1)" sha1="637ceb49d6e9ff89009b26d848b6097a54969d65"/>
 			</diskarea>
 		</part>
 		<part name="cdrom2" interface="scd_cdrom">
 			<feature name="part_id" value="Disc 2 - Juice" />
 			<diskarea name="cdrom2">
-				<disk name="slam city with scottie pippen (usa, alt) (disc 2)" sha1="f2bf354ef463367a21ee50d8ad73d01050e5ae59"/>
+				<disk name="slam city with scottie pippen (usa, alt) (disc 2)" sha1="e5cc52a7686824b14ee471682f30b0b4a09dbe97"/>
 			</diskarea>
 		</part>
 		<part name="cdrom3" interface="scd_cdrom">
 			<feature name="part_id" value="Disc 3 - Mad Dog" />
 			<diskarea name="cdrom3">
-				<disk name="slam city with scottie pippen (usa, alt) (disc 3)" sha1="ba74c91f257647005e519b48858c450ff02ffca8"/>
+				<disk name="slam city with scottie pippen (usa, alt) (disc 3)" sha1="6d144435110bc0fcd97313c75dbb56f472e4e123"/>
 			</diskarea>
 		</part>
 		<part name="cdrom4" interface="scd_cdrom">
 			<feature name="part_id" value="Disc 4 - Smash" />
 			<diskarea name="cdrom4">
-				<disk name="slam city with scottie pippen (usa, alt) (disc 4)" sha1="8dac02dbde34a56b51b6d09367792ab3636d9f88"/>
+				<disk name="slam city with scottie pippen (usa, alt) (disc 4)" sha1="ddffdf4dd92fcb3f93f285ff24384815ba401cab"/>
 			</diskarea>
 		</part>
 	</software>
@@ -3061,7 +3060,7 @@ See: http://rawdump.net/
 		<info name="ring_code" value="T95035-U12 1"/>
 		<part name="cdrom" interface="scd_cdrom">
 			<diskarea name="cdrom">
-				<disk name="snatcher (usa)" sha1="656d45f88930caf9ea9781e7c44d3b8410d9acd1"/>
+				<disk name="snatcher (usa)" sha1="815edc5df272e4b10edd5919b29c3a996a1799c2"/>
 			</diskarea>
 		</part>
 	</software>
@@ -3096,7 +3095,7 @@ See: http://rawdump.net/
 		<info name="ring_code" value="SEGA4130RE2 R3C MFD BY JVC"/>
 		<part name="cdrom" interface="scd_cdrom">
 			<diskarea name="cdrom">
-				<disk name="sol-feace (usa)" sha1="a083967c80de7ed2fbc7750844c90f0673c47e24"/>
+				<disk name="sol-feace (usa)" sha1="498ebd9c1fe4bd2f84cf6c32829b68e471eb3b07"/>
 			</diskarea>
 		</part>
 	</software>
@@ -3202,7 +3201,7 @@ See: http://rawdump.net/
 		<info name="ring_code" value="SEGA4407RE125 R7D MFD BY JVC"/>
 		<part name="cdrom" interface="scd_cdrom">
 			<diskarea name="cdrom">
-				<disk name="sonic cd (usa, alt)" sha1="3ca4038a423e2970b162a1fba7b6904315a6b585"/>
+				<disk name="sonic cd (usa, alt)" sha1="a8a968a6239da07c6143dd420a6a3093f4dddcd2"/>
 			</diskarea>
 		</part>
 	</software>
@@ -3255,7 +3254,7 @@ See: http://rawdump.net/
 		<info name="ring_code" value="SEGA4407RE125 R8C MFD BY JVC"/>
 		<part name="cdrom" interface="scd_cdrom">
 			<diskarea name="cdrom">
-				<disk name="sonic cd (usa, alt 2)" sha1="19c1bb0f58e08f253f81b3a1f88c98b50e033810"/>
+				<disk name="sonic cd (usa, alt 2)" sha1="824b78678ce7aa0b845d14de3e7df737105329f4"/>
 			</diskarea>
 		</part>
 	</software>
@@ -3289,7 +3288,7 @@ See: http://rawdump.net/
 		<info name="ring_code" value="SEGAT115035 R1J MFD BY JVC"/>
 		<part name="cdrom" interface="scd_cdrom">
 			<diskarea name="cdrom">
-				<disk name="soulstar (usa)" sha1="0576c766b187ffbb4c4ddf01a4f7fc5b5de63738"/>
+				<disk name="soulstar (usa)" sha1="4e2ab5b51dca2a4c23700b4d3587a9a08ac6d29f"/>
 			</diskarea>
 		</part>
 	</software>
@@ -3307,7 +3306,7 @@ See: http://rawdump.net/
 		<info name="ring_code" value="CDAC-080300 2"/>
 		<part name="cdrom" interface="scd_cdrom">
 			<diskarea name="cdrom">
-				<disk name="space ace (usa)" sha1="e953da892df97b40422fbf8a03eb01df35bb70e3"/>
+				<disk name="space ace (usa)" sha1="d5f5125af3e9e59a59f775576ddc99b4aadaf505"/>
 			</diskarea>
 		</part>
 	</software>
@@ -3344,7 +3343,7 @@ See: http://rawdump.net/
 		<info name="ring_code" value="CDAC-073400 2"/>
 		<part name="cdrom" interface="scd_cdrom">
 			<diskarea name="cdrom">
-				<disk name="starblade (usa)" sha1="4dafc73e1cbe0d69cacb62de74bb50993b40c975"/>
+				<disk name="starblade (usa)" sha1="6233ca426d0797a5bccf98261b5164c44feb5203"/>
 			</diskarea>
 		</part>
 	</software>
@@ -3401,7 +3400,7 @@ See: http://rawdump.net/
 		<info name="ring_code" value="CDAC-088700 1"/>
 		<part name="cdrom" interface="scd_cdrom">
 			<diskarea name="cdrom">
-				<disk name="surgical strike (usa)" sha1="3f925e8a1a98e094227dfe4c9851d63a9b22d3ea"/>
+				<disk name="surgical strike (usa)" sha1="37ba598fdc774b805f89d43962591a176c2215d4"/>
 			</diskarea>
 		</part>
 	</software>
@@ -3489,6 +3488,50 @@ See: http://rawdump.net/
 			</diskarea>
 		</part>
 	</software>
+	
+	<software name="monkey">
+		<!-- Source: redump.org - http://redump.org/disc/36040/
+		<rom name="Secret of Monkey Island, The (USA).cue" size="3488" crc="04a1e02f" md5="027ccf6397d96b6d9a5b7b33adcaa9fc" sha1="2c14e74a3fca8214008621434a530d861268307c"/>
+		<rom name="Secret of Monkey Island, The (USA) (Track 01).bin" size="13063008" crc="8a9c032d" md5="9efbaf7fa3ebe088db4deb78f93f05e4" sha1="a63fc8aad1001064f16fda2f57c4c59eb7994908"/>
+		<rom name="Secret of Monkey Island, The (USA) (Track 02).bin" size="21525504" crc="2482c4ef" md5="c1d50fb26e4b5cf8d2c05a7082f3ba9a" sha1="65546e87bc9af111574aaf822a57e41771871fcc"/>
+		<rom name="Secret of Monkey Island, The (USA) (Track 03).bin" size="22191120" crc="da8b6224" md5="d059d6380fa77302a0d0fdeabbe06a10" sha1="bc2abcf39cc6456a55c4830f109b8d58bfa530af"/>
+		<rom name="Secret of Monkey Island, The (USA) (Track 04).bin" size="22028832" crc="495e93eb" md5="2c3dea8e3b24b8bd2bcc5b4b4a356196" sha1="a73300d83ea9ec409c75abe2c43291cd66ef4f19"/>
+		<rom name="Secret of Monkey Island, The (USA) (Track 05).bin" size="20664672" crc="05270610" md5="75c10fe3bcec589ebd50b91ca4fe2d83" sha1="b091da229f4b02661f29fce6beba66a43b7096da"/>
+		<rom name="Secret of Monkey Island, The (USA) (Track 06).bin" size="22640352" crc="d7b6273c" md5="7144f45d4d8582b4254a758b5d59de6b" sha1="a29f3629be7c30ce0e4fd55455038bd7c542c050"/>
+		<rom name="Secret of Monkey Island, The (USA) (Track 07).bin" size="2232048" crc="328d0de3" md5="a1fecf996e3757cdfea45e58c2224ef0" sha1="94c1d27f9d10654ef793bac346c57f3302cf003d"/>
+		<rom name="Secret of Monkey Island, The (USA) (Track 08).bin" size="12825456" crc="b8e130e5" md5="f4c3dc04f4f089dc2c8229ff24a9f672" sha1="4e03112a6927e5d7f193441d4b1caf35c4a2f522"/>
+		<rom name="Secret of Monkey Island, The (USA) (Track 09).bin" size="24660720" crc="f401c2f6" md5="c79f71393f89addf09fd0d1f5777c2cc" sha1="8e9f68caa759aa24d709749cdf1395df1a697182"/>
+		<rom name="Secret of Monkey Island, The (USA) (Track 10).bin" size="22108800" crc="a458dbc4" md5="769c81ef036f86f89f85ab3d492967e8" sha1="e27f4fdc0786e0de0bb5274cd5600dd578810488"/>
+		<rom name="Secret of Monkey Island, The (USA) (Track 11).bin" size="16689792" crc="06ffb55e" md5="5c2e9bd143d7e86a80b69cbed6217f2f" sha1="1dc75204d1de20d253d0f90a0b2f2b4a5fe33e6b"/>
+		<rom name="Secret of Monkey Island, The (USA) (Track 12).bin" size="24681888" crc="d6352466" md5="880a7e12daffb1c246e7fc14b8450386" sha1="ed86ad7b8c48ec3c5a5823d40aa7426e9559d5d8"/>
+		<rom name="Secret of Monkey Island, The (USA) (Track 13).bin" size="21864192" crc="d42b7633" md5="4befad6c1bf3b5edbe4e02cfe4e308b1" sha1="9b18004634b54dbb1bf436afe8adbffbfa135d35"/>
+		<rom name="Secret of Monkey Island, The (USA) (Track 14).bin" size="3473904" crc="238b259d" md5="0f00ddbf5a05e9725ef021212f426cf9" sha1="b2dc0cb90a7d8c68caf9852301fb8b6d9f1a73ae"/>
+		<rom name="Secret of Monkey Island, The (USA) (Track 15).bin" size="27906480" crc="04f0c8fa" md5="ee41f892a62ad037b37a9f20c4cc4f97" sha1="cbe71e2d195b90274498a70cbf4ab46f5b573347"/>
+		<rom name="Secret of Monkey Island, The (USA) (Track 16).bin" size="26570544" crc="7a18b50b" md5="645746b8bbbe67a422d3b83a13570ffb" sha1="dca486d85f1989d4da9c02247ed881d87e288881"/>
+		<rom name="Secret of Monkey Island, The (USA) (Track 17).bin" size="39290160" crc="6549b6a0" md5="6ba208d8b179b19453ac7c3e587e24a1" sha1="4ecb03aa1ceda93443372050338a68b825f69cf5"/>
+		<rom name="Secret of Monkey Island, The (USA) (Track 18).bin" size="28252224" crc="fa730181" md5="bb88a8a9f068f59700c2343ff8d4a3c7" sha1="4076250e427a7ed64ea00c99b3da6aeb0a6a4de9"/>
+		<rom name="Secret of Monkey Island, The (USA) (Track 19).bin" size="28129920" crc="dc424e70" md5="fcbc1ebc536f7927418c5c5770273dc8" sha1="03cecdb076be6e8fcf5122a4b764a37b88810c7f"/>
+		<rom name="Secret of Monkey Island, The (USA) (Track 20).bin" size="3259872" crc="b2316a26" md5="ff9e29f85d1dfb4c4e8b576e81f54a90" sha1="5e7ca2dff6a50df67e49d9479806161e6c4f7654"/>
+		<rom name="Secret of Monkey Island, The (USA) (Track 21).bin" size="3582096" crc="55d45007" md5="1c41ab06d5be1af87d925b33a785acab" sha1="096b4c2c2c8db86cbd53659a612ac2325cad6870"/>
+		<rom name="Secret of Monkey Island, The (USA) (Track 22).bin" size="23849280" crc="7a976e2b" md5="9e318fc9e0b65894e749a802c0d819f1" sha1="fa5dc2d515a6cf1e640b85b9b8027d0dc254de4a"/>
+		<rom name="Secret of Monkey Island, The (USA) (Track 23).bin" size="18028080" crc="8fabb577" md5="36229c07217a6279cb0c202d6968c96f" sha1="37e3c14140228d8e03cd22897aa15dbeff660d3e"/>
+		<rom name="Secret of Monkey Island, The (USA) (Track 24).bin" size="1773408" crc="9631ea37" md5="d1a1e85a65ba10015071e16b720aeffa" sha1="71f184bc537b192311288706dbdc6dbeecf9ab47"/>
+		<rom name="Secret of Monkey Island, The (USA) (Track 25).bin" size="2222640" crc="c3a65f1a" md5="114e66fee7874436612dd9f44235f880" sha1="e2757ec7964b2af6c918dd3c54fcd1291f3caa77"/>
+		<rom name="Secret of Monkey Island, The (USA) (Track 26).bin" size="11176704" crc="8c96311a" md5="8909aa0e697bdf42d985df2f2797bf90" sha1="eb849d37fd8c13e0c012440721cceeebd6c2f400"/>
+		<rom name="Secret of Monkey Island, The (USA) (Track 27).bin" size="10252368" crc="490d3101" md5="f06a4ae585d3b0ff91b6d877e9115145" sha1="dbf7032596f941ef29980580eaf96c52811ec08b"/>
+		-->
+		<description>The Secret of Monkey Island (USA)</description>
+		<year>1992</year>
+		<publisher>JVC</publisher>
+		<info name="serial" value="T-60035"/>
+		<info name="release" value="199212xx" />
+		<info name="ring_code" value="SEGAT60035RE R1C MFD BY JVC"/>
+		<part name="cdrom" interface="scd_cdrom">
+			<diskarea name="cdrom">
+				<disk name="the secret of monkey island (usa)" sha1="a894a9e6ba908f742d686fb85b7ae3c700fb1d36"/>
+			</diskarea>
+		</part>
+	</software>
 
 	<software name="swchess">
 		<!-- Source: redump.org - http://redump.org/disc/21448/
@@ -3503,7 +3546,7 @@ See: http://rawdump.net/
 		<info name="release" value="199405xx" />
 		<part name="cdrom" interface="scd_cdrom">
 			<diskarea name="cdrom">
-				<disk name="star wars chess (usa)" sha1="3e397b7a4028a79bb03e0df0440e178e23dada22"/>
+				<disk name="star wars chess (usa)" sha1="fe03505a7c2f1ebdef4d2c32c8b73677288d635b"/>
 			</diskarea>
 		</part>
 	</software>
@@ -3530,7 +3573,7 @@ See: http://rawdump.net/
 		<info name="ring_code" value="SEGACD86003 R1D MFD BY JVC"/>
 		<part name="cdrom" interface="scd_cdrom">
 			<diskarea name="cdrom">
-				<disk name="the terminator (usa)" sha1="892985b7c40bf1d4ac9c0618daf5b19221fb7d50"/>
+				<disk name="the terminator (usa)" sha1="43bf02bf06fc5d1bd32bc61b11acd1745d2d7a1d"/>
 			</diskarea>
 		</part>
 	</software>
@@ -3586,7 +3629,7 @@ See: http://rawdump.net/
 		<info name="ring_code" value="CDAC-058500 1, CDAC-058500 2"/>
 		<part name="cdrom" interface="scd_cdrom">
 			<diskarea name="cdrom">
-				<disk name="tomcat alley (usa, alt)" sha1="666c83baa034c91ad0243fb0e47eff043f8e746a"/>
+				<disk name="tomcat alley (usa, alt)" sha1="0d2ab8e7934c162ef16d233c62f02b9c0268aca4"/>
 			</diskarea>
 		</part>
 	</software>
@@ -3624,7 +3667,7 @@ See: http://rawdump.net/
 		<info name="ring_code" value="SEGAT127025ARE R1D MFD BY JVC"/>
 		<part name="cdrom" interface="scd_cdrom">
 			<diskarea name="cdrom">
-				<disk name="vay (usa)" sha1="061e99fbb2065c450e998a365f295b379dfb76da"/>
+				<disk name="vay (usa)" sha1="099e4c43d8ca5eb57854db25cbcbfc3139e41a9e"/>
 			</diskarea>
 		</part>
 	</software>
@@ -3689,7 +3732,7 @@ See: http://rawdump.net/
 		<info name="ring_code" value="CDAC-059000 2"/>
 		<part name="cdrom" interface="scd_cdrom">
 			<diskarea name="cdrom">
-				<disk name="wing commander (usa)" sha1="065ac2534ca4a0c17a5a98d557abeedd9d7e3640"/>
+				<disk name="wing commander (usa)" sha1="d36f61f84a87518691438a3c4f9862b2ce23e483"/>
 			</diskarea>
 		</part>
 	</software>
@@ -3707,7 +3750,7 @@ See: http://rawdump.net/
 		<info name="ring_code" value="1008604437 8/95 1RA2"/>
 		<part name="cdrom" interface="scd_cdrom">
 			<diskarea name="cdrom">
-				<disk name="wirehead (usa)" sha1="488fc4e55bdc515edc54df3e2b3d06207f45437c"/>
+				<disk name="wirehead (usa)" sha1="762bb917b936f1a781a2fbe66bbe3a9bf5dd5d43"/>
 			</diskarea>
 		</part>
 	</software>
@@ -3741,7 +3784,7 @@ See: http://rawdump.net/
 		<info name="ring_code" value="SEGAT79025 R2D MFD BY JVC"/>
 		<part name="cdrom" interface="scd_cdrom">
 			<diskarea name="cdrom">
-				<disk name="world cup usa 94 (usa)" sha1="4e976d3ba61f8c460d29cccb3772ab555f1f0875"/>
+				<disk name="world cup usa 94 (usa)" sha1="cb17c8ea42ec3a7d9562a0e188610a687f6b8829"/>
 			</diskarea>
 		</part>
 	</software>
@@ -3760,7 +3803,7 @@ See: http://rawdump.net/
 		<info name="ring_code" value="SEGAT81015 R3D MFD BY JVC"/>
 		<part name="cdrom" interface="scd_cdrom">
 			<diskarea name="cdrom">
-				<disk name="wwf rage in the cage (usa)" sha1="77d4b9e53bbd04a123d0aed427b9888f674cca7e"/>
+				<disk name="wwf rage in the cage (usa)" sha1="960a6ffa31b52e7ca8e7759f3d385940c8f2eb56"/>
 			</diskarea>
 		</part>
 	</software>
@@ -3836,7 +3879,7 @@ See: http://rawdump.net/
 		<publisher>Good Deal Games</publisher>
 		<part name="cdrom" interface="scd_cdrom">
 			<diskarea name="cdrom">
-				<disk name="battle frenzy (usa, prototype)" sha1="1e04f8a0a4b21a35ea858da1f94f6a52b0b23dfa"/>
+				<disk name="battle frenzy (usa, prototype)" sha1="5c60726206f1eb789358500c634924c9e7d8e798"/>
 			</diskarea>
 		</part>
 	</software>
@@ -3856,7 +3899,7 @@ See: http://rawdump.net/
 		<publisher>Good Deal Games</publisher>
 		<part name="cdrom" interface="scd_cdrom">
 			<diskarea name="cdrom">
-				<disk name="battletech - gray death legion (usa, prototype)" sha1="14f4bd7300ed0e0239fcf3380c9854430cccc9a7"/>
+				<disk name="battletech - gray death legion (usa, prototype)" sha1="c27d1f4447a3ba431ee283266ba26ecd93e67916"/>
 			</diskarea>
 		</part>
 	</software>
@@ -3920,7 +3963,7 @@ See: http://rawdump.net/
 		<info name="alt_title" value="Bug Blasters - The Exterminators (Box)" />
 		<part name="cdrom" interface="scd_cdrom">
 			<diskarea name="cdrom">
-				<disk name="the exterminators (usa, prototype)" sha1="061341a8e8828ecf3364823d2bad978e35aee1e0"/>
+				<disk name="the exterminators (usa, prototype)" sha1="9c1e73e31c90d2cfdff50dce0e2c95c562934d96"/>
 			</diskarea>
 		</part>
 	</software>
@@ -3943,7 +3986,7 @@ See: http://rawdump.net/
 		<info name="alt_title" value="Bug Blasters - The Exterminators (Box)" />
 		<part name="cdrom" interface="scd_cdrom">
 			<diskarea name="cdrom">
-				<disk name="the exterminators - special edition (usa, prototype)" sha1="b9d600e1ff638c8dc3a42687c08c2cc0874cdfa3"/>
+				<disk name="the exterminators - special edition (usa, prototype)" sha1="cb14ae1bf6825ac804a5508142759ff64d1d5b70"/>
 			</diskarea>
 		</part>
 	</software>
@@ -4186,7 +4229,7 @@ See: http://rawdump.net/
 		<info name="alt_title" value="Burning Fists - Force Striker (Box)" />
 		<part name="cdrom" interface="scd_cdrom">
 			<diskarea name="cdrom">
-				<disk name="force striker (usa, prototype)" sha1="002c8c948ab1d9319a19c29fc94c79ab62cc2068"/>
+				<disk name="force striker (usa, prototype)" sha1="593892565e8ba7df9204128bd7bc36e72f92b803"/>
 			</diskarea>
 		</part>
 	</software>
@@ -4204,7 +4247,7 @@ See: http://rawdump.net/
 		<publisher>RasterSoft</publisher>
 		<part name="cdrom" interface="scd_cdrom">
 			<diskarea name="cdrom">
-				<disk name="frog feast (usa)" sha1="85fcefff26409c3cd8eddbe38ac6d6e99002551f"/>
+				<disk name="frog feast (usa)" sha1="4dcd26df32f6463d5e9417558bbbf22c910ac65a"/>
 			</diskarea>
 		</part>
 	</software>
@@ -4424,7 +4467,7 @@ See: http://rawdump.net/
 		<publisher>Good Deal Games</publisher>
 		<part name="cdrom" interface="scd_cdrom">
 			<diskarea name="cdrom">
-				<disk name="marko (usa, prototype)" sha1="c672a0c7c2a7b889afd86ba17fc9a89552cc9b4c"/>
+				<disk name="marko (usa, prototype)" sha1="c4e51740ca8ff7c9574519bc849082220efe69f5"/>
 			</diskarea>
 		</part>
 	</software>
@@ -4490,7 +4533,7 @@ See: http://rawdump.net/
 		<publisher>Good Deal Games</publisher>
 		<part name="cdrom" interface="scd_cdrom">
 			<diskarea name="cdrom">
-				<disk name="mighty mighty missile! (usa)" sha1="d5a3cd7778f057113ef0d658c7339b4102c77765"/>
+				<disk name="mighty mighty missile! (usa)" sha1="561a66d7ed2df029ad07b49c4f0bca11f8ae0eb4"/>
 			</diskarea>
 		</part>
 	</software>
@@ -4557,7 +4600,7 @@ See: http://rawdump.net/
 		<part name="cdrom1" interface="scd_cdrom">
 			<feature name="part_id" value="Disc 1" />
 			<diskarea name="cdrom">
-				<disk name="prize fighter (usa) (disc 1)" sha1="625222afd60f88fa8877c206fd5671953fa88383"/>
+				<disk name="prize fighter (usa) (disc 1)" sha1="37742af63ba540380b8285a1e82be8d1898914e6"/>
 			</diskarea>
 		</part>
 
@@ -4825,7 +4868,7 @@ See: http://rawdump.net/
 		<publisher>Good Deal Games</publisher>
 		<part name="cdrom" interface="scd_cdrom">
 			<diskarea name="cdrom">
-				<disk name="star strike (usa, prototype)" sha1="b9b9a8287c003e879a2a21b177fbd99365fdb564" />
+				<disk name="star strike (usa, prototype)" sha1="65552aa20d2b799083fc4d27efc590fe91aa77af" />
 			</diskarea>
 		</part>
 	</software>
@@ -5039,7 +5082,7 @@ See: http://rawdump.net/
 		<publisher>Good Deal Games</publisher>
 		<part name="cdrom" interface="scd_cdrom">
 			<diskarea name="cdrom">
-				<disk name="timecop (usa, prototype)" sha1="fe146623b2808d8126f78c3a2c3f5d98c8a0b343"/>
+				<disk name="timecop (usa, prototype)" sha1="8b002f1767595cbc2a753114574ba3487d5a0011"/>
 			</diskarea>
 		</part>
 	</software>
@@ -5421,7 +5464,7 @@ See: http://rawdump.net/
 		<publisher>RasterSoft</publisher>
 		<part name="cdrom" interface="scd_cdrom">
 			<diskarea name="cdrom">
-				<disk name="frog feast (usa, demo)" sha1="4c476e0576225a7a19e27dde4b838afbfebaf3a0"/>
+				<disk name="frog feast (usa, demo)" sha1="8411e49c5ef3a39a70d3e1612a04c66e3161eea9"/>
 			</diskarea>
 		</part>
 	</software>
@@ -5660,7 +5703,7 @@ See: http://rawdump.net/
 		<publisher>Sega</publisher>
 		<part name="cdrom" interface="scd_cdrom">
 			<diskarea name="cdrom">
-				<disk name="road rash (usa, prototype, beta 3 - 19950211)" sha1="7b1c9816eb7297bb091c036bab85a0af30d38307" status="baddump"/>
+				<disk name="road rash (usa, prototype, beta 3 - 19950211)" sha1="e05bbc530b2b3f88e6efc7a367f931e65049a33c" status="baddump"/>
 			</diskarea>
 		</part>
 	</software>
@@ -5798,24 +5841,6 @@ See: http://rawdump.net/
 		<part name="cdrom" interface="scd_cdrom">
 			<diskarea name="cdrom">
 				<disk name="syndicate (usa, prototype)" sha1="7441856d59cee9e7425a7d0716b712be2020082a"/>
-			</diskarea>
-		</part>
-	</software>
-
-	<software name="monkey">
-		<!-- Source: TruRip
-		<rom name="Media (CD-ROM)\Secret of Monkey Island, The (1993)(Victor)(US).ccd" size="4885" crc="86dddc39" md5="d17f97346dc4ef44109c7710f669c28c" sha1="9c0fd0075e2c1dcf7a39192fd82f9019c9a11399"/>
-		<rom name="Media (CD-ROM)\Secret of Monkey Island, The (1993)(Victor)(US).img" size="474944064" crc="46c410b9" md5="eaef9beeb2aba022919d6ed03e565258" sha1="fc4a3df1253d237b58958c3084ba800100b8e12a"/>
-		<rom name="Media (CD-ROM)\Secret of Monkey Island, The (1993)(Victor)(US).sub" size="19385472" crc="5dcb20a1" md5="0b4d414e82921967878a51417b1b7eec" sha1="1bd31c217283826dda3de1f9dc828ff15635b188"/>
-		-->
-		<description>The Secret of Monkey Island (USA)</description>
-		<year>1992</year>
-		<publisher>JVC</publisher>
-		<info name="serial" value="T-60035"/>
-		<info name="release" value="199212xx" />
-		<part name="cdrom" interface="scd_cdrom">
-			<diskarea name="cdrom">
-				<disk name="the secret of monkey island (usa)" sha1="1f90af90c880bad8e9acf6c0f2fa10000072abbe"/>
 			</diskarea>
 		</part>
 	</software>

--- a/hash/segacd.xml
+++ b/hash/segacd.xml
@@ -3842,7 +3842,7 @@ See: http://rawdump.net/
 		<info name="ring_code" value="T-163015-00"/>
 		<part name="cdrom" interface="scd_cdrom">
 			<diskarea name="cdrom">
-				<disk name="bari-arm (usa)" sha1=""/>
+				<disk name="bari-arm (usa)" sha1="99419bf60689cf563a26236f7db116b72ad6ab8b"/>
 			</diskarea>
 		</part>
 	</software>

--- a/hash/segacd.xml
+++ b/hash/segacd.xml
@@ -249,7 +249,7 @@ See: http://rawdump.net/
 		<info name="ring_code" value="SEGAT86015RE R1J MFD BY JVC"/>
 		<part name="cdrom" interface="scd_cdrom">
 			<diskarea name="cdrom">
-				<disk name="ax-101 (usa)" sha1=""/>
+				<disk name="ax-101 (usa)" sha1="4a0200c4b1d6b7f486d1946b6ce886d35872aae7"/>
 			</diskarea>
 		</part>
 	</software>
@@ -278,7 +278,7 @@ See: http://rawdump.net/
 		<info name="ring_code" value="CDAC-040200 3"/>
 		<part name="cdrom" interface="scd_cdrom">
 			<diskarea name="cdrom">
-				<disk name="after burner iii (usa)" sha1=""/>
+				<disk name="after burner iii (usa)" sha1="5387cce37990836db962ce82ec217edbe2c1fd0d"/>
 			</diskarea>
 		</part>
 	</software>
@@ -345,7 +345,7 @@ See: http://rawdump.net/
 		<info name="ring_code" value="CDAC-040500 1"/>
 		<part name="cdrom" interface="scd_cdrom">
 			<diskarea name="cdrom">
-				<disk name="batman returns (usa)" sha1=""/>
+				<disk name="batman returns (usa)" sha1="fcef5b725f01b928a29a60a5e3d4c493908b209f"/>
 			</diskarea>
 		</part>
 	</software>
@@ -484,7 +484,7 @@ See: http://rawdump.net/
 		<info name="ring_code" value="CDAC-031700 1"/>
 		<part name="cdrom" interface="scd_cdrom">
 			<diskarea name="cdrom">
-				<disk name="black hole assault (usa)" sha1=""/>
+				<disk name="black hole assault (usa)" sha1="e7533c9de5cea95b3d3ddbcc19d0002aa4fabb2b"/>
 			</diskarea>
 		</part>
 	</software>
@@ -510,7 +510,7 @@ See: http://rawdump.net/
 		<info name="ring_code" value="CDAC 082400 1"/>
 		<part name="cdrom" interface="scd_cdrom">
 			<diskarea name="cdrom">
-				<disk name="bouncers (usa)" sha1=""/>
+				<disk name="bouncers (usa)" sha1="ec21e095b7670989495095f6a6cb9a94ba24a405"/>
 			</diskarea>
 		</part>
 	</software>
@@ -582,7 +582,7 @@ See: http://rawdump.net/
 		<info name="ring_code" value="CDAC-068700 1"/>
 		<part name="cdrom" interface="scd_cdrom">
 			<diskarea name="cdrom">
-				<disk name="bram stoker's dracula (usa, rev. a)" sha1=""/>
+				<disk name="bram stoker's dracula (usa, rev. a)" sha1="ff8b30072085ed157c94859371e6a8f087ebd132"/>
 			</diskarea>
 		</part>
 	</software>
@@ -642,7 +642,7 @@ See: http://rawdump.net/
 		<info name="ring_code" value="CDAC-032500 5"/>
 		<part name="cdrom" interface="scd_cdrom">
 			<diskarea name="cdrom">
-				<disk name="chuck rock (usa)" sha1=""/>
+				<disk name="chuck rock (usa)" sha1="2a0ca620f253992e92af5655c7ed4203a1537b0e"/>
 			</diskarea>
 		</part>
 	</software>
@@ -671,7 +671,7 @@ See: http://rawdump.net/
 		<info name="ring_code" value="SEGACD86006 R1D MFD BY JVC"/>
 		<part name="cdrom" interface="scd_cdrom">
 			<diskarea name="cdrom">
-				<disk name="chuck rock ii - son of chuck (usa)" sha1=""/>
+				<disk name="chuck rock ii - son of chuck (usa)" sha1="d47e53ee53653ee9b5623f276060e7a5f4f28c9e"/>
 			</diskarea>
 		</part>
 	</software>
@@ -732,7 +732,7 @@ See: http://rawdump.net/
 		<info name="ring_code" value="SEGAT118025 R1F MFD BY JVC"/>
 		<part name="cdrom" interface="scd_cdrom">
 			<diskarea name="cdrom">
-				<disk name="compton's interactive encyclopedia v2.01r (usa)" sha1=""/>
+				<disk name="compton's interactive encyclopedia v2.01r (usa)" sha1="2df62d0e0a8f37e7b52c549ce7605d8c55fadf00"/>
 			</diskarea>
 		</part>
 	</software>
@@ -3454,7 +3454,7 @@ See: http://rawdump.net/
 		<info name="ring_code" value="SEGAT110015 R1J"/>
 		<part name="cdrom" interface="scd_cdrom">
 			<diskarea name="cdrom">
-				<disk name="the adventures of willy beamish (usa)" sha1=""/>
+				<disk name="the adventures of willy beamish (usa)" sha1="694476e5e82d7317ec6943d5d749764592045f37"/>
 			</diskarea>
 		</part>
 	</software>
@@ -3484,7 +3484,7 @@ See: http://rawdump.net/
 		<info name="ring_code" value="CDAC-047100 2"/>
 		<part name="cdrom" interface="scd_cdrom">
 			<diskarea name="cdrom">
-				<disk name="the amazing spider-man vs. the kingpin (usa)" sha1=""/>
+				<disk name="the amazing spider-man vs. the kingpin (usa)" sha1="4102f007184635832ca13ab770ccadcde32242da"/>
 			</diskarea>
 		</part>
 	</software>

--- a/hash/segacd.xml
+++ b/hash/segacd.xml
@@ -5197,7 +5197,7 @@ See: http://rawdump.net/
 		<info name="serial" value="T-115075"/>
 		<part name="cdrom" interface="scd_cdrom">
 			<diskarea name="cdrom">
-				<disk name="bc racers (usa)" sha1="7550f60f088232ea714d7a43ee134980ad849491"/>
+				<disk name="bc racers (usa)" sha1="b60b60c6fccc892bf9bf4ebc876b78da10182350"/>
 			</diskarea>
 		</part>
 	</software>
@@ -5244,7 +5244,7 @@ See: http://rawdump.net/
 		<info name="serial" value="T-93185"/>
 		<part name="cdrom" interface="scd_cdrom">
 			<diskarea name="cdrom">
-				<disk name="championship soccer '94 (usa)" sha1="ff926905e5e633f839c380e7c9c101df465a63b2"/>
+				<disk name="championship soccer '94 (usa)" sha1="314522011b559b18082a1c867de1ace574a4a680"/>
 			</diskarea>
 		</part>
 	</software>
@@ -5291,7 +5291,7 @@ See: http://rawdump.net/
 		<info name="serial" value="T-118025"/>
 		<part name="cdrom" interface="scd_cdrom">
 			<diskarea name="cdrom">
-				<disk name="compton's interactive encyclopedia v2.01s (usa)" sha1="8a1139781c870b71525ed0881d0087561813d251" />
+				<disk name="compton's interactive encyclopedia v2.01s (usa)" sha1="79ca6bb38c296ac3cc6352823be337371ad7a396" />
 			</diskarea>
 		</part>
 	</software>
@@ -5309,7 +5309,7 @@ See: http://rawdump.net/
 		<part name="cdrom" interface="scd_cdrom">
 			<feature name="peripheral" value="menacer" />
 			<diskarea name="cdrom">
-				<disk name="crime patrol (usa)" sha1="d1380a6e3325e74eb1ab90ec12e4f7aff2bfecc4"/>
+				<disk name="crime patrol (usa)" sha1="544f2ac30e49c141d5a185a30c80b2ee51f12fd1"/>
 			</diskarea>
 		</part>
 	</software>
@@ -5326,7 +5326,7 @@ See: http://rawdump.net/
 		<info name="serial" value="T-81045"/>
 		<part name="cdrom" interface="scd_cdrom">
 			<diskarea name="cdrom">
-				<disk name="demolition man (usa)" sha1="e740d0801ae4dc7906a45016b394848562c8ab61"/>
+				<disk name="demolition man (usa)" sha1="5d7a96692fe79c8a1f6105c208bd60ced82d6014"/>
 			</diskarea>
 		</part>
 	</software>
@@ -5343,7 +5343,7 @@ See: http://rawdump.net/
 		<info name="serial" value="T-125045"/>
 		<part name="cdrom" interface="scd_cdrom">
 			<diskarea name="cdrom">
-				<disk name="earthworm jim - special edition (usa)" sha1="7da7ca78e62a19e353fc322bfe01e30ba0573e56"/>
+				<disk name="earthworm jim - special edition (usa)" sha1="0f7052a3c22367e7c5e0f857254849ffee9c941b"/>
 			</diskarea>
 		</part>
 	</software>
@@ -5360,7 +5360,7 @@ See: http://rawdump.net/
 		<info name="serial" value="T-93245 "/>
 		<part name="cdrom" interface="scd_cdrom">
 			<diskarea name="cdrom">
-				<disk name="espn nba hangtime '95 (usa)" sha1="da5998bfc4354a4475abd3d23ab078f701e6f8e7"/>
+				<disk name="espn nba hangtime '95 (usa)" sha1="86f1f4ee8da0f04109cf20b6b8ad455900562abe"/>
 			</diskarea>
 		</part>
 	</software>
@@ -5377,7 +5377,7 @@ See: http://rawdump.net/
 		<info name="serial" value="T-60165"/>
 		<part name="cdrom" interface="scd_cdrom">
 			<diskarea name="cdrom">
-				<disk name="fatal fury special (usa)" sha1="0ccce1d896124f261af478e3dc521e01859751d0"/>
+				<disk name="fatal fury special (usa)" sha1="07010baf387179950d62efe19745718fd5bc0744"/>
 			</diskarea>
 		</part>
 	</software>
@@ -5407,7 +5407,7 @@ See: http://rawdump.net/
 		<info name="serial" value="T-23055"/>
 		<part name="cdrom" interface="scd_cdrom">
 			<diskarea name="cdrom">
-				<disk name="flink (usa)" sha1="f287ffa7efd7a9d92b03fd11b4da1a693963db12"/>
+				<disk name="flink (usa)" sha1="3395bc2c0291f5af9f19ce5ab246c8ff15f6ced3"/>
 			</diskarea>
 		</part>
 	</software>
@@ -5477,7 +5477,7 @@ See: http://rawdump.net/
 		<info name="serial" value="ACDG-GP1"/>
 		<part name="cdrom" interface="scd_cdrom">
 			<diskarea name="cdrom">
-				<disk name="karaoke - jvc cd+g karaoke - top hit sampler (usa)" sha1="95e3d4bf84d8fb39e7548adab933c514bda0df78" status="baddump" />
+				<disk name="karaoke - jvc cd+g karaoke - top hit sampler (usa)" sha1="e969df346a8106b837b471cc87670b6aab981ec3" status="baddump" />
 			</diskarea>
 		</part>
 	</software>
@@ -5495,7 +5495,7 @@ See: http://rawdump.net/
 		<info name="release" value="199501xx" />
 		<part name="cdrom" interface="scd_cdrom">
 			<diskarea name="cdrom">
-				<disk name="keio flying squadron (usa)" sha1="b9fa1b5b06b4da724323ae8665fc423713c3410e"/>
+				<disk name="keio flying squadron (usa)" sha1="4e47afd43c13ae481dd159fd6e0f2fc4d180a211"/>
 			</diskarea>
 		</part>
 	</software>
@@ -5512,7 +5512,7 @@ See: http://rawdump.net/
 		<info name="serial" value="T-111065"/>
 		<part name="cdrom" interface="scd_cdrom">
 			<diskarea name="cdrom">
-				<disk name="mad dog ii - the lost gold (usa)" sha1="d5da43e27679382a010c2df1c71199c4e8a35c08"/>
+				<disk name="mad dog ii - the lost gold (usa)" sha1="bb599adbb99cfc6fbd667f60429bb1f504af16c6"/>
 			</diskarea>
 		</part>
 	</software>
@@ -5543,7 +5543,7 @@ See: http://rawdump.net/
 		<info name="serial" value="T-109015"/>
 		<part name="cdrom" interface="scd_cdrom">
 			<diskarea name="cdrom">
-				<disk name="my paint (usa)" sha1="82827238d892956329191189963be9b5e786ef95"/>
+				<disk name="my paint (usa)" sha1="30917da8038266ad3d76498e3fbe565c4456d602"/>
 			</diskarea>
 		</part>
 	</software>
@@ -5560,7 +5560,7 @@ See: http://rawdump.net/
 		<info name="serial" value="T-135015"/>
 		<part name="cdrom" interface="scd_cdrom">
 			<diskarea name="cdrom">
-				<disk name="nfl football trivia challenge (usa)" sha1="28d65b5541fe70a3888bf71482f1a6b90c0b9d0b"/>
+				<disk name="nfl football trivia challenge (usa)" sha1="eadf0633891eb5d94dcb0336d367abca750fa903"/>
 			</diskarea>
 		</part>
 	</software>
@@ -5582,13 +5582,13 @@ See: http://rawdump.net/
 		<part name="cdrom1" interface="scd_cdrom">
 			<feature name="part_id" value="Disc 1" />
 			<diskarea name="cdrom">
-				<disk name="night trap (usa, re-release) (disc 1)" sha1="96d1119f7672ddffb140f2e550776ce78ceea7db"/>
+				<disk name="night trap (usa, re-release) (disc 1)" sha1="69cd893b1b2d971da405cac1c4c71114e8a91648"/>
 			</diskarea>
 		</part>
 		<part name="cdrom2" interface="scd_cdrom">
 			<feature name="part_id" value="Disc 2" />
 			<diskarea name="cdrom">
-				<disk name="night trap (usa, re-release) (disc 2)" sha1="cc06731d2167bb5770d61014747daa3cadbee461"/>
+				<disk name="night trap (usa, re-release) (disc 2)" sha1="d8447c507abf9b7afc64b943fa3b4f794ddf25f1"/>
 			</diskarea>
 		</part>
 	</software>
@@ -5606,7 +5606,7 @@ See: http://rawdump.net/
 		<info name="release" value="199406xx" />
 		<part name="cdrom" interface="scd_cdrom">
 			<diskarea name="cdrom">
-				<disk name="panic! (usa)" sha1="753925aab3ba016b5c6c8bfd6f07f7264dd6a10a"/>
+				<disk name="panic! (usa)" sha1="44216917d5e42f131c0854cd8fb5066f5e39c87f"/>
 			</diskarea>
 		</part>
 	</software>
@@ -5643,7 +5643,7 @@ See: http://rawdump.net/
 		<info name="serial" value="T-22035"/>
 		<part name="cdrom" interface="scd_cdrom">
 			<diskarea name="cdrom">
-				<disk name="revengers of vengeance (usa)" sha1="2f323e3cb3b16c47c22c508b5fac14d504b2d701"/>
+				<disk name="revengers of vengeance (usa)" sha1="fda7766a0480655c1a23ca40f33258c0d83abe3e"/>
 			</diskarea>
 		</part>
 	</software>
@@ -5678,7 +5678,7 @@ See: http://rawdump.net/
 		<info name="release" value="199308xx" />
 		<part name="cdrom" interface="scd_cdrom">
 			<diskarea name="cdrom">
-				<disk name="robo aleste (usa)" sha1="e4f48ddcd1b8bc66a4b1c0e3c6d9fb3b95ee3904"/>
+				<disk name="robo aleste (usa)" sha1="16f734ed901182e0e435e6c2b4f559e99615f148"/>
 			</diskarea>
 		</part>
 	</software>
@@ -5701,7 +5701,7 @@ See: http://rawdump.net/
 		<info name="release" value="19921015" />
 		<part name="cdrom" interface="scd_cdrom">
 			<diskarea name="cdrom">
-				<disk name="rock paintings (usa)" sha1="fbd05b5cfe361871ab155ba40438bb395b0f661e" status="baddump" />
+				<disk name="rock paintings (usa)" sha1="614f3f8e89e4b91923ff69719c38baef679f8e8d" status="baddump" />
 			</diskarea>
 		</part>
 	</software>
@@ -5718,7 +5718,7 @@ See: http://rawdump.net/
 		<info name="serial" value="T-113045"/>
 		<part name="cdrom" interface="scd_cdrom">
 			<diskarea name="cdrom">
-				<disk name="shadow of the beast ii (usa)" sha1="882e8574b002c6ce5d82e115d8eb4535eba22e32"/>
+				<disk name="shadow of the beast ii (usa)" sha1="7c341dbce23c5b166d4d949e977dae44a553f8a4"/>
 			</diskarea>
 		</part>
 	</software>
@@ -5815,7 +5815,7 @@ See: http://rawdump.net/
 		<info name="release" value="199212xx" />
 		<part name="cdrom" interface="scd_cdrom">
 			<diskarea name="cdrom">
-				<disk name="the secret of monkey island (usa)" sha1="e374566e1efbf937b75561debab625d388840b1b"/>
+				<disk name="the secret of monkey island (usa)" sha1="1f90af90c880bad8e9acf6c0f2fa10000072abbe"/>
 			</diskarea>
 		</part>
 	</software>
@@ -5851,7 +5851,7 @@ See: http://rawdump.net/
 		<info name="alt_title" value="The Space Adventure (Box)" />
 		<part name="cdrom" interface="scd_cdrom">
 			<diskarea name="cdrom">
-				<disk name="the space adventure - cobra the legendary bandit (usa)" sha1="3fd85178155f7644bd0ff8c14b75d8e170138a46"/>
+				<disk name="the space adventure - cobra the legendary bandit (usa)" sha1="51a755087713cc945adf5d5e85da713343ea3a0e"/>
 			</diskarea>
 		</part>
 	</software>
@@ -5896,7 +5896,7 @@ See: http://rawdump.net/
 		<info name="release" value="199212xx" />
 		<part name="cdrom" interface="scd_cdrom">
 			<diskarea name="cdrom">
-				<disk name="wolfchild (usa)" sha1="11cbe214ddfdf2536a7448bfd1534d17434f2783"/>
+				<disk name="wolfchild (usa)" sha1="700228109f9fe28bd5af6525c9fe0354913e1c6a"/>
 			</diskarea>
 		</part>
 	</software>

--- a/hash/segacd.xml
+++ b/hash/segacd.xml
@@ -231,7 +231,7 @@ See: http://rawdump.net/
 		<info name="ring_code" value="CDAC-078200 2"/>
 		<part name="cdrom" interface="scd_cdrom">
 			<diskarea name="cdrom">
-				<disk name="3 ninjas kick back (usa)" sha1="6ebb602efa04127f905b39fafa6aa37ef69d1c7c"/>
+				<disk name="3 ninjas kick back (usa)" sha1=""/>
 			</diskarea>
 		</part>
 	</software>
@@ -249,7 +249,7 @@ See: http://rawdump.net/
 		<info name="ring_code" value="SEGAT86015RE R1J MFD BY JVC"/>
 		<part name="cdrom" interface="scd_cdrom">
 			<diskarea name="cdrom">
-				<disk name="ax-101 (usa)" sha1="e0a323a38305dc8cbb4d9c778d8256dd0fcd4dc5"/>
+				<disk name="ax-101 (usa)" sha1=""/>
 			</diskarea>
 		</part>
 	</software>
@@ -278,7 +278,7 @@ See: http://rawdump.net/
 		<info name="ring_code" value="CDAC-040200 3"/>
 		<part name="cdrom" interface="scd_cdrom">
 			<diskarea name="cdrom">
-				<disk name="after burner iii (usa)" sha1="95697301e1a81136a635f9dc93db9645cd31d3f8"/>
+				<disk name="after burner iii (usa)" sha1=""/>
 			</diskarea>
 		</part>
 	</software>
@@ -345,7 +345,7 @@ See: http://rawdump.net/
 		<info name="ring_code" value="CDAC-040500 1"/>
 		<part name="cdrom" interface="scd_cdrom">
 			<diskarea name="cdrom">
-				<disk name="batman returns (usa)" sha1="49dc8d5f2760123f8babc57837c3818b90c546c8"/>
+				<disk name="batman returns (usa)" sha1=""/>
 			</diskarea>
 		</part>
 	</software>
@@ -484,7 +484,7 @@ See: http://rawdump.net/
 		<info name="ring_code" value="CDAC-031700 1"/>
 		<part name="cdrom" interface="scd_cdrom">
 			<diskarea name="cdrom">
-				<disk name="black hole assault (usa)" sha1="028afbfd19ac39d3573725fb0caa5c05e3288fa5"/>
+				<disk name="black hole assault (usa)" sha1=""/>
 			</diskarea>
 		</part>
 	</software>
@@ -510,7 +510,7 @@ See: http://rawdump.net/
 		<info name="ring_code" value="CDAC 082400 1"/>
 		<part name="cdrom" interface="scd_cdrom">
 			<diskarea name="cdrom">
-				<disk name="bouncers (usa)" sha1="278c615b7d3411f7cc760e0147988c64b848cfdf"/>
+				<disk name="bouncers (usa)" sha1=""/>
 			</diskarea>
 		</part>
 	</software>
@@ -582,7 +582,7 @@ See: http://rawdump.net/
 		<info name="ring_code" value="CDAC-068700 1"/>
 		<part name="cdrom" interface="scd_cdrom">
 			<diskarea name="cdrom">
-				<disk name="bram stoker's dracula (usa, rev. a)" sha1="ae70b55e7e614b3cb98e03e207103fec0bc31873"/>
+				<disk name="bram stoker's dracula (usa, rev. a)" sha1=""/>
 			</diskarea>
 		</part>
 	</software>
@@ -642,7 +642,7 @@ See: http://rawdump.net/
 		<info name="ring_code" value="CDAC-032500 5"/>
 		<part name="cdrom" interface="scd_cdrom">
 			<diskarea name="cdrom">
-				<disk name="chuck rock (usa)" sha1="409746c3e505b9d5dade6cf4b5b01165930ade86"/>
+				<disk name="chuck rock (usa)" sha1=""/>
 			</diskarea>
 		</part>
 	</software>
@@ -671,7 +671,7 @@ See: http://rawdump.net/
 		<info name="ring_code" value="SEGACD86006 R1D MFD BY JVC"/>
 		<part name="cdrom" interface="scd_cdrom">
 			<diskarea name="cdrom">
-				<disk name="chuck rock ii - son of chuck (usa)" sha1="b8445f6352fed1242b6dbf40807a0b1913a3cdad"/>
+				<disk name="chuck rock ii - son of chuck (usa)" sha1=""/>
 			</diskarea>
 		</part>
 	</software>
@@ -732,7 +732,7 @@ See: http://rawdump.net/
 		<info name="ring_code" value="SEGAT118025 R1F MFD BY JVC"/>
 		<part name="cdrom" interface="scd_cdrom">
 			<diskarea name="cdrom">
-				<disk name="compton's interactive encyclopedia v2.01r (usa)" sha1="14ee396c5d4d02059527d9894fbf1d4ae17e2f0a"/>
+				<disk name="compton's interactive encyclopedia v2.01r (usa)" sha1=""/>
 			</diskarea>
 		</part>
 	</software>
@@ -3454,7 +3454,7 @@ See: http://rawdump.net/
 		<info name="ring_code" value="SEGAT110015 R1J"/>
 		<part name="cdrom" interface="scd_cdrom">
 			<diskarea name="cdrom">
-				<disk name="the adventures of willy beamish (usa)" sha1="c1516b30726c0335ca732e9595eba12b9dd62deb"/>
+				<disk name="the adventures of willy beamish (usa)" sha1=""/>
 			</diskarea>
 		</part>
 	</software>
@@ -3484,7 +3484,7 @@ See: http://rawdump.net/
 		<info name="ring_code" value="CDAC-047100 2"/>
 		<part name="cdrom" interface="scd_cdrom">
 			<diskarea name="cdrom">
-				<disk name="the amazing spider-man vs. the kingpin (usa)" sha1="f0b2ef9e37fb5f3f10129e438a1a98d7c36f10fd"/>
+				<disk name="the amazing spider-man vs. the kingpin (usa)" sha1=""/>
 			</diskarea>
 		</part>
 	</software>
@@ -3842,7 +3842,7 @@ See: http://rawdump.net/
 		<info name="ring_code" value="T-163015-00"/>
 		<part name="cdrom" interface="scd_cdrom">
 			<diskarea name="cdrom">
-				<disk name="bari-arm (usa)" sha1="a89e004547338bbe021f9acde219748a4c948661"/>
+				<disk name="bari-arm (usa)" sha1=""/>
 			</diskarea>
 		</part>
 	</software>

--- a/hash/segacd.xml
+++ b/hash/segacd.xml
@@ -231,7 +231,7 @@ See: http://rawdump.net/
 		<info name="ring_code" value="CDAC-078200 2"/>
 		<part name="cdrom" interface="scd_cdrom">
 			<diskarea name="cdrom">
-				<disk name="3 ninjas kick back (usa)" sha1=""/>
+				<disk name="3 ninjas kick back (usa)" sha1="7dfca4e3bfad7b8e6f98b24651970409fd0d7d6f"/>
 			</diskarea>
 		</part>
 	</software>


### PR DESCRIPTION
This should have all the faulty hashes fixed. 

Secret of Monkey Island changed to the redump.org dump as well.