### PR TITLE
Some new entries for the IBM5170 softlist

### DIFF
--- a/hash/ibm5170.xml
+++ b/hash/ibm5170.xml
@@ -2671,6 +2671,17 @@ Missing files come here
 
 	<!-- Driver Disks -->
 
+	<software name="amouse7">
+		<description>AMouse Mouse Driver Disk</description>
+		<year>1991</year>
+		<publisher>ULTIMA Electronics Corp.</publisher>
+		<part name="flop1" interface="floppy_3_5">
+			<dataarea name="flop" size="737280">
+				<rom name="AMouse-driver-disk-7.0.img" size="737280" crc="e49af872" sha1="4ee28d6149cf6c4e3fc8562a8fe6f738c6b1b83d" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+	
 	<software name="scrlmous">
 		<description>Genius Scroll Mouse</description>
 		<year>2004</year>

--- a/hash/ibm5170.xml
+++ b/hash/ibm5170.xml
@@ -3577,6 +3577,94 @@ Missing files come here
 		</part>
 	</software>
 
+	<software name="bpdx301g">
+		<!-- KryoFlux dump from original media, many modified sectors -->
+		<description>Borland Paradox 3.01 (German)</description>
+		<year>1989</year>
+		<publisher>Borland</publisher>
+		<info name="version" value="3.01" />
+        <part name="flop01" interface="floppy_5_25">
+                <dataarea name="flop" size="368640">
+                        <rom name="borland_paradox_3.01_German_disk01.img" size="368640" crc="d1412b21" sha1="4fc367a229031dd3134100eece7bfb9b3b8dbd2d" offset="0" />
+                </dataarea>
+        </part>
+        <part name="flop02" interface="floppy_5_25">
+                <dataarea name="flop" size="368640">
+                        <rom name="borland_paradox_3.01_German_disk02.img" size="368640" crc="56e083c3" sha1="aea7a20f9e22ab78d9377e3dce1ac5fdee83fbed" offset="0" />
+                </dataarea>
+        </part>
+        <part name="flop03" interface="floppy_5_25">
+                <dataarea name="flop" size="368640">
+                        <rom name="borland_paradox_3.01_German_disk03.img" size="368640" crc="0bfcd167" sha1="b29c61e067d450090f611bf0f7ae58881124e984" offset="0" />
+                </dataarea>
+        </part>
+        <part name="flop04" interface="floppy_5_25">
+                <dataarea name="flop" size="368640">
+                        <rom name="borland_paradox_3.01_German_disk04.img" size="368640" crc="cbed452b" sha1="0e6bf5519349297d377704bcd1e9568b12ad706d" offset="0" />
+                </dataarea>
+        </part>
+        <part name="flop05" interface="floppy_5_25">
+                <dataarea name="flop" size="368640">
+                        <rom name="borland_paradox_3.01_German_disk05.img" size="368640" crc="43bf368f" sha1="0e59b71c067ad578a73ed8b9a9ad8fb52766efbd" offset="0" />
+                </dataarea>
+        </part>
+        <part name="flop06" interface="floppy_5_25">
+                <dataarea name="flop" size="368640">
+                        <rom name="borland_paradox_3.01_German_disk06.img" size="368640" crc="d5314389" sha1="46ba14cb52f0c7f04753023eff77ccc8f40c3911" offset="0" />
+                </dataarea>
+        </part>
+        <part name="flop07" interface="floppy_5_25">
+                <dataarea name="flop" size="368640">
+                        <rom name="borland_paradox_3.01_German_disk07.img" size="368640" crc="27f29554" sha1="150436b12138ef74b154b5080658ed97a7849cb0" offset="0" />
+                </dataarea>
+        </part>
+        <part name="flop08" interface="floppy_5_25">
+                <dataarea name="flop" size="368640">
+                        <rom name="borland_paradox_3.01_German_disk08.img" size="368640" crc="19549090" sha1="6c16e114571422ce71c8ad8ef9f07c518724b506" offset="0" />
+                </dataarea>
+        </part>
+        <part name="flop09" interface="floppy_5_25">
+                <dataarea name="flop" size="368640">
+                        <rom name="borland_paradox_3.01_German_disk09.img" size="368640" crc="29cf72df" sha1="a019ddbb81baa4afbed94cea10f8cb63f64b1937" offset="0" />
+                </dataarea>
+        </part>
+        <part name="flop10" interface="floppy_5_25">
+                <dataarea name="flop" size="368640">
+                        <rom name="borland_paradox_3.01_German_disk10.img" size="368640" crc="385d1f10" sha1="0850e25d4d418822cccb1c6aefd3131bffe814ff" offset="0" />
+                </dataarea>
+        </part>
+        <part name="flop11" interface="floppy_5_25">
+                <dataarea name="flop" size="368640">
+                        <rom name="borland_paradox_3.01_German_disk11.img" size="368640" crc="cee1c377" sha1="f9eea75e284c59f71f9adad6fa4da3287c451fec" offset="0" />
+                </dataarea>
+        </part>
+        <part name="flop12" interface="floppy_5_25">
+                <dataarea name="flop" size="368640">
+                        <rom name="borland_paradox_3.01_German_disk12.img" size="368640" crc="7aa5fe5f" sha1="95238693de43a1f6a8062a0b09d920f6c39ea18b" offset="0" />
+                </dataarea>
+        </part>
+        <part name="flop13" interface="floppy_5_25">
+                <dataarea name="flop" size="368640">
+                        <rom name="borland_paradox_3.01_German_disk13.img" size="368640" crc="159151e7" sha1="71082a91f55aebe8d0efa21cb8afedc3482131e9" offset="0" />
+                </dataarea>
+        </part>
+        <part name="flop14" interface="floppy_5_25">
+                <dataarea name="flop" size="368640">
+                        <rom name="borland_paradox_3.01_German_disk14.img" size="368640" crc="6df1d631" sha1="ba39fba55d21da98c294df456980724bbb83cc7a" offset="0" />
+                </dataarea>
+        </part>
+        <part name="flop15" interface="floppy_5_25">
+                <dataarea name="flop" size="368640">
+                        <rom name="borland_paradox_3.01_German_disk15.img" size="368640" crc="710bc39f" sha1="985a1ff252c17fe91aba5f40994dda853389c5d1" offset="0" />
+                </dataarea>
+        </part>
+        <part name="flop16" interface="floppy_5_25">
+                <dataarea name="flop" size="368640">
+                        <rom name="borland_paradox_3.01_German_disk16.img" size="368640" crc="8941eb6a" sha1="ebe7bad7a92505664ec3a61aad4065dd6e72ca7a" offset="0" />
+                </dataarea>
+        </part>
+	</software>
+
 	<software name="btpscl55">
 		<description>Borland Turbo Pascal 5.5</description>
 		<year>1989</year>

