### PR TITLE
Changed the cop410 disassembler to use 'std::ostream &' internally

### DIFF
--- a/src/devices/cpu/cop400/cop410ds.cpp
+++ b/src/devices/cpu/cop400/cop410ds.cpp
@@ -10,7 +10,7 @@
 
 #include "emu.h"
 
-CPU_DISASSEMBLE( cop410 )
+static offs_t internal_disasm_cop410(cpu_device *device, std::ostream &stream, offs_t pc, const uint8_t *oprom, const uint8_t *opram, int options)
 {
 	uint8_t opcode = oprom[0];
 	uint8_t next_opcode = oprom[1];
@@ -23,130 +23,130 @@ CPU_DISASSEMBLE( cop410 )
 		if ((pc & 0x3E0) >= 0x80 && (pc & 0x3E0) < 0x100) //JP pages 2,3
 		{
 			address = (uint16_t)((pc & 0x380) | (opcode & 0x7F));
-			sprintf(buffer, "JP %x", address);
+			util::stream_format(stream, "JP %x", address);
 		}
 		else
 		{
 			if ((opcode & 0xC0) == 0xC0) //JP other pages
 			{
 				address = (uint16_t)((pc & 0x3C0) | (opcode & 0x3F));
-				sprintf(buffer, "JP %x", address);
+				util::stream_format(stream, "JP %x", address);
 			}
 			else                    //JSRP
 			{
 				address = (uint16_t)(0x80 | (opcode & 0x3F));
-				sprintf(buffer, "JSRP %x", address);
+				util::stream_format(stream, "JSRP %x", address);
 				flags = DASMFLAG_STEP_OVER;
 			}
 		}
 	}
 	else if (opcode >= 0x08 && opcode <= 0x0F)
 	{
-		sprintf(buffer, "LBI 0,%u", ((opcode & 0xF) + 1) & 0xF);
+		util::stream_format(stream, "LBI 0,%u", ((opcode & 0xF) + 1) & 0xF);
 	}
 	else if (opcode >= 0x18 && opcode <= 0x1F)
 	{
-		sprintf(buffer, "LBI 1,%u", ((opcode & 0xF) + 1) & 0xF);
+		util::stream_format(stream, "LBI 1,%u", ((opcode & 0xF) + 1) & 0xF);
 	}
 	else if (opcode >= 0x28 && opcode <= 0x2F)
 	{
-		sprintf(buffer, "LBI 2,%u", ((opcode & 0xF) + 1) & 0xF);
+		util::stream_format(stream, "LBI 2,%u", ((opcode & 0xF) + 1) & 0xF);
 	}
 	else if (opcode >= 0x38 && opcode <= 0x3F)
 	{
-		sprintf(buffer, "LBI 3,%u", ((opcode & 0xF) + 1) & 0xF);
+		util::stream_format(stream, "LBI 3,%u", ((opcode & 0xF) + 1) & 0xF);
 	}
 	else if (opcode >= 0x51 && opcode <= 0x5F)
 	{
-		sprintf(buffer, "AISC %u", opcode & 0xF);
+		util::stream_format(stream, "AISC %u", opcode & 0xF);
 	}
 	else if (opcode >= 0x60 && opcode <= 0x61)
 	{
 		address = ((opcode & 0x01) << 8) | next_opcode;
-		sprintf(buffer, "JMP %x", address);
+		util::stream_format(stream, "JMP %x", address);
 		bytes = 2;
 	}
 	else if (opcode >= 0x68 && opcode <= 0x69)
 	{
 		address = ((opcode & 0x01) << 8) | next_opcode;
-		sprintf(buffer, "JSR %x", address);
+		util::stream_format(stream, "JSR %x", address);
 		flags = DASMFLAG_STEP_OVER;
 		bytes = 2;
 	}
 	else if (opcode >= 0x70 && opcode <= 0x7F)
 	{
-		sprintf(buffer, "STII %u", opcode & 0xF);
+		util::stream_format(stream, "STII %u", opcode & 0xF);
 	}
 	else
 	{
 		switch (opcode)
 		{
 		case 0:
-			sprintf(buffer, "CLRA");
+			util::stream_format(stream, "CLRA");
 			break;
 
 		case 1:
-			sprintf(buffer, "SKMBZ 0");
+			util::stream_format(stream, "SKMBZ 0");
 			break;
 
 		case 2:
-			sprintf(buffer, "XOR");
+			util::stream_format(stream, "XOR");
 			break;
 
 		case 3:
-			sprintf(buffer, "SKMBZ 2");
+			util::stream_format(stream, "SKMBZ 2");
 			break;
 
 		case 4:
-			sprintf(buffer, "XIS 0");
+			util::stream_format(stream, "XIS 0");
 			break;
 
 		case 5:
-			sprintf(buffer, "LD 0");
+			util::stream_format(stream, "LD 0");
 			break;
 
 		case 6:
-			sprintf(buffer, "X 0");
+			util::stream_format(stream, "X 0");
 			break;
 
 		case 7:
-			sprintf(buffer, "XDS 0");
+			util::stream_format(stream, "XDS 0");
 			break;
 
 		case 0x11:
-			sprintf(buffer, "SKMBZ 1");
+			util::stream_format(stream, "SKMBZ 1");
 			break;
 
 		case 0x13:
-			sprintf(buffer, "SKMBZ 3");
+			util::stream_format(stream, "SKMBZ 3");
 			break;
 
 		case 0x14:
-			sprintf(buffer, "XIS 1");
+			util::stream_format(stream, "XIS 1");
 			break;
 
 		case 0x15:
-			sprintf(buffer, "LD 1");
+			util::stream_format(stream, "LD 1");
 			break;
 
 		case 0x16:
-			sprintf(buffer, "X 1");
+			util::stream_format(stream, "X 1");
 			break;
 
 		case 0x17:
-			sprintf(buffer, "XDS 1");
+			util::stream_format(stream, "XDS 1");
 			break;
 
 		case 0x20:
-			sprintf(buffer, "SKC");
+			util::stream_format(stream, "SKC");
 			break;
 
 		case 0x21:
-			sprintf(buffer, "SKE");
+			util::stream_format(stream, "SKE");
 			break;
 
 		case 0x22:
-			sprintf(buffer, "SC");
+			util::stream_format(stream, "SC");
 			break;
 
 		case 0x23:
@@ -155,40 +155,40 @@ CPU_DISASSEMBLE( cop410 )
 			if (next_opcode >= 0x80 && next_opcode <= 0xbf)
 			{
 				address = (uint16_t)(next_opcode & 0x3F);
-				sprintf(buffer, "XAD %x,%x", ((address & 0x30) >> 4),address & 0x0F);
+				util::stream_format(stream, "XAD %x,%x", ((address & 0x30) >> 4),address & 0x0F);
 			}
 			else
 			{
-				sprintf(buffer, "Invalid");
+				util::stream_format(stream, "Invalid");
 			}
 			break;
 
 		case 0x24:
-			sprintf(buffer, "XIS 2");
+			util::stream_format(stream, "XIS 2");
 			break;
 
 		case 0x25:
-			sprintf(buffer, "LD 2");
+			util::stream_format(stream, "LD 2");
 			break;
 
 		case 0x26:
-			sprintf(buffer, "X 2");
+			util::stream_format(stream, "X 2");
 			break;
 
 		case 0x27:
-			sprintf(buffer, "XDS 2");
+			util::stream_format(stream, "XDS 2");
 			break;
 
 		case 0x30:
-			sprintf(buffer, "ASC");
+			util::stream_format(stream, "ASC");
 			break;
 
 		case 0x31:
-			sprintf(buffer, "ADD");
+			util::stream_format(stream, "ADD");
 			break;
 
 		case 0x32:
-			sprintf(buffer, "RC");
+			util::stream_format(stream, "RC");
 			break;
 
 		case 0x33:
@@ -196,154 +196,165 @@ CPU_DISASSEMBLE( cop410 )
 
 			if (next_opcode >= 0x60 && next_opcode <= 0x6F)
 			{
-				sprintf(buffer, "LEI %x", next_opcode & 0xF);
+				util::stream_format(stream, "LEI %x", next_opcode & 0xF);
 			}
 			else
 			{
 				switch (next_opcode)
 				{
 				case 0x01:
-					sprintf(buffer, "SKGBZ 0");
+					util::stream_format(stream, "SKGBZ 0");
 					break;
 
 				case 0x03:
-					sprintf(buffer, "SKGBZ 2");
+					util::stream_format(stream, "SKGBZ 2");
 					break;
 
 				case 0x11:
-					sprintf(buffer, "SKGBZ 1");
+					util::stream_format(stream, "SKGBZ 1");
 					break;
 
 				case 0x13:
-					sprintf(buffer, "SKGBZ 3");
+					util::stream_format(stream, "SKGBZ 3");
 					break;
 
 				case 0x21:
-					sprintf(buffer, "SKGZ");
+					util::stream_format(stream, "SKGZ");
 					break;
 
 				case 0x2A:
-					sprintf(buffer, "ING");
+					util::stream_format(stream, "ING");
 					break;
 
 				case 0x2E:
-					sprintf(buffer, "INL");
+					util::stream_format(stream, "INL");
 					break;
 
 				case 0x38:
-					sprintf(buffer, "HALT");
+					util::stream_format(stream, "HALT");
 					break;
 
 				case 0x3A:
-					sprintf(buffer, "OMG");
+					util::stream_format(stream, "OMG");
 					break;
 
 				case 0x3C:
-					sprintf(buffer, "CAMQ");
+					util::stream_format(stream, "CAMQ");
 					break;
 
 				case 0x3E:
-					sprintf(buffer, "OBD");
+					util::stream_format(stream, "OBD");
 					break;
 
 				default:
-					sprintf(buffer, "Invalid");
+					util::stream_format(stream, "Invalid");
 					break;
 				}
 				break;
 			}
+			break;
 
 		case 0x34:
-			sprintf(buffer, "XIS 3");
+			util::stream_format(stream, "XIS 3");
 			break;
 
 		case 0x35:
-			sprintf(buffer, "LD 3");
+			util::stream_format(stream, "LD 3");
 			break;
 
 		case 0x36:
-			sprintf(buffer, "X 3");
+			util::stream_format(stream, "X 3");
 			break;
 
 		case 0x37:
-			sprintf(buffer, "XDS 3");
+			util::stream_format(stream, "XDS 3");
 			break;
 
 		case 0x40:
-			sprintf(buffer, "COMP");
+			util::stream_format(stream, "COMP");
 			break;
 
 		case 0x42:
-			sprintf(buffer, "RMB 2");
+			util::stream_format(stream, "RMB 2");
 			break;
 
 		case 0x43:
-			sprintf(buffer, "RMB 3");
+			util::stream_format(stream, "RMB 3");
 			break;
 
 		case 0x44:
-			sprintf(buffer, "NOP");
+			util::stream_format(stream, "NOP");
 			break;
 
 		case 0x45:
-			sprintf(buffer, "RMB 1");
+			util::stream_format(stream, "RMB 1");
 			break;
 
 		case 0x46:
-			sprintf(buffer, "SMB 2");
+			util::stream_format(stream, "SMB 2");
 			break;
 
 		case 0x47:
-			sprintf(buffer, "SMB 1");
+			util::stream_format(stream, "SMB 1");
 			break;
 
 		case 0x48:
-			sprintf(buffer, "RET");
+			util::stream_format(stream, "RET");
 			flags = DASMFLAG_STEP_OUT;
 			break;
 
 		case 0x49:
-			sprintf(buffer, "RETSK");
+			util::stream_format(stream, "RETSK");
 			flags = DASMFLAG_STEP_OUT;
 			break;
 
 		case 0x4B:
-			sprintf(buffer, "SMB 3");
+			util::stream_format(stream, "SMB 3");
 			break;
 
 		case 0x4C:
-			sprintf(buffer, "RMB 0");
+			util::stream_format(stream, "RMB 0");
 			break;
 
 		case 0x4D:
-			sprintf(buffer, "SMB 0");
+			util::stream_format(stream, "SMB 0");
 			break;
 
 		case 0x4E:
-			sprintf(buffer, "CBA");
+			util::stream_format(stream, "CBA");
 			break;
 
 		case 0x4F:
-			sprintf(buffer, "XAS");
+			util::stream_format(stream, "XAS");
 			break;
 
 		case 0x50:
-			sprintf(buffer, "CAB");
+			util::stream_format(stream, "CAB");
 			break;
 
 		case 0xBF:
-			sprintf(buffer, "LQID");
+			util::stream_format(stream, "LQID");
 			break;
 
 		case 0xFF:
-			sprintf(buffer, "JID");
+			util::stream_format(stream, "JID");
 			break;
 
 		default:
-			sprintf(buffer, "Invalid");
+			util::stream_format(stream, "Invalid");
 			break;
 		}
 	}
 
 	return bytes | flags | DASMFLAG_SUPPORTED;
+}
+
+
+CPU_DISASSEMBLE(cop410)
+{
+	std::ostringstream stream;
+	offs_t result = internal_disasm_cop410(device, stream, pc, oprom, opram, options);
+	std::string stream_str = stream.str();
+	strcpy(buffer, stream_str.c_str());
+	return result;
 }


### PR DESCRIPTION
This one actually had a change in behavior; I had to insert a 'break' somewhere.  Judging from the other cop4x0 disassemblers, this seems to be a bug in the existing disassembler