### PR TITLE
Clone ROM filename discrepancies

### DIFF
--- a/src/tools/discrepancy-fixer.py
+++ b/src/tools/discrepancy-fixer.py
@@ -1,0 +1,53 @@
+#!/usr/bin/python
+
+# Fix discrepancies in arcade ROM dump names, by Zoe Blade
+# For Python 2
+
+import xml.etree.ElementTree
+
+print('Loading XML file...')
+root = xml.etree.ElementTree.parse('arcade.xml').getroot()
+print('Done.')
+
+for childMachine in root.iter('machine'):
+	if not childMachine.get('cloneof'):
+		continue
+
+	for parentMachine in root.iter('machine'):
+		if not parentMachine.get('name') == childMachine.get('cloneof'):
+			continue
+
+		# Machine pair found
+
+		for childRom in childMachine.iter('rom'):
+			for parentRom in parentMachine.iter('rom'):
+				if not parentRom.get('sha1') == childRom.get('sha1'):
+					continue
+
+				# ROM pair found
+
+				if parentRom.get('name') == childRom.get('name'):
+					break
+
+				# The names don't match
+
+				sourceFilename = childMachine.get('sourcefile')
+
+				input = open(sourceFilename, 'r')
+				source = input.read()
+				input.close()
+
+				oldRomFilename = '"' + childRom.get('name') + '"'
+				newRomFilename = '"' + parentRom.get('name') + '"'
+
+				oldRomFilenamePadded = oldRomFilename.ljust(14, ' ')
+				newRomFilenamePadded = newRomFilename.ljust(14, ' ')
+
+				source = source.replace(oldRomFilenamePadded, newRomFilenamePadded) # Try to preserve fancy spacing where possible
+				source = source.replace(oldRomFilename, newRomFilename) # Fallback on just replacing the filename
+
+				output = open(sourceFilename, 'w')
+				output.write(source)
+				output.close()
+
+				print(sourceFilename + ': ' + oldRomFilename + ' -> ' + newRomFilename)

--- a/src/tools/discrepancy-spotter.py
+++ b/src/tools/discrepancy-spotter.py
@@ -1,0 +1,34 @@
+#!/usr/bin/python
+
+# Find discrepancies in arcade ROM dump names, by Zoe Blade
+# For Python 2
+
+import xml.etree.ElementTree
+
+print('Loading XML file...')
+root = xml.etree.ElementTree.parse('arcade.xml').getroot()
+print('Done.')
+
+for childMachine in root.iter('machine'):
+	if not childMachine.get('cloneof'):
+		continue
+
+	for parentMachine in root.iter('machine'):
+		if not parentMachine.get('name') == childMachine.get('cloneof'):
+			continue
+
+		# Machine pair found
+
+		for childRom in childMachine.iter('rom'):
+			for parentRom in parentMachine.iter('rom'):
+				if not parentRom.get('sha1') == childRom.get('sha1'):
+					continue
+
+				# ROM pair found
+
+				if parentRom.get('name') == childRom.get('name'):
+					break
+
+				# The names don't match
+
+				print(childMachine.get('sourcefile') + ' ' + childMachine.get('name') + ': ' + childRom.get('name') + ' -> ' + parentRom.get('name'))


### PR DESCRIPTION
Hi all!

So I noticed that some clone machines have different ROM names to the machines that they're clones of, even for chips that contain completely identical data.  I'm guessing sometimes this should be the case, while sometimes it's due to the original ROM names being updated and the person forgetting about the clones (easily done)?

On the offchance it's at least sometimes the latter, I made a handy Python script that finds identical ROM chips in original-and-clone pairs, that have different filenames.  You can use it like this:

```
$ ./mame64 -listxml > arcade.xml
$ src/tools/discrepancy-spotter.py
```

This lists the source code's filename, clone machine's name, clone ROM's name and identical parent ROM's name, like this:

```
Loading XML file...
Done.
m58.cpp 10yard85: yf-s-3b.3b -> yf-s.3b
m58.cpp 10yard85: yf-s-1b.1b -> yf-s.1b
m58.cpp 10yard85: yf-s-3a.3a -> yf-s.3a
```

And so on.

As manually making these changes would be a hassle, I went a step further and somewhat automated that:

```
$ mv arcade.xml src/mame/drivers/
$ cd src/mame/drivers/
$ ../../tools/discrepancy-fixer.py
```

Clearly, this goes overboard with false positives, but you can then tidy and git-add only the files you wish... and then delete the XML file and presumably my Python scripts, once their work is complete.

Anyway, I offer these scripts on the offchance they're of any use.  If not, feel free to ignore me.

Cheers,
Zoë.