### PR TITLE
[Imgtool] Changed to use wcout/wcerr in order to support Unicode console output

### DIFF
--- a/src/lib/util/unicode.cpp
+++ b/src/lib/util/unicode.cpp
@@ -8,9 +8,6 @@
 
 ***************************************************************************/
 
-#include <codecvt>
-#include <locale>
-
 #include "unicode.h"
 
 #ifdef _WIN32
@@ -19,6 +16,9 @@
 #endif
 
 #include "utf8proc/utf8proc.h"
+
+#include <codecvt>
+#include <locale>
 
 
 //-------------------------------------------------

--- a/src/lib/util/unicode.cpp
+++ b/src/lib/util/unicode.cpp
@@ -8,9 +8,13 @@
 
 ***************************************************************************/
 
+#include <codecvt>
+#include <locale>
+
 #include "unicode.h"
 
 #ifdef _WIN32
+#include "strconv.h"
 #define UTF8PROC_DLLEXPORT
 #endif
 
@@ -348,6 +352,38 @@ int utf16f_from_uchar(char16_t *utf16string, size_t count, char32_t uchar)
 	if (rc >= 2)
 		utf16string[1] = flipendian_int16(buf[1]);
 	return rc;
+}
+
+
+//-------------------------------------------------
+// wstring_from_utf8
+//-------------------------------------------------
+
+std::wstring wstring_from_utf8(const std::string &utf8string)
+{
+#ifdef WIN32
+	// for some reason, using codecvt yields bad results on MinGW (but not MSVC)
+	return osd::text::to_wstring(utf8string);
+#else
+	std::wstring_convert<std::codecvt_utf8<wchar_t>> converter;
+	return converter.from_bytes(utf8string);
+#endif
+}
+
+
+//-------------------------------------------------
+// utf8_from_wstring
+//-------------------------------------------------
+
+std::string utf8_from_wstring(const std::wstring &string)
+{
+#ifdef WIN32
+	// for some reason, using codecvt yields bad results on MinGW (but not MSVC)
+	return osd::text::from_wstring(string);
+#else
+	std::wstring_convert<std::codecvt_utf8<wchar_t>> converter;
+	return converter.to_bytes(string);
+#endif
 }
 
 

--- a/src/lib/util/unicode.h
+++ b/src/lib/util/unicode.h
@@ -100,6 +100,10 @@ std::string utf8_from_uchar(char32_t uchar);
 int utf16_from_uchar(char16_t *utf16string, size_t count, char32_t uchar);
 int utf16f_from_uchar(char16_t *utf16string, size_t count, char32_t uchar);
 
+// converting UTF-8 strings to/from "wide" strings
+std::wstring wstring_from_utf8(const std::string &utf8string);
+std::string utf8_from_wstring(const std::wstring &string);
+
 // unicode normalization
 std::string normalize_unicode(const std::string &s, unicode_normalization_form normalization_form);
 std::string normalize_unicode(const char *s, unicode_normalization_form normalization_form);

--- a/src/tools/imgtool/main.cpp
+++ b/src/tools/imgtool/main.cpp
@@ -268,7 +268,7 @@ static int cmd_dir(const struct command *c, int argc, char *argv[])
 	util::stream_format(std::wcout, L"%s\n", wstring_from_utf8(separator));
 	util::stream_format(std::wcout, L"%8i File(s)        %8i bytes", total_count, total_size);
 	if (!freespace_err)
-		util::string_format(std::wcout, L"                        %8u bytes free\n", (unsigned int)freespace);
+		util::stream_format(std::wcout, L"                        %8u bytes free\n", (unsigned int)freespace);
 
 done:
 	if (err)

--- a/src/tools/imgtool/main.cpp
+++ b/src/tools/imgtool/main.cpp
@@ -34,7 +34,7 @@ static void writeusage(std::wostream &output, bool write_word_usage, const struc
 	util::stream_format(output,
 		L"%s %s %s %s\n",
 		(write_word_usage ? L"Usage:" : L"      "),
-		cmdname,
+		wstring_from_utf8(cmdname),
 		c->name,
 		c->usage ? wstring_from_utf8(c->usage) : std::wstring());
 }
