### PR TITLE
Fix division by zero in update_graphics

### DIFF
--- a/src/devices/video/upd7220.cpp
+++ b/src/devices/video/upd7220.cpp
@@ -641,7 +641,7 @@ upd7220_device::upd7220_device(const machine_config &mconfig, const char *tag, d
 	m_br(0),
 	m_ctop(0),
 	m_cbot(0),
-	m_lr(0),
+	m_lr(1),
 	m_disp(0),
 	m_gchr(0),
 	m_bitmap_mod(0),


### PR DESCRIPTION
Calculation of 'addr' in inner for() loop of 'update_graphics": division by zero occurrs if mixed = false and m_lr = 0.