### PR TITLE
minor floppy internals improvements

### DIFF
--- a/src/devices/imagedev/floppy.cpp
+++ b/src/devices/imagedev/floppy.cpp
@@ -181,6 +181,7 @@ floppy_image_device::floppy_image_device(const machine_config &mconfig, device_t
 		form_factor(0),
 		motor_always_on(false),
 		dskchg_writable(false),
+		has_trk00_sensor(true),
 		dir(0), stp(0), wtg(0), mon(0), ss(0), idx(0), wpt(0), rdy(0), dskchg(0),
 		ready(false),
 		rpm(0),
@@ -316,6 +317,7 @@ void floppy_image_device::device_start()
 	rpm = 0;
 	motor_always_on = false;
 	dskchg_writable = false;
+	has_trk00_sensor = true;
 
 	idx = 0;
 
@@ -2283,14 +2285,13 @@ ibm_6360::~ibm_6360()
 {
 }
 
-//ol ibm_6360::trk00_r() { return true; }
-
 void ibm_6360::setup_characteristics()
 {
 	form_factor = floppy_image::FF_8;
 	tracks = 77;
 	sides = 1;
 	motor_always_on = true;
+	has_trk00_sensor = false;
 	set_rpm(360);
 }
 

--- a/src/devices/imagedev/floppy.cpp
+++ b/src/devices/imagedev/floppy.cpp
@@ -180,6 +180,7 @@ floppy_image_device::floppy_image_device(const machine_config &mconfig, device_t
 		sides(0),
 		form_factor(0),
 		motor_always_on(false),
+		dskchg_writable(false),
 		dir(0), stp(0), wtg(0), mon(0), ss(0), idx(0), wpt(0), rdy(0), dskchg(0),
 		ready(false),
 		rpm(0),
@@ -314,6 +315,7 @@ void floppy_image_device::device_start()
 {
 	rpm = 0;
 	motor_always_on = false;
+	dskchg_writable = false;
 
 	idx = 0;
 
@@ -449,6 +451,9 @@ image_init_result floppy_image_device::call_load()
 		mon_w(0);
 	} else if(!mon)
 		ready_counter = 2;
+
+	if (dskchg_writable)
+		dskchg = 1;
 
 	return image_init_result::PASS;
 }
@@ -651,7 +656,7 @@ void floppy_image_device::stp_w(int state)
 				if (m_make_sound) m_sound_out->step(cyl*5/tracks);
 			}
 			/* Update disk detection if applicable */
-			if (exists())
+			if (exists() && !dskchg_writable)
 			{
 				if (dskchg==0) dskchg = 1;
 			}
@@ -696,7 +701,7 @@ void floppy_image_device::seek_phase_w(int phases)
 		logerror("%s: track %d.%d\n", tag(), cyl, subcyl);
 
 	/* Update disk detection if applicable */
-	if (exists())
+	if (exists() && !dskchg_writable)
 		if (dskchg==0)
 			dskchg = 1;
 }
@@ -2040,6 +2045,7 @@ void sony_oa_d31v::setup_characteristics()
 	form_factor = floppy_image::FF_35;
 	tracks = 70;
 	sides = 1;
+	dskchg_writable = true;
 	set_rpm(600);
 }
 
@@ -2075,6 +2081,7 @@ void sony_oa_d32w::setup_characteristics()
 	form_factor = floppy_image::FF_35;
 	tracks = 80;
 	sides = 2;
+	dskchg_writable = true;
 	set_rpm(600);
 }
 
@@ -2111,6 +2118,7 @@ void sony_oa_d32v::setup_characteristics()
 	form_factor = floppy_image::FF_35;
 	tracks = 80;
 	sides = 1;
+	dskchg_writable = true;
 	set_rpm(600);
 }
 

--- a/src/devices/imagedev/floppy.h
+++ b/src/devices/imagedev/floppy.h
@@ -124,6 +124,7 @@ public:
 	void dir_w(int state) { dir = state; }
 	void ss_w(int state) { ss = state; }
 	void inuse_w(int state) { }
+	void dskchg_w(int state) { if (dskchg_writable) dskchg = state; }
 
 	void index_resync();
 	attotime time_next_index();
