### PR TITLE
Expansion of device_nvram_interface

### DIFF
--- a/src/devices/machine/ds2404.cpp
+++ b/src/devices/machine/ds2404.cpp
@@ -104,6 +104,8 @@ void ds2404_device::device_start()
 
 	m_tick_timer = timer_alloc(0);
 	m_tick_timer->adjust(attotime::from_hz(256), 0, attotime::from_hz(256));
+
+	memarray().set(m_sram, sizeof(m_sram), 8, ENDIANNESS_LITTLE, 1);
 }
 
 
@@ -380,26 +382,4 @@ void ds2404_device::device_timer(emu_timer &timer, device_timer_id id, int param
 void ds2404_device::nvram_default()
 {
 	memset(m_sram, 0, sizeof(m_sram));
-}
-
-
-//-------------------------------------------------
-//  nvram_read - called to read NVRAM from the
-//  .nv file
-//-------------------------------------------------
-
-void ds2404_device::nvram_read(emu_file &file)
-{
-	file.read(m_sram, sizeof(m_sram));
-}
-
-
-//-------------------------------------------------
-//  nvram_write - called to write NVRAM to the
-//  .nv file
-//-------------------------------------------------
-
-void ds2404_device::nvram_write(emu_file &file)
-{
-	file.write(m_sram, sizeof(m_sram));
 }

--- a/src/devices/machine/ds2404.h
+++ b/src/devices/machine/ds2404.h
@@ -74,8 +74,6 @@ protected:
 
 	// device_nvram_interface overrides
 	virtual void nvram_default() override;
-	virtual void nvram_read(emu_file &file) override;
-	virtual void nvram_write(emu_file &file) override;
 
 	virtual void device_timer(emu_timer &timer, device_timer_id id, int param, void *ptr) override;
 

--- a/src/devices/machine/eeprom.cpp
+++ b/src/devices/machine/eeprom.cpp
@@ -209,8 +209,10 @@ void eeprom_base_device::device_validity_check(validity_checker &valid) const
 
 void eeprom_base_device::device_start()
 {
-	uint32_t size = (m_data_bits == 8 ? 1 : 2) << m_address_bits;
+	int bpe = m_data_bits / 8;
+	uint32_t size = bpe * m_cells;
 	m_data = std::make_unique<uint8_t []>(size);
+	memarray().set(&m_data[0], size, 8, ENDIANNESS_LITTLE, bpe);
 
 	// save states
 	save_item(NAME(m_completion_time));
@@ -270,34 +272,6 @@ void eeprom_base_device::nvram_default()
 
 		memcpy(&m_data[0], m_region->base(), eeprom_bytes);
 	}
-}
-
-
-//-------------------------------------------------
-//  nvram_read - called to read NVRAM from the
-//  .nv file
-//-------------------------------------------------
-
-void eeprom_base_device::nvram_read(emu_file &file)
-{
-	uint32_t eeprom_length = 1 << m_address_bits;
-	uint32_t eeprom_bytes = eeprom_length * m_data_bits / 8;
-
-	file.read(&m_data[0], eeprom_bytes);
-}
-
-
-//-------------------------------------------------
-//  nvram_write - called to write NVRAM to the
-//  .nv file
-//-------------------------------------------------
-
-void eeprom_base_device::nvram_write(emu_file &file)
-{
-	uint32_t eeprom_length = 1 << m_address_bits;
-	uint32_t eeprom_bytes = eeprom_length * m_data_bits / 8;
-
-	file.write(&m_data[0], eeprom_bytes);
 }
 
 

--- a/src/devices/machine/eeprom.h
+++ b/src/devices/machine/eeprom.h
@@ -90,8 +90,6 @@ protected:
 
 	// device_nvram_interface overrides
 	virtual void nvram_default() override;
-	virtual void nvram_read(emu_file &file) override;
-	virtual void nvram_write(emu_file &file) override;
 
 	optional_memory_region  m_region;
 

--- a/src/devices/machine/intelfsh.cpp
+++ b/src/devices/machine/intelfsh.cpp
@@ -441,6 +441,9 @@ void intelfsh_device::device_start()
 	save_item( NAME(m_flash_mode) );
 	save_item( NAME(m_flash_master_lock) );
 	save_pointer( &m_data[0], "m_data", m_size);
