### PR TITLE
Cleanup of consolewininfo.cpp

### DIFF
--- a/src/osd/modules/debugger/win/consolewininfo.cpp
+++ b/src/osd/modules/debugger/win/consolewininfo.cpp
@@ -2,7 +2,7 @@
 // copyright-holders:Aaron Giles, Vas Crabb
 //============================================================
 //
-//  consolewininfo.c - Win32 debug window handling
+//  consolewininfo.cpp - Win32 debug window handling
 //
 //============================================================
 
@@ -20,10 +20,185 @@
 #include "strconv.h"
 #include "winutf8.h"
 
+#include <string>
 
-consolewin_info::consolewin_info(debugger_windows_interface &debugger) :
-	disasmbasewin_info(debugger, true, "Debug", nullptr),
-	m_devices_menu(nullptr)
+using namespace std::literals;
+
+
+//**************************************************************************
+//  ANONYMOUS NAMESPACE
+//**************************************************************************
+
+namespace
+{
+
+//-------------------------------------------------
+//  copy_extension_list
+//-------------------------------------------------
+
+void copy_extension_list(std::ostringstream &dest, const char *extensions)
+{
+	// our extension lists are comma delimited; Win32 expects to see lists
+	// delimited by semicolons
+	char const *s = extensions;
+	while (*s)
+	{
+		// append a semicolon if not at the beginning
+		if (s != extensions)
+			dest << ';';
+
+		// append ".*"
+		dest << "*.";
+
+		// append the file extension
+		while (*s && (*s != ','))
+			dest << *s++;
+
+		// if we found a comma, advance
+		while (*s == ',')
+			s++;
+	}
+}
+
+
+//-------------------------------------------------
+//  add_filter_entry
+//-------------------------------------------------
+
+void add_filter_entry(std::ostringstream &dest, const char *description, const char *extensions)
+{
+	// add the description
+	dest << description;
+	dest << " (";
+
+	// add the extensions to the description
+	copy_extension_list(dest, extensions);
+
+	// add the trailing rparen and '\0' character
+	dest << ")\0"s;
+
+	// now add the extension list itself
+	copy_extension_list(dest, extensions);
+
+	// append a '\0'
+	dest << '\0';
+}
+
+
+//-------------------------------------------------
+//  build_generic_filter
+//-------------------------------------------------
+
+std::string build_generic_filter(device_image_interface *img, bool is_save)
+{
+	std::ostringstream filter;
+	std::string file_extension;
+
+	if (img)
+		file_extension = img->file_extensions();
+
+	if (!is_save)
+		file_extension.append(",zip,7z");
+
+	add_filter_entry(filter, "Common image types", file_extension.c_str());
+
+	filter << "All files (*.*)\0*.*\0"s;
+
+	if (!is_save)
+		filter << "Compressed Images (*.zip;*.7z)\0*.zip;*.7z\0"s;
+
+	return filter.str();
+}
+
+
+//-------------------------------------------------
+//  win_get_file_name
+//-------------------------------------------------
+
+enum class win_get_file_name_type
+{
+	OPEN,
+	SAVE
+};
+
+std::string win_get_file_name(win_get_file_name_type type, const std::string &filter, const std::string &dir)
+{
+	// convert to TCHAR
+	osd::text::tstring t_filter = osd::text::to_tstring(filter);
+	osd::text::tstring t_dir = osd::text::to_tstring(dir);
+
+	// this is where the selected filename is stored
+	TCHAR selected_filename[MAX_PATH];
+	selected_filename[0] = '\0';
+
+	// record the current working directory
+	DWORD working_directory_length = GetCurrentDirectory(0, nullptr);
+	TCHAR *working_directory = (TCHAR *) alloca(working_directory_length * sizeof(TCHAR));
+	GetCurrentDirectory(working_directory_length, working_directory);
+
+	// determine the flags
+	DWORD flags;
+	switch (type)
+	{
+	case win_get_file_name_type::OPEN:
+		flags = OFN_PATHMUSTEXIST | OFN_FILEMUSTEXIST;
+		break;
+	case win_get_file_name_type::SAVE:
+		flags = OFN_PATHMUSTEXIST;
+		break;
+	default:
+		throw false;
+	}
+
+	// create the gnarly OPENFILENAME struct
+	OPENFILENAME ofn;
+	memset(&ofn, 0, sizeof(ofn));
+	ofn.lStructSize = sizeof(ofn);
+	ofn.hwndOwner = nullptr;
+	ofn.lpstrFile = selected_filename;
+	ofn.nMaxFile = MAX_PATH;
+	ofn.lpstrFilter = t_filter.c_str();
+	ofn.nFilterIndex = 1;
+	ofn.lpstrFileTitle = nullptr;
+	ofn.nMaxFileTitle = 0;
+	ofn.lpstrInitialDir = t_dir.c_str();
+	ofn.Flags = flags;
+
+	// get the filename
+	BOOL result;
+	switch (type)
+	{
+	case win_get_file_name_type::OPEN:
+		result = GetOpenFileName(&ofn);
+		break;
+	case win_get_file_name_type::SAVE:
+		result = GetSaveFileName(&ofn);
+		break;
+	default:
+		throw false;
+	}
+
+	// restore the current working directory
+	SetCurrentDirectory(working_directory);
+
+	return result
+		? osd::text::from_tstring(selected_filename)
+		: "";
+}
+
+}
+
+//**************************************************************************
+//  CONSOLE WIN INFO
+//**************************************************************************
+
+//-------------------------------------------------
+//  ctor
+//-------------------------------------------------
+
+consolewin_info::consolewin_info(debugger_windows_interface &debugger)
+	: disasmbasewin_info(debugger, true, "Debug", nullptr)
+	, m_devices_menu(nullptr)
 {
 	if ((window() == nullptr) || (m_views[0] == nullptr))
 		goto cleanup;
@@ -90,10 +265,18 @@ cleanup:
 }
 
 
