### PR TITLE
Fix softwarelist cart memory cheats

### DIFF
--- a/src/emu/machine.cpp
+++ b/src/emu/machine.cpp
@@ -264,6 +264,7 @@ void running_machine::start()
 	save().register_presave(save_prepost_delegate(FUNC(running_machine::presave_all_devices), this));
 	start_all_devices();
 	save().register_postload(save_prepost_delegate(FUNC(running_machine::postload_all_devices), this));
+	manager().load_cheatfiles(*this);
 
 	// if we're coming in with a savegame request, process it now
 	const char *savegame = options().state();

--- a/src/emu/main.h
+++ b/src/emu/main.h
@@ -95,6 +95,7 @@ public:
 
 	virtual ui_manager* create_ui(running_machine& machine) { return nullptr;  }
 	virtual void create_custom(running_machine& machine) { }
+	virtual void load_cheatfiles(running_machine& machine) { }
 	virtual void ui_initialize(running_machine& machine) { }
 
 	virtual void update_machine() { }

--- a/src/frontend/mame/mame.cpp
+++ b/src/frontend/mame/mame.cpp
@@ -299,7 +299,10 @@ void mame_machine_manager::create_custom(running_machine& machine)
 
 	// start favorite manager
 	m_favorite = std::make_unique<favorite_manager>(machine, m_ui->options());
+}
 
+void mame_machine_manager::load_cheatfiles(running_machine& machine)
+{
 	// set up the cheat engine
 	m_cheat = std::make_unique<cheat_manager>(machine);
 }

--- a/src/frontend/mame/mame.h
+++ b/src/frontend/mame/mame.h
@@ -51,6 +51,8 @@ public:
 	virtual ui_manager* create_ui(running_machine& machine) override;
 
 	virtual void create_custom(running_machine& machine) override;
+	
+	virtual void load_cheatfiles(running_machine& machine) override;
 
 	virtual void ui_initialize(running_machine& machine) override;
 


### PR DESCRIPTION
Moved the initial cheat file loading to later in the start up process after the software list cart_rom has been loaded. Otherwise it will not load the cheats as the cart_rom will not exist.
Eg. mame coleco qbert