### PR TITLE
apple1.xml redump dis-assembler

### DIFF
--- a/hash/apple1.xml
+++ b/hash/apple1.xml
@@ -94,10 +94,10 @@
 		<year>1976</year>
 		<publisher>apple computer inc</publisher>
 			<!-- P/N A1T008X-->
-		<info name="usage" value="Load at 800.09FFR, enter at 0800R" />
+		<info name="usage" value="Load at 800.09FFR, enter at 09F0R" />
 		<part name="cass" interface="apple1_cass">
-			<dataarea name="cass" size="1393604">
-				<rom name="dis-assembler.wav" size="1393604" crc="a49c7474" sha1="1722bada9de231b90233c8aafe474e9c738366e8" offset="0" />
+			<dataarea name="cass" size="1905164">
+				<rom name="dis-assembler.wav" size="1905164" crc="3fb58ea4" sha1="194829241eec0e418469e1fc8e92d5a2721dcb6d" offset="0" />
 			</dataarea>
 		</part>
 	</software>


### PR DESCRIPTION
includes $09DC-$09FF. To use: put disassemble address in $44-$45 (low byte first) then 09F0R <enter>

[dis-assembler.zip](https://github.com/mamedev/mame/files/668839/dis-assembler.zip)
