### PR TITLE
a7800 - Add proper slotted controllers [Mike Saarna, Robert Tuccitto]

### DIFF
--- a/scripts/src/bus.lua
+++ b/scripts/src/bus.lua
@@ -30,6 +30,37 @@ if (BUSES["A7800"]~=null) then
 	}
 end
 
+---------------------------------------------------
+--
+--@src/devices/bus/a7800_ctrl/ctrl.h,BUSES["A7800_CTRL"] = true
+---------------------------------------------------
+
+if (BUSES["A7800_CTRL"]~=null) then
+	files {
+		MAME_DIR .. "src/devices/bus/a7800_ctrl/ctrl.cpp",
+		MAME_DIR .. "src/devices/bus/a7800_ctrl/ctrl.h",
+		MAME_DIR .. "src/devices/bus/a7800_ctrl/joystick.cpp",
+		MAME_DIR .. "src/devices/bus/a7800_ctrl/joystick.h",
+		MAME_DIR .. "src/devices/bus/a7800_ctrl/joyproline.cpp",
+		MAME_DIR .. "src/devices/bus/a7800_ctrl/joyproline.h",
+		MAME_DIR .. "src/devices/bus/a7800_ctrl/keypad.cpp",
+		MAME_DIR .. "src/devices/bus/a7800_ctrl/keypad.h",
+		MAME_DIR .. "src/devices/bus/a7800_ctrl/lightgun.cpp",
+		MAME_DIR .. "src/devices/bus/a7800_ctrl/lightgun.h",
+		MAME_DIR .. "src/devices/bus/a7800_ctrl/paddles.cpp",
+		MAME_DIR .. "src/devices/bus/a7800_ctrl/paddles.h",
+		MAME_DIR .. "src/devices/bus/a7800_ctrl/wheel.cpp",
+		MAME_DIR .. "src/devices/bus/a7800_ctrl/wheel.h",
+		MAME_DIR .. "src/devices/bus/a7800_ctrl/trackball.cpp",
+		MAME_DIR .. "src/devices/bus/a7800_ctrl/trackball.h",
+		MAME_DIR .. "src/devices/bus/a7800_ctrl/stmouse.cpp",
+		MAME_DIR .. "src/devices/bus/a7800_ctrl/stmouse.h",
+		MAME_DIR .. "src/devices/bus/a7800_ctrl/amigamouse.cpp",
+		MAME_DIR .. "src/devices/bus/a7800_ctrl/amigamouse.h",
+	}
+end
+
+
 
 ---------------------------------------------------
 --
@@ -867,14 +898,8 @@ end
 
 if (BUSES["INTELLEC4"]~=null) then
 	files {
-		MAME_DIR .. "src/devices/bus/intellec4/insdatastor.cpp",
-		MAME_DIR .. "src/devices/bus/intellec4/insdatastor.h",
 		MAME_DIR .. "src/devices/bus/intellec4/intellec4.cpp",
 		MAME_DIR .. "src/devices/bus/intellec4/intellec4.h",
-		MAME_DIR .. "src/devices/bus/intellec4/prommemory.cpp",
-		MAME_DIR .. "src/devices/bus/intellec4/prommemory.h",
-		MAME_DIR .. "src/devices/bus/intellec4/tapereader.cpp",
-		MAME_DIR .. "src/devices/bus/intellec4/tapereader.h",
 	}
 end
 

--- a/scripts/target/mame/mess.lua
+++ b/scripts/target/mame/mess.lua
@@ -203,7 +203,7 @@ SOUNDS["K051649"] = true
 --SOUNDS["K054539"] = true
 --SOUNDS["K056800"] = true
 --SOUNDS["SEGAPCM"] = true
-SOUNDS["MULTIPCM"] = true
+--SOUNDS["MULTIPCM"] = true
 SOUNDS["SCSP"] = true
 SOUNDS["AICA"] = true
 SOUNDS["RF5C68"] = true
@@ -327,7 +327,6 @@ VIDEOS["PSX"] = true
 VIDEOS["RAMDAC"] = true
 VIDEOS["S2636"] = true
 VIDEOS["SAA5050"] = true
-VIDEOS["SDA5708"] = true
 VIDEOS["SED1200"] = true
 VIDEOS["SED1330"] = true
 VIDEOS["SED1520"] = true
@@ -619,6 +618,7 @@ MACHINES["INPUT_MERGER"] = true
 BUSES["A1BUS"] = true
 BUSES["A2BUS"] = true
 BUSES["A7800"] = true
+BUSES["A7800_CTRL"] = true
 BUSES["A800"] = true
 BUSES["ABCBUS"] = true
 BUSES["ABCKB"] = true