@@ -224,7 +224,7 @@ static int cmd_dir(const struct command *c, int argc, char *argv[])
 
 	info = image->info();
 	if (!info.empty())
-		util::stream_format(std::wcout, L"%s\n", info);
+		util::stream_format(std::wcout, L"%s\n", wstring_from_utf8(info));
 
 	util::stream_format(std::wcout, L"%s\n", wstring_from_utf8(separator));
 
@@ -769,9 +769,9 @@ static void listoptions(const util::option_guide &opt_guide, const char *opt_spe
 		}
 
 		util::stream_format(std::wcout, L"%16s %-30s %s\n",
-			opt_name,
-			description_buffer.str(),
-			opt_desc);
+			wstring_from_utf8(opt_name),
+			wstring_from_utf8(description_buffer.str()),
+			wstring_from_utf8(opt_desc));
 	}
 }
 

--- a/src/tools/imgtool/main.cpp
+++ b/src/tools/imgtool/main.cpp
@@ -8,6 +8,11 @@
 
 ***************************************************************************/
 
+#include "imgtool.h"
+#include "main.h"
+#include "modules.h"
+#include "strformat.h"
+
 #include <stdio.h>
 #include <string.h>
 #include <ctype.h>
@@ -20,21 +25,18 @@
 #include <fcntl.h>
 #endif
 
-#include "imgtool.h"
-#include "main.h"
-#include "modules.h"
-#include "strformat.h"
-
 // ----------------------------------------------------------------------
 
-static void writeusage(std::wostream &output, int write_word_usage, const struct command *c, char *argv[])
+static void writeusage(std::wostream &output, bool write_word_usage, const struct command *c, char *argv[])
 {
 	std::string cmdname = core_filename_extract_base(argv[0]);
-	output << (write_word_usage ? L"Usage: " : L"       ")
-		<< wstring_from_utf8(cmdname)
-		<< L" "
-		<< c->name
-		<< c->usage ? wstring_from_utf8(c->usage) : L"";
+
+	util::stream_format(output,
+		L"%s %s %s %s\n",
+		(write_word_usage ? L"Usage:" : L"      "),
+		cmdname,
+		c->name,
+		c->usage ? wstring_from_utf8(c->usage) : std::wstring());
 }
 
 
@@ -111,15 +113,15 @@ static int parse_options(int argc, char *argv[], int minunnamed, int maxunnamed,
 	return lastunnamed;
 
 filternotfound:
-	std::wcerr << wstring_from_utf8(value) << L": Unknown filter type" << std::endl;
+	util::stream_format(std::wcerr, L"%s: Unknown filter type\n", wstring_from_utf8(value));
 	return -1;
 
 optionalreadyspecified:
-	std::wcerr << L"Cannot specify multiple " << wstring_from_utf8(name) << L"s" << std::endl;
+	util::stream_format(std::wcerr, L"Cannot specify multiple %ss\n", wstring_from_utf8(name));
 	return -1;
 
 error:
-	std::wcerr << wstring_from_utf8(argv[i]) << L": Unrecognized option" << std::endl;
+	util::stream_format(std::wcerr, L"%s: Unrecognized option\n", wstring_from_utf8(argv[i]));
 	return -1;
 }
 
@@ -155,7 +157,7 @@ void reporterror(imgtoolerr_t err, const struct command *c, const char *format, 
 
 	if (!src)
 		src = c->name;
-	std::wcerr << wstring_from_utf8(src) << L": " << wstring_from_utf8(err_name) << std::endl;
+	util::stream_format(std::wcerr, L"%s: %s\n", wstring_from_utf8(src), wstring_from_utf8(err_name));
 }
 
 
@@ -218,13 +220,13 @@ static int cmd_dir(const struct command *c, int argc, char *argv[])
 	total_count = 0;
 	total_size = 0;
 
-	std::wcout << L"Contents of " << wstring_from_utf8(argv[1]) << L":" << wstring_from_utf8(path) << std::endl;;
+	util::stream_format(std::wcout, L"Contents of %s:%s\n", wstring_from_utf8(argv[1]), wstring_from_utf8(path));
 
 	info = image->info();
 	if (!info.empty())
