### PR TITLE
Workaround for MSVC stupidity

### DIFF
--- a/src/lib/netlist/nl_base.h
+++ b/src/lib/netlist/nl_base.h
@@ -835,8 +835,9 @@ namespace netlist
 		devices::matrix_solver_t *solver() const NL_NOEXCEPT { return m_solver; }
 		void set_solver(devices::matrix_solver_t *solver) NL_NOEXCEPT { m_solver = solver; }
 
-	private:
 		state_var<nl_double>     m_cur_Analog;
+
+	private:
 		devices::matrix_solver_t *m_solver;
 	};
 

--- a/src/lib/netlist/plib/pconfig.h
+++ b/src/lib/netlist/plib/pconfig.h
@@ -48,6 +48,8 @@
 #define C14CONSTEXPR constexpr
 #elif __cplusplus == 201703L
 #define C14CONSTEXPR constexpr
+#elif defined(_MSC_VER)
+#define C14CONSTEXPR
 #else
 #error "C++ version not supported"
 #endif

--- a/src/lib/netlist/plib/pstring.h
+++ b/src/lib/netlist/plib/pstring.h
@@ -34,10 +34,10 @@ public:
 
 	pstring_const_iterator() noexcept : p() { }
 	explicit constexpr pstring_const_iterator(const typename string_type::const_iterator &x) noexcept : p(x) { }
-	pstring_const_iterator(const pstring_const_iterator &rhs) noexcept = default;
-	pstring_const_iterator(pstring_const_iterator &&rhs) noexcept = default;
-	pstring_const_iterator &operator=(const pstring_const_iterator &rhs) noexcept = default;
-	pstring_const_iterator &operator=(pstring_const_iterator &&rhs) noexcept = default;
+	pstring_const_iterator(const pstring_const_iterator &rhs) noexcept : p(rhs.p) { }
+	pstring_const_iterator(pstring_const_iterator &&rhs) noexcept : p(rhs.p) { }
+	pstring_const_iterator &operator=(const pstring_const_iterator &rhs) noexcept { p = rhs.p; return *this; }
+	pstring_const_iterator &operator=(pstring_const_iterator &&rhs) noexcept { p = rhs.p; return *this; }
 
 	pstring_const_iterator& operator++() noexcept { p += static_cast<difference_type>(traits_type::codelen(&(*p))); return *this; }
 	pstring_const_iterator operator++(int) noexcept { pstring_const_iterator tmp(*this); operator++(); return tmp; }
@@ -153,6 +153,7 @@ public:
 			*this += c;
 		return *this;
 	}
+
 
 	// no non-const const_iterator for now
 	typedef pstring_const_iterator<pstring_t> iterator;

--- a/src/lib/netlist/solver/nld_ms_gcr.h
+++ b/src/lib/netlist/solver/nld_ms_gcr.h
@@ -388,7 +388,7 @@ unsigned matrix_solver_GCR_t<m_N, storage_N>::vsolve_non_dynamic(const bool newt
 	if (m_proc.resolved())
 	{
 		//static_solver(m_A, RHS);
-		m_proc(mat.A, RHS, new_V);
+		m_proc((double *) mat.A, (double *)RHS, (double *)new_V);
 	}
 	else
 	{


### PR DESCRIPTION
Much of the netlist stuff seems to blow up in MSVC2015, and as far as I can tell this is an MSVC problem, but if we consider MSVC2015 a supported compiler we need a work around.

https://connect.microsoft.com/VisualStudio/feedback/details/763051/a-value-of-predefined-macro-cplusplus-is-still-199711l