### PR TITLE
ppcdrc.cpp: clear two LSBs of the branch target address.

### DIFF
--- a/src/devices/cpu/powerpc/ppcdrc.cpp
+++ b/src/devices/cpu/powerpc/ppcdrc.cpp
@@ -1942,8 +1942,11 @@ void ppc_device::generate_branch(drcuml_block *block, compiler_state *compiler, 
 	}
 	else
 	{
-		generate_update_cycles(block, &compiler_temp, mem(srcptr), true);              // <subtract cycles>
-		UML_HASHJMP(block, m_core->mode, mem(srcptr), *m_nocode);   // hashjmp <mode>,<rsreg>,nocode
+		generate_update_cycles(block, &compiler_temp, mem(srcptr), true);    // <subtract cycles>
+
+        /* clear two LSBs of the target address to prevent branching to an invalid address */
+        UML_AND(block, I0, mem(srcptr), 0xFFFFFFFC);                         // and i0, 0xFFFFFFFC
+        UML_HASHJMP(block, m_core->mode, I0, *m_nocode);                     // hashjmp <mode>,i0,nocode
 	}
 
 	/* update the label */


### PR DESCRIPTION
This is what a real CPU does in order to prevent branching to an invalid address.

This patch fixes an issue preventing the Power Macintosh 6100 from starting up.