### PR TITLE
Add more softlist documentation based off new dumps

### DIFF
--- a/hash/a2600.xml
+++ b/hash/a2600.xml
@@ -5036,7 +5036,7 @@ Info from Atariage and Atarimania
 	</software>
 
 	<software name="dodgeeme2" cloneof="dodgeem">
-		<description>Dodge 'Em (PAL, Alt)</description>
+		<description>Dodge 'Em (PAL, Earlier)</description>
 		<year>1980</year>
 		<publisher>Atari</publisher>
 		<part name="cart" interface="a2600_cart">
@@ -5047,7 +5047,7 @@ Info from Atariage and Atarimania
 	</software>
 
 	<software name="dodgeeme" cloneof="dodgeem">
-		<description>Dodge 'Em (PAL)</description>
+		<description>Dodge 'Em (PAL, Later)</description>
 		<year>1987</year>
 		<publisher>Atari</publisher>
 		<info name="serial" value="CX2637" />

--- a/hash/a2600.xml
+++ b/hash/a2600.xml
@@ -1954,7 +1954,7 @@ Info from Atariage and Atarimania
 	- add correct parent/clone relations for games with different descriptions
 	- add programmers and serial numbers in <info>
 	- verify PAL publishers when multiple ones were present (only 1 got picked up the most common, but this might have
-			lead to a bunch of mistakes, e.g. for Ariola releases)... case by case checks are needed!
+	  lead to a bunch of mistakes, e.g. for Ariola releases)... case by case checks are needed!
 	- verify games with multiple titles
 	-->
 

--- a/hash/a2600.xml
+++ b/hash/a2600.xml
@@ -1954,7 +1954,7 @@ Info from Atariage and Atarimania
 	- add correct parent/clone relations for games with different descriptions
 	- add programmers and serial numbers in <info>
 	- verify PAL publishers when multiple ones were present (only 1 got picked up the most common, but this might have
-	  lead to a bunch of mistakes, e.g. for Ariola releases)... case by case checks are needed!
+			lead to a bunch of mistakes, e.g. for Ariola releases)... case by case checks are needed!
 	- verify games with multiple titles
 	-->
 
@@ -5035,8 +5035,8 @@ Info from Atariage and Atarimania
 		</part>
 	</software>
 
-	<software name="dodgeeme" cloneof="dodgeem">
-		<description>Dodge 'Em (PAL)</description>
+	<software name="dodgeeme2" cloneof="dodgeem">
+		<description>Dodge 'Em (PAL, Alt)</description>
 		<year>1980</year>
 		<publisher>Atari</publisher>
 		<part name="cart" interface="a2600_cart">
@@ -5046,13 +5046,16 @@ Info from Atariage and Atarimania
 		</part>
 	</software>
 
-	<software name="dodgeemef" cloneof="dodgeem">
-		<description>Dodge 'Em (PAL) (Fixed?)</description>
-		<year>1980</year>
+	<software name="dodgeeme" cloneof="dodgeem">
+		<description>Dodge 'Em (PAL)</description>
+		<year>1987</year>
 		<publisher>Atari</publisher>
+		<info name="serial" value="CX2637" />
 		<part name="cart" interface="a2600_cart">
+												<feature name="pcb" value="C011885 REV F" />
+												<feature name="u1" value="" /> <!-- ROM -->
 			<dataarea name="rom" size="4096">
-				<rom name="dodge 'em (head on) (1980) (atari, carla meninsky) (cx2637, cx2637p) (pal) [fixed].bin" size="4096" crc="10cfc6c0" sha1="b26674d6e30d1a0bb2719b9bb1b3ccfa346260cf" offset="0" />
+				<rom name="AIP.u1" size="4096" crc="10cfc6c0" sha1="b26674d6e30d1a0bb2719b9bb1b3ccfa346260cf" offset="0" />
 			</dataarea>
 		</part>
 	</software>
