### PR TITLE
i386/pc_vga: save state fixes

### DIFF
--- a/src/devices/cpu/i386/i386.cpp
+++ b/src/devices/cpu/i386/i386.cpp
@@ -3277,6 +3277,7 @@ void i386_device::i386_common_init()
 	save_item(NAME(m_sreg[GS].d));
 	save_item(NAME(m_eip));
 	save_item(NAME(m_prev_eip));
+
 	save_item(NAME(m_CF));
 	save_item(NAME(m_DF));
 	save_item(NAME(m_SF));
@@ -3286,9 +3287,24 @@ void i386_device::i386_common_init()
 	save_item(NAME(m_AF));
 	save_item(NAME(m_IF));
 	save_item(NAME(m_TF));
+	save_item(NAME(m_IOP1));
+	save_item(NAME(m_IOP2));
+	save_item(NAME(m_NT));
+	save_item(NAME(m_RF));
+	save_item(NAME(m_VM));
+	save_item(NAME(m_AC));
+	save_item(NAME(m_VIF));
+	save_item(NAME(m_VIP));
+	save_item(NAME(m_ID));
+
+	save_item(NAME(m_CPL));
+
+	save_item(NAME(m_performed_intersegment_jump));
+
 	save_item(NAME(m_cr));
 	save_item(NAME(m_dr));
 	save_item(NAME(m_tr));
+
 	save_item(NAME(m_idtr.base));
 	save_item(NAME(m_idtr.limit));
 	save_item(NAME(m_gdtr.base));
@@ -3301,12 +3317,17 @@ void i386_device::i386_common_init()
 	save_item(NAME(m_ldtr.segment));
 	save_item(NAME(m_ldtr.limit));
 	save_item(NAME(m_ldtr.flags));
+
+	save_item(NAME(m_segment_override));
+
 	save_item(NAME(m_irq_state));
-	save_item(NAME(m_performed_intersegment_jump));
+	save_item(NAME(m_a20_mask));
+
 	save_item(NAME(m_mxcsr));
+
 	save_item(NAME(m_smm));
-	save_item(NAME(m_smi_latched));
 	save_item(NAME(m_smi));
+	save_item(NAME(m_smi_latched));
 	save_item(NAME(m_nmi_masked));
 	save_item(NAME(m_nmi_latched));
 	save_item(NAME(m_smbase));

--- a/src/devices/cpu/i386/i386ops.hxx
+++ b/src/devices/cpu/i386/i386ops.hxx
@@ -2559,7 +2559,7 @@ void i386_device::i386_loadall()       // Opcode 0x0f 0x07 (0x0f 0x05 on 80286),
 	m_sreg[ES].limit = READ32(ea + 0xc8);
 	m_CPL = (m_sreg[SS].flags >> 5) & 3; // cpl == dpl of ss
 
