### PR TITLE
Fixed an issue that could cause the debugger 'source' command to falsely display I/O error

### DIFF
--- a/src/emu/debug/debugcpu.cpp
+++ b/src/emu/debug/debugcpu.cpp
@@ -893,7 +893,7 @@ void debugger_cpu::process_source_file()
 
 	if (m_source_file && !m_source_file->good())
 	{
-		if (m_source_file->fail())
+		if (!m_source_file->eof())
 			m_machine.debugger().console().printf("I/O error, script processing terminated\n");
 		m_source_file.reset();
 	}


### PR DESCRIPTION
I've discovered a scenario where reading to the end of file seems to trigger the fail bit, in addition to the eof bit.  Because of this, I've changed the error message to display when we can't read from the stream, but the eof bit is _not_ set