### PR TITLE
Update exp.h

### DIFF
--- a/src/devices/bus/coleco/exp.h
+++ b/src/devices/bus/coleco/exp.h
@@ -87,7 +87,7 @@ protected:
 	virtual bool is_creatable() const override { return 0; }
 	virtual bool must_be_loaded() const override { return 0; }
 	virtual bool is_reset_on_load() const override { return 1; }
-	virtual const char *image_interface() const override { return ":coleco_cart"; }
+	virtual const char *image_interface() const override { return "coleco_cart"; }
 	virtual const char *file_extensions() const override { return "rom,col,bin"; }
 
 	// slot interface overrides


### PR DESCRIPTION
Removed colon (":") from image_interface value that was preventing some front-ends, such as QMC2, from being able to launch ColecoVision software from the software list (the software rom itself ended up being omitted so it just booted the main bios, like starting a real CV without a game inserted.)