### PR TITLE
Refactoring in response to MT#6531

### DIFF
--- a/src/emu/device.h
+++ b/src/emu/device.h
@@ -353,6 +353,7 @@ public:
 	virtual ~device_t();
 
 	// getters
+	bool has_running_machine() const { return m_machine != nullptr; }
 	running_machine &machine() const { /*assert(m_machine != nullptr);*/ return *m_machine; }
 	const char *tag() const { return m_tag.c_str(); }
 	const char *basetag() const { return m_basetag.c_str(); }

--- a/src/emu/diimage.h
+++ b/src/emu/diimage.h
@@ -194,7 +194,6 @@ public:
 	int image_feof() { check_for_file(); return m_file->eof(); }
 	void *ptr() {check_for_file(); return const_cast<void *>(m_file->buffer()); }
 	// configuration access
-	void set_init_phase() { m_init_phase = true; }
 
 	const std::string &longname() const { return m_longname; }
 	const std::string &manufacturer() const { return m_manufacturer; }
@@ -234,7 +233,6 @@ public:
 	// loads a softlist item by name
 	image_init_result load_software(const std::string &software_identifier);
 
-	bool open_image_file(emu_options &options);
 	image_init_result finish_load();
 	void unload();
 	image_init_result create(const std::string &path, const image_device_format *create_format, util::option_resolution *create_args);
@@ -281,6 +279,7 @@ protected:
 	const software_part *find_software_item(const std::string &identifier, bool restrict_to_interface, software_list_device **device = nullptr) const;
 	bool load_software_part(const std::string &identifier);
 	std::string software_get_default_slot(const char *default_card_slot) const;
+	bool open_image_file(emu_options &options);
 
 	void add_format(std::unique_ptr<image_device_format> &&format);
 	void add_format(std::string &&name, std::string &&description, std::string &&extensions, std::string &&optspec);
@@ -310,9 +309,14 @@ protected:
 
 private:
 	static image_error_t image_error_from_file_error(osd_file::error filerr);
-	bool schedule_postload_hard_reset_if_needed();
 	std::vector<u32> determine_open_plan(bool is_create);
 	void update_names();
+
+	bool init_phase() const;
+
+	// loads an image or software items and resets - called internally when we
+	// load an is_reset_on_load() item
+	void reset_and_load(const std::string &path);
 
 	// creation info
 	formatlist_type m_formatlist;
@@ -329,8 +333,7 @@ private:
 	// flags
 	bool m_readonly;
 	bool m_created;
-	bool m_init_phase;
-
+	
 	// special - used when creating
 	int m_create_format;
 	util::option_resolution *m_create_args;

--- a/src/emu/dislot.cpp
+++ b/src/emu/dislot.cpp
@@ -9,16 +9,31 @@
 #include "emu.h"
 #include "emuopts.h"
 
+// -------------------------------------------------
+// ctor
+// -------------------------------------------------
+
 device_slot_interface::device_slot_interface(const machine_config &mconfig, device_t &device)
 	: device_interface(device, "slot"),
 	m_default_option(nullptr),
-	m_fixed(false)
+	m_fixed(false),
+	m_card_device(nullptr)
 {
 }
+
+
+// -------------------------------------------------
+// dtor
+// -------------------------------------------------
 
 device_slot_interface::~device_slot_interface()
 {
 }
+
+
+// -------------------------------------------------
+// device_slot_option ctor
+// -------------------------------------------------
 
 device_slot_option::device_slot_option(const char *name, const device_type &devtype):
 	m_name(name),
