### PR TITLE
latch8, discrete: Major device cleanup (nw)

### DIFF
--- a/src/devices/machine/latch8.cpp
+++ b/src/devices/machine/latch8.cpp
@@ -19,19 +19,10 @@ void latch8_device::update(uint8_t new_val, uint8_t mask)
 
 	if (m_has_write)
 	{
-		int i;
 		uint8_t changed = old_val ^ m_value;
-		for (i=0; i<8; i++)
-			if (((changed & (1<<i)) != 0)) {
-				if (i==0 && !m_write_0.isnull()) m_write_0(machine().dummy_space(), m_offset[i] , (m_value >> i) & 1);
-				if (i==1 && !m_write_1.isnull()) m_write_1(machine().dummy_space(), m_offset[i] , (m_value >> i) & 1);
-				if (i==2 && !m_write_2.isnull()) m_write_2(machine().dummy_space(), m_offset[i] , (m_value >> i) & 1);
-				if (i==3 && !m_write_3.isnull()) m_write_3(machine().dummy_space(), m_offset[i] , (m_value >> i) & 1);
-				if (i==4 && !m_write_4.isnull()) m_write_4(machine().dummy_space(), m_offset[i] , (m_value >> i) & 1);
-				if (i==5 && !m_write_5.isnull()) m_write_5(machine().dummy_space(), m_offset[i] , (m_value >> i) & 1);
-				if (i==6 && !m_write_6.isnull()) m_write_6(machine().dummy_space(), m_offset[i] , (m_value >> i) & 1);
-				if (i==7 && !m_write_7.isnull()) m_write_7(machine().dummy_space(), m_offset[i] , (m_value >> i) & 1);
-			}
+		for (int i = 0; i < 8; i++)
+			if (BIT(changed, i) && !m_write_cb[i].isnull())
+				m_write_cb[i](BIT(m_value, i));
 	}
 }
 