+
+	assert(m_bits == 8 || m_bits == 16);
+	memarray().set(&m_data[0], m_size, 8, ENDIANNESS_BIG, m_bits / 8);
 }
 
 
@@ -495,28 +498,6 @@ void intelfsh_device::nvram_default()
 
 	// otherwise, default to 0xff
 	memset(&m_data[0], 0xff, m_size);
-}
-
-
-//-------------------------------------------------
-//  nvram_read - called to read NVRAM from the
-//  .nv file
-//-------------------------------------------------
-
-void intelfsh_device::nvram_read(emu_file &file)
-{
-	file.read(&m_data[0], m_size);
-}
-
-
-//-------------------------------------------------
-//  nvram_write - called to write NVRAM to the
-//  .nv file
-//-------------------------------------------------
-
-void intelfsh_device::nvram_write(emu_file &file)
-{
-	file.write(&m_data[0], m_size);
 }
 
 

--- a/src/devices/machine/intelfsh.h
+++ b/src/devices/machine/intelfsh.h
@@ -161,8 +161,6 @@ protected:
 
 	// device_nvram_interface overrides
 	virtual void nvram_default() override;
-	virtual void nvram_read(emu_file &file) override;
-	virtual void nvram_write(emu_file &file) override;
 
 	// derived helpers
 	uint32_t read_full(uint32_t offset);

--- a/src/devices/machine/rp5c01.cpp
+++ b/src/devices/machine/rp5c01.cpp
@@ -171,9 +171,8 @@ inline void rp5c01_device::check_alarm()
 rp5c01_device::rp5c01_device(const machine_config &mconfig, const char *tag, device_t *owner, uint32_t clock)
 	: device_t(mconfig, RP5C01, "RP5C01", tag, owner, clock, "rp5c01", __FILE__),
 		device_rtc_interface(mconfig, *this),
-		device_nvram_interface(mconfig, *this),
+		device_optional_nvram_interface(mconfig, *this, true),
 		m_out_alarm_cb(*this),
-		m_battery_backed(true),
 		m_mode(0),
 		m_reset(0),
 		m_alarm(1),
@@ -204,6 +203,7 @@ void rp5c01_device::device_start()
 
 	memset(m_reg, 0, sizeof(m_reg));
 	memset(m_ram, 0, sizeof(m_ram));
+	memarray().set(m_ram, RAM_SIZE, 8, ENDIANNESS_LITTLE, 1);
 
 	// 24 hour mode
 	m_reg[MODE01][REGISTER_12_24_SELECT] = 1;