@@ -7275,12 +7278,15 @@ Info from Atariage and Atarimania
 	</software>
 
 	<software name="haunted">
-		<description>Haunted House</description>
-		<year>1982</year>
+		<description>Haunted House (NTSC)</description>
+		<year>1981</year>
 		<publisher>Atari</publisher>
+		<info name="serial" value="CX2654" />
 		<part name="cart" interface="a2600_cart">
+			<feature name="pcb" value="C011885 REV F" />
+			<feature name="u1" value="" /> <!-- ROM -->
 			<dataarea name="rom" size="4096">
-				<rom name="haunted house (mystery mansion, graves' manor, nightmare manor) (1982) (atari, james andreasen - sears) (cx2654 - 49-75141).bin" size="4096" crc="aa62d961" sha1="1476c869619075b551b20f2c7f95b11e0d16aec1" offset="0" />
+				<rom name="054.u1" size="4096" crc="aa62d961" sha1="1476c869619075b551b20f2c7f95b11e0d16aec1" offset="0" />
 			</dataarea>
 		</part>
 	</software>
@@ -10655,11 +10661,14 @@ Info from Atariage and Atarimania
 
 	<software name="outlawe" cloneof="outlaw">
 		<description>Outlaw (PAL)</description>
-		<year>1978</year>
+		<year>1979</year>
 		<publisher>Atari</publisher>
+		<info name="serial" value="CX-2605-P" />
 		<part name="cart" interface="a2600_cart">
+			<feature name="pcb" value="C010789" />
+												<feature name="u1" value="" /> <!-- ROM -->
 			<dataarea name="rom" size="2048">
-				<rom name="outlaw (1978) (atari, david crane) (cx2605, cx2605p) (pal).bin" size="2048" crc="64f136d2" sha1="4a1514a7cf4279fded1b0db6f5b31818b9ff011c" offset="0" />
+				<rom name="B113.u1" size="2048" crc="64f136d2" sha1="4a1514a7cf4279fded1b0db6f5b31818b9ff011c" offset="0" />
 			</dataarea>
 		</part>
 	</software>
@@ -16865,11 +16874,15 @@ Info from Atariage and Atarimania
 
 	<software name="tubybird">
 		<description>Tuby Bird (PAL)</description>
-		<year>19??</year>
-		<publisher>Suntek</publisher>
+		<year>1983?</year>
+		<publisher>Suntek, Quelle</publisher>
+		<info name="serial" value="SS-020 (Suntek), 465.302 8 (Quelle)" />
+		<info name="alt_title" value="Vogel Flieh (Quelle)"/>
 		<part name="cart" interface="a2600_cart">
+			<feature name="pcb" value="21003A" />
+												<feature name="u1" value="" /> <!-- Epoxy blob ROM -->
 			<dataarea name="rom" size="4096">
-				<rom name="tuby bird (aka dolphin) (rainbow vision - suntek) (ss-020) (pal).bin" size="4096" crc="1ca034ca" sha1="f4f941b779bcb7902df0eb7cf6b985f56e751183" offset="0" />
+				<rom name="u1" size="4096" crc="1ca034ca" sha1="f4f941b779bcb7902df0eb7cf6b985f56e751183" offset="0" />
 			</dataarea>
 		</part>
 	</software>
@@ -17539,9 +17552,12 @@ Info from Atariage and Atarimania
 		<description>Weltraumtunnel (PAL)</description>
 		<year>1983</year>
 		<publisher>Quelle</publisher>
+		<info name="alt_title" value="Laaser Voley"/>
 		<part name="cart" interface="a2600_cart">
+			<feature name="pcb" value="0019" />
+												<feature name="u1" value="" /> <!-- Epoxy blob ROM -->
 			<dataarea name="rom" size="4096">
