### PR TITLE
via6522 shifter support for external clock

### DIFF
--- a/src/devices/machine/6522via.h
+++ b/src/devices/machine/6522via.h
@@ -135,6 +135,7 @@ private:
 	static const device_timer_id TIMER_T1 = 1;
 	static const device_timer_id TIMER_T2 = 2;
 	static const device_timer_id TIMER_CA2 = 3;
+	static const device_timer_id TIMER_SHIFT_IRQ = 4;
 
 	uint16_t get_counter1_value();
 
@@ -206,6 +207,7 @@ private:
 	emu_timer *m_ca2_timer;
 
 	emu_timer *m_shift_timer;
+	emu_timer *m_shift_irq_timer;
 	uint8_t m_shift_counter;
 };
 

--- a/src/devices/machine/6522via.h
+++ b/src/devices/machine/6522via.h
@@ -207,14 +207,6 @@ private:
 
 	emu_timer *m_shift_timer;
 	uint8_t m_shift_counter;
-	enum m_shift_state_t
-	{
-		SHIFTER_IDLE,
-		SHIFTER_SHIFT,
-		SHIFTER_FINISH,
-		SHIFTER_IRQ
-	};
-	m_shift_state_t m_shift_state;
 };
 
 


### PR DESCRIPTION
The regression of the Mac adb bus support caused me to refactor the shifter and I feel much better about this implementation as it got rid of ugly sub states and purely handles flanks now as opposed to a mix of flanks and cycles before. In my regression tests I noticed that some systems seems to work a bit better and of course both Mac adb bus and the Prodigy. Let me know any problems asap 