### PR TITLE
Attempted to sanitize/rationalize how we access UTF-8 command line arguments

### DIFF
--- a/scripts/src/main.lua
+++ b/scripts/src/main.lua
@@ -68,11 +68,6 @@ end
 			}
 	end
 
-	configuration { "vs*" }
-	flags {
-		"Unicode",
-	}
-
 	configuration { "winstore*" }
 		-- Windows Required Files
 		files {

--- a/scripts/src/osd/sdl.lua
+++ b/scripts/src/osd/sdl.lua
@@ -94,14 +94,6 @@ function maintargetosdoptions(_target,_subtarget)
 		links {
 			"psapi",
 		}
-		configuration { "mingw*" }
-			linkoptions{
-				"-municode",
-			}
-		configuration { "vs*" }
-			flags {
-				"Unicode",
-			}
 		configuration {}
 	elseif _OPTIONS["targetos"]=="haiku" then
 		links {

--- a/scripts/src/osd/sdl_cfg.lua
+++ b/scripts/src/osd/sdl_cfg.lua
@@ -107,7 +107,6 @@ if _OPTIONS["targetos"]=="windows" then
 		defines {
 			"UNICODE",
 			"_UNICODE",
-			"main=utf8_main",
 			"_WIN32_WINNT=0x0501",
 			"WIN32_LEAN_AND_MEAN",
 			"NOMINMAX",

--- a/scripts/src/osd/windows.lua
+++ b/scripts/src/osd/windows.lua
@@ -16,9 +16,6 @@ function maintargetosdoptions(_target,_subtarget)
 	osdmodulestargetconf()
 
 	configuration { "mingw*" }
-		linkoptions {
-			"-municode",
-		}
 		links {
 			"mingw32",
 		}

--- a/scripts/src/osd/windows_cfg.lua
+++ b/scripts/src/osd/windows_cfg.lua
@@ -10,8 +10,7 @@ defines {
 configuration { "mingw* or vs*" }
 	defines {
 		"UNICODE",
-		"_UNICODE",
-		"main=utf8_main",
+		"_UNICODE"
 	}
 
 configuration { "vs*" }

--- a/src/osd/osdcore.h
+++ b/src/osd/osdcore.h
@@ -26,6 +26,7 @@
 #include <cstdint>
 #include <memory>
 #include <string>
+#include <vector>
 
 
 /***************************************************************************
@@ -882,6 +883,9 @@ void CLIB_DECL osd_printf_warning(const char *format, ...) ATTR_PRINTF(1,2);
 void CLIB_DECL osd_printf_info(const char *format, ...) ATTR_PRINTF(1,2);
 void CLIB_DECL osd_printf_verbose(const char *format, ...) ATTR_PRINTF(1,2);
 void CLIB_DECL osd_printf_debug(const char *format, ...) ATTR_PRINTF(1,2);
+
+// returns command line arguments as an std::vector<std::string> in UTF-8
+std::vector<std::string> osd_get_command_line(int argc, char *argv[]);
 
 /* discourage the use of printf directly */
 /* sadly, can't do this because of the ATTR_PRINTF under GCC */

--- a/src/osd/sdl/sdlmain.cpp
+++ b/src/osd/sdl/sdlmain.cpp
@@ -180,15 +180,9 @@ sdl_options::sdl_options()
 extern "C" DECLSPEC void SDLCALL SDL_SetModuleHandle(void *hInst);
 #endif
 
-// translated to utf8_main
-#if defined(SDLMAME_WIN32)
-int main(std::vector<std::string> &args)
-{
-#else
 int main(int argc, char** argv)
 {
-	std::vector<std::string> args(argv, argv+argc);
-#endif
+	std::vector<std::string> args = osd_get_command_line(argc, argv);
 	int res = 0;
 
 	// disable I/O buffering

--- a/src/osd/windows/main.cpp
+++ b/src/osd/windows/main.cpp
@@ -18,29 +18,7 @@
 
 #include "strconv.h"
 
-#if WINAPI_FAMILY_PARTITION(WINAPI_PARTITION_DESKTOP)
-
-extern int utf8_main(std::vector<std::string> &args);
-//============================================================
-//  main
-//============================================================
-
-#ifdef UNICODE
-extern "C" int _tmain(int argc, TCHAR **argv)
-{
-	int i;
-	std::vector<std::string> argv_vectors(argc);
-
-	// convert arguments to UTF-8
-	for (i = 0; i < argc; i++)
-		argv_vectors[i] = osd::text::from_tstring(argv[i]);
-
-	// run utf8_main
-	return utf8_main(argv_vectors);
-}
-#endif
-
-#else
+#if !WINAPI_FAMILY_PARTITION(WINAPI_PARTITION_DESKTOP)
 
 #include "winmain.h"
 

--- a/src/osd/windows/winmain.cpp
+++ b/src/osd/windows/winmain.cpp
@@ -273,11 +273,13 @@ const options_entry windows_options::s_option_entries[] =
 #if WINAPI_FAMILY_PARTITION(WINAPI_PARTITION_DESKTOP)
 
 //============================================================
-//  utf8_main
+//  main
 //============================================================
 
-int main(std::vector<std::string> &args)
+int main(int argc, char *argv[])
 {
+	std::vector<std::string> args = osd_get_command_line(argc, argv);
+
 	// use small output buffers on non-TTYs (i.e. pipes)
 	if (!isatty(fileno(stdout)))
 		setvbuf(stdout, (char *) nullptr, _IOFBF, 64);

--- a/src/tools/imgtool/main.cpp
+++ b/src/tools/imgtool/main.cpp
@@ -864,6 +864,12 @@ int main(int argc, char *argv[])
 		return -1;
 #endif // MAME_DEBUG
 
+	// convert arguments to UTF-8
+	std::vector<std::string> args = osd_get_command_line(argc, argv);
+	argv = (char **)alloca(sizeof(char *) * args.size());
+	for (i = 0; i < args.size(); i++)
+		argv[i] = (char *)args[i].c_str();
+
 	util::stream_format(std::wcout, L"\n");
 
 	if (argc > 1)


### PR DESCRIPTION
Specifically, this creates a call osd_get_command_line() that returns UTF-8 command line arguments as std::vector<std::string>.  On non-Windows platforms, this does nothing more than build the vector.  On Windows, this invokes GetCommandLineW() and CommandLineToArgvW().  This also attempts to unwind usage of wmain()/_tmain() on Windows, which is not standard.

Related to this, this fixes a bug in Imgtool; specifically, non-7 bit ASCII was not being handled correctly in Windows.

This is really an admission that the way that Windows handles Unicode and command line arguments sucks, and it is my belief that having a wmain() or _tmain() declaration specific for Windows is a worse solution.  C'est la vie.

I'm very open to the idea that src/osd/osdcore.[cpp|h] is not the best place to do this.  Let me know if I should move it.