### PR TITLE
VME bus: added default bus address space and prepared for bus specifi…

### DIFF
--- a/src/devices/bus/vme/vme.cpp
+++ b/src/devices/bus/vme/vme.cpp
@@ -78,7 +78,7 @@
 #define LOG_SETUP   0x02
 #define LOG_PRINTF  0x04
 
-#define VERBOSE 0 //(LOG_PRINTF | LOG_SETUP  | LOG_GENERAL)
+#define VERBOSE 0 // (LOG_PRINTF | LOG_SETUP  | LOG_GENERAL)
 
 #define LOGMASK(mask, ...)   do { if (VERBOSE & mask) logerror(__VA_ARGS__); } while (0)
 #define LOGLEVEL(mask, level, ...) do { if ((VERBOSE & mask) >= level) logerror(__VA_ARGS__); } while (0)
@@ -110,6 +110,7 @@ vme_slot_device::vme_slot_device(const machine_config &mconfig, const char *tag,
 		,m_vme_slottag(nullptr)
 		,m_vme_j1_callback(*this)
 {
+	LOG("%s %s\n", tag, FUNCNAME);
 }
 
 vme_slot_device::vme_slot_device(const machine_config &mconfig, device_type type, const char *name, const char *tag, device_t *owner, uint32_t clock, const char *shortname, const char *source) :
@@ -119,10 +120,19 @@ vme_slot_device::vme_slot_device(const machine_config &mconfig, device_type type
 		,m_vme_slottag(nullptr)
 		,m_vme_j1_callback(*this)
 {
+	LOG("%s %s\n", tag, FUNCNAME);
 }
 
 //-------------------------------------------------
-//  device_start - device-specific startup
+//  static_update_vme_chains
+//-------------------------------------------------
+void vme_slot_device::static_update_vme_chains(device_t &device, uint32_t slot_nbr)
+{
+	LOG("%s %s - %d\n", FUNCNAME, device.tag(), slot_nbr);
+}
+
+//-------------------------------------------------
+//  static_set_vme_slot
 //-------------------------------------------------
 void vme_slot_device::static_set_vme_slot(device_t &device, const char *tag, const char *slottag)
 {
@@ -202,95 +212,194 @@ SLOT_INTERFACE_END
 
 const device_type VME = &device_creator<vme_device>;
 
+// static_set_cputag - used to be able to lookup the CPU owning this VME bus
+void vme_device::static_set_cputag(device_t &device, const char *tag)
+{
+	vme_device &vme = downcast<vme_device &>(device);
+	vme.m_cputag = tag;
+}
+
+// static_set_use_owner_spaces - disables use of the memory interface and use the address spaces 
+// of the owner instead. This is useful for VME buses where no address modifiers or arbitration is
+// being used and gives some gain in performance. 
+void vme_device::static_use_owner_spaces(device_t &device)
+{
+	LOG("%s %s\n", device.tag(), FUNCNAME);
+	vme_device &vme = downcast<vme_device &>(device);
+
+	vme.m_allocspaces = false;
+}
+
 vme_device::vme_device(const machine_config &mconfig, const char *tag, device_t *owner, uint32_t clock) :
 	device_t(mconfig, VME, "VME", tag, owner, clock, "vme", __FILE__)
+	, device_memory_interface(mconfig, *this)
+	, m_a32_config("VME A32", ENDIANNESS_BIG, 32, 32, 0, nullptr)
+	, m_allocspaces(true)
+	, m_cputag("maincpu")
 {
+	LOG("%s %s\n", tag, FUNCNAME);
 }
 
 vme_device::vme_device(const machine_config &mconfig, device_type type, const char *name, const char *tag, device_t *owner, uint32_t clock, const char *shortname, const char *source) :
 	device_t(mconfig, type, name, tag, owner, clock, shortname, source)
+	, device_memory_interface(mconfig, *this)
+	, m_a32_config("VME A32", ENDIANNESS_BIG, 32, 32, 0, nullptr)
+	, m_allocspaces(true)
+	, m_cputag("maincpu")
 {
+	LOG("%s %s\n", tag, FUNCNAME);
 }
 
 vme_device::~vme_device()
 {
+	LOG("%s %s\n", tag(), FUNCNAME);
 	m_device_list.detach_all();
 }
 
 void vme_device::device_start()
 {
+	LOG("%s %s %s\n", owner()->tag(), tag(), FUNCNAME);
+	if (m_allocspaces)
+	{
+		LOG(" - using my own memory spaces\n");
+		m_prgspace = &space(AS_PROGRAM);
+		m_prgwidth = m_prgspace->data_width();
+		LOG(" - Done at %d width\n", m_prgwidth);
+	}
+	else    // use host CPU's spaces directly
+	{
+		LOG(" - using owner memory spaces for %s\n", m_cputag);
+		m_maincpu = owner()->subdevice<cpu_device>(m_cputag);
+		m_prgspace = &m_maincpu->space(AS_PROGRAM);
+		m_prgwidth = m_maincpu->space_config(AS_PROGRAM)->m_databus_width;
+		LOG(" - Done at %d width\n", m_prgwidth);
+	}
 }
 
 void vme_device::device_reset()
 {
+	LOG("%s %s\n", tag(), FUNCNAME);
 }
 
 void vme_device::add_vme_card(device_vme_card_interface *card)
 {
+	LOG("%s %s\n", tag(), FUNCNAME);
 	m_device_list.append(*card);
 }
 
-void vme_device::install_device(offs_t start, offs_t end, read8_delegate rhandler, write8_delegate whandler, uint32_t mask)
+#if 0
+/* 
+ *  Install UB (Utility Bus) handlers for this board
+ * 
+ * The Utility Bus signal lines
+ *------------------------------
+ * System Clock (SYSCLK)
+ * Serial Clock (SERCLK)
+ * Serial Data (SERDAT*)
+ * AC Fail (ACFAIL*)
+ * System Reset (SYSRESET*)
+ * System Failure (SYSFAIL*)
+ *------------------------------
+ */
+void vme_device::install_ub_handler(offs_t start, offs_t end, read8_delegate rhandler, write8_delegate whandler, uint32_t mask)
 {
-	cpu_device  *m_maincpu = machine().device<cpu_device>("maincpu");
+}
+#endif
 
-	int buswidth = m_maincpu->space_config(AS_PROGRAM)->m_databus_width;
-	LOG("%s width:%d\n", FUNCNAME, buswidth);
-	switch(buswidth)
+/* 
+ *  Install DTB (Data Transfer Bus) handlers for this board
+ */
+
+// D8 bit devices in A16, A24 and A32
+void vme_device::install_device(vme_amod_t amod, offs_t start, offs_t end, read8_delegate rhandler, write8_delegate whandler, uint32_t mask)
+{
+	LOG("%s %s AM%d D%02x\n", tag(), FUNCNAME, amod, m_prgwidth);
+
+	LOG(" - width:%d\n", m_prgwidth);
+
+	// TODO: support address modifiers and buscycles other than single access cycles
+	switch(amod)
 	{
-	case 32:
-		m_maincpu->space(AS_PROGRAM).install_readwrite_handler(start, end, rhandler, whandler, mask);
-		break;
-	case 24:
-		m_maincpu->space(AS_PROGRAM).install_readwrite_handler(start, end, rhandler, whandler, mask);
-		break;
+	case A16_SC: break;
+	case A24_SC: break;
+	case A32_SC: break;
+	default: fatalerror("VME D8: Non supported Address modifier: AM%02x\n", amod);
+	}
+
+	switch(m_prgwidth)
+	{
 	case 16:
-		m_maincpu->space(AS_PROGRAM).install_readwrite_handler(start, end, rhandler, whandler, (uint16_t)(mask & 0xffff));
+		m_prgspace->install_readwrite_handler(start, end, rhandler, whandler, (uint16_t)(mask & 0x0000ffff));
 		break;
-	default:
-		fatalerror("VME D8: Bus width %d not supported\n", buswidth);
+	case 24: 
+		m_prgspace->install_readwrite_handler(start, end, rhandler, whandler, (uint32_t)(mask & 0x00ffffff));
+		break;
+	case 32:
+		m_prgspace->install_readwrite_handler(start, end, rhandler, whandler, mask); 
+		break;
+	default: fatalerror("VME D8: Bus width %d not supported\n", m_prgwidth);
 	}
 }
 
-void vme_device::install_device(offs_t start, offs_t end, read16_delegate rhandler, write16_delegate whandler, uint32_t mask)
+// D16 bit devices in A16, A24 and A32
+void vme_device::install_device(vme_amod_t amod, offs_t start, offs_t end, read16_delegate rhandler, write16_delegate whandler, uint32_t mask)
 {
-	cpu_device *m_maincpu = machine().device<cpu_device>("maincpu");
-	int buswidth = m_maincpu->space_config(AS_PROGRAM)->m_databus_width;
-	LOG("%s width:%d\n", FUNCNAME, buswidth);
-	switch(buswidth)
+	LOG("%s %s AM%d D%02x\n", tag(), FUNCNAME, amod, m_prgwidth);
+
+	LOG(" - width:%d\n", m_prgwidth);
+
+	// TODO: support address modifiers and buscycles other than single access cycles
+	switch(amod)
 	{
-	case 32:
-		m_maincpu->space(AS_PROGRAM).install_readwrite_handler(start, end, rhandler, whandler, mask);
-		break;
-	case 24:
-		m_maincpu->space(AS_PROGRAM).install_readwrite_handler(start, end, rhandler, whandler, mask);
-		break;
+	case A16_SC: break;
+	case A24_SC: break;
+	case A32_SC: break;
+	default: fatalerror("VME D16: Non supported Address modifier: %02x\n", amod);
+	}
+
+	switch(m_prgwidth)
+	{
 	case 16:
-		m_maincpu->space(AS_PROGRAM).install_readwrite_handler(start, end, rhandler, whandler, (uint16_t)(mask & 0xffff));
+		m_prgspace->install_readwrite_handler(start, end, rhandler, whandler, (uint16_t)(mask & 0x0000ffff));
 		break;
-	default:
-		fatalerror("VME D16: Bus width %d not supported\n", buswidth);
+	case 24: 
+		m_prgspace->install_readwrite_handler(start, end, rhandler, whandler, (uint32_t)(mask & 0x00ffffff));
+		break;
+	case 32:
+		m_prgspace->install_readwrite_handler(start, end, rhandler, whandler, mask); 
+		break;
+	default: fatalerror("VME D16: Bus width %d not supported\n", m_prgwidth);
 	}
 }
 
-void vme_device::install_device(offs_t start, offs_t end, read32_delegate rhandler, write32_delegate whandler, uint32_t mask)
+// D32 bit devices in A16, A24 and A32
+void vme_device::install_device(vme_amod_t amod, offs_t start, offs_t end, read32_delegate rhandler, write32_delegate whandler, uint32_t mask)
 {
-	cpu_device *m_maincpu = machine().device<cpu_device>("maincpu");
-	int buswidth = m_maincpu->space_config(AS_PROGRAM)->m_databus_width;
-	LOG("%s width:%d\n", FUNCNAME, buswidth);
-	switch(buswidth)
+	LOG("%s %s AM%d D%02x\n", tag(), FUNCNAME, amod, m_prgwidth);
+
+	LOG(" - width:%d\n", m_prgwidth);
+
+	// TODO: support address modifiers and buscycles other than single access cycles
+	switch(amod)
 	{
-	case 32:
-		m_maincpu->space(AS_PROGRAM).install_readwrite_handler(start, end, rhandler, whandler, mask);
-		break;
-	case 24:
-		m_maincpu->space(AS_PROGRAM).install_readwrite_handler(start, end, rhandler, whandler, mask);
-		break;
+	case A16_SC: break;
+	case A24_SC: break;
+	case A32_SC: break;
+	default: fatalerror("VME D32: Non supported Address modifier: %02x\n", amod);
+	}
+
+	switch(m_prgwidth)
+	{
 	case 16:
-		m_maincpu->space(AS_PROGRAM).install_readwrite_handler(start, end, rhandler, whandler, (uint16_t)(mask & 0xffff));
+		m_prgspace->install_readwrite_handler(start, end, rhandler, whandler, (uint16_t)(mask & 0x0000ffff));
 		break;
-	default:
-		fatalerror("VME D32: Bus width %d not supported\n", buswidth);
+	case 24: 
+		m_prgspace->install_readwrite_handler(start, end, rhandler, whandler, (uint32_t)(mask & 0x00ffffff));
+		break;
+	case 32:
+		m_prgspace->install_readwrite_handler(start, end, rhandler, whandler, mask); 
+		break;
+	default: fatalerror("VME D32: Bus width %d not supported\n", m_prgwidth);
 	}
 }
 
@@ -316,6 +425,7 @@ device_vme_card_interface::~device_vme_card_interface()
 
 void device_vme_card_interface::static_set_vme_tag(device_t &device, const char *tag, const char *slottag)
 {
+	LOG("%s %s\n", tag, FUNCNAME);
 	device_vme_card_interface &vme_card = dynamic_cast<device_vme_card_interface &>(device);
 	vme_card.m_vme_tag = tag;
 	vme_card.m_vme_slottag = slottag;

--- a/src/devices/bus/vme/vme_fccpu20.cpp
+++ b/src/devices/bus/vme/vme_fccpu20.cpp
@@ -25,7 +25,7 @@
  * BM    C|                   |  XTAL |    +-----------------------+ | |   |
  *       ||                   | 40MHz |    +-----------------------+ | |P1 |
  *       ||                   +-------+    |     PIT               | | |   |
- * FLMA  C|                   +-------+    |   MC68230P8           | | |   |
+ * FLME  C|                   +-------+    |   MC68230P8           | | |   |
  * EPROM C|                   |  XTAL |    +-----------------------+ | |   |
  * 2WST  C|                   | 32MHz |                              | |   |
  * 4WST  C|                   +-------+                              | |   |
@@ -456,12 +456,36 @@ void vme_fccpu20_device::device_start()
 	m_vme->install_device(base + 2, base + 3, // Channel B - Control
 							 read8_delegate(FUNC(z80sio_device::cb_r),  subdevice<z80sio_device>("pit")), write8_delegate(FUNC(z80sio_device::cb_w), subdevice<z80sio_device>("pit")), 0x00ff);
 #endif
-
 }
+
+enum
+{
+	TIMER_ID_BUS_GRANT
+};
 
 void vme_fccpu20_device::device_reset()
 {
 	LOG("%s\n", FUNCNAME);
+
+	/* We need to delay the static bus grant signal until we have it from the VME interface or MAME supports bus arbitration */
+	m_arbiter_start = timer_alloc(TIMER_ID_BUS_GRANT);
+	m_arbiter_start->adjust(attotime::from_msec(10), TIMER_ID_BUS_GRANT, attotime::never);
+}
+
+//-------------------------------------------------
+//  device_timer - handler timer events
+//-------------------------------------------------
+void vme_fccpu20_device::device_timer (emu_timer &timer, device_timer_id id, int32_t param, void *ptr)
+{
+	switch(id)
+	{
+	case TIMER_ID_BUS_GRANT:
+		m_pit->h1_w(ASSERT_LINE); // Grant bus always
+		break;
+	default:
+		LOG("Unhandled Timer ID %d\n", id);
+		break;
+	}
 }
 
 /* Boot vector handler, the PCB hardwires the first 8 bytes from 0xff800000 to 0x0 at reset*/
@@ -541,6 +565,7 @@ READ8_MEMBER (vme_fccpu20_device::pitb_r)
 }
 
 /* VME board ID bit and bus release software settings (output) (ROR, RAT, RATAR, RATBCLR, RORAT, RORRAT */
+/* Bit 4 is bus available */
 READ8_MEMBER (vme_fccpu20_device::pitc_r)
 {
 	uint8_t board_id = 0;

--- a/src/devices/bus/vme/vme_fccpu20.h
+++ b/src/devices/bus/vme/vme_fccpu20.h
@@ -77,6 +77,8 @@ private:
 	// Below replaces machine_start and machine_reset from  src/mame/drivers/fccpu20.cpp
 protected:
 	virtual void device_reset() override;
+	virtual void device_timer (emu_timer &timer, device_timer_id id, int param, void *ptr) override;
+	emu_timer *m_arbiter_start; // Need a startup delay because it is hooked up to the sense inputs of the PIT
 };
 
 //**************************************************************************

--- a/src/devices/bus/vme/vme_mzr8300.cpp
+++ b/src/devices/bus/vme/vme_mzr8300.cpp
@@ -171,14 +171,20 @@ void vme_mzr8300_card_device::device_start()
 
 	/* Setup r/w handlers for first SIO in A16 */
 	uint32_t base = 0xFF0000;
-	m_vme->install_device(base + 0, base + 1, // Channel B - Data
-							 read8_delegate(FUNC(z80sio_device::db_r),  subdevice<z80sio_device>("sio0")), write8_delegate(FUNC(z80sio_device::db_w), subdevice<z80sio_device>("sio0")), 0x00ff);
-	m_vme->install_device(base + 2, base + 3, // Channel B - Control
-							 read8_delegate(FUNC(z80sio_device::cb_r),  subdevice<z80sio_device>("sio0")), write8_delegate(FUNC(z80sio_device::cb_w), subdevice<z80sio_device>("sio0")), 0x00ff);
-	m_vme->install_device(base + 4, base + 5, // Channel A - Data
-							 read8_delegate(FUNC(z80sio_device::da_r),  subdevice<z80sio_device>("sio0")), write8_delegate(FUNC(z80sio_device::da_w), subdevice<z80sio_device>("sio0")), 0x00ff);
-	m_vme->install_device(base + 6, base + 7, // Channel A - Control
-							 read8_delegate(FUNC(z80sio_device::ca_r),  subdevice<z80sio_device>("sio0")), write8_delegate(FUNC(z80sio_device::ca_w), subdevice<z80sio_device>("sio0")), 0x00ff);
+	//	m_vme->static_set_custom_spaces(*this);
+
+	m_vme->install_device(vme_device::A16_SC, base + 0, base + 1, // Channel B - Data
+						  read8_delegate(FUNC(z80sio_device::db_r),  subdevice<z80sio_device>("sio0")),
+						  write8_delegate(FUNC(z80sio_device::db_w), subdevice<z80sio_device>("sio0")), 0x00ff);
+	m_vme->install_device(vme_device::A16_SC, base + 2, base + 3, // Channel B - Control
+						  read8_delegate(FUNC(z80sio_device::cb_r),  subdevice<z80sio_device>("sio0")),
+						  write8_delegate(FUNC(z80sio_device::cb_w), subdevice<z80sio_device>("sio0")), 0x00ff);
+	m_vme->install_device(vme_device::A16_SC, base + 4, base + 5, // Channel A - Data
+						  read8_delegate(FUNC(z80sio_device::da_r),  subdevice<z80sio_device>("sio0")),
+						  write8_delegate(FUNC(z80sio_device::da_w), subdevice<z80sio_device>("sio0")), 0x00ff);
+	m_vme->install_device(vme_device::A16_SC, base + 6, base + 7, // Channel A - Control
+						  read8_delegate(FUNC(z80sio_device::ca_r),  subdevice<z80sio_device>("sio0")),
+						  write8_delegate(FUNC(z80sio_device::ca_w), subdevice<z80sio_device>("sio0")), 0x00ff);
 }
 
 void vme_mzr8300_card_device::device_reset()

--- a/src/mame/drivers/fccpu20.cpp
+++ b/src/mame/drivers/fccpu20.cpp
@@ -94,7 +94,10 @@ cpu20_state(const machine_config &mconfig, device_type type, const char *tag)
 		: driver_device (mconfig, type, tag) 
 	{
 	}
+	virtual void machine_start () override { LOGSETUP("%s\n", FUNCNAME); }
+//	virtual void machine_reset () override;
 
+	DECLARE_DRIVER_INIT(cpu20)		{ LOGSETUP("%s\n", FUNCNAME); }
 	DECLARE_DRIVER_INIT(cpu21s)		{ LOGSETUP("%s\n", FUNCNAME); }
 	DECLARE_DRIVER_INIT(cpu21)		{ LOGSETUP("%s\n", FUNCNAME); }
 	DECLARE_DRIVER_INIT(cpu21a)		{ LOGSETUP("%s\n", FUNCNAME); }
@@ -139,37 +142,37 @@ SLOT_INTERFACE_END
 /* Machine configurations */
 MACHINE_CONFIG_START (cpu20, cpu20_state)
 	MCFG_VME_DEVICE_ADD("vme")
-	MCFG_VME_SLOT_ADD ("vme", "slot1", cpu20_vme_cards, "fccpu20")
+	MCFG_VME_SLOT_ADD ("vme", 1, cpu20_vme_cards, "fccpu20")
 MACHINE_CONFIG_END
 
 MACHINE_CONFIG_START (cpu21s, cpu20_state)
 	MCFG_VME_DEVICE_ADD("vme")
-	MCFG_VME_SLOT_ADD ("vme", "slot1", cpu21s_vme_cards, "fccpu21s")
+	MCFG_VME_SLOT_ADD ("vme", 1, cpu21s_vme_cards, "fccpu21s")
 MACHINE_CONFIG_END
 
 MACHINE_CONFIG_START (cpu21, cpu20_state)
 	MCFG_VME_DEVICE_ADD("vme")
-	MCFG_VME_SLOT_ADD ("vme", "slot1", cpu21_vme_cards, "fccpu21")
+	MCFG_VME_SLOT_ADD ("vme", 1, cpu21_vme_cards, "fccpu21")
 MACHINE_CONFIG_END
 
 MACHINE_CONFIG_START (cpu21a, cpu20_state)
 	MCFG_VME_DEVICE_ADD("vme")
-	MCFG_VME_SLOT_ADD ("vme", "slot1", cpu21a_vme_cards, "fccpu21a")
+	MCFG_VME_SLOT_ADD ("vme", 1, cpu21a_vme_cards, "fccpu21a")
 MACHINE_CONFIG_END
 
 MACHINE_CONFIG_START (cpu21ya, cpu20_state)
 	MCFG_VME_DEVICE_ADD("vme")
-	MCFG_VME_SLOT_ADD ("vme", "slot1", cpu21ya_vme_cards, "fccpu21ya")
+	MCFG_VME_SLOT_ADD ("vme", 1, cpu21ya_vme_cards, "fccpu21ya")
 MACHINE_CONFIG_END
 
 MACHINE_CONFIG_START (cpu21b, cpu20_state)
 	MCFG_VME_DEVICE_ADD("vme")
-	MCFG_VME_SLOT_ADD ("vme", "slot1", cpu21b_vme_cards, "fccpu21b")
+	MCFG_VME_SLOT_ADD ("vme", 1, cpu21b_vme_cards, "fccpu21b")
 MACHINE_CONFIG_END
 
 MACHINE_CONFIG_START (cpu21yb, cpu20_state)
 	MCFG_VME_DEVICE_ADD("vme")
-	MCFG_VME_SLOT_ADD ("vme", "slot1", cpu21yb_vme_cards, "fccpu21yb")
+	MCFG_VME_SLOT_ADD ("vme", 1, cpu21yb_vme_cards, "fccpu21yb")
 MACHINE_CONFIG_END
 
 /* ROM configurations */

--- a/src/mame/drivers/fccpu30.cpp
+++ b/src/mame/drivers/fccpu30.cpp
@@ -657,7 +657,7 @@ static MACHINE_CONFIG_START (cpu30, cpu30_state)
 	MCFG_NVRAM_ADD_0FILL("nvram")
 
 	MCFG_VME_DEVICE_ADD("vme")
-	MCFG_VME_SLOT_ADD ("vme", "slot1", fccpu30_vme_cards, nullptr)
+	MCFG_VME_SLOT_ADD ("vme", 1, fccpu30_vme_cards, nullptr)
 	/* Terminal Port config */
 	/* Force CPU30 series of boards has up to four serial ports, p1-p4, the FGA boot uses p4 as console and subsequent
 	   firmware uses p1 as console and in an operating system environment there may be user login shells on the other.

--- a/src/mame/drivers/force68k.cpp
+++ b/src/mame/drivers/force68k.cpp
@@ -492,7 +492,7 @@ static MACHINE_CONFIG_START (fccpu1, force68k_state)
 
 	// VME interface
 	MCFG_VME_DEVICE_ADD("vme")
-	MCFG_VME_SLOT_ADD ("vme", "slot1", fccpu1_vme_cards, nullptr)
+	MCFG_VME_SLOT_ADD ("vme", 1, fccpu1_vme_cards, nullptr)
 MACHINE_CONFIG_END
 
 #if 0 /*

--- a/src/mame/drivers/hk68v10.cpp
+++ b/src/mame/drivers/hk68v10.cpp
@@ -348,7 +348,7 @@ static MACHINE_CONFIG_START (hk68v10, hk68v10_state)
 	MCFG_RS232_CTS_HANDLER (DEVWRITELINE ("scc", scc8530_device, ctsa_w))
 
 	MCFG_VME_DEVICE_ADD("vme")
-	MCFG_VME_SLOT_ADD ("vme", "slot1", hk68_vme_cards, nullptr)
+	MCFG_VME_SLOT_ADD ("vme", 1, hk68_vme_cards, nullptr)
 MACHINE_CONFIG_END
 
 /* ROM definitions */

--- a/src/mame/drivers/miniforce.cpp
+++ b/src/mame/drivers/miniforce.cpp
@@ -10,34 +10,34 @@
  * required to start the work with this driver.
  *
  * +=============================================================================================================================+
- * |  CPU-20   |     |     |     |     |     |     |WFC-1|     |  SYS68K/PWR-09A | SYS68K/WFMOD-50                               |
- * |           |     |     |     |     |     |     |     |     |                 |                                               |
- * | RST       |     |     |     |     |     |     |O RUN|     |                 |                                               |
- * | ABT       |     |     |     |     |     |     | R/L |     |O +5v            |+---------------------------------------------+|
- * |           |     |     |     |     |     |     |O LOC|     |O +12v           ||                                             ||
- * |O RUN O RUN|     |     |     |     |     |     |O ERR|     |O -12v           ||                                             ||
- * |O HLT      |     |     |     |     |     |     |O BSY|     |O ON             ||                                             ||
- * |O BM       |     |     |     |     |     |     |     |     |                 ||                                             ||
- * |           |     |     |     |     |     |     |     |     |                 |+---------------------------------------------+|
- * |O FLM O SL0|     |     |     |     |     |     |     |     |                 || FDD                                         ||
- * |O EPR O SL1|     |     |     |     |     |     |     |     |                 ||                                             ||
- * |O 2WS      |     |     |     |     |     |     |     |     |    +-------+    ||                                             ||
- * |O 4WS      |     |     |     |     |     |     |     |     |    |   o   |PWR ||                                             ||
- * |O 6WS      |     |     |     |     |     |     |     |     |    |       |    |+---------------------------------------------+|
- * |O 8WS      |     |     |     |     |     |     |     |     |    +-------+    |                                               |
- * |O12WS      |     |     |     |     |     |     |     |     |                 |                                               |
- * |O14WS      |     |     |     |     |     |     |     |     |                 |+---------------------------------------------+|
- * |           |     |     |     |     |     |     |     |     |                 || HDD                                         ||
- * | CSH       |     |     |     |     |     |     |     |     |                 ||                                             ||
- * | R/M       |     |     |     |     |     |     |     |     |                 ||                                             ||
- * |           |     |     |     |     |     |     |     |     |                 ||                                             ||
- * |  o        |     |     |     |     |     |     |     |     |                 |+---------------------------------------------+|
- * |  o        |     |     |     |     |     |     |     |     |                 ||                                             ||
- * |  o        |     |     |     |     |     |     |     |     |                 ||                                             ||
- * |  o        |     |     |     |     |     |     |     |     |                 ||                                             ||
+ * |CPU  |SRAM |     |     |     |     |     |     |WFC-1|     |  SYS68K/PWR-09A | SYS68K/WFMOD-50                               |
+ * |-21  | -22 |     |     |     |     |     |     |     |     |                 |                                               |
+ * | RST |     |     |     |     |     |     |     |O RUN|     |                 |                                               |
+ * | ABT |     |     |     |     |     |     |     | R/L |     |O +5v            |+---------------------------------------------+|
+ * |     |     |     |     |     |     |     |     |O LOC|     |O +12v           ||                                             ||
+ * |O RUN|O RUN|     |     |     |     |     |     |O ERR|     |O -12v           ||                                             ||
+ * |O HLT|     |     |     |     |     |     |     |O BSY|     |O ON             ||                                             ||
+ * |O BM |     |     |     |     |     |     |     |     |     |                 ||                                             ||
+ * |     |     |     |     |     |     |     |     |     |     |                 |+---------------------------------------------+|
+ * |O FLM|O SL0|     |     |     |     |     |     |     |     |                 || FDD                                         ||
+ * |O EPR|O SL1|     |     |     |     |     |     |     |     |                 ||                                             ||
+ * |O 2WS|     |     |     |     |     |     |     |     |     |    +-------+    ||                                             ||
+ * |O 4WS|     |     |     |     |     |     |     |     |     |    |   o   |PWR ||                                             ||
+ * |O 6WS|     |     |     |     |     |     |     |     |     |    |       |    |+---------------------------------------------+|
+ * |O 8WS|     |     |     |     |     |     |     |     |     |    +-------+    |                                               |
+ * |O12WS|     |     |     |     |     |     |     |     |     |                 |                                               |
+ * |O14WS|     |     |     |     |     |     |     |     |     |                 |+---------------------------------------------+|
+ * |     |     |     |     |     |     |     |     |     |     |                 || HDD                                         ||
+ * | CSH |     |     |     |     |     |     |     |     |     |                 ||                                             ||
+ * | R/M |     |     |     |     |     |     |     |     |     |                 ||                                             ||
+ * |     |     |     |     |     |     |     |     |     |     |                 ||                                             ||
+ * |  o  |     |     |     |     |     |     |     |     |     |                 |+---------------------------------------------+|
+ * |  o  |     |     |     |     |     |     |     |     |     |                 ||                                             ||
+ * |  o  |     |     |     |     |     |     |     |     |     |                 ||                                             ||
+ * |  o  |     |     |     |     |     |     |     |     |     |                 ||                                             ||
  * | RS232/422 |     |     |     |     |     |     |     |     |                 ||                                             ||
- * | P4    P3  |     |     |     |     |     |     |     |     |                 |+---------------------------------------------+|
- * |           |     |     |     |     |     |     |     |     |                 |                                               |
+ * | P4  | P3  |     |     |     |     |     |     |     |     |                 |+---------------------------------------------+|
+ * |     |     |     |     |     |     |     |     |     |     |                 |                                               |
  * |SLOT1|SLOT2|SLOT3|SLOT4|SLOT5|SLOT6|SLOT7|SLOT7|SLOT9|     |                 |                                               |
  * +=============================================================================================================================+
  *
@@ -100,6 +100,7 @@
 #include "bus/vme/vme_fccpu20.h"
 #include "bus/vme/vme_fcisio.h"
 #include "bus/vme/vme_fcscsi.h"
+#include "bus/vme/vme_mzr8300.h"
 #include "machine/clock.h"
 
 #define LOG_GENERAL 0x01
@@ -164,7 +165,7 @@ static INPUT_PORTS_START (miniforce)
 INPUT_PORTS_END
 
 static SLOT_INTERFACE_START(miniforce_vme_cards)
-	SLOT_INTERFACE("fccpu20", VME_FCCPU20)
+	SLOT_INTERFACE("fccpu21", VME_FCCPU21)
 	SLOT_INTERFACE("fcisio", VME_FCISIO1)
 	SLOT_INTERFACE("fcscsi", VME_FCSCSI1)
 SLOT_INTERFACE_END
@@ -173,17 +174,17 @@ SLOT_INTERFACE_END
  * Machine configuration
  */
 MACHINE_CONFIG_START (miniforce, miniforce_state)
-//  MCFG_CPU_PROGRAM_MAP (miniforce_mem)
+//	MCFG_CPU_PROGRAM_MAP (miniforce_mem)
 	MCFG_VME_DEVICE_ADD("vme")
-	MCFG_VME_SLOT_ADD ("vme", "slot1", miniforce_vme_cards, "fccpu20")
-	MCFG_VME_SLOT_ADD ("vme", "slot2", miniforce_vme_cards, nullptr)
-	MCFG_VME_SLOT_ADD ("vme", "slot3", miniforce_vme_cards, nullptr)
-	MCFG_VME_SLOT_ADD ("vme", "slot4", miniforce_vme_cards, nullptr)
-	MCFG_VME_SLOT_ADD ("vme", "slot5", miniforce_vme_cards, nullptr)
-	MCFG_VME_SLOT_ADD ("vme", "slot6", miniforce_vme_cards, nullptr)
-	MCFG_VME_SLOT_ADD ("vme", "slot7", miniforce_vme_cards, nullptr)
-	MCFG_VME_SLOT_ADD ("vme", "slot8", miniforce_vme_cards, nullptr)
-	MCFG_VME_SLOT_ADD ("vme", "slot9", miniforce_vme_cards, nullptr)
+	MCFG_VME_SLOT_ADD ("vme", 1, miniforce_vme_cards, "fccpu21")
+	MCFG_VME_SLOT_ADD ("vme", 2, miniforce_vme_cards, nullptr)
+	MCFG_VME_SLOT_ADD ("vme", 3, miniforce_vme_cards, nullptr)
+	MCFG_VME_SLOT_ADD ("vme", 4, miniforce_vme_cards, nullptr)
+	MCFG_VME_SLOT_ADD ("vme", 5, miniforce_vme_cards, nullptr)
+	MCFG_VME_SLOT_ADD ("vme", 6, miniforce_vme_cards, nullptr)
+	MCFG_VME_SLOT_ADD ("vme", 7, miniforce_vme_cards, nullptr)
+	MCFG_VME_SLOT_ADD ("vme", 8, miniforce_vme_cards, nullptr)
+	MCFG_VME_SLOT_ADD ("vme", 9, miniforce_vme_cards, nullptr)
 MACHINE_CONFIG_END
 
 ROM_START(miniforce)

--- a/src/mame/drivers/mvme147.cpp
+++ b/src/mame/drivers/mvme147.cpp
@@ -649,7 +649,7 @@ static MACHINE_CONFIG_START (mvme147, mvme147_state)
 	MCFG_CPU_ADD ("maincpu", M68030, XTAL_16MHz)
 	MCFG_CPU_PROGRAM_MAP (mvme147_mem)
 	MCFG_VME_DEVICE_ADD("vme")
-	MCFG_VME_SLOT_ADD ("vme", "slot1", mvme147_vme_cards, nullptr)
+	MCFG_VME_SLOT_ADD ("vme", 1, mvme147_vme_cards, nullptr)
 
 	MCFG_M48T02_ADD("m48t18") /* t08 differs only in accepted voltage levels compared to t18 */
 

--- a/src/mame/drivers/mzr8105.cpp
+++ b/src/mame/drivers/mzr8105.cpp
@@ -207,7 +207,8 @@ MACHINE_CONFIG_START (mzr8105, mzr8105_state)
 	MCFG_CPU_ADD ("maincpu", M68000, XTAL_10MHz)
 	MCFG_CPU_PROGRAM_MAP (mzr8105_mem)
 	MCFG_VME_DEVICE_ADD("vme")
-	MCFG_VME_SLOT_ADD ("vme", "slot1", mzr8105_vme_cards, nullptr)
+	MCFG_VME_BUS_OWNER_SPACES()
+	MCFG_VME_SLOT_ADD ("vme", 1, mzr8105_vme_cards, "mzr8300")
 MACHINE_CONFIG_END
 
 /* ROM definitions */


### PR DESCRIPTION
…c features

The VME bus interface now allocate its own  memory space default. This can be turned off in the case of computers with an internal VME bus, performance reasons or if there is no risk of more complicated use cases involving address modifiers or need for daisy chaining of VME bus signals. The slot naming is now hidden and replaced by a slot number in the MCFG interface in order to be used for daisy chaining and also to warn about real estate problems. 