### PR TITLE
manual video mixing in gaelco.cpp

### DIFF
--- a/src/mame/includes/gaelco.h
+++ b/src/mame/includes/gaelco.h
@@ -18,26 +18,12 @@ public:
 		m_palette(*this, "palette"),
 		m_audiocpu(*this, "audiocpu"),
 		m_soundlatch(*this, "soundlatch"),
+		m_screen(*this, "screen"),
 		m_videoram(*this, "videoram"),
 		m_vregs(*this, "vregs"),
 		m_spriteram(*this, "spriteram"),
-		m_screenram(*this, "screenram") { }
-
-	/* devices */
-	required_device<cpu_device> m_maincpu;
-	required_device<gfxdecode_device> m_gfxdecode;
-	required_device<palette_device> m_palette;
-	optional_device<cpu_device> m_audiocpu;
-	optional_device<generic_latch_8_device> m_soundlatch;
-
-	/* memory pointers */
-	required_shared_ptr<uint16_t> m_videoram;
-	required_shared_ptr<uint16_t> m_vregs;
-	required_shared_ptr<uint16_t> m_spriteram;
-	optional_shared_ptr<uint16_t> m_screenram;
-
-	/* video-related */
-	tilemap_t      *m_tilemap[2];
+		m_screenram(*this, "screenram")
+	{ }
 
 	DECLARE_WRITE8_MEMBER(bigkarnk_sound_command_w);
 	DECLARE_WRITE8_MEMBER(bigkarnk_coin_w);
@@ -57,5 +43,29 @@ public:
 
 	uint32_t screen_update_bigkarnk(screen_device &screen, bitmap_ind16 &bitmap, const rectangle &cliprect);
 	uint32_t screen_update_maniacsq(screen_device &screen, bitmap_ind16 &bitmap, const rectangle &cliprect);
+
+private:
+	/* devices */
+	required_device<cpu_device> m_maincpu;
+	required_device<gfxdecode_device> m_gfxdecode;
+	required_device<palette_device> m_palette;
+	optional_device<cpu_device> m_audiocpu;
+	optional_device<generic_latch_8_device> m_soundlatch;
+	required_device<screen_device> m_screen;
+
+	/* memory pointers */
+	required_shared_ptr<uint16_t> m_videoram;
+	required_shared_ptr<uint16_t> m_vregs;
+	required_shared_ptr<uint16_t> m_spriteram;
+	optional_shared_ptr<uint16_t> m_screenram;
+
+	/* video-related */
+	tilemap_t      *m_tilemap[2];
+
+	bitmap_ind16 m_temp_bitmap_bg0;
+	bitmap_ind16 m_temp_bitmap_bg1;
+	bitmap_ind16 m_temp_bitmap_sprites;
+
 	void draw_sprites( screen_device &screen, bitmap_ind16 &bitmap, const rectangle &cliprect );
+	void draw_sprites_bigkarnk(screen_device &screen, bitmap_ind16 &bitmap, const rectangle &cliprect);
 };

--- a/src/mame/video/gaelco.cpp
+++ b/src/mame/video/gaelco.cpp
@@ -86,11 +86,12 @@ VIDEO_START_MEMBER(gaelco_state,bigkarnk)
 
 VIDEO_START_MEMBER(gaelco_state,maniacsq)
 {
+	m_screen->register_screen_bitmap(m_temp_bitmap_bg0);
+	m_screen->register_screen_bitmap(m_temp_bitmap_bg1);
+	m_screen->register_screen_bitmap(m_temp_bitmap_sprites);
+
 	m_tilemap[0] = &machine().tilemap().create(*m_gfxdecode, tilemap_get_info_delegate(FUNC(gaelco_state::get_tile_info_gaelco_screen0),this), TILEMAP_SCAN_ROWS, 16, 16, 32, 32);
 	m_tilemap[1] = &machine().tilemap().create(*m_gfxdecode, tilemap_get_info_delegate(FUNC(gaelco_state::get_tile_info_gaelco_screen1),this), TILEMAP_SCAN_ROWS, 16, 16, 32, 32);
-
-	m_tilemap[0]->set_transparent_pen(0);
-	m_tilemap[1]->set_transparent_pen(0);
 }
 
 
