### PR TITLE
Fixed an options overhaul regression

### DIFF
--- a/src/emu/emuopts.h
+++ b/src/emu/emuopts.h
@@ -523,4 +523,7 @@ private:
 	std::string                                         m_software_name;
 };
 
+// takes an existing emu_options and adds system specific options
+void osd_setup_osd_specific_emu_options(emu_options &opts);
+
 #endif  // MAME_EMU_EMUOPTS_H

--- a/src/frontend/mame/ui/miscmenu.cpp
+++ b/src/frontend/mame/ui/miscmenu.cpp
@@ -676,6 +676,7 @@ menu_machine_configure::menu_machine_configure(mame_ui_manager &mui, render_cont
 {
 	// parse the INI file
 	std::ostringstream error;
+	osd_setup_osd_specific_emu_options(m_opts);
 	mame_options::parse_standard_inis(m_opts, error, m_drv);
 	setup_bios();
 }

--- a/src/frontend/mame/ui/miscmenu.h
+++ b/src/frontend/mame/ui/miscmenu.h
@@ -15,17 +15,9 @@
 
 #include "crsshair.h"
 #include "emuopts.h"
-#include "modules/lib/osdobj_common.h"
 
 #include <utility>
 #include <vector>
-
-#ifdef WIN32
-#include "windows/winmain.h"
-typedef windows_options actual_options;
-#else
-typedef osd_options actual_options;
-#endif
 
 namespace ui {
 class menu_keyboard_mode : public menu
@@ -167,7 +159,7 @@ private:
 	virtual void handle() override;
 
 	const game_driver *m_drv;
-	actual_options m_opts;
+	emu_options m_opts;
 	float x0, y0;
 	s_bios m_bios;
 	std::size_t m_curbios;

--- a/src/frontend/mame/ui/miscmenu.h
+++ b/src/frontend/mame/ui/miscmenu.h
@@ -15,10 +15,17 @@
 
 #include "crsshair.h"
 #include "emuopts.h"
+#include "modules/lib/osdobj_common.h"
 
 #include <utility>
 #include <vector>
 
+#ifdef WIN32
+#include "windows/winmain.h"
+typedef windows_options actual_options;
+#else
+typedef osd_options actual_options;
+#endif
 
 namespace ui {
 class menu_keyboard_mode : public menu
@@ -160,7 +167,7 @@ private:
 	virtual void handle() override;
 
 	const game_driver *m_drv;
-	emu_options m_opts;
+	actual_options m_opts;
 	float x0, y0;
 	s_bios m_bios;
 	std::size_t m_curbios;

--- a/src/osd/modules/lib/osdobj_common.h
+++ b/src/osd/modules/lib/osdobj_common.h
@@ -169,7 +169,6 @@ public:
 	const char *pa_device() const { return value(OSDOPTION_PA_DEVICE); }
 	const float pa_latency() const { return float_value(OSDOPTION_PA_LATENCY); }
 
-private:
 	static const options_entry s_option_entries[];
 };
 

--- a/src/osd/sdl/sdlmain.cpp
+++ b/src/osd/sdl/sdlmain.cpp
@@ -396,6 +396,16 @@ void sdl_osd_interface::output_oslog(const char *buffer)
 
 
 //============================================================
+//  osd_setup_osd_specific_emu_options
+//============================================================
+
+void osd_setup_osd_specific_emu_options(emu_options &opts)
+{
+	opts.add_entries(osd_options::s_option_entries);
+}
+
+
+//============================================================
 //  init
 //============================================================
 

--- a/src/osd/windows/winmain.cpp
+++ b/src/osd/windows/winmain.cpp
@@ -617,6 +617,17 @@ void windows_osd_interface::osd_exit()
 }
 
 
+//============================================================
+//  osd_setup_osd_specific_emu_options
+//============================================================
+
+void osd_setup_osd_specific_emu_options(emu_options &opts)
+{
+	opts.add_entries(osd_options::s_option_entries);
+	opts.add_entries(windows_options::s_option_entries);
+}
+
+
 #if WINAPI_FAMILY_PARTITION(WINAPI_PARTITION_DESKTOP)
 
 //============================================================

--- a/src/osd/windows/winmain.h
+++ b/src/osd/windows/winmain.h
@@ -210,7 +210,6 @@ public:
 	bool global_inputs() const { return bool_value(WINOPTION_GLOBAL_INPUTS); }
 	bool dual_lightgun() const { return bool_value(WINOPTION_DUAL_LIGHTGUN); }
 
-private:
 	static const options_entry s_option_entries[];
 };
 


### PR DESCRIPTION
This crash (discovered by Wizz) had the following symptoms:
1.  Start MAME
2.  Choose "Configure Machine"
3.  Choose "Video Options"
CRASH

This was the result of the options editor not having a fully formed list of options where it was expecting one.  The fix is to change the declaration of emu_options to one that have full OSD options (it is possible that SDLMAME needs something slightly different)

Please scrutinize this fix.  I hate it.  I also hate how all of the OSD options are duplicatively declared in submenu.cpp, but with a different data structure.  At the very least we should be having some sort of factory to create "full" options for the pertinent platform; but I'm not sure how precisely we would want it to work.