### PR TITLE
Fix include path with USE_LIBSDL on macOS

### DIFF
--- a/scripts/src/osd/sdl_cfg.lua
+++ b/scripts/src/osd/sdl_cfg.lua
@@ -86,7 +86,7 @@ if BASE_TARGETOS=="unix" then
 					"MACOSX_USE_LIBSDL",
 				}
 				buildoptions {
-					backtick(sdlconfigcmd() .. " --cflags | sed 's:/SDL::'"),
+					backtick(sdlconfigcmd() .. " --cflags | sed 's:/SDL2::'"),
 				}
 			end
 			end


### PR DESCRIPTION
The cflags will contain an include path ending in "SDL2", not just "SDL", and removing just the latter leaves a stray "2" on the end.