### PR TITLE
Fixed regression pertaining to auxillary verbs with system name parameters and the "best matches" list

### DIFF
--- a/src/emu/emuopts.cpp
+++ b/src/emu/emuopts.cpp
@@ -445,6 +445,9 @@ void emu_options::set_system_name(const std::string &new_system_name)
 {
 	const game_driver *new_system = nullptr;
 
+	// we are making an attempt - record what we're attempting
+	m_attempted_system_name = new_system_name;
+
 	// was a system name specified?
 	if (!new_system_name.empty())
 	{

--- a/src/emu/emuopts.h
+++ b/src/emu/emuopts.h
@@ -284,6 +284,7 @@ public:
 	// core options
 	const game_driver *system() const { return m_system; }
 	const char *system_name() const;
+	const std::string &attempted_system_name() const { return m_attempted_system_name; }
 
 	// core configuration options
 	bool read_config() const { return bool_value(OPTION_READCONFIG); }
@@ -498,6 +499,9 @@ private:
 	bool                                                m_sleep;
 	bool                                                m_refresh_speed;
 	ui_option                                           m_ui;
+
+	// special option; the system name we tried to specify
+	std::string											m_attempted_system_name;
 };
 
 #endif  // MAME_EMU_EMUOPTS_H

--- a/src/frontend/mame/clifront.h
+++ b/src/frontend/mame/clifront.h
@@ -34,24 +34,24 @@ public:
 	int execute(std::vector<std::string> &args);
 
 	// direct access to the command operations
-	void listxml(const char *gamename = "*");
-	void listfull(const char *gamename = "*");
-	void listsource(const char *gamename = "*");
-	void listclones(const char *gamename = "*");
-	void listbrothers(const char *gamename = "*");
-	void listcrc(const char *gamename = "*");
-	void listroms(const char *gamename = "*");
-	void listsamples(const char *gamename = "*");
-	void listdevices(const char *gamename = "*");
-	void listslots(const char *gamename = "*");
-	void listmedia(const char *gamename = "*");
-	void listsoftware(const char *gamename = "*");
-	void verifysoftware(const char *gamename = "*");
-	void verifyroms(const char *gamename = "*");
-	void verifysamples(const char *gamename = "*");
-	void romident(const char *filename);
-	void getsoftlist(const char *gamename = "*");
-	void verifysoftlist(const char *gamename = "*");
+	void listxml(const std::string &gamename = "*");
+	void listfull(const std::string &gamename = "*");
+	void listsource(const std::string &gamename = "*");
+	void listclones(const std::string &gamename = "*");
+	void listbrothers(const std::string &gamename = "*");
+	void listcrc(const std::string &gamename = "*");
+	void listroms(const std::string &gamename = "*");
+	void listsamples(const std::string &gamename = "*");
+	void listdevices(const std::string &gamename = "*");
+	void listslots(const std::string &gamename = "*");
+	void listmedia(const std::string &gamename = "*");
+	void listsoftware(const std::string &gamename = "*");
+	void verifysoftware(const std::string &gamename = "*");
+	void verifyroms(const std::string &gamename = "*");
+	void verifysamples(const std::string &gamename = "*");
+	void romident(const std::string &filename);
+	void getsoftlist(const std::string &gamename = "*");
+	void verifysoftlist(const std::string &gamename = "*");
 
 private:
 	// internal helpers
@@ -60,6 +60,7 @@ private:
 	void display_suggestions(const char *gamename);
 	void output_single_softlist(FILE *out, software_list_device &swlist);
 	void start_execution(mame_machine_manager *manager, std::vector<std::string> &args);
+	emu_options create_clean_options();
 
 	// internal state
 	emu_options &       m_options;

--- a/src/lib/util/options.cpp
+++ b/src/lib/util/options.cpp
@@ -735,7 +735,7 @@ void core_options::throw_options_exception_if_appropriate(core_options::conditio
 		throw options_warning_exception(error_stream.str());
 
 	case condition_type::ERR:
-		throw options_warning_exception(error_stream.str());
+		throw options_error_exception(error_stream.str());
 
 	default:
 		// should not get here


### PR DESCRIPTION
The new options system doesn't let emu_options::system_name() to be an invalid value.  I had to separately track an "attempted_system_name()" to snake this information through.

Also fixed an issue that caused aggregate errors to be reported as warnings.