### PR TITLE
Gameboy v8

### DIFF
--- a/hash/gameboy.xml
+++ b/hash/gameboy.xml
@@ -7,7 +7,6 @@
   - Shanghai Pocket by Sunsoft: are serial and release date correct or do they refer to the GBC version?
 
   Undumped pirate carts:
-  - 4B-003: Sachen 4-in-1 version 3 (Taiwan's Mahjong, Japan's Mahjong, Hong Kong's Mahjong, Store Tris)
   - GOWIN carts (see below the list of known games)
 
 -->
@@ -24947,6 +24946,19 @@
 			<feature name="slot" value="rom_sachen1" />
 			<dataarea name="rom" size="65536">
 				<rom name="4b-002.bin" size="65536" crc="5e438db8" sha1="d9cb1721854709be7667f5dbce0adf2488c0919b" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+	
+	<software name="4in1_003">
+		<description>4 in 1 (Euro, 4B-003)</description>
+		<year>19??</year>
+		<publisher>Sachen</publisher>
+		<info name="serial" value="4B-003"/>
+		<part name="cart" interface="gameboy_cart">
+			<feature name="slot" value="rom_sachen1" />
+			<dataarea name="rom" size="65536">
+				<rom name="4b-003.bin" size="65536" crc="c294aa21" sha1="b5a3ee09692476d801d873a703d508d17ee24fbd" offset="0" />
 			</dataarea>
 		</part>
 	</software>

--- a/src/devices/bus/gameboy/gb_slot.cpp
+++ b/src/devices/bus/gameboy/gb_slot.cpp
@@ -480,9 +480,11 @@ bool gb_cart_slot_device_base::is_mbc1col_game(const uint8_t *ROM, uint32_t len)
 		"MORTALKOMBAT DUO",
 		/* Mortal Kombat I & II US */
 		"MORTALKOMBATI&II",
+		/* Super Chinese Land 1,2,3' */
+		"SUPERCHINESE 123"
 	};
 
-	const uint8_t rows = sizeof(internal_names) / sizeof(internal_names[0]);
+	const uint8_t rows = ARRAY_LENGTH(internal_names);
 
 	for (uint8_t i = 0x00; i < rows; ++i) {
 		if (0 == memcmp(&ROM[0x134], &internal_names[i][0], name_length))

--- a/src/devices/bus/gameboy/mbc.cpp
+++ b/src/devices/bus/gameboy/mbc.cpp
@@ -720,7 +720,7 @@ WRITE8_MEMBER(gb_rom_m161_device::write_bank)
 
 READ8_MEMBER(gb_rom_mmm01_device::read_rom)
 {
-	uint16_t romb = m_romb & ~m_romb_nwe;
+	uint16_t romb = m_romb & ~(0x1e0 | m_romb_nwe);
 	uint16_t romb_base = m_romb & (0x1e0 | m_romb_nwe);
 	uint8_t ramb_masked = ((offset & 0x4000) | m_mode ? m_ramb : m_ramb & ~0x03);
 


### PR DESCRIPTION
Miscellaneous Game Boy changes. Please use fast-forward merge to preserve the commit comments.

- Fixes an issue with a previous pull request where I forgot one MBC1 collection game.
- Fixes an issue with MMM01 emulation of ROMB0 switching (broken select ROM bank 0x00 at 0x4000-0x7FFF; not visible due to games behaving themselves)
- add Sachen 4B-003 that was dumped a little while ago to xml