-				<rom name="weltraumtunnel (aka laser gates) (1983) (quelle) (292.651 7) (pal).bin" size="4096" crc="dc1d3627" sha1="c513703d638c01b0c26922d5e3e7bfb65ea597da" offset="0" />
+				<rom name="u1" size="4096" crc="dc1d3627" sha1="c513703d638c01b0c26922d5e3e7bfb65ea597da" offset="0" />
 			</dataarea>
 		</part>
 	</software>

--- a/hash/a2600.xml
+++ b/hash/a2600.xml
@@ -5052,8 +5052,8 @@ Info from Atariage and Atarimania
 		<publisher>Atari</publisher>
 		<info name="serial" value="CX2637" />
 		<part name="cart" interface="a2600_cart">
-												<feature name="pcb" value="C011885 REV F" />
-												<feature name="u1" value="" /> <!-- ROM -->
+			<feature name="pcb" value="C011885 REV F" />
+			<feature name="u1" value="" /> <!-- ROM -->
 			<dataarea name="rom" size="4096">
 				<rom name="AIP.u1" size="4096" crc="10cfc6c0" sha1="b26674d6e30d1a0bb2719b9bb1b3ccfa346260cf" offset="0" />
 			</dataarea>
@@ -10666,7 +10666,7 @@ Info from Atariage and Atarimania
 		<info name="serial" value="CX-2605-P" />
 		<part name="cart" interface="a2600_cart">
 			<feature name="pcb" value="C010789" />
-												<feature name="u1" value="" /> <!-- ROM -->
+			<feature name="u1" value="" /> <!-- ROM -->
 			<dataarea name="rom" size="2048">
 				<rom name="B113.u1" size="2048" crc="64f136d2" sha1="4a1514a7cf4279fded1b0db6f5b31818b9ff011c" offset="0" />
 			</dataarea>
@@ -16880,7 +16880,7 @@ Info from Atariage and Atarimania
 		<info name="alt_title" value="Vogel Flieh (Quelle)"/>
 		<part name="cart" interface="a2600_cart">
 			<feature name="pcb" value="21003A" />
-												<feature name="u1" value="" /> <!-- Epoxy blob ROM -->
+			<feature name="u1" value="" /> <!-- Epoxy blob ROM -->
 			<dataarea name="rom" size="4096">
 				<rom name="u1" size="4096" crc="1ca034ca" sha1="f4f941b779bcb7902df0eb7cf6b985f56e751183" offset="0" />
 			</dataarea>
@@ -17555,7 +17555,7 @@ Info from Atariage and Atarimania
 		<info name="alt_title" value="Laaser Voley"/>
 		<part name="cart" interface="a2600_cart">
 			<feature name="pcb" value="0019" />
-												<feature name="u1" value="" /> <!-- Epoxy blob ROM -->
+			<feature name="u1" value="" /> <!-- Epoxy blob ROM -->
 			<dataarea name="rom" size="4096">
 				<rom name="u1" size="4096" crc="dc1d3627" sha1="c513703d638c01b0c26922d5e3e7bfb65ea597da" offset="0" />
 			</dataarea>

--- a/hash/megadriv.xml
+++ b/hash/megadriv.xml
@@ -4816,11 +4816,12 @@ Info on Sega chip labels (from Sunbeam / Digital Corruption)
 		<description>Mega Games I (Euro)</description>
 		<year>1992</year>
 		<publisher>Sega</publisher>
+		<info name="release" value="19921001"/>
 		<part name="cart" interface="megadriv_cart">
-			<feature name="pcb" value="171-5978BA"/>
+			<feature name="pcb" value="171-5978BA"/> <!-- Also found with 171-5978B -->
 			<feature name="u1" value="MPR-15009 W50"/> <!-- location not really marked on PCB, using u1 for consistency -->
 			<dataarea name="rom" width="16" endianness="big" size="1048576">
