### PR TITLE
Changes to make get_default_card_software() less stupid

### DIFF
--- a/src/devices/bus/a7800/a78_slot.cpp
+++ b/src/devices/bus/a7800/a78_slot.cpp
@@ -511,9 +511,9 @@ image_verify_result a78_cart_slot_device::verify_header(char *header)
  get default card software
  -------------------------------------------------*/
 
-std::string a78_cart_slot_device::get_default_card_software()
+std::string a78_cart_slot_device::get_default_card_software(get_default_card_software_hook &hook) const
 {
-	if (open_image_file(mconfig().options()))
+	if (hook.image_file())
 	{
 		const char *slot_string;
 		std::vector<uint8_t> head(128);
@@ -568,8 +568,6 @@ std::string a78_cart_slot_device::get_default_card_software()
 
 		logerror("Cart type: %x\n", type);
 		slot_string = a78_get_slot(type);
-
-		clear();
 
 		return std::string(slot_string);
 	}

--- a/src/devices/bus/a7800/a78_slot.h
+++ b/src/devices/bus/a7800/a78_slot.h
@@ -114,7 +114,7 @@ public:
 	virtual device_image_partialhash_func get_partial_hash() const override { return &a78_partialhash; }
 
 	// slot interface overrides
-	virtual std::string get_default_card_software() override;
+	virtual std::string get_default_card_software(get_default_card_software_hook &hook) const override;
 
 	// reading and writing
 	virtual DECLARE_READ8_MEMBER(read_04xx);

--- a/src/devices/bus/a800/a800_slot.cpp
+++ b/src/devices/bus/a800/a800_slot.cpp
@@ -388,9 +388,9 @@ int a800_cart_slot_device::identify_cart_type(const uint8_t *header) const
  get default card software
  -------------------------------------------------*/
 
-std::string a800_cart_slot_device::get_default_card_software()
+std::string a800_cart_slot_device::get_default_card_software(get_default_card_software_hook &hook) const
 {
-	if (open_image_file(mconfig().options()))
+	if (hook.image_file())
 	{
 		const char *slot_string;
 		std::vector<uint8_t> head(0x10);
@@ -416,8 +416,6 @@ std::string a800_cart_slot_device::get_default_card_software()
 
 		slot_string = a800_get_slot(type);
 
-		clear();
-
 		return std::string(slot_string);
 	}
 	else
@@ -425,33 +423,31 @@ std::string a800_cart_slot_device::get_default_card_software()
 }
 
 
-std::string a5200_cart_slot_device::get_default_card_software()
+std::string a5200_cart_slot_device::get_default_card_software(get_default_card_software_hook &hook) const
 {
-	if (open_image_file(mconfig().options()))
+	if (hook.image_file())
 	{
 		const char *slot_string;
 		std::vector<uint8_t> head(0x10);
-		uint32_t len = m_file->size();
+		uint32_t len = hook.image_file()->size();
 		int type = A5200_8K;
 
 		// check whether there is an header, to identify the cart type
 		if ((len % 0x1000) == 0x10)
 		{
-			m_file->read(&head[0], 0x10);
+			hook.image_file()->read(&head[0], 0x10);
 			type = identify_cart_type(&head[0]);
 		}
 		else
 		{
 			std::string info;
-			if (hashfile_extrainfo(*this, info) && info.compare("A13MIRRORING")==0)
+			if (hook.hashfile_extrainfo(info) && info.compare("A13MIRRORING")==0)
 				type = A5200_16K_2CHIPS;
 		}
 		if (type < A5200_4K)
 			osd_printf_info("This game is not designed for A5200. You might want to run it in A800 or A800XL.\n");
 
 		slot_string = a800_get_slot(type);
-
-		clear();
 
 		return std::string(slot_string);
 	}
@@ -460,19 +456,19 @@ std::string a5200_cart_slot_device::get_default_card_software()
 }
 
 
-std::string xegs_cart_slot_device::get_default_card_software()
+std::string xegs_cart_slot_device::get_default_card_software(get_default_card_software_hook &hook) const
 {
-	if (open_image_file(mconfig().options()))
+	if (hook.image_file())
 	{
 		const char *slot_string;
 		std::vector<uint8_t> head(0x10);
-		uint32_t len = m_file->size();
+		uint32_t len = hook.image_file()->size();
 		int type = A800_8K;
 
 		// check whether there is an header, to identify the cart type
 		if ((len % 0x1000) == 0x10)
 		{
-			m_file->read(&head[0], 0x10);
+			hook.image_file()->read(&head[0], 0x10);
 			type = identify_cart_type(&head[0]);
 		}
 		if (type != A800_XEGS)
@@ -485,8 +481,6 @@ std::string xegs_cart_slot_device::get_default_card_software()
 		}
 
 		slot_string = a800_get_slot(type);
-
-		clear();
 
 		return std::string(slot_string);
 	}

--- a/src/devices/bus/a800/a800_slot.h
+++ b/src/devices/bus/a800/a800_slot.h
@@ -113,7 +113,7 @@ public:
 	virtual const char *file_extensions() const override { return "bin,rom,car"; }
 
 	// slot interface overrides
-	virtual std::string get_default_card_software() override;
+	virtual std::string get_default_card_software(get_default_card_software_hook &hook) const override;
 
 	// reading and writing
 	virtual DECLARE_READ8_MEMBER(read_80xx);
@@ -142,7 +142,7 @@ public:
 	virtual const char *file_extensions() const override { return "bin,rom,car,a52"; }
 
 	// slot interface overrides
-	virtual std::string get_default_card_software() override;
+	virtual std::string get_default_card_software(get_default_card_software_hook &hook) const override;
 };
 
 // ======================> xegs_cart_slot_device
@@ -157,7 +157,7 @@ public:
 	virtual const char *file_extensions() const override { return "bin,rom,car"; }
 
 	// slot interface overrides
-	virtual std::string get_default_card_software() override;
+	virtual std::string get_default_card_software(get_default_card_software_hook &hook) const override;
 };
 
 // device type definition

--- a/src/devices/bus/adam/exp.cpp
+++ b/src/devices/bus/adam/exp.cpp
@@ -113,7 +113,7 @@ image_init_result adam_expansion_slot_device::call_load()
 //  get_default_card_software -
 //-------------------------------------------------
 
-std::string adam_expansion_slot_device::get_default_card_software()
+std::string adam_expansion_slot_device::get_default_card_software(get_default_card_software_hook &hook) const
 {
 	return software_get_default_slot("standard");
 }

--- a/src/devices/bus/adam/exp.h
+++ b/src/devices/bus/adam/exp.h
@@ -84,7 +84,7 @@ protected:
 	virtual const char *file_extensions() const override { return "bin,rom"; }
 
 	// slot interface overrides
-	virtual std::string get_default_card_software() override;
+	virtual std::string get_default_card_software(get_default_card_software_hook &hook) const override;
 
 	devcb_write_line   m_write_irq;
 

--- a/src/devices/bus/apf/slot.cpp
+++ b/src/devices/bus/apf/slot.cpp
@@ -198,12 +198,12 @@ image_init_result apf_cart_slot_device::call_load()
  get default card software
  -------------------------------------------------*/
 
