### PR TITLE
SDL2 include folder for boundled edition

### DIFF
--- a/makefile
+++ b/makefile
@@ -1513,12 +1513,7 @@ generate: \
 		$(patsubst %.po,%.mo,$(call rwildcard, language/, *.po)) \
 		$(patsubst $(SRC)/%.lay,$(GENDIR)/%.lh,$(LAYOUTS)) \
 		$(GENDIR)/mame/drivers/ymmu100.hxx \
-		$(SRC)/devices/cpu/m68000/m68kops.cpp \
-		$(GENDIR)/includes/SDL2
-
-$(GENDIR)/includes/SDL2:
-	-$(call MKDIR,$@)
-	-$(call COPY,3rdparty/SDL2/include/,$(GENDIR)/includes/SDL2)
+		$(SRC)/devices/cpu/m68000/m68kops.cpp
 
 ifneq ($(NEW_GIT_VERSION),$(OLD_GIT_VERSION))
 stale:

--- a/scripts/src/osd/sdl.lua
+++ b/scripts/src/osd/sdl.lua
@@ -241,7 +241,10 @@ end
 
 if _OPTIONS["with-bundled-sdl2"]~=nil then
 	includedirs {
-		GEN_DIR .. "includes",
+		MAME_DIR .. "3rdparty/SDL2/include",
+	}
+	defines {
+		"SDL2_BOUNDLED",
 	}
 end
 if BASE_TARGETOS=="unix" then

--- a/src/osd/modules/font/font_sdl.cpp
+++ b/src/osd/modules/font/font_sdl.cpp
@@ -15,11 +15,12 @@
 #include "fileio.h"
 #include "unicode.h"
 
-#ifdef SDLMAME_EMSCRIPTEN
-#include <SDL_ttf.h>
+#if defined(SDLMAME_EMSCRIPTEN) || defined(SDL2_BOUNDLED)
+#include <SDL_ttf>
 #else
 #include <SDL2/SDL_ttf.h>
 #endif
+
 #if !defined(SDLMAME_HAIKU) && !defined(SDLMAME_EMSCRIPTEN)
 #include <fontconfig/fontconfig.h>
 #endif

--- a/src/osd/modules/input/input_common.cpp
+++ b/src/osd/modules/input/input_common.cpp
@@ -33,7 +33,11 @@
 #define KEY_TRANS_ENTRY1(mame, sdlsc, sdlkey, disc, virtual, uwp, ascii)     { ITEM_ID_##mame, KEY_ ## disc, virtual, ascii, "ITEM_ID_"#mame, (char*) #mame }
 #elif defined(OSD_SDL)
 // SDL include
+#if defined(SDL2_BOUNDLED)
+#include <SDL.h>
+#else
 #include <SDL2/SDL.h>
+#endif
 #define KEY_TRANS_ENTRY0(mame, sdlsc, sdlkey, disc, virtual, uwp, ascii, UI) { ITEM_ID_##mame, SDL_SCANCODE_ ## sdlsc, SDLK_ ## sdlkey, ascii, "ITEM_ID_"#mame, (char *) UI }
 #define KEY_TRANS_ENTRY1(mame, sdlsc, sdlkey, disc, virtual, uwp, ascii)     { ITEM_ID_##mame, SDL_SCANCODE_ ## sdlsc, SDLK_ ## sdlkey, ascii, "ITEM_ID_"#mame, (char*) #mame }
 #elif defined(OSD_UWP)

--- a/src/osd/modules/input/input_sdl.cpp
+++ b/src/osd/modules/input/input_sdl.cpp
@@ -17,7 +17,11 @@
 #if defined(SDLMAME_SDL2)
 
 // standard sdl header
+#if defined(SDL2_BOUNDLED)
+#include <SDL.h>
+#else
 #include <SDL2/SDL.h>
+#endif
 #include <ctype.h>
 // ReSharper disable once CppUnusedIncludeDirective
 #include <stddef.h>

--- a/src/osd/modules/input/input_sdlcommon.cpp
+++ b/src/osd/modules/input/input_sdlcommon.cpp
@@ -14,7 +14,11 @@
 #if defined(OSD_SDL)
 
 // standard sdl header
