### PR TITLE
[CoCo] Follow up hygiene on CoCo cartridge slot refactoring

### DIFF
--- a/src/devices/bus/coco/coco_dcmodem.cpp
+++ b/src/devices/bus/coco/coco_dcmodem.cpp
@@ -50,9 +50,7 @@ namespace
 		// callbacks
 		WRITE_LINE_MEMBER(uart_irq_w)
 		{
-			set_line_value(cococart_slot_device::line::CART, state
-				? cococart_slot_device::line_value::ASSERT
-				: cococart_slot_device::line_value::CLEAR);
+			set_line_value(line::CART, state != 0);
 		}
 
 	protected:

--- a/src/devices/bus/coco/coco_fdc.cpp
+++ b/src/devices/bus/coco/coco_fdc.cpp
@@ -228,10 +228,10 @@ void coco_fdc_device_base::update_lines()
 		set_dskreg(dskreg() & ~0x80);  // clear halt enable
 
 	// set the NMI line
-	cart_set_line(cococart_slot_device::line::NMI, intrq() && (dskreg() & 0x20));
+	set_line_value(line::NMI, intrq() && (dskreg() & 0x20));
 
 	// set the HALT line
-	cart_set_line(cococart_slot_device::line::HALT, !drq() && (dskreg() & 0x80));
+	set_line_value(line::HALT, !drq() && (dskreg() & 0x80));
 }
 
 

--- a/src/devices/bus/coco/coco_fdc.h
+++ b/src/devices/bus/coco/coco_fdc.h
@@ -47,16 +47,6 @@ protected:
 	virtual void update_lines() = 0;
 	virtual uint8_t* get_cart_base() override;
 
-	// wrapper for setting the cart line
-	void cart_set_line(cococart_slot_device::line which, cococart_slot_device::line_value value)
-	{
-		owning_slot().set_line_value(which, value);
-	}
-	void cart_set_line(cococart_slot_device::line which, bool value)
-	{
-		cart_set_line(which, value ? cococart_slot_device::line_value::ASSERT : cococart_slot_device::line_value::CLEAR);
-	}
-
 	// accessors
 	uint8_t dskreg() const { return m_dskreg; }
 	bool intrq() const { return m_intrq; }

--- a/src/devices/bus/coco/coco_multi.cpp
+++ b/src/devices/bus/coco/coco_multi.cpp
@@ -126,7 +126,7 @@ namespace
 		// methods
 		void set_select(uint8_t new_select);
 		DECLARE_WRITE8_MEMBER(ff7f_write);
-		void update_line(int slot_number, cococart_slot_device::line line);
+		void update_line(int slot_number, line line);
 	};
 };
 
@@ -296,7 +296,7 @@ cococart_slot_device &coco_multipak_device::active_cts_slot()
 void coco_multipak_device::set_select(uint8_t new_select)
 {
 	// identify old value for CART, in case this needs to change
-	cococart_slot_device::line_value old_cart = active_cts_slot().get_line_value(cococart_slot_device::line::CART);
+	cococart_slot_device::line_value old_cart = active_cts_slot().get_line_value(line::CART);
 
 	// change value
 	uint8_t xorval = m_select ^ new_select;
@@ -307,9 +307,9 @@ void coco_multipak_device::set_select(uint8_t new_select)
 		cart_base_changed();
 
 	// did the CART line change?
-	cococart_slot_device::line_value new_cart = active_cts_slot().get_line_value(cococart_slot_device::line::CART);
+	line_value new_cart = active_cts_slot().get_line_value(line::CART);
 	if (new_cart != old_cart)
-		update_line(active_cts_slot_number(), cococart_slot_device::line::CART);
+		update_line(active_cts_slot_number(), line::CART);
 }
 
 
@@ -327,20 +327,20 @@ WRITE8_MEMBER(coco_multipak_device::ff7f_write)
 //  update_line
 //-------------------------------------------------
 
