### PR TITLE
taito_f3: fix missing graphics on state load

### DIFF
--- a/src/mame/includes/taito_f3.h
+++ b/src/mame/includes/taito_f3.h
@@ -315,6 +315,7 @@ public:
 
 protected:
 	virtual void device_timer(emu_timer &timer, device_timer_id id, int param, void *ptr) override;
+	virtual void device_post_load(void) override;
 
 private:
 	inline void get_tile_info(tile_data &tileinfo, int tile_index, uint16_t *gfx_base);

--- a/src/mame/video/taito_f3.cpp
+++ b/src/mame/video/taito_f3.cpp
@@ -322,6 +322,13 @@ pri_alp_bitmap
 1111 1111    opaque pixel
 */
 
+
+void taito_f3_state::device_post_load() 
+{
+	/* force a reread of the dynamic tiles in the pixel layer */
+	m_gfxdecode->gfx(3)->mark_all_dirty();
+}
+
 /******************************************************************************/
 
 void taito_f3_state::print_debug_info(bitmap_rgb32 &bitmap)
@@ -647,6 +654,13 @@ VIDEO_START_MEMBER(taito_f3_state,f3)
 	m_flipscreen = 0;
 	memset(m_spriteram16_buffered.get(),0,0x10000);
 	memset(m_spriteram.get(),0,0x10000);
+
+	save_pointer(NAME(m_videoram.get()), 0x2000/2);
+	save_pointer(NAME(m_spriteram.get()), 0x10000/2);
+	save_pointer(NAME(m_f3_vram.get()), 0x2000/2);
+	save_pointer(NAME(m_f3_pf_data.get()), 0xc000/2);
+	save_pointer(NAME(m_f3_line_ram.get()), 0x10000/2);
+	save_pointer(NAME(m_f3_pivot_ram.get()), 0x10000/2);
 
 	save_item(NAME(m_f3_control_0));
 	save_item(NAME(m_f3_control_1));


### PR DESCRIPTION
Taito F3 states loaded from a cold boot would execute okay with perfect sound, but large chunks of the graphics would be missing. This patch adds the F3 video RAM to the save state, and adds a device_post_load hook to force the MAME gfx_element for the F3's "pixel layer" to reread the tiles from the pivot RAM.