### PR TITLE
Added option to speed up game start.

### DIFF
--- a/docs/man/mame.6
+++ b/docs/man/mame.6
@@ -497,6 +497,13 @@ consistent environment for benchmarking MAME performance. In addition,
 upon exit, the \-str option will write a screenshot called final.png
 to the game's snapshot directory.
 .TP
+.B \-seconds_to_skip, \-sts \fIvalue
+This option can be used to skip a fixed number of seconds at game
+start. It tells MAME to run the emulation as fast as possible until
+the specified number of seconds has been emulated. This can be 
+used to speed up the start of games with long power on test sequences.
+
+.TP
 .B \-[no]throttle
 Configures the default thottling setting. When throttling is on, MAME
 attempts to keep the game running at the game's intended speed. When

--- a/docs/source/commandline/commandline-all.rst
+++ b/docs/source/commandline/commandline-all.rst
@@ -418,6 +418,10 @@ Core performance options
 
 	This option can be used for benchmarking and automated testing. It tells MAME to stop execution after a fixed number of seconds. By combining this with a fixed set of other command line options, you can set up a consistent environment for benchmarking MAME performance. In addition, upon exit, the **-str** option will write a screenshot called *final.png* to the game's snapshot directory.
 
+**-seconds_to_skip** / **-sts** *<seconds>*
+
+    This option can be used to skip a fixed number of seconds at game start. It tells MAME to run the emulation as fast as possible until the specified number of seconds has been emulated. This can be used to speed up the start of games with long power on test sequences.
+
 **-[no]throttle**
 
 	Configures the default thottling setting. When throttling is on, MAME attempts to keep the game running at the game's intended speed. When throttling is off, MAME runs the game as fast as it can. Note that the fastest speed is more often than not limited by your graphics card, especially for older games. The default is ON (*-throttle*).

--- a/src/emu/emuopts.cpp
+++ b/src/emu/emuopts.cpp
@@ -79,6 +79,7 @@ const options_entry emu_options::s_option_entries[] =
 	{ OPTION_AUTOFRAMESKIP ";afs",                       "0",         OPTION_BOOLEAN,    "enable automatic frameskip selection" },
 	{ OPTION_FRAMESKIP ";fs(0-10)",                      "0",         OPTION_INTEGER,    "set frameskip to fixed value, 0-10 (autoframeskip must be disabled)" },
 	{ OPTION_SECONDS_TO_RUN ";str",                      "0",         OPTION_INTEGER,    "number of emulated seconds to run before automatically exiting" },
+	{ OPTION_SECONDS_TO_SKIP ";sts",                     "0",         OPTION_INTEGER,    "number of emulated seconds to run unthrottled" },
 	{ OPTION_THROTTLE,                                   "1",         OPTION_BOOLEAN,    "enable throttling to keep game running in sync with real time" },
 	{ OPTION_SLEEP,                                      "1",         OPTION_BOOLEAN,    "enable sleeping, which gives time back to other applications when idle" },
 	{ OPTION_SPEED "(0.01-100)",                         "1.0",       OPTION_FLOAT,      "controls the speed of gameplay, relative to realtime; smaller numbers are slower" },

--- a/src/emu/emuopts.h
+++ b/src/emu/emuopts.h
@@ -72,6 +72,7 @@
 #define OPTION_AUTOFRAMESKIP        "autoframeskip"
 #define OPTION_FRAMESKIP            "frameskip"
 #define OPTION_SECONDS_TO_RUN       "seconds_to_run"
+#define OPTION_SECONDS_TO_SKIP      "seconds_to_skip"
 #define OPTION_THROTTLE             "throttle"
 #define OPTION_SLEEP                "sleep"
 #define OPTION_SPEED                "speed"
@@ -266,6 +267,7 @@ public:
 	bool auto_frameskip() const { return bool_value(OPTION_AUTOFRAMESKIP); }
 	int frameskip() const { return int_value(OPTION_FRAMESKIP); }
 	int seconds_to_run() const { return int_value(OPTION_SECONDS_TO_RUN); }
+	int seconds_to_skip() const { return int_value(OPTION_SECONDS_TO_SKIP); }
 	bool throttle() const { return bool_value(OPTION_THROTTLE); }
 	bool sleep() const { return m_sleep; }
 	float speed() const { return float_value(OPTION_SPEED); }

