### PR TITLE
ioport_list construction overhaul (nw)

### DIFF
--- a/src/emu/device.cpp
+++ b/src/emu/device.cpp
@@ -551,6 +551,23 @@ machine_config_constructor device_t::device_mconfig_additions() const
 
 
 //-------------------------------------------------
+//  append_ports - append the given device's input
+//  ports to the current list
+//-------------------------------------------------
+
+void device_t::device_append_ports(ioport_list &portlist)
+{
+	// no constructor, no list
+	ioport_constructor constructor = device_input_ports();
+	if (constructor == nullptr)
+		return;
+
+	// detokenize into the list
+	(*constructor)(*this, portlist);
+}
+
+
+//-------------------------------------------------
 //  input_ports - return a pointer to the implicit
 //  input ports description for this device
 //-------------------------------------------------

--- a/src/emu/device.h
+++ b/src/emu/device.h
@@ -215,7 +215,7 @@ public:
 	const std::vector<rom_entry> &rom_region_vector() const;
 	const rom_entry *rom_region() const { return rom_region_vector().data(); }
 	machine_config_constructor machine_config_additions() const { return device_mconfig_additions(); }
-	ioport_constructor input_ports() const { return device_input_ports(); }
+	void append_ports(ioport_list &portlist) { device_append_ports(portlist); }
 	u8 default_bios() const { return m_default_bios; }
 	u8 system_bios() const { return m_system_bios; }
 	std::string default_bios_tag() const { return m_default_bios_tag; }
@@ -316,6 +316,7 @@ protected:
 	// device-level overrides
 	virtual const tiny_rom_entry *device_rom_region() const;
 	virtual machine_config_constructor device_mconfig_additions() const;
+	virtual void device_append_ports(ioport_list &portlist);
 	virtual ioport_constructor device_input_ports() const;
 	virtual void device_config_complete();
 	virtual void device_validity_check(validity_checker &valid) const ATTR_COLD;

--- a/src/emu/ioport.h
+++ b/src/emu/ioport.h
@@ -663,9 +663,10 @@ class ioport_manager;
 class natural_keyboard;
 class xml_data_node;
 class analog_field;
+class device_iterator;
 
 // constructor function pointer
-typedef void(*ioport_constructor)(device_t &owner, ioport_list &portlist, std::string &errorbuf);
+typedef void(*ioport_constructor)(device_t &owner, ioport_list &portlist);
 
 // I/O port callback function delegates
 typedef device_delegate<ioport_value (ioport_field &, void *)> ioport_field_read_delegate;
@@ -1115,7 +1116,7 @@ public:
 	void set_user_settings(const user_settings &settings);
 
 private:
-	void expand_diplocation(const char *location, std::string &errorbuf);
+	void expand_diplocation(const char *location);
 
 	// internal state
 	ioport_field *              m_next;             // pointer to next field in sequence
@@ -1197,7 +1198,7 @@ class ioport_list : public std::map<std::string, std::unique_ptr<ioport_port>>
 public:
 	ioport_list() { }
 
-	void append(device_t &device, std::string &errorbuf);
+	void append(const device_iterator &iter);
 };
 
 
@@ -1232,13 +1233,13 @@ public:
 
 	// other operations
 	ioport_field *field(ioport_value mask) const;
-	void collapse_fields(std::string &errorbuf);
+	void collapse_fields();
 	void frame_update();
 	void init_live_state();
 	void update_defvalue(bool flush_defaults);
 
 private:
-	void insert_field(ioport_field &newfield, ioport_value &disallowedbits, std::string &errorbuf);
+	void insert_field(ioport_field &newfield, ioport_value &disallowedbits);
 
 	// internal state
 	ioport_port *               m_next;         // pointer to next port
