### PR TITLE
Fixed a regression in the mandatory image check

### DIFF
--- a/src/frontend/mame/ui/info.cpp
+++ b/src/frontend/mame/ui/info.cpp
@@ -319,12 +319,23 @@ std::string machine_info::game_info_string()
 std::string machine_info::mandatory_images()
 {
 	std::ostringstream buf;
+	bool is_first = true;
 
 	// make sure that any required image has a mounted file
 	for (device_image_interface &image : image_interface_iterator(m_machine.root_device()))
 	{
-		if (image.must_be_loaded() && m_machine.options().image_options().count(image.instance_name()) == 0)
-			buf << "\"" << image.instance_name() << "\", ";
+		if (image.must_be_loaded())
+		{
+			auto iter = m_machine.options().image_options().find(image.instance_name());
+			if (iter == m_machine.options().image_options().end() || iter->second.empty())
+			{
+				if (is_first)
+					is_first = false;
+				else
+					buf << ", ";
+				buf << "\"" << image.instance_name() << "\"";
+			}
+		}
 	}
 	return buf.str();
 }

--- a/src/frontend/mame/ui/ui.cpp
+++ b/src/frontend/mame/ui/ui.cpp
@@ -341,8 +341,7 @@ void mame_ui_manager::display_startup_screens(bool first_time)
 					messagebox_text = machine_info().mandatory_images();
 				if (!messagebox_text.empty())
 				{
-					std::string warning;
-					warning.assign(_("This driver requires images to be loaded in the following device(s): ")).append(messagebox_text.substr(0, messagebox_text.length() - 2));
+					std::string warning = std::string(_("This driver requires images to be loaded in the following device(s): ")) + messagebox_text;
 					ui::menu_file_manager::force_file_manager(*this, machine().render().ui_container(), warning.c_str());
 				}
 				break;


### PR DESCRIPTION
As a consequence of recent changes, we were not properly blocking the emulation from starting when a must_be_loaded() image had an unspecified image.