### PR TITLE
Support for earlier COS versions on the RM380Z

### DIFF
--- a/src/devices/video/tms9927.cpp
+++ b/src/devices/video/tms9927.cpp
@@ -21,7 +21,7 @@ static const uint8_t skew_bits_value[4] = { 0, 1, 2, 2 };
 #define SCANS_PER_DATA_ROW   (((m_reg[2] >> 3) & 0x0f) + 1)
 #define CHARS_PER_DATA_ROW   (chars_per_row_value[(m_reg[2] >> 0) & 0x07])
 #define SKEW_BITS            (skew_bits_value[(m_reg[3] >> 6) & 0x03])
-#define DATA_ROWS_PER_FRAME  (((m_reg[3] >> 0) & 0x3f) + 1)
+#define DATA_ROWS_PER_FRAME  ((m_reg[3] & 0x3f) + 1)
 #define SCAN_LINES_PER_FRAME ((m_reg[4] * 2) + 256 + (((m_reg[1] >> 7) & 0x01) * 257))
 #define VERTICAL_DATA_START  (m_reg[5])
 #define LAST_DISP_DATA_ROW   (m_reg[6] & 0x3f)
@@ -179,7 +179,6 @@ void tms9927_device::generic_access(address_space &space, offs_t offset)
 			break;
 
 		case 0x0b:  /* Up scroll */
-osd_printf_debug("Up scroll\n");
 			m_screen->update_now();
 			m_start_datarow = (m_start_datarow + 1) % DATA_ROWS_PER_FRAME;
 			break;
@@ -215,7 +214,9 @@ WRITE8_MEMBER( tms9927_device::write )
 		case 0x0d:  /* LOAD CURSOR ROW ADDRESS */
 osd_printf_debug("Cursor address changed\n");
 			m_reg[offset - 0x0c + 7] = data;
-			recompute_parameters(false);
+			/* Recomputing parameters here will break the scrollup on the Attachè 
+			   and probably other machines due to m_start_datarow being reset ! */
+			//recompute_parameters(false);
 			break;
 
 		default:

--- a/src/mame/drivers/expro02.cpp
+++ b/src/mame/drivers/expro02.cpp
@@ -1652,8 +1652,8 @@ ROM_END
 
 ROM_START( missw02)
 	ROM_REGION( 0x500000, "maincpu", 0 )    /* 68000 code */
-	ROM_LOAD16_BYTE( "8.u81",      0x000000, 0x80000,  CRC(316666d0) SHA1(0ebebc55b49c1d00adac2b04bcfe9cfb317e8e74) ) // stickered as Miss World 2002 Rev.A, however
-	ROM_LOAD16_BYTE( "7.u80",      0x000001, 0x80000,  CRC(d61f4d18) SHA1(caef5fb221cafc354875ef5b68e84419f91c0db7) ) // "B" nudity level comparable to Miss World '96 (Nude) (C-3000B)
+	ROM_LOAD16_BYTE( "8.u81",      0x000000, 0x80000,  CRC(316666d0) SHA1(0ebebc55b49c1d00adac2b04bcfe9cfb317e8e74) ) // stickered as Miss World 2002 Rev.A
+	ROM_LOAD16_BYTE( "7.u80",      0x000001, 0x80000,  CRC(d61f4d18) SHA1(caef5fb221cafc354875ef5b68e84419f91c0db7) )
 	ROM_LOAD16_WORD_SWAP( "3.bin", 0x100000, 0x200000, CRC(fdfe36ba) SHA1(128277e44e2368267e097bb3510c797cc690d1ff) )
 	ROM_LOAD16_WORD_SWAP( "4.bin", 0x300000, 0x200000, CRC(aa769a81) SHA1(2beb6da9327ddce7bec934bcf610061fc3b9ab09) )
 
