### PR TITLE
Service mode DIP switch adjustments

### DIFF
--- a/src/emu/ioport.h
+++ b/src/emu/ioport.h
@@ -1058,6 +1058,8 @@ public:
 	const input_seq &seq(input_seq_type seqtype = SEQ_TYPE_STANDARD) const;
 	const input_seq &defseq(input_seq_type seqtype = SEQ_TYPE_STANDARD) const;
 	const input_seq &defseq_unresolved(input_seq_type seqtype = SEQ_TYPE_STANDARD) const { return m_seq[seqtype]; }
+	void set_defseq(const input_seq &newseq) { set_defseq(SEQ_TYPE_STANDARD, newseq); }
+	void set_defseq(input_seq_type seqtype, const input_seq &newseq);
 	bool has_dynamic_read() const { return !m_read.isnull(); }
 	bool has_dynamic_write() const { return !m_write.isnull(); }
 

--- a/src/frontend/mame/ui/info.cpp
+++ b/src/frontend/mame/ui/info.cpp
@@ -54,24 +54,6 @@ machine_info::machine_info(running_machine &machine)
 }
 
 
-//-------------------------------------------------
-//  find_dipname - look up DIP switch by name
-//-------------------------------------------------
-
-ioport_field *machine_info::find_dipname(const char *name) const
-{
-	if (!m_has_dips)
-		return nullptr;
-
-	for (auto &port : m_machine.ioport().ports())
-		for (ioport_field &field : port.second->fields())
-			if (field.type() == IPT_DIPSWITCH && strcmp(field.name(), name) == 0)
-				return &field;
-
-	return nullptr;
-}
-
-
 /***************************************************************************
     TEXT GENERATORS
 ***************************************************************************/

--- a/src/frontend/mame/ui/info.cpp
+++ b/src/frontend/mame/ui/info.cpp
@@ -30,6 +30,7 @@ machine_info::machine_info(running_machine &machine)
 	m_has_dips = false;
 	m_has_bioses = false;
 	m_has_keyboard = false;
+	m_has_test_switch = false;
 
 	// scan the input port array to see what options we need to enable
 	for (auto &port : machine.ioport().ports())
@@ -43,11 +44,31 @@ machine_info::machine_info(running_machine &machine)
 				m_has_analog = true;
 			if (field.type() == IPT_KEYBOARD)
 				m_has_keyboard = true;
+			if (field.type() == IPT_SERVICE)
+				m_has_test_switch = true;
 		}
 
 	for (device_t &device : device_iterator(machine.root_device()))
 		for (const rom_entry &rom : device.rom_region_vector())
 			if (ROMENTRY_ISSYSTEM_BIOS(&rom)) { m_has_bioses = true; break; }
+}
+
+
+//-------------------------------------------------
+//  find_dipname - look up DIP switch by name
+//-------------------------------------------------
+
+ioport_field *machine_info::find_dipname(const char *name) const
+{
+	if (!m_has_dips)
+		return nullptr;
+
+	for (auto &port : m_machine.ioport().ports())
+		for (ioport_field &field : port.second->fields())
+			if (field.type() == IPT_DIPSWITCH && strcmp(field.name(), name) == 0)
+				return &field;
+
+	return nullptr;
 }
 
 

--- a/src/frontend/mame/ui/info.h
+++ b/src/frontend/mame/ui/info.h
@@ -31,8 +31,6 @@ public:
 	bool has_keyboard() const { return m_has_keyboard; }
 	bool has_test_switch() const { return m_has_test_switch; }
 
-	ioport_field *find_dipname(const char *name) const;
-
 	// text generators
 	std::string warnings_string();
 	std::string game_info_string();

--- a/src/frontend/mame/ui/info.h
+++ b/src/frontend/mame/ui/info.h
@@ -29,6 +29,9 @@ public:
 	bool has_dips() const { return m_has_dips; }
 	bool has_bioses() const { return m_has_bioses; }
 	bool has_keyboard() const { return m_has_keyboard; }
+	bool has_test_switch() const { return m_has_test_switch; }
+
+	ioport_field *find_dipname(const char *name) const;
 
 	// text generators
 	std::string warnings_string();
@@ -46,6 +49,7 @@ private:
 	bool                    m_has_dips;
 	bool                    m_has_bioses;
 	bool                    m_has_keyboard;
+	bool                    m_has_test_switch;
 };
 
 class menu_game_info : public menu

--- a/src/frontend/mame/ui/ui.cpp
+++ b/src/frontend/mame/ui/ui.cpp
@@ -256,6 +256,13 @@ void mame_ui_manager::initialize(running_machine &machine)
 	{
 		slider_current = nullptr;
 	}
+
+	if (!m_machine_info->has_test_switch())
+	{
+		ioport_field *service_mode_sw = m_machine_info->find_dipname(ioport_configurer::string_from_token(DEF_STR(Service_Mode)));
+		if (service_mode_sw != nullptr)
+			service_mode_sw->set_defseq(machine.ioport().type_seq(IPT_SERVICE));
+	}
 }
 
 

--- a/src/frontend/mame/ui/ui.cpp
+++ b/src/frontend/mame/ui/ui.cpp
@@ -257,11 +257,14 @@ void mame_ui_manager::initialize(running_machine &machine)
 		slider_current = nullptr;
 	}
 
-	if (!m_machine_info->has_test_switch())
+	// if no test switch found, assign its input sequence to a service mode DIP
+	if (!m_machine_info->has_test_switch() && m_machine_info->has_dips())
 	{
-		ioport_field *service_mode_sw = m_machine_info->find_dipname(ioport_configurer::string_from_token(DEF_STR(Service_Mode)));
-		if (service_mode_sw != nullptr)
-			service_mode_sw->set_defseq(machine.ioport().type_seq(IPT_SERVICE));
+		const char *const service_mode_dipname = ioport_configurer::string_from_token(DEF_STR(Service_Mode));
+		for (auto &port : machine.ioport().ports())
+			for (ioport_field &field : port.second->fields())
+				if (field.type() == IPT_DIPSWITCH && strcmp(field.name(), service_mode_dipname) == 0)
+					field.set_defseq(machine.ioport().type_seq(IPT_SERVICE));
 	}
 }
 


### PR DESCRIPTION
- Changed how input sequences are assigned to service mode DIP switches. The frontend now assigns them the default sequence for the non-toggle service mode/test switch (not necessarily the F2 key, the previously hardcoded default) unless the machine happens to have one of those as well (as is somewhat common with gambling games).
- All DIP and configuration switches are automatically defined as toggle fields to make assigning input codes to them easier.