### PR TITLE
Fix for a segfault when emulating HP9895 drive (take 2)

### DIFF
--- a/src/devices/imagedev/floppy.cpp
+++ b/src/devices/imagedev/floppy.cpp
@@ -737,7 +737,14 @@ uint32_t floppy_image_device::find_position(attotime &base, const attotime &when
 		base -= rev_time;
 	}
 
-	return (delta*floppy_ratio_1).as_ticks(1000000000/1000);
+	uint32_t res = (delta*floppy_ratio_1).as_ticks(1000000000/1000);
+	if (res > 200000000) {
+		// Due to rounding errors in the previous operation,
+		// 'res' sometimes overflows 2E+8
+		res -= 200000000;
+		base += rev_time;
+	}
+	return res;
 }
 
 attotime floppy_image_device::get_next_index_time(std::vector<uint32_t> &buf, int index, int delta, attotime base)

--- a/src/devices/imagedev/floppy.cpp
+++ b/src/devices/imagedev/floppy.cpp
@@ -845,6 +845,12 @@ void floppy_image_device::write_flux(const attotime &start, const attotime &end,
 
 void floppy_image_device::write_zone(uint32_t *buf, int &cells, int &index, uint32_t spos, uint32_t epos, uint32_t mg)
 {
+	spos = std::min(spos , 200000000U);
+	epos = std::min(epos , 200000000U);
+    if (spos >= epos) {
+		return;
+	}
+
 	while(spos < epos) {
 		while(index != cells-1 && (buf[index+1] & floppy_image::TIME_MASK) <= spos)
 			index++;

--- a/src/devices/imagedev/floppy.cpp
+++ b/src/devices/imagedev/floppy.cpp
@@ -845,12 +845,6 @@ void floppy_image_device::write_flux(const attotime &start, const attotime &end,
 
 void floppy_image_device::write_zone(uint32_t *buf, int &cells, int &index, uint32_t spos, uint32_t epos, uint32_t mg)
 {
-	spos = std::min(spos , 200000000U);
-	epos = std::min(epos , 200000000U);
-    if (spos >= epos) {
-		return;
-	}
-
 	while(spos < epos) {
 		while(index != cells-1 && (buf[index+1] & floppy_image::TIME_MASK) <= spos)
 			index++;


### PR DESCRIPTION
Hi,
this is the 2nd attempt to fix the bug that sometimes caused segfaults when emulating hp9895 drive. My previous attempt was in PR #2319.
I think this addresses the problem better. It was due to a rounding error in floppy_image_device::find_position function that overflowed the "sacred" 2E+8 limit.
Thanks.
--F.Ulivi
