### PR TITLE
gameboy: fix SGB VRAM transfers

### DIFF
--- a/hash/gameboy.xml
+++ b/hash/gameboy.xml
@@ -24963,8 +24963,6 @@
 		</part>
 	</software>
 
-	<!-- 4in1_003 missing -->
-
 	<software name="4in1_004">
 		<description>4 in 1 (Euro, 4B-004)</description>
 		<year>19??</year>

--- a/src/devices/bus/gameboy/gb_slot.cpp
+++ b/src/devices/bus/gameboy/gb_slot.cpp
@@ -226,7 +226,7 @@ static int gb_get_pcb_id(const char *slot)
 			return elem.pcb_id;
 	}
 
-	return 0;
+	return GB_MBC_NONE;
 }
 
 static const char *gb_get_slot(int type)

--- a/src/devices/bus/gameboy/gb_slot.cpp
+++ b/src/devices/bus/gameboy/gb_slot.cpp
@@ -141,7 +141,6 @@ gb_cart_slot_device_base::gb_cart_slot_device_base(const machine_config &mconfig
 	device_t(mconfig, type, tag, owner, clock),
 	device_image_interface(mconfig, *this),
 	device_slot_interface(mconfig, *this),
-	m_sgb_hack(0),
 	m_type(GB_MBC_UNKNOWN),
 	m_cart(nullptr)
 {
@@ -385,12 +384,6 @@ image_init_result gb_cart_slot_device_base::call_load()
 		//printf("Type: %s\n", gb_get_slot(m_type));
 
 		internal_header_logging(ROM + offset, len);
-
-		// Hack to support Donkey Kong Land 2 + 3 in SGB
-		// For some reason, these store the tile data differently. Hacks will go once it's been figured out
-		if (strncmp((const char*)(ROM + 0x134), "DONKEYKONGLAND 2", 16) == 0 ||
-			strncmp((const char*)(ROM + 0x134), "DONKEYKONGLAND 3", 16) == 0)
-			m_sgb_hack = 1;
 
 		return image_init_result::PASS;
 	}

--- a/src/devices/bus/gameboy/gb_slot.h
+++ b/src/devices/bus/gameboy/gb_slot.h
@@ -127,8 +127,6 @@ public:
 	static int get_cart_type(const uint8_t *ROM, uint32_t len);
 	static bool get_mmm01_candidate(const uint8_t *ROM, uint32_t len);
 	static bool is_mbc1col_game(const uint8_t *ROM, uint32_t len);
-	// remove me when SGB is properly emulated
-	int get_sgb_hack() { return m_sgb_hack; }
 
 	void setup_ram(uint8_t banks);
 	void internal_header_logging(uint8_t *ROM, uint32_t len);
@@ -155,9 +153,6 @@ public:
 
 protected:
 	gb_cart_slot_device_base(const machine_config &mconfig, device_type type, const char *tag, device_t *owner, uint32_t clock);
-
-	// Donkey Kong Land 2 + 3 store SGB border tiles differently... this will be hopefully be removed when SGB is properly emulated!
-	int m_sgb_hack;
 
 	int m_type;
 	device_gb_cart_interface*       m_cart;

--- a/src/devices/video/gb_lcd.cpp
+++ b/src/devices/video/gb_lcd.cpp
@@ -3513,18 +3513,16 @@ WRITE8_MEMBER(cgb_ppu_device::video_w)
  * @param start     Logical Start Tile index inside display area.
  * @param num_tiles Number of DMG tiles (0x10u bytes) to copy.
  */
-void sgb_ppu_device::sgb_vram_memcpy(uint8_t* dst, uint8_t start, size_t num_tiles) {
+void sgb_ppu_device::sgb_vram_memcpy(uint8_t *dst, uint8_t start, size_t num_tiles) {
 	
-	size_t i;
 	uint16_t bg_ix = (start / 0x14u) * 0x20u + (start % 0x14u);
-	uint8_t tile_ix;
-	const uint8_t* map = m_layer[0].bg_map;
-	const uint8_t* tiles = m_layer[0].bg_tiles;
+	const uint8_t* const map = m_layer[0].bg_map;
+	const uint8_t* const tiles = m_layer[0].bg_tiles;
 	const uint8_t mod = m_gb_tile_no_mod;
 	
-	for (i = 0x00u; i < num_tiles && i < 0x100u; ++i) {
+	for (size_t i = 0x00u; i < num_tiles && i < 0x100u; ++i) {
 		
-		tile_ix = map[bg_ix] ^ mod;
+		const uint8_t tile_ix = map[bg_ix] ^ mod;
 		memcpy(dst, &tiles[tile_ix << 4], 0x10u);
 		dst += 0x10u;
 		

--- a/src/devices/video/gb_lcd.cpp
+++ b/src/devices/video/gb_lcd.cpp
@@ -12,7 +12,7 @@
   Improvements to match real hardware         Wilbert Pol        2006-2008
 
   Timing is not accurate enough:
-  - Mode 3 takes 172 cycles (measuered with logic analyzer by costis)
+  - Mode 3 takes 172 cycles (measured with logic analyzer by costis)
 
 The following timing of the first frame when the LCD is turned on, is with
 no sprites being displayed. If sprites are displayed then the timing of mode
@@ -3847,6 +3847,9 @@ void sgb_ppu_device::sgb_io_write_pal(int offs, uint8_t *data)
 		case 0x10:  /* DATA_TRN */
 			/* Not Implemented */
 			break;
+		case 0x11:  /* MLT_REQ */
+			/* MLT_REQ currently handled inside gb.cpp logic */
+			break;
 		case 0x12:  /* JUMP */
 			/* Not Implemented */
 			break;
@@ -3895,11 +3898,10 @@ void sgb_ppu_device::sgb_io_write_pal(int offs, uint8_t *data)
 			m_sgb_window_mask = data[1];
 			break;
 		case 0x18:  /* OBJ_TRN */
-			/* Not Implemnted */
+			/* Not Implemented */
 			break;
-		case 0x19:  /* ? */
-			/* Called by: dkl,dkl2,dkl3,zeldadx
-			 But I don't know what it is for. */
+		case 0x19:  /* PAL_PRI */
+			/* Called by: dkl,dkl2,dkl3,zeldadx */
 			/* Not Implemented */
 			break;
 		case 0x1E:  /* Used by bootrom to transfer the gb cart header */

--- a/src/devices/video/gb_lcd.h
+++ b/src/devices/video/gb_lcd.h
@@ -32,9 +32,6 @@ public:
 	virtual DECLARE_READ8_MEMBER(video_r);
 	virtual DECLARE_WRITE8_MEMBER(video_w);
 
-	// FIXME: remove it when proper sgb support is added
-	void set_sgb_hack(bool val) { m_sgb_border_hack = val ? 1 : 0; }
-
 	virtual void update_state();
 
 protected:
@@ -90,7 +87,7 @@ protected:
 	// state variables
 	bitmap_ind16 m_bitmap;
 
-	uint8_t m_sgb_atf_data[4050];       /* (SGB) Attributes files */
+	uint8_t m_sgb_atf_data[4096];       /* (SGB) Attributes files 4050 bytes, but it's in WRAM, because 4k is transferred */
 	uint32_t m_sgb_atf;
 	uint16_t m_sgb_pal_data[4096];
 	uint8_t m_sgb_pal_map[20][18];
@@ -98,9 +95,6 @@ protected:
 	std::unique_ptr<uint8_t[]> m_sgb_tile_data;
 	uint8_t m_sgb_tile_map[2048];
 	uint8_t m_sgb_window_mask;
-
-	// this is temporarily needed for a bunch of games which draw the border differently...
-	int m_sgb_border_hack;
 
 	int m_window_lines_drawn;
 
@@ -262,6 +256,8 @@ protected:
 	virtual void update_sprites() override;
 	virtual void update_scanline(uint32_t cycles_to_go) override;
 	void refresh_border();
+	
+	void sgb_vram_memcpy(uint8_t* dst, uint8_t start, size_t num_tiles);
 };
 
 

--- a/src/devices/video/gb_lcd.h
+++ b/src/devices/video/gb_lcd.h
@@ -257,7 +257,7 @@ protected:
 	virtual void update_scanline(uint32_t cycles_to_go) override;
 	void refresh_border();
 	
-	void sgb_vram_memcpy(uint8_t* dst, uint8_t start, size_t num_tiles);
+	void sgb_vram_memcpy(uint8_t *dst, uint8_t start, size_t num_tiles);
 };
 
 

--- a/src/mame/machine/gb.cpp
+++ b/src/mame/machine/gb.cpp
@@ -190,10 +190,6 @@ MACHINE_START_MEMBER(gb_state,sgb)
 
 	save_gb_base();
 	save_sgb_only();
-
-	if (m_cartslot && m_cartslot->get_sgb_hack()) {
-		dynamic_cast<sgb_ppu_device*>(m_ppu.target())->set_sgb_hack(true);
-	}
 }
 
 void gb_state::machine_reset()
@@ -323,38 +319,38 @@ WRITE8_MEMBER(gb_state::gb_io2_w)
 #ifdef MAME_DEBUG
 static const char *const sgbcmds[32] =
 {
-	"PAL01   ",
-	"PAL23   ",
-	"PAL03   ",
-	"PAL12   ",
-	"ATTR_BLK",
-	"ATTR_LIN",
-	"ATTR_DIV",
-	"ATTR_CHR",
-	"SOUND   ",
-	"SOU_TRN ",
-	"PAL_SET ",
-	"PAL_TRN ",
-	"ATRC_EN ",
-	"TEST_EN ",
-	"ICON_EN ",
-	"DATA_SND",
-	"DATA_TRN",
-	"MLT_REG ",
-	"JUMP    ",
-	"CHR_TRN ",
-	"PCT_TRN ",
-	"ATTR_TRN",
-	"ATTR_SET",
-	"MASK_EN ",
-	"OBJ_TRN ",
-	"????????",
-	"????????",
-	"????????",
-	"????????",
-	"????????",
-	"????????",
-	"????????"
+	/* 0x00 */ "PAL01   ",
+	/* 0x01 */ "PAL23   ",
+	/* 0x02 */ "PAL03   ",
+	/* 0x03 */ "PAL12   ",
+	/* 0x04 */ "ATTR_BLK",
+	/* 0x05 */ "ATTR_LIN",
+	/* 0x06 */ "ATTR_DIV",
+	/* 0x07 */ "ATTR_CHR",
+	/* 0x08 */ "SOUND   ",
+	/* 0x09 */ "SOU_TRN ",
+	/* 0x0A */ "PAL_SET ",
+	/* 0x0B */ "PAL_TRN ",
+	/* 0x0C */ "ATRC_EN ",
+	/* 0x0D */ "TEST_EN ",
+	/* 0x0E */ "ICON_EN ",
+	/* 0x0F */ "DATA_SND",
+	/* 0x10 */ "DATA_TRN",
+	/* 0x11 */ "MLT_REG ",
+	/* 0x12 */ "JUMP    ",
+	/* 0x13 */ "CHR_TRN ",
+	/* 0x14 */ "PCT_TRN ",
+	/* 0x15 */ "ATTR_TRN",
+	/* 0x16 */ "ATTR_SET",
+	/* 0x17 */ "MASK_EN ",
+	/* 0x18 */ "OBJ_TRN ",
+	/* 0x19 */ "PAL_PRI ",
+	/* 0x1A */ "????????",
+	/* 0x1B */ "????????",
+	/* 0x1C */ "????????",
+	/* 0x1D */ "????????",
+	/* 0x1E */ "????????",
+	/* 0x1F */ "????????"
 };
 #endif
 


### PR DESCRIPTION
I noticed that there was an ugly SGB border hack in the Game Boy system. I looked at it and realized that the SGB VRAM transfer method was broken (even though it works for most games due to Nintendo's SGB SDK).

The SGB VRAM transfer is actually done through the display signals, so the contents have to be shown on screen. It's not really known if window and bg scroll take/attributes take effect or not, so somebody with actual hardware might need to investigate further. If that's the case, a possible redesign would be to make the PPU render to a frame buffer and use that frame for VRAM access and final rendering, but that would entail a big change and it's unclear if it wouldn't be easier to actually emulate the SGB on a SNES with a GB slot.

Anyway, the actual transfers work now as expected and the hack for certain games (Donkey Kong 2 and 3 amongst others) are gone.