### PR TITLE
Added parsing of resolution based ini files, e.g. 336x240H.ini

### DIFF
--- a/docs/man/mame.6
+++ b/docs/man/mame.6
@@ -188,25 +188,45 @@ Enables or disables the reading of the config files. When enabled
 .br
 the main configuration file
 .br
-2. \fIname\fB.ini\fR
+2. \fBdebug.ini\fR
 .br
-where \fIname\fR is your executable name, i.e. mame unless you changed it
-(e.g. if you renamed mame to mame0137, the parsed file will be
-\fImame0137.ini\fR)
+if the debugger is enabled
 .br
-3. \fBdebug.ini\fR, if the debugger is enabled
+3. \fBvertical.ini\fR or \fBhorizont.ini\fR
 .br
-4. \fBvector.ini\fR, for vector games only
+depending on monitor orientation
 .br
-5. \fI[driver]\fB.ini\fR
+4. \fBarcade.ini\fR or \fBconsole.ini\fR or \fBcomputer.ini\fR or \fBothersys.ini\fR
+.br
+depending on system type
+.br
+5. \fBraster.ini\fR or \fBvector.ini\fR or \fBlcd.ini\fR
+.br
+depending on screen type
+.br
+6. \fI[width]x[height][orientation]\fB.ini\fR
+.br
+based on screen size and orientation for raster games only.
+.br
+e.g. 640x480H.ini 
+.br
+7. \fI[width]x[height][orientation]@[refreshrate]\fB.ini\fR
+.br
+based on the screen size, orientation and refreshrate of raster games.
+.br
+refreshrate is rounded to nearest whole number
+.br
+e.g. 288x224V@60.ini
+.br
+8. \fI[driver]\fB.ini\fR
 .br
 based on the source filename of the game driver
 .br
-6. \fI[parent]\fB.ini\fR
+9. \fI[parent]\fB.ini\fR
 .br
 for clones only, may be called recursively
 .br
-7. \fI[gamename]\fB.ini\fR
+10. \fI[gamename]\fB.ini\fR
 .br
 note this sometimes resolves to the same of the source driver
 .br

--- a/docs/source/advanced/multiconfig.rst
+++ b/docs/source/advanced/multiconfig.rst
@@ -13,19 +13,19 @@ Order of Config Loading
     The first pass may change various path settings, so the second pass is done to see if there is a valid config file at that new location (and if so, change settings using that file)
 3. **DEBUG.INI** if in debug mode.
     This is an advanced config file, most people won't need to use it or be concerned by it. 
-4. System-specific INI files where appropriate (e.g. **NEOGEO_NOSLOT.INI** or **CPS2.INI**)
-    As an example, Street Fighter Alpha is a CPS2 game, and so **CPS2.INI** would be loaded here.
-5. Monitor orientation INI file (either **HORIZONT.INI** or **VERTICAL.INI**)
+4. Monitor orientation INI file (either **HORIZONT.INI** or **VERTICAL.INI**)
     Pac-Man, for one example, is a vertical monitor setup, so it would load **VERTICAL.INI**. Street Fighter Alpha is a horizontal game, so it loads **HORIZONT.INI**.
-6. System-type INI files (**ARCADE.INI**, **CONSOLE.INI**, **COMPUTER.INI**, or **OTHERSYS.INI**)
+5. System-type INI files (**ARCADE.INI**, **CONSOLE.INI**, **COMPUTER.INI**, or **OTHERSYS.INI**)
     Both Pac-Man and Street Fighter Alpha are arcade games, so **ARCADE.INI** would be loaded here. Atari 2600 would load **CONSOLE.INI**.
-7. Screen-type INI file  (**VECTOR.INI** for vector games, **RASTER.INI** for raster games, **LCD.INI** for LCD games)
+6. Screen-type INI file  (**VECTOR.INI** for vector games, **RASTER.INI** for raster games, **LCD.INI** for LCD games)
     Pac-Man and Street Fighter Alpha are raster, so **RASTER.INI** gets loaded here. Tempest is a vector monitor game, and **VECTOR.INI** would be loaded here.
