### PR TITLE
Fix for a segfault when emulating HP9895 drive

### DIFF
--- a/src/devices/imagedev/floppy.cpp
+++ b/src/devices/imagedev/floppy.cpp
@@ -845,6 +845,12 @@ void floppy_image_device::write_flux(const attotime &start, const attotime &end,
 
 void floppy_image_device::write_zone(uint32_t *buf, int &cells, int &index, uint32_t spos, uint32_t epos, uint32_t mg)
 {
+	spos = std::min(spos , 200000000U);
+	epos = std::min(epos , 200000000U);
+    if (spos >= epos) {
+		return;
+	}
+
 	while(spos < epos) {
 		while(index != cells-1 && (buf[index+1] & floppy_image::TIME_MASK) <= spos)
 			index++;


### PR DESCRIPTION
Hi,
this commit fixes a segfault that sometimes happens when formatting a floppy in an emulated HP9895 drive.
It is caused by spos being > epos (and both > 2E8) when floppy_image_device::write_zone is called.
I don't think this fix should cause regression in other floppy drives but I couldn't test it.
Thanks.
--F.Ulivi