-std::string apf_cart_slot_device::get_default_card_software()
+std::string apf_cart_slot_device::get_default_card_software(get_default_card_software_hook &hook) const
 {
-	if (open_image_file(mconfig().options()))
+	if (hook.image_file())
 	{
 		const char *slot_string;
-		uint32_t size = m_file->size();
+		uint32_t size = hook.image_file()->size();
 		int type = APF_STD;
 
 		// attempt to identify Space Destroyer, which needs 1K of additional RAM
@@ -215,7 +215,6 @@ std::string apf_cart_slot_device::get_default_card_software()
 		slot_string = apf_get_slot(type);
 
 		//printf("type: %s\n", slot_string);
-		clear();
 
 		return std::string(slot_string);
 	}

--- a/src/devices/bus/apf/slot.h
+++ b/src/devices/bus/apf/slot.h
@@ -84,7 +84,7 @@ public:
 	virtual const char *file_extensions() const override { return "bin"; }
 
 	// slot interface overrides
-	virtual std::string get_default_card_software() override;
+	virtual std::string get_default_card_software(get_default_card_software_hook &hook) const override;
 
 	// reading and writing
 	virtual DECLARE_READ8_MEMBER(read_rom);

--- a/src/devices/bus/arcadia/slot.cpp
+++ b/src/devices/bus/arcadia/slot.cpp
@@ -206,7 +206,7 @@ image_init_result arcadia_cart_slot_device::call_load()
  get default card software
  -------------------------------------------------*/
 
-std::string arcadia_cart_slot_device::get_default_card_software()
+std::string arcadia_cart_slot_device::get_default_card_software(get_default_card_software_hook &hook) const
 {
 	return software_get_default_slot("std");
 }

--- a/src/devices/bus/arcadia/slot.h
+++ b/src/devices/bus/arcadia/slot.h
@@ -74,7 +74,7 @@ public:
 	virtual const char *file_extensions() const override { return "bin"; }
 
 	// slot interface overrides
-	virtual std::string get_default_card_software() override;
+	virtual std::string get_default_card_software(get_default_card_software_hook &hook) const override;
 
 	// reading and writing
 	virtual DECLARE_READ8_MEMBER(read_rom);

--- a/src/devices/bus/astrocde/slot.cpp
+++ b/src/devices/bus/astrocde/slot.cpp
@@ -175,12 +175,12 @@ image_init_result astrocade_cart_slot_device::call_load()
  get default card software
  -------------------------------------------------*/
 
-std::string astrocade_cart_slot_device::get_default_card_software()
+std::string astrocade_cart_slot_device::get_default_card_software(get_default_card_software_hook &hook) const
 {
-	if (open_image_file(mconfig().options()))
+	if (hook.image_file())
 	{
 		const char *slot_string;
-		uint32_t size = m_file->size();
+		uint32_t size = hook.image_file()->size();
 		int type = ASTROCADE_STD;
 
 		if (size == 0x40000)
@@ -191,7 +191,6 @@ std::string astrocade_cart_slot_device::get_default_card_software()
 		slot_string = astrocade_get_slot(type);
 
 		//printf("type: %s\n", slot_string);
-		clear();
 
 		return std::string(slot_string);
 	}

--- a/src/devices/bus/astrocde/slot.h
+++ b/src/devices/bus/astrocde/slot.h
@@ -74,7 +74,7 @@ public:
 	virtual const char *file_extensions() const override { return "bin"; }
 
 	// slot interface overrides
-	virtual std::string get_default_card_software() override;
+	virtual std::string get_default_card_software(get_default_card_software_hook &hook) const override;
 
 	// reading and writing
 	virtual DECLARE_READ8_MEMBER(read_rom);

--- a/src/devices/bus/c64/exp.cpp
+++ b/src/devices/bus/c64/exp.cpp
@@ -206,14 +206,12 @@ image_init_result c64_expansion_slot_device::call_load()
 //  get_default_card_software -
 //-------------------------------------------------
 
-std::string c64_expansion_slot_device::get_default_card_software()
+std::string c64_expansion_slot_device::get_default_card_software(get_default_card_software_hook &hook) const
 {
-	if (open_image_file(mconfig().options()))
+	if (hook.image_file())
 	{
-		if (is_filetype("crt"))
-			return cbm_crt_get_card(*m_file);
-
-		clear();
+		if (hook.is_filetype("crt"))
+			return cbm_crt_get_card(*hook.image_file());
 	}
 
 	return software_get_default_slot("standard");

--- a/src/devices/bus/c64/exp.h
+++ b/src/devices/bus/c64/exp.h
@@ -147,7 +147,7 @@ protected:
 	virtual const char *file_extensions() const override { return "80,a0,e0,crt"; }
 
 	// slot interface overrides
-	virtual std::string get_default_card_software() override;
+	virtual std::string get_default_card_software(get_default_card_software_hook &hook) const override;
 
 	devcb_read8        m_read_dma_cd;
 	devcb_write8       m_write_dma_cd;

--- a/src/devices/bus/cbm2/exp.cpp
+++ b/src/devices/bus/cbm2/exp.cpp
@@ -144,7 +144,7 @@ image_init_result cbm2_expansion_slot_device::call_load()
 //  get_default_card_software -
 //-------------------------------------------------
 
-std::string cbm2_expansion_slot_device::get_default_card_software()
+std::string cbm2_expansion_slot_device::get_default_card_software(get_default_card_software_hook &hook) const
 {
 	return software_get_default_slot("standard");
 }

--- a/src/devices/bus/cbm2/exp.h
+++ b/src/devices/bus/cbm2/exp.h
@@ -94,7 +94,7 @@ protected:
 	virtual const char *file_extensions() const override { return "20,40,60"; }
 
 	// slot interface overrides
-	virtual std::string get_default_card_software() override;
+	virtual std::string get_default_card_software(get_default_card_software_hook &hook) const override;
 
 	device_cbm2_expansion_card_interface *m_card;
 };

--- a/src/devices/bus/chanf/slot.cpp
+++ b/src/devices/bus/chanf/slot.cpp
@@ -193,12 +193,12 @@ image_init_result channelf_cart_slot_device::call_load()
  get default card software
  -------------------------------------------------*/
 
-std::string channelf_cart_slot_device::get_default_card_software()
+std::string channelf_cart_slot_device::get_default_card_software(get_default_card_software_hook &hook) const
 {
-	if (open_image_file(mconfig().options()))
+	if (hook.image_file())
 	{
 		const char *slot_string;
-		uint32_t len = m_file->size();
+		uint32_t len = hook.image_file()->size();
 		int type;
 
 		if (len == 0x40000)
@@ -209,7 +209,6 @@ std::string channelf_cart_slot_device::get_default_card_software()
 		slot_string = chanf_get_slot(type);
 
 		//printf("type: %s\n", slot_string);
-		clear();
 
 		return std::string(slot_string);
 	}

--- a/src/devices/bus/chanf/slot.h
+++ b/src/devices/bus/chanf/slot.h
@@ -88,7 +88,7 @@ public:
 	virtual const char *file_extensions() const override { return "bin,chf"; }
 
 	// slot interface overrides
-	virtual std::string get_default_card_software() override;
+	virtual std::string get_default_card_software(get_default_card_software_hook &hook) const override;
 
 	// reading and writing
 	virtual DECLARE_READ8_MEMBER(read_rom);

--- a/src/devices/bus/coco/cococart.cpp
+++ b/src/devices/bus/coco/cococart.cpp
@@ -368,7 +368,7 @@ image_init_result cococart_slot_device::call_load()
 //  get_default_card_software
 //-------------------------------------------------
 
-std::string cococart_slot_device::get_default_card_software()
+std::string cococart_slot_device::get_default_card_software(get_default_card_software_hook &hook) const
 {
 	return software_get_default_slot("pak");
 }

--- a/src/devices/bus/coco/cococart.h
+++ b/src/devices/bus/coco/cococart.h
@@ -84,7 +84,7 @@ public:
 	virtual const char *file_extensions() const override { return "ccc,rom"; }
 
 	// slot interface overrides
-	virtual std::string get_default_card_software() override;
+	virtual std::string get_default_card_software(get_default_card_software_hook &hook) const override;
 
 	// reading and writing to $FF40-$FF7F
 	DECLARE_READ8_MEMBER(read);

--- a/src/devices/bus/coleco/exp.cpp
+++ b/src/devices/bus/coleco/exp.cpp
@@ -101,11 +101,11 @@ image_init_result colecovision_cartridge_slot_device::call_load()
 //  get_default_card_software -
 //-------------------------------------------------
 
-std::string colecovision_cartridge_slot_device::get_default_card_software()
+std::string colecovision_cartridge_slot_device::get_default_card_software(get_default_card_software_hook &hook) const
 {
-	if (open_image_file(mconfig().options()))
+	if (hook.image_file())
 	{
-		uint32_t length = m_file->size();
+		uint32_t length = hook.image_file()->size();
 		if (length == 0x100000 || length == 0x200000)
 			return software_get_default_slot("xin1");
 	}

--- a/src/devices/bus/coleco/exp.h
+++ b/src/devices/bus/coleco/exp.h
@@ -90,7 +90,7 @@ protected:
 	virtual const char *file_extensions() const override { return "rom,col,bin"; }
 
 	// slot interface overrides
-	virtual std::string get_default_card_software() override;
+	virtual std::string get_default_card_software(get_default_card_software_hook &hook) const override;
 
 	device_colecovision_cartridge_interface *m_card;
 };

--- a/src/devices/bus/crvision/slot.cpp
+++ b/src/devices/bus/crvision/slot.cpp
@@ -206,12 +206,12 @@ image_init_result crvision_cart_slot_device::call_load()
  get default card software
  -------------------------------------------------*/
 
-std::string crvision_cart_slot_device::get_default_card_software()
+std::string crvision_cart_slot_device::get_default_card_software(get_default_card_software_hook &hook) const
 {
-	if (open_image_file(mconfig().options()))
+	if (hook.image_file())
 	{
 		const char *slot_string;
-		uint32_t size = m_file->size();
+		uint32_t size = hook.image_file()->size();
 		int type = CRV_4K;
 
 		switch (size)
@@ -242,7 +242,6 @@ std::string crvision_cart_slot_device::get_default_card_software()
 		slot_string = crvision_get_slot(type);
 
 		//printf("type: %s\n", slot_string);
-		clear();
 
 		return std::string(slot_string);
 	}

--- a/src/devices/bus/crvision/slot.h
+++ b/src/devices/bus/crvision/slot.h
@@ -79,7 +79,7 @@ public:
 	virtual const char *file_extensions() const override { return "bin,rom"; }
 
 	// slot interface overrides
-	virtual std::string get_default_card_software() override;
+	virtual std::string get_default_card_software(get_default_card_software_hook &hook) const override;
 
 	// reading and writing
 	virtual DECLARE_READ8_MEMBER(read_rom40);

--- a/src/devices/bus/gameboy/gb_slot.cpp
+++ b/src/devices/bus/gameboy/gb_slot.cpp
@@ -440,7 +440,7 @@ void base_gb_cart_slot_device::setup_ram(uint8_t banks)
 
 
 // This fails to catch Mani 4-in-1 carts... even when they match this, then they have MBC1/3 in the internal header instead of MMM01...
-bool base_gb_cart_slot_device::get_mmm01_candidate(uint8_t *ROM, uint32_t len)
+bool base_gb_cart_slot_device::get_mmm01_candidate(const uint8_t *ROM, uint32_t len)
 {
 	if (len < 0x8147)
 		return false;
@@ -463,7 +463,7 @@ bool base_gb_cart_slot_device::get_mmm01_candidate(uint8_t *ROM, uint32_t len)
 		return false;
 }
 
-int base_gb_cart_slot_device::get_cart_type(uint8_t *ROM, uint32_t len)
+int base_gb_cart_slot_device::get_cart_type(const uint8_t *ROM, uint32_t len)
 {
 	int type = GB_MBC_NONE;
 
@@ -579,9 +579,9 @@ int base_gb_cart_slot_device::get_cart_type(uint8_t *ROM, uint32_t len)
  get default card software
  -------------------------------------------------*/
 
-std::string base_gb_cart_slot_device::get_default_card_software()
+std::string base_gb_cart_slot_device::get_default_card_software(get_default_card_software_hook &hook) const
 {
-	if (open_image_file(mconfig().options()))
+	if (hook.image_file())
 	{
 		const char *slot_string;
 		uint32_t len = m_file->size(), offset = 0;
@@ -600,7 +600,6 @@ std::string base_gb_cart_slot_device::get_default_card_software()
 		slot_string = gb_get_slot(type);
 
 		//printf("type: %s\n", slot_string);
-		clear();
 
 		return std::string(slot_string);
 	}
@@ -609,9 +608,9 @@ std::string base_gb_cart_slot_device::get_default_card_software()
 }
 
 
-std::string megaduck_cart_slot_device::get_default_card_software()
+std::string megaduck_cart_slot_device::get_default_card_software(get_default_card_software_hook &hook) const
 {
-	if (open_image_file(mconfig().options()))
+	if (hook.image_file())
 		return std::string("rom");
 
 	return software_get_default_slot("rom");

--- a/src/devices/bus/gameboy/gb_slot.h
+++ b/src/devices/bus/gameboy/gb_slot.h
@@ -123,8 +123,8 @@ public:
 	virtual const software_list_loader &get_software_list_loader() const override { return rom_software_list_loader::instance(); }
 
 	int get_type() { return m_type; }
-	int get_cart_type(uint8_t *ROM, uint32_t len);
-	bool get_mmm01_candidate(uint8_t *ROM, uint32_t len);
+	static int get_cart_type(const uint8_t *ROM, uint32_t len);
+	static bool get_mmm01_candidate(const uint8_t *ROM, uint32_t len);
 	// remove me when SGB is properly emulated
 	int get_sgb_hack() { return m_sgb_hack; }
 
@@ -142,7 +142,7 @@ public:
 	virtual const char *file_extensions() const override { return "bin,gb,gbc"; }
 
 	// slot interface overrides
-	virtual std::string get_default_card_software() override;
+	virtual std::string get_default_card_software(get_default_card_software_hook &hook) const override;
 
 	// reading and writing
 	virtual DECLARE_READ8_MEMBER(read_rom);
@@ -183,7 +183,7 @@ public:
 	virtual const char *file_extensions() const override { return "bin"; }
 
 	// slot interface overrides
-	virtual std::string get_default_card_software() override;
+	virtual std::string get_default_card_software(get_default_card_software_hook &hook) const override;
 };
 
 

--- a/src/devices/bus/gba/gba_slot.cpp
+++ b/src/devices/bus/gba/gba_slot.cpp
@@ -278,7 +278,7 @@ static inline int gba_chip_has_conflict( uint32_t chip )
 }
 
 
-int gba_cart_slot_device::get_cart_type(uint8_t *ROM, uint32_t len)
+int gba_cart_slot_device::get_cart_type(const uint8_t *ROM, uint32_t len)
 {
 	uint32_t chip = 0;
 	int type = GBA_STD;
@@ -415,12 +415,12 @@ int gba_cart_slot_device::get_cart_type(uint8_t *ROM, uint32_t len)
  get default card software
  -------------------------------------------------*/
 
-std::string gba_cart_slot_device::get_default_card_software()
+std::string gba_cart_slot_device::get_default_card_software(get_default_card_software_hook &hook) const
 {
-	if (open_image_file(mconfig().options()))
+	if (hook.image_file())
 	{
 		const char *slot_string;
-		uint32_t len = m_file->size();
+		uint32_t len = hook.image_file()->size();
 		std::vector<uint8_t> rom(len);
 		int type;
 
@@ -430,7 +430,6 @@ std::string gba_cart_slot_device::get_default_card_software()
 		slot_string = gba_get_slot(type);
 
 		//printf("type: %s\n", slot_string);
-		clear();
 
 		return std::string(slot_string);
 	}

--- a/src/devices/bus/gba/gba_slot.h
+++ b/src/devices/bus/gba/gba_slot.h
@@ -92,7 +92,7 @@ public:
 	virtual const software_list_loader &get_software_list_loader() const override { return rom_software_list_loader::instance(); }
 
 	int get_type() { return m_type; }
-	int get_cart_type(uint8_t *ROM, uint32_t len);
+	static int get_cart_type(const uint8_t *ROM, uint32_t len);
 
 	void internal_header_logging(uint8_t *ROM, uint32_t len);
 
@@ -109,7 +109,7 @@ public:
 	virtual const char *file_extensions() const override { return "gba,bin"; }
 
 	// slot interface overrides
-	virtual std::string get_default_card_software() override;
+	virtual std::string get_default_card_software(get_default_card_software_hook &hook) const override;
 
 	// reading and writing
 	virtual DECLARE_READ32_MEMBER(read_rom);

--- a/src/devices/bus/generic/slot.cpp
+++ b/src/devices/bus/generic/slot.cpp
@@ -156,7 +156,7 @@ void generic_slot_device::call_unload()
  get default card software
  -------------------------------------------------*/
 
-std::string generic_slot_device::get_default_card_software()
+std::string generic_slot_device::get_default_card_software(get_default_card_software_hook &hook) const
 {
 	return software_get_default_slot(m_default_card);
 }

--- a/src/devices/bus/generic/slot.h
+++ b/src/devices/bus/generic/slot.h
@@ -131,7 +131,7 @@ public:
 	virtual const char *file_extensions() const override { return m_extensions; }
 
 	// slot interface overrides
-	virtual std::string get_default_card_software() override;
+	virtual std::string get_default_card_software(get_default_card_software_hook &hook) const override;
 
 	// reading and writing
 	virtual DECLARE_READ8_MEMBER(read_rom);

--- a/src/devices/bus/hp_optroms/hp_optrom.cpp
+++ b/src/devices/bus/hp_optroms/hp_optrom.cpp
@@ -122,7 +122,7 @@ void hp_optrom_slot_device::call_unload()
 		}
 }
 
-std::string hp_optrom_slot_device::get_default_card_software()
+std::string hp_optrom_slot_device::get_default_card_software(get_default_card_software_hook &hook) const
 {
 		return software_get_default_slot("rom");
 }

--- a/src/devices/bus/hp_optroms/hp_optrom.h
+++ b/src/devices/bus/hp_optroms/hp_optrom.h
@@ -55,7 +55,7 @@ public:
 		virtual const char *file_extensions() const override { return "bin"; }
 
 		// slot interface overrides
-		virtual std::string get_default_card_software() override;
+		virtual std::string get_default_card_software(get_default_card_software_hook &hook) const override;
 
 protected:
 		hp_optrom_cart_device *m_cart;

--- a/src/devices/bus/intv/slot.cpp
+++ b/src/devices/bus/intv/slot.cpp
@@ -435,16 +435,16 @@ image_init_result intv_cart_slot_device::call_load()
  get default card software
  -------------------------------------------------*/
 
-std::string intv_cart_slot_device::get_default_card_software()
+std::string intv_cart_slot_device::get_default_card_software(get_default_card_software_hook &hook) const
 {
-	if (open_image_file(mconfig().options()))
+	if (hook.image_file())
 	{
 		const char *slot_string;
-		uint32_t len = m_file->size();
+		uint32_t len = hook.image_file()->size();
 		std::vector<uint8_t> rom(len);
 		int type = INTV_STD;
 
-		m_file->read(&rom[0], len);
+		hook.image_file()->read(&rom[0], len);
 
 		if (rom[0] == 0xa8 && (rom[1] == (rom[2] ^ 0xff)))
 		{
@@ -457,7 +457,7 @@ std::string intv_cart_slot_device::get_default_card_software()
 			int mapper, rom[5], ram, extra;
 			std::string extrainfo;
 
-			if (hashfile_extrainfo(*this, extrainfo))
+			if (hook.hashfile_extrainfo(extrainfo))
 			{
 				sscanf(extrainfo.c_str() ,"%d %d %d %d %d %d %d", &mapper, &rom[0], &rom[1], &rom[2],
 						&rom[3], &ram, &extra);
@@ -477,7 +477,6 @@ std::string intv_cart_slot_device::get_default_card_software()
 		slot_string = intv_get_slot(type);
 
 		//printf("type: %s\n", slot_string);
-		clear();
 
 		return std::string(slot_string);
 	}

--- a/src/devices/bus/intv/slot.h
+++ b/src/devices/bus/intv/slot.h
@@ -121,7 +121,7 @@ public:
 	virtual const char *file_extensions() const override { return "bin,int,rom,itv"; }
 
 	// slot interface overrides
-	virtual std::string get_default_card_software() override;
+	virtual std::string get_default_card_software(get_default_card_software_hook &hook) const override;
 
 	// reading and writing
 	virtual DECLARE_READ16_MEMBER(read_rom04) { if (m_cart) return m_cart->read_rom04(space, offset, mem_mask); else return 0xffff; }

--- a/src/devices/bus/iq151/iq151.cpp
+++ b/src/devices/bus/iq151/iq151.cpp
@@ -181,7 +181,7 @@ image_init_result iq151cart_slot_device::call_load()
     get default card software
 -------------------------------------------------*/
 
-std::string iq151cart_slot_device::get_default_card_software()
+std::string iq151cart_slot_device::get_default_card_software(get_default_card_software_hook &hook) const
 {
 	return software_get_default_slot("basic6");
 }

--- a/src/devices/bus/iq151/iq151.h
+++ b/src/devices/bus/iq151/iq151.h
@@ -106,7 +106,7 @@ public:
 	virtual const char *file_extensions() const override { return "bin,rom"; }
 
 	// slot interface overrides
-	virtual std::string get_default_card_software() override;
+	virtual std::string get_default_card_software(get_default_card_software_hook &hook) const override;
 
 	// reading and writing
 	virtual void read(offs_t offset, uint8_t &data);

--- a/src/devices/bus/kc/kc.cpp
+++ b/src/devices/bus/kc/kc.cpp
@@ -347,7 +347,7 @@ image_init_result kccart_slot_device::call_load()
     get default card software
 -------------------------------------------------*/
 
-std::string kccart_slot_device::get_default_card_software()
+std::string kccart_slot_device::get_default_card_software(get_default_card_software_hook &hook) const
 {
 	return software_get_default_slot("standard");
 }

--- a/src/devices/bus/kc/kc.h
+++ b/src/devices/bus/kc/kc.h
@@ -102,7 +102,7 @@ public:
 	virtual const char *file_extensions() const override { return "bin"; }
 
 	// slot interface overrides
-	virtual std::string get_default_card_software() override;
+	virtual std::string get_default_card_software(get_default_card_software_hook &hook) const override;
 };
 
 // device type definition

--- a/src/devices/bus/m5/slot.cpp
+++ b/src/devices/bus/m5/slot.cpp
@@ -194,10 +194,10 @@ image_init_result m5_cart_slot_device::call_load()
  get default card software
  -------------------------------------------------*/
 
-std::string m5_cart_slot_device::get_default_card_software()
+std::string m5_cart_slot_device::get_default_card_software(get_default_card_software_hook &hook) const
 {
 	std::string result;
-	if (open_image_file(mconfig().options()))
+	if (hook.image_file())
 	{
 		const char *slot_string = "std";
 		//uint32_t size = core_fsize(m_file);
@@ -207,7 +207,6 @@ std::string m5_cart_slot_device::get_default_card_software()
 		slot_string = m5_get_slot(type);
 
 		//printf("type: %s\n", slot_string);
-		clear();
 
 		result.assign(slot_string);
 		return result;

--- a/src/devices/bus/m5/slot.h
+++ b/src/devices/bus/m5/slot.h
@@ -88,7 +88,7 @@ public:
 	virtual const char *file_extensions() const override { return "bin,rom"; }
 
 	// slot interface overrides
-	virtual std::string get_default_card_software() override;
+	virtual std::string get_default_card_software(get_default_card_software_hook &hook) const override;
 
 	// reading and writing
 	virtual DECLARE_READ8_MEMBER(read_rom);

--- a/src/devices/bus/megadrive/md_slot.cpp
+++ b/src/devices/bus/megadrive/md_slot.cpp
@@ -901,24 +901,22 @@ int base_md_cart_slot_device::get_cart_type(const uint8_t *ROM, uint32_t len)
  get default card software
  -------------------------------------------------*/
 
-std::string base_md_cart_slot_device::get_default_card_software()
+std::string base_md_cart_slot_device::get_default_card_software(get_default_card_software_hook &hook) const
 {
-	if (open_image_file(mconfig().options()))
+	if (hook.image_file())
 	{
 		const char *slot_string;
-		uint32_t len = m_file->size(), offset = 0;
+		uint32_t len = hook.image_file()->size(), offset = 0;
 		std::vector<uint8_t> rom(len);
 		int type;
 
-		m_file->read(&rom[0], len);
+		hook.image_file()->read(&rom[0], len);
 
 		if (genesis_is_SMD(&rom[0x200], len - 0x200))
 				offset = 0x200;
 
 		type = get_cart_type(&rom[offset], len - offset);
 		slot_string = md_get_slot(type);
-
-		clear();
 
 		return std::string(slot_string);
 	}

--- a/src/devices/bus/megadrive/md_slot.h
+++ b/src/devices/bus/megadrive/md_slot.h
@@ -164,7 +164,7 @@ public:
 	virtual bool is_reset_on_load() const override { return 1; }
 
 	// slot interface overrides
-	virtual std::string get_default_card_software() override;
+	virtual std::string get_default_card_software(get_default_card_software_hook &hook) const override;
 
 	int get_type() { return m_type; }
 

--- a/src/devices/bus/msx_slot/cartridge.cpp
+++ b/src/devices/bus/msx_slot/cartridge.cpp
@@ -271,9 +271,9 @@ int msx_slot_cartridge_device::get_cart_type(const uint8_t *rom, uint32_t length
 }
 
 
-std::string msx_slot_cartridge_device::get_default_card_software()
+std::string msx_slot_cartridge_device::get_default_card_software(get_default_card_software_hook &hook) const
 {
-	if (open_image_file(mconfig().options()))
+	if (hook.image_file())
 	{
 		const char *slot_string = "nomapper";
 		uint32_t length = m_file->size();
@@ -282,7 +282,7 @@ std::string msx_slot_cartridge_device::get_default_card_software()
 
 		// Check if there's some mapper related information in the hashfiles
 		std::string extrainfo;
-		if (hashfile_extrainfo(*this, extrainfo))
+		if (hook.hashfile_extrainfo(extrainfo))
 		{
 			int extrainfo_type = -1;
 			if (1 == sscanf(extrainfo.c_str(), "%d", &extrainfo_type))

--- a/src/devices/bus/msx_slot/cartridge.h
+++ b/src/devices/bus/msx_slot/cartridge.h
@@ -56,7 +56,7 @@ public:
 	virtual const char *custom_brief_instance_name() const override { return "cart"; }
 
 	// slot interface overrides
-	virtual std::string get_default_card_software() override;
+	virtual std::string get_default_card_software(get_default_card_software_hook &hook) const override;
 
 	// msx_internal_slot-level overrides
 	virtual DECLARE_READ8_MEMBER(read) override;

--- a/src/devices/bus/neogeo/slot.cpp
+++ b/src/devices/bus/neogeo/slot.cpp
@@ -323,7 +323,7 @@ void neogeo_cart_slot_device::call_unload()
  get default card software
  -------------------------------------------------*/
 
-std::string neogeo_cart_slot_device::get_default_card_software()
+std::string neogeo_cart_slot_device::get_default_card_software(get_default_card_software_hook &hook) const
 {
 	return software_get_default_slot("rom");
 }

--- a/src/devices/bus/neogeo/slot.h
+++ b/src/devices/bus/neogeo/slot.h
@@ -207,7 +207,7 @@ public:
 	virtual const char *file_extensions() const override { return "bin"; }
 
 	// slot interface overrides
-	virtual std::string get_default_card_software() override;
+	virtual std::string get_default_card_software(get_default_card_software_hook &hook) const override;
 
 	// reading and writing
 	DECLARE_READ16_MEMBER(rom_r);

--- a/src/devices/bus/nes/aladdin.cpp
+++ b/src/devices/bus/nes/aladdin.cpp
@@ -136,16 +136,16 @@ image_init_result nes_aladdin_slot_device::call_load()
 }
 
 
-std::string nes_aladdin_slot_device::get_default_card_software()
+std::string nes_aladdin_slot_device::get_default_card_software(get_default_card_software_hook &hook) const
 {
-	if (open_image_file(mconfig().options()))
+	if (hook.image_file())
 	{
 		const char *slot_string = "algn";
 		uint32_t len = m_file->size();
 		std::vector<uint8_t> rom(len);
 		uint8_t mapper;
 
-		m_file->read(&rom[0], len);
+		hook.image_file()->read(&rom[0], len);
 
 		mapper = (rom[6] & 0xf0) >> 4;
 		mapper |= rom[7] & 0xf0;
@@ -154,8 +154,6 @@ std::string nes_aladdin_slot_device::get_default_card_software()
 //          slot_string = "algn";
 		if (mapper == 232)
 			slot_string = "algq";
-
-		clear();
 
 		return std::string(slot_string);
 	}

--- a/src/devices/bus/nes/aladdin.h
+++ b/src/devices/bus/nes/aladdin.h
@@ -64,7 +64,7 @@ public:
 	virtual const char *file_extensions() const override { return "nes,bin"; }
 
 	// slot interface overrides
-	virtual std::string get_default_card_software() override;
+	virtual std::string get_default_card_software(get_default_card_software_hook &hook) const override;
 
 	virtual DECLARE_READ8_MEMBER(read);
 	void write_prg(uint32_t offset, uint8_t data) { if (m_cart) m_cart->write_prg(offset, data); }

--- a/src/devices/bus/nes/datach.cpp
+++ b/src/devices/bus/nes/datach.cpp
@@ -137,7 +137,7 @@ image_init_result nes_datach_slot_device::call_load()
 }
 
 
-std::string nes_datach_slot_device::get_default_card_software()
+std::string nes_datach_slot_device::get_default_card_software(get_default_card_software_hook &hook) const
 {
 	// any way to detect the game with X24C01?
 	return software_get_default_slot("datach_rom");

--- a/src/devices/bus/nes/datach.h
+++ b/src/devices/bus/nes/datach.h
@@ -66,7 +66,7 @@ public:
 	virtual const char *file_extensions() const override { return "nes,bin"; }
 
 	// slot interface overrides
-	virtual std::string get_default_card_software() override;
+	virtual std::string get_default_card_software(get_default_card_software_hook &hook) const override;
 
 	virtual DECLARE_READ8_MEMBER(read);
 	void write_prg_bank(uint8_t bank) { if (m_cart) m_cart->write_prg_bank(bank); }

--- a/src/devices/bus/nes/karastudio.cpp
+++ b/src/devices/bus/nes/karastudio.cpp
@@ -126,7 +126,7 @@ image_init_result nes_kstudio_slot_device::call_load()
 }
 
 
-std::string nes_kstudio_slot_device::get_default_card_software()
+std::string nes_kstudio_slot_device::get_default_card_software(get_default_card_software_hook &hook) const
 {
 	return software_get_default_slot("ks_exp");
 }

--- a/src/devices/bus/nes/karastudio.h
+++ b/src/devices/bus/nes/karastudio.h
@@ -63,7 +63,7 @@ public:
 	virtual const char *file_extensions() const override { return "bin"; }
 
 	// slot interface overrides
-	virtual std::string get_default_card_software() override;
+	virtual std::string get_default_card_software(get_default_card_software_hook &hook) const override;
 
 	virtual DECLARE_READ8_MEMBER(read);
 	void write_prg_bank(uint8_t bank) { if (m_cart) m_cart->write_prg_bank(bank); }

--- a/src/devices/bus/nes/nes_ines.hxx
+++ b/src/devices/bus/nes/nes_ines.hxx
@@ -811,7 +811,7 @@ void nes_cart_slot_device::call_load_ines()
 	}
 }
 
-const char * nes_cart_slot_device::get_default_card_ines(uint8_t *ROM, uint32_t len)
+const char * nes_cart_slot_device::get_default_card_ines(get_default_card_software_hook &hook, const uint8_t *ROM, uint32_t len) const
 {
 	uint8_t mapper, submapper = 0;
 	bool ines20 = false;
@@ -837,7 +837,7 @@ const char * nes_cart_slot_device::get_default_card_ines(uint8_t *ROM, uint32_t 
 	}
 
 	// use info from nes.hsi if available!
-	if (hashfile_extrainfo(*this, mapinfo))
+	if (hook.hashfile_extrainfo(mapinfo))
 	{
 		if (4 == sscanf(mapinfo.c_str(),"%d %d %d %d", &mapint1, &mapint2, &mapint3, &mapint4))
 		{

--- a/src/devices/bus/nes/nes_slot.cpp
+++ b/src/devices/bus/nes/nes_slot.cpp
@@ -890,23 +890,21 @@ void nes_cart_slot_device::call_unload()
  get default card software
  -------------------------------------------------*/
 
-std::string nes_cart_slot_device::get_default_card_software()
+std::string nes_cart_slot_device::get_default_card_software(get_default_card_software_hook &hook) const
 {
-	if (open_image_file(mconfig().options()))
+	if (hook.image_file())
 	{
 		const char *slot_string = "nrom";
-		uint32_t len = m_file->size();
+		uint32_t len = hook.image_file()->size();
 		std::vector<uint8_t> rom(len);
 
-		m_file->read(&rom[0], len);
+		hook.image_file()->read(&rom[0], len);
 
 		if ((rom[0] == 'N') && (rom[1] == 'E') && (rom[2] == 'S'))
-			slot_string = get_default_card_ines(&rom[0], len);
+			slot_string = get_default_card_ines(hook, &rom[0], len);
 
 		if ((rom[0] == 'U') && (rom[1] == 'N') && (rom[2] == 'I') && (rom[3] == 'F'))
 			slot_string = get_default_card_unif(&rom[0], len);
-
-		clear();
 
 		return std::string(slot_string);
 	}

--- a/src/devices/bus/nes/nes_slot.h
+++ b/src/devices/bus/nes/nes_slot.h
@@ -365,8 +365,8 @@ public:
 	virtual device_image_partialhash_func get_partial_hash() const override { return &nes_partialhash; }
 
 	// slot interface overrides
-	virtual std::string get_default_card_software() override;
-	const char * get_default_card_ines(uint8_t *ROM, uint32_t len);
+	virtual std::string get_default_card_software(get_default_card_software_hook &hook) const override;
+	const char * get_default_card_ines(get_default_card_software_hook &hook, const uint8_t *ROM, uint32_t len) const;
 	static const char * get_default_card_unif(const uint8_t *ROM, uint32_t len);
 	static const char * nes_get_slot(int pcb_id);
 	int nes_get_pcb_id(const char *slot);

--- a/src/devices/bus/nes/sunsoft_dcs.cpp
+++ b/src/devices/bus/nes/sunsoft_dcs.cpp
@@ -105,7 +105,7 @@ image_init_result nes_ntb_slot_device::call_load()
 }
 
 
-std::string nes_ntb_slot_device::get_default_card_software()
+std::string nes_ntb_slot_device::get_default_card_software(get_default_card_software_hook &hook) const
 {
 	return software_get_default_slot("ntbrom");
 }

--- a/src/devices/bus/nes/sunsoft_dcs.h
+++ b/src/devices/bus/nes/sunsoft_dcs.h
@@ -60,7 +60,7 @@ public:
 	virtual const char *file_extensions() const override { return "bin"; }
 
 	// slot interface overrides
-	virtual std::string get_default_card_software() override;
+	virtual std::string get_default_card_software(get_default_card_software_hook &hook) const override;
 
 	virtual DECLARE_READ8_MEMBER(read);
 

--- a/src/devices/bus/odyssey2/slot.cpp
+++ b/src/devices/bus/odyssey2/slot.cpp
@@ -186,12 +186,12 @@ image_init_result o2_cart_slot_device::call_load()
  get default card software
  -------------------------------------------------*/
 
-std::string o2_cart_slot_device::get_default_card_software()
+std::string o2_cart_slot_device::get_default_card_software(get_default_card_software_hook &hook) const
 {
-	if (open_image_file(mconfig().options()))
+	if (hook.image_file())
 	{
 		const char *slot_string;
-		uint32_t size = m_file->size();
+		uint32_t size = hook.image_file()->size();
 		int type = O2_STD;
 
 		if (size == 12288)
@@ -202,7 +202,6 @@ std::string o2_cart_slot_device::get_default_card_software()
 		slot_string = o2_get_slot(type);
 
 		//printf("type: %s\n", slot_string);
-		clear();
 
 		return std::string(slot_string);
 	}

--- a/src/devices/bus/odyssey2/slot.h
+++ b/src/devices/bus/odyssey2/slot.h
@@ -85,7 +85,7 @@ public:
 	virtual const char *file_extensions() const override { return "bin,rom"; }
 
 	// slot interface overrides
-	virtual std::string get_default_card_software() override;
+	virtual std::string get_default_card_software(get_default_card_software_hook &hook) const override;
 
 	// reading and writing
 	virtual DECLARE_READ8_MEMBER(read_rom04);

--- a/src/devices/bus/pce/pce_slot.cpp
+++ b/src/devices/bus/pce/pce_slot.cpp
@@ -315,22 +315,21 @@ int pce_cart_slot_device::get_cart_type(const uint8_t *ROM, uint32_t len)
  get default card software
  -------------------------------------------------*/
 
-std::string pce_cart_slot_device::get_default_card_software()
+std::string pce_cart_slot_device::get_default_card_software(get_default_card_software_hook &hook) const
 {
-	if (open_image_file(mconfig().options()))
+	if (hook.image_file())
 	{
 		const char *slot_string;
-		uint32_t len = m_file->size();
+		uint32_t len = hook.image_file()->size();
 		std::vector<uint8_t> rom(len);
 		int type;
 
-		m_file->read(&rom[0], len);
+		hook.image_file()->read(&rom[0], len);
 
 		type = get_cart_type(&rom[0], len);
 		slot_string = pce_get_slot(type);
 
 		//printf("type: %s\n", slot_string);
-		clear();
 
 		return std::string(slot_string);
 	}

--- a/src/devices/bus/pce/pce_slot.h
+++ b/src/devices/bus/pce/pce_slot.h
@@ -89,7 +89,7 @@ public:
 	virtual const char *file_extensions() const override { return "pce,bin"; }
 
 	// slot interface overrides
-	virtual std::string get_default_card_software() override;
+	virtual std::string get_default_card_software(get_default_card_software_hook &hook) const override;
 
 	// reading and writing
 	virtual DECLARE_READ8_MEMBER(read_cart);

--- a/src/devices/bus/plus4/exp.cpp
+++ b/src/devices/bus/plus4/exp.cpp
@@ -146,7 +146,7 @@ image_init_result plus4_expansion_slot_device::call_load()
 //  get_default_card_software -
 //-------------------------------------------------
 
-std::string plus4_expansion_slot_device::get_default_card_software()
+std::string plus4_expansion_slot_device::get_default_card_software(get_default_card_software_hook &hook) const
 {
 	return software_get_default_slot("standard");
 }

--- a/src/devices/bus/plus4/exp.h
+++ b/src/devices/bus/plus4/exp.h
@@ -132,7 +132,7 @@ protected:
 	virtual const char *file_extensions() const override { return "rom,bin"; }
 
 	// slot interface overrides
-	virtual std::string get_default_card_software() override;
+	virtual std::string get_default_card_software(get_default_card_software_hook &hook) const override;
 
 	devcb_write_line   m_write_irq;
 	devcb_read8        m_read_dma_cd;

--- a/src/devices/bus/pofo/ccm.cpp
+++ b/src/devices/bus/pofo/ccm.cpp
@@ -90,7 +90,7 @@ image_init_result portfolio_memory_card_slot_t::call_load()
 //  get_default_card_software -
 //-------------------------------------------------
 
-std::string portfolio_memory_card_slot_t::get_default_card_software()
+std::string portfolio_memory_card_slot_t::get_default_card_software(get_default_card_software_hook &hook) const
 {
 	return software_get_default_slot("rom");
 }

--- a/src/devices/bus/pofo/ccm.h
+++ b/src/devices/bus/pofo/ccm.h
@@ -137,7 +137,7 @@ protected:
 	virtual const char *file_extensions() const override { return "rom,bin"; }
 
 	// slot interface overrides
-	virtual std::string get_default_card_software() override;
+	virtual std::string get_default_card_software(get_default_card_software_hook &hook) const override;
 
 	device_portfolio_memory_card_slot_interface *m_card;
 };

--- a/src/devices/bus/ql/rom.cpp
+++ b/src/devices/bus/ql/rom.cpp
@@ -103,7 +103,7 @@ image_init_result ql_rom_cartridge_slot_t::call_load()
 //  get_default_card_software -
 //-------------------------------------------------
 
-std::string ql_rom_cartridge_slot_t::get_default_card_software()
+std::string ql_rom_cartridge_slot_t::get_default_card_software(get_default_card_software_hook &hook) const
 {
 	return software_get_default_slot("standard");
 }

--- a/src/devices/bus/ql/rom.h
+++ b/src/devices/bus/ql/rom.h
@@ -107,7 +107,7 @@ protected:
 	virtual const char *file_extensions() const override { return "rom,bin"; }
 
 	// slot interface overrides
-	virtual std::string get_default_card_software() override;
+	virtual std::string get_default_card_software(get_default_card_software_hook &hook) const override;
 
 	device_ql_rom_cartridge_card_interface *m_card;
 };

--- a/src/devices/bus/saturn/sat_slot.cpp
+++ b/src/devices/bus/saturn/sat_slot.cpp
@@ -196,7 +196,7 @@ void sat_cart_slot_device::call_unload()
  get default card software
  -------------------------------------------------*/
 
-std::string sat_cart_slot_device::get_default_card_software()
+std::string sat_cart_slot_device::get_default_card_software(get_default_card_software_hook &hook) const
 {
 	return software_get_default_slot("rom");
 }

--- a/src/devices/bus/saturn/sat_slot.h
+++ b/src/devices/bus/saturn/sat_slot.h
@@ -90,7 +90,7 @@ public:
 	virtual const char *file_extensions() const override { return "bin"; }
 
 	// slot interface overrides
-	virtual std::string get_default_card_software() override;
+	virtual std::string get_default_card_software(get_default_card_software_hook &hook) const override;
 
 	// reading and writing
 	virtual DECLARE_READ32_MEMBER(read_rom);

--- a/src/devices/bus/scv/slot.cpp
+++ b/src/devices/bus/scv/slot.cpp
@@ -235,22 +235,21 @@ int scv_cart_slot_device::get_cart_type(const uint8_t *ROM, uint32_t len)
  get default card software
  -------------------------------------------------*/
 
-std::string scv_cart_slot_device::get_default_card_software()
+std::string scv_cart_slot_device::get_default_card_software(get_default_card_software_hook &hook) const
 {
-	if (open_image_file(mconfig().options()))
+	if (hook.image_file())
 	{
 		const char *slot_string;
-		uint32_t len = m_file->size();
+		uint32_t len = hook.image_file()->size();
 		std::vector<uint8_t> rom(len);
 		int type;
 
-		m_file->read(&rom[0], len);
+		hook.image_file()->read(&rom[0], len);
 
 		type = get_cart_type(&rom[0], len);
 		slot_string = scv_get_slot(type);
 
 		//printf("type: %s\n", slot_string);
-		clear();
 
 		return std::string(slot_string);
 	}

--- a/src/devices/bus/scv/slot.h
+++ b/src/devices/bus/scv/slot.h
@@ -89,7 +89,7 @@ public:
 	virtual const char *file_extensions() const override { return "bin"; }
 
 	// slot interface overrides
-	virtual std::string get_default_card_software() override;
+	virtual std::string get_default_card_software(get_default_card_software_hook &hook) const override;
 
 	// reading and writing
 	virtual DECLARE_READ8_MEMBER(read_cart);

--- a/src/devices/bus/sega8/sega8_slot.cpp
+++ b/src/devices/bus/sega8/sega8_slot.cpp
@@ -593,16 +593,16 @@ int sega8_cart_slot_device::get_cart_type(const uint8_t *ROM, uint32_t len) cons
  get default card software
  -------------------------------------------------*/
 
-std::string sega8_cart_slot_device::get_default_card_software()
+std::string sega8_cart_slot_device::get_default_card_software(get_default_card_software_hook &hook) const
 {
-	if (open_image_file(mconfig().options()))
+	if (hook.image_file())
 	{
 		const char *slot_string;
-		uint32_t len = m_file->size(), offset = 0;
+		uint32_t len = hook.image_file()->size(), offset = 0;
 		std::vector<uint8_t> rom(len);
 		int type;
 
-		m_file->read(&rom[0], len);
+		hook.image_file()->read(&rom[0], len);
 
 		if ((len % 0x4000) == 512)
 			offset = 512;
@@ -611,7 +611,6 @@ std::string sega8_cart_slot_device::get_default_card_software()
 		slot_string = sega8_get_slot(type);
 
 		//printf("type: %s\n", slot_string);
-		clear();
 
 		return std::string(slot_string);
 	}

--- a/src/devices/bus/sega8/sega8_slot.h
+++ b/src/devices/bus/sega8/sega8_slot.h
@@ -141,7 +141,7 @@ public:
 	virtual const char *file_extensions() const override { return m_extensions; }
 
 	// slot interface overrides
-	virtual std::string get_default_card_software() override;
+	virtual std::string get_default_card_software(get_default_card_software_hook &hook) const override;
 
 	// reading and writing
 	virtual DECLARE_READ8_MEMBER(read_cart);

--- a/src/devices/bus/snes/snes_slot.cpp
+++ b/src/devices/bus/snes/snes_slot.cpp
@@ -977,11 +977,9 @@ void base_sns_cart_slot_device::get_cart_type_addon(const uint8_t *ROM, uint32_t
  get default card software
  -------------------------------------------------*/
 
-std::string base_sns_cart_slot_device::get_default_card_software()
+std::string base_sns_cart_slot_device::get_default_card_software(get_default_card_software_hook &hook) const
 {
-	bool fullpath = open_image_file(mconfig().options());
-
-	if (fullpath)
+	if (hook.image_file())
 	{
 		const char *slot_string;
 		uint32_t offset;
@@ -1033,8 +1031,6 @@ std::string base_sns_cart_slot_device::get_default_card_software()
 		}
 
 		slot_string = sns_get_slot(type);
-
-		clear();
 
 		return std::string(slot_string);
 	}

--- a/src/devices/bus/snes/snes_slot.h
+++ b/src/devices/bus/snes/snes_slot.h
@@ -181,7 +181,7 @@ public:
 	virtual bool is_reset_on_load() const override { return 1; }
 
 	// slot interface overrides
-	virtual std::string get_default_card_software() override;
+	virtual std::string get_default_card_software(get_default_card_software_hook &hook) const override;
 
 	// reading and writing
 	virtual DECLARE_READ8_MEMBER(read_l);

--- a/src/devices/bus/vboy/slot.cpp
+++ b/src/devices/bus/vboy/slot.cpp
@@ -209,7 +209,7 @@ void vboy_cart_slot_device::call_unload()
  get default card software
  -------------------------------------------------*/
 
-std::string vboy_cart_slot_device::get_default_card_software()
+std::string vboy_cart_slot_device::get_default_card_software(get_default_card_software_hook &hook) const
 {
 	return software_get_default_slot("vb_rom");
 }

--- a/src/devices/bus/vboy/slot.h
+++ b/src/devices/bus/vboy/slot.h
@@ -84,7 +84,7 @@ public:
 	virtual const char *file_extensions() const override { return "vb,bin"; }
 
 	// slot interface overrides
-	virtual std::string get_default_card_software() override;
+	virtual std::string get_default_card_software(get_default_card_software_hook &hook) const override;
 
 	// reading and writing
 	virtual DECLARE_READ32_MEMBER(read_cart);

--- a/src/devices/bus/vc4000/slot.cpp
+++ b/src/devices/bus/vc4000/slot.cpp
@@ -226,12 +226,12 @@ image_init_result vc4000_cart_slot_device::call_load()
  get default card software
  -------------------------------------------------*/
 
-std::string vc4000_cart_slot_device::get_default_card_software()
+std::string vc4000_cart_slot_device::get_default_card_software(get_default_card_software_hook &hook) const
 {
-	if (open_image_file(mconfig().options()))
+	if (hook.image_file())
 	{
 		const char *slot_string;
-		uint32_t size = m_file->size();
+		uint32_t size = hook.image_file()->size();
 		int type = VC4000_STD;
 
 		// attempt to identify the non-standard types
@@ -243,7 +243,6 @@ std::string vc4000_cart_slot_device::get_default_card_software()
 		slot_string = vc4000_get_slot(type);
 
 		//printf("type: %s\n", slot_string);
-		clear();
 
 		return std::string(slot_string);
 	}

--- a/src/devices/bus/vc4000/slot.h
+++ b/src/devices/bus/vc4000/slot.h
@@ -86,7 +86,7 @@ public:
 	virtual const char *file_extensions() const override { return "bin,rom"; }
 
 	// slot interface overrides
-	virtual std::string get_default_card_software() override;
+	virtual std::string get_default_card_software(get_default_card_software_hook &hook) const override;
 
 	// reading and writing
 	virtual DECLARE_READ8_MEMBER(read_rom);

--- a/src/devices/bus/vcs/vcs_slot.cpp
+++ b/src/devices/bus/vcs/vcs_slot.cpp
@@ -758,21 +758,19 @@ int vcs_cart_slot_device::identify_cart_type(const uint8_t *ROM, uint32_t len)
  get default card software
  -------------------------------------------------*/
 
-std::string vcs_cart_slot_device::get_default_card_software()
+std::string vcs_cart_slot_device::get_default_card_software(get_default_card_software_hook &hook) const
 {
-	if (open_image_file(mconfig().options()))
+	if (hook.image_file())
 	{
 		const char *slot_string;
-		uint32_t len = m_file->size();
+		uint32_t len = hook.image_file()->size();
 		std::vector<uint8_t> rom(len);
 		int type;
 
-		m_file->read(&rom[0], len);
+		hook.image_file()->read(&rom[0], len);
 
 		type = identify_cart_type(&rom[0], len);
 		slot_string = vcs_get_slot(type);
-
-		clear();
 
 		return std::string(slot_string);
 	}

--- a/src/devices/bus/vcs/vcs_slot.h
+++ b/src/devices/bus/vcs/vcs_slot.h
@@ -109,7 +109,7 @@ public:
 	virtual const char *file_extensions() const override { return "bin,a26"; }
 
 	// slot interface overrides
-	virtual std::string get_default_card_software() override;
+	virtual std::string get_default_card_software(get_default_card_software_hook &hook) const override;
 
 	// reading and writing
 	virtual DECLARE_READ8_MEMBER(read_rom);

--- a/src/devices/bus/vectrex/slot.cpp
+++ b/src/devices/bus/vectrex/slot.cpp
@@ -194,16 +194,16 @@ image_init_result vectrex_cart_slot_device::call_load()
  get default card software
  -------------------------------------------------*/
 
-std::string vectrex_cart_slot_device::get_default_card_software()
+std::string vectrex_cart_slot_device::get_default_card_software(get_default_card_software_hook &hook) const
 {
-	if (open_image_file(mconfig().options()))
+	if (hook.image_file())
 	{
 		const char *slot_string;
 		uint32_t size = m_file->size();
 		std::vector<uint8_t> rom(size);
 		int type = VECTREX_STD;
 
-		m_file->read(&rom[0], size);
+		hook.image_file()->read(&rom[0], size);
 
 		if (!memcmp(&rom[0x06], "SRAM", 4))
 			type = VECTREX_SRAM;
@@ -213,7 +213,6 @@ std::string vectrex_cart_slot_device::get_default_card_software()
 		slot_string = vectrex_get_slot(type);
 
 		//printf("type: %s\n", slot_string);
-		clear();
 
 		return std::string(slot_string);
 	}

--- a/src/devices/bus/vectrex/slot.h
+++ b/src/devices/bus/vectrex/slot.h
@@ -85,7 +85,7 @@ public:
 	virtual const char *file_extensions() const override { return "bin,gam,vec"; }
 
 	// slot interface overrides
-	virtual std::string get_default_card_software() override;
+	virtual std::string get_default_card_software(get_default_card_software_hook &hook) const override;
 
 	// reading and writing
 	virtual DECLARE_READ8_MEMBER(read_rom);

--- a/src/devices/bus/vic10/exp.cpp
+++ b/src/devices/bus/vic10/exp.cpp
@@ -170,14 +170,12 @@ image_init_result vic10_expansion_slot_device::call_load()
 //  get_default_card_software -
 //-------------------------------------------------
 
-std::string vic10_expansion_slot_device::get_default_card_software()
+std::string vic10_expansion_slot_device::get_default_card_software(get_default_card_software_hook &hook) const
 {
-	if (open_image_file(mconfig().options()))
+	if (hook.image_file())
 	{
-		if (is_filetype("crt"))
-			return cbm_crt_get_card(*m_file);
-
-		clear();
+		if (hook.is_filetype("crt"))
+			return cbm_crt_get_card(*hook.image_file());
 	}
 
 	return software_get_default_slot("standard");

--- a/src/devices/bus/vic10/exp.h
+++ b/src/devices/bus/vic10/exp.h
@@ -131,7 +131,7 @@ protected:
 	virtual const char *file_extensions() const override { return "80,e0"; }
 
 	// slot interface overrides
-	virtual std::string get_default_card_software() override;
+	virtual std::string get_default_card_software(get_default_card_software_hook &hook) const override;
 
 	devcb_write_line   m_write_irq;
 	devcb_write_line   m_write_res;

--- a/src/devices/bus/vic20/exp.cpp
+++ b/src/devices/bus/vic20/exp.cpp
@@ -156,7 +156,7 @@ image_init_result vic20_expansion_slot_device::call_load()
 //  get_default_card_software -
 //-------------------------------------------------
 
-std::string vic20_expansion_slot_device::get_default_card_software()
+std::string vic20_expansion_slot_device::get_default_card_software(get_default_card_software_hook &hook) const
 {
 	return software_get_default_slot("standard");
 }

--- a/src/devices/bus/vic20/exp.h
+++ b/src/devices/bus/vic20/exp.h
@@ -122,7 +122,7 @@ protected:
 	virtual const char *file_extensions() const override { return "20,40,60,70,a0,b0,crt"; }
 
 	// slot interface overrides
-	virtual std::string get_default_card_software() override;
+	virtual std::string get_default_card_software(get_default_card_software_hook &hook) const override;
 
 	devcb_write_line   m_write_irq;
 	devcb_write_line   m_write_nmi;

--- a/src/devices/bus/vidbrain/exp.cpp
+++ b/src/devices/bus/vidbrain/exp.cpp
@@ -143,7 +143,7 @@ image_init_result videobrain_expansion_slot_device::call_load()
 //  get_default_card_software -
 //-------------------------------------------------
 
-std::string videobrain_expansion_slot_device::get_default_card_software()
+std::string videobrain_expansion_slot_device::get_default_card_software(get_default_card_software_hook &hook) const
 {
 	return software_get_default_slot("standard");
 }

--- a/src/devices/bus/vidbrain/exp.h
+++ b/src/devices/bus/vidbrain/exp.h
@@ -147,7 +147,7 @@ protected:
 	virtual const char *file_extensions() const override { return "bin"; }
 
 	// slot interface overrides
-	virtual std::string get_default_card_software() override;
+	virtual std::string get_default_card_software(get_default_card_software_hook &hook) const override;
 
 	devcb_write_line   m_write_extres;
 

--- a/src/devices/bus/wswan/slot.cpp
+++ b/src/devices/bus/wswan/slot.cpp
@@ -283,9 +283,9 @@ int ws_cart_slot_device::get_cart_type(const uint8_t *ROM, uint32_t len, uint32_
  get default card software
  -------------------------------------------------*/
 
-std::string ws_cart_slot_device::get_default_card_software()
+std::string ws_cart_slot_device::get_default_card_software(get_default_card_software_hook &hook) const
 {
-	if (open_image_file(mconfig().options()))
+	if (hook.image_file())
 	{
 		const char *slot_string;
 		uint32_t size = m_file->size();
@@ -293,14 +293,13 @@ std::string ws_cart_slot_device::get_default_card_software()
 		int type;
 		uint32_t nvram;
 
-		m_file->read(&rom[0], size);
+		hook.image_file()->read(&rom[0], size);
 
 		// nvram size is not really used here, but we set it up nevertheless
 		type = get_cart_type(&rom[0], size, nvram);
 		slot_string = ws_get_slot(type);
 
 		//printf("type: %s\n", slot_string);
-		clear();
 
 		return std::string(slot_string);
 	}

--- a/src/devices/bus/wswan/slot.h
+++ b/src/devices/bus/wswan/slot.h
@@ -97,7 +97,7 @@ public:
 	virtual const char *file_extensions() const override { return "ws,wsc,bin"; }
 
 	// slot interface overrides
-	virtual std::string get_default_card_software() override;
+	virtual std::string get_default_card_software(get_default_card_software_hook &hook) const override;
 
 	// reading and writing
 	virtual DECLARE_READ8_MEMBER(read_rom20);

--- a/src/devices/bus/z88/z88.cpp
+++ b/src/devices/bus/z88/z88.cpp
@@ -163,7 +163,7 @@ void z88cart_slot_device::call_unload()
     get default card software
 -------------------------------------------------*/
 
-std::string z88cart_slot_device::get_default_card_software()
+std::string z88cart_slot_device::get_default_card_software(get_default_card_software_hook &hook) const
 {
 	return software_get_default_slot("128krom");
 }

--- a/src/devices/bus/z88/z88.h
+++ b/src/devices/bus/z88/z88.h
@@ -110,7 +110,7 @@ public:
 	virtual const char *file_extensions() const override { return "epr,bin"; }
 
 	// slot interface overrides
-	virtual std::string get_default_card_software() override;
+	virtual std::string get_default_card_software(get_default_card_software_hook &hook) const override;
 
 	// reading and writing
 	virtual DECLARE_READ8_MEMBER(read);

--- a/src/emu/diimage.h
+++ b/src/emu/diimage.h
@@ -215,6 +215,7 @@ public:
 
 	u32 crc();
 	util::hash_collection& hash() { return m_hash; }
+	util::hash_collection calculate_hash_on_file(util::core_file &file) const;
 
 	void battery_load(void *buffer, int length, int fill);
 	void battery_load(void *buffer, int length, void *def_buffer);
@@ -257,7 +258,7 @@ protected:
 	virtual const software_list_loader &get_software_list_loader() const;
 	virtual const bool use_software_list_file_extension_for_filetype() const { return false; }
 
-	image_init_result load_internal(const std::string &path, bool is_create, int create_format, util::option_resolution *create_args, bool just_load);
+	image_init_result load_internal(const std::string &path, bool is_create, int create_format, util::option_resolution *create_args);
 	image_error_t load_image_by_path(u32 open_flags, const std::string &path);
 	void clear();
 	bool is_loaded();
@@ -273,13 +274,11 @@ protected:
 
 	void make_readonly() { m_readonly = true; }
 
-	void run_hash(void (*partialhash)(util::hash_collection &, const unsigned char *, unsigned long, const char *), util::hash_collection &hashes, const char *types);
 	void image_checkhash();
 
 	const software_part *find_software_item(const std::string &identifier, bool restrict_to_interface, software_list_device **device = nullptr) const;
 	bool load_software_part(const std::string &identifier);
 	std::string software_get_default_slot(const char *default_card_slot) const;
-	bool open_image_file(emu_options &options);
 
 	void add_format(std::unique_ptr<image_device_format> &&format);
 	void add_format(std::string &&name, std::string &&description, std::string &&extensions, std::string &&optspec);
@@ -313,6 +312,7 @@ private:
 	void update_names();
 
 	bool init_phase() const;
+	static void run_hash(util::core_file &file, void(*partialhash)(util::hash_collection &, const unsigned char *, unsigned long, const char *), util::hash_collection &hashes, const char *types);
 
 	// loads an image or software items and resets - called internally when we
 	// load an is_reset_on_load() item

--- a/src/emu/dislot.h
+++ b/src/emu/dislot.h
@@ -91,6 +91,34 @@ private:
 };
 
 
+// ======================> get_default_card_software_hook
+
+class get_default_card_software_hook
+{
+	// goofy "hook" to pass to device_slot_interface::get_default_card_software
+public:
+	get_default_card_software_hook(const std::string &path, std::function<bool(util::core_file &, std::string&)> &&get_hashfile_extrainfo);
+
+	// accesses the image file to be scrutinized by get_default_card_software(); is 
+	// nullptr in the case of images loaded by software list
+	util::core_file::ptr &image_file() { return m_image_file;  }
+
+	// checks to see if image is of the specified "file type" (in practice, file extension)
+	bool is_filetype(const char *candidate_filetype) const { return !core_stricmp(m_file_type.c_str(), candidate_filetype); }
+
+	// extra info from hashfile
+	bool hashfile_extrainfo(std::string &extrainfo);
+
+private:
+	util::core_file::ptr									m_image_file;
+	std::string												m_file_type;
+	std::function<bool(util::core_file &, std::string&)>	m_get_hashfile_extrainfo;
+	bool													m_called_get_hashfile_extrainfo;
+	bool													m_has_hash_extrainfo;
+	std::string												m_hash_extrainfo;
+};
+
+
 // ======================> device_slot_interface
 
 class device_slot_interface : public device_interface
@@ -114,7 +142,7 @@ public:
 	const char *default_option() const { return m_default_option; }
 	const std::unordered_map<std::string, std::unique_ptr<device_slot_option>> &option_list() const { return m_options; }
 	device_slot_option *option(const char *name) const;
-	virtual std::string get_default_card_software() { return std::string(); }
+	virtual std::string get_default_card_software(get_default_card_software_hook &hook) const { return std::string(); }
 	device_t *get_card_device() { return m_card_device; }
 	void set_card_device(device_t *dev) { m_card_device = dev; }
 

--- a/src/emu/hashfile.cpp
+++ b/src/emu/hashfile.cpp
@@ -21,10 +21,10 @@
     hashfile_lookup
 -------------------------------------------------*/
 
-bool read_hash_config(device_image_interface &image, const char *sysname, std::string &result)
+static bool read_hash_config(const char *hash_path, const util::hash_collection &hashes, const char *sysname, std::string &result)
 {
 	/* open a file */
-	emu_file file(image.device().mconfig().options().hash_path(), OPEN_FLAG_READ);
+	emu_file file(hash_path, OPEN_FLAG_READ);
 	if (file.open(sysname, ".hsi") != osd_file::error::NONE)
 	{
 		return false;
@@ -37,8 +37,8 @@ bool read_hash_config(device_image_interface &image, const char *sysname, std::s
 	{
 		// Do search by CRC32 and SHA1
 		std::string query = "/hashfile/hash[";
-		auto crc = image.hash().internal_string().substr(1,8);
-		auto sha1 = image.hash().internal_string().substr(10, 40);
+		auto crc = hashes.internal_string().substr(1,8);
+		auto sha1 = hashes.internal_string().substr(10, 40);
 		query += "@crc32='" + crc + "' and @sha1='" + sha1 + "']/extrainfo";
 		pugi::xpath_node_set tools = doc.select_nodes(query.c_str());
 		for (pugi::xpath_node_set::const_iterator it = tools.begin(); it != tools.end(); ++it)
@@ -61,16 +61,16 @@ bool read_hash_config(device_image_interface &image, const char *sysname, std::s
 	return false;
 }
 
-bool hashfile_extrainfo(device_image_interface &image, std::string &result)
+
+bool hashfile_extrainfo(const char *hash_path, const game_driver &driver, const util::hash_collection &hashes, std::string &result)
 {
 	/* now read the hash file */
-	image.crc();
-	int drv = driver_list::find(image.device().mconfig().gamedrv());
+	int drv = driver_list::find(driver);
 	int compat, open = drv;
 	bool hashfound;
 	do
 	{
-		hashfound = read_hash_config(image, driver_list::driver(open).name, result);
+		hashfound = read_hash_config(hash_path, hashes, driver_list::driver(open).name, result);
 		// first check if there are compatible systems
 		compat = driver_list::compatible_with(open);
 		// if so, try to open its hashfile
@@ -87,3 +87,16 @@ bool hashfile_extrainfo(device_image_interface &image, std::string &result)
 	while (!hashfound && open != -1);
 	return hashfound;
 }
+
+
+
+bool hashfile_extrainfo(device_image_interface &image, std::string &result)
+{
+	return hashfile_extrainfo(
+		image.device().mconfig().options().hash_path(),
+		image.device().mconfig().gamedrv(),
+		image.hash(),
+		result);
+}
+
+

--- a/src/emu/hashfile.h
+++ b/src/emu/hashfile.h
@@ -14,5 +14,6 @@
 
 
 bool hashfile_extrainfo(device_image_interface &image, std::string &result);
+bool hashfile_extrainfo(const char *hash_path, const game_driver &driver, const util::hash_collection &hashes, std::string &result);
 
 #endif /* __HASHFILE_H__ */

--- a/src/frontend/mame/mameopts.h
+++ b/src/frontend/mame/mameopts.h
@@ -73,6 +73,7 @@ private:
 	static void parse_slot_devices(emu_options &options, value_specifier_func value_specifier);
 	static std::string get_full_option_name(const device_image_interface &image);
 	static slot_option parse_slot_option(std::string &&text);
+	static std::string get_default_card_software(device_slot_interface &slot, const emu_options &options);
 
 	// INI parsing helper
 	static bool parse_one_ini(emu_options &options, const char *basename, int priority, std::string *error_string = nullptr);


### PR DESCRIPTION
The goals with this change is to make get_default_card_software() a bit more standalone by making it a const method that does not mutate the state of the device_image_interface.  This is done by passing in a small structure that encapsulates the minimum of information that get_default_card_software() needs.

This also eliminates the need for device_image_interface::open_image_file()

I agree with Sarayan that get_default_card_software() is terrible and needs to ultimately go away.  This is a small step in that direction.

Lastly, I don't care for the name of get_default_card_software_hook (or get_default_card_software() for that matter).  If anybody has better ideas, let me know.