### PR TITLE
Cleanups to src/frontend/mame/ui/slotopt.[cpp|h]

### DIFF
--- a/src/emu/dislot.h
+++ b/src/emu/dislot.h
@@ -145,6 +145,7 @@ public:
 	virtual std::string get_default_card_software(get_default_card_software_hook &hook) const { return std::string(); }
 	device_t *get_card_device() { return m_card_device; }
 	void set_card_device(device_t *dev) { m_card_device = dev; }
+	const char *slot_name() const { return device().tag() + 1; }
 
 private:
 	// internal state

--- a/src/frontend/mame/ui/slotopt.h
+++ b/src/frontend/mame/ui/slotopt.h
@@ -27,12 +27,10 @@ private:
 	virtual void populate(float &customtop, float &custombottom) override;
 	virtual void handle() override;
 
-	device_slot_option *slot_get_current_option(device_slot_interface &slot);
-	int slot_get_current_index(device_slot_interface &slot);
-	int slot_get_length(device_slot_interface &slot);
-	const char *slot_get_next(device_slot_interface &slot);
-	const char *slot_get_prev(device_slot_interface &slot);
-	const char *slot_get_option(device_slot_interface &slot, int index);
+	device_slot_option *get_current_option(device_slot_interface &slot) const;
+	int get_current_index(device_slot_interface &slot) const;
+	const char *get_next_slot(device_slot_interface &slot) const;
+	const char *get_previous_slot(device_slot_interface &slot) const;
 	void set_slot_device(device_slot_interface &slot, const char *val);
 };
 


### PR DESCRIPTION
Did the following:
  1.  Polished up residual traces of this code's pre-C++ heritage
  2.  Moved completely private code to an anonymous namespace
  3.  Created device_slot_interface::slot_name() to wrap the pattern of taking the tag and removing the initial colon