@@ -1502,7 +1503,7 @@ class ioport_configurer
 {
 public:
 	// construction/destruction
-	ioport_configurer(device_t &owner, ioport_list &portlist, std::string &errorbuf);
+	ioport_configurer(device_t &owner, ioport_list &portlist);
 
 	// static helpers
 	static const char *string_from_token(const char *string);
@@ -1537,7 +1538,7 @@ public:
 	ioport_configurer& field_set_analog_invert() { m_curfield->m_flags |= ioport_field::ANALOG_FLAG_INVERT; return *this; }
 	ioport_configurer& field_set_dynamic_read(ioport_field_read_delegate delegate, void *param = nullptr) { m_curfield->m_read = delegate; m_curfield->m_read_param = param; return *this; }
 	ioport_configurer& field_set_dynamic_write(ioport_field_write_delegate delegate, void *param = nullptr) { m_curfield->m_write = delegate; m_curfield->m_write_param = param; return *this; }
-	ioport_configurer& field_set_diplocation(const char *location) { m_curfield->expand_diplocation(location, m_errorbuf); return *this; }
+	ioport_configurer& field_set_diplocation(const char *location) { m_curfield->expand_diplocation(location); return *this; }
 
 	// setting helpers
 	ioport_configurer& setting_alloc(ioport_value value, const char *name);
@@ -1550,7 +1551,6 @@ private:
 	// internal state
 	device_t &          m_owner;
 	ioport_list &       m_portlist;
-	std::string &       m_errorbuf;
 
 	ioport_port *       m_curport;
 	ioport_field *      m_curfield;
@@ -1594,20 +1594,20 @@ private:
 
 // start of table
 #define INPUT_PORTS_START(_name) \
-ATTR_COLD void INPUT_PORTS_NAME(_name)(device_t &owner, ioport_list &portlist, std::string &errorbuf) \
+ATTR_COLD void INPUT_PORTS_NAME(_name)(device_t &owner, ioport_list &portlist) \
 { \
-	ioport_configurer configurer(owner, portlist, errorbuf);
+	ioport_configurer configurer(owner, portlist);
 // end of table
 #define INPUT_PORTS_END \
 }
 
 // aliasing
 #define INPUT_PORTS_EXTERN(_name) \
-	extern void INPUT_PORTS_NAME(_name)(device_t &owner, ioport_list &portlist, std::string &errorbuf)
+	extern void INPUT_PORTS_NAME(_name)(device_t &owner, ioport_list &portlist)
 
 // including
 #define PORT_INCLUDE(_name) \
-	INPUT_PORTS_NAME(_name)(owner, portlist, errorbuf);
+	INPUT_PORTS_NAME(_name)(owner, portlist);
 // start of a new input port (with included tag)
 #define PORT_START(_tag) \
 	configurer.port_alloc(_tag);

--- a/src/emu/validity.h
+++ b/src/emu/validity.h
@@ -86,7 +86,6 @@ private:
 
 	// output helpers
 	void build_output_prefix(std::string &str);
-	void output_via_delegate(osd_output_channel channel, const char *format, ...) ATTR_PRINTF(3,4);
 	void output_indented_errors(std::string &text, const char *header);
 
 	// random number generation

--- a/src/frontend/mame/info.cpp
+++ b/src/frontend/mame/info.cpp
@@ -248,10 +248,8 @@ void info_xml_creator::output_one()
 	// allocate input ports
 	machine_config &config = m_drivlist.config();
 	ioport_list portlist;
-	std::string errors;
 	device_iterator iter(config.root_device());
-	for (device_t &device : iter)
-		portlist.append(device, errors);
+	portlist.append(iter);
 
 	// renumber player numbers for controller ports
 	int player_offset = 0;
@@ -360,11 +358,11 @@ void info_xml_creator::output_one_device(device_t &device, const char *devtag)
 	sound_interface_iterator snditer(device);
 	if (snditer.first() != nullptr)
 		has_speaker = true;
+
 	// generate input list
 	ioport_list portlist;
-	std::string errors;
-	for (device_t &dev : device_iterator(device))
-		portlist.append(dev, errors);
+	portlist.append(device_iterator(device));
+
 	// check if the device adds player inputs (other than dsw and configs) to the system
 	for (auto &port : portlist)
 		for (ioport_field &field : port.second->fields())

--- a/src/frontend/mame/ui/devopt.cpp
+++ b/src/frontend/mame/ui/devopt.cpp
@@ -168,14 +168,13 @@ void menu_device_config::populate(float &customtop, float &custombottom)
 
 	int input = 0, input_mj = 0, input_hana = 0, input_gamble = 0, input_analog = 0, input_adjust = 0;
 	int input_keypad = 0, input_keyboard = 0, dips = 0, confs = 0;
-	std::string errors;
 	std::ostringstream dips_opt, confs_opt;
 	ioport_list portlist;
-	for (device_t &iptdev : device_iterator(*dev))
-		portlist.append(iptdev, errors);
+	portlist.append(device_iterator(*dev));
 
 	// check if the device adds inputs to the system
 	for (auto &port : portlist)
+	{
 		for (ioport_field &field : port.second->fields())
 		{
 			if (field.type() >= IPT_MAHJONG_FIRST && field.type() < IPT_MAHJONG_LAST)
@@ -221,6 +220,7 @@ void menu_device_config::populate(float &customtop, float &custombottom)
 				}
 			}
 		}
