### PR TITLE
Corrected ITT3030 70 track drive type and added 35 track ... drive type and for…

### DIFF
--- a/src/lib/formats/itt3030_dsk.cpp
+++ b/src/lib/formats/itt3030_dsk.cpp
@@ -36,10 +36,21 @@ const char *itt3030_format::extensions() const
 // gap info is a total guess
 const itt3030_format::format itt3030_format::formats[] = {
 	{   /*  5,25" DS DD 70 tracks 16 SPT 256 bytes/sector */
-		floppy_image::FF_525,  floppy_image::DSDD, floppy_image::MFM,
-		2000, 16, 70, 2, 256, {}, 1, {}, 32, 22, 31
+		floppy_image::FF_525,  floppy_image::DSQD, floppy_image::MFM,
+		2000, 
+		16, 70, 2, 
+		256, {}, 
+		1, {}, 
+		32, 22, 31
 	},
-	{}
+	{/*  5,25" DS DD 35 tracks 16 SPT 256 bytes/sector */
+		floppy_image::FF_525,  floppy_image::DSDD, floppy_image::MFM,
+		2000, 
+		16, 35, 2, 
+		256, {}, 
+		1, {}, 
+		32, 22, 31
+	}
 };
 
 

--- a/src/mame/drivers/itt3030.cpp
+++ b/src/mame/drivers/itt3030.cpp
@@ -646,7 +646,8 @@ FLOPPY_FORMATS_END
 
 
 static SLOT_INTERFACE_START( itt3030_floppies )
-	SLOT_INTERFACE( "525dd", FLOPPY_525_QD )
+	SLOT_INTERFACE( "525dd", FLOPPY_525_DD )
+	SLOT_INTERFACE( "525qd", FLOPPY_525_QD )
 SLOT_INTERFACE_END
 
 PALETTE_INIT_MEMBER(itt3030_state, itt3030)
@@ -698,9 +699,9 @@ static MACHINE_CONFIG_START( itt3030 )
 	MCFG_WD_FDC_INTRQ_CALLBACK(WRITELINE(itt3030_state, fdcirq_w))
 	MCFG_WD_FDC_DRQ_CALLBACK(WRITELINE(itt3030_state, fdcdrq_w))
 	MCFG_WD_FDC_HLD_CALLBACK(WRITELINE(itt3030_state, fdchld_w))
-	MCFG_FLOPPY_DRIVE_ADD("fdc:0", itt3030_floppies, "525dd", itt3030_state::itt3030_floppy_formats)
-	MCFG_FLOPPY_DRIVE_ADD("fdc:1", itt3030_floppies, "525dd", itt3030_state::itt3030_floppy_formats)
-	MCFG_FLOPPY_DRIVE_ADD("fdc:2", itt3030_floppies, "525dd", itt3030_state::itt3030_floppy_formats)
+	MCFG_FLOPPY_DRIVE_ADD("fdc:0", itt3030_floppies, "525qd", itt3030_state::itt3030_floppy_formats)
+	MCFG_FLOPPY_DRIVE_ADD("fdc:1", itt3030_floppies, "525qd", itt3030_state::itt3030_floppy_formats)
+	MCFG_FLOPPY_DRIVE_ADD("fdc:2", itt3030_floppies, "525qd", itt3030_state::itt3030_floppy_formats)
 
 	MCFG_GFXDECODE_ADD("gfxdecode", "palette", itt3030)
 


### PR DESCRIPTION
drive type and format definition. [helwie44 and rfka01]
This change reflects the originally available drive types and will allow easier data exchange with machines from the same design company (SKS): alphatronic P1, P2, P3, P4, sks nano and others.