--- a/hash/ibm5170.xml
+++ b/hash/ibm5170.xml
@@ -3564,6 +3564,19 @@ Missing files come here
 		</part>
 	</software>
 
+	<software name="beureka">
+		<!-- KryoFlux dump, not original -->
+		<description>Borland Eureka: The Solver</description>
+		<year>1987</year>
+		<publisher>Borland</publisher>
+		<info name="version" value="1.0" />
+		<part name="flop1" interface="floppy_5_25">
+			<dataarea name="flop" size="368640">
+				<rom name="borland_eureka_1.0.img" size="368640" crc="7455a391" sha1="7be111d5b295ef9951454b1e84f121a34c2cd1a6" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
 	<software name="btpscl55">
 		<description>Borland Turbo Pascal 5.5</description>
 		<year>1989</year>

--- a/hash/ibm5170.xml
+++ b/hash/ibm5170.xml
@@ -1457,7 +1457,7 @@ Missing files come here
 		</part>
 	</software>
 
-	<software name="msdos622g">
+	<software name="msdos622g" cloneof="msdos622">
 		<!-- KryoFlux dump from original disks, shows as unmodified -->
 		<description>MS-DOS (Version 6.22, German)</description>
 		<year>1994</year>

--- a/hash/ibm5170.xml
+++ b/hash/ibm5170.xml
@@ -2300,6 +2300,48 @@ Missing files come here
 		</part>
 	</software>
 
