### PR TITLE
including "emu.h" from "rs232.h"

### DIFF
--- a/src/devices/bus/rs232/rs232.h
+++ b/src/devices/bus/rs232/rs232.h
@@ -5,6 +5,7 @@
 
 #pragma once
 
+#include "emu.h"
 
 #define MCFG_RS232_PORT_ADD(_tag, _slot_intf, _def_slot) \
 	MCFG_DEVICE_ADD(_tag, RS232_PORT, 0) \


### PR DESCRIPTION
ie15.cpp includes "rs232.h" at the top, which previously assumed that emu.h etc have been included