### PR TITLE
Fix build breakage caused by 0a323f7da0249f218ffb4e28c8cf6a95f31a90c2…

### DIFF
--- a/src/mame/drivers/aristmk5.cpp
+++ b/src/mame/drivers/aristmk5.cpp
@@ -249,7 +249,6 @@ private:
 	emu_timer *     m_mk5_2KHz_timer;
 	emu_timer *     m_mk5_VSYNC_timer;
 	emu_timer *     m_spi_timer;
-	uint8_t         m_ext_latch;
 	uint8_t         m_sram_bank;
 	uint8_t         m_ldor_shift_reg;
 	uint8_t         m_hopper_test;


### PR DESCRIPTION
… (nw)