### PR TITLE
Remove USE_BGFX option (nw)

### DIFF
--- a/makefile
+++ b/makefile
@@ -591,10 +591,6 @@ ifdef MAP
 PARAMS += --MAP='$(MAP)'
 endif
 
-ifdef USE_BGFX
-PARAMS += --USE_BGFX='$(USE_BGFX)'
-endif
-
 ifdef NOASM
 TARGET_PARAMS += --NOASM='$(NOASM)'
 endif


### PR DESCRIPTION
Wasn't removed when mmicko did 9eb2734495cda6ff0391f317ca2565b421476738