### PR TITLE
gcpinbal: Modernization and sound improvements

### DIFF
--- a/src/mame/includes/gcpinbal.h
+++ b/src/mame/includes/gcpinbal.h
@@ -24,7 +24,8 @@ public:
 		m_msm(*this, "msm"),
 		m_adpcm_select(*this, "adpcm_select"),
 		m_tilemapram(*this, "tilemapram"),
-		m_ioc_ram(*this, "ioc_ram"),
+		m_d80010_ram(*this, "d80010"),
+		m_d80060_ram(*this, "d80060"),
 		m_gfxdecode(*this, "gfxdecode"),
 		m_palette(*this, "palette"),
 		m_sprgen(*this, "spritegen")
@@ -39,7 +40,8 @@ public:
 
 	/* memory pointers */
 	required_shared_ptr<uint16_t> m_tilemapram;
-	required_shared_ptr<uint16_t> m_ioc_ram;
+	required_shared_ptr<uint16_t> m_d80010_ram;
+	required_shared_ptr<uint16_t> m_d80060_ram;
 
 	required_device<gfxdecode_device> m_gfxdecode;
 	required_device<palette_device> m_palette;
@@ -63,8 +65,13 @@ public:
 	uint32_t      m_adpcm_idle;
 	uint8_t       m_adpcm_trigger;
 
-	DECLARE_READ16_MEMBER(ioc_r);
-	DECLARE_WRITE16_MEMBER(ioc_w);
+	DECLARE_WRITE16_MEMBER(d80010_w);
+	DECLARE_WRITE8_MEMBER(d80040_w);
+	DECLARE_WRITE16_MEMBER(d80060_w);
+	DECLARE_WRITE8_MEMBER(bank_w);
+	DECLARE_WRITE8_MEMBER(eeprom_w);
+	DECLARE_WRITE8_MEMBER(unknown_w);
+	DECLARE_WRITE8_MEMBER(es8712_w);
 	DECLARE_READ16_MEMBER(gcpinbal_tilemaps_word_r);
 	DECLARE_WRITE16_MEMBER(gcpinbal_tilemaps_word_w);
 	TILE_GET_INFO_MEMBER(get_bg0_tile_info);

--- a/src/mame/video/gcpinbal.cpp
+++ b/src/mame/video/gcpinbal.cpp
@@ -97,7 +97,6 @@ WRITE16_MEMBER(gcpinbal_state::gcpinbal_tilemaps_word_w)
 uint32_t gcpinbal_state::screen_update_gcpinbal(screen_device &screen, bitmap_ind16 &bitmap, const rectangle &cliprect)
 {
 	int i;
-	uint16_t tile_sets = 0;
 	uint8_t layer[3];
 
 #ifdef MAME_DEBUG
@@ -120,16 +119,12 @@ uint32_t gcpinbal_state::screen_update_gcpinbal(screen_device &screen, bitmap_in
 	}
 #endif
 
-	m_scrollx[0] =  m_ioc_ram[0x14 / 2];
-	m_scrolly[0] =  m_ioc_ram[0x16 / 2];
-	m_scrollx[1] =  m_ioc_ram[0x18 / 2];
-	m_scrolly[1] =  m_ioc_ram[0x1a / 2];
-	m_scrollx[2] =  m_ioc_ram[0x1c / 2];
-	m_scrolly[2] =  m_ioc_ram[0x1e / 2];
-
-	tile_sets = m_ioc_ram[0x88 / 2];
-	m_bg0_gfxset = (tile_sets & 0x400) ? 0x1000 : 0;
-	m_bg1_gfxset = (tile_sets & 0x800) ? 0x1000 : 0;
+	m_scrollx[0] = m_d80010_ram[0x4 / 2];
+	m_scrolly[0] = m_d80010_ram[0x6 / 2];
+	m_scrollx[1] = m_d80010_ram[0x8 / 2];
+	m_scrolly[1] = m_d80010_ram[0xa / 2];
+	m_scrollx[2] = m_d80010_ram[0xc / 2];
+	m_scrolly[2] = m_d80010_ram[0xe / 2];
 
 	for (i = 0; i < 3; i++)
 	{
@@ -160,7 +155,7 @@ uint32_t gcpinbal_state::screen_update_gcpinbal(screen_device &screen, bitmap_in
 #endif
 	m_tilemap[layer[2]]->draw(screen, bitmap, cliprect, 0, 4);
 
-	int sprpri = (m_ioc_ram[0x68 / 2] & 0x8800) ? 0 : 1;
+	int sprpri = (m_d80060_ram[0x8 / 2] & 0x8800) ? 0 : 1;
 	m_sprgen->gcpinbal_draw_sprites(screen, bitmap, cliprect, m_gfxdecode, 16, sprpri);
 
 #if 0


### PR DESCRIPTION
- Break up the bogus IOC structure and use 8-bit handlers where appropriate. This fixes a music playback glitch due to the old handler's failure to take byte mirroring into account.
- Improve OKI M6295 sounds by using correct bit for banking