### PR TITLE
Fixed a recently introduced bug in the 6x09 disassembler

### DIFF
--- a/src/devices/cpu/m6809/6x09dasm.cpp
+++ b/src/devices/cpu/m6809/6x09dasm.cpp
@@ -167,6 +167,11 @@ const opcodeinfo *m6x09_disassembler_base::fetch_opcode(const uint8_t *oprom, in
 			break;
 		}
 	};
+
+	// is this an HD6309 exclusive instruction, and we're not HD6309?  if so, reject it
+	if (op && (op->level() > m_level))
+		op = nullptr;
+
 	return op;
 }
 


### PR DESCRIPTION
Fixed a recently introduced bug in the 6x09 disassembler that could cause asserts when hitting what would be a legal 6309 instruction when disassembling non-6309 code