### PR TITLE
vicdual: add 97269-P-B and 97271-P daughterboards for nsub

### DIFF
--- a/scripts/target/mame/arcade.lua
+++ b/scripts/target/mame/arcade.lua
@@ -3281,6 +3281,8 @@ files {
 	MAME_DIR .. "src/mame/audio/vicdual.cpp",
 	MAME_DIR .. "src/mame/audio/vicdual.h",
 	MAME_DIR .. "src/mame/video/vicdual.cpp",
+	MAME_DIR .. "src/mame/video/vicdual-97269pb.cpp",
+	MAME_DIR .. "src/mame/video/vicdual-97269pb.h",
 	MAME_DIR .. "src/mame/audio/carnival.cpp",
 	MAME_DIR .. "src/mame/audio/carnival.h",
 	MAME_DIR .. "src/mame/audio/depthch.cpp",

--- a/scripts/target/mame/arcade.lua
+++ b/scripts/target/mame/arcade.lua
@@ -3280,6 +3280,8 @@ files {
 	MAME_DIR .. "src/mame/includes/vicdual.h",
 	MAME_DIR .. "src/mame/audio/vicdual.cpp",
 	MAME_DIR .. "src/mame/audio/vicdual.h",
+	MAME_DIR .. "src/mame/audio/vicdual-97271p.cpp",
+	MAME_DIR .. "src/mame/audio/vicdual-97271p.h",
 	MAME_DIR .. "src/mame/video/vicdual.cpp",
 	MAME_DIR .. "src/mame/video/vicdual-97269pb.cpp",
 	MAME_DIR .. "src/mame/video/vicdual-97269pb.h",

--- a/src/mame/audio/vicdual-97271p.cpp
+++ b/src/mame/audio/vicdual-97271p.cpp
@@ -1,0 +1,206 @@
+// license:BSD-3-Clause
+// copyright-holders:Ariane Fugmann
+
+/*
+N-Sub Oscillator 97271-P
+-----------------------------
+for the time being this is a simple sample player based on the work by MASH.
+*/
+
+#include "emu.h"
+#include "speaker.h"
+#include "audio/vicdual-97271p.h"
+
+#define S97271P_TAG     "s97271p"
+
+//**************************************************************************
+//  GLOBAL VARIABLES
+//**************************************************************************
+
+const device_type S97271P = device_creator<s97271p_device>;
+
+/* bit definitions - sound effect drive outputs */
+#define S97271P_WARNING      0x01
+#define S97271P_SONAR        0x02
+#define S97271P_LAUNCH       0x04
+#define S97271P_EXPL_L       0x08
+#define S97271P_EXPL_S       0x10
+#define S97271P_BONUS        0x20
+#define S97271P_CODE         0x40
+#define S97271P_BOAT         0x80
+
+/* sample file names */
+static const char *const nsub_sample_names[] =
+{
+	"*nsub",
+	"0_0",
+	"0_1",
+	"1_0",
+	"2_0",
+	"2_1",
+	"3_0",
+	"3_1",
+	"4_0",
+	"4_1",
+	"5_0",
+	"5_1",
+	"6_0",
+	"7_0",
+	nullptr
+};
+
+/* sample IDs - must match sample file name table above */
+enum 
+{
+	SND_EXPL_L0 = 0,
+	SND_EXPL_L1,
+	SND_SONAR,
+	SND_LAUNCH0,
+	SND_LAUNCH1,
+	SND_WARNING0,
+	SND_WARNING1,
+	SND_EXPL_S0,
+	SND_EXPL_S1,
+	SND_BONUS0,
+	SND_BONUS1,
+	SND_CODE,
+	SND_BOAT
+};
+
+
+//**************************************************************************
+//  MACHINE FRAGMENTS
+//**************************************************************************
+
+MACHINE_CONFIG_FRAGMENT( nsub_audio )
+	MCFG_SPEAKER_STANDARD_MONO("mono")
+
+	/* samples */
+	MCFG_SOUND_ADD("samples", SAMPLES, 0)
+	MCFG_SAMPLES_CHANNELS(13)
+	MCFG_SAMPLES_NAMES(nsub_sample_names)
+	MCFG_SOUND_ROUTE(ALL_OUTPUTS, "mono", 0.5)
+MACHINE_CONFIG_END
+
+//**************************************************************************
+//  LIVE DEVICE
+//**************************************************************************
+
+//-------------------------------------------------
+//  s97271p_device - constructor
+//-------------------------------------------------
+
+s97271p_device::s97271p_device(const machine_config &mconfig, const char *tag, device_t *owner, uint32_t clock) :
+	device_t(mconfig, S97271P, "N-Sub Oscillator 97271-P", tag, owner, clock, "s97271p", __FILE__),
+	m_samples(*this, "samples")
+{
+}
+
+//-------------------------------------------------
+//  machine_config_additions - device-specific
+//  machine configurations
+//-------------------------------------------------
+
+machine_config_constructor s97271p_device::device_mconfig_additions() const
+{
+	return MACHINE_CONFIG_NAME( nsub_audio );
+}
+
+//-------------------------------------------------
+//  device_start - device-specific startup
+//-------------------------------------------------
+
+void s97271p_device::device_start()
+{
+}
+
+//-------------------------------------------------
+//  device_reset - device-specific reset
+//-------------------------------------------------
+
+void s97271p_device::device_reset()
+{
+	m_state = 0xff;
+}
+
+void s97271p_device::port_w(uint8_t data)
+{
+	uint8_t bitsChanged = m_state ^ data;
+	uint8_t bitsGoneHigh = bitsChanged & data;
+	uint8_t bitsGoneLow = bitsChanged & ~data;
+	m_state = data;
+
+	if (bitsGoneLow & S97271P_WARNING)
+	{
+		m_samples->start(SND_WARNING0, SND_WARNING0, 1);
+		m_samples->stop(SND_WARNING1);
+	} else if (bitsGoneHigh & S97271P_WARNING)
+	{
+		m_samples->start(SND_WARNING1, SND_WARNING1, 0);
+		m_samples->stop(SND_WARNING0);
+	}
+
+	if (bitsGoneLow & S97271P_SONAR)
+	{
+		m_samples->start(SND_SONAR, SND_SONAR, 1);
+	} else if (bitsGoneHigh & S97271P_SONAR)
+	{
+		m_samples->stop(SND_SONAR);
+	}
+
+	if (bitsGoneLow & S97271P_LAUNCH)
+	{
+		m_samples->start(SND_LAUNCH0, SND_LAUNCH0, 1);
+		m_samples->stop(SND_LAUNCH1);
+	} else if (bitsGoneHigh & S97271P_LAUNCH)
+	{
+		m_samples->start(SND_LAUNCH1, SND_LAUNCH1, 0);
+		m_samples->stop(SND_LAUNCH0);
+	}
+
+	if (bitsGoneLow & S97271P_WARNING)
+	{
+		m_samples->start(SND_WARNING0, SND_WARNING0, 1);
+		m_samples->stop(SND_WARNING1);
+	} else if (bitsGoneHigh & S97271P_WARNING)
+	{
+		m_samples->start(SND_WARNING1, SND_WARNING1, 0);
+		m_samples->stop(SND_WARNING0);
+	}
+
+	if (bitsGoneLow & S97271P_EXPL_S)
+	{
+		m_samples->start(SND_EXPL_S0, SND_EXPL_S0, 1);
+		m_samples->stop(SND_EXPL_S1);
+	} else if (bitsGoneHigh & S97271P_EXPL_S)
+	{
+		m_samples->start(SND_EXPL_S1, SND_EXPL_S1, 0);
+		m_samples->stop(SND_EXPL_S0);
+	}
+
+	if (bitsGoneLow & S97271P_BONUS)
+	{
+		m_samples->start(SND_BONUS0, SND_BONUS0, 1);
+		m_samples->stop(SND_BONUS1);
+	} else if (bitsGoneHigh & S97271P_BONUS)
+	{
+		m_samples->start(SND_BONUS1, SND_BONUS1, 0);
+		m_samples->stop(SND_BONUS0);
+	}
+
+	if (bitsGoneLow & S97271P_CODE)
+	{
+		m_samples->start(SND_CODE, SND_CODE, 1);
+	} else if (bitsGoneHigh & S97271P_CODE)
+	{
+		m_samples->stop(SND_CODE);
+	}
+
+	if (bitsGoneLow & S97271P_BOAT)
+	{
+		m_samples->start(SND_BOAT, SND_BOAT, 1);
+	} else if (bitsGoneHigh & S97271P_BOAT)
+	{
+		m_samples->stop(SND_BOAT);
+	}
+}

--- a/src/mame/audio/vicdual-97271p.cpp
+++ b/src/mame/audio/vicdual-97271p.cpp
@@ -72,7 +72,7 @@ enum
 //  MACHINE FRAGMENTS
 //**************************************************************************
 
-MACHINE_CONFIG_FRAGMENT( nsub_audio )
+static MACHINE_CONFIG_FRAGMENT( nsub_audio )
 	MCFG_SPEAKER_STANDARD_MONO("mono")
 
 	/* samples */
@@ -112,6 +112,7 @@ machine_config_constructor s97271p_device::device_mconfig_additions() const
 
 void s97271p_device::device_start()
 {
+	save_item(NAME(m_state));
 }
 
 //-------------------------------------------------

--- a/src/mame/audio/vicdual-97271p.cpp
+++ b/src/mame/audio/vicdual-97271p.cpp
@@ -33,23 +33,23 @@ const device_type S97271P = device_creator<s97271p_device>;
 static const char *const nsub_sample_names[] =
 {
 	"*nsub",
-	"0_0",
-	"0_1",
-	"1_0",
-	"2_0",
-	"2_1",
-	"3_0",
-	"3_1",
-	"4_0",
-	"4_1",
-	"5_0",
-	"5_1",
-	"6_0",
-	"7_0",
+	"SND_EXPL_L0",
+	"SND_EXPL_L1",
+	"SND_SONAR",
+	"SND_LAUNCH0",
+	"SND_LAUNCH1",
+	"SND_WARNING0",
+	"SND_WARNING1",
+	"SND_EXPL_S0",
+	"SND_EXPL_S1",
+	"SND_BONUS0",
+	"SND_BONUS1",
+	"SND_CODE",
+	"SND_BOAT",
 	nullptr
 };
 
-/* sample IDs - must match sample file name table above */
+/* sample ids - must match sample file name table above */
 enum 
 {
 	SND_EXPL_L0 = 0,

--- a/src/mame/audio/vicdual-97271p.h
+++ b/src/mame/audio/vicdual-97271p.h
@@ -2,8 +2,8 @@
 // copyright-holders:Ariane Fugmann
 #pragma once
 
-#ifndef __S97271P_H__
-#define __S97271P_H__
+#ifndef MAME_AUDIO_VICDUAL_97271P_H
+#define MAME_AUDIO_VICDUAL_97271P_H
 
 #include "sound/samples.h"
 
@@ -23,8 +23,6 @@ public:
 	// optional information overrides
 	virtual machine_config_constructor device_mconfig_additions() const override;
 
-	required_device<samples_device> m_samples;
-
 	// daughterboard logic
 	void port_w(uint8_t data);
 
@@ -34,12 +32,12 @@ protected:
 	virtual void device_reset() override;
 
 private:
+	required_device<samples_device> m_samples;
+
 	uint8_t m_state;
 };
 
 // device type definition
 extern const device_type S97271P;
 
-MACHINE_CONFIG_EXTERN( nsub_audio ); 
-
-#endif  /* __S97271P_H__ */
+#endif  /* MAME_AUDIO_VICDUAL_97271P_H */

--- a/src/mame/audio/vicdual-97271p.h
+++ b/src/mame/audio/vicdual-97271p.h
@@ -1,0 +1,45 @@
+// license:BSD-3-Clause
+// copyright-holders:Ariane Fugmann
+#pragma once
+
+#ifndef __S97271P_H__
+#define __S97271P_H__
+
+#include "sound/samples.h"
+
+#define MCFG_S97271P_ADD(_tag ) \
+	MCFG_DEVICE_ADD(_tag, S97271P, 0)
+
+//**************************************************************************
+//  TYPE DEFINITIONS
+//**************************************************************************
+
+class s97271p_device : public device_t
+{
+public:
+	// construction/destruction
+	s97271p_device(const machine_config &mconfig, const char *tag, device_t *owner, uint32_t clock);
+
+	// optional information overrides
+	virtual machine_config_constructor device_mconfig_additions() const override;
+
+	required_device<samples_device> m_samples;
+
+	// daughterboard logic
+	void port_w(uint8_t data);
+
+protected:
+	// device-level overrides
+	virtual void device_start() override;
+	virtual void device_reset() override;
+
+private:
+	uint8_t m_state;
+};
+
+// device type definition
+extern const device_type S97271P;
+
+MACHINE_CONFIG_EXTERN( nsub_audio ); 
+
+#endif  /* __S97271P_H__ */

--- a/src/mame/drivers/vicdual.cpp
+++ b/src/mame/drivers/vicdual.cpp
@@ -58,6 +58,7 @@
 #include "audio/invinco.h"
 #include "audio/pulsar.h"
 #include "audio/vicdual.h"
+#include "audio/vicdual-97271p.h"
 #include "video/vicdual-97269pb.h"
 
 #include "cpu/i8085/i8085.h"
@@ -2247,7 +2248,10 @@ READ8_MEMBER(vicdual_state::nsub_io_r)
 WRITE8_MEMBER(vicdual_state::nsub_io_w)
 {
 	if (offset & 0x01)  assert_coin_status();
-	if (offset & 0x02) { /* nsub_audio_w(0, data) */ }
+	if (offset & 0x02)
+	{
+		m_s97271p->port_w(data);
+	}
 	if (offset & 0x04)
 	{
 		palette_bank_w(space, 0, data);
@@ -2411,6 +2415,9 @@ static MACHINE_CONFIG_DERIVED( nsub, vicdual_root )
 
 	// daughterboard
 	MCFG_S97269PB_ADD("s97269pb")
+
+	/* audio hardware */
+	MCFG_S97271P_ADD("s97271p")
 MACHINE_CONFIG_END
 
 

--- a/src/mame/drivers/vicdual.cpp
+++ b/src/mame/drivers/vicdual.cpp
@@ -3654,7 +3654,7 @@ GAME( 1979, headon2,    0,        headon2,   headon2,   driver_device, 0, ROT0, 
 GAME( 1979, headon2s,   headon2,  headon2bw, car2,      driver_device, 0, ROT0,   "bootleg (Sidam)", "Head On 2 (Sidam bootleg)",  MACHINE_NOT_WORKING | MACHINE_SUPPORTS_SAVE ) // won't coin up?
 GAME( 1979, car2,       headon2,  headon2bw, car2,      driver_device, 0, ROT0,   "bootleg (RZ Bologna)", "Car 2 (bootleg of Head On 2)",  MACHINE_IMPERFECT_SOUND | MACHINE_SUPPORTS_SAVE ) // title still says 'HeadOn 2'
 GAME( 1979, invho2,     0,        invho2,    invho2,    driver_device, 0, ROT270, "Sega", "Invinco / Head On 2", MACHINE_IMPERFECT_SOUND | MACHINE_SUPPORTS_SAVE )
-GAME( 1980, nsub,       0,        nsub,      nsub,      driver_device, 0, ROT270, "Sega", "N-Sub (upright)", MACHINE_IMPERFECT_GRAPHICS | MACHINE_NO_SOUND | MACHINE_SUPPORTS_SAVE ) // this is the upright set. cocktail set still needs to be dumped
+GAME( 1980, nsub,       0,        nsub,      nsub,      driver_device, 0, ROT270, "Sega", "N-Sub (upright)", MACHINE_IMPERFECT_GRAPHICS | MACHINE_IMPERFECT_SOUND | MACHINE_SUPPORTS_SAVE ) // this is the upright set. cocktail set still needs to be dumped
 GAME( 1980, samurai,    0,        samurai,   samurai,   driver_device, 0, ROT270, "Sega", "Samurai", MACHINE_NO_SOUND | MACHINE_SUPPORTS_SAVE )
 GAME( 1979, invinco,    0,        invinco,   invinco,   driver_device, 0, ROT270, "Sega", "Invinco", MACHINE_IMPERFECT_SOUND | MACHINE_SUPPORTS_SAVE )
 GAME( 1979, invds,      0,        invds,     invds,     driver_device, 0, ROT270, "Sega", "Invinco / Deep Scan", MACHINE_IMPERFECT_SOUND | MACHINE_SUPPORTS_SAVE )

--- a/src/mame/drivers/vicdual.cpp
+++ b/src/mame/drivers/vicdual.cpp
@@ -58,6 +58,7 @@
 #include "audio/invinco.h"
 #include "audio/pulsar.h"
 #include "audio/vicdual.h"
+#include "video/vicdual-97269pb.h"
 
 #include "cpu/i8085/i8085.h"
 #include "cpu/z80/z80.h"
@@ -2250,7 +2251,7 @@ WRITE8_MEMBER(vicdual_state::nsub_io_w)
 	if (offset & 0x04)
 	{
 		palette_bank_w(space, 0, data);
-		m_gradient = data & 4;
+		m_s97269pb->palette_bank_w(data);
 	}
 }
 
@@ -2407,6 +2408,9 @@ static MACHINE_CONFIG_DERIVED( nsub, vicdual_root )
 	/* video hardware */
 	MCFG_SCREEN_MODIFY("screen")
 	MCFG_SCREEN_UPDATE_DRIVER(vicdual_state, screen_update_color)
+
+	// daughterboard
+	MCFG_S97269PB_ADD("s97269pb")
 MACHINE_CONFIG_END
 
 
@@ -2664,11 +2668,8 @@ Epr-274.u42
 Epr-275.u41
 Pr-69.u11
 
-Also PR33.u82 and PR34.u83 were not dumped from this pcb, couldn't be read because aluminium cooler on it.
-They're probably the same as on other games.
-
-This game use a separate "daughter" board for input ??? ref: 97269-P-B
-with a prom on it : PR-02 type MMI 6336-1j which is soldered.
+This game use a separate "daughter" board for gradient and starfield ref: 97269-P-B
+with 3 proms on it : PR-02 type MMI 6336-1j, PR-56 type MB7054 and PR-57 type MB7054
 
 */
 

--- a/src/mame/includes/vicdual.h
+++ b/src/mame/includes/vicdual.h
@@ -11,6 +11,7 @@
 #include "sound/discrete.h"
 #include "sound/samples.h"
 #include "screen.h"
+#include "audio/vicdual-97271p.h"
 #include "video/vicdual-97269pb.h"
 
 class vicdual_state : public driver_device
@@ -27,6 +28,7 @@ public:
 		m_nsub_coinage_timer(*this, "nsub_coin"),
 		m_screen(*this, "screen"),
 		m_s97269pb(*this,"s97269pb"),
+		m_s97271p(*this,"s97271p"),
 		m_proms(*this, "proms"),
 		m_videoram(*this, "videoram"),
 		m_characterram(*this, "characterram"),
@@ -47,6 +49,7 @@ public:
 	optional_device<timer_device> m_nsub_coinage_timer;
 	required_device<screen_device> m_screen;
 	optional_device<s97269pb_device> m_s97269pb;
+	optional_device<s97271p_device> m_s97271p;
 	optional_memory_region m_proms;
 
 	required_shared_ptr<uint8_t> m_videoram;

--- a/src/mame/includes/vicdual.h
+++ b/src/mame/includes/vicdual.h
@@ -27,8 +27,6 @@ public:
 		m_coinstate_timer(*this, "coinstate"),
 		m_nsub_coinage_timer(*this, "nsub_coin"),
 		m_screen(*this, "screen"),
-		m_s97269pb(*this,"s97269pb"),
-		m_s97271p(*this,"s97271p"),
 		m_proms(*this, "proms"),
 		m_videoram(*this, "videoram"),
 		m_characterram(*this, "characterram"),
@@ -48,8 +46,6 @@ public:
 	required_device<timer_device> m_coinstate_timer;
 	optional_device<timer_device> m_nsub_coinage_timer;
 	required_device<screen_device> m_screen;
-	optional_device<s97269pb_device> m_s97269pb;
-	optional_device<s97271p_device> m_s97271p;
 	optional_memory_region m_proms;
 
 	required_shared_ptr<uint8_t> m_videoram;
@@ -65,8 +61,6 @@ public:
 	uint8_t m_coin_status;
 	uint8_t m_palette_bank;
 	uint8_t m_samurai_protection_data;
-	int m_nsub_coin_counter;
-	int m_nsub_play_counter;
 	int m_port1State;
 	int m_port2State;
 	int m_psgData;
@@ -107,8 +101,6 @@ public:
 	DECLARE_WRITE8_MEMBER(alphaho_io_w);
 	DECLARE_WRITE8_MEMBER(samurai_protection_w);
 	DECLARE_WRITE8_MEMBER(samurai_io_w);
-	DECLARE_READ8_MEMBER(nsub_io_r);
-	DECLARE_WRITE8_MEMBER(nsub_io_w);
 	DECLARE_READ8_MEMBER(invinco_io_r);
 	DECLARE_WRITE8_MEMBER(invinco_io_w);
 
@@ -144,14 +136,10 @@ public:
 	DECLARE_CUSTOM_INPUT_MEMBER(fake_lives_r);
 	DECLARE_CUSTOM_INPUT_MEMBER(samurai_protection_r);
 	DECLARE_INPUT_CHANGED_MEMBER(coin_changed);
-	DECLARE_INPUT_CHANGED_MEMBER(nsub_coin_in);
 
 	TIMER_DEVICE_CALLBACK_MEMBER(clear_coin_status);
-	TIMER_DEVICE_CALLBACK_MEMBER(nsub_coin_pulse);
 
 	DECLARE_MACHINE_START(samurai);
-	DECLARE_MACHINE_START(nsub);
-	DECLARE_MACHINE_RESET(nsub);
 	DECLARE_MACHINE_START(frogs_audio);
 
 	virtual void machine_start() override;
@@ -161,4 +149,33 @@ public:
 	uint32_t screen_update_color(screen_device &screen, bitmap_rgb32 &bitmap, const rectangle &cliprect);
 	int get_vcounter();
 	int is_cabinet_color();
+	virtual pen_t choose_pen(uint8_t x, uint8_t y, pen_t back_pen);
+};
+
+class nsub_state : public vicdual_state
+{
+public:
+	nsub_state(const machine_config &mconfig, device_type type, const char *tag)
+		: vicdual_state(mconfig, type, tag),
+		m_s97269pb(*this,"s97269pb"),
+		m_s97271p(*this,"s97271p")
+	{ }
+
+	required_device<s97269pb_device> m_s97269pb;
+	required_device<s97271p_device> m_s97271p;
+
+	int m_nsub_coin_counter;
+	int m_nsub_play_counter;
+
+	DECLARE_READ8_MEMBER(nsub_io_r);
+	DECLARE_WRITE8_MEMBER(nsub_io_w);
+
+	DECLARE_INPUT_CHANGED_MEMBER(nsub_coin_in);
+
+	TIMER_DEVICE_CALLBACK_MEMBER(nsub_coin_pulse);
+
+	DECLARE_MACHINE_START(nsub);
+	DECLARE_MACHINE_RESET(nsub);
+
+	virtual pen_t choose_pen(uint8_t x, uint8_t y, pen_t back_pen);
 };

--- a/src/mame/includes/vicdual.h
+++ b/src/mame/includes/vicdual.h
@@ -11,6 +11,7 @@
 #include "sound/discrete.h"
 #include "sound/samples.h"
 #include "screen.h"
+#include "video/vicdual-97269pb.h"
 
 class vicdual_state : public driver_device
 {
@@ -25,6 +26,7 @@ public:
 		m_coinstate_timer(*this, "coinstate"),
 		m_nsub_coinage_timer(*this, "nsub_coin"),
 		m_screen(*this, "screen"),
+		m_s97269pb(*this,"s97269pb"),
 		m_proms(*this, "proms"),
 		m_videoram(*this, "videoram"),
 		m_characterram(*this, "characterram"),
@@ -44,6 +46,7 @@ public:
 	required_device<timer_device> m_coinstate_timer;
 	optional_device<timer_device> m_nsub_coinage_timer;
 	required_device<screen_device> m_screen;
+	optional_device<s97269pb_device> m_s97269pb;
 	optional_memory_region m_proms;
 
 	required_shared_ptr<uint8_t> m_videoram;
@@ -58,7 +61,6 @@ public:
 
 	uint8_t m_coin_status;
 	uint8_t m_palette_bank;
-	uint8_t m_gradient;
 	uint8_t m_samurai_protection_data;
 	int m_nsub_coin_counter;
 	int m_nsub_play_counter;

--- a/src/mame/video/vicdual-97269pb.cpp
+++ b/src/mame/video/vicdual-97269pb.cpp
@@ -1,0 +1,157 @@
+// license:BSD-3-Clause
+// copyright-holders:Ariane Fugmann
+
+/*
+N-Sub Daughterboard 97269-P-B
+-----------------------------
+Reference Image: http://images.arianchen.de/2017-01/030320171775.jpg
+Wiring Notes:    http://files.arianchen.de/nsub/97269-P-B.txt
+
+|---------------------------------------------------|
+| PR-02   74393   PR-57   74175   74367   7417  (A) |
+|                                                   |
+|         PR-56   7410    74393   7400    74367 (B) |
+|                                                   |
+|         74161   74161   74157   74175   74365 (C) |
+|                                                   |
+| (1)     (2)     (3)     (4)     (5)     (6)       |
+|         SEGA    97269-P-B                         |
+| [---CON-F---]   [-----------CON-X-----------]     |
+|---------------------------------------------------|
+Notes:
+      PR-02.A1 - MMI 6336-1J 256*8 PROM (DIP24, labelled 'PR-02')
+      PR-56.B2 - Fujitsu MB7054 1024*4  (DIP18, labelled 'PR-56')
+      PR-57.A3 - Fujitsu MB7054 1024*4  (DIP18, labelled 'PR-57')
+
+      CON-F    - A 3.6 Pin Connector for monitor (different pinout!)
+               01 - NC
+               02 - NC
+               03 - GND
+               04 - KEY
+               05 - NC
+               06 - NC
+               07 - CSYNC
+               08 - GREEN
+               09 - BLUE
+               10 - RED
+
+      CON-X    - A 15 Pin Connector which is wired to various places on the mainboard
+               01 - VCC
+               02 - GND
+               03 - CSYNC (U53.1)
+               04 - PALBANK-B2 (U18.7)
+               05 - EXTBLANK (U84.8)
+               06 - VIDEO (U54.13)
+               07 - PALBANK-B3 (U18.2)
+               08 - VSYNC (U53.12)
+               09 - VBLANK (U17.5)
+               10 - BLUE (U8.7)
+               11 - GREEN (U8.9)
+               12 - RED (U8.4)
+               13 - HSYNC- (U13.9)
+               14 - HRESET (U13.6)
+               15 - SRCK (U54.7)
+*/
+
+#include "emu.h"
+#include "emuopts.h"
+#include "video/vicdual-97269pb.h"
+
+#define S97269PB_TAG     "s97269pb"
+
+/*************************************
+ *  97269PB PROMS
+ *************************************/
+ROM_START( s97269pb )
+	ROM_REGION( 0x1000, S97269PB_TAG, ROMREGION_ERASEFF )
+	ROM_LOAD( "pr-02.a1", 0x0000, 0x0100, CRC(8e633b5c) SHA1(7ee40abe0e8a56aae2cc5f1102fa8c334a19e075) )
+	ROM_LOAD( "pr-56.b2", 0x0800, 0x0400, CRC(f79c8e91) SHA1(eafff661e2aa1a6ef64f51faa9b1dac7af843557) )
+	ROM_LOAD( "pr-57.a3", 0x0c00, 0x0400, CRC(00d52430) SHA1(5f4de97cfe6fe39da75761e0f434de28d30f3e3b) )
+ROM_END
+
+//**************************************************************************
+//  GLOBAL VARIABLES
+//**************************************************************************
+
+const device_type S97269PB = device_creator<s97269pb_device>;
+
+//-------------------------------------------------
+//  rom_region - device-specific ROM region
+//-------------------------------------------------
+
+const tiny_rom_entry *s97269pb_device::device_rom_region() const
+{
+	return ROM_NAME( s97269pb );
+}
+
+//**************************************************************************
+//  LIVE DEVICE
+//**************************************************************************
+
+//-------------------------------------------------
+//  m1comm_device - constructor
+//-------------------------------------------------
+
+s97269pb_device::s97269pb_device(const machine_config &mconfig, const char *tag, device_t *owner, uint32_t clock) :
+	device_t(mconfig, S97269PB, "N-Sub Daughterboard 97269-P-B", tag, owner, clock, "s97269pb", __FILE__)
+{
+}
+
+//-------------------------------------------------
+//  device_start - device-specific startup
+//-------------------------------------------------
+
+void s97269pb_device::device_start()
+{
+}
+
+//-------------------------------------------------
+//  device_reset - device-specific reset
+//-------------------------------------------------
+
+void s97269pb_device::device_reset()
+{
+	m_palette_bank = 0;
+}
+
+void s97269pb_device::palette_bank_w(uint8_t data)
+{
+	m_palette_bank = data & 0x0c;
+}
+
+pen_t s97269pb_device::choosePen(uint8_t x, uint8_t y, pen_t back_pen)
+{
+	if (m_palette_bank & 0x04)
+	{
+		// TODO - starfield
+		// gradient is offset by about 10 pixels
+
+		// bit 2 enables the gradient and starfield/gradient
+		// bit 3 seems to be used for cocktail mode
+		uint8_t offset = ((x + 5) & 0xff) / 2;
+		if (m_palette_bank & 0x08)
+			offset |= 0x80;
+
+		uint8_t *prombase = memregion("s97269pb")->base();
+		uint8_t gradient_flags = prombase[offset];
+
+		switch (gradient_flags >> 4)
+		{
+			case 0x1:
+				// blue-to-cyan
+				return rgb_t(0, 0x80 + (gradient_flags & 0x0f) * 0x08, 0xff);
+				break;
+
+			case 0x4:
+				// black-to-blue
+				return rgb_t(0, 0, (gradient_flags & 0x0f) * 0x11);;
+				break;
+
+			case 0xf:
+			default:
+				return back_pen;
+				break;
+		}
+	}
+	return back_pen;
+}

--- a/src/mame/video/vicdual-97269pb.cpp
+++ b/src/mame/video/vicdual-97269pb.cpp
@@ -54,7 +54,6 @@ Notes:
 */
 
 #include "emu.h"
-#include "emuopts.h"
 #include "video/vicdual-97269pb.h"
 
 #define S97269PB_TAG     "s97269pb"
@@ -89,7 +88,7 @@ const tiny_rom_entry *s97269pb_device::device_rom_region() const
 //**************************************************************************
 
 //-------------------------------------------------
-//  m1comm_device - constructor
+//  s97269pb_device - constructor
 //-------------------------------------------------
 
 s97269pb_device::s97269pb_device(const machine_config &mconfig, const char *tag, device_t *owner, uint32_t clock) :

--- a/src/mame/video/vicdual-97269pb.cpp
+++ b/src/mame/video/vicdual-97269pb.cpp
@@ -92,7 +92,8 @@ const tiny_rom_entry *s97269pb_device::device_rom_region() const
 //-------------------------------------------------
 
 s97269pb_device::s97269pb_device(const machine_config &mconfig, const char *tag, device_t *owner, uint32_t clock) :
-	device_t(mconfig, S97269PB, "N-Sub Daughterboard 97269-P-B", tag, owner, clock, "s97269pb", __FILE__)
+	device_t(mconfig, S97269PB, "N-Sub Daughterboard 97269-P-B", tag, owner, clock, "s97269pb", __FILE__),
+	m_prom_ptr(*this, "s97269pb")
 {
 }
 
@@ -102,6 +103,7 @@ s97269pb_device::s97269pb_device(const machine_config &mconfig, const char *tag,
 
 void s97269pb_device::device_start()
 {
+	save_item(NAME(m_palette_bank));
 }
 
 //-------------------------------------------------
@@ -118,7 +120,7 @@ void s97269pb_device::palette_bank_w(uint8_t data)
 	m_palette_bank = data & 0x0c;
 }
 
-pen_t s97269pb_device::choosePen(uint8_t x, uint8_t y, pen_t back_pen)
+pen_t s97269pb_device::choose_pen(uint8_t x, uint8_t y, pen_t back_pen)
 {
 	if (m_palette_bank & 0x04)
 	{
@@ -131,8 +133,7 @@ pen_t s97269pb_device::choosePen(uint8_t x, uint8_t y, pen_t back_pen)
 		if (m_palette_bank & 0x08)
 			offset |= 0x80;
 
-		uint8_t *prombase = memregion("s97269pb")->base();
-		uint8_t gradient_flags = prombase[offset];
+		uint8_t gradient_flags = m_prom_ptr[offset];
 
 		switch (gradient_flags >> 4)
 		{

--- a/src/mame/video/vicdual-97269pb.h
+++ b/src/mame/video/vicdual-97269pb.h
@@ -2,8 +2,8 @@
 // copyright-holders:Ariane Fugmann
 #pragma once
 
-#ifndef __S97269PB_H__
-#define __S97269PB_H__
+#ifndef MAME_VIDEO_VICDUAL_97269PB_H
+#define MAME_VIDEO_VICDUAL_97269PB_H
 
 #define MCFG_S97269PB_ADD(_tag ) \
 	MCFG_DEVICE_ADD(_tag, S97269PB, 0)
@@ -20,7 +20,7 @@ public:
 
 	// daughterboard logic
 	void palette_bank_w(uint8_t data);
-	pen_t choosePen(uint8_t x, uint8_t y, pen_t back_pen);
+	pen_t choose_pen(uint8_t x, uint8_t y, pen_t back_pen);
 
 protected:
 	// device-level overrides
@@ -29,6 +29,8 @@ protected:
 	virtual const tiny_rom_entry *device_rom_region() const override;
 
 private:
+	required_region_ptr<uint8_t> m_prom_ptr;
+
 	// bit 2 enables gradient and starfield 
 	// bit 3 seems to be used to flip for cocktail
 	uint8_t m_palette_bank;
@@ -37,4 +39,4 @@ private:
 // device type definition
 extern const device_type S97269PB;
 
-#endif  /* __S97269PB_H__ */
+#endif  /* MAME_VIDEO_VICDUAL_97269PB_H */

--- a/src/mame/video/vicdual-97269pb.h
+++ b/src/mame/video/vicdual-97269pb.h
@@ -1,0 +1,40 @@
+// license:BSD-3-Clause
+// copyright-holders:Ariane Fugmann
+#pragma once
+
+#ifndef __S97269PB_H__
+#define __S97269PB_H__
+
+#define MCFG_S97269PB_ADD(_tag ) \
+	MCFG_DEVICE_ADD(_tag, S97269PB, 0)
+
+//**************************************************************************
+//  TYPE DEFINITIONS
+//**************************************************************************
+
+class s97269pb_device : public device_t
+{
+public:
+	// construction/destruction
+	s97269pb_device(const machine_config &mconfig, const char *tag, device_t *owner, uint32_t clock);
+
+	// daughterboard logic
+	void palette_bank_w(uint8_t data);
+	pen_t choosePen(uint8_t x, uint8_t y, pen_t back_pen);
+
+protected:
+	// device-level overrides
+	virtual void device_start() override;
+	virtual void device_reset() override;
+	virtual const tiny_rom_entry *device_rom_region() const override;
+
+private:
+	// bit 2 enables gradient and starfield 
+	// bit 3 seems to be used to flip for cocktail
+	uint8_t m_palette_bank;
+};
+
+// device type definition
+extern const device_type S97269PB;
+
+#endif  /* __S97269PB_H__ */

--- a/src/mame/video/vicdual.cpp
+++ b/src/mame/video/vicdual.cpp
@@ -112,9 +112,9 @@ uint32_t vicdual_state::screen_update_color(screen_device &screen, bitmap_rgb32 
 			fore_pen = pens_from_color_prom[(color_prom[offs] >> 5) & 0x07];
 		}
 
-		if (m_s97269pb != nullptr)
-			back_pen = m_s97269pb->choose_pen(x, y, back_pen);
-		
+		// this does nothing by default, but is used to enable overrides
+		back_pen = choose_pen(x, y, back_pen);
+
 		/* plot the current pixel */
 		pen = (video_data & 0x80) ? fore_pen : back_pen;
 		bitmap.pix32(y, x) = pen;
@@ -149,4 +149,16 @@ uint32_t vicdual_state::screen_update_bw_or_color(screen_device &screen, bitmap_
 		screen_update_bw(screen, bitmap, cliprect);
 
 	return 0;
+}
+
+
+pen_t vicdual_state::choose_pen(uint8_t x, uint8_t y, pen_t back_pen)
+{
+	return back_pen;
+}
+
+
+pen_t nsub_state::choose_pen(uint8_t x, uint8_t y, pen_t back_pen)
+{
+	return m_s97269pb->choose_pen(x, y, back_pen);
 }

--- a/src/mame/video/vicdual.cpp
+++ b/src/mame/video/vicdual.cpp
@@ -112,23 +112,9 @@ uint32_t vicdual_state::screen_update_color(screen_device &screen, bitmap_rgb32 
 			fore_pen = pens_from_color_prom[(color_prom[offs] >> 5) & 0x07];
 		}
 
-		if (m_gradient == 0x04)
-		{
-			// used by nsub and starrkr (maybe others)
-			// bit 4 on palette_bank_w seems to enable/disable the starfield/gradient
-			// how exactly those work is unclear right now
-			if (x >= 24 && x < 105)
-			{
-				// nsub - black to blue gradient
-				back_pen = rgb_t(0x00, 0x00, (x - 24) * 3);
-			}
-			if (x >= 105 && x < 233)
-			{
-				// nsub - blue to cyan gradient
-				back_pen = rgb_t(0x00, 0x80 + (x - 105), 0xff);
-			}
-		}
-
+		if (m_s97269pb != nullptr)
+			back_pen = m_s97269pb->choosePen(x, y, back_pen);
+		
 		/* plot the current pixel */
 		pen = (video_data & 0x80) ? fore_pen : back_pen;
 		bitmap.pix32(y, x) = pen;

--- a/src/mame/video/vicdual.cpp
+++ b/src/mame/video/vicdual.cpp
@@ -113,7 +113,7 @@ uint32_t vicdual_state::screen_update_color(screen_device &screen, bitmap_rgb32 
 		}
 
 		if (m_s97269pb != nullptr)
-			back_pen = m_s97269pb->choosePen(x, y, back_pen);
+			back_pen = m_s97269pb->choose_pen(x, y, back_pen);
 		
 		/* plot the current pixel */
 		pen = (video_data & 0x80) ? fore_pen : back_pen;


### PR DESCRIPTION
*EDIT*
this is a followup to https://github.com/mamedev/mame/pull/2092 and https://github.com/mamedev/mame/pull/2124
*EDIT*

confirmed PR-33 and PR-34 on the nsub motherboard. type is MMI 6331 (32*8)

added the 97269-P-B daughterboard.
not complete - gradient is still a simulation, but now uses the PROMs
starfield is still completely missing.

reference image: http://images.arianchen.de/2017-01/030320171775.jpg
wiring notes: http://files.arianchen.de/nsub/97269-P-B.txt

the 1024*4 proms are are one nybble-per-byte with the upper 4 bits being zero

PROMs: http://files.arianchen.de/nsub/s97269pb.zip