+//-------------------------------------------------
+//  dtor
+//-------------------------------------------------
+
 consolewin_info::~consolewin_info()
 {
 }
 
+
+//-------------------------------------------------
+//  set_cpu
+//-------------------------------------------------
 
 void consolewin_info::set_cpu(device_t &device)
 {
@@ -111,6 +294,10 @@ void consolewin_info::set_cpu(device_t &device)
 	recompute_children();
 }
 
+
+//-------------------------------------------------
+//  recompute_children
+//-------------------------------------------------
 
 void consolewin_info::recompute_children()
 {
@@ -152,6 +339,10 @@ void consolewin_info::recompute_children()
 	set_editwnd_bounds(editrect);
 }
 
+
+//-------------------------------------------------
+//  update_menu
+//-------------------------------------------------
 
 void consolewin_info::update_menu()
 {
@@ -236,6 +427,10 @@ void consolewin_info::update_menu()
 }
 
 
+//-------------------------------------------------
+//  handle_command
+//-------------------------------------------------
+
 bool consolewin_info::handle_command(WPARAM wparam, LPARAM lparam)
 {
 	if ((HIWORD(wparam) == 0) && (LOWORD(wparam) >= ID_DEVICE_OPTIONS))
@@ -249,18 +444,8 @@ bool consolewin_info::handle_command(WPARAM wparam, LPARAM lparam)
 			{
 			case DEVOPTION_ITEM :
 				{
-					std::string filter;
-					build_generic_filter(nullptr, false, filter);
+					std::string filter = build_generic_filter(nullptr, false);
 					{
-						osd::text::tstring t_filter = osd::text::to_tstring(filter);
-
-						// convert a pipe-char delimited string into a NUL delimited string
-						for (int i = 0; t_filter[i] != '\0'; i++)
-						{
-							if (t_filter[i] == '|')
-								t_filter[i] = '\0';
-						}
-
 						std::string opt_name = img->instance_name();
 						std::string as = slmap.find(opt_name)->second;
 
@@ -270,28 +455,10 @@ bool consolewin_info::handle_command(WPARAM wparam, LPARAM lparam)
 							/* Default to emu directory */
 							osd_get_full_path(as, ".");
 						}
-						osd::text::tstring t_dir = osd::text::to_tstring(as);
 
-						// display the dialog
-						TCHAR selectedFilename[MAX_PATH];
-						selectedFilename[0] = '\0';
-						OPENFILENAME ofn;
-						memset(&ofn, 0, sizeof(ofn));
-						ofn.lStructSize = sizeof(ofn);
-						ofn.hwndOwner = nullptr;
-						ofn.lpstrFile = selectedFilename;
-						ofn.lpstrFile[0] = '\0';
-						ofn.nMaxFile = MAX_PATH;
-						ofn.lpstrFilter = t_filter.c_str();
-						ofn.nFilterIndex = 1;
-						ofn.lpstrFileTitle = nullptr;
-						ofn.nMaxFileTitle = 0;
-						ofn.lpstrInitialDir = t_dir.c_str();
-						ofn.Flags = OFN_PATHMUSTEXIST | OFN_FILEMUSTEXIST;
-
-						if (GetOpenFileName(&ofn))
+						std::string buf = win_get_file_name(win_get_file_name_type::OPEN, filter, as);
+						if (!buf.empty())
 						{
-							std::string buf = std::string(osd::text::from_tstring(selectedFilename));
 							// Get the Item name out of the full path
 							size_t t1 = buf.find(".zip"); // get rid of zip name and anything after
 							if (t1 != std::string::npos)
@@ -305,25 +472,15 @@ bool consolewin_info::handle_command(WPARAM wparam, LPARAM lparam)
 							buf.erase(0, t1+1);
 
 							// load software
-							img->load_software( buf.c_str());
+							img->load_software(buf.c_str());
 						}
 					}
 				}
 				return true;
 			case DEVOPTION_OPEN :
 				{
-					std::string filter;
-					build_generic_filter(img, false, filter);
+					std::string filter = build_generic_filter(img, false);
 					{
-						osd::text::tstring t_filter = osd::text::to_tstring(filter);
-
-						// convert a pipe-char delimited string into a NUL delimited string
-						for (int i = 0; t_filter[i] != '\0'; i++)
-						{
-							if (t_filter[i] == '|')
-								t_filter[i] = '\0';
-						}
-
 						char buf[400];
 						std::string as;
 						strcpy(buf, machine().options().emu_options::sw_path());
@@ -340,45 +497,17 @@ bool consolewin_info::handle_command(WPARAM wparam, LPARAM lparam)
 							/* Default to emu directory */
 							osd_get_full_path(as, ".");
 						}
-						osd::text::tstring t_dir = osd::text::to_tstring(as);
 
-						TCHAR selectedFilename[MAX_PATH];
-						selectedFilename[0] = '\0';
-						OPENFILENAME ofn;
-						memset(&ofn, 0, sizeof(ofn));
-						ofn.lStructSize = sizeof(ofn);
-						ofn.hwndOwner = nullptr;
-						ofn.lpstrFile = selectedFilename;
-						ofn.lpstrFile[0] = '\0';
-						ofn.nMaxFile = MAX_PATH;
-						ofn.lpstrFilter = t_filter.c_str();
-						ofn.nFilterIndex = 1;
-						ofn.lpstrFileTitle = nullptr;
-						ofn.nMaxFileTitle = 0;
-						ofn.lpstrInitialDir = t_dir.c_str();
-						ofn.Flags = OFN_PATHMUSTEXIST | OFN_FILEMUSTEXIST;
-
-						if (GetOpenFileName(&ofn))
-						{
-							auto utf8_buf = osd::text::from_tstring(selectedFilename);
-							img->load(utf8_buf.c_str());
-						}
+						std::string result = win_get_file_name(win_get_file_name_type::OPEN, filter, as);
+						if (!result.empty())
+							img->load(result);
 					}
 				}
 				return true;
 			case DEVOPTION_CREATE:
 				{
-					std::string filter;
-					build_generic_filter(img, true, filter);
+					std::string filter = build_generic_filter(img, true);
 					{
-						osd::text::tstring t_filter = osd::text::to_tstring(filter);
-						// convert a pipe-char delimited string into a NUL delimited string
-						for (int i = 0; t_filter[i] != '\0'; i++)
-						{
-							if (t_filter[i] == '|')
-								t_filter[i] = '\0';
-						}
-
 						char buf[400];
 						std::string as;
 						strcpy(buf, machine().options().emu_options::sw_path());
@@ -395,29 +524,10 @@ bool consolewin_info::handle_command(WPARAM wparam, LPARAM lparam)
 							/* Default to emu directory */
 							osd_get_full_path(as, ".");
 						}
-						osd::text::tstring t_dir = osd::text::to_tstring(as);
 
-						TCHAR selectedFilename[MAX_PATH];
-						selectedFilename[0] = '\0';
-						OPENFILENAME ofn;
-						memset(&ofn, 0, sizeof(ofn));
-						ofn.lStructSize = sizeof(ofn);
-						ofn.hwndOwner = nullptr;
-						ofn.lpstrFile = selectedFilename;
-						ofn.lpstrFile[0] = '\0';
-						ofn.nMaxFile = MAX_PATH;
-						ofn.lpstrFilter = t_filter.c_str();
-						ofn.nFilterIndex = 1;
-						ofn.lpstrFileTitle = nullptr;
-						ofn.nMaxFileTitle = 0;
-						ofn.lpstrInitialDir = t_dir.c_str();
-						ofn.Flags = OFN_PATHMUSTEXIST;
-
-						if (GetSaveFileName(&ofn))
-						{
-							auto utf8_buf = osd::text::from_tstring(selectedFilename);
-							img->create(utf8_buf.c_str(), img->device_get_indexed_creatable_format(0), nullptr);
-						}
+						std::string result = win_get_file_name(win_get_file_name_type::SAVE, filter, as);
+						if (!result.empty())
+							img->create(result, img->device_get_indexed_creatable_format(0), nullptr);
 					}
 				}
 				return true;
