### PR TITLE
HP9845C driver

### DIFF
--- a/src/devices/bus/hp9845_io/98034.cpp
+++ b/src/devices/bus/hp9845_io/98034.cpp
@@ -18,7 +18,7 @@
 #include "coreutil.h"
 
 // Debugging
-#define VERBOSE 1
+#define VERBOSE 0
 #define LOG(x)  do { if (VERBOSE) logerror x; } while (0)
 
 #define BIT_MASK(n) (1U << (n))

--- a/src/devices/bus/hp9845_io/98034.cpp
+++ b/src/devices/bus/hp9845_io/98034.cpp
@@ -18,7 +18,7 @@
 #include "coreutil.h"
 
 // Debugging
-#define VERBOSE 0
+#define VERBOSE 1
 #define LOG(x)  do { if (VERBOSE) logerror x; } while (0)
 
 #define BIT_MASK(n) (1U << (n))
@@ -102,7 +102,6 @@ void hp98034_io_card::device_start()
 void hp98034_io_card::device_reset()
 {
 	hp9845_io_card_device::device_reset();
-	install_readwrite_handler(read16_delegate(FUNC(hp98034_io_card::reg_r) , this) , write16_delegate(FUNC(hp98034_io_card::reg_w) , this));
 
 	m_idr = 0;
 	m_odr = 0;

--- a/src/devices/bus/hp9845_io/98034.h
+++ b/src/devices/bus/hp9845_io/98034.h
@@ -31,8 +31,8 @@ public:
 	virtual const tiny_rom_entry *device_rom_region() const override;
 	virtual machine_config_constructor device_mconfig_additions() const override;
 
-	DECLARE_READ16_MEMBER(reg_r);
-	DECLARE_WRITE16_MEMBER(reg_w);
+	virtual DECLARE_READ16_MEMBER(reg_r) override;
+	virtual DECLARE_WRITE16_MEMBER(reg_w) override;
 
 	DECLARE_WRITE8_MEMBER(dc_w);
 	DECLARE_READ8_MEMBER(dc_r);

--- a/src/devices/bus/hp9845_io/98035.cpp
+++ b/src/devices/bus/hp9845_io/98035.cpp
@@ -192,7 +192,6 @@ void hp98035_io_card::device_start()
 void hp98035_io_card::device_reset()
 {
 	hp9845_io_card_device::device_reset();
-	install_readwrite_handler(read16_delegate(FUNC(hp98035_io_card::reg_r) , this) , write16_delegate(FUNC(hp98035_io_card::reg_w) , this));
 
 	m_idr_full = false;
 	m_idr = 0;

--- a/src/devices/bus/hp9845_io/98035.h
+++ b/src/devices/bus/hp9845_io/98035.h
@@ -33,8 +33,8 @@ public:
 	virtual const tiny_rom_entry *device_rom_region() const override;
 	virtual machine_config_constructor device_mconfig_additions() const override;
 
-	DECLARE_READ16_MEMBER(reg_r);
-	DECLARE_WRITE16_MEMBER(reg_w);
+	virtual DECLARE_READ16_MEMBER(reg_r) override;
+	virtual DECLARE_WRITE16_MEMBER(reg_w) override;
 
 	DECLARE_WRITE8_MEMBER(ram_addr_w);
 	DECLARE_READ8_MEMBER(ram_data_r);

--- a/src/devices/bus/hp9845_io/hp9845_io.cpp
+++ b/src/devices/bus/hp9845_io/hp9845_io.cpp
@@ -10,7 +10,6 @@
 
 #include "emu.h"
 #include "hp9845_io.h"
-#include "includes/hp9845.h"
 
 // device type definition
 const device_type HP9845_IO_SLOT = device_creator<hp9845_io_slot_device>;
@@ -20,9 +19,11 @@ const device_type HP9845_IO_SLOT = device_creator<hp9845_io_slot_device>;
 // +---------------------+
 hp9845_io_slot_device::hp9845_io_slot_device(const machine_config &mconfig, const char *tag, device_t *owner, uint32_t clock) :
 	device_t(mconfig, HP9845_IO_SLOT, "HP9845 I/O Slot", tag, owner, clock, "hp9845_io_slot", __FILE__),
-	device_slot_interface(mconfig, *this)
+	device_slot_interface(mconfig, *this),
+	m_irq_cb_func(*this),
+	m_sts_cb_func(*this),
+	m_flg_cb_func(*this)
 {
-	//printf("hp9845_io_slot_device %s %p\n" , tag , this);
 }
 
 hp9845_io_slot_device::~hp9845_io_slot_device()
@@ -31,16 +32,62 @@ hp9845_io_slot_device::~hp9845_io_slot_device()
 
 void hp9845_io_slot_device::device_start()
 {
-	//printf("hp9845_io_slot_device::device_start\n");
+	m_irq_cb_func.resolve_safe();
+	m_sts_cb_func.resolve_safe();
+	m_flg_cb_func.resolve_safe();
+
+	hp9845_io_card_device *card = dynamic_cast<hp9845_io_card_device*>(get_card_device());
+
+	if (card != nullptr) {
+		card->set_slot_device(this);
+	}
+}
+
+void hp9845_io_slot_device::irq_w(uint8_t sc , int state)
+{
+	m_irq_cb_func(sc , state , 0xff);
+}
+
+void hp9845_io_slot_device::sts_w(uint8_t sc , int state)
+{
+	m_sts_cb_func(sc , state , 0xff);
+}
+
+void hp9845_io_slot_device::flg_w(uint8_t sc , int state)
+{
+	m_flg_cb_func(sc , state , 0xff);
+}
+
+int hp9845_io_slot_device::get_rw_handlers(read16_delegate& rhandler , write16_delegate& whandler)
+{
+	hp9845_io_card_device *card = dynamic_cast<hp9845_io_card_device*>(get_card_device());
+
+	if (card != nullptr) {
+		rhandler = read16_delegate(FUNC(hp9845_io_card_device::reg_r) , card);
+		whandler = write16_delegate(FUNC(hp9845_io_card_device::reg_w) , card);
+		return card->get_sc();
+	} else {
+		return -1;
+	}
 }
 
 // +---------------------+
 // |hp9845_io_card_device|
 // +---------------------+
+void hp9845_io_card_device::set_slot_device(hp9845_io_slot_device* dev)
+{
+	m_slot_dev = dev;
+}
+
+uint8_t hp9845_io_card_device::get_sc(void)
+{
+	return m_select_code_port->read() + HP9845_IO_FIRST_SC;
+}
+
 hp9845_io_card_device::hp9845_io_card_device(const machine_config &mconfig, device_type type, const char *name, const char *tag, device_t *owner, uint32_t clock, const char *shortname, const char *source) :
 	device_t(mconfig, type, name, tag, owner, clock, shortname, source),
 	device_slot_card_interface(mconfig, *this),
-	m_sys(nullptr),
+	m_slot_dev(nullptr),
 	m_select_code_port(*this , "SC"),
 	m_my_sc(0)
 {
@@ -52,31 +99,27 @@ hp9845_io_card_device::~hp9845_io_card_device()
 
 void hp9845_io_card_device::device_reset()
 {
-	m_my_sc = m_select_code_port->read() + HP9845_IO_FIRST_SC;
-	//printf("m_my_sc=%u\n" , m_my_sc);
+	m_my_sc = get_sc();
 }
 
 void hp9845_io_card_device::irq_w(int state)
 {
-	m_sys->irq_w(m_my_sc , state);
+	if (m_slot_dev) {
+		m_slot_dev->irq_w(m_my_sc , state);
+	}
 }
 
 void hp9845_io_card_device::sts_w(int state)
 {
-	m_sys->sts_w(m_my_sc , state);
+	if (m_slot_dev) {
+		m_slot_dev->sts_w(m_my_sc , state);
+	}
 }
 
 void hp9845_io_card_device::flg_w(int state)
 {
-	m_sys->flg_w(m_my_sc , state);
-}
-
-void hp9845_io_card_device::install_readwrite_handler(read16_delegate rhandler, write16_delegate whandler)
-{
-	if (m_sys == nullptr) {
-		m_sys = dynamic_cast<hp9845_base_state*>(&machine().root_device());
-		//printf("m_sys=%p\n" , m_sys);
-		m_sys->install_readwrite_handler(m_my_sc , rhandler, whandler);
+	if (m_slot_dev) {
+		m_slot_dev->flg_w(m_my_sc , state);
 	}
 }
 

--- a/src/devices/bus/hp9845_io/hp9845_io.cpp
+++ b/src/devices/bus/hp9845_io/hp9845_io.cpp
@@ -74,7 +74,7 @@ void hp9845_io_card_device::flg_w(int state)
 void hp9845_io_card_device::install_readwrite_handler(read16_delegate rhandler, write16_delegate whandler)
 {
 	if (m_sys == nullptr) {
-		m_sys = dynamic_cast<hp9845b_state*>(&machine().root_device());
+		m_sys = dynamic_cast<hp9845_base_state*>(&machine().root_device());
 		//printf("m_sys=%p\n" , m_sys);
 		m_sys->install_readwrite_handler(m_my_sc , rhandler, whandler);
 	}

--- a/src/devices/bus/hp9845_io/hp9845_io.h
+++ b/src/devices/bus/hp9845_io/hp9845_io.h
@@ -18,6 +18,15 @@
 	MCFG_DEVICE_ADD(_tag, HP9845_IO_SLOT, 0) \
 	MCFG_DEVICE_SLOT_INTERFACE(hp9845_io_slot_devices, nullptr, false)
 
+#define MCFG_HP9845_IO_IRQ_CB(_devcb) \
+	devcb = &hp9845_io_slot_device::set_irq_cb_func(*device , DEVCB_##_devcb);
+
+#define MCFG_HP9845_IO_STS_CB(_devcb) \
+	devcb = &hp9845_io_slot_device::set_sts_cb_func(*device , DEVCB_##_devcb);
+
+#define MCFG_HP9845_IO_FLG_CB(_devcb) \
+	devcb = &hp9845_io_slot_device::set_flg_cb_func(*device , DEVCB_##_devcb);
+
 #define HP9845_IO_FIRST_SC  1   // Lowest SC used by I/O cards
 
 #define MCFG_HP9845_IO_SC(_default_sc)              \
@@ -46,13 +55,39 @@ public:
 
 	// device-level overrides
 	virtual void device_start() override;
-};
 
-class hp9845_base_state;
+	// Callback setups
+	template<class _Object> static devcb_base &set_irq_cb_func(device_t &device, _Object object) { return downcast<hp9845_io_slot_device &>(device).m_irq_cb_func.set_callback(object); }
+	template<class _Object> static devcb_base &set_sts_cb_func(device_t &device, _Object object) { return downcast<hp9845_io_slot_device &>(device).m_sts_cb_func.set_callback(object); }
+	template<class _Object> static devcb_base &set_flg_cb_func(device_t &device, _Object object) { return downcast<hp9845_io_slot_device &>(device).m_flg_cb_func.set_callback(object); }
+
+	// irq/sts/flg signal handlers
+	void irq_w(uint8_t sc , int state);
+	void sts_w(uint8_t sc , int state);
+	void flg_w(uint8_t sc , int state);
+
+	// getter for r/w handlers
+	// return value is SC (negative if no card is attached to slot)
+	int get_rw_handlers(read16_delegate& rhandler , write16_delegate& whandler);
+
+private:
+	devcb_write8 m_irq_cb_func;
+	devcb_write8 m_sts_cb_func;
+	devcb_write8 m_flg_cb_func;
+};
 
 class hp9845_io_card_device : public device_t,
 							  public device_slot_card_interface
 {
+public:
+	void set_slot_device(hp9845_io_slot_device* dev);
+
+	virtual DECLARE_READ16_MEMBER(reg_r) = 0;
+	virtual DECLARE_WRITE16_MEMBER(reg_w) = 0;
+
+	// SC getter
+	uint8_t get_sc(void);
+
 protected:
 	// construction/destruction
 	hp9845_io_card_device(const machine_config &mconfig, device_type type, const char *name, const char *tag, device_t *owner, uint32_t clock, const char *shortname, const char *source);
@@ -61,7 +96,7 @@ protected:
 	// device-level overrides
 	virtual void device_reset() override;
 
-	hp9845_base_state *m_sys;
+	hp9845_io_slot_device *m_slot_dev;
 	required_ioport m_select_code_port;
 	uint8_t m_my_sc;
 
@@ -69,7 +104,6 @@ protected:
 	void irq_w(int state);
 	void sts_w(int state);
 	void flg_w(int state);
-	void install_readwrite_handler(read16_delegate rhandler, write16_delegate whandler);
 };
 
 // device type definition

--- a/src/devices/bus/hp9845_io/hp9845_io.h
+++ b/src/devices/bus/hp9845_io/hp9845_io.h
@@ -48,7 +48,7 @@ public:
 	virtual void device_start() override;
 };
 
-class hp9845b_state;
+class hp9845_base_state;
 
 class hp9845_io_card_device : public device_t,
 							  public device_slot_card_interface
@@ -61,7 +61,7 @@ protected:
 	// device-level overrides
 	virtual void device_reset() override;
 
-	hp9845b_state *m_sys;
+	hp9845_base_state *m_sys;
 	required_ioport m_select_code_port;
 	uint8_t m_my_sc;
 

--- a/src/devices/cpu/nanoprocessor/nanoprocessor.cpp
+++ b/src/devices/cpu/nanoprocessor/nanoprocessor.cpp
@@ -117,9 +117,11 @@ void hp_nanoprocessor_device::execute_run()
 		if (BIT(m_flags , NANO_I_BIT)) {
 			m_reg_ISR = m_reg_PA;
 			m_reg_PA = (uint16_t)(standard_irq_callback(0) & 0xff);
-			dc_clr(HP_NANO_IE_DC);
 			// Vector fetching takes 1 cycle
 			m_icount -= 1;
+			dc_clr(HP_NANO_IE_DC);
+			// Need this to propagate the clearing of DC7 to the clearing of int. line
+			yield();
 		} else {
 			debugger_instruction_hook(this , m_reg_PA);
 

--- a/src/devices/machine/fdc_pll.cpp
+++ b/src/devices/machine/fdc_pll.cpp
@@ -17,9 +17,10 @@ std::string fdc_pll_t::tts(attotime t)
 void fdc_pll_t::set_clock(const attotime &_period)
 {
 	period = _period;
-	period_adjust_base = period * 0.05;
-	min_period = period * 0.75;
-	max_period = period * 1.25;
+	double period_as_double = period.as_double();
+	period_adjust_base = attotime::from_double(period_as_double * 0.05);
+	min_period = attotime::from_double(period_as_double * 0.75);
+	max_period = attotime::from_double(period_as_double * 1.25);
 }
 
 void fdc_pll_t::reset(const attotime &when)

--- a/src/mame/drivers/hp9845.cpp
+++ b/src/mame/drivers/hp9845.cpp
@@ -173,6 +173,9 @@
 #define PEN_CURSOR	3	// Graphic cursor
 #define PEN_LP		4	// Light pen cursor
 
+// Peripheral Addresses (PA)
+#define IO_SLOT_FIRST_PA	1
+#define IO_SLOT_LAST_PA		12
 #define T15_PA                  15
 
 #define KEY_SCAN_OSCILLATOR     327680
@@ -411,11 +414,11 @@ void hp9845_base_state::machine_reset()
 	m_ppu->halt_w(0);
 
 	// First, unmap every r/w handler in 1..12 select codes
-	for (unsigned sc = 1; sc < 13; sc++) {
+	for (unsigned sc = IO_SLOT_FIRST_PA; sc < (IO_SLOT_LAST_PA + 1); sc++) {
 		m_ppu->space(AS_IO).unmap_readwrite(sc * 4 , sc * 4 + 3);
 	}
 
-	// Then, set r/w handlers of all installed I/O slot cards
+	// Then, set r/w handlers of all installed I/O cards
 	int sc;
 	read16_delegate rhandler;
 	write16_delegate whandler;
@@ -436,10 +439,6 @@ void hp9845_base_state::machine_reset()
 		m_ppu->space(AS_IO).install_readwrite_handler(sc * 4 , sc * 4 + 3 , rhandler , whandler);
 	}
 
-	{
-		device_execute_interface *dei = dynamic_cast<device_execute_interface *>(&(*m_ppu));
-		logerror("ppu %p\n" , dei);
-	}
 	// Some sensible defaults
 	m_video_load_mar = false;
 	m_video_first_mar = false;
@@ -1561,13 +1560,6 @@ void hp9845ct_state::update_graphic_bits(void)
 
 	m_ppu->dmar_w(dmar);
 }
-
-#if 0
-bool hp9845ct_state::extra_gv_irqs(void)
-{
-	return m_gv_lp_status || m_gv_sk_status;
-}
-#endif
 
 void hp9845ct_state::lp_r4_w(uint16_t data)
 {

--- a/src/mame/drivers/hp9845.cpp
+++ b/src/mame/drivers/hp9845.cpp
@@ -265,7 +265,10 @@ hp9845b_state::hp9845b_state(const machine_config &mconfig, device_type type, co
 			  m_t15(*this , "t15"),
 			  m_beeper(*this , "beeper"),
 			  m_beep_timer(*this , "beep_timer"),
-			  m_io_slot0(*this , "slot0")
+			  m_io_slot0(*this , "slot0"),
+			  m_io_slot1(*this , "slot1"),
+			  m_io_slot2(*this , "slot2"),
+			  m_io_slot3(*this , "slot3")
 {
 }
 
@@ -1127,6 +1130,9 @@ static MACHINE_CONFIG_START( hp9845b, hp9845b_state )
 	MCFG_SOFTWARE_LIST_ADD("optrom_list", "hp9845b_rom")
 
 	MCFG_HP9845_IO_SLOT_ADD("slot0")
+	MCFG_HP9845_IO_SLOT_ADD("slot1")
+	MCFG_HP9845_IO_SLOT_ADD("slot2")
+	MCFG_HP9845_IO_SLOT_ADD("slot3")
 MACHINE_CONFIG_END
 
 ROM_START( hp9845a )

--- a/src/mame/includes/hp9845.h
+++ b/src/mame/includes/hp9845.h
@@ -69,6 +69,9 @@ private:
 	required_device<beep_device> m_beeper;
 	required_device<timer_device> m_beep_timer;
 	required_device<hp9845_io_slot_device> m_io_slot0;
+	required_device<hp9845_io_slot_device> m_io_slot1;
+	required_device<hp9845_io_slot_device> m_io_slot2;
+	required_device<hp9845_io_slot_device> m_io_slot3;
 
 	void set_video_mar(uint16_t mar);
 	void video_fill_buff(bool buff_idx);

--- a/src/mame/includes/hp9845.h
+++ b/src/mame/includes/hp9845.h
@@ -1,8 +1,8 @@
 // license:BSD-3-Clause
 // copyright-holders:F. Ulivi
-// **************************
-// Driver for HP 9845B system
-// **************************
+// *******************************
+// Driver for HP 9845B/C/T systems
+// *******************************
 #ifndef _HP9845_H_
 #define _HP9845_H_
 
@@ -13,10 +13,10 @@
 #include "screen.h"
 #include "machine/ram.h"
 
-class hp9845b_state : public driver_device
+class hp9845_base_state : public driver_device
 {
 public:
-	hp9845b_state(const machine_config &mconfig, device_type type, const char *tag);
+	hp9845_base_state(const machine_config &mconfig, device_type type, const char *tag);
 
 	uint32_t screen_update(screen_device &screen, bitmap_rgb32 &bitmap, const rectangle &cliprect);
 
@@ -56,7 +56,7 @@ public:
 	DECLARE_WRITE_LINE_MEMBER(t15_flg_w);
 	DECLARE_WRITE_LINE_MEMBER(t15_sts_w);
 
-private:
+protected:
 	required_device<hp_5061_3001_cpu_device> m_lpu;
 	required_device<hp_5061_3001_cpu_device> m_ppu;
 	required_device<screen_device> m_screen;

--- a/src/mame/includes/hp9845.h
+++ b/src/mame/includes/hp9845.h
@@ -24,10 +24,9 @@ public:
 
 	TIMER_DEVICE_CALLBACK_MEMBER(gv_timer);
 
-	DECLARE_READ16_MEMBER(graphic_r);
-	DECLARE_WRITE16_MEMBER(graphic_w);
+	virtual DECLARE_READ16_MEMBER(graphic_r) = 0;
+	virtual DECLARE_WRITE16_MEMBER(graphic_w) = 0;
 	attotime time_to_gv_mem_availability(void) const;
-	void update_graphic_bits(void);
 
 	IRQ_CALLBACK_MEMBER(irq_callback);
 	void update_irq(void);
@@ -70,15 +69,13 @@ protected:
 
 	void setup_ram_block(unsigned block , unsigned offset);
 
-	virtual uint16_t graphic_r5_r(void) = 0;
-	virtual void     graphic_r5_w(uint16_t data) = 0;
 	virtual void advance_gv_fsm(bool ds , bool trigger) = 0;
 
 	// Character generator
 	required_region_ptr<uint8_t> m_chargen;
 
 	// Optional character generator
-	optional_region_ptr<uint8_t> m_optional_chargen;
+	required_region_ptr<uint8_t> m_optional_chargen;
 
 	// Text mode video I/F
 	typedef struct {
@@ -117,7 +114,11 @@ protected:
 	uint8_t m_gv_cmd; // U65 (GC)
 	uint16_t m_gv_data_w;     // U29, U45, U28 & U44 (GC)
 	uint16_t m_gv_data_r;     // U59 & U60 (GC)
-	uint16_t m_gv_cursor_w;   // U38 & U39 (GS)
+	uint16_t m_gv_io_counter; // U1, U2, U14 & U15 (GC)
+	uint16_t m_gv_cursor_x;   // U31 & U23 (GS)
+	uint16_t m_gv_cursor_y;   // U15 & U8 (GS)
+	bool m_gv_cursor_gc;    // U8 (GS)
+	bool m_gv_cursor_fs;    // U8 (GS)
 
 	// Interrupt handling
 	uint8_t m_irl_pending;

--- a/src/mame/includes/hp9845.h
+++ b/src/mame/includes/hp9845.h
@@ -11,6 +11,7 @@
 #include "sound/beep.h"
 #include "bus/hp9845_io/hp9845_io.h"
 #include "screen.h"
+#include "machine/ram.h"
 
 class hp9845b_state : public driver_device
 {
@@ -72,7 +73,9 @@ private:
 	required_device<hp9845_io_slot_device> m_io_slot1;
 	required_device<hp9845_io_slot_device> m_io_slot2;
 	required_device<hp9845_io_slot_device> m_io_slot3;
+	required_device<ram_device> m_ram;
 
+	void setup_ram_block(unsigned block , unsigned offset);
 	void set_video_mar(uint16_t mar);
 	void video_fill_buff(bool buff_idx);
 	void video_render_buff(unsigned video_scanline , unsigned line_in_row, bool buff_idx);

--- a/src/mame/includes/hp9845.h
+++ b/src/mame/includes/hp9845.h
@@ -18,22 +18,15 @@ class hp9845_base_state : public driver_device
 public:
 	hp9845_base_state(const machine_config &mconfig, device_type type, const char *tag);
 
-	uint32_t screen_update(screen_device &screen, bitmap_rgb32 &bitmap, const rectangle &cliprect);
-
 	virtual void machine_start() override;
 	virtual void machine_reset() override;
 	virtual void device_reset() override;
 
-	TIMER_DEVICE_CALLBACK_MEMBER(scanline_timer);
 	TIMER_DEVICE_CALLBACK_MEMBER(gv_timer);
 
-	void vblank_w(screen_device &screen, bool state);
-
-	void set_graphic_mode(bool graphic);
 	DECLARE_READ16_MEMBER(graphic_r);
 	DECLARE_WRITE16_MEMBER(graphic_w);
 	attotime time_to_gv_mem_availability(void) const;
-	void advance_gv_fsm(bool ds , bool trigger);
 	void update_graphic_bits(void);
 
 	IRQ_CALLBACK_MEMBER(irq_callback);
@@ -76,16 +69,16 @@ protected:
 	required_device<ram_device> m_ram;
 
 	void setup_ram_block(unsigned block , unsigned offset);
-	void set_video_mar(uint16_t mar);
-	void video_fill_buff(bool buff_idx);
-	void video_render_buff(unsigned video_scanline , unsigned line_in_row, bool buff_idx);
-	void graphic_video_render(unsigned video_scanline);
+
+	virtual uint16_t graphic_r5_r(void) = 0;
+	virtual void     graphic_r5_w(uint16_t data) = 0;
+	virtual void advance_gv_fsm(bool ds , bool trigger) = 0;
 
 	// Character generator
-	const uint8_t *m_chargen;
+	required_region_ptr<uint8_t> m_chargen;
 
 	// Optional character generator
-	const uint8_t *m_optional_chargen;
+	optional_region_ptr<uint8_t> m_optional_chargen;
 
 	// Text mode video I/F
 	typedef struct {
@@ -100,7 +93,6 @@ protected:
 	bool m_video_load_mar;
 	bool m_video_first_mar;
 	bool m_video_byte_idx;
-	uint8_t m_video_attr;
 	bool m_video_buff_idx;
 	bool m_video_blanked;
 	video_buffer_t m_video_buff[ 2 ];
@@ -125,13 +117,7 @@ protected:
 	uint8_t m_gv_cmd; // U65 (GC)
 	uint16_t m_gv_data_w;     // U29, U45, U28 & U44 (GC)
 	uint16_t m_gv_data_r;     // U59 & U60 (GC)
-	uint16_t m_gv_io_counter; // U1, U2, U14 & U15 (GC)
 	uint16_t m_gv_cursor_w;   // U38 & U39 (GS)
-	uint16_t m_gv_cursor_x;   // U31 & U23 (GS)
-	uint16_t m_gv_cursor_y;   // U15 & U8 (GS)
-	bool m_gv_cursor_gc;    // U8 (GS)
-	bool m_gv_cursor_fs;    // U8 (GS)
-	std::vector<uint16_t> m_graphic_mem;
 
 	// Interrupt handling
 	uint8_t m_irl_pending;

--- a/src/mame/includes/hp9845.h
+++ b/src/mame/includes/hp9845.h
@@ -30,11 +30,13 @@ public:
 
 	IRQ_CALLBACK_MEMBER(irq_callback);
 	void update_irq(void);
+	DECLARE_WRITE8_MEMBER(irq_w);
 	void irq_w(uint8_t sc , int state);
 	void update_flg_sts(void);
+	DECLARE_WRITE8_MEMBER(sts_w);
 	void sts_w(uint8_t sc , int state);
+	DECLARE_WRITE8_MEMBER(flg_w);
 	void flg_w(uint8_t sc , int state);
-	void install_readwrite_handler(uint8_t sc , read16_delegate rhandler, write16_delegate whandler);
 
 	TIMER_DEVICE_CALLBACK_MEMBER(kb_scan);
 	DECLARE_READ16_MEMBER(kb_scancode_r);


### PR DESCRIPTION
Hi,

this hefty set of commits implements the HP-9845C driver.
This system was the color version of the 9845 range of machines.
The driver was written together with Ansgar Kueckes who did a lot of reverse engineering of the video and lightpen sub-systems. 

The best way to try the emulator is running the DEMO tape.
Quick instructions:
* Load the colorgfx optional ROM (-rom1 colorgfx)
* Load the demo1.hti into cassette drive (-magt demo1.hti)
* Optionally, enable lightpen emulation (-lightgun -lightgun_device mouse)
* Map the k8..k15 keys, they are not mapped by default and they are needed for menu navigation (see below).
* Start the demo with: LOAD "AUTOST",1 <EXECUTE>
* Be patient, demo takes a while to load..
* Once the system asks for the type of printer paper, load the demo2.hti image and answer the question (see next point)
* Use the 8 softkeys to navigate the menus. At the moment softkeys are not directly emulated but you can use the keyboard substitutes (SK1-8 map to SHIFT + K8-15 respectively)
* Enjoy!

I'm mailing all the necessary ROM & tape images to the usual "code" e-mail.
Beside this major change, this set of commits also fixes a subtle bug in nanoprocessor emulation.

Thanks.
--F.Ulivi
