### PR TITLE
hp9845: implemented correct aspect of alpha & graphic video modes

### DIFF
--- a/src/mame/drivers/hp9845.cpp
+++ b/src/mame/drivers/hp9845.cpp
@@ -32,6 +32,8 @@
 #include "includes/hp9845.h"
 #include "softlist.h"
 #include "bus/hp_optroms/hp_optrom.h"
+#include "hp9845b.lh"
+#include "render.h"
 
 #define BIT_MASK(n) (1U << (n))
 
@@ -495,8 +497,12 @@ void hp9845b_state::set_graphic_mode(bool graphic)
 				logerror("GS=%d\n" , graphic);
 				if (m_graphic_sel) {
 						m_screen->configure(GVIDEO_HTOTAL , GVIDEO_VTOTAL , rectangle(GVIDEO_HBEND , GVIDEO_HBSTART - 1 , GVIDEO_VBEND , GVIDEO_VBSTART - 1) , HZ_TO_ATTOSECONDS(VIDEO_PIXEL_CLOCK) * GVIDEO_HTOTAL * GVIDEO_VTOTAL);
+						// Set graphic mode view (1.23:1 aspect ratio)
+						machine().render().first_target()->set_view(1);
 				} else {
 						m_screen->configure(VIDEO_HTOTAL , VIDEO_VTOTAL , rectangle(0 , VIDEO_HBSTART - 1 , 0 , VIDEO_ACTIVE_SCANLINES - 1) , HZ_TO_ATTOSECONDS(VIDEO_PIXEL_CLOCK) * VIDEO_HTOTAL * VIDEO_VTOTAL);
+						// Set alpha mode view (1.92:1 aspect ratio)
+						machine().render().first_target()->set_view(0);
 				}
 		}
 }
@@ -1073,6 +1079,8 @@ static MACHINE_CONFIG_START( hp9845b, hp9845b_state )
 
 	MCFG_TIMER_DRIVER_ADD_SCANLINE("scantimer", hp9845b_state, scanline_timer, "screen", 0, 1)
 		MCFG_TIMER_DRIVER_ADD("gv_timer", hp9845b_state, gv_timer)
+
+	MCFG_DEFAULT_LAYOUT(layout_hp9845b)
 
 	// Actual keyboard refresh rate should be KEY_SCAN_OSCILLATOR / 128 (2560 Hz)
 	MCFG_TIMER_DRIVER_ADD_PERIODIC("kb_timer" , hp9845b_state , kb_scan , attotime::from_hz(100))

--- a/src/mame/layout/hp9845b.lay
+++ b/src/mame/layout/hp9845b.lay
@@ -1,0 +1,16 @@
+<?xml version="1.0"?>
+<mamelayout version="2">
+  <!-- All dimensions are in 0.01 inch units -->
+	<view name="Text mode (1.92:1)">
+	  <bounds left="0" top="0" right="930" bottom="640" />
+		<screen index="0">
+			<bounds left="0" top="78" right="930" bottom="562" />
+		</screen>
+	</view>
+	<view name="Graphic mode (1.23:1)">
+	  <bounds left="0" top="0" right="930" bottom="640" />
+		<screen index="0">
+			<bounds left="70" top="0" right="860" bottom="640" />
+		</screen>
+	</view>
+</mamelayout>


### PR DESCRIPTION
Hi,

this PR implements the correct aspect ratios of text & graphic modes of HP9845B and their relative sizes on the screen.
See my post about this: [MAME forum](http://forums.bannister.org/ubbthreads.php?ubb=showflat&Number=108376)
Thanks.
--F.Ulivi
