### PR TITLE
m68k cpu core: run a callback every time FC bits change.

### DIFF
--- a/src/devices/cpu/m68000/m68000.h
+++ b/src/devices/cpu/m68000/m68000.h
@@ -98,6 +98,9 @@ enum
  */
 #define M68K_INT_ACK_SPURIOUS      0xfffffffe
 
+#define MCFG_M68K_FC_CB(_devcb) \
+	m68000_base_device::set_fc_cb_func(*device, DEVCB_##_devcb);
+
 enum
 {
 	/* NOTE: M68K_SP fetches the current SP, be it USP, ISP, or MSP */
@@ -128,6 +131,9 @@ public:
 						const device_type type, uint32_t prg_data_width, uint32_t prg_address_bits, address_map_constructor internal_map, const char *shortname, const char *source);
 
 	m68000_base_device(const machine_config &mconfig, const char *tag, device_t *owner, uint32_t clock);
+
+	// static configuration helpers
+	template<class _Object> static devcb_base &set_fc_cb_func(device_t &device, _Object object) { return downcast<m68000_base_device &>(device).m_fc_cb.set_callback(object); }
 
 	void presave();
 	void postload();
@@ -165,6 +171,7 @@ public:
 	void set_cmpild_callback(write32_delegate callback);
 	void set_rte_callback(write_line_delegate callback);
 	void set_tas_write_callback(write8_delegate callback);
+	devcb_write16 m_fc_cb;
 	uint16_t get_fc();
 	void set_hmmu_enable(int enable);
 	void set_fpu_enable(int enable);

--- a/src/devices/cpu/m68000/m68kcpu.cpp
+++ b/src/devices/cpu/m68000/m68kcpu.cpp
@@ -995,6 +995,7 @@ void m68000_base_device::init_cpu_common(void)
 	m_icountptr = &remaining_cycles;
 	remaining_cycles = 0;
 
+	m_fc_cb.resolve_safe();
 }
 
 void m68000_base_device::reset_cpu(void)
@@ -2280,7 +2281,8 @@ const device_type M68K = &device_creator<m68000_base_device>;
 m68000_base_device::m68000_base_device(const machine_config &mconfig, const char *tag, device_t *owner, uint32_t clock)
 	: cpu_device(mconfig, M68K, "M68K", tag, owner, clock, "m68k", __FILE__),
 		m_program_config("program", ENDIANNESS_BIG, 16, 24),
-		m_oprogram_config("decrypted_opcodes", ENDIANNESS_BIG, 16, 24)
+		m_oprogram_config("decrypted_opcodes", ENDIANNESS_BIG, 16, 24),
+		m_fc_cb(*this)
 {
 	clear_all();
 }
@@ -2292,7 +2294,8 @@ m68000_base_device::m68000_base_device(const machine_config &mconfig, const char
 										const device_type type, uint32_t prg_data_width, uint32_t prg_address_bits, address_map_constructor internal_map, const char *shortname, const char *source)
 	: cpu_device(mconfig, type, name, tag, owner, clock, shortname, source),
 		m_program_config("program", ENDIANNESS_BIG, prg_data_width, prg_address_bits, 0, internal_map),
-		m_oprogram_config("decrypted_opcodes", ENDIANNESS_BIG, prg_data_width, prg_address_bits, 0, internal_map)
+		m_oprogram_config("decrypted_opcodes", ENDIANNESS_BIG, prg_data_width, prg_address_bits, 0, internal_map),
+		m_fc_cb(*this)
 {
 	clear_all();
 }
@@ -2302,7 +2305,8 @@ m68000_base_device::m68000_base_device(const machine_config &mconfig, const char
 										const device_type type, uint32_t prg_data_width, uint32_t prg_address_bits, const char *shortname, const char *source)
 	: cpu_device(mconfig, type, name, tag, owner, clock, shortname, source),
 		m_program_config("program", ENDIANNESS_BIG, prg_data_width, prg_address_bits),
-		m_oprogram_config("decrypted_opcodes", ENDIANNESS_BIG, prg_data_width, prg_address_bits)
+		m_oprogram_config("decrypted_opcodes", ENDIANNESS_BIG, prg_data_width, prg_address_bits),
+		m_fc_cb(*this)
 {
 	clear_all();
 }

--- a/src/devices/cpu/m68000/m68kcpu.h
+++ b/src/devices/cpu/m68000/m68kcpu.h
@@ -737,6 +737,7 @@ static inline uint32_t m68ki_read_imm_16(m68000_base_device *m68k)
 
 	m68k->mmu_tmp_fc = m68k->s_flag | FUNCTION_CODE_USER_PROGRAM;
 	m68k->mmu_tmp_rw = 1;
