### PR TITLE
DEC Rainbow: apply fix for serial RX proposed by Shattered

### DIFF
--- a/src/mame/drivers/rainbow.cpp
+++ b/src/mame/drivers/rainbow.cpp
@@ -1274,12 +1274,12 @@ void rainbow_state::lower_8088_irq(int ref)
 // IRQ service for 7201 (commm / printer)
 void rainbow_state::update_mpsc_irq()
 {
-	if (m_mpsc_irq == 0)
-		lower_8088_irq(IRQ_COMM_PTR_INTR_L);
-	else
-		raise_8088_irq(IRQ_COMM_PTR_INTR_L);
+    if (m_mpsc_irq == 0) {
+        lower_8088_irq(IRQ_COMM_PTR_INTR_L);
+        m_mpsc->m1_r();  // interrupt acknowledge
+    } else
+        raise_8088_irq(IRQ_COMM_PTR_INTR_L);
 
-	m_mpsc->m1_r(); // interrupt acknowledge
 }
 
 WRITE_LINE_MEMBER(rainbow_state::mpsc_irq)


### PR DESCRIPTION
Small fix for serial RX proposed on page 38 of Requirements-thread at Bannisters. Terminal mode (key "T") still misbehaves afterwards (handshake or keyboard problem...?)  Note that you can change TX and RX baud rates as well as handshake parameters in SETUP mode ("F3", tried FDXA or FDXB mode, 8,N,1, XON/XOFF, 9600 bps with Putty connected on 127.0.0.1). Thanks to all who help to narrow this down!
For reference: http://forums.bannister.org/ubbthreads.php?ubb=showflat&Number=103331&page=38