@@ -2131,8 +2131,6 @@ files {
 	MAME_DIR .. "src/mame/drivers/isbc.cpp",
 	MAME_DIR .. "src/mame/drivers/isbc8010.cpp",
 	MAME_DIR .. "src/mame/drivers/isbc8030.cpp",
-	MAME_DIR .. "src/mame/machine/imm6_76.cpp",
-	MAME_DIR .. "src/mame/machine/imm6_76.h",
 	MAME_DIR .. "src/mame/machine/isbc_215g.cpp",
 	MAME_DIR .. "src/mame/machine/isbc_215g.h",
 	MAME_DIR .. "src/mame/machine/isbc_208.cpp",
@@ -2814,7 +2812,6 @@ files {
 	MAME_DIR .. "src/mame/drivers/mz6500.cpp",
 	MAME_DIR .. "src/mame/drivers/zaurus.cpp",
 	MAME_DIR .. "src/mame/machine/pxa255.h",
-	MAME_DIR .. "src/mame/drivers/fontwriter.cpp",
 }
 
 createMESSProjects(_target, _subtarget, "sinclair")
@@ -3323,7 +3320,6 @@ createMESSProjects(_target, _subtarget, "yamaha")
 files {
 	MAME_DIR .. "src/mame/drivers/ymmu100.cpp",
 	MAME_DIR .. "src/mame/drivers/fb01.cpp",
-	MAME_DIR .. "src/mame/drivers/tg100.cpp",
 }
 
 createMESSProjects(_target, _subtarget, "zenith")

--- a/src/devices/bus/a7800_ctrl/amigamouse.cpp
+++ b/src/devices/bus/a7800_ctrl/amigamouse.cpp
@@ -1,0 +1,93 @@
+// license:BSD-3-Clause
+// copyright-holders:Curt Coder, Mike Saarna
+/**********************************************************************
+
+    Amiga mouse controller
+
+**********************************************************************/
+
+#include "emu.h"
+#include "amigamouse.h"
+
+
+
+//**************************************************************************
+//  DEVICE DEFINITIONS
+//**************************************************************************
+
+DEFINE_DEVICE_TYPE(A7800_AMIGAMOUSE, a7800_amigamouse_device, "a7800_amigamouse", "Amiga mouse")
+
+	// Only 1 button is presently supported. It's not clear at this time if the Amiga
+	// mouse has pull-ups on the second and third buttons, which would be required for
+	// them to be reliably used with the 7800 paddle lines.
+
+static INPUT_PORTS_START( a7800_amigamouse )
+	PORT_START("JOY")
+	PORT_BIT( 0x20, IP_ACTIVE_LOW, IPT_BUTTON1 ) //pin 6
+	PORT_BIT( 0x5F, IP_ACTIVE_HIGH, IPT_UNUSED  )
+	PORT_BIT( 0x80, IP_ACTIVE_LOW, IPT_UNUSED )
+
+	PORT_START("MOUSEX")
+	PORT_BIT( 0xff, 0x00, IPT_TRACKBALL_X ) PORT_SENSITIVITY(40) PORT_KEYDELTA(5)
+
+	PORT_START("MOUSEY")
+	PORT_BIT( 0xff, 0x00, IPT_TRACKBALL_Y ) PORT_SENSITIVITY(40) PORT_KEYDELTA(5)
+INPUT_PORTS_END
+
+
+//-------------------------------------------------
+//  input_ports - device-specific input ports
+//-------------------------------------------------
+
+ioport_constructor a7800_amigamouse_device::device_input_ports() const
+{
+	return INPUT_PORTS_NAME( a7800_amigamouse );
+}
+
+
+
+//**************************************************************************
+//  LIVE DEVICE
+//**************************************************************************
+
+//-------------------------------------------------
+//  a7800_amigamouse_device - constructor
+//-------------------------------------------------
+
+a7800_amigamouse_device::a7800_amigamouse_device(const machine_config &mconfig, const char *tag, device_t *owner, uint32_t clock) :
+	device_t(mconfig, A7800_AMIGAMOUSE, tag, owner, clock),
+	device_a7800_control_port_interface(mconfig, *this),
+	m_joy(*this, "JOY"),
+	m_amigamousex(*this, "MOUSEX"),
+	m_amigamousey(*this, "MOUSEY")
+{
+}
+
+
+//-------------------------------------------------
+//  device_start - device-specific startup
+//-------------------------------------------------
+
+void a7800_amigamouse_device::device_start()
+{
+}
+
+
+//-------------------------------------------------
+//  a7800_joy_r - joystick read
+//-------------------------------------------------
+
+uint8_t a7800_amigamouse_device::a7800_joy_r()
+{
+	// The Amiga mouse uses 2 bits of quadrature encoding per axis.
+	// The X bits use pins 2 and 4, so encoding uses 0x02 and 0x08.
+	// The Y bits use pins 1 and 3, so encoding uses 0x01 and 0x04.
+	
+	static const uint8_t axis_lookup_x[4] = { 0x00, 0x02, 0x0a, 0x08 };
+	static const uint8_t axis_lookup_y[4] = { 0x00, 0x01, 0x05, 0x04 };
+
+	return m_joy->read() | axis_lookup_x[ m_amigamousex->read() & 0x3 ] |
+		axis_lookup_y[ m_amigamousey->read() & 0x3 ];
+}
+
+

--- a/src/devices/bus/a7800_ctrl/amigamouse.h
+++ b/src/devices/bus/a7800_ctrl/amigamouse.h
@@ -1,0 +1,51 @@
+// license:BSD-3-Clause
+// copyright-holders:Curt Coder
+/**********************************************************************
+
+    Amiga mouse controller
+
+**********************************************************************/
+
+#ifndef MAME_BUS_A7800_CTRL_AMIGAMOUSE_H
+#define MAME_BUS_A7800_CTRL_AMIGAMOUSE_H
+
+#pragma once
+
+#include "ctrl.h"
+
+
+
+//**************************************************************************
+//  TYPE DEFINITIONS
+//**************************************************************************
+
+// ======================> a7800_amigamouse_device
+
+class a7800_amigamouse_device : public device_t,
+							public device_a7800_control_port_interface
+{
+public:
+	// construction/destruction
+	a7800_amigamouse_device(const machine_config &mconfig, const char *tag, device_t *owner, uint32_t clock);
+
+	// optional information overrides
+	virtual ioport_constructor device_input_ports() const override;
+
+protected:
+	// device-level overrides
+	virtual void device_start() override;
+
+	// device_a7800_control_port_interface overrides
+	virtual uint8_t a7800_joy_r() override;
+
+private:
+	required_ioport m_joy;
+	required_ioport m_amigamousex;
+	required_ioport m_amigamousey;
+};
+
+
+// device type definition
+DECLARE_DEVICE_TYPE(A7800_AMIGAMOUSE, a7800_amigamouse_device)
+
+#endif // MAME_BUS_A7800_CTRL_AMIGAMOUSE_H

--- a/src/devices/bus/a7800_ctrl/ctrl.cpp
+++ b/src/devices/bus/a7800_ctrl/ctrl.cpp
@@ -1,0 +1,90 @@
+// license:BSD-3-Clause
+// copyright-holders:Curt Coder
+/**********************************************************************
+
+    Atari Video Computer System controller port emulation
+
+**********************************************************************/
+
+#include "emu.h"
+#include "ctrl.h"
+
+
+
+//**************************************************************************
+//  DEVICE DEFINITION
+//**************************************************************************
+
+DEFINE_DEVICE_TYPE(A7800_CONTROL_PORT, a7800_control_port_device, "a7800_control_port", "Atari 7800 controller port")
+
+
+
+//**************************************************************************
+//  CARD INTERFACE
+//**************************************************************************
+
+//-------------------------------------------------
+//  device_a7800_control_port_interface - constructor
+//-------------------------------------------------
+
+device_a7800_control_port_interface::device_a7800_control_port_interface(const machine_config &mconfig, device_t &device) :
+	device_slot_card_interface(mconfig, device)
+{
+	m_port = dynamic_cast<a7800_control_port_device *>(device.owner());
+}
+
+
+
+//**************************************************************************
+//  LIVE DEVICE
+//**************************************************************************
+
+//-------------------------------------------------
+//  a7800_control_port_device - constructor
+//-------------------------------------------------
+
+a7800_control_port_device::a7800_control_port_device(const machine_config &mconfig, const char *tag, device_t *owner, uint32_t clock) :
+	device_t(mconfig, A7800_CONTROL_PORT, tag, owner, clock),
+	device_slot_interface(mconfig, *this), m_device(nullptr),
+	m_write_trigger(*this)
+{
+}
+
+
+//-------------------------------------------------
+//  device_start - device-specific startup
+//-------------------------------------------------
+
+void a7800_control_port_device::device_start()
+{
+	m_device = dynamic_cast<device_a7800_control_port_interface *>(get_card_device());
+
+	m_write_trigger.resolve_safe();
+}
+
+
+//-------------------------------------------------
+//  SLOT_INTERFACE( a7800_control_port_devices )
+//-------------------------------------------------
+
+#include "joyproline.h"
+#include "joystick.h"
+#include "keypad.h"
+#include "lightgun.h"
+#include "paddles.h"
+#include "wheel.h"
+#include "trackball.h"
+#include "stmouse.h"
+#include "amigamouse.h"
+
+SLOT_INTERFACE_START( a7800_control_port_devices )
+	SLOT_INTERFACE("proline_joystick", A7800_JOYSTICK_PROLINE)
+	SLOT_INTERFACE("vcs_joystick", A7800_JOYSTICK)
+	SLOT_INTERFACE("paddle", A7800_PADDLES)
+	SLOT_INTERFACE("lightgun", A7800_LIGHTGUN)
+	SLOT_INTERFACE("driving_wheel", A7800_WHEEL)
+	SLOT_INTERFACE("cx22_trakball", A7800_TRACKBALL)
+	SLOT_INTERFACE("keypad", A7800_KEYPAD)
+	SLOT_INTERFACE("amiga_mouse", A7800_AMIGAMOUSE)
+	SLOT_INTERFACE("st_mouse", A7800_STMOUSE)
+SLOT_INTERFACE_END

--- a/src/devices/bus/a7800_ctrl/ctrl.h
+++ b/src/devices/bus/a7800_ctrl/ctrl.h
@@ -1,0 +1,131 @@
+// license:BSD-3-Clause
+// copyright-holders:Curt Coder
+/**********************************************************************
+
+    Atari 7800 controller port emulation
+
+**********************************************************************
+
+
+**********************************************************************/
+
+#ifndef MAME_BUS_A7800_CTRL_CTRL_H
+#define MAME_BUS_A7800_CTRL_CTRL_H
+
+#pragma once
+
+
+
+
+//**************************************************************************
+//  INTERFACE CONFIGURATION MACROS
+//**************************************************************************
+
+#define MCFG_A7800_CONTROL_PORT_ADD(_tag, _slot_intf, _def_slot) \
+	MCFG_DEVICE_ADD(_tag, A7800_CONTROL_PORT, 0) \
+	MCFG_DEVICE_SLOT_INTERFACE(_slot_intf, _def_slot, false)
+
+
+#define MCFG_A7800_CONTROL_PORT_TRIGGER_CALLBACK(_write) \
+	devcb = &a7800_control_port_device::set_trigger_wr_callback(*device, DEVCB_##_write);
+
+
+
+//**************************************************************************
+//  TYPE DEFINITIONS
+//**************************************************************************
+
+class a7800_control_port_device;
+
+
+// ======================> device_a7800_control_port_interface
+
+class device_a7800_control_port_interface : public device_slot_card_interface
+{
+public:
+	// construction/destruction
+	device_a7800_control_port_interface(const machine_config &mconfig, device_t &device);
+	virtual ~device_a7800_control_port_interface() { }
+
+	virtual uint8_t a7800_joy_r() { return 0xff; };
+	virtual uint8_t a7800_pot_x_r() { return 0xff; };
+	virtual uint8_t a7800_pot_y_r() { return 0xff; };
+	virtual uint8_t a7800_light_x_r() { return 0xff; };
+	virtual uint8_t a7800_light_y_r() { return 0xff; };
+	virtual void a7800_joy_w(uint8_t data) { };
+
+	virtual bool has_pot_x() { return false; }
+	virtual bool has_pot_y() { return false; }
+	virtual bool is_paddle() { return false; }
+	virtual bool is_lightgun() { return false; }
+	virtual bool has_pro_buttons() { return false; }
+
+protected:
+	a7800_control_port_device *m_port;
+};
+
+
+// ======================> a7800_control_port_device
+
+class a7800_control_port_device : public device_t,
+								public device_slot_interface
+{
+public:
+	// construction/destruction
+	a7800_control_port_device(const machine_config &mconfig, const char *tag, device_t *owner, uint32_t clock);
+
+	// static configuration helpers
+	template <class Object> static devcb_base &set_trigger_wr_callback(device_t &device, Object &&cb) { return downcast<a7800_control_port_device &>(device).m_write_trigger.set_callback(std::forward<Object>(cb)); }
+
+	// computer interface
+
+	// Data returned by the joy_r methods:
+	// bit 0 0x01 - pin 1 - Up
+	// bit 1 0x02 - pin 2 - Down
+	// bit 2 0x04 - pin 3 - Left             
+	// bit 3 0x08 - pin 4 - Right
+	// bit 4 0x10 - pin 5 - Proline A button
+	// bit 5 0x20 - pin 6 - VCS button
+	//              pin 7 - +5V
+	//              pin 8 - GND
+	// bit 6 0x40 - pin 9 - Proline B button
+	//
+	uint8_t joy_r() { uint8_t data = 0xff; if (exists()) data = m_device->a7800_joy_r(); return data; }
+	DECLARE_READ8_MEMBER( joy_r ) { return joy_r(); }
+	uint8_t pot_x_r() { uint8_t data = 0xff; if (exists()) data = m_device->a7800_pot_x_r(); return data; }
+	DECLARE_READ8_MEMBER( pot_x_r ) { return pot_x_r(); }
+	uint8_t pot_y_r() { uint8_t data = 0xff; if (exists()) data = m_device->a7800_pot_y_r(); return data; }
+	DECLARE_READ8_MEMBER( pot_y_r ) { return pot_y_r(); }
+	uint8_t light_x_r() { uint16_t data = 0xff; if (exists()) data = m_device->a7800_light_x_r(); return data; }
+	DECLARE_READ8_MEMBER( light_x_r ) { return light_x_r(); }
+	uint8_t light_y_r() { uint16_t data = 0xff; if (exists()) data = m_device->a7800_light_y_r(); return data; }
+	DECLARE_READ8_MEMBER( light_y_r ) { return light_y_r(); }
+
+	void joy_w( uint8_t data ) { if ( exists() ) m_device->a7800_joy_w( data ); }
+
+	bool exists() { return m_device != nullptr; }
+	bool has_pot_x() { return exists() && m_device->has_pot_x(); }
+	bool has_pot_y() { return exists() && m_device->has_pot_y(); }
+	bool is_paddle() { return exists() && m_device->is_paddle(); }
+	bool is_lightgun() { return exists() && m_device->is_lightgun(); }
+	bool has_pro_buttons() { return exists() && m_device->has_pro_buttons(); }
+
+	void trigger_w(int state) { m_write_trigger(state); }
+
+protected:
+	// device-level overrides
+	virtual void device_start() override;
+
+	device_a7800_control_port_interface *m_device;
+
+private:
+	devcb_write_line m_write_trigger;
+};
+
+
+// device type definition
+DECLARE_DEVICE_TYPE(A7800_CONTROL_PORT, a7800_control_port_device)
+
+SLOT_INTERFACE_EXTERN( a7800_control_port_devices );
+
+#endif // MAME_BUS_A7800_CTRL_CTRL_H

--- a/src/devices/bus/a7800_ctrl/joyproline.cpp
+++ b/src/devices/bus/a7800_ctrl/joyproline.cpp
@@ -1,0 +1,76 @@
+// license:BSD-3-Clause
+// copyright-holders:Curt Coder, Mike Saarna
+/**********************************************************************
+
+    Atari 7800 Prosystem joystick emulation
+
+**********************************************************************/
+
+#include "emu.h"
+#include "joyproline.h"
+
+
+
+//**************************************************************************
+//  DEVICE DEFINITIONS
+//**************************************************************************
+
+DEFINE_DEVICE_TYPE(A7800_JOYSTICK_PROLINE, a7800_joystick_proline_device, "a7800_joystick_proline", "Atari 7800 Proline joystick")
+
+
+static INPUT_PORTS_START( a7800_joystick_proline )
+	PORT_START("JOY")
+	PORT_BIT( 0x01, IP_ACTIVE_LOW, IPT_JOYSTICK_UP ) PORT_8WAY
+	PORT_BIT( 0x02, IP_ACTIVE_LOW, IPT_JOYSTICK_DOWN ) PORT_8WAY
+	PORT_BIT( 0x04, IP_ACTIVE_LOW, IPT_JOYSTICK_LEFT ) PORT_8WAY
+	PORT_BIT( 0x08, IP_ACTIVE_LOW, IPT_JOYSTICK_RIGHT ) PORT_8WAY
+	PORT_BIT( 0x10, IP_ACTIVE_HIGH, IPT_BUTTON2 ) //PROLINE A
+	PORT_BIT( 0x40, IP_ACTIVE_HIGH, IPT_BUTTON1 ) //PROLINE B
+	PORT_BIT( 0xA0, IP_ACTIVE_LOW, IPT_UNUSED )
+INPUT_PORTS_END
+
+
+//-------------------------------------------------
+//  input_ports - device-specific input ports
+//-------------------------------------------------
+
+ioport_constructor a7800_joystick_proline_device::device_input_ports() const
+{
+	return INPUT_PORTS_NAME( a7800_joystick_proline );
+}
+
+
+
+//**************************************************************************
+//  LIVE DEVICE
+//**************************************************************************
+
+//-------------------------------------------------
+//  a7800_joystick_proline_device - constructor
+//-------------------------------------------------
+
+a7800_joystick_proline_device::a7800_joystick_proline_device(const machine_config &mconfig, const char *tag, device_t *owner, uint32_t clock) :
+	device_t(mconfig, A7800_JOYSTICK_PROLINE, tag, owner, clock),
+	device_a7800_control_port_interface(mconfig, *this),
+	m_joy(*this, "JOY")
+{
+}
+
+
+//-------------------------------------------------
+//  device_start - device-specific startup
+//-------------------------------------------------
+
+void a7800_joystick_proline_device::device_start()
+{
+}
+
+
+//-------------------------------------------------
+//  a7800_joy_r - joystick_proline read
+//-------------------------------------------------
+
+uint8_t a7800_joystick_proline_device::a7800_joy_r()
+{
+	return m_joy->read();
+}

--- a/src/devices/bus/a7800_ctrl/joyproline.h
+++ b/src/devices/bus/a7800_ctrl/joyproline.h
@@ -1,0 +1,52 @@
+// license:BSD-3-Clause
+// copyright-holders:Curt Coder, Mike Saarna
+/**********************************************************************
+
+    Atari Prosystem joystick emulation
+
+**********************************************************************/
+
+#ifndef MAME_BUS_A7800_CTRL_JOYSTICK_PROLINE_H
+#define MAME_BUS_A7800_CTRL_JOYSTICK_PROLINE_H
+
+#pragma once
+
+#include "ctrl.h"
+
+
+
+//**************************************************************************
+//  TYPE DEFINITIONS
+//**************************************************************************
+
+// ======================> a7800_joystick_proline_device
+
+class a7800_joystick_proline_device : public device_t,
+							public device_a7800_control_port_interface
+{
+public:
+	// construction/destruction
+	a7800_joystick_proline_device(const machine_config &mconfig, const char *tag, device_t *owner, uint32_t clock);
+
+	// optional information overrides
+	virtual ioport_constructor device_input_ports() const override;
+
+protected:
+	// device-level overrides
+	virtual void device_start() override;
+
+	// device_a7800_control_port_interface overrides
+	virtual uint8_t a7800_joy_r() override;
+
+	virtual bool has_pro_buttons() override { return true; }
+
+private:
+	required_ioport m_joy;
+};
+
+
+// device type definition
+DECLARE_DEVICE_TYPE(A7800_JOYSTICK_PROLINE, a7800_joystick_proline_device)
+
+
+#endif // MAME_BUS_A7800_CTRL_JOYSTICK_PROLINE_H

--- a/src/devices/bus/a7800_ctrl/joystick.cpp
+++ b/src/devices/bus/a7800_ctrl/joystick.cpp
@@ -1,0 +1,76 @@
+// license:BSD-3-Clause
+// copyright-holders:Curt Coder
+/**********************************************************************
+
+    Atari Video Computer System digital joystick emulation
+
+**********************************************************************/
+
+#include "emu.h"
+#include "joystick.h"
+
+
+
+//**************************************************************************
+//  DEVICE DEFINITIONS
+//**************************************************************************
+
+DEFINE_DEVICE_TYPE(A7800_JOYSTICK, a7800_joystick_device, "a7800_joystick", "Atari / CBM Digital joystick")
+
+
+static INPUT_PORTS_START( a7800_joystick )
+	PORT_START("JOY")
+	PORT_BIT( 0x01, IP_ACTIVE_LOW,  IPT_JOYSTICK_UP ) PORT_8WAY
+	PORT_BIT( 0x02, IP_ACTIVE_LOW,  IPT_JOYSTICK_DOWN ) PORT_8WAY
+	PORT_BIT( 0x04, IP_ACTIVE_LOW,  IPT_JOYSTICK_LEFT ) PORT_8WAY
+	PORT_BIT( 0x08, IP_ACTIVE_LOW,  IPT_JOYSTICK_RIGHT ) PORT_8WAY
+	PORT_BIT( 0x20, IP_ACTIVE_LOW,  IPT_BUTTON1 )
+	PORT_BIT( 0x50, IP_ACTIVE_HIGH, IPT_UNUSED )
+	PORT_BIT( 0x80, IP_ACTIVE_LOW,  IPT_UNUSED )
+INPUT_PORTS_END
+
+
+//-------------------------------------------------
+//  input_ports - device-specific input ports
+//-------------------------------------------------
+
+ioport_constructor a7800_joystick_device::device_input_ports() const
+{
+	return INPUT_PORTS_NAME( a7800_joystick );
+}
+
+
+
+//**************************************************************************
+//  LIVE DEVICE
+//**************************************************************************
+
+//-------------------------------------------------
+//  a7800_joystick_device - constructor
+//-------------------------------------------------
+
+a7800_joystick_device::a7800_joystick_device(const machine_config &mconfig, const char *tag, device_t *owner, uint32_t clock) :
+	device_t(mconfig, A7800_JOYSTICK, tag, owner, clock),
+	device_a7800_control_port_interface(mconfig, *this),
+	m_joy(*this, "JOY")
+{
+}
+
+
+//-------------------------------------------------
+//  device_start - device-specific startup
+//-------------------------------------------------
+
+void a7800_joystick_device::device_start()
+{
+}
+
+
+//-------------------------------------------------
+//  a7800_joy_r - joystick read
+//-------------------------------------------------
+
+uint8_t a7800_joystick_device::a7800_joy_r()
+{
+	return m_joy->read();
+}

--- a/src/devices/bus/a7800_ctrl/joystick.h
+++ b/src/devices/bus/a7800_ctrl/joystick.h
@@ -1,0 +1,50 @@
+// license:BSD-3-Clause
+// copyright-holders:Curt Coder
+/**********************************************************************
+
+    Atari Video Computer System digital joystick emulation
+
+**********************************************************************/
+
+#ifndef MAME_BUS_A7800_CTRL_JOYSTICK_H
+#define MAME_BUS_A7800_CTRL_JOYSTICK_H
+
+#pragma once
+
+#include "ctrl.h"
+
+
+
+//**************************************************************************
+//  TYPE DEFINITIONS
+//**************************************************************************
+
+// ======================> a7800_joystick_device
+
+class a7800_joystick_device : public device_t,
+							public device_a7800_control_port_interface
+{
+public:
+	// construction/destruction
+	a7800_joystick_device(const machine_config &mconfig, const char *tag, device_t *owner, uint32_t clock);
+
+	// optional information overrides
+	virtual ioport_constructor device_input_ports() const override;
+
+protected:
+	// device-level overrides
+	virtual void device_start() override;
+
+	// device_a7800_control_port_interface overrides
+	virtual uint8_t a7800_joy_r() override;
+
+private:
+	required_ioport m_joy;
+};
+
+
+// device type definition
+DECLARE_DEVICE_TYPE(A7800_JOYSTICK, a7800_joystick_device)
+
+
+#endif // MAME_BUS_A7800_CTRL_JOYSTICK_H

--- a/src/devices/bus/a7800_ctrl/keypad.cpp
+++ b/src/devices/bus/a7800_ctrl/keypad.cpp
@@ -1,0 +1,147 @@
+// license:BSD-3-Clause
+// copyright-holders:Curt Coder
+/**********************************************************************
+
+    Atari Video Computer System keypad emulation
+
+**********************************************************************/
+
+#include "emu.h"
+#include "keypad.h"
+
+
+
+//**************************************************************************
+//  DEVICE DEFINITIONS
+//**************************************************************************
+
+DEFINE_DEVICE_TYPE(A7800_KEYPAD, a7800_keypad_device, "a7800_keypad", "Atari / CBM Keypad")
+
+
+static INPUT_PORTS_START( a7800_keypad )
+	PORT_START("KEYPAD")
+	PORT_BIT( 0x0001, IP_ACTIVE_LOW, IPT_KEYPAD ) PORT_NAME("keypad 1") PORT_CODE(KEYCODE_7_PAD)
+	PORT_BIT( 0x0002, IP_ACTIVE_LOW, IPT_KEYPAD ) PORT_NAME("keypad 2") PORT_CODE(KEYCODE_8_PAD)
+	PORT_BIT( 0x0004, IP_ACTIVE_LOW, IPT_KEYPAD ) PORT_NAME("keypad 3") PORT_CODE(KEYCODE_9_PAD)
+	PORT_BIT( 0x0008, IP_ACTIVE_LOW, IPT_KEYPAD ) PORT_NAME("keypad 4") PORT_CODE(KEYCODE_4_PAD)
+	PORT_BIT( 0x0010, IP_ACTIVE_LOW, IPT_KEYPAD ) PORT_NAME("keypad 5") PORT_CODE(KEYCODE_5_PAD)
+	PORT_BIT( 0x0020, IP_ACTIVE_LOW, IPT_KEYPAD ) PORT_NAME("keypad 6") PORT_CODE(KEYCODE_6_PAD)
+	PORT_BIT( 0x0040, IP_ACTIVE_LOW, IPT_KEYPAD ) PORT_NAME("keypad 7") PORT_CODE(KEYCODE_1_PAD)
+	PORT_BIT( 0x0080, IP_ACTIVE_LOW, IPT_KEYPAD ) PORT_NAME("keypad 8") PORT_CODE(KEYCODE_2_PAD)
+	PORT_BIT( 0x0100, IP_ACTIVE_LOW, IPT_KEYPAD ) PORT_NAME("keypad 9") PORT_CODE(KEYCODE_3_PAD)
+	PORT_BIT( 0x0200, IP_ACTIVE_LOW, IPT_KEYPAD ) PORT_NAME("keypad *") PORT_CODE(KEYCODE_0_PAD)
+	PORT_BIT( 0x0400, IP_ACTIVE_LOW, IPT_KEYPAD ) PORT_NAME("keypad 0") PORT_CODE(KEYCODE_DEL_PAD)
+	PORT_BIT( 0x0800, IP_ACTIVE_LOW, IPT_KEYPAD ) PORT_NAME("keypad #") PORT_CODE(KEYCODE_ENTER_PAD)
+INPUT_PORTS_END
+
+
+//-------------------------------------------------
+//  input_ports - device-specific input ports
+//-------------------------------------------------
+
+ioport_constructor a7800_keypad_device::device_input_ports() const
+{
+	return INPUT_PORTS_NAME( a7800_keypad );
+}
+
+
+
+//**************************************************************************
+//  LIVE DEVICE
+//**************************************************************************
+
+//-------------------------------------------------
+//  a7800_keypad_device - constructor
+//-------------------------------------------------
+
+a7800_keypad_device::a7800_keypad_device(const machine_config &mconfig, const char *tag, device_t *owner, uint32_t clock) :
+	device_t(mconfig, A7800_KEYPAD, tag, owner, clock),
+	device_a7800_control_port_interface(mconfig, *this),
+	m_keypad(*this, "KEYPAD"),
+	m_column(0)
+{
+}
+
+
+//-------------------------------------------------
+//  device_start - device-specific startup
+//-------------------------------------------------
+
+void a7800_keypad_device::device_start()
+{
+	m_column = 0;
+	save_item(NAME(m_column));
+}
+
+
+//-------------------------------------------------
+//  a7800_joy_r - joystick read
+//-------------------------------------------------
+
+uint8_t a7800_keypad_device::a7800_joy_r()
+{
+	for ( int i = 0; i < 4; i++ )
+	{
+		if ( ! ( ( m_column >> i ) & 0x01 ) )
+		{
+			if ( ( m_keypad->read() >> 3*i ) & 0x04 )
+			{
+				return 0xff;
+			}
+			else
+			{
+				return 0;
+			}
+		}
+	}
+	return 0xff;
+}
+
+//-------------------------------------------------
+//  a7800_joy_w - joystick write
+//-------------------------------------------------
+
+void a7800_keypad_device::a7800_joy_w( uint8_t data )
+{
+	// TODO: a real keypad controller takes ~400us to respond to a a row change.
+	// the column setting should really only be updated after the delay.
+	m_column = data & 0x0F;
+}
+
+uint8_t a7800_keypad_device::a7800_pot_x_r()
+{
+	for ( int i = 0; i < 4; i++ )
+	{
+		if ( ! ( ( m_column >> i ) & 0x01 ) )
+		{
+			if ( ( m_keypad->read() >> 3*i ) & 0x01 )
+			{
+				return 0;
+			}
+			else
+			{
+				return 0xff;
+			}
+		}
+	}
+	return 0;
+}
+
+uint8_t a7800_keypad_device::a7800_pot_y_r()
+{
+	for ( int i = 0; i < 4; i++ )
+	{
+		if ( ! ( ( m_column >> i ) & 0x01 ) )
+		{
+			if ( ( m_keypad->read() >> 3*i ) & 0x02 )
+			{
+				return 0;
+			}
+			else
+			{
+				return 0xff;
+			}
+		}
+	}
+	return 0;
+}

--- a/src/devices/bus/a7800_ctrl/keypad.h
+++ b/src/devices/bus/a7800_ctrl/keypad.h
@@ -1,0 +1,57 @@
+// license:BSD-3-Clause
+// copyright-holders:Curt Coder
+/**********************************************************************
+
+    Atari Video Computer System Keypad emulation
+
+**********************************************************************/
+
+#ifndef MAME_BUS_A7800_CTRL_KEYPAD_H
+#define MAME_BUS_A7800_CTRL_KEYPAD_H
+
+#pragma once
+
+#include "ctrl.h"
+
+
+
+//**************************************************************************
+//  TYPE DEFINITIONS
+//**************************************************************************
+
+// ======================> a7800_keypad_device
+
+class a7800_keypad_device : public device_t,
+							public device_a7800_control_port_interface
+{
+public:
+	// construction/destruction
+	a7800_keypad_device(const machine_config &mconfig, const char *tag, device_t *owner, uint32_t clock);
+
+	// optional information overrides
+	virtual ioport_constructor device_input_ports() const override;
+
+protected:
+	// device-level overrides
+	virtual void device_start() override;
+
+	// device_a7800_control_port_interface overrides
+	virtual uint8_t a7800_joy_r() override;
+	virtual void a7800_joy_w( uint8_t data ) override;
+	virtual uint8_t a7800_pot_x_r() override;
+	virtual uint8_t a7800_pot_y_r() override;
+
+	virtual bool has_pot_x() override { return true; }
+	virtual bool has_pot_y() override { return true; }
+
+private:
+	required_ioport m_keypad;
+
+	uint8_t   m_column;
+};
+
+
+// device type definition
+DECLARE_DEVICE_TYPE(A7800_KEYPAD, a7800_keypad_device)
+
+#endif // MAME_BUS_A7800_CTRL_KEYPAD_H

--- a/src/devices/bus/a7800_ctrl/lightgun.cpp
+++ b/src/devices/bus/a7800_ctrl/lightgun.cpp
@@ -1,0 +1,100 @@
+// license:BSD-3-Clause
+// copyright-holders:Curt Coder
+/**********************************************************************
+
+    Atari lightgun emulation
+
+**********************************************************************/
+
+#include "emu.h"
+#include "lightgun.h"
+
+
+
+//**************************************************************************
+//  DEVICE DEFINITIONS
+//**************************************************************************
+
+DEFINE_DEVICE_TYPE(A7800_LIGHTGUN, a7800_lightgun_device, "a7800_lightgun", "Atari Light Gun")
+
+
+static INPUT_PORTS_START( a7800_lightgun )
+	PORT_START("JOY")
+	PORT_BIT( 0x01, IP_ACTIVE_HIGH, IPT_BUTTON1 ) 
+	PORT_BIT( 0xAE, IP_ACTIVE_LOW,  IPT_UNUSED )
+	PORT_BIT( 0x50, IP_ACTIVE_HIGH, IPT_UNUSED )
+
+	PORT_START("LIGHTX")
+	PORT_BIT( 0xff, 0x00, IPT_LIGHTGUN_X) PORT_CROSSHAIR(X, 1.0, 0.0, 0) PORT_SENSITIVITY(45) PORT_KEYDELTA(15)
+
+	PORT_START("LIGHTY")
+	PORT_BIT( 0xff, 0x00, IPT_LIGHTGUN_Y) PORT_CROSSHAIR(Y, 1.0, 0.0, 0) PORT_SENSITIVITY(45) PORT_KEYDELTA(15)
+INPUT_PORTS_END
+
+
+//-------------------------------------------------
+//  input_ports - device-specific input ports
+//-------------------------------------------------
+
+ioport_constructor a7800_lightgun_device::device_input_ports() const
+{
+	return INPUT_PORTS_NAME( a7800_lightgun );
+}
+
+
+
+//**************************************************************************
+//  LIVE DEVICE
+//**************************************************************************
+
+//-------------------------------------------------
+//  a7800_lightgun_device - constructor
+//-------------------------------------------------
+
+a7800_lightgun_device::a7800_lightgun_device(const machine_config &mconfig, const char *tag, device_t *owner, uint32_t clock) :
+	device_t(mconfig, A7800_LIGHTGUN, tag, owner, clock),
+	device_a7800_control_port_interface(mconfig, *this),
+	m_joy(*this, "JOY"),
+	m_lightx(*this, "LIGHTX"),
+	m_lighty(*this, "LIGHTY")
+{
+}
+
+
+//-------------------------------------------------
+//  device_start - device-specific startup
+//-------------------------------------------------
+
+void a7800_lightgun_device::device_start()
+{
+}
+
+
+//-------------------------------------------------
+//  a7800_joy_r - lightgun read
+//-------------------------------------------------
+
+uint8_t a7800_lightgun_device::a7800_joy_r()
+{
+	return m_joy->read();
+}
+
+//-------------------------------------------------
+//  a7800_lightgun_x_r - lightgun X read
+//-------------------------------------------------
+
+uint8_t a7800_lightgun_device::a7800_light_x_r()
+{
+        return m_lightx->read();
+}
+
+
+//-------------------------------------------------
+//  a7800_lightgun_y_r - lightgun Y read
+//-------------------------------------------------
+
+uint8_t a7800_lightgun_device::a7800_light_y_r()
+{
+        return m_lighty->read();
+}
+

--- a/src/devices/bus/a7800_ctrl/lightgun.h
+++ b/src/devices/bus/a7800_ctrl/lightgun.h
@@ -1,0 +1,54 @@
+// license:BSD-3-Clause
+// copyright-holders:Curt Coder
+/**********************************************************************
+
+    Atari lightgun emulation
+
+**********************************************************************/
+
+#ifndef MAME_BUS_A7800_CTRL_LIGHTGUN_H
+#define MAME_BUS_A7800_CTRL_LIGHTGUN_H
+
+#pragma once
+
+#include "ctrl.h"
+
+
+
+//**************************************************************************
+//  TYPE DEFINITIONS
+//**************************************************************************
+
+// ======================> a7800_lightgun_device
+
+class a7800_lightgun_device : public device_t,
+							public device_a7800_control_port_interface
+{
+public:
+	// construction/destruction
+	a7800_lightgun_device(const machine_config &mconfig, const char *tag, device_t *owner, uint32_t clock);
+
+	// optional information overrides
+	virtual ioport_constructor device_input_ports() const override;
+
+protected:
+	// device-level overrides
+	virtual void device_start() override;
+
+	// device_a7800_control_port_interface overrides
+	virtual uint8_t a7800_joy_r() override;
+	virtual uint8_t a7800_light_x_r() override;
+	virtual uint8_t a7800_light_y_r() override;
+	virtual bool is_lightgun() override { return true; }
+
+private:
+	required_ioport m_joy;
+	required_ioport m_lightx;
+	required_ioport m_lighty;
+};
+
+
+// device type definition
+DECLARE_DEVICE_TYPE(A7800_LIGHTGUN, a7800_lightgun_device)
+
+#endif // MAME_BUS_A7800_CTRL_LIGHTGUN_H

--- a/src/devices/bus/a7800_ctrl/paddles.cpp
+++ b/src/devices/bus/a7800_ctrl/paddles.cpp
@@ -1,0 +1,100 @@
+// license:BSD-3-Clause
+// copyright-holders:Curt Coder
+/**********************************************************************
+
+    Atari analog paddles emulation
+
+**********************************************************************/
+
+#include "emu.h"
+#include "paddles.h"
+
+
+
+//**************************************************************************
+//  DEVICE DEFINITIONS
+//**************************************************************************
+
+DEFINE_DEVICE_TYPE(A7800_PADDLES, a7800_paddles_device, "a7800_paddles", "Atari paddles")
+
+
+static INPUT_PORTS_START( a7800_paddles )
+	PORT_START("JOY")
+	PORT_BIT( 0x08, IP_ACTIVE_LOW, IPT_BUTTON1 ) PORT_PLAYER(1)
+	PORT_BIT( 0x04, IP_ACTIVE_LOW, IPT_BUTTON1 ) PORT_PLAYER(2)
+	PORT_BIT( 0xf3, IP_ACTIVE_LOW, IPT_UNUSED )
+
+	PORT_START("POTX")
+	PORT_BIT( 0xff, 0x80, IPT_PADDLE) PORT_PLAYER(1) PORT_SENSITIVITY(30) PORT_KEYDELTA(20) PORT_MINMAX(0, 255)
+
+	PORT_START("POTY")
+	PORT_BIT( 0xff, 0x80, IPT_PADDLE) PORT_PLAYER(2) PORT_SENSITIVITY(30) PORT_KEYDELTA(20) PORT_MINMAX(0, 255)
+INPUT_PORTS_END
+
+
+//-------------------------------------------------
+//  input_ports - device-specific input ports
+//-------------------------------------------------
+
+ioport_constructor a7800_paddles_device::device_input_ports() const
+{
+	return INPUT_PORTS_NAME( a7800_paddles );
+}
+
+
+
+//**************************************************************************
+//  LIVE DEVICE
+//**************************************************************************
+
+//-------------------------------------------------
+//  a7800_paddles_device - constructor
+//-------------------------------------------------
+
+a7800_paddles_device::a7800_paddles_device(const machine_config &mconfig, const char *tag, device_t *owner, uint32_t clock) :
+	device_t(mconfig, A7800_PADDLES, tag, owner, clock),
+	device_a7800_control_port_interface(mconfig, *this),
+	m_joy(*this, "JOY"),
+	m_potx(*this, "POTX"),
+	m_poty(*this, "POTY")
+{
+}
+
+
+//-------------------------------------------------
+//  device_start - device-specific startup
+//-------------------------------------------------
+
+void a7800_paddles_device::device_start()
+{
+}
+
+
+//-------------------------------------------------
+//  a7800_joy_r - joystick read
+//-------------------------------------------------
+
+uint8_t a7800_paddles_device::a7800_joy_r()
+{
+	return m_joy->read();
+}
+
+
+//-------------------------------------------------
+//  a7800_pot_x_r - potentiometer X read
+//-------------------------------------------------
+
+uint8_t a7800_paddles_device::a7800_pot_x_r()
+{
+	return m_potx->read();
+}
+
+
+//-------------------------------------------------
+//  a7800_pot_y_r - potentiometer Y read
+//-------------------------------------------------
+
+uint8_t a7800_paddles_device::a7800_pot_y_r()
+{
+	return m_poty->read();
+}

--- a/src/devices/bus/a7800_ctrl/paddles.h
+++ b/src/devices/bus/a7800_ctrl/paddles.h
@@ -1,0 +1,58 @@
+// license:BSD-3-Clause
+// copyright-holders:Curt Coder
+/**********************************************************************
+
+    Atari analog paddles emulation
+
+**********************************************************************/
+
+#ifndef MAME_BUS_A7800_CTRL_PADDLES_H
+#define MAME_BUS_A7800_CTRL_PADDLES_H
+
+#pragma once
+
+#include "ctrl.h"
+
+
+
+//**************************************************************************
+//  TYPE DEFINITIONS
+//**************************************************************************
+
+// ======================> a7800_paddles_device
+
+class a7800_paddles_device : public device_t,
+							public device_a7800_control_port_interface
+{
+public:
+	// construction/destruction
+	a7800_paddles_device(const machine_config &mconfig, const char *tag, device_t *owner, uint32_t clock);
+
+	// optional information overrides
+	virtual ioport_constructor device_input_ports() const override;
+
+
+protected:
+	// device-level overrides
+	virtual void device_start() override;
+
+	// device_a7800_control_port_interface overrides
+	virtual uint8_t a7800_joy_r() override;
+	virtual uint8_t a7800_pot_x_r() override;
+	virtual uint8_t a7800_pot_y_r() override;
+
+	virtual bool has_pot_x() override { return true; }
+	virtual bool has_pot_y() override { return true; }
+	virtual bool is_paddle() override { return true; }
+
+private:
+	required_ioport m_joy;
+	required_ioport m_potx;
+	required_ioport m_poty;
+};
+
+
+// device type definition
+DECLARE_DEVICE_TYPE(A7800_PADDLES, a7800_paddles_device)
+
+#endif // MAME_BUS_A7800_CTRL_PADDLES_H

--- a/src/devices/bus/a7800_ctrl/stmouse.cpp
+++ b/src/devices/bus/a7800_ctrl/stmouse.cpp
@@ -1,0 +1,94 @@
+// license:BSD-3-Clause
+// copyright-holders:Curt Coder, Mike Saarna
+/**********************************************************************
+
+    Atari ST mouse controller emulation
+
+**********************************************************************/
+
+#include "emu.h"
+#include "stmouse.h"
+
+
+
+//**************************************************************************
+//  DEVICE DEFINITIONS
+//**************************************************************************
+
+DEFINE_DEVICE_TYPE(A7800_STMOUSE, a7800_stmouse_device, "a7800_stmouse", "Atari ST mouse")
+
+
+	// Only 1 button is presently supported. It's not clear at this time if the ST
+	// mouse has pull-ups on the second button, which would be required for it to 
+	// be reliably used with the 7800 paddle lines.
+
+static INPUT_PORTS_START( a7800_stmouse )
+	PORT_START("JOY")
+	PORT_BIT( 0x20, IP_ACTIVE_LOW, IPT_BUTTON1 ) 	//pin 6
+	PORT_BIT( 0x5F, IP_ACTIVE_HIGH, IPT_UNUSED  )
+	PORT_BIT( 0x80, IP_ACTIVE_LOW, IPT_UNUSED )
+
+	PORT_START("MOUSEX")
+	PORT_BIT( 0xff, 0x00, IPT_TRACKBALL_X ) PORT_SENSITIVITY(40) PORT_KEYDELTA(5)
+
+	PORT_START("MOUSEY")
+	PORT_BIT( 0xff, 0x00, IPT_TRACKBALL_Y ) PORT_SENSITIVITY(40) PORT_KEYDELTA(5)
+INPUT_PORTS_END
+
+
+//-------------------------------------------------
+//  input_ports - device-specific input ports
+//-------------------------------------------------
+
+ioport_constructor a7800_stmouse_device::device_input_ports() const
+{
+	return INPUT_PORTS_NAME( a7800_stmouse );
+}
+
+
+
+//**************************************************************************
+//  LIVE DEVICE
+//**************************************************************************
+
+//-------------------------------------------------
+//  a7800_stmouse_device - constructor
+//-------------------------------------------------
+
+a7800_stmouse_device::a7800_stmouse_device(const machine_config &mconfig, const char *tag, device_t *owner, uint32_t clock) :
+	device_t(mconfig, A7800_STMOUSE, tag, owner, clock),
+	device_a7800_control_port_interface(mconfig, *this),
+	m_joy(*this, "JOY"),
+	m_stmousex(*this, "MOUSEX"),
+	m_stmousey(*this, "MOUSEY")
+{
+}
+
+
+//-------------------------------------------------
+//  device_start - device-specific startup
+//-------------------------------------------------
+
+void a7800_stmouse_device::device_start()
+{
+}
+
+
+//-------------------------------------------------
+//  a7800_joy_r - joystick read
+//-------------------------------------------------
+
+uint8_t a7800_stmouse_device::a7800_joy_r()
+{
+	// The ST mouse uses 2 bits of quadrature encoding per axis.
+	// The X bits use pins 1 and 2, so encoding uses 0x01 and 0x02.
+	// The Y bits use pins 3 and 4, so encoding uses 0x04 and 0x08.
+
+	static const uint8_t axis_lookup_x[4] = { 0x00, 0x02, 0x03, 0x01 };
+	static const uint8_t axis_lookup_y[4] = { 0x00, 0x08, 0x0C, 0x04 };
+
+	return m_joy->read() | axis_lookup_x[ m_stmousex->read() & 0x3 ] |
+		axis_lookup_y[ ( m_stmousey->read() & 0x3 )]  ;
+
+}
+

--- a/src/devices/bus/a7800_ctrl/stmouse.h
+++ b/src/devices/bus/a7800_ctrl/stmouse.h
@@ -1,0 +1,51 @@
+// license:BSD-3-Clause
+// copyright-holders:Curt Coder
+/**********************************************************************
+
+    Atari ST mouse controller emulation
+
+**********************************************************************/
+
+#ifndef MAME_BUS_A7800_CTRL_STMOUSE_H
+#define MAME_BUS_A7800_CTRL_STMOUSE_H
+
+#pragma once
+
+#include "ctrl.h"
+
+
+
+//**************************************************************************
+//  TYPE DEFINITIONS
+//**************************************************************************
+
+// ======================> a7800_stmouse_device
+
+class a7800_stmouse_device : public device_t,
+							public device_a7800_control_port_interface
+{
+public:
+	// construction/destruction
+	a7800_stmouse_device(const machine_config &mconfig, const char *tag, device_t *owner, uint32_t clock);
+
+	// optional information overrides
+	virtual ioport_constructor device_input_ports() const override;
+
+protected:
+	// device-level overrides
+	virtual void device_start() override;
+
+	// device_a7800_control_port_interface overrides
+	virtual uint8_t a7800_joy_r() override;
+
+private:
+	required_ioport m_joy;
+	required_ioport m_stmousex;
+	required_ioport m_stmousey;
+};
+
+
+// device type definition
+DECLARE_DEVICE_TYPE(A7800_STMOUSE, a7800_stmouse_device)
+
+#endif // MAME_BUS_A7800_CTRL_STMOUSE_H

--- a/src/devices/bus/a7800_ctrl/trackball.cpp
+++ b/src/devices/bus/a7800_ctrl/trackball.cpp
@@ -1,0 +1,112 @@
+// license:BSD-3-Clause
+// copyright-holders:Curt Coder, Mike Saarna
+/**********************************************************************
+
+    Atari CX22 trackball controller
+
+**********************************************************************/
+
+#include "emu.h"
+#include "trackball.h"
+
+
+
+//**************************************************************************
+//  DEVICE DEFINITIONS
+//**************************************************************************
+
+DEFINE_DEVICE_TYPE(A7800_TRACKBALL, a7800_trackball_device, "a7800_trackball", "Atari CX22 Trackball")
+
+
+static INPUT_PORTS_START( a7800_trackball )
+	PORT_START("JOY")
+	PORT_BIT( 0x20, IP_ACTIVE_LOW, IPT_BUTTON1 )                     // Pin 6
+	PORT_BIT( 0x5F, IP_ACTIVE_HIGH, IPT_UNUSED  )
+	PORT_BIT( 0x80, IP_ACTIVE_LOW, IPT_UNUSED )
+
+	PORT_START("TRACKBALLX")
+	PORT_BIT( 0xff, 0x00, IPT_TRACKBALL_X ) PORT_SENSITIVITY(40) PORT_KEYDELTA(5)
+
+	PORT_START("TRACKBALLY")
+	PORT_BIT( 0xff, 0x00, IPT_TRACKBALL_Y ) PORT_SENSITIVITY(40) PORT_KEYDELTA(5)
+INPUT_PORTS_END
+
+
+//-------------------------------------------------
+//  input_ports - device-specific input ports
+//-------------------------------------------------
+
+ioport_constructor a7800_trackball_device::device_input_ports() const
+{
+	return INPUT_PORTS_NAME( a7800_trackball );
+}
+
+
+
+//**************************************************************************
+//  LIVE DEVICE
+//**************************************************************************
+
+//-------------------------------------------------
+//  a7800_trackball_device - constructor
+//-------------------------------------------------
+
+a7800_trackball_device::a7800_trackball_device(const machine_config &mconfig, const char *tag, device_t *owner, uint32_t clock) :
+	device_t(mconfig, A7800_TRACKBALL, tag, owner, clock),
+	device_a7800_control_port_interface(mconfig, *this),
+	m_joy(*this, "JOY"),
+	m_trackballx(*this, "TRACKBALLX"),
+	m_trackbally(*this, "TRACKBALLY")
+{
+}
+
+
+//-------------------------------------------------
+//  device_start - device-specific startup
+//-------------------------------------------------
+
+void a7800_trackball_device::device_start()
+{
+}
+
+
+//-------------------------------------------------
+//  a7800_joy_r - joystick read
+//-------------------------------------------------
+
+uint8_t a7800_trackball_device::a7800_joy_r()
+{
+
+	// The CX22 trakball uses 2 bits of traditional trackball encoding per axis.
+	//     b0 = the current trackball spin direction for the axis.
+	//     b1 = alternates when motion occurs on the axis
+	// The X bits use controller pins 1 and 2.
+	// The Y bits use controller pins 3 and 4.
+
+	static uint8_t last_x = 0;
+	static uint8_t last_y = 0;
+
+	static uint8_t last_xcode = 0;
+	static uint8_t last_ycode = 0;
+
+	uint8_t this_x = m_trackballx->read();
+	uint8_t this_y = m_trackbally->read();
+
+	if (this_x>last_x)
+		last_xcode=(last_xcode^2) | 0x01;
+	if (this_x<last_x)
+		last_xcode=(last_xcode^2) & 0xfe;
+
+	if (this_y>last_y)
+		last_ycode=(last_ycode^2) | 0x01;
+	if (this_y<last_y)
+		last_ycode=(last_ycode^2) & 0xfe;
+
+	last_x=this_x;
+	last_y=this_y;
+
+	return (m_joy->read() | last_xcode | last_ycode<<2);
+}
+
+
+

--- a/src/devices/bus/a7800_ctrl/trackball.h
+++ b/src/devices/bus/a7800_ctrl/trackball.h
@@ -1,0 +1,51 @@
+// license:BSD-3-Clause
+// copyright-holders:Curt Coder
+/**********************************************************************
+
+    Atari CX22 trackball controller
+
+**********************************************************************/
+
+#ifndef MAME_BUS_A7800_CTRL_TRACKBALL_H
+#define MAME_BUS_A7800_CTRL_TRACKBALL_H
+
+#pragma once
+
+#include "ctrl.h"
+
+
+
+//**************************************************************************
+//  TYPE DEFINITIONS
+//**************************************************************************
+
+// ======================> a7800_trackball_device
+
+class a7800_trackball_device : public device_t,
+							public device_a7800_control_port_interface
+{
+public:
+	// construction/destruction
+	a7800_trackball_device(const machine_config &mconfig, const char *tag, device_t *owner, uint32_t clock);
+
+	// optional information overrides
+	virtual ioport_constructor device_input_ports() const override;
+
+protected:
+	// device-level overrides
+	virtual void device_start() override;
+
+	// device_a7800_control_port_interface overrides
+	virtual uint8_t a7800_joy_r() override;
+
+private:
+	required_ioport m_joy;
+	required_ioport m_trackballx;
+	required_ioport m_trackbally;
+};
+
+
+// device type definition
+DECLARE_DEVICE_TYPE(A7800_TRACKBALL, a7800_trackball_device)
+
+#endif // MAME_BUS_A7800_CTRL_TRACKBALL_H

--- a/src/devices/bus/a7800_ctrl/wheel.cpp
+++ b/src/devices/bus/a7800_ctrl/wheel.cpp
@@ -1,0 +1,78 @@
+// license:BSD-3-Clause
+// copyright-holders:Curt Coder
+/**********************************************************************
+
+    Atari Video Computer System Driving Wheel emulation
+
+**********************************************************************/
+
+#include "emu.h"
+#include "wheel.h"
+
+
+
+//**************************************************************************
+//  DEVICE DEFINITIONS
+//**************************************************************************
+
+DEFINE_DEVICE_TYPE(A7800_WHEEL, a7800_wheel_device, "a7800_wheel", "Atari Driving Wheel")
+
+
+static INPUT_PORTS_START( a7800_wheel )
+	PORT_START("JOY")
+	PORT_BIT( 0x20, IP_ACTIVE_LOW,  IPT_BUTTON1 )                     // Pin 6
+	PORT_BIT( 0x50, IP_ACTIVE_HIGH, IPT_UNUSED  )
+	PORT_BIT( 0x8C, IP_ACTIVE_LOW,  IPT_UNUSED  )
+
+	PORT_START("WHEEL")
+	PORT_BIT( 0xff, 0x00, IPT_TRACKBALL_X ) PORT_SENSITIVITY(40) PORT_KEYDELTA(5)
+INPUT_PORTS_END
+
+
+//-------------------------------------------------
+//  input_ports - device-specific input ports
+//-------------------------------------------------
+
+ioport_constructor a7800_wheel_device::device_input_ports() const
+{
+	return INPUT_PORTS_NAME( a7800_wheel );
+}
+
+
+
+//**************************************************************************
+//  LIVE DEVICE
+//**************************************************************************
+
+//-------------------------------------------------
+//  a7800_wheel_device - constructor
+//-------------------------------------------------
+
+a7800_wheel_device::a7800_wheel_device(const machine_config &mconfig, const char *tag, device_t *owner, uint32_t clock) :
+	device_t(mconfig, A7800_WHEEL, tag, owner, clock),
+	device_a7800_control_port_interface(mconfig, *this),
+	m_joy(*this, "JOY"),
+	m_wheel(*this, "WHEEL")
+{
+}
+
+
+//-------------------------------------------------
+//  device_start - device-specific startup
+//-------------------------------------------------
+
+void a7800_wheel_device::device_start()
+{
+}
+
+
+//-------------------------------------------------
+//  a7800_joy_r - joystick read
+//-------------------------------------------------
+
+uint8_t a7800_wheel_device::a7800_joy_r()
+{
+	static const uint8_t driving_lookup[4] = { 0x00, 0x02, 0x03, 0x01 };
+
+	return m_joy->read() | driving_lookup[ ( m_wheel->read() & 0x18 ) >> 3 ];
+}

--- a/src/devices/bus/a7800_ctrl/wheel.h
+++ b/src/devices/bus/a7800_ctrl/wheel.h
@@ -1,0 +1,50 @@
+// license:BSD-3-Clause
+// copyright-holders:Curt Coder
+/**********************************************************************
+
+    Atari Video Computer System Driving Wheel emulation
+
+**********************************************************************/
+
+#ifndef MAME_BUS_A7800_CTRL_WHEEL_H
+#define MAME_BUS_A7800_CTRL_WHEEL_H
+
+#pragma once
+
+#include "ctrl.h"
+
+
+
+//**************************************************************************
+//  TYPE DEFINITIONS
+//**************************************************************************
+
+// ======================> a7800_wheel_device
+
+class a7800_wheel_device : public device_t,
+							public device_a7800_control_port_interface
+{
+public:
+	// construction/destruction
+	a7800_wheel_device(const machine_config &mconfig, const char *tag, device_t *owner, uint32_t clock);
+
+	// optional information overrides
+	virtual ioport_constructor device_input_ports() const override;
+
+protected:
+	// device-level overrides
+	virtual void device_start() override;
+
+	// device_a7800_control_port_interface overrides
+	virtual uint8_t a7800_joy_r() override;
+
+private:
+	required_ioport m_joy;
+	required_ioport m_wheel;
+};
+
+
+// device type definition
+DECLARE_DEVICE_TYPE(A7800_WHEEL, a7800_wheel_device)
+
+#endif // MAME_BUS_A7800_CTRL_WHEEL_H

--- a/src/mame/drivers/a7800.cpp
+++ b/src/mame/drivers/a7800.cpp
@@ -94,6 +94,11 @@
     2014/08/25 Fabio Priuli Converted carts to be slot devices and cleaned
                up the driver (removed the pokey, cleaned up rom regions, etc.)
 
+    2017/07/14 Mike Saarna/Robert Tuccito   Converted to slotted controls and
+               added support for proline joysticks, vcs joysticks, paddles,
+               lightguns, keypads, driving wheels, cx22 trakballs, amiga mice, 
+               st mice/cx80. 
+
 ***************************************************************************/
 
 #include "emu.h"
@@ -102,10 +107,12 @@
 #include "sound/tiasound.h"
 #include "machine/mos6530n.h"
 #include "video/maria.h"
+#include "bus/a7800_ctrl/ctrl.h"
 #include "bus/a7800/a78_carts.h"
 #include "screen.h"
 #include "softlist.h"
 #include "speaker.h"
+
 
 #define A7800_NTSC_Y1   XTAL_14_31818MHz
 #define CLK_PAL 1773447
@@ -119,12 +126,13 @@ public:
 	m_maincpu(*this, "maincpu"),
 	m_tia(*this, "tia"),
 	m_maria(*this, "maria"),
-	m_io_joysticks(*this, "joysticks"),
-	m_io_buttons(*this, "buttons"),
+	m_joy1(*this, "joy1"),
+	m_joy2(*this, "joy2"),
 	m_io_console_buttons(*this, "console_buttons"),
 	m_cart(*this, "cartslot"),
 	m_screen(*this, "screen"),
 	m_bios(*this, "maincpu") { }
+
 
 	int m_lines;
 	int m_ispal;
@@ -135,6 +143,7 @@ public:
 	int m_p1_one_button;
 	int m_p2_one_button;
 	int m_bios_enabled;
+
 
 	DECLARE_READ8_MEMBER(bios_or_cart_r);
 	DECLARE_READ8_MEMBER(tia_r);
@@ -148,19 +157,23 @@ public:
 	TIMER_DEVICE_CALLBACK_MEMBER(interrupt);
 	TIMER_CALLBACK_MEMBER(maria_startdma);
 	DECLARE_READ8_MEMBER(riot_joystick_r);
+	DECLARE_WRITE8_MEMBER(riot_joystick_w);
 	DECLARE_READ8_MEMBER(riot_console_button_r);
 	DECLARE_WRITE8_MEMBER(riot_button_pullup_w);
+
 
 protected:
 	required_device<cpu_device> m_maincpu;
 	required_device<tia_device> m_tia;
 	required_device<atari_maria_device> m_maria;
-	required_ioport m_io_joysticks;
-	required_ioport m_io_buttons;
+	required_device<a7800_control_port_device> m_joy1;
+	required_device<a7800_control_port_device> m_joy2;
 	required_ioport m_io_console_buttons;
 	required_device<a78_cart_slot_device> m_cart;
 	required_device<screen_device> m_screen;
 	required_region_ptr<uint8_t> m_bios;
+	uint64_t paddle_start;
+	uint8_t  tia_delay;
 };
 
 
@@ -171,7 +184,27 @@ protected:
 // RIOT
 READ8_MEMBER(a7800_state::riot_joystick_r)
 {
-	return m_io_joysticks->read();
+	uint8_t val = 0;
+
+
+	/* Left controller port PINs 1-4 ( 4321 ) */
+	val |= ( m_joy1->joy_r() & 0x0F ) << 4;
+
+	/* Right controller port PINs 1-4 ( 4321 ) */
+	val |= m_joy2->joy_r() & 0x0F;
+
+	return val;
+}
+
+WRITE8_MEMBER(a7800_state::riot_joystick_w)
+{
+
+	/* Left controller port */
+	m_joy1->joy_w( data >> 4 );
+
+	/* Right controller port */
+	m_joy2->joy_w( data & 0x0f );
+
 }
 
 READ8_MEMBER(a7800_state::riot_console_button_r)
@@ -189,6 +222,26 @@ WRITE8_MEMBER(a7800_state::riot_button_pullup_w)
 
 READ8_MEMBER(a7800_state::tia_r)
 {
+
+	uint64_t elapsed; 
+	int16_t cpu_x, cpu_y;
+	int16_t gun_x, gun_y;
+
+	/* For now we only apply the 0.5 cycle penalty to lightgun games, where it's required.
+	   Other games (mostly paddle) may jitter from frame to frame, because we can't actually 
+	   wait 0.5 cycles, and instead wait for 1 cycle every 2x TIA accesses. Without this fix
+	   our 6502 on-screen position is severely skewed. */
+	if ((m_joy1->is_lightgun())||(m_joy2->is_lightgun()))
+	{
+		tia_delay++;
+		if(tia_delay==2)
+		{
+			tia_delay=0;
+			//+3 gives us +1 cpu cycle, because we're partway through an instruction.
+			m_maincpu->spin_until_time(m_maincpu->cycles_to_attotime(3));
+		}
+	}
+
 	switch (offset & 0x0f)
 	{
 		case 0x00:
@@ -200,26 +253,141 @@ READ8_MEMBER(a7800_state::tia_r)
 		case 0x06:
 		case 0x07:
 			/* Even though the 7800 doesn't use the TIA graphics the collision registers should
-			 still return a reasonable value */
+			   still return a reasonable value */
 			return 0x00;
-		case 0x08:
-			return ((m_io_buttons->read() & 0x02) << 6);
-		case 0x09:
-			return ((m_io_buttons->read() & 0x08) << 4);
-		case 0x0a:
-			return ((m_io_buttons->read() & 0x01) << 7);
-		case 0x0b:
-			return ((m_io_buttons->read() & 0x04) << 5);
-		case 0x0c:
-			if (((m_io_buttons->read() & 0x08) ||(m_io_buttons->read() & 0x02)) && m_p1_one_button)
+		case 0x08: //INPT0
+			if ( m_joy1->has_pro_buttons() && m_p1_one_button) // don't report A or B in 1 button mode
 				return 0x00;
-			else
-				return 0x80;
-		case 0x0d:
-			if (((m_io_buttons->read() & 0x01) ||(m_io_buttons->read() & 0x04)) && m_p2_one_button)
+			if ( m_joy1->is_paddle() )
+			{
+				/* Scale the elapsed cycles to approximately fit the digital paddle-scale. This
+				   is always a bit different from game to game, so we'll invariably wind up with
+				   some wasted digital paddle-range and an in-game non-centered center point. */
+				elapsed = (machine().device<cpu_device>("maincpu")->total_cycles() - paddle_start)/97;
+				if ( elapsed > m_joy1->pot_x_r() )
+					return 0x80;
+				else
+					return 0x00;
+			}
+			if(m_joy1->has_pot_x())
+				return m_joy1->pot_x_r();
+			return ((m_joy1->joy_r() & 0x10)<<3);
+		case 0x09: //INPT1
+			if ( m_joy1->has_pro_buttons() && m_p1_one_button) // don't report A or B in 1 button mode
 				return 0x00;
+			if ( m_joy1->is_paddle() )
+			{
+				/* Scale the elapsed cycles to approximately fit the digital paddle-scale. This
+				   is always a bit different from game to game, so we'll invariably wind up with
+				   some wasted digital paddle-range and an in-game non-centered center point. */
+				elapsed = (machine().device<cpu_device>("maincpu")->total_cycles() - paddle_start)/97;
+				if ( elapsed > m_joy1->pot_y_r() )
+					return 0x80;
+				else
+					return 0x00;
+			}
+			if(m_joy1->has_pot_y())
+				return m_joy1->pot_y_r();
+			return ((m_joy1->joy_r() & 0x40)<<1);
+		case 0x0a: //INPT2
+			if ( m_joy2->has_pro_buttons() && m_p2_one_button) // don't report A or B in 1 button mode
+				return 0x00;
+			if ( m_joy2->is_paddle() )
+			{
+				/* Scale the elapsed cycles to approximately fit the digital paddle-scale. This
+				   is always a bit different from game to game, so we'll invariably wind up with
+				   some wasted digital paddle-range and an in-game non-centered center point. */
+				elapsed = (machine().device<cpu_device>("maincpu")->total_cycles() - paddle_start)/97;
+				if ( elapsed > (m_joy2->pot_x_r()^0xff) )
+					return 0x80;
+				else
+					return 0x00;
+			}
+			if(m_joy2->has_pot_x())
+				return m_joy2->pot_x_r();
+			return ((m_joy2->joy_r() & 0x10)<<3);
+		case 0x0b: //INPT3
+			if ( m_joy2->has_pro_buttons() && m_p2_one_button) // don't report A or B in 1 button mode
+				return 0x00;
+			if ( m_joy2->is_paddle() )
+			{
+				/* Scale the elapsed cycles to approximately fit the digital paddle-scale. This
+				   is always a bit different from game to game, so we'll invariably wind up with
+				   some wasted digital paddle-range and an in-game non-centered center point. */
+				elapsed = (machine().device<cpu_device>("maincpu")->total_cycles() - paddle_start)/97;
+				if ( elapsed > m_joy2->pot_y_r() )
+					return 0x80;
+				else
+					return 0x00;
+			}
+			if(m_joy2->has_pot_y())
+				return m_joy2->pot_y_r();
+			return ((m_joy2->joy_r() & 0x40)<<1);
+		case 0x0c: //INPT4
+			if ( m_joy1->has_pro_buttons() && m_p1_one_button && (m_joy1->joy_r() & 0x50) )
+				return 0x00; // A and B buttons activate the vcs button line in 1 button mode
+			if (m_joy1->is_lightgun())
+			{
+				/* To support 7800 lightguns, the 6502 races the beam 2600 style, checking
+				   the INPT4 light sensor. If it's being checked, we need to find out
+				   the current cpu position, and compare it to the GUI gunsight. If the
+				   gunsight is nearby, we need to return a "lit-up" sensor value. */
+
+				cpu_x=m_screen->hpos()/2;
+				cpu_y=(m_screen->vpos() % m_lines); 
+
+				// Scale the gun X coordinates to the screen. Offset and wrap the X.
+				gun_x=((((m_joy1->light_x_r())*160)/255)+95)%227;
+
+				// Scale the gun Y coordinates to the visible screen length. Offset the Y.
+				if(m_ispal)
+					gun_y=(((m_joy1->light_y_r())*260)/255)+24;
+				else //ntsc
+					gun_y=(((m_joy1->light_y_r())*228)/255)+16;
+
+				/* Calculate the distance between the gunsight and beam. If it's within 8 pixels,
+				   light up the sensor. We use 8 squared instead of 8 for the comparison, so that
+				   we can skip the square root on the distance calculation. */
+				if( (((gun_x-cpu_x)*(gun_x-cpu_x))+((gun_y-cpu_y)*(gun_y-cpu_y))) < 64 )
+					return 0x00;
+				else
+					return 0x80;
+			}
 			else
-				return 0x80;
+				return((m_joy1->joy_r()&0x20)<<2);
+
+		case 0x0d: //INPT5
+			if ( m_joy2->has_pro_buttons() && m_p2_one_button && (m_joy2->joy_r() & 0x50) )
+				return 0x00; // A and B buttons activate the vcs button line in 1 button mode
+			if (m_joy2->is_lightgun())
+			{
+				/* To support 7800 lightguns, the 6502 races the beam 2600 style, checking
+				   the INPT5 light sensor. If it's being checked, we need to find out
+				   the current cpu position, and compare it to the GUI gunsight. If the
+				   gunsight is nearby, we need to return a "lit-up" sensor value. */
+
+				cpu_x=m_screen->hpos()/2;
+				cpu_y=(m_screen->vpos() % m_lines); 
+
+				// Scale the gun X coordinates to the screen. Offset and wrap the X.
+				gun_x=((((m_joy2->light_x_r())*160)/255)+95)%227;
+
+				// Scale the gun Y coordinates to the visible screen length. Offset the Y.
+				if(m_ispal)
+					gun_y=(((m_joy2->light_y_r())*260)/255)+24;
+				else //ntsc
+					gun_y=(((m_joy2->light_y_r())*228)/255)+16;
+
+				/* Calculate the distance between the gunsight and beam. If it's within 8 pixels,
+				   light up the sensor. We use 8 squared instead of 8 for the comparison, so we 
+				   can skip the square root on the distance calculation. */
+				if( (((gun_x-cpu_x)*(gun_x-cpu_x))+((gun_y-cpu_y)*(gun_y-cpu_y))) < 64 )
+					return 0x00;
+				else
+					return 0x80;
+			}
+			else
+				return((m_joy2->joy_r()&0x20)<<2);
 		default:
 			logerror("undefined TIA read %x\n",offset);
 
@@ -230,6 +398,23 @@ READ8_MEMBER(a7800_state::tia_r)
 // TIA
 WRITE8_MEMBER(a7800_state::tia_w)
 {
+	static uint8_t paddle_is_grounded = 0;
+
+	/* For now we only apply the 0.5 cycle penalty to lightgun games, where it's required.
+	   Other games (mostly paddle) may jitter from frame to frame, because we can't actually 
+	   wait 0.5 cycles, and instead wait for 1 cycle every 2x TIA accesses. Without this fix
+	   our 6502 on-screen position is severely skewed. */
+	if ((m_joy1->is_lightgun())||(m_joy2->is_lightgun()))
+	{
+		tia_delay++;
+		if(tia_delay==2)
+		{
+			tia_delay=0;
+			//+3 gives us +1 cpu cycle, because we're partway through an instruction.
+			m_maincpu->spin_until_time(m_maincpu->cycles_to_attotime(3));
+		}
+	}
+
 	if (offset < 0x20)
 	{ //INPTCTRL covers TIA registers 0x00-0x1F until locked
 		if (data & 0x01)
@@ -245,7 +430,20 @@ WRITE8_MEMBER(a7800_state::tia_w)
 			m_ctrl_reg = data;
 		}
 	}
-	m_tia->tia_sound_w(space, offset, data);
+	if(offset==1) // VBLANK
+	{
+		// paddle_start is when the paddles have been grounded and released from ground.
+		if(data & 0x80) 
+			paddle_is_grounded=1;
+		else if (paddle_is_grounded)
+		{
+			paddle_is_grounded=0;
+			paddle_start = machine().device<cpu_device>("maincpu")->total_cycles();
+		}
+	}
+	else
+		m_tia->tia_sound_w(space, offset, data);
+
 }
 
 
@@ -304,22 +502,6 @@ ADDRESS_MAP_END
 ***************************************************************************/
 
 static INPUT_PORTS_START( a7800 )
-	PORT_START("joysticks")
-	PORT_BIT(0x01, IP_ACTIVE_LOW, IPT_JOYSTICK_UP)    PORT_PLAYER(2) PORT_8WAY
-	PORT_BIT(0x02, IP_ACTIVE_LOW, IPT_JOYSTICK_DOWN)  PORT_PLAYER(2) PORT_8WAY
-	PORT_BIT(0x04, IP_ACTIVE_LOW, IPT_JOYSTICK_LEFT)  PORT_PLAYER(2) PORT_8WAY
-	PORT_BIT(0x08, IP_ACTIVE_LOW, IPT_JOYSTICK_RIGHT) PORT_PLAYER(2) PORT_8WAY
-	PORT_BIT(0x10, IP_ACTIVE_LOW, IPT_JOYSTICK_UP)    PORT_PLAYER(1) PORT_8WAY
-	PORT_BIT(0x20, IP_ACTIVE_LOW, IPT_JOYSTICK_DOWN)  PORT_PLAYER(1) PORT_8WAY
-	PORT_BIT(0x40, IP_ACTIVE_LOW, IPT_JOYSTICK_LEFT)  PORT_PLAYER(1) PORT_8WAY
-	PORT_BIT(0x80, IP_ACTIVE_LOW, IPT_JOYSTICK_RIGHT) PORT_PLAYER(1) PORT_8WAY
-
-	PORT_START("buttons")
-	PORT_BIT(0x01, IP_ACTIVE_HIGH, IPT_BUTTON2)       PORT_PLAYER(2)
-	PORT_BIT(0x02, IP_ACTIVE_HIGH, IPT_BUTTON2)       PORT_PLAYER(1)
-	PORT_BIT(0x04, IP_ACTIVE_HIGH, IPT_BUTTON1)       PORT_PLAYER(2)
-	PORT_BIT(0x08, IP_ACTIVE_HIGH, IPT_BUTTON1)       PORT_PLAYER(1)
-	PORT_BIT(0xF0, IP_ACTIVE_LOW, IPT_UNUSED)
 
 	PORT_START("console_buttons")
 	PORT_BIT(0x01, IP_ACTIVE_LOW, IPT_OTHER)  PORT_NAME("Reset")         PORT_CODE(KEYCODE_R)
@@ -1349,11 +1531,12 @@ void a7800_state::machine_reset()
 	m_ctrl_reg = 0;
 	m_maria_flag = 0;
 	m_bios_enabled = 0;
+	tia_delay = 0;
 }
 
 static MACHINE_CONFIG_START( a7800_ntsc )
 	/* basic machine hardware */
-	MCFG_CPU_ADD("maincpu", M6502, A7800_NTSC_Y1/8) /* 1.79 MHz (switches to 1.19 MHz on TIA or RIOT access) */
+	MCFG_CPU_ADD("maincpu", M6502, A7800_NTSC_Y1/8) /* 1.79 MHz (switches to 1.19 MHz on TIA or RIOT RAM access) */
 	MCFG_CPU_PROGRAM_MAP(a7800_mem)
 	MCFG_TIMER_DRIVER_ADD_SCANLINE("scantimer", a7800_state, interrupt, "screen", 0, 1)
 
@@ -1377,8 +1560,13 @@ static MACHINE_CONFIG_START( a7800_ntsc )
 	/* devices */
 	MCFG_DEVICE_ADD("riot", MOS6532_NEW, A7800_NTSC_Y1/8)
 	MCFG_MOS6530n_IN_PA_CB(READ8(a7800_state, riot_joystick_r))
+	MCFG_MOS6530n_OUT_PA_CB(WRITE8(a7800_state, riot_joystick_w))
 	MCFG_MOS6530n_IN_PB_CB(READ8(a7800_state, riot_console_button_r))
 	MCFG_MOS6530n_OUT_PB_CB(WRITE8(a7800_state, riot_button_pullup_w))
+
+
+	MCFG_A7800_CONTROL_PORT_ADD("joy1", a7800_control_port_devices, "proline_joystick")
+	MCFG_A7800_CONTROL_PORT_ADD("joy2", a7800_control_port_devices, "proline_joystick")
 
 	MCFG_A78_CARTRIDGE_ADD("cartslot", a7800_cart, nullptr)
 
@@ -1404,6 +1592,7 @@ static MACHINE_CONFIG_DERIVED( a7800_pal, a7800_ntsc )
 	MCFG_DEVICE_REMOVE("riot")
 	MCFG_DEVICE_ADD("riot", MOS6532_NEW, CLK_PAL)
 	MCFG_MOS6530n_IN_PA_CB(READ8(a7800_state, riot_joystick_r))
+	MCFG_MOS6530n_OUT_PA_CB(WRITE8(a7800_state, riot_joystick_w))
 	MCFG_MOS6530n_IN_PB_CB(READ8(a7800_state, riot_console_button_r))
 	MCFG_MOS6530n_OUT_PB_CB(WRITE8(a7800_state, riot_button_pullup_w))
 

--- a/src/mame/video/maria.cpp
+++ b/src/mame/video/maria.cpp
@@ -6,8 +6,10 @@
 
 
   - some history:
+
     2014-12-01 Mike Saarna, Robert Tuccitto Implemented "colorburst kill" bit
                 of the MARIA CTRL register.
+
     2014-10-05 Mike Saarna, Robert Tuccitto Last Line DMA value corrected
                 to 6. GCC and Atari docs both show a difference between
                 Other Line and Last Line as +6 at the lowest part of the
@@ -53,7 +55,8 @@
 
 #define TRIGGER_HSYNC   64717
 
-#define READ_MEM(x) space.read_byte(x)
+//#define READ_MEM(x) space.read_byte(x)
+#define READ_MEM(x) (((x)<0x20) ? 0:space.read_byte(x)) //TODO: track down spurious writes to TIA
 
 DEFINE_DEVICE_TYPE(ATARI_MARIA, atari_maria_device, "atari_maria", "Atari MARIA")
 
@@ -270,8 +273,10 @@ void atari_maria_device::draw_scanline()
 		if (m_offset == 0)
 		{
 			maria_cycles += 6; // extra shutdown time
+
 			if (READ_MEM(m_dll + 3) & 0x80)
 				maria_cycles += 17; // interrupt overhead
+
 		}
 
 		// If MARIA used up all of the DMA time then the CPU can't run until next line...


### PR DESCRIPTION
Update Atari 7800 controller inputs to proper slot devices, includes: lightgun, paddles, keypad, driving, trakball, st mouse, amiga mouse, vcs joystick, and proline joystick support.

Reasons why this can't share the existing vcs_ctrl 9-pin controller abstraction and controllers:

The 7800 has a circuit to enable/disable 2 button functionality, which interacts with resistors in 2 button controls. The alternate drivers using vcs_ctrl would have this new controller that is broken for them if we didn't use a a7800_ctrl. A vcs cannot use the 2 buttons of a 2-button 7800 controller, and drivers will need special code to correctly tie the 2 buttons together to act like a single button. This will be exacerbated if we need to later add controls like the prototype 2-button 7800 trakball, and homebrew soft start+reset button support.

Additionally, on a 7800 the INPT0-3 bits are ACTIVE_HIGH instead of the ACTIVE_LOW used in the vcs_ctrl tree. This reflects the actual unplugged state of those lines on a 7800. If we were to use the vcs controls without this change, the INPT0-3 bits would be incorrect and the 7800 would be perma-firing the secondary joystick buttons. Or else we'd need to intercept and conditionally invert these bits, probably with additional methods needing to added, or HIGH/LOW state being inverted to reality in the 2 button controls.

The a7800 driver also has only an audio TIA, so we wind up handling some other 7800 registers that the 7800 does see in-driver, which is complicated a bit due to that 2-button mode resistor. Due to that we needed to add methods that the vcs_ctrl tree didn't have.