### PR TITLE
Adding hack to fish hashpath option out of INI files prior to softlist evaluation

### DIFF
--- a/src/frontend/mame/mameopts.cpp
+++ b/src/frontend/mame/mameopts.cpp
@@ -321,6 +321,11 @@ bool mame_options::parse_command_line(emu_options &options, std::vector<std::str
 	if (!options.parse_command_line(args, OPTION_PRIORITY_CMDLINE, error_string))
 		return false;
 
+	// in order to evaluate softlist options, we need to fish any hashpath variable out of INI files; this is
+	// because hashpath in particular can affect softlist evaluation
+	if (options.software_name()[0] != '\0' && options.read_config())
+		populate_hashpath_from_ini_files(options);
+
 	// identify any options as a result of softlists
 	auto softlist_opts = evaluate_initial_softlist_options(options);
 
@@ -690,3 +695,24 @@ bool mame_options::parse_one_ini(emu_options &options, const char *basename, int
 	return result;
 }
 
+
+//-------------------------------------------------
+//  populate_hashpath_from_ini_files
+//-------------------------------------------------
+
+void mame_options::populate_hashpath_from_ini_files(emu_options &options)
+{
+	// create temporary emu_options for the purposes of evaluating the INI files
+	emu_options temp_options;
+	std::string temp_error_string;
+	temp_options.set_value(OPTION_SYSTEMNAME, options.system_name(), OPTION_PRIORITY_MAXIMUM, temp_error_string);
+	temp_options.set_value(OPTION_INIPATH, options.ini_path(), OPTION_PRIORITY_MAXIMUM, temp_error_string);
+
+	// read the INIs into temp_options
+	parse_standard_inis(temp_options, temp_error_string);
+
+	// and fish out hashpath
+	const auto entry = temp_options.get_entry(OPTION_HASHPATH);
+	if (entry)
+		options.set_value(OPTION_HASHPATH, entry->value(), entry->priority(), temp_error_string);
+}

--- a/src/frontend/mame/mameopts.h
+++ b/src/frontend/mame/mameopts.h
@@ -80,6 +80,9 @@ private:
 	// softlist handling
 	static std::map<std::string, std::string> evaluate_initial_softlist_options(emu_options &options);
 
+	// special function to fish hashpath out of INI files - needed for softlist processing
+	static void populate_hashpath_from_ini_files(emu_options &options);
+
 	// represents an "invalid" value (an empty string is valid so we can't use that; what I
 	// really want to return is std::optional<std::string> but C++17 isn't here yet)
 	static std::string value_specifier_invalid_value() { return std::string("\x01\x02\x03"); }


### PR DESCRIPTION
eientei95 reported an error where the hashpath specified in INI files was not being honored in softlist evaluation.  This is a change to preprocess INI files for the sole purpose of finding the hashpath prior to evaluating softlists.