-	for(int i = 0; i < GS; i++)
+	for(int i = 0; i <= GS; i++)
 	{
 		m_sreg[i].valid = (m_sreg[i].flags & 0x80) ? true : false;
 		m_sreg[i].d = (m_sreg[i].flags & 0x4000) ? 1 : 0;

--- a/src/devices/cpu/i386/pentops.hxx
+++ b/src/devices/cpu/i386/pentops.hxx
@@ -166,7 +166,7 @@ void i386_device::pentium_rsm()
 
 	m_CPL = (m_sreg[SS].flags >> 13) & 3; // cpl == dpl of ss
 
-	for(int i = 0; i < GS; i++)
+	for(int i = 0; i <= GS; i++)
 	{
 		if(PROTECTED_MODE && !V8086_MODE)
 		{

--- a/src/devices/video/pc_vga.cpp
+++ b/src/devices/video/pc_vga.cpp
@@ -258,6 +258,10 @@ void vga_device::device_start()
 	vga.memory.resize(vga.svga_intf.vram_size);
 	memset(&vga.memory[0], 0, vga.svga_intf.vram_size);
 	save_item(NAME(vga.memory));
+	save_item(NAME(vga.pens));
+
+	save_item(NAME(vga.miscellaneous_output));
+	save_item(NAME(vga.feature_control));
 
 	save_item(NAME(vga.sequencer.index));
 	save_item(NAME(vga.sequencer.data));

--- a/src/devices/video/pc_vga.cpp
+++ b/src/devices/video/pc_vga.cpp
@@ -335,6 +335,14 @@ void vga_device::device_start()
 	save_item(NAME(vga.attribute.pel_shift));
 	save_item(NAME(vga.attribute.pel_shift_latch));
 
+	save_item(NAME(vga.dac.read_index));
+	save_item(NAME(vga.dac.write_index));
+	save_item(NAME(vga.dac.mask));
+	save_item(NAME(vga.dac.read));
+	save_item(NAME(vga.dac.state));
+	save_item(NAME(vga.dac.color));
+	save_item(NAME(vga.dac.dirty));
+
 	m_vblank_timer = machine().scheduler().timer_alloc(timer_expired_delegate(FUNC(vga_device::vblank_timer_cb),this));
 }
 
@@ -924,9 +932,9 @@ uint8_t vga_device::pc_vga_choosevideomode()
 			for (i=0; i<256;i++)
 			{
 				/* TODO: color shifters? */
-				m_palette->set_pen_color(i, (vga.dac.color[i & vga.dac.mask].red & 0x3f) << 2,
-										(vga.dac.color[i & vga.dac.mask].green & 0x3f) << 2,
-										(vga.dac.color[i & vga.dac.mask].blue & 0x3f) << 2);
+				m_palette->set_pen_color(i, (vga.dac.color[3*(i & vga.dac.mask)] & 0x3f) << 2,
+										(vga.dac.color[3*(i & vga.dac.mask) + 1] & 0x3f) << 2,
+										(vga.dac.color[3*(i & vga.dac.mask) + 2] & 0x3f) << 2);
 			}
 			vga.dac.dirty = 0;
 		}
@@ -985,9 +993,9 @@ uint8_t svga_device::pc_vga_choosevideomode()
 			for (i=0; i<256;i++)
 			{
 				/* TODO: color shifters? */
-				m_palette->set_pen_color(i, (vga.dac.color[i & vga.dac.mask].red & 0x3f) << 2,
-										(vga.dac.color[i & vga.dac.mask].green & 0x3f) << 2,
-										(vga.dac.color[i & vga.dac.mask].blue & 0x3f) << 2);
+				m_palette->set_pen_color(i, (vga.dac.color[3*(i & vga.dac.mask)] & 0x3f) << 2,
+										(vga.dac.color[3*(i & vga.dac.mask) + 1] & 0x3f) << 2,
+										(vga.dac.color[3*(i & vga.dac.mask) + 2] & 0x3f) << 2);
 			}
 			vga.dac.dirty = 0;
 		}
@@ -1802,13 +1810,13 @@ READ8_MEMBER(vga_device::port_03c0_r)
 				switch (vga.dac.state++)
 				{
 					case 0:
-						data = vga.dac.color[vga.dac.read_index].red;
+						data = vga.dac.color[3*vga.dac.read_index];
 						break;
 					case 1:
-						data = vga.dac.color[vga.dac.read_index].green;
+						data = vga.dac.color[3*vga.dac.read_index + 1];
 						break;
 					case 2:
-						data = vga.dac.color[vga.dac.read_index].blue;
+						data = vga.dac.color[3*vga.dac.read_index + 2];
 						break;
 				}
 
@@ -1990,13 +1998,13 @@ WRITE8_MEMBER(vga_device::port_03c0_w)
 		{
 			switch (vga.dac.state++) {
 			case 0:
-				vga.dac.color[vga.dac.write_index].red=data;
+				vga.dac.color[3*vga.dac.write_index]=data;
 				break;
 			case 1:
-				vga.dac.color[vga.dac.write_index].green=data;
+				vga.dac.color[3*vga.dac.write_index + 1]=data;
 				break;
 			case 2:
-				vga.dac.color[vga.dac.write_index].blue=data;
+				vga.dac.color[3*vga.dac.write_index + 2]=data;
 				break;
 			}
 			vga.dac.dirty=1;

--- a/src/devices/video/pc_vga.h
+++ b/src/devices/video/pc_vga.h
@@ -215,12 +215,11 @@ protected:
 			uint8_t pel_shift_latch;
 		} attribute;
 
-
 		struct {
 			uint8_t read_index, write_index, mask;
 			int read;
 			int state;
-			struct { uint8_t red, green, blue; } color[0x100];
+			uint8_t color[0x300]; /* flat RGB triplets */
 			int dirty;
 		} dac;
 


### PR DESCRIPTION
- VGA card now saves vga.dac to the state, as the MAME palette is clobbered periodically with data from here. Changed the type of vga.dac.colour to a flat uint8_t array seeing as save_item isn't struct-friendly. Fixes Liero.
- Saved more VGA flags, including vga.miscellaneous_output, which despite the vague name is needed for reading from the ports.
- Fixed an enum range check miss.
- Saved more i386 flags required for 32-bit save states. Fixes Jump 'n Bump.