@@ -162,6 +163,7 @@ protected:
 	int sides;  /* number of heads */
 	uint32_t form_factor; /* 3"5, 5"25, etc */
 	bool motor_always_on;
+	bool dskchg_writable;
 
 	/* state of input lines */
 	int dir;  /* direction */

--- a/src/devices/imagedev/floppy.h
+++ b/src/devices/imagedev/floppy.h
@@ -113,7 +113,7 @@ public:
 
 	bool wpt_r() { return wpt; }
 	int dskchg_r() { return dskchg; }
-	bool trk00_r() { return cyl != 0; }
+	bool trk00_r() { return (has_trk00_sensor ? (cyl != 0) : 1); }
 	int idx_r() { return idx; }
 	int mon_r() { return mon; }
 	bool ss_r() { return ss; }
@@ -164,6 +164,7 @@ protected:
 	uint32_t form_factor; /* 3"5, 5"25, etc */
 	bool motor_always_on;
 	bool dskchg_writable;
+	bool has_trk00_sensor;
 
 	/* state of input lines */
 	int dir;  /* direction */

--- a/src/lib/formats/wd177x_dsk.cpp
+++ b/src/lib/formats/wd177x_dsk.cpp
@@ -55,7 +55,7 @@ int wd177x_format::compute_track_size(const format &f) const
 	return track_size;
 }
 
-void wd177x_format::build_sector_description(const format &f, uint8_t *sectdata, desc_s *sectors) const
+void wd177x_format::build_sector_description(const format &f, uint8_t *sectdata, desc_s *sectors, int track, int head) const
 {
 	if(f.sector_base_id == -1) {
 		for(int i=0; i<f.sector_count; i++) {
@@ -200,7 +200,6 @@ bool wd177x_format::load(io_generic *io, uint32_t form_factor, floppy_image *ima
 
 	uint8_t sectdata[40*512];
 	desc_s sectors[40];
-	build_sector_description(f, sectdata, sectors);
 
 	for(int track=0; track < f.track_count; track++)
 		for(int head=0; head < f.head_count; head++) {
@@ -209,6 +208,7 @@ bool wd177x_format::load(io_generic *io, uint32_t form_factor, floppy_image *ima
 			else
 				desc[16].p1 = get_track_dam_mfm(f, head, track);
 
+			build_sector_description(f, sectdata, sectors, track, head);
 			io_generic_read(io, sectdata, get_image_offset(f, head, track), track_size);
 			generate_track(desc, track, head, sectors, f.sector_count, total_size, image);
 		}
@@ -330,10 +330,10 @@ bool wd177x_format::save(io_generic *io, floppy_image *image)
 
 	uint8_t sectdata[40*512];
 	desc_s sectors[40];
-	build_sector_description(f, sectdata, sectors);
 
 	for(int track=0; track < f.track_count; track++)
 		for(int head=0; head < f.head_count; head++) {
+			build_sector_description(f, sectdata, sectors, track, head);
 			extract_sectors(image, f, sectors, track, head);
 			io_generic_write(io, sectdata, get_image_offset(f, head, track), track_size);
 		}

--- a/src/lib/formats/wd177x_dsk.h
+++ b/src/lib/formats/wd177x_dsk.h
@@ -55,7 +55,7 @@ protected:
 	virtual int get_track_dam_mfm(const format &f, int head, int track);
 
 	int compute_track_size(const format &f) const;
-	void build_sector_description(const format &d, uint8_t *sectdata, desc_s *sectors) const;
+	virtual void build_sector_description(const format &d, uint8_t *sectdata, desc_s *sectors, int track, int head) const;
 	void check_compatibility(floppy_image *image, std::vector<int> &candidates);
 	void extract_sectors(floppy_image *image, const format &f, desc_s *sdesc, int track, int head);
 };


### PR DESCRIPTION
dskchg_writable is required for hp_ipc -- it polls dskchg line and resets it once a new floppy is detected.
has_trk00 is wanted by ibm6580 -- mostly by diags, which expect 'recalibrate' command to fail.
wd177x change is for upcoming PPG Waveterm driver -- sector numbering does not start from 1 on reverse side of disk but continues from last sector number on previous side.
