### PR TITLE
Allow clock frequency changes in ay8910.

### DIFF
--- a/src/devices/sound/ay8910.cpp
+++ b/src/devices/sound/ay8910.cpp
@@ -991,6 +991,11 @@ void ay8910_device::ay_set_clock(int clock)
 	m_channel->set_sample_rate( clock / 8 );
 }
 
+void ay8910_device::device_clock_changed()
+{
+	ay_set_clock(clock());
+}
+
 void ay8910_device::ay8910_write_ym(int addr, uint8_t data)
 {
 	if (addr & 1)

--- a/src/devices/sound/ay8910.h
+++ b/src/devices/sound/ay8910.h
@@ -156,6 +156,7 @@ protected:
 	// device-level overrides
 	virtual void device_start() override;
 	virtual void device_reset() override;
+	void device_clock_changed() override;
 
 	// sound stream update overrides
 	virtual void sound_stream_update(sound_stream &stream, stream_sample_t **inputs, stream_sample_t **outputs, int samples) override;

--- a/src/devices/sound/ay8910.h
+++ b/src/devices/sound/ay8910.h
@@ -156,7 +156,7 @@ protected:
 	// device-level overrides
 	virtual void device_start() override;
 	virtual void device_reset() override;
-	void device_clock_changed() override;
+	virtual void device_clock_changed() override;
 
 	// sound stream update overrides
 	virtual void sound_stream_update(sound_stream &stream, stream_sample_t **inputs, stream_sample_t **outputs, int samples) override;


### PR DESCRIPTION
Overrided device method to support changing clock frequencies in the ay8910.