### PR TITLE
Use shared SDL2 on macOS

### DIFF
--- a/scripts/src/osd/sdl.lua
+++ b/scripts/src/osd/sdl.lua
@@ -265,6 +265,7 @@ if BASE_TARGETOS=="unix" then
 		if _OPTIONS["with-bundled-sdl2"]~=nil then
 			linkoptions {
 				"-framework AudioUnit",
+				"-framework AudioToolbox",
 				"-framework CoreAudio",
 				"-framework Carbon",
 				"-framework ForceFeedback",

--- a/scripts/src/osd/sdl.lua
+++ b/scripts/src/osd/sdl.lua
@@ -281,7 +281,7 @@ if BASE_TARGETOS=="unix" then
 					"SDL2.framework",
 				}
 			else
-				local str = backtick(sdlconfigcmd() .. " --libs --static | sed 's/-lSDLmain//'")
+				local str = backtick(sdlconfigcmd() .. " --libs")
 				addlibfromstring(str)
 				addoptionsfromstring(str)
 			end


### PR DESCRIPTION
I'm not sure if there was a reason behind static linking SDL2 on macOS, but it'd be nice to leave it shared for better integration with dependency managers, i.e. Homebrew.

By the way, stripping `-lSDLmain` is outdated that it's for SDL1; there's `SDL2main` for SDL2, but it gets no longer linked by default, hence no need to strip.

`AudioToolbox` framework is added just in case because it's the only missing framework we don't have from `pkg-config sdl2 --libs`.