### PR TITLE
Fix to MameTesters bug #6657

### DIFF
--- a/src/emu/dislot.h
+++ b/src/emu/dislot.h
@@ -124,8 +124,6 @@ private:
 class device_slot_interface : public device_interface
 {
 public:
-	typedef std::map<std::string, std::unique_ptr<device_slot_option>> option_list_type;
-
 	// construction/destruction
 	device_slot_interface(const machine_config &mconfig, device_t &device);
 	virtual ~device_slot_interface();
@@ -142,7 +140,7 @@ public:
 	bool fixed() const { return m_fixed; }
 	bool has_selectable_options() const;
 	const char *default_option() const { return m_default_option; }
-	const option_list_type &option_list() const { return m_options; }
+	const std::unordered_map<std::string, std::unique_ptr<device_slot_option>> &option_list() const { return m_options; }
 	device_slot_option *option(const char *name) const;
 	virtual std::string get_default_card_software(get_default_card_software_hook &hook) const { return std::string(); }
 	device_t *get_card_device() const { return m_card_device; }
@@ -151,7 +149,7 @@ public:
 
 private:
 	// internal state
-	option_list_type m_options;
+	std::unordered_map<std::string,std::unique_ptr<device_slot_option>> m_options;
 	const char *m_default_option;
 	bool m_fixed;
 	device_t *m_card_device;

--- a/src/emu/dislot.h
+++ b/src/emu/dislot.h
@@ -124,6 +124,8 @@ private:
 class device_slot_interface : public device_interface
 {
 public:
+	typedef std::map<std::string, std::unique_ptr<device_slot_option>> option_list_type;
+
 	// construction/destruction
 	device_slot_interface(const machine_config &mconfig, device_t &device);
 	virtual ~device_slot_interface();
@@ -140,7 +142,7 @@ public:
 	bool fixed() const { return m_fixed; }
 	bool has_selectable_options() const;
 	const char *default_option() const { return m_default_option; }
-	const std::unordered_map<std::string, std::unique_ptr<device_slot_option>> &option_list() const { return m_options; }
+	const option_list_type &option_list() const { return m_options; }
 	device_slot_option *option(const char *name) const;
 	virtual std::string get_default_card_software(get_default_card_software_hook &hook) const { return std::string(); }
 	device_t *get_card_device() const { return m_card_device; }
@@ -149,7 +151,7 @@ public:
 
 private:
 	// internal state
-	std::unordered_map<std::string,std::unique_ptr<device_slot_option>> m_options;
+	option_list_type m_options;
 	const char *m_default_option;
 	bool m_fixed;
 	device_t *m_card_device;

--- a/src/frontend/mame/ui/slotopt.h
+++ b/src/frontend/mame/ui/slotopt.h
@@ -29,9 +29,6 @@ private:
 	virtual void handle() override;
 
 	device_slot_option *get_current_option(device_slot_interface &slot) const;
-	int get_current_index(device_slot_interface &slot) const;
-	const char *get_next_slot(device_slot_interface &slot) const;
-	const char *get_previous_slot(device_slot_interface &slot) const;
 	void set_slot_device(device_slot_interface &slot, const char *val);
 	void record_current_options();
 	bool try_refresh_current_options();

--- a/src/frontend/mame/ui/slotopt.h
+++ b/src/frontend/mame/ui/slotopt.h
@@ -24,6 +24,12 @@ public:
 	virtual ~menu_slot_devices() override;
 
 private:
+	enum class step_t
+	{
+		NEXT,
+		PREVIOUS
+	};
+
 	virtual void populate(float &customtop, float &custombottom) override;
 	virtual void custom_render(void *selectedref, float top, float bottom, float origx1, float origy1, float origx2, float origy2) override;
 	virtual void handle() override;
@@ -32,10 +38,14 @@ private:
 	void set_slot_device(device_slot_interface &slot, const char *val);
 	void record_current_options();
 	bool try_refresh_current_options();
+	void rotate_slot_device(device_slot_interface &slot, step_t step);
 
 	// variables
 	std::unique_ptr<machine_config>                 m_config;
 	std::unordered_map<std::string, std::string>    m_slot_options;
+	std::string										m_current_option_list_slot_tag;
+	std::vector<std::string>						m_current_option_list;
+	std::vector<std::string>::const_iterator		m_current_option_list_iter;
 };
 
 } // namespace ui


### PR DESCRIPTION
The source of the issue is that the logic for rotating slot options was broken.  It would count selectable options and skip over options that were not selectable, except for the specific scenario where the index was zero.  I ended up largely replacing the logic to be more C++-ish.

I also changed the options list to be std::map instead of std::unordered_map.  Rotating the latter is indeterminent.