### PR TITLE
Show emulated position of analog controls

### DIFF
--- a/docs/source/usingmame/defaultkeys.rst
+++ b/docs/source/usingmame/defaultkeys.rst
@@ -84,6 +84,10 @@ All the keys below are fully configurable in the user interface. This list shows
 **F9**            | Increase frame skip on the fly.
 **F10**           | Toggle speed throttling.
 **F11**           | Toggles speed display.
+                  | For games with at least one analog control it will also display a series of
+                  | lines at the bottom of the display. The lines represents MAME's view of
+                  | each control's current position. Can make it easier to calibrate
+                  | analog controllers.
 **Shift+F11**     | Toggles internal profiler display (if compiled in).
 **Alt+F11**       | Record HLSL Rendered Video.
 **F12**           | Saves a screen snapshot.

--- a/src/frontend/mame/ui/ui.h
+++ b/src/frontend/mame/ui/ui.h
@@ -265,6 +265,8 @@ private:
 	uint32_t handler_load_save(render_container &container, uint32_t state);
 	uint32_t handler_confirm_quit(render_container &container);
 
+	void show_analog_controls(render_container &container);
+
 	// private methods
 	void exit();
 	slider_state* slider_alloc(running_machine &machine, int id, const char *title, int32_t minval, int32_t defval, int32_t maxval, int32_t incval, void *arg);


### PR DESCRIPTION
This is my fourth PR with my cabinet changes (see #1982). All my changes are "BSD-3-Clause License".

This PR shows the current status of analog controls as lines at the bottom of the screen.

I find it very hard to map analog controls to other inputs, e.g. steering wheel to spinner.
The problem is that I don't get any visible indication on the current position of the analog controller.
It becomes event more difficult with games like Cruis'n USA who asks you to calibrate the control by centering it at first startup.

The lines added at the bottom will show the position of each analog control together with it's "zero" position.

I activate the analog control indicators with the F11 "show fps" button to keep the source code change small. If the PR is accepted it might be better to let it have its own key and maybe also rotate the controls one at a time to interfere less with the game screen.

