### PR TITLE
[Imgtool] C++-ification of imgtool_dirent

### DIFF
--- a/src/tools/imgtool/imgtool.cpp
+++ b/src/tools/imgtool/imgtool.cpp
@@ -2511,12 +2511,12 @@ imgtoolerr_t imgtool::directory::get_next(imgtool::dirent &ent)
 	}
 
 	// don't trust the module!
-	if (!m_partition.m_supports_creation_time && (ent.creation_time != 0))
+	if (!m_partition.m_supports_creation_time && (ent.creation_time.type() != imgtool::datetime::datetime_type::NONE))
 	{
 		internal_error(nullptr, "next_enum() specified creation_time, which is marked as unsupported by this module");
 		return IMGTOOLERR_UNEXPECTED;
 	}
-	if (!m_partition.m_supports_lastmodified_time && (ent.lastmodified_time != 0))
+	if (!m_partition.m_supports_lastmodified_time && (ent.lastmodified_time.type() != imgtool::datetime::datetime_type::NONE))
 	{
 		internal_error(nullptr, "next_enum() specified lastmodified_time, which is marked as unsupported by this module");
 		return IMGTOOLERR_UNEXPECTED;

--- a/src/tools/imgtool/imgtool.h
+++ b/src/tools/imgtool/imgtool.h
@@ -151,7 +151,7 @@ namespace imgtool
 		imgtool::image &image() { return m_image; }
 
 		// ----- partition operations -----
-		imgtoolerr_t get_directory_entry(const char *path, int index, imgtool_dirent &ent);
+		imgtoolerr_t get_directory_entry(const char *path, int index, imgtool::dirent &ent);
 		imgtoolerr_t get_file_size(const char *filename, uint64_t &filesize);
 		imgtoolerr_t get_free_space(uint64_t &sz);
 		imgtoolerr_t read_file(const char *filename, const char *fork, imgtool::stream &destf, filter_getinfoproc filter);
@@ -204,7 +204,7 @@ namespace imgtool
 		unsigned int m_supports_bootblock : 1;            /* this module supports loading/storing the boot block */
 
 		std::function<imgtoolerr_t(imgtool::directory &enumeration, const char *path)> m_begin_enum;
-		std::function<imgtoolerr_t(imgtool::directory &enumeration, imgtool_dirent &ent)> m_next_enum;
+		std::function<imgtoolerr_t(imgtool::directory &enumeration, imgtool::dirent &ent)> m_next_enum;
 		std::function<void(imgtool::directory &enumeration)> m_close_enum;
 		std::function<imgtoolerr_t(imgtool::partition &partition, uint64_t *size)> m_free_space;
 		std::function<imgtoolerr_t(imgtool::partition &partition, const char *filename, const char *fork, imgtool::stream &destf)> m_read_file;
@@ -245,7 +245,7 @@ namespace imgtool
 
 		// methods
 		static imgtoolerr_t open(imgtool::partition &partition, const std::string &path, ptr &outenum);
-		imgtoolerr_t get_next(imgtool_dirent &ent);
+		imgtoolerr_t get_next(imgtool::dirent &ent);
 
 		// accessors
 		imgtool::partition &partition() { return m_partition; }
@@ -264,7 +264,6 @@ namespace imgtool
 int imgtool_validitychecks(void);
 void unknown_partition_get_info(const imgtool_class *imgclass, uint32_t state, union imgtoolinfo *info);
 
-char *strncpyz(char *dest, const char *source, size_t len);
 void rtrim(char *buf);
 std::string extract_padded_filename(const char *source, size_t filename_length, size_t extension_length);
 

--- a/src/tools/imgtool/library.h
+++ b/src/tools/imgtool/library.h
@@ -55,24 +55,27 @@ union filterinfo
 
 typedef void (*filter_getinfoproc)(uint32_t state, union filterinfo *info);
 
-struct imgtool_dirent
+namespace imgtool
 {
-	char filename[1024];
-	char attr[64];
-	uint64_t filesize;
+	struct dirent
+	{
+		std::string filename;
+		std::string attr;
+		uint64_t filesize;
 
-	time_t creation_time;
-	time_t lastmodified_time;
-	time_t lastaccess_time;
+		time_t creation_time;
+		time_t lastmodified_time;
+		time_t lastaccess_time;
 
-	char softlink[1024];
-	char comment[256];
+		std::string softlink;
+		std::string comment;
 
-	/* flags */
-	unsigned int eof : 1;
-	unsigned int corrupt : 1;
-	unsigned int directory : 1;
-	unsigned int hardlink : 1;
+		// flags
+		bool eof : 1;
+		bool corrupt : 1;
+		bool directory : 1;
+		bool hardlink : 1;
+	};
 };
 
 struct imgtool_chainent
@@ -283,7 +286,7 @@ union imgtoolinfo
 	imgtoolerr_t    (*create_partition) (imgtool::image &image, uint64_t first_block, uint64_t block_count);
 	void            (*info)             (imgtool::image &image, std::ostream &stream);
 	imgtoolerr_t    (*begin_enum)       (imgtool::directory &enumeration, const char *path);
-	imgtoolerr_t    (*next_enum)        (imgtool::directory &enumeration, imgtool_dirent &ent);
+	imgtoolerr_t    (*next_enum)        (imgtool::directory &enumeration, imgtool::dirent &ent);
 	void            (*close_enum)       (imgtool::directory &enumeration);
 	imgtoolerr_t    (*open_partition)   (imgtool::partition &partition, uint64_t first_block, uint64_t block_count);
 	imgtoolerr_t    (*free_space)       (imgtool::partition &partition, uint64_t *size);

--- a/src/tools/imgtool/library.h
+++ b/src/tools/imgtool/library.h
@@ -59,6 +59,10 @@ namespace imgtool
 {
 	struct dirent
 	{
+		dirent() = default;
+		dirent(const dirent &that) = default;
+		dirent(dirent &&that) = default;
+
 		std::string filename;
 		std::string attr;
 		uint64_t filesize;
@@ -71,10 +75,10 @@ namespace imgtool
 		std::string comment;
 
 		// flags
-		bool eof : 1;
-		bool corrupt : 1;
-		bool directory : 1;
-		bool hardlink : 1;
+		bool eof;
+		bool corrupt;
+		bool directory;
+		bool hardlink;
 	};
 };
 

--- a/src/tools/imgtool/main.cpp
+++ b/src/tools/imgtool/main.cpp
@@ -245,7 +245,7 @@ static int cmd_dir(const struct command *c, int argc, char *argv[])
 			L"%*s %*s %*s %*s\n",
 			-columnwidth_filename, wstring_from_utf8(ent.filename),
 			columnwidth_filesize, wstring_from_utf8(filesize_string),
-			columnwidth_attributes, ent.attr,
+			columnwidth_attributes, wstring_from_utf8(ent.attr),
 			columnwidth_lastmodified, wstring_from_utf8(last_modified));
 
 		if (ent.softlink && ent.softlink[0] != '\0')

