### PR TITLE
Seibu sound device cleanup (nw)

### DIFF
--- a/src/mame/audio/seibu.h
+++ b/src/mame/audio/seibu.h
@@ -26,19 +26,10 @@
 ***************************************************************************/
 
 #include "cpu/z80/z80.h"
-#include "sound/3812intf.h"
-#include "sound/ym2151.h"
-#include "sound/2203intf.h"
-#include "sound/okim6295.h"
+#include "sound/okiadpcm.h"
 
 ADDRESS_MAP_EXTERN(seibu_sound_decrypted_opcodes_map, 8);
 ADDRESS_MAP_EXTERN(seibu_sound_map, 8);
-ADDRESS_MAP_EXTERN(seibu2_sound_map, 8);
-ADDRESS_MAP_EXTERN(seibu2_airraid_sound_map, 8);
-ADDRESS_MAP_EXTERN(seibu2_raiden2_sound_map, 8);
-ADDRESS_MAP_EXTERN(seibu_newzeroteam_sound_map, 8);
-ADDRESS_MAP_EXTERN(seibu3_sound_map, 8);
-ADDRESS_MAP_EXTERN(seibu3_adpcm_sound_map, 8);
 
 class seibu_sound_device : public device_t
 {
@@ -46,12 +37,19 @@ public:
 	seibu_sound_device(const machine_config &mconfig, const char *tag, device_t *owner, uint32_t clock);
 	~seibu_sound_device() {}
 
+	// static configuration
+	static void set_cpu_tag_and_encryption(device_t &device, const char *tag, int mode);
+	template<class _Object> static devcb_base &set_ym_read_callback(device_t &device, _Object object)  { return downcast<seibu_sound_device &>(device).m_ym_read_cb.set_callback(object); }
+	template<class _Object> static devcb_base &set_ym_write_callback(device_t &device, _Object object) { return downcast<seibu_sound_device &>(device).m_ym_write_cb.set_callback(object); }
+
 	DECLARE_READ16_MEMBER( main_word_r );
 	DECLARE_WRITE16_MEMBER( main_word_w );
 	DECLARE_WRITE16_MEMBER( main_mustb_w );
 	DECLARE_WRITE8_MEMBER( irq_clear_w );
 	DECLARE_WRITE8_MEMBER( rst10_ack_w );
 	DECLARE_WRITE8_MEMBER( rst18_ack_w );
+	DECLARE_READ8_MEMBER( ym_r );
+	DECLARE_WRITE8_MEMBER( ym_w );
 	DECLARE_WRITE8_MEMBER( bank_w );
 	DECLARE_WRITE8_MEMBER( coin_w );
 	WRITE_LINE_MEMBER( fm_irqhandler );
@@ -61,7 +59,6 @@ public:
 	DECLARE_WRITE8_MEMBER( pending_w );
 
 	static void apply_decrypt(uint8_t *rom, uint8_t *opcodes, int length);
-	void set_encryption(int mode);
 	uint8_t *get_custom_decrypt();
 	void update_irq_lines(int param);
 
@@ -70,12 +67,16 @@ protected:
 	virtual void device_start() override;
 	virtual void device_reset() override;
 
-	private:
+private:
 	int m_encryption_mode;
 	std::unique_ptr<uint8_t[]> m_decrypted_opcodes;
 
+	// device callbacks
+	devcb_read8 m_ym_read_cb;
+	devcb_write8 m_ym_write_cb;
+
 	// internal state
-	device_t *m_sound_cpu;
+	required_device<cpu_device> m_sound_cpu;
 	required_region_ptr<uint8_t> m_sound_rom;
 	uint8_t m_main2sub[2];
 	uint8_t m_sub2main[2];
@@ -117,7 +118,7 @@ protected:
 	// sound stream update overrides
 	virtual void sound_stream_update(sound_stream &stream, stream_sample_t **inputs, stream_sample_t **outputs, int samples) override;
 
-	private:
+private:
 	// internal state
 	oki_adpcm_state m_adpcm;
 	sound_stream *m_stream;
@@ -154,128 +155,22 @@ extern const device_type SEIBU_ADPCM;
 	PORT_BIT( 0x40, IP_ACTIVE_LOW, IPT_UNUSED )                     \
 	PORT_BIT( 0x80, IP_ACTIVE_LOW, IPT_UNUSED )
 
+#define MCFG_SEIBU_SOUND_CPU(_audiocputag) \
+	seibu_sound_device::set_cpu_tag_and_encryption(*device, "^" _audiocputag, 0);
 
-#define SEIBU_SOUND_SYSTEM_CPU(freq)                                \
-	MCFG_CPU_ADD("audiocpu", Z80, freq)                             \
-	MCFG_CPU_PROGRAM_MAP(seibu_sound_map)                           \
-	MCFG_DEVICE_ADD("seibu_sound", SEIBU_SOUND, 0)
+#define MCFG_SEIBU_SOUND_CPU_ENCRYPTED_LOW(_audiocputag) \
+	seibu_sound_device::set_cpu_tag_and_encryption(*device, "^" _audiocputag, 1);
 
-#define SEIBU2_SOUND_SYSTEM_CPU(freq)                               \
-	MCFG_CPU_ADD("audiocpu", Z80, freq)                             \
-	MCFG_CPU_PROGRAM_MAP(seibu2_sound_map)                          \
-	MCFG_DEVICE_ADD("seibu_sound", SEIBU_SOUND, 0)
+#define MCFG_SEIBU_SOUND_CPU_ENCRYPTED_CUSTOM(_audiocputag) \
+	seibu_sound_device::set_cpu_tag_and_encryption(*device, "^" _audiocputag, 2);
 
-#define SEIBU2_AIRRAID_SOUND_SYSTEM_CPU(freq)                       \
-	MCFG_CPU_ADD("audiocpu", Z80, freq)                             \
-	MCFG_CPU_PROGRAM_MAP(seibu2_airraid_sound_map)                  \
-	MCFG_DEVICE_ADD("seibu_sound", SEIBU_SOUND, 0)
+#define MCFG_SEIBU_SOUND_CPU_ENCRYPTED_FULL(_audiocputag) \
+	seibu_sound_device::set_cpu_tag_and_encryption(*device, "^" _audiocputag, 3);
 
-#define SEIBU2_RAIDEN2_SOUND_SYSTEM_CPU(freq)                       \
-	MCFG_CPU_ADD("audiocpu",  Z80, freq)                            \
-	MCFG_CPU_PROGRAM_MAP(seibu2_raiden2_sound_map)                  \
-	MCFG_DEVICE_ADD("seibu_sound", SEIBU_SOUND, 0)
+#define MCFG_SEIBU_SOUND_YM_READ_CB(_devcb) \
+	devcb = &seibu_sound_device::set_ym_read_callback(*device, DEVCB_##_devcb);
 
-#define SEIBU_NEWZEROTEAM_SOUND_SYSTEM_CPU(freq)                    \
-	MCFG_CPU_ADD("audiocpu", Z80, freq)                             \
-	MCFG_CPU_PROGRAM_MAP(seibu_newzeroteam_sound_map)               \
-	MCFG_DEVICE_ADD("seibu_sound", SEIBU_SOUND, 0)
-
-#define SEIBU3_SOUND_SYSTEM_CPU(freq)                               \
-	MCFG_CPU_ADD("audiocpu", Z80, freq)                             \
-	MCFG_CPU_PROGRAM_MAP(seibu3_sound_map)                          \
-	MCFG_DEVICE_ADD("seibu_sound", SEIBU_SOUND, 0)
-
-#define SEIBU3A_SOUND_SYSTEM_CPU(freq)                              \
-	MCFG_CPU_ADD("audiocpu", Z80, freq)                             \
-	MCFG_CPU_PROGRAM_MAP(seibu3_adpcm_sound_map)                    \
-	MCFG_DEVICE_ADD("seibu_sound", SEIBU_SOUND, 0)
-
-#define SEIBU_SOUND_SYSTEM_ENCRYPTED_LOW()                          \
-	MCFG_DEVICE_MODIFY("seibu_sound")                               \
-	downcast<seibu_sound_device *>(device)->set_encryption(1);      \
-	MCFG_DEVICE_MODIFY("audiocpu")                                  \
-	MCFG_CPU_DECRYPTED_OPCODES_MAP(seibu_sound_decrypted_opcodes_map)
-
-#define SEIBU_SOUND_SYSTEM_ENCRYPTED_FULL()                         \
-	MCFG_DEVICE_MODIFY("seibu_sound")                               \
-	downcast<seibu_sound_device *>(device)->set_encryption(2);      \
-	MCFG_DEVICE_MODIFY("audiocpu")                                  \
-	MCFG_CPU_DECRYPTED_OPCODES_MAP(seibu_sound_decrypted_opcodes_map)
-
-#define SEIBU_SOUND_SYSTEM_ENCRYPTED_CUSTOM()                       \
-	MCFG_DEVICE_MODIFY("seibu_sound")                               \
-	downcast<seibu_sound_device *>(device)->set_encryption(3);      \
-	MCFG_DEVICE_MODIFY("audiocpu")                                  \
-	MCFG_CPU_DECRYPTED_OPCODES_MAP(seibu_sound_decrypted_opcodes_map)
-
-#define SEIBU_SOUND_SYSTEM_YM3812_INTERFACE(freq1,freq2)            \
-	MCFG_SPEAKER_STANDARD_MONO("mono")                              \
-																	\
-	MCFG_SOUND_ADD("ymsnd", YM3812, freq1)                          \
-	MCFG_YM3812_IRQ_HANDLER(DEVWRITELINE("seibu_sound", seibu_sound_device, fm_irqhandler)) \
-	MCFG_SOUND_ROUTE(ALL_OUTPUTS, "mono", 1.0)                      \
-																	\
-	MCFG_OKIM6295_ADD("oki", freq2, OKIM6295_PIN7_LOW)              \
-	MCFG_SOUND_ROUTE(ALL_OUTPUTS, "mono", 0.40)
-
-#define SEIBU_SOUND_SYSTEM_YM3812_RAIDEN_INTERFACE(freq1,freq2)     \
-	MCFG_SPEAKER_STANDARD_MONO("mono")                              \
-																	\
-	MCFG_SOUND_ADD("ymsnd", YM3812, freq1)                          \
-	MCFG_YM3812_IRQ_HANDLER(DEVWRITELINE("seibu_sound", seibu_sound_device, fm_irqhandler)) \
-	MCFG_SOUND_ROUTE(ALL_OUTPUTS, "mono", 1.0)                      \
-																	\
-	MCFG_OKIM6295_ADD("oki", freq2, OKIM6295_PIN7_HIGH)             \
-	MCFG_SOUND_ROUTE(ALL_OUTPUTS, "mono", 1.0)
-
-#define SEIBU_SOUND_SYSTEM_YM2151_INTERFACE(freq1,freq2)            \
-	MCFG_SPEAKER_STANDARD_MONO("mono")                              \
-																	\
-	MCFG_YM2151_ADD("ymsnd", freq1)                                 \
-	MCFG_YM2151_IRQ_HANDLER(DEVWRITELINE("seibu_sound", seibu_sound_device, fm_irqhandler)) \
-	MCFG_SOUND_ROUTE(0, "mono", 0.50)                               \
-	MCFG_SOUND_ROUTE(1, "mono", 0.50)                               \
-																	\
-	MCFG_OKIM6295_ADD("oki", freq2, OKIM6295_PIN7_LOW)              \
-	MCFG_SOUND_ROUTE(ALL_OUTPUTS, "mono", 0.40)
-
-#define SEIBU_AIRRAID_SOUND_SYSTEM_YM2151_INTERFACE(freq1)          \
-	MCFG_SPEAKER_STANDARD_MONO("mono")                              \
-																	\
-	MCFG_YM2151_ADD("ymsnd", freq1)                                 \
-	MCFG_YM2151_IRQ_HANDLER(DEVWRITELINE("seibu_sound", seibu_sound_device, fm_irqhandler)) \
-	MCFG_SOUND_ROUTE(0, "mono", 0.50)                               \
-	MCFG_SOUND_ROUTE(1, "mono", 0.50)
-
-#define SEIBU_SOUND_SYSTEM_YM2151_RAIDEN2_INTERFACE(freq1, freq2, regiona, regionb) \
-	MCFG_SPEAKER_STANDARD_MONO("mono")                              \
-																	\
-	MCFG_YM2151_ADD("ymsnd", freq1)                                 \
-	MCFG_YM2151_IRQ_HANDLER(DEVWRITELINE("seibu_sound", seibu_sound_device, fm_irqhandler)) \
-	MCFG_SOUND_ROUTE(0, "mono", 0.50)                               \
-	MCFG_SOUND_ROUTE(1, "mono", 0.50)                               \
-																	\
-	MCFG_OKIM6295_ADD("oki1", freq2, OKIM6295_PIN7_HIGH)            \
-	MCFG_SOUND_ROUTE(ALL_OUTPUTS, "mono", 0.40)                     \
-																	\
-	MCFG_OKIM6295_ADD("oki2", freq2, OKIM6295_PIN7_HIGH)            \
-	MCFG_SOUND_ROUTE(ALL_OUTPUTS, "mono", 0.40)
-
-#define SEIBU_SOUND_SYSTEM_YM2203_INTERFACE(freq)                   \
-	MCFG_SPEAKER_STANDARD_MONO("mono")                              \
-																	\
-	MCFG_SOUND_ADD("ym1", YM2203, freq)                             \
-	MCFG_YM2203_IRQ_HANDLER(DEVWRITELINE("seibu_sound", seibu_sound_device, fm_irqhandler)) \
-	MCFG_SOUND_ROUTE(ALL_OUTPUTS, "mono", 0.15)                     \
-																	\
-	MCFG_SOUND_ADD("ym2", YM2203, freq)                             \
-	MCFG_SOUND_ROUTE(ALL_OUTPUTS, "mono", 0.15)
-
-#define SEIBU_SOUND_SYSTEM_ADPCM_INTERFACE                          \
-	MCFG_SOUND_ADD("adpcm1", SEIBU_ADPCM, 8000)                     \
-	MCFG_SOUND_ROUTE(ALL_OUTPUTS, "mono", 0.40)                     \
-																	\
-	MCFG_SOUND_ADD("adpcm2", SEIBU_ADPCM, 8000)                     \
-	MCFG_SOUND_ROUTE(ALL_OUTPUTS, "mono", 0.40)
+#define MCFG_SEIBU_SOUND_YM_WRITE_CB(_devcb) \
+	devcb = &seibu_sound_device::set_ym_write_callback(*device, DEVCB_##_devcb);
 
 /**************************************************************************/

--- a/src/mame/audio/seibu.h
+++ b/src/mame/audio/seibu.h
@@ -161,10 +161,10 @@ extern const device_type SEIBU_ADPCM;
 #define MCFG_SEIBU_SOUND_CPU_ENCRYPTED_LOW(_audiocputag) \
 	seibu_sound_device::set_cpu_tag_and_encryption(*device, "^" _audiocputag, 1);
 
-#define MCFG_SEIBU_SOUND_CPU_ENCRYPTED_CUSTOM(_audiocputag) \
+#define MCFG_SEIBU_SOUND_CPU_ENCRYPTED_FULL(_audiocputag) \
 	seibu_sound_device::set_cpu_tag_and_encryption(*device, "^" _audiocputag, 2);
 
-#define MCFG_SEIBU_SOUND_CPU_ENCRYPTED_FULL(_audiocputag) \
+#define MCFG_SEIBU_SOUND_CPU_ENCRYPTED_CUSTOM(_audiocputag) \
 	seibu_sound_device::set_cpu_tag_and_encryption(*device, "^" _audiocputag, 3);
 
 #define MCFG_SEIBU_SOUND_YM_READ_CB(_devcb) \

--- a/src/mame/drivers/airraid.cpp
+++ b/src/mame/drivers/airraid.cpp
@@ -150,6 +150,7 @@ Stephh's notes (based on the game Z80 code and some tests) :
 
 #include "emu.h"
 #include "cpu/z80/z80.h"
+#include "sound/ym2151.h"
 #include "audio/seibu.h"
 #include "video/airraid_dev.h"
 
@@ -277,6 +278,23 @@ static ADDRESS_MAP_START( decrypted_opcodes_map, AS_DECRYPTED_OPCODES, 8, airrai
 	AM_RANGE(0x0000, 0x7fff) AM_ROM AM_SHARE("decrypted_opcodes")
 ADDRESS_MAP_END
 
+static ADDRESS_MAP_START( airraid_sound_map, AS_PROGRAM, 8, airraid_state )
+	AM_RANGE(0x0000, 0x1fff) AM_ROM
+	AM_RANGE(0x2000, 0x27ff) AM_RAM
+	AM_RANGE(0x4000, 0x4000) AM_DEVWRITE("seibu_sound", seibu_sound_device, pending_w)
+	AM_RANGE(0x4001, 0x4001) AM_DEVWRITE("seibu_sound", seibu_sound_device, irq_clear_w)
+	AM_RANGE(0x4002, 0x4002) AM_DEVWRITE("seibu_sound", seibu_sound_device, rst10_ack_w)
+	AM_RANGE(0x4003, 0x4003) AM_DEVWRITE("seibu_sound", seibu_sound_device, rst18_ack_w)
+	AM_RANGE(0x4007, 0x4007) AM_DEVWRITE("seibu_sound", seibu_sound_device, bank_w)
+	AM_RANGE(0x4008, 0x4009) AM_DEVREADWRITE("seibu_sound", seibu_sound_device, ym_r, ym_w)
+	AM_RANGE(0x4010, 0x4011) AM_DEVREAD("seibu_sound", seibu_sound_device, soundlatch_r)
+	AM_RANGE(0x4012, 0x4012) AM_DEVREAD("seibu_sound", seibu_sound_device, main_data_pending_r)
+	AM_RANGE(0x4013, 0x4013) AM_READ_PORT("COIN")
+	AM_RANGE(0x4018, 0x4019) AM_DEVWRITE("seibu_sound", seibu_sound_device, main_data_w)
+	AM_RANGE(0x401b, 0x401b) AM_DEVWRITE("seibu_sound", seibu_sound_device, coin_w)
+	AM_RANGE(0x8000, 0xffff) AM_ROMBANK("seibu_bank1")
+ADDRESS_MAP_END
+
 
 static INPUT_PORTS_START( airraid )
 	PORT_START("IN0")   /* IN0  (0xc200) */
@@ -368,8 +386,9 @@ static MACHINE_CONFIG_START( airraid, airraid_state )
 	MCFG_CPU_PROGRAM_MAP(airraid_map)
 	MCFG_TIMER_DRIVER_ADD_SCANLINE("scantimer", airraid_state, cshooter_scanline, "airraid_vid:screen", 0, 1)
 
-	SEIBU2_AIRRAID_SOUND_SYSTEM_CPU(XTAL_14_31818MHz/4)      /* verified on pcb */
-	SEIBU_SOUND_SYSTEM_ENCRYPTED_LOW()
+	MCFG_CPU_ADD("audiocpu", Z80, XTAL_14_31818MHz/4)      /* verified on pcb */
+	MCFG_CPU_PROGRAM_MAP(airraid_sound_map)
+	MCFG_CPU_DECRYPTED_OPCODES_MAP(seibu_sound_decrypted_opcodes_map)
 
 	MCFG_QUANTUM_PERFECT_CPU("maincpu")
 
@@ -379,7 +398,17 @@ static MACHINE_CONFIG_START( airraid, airraid_state )
 	MCFG_AIRRAID_VIDEO_ADD("airraid_vid")
 
 	/* sound hardware */
-	SEIBU_AIRRAID_SOUND_SYSTEM_YM2151_INTERFACE(XTAL_14_31818MHz/4)
+	MCFG_SPEAKER_STANDARD_MONO("mono")
+
+	MCFG_YM2151_ADD("ymsnd", XTAL_14_31818MHz/4)
+	MCFG_YM2151_IRQ_HANDLER(DEVWRITELINE("seibu_sound", seibu_sound_device, fm_irqhandler))
+	MCFG_SOUND_ROUTE(0, "mono", 0.50)
+	MCFG_SOUND_ROUTE(1, "mono", 0.50)
+
+	MCFG_DEVICE_ADD("seibu_sound", SEIBU_SOUND, 0)
+	MCFG_SEIBU_SOUND_CPU_ENCRYPTED_LOW("audiocpu")
+	MCFG_SEIBU_SOUND_YM_READ_CB(DEVREAD8("ymsnd", ym2151_device, read))
+	MCFG_SEIBU_SOUND_YM_WRITE_CB(DEVWRITE8("ymsnd", ym2151_device, write))
 MACHINE_CONFIG_END
 
 

--- a/src/mame/drivers/bloodbro.cpp
+++ b/src/mame/drivers/bloodbro.cpp
@@ -133,6 +133,7 @@ DIP locations verified for Blood Bros. & Sky Smasher via manual & DIP-SW setting
 #include "cpu/m68000/m68000.h"
 #include "cpu/z80/z80.h"
 #include "sound/3812intf.h"
+#include "sound/okim6295.h"
 #include "includes/bloodbro.h"
 #include "video/seibu_crtc.h"
 
@@ -484,7 +485,8 @@ static MACHINE_CONFIG_START( bloodbro, bloodbro_state )
 	MCFG_CPU_PROGRAM_MAP(bloodbro_map)
 	MCFG_CPU_VBLANK_INT_DRIVER("screen", bloodbro_state,  irq4_line_hold)
 
-	SEIBU_SOUND_SYSTEM_CPU(XTAL_7_15909MHz/2) /* verified on pcb */
+	MCFG_CPU_ADD("audiocpu", Z80, XTAL_7_15909MHz/2) /* verified on pcb */
+	MCFG_CPU_PROGRAM_MAP(seibu_sound_map)
 
 	// video hardware
 
@@ -506,7 +508,19 @@ static MACHINE_CONFIG_START( bloodbro, bloodbro_state )
 	MCFG_PALETTE_FORMAT(xxxxBBBBGGGGRRRR)
 
 	// sound hardware
-	SEIBU_SOUND_SYSTEM_YM3812_RAIDEN_INTERFACE(XTAL_7_15909MHz/2, XTAL_12MHz/12)
+	MCFG_SPEAKER_STANDARD_MONO("mono")
+
+	MCFG_SOUND_ADD("ymsnd", YM3812, XTAL_7_15909MHz/2)
+	MCFG_YM3812_IRQ_HANDLER(DEVWRITELINE("seibu_sound", seibu_sound_device, fm_irqhandler))
+	MCFG_SOUND_ROUTE(ALL_OUTPUTS, "mono", 1.0)
+
+	MCFG_OKIM6295_ADD("oki", XTAL_12MHz/12, OKIM6295_PIN7_HIGH)
+	MCFG_SOUND_ROUTE(ALL_OUTPUTS, "mono", 1.0)
+
+	MCFG_DEVICE_ADD("seibu_sound", SEIBU_SOUND, 0)
+	MCFG_SEIBU_SOUND_CPU("audiocpu")
+	MCFG_SEIBU_SOUND_YM_READ_CB(DEVREAD8("ymsnd", ym3812_device, read))
+	MCFG_SEIBU_SOUND_YM_WRITE_CB(DEVWRITE8("ymsnd", ym3812_device, write))
 MACHINE_CONFIG_END
 
 static MACHINE_CONFIG_DERIVED( weststry, bloodbro )

--- a/src/mame/drivers/cabal.cpp
+++ b/src/mame/drivers/cabal.cpp
@@ -189,7 +189,7 @@ static ADDRESS_MAP_START( sound_map, AS_PROGRAM, 8, cabal_state )
 	AM_RANGE(0x4002, 0x4002) AM_DEVWRITE("seibu_sound", seibu_sound_device, rst10_ack_w)
 	AM_RANGE(0x4003, 0x4003) AM_DEVWRITE("seibu_sound", seibu_sound_device, rst18_ack_w)
 	AM_RANGE(0x4005, 0x4006) AM_DEVWRITE("adpcm1", seibu_adpcm_device, adr_w)
-	AM_RANGE(0x4008, 0x4009) AM_DEVREADWRITE("ymsnd", ym2151_device, read, write)
+	AM_RANGE(0x4008, 0x4009) AM_DEVREADWRITE("seibu_sound", seibu_sound_device, ym_r, ym_w)
 	AM_RANGE(0x4010, 0x4011) AM_DEVREAD("seibu_sound", seibu_sound_device, soundlatch_r)
 	AM_RANGE(0x4012, 0x4012) AM_DEVREAD("seibu_sound", seibu_sound_device, main_data_pending_r)
 	AM_RANGE(0x4013, 0x4013) AM_READ_PORT("COIN")
@@ -496,6 +496,9 @@ static MACHINE_CONFIG_START( cabal_base, cabal_state )
 
 	/* sound hardware */
 	MCFG_DEVICE_ADD("seibu_sound", SEIBU_SOUND, 0)
+	MCFG_SEIBU_SOUND_CPU("audiocpu")
+	MCFG_SEIBU_SOUND_YM_READ_CB(DEVREAD8("ymsnd", ym2151_device, read))
+	MCFG_SEIBU_SOUND_YM_WRITE_CB(DEVWRITE8("ymsnd", ym2151_device, write))
 
 	MCFG_SPEAKER_STANDARD_MONO("mono")
 
@@ -511,11 +514,19 @@ static MACHINE_CONFIG_START( cabal_base, cabal_state )
 MACHINE_CONFIG_END
 
 static MACHINE_CONFIG_DERIVED( cabal, cabal_base )
-	SEIBU_SOUND_SYSTEM_ENCRYPTED_LOW()
+	MCFG_DEVICE_MODIFY("seibu_sound")
+	MCFG_SEIBU_SOUND_CPU_ENCRYPTED_LOW("audiocpu")
+
+	MCFG_DEVICE_MODIFY("audiocpu")
+	MCFG_CPU_DECRYPTED_OPCODES_MAP(seibu_sound_decrypted_opcodes_map)
 MACHINE_CONFIG_END
 
 static MACHINE_CONFIG_DERIVED( cabalbl2, cabal_base )
-	SEIBU_SOUND_SYSTEM_ENCRYPTED_CUSTOM()
+	MCFG_DEVICE_MODIFY("seibu_sound")
+	MCFG_SEIBU_SOUND_CPU_ENCRYPTED_CUSTOM("audiocpu")
+
+	MCFG_DEVICE_MODIFY("audiocpu")
+	MCFG_CPU_DECRYPTED_OPCODES_MAP(seibu_sound_decrypted_opcodes_map)
 MACHINE_CONFIG_END
 
 

--- a/src/mame/drivers/dcon.cpp
+++ b/src/mame/drivers/dcon.cpp
@@ -17,6 +17,9 @@
 #include "emu.h"
 #include "cpu/m68000/m68000.h"
 #include "cpu/z80/z80.h"
+#include "sound/3812intf.h"
+#include "sound/ym2151.h"
+#include "sound/okim6295.h"
 #include "audio/seibu.h"
 #include "includes/dcon.h"
 #include "video/seibu_crtc.h"
@@ -261,7 +264,8 @@ static MACHINE_CONFIG_START( dcon, dcon_state )
 	MCFG_CPU_PROGRAM_MAP(dcon_map)
 	MCFG_CPU_VBLANK_INT_DRIVER("screen", dcon_state,  irq4_line_hold)
 
-	SEIBU_SOUND_SYSTEM_CPU(4000000) /* Perhaps 14318180/4? */
+	MCFG_CPU_ADD("audiocpu", Z80, 4000000) /* Perhaps 14318180/4? */
+	MCFG_CPU_PROGRAM_MAP(seibu_sound_map)
 
 	/* video hardware */
 	MCFG_SCREEN_ADD("screen", RASTER)
@@ -281,7 +285,19 @@ static MACHINE_CONFIG_START( dcon, dcon_state )
 	MCFG_PALETTE_FORMAT(xBBBBBGGGGGRRRRR)
 
 	/* sound hardware */
-	SEIBU_SOUND_SYSTEM_YM3812_INTERFACE(4000000,1320000)
+	MCFG_SPEAKER_STANDARD_MONO("mono")
+
+	MCFG_SOUND_ADD("ymsnd", YM3812, 4000000)
+	MCFG_YM3812_IRQ_HANDLER(DEVWRITELINE("seibu_sound", seibu_sound_device, fm_irqhandler))
+	MCFG_SOUND_ROUTE(ALL_OUTPUTS, "mono", 1.0)
+
+	MCFG_OKIM6295_ADD("oki", 1320000, OKIM6295_PIN7_LOW)
+	MCFG_SOUND_ROUTE(ALL_OUTPUTS, "mono", 0.40)
+
+	MCFG_DEVICE_ADD("seibu_sound", SEIBU_SOUND, 0)
+	MCFG_SEIBU_SOUND_CPU("audiocpu")
+	MCFG_SEIBU_SOUND_YM_READ_CB(DEVREAD8("ymsnd", ym3812_device, read))
+	MCFG_SEIBU_SOUND_YM_WRITE_CB(DEVWRITE8("ymsnd", ym3812_device, write))
 MACHINE_CONFIG_END
 
 static MACHINE_CONFIG_START( sdgndmps, dcon_state )
@@ -291,7 +307,8 @@ static MACHINE_CONFIG_START( sdgndmps, dcon_state )
 	MCFG_CPU_PROGRAM_MAP(dcon_map)
 	MCFG_CPU_VBLANK_INT_DRIVER("screen", dcon_state,  irq4_line_hold)
 
-	SEIBU2_SOUND_SYSTEM_CPU(14318180/4)
+	MCFG_CPU_ADD("audiocpu", Z80, 14318180/4)
+	MCFG_CPU_PROGRAM_MAP(seibu_sound_map)
 
 	/* video hardware */
 	MCFG_SCREEN_ADD("screen", RASTER)
@@ -311,7 +328,20 @@ static MACHINE_CONFIG_START( sdgndmps, dcon_state )
 	MCFG_PALETTE_FORMAT(xBBBBBGGGGGRRRRR)
 
 	/* sound hardware */
-	SEIBU_SOUND_SYSTEM_YM2151_INTERFACE(14318180/4,1320000)
+	MCFG_SPEAKER_STANDARD_MONO("mono")
+
+	MCFG_YM2151_ADD("ymsnd", 14318180/4)
+	MCFG_YM2151_IRQ_HANDLER(DEVWRITELINE("seibu_sound", seibu_sound_device, fm_irqhandler))
+	MCFG_SOUND_ROUTE(0, "mono", 0.50)
+	MCFG_SOUND_ROUTE(1, "mono", 0.50)
+
+	MCFG_OKIM6295_ADD("oki", 1320000, OKIM6295_PIN7_LOW)
+	MCFG_SOUND_ROUTE(ALL_OUTPUTS, "mono", 0.40)
+
+	MCFG_DEVICE_ADD("seibu_sound", SEIBU_SOUND, 0)
+	MCFG_SEIBU_SOUND_CPU("audiocpu")
+	MCFG_SEIBU_SOUND_YM_READ_CB(DEVREAD8("ymsnd", ym2151_device, read))
+	MCFG_SEIBU_SOUND_YM_WRITE_CB(DEVWRITE8("ymsnd", ym2151_device, write))
 MACHINE_CONFIG_END
 
 /***************************************************************************/

--- a/src/mame/drivers/deadang.cpp
+++ b/src/mame/drivers/deadang.cpp
@@ -88,6 +88,28 @@ static ADDRESS_MAP_START( sub_map, AS_PROGRAM, 16, deadang_state )
 	AM_RANGE(0xe0000, 0xfffff) AM_ROM
 ADDRESS_MAP_END
 
+static ADDRESS_MAP_START( sound_map, AS_PROGRAM, 8, deadang_state )
+	AM_RANGE(0x0000, 0x1fff) AM_ROM
+	AM_RANGE(0x2000, 0x27ff) AM_RAM
+	AM_RANGE(0x4000, 0x4000) AM_DEVWRITE("seibu_sound", seibu_sound_device, pending_w)
+	AM_RANGE(0x4001, 0x4001) AM_DEVWRITE("seibu_sound", seibu_sound_device, irq_clear_w)
+	AM_RANGE(0x4002, 0x4002) AM_DEVWRITE("seibu_sound", seibu_sound_device, rst10_ack_w)
+	AM_RANGE(0x4003, 0x4003) AM_DEVWRITE("seibu_sound", seibu_sound_device, rst18_ack_w)
+	AM_RANGE(0x4005, 0x4006) AM_DEVWRITE("adpcm1", seibu_adpcm_device, adr_w)
+	AM_RANGE(0x4007, 0x4007) AM_DEVWRITE("seibu_sound", seibu_sound_device, bank_w)
+	AM_RANGE(0x4008, 0x4009) AM_DEVREADWRITE("seibu_sound", seibu_sound_device, ym_r, ym_w)
+	AM_RANGE(0x4010, 0x4011) AM_DEVREAD("seibu_sound", seibu_sound_device, soundlatch_r)
+	AM_RANGE(0x4012, 0x4012) AM_DEVREAD("seibu_sound", seibu_sound_device, main_data_pending_r)
+	AM_RANGE(0x4013, 0x4013) AM_READ_PORT("COIN")
+	AM_RANGE(0x4018, 0x4019) AM_DEVWRITE("seibu_sound", seibu_sound_device, main_data_w)
+	AM_RANGE(0x401a, 0x401a) AM_DEVWRITE("adpcm1", seibu_adpcm_device, ctl_w)
+	AM_RANGE(0x401b, 0x401b) AM_DEVWRITE("seibu_sound", seibu_sound_device, coin_w)
+	AM_RANGE(0x6005, 0x6006) AM_DEVWRITE("adpcm2", seibu_adpcm_device, adr_w)
+	AM_RANGE(0x6008, 0x6009) AM_DEVREADWRITE("ym2", ym2203_device, read, write)
+	AM_RANGE(0x601a, 0x601a) AM_DEVWRITE("adpcm2", seibu_adpcm_device, ctl_w)
+	AM_RANGE(0x8000, 0xffff) AM_ROMBANK("seibu_bank1")
+ADDRESS_MAP_END
+
 /* Input Ports */
 
 static INPUT_PORTS_START( deadang )
@@ -246,8 +268,9 @@ static MACHINE_CONFIG_START( deadang, deadang_state )
 	MCFG_CPU_PROGRAM_MAP(sub_map)
 	MCFG_TIMER_DRIVER_ADD_SCANLINE("scantimer2", deadang_state, sub_scanline, "screen", 0, 1)
 
-	SEIBU3A_SOUND_SYSTEM_CPU(XTAL_14_31818MHz/4)
-	SEIBU_SOUND_SYSTEM_ENCRYPTED_LOW()
+	MCFG_CPU_ADD("audiocpu", Z80, XTAL_14_31818MHz/4)
+	MCFG_CPU_PROGRAM_MAP(sound_map)
+	MCFG_CPU_DECRYPTED_OPCODES_MAP(seibu_sound_decrypted_opcodes_map)
 
 	MCFG_QUANTUM_TIME(attotime::from_hz(60)) // the game stops working with higher interleave rates..
 
@@ -266,10 +289,26 @@ static MACHINE_CONFIG_START( deadang, deadang_state )
 	MCFG_PALETTE_ADD("palette", 2048)
 	MCFG_PALETTE_FORMAT(xxxxBBBBGGGGRRRR)
 
-
 	/* sound hardware */
-	SEIBU_SOUND_SYSTEM_YM2203_INTERFACE(XTAL_14_31818MHz/4)
-	SEIBU_SOUND_SYSTEM_ADPCM_INTERFACE
+	MCFG_SPEAKER_STANDARD_MONO("mono")
+
+	MCFG_DEVICE_ADD("seibu_sound", SEIBU_SOUND, 0)
+	MCFG_SEIBU_SOUND_CPU_ENCRYPTED_LOW("audiocpu")
+	MCFG_SEIBU_SOUND_YM_READ_CB(DEVREAD8("ym1", ym2203_device, read))
+	MCFG_SEIBU_SOUND_YM_WRITE_CB(DEVWRITE8("ym1", ym2203_device, write))
+
+	MCFG_SOUND_ADD("ym1", YM2203, XTAL_14_31818MHz/4)
+	MCFG_YM2203_IRQ_HANDLER(DEVWRITELINE("seibu_sound", seibu_sound_device, fm_irqhandler))
+	MCFG_SOUND_ROUTE(ALL_OUTPUTS, "mono", 0.15)
+
+	MCFG_SOUND_ADD("ym2", YM2203, XTAL_14_31818MHz/4)
+	MCFG_SOUND_ROUTE(ALL_OUTPUTS, "mono", 0.15)
+
+	MCFG_SOUND_ADD("adpcm1", SEIBU_ADPCM, 8000)
+	MCFG_SOUND_ROUTE(ALL_OUTPUTS, "mono", 0.40)
+
+	MCFG_SOUND_ADD("adpcm2", SEIBU_ADPCM, 8000)
+	MCFG_SOUND_ROUTE(ALL_OUTPUTS, "mono", 0.40)
 MACHINE_CONFIG_END
 
 /* ROMs */

--- a/src/mame/drivers/dynduke.cpp
+++ b/src/mame/drivers/dynduke.cpp
@@ -285,8 +285,9 @@ static MACHINE_CONFIG_START( dynduke, dynduke_state )
 	MCFG_CPU_PROGRAM_MAP(slave_map)
 	MCFG_CPU_VBLANK_INT_DRIVER("screen", dynduke_state, interrupt)
 
-	SEIBU_SOUND_SYSTEM_CPU(14318180/4)
-	SEIBU_SOUND_SYSTEM_ENCRYPTED_FULL()
+	MCFG_CPU_ADD("audiocpu", Z80, 14318180/4)
+	MCFG_CPU_PROGRAM_MAP(seibu_sound_map)
+	MCFG_CPU_DECRYPTED_OPCODES_MAP(seibu_sound_decrypted_opcodes_map)
 
 	MCFG_QUANTUM_TIME(attotime::from_hz(3600))
 
@@ -308,7 +309,19 @@ static MACHINE_CONFIG_START( dynduke, dynduke_state )
 	MCFG_PALETTE_FORMAT(xxxxBBBBGGGGRRRR)
 
 	// sound hardware
-	SEIBU_SOUND_SYSTEM_YM3812_INTERFACE(14318180/4,1320000)
+	MCFG_SPEAKER_STANDARD_MONO("mono")
+
+	MCFG_SOUND_ADD("ymsnd", YM3812, 14318180/4)
+	MCFG_YM3812_IRQ_HANDLER(DEVWRITELINE("seibu_sound", seibu_sound_device, fm_irqhandler))
+	MCFG_SOUND_ROUTE(ALL_OUTPUTS, "mono", 1.0)
+
+	MCFG_OKIM6295_ADD("oki", 1320000, OKIM6295_PIN7_LOW)
+	MCFG_SOUND_ROUTE(ALL_OUTPUTS, "mono", 0.40)
+
+	MCFG_DEVICE_ADD("seibu_sound", SEIBU_SOUND, 0)
+	MCFG_SEIBU_SOUND_CPU_ENCRYPTED_FULL("audiocpu")
+	MCFG_SEIBU_SOUND_YM_READ_CB(DEVREAD8("ymsnd", ym3812_device, read))
+	MCFG_SEIBU_SOUND_YM_WRITE_CB(DEVWRITE8("ymsnd", ym3812_device, write))
 MACHINE_CONFIG_END
 
 static MACHINE_CONFIG_DERIVED( dbldyn, dynduke )

--- a/src/mame/drivers/goodejan.cpp
+++ b/src/mame/drivers/goodejan.cpp
@@ -74,6 +74,7 @@ Secret menu hack [totmejan only] (I couldn't find official way to enter, so it's
 #include "cpu/nec/nec.h"
 #include "audio/seibu.h"
 #include "sound/3812intf.h"
+#include "sound/okim6295.h"
 #include "video/seibu_crtc.h"
 
 
@@ -634,7 +635,8 @@ static MACHINE_CONFIG_START( goodejan, goodejan_state )
 	MCFG_CPU_IO_MAP(goodejan_io_map)
 	MCFG_CPU_VBLANK_INT_DRIVER("screen", goodejan_state, irq)
 
-	SEIBU_SOUND_SYSTEM_CPU(GOODEJAN_MHZ1/2)
+	MCFG_CPU_ADD("audiocpu", Z80, GOODEJAN_MHZ1/2)
+	MCFG_CPU_PROGRAM_MAP(seibu_sound_map)
 
 	/* video hardware */
 	MCFG_SCREEN_ADD("screen", RASTER)
@@ -654,7 +656,19 @@ static MACHINE_CONFIG_START( goodejan, goodejan_state )
 	MCFG_PALETTE_FORMAT(xxxxBBBBGGGGRRRR)
 
 	/* sound hardware */
-	SEIBU_SOUND_SYSTEM_YM3812_INTERFACE(GOODEJAN_MHZ1/2,GOODEJAN_MHZ2/16)
+	MCFG_SPEAKER_STANDARD_MONO("mono")
+
+	MCFG_SOUND_ADD("ymsnd", YM3812, GOODEJAN_MHZ1/2)
+	MCFG_YM3812_IRQ_HANDLER(DEVWRITELINE("seibu_sound", seibu_sound_device, fm_irqhandler))
+	MCFG_SOUND_ROUTE(ALL_OUTPUTS, "mono", 1.0)
+
+	MCFG_OKIM6295_ADD("oki", GOODEJAN_MHZ2/16, OKIM6295_PIN7_LOW)
+	MCFG_SOUND_ROUTE(ALL_OUTPUTS, "mono", 0.40)
+
+	MCFG_DEVICE_ADD("seibu_sound", SEIBU_SOUND, 0)
+	MCFG_SEIBU_SOUND_CPU("audiocpu")
+	MCFG_SEIBU_SOUND_YM_READ_CB(DEVREAD8("ymsnd", ym3812_device, read))
+	MCFG_SEIBU_SOUND_YM_WRITE_CB(DEVWRITE8("ymsnd", ym3812_device, write))
 MACHINE_CONFIG_END
 
 static MACHINE_CONFIG_DERIVED( totmejan, goodejan )

--- a/src/mame/drivers/legionna.cpp
+++ b/src/mame/drivers/legionna.cpp
@@ -83,6 +83,7 @@ Preliminary COP MCU memory map
 #include "emu.h"
 #include "cpu/z80/z80.h"
 #include "sound/3812intf.h"
+#include "sound/ym2151.h"
 #include "cpu/m68000/m68000.h"
 #include "machine/seicop.h"
 #include "includes/legionna.h"
@@ -1157,7 +1158,8 @@ static MACHINE_CONFIG_START( legionna, legionna_state )
 	MCFG_CPU_PROGRAM_MAP(legionna_map)
 	MCFG_CPU_VBLANK_INT_DRIVER("screen", legionna_state,  irq4_line_hold)/* VBL */
 
-	SEIBU_SOUND_SYSTEM_CPU(14318180/4)
+	MCFG_CPU_ADD("audiocpu", Z80, 14318180/4)
+	MCFG_CPU_PROGRAM_MAP(seibu_sound_map)
 
 	MCFG_DEVICE_ADD("raiden2cop", RAIDEN2COP, 0)
 	MCFG_RAIDEN2COP_VIDEORAM_OUT_CB(WRITE16(legionna_state, videowrite_cb_w))
@@ -1183,7 +1185,19 @@ static MACHINE_CONFIG_START( legionna, legionna_state )
 	MCFG_VIDEO_START_OVERRIDE(legionna_state,legionna)
 
 	/* sound hardware */
-	SEIBU_SOUND_SYSTEM_YM3812_INTERFACE(14318180/4,1320000)
+	MCFG_SPEAKER_STANDARD_MONO("mono")
+
+	MCFG_SOUND_ADD("ymsnd", YM3812, 14318180/4)
+	MCFG_YM3812_IRQ_HANDLER(DEVWRITELINE("seibu_sound", seibu_sound_device, fm_irqhandler))
+	MCFG_SOUND_ROUTE(ALL_OUTPUTS, "mono", 1.0)
+
+	MCFG_OKIM6295_ADD("oki", 1320000, OKIM6295_PIN7_LOW)
+	MCFG_SOUND_ROUTE(ALL_OUTPUTS, "mono", 0.40)
+
+	MCFG_DEVICE_ADD("seibu_sound", SEIBU_SOUND, 0)
+	MCFG_SEIBU_SOUND_CPU("audiocpu")
+	MCFG_SEIBU_SOUND_YM_READ_CB(DEVREAD8("ymsnd", ym3812_device, read))
+	MCFG_SEIBU_SOUND_YM_WRITE_CB(DEVWRITE8("ymsnd", ym3812_device, write))
 MACHINE_CONFIG_END
 
 
@@ -1194,7 +1208,8 @@ static MACHINE_CONFIG_START( heatbrl, legionna_state )
 	MCFG_CPU_PROGRAM_MAP(heatbrl_map)
 	MCFG_CPU_VBLANK_INT_DRIVER("screen", legionna_state,  irq4_line_hold)/* VBL */
 
-	SEIBU_SOUND_SYSTEM_CPU(14318180/4)
+	MCFG_CPU_ADD("audiocpu", Z80, 14318180/4)
+	MCFG_CPU_PROGRAM_MAP(seibu_sound_map)
 
 	MCFG_DEVICE_ADD("raiden2cop", RAIDEN2COP, 0)
 	MCFG_RAIDEN2COP_VIDEORAM_OUT_CB(WRITE16(legionna_state, videowrite_cb_w))
@@ -1222,7 +1237,19 @@ static MACHINE_CONFIG_START( heatbrl, legionna_state )
 	MCFG_VIDEO_START_OVERRIDE(legionna_state,heatbrl)
 
 	/* sound hardware */
-	SEIBU_SOUND_SYSTEM_YM3812_INTERFACE(14318180/4,1320000)
+	MCFG_SPEAKER_STANDARD_MONO("mono")
+
+	MCFG_SOUND_ADD("ymsnd", YM3812, 14318180/4)
+	MCFG_YM3812_IRQ_HANDLER(DEVWRITELINE("seibu_sound", seibu_sound_device, fm_irqhandler))
+	MCFG_SOUND_ROUTE(ALL_OUTPUTS, "mono", 1.0)
+
+	MCFG_OKIM6295_ADD("oki", 1320000, OKIM6295_PIN7_LOW)
+	MCFG_SOUND_ROUTE(ALL_OUTPUTS, "mono", 0.40)
+
+	MCFG_DEVICE_ADD("seibu_sound", SEIBU_SOUND, 0)
+	MCFG_SEIBU_SOUND_CPU("audiocpu")
+	MCFG_SEIBU_SOUND_YM_READ_CB(DEVREAD8("ymsnd", ym3812_device, read))
+	MCFG_SEIBU_SOUND_YM_WRITE_CB(DEVWRITE8("ymsnd", ym3812_device, write))
 MACHINE_CONFIG_END
 
 static MACHINE_CONFIG_START( godzilla, legionna_state )
@@ -1232,7 +1259,8 @@ static MACHINE_CONFIG_START( godzilla, legionna_state )
 	MCFG_CPU_PROGRAM_MAP(godzilla_map)
 	MCFG_CPU_VBLANK_INT_DRIVER("screen", legionna_state,  irq4_line_hold)
 
-	SEIBU2_SOUND_SYSTEM_CPU(14318180/4)
+	MCFG_CPU_ADD("audiocpu", Z80, 14318180/4)
+	MCFG_CPU_PROGRAM_MAP(seibu_sound_map)
 
 	MCFG_DEVICE_ADD("raiden2cop", RAIDEN2COP, 0)
 	MCFG_RAIDEN2COP_VIDEORAM_OUT_CB(WRITE16(legionna_state, videowrite_cb_w))
@@ -1261,7 +1289,20 @@ static MACHINE_CONFIG_START( godzilla, legionna_state )
 	MCFG_VIDEO_START_OVERRIDE(legionna_state,godzilla)
 
 	/* sound hardware */
-	SEIBU_SOUND_SYSTEM_YM2151_INTERFACE(14318180/4,1320000)
+	MCFG_SPEAKER_STANDARD_MONO("mono")
+
+	MCFG_YM2151_ADD("ymsnd", 14318180/4)
+	MCFG_YM2151_IRQ_HANDLER(DEVWRITELINE("seibu_sound", seibu_sound_device, fm_irqhandler))
+	MCFG_SOUND_ROUTE(0, "mono", 0.50)
+	MCFG_SOUND_ROUTE(1, "mono", 0.50)
+
+	MCFG_OKIM6295_ADD("oki", 1320000, OKIM6295_PIN7_LOW)
+	MCFG_SOUND_ROUTE(ALL_OUTPUTS, "mono", 0.40)
+
+	MCFG_DEVICE_ADD("seibu_sound", SEIBU_SOUND, 0)
+	MCFG_SEIBU_SOUND_CPU("audiocpu")
+	MCFG_SEIBU_SOUND_YM_READ_CB(DEVREAD8("ymsnd", ym2151_device, read))
+	MCFG_SEIBU_SOUND_YM_WRITE_CB(DEVWRITE8("ymsnd", ym2151_device, write))
 MACHINE_CONFIG_END
 
 static MACHINE_CONFIG_START( denjinmk, legionna_state )
@@ -1271,7 +1312,8 @@ static MACHINE_CONFIG_START( denjinmk, legionna_state )
 	MCFG_CPU_PROGRAM_MAP(denjinmk_map)
 	MCFG_CPU_VBLANK_INT_DRIVER("screen", legionna_state,  irq4_line_hold)
 
-	SEIBU2_SOUND_SYSTEM_CPU(14318180/4)
+	MCFG_CPU_ADD("audiocpu", Z80, 14318180/4)
+	MCFG_CPU_PROGRAM_MAP(seibu_sound_map)
 
 	MCFG_DEVICE_ADD("raiden2cop", RAIDEN2COP, 0)
 	MCFG_RAIDEN2COP_VIDEORAM_OUT_CB(WRITE16(legionna_state, videowrite_cb_w))
@@ -1299,7 +1341,20 @@ static MACHINE_CONFIG_START( denjinmk, legionna_state )
 	MCFG_VIDEO_START_OVERRIDE(legionna_state,denjinmk)
 
 	/* sound hardware */
-	SEIBU_SOUND_SYSTEM_YM2151_INTERFACE(14318180/4,1320000)
+	MCFG_SPEAKER_STANDARD_MONO("mono")
+
+	MCFG_YM2151_ADD("ymsnd", 14318180/4)
+	MCFG_YM2151_IRQ_HANDLER(DEVWRITELINE("seibu_sound", seibu_sound_device, fm_irqhandler))
+	MCFG_SOUND_ROUTE(0, "mono", 0.50)
+	MCFG_SOUND_ROUTE(1, "mono", 0.50)
+
+	MCFG_OKIM6295_ADD("oki", 1320000, OKIM6295_PIN7_LOW)
+	MCFG_SOUND_ROUTE(ALL_OUTPUTS, "mono", 0.40)
+
+	MCFG_DEVICE_ADD("seibu_sound", SEIBU_SOUND, 0)
+	MCFG_SEIBU_SOUND_CPU("audiocpu")
+	MCFG_SEIBU_SOUND_YM_READ_CB(DEVREAD8("ymsnd", ym2151_device, read))
+	MCFG_SEIBU_SOUND_YM_WRITE_CB(DEVWRITE8("ymsnd", ym2151_device, write))
 MACHINE_CONFIG_END
 
 static MACHINE_CONFIG_START( grainbow, legionna_state )
@@ -1309,7 +1364,8 @@ static MACHINE_CONFIG_START( grainbow, legionna_state )
 	MCFG_CPU_PROGRAM_MAP(grainbow_map)
 	MCFG_CPU_VBLANK_INT_DRIVER("screen", legionna_state,  irq4_line_hold)
 
-	SEIBU2_SOUND_SYSTEM_CPU(14318180/4)
+	MCFG_CPU_ADD("audiocpu", Z80, 14318180/4)
+	MCFG_CPU_PROGRAM_MAP(seibu_sound_map)
 
 	MCFG_DEVICE_ADD("raiden2cop", RAIDEN2COP, 0)
 	MCFG_RAIDEN2COP_VIDEORAM_OUT_CB(WRITE16(legionna_state, videowrite_cb_w))
@@ -1337,7 +1393,20 @@ static MACHINE_CONFIG_START( grainbow, legionna_state )
 	MCFG_VIDEO_START_OVERRIDE(legionna_state,grainbow)
 
 	/* sound hardware */
-	SEIBU_SOUND_SYSTEM_YM2151_INTERFACE(14318180/4,1320000)
+	MCFG_SPEAKER_STANDARD_MONO("mono")
+
+	MCFG_YM2151_ADD("ymsnd", 14318180/4)
+	MCFG_YM2151_IRQ_HANDLER(DEVWRITELINE("seibu_sound", seibu_sound_device, fm_irqhandler))
+	MCFG_SOUND_ROUTE(0, "mono", 0.50)
+	MCFG_SOUND_ROUTE(1, "mono", 0.50)
+
+	MCFG_OKIM6295_ADD("oki", 1320000, OKIM6295_PIN7_LOW)
+	MCFG_SOUND_ROUTE(ALL_OUTPUTS, "mono", 0.40)
+
+	MCFG_DEVICE_ADD("seibu_sound", SEIBU_SOUND, 0)
+	MCFG_SEIBU_SOUND_CPU("audiocpu")
+	MCFG_SEIBU_SOUND_YM_READ_CB(DEVREAD8("ymsnd", ym2151_device, read))
+	MCFG_SEIBU_SOUND_YM_WRITE_CB(DEVWRITE8("ymsnd", ym2151_device, write))
 MACHINE_CONFIG_END
 
 
@@ -1348,7 +1417,8 @@ static MACHINE_CONFIG_START( cupsoc, legionna_state )
 	MCFG_CPU_PROGRAM_MAP(cupsoc_mem)
 	MCFG_CPU_VBLANK_INT_DRIVER("screen", legionna_state,  irq4_line_hold)/* VBL */
 
-	SEIBU_SOUND_SYSTEM_CPU(14318180/4)
+	MCFG_CPU_ADD("audiocpu", Z80, 14318180/4)
+	MCFG_CPU_PROGRAM_MAP(seibu_sound_map)
 
 	MCFG_DEVICE_ADD("raiden2cop", RAIDEN2COP, 0)
 	MCFG_RAIDEN2COP_VIDEORAM_OUT_CB(WRITE16(legionna_state, videowrite_cb_w))
@@ -1376,7 +1446,20 @@ static MACHINE_CONFIG_START( cupsoc, legionna_state )
 	MCFG_VIDEO_START_OVERRIDE(legionna_state,cupsoc)
 
 	/* sound hardware */
-	SEIBU_SOUND_SYSTEM_YM3812_INTERFACE(14318180/4,1320000)
+	MCFG_SPEAKER_STANDARD_MONO("mono")
+
+	MCFG_YM2151_ADD("ymsnd", 14318180/4)
+	MCFG_YM2151_IRQ_HANDLER(DEVWRITELINE("seibu_sound", seibu_sound_device, fm_irqhandler))
+	MCFG_SOUND_ROUTE(0, "mono", 0.50)
+	MCFG_SOUND_ROUTE(1, "mono", 0.50)
+
+	MCFG_OKIM6295_ADD("oki", 1320000, OKIM6295_PIN7_LOW)
+	MCFG_SOUND_ROUTE(ALL_OUTPUTS, "mono", 0.40)
+
+	MCFG_DEVICE_ADD("seibu_sound", SEIBU_SOUND, 0)
+	MCFG_SEIBU_SOUND_CPU("audiocpu")
+	MCFG_SEIBU_SOUND_YM_READ_CB(DEVREAD8("ymsnd", ym2151_device, read))
+	MCFG_SEIBU_SOUND_YM_WRITE_CB(DEVWRITE8("ymsnd", ym2151_device, write))
 MACHINE_CONFIG_END
 
 static MACHINE_CONFIG_DERIVED( cupsocs, cupsoc )

--- a/src/mame/drivers/nmk16.cpp
+++ b/src/mame/drivers/nmk16.cpp
@@ -154,6 +154,7 @@ Afega stands for "Art-Fiction Electronic Game"
 #include "sound/2203intf.h"
 #include "sound/okim6295.h"
 #include "sound/3812intf.h"
+#include "sound/ym2151.h"
 #include "machine/nmk004.h"
 #include "cpu/pic16c5x/pic16c5x.h"
 #include "includes/nmk16.h"
@@ -3950,7 +3951,8 @@ static MACHINE_CONFIG_START( mustangb, nmk16_state )
 	MCFG_CPU_PROGRAM_MAP(mustangb_map)
 	NMK_HACKY_INTERRUPT_TIMING
 
-	SEIBU_SOUND_SYSTEM_CPU(14318180/4)
+	MCFG_CPU_ADD("audiocpu", Z80, 14318180/4)
+	MCFG_CPU_PROGRAM_MAP(seibu_sound_map)
 
 	/* video hardware */
 	NMK_HACKY_SCREEN_LOWRES
@@ -3964,8 +3966,19 @@ static MACHINE_CONFIG_START( mustangb, nmk16_state )
 	MCFG_VIDEO_START_OVERRIDE(nmk16_state,macross)
 
 	/* sound hardware */
-	SEIBU_SOUND_SYSTEM_YM3812_INTERFACE(14318180/4, 1320000)
+	MCFG_SPEAKER_STANDARD_MONO("mono")
 
+	MCFG_SOUND_ADD("ymsnd", YM3812, 14318180/4)
+	MCFG_YM3812_IRQ_HANDLER(DEVWRITELINE("seibu_sound", seibu_sound_device, fm_irqhandler))
+	MCFG_SOUND_ROUTE(ALL_OUTPUTS, "mono", 1.0)
+
+	MCFG_OKIM6295_ADD("oki", 1320000, OKIM6295_PIN7_LOW)
+	MCFG_SOUND_ROUTE(ALL_OUTPUTS, "mono", 0.40)
+
+	MCFG_DEVICE_ADD("seibu_sound", SEIBU_SOUND, 0)
+	MCFG_SEIBU_SOUND_CPU("audiocpu")
+	MCFG_SEIBU_SOUND_YM_READ_CB(DEVREAD8("ymsnd", ym3812_device, read))
+	MCFG_SEIBU_SOUND_YM_WRITE_CB(DEVWRITE8("ymsnd", ym3812_device, write))
 MACHINE_CONFIG_END
 
 #define BIOSHIP_CRYSTAL1 10000000
@@ -4124,7 +4137,8 @@ static MACHINE_CONFIG_START( tdragonb, nmk16_state )    /* bootleg using Raiden 
 	MCFG_CPU_PROGRAM_MAP(tdragonb_map)
 	NMK_HACKY_INTERRUPT_TIMING
 
-	SEIBU_SOUND_SYSTEM_CPU(14318180/4)
+	MCFG_CPU_ADD("audiocpu", Z80, 14318180/4)
+	MCFG_CPU_PROGRAM_MAP(seibu_sound_map)
 
 	/* video hardware */
 	NMK_HACKY_SCREEN_LOWRES
@@ -4138,7 +4152,19 @@ static MACHINE_CONFIG_START( tdragonb, nmk16_state )    /* bootleg using Raiden 
 	MCFG_VIDEO_START_OVERRIDE(nmk16_state,macross)
 
 	/* sound hardware */
-	SEIBU_SOUND_SYSTEM_YM3812_INTERFACE(14318180/4, 1320000)
+	MCFG_SPEAKER_STANDARD_MONO("mono")
+
+	MCFG_SOUND_ADD("ymsnd", YM3812, 14318180/4)
+	MCFG_YM3812_IRQ_HANDLER(DEVWRITELINE("seibu_sound", seibu_sound_device, fm_irqhandler))
+	MCFG_SOUND_ROUTE(ALL_OUTPUTS, "mono", 1.0)
+
+	MCFG_OKIM6295_ADD("oki", 1320000, OKIM6295_PIN7_LOW)
+	MCFG_SOUND_ROUTE(ALL_OUTPUTS, "mono", 0.40)
+
+	MCFG_DEVICE_ADD("seibu_sound", SEIBU_SOUND, 0)
+	MCFG_SEIBU_SOUND_CPU("audiocpu")
+	MCFG_SEIBU_SOUND_YM_READ_CB(DEVREAD8("ymsnd", ym3812_device, read))
+	MCFG_SEIBU_SOUND_YM_WRITE_CB(DEVWRITE8("ymsnd", ym3812_device, write))
 MACHINE_CONFIG_END
 
 static MACHINE_CONFIG_START( tdragon, nmk16_state )

--- a/src/mame/drivers/r2dx_v33.cpp
+++ b/src/mame/drivers/r2dx_v33.cpp
@@ -66,6 +66,8 @@ Then it puts settings at 0x9e08 and 0x9e0a (bp 91acb)
 #include "cpu/nec/nec.h"
 #include "cpu/z80/z80.h"
 #include "machine/eepromser.h"
+#include "sound/3812intf.h"
+//#include "sound/ym2151.h"
 #include "sound/okim6295.h"
 #include "includes/raiden2.h"
 #include "machine/r2crypt.h"
@@ -804,9 +806,8 @@ static MACHINE_CONFIG_START( nzerotea, r2dx_v33_state )
 
 	MCFG_MACHINE_RESET_OVERRIDE(r2dx_v33_state,nzeroteam)
 
-
-	//  SEIBU2_RAIDEN2_SOUND_SYSTEM_CPU(14318180/4)
-	SEIBU_NEWZEROTEAM_SOUND_SYSTEM_CPU(14318180/4)
+	MCFG_CPU_ADD("audiocpu", Z80, 14318180/4)
+	MCFG_CPU_PROGRAM_MAP(zeroteam_sound_map)
 
 	MCFG_SCREEN_ADD("screen", RASTER)
 	MCFG_SCREEN_VIDEO_ATTRIBUTES(VIDEO_UPDATE_AFTER_VBLANK)
@@ -827,9 +828,19 @@ static MACHINE_CONFIG_START( nzerotea, r2dx_v33_state )
 	MCFG_SEIBU_CRTC_LAYER_SCROLL_CB(WRITE16(raiden2_state, tile_scroll_w))
 
 	/* sound hardware */
-//  SEIBU_SOUND_SYSTEM_YM2151_RAIDEN2_INTERFACE(28636360/8,28636360/28,1,2)
-	SEIBU_SOUND_SYSTEM_YM3812_INTERFACE(14318180/4,1320000)
+	MCFG_SPEAKER_STANDARD_MONO("mono")
 
+	MCFG_SOUND_ADD("ymsnd", YM3812, 14318180/4)
+	MCFG_YM3812_IRQ_HANDLER(DEVWRITELINE("seibu_sound", seibu_sound_device, fm_irqhandler))
+	MCFG_SOUND_ROUTE(ALL_OUTPUTS, "mono", 1.0)
+
+	MCFG_OKIM6295_ADD("oki", 1320000, OKIM6295_PIN7_LOW)
+	MCFG_SOUND_ROUTE(ALL_OUTPUTS, "mono", 0.40)
+
+	MCFG_DEVICE_ADD("seibu_sound", SEIBU_SOUND, 0)
+	MCFG_SEIBU_SOUND_CPU("audiocpu")
+	MCFG_SEIBU_SOUND_YM_READ_CB(DEVREAD8("ymsnd", ym3812_device, read))
+	MCFG_SEIBU_SOUND_YM_WRITE_CB(DEVWRITE8("ymsnd", ym3812_device, write))
 MACHINE_CONFIG_END
 
 static MACHINE_CONFIG_DERIVED( zerotm2k, nzerotea )

--- a/src/mame/drivers/seicupbl.cpp
+++ b/src/mame/drivers/seicupbl.cpp
@@ -546,7 +546,6 @@ static MACHINE_CONFIG_START( cupsocbl, seicupbl_state )
 	MCFG_DEVICE_SEIBUCOP_BOOTLEG_ADD("seibucop_boot")
 
 	/*Different Sound hardware*/
-	//SEIBU_SOUND_SYSTEM_CPU(14318180/4)
 	MCFG_CPU_ADD("audiocpu", Z80,14318180/4)
 	MCFG_CPU_PROGRAM_MAP(cupsocbl_sound_mem)
 	//MCFG_PERIODIC_INT("screen", nmi_line_pulse)

--- a/src/mame/drivers/sengokmj.cpp
+++ b/src/mame/drivers/sengokmj.cpp
@@ -57,6 +57,7 @@ RSSENGO2.72   chr.
 #include "cpu/nec/nec.h"
 #include "audio/seibu.h"
 #include "sound/3812intf.h"
+#include "sound/okim6295.h"
 #include "video/seibu_crtc.h"
 #include "machine/nvram.h"
 
@@ -570,7 +571,8 @@ static MACHINE_CONFIG_START( sengokmj, sengokmj_state )
 	MCFG_CPU_IO_MAP(sengokmj_io_map)
 	MCFG_CPU_VBLANK_INT_DRIVER("screen", sengokmj_state,  interrupt)
 
-	SEIBU_SOUND_SYSTEM_CPU(14318180/4)
+	MCFG_CPU_ADD("audiocpu", Z80, 14318180/4)
+	MCFG_CPU_PROGRAM_MAP(seibu_sound_map)
 
 	MCFG_NVRAM_ADD_0FILL("nvram")
 
@@ -592,7 +594,19 @@ static MACHINE_CONFIG_START( sengokmj, sengokmj_state )
 	MCFG_PALETTE_FORMAT(xBBBBBGGGGGRRRRR)
 
 	/* sound hardware */
-	SEIBU_SOUND_SYSTEM_YM3812_INTERFACE(14318180/4,1320000)
+	MCFG_SPEAKER_STANDARD_MONO("mono")
+
+	MCFG_SOUND_ADD("ymsnd", YM3812, 14318180/4)
+	MCFG_YM3812_IRQ_HANDLER(DEVWRITELINE("seibu_sound", seibu_sound_device, fm_irqhandler))
+	MCFG_SOUND_ROUTE(ALL_OUTPUTS, "mono", 1.0)
+
+	MCFG_OKIM6295_ADD("oki", 1320000, OKIM6295_PIN7_LOW)
+	MCFG_SOUND_ROUTE(ALL_OUTPUTS, "mono", 0.40)
+
+	MCFG_DEVICE_ADD("seibu_sound", SEIBU_SOUND, 0)
+	MCFG_SEIBU_SOUND_CPU("audiocpu")
+	MCFG_SEIBU_SOUND_YM_READ_CB(DEVREAD8("ymsnd", ym3812_device, read))
+	MCFG_SEIBU_SOUND_YM_WRITE_CB(DEVWRITE8("ymsnd", ym3812_device, write))
 MACHINE_CONFIG_END
 
 

--- a/src/mame/includes/raiden2.h
+++ b/src/mame/includes/raiden2.h
@@ -4,6 +4,9 @@
 #include "machine/seibucop/seibucop.h"
 #include "video/seibu_crtc.h"
 
+ADDRESS_MAP_EXTERN(raiden2_sound_map, 8);
+ADDRESS_MAP_EXTERN(zeroteam_sound_map, 8);
+
 class raiden2_state : public driver_device
 {
 public:


### PR DESCRIPTION
- Eliminate SEIBU_SOUND_SYSTEM configuration macros hiding details of device construction
- Start using devcb for generic YM hookups
- Use device finder to connect seibu_sound_device to audiocpu
- kothello has only one YM2203 and one ADPCM, not two of each

Future changes planned
- Separate SEI0100BU and SIE150 types; Cabal and Dead Angle should each be using two of the former
- Separate SEI80BU device to handle Z80 decryption (Mustache Boy uses this for its main CPU)