### PR TITLE
Export additional functions for Emscripten builds

### DIFF
--- a/scripts/resources/emscripten/emscripten_post.js
+++ b/scripts/resources/emscripten/emscripten_post.js
@@ -8,4 +8,11 @@ JSMAME.ui_get_show_fps = Module.cwrap('_ZNK15mame_ui_manager8show_fpsEv', 'numbe
 JSMAME.sound_manager_mute = Module.cwrap('_ZN13sound_manager4muteEbh', '', ['number', 'number', 'number']);
 JSMAME.sdl_pauseaudio = Module.cwrap('SDL_PauseAudio', '', ['number']);
 JSMAME.sdl_sendkeyboardkey = Module.cwrap('SDL_SendKeyboardKey', '', ['number', 'number']);
+
+JSMAME.soft_reset = Module.cwrap('_ZN15running_machine21emscripten_soft_resetEv', null);
+JSMAME.hard_reset = Module.cwrap('_ZN15running_machine21emscripten_hard_resetEv', null);
+JSMAME.exit = Module.cwrap('_ZN15running_machine15emscripten_exitEv', null, []);
+JSMAME.save = Module.cwrap('_ZN15running_machine15emscripten_saveEPKc', null, ['string']);
+JSMAME.load = Module.cwrap('_ZN15running_machine15emscripten_loadEPKc', null, ['string']);
+
 var JSMESS = JSMAME;

--- a/scripts/src/main.lua
+++ b/scripts/src/main.lua
@@ -157,7 +157,7 @@ end
 				.. " -s TOTAL_MEMORY=268435456"
 				.. " -s DISABLE_EXCEPTION_CATCHING=2"
 				.. " -s EXCEPTION_CATCHING_WHITELIST='[\"__ZN15running_machine17start_all_devicesEv\",\"__ZN12cli_frontend7executeEiPPc\"]'"
-				.. " -s EXPORTED_FUNCTIONS=\"['_main', '_malloc', '__ZN15running_machine30emscripten_get_running_machineEv', '__ZN15running_machine17emscripten_get_uiEv', '__ZN15running_machine20emscripten_get_soundEv', '__ZN15mame_ui_manager12set_show_fpsEb', '__ZNK15mame_ui_manager8show_fpsEv', '__ZN13sound_manager4muteEbh', '_SDL_PauseAudio', '_SDL_SendKeyboardKey']\""
+				.. " -s EXPORTED_FUNCTIONS=\"['_main', '_malloc', '__ZN15running_machine30emscripten_get_running_machineEv', '__ZN15running_machine17emscripten_get_uiEv', '__ZN15running_machine20emscripten_get_soundEv', '__ZN15mame_ui_manager12set_show_fpsEb', '__ZNK15mame_ui_manager8show_fpsEv', '__ZN13sound_manager4muteEbh', '_SDL_PauseAudio', '_SDL_SendKeyboardKey', '__ZN15running_machine15emscripten_saveEPKc', '__ZN15running_machine15emscripten_loadEPKc', '__ZN15running_machine21emscripten_hard_resetEv', '__ZN15running_machine21emscripten_soft_resetEv', '__ZN15running_machine15emscripten_exitEv']\""
 				.. " --pre-js " .. _MAKE.esc(MAME_DIR) .. "src/osd/modules/sound/js_sound.js"
 				.. " --post-js " .. _MAKE.esc(MAME_DIR) .. "scripts/resources/emscripten/emscripten_post.js"
 				.. " --embed-file " .. _MAKE.esc(MAME_DIR) .. "bgfx/chains@bgfx/chains"

--- a/src/emu/machine.cpp
+++ b/src/emu/machine.cpp
@@ -1381,4 +1381,20 @@ sound_manager * running_machine::emscripten_get_sound()
 	return &(emscripten_running_machine->sound());
 }
 
+void running_machine::emscripten_soft_reset() {
+	emscripten_running_machine->schedule_soft_reset();
+}
+void running_machine::emscripten_hard_reset() {
+	emscripten_running_machine->schedule_hard_reset();
+}
+void running_machine::emscripten_exit() {
+	emscripten_running_machine->schedule_exit();
+}
+void running_machine::emscripten_save(const char *name) {
+	emscripten_running_machine->schedule_save(name);
+}
+void running_machine::emscripten_load(const char *name) {
+	emscripten_running_machine->schedule_load(name);
+}
+
 #endif /* defined(EMSCRIPTEN) */

--- a/src/emu/machine.h
+++ b/src/emu/machine.h
@@ -406,6 +406,12 @@ public:
 	static running_machine * emscripten_get_running_machine();
 	static ui_manager * emscripten_get_ui();
 	static sound_manager * emscripten_get_sound();
+
+	static void emscripten_exit();
+	static void emscripten_hard_reset();
+	static void emscripten_soft_reset();
+	static void emscripten_save(const char *name);
+	static void emscripten_load(const char *name);
 #endif
 };
 


### PR DESCRIPTION
This patch adds some additional static member functions and exports them to allow control of the running system via a Javascript API in the web builds.  Example:

```js
JSMESS.save('statename');
JSMESS.load('statename');
JSMESS.soft_reset();
JSMESS.hard_reset();
JSMESS.exit();
```