-				<rom name="mpr-15009 w50.u1" size="1048576" crc="db753224" sha1="076df34a01094ce0893f32600e24323567e2a23b" offset="0x000000"/>
+				<rom name="MPR-15009 W50.u1" size="1048576" crc="db753224" sha1="076df34a01094ce0893f32600e24323567e2a23b" offset="0x000000"/>
 			</dataarea>
 		</part>
 	</software>
@@ -7385,11 +7386,12 @@ Info on Sega chip labels (from Sunbeam / Digital Corruption)
 		<description>Sonic the Hedgehog (Euro, USA)</description>
 		<year>1991</year>
 		<publisher>Sega</publisher>
+		<info name="release" value="19910623"/>
 		<part name="cart" interface="megadriv_cart">
 			<feature name="pcb" value="171-5703"/>
 			<feature name="ic1" value="MPR-13913-F, MPR-13913 W33"/>
 			<dataarea name="rom" width="16" endianness="big" size="524288">
-				<rom name="mpr-13913-f.ic1" size="524288" crc="f9394e97" sha1="6ddb7de1e17e7f6cdb88927bd906352030daa194" offset="0x000000"/>
+				<rom name="MPR-13913-F.ic1" size="524288" crc="f9394e97" sha1="6ddb7de1e17e7f6cdb88927bd906352030daa194" offset="0x000000"/>
 			</dataarea>
 		</part>
 	</software>

--- a/hash/n64.xml
+++ b/hash/n64.xml
@@ -10902,12 +10902,12 @@ clips onto the player's ear.
 		<info name="release" value="19991226"/>
 		<info name="alt_title" value="Turok - Rage Wars (Cart)"/>
 		<part name="cart" interface="n64_cart">
-      <feature name="pcb_model" value="NUS-01A-02" />
-      <feature name="u1" value="U1" /> <!-- ROM -->
-      <feature name="u2" value="U2" /> <!-- empty socket -->
-      <feature name="u3" value="U3" /> <!-- CIC -->
-      <feature name="cart_back_label" value="NUS-EUR-1" />
-      <dataarea name="rom" size="8388608">
+			<feature name="pcb_model" value="NUS-01A-02" />
+			<feature name="u1" value="U1" /> <!-- ROM -->
+			<feature name="u2" value="U2" /> <!-- empty socket -->
+			<feature name="u3" value="U3" /> <!-- CIC -->
+			<feature name="cart_back_label" value="NUS-EUR-1" />
+			<dataarea name="rom" size="8388608">
 				<rom name="NUS-NRWD-0.u1" size="8388608" crc="a2754ca4" sha1="51792351f4fd61c11f4b3b755a5eb8b9ea725b72" offset="000000" />
 			</dataarea>
 		</part>

--- a/hash/n64.xml
+++ b/hash/n64.xml
@@ -10899,9 +10899,16 @@ clips onto the player's ear.
 		<year>1999</year>
 		<publisher>Acclaim Entertainment</publisher>
 		<info name="serial" value="NUS-NRWD-NOE"/>
+		<info name="release" value="19991226"/>
+		<info name="alt_title" value="Turok - Rage Wars (Cart)"/>
 		<part name="cart" interface="n64_cart">
+      <feature name="pcb_model" value="NUS-01A-02" />
+      <feature name="u1" value="U1" /> <!-- ROM -->
+      <feature name="u2" value="U2" /> <!-- empty socket -->
+      <feature name="u3" value="U3" /> <!-- CIC -->
+      <feature name="cart_back_label" value="NUS-EUR-1" />
 			<dataarea name="rom" size="8388608">
-				<rom name="turok - legenden des verlorenen landes (germany).bin" size="8388608" crc="a2754ca4" sha1="51792351f4fd61c11f4b3b755a5eb8b9ea725b72" offset="000000" />
+				<rom name="NUS-NRWD-0.u1" size="8388608" crc="a2754ca4" sha1="51792351f4fd61c11f4b3b755a5eb8b9ea725b72" offset="000000" />
 			</dataarea>
 		</part>
 	</software>

