### PR TITLE
konamigx.cpp: fix save states

### DIFF
--- a/src/devices/sound/k054539.cpp
+++ b/src/devices/sound/k054539.cpp
@@ -329,9 +329,19 @@ void k054539_device::init_chip()
 
 	stream = stream_alloc(0, 2, clock() / 384);
 
+	save_item(NAME(voltab));
+	save_item(NAME(pantab));
+	save_item(NAME(gain));
+	save_item(NAME(posreg_latch));
+	save_item(NAME(flags));
+
 	save_item(NAME(regs));
 	save_pointer(NAME(ram.get()), 0x4000);
+	save_item(NAME(reverb_pos));
 	save_item(NAME(cur_ptr));
+	save_item(NAME(cur_limit));
+
+	save_item(NAME(m_timer_state));
 }
 
 WRITE8_MEMBER(k054539_device::write)

--- a/src/devices/sound/k056800.cpp
+++ b/src/devices/sound/k056800.cpp
@@ -36,6 +36,7 @@ void k056800_device::device_start()
 	m_int_handler.resolve_safe();
 
 	save_item(NAME(m_int_pending));
+	save_item(NAME(m_int_enabled));
 	save_item(NAME(m_host_to_snd_regs));
 	save_item(NAME(m_snd_to_host_regs));
 }

--- a/src/emu/save.cpp
+++ b/src/emu/save.cpp
@@ -291,8 +291,6 @@ save_error save_manager::write_file(emu_file &file)
 	if (m_illegal_regs > 0)
 		return STATERR_ILLEGAL_REGISTRATIONS;
 
-    dump_registry();
-
 	// generate the header
 	u8 header[HEADER_SIZE];
 	memcpy(&header[0], STATE_MAGIC_NUM, 8);
@@ -355,7 +353,7 @@ u32 save_manager::signature() const
 void save_manager::dump_registry() const
 {
 	for (auto &entry : m_entry_list)
-		osd_printf_verbose("%s: %d x %d\n", entry->m_name.c_str(), entry->m_typesize, entry->m_typecount);
+		LOG(("%s: %d x %d\n", entry->m_name.c_str(), entry->m_typesize, entry->m_typecount));
 }
 
 

--- a/src/emu/save.cpp
+++ b/src/emu/save.cpp
@@ -291,6 +291,8 @@ save_error save_manager::write_file(emu_file &file)
 	if (m_illegal_regs > 0)
 		return STATERR_ILLEGAL_REGISTRATIONS;
 
+    dump_registry();
+
 	// generate the header
 	u8 header[HEADER_SIZE];
 	memcpy(&header[0], STATE_MAGIC_NUM, 8);
@@ -353,7 +355,7 @@ u32 save_manager::signature() const
 void save_manager::dump_registry() const
 {
 	for (auto &entry : m_entry_list)
-		LOG(("%s: %d x %d\n", entry->m_name.c_str(), entry->m_typesize, entry->m_typecount));
+		osd_printf_verbose("%s: %d x %d\n", entry->m_name.c_str(), entry->m_typesize, entry->m_typecount);
 }
 
 

--- a/src/mame/drivers/konamigx.cpp
+++ b/src/mame/drivers/konamigx.cpp
@@ -3707,7 +3707,14 @@ ROM_END
 
 MACHINE_START_MEMBER(konamigx_state,konamigx)
 {
+	save_item(NAME(m_gx_wrport1_0));
 	save_item(NAME(m_gx_wrport1_1));
+	save_item(NAME(m_gx_wrport2));
+
+	save_item(NAME(m_gx_rdport1_3));
+	save_item(NAME(m_gx_syncen));
+	save_item(NAME(m_suspension_active));
+	save_item(NAME(m_prev_pixel_clock));
 }
 
 MACHINE_RESET_MEMBER(konamigx_state,konamigx)