@@ -31,12 +46,22 @@ device_slot_option::device_slot_option(const char *name, const device_type &devt
 {
 }
 
+
+// -------------------------------------------------
+// static_option_reset
+// -------------------------------------------------
+
 void device_slot_interface::static_option_reset(device_t &device)
 {
 	device_slot_interface &intf = dynamic_cast<device_slot_interface &>(device);
 
 	intf.m_options.clear();
 }
+
+
+// -------------------------------------------------
+// static_option_add
+// -------------------------------------------------
 
 void device_slot_interface::static_option_add(device_t &device, const char *name, const device_type &devtype)
 {
@@ -49,6 +74,11 @@ void device_slot_interface::static_option_add(device_t &device, const char *name
 	intf.m_options.emplace(std::make_pair(name, std::make_unique<device_slot_option>(name, devtype)));
 }
 
+
+// -------------------------------------------------
+// static_option
+// -------------------------------------------------
+
 device_slot_option *device_slot_interface::static_option(device_t &device, const char *name)
 {
 	device_slot_interface &intf = dynamic_cast<device_slot_interface &>(device);
@@ -60,22 +90,10 @@ device_slot_option *device_slot_interface::static_option(device_t &device, const
 	return option;
 }
 
-device_t* device_slot_interface::get_card_device()
-{
-	std::string subtag;
-	device_t *dev = nullptr;
-	if (device().mconfig().options().exists(device().tag()+1))
-		subtag = device().mconfig().options().main_value(device().tag()+1);
-	else if (m_default_option != nullptr)
-		subtag.assign(m_default_option);
-	if (!subtag.empty()) {
-		device_slot_card_interface *intf = nullptr;
-		dev = device().subdevice(subtag.c_str());
-		if (dev!=nullptr && !dev->interface(intf))
-			throw emu_fatalerror("get_card_device called for device '%s' with no slot card interface", dev->tag());
-	}
-	return dev;
-}
+
+// -------------------------------------------------
+// has_selectable_options
+// -------------------------------------------------
 
 bool device_slot_interface::has_selectable_options() const
 {
@@ -86,6 +104,23 @@ bool device_slot_interface::has_selectable_options() const
 				return true;
 	}
 	return false;
+}
+
+
+// -------------------------------------------------
+// option
+// -------------------------------------------------
+
+device_slot_option *device_slot_interface::option(const char *name) const
+{
+	device_slot_option *result = nullptr;
+	if (name)
+	{
+		auto search = m_options.find(name);
+		if (search != m_options.end())
+			result = search->second.get();
+	}
+	return result;
 }
 
 

--- a/src/emu/dislot.h
+++ b/src/emu/dislot.h
@@ -113,16 +113,19 @@ public:
 	bool has_selectable_options() const;
 	const char *default_option() const { return m_default_option; }
 	const std::unordered_map<std::string, std::unique_ptr<device_slot_option>> &option_list() const { return m_options; }
-	device_slot_option *option(const char *name) const { if (name) { auto search = m_options.find(name); if (search != m_options.end()) return search->second.get(); else return nullptr; } else return nullptr; }
+	device_slot_option *option(const char *name) const;
 	virtual std::string get_default_card_software() { return std::string(); }
-	device_t *get_card_device();
+	device_t *get_card_device() { return m_card_device; }
+	void set_card_device(device_t *dev) { m_card_device = dev; }
 
 private:
 	// internal state
-	static device_slot_option *static_option(device_t &device, const char *option);
 	std::unordered_map<std::string,std::unique_ptr<device_slot_option>> m_options;
 	const char *m_default_option;
 	bool m_fixed;
+	device_t *m_card_device;
+
+	static device_slot_option *static_option(device_t &device, const char *option);
 };
 
 // iterator

--- a/src/emu/emuopts.cpp
+++ b/src/emu/emuopts.cpp
@@ -231,33 +231,6 @@ emu_options::emu_options()
 }
 
 
-std::string emu_options::main_value(const char *name) const
-{
-	std::string buffer = value(name);
-	int pos = buffer.find_first_of(',');
-	if (pos != -1)
-		buffer = buffer.substr(0, pos);
-	return buffer;
-}
-
-std::string emu_options::sub_value(const char *name, const char *subname) const
-{
-	std::string tmp = std::string(",").append(subname).append("=");
-	std::string buffer = value(name);
-	int pos = buffer.find(tmp);
-	if (pos != -1)
-	{
-		int endpos = buffer.find_first_of(',', pos + 1);
-		if (endpos == -1)
-			endpos = buffer.length();
-		buffer = buffer.substr(pos + tmp.length(), endpos - pos - tmp.length());
-	}
-	else
-		buffer.clear();
-	return buffer;
-}
-
-
 //-------------------------------------------------
 //  value_changed - to prevent tagmap
 //    lookups keep copies of frequently requested

