### PR TITLE
Bug fix to -romident and aux verb cleanup

### DIFF
--- a/src/frontend/mame/clifront.cpp
+++ b/src/frontend/mame/clifront.cpp
@@ -317,15 +317,15 @@ int cli_frontend::execute(std::vector<std::string> &args)
 //  games
 //-------------------------------------------------
 
-void cli_frontend::listxml(const char *gamename)
+void cli_frontend::listxml(const std::string &gamename)
 {
 	// determine which drivers to output; return an error if none found
-	driver_enumerator drivlist(m_options, gamename);
+	driver_enumerator drivlist(m_options, gamename.c_str());
 	if (drivlist.count() == 0)
-		throw emu_fatalerror(EMU_ERR_NO_SUCH_GAME, "No matching games found for '%s'", gamename);
+		throw emu_fatalerror(EMU_ERR_NO_SUCH_GAME, "No matching games found for '%s'", gamename.c_str());
 
 	// create the XML and print it to stdout
-	info_xml_creator creator(drivlist, gamename && *gamename);
+	info_xml_creator creator(drivlist, !gamename.empty());
 	creator.output(stdout);
 }
 
@@ -335,12 +335,12 @@ void cli_frontend::listxml(const char *gamename)
 //  one or more games
 //-------------------------------------------------
 
