### PR TITLE
Input controller alias in controller files.

### DIFF
--- a/docs/man/mame.6
+++ b/docs/man/mame.6
@@ -948,8 +948,9 @@ signal will be ignored. The default is ON (\-coin_lockout).
 .B \-ctrlr \fIcontroller
 Enables support for special controllers. Configuration files are
 loaded from the ctrlrpath. They are in the same format as the .cfg
-files that are saved, but only control configuration data is read
-from the file. The default is NULL (no controller file).
+files that are saved, but only control configuration data and aliases
+is read from the file. Multiple files are separated with semicolon.
+The default is NULL (no controller file).
 .TP
 .B \-[no]mouse
 Controls whether or not MAME looks for a mouse controller to use. Note

--- a/docs/source/advanced/controlleralias.rst
+++ b/docs/source/advanced/controlleralias.rst
@@ -1,0 +1,47 @@
+Controller aliases
+=====================
+
+By default MAME will map all controls and functions to keyboard keys and mouse-/joystickaxis and buttons.
+Controls are then listed and configured with generic names like "KEY X", "MOUSE XAXIS", "JOY BUTTON 1" etc.
+This works well as long as you use a keyboard, mouse and joystick but if you for example run MAME in
+a converted arcade cabinet it gets confusing. Which button on the cabinet is "KEY A" or "MOUSE BUTTON 1".
+(if you have confirm_exit activated you get a message saying "Press "KEY ENTER" to exit")
+
+Controller aliases allow you to give arbitrary names to keyboard keys and other input methods.
+e.g. change "KEY ENTER" to "Blue button" or "MOUSE XAXIS" to "Spinner"
+
+Usage of controller aliases
+============================
+
+Controller aliases must be in a controller file specified in the "ctrlr" tag in a .ini file.
+e.g. in mame.ini under "CORE INPUT OPTIONS"
+ctrlr		jpac
+
+Each alias is listed under the <aliases> xml element which is under the <system> xml element in the controller file.
+The <alias> tag requires a "code" tag and a name as content.
+e.g.
+<mameconfig version="10">
+  <system name="default">
+    <input>
+	  ...
+    </input>
+    <aliases>
+	  <alias code="KEYCODE_RIGHT">Joy1Right</alias>
+	  <alias code="KEYCODE_LEFT">Joy1Left</alias>
+      <alias code="KEYCODE_LCONTROL">P1Btn1</alias>
+      <alias code="KEYCODE_X">P1Btn6</alias>
+      <alias code="MOUSECODE_XAXIS">Spinner</alias>
+	</aliases>
+  </system>
+</mameconfig>
+
+The code is the standard MAME name for input. They are listed in the source file src/emu/input.cpp but the general format is:
+KEYCODE_*
+MOUSECODE_*
+GUNCODE_*
+JOYCODE_*
+
+Note that mouse/joystick/gun directions are name XAXIS, YAXIS etc. e.g. MOUSECODE_XAXIS.
+(MOUSECODE_X is a valid name but will never happen)
+
+For a complete example look in the jpac.cfg file in the ctrlr folder.

--- a/docs/source/advanced/index.rst
+++ b/docs/source/advanced/index.rst
@@ -11,3 +11,4 @@ Advanced configuration
 	hlsl
 	glsl
 	devicemap
+	controlleralias

--- a/src/emu/config.cpp
+++ b/src/emu/config.cpp
@@ -76,10 +76,10 @@ int configuration_manager::load_settings()
 			osd_file::error filerr = file.open(filename, ".cfg");
 
 			if (filerr != osd_file::error::NONE)
-				throw emu_fatalerror("Could not load controller file %s.cfg", controller);
+				throw emu_fatalerror("Could not load controller file %s.cfg", filename.c_str());
 
 			if (!load_xml(file, config_type::CONTROLLER))
-				throw emu_fatalerror("Could not load controller file %s.cfg", controller);
+				throw emu_fatalerror("Could not load controller file %s.cfg", filename.c_str());
 		}
 	}
 

