### PR TITLE
Make "requirement" field in softlists actually work (MT 6464)

### DIFF
--- a/src/emu/diimage.cpp
+++ b/src/emu/diimage.cpp
@@ -1153,12 +1153,30 @@ image_init_result device_image_interface::load_software(const std::string &softw
 bool device_image_interface::open_image_file(emu_options &options)
 {
 	const char* path = options.value(instance_name());
-	if (*path != 0)
+	if (*path != 0 && m_software_part_ptr == nullptr)
 	{
 		set_init_phase();
 		if (load_internal(path, false, 0, nullptr, true) == image_init_result::PASS)
 		{
 			if (software_entry()==nullptr) return true;
+		}
+		else
+			m_software_part_ptr = find_software_item(path, true);
+
+		// if we're loading from a software list, check requirements
+		if (m_software_part_ptr != nullptr)
+		{
+			const char *requirement = m_software_part_ptr->feature("requirement");
+			if (requirement != nullptr)
+			{
+				const software_part *req_swpart = find_software_item(requirement, false);
+				if (req_swpart != nullptr)
+				{
+					device_image_interface *req_image = software_list_device::find_mountable_image(device().mconfig(), *req_swpart);
+					if (req_image != nullptr)
+						req_image->m_software_part_ptr = req_swpart;
+				}
+			}
 		}
 	}
 	return false;
@@ -1429,7 +1447,7 @@ bool device_image_interface::load_software_part(const std::string &identifier, c
 
 #ifdef UNUSED_VARIABLE
 	// Tell the world which part we actually loaded
-	std::string full_sw_name = string_format("%s:%s:%s", swlist.list_name(), swpart->info().shortname(), swpart->name());
+	std::string full_sw_name = string_format("%s:%s:%s", swlist->list_name(), swpart->info().shortname(), swpart->name());
 #endif
 
 	// check compatibility
@@ -1458,7 +1476,8 @@ bool device_image_interface::load_software_part(const std::string &identifier, c
 			if (req_image != nullptr)
 			{
 				req_image->set_init_phase();
-				req_image->load(requirement);
+				if (req_image->load_software(requirement) != image_init_result::PASS)
+					result = false;
 			}
 		}
 	}
@@ -1473,20 +1492,18 @@ bool device_image_interface::load_software_part(const std::string &identifier, c
 
 std::string device_image_interface::software_get_default_slot(const char *default_card_slot) const
 {
-	const char *path = device().mconfig().options().value(instance_name());
-	std::string result;
-	if (*path != '\0')
+	if (m_software_part_ptr != nullptr)
 	{
-		result.assign(default_card_slot);
-		const software_part *swpart = find_software_item(path, true);
-		if (swpart != nullptr)
-		{
-			const char *slot = swpart->feature("slot");
-			if (slot != nullptr)
-				result.assign(slot);
-		}
+		// use slot value if available
+		const char *slot = m_software_part_ptr->feature("slot");
+		return (slot != nullptr) ? slot : default_card_slot;
 	}
-	return result;
+
+	// necessary for image file creation???
+	if (*device().mconfig().options().value(instance_name()) != '\0')
+		return default_card_slot;
+
+	return std::string();
 }
 
 //----------------------------------------------------------------------------

--- a/src/emu/softlist_dev.cpp
+++ b/src/emu/softlist_dev.cpp
@@ -377,7 +377,7 @@ device_image_interface *software_list_device::find_mountable_image(const machine
 		{
 			// mount only if not already mounted
 			const char *option = mconfig.options().value(image.brief_instance_name());
-			if (*option == '\0' && !image.filename())
+			if (*option == '\0' && !image.filename() && image.part_entry() == nullptr)
 				return &image;
 		}
 	}

--- a/src/frontend/mame/mameopts.cpp
+++ b/src/frontend/mame/mameopts.cpp
@@ -83,6 +83,10 @@ void mame_options::update_slot_options(emu_options &options, const software_part
 		return;
 	machine_config config(*cursystem, options);
 
+	// preopen all images (this allows slots to be assigned for all required software)
+	for (device_image_interface &image : image_interface_iterator(config.root_device()))
+		image.open_image_file(options);
+
 	// iterate through all slot devices
 	for (device_slot_interface &slot : slot_interface_iterator(config.root_device()))
 	{


### PR DESCRIPTION
(nw) MAME's architecture for software loading remains gruesomely overcomplicated, and this makes it even less efficient than it already was. However, I think more invasive cleanups would best be left until later.