+7. Screen size INI files (for raster games only)
+	An ini file **[Width]X[Height][Orientation].INI** gets loded first and then an inifile **[Width]X[Height][Orientation]@[Refreshrate].INI** is loaded
+	For example **768X576H.INI** and **768X576H@50.INI** or **224X288V.INI** and **224X288V@60.INI**
 8. Source INI files. 
     This is an advanced config file, most people won't need to use it and it can be safely ignored.
     MAME will attempt to load **SOURCE/SOURCEFILE.INI** and **SOURCEFILE.INI**, where sourcefile is the actual filename of the source code file.
     *mame -listsource <game>* will show the source file for a given game.
-
     For instance, Banpresto's Sailor Moon, Atlus's Dodonpachi, and Nihon System's Dangun Feveron all share a large amount of hardware and are grouped into the CAVE.C file, meaning they all parse **source/cave.ini**
 9. Parent INI file.
     For example, if running Pac-Man, which is a clone of Puck-Man, it'd be **PUCKMAN.INI**
@@ -37,10 +37,10 @@ Examples of Config Loading Order
 --------------------------------
 
 1. Alcon, which is the US clone of Slap Fight. (*mame alcon*)
-    Command line, MAME.INI, VERTICAL.INI, ARCADE.INI, RASTER.INI, SLAPFGHT.INI, and lastly ALCON.INI (*remember command line parameters take precedence over all else!*)
+    Command line, MAME.INI, VERTICAL.INI, ARCADE.INI, RASTER.INI, 280X240V.INI, 280X240V@60.INI, SLAPFGHT.INI, and lastly ALCON.INI (*remember command line parameters take precedence over all else!*)
 
 2. Super Street Fighter 2 Turbo (*mame ssf2t*)
-    Command line, MAME.INI, HORIZONT.INI, ARCADE.INI, RASTER.INI, CPS2.INI, and lastly SSF2T.INI (*remember command line parameters take precedence over all else!*)
+    Command line, MAME.INI, HORIZONT.INI, ARCADE.INI, RASTER.INI, 384X224H.INI, 384X224H@60.INI, CPS2.INI, and lastly SSF2T.INI (*remember command line parameters take precedence over all else!*)
 
 
 Tricks to Make Life Easier

--- a/src/frontend/mame/mameopts.cpp
+++ b/src/frontend/mame/mameopts.cpp
@@ -279,6 +279,18 @@ void mame_options::parse_standard_inis(emu_options &options, std::string &error_
 		if (device.screen_type() == SCREEN_TYPE_RASTER)
 		{
 			parse_one_ini(options,"raster", OPTION_PRIORITY_SCREEN_INI, &error_string);
+
+			// parse resolution based ({width}x{height}{orientation}@{refreshrate}
+			const rectangle &visarea = device.visible_area();
+			std::string sizename = string_format("%dx%d%s",
+			                                     visarea.width(), 
+			                                     visarea.height(),
+			                                     (cursystem->flags & ORIENTATION_SWAP_XY) ? "V" : "H");
+			parse_one_ini(options, sizename.c_str(), OPTION_PRIORITY_SCREEN_INI, &error_string);
+
+			sizename += string_format("@%d", (int)(ATTOSECONDS_TO_HZ(device.frame_period().attoseconds()) + 0.5));
+			parse_one_ini(options, sizename.c_str(), OPTION_PRIORITY_SCREEN_INI, &error_string);
+
 			break;
 		}
 		// parse "vector.ini" for vector games


### PR DESCRIPTION
I have used  my own version of mame104 in a cabinet for a decade. I recently updated it to the latest mame version. For several of the changes I have in my version there are now similar functionality in the main version (clean stretch, confirm_exit...).

I will now contribute most of the remaining changes as pull requests to be merged if they are accepted.
The changes are useful for me but I have not investigated if they break any "rules" about what is accepted.
Feel free to reject them. 

All my changes are "BSD-3-Clause License"

--
This first PR adds parsing of screen resolution dependent ini-files for raster games.
The ini-files parsed are `[Width]x[Height][Orientation].ini` and `[Width]x[Height][Orientation]@[Refreshrate].ini` (refreshrate is rounded to nearest integer)
e.g.  
Gauntlet will parse `336x240H.ini` and `336x240H@60.ini`
Pacman will parse `288x224V.ini` and `288x224V@60.ini`

This is very useful in my cabinet since I don't need to create an ini-file for each game just to select correct resolution.
It is also mentioned in issue #755
