### PR TITLE
Fix scanout of mc6845

### DIFF
--- a/src/devices/video/mc6845.cpp
+++ b/src/devices/video/mc6845.cpp
@@ -988,7 +988,7 @@ uint32_t mc6845_device::screen_update(screen_device &screen, bitmap_rgb32 &bitma
 		}
 
 		/* for each row in the visible region */
-		for (uint16_t y = cliprect.min_y; y <= cliprect.max_y; y++)
+		for (uint16_t y = cliprect.min_y; y <= cliprect.max_y && y <= m_max_visible_y; y++)
 		{
 			this->draw_scanline(y, bitmap, cliprect);
 		}


### PR DESCRIPTION
The device should not try to scan-out more lines than has been programmed into the 'visible' register.