### PR TITLE
UI: Add the ability to select different tilemap categories

### DIFF
--- a/src/emu/tilemap.cpp
+++ b/src/emu/tilemap.cpp
@@ -1456,12 +1456,16 @@ void tilemap_t::draw_roz_core(screen_device &screen, _BitmapClass &destbitmap, c
 //  rowscroll and with fixed parameters
 //-------------------------------------------------
 
-void tilemap_t::draw_debug(screen_device &screen, bitmap_rgb32 &dest, u32 scrollx, u32 scrolly)
+void tilemap_t::draw_debug(screen_device &screen, bitmap_rgb32 &dest, u32 scrollx, u32 scrolly, u32 flags)
 {
 	// set up for the blit, using hard-coded parameters (no priority, etc)
 	blit_parameters blit;
 	bitmap_ind8 dummy_priority;
-	configure_blit_parameters(blit, dummy_priority, dest.cliprect(), TILEMAP_DRAW_OPAQUE | TILEMAP_DRAW_ALL_CATEGORIES, 0, 0xff);
+
+	// draw everything
+	flags |= TILEMAP_DRAW_OPAQUE;
+
+	configure_blit_parameters(blit, dummy_priority, dest.cliprect(), flags, 0, 0xff);
 
 	// compute the effective scroll positions
 	scrollx = m_width  - scrollx % m_width;

--- a/src/emu/tilemap.h
+++ b/src/emu/tilemap.h
@@ -558,7 +558,7 @@ public:
 	void draw(screen_device &screen, bitmap_rgb32 &dest, const rectangle &cliprect, u32 flags, u8 priority = 0, u8 priority_mask = 0xff);
 	void draw_roz(screen_device &screen, bitmap_ind16 &dest, const rectangle &cliprect, u32 startx, u32 starty, int incxx, int incxy, int incyx, int incyy, bool wraparound, u32 flags, u8 priority = 0, u8 priority_mask = 0xff);
 	void draw_roz(screen_device &screen, bitmap_rgb32 &dest, const rectangle &cliprect, u32 startx, u32 starty, int incxx, int incxy, int incyx, int incyy, bool wraparound, u32 flags, u8 priority = 0, u8 priority_mask = 0xff);
-	void draw_debug(screen_device &screen, bitmap_rgb32 &dest, u32 scrollx, u32 scrolly);
+	void draw_debug(screen_device &screen, bitmap_rgb32 &dest, u32 scrollx, u32 scrolly, u32 flags = TILEMAP_DRAW_ALL_CATEGORIES);
 
 	// mappers
 	// scan in row-major order with optional flipping

--- a/src/frontend/mame/ui/viewgfx.cpp
+++ b/src/frontend/mame/ui/viewgfx.cpp
@@ -88,6 +88,7 @@ struct ui_gfx_state
 		int   yoffs;                // current Y offset
 		int   zoom;                 // zoom factor
 		uint8_t rotate;               // current rotation (orientation) value
+		uint32_t flags;				// render flags
 	} tilemap;
 };
 
@@ -158,6 +159,7 @@ void ui_gfx_init(running_machine &machine)
 
 	// set up the tilemap state
 	state->tilemap.rotate = rotate;
+	state->tilemap.flags = TILEMAP_DRAW_ALL_CATEGORIES;
 }
 
 
@@ -1074,7 +1076,7 @@ static void tilemap_handler(mame_ui_manager &mui, render_container &container, u
 
 	// figure out the title
 	std::ostringstream title_buf;
-	util::stream_format(title_buf, "TILEMAP %d/%d", state.tilemap.which, mui.machine().tilemap().count() - 1);
+	util::stream_format(title_buf, "TILEMAP %d/%d", state.tilemap.which + 1, mui.machine().tilemap().count());
 
 	// if the mouse pointer is over a tile, add some info about its coordinates and color
 	int32_t mouse_target_x, mouse_target_y;
@@ -1104,6 +1106,9 @@ static void tilemap_handler(mame_ui_manager &mui, render_container &container, u
 	}
 	else
 		util::stream_format(title_buf, " %dx%d OFFS %d,%d", tilemap->width(), tilemap->height(), state.tilemap.xoffs, state.tilemap.yoffs);
+
+	if (state.tilemap.flags != TILEMAP_DRAW_ALL_CATEGORIES)
+		util::stream_format(title_buf, " CAT %d", state.tilemap.flags);
 
 	// expand the outer box to fit the title
 	const std::string title = title_buf.str();
@@ -1190,6 +1195,31 @@ static void tilemap_handle_keys(running_machine &machine, ui_gfx_state &state, i
 		state.bitmap_dirty = true;
 	}
 
+	// handle flags (category)
+	if (machine.ui_input().pressed(IPT_UI_PAGE_UP) && state.tilemap.flags != TILEMAP_DRAW_ALL_CATEGORIES)
+	{
+		if (state.tilemap.flags > 0)
+		{
+			state.tilemap.flags--;
+			machine.popmessage("Category = %d", state.tilemap.flags);
+		}
+		else
+		{
+			state.tilemap.flags = TILEMAP_DRAW_ALL_CATEGORIES;
+			machine.popmessage("Category All");
+		}
+		state.bitmap_dirty = true;
+	}
+	if (machine.ui_input().pressed(IPT_UI_PAGE_DOWN) && (state.tilemap.flags < TILEMAP_DRAW_CATEGORY_MASK || (state.tilemap.flags == TILEMAP_DRAW_ALL_CATEGORIES)))
+	{
+		if (state.tilemap.flags == TILEMAP_DRAW_ALL_CATEGORIES)
+			state.tilemap.flags = 0;
+		else
+			state.tilemap.flags++;
+		state.bitmap_dirty = true;
+		machine.popmessage("Category = %d", state.tilemap.flags);
+	}
+
 	// handle navigation (up,down,left,right), taking orientation into account
 	int step = 8; // this may be applied more than once if multiple directions are pressed
 	if (machine.input().code_pressed(KEYCODE_LSHIFT)) step = 1;
@@ -1251,7 +1281,7 @@ static void tilemap_update_bitmap(running_machine &machine, ui_gfx_state &state,
 		std::swap(width, height);
 
 	// realloc the bitmap if it is too small
-	if (state.bitmap == nullptr || state.texture == nullptr || state.bitmap->width() != width || state.bitmap->height() != height)
+	if (state.bitmap_dirty || state.bitmap == nullptr || state.texture == nullptr || state.bitmap->width() != width || state.bitmap->height() != height)
 	{
 		// free the old stuff
 		machine.render().texture_free(state.texture);
@@ -1270,7 +1300,7 @@ static void tilemap_update_bitmap(running_machine &machine, ui_gfx_state &state,
 	if (state.bitmap_dirty)
 	{
 		tilemap_t *tilemap = machine.tilemap().find(state.tilemap.which);
-		tilemap->draw_debug(*machine.first_screen(), *state.bitmap, state.tilemap.xoffs, state.tilemap.yoffs);
+		tilemap->draw_debug(*machine.first_screen(), *state.bitmap, state.tilemap.xoffs, state.tilemap.yoffs, state.tilemap.flags);
 
 		// reset the texture to force an update
 		state.texture->set_bitmap(*state.bitmap, state.bitmap->cliprect(), TEXFORMAT_RGB32);


### PR DESCRIPTION
This allows you to select different tilemap categories in the
built-in tilemap viewer. The default is to render all categories
(same as before), but you can select to render only a specific
tilemap category with the PAGE_UP and PAGE_DOWN keys.