@@ -120,6 +121,59 @@ VIDEO_START_MEMBER(gaelco_state,maniacsq)
 */
 
 void gaelco_state::draw_sprites( screen_device &screen, bitmap_ind16 &bitmap, const rectangle &cliprect )
+{
+	int i, x, y, ex, ey;
+	gfx_element *gfx = m_gfxdecode->gfx(0);
+
+	static const int x_offset[2] = {0x0,0x2};
+	static const int y_offset[2] = {0x0,0x1};
+
+	for (i = 3; i < 0x800; i += 4)
+	{
+		int sx = m_spriteram[i + 2] & 0x01ff;
+		int sy = (240 - (m_spriteram[i] & 0x00ff)) & 0x00ff;
+		int number = m_spriteram[i + 3];
+		int color = (m_spriteram[i + 2] & 0x7e00) >> 9;
+		int attr = (m_spriteram[i] & 0xfe00) >> 9;
+		int priority = (m_spriteram[i] & 0x1000) >> 12;
+		int priority2 = (m_spriteram[i] & 0x2000) >> 13;
+
+		int xflip = attr & 0x20;
+		int yflip = attr & 0x40;
+		int spr_size;
+
+		// these do appear to be in reverse order
+		color |= priority2 << 6;
+		color |= priority << 7;
+
+		if (attr & 0x04)
+			spr_size = 1;
+		else
+		{
+			spr_size = 2;
+			number &= (~3);
+		}
+
+		for (y = 0; y < spr_size; y++)
+		{
+			for (x = 0; x < spr_size; x++)
+			{
+				ex = xflip ? (spr_size - 1 - x) : x;
+				ey = yflip ? (spr_size - 1 - y) : y;
+
+				gfx->transpen_raw(bitmap,cliprect,number + x_offset[ex] + y_offset[ey],
+						color<<4,xflip,yflip,
+						sx-0x0f+x*8,sy+y*8,
+						0);
+			}
+		}
+	}
+}
+
+// Big Karnak still relies on sprites with palettes 0x38 - 0x3f being forced to higher priority
+// I have a feeling this isn't entirely correct but works for this game, however the mixing
+// etc. does not appear to work the same way as the other games
+void gaelco_state::draw_sprites_bigkarnk( screen_device &screen, bitmap_ind16 &bitmap, const rectangle &cliprect )
 {
 	int i, x, y, ex, ey;
 	gfx_element *gfx = m_gfxdecode->gfx(0);
@@ -186,28 +240,71 @@ void gaelco_state::draw_sprites( screen_device &screen, bitmap_ind16 &bitmap, co
 
 uint32_t gaelco_state::screen_update_maniacsq(screen_device &screen, bitmap_ind16 &bitmap, const rectangle &cliprect)
 {
-	/* set scroll registers */
-	m_tilemap[0]->set_scrolly(0, m_vregs[0]);
-	m_tilemap[0]->set_scrollx(0, m_vregs[1] + 4);
-	m_tilemap[1]->set_scrolly(0, m_vregs[2]);
-	m_tilemap[1]->set_scrollx(0, m_vregs[3]);
+	m_temp_bitmap_bg0.fill(0, cliprect);
+	m_temp_bitmap_bg1.fill(0, cliprect);
+	m_temp_bitmap_sprites.fill(0, cliprect);
 
-	screen.priority().fill(0, cliprect);
-	bitmap.fill(0, cliprect);
+	draw_sprites(screen, m_temp_bitmap_sprites, cliprect);
 
-	m_tilemap[1]->draw(screen, bitmap, cliprect, 3, 0);
-	m_tilemap[0]->draw(screen, bitmap, cliprect, 3, 0);
+	const bitmap_ind16 &bg0_pixmap = m_tilemap[0]->pixmap();
+	const bitmap_ind8 &bg0_flagsmap = m_tilemap[0]->flagsmap();
+	const bitmap_ind16 &bg1_pixmap = m_tilemap[1]->pixmap();
+	const bitmap_ind8 &bg1_flagsmap = m_tilemap[1]->flagsmap();
 
-	m_tilemap[1]->draw(screen, bitmap, cliprect, 2, 1);
-	m_tilemap[0]->draw(screen, bitmap, cliprect, 2, 1);
+	for (int y = cliprect.min_y;y < cliprect.max_y;y++)
+	{
+		int yoff;
+		yoff = (y + m_vregs[0])&(m_tilemap[0]->height() - 1);
+		uint16_t *src1 = &bg0_pixmap.pix16(yoff);
+		uint8_t *src1flags = &bg0_flagsmap.pix8(yoff);
+		yoff = (y + m_vregs[2])&(m_tilemap[1]->height() - 1);
+		uint16_t *src2 = &bg1_pixmap.pix16(yoff);
+		uint8_t *src2flags = &bg1_flagsmap.pix8(yoff);
 
-	m_tilemap[1]->draw(screen, bitmap, cliprect, 1, 2);
-	m_tilemap[0]->draw(screen, bitmap, cliprect, 1, 2);
+		uint16_t *src3 = &m_temp_bitmap_sprites.pix16(y);
 
-	m_tilemap[1]->draw(screen, bitmap, cliprect, 0, 4);
-	m_tilemap[0]->draw(screen, bitmap, cliprect, 0, 4);
+		uint16_t *dst = &bitmap.pix16(y);
 
-	draw_sprites(screen, bitmap, cliprect);
+		for (int x = cliprect.min_x;x < cliprect.max_x;x++)
+		{
+			int xoff;
+			xoff = (x + m_vregs[1] + 4)&(m_tilemap[0]->width() - 1);
+			uint16_t src1dat = src1[xoff] | (src1flags[xoff] & 0x03) << 10;
+			xoff = (x + m_vregs[3])&(m_tilemap[0]->width() - 1);
+			uint16_t src2dat = src2[xoff] | (src2flags[xoff] & 0x03) << 10;;
+
+			uint16_t src3dat = src3[x];
+
+			dst[x] = src1dat & 0x3ff; // so we have a bgpen
+
+			uint16_t lastdrawn = 0xffff;
+
+			if (src1dat & 0xf)
+			{
+				dst[x] = src1dat & 0x3ff;
+				lastdrawn = src1dat & 0xfff;
+			}
+
+			if (src2dat & 0xf)
+			{
+				if (((src2dat & 0xfff) <= lastdrawn)) // could be <= or <
+				{
+					dst[x] = src2dat & 0x3ff;
+					lastdrawn = src2dat & 0xfff;
+				}
+			}
+
+			if (src3dat & 0xf)
+			{
+				if (((src3dat & 0xfff) <= lastdrawn))
+				{
+					dst[x] = src3dat & 0x3ff;
+					lastdrawn = src3dat & 0xfff;
+				}
+			}
+		}
+	}
+
 	return 0;
 }
 
@@ -246,6 +343,6 @@ uint32_t gaelco_state::screen_update_bigkarnk(screen_device &screen, bitmap_ind1
 	m_tilemap[1]->draw(screen, bitmap, cliprect, TILEMAP_DRAW_LAYER0 | 0, 8);
 	m_tilemap[0]->draw(screen, bitmap, cliprect, TILEMAP_DRAW_LAYER0 | 0, 8);
 
-	draw_sprites(screen, bitmap, cliprect);
+	draw_sprites_bigkarnk(screen, bitmap, cliprect);
 	return 0;
 }


### PR DESCRIPTION
this improves the priorities in squash (players are behind the glass barrier) and thunder hoop (green slime in first level) at least.

I wasn't able to get it working properly with Big Karnak, but that does seem to be slightly different hardware so might have different mixing.

I'd be interested in knowing if anybody finds any regressions with Thunder Hoop, Biomechanical Toy, Squash or Maniac Square (prototype) with these changes, I haven't found any myself but I'm not great at the games.