### PR TITLE
Changed the profiler so that TEXT_UPDATE_TIME also applies to real time

### DIFF
--- a/src/emu/profiler.h
+++ b/src/emu/profiler.h
@@ -168,7 +168,8 @@ private:
 	// internal state
 	filo_entry *        m_filoptr;                  // current FILO index
 	std::string         m_text;                     // profiler text
-	attotime            m_text_time;                // profiler text last update
+	attotime            m_text_emu_time;            // profiler text last update (emulated time)
+	osd_ticks_t         m_text_real_time;           // profiler text last update (real time)
 	filo_entry          m_filo[32];                 // array of FILO entries
 	osd_ticks_t         m_data[PROFILER_TOTAL + 1]; // array of data
 };


### PR DESCRIPTION
Previously, TEXT_UPDATE_TIME (specified at a half of a second) was the minimum amount of emulated time after which the profiler would update itself.  With this change, we check both emulated and real time and only update if TEXT_UPDATE_TIME elapsed for both types of time.