### PR TITLE
Fixed building on ppc64le

### DIFF
--- a/makefile
+++ b/makefile
@@ -280,6 +280,9 @@ endif
 ifeq ($(firstword $(filter ppc64,$(UNAME))),ppc64)
 ARCHITECTURE := _x64
 endif
+ifeq ($(firstword $(filter ppc64le,$(UNAME))),ppc64le)
+ARCHITECTURE := _x64
+endif
 endif
 
 else
@@ -342,7 +345,11 @@ BIGENDIAN := 1
 endif
 # Linux
 ifneq (,$(findstring ppc,$(UNAME)))
+ifneq (,$(findstring ppc64le,$(UNAME)))
+BIGENDIAN := 0
+else
 BIGENDIAN := 1
+endif
 endif
 endif # BIGENDIAN
 

--- a/makefile
+++ b/makefile
@@ -283,6 +283,9 @@ endif
 ifeq ($(firstword $(filter ppc64le,$(UNAME))),ppc64le)
 ARCHITECTURE := _x64
 endif
+ifeq ($(firstword $(filter s390x,$(UNAME))),s390x)
+ARCHITECTURE := _x64
+endif
 endif
 
 else
@@ -328,6 +331,12 @@ ifndef NOASM
 endif
 endif
 
+ifeq ($(findstring s390x,$(UNAME)),s390x)
+ifndef NOASM
+	NOASM := 1
+endif
+endif
+
 # Emscripten
 ifeq ($(findstring emcc,$(CC)),emcc)
 TARGETOS := asmjs
@@ -350,6 +359,9 @@ BIGENDIAN := 0
 else
 BIGENDIAN := 1
 endif
+endif
+ifneq (,$(findstring s390x,$(UNAME)))
+BIGENDIAN := 1
 endif
 endif # BIGENDIAN
 


### PR DESCRIPTION
Fedora have recently enabled ppc64 and ppc64le on their rawhide builders. The change requested here fixes building on ppc64le.