### PR TITLE
Fix save/load states in Emscripten build

### DIFF
--- a/scripts/resources/emscripten/emscripten_post.js
+++ b/scripts/resources/emscripten/emscripten_post.js
@@ -1,8 +1,8 @@
 // MAME-JavaScript function mappings
 var JSMAME = JSMAME || {};
-JSMAME.get_machine = Module.cwrap('_Z14js_get_machinev', 'number');
-JSMAME.get_ui = Module.cwrap('_Z9js_get_uiv', 'number');
-JSMAME.get_sound = Module.cwrap('_Z12js_get_soundv', 'number');
+JSMAME.get_machine = Module.cwrap('_ZN15running_machine30emscripten_get_running_machineEv', 'number');
+JSMAME.get_ui = Module.cwrap('_ZN15running_machine17emscripten_get_uiEv', 'number');
+JSMAME.get_sound = Module.cwrap('_ZN15running_machine20emscripten_get_soundEv', 'number');
 JSMAME.ui_set_show_fps = Module.cwrap('_ZN15mame_ui_manager12set_show_fpsEb', '', ['number', 'number']);
 JSMAME.ui_get_show_fps = Module.cwrap('_ZNK15mame_ui_manager8show_fpsEv', 'number', ['number']);
 JSMAME.sound_manager_mute = Module.cwrap('_ZN13sound_manager4muteEbh', '', ['number', 'number', 'number']);

--- a/scripts/src/main.lua
+++ b/scripts/src/main.lua
@@ -157,7 +157,7 @@ end
 				.. " -s TOTAL_MEMORY=268435456"
 				.. " -s DISABLE_EXCEPTION_CATCHING=2"
 				.. " -s EXCEPTION_CATCHING_WHITELIST='[\"__ZN15running_machine17start_all_devicesEv\",\"__ZN12cli_frontend7executeEiPPc\"]'"
-				.. " -s EXPORTED_FUNCTIONS=\"['_main', '_malloc', '__Z14js_get_machinev', '__Z9js_get_uiv', '__Z12js_get_soundv', '__ZN15mame_ui_manager12set_show_fpsEb', '__ZNK15mame_ui_manager8show_fpsEv', '__ZN13sound_manager4muteEbh', '_SDL_PauseAudio', '_SDL_SendKeyboardKey']\""
+				.. " -s EXPORTED_FUNCTIONS=\"['_main', '_malloc', '__ZN15running_machine30emscripten_get_running_machineEv', '__ZN15running_machine17emscripten_get_uiEv', '__ZN15running_machine20emscripten_get_soundEv', '__ZN15mame_ui_manager12set_show_fpsEb', '__ZNK15mame_ui_manager8show_fpsEv', '__ZN13sound_manager4muteEbh', '_SDL_PauseAudio', '_SDL_SendKeyboardKey']\""
 				.. " --pre-js " .. _MAKE.esc(MAME_DIR) .. "src/osd/modules/sound/js_sound.js"
 				.. " --post-js " .. _MAKE.esc(MAME_DIR) .. "scripts/resources/emscripten/emscripten_post.js"
 				.. " --embed-file " .. _MAKE.esc(MAME_DIR) .. "bgfx/chains@bgfx/chains"

--- a/src/emu/machine.cpp
+++ b/src/emu/machine.cpp
@@ -1334,12 +1334,14 @@ void js_main_loop()
 	const attotime frametime(0,HZ_TO_ATTOSECONDS(60));
 	const attotime stoptime(scheduler->time() + frametime);
 
-	while (scheduler->time() < stoptime) {
+	while (scheduler->time() < stoptime)
+	{
 		jsmess_machine->run_timeslice();
 	}
 }
 