+#if defined(SDL2_BOUNDLED)
+#include <SDL.h>
+#else
 #include <SDL2/SDL.h>
+#endif
 #include <ctype.h>
 #include <stddef.h>
 #include <mutex>

--- a/src/osd/modules/input/input_x11.cpp
+++ b/src/osd/modules/input/input_x11.cpp
@@ -19,7 +19,12 @@
 #include <X11/Xutil.h>
 
 // standard sdl header
+#if defined(SDL2_BOUNDLED)
+#include <SDL.h>
+#else
 #include <SDL2/SDL.h>
+#endif
+
 #include <ctype.h>
 #include <stddef.h>
 #include <mutex>

--- a/src/osd/modules/lib/osdlib_unix.cpp
+++ b/src/osd/modules/lib/osdlib_unix.cpp
@@ -24,7 +24,11 @@
 #include "osdcore.h"
 #include "osdlib.h"
 
+#if defined(SDL2_BOUNDLED)
+#include <SDL.h>
+#else
 #include <SDL2/SDL.h>
+#endif
 
 //============================================================
 //  osd_getenv

--- a/src/osd/modules/monitor/monitor_sdl.cpp
+++ b/src/osd/modules/monitor/monitor_sdl.cpp
@@ -11,7 +11,11 @@
 #if defined(OSD_SDL)
 
 #include <algorithm>
+#if defined(SDL2_BOUNDLED)
+#include <SDL.h>
+#else
 #include <SDL2/SDL.h>
+#endif
 
 #include "modules/osdwindow.h"
 #include "monitor_common.h"

--- a/src/osd/modules/opengl/osd_opengl.h
+++ b/src/osd/modules/opengl/osd_opengl.h
@@ -33,14 +33,22 @@
 			#endif
 		#endif
 	#else
+	#if defined(SDL2_BOUNDLED)
+	#include <SDL_version.h>
+	#else
 	#include <SDL2/SDL_version.h>
+	#endif
 
 	#if (SDL_VERSION_ATLEAST(1,2,10))
 	#if defined(SDLMAME_WIN32)
 		// Avoid that winnt.h (included via sdl_opengl.h, windows.h, windef.h includes intrin.h
 		#define __INTRIN_H_
 	#endif
+	#if defined(SDL2_BOUNDLED)
+	#include <SDL_opengl.h>
+	#else
 	#include <SDL2/SDL_opengl.h>
+	#endif
 	#endif
 	#endif
 

--- a/src/osd/modules/render/draw13.h
+++ b/src/osd/modules/render/draw13.h
@@ -23,7 +23,11 @@ typedef uint64_t HashT;
 #endif
 
 // standard SDL headers
+#if defined(SDL2_BOUNDLED)
+#include <SDL.h>
+#else
 #include <SDL2/SDL.h>
