### PR TITLE
Fixed issue that could cause bogus arguments to be reported incorrectly

### DIFF
--- a/src/lib/util/options.cpp
+++ b/src/lib/util/options.cpp
@@ -361,13 +361,18 @@ bool core_options::parse_command_line(std::vector<std::string> &args, int priori
 		{
 			// we need to relocate this option
 			if (new_argc != arg)
-				args[new_argc++] = std::move(args[arg]);
+				args[new_argc] = std::move(args[arg]);
+			new_argc++;
 
 			if (!is_unadorned)
 			{
 				arg++;
-				if (new_argc != arg && arg < args.size())
-					args[new_argc++] = std::move(args[arg]);
+				if (arg < args.size())
+				{
+					if (new_argc != arg)
+						args[new_argc] = std::move(args[arg]);
+					new_argc++;
+				}
 			}
 			continue;
 		}


### PR DESCRIPTION
Examples:  'mame -whatever nes' would previously be reported as "Unrecognized argument: nes"