--- a/src/emu/video.cpp
+++ b/src/emu/video.cpp
@@ -88,6 +88,7 @@ video_manager::video_manager(running_machine &machine)
 		m_throttle_rate(1.0f),
 		m_fastforward(false),
 		m_seconds_to_run(machine.options().seconds_to_run()),
+		m_seconds_to_skip(machine.options().seconds_to_skip()),
 		m_auto_frameskip(machine.options().auto_frameskip()),
 		m_speed(original_speed_setting()),
 		m_empty_skip_count(0),
@@ -224,8 +225,16 @@ void video_manager::frame_update(bool from_debugger)
 	// draw the user interface
 	emulator_info::draw_user_interface(machine());
 
-	// if we're throttling, synchronize before rendering
 	attotime current_time = machine().time();
+
+	// revert to throttling after some time
+	if (m_seconds_to_skip > 0 && m_seconds_to_skip <= current_time.seconds())
+	{
+		m_seconds_to_skip = 0;
+		set_throttled(true);
+	}
+	
+	// if we're throttling, synchronize before rendering
 	if (!from_debugger && !skipped_it && effective_throttle())
 		update_throttle(current_time);
 
@@ -276,7 +285,7 @@ std::string video_manager::speed_text()
 		str << "paused";
 
 	// if we're fast forwarding, just display Fast-forward
-	else if (m_fastforward)
+	else if (m_fastforward || m_seconds_to_skip > 0)
 		str << "fast ";
 
 	// if we're auto frameskipping, display that plus the level
@@ -631,7 +640,7 @@ void video_manager::postload()
 inline bool video_manager::effective_autoframeskip() const
 {
 	// if we're fast forwarding or paused, autoframeskip is disabled
-	if (m_fastforward || machine().paused())
+	if (m_fastforward || m_seconds_to_skip > 0 || machine().paused())
 		return false;
 
 	// otherwise, it's up to the user
@@ -648,7 +657,7 @@ inline bool video_manager::effective_autoframeskip() const
 inline int video_manager::effective_frameskip() const
 {
 	// if we're fast forwarding, use the maximum frameskip
-	if (m_fastforward)
+	if (m_fastforward || m_seconds_to_skip > 0)
 		return FRAMESKIP_LEVELS - 1;
 
 	// otherwise, it's up to the user
@@ -669,7 +678,7 @@ inline bool video_manager::effective_throttle() const
 		return true;
 
 	// if we're fast forwarding, we don't throttle
-	if (m_fastforward)
+	if (m_fastforward || m_seconds_to_skip > 0)
 		return false;
 
 	// otherwise, it's up to the user
@@ -1062,7 +1071,7 @@ void video_manager::recompute_speed(const attotime &emutime)
 		m_speed_last_emutime = emutime;
 
 		// if we're throttled, this time period counts for overall speed; otherwise, we reset the counter
-		if (!m_fastforward)
+		if (!m_fastforward || m_seconds_to_skip > 0)
 			m_overall_valid_counter++;
 		else
 			m_overall_valid_counter = 0;

--- a/src/emu/video.h
+++ b/src/emu/video.h
@@ -161,6 +161,7 @@ private:
 	float               m_throttle_rate;            // target rate for throttling
 	bool                m_fastforward;              // flag: true if we're currently fast-forwarding
 	u32                 m_seconds_to_run;           // number of seconds to run before quitting
+	u32                 m_seconds_to_skip;          // number of seconds to run unthrottled
 	bool                m_auto_frameskip;           // flag: true if we're automatically frameskipping
 	u32                 m_speed;                    // overall speed (*1000)
 


### PR DESCRIPTION
This is my third PR with my cabinet changes (see #1982). All my changes are "BSD-3-Clause License".

This PR adds an option to fast forward at startup.
Some games, e.g. defender, has a lengthy power on test sequence.
With this PR it is possible to start the game without throttling and then automatically revert
to normal speed after some time.
The option is called `seconds_to_skip` with shortcut `sts` and is used like other configurations in ini-files or on command line like:
`mame defender -seconds_to_skip 20`
