### PR TITLE
SDA5708 layout for dbox

### DIFF
--- a/src/devices/video/sda5708.h
+++ b/src/devices/video/sda5708.h
@@ -71,6 +71,8 @@ protected:
 	virtual void device_start() override;
 	virtual void device_reset() override;
 
+	void update_display();
+
 private:
 	enum {
 		SDA5708_REG_MASK       = 0xE0,
@@ -111,6 +113,9 @@ private:
 	uint8_t m_dispmem[7 * 8];
 	uint8_t m_cdp;
 	uint8_t m_digit;
+	uint8_t m_bright;
+	uint8_t m_clear;
+	uint8_t m_ip;
 };
 
 

--- a/src/mame/drivers/dbox.cpp
+++ b/src/mame/drivers/dbox.cpp
@@ -340,6 +340,8 @@
 #include "video/sda5708.h"
 #include "machine/latch8.h" // IP16
 
+#include "sda5708.lh"
+
 //**************************************************************************
 //  MACROS / CONSTANTS
 //**************************************************************************
@@ -427,7 +429,7 @@ static MACHINE_CONFIG_START( dbox )
 
 	/* LED Matrix Display */
 	MCFG_SDA5708_ADD("display")
-
+	MCFG_DEFAULT_LAYOUT(layout_sda5708)
 	/* IP16 74256 8 bit latch */
 	MCFG_LATCH8_ADD("hct259.ip16")
 	MCFG_LATCH8_WRITE_4(DEVWRITELINE("display", sda5708_device, reset_w))

