### PR TITLE
Created a new debugger command 'tracesym'

### DIFF
--- a/src/emu/debug/debugcmd.cpp
+++ b/src/emu/debug/debugcmd.cpp
@@ -136,6 +136,7 @@ debugger_commands::debugger_commands(running_machine& machine, debugger_cpu& cpu
 	m_console.register_command("printf",    CMDFLAG_NONE, 0, 1, MAX_COMMAND_PARAMS, std::bind(&debugger_commands::execute_printf, this, _1, _2, _3));
 	m_console.register_command("logerror",  CMDFLAG_NONE, 0, 1, MAX_COMMAND_PARAMS, std::bind(&debugger_commands::execute_logerror, this, _1, _2, _3));
 	m_console.register_command("tracelog",  CMDFLAG_NONE, 0, 1, MAX_COMMAND_PARAMS, std::bind(&debugger_commands::execute_tracelog, this, _1, _2, _3));
+	m_console.register_command("tracesym",  CMDFLAG_NONE, 0, 1, MAX_COMMAND_PARAMS, std::bind(&debugger_commands::execute_tracesym, this, _1, _2, _3));
 	m_console.register_command("quit",      CMDFLAG_NONE, 0, 0, 0, std::bind(&debugger_commands::execute_quit, this, _1, _2, _3));
 	m_console.register_command("exit",      CMDFLAG_NONE, 0, 0, 0, std::bind(&debugger_commands::execute_quit, this, _1, _2, _3));
 	m_console.register_command("do",        CMDFLAG_NONE, 0, 1, 1, std::bind(&debugger_commands::execute_do, this, _1, _2, _3));
@@ -720,6 +721,42 @@ void debugger_commands::execute_tracelog(int ref, int params, const char *param[
 	/* then do a printf */
 	char buffer[1024];
 	if (mini_printf(buffer, param[0], params - 1, &values[1]))
+		m_cpu.get_visible_cpu()->debug()->trace_printf("%s", buffer);
+}
+
+
+/*-------------------------------------------------
+	execute_tracesym - execute the tracesym command
+-------------------------------------------------*/
+
+void debugger_commands::execute_tracesym(int ref, int params, const char *param[])
+{
+	// build a format string appropriate for the parameters and validate them
+	std::stringstream format;
+	u64 values[MAX_COMMAND_PARAMS];
+	for (int i = 0; i < params; i++)
+	{
+		// find this symbol
+		symbol_entry *sym = m_cpu.get_visible_symtable()->find(param[i]);
+		if (!sym)
+		{
+			m_console.printf("Unknown symbol: %s\n", param[i]);
+			return;
+		}
+
+		// build the format string
+		util::stream_format(format, "%s=%s ",
+			param[i],
+			sym->format().empty() ? "%16X" : sym->format());
+
+		// validate the parameter
+		if (!validate_number_parameter(param[i], &values[i]))
+			return;
+	}
+
+	// then do a printf
+	char buffer[1024];
+	if (mini_printf(buffer, format.str().c_str(), params, values))
 		m_cpu.get_visible_cpu()->debug()->trace_printf("%s", buffer);
 }
 

--- a/src/emu/debug/debugcmd.h
+++ b/src/emu/debug/debugcmd.h
@@ -98,6 +98,7 @@ private:
 	void execute_printf(int ref, int params, const char **param);
 	void execute_logerror(int ref, int params, const char **param);
 	void execute_tracelog(int ref, int params, const char **param);
+	void execute_tracesym(int ref, int params, const char **param);
 	void execute_quit(int ref, int params, const char **param);
 	void execute_do(int ref, int params, const char **param);
 	void execute_step(int ref, int params, const char **param);

--- a/src/emu/debug/debugcpu.cpp
+++ b/src/emu/debug/debugcpu.cpp
@@ -1668,10 +1668,10 @@ device_debug::device_debug(device_t &device)
 
 		// add all registers into it
 		std::string tempstr;
-		for (auto &entry : m_state->state_entries())
+		for (const auto &entry : m_state->state_entries())
 		{
 			strmakelower(tempstr.assign(entry->symbol()));
-			m_symtable.add(tempstr.c_str(), (void *)(uintptr_t)entry->index(), get_state, set_state);
+			m_symtable.add(tempstr.c_str(), (void *)(uintptr_t)entry->index(), get_state, set_state, entry->format_string());
 		}
 	}
 

--- a/src/emu/debug/debughlp.cpp
+++ b/src/emu/debug/debughlp.cpp
@@ -86,6 +86,7 @@ static const help_item static_help_list[] =
 		"  printf <format>[,<item>[,...]] -- prints one or more <item>s to the console using <format>\n"
 		"  logerror <format>[,<item>[,...]] -- outputs one or more <item>s to the error.log\n"
 		"  tracelog <format>[,<item>[,...]] -- outputs one or more <item>s to the trace file using <format>\n"
+		"  tracesym <item>[,...]] -- outputs one or more <item>s to the trace file\n"
 		"  history [<cpu>,<length>] -- outputs a brief history of visited opcodes\n"
 		"  trackpc [<bool>,<cpu>,<bool>] -- visually track visited opcodes [boolean to turn on and off, for the given cpu, clear]\n"
 		"  trackmem [<bool>,<bool>] -- record which PC writes to each memory address [boolean to turn on and off, clear]\n"
@@ -383,6 +384,22 @@ static const help_item static_help_list[] =
 		"\n"
 		"printf \"A=%d, B=%d\\nC=%d\",a,b,a+b\n"
 		"  Outputs A=<aval>, B=<bval> on one line, and C=<a+bval> on a second line.\n"
+	},
+	{
+		"tracesym",
+		"\n"
+		"  tracesym <item>[,...]\n"
+			"\n"
+			"The tracesym command prints the specified symbols and routes the output to the currently open trace "
+			"file (see the 'trace' command for details). If no file is currently open, tracesym does nothing. "
+			"\n"
+			"Examples:\n"
+			"\n"
+			"tracelog pc\n"
+			"  Outputs PC=<pcval> where <pcval> is displayed in the default format.\n"
+			"\n"
+			"printf a,b\n"
+			"  Outputs A=<aval>, B=<bval> on one line.\n"
 	},
 	{
 		"trackpc",

--- a/src/emu/debug/express.h
+++ b/src/emu/debug/express.h
@@ -116,13 +116,14 @@ protected:
 	};
 
 	// construction/destruction