-void cli_frontend::listfull(const char *gamename)
+void cli_frontend::listfull(const std::string &gamename)
 {
 	// determine which drivers to output; return an error if none found
-	driver_enumerator drivlist(m_options, gamename);
+	driver_enumerator drivlist(m_options, gamename.c_str());
 	if (drivlist.count() == 0)
-		throw emu_fatalerror(EMU_ERR_NO_SUCH_GAME, "No matching games found for '%s'", gamename);
+		throw emu_fatalerror(EMU_ERR_NO_SUCH_GAME, "No matching games found for '%s'", gamename.c_str());
 
 	// print the header
 	osd_printf_info("Name:             Description:\n");
@@ -357,12 +357,12 @@ void cli_frontend::listfull(const char *gamename)
 //  filename of one or more games
 //-------------------------------------------------
 
-void cli_frontend::listsource(const char *gamename)
+void cli_frontend::listsource(const std::string &gamename)
 {
 	// determine which drivers to output; return an error if none found
-	driver_enumerator drivlist(m_options, gamename);
+	driver_enumerator drivlist(m_options, gamename.c_str());
 	if (drivlist.count() == 0)
-		throw emu_fatalerror(EMU_ERR_NO_SUCH_GAME, "No matching games found for '%s'", gamename);
+		throw emu_fatalerror(EMU_ERR_NO_SUCH_GAME, "No matching games found for '%s'", gamename.c_str());
 
 	// iterate through drivers and output the info
 	while (drivlist.next())
@@ -375,10 +375,10 @@ void cli_frontend::listsource(const char *gamename)
 //  clones matching the given pattern
 //-------------------------------------------------
 
-void cli_frontend::listclones(const char *gamename)
+void cli_frontend::listclones(const std::string &gamename)
 {
 	// start with a filtered list of drivers
-	driver_enumerator drivlist(m_options, gamename);
+	driver_enumerator drivlist(m_options, gamename.c_str());
 	int original_count = drivlist.count();
 
 	// iterate through the remaining ones to see if their parent matches
@@ -387,7 +387,7 @@ void cli_frontend::listclones(const char *gamename)
 		// if we have a non-bios clone and it matches, keep it
 		int clone_of = drivlist.clone();
 		if (clone_of != -1 && (drivlist.driver(clone_of).flags & MACHINE_IS_BIOS_ROOT) == 0)
-			if (drivlist.matches(gamename, drivlist.driver(clone_of).name))
+			if (drivlist.matches(gamename.c_str(), drivlist.driver(clone_of).name))
 				drivlist.include();
 	}
 
@@ -396,9 +396,9 @@ void cli_frontend::listclones(const char *gamename)
 	{
 		// see if we match but just weren't a clone
 		if (original_count == 0)
-			throw emu_fatalerror(EMU_ERR_NO_SUCH_GAME, "No matching games found for '%s'", gamename);
+			throw emu_fatalerror(EMU_ERR_NO_SUCH_GAME, "No matching games found for '%s'", gamename.c_str());
 		else
-			osd_printf_info("Found %lu matches for '%s' but none were clones\n", (unsigned long)drivlist.count(), gamename);
+			osd_printf_info("Found %lu matches for '%s' but none were clones\n", (unsigned long)drivlist.count(), gamename.c_str());
 		return;
 	}
 
@@ -422,12 +422,12 @@ void cli_frontend::listclones(const char *gamename)
 //  source file
 //-------------------------------------------------
 
-void cli_frontend::listbrothers(const char *gamename)
+void cli_frontend::listbrothers(const std::string &gamename)
 {
 	// start with a filtered list of drivers; return an error if none found
-	driver_enumerator initial_drivlist(m_options, gamename);
+	driver_enumerator initial_drivlist(m_options, gamename.c_str());
 	if (initial_drivlist.count() == 0)
-		throw emu_fatalerror(EMU_ERR_NO_SUCH_GAME, "No matching games found for '%s'", gamename);
+		throw emu_fatalerror(EMU_ERR_NO_SUCH_GAME, "No matching games found for '%s'", gamename.c_str());
 
 	// for the final list, start with an empty driver list
 	driver_enumerator drivlist(m_options);
@@ -465,12 +465,12 @@ void cli_frontend::listbrothers(const char *gamename)
 //  referenced by the emulator
 //-------------------------------------------------
 
-void cli_frontend::listcrc(const char *gamename)
+void cli_frontend::listcrc(const std::string &gamename)
 {
 	// determine which drivers to output; return an error if none found
-	driver_enumerator drivlist(m_options, gamename);
+	driver_enumerator drivlist(m_options, gamename.c_str());
 	if (drivlist.count() == 0)
-		throw emu_fatalerror(EMU_ERR_NO_SUCH_GAME, "No matching games found for '%s'", gamename);
+		throw emu_fatalerror(EMU_ERR_NO_SUCH_GAME, "No matching games found for '%s'", gamename.c_str());
 
 	// iterate through matches, and then through ROMs
 	while (drivlist.next())
@@ -493,12 +493,12 @@ void cli_frontend::listcrc(const char *gamename)
 //  by a given game or set of games
 //-------------------------------------------------
 
-void cli_frontend::listroms(const char *gamename)
+void cli_frontend::listroms(const std::string &gamename)
 {
 	// determine which drivers to output; return an error if none found
-	driver_enumerator drivlist(m_options, gamename);
+	driver_enumerator drivlist(m_options, gamename.c_str());
 	if (drivlist.count() == 0)
-		throw emu_fatalerror(EMU_ERR_NO_SUCH_GAME, "No matching games found for '%s'", gamename);
+		throw emu_fatalerror(EMU_ERR_NO_SUCH_GAME, "No matching games found for '%s'", gamename.c_str());
 
 	// iterate through matches
 	bool first = true;
@@ -554,12 +554,12 @@ void cli_frontend::listroms(const char *gamename)
 //  referenced by a given game or set of games
 //-------------------------------------------------
 
-void cli_frontend::listsamples(const char *gamename)
+void cli_frontend::listsamples(const std::string &gamename)
 {
 	// determine which drivers to output; return an error if none found
-	driver_enumerator drivlist(m_options, gamename);
+	driver_enumerator drivlist(m_options, gamename.c_str());
 	if (drivlist.count() == 0)
-		throw emu_fatalerror(EMU_ERR_NO_SUCH_GAME, "No matching games found for '%s'", gamename);
+		throw emu_fatalerror(EMU_ERR_NO_SUCH_GAME, "No matching games found for '%s'", gamename.c_str());
 
 	// iterate over drivers, looking for SAMPLES devices
 	bool first = true;
@@ -592,12 +592,12 @@ void cli_frontend::listsamples(const char *gamename)
 //  referenced by a given game or set of games
 //-------------------------------------------------
 
-void cli_frontend::listdevices(const char *gamename)
+void cli_frontend::listdevices(const std::string &gamename)
 {
 	// determine which drivers to output; return an error if none found
-	driver_enumerator drivlist(m_options, gamename);
+	driver_enumerator drivlist(m_options, gamename.c_str());
 	if (drivlist.count() == 0)
-		throw emu_fatalerror(EMU_ERR_NO_SUCH_GAME, "No matching games found for '%s'", gamename);
+		throw emu_fatalerror(EMU_ERR_NO_SUCH_GAME, "No matching games found for '%s'", gamename.c_str());
 
 	// iterate over drivers, looking for SAMPLES devices
 	bool first = true;
@@ -667,12 +667,12 @@ void cli_frontend::listdevices(const char *gamename)
 //  referenced by a given game or set of games
 //-------------------------------------------------
 
-void cli_frontend::listslots(const char *gamename)
+void cli_frontend::listslots(const std::string &gamename)
 {
 	// determine which drivers to output; return an error if none found
-	driver_enumerator drivlist(m_options, gamename);
+	driver_enumerator drivlist(m_options, gamename.c_str());
 	if (drivlist.count() == 0)
-		throw emu_fatalerror(EMU_ERR_NO_SUCH_GAME, "No matching games found for '%s'", gamename);
+		throw emu_fatalerror(EMU_ERR_NO_SUCH_GAME, "No matching games found for '%s'", gamename.c_str());
 
 	// print header
 	printf("%-16s %-16s %-16s %s\n", "SYSTEM", "SLOT NAME", "SLOT OPTIONS", "SLOT DEVICE NAME");
@@ -725,12 +725,12 @@ void cli_frontend::listslots(const char *gamename)
 //  referenced by a given game or set of games
 //-------------------------------------------------
 
-void cli_frontend::listmedia(const char *gamename)
+void cli_frontend::listmedia(const std::string &gamename)
 {
 	// determine which drivers to output; return an error if none found
-	driver_enumerator drivlist(m_options, gamename);
+	driver_enumerator drivlist(m_options, gamename.c_str());
 	if (drivlist.count() == 0)
-		throw emu_fatalerror(EMU_ERR_NO_SUCH_GAME, "No matching games found for '%s'", gamename);
+		throw emu_fatalerror(EMU_ERR_NO_SUCH_GAME, "No matching games found for '%s'", gamename.c_str());
 
 	// print header
 	printf("%-16s %-16s %-10s %s\n", "SYSTEM", "MEDIA NAME", "(brief)", "IMAGE FILE EXTENSIONS SUPPORTED");
@@ -777,10 +777,10 @@ void cli_frontend::listmedia(const char *gamename)
 //  verifyroms - verify the ROM sets of one or
 //  more games
 //-------------------------------------------------
-void cli_frontend::verifyroms(const char *gamename)
+void cli_frontend::verifyroms(const std::string &gamename)
 {
 	// determine which drivers to output;
-	driver_enumerator drivlist(m_options, gamename);
+	driver_enumerator drivlist(m_options, gamename.c_str());
 
 	unsigned correct = 0;
 	unsigned incorrect = 0;
@@ -809,7 +809,7 @@ void cli_frontend::verifyroms(const char *gamename)
 	for (device_type type : registered_device_types)
 	{
 		device_t *const dev = config.device_add(&config.root_device(), "_tmp", type, 0);
-		if (!gamename || !core_strwildcmp(gamename, dev->shortname()))
+		if (gamename.empty() || !core_strwildcmp(gamename.c_str(), dev->shortname()))
 		{
 			matched++;
 
@@ -830,15 +830,15 @@ void cli_frontend::verifyroms(const char *gamename)
 
 	// return an error if none found
 	if (matched == 0)
-		throw emu_fatalerror(EMU_ERR_NO_SUCH_GAME, "No matching games found for '%s'", gamename ? gamename : "");
+		throw emu_fatalerror(EMU_ERR_NO_SUCH_GAME, "No matching games found for '%s'", gamename.c_str());
 
 	// if we didn't get anything at all, display a generic end message
 	if (matched > 0 && correct == 0 && incorrect == 0)
 	{
 		if (notfound > 0)
-			throw emu_fatalerror(EMU_ERR_MISSING_FILES, "romset \"%s\" not found!\n", gamename ? gamename : "");
+			throw emu_fatalerror(EMU_ERR_MISSING_FILES, "romset \"%s\" not found!\n", gamename.c_str());
 		else
-			throw emu_fatalerror(EMU_ERR_MISSING_FILES, "romset \"%s\" has no roms!\n", gamename ? gamename : "");
+			throw emu_fatalerror(EMU_ERR_MISSING_FILES, "romset \"%s\" has no roms!\n", gamename.c_str());
 	}
 
 	// otherwise, print a summary
@@ -856,10 +856,9 @@ void cli_frontend::verifyroms(const char *gamename)
 //  one or more games
 //-------------------------------------------------
 
-void cli_frontend::verifysamples(const char *gamename)
+void cli_frontend::verifysamples(const std::string &gamename_str)
 {
-	if (!gamename)
-		gamename = "*";
+	const char *gamename = gamename_str.empty() ? "*" : gamename_str.c_str();
 
 	// determine which drivers to output; return an error if none found
 	driver_enumerator drivlist(m_options, gamename);
@@ -1093,16 +1092,16 @@ void cli_frontend::output_single_softlist(FILE *out, software_list_device &swlis
         identifying duplicate lists.
 -------------------------------------------------*/
 
-void cli_frontend::listsoftware(const char *gamename)
+void cli_frontend::listsoftware(const std::string &gamename)
 {
 	FILE *out = stdout;
 	std::unordered_set<std::string> list_map;
 	bool isfirst = true;
 
 	// determine which drivers to output; return an error if none found
-	driver_enumerator drivlist(m_options, gamename);
+	driver_enumerator drivlist(m_options, gamename.c_str());
 	if (drivlist.count() == 0)
-		throw emu_fatalerror(EMU_ERR_NO_SUCH_GAME, "No matching games found for '%s'", gamename);
+		throw emu_fatalerror(EMU_ERR_NO_SUCH_GAME, "No matching games found for '%s'", gamename.c_str());
 
 	while (drivlist.next())
 	{
@@ -1126,10 +1125,9 @@ void cli_frontend::listsoftware(const char *gamename)
     verifysoftware - verify roms from the software
     list of the specified driver(s)
 -------------------------------------------------*/
-void cli_frontend::verifysoftware(const char *gamename)
+void cli_frontend::verifysoftware(const std::string &gamename_str)
 {
-	if (!gamename)
-		gamename = "*";
+	const char *gamename = gamename_str.empty() ? "*" : gamename_str.c_str();
 
 	std::unordered_set<std::string> list_map;
 
@@ -1203,10 +1201,9 @@ void cli_frontend::verifysoftware(const char *gamename)
     getsoftlist - retrieve software list by name
 -------------------------------------------------*/
 
-void cli_frontend::getsoftlist(const char *gamename)
+void cli_frontend::getsoftlist(const std::string &gamename_str)
 {
-	if (!gamename)
-		gamename = "*";
+	const char *gamename = gamename_str.empty() ? "*" : gamename_str.c_str();
 
 	FILE *out = stdout;
 	std::unordered_set<std::string> list_map;
@@ -1234,10 +1231,9 @@ void cli_frontend::getsoftlist(const char *gamename)
 /*-------------------------------------------------
     verifysoftlist - verify software list by name
 -------------------------------------------------*/
-void cli_frontend::verifysoftlist(const char *gamename)
+void cli_frontend::verifysoftlist(const std::string &gamename_str)
 {
-	if (!gamename)
-		gamename = "*";
+	const char *gamename = gamename_str.empty() ? "*" : gamename_str.c_str();
 
 	std::unordered_set<std::string> list_map;
 	unsigned correct = 0;
@@ -1301,13 +1297,19 @@ void cli_frontend::verifysoftlist(const char *gamename)
 //  matches in our internal database
 //-------------------------------------------------
 
-void cli_frontend::romident(const char *filename)
+void cli_frontend::romident(const std::string &filename)
 {
-	media_identifier ident(m_options);
+	// create our own copy of options for the purposes of ROM identification
+	// so we are not "polluted" with driver-specific slot/image options
+	emu_options options;
+	std::string error_string;
+	options.set_value(OPTION_MEDIAPATH, m_options.media_path(), OPTION_PRIORITY_DEFAULT, error_string);
+
+	media_identifier ident(options);
 
 	// identify the file, then output results
-	osd_printf_info("Identifying %s....\n", filename);
-	ident.identify(filename);
+	osd_printf_info("Identifying %s....\n", filename.c_str());
+	ident.identify(filename.c_str());
 
 	// return the appropriate error code
 	if (ident.matches() == ident.total())
@@ -1409,7 +1411,7 @@ void cli_frontend::execute_commands(const char *exename)
 	static const struct
 	{
 		const char *option;
-		void (cli_frontend::*function)(const char *gamename);
+		void (cli_frontend::*function)(const std::string &gamename);
 	} info_commands[] =
 	{
 		{ CLICOMMAND_LISTXML,       &cli_frontend::listxml },
@@ -1439,7 +1441,7 @@ void cli_frontend::execute_commands(const char *exename)
 		{
 			// parse any relevant INI files before proceeding
 			const char *sysname = m_options.system_name();
-			(this->*info_command.function)((sysname[0] == 0) ? nullptr : sysname);
+			(this->*info_command.function)(sysname);
 			return;
 		}
 	}

--- a/src/frontend/mame/clifront.cpp
+++ b/src/frontend/mame/clifront.cpp
@@ -2,7 +2,7 @@
 // copyright-holders:Aaron Giles
 /***************************************************************************
 
-    clifront.c
+    clifront.cpp
 
     Command-line interface frontend for MAME.
 
@@ -317,15 +317,17 @@ int cli_frontend::execute(std::vector<std::string> &args)
 //  games
 //-------------------------------------------------
 
-void cli_frontend::listxml(const std::string &gamename)
+void cli_frontend::listxml(const std::vector<std::string> &args)
 {
+	const char *gamename = args.size() > 0 ? args[0].c_str() : nullptr;
+
 	// determine which drivers to output; return an error if none found
-	driver_enumerator drivlist(m_options, gamename.c_str());
+	driver_enumerator drivlist(m_options, gamename);
 	if (drivlist.count() == 0)
-		throw emu_fatalerror(EMU_ERR_NO_SUCH_GAME, "No matching games found for '%s'", gamename.c_str());
+		throw emu_fatalerror(EMU_ERR_NO_SUCH_GAME, "No matching games found for '%s'", gamename ? gamename : "");
 
 	// create the XML and print it to stdout
-	info_xml_creator creator(drivlist, !gamename.empty());
+	info_xml_creator creator(drivlist, gamename && *gamename);
 	creator.output(stdout);
 }
 
@@ -335,12 +337,14 @@ void cli_frontend::listxml(const std::string &gamename)
 //  one or more games
 //-------------------------------------------------
 
-void cli_frontend::listfull(const std::string &gamename)
+void cli_frontend::listfull(const std::vector<std::string> &args)
 {
+	const char *gamename = args.size() > 0 ? args[0].c_str() : nullptr;
+
 	// determine which drivers to output; return an error if none found
-	driver_enumerator drivlist(m_options, gamename.c_str());
+	driver_enumerator drivlist(m_options, gamename);
 	if (drivlist.count() == 0)
-		throw emu_fatalerror(EMU_ERR_NO_SUCH_GAME, "No matching games found for '%s'", gamename.c_str());
+		throw emu_fatalerror(EMU_ERR_NO_SUCH_GAME, "No matching games found for '%s'", gamename);
 
 	// print the header
 	osd_printf_info("Name:             Description:\n");
@@ -357,12 +361,14 @@ void cli_frontend::listfull(const std::string &gamename)
 //  filename of one or more games
 //-------------------------------------------------
 
-void cli_frontend::listsource(const std::string &gamename)
+void cli_frontend::listsource(const std::vector<std::string> &args)
 {
+	const char *gamename = args.size() > 0 ? args[0].c_str() : nullptr;
+
 	// determine which drivers to output; return an error if none found
-	driver_enumerator drivlist(m_options, gamename.c_str());
+	driver_enumerator drivlist(m_options, gamename);
 	if (drivlist.count() == 0)
-		throw emu_fatalerror(EMU_ERR_NO_SUCH_GAME, "No matching games found for '%s'", gamename.c_str());
+		throw emu_fatalerror(EMU_ERR_NO_SUCH_GAME, "No matching games found for '%s'", gamename);
 
 	// iterate through drivers and output the info
 	while (drivlist.next())
@@ -375,10 +381,12 @@ void cli_frontend::listsource(const std::string &gamename)
 //  clones matching the given pattern
 //-------------------------------------------------
 
-void cli_frontend::listclones(const std::string &gamename)
+void cli_frontend::listclones(const std::vector<std::string> &args)
 {
+	const char *gamename = args.size() > 0 ? args[0].c_str() : nullptr;
+
 	// start with a filtered list of drivers
-	driver_enumerator drivlist(m_options, gamename.c_str());
+	driver_enumerator drivlist(m_options, gamename);
 	int original_count = drivlist.count();
 
 	// iterate through the remaining ones to see if their parent matches
@@ -387,7 +395,7 @@ void cli_frontend::listclones(const std::string &gamename)
 		// if we have a non-bios clone and it matches, keep it
 		int clone_of = drivlist.clone();
 		if (clone_of != -1 && (drivlist.driver(clone_of).flags & MACHINE_IS_BIOS_ROOT) == 0)
-			if (drivlist.matches(gamename.c_str(), drivlist.driver(clone_of).name))
+			if (drivlist.matches(gamename, drivlist.driver(clone_of).name))
 				drivlist.include();
 	}
 
@@ -396,9 +404,9 @@ void cli_frontend::listclones(const std::string &gamename)
 	{
 		// see if we match but just weren't a clone
 		if (original_count == 0)
-			throw emu_fatalerror(EMU_ERR_NO_SUCH_GAME, "No matching games found for '%s'", gamename.c_str());
+			throw emu_fatalerror(EMU_ERR_NO_SUCH_GAME, "No matching games found for '%s'", gamename);
 		else
-			osd_printf_info("Found %lu matches for '%s' but none were clones\n", (unsigned long)drivlist.count(), gamename.c_str());
+			osd_printf_info("Found %lu matches for '%s' but none were clones\n", (unsigned long)drivlist.count(), gamename);
 		return;
 	}
 
@@ -422,12 +430,14 @@ void cli_frontend::listclones(const std::string &gamename)
 //  source file
 //-------------------------------------------------
 
-void cli_frontend::listbrothers(const std::string &gamename)
+void cli_frontend::listbrothers(const std::vector<std::string> &args)
 {
+	const char *gamename = args.size() > 0 ? args[0].c_str() : nullptr;
+
 	// start with a filtered list of drivers; return an error if none found
-	driver_enumerator initial_drivlist(m_options, gamename.c_str());
+	driver_enumerator initial_drivlist(m_options, gamename);
 	if (initial_drivlist.count() == 0)
-		throw emu_fatalerror(EMU_ERR_NO_SUCH_GAME, "No matching games found for '%s'", gamename.c_str());
+		throw emu_fatalerror(EMU_ERR_NO_SUCH_GAME, "No matching games found for '%s'", gamename);
 
 	// for the final list, start with an empty driver list
 	driver_enumerator drivlist(m_options);
@@ -465,12 +475,14 @@ void cli_frontend::listbrothers(const std::string &gamename)
 //  referenced by the emulator
 //-------------------------------------------------
 
-void cli_frontend::listcrc(const std::string &gamename)
+void cli_frontend::listcrc(const std::vector<std::string> &args)
 {
+	const char *gamename = args.size() > 0 ? args[0].c_str() : nullptr;
+
 	// determine which drivers to output; return an error if none found
-	driver_enumerator drivlist(m_options, gamename.c_str());
+	driver_enumerator drivlist(m_options, gamename);
 	if (drivlist.count() == 0)
-		throw emu_fatalerror(EMU_ERR_NO_SUCH_GAME, "No matching games found for '%s'", gamename.c_str());
+		throw emu_fatalerror(EMU_ERR_NO_SUCH_GAME, "No matching games found for '%s'", gamename);
 
 	// iterate through matches, and then through ROMs
 	while (drivlist.next())
@@ -493,12 +505,14 @@ void cli_frontend::listcrc(const std::string &gamename)
 //  by a given game or set of games
 //-------------------------------------------------
 
-void cli_frontend::listroms(const std::string &gamename)
+void cli_frontend::listroms(const std::vector<std::string> &args)
 {
+	const char *gamename = args.size() > 0 ? args[0].c_str() : nullptr;
+
 	// determine which drivers to output; return an error if none found
-	driver_enumerator drivlist(m_options, gamename.c_str());
+	driver_enumerator drivlist(m_options, gamename);
 	if (drivlist.count() == 0)
-		throw emu_fatalerror(EMU_ERR_NO_SUCH_GAME, "No matching games found for '%s'", gamename.c_str());
+		throw emu_fatalerror(EMU_ERR_NO_SUCH_GAME, "No matching games found for '%s'", gamename);
 
 	// iterate through matches
 	bool first = true;
@@ -554,12 +568,14 @@ void cli_frontend::listroms(const std::string &gamename)
 //  referenced by a given game or set of games
 //-------------------------------------------------
 
-void cli_frontend::listsamples(const std::string &gamename)
+void cli_frontend::listsamples(const std::vector<std::string> &args)
 {
+	const char *gamename = args.size() > 0 ? args[0].c_str() : nullptr;
+
 	// determine which drivers to output; return an error if none found
-	driver_enumerator drivlist(m_options, gamename.c_str());
+	driver_enumerator drivlist(m_options, gamename);
 	if (drivlist.count() == 0)
-		throw emu_fatalerror(EMU_ERR_NO_SUCH_GAME, "No matching games found for '%s'", gamename.c_str());
+		throw emu_fatalerror(EMU_ERR_NO_SUCH_GAME, "No matching games found for '%s'", gamename);
 
 	// iterate over drivers, looking for SAMPLES devices
 	bool first = true;
@@ -592,12 +608,14 @@ void cli_frontend::listsamples(const std::string &gamename)
 //  referenced by a given game or set of games
 //-------------------------------------------------
 
-void cli_frontend::listdevices(const std::string &gamename)
+void cli_frontend::listdevices(const std::vector<std::string> &args)
 {
+	const char *gamename = args.size() > 0 ? args[0].c_str() : nullptr;
+
 	// determine which drivers to output; return an error if none found
-	driver_enumerator drivlist(m_options, gamename.c_str());
+	driver_enumerator drivlist(m_options, gamename);
 	if (drivlist.count() == 0)
-		throw emu_fatalerror(EMU_ERR_NO_SUCH_GAME, "No matching games found for '%s'", gamename.c_str());
+		throw emu_fatalerror(EMU_ERR_NO_SUCH_GAME, "No matching games found for '%s'", gamename);
 
 	// iterate over drivers, looking for SAMPLES devices
 	bool first = true;
@@ -667,12 +685,14 @@ void cli_frontend::listdevices(const std::string &gamename)
 //  referenced by a given game or set of games
 //-------------------------------------------------
 
-void cli_frontend::listslots(const std::string &gamename)
+void cli_frontend::listslots(const std::vector<std::string> &args)
 {
+	const char *gamename = args.size() > 0 ? args[0].c_str() : nullptr;
+
 	// determine which drivers to output; return an error if none found
-	driver_enumerator drivlist(m_options, gamename.c_str());
+	driver_enumerator drivlist(m_options, gamename);
 	if (drivlist.count() == 0)
-		throw emu_fatalerror(EMU_ERR_NO_SUCH_GAME, "No matching games found for '%s'", gamename.c_str());
+		throw emu_fatalerror(EMU_ERR_NO_SUCH_GAME, "No matching games found for '%s'", gamename);
 
 	// print header
 	printf("%-16s %-16s %-16s %s\n", "SYSTEM", "SLOT NAME", "SLOT OPTIONS", "SLOT DEVICE NAME");
@@ -725,12 +745,14 @@ void cli_frontend::listslots(const std::string &gamename)
 //  referenced by a given game or set of games
 //-------------------------------------------------
 
-void cli_frontend::listmedia(const std::string &gamename)
+void cli_frontend::listmedia(const std::vector<std::string> &args)
 {
+	const char *gamename = args.size() > 0 ? args[0].c_str() : nullptr;
+
 	// determine which drivers to output; return an error if none found
-	driver_enumerator drivlist(m_options, gamename.c_str());
+	driver_enumerator drivlist(m_options, gamename);
 	if (drivlist.count() == 0)
-		throw emu_fatalerror(EMU_ERR_NO_SUCH_GAME, "No matching games found for '%s'", gamename.c_str());
+		throw emu_fatalerror(EMU_ERR_NO_SUCH_GAME, "No matching games found for '%s'", gamename);
 
 	// print header
 	printf("%-16s %-16s %-10s %s\n", "SYSTEM", "MEDIA NAME", "(brief)", "IMAGE FILE EXTENSIONS SUPPORTED");
@@ -777,10 +799,12 @@ void cli_frontend::listmedia(const std::string &gamename)
 //  verifyroms - verify the ROM sets of one or
 //  more games
 //-------------------------------------------------
-void cli_frontend::verifyroms(const std::string &gamename)
+void cli_frontend::verifyroms(const std::vector<std::string> &args)
 {
+	const char *gamename = args.size() > 0 ? args[0].c_str() : nullptr;
+
 	// determine which drivers to output;
-	driver_enumerator drivlist(m_options, gamename.c_str());
+	driver_enumerator drivlist(m_options, gamename);
 
 	unsigned correct = 0;
 	unsigned incorrect = 0;
@@ -809,7 +833,7 @@ void cli_frontend::verifyroms(const std::string &gamename)
 	for (device_type type : registered_device_types)
 	{
 		device_t *const dev = config.device_add(&config.root_device(), "_tmp", type, 0);
-		if (gamename.empty() || !core_strwildcmp(gamename.c_str(), dev->shortname()))
+		if (!gamename || !core_strwildcmp(gamename, dev->shortname()))
 		{
 			matched++;
 
@@ -830,15 +854,15 @@ void cli_frontend::verifyroms(const std::string &gamename)
 
 	// return an error if none found
 	if (matched == 0)
-		throw emu_fatalerror(EMU_ERR_NO_SUCH_GAME, "No matching games found for '%s'", gamename.c_str());
+		throw emu_fatalerror(EMU_ERR_NO_SUCH_GAME, "No matching games found for '%s'", gamename ? gamename : "");
 
 	// if we didn't get anything at all, display a generic end message
 	if (matched > 0 && correct == 0 && incorrect == 0)
 	{
 		if (notfound > 0)
-			throw emu_fatalerror(EMU_ERR_MISSING_FILES, "romset \"%s\" not found!\n", gamename.c_str());
+			throw emu_fatalerror(EMU_ERR_MISSING_FILES, "romset \"%s\" not found!\n", gamename ? gamename : "");
 		else
-			throw emu_fatalerror(EMU_ERR_MISSING_FILES, "romset \"%s\" has no roms!\n", gamename.c_str());
+			throw emu_fatalerror(EMU_ERR_MISSING_FILES, "romset \"%s\" has no roms!\n", gamename ? gamename : "");
 	}
 
 	// otherwise, print a summary
@@ -856,9 +880,9 @@ void cli_frontend::verifyroms(const std::string &gamename)
 //  one or more games
 //-------------------------------------------------
 
-void cli_frontend::verifysamples(const std::string &gamename_str)
+void cli_frontend::verifysamples(const std::vector<std::string> &args)
 {
-	const char *gamename = gamename_str.empty() ? "*" : gamename_str.c_str();
+	const char *gamename = args.size() == 0 ? "*" : args[0].c_str();
 
 	// determine which drivers to output; return an error if none found
 	driver_enumerator drivlist(m_options, gamename);
@@ -1092,16 +1116,18 @@ void cli_frontend::output_single_softlist(FILE *out, software_list_device &swlis
         identifying duplicate lists.
 -------------------------------------------------*/
 
-void cli_frontend::listsoftware(const std::string &gamename)
+void cli_frontend::listsoftware(const std::vector<std::string> &args)
 {
+	const char *gamename = args.size() > 0 ? args[0].c_str() : nullptr;
+
 	FILE *out = stdout;
 	std::unordered_set<std::string> list_map;
 	bool isfirst = true;
 
 	// determine which drivers to output; return an error if none found
-	driver_enumerator drivlist(m_options, gamename.c_str());
+	driver_enumerator drivlist(m_options, gamename);
 	if (drivlist.count() == 0)
-		throw emu_fatalerror(EMU_ERR_NO_SUCH_GAME, "No matching games found for '%s'", gamename.c_str());
+		throw emu_fatalerror(EMU_ERR_NO_SUCH_GAME, "No matching games found for '%s'", gamename);
 
 	while (drivlist.next())
 	{
@@ -1125,9 +1151,9 @@ void cli_frontend::listsoftware(const std::string &gamename)
     verifysoftware - verify roms from the software
     list of the specified driver(s)
 -------------------------------------------------*/
-void cli_frontend::verifysoftware(const std::string &gamename_str)
+void cli_frontend::verifysoftware(const std::vector<std::string> &args)
 {
-	const char *gamename = gamename_str.empty() ? "*" : gamename_str.c_str();
+	const char *gamename = args.size() > 0 ? args[0].c_str() : "*";
 
 	std::unordered_set<std::string> list_map;
 
@@ -1201,9 +1227,9 @@ void cli_frontend::verifysoftware(const std::string &gamename_str)
     getsoftlist - retrieve software list by name
 -------------------------------------------------*/
 
-void cli_frontend::getsoftlist(const std::string &gamename_str)
+void cli_frontend::getsoftlist(const std::vector<std::string> &args)
 {
-	const char *gamename = gamename_str.empty() ? "*" : gamename_str.c_str();
+	const char *gamename = args.size() > 0 ? args[0].c_str() : "*";
 
 	FILE *out = stdout;
 	std::unordered_set<std::string> list_map;
@@ -1231,9 +1257,9 @@ void cli_frontend::getsoftlist(const std::string &gamename_str)
 /*-------------------------------------------------
     verifysoftlist - verify software list by name
 -------------------------------------------------*/
-void cli_frontend::verifysoftlist(const std::string &gamename_str)
+void cli_frontend::verifysoftlist(const std::vector<std::string> &args)
 {
-	const char *gamename = gamename_str.empty() ? "*" : gamename_str.c_str();
+	const char *gamename = args.size() > 0 ? args[0].c_str() : "*";
 
 	std::unordered_set<std::string> list_map;
 	unsigned correct = 0;
@@ -1297,8 +1323,10 @@ void cli_frontend::verifysoftlist(const std::string &gamename_str)
 //  matches in our internal database
 //-------------------------------------------------
 
-void cli_frontend::romident(const std::string &filename)
+void cli_frontend::romident(const std::vector<std::string> &args)
 {
+	const char *filename = args[0].c_str();
+
 	// create our own copy of options for the purposes of ROM identification
 	// so we are not "polluted" with driver-specific slot/image options
 	emu_options options;
@@ -1308,8 +1336,8 @@ void cli_frontend::romident(const std::string &filename)
 	media_identifier ident(options);
 
 	// identify the file, then output results
-	osd_printf_info("Identifying %s....\n", filename.c_str());
-	ident.identify(filename.c_str());
+	osd_printf_info("Identifying %s....\n", filename);
+	ident.identify(filename);
 
 	// return the appropriate error code
 	if (ident.matches() == ident.total())
@@ -1411,27 +1439,29 @@ void cli_frontend::execute_commands(const char *exename)
 	static const struct
 	{
 		const char *option;
-		void (cli_frontend::*function)(const std::string &gamename);
+		int min_args;
+		int max_args;
+		void (cli_frontend::*function)(const std::vector<std::string> &args);
 	} info_commands[] =
 	{
-		{ CLICOMMAND_LISTXML,       &cli_frontend::listxml },
-		{ CLICOMMAND_LISTFULL,      &cli_frontend::listfull },
-		{ CLICOMMAND_LISTSOURCE,    &cli_frontend::listsource },
-		{ CLICOMMAND_LISTCLONES,    &cli_frontend::listclones },
-		{ CLICOMMAND_LISTBROTHERS,  &cli_frontend::listbrothers },
-		{ CLICOMMAND_LISTCRC,       &cli_frontend::listcrc },
-		{ CLICOMMAND_LISTDEVICES,   &cli_frontend::listdevices },
-		{ CLICOMMAND_LISTSLOTS,     &cli_frontend::listslots },
-		{ CLICOMMAND_LISTROMS,      &cli_frontend::listroms },
-		{ CLICOMMAND_LISTSAMPLES,   &cli_frontend::listsamples },
-		{ CLICOMMAND_VERIFYROMS,    &cli_frontend::verifyroms },
-		{ CLICOMMAND_VERIFYSAMPLES, &cli_frontend::verifysamples },
-		{ CLICOMMAND_LISTMEDIA,     &cli_frontend::listmedia },
-		{ CLICOMMAND_LISTSOFTWARE,  &cli_frontend::listsoftware },
-		{ CLICOMMAND_VERIFYSOFTWARE,&cli_frontend::verifysoftware },
-		{ CLICOMMAND_ROMIDENT,      &cli_frontend::romident },
-		{ CLICOMMAND_GETSOFTLIST,   &cli_frontend::getsoftlist },
-		{ CLICOMMAND_VERIFYSOFTLIST,&cli_frontend::verifysoftlist },
+		{ CLICOMMAND_LISTXML,			0, 1, &cli_frontend::listxml },
+		{ CLICOMMAND_LISTFULL,			0, 1, &cli_frontend::listfull },
+		{ CLICOMMAND_LISTSOURCE,		0, 1, &cli_frontend::listsource },
+		{ CLICOMMAND_LISTCLONES,		0, 1, &cli_frontend::listclones },
+		{ CLICOMMAND_LISTBROTHERS,		0, 1, &cli_frontend::listbrothers },
+		{ CLICOMMAND_LISTCRC,			0, 1, &cli_frontend::listcrc },
+		{ CLICOMMAND_LISTDEVICES,		0, 1, &cli_frontend::listdevices },
+		{ CLICOMMAND_LISTSLOTS,			0, 1, &cli_frontend::listslots },
+		{ CLICOMMAND_LISTROMS,			0, 1, &cli_frontend::listroms },
+		{ CLICOMMAND_LISTSAMPLES,		0, 1, &cli_frontend::listsamples },
+		{ CLICOMMAND_VERIFYROMS,		0, 1, &cli_frontend::verifyroms },
+		{ CLICOMMAND_VERIFYSAMPLES,		0, 1, &cli_frontend::verifysamples },
+		{ CLICOMMAND_LISTMEDIA,			0, 1, &cli_frontend::listmedia },
+		{ CLICOMMAND_LISTSOFTWARE,		0, 1, &cli_frontend::listsoftware },
+		{ CLICOMMAND_VERIFYSOFTWARE,	0, 1, &cli_frontend::verifysoftware },
+		{ CLICOMMAND_ROMIDENT,			1, 1, &cli_frontend::romident },
+		{ CLICOMMAND_GETSOFTLIST,		0, 1, &cli_frontend::getsoftlist },
+		{ CLICOMMAND_VERIFYSOFTLIST,	0, 1, &cli_frontend::verifysoftlist },
 	};
 
 	// find the command
@@ -1439,9 +1469,14 @@ void cli_frontend::execute_commands(const char *exename)
 	{
 		if (m_options.command() == info_command.option)
 		{
-			// parse any relevant INI files before proceeding
-			const char *sysname = m_options.system_name();
-			(this->*info_command.function)(sysname);
+			// validate argument count
+			if (m_options.command_arguments().size() < info_command.min_args)
+				throw emu_fatalerror(EMU_ERR_INVALID_CONFIG, "Auxillary verb -%s requires at least %d argument(s)", info_command.option, info_command.min_args);
+			if (m_options.command_arguments().size() > info_command.max_args)
+				throw emu_fatalerror(EMU_ERR_INVALID_CONFIG, "Auxillary verb -%s takes at most %d argument(s)", info_command.option, info_command.max_args);
+
+			// invoke the auxillary command!
+			(this->*info_command.function)(m_options.command_arguments());
 			return;
 		}
 	}

--- a/src/frontend/mame/clifront.cpp
+++ b/src/frontend/mame/clifront.cpp
@@ -319,7 +319,7 @@ int cli_frontend::execute(std::vector<std::string> &args)
 
 void cli_frontend::listxml(const std::vector<std::string> &args)
 {
-	const char *gamename = args.size() > 0 ? args[0].c_str() : nullptr;
+	const char *gamename = args.empty() ? nullptr : args[0].c_str();
 
 	// determine which drivers to output; return an error if none found
 	driver_enumerator drivlist(m_options, gamename);
@@ -339,7 +339,7 @@ void cli_frontend::listxml(const std::vector<std::string> &args)
 
 void cli_frontend::listfull(const std::vector<std::string> &args)
 {
-	const char *gamename = args.size() > 0 ? args[0].c_str() : nullptr;
+	const char *gamename = args.empty() ? nullptr : args[0].c_str();
 
 	// determine which drivers to output; return an error if none found
 	driver_enumerator drivlist(m_options, gamename);
@@ -363,7 +363,7 @@ void cli_frontend::listfull(const std::vector<std::string> &args)
 
 void cli_frontend::listsource(const std::vector<std::string> &args)
 {
-	const char *gamename = args.size() > 0 ? args[0].c_str() : nullptr;
+	const char *gamename = args.empty() ? nullptr : args[0].c_str();
 
 	// determine which drivers to output; return an error if none found
 	driver_enumerator drivlist(m_options, gamename);
@@ -383,7 +383,7 @@ void cli_frontend::listsource(const std::vector<std::string> &args)
 
 void cli_frontend::listclones(const std::vector<std::string> &args)
 {
-	const char *gamename = args.size() > 0 ? args[0].c_str() : nullptr;
+	const char *gamename = args.empty() ? nullptr : args[0].c_str();
 
 	// start with a filtered list of drivers
 	driver_enumerator drivlist(m_options, gamename);
@@ -432,7 +432,7 @@ void cli_frontend::listclones(const std::vector<std::string> &args)
 
 void cli_frontend::listbrothers(const std::vector<std::string> &args)
 {
-	const char *gamename = args.size() > 0 ? args[0].c_str() : nullptr;
+	const char *gamename = args.empty() ? nullptr : args[0].c_str();
 
 	// start with a filtered list of drivers; return an error if none found
 	driver_enumerator initial_drivlist(m_options, gamename);
@@ -477,7 +477,7 @@ void cli_frontend::listbrothers(const std::vector<std::string> &args)
 
 void cli_frontend::listcrc(const std::vector<std::string> &args)
 {
-	const char *gamename = args.size() > 0 ? args[0].c_str() : nullptr;
+	const char *gamename = args.empty() ? nullptr : args[0].c_str();
 
 	// determine which drivers to output; return an error if none found
 	driver_enumerator drivlist(m_options, gamename);
@@ -507,7 +507,7 @@ void cli_frontend::listcrc(const std::vector<std::string> &args)
 
 void cli_frontend::listroms(const std::vector<std::string> &args)
 {
-	const char *gamename = args.size() > 0 ? args[0].c_str() : nullptr;
+	const char *gamename = args.empty() ? nullptr : args[0].c_str();
 
 	// determine which drivers to output; return an error if none found
 	driver_enumerator drivlist(m_options, gamename);
@@ -570,7 +570,7 @@ void cli_frontend::listroms(const std::vector<std::string> &args)
 
 void cli_frontend::listsamples(const std::vector<std::string> &args)
 {
-	const char *gamename = args.size() > 0 ? args[0].c_str() : nullptr;
+	const char *gamename = args.empty() ? nullptr : args[0].c_str();
 
 	// determine which drivers to output; return an error if none found
 	driver_enumerator drivlist(m_options, gamename);
@@ -610,7 +610,7 @@ void cli_frontend::listsamples(const std::vector<std::string> &args)
 
 void cli_frontend::listdevices(const std::vector<std::string> &args)
 {
-	const char *gamename = args.size() > 0 ? args[0].c_str() : nullptr;
+	const char *gamename = args.empty() ? nullptr : args[0].c_str();
 
 	// determine which drivers to output; return an error if none found
 	driver_enumerator drivlist(m_options, gamename);
@@ -687,7 +687,7 @@ void cli_frontend::listdevices(const std::vector<std::string> &args)
 
 void cli_frontend::listslots(const std::vector<std::string> &args)
 {
-	const char *gamename = args.size() > 0 ? args[0].c_str() : nullptr;
+	const char *gamename = args.empty() ? nullptr : args[0].c_str();
 
 	// determine which drivers to output; return an error if none found
 	driver_enumerator drivlist(m_options, gamename);
@@ -747,7 +747,7 @@ void cli_frontend::listslots(const std::vector<std::string> &args)
 
 void cli_frontend::listmedia(const std::vector<std::string> &args)
 {
-	const char *gamename = args.size() > 0 ? args[0].c_str() : nullptr;
+	const char *gamename = args.empty() ? nullptr : args[0].c_str();
 
 	// determine which drivers to output; return an error if none found
 	driver_enumerator drivlist(m_options, gamename);
@@ -801,7 +801,7 @@ void cli_frontend::listmedia(const std::vector<std::string> &args)
 //-------------------------------------------------
 void cli_frontend::verifyroms(const std::vector<std::string> &args)
 {
-	const char *gamename = args.size() > 0 ? args[0].c_str() : nullptr;
+	const char *gamename = args.empty() ? nullptr : args[0].c_str();
 
 	// determine which drivers to output;
 	driver_enumerator drivlist(m_options, gamename);
@@ -882,7 +882,7 @@ void cli_frontend::verifyroms(const std::vector<std::string> &args)
 
 void cli_frontend::verifysamples(const std::vector<std::string> &args)
 {
-	const char *gamename = args.size() == 0 ? "*" : args[0].c_str();
+	const char *gamename = args.empty() ? "*" : args[0].c_str();
 
 	// determine which drivers to output; return an error if none found
 	driver_enumerator drivlist(m_options, gamename);
@@ -1118,7 +1118,7 @@ void cli_frontend::output_single_softlist(FILE *out, software_list_device &swlis
 
 void cli_frontend::listsoftware(const std::vector<std::string> &args)
 {
-	const char *gamename = args.size() > 0 ? args[0].c_str() : nullptr;
+	const char *gamename = args.empty() ? nullptr : args[0].c_str();
 
 	FILE *out = stdout;
 	std::unordered_set<std::string> list_map;
@@ -1442,26 +1442,27 @@ void cli_frontend::execute_commands(const char *exename)
 		int min_args;
 		int max_args;
 		void (cli_frontend::*function)(const std::vector<std::string> &args);
+		const char *usage;
 	} info_commands[] =
 	{
-		{ CLICOMMAND_LISTXML,			0, 1, &cli_frontend::listxml },
-		{ CLICOMMAND_LISTFULL,			0, 1, &cli_frontend::listfull },
-		{ CLICOMMAND_LISTSOURCE,		0, 1, &cli_frontend::listsource },
-		{ CLICOMMAND_LISTCLONES,		0, 1, &cli_frontend::listclones },
-		{ CLICOMMAND_LISTBROTHERS,		0, 1, &cli_frontend::listbrothers },
-		{ CLICOMMAND_LISTCRC,			0, 1, &cli_frontend::listcrc },
-		{ CLICOMMAND_LISTDEVICES,		0, 1, &cli_frontend::listdevices },
-		{ CLICOMMAND_LISTSLOTS,			0, 1, &cli_frontend::listslots },
-		{ CLICOMMAND_LISTROMS,			0, 1, &cli_frontend::listroms },
-		{ CLICOMMAND_LISTSAMPLES,		0, 1, &cli_frontend::listsamples },
-		{ CLICOMMAND_VERIFYROMS,		0, 1, &cli_frontend::verifyroms },
-		{ CLICOMMAND_VERIFYSAMPLES,		0, 1, &cli_frontend::verifysamples },
-		{ CLICOMMAND_LISTMEDIA,			0, 1, &cli_frontend::listmedia },
-		{ CLICOMMAND_LISTSOFTWARE,		0, 1, &cli_frontend::listsoftware },
-		{ CLICOMMAND_VERIFYSOFTWARE,	0, 1, &cli_frontend::verifysoftware },
-		{ CLICOMMAND_ROMIDENT,			1, 1, &cli_frontend::romident },
-		{ CLICOMMAND_GETSOFTLIST,		0, 1, &cli_frontend::getsoftlist },
-		{ CLICOMMAND_VERIFYSOFTLIST,	0, 1, &cli_frontend::verifysoftlist },
+		{ CLICOMMAND_LISTXML,			0, 1, &cli_frontend::listxml,			"[system name]" },
+		{ CLICOMMAND_LISTFULL,			0, 1, &cli_frontend::listfull,			"[system name]" },
+		{ CLICOMMAND_LISTSOURCE,		0, 1, &cli_frontend::listsource,		"[system name]" },
+		{ CLICOMMAND_LISTCLONES,		0, 1, &cli_frontend::listclones,		"[system name]" },
+		{ CLICOMMAND_LISTBROTHERS,		0, 1, &cli_frontend::listbrothers,		"[system name]" },
+		{ CLICOMMAND_LISTCRC,			0, 1, &cli_frontend::listcrc,			"[system name]" },
+		{ CLICOMMAND_LISTDEVICES,		0, 1, &cli_frontend::listdevices,		"[system name]" },
+		{ CLICOMMAND_LISTSLOTS,			0, 1, &cli_frontend::listslots,			"[system name]" },
+		{ CLICOMMAND_LISTROMS,			0, 1, &cli_frontend::listroms,			"[system name]" },
+		{ CLICOMMAND_LISTSAMPLES,		0, 1, &cli_frontend::listsamples,		"[system name]" },
+		{ CLICOMMAND_VERIFYROMS,		0, 1, &cli_frontend::verifyroms,		"[system name]" },
+		{ CLICOMMAND_VERIFYSAMPLES,		0, 1, &cli_frontend::verifysamples,		"[system name|*]" },
+		{ CLICOMMAND_LISTMEDIA,			0, 1, &cli_frontend::listmedia,			"[system name]" },
+		{ CLICOMMAND_LISTSOFTWARE,		0, 1, &cli_frontend::listsoftware,		"[system name]" },
+		{ CLICOMMAND_VERIFYSOFTWARE,	0, 1, &cli_frontend::verifysoftware,	"[system name|*]" },
+		{ CLICOMMAND_ROMIDENT,			1, 1, &cli_frontend::romident,			"(system name)" },
+		{ CLICOMMAND_GETSOFTLIST,		0, 1, &cli_frontend::getsoftlist,		"[system name|*]" },
+		{ CLICOMMAND_VERIFYSOFTLIST,	0, 1, &cli_frontend::verifysoftlist,	"[system name|*]" },
 	};
 
 	// find the command
@@ -1470,10 +1471,18 @@ void cli_frontend::execute_commands(const char *exename)
 		if (m_options.command() == info_command.option)
 		{
 			// validate argument count
+			const char *error_message = nullptr;
 			if (m_options.command_arguments().size() < info_command.min_args)
-				throw emu_fatalerror(EMU_ERR_INVALID_CONFIG, "Auxillary verb -%s requires at least %d argument(s)", info_command.option, info_command.min_args);
+				error_message = "Auxillary verb -%s requires at least %d argument(s)\n";
 			if (m_options.command_arguments().size() > info_command.max_args)
-				throw emu_fatalerror(EMU_ERR_INVALID_CONFIG, "Auxillary verb -%s takes at most %d argument(s)", info_command.option, info_command.max_args);
+				error_message = "Auxillary verb -%s takes at most %d argument(s)\n";
+			if (error_message)
+			{
+				osd_printf_info(error_message, info_command.option, info_command.max_args);
+				osd_printf_info("\n");
+				osd_printf_info("Usage:  %s -%s %s\n", exename, info_command.option, info_command.usage);
+				return;
+			}
 
 			// invoke the auxillary command!
 			(this->*info_command.function)(m_options.command_arguments());

--- a/src/frontend/mame/clifront.h
+++ b/src/frontend/mame/clifront.h
@@ -34,24 +34,24 @@ public:
 	int execute(std::vector<std::string> &args);
 
 	// direct access to the command operations
-	void listxml(const char *gamename = "*");
-	void listfull(const char *gamename = "*");
-	void listsource(const char *gamename = "*");
-	void listclones(const char *gamename = "*");
-	void listbrothers(const char *gamename = "*");
-	void listcrc(const char *gamename = "*");
-	void listroms(const char *gamename = "*");
-	void listsamples(const char *gamename = "*");
-	void listdevices(const char *gamename = "*");
-	void listslots(const char *gamename = "*");
-	void listmedia(const char *gamename = "*");
-	void listsoftware(const char *gamename = "*");
-	void verifysoftware(const char *gamename = "*");
-	void verifyroms(const char *gamename = "*");
-	void verifysamples(const char *gamename = "*");
-	void romident(const char *filename);
-	void getsoftlist(const char *gamename = "*");
-	void verifysoftlist(const char *gamename = "*");
+	void listxml(const std::string &gamename = "*");
+	void listfull(const std::string &gamename = "*");
+	void listsource(const std::string &gamename = "*");
+	void listclones(const std::string &gamename = "*");
+	void listbrothers(const std::string &gamename = "*");
+	void listcrc(const std::string &gamename = "*");
+	void listroms(const std::string &gamename = "*");
+	void listsamples(const std::string &gamename = "*");
+	void listdevices(const std::string &gamename = "*");
+	void listslots(const std::string &gamename = "*");
+	void listmedia(const std::string &gamename = "*");
+	void listsoftware(const std::string &gamename = "*");
+	void verifysoftware(const std::string &gamename = "*");
+	void verifyroms(const std::string &gamename = "*");
+	void verifysamples(const std::string &gamename = "*");
+	void romident(const std::string &filename);
+	void getsoftlist(const std::string &gamename = "*");
+	void verifysoftlist(const std::string &gamename = "*");
 
 private:
 	// internal helpers

--- a/src/frontend/mame/clifront.h
+++ b/src/frontend/mame/clifront.h
@@ -34,26 +34,28 @@ public:
 	int execute(std::vector<std::string> &args);
 
 	// direct access to the command operations
-	void listxml(const std::string &gamename = "*");
-	void listfull(const std::string &gamename = "*");
-	void listsource(const std::string &gamename = "*");
-	void listclones(const std::string &gamename = "*");
-	void listbrothers(const std::string &gamename = "*");
-	void listcrc(const std::string &gamename = "*");
-	void listroms(const std::string &gamename = "*");
-	void listsamples(const std::string &gamename = "*");
-	void listdevices(const std::string &gamename = "*");
-	void listslots(const std::string &gamename = "*");
-	void listmedia(const std::string &gamename = "*");
-	void listsoftware(const std::string &gamename = "*");
-	void verifysoftware(const std::string &gamename = "*");
-	void verifyroms(const std::string &gamename = "*");
-	void verifysamples(const std::string &gamename = "*");
-	void romident(const std::string &filename);
-	void getsoftlist(const std::string &gamename = "*");
-	void verifysoftlist(const std::string &gamename = "*");
 
 private:
+	// commands
+	void listxml(const std::vector<std::string> &args);
+	void listfull(const std::vector<std::string> &args);
+	void listsource(const std::vector<std::string> &args);
+	void listclones(const std::vector<std::string> &args);
+	void listbrothers(const std::vector<std::string> &args);
+	void listcrc(const std::vector<std::string> &args);
+	void listroms(const std::vector<std::string> &args);
+	void listsamples(const std::vector<std::string> &args);
+	void listdevices(const std::vector<std::string> &args);
+	void listslots(const std::vector<std::string> &args);
+	void listmedia(const std::vector<std::string> &args);
+	void listsoftware(const std::vector<std::string> &args);
+	void verifysoftware(const std::vector<std::string> &args);
+	void verifyroms(const std::vector<std::string> &args);
+	void verifysamples(const std::vector<std::string> &args);
+	void romident(const std::vector<std::string> &args);
+	void getsoftlist(const std::vector<std::string> &args);
+	void verifysoftlist(const std::vector<std::string> &args);
+
 	// internal helpers
 	void execute_commands(const char *exename);
 	void display_help(const char *exename);

--- a/src/lib/util/options.cpp
+++ b/src/lib/util/options.cpp
@@ -376,7 +376,6 @@ bool core_options::parse_command_line(std::vector<std::string> &args, int priori
 		// special case - collect unadorned arguments after commands into a special place
 		if (is_unadorned && !m_command.empty())
 		{
-			trim_spaces_and_quotes(args[arg]);
 			m_command_arguments.push_back(std::move(args[arg]));
 			args[arg].clear();
 			continue;
@@ -507,7 +506,9 @@ bool core_options::parse_ini_file(util::core_file &inifile, int priority, int ig
 		}
 
 		// set the new data
-		validate_and_set_data(*curentry->second, optiondata, priority, error_string);
+		std::string data = optiondata;
+		trim_spaces_and_quotes(data);
+		validate_and_set_data(*curentry->second, std::move(data), priority, error_string);
 	}
 	return true;
 }
@@ -861,8 +862,6 @@ void core_options::copyfrom(const core_options &src)
 
 bool core_options::validate_and_set_data(core_options::entry &curentry, std::string &&data, int priority, std::string &error_string)
 {
-	trim_spaces_and_quotes(data);
-
 	// let derived classes override how we set this data
 	if (override_set_value(curentry.name(), data))
 		return true;

--- a/src/lib/util/options.h
+++ b/src/lib/util/options.h
@@ -129,6 +129,7 @@ public:
 	// getters
 	entry *first() const { return m_entrylist.first(); }
 	const std::string &command() const { return m_command; }
+	const std::vector<std::string> &command_arguments() const { assert(!m_command.empty()); return m_command_arguments; }
 	entry *get_entry(const char *name) const;
 
 	// range iterators
@@ -201,6 +202,7 @@ private:
 	simple_list<entry>      m_entrylist;            // head of list of entries
 	std::unordered_map<std::string,entry *>       m_entrymap;             // map for fast lookup
 	std::string             m_command;              // command found
+	std::vector<std::string>	m_command_arguments;	// command arguments
 	static const char *const s_option_unadorned[];  // array of unadorned option "names"
 };
 


### PR DESCRIPTION
Made the following changes:
 1.  Fixed a bug where resolved slot/image options would choke -romident (reproducible in MAME 0.185 with 'mame64 -romident coco.zip')
 2.  'mame64 -romident' no longer crashes (though it doesn't do anything useful)
 3.  Changed the aux verb functions to take 'const std::string &'