### PR TITLE
Update om6502.lst

### DIFF
--- a/src/devices/cpu/m6502/om6502.lst
+++ b/src/devices/cpu/m6502/om6502.lst
@@ -1395,9 +1395,10 @@ lax_aba
 lax_aby
 	TMP = read_pc();
 	TMP = set_h(TMP, read_pc());
-	read(set_l(TMP, TMP+Y));
-	TMP += Y;
-	A = X = read(TMP);
+	if(page_changing(TMP, Y)) {
+		read(set_l(TMP, TMP+Y));
+	}
+	A = X = read(TMP+Y);
 	set_nz(A);
 	prefetch();
 


### PR DESCRIPTION
Now passes Lorenz testsuite-2.15's cputiming.prg (and does not break laxay.prg)
Ref: NMOS 6510 Unintended Opcodes no more secrets (v0.91 - 24/12/16) http://csdb.dk/release/?id=152327 page 14 ($BF) cycles = 3 to read, and 4+1 if page boundary.