+	<software name="win31g">
+		<!-- KryoFlux dump from original disks, shows as unmodified except for disk 7-->
+		<description>Windows Version 3.1 (German)</description>
+		<year>1992</year>
+		<publisher>Microsoft</publisher>
+		<part name="flop1" interface="floppy_3_5">
+			<dataarea name="flop" size="1474560">
+				<rom name="Windows_3.1_German_Disk1.img" size="1474560" crc="b74eee18" sha1="fda4f76e32a45979c9b4a1b44cd0fbae04d650c3" offset="0" />
+			</dataarea>
+		</part>
+		<part name="flop2" interface="floppy_3_5">
+			<dataarea name="flop" size="1474560">
+				<rom name="Windows_3.1_German_Disk2.img" size="1474560" crc="4a3738ae" sha1="df554fba616e993981723ab4dfce0487ac761232" offset="0" />
+			</dataarea>
+		</part>
+		<part name="flop3" interface="floppy_3_5">
+			<dataarea name="flop" size="1474560">
+				<rom name="Windows_3.1_German_Disk3.img" size="1474560" crc="a2605b54" sha1="4b0eac2ecdf3946bfec6be64617ba95fd03c2714" offset="0" />
+			</dataarea>
+		</part>
+		<part name="flop4" interface="floppy_3_5">
+			<dataarea name="flop" size="1474560">
+				<rom name="Windows_3.1_German_Disk4.img" size="1474560" crc="c2c2cfb5" sha1="a428f2b0f11ab339d5f606b18ac63c77b9d6dece" offset="0" />
+			</dataarea>
+		</part>
+		<part name="flop5" interface="floppy_3_5">
+			<dataarea name="flop" size="1474560">
+				<rom name="Windows_3.1_German_Disk5.img" size="1474560" crc="5aba21f1" sha1="3512aa478081e899fb08f589170ab030a65b7e4f" offset="0" />
+			</dataarea>
+		</part>
+		<part name="flop6" interface="floppy_3_5">
+			<dataarea name="flop" size="1474560">
+				<rom name="Windows_3.1_German_Disk6.img" size="1474560" crc="3627eca0" sha1="9895d6bf967f7bf1fb36e650f3d0a7834e3059d6" offset="0" />
+			</dataarea>
+		</part>
+		<part name="flop7" interface="floppy_3_5">
+			<dataarea name="flop" size="1474560">
+				<rom name="Windows_3.1_German_Disk7.img" size="1474560" crc="ecf660ee" sha1="06256f221e110214a32ab064d2138acc54e7ff3f" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
 	<software name="win31m">
 		<description>Windows Version 3.1 (5.25")</description>
 		<year>1992</year>

--- a/hash/ibm5170.xml
+++ b/hash/ibm5170.xml
@@ -2866,6 +2866,28 @@ Missing files come here
 		</part>
 	</software>
 
+	<software name="ezscsi31g">
+		<!-- dumped via Kryoflux from original media, shows as unmodified -->
+		<description>Adaptec EZ-SCSI 3.1 (German)</description>
+		<year>1995</year>
+		<publisher>Adaptec, Inc.</publisher>
+		<part name="flop1" interface="floppy_3_5">
+			<dataarea name="flop" size="1474560">
+				<rom name="adaptec_ez-scsi_3.1_german_disk1.img" size="1474560" crc="0c19cd2a" sha1="fdd3cdf1941c985f641cdd1406806938cc6dbfc9" offset="0" />
+			</dataarea>
+		</part>
+		<part name="flop2" interface="floppy_3_5">
+			<dataarea name="flop" size="1474560">
+				<rom name="adaptec_ez-scsi_3.1_german_disk2.img" size="1474560" crc="1c581b13" sha1="e70aae5ff6a1e619888908d7d5a672d08c30a73a" offset="0" />
+			</dataarea>
+		</part>
+		<part name="flop3" interface="floppy_3_5">
+			<dataarea name="flop" size="1474560">
+				<rom name="adaptec_ez-scsi_3.1_german_disk3.img" size="1474560" crc="cf9f214d" sha1="adf919dad493764656d27b5f51af80053b028c7f" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
 	<software name="ltdrv52c">
 		<description>LT Windows Modem V.90 Data+Fax Modem Version (Version 5.31)</description>
 		<year>1999</year>

--- a/hash/ibm5170.xml
+++ b/hash/ibm5170.xml
@@ -1457,6 +1457,29 @@ Missing files come here
 		</part>
 	</software>
 
+	<software name="msdos622g">
+		<!-- KryoFlux dump from original disks, shows as unmodified -->
+		<description>MS-DOS (Version 6.22, German)</description>
+		<year>1994</year>
+		<publisher>Microsoft</publisher>
+		<info name="version" value="6.22" />
+		<part name="flop1" interface="floppy_3_5">
+			<dataarea name="flop" size="1474560">
+				<rom name="MS_DOS_6.22_German_disk1.img" size="1474560" crc="59641924" sha1="df473043d61524d74a8391c4649e7362858b6d81" offset="0" />
+			</dataarea>
+		</part>
+		<part name="flop2" interface="floppy_3_5">
+			<dataarea name="flop" size="1474560">
+				<rom name="MS_DOS_6.22_German_disk2.img" size="1474560" crc="600c5a02" sha1="2b1b7e938cb8eb7bb4eac35a36bd9415fbfe31d3" offset="0" />
+			</dataarea>
+		</part>
+		<part name="flop3" interface="floppy_3_5">
+			<dataarea name="flop" size="1474560">
+				<rom name="MS_DOS_6.22_German_disk3.img" size="1474560" crc="95f32c5d" sha1="ed1358083d1c56105356e4b029e2beca6d6211da" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
 	<software name="msdos622a" cloneof="msdos622">
 		<!-- from Acer CPR 1.2 recovery CD-ROM -->
 		<description>MS-DOS (Version 6.22, Alt)</description>

--- a/hash/ibm5170.xml
+++ b/hash/ibm5170.xml
@@ -2582,6 +2582,58 @@ Missing files come here
 		</part>
 	</software>
 
+	<software name="wfw311g">
+		<!-- KryoFlux dump from original disks, shows as unmodified -->
+		<description>Windows for Workgroups Verison 3.11 (German)</description>
+		<year>1993</year>
+		<publisher>Microsoft</publisher>
+		<part name="flop1" interface="floppy_3_5">
+			<dataarea name="flop" size="1474560">
+				<rom name="Windows_for_Workgroups_3.11_German_disk1.img" size="1474560" crc="43524fe7" sha1="039c817f3cfec479f61b92f5c90f10ae58d43aa5" offset="0" />
+			</dataarea>
+		</part>
+		<part name="flop2" interface="floppy_3_5">
+			<dataarea name="flop" size="1474560">
+				<rom name="Windows_for_Workgroups_3.11_German_disk2.img" size="1474560" crc="cd23933a" sha1="83dd69871278e957d7e241bc2cdd8e11494ea2af" offset="0" />
+			</dataarea>
+		</part>
+		<part name="flop3" interface="floppy_3_5">
+			<dataarea name="flop" size="1474560">
+				<rom name="Windows_for_Workgroups_3.11_German_disk3.img" size="1474560" crc="451ae63f" sha1="626febc9e474f0599eeec6eb543803edd7d12245" offset="0" />
+			</dataarea>
+		</part>
+		<part name="flop4" interface="floppy_3_5">
+			<dataarea name="flop" size="1474560">
+				<rom name="Windows_for_Workgroups_3.11_German_disk4.img" size="1474560" crc="dcd5ab20" sha1="564c72f83b101f1dab353968aed0a78e15b0d479" offset="0" />
+			</dataarea>
+		</part>
+		<part name="flop5" interface="floppy_3_5">
+			<dataarea name="flop" size="1474560">
+				<rom name="Windows_for_Workgroups_3.11_German_disk5.img" size="1474560" crc="47717a5d" sha1="60c0366580874a7c0de023b8b2f113430bffa474" offset="0" />
+			</dataarea>
+		</part>
+		<part name="flop6" interface="floppy_3_5">
+			<dataarea name="flop" size="1474560">
+				<rom name="Windows_for_Workgroups_3.11_German_disk6.img" size="1474560" crc="3e8b52f6" sha1="ecc6ddd1ae24961d6ba57a5f8a56e32fcfd69937" offset="0" />
+			</dataarea>
+		</part>
+		<part name="flop7" interface="floppy_3_5">
+			<dataarea name="flop" size="1474560">
+				<rom name="Windows_for_Workgroups_3.11_German_disk7.img" size="1474560" crc="41bda462" sha1="bb990adbd048131d4961add7174c31ae9af1cc38" offset="0" />
+			</dataarea>
+		</part>
+		<part name="flop8" interface="floppy_3_5">
+			<dataarea name="flop" size="1474560">
+				<rom name="Windows_for_Workgroups_3.11_German_disk8.img" size="1474560" crc="58797771" sha1="6b38b4d6c31bfa086a2fe884626b5aadfece29f1" offset="0" />
+			</dataarea>
+		</part>
+		<part name="flop9" interface="floppy_3_5">
+			<dataarea name="flop" size="1474560">
+				<rom name="Windows_for_Workgroups_3.11_German_disk9.img" size="1474560" crc="b35d8025" sha1="3715a7ba0d976bda38a0cde7a3807a452b42ffc0" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
 	<software name="wfw311u">
 		<description>Windows for Workgroups Version 3.11 (Upgrade)</description>
 		<year>1993</year>

--- a/hash/ibm5170.xml
+++ b/hash/ibm5170.xml
@@ -3665,6 +3665,79 @@ Missing files come here
         </part>
 	</software>
 
+	<software name="bpdx40g">
+		<!-- dumped via Kryoflux from original media, shows as unmodified -->
+		<description>Borland Paradox 4.0 (German, 3.5")</description>
+		<year>1992</year>
+		<publisher>Borland</publisher>
+		<info name="version" value="4.0" />
+		<info name="serial" value="IC235A10202871" />
+		<part name="flop1" interface="floppy_3_5">
+			<dataarea name="flop" size="737280">
+				<rom name="borland_paradox_4.0_German_3.5_disk1.img" size="737280" crc="79ed537c" sha1="f15f2fd442c383a10b5aaed82e675aa8d86a470f" offset="0" />
+			</dataarea>
+		</part>
+		<part name="flop2" interface="floppy_3_5">
+			<dataarea name="flop" size="737280">
+				<rom name="borland_paradox_4.0_German_3.5_disk2.img" size="737280" crc="3485730b" sha1="a4d1d545aa414754cd3144cbd0994719fd0a3fb9" offset="0" />
+			</dataarea>
+		</part>
+		<part name="flop3" interface="floppy_3_5">
+			<dataarea name="flop" size="737280">
+				<rom name="borland_paradox_4.0_German_3.5_disk3.img" size="737280" crc="73cd5f6d" sha1="6c931189ec6d6922960101da5d137d54e94a6866" offset="0" />
+			</dataarea>
+		</part>
+		<part name="flop4" interface="floppy_3_5">
+			<dataarea name="flop" size="737280">
+				<rom name="borland_paradox_4.0_German_3.5_disk4.img" size="737280" crc="b273c866" sha1="2776d8d19ee2a9fe79ed677e4c856a1692db0801" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+	<software name="bpdx40ga">
+		<!-- dumped via Kryoflux from original media, shows as unmodified -->
+		<description>Borland Paradox 4.0 (German, 5.25")</description>
+		<year>1992</year>
+		<publisher>Borland</publisher>
+		<info name="version" value="4.0" />
+		<info name="serial" value="IC235A10202871" />
+		<part name="flop1" interface="floppy_5_25">
+			<dataarea name="flop" size="368640">
+				<rom name="borland_paradox_4.0_German_5.25_disk1.img" size="368640" crc="74ae85d1" sha1="61a1464fab38ced8dbc92db06c9de51b7aa383bd" offset="0" />
+			</dataarea>
+		</part>
+		<part name="flop2" interface="floppy_5_25">
+			<dataarea name="flop" size="368640">
+				<rom name="borland_paradox_4.0_German_5.25_disk2.img" size="368640" crc="aa756130" sha1="c627f099d150ed59944e769c0fa89e6f027f6ca7" offset="0" />
+			</dataarea>
+		</part>
+		<part name="flop3" interface="floppy_5_25">
+			<dataarea name="flop" size="368640">
+				<rom name="borland_paradox_4.0_German_5.25_disk3.img" size="368640" crc="3b8568bf" sha1="cf3d4dac6286d8548fb18e15e08ddf66b568b07f" offset="0" />
+			</dataarea>
+		</part>
+		<part name="flop4" interface="floppy_5_25">
+			<dataarea name="flop" size="368640">
+				<rom name="borland_paradox_4.0_German_5.25_disk4.img" size="368640" crc="a2780d41" sha1="3fe256addb419ceb3e45b3a8be6c52901db80322" offset="0" />
+			</dataarea>
+		</part>
+		<part name="flop5" interface="floppy_5_25">
+			<dataarea name="flop" size="368640">
+				<rom name="borland_paradox_4.0_German_5.25_disk5.img" size="368640" crc="5c7fac58" sha1="142204a984b19c379c4b5510191357779576ed2b" offset="0" />
+			</dataarea>
+		</part>
+		<part name="flop6" interface="floppy_5_25">
+			<dataarea name="flop" size="368640">
+				<rom name="borland_paradox_4.0_German_5.25_disk6.img" size="368640" crc="cf316a6e" sha1="ad17ad662594f8a480e9aeb8c73fcd9fc5130f9b" offset="0" />
+			</dataarea>
+		</part>
+		<part name="flop7" interface="floppy_5_25">
+			<dataarea name="flop" size="368640">
+				<rom name="borland_paradox_4.0_German_5.25_disk7.img" size="368640" crc="ba0b4ba6" sha1="ae0002c22b8f76cfc17c5f8cb556c26a5326b20d" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
 	<software name="btpscl55">
 		<description>Borland Turbo Pascal 5.5</description>
 		<year>1989</year>

--- a/hash/ibm5170.xml
+++ b/hash/ibm5170.xml
@@ -2672,6 +2672,7 @@ Missing files come here
 	<!-- Driver Disks -->
 
 	<software name="amouse7">
+		<!-- dumped via Kryoflux from original floppy, some modified sectors present -->
 		<description>AMouse Mouse Driver Disk</description>
 		<year>1991</year>
 		<publisher>ULTIMA Electronics Corp.</publisher>

--- a/hash/ibm5170.xml
+++ b/hash/ibm5170.xml
@@ -1170,6 +1170,29 @@ Missing files come here
 		</part>
 	</software>
 
+	<software name="pcdos5g">
+		<!-- KryoFlux dump from original disks, shows as unmodified -->
+		<description>IBM DOS 5.02 "for preload" (German)</description>
+		<year>1992</year>
+		<publisher>IBM</publisher>
+		<info name="version" value="5.02" />
+		<part name="flop1" interface="floppy_3_5">
+			<dataarea name="flop" size="737280">
+				<rom name="IBM_DOS_5.02_for_preload_German_disk1.img" size="737280" crc="e76398bc" sha1="2eeb89aff04aa28fa040d57e8f0b0ee899025a99" offset="0" />
+			</dataarea>
+		</part>
+		<part name="flop2" interface="floppy_3_5">
+			<dataarea name="flop" size="737280">
+				<rom name="IBM_DOS_5.02_for_preload_German_disk2.img" size="737280" crc="484aa5a6" sha1="1b2741a4d20614ec744ed987c004269830cde6bd" offset="0" />
+			</dataarea>
+		</part>
+		<part name="flop3" interface="floppy_3_5">
+			<dataarea name="flop" size="737280">
+				<rom name="IBM_DOS_5.02_for_preload_German_disk3.img" size="737280" crc="05cf4590" sha1="dcc750a969acc502629098cbc70552d939d98d90" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
 	<software name="pcdos61">
 		<description>IBM DOS (Version 6.1)</description>
 		<year>1993</year>

--- a/hash/ibm5170.xml
+++ b/hash/ibm5170.xml
@@ -2258,7 +2258,7 @@ Missing files come here
 		</part>
 	</software>
 
-	<software name="win31a">
+	<software name="win31a" cloneof="win31">
 		<description>Microsoft Windows Version 3.1 (Alt)</description>
 		<year>1992</year>
 		<publisher>Microsoft</publisher>
@@ -2300,7 +2300,7 @@ Missing files come here
 		</part>
 	</software>
 
-	<software name="win31g">
+	<software name="win31g" cloneof="win31">
 		<!-- KryoFlux dump from original disks, shows as unmodified except for disk 7-->
 		<description>Windows Version 3.1 (German)</description>
 		<year>1992</year>
@@ -2342,7 +2342,7 @@ Missing files come here
 		</part>
 	</software>
 
-	<software name="win31m">
+	<software name="win31m" cloneof="win31">
 		<description>Windows Version 3.1 (5.25")</description>
 		<year>1992</year>
 		<publisher>Microsoft</publisher>
@@ -2582,7 +2582,7 @@ Missing files come here
 		</part>
 	</software>
 
-	<software name="wfw311g">
+	<software name="wfw311g" cloneof="wfw311">
 		<!-- KryoFlux dump from original disks, shows as unmodified -->
 		<description>Windows for Workgroups Verison 3.11 (German)</description>
 		<year>1993</year>
@@ -3834,7 +3834,7 @@ Missing files come here
 		</part>
 	</software>
 
-	<software name="bpdx40ga">
+	<software name="bpdx40ga" cloneof="bpdx40g">
 		<!-- dumped via Kryoflux from original media, shows as unmodified -->
 		<description>Borland Paradox 4.0 (German, 5.25")</description>
 		<year>1992</year>


### PR DESCRIPTION
I dumped a lot of floppies recently, and these are the first ones that I create a pull-request for

All floppies were dumped with a KryoFlux and converted to img.

The *.img files as well as the KryoFlux stream dumps, KF logs and scans of the media are available on my archive.org account (archive.org/details/@ dark-star)

If you prefer a different submission method for the *.img files let me know