### PR TITLE
Fixes broken 144k + POKEY@450 emulation.

### DIFF
--- a/a78slotfix.diff
+++ b/a78slotfix.diff
@@ -1,0 +1,12 @@
+--- C:\msys64\src\mame\src\devices\bus\a7800\a78_slot.h	2016-12-27 18:09:06.000000000 -0500
++++ C:\temp\a78_slot.h	2017-01-03 16:49:51.000000000 -0500
+@@ -19,8 +19,8 @@
+ 	A78_TYPE2,          // Atari SuperGame pcb (8x16K banks with bankswitch)
+ 	A78_TYPE3,          // as TYPE1 + POKEY chip on the PCB
+ 	A78_TYPE6,          // as TYPE1 + RAM IC on the PCB
++	A78_TYPEA,          // Alien Brigade, Crossbow (9x16K banks with diff bankswitch)
+ 	A78_TYPE8,          // Rescue on Fractalus, as TYPE0 + 2K Mirror RAM IC on the PCB
+- 	A78_TYPEA,          // Alien Brigade, Crossbow (9x16K banks with diff bankswitch)
+ 	A78_ABSOLUTE,       // F18 Hornet
+ 	A78_ACTIVISION,     // Double Dragon, Rampage
+ 	A78_HSC,            // Atari HighScore cart


### PR DESCRIPTION
The addition of A78_TYPE8 in a previous update changed the value A78_TYPEA was assigned by enumeration from 5 to 6. 

The patch provides reordered A78_TYPEA and A78_TYPE8, changing A78_TYPEA back to a constant of 5, fixing the hardware setup in a78_slot.cpp for 144k + POKEY@450 hardware. CPUWIZ formats linked to 144k TYPEA format (I.E. Bentley Bear's Crystal Quest, Donkey Kong PK-XM) will no longer crash as a result.