### PR TITLE
[CoCo] Changed device_cococart_interface implementations to do dynamic_casts at config completion

### DIFF
--- a/src/devices/bus/coco/coco_fdc.h
+++ b/src/devices/bus/coco/coco_fdc.h
@@ -37,7 +37,6 @@ protected:
 		: device_t(mconfig, type, tag, owner, clock)
 		, device_cococart_interface(mconfig, *this)
 	{
-		m_owner = dynamic_cast<cococart_slot_device *>(owner);
 	};
 
 	// device-level overrides
@@ -51,7 +50,7 @@ protected:
 	// wrapper for setting the cart line
 	void cart_set_line(cococart_slot_device::line which, cococart_slot_device::line_value value)
 	{
-		m_owner->set_line_value(which, value);
+		owning_slot().set_line_value(which, value);
 	}
 	void cart_set_line(cococart_slot_device::line which, bool value)
 	{
@@ -65,9 +64,6 @@ protected:
 	void set_dskreg(uint8_t data) { m_dskreg = data; }
 
 private:
-	// internal state
-	cococart_slot_device *m_owner;
-
 	// registers
 	uint8_t m_dskreg;
 	bool m_intrq;

--- a/src/devices/bus/coco/coco_multi.cpp
+++ b/src/devices/bus/coco/coco_multi.cpp
@@ -117,7 +117,6 @@ namespace
 		uint8_t m_select;
 
 		// internal accessors
-		cococart_slot_device &owning_slot();
 		int active_scs_slot_number() const;
 		int active_cts_slot_number() const;
 		cococart_slot_device &slot(int slot_number);
@@ -232,12 +231,6 @@ void coco_multipak_device::device_reset()
 //**************************************************************************
 //  INTERNAL ACCESSORS
 //**************************************************************************
-
-cococart_slot_device &coco_multipak_device::owning_slot()
-{
-	return *dynamic_cast<cococart_slot_device *>(owner());
-}
-
 
 //-------------------------------------------------
 //  active_scs_slot_number

--- a/src/devices/bus/coco/coco_pak.cpp
+++ b/src/devices/bus/coco/coco_pak.cpp
@@ -69,7 +69,6 @@ coco_pak_device::coco_pak_device(const machine_config &mconfig, const char *tag,
 void coco_pak_device::device_start()
 {
 	m_cart = dynamic_cast<device_image_interface *>(owner());
-	m_owner = dynamic_cast<cococart_slot_device *>(owner());
 }
 
 

--- a/src/devices/bus/coco/coco_t4426.cpp
+++ b/src/devices/bus/coco/coco_t4426.cpp
@@ -111,7 +111,6 @@ namespace
 
 		// internal state
 		device_image_interface *m_cart;
-		cococart_slot_device *m_owner;
 		uint8_t m_select;
 
 		optional_ioport m_autostart;
@@ -189,7 +188,6 @@ coco_t4426_device::coco_t4426_device(const machine_config &mconfig, device_type 
 	: device_t(mconfig, type, tag, owner, clock)
 	, device_cococart_interface(mconfig, *this)
 	, m_cart(nullptr)
-	, m_owner(nullptr)
 	, m_select(0)
 	, m_autostart(*this, CART_AUTOSTART_TAG)
 	, m_uart(*this, UART_TAG)
@@ -210,7 +208,6 @@ void coco_t4426_device::device_start()
 {
 	LOG("%s()\n", FUNCNAME );
 	m_cart = dynamic_cast<device_image_interface *>(owner());
-	m_owner = dynamic_cast<cococart_slot_device *>(owner());
 }
 
 
@@ -242,7 +239,7 @@ void coco_t4426_device::device_reset()
 {
 	LOG("%s()\n", FUNCNAME );
 	auto cart_line = cococart_slot_device::line_value::Q;
-	m_owner->set_line_value(cococart_slot_device::line::CART, cart_line);
+	set_line_value(cococart_slot_device::line::CART, cart_line);
 }
 
 /*-------------------------------------------------

--- a/src/devices/bus/coco/cococart.cpp
+++ b/src/devices/bus/coco/cococart.cpp
@@ -451,11 +451,22 @@ device_cococart_interface::~device_cococart_interface()
 void device_cococart_interface::interface_config_complete()
 {
 	m_owning_slot = dynamic_cast<cococart_slot_device *>(device().owner());
+	m_host = m_owning_slot
+		? dynamic_cast<device_cococart_host_interface *>(m_owning_slot->owner())
+		: nullptr;
+}
+
+
+//-------------------------------------------------
+//  interface_pre_start
+//-------------------------------------------------
+
+void device_cococart_interface::interface_pre_start()
+{
 	if (!m_owning_slot)
-		throw new emu_fatalerror("Expected device().owner() to be of type cococart_slot_device");
-	m_host = dynamic_cast<device_cococart_host_interface *>(m_owning_slot->owner());
+		throw emu_fatalerror("Expected device().owner() to be of type cococart_slot_device");
 	if (!m_host)
-		throw new emu_fatalerror("Expected m_owning_slot->owner() to be of type device_cococart_host_interface");
+		throw emu_fatalerror("Expected m_owning_slot->owner() to be of type device_cococart_host_interface");
 }
 
 

--- a/src/devices/bus/coco/cococart.cpp
+++ b/src/devices/bus/coco/cococart.cpp
@@ -429,6 +429,8 @@ std::string cococart_slot_device::get_default_card_software(get_default_card_sof
 
 device_cococart_interface::device_cococart_interface(const machine_config &mconfig, device_t &device)
 	: device_slot_card_interface(mconfig, device)
+	, m_owning_slot(nullptr)
+	, m_host(nullptr)
 {
 }
 
@@ -439,6 +441,21 @@ device_cococart_interface::device_cococart_interface(const machine_config &mconf
 
 device_cococart_interface::~device_cococart_interface()
 {
+}
+
+
+//-------------------------------------------------
+//  interface_config_complete
+//-------------------------------------------------
+
+void device_cococart_interface::interface_config_complete()
+{
+	m_owning_slot = dynamic_cast<cococart_slot_device *>(device().owner());
+	if (!m_owning_slot)
+		throw new emu_fatalerror("Expected device().owner() to be of type cococart_slot_device");
+	m_host = dynamic_cast<device_cococart_host_interface *>(m_owning_slot->owner());
+	if (!m_host)
+		throw new emu_fatalerror("Expected m_owning_slot->owner() to be of type device_cococart_host_interface");
 }
 
 
@@ -509,13 +526,7 @@ void device_cococart_interface::cart_base_changed(void)
 
 address_space &device_cococart_interface::cartridge_space()
 {
-	// sanity check - our parent should always be a cococart_slot_device
-	assert(dynamic_cast<cococart_slot_device *>(device().owner()));
-
-	// get my owner's owner - it had better implement device_cococart_host_interface
-	device_cococart_host_interface *host = dynamic_cast<device_cococart_host_interface *>(device().owner()->owner());
-	assert(host);
-	return host->cartridge_space();
+	return host().cartridge_space();
 }
 
 

--- a/src/devices/bus/coco/cococart.h
+++ b/src/devices/bus/coco/cococart.h
@@ -192,10 +192,16 @@ public:
 	virtual uint8_t* get_cart_base();
 	void set_cart_base_update(cococart_base_update_delegate update);
 
+	virtual void interface_config_complete() override;
+
 protected:
 	device_cococart_interface(const machine_config &mconfig, device_t &device);
 
 	void cart_base_changed(void);
+
+	// accessors for containers
+	cococart_slot_device &owning_slot()		{ assert(m_owning_slot); return *m_owning_slot; }
+	device_cococart_host_interface &host()	{ assert(m_host); return *m_host; }
 
 	// CoCo cartridges can read directly from the address bus.  This is used by a number of
 	// cartridges (e.g. - Orch-90, Multi-Pak interface) for their control registers, independently
@@ -209,7 +215,9 @@ protected:
 	void set_line_value(cococart_slot_device::line line, cococart_slot_device::line_value value);
 
 private:
-	cococart_base_update_delegate m_update;
+	cococart_base_update_delegate		m_update;
+	cococart_slot_device *				m_owning_slot;
+	device_cococart_host_interface *	m_host;
 };
 
 

--- a/src/devices/bus/coco/cococart.h
+++ b/src/devices/bus/coco/cococart.h
@@ -193,6 +193,7 @@ public:
 	void set_cart_base_update(cococart_base_update_delegate update);
 
 	virtual void interface_config_complete() override;
+	virtual void interface_pre_start() override;
 
 protected:
 	device_cococart_interface(const machine_config &mconfig, device_t &device);


### PR DESCRIPTION
This should be considered part of the CoCo cartridge overhaul.  Vas (correctly) suggested that dynamic_casts should be done in interface_config_complete() to avoid calling them at runtime.  This was actually happening inconsistently in the various implementations, and consolidating them is a good cleanup.