### PR TITLE
dipalette: A return to sanity (nw)

### DIFF
--- a/src/devices/video/v9938.h
+++ b/src/devices/video/v9938.h
@@ -284,7 +284,7 @@ public:
 
 protected:
 	virtual void palette_init() override;
-	virtual int palette_entries() const override { return 512; }
+	virtual u32 palette_entries() const override { return 512; }
 };
 
 class v9958_device : public v99x8_device
@@ -294,7 +294,7 @@ public:
 
 protected:
 	virtual void palette_init() override;
-	virtual int palette_entries() const override { return 19780; }
+	virtual u32 palette_entries() const override { return 19780; }
 };
 
 

--- a/src/emu/dipalette.cpp
+++ b/src/emu/dipalette.cpp
@@ -62,7 +62,7 @@ void device_palette_interface::interface_pre_start()
 	m_format = (screen != nullptr) ? screen->format() : BITMAP_FORMAT_INVALID;
 
 	// allocate the palette
-	int numentries = palette_entries();
+	u32 numentries = palette_entries();
 	allocate_palette(numentries);
 	allocate_color_tables();
 	allocate_shadow_tables();
@@ -339,7 +339,7 @@ void device_palette_interface::set_shadow_dRGB32(int mode, int dr, int dg, int d
 //  palette object itself
 //-------------------------------------------------
 
-void device_palette_interface::allocate_palette(int numentries)
+void device_palette_interface::allocate_palette(u32 numentries)
 {
 	assert(numentries > 0);
 

--- a/src/emu/dipalette.h
+++ b/src/emu/dipalette.h
@@ -46,8 +46,8 @@ public:
 	device_palette_interface(const machine_config &mconfig, device_t &device);
 
 	// getters
-	int entries() const { return (m_palette != nullptr) ? m_palette->num_colors() : 0; }
-	int indirect_entries() const { return m_indirect_colors.size(); }
+	int entries() const { return palette_entries(); }
+	int indirect_entries() const { return palette_indirect_entries(); }
 	palette_t *palette() const { return m_palette; }
 	const pen_t &pen(int index) const { return m_pens[index]; }
 	const pen_t *pens() const { return m_pens; }
@@ -56,8 +56,8 @@ public:
 	double pen_contrast(pen_t pen) const { return m_palette->entry_contrast(pen); }
 	pen_t black_pen() const { return m_black_pen; }
 	pen_t white_pen() const { return m_white_pen; }
-	bool shadows_enabled() const { return m_shadow_group != 0; }
-	bool hilights_enabled() const { return m_hilight_group != 0; }
+	bool shadows_enabled() const { return palette_shadows_enabled(); }
+	bool hilights_enabled() const { return palette_hilights_enabled(); }
 
 	// setters
 	void set_pen_color(pen_t pen, rgb_t rgb) { m_palette->entry_set_color(pen, rgb); }
@@ -83,6 +83,7 @@ public:
 
 protected:
 	// interface-level overrides
+	virtual void interface_validity_check(validity_checker &valid) const override;
 	virtual void interface_pre_start() override;
 	virtual void interface_post_start() override;
 	virtual void interface_pre_save() override;

--- a/src/emu/dipalette.h
+++ b/src/emu/dipalette.h
@@ -46,8 +46,8 @@ public:
 	device_palette_interface(const machine_config &mconfig, device_t &device);
 
 	// getters
-	int entries() const { return palette_entries(); }
-	int indirect_entries() const { return palette_indirect_entries(); }
+	u32 entries() const { return palette_entries(); }
+	u32 indirect_entries() const { return palette_indirect_entries(); }
 	palette_t *palette() const { return m_palette; }
 	const pen_t &pen(int index) const { return m_pens[index]; }
 	const pen_t *pens() const { return m_pens; }
@@ -91,14 +91,14 @@ protected:
 	virtual void interface_post_stop() override;
 
 	// configuration-related overrides
-	virtual int palette_entries() const = 0;
-	virtual int palette_indirect_entries() const { return 0; }
+	virtual u32 palette_entries() const = 0;
+	virtual u32 palette_indirect_entries() const { return 0; }
 	virtual bool palette_shadows_enabled() const { return false; }
 	virtual bool palette_hilights_enabled() const { return false; }
 
 private:
 	// internal helpers
-	void allocate_palette(int numentries);
+	void allocate_palette(u32 numentries);
 	void allocate_color_tables();
 	void allocate_shadow_tables();
 public: // needed by konamigx

--- a/src/emu/emupal.cpp
+++ b/src/emu/emupal.cpp
@@ -66,13 +66,13 @@ void palette_device::static_set_endianness(device_t &device, endianness_t endian
 }
 
 
-void palette_device::static_set_entries(device_t &device, int entries)
+void palette_device::static_set_entries(device_t &device, u32 entries)
 {
 	downcast<palette_device &>(device).m_entries = entries;
 }
 
 
-void palette_device::static_set_indirect_entries(device_t &device, int entries)
+void palette_device::static_set_indirect_entries(device_t &device, u32 entries)
 {
 	downcast<palette_device &>(device).m_indirect_entries = entries;
 }

--- a/src/emu/emupal.h
+++ b/src/emu/emupal.h
@@ -367,8 +367,8 @@ public:
 	static void static_set_format(device_t &device, raw_to_rgb_converter raw_to_rgb);
 	static void static_set_membits(device_t &device, int membits);
 	static void static_set_endianness(device_t &device, endianness_t endianness);
-	static void static_set_entries(device_t &device, int entries);
-	static void static_set_indirect_entries(device_t &device, int entries);
+	static void static_set_entries(device_t &device, u32 entries);
+	static void static_set_indirect_entries(device_t &device, u32 entries);
 	static void static_enable_shadows(device_t &device);
 	static void static_enable_hilights(device_t &device);
 
@@ -421,8 +421,8 @@ protected:
 	virtual void device_start() override;
 
 	// device_palette_interface overrides
-	virtual int palette_entries() const override { return m_entries; }
-	virtual int palette_indirect_entries() const override { return m_indirect_entries; }
+	virtual u32 palette_entries() const override { return m_entries; }
+	virtual u32 palette_indirect_entries() const override { return m_indirect_entries; }
 	virtual bool palette_shadows_enabled() const override { return m_enable_shadows; }
 	virtual bool palette_hilights_enabled() const override { return m_enable_hilights; }
 
@@ -430,8 +430,8 @@ private:
 	void update_for_write(offs_t byte_offset, int bytes_modified, bool indirect = false);
 
 	// configuration state
-	int                 m_entries;              // number of entries in the palette
-	int                 m_indirect_entries;     // number of indirect colors in the palette
+	u32                 m_entries;              // number of entries in the palette
+	u32                 m_indirect_entries;     // number of indirect colors in the palette
 	bool                m_enable_shadows;       // are shadows enabled?
 	bool                m_enable_hilights;      // are hilights enabled?
 	int                 m_membits;              // width of palette RAM, if different from native


### PR DESCRIPTION
* Revert entries(), indirect_entries(), shadows_enabled() and hilights_enabled() to return the configuration parameters instead of accessing the live state. The thought behind the implementation change was that palette devices could potentially determine the number of entries from the sizes of devfind objects. The regressions caused by this have been worked around, but it was probably a bad idea in the first place.
* Zero-entry palettes are no longer valid. The code that tried to support them was basically left over from when every running machine had a single global palette.