### PR TITLE
automat: Sound improvements

### DIFF
--- a/src/mame/drivers/dec0.cpp
+++ b/src/mame/drivers/dec0.cpp
@@ -43,7 +43,8 @@ Original Service Manuals and Service Mode (when available).
 
 ToDo:
 - Fix protection simulation in Birdie Try (that part needs at least comparison with a real board);
-- graphics are completely broken in Automat and Secret Agent (bootleg);
+- Fix remaining graphical problems in Automat (bootleg);
+- graphics and sound are completely broken in Secret Agent (bootleg);
 - Fighting Fantasy (bootleg) doesn't boot at all;
 - Hook up the 68705 in Midnight Resistance (bootleg) (it might not be used, leftover from the Fighting Fantasy bootleg on the same PCB?)
 - Get rid of ROM patches in Sly Spy and Hippodrome;
@@ -531,9 +532,14 @@ ADDRESS_MAP_END
 
 void dec0_automat_state::machine_start()
 {
-	save_item(NAME(m_automat_adpcm_byte));
-	save_item(NAME(m_automat_msm5205_vclk_toggle));
+	m_adpcm_toggle1 = false;
+	m_adpcm_toggle2 = false;
+	save_item(NAME(m_adpcm_toggle1));
+	save_item(NAME(m_adpcm_toggle2));
 	save_item(NAME(m_automat_scroll_regs));
+
+	m_soundbank->configure_entries(0, 4, memregion("audiocpu")->base(), 0x4000);
+	m_soundbank->set_entry(0);
 }
 
 
@@ -584,6 +590,8 @@ static ADDRESS_MAP_START( automat_map, AS_PROGRAM, 16, dec0_automat_state )
 	AM_RANGE(0x400000, 0x400007) AM_WRITE(automat_scroll_w)
 	AM_RANGE(0x400008, 0x400009) AM_WRITE(dec0_priority_w)
 
+	AM_RANGE(0x500000, 0x500001) AM_WRITENOP // ???
+
 	AM_RANGE(0xff8000, 0xffbfff) AM_RAM AM_SHARE("ram")             /* Main ram */
 	AM_RANGE(0xffc000, 0xffcfff) AM_RAM AM_SHARE("spriteram")           /* Sprites */
 ADDRESS_MAP_END
@@ -616,19 +624,16 @@ static ADDRESS_MAP_START( secretab_map, AS_PROGRAM, 16, dec0_automat_state )
 ADDRESS_MAP_END
 
 
-WRITE8_MEMBER(dec0_automat_state::automat_adpcm_w)
-{
-	m_automat_adpcm_byte = data;
-}
-
 static ADDRESS_MAP_START( automat_s_map, AS_PROGRAM, 8, dec0_automat_state )
-	AM_RANGE(0x0103, 0x0103) AM_WRITENOP
+	AM_RANGE(0x0000, 0x7fff) AM_ROM
+	AM_RANGE(0x8000, 0xbfff) AM_ROMBANK("soundbank")
 	AM_RANGE(0xc000, 0xc7ff) AM_RAM
-	AM_RANGE(0xc800, 0xc801) AM_DEVWRITE("2203a", ym2203_device, write)
-	AM_RANGE(0xd800, 0xd800) AM_DEVREAD("soundlatch", generic_latch_8_device, read)
-	AM_RANGE(0xd000, 0xd001) AM_DEVWRITE("2203b", ym2203_device, write)
-	AM_RANGE(0xf000, 0xf000) AM_WRITE(automat_adpcm_w)
-	AM_RANGE(0x0000, 0xffff) AM_ROM
+	AM_RANGE(0xc800, 0xc801) AM_DEVREADWRITE("2203a", ym2203_device, read, write)
+	AM_RANGE(0xd000, 0xd001) AM_DEVREADWRITE("2203b", ym2203_device, read, write)
+	AM_RANGE(0xd800, 0xd800) AM_READ(sound_command_r)
+	AM_RANGE(0xe000, 0xe000) AM_DEVWRITE("adpcm_select2", ls157_device, ba_w)
+	AM_RANGE(0xe800, 0xe800) AM_WRITE(sound_bankswitch_w)
+	AM_RANGE(0xf000, 0xf000) AM_DEVWRITE("adpcm_select1", ls157_device, ba_w)
 ADDRESS_MAP_END
 
 static ADDRESS_MAP_START( mcu_io_map, AS_IO, 8, dec0_state )
@@ -1358,19 +1363,37 @@ static MACHINE_CONFIG_DERIVED( dec1, dec0_base )
 MACHINE_CONFIG_END
 
 
-WRITE_LINE_MEMBER(dec0_automat_state::automat_vclk_cb)
+READ8_MEMBER(dec0_automat_state::sound_command_r)
 {
-	if (m_automat_msm5205_vclk_toggle == 0)
-	{
-		m_msm->data_w(m_automat_adpcm_byte & 0xf);
-	}
-	else
-	{
-		m_msm->data_w(m_automat_adpcm_byte >> 4);
-		//device->m_audiocpu->set_input_line(INPUT_LINE_NMI, PULSE_LINE); // gives some scratch samples but breaks other sounds too
-	}
+	m_audiocpu->set_input_line(0, CLEAR_LINE);
+	return m_soundlatch->read(space, 0);
+}
 
