### PR TITLE
Update sorcerer_cass.xml

### DIFF
--- a/hash/sorcerer_cass.xml
+++ b/hash/sorcerer_cass.xml
@@ -775,7 +775,7 @@
 	</software>
 	<software name="interceptor">
 		<description>Interceptor</description>
-		<year>198?</year>
+		<year>1983</year>
 		<publisher>Blair Rideout</publisher>
 		<info name="usage" value="Boot to Monitor, LOG" />
 		<part name="cass" interface="sorcerer_cass">


### PR DESCRIPTION
Added year of publication for Blair Rideout's Interceptor (Scramble clone) based on it being described as a new game in the System Software Christmas 1983 catalogue.