### PR TITLE
MSM5205 architectural cleanups (nw)

### DIFF
--- a/src/devices/sound/msm5205.h
+++ b/src/devices/sound/msm5205.h
@@ -43,15 +43,15 @@ class msm5205_device : public device_t,
 							public device_sound_interface
 {
 public:
-	msm5205_device(const machine_config &mconfig, const char *tag, device_t *owner, uint32_t clock);
-	msm5205_device(const machine_config &mconfig, device_type type, const char *name, const char *tag, device_t *owner, uint32_t clock, const char *shortname, const char *source);
+	msm5205_device(const machine_config &mconfig, const char *tag, device_t *owner, u32 clock);
+	msm5205_device(const machine_config &mconfig, device_type type, const char *name, const char *tag, device_t *owner, u32 clock, const char *shortname, const char *source);
 	~msm5205_device() {}
 
-	static void set_prescaler_selector(device_t &device, int select) { downcast<msm5205_device &>(device).m_select = select; }
+	static void set_prescaler_selector(device_t &device, int select);
 	template<class _Object> static devcb_base &set_vclk_callback(device_t &device, _Object object) { return downcast<msm5205_device &>(device).m_vclk_cb.set_callback(object); }
 
 	// reset signal should keep for 2cycle of VCLK
-	void reset_w(int reset);
+	DECLARE_WRITE_LINE_MEMBER(reset_w);
 
 	// adpcmata is latched after vclk_interrupt callback
 	void data_w(int data);
@@ -60,17 +60,18 @@ public:
 	// VCLK slave mode option
 	// if VCLK and reset or data is changed at the same time,
 	// call vclk_w after data_w and reset_w.
-	void vclk_w(int vclk);
+	DECLARE_WRITE_LINE_MEMBER(vclk_w);
 
 	// option , selected pin selector
 	void playmode_w(int select);
-
-	void change_clock_w(int32_t clock);
+	DECLARE_WRITE_LINE_MEMBER(s1_w);
+	DECLARE_WRITE_LINE_MEMBER(s2_w);
 
 protected:
 	// device-level overrides
 	virtual void device_start() override;
 	virtual void device_reset() override;
+	virtual void device_clock_changed() override;
 
 	TIMER_CALLBACK_MEMBER(vclk_callback);
 
@@ -78,20 +79,20 @@ protected:
 	virtual void sound_stream_update(sound_stream &stream, stream_sample_t **inputs, stream_sample_t **outputs, int samples) override;
 
 	void compute_tables();
+	virtual int get_prescaler() const;
 
 	// internal state
-	sound_stream * m_stream;    /* number of stream system      */
-	int32_t m_mod_clock;          /* clock rate                   */
-	emu_timer *m_timer;         /* VCLK callback timer          */
-	int32_t m_data;               /* next adpcm data              */
-	int32_t m_vclk;               /* vclk signal (external mode)  */
-	int32_t m_reset;              /* reset pin signal             */
-	int32_t m_prescaler;          /* prescaler selector S1 and S2 */
-	int32_t m_bitwidth;           /* bit width selector -3B/4B    */
-	int32_t m_signal;             /* current ADPCM signal         */
-	int32_t m_step;               /* current ADPCM step           */
+	sound_stream * m_stream;    // number of stream system
+	emu_timer *m_timer;         // VCK callback timer
+	u8 m_data;                  // next adpcm data
+	bool m_vclk;                // VCK signal (external mode)
+	bool m_reset;               // reset pin signal
+	bool m_s1;                  // prescaler selector S1
+	bool m_s2;                  // prescaler selector S2
+	u8 m_bitwidth;              // bit width selector -3B/4B
+	int32_t m_signal;           // current ADPCM signal
+	int32_t m_step;             // current ADPCM step
 	int m_diff_lookup[49*16];
-	int m_select;
 	devcb_write_line m_vclk_cb;
 };
 
@@ -100,7 +101,10 @@ extern const device_type MSM5205;
 class msm6585_device : public msm5205_device
 {
 public:
-	msm6585_device(const machine_config &mconfig, const char *tag, device_t *owner, uint32_t clock);
+	msm6585_device(const machine_config &mconfig, const char *tag, device_t *owner, u32 clock);
+
+protected:
+	virtual int get_prescaler() const override;
 
 	// sound stream update overrides
 	virtual void sound_stream_update(sound_stream &stream, stream_sample_t **inputs, stream_sample_t **outputs, int samples) override;

--- a/src/devices/sound/msm5205.h
+++ b/src/devices/sound/msm5205.h
@@ -90,8 +90,8 @@ protected:
 	bool m_s1;                  // prescaler selector S1
 	bool m_s2;                  // prescaler selector S2
 	u8 m_bitwidth;              // bit width selector -3B/4B
-	int32_t m_signal;           // current ADPCM signal
-	int32_t m_step;             // current ADPCM step
+	s32 m_signal;               // current ADPCM signal
+	s32 m_step;                 // current ADPCM step
 	int m_diff_lookup[49*16];
 	devcb_write_line m_vclk_cb;
 };

--- a/src/mame/drivers/joctronic.cpp
+++ b/src/mame/drivers/joctronic.cpp
@@ -234,7 +234,7 @@ WRITE8_MEMBER(joctronic_state::resint_w)
 WRITE8_MEMBER(joctronic_state::slalom03_oki_bank_w)
 {
 	m_soundbank->set_entry((data & 0xc0) >> 6);
-	m_oki->playmode_w(BIT(data, 1) ? MSM5205_S48_4B : MSM5205_S96_4B); // to S1 on MSM5205
+	m_oki->s1_w(BIT(data, 1));
 	m_oki->reset_w(BIT(data, 0));
 }
 

--- a/src/mame/machine/pce_cd.cpp
+++ b/src/mame/machine/pce_cd.cpp
@@ -229,7 +229,7 @@ void pce_cd_device::late_setup()
 	}
 
 	// MSM5205 might be initialized after PCE CD as well...
-	m_msm->change_clock_w((PCE_CD_CLOCK / 6) / m_adpcm_clock_divider);
+	m_msm->set_unscaled_clock((PCE_CD_CLOCK / 6) / m_adpcm_clock_divider);
 }
 
 void pce_cd_device::nvram_init(nvram_device &nvram, void *data, size_t size)
@@ -1180,7 +1180,7 @@ WRITE8_MEMBER(pce_cd_device::intf_w)
 			break;
 		case 0x0E:  /* ADPCM playback rate */
 			m_adpcm_clock_divider = 0x10 - (data & 0x0f);
-			m_msm->change_clock_w((PCE_CD_CLOCK / 6) / m_adpcm_clock_divider);
+			m_msm->set_unscaled_clock((PCE_CD_CLOCK / 6) / m_adpcm_clock_divider);
 			break;
 		case 0x0F:  /* ADPCM and CD audio fade timer */
 			/* TODO: timers needs HW tests */


### PR DESCRIPTION
- Implement device_clock_changed instead of using custom handler
- Add proper write handlers for S1 and S2 lines and store their state internally