### PR TITLE
fccpu30: WIP New board variants added

### DIFF
--- a/src/devices/machine/fga002.cpp
+++ b/src/devices/machine/fga002.cpp
@@ -33,14 +33,15 @@
 */
 #define VERBOSE 0
 
-#define LOGPRINT(x)  do { if (VERBOSE) logerror x; } while (0)
-#define LOG(x)
-#define LOGR(x)
-#define LOGSETUP(x)
-#define LOGINT(x)   LOGPRINT(x)
-#define LOGVEC(x)
-#define LOGLVL(x)
-#define LOGIACK(x) LOGPRINT(x)
+#define LOGPRINT(x) { do { if (VERBOSE) logerror x; } while (0); }
+#define LOG(x)		{} LOGPRINT(x)
+#define LOGR(x)		{} LOGPRINT(x)
+#define LOGSETUP(x)	{} LOGPRINT(x)
+#define LOGINT(x)	{} LOGPRINT(x)
+#define LOGVEC(x)	{} LOGPRINT(x)
+#define LOGLVL(x)	{} LOGPRINT(x)
+#define LOGIACK(x)	{} LOGPRINT(x)
+
 #if VERBOSE == 2
 #define logerror printf
 #endif

--- a/src/devices/machine/fga002.h
+++ b/src/devices/machine/fga002.h
@@ -6,10 +6,6 @@
 #include "emu.h"
 #include "cpu/m68000/m68000.h" // The FGA002 is designed for the 68K interrupt PL0-PL2 signalling, however used on Sparc and x86 boards too
 
-#ifndef VERBOSE
-#define LOG(x)
-#endif
-
 #define MCFG_FGA002_ADD(_tag, _clock)   MCFG_DEVICE_ADD(_tag, FGA002, _clock)
 
 // LOCAL IRQ callbacks

--- a/src/devices/machine/scnxx562.cpp
+++ b/src/devices/machine/scnxx562.cpp
@@ -87,13 +87,13 @@ DONE (x) (p=partly)         NMOS         CMOS
 
 #define VERBOSE 0
 
-#define LOGPRINT(x)  do { if (VERBOSE) logerror x; } while (0)
-#define LOG(x) do {} while (0)
-#define LOGR(x)
-#define LOGTX(x)
-#define LOGRX(x)
-#define LOGSETUP(x)
-#define LOGINT(x) LOGPRINT(x)
+#define LOGPRINT(x) { do { if (VERBOSE) logerror x; } while (0); }
+#define LOG(x)		{} 
+#define LOGR(x)		{} 
+#define LOGTX(x)   	{} 
+#define LOGRX(x)	{} 
+#define LOGSETUP(x)	{} LOGPRINT(x)
+#define LOGINT(x)	{} 
 
 #if VERBOSE > 1
 #define logerror printf
@@ -824,11 +824,11 @@ void duscc_channel::device_timer(emu_timer &timer, device_timer_id id, int param
 			m_uart->m_out_trxcb_cb(m_trxc);
 		break;
 	default:
-		LOGR(("Unhandled Timer ID %d\n", id));
+		LOGR(("Unhandled Timer ID passed to device_serial_interface%d\n", id));
+		device_serial_interface::device_timer(timer, id, param, ptr);
 		break;
 	}
 	//  LOG(("%s %d\n", FUNCNAME, id));
-	device_serial_interface::device_timer(timer, id, param, ptr);
 }
 
 /*  The DUSCC 16 bit Timer
@@ -894,14 +894,12 @@ uint8_t duscc_channel::do_dusccreg_ctprh_r()
 	uint8_t ret = ((m_ctpr >> 8) & 0xff );
 	LOG(("%s(%02x)\n", FUNCNAME, ret));
 
-	//  return m_ctprh;
 	return ret;
 }
 
 void duscc_channel::do_dusccreg_ctprh_w(uint8_t data)
 {
-	LOG(("%s(%02x) -  not supported yet\n", FUNCNAME, data));
-	//  m_ctprh = data;
+	LOG(("%s(%02x)\n", FUNCNAME, data));
 	m_ctpr &= ~0x0000ff00;
 	m_ctpr |= ((data << 8) & 0x0000ff00);
 	return;
@@ -916,14 +914,12 @@ uint8_t duscc_channel::do_dusccreg_ctprl_r()
 {
 	uint8_t ret = (m_ctpr & 0xff);
 	LOG(("%s(%02x)\n", FUNCNAME, ret));
-	//  return m_ctprl;
 	return ret;
 }
 
 void duscc_channel::do_dusccreg_ctprl_w(uint8_t data)
 {
-	LOG(("%s(%02x) -  not supported yet\n", FUNCNAME, data));
-	//  m_ctprl = data;
+	LOG(("%s(%02x)\n", FUNCNAME, data));
 	m_ctpr &= ~0x000000ff;
 	m_ctpr |= (data & 0x000000ff);
 	return;
@@ -939,7 +935,6 @@ uint8_t duscc_channel::do_dusccreg_cth_r()
 {
 	uint8_t ret = ((m_ct >> 8) & 0xff );
 	LOG(("%s(%02x)\n", FUNCNAME, ret));
-
 	return ret;
 }
 
@@ -953,7 +948,6 @@ uint8_t duscc_channel::do_dusccreg_ctl_r()
 {
 	uint8_t ret = (m_ct & 0xff);
 	LOG(("%s(%02x)\n", FUNCNAME, ret));
-	//  return m_ctl;
 	return ret;
 }
 
@@ -1872,9 +1866,13 @@ void duscc_channel::do_dusccreg_omr_w(uint8_t data)
 	m_omr = data;
 	LOG(("- Tx Residual Character Length is "));
 	if ((m_omr & REG_OMR_TXRCL_MASK) == REG_OMR_TXRCL_8BIT)
+	{
 		LOG(("determined by TPR[1:0], the Transmitter Parameter Register\n"));
+	}
 	else
+	{
 		LOG(("%u bits\n", (((m_omr & REG_OMR_TXRCL_MASK) >> 5) & 0x07) + 1));
+	}
 	LOG(("- TxRDY activated by %s\n", m_omr & REG_OMR_TXRDY_ACTIVATED ? "FIFO empty" : "FIFO not full"));
 	LOG(("- RxRDY activated by %s\n", m_omr & REG_OMR_RXRDY_ACTIVATED ? "FIFO full"  : "FIFO not empty"));
 	LOG(("- GP02, if configured as output, is: %u\n", m_omr & REG_OMR_GP02 ? 0 : 1));
@@ -2279,7 +2277,7 @@ void duscc_channel::write(uint8_t data, offs_t &offset)
 {
 	int reg = (offset | m_a7) & ~0x20; // Add extended rgisters and remove the channel B bit from offset
 
-	LOGSETUP((" *  %c Reg %02x <- %02x  \n", 'A' + m_index, reg, data));
+	LOGSETUP((" *  %s%c Reg %02x <- %02x  \n", m_owner->tag(), 'A' + m_index, reg, data));
 	LOG(("\"%s\" %s: %c : Register write '%02x' -> [%02x]", m_owner->tag(), FUNCNAME, 'A' + m_index, data, reg ));
 	switch (reg)
 	{

--- a/src/mame/drivers/fccpu30.cpp
+++ b/src/mame/drivers/fccpu30.cpp
@@ -197,14 +197,14 @@
 #include "machine/clock.h"
 //#include "machine/timekpr.h"
 
-#define VERBOSE 0
+#define VERBOSE 2
 
-#define LOGPRINT(x)  do { if (VERBOSE) logerror x; } while (0)
-#define LOG(x) LOGPRINT(x)
-#define LOGINIT(x)
-#define LOGR(x)
-#define LOGSETUP(x)
-#define LOGINT(x) LOGPRINT(x)
+#define LOGPRINT(x)  { do { if (VERBOSE) logerror x; } while (0); }
+#define LOG(x) 		{}
+#define LOGINIT(x)	{} LOGPRINT(x)
+#define LOGR(x)		{}
+#define LOGSETUP(x)	{}
+#define LOGINT(x)	{}
 #if VERBOSE >= 2
 #define logerror printf
 #endif
@@ -318,7 +318,7 @@ INPUT_PORTS_END
 /* Start it up */
 void cpu30_state::machine_start ()
 {
-	LOG(("--->%s\n", FUNCNAME));
+	LOGINIT(("%s\n", FUNCNAME));
 
 	save_pointer (NAME (m_sysrom), sizeof(m_sysrom));
 	save_pointer (NAME (m_sysram), sizeof(m_sysram));
@@ -326,31 +326,29 @@ void cpu30_state::machine_start ()
 	/* setup ram */
 	m_maincpu->space(AS_PROGRAM).install_ram(0x08, m_ram->size() - 1, m_ram->pointer());
 
-	/* setup board ID */
-	m_board_id = 0x50;
-
 	/* Setup pointer to bootvector in ROM for bootvector handler bootvect_r */
 	m_sysrom = (uint32_t*)(memregion ("roms")->base () + 0x800000);
 }
 
 void cpu30_state::machine_reset ()
 {
-	LOG(("--->%s\n", FUNCNAME));
+	LOGINIT(("%s\n", FUNCNAME));
 
 	/* Reset pointer to bootvector in ROM for bootvector handler bootvect_r */
 	if (m_sysrom == &m_sysram[0]) /* Condition needed because memory map is not setup first time */
 		m_sysrom = (uint32_t*)(memregion ("roms")->base () + 0x800000);
 }
 
