### PR TITLE
FPU enable/disable methods

### DIFF
--- a/src/devices/cpu/m68000/m68000.h
+++ b/src/devices/cpu/m68000/m68000.h
@@ -168,9 +168,13 @@ public:
 	void set_tas_write_callback(write8_delegate callback);
 	uint16_t get_fc();
 	void set_hmmu_enable(int enable);
+	void set_fpu_enable(int enable);
+	int get_fpu_enable();
 	void set_instruction_hook(read32_delegate ihook);
 	void set_buserror_details(uint32_t fault_addr, uint8_t rw, uint8_t fc);
 
+private:
+	int    has_fpu;      /* Indicates if a FPU is available (yes on 030, 040, may be on 020) */
 public:
 
 
@@ -211,7 +215,6 @@ public:
 	int    has_hmmu;     /* Indicates if an Apple HMMU is available in place of the 68851 (020 only) */
 	int    pmmu_enabled; /* Indicates if the PMMU is enabled */
 	int    hmmu_enabled; /* Indicates if the HMMU is enabled */
-	int    has_fpu;      /* Indicates if a FPU is available (yes on 030, 040, may be on 020) */
 	int    fpu_just_reset; /* Indicates the FPU was just reset */
 
 	/* Clocks required for instructions / exceptions */

--- a/src/devices/cpu/m68000/m68k_in.cpp
+++ b/src/devices/cpu/m68000/m68k_in.cpp
@@ -902,7 +902,7 @@ M68KMAKE_OP(1111, 0, ., .)
 
 M68KMAKE_OP(040fpu0, 32, ., .)
 {
-	if((mc68kcpu)->has_fpu)
+	if((mc68kcpu)->get_fpu_enable())
 	{
 		m68040_fpu_op0(mc68kcpu);
 		return;
@@ -913,7 +913,7 @@ M68KMAKE_OP(040fpu0, 32, ., .)
 
 M68KMAKE_OP(040fpu1, 32, ., .)
 {
-	if((mc68kcpu)->has_fpu)
+	if((mc68kcpu)->get_fpu_enable())
 	{
 		m68040_fpu_op1(mc68kcpu);
 		return;
@@ -4437,7 +4437,7 @@ M68KMAKE_OP(cpdbcc, 32, ., .)
 
 M68KMAKE_OP(cpgen, 32, ., .)
 {
-	if(CPU_TYPE_IS_EC020_PLUS((mc68kcpu)->cpu_type) && (mc68kcpu->has_fpu || mc68kcpu->has_pmmu))
+	if(CPU_TYPE_IS_EC020_PLUS((mc68kcpu)->cpu_type) && (mc68kcpu->get_fpu_enable() || mc68kcpu->has_pmmu))
 	{
 		mc68kcpu->logerror("%s at %08x: called unimplemented instruction %04x (cpgen)\n",
 						(mc68kcpu)->tag(), REG_PC(mc68kcpu) - 2, (mc68kcpu)->ir);
@@ -4472,7 +4472,7 @@ M68KMAKE_OP(cptrapcc, 32, ., .)
 
 M68KMAKE_OP(ftrapcc, 32, ., .)
 {
-	if((mc68kcpu)->has_fpu)
+	if((mc68kcpu)->get_fpu_enable())
 	{
 		m68881_ftrap(mc68kcpu);
 		return;

--- a/src/devices/cpu/m68000/m68kcpu.cpp
+++ b/src/devices/cpu/m68000/m68kcpu.cpp
@@ -1208,6 +1208,16 @@ void m68000_base_device::set_hmmu_enable(int enable)
 	hmmu_enabled = enable;
 }
 
+void m68000_base_device::set_fpu_enable(int enable)
+{
+	has_fpu = enable;
+}
+
+int m68000_base_device::get_fpu_enable()
+{
+	return has_fpu;
+}
+
 void m68000_base_device::set_instruction_hook(read32_delegate ihook)
 {
 	instruction_hook = ihook;

--- a/src/mame/drivers/apollo.cpp
+++ b/src/mame/drivers/apollo.cpp
@@ -151,7 +151,7 @@ void apollo_set_cpu_has_fpu(m68000_base_device *device, int onoff)
 	}
 	else
 	{
-		device->has_fpu = onoff;
+		device->set_fpu_enable(onoff);
 		DLOG1(("apollo_set_cpu_has_fpu: FPU has been %s", onoff ? "enabled" : "disabled"));
 	}
 }
@@ -242,7 +242,7 @@ READ32_MEMBER(apollo_state::apollo_instruction_hook)
 		idle_counter = 0;
 	}
 
-	if (!m_maincpu->has_fpu && !m_maincpu->pmmu_enabled && (m_maincpu->ir & 0xff00) == 0xf200)
+	if (!m_maincpu->get_fpu_enable() && !m_maincpu->pmmu_enabled && (m_maincpu->ir & 0xff00) == 0xf200)
 	{
 		// set APOLLO_CSR_SR_FP_TRAP in cpu status register for /sau7/self_test
 		apollo_csr_set_status_register(APOLLO_CSR_SR_FP_TRAP, APOLLO_CSR_SR_FP_TRAP);

--- a/src/mame/drivers/fccpu30.cpp
+++ b/src/mame/drivers/fccpu30.cpp
@@ -478,7 +478,7 @@ WRITE8_MEMBER (cpu30_state::flop_dmac_w){
 // TODO: Connect PC0, PC1, PC4 and PC7 to B5 and/or P2 connector
 READ8_MEMBER (cpu30_state::pit1c_r){
 	LOG(("%s\n", FUNCNAME));
-	m_maincpu->has_fpu = 1;    // Lets assume the FPCP is always installed ( which is default for 68030 atm )
+	m_maincpu->set_fpu_enable(1);    // Lets assume the FPCP is always installed ( which is default for 68030 atm )
 	return 0xff & ~FPCP_SENSE; // Should really be command line for the edge cases...
 }
 

--- a/src/mame/drivers/fccpu30.cpp
+++ b/src/mame/drivers/fccpu30.cpp
@@ -280,7 +280,7 @@ cpu30_state(const machine_config &mconfig, device_type type, const char *tag)
 protected:
 
 private:
-	required_device<cpu_device> m_maincpu;
+	required_device<m68000_base_device> m_maincpu;
 	required_device<ram_device> m_ram;
 
 	required_device<duscc68562_device> m_dusccterm;
@@ -473,11 +473,13 @@ WRITE8_MEMBER (cpu30_state::flop_dmac_w){
 	LOG(("%s(%02x)\n", FUNCNAME, data));
 }
 
-// PIT#1 Port C TODO: implement timer+port interrupts and 68882 sense
+#define FPCP_SENSE 0x40 /* Port C bit 6 is low if a Floating Point Co Processor is installed */
+// PIT#1 Port C TODO: implement timer+port interrupts
 // TODO: Connect PC0, PC1, PC4 and PC7 to B5 and/or P2 connector
 READ8_MEMBER (cpu30_state::pit1c_r){
 	LOG(("%s\n", FUNCNAME));
-	return 0xff;
+	m_maincpu->has_fpu = 1;    // Lets assume the FPCP is always installed ( which is default for 68030 atm )
+	return 0xff & ~FPCP_SENSE; // Should really be command line for the edge cases...
 }
 
 WRITE8_MEMBER (cpu30_state::pit1c_w){


### PR DESCRIPTION
I needed some way of indicating that the FPU socket is populated or not and found that the Apollo driver fiddles with the internal but public has_fpu parameter. I added methods to set and get it instead and moved it to the private section.
