### PR TITLE
Adding #include <cctype>

### DIFF
--- a/src/lib/util/server_http.hpp
+++ b/src/lib/util/server_http.hpp
@@ -12,6 +12,7 @@
 #include <iostream>
 #include <sstream>
 #include <regex>
+#include <cctype>
 
 #ifndef CASE_INSENSITIVE_EQUALS_AND_HASH
 #define CASE_INSENSITIVE_EQUALS_AND_HASH


### PR DESCRIPTION
This seems to be necessary for MSVC to get std::tolower()