### PR TITLE
Address map fixes (nw)

### DIFF
--- a/src/devices/cpu/tms32025/tms32025.cpp
+++ b/src/devices/cpu/tms32025/tms32025.cpp
@@ -186,7 +186,7 @@ Table 3-2.  TMS32025/26 Memory Blocks
 const device_type TMS32025 = &device_creator<tms32025_device>;
 const device_type TMS32026 = &device_creator<tms32026_device>;
 
-static ADDRESS_MAP_START( tms32025_data, AS_PROGRAM, 16, tms32025_device )
+static ADDRESS_MAP_START( tms32025_data, AS_DATA, 16, tms32025_device )
 	AM_RANGE(0x0000, 0x0000) AM_READWRITE(drr_r, drr_w)
 	AM_RANGE(0x0001, 0x0001) AM_READWRITE(dxr_r, dxr_w)
 	AM_RANGE(0x0002, 0x0002) AM_READWRITE(tim_r, tim_w)
@@ -198,7 +198,7 @@ static ADDRESS_MAP_START( tms32025_data, AS_PROGRAM, 16, tms32025_device )
 	AM_RANGE(0x0300, 0x03ff) AM_RAM AM_SHARE("b1")
 ADDRESS_MAP_END
 
-static ADDRESS_MAP_START( tms32026_data, AS_PROGRAM, 16, tms32025_device )
+static ADDRESS_MAP_START( tms32026_data, AS_DATA, 16, tms32025_device )
 	AM_RANGE(0x0000, 0x0000) AM_READWRITE(drr_r, drr_w)
 	AM_RANGE(0x0001, 0x0001) AM_READWRITE(dxr_r, dxr_w)
 	AM_RANGE(0x0002, 0x0002) AM_READWRITE(tim_r, tim_w)

--- a/src/emu/addrmap.cpp
+++ b/src/emu/addrmap.cpp
@@ -401,11 +401,13 @@ address_map::~address_map()
 
 void address_map::configure(address_spacenum spacenum, u8 databits)
 {
-	assert(m_spacenum == spacenum);
+	if (spacenum != m_spacenum)
+		osd_printf_error("Space %d configured as address space %d\n", m_spacenum, spacenum);
+
 	if (m_databits == 0xff)
 		m_databits = databits;
-	else
-		assert(m_databits == databits);
+	else if (databits != m_databits)
+		osd_printf_error("Space %d configured with %d data bits when %d expected\n", m_spacenum, databits, m_databits);
 }
 
 

--- a/src/mame/drivers/mc1000.cpp
+++ b/src/mame/drivers/mc1000.cpp
@@ -225,7 +225,7 @@ WRITE8_MEMBER( mc1000_state::mc6847_attr_w )
 static ADDRESS_MAP_START( mc1000_mem, AS_PROGRAM, 8, mc1000_state )
 	AM_RANGE(0x0000, 0x1fff) AM_RAMBANK("bank1")
 	AM_RANGE(0x2000, 0x27ff) AM_RAMBANK("bank2") AM_SHARE("mc6845_vram")
-	AM_RANGE(0x2800, 0x3fff) AM_RAM
+	AM_RANGE(0x2800, 0x3fff) AM_RAM AM_SHARE("ram2800")
 	AM_RANGE(0x4000, 0x7fff) AM_RAMBANK("bank3")
 	AM_RANGE(0x8000, 0x97ff) AM_RAMBANK("bank4") AM_SHARE("mc6847_vram")
 	AM_RANGE(0x9800, 0xbfff) AM_RAMBANK("bank5")
@@ -233,8 +233,13 @@ static ADDRESS_MAP_START( mc1000_mem, AS_PROGRAM, 8, mc1000_state )
 ADDRESS_MAP_END
 
 static ADDRESS_MAP_START( mc1000_banking_mem, AS_DECRYPTED_OPCODES, 8, mc1000_state )
+	AM_RANGE(0x0000, 0x1fff) AM_RAMBANK("bank1")
+	AM_RANGE(0x2000, 0x27ff) AM_RAMBANK("bank2") AM_SHARE("mc6845_vram")
+	AM_RANGE(0x2800, 0x3fff) AM_RAM AM_SHARE("ram2800")
+	AM_RANGE(0x4000, 0x7fff) AM_RAMBANK("bank3")
+	AM_RANGE(0x8000, 0x97ff) AM_RAMBANK("bank4") AM_SHARE("mc6847_vram")
+	AM_RANGE(0x9800, 0xbfff) AM_RAMBANK("bank5")
 	AM_RANGE(0xc000, 0xffff) AM_READ(rom_banking_r)
-	AM_IMPORT_FROM(mc1000_mem)
 ADDRESS_MAP_END
 
 static ADDRESS_MAP_START( mc1000_io, AS_IO, 8, mc1000_state )


### PR DESCRIPTION
- tms32025: Correct space of internal data maps
- mc1000: Separate out opcodes map
- addrmap.cpp: Replace a few debug asserts with friendlier error messages (makes validation less dangerous in debug builds)