### PR TITLE
Fixed a bug that caused "Switch Item Ordering" in the software list menu to dupe entries

### DIFF
--- a/src/frontend/mame/ui/swlist.cpp
+++ b/src/frontend/mame/ui/swlist.cpp
@@ -22,8 +22,11 @@ namespace ui {
     CONSTANTS
 ***************************************************************************/
 
-/* time (in seconds) to display errors */
+// time (in seconds) to display errors
 #define ERROR_MESSAGE_TIME      5
+
+// item reference for "Switch Item Ordering"
+#define ITEMREF_SWITCH_ITEM_ORDERING	((void *)1)
 
 
 /***************************************************************************
@@ -214,12 +217,15 @@ void menu_software_list::append_software_entry(const software_info &swinfo)
 
 void menu_software_list::populate(float &customtop, float &custombottom)
 {
+	// clear all entries before populating
+	m_entrylist.clear();
+
 	// build up the list of entries for the menu
 	for (const software_info &swinfo : m_swlist->get_info())
 		append_software_entry(swinfo);
 
 	// add an entry to change ordering
-	item_append(_("Switch Item Ordering"), "", 0, (void *)1);
+	item_append(_("Switch Item Ordering"), "", 0, ITEMREF_SWITCH_ITEM_ORDERING);
 
 	// append all of the menu entries
 	for (auto &entry : m_entrylist)
@@ -241,7 +247,7 @@ void menu_software_list::handle()
 
 	if (event && event->itemref)
 	{
-		if ((uintptr_t)event->itemref == 1 && event->iptkey == IPT_UI_SELECT)
+		if (event->itemref == ITEMREF_SWITCH_ITEM_ORDERING && event->iptkey == IPT_UI_SELECT)
 		{
 			m_ordered_by_shortname = !m_ordered_by_shortname;
 


### PR DESCRIPTION
This was MT#6402