### PR TITLE
Fixed an issue that could cause problems when loading reset_on_load devices (like cartridges) from softlists at runtime

### DIFF
--- a/src/emu/diimage.cpp
+++ b/src/emu/diimage.cpp
@@ -1082,6 +1082,13 @@ image_init_result device_image_interface::load(const std::string &path)
 
 image_init_result device_image_interface::load_software(const std::string &software_identifier)
 {
+	// Is this a software part that forces a reset and we're at runtime?  If so, get this loaded through reset_and_load
+	if (is_reset_on_load() && !init_phase())
+	{
+		reset_and_load(software_identifier);
+		return image_init_result::PASS;
+	}
+
 	// Prepare to load
 	unload();
 	clear_error();
@@ -1408,13 +1415,6 @@ bool device_image_interface::load_software_part(const std::string &identifier)
 	{
 		software_list_device::display_matches(device().machine().config(), image_interface(), identifier);
 		return false;
-	}
-
-	// Is this a software part that forces a reset and we're at runtime?  If so, get this loaded through reset_and_load
-	if (is_reset_on_load() && !init_phase())
-	{
-		reset_and_load(identifier);
-		return true;
 	}
 
 	// Load the software part

--- a/src/emu/diimage.h
+++ b/src/emu/diimage.h
@@ -278,7 +278,6 @@ protected:
 	void image_checkhash();
 
 	const software_part *find_software_item(const std::string &identifier, bool restrict_to_interface, software_list_device **device = nullptr) const;
-	bool load_software_part(const std::string &identifier);
 	std::string software_get_default_slot(const char *default_card_slot) const;
 
 	void add_format(std::unique_ptr<image_device_format> &&format);
@@ -311,6 +310,7 @@ private:
 	static image_error_t image_error_from_file_error(osd_file::error filerr);
 	std::vector<u32> determine_open_plan(bool is_create);
 	void update_names();
+	bool load_software_part(const std::string &identifier);
 
 	bool init_phase() const;
 	static void run_hash(util::core_file &file, void(*partialhash)(util::hash_collection &, const unsigned char *, unsigned long, const char *), util::hash_collection &hashes, const char *types);


### PR DESCRIPTION
This was not guaranteed to cause a problem; the specific issue here was reported by mr_gw in the context of the CoCo, and the proximate issue (hanging) was in CoCo-specific code.   That said, this could cause problems elsewhere.

This was MT#6560