-void coco_multipak_device::update_line(int slot_number, cococart_slot_device::line line)
+void coco_multipak_device::update_line(int slot_number, line ln)
 {
 	bool propagate;
 
 	// one of our child devices set a line; we may need to propagate it upwards
-	switch (line)
+	switch (ln)
 	{
-	case cococart_slot_device::line::CART:
+	case line::CART:
 		// only propagate if this is coming from the slot specified
 		propagate = slot_number == active_cts_slot_number();
 		break;
 
-	case cococart_slot_device::line::NMI:
-	case cococart_slot_device::line::HALT:
+	case line::NMI:
+	case line::HALT:
 		// always propagate these
 		propagate = true;
 		break;
@@ -352,7 +352,7 @@ void coco_multipak_device::update_line(int slot_number, cococart_slot_device::li
 	}
 
 	if (propagate)
-		owning_slot().set_line_value(line, slot(slot_number).get_line_value(line));
+		owning_slot().set_line_value(ln, slot(slot_number).get_line_value(ln));
 }
 
 
@@ -364,7 +364,7 @@ void coco_multipak_device::set_sound_enable(bool sound_enable)
 {
 	// the SOUND_ENABLE (SNDEN) line is different; it is controlled by the CPU
 	for (cococart_slot_device *slot : m_slots)
-		slot->set_line_value(cococart_slot_device::line::SOUND_ENABLE, sound_enable ? cococart_slot_device::line_value::ASSERT : cococart_slot_device::line_value::CLEAR);
+		slot->set_line_value(line::SOUND_ENABLE, sound_enable ? line_value::ASSERT : line_value::CLEAR);
 }
 
 
@@ -402,18 +402,18 @@ WRITE8_MEMBER(coco_multipak_device::scs_write)
 //  multiX_slotX_[cart|nmi|halt] trampolines
 //-------------------------------------------------
 
-WRITE_LINE_MEMBER(coco_multipak_device::multi_slot1_cart_w) { update_line(1, cococart_slot_device::line::CART); }
-WRITE_LINE_MEMBER(coco_multipak_device::multi_slot1_nmi_w)  { update_line(1, cococart_slot_device::line::NMI); }
-WRITE_LINE_MEMBER(coco_multipak_device::multi_slot1_halt_w) { update_line(1, cococart_slot_device::line::HALT); }
-WRITE_LINE_MEMBER(coco_multipak_device::multi_slot2_cart_w) { update_line(2, cococart_slot_device::line::CART); }
-WRITE_LINE_MEMBER(coco_multipak_device::multi_slot2_nmi_w)  { update_line(2, cococart_slot_device::line::NMI); }
-WRITE_LINE_MEMBER(coco_multipak_device::multi_slot2_halt_w) { update_line(2, cococart_slot_device::line::HALT); }
-WRITE_LINE_MEMBER(coco_multipak_device::multi_slot3_cart_w) { update_line(3, cococart_slot_device::line::CART); }
-WRITE_LINE_MEMBER(coco_multipak_device::multi_slot3_nmi_w)  { update_line(3, cococart_slot_device::line::NMI); }
-WRITE_LINE_MEMBER(coco_multipak_device::multi_slot3_halt_w) { update_line(3, cococart_slot_device::line::HALT); }
-WRITE_LINE_MEMBER(coco_multipak_device::multi_slot4_cart_w) { update_line(4, cococart_slot_device::line::CART); }
-WRITE_LINE_MEMBER(coco_multipak_device::multi_slot4_nmi_w)  { update_line(4, cococart_slot_device::line::NMI); }
-WRITE_LINE_MEMBER(coco_multipak_device::multi_slot4_halt_w) { update_line(4, cococart_slot_device::line::HALT); }
+WRITE_LINE_MEMBER(coco_multipak_device::multi_slot1_cart_w) { update_line(1, line::CART); }
+WRITE_LINE_MEMBER(coco_multipak_device::multi_slot1_nmi_w)  { update_line(1, line::NMI); }
+WRITE_LINE_MEMBER(coco_multipak_device::multi_slot1_halt_w) { update_line(1, line::HALT); }
+WRITE_LINE_MEMBER(coco_multipak_device::multi_slot2_cart_w) { update_line(2, line::CART); }
+WRITE_LINE_MEMBER(coco_multipak_device::multi_slot2_nmi_w)  { update_line(2, line::NMI); }
+WRITE_LINE_MEMBER(coco_multipak_device::multi_slot2_halt_w) { update_line(2, line::HALT); }
+WRITE_LINE_MEMBER(coco_multipak_device::multi_slot3_cart_w) { update_line(3, line::CART); }
+WRITE_LINE_MEMBER(coco_multipak_device::multi_slot3_nmi_w)  { update_line(3, line::NMI); }
+WRITE_LINE_MEMBER(coco_multipak_device::multi_slot3_halt_w) { update_line(3, line::HALT); }
+WRITE_LINE_MEMBER(coco_multipak_device::multi_slot4_cart_w) { update_line(4, line::CART); }
+WRITE_LINE_MEMBER(coco_multipak_device::multi_slot4_nmi_w)  { update_line(4, line::NMI); }
+WRITE_LINE_MEMBER(coco_multipak_device::multi_slot4_halt_w) { update_line(4, line::HALT); }
 
 
 //-------------------------------------------------

--- a/src/devices/bus/coco/coco_multi.cpp
+++ b/src/devices/bus/coco/coco_multi.cpp
@@ -126,7 +126,7 @@ namespace
 		// methods
 		void set_select(uint8_t new_select);
 		DECLARE_WRITE8_MEMBER(ff7f_write);
-		void update_line(int slot_number, line line);
+		void update_line(int slot_number, line ln);
 	};
 };
 

--- a/src/devices/bus/coco/coco_orch90.cpp
+++ b/src/devices/bus/coco/coco_orch90.cpp
@@ -64,7 +64,7 @@ namespace
 			install_write_handler(0xFF7B, 0xFF7B, write8_delegate(FUNC(coco_orch90_device::write_right), this));
 
 			// Orch-90 ties CART to Q
