### PR TITLE
Removing unnecessary callback

### DIFF
--- a/src/emu/main.cpp
+++ b/src/emu/main.cpp
@@ -182,7 +182,7 @@ void machine_manager::start_http_server()
 		endpoint.on_open = [&](auto connection) {
 			auto send_stream = std::make_shared<webpp::ws_server::SendStream>();
 			*send_stream << "update_machine";
-			m_wsserver->send(connection, send_stream, [](const std::error_code& ec) { });
+			m_wsserver->send(connection, send_stream);
 		};
 	
 		m_server->on_upgrade = [this](auto socket, auto request) {


### PR DESCRIPTION
I'm doing this in response to a compilation error on MSVC 2015.  As far as I can tell, this is a bug in the compiler.  My basis for asserting this is that placing the following declaration within the 'endpoint.on_open = <<lambda>>' gives the same compilation error:

	const std::function<void(void)> mycallback = [](void) {};

Whereas moving that logic outside of the 'endpoint.on_open = <<lambda>>' does not give an error.

Normally I don't like working around buggy compilers, but in this case the callback is supposed to be optional anyways.