### PR TITLE
add the missing rom to the smssgame set [Astroblaster]

### DIFF
--- a/src/mame/drivers/sms_bootleg.cpp
+++ b/src/mame/drivers/sms_bootleg.cpp
@@ -6,11 +6,6 @@
 this is an SMS multi-game bootleg with 32 games
 
 
-the dump is incomplete; there is a chip near a position marked on the board as ROM4 with the following markings
-"SG11004A
-79ST0086END
-9045"
-it should be a 512KB MASK rom containing 11 of the games.
 
 there are also empty k9/k10/k11/k12 positions, but they were clearly never used.
 
@@ -283,12 +278,10 @@ DRIVER_INIT_MEMBER(smsbootleg_state,sms_supergame)
 
 ROM_START( smssgame )
 	ROM_REGION( 0x200000, "maincpu", 0 )
-	ROM_LOAD( "Rom1.bin", 0x00000, 0x10000, CRC(0e1f258e) SHA1(9240dc0d01e3061c0c8807c07c0a1d033ebe9116) ) // yes, this rom is smaller (menu rom)
+	ROM_LOAD( "rom1.bin", 0x00000, 0x10000, CRC(0e1f258e) SHA1(9240dc0d01e3061c0c8807c07c0a1d033ebe9116) ) // yes, this rom is smaller (menu rom)
 
 	ROM_LOAD( "rom2.bin",0x020000, 0x20000, CRC(c1478323) SHA1(27b524a234f072e81ef41fb89a5fff5617e9b951) ) // Buk Doo Sun
 	ROM_LOAD( "rom3.bin",0x040000, 0x20000, CRC(96c8705d) SHA1(ba4f4af0cfdad1d63a08201ed186c79aea062b95) ) // ? Kung Fu game (Hello Kang Si?)
-	// there is something in the position marked ROM4.
-
 	// k12 unpopulated
 	// k11 unpopulated
 	// k10 unpopulated
@@ -302,7 +295,8 @@ ROM_START( smssgame )
 	ROM_LOAD( "K2.bin",  0x120000, 0x20000, CRC(a12439f4) SHA1(e957d4fe275e982bedef28af8cc2957da27dc512) ) // Final Bubble Bobble (1/2)
 	ROM_LOAD( "K1.bin",  0x140000, 0x20000, CRC(dadffecd) SHA1(68ebb968539049a9e193da5200856b9f956f7e02) ) // Final Bubble Bobble (2/2)
 
-	ROM_LOAD( "rom4.bin",0x180000, 0x80000, NO_DUMP ) // missing
+	// this mask rom appears to be taken straight from an SMS multi-game cart, bank 0 of it is even a menu just for the games in this ROM! same style, so presumably the same developer (Seo Jin 1990 copyright)
+	ROM_LOAD( "SG11004A 79ST0086END 9045.rom4",0x180000, 0x080000, CRC(cb6cbe40) SHA1(f7735f3357bb89ad2918c28eafeaf9808532f599) )
 
 	// there seems to be some kind of MCU for the timer?
 ROM_END


### PR DESCRIPTION
note, this is actually quite interesting, this is a 512KB MASK rom, hence why it got missed the first time around.

it actually appears to have been pulled straight from a home Sega Master System mulit-game cartridge and used on the arcade PCB.  The rom contains another copy of the games menu in the first bank, except this copy of the menu has no timer/credit support and only references games in this specific rom.  It is completely ignored by the arcade hardware which uses the game data part of the rom only, never banking this copy of the menu in.

as this almost certainly came straight from a bootleg cartridge, this specific rom could also be added to the softlist with a custom mapper for the banking.