### PR TITLE
Negative file cache

### DIFF
--- a/src/emu/fileio.cpp
+++ b/src/emu/fileio.cpp
@@ -678,7 +678,7 @@ osd_file::error emu_file::attempt_zipped()
 
 			// attempt to open the archive file
 			util::archive_file::ptr zip;
-			util::archive_file::error ziperr = util::archive_file::error::NONE;
+			util::archive_file::error ziperr = util::archive_file::error::FILE_ERROR;
 			auto preverr = ziperr_cache.find(m_fullpath);
 			if (preverr == ziperr_cache.end())
 			{


### PR DESCRIPTION
If the zip open returns an error hold onto that error for the next time we ask for the same file.  Has decent speed up on verify for files stored on a remote network drive.