### PR TITLE
Fixes a crash when returning to the front end when a system was launched from favorites

### DIFF
--- a/src/frontend/mame/ui/selgame.cpp
+++ b/src/frontend/mame/ui/selgame.cpp
@@ -184,7 +184,9 @@ void menu_select_game::handle()
 	// if i have to reselect a software, force software list submenu
 	if (reselect_last::get())
 	{
-		const game_driver *const driver = reinterpret_cast<const game_driver *>(get_selection_ref());
+		const game_driver *driver;
+		const ui_software_info *software;
+		get_selection(software, driver);
 		menu::stack_push<menu_select_software>(ui(), container(), driver);
 		return;
 	}


### PR DESCRIPTION
This bug could be reproduced with the following steps:
  1.  Put 'nes' in 'Favorites'
  2.  Launch 'nes'
  3.  Choose something from the software menu and run the emulation
  4.  Escape back  -- CRASH