### PR TITLE
Fix Super19 version of Heath H19.

### DIFF
--- a/src/mame/drivers/h19.cpp
+++ b/src/mame/drivers/h19.cpp
@@ -20,10 +20,6 @@
 	- speed up emulation
 	- update SW401 baud rate options for Watz ROM
 	- update SW401 & SW402 definitions for Super-19 ROM
-	- SuperSet support
-	   - connect 8250 modem control lines to bank-switching for
-	     character generation
-	   - properly handle 32k ROM with only 16K of data. 
 
 ****************************************************************************/
 /***************************************************************************
@@ -158,26 +154,6 @@ static ADDRESS_MAP_START(h19_mem, AS_PROGRAM, 8, h19_state)
 	AM_RANGE(0x4000, 0x4100) AM_MIRROR(0x3e00) AM_RAM
 	AM_RANGE(0xc000, 0xc7ff) AM_MIRROR(0x3800) AM_RAM AM_SHARE("videoram")
 ADDRESS_MAP_END
-
-//#define APPROACH_1
-//#define APPROACH_2
-#if defined(APPROACH_1)
-static ADDRESS_MAP_START(ssh19_mem, AS_PROGRAM, 8, h19_state)
-	ADDRESS_MAP_UNMAP_HIGH
-	AM_RANGE(0x0000, 0x3fff) AM_ROM
-	AM_RANGE(0x4000, 0x4100) AM_MIRROR(0x3e00) AM_RAM
-	AM_RANGE(0xc000, 0xc7ff) AM_MIRROR(0x3800) AM_RAM AM_SHARE("videoram")
-ADDRESS_MAP_END
-
-#elif defined(APPROACH_2)
-static ADDRESS_MAP_START(ssh19_mem, AS_PROGRAM, 8, h19_state)
-	ADDRESS_MAP_UNMAP_HIGH
-        AM_RANGE(0x0000, 0x1fff) AM_ROM AM_REGION("roms", 0x2000)
-        AM_RANGE(0x2000, 0x3fff) AM_ROM AM_REGION("roms", 0x6000)
-	AM_RANGE(0x4000, 0x4100) AM_MIRROR(0x3e00) AM_RAM
-	AM_RANGE(0xc000, 0xc7ff) AM_MIRROR(0x3800) AM_RAM AM_SHARE("videoram")
-ADDRESS_MAP_END
-#endif
 
 static ADDRESS_MAP_START( h19_io, AS_IO, 8, h19_state)
 	ADDRESS_MAP_UNMAP_HIGH
@@ -585,12 +561,6 @@ static MACHINE_CONFIG_START( h19, h19_state )
 	MCFG_SOUND_ROUTE(ALL_OUTPUTS, "mono", 1.00)
 MACHINE_CONFIG_END
 
-#if defined(APPROACH_1) || defined(APPROACH_2)
-static MACHINE_CONFIG_DERIVED( ssh19, h19 )
-	MCFG_CPU_PROGRAM_MAP(ssh19_mem)
-MACHINE_CONFIG_END
-#endif
-
 /* ROM definition */
 ROM_START( h19 )
 	ROM_REGION( 0x10000, "maincpu", ROMREGION_ERASEFF )
@@ -633,48 +603,10 @@ ROM_START( watz19 )
 	ROM_LOAD( "keybd.bin", 0x0000, 0x0800, CRC(58dc8217) SHA1(1b23705290bdf9fc6342065c6a528c04bff67b13))
 ROM_END
 