-	m_automat_msm5205_vclk_toggle ^= 1;
+WRITE8_MEMBER(dec0_automat_state::sound_bankswitch_w)
+{
+	m_msm1->reset_w(BIT(data, 3));
+	m_msm2->reset_w(BIT(data, 4));
+
+	m_soundbank->set_entry(data & 3);
+}
+
+WRITE_LINE_MEMBER(dec0_automat_state::msm1_vclk_cb)
+{
+	if (!state)
+		return;
+
+	m_adpcm_toggle1 = !m_adpcm_toggle1;
+	m_adpcm_select1->select_w(m_adpcm_toggle1);
+	m_audiocpu->set_input_line(INPUT_LINE_NMI, m_adpcm_toggle1);
+}
+
+WRITE_LINE_MEMBER(dec0_automat_state::msm2_vclk_cb)
+{
+	if (!state)
+		return;
+
+	m_adpcm_toggle2 = !m_adpcm_toggle2;
+	m_adpcm_select2->select_w(m_adpcm_toggle2);
 }
 
 
@@ -1418,21 +1441,32 @@ static MACHINE_CONFIG_START( automat, dec0_automat_state )
 
 	MCFG_GENERIC_LATCH_8_ADD("soundlatch")
 
-	MCFG_SOUND_ADD("2203a", YM2203, 1500000)
+	MCFG_SOUND_ADD("2203a", YM2203, 1250000)
 	MCFG_SOUND_ROUTE(0, "mono", 0.90)
 	MCFG_SOUND_ROUTE(1, "mono", 0.90)
 	MCFG_SOUND_ROUTE(2, "mono", 0.90)
 	MCFG_SOUND_ROUTE(3, "mono", 0.35)
 
-	MCFG_SOUND_ADD("2203b", YM2203, 1500000)
+	MCFG_SOUND_ADD("2203b", YM2203, 1250000)
 	MCFG_SOUND_ROUTE(0, "mono", 0.90)
 	MCFG_SOUND_ROUTE(1, "mono", 0.90)
 	MCFG_SOUND_ROUTE(2, "mono", 0.90)
 	MCFG_SOUND_ROUTE(3, "mono", 0.35)
 
-	MCFG_SOUND_ADD("msm", MSM5205, 384000/2)
-	MCFG_MSM5205_VCLK_CB(WRITELINE(dec0_automat_state, automat_vclk_cb))
-	MCFG_MSM5205_PRESCALER_SELECTOR(MSM5205_S48_4B)
+	MCFG_DEVICE_ADD("adpcm_select1", LS157, 0)
+	MCFG_74LS157_OUT_CB(DEVWRITE8("msm1", msm5205_device, data_w))
+
+	MCFG_DEVICE_ADD("adpcm_select2", LS157, 0)
+	MCFG_74LS157_OUT_CB(DEVWRITE8("msm2", msm5205_device, data_w))
+
+	MCFG_SOUND_ADD("msm1", MSM5205, 384000)
+	MCFG_MSM5205_VCLK_CB(WRITELINE(dec0_automat_state, msm1_vclk_cb))
+	MCFG_MSM5205_PRESCALER_SELECTOR(MSM5205_S96_4B)
+	MCFG_SOUND_ROUTE(ALL_OUTPUTS, "mono", 1.0)
+
+	MCFG_SOUND_ADD("msm2", MSM5205, 384000)
+	MCFG_MSM5205_VCLK_CB(WRITELINE(dec0_automat_state, msm2_vclk_cb))
+	MCFG_MSM5205_PRESCALER_SELECTOR(MSM5205_S96_4B)
 	MCFG_SOUND_ROUTE(ALL_OUTPUTS, "mono", 1.0)
 MACHINE_CONFIG_END
 
@@ -1481,23 +1515,33 @@ static MACHINE_CONFIG_START( secretab, dec0_automat_state )
 
 	MCFG_GENERIC_LATCH_8_ADD("soundlatch")
 
-	MCFG_SOUND_ADD("2203a", YM2203, 1500000)
+	MCFG_SOUND_ADD("2203a", YM2203, 1250000)
 	MCFG_SOUND_ROUTE(0, "mono", 0.90)
 	MCFG_SOUND_ROUTE(1, "mono", 0.90)
 	MCFG_SOUND_ROUTE(2, "mono", 0.90)
 	MCFG_SOUND_ROUTE(3, "mono", 0.35)
 
-	MCFG_SOUND_ADD("2203b", YM2203, 1500000)
+	MCFG_SOUND_ADD("2203b", YM2203, 1250000)
 	MCFG_SOUND_ROUTE(0, "mono", 0.90)
 	MCFG_SOUND_ROUTE(1, "mono", 0.90)
 	MCFG_SOUND_ROUTE(2, "mono", 0.90)
 	MCFG_SOUND_ROUTE(3, "mono", 0.35)
 
