### PR TITLE
Fix for hp9845_tape module in imgtool

### DIFF
--- a/src/tools/imgtool/modules/hp9845_tape.cpp
+++ b/src/tools/imgtool/modules/hp9845_tape.cpp
@@ -1086,6 +1086,14 @@ static void hp9845_tape_close(imgtool::image &image)
 	global_free(&tape_image);
 }
 
+void hp9845_tape_get_info(const imgtool_class *imgclass, uint32_t state, union imgtoolinfo *info);
+
+static imgtoolerr_t hp9845_tape_list_partitions(imgtool::image &image, std::vector<imgtool::partition_info> &partitions)
+{
+	partitions.emplace_back(hp9845_tape_get_info , 0 , TOT_SECTORS);
+	return IMGTOOLERR_SUCCESS;
+}
+
 static imgtoolerr_t hp9845_tape_begin_enum (imgtool::directory &enumeration, const char *path)
 {
 	dir_state_t *ds = (dir_state_t*)enumeration.extra_bytes();
@@ -1348,6 +1356,10 @@ void hp9845_tape_get_info(const imgtool_class *imgclass, uint32_t state, union i
 
 	case IMGTOOLINFO_PTR_WRITEFILE_OPTGUIDE:
 		info->writefile_optguide = &hp9845_write_optguide;
+		break;
+
+	case IMGTOOLINFO_PTR_LIST_PARTITIONS:
+		info->list_partitions = &hp9845_tape_list_partitions;
 		break;
 
 	case IMGTOOLINFO_STR_WRITEFILE_OPTSPEC:


### PR DESCRIPTION
Hi,

I've just pushed a correction to my imgtool module for HP9845 tape images.
It stopped working after a recent set of commits by N.Woods but I realized it only now.
When I investigated the problem I noticed that other modules may have the same bug:
unless the function LIST_PARTITIONS is defined every command will fail with the "command unimplemented" error. Apparently, this function is now needed even for image formats that have a single partition.
Thanks.
--F.Ulivi
