### PR TITLE
[MC6847] Fixed the "Semigraphics 6" mode on the CoCo/MC-10

### DIFF
--- a/src/devices/video/mc6847.cpp
+++ b/src/devices/video/mc6847.cpp
@@ -923,7 +923,7 @@ mc6847_friend_device::character_map::character_map(const uint8_t *text_fontdata,
 		uint16_t color_base_0;
 		uint16_t color_base_1;
 
-		if ((mode & (MODE_INTEXT | MODE_AS)) == MODE_AS)
+		if ((mode & ((is_mc6847t1 ? 0 : MODE_INTEXT) | MODE_AS)) == MODE_AS)
 		{
 			// semigraphics 4
 			fontdata = semigraphics4_fontdata8x12;

--- a/src/devices/video/mc6847.cpp
+++ b/src/devices/video/mc6847.cpp
@@ -908,6 +908,8 @@ mc6847_friend_device::character_map::character_map(const uint8_t *text_fontdata,
 		m_text_fontdata_lower_case[i]           = text_fontdata[i + (i < 32*12 ? 64*12 : 0)] ^ (i < 32*12 ? 0xFF : 0x00);
 		m_text_fontdata_lower_case_inverse[i]   = m_text_fontdata_lower_case[i] ^ 0xFF;
 	}
+	for (int i = 0; i < 128*12; i++)
+		m_stripes[i] = ~(i / 12);
 
 	// loop through all modes
 	for (mode = 0; mode < ARRAY_LENGTH(m_entries); mode++)
@@ -921,7 +923,17 @@ mc6847_friend_device::character_map::character_map(const uint8_t *text_fontdata,
 		uint16_t color_base_0;
 		uint16_t color_base_1;
 
-		if ((mode & MODE_INTEXT) && !is_mc6847t1)
+		if ((mode & (MODE_INTEXT | MODE_AS)) == MODE_AS)
+		{
+			// semigraphics 4
+			fontdata = semigraphics4_fontdata8x12;
+			character_mask      = 0x0F;
+			color_base_0        = 8;
+			color_base_1        = 0;
+			color_shift_1       = 4;
+			color_mask_1        = 0x07;
+		}
+		else if (((mode & (MODE_INTEXT | MODE_AS)) == (MODE_INTEXT | MODE_AS)) && !is_mc6847t1)
 		{
 			// semigraphics 6
 			fontdata            = semigraphics6_fontdata8x12;
@@ -931,15 +943,14 @@ mc6847_friend_device::character_map::character_map(const uint8_t *text_fontdata,
 			color_shift_1       = 6;
 			color_mask_1        = 0x03;
 		}
-		else if (mode & MODE_AS)
+		else if (((mode & (MODE_INTEXT | MODE_AS)) == MODE_INTEXT) && !is_mc6847t1)
 		{
-			// semigraphics 4
-			fontdata            = semigraphics4_fontdata8x12;
-			character_mask      = 0x0F;
-			color_base_0        = 8;
-			color_base_1        = 0;
-			color_shift_1       = 4;
-			color_mask_1        = 0x07;
+			// so-called "stripe" mode - this is when INTEXT is specified but we don't have
+			// an external ROM nor are we on an MC6847T1
+			fontdata            = m_stripes;
+			character_mask      = 0x7F;
+			color_base_0		= (mode & MODE_CSS ? 14 : 12);
+			color_base_1		= (mode & MODE_CSS ? 15 : 13);
 		}
 		else
 		{

--- a/src/devices/video/mc6847.h
+++ b/src/devices/video/mc6847.h
@@ -109,6 +109,7 @@ protected:
 	static const uint8_t semigraphics4_fontdata8x12[];
 	static const uint8_t semigraphics6_fontdata8x12[];
 	static const uint8_t s68047_fontdata8x12[];
+	static const uint8_t stripes[];
 
 	// pixel definitions
 	typedef uint32_t pixel_t;
@@ -186,6 +187,7 @@ protected:
 		uint8_t m_text_fontdata_inverse[64*12];
 		uint8_t m_text_fontdata_lower_case[64*12];
 		uint8_t m_text_fontdata_lower_case_inverse[64*12];
+		uint8_t m_stripes[128*12];
 
 		// optimized function that tests a single bit
 		ATTR_FORCE_INLINE pixel_t bit_test(uint8_t data, int shift, pixel_t color_0, pixel_t color_1)


### PR DESCRIPTION
On these systems, the "Semigraphics 6" mode (contrary to most literature) will display "stripes" for video bytes from $00-$7F.  This is because the INTEXT pin on the MC6847 VDG is set, but AS is not and there is no external ROM.

This was reported by Jim Gerrie:  https://www.youtube.com/watch?v=VmsWqdiwH2o