-ROM_START( ssh19 ) // Superset for H19
-#if defined(APPROACH_1)
-	// reserve an extra 16k outside of addressable space to hide the empty blocks of ram
-	ROM_REGION( 0x14000, "maincpu", ROMREGION_ERASEFF )
-	// Superset ROM - although the ROM is 32K, only 16K is accessible - hide the first 8k
-	ROM_LOAD( "27256_101-402_superset_code.bin", 0x10000, 0x2000, CRC(a6896076) SHA1(a4e2d25028dc75a665c3f5a830a4e8cdecbd481c))
-	// load the 2nd 8k into low memory
-	ROM_CONTINUE(0x00000, 0x2000)
-	// hide the 3rd 8k
-	ROM_CONTINUE(0x12000, 0x2000)
-	// load the last 8k
-	ROM_CONTINUE(0x02000, 0x2000)
-#elif defined(APPROACH_2)
-        ROM_REGION( 0x10000, "roms", ROMREGION_ERASEFF )
-        // Superset ROM - although the ROM is 32K, only 16K is accessible - hide the first 8k
-        ROM_LOAD( "27256_101-402_superset_code.bin", 0x0000, 0x8000, CRC(a6896076) SHA1(a4e2d25028dc75a665c3f5a830a4e8cdecbd481c))
-#else
-	ROM_REGION( 0x10000, "maincpu", ROMREGION_ERASEFF )
-	// Superset ROM - TODO although the ROM is 32K, only 16K is accessible
-	ROM_LOAD( "27256_101-402_superset_code.bin", 0x0000, 0x8000, CRC(a6896076) SHA1(a4e2d25028dc75a665c3f5a830a4e8cdecbd481c))
-#endif
-
-	ROM_REGION( 0x0800, "chargen", 0 )
-	// Superset font - 32k
-	// TODO: connect the output lines from the 8250(OUT1,OUT2,DTR,RTS) to  control bank switching of this ROM and
-	//       select the proper character set
-	ROM_LOAD( "27256_101-431_superset_font.bin", 0x0000, 0x0800, CRC(4c0688f6) SHA1(be6059913420ad66f5c839d619fdcb164ffae85a))
-
-	ROM_REGION( 0x1000, "keyboard", 0 )
-	// Original dump
-	ROM_LOAD( "2716_101-422_superset_kbd.bin", 0x0000, 0x0800, CRC(549d15b3) SHA1(981962e5e05bbdc5a66b0e86870853ce5596e877))
-ROM_END
-
 
 /*    YEAR  NAME    PARENT  COMPAT    MACHINE    INPUT          INIT    COMPANY      FULLNAME          FLAGS */
 COMP( 1979, h19,     0,       0,    h19,    h19, driver_device,  0,     "Heath Inc", "Heathkit H-19", 0 )
 /*  TODO - verify the years for these third-party replacement ROMs. */
 COMP( 1982, super19, h19,     0,    h19,    h19, driver_device,  0,     "Heath Inc", "Heathkit H-19 w/ Super-19 ROM", 0 )
 COMP( 1982, watz19,  h19,     0,    h19,    h19, driver_device,  0,     "Heath Inc", "Heathkit H-19 w/ Watzman ROM", 0 )
-#if defined(APPROACH_1) || defined(APPROACH_2)
-COMP( 1982, ssh19,   h19,     0,    ssh19,  h19, driver_device,  0,     "Heath Inc", "Heathkit H-19 w/ SuperSet ROM", MACHINE_NOT_WORKING )
-#else
-COMP( 1982, ssh19,   h19,     0,    h19,    h19, driver_device,  0,     "Heath Inc", "Heathkit H-19 w/ SuperSet ROM", MACHINE_NOT_WORKING )
-#endif
 

--- a/src/mame/mame.lst
+++ b/src/mame/mame.lst
@@ -14153,9 +14153,10 @@ gyrussce                        // GX347 (c) 1983 + Centuri license
 venus                           // bootleg
 
 @source:h19.cpp
-h19                             //
-super19                         //
-watz19                          //
+h19                             // Heath H19 (Zenith Z-19)
+super19                         // Super19 replacement ROMS for H19
+watz19                          // Watzman replacement ROMS for H19
+ssh19                           // Superset replacement Roms for H19
 
 @source:h8.cpp
 h8                              //

--- a/src/mame/mame.lst
+++ b/src/mame/mame.lst
@@ -14156,7 +14156,6 @@ venus                           // bootleg
 h19                             // Heath H19 (Zenith Z-19)
 super19                         // Super19 replacement ROMS for H19
 watz19                          // Watzman replacement ROMS for H19
-ssh19                           // Superset replacement Roms for H19
 
 @source:h8.cpp
 h8                              //


### PR DESCRIPTION
Adds the AM_MIRROR settings which the Super19 ROM relied on.  The CRTC ports and the videoram memory were the only ones I saw, which was REQUIRED to get it working, but figured I'd update all the memory and ports to properly reflect the real board in case the ROM used it in other code paths I hadn't tested.

Also added preliminary definitions for the SuperSet ROM, not sure if the current AM_MIRROR options allows a way to properly define how it is configured. My initial attempts to define it, caused run-time crashes. The ROM chip is a 32K chip, of which 16K is used. But the valid data is in the 2nd and 4th 8K blocks of the chip, not the 1st and 3rd. So it would either error with 'mirror touching a set bit' or have the memory reflect the invalid parts of the ROM chip.