### PR TITLE
Update a78_slot.h

### DIFF
--- a/src/devices/bus/a7800/a78_slot.h
+++ b/src/devices/bus/a7800/a78_slot.h
@@ -19,8 +19,8 @@ enum
 	A78_TYPE2,          // Atari SuperGame pcb (8x16K banks with bankswitch)
 	A78_TYPE3,          // as TYPE1 + POKEY chip on the PCB
 	A78_TYPE6,          // as TYPE1 + RAM IC on the PCB
-	A78_TYPE8,          // Rescue on Fractalus, as TYPE0 + 2K Mirror RAM IC on the PCB
- 	A78_TYPEA,          // Alien Brigade, Crossbow (9x16K banks with diff bankswitch)
+	A78_TYPEA,          // Alien Brigade, Crossbow (9x16K banks with diff bankswitch)
+ 	A78_TYPE8,          // Rescue on Fractalus, as TYPE0 + 2K Mirror RAM IC on the PCB
 	A78_ABSOLUTE,       // F18 Hornet
 	A78_ACTIVISION,     // Double Dragon, Rampage
 	A78_HSC,            // Atari HighScore cart


### PR DESCRIPTION
Fixes broken 144k + POKEY@450 emulation.

The patch provides reordered A78_TYPEA and A78_TYPE8, changing A78_TYPEA back to a constant of 5, fixing the hardware setup in a78_slot.cpp for 144k + POKEY@450 hardware. CPUWIZ formats linked to 144k TYPEA format (I.E. Bentley Bear's Crystal Quest, Donkey Kong PK-XM) will no longer crash as a result.