### PR TITLE
legacy floppy: unbreak floppy_stp_w

### DIFF
--- a/src/devices/imagedev/flopdrv.cpp
+++ b/src/devices/imagedev/flopdrv.cpp
@@ -641,6 +641,10 @@ WRITE_LINE_MEMBER( legacy_floppy_image_device::floppy_stp_w )
 
 		/* update track 0 line with new status */
 		//m_out_tk00_func(m_tk00);
+
+		/* inform disk image of step operation so it can cache information */
+		if (exists())
+			m_track = m_current_track;
 	}
 
 	m_stp = state;


### PR DESCRIPTION
makes certain wip code actually step correctly.