### PR TITLE
Changed validity_checker to keep a fresh emu_options for validation purposes

### DIFF
--- a/src/emu/validity.cpp
+++ b/src/emu/validity.cpp
@@ -298,8 +298,7 @@ void validity_checker::validate_one(const game_driver &driver)
 	// wrap in try/except to catch fatalerrors
 	try
 	{
-		emu_options options;
-		machine_config config(driver, options);
+		machine_config config(driver, m_blank_options);
 		m_current_config = &config;
 		validate_driver();
 		validate_roms();

--- a/src/emu/validity.h
+++ b/src/emu/validity.h
@@ -99,7 +99,7 @@ private:
 	// internal driver list
 	driver_enumerator       m_drivlist;
 
-	// blank options for use during valudation
+	// blank options for use during validation
 	emu_options				m_blank_options;
 
 	// error tracking

--- a/src/emu/validity.h
+++ b/src/emu/validity.h
@@ -14,6 +14,7 @@
 #pragma once
 
 #include "drivenum.h"
+#include "emuopts.h"
 
 
 //**************************************************************************
@@ -97,6 +98,9 @@ private:
 
 	// internal driver list
 	driver_enumerator       m_drivlist;
+
+	// blank options for use during valudation
+	emu_options				m_blank_options;
 
 	// error tracking
 	int                     m_errors;


### PR DESCRIPTION
This seems to solve the performance problems introduced by PR#2221 while keeping with that PR's goals of not using the "runtime" emu_options for purposes of validation.