--- a/src/mame/layout/sda5708.lay
+++ b/src/mame/layout/sda5708.lay
@@ -1,0 +1,365 @@
+<?xml version="1.0"?>
+<!-- sda5708.lay -->
+<!-- 2017-07-18:  -->
+
+<mamelayout version="2">
+
+	<element name="Pixel">
+	<!-- The data sheet says 575nm wave length which is yellow but occular comparison
+		 suggests ~515nm which is green and also stated as the color in the data sheet
+		 The colors below are green based on the occular comparison with the real hardware -->
+		<disk state="0">
+			<color red="0.12" green="1.0" blue="0.0" />
+			<bounds x="0" y="0" width="1" height="1" />
+		</disk>
+		<disk state="1">
+			<color red="0.064" green="0.53" blue="0.0" />
+			<bounds x="0" y="0" width="1" height="1" />
+		</disk>
+		<disk state="2">
+			<color red="0.048" green="0.4" blue="0.0" />
+			<bounds x="0" y="0" width="1" height="1" />
+		</disk>
+		<disk state="3">
+			<color red="0.032" green="0.27" blue="0.0" />
+			<bounds x="0" y="0" width="1" height="1" />
+		</disk>
+		<disk state="4">
+			<color red="0.024" green="0.2" blue="0.0" />
+			<bounds x="0" y="0" width="1" height="1" />
+		</disk>
+		<disk state="5">
+			<color red="0.016" green="0.13" blue="0.0" />
+			<bounds x="0" y="0" width="1" height="1" />
+		</disk>
+		<disk state="6">
+			<color red="0.008" green="0.066" blue="0.0" />
+			<bounds x="0" y="0" width="1" height="1" />
+		</disk>
+		<disk state="7">
+			<color red="0.0" green="0.0" blue="0.0" />
+			<bounds x="0" y="0" width="1" height="1" />
+		</disk>
+	</element>
+
+	<element name="background">
+		<rect>
+			<bounds left="0" top="0" right="1" bottom="1" />
+			<color red="0.0" green="0.0" blue="0.0" />
+		</rect>
+	</element>
+
+	<view name="Default Layout">
+		<!-- Background -->
+		<backdrop element="background">
+			<bounds left="0" top="0" right="150" bottom="20" />
+		</backdrop>
+
+<!-- The following program generated the bezels with mechanical data from the data sheet
+#include <stdio.h>      /* printf */
+
+int main()
+{
+	int digits = 8; // 8 digits
+	int cols   = 5; // 5 rows in each digit
+	int rows   = 7; // 7 columns in each digit
+	int size   = 100; // size of each led
+	int dsx    = 380; // distance between each digit
+	int psx    = 111 - size; // horizontal distance between leds
+	int psy    = 114 - size; // vertical distance between leds
+
+	for (int d = 1; d <= digits; d++ ){
+		for (int y = 1; y <= rows; y++){
+			for (int x = 1; x <= cols; x++)	{
+					printf( "<bezel name=\"Dot_%d\" element=\"Pixel\" state=\"0\"><bounds x=\"%d\" y=\"%d\" width=\"%d\" height=\"%d\"/></bezel>\n",
+							d * 100 + y * 10 +  x,
+							(d - 1) * (cols *(size + psx) + dsx) + (x - 1) * (size + psx),
+							(y - 1) * (psy + size), size, size);
+			}
+		}
+	}
+}
+-->
+<bezel name="Dot_111" element="Pixel" state="0"><bounds x="0" y="0" width="100" height="100"/></bezel>
+<bezel name="Dot_112" element="Pixel" state="0"><bounds x="111" y="0" width="100" height="100"/></bezel>
+<bezel name="Dot_113" element="Pixel" state="0"><bounds x="222" y="0" width="100" height="100"/></bezel>
+<bezel name="Dot_114" element="Pixel" state="0"><bounds x="333" y="0" width="100" height="100"/></bezel>
+<bezel name="Dot_115" element="Pixel" state="0"><bounds x="444" y="0" width="100" height="100"/></bezel>
+<bezel name="Dot_121" element="Pixel" state="0"><bounds x="0" y="114" width="100" height="100"/></bezel>
+<bezel name="Dot_122" element="Pixel" state="0"><bounds x="111" y="114" width="100" height="100"/></bezel>
+<bezel name="Dot_123" element="Pixel" state="0"><bounds x="222" y="114" width="100" height="100"/></bezel>
+<bezel name="Dot_124" element="Pixel" state="0"><bounds x="333" y="114" width="100" height="100"/></bezel>
+<bezel name="Dot_125" element="Pixel" state="0"><bounds x="444" y="114" width="100" height="100"/></bezel>
+<bezel name="Dot_131" element="Pixel" state="0"><bounds x="0" y="228" width="100" height="100"/></bezel>
+<bezel name="Dot_132" element="Pixel" state="0"><bounds x="111" y="228" width="100" height="100"/></bezel>
+<bezel name="Dot_133" element="Pixel" state="0"><bounds x="222" y="228" width="100" height="100"/></bezel>
+<bezel name="Dot_134" element="Pixel" state="0"><bounds x="333" y="228" width="100" height="100"/></bezel>
+<bezel name="Dot_135" element="Pixel" state="0"><bounds x="444" y="228" width="100" height="100"/></bezel>
+<bezel name="Dot_141" element="Pixel" state="0"><bounds x="0" y="342" width="100" height="100"/></bezel>
+<bezel name="Dot_142" element="Pixel" state="0"><bounds x="111" y="342" width="100" height="100"/></bezel>
+<bezel name="Dot_143" element="Pixel" state="0"><bounds x="222" y="342" width="100" height="100"/></bezel>
+<bezel name="Dot_144" element="Pixel" state="0"><bounds x="333" y="342" width="100" height="100"/></bezel>
+<bezel name="Dot_145" element="Pixel" state="0"><bounds x="444" y="342" width="100" height="100"/></bezel>
+<bezel name="Dot_151" element="Pixel" state="0"><bounds x="0" y="456" width="100" height="100"/></bezel>
+<bezel name="Dot_152" element="Pixel" state="0"><bounds x="111" y="456" width="100" height="100"/></bezel>
+<bezel name="Dot_153" element="Pixel" state="0"><bounds x="222" y="456" width="100" height="100"/></bezel>
+<bezel name="Dot_154" element="Pixel" state="0"><bounds x="333" y="456" width="100" height="100"/></bezel>
+<bezel name="Dot_155" element="Pixel" state="0"><bounds x="444" y="456" width="100" height="100"/></bezel>
+<bezel name="Dot_161" element="Pixel" state="0"><bounds x="0" y="570" width="100" height="100"/></bezel>
+<bezel name="Dot_162" element="Pixel" state="0"><bounds x="111" y="570" width="100" height="100"/></bezel>
+<bezel name="Dot_163" element="Pixel" state="0"><bounds x="222" y="570" width="100" height="100"/></bezel>
+<bezel name="Dot_164" element="Pixel" state="0"><bounds x="333" y="570" width="100" height="100"/></bezel>
+<bezel name="Dot_165" element="Pixel" state="0"><bounds x="444" y="570" width="100" height="100"/></bezel>
+<bezel name="Dot_171" element="Pixel" state="0"><bounds x="0" y="684" width="100" height="100"/></bezel>
+<bezel name="Dot_172" element="Pixel" state="0"><bounds x="111" y="684" width="100" height="100"/></bezel>
+<bezel name="Dot_173" element="Pixel" state="0"><bounds x="222" y="684" width="100" height="100"/></bezel>
+<bezel name="Dot_174" element="Pixel" state="0"><bounds x="333" y="684" width="100" height="100"/></bezel>
+<bezel name="Dot_175" element="Pixel" state="0"><bounds x="444" y="684" width="100" height="100"/></bezel>
+<bezel name="Dot_211" element="Pixel" state="0"><bounds x="935" y="0" width="100" height="100"/></bezel>
+<bezel name="Dot_212" element="Pixel" state="0"><bounds x="1046" y="0" width="100" height="100"/></bezel>
+<bezel name="Dot_213" element="Pixel" state="0"><bounds x="1157" y="0" width="100" height="100"/></bezel>
+<bezel name="Dot_214" element="Pixel" state="0"><bounds x="1268" y="0" width="100" height="100"/></bezel>
+<bezel name="Dot_215" element="Pixel" state="0"><bounds x="1379" y="0" width="100" height="100"/></bezel>
+<bezel name="Dot_221" element="Pixel" state="0"><bounds x="935" y="114" width="100" height="100"/></bezel>
+<bezel name="Dot_222" element="Pixel" state="0"><bounds x="1046" y="114" width="100" height="100"/></bezel>
+<bezel name="Dot_223" element="Pixel" state="0"><bounds x="1157" y="114" width="100" height="100"/></bezel>
+<bezel name="Dot_224" element="Pixel" state="0"><bounds x="1268" y="114" width="100" height="100"/></bezel>
+<bezel name="Dot_225" element="Pixel" state="0"><bounds x="1379" y="114" width="100" height="100"/></bezel>
+<bezel name="Dot_231" element="Pixel" state="0"><bounds x="935" y="228" width="100" height="100"/></bezel>
+<bezel name="Dot_232" element="Pixel" state="0"><bounds x="1046" y="228" width="100" height="100"/></bezel>
+<bezel name="Dot_233" element="Pixel" state="0"><bounds x="1157" y="228" width="100" height="100"/></bezel>
+<bezel name="Dot_234" element="Pixel" state="0"><bounds x="1268" y="228" width="100" height="100"/></bezel>
+<bezel name="Dot_235" element="Pixel" state="0"><bounds x="1379" y="228" width="100" height="100"/></bezel>
+<bezel name="Dot_241" element="Pixel" state="0"><bounds x="935" y="342" width="100" height="100"/></bezel>
+<bezel name="Dot_242" element="Pixel" state="0"><bounds x="1046" y="342" width="100" height="100"/></bezel>
+<bezel name="Dot_243" element="Pixel" state="0"><bounds x="1157" y="342" width="100" height="100"/></bezel>
+<bezel name="Dot_244" element="Pixel" state="0"><bounds x="1268" y="342" width="100" height="100"/></bezel>
+<bezel name="Dot_245" element="Pixel" state="0"><bounds x="1379" y="342" width="100" height="100"/></bezel>
+<bezel name="Dot_251" element="Pixel" state="0"><bounds x="935" y="456" width="100" height="100"/></bezel>
+<bezel name="Dot_252" element="Pixel" state="0"><bounds x="1046" y="456" width="100" height="100"/></bezel>
+<bezel name="Dot_253" element="Pixel" state="0"><bounds x="1157" y="456" width="100" height="100"/></bezel>
+<bezel name="Dot_254" element="Pixel" state="0"><bounds x="1268" y="456" width="100" height="100"/></bezel>
+<bezel name="Dot_255" element="Pixel" state="0"><bounds x="1379" y="456" width="100" height="100"/></bezel>
+<bezel name="Dot_261" element="Pixel" state="0"><bounds x="935" y="570" width="100" height="100"/></bezel>
+<bezel name="Dot_262" element="Pixel" state="0"><bounds x="1046" y="570" width="100" height="100"/></bezel>
+<bezel name="Dot_263" element="Pixel" state="0"><bounds x="1157" y="570" width="100" height="100"/></bezel>
+<bezel name="Dot_264" element="Pixel" state="0"><bounds x="1268" y="570" width="100" height="100"/></bezel>
+<bezel name="Dot_265" element="Pixel" state="0"><bounds x="1379" y="570" width="100" height="100"/></bezel>
+<bezel name="Dot_271" element="Pixel" state="0"><bounds x="935" y="684" width="100" height="100"/></bezel>
+<bezel name="Dot_272" element="Pixel" state="0"><bounds x="1046" y="684" width="100" height="100"/></bezel>
+<bezel name="Dot_273" element="Pixel" state="0"><bounds x="1157" y="684" width="100" height="100"/></bezel>
+<bezel name="Dot_274" element="Pixel" state="0"><bounds x="1268" y="684" width="100" height="100"/></bezel>
+<bezel name="Dot_275" element="Pixel" state="0"><bounds x="1379" y="684" width="100" height="100"/></bezel>
+<bezel name="Dot_311" element="Pixel" state="0"><bounds x="1870" y="0" width="100" height="100"/></bezel>
+<bezel name="Dot_312" element="Pixel" state="0"><bounds x="1981" y="0" width="100" height="100"/></bezel>
+<bezel name="Dot_313" element="Pixel" state="0"><bounds x="2092" y="0" width="100" height="100"/></bezel>
+<bezel name="Dot_314" element="Pixel" state="0"><bounds x="2203" y="0" width="100" height="100"/></bezel>
+<bezel name="Dot_315" element="Pixel" state="0"><bounds x="2314" y="0" width="100" height="100"/></bezel>
+<bezel name="Dot_321" element="Pixel" state="0"><bounds x="1870" y="114" width="100" height="100"/></bezel>
+<bezel name="Dot_322" element="Pixel" state="0"><bounds x="1981" y="114" width="100" height="100"/></bezel>
+<bezel name="Dot_323" element="Pixel" state="0"><bounds x="2092" y="114" width="100" height="100"/></bezel>
+<bezel name="Dot_324" element="Pixel" state="0"><bounds x="2203" y="114" width="100" height="100"/></bezel>
+<bezel name="Dot_325" element="Pixel" state="0"><bounds x="2314" y="114" width="100" height="100"/></bezel>
+<bezel name="Dot_331" element="Pixel" state="0"><bounds x="1870" y="228" width="100" height="100"/></bezel>
+<bezel name="Dot_332" element="Pixel" state="0"><bounds x="1981" y="228" width="100" height="100"/></bezel>
+<bezel name="Dot_333" element="Pixel" state="0"><bounds x="2092" y="228" width="100" height="100"/></bezel>
+<bezel name="Dot_334" element="Pixel" state="0"><bounds x="2203" y="228" width="100" height="100"/></bezel>
+<bezel name="Dot_335" element="Pixel" state="0"><bounds x="2314" y="228" width="100" height="100"/></bezel>
+<bezel name="Dot_341" element="Pixel" state="0"><bounds x="1870" y="342" width="100" height="100"/></bezel>
+<bezel name="Dot_342" element="Pixel" state="0"><bounds x="1981" y="342" width="100" height="100"/></bezel>
+<bezel name="Dot_343" element="Pixel" state="0"><bounds x="2092" y="342" width="100" height="100"/></bezel>
+<bezel name="Dot_344" element="Pixel" state="0"><bounds x="2203" y="342" width="100" height="100"/></bezel>
+<bezel name="Dot_345" element="Pixel" state="0"><bounds x="2314" y="342" width="100" height="100"/></bezel>
+<bezel name="Dot_351" element="Pixel" state="0"><bounds x="1870" y="456" width="100" height="100"/></bezel>
+<bezel name="Dot_352" element="Pixel" state="0"><bounds x="1981" y="456" width="100" height="100"/></bezel>
+<bezel name="Dot_353" element="Pixel" state="0"><bounds x="2092" y="456" width="100" height="100"/></bezel>
+<bezel name="Dot_354" element="Pixel" state="0"><bounds x="2203" y="456" width="100" height="100"/></bezel>
+<bezel name="Dot_355" element="Pixel" state="0"><bounds x="2314" y="456" width="100" height="100"/></bezel>
+<bezel name="Dot_361" element="Pixel" state="0"><bounds x="1870" y="570" width="100" height="100"/></bezel>
+<bezel name="Dot_362" element="Pixel" state="0"><bounds x="1981" y="570" width="100" height="100"/></bezel>
+<bezel name="Dot_363" element="Pixel" state="0"><bounds x="2092" y="570" width="100" height="100"/></bezel>
+<bezel name="Dot_364" element="Pixel" state="0"><bounds x="2203" y="570" width="100" height="100"/></bezel>
+<bezel name="Dot_365" element="Pixel" state="0"><bounds x="2314" y="570" width="100" height="100"/></bezel>
+<bezel name="Dot_371" element="Pixel" state="0"><bounds x="1870" y="684" width="100" height="100"/></bezel>
+<bezel name="Dot_372" element="Pixel" state="0"><bounds x="1981" y="684" width="100" height="100"/></bezel>
+<bezel name="Dot_373" element="Pixel" state="0"><bounds x="2092" y="684" width="100" height="100"/></bezel>
+<bezel name="Dot_374" element="Pixel" state="0"><bounds x="2203" y="684" width="100" height="100"/></bezel>
+<bezel name="Dot_375" element="Pixel" state="0"><bounds x="2314" y="684" width="100" height="100"/></bezel>
+<bezel name="Dot_411" element="Pixel" state="0"><bounds x="2805" y="0" width="100" height="100"/></bezel>
+<bezel name="Dot_412" element="Pixel" state="0"><bounds x="2916" y="0" width="100" height="100"/></bezel>
+<bezel name="Dot_413" element="Pixel" state="0"><bounds x="3027" y="0" width="100" height="100"/></bezel>
+<bezel name="Dot_414" element="Pixel" state="0"><bounds x="3138" y="0" width="100" height="100"/></bezel>
+<bezel name="Dot_415" element="Pixel" state="0"><bounds x="3249" y="0" width="100" height="100"/></bezel>
+<bezel name="Dot_421" element="Pixel" state="0"><bounds x="2805" y="114" width="100" height="100"/></bezel>
+<bezel name="Dot_422" element="Pixel" state="0"><bounds x="2916" y="114" width="100" height="100"/></bezel>
+<bezel name="Dot_423" element="Pixel" state="0"><bounds x="3027" y="114" width="100" height="100"/></bezel>
+<bezel name="Dot_424" element="Pixel" state="0"><bounds x="3138" y="114" width="100" height="100"/></bezel>
+<bezel name="Dot_425" element="Pixel" state="0"><bounds x="3249" y="114" width="100" height="100"/></bezel>
+<bezel name="Dot_431" element="Pixel" state="0"><bounds x="2805" y="228" width="100" height="100"/></bezel>
+<bezel name="Dot_432" element="Pixel" state="0"><bounds x="2916" y="228" width="100" height="100"/></bezel>
+<bezel name="Dot_433" element="Pixel" state="0"><bounds x="3027" y="228" width="100" height="100"/></bezel>
+<bezel name="Dot_434" element="Pixel" state="0"><bounds x="3138" y="228" width="100" height="100"/></bezel>
+<bezel name="Dot_435" element="Pixel" state="0"><bounds x="3249" y="228" width="100" height="100"/></bezel>
+<bezel name="Dot_441" element="Pixel" state="0"><bounds x="2805" y="342" width="100" height="100"/></bezel>
+<bezel name="Dot_442" element="Pixel" state="0"><bounds x="2916" y="342" width="100" height="100"/></bezel>
+<bezel name="Dot_443" element="Pixel" state="0"><bounds x="3027" y="342" width="100" height="100"/></bezel>
+<bezel name="Dot_444" element="Pixel" state="0"><bounds x="3138" y="342" width="100" height="100"/></bezel>
+<bezel name="Dot_445" element="Pixel" state="0"><bounds x="3249" y="342" width="100" height="100"/></bezel>
+<bezel name="Dot_451" element="Pixel" state="0"><bounds x="2805" y="456" width="100" height="100"/></bezel>
+<bezel name="Dot_452" element="Pixel" state="0"><bounds x="2916" y="456" width="100" height="100"/></bezel>
+<bezel name="Dot_453" element="Pixel" state="0"><bounds x="3027" y="456" width="100" height="100"/></bezel>
+<bezel name="Dot_454" element="Pixel" state="0"><bounds x="3138" y="456" width="100" height="100"/></bezel>
+<bezel name="Dot_455" element="Pixel" state="0"><bounds x="3249" y="456" width="100" height="100"/></bezel>
+<bezel name="Dot_461" element="Pixel" state="0"><bounds x="2805" y="570" width="100" height="100"/></bezel>
+<bezel name="Dot_462" element="Pixel" state="0"><bounds x="2916" y="570" width="100" height="100"/></bezel>
+<bezel name="Dot_463" element="Pixel" state="0"><bounds x="3027" y="570" width="100" height="100"/></bezel>
+<bezel name="Dot_464" element="Pixel" state="0"><bounds x="3138" y="570" width="100" height="100"/></bezel>
+<bezel name="Dot_465" element="Pixel" state="0"><bounds x="3249" y="570" width="100" height="100"/></bezel>
+<bezel name="Dot_471" element="Pixel" state="0"><bounds x="2805" y="684" width="100" height="100"/></bezel>
+<bezel name="Dot_472" element="Pixel" state="0"><bounds x="2916" y="684" width="100" height="100"/></bezel>
+<bezel name="Dot_473" element="Pixel" state="0"><bounds x="3027" y="684" width="100" height="100"/></bezel>
+<bezel name="Dot_474" element="Pixel" state="0"><bounds x="3138" y="684" width="100" height="100"/></bezel>
+<bezel name="Dot_475" element="Pixel" state="0"><bounds x="3249" y="684" width="100" height="100"/></bezel>
+<bezel name="Dot_511" element="Pixel" state="0"><bounds x="3740" y="0" width="100" height="100"/></bezel>
+<bezel name="Dot_512" element="Pixel" state="0"><bounds x="3851" y="0" width="100" height="100"/></bezel>
+<bezel name="Dot_513" element="Pixel" state="0"><bounds x="3962" y="0" width="100" height="100"/></bezel>
+<bezel name="Dot_514" element="Pixel" state="0"><bounds x="4073" y="0" width="100" height="100"/></bezel>
+<bezel name="Dot_515" element="Pixel" state="0"><bounds x="4184" y="0" width="100" height="100"/></bezel>
+<bezel name="Dot_521" element="Pixel" state="0"><bounds x="3740" y="114" width="100" height="100"/></bezel>
+<bezel name="Dot_522" element="Pixel" state="0"><bounds x="3851" y="114" width="100" height="100"/></bezel>
+<bezel name="Dot_523" element="Pixel" state="0"><bounds x="3962" y="114" width="100" height="100"/></bezel>
+<bezel name="Dot_524" element="Pixel" state="0"><bounds x="4073" y="114" width="100" height="100"/></bezel>
+<bezel name="Dot_525" element="Pixel" state="0"><bounds x="4184" y="114" width="100" height="100"/></bezel>
+<bezel name="Dot_531" element="Pixel" state="0"><bounds x="3740" y="228" width="100" height="100"/></bezel>
+<bezel name="Dot_532" element="Pixel" state="0"><bounds x="3851" y="228" width="100" height="100"/></bezel>
+<bezel name="Dot_533" element="Pixel" state="0"><bounds x="3962" y="228" width="100" height="100"/></bezel>
+<bezel name="Dot_534" element="Pixel" state="0"><bounds x="4073" y="228" width="100" height="100"/></bezel>
+<bezel name="Dot_535" element="Pixel" state="0"><bounds x="4184" y="228" width="100" height="100"/></bezel>
+<bezel name="Dot_541" element="Pixel" state="0"><bounds x="3740" y="342" width="100" height="100"/></bezel>
+<bezel name="Dot_542" element="Pixel" state="0"><bounds x="3851" y="342" width="100" height="100"/></bezel>
+<bezel name="Dot_543" element="Pixel" state="0"><bounds x="3962" y="342" width="100" height="100"/></bezel>
+<bezel name="Dot_544" element="Pixel" state="0"><bounds x="4073" y="342" width="100" height="100"/></bezel>
+<bezel name="Dot_545" element="Pixel" state="0"><bounds x="4184" y="342" width="100" height="100"/></bezel>
+<bezel name="Dot_551" element="Pixel" state="0"><bounds x="3740" y="456" width="100" height="100"/></bezel>
+<bezel name="Dot_552" element="Pixel" state="0"><bounds x="3851" y="456" width="100" height="100"/></bezel>
+<bezel name="Dot_553" element="Pixel" state="0"><bounds x="3962" y="456" width="100" height="100"/></bezel>
+<bezel name="Dot_554" element="Pixel" state="0"><bounds x="4073" y="456" width="100" height="100"/></bezel>
+<bezel name="Dot_555" element="Pixel" state="0"><bounds x="4184" y="456" width="100" height="100"/></bezel>
+<bezel name="Dot_561" element="Pixel" state="0"><bounds x="3740" y="570" width="100" height="100"/></bezel>
+<bezel name="Dot_562" element="Pixel" state="0"><bounds x="3851" y="570" width="100" height="100"/></bezel>
+<bezel name="Dot_563" element="Pixel" state="0"><bounds x="3962" y="570" width="100" height="100"/></bezel>
+<bezel name="Dot_564" element="Pixel" state="0"><bounds x="4073" y="570" width="100" height="100"/></bezel>
+<bezel name="Dot_565" element="Pixel" state="0"><bounds x="4184" y="570" width="100" height="100"/></bezel>
+<bezel name="Dot_571" element="Pixel" state="0"><bounds x="3740" y="684" width="100" height="100"/></bezel>
+<bezel name="Dot_572" element="Pixel" state="0"><bounds x="3851" y="684" width="100" height="100"/></bezel>
+<bezel name="Dot_573" element="Pixel" state="0"><bounds x="3962" y="684" width="100" height="100"/></bezel>
+<bezel name="Dot_574" element="Pixel" state="0"><bounds x="4073" y="684" width="100" height="100"/></bezel>
+<bezel name="Dot_575" element="Pixel" state="0"><bounds x="4184" y="684" width="100" height="100"/></bezel>
+<bezel name="Dot_611" element="Pixel" state="0"><bounds x="4675" y="0" width="100" height="100"/></bezel>
+<bezel name="Dot_612" element="Pixel" state="0"><bounds x="4786" y="0" width="100" height="100"/></bezel>
+<bezel name="Dot_613" element="Pixel" state="0"><bounds x="4897" y="0" width="100" height="100"/></bezel>
+<bezel name="Dot_614" element="Pixel" state="0"><bounds x="5008" y="0" width="100" height="100"/></bezel>
+<bezel name="Dot_615" element="Pixel" state="0"><bounds x="5119" y="0" width="100" height="100"/></bezel>
+<bezel name="Dot_621" element="Pixel" state="0"><bounds x="4675" y="114" width="100" height="100"/></bezel>
+<bezel name="Dot_622" element="Pixel" state="0"><bounds x="4786" y="114" width="100" height="100"/></bezel>
+<bezel name="Dot_623" element="Pixel" state="0"><bounds x="4897" y="114" width="100" height="100"/></bezel>
+<bezel name="Dot_624" element="Pixel" state="0"><bounds x="5008" y="114" width="100" height="100"/></bezel>
+<bezel name="Dot_625" element="Pixel" state="0"><bounds x="5119" y="114" width="100" height="100"/></bezel>
+<bezel name="Dot_631" element="Pixel" state="0"><bounds x="4675" y="228" width="100" height="100"/></bezel>
+<bezel name="Dot_632" element="Pixel" state="0"><bounds x="4786" y="228" width="100" height="100"/></bezel>
+<bezel name="Dot_633" element="Pixel" state="0"><bounds x="4897" y="228" width="100" height="100"/></bezel>
+<bezel name="Dot_634" element="Pixel" state="0"><bounds x="5008" y="228" width="100" height="100"/></bezel>
+<bezel name="Dot_635" element="Pixel" state="0"><bounds x="5119" y="228" width="100" height="100"/></bezel>
+<bezel name="Dot_641" element="Pixel" state="0"><bounds x="4675" y="342" width="100" height="100"/></bezel>
+<bezel name="Dot_642" element="Pixel" state="0"><bounds x="4786" y="342" width="100" height="100"/></bezel>
+<bezel name="Dot_643" element="Pixel" state="0"><bounds x="4897" y="342" width="100" height="100"/></bezel>
+<bezel name="Dot_644" element="Pixel" state="0"><bounds x="5008" y="342" width="100" height="100"/></bezel>
+<bezel name="Dot_645" element="Pixel" state="0"><bounds x="5119" y="342" width="100" height="100"/></bezel>
+<bezel name="Dot_651" element="Pixel" state="0"><bounds x="4675" y="456" width="100" height="100"/></bezel>
+<bezel name="Dot_652" element="Pixel" state="0"><bounds x="4786" y="456" width="100" height="100"/></bezel>
+<bezel name="Dot_653" element="Pixel" state="0"><bounds x="4897" y="456" width="100" height="100"/></bezel>
+<bezel name="Dot_654" element="Pixel" state="0"><bounds x="5008" y="456" width="100" height="100"/></bezel>
+<bezel name="Dot_655" element="Pixel" state="0"><bounds x="5119" y="456" width="100" height="100"/></bezel>
+<bezel name="Dot_661" element="Pixel" state="0"><bounds x="4675" y="570" width="100" height="100"/></bezel>
+<bezel name="Dot_662" element="Pixel" state="0"><bounds x="4786" y="570" width="100" height="100"/></bezel>
+<bezel name="Dot_663" element="Pixel" state="0"><bounds x="4897" y="570" width="100" height="100"/></bezel>
+<bezel name="Dot_664" element="Pixel" state="0"><bounds x="5008" y="570" width="100" height="100"/></bezel>
+<bezel name="Dot_665" element="Pixel" state="0"><bounds x="5119" y="570" width="100" height="100"/></bezel>
+<bezel name="Dot_671" element="Pixel" state="0"><bounds x="4675" y="684" width="100" height="100"/></bezel>
+<bezel name="Dot_672" element="Pixel" state="0"><bounds x="4786" y="684" width="100" height="100"/></bezel>
+<bezel name="Dot_673" element="Pixel" state="0"><bounds x="4897" y="684" width="100" height="100"/></bezel>
+<bezel name="Dot_674" element="Pixel" state="0"><bounds x="5008" y="684" width="100" height="100"/></bezel>
+<bezel name="Dot_675" element="Pixel" state="0"><bounds x="5119" y="684" width="100" height="100"/></bezel>
+<bezel name="Dot_711" element="Pixel" state="0"><bounds x="5610" y="0" width="100" height="100"/></bezel>
+<bezel name="Dot_712" element="Pixel" state="0"><bounds x="5721" y="0" width="100" height="100"/></bezel>
+<bezel name="Dot_713" element="Pixel" state="0"><bounds x="5832" y="0" width="100" height="100"/></bezel>
+<bezel name="Dot_714" element="Pixel" state="0"><bounds x="5943" y="0" width="100" height="100"/></bezel>
+<bezel name="Dot_715" element="Pixel" state="0"><bounds x="6054" y="0" width="100" height="100"/></bezel>
+<bezel name="Dot_721" element="Pixel" state="0"><bounds x="5610" y="114" width="100" height="100"/></bezel>
+<bezel name="Dot_722" element="Pixel" state="0"><bounds x="5721" y="114" width="100" height="100"/></bezel>
+<bezel name="Dot_723" element="Pixel" state="0"><bounds x="5832" y="114" width="100" height="100"/></bezel>
+<bezel name="Dot_724" element="Pixel" state="0"><bounds x="5943" y="114" width="100" height="100"/></bezel>
+<bezel name="Dot_725" element="Pixel" state="0"><bounds x="6054" y="114" width="100" height="100"/></bezel>
+<bezel name="Dot_731" element="Pixel" state="0"><bounds x="5610" y="228" width="100" height="100"/></bezel>
+<bezel name="Dot_732" element="Pixel" state="0"><bounds x="5721" y="228" width="100" height="100"/></bezel>
+<bezel name="Dot_733" element="Pixel" state="0"><bounds x="5832" y="228" width="100" height="100"/></bezel>
+<bezel name="Dot_734" element="Pixel" state="0"><bounds x="5943" y="228" width="100" height="100"/></bezel>
+<bezel name="Dot_735" element="Pixel" state="0"><bounds x="6054" y="228" width="100" height="100"/></bezel>
+<bezel name="Dot_741" element="Pixel" state="0"><bounds x="5610" y="342" width="100" height="100"/></bezel>
+<bezel name="Dot_742" element="Pixel" state="0"><bounds x="5721" y="342" width="100" height="100"/></bezel>
+<bezel name="Dot_743" element="Pixel" state="0"><bounds x="5832" y="342" width="100" height="100"/></bezel>
+<bezel name="Dot_744" element="Pixel" state="0"><bounds x="5943" y="342" width="100" height="100"/></bezel>
+<bezel name="Dot_745" element="Pixel" state="0"><bounds x="6054" y="342" width="100" height="100"/></bezel>
+<bezel name="Dot_751" element="Pixel" state="0"><bounds x="5610" y="456" width="100" height="100"/></bezel>
+<bezel name="Dot_752" element="Pixel" state="0"><bounds x="5721" y="456" width="100" height="100"/></bezel>
+<bezel name="Dot_753" element="Pixel" state="0"><bounds x="5832" y="456" width="100" height="100"/></bezel>
+<bezel name="Dot_754" element="Pixel" state="0"><bounds x="5943" y="456" width="100" height="100"/></bezel>
+<bezel name="Dot_755" element="Pixel" state="0"><bounds x="6054" y="456" width="100" height="100"/></bezel>
+<bezel name="Dot_761" element="Pixel" state="0"><bounds x="5610" y="570" width="100" height="100"/></bezel>
+<bezel name="Dot_762" element="Pixel" state="0"><bounds x="5721" y="570" width="100" height="100"/></bezel>
+<bezel name="Dot_763" element="Pixel" state="0"><bounds x="5832" y="570" width="100" height="100"/></bezel>
+<bezel name="Dot_764" element="Pixel" state="0"><bounds x="5943" y="570" width="100" height="100"/></bezel>
+<bezel name="Dot_765" element="Pixel" state="0"><bounds x="6054" y="570" width="100" height="100"/></bezel>
+<bezel name="Dot_771" element="Pixel" state="0"><bounds x="5610" y="684" width="100" height="100"/></bezel>
+<bezel name="Dot_772" element="Pixel" state="0"><bounds x="5721" y="684" width="100" height="100"/></bezel>
+<bezel name="Dot_773" element="Pixel" state="0"><bounds x="5832" y="684" width="100" height="100"/></bezel>
+<bezel name="Dot_774" element="Pixel" state="0"><bounds x="5943" y="684" width="100" height="100"/></bezel>
+<bezel name="Dot_775" element="Pixel" state="0"><bounds x="6054" y="684" width="100" height="100"/></bezel>
+<bezel name="Dot_811" element="Pixel" state="0"><bounds x="6545" y="0" width="100" height="100"/></bezel>
+<bezel name="Dot_812" element="Pixel" state="0"><bounds x="6656" y="0" width="100" height="100"/></bezel>
+<bezel name="Dot_813" element="Pixel" state="0"><bounds x="6767" y="0" width="100" height="100"/></bezel>
+<bezel name="Dot_814" element="Pixel" state="0"><bounds x="6878" y="0" width="100" height="100"/></bezel>
+<bezel name="Dot_815" element="Pixel" state="0"><bounds x="6989" y="0" width="100" height="100"/></bezel>
+<bezel name="Dot_821" element="Pixel" state="0"><bounds x="6545" y="114" width="100" height="100"/></bezel>
+<bezel name="Dot_822" element="Pixel" state="0"><bounds x="6656" y="114" width="100" height="100"/></bezel>
+<bezel name="Dot_823" element="Pixel" state="0"><bounds x="6767" y="114" width="100" height="100"/></bezel>
+<bezel name="Dot_824" element="Pixel" state="0"><bounds x="6878" y="114" width="100" height="100"/></bezel>
+<bezel name="Dot_825" element="Pixel" state="0"><bounds x="6989" y="114" width="100" height="100"/></bezel>
+<bezel name="Dot_831" element="Pixel" state="0"><bounds x="6545" y="228" width="100" height="100"/></bezel>
+<bezel name="Dot_832" element="Pixel" state="0"><bounds x="6656" y="228" width="100" height="100"/></bezel>
+<bezel name="Dot_833" element="Pixel" state="0"><bounds x="6767" y="228" width="100" height="100"/></bezel>
+<bezel name="Dot_834" element="Pixel" state="0"><bounds x="6878" y="228" width="100" height="100"/></bezel>
+<bezel name="Dot_835" element="Pixel" state="0"><bounds x="6989" y="228" width="100" height="100"/></bezel>
+<bezel name="Dot_841" element="Pixel" state="0"><bounds x="6545" y="342" width="100" height="100"/></bezel>
+<bezel name="Dot_842" element="Pixel" state="0"><bounds x="6656" y="342" width="100" height="100"/></bezel>
+<bezel name="Dot_843" element="Pixel" state="0"><bounds x="6767" y="342" width="100" height="100"/></bezel>
+<bezel name="Dot_844" element="Pixel" state="0"><bounds x="6878" y="342" width="100" height="100"/></bezel>
+<bezel name="Dot_845" element="Pixel" state="0"><bounds x="6989" y="342" width="100" height="100"/></bezel>
+<bezel name="Dot_851" element="Pixel" state="0"><bounds x="6545" y="456" width="100" height="100"/></bezel>
+<bezel name="Dot_852" element="Pixel" state="0"><bounds x="6656" y="456" width="100" height="100"/></bezel>
+<bezel name="Dot_853" element="Pixel" state="0"><bounds x="6767" y="456" width="100" height="100"/></bezel>
+<bezel name="Dot_854" element="Pixel" state="0"><bounds x="6878" y="456" width="100" height="100"/></bezel>
+<bezel name="Dot_855" element="Pixel" state="0"><bounds x="6989" y="456" width="100" height="100"/></bezel>
+<bezel name="Dot_861" element="Pixel" state="0"><bounds x="6545" y="570" width="100" height="100"/></bezel>
+<bezel name="Dot_862" element="Pixel" state="0"><bounds x="6656" y="570" width="100" height="100"/></bezel>
+<bezel name="Dot_863" element="Pixel" state="0"><bounds x="6767" y="570" width="100" height="100"/></bezel>
+<bezel name="Dot_864" element="Pixel" state="0"><bounds x="6878" y="570" width="100" height="100"/></bezel>
+<bezel name="Dot_865" element="Pixel" state="0"><bounds x="6989" y="570" width="100" height="100"/></bezel>
+<bezel name="Dot_871" element="Pixel" state="0"><bounds x="6545" y="684" width="100" height="100"/></bezel>
+<bezel name="Dot_872" element="Pixel" state="0"><bounds x="6656" y="684" width="100" height="100"/></bezel>
+<bezel name="Dot_873" element="Pixel" state="0"><bounds x="6767" y="684" width="100" height="100"/></bezel>
+<bezel name="Dot_874" element="Pixel" state="0"><bounds x="6878" y="684" width="100" height="100"/></bezel>
+<bezel name="Dot_875" element="Pixel" state="0"><bounds x="6989" y="684" width="100" height="100"/></bezel>
+
+	</view>
+</mamelayout>


### PR DESCRIPTION
This works enough to give some output improving the driver. Right now the driver hangs right after putting the BIOS version on the display and I have a film of the real hardware what texts should be put there when it works correctly so it is useful.

Ideally one would like the sda5708 device to offer a sub-layout element to the dbox driver layout to place on the right spot of the dbox-1 front. Maybe there is a way to do that I don't know about.