### PR TITLE
Updated Fedora instructions

### DIFF
--- a/docs/source/initialsetup/compilingmame.rst
+++ b/docs/source/initialsetup/compilingmame.rst
@@ -48,7 +48,7 @@ Fedora Linux
 
 You'll need a few prerequisites from your distro. Make sure you get SDL2 2.0.3 or 2.0.4 as earlier versions are buggy.
 
-**sudo yum install gcc gcc-c++ SDL2-devel SDL2_ttf-devel libXinerama-devel qt5-qtbase-devel qt5-qttools expat-devel fontconfig-devel**
+**sudo dnf install gcc gcc-c++ SDL2-devel SDL2_ttf-devel libXinerama-devel qt5-qtbase-devel qt5-qttools expat-devel fontconfig-devel alsa-lib-devel** 
 
 Compilation is exactly as described above in All Platforms.
 


### PR DESCRIPTION
DNF is now preferred package manager. alsa-lib-devel is also required (not mentioned in the current docs)