--- a/src/emu/romload.cpp
+++ b/src/emu/romload.cpp
@@ -1467,9 +1467,13 @@ rom_load_manager::rom_load_manager(running_machine &machine)
 				specbios.assign(machine.options().bios());
 			else
 			{
-				specbios = machine.options().sub_value(device.owner()->tag()+1,"bios");
-				if (specbios.empty())
-					specbios = device.default_bios_tag();
+				const char *slot_option_name = device.owner()->tag() + 1;
+				const slot_option *opt = machine.options().slot_options().count(slot_option_name)
+					? &machine.options().slot_options()[slot_option_name]
+					: nullptr;
+				specbios = opt && !opt->bios().empty()
+					? opt->bios().c_str()
+					: device.default_bios_tag();
 			}
 			determine_bios_rom(device, specbios.c_str());
 		}

--- a/src/frontend/mame/mame.cpp
+++ b/src/frontend/mame/mame.cpp
@@ -216,6 +216,11 @@ int mame_machine_manager::execute()
 			valid.check_shared_source(*system);
 		}
 
+		// reevaluate slot options until nothing changes
+		while (mame_options::reevaluate_slot_options(m_options))
+		{
+		}
+
 		// create the machine configuration
 		machine_config config(*system, m_options);
 

--- a/src/frontend/mame/mameopts.h
+++ b/src/frontend/mame/mameopts.h
@@ -53,6 +53,8 @@ class mame_options
 	static const uint32_t OPTION_FLAG_DEVICE = 0x80000000;
 
 public:
+	typedef std::function<std::string (const std::string &)> value_specifier_func;
+
 	// parsing wrappers
 	static bool parse_command_line(emu_options &options, std::vector<std::string> &args, std::string &error_string);
 	static void parse_standard_inis(emu_options &options, std::string &error_string, const game_driver *driver = nullptr);
@@ -61,21 +63,26 @@ public:
 
 	static const game_driver *system(const emu_options &options);
 	static void set_system_name(emu_options &options, const char *name);
-	static bool add_slot_options(emu_options &options, std::function<void(emu_options &options, const std::string &)> value_specifier = nullptr);
+	static bool add_slot_options(emu_options &options, value_specifier_func value_specifier = nullptr);
+	static bool reevaluate_slot_options(emu_options &options);
 
 private:
 	// device-specific option handling
-	static void add_device_options(emu_options &options, std::function<void(emu_options &options, const std::string &)> value_specifier = nullptr);
+	static void add_device_options(emu_options &options, value_specifier_func value_specifier = nullptr);
 	static void update_slot_options(emu_options &options, const software_part *swpart = nullptr);
-	static void parse_slot_devices(emu_options &options, std::function<void(emu_options &options, const std::string &)> value_specifier);
+	static void parse_slot_devices(emu_options &options, value_specifier_func value_specifier);
 	static std::string get_full_option_name(const device_image_interface &image);
-	static bool reevaluate_slot_options(emu_options &options);
+	static slot_option parse_slot_option(std::string &&text);
 
 	// INI parsing helper
 	static bool parse_one_ini(emu_options &options, const char *basename, int priority, std::string *error_string = nullptr);
 
 	// softlist handling
 	static std::map<std::string, std::string> evaluate_initial_softlist_options(emu_options &options);
+
+	// represents an "invalid" value (an empty string is valid so we can't use that; what I
+	// really want to return is std::optional<std::string> but C++17 isn't here yet)
+	static std::string value_specifier_invalid_value() { return std::string("\x01\x02\x03"); }
 
 	static int m_slot_options;
 	static int m_device_options;

