### PR TITLE
Fixed issue when the hash length is zero

### DIFF
--- a/src/devices/bus/a7800/a78_slot.cpp
+++ b/src/devices/bus/a7800/a78_slot.cpp
@@ -468,15 +468,6 @@ image_init_result a78_cart_slot_device::call_load()
 }
 
 
-void a78_partialhash(util::hash_collection &dest, const unsigned char *data,
-						unsigned long length, const char *functions)
-{
-	if (length <= 128)
-		return;
-	dest.compute(&data[128], length - 128, functions);
-}
-
-
 /*-------------------------------------------------
  call_unload
  -------------------------------------------------*/

--- a/src/devices/bus/a7800/a78_slot.h
+++ b/src/devices/bus/a7800/a78_slot.h
@@ -81,9 +81,6 @@ protected:
 };
 
 
-void a78_partialhash(util::hash_collection &dest, const unsigned char *data, unsigned long length, const char *functions);
-
-
 // ======================> a78_cart_slot_device
 
 class a78_cart_slot_device : public device_t,
@@ -114,7 +111,7 @@ public:
 	virtual bool is_reset_on_load() const override { return 1; }
 	virtual const char *image_interface() const override { return "a7800_cart"; }
 	virtual const char *file_extensions() const override { return "bin,a78"; }
-	virtual device_image_partialhash_func get_partial_hash() const override { return &a78_partialhash; }
+	virtual uint32_t unhashed_header_length() const override { return 128; }
 
 	// slot interface overrides
 	virtual std::string get_default_card_software(get_default_card_software_hook &hook) const override;

--- a/src/devices/bus/a7800/a78_slot.h
+++ b/src/devices/bus/a7800/a78_slot.h
@@ -111,7 +111,7 @@ public:
 	virtual bool is_reset_on_load() const override { return 1; }
 	virtual const char *image_interface() const override { return "a7800_cart"; }
 	virtual const char *file_extensions() const override { return "bin,a78"; }
-	virtual uint32_t unhashed_header_length() const override { return 128; }
+	virtual u32 unhashed_header_length() const override { return 128; }
 
 	// slot interface overrides
 	virtual std::string get_default_card_software(get_default_card_software_hook &hook) const override;

--- a/src/devices/bus/nes/nes_slot.cpp
+++ b/src/devices/bus/nes/nes_slot.cpp
@@ -1015,17 +1015,3 @@ WRITE8_MEMBER(nes_cart_slot_device::write_ex)
 		m_cart->set_open_bus(((offset + 0x4020) & 0xff00) >> 8);
 	}
 }
-
-
-//-------------------------------------------------
-//  partial hash function to be used by
-//  device_image_partialhash_func
-//-------------------------------------------------
-
-void nes_partialhash(util::hash_collection &dest, const unsigned char *data,
-						unsigned long length, const char *functions)
-{
-	if (length <= 16)
-		return;
-	dest.compute(&data[16], length - 16, functions);
-}

--- a/src/devices/bus/nes/nes_slot.h
+++ b/src/devices/bus/nes/nes_slot.h
@@ -362,7 +362,7 @@ public:
 	virtual bool is_reset_on_load() const override { return 1; }
 	virtual const char *image_interface() const override { return "nes_cart"; }
 	virtual const char *file_extensions() const override { return "nes,unf,unif"; }
-	virtual uint32_t unhashed_header_length() const override { return 16; }
+	virtual u32 unhashed_header_length() const override { return 16; }
 
 	// slot interface overrides
 	virtual std::string get_default_card_software(get_default_card_software_hook &hook) const override;

--- a/src/devices/bus/nes/nes_slot.h
+++ b/src/devices/bus/nes/nes_slot.h
@@ -331,8 +331,6 @@ protected:
 	std::vector<uint16_t> m_prg_bank_map;
 };
 
-void nes_partialhash(util::hash_collection &dest, const unsigned char *data, unsigned long length, const char *functions);
-
 // ======================> nes_cart_slot_device
 
 class nes_cart_slot_device : public device_t,