-	symbol_entry(symbol_table &table, symbol_type type, const char *name, void *ref);
+	symbol_entry(symbol_table &table, symbol_type type, const char *name, const std::string &format, void *ref);
 public:
 	virtual ~symbol_entry();
 
 	// getters
 	symbol_entry *next() const { return m_next; }
 	const char *name() const { return m_name.c_str(); }
+	const std::string &format() const { return m_format; }
 
 	// type checking
 	bool is_function() const { return (m_type == SMT_FUNCTION); }
@@ -138,6 +139,7 @@ protected:
 	symbol_table &  m_table;                    // pointer back to the owning table
 	symbol_type     m_type;                     // type of symbol
 	std::string     m_name;                     // name of the symbol
+	std::string		m_format;					// format of symbol (or empty if unspecified)
 	void *          m_ref;                      // internal reference
 };
 
@@ -181,7 +183,7 @@ public:
 	// symbol access
 	void add(const char *name, read_write rw, u64 *ptr = nullptr);
 	void add(const char *name, u64 constvalue);
-	void add(const char *name, void *ref, getter_func getter, setter_func setter = nullptr);
+	void add(const char *name, void *ref, getter_func getter, setter_func setter = nullptr, const std::string &format_string = "");
 	void add(const char *name, void *ref, int minparams, int maxparams, execute_func execute);
 	symbol_entry *find(const char *name) const { if (name) { auto search = m_symlist.find(name); if (search != m_symlist.end()) return search->second.get(); else return nullptr; } else return nullptr; }
 	symbol_entry *find_deep(const char *name);

--- a/src/emu/distate.h
+++ b/src/emu/distate.h
@@ -65,6 +65,7 @@ public:
 	bool visible() const { return ((m_flags & DSF_NOSHOW) == 0); }
 	bool divider() const { return m_flags & DSF_DIVIDER; }
 	device_state_interface *parent_state() const {return m_device_state;}
+	const std::string &format_string() const { return m_format; }
 
 protected:
 	// device state flags


### PR DESCRIPTION
'tracesym' is intended to be a shorthand of 'tracelog', whereby the user doesn't have to specify a format string; the default format string is used