--- a/src/frontend/mame/ui/imgcntrl.cpp
+++ b/src/frontend/mame/ui/imgcntrl.cpp
@@ -158,7 +158,6 @@ void menu_control_device_image::load_software_part()
 
 void menu_control_device_image::hook_load(const std::string &name)
 {
-	if (m_image.is_reset_on_load()) m_image.set_init_phase();
 	m_image.load(name);
 	stack_pop();
 }

--- a/src/frontend/mame/ui/info.cpp
+++ b/src/frontend/mame/ui/info.cpp
@@ -15,6 +15,7 @@
 
 #include "drivenum.h"
 #include "softlist.h"
+#include "emuopts.h"
 
 namespace ui {
 //-------------------------------------------------
@@ -322,7 +323,7 @@ std::string machine_info::mandatory_images()
 	// make sure that any required image has a mounted file
 	for (device_image_interface &image : image_interface_iterator(m_machine.root_device()))
 	{
-		if (image.filename() == nullptr && image.must_be_loaded())
+		if (image.must_be_loaded() && m_machine.options().image_options().count(image.instance_name()) == 0)
 			buf << "\"" << image.instance_name() << "\", ";
 	}
 	return buf.str();

--- a/src/frontend/mame/ui/miscmenu.cpp
+++ b/src/frontend/mame/ui/miscmenu.cpp
@@ -131,10 +131,8 @@ void menu_bios_selection::handle()
 				machine().options().set_value("bios", val-1, OPTION_PRIORITY_CMDLINE, error);
 				assert(error.empty());
 			} else {
-				std::string error;
-				std::string value = string_format("%s,bios=%d", machine().options().main_value(dev->owner()->tag()+1), val-1);
-				machine().options().set_value(dev->owner()->tag()+1, value.c_str(), OPTION_PRIORITY_CMDLINE, error);
-				assert(error.empty());
+				const char *slot_option_name = dev->owner()->tag() + 1;
+				machine().options().slot_options()[slot_option_name].set_bios(string_format("%d", val - 1));
 			}
 			reset(reset_options::REMEMBER_REF);
 		}

--- a/src/frontend/mame/ui/slotopt.cpp
+++ b/src/frontend/mame/ui/slotopt.cpp
@@ -25,14 +25,17 @@ namespace ui {
 device_slot_option *menu_slot_devices::slot_get_current_option(device_slot_interface &slot)
 {
 	std::string current;
-	if (slot.fixed())
+
+	const char *slot_option_name = slot.device().tag() + 1;
+	if (!slot.fixed() && machine().options().slot_options().count(slot_option_name) > 0)
 	{
-		if (slot.default_option() == nullptr) return nullptr;
-		current.assign(slot.default_option());
+		current = machine().options().slot_options()[slot_option_name].value();
 	}
 	else
 	{
-		current = machine().options().main_value(slot.device().tag() + 1);
+		if (slot.default_option() == nullptr)
+			return nullptr;
+		current.assign(slot.default_option());
 	}
 
 	return slot.option(current.c_str());


### PR DESCRIPTION
Prior to this change, options for images and slots were stored in the emu_options collection.  Anything that might restart the emulation (such as slot changes and images that reset on load) had to manipulate the emu_options structure directly.  The dynamic nature of images and slots meant that some elaborate conventions for setting up this collection had to be understood by clients.

After this change, emu_options has two new members (image_options and slot_options) that expose image and slot selections via an std::map.  Anything that changes images or slots in a fashion that needs to persist across sessions needs to modify these data structures.  Additionally, some of the hairly logic (e.g. - get_default_card_software) now records its data here rather than trying to subvert the core_options system.

This is how MT#6531 was fixed; now when diimage.cpp sees an image that resets on load, it just modifies the image_options structure and forces a reset.  This allowed some further cleanups to happen within diimage.

This should be considered a very risky change, and scrutiny/feedback is welcome.  In particular, there seems to be functionality surrounding device bioses that I'm not 100% sure how it works; the syntax seems to imply that it only works on slot devices.