### PR TITLE
Making the RTC chip react on the Aussie Byte

### DIFF
--- a/src/mame/drivers/aussiebyte.cpp
+++ b/src/mame/drivers/aussiebyte.cpp
@@ -64,11 +64,12 @@ static ADDRESS_MAP_START( aussiebyte_io, AS_IO, 8, aussiebyte_state )
 	AM_RANGE(0x1a, 0x1a) AM_WRITE(port1a_w) // membank
 	AM_RANGE(0x1b, 0x1b) AM_WRITE(port1b_w) // winchester control
 	AM_RANGE(0x1c, 0x1f) AM_WRITE(port1c_w) // gpebh select
-	AM_RANGE(0x20, 0x23) AM_DEVREADWRITE("pio2", z80pio_device, read, write)
+	AM_RANGE(0x20, 0x23) AM_DEVREADWRITE("pio2", z80pio_device, read, write)	// kpio
 	AM_RANGE(0x24, 0x27) AM_DEVREADWRITE("sio2", z80sio0_device, ba_cd_r, ba_cd_w)
 	AM_RANGE(0x28, 0x28) AM_READ(port28_r) AM_DEVWRITE("votrax", votrax_sc01_device, write)
 	AM_RANGE(0x2c, 0x2c) AM_DEVWRITE("votrax", votrax_sc01_device, inflection_w)
 	AM_RANGE(0x30, 0x30) AM_WRITE(address_w)
+	//AM_RANGE(0x30, 0x30) AM_DEVWRITE("crtc", mc6845_device, address_w)
 	AM_RANGE(0x31, 0x31) AM_DEVREAD("crtc", mc6845_device, status_r)
 	AM_RANGE(0x32, 0x32) AM_WRITE(register_w)
 	AM_RANGE(0x33, 0x33) AM_READ(port33_r)
@@ -76,7 +77,11 @@ static ADDRESS_MAP_START( aussiebyte_io, AS_IO, 8, aussiebyte_state )
 	AM_RANGE(0x35, 0x35) AM_WRITE(port35_w) // data to vram and aram
 	AM_RANGE(0x36, 0x36) AM_READ(port36_r) // data from vram and aram
 	AM_RANGE(0x37, 0x37) AM_READ(port37_r) // read dispen flag
-	AM_RANGE(0x40, 0x4f) AM_DEVREADWRITE("rtc", msm5832_device, data_r, data_w)
+	AM_RANGE(0x40, 0x4f) AM_READWRITE(rtc_data_r, rtc_data_w)
+	//AM_RANGE(0x40, 0x4f) AM_DEVREADWRITE("rtc", msm5832_device, data_r, data_w)
+	//AM_RANGE(0x40, 0x4f) AM_DEVREAD("rtc", msm5832_device, data_r)
+	//AM_RANGE(0x40, 0x4f) AM_DEVWRITE("rtc", msm5832_device, data_w)
+
 ADDRESS_MAP_END
 
 /***********************************************************
@@ -92,6 +97,31 @@ INPUT_PORTS_END
     I/O Ports
 
 ************************************************************/
+
+
+// Realt Time Clock.
+// Enable signals are controlled by port 20h,
+// 40h .. 4fh reach the clock data
+
+READ8_MEMBER( aussiebyte_state::rtc_data_r )
+{
+	m_rtc->address_w(offset & 0x0f);
+	m_rtc->write_w(0);
+	m_rtc->read_w(1);
+	return (m_rtc->data_r(space,0));
+}
+
+WRITE8_MEMBER( aussiebyte_state::rtc_data_w )
+{
+	m_rtc->write_w(0);
+	m_rtc->read_w(0);
+	m_rtc->address_w(offset & 0x0f);
+	//m_rtc->data_w(space,0,data & 0x0f);
+	m_rtc->data_w(space,0,data);
+	m_rtc->write_w(1);
+}
+
+
 WRITE8_MEMBER( aussiebyte_state::port15_w )
 {
 	membank("bankr0")->set_entry(m_port15); // point at ram
@@ -212,9 +242,12 @@ WRITE8_MEMBER( aussiebyte_state::port1c_w )
 {
 }
 
+// kpio
 WRITE8_MEMBER( aussiebyte_state::port20_w )
 {
 	m_speaker->level_w(BIT(data, 7));
+	m_rtc->cs_w(BIT(data, 6));	// BIOS keeps bit 6 always set
+	m_rtc->hold_w(BIT(data, 0));	// BIOS outputs to $41/$40, for RTC, in comments is is said to set/reset "hold line"
 }
 
 READ8_MEMBER( aussiebyte_state::port28_r )
@@ -436,6 +469,7 @@ MACHINE_RESET_MEMBER( aussiebyte_state, aussiebyte )
 	membank("bankw0")->set_entry(1); // always write to ram
 	membank("bank1")->set_entry(2);
 	membank("bank2")->set_entry(3);
+
 	m_maincpu->reset();
 }
 
@@ -496,6 +530,7 @@ static MACHINE_CONFIG_START( aussiebyte, aussiebyte_state )
 	MCFG_Z80PIO_IN_PB_CB(DEVREAD8("cent_data_in", input_buffer_device, read))
 	MCFG_Z80PIO_OUT_ARDY_CB(DEVWRITELINE("centronics", centronics_device, write_strobe)) MCFG_DEVCB_INVERT
 
+	// kpio
 	MCFG_DEVICE_ADD("pio2", Z80PIO, XTAL_16MHz / 4)
 	MCFG_Z80PIO_OUT_INT_CB(INPUTLINE("maincpu", INPUT_LINE_IRQ0))
 	MCFG_Z80PIO_OUT_PA_CB(WRITE8(aussiebyte_state, port20_w))

--- a/src/mame/includes/aussiebyte.h
+++ b/src/mame/includes/aussiebyte.h
@@ -47,6 +47,7 @@ public:
 		, m_floppy0(*this, "fdc:0")
 		, m_floppy1(*this, "fdc:1")
 		, m_crtc(*this, "crtc")
+		, m_rtc(*this, "rtc")
 		, m_speaker(*this, "speaker")
 		, m_votrax(*this, "votrax")
 	{}
@@ -80,6 +81,9 @@ public:
 	DECLARE_WRITE_LINE_MEMBER(sio2_rdya_w);
 	DECLARE_WRITE_LINE_MEMBER(sio2_rdyb_w);
 	DECLARE_WRITE_LINE_MEMBER(clock_w);
+	DECLARE_READ_LINE_MEMBER(clock_r);
+	DECLARE_READ8_MEMBER(rtc_data_r);
+	DECLARE_WRITE8_MEMBER(rtc_data_w);
 	DECLARE_MACHINE_RESET(aussiebyte);
 	DECLARE_DRIVER_INIT(aussiebyte);
 	DECLARE_WRITE_LINE_MEMBER(ctc_z0_w);
@@ -122,6 +126,7 @@ private:
 	required_device<floppy_connector> m_floppy0;
 	optional_device<floppy_connector> m_floppy1;
 	required_device<mc6845_device> m_crtc;
+	required_device<msm5832_device> m_rtc;
 	required_device<speaker_sound_device> m_speaker;
 	required_device<votrax_sc01_device> m_votrax;
 };


### PR DESCRIPTION
The Aussie Byte Single Board Computer has the Real Time Clock chip directly connected to the internal BUS (no extra I/O layer is present), so many port addresses are used.   The current clock chip driver expect such layer, thus a workaround similar to the one used for the Otrona Attache is necessary.