--- a/hash/n64.xml
+++ b/hash/n64.xml
@@ -10907,7 +10907,7 @@ clips onto the player's ear.
       <feature name="u2" value="U2" /> <!-- empty socket -->
       <feature name="u3" value="U3" /> <!-- CIC -->
       <feature name="cart_back_label" value="NUS-EUR-1" />
-			<dataarea name="rom" size="8388608">
+      <dataarea name="rom" size="8388608">
 				<rom name="NUS-NRWD-0.u1" size="8388608" crc="a2754ca4" sha1="51792351f4fd61c11f4b3b755a5eb8b9ea725b72" offset="000000" />
 			</dataarea>
 		</part>

--- a/hash/snes.xml
+++ b/hash/snes.xml
@@ -33294,14 +33294,14 @@ Alternate board (XL-1)
 		<info name="serial" value="SNSP-LV-SCN" />
 		<info name="release" value="19931028" />
 		<part name="cart" interface="snes_cart">
-      <feature name="pcb" value="SHVC-1A0N-20" />
-      <feature name="u1" value="U1 MASK ROM" />
-      <feature name="u2" value="U2 CIC" />
-      <feature name="lockout" value="" />
-      <feature name="cart_model" value="SNSP-006" />
-      <feature name="cart_back_label" value="SNSP-UKV" />
-      <feature name="slot" value="lorom" />
-      <dataarea name="rom" size="1048576">
+			<feature name="pcb" value="SHVC-1A0N-20" />
+			<feature name="u1" value="U1 MASK ROM" />
+			<feature name="u2" value="U2 CIC" />
+			<feature name="lockout" value="" />
+			<feature name="cart_model" value="SNSP-006" />
+			<feature name="cart_back_label" value="SNSP-UKV" />
+			<feature name="slot" value="lorom" />
+			<dataarea name="rom" size="1048576">
 				<rom name="SPAL-LV-0.u1" size="1048576" crc="66989491" sha1="2bd4c2af6e5d7252d16342fd1a64454dca3ce557" offset="0x000000" />
 			</dataarea>
 		</part>

--- a/hash/snes.xml
+++ b/hash/snes.xml
@@ -59528,19 +59528,6 @@ to ensure nothing has been touched in the Retro Quest cart production in 2013/20
 		</part>
 	</software>
 
-  <!-- Most likely this is simply a bad dump of syvalionp. -->
-	<software name="syvalionp2" cloneof="syvalion">
-		<description>Syvalion (Euro, Prototype 2)</description>
-		<year>1992</year>
-		<publisher>Toshiba EMI</publisher>
-		<part name="cart" interface="snes_cart">
-			<feature name="slot" value="lorom" />
-			<dataarea name="rom" size="1048576">
-				<rom name="syvalion (europe) (beta).sfc" size="1048576" crc="be122755" sha1="ddfa611f1177f371c1107dbd8e8ecdb19011a232" offset="0x000000" status="baddump" />
-			</dataarea>
-		</part>
-	</software>
-
 	<software name="syvalion">
 		<description>Syvalion (Euro)</description>
 		<year>1992</year>

--- a/hash/snes.xml
+++ b/hash/snes.xml
@@ -9929,8 +9929,8 @@ more investigation needed...
 			<feature name="cart_back_label" value="920214" />
 			<feature name="slot" value="hirom" />
 			<dataarea name="rom" size="3145728">
-				<rom name="shvc-adkj-0 p0.u1" size="2097152" crc="5b606ef7" sha1="6b47084fba80ce07347010a7bb4af063f058936b" offset="0x000000" />
-				<rom name="shvc-adkj-0 p3.u2" size="1048576" crc="5b379b50" sha1="83b0507f1a84e686d76b5b869c1a5f2e22278097" offset="0x200000" />
+				<rom name="SHVC-ADKJ-0 P0.u1" size="2097152" crc="5b606ef7" sha1="6b47084fba80ce07347010a7bb4af063f058936b" offset="0x000000" />
+				<rom name="SHVC-ADKJ-0 P3.u2" size="1048576" crc="5b379b50" sha1="83b0507f1a84e686d76b5b869c1a5f2e22278097" offset="0x200000" />
 			</dataarea>
 			<dataarea name="nvram" size="8192">
 			</dataarea>
