### PR TITLE
Fixed regression when loading multipart softlists

### DIFF
--- a/src/emu/diimage.h
+++ b/src/emu/diimage.h
@@ -173,7 +173,7 @@ public:
 	void seterror(image_error_t err, const char *message);
 	void message(const char *format, ...) ATTR_PRINTF(2,3);
 
-	bool exists() { return !m_image_name.empty(); }
+	bool exists() const { return !m_image_name.empty(); }
 	const char *filename() const { if (m_image_name.empty()) return nullptr; else return m_image_name.c_str(); }
 	const char *basename() const { if (m_basename.empty()) return nullptr; else return m_basename.c_str(); }
 	const char *basename_noext()  const { if (m_basename_noext.empty()) return nullptr; else return m_basename_noext.c_str(); }

--- a/src/emu/softlist_dev.cpp
+++ b/src/emu/softlist_dev.cpp
@@ -365,7 +365,7 @@ software_compatibility software_list_device::is_compatible(const software_part &
 //  that can automatically mount this software part
 //-------------------------------------------------
 
-device_image_interface *software_list_device::find_mountable_image(const machine_config &mconfig, const software_part &part)
+device_image_interface *software_list_device::find_mountable_image(const machine_config &mconfig, const software_part &part, std::function<bool(const device_image_interface &)> filter)
 {
 	// if automount="no", don't bother
 	const char *mount = part.feature("automount");
@@ -375,13 +375,32 @@ device_image_interface *software_list_device::find_mountable_image(const machine
 	for (device_image_interface &image : image_interface_iterator(mconfig.root_device()))
 	{
 		const char *interface = image.image_interface();
-		if (interface != nullptr && part.matches_interface(interface))
-		{
-			if (!image.filename())
-				return &image;
-		}
+		if (interface != nullptr && part.matches_interface(interface) && filter(image))
+			return &image;
 	}
 	return nullptr;
+}
+
+
+//-------------------------------------------------
+//  find_mountable_image - find an image interface
+//  that can automatically mount this software part
+//-------------------------------------------------
+
+device_image_interface *software_list_device::find_mountable_image(const machine_config &mconfig, const software_part &part)
+{
+	// Multi-part softlists will distribute individual images serially (e.g. - first floppy to flop1, next one to flop2
+	// etc).  Pre MAME 0.183 relied on the core doing this distribution between calls to find_mountable_image() so it
+	// could check to see if the slot was empty.
+	//
+	// When softlists were refactored in MAME 0.183, this was changed to build a "plan" for what needs to be loaded, so
+	// it was incorrect to check the image slot.  This is why an overload for find_mountable_image() was created that
+	// takes an std::function.  This overload is being preserved for compatibility with existing code, but I regard the
+	// continued existance of this overload is a red flag.
+	return find_mountable_image(
+		mconfig,
+		part,
+		[](const device_image_interface &image) { return !image.exists(); });
 }
 
 

--- a/src/emu/softlist_dev.h
+++ b/src/emu/softlist_dev.h
@@ -159,7 +159,8 @@ public:
 	// static helpers
 	static software_list_device *find_by_name(const machine_config &mconfig, const std::string &name);
 	static void display_matches(const machine_config &config, const char *interface, const std::string &name);
-	static device_image_interface *find_mountable_image(const machine_config &mconfig, const software_part &part);
+	static device_image_interface *find_mountable_image(const machine_config &mconfig, const software_part &part, std::function<bool (const device_image_interface &)> filter);
+	static device_image_interface *find_mountable_image(const machine_config &mconfig, const software_part &part);	
 
 protected:
 	// device-level overrides

--- a/src/frontend/mame/mameopts.cpp
+++ b/src/frontend/mame/mameopts.cpp
@@ -377,7 +377,14 @@ std::map<std::string, std::string> mame_options::evaluate_initial_softlist_optio
 							// only load compatible software this way
 							if (swlistdev.is_compatible(swpart) == SOFTWARE_IS_COMPATIBLE)
 							{
-								device_image_interface *image = software_list_device::find_mountable_image(config, swpart);
+								// we need to find a mountable image slot, but we need to ensure it is a slot
+								// for which we have not already distributed a part to
+								device_image_interface *image = software_list_device::find_mountable_image(
+									config,
+									swpart,
+									[&results](const device_image_interface &candidate) { return results.count(candidate.instance_name()) == 0; });
+
+								// did we find a slot to put this part into?
 								if (image != nullptr)
 								{
 									// we've resolved this software


### PR DESCRIPTION
Pernod found a regression introduced in the 0.183 softlist refactoring whereby multi-part softlist items would not distribute to multiple slots.  The problem was that the old code was relying on the image slots being loaded into the core.  This is not the way the new system works, so I've added a hook into software_list_device::find_mountable_image() that allows the new approach to work.