-	MCFG_SOUND_ADD("msm", MSM5205, 384000/2)
-	MCFG_MSM5205_VCLK_CB(WRITELINE(dec0_automat_state, automat_vclk_cb))
-	MCFG_MSM5205_PRESCALER_SELECTOR(MSM5205_S48_4B)
+	MCFG_DEVICE_ADD("adpcm_select1", LS157, 0)
+	MCFG_74LS157_OUT_CB(DEVWRITE8("msm1", msm5205_device, data_w))
+
+	MCFG_DEVICE_ADD("adpcm_select2", LS157, 0)
+	MCFG_74LS157_OUT_CB(DEVWRITE8("msm2", msm5205_device, data_w))
+
+	MCFG_SOUND_ADD("msm1", MSM5205, 384000)
+	MCFG_MSM5205_VCLK_CB(WRITELINE(dec0_automat_state, msm1_vclk_cb))
+	MCFG_MSM5205_PRESCALER_SELECTOR(MSM5205_S96_4B)
 	MCFG_SOUND_ROUTE(ALL_OUTPUTS, "mono", 1.0)
 
+	MCFG_SOUND_ADD("msm2", MSM5205, 384000)
+	MCFG_MSM5205_VCLK_CB(WRITELINE(dec0_automat_state, msm2_vclk_cb))
+	MCFG_MSM5205_PRESCALER_SELECTOR(MSM5205_S96_4B)
+	MCFG_SOUND_ROUTE(ALL_OUTPUTS, "mono", 1.0)
 MACHINE_CONFIG_END
 
 

--- a/src/mame/includes/dec0.h
+++ b/src/mame/includes/dec0.h
@@ -1,5 +1,6 @@
 // license:BSD-3-Clause
 // copyright-holders:Bryan McPhail
+#include "machine/74157.h"
 #include "machine/bankdev.h"
 #include "machine/gen_latch.h"
 #include "video/decbac06.h"
@@ -15,7 +16,6 @@ public:
 		m_audiocpu(*this, "audiocpu"),
 		m_subcpu(*this, "sub"),
 		m_mcu(*this, "mcu"),
-		m_msm(*this, "msm"),
 		m_palette(*this, "palette"),
 		m_tilegen1(*this, "tilegen1"),
 		m_tilegen2(*this, "tilegen2"),
@@ -33,7 +33,6 @@ public:
 	required_device<cpu_device> m_audiocpu;
 	optional_device<cpu_device> m_subcpu;
 	optional_device<cpu_device> m_mcu;
-	optional_device<msm5205_device> m_msm;
 	required_device<palette_device> m_palette;
 	optional_device<deco_bac06_device> m_tilegen1;
 	optional_device<deco_bac06_device> m_tilegen2;
@@ -115,22 +114,36 @@ class dec0_automat_state : public dec0_state
 {
 public:
 	dec0_automat_state(const machine_config &mconfig, device_type type, const char *tag)
-		: dec0_state(mconfig, type, tag) {
+		: dec0_state(mconfig, type, tag),
+		m_msm1(*this, "msm1"),
+		m_msm2(*this, "msm2"),
+		m_adpcm_select1(*this, "adpcm_select1"),
+		m_adpcm_select2(*this, "adpcm_select2"),
+		m_soundbank(*this, "soundbank")
+	{
 	}
 
-	uint8_t m_automat_adpcm_byte;
-	int m_automat_msm5205_vclk_toggle;
+	required_device<msm5205_device> m_msm1;
+	required_device<msm5205_device> m_msm2;
+	required_device<ls157_device> m_adpcm_select1;
+	required_device<ls157_device> m_adpcm_select2;
+	required_memory_bank m_soundbank;
+
+	bool m_adpcm_toggle1;
+	bool m_adpcm_toggle2;
 	uint16_t m_automat_scroll_regs[4];
 
 	DECLARE_WRITE16_MEMBER(automat_control_w);
-	DECLARE_WRITE8_MEMBER(automat_adpcm_w);
 	DECLARE_READ16_MEMBER( automat_palette_r );
 	DECLARE_WRITE16_MEMBER( automat_palette_w );
 	DECLARE_WRITE16_MEMBER( automat_scroll_w )
 	{
 		COMBINE_DATA(&m_automat_scroll_regs[offset]);
 	}
-	DECLARE_WRITE_LINE_MEMBER(automat_vclk_cb);
+	DECLARE_READ8_MEMBER(sound_command_r);
+	DECLARE_WRITE8_MEMBER(sound_bankswitch_w);
+	DECLARE_WRITE_LINE_MEMBER(msm1_vclk_cb);
+	DECLARE_WRITE_LINE_MEMBER(msm2_vclk_cb);
 
 	virtual void machine_start() override;
 


### PR DESCRIPTION
- Reduce YM2203 speed to match music pitch on reference video
- Add second MSM5205 + two 74LS157 and fix communications
- Add sound banking (probably not entirely correct)