@@ -11930,7 +11930,7 @@ more investigation needed...
 			<feature name="cart_back_label" value="901121" />
 			<feature name="slot" value="lorom" />
 			<dataarea name="rom" size="1048576">
-				<rom name="shvc-eh-0.u1" size="1048576" crc="5cb9bc35" sha1="745ebf8164ca7be58829c6130c0e06f330cd0748" offset="0x000000" />
+				<rom name="SHVC-EH-0.u1" size="1048576" crc="5cb9bc35" sha1="745ebf8164ca7be58829c6130c0e06f330cd0748" offset="0x000000" />
 			</dataarea>
 			<dataarea name="nvram" size="8192">
 			</dataarea>
@@ -19340,17 +19340,17 @@ more investigation needed...
 		<description>Nintendo Scope 6 (Euro)</description>
 		<year>1992</year>
 		<publisher>Nintendo</publisher>
-		<info name="serial" value="SNSP-LR-FAH, SNSP-LR-FAH-1" />
+		<info name="serial" value="SNSP-LR-FAH, SNSP-LR-FAH-1, SNSP-LR-UKV" />
 		<part name="cart" interface="snes_cart">
 			<feature name="pcb" value="SHVC-1A0N-02" />
 			<feature name="u1" value="U1 MASK ROM" />
 			<feature name="u2" value="U2 CIC" />
 			<feature name="lockout" value="" />
 			<feature name="cart_model" value="SNSP-006" />
-			<feature name="cart_back_label" value="SNSP-FAH" />
+			<feature name="cart_back_label" value="SNSP-FAH, SNSP-UKV" />
 			<feature name="slot" value="lorom" />
 			<dataarea name="rom" size="1048576">
-				<rom name="spal-lr-0.u1" size="1048576" crc="b1859ca4" sha1="e5efb589e2dd783ef2d99f01caa866d8a3a04d16" offset="0x000000" />
+				<rom name="SPAL-LR-0.u1" size="1048576" crc="b1859ca4" sha1="e5efb589e2dd783ef2d99f01caa866d8a3a04d16" offset="0x000000" />
 			</dataarea>
 		</part>
 	</software>
@@ -25243,7 +25243,7 @@ more investigation needed...
 			<feature name="cart_back_label" value="920214" />
 			<feature name="slot" value="lorom" />
 			<dataarea name="rom" size="1048576">
-				<rom name="shvc-fc-0.u1" size="1048576" crc="7c94c86c" sha1="9d60d55b690c02413aa668ed9da196b4f1449e81" offset="0x000000" />
+				<rom name="SHVC-FC-0.u1" size="1048576" crc="7c94c86c" sha1="9d60d55b690c02413aa668ed9da196b4f1449e81" offset="0x000000" />
 			</dataarea>
 			<dataarea name="nvram" size="8192">
 			</dataarea>
@@ -28147,7 +28147,7 @@ Alternate board (XL-1)
 			<feature name="cart_back_label" value="SNSP-EUR, SNSP-FAH" />
 			<feature name="slot" value="lorom" />
 			<dataarea name="rom" size="524288">
-				<rom name="spal-fs-0.u1" size="524288" crc="442c47cb" sha1="6eb6dd6da1e8eefad24c30b59ededbd671b9db2c" offset="0x000000" />
+				<rom name="SPAL-FS-0.u1" size="524288" crc="442c47cb" sha1="6eb6dd6da1e8eefad24c30b59ededbd671b9db2c" offset="0x000000" />
 			</dataarea>
 		</part>
 	</software>
