### PR TITLE
Removed unused MSVC incompatibility defines

### DIFF
--- a/src/devices/machine/68561mpcc.cpp
+++ b/src/devices/machine/68561mpcc.cpp
@@ -76,10 +76,8 @@ FEATURES
 
 #ifdef _MSC_VER
 #define FUNCNAME __func__
-#define LLFORMAT "%I64d"
 #else
 #define FUNCNAME __PRETTY_FUNCTION__
-#define LLFORMAT "%lld"
 #endif
 
 //**************************************************************************

--- a/src/devices/machine/mc14411.cpp
+++ b/src/devices/machine/mc14411.cpp
@@ -46,10 +46,8 @@
 
 #ifdef _MSC_VER
 #define FUNCNAME __func__
-#define LLFORMAT "%I64d"
 #else
 #define FUNCNAME __PRETTY_FUNCTION__
-#define LLFORMAT "%lld"
 #endif
 
 

--- a/src/devices/machine/z80sio.cpp
+++ b/src/devices/machine/z80sio.cpp
@@ -84,10 +84,8 @@
 
 #ifdef _MSC_VER
 #define FUNCNAME __func__
-#define LLFORMAT "%I64d"
 #else
 #define FUNCNAME __PRETTY_FUNCTION__
-#define LLFORMAT "%lld"
 #endif
 
 #define CHANA_TAG   "cha"

--- a/src/devices/video/sda5708.cpp
+++ b/src/devices/video/sda5708.cpp
@@ -36,10 +36,8 @@
 
 #ifdef _MSC_VER
 #define FUNCNAME __func__
-#define LLFORMAT "%I64d"
 #else
 #define FUNCNAME __PRETTY_FUNCTION__
-#define LLFORMAT "%lld"
 #endif
 
 

--- a/src/mame/drivers/didact.cpp
+++ b/src/mame/drivers/didact.cpp
@@ -93,10 +93,8 @@
 
 #ifdef _MSC_VER
 #define FUNCNAME __func__
-#define LLFORMAT "%I64d"
 #else
 #define FUNCNAME __PRETTY_FUNCTION__
-#define LLFORMAT "%lld"
 #endif
 
 #define PIA1_TAG "pia1"


### PR DESCRIPTION
As per Vas comment I remove these defines when not used as they do not cover all corner cases when printing formatted 64 bit values to the terminal. 