+	}
 
 	if (dips)
 		str << "* Dispwitch settings:\n" << dips_opt.str();

--- a/src/mame/drivers/tranz330.cpp
+++ b/src/mame/drivers/tranz330.cpp
@@ -49,9 +49,9 @@ static void construct_address_map_tranz330_io(address_map &map)
 									  write8_delegate(&msm6242_device::write, "msm6242_device::write", RTC_TAG, (msm6242_device *)nullptr));
 }
 
-static void construct_ioport_tranz330(device_t &owner, ioport_list &portlist, std::string &errorbuf)
+void tranz330_state::device_append_ports(ioport_list &portlist)
 {
-	ioport_configurer configurer(owner, portlist, errorbuf);
+	ioport_configurer configurer(*this, portlist);
 
 	configurer.port_alloc("COL.0");
 	configurer.field_alloc(IPT_BUTTON1, IP_ACTIVE_LOW, 0x01).field_add_code(SEQ_TYPE_STANDARD, KEYCODE_1).field_set_name("1 QZ.");
@@ -196,4 +196,4 @@ ROM_END
 
 
 //    YEAR  NAME      PARENT  COMPAT  MACHINE   INPUT     CLASS             INIT    COMPANY     FULLNAME        FLAGS
-COMP( 1985, tranz330, 0,      0,      tranz330, tranz330, driver_device,    0,     "VeriFone",  "Tranz 330",    MACHINE_CLICKABLE_ARTWORK )
+COMP( 1985, tranz330, 0,      0,      tranz330, 0,        driver_device,    0,     "VeriFone",  "Tranz 330",    MACHINE_CLICKABLE_ARTWORK )

--- a/src/mame/includes/tranz330.h
+++ b/src/mame/includes/tranz330.h
@@ -46,6 +46,7 @@ public:
 
 	virtual void machine_start() override;
 	virtual void machine_reset() override;
+	virtual void device_append_ports(ioport_list &portlist) override;
 
 	DECLARE_WRITE_LINE_MEMBER( syncb_w );
 	DECLARE_WRITE_LINE_MEMBER(clock_w);

--- a/src/osd/osdcore.cpp
+++ b/src/osd/osdcore.cpp
@@ -194,3 +194,19 @@ void osd_sleep(osd_ticks_t duration)
 {
 	std::this_thread::sleep_for(std::chrono::high_resolution_clock::duration(duration));
 }
+
+//-------------------------------------------------
+//  output_via_delegate - helper to output a
+//  message via a varargs string, so the argptr
+//  can be forwarded onto the given delegate
+//-------------------------------------------------
+
+void osd_output::output_via_delegate(osd_output_channel channel, const char *format, ...)
+{
+	va_list argptr;
+
+	// call through to the delegate with the proper parameters
+	va_start(argptr, format);
+	chain_output(channel, format, argptr);
+	va_end(argptr);
+}

--- a/src/osd/osdcore.h
+++ b/src/osd/osdcore.h
@@ -865,13 +865,15 @@ public:
 
 	static void push(osd_output *delegate);
 	static void pop(osd_output *delegate);
-protected:
 
+protected:
+	void output_via_delegate(osd_output_channel channel, const char *format, ...) ATTR_PRINTF(3,4);
 	void chain_output(osd_output_channel channel, const char *msg, va_list args) const
 	{
 		if (m_chain != nullptr)
 			m_chain->output_callback(channel, msg, args);
 	}
+
 private:
 	osd_output *m_chain;
 };


### PR DESCRIPTION
- Use osd_printf_error to report all I/O port errors rather than pass a string buffer around everywhere
- Only do one collapse_fields pass over the portlist for all devices
- New overridable device_t::device_append_ports method to replace old-fashioned static constructors (as implemented in tranz330)

Move validity_checker::output_via_delegate to osd_output superclass (nw)