### PR TITLE
More options refactoring

### DIFF
--- a/src/emu/diimage.h
+++ b/src/emu/diimage.h
@@ -250,6 +250,7 @@ public:
 	}
 
 	bool user_loadable() const { return m_user_loadable; }
+	const std::string &full_software_name() const { return m_full_software_name; }
 
 protected:
 	// interface-level overrides

--- a/src/emu/emuopts.h
+++ b/src/emu/emuopts.h
@@ -198,44 +198,48 @@
 class slot_option
 {
 public:
-	slot_option()
-		: slot_option("", "", true)
-	{
-	}
-
-	slot_option(std::string &&value, std::string &&bios, bool selectable)
-		: m_value(std::move(value)), m_bios(std::move(bios)), m_selectable(selectable)
-	{
-	}
+	slot_option(const char *default_value = nullptr);
 	slot_option(const slot_option &that) = default;
 	slot_option(slot_option &&that) = default;
 
 	const slot_option &operator=(const slot_option &that)
 	{
-		// I thought you got this implicitly by declaring a default copy constructor?
-		m_value = that.m_value;
+		m_specified = that.m_specified;
+		m_specified_value = that.m_specified_value;
+		m_specified_bios = that.m_specified_bios;
 		m_default_card_software = that.m_default_card_software;
-		m_bios = that.m_bios;
-		return that;
+		m_default_value = that.m_default_value;
+		return *this;
+	}
+
+	const slot_option &operator=(slot_option &&that)
+	{
+		m_specified = that.m_specified;
+		m_specified_value = std::move(that.m_specified_value);
+		m_specified_bios = std::move(that.m_specified_bios);
+		m_default_card_software = std::move(that.m_default_card_software);
+		m_default_value = std::move(that.m_default_value);
+		return *this;
 	}
 
 	// accessors
-	const std::string &value() const { return m_value.empty() ? m_default_card_software : m_value; }
-	const std::string &bios() const { return m_bios; }
+	const std::string &value() const;
+	std::string specified_value() const;
+	const std::string &bios() const { return m_specified_bios; }
 	const std::string &default_card_software() const { return m_default_card_software; }
-	bool is_default() const { return m_value.empty(); }
-	bool is_selectable() const { return m_selectable; }
+	bool specified() const { return m_specified; }
 
 	// seters
-	void set_bios(std::string &&s) { m_bios = std::move(s); }
+	void specify(std::string &&text);
+	void set_bios(std::string &&text);
 	void set_default_card_software(std::string &&s) { m_default_card_software = std::move(s); }
-	void set_is_selectable(bool selectable) { m_selectable = selectable; }
 
 private:
-	std::string m_value;
-	std::string m_bios;
-	std::string	m_default_card_software;
-	bool m_selectable;
+	bool			m_specified;
+	std::string		m_specified_value;
+	std::string		m_specified_bios;
+	std::string		m_default_card_software;
+	std::string		m_default_value;
 };
 
 
@@ -435,11 +439,9 @@ public:
 	std::map<std::string, std::string> &image_options() { return m_image_options; }
 	const std::map<std::string, std::string> &image_options() const { return m_image_options; }
 
-	static slot_option parse_slot_option(std::string &&text, bool selectable);
-
 protected:
 	virtual void value_changed(const std::string &name, const std::string &value) override;
-	virtual bool override_get_value(const char *name, std::string &value) const override;
+	virtual override_get_value_result override_get_value(const char *name, std::string &value) const override;
 	virtual bool override_set_value(const char *name, const std::string &value) override;
 
 private:

--- a/src/emu/mconfig.cpp
+++ b/src/emu/mconfig.cpp
@@ -44,6 +44,10 @@ machine_config::machine_config(const game_driver &gamedrv, emu_options &options)
 		bool is_default;
 		if (!has_option)
 		{
+			// Theoretically we should never get here; in the long run the expectation is that
+			// options.slot_options() should be fully qualified and all options should be
+			// present.  However, we're getting late in the MAME 0.185 development cycle and
+			// I don't want to rip this out (yet)
 			selval = slot.default_option();
 			is_default = true;
 		}
