### PR TITLE
Fix compilation error against GCC 5.4.0

### DIFF
--- a/src/mame/drivers/pong.cpp
+++ b/src/mame/drivers/pong.cpp
@@ -139,7 +139,7 @@ public:
 
 	NETDEV_ANALOG_CALLBACK_MEMBER(sound_cb)
 	{
-		m_dac->write(std::round(16384 * data));
+		m_dac->write(::round(16384 * data));
 	}
 
 protected:


### PR DESCRIPTION
Replace call to `std::round` with call to `::round`.

This fixes the following error when compiling:

    Compiling src/mame/machine/nl_pong.cpp...
    ../../../../../src/mame/drivers/pong.cpp: In member function 'void ttl_mono_state::sound_cb(double, const attotime&)':
    ../../../../../src/mame/drivers/pong.cpp:142:16: error: 'round' is not a member of 'std'
       m_dac->write(std::round(16384 * data));
                    ^
    ../../../../../src/mame/drivers/pong.cpp:142:16: note: suggested alternative:
    In file included from /usr/include/features.h:368:0,
                     from /usr/include/c++/5.4.0/x86_64-slackware-linux/bits/os_defines.h:39,
                     from /usr/include/c++/5.4.0/x86_64-slackware-linux/bits/c++config.h:482,
                     from /usr/include/c++/5.4.0/bits/stl_algobase.h:59,
                     from /usr/include/c++/5.4.0/list:60,
                     from ../../../../../src/emu/emu.h:21:
    /usr/include/bits/mathcalls.h:326:1: note:   'round'
     __MATHCALLX (round,, (_Mdouble_ __x), (__const__));
     ^
    make[2]: *** [atari.make:1925: ../../../../linux_gcc/obj/x64/Release/src/mame/drivers/pong.o] Error 1

Based on the SO text here:
http://stackoverflow.com/questions/12696764/round-is-not-a-member-of-std

Other information:

Slackware x86_64 current (kernel 4.4.14).

Make(1) arguments used to generate this error:

		OPTIMIZE=3
		OSD='sdl'
		TOOLS=1
		BUILD_{ZLIB,FLAC,EXPAT,JPEGLIB}=0
		{FLAC,JPEG}_LIB=''
		NOWERROR=1
		USE_QTDEBUG=0
		TARGET=mame