@@ -49,22 +40,16 @@ READ8_MEMBER( latch8_device::read )
 {
 	uint8_t res;
 
-	assert(offset == 0);
+	// FIXME: AM_MIRROR(0xff) doesn't work properly
+	//assert(offset == 0);
 
 	res = m_value;
 	if (m_has_read)
 	{
-		int i;
-		for (i=0; i<8; i++)
+		for (int i = 0; i < 8; i++)
 		{
-			if (i==0 && !m_read_0.isnull()) { res &= ~( 1 << i); res |= ((m_read_0(space, 0, 0xff) >> m_offset[i]) & 0x01) << i; }
-			if (i==1 && !m_read_1.isnull()) { res &= ~( 1 << i); res |= ((m_read_1(space, 0, 0xff) >> m_offset[i]) & 0x01) << i; }
-			if (i==2 && !m_read_2.isnull()) { res &= ~( 1 << i); res |= ((m_read_2(space, 0, 0xff) >> m_offset[i]) & 0x01) << i; }
-			if (i==3 && !m_read_3.isnull()) { res &= ~( 1 << i); res |= ((m_read_3(space, 0, 0xff) >> m_offset[i]) & 0x01) << i; }
-			if (i==4 && !m_read_4.isnull()) { res &= ~( 1 << i); res |= ((m_read_4(space, 0, 0xff) >> m_offset[i]) & 0x01) << i; }
-			if (i==5 && !m_read_5.isnull()) { res &= ~( 1 << i); res |= ((m_read_5(space, 0, 0xff) >> m_offset[i]) & 0x01) << i; }
-			if (i==6 && !m_read_6.isnull()) { res &= ~( 1 << i); res |= ((m_read_6(space, 0, 0xff) >> m_offset[i]) & 0x01) << i; }
-			if (i==7 && !m_read_7.isnull()) { res &= ~( 1 << i); res |= ((m_read_7(space, 0, 0xff) >> m_offset[i]) & 0x01) << i;}
+			if (!m_read_cb[i].isnull())
+				res = (res & ~(1 << i)) | (m_read_cb[i]() << i);
 		}
 	}
 	return (res & ~m_maskout) ^ m_xorvalue;
@@ -92,30 +77,23 @@ WRITE8_MEMBER( latch8_device::reset_w )
 /* read bit x                 */
 /* return (latch >> x) & 0x01 */
 
-uint8_t latch8_device::bitx_r( offs_t offset, int bit)
-{
-	assert( offset == 0);
+READ_LINE_MEMBER(latch8_device::bit0_r) { return BIT(m_value, 0); }
+READ_LINE_MEMBER(latch8_device::bit1_r) { return BIT(m_value, 1); }
+READ_LINE_MEMBER(latch8_device::bit2_r) { return BIT(m_value, 2); }
+READ_LINE_MEMBER(latch8_device::bit3_r) { return BIT(m_value, 3); }
+READ_LINE_MEMBER(latch8_device::bit4_r) { return BIT(m_value, 4); }
+READ_LINE_MEMBER(latch8_device::bit5_r) { return BIT(m_value, 5); }
+READ_LINE_MEMBER(latch8_device::bit6_r) { return BIT(m_value, 6); }
+READ_LINE_MEMBER(latch8_device::bit7_r) { return BIT(m_value, 7); }
 
-	return (m_value >> bit) & 0x01;
-}
-
-READ8_MEMBER( latch8_device::bit0_r) { return bitx_r(offset, 0); }
-READ8_MEMBER( latch8_device::bit1_r) { return bitx_r(offset, 1); }
-READ8_MEMBER( latch8_device::bit2_r) { return bitx_r(offset, 2); }
-READ8_MEMBER( latch8_device::bit3_r) { return bitx_r(offset, 3); }
-READ8_MEMBER( latch8_device::bit4_r) { return bitx_r(offset, 4); }
-READ8_MEMBER( latch8_device::bit5_r) { return bitx_r(offset, 5); }
-READ8_MEMBER( latch8_device::bit6_r) { return bitx_r(offset, 6); }
-READ8_MEMBER( latch8_device::bit7_r) { return bitx_r(offset, 7); }
-
-READ8_MEMBER( latch8_device::bit0_q_r) { return bitx_r(offset, 0) ^ 1; }
-READ8_MEMBER( latch8_device::bit1_q_r) { return bitx_r(offset, 1) ^ 1; }
-READ8_MEMBER( latch8_device::bit2_q_r) { return bitx_r(offset, 2) ^ 1; }
-READ8_MEMBER( latch8_device::bit3_q_r) { return bitx_r(offset, 3) ^ 1; }
-READ8_MEMBER( latch8_device::bit4_q_r) { return bitx_r(offset, 4) ^ 1; }
-READ8_MEMBER( latch8_device::bit5_q_r) { return bitx_r(offset, 5) ^ 1; }
-READ8_MEMBER( latch8_device::bit6_q_r) { return bitx_r(offset, 6) ^ 1; }
-READ8_MEMBER( latch8_device::bit7_q_r) { return bitx_r(offset, 7) ^ 1; }
+READ_LINE_MEMBER(latch8_device::bit0_q_r) { return BIT(m_value, 0) ^ 1; }
+READ_LINE_MEMBER(latch8_device::bit1_q_r) { return BIT(m_value, 1) ^ 1; }
+READ_LINE_MEMBER(latch8_device::bit2_q_r) { return BIT(m_value, 2) ^ 1; }
+READ_LINE_MEMBER(latch8_device::bit3_q_r) { return BIT(m_value, 3) ^ 1; }
+READ_LINE_MEMBER(latch8_device::bit4_q_r) { return BIT(m_value, 4) ^ 1; }
+READ_LINE_MEMBER(latch8_device::bit5_q_r) { return BIT(m_value, 5) ^ 1; }
+READ_LINE_MEMBER(latch8_device::bit6_q_r) { return BIT(m_value, 6) ^ 1; }
+READ_LINE_MEMBER(latch8_device::bit7_q_r) { return BIT(m_value, 7) ^ 1; }
 
 /* write bit x from data into bit determined by offset */
 /* latch = (latch & ~(1<<offset)) | (((data >> x) & 0x01) << offset) */
@@ -153,24 +131,9 @@ latch8_device::latch8_device(const machine_config &mconfig, const char *tag, dev
 		m_maskout(0),
 		m_xorvalue(0),
 		m_nosync(0),
-		m_write_0(*this),
-		m_write_1(*this),
-		m_write_2(*this),
-		m_write_3(*this),
-		m_write_4(*this),
-		m_write_5(*this),
-		m_write_6(*this),
-		m_write_7(*this),
-		m_read_0(*this),
-		m_read_1(*this),
-		m_read_2(*this),
-		m_read_3(*this),
-		m_read_4(*this),
-		m_read_5(*this),
-		m_read_6(*this),
-		m_read_7(*this)
+		m_write_cb{{*this}, {*this}, {*this}, {*this}, {*this}, {*this}, {*this}, {*this}},
+		m_read_cb{{*this}, {*this}, {*this}, {*this}, {*this}, {*this}, {*this}, {*this}}
 {
-	memset(m_offset, 0, sizeof(m_offset));
 }
 
 
@@ -181,58 +144,30 @@ latch8_device::latch8_device(const machine_config &mconfig, const char *tag, dev
 
 void latch8_device::device_validity_check(validity_checker &valid) const
 {
-	if (!m_read_0.isnull() && !m_write_0.isnull()) osd_printf_error("Device %s: Bit 0 already has a handler.\n", tag());
-	if (!m_read_1.isnull() && !m_write_1.isnull()) osd_printf_error("Device %s: Bit 1 already has a handler.\n", tag());
-	if (!m_read_2.isnull() && !m_write_2.isnull()) osd_printf_error("Device %s: Bit 2 already has a handler.\n", tag());
-	if (!m_read_3.isnull() && !m_write_3.isnull()) osd_printf_error("Device %s: Bit 3 already has a handler.\n", tag());
-	if (!m_read_4.isnull() && !m_write_4.isnull()) osd_printf_error("Device %s: Bit 4 already has a handler.\n", tag());
-	if (!m_read_5.isnull() && !m_write_5.isnull()) osd_printf_error("Device %s: Bit 5 already has a handler.\n", tag());
-	if (!m_read_6.isnull() && !m_write_6.isnull()) osd_printf_error("Device %s: Bit 6 already has a handler.\n", tag());
-	if (!m_read_7.isnull() && !m_write_7.isnull()) osd_printf_error("Device %s: Bit 7 already has a handler.\n", tag());
+	for (int i = 0; i < 8; i++)
+		if (!m_read_cb[i].isnull() && !m_write_cb[i].isnull())
+			osd_printf_error("Device %s: Bit %d already has a handler.\n", tag(), i);
 }
+
 //-------------------------------------------------
 //  device_start - device-specific startup
 //-------------------------------------------------
 
 void latch8_device::device_start()
 {
-	m_write_0.resolve();
-	m_write_1.resolve();
-	m_write_2.resolve();
-	m_write_3.resolve();
-	m_write_4.resolve();
-	m_write_5.resolve();
-	m_write_6.resolve();
-	m_write_7.resolve();
-
-	m_read_0.resolve();
-	m_read_1.resolve();
-	m_read_2.resolve();
-	m_read_3.resolve();
-	m_read_4.resolve();
-	m_read_5.resolve();
-	m_read_6.resolve();
-	m_read_7.resolve();
-
 	/* setup nodemap */
-	if (!m_write_0.isnull()) m_has_write = 1;
-	if (!m_write_1.isnull()) m_has_write = 1;
-	if (!m_write_2.isnull()) m_has_write = 1;
-	if (!m_write_3.isnull()) m_has_write = 1;
-	if (!m_write_4.isnull()) m_has_write = 1;
-	if (!m_write_5.isnull()) m_has_write = 1;
-	if (!m_write_6.isnull()) m_has_write = 1;
-	if (!m_write_7.isnull()) m_has_write = 1;
+	for (auto &cb : m_write_cb)
+	{
+		if (!cb.isnull()) m_has_write = 1;
+		cb.resolve();
+	}
 
 	/* setup device read handlers */
-	if (!m_read_0.isnull()) m_has_read = 1;
-	if (!m_read_1.isnull()) m_has_read = 1;
-	if (!m_read_2.isnull()) m_has_read = 1;
-	if (!m_read_3.isnull()) m_has_read = 1;
-	if (!m_read_4.isnull()) m_has_read = 1;
-	if (!m_read_5.isnull()) m_has_read = 1;
-	if (!m_read_6.isnull()) m_has_read = 1;
-	if (!m_read_7.isnull()) m_has_read = 1;
+	for (auto &cb : m_read_cb)
+	{
+		if (!cb.isnull()) m_has_read = 1;
+		cb.resolve();
+	}
 
 	save_item(NAME(m_value));
 }

--- a/src/devices/machine/latch8.h
+++ b/src/devices/machine/latch8.h
@@ -7,8 +7,7 @@
     Generic emulation of 74LS174/175, 74LS259 and other latches.
     Apart from providing synched latch operation, these
     latches can be configured to read their input bitwise from other
-    devices as well and individual bits can be connected to
-    discrete nodes.
+    devices as well.
 
     Please see audio/dkong.c for examples.
 
@@ -42,26 +41,26 @@ public:
 	/* read bit x                 */
 	/* return (latch >> x) & 0x01 */
 
-	DECLARE_READ8_MEMBER( bit0_r );
-	DECLARE_READ8_MEMBER( bit1_r );
-	DECLARE_READ8_MEMBER( bit2_r );
-	DECLARE_READ8_MEMBER( bit3_r );
-	DECLARE_READ8_MEMBER( bit4_r );
-	DECLARE_READ8_MEMBER( bit5_r );
-	DECLARE_READ8_MEMBER( bit6_r );
-	DECLARE_READ8_MEMBER( bit7_r );
+	DECLARE_READ_LINE_MEMBER( bit0_r );
+	DECLARE_READ_LINE_MEMBER( bit1_r );
+	DECLARE_READ_LINE_MEMBER( bit2_r );
+	DECLARE_READ_LINE_MEMBER( bit3_r );
+	DECLARE_READ_LINE_MEMBER( bit4_r );
+	DECLARE_READ_LINE_MEMBER( bit5_r );
+	DECLARE_READ_LINE_MEMBER( bit6_r );
+	DECLARE_READ_LINE_MEMBER( bit7_r );
 
 	/* read inverted bit x        */
 	/* return (latch >> x) & 0x01 */
 
-	DECLARE_READ8_MEMBER( bit0_q_r );
-	DECLARE_READ8_MEMBER( bit1_q_r );
-	DECLARE_READ8_MEMBER( bit2_q_r );
-	DECLARE_READ8_MEMBER( bit3_q_r );
-	DECLARE_READ8_MEMBER( bit4_q_r );
-	DECLARE_READ8_MEMBER( bit5_q_r );
-	DECLARE_READ8_MEMBER( bit6_q_r );
-	DECLARE_READ8_MEMBER( bit7_q_r );
+	DECLARE_READ_LINE_MEMBER( bit0_q_r );
+	DECLARE_READ_LINE_MEMBER( bit1_q_r );
+	DECLARE_READ_LINE_MEMBER( bit2_q_r );
+	DECLARE_READ_LINE_MEMBER( bit3_q_r );
+	DECLARE_READ_LINE_MEMBER( bit4_q_r );
+	DECLARE_READ_LINE_MEMBER( bit5_q_r );
+	DECLARE_READ_LINE_MEMBER( bit6_q_r );
+	DECLARE_READ_LINE_MEMBER( bit7_q_r );
 
 	/* write bit x from data into bit determined by offset */
 	/* latch = (latch & ~(1<<offset)) | (((data >> x) & 0x01) << offset) */
@@ -79,23 +78,9 @@ public:
 	static void set_xorvalue(device_t &device, uint32_t xorvalue) { downcast<latch8_device &>(device).m_xorvalue = xorvalue; }
 	static void set_nosync(device_t &device, uint32_t nosync) { downcast<latch8_device &>(device).m_nosync = nosync; }
 
-	template<class _Object> static devcb_base &set_write_0(device_t &device, _Object object, uint32_t offset) { downcast<latch8_device &>(device).m_offset[0] = offset; return downcast<latch8_device &>(device).m_write_0.set_callback(object); }
-	template<class _Object> static devcb_base &set_write_1(device_t &device, _Object object, uint32_t offset) { downcast<latch8_device &>(device).m_offset[1] = offset; return downcast<latch8_device &>(device).m_write_1.set_callback(object); }
-	template<class _Object> static devcb_base &set_write_2(device_t &device, _Object object, uint32_t offset) { downcast<latch8_device &>(device).m_offset[2] = offset; return downcast<latch8_device &>(device).m_write_2.set_callback(object); }
-	template<class _Object> static devcb_base &set_write_3(device_t &device, _Object object, uint32_t offset) { downcast<latch8_device &>(device).m_offset[3] = offset; return downcast<latch8_device &>(device).m_write_3.set_callback(object); }
-	template<class _Object> static devcb_base &set_write_4(device_t &device, _Object object, uint32_t offset) { downcast<latch8_device &>(device).m_offset[4] = offset; return downcast<latch8_device &>(device).m_write_4.set_callback(object); }
-	template<class _Object> static devcb_base &set_write_5(device_t &device, _Object object, uint32_t offset) { downcast<latch8_device &>(device).m_offset[5] = offset; return downcast<latch8_device &>(device).m_write_5.set_callback(object); }
-	template<class _Object> static devcb_base &set_write_6(device_t &device, _Object object, uint32_t offset) { downcast<latch8_device &>(device).m_offset[6] = offset; return downcast<latch8_device &>(device).m_write_6.set_callback(object); }
-	template<class _Object> static devcb_base &set_write_7(device_t &device, _Object object, uint32_t offset) { downcast<latch8_device &>(device).m_offset[7] = offset; return downcast<latch8_device &>(device).m_write_7.set_callback(object); }
+	template<class _Object> static devcb_base &set_write_cb(device_t &device, int i, _Object object) { return downcast<latch8_device &>(device).m_write_cb[i].set_callback(object); }
 
-	template<class _Object> static devcb_base &set_read_0(device_t &device, _Object object, uint32_t offset) { downcast<latch8_device &>(device).m_offset[0] = offset; return downcast<latch8_device &>(device).m_read_0.set_callback(object); }
-	template<class _Object> static devcb_base &set_read_1(device_t &device, _Object object, uint32_t offset) { downcast<latch8_device &>(device).m_offset[1] = offset; return downcast<latch8_device &>(device).m_read_1.set_callback(object); }
-	template<class _Object> static devcb_base &set_read_2(device_t &device, _Object object, uint32_t offset) { downcast<latch8_device &>(device).m_offset[2] = offset; return downcast<latch8_device &>(device).m_read_2.set_callback(object); }
-	template<class _Object> static devcb_base &set_read_3(device_t &device, _Object object, uint32_t offset) { downcast<latch8_device &>(device).m_offset[3] = offset; return downcast<latch8_device &>(device).m_read_3.set_callback(object); }
-	template<class _Object> static devcb_base &set_read_4(device_t &device, _Object object, uint32_t offset) { downcast<latch8_device &>(device).m_offset[4] = offset; return downcast<latch8_device &>(device).m_read_4.set_callback(object); }
-	template<class _Object> static devcb_base &set_read_5(device_t &device, _Object object, uint32_t offset) { downcast<latch8_device &>(device).m_offset[5] = offset; return downcast<latch8_device &>(device).m_read_5.set_callback(object); }
-	template<class _Object> static devcb_base &set_read_6(device_t &device, _Object object, uint32_t offset) { downcast<latch8_device &>(device).m_offset[6] = offset; return downcast<latch8_device &>(device).m_read_6.set_callback(object); }
-	template<class _Object> static devcb_base &set_read_7(device_t &device, _Object object, uint32_t offset) { downcast<latch8_device &>(device).m_offset[7] = offset; return downcast<latch8_device &>(device).m_read_7.set_callback(object); }
+	template<class _Object> static devcb_base &set_read_cb(device_t &device, int i, _Object object) { return downcast<latch8_device &>(device).m_read_cb[i].set_callback(object); }
 
 protected:
 	// device-level overrides
@@ -105,8 +90,8 @@ protected:
 
 	TIMER_CALLBACK_MEMBER( timerproc );
 	void update(uint8_t new_val, uint8_t mask);
-	inline uint8_t bitx_r( offs_t offset, int bit);
 	inline void bitx_w(int bit, offs_t offset, uint8_t data);
+
 private:
 	// internal state
 	uint8_t            m_value;
@@ -118,25 +103,8 @@ private:
 	uint32_t           m_xorvalue;  /* after mask */
 	uint32_t           m_nosync;
 
-	devcb_write8    m_write_0;
-	devcb_write8    m_write_1;
-	devcb_write8    m_write_2;
-	devcb_write8    m_write_3;
-	devcb_write8    m_write_4;
-	devcb_write8    m_write_5;
-	devcb_write8    m_write_6;
-	devcb_write8    m_write_7;
-
-	devcb_read8     m_read_0;
-	devcb_read8     m_read_1;
-	devcb_read8     m_read_2;
-	devcb_read8     m_read_3;
-	devcb_read8     m_read_4;
-	devcb_read8     m_read_5;
-	devcb_read8     m_read_6;
-	devcb_read8     m_read_7;
-
-	uint32_t           m_offset[8];
+	devcb_write_line   m_write_cb[8];
+	devcb_read_line    m_read_cb[8];
 };
 
 extern const device_type LATCH8;
@@ -161,68 +129,54 @@ extern const device_type LATCH8;
 	latch8_device::set_nosync(*device, _nosync);
 
 /* Write bit to discrete node */
-#define MCFG_LATCH8_WRITE_0(_devcb, _node) \
-	devcb = &latch8_device::set_write_0(*device, DEVCB_##_devcb, _node);
+#define MCFG_LATCH8_WRITE_0(_devcb) \
+	devcb = &latch8_device::set_write_cb(*device, 0, DEVCB_##_devcb);
 
-#define MCFG_LATCH8_WRITE_1(_devcb, _node) \
-	devcb = &latch8_device::set_write_1(*device, DEVCB_##_devcb, _node);
+#define MCFG_LATCH8_WRITE_1(_devcb) \
+	devcb = &latch8_device::set_write_cb(*device, 1, DEVCB_##_devcb);
 
-#define MCFG_LATCH8_WRITE_2(_devcb, _node) \
-	devcb = &latch8_device::set_write_2(*device, DEVCB_##_devcb, _node);
+#define MCFG_LATCH8_WRITE_2(_devcb) \
+	devcb = &latch8_device::set_write_cb(*device, 2, DEVCB_##_devcb);
 
-#define MCFG_LATCH8_WRITE_3(_devcb, _node) \
-	devcb = &latch8_device::set_write_3(*device, DEVCB_##_devcb, _node);
+#define MCFG_LATCH8_WRITE_3(_devcb) \
+	devcb = &latch8_device::set_write_cb(*device, 3, DEVCB_##_devcb);
 
-#define MCFG_LATCH8_WRITE_4(_devcb, _node) \
-	devcb = &latch8_device::set_write_4(*device, DEVCB_##_devcb, _node);
+#define MCFG_LATCH8_WRITE_4(_devcb) \
+	devcb = &latch8_device::set_write_cb(*device, 4, DEVCB_##_devcb);
 
-#define MCFG_LATCH8_WRITE_5(_devcb, _node) \
-	devcb = &latch8_device::set_write_5(*device, DEVCB_##_devcb, _node);
+#define MCFG_LATCH8_WRITE_5(_devcb) \
+	devcb = &latch8_device::set_write_cb(*device, 5, DEVCB_##_devcb);
 
-#define MCFG_LATCH8_WRITE_6(_devcb, _node) \
-	devcb = &latch8_device::set_write_6(*device, DEVCB_##_devcb, _node);
+#define MCFG_LATCH8_WRITE_6(_devcb) \
+	devcb = &latch8_device::set_write_cb(*device, 6, DEVCB_##_devcb);
 
-#define MCFG_LATCH8_WRITE_7(_devcb, _node) \
-	devcb = &latch8_device::set_write_7(*device, DEVCB_##_devcb, _node);
+#define MCFG_LATCH8_WRITE_7(_devcb) \
+	devcb = &latch8_device::set_write_cb(*device, 7, DEVCB_##_devcb);
 
 /* Upon read, replace bits by reading from another device handler */
-#define MCFG_LATCH8_READ_0(_devcb, _from_bit) \
-	devcb = &latch8_device::set_read_0(*device, DEVCB_##_devcb, _from_bit);
+#define MCFG_LATCH8_READ_0(_devcb) \
+	devcb = &latch8_device::set_read_cb(*device, 0, DEVCB_##_devcb);
 
-#define MCFG_LATCH8_READ_1(_devcb, _from_bit) \
-	devcb = &latch8_device::set_read_1(*device, DEVCB_##_devcb, _from_bit);
+#define MCFG_LATCH8_READ_1(_devcb) \
+	devcb = &latch8_device::set_read_cb(*device, 1, DEVCB_##_devcb);
 
-#define MCFG_LATCH8_READ_2(_devcb, _from_bit) \
-	devcb = &latch8_device::set_read_2(*device, DEVCB_##_devcb, _from_bit);
+#define MCFG_LATCH8_READ_2(_devcb) \
+	devcb = &latch8_device::set_read_cb(*device, 2, DEVCB_##_devcb);
 
-#define MCFG_LATCH8_READ_3(_devcb, _from_bit) \
-	devcb = &latch8_device::set_read_3(*device, DEVCB_##_devcb, _from_bit);
+#define MCFG_LATCH8_READ_3(_devcb) \
+	devcb = &latch8_device::set_read_cb(*device, 3, DEVCB_##_devcb);
 
-#define MCFG_LATCH8_READ_4(_devcb, _from_bit) \
-	devcb = &latch8_device::set_read_4(*device, DEVCB_##_devcb, _from_bit);
+#define MCFG_LATCH8_READ_4(_devcb) \
+	devcb = &latch8_device::set_read_cb(*device, 4, DEVCB_##_devcb);
 
-#define MCFG_LATCH8_READ_5(_devcb, _from_bit) \
-	devcb = &latch8_device::set_read_5(*device, DEVCB_##_devcb, _from_bit);
+#define MCFG_LATCH8_READ_5(_devcb) \
+	devcb = &latch8_device::set_read_cb(*device, 5, DEVCB_##_devcb);
 
-#define MCFG_LATCH8_READ_6(_devcb, _from_bit) \
-	devcb = &latch8_device::set_read_6(*device, DEVCB_##_devcb, _from_bit);
+#define MCFG_LATCH8_READ_6(_devcb) \
+	devcb = &latch8_device::set_read_cb(*device, 6, DEVCB_##_devcb);
 
-#define MCFG_LATCH8_READ_7(_devcb, _from_bit) \
-	devcb = &latch8_device::set_read_7(*device, DEVCB_##_devcb, _from_bit);
+#define MCFG_LATCH8_READ_7(_devcb) \
+	devcb = &latch8_device::set_read_cb(*device, 7, DEVCB_##_devcb);
 
-
-/* Accessor macros */
-
-#define AM_LATCH8_READ(_tag) \
-	AM_DEVREAD(_tag, latch8_device, read)
-
-#define AM_LATCH8_READBIT(_tag, _bit) \
-	AM_DEVREAD(_tag, latch8_device, bit ## _bit ## _q_r)
-
-#define AM_LATCH8_WRITE(_tag) \
-	AM_DEVWRITE(_tag, latch8_device, write)
-
-#define AM_LATCH8_READWRITE(_tag) \
-	AM_DEVREADWRITE(_tag, latch8_device, read, write)
 
 #endif /* __LATCH8_H_ */

--- a/src/devices/sound/discrete.h
+++ b/src/devices/sound/discrete.h
@@ -4292,6 +4292,12 @@ public:
 	DECLARE_WRITE8_MEMBER(write);
 	virtual ~discrete_device(void);
 
+	template<int DiscreteInput>
+	DECLARE_WRITE_LINE_MEMBER(write_line)
+	{
+		write(machine().dummy_space(), DiscreteInput, state ? 1 : 0);
+	}
+
 	/* --------------------------------- */
 
 	virtual void update_to_current_time(void) const {  }

--- a/src/mame/audio/dkong.cpp
+++ b/src/mame/audio/dkong.cpp
@@ -1207,12 +1207,6 @@ WRITE8_MEMBER(dkong_state::M58817_command_w)
 	/* FIXME 0x20 is CS */
 }
 
-READ8_MEMBER(dkong_state::M58817_status_r)
-{
-	m58817_device *m58817 = machine().device<m58817_device>("tms");
-	return m58817->status_r(space, offset, mem_mask);
-}
-
 
 /****************************************************************
  *
@@ -1279,6 +1273,16 @@ WRITE8_MEMBER(dkong_state::dkong_audio_irq_w)
  *
  *************************************/
 
+READ8_MEMBER(dkong_state::sound_t0_r)
+{
+	return m_dev_6h->bit5_q_r();
+}
+
+READ8_MEMBER(dkong_state::sound_t1_r)
+{
+	return m_dev_6h->bit4_q_r();
+}
+
 static ADDRESS_MAP_START( dkong_sound_map, AS_PROGRAM, 8, dkong_state )
 	AM_RANGE(0x0000, 0x0fff) AM_ROM
 ADDRESS_MAP_END
@@ -1287,38 +1291,38 @@ static ADDRESS_MAP_START( dkong_sound_io_map, AS_IO, 8, dkong_state )
 	AM_RANGE(0x00, 0xFF) AM_READWRITE(dkong_tune_r, dkong_voice_w)
 	AM_RANGE(MCS48_PORT_BUS, MCS48_PORT_BUS) AM_READWRITE(dkong_tune_r, dkong_voice_w)
 	AM_RANGE(MCS48_PORT_P1, MCS48_PORT_P1) AM_WRITE(dkong_p1_w) /* only write to dac */
-	AM_RANGE(MCS48_PORT_P2, MCS48_PORT_P2) AM_LATCH8_READWRITE("virtual_p2")
-	AM_RANGE(MCS48_PORT_T0, MCS48_PORT_T0) AM_LATCH8_READBIT("ls259.6h", 5)
-	AM_RANGE(MCS48_PORT_T1, MCS48_PORT_T1) AM_LATCH8_READBIT("ls259.6h", 4)
+	AM_RANGE(MCS48_PORT_P2, MCS48_PORT_P2) AM_DEVREADWRITE("virtual_p2", latch8_device, read, write)
+	AM_RANGE(MCS48_PORT_T0, MCS48_PORT_T0) AM_READ(sound_t0_r)
+	AM_RANGE(MCS48_PORT_T1, MCS48_PORT_T1) AM_READ(sound_t1_r)
 ADDRESS_MAP_END
 
 static ADDRESS_MAP_START( dkongjr_sound_io_map, AS_IO, 8, dkong_state )
-	AM_RANGE(0x00, 0x00) AM_MIRROR(0xff) AM_LATCH8_READ("ls174.3d")
+	AM_RANGE(0x00, 0x00) AM_MIRROR(0xff) AM_DEVREAD("ls174.3d", latch8_device, read)
 	AM_RANGE(MCS48_PORT_P1, MCS48_PORT_P1) AM_WRITE(dkong_p1_w) /* only write to dac */
-	AM_RANGE(MCS48_PORT_P2, MCS48_PORT_P2) AM_LATCH8_READWRITE("virtual_p2")
-	AM_RANGE(MCS48_PORT_T0, MCS48_PORT_T0) AM_LATCH8_READBIT("ls259.6h", 5)
-	AM_RANGE(MCS48_PORT_T1, MCS48_PORT_T1) AM_LATCH8_READBIT("ls259.6h", 4)
+	AM_RANGE(MCS48_PORT_P2, MCS48_PORT_P2) AM_DEVREADWRITE("virtual_p2", latch8_device, read, write)
+	AM_RANGE(MCS48_PORT_T0, MCS48_PORT_T0) AM_READ(sound_t0_r)
+	AM_RANGE(MCS48_PORT_T1, MCS48_PORT_T1) AM_READ(sound_t1_r)
 ADDRESS_MAP_END
 
 static ADDRESS_MAP_START( radarscp1_sound_io_map, AS_IO, 8, dkong_state )
 	AM_RANGE(0x00, 0x00) AM_MIRROR(0xff) AM_DEVREAD("ls175.3d", latch8_device, read)
 	AM_RANGE(0x00, 0xff) AM_WRITE(dkong_p1_w) /* DAC here */
-	AM_RANGE(MCS48_PORT_P1, MCS48_PORT_P1) AM_LATCH8_READ("virtual_p1") AM_WRITE(M58817_command_w)
-	AM_RANGE(MCS48_PORT_P2, MCS48_PORT_P2) AM_LATCH8_WRITE("virtual_p2")
-	AM_RANGE(MCS48_PORT_T0, MCS48_PORT_T0) AM_LATCH8_READBIT("ls259.6h", 5)
-	AM_RANGE(MCS48_PORT_T1, MCS48_PORT_T1) AM_LATCH8_READBIT("ls259.6h", 4)
+	AM_RANGE(MCS48_PORT_P1, MCS48_PORT_P1) AM_DEVREAD("virtual_p1", latch8_device, read) AM_WRITE(M58817_command_w)
+	AM_RANGE(MCS48_PORT_P2, MCS48_PORT_P2) AM_DEVWRITE("virtual_p2", latch8_device, write)
+	AM_RANGE(MCS48_PORT_T0, MCS48_PORT_T0) AM_READ(sound_t0_r)
+	AM_RANGE(MCS48_PORT_T1, MCS48_PORT_T1) AM_READ(sound_t1_r)
 ADDRESS_MAP_END
 
 static ADDRESS_MAP_START( dkong3_sound1_map, AS_PROGRAM, 8, dkong_state )
 	AM_RANGE(0x0000, 0x01ff) AM_RAM
-	AM_RANGE(0x4016, 0x4016) AM_LATCH8_READ("latch1")       /* overwrite default */
-	AM_RANGE(0x4017, 0x4017) AM_LATCH8_READ("latch2")
+	AM_RANGE(0x4016, 0x4016) AM_DEVREAD("latch1", latch8_device, read)       /* overwrite default */
+	AM_RANGE(0x4017, 0x4017) AM_DEVREAD("latch2", latch8_device, read)
 	AM_RANGE(0xe000, 0xffff) AM_ROM
 ADDRESS_MAP_END
 
 static ADDRESS_MAP_START( dkong3_sound2_map, AS_PROGRAM, 8, dkong_state )
 	AM_RANGE(0x0000, 0x01ff) AM_RAM
-	AM_RANGE(0x4016, 0x4016) AM_LATCH8_READ("latch3")       /* overwrite default */
+	AM_RANGE(0x4016, 0x4016) AM_DEVREAD("latch3", latch8_device, read)       /* overwrite default */
 	AM_RANGE(0xe000, 0xffff) AM_ROM
 ADDRESS_MAP_END
 
@@ -1336,11 +1340,11 @@ MACHINE_CONFIG_FRAGMENT( dkong2b_audio )
 	MCFG_LATCH8_INVERT(0x0F)
 
 	MCFG_LATCH8_ADD("ls259.6h")
-	MCFG_LATCH8_WRITE_0(DEVWRITE8("discrete", discrete_device, write),DS_SOUND0_INP)
-	MCFG_LATCH8_WRITE_1(DEVWRITE8("discrete", discrete_device, write),DS_SOUND1_INP)
-	MCFG_LATCH8_WRITE_2(DEVWRITE8("discrete", discrete_device, write),DS_SOUND2_INP)
-	MCFG_LATCH8_WRITE_6(DEVWRITE8("discrete", discrete_device, write),DS_SOUND6_INP)
-	MCFG_LATCH8_WRITE_7(DEVWRITE8("discrete", discrete_device, write),DS_SOUND7_INP)
+	MCFG_LATCH8_WRITE_0(DEVWRITELINE("discrete", discrete_device, write_line<DS_SOUND0_INP>))
+	MCFG_LATCH8_WRITE_1(DEVWRITELINE("discrete", discrete_device, write_line<DS_SOUND1_INP>))
+	MCFG_LATCH8_WRITE_2(DEVWRITELINE("discrete", discrete_device, write_line<DS_SOUND2_INP>))
+	MCFG_LATCH8_WRITE_6(DEVWRITELINE("discrete", discrete_device, write_line<DS_SOUND6_INP>))
+	MCFG_LATCH8_WRITE_7(DEVWRITELINE("discrete", discrete_device, write_line<DS_SOUND7_INP>))
 
 	/*   If P2.Bit7 -> is apparently an external signal decay or other output control
 	 *   If P2.Bit6 -> activates the external compressed sample ROM (not radarscp1)
@@ -1351,8 +1355,8 @@ MACHINE_CONFIG_FRAGMENT( dkong2b_audio )
 
 	MCFG_LATCH8_ADD( "virtual_p2" ) /* virtual latch for port B */
 	MCFG_LATCH8_INVERT( 0x20 )      /* signal is inverted       */
-	MCFG_LATCH8_READ_5(DEVREAD8("ls259.6h", latch8_device, read), 3)
-	MCFG_LATCH8_WRITE_7(DEVWRITE8("discrete", discrete_device, write), DS_DISCHARGE_INV)
+	MCFG_LATCH8_READ_5(DEVREADLINE("ls259.6h", latch8_device, bit3_r))
+	MCFG_LATCH8_WRITE_7(DEVWRITELINE("discrete", discrete_device, write_line<DS_DISCHARGE_INV>))
 
 	MCFG_CPU_ADD("soundcpu", MB8884, I8035_CLOCK)
 	MCFG_CPU_PROGRAM_MAP(dkong_sound_map)
@@ -1378,8 +1382,8 @@ MACHINE_CONFIG_DERIVED( radarscp1_audio, radarscp_audio )
 	/* virtual_p2 is not read -see memory map-, all bits are output bits */
 	MCFG_LATCH8_ADD( "virtual_p1" ) /* virtual latch for port A */
 	MCFG_LATCH8_INVERT( 0x80 )      /* signal is inverted       */
-	MCFG_LATCH8_READ_7(DEVREAD8("ls259.6h", latch8_device, read), 3)
-	MCFG_LATCH8_READ_6(READ8(dkong_state, M58817_status_r), 0)
+	MCFG_LATCH8_READ_7(DEVREADLINE("ls259.6h", latch8_device, bit3_r))
+	MCFG_LATCH8_READ_6(DEVREAD8("tms", m58817_device, status_r))
 
 	/* tms memory controller */
 	MCFG_DEVICE_ADD("m58819", M58819, 0)
@@ -1400,22 +1404,22 @@ MACHINE_CONFIG_FRAGMENT( dkongjr_audio )
 	MCFG_LATCH8_MASKOUT(0xE0)
 
 	MCFG_LATCH8_ADD( "ls259.6h")
-	MCFG_LATCH8_WRITE_0(DEVWRITE8("discrete", discrete_device, write), DS_SOUND0_INP)
-	MCFG_LATCH8_WRITE_1(DEVWRITE8("discrete", discrete_device, write), DS_SOUND1_INP)
-	MCFG_LATCH8_WRITE_2(DEVWRITE8("discrete", discrete_device, write), DS_SOUND2_INP)
-	MCFG_LATCH8_WRITE_7(DEVWRITE8("discrete", discrete_device, write), DS_SOUND7_INP)
+	MCFG_LATCH8_WRITE_0(DEVWRITELINE("discrete", discrete_device, write_line<DS_SOUND0_INP>))
+	MCFG_LATCH8_WRITE_1(DEVWRITELINE("discrete", discrete_device, write_line<DS_SOUND1_INP>))
+	MCFG_LATCH8_WRITE_2(DEVWRITELINE("discrete", discrete_device, write_line<DS_SOUND2_INP>))
+	MCFG_LATCH8_WRITE_7(DEVWRITELINE("discrete", discrete_device, write_line<DS_SOUND7_INP>))
 
 	MCFG_LATCH8_ADD( "ls259.5h")
-	MCFG_LATCH8_WRITE_1(DEVWRITE8("discrete", discrete_device, write), DS_SOUND9_INP)
+	MCFG_LATCH8_WRITE_1(DEVWRITELINE("discrete", discrete_device, write_line<DS_SOUND9_INP>))
 
 	MCFG_LATCH8_ADD( "ls259.4h")
 
 	MCFG_LATCH8_ADD( "virtual_p2" ) /* virtual latch for port B */
 	MCFG_LATCH8_INVERT( 0x70 )      /* all signals are inverted */
-	MCFG_LATCH8_READ_6(DEVREAD8("ls259.4h", latch8_device, read), 1)
-	MCFG_LATCH8_READ_5(DEVREAD8("ls259.6h", latch8_device, read), 3)
-	MCFG_LATCH8_READ_4(DEVREAD8("ls259.6h", latch8_device, read), 6)
-	MCFG_LATCH8_WRITE_7(DEVWRITE8("discrete", discrete_device, write), DS_DISCHARGE_INV)
+	MCFG_LATCH8_READ_6(DEVREADLINE("ls259.4h", latch8_device, bit1_r))
+	MCFG_LATCH8_READ_5(DEVREADLINE("ls259.6h", latch8_device, bit3_r))
+	MCFG_LATCH8_READ_4(DEVREADLINE("ls259.6h", latch8_device, bit6_r))
+	MCFG_LATCH8_WRITE_7(DEVWRITELINE("discrete", discrete_device, write_line<DS_DISCHARGE_INV>))
 
 	MCFG_CPU_ADD("soundcpu", MB8884, I8035_CLOCK)
 	MCFG_CPU_PROGRAM_MAP(dkong_sound_map)

--- a/src/mame/drivers/dkong.cpp
+++ b/src/mame/drivers/dkong.cpp
@@ -617,7 +617,7 @@ WRITE8_MEMBER(dkong_state::p8257_drq_w)
 READ8_MEMBER(dkong_state::dkong_in2_r)
 {
 	/* mcu status (sound feedback) is inverted bit4 from port B (8039) */
-	uint8_t mcustatus = m_dev_vp2->bit4_q_r(space, 0);
+	uint8_t mcustatus = m_dev_vp2->bit4_q_r();
 	uint8_t r;
 
 	r = (ioport("IN2")->read() & 0xBF) | (mcustatus << 6);
@@ -811,7 +811,7 @@ static ADDRESS_MAP_START( dkong_map, AS_PROGRAM, 8, dkong_state )
 	AM_RANGE(0x7000, 0x73ff) AM_RAM AM_SHARE("sprite_ram") /* sprite set 1 */
 	AM_RANGE(0x7400, 0x77ff) AM_RAM_WRITE(dkong_videoram_w) AM_SHARE("video_ram")
 	AM_RANGE(0x7800, 0x780f) AM_DEVREADWRITE("dma8257", i8257_device, read, write)   /* P8257 control registers */
-	AM_RANGE(0x7c00, 0x7c00) AM_READ_PORT("IN0") AM_LATCH8_WRITE("ls175.3d")    /* IN0, sound CPU intf */
+	AM_RANGE(0x7c00, 0x7c00) AM_READ_PORT("IN0") AM_DEVWRITE("ls175.3d", latch8_device, write)    /* IN0, sound CPU intf */
 	AM_RANGE(0x7c80, 0x7c80) AM_READ_PORT("IN1") AM_WRITE(radarscp_grid_color_w)/* IN1 */
 
 	AM_RANGE(0x7d00, 0x7d00) AM_READ(dkong_in2_r)                               /* IN2 */
@@ -834,7 +834,7 @@ static ADDRESS_MAP_START( dkongjr_map, AS_PROGRAM, 8, dkong_state )
 	AM_RANGE(0x7400, 0x77ff) AM_RAM_WRITE(dkong_videoram_w) AM_SHARE("video_ram")
 	AM_RANGE(0x7800, 0x780f) AM_DEVREADWRITE("dma8257", i8257_device, read, write)   /* P8257 control registers */
 
-	AM_RANGE(0x7c00, 0x7c00) AM_READ_PORT("IN0") AM_LATCH8_WRITE("ls174.3d")    /* IN0, sound interface */
+	AM_RANGE(0x7c00, 0x7c00) AM_READ_PORT("IN0") AM_DEVWRITE("ls174.3d", latch8_device, write)    /* IN0, sound interface */
 
 	AM_RANGE(0x7c80, 0x7c80) AM_READ_PORT("IN1") AM_WRITE(dkongjr_gfxbank_w)
 	AM_RANGE(0x7c80, 0x7c87) AM_DEVWRITE("ls259.4h", latch8_device, bit0_w)     /* latch for sound and signals above */
@@ -861,9 +861,9 @@ static ADDRESS_MAP_START( dkong3_map, AS_PROGRAM, 8, dkong_state )
 	AM_RANGE(0x6800, 0x6fff) AM_RAM
 	AM_RANGE(0x7000, 0x73ff) AM_RAM AM_SHARE("sprite_ram") /* sprite set 1 */
 	AM_RANGE(0x7400, 0x77ff) AM_RAM_WRITE(dkong_videoram_w) AM_SHARE("video_ram")
-	AM_RANGE(0x7c00, 0x7c00) AM_READ_PORT("IN0")  AM_LATCH8_WRITE("latch1")
-	AM_RANGE(0x7c80, 0x7c80) AM_READ_PORT("IN1")  AM_LATCH8_WRITE("latch2")
-	AM_RANGE(0x7d00, 0x7d00) AM_READ_PORT("DSW0") AM_LATCH8_WRITE("latch3")
+	AM_RANGE(0x7c00, 0x7c00) AM_READ_PORT("IN0")  AM_DEVWRITE("latch1", latch8_device, write)
+	AM_RANGE(0x7c80, 0x7c80) AM_READ_PORT("IN1")  AM_DEVWRITE("latch2", latch8_device, write)
+	AM_RANGE(0x7d00, 0x7d00) AM_READ_PORT("DSW0") AM_DEVWRITE("latch3", latch8_device, write)
 	AM_RANGE(0x7d80, 0x7d80) AM_READ_PORT("DSW1") AM_WRITE(dkong3_2a03_reset_w)
 	AM_RANGE(0x7e80, 0x7e80) AM_WRITE(dkong3_coin_counter_w)
 	AM_RANGE(0x7e81, 0x7e81) AM_WRITE(dkong3_gfxbank_w)

--- a/src/mame/includes/dkong.h
+++ b/src/mame/includes/dkong.h
@@ -266,10 +266,11 @@ public:
 	DECLARE_MACHINE_RESET(strtheat);
 	DECLARE_MACHINE_RESET(drakton);
 	DECLARE_WRITE8_MEMBER(M58817_command_w);
-	DECLARE_READ8_MEMBER(M58817_status_r);
 	DECLARE_READ8_MEMBER(dkong_voice_status_r);
 	DECLARE_READ8_MEMBER(dkong_tune_r);
 	DECLARE_WRITE8_MEMBER(dkong_p1_w);
+	DECLARE_READ8_MEMBER(sound_t0_r);
+	DECLARE_READ8_MEMBER(sound_t1_r);
 	uint32_t screen_update_dkong(screen_device &screen, bitmap_ind16 &bitmap, const rectangle &cliprect);
 	uint32_t screen_update_pestplce(screen_device &screen, bitmap_ind16 &bitmap, const rectangle &cliprect);
 	uint32_t screen_update_spclforc(screen_device &screen, bitmap_ind16 &bitmap, const rectangle &cliprect);

--- a/src/mame/video/dkong.cpp
+++ b/src/mame/video/dkong.cpp
@@ -708,8 +708,7 @@ void dkong_state::radarscp_step(int line_cnt)
 	 */
 
 	/* Now mix with SND02 (sound 2) line - on 74ls259, bit2 */
-	address_space &space = machine().dummy_space();
-	m_rflip_sig = m_dev_6h->bit2_r(space, 0) & m_lfsr_5I;
+	m_rflip_sig = m_dev_6h->bit2_r() & m_lfsr_5I;
 
 	/* blue background generation */
 
@@ -774,7 +773,7 @@ void dkong_state::radarscp_step(int line_cnt)
 	 *
 	 * Mixed with ANS line (bit 5) from Port B of 8039
 	 */
-	if (m_grid_on && m_dev_vp2->bit5_r(space, 0))
+	if (m_grid_on && m_dev_vp2->bit5_r())
 	{
 		diff = (0.0 - m_cv3);
 		diff = diff - diff*exp(0.0 - (1.0/RC32 * dt) );


### PR DESCRIPTION
- Eliminate the AM_LATCH8_XXX address map macros. The normal DEVREAD/DEVWRITE ought to be good enough.
- Eliminate the "offset" specifications from latch8_device. This was used mostly to funnel outputs to discrete_device, which now has a templated write_line handler. (Inputs can use MCFG_DEVCB_RSHIFT instead.)
- Organize latch8_device's callbacks as arrays of devcb_readline/devcb_writeline, helping simplifying code greatly.
- Change latch8_device::bit[0-7]_(q_)?r to be proper line read handlers. This requires two extra READ8 handlers in audio/dkong.cpp, but memory-mapping for the MCS-48 T0 and T1 lines is totally artificial anyway.
- Comment out an assert that now tends to fail due to buggy AM_MIRROR behavior.