### PR TITLE
added a dump of one of the hng64 tmp87ph40an i/o chips [Caps0ff]

### DIFF
--- a/src/mame/drivers/hng64.cpp
+++ b/src/mame/drivers/hng64.cpp
@@ -1573,7 +1573,11 @@ MACHINE_CONFIG_END
 	ROM_REGION( 0x0100000, "user2", 0 ) /* KL5C80 BIOS */ \
 	ROM_LOAD ( "from1.bin", 0x000000, 0x080000,  CRC(6b933005) SHA1(e992747f46c48b66e5509fe0adf19c91250b00c7) ) \
 	ROM_REGION( 0x0100000, "fpga", 0 ) /* FPGA data  */ \
-	ROM_LOAD ( "rom1.bin",  0x000000, 0x01ff32,  CRC(4a6832dc) SHA1(ae504f7733c2f40450157cd1d3b85bc83fac8569) )
+	ROM_LOAD ( "rom1.bin",  0x000000, 0x01ff32,  CRC(4a6832dc) SHA1(ae504f7733c2f40450157cd1d3b85bc83fac8569) ) \
+	ROM_REGION( 0x08000, "iomcu", 0 ) /* unknown I/O MCU, might be Shooting type, came from recycled OTP chip sample, not a HNG64 board. */ \
+									  /* "64Bit I/O Controller Ver 1.0 1997.06.29(C)SNK" internal ID string */ \
+	ROM_LOAD ( "tmp87ph40an.bin",  0x000000, 0x08000,  CRC(b70df21f) SHA1(5b742e8a0bbf4c0ae4f4398d34c7058fb24acc92) )
+
 
 ROM_START( hng64 )
 	/* BIOS */


### PR DESCRIPTION
note, this came from a sample OTP chip that was purchased for testing / analysis, not one of the chips actually taken from a hng64 unit!  The chip had no protection and read out without issue.  It just ended up turning out to be the case that the sample chip had clearly been pulled from such a board at some point in the past.  As a result it isn't clear if this is the driving, shooting or fighting MCU type.

contains the internal string "64Bit I/O Controller Ver 1.0 1997.06.29(C)SNK"

a CPU core is needed (I'll probably do a basic skeleton in the next few days.