+#endif
 
 struct quad_setup_data
 {

--- a/src/osd/modules/render/drawbgfx.cpp
+++ b/src/osd/modules/render/drawbgfx.cpp
@@ -9,9 +9,10 @@
 // standard windows headers
 #define WIN32_LEAN_AND_MEAN
 #include <windows.h>
-#if defined(SDLMAME_WIN32)
-#include <SDL2/SDL_syswm.h>
 #endif
+
+#if defined(SDL2_BOUNDLED)
+#include <SDL_syswm.h>
 #else
 #include <SDL2/SDL_syswm.h>
 #endif

--- a/src/osd/modules/render/drawogl.cpp
+++ b/src/osd/modules/render/drawogl.cpp
@@ -24,7 +24,11 @@
 #ifndef OSD_WINDOWS
 // standard SDL headers
 #define TOBEMIGRATED 1
+#if defined(SDL2_BOUNDLED)
+#include <SDL.h>
+#else
 #include <SDL2/SDL.h>
+#endif
 #endif
 
 #include "modules/lib/osdlib.h"

--- a/src/osd/modules/render/drawsdl.cpp
+++ b/src/osd/modules/render/drawsdl.cpp
@@ -20,7 +20,11 @@
 #include "rendersw.hxx"
 
 // standard SDL headers
+#if defined(SDL2_BOUNDLED)
+#include <SDL.h>
+#else
 #include <SDL2/SDL.h>
+#endif
 
 // OSD headers
 #include "osdsdl.h"

--- a/src/osd/modules/render/drawsdl.h
+++ b/src/osd/modules/render/drawsdl.h
@@ -15,7 +15,11 @@
 #ifndef __DRAWSDL1__
 #define __DRAWSDL1__
 
+#if defined(SDL2_BOUNDLED)
+#include <SDL.h>
+#else
 #include <SDL2/SDL.h>
+#endif
 
 /* renderer_sdl2 is the information about SDL for the current screen */
 class renderer_sdl1 : public osd_renderer

--- a/src/osd/modules/render/sdlglcontext.h
+++ b/src/osd/modules/render/sdlglcontext.h
@@ -13,7 +13,12 @@
 #ifndef __SDL_GL_CONTEXT__
 #define __SDL_GL_CONTEXT__
 
+#if defined(SDL2_BOUNDLED)
+#include <SDL.h>
+#else
 #include <SDL2/SDL.h>
+#endif
+
 #include "modules/opengl/osd_opengl.h"
 
 class sdl_gl_context : public osd_gl_context

--- a/src/osd/modules/sound/direct_sound.cpp
+++ b/src/osd/modules/sound/direct_sound.cpp
@@ -30,7 +30,11 @@
 
 #ifdef SDLMAME_WIN32
 #include "../../sdl/osdsdl.h"
+#if defined(SDL2_BOUNDLED)
+#include <SDL_syswm.h>
+#else
 #include <SDL2/SDL_syswm.h>
+#endif
 #include "../../sdl/window.h"
 #else
 #include "winmain.h"

--- a/src/osd/modules/sound/sdl_sound.cpp
+++ b/src/osd/modules/sound/sdl_sound.cpp
@@ -14,7 +14,11 @@
 #if (defined(OSD_SDL) || defined(USE_SDL_SOUND))
 
 // standard sdl header
+#if defined(SDL2_BOUNDLED)
+#include <SDL.h>
+#else
 #include <SDL2/SDL.h>
+#endif
 
 // MAME headers
 #include "emu.h"

--- a/src/osd/osdcore.cpp
+++ b/src/osd/osdcore.cpp
@@ -6,7 +6,7 @@
 #include <chrono>
 
 #if defined(SDLMAME_ANDROID)
-#include <SDL2/SDL.h>
+#include <SDL.h>
 #endif
 static const int MAXSTACK = 10;
 static osd_output *m_stack[MAXSTACK];

--- a/src/osd/sdl/sdlmain.cpp
+++ b/src/osd/sdl/sdlmain.cpp
@@ -33,7 +33,11 @@
 #include <windows.h>
 #endif
 
+#if defined(SDL2_BOUNDLED)
+#include <SDL.h>
+#else
 #include <SDL2/SDL.h>
+#endif
 
 // MAME headers
 #include "osdepend.h"

--- a/src/osd/sdl/video.cpp
+++ b/src/osd/sdl/video.cpp
@@ -7,7 +7,11 @@
 //  SDLMAME by Olivier Galibert and R. Belmont
 //
 //============================================================
+#if defined(SDL2_BOUNDLED)
+#include <SDL.h>
+#else
 #include <SDL2/SDL.h>
+#endif
 
 // MAME headers
 #include "emu.h"

--- a/src/osd/sdl/window.cpp
+++ b/src/osd/sdl/window.cpp
@@ -14,7 +14,11 @@
 #endif
 
 // standard SDL headers
+#if defined(SDL2_BOUNDLED)
+#include <SDL.h>
+#else
 #include <SDL2/SDL.h>
+#endif
 
 // standard C headers
 #include <math.h>


### PR DESCRIPTION
PLEASE DO NOT MERGE THIS BEFORE RELEASE

Since previous hack to copy include files in generated folder was not very good (one reason is that in case of change it will not be updated for example) this build now take into consideration if we are using boundled SDL2 or one from system. 

Boundled is used for all Android builds and VS2015 when OSD=sdl is used.