@@ -33283,6 +33283,26 @@ Alternate board (XL-1)
 				<rom name="shvc-7m-1.u1" size="2097152" crc="cb148365" sha1="a90412a32828fdf02968bf7b1f2efd57453ef031" offset="0x000000" />
 			</dataarea>
 			<dataarea name="nvram" size="8192">
+			</dataarea>
+		</part>
+	</software>
+  
+  <software name="lostvik">
+		<description>The Lost Vikings (Euro)</description>
+		<year>1993</year>
+		<publisher>Interplay</publisher>
+		<info name="serial" value="SNSP-LV-SCN" />
+		<info name="release" value="19931028" />
+		<part name="cart" interface="snes_cart">
+      <feature name="pcb" value="SHVC-1A0N-20" />
+			<feature name="u1" value="U1 MASK ROM" />
+			<feature name="u2" value="U2 CIC" />
+			<feature name="lockout" value="" />
+			<feature name="cart_model" value="SNSP-006" />
+			<feature name="cart_back_label" value="SNSP-UKV" />
+			<feature name="slot" value="lorom" />
+			<dataarea name="rom" size="1048576">
+				<rom name="SPAL-LV-0.u1" size="1048576" crc="66989491" sha1="2bd4c2af6e5d7252d16342fd1a64454dca3ce557" offset="0x000000" />
 			</dataarea>
 		</part>
 	</software>
@@ -46109,18 +46129,6 @@ to ensure nothing has been touched in the Retro Quest cart production in 2013/20
 			<feature name="slot" value="lorom" />
 			<dataarea name="rom" size="1048576">
 				<rom name="lost vikings ii, the (usa).sfc" size="1048576" crc="3aa01dbd" sha1="7a461513fcea58e3c8c9dbaa431ab6635dbb3ffd" offset="0x000000" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="lostvik">
-		<description>The Lost Vikings (Euro)</description>
-		<year>1993</year>
-		<publisher>Interplay</publisher>
-		<part name="cart" interface="snes_cart">
-			<feature name="slot" value="lorom" />
-			<dataarea name="rom" size="1048576">
-				<rom name="lost vikings, the (europe).sfc" size="1048576" crc="66989491" sha1="2bd4c2af6e5d7252d16342fd1a64454dca3ce557" offset="0x000000" />
 			</dataarea>
 		</part>
 	</software>

--- a/hash/snes.xml
+++ b/hash/snes.xml
@@ -33295,13 +33295,13 @@ Alternate board (XL-1)
 		<info name="release" value="19931028" />
 		<part name="cart" interface="snes_cart">
       <feature name="pcb" value="SHVC-1A0N-20" />
-			<feature name="u1" value="U1 MASK ROM" />
-			<feature name="u2" value="U2 CIC" />
-			<feature name="lockout" value="" />
-			<feature name="cart_model" value="SNSP-006" />
-			<feature name="cart_back_label" value="SNSP-UKV" />
-			<feature name="slot" value="lorom" />
-			<dataarea name="rom" size="1048576">
+      <feature name="u1" value="U1 MASK ROM" />
+      <feature name="u2" value="U2 CIC" />
+      <feature name="lockout" value="" />
+      <feature name="cart_model" value="SNSP-006" />
+      <feature name="cart_back_label" value="SNSP-UKV" />
+      <feature name="slot" value="lorom" />
+      <dataarea name="rom" size="1048576">
 				<rom name="SPAL-LV-0.u1" size="1048576" crc="66989491" sha1="2bd4c2af6e5d7252d16342fd1a64454dca3ce557" offset="0x000000" />
 			</dataarea>
 		</part>


### PR DESCRIPTION
Carts for a2600, megadriv, n64 and snes got redumped recently by TeamEurope. Add in newfound information from those dumps to the softlists.

Also remove syvalionp2 as it's simply a bad dump of syvalionp.