@@ -453,6 +563,10 @@ bool consolewin_info::handle_command(WPARAM wparam, LPARAM lparam)
 }
 
 
+//-------------------------------------------------
+//  process_string
+//-------------------------------------------------
+
 void consolewin_info::process_string(char const *string)
 {
 	if (string[0] == 0) // an empty string is a single step
@@ -465,72 +579,10 @@ void consolewin_info::process_string(char const *string)
 }
 
 
-void consolewin_info::build_generic_filter(device_image_interface *img, bool is_save, std::string &filter)
-{
-	std::string file_extension;
-
-	if (img)
-		file_extension = img->file_extensions();
-
-	if (!is_save)
-		file_extension.append(",zip,7z");
-
-	add_filter_entry(filter, "Common image types", file_extension.c_str());
-
-	filter.append("All files (*.*)|*.*|");
-
-	if (!is_save)
-		filter.append("Compressed Images (*.zip;*.7z)|*.zip;*.7z|");
-}
-
-
-void consolewin_info::add_filter_entry(std::string &dest, const char *description, const char *extensions)
-{
-	// add the description
-	dest.append(description);
-	dest.append(" (");
-
-	// add the extensions to the description
-	copy_extension_list(dest, extensions);
-
-	// add the trailing rparen and '|' character
-	dest.append(")|");
-
-	// now add the extension list itself
-	copy_extension_list(dest, extensions);
-
-	// append a '|'
-	dest.append("|");
-}
-
-
-void consolewin_info::copy_extension_list(std::string &dest, const char *extensions)
-{
-	// our extension lists are comma delimited; Win32 expects to see lists
-	// delimited by semicolons
-	char const *s = extensions;
-	while (*s)
-	{
-		// append a semicolon if not at the beginning
-		if (s != extensions)
-			dest.push_back(';');
-
-		// append ".*"
-		dest.append("*.");
-
-		// append the file extension
-		while (*s && (*s != ','))
-			dest.push_back(*s++);
-
-		// if we found a comma, advance
-		while(*s == ',')
-			s++;
-	}
-}
-
-//============================================================
+//-------------------------------------------------
 //  get_softlist_info