--- a/src/emu/config.cpp
+++ b/src/emu/config.cpp
@@ -68,14 +68,19 @@ int configuration_manager::load_settings()
 	{
 		/* open the config file */
 		emu_file file(machine().options().ctrlr_path(), OPEN_FLAG_READ);
-		osd_file::error filerr = file.open(controller, ".cfg");
+		path_iterator ctrlriter(controller);
+		std::string filename;
 
-		if (filerr != osd_file::error::NONE)
-			throw emu_fatalerror("Could not load controller file %s.cfg", controller);
+		while (ctrlriter.next(filename, nullptr))
+		{
+			osd_file::error filerr = file.open(filename, ".cfg");
 
-		/* load the XML */
-		if (!load_xml(file, config_type::CONTROLLER))
-			throw emu_fatalerror("Could not load controller file %s.cfg", controller);
+			if (filerr != osd_file::error::NONE)
+				throw emu_fatalerror("Could not load controller file %s.cfg", controller);
+
+			if (!load_xml(file, config_type::CONTROLLER))
+				throw emu_fatalerror("Could not load controller file %s.cfg", controller);
+		}
 	}
 
 	/* next load the defaults file */

--- a/src/emu/input.cpp
+++ b/src/emu/input.cpp
@@ -1021,6 +1021,12 @@ std::string input_manager::code_name(input_code code) const
 		devindex.clear();
 	}
 
+	// if item got an alias we don't need class nor index
+	if (item->has_alias()) {
+		devclass = "";
+		devindex.clear();
+	}
+
 	// devcode part comes from the item name
 	const char *devcode = item->name();
 

--- a/src/emu/inputdev.h
+++ b/src/emu/inputdev.h
@@ -89,7 +89,8 @@ public:
 	input_device &device() const { return m_device; }
 	input_manager &manager() const;
 	running_machine &machine() const;
-	const char *name() const { return m_name.c_str(); }
+	bool has_alias() const { return !m_alias.empty(); }
+	const char *name() const { return has_alias() ? m_alias.c_str() : m_name.c_str(); }
 	void *internal() const { return m_internal; }
 	input_item_id itemid() const { return m_itemid; }
 	input_item_class itemclass() const { return m_itemclass; }
@@ -101,6 +102,7 @@ public:
 	// helpers
 	s32 update_value();
 	void set_memory(s32 value) { m_memory = value; }
+	void set_alias(const char* newname) { m_alias = newname; }
 
 	// readers
 	virtual s32 read_as_switch(input_item_modifier modifier) = 0;
@@ -111,6 +113,7 @@ protected:
 	// internal state
 	input_device &          m_device;               // reference to our owning device
 	std::string             m_name;                 // string name of item
+	std::string             m_alias;                // alias name for item
 	void *                  m_internal;             // internal callback pointer
 	input_item_id           m_itemid;               // originally specified item id
 	input_item_class        m_itemclass;            // class of the item

--- a/src/emu/ioport.h
+++ b/src/emu/ioport.h
@@ -1449,6 +1449,9 @@ private:
 	void save_default_inputs(util::xml::data_node &parentnode);
 	void save_game_inputs(util::xml::data_node &parentnode);
 
+	void load_alias(config_type cfg_type, util::xml::data_node const *parentnode);
+	void save_alias(config_type cfg_type, util::xml::data_node *parentnode);
+
 	template<typename _Type> _Type playback_read(_Type &result);
 	time_t playback_init();
 	void playback_end(const char *message = nullptr);


### PR DESCRIPTION
This is my second PR with my cabinet changes (see #1982). All my changes are "BSD-3-Clause License".

This PR makes it possible to create alias for inputs.
A game input specified as "KEY X" or the confirm_quit dialog message "Press KEY ENTER to quit" doesn't help much in a cabinet where all you got is joysticks and differently colored buttons.

Make it more user friendly by adding alias in the controller file. The alias will be used everywhere in the MAME GUI. Configuration looks like this
```
      <alias code="KEYCODE_LCONTROL">Blue button</alias>
      <alias code="KEYCODE_X">Green button</alias>
      <alias code="MOUSECODE_XAXIS">Spinner</alias>
``` 
See the controlleralias documentation on how to use it.
I also have an example file to include in the `ctrlr` folder, [jpac.cfg](https://github.com/mamedev/mame/files/706876/jpac.txt), but could not find the folder in the repository.

The PR also allow configuration with several controller files separated with semicolon.
e.g. -ctrlr common;jpac;gamespecific
