### PR TITLE
Remove starshp1 hack to restore correct behavior

### DIFF
--- a/src/mame/video/starshp1.cpp
+++ b/src/mame/video/starshp1.cpp
@@ -119,13 +119,13 @@ WRITE8_MEMBER(starshp1_state::starshp1_ssadd_w)
 WRITE8_MEMBER(starshp1_state::starshp1_sspic_w)
 {
 	/*
-	 * Some mysterious game code at address $2CCE is causing
-	 * erratic images in the target explosion sequence. The
-	 * following condition is a hack to filter these images.
+	 * Some mysterious game code at address $2CCE is causes
+	 * erratic images in the target explosion sequence. But
+	 * This is the way the actual game worked!
 	 */
 
-	if (data != 0x87)
-		m_ship_picture = data;
+	m_ship_picture = data;
+
 }
 
 


### PR DESCRIPTION
A very old (> 10 years?) hack seemed to clean up the way the ships explode in Atari Starship 1.  But this is different than the actual game behavior.  See this video of the way the ships behave when they are hit: https://youtu.be/-crXVuoKlL4?t=573  I'm pretty sure this is the way it used to work when I originally coded it from the schematics.  I have removed the hack and modified the comments in the code in video/starshp1.cpp

