### PR TITLE
Added UPD7201 device type to z80sio.cpp and used it in mzr8105.cpp, p…

### DIFF
--- a/src/devices/machine/z80sio.h
+++ b/src/devices/machine/z80sio.h
@@ -66,9 +66,18 @@
 	MCFG_DEVICE_ADD(_tag, Z80SIO, _clock) \
 	MCFG_Z80SIO_OFFSETS(_rxa, _txa, _rxb, _txb)
 
+#define MCFG_UPD7201_ADD(_tag, _clock, _rxa, _txa, _rxb, _txb) \
+	MCFG_DEVICE_ADD(_tag, UPD7201N, _clock) \
+	MCFG_Z80SIO_OFFSETS(_rxa, _txa, _rxb, _txb)
+
+/* Generic macros */
 #define MCFG_Z80SIO_OFFSETS(_rxa, _txa, _rxb, _txb) \
 	z80sio_device::configure_channels(*device, _rxa, _txa, _rxb, _txb);
 
+#define MCFG_Z80SIO_OUT_INT_CB(_devcb) \
+	devcb = &z80sio_device::set_out_int_callback(*device, DEVCB_##_devcb);
+
+// Port A callbacks
 #define MCFG_Z80SIO_OUT_TXDA_CB(_devcb) \
 	devcb = &z80sio_device::set_out_txda_callback(*device, DEVCB_##_devcb);
 
@@ -84,6 +93,13 @@
 #define MCFG_Z80SIO_OUT_SYNCA_CB(_devcb) \
 	devcb = &z80sio_device::set_out_synca_callback(*device, DEVCB_##_devcb);
 
+#define MCFG_Z80SIO_OUT_RXDRQA_CB(_devcb) \
+	devcb = &z80sio_device::set_out_rxdrqa_callback(*device, DEVCB_##_devcb);
+
+#define MCFG_Z80SIO_OUT_TXDRQA_CB(_devcb) \
+	devcb = &z80sio_device::set_out_txdrqa_callback(*device, DEVCB_##_devcb);
+
+// Port B callbacks
 #define MCFG_Z80SIO_OUT_TXDB_CB(_devcb) \
 	devcb = &z80sio_device::set_out_txdb_callback(*device, DEVCB_##_devcb);
 
@@ -98,15 +114,6 @@
 
 #define MCFG_Z80SIO_OUT_SYNCB_CB(_devcb) \
 	devcb = &z80sio_device::set_out_syncb_callback(*device, DEVCB_##_devcb);
-
-#define MCFG_Z80SIO_OUT_INT_CB(_devcb) \
-	devcb = &z80sio_device::set_out_int_callback(*device, DEVCB_##_devcb);
-
-#define MCFG_Z80SIO_OUT_RXDRQA_CB(_devcb) \
-	devcb = &z80sio_device::set_out_rxdrqa_callback(*device, DEVCB_##_devcb);
-
-#define MCFG_Z80SIO_OUT_TXDRQA_CB(_devcb) \
-	devcb = &z80sio_device::set_out_txdrqa_callback(*device, DEVCB_##_devcb);
 
 #define MCFG_Z80SIO_OUT_RXDRQB_CB(_devcb) \
 	devcb = &z80sio_device::set_out_rxdrqb_callback(*device, DEVCB_##_devcb);
@@ -403,7 +410,7 @@ class z80sio_device :  public device_t,
 {
 	friend class z80sio_channel;
 
-	public:
+public:
 	// construction/destruction
 	z80sio_device(const machine_config &mconfig, device_type type, const char *name, const char *tag, device_t *owner, uint32_t clock, uint32_t variant, const char *shortname, const char *source);
 	z80sio_device(const machine_config &mconfig, const char *tag, device_t *owner, uint32_t clock);
@@ -486,7 +493,8 @@ protected:
 
 	enum
 	{
-		TYPE_Z80SIO
+		TYPE_Z80SIO		= 0x001,
+		TYPE_UPD7201	= 0x002
 	};
 
 	enum
@@ -526,8 +534,15 @@ protected:
 	int m_variant;
 };
 
+class upd7201N_device : public z80sio_device
+{
+public :
+	upd7201N_device(const machine_config &mconfig, const char *tag, device_t *owner, uint32_t clock);
+};
 
 // device type definition
 extern const device_type Z80SIO;
 extern const device_type Z80SIO_CHANNEL;
+extern const device_type UPD7201N;
+
 #endif

--- a/src/mame/drivers/mzr8105.cpp
+++ b/src/mame/drivers/mzr8105.cpp
@@ -102,20 +102,24 @@
  *
  * Known boards from Mizar:
  *
- *-Comp.Os.Vxworks diguest mailing list May 1992: VxWorks Drivers Available from Mizar:
- * EMX 7320 Serial I/O Board
- * EMX 7550 Ethernet Controller Board (AMD 7990 Lance) MAC: 00:80:F8 MIZAR, INC.
+ * MZX 414
+ * MZ 7122 
+ * MZ 7132 
  * MZ 7300 Serial I/O Board (Z8530)
+ * EMX 7320 Serial I/O Board
  * MZ 7400 Disk Controller Board (WD 2010; WD 1772)
  * MZ 7500 IEEE-488 (GPIB) Interface Board
+ * EMX 7550 Ethernet Controller Board (AMD 7990 Lance) MAC: 00:80:F8 MIZAR, INC.
+ * MZ 7772 
  * MZ 7810 I/O Expansion Module (6681 DUART)
  * MZ 7831 SCSI Expansion Module (WD 33C93A)
  * MZ 7850 Ethernet Expansion Module (WD 83C690)
- * MZ 8505 IEEE-488 (GPIB) Interface Board"
- *- Other sources:
  * MZ 8000 ??
  * MZ 8105 3U 68000 CPU board
- * MZ 8300 3U serial board, 2 NEC 7201 (Z80 DART) and 1 AMD CTS9513 5 x 16 bit Counter/Timer
+ * MZ 8115 
+ * MZ 8300 3U serial board, 2 NEC 7201 and 1 AMD CTS9513 5 x 16 bit Counter/Timer
+ * MZ 8310 timing module 2 x AM9513
+ * MZ 8505 IEEE-488 (GPIB) Interface Board"
  *
  * From http://www.megalextoria.com/forum2/index.php?t=msg&goto=73945&
  *--------------------------------------------------------------------
@@ -155,25 +159,50 @@
  *  - Dump the ROMs (DONE)
  *  - Setup a working address map (DONE)
  *  - Add VME bus driver (Faked one)
+ *  - understand what other device is expected in VME space ff0011-13
  *
  ****************************************************************************/
 
 #include "emu.h"
 #include "cpu/m68000/m68000.h"
-#include "machine/z80dart.h"
 #include "bus/rs232/rs232.h"
 #include "machine/clock.h"
 #include "softlist.h"
 
+// The board needs a SIO board to get a user interface so lets fake one until the VME devices is done
+#define FAKEVME 1 
+
+// There are two user prom sockets
 #define CARDSLOT 0
+
+#if FAKEVME
+#include "machine/z80sio.h"
+#endif
 
 #if CARDSLOT // Awaiting info on how to boot the user eproms
 #include "bus/generic/slot.h"
 #include "bus/generic/carts.h"
 #endif
 
-#define LOG(x) x
+#define VERBOSE 0
 
+#define LOGPRINT(x) { do { if (VERBOSE) logerror x; } while (0); }
+#define LOG(x)      {} LOGPRINT(x)
+#define LOGR(x)     {} LOGPRINT(x)
+#define LOGSETUP(x) {} LOGPRINT(x)
+#define LOGINT(x)   {} LOGPRINT(x)
+
+#if VERBOSE >= 2
+#define logerror printf
+#endif
+
+#ifdef _MSC_VER
+#define LLFORMAT "%I64%"
+#define FUNCNAME __func__
+#else
+#define LLFORMAT "%lld"
+#define FUNCNAME __PRETTY_FUNCTION__
+#endif
 
 /* These values are borrowed just to get the terminal going and should be replaced
  * once a proper serial board hardware (ie MZ 8300) is found and emulated. */
@@ -184,59 +213,56 @@ class mzr8105_state : public driver_device
 {
 public:
 mzr8105_state(const machine_config &mconfig, device_type type, const char *tag) :
-		driver_device (mconfig, type, tag),
-				m_maincpu (*this, "maincpu")
-				,m_updterm(*this, "upd")
-//        ,m_cart(*this, "exp_rom1")
+	driver_device (mconfig, type, tag)
+	,m_maincpu (*this, "maincpu")
+	,m_updterm(*this, "upd")
+#if CARDSLOT
+	,m_cart(*this, "exp_rom1")
+#endif
 {
 }
 
-DECLARE_READ16_MEMBER (vme_a24_r);
-DECLARE_WRITE16_MEMBER (vme_a24_w);
-DECLARE_READ16_MEMBER (vme_a16_r);
-DECLARE_WRITE16_MEMBER (vme_a16_w);
-virtual void machine_start () override;
-DECLARE_WRITE_LINE_MEMBER (write_updterm_clock);
+	DECLARE_READ16_MEMBER (vme_a24_r);
+	DECLARE_WRITE16_MEMBER (vme_a24_w);
+	DECLARE_READ16_MEMBER (vme_a16_r);
+	DECLARE_WRITE16_MEMBER (vme_a16_w);
+	virtual void machine_start () override;
+	DECLARE_WRITE_LINE_MEMBER (write_updterm_clock);
 
 #if CARDSLOT
-// User EPROM/SRAM slot(s)
-int mzr8105_load_cart(device_image_interface &image, generic_slot_device *slot);
-DECLARE_DEVICE_IMAGE_LOAD_MEMBER (exp1_load) { return mzr8105_load_cart(image, m_cart); }
-DECLARE_READ16_MEMBER (read16_rom);
+	// User EPROM/SRAM slot(s)
+	int mzr8105_load_cart(device_image_interface &image, generic_slot_device *slot);
+	DECLARE_DEVICE_IMAGE_LOAD_MEMBER (exp1_load) { return mzr8105_load_cart(image, m_cart); }
+	DECLARE_READ16_MEMBER (read16_rom);
 #endif
 
 protected:
 
 private:
-required_device<cpu_device> m_maincpu;
-required_device<upd7201_device> m_updterm;
-
-// Pointer to System ROMs needed by bootvect_r
-// uint16_t  *m_sysrom;
+	required_device<cpu_device> m_maincpu;
+	required_device<upd7201N_device> m_updterm;
 
 #if CARDSLOT
-uint16_t  *m_usrrom;
-required_device<generic_slot_device> m_cart;
+	uint16_t  *m_usrrom;
+	required_device<generic_slot_device> m_cart;
 #endif
 };
 
 static ADDRESS_MAP_START (mzr8105_mem, AS_PROGRAM, 16, mzr8105_state)
-ADDRESS_MAP_UNMAP_HIGH
-//AM_RANGE (0x000000, 0x000007) AM_ROM AM_READ (bootvect_r)       /* Not verified */
-AM_RANGE (0x000000, 0x003fff) AM_ROM /* System EPROM Area 16Kb OS9 DEBUG - not verified     */
-AM_RANGE (0x004000, 0x01ffff) AM_ROM /* System EPROM Area 112Kb for System ROM - not verified    */
-AM_RANGE (0x020000, 0x03ffff) AM_RAM /* Not verified */
-//AM_RANGE (0x0a0000, 0x0bffff) AM_ROM /* User EPROM/SRAM Area, max 128Kb mapped by a cartslot  */
-//AM_RANGE (0x0c0080, 0x0c0081) AM_DEVREADWRITE8 ("aciaterm", acia6850_device, status_r, control_w, 0xff00)
-//AM_RANGE (0x0c0082, 0x0c0083) AM_DEVREADWRITE8 ("aciaterm", acia6850_device, data_r, data_w, 0xff00)
-AM_RANGE(0x100000, 0xfeffff)  AM_READWRITE(vme_a24_r, vme_a24_w) /* VMEbus Rev B addresses (24 bits) - not verified */
-//AM_RANGE(0xff0000, 0xffffff)  AM_READWRITE(vme_a16_r, vme_a16_w) /* VMEbus Rev B addresses (16 bits) - not verified */
-// Faking a Mizar 8300 SIO BOARD in VME A16 adress space
-		AM_RANGE (0xFF0000, 0xFF0001) AM_DEVREADWRITE8("upd", upd7201_device, da_r, da_w, 0x00ff) /* Dual serial port NEC uPD7201 */
-		AM_RANGE (0xFF0002, 0xFF0003) AM_DEVREADWRITE8("upd", upd7201_device, ca_r, ca_w, 0x00ff) /* Dual serial port NEC uPD7201 */
-		AM_RANGE (0xFF0004, 0xFF0005) AM_DEVREADWRITE8("upd", upd7201_device, db_r, db_w, 0x00ff) /* Dual serial port NEC uPD7201 */
-		AM_RANGE (0xFF0006, 0xFF0007) AM_DEVREADWRITE8("upd", upd7201_device, cb_r, cb_w, 0x00ff) /* Dual serial port NEC uPD7201 */
-
+	ADDRESS_MAP_UNMAP_HIGH
+	AM_RANGE (0x000000, 0x003fff) AM_ROM AM_REGION("roms", 0x000000) /* System EPROM Area 16Kb OS9 DEBUG - not verified     */
+	AM_RANGE (0x004000, 0x01ffff) AM_ROM AM_REGION("roms", 0x004000)/* System EPROM Area 112Kb for System ROM - not verified    */
+	AM_RANGE (0x020000, 0x03ffff) AM_RAM /* Not verified */
+//	AM_RANGE (0x0a0000, 0x0bffff) AM_ROM /* User EPROM/SRAM Area, max 128Kb mapped by a cartslot  */
+//	AM_RANGE(0x100000, 0xfeffff)  AM_READWRITE(vme_a24_r, vme_a24_w) /* VMEbus Rev B addresses (24 bits) - not verified */
+//	AM_RANGE(0xff0000, 0xffffff)  AM_READWRITE(vme_a16_r, vme_a16_w) /* VMEbus Rev B addresses (16 bits) - not verified */
+#if FAKEVME
+// Faking a Mizar 8300 SIO UPD7201 BOARD in VME A16 adress space
+	AM_RANGE (0xFF0000, 0xFF0001) AM_DEVREADWRITE8("upd", upd7201N_device, db_r, db_w, 0x00ff)
+	AM_RANGE (0xFF0002, 0xFF0003) AM_DEVREADWRITE8("upd", upd7201N_device, cb_r, cb_w, 0x00ff)
+	AM_RANGE (0xFF0004, 0xFF0005) AM_DEVREADWRITE8("upd", upd7201N_device, da_r, da_w, 0x00ff)
+	AM_RANGE (0xFF0006, 0xFF0007) AM_DEVREADWRITE8("upd", upd7201N_device, ca_r, ca_w, 0x00ff)
+#endif
 ADDRESS_MAP_END
 
 /* Input ports */
@@ -246,50 +272,50 @@ INPUT_PORTS_END
 /* Start it up */
 void mzr8105_state::machine_start ()
 {
-		LOG (logerror ("machine_start\n"));
+	LOG(("%s()\n", FUNCNAME));
 
 #if CARDSLOT
-		/* Map user ROM/RAM socket(s) */
-		if (m_cart->exists())
-		{
-				m_usrrom = (uint16_t*)m_cart->get_rom_base();
-				m_maincpu->space(AS_PROGRAM).install_read_handler(0xa0000, 0xbffff, read16_delegate(FUNC(generic_slot_device::read16_rom), (generic_slot_device*)m_cart));
-		}
+	/* Map user ROM/RAM socket(s) */
+	if (m_cart->exists())
+	{
+		m_usrrom = (uint16_t*)m_cart->get_rom_base();
+		m_maincpu->space(AS_PROGRAM).install_read_handler(0xa0000, 0xbffff, read16_delegate(FUNC(generic_slot_device::read16_rom), (generic_slot_device*)m_cart));
+	}
 #endif
 }
 
 /* Dummy VME access methods until the VME bus device is ready for use */
 READ16_MEMBER (mzr8105_state::vme_a24_r){
-		LOG (logerror ("vme_a24_r\n"));
-		return (uint16_t) 0;
+	LOG(("%s()\n", FUNCNAME));
+	return (uint16_t) 0;
 }
 
 WRITE16_MEMBER (mzr8105_state::vme_a24_w){
-		LOG (logerror ("vme_a24_w\n"));
+	LOG(("%s()\n", FUNCNAME));
 }
 
 READ16_MEMBER (mzr8105_state::vme_a16_r){
-		LOG (logerror ("vme_16_r\n"));
-		return (uint16_t) 0;
+	LOG(("%s()\n", FUNCNAME));
+	return (uint16_t) 0;
 }
 
 WRITE16_MEMBER (mzr8105_state::vme_a16_w){
-		LOG (logerror ("vme_a16_w\n"));
+	LOG(("%s()\n", FUNCNAME));
 }
 
 #if CARDSLOT
 /*
- * 4. The USER EPROM Area
+ * The USER EPROM Area
  */
 // Implementation of static 2 x 64K EPROM in sockets U1/U3 as 16 bit wide cartridge for easier
 // software handling. TODO: make configurable according to table above.
 static MACHINE_CONFIG_FRAGMENT( mzr8105_eprom_sockets )
-		MCFG_GENERIC_CARTSLOT_ADD("exp_rom1", generic_plain_slot, "mzr8105_cart")
-		MCFG_GENERIC_EXTENSIONS("bin,rom")
-		MCFG_GENERIC_WIDTH(GENERIC_ROM16_WIDTH)
-		MCFG_GENERIC_ENDIAN(ENDIANNESS_BIG)
-		MCFG_GENERIC_LOAD(mzr8105_state, exp1_load)
-//      MCFG_SOFTWARE_LIST_ADD("cart_list", "mzr8105_cart")
+	MCFG_GENERIC_CARTSLOT_ADD("exp_rom1", generic_plain_slot, "mzr8105_cart")
+	MCFG_GENERIC_EXTENSIONS("bin,rom")
+	MCFG_GENERIC_WIDTH(GENERIC_ROM16_WIDTH)
+	MCFG_GENERIC_ENDIAN(ENDIANNESS_BIG)
+	MCFG_GENERIC_LOAD(mzr8105_state, exp1_load)
+//  MCFG_SOFTWARE_LIST_ADD("cart_list", "mzr8105_cart")
 MACHINE_CONFIG_END
 
 /***************************
@@ -297,74 +323,72 @@ MACHINE_CONFIG_END
 ****************************/
 int mzr8105_state::mzr8105_load_cart(device_image_interface &image, generic_slot_device *slot)
 {
-		uint32_t size = slot->common_get_size("rom");
+	uint32_t size = slot->common_get_size("rom");
 
-		if (size > 0x20000) // Max 128Kb - not verified
-		{
-				LOG( printf("Cartridge size exceeding max size (128Kb): %d\n", size) );
-				image.seterror(IMAGE_ERROR_UNSPECIFIED, "Cartridge size exceeding max size (128Kb)");
-				return IMAGE_INIT_FAIL;
-		}
+	if (size > 0x20000) // Max 128Kb - not verified
+	{
+		LOG(("Cartridge size exceeding max size (128Kb): %d\n", size) );
+		image.seterror(IMAGE_ERROR_UNSPECIFIED, "Cartridge size exceeding max size (128Kb)");
+		return IMAGE_INIT_FAIL;
+	}
 
-		slot->rom_alloc(size, GENERIC_ROM16_WIDTH, ENDIANNESS_BIG);
-		slot->common_load_rom(slot->get_rom_base(), size, "rom");
+	slot->rom_alloc(size, GENERIC_ROM16_WIDTH, ENDIANNESS_BIG);
+	slot->common_load_rom(slot->get_rom_base(), size, "rom");
 
-		return IMAGE_INIT_PASS;
+	return IMAGE_INIT_PASS;
 }
 #endif
 
 WRITE_LINE_MEMBER (mzr8105_state::write_updterm_clock){
-		m_updterm->txca_w (state);
-		m_updterm->rxca_w (state);
+	m_updterm->txcb_w (state);
+	m_updterm->rxcb_w (state);
 }
 
 /*
  * Machine configuration
  */
 static MACHINE_CONFIG_START (mzr8105, mzr8105_state)
-/* basic machine hardware */
-MCFG_CPU_ADD ("maincpu", M68000, XTAL_10MHz)
-MCFG_CPU_PROGRAM_MAP (mzr8105_mem)
-
-
+	MCFG_CPU_ADD ("maincpu", M68000, XTAL_10MHz)
+	MCFG_CPU_PROGRAM_MAP (mzr8105_mem)
+	
 /* Terminal Port config */
-MCFG_UPD7201_ADD("upd", XTAL_4MHz, 0, 0, 0, 0 )
-MCFG_Z80DART_OUT_TXDA_CB(DEVWRITELINE("rs232trm", rs232_port_device, write_txd))
-MCFG_Z80DART_OUT_DTRA_CB(DEVWRITELINE("rs232trm", rs232_port_device, write_dtr))
-MCFG_Z80DART_OUT_RTSA_CB(DEVWRITELINE("rs232trm", rs232_port_device, write_rts))
+	MCFG_UPD7201_ADD("upd", XTAL_4MHz, 0, 0, 0, 0 )
+	MCFG_Z80SIO_OUT_TXDB_CB(DEVWRITELINE("rs232trm", rs232_port_device, write_txd))
+	MCFG_Z80SIO_OUT_DTRB_CB(DEVWRITELINE("rs232trm", rs232_port_device, write_dtr))
+	MCFG_Z80SIO_OUT_RTSB_CB(DEVWRITELINE("rs232trm", rs232_port_device, write_rts))
+	
+	MCFG_RS232_PORT_ADD ("rs232trm", default_rs232_devices, "terminal")
+	MCFG_RS232_RXD_HANDLER (DEVWRITELINE ("upd", upd7201N_device, rxb_w))
+	MCFG_RS232_CTS_HANDLER (DEVWRITELINE ("upd", upd7201N_device, ctsb_w))
 
-MCFG_RS232_PORT_ADD ("rs232trm", default_rs232_devices, "terminal")
-MCFG_RS232_RXD_HANDLER (DEVWRITELINE ("upd", upd7201_device, rxa_w))
-MCFG_RS232_CTS_HANDLER (DEVWRITELINE ("upd", upd7201_device, ctsa_w))
-
-MCFG_DEVICE_ADD ("updterm_clock", CLOCK, UPD_CLOCK)
-MCFG_CLOCK_SIGNAL_HANDLER (WRITELINE (mzr8105_state, write_updterm_clock))
+	MCFG_DEVICE_ADD ("updterm_clock", CLOCK, UPD_CLOCK)
+	MCFG_CLOCK_SIGNAL_HANDLER (WRITELINE (mzr8105_state, write_updterm_clock))
 
 #if CARDSLOT
-
 // EPROM sockets
-MCFG_FRAGMENT_ADD(mzr8105_eprom_sockets)
+	MCFG_FRAGMENT_ADD(mzr8105_eprom_sockets)
 #endif
 
 MACHINE_CONFIG_END
 
 /* ROM definitions */
-ROM_START (mzr8105)
-ROM_REGION (0x1000000, "maincpu", 0)
-
-ROM_LOAD16_BYTE ("mzros9LB.bin", 0x000001, 0x2000, CRC (7c6a354d) SHA1 (2721eb649c8046dbcb517a36a97dc0816cd133f2))
-ROM_LOAD16_BYTE ("mzros9HB.bin", 0x000000, 0x2000, CRC (d18e69a6) SHA1 (a00b68f4d649bcc09a29361f8692e52be12b3792))
-
-/*
- * System ROM information
- *
- * The ROMs contains an OS9 bootloader. It is position independent but reset vector suggests that it sits flat on adress 0 (zero)
- *
- * We got a prompt but the command reportoair are very sparse to non OS9 users so investigation needed.
- *
+/* UPD7201 init sequence
+ * :upd B Reg 02 <- 04 Interrupt vector 
+ * :upd B Reg 06 <- 00 Sync byte
+ * :upd B Reg 07 <- 00 Sync byte
+ * :upd B Reg 03 <- c1 Rx 8 bit chars + Rx enable
+ * :upd B Reg 04 <- 44 16x clock, 1 stop bit ( == async mode), no parity
+ * :upd B Reg 05 <- 68 Tx 8 bit chars + Tx enable
  */
+ROM_START (mzr8105)
+	ROM_REGION (0x20000, "roms", 0)
+
+/* The ROMs contains an OS9 bootloader. It is position independent but reset vector suggests that it sits flat on adress 0 (zero) */
+	ROM_LOAD16_BYTE ("mzros9LB.bin", 0x000000, 0x2000, CRC (7c6a354d) SHA1 (2721eb649c8046dbcb517a36a97dc0816cd133f2))
+	ROM_LOAD16_BYTE ("mzros9HB.bin", 0x000001, 0x2000, CRC (d18e69a6) SHA1 (a00b68f4d649bcc09a29361f8692e52be12b3792))
+
 ROM_END
 
 /* Driver */
 /*    YEAR  NAME          PARENT  COMPAT   MACHINE         INPUT     CLASS          INIT COMPANY                  FULLNAME          FLAGS */
-COMP (1987, mzr8105,      0,      0,       mzr8105,        mzr8105, driver_device, 0,   "Mizar Inc",             "Mizar VME8105", MACHINE_IS_SKELETON )
+COMP (1987, mzr8105,      0,      0,       mzr8105,        mzr8105, driver_device,  0,   "Mizar Inc",             "Mizar VME8105",  MACHINE_NOT_WORKING | MACHINE_NO_SOUND_HW | MACHINE_TYPE_COMPUTER )


### PR DESCRIPTION
…lus some maintenance. It is called UPD7201N to not collide with the widely used UPD7201 type in z80dart.cpp. Since the SIO has synchronous modes which the DART doesn't have, the long term plan is to replace the SIO support in z80dart.cpp and move drivers to use z80sio.cpp, unless it makes someone unhappy?