-		std::wcout << wstring_from_utf8(info) << std::endl;
+		util::stream_format(std::wcout, L"%s\n", info);
 
-	std::wcout << wstring_from_utf8(separator) << std::endl;
+	util::stream_format(std::wcout, L"%s\n", wstring_from_utf8(separator));
 
 	while (((err = imgenum->get_next(ent)) == 0) && !ent.eof)
 	{
@@ -239,18 +241,18 @@ static int cmd_dir(const struct command *c, int argc, char *argv[])
 		if (ent.hardlink)
 			strcat(ent.filename, " <hl>");
 
-		std::wcout << wstring_from_utf8(util::string_format(
-			"%*s %*s %*s %*s",
-			-columnwidth_filename, ent.filename,
-			columnwidth_filesize, filesize_string,
+		util::stream_format(std::wcout,
+			L"%*s %*s %*s %*s\n",
+			-columnwidth_filename, wstring_from_utf8(ent.filename),
+			columnwidth_filesize, wstring_from_utf8(filesize_string),
 			columnwidth_attributes, ent.attr,
-			columnwidth_lastmodified, last_modified)) << std::endl;
+			columnwidth_lastmodified, wstring_from_utf8(last_modified));
 
 		if (ent.softlink && ent.softlink[0] != '\0')
-			std::wcout << L"-> " << wstring_from_utf8(ent.softlink) << std::endl;
+			util::stream_format(std::wcout, L"-> %s\n", wstring_from_utf8(ent.softlink));
 
 		if (ent.comment && ent.comment[0] != '\0')
-			std::wcout << L": " << wstring_from_utf8(ent.comment) << std::endl;
+			util::stream_format(std::wcout, L": %s\n", wstring_from_utf8(ent.comment));
 
 		total_count++;
 		total_size += ent.filesize;
@@ -263,10 +265,10 @@ static int cmd_dir(const struct command *c, int argc, char *argv[])
 	if (err)
 		goto done;
 
-	std::wcout << wstring_from_utf8(separator) << std::endl;
-	std::wcout << wstring_from_utf8(util::string_format("%8i File(s)        %8i bytes", total_count, total_size)) << std::endl;
+	util::stream_format(std::wcout, L"%s\n", wstring_from_utf8(separator));
+	util::stream_format(std::wcout, L"%8i File(s)        %8i bytes", total_count, total_size);
 	if (!freespace_err)
-		std::wcout << wstring_from_utf8(util::string_format("                        %8u bytes free", (unsigned int)freespace)) << std::endl;
+		util::string_format(std::wcout, L"                        %8u bytes free\n", (unsigned int)freespace);
 
 done:
 	if (err)
@@ -387,7 +389,7 @@ static int cmd_put(const struct command *c, int argc, char *argv[])
 	for (i = 0; i < filename_count; i++)
 	{
 		filename = filename_list[i];
-		std::wcout << L"Putting file '" << wstring_from_utf8(filename) << L"'..." << std::endl;
+		util::stream_format(std::wcout, L"Putting file '%s'...\n", wstring_from_utf8(filename));
 		err = partition->put_file(new_filename, fork, filename, resolution.get(), filter);
 		if (err)
 			goto done;
@@ -440,7 +442,7 @@ static int cmd_getall(const struct command *c, int argc, char *argv[])
 
 	while (((err = imgenum->get_next(ent)) == 0) && !ent.eof)
 	{
-		std::wcout << L"Retrieving " << wstring_from_utf8(ent.filename) << L" (" << (unsigned int)ent.filesize << L" bytes)" << std::endl;
+		util::stream_format(std::wcout, L"Retrieving %s (%u bytes)\n", wstring_from_utf8(ent.filename), (unsigned int)ent.filesize);
 
 		err = partition->get_file(ent.filename, nullptr, nullptr, filter);
 		if (err)
@@ -552,7 +554,7 @@ static int cmd_identify(const struct command *c, int argc, char *argv[])
 	{
 		for (i = 0; modules[i]; i++)
 		{
-			std::wcout << wstring_from_utf8(util::string_format("%.16s %s", modules[i]->name, modules[i]->description)) << std::endl;
+			util::stream_format(std::wcout, L"%.16s %s\n", wstring_from_utf8(modules[i]->name), wstring_from_utf8(modules[i]->description));
 		}
 
 		return 0;
@@ -685,11 +687,11 @@ done:
 
 static int cmd_listformats(const struct command *c, int argc, char *argv[])
 {
-	std::wcout << L"Image formats supported by imgtool:" << std::endl << std::endl;
+	util::stream_format(std::wcout, L"Image formats supported by imgtool:\n\n");
 
 	for (const auto &module : imgtool_get_modules())
 	{
-		std::wcout << wstring_from_utf8(util::string_format("  %-25s%s", module->name, module->description)) << std::endl;
+		util::stream_format(std::wcout, L"  %-25s%s\n", wstring_from_utf8(module->name), wstring_from_utf8(module->description));
 	}
 
 	return 0;
@@ -701,14 +703,13 @@ static int cmd_listfilters(const struct command *c, int argc, char *argv[])
 {
 	int i;
 
-	std::wcout << L"Filters supported by imgtool:" << std::endl << std::endl;
+	util::stream_format(std::wcout, L"Filters supported by imgtool:\n\n");
 
 	for (i = 0; filters[i]; i++)
 	{
-		std::wcout << wstring_from_utf8(util::string_format(
-			"  %-11s%s",
+		util::stream_format(std::wcout, L"  %-11s%s\n",
 			filter_get_info_string(filters[i], FILTINFO_STR_NAME),
-			filter_get_info_string(filters[i], FILTINFO_STR_HUMANNAME))) << std::endl;
+			filter_get_info_string(filters[i], FILTINFO_STR_HUMANNAME));
 	}
 
 	return 0;
@@ -719,8 +720,8 @@ static void listoptions(const util::option_guide &opt_guide, const char *opt_spe
 	util::option_resolution resolution(opt_guide);
 	resolution.set_specification(opt_spec);
 
-	std::wcout << L"Option           Allowed values                 Description" << std::endl;
-	std::wcout << L"---------------- ------------------------------ -----------" << std::endl;
+	util::stream_format(std::wcout, L"Option           Allowed values                 Description\n");
+	util::stream_format(std::wcout, L"---------------- ------------------------------ -----------\n");
 
 	for (auto iter = resolution.entries_begin(); iter != resolution.entries_end(); iter++)
 	{
@@ -767,11 +768,10 @@ static void listoptions(const util::option_guide &opt_guide, const char *opt_spe
 			break;
 		}
 
-		std::wcout << wstring_from_utf8(util::string_format(
-			"%16s %-30s %s",
+		util::stream_format(std::wcout, L"%16s %-30s %s\n",
 			opt_name,
 			description_buffer.str(),
-			opt_desc)) << std::endl;
+			opt_desc);
 	}
 }
 
@@ -790,33 +790,33 @@ static int cmd_listdriveroptions(const struct command *c, int argc, char *argv[]
 		return -1;
 	}
 
-	std::wcout << L"Driver specific options for module '" << wstring_from_utf8(argv[0]) << L":" << std::endl << std::endl;
+	util::stream_format(std::wcout, L"Driver specific options for module '%s':\n\n", wstring_from_utf8(argv[0]));
 
 	/* list write options */
 	opt_guide = (const util::option_guide *) imgtool_get_info_ptr(&mod->imgclass, IMGTOOLINFO_PTR_WRITEFILE_OPTGUIDE);
 	opt_spec = imgtool_get_info_string(&mod->imgclass, IMGTOOLINFO_STR_WRITEFILE_OPTSPEC);
 	if (opt_guide)
 	{
-		std::wcout << L"Image specific file options (usable on the 'put' command):" << std::endl << std::endl;
+		util::stream_format(std::wcout, L"Image specific file options (usable on the 'put' command):\n\n");
 		listoptions(*opt_guide, opt_spec);
-		std::wcout << std::endl;
+		util::stream_format(std::wcout, L"\n");
 	}
 	else
 	{
-		std::wcout << L"No image specific file options" << std::endl << std::endl;
+		util::stream_format(std::wcout, L"No image specific file options\n\n");
 	}
 
 	/* list create options */
 	opt_guide = mod->createimage_optguide;
 	if (opt_guide)
 	{
-		std::wcout << L"Image specific creation options (usable on the 'create' command):" << std::endl << std::endl;
+		util::stream_format(std::wcout, L"Image specific creation options (usable on the 'create' command):\n\n");
 		listoptions(*opt_guide, mod->createimage_optspec);
-		std::wcout << std::endl;
+		util::stream_format(std::wcout, L"\n");
 	}
 	else
 	{
-		std::wcout << L"No image specific creation options" << std::endl << std::endl;
+		util::stream_format(std::wcout, L"No image specific creation options\n\n");
 	}
 
 	return 0;
@@ -856,7 +856,7 @@ int main(int argc, char *argv[])
 	std::string cmdname = core_filename_extract_base(argv[0]);
 
 #ifdef _WIN32
-	_setmode(_fileno(stdout), _O_U16TEXT);
+	_setmode(_fileno(stdout), _O_U8TEXT);
 #endif // _WIN32
 
 #ifdef MAME_DEBUG
@@ -864,7 +864,7 @@ int main(int argc, char *argv[])
 		return -1;
 #endif // MAME_DEBUG
 
-	std::wcout << std::endl;
+	util::stream_format(std::wcout, L"\n");
 
 	if (argc > 1)
 	{
@@ -907,20 +907,18 @@ int main(int argc, char *argv[])
 	}
 
 	// Usage
-	std::wcerr << L"imgtool - Generic image manipulation tool for use with MAME" << std::endl << std::endl;
+	util::stream_format(std::wcerr, L"imgtool - Generic image manipulation tool for use with MAME\n\n");
 	for (i = 0; i < ARRAY_LENGTH(cmds); i++)
 	{
-		writeusage(std::wcout, (i == 0), &cmds[i], argv);
+		writeusage(std::wcerr, (i == 0), &cmds[i], argv);
 	}
-	std::wcerr << std::endl;
-	std::wcerr << L"<format> is the image format, e.g. " << wstring_from_utf8(sample_format) << std::endl;
-	std::wcerr << L"<imagename> is the image filename; can specify a ZIP file for image name" << std::endl;
+	util::stream_format(std::wcerr, L"\n<format> is the image format, e.g. %s\n", wstring_from_utf8(sample_format));
+	util::stream_format(std::wcerr, L"<imagename> is the image filename; can specify a ZIP file for image name\n");
 
-	std::wcerr << std::endl;
-	std::wcerr << L"Example usage:" << std::endl;
-	std::wcerr << L"\t" << wstring_from_utf8(cmdname) << L" dir "    << wstring_from_utf8(sample_format) << L" myimageinazip.zip" << std::endl;
-	std::wcerr << L"\t" << wstring_from_utf8(cmdname) << L" get "    << wstring_from_utf8(sample_format) << L" myimage.dsk myfile.bin mynewfile.txt" << std::endl;
-	std::wcerr << L"\t" << wstring_from_utf8(cmdname) << L" getall " << wstring_from_utf8(sample_format) << L" myimage.dsk" << std::endl;
+	util::stream_format(std::wcerr, L"\nExample usage:\n");
+	util::stream_format(std::wcerr, L"\t%s dir %s myimageinazip.zip\n", wstring_from_utf8(cmdname), wstring_from_utf8(sample_format));
+	util::stream_format(std::wcerr, L"\t%s get %s myimage.dsk myfile.bin mynewfile.txt\n", wstring_from_utf8(cmdname), wstring_from_utf8(sample_format));
+	util::stream_format(std::wcerr, L"\t%s getall %s myimage.dsk\n", wstring_from_utf8(cmdname), wstring_from_utf8(sample_format));
 	result = 0;
 	goto done;
 


### PR DESCRIPTION
I really don't like the prevalence of '#ifdef WIN32' in this change, both the _setmode() and bypassing codecvt.  I strongly suspect that the latter is the consequence of some mistake that in practice doesn't cause problems in MSVC.  I welcome all eyes.