### PR TITLE
luaengine: save to string [Carl]

### DIFF
--- a/src/emu/schedule.cpp
+++ b/src/emu/schedule.cpp
@@ -377,7 +377,7 @@ bool device_scheduler::can_save() const
 {
 	// if any live temporary timers exit, fail
 	for (emu_timer *timer = m_timer_list; timer != nullptr; timer = timer->next())
-		if (timer->m_temporary && !timer->expire().is_never())
+		if (timer->m_temporary && !timer->expire().is_never() && timer->enabled())
 		{
 			machine().logerror("Failed save state attempt due to anonymous timers:\n");
 			dump_timers();


### PR DESCRIPTION
AFAICT the only way an anon timer can be disabled is if you're inside it's callback so the can_save change shouldn't hurt anything.  If I'm wrong, let me know.  Otherwise this seems to work,