### PR TITLE
Add a way to avoid compiling in linenoise.

### DIFF
--- a/makefile
+++ b/makefile
@@ -781,6 +781,10 @@ endif
 ifdef WEBASSEMBLY
 PARAMS += --WEBASSEMBLY='$(WEBASSEMBLY)'
 endif
+
+ifdef NO_USE_LINENOISE
+PARAMS += --NO_USE_LINENOISE=1
+endif
 #-------------------------------------------------
 # All scripts
 #-------------------------------------------------

--- a/scripts/genie.lua
+++ b/scripts/genie.lua
@@ -387,6 +387,11 @@ newoption {
 }
 
 newoption {
+	trigger = "NO_USE_LINENOISE",
+	description = "Avoid using linenoise for licensing reasons.",
+}
+
+newoption {
 	trigger = "PROJECT",
 	description = "Select projects to be built. Will look into project folder for files.",
 }

--- a/scripts/src/3rdparty.lua
+++ b/scripts/src/3rdparty.lua
@@ -572,7 +572,7 @@ project "lualibs"
 	includedirs {
 		MAME_DIR .. "3rdparty",
 	}
-if (_OPTIONS["osd"] ~= "uwp") then
+if (_OPTIONS["osd"] ~= "uwp") and (not _OPTIONS["NO_USE_LINENOISE"]) then
 	includedirs {
 		MAME_DIR .. "3rdparty/linenoise-ng/include",
 	}
@@ -595,7 +595,7 @@ end
 		MAME_DIR .. "3rdparty/lua-zlib/lua_zlib.c",
 		MAME_DIR .. "3rdparty/luafilesystem/src/lfs.c",
 	}
-if (_OPTIONS["osd"] == "uwp") then
+if (_OPTIONS["osd"] == "uwp") or (_OPTIONS["NO_USE_LINENOISE"]) then
 	files {
 		MAME_DIR .. "3rdparty/lua-linenoise/linenoise_none.c",
 	}
@@ -1621,7 +1621,7 @@ end
 --------------------------------------------------
 -- linenoise-ng library
 --------------------------------------------------
-if (_OPTIONS["osd"] ~= "uwp") then
+if (_OPTIONS["osd"] ~= "uwp") and (not _OPTIONS["NO_USE_LINENOISE"]) then
 project "linenoise-ng"
 	uuid "7320ffc8-2748-4add-8864-ae29b72a8511"
 	kind (LIBTYPE)

--- a/scripts/src/main.lua
+++ b/scripts/src/main.lua
@@ -267,7 +267,7 @@ if (STANDALONE~=true) then
 		ext_lib("lua"),
 		"lualibs",
 	}
-if (_OPTIONS["osd"] ~= "uwp") then
+if (_OPTIONS["osd"] ~= "uwp") and (not _OPTIONS["NO_USE_LINENOISE"]) then
 	links {
 		"linenoise-ng",
 	}


### PR DESCRIPTION
Linenoise's source contains a (modified) copy of ConvertUTF.[ch], with the
following copyright header:

  Copyright 2001-2004 Unicode, Inc.

  Disclaimer

  This source code is provided as is by Unicode, Inc. No claims are
  made as to fitness for any particular purpose. No warranties of any
  kind are expressed or implied. The recipient agrees to determine
  applicability of information provided. If this file has been
  purchased on magnetic or optical media from Unicode, Inc., the
  sole remedy for any claim will be exchange of defective media
  within 90 days of receipt.

  Limitations on Rights to Redistribute This Code

  Unicode, Inc. hereby grants the right to freely use the information
  supplied in this file in the creation of products supporting the
  Unicode Standard, and to make copies of this file in any form
  for internal or external distribution as long as this notice
  remains attached.

This license is incompatible with the GPL as it does not explicitly allow
for modifications, and limits the field of endeavour for its usage.

This patch adds a NO_USE_LINENOISE that makes the build avoid linking in
linenoise.