### PR TITLE
Changed the validity checks to have its own emu_options

### DIFF
--- a/src/emu/validity.cpp
+++ b/src/emu/validity.cpp
@@ -298,7 +298,8 @@ void validity_checker::validate_one(const game_driver &driver)
 	// wrap in try/except to catch fatalerrors
 	try
 	{
-		machine_config config(driver, m_drivlist.options());
+		emu_options options;
+		machine_config config(driver, options);
 		m_current_config = &config;
 		validate_driver();
 		validate_roms();


### PR DESCRIPTION
This comes from a regression reported by Tafoid whereby the following command line:

	mame coco wildcat

Would report the following error (which was not really fatal because it happened within validation):

	Driver t4426 (file coco12.cpp): 1 errors, 0 warnings
	Errors:
		Fatal error Unknown slot option 'pak' in slot 'ext'

My changes to option processing changed emu_options to put image and slot options in their own arrays, and I expect those image/slot options to be pertinent to the active driver.  However, driver validation was passing the emu_options associated with the main emulation  to validation specific maching_config for other drivers.  This changes validate_one() to always use a fresh emu_options with each individual validation.