### PR TITLE
Added NES carts information

### DIFF
--- a/hash/nes.xml
+++ b/hash/nes.xml
@@ -35978,6 +35978,10 @@
 			<feature name="slot" value="nrom" />
 			<feature name="pcb" value="NES-NROM-256" />
 			<feature name="mirroring" value="vertical" />
+			<feature name="pcb_model" value="NES-NROM-256-06" />
+			<feature name="u1" value="U1 PRG" />
+			<feature name="u2" value="U2 CHR" />
+			<feature name="u3" value="U3 CIC" />
 			<dataarea name="prg" size="32768">
 				<rom name="pal-sm-0 prg" size="32768" crc="967a605f" sha1="31b332f6bc338e058a7b958dca285066c405b697" offset="00000" />
 			</dataarea>

--- a/hash/nes.xml
+++ b/hash/nes.xml
@@ -36170,11 +36170,17 @@
 		<description>Super Mario Bros. 2 (Euro)</description>
 		<year>1989</year>
 		<publisher>Nintendo</publisher>
-		<info name="serial" value="NES-MW (EEC/NOE/SCN)"/>
+		<info name="serial" value="NES-MW-(EEC/NOE/SCN/ESP)"/>
 		<info name="release" value="19890428"/>
 		<part name="cart" interface="nes_cart">
 			<feature name="slot" value="txrom" />
 			<feature name="pcb" value="NES-TSROM" />
+			<feature name="pcb_model" value="NES-TSROM-08" />
+			<feature name="u1" value="U1 PRG" />
+			<feature name="u2" value="U2 CHR" />
+			<feature name="u3" value="U3 CIC" />
+			<feature name="u4" value="U4" /> <!-- Not printed: MMC3B -->
+			<feature name="u5" value="U5 W-RAM" />
 			<feature name="mmc3_type" value="MMC3B" />
 			<dataarea name="prg" size="131072">
 				<rom name="pal-mw-0 prg" size="131072" crc="08af16a0" sha1="f38f8823112e1a33794fe638cdded7efbb98c67a" offset="00000" />

--- a/hash/nes.xml
+++ b/hash/nes.xml
@@ -39879,11 +39879,17 @@
 		<description>Trog! (Euro)</description>
 		<year>1991</year>
 		<publisher>Acclaim Entertainment</publisher>
-		<info name="serial" value="NES-4A (NOE/ESP)"/>
+		<info name="serial" value="NES-4A-(NOE/ESP)"/>
 		<part name="cart" interface="nes_cart">
 			<feature name="slot" value="uxrom" />
 			<feature name="pcb" value="NES-UNROM" />
 			<feature name="mirroring" value="vertical" />
+			<feature name="pcb_model" value="NES-UNROM-09" />
+			<feature name="u1" value="U1 PRG" />
+			<feature name="u2" value="U2 CHR RAM" />
+			<feature name="u3" value="U3 CIC" />
+			<feature name="u4" value="U4 HC161" />
+			<feature name="u5" value="U5 HC32" />
 			<dataarea name="prg" size="131072">
 				<rom name="pal-4a-0 prg" size="131072" crc="b6b5c372" sha1="60065354f49a9880407e871ad8d9eb6784004cfe" offset="00000" />
 			</dataarea>

--- a/hash/nes.xml
+++ b/hash/nes.xml
@@ -28297,12 +28297,16 @@
 		<description>Pinball (Euro, Rev. A)</description>
 		<year>1986</year>
 		<publisher>Nintendo</publisher>
-		<info name="serial" value="NES-PN (EEC/NOE/ESP)"/>
+		<info name="serial" value="NES-PN-(EEC/NOE/ESP)"/>
 		<info name="release" value="19860109"/>
 		<part name="cart" interface="nes_cart">
 			<feature name="slot" value="nrom" />
 			<feature name="pcb" value="NES-NROM-128" />
 			<feature name="mirroring" value="horizontal" />
+			<feature name="pcb_model" value="NES-NROM-128-06" />
+			<feature name="u1" value="U1 PRG" />
+			<feature name="u2" value="U2 CHR" />
+			<feature name="u3" value="U3 CIC" />
 			<dataarea name="prg" size="32768">
 				<rom name="pal-pn-0 prg" size="16384" crc="b8571339" sha1="9fb84f4b9e3eaa1df88be37c679ce20204acef77" offset="00000" />
 				<rom size="16384" offset="0x4000" loadflag="reload" />


### PR DESCRIPTION
I've been extended the information in the NES game list with some games I own. Although I have kept the dates in the game list, they vary in my games, so they may need to be changed:

- [Super Mario Bros.](http://imgur.com/a/5enCg): The date in [my cart's PCB](http://imgur.com/zKCDZNc) is 1986 instead of 1987.
- [Super Mario Bros. 2](http://imgur.com/a/S919p): The date in [my cart's PCB](http://imgur.com/7la09k2) is 1988 instead of 1989.
- [Trog!](http://imgur.com/a/NFI53): The date in [my cart's PCB](http://imgur.com/6AHcdIj) is 1986 instead of 1991.

I have also uploaded [some images of Pinball](http://imgur.com/a/mmGmg) that verify the information that has been added.

Finally I followed the current rom naming from the game list, as I did in #2537 with SNES, and again, strictly speaking and looking at the labels on the carts, shouldn't the names be in uppercase?