-//============================================================
+//-------------------------------------------------
+
 bool consolewin_info::get_softlist_info(device_image_interface *img)
 {
 	bool has_software = false;

--- a/src/osd/modules/debugger/win/consolewininfo.cpp
+++ b/src/osd/modules/debugger/win/consolewininfo.cpp
@@ -22,8 +22,6 @@
 
 #include <string>
 
-using namespace std::literals;
-
 
 //**************************************************************************
 //  ANONYMOUS NAMESPACE
@@ -36,7 +34,7 @@ namespace
 //  copy_extension_list
 //-------------------------------------------------
 
-void copy_extension_list(std::ostringstream &dest, const char *extensions)
+void copy_extension_list(std::ostream &dest, const char *extensions)
 {
 	// our extension lists are comma delimited; Win32 expects to see lists
 	// delimited by semicolons
@@ -65,8 +63,10 @@ void copy_extension_list(std::ostringstream &dest, const char *extensions)
 //  add_filter_entry
 //-------------------------------------------------
 
-void add_filter_entry(std::ostringstream &dest, const char *description, const char *extensions)
+void add_filter_entry(std::ostream &dest, const char *description, const char *extensions)
 {
+	using namespace std::literals;
+
 	// add the description
 	dest << description;
 	dest << " (";
@@ -91,6 +91,8 @@ void add_filter_entry(std::ostringstream &dest, const char *description, const c
 
 std::string build_generic_filter(device_image_interface *img, bool is_save)
 {
+	using namespace std::literals;
+
 	std::ostringstream filter;
 	std::string file_extension;
 
@@ -266,16 +268,7 @@ cleanup:
 
 
 //-------------------------------------------------
-//  dtor
-//-------------------------------------------------
-
-consolewin_info::~consolewin_info()
-{
-}
-
-
-//-------------------------------------------------
-//  set_cpu
+//  set_cpu - sets the CPU device for the console
 //-------------------------------------------------
 
 void consolewin_info::set_cpu(device_t &device)
@@ -288,7 +281,7 @@ void consolewin_info::set_cpu(device_t &device)
 	std::string title = string_format("Debug: %s - %s '%s'", device.machine().system().name, device.name(), device.tag());
 	std::string curtitle = win_get_window_text_utf8(window());
 	if (title != curtitle)
-		win_set_window_text_utf8(window(), title.c_str());
+		win_set_window_text_utf8(window(), title);
 
 	// and recompute the children
 	recompute_children();
@@ -296,7 +289,8 @@ void consolewin_info::set_cpu(device_t &device)
 
 
 //-------------------------------------------------
-//  recompute_children
+//  recompute_children - recompute the size of
+//	the child views
 //-------------------------------------------------
 
 void consolewin_info::recompute_children()
@@ -341,7 +335,8 @@ void consolewin_info::recompute_children()
 
 
 //-------------------------------------------------
-//  update_menu
+//  update_menu - updates the contents of each menu
+//	based on device info
 //-------------------------------------------------
 
 void consolewin_info::update_menu()
@@ -428,7 +423,7 @@ void consolewin_info::update_menu()
 
 
 //-------------------------------------------------
-//  handle_command
+//  handle_command - handles a Win32 message
 //-------------------------------------------------
 
 bool consolewin_info::handle_command(WPARAM wparam, LPARAM lparam)
@@ -564,15 +559,15 @@ bool consolewin_info::handle_command(WPARAM wparam, LPARAM lparam)
 
 
 //-------------------------------------------------
-//  process_string
+//  process_string - inputs a string from the user
 //-------------------------------------------------
 
-void consolewin_info::process_string(char const *string)
+void consolewin_info::process_string(std::string &&string)
 {
-	if (string[0] == 0) // an empty string is a single step
+	if (string.empty()) // an empty string is a single step
 		machine().debugger().cpu().get_visible_cpu()->debug()->single_step();
 	else                // otherwise, just process the command
-		machine().debugger().console().execute_command(string, true);
+		machine().debugger().console().execute_command(string.c_str(), true);
 
 	// clear the edit text box
 	set_editwnd_text("");
@@ -580,7 +575,8 @@ void consolewin_info::process_string(char const *string)
 
 
 //-------------------------------------------------
-//  get_softlist_info
+//  get_softlist_info - gets info about a softlist
+//	for a particular device
 //-------------------------------------------------
 
 bool consolewin_info::get_softlist_info(device_image_interface *img)

--- a/src/osd/modules/debugger/win/consolewininfo.h
+++ b/src/osd/modules/debugger/win/consolewininfo.h
@@ -44,9 +44,6 @@ private:
 
 	virtual void process_string(char const *string) override;
 
-	static void build_generic_filter(device_image_interface *img, bool is_save, std::string &filter);
-	static void add_filter_entry(std::string &dest, char const *description, char const *extensions);
-	static void copy_extension_list(std::string &dest, char const *extensions);
 	bool get_softlist_info(device_image_interface *img);
 
 	HMENU   m_devices_menu;

--- a/src/osd/modules/debugger/win/consolewininfo.h
+++ b/src/osd/modules/debugger/win/consolewininfo.h
@@ -18,7 +18,6 @@ class consolewin_info : public disasmbasewin_info
 {
 public:
 	consolewin_info(debugger_windows_interface &debugger);
-	virtual ~consolewin_info();
 
 	void set_cpu(device_t &device);
 
@@ -42,7 +41,7 @@ private:
 		DEVOPTION_MAX
 	};
 
-	virtual void process_string(char const *string) override;
+	virtual void process_string(std::string &&string) override;
 
 	bool get_softlist_info(device_image_interface *img);
 

--- a/src/osd/modules/debugger/win/disasmwininfo.cpp
+++ b/src/osd/modules/debugger/win/disasmwininfo.cpp
@@ -126,20 +126,20 @@ void disasmwin_info::draw_contents(HDC dc)
 }
 
 
-void disasmwin_info::process_string(char const *string)
+void disasmwin_info::process_string(std::string &&string)
 {
 	// set the string to the disasm view
-	downcast<disasmview_info *>(m_views[0].get())->set_expression(string);
+	downcast<disasmview_info *>(m_views[0].get())->set_expression(string.c_str());
 
 	// select everything in the edit text box
 	editwnd_select_all();
 
 	// update the default string to match
-	set_edit_defstr(string);
+	set_edit_defstr(std::move(string));
 }
 
 
 void disasmwin_info::update_caption()
 {
-	win_set_window_text_utf8(window(), std::string("Disassembly: ").append(m_views[0]->source_name()).c_str());
+	win_set_window_text_utf8(window(), std::string("Disassembly: ").append(m_views[0]->source_name()));
 }

--- a/src/osd/modules/debugger/win/disasmwininfo.h
+++ b/src/osd/modules/debugger/win/disasmwininfo.h
@@ -26,7 +26,7 @@ protected:
 	virtual void draw_contents(HDC dc) override;
 
 private:
-	virtual void process_string(char const *string) override;
+	virtual void process_string(std::string &&string) override;
 
 	void update_caption();
 

--- a/src/osd/modules/debugger/win/editwininfo.cpp
+++ b/src/osd/modules/debugger/win/editwininfo.cpp
@@ -199,7 +199,7 @@ LRESULT editwin_info::edit_proc(UINT message, WPARAM wparam, LPARAM lparam)
 						// process
 						{
 							auto utf8_buffer = osd::text::from_tstring(buffer);
-							process_string(utf8_buffer.c_str());
+							process_string(std::move(utf8_buffer));
 						}
 					}
 					break;

--- a/src/osd/modules/debugger/win/editwininfo.h
+++ b/src/osd/modules/debugger/win/editwininfo.h
@@ -34,14 +34,14 @@ protected:
 	void set_editwnd_bounds(RECT const &bounds);
 	void set_editwnd_text(char const *text);
 	void editwnd_select_all();
-	void set_edit_defstr(char const *string) { m_edit_defstr = string; }
+	void set_edit_defstr(std::string &&string) { m_edit_defstr = std::move(string); }
 
 	virtual void draw_contents(HDC dc) override;
 
 private:
 	typedef std::deque<std::basic_string<TCHAR> > history_deque;
 
-	virtual void process_string(char const *string) = 0;
+	virtual void process_string(std::string &&string) = 0;
 
 	LRESULT edit_proc(UINT message, WPARAM wparam, LPARAM lparam);
 

--- a/src/osd/modules/debugger/win/memorywininfo.cpp
+++ b/src/osd/modules/debugger/win/memorywininfo.cpp
@@ -283,20 +283,20 @@ void memorywin_info::draw_contents(HDC dc)
 }
 
 
-void memorywin_info::process_string(char const *string)
+void memorywin_info::process_string(std::string &&string)
 {
 	// set the string to the memory view
-	downcast<memoryview_info *>(m_views[0].get())->set_expression(string);
+	downcast<memoryview_info *>(m_views[0].get())->set_expression(string.c_str());
 
 	// select everything in the edit text box
 	editwnd_select_all();
 
 	// update the default string to match
-	set_edit_defstr(string);
+	set_edit_defstr(std::move(string));
 }
 
 
 void memorywin_info::update_caption()
 {
-	win_set_window_text_utf8(window(), std::string("Memory: ").append(m_views[0]->source_name()).c_str());
+	win_set_window_text_utf8(window(), std::string("Memory: ").append(m_views[0]->source_name()));
 }

--- a/src/osd/modules/debugger/win/memorywininfo.h
+++ b/src/osd/modules/debugger/win/memorywininfo.h
@@ -29,7 +29,7 @@ protected:
 	virtual void draw_contents(HDC dc) override;
 
 private:
-	virtual void process_string(char const *string) override;
+	virtual void process_string(std::string &&string) override;
 
 	void update_caption();
 

--- a/src/osd/windows/winutf8.cpp
+++ b/src/osd/windows/winutf8.cpp
@@ -60,6 +60,24 @@ int win_message_box_utf8(HWND window, const char *text, const char *caption, UIN
 
 
 //============================================================
+//  internal_set_window_text
+//============================================================
+
+static BOOL internal_set_window_text(HWND window, LPCTSTR t_text)
+{
+	BOOL result;
+#if WINAPI_FAMILY_PARTITION(WINAPI_PARTITION_DESKTOP)
+	result = SetWindowText(window, t_text);
+#else
+	Windows::UI::ViewManagement::ApplicationView::GetForCurrentView()->Title = ref new Platform::String(t_text);
+	result = TRUE;
+#endif
+	return result;
+}
+
+
+
+//============================================================
 //  win_set_window_text_utf8
 //============================================================
 
@@ -67,7 +85,7 @@ BOOL win_set_window_text_utf8(HWND window, const char *text)
 {
 	BOOL result = FALSE;
 	LPCTSTR t_text = nullptr;
-	std::basic_string<TCHAR> ts_text;
+	osd::text::tstring ts_text;
 
 	if (text)
 	{
@@ -75,14 +93,19 @@ BOOL win_set_window_text_utf8(HWND window, const char *text)
 		t_text = ts_text.c_str();
 	}
 
-#if WINAPI_FAMILY_PARTITION(WINAPI_PARTITION_DESKTOP)
-	result = SetWindowText(window, t_text);
-#else
-	Windows::UI::ViewManagement::ApplicationView::GetForCurrentView()->Title = ref new Platform::String(t_text);
-	result = TRUE;
-#endif
+	return internal_set_window_text(window, t_text);
+}
 
-	return result;
+
+
+//============================================================
+//  win_set_window_text_utf8
+//============================================================
+
+BOOL win_set_window_text_utf8(HWND window, const std::string &text)
+{
+	osd::text::tstring ts_text = osd::text::to_tstring(text);
+	return internal_set_window_text(window, ts_text.c_str());
 }
 
 

--- a/src/osd/windows/winutf8.h
+++ b/src/osd/windows/winutf8.h
@@ -17,6 +17,7 @@ void win_output_debug_string_utf8(const char *string);
 // wrappers for user32.dll
 int win_message_box_utf8(HWND window, const char *text, const char *caption, UINT type);
 BOOL win_set_window_text_utf8(HWND window, const char *text);
+BOOL win_set_window_text_utf8(HWND window, const std::string &text);
 std::string win_get_window_text_utf8(HWND window);
 HWND win_create_window_ex_utf8(DWORD exstyle, const char* classname, const char* windowname, DWORD style,
 								int x, int y, int width, int height, HWND wndparent, HMENU menu,


### PR DESCRIPTION
- Moved private static methods to an anonymous namespace
- Made better usage of string classes
- Moved invocations of Get[Open|Save]FileName() to function, to reduce copy and paste code
- Saving and restoring working directory around calls to Get[Open|Save]FileName(), to not break relative paths in settings (this fixes a problem Robert found)

This class is a mess.  The functionality of using GetOpenFileName() to try to open a software list makes some very eggregious assumptions, but this change is still an improvement.