### PR TITLE
Fix sound_sdl::sdl_callback, fill buffer with silence when underflow.

### DIFF
--- a/src/osd/modules/sound/sdl_sound.cpp
+++ b/src/osd/modules/sound/sdl_sound.cpp
@@ -359,6 +359,7 @@ static void sdl_callback(void *userdata, Uint8 *stream, int len)
 		if (LOG_SOUND)
 			fprintf(sound_log, "Underflow at sdl_callback: SPP=%d SBI=%d(%d) Len=%d\n", (int)thiz->stream_playpos, (int)sb_in, (int)thiz->stream_buffer_in, (int)len);
 
+		memset(stream, 0, len);
 		return;
 	}
 	else if ((thiz->stream_playpos+len) > thiz->stream_buffer_size)


### PR DESCRIPTION
The problem is most noticeable when you are saving state, and the
save takes a relatively long time, short period of audio gets played
repeatedly, which is usually unpleasant.

I found out it's caused by sdl_sound::sdl_callback not fill the audio
buffer with silence when underflow occurs. According to
https://wiki.libsdl.org/SDL_AudioSpec, if there's nothing to play,
the callback should fill the buffer with silence.

I tested this change and the problem is gone.