--- a/src/tools/imgtool/main.cpp
+++ b/src/tools/imgtool/main.cpp
@@ -183,7 +183,7 @@ static int cmd_dir(const struct command *c, int argc, char *argv[])
 	imgtool::image::ptr image;
 	imgtool::partition::ptr partition;
 	imgtool::directory::ptr imgenum;
-	imgtool_dirent ent;
+	imgtool::dirent ent;
 	char last_modified[19];
 	std::string path;
 	int partition_index = 0;
@@ -239,7 +239,7 @@ static int cmd_dir(const struct command *c, int argc, char *argv[])
 				localtime(&ent.lastmodified_time));
 
 		if (ent.hardlink)
-			strcat(ent.filename, " <hl>");
+			ent.filename += " <hl>";
 
 		util::stream_format(std::wcout,
 			L"%*s %*s %*s %*s\n",
@@ -248,10 +248,10 @@ static int cmd_dir(const struct command *c, int argc, char *argv[])
 			columnwidth_attributes, wstring_from_utf8(ent.attr),
 			columnwidth_lastmodified, wstring_from_utf8(last_modified));
 
-		if (ent.softlink && ent.softlink[0] != '\0')
+		if (!ent.softlink.empty())
 			util::stream_format(std::wcout, L"-> %s\n", wstring_from_utf8(ent.softlink));
 
-		if (ent.comment && ent.comment[0] != '\0')
+		if (!ent.comment.empty())
 			util::stream_format(std::wcout, L": %s\n", wstring_from_utf8(ent.comment));
 
 		total_count++;
@@ -409,7 +409,7 @@ static int cmd_getall(const struct command *c, int argc, char *argv[])
 	imgtool::image::ptr image;
 	imgtool::partition::ptr partition;
 	imgtool::directory::ptr imgenum;
-	imgtool_dirent ent;
+	imgtool::dirent ent;
 	filter_getinfoproc filter;
 	int unnamedargs;
 	const char *path = nullptr;
@@ -444,7 +444,7 @@ static int cmd_getall(const struct command *c, int argc, char *argv[])
 	{
 		util::stream_format(std::wcout, L"Retrieving %s (%u bytes)\n", wstring_from_utf8(ent.filename), (unsigned int)ent.filesize);
 
-		err = partition->get_file(ent.filename, nullptr, nullptr, filter);
+		err = partition->get_file(ent.filename.c_str(), nullptr, nullptr, filter);
 		if (err)
 			goto done;
 	}

--- a/src/tools/imgtool/main.cpp
+++ b/src/tools/imgtool/main.cpp
@@ -234,9 +234,11 @@ static int cmd_dir(const struct command *c, int argc, char *argv[])
 			? "<DIR>"
 			: string_format("%u", (unsigned int) ent.filesize);
 
-		if (ent.lastmodified_time != 0)
-			strftime(last_modified, sizeof(last_modified), "%d-%b-%y %H:%M:%S",
-				localtime(&ent.lastmodified_time));
+		if (!ent.lastmodified_time.empty())
+		{
+			time_t t = ent.lastmodified_time.to_time_t();
+			strftime(last_modified, sizeof(last_modified), "%d-%b-%y %H:%M:%S", localtime(&t));
+		}
 
 		if (ent.hardlink)
 			ent.filename += " <hl>";

--- a/src/tools/imgtool/modules/amiga.cpp
+++ b/src/tools/imgtool/modules/amiga.cpp
@@ -348,18 +348,18 @@ static void amiga_setup_time(time_t time, amiga_date *dest)
 
 
 /* convert flags to human readable form */
-static void amiga_decode_flags(uint32_t flags, char *dest)
+static void amiga_decode_flags(uint32_t flags, std::string &dest)
 {
 	/* test for flags */
-	dest[0] = (flags & 0x80) ? 'h' : '-';
-	dest[1] = (flags & 0x40) ? 's' : '-';
-	dest[2] = (flags & 0x20) ? 'p' : '-';
-	dest[3] = (flags & 0x10) ? 'a' : '-';
-	dest[4] = (flags & 0x08) ? '-' : 'r';
-	dest[5] = (flags & 0x04) ? '-' : 'w';
-	dest[6] = (flags & 0x02) ? '-' : 'e';
-	dest[7] = (flags & 0x01) ? '-' : 'd';
-	dest[8] = '\0';
+	dest = util::string_format("%c%c%c%c%c%c%c%c",
+		(flags & 0x80) ? 'h' : '-',
+		(flags & 0x40) ? 's' : '-',
+		(flags & 0x20) ? 'p' : '-',
+		(flags & 0x10) ? 'a' : '-',
+		(flags & 0x08) ? '-' : 'r',
+		(flags & 0x04) ? '-' : 'w',
+		(flags & 0x02) ? '-' : 'e',
+		(flags & 0x01) ? '-' : 'd');
 }
 
 
@@ -1884,7 +1884,7 @@ static imgtoolerr_t amiga_image_beginenum(imgtool::directory &enumeration, const
 }
 
 