+	m68k->m_fc_cb(m68k->mmu_tmp_fc);
 
 	m68ki_check_address_error(m68k, REG_PC(m68k), MODE_READ, m68k->s_flag | FUNCTION_CODE_USER_PROGRAM); /* auto-disable (see m68kcpu.h) */
 
@@ -764,6 +765,7 @@ static inline uint32_t m68ki_read_imm_32(m68000_base_device *m68k)
 
 	m68k->mmu_tmp_fc = m68k->s_flag | FUNCTION_CODE_USER_PROGRAM;
 	m68k->mmu_tmp_rw = 1;
+	m68k->m_fc_cb(m68k->mmu_tmp_fc);
 
 	m68ki_check_address_error(m68k, REG_PC(m68k), MODE_READ, m68k->s_flag | FUNCTION_CODE_USER_PROGRAM); /* auto-disable (see m68kcpu.h) */
 
@@ -799,6 +801,7 @@ static inline uint32_t m68ki_read_8_fc(m68000_base_device *m68k, uint32_t addres
 {
 	m68k->mmu_tmp_fc = fc;
 	m68k->mmu_tmp_rw = 1;
+	m68k->m_fc_cb(m68k->mmu_tmp_fc);
 	return m68k->/*memory.*/read8(address);
 }
 static inline uint32_t m68ki_read_16_fc(m68000_base_device *m68k, uint32_t address, uint32_t fc)
@@ -809,6 +812,7 @@ static inline uint32_t m68ki_read_16_fc(m68000_base_device *m68k, uint32_t addre
 	}
 	m68k->mmu_tmp_fc = fc;
 	m68k->mmu_tmp_rw = 1;
+	m68k->m_fc_cb(m68k->mmu_tmp_fc);
 	return m68k->/*memory.*/read16(address);
 }
 static inline uint32_t m68ki_read_32_fc(m68000_base_device *m68k, uint32_t address, uint32_t fc)
@@ -819,6 +823,7 @@ static inline uint32_t m68ki_read_32_fc(m68000_base_device *m68k, uint32_t addre
 	}
 	m68k->mmu_tmp_fc = fc;
 	m68k->mmu_tmp_rw = 1;
+	m68k->m_fc_cb(m68k->mmu_tmp_fc);
 	return m68k->/*memory.*/read32(address);
 }
 
@@ -826,6 +831,7 @@ static inline void m68ki_write_8_fc(m68000_base_device *m68k, uint32_t address, 
 {
 	m68k->mmu_tmp_fc = fc;
 	m68k->mmu_tmp_rw = 0;
+	m68k->m_fc_cb(m68k->mmu_tmp_fc);
 	m68k->/*memory.*/write8(address, value);
 }
 static inline void m68ki_write_16_fc(m68000_base_device *m68k, uint32_t address, uint32_t fc, uint32_t value)
@@ -836,6 +842,7 @@ static inline void m68ki_write_16_fc(m68000_base_device *m68k, uint32_t address,
 	}
 	m68k->mmu_tmp_fc = fc;
 	m68k->mmu_tmp_rw = 0;
+	m68k->m_fc_cb(m68k->mmu_tmp_fc);
 	m68k->/*memory.*/write16(address, value);
 }
 static inline void m68ki_write_32_fc(m68000_base_device *m68k, uint32_t address, uint32_t fc, uint32_t value)
@@ -846,6 +853,7 @@ static inline void m68ki_write_32_fc(m68000_base_device *m68k, uint32_t address,
 	}
 	m68k->mmu_tmp_fc = fc;
 	m68k->mmu_tmp_rw = 0;
+	m68k->m_fc_cb(m68k->mmu_tmp_fc);
 	m68k->/*memory.*/write32(address, value);
 }
 
@@ -862,6 +870,7 @@ static inline void m68ki_write_32_pd_fc(m68000_base_device *m68k, uint32_t addre
 	}
 	m68k->mmu_tmp_fc = fc;
 	m68k->mmu_tmp_rw = 0;
+	m68k->m_fc_cb(m68k->mmu_tmp_fc);
 	m68k->/*memory.*/write16(address+2, value>>16);
 	m68k->/*memory.*/write16(address, value&0xffff);
 }


### PR DESCRIPTION
MMU in HP Integral PC (hp_ipc.cpp) swaps two halves of address space on going into user mode (i.e. start of RAM is at 0 in user mode but at 0x800000 in supervisor; etc.).   My WIP code uses a bankdev + this callback to handle this setup.