### PR TITLE
Fixed a regression that could cause options in INI files overriding softlist values at the command line

### DIFF
--- a/src/emu/emuopts.h
+++ b/src/emu/emuopts.h
@@ -215,7 +215,7 @@ public:
 	core_options::entry::shared_ptr option_entry() const { return m_entry.lock(); }
 
 	// seters
-	void specify(std::string &&text);
+	void specify(std::string &&text, bool peg_priority = true);
 	void set_bios(std::string &&text);
 	void set_default_card_software(std::string &&s);
 
@@ -248,8 +248,8 @@ public:
 	core_options::entry::shared_ptr option_entry() const { return m_entry.lock(); }
 
 	// mutators
-	void specify(const std::string &value);
-	void specify(std::string &&value);
+	void specify(const std::string &value, bool peg_priority = true);
+	void specify(std::string &&value, bool peg_priority = true);
 
 	// instantiates an option entry (don't call outside of emuopts.cpp)
 	core_options::entry::shared_ptr setup_option_entry(std::vector<std::string> &&names);

--- a/src/lib/util/options.h
+++ b/src/lib/util/options.h
@@ -117,6 +117,7 @@ public:
 		const std::string &name() const { return m_names[0]; }
 		virtual const char *value() const;
 		int priority() const { return m_priority;  }
+		void set_priority(int priority) { m_priority = priority; }
 		option_type type() const { return m_type; }
 		const char *description() const { return m_description; }
 		virtual const std::string &default_value() const;


### PR DESCRIPTION
This fixes a regression whereby if something like the following was in nes.ini:

	cartridge 	nes:zelda:cart

The INI could take preference if 'mame64 nes zelda2' was entered at the command line.  The issue was a consequence of the priority not being updated when softlist options were resolved.