@@ -1862,7 +1862,7 @@ GAME( 1997, fantsia2a,fantsia2, fantsia2, missw96,   driver_device, 0, ROT0,  "C
 GAME( 1998, fantsia2n,fantsia2, fantsia2, missw96,   driver_device, 0, ROT0,  "Comad",                    "Fantasia II (1998)", MACHINE_NO_COCKTAIL | MACHINE_SUPPORTS_SAVE )          // "A" nudity level
 
 GAME( 2002, wownfant, 0,        fantsia2, missw96,   driver_device, 0, ROT0,  "Comad",                    "WOW New Fantasia", MACHINE_NO_COCKTAIL | MACHINE_SUPPORTS_SAVE ) // "B" nudity level
-GAME( 2002, missw02,  0,        fantsia2, missw96,   driver_device, 0, ROT0,  "Diagom",                   "Miss World 2002", MACHINE_NO_COCKTAIL | MACHINE_SUPPORTS_SAVE )  // "B" nudity level
+GAME( 2002, missw02,  0,        fantsia2, missw96,   driver_device, 0, ROT0,  "Diagom",                   "Miss World 2002", MACHINE_NO_COCKTAIL | MACHINE_SUPPORTS_SAVE )  // "A" nudity level
 
 GAME( 1996, pgalvip,  0,        galhustl, galhustl,  driver_device, 0, ROT0,  "ACE International / Afega","Pocket Gals V.I.P (set 1)", MACHINE_IMPERFECT_GRAPHICS | MACHINE_SUPPORTS_SAVE ) // roms were all AFEGA stickered, select screen seems wrong? maybe not a final version.
 GAME( 1997, pgalvipa, pgalvip,  galhustl, galhustl,  driver_device, 0, ROT0,  "<unknown>",                "Pocket Gals V.I.P (set 2)", MACHINE_SUPPORTS_SAVE )

--- a/src/mame/drivers/expro02.cpp
+++ b/src/mame/drivers/expro02.cpp
@@ -1862,7 +1862,7 @@ GAME( 1997, fantsia2a,fantsia2, fantsia2, missw96,   driver_device, 0, ROT0,  "C
 GAME( 1998, fantsia2n,fantsia2, fantsia2, missw96,   driver_device, 0, ROT0,  "Comad",                    "Fantasia II (1998)", MACHINE_NO_COCKTAIL | MACHINE_SUPPORTS_SAVE )          // "A" nudity level
 
 GAME( 2002, wownfant, 0,        fantsia2, missw96,   driver_device, 0, ROT0,  "Comad",                    "WOW New Fantasia", MACHINE_NO_COCKTAIL | MACHINE_SUPPORTS_SAVE ) // "B" nudity level
-GAME( 2002, missw02,  0,        fantsia2, missw96,   driver_device, 0, ROT0,  "Diagom",                   "Miss World 2002", MACHINE_NO_COCKTAIL | MACHINE_SUPPORTS_SAVE )  // "A" nudity level
+GAME( 2002, missw02,  0,        fantsia2, missw96,   driver_device, 0, ROT0,  "Daigom",                   "Miss World 2002", MACHINE_NO_COCKTAIL | MACHINE_SUPPORTS_SAVE )  // "A" nudity level
 
 GAME( 1996, pgalvip,  0,        galhustl, galhustl,  driver_device, 0, ROT0,  "ACE International / Afega","Pocket Gals V.I.P (set 1)", MACHINE_IMPERFECT_GRAPHICS | MACHINE_SUPPORTS_SAVE ) // roms were all AFEGA stickered, select screen seems wrong? maybe not a final version.
 GAME( 1997, pgalvipa, pgalvip,  galhustl, galhustl,  driver_device, 0, ROT0,  "<unknown>",                "Pocket Gals V.I.P (set 2)", MACHINE_SUPPORTS_SAVE )

--- a/src/mame/drivers/rm380z.cpp
+++ b/src/mame/drivers/rm380z.cpp
@@ -8,6 +8,9 @@ Microcomputer produced by Research Machines Limited, Oxford, UK
 MESS driver by Wilbert Pol and friol (dantonag (at) gmail.com)
 Driver started on 22/12/2011
 
+Stefano Bodrato, 09/12/2016 - skeleton for cassette support
+True tape samples are needed to continue !
+
 ===
 
 Memory map from sevice manual:
@@ -146,6 +149,12 @@ static MACHINE_CONFIG_START( rm380z, rm380z_state )
 
 	MCFG_PALETTE_ADD_MONOCHROME("palette")
 
+	/* cassette */
+	MCFG_CASSETTE_ADD( "cassette" )
+//	MCFG_CASSETTE_DEFAULT_STATE(CASSETTE_STOPPED | CASSETTE_MOTOR_ENABLED | CASSETTE_SPEAKER_MUTED)
+	MCFG_CASSETTE_DEFAULT_STATE(CASSETTE_PLAY | CASSETTE_MOTOR_ENABLED)
+	//m_cassette->change_state((BIT(data,x)) ? CASSETTE_MOTOR_DISABLED : CASSETTE_MOTOR_ENABLED, CASSETTE_MASK_MOTOR);
+
 	/* RAM configurations */
 	MCFG_RAM_ADD(RAM_TAG)
 	MCFG_RAM_DEFAULT_SIZE("56K")
@@ -161,10 +170,28 @@ static MACHINE_CONFIG_START( rm380z, rm380z_state )
 	MCFG_GENERIC_KEYBOARD_CB(WRITE8(rm380z_state, keyboard_put))
 MACHINE_CONFIG_END
 
-/* ROM definition */
+
+
+/* ROM definitions */
+
+ROM_START( rm380z34d )
+	ROM_REGION( 0x10000, RM380Z_MAINCPU_TAG, 0 )	
+	ROM_LOAD( "cos34d-f.bin", 0x0000, 0x1000, CRC(eb128b40) SHA1(c46f358fb76459987e41750d052995563f2f7d53))
+	// chargen ROM is undumped, afaik
+	ROM_REGION( 0x1680, "chargen", 0 )
+	ROM_LOAD( "ch3.raw", 0x0000, 0x1680, BAD_DUMP CRC(c223622b) SHA1(185ef24896419d7ff46f71a760ac217de3811684))
+ROM_END
+
+ROM_START( rm380z34e )
+	ROM_REGION( 0x10000, RM380Z_MAINCPU_TAG, 0 )
+	ROM_LOAD( "cos34e-m.bin", 0x0000, 0x1000, CRC(20e2ddf4) SHA1(3177b28793d5a348c94fd0ae6393d74e2e9a8662))
+	// chargen ROM is undumped, afaik
+	ROM_REGION( 0x1680, "chargen", 0 )
+	ROM_LOAD( "ch3.raw", 0x0000, 0x1680, BAD_DUMP CRC(c223622b) SHA1(185ef24896419d7ff46f71a760ac217de3811684))
+ROM_END
+
 ROM_START( rm380z )
 	ROM_REGION( 0x10000, RM380Z_MAINCPU_TAG, 0 )
-//  ROM_LOAD( "cos34e-m.bin", 0x0000, 0x1000, CRC(20e2ddf4) SHA1(3177b28793d5a348c94fd0ae6393d74e2e9a8662))
 	// I'm not sure of how those roms have been dumped. I don't know if those are good dumps or not.
 	ROM_LOAD( "cos40b-m.bin", 0x0000, 0x1000, BAD_DUMP CRC(1f0b3a5c) SHA1(0b29cb2a3b7eaa3770b34f08c4fd42844f42700f))
 	ROM_LOAD( "cos40b-m_f600-f9ff.bin", 0x1000, 0x400, BAD_DUMP CRC(e3397d9d) SHA1(490a0c834b0da392daf782edc7d51ca8f0668b1a))
@@ -172,8 +199,15 @@ ROM_START( rm380z )
 	// chargen ROM is undumped, afaik
 	ROM_REGION( 0x1680, "chargen", 0 )
 	ROM_LOAD( "ch3.raw", 0x0000, 0x1680, BAD_DUMP CRC(c223622b) SHA1(185ef24896419d7ff46f71a760ac217de3811684))
+	// The characters on the 480Z are very close (or identical) to the 380Z ones
+	//ROM_REGION( 0x2000, "chargen", 0 )
+	//ROM_LOAD( "CG06.BIN", 0x0000, 0x2000, CRC(15d40f7e) SHA1(a7266357eb9be849f77a97ff3013b236c0af8289))
 ROM_END
 
-/* Driver */
 
-COMP(1978, rm380z, 0,      0,       rm380z,    rm380z, driver_device,  0,    "Research Machines", "RM-380Z", MACHINE_NO_SOUND_HW)
+/* Driver */
+/*   YEAR  NAME        PARENT    COMPAT   MACHINE     INPUT     CLASS            INIT        COMPANY                 FULLNAME */
+COMP(1978, rm380z,       0,        0,     rm380z,     rm380z,   rm380z_state,    rm380z,     "Research Machines",    "RM-380Z, COS 4.0B", MACHINE_NO_SOUND_HW)
+COMP(1978, rm380z34d,   rm380z,    0,     rm380z,     rm380z,   rm380z_state,    rm380z34d,  "Research Machines",    "RM-380Z, COS 3.4D", MACHINE_BTANB_FLAGS)
+COMP(1978, rm380z34e,   rm380z,    0,     rm380z,     rm380z,   rm380z_state,    rm380z34e,  "Research Machines",    "RM-380Z, COS 3.4E", MACHINE_BTANB_FLAGS)
+

--- a/src/mame/includes/aussiebyte.h
+++ b/src/mame/includes/aussiebyte.h
@@ -47,9 +47,9 @@ public:
 		, m_floppy0(*this, "fdc:0")
 		, m_floppy1(*this, "fdc:1")
 		, m_crtc(*this, "crtc")
-		, m_rtc(*this, "rtc")
 		, m_speaker(*this, "speaker")
 		, m_votrax(*this, "votrax")
+		, m_rtc(*this, "rtc")
 	{}
 
 	DECLARE_READ8_MEMBER(memory_read_byte);
@@ -72,6 +72,8 @@ public:
 	DECLARE_WRITE8_MEMBER(port35_w);
 	DECLARE_READ8_MEMBER(port36_r);
 	DECLARE_READ8_MEMBER(port37_r);
+	DECLARE_READ8_MEMBER(rtc_r);
+	DECLARE_WRITE8_MEMBER(rtc_w);
 	DECLARE_WRITE_LINE_MEMBER(fdc_intrq_w);
 	DECLARE_WRITE_LINE_MEMBER(fdc_drq_w);
 	DECLARE_WRITE_LINE_MEMBER(busreq_w);
@@ -81,9 +83,6 @@ public:
 	DECLARE_WRITE_LINE_MEMBER(sio2_rdya_w);
 	DECLARE_WRITE_LINE_MEMBER(sio2_rdyb_w);
 	DECLARE_WRITE_LINE_MEMBER(clock_w);
-	DECLARE_READ_LINE_MEMBER(clock_r);
-	DECLARE_READ8_MEMBER(rtc_data_r);
-	DECLARE_WRITE8_MEMBER(rtc_data_w);
 	DECLARE_MACHINE_RESET(aussiebyte);
 	DECLARE_DRIVER_INIT(aussiebyte);
 	DECLARE_WRITE_LINE_MEMBER(ctc_z0_w);
@@ -126,7 +125,7 @@ private:
 	required_device<floppy_connector> m_floppy0;
 	optional_device<floppy_connector> m_floppy1;
 	required_device<mc6845_device> m_crtc;
-	required_device<msm5832_device> m_rtc;
 	required_device<speaker_sound_device> m_speaker;
 	required_device<votrax_sc01_device> m_votrax;
+	required_device<msm5832_device> m_rtc;
 };

--- a/src/mame/includes/rm380z.h
+++ b/src/mame/includes/rm380z.h
@@ -12,6 +12,7 @@ Research Machines RM 380Z
 
 #include "emu.h"
 #include "cpu/z80/z80.h"
+#include "imagedev/cassette.h"
 #include "machine/ram.h"
 #include "imagedev/flopdrv.h"
 #include "machine/wd_fdc.h"
@@ -66,6 +67,7 @@ protected:
 public:
 
 	uint8_t m_port0;
+	uint8_t m_port0_mask;
 	uint8_t m_port0_kbd;
 	uint8_t m_port1;
 	uint8_t m_fbfd;
@@ -88,6 +90,7 @@ public:
 	int m_old_videomode;
 
 	required_device<cpu_device> m_maincpu;
+	required_device<cassette_image_device> m_cassette;
 	required_device<ram_device> m_messram;
 	required_device<fd1771_t> m_fdc;
 	required_device<floppy_connector> m_floppy0;
@@ -96,6 +99,7 @@ public:
 	rm380z_state(const machine_config &mconfig, device_type type, const char *tag)
 		: driver_device(mconfig, type, tag),
 		m_maincpu(*this, RM380Z_MAINCPU_TAG),
+		m_cassette(*this, "cassette"),
 		m_messram(*this, RAM_TAG),
 		m_fdc(*this, "wd1771"),
 		m_floppy0(*this, "wd1771:0"),
@@ -123,6 +127,11 @@ public:
 	DECLARE_WRITE8_MEMBER(disk_0_control);
 
 	DECLARE_WRITE8_MEMBER( keyboard_put );
+	
+	DECLARE_DRIVER_INIT(rm380z);
+	DECLARE_DRIVER_INIT(rm380z34d);
+	DECLARE_DRIVER_INIT(rm380z34e);
+	DECLARE_DRIVER_INIT(rm480z);
 
 	void config_memory_map();
 	void update_screen(bitmap_ind16 &bitmap);

--- a/src/mame/machine/rm380z.cpp
+++ b/src/mame/machine/rm380z.cpp
@@ -33,6 +33,9 @@ WRITE8_MEMBER( rm380z_state::port_write )
 	case 0xFC:      // PORT0
 		//printf("FBFCw[%2.2x] FBFD [%2.2x] FBFE [%2.2x] PC [%4.4x] writenum [%4.4x]\n",data,m_fbfd,m_fbfe,m_maincpu->safe_pc(),writenum);
 		m_port0 = data;
+		
+		m_cassette->output((m_port0 & 0xEF) ? +1.0 : -1.0);	// set 2400hz, bit 4
+
 		if (data&0x01)
 		{
 			//printf("WARNING: bit0 of port0 reset\n");
@@ -57,9 +60,11 @@ WRITE8_MEMBER( rm380z_state::port_write )
 
 		break;
 
+	// port 1
 	case 0xFE:      // line on screen to write to divided by 2
 		//printf("FBFC [%2.2x] FBFD [%2.2x] FBFEw[%2.2x] PC [%4.4x] writenum [%4.4x]\n",m_port0,m_fbfd,data,m_maincpu->safe_pc(),writenum);
 		m_fbfe=data;
+		
 		break;
 
 	case 0xFF:      // user I/O port
@@ -92,6 +97,11 @@ READ8_MEMBER( rm380z_state::port_read )
 		break;
 
 	case 0xFE:      // PORT1
+		if ((m_cassette)->input() < +0.0)
+			m_port1 &= 0xDF;	// bit 5 off
+		else
+			m_port1 |= 0x20;	// bit 5 on
+			
 		data = m_port1;
 		//printf("read of port1 from PC [%x]\n",m_maincpu->safe_pc());
 		break;
@@ -230,6 +240,28 @@ void rm380z_state::machine_start()
 	machine().scheduler().timer_pulse(attotime::from_hz(TIMER_SPEED), timer_expired_delegate(FUNC(rm380z_state::static_vblank_timer),this));
 }
 
+DRIVER_INIT_MEMBER( rm380z_state, rm380z )
+{
+	m_videomode=RM380Z_VIDEOMODE_80COL;
+	m_old_videomode=m_videomode;
+	m_port0_mask=0xff;
+}
+
+DRIVER_INIT_MEMBER( rm380z_state, rm380z34d )
+{
+	m_videomode=RM380Z_VIDEOMODE_40COL;
+	m_old_videomode=m_videomode;
+	m_port0_mask=0xdf;		// disable 80 column mode
+}
+
+DRIVER_INIT_MEMBER( rm380z_state, rm380z34e )
+{
+	m_videomode=RM380Z_VIDEOMODE_40COL;
+	m_old_videomode=m_videomode;
+	m_port0_mask=0xdf;		// disable 80 column mode
+}
+
+
 void rm380z_state::machine_reset()
 {
 	m_port0=0x00;
@@ -241,8 +273,8 @@ void rm380z_state::machine_reset()
 	m_old_old_fbfd=0x00;
 	writenum=0;
 
-	m_videomode=RM380Z_VIDEOMODE_80COL;
-	m_old_videomode=m_videomode;
+//	m_videomode=RM380Z_VIDEOMODE_80COL;
+//	m_old_videomode=m_videomode;
 	m_rasterlineCtr=0;
 
 	// note: from COS 4.0 videos, screen seems to show garbage at the beginning

--- a/src/mame/video/rm380z.cpp
+++ b/src/mame/video/rm380z.cpp
@@ -51,7 +51,7 @@ void rm380z_state::init_graphic_chars()
 
 void rm380z_state::config_videomode()
 {
-	if (m_port0&0x20)
+	if (m_port0&0x20&m_port0_mask)
 	{
 		// 80 cols
 		m_videomode=RM380Z_VIDEOMODE_80COL;


### PR DESCRIPTION
The Research Machines 380Z was delivered in several variants.   The earlier versions had only a 40 columns display and the cassette tape interface.