-void js_set_main_loop(running_machine * machine) {
+void js_set_main_loop(running_machine * machine)
+{
 	jsmess_machine = machine;
 	EM_ASM (
 		JSMESS.running = true;
@@ -1347,15 +1349,18 @@ void js_set_main_loop(running_machine * machine) {
 	emscripten_set_main_loop(&js_main_loop, 0, 1);
 }
 
-running_machine * js_get_machine() {
+running_machine * js_get_machine()
+{
 	return jsmess_machine;
 }
 
-ui_manager * js_get_ui() {
+ui_manager * js_get_ui()
+{
 	return &(jsmess_machine->ui());
 }
 
-sound_manager * js_get_sound() {
+sound_manager * js_get_sound()
+{
 	return &(jsmess_machine->sound());
 }
 

--- a/src/emu/machine.cpp
+++ b/src/emu/machine.cpp
@@ -89,7 +89,6 @@
 
 #if defined(EMSCRIPTEN)
 #include <emscripten.h>
-
 #endif
 
 
@@ -1336,12 +1335,9 @@ void running_machine::emscripten_main_loop()
 		const attotime frametime(0,HZ_TO_ATTOSECONDS(60));
 		const attotime stoptime(scheduler->time() + frametime);
 
-		while (!machine->m_paused && 
-		       !machine->m_hard_reset_pending &&
-		       !machine->m_exit_pending &&
-		       scheduler->time() < stoptime)
+		while (!machine->m_paused && !machine->scheduled_event_pending() && scheduler->time() < stoptime)
 		{
-			machine->m_scheduler.timeslice();
+			scheduler->timeslice();
 			// handle save/load
 			if (machine->m_saveload_schedule != saveload_schedule::NONE)
 			{
@@ -1355,7 +1351,7 @@ void running_machine::emscripten_main_loop()
 		machine->m_video->frame_update();
 
 	// cancel the emscripten loop if the system has been told to exit
-	if (machine->m_exit_pending)
+	if (machine->exit_pending())
 	{
 		emscripten_cancel_main_loop();
 	}

--- a/src/emu/machine.cpp
+++ b/src/emu/machine.cpp
@@ -415,7 +415,7 @@ int running_machine::run(bool quiet)
 //  machine, optionally for a specific frame time
 //-------------------------------------------------
 
-int running_machine::run_timeslices(attotime frametime)
+void running_machine::run_timeslices(attotime frametime)
 {
 	g_profiler.start(PROFILER_EXTRA);
 

--- a/src/emu/machine.cpp
+++ b/src/emu/machine.cpp
@@ -352,7 +352,7 @@ int running_machine::run(bool quiet)
 		m_hard_reset_pending = false;
 		while ((!m_hard_reset_pending && !m_exit_pending) || m_saveload_schedule != saveload_schedule::NONE)
 		{
-			run_frame();
+			run_timeslices();
 		}
 		m_manager.http()->clear();
 
@@ -411,19 +411,22 @@ int running_machine::run(bool quiet)
 }
 
 //-------------------------------------------------
-//  run_frame - execute one frame for this machine
+//  run_timeslices - execute timeslices for this 
+//  machine, optionally for a specific frame time
 //-------------------------------------------------
 
-int running_machine::run_frame(attotime frametime)
+int running_machine::run_timeslices(attotime frametime)
 {
 	g_profiler.start(PROFILER_EXTRA);
 
 	// execute CPUs if not paused
-	if (!m_paused) {
-		attotime stoptime(m_scheduler.time() + frametime);
-		while (m_scheduler.time() < stoptime) {
+	if (!m_paused) 
+	{
+		const attotime stoptime(m_scheduler.time() + frametime);
+		do
+		{
 			m_scheduler.timeslice();
-		}
+		} while (m_scheduler.time() < stoptime);
 	}
 	// otherwise, just pump video updates through
 	else

--- a/src/emu/machine.h
+++ b/src/emu/machine.h
@@ -215,7 +215,7 @@ public:
 
 	// immediate operations
 	int run(bool quiet);
-	int run_timeslices(attotime frametime=attotime::zero);
+	void run_timeslices(attotime frametime=attotime::zero);
 	void pause();
 	void resume();
 	void toggle_pause();

--- a/src/emu/machine.h
+++ b/src/emu/machine.h
@@ -215,7 +215,7 @@ public:
 
 	// immediate operations
 	int run(bool quiet);
-	void run_timeslices(attotime frametime=attotime::zero);
+	void run_timeslice();
 	void pause();
 	void resume();
 	void toggle_pause();

--- a/src/emu/machine.h
+++ b/src/emu/machine.h
@@ -215,7 +215,6 @@ public:
 
 	// immediate operations
 	int run(bool quiet);
-	void run_timeslice();
 	void pause();
 	void resume();
 	void toggle_pause();
@@ -256,6 +255,8 @@ public:
 	cpu_device *            firstcpu;           // first CPU
 
 private:
+	void run_timeslice();
+
 	// video-related information
 	screen_device *         primary_screen;     // the primary screen device, or nullptr if screenless
 
@@ -398,6 +399,17 @@ private:
 
 	// configuration state
 	dummy_space_device m_dummy_space;
+
+#if defined(EMSCRIPTEN)
+private:
+	static running_machine *emscripten_running_machine;
+	static void emscripten_main_loop();
+public:
+	static void emscripten_set_running_machine(running_machine *machine);
+	static running_machine * emscripten_get_running_machine();
+	static ui_manager * emscripten_get_ui();
+	static sound_manager * emscripten_get_sound();
+#endif
 };
 
 

--- a/src/emu/machine.h
+++ b/src/emu/machine.h
@@ -215,6 +215,7 @@ public:
 
 	// immediate operations
 	int run(bool quiet);
+	int run_frame(attotime frametime=attotime::zero);
 	void pause();
 	void resume();
 	void toggle_pause();

--- a/src/emu/machine.h
+++ b/src/emu/machine.h
@@ -215,7 +215,7 @@ public:
 
 	// immediate operations
 	int run(bool quiet);
-	int run_frame(attotime frametime=attotime::zero);
+	int run_timeslices(attotime frametime=attotime::zero);
 	void pause();
 	void resume();
 	void toggle_pause();

--- a/src/emu/machine.h
+++ b/src/emu/machine.h
@@ -255,8 +255,6 @@ public:
 	cpu_device *            firstcpu;           // first CPU
 
 private:
-	void run_timeslice();
-
 	// video-related information
 	screen_device *         primary_screen;     // the primary screen device, or nullptr if screenless
 


### PR DESCRIPTION
Slightly rearranges the ```running_machine::run()``` function so that the Emscripten build can share the same codepath, allowing it to access the scheduler to process any save/load commands that may have been queued.