### PR TITLE
[Imgtool] Fix to MT#6576

### DIFF
--- a/src/tools/imgtool/imghd.cpp
+++ b/src/tools/imgtool/imghd.cpp
@@ -131,16 +131,15 @@ imgtoolerr_t imghd_open(imgtool::stream &stream, struct mess_hard_disk_file *har
 	imgtoolerr_t err = IMGTOOLERR_SUCCESS;
 
 	hard_disk->hard_disk = nullptr;
-	hard_disk->chd = nullptr;
 
-	chderr = hard_disk->chd->open(*stream.core_file(), stream.is_read_only());
+	chderr = hard_disk->chd.open(*stream.core_file(), !stream.is_read_only());
 	if (chderr)
 	{
 		err = map_chd_error(chderr);
 		goto done;
 	}
 
-	hard_disk->hard_disk = hard_disk_open(hard_disk->chd);
+	hard_disk->hard_disk = hard_disk_open(&hard_disk->chd);
 	if (!hard_disk->hard_disk)
 	{
 		err = IMGTOOLERR_UNEXPECTED;

--- a/src/tools/imgtool/imghd.h
+++ b/src/tools/imgtool/imghd.h
@@ -17,7 +17,7 @@ struct mess_hard_disk_file
 {
 	imgtool::stream *stream;
 	hard_disk_file *hard_disk;
-	chd_file *chd;
+	chd_file chd;
 };
 
 
@@ -25,7 +25,7 @@ struct mess_hard_disk_file
 imgtoolerr_t imghd_create(imgtool::stream &stream, uint32_t blocksize, uint32_t cylinders, uint32_t heads, uint32_t sectors, uint32_t seclen);
 
 /* opens a hard disk given an Imgtool stream */
-imgtoolerr_t imghd_open(imgtool::stream &stream, struct mess_hard_disk_file *hard_disk);
+imgtoolerr_t imghd_open(imgtool::stream &stream, mess_hard_disk_file *hard_disk);
 
 /* close a hard disk */
 void imghd_close(struct mess_hard_disk_file *disk);

--- a/src/tools/imgtool/main.cpp
+++ b/src/tools/imgtool/main.cpp
@@ -708,8 +708,8 @@ static int cmd_listfilters(const struct command *c, int argc, char *argv[])
 	for (i = 0; filters[i]; i++)
 	{
 		util::stream_format(std::wcout, L"  %-11s%s\n",
-			filter_get_info_string(filters[i], FILTINFO_STR_NAME),
-			filter_get_info_string(filters[i], FILTINFO_STR_HUMANNAME));
+			wstring_from_utf8(filter_get_info_string(filters[i], FILTINFO_STR_NAME)),
+			wstring_from_utf8(filter_get_info_string(filters[i], FILTINFO_STR_HUMANNAME)));
 	}
 
 	return 0;

--- a/src/tools/imgtool/stream.cpp
+++ b/src/tools/imgtool/stream.cpp
@@ -492,7 +492,7 @@ uint64_t imgtool::stream::fill(unsigned char b, uint64_t sz)
 //  is_read_only
 //-------------------------------------------------
 
-int imgtool::stream::is_read_only()
+bool imgtool::stream::is_read_only()
 {
 	return write_protect;
 }

--- a/src/tools/imgtool/stream.h
+++ b/src/tools/imgtool/stream.h
@@ -50,7 +50,7 @@ namespace imgtool
 		static int file_crc(const char *fname, unsigned long *result);
 
 		// returns whether a stream is read only or not
-		int is_read_only();
+		bool is_read_only();
 
 	private:
 		enum imgtype_t


### PR DESCRIPTION
Two independent issues reported under MT#6576
- The 'listformats' command was broken
- imghd.cpp (the Imgtool <==> CHD HD bridge) was pretty much completely broken (more work is needed here)