### PR TITLE
add basic device for saturn_cdb to load the roms

### DIFF
--- a/scripts/target/mame/arcade.lua
+++ b/scripts/target/mame/arcade.lua
@@ -3284,6 +3284,8 @@ files {
 	MAME_DIR .. "src/mame/includes/saturn.h",
 	MAME_DIR .. "src/mame/drivers/saturn.cpp",
 	MAME_DIR .. "src/mame/machine/saturn.cpp",
+	MAME_DIR .. "src/mame/machine/saturn_cdb.cpp",
+	MAME_DIR .. "src/mame/machine/saturn_cdb.h",
 	MAME_DIR .. "src/mame/includes/stv.h",
 	MAME_DIR .. "src/mame/machine/stvprot.cpp",
 	MAME_DIR .. "src/mame/machine/stvprot.h",

--- a/scripts/target/mame/mess.lua
+++ b/scripts/target/mame/mess.lua
@@ -1286,6 +1286,8 @@ files {
 	MAME_DIR .. "src/mame/includes/saturn.h",
 	MAME_DIR .. "src/mame/drivers/saturn.cpp",
 	MAME_DIR .. "src/mame/machine/saturn.cpp",
+	MAME_DIR .. "src/mame/machine/saturn_cdb.cpp",
+	MAME_DIR .. "src/mame/machine/saturn_cdb.h",
 }
 end
 --------------------------------------------------

--- a/src/mame/drivers/saturn.cpp
+++ b/src/mame/drivers/saturn.cpp
@@ -433,6 +433,7 @@ test1f diagnostic hacks:
 #include "machine/nvram.h"
 #include "machine/smpc.h"
 #include "machine/stvcd.h"
+#include "machine/saturn_cdb.h"
 #include "sound/cdda.h"
 #include "sound/scsp.h"
 #include "video/stvvdp1.h"
@@ -865,6 +866,8 @@ SLOT_INTERFACE_END
 MACHINE_CONFIG_DERIVED( saturnus, saturn )
 	MCFG_CDROM_ADD( "cdrom" )
 	MCFG_CDROM_INTERFACE("sat_cdrom")
+	MCFG_DEVICE_ADD("saturn_cdb", SATURN_CDB, 16000000)
+
 	MCFG_SOFTWARE_LIST_ADD("cd_list","saturn")
 	MCFG_SOFTWARE_LIST_FILTER("cd_list","NTSC-U")
 
@@ -876,6 +879,8 @@ MACHINE_CONFIG_END
 MACHINE_CONFIG_DERIVED( saturneu, saturn )
 	MCFG_CDROM_ADD( "cdrom" )
 	MCFG_CDROM_INTERFACE("sat_cdrom")
+	MCFG_DEVICE_ADD("saturn_cdb", SATURN_CDB, 16000000)
+
 	MCFG_SOFTWARE_LIST_ADD("cd_list","saturn")
 	MCFG_SOFTWARE_LIST_FILTER("cd_list","PAL")
 
@@ -887,6 +892,8 @@ MACHINE_CONFIG_END
 MACHINE_CONFIG_DERIVED( saturnjp, saturn )
 	MCFG_CDROM_ADD( "cdrom" )
 	MCFG_CDROM_INTERFACE("sat_cdrom")
+	MCFG_DEVICE_ADD("saturn_cdb", SATURN_CDB, 16000000)
+
 	MCFG_SOFTWARE_LIST_ADD("cd_list","saturn")
 	MCFG_SOFTWARE_LIST_FILTER("cd_list","NTSC-J")
 

--- a/src/mame/machine/saturn_cdb.cpp
+++ b/src/mame/machine/saturn_cdb.cpp
@@ -1,0 +1,49 @@
+// license:BSD-3-Clause
+// copyright-holders:David Haywood
+
+/* Notes
+
+YGR019B - Hitachi YGR019B CD-Subsystem LSI. Earlier revision is YGR019A. Later revision combines this IC and the SH1 together
+        into one IC (YGR022 315-5962). The SH1 and the YGR019B make up the 'CD Block' CD Authentication and CD I/O data controller.
+        Another of it's functions is to prevent copied CDs from being played
+
+*/
+
+#include "emu.h"
+#include "machine/saturn_cdb.h"
+
+DEFINE_DEVICE_TYPE(SATURN_CDB, saturn_cdb_device, "satcdb", "Saturn CDB (CD Block)")
+
+saturn_cdb_device::saturn_cdb_device(const machine_config &mconfig, const char *tag, device_t *owner, uint32_t clock)
+	: device_t(mconfig, SATURN_CDB, tag, owner, clock)
+{
+}
+
+void saturn_cdb_device::device_start()
+{
+}
+
+static ADDRESS_MAP_START( saturn_cdb_map, AS_PROGRAM, 32, saturn_cdb_device )
+	AM_RANGE(0x00000000, 0x0000ffff) AM_ROM
+ADDRESS_MAP_END
+
+MACHINE_CONFIG_MEMBER( saturn_cdb_device::device_add_mconfig )
+	MCFG_CPU_ADD("cdbcpu", SH1, DERIVED_CLOCK(1, 1))
+	MCFG_CPU_PROGRAM_MAP(saturn_cdb_map)
+	MCFG_DEVICE_DISABLE() // we're not actually using the CD Block ROM for now
+MACHINE_CONFIG_END
+
+ROM_START( satcdb )
+	ROM_REGION( 0x10000, "cdbcpu", 0 )
+	ROM_SYSTEM_BIOS( 0, "cdb106", "Saturn CD Block 1.06" )
+	ROMX_LOAD( "cdb106.bin", 0x00000, 0x10000, CRC(3681d3b0) SHA1(b3c20fbe57cd2eb595e9edac86817e5948dccae4), ROM_BIOS(1) ) // for YGR019B?
+	ROM_SYSTEM_BIOS( 1, "cdb105", "Saturn CD Block 1.05" )
+	ROMX_LOAD( "cdb105.bin", 0x00000, 0x10000, CRC(2a2ced5c) SHA1(eb8393058f324e922c11b43709b64fc6ca94ab86), ROM_BIOS(2) ) // for YGR019A?
+	ROM_SYSTEM_BIOS( 2, "cdb105", "Saturn CD Block (YGR022 315-5962)" )
+	ROMX_LOAD( "ygr022.bin", 0x00000, 0x10000, CRC(1c8b9f38) SHA1(f4f6c2aac68c352814d396ae41f81f54ad228e68), ROM_BIOS(3) ) // combined package?
+ROM_END
+
+const tiny_rom_entry *saturn_cdb_device::device_rom_region() const
+{
+	return ROM_NAME(satcdb);
+}

--- a/src/mame/machine/saturn_cdb.h
+++ b/src/mame/machine/saturn_cdb.h
@@ -1,0 +1,28 @@
+// license:BSD-3-Clause
+// copyright-holders:David Haywood
+
+#ifndef MAME_MACHINE_SATURN_CDB_H
+#define MAME_MACHINE_SATURN_CDB_H
+
+#pragma once
+
+#include "cpu/sh2/sh2.h"
+
+DECLARE_DEVICE_TYPE(SATURN_CDB, saturn_cdb_device)
+
+class saturn_cdb_device : public device_t
+{
+public:
+	// construction/destruction
+	saturn_cdb_device(const machine_config &mconfig, const char *tag, device_t *owner, uint32_t clock);
+
+protected:
+	virtual void device_start() override;
+	virtual const tiny_rom_entry *device_rom_region() const override;
+	virtual void device_add_mconfig(machine_config &config) override;
+
+private:
+
+};
+
+#endif // MAME_MACHINE_SATURN_CDB_H


### PR DESCRIPTION
seems to make more sense than just sitting on the ROMs, which as far as I can tell benefits absolutely nobody...