### PR TITLE
fix mitchell.cpp nvram saving

### DIFF
--- a/src/mame/drivers/mitchell.cpp
+++ b/src/mame/drivers/mitchell.cpp
@@ -2303,27 +2303,31 @@ DRIVER_INIT_MEMBER(mitchell_state,hatena)
 DRIVER_INIT_MEMBER(mitchell_state,spang)
 {
 	m_input_type = 3;
-	m_nvram->set_base(&memregion("maincpu")->base()[0xe000], 0x80); /* NVRAM */
+	m_nvram->set_base(m_mainram, m_mainram.bytes());
+	// m_nvram->set_base(m_mainram, 0x80);
 	configure_banks(spang_decode);
 }
 
 DRIVER_INIT_MEMBER(mitchell_state,spangbl)
 {
 	m_input_type = 3;
-	m_nvram->set_base(&memregion("maincpu")->base()[0xe000], 0x80); /* NVRAM */
+	m_nvram->set_base(m_mainram, m_mainram.bytes());
+	// m_nvram->set_base(m_mainram, 0x80);
 	bootleg_decode();
 }
 
 DRIVER_INIT_MEMBER(mitchell_state,spangj)
 {
 	m_input_type = 3;
-	m_nvram->set_base(&memregion("maincpu")->base()[0xe000], 0x80); /* NVRAM */
+	m_nvram->set_base(m_mainram, m_mainram.bytes());
+	// m_nvram->set_base(m_mainram, 0x80);
 	configure_banks(spangj_decode);
 }
 DRIVER_INIT_MEMBER(mitchell_state,sbbros)
 {
 	m_input_type = 3;
-	m_nvram->set_base(&memregion("maincpu")->base()[0xe000], 0x80); /* NVRAM */
+	m_nvram->set_base(m_mainram, m_mainram.bytes());
+	// m_nvram->set_base(m_mainram, 0x80);
 	configure_banks(sbbros_decode);
 }
 DRIVER_INIT_MEMBER(mitchell_state,qtono1)
@@ -2367,13 +2371,15 @@ DRIVER_INIT_MEMBER(mitchell_state,marukin)
 DRIVER_INIT_MEMBER(mitchell_state,block)
 {
 	m_input_type = 2;
-	m_nvram->set_base(&memregion("maincpu")->base()[0xff80], 0x80); /* NVRAM */
+	m_nvram->set_base(m_mainram, m_mainram.bytes());
+	// m_nvram->set_base(m_mainram+0x1f80, 0x80);
 	configure_banks(block_decode);
 }
 DRIVER_INIT_MEMBER(mitchell_state,blockbl)
 {
 	m_input_type = 2;
-	m_nvram->set_base(&memregion("maincpu")->base()[0xff80], 0x80); /* NVRAM */
+	m_nvram->set_base(m_mainram, m_mainram.bytes());
+	// m_nvram->set_base(m_mainram+0x1f80, 0x80);
 	bootleg_decode();
 }
 

--- a/src/mame/drivers/mitchell.cpp
+++ b/src/mame/drivers/mitchell.cpp
@@ -2304,7 +2304,6 @@ DRIVER_INIT_MEMBER(mitchell_state,spang)
 {
 	m_input_type = 3;
 	m_nvram->set_base(m_mainram, m_mainram.bytes());
-	// m_nvram->set_base(m_mainram, 0x80);
 	configure_banks(spang_decode);
 }
 
@@ -2312,7 +2311,6 @@ DRIVER_INIT_MEMBER(mitchell_state,spangbl)
 {
 	m_input_type = 3;
 	m_nvram->set_base(m_mainram, m_mainram.bytes());
-	// m_nvram->set_base(m_mainram, 0x80);
 	bootleg_decode();
 }
 
@@ -2320,14 +2318,12 @@ DRIVER_INIT_MEMBER(mitchell_state,spangj)
 {
 	m_input_type = 3;
 	m_nvram->set_base(m_mainram, m_mainram.bytes());
-	// m_nvram->set_base(m_mainram, 0x80);
 	configure_banks(spangj_decode);
 }
 DRIVER_INIT_MEMBER(mitchell_state,sbbros)
 {
 	m_input_type = 3;
 	m_nvram->set_base(m_mainram, m_mainram.bytes());
-	// m_nvram->set_base(m_mainram, 0x80);
 	configure_banks(sbbros_decode);
 }
 DRIVER_INIT_MEMBER(mitchell_state,qtono1)
@@ -2372,14 +2368,12 @@ DRIVER_INIT_MEMBER(mitchell_state,block)
 {
 	m_input_type = 2;
 	m_nvram->set_base(m_mainram, m_mainram.bytes());
-	// m_nvram->set_base(m_mainram+0x1f80, 0x80);
 	configure_banks(block_decode);
 }
 DRIVER_INIT_MEMBER(mitchell_state,blockbl)
 {
 	m_input_type = 2;
 	m_nvram->set_base(m_mainram, m_mainram.bytes());
-	// m_nvram->set_base(m_mainram+0x1f80, 0x80);
 	bootleg_decode();
 }
 

--- a/src/mame/includes/mitchell.h
+++ b/src/mame/includes/mitchell.h
@@ -30,6 +30,7 @@ public:
 		m_soundlatch(*this, "soundlatch"),
 		m_colorram(*this, "colorram"),
 		m_videoram(*this, "videoram"),
+		m_mainram(*this, "ram"),
 		m_bank1(*this, "bank1"),
 		m_bank0d(*this, "bank0d"),
 		m_bank1d(*this, "bank1d"),
@@ -50,6 +51,7 @@ public:
 	/* memory pointers */
 	required_shared_ptr<uint8_t> m_colorram;
 	required_shared_ptr<uint8_t> m_videoram;
+	optional_shared_ptr<uint8_t> m_mainram;
 	required_memory_bank m_bank1;
 	optional_memory_bank m_bank0d;
 	optional_memory_bank m_bank1d;


### PR DESCRIPTION
this must have been broken for a while, it was assuming that MAME used the CPU region as RAM for 8-bit CPUs and that hasn't been an valid for a long time. (15+ years?)  As a result data wasn't being saved / restored properly at all.

Corrado Tomaselli noticed this when playing with his Super Pang PCB, after replacing a hacked set with a proper original + Kabuki battery he noticed the game no longer showed '8Mhz Original Board' on bootup.  This is because the battery also backs up at least part of main RAM, and it only displays that string the first time it initializes main ram.

The previous MAME code only tried to save 0x80 bytes of the RAM, with a different location for some games.  I've left that behavior commented in case it turns out the original does only save that area, but it seems more likely it just backs up the whole of the RAM.




