### PR TITLE
Fixes issues specifying image/slot options fron INI files (reported by Robbbert)

### DIFF
--- a/src/emu/emuopts.h
+++ b/src/emu/emuopts.h
@@ -198,8 +198,13 @@
 class slot_option
 {
 public:
-	slot_option(std::string &&value = "", std::string &&bios = "")
-		: m_value(std::move(value)), m_bios(std::move(bios))
+	slot_option()
+		: slot_option("", "", true)
+	{
+	}
+
+	slot_option(std::string &&value, std::string &&bios, bool selectable)
+		: m_value(std::move(value)), m_bios(std::move(bios)), m_selectable(selectable)
 	{
 	}
 	slot_option(const slot_option &that) = default;
@@ -219,15 +224,18 @@ public:
 	const std::string &bios() const { return m_bios; }
 	const std::string &default_card_software() const { return m_default_card_software; }
 	bool is_default() const { return m_value.empty(); }
+	bool is_selectable() const { return m_selectable; }
 
 	// seters
 	void set_bios(std::string &&s) { m_bios = std::move(s); }
 	void set_default_card_software(std::string &&s) { m_default_card_software = std::move(s); }
+	void set_is_selectable(bool selectable) { m_selectable = selectable; }
 
 private:
 	std::string m_value;
 	std::string m_bios;
 	std::string	m_default_card_software;
+	bool m_selectable;
 };
 
 
@@ -427,8 +435,12 @@ public:
 	std::map<std::string, std::string> &image_options() { return m_image_options; }
 	const std::map<std::string, std::string> &image_options() const { return m_image_options; }
 
+	static slot_option parse_slot_option(std::string &&text, bool selectable);
+
 protected:
 	virtual void value_changed(const std::string &name, const std::string &value) override;
+	virtual bool override_get_value(const char *name, std::string &value) const override;
+	virtual bool override_set_value(const char *name, const std::string &value) override;
 
 private:
 	static const options_entry s_option_entries[];

--- a/src/frontend/mame/mameopts.h
+++ b/src/frontend/mame/mameopts.h
@@ -72,7 +72,6 @@ private:
 	static void update_slot_options(emu_options &options, const software_part *swpart = nullptr);
 	static void parse_slot_devices(emu_options &options, value_specifier_func value_specifier);
 	static std::string get_full_option_name(const device_image_interface &image);
-	static slot_option parse_slot_option(std::string &&text);
 	static std::string get_default_card_software(device_slot_interface &slot, const emu_options &options);
 
 	// INI parsing helper

--- a/src/lib/util/options.cpp
+++ b/src/lib/util/options.cpp
@@ -559,12 +559,15 @@ std::string core_options::output_ini(const core_options *diff) const
 	int num_valid_headers = 0;
 	int unadorned_index = 0;
 	const char *last_header = nullptr;
+	std::string overridden_value;
 
 	// loop over all items
 	for (entry &curentry : m_entrylist)
 	{
 		const char *name = curentry.name();
-		const char *value = curentry.value();
+		const char *value = name && override_get_value(name, overridden_value)
+			? overridden_value.c_str()
+			: curentry.value();
 		bool is_unadorned = false;
 
 		// check if it's unadorned
@@ -847,6 +850,10 @@ bool core_options::validate_and_set_data(core_options::entry &curentry, std::str
 		data.erase(0, 1);
 		data.erase(data.length() - 1, 1);
 	}
+
+	// let derived classes override how we set this data
+	if (override_set_value(curentry.name(), data))
+		return true;
 
 	// validate the type of data and optionally the range
 	float fval;

--- a/src/lib/util/options.h
+++ b/src/lib/util/options.h
@@ -182,6 +182,8 @@ public:
 
 protected:
 	virtual void value_changed(const std::string &name, const std::string &value) {}
+	virtual bool override_get_value(const char *name, std::string &value) const { return false; }
+	virtual bool override_set_value(const char *name, const std::string &value) { return false; }
 
 private:
 	// internal helpers


### PR DESCRIPTION
This fix really doesn't go far enough.  I added hooks so that options specified at the command line can also be responded to when parsed from INI files, but in the long run much of the logic that is currently in mame_options should go into emu_options so that when an option is specified, all of the wacko logic around slot/image specification "just works" because it is encapsulated within emu_options.

We have a release 11 days away; I want to be in stabilization mode.