### PR TITLE
DART: Refactored FIFO:s using new template based fifo class

### DIFF
--- a/src/devices/machine/z80dart.cpp
+++ b/src/devices/machine/z80dart.cpp
@@ -31,13 +31,11 @@
 
 #include "z80dart.h"
 
-
-
 //**************************************************************************
 //  MACROS / CONSTANTS
 //**************************************************************************
 
-#define VERBOSE 2
+#define VERBOSE 0
 #define LOGPRINT(x) do { if (VERBOSE) logerror x; } while (0)
 #define LOG(x)      {} LOGPRINT(x)
 
@@ -505,7 +503,6 @@ z80dart_channel::z80dart_channel(const machine_config &mconfig, const char *tag,
 	: device_t(mconfig, Z80DART_CHANNEL, "Z80 DART channel", tag, owner, clock, "z80dart_channel", __FILE__),
 		device_serial_interface(mconfig, *this),
 		m_rx_error(0),
-	  //		m_rx_fifo(-1),
 		m_rx_clock(0),
 		m_rx_first(0),
 		m_rx_break(0),
@@ -525,13 +522,6 @@ z80dart_channel::z80dart_channel(const machine_config &mconfig, const char *tag,
 
 	for (auto & elem : m_wr)
 		elem = 0;
-#if 0
-	for (int i = 0; i < 3; i++)
-	{
-		m_rx_data_fifo[i] = 0;
-		m_rx_error_fifo[i] = 0;
-	}
-#endif
 }
 
 
@@ -547,15 +537,8 @@ void z80dart_channel::device_start()
 	// state saving
 	save_item(NAME(m_rr));
 	save_item(NAME(m_wr));
-#if 0
-	save_item(NAME(m_rx_data_fifo));
-	save_item(NAME(m_rx_error_fifo));
-	save_item(NAME(m_rx_fifo));
-	save_item(NAME(m_rx_error));
-#else
-	//	save_item(NAME(m_rx_data_fifot));
-	//	save_item(NAME(m_rx_error_fifot));
-#endif
+	//	save_item(NAME(m_rx_data_fifo));
+	//	save_item(NAME(m_rx_error_fifo));
 	save_item(NAME(m_rx_clock));
 	save_item(NAME(m_rx_first));
 	save_item(NAME(m_rx_break));
@@ -1009,22 +992,15 @@ uint8_t z80dart_channel::data_read()
 {
 	uint8_t data = 0;
 
-//	if (m_rx_fifo >= 0)
-	if (!m_rx_data_fifot.empty())
+	if (!m_rx_data_fifo.empty())
 	{
 		// load data from the FIFO
-//		data = m_rx_data_fifo[m_rx_fifo];
-		data = m_rx_data_fifot.dequeue();
+		data = m_rx_data_fifo.dequeue();
 
 		// load error status from the FIFO
-//		m_rr[1] = (m_rr[1] & ~(RR1_CRC_FRAMING_ERROR | RR1_RX_OVERRUN_ERROR | RR1_PARITY_ERROR)) | m_rx_error_fifo[m_rx_fifo];
-		m_rr[1] = (m_rr[1] & ~(RR1_CRC_FRAMING_ERROR | RR1_RX_OVERRUN_ERROR | RR1_PARITY_ERROR)) | m_rx_error_fifot.dequeue();
+		m_rr[1] = (m_rr[1] & ~(RR1_CRC_FRAMING_ERROR | RR1_RX_OVERRUN_ERROR | RR1_PARITY_ERROR)) | m_rx_error_fifo.dequeue();
 
-		// decrease FIFO pointer
-//		m_rx_fifo--;
-
-//		if (m_rx_fifo < 0)
-		if (m_rx_data_fifot.empty())
+		if (m_rx_data_fifo.empty())
 		{
 			// no more characters available in the FIFO
 			m_rr[0] &= ~ RR0_RX_CHAR_AVAILABLE;
@@ -1076,8 +1052,7 @@ void z80dart_channel::receive_data(uint8_t data)
 {
 	LOG(("Z80DART \"%s\" Channel %c : Receive Data Byte '%02x'\n", m_owner->tag(), 'A' + m_index, data));
 
-//	if (m_rx_fifo == 2)
-	if (m_rx_data_fifot.full())
+	if (m_rx_data_fifo.full())
 	{
 		// receive overrun error detected
 		m_rx_error |= RR1_RX_OVERRUN_ERROR;
@@ -1096,19 +1071,16 @@ void z80dart_channel::receive_data(uint8_t data)
 			m_uart->trigger_interrupt(m_index, INT_SPECIAL);
 			break;
 		}
-		m_rx_data_fifot.poke(data);
-		m_rx_error_fifot.poke(m_rx_error);
+		// overwrite last character/error with received character and error status into FIFO
+		m_rx_data_fifo.poke(data);
+		m_rx_error_fifo.poke(m_rx_error);
 	}
 	else
 	{
-//		m_rx_fifo++;
-		m_rx_data_fifot.enqueue(data);
-		m_rx_error_fifot.enqueue(m_rx_error);
+		// store received character and error status into FIFO
+		m_rx_data_fifo.enqueue(data);
+		m_rx_error_fifo.enqueue(m_rx_error);
 	}
-
-// store received character and error status into FIFO
-//	m_rx_data_fifo[m_rx_fifo] = data;
-//	m_rx_error_fifo[m_rx_fifo] = m_rx_error;
 
 	m_rr[0] |= RR0_RX_CHAR_AVAILABLE;
 

--- a/src/devices/machine/z80dart.h
+++ b/src/devices/machine/z80dart.h
@@ -241,61 +241,6 @@
 
 // ======================> z80dart_channel
 
-template <typename T, int N>
-class fifo
-{
-	T m_arr[N];
-	int m_wp;
-	int m_rp;
-	bool m_empty;
-public:
-	fifo()
-		: m_arr()
-		, m_wp(0)
-		, m_rp(0)
-		, m_empty(true)
-	{
-		static_assert(0U < N, "FIFO must have at least one element");
-	}
-
-	bool full() const { return !m_empty && (m_wp == m_rp); }
-	bool empty() const { return m_empty; }
-
-	void enqueue(T v)
-	{
-		if (m_empty || (m_wp != m_rp))
-		{
-			m_arr[m_wp] = v;
-			if (++m_wp == N) 
-				m_wp = 0;
-			m_empty = false;
-		}
-	}
-
-	T dequeue()
-	{
-		T result = -1;
-		if (!m_empty)
-		{
-			result = m_arr[m_rp];
-			if (++m_rp == N)
-				m_rp = 0;
-			m_empty = (m_rp == m_wp);
-		}
-		return result;
-	}
-
-	T const peek() const
-	{
-		return m_arr[m_rp];
-	}
-
-	void poke(T v)
-	{
-		m_arr[m_wp] = v;
-	}
-};
-
 class z80dart_device;
 
 class z80dart_channel : public device_t,
@@ -483,14 +428,9 @@ protected:
 	int get_tx_word_length();
 
 	// receiver state
-//#if 0
-	uint8_t m_rx_data_fifo[3];    // receive data FIFO
-	uint8_t m_rx_error_fifo[3];   // receive error FIFO
-	int m_rx_fifo;              // receive FIFO pointer
-//#else
-	fifo<uint8_t, 3> m_rx_data_fifot;
-	fifo<uint8_t, 3> m_rx_error_fifot;
-//#endif
+	util::fifo<uint8_t, 3> m_rx_data_fifo;
+	util::fifo<uint8_t, 3> m_rx_error_fifo;
+
 	uint8_t m_rx_error;           // current receive error
 	int m_rx_clock;             // receive clock pulse count
 	int m_rx_first;             // first character received

--- a/src/devices/machine/z80dart.h
+++ b/src/devices/machine/z80dart.h
@@ -241,6 +241,61 @@
 
 // ======================> z80dart_channel
 
+template <typename T, int N>
+class fifo
+{
+	T m_arr[N];
+	int m_wp;
+	int m_rp;
+	bool m_empty;
+public:
+	fifo()
+		: m_arr()
+		, m_wp(0)
+		, m_rp(0)
+		, m_empty(true)
+	{
+		static_assert(0U < N, "FIFO must have at least one element");
+	}
+
+	bool full() const { return !m_empty && (m_wp == m_rp); }
+	bool empty() const { return m_empty; }
+
+	void enqueue(T v)
+	{
+		if (m_empty || (m_wp != m_rp))
+		{
+			m_arr[m_wp] = v;
+			if (++m_wp == N) 
+				m_wp = 0;
+			m_empty = false;
+		}
+	}
+
+	T dequeue()
+	{
+		T result = -1;
+		if (!m_empty)
+		{
+			result = m_arr[m_rp];
+			if (++m_rp == N)
+				m_rp = 0;
+			m_empty = (m_rp == m_wp);
+		}
+		return result;
+	}
+
+	T const peek() const
+	{
+		return m_arr[m_rp];
+	}
+
+	void poke(T v)
+	{
+		m_arr[m_wp] = v;
+	}
+};
+
 class z80dart_device;
 
 class z80dart_channel : public device_t,
@@ -428,11 +483,15 @@ protected:
 	int get_tx_word_length();
 
 	// receiver state
+//#if 0
 	uint8_t m_rx_data_fifo[3];    // receive data FIFO
 	uint8_t m_rx_error_fifo[3];   // receive error FIFO
-	uint8_t m_rx_error;           // current receive error
 	int m_rx_fifo;              // receive FIFO pointer
-
+//#else
+	fifo<uint8_t, 3> m_rx_data_fifot;
+	fifo<uint8_t, 3> m_rx_error_fifot;
+//#endif
+	uint8_t m_rx_error;           // current receive error
 	int m_rx_clock;             // receive clock pulse count
 	int m_rx_first;             // first character received
 	int m_rx_break;             // receive break condition

--- a/src/lib/util/coretmpl.h
+++ b/src/lib/util/coretmpl.h
@@ -428,7 +428,7 @@ public:
 	fifo()
 		: std::array<T, N>()
 		, m_head(this->begin())
-		, m_tail(this->end())
+		, m_tail(this->begin())
 		, m_empty(true)
 	{
 		static_assert(0U < N, "FIFO must have at least one element");
@@ -513,8 +513,25 @@ public:
 		return result;
 	}
 
+	void poke(T &v)
+	{
+		*m_tail = v;
+	}
+
+	void poke(T &&v)
+	{
+		*m_tail = std::move(v);
+	}
+
 	T const &peek() const
 	{
+		return *m_head;
+	}
+
+	void clear() const
+	{
+		m_head = m_tail = this->begin();
+		m_empty = true;
 		return *m_head;
 	}
 


### PR DESCRIPTION
Don't merge this just yet, I want to switch to the new core template but couldn't get it to work so I implemented a simplified local template. I also feel, as an embedded C programmer by heart, that all the type abstraction in the core template might be quite heavy when using FIFO:s in emulated DMA transfers?

So let me know what you think and I go either way. Maybe we can have a bfifo for base types that can be represented in a one dimensional array, rather than de-referring pointers?

The code is regression tested for the pulsar, ampro and compis drivers at boot rom level. But I don't know how to do save_item on these fifo objects.