### PR TITLE
Introduction of osd::text::normalized_unicode() function

### DIFF
--- a/src/osd/strconv.h
+++ b/src/osd/strconv.h
@@ -17,6 +17,16 @@
 //  FUNCTION PROTOTYPES
 //============================================================
 
+namespace osd
+{
+	namespace text
+	{
+		enum class unicode_normalization_form { C, D, KC, KD };
+
+		std::string normalize_unicode(const std::string &s, unicode_normalization_form normalization_form);
+	};
+};
+
 #if defined(WIN32)
 
 #ifndef WIN32_LEAN_AND_MEAN


### PR DESCRIPTION
This work is not complete - DO NOT MERGE YET

Open issues:
1.  This has been implemented for Win32 and Qt.  The Qt implementation kicks in all non-Win32 scenarios.  This is not correct.
2.  There is no implementation on Mac yet.
3.  There are unresolved linkage errors on Linux, presumably the result of introducing a Qt dependency in tools
4.  I suspect that having all of this stuff in src/osd/strconv.cpp is not what we want to do in the long run

Another issue:  In Win32, this introduced a dependency on the Win32 NormalizeString() function.  This is not implemented prior to Windows Vista.  Therefore, this change implicitly drops support for Windows XP.