@@ -273,30 +273,6 @@ void rp5c01_device::rtc_clock_updated(int year, int month, int day, int day_of_w
 
 void rp5c01_device::nvram_default()
 {
-}
-
-
-//-------------------------------------------------
-//  nvram_read - called to read NVRAM from the
-//  .nv file
-//-------------------------------------------------
-
-void rp5c01_device::nvram_read(emu_file &file)
-{
-	if (m_battery_backed)
-		file.read(m_ram, RAM_SIZE);
-}
-
-
-//-------------------------------------------------
-//  nvram_write - called to write NVRAM to the
-//  .nv file
-//-------------------------------------------------
-
-void rp5c01_device::nvram_write(emu_file &file)
-{
-	if (m_battery_backed)
-		file.write(m_ram, RAM_SIZE);
 }
 
 

--- a/src/devices/machine/rp5c01.h
+++ b/src/devices/machine/rp5c01.h
@@ -34,10 +34,6 @@
 #define MCFG_RP5C01_OUT_ALARM_CB(_devcb) \
 	devcb = &rp5c01_device::set_out_alarm_callback(*device, DEVCB_##_devcb);
 
-// include this macro if the chip is not battery backed
-#define MCFG_RP5C01_REMOVE_BATTERY() \
-	rp5c01_device::remove_battery(*device);
-
 
 //**************************************************************************
 //  TYPE DEFINITIONS
@@ -47,14 +43,13 @@
 
 class rp5c01_device :   public device_t,
 						public device_rtc_interface,
-						public device_nvram_interface
+						public device_optional_nvram_interface
 {
 public:
 	// construction/destruction
 	rp5c01_device(const machine_config &mconfig, const char *tag, device_t *owner, uint32_t clock);
 
 	template<class _Object> static devcb_base &set_out_alarm_callback(device_t &device, _Object object) { return downcast<rp5c01_device &>(device).m_out_alarm_cb.set_callback(object); }
-	static void remove_battery(device_t &device) { downcast<rp5c01_device &>(device).m_battery_backed = false; }
 
 	DECLARE_READ8_MEMBER( read );
 	DECLARE_WRITE8_MEMBER( write );
@@ -68,13 +63,10 @@ protected:
 
 	// device_rtc_interface overrides
 	virtual bool rtc_feature_leap_year() const override { return true; }
-	virtual bool rtc_battery_backed() const override { return m_battery_backed; }
 	virtual void rtc_clock_updated(int year, int month, int day, int day_of_week, int hour, int minute, int second) override;
 
 	// device_nvram_interface overrides
 	virtual void nvram_default() override;
-	virtual void nvram_read(emu_file &file) override;
-	virtual void nvram_write(emu_file &file) override;
 
 private:
 	inline void set_alarm_line();
@@ -86,7 +78,6 @@ private:
 	static const device_timer_id TIMER_16HZ = 1;
 
 	devcb_write_line m_out_alarm_cb;
-	bool m_battery_backed;
 
 	uint8_t m_reg[2][13];         // clock registers
 	uint8_t m_ram[13];            // RAM

--- a/src/emu/dinvram.cpp
+++ b/src/emu/dinvram.cpp
@@ -33,3 +33,56 @@ device_nvram_interface::device_nvram_interface(const machine_config &mconfig, de
 device_nvram_interface::~device_nvram_interface()
 {
 }
+
+
+//-------------------------------------------------
+//  nvram_read - called to read NVRAM from the
+//  provided file
+//-------------------------------------------------
+
+void device_nvram_interface::nvram_read(emu_file &file)
+{
+	if (memarray().base() != nullptr)
+		file.read(memarray().base(), memarray().bytes());
+}
+
+
+//-------------------------------------------------
+//  nvram_write - called to write NVRAM to the
+//  provided file
+//-------------------------------------------------
+
+void device_nvram_interface::nvram_write(emu_file &file)
+{
+	if (memarray().base() != nullptr)
+		file.write(memarray().base(), memarray().bytes());
+}
+
+
+//**************************************************************************
+//  OPTIONAL NVRAM INTERFACE
+//**************************************************************************
+
+//-------------------------------------------------
+//  device_optional_nvram_interface - constructor
+//-------------------------------------------------
+
+device_optional_nvram_interface::device_optional_nvram_interface(const machine_config &mconfig, device_t &device, bool has_battery_by_default)
+	: device_nvram_interface(mconfig, device),
+		m_has_battery(has_battery_by_default)
+{
+}
+
+
+//-------------------------------------------------
+//  static_set_has_battery - configuration helper
+//-------------------------------------------------
+
+void device_optional_nvram_interface::static_set_has_battery(device_t &device, bool has_battery)
+{
+	device_optional_nvram_interface *optnvram;
+	if (!device.interface(optnvram))
+		throw emu_fatalerror("MCFG_DEVICE_HAS_BATTERY called on device '%s' with no optional NVRAM interface\n", device.tag());
+
+	optnvram->m_has_battery = has_battery;
+}

--- a/src/emu/dinvram.h
+++ b/src/emu/dinvram.h
@@ -17,6 +17,14 @@
 #ifndef MAME_EMU_DINVRAM
 #define MAME_EMU_DINVRAM
 
+//**************************************************************************
+//  CONFIGURATION MACROS
+//**************************************************************************
+
+#define MCFG_DEVICE_HAS_BATTERY(_batt) \
+	device_optional_nvram_interface::static_set_has_battery(*device, _batt);
+
+
 
 //**************************************************************************
 //  TYPE DEFINITIONS
@@ -38,15 +46,43 @@ public:
 	void nvram_load(emu_file &file) { nvram_read(file); }
 	void nvram_save(emu_file &file) { nvram_write(file); }
 
+	bool has_battery_backup() const { return device_has_battery_backup(); }
+
+	memory_array &memarray() { return m_memarray; }
+
 protected:
 	// derived class overrides
 	virtual void nvram_default() = 0;
-	virtual void nvram_read(emu_file &file) = 0;
-	virtual void nvram_write(emu_file &file) = 0;
+	virtual void nvram_read(emu_file &file);
+	virtual void nvram_write(emu_file &file);
+	virtual bool device_has_battery_backup() const { return true; }
+
+private:
+	memory_array m_memarray;
 };
 
 // iterator
 typedef device_interface_iterator<device_nvram_interface> nvram_interface_iterator;
+
+// ======================> device_optional_nvram_interface
+
+// interface subclass for memories that may or may not be battery-backed
+class device_optional_nvram_interface : public device_nvram_interface
+{
+public:
+	// construction/destruction
+	device_optional_nvram_interface(const machine_config &mconfig, device_t &device, bool has_battery_by_default);
+
+	// static configuration
+	static void static_set_has_battery(device_t &device, bool has_battery);
+
+protected:
+	// device_nvram_interface overrides
+	virtual bool device_has_battery_backup() const override { return m_has_battery; }
+
+private:
+	bool m_has_battery;
+};
 
 
 #endif  /* MAME_EMU_DINVRAM */

--- a/src/emu/dirtc.cpp
+++ b/src/emu/dirtc.cpp
@@ -78,6 +78,10 @@ void device_rtc_interface::set_time(bool update, int year, int month, int day, i
 
 void device_rtc_interface::set_current_time(const system_time &systime)
 {
+	device_nvram_interface *nvram;
+	if (device().interface(nvram) && !nvram->has_battery_backup())
+		return;
+
 	set_time(true, systime.local_time.year, systime.local_time.month + 1, systime.local_time.mday, systime.local_time.weekday + 1,
 		systime.local_time.hour, systime.local_time.minute, systime.local_time.second);
 }

--- a/src/emu/dirtc.h
+++ b/src/emu/dirtc.h
@@ -50,8 +50,6 @@ public:
 	void set_time(bool update, int year, int month, int day, int day_of_week, int hour, int minute, int second);
 	void set_current_time(const system_time &systime);
 
-	bool has_battery() const { return rtc_battery_backed(); }
-
 protected:
 	static u8 convert_to_bcd(int val);
 	static int bcd_to_integer(u8 val);
@@ -68,7 +66,6 @@ protected:
 	// derived class overrides
 	virtual bool rtc_feature_y2k() const { return false; }
 	virtual bool rtc_feature_leap_year() const { return false; }
-	virtual bool rtc_battery_backed() const { return true; }
 	virtual void rtc_clock_updated(int year, int month, int day, int day_of_week, int hour, int minute, int second) = 0;
 
 	int m_register[7];

--- a/src/mame/drivers/punchout.cpp
+++ b/src/mame/drivers/punchout.cpp
@@ -694,7 +694,7 @@ static MACHINE_CONFIG_DERIVED( spnchout, punchout )
 	MCFG_CPU_IO_MAP(spnchout_io_map)
 
 	MCFG_DEVICE_ADD("rtc", RP5C01, 0) // OSCIN -> Vcc
-	MCFG_RP5C01_REMOVE_BATTERY()
+	MCFG_DEVICE_HAS_BATTERY(false)
 	MCFG_RP5H01_ADD("rp5h01")
 
 	MCFG_MACHINE_RESET_OVERRIDE(punchout_state, spnchout)


### PR DESCRIPTION
- Interface now holds a memory_array object whose contents, if any, are loaded and saved by the default implementation. Not all NVRAM devices have been updated to use this yet; this may become more important in the future, when this array may also be made viewable through the debugger or accessible through the Lua engine.
- NVRAM devices can implement a new device callback to optionally disable battery backup, in which case the emulation will neither create or load a NVRAM file. A subclass of device_nvram_interface provides a standard configuration macro for this.
- Remove some unnecessary c_str() accesses in running_machine.