-DRIVER_INIT_MEMBER( cpu30_state, cpu30x )      { LOGINIT(("%s\n", FUNCNAME)); }
-DRIVER_INIT_MEMBER( cpu30_state, cpu30xa )     { LOGINIT(("%s\n", FUNCNAME)); }
-DRIVER_INIT_MEMBER( cpu30_state, cpu30za )     { LOGINIT(("%s\n", FUNCNAME)); }
-DRIVER_INIT_MEMBER( cpu30_state, cpu30zbe )    { LOGINIT(("%s\n", FUNCNAME)); }
-DRIVER_INIT_MEMBER( cpu30_state, cpu30be8 )    { LOGINIT(("%s\n", FUNCNAME)); }
-DRIVER_INIT_MEMBER( cpu30_state, cpu30be16 )   { LOGINIT(("%s\n", FUNCNAME)); }
-DRIVER_INIT_MEMBER( cpu30_state, cpu30lite4 )  { LOGINIT(("%s\n", FUNCNAME)); }
-DRIVER_INIT_MEMBER( cpu30_state, cpu30lite8 )  { LOGINIT(("%s\n", FUNCNAME)); }
-DRIVER_INIT_MEMBER( cpu30_state, cpu33 )  	   { LOGINIT(("%s\n", FUNCNAME)); }
+/* 																				setup board ID */
+DRIVER_INIT_MEMBER( cpu30_state, cpu30x )      { LOGINIT(("%s\n", FUNCNAME)); m_board_id = 0x50; }
+DRIVER_INIT_MEMBER( cpu30_state, cpu30xa )     { LOGINIT(("%s\n", FUNCNAME)); m_board_id = 0x50; }
+DRIVER_INIT_MEMBER( cpu30_state, cpu30za )     { LOGINIT(("%s\n", FUNCNAME)); m_board_id = 0x50; }
+DRIVER_INIT_MEMBER( cpu30_state, cpu30zbe )    { LOGINIT(("%s\n", FUNCNAME)); m_board_id = 0x50; }
+DRIVER_INIT_MEMBER( cpu30_state, cpu30be8 )    { LOGINIT(("%s\n", FUNCNAME)); m_board_id = 0x50; }
+DRIVER_INIT_MEMBER( cpu30_state, cpu30be16 )   { LOGINIT(("%s\n", FUNCNAME)); m_board_id = 0x50; }
+DRIVER_INIT_MEMBER( cpu30_state, cpu30lite4 )  { LOGINIT(("%s\n", FUNCNAME)); m_board_id = 0x50; }
+DRIVER_INIT_MEMBER( cpu30_state, cpu30lite8 )  { LOGINIT(("%s\n", FUNCNAME)); m_board_id = 0x50; }
+DRIVER_INIT_MEMBER( cpu30_state, cpu33 )  	   { LOGINIT(("%s\n", FUNCNAME)); m_board_id = 0x68; } // 0x60 skips FGA prompt
 
 /* Boot vector handler, the PCB hardwires the first 8 bytes from 0xff800000 to 0x0 at reset*/
 READ32_MEMBER (cpu30_state::bootvect_r){

--- a/src/mame/drivers/fccpu30.cpp
+++ b/src/mame/drivers/fccpu30.cpp
@@ -6,7 +6,7 @@
  *
  *  21/05/2016
  *
- * Thanks to Al Kossow his site http://www.bitsavers.org/ I got the information
+ * Thanks to Al Kossow and his site http://www.bitsavers.org/ I got the information
  * required to start the work with this driver.
  *
  * The driver is currently starting up and the Boot ROM asks for input do start FGA-002
@@ -188,6 +188,7 @@
 
 #include "emu.h"
 #include "cpu/m68000/m68000.h"
+#include "machine/ram.h" // For variants that only differs in amount of RAM
 #include "machine/scnxx562.h"
 #include "machine/68230pit.h"
 #include "machine/fga002.h"
@@ -199,7 +200,8 @@
 #define VERBOSE 0
 
 #define LOGPRINT(x)  do { if (VERBOSE) logerror x; } while (0)
-#define LOG(x)
+#define LOG(x) LOGPRINT(x)
+#define LOGINIT(x)
 #define LOGR(x)
 #define LOGSETUP(x)
 #define LOGINT(x) LOGPRINT(x)
@@ -215,16 +217,18 @@
 
 #define DUSCC_CLOCK XTAL_14_7456MHz /* Verified */
 
-class fccpu30_state : public driver_device
+class cpu30_state : public driver_device
 {
 public:
-fccpu30_state(const machine_config &mconfig, device_type type, const char *tag)
+cpu30_state(const machine_config &mconfig, device_type type, const char *tag)
 		: driver_device (mconfig, type, tag)
 		, m_maincpu (*this, "maincpu")
+		, m_ram(*this, RAM_TAG)
 		, m_dusccterm(*this, "duscc")
 		, m_pit1 (*this, "pit1")
 		, m_pit2 (*this, "pit2")
 		, m_fga002 (*this, "fga002")
+		, m_board_id(0x50)
 	{
 	}
 
@@ -257,10 +261,21 @@ fccpu30_state(const machine_config &mconfig, device_type type, const char *tag)
 	//DECLARE_WRITE16_MEMBER (vme_a16_w);
 	virtual void machine_start () override;
 	virtual void machine_reset () override;
+	DECLARE_DRIVER_INIT(cpu30x);
+	DECLARE_DRIVER_INIT(cpu30xa);
+	DECLARE_DRIVER_INIT(cpu30za);
+	DECLARE_DRIVER_INIT(cpu30zbe);
+	DECLARE_DRIVER_INIT(cpu30be8);
+	DECLARE_DRIVER_INIT(cpu30be16);
+	DECLARE_DRIVER_INIT(cpu30lite4);
+	DECLARE_DRIVER_INIT(cpu30lite8);
+	DECLARE_DRIVER_INIT(cpu33);
 protected:
 
 private:
 	required_device<cpu_device> m_maincpu;
+	required_device<ram_device> m_ram;
+
 	required_device<duscc68562_device> m_dusccterm;
 
 	required_device<pit68230_device> m_pit1;
@@ -274,13 +289,15 @@ private:
 	// Pointer to System ROMs needed by bootvect_r and masking RAM buffer for post reset accesses
 	uint32_t  *m_sysrom;
 	uint32_t  m_sysram[2];
+
+	uint8_t m_board_id;
 };
 
-static ADDRESS_MAP_START (fccpu30_mem, AS_PROGRAM, 32, fccpu30_state)
+static ADDRESS_MAP_START (cpu30_mem, AS_PROGRAM, 32, cpu30_state)
 	ADDRESS_MAP_UNMAP_HIGH
 	AM_RANGE (0x00000000, 0x00000007) AM_ROM AM_READ  (bootvect_r)   /* ROM mirror just during reset */
 	AM_RANGE (0x00000000, 0x00000007) AM_RAM AM_WRITE (bootvect_w)   /* After first write we act as RAM */
-	AM_RANGE (0x00000008, 0x003fffff) AM_RAM /* 4 Mb RAM */
+//	AM_RANGE (0x00000008, 0x003fffff) AM_RAM /* RAM  installed in machine start */
 	AM_RANGE (0xff000000, 0xff7fffff) AM_ROM AM_REGION("roms", 0x000000)
 	AM_RANGE (0xff802000, 0xff8021ff) AM_DEVREADWRITE8("duscc", duscc68562_device, read, write, 0xffffffff) /* Port 1&2 - Dual serial port DUSCC   */
 	AM_RANGE (0xff802200, 0xff8023ff) AM_DEVREADWRITE8("duscc2", duscc68562_device, read, write, 0xffffffff) /* Port 3&4 - Dual serial port DUSCC   */
@@ -295,22 +312,28 @@ static ADDRESS_MAP_START (fccpu30_mem, AS_PROGRAM, 32, fccpu30_state)
 ADDRESS_MAP_END
 
 /* Input ports */
-static INPUT_PORTS_START (fccpu30)
+static INPUT_PORTS_START (cpu30)
 INPUT_PORTS_END
 
 /* Start it up */
-void fccpu30_state::machine_start ()
+void cpu30_state::machine_start ()
 {
 	LOG(("--->%s\n", FUNCNAME));
 
 	save_pointer (NAME (m_sysrom), sizeof(m_sysrom));
 	save_pointer (NAME (m_sysram), sizeof(m_sysram));
 
+	/* setup ram */
+	m_maincpu->space(AS_PROGRAM).install_ram(0x08, m_ram->size() - 1, m_ram->pointer());
+
+	/* setup board ID */
+	m_board_id = 0x50;
+
 	/* Setup pointer to bootvector in ROM for bootvector handler bootvect_r */
 	m_sysrom = (uint32_t*)(memregion ("roms")->base () + 0x800000);
 }
 
-void fccpu30_state::machine_reset ()
+void cpu30_state::machine_reset ()
 {
 	LOG(("--->%s\n", FUNCNAME));
 
@@ -319,12 +342,22 @@ void fccpu30_state::machine_reset ()
 		m_sysrom = (uint32_t*)(memregion ("roms")->base () + 0x800000);
 }
 
+DRIVER_INIT_MEMBER( cpu30_state, cpu30x )      { LOGINIT(("%s\n", FUNCNAME)); }
+DRIVER_INIT_MEMBER( cpu30_state, cpu30xa )     { LOGINIT(("%s\n", FUNCNAME)); }
+DRIVER_INIT_MEMBER( cpu30_state, cpu30za )     { LOGINIT(("%s\n", FUNCNAME)); }
+DRIVER_INIT_MEMBER( cpu30_state, cpu30zbe )    { LOGINIT(("%s\n", FUNCNAME)); }
+DRIVER_INIT_MEMBER( cpu30_state, cpu30be8 )    { LOGINIT(("%s\n", FUNCNAME)); }
+DRIVER_INIT_MEMBER( cpu30_state, cpu30be16 )   { LOGINIT(("%s\n", FUNCNAME)); }
+DRIVER_INIT_MEMBER( cpu30_state, cpu30lite4 )  { LOGINIT(("%s\n", FUNCNAME)); }
+DRIVER_INIT_MEMBER( cpu30_state, cpu30lite8 )  { LOGINIT(("%s\n", FUNCNAME)); }
+DRIVER_INIT_MEMBER( cpu30_state, cpu33 )  	   { LOGINIT(("%s\n", FUNCNAME)); }
+
 /* Boot vector handler, the PCB hardwires the first 8 bytes from 0xff800000 to 0x0 at reset*/
-READ32_MEMBER (fccpu30_state::bootvect_r){
+READ32_MEMBER (cpu30_state::bootvect_r){
 	return m_sysrom[offset];
 }
 
-WRITE32_MEMBER (fccpu30_state::bootvect_w){
+WRITE32_MEMBER (cpu30_state::bootvect_w){
 	m_sysram[offset % sizeof(m_sysram)] &= ~mem_mask;
 	m_sysram[offset % sizeof(m_sysram)] |= (data & mem_mask);
 	m_sysrom = &m_sysram[0]; // redirect all upcomming accesses to masking RAM until reset.
@@ -384,99 +417,139 @@ WRITE32_MEMBER (fccpu30_state::bootvect_w){
  *
  * "To start VMEPROM, the rotary switches must both be set to 'F':" Hmm...
  */
-READ8_MEMBER (fccpu30_state::rotary_rd){
+READ8_MEMBER (cpu30_state::rotary_rd){
 	LOG(("%s\n", FUNCNAME));
 	return 0xff; // TODO: make this configurable from commandline or artwork
 }
 
 // PIT#1 Port B TODO: implement floppy and dma control
-READ8_MEMBER (fccpu30_state::flop_dmac_r){
+READ8_MEMBER (cpu30_state::flop_dmac_r){
 	LOG(("%s\n", FUNCNAME));
 	return 0xff;
 }
 
-WRITE8_MEMBER (fccpu30_state::flop_dmac_w){
+WRITE8_MEMBER (cpu30_state::flop_dmac_w){
 	LOG(("%s(%02x)\n", FUNCNAME, data));
 }
 
 // PIT#1 Port C TODO: implement timer+port interrupts and 68882 sense
 // TODO: Connect PC0, PC1, PC4 and PC7 to B5 and/or P2 connector
-READ8_MEMBER (fccpu30_state::pit1c_r){
+READ8_MEMBER (cpu30_state::pit1c_r){
 	LOG(("%s\n", FUNCNAME));
 	return 0xff;
 }
 
-WRITE8_MEMBER (fccpu30_state::pit1c_w){
+WRITE8_MEMBER (cpu30_state::pit1c_w){
 	LOG(("%s(%02x)\n", FUNCNAME, data));
 }
 
 // PIT#2 Port A TODO: Connect to B5 and /or P2 connector
-READ8_MEMBER (fccpu30_state::pit2a_r){
+READ8_MEMBER (cpu30_state::pit2a_r){
 	LOG(("%s\n", FUNCNAME));
 	logerror("Unsupported user i/o on PIT2 port A detected\n");
 	return 0xff;
 }
 
-WRITE8_MEMBER (fccpu30_state::pit2a_w){
+WRITE8_MEMBER (cpu30_state::pit2a_w){
 	LOG(("%s(%02x)\n", FUNCNAME, data));
 	logerror("Unsupported user i/o on PIT2 port A detected\n");
 }
 
 /*
  * PI/T #2 Factory settings
- * B0-B2 Shared Memory Size - From these lines, the on-board Shared RAM capacity can be read in by software.
- * 0 0 0 32 Mb
- * 0 0 1 16 Mb
- * 0 1 0  8 Mb
- * 0 1 1  4 Mb
+ * B2 B1 B0 Shared Memory Size - From these lines, the on-board Shared RAM capacity can be read in by software.
+ *  0  0  0 32 Mb
+ *  0  0  1 16 Mb
+ *  0  1  0  8 Mb
+ *  0  1  1  4 Mb
  * 1 x x  Reserved
  * B3-B7 Board ID(s) -  From these lines, the CPU board identification number can be read in by
  * 0 1 0 1 0 CPU-30 R4  software. Every CPU board has a unique number. Different versions of
  * (fill in more)       one CPU board (i.e. different speeds, capacity of memory, or modules)
  *                      contain the same identification number. In the case of the CPU-30 R4, the
- *                      number is ten ("10" decimal or 0A16 hexadecimal "01010" binary).
+ *                      number is 0x0a
+ *
+ * The speed of the board is meassured by looping some instructions and meassure the time it takes with a timer
+ * Currently this doesn't work so the wrong speed is displayed on the screen. To fix this timing needs to be more exact.
+ * Speed meassure subroutine is at address 0xffe033c4 in the FGA-002 firmware with CRC (faa38972) (for example)
  */
-READ8_MEMBER (fccpu30_state::board_mem_id_rd){
+READ8_MEMBER (cpu30_state::board_mem_id_rd)
+{
+	int sz;
 	LOG(("%s\n", FUNCNAME));
+	switch (m_ram->size())
+	{
+	case (1024 * 1024 * 32): sz = 0; break;
+	case (1024 * 1024 * 16): sz = 1; break;
+	case (1024 * 1024 * 8):	 sz = 2; break;
+	case (1024 * 1024 * 4):	 sz = 3; break;
+	case (1024 * 1024 * 2):	 sz = 4; break;
+	case (1024 * 1024 * 1):	 sz = 5; break;
+	case (1024 * 512  * 1):	 sz = 6; break;
+	case (1024 * 256  * 1):	 sz = 7; break;
+    default:
+		logerror("No supported RAM size, telling VMEPROM 4Mb\n");
+		sz = 4;
+	}
 	//  return 0x6A; // CPU-30 R4 with 4Mb of shared RAM. TODO: make this configurable from commandline or artwork
 	//  return 0x57; // blankt 53 56
 	//      return 0x36; // CPU-26 1Mb 36 MHz
 	//      return 0x35; // CPU-26 1Mb 36 MHz
-			return 0x36; // CPU-26 1Mb 36 MHz
+	// calculate response from m_ram (default 4M or command line -ramsize) Bit 2 is reserved and always 0 on CPU-30
+	// return 0x6B;// CPU-33, 4Mb, 36MHz p4
+	// return 0x6B;// CPU-33, 4Mb, 36MHz p4
+	// return 0x99;// CPU-26, 4Mb, 36MHz p4
+	// return 0x33;// CPU-26, 4Mb, 36MHz p4
+	// return 0x37;// CPU-26, 4Mb, 36MHz p4
+	// return 0x35;// CPU-26, 1Mb, 36MHz p4
+	// return 0x36;// CPU-26, 1Mb, 36MHz p4
+	// return 0x55;// CPU-30, 1Mb, 36MHz
+	// return 0x56;// CPU-30, 1Mb, 36MHz
+	// return 0x53;// CPU-30, 4Mb, 36MHz
+	// return 0x57;// CPU-30, 4Mb, 36MHz
+	//	return 0x48 + sz;// none
+	//	return 0x38 + sz;// none
+	//	return 0x28 + sz;// none
+	//	return 0x18 + sz;// CPU-23 p1
+	//	return 0x10 + sz;// CPU-22 p4
+	//	return 0x20 + sz;// p1: Wait until hard disk is up to speed
+	//	printf("SIZE:%02x\n", sz);
+	LOG(("- Board ID:%02x Size:%02x\n", m_board_id, sz));
+	return m_board_id + sz;
 }
 
 // PIT#2 Port C TODO: implement timer interrupt, DMA i/o, memory control and Hardware ID
-READ8_MEMBER (fccpu30_state::pit2c_r){
+READ8_MEMBER (cpu30_state::pit2c_r){
 	LOG(("%s\n", FUNCNAME));
-	return 0xff;
+	return 0xfe;
 }
 
-WRITE8_MEMBER (fccpu30_state::pit2c_w){
+WRITE8_MEMBER (cpu30_state::pit2c_w){
 	LOG(("%s(%02x)\n", FUNCNAME, data));
 }
 
 #if 0
 /* Dummy VME access methods until the VME bus device is ready for use */
-READ16_MEMBER (fccpu30_state::vme_a24_r){
+READ16_MEMBER (cpu30_state::vme_a24_r){
 	LOG (logerror ("vme_a24_r\n"));
 	return (uint16_t) 0;
 }
 
-WRITE16_MEMBER (fccpu30_state::vme_a24_w){
+WRITE16_MEMBER (cpu30_state::vme_a24_w){
 	LOG (logerror ("vme_a24_w\n"));
 }
 
-READ16_MEMBER (fccpu30_state::vme_a16_r){
+READ16_MEMBER (cpu30_state::vme_a16_r){
 	LOG (logerror ("vme_16_r\n"));
 	return (uint16_t) 0;
 }
 
-WRITE16_MEMBER (fccpu30_state::vme_a16_w){
+WRITE16_MEMBER (cpu30_state::vme_a16_w){
 	LOG (logerror ("vme_a16_w\n"));
 }
 #endif
 
-WRITE_LINE_MEMBER(fccpu30_state::fga_irq_callback)
+WRITE_LINE_MEMBER(cpu30_state::fga_irq_callback)
 {
 	LOGINT(("%s(%02x)\n", FUNCNAME, state));
 
@@ -486,7 +559,7 @@ WRITE_LINE_MEMBER(fccpu30_state::fga_irq_callback)
 	update_irq_to_maincpu();
 }
 
-void fccpu30_state::update_irq_to_maincpu()
+void cpu30_state::update_irq_to_maincpu()
 {
 	LOGINT(("%s()\n", FUNCNAME));
 	LOGINT((" - fga_irq_level: %02x\n", fga_irq_level));
@@ -507,10 +580,10 @@ void fccpu30_state::update_irq_to_maincpu()
 /*
  * Machine configuration
  */
-static MACHINE_CONFIG_START (fccpu30, fccpu30_state)
+static MACHINE_CONFIG_START (cpu30, cpu30_state)
 	/* basic machine hardware */
 	MCFG_CPU_ADD ("maincpu", M68030, XTAL_25MHz)
-	MCFG_CPU_PROGRAM_MAP (fccpu30_mem)
+	MCFG_CPU_PROGRAM_MAP (cpu30_mem)
 	MCFG_CPU_IRQ_ACKNOWLEDGE_DEVICE("fga002", fga002_device, iack)
 	MCFG_NVRAM_ADD_0FILL("nvram")
 
@@ -521,12 +594,12 @@ static MACHINE_CONFIG_START (fccpu30, fccpu30_state)
 	   In order to use more than just one terminal MAME supports serial socket servers to which it is possible to
 	   connect a telnet terminal to. The general syntax to open a socket server from the command prompts is:
 
-	   mame  fccpu30 -window -rs232p4 null_modem -bitbngr socket.127.0.0.1:1001
+	   mame  cpu30 -window -rs232p4 null_modem -bitbngr socket.127.0.0.1:1001
 
 	   At the opening screen, before the board starts to execute code, start up the telnet client and give 127.0.0.1:1001 as host
 	   It is also possible to enumerate more than one terminal server in order to have several terminal session attached.
 
-	   mame  fccpu30 -window -rs232p4 null_modem -bitbngr1 socket.127.0.0.1:1001 -rs232p1 null_modem -bitbngr2 socket.127.0.0.1:1002
+	   mame  cpu30 -window -rs232p4 null_modem -bitbngr1 socket.127.0.0.1:1001 -rs232p1 null_modem -bitbngr2 socket.127.0.0.1:1002
 
 	   Now just start up the telnet clients with 127.0.0.1:1001 and 127.0.0.1:1002 as hosts and you have control of input for each port.
 	*/
@@ -578,48 +651,165 @@ static MACHINE_CONFIG_START (fccpu30, fccpu30_state)
 
 	/* PIT Parallel Interface and Timer device, assumed strapped for on board clock */
 	MCFG_DEVICE_ADD ("pit1", PIT68230, XTAL_16MHz / 2) // The PIT clock is not verified on schema but reversed from behaviour
-	MCFG_PIT68230_PA_INPUT_CB(READ8(fccpu30_state, rotary_rd))
-	MCFG_PIT68230_PB_INPUT_CB(READ8(fccpu30_state, flop_dmac_r))
-	MCFG_PIT68230_PB_OUTPUT_CB(WRITE8(fccpu30_state, flop_dmac_w))
-	MCFG_PIT68230_PC_INPUT_CB(READ8(fccpu30_state, pit1c_r))
-	MCFG_PIT68230_PC_OUTPUT_CB(WRITE8(fccpu30_state, pit1c_w))
+	MCFG_PIT68230_PA_INPUT_CB(READ8(cpu30_state, rotary_rd))
+	MCFG_PIT68230_PB_INPUT_CB(READ8(cpu30_state, flop_dmac_r))
+	MCFG_PIT68230_PB_OUTPUT_CB(WRITE8(cpu30_state, flop_dmac_w))
+	MCFG_PIT68230_PC_INPUT_CB(READ8(cpu30_state, pit1c_r))
+	MCFG_PIT68230_PC_OUTPUT_CB(WRITE8(cpu30_state, pit1c_w))
 // MCFG_PIT68230_OUT_INT_CB(DEVWRITELINE("fga002", fga002_device, lirq2_w)) // Interrupts not yet supported by 68230
 
 	MCFG_DEVICE_ADD ("pit2", PIT68230, XTAL_16MHz / 2) // Th PIT clock is not verified on schema but reversed from behaviour
-	MCFG_PIT68230_PB_INPUT_CB(READ8(fccpu30_state, board_mem_id_rd))
-	MCFG_PIT68230_PA_INPUT_CB(READ8(fccpu30_state, pit2a_r))
-	MCFG_PIT68230_PA_OUTPUT_CB(WRITE8(fccpu30_state, pit2a_w))
-	MCFG_PIT68230_PC_INPUT_CB(READ8(fccpu30_state, pit2c_r))
-	MCFG_PIT68230_PC_OUTPUT_CB(WRITE8(fccpu30_state, pit2c_w))
+	MCFG_PIT68230_PB_INPUT_CB(READ8(cpu30_state, board_mem_id_rd))
+	MCFG_PIT68230_PA_INPUT_CB(READ8(cpu30_state, pit2a_r))
+	MCFG_PIT68230_PA_OUTPUT_CB(WRITE8(cpu30_state, pit2a_w))
+	MCFG_PIT68230_PC_INPUT_CB(READ8(cpu30_state, pit2c_r))
+	MCFG_PIT68230_PC_OUTPUT_CB(WRITE8(cpu30_state, pit2c_w))
 // MCFG_PIT68230_OUT_INT_CB(DEVWRITELINE("fga002", fga002_device, lirq3_w)) // Interrupts not yet supported by 68230
 
 	/* FGA-002, Force Gate Array */
 	MCFG_FGA002_ADD("fga002", 0)
-	MCFG_FGA002_OUT_INT_CB(WRITELINE(fccpu30_state, fga_irq_callback))
+	MCFG_FGA002_OUT_INT_CB(WRITELINE(cpu30_state, fga_irq_callback))
 	MCFG_FGA002_OUT_LIACK4_CB(DEVREAD8("duscc",  duscc_device, iack))
 	MCFG_FGA002_OUT_LIACK5_CB(DEVREAD8("duscc2",  duscc_device, iack))
+
+	// dual ported ram
+	MCFG_RAM_ADD(RAM_TAG)
+	MCFG_RAM_DEFAULT_SIZE("4M")
+	MCFG_RAM_EXTRA_OPTIONS("8M, 16M, 32M")
+MACHINE_CONFIG_END
+
+/* SYS68K/CPU-30X Part No.1 01300: 16.7 MHz 68030 based CPU board with 68882 FPCP, DMAC, 1 Mbyte Dual Ported RAM capacity and VMEPROM. */
+static MACHINE_CONFIG_DERIVED( cpu30x, cpu30 )
+	MCFG_DEVICE_MODIFY("maincpu")
+	MCFG_DEVICE_CLOCK(XTAL_16_777216MHz) /* 16.7 MHz  from description, crystal needs verification */
+
+//	MCFG_DEVICE_REMOVE("")
+
+	// dual ported ram
+	MCFG_RAM_MODIFY(RAM_TAG)
+	MCFG_RAM_DEFAULT_SIZE("1M")
+	MCFG_RAM_EXTRA_OPTIONS("1M, 2M, 4M")
+MACHINE_CONFIG_END
+
+/* SYS68K/CPU-30XA Part No.1 01301: 20.0 MHz 68030 based CPU board with 68882 FPCP, DMAC, 1 Mbyte Dual Ported RAM capacity and VMEPROM. Documentation included.*/
+static MACHINE_CONFIG_DERIVED( cpu30xa, cpu30x )
+	MCFG_DEVICE_MODIFY("maincpu")
+	MCFG_DEVICE_CLOCK(XTAL_20MHz) /* 20.0 MHz  from description, crystal needs verification */
+MACHINE_CONFIG_END
+
+/* SYS68K/CPU-30ZA Part No.1 01302: 20.0 MHz 68030 based CPU board with 68882 FPCP, DMAC, 4 Mbyte Dual Ported RAM capacity and VMEPROM. Documentation included.*/
+static MACHINE_CONFIG_DERIVED( cpu30za, cpu30xa )
+	MCFG_DEVICE_MODIFY("maincpu")
+	MCFG_DEVICE_CLOCK(XTAL_20MHz) /* 20.0 MHz  from description, crystal needs verification */
+
+	// dual ported ram
+	MCFG_RAM_MODIFY(RAM_TAG)
+	MCFG_RAM_DEFAULT_SIZE("4M")
+	MCFG_RAM_EXTRA_OPTIONS("1M, 2M, 4M")
+MACHINE_CONFIG_END
+
+/* SYS68K/CPU-30ZBE 68030/68882 CPU, 25 MHz,  4 Mbyte shared DRAM, 4 Mbyte Flash, SCSI, Ethernet, Floppy disk, 4 serial I/O ports, 32-bit VMEbus interface */
+static MACHINE_CONFIG_DERIVED( cpu30zbe, cpu30za )
+	MCFG_DEVICE_MODIFY("maincpu")
+	MCFG_DEVICE_CLOCK(XTAL_25MHz) /* 25.0 MHz  from description, crystal needs verification */
+
+	// dual ported ram
+	MCFG_RAM_MODIFY(RAM_TAG)
+	MCFG_RAM_DEFAULT_SIZE("4M")
+	MCFG_RAM_EXTRA_OPTIONS("256K, 512K, 1M, 2M, 4M, 8M, 16M, 32M")
+MACHINE_CONFIG_END
+
+/* SYS68K/CPU-33 */
+static MACHINE_CONFIG_DERIVED( cpu33, cpu30zbe )
+	MCFG_DEVICE_MODIFY("maincpu")
+	MCFG_DEVICE_CLOCK(XTAL_25MHz) /* 25.0 MHz  from description, crystal needs verification */
+
+	// dual ported ram
+	MCFG_RAM_MODIFY(RAM_TAG)
+	MCFG_RAM_DEFAULT_SIZE("4M")
+	MCFG_RAM_EXTRA_OPTIONS("256K, 512K, 1M, 2M, 4M, 8M, 16M, 32M")
+MACHINE_CONFIG_END
+
+/* SYS68K/CPU-30BE/8 68030/68882 CPU, 25 MHz,  8 Mbyte shared DRAM, 4 Mbyte Flash, SCSI, Ethernet, Floppy disk, 4 serial I/O ports, 32-bit VMEbus interface, VMEPROM firmware*/
+static MACHINE_CONFIG_DERIVED( cpu30be8, cpu30zbe )
+	// dual ported ram
+	MCFG_RAM_MODIFY(RAM_TAG)
+	MCFG_RAM_DEFAULT_SIZE("8M")
+	MCFG_RAM_EXTRA_OPTIONS("256K, 512K, 1M, 2M, 4M, 8M, 16M, 32M")
+MACHINE_CONFIG_END
+
+/* SYS68K/CPU-30BE/16 68030/68882 CPU, 25 MHz, 16 Mbyte shared DRAM, 4 Mbyte Flash, SCSI, Ethernet, Floppy disk, 4 serial I/O ports, 32-bit VMEbus interface, VMEPROM firmware*/
+static MACHINE_CONFIG_DERIVED( cpu30be16, cpu30zbe )
+	// dual ported ram
+	MCFG_RAM_MODIFY(RAM_TAG)
+	MCFG_RAM_DEFAULT_SIZE("16M")
+	MCFG_RAM_EXTRA_OPTIONS("256K, 512K, 1M, 2M, 4M, 8M, 16M, 32M")
+MACHINE_CONFIG_END
+
+/* SYS68K/CPU-30Lite/4 68030 CPU, 25 MHz, 4 Mbyte shared DRAM, 4 Mbyte Flash, 4 serial ports, 32-bit VMEbus interface, VMEPROM firmware. */
+static MACHINE_CONFIG_DERIVED( cpu30lite4, cpu30zbe )
+// Enable these when added to main config
+//	MCFG_DEVICE_REMOVE("fpu")
+//	MCFG_DEVICE_REMOVE("scsi")
+//	MCFG_DEVICE_REMOVE("eth")
+//	MCFG_DEVICE_REMOVE("fdc")
+	// dual ported ram
+	MCFG_RAM_MODIFY(RAM_TAG)
+	MCFG_RAM_DEFAULT_SIZE("4M")
+	MCFG_RAM_EXTRA_OPTIONS("256K, 512K, 1M, 2M, 4M, 8M, 16M, 32M")
+MACHINE_CONFIG_END
+
+/* SYS68K/CPU-30Lite/8 68030 CPU, 25 MHz, 4 Mbyte shared DRAM, 8 Mbyte Flash, 4 serial ports, 32-bit VMEbus interface, VMEPROM firmware. */
+static MACHINE_CONFIG_DERIVED( cpu30lite8, cpu30lite4 )
+	// dual ported ram
+	MCFG_RAM_MODIFY(RAM_TAG)
+	MCFG_RAM_DEFAULT_SIZE("8M")
+	MCFG_RAM_EXTRA_OPTIONS("256K, 512K, 1M, 2M, 4M, 8M, 16M, 32M")
 MACHINE_CONFIG_END
 
 /* ROM definitions */
-ROM_START (fccpu30)
+ROM_START (fccpu30) /* This is an original rom dump */
 	ROM_REGION32_BE(0x900000, "roms", 0)
-
-#if 1
-// Boots with Board ID set to: 0x36  (FGA002 BOOT and VMEPROM on terminal P4)
-	ROM_LOAD16_BYTE("CPU33LO.BIN",  0x000001, 0x40000, CRC (49895fdf) SHA1 (733abd144c95225a2faf920490e31df2a27f8e03))
-	ROM_LOAD16_BYTE("CPU33UP.BIN",  0x000000, 0x40000, CRC (cfe75e94) SHA1 (d40e0635a48607be25f7c58c74b53b7e58fe735d))
-
 // Boots with Board ID set to: 0x36 (FGA002 BOOT on terminal P4, "Wait until harddisk is up to speed " on terminal P1)
-#else
-	ROM_LOAD32_BYTE("CPU30LL.BIN",  0x000003, 0x20000, CRC (a03ebf46) SHA1 (48fa0268cb10e20679c093e02574dbd9925f95d1))
-	ROM_LOAD32_BYTE("CPU30LO.BIN",  0x000002, 0x20000, CRC (fefa88ed) SHA1 (71a9ad807c0c2da5c6f6a6dc68c73ad8b52f3ea9))
-	ROM_LOAD32_BYTE("CPU30UP.BIN",  0x000001, 0x20000, CRC (dfed1f68) SHA1 (71478a77d5ab5da0fabcd78e69537919b560e3b8))
-	ROM_LOAD32_BYTE("CPU30UU.BIN",  0x000000, 0x20000, CRC (66e95cc2) SHA1 (acdb468a3a5974295b81271d617de7f101098891))
-#endif
+	ROM_LOAD32_BYTE("cpu30ll-ubr-v2.1.rom",  0x000003, 0x20000, CRC (a03ebf46) SHA1 (48fa0268cb10e20679c093e02574dbd9925f95d1))
+	ROM_LOAD32_BYTE("cpu30lo-ubr-v2.1.rom",  0x000002, 0x20000, CRC (fefa88ed) SHA1 (71a9ad807c0c2da5c6f6a6dc68c73ad8b52f3ea9))
+	ROM_LOAD32_BYTE("cpu30up-ubr-v2.1.rom",  0x000001, 0x20000, CRC (dfed1f68) SHA1 (71478a77d5ab5da0fabcd78e69537919b560e3b8))
+	ROM_LOAD32_BYTE("cpu30uu-ubr-v2.1.rom",  0x000000, 0x20000, CRC (66e95cc2) SHA1 (acdb468a3a5974295b81271d617de7f101098891))
+// Same binary for many boards, attempts to detect CPU speed etc, currently failing detection but boots system roms anyway
+	ROM_LOAD       ("fga002-3.1.rom",  0x800000, 0x10000, CRC (faa38972) SHA1 (651dfc2f9a865fc6adf49dad90f9e705f2889919) )
+ROM_END
+
+ROM_START (fccpu33) /* This is an original rom dump */
+	ROM_REGION32_BE(0x900000, "roms", 0)
+// Boots with Board ID set to: 0x36  (FGA002 BOOT and VMEPROM on terminal P4)
+	ROM_LOAD16_BYTE("cpu33lo-ubr-v1.01.rom",  0x000001, 0x40000, CRC (49895fdf) SHA1 (733abd144c95225a2faf920490e31df2a27f8e03))
+	ROM_LOAD16_BYTE("cpu33up-ubr-v1.01.rom",  0x000000, 0x40000, CRC (cfe75e94) SHA1 (d40e0635a48607be25f7c58c74b53b7e58fe735d))
 
 // Same binary for many boards, attempts to detect CPU speed etc, currently failing detection but boots system roms anyway
-	ROM_LOAD       ("PGA-002.bin",  0x800000, 0x10000, CRC(faa38972) SHA1(651dfc2f9a865fc6adf49dad90f9e705f2889919) )
+	ROM_LOAD       ("fga002-3.1.rom",  0x800000, 0x10000, CRC (faa38972) SHA1 (651dfc2f9a865fc6adf49dad90f9e705f2889919) )
 ROM_END
+
+ROM_START (nodump)
+	ROM_REGION32_BE(0x900000, "roms", 0)
+	ROM_LOAD("rom.bin",  0x800000, 0x10000, NO_DUMP)
+ROM_END
+
+/* These needs reality check as they has 1Mb of RAM which is not a suitable size for later CPU_30:s */
+#define rom_fccpu30x		rom_fccpu30
+#define rom_fccpu30xa 		rom_fccpu30
+#define rom_fccpu30za 		rom_fccpu30
+
+#define rom_fccpu30zbe 		rom_fccpu30
+#define rom_fccpu30be8 		rom_fccpu30
+#define rom_fccpu30be16     rom_fccpu30
+
+/* These needs dumps */
+#define rom_fccpu30lite4    rom_nodump
+#define rom_fccpu30lite8    rom_nodump
+
+/* These are most likelly wrong, needs dump */
+#define rom_fccpu30senr 	rom_nodump
+#define rom_fccpu30senr501  rom_nodump
 
 /*
  * System ROM information
@@ -757,10 +947,35 @@ void fga002_device::trigger_interrupt(uint8_t)(34)
 Interrupt Level 4, caused by ICR 1c with vector 34
 void fga002_device::check_interrupts()()
 :fga002 virtual int fga002_device::z80daisy_irq_state() Level 0-7:[00][00] [00][00] [01][00] [00][00]
-void fccpu30_state::fga_irq_callback(int)(01)
+void cpu30_state::fga_irq_callback(int)(01)
 void fga002_device::check_interrupts()()
  */
 
 /* Driver */
-/*    YEAR  NAME          PARENT  COMPAT   MACHINE         INPUT     CLASS          INIT COMPANY                  FULLNAME          FLAGS */
-COMP (1990, fccpu30,      0,      0,       fccpu30,        fccpu30, driver_device, 0,   "Force Computers Gmbh",   "SYS68K/CPU-30", MACHINE_NOT_WORKING | MACHINE_NO_SOUND_HW | MACHINE_TYPE_COMPUTER )
+/*    YEAR  NAME          PARENT  COMPAT   MACHINE         INPUT     CLASS          INIT         COMPANY                   FULLNAME                FLAGS */
+COMP (1988, fccpu30,      0,       0,      cpu30,          cpu30,    driver_device,      0,      "Force Computers Gmbh",   "SYS68K/CPU-30",        MACHINE_NOT_WORKING | MACHINE_NO_SOUND_HW | MACHINE_TYPE_COMPUTER )
+COMP (1988, fccpu30x,     fccpu30,   0,      cpu30x,         cpu30,    cpu30_state,   cpu30x,      "Force Computers Gmbh",   "SYS68K/CPU-30X",       MACHINE_NOT_WORKING | MACHINE_NO_SOUND_HW | MACHINE_TYPE_COMPUTER )
+COMP (1988, fccpu30xa,    fccpu30,   0,      cpu30xa,        cpu30,    cpu30_state,   cpu30xa,     "Force Computers Gmbh",   "SYS68K/CPU-30XA",      MACHINE_NOT_WORKING | MACHINE_NO_SOUND_HW | MACHINE_TYPE_COMPUTER )
+COMP (1988, fccpu30za,    fccpu30,   0,      cpu30za,        cpu30,    cpu30_state,   cpu30za,     "Force Computers Gmbh",   "SYS68K/CPU-30ZA",      MACHINE_NOT_WORKING | MACHINE_NO_SOUND_HW | MACHINE_TYPE_COMPUTER )
+COMP (1996, fccpu30zbe,   fccpu30,   0,      cpu30zbe,       cpu30,    cpu30_state,   cpu30zbe,    "Force Computers Gmbh",   "SYS68K/CPU-30ZBE",     MACHINE_NOT_WORKING | MACHINE_NO_SOUND_HW | MACHINE_TYPE_COMPUTER )
+COMP (1996, fccpu30be8,   fccpu30,   0,      cpu30be8,       cpu30,    cpu30_state,   cpu30be8,    "Force Computers Gmbh",   "SYS68K/CPU-30BE/8",    MACHINE_NOT_WORKING | MACHINE_NO_SOUND_HW | MACHINE_TYPE_COMPUTER )
+COMP (1996, fccpu30be16,  fccpu30,   0,      cpu30be16,      cpu30,    cpu30_state,   cpu30be16,   "Force Computers Gmbh",   "SYS68K/CPU-30BE/16",   MACHINE_NOT_WORKING | MACHINE_NO_SOUND_HW | MACHINE_TYPE_COMPUTER )
+COMP (1996, fccpu30lite4, fccpu30,   0,      cpu30lite4,     cpu30,    cpu30_state,   cpu30lite4,  "Force Computers Gmbh",   "SYS68K/CPU-30Lite/4",  MACHINE_NOT_WORKING | MACHINE_NO_SOUND_HW | MACHINE_TYPE_COMPUTER )
+COMP (1996, fccpu30lite8, fccpu30,   0,      cpu30lite8,     cpu30,    cpu30_state,   cpu30lite8,  "Force Computers Gmbh",   "SYS68K/CPU-30Lite/8",  MACHINE_NOT_WORKING | MACHINE_NO_SOUND_HW | MACHINE_TYPE_COMPUTER )
+COMP (199?, fccpu33,      fccpu30,   0,      cpu33,          cpu30,    cpu30_state,   cpu33,       "Force Computers Gmbh",   "SYS68K/CPU-33",        MACHINE_NOT_WORKING | MACHINE_NO_SOUND_HW | MACHINE_TYPE_COMPUTER )
+
+/* Below are not fully configured variants defaulting to generic cpu30 */
+
+/* The following boards were manufactured for Ericsson to be used in their fixed network switches. They support hot swap and the Ericsson APNbus */
+/* SYS68K/CPU-30SEN-R/32 assumed as generic until spec is found. 25 MHz 68030 based CPU board with DMAC, 32 MByte Shared RAM capacity and VMEPROM.
+   4 MByte System Flash memory, SCSI via on-board EAGLE Controller FC68165 with DMA, 2 serial I/O ports, APNbus interface, VMEPROM firmware */
+COMP (1997, fccpu30senr,    0,      0,       cpu30,        cpu30, driver_device, 0,   "Force Computers Gmbh",   "SYS68K/CPU-30SEN-R", MACHINE_NOT_WORKING | MACHINE_NO_SOUND_HW | MACHINE_TYPE_COMPUTER )
+/* SYS68K/CPU-30SEN-R-501/4 assumed as generic until spec is found. 25 MHz 68030 based CPU board with DMAC, 4 MByte Shared RAM capacity and VMEPROM.
+   48V DC/DC onboard, metric backplane connectors, BYB501 PCB formfactor (TVJ807). 4 MByte System Flash memory, SCSI via onboard EAGLEController
+   FC68165 with DMA, 2 serial I/O ports, APNbus interface, VMEPROM firmware*/
+COMP (1997, fccpu30senr501, 0,      0,       cpu30,        cpu30, driver_device, 0,   "Force Computers Gmbh",   "SYS68K/CPU-30SEN-R-501", MACHINE_NOT_WORKING | MACHINE_NO_SOUND_HW | MACHINE_TYPE_COMPUTER )
+
+/*CPU-33XB MC68030 25MHz CPU, 68882 FPC, 1MB, 2 SERIAL, RS-232, VME BOARD*/
+//COMP (1990, cpu33xb,      0,      0,       cpu30,        cpu30, driver_device, 0,   "Force Computers Gmbh",   "SYS68K/CPU-33XB",   MACHINE_NOT_WORKING | MACHINE_NO_SOUND_HW | MACHINE_TYPE_COMPUTER )
+/*CPU-33B/4 MC68030 25MHz CPU, 68882 FPC, 1MB, 2 SERIAL, RS-232, VME BOARD*/
+//COMP (1990, cpu30b4,      0,      0,       cpu30,        cpu30, driver_device, 0,   "Force Computers Gmbh",   "SYS68K/CPU-33B/4",   MACHINE_NOT_WORKING | MACHINE_NO_SOUND_HW | MACHINE_TYPE_COMPUTER )

--- a/src/mame/mame.lst
+++ b/src/mame/mame.lst
@@ -12181,7 +12181,21 @@ fb01                            // 1986 FB-01
 fc100                           //
 
 @source:fccpu30.cpp
-fccpu30                         //
+fccpu30
+fccpu30x
+fccpu30xa
+fccpu30za
+fccpu30zbe
+fccpu30be8
+fccpu30be16
+fccpu30lite4
+fccpu30lite8
+fccpu30senr
+fccpu30senr501
+fccpu33
+
+//@source:fccpu40.cpp
+//fccpu40                         //
 
 @source:fcscsi.cpp
 fcscsi1                         //


### PR DESCRIPTION
- fccpu30: WIP New board variants added: cpu30x, cpu30xa, cpu30za, cpu30zbe, cpu30be8, cpu30be16, cpu30lite4, cpu30lite8, cpu30senr, cpu30senr501, cpu33
- fccpu30: support for -ramsize according to each board variant
- fccpu: Prepared to split out base fccpu class to support drivers for cpu2x and cpu4x boards etc
- fccpu30: renamed roms to reflect on content and versions
- Small fixes: PIT68230, FGA022, DUSCC