--- a/src/mame/drivers/konamigx.cpp
+++ b/src/mame/drivers/konamigx.cpp
@@ -3707,6 +3707,9 @@ ROM_END
 
 MACHINE_START_MEMBER(konamigx_state,konamigx)
 {
+	save_item(NAME(m_sound_ctrl));
+	save_item(NAME(m_sound_intck));
+
 	save_item(NAME(m_gx_wrport1_0));
 	save_item(NAME(m_gx_wrport1_1));
 	save_item(NAME(m_gx_wrport2));

--- a/src/mame/machine/konamigx.cpp
+++ b/src/mame/machine/konamigx.cpp
@@ -468,6 +468,7 @@ if((data1=obj[0])&0x80000000)\
 void konamigx_state::fantjour_dma_install()
 {
 	save_item(NAME(m_fantjour_dma));
+	save_item(NAME(m_prot_data));
 	m_maincpu->space(AS_PROGRAM).install_write_handler(0xdb0000, 0xdb001f, write32_delegate(FUNC(konamigx_state::fantjour_dma_w),this));
 	memset(m_fantjour_dma, 0, sizeof(m_fantjour_dma));
 }

--- a/src/mame/video/k053246_k053247_k055673.cpp
+++ b/src/mame/video/k053246_k053247_k055673.cpp
@@ -1023,10 +1023,10 @@ void k055673_device::device_start()
 	memset(m_kx46_regs, 0, 8);
 	memset(m_kx47_regs, 0, 32);
 
-	machine().save().save_pointer(NAME(m_ram.get()), 0x800);
-	machine().save().save_item(NAME(m_kx46_regs));
-	machine().save().save_item(NAME(m_kx47_regs));
-	machine().save().save_item(NAME(m_objcha_line));
+	save_pointer(NAME(m_ram.get()), 0x800);
+	save_item(NAME(m_kx46_regs));
+	save_item(NAME(m_kx47_regs));
+	save_item(NAME(m_objcha_line));
 }
 
 //-------------------------------------------------

--- a/src/mame/video/k054156_k054157_k056832.cpp
+++ b/src/mame/video/k054156_k054157_k056832.cpp
@@ -291,8 +291,6 @@ void k056832_device::create_tilemaps()
 
 void k056832_device::finalize_init()
 {
-	int i;
-
 	update_page_layout();
 
 	change_rambank();
@@ -301,37 +299,33 @@ void k056832_device::finalize_init()
 	save_item(NAME(m_videoram));
 	save_item(NAME(m_regs));
 	save_item(NAME(m_regsb));
+
+	save_item(NAME(m_cur_gfx_banks));
+
+	save_item(NAME(m_rom_half));
+
+	save_item(NAME(m_layer_assoc_with_page));
+	save_item(NAME(m_layer_offs));
+	save_item(NAME(m_lsram_page));
 	save_item(NAME(m_x));
 	save_item(NAME(m_y));
 	save_item(NAME(m_w));
 	save_item(NAME(m_h));
 	save_item(NAME(m_dx));
 	save_item(NAME(m_dy));
+	save_item(NAME(m_line_dirty));
+	save_item(NAME(m_all_lines_dirty));
+	save_item(NAME(m_page_tile_mode));
+	save_item(NAME(m_last_colorbase));
 	save_item(NAME(m_layer_tile_mode));
-
 	save_item(NAME(m_default_layer_association));
+	save_item(NAME(m_layer_association));
 	save_item(NAME(m_active_layer));
 	save_item(NAME(m_linemap_enabled));
 	save_item(NAME(m_use_ext_linescroll));
 	save_item(NAME(m_uses_tile_banks));
 	save_item(NAME(m_cur_tile_bank));
-	save_item(NAME(m_rom_half));
-	save_item(NAME(m_all_lines_dirty));
-	save_item(NAME(m_page_tile_mode));
 
-	for (i = 0; i < 8; i++)
-	{
-		save_item(NAME(m_layer_offs[i]), i);
-		save_item(NAME(m_lsram_page[i]), i);
-	}
-
-	for (i = 0; i < K056832_PAGE_COUNT; i++)
-	{
-		save_item(NAME(m_line_dirty[i]), i);
-		save_item(NAME(m_all_lines_dirty[i]), i);
-		save_item(NAME(m_page_tile_mode[i]), i);
-		save_item(NAME(m_last_colorbase[i]), i);
-	}
 
 	machine().save().register_postload(save_prepost_delegate(FUNC(k056832_device::postload), this));
 }

--- a/src/mame/video/konamigx.cpp
+++ b/src/mame/video/konamigx.cpp
@@ -1097,7 +1097,20 @@ void konamigx_state::common_init()
 		m_gx_tilebanks[i] = m_gx_oldbanks[i] = 0;
 	}
 
-	machine().save().save_item(NAME(m_gx_tilebanks));
+	save_pointer(NAME(m_gx_spriteram), 0x800);
+	save_item(NAME(m_gx_tilebanks));
+	save_item(NAME(m_k053247_vrcbk));
+	save_item(NAME(m_k053247_coreg));
+	save_item(NAME(m_k053247_coregshift));
+	save_item(NAME(m_k053247_opset));
+	save_item(NAME(m_opri));
+	save_item(NAME(m_oinprion));
+	save_item(NAME(m_vcblk));
+	save_item(NAME(m_ocblk));
+	save_item(NAME(m_vinmix));
+	save_item(NAME(m_vmixon));
+	save_item(NAME(m_osinmix));
+	save_item(NAME(m_osmixon));
 
 	m_gx_tilemode = 0;
 


### PR DESCRIPTION
Previously, loading Konami GX states from a cold boot would hang because several items missed from the save were blocking the vsync and sound update IRQs. This patch fixes this issue; states can be loaded from a cold boot without impacting execution.