### PR TITLE
added id8751h dumps to 'csilver' and 'srdarwin', not hooked up yet [Caps0ff]

### DIFF
--- a/src/mame/drivers/dec8.cpp
+++ b/src/mame/drivers/dec8.cpp
@@ -3210,7 +3210,8 @@ ROM_START( csilver )
 	ROM_CONTINUE(   0x08000, 0x08000 )
 
 	ROM_REGION( 0x1000, "mcu", 0 )    /* ID8751H MCU */
-	ROM_LOAD( "id8751h.mcu", 0x0000, 0x1000, NO_DUMP ) // dx-8.19a ?
+	// 017F: B4 4C 0D : cjne  a,#$4C,$018F   (ID code 0x4c = World version)
+	ROM_LOAD( "id8751h.mcu", 0x0000, 0x1000, CRC(ca663965) SHA1(a5fb7afdfd324761bde4bb90ba12efc9954627af) ) // dx-8.19a ?
 
 	ROM_REGION( 0x08000, "gfx1", 0 )    /* characters */
 	ROM_LOAD( "dx00.3d",  0x00000, 0x08000, CRC(f01ef985) SHA1(d5b823bd7c0efcf3137f8643c5d99a260bed5675) )
@@ -3410,7 +3411,8 @@ ROM_START( srdarwin )
 	ROM_LOAD( "dy04.d7", 0x8000, 0x8000, CRC(2ae3591c) SHA1(f21b06d84e2c3d3895be0812024641fd006e45cf) )
 
 	ROM_REGION( 0x1000, "mcu", 0 )    /* ID8751H MCU */
-	ROM_LOAD( "id8751h.mcu", 0x0000, 0x1000, NO_DUMP )
+	// 0160: B4 6B 0D : cjne  a,#$6B,$0170   (ID code 0x6b = World version)
+	ROM_LOAD( "id8751h.mcu", 0x0000, 0x1000, CRC(11cd6ca4) SHA1(ec70f84228e37f9fc1bda85fa52a009f61c500b2) )
 
 	ROM_REGION( 0x08000, "gfx1", 0 )    /* characters */
 	ROM_LOAD( "dy05.b6", 0x00000, 0x4000, CRC(8780e8a3) SHA1(03ea91fdc5aba8e139201604fb3bf9b69f71f056) )


### PR DESCRIPTION
(dumps look good, hookups appears to be slightly different to other games due to different main CPU and interrupt schemes, still investigating)

(these can probably be used for the japanese clones if the ID byte is changed to create a fake rom, as was done for the other sets in the driver)