@@ -364,7 +362,7 @@ public:
 	virtual bool is_reset_on_load() const override { return 1; }
 	virtual const char *image_interface() const override { return "nes_cart"; }
 	virtual const char *file_extensions() const override { return "nes,unf,unif"; }
-	virtual device_image_partialhash_func get_partial_hash() const override { return &nes_partialhash; }
+	virtual uint32_t unhashed_header_length() const override { return 16; }
 
 	// slot interface overrides
 	virtual std::string get_default_card_software(get_default_card_software_hook &hook) const override;

--- a/src/emu/diimage.cpp
+++ b/src/emu/diimage.cpp
@@ -496,28 +496,28 @@ bool device_image_interface::load_software_region(const char *tag, optional_shar
 // to be loaded
 // ****************************************************************************
 
-bool device_image_interface::run_hash(util::core_file &file, uint32_t skip_bytes, util::hash_collection &hashes, const char *types)
+bool device_image_interface::run_hash(util::core_file &file, u32 skip_bytes, util::hash_collection &hashes, const char *types)
 {
 	// reset the hash; we want to override existing data
 	hashes.reset();
 
 	// figure out the size, and "cap" the skip bytes
-	uint64_t size = file.size();
-	skip_bytes = (uint32_t) std::min((uint64_t) skip_bytes, size);
+	u64 size = file.size();
+	skip_bytes = (u32) std::min((u64) skip_bytes, size);
 
 	// seek to the beginning
 	file.seek(skip_bytes, SEEK_SET);
-	uint64_t position = skip_bytes;
+	u64 position = skip_bytes;
 
 	// keep on reading hashes
 	hashes.begin(types);
-	while(position < size)
+	while (position < size)
 	{
 		uint8_t buffer[8192];
 
 		// read bytes
-		const uint32_t count = (uint32_t) std::min(size - position, (uint64_t) sizeof(buffer));
-		const uint32_t actual_count = file.read(buffer, count);
+		const u32 count = (u32) std::min(size - position, (u64) sizeof(buffer));
+		const u32 actual_count = file.read(buffer, count);
 		if (actual_count == 0)
 			return false;
 		position += actual_count;		
@@ -561,7 +561,8 @@ util::hash_collection device_image_interface::calculate_hash_on_file(util::core_
 {
 	// calculate the hash
 	util::hash_collection hash;
-	run_hash(file, unhashed_header_length(), hash, util::hash_collection::HASH_TYPES_ALL);
+	if (!run_hash(file, unhashed_header_length(), hash, util::hash_collection::HASH_TYPES_ALL))
+		hash.reset();
 	return hash;
 }
 

--- a/src/emu/diimage.cpp
+++ b/src/emu/diimage.cpp
@@ -516,23 +516,28 @@ bool device_image_interface::load_software_region(const char *tag, optional_shar
 void device_image_interface::run_hash(util::core_file &file, void (*partialhash)(util::hash_collection &, const unsigned char *, unsigned long, const char *),
 	util::hash_collection &hashes, const char *types)
 {
-	u32 size;
-	std::vector<u8> buf;
+	// instantiate the vector
+	u32 size = (u32) file.size();
+	if (size != file.size())
+		throw false;
+	std::vector<u8> buf((size_t)size);
 
-	hashes.reset();
-	size = (u32) file.size();
+	// get a pointer
+	u8 *ptr = size > 0 ? &buf[0] : nullptr;
 
-	buf.resize(size);
-	memset(&buf[0], 0, size);
+	// clear it out
+	memset(ptr, 0, size);
 
 	// read the file
 	file.seek(0, SEEK_SET);
-	file.read(&buf[0], size);
-
+	file.read(ptr, size);
+	
+	// get the hashes
+	hashes.reset();
 	if (partialhash)
-		partialhash(hashes, &buf[0], size, types);
+		partialhash(hashes, ptr, size, types);
 	else
-		hashes.compute(&buf[0], size, types);
+		hashes.compute(ptr, size, types);
 
 	// cleanup
 	file.seek(0, SEEK_SET);

--- a/src/emu/diimage.h
+++ b/src/emu/diimage.h
@@ -105,8 +105,6 @@ enum class image_verify_result { PASS, FAIL };
 // device image interface function types
 typedef delegate<image_init_result (device_image_interface &)> device_image_load_delegate;
 typedef delegate<void (device_image_interface &)> device_image_func_delegate;
-// legacy
-typedef void (*device_image_partialhash_func)(util::hash_collection &, const unsigned char *, unsigned long, const char *);
 
 //**************************************************************************
 //  MACROS
@@ -144,13 +142,11 @@ public:
 	static const char *device_brieftypename(iodevice_t type);
 	static iodevice_t device_typeid(const char *name);
 
-	virtual void device_compute_hash(util::hash_collection &hashes, const void *data, size_t length, const char *types) const;
-
 	virtual image_init_result call_load() { return image_init_result::PASS; }
 	virtual image_init_result call_create(int format_type, util::option_resolution *format_options) { return image_init_result::PASS; }
 	virtual void call_unload() { }
 	virtual std::string call_display() { return std::string(); }
-	virtual device_image_partialhash_func get_partial_hash() const { return nullptr; }
+	virtual uint32_t unhashed_header_length() const { return 0; }
 	virtual bool core_opens_image_file() const { return true; }
 	virtual iodevice_t image_type()  const = 0;
 	virtual bool is_readable()  const = 0;
@@ -313,7 +309,7 @@ private:
 	bool load_software_part(const std::string &identifier);
 
 	bool init_phase() const;
-	static void run_hash(util::core_file &file, void(*partialhash)(util::hash_collection &, const unsigned char *, unsigned long, const char *), util::hash_collection &hashes, const char *types);
+	static void run_hash(util::core_file &file, uint32_t skip_bytes, util::hash_collection &hashes, const char *types);
 
 	// loads an image or software items and resets - called internally when we
 	// load an is_reset_on_load() item

--- a/src/emu/diimage.h
+++ b/src/emu/diimage.h
@@ -271,7 +271,7 @@ protected:
 
 	void make_readonly() { m_readonly = true; }
 
-	void image_checkhash();
+	bool image_checkhash();
 
 	const software_part *find_software_item(const std::string &identifier, bool restrict_to_interface, software_list_device **device = nullptr) const;
 	std::string software_get_default_slot(const char *default_card_slot) const;
@@ -309,7 +309,7 @@ private:
 	bool load_software_part(const std::string &identifier);
 
 	bool init_phase() const;
-	static void run_hash(util::core_file &file, uint32_t skip_bytes, util::hash_collection &hashes, const char *types);
+	static bool run_hash(util::core_file &file, uint32_t skip_bytes, util::hash_collection &hashes, const char *types);
 
 	// loads an image or software items and resets - called internally when we
 	// load an is_reset_on_load() item

--- a/src/emu/diimage.h
+++ b/src/emu/diimage.h
@@ -309,7 +309,7 @@ private:
 	bool load_software_part(const std::string &identifier);
 
 	bool init_phase() const;
-	static bool run_hash(util::core_file &file, uint32_t skip_bytes, util::hash_collection &hashes, const char *types);
+	static bool run_hash(util::core_file &file, u32 skip_bytes, util::hash_collection &hashes, const char *types);
 
 	// loads an image or software items and resets - called internally when we
 	// load an is_reset_on_load() item

--- a/src/emu/diimage.h
+++ b/src/emu/diimage.h
@@ -146,7 +146,7 @@ public:
 	virtual image_init_result call_create(int format_type, util::option_resolution *format_options) { return image_init_result::PASS; }
 	virtual void call_unload() { }
 	virtual std::string call_display() { return std::string(); }
-	virtual uint32_t unhashed_header_length() const { return 0; }
+	virtual u32 unhashed_header_length() const { return 0; }
 	virtual bool core_opens_image_file() const { return true; }
 	virtual iodevice_t image_type()  const = 0;
 	virtual bool is_readable()  const = 0;


### PR DESCRIPTION
The following is illegal, even if no elements in the pointer are accessed:

	std::vector<my_struct> my_vec(0);	// create an empty std::vector
	my_struct *ptr = &my_vec[0];

While this is a degenerate scenario, this should be fixed