### PR TITLE
Fixed vector modification

### DIFF
--- a/src/devices/machine/z80scc.h
+++ b/src/devices/machine/z80scc.h
@@ -750,6 +750,7 @@ protected:
 	devcb_write_line    m_out_txdrqb_cb;
 
 	int m_int_state[6]; // interrupt state
+	int m_int_source[6]; // interrupt source
 
 	int m_variant;
 	UINT8 m_wr0_ptrbits;


### PR DESCRIPTION
reading the modified vector through channel B register 2 didn't work. There was also a theoretical possibility that the unmodified vector had bits set in the vector fields. Both should be fixed now