-static imgtoolerr_t amiga_image_nextenum(imgtool::directory &enumeration, imgtool_dirent &ent)
+static imgtoolerr_t amiga_image_nextenum(imgtool::directory &enumeration, imgtool::dirent &ent)
 {
 	amiga_iterator *iter = (amiga_iterator *) enumeration.extra_bytes();
 	imgtoolerr_t ret;
@@ -1928,11 +1928,11 @@ static imgtoolerr_t amiga_image_nextenum(imgtool::directory &enumeration, imgtoo
 		if (ret) return ret;
 
 		/* fill directory entry */
-		strncpyz(ent.filename, (char *)file.filename, file.name_len + 1);
+		ent.filename.assign((const char *)file.filename);
 		ent.filesize = file.byte_size;
 		ent.lastmodified_time = amiga_crack_time(&file.date);
 		amiga_decode_flags(file.protect, ent.attr);
-		strncpyz(ent.comment, (char *)file.comment, file.comm_len + 1);
+		ent.comment.assign((const char *)file.comment);
 
 		iter->next_block = file.hash_chain;
 
@@ -1948,10 +1948,10 @@ static imgtoolerr_t amiga_image_nextenum(imgtool::directory &enumeration, imgtoo
 		if (ret) return ret;
 
 		/* fill directory entry */
-		strncpyz(ent.filename, (char *)dir.dirname, dir.name_len + 1);
+		ent.filename = std::string((const char *)dir.dirname, dir.name_len + 1);
 		ent.lastmodified_time = amiga_crack_time(&dir.date);
 		amiga_decode_flags(dir.protect, ent.attr);
-		strncpyz(ent.comment, (char *)dir.comment, dir.comm_len + 1);
+		ent.comment = std::string((const char *)dir.comment, dir.comm_len + 1);
 		ent.directory = 1;
 
 		iter->next_block = dir.hash_chain;
@@ -1968,11 +1968,11 @@ static imgtoolerr_t amiga_image_nextenum(imgtool::directory &enumeration, imgtoo
 		if (ret) return ret;
 
 		/* fill directory entry */
-		strncpyz(ent.filename, (char *)sl.slname, sl.name_len + 1);
+		ent.filename = std::string((const char *) sl.slname, sl.name_len + 1);
 		ent.lastmodified_time = amiga_crack_time(&sl.date);
 		amiga_decode_flags(sl.protect, ent.attr);
-		strncpyz(ent.comment, (char *)sl.comment, sl.comm_len + 1);
-		strcpy(ent.softlink, (char *)sl.symbolic_name);
+		ent.comment = std::string((const char *) sl.comment, sl.comm_len + 1);
+		ent.softlink = std::string((const char *) sl.symbolic_name);
 
 		iter->next_block = sl.hash_chain;
 
@@ -2001,10 +2001,10 @@ static imgtoolerr_t amiga_image_nextenum(imgtool::directory &enumeration, imgtoo
 		}
 
 		/* fill directory entry */
-		strncpyz(ent.filename, (char *)hl.hlname, hl.name_len + 1);
+		ent.filename = std::string((const char *)hl.hlname, hl.name_len + 1);
 		ent.lastmodified_time = amiga_crack_time(&hl.date);
 		amiga_decode_flags(hl.protect, ent.attr);
-		strncpyz(ent.comment, (char *)hl.comment, hl.comm_len + 1);
+		ent.comment = std::string((const char *) hl.comment, hl.comm_len + 1);
 		ent.hardlink = 1;
 
 		iter->next_block = hl.hash_chain;

--- a/src/tools/imgtool/modules/amiga.cpp
+++ b/src/tools/imgtool/modules/amiga.cpp
@@ -290,7 +290,7 @@ static int is_leap(int year)
 
 
 /* Convert amiga time to standard time */
-static time_t amiga_crack_time(amiga_date *date)
+static imgtool::datetime amiga_crack_time(amiga_date *date)
 {
 	int month_days[12] = { 31, 28, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31 };
 	int year = 1978, month = 1, year_days = 365; /* base date */
@@ -324,7 +324,7 @@ static time_t amiga_crack_time(amiga_date *date)
 	t.tm_min  = date->mins % 60;
 	t.tm_sec  = date->ticks / 50;
 
-	return mktime(&t);
+	return imgtool::datetime(imgtool::datetime::datetime_type::LOCAL, &t);
 }
 
 
@@ -1785,9 +1785,9 @@ static void amiga_image_info(imgtool::image &img, std::ostream &stream)
 	ret = read_root_block(img, &root);
 	if (ret) return;
 
-	t_c = amiga_crack_time(&root.c);
-	t_v = amiga_crack_time(&root.v);
-	t_r = amiga_crack_time(&root.r);
+	t_c = amiga_crack_time(&root.c).to_time_t();
+	t_v = amiga_crack_time(&root.v).to_time_t();
+	t_r = amiga_crack_time(&root.r).to_time_t();
 
 	strftime(c, sizeof(c), "%d-%b-%y %H:%M:%S", localtime(&t_c));
 	strftime(v, sizeof(v), "%d-%b-%y %H:%M:%S", localtime(&t_v));

--- a/src/tools/imgtool/modules/bml3.cpp
+++ b/src/tools/imgtool/modules/bml3.cpp
@@ -548,7 +548,7 @@ static imgtoolerr_t bml3_diskimage_open(imgtool::image &image, imgtool::stream::
 
 
 
-static imgtoolerr_t bml3_diskimage_nextenum(imgtool::directory &enumeration, imgtool_dirent &ent)
+static imgtoolerr_t bml3_diskimage_nextenum(imgtool::directory &enumeration, imgtool::dirent &ent)
 {
 	floperr_t ferr;
 	imgtoolerr_t err;
@@ -604,8 +604,8 @@ eof:
 
 		get_dirent_fname(fname, &rsent);
 
-		snprintf(ent.filename, ARRAY_LENGTH(ent.filename), "%s", fname);
-		snprintf(ent.attr, ARRAY_LENGTH(ent.attr), "%d %c", (int) rsent.ftype, (char) (rsent.asciiflag + 'B'));
+		ent.filename = fname;
+		ent.attr = util::string_format("%d %c", (int) rsent.ftype, (char) (rsent.asciiflag + 'B'));
 	}
 	return IMGTOOLERR_SUCCESS;
 }

--- a/src/tools/imgtool/modules/concept.cpp
+++ b/src/tools/imgtool/modules/concept.cpp
@@ -130,7 +130,7 @@ static imgtoolerr_t concept_image_init(imgtool::image &img, imgtool::stream::ptr
 static void concept_image_exit(imgtool::image &img);
 static void concept_image_info(imgtool::image &img, std::ostream &stream);
 static imgtoolerr_t concept_image_beginenum(imgtool::directory &enumeration, const char *path);
-static imgtoolerr_t concept_image_nextenum(imgtool::directory &enumeration, imgtool_dirent &ent);
+static imgtoolerr_t concept_image_nextenum(imgtool::directory &enumeration, imgtool::dirent &ent);
 static void concept_image_closeenum(imgtool::directory &enumeration);
 static imgtoolerr_t concept_image_freespace(imgtool::partition &partition, uint64_t *size);
 static imgtoolerr_t concept_image_readfile(imgtool::partition &partition, const char *filename, const char *fork, imgtool::stream &destf);
@@ -336,7 +336,7 @@ static imgtoolerr_t concept_image_beginenum(imgtool::directory &enumeration, con
 /*
     Enumerate disk catalog next entry
 */
-static imgtoolerr_t concept_image_nextenum(imgtool::directory &enumeration, imgtool_dirent &ent)
+static imgtoolerr_t concept_image_nextenum(imgtool::directory &enumeration, imgtool::dirent &ent)
 {
 	concept_iterator *iter = (concept_iterator *) enumeration.extra_bytes();
 
@@ -357,10 +357,7 @@ static imgtoolerr_t concept_image_nextenum(imgtool::directory &enumeration, imgt
 		int len = iter->image->dev_dir.file_dir[iter->index].filename[0];
 		const char *type;
 
-		if (len > ARRAY_LENGTH(ent.filename))
-			len = ARRAY_LENGTH(ent.filename);
-		memcpy(ent.filename, iter->image->dev_dir.file_dir[iter->index].filename + 1, len);
-		ent.filename[len] = 0;
+		ent.filename = std::string((const char *)iter->image->dev_dir.file_dir[iter->index].filename + 1, len);
 
 		/* parse flags */
 		switch (get_UINT16xE(iter->image->dev_dir.vol_hdr.disk_flipped, iter->image->dev_dir.file_dir[iter->index].ftype) & 0xf)
@@ -382,7 +379,7 @@ static imgtoolerr_t concept_image_nextenum(imgtool::directory &enumeration, imgt
 			type = "???";
 			break;
 		}
-		snprintf(ent.attr, ARRAY_LENGTH(ent.attr), "%s", type);
+		ent.attr.assign(type);
 
 		/* len in physrecs */
 		ent.filesize = get_UINT16xE(iter->image->dev_dir.vol_hdr.disk_flipped, iter->image->dev_dir.file_dir[iter->index].next_block)

--- a/src/tools/imgtool/modules/cybiko.cpp
+++ b/src/tools/imgtool/modules/cybiko.cpp
@@ -389,7 +389,7 @@ static imgtoolerr_t cybiko_image_begin_enum(imgtool::directory &enumeration, con
 	return IMGTOOLERR_SUCCESS;
 }
 
-static imgtoolerr_t cybiko_image_next_enum(imgtool::directory &enumeration, imgtool_dirent &ent)
+static imgtoolerr_t cybiko_image_next_enum(imgtool::directory &enumeration, imgtool::dirent &ent)
 {
 	imgtool::image &image(enumeration.image());
 	cybiko_file_system *cfs = get_cfs(image);
@@ -410,7 +410,7 @@ static imgtoolerr_t cybiko_image_next_enum(imgtool::directory &enumeration, imgt
 	// get file information
 	if ((file_id != INVALID_FILE_ID) && cfs_file_info(cfs, file_id, &file))
 	{
-		strcpy(ent.filename, file.name);
+		ent.filename = file.name;
 		ent.filesize = file.size;
 		ent.lastmodified_time = time_crack(file.date);
 		ent.filesize = file.size;

--- a/src/tools/imgtool/modules/cybiko.cpp
+++ b/src/tools/imgtool/modules/cybiko.cpp
@@ -65,9 +65,9 @@ static cybiko_file_system *get_cfs(imgtool::image &image)
 
 // 2208988800 is the number of seconds between 1900/01/01 and 1970/01/01
 
-static time_t time_crack( uint32_t cfs_time)
+static imgtool::datetime time_crack( uint32_t cfs_time)
 {
-	return (time_t)(cfs_time - 2208988800UL);
+	return imgtool::datetime(imgtool::datetime::datetime_type::LOCAL, (time_t)(cfs_time - 2208988800UL));
 }
 
 static uint32_t time_setup( time_t ansi_time)

--- a/src/tools/imgtool/modules/cybikoxt.cpp
+++ b/src/tools/imgtool/modules/cybikoxt.cpp
@@ -57,9 +57,9 @@ static cybiko_file_system *get_cfs(imgtool::image &image)
 
 // 2208988800 is the number of seconds between 1900/01/01 and 1970/01/01
 
-static time_t time_crack( uint32_t cfs_time)
+static imgtool::datetime time_crack( uint32_t cfs_time)
 {
-	return (time_t)(cfs_time - 2208988800UL);
+	return imgtool::datetime(imgtool::datetime::datetime_type::LOCAL, (time_t)(cfs_time - 2208988800UL));
 }
 
 static uint32_t time_setup( time_t ansi_time)

--- a/src/tools/imgtool/modules/cybikoxt.cpp
+++ b/src/tools/imgtool/modules/cybikoxt.cpp
@@ -359,7 +359,7 @@ static imgtoolerr_t cybiko_image_begin_enum(imgtool::directory &enumeration, con
 	return IMGTOOLERR_SUCCESS;
 }
 
-static imgtoolerr_t cybiko_image_next_enum(imgtool::directory &enumeration, imgtool_dirent &ent)
+static imgtoolerr_t cybiko_image_next_enum(imgtool::directory &enumeration, imgtool::dirent &ent)
 {
 	imgtool::image &image(enumeration.image());
 	cybiko_file_system *cfs = get_cfs(image);
@@ -380,7 +380,7 @@ static imgtoolerr_t cybiko_image_next_enum(imgtool::directory &enumeration, imgt
 	// get file information
 	if ((file_id != INVALID_FILE_ID) && cfs_file_info(cfs, file_id, &file))
 	{
-		strcpy(ent.filename, file.name);
+		ent.filename = file.name;
 		ent.filesize = file.size;
 		ent.lastmodified_time = time_crack(file.date);
 		ent.filesize = file.size;

--- a/src/tools/imgtool/modules/fat.cpp
+++ b/src/tools/imgtool/modules/fat.cpp
@@ -1842,8 +1842,8 @@ static imgtoolerr_t fat_partition_nextenum(imgtool::directory &enumeration, imgt
 	ent.filesize = fatent.filesize;
 	ent.directory = fatent.directory;
 	ent.eof = fatent.eof;
-	ent.creation_time = fatent.creation_time;
-	ent.lastmodified_time = fatent.lastmodified_time;
+	ent.creation_time = imgtool::datetime(imgtool::datetime::datetime_type::LOCAL, fatent.creation_time);
+	ent.lastmodified_time = imgtool::datetime(imgtool::datetime::datetime_type::LOCAL, fatent.lastmodified_time);
 	return IMGTOOLERR_SUCCESS;
 }
 

--- a/src/tools/imgtool/modules/fat.cpp
+++ b/src/tools/imgtool/modules/fat.cpp
@@ -1826,7 +1826,7 @@ static imgtoolerr_t fat_partition_beginenum(imgtool::directory &enumeration, con
 
 
 
-static imgtoolerr_t fat_partition_nextenum(imgtool::directory &enumeration, imgtool_dirent &ent)
+static imgtoolerr_t fat_partition_nextenum(imgtool::directory &enumeration, imgtool::dirent &ent)
 {
 	imgtoolerr_t err;
 	fat_file *file;
@@ -1838,8 +1838,7 @@ static imgtoolerr_t fat_partition_nextenum(imgtool::directory &enumeration, imgt
 		return err;
 
 	/* copy stuff from the FAT dirent to the Imgtool dirent */
-	snprintf(ent.filename, ARRAY_LENGTH(ent.filename), "%s", fatent.long_filename[0]
-		? fatent.long_filename : fatent.short_filename);
+	ent.filename = fatent.long_filename[0] ? fatent.long_filename : fatent.short_filename;
 	ent.filesize = fatent.filesize;
 	ent.directory = fatent.directory;
 	ent.eof = fatent.eof;

--- a/src/tools/imgtool/modules/hp48.cpp
+++ b/src/tools/imgtool/modules/hp48.cpp
@@ -199,14 +199,14 @@ static int read8(uint8_t* data)
 		return data[0] | (data[1] << 4);
 }
 
-static void readstring(char* dst, uint8_t* data, int nb)
+static void readstring(std::string &dst, uint8_t* data, int nb)
 {
-		int i;
-		for ( i = 0; i < nb; i++ )
-		{
-				dst[i] = read8( data + 2*i );
-		}
-		dst[nb] = 0;
+	dst.clear();
+	int i;
+	for ( i = 0; i < nb; i++ )
+	{
+		dst += (char) read8( data + 2*i );
+	}
 }
 
 static void write20(uint8_t* data, int v)
@@ -277,12 +277,12 @@ static int find_file(hp48_partition* p, const char* filename, int *ptotalsize, i
 				{
 						/* get name */
 						int namelen = read8( data + pos + 10 );
-						char name[257];
+						std::string name;
 						if ( 9 + 2*namelen > totalsize ) return -1;
 						readstring( name, data + pos + 12, namelen );
 
 						/* check name */
-						if ( !strcmp( name, filename ) )
+						if ( !strcmp( name.c_str(), filename ) )
 						{
 								/* found! */
 								if ( ptotalsize ) *ptotalsize = totalsize;
@@ -468,7 +468,7 @@ static imgtoolerr_t hp48_beginenum(imgtool::directory &enumeration, const char *
 
 
 
-static imgtoolerr_t hp48_nextenum(imgtool::directory &enumeration, imgtool_dirent &ent)
+static imgtoolerr_t hp48_nextenum(imgtool::directory &enumeration, imgtool::dirent &ent)
 {
 	imgtool::partition &part(enumeration.partition());
 	//imgtool::image &img(part.image());
@@ -508,9 +508,9 @@ static imgtoolerr_t hp48_nextenum(imgtool::directory &enumeration, imgtool_diren
 
 				switch (prolog)
 				{
-				case PROLOG_LIBRARY:  strncpy( ent.attr, "LIB", sizeof(ent.attr) ); break;
-				case PROLOG_BACKUP:   strncpy( ent.attr, "BAK", sizeof(ent.attr) ); break;
-				default:              strncpy( ent.attr, "?", sizeof(ent.attr) );
+				case PROLOG_LIBRARY:  ent.attr = "LIB"; break;
+				case PROLOG_BACKUP:   ent.attr = "BAK"; break;
+				default:              ent.attr = "?";
 				}
 
 				d->pos = d->pos + totalsize + 5;

--- a/src/tools/imgtool/modules/mac.cpp
+++ b/src/tools/imgtool/modules/mac.cpp
@@ -5814,10 +5814,10 @@ static imgtoolerr_t mac_image_getattrs(imgtool::partition &partition, const char
 				break;
 
 			case IMGTOOLATTR_TIME_CREATED:
-				values[i].t = mac_crack_time(cat_info.createDate);
+				values[i].t = mac_crack_time(cat_info.createDate).to_time_t();
 				break;
 			case IMGTOOLATTR_TIME_LASTMODIFIED:
-				values[i].t = mac_crack_time(cat_info.modifyDate);
+				values[i].t = mac_crack_time(cat_info.modifyDate).to_time_t();
 				break;
 		}
 	}

--- a/src/tools/imgtool/modules/macbin.cpp
+++ b/src/tools/imgtool/modules/macbin.cpp
@@ -315,8 +315,8 @@ static imgtoolerr_t macbinary_writefile(imgtool::partition &partition, const cha
 			return err;
 
 		/* set up attributes */
-		attr_values[0].t = mac_crack_time(creation_time);
-		attr_values[1].t = mac_crack_time(lastmodified_time);
+		attr_values[0].t = mac_crack_time(creation_time).to_time_t();
+		attr_values[1].t = mac_crack_time(lastmodified_time).to_time_t();
 		attr_values[2].i = type_code;
 		attr_values[3].i = creator_code;
 		attr_values[4].i = finder_flags;

--- a/src/tools/imgtool/modules/macutil.cpp
+++ b/src/tools/imgtool/modules/macutil.cpp
@@ -12,18 +12,28 @@
 #include "macutil.h"
 
 
-time_t mac_crack_time(uint32_t t)
+imgtool::datetime mac_crack_time(uint32_t t)
 {
-	/* not sure if this is correct... */
-	return t - (((1970 - 1904) * 365) + 17) * 24 * 60 * 60;
+	// not sure if this is correct...
+	// NPW 15-Jan-2017 - This is not correct; time_t is not necessarily POSIX time 
+	return imgtool::datetime(imgtool::datetime::datetime_type::LOCAL, t - (((1970 - 1904) * 365) + 17) * 24 * 60 * 60);
+}
+
+
+
+uint32_t mac_setup_time(const imgtool::datetime &t)
+{
+	// not sure if this is correct...
+	// NPW 15-Jan-2017 - This is not correct; time_t is not necessarily POSIX time 
+	return t.to_time_t() + (((1970 - 1904) * 365) + 17) * 24 * 60 * 60;
 }
 
 
 
 uint32_t mac_setup_time(time_t t)
 {
-	/* not sure if this is correct... */
-	return t + (((1970 - 1904) * 365) + 17) * 24 * 60 * 60;
+	imgtool::datetime dt = imgtool::datetime(imgtool::datetime::LOCAL, t);
+	return mac_setup_time(dt);
 }
 
 
@@ -32,7 +42,7 @@ uint32_t mac_time_now(void)
 {
 	time_t now;
 	time(&now);
-	return mac_setup_time(now);
+	return mac_setup_time(imgtool::datetime(imgtool::datetime::datetime_type::LOCAL, now));
 }
 
 

--- a/src/tools/imgtool/modules/macutil.h
+++ b/src/tools/imgtool/modules/macutil.h
@@ -29,7 +29,8 @@ enum mac_filecategory_t
 
 
 /* converting Classic Mac OS time <==> Imgtool time */
-time_t mac_crack_time(uint32_t t);
+imgtool::datetime mac_crack_time(uint32_t t);
+uint32_t mac_setup_time(const imgtool::datetime &t);
 uint32_t mac_setup_time(time_t t);
 uint32_t mac_time_now(void);
 

--- a/src/tools/imgtool/modules/os9.cpp
+++ b/src/tools/imgtool/modules/os9.cpp
@@ -872,7 +872,7 @@ done:
 
 
 
-static imgtoolerr_t os9_diskimage_nextenum(imgtool::directory &enumeration, imgtool_dirent &ent)
+static imgtoolerr_t os9_diskimage_nextenum(imgtool::directory &enumeration, imgtool::dirent &ent)
 {
 	struct os9_direnum *os9enum;
 	uint32_t lsn, index;
@@ -951,9 +951,9 @@ static imgtoolerr_t os9_diskimage_nextenum(imgtool::directory &enumeration, imgt
 	if (err)
 		return err;
 
-	/* fill out imgtool_dirent structure */
-	snprintf(ent.filename, ARRAY_LENGTH(ent.filename), "%s", filename);
-	snprintf(ent.attr, ARRAY_LENGTH(ent.attr), "%c%c%c%c%c%c%c%c",
+	/* fill out imgtool::dirent structure */
+	ent.filename = filename;
+	ent.attr = util::string_format("%c%c%c%c%c%c%c%c",
 		file_info.directory      ? 'd' : '-',
 		file_info.non_sharable   ? 's' : '-',
 		file_info.public_execute ? 'x' : '-',

--- a/src/tools/imgtool/modules/prodos.cpp
+++ b/src/tools/imgtool/modules/prodos.cpp
@@ -186,7 +186,7 @@ enum creation_policy_t
 
 
 
-static time_t prodos_crack_time(uint32_t prodos_time)
+static imgtool::datetime prodos_crack_time(uint32_t prodos_time)
 {
 	struct tm t;
 	time_t now;
@@ -203,7 +203,7 @@ static time_t prodos_crack_time(uint32_t prodos_time)
 
 	if (t.tm_year <= 49)
 		t.tm_year += 100;
-	return mktime(&t);
+	return imgtool::datetime(imgtool::datetime::datetime_type::LOCAL, &t);
 }
 
 
@@ -2047,10 +2047,10 @@ static imgtoolerr_t prodos_diskimage_getattrs(imgtool::partition &partition, con
 				break;
 
 			case IMGTOOLATTR_TIME_CREATED:
-				values[i].t = prodos_crack_time(ent.creation_time);
+				values[i].t = prodos_crack_time(ent.creation_time).to_time_t();
 				break;
 			case IMGTOOLATTR_TIME_LASTMODIFIED:
-				values[i].t = prodos_crack_time(ent.lastmodified_time);
+				values[i].t = prodos_crack_time(ent.lastmodified_time).to_time_t();
 				break;
 		}
 	}

--- a/src/tools/imgtool/modules/prodos.cpp
+++ b/src/tools/imgtool/modules/prodos.cpp
@@ -1520,7 +1520,7 @@ static imgtoolerr_t prodos_diskimage_beginenum(imgtool::directory &enumeration, 
 
 
 
-static imgtoolerr_t prodos_diskimage_nextenum(imgtool::directory &enumeration, imgtool_dirent &ent)
+static imgtoolerr_t prodos_diskimage_nextenum(imgtool::directory &enumeration, imgtool::dirent &ent)
 {
 	imgtoolerr_t err;
 	imgtool::image &image(enumeration.image());
@@ -1547,10 +1547,10 @@ static imgtoolerr_t prodos_diskimage_nextenum(imgtool::directory &enumeration, i
 		return IMGTOOLERR_SUCCESS;
 	}
 
-	strcpy(ent.filename, pd_ent.filename);
-	ent.directory          = is_dir_storagetype(pd_ent.storage_type);
-	ent.creation_time      = prodos_crack_time(pd_ent.creation_time);
-	ent.lastmodified_time  = prodos_crack_time(pd_ent.lastmodified_time);
+	ent.filename			= pd_ent.filename;
+	ent.directory			= is_dir_storagetype(pd_ent.storage_type);
+	ent.creation_time		= prodos_crack_time(pd_ent.creation_time);
+	ent.lastmodified_time	= prodos_crack_time(pd_ent.lastmodified_time);
 
 	if (!ent.directory)
 	{

--- a/src/tools/imgtool/modules/psion.cpp
+++ b/src/tools/imgtool/modules/psion.cpp
@@ -470,7 +470,7 @@ static imgtoolerr_t datapack_begin_enum(imgtool::directory &enumeration, const c
 	return IMGTOOLERR_SUCCESS;
 }
 
-static imgtoolerr_t datapack_next_enum(imgtool::directory &enumeration, imgtool_dirent &ent)
+static imgtoolerr_t datapack_next_enum(imgtool::directory &enumeration, imgtool::dirent &ent)
 {
 	imgtool::image &image(enumeration.image());
 	psion_pack *pack = get_psion_pack(image);
@@ -482,8 +482,8 @@ static imgtoolerr_t datapack_next_enum(imgtool::directory &enumeration, imgtool_
 		ent.eof = 1;
 		return IMGTOOLERR_SUCCESS;
 	}
-	memcpy(ent.filename, pack->pack_index[iter->index].filename, 8);
-	sprintf(ent.attr, "Type: %02x ID: %02x", pack->pack_index[iter->index].type, pack->pack_index[iter->index].id);
+	ent.filename = std::string(pack->pack_index[iter->index].filename, 8);
+	ent.attr = util::string_format("Type: %02x ID: %02x", pack->pack_index[iter->index].type, pack->pack_index[iter->index].id);
 
 	if (pack->pack_index[iter->index].data_rec)
 	{

--- a/src/tools/imgtool/modules/rsdos.cpp
+++ b/src/tools/imgtool/modules/rsdos.cpp
@@ -285,7 +285,7 @@ static imgtoolerr_t prepare_dirent(rsdos_dirent &ent, const char *fname)
 //  rsdos_diskimage_nextenum
 //-------------------------------------------------
 
-static imgtoolerr_t rsdos_diskimage_nextenum(imgtool::directory &enumeration, imgtool_dirent &ent)
+static imgtoolerr_t rsdos_diskimage_nextenum(imgtool::directory &enumeration, imgtool::dirent &ent)
 {
 	floperr_t ferr;
 	imgtoolerr_t err;
@@ -338,10 +338,8 @@ eof:
 		}
 		ent.eof = 0;
 
-		std::string fname = get_dirent_fname(rsent);
-
-		snprintf(ent.filename, ARRAY_LENGTH(ent.filename), "%s", fname.c_str());
-		snprintf(ent.attr, ARRAY_LENGTH(ent.attr), "%d %c", (int) rsent.ftype, (char) (rsent.asciiflag + 'B'));
+		ent.filename = get_dirent_fname(rsent);
+		ent.attr = util::string_format("%d %c", (int) rsent.ftype, (char) (rsent.asciiflag + 'B'));
 	}
 	return IMGTOOLERR_SUCCESS;
 }

--- a/src/tools/imgtool/modules/thomson.cpp
+++ b/src/tools/imgtool/modules/thomson.cpp
@@ -894,7 +894,7 @@ static imgtoolerr_t thom_begin_enum(imgtool::directory &enumeration,
 	return IMGTOOLERR_SUCCESS;
 }
 
-static imgtoolerr_t thom_next_enum(imgtool::directory &enumeration, imgtool_dirent &ent)
+static imgtoolerr_t thom_next_enum(imgtool::directory &enumeration, imgtool::dirent &ent)
 {
 	imgtool::partition &part(enumeration.partition());
 	int head = *( (int*) part.extra_bytes() );
@@ -903,30 +903,34 @@ static imgtoolerr_t thom_next_enum(imgtool::directory &enumeration, imgtool_dire
 	int* n = (int*) enumeration.extra_bytes();
 	thom_dirent d;
 
-	do {
-	thom_get_dirent( f, head, *n, &d );
-	(*n) ++;
+	do
+	{
+		thom_get_dirent( f, head, *n, &d );
+		(*n) ++;
 	}
 	while ( d.type == THOM_DIRENT_FREE );
 	if ( d.type == THOM_DIRENT_END ) ent.eof = 1;
-	else if ( d.type == THOM_DIRENT_INVALID ) {
-	ent.corrupt = 1;
+	else if ( d.type == THOM_DIRENT_INVALID )
+	{
+		ent.corrupt = 1;
 	}
-	else {
-	int size;
-	snprintf( ent.filename, sizeof(ent.filename), "%s.%s", d.name, d.ext );
-	snprintf( ent.attr, sizeof(ent.attr), "%c %c %s",
+	else
+	{
+		int size;
+		ent.filename = util::string_format("%s.%s", d.name, d.ext);
+		ent.attr = util::string_format("%c %c %s",
 			(d.ftype == 0) ? 'B' :  (d.ftype == 1) ? 'D' :
 			(d.ftype == 2) ? 'M' :  (d.ftype == 3) ? 'A' : '?',
 			(d.format == 0) ? 'B' : (d.format == 0xff) ? 'A' : '?',
-			d.comment );
-	ent.creation_time = thom_crack_time( &d );
-	size  = thom_get_file_size( f, head, &d );
-	if ( size >= 0 ) ent.filesize = size;
-	else {
-		ent.filesize = 0;
-		ent.corrupt = 1;
-	}
+			d.comment);
+		ent.creation_time = thom_crack_time( &d );
+		size  = thom_get_file_size( f, head, &d );
+		if ( size >= 0 ) ent.filesize = size;
+		else
+		{
+			ent.filesize = 0;
+			ent.corrupt = 1;
+		}
 	}
 	return IMGTOOLERR_SUCCESS;
 }

--- a/src/tools/imgtool/modules/thomson.cpp
+++ b/src/tools/imgtool/modules/thomson.cpp
@@ -485,13 +485,13 @@ static void thom_conv_filename(const char* s, char name[9], char ext[4])
 	}
 }
 
-static time_t thom_crack_time(thom_dirent* d)
+static imgtool::datetime thom_crack_time(thom_dirent* d)
 {
 	struct tm t;
 	time_t now;
 
 	/* check */
-	if ( d->day < 1 || d->day > 31 || d->month < 1 || d->month > 12 ) return 0;
+	if ( d->day < 1 || d->day > 31 || d->month < 1 || d->month > 12 ) return imgtool::datetime();
 
 	/* converts */
 	time( &now );
@@ -502,7 +502,7 @@ static time_t thom_crack_time(thom_dirent* d)
 	t.tm_mday = d->day;
 	t.tm_mon = d->month - 1;
 	t.tm_year = (d->year < 65 ) ? d->year + 100 : d->year;
-	return mktime(&t);
+	return imgtool::datetime(imgtool::datetime::datetime_type::LOCAL, &t);
 }
 
 static void thom_make_time(thom_dirent* d, time_t time)

--- a/src/tools/imgtool/modules/ti990hd.cpp
+++ b/src/tools/imgtool/modules/ti990hd.cpp
@@ -395,7 +395,7 @@ static imgtoolerr_t ti990_image_init(imgtool::image &img, imgtool::stream::ptr &
 static void ti990_image_exit(imgtool::image &img);
 static void ti990_image_info(imgtool::image &img, std::ostream &stream);
 static imgtoolerr_t ti990_image_beginenum(imgtool::directory &enumeration, const char *path);
-static imgtoolerr_t ti990_image_nextenum(imgtool::directory &enumeration, imgtool_dirent &ent);
+static imgtoolerr_t ti990_image_nextenum(imgtool::directory &enumeration, imgtool::dirent &ent);
 static void ti990_image_closeenum(imgtool::directory &enumeration);
 static imgtoolerr_t ti990_image_freespace(imgtool::partition &partition, uint64_t *size);
 #ifdef UNUSED_FUNCTION
@@ -1218,7 +1218,7 @@ static imgtoolerr_t ti990_image_beginenum(imgtool::directory &enumeration, const
 /*
     Enumerate disk catalog next entry
 */
-static imgtoolerr_t ti990_image_nextenum(imgtool::directory &enumeration, imgtool_dirent &ent)
+static imgtoolerr_t ti990_image_nextenum(imgtool::directory &enumeration, imgtool::dirent &ent)
 {
 	ti990_iterator *iter = (ti990_iterator *) enumeration.extra_bytes();
 	int flag;
@@ -1257,15 +1257,15 @@ static imgtoolerr_t ti990_image_nextenum(imgtool::directory &enumeration, imgtoo
 			int i;
 			char buf[9];
 
-			ent.filename[0] = '\0';
+			ent.filename.clear();
 			for (i=0; i<iter->level; i++)
 			{
 				fname_to_str(buf, iter->xdr[i].fdr.fnm, 9);
-				strncat(ent.filename, buf, ARRAY_LENGTH(ent.filename) - 1);
-				strncat(ent.filename, ".", ARRAY_LENGTH(ent.filename) - 1);
+				ent.filename += buf;
+				ent.filename += ".";
 			}
 			fname_to_str(buf, iter->xdr[iter->level].fdr.fnm, 9);
-			strncat(ent.filename, buf, ARRAY_LENGTH(ent.filename) - 1);
+			ent.filename += buf;
 		}
 #endif
 
@@ -1273,7 +1273,7 @@ static imgtoolerr_t ti990_image_nextenum(imgtool::directory &enumeration, imgtoo
 		flag = get_UINT16BE(iter->xdr[iter->level].fdr.flg);
 		if (flag & fdr_flg_cdr)
 		{
-			snprintf(ent.attr, ARRAY_LENGTH(ent.attr), "CHANNEL");
+			ent.attr = "CHANNEL";
 
 			ent.filesize = 0;
 		}
@@ -1291,7 +1291,7 @@ static imgtoolerr_t ti990_image_nextenum(imgtool::directory &enumeration, imgtoo
 
 			fname_to_str(buf, target_fdr.fnm, 9);
 
-			snprintf(ent.attr, ARRAY_LENGTH(ent.attr), "ALIAS OF %s", buf);
+			ent.attr = util::string_format("ALIAS OF %s", buf);
 
 			ent.filesize = 0;
 		}
@@ -1341,7 +1341,7 @@ static imgtoolerr_t ti990_image_nextenum(imgtool::directory &enumeration, imgtoo
 				}
 				break;
 			}
-			snprintf(ent.attr, ARRAY_LENGTH(ent.attr),
+			ent.attr = util::string_format(
 						"%s %c %s%s%s%s%s", fmt, (flag & fdr_flg_all) ? 'N' : 'C', type,
 							(flag & fdr_flg_blb) ? "" : " BLK",
 							(flag & fdr_flg_tmp) ? " TMP" : "",

--- a/src/tools/imgtool/modules/vzdos.cpp
+++ b/src/tools/imgtool/modules/vzdos.cpp
@@ -398,7 +398,7 @@ static imgtoolerr_t vzdos_diskimage_beginenum(imgtool::directory &enumeration, c
 	return IMGTOOLERR_SUCCESS;
 }
 
-static imgtoolerr_t vzdos_diskimage_nextenum(imgtool::directory &enumeration, imgtool_dirent &ent)
+static imgtoolerr_t vzdos_diskimage_nextenum(imgtool::directory &enumeration, imgtool::dirent &ent)
 {
 	vz_iterator *iter = (vz_iterator *) enumeration.extra_bytes();
 
@@ -429,7 +429,7 @@ static imgtoolerr_t vzdos_diskimage_nextenum(imgtool::directory &enumeration, im
 			}
 		}
 
-		memcpy(ent.filename, &dirent.fname, len + 1);
+		ent.filename = std::string(dirent.fname, len);
 		ent.filesize = dirent.end_address - dirent.start_address;
 
 		switch (dirent.ftype)
@@ -445,7 +445,7 @@ static imgtoolerr_t vzdos_diskimage_nextenum(imgtool::directory &enumeration, im
 		default:   type = "Unknown";
 		}
 
-		snprintf(ent.attr, ARRAY_LENGTH(ent.attr), "%s", type);
+		ent.attr = type;
 
 		iter->index++;
 	}


### PR DESCRIPTION
Changed imgtool_dirent ==> imgtool::dirent, and also changed a number of the members to be std::string

Was also able to remove strncpyz() function