-			set_line_value(cococart_slot_device::line::CART, cococart_slot_device::line_value::Q);
+			set_line_value(line::CART, line_value::Q);
 		}
 
 		virtual const tiny_rom_entry *device_rom_region() const override

--- a/src/devices/bus/coco/coco_pak.cpp
+++ b/src/devices/bus/coco/coco_pak.cpp
@@ -99,11 +99,11 @@ void coco_pak_device::device_reset()
 	if (m_cart->exists())
 	{
 		auto cart_line = m_autostart.read_safe(0x01)
-			? cococart_slot_device::line_value::Q
-			: cococart_slot_device::line_value::CLEAR;
+			? line_value::Q
+			: line_value::CLEAR;
 
 		// normal CoCo PAKs tie their CART line to Q - the system clock
-		set_line_value(cococart_slot_device::line::CART, cart_line);
+		set_line_value(line::CART, cart_line);
 	}
 }
 

--- a/src/devices/bus/coco/coco_t4426.cpp
+++ b/src/devices/bus/coco/coco_t4426.cpp
@@ -238,8 +238,8 @@ ioport_constructor coco_t4426_device::device_input_ports() const
 void coco_t4426_device::device_reset()
 {
 	LOG("%s()\n", FUNCNAME );
-	auto cart_line = cococart_slot_device::line_value::Q;
-	set_line_value(cococart_slot_device::line::CART, cart_line);
+	auto cart_line = line_value::Q;
+	set_line_value(line::CART, cart_line);
 }
 
 /*-------------------------------------------------

--- a/src/devices/bus/coco/cococart.cpp
+++ b/src/devices/bus/coco/cococart.cpp
@@ -48,6 +48,18 @@
 #define LOG_LINE                0
 
 
+/***************************************************************************
+	CONSTANTS
+***************************************************************************/
+
+enum
+{
+	TIMER_CART,
+	TIMER_NMI,
+	TIMER_HALT
+};
+
+
 //**************************************************************************
 //  GLOBAL VARIABLES
 //**************************************************************************
@@ -581,5 +593,5 @@ void device_cococart_interface::install_readwrite_handler(uint16_t addrstart, ui
 
 void device_cococart_interface::set_line_value(cococart_slot_device::line line, cococart_slot_device::line_value value)
 {
-	dynamic_cast<cococart_slot_device *>(device().owner())->set_line_value(line, value);
+	owning_slot().set_line_value(line, value);
 }

--- a/src/devices/bus/coco/cococart.h
+++ b/src/devices/bus/coco/cococart.h
@@ -56,7 +56,7 @@ typedef delegate<void (uint8_t *)> cococart_base_update_delegate;
 // ======================> cococart_slot_device
 class device_cococart_interface;
 
-class cococart_slot_device : public device_t,
+class cococart_slot_device final : public device_t,
 								public device_slot_interface,
 								public device_image_interface
 {

--- a/src/devices/bus/coco/cococart.h
+++ b/src/devices/bus/coco/cococart.h
@@ -126,13 +126,6 @@ private:
 	// TIMER_POOL: Must be power of two
 	static constexpr int TIMER_POOL = 2;
 
-	enum
-	{
-		TIMER_CART,
-		TIMER_NMI,
-		TIMER_HALT
-	};
-
 	struct coco_cartridge_line
 	{
 		emu_timer                   *timer[TIMER_POOL];
@@ -215,6 +208,10 @@ protected:
 
 	// setting line values
 	void set_line_value(cococart_slot_device::line line, cococart_slot_device::line_value value);
+	void set_line_value(cococart_slot_device::line line, bool value) { set_line_value(line, value ? cococart_slot_device::line_value::ASSERT : cococart_slot_device::line_value::CLEAR); }
+
+	typedef cococart_slot_device::line line;
+	typedef cococart_slot_device::line_value line_value;
 
 private:
 	cococart_base_update_delegate		m_update;

--- a/src/devices/bus/coco/dragon_fdc.cpp
+++ b/src/devices/bus/coco/dragon_fdc.cpp
@@ -160,10 +160,10 @@ dragon_fdc_device_base::dragon_fdc_device_base(const machine_config &mconfig, de
 void dragon_fdc_device_base::update_lines()
 {
 	// set the NMI line
-	cart_set_line(cococart_slot_device::line::NMI, intrq() && (dskreg() & 0x20));
+	set_line_value(line::NMI, intrq() && (dskreg() & 0x20));
 
 	// set the CART line
-	cart_set_line(cococart_slot_device::line::CART, drq());
+	set_line_value(line::CART, drq());
 }
 
 


### PR DESCRIPTION
- Removed now-extraneous cart_set_line() specific to the FDC code
- Added typedefs for line and line_value within device_cococart_interface()
- Moved private TIMER_* declarations to source file
- Added overload of set_line_value() that takes a 'bool' instead of 'line_value'