@@ -51,7 +55,7 @@ machine_config::machine_config(const game_driver &gamedrv, emu_options &options)
 		{
 			const slot_option &opt = options.slot_options()[slot_option_name];
 			selval = opt.value().c_str();
-			is_default = opt.is_default();
+			is_default = !opt.specified();
 		}
 
 		if (selval && *selval)

--- a/src/frontend/mame/mameopts.cpp
+++ b/src/frontend/mame/mameopts.cpp
@@ -57,20 +57,14 @@ bool mame_options::add_slot_options(emu_options &options, value_specifier_func v
 
 			// add the option
 			options.add_entry(name, nullptr, OPTION_STRING | OPTION_FLAG_DEVICE, slot.default_option(), true);
-			options.slot_options()[name] = slot_option();
+			options.slot_options()[name] = slot_option(slot.default_option());
 
 			// allow opportunity to specify this value
 			if (value_specifier)
 			{
-				std::string value = value_specifier(name);
-				if (value != value_specifier_invalid_value())
-				{
-					const device_slot_option *option = slot.option(value.c_str());
-					if (option)
-					{
-						options.slot_options()[name] = emu_options::parse_slot_option(std::move(value), option->selectable());
-					}
-				}
+				std::string specified_value = value_specifier(name);
+				if (specified_value != value_specifier_invalid_value())
+					options.slot_options()[name].specify(std::move(specified_value));
 			}
 		}
 	}
@@ -307,13 +301,6 @@ bool mame_options::reevaluate_slot_options(emu_options &options)
 				if (options.slot_options()[name].default_card_software() != default_card_software)
 				{
 					options.slot_options()[name].set_default_card_software(std::move(default_card_software));
-
-					// the value of this slot option has changed.  we may need to change is_selectable(); this
-					// should really be encapsulated within emu_options
-					const device_slot_option *option = slot.option(options.slot_options()[name].value().c_str());
-					if (option)
-						options.slot_options()[name].set_is_selectable(option->selectable());
-
 					result = true;
 				}
 			}

--- a/src/lib/util/options.cpp
+++ b/src/lib/util/options.cpp
@@ -565,9 +565,21 @@ std::string core_options::output_ini(const core_options *diff) const
 	for (entry &curentry : m_entrylist)
 	{
 		const char *name = curentry.name();
-		const char *value = name && override_get_value(name, overridden_value)
-			? overridden_value.c_str()
-			: curentry.value();
+		const char *value;
+		switch (override_get_value(name, overridden_value))
+		{
+			case override_get_value_result::NONE:
+			default:
+				value = curentry.value();
+				break;
+
+			case override_get_value_result::SKIP:
+				continue;
+
+			case override_get_value_result::OVERRIDE:
+				value = overridden_value.c_str();
+				break;
+		}
 		bool is_unadorned = false;
 
 		// check if it's unadorned

--- a/src/lib/util/options.h
+++ b/src/lib/util/options.h
@@ -181,8 +181,17 @@ public:
 	int options_count() const { return m_entrylist.count(); }
 
 protected:
+	// This is a hook to allow option value retrieval to be overridden for various reasons; this is a crude
+	// extensibility mechanism that should really be replaced by something better
+	enum class override_get_value_result
+	{
+		NONE,
+		OVERRIDE,
+		SKIP
+	};
+
 	virtual void value_changed(const std::string &name, const std::string &value) {}
-	virtual bool override_get_value(const char *name, std::string &value) const { return false; }
+	virtual override_get_value_result override_get_value(const char *name, std::string &value) const { return override_get_value_result::NONE; }
 	virtual bool override_set_value(const char *name, const std::string &value) { return false; }
 
 private:


### PR DESCRIPTION
This should address outstanding concerns with PR#2231.  I'm trying to turn emu_options into a self contained structure that encapsulates behaviors related to options, including the gymnastics pertaining to image/slot loading and interactions with get_default_card_software() and "just works".

When the MAME 0.186 development cycle starts up, I hope to take this further.  I want to make core_options::entry an abstract base class so that the entries associated with image options and slot options can derive from it.  This will eliminate the current need for emu_options to directly expose maps for image and slot options.

For now, I'm in stabilization mode, and I hope to get things working for a stable 0.185 release.