### PR TITLE
Via6522 fixes

### DIFF
--- a/src/devices/machine/6522via.cpp
+++ b/src/devices/machine/6522via.cpp
@@ -989,12 +989,12 @@ WRITE_LINE_MEMBER( via6522_device::write_cb1 )
 				m_latch_b = input_pb();
 			}
 
-			if (SO_EXT_CONTROL(m_acr))
+			if (!state && SO_EXT_CONTROL(m_acr))
 			{
 				shift_out();
 			}
 
-			if (SI_EXT_CONTROL(m_acr))
+			if (state && SI_EXT_CONTROL(m_acr))
 			{
 				shift_in();
 			}
@@ -1005,6 +1005,18 @@ WRITE_LINE_MEMBER( via6522_device::write_cb1 )
 			{
 				m_out_cb2 = 1;
 				m_cb2_handler(1);
+			}
+		}
+		else // shift is not controlled by m_pcr
+		{
+			if (!state && SO_EXT_CONTROL(m_acr)) 
+			{
+				shift_out();
+			}
+
+			if (state && SI_EXT_CONTROL(m_acr))
+			{
+				shift_in();
 			}
 		}
 	}


### PR DESCRIPTION
A couple of fixes to the VIA6522 shift register as we've scrutinized the datasheet. There are still details not emulated perfectly but at least we haev a 50/50 duty cycle now required to interact with a netlist device and we try to do things on the right flank. There is also a fix for spurious timer events that occured when changing shifter mode between internal and external clock. This is abused by the mac128k rom set for instance, see attached regression test logs for details. I am still curious what Tafoid will find if anything :)
[via6255regressions.txt](https://github.com/mamedev/mame/files/743586/via6255regressions.txt)
