### PR TITLE
[Ram Device] Better detection of bad -ramsize strings, move some private code to anonymous namespace

### DIFF
--- a/src/devices/machine/ram.cpp
+++ b/src/devices/machine/ram.cpp
@@ -17,6 +17,87 @@
 #include <algorithm>
 
 
+namespace {
+
+//-------------------------------------------------
+//  parse_string - convert a ram string to an
+//  integer value
+//-------------------------------------------------
+
+uint32_t parse_string(const char *s)
+{
+	unsigned ram;
+	char suffix;
+	char extraneous;
+
+	switch (sscanf(s, "%u%c%c", &ram, &suffix, &extraneous))
+	{
+	case 1:
+		// no suffix; proceed
+		break;
+
+	case 2:
+		// suffix present; must interpret it
+		switch (tolower(suffix))
+		{
+		case 'k':
+			// kilobytes
+			ram *= 1024;
+			break;
+
+		case 'm':
+			// megabytes
+			ram *= 1024 * 1024;
+			break;
+
+		default:
+			// parse failure
+			ram = 0;
+			break;
+		}
+		break;
+
+	default:
+		// parse failure
+		ram = 0;
+		break;
+	}
+	return ram;
+}
+
+
+//-------------------------------------------------
+//  calculate_extra_options
+//-------------------------------------------------
+
+std::vector<uint32_t> calculate_extra_options(const char *extra_options_string, std::string *bad_option)
+{
+	std::vector<uint32_t> result;
+	std::string options(extra_options_string);
+
+	bool done = false;
+	for (std::string::size_type start = 0, end = options.find_first_of(','); !done; start = end + 1, end = options.find_first_of(',', start))
+	{
+		// parse the option
+		const std::string ram_option_string = options.substr(start, (end == -1) ? -1 : end - start);
+		const uint32_t ram_option = parse_string(ram_option_string.c_str());
+		if (ram_option == 0)
+		{
+			if (bad_option)
+				*bad_option = std::move(ram_option_string);
+			return result;
+		}
+
+		// and add it to the results
+		result.push_back(ram_option);
+		done = end == std::string::npos;
+	}
+	return result;
+}
+
+};
+
+
 /*****************************************************************************
     LIVE DEVICE
 *****************************************************************************/
@@ -122,44 +203,6 @@ bool ram_device::is_valid_size(uint32_t size) const
 
 
 //-------------------------------------------------
-//  parse_string - convert a ram string to an
-//  integer value
-//-------------------------------------------------
-
-uint32_t ram_device::parse_string(const char *s)
-{
-	uint32_t ram;
-	char suffix = '\0';
-
-	sscanf(s, "%u%c", &ram, &suffix);
-
-	switch(tolower(suffix))
-	{
-		case 'k':
-			/* kilobytes */
-			ram *= 1024;
-			break;
-
-		case 'm':
-			/* megabytes */
-			ram *= 1024*1024;
-			break;
-
-		case '\0':
-			/* no suffix */
-			break;
-
-		default:
-			/* parse failure */
-			ram = 0;
-			break;
-	}
-
-	return ram;
-}
-
-
-//-------------------------------------------------
 //  default_size
 //-------------------------------------------------
 
@@ -178,34 +221,4 @@ const std::vector<uint32_t> &ram_device::extra_options(void) const
 	if (m_extra_options_string && m_extra_options.empty())
 		m_extra_options = calculate_extra_options(m_extra_options_string, nullptr);
 	return m_extra_options;
-}
-
-
-//-------------------------------------------------
-//  calculate_extra_options
-//-------------------------------------------------
-
-std::vector<uint32_t> ram_device::calculate_extra_options(const char *extra_options_string, std::string *bad_option)
-{
-	std::vector<uint32_t> result;
-	std::string options(extra_options_string);
-
-	bool done = false;
-	for (std::string::size_type start = 0, end = options.find_first_of(','); !done; start = end + 1, end = options.find_first_of(',', start))
-	{
-		// parse the option
-		const std::string ram_option_string = options.substr(start, (end == -1) ? -1 : end - start);
-		const uint32_t ram_option = parse_string(ram_option_string.c_str());
-		if (ram_option == 0)
-		{
-			if (bad_option)
-				*bad_option = std::move(ram_option_string);
-			return result;
-		}
-
-		// and add it to the results
-		result.push_back(ram_option);
-		done = end == std::string::npos;
-	}
-	return result;
 }

--- a/src/devices/machine/ram.h
+++ b/src/devices/machine/ram.h
@@ -76,8 +76,6 @@ protected:
 	virtual void device_validity_check(validity_checker &valid) const override;
 
 private:
-	static std::vector<uint32_t> calculate_extra_options(const char *extra_options_string, std::string *bad_option);
-	static uint32_t parse_string(const char *s);
 	bool is_valid_size(uint32_t size) const;
 
 	// device state


### PR DESCRIPTION
There was a longstanding bug where '-ramsize 16kfoo' would be treated as '-ramsize 16k'