### PR TITLE
Add address-shifted versions of AM_DEVREAD/_DEVWRITE/_DEVREADWRITE (nw)

### DIFF
--- a/src/emu/addrmap.h
+++ b/src/emu/addrmap.h
@@ -236,6 +236,7 @@ void ADDRESS_MAP_NAME(_name)(address_map &map) \
 { \
 	typedef read##_bits##_delegate read_delegate ATTR_UNUSED; \
 	typedef write##_bits##_delegate write_delegate ATTR_UNUSED; \
+	typedef u##_bits native_type ATTR_UNUSED; \
 	map.configure(_space, _bits); \
 	typedef _class drivdata_class ATTR_UNUSED
 #define DEVICE_ADDRESS_MAP_START(_name, _bits, _class) \
@@ -243,6 +244,7 @@ void _class :: _name(::address_map &map) \
 { \
 	typedef read##_bits##_delegate read_delegate ATTR_UNUSED; \
 	typedef write##_bits##_delegate write_delegate ATTR_UNUSED; \
+	typedef u##_bits native_type ATTR_UNUSED; \
 	map.configure(AS_PROGRAM, _bits);  \
 	typedef _class drivdata_class ATTR_UNUSED
 #define ADDRESS_MAP_END \
@@ -347,6 +349,36 @@ void _class :: _name(::address_map &map) \
 	.set_handler(read16_delegate(&_class::_rhandler, #_class "::" #_rhandler, _tag, (_class *)nullptr), write16_delegate(&_class::_whandler, #_class "::" #_whandler, _tag, (_class *)nullptr), _unitmask)
 #define AM_DEVREADWRITE32(_tag, _class, _rhandler, _whandler, _unitmask) \
 	.set_handler(read32_delegate(&_class::_rhandler, #_class "::" #_rhandler, _tag, (_class *)nullptr), write32_delegate(&_class::_whandler, #_class "::" #_whandler, _tag, (_class *)nullptr), _unitmask)
+
+// device reads with address shift
+#define AM_DEVREAD_RSHIFT(_tag, _class, _handler, _rshift) \
+	.set_handler(read_delegate([](_class &device, address_space &space, offs_t offset, native_type mem_mask)->native_type { return device._handler(space, offset >> _rshift, mem_mask); }, #_class "::" #_handler, _tag, (_class *)nullptr))
+#define AM_DEVREAD8_RSHIFT(_tag, _class, _handler, _unitmask, _rshift) \
+	.set_handler(read8_delegate([](_class &device, address_space &space, offs_t offset, u8 mem_mask)->u8 { return device._handler(space, offset >> _rshift, mem_mask); }, #_class "::" #_handler, _tag, (_class *)nullptr), _unitmask)
+#define AM_DEVREAD16_RSHIFT(_tag, _class, _handler, _unitmask, _rshift) \
+	.set_handler(read16_delegate([](_class &device, address_space &space, offs_t offset, u16 mem_mask)->u16 { return device._handler(space, offset >> _rshift, mem_mask); }, #_class "::" #_handler, _tag, (_class *)nullptr), _unitmask)
+#define AM_DEVREAD32_RSHIFT(_tag, _class, _handler, _unitmask, _rshift) \
+	.set_handler(read32_delegate([](_class &device, address_space &space, offs_t offset, u32 mem_mask)->u32 { return device._handler(space, offset >> _rshift, mem_mask); }, #_class "::" #_handler, _tag, (_class *)nullptr), _unitmask)
+
+// device writes with address shift
+#define AM_DEVWRITE_RSHIFT(_tag, _class, _handler, _rshift) \
+	.set_handler(write_delegate([](_class &device, address_space &space, offs_t offset, native_type data, native_type mem_mask) { device._handler(space, offset >> _rshift, data, mem_mask); }, #_class "::" #_handler, _tag, (_class *)nullptr))
+#define AM_DEVWRITE8_RSHIFT(_tag, _class, _handler, _unitmask, _rshift) \
+	.set_handler(write8_delegate([](_class &device, address_space &space, offs_t offset, u8 data, u8 mem_mask) { device._handler(space, offset >> _rshift, data, mem_mask); }, #_class "::" #_handler, _tag, (_class *)nullptr), _unitmask)
+#define AM_DEVWRITE16_RSHIFT(_tag, _class, _handler, _unitmask, _rshift) \
+	.set_handler(write16_delegate([](_class &device, address_space &space, offs_t offset, u16 data, u16 mem_mask) { device._handler(space, offset >> _rshift, data, mem_mask); }, #_class "::" #_handler, _tag, (_class *)nullptr), _unitmask)
+#define AM_DEVWRITE32_RSHIFT(_tag, _class, _handler, _unitmask, _rshift) \
+	.set_handler(write32_delegate([](_class &device, address_space &space, offs_t offset, u32 data, u32 mem_mask) { device._handler(space, offset >> _rshift, data, mem_mask); }, #_class "::" #_handler, _tag, (_class *)nullptr), _unitmask)
+
+// device reads/writes with address shift
+#define AM_DEVREADWRITE_RSHIFT(_tag, _class, _rhandler, _whandler, _rshift) \
+	.set_handler(read_delegate([](_class &device, address_space &space, offs_t offset, native_type mem_mask)->native_type { return device._rhandler(space, offset >> _rshift, mem_mask); }, #_class "::" #_rhandler, _tag, (_class *)nullptr), write_delegate([](_class &device, address_space &space, offs_t offset, native_type data, native_type mem_mask) { device._whandler(space, offset >> _rshift, data, mem_mask); }, #_class "::" #_whandler, _tag, (_class *)nullptr))
+#define AM_DEVREADWRITE8_RSHIFT(_tag, _class, _rhandler, _whandler, _unitmask, _rshift) \
+	.set_handler(read8_delegate([](_class &device, address_space &space, offs_t offset, u8 mem_mask)->u8 { return device._rhandler(space, offset >> _rshift, mem_mask); }, #_class "::" #_rhandler, _tag, (_class *)nullptr), write8_delegate([](_class &device, address_space &space, offs_t offset, u8 data, u8 mem_mask) { device._whandler(space, offset >> _rshift, data, mem_mask); }, #_class "::" #_whandler, _tag, (_class *)nullptr), _unitmask)
+#define AM_DEVREADWRITE16_RSHIFT(_tag, _class, _rhandler, _whandler, _unitmask, _rshift) \
+	.set_handler(read16_delegate([](_class &device, address_space &space, offs_t offset, u16 mem_mask)->u16 { return device._rhandler(space, offset >> _rshift, mem_mask); }, #_class "::" #_rhandler, _tag, (_class *)nullptr), write16_delegate([](_class &device, address_space &space, offs_t offset, u16 data, u16 mem_mask) { device._whandler(space, offset >> _rshift, data, mem_mask); }, #_class "::" #_whandler, _tag, (_class *)nullptr), _unitmask)
+#define AM_DEVREADWRITE32_RSHIFT(_tag, _class, _rhandler, _whandler, _unitmask, _rshift) \
+	.set_handler(read32_delegate([](_class &device, address_space &space, offs_t offset, u32 mem_mask)->u32 { return device._rhandler(space, offset >> _rshift, mem_mask); }, #_class "::" #_rhandler, _tag, (_class *)nullptr), write32_delegate([](_class &device, address_space &space, offs_t offset, u32 data, u32 mem_mask) { device._whandler(space, offset >> _rshift, data, mem_mask); }, #_class "::" #_whandler, _tag, (_class *)nullptr), _unitmask)
 
 // device set offset
 #define AM_DEVSETOFFSET(_tag, _class, _handler) \

--- a/src/mame/drivers/bbcbc.cpp
+++ b/src/mame/drivers/bbcbc.cpp
@@ -42,14 +42,10 @@ public:
 	bbcbc_state(const machine_config &mconfig, device_type type, const char *tag)
 		: driver_device(mconfig, type, tag),
 		m_maincpu(*this, "maincpu"),
-		m_pio(*this, "z80pio"),
-		m_cart(*this, "cartslot"),
 		m_buttons(*this, "BUTTONS.%u", 0)
 	{ }
 
 	required_device<cpu_device> m_maincpu;
-	required_device<z80pio_device> m_pio;
-	required_device<generic_slot_device> m_cart;
 	required_ioport_array<3> m_buttons;
 
 	uint8_t m_input_select;
@@ -57,8 +53,6 @@ public:
 	virtual void machine_start() override;
 	virtual void machine_reset() override;
 
-	DECLARE_READ8_MEMBER(pio_r);
-	DECLARE_WRITE8_MEMBER(pio_w);
 	DECLARE_READ8_MEMBER(input_r);
 	DECLARE_WRITE8_MEMBER(input_select_w);
 };
@@ -66,16 +60,6 @@ public:
 
 #define MAIN_CLOCK XTAL_4_433619MHz
 
-
-READ8_MEMBER(bbcbc_state::pio_r)
-{
-	return m_pio->read(space, offset >> 5, mem_mask);
-}
-
-WRITE8_MEMBER(bbcbc_state::pio_w)
-{
-	m_pio->write(space, offset >> 5, data, mem_mask);
-}
 
 static ADDRESS_MAP_START( bbcbc_prg, AS_PROGRAM, 8, bbcbc_state )
 	AM_RANGE(0x0000, 0x3fff) AM_ROM
@@ -85,7 +69,7 @@ ADDRESS_MAP_END
 
 static ADDRESS_MAP_START( bbcbc_io, AS_IO, 8, bbcbc_state )
 	ADDRESS_MAP_GLOBAL_MASK(0xff)
-	AM_RANGE(0x00, 0x7f) AM_READWRITE(pio_r, pio_w) // actually only $00, $20, $40, $60
+	AM_RANGE(0x00, 0x7f) AM_DEVREADWRITE_RSHIFT("z80pio", z80pio_device, read, write, 5)
 	AM_RANGE(0x80, 0x80) AM_DEVREADWRITE("tms9129", tms9129_device, vram_read, vram_write)
 	AM_RANGE(0x81, 0x81) AM_DEVREADWRITE("tms9129", tms9129_device, register_read, register_write)
 ADDRESS_MAP_END

--- a/src/mame/drivers/equites.cpp
+++ b/src/mame/drivers/equites.cpp
@@ -364,6 +364,7 @@ D                                                                               
 #include "cpu/alph8201/alph8201.h"
 #include "cpu/i8085/i8085.h"
 #include "cpu/m68000/m68000.h"
+#include "machine/74259.h"
 #include "machine/i8155.h"
 #include "machine/nvram.h"
 #include "machine/watchdog.h"
@@ -605,12 +606,6 @@ READ16_MEMBER(equites_state::equites_spriteram_kludge_r)
 		return m_spriteram[0];
 }
 
-WRITE8_MEMBER(equites_state::mainlatch_w)
-{
-	// data bit is A17; address bits are A16(?)-A14 (offset is shifted by 1 here)
-	m_mainlatch->write_bit((offset & 0xe000) >> 13, BIT(offset, 16));
-}
-
 READ8_MEMBER(equites_state::mcu_ram_r)
 {
 	if (m_fakemcu == nullptr)
@@ -657,7 +652,7 @@ static ADDRESS_MAP_START( equites_map, AS_PROGRAM, 16, equites_state )
 	AM_RANGE(0x100000, 0x1001ff) AM_RAM AM_SHARE("spriteram")
 	AM_RANGE(0x140000, 0x1407ff) AM_READWRITE8(mcu_ram_r, mcu_ram_w, 0x00ff)
 	AM_RANGE(0x180000, 0x180001) AM_READ_PORT("IN1") AM_DEVWRITE8("soundlatch", generic_latch_8_device, write, 0x00ff)
-	AM_RANGE(0x180000, 0x180001) AM_SELECT(0x03c000) AM_WRITE8(mainlatch_w, 0xff00)
+	AM_RANGE(0x180000, 0x180001) AM_SELECT(0x03c000) AM_DEVWRITE8_RSHIFT("mainlatch", ls259_device, write_a3, 0xff00, 13)
 	AM_RANGE(0x1c0000, 0x1c0001) AM_READ_PORT("IN0") AM_WRITE(equites_scrollreg_w)
 	AM_RANGE(0x380000, 0x380001) AM_WRITE8(equites_bgcolor_w, 0xff00)
 	AM_RANGE(0x780000, 0x780001) AM_DEVWRITE("watchdog", watchdog_timer_device, reset16_w)
@@ -676,8 +671,8 @@ static ADDRESS_MAP_START( splndrbt_map, AS_PROGRAM, 16, equites_state )
 	AM_RANGE(0x040000, 0x040fff) AM_RAM
 	AM_RANGE(0x080000, 0x080001) AM_READ_PORT("IN0")
 	AM_RANGE(0x0c0000, 0x0c0001) AM_READ_PORT("IN1")
-	AM_RANGE(0x0c0000, 0x0c0001) AM_SELECT(0x020000) AM_WRITE8(equites_bgcolor_w, 0xff00) // note: addressmask does not apply here
-	AM_RANGE(0x0c0000, 0x0c0001) AM_SELECT(0x03c000) AM_WRITE8(mainlatch_w, 0x00ff)
+	AM_RANGE(0x0c0000, 0x0c0001) AM_SELECT(0x020000) AM_WRITE8(equites_bgcolor_w, 0xff00)
+	AM_RANGE(0x0c0000, 0x0c0001) AM_SELECT(0x03c000) AM_DEVWRITE8_RSHIFT("mainlatch", ls259_device, write_a3, 0x00ff, 13)
 	AM_RANGE(0x100000, 0x100001) AM_WRITE(splndrbt_bg_scrollx_w)
 	AM_RANGE(0x140000, 0x140001) AM_DEVWRITE8("soundlatch", generic_latch_8_device, write, 0x00ff)
 	AM_RANGE(0x1c0000, 0x1c0001) AM_WRITE(splndrbt_bg_scrolly_w)

--- a/src/mame/drivers/gaelco.cpp
+++ b/src/mame/drivers/gaelco.cpp
@@ -25,6 +25,7 @@ Year   Game                PCB            NOTES
 
 #include "cpu/m6809/m6809.h"
 #include "cpu/m68000/m68000.h"
+#include "machine/74259.h"
 #include "sound/okim6295.h"
 #include "sound/3812intf.h"
 
@@ -42,11 +43,6 @@ WRITE8_MEMBER(gaelco_state::bigkarnk_sound_command_w)
 {
 	m_soundlatch->write(space, 0, data);
 	m_audiocpu->set_input_line(M6809_FIRQ_LINE, HOLD_LINE);
-}
-
-WRITE8_MEMBER(gaelco_state::output_latch_w)
-{
-	m_outlatch->write_bit(offset >> 3, BIT(data, 0));
 }
 
 WRITE_LINE_MEMBER(gaelco_state::coin1_lockout_w)
@@ -130,7 +126,7 @@ static ADDRESS_MAP_START( bigkarnk_map, AS_PROGRAM, 16, gaelco_state )
 	AM_RANGE(0x700004, 0x700005) AM_READ_PORT("P1")
 	AM_RANGE(0x700006, 0x700007) AM_READ_PORT("P2")
 	AM_RANGE(0x700008, 0x700009) AM_READ_PORT("SERVICE")
-	AM_RANGE(0x70000a, 0x70000b) AM_SELECT(0x000070) AM_WRITE8(output_latch_w, 0x00ff)                       /* Coin Counters + Coin Lockout */
+	AM_RANGE(0x70000a, 0x70000b) AM_SELECT(0x000070) AM_DEVWRITE8_RSHIFT("outlatch", ls259_device, write_d0, 0x00ff, 3)
 	AM_RANGE(0x70000e, 0x70000f) AM_WRITE8(bigkarnk_sound_command_w, 0x00ff)                                     /* Triggers a FIRQ on the sound CPU */
 	AM_RANGE(0xff8000, 0xffffff) AM_RAM                                                         /* Work RAM */
 ADDRESS_MAP_END
@@ -173,7 +169,7 @@ static ADDRESS_MAP_START( squash_map, AS_PROGRAM, 16, gaelco_state )
 	AM_RANGE(0x700002, 0x700003) AM_READ_PORT("DSW1")
 	AM_RANGE(0x700004, 0x700005) AM_READ_PORT("P1")
 	AM_RANGE(0x700006, 0x700007) AM_READ_PORT("P2")
-	AM_RANGE(0x70000a, 0x70000b) AM_SELECT(0x000070) AM_WRITE8(output_latch_w, 0x00ff)
+	AM_RANGE(0x70000a, 0x70000b) AM_SELECT(0x000070) AM_DEVWRITE8_RSHIFT("outlatch", ls259_device, write_d0, 0x00ff, 3)
 	AM_RANGE(0x70000c, 0x70000d) AM_WRITE8(OKIM6295_bankswitch_w, 0x00ff)
 	AM_RANGE(0x70000e, 0x70000f) AM_DEVREADWRITE8("oki", okim6295_device, read, write, 0x00ff)                      /* OKI6295 status register */
 	AM_RANGE(0xff0000, 0xffffff) AM_RAM                                                         /* Work RAM */
@@ -191,7 +187,7 @@ static ADDRESS_MAP_START( thoop_map, AS_PROGRAM, 16, gaelco_state )
 	AM_RANGE(0x700002, 0x700003) AM_READ_PORT("DSW1")
 	AM_RANGE(0x700004, 0x700005) AM_READ_PORT("P1")
 	AM_RANGE(0x700006, 0x700007) AM_READ_PORT("P2")
-	AM_RANGE(0x70000a, 0x70000b) AM_SELECT(0x000070) AM_WRITE8(output_latch_w, 0x00ff)
+	AM_RANGE(0x70000a, 0x70000b) AM_SELECT(0x000070) AM_DEVWRITE8_RSHIFT("outlatch", ls259_device, write_d0, 0x00ff, 3)
 	AM_RANGE(0x70000c, 0x70000d) AM_WRITE8(OKIM6295_bankswitch_w, 0x00ff)
 	AM_RANGE(0x70000e, 0x70000f) AM_DEVREADWRITE8("oki", okim6295_device, read, write, 0x00ff)                      /* OKI6295 status register */
 	AM_RANGE(0xff0000, 0xffffff) AM_RAM                                                         /* Work RAM */

--- a/src/mame/drivers/gaelco3d.cpp
+++ b/src/mame/drivers/gaelco3d.cpp
@@ -150,7 +150,7 @@ REF. 970429
 #include "cpu/adsp2100/adsp2100.h"
 #include "cpu/m68000/m68000.h"
 #include "cpu/tms32031/tms32031.h"
-#include "machine/eepromser.h"
+#include "machine/74259.h"
 
 #include "speaker.h"
 
@@ -697,16 +697,6 @@ WRITE_LINE_MEMBER(gaelco3d_state::unknown_13a_w)
  *
  *************************************/
 
-WRITE8_MEMBER(gaelco3d_state::mainlatch_68000_w)
-{
-	m_mainlatch->write_bit(offset >> 2, BIT(data, 0));
-}
-
-WRITE8_MEMBER(gaelco3d_state::outlatch_68000_w)
-{
-	m_outlatch->write_bit(offset >> 3, BIT(data, 0));
-}
-
 static ADDRESS_MAP_START( main_map, AS_PROGRAM, 16, gaelco3d_state )
 	ADDRESS_MAP_UNMAP_HIGH
 	AM_RANGE(0x000000, 0x1fffff) AM_ROM
@@ -719,23 +709,13 @@ static ADDRESS_MAP_START( main_map, AS_PROGRAM, 16, gaelco3d_state )
 	AM_RANGE(0x510042, 0x510043) AM_READ(sound_status_r)
 	AM_RANGE(0x510100, 0x510101) AM_READWRITE(eeprom_data_r, irq_ack_w)
 	AM_RANGE(0x510102, 0x510103) AM_DEVREAD8("serial", gaelco_serial_device, data_r, 0x00ff)
-	AM_RANGE(0x510102, 0x510103) AM_SELECT(0x000038) AM_WRITE8(mainlatch_68000_w, 0x00ff)
+	AM_RANGE(0x510102, 0x510103) AM_SELECT(0x000038) AM_DEVWRITE8_RSHIFT("mainlatch", ls259_device, write_d0, 0x00ff, 2)
 	AM_RANGE(0x510104, 0x510105) AM_DEVWRITE8("serial", gaelco_serial_device, data_w, 0x00ff)
-	AM_RANGE(0x510106, 0x510107) AM_SELECT(0x000070) AM_WRITE8(outlatch_68000_w, 0x00ff)
+	AM_RANGE(0x510106, 0x510107) AM_SELECT(0x000070) AM_DEVWRITE8_RSHIFT("outlatch", ls259_device, write_d0, 0x00ff, 3)
 	AM_RANGE(0xfe7f80, 0xfe7fff) AM_WRITE(tms_comm_w) AM_SHARE("tms_comm_base")
 	AM_RANGE(0xfe0000, 0xfeffff) AM_RAM AM_SHARE("m68k_ram_base")
 ADDRESS_MAP_END
 
-
-WRITE8_MEMBER(gaelco3d_state::mainlatch_68020_w)
-{
-	m_mainlatch->write_bit(offset >> 1, BIT(data, 0));
-}
-
-WRITE8_MEMBER(gaelco3d_state::outlatch_68020_w)
-{
-	m_outlatch->write_bit(offset >> 2, BIT(data, 0));
-}
 
 static ADDRESS_MAP_START( main020_map, AS_PROGRAM, 32, gaelco3d_state )
 	AM_RANGE(0x000000, 0x1fffff) AM_ROM
@@ -748,9 +728,9 @@ static ADDRESS_MAP_START( main020_map, AS_PROGRAM, 32, gaelco3d_state )
 	AM_RANGE(0x510040, 0x510043) AM_WRITE16(sound_data_w, 0xffff0000)
 	AM_RANGE(0x510100, 0x510103) AM_READWRITE16(eeprom_data_r, irq_ack_w, 0xffff0000)
 	AM_RANGE(0x510100, 0x510103) AM_DEVREAD8("serial", gaelco_serial_device, data_r, 0x000000ff)
-	AM_RANGE(0x510100, 0x510103) AM_SELECT(0x000038) AM_WRITE8(mainlatch_68020_w, 0x000000ff)
+	AM_RANGE(0x510100, 0x510103) AM_SELECT(0x000038) AM_DEVWRITE8_RSHIFT("mainlatch", ls259_device, write_d0, 0x000000ff, 1)
 	AM_RANGE(0x510104, 0x510107) AM_DEVWRITE8("serial", gaelco_serial_device, data_w, 0x00ff0000)
-	AM_RANGE(0x510104, 0x510107) AM_SELECT(0x000070) AM_WRITE8(outlatch_68020_w, 0x000000ff)
+	AM_RANGE(0x510104, 0x510107) AM_SELECT(0x000070) AM_DEVWRITE8_RSHIFT("outlatch", ls259_device, write_d0, 0x000000ff, 2)
 	AM_RANGE(0xfe7f80, 0xfe7fff) AM_WRITE16(tms_comm_w, 0xffffffff) AM_SHARE("tms_comm_base")
 	AM_RANGE(0xfe0000, 0xfeffff) AM_RAM AM_SHARE("m68k_ram_base")
 ADDRESS_MAP_END

--- a/src/mame/drivers/gridlee.cpp
+++ b/src/mame/drivers/gridlee.cpp
@@ -83,6 +83,7 @@
 #include "includes/gridlee.h"
 
 #include "cpu/m6809/m6809.h"
+#include "machine/74259.h"
 #include "sound/samples.h"
 #include "machine/nvram.h"
 #include "machine/watchdog.h"
@@ -270,12 +271,6 @@ READ8_MEMBER(gridlee_state::random_num_r)
  *
  *************************************/
 
-WRITE8_MEMBER(gridlee_state::latch_w)
-{
-	m_latch->write_bit(offset >> 4, data);
-}
-
-
 WRITE_LINE_MEMBER(gridlee_state::led_0_w)
 {
 	output().set_led_value(0, state);
@@ -308,7 +303,7 @@ WRITE_LINE_MEMBER(gridlee_state::coin_counter_w)
 static ADDRESS_MAP_START( cpu1_map, AS_PROGRAM, 8, gridlee_state )
 	AM_RANGE(0x0000, 0x07ff) AM_RAM AM_SHARE("spriteram")
 	AM_RANGE(0x0800, 0x7fff) AM_RAM_WRITE(gridlee_videoram_w) AM_SHARE("videoram")
-	AM_RANGE(0x9000, 0x9000) AM_SELECT(0x0070) AM_WRITE(latch_w)
+	AM_RANGE(0x9000, 0x9000) AM_SELECT(0x0070) AM_DEVWRITE_RSHIFT("latch", ls259_device, write_d0, 4)
 	AM_RANGE(0x9200, 0x9200) AM_WRITE(gridlee_palette_select_w)
 	AM_RANGE(0x9380, 0x9380) AM_DEVWRITE("watchdog", watchdog_timer_device, reset_w)
 	AM_RANGE(0x9500, 0x9501) AM_READ(analog_port_r)

--- a/src/mame/drivers/legionna.cpp
+++ b/src/mame/drivers/legionna.cpp
@@ -95,11 +95,6 @@ Preliminary COP MCU memory map
 
 /*****************************************************************************/
 
-READ8_MEMBER(legionna_state::sound_comms_r)
-{
-	return m_seibu_sound->main_r(space, (offset >> 1) & 7);
-}
-
 READ8_MEMBER(legionna_state::denjinmk_sound_comms_r)
 {
 	// Routine at 5FDC spins indefinitely until the lowest bit becomes 1
@@ -107,11 +102,6 @@ READ8_MEMBER(legionna_state::denjinmk_sound_comms_r)
 		return 1;
 
 	return m_seibu_sound->main_r(space, (offset >> 1) & 7);
-}
-
-WRITE8_MEMBER(legionna_state::sound_comms_w)
-{
-	m_seibu_sound->main_w(space, (offset >> 1) & 7, data);
 }
 
 static ADDRESS_MAP_START( legionna_cop_mem, AS_PROGRAM, 16, legionna_state )
@@ -197,7 +187,7 @@ static ADDRESS_MAP_START( legionna_map, AS_PROGRAM, 16, legionna_state )
 	AM_RANGE(0x100470, 0x100471) AM_WRITENOP // toggles 0x2000 / 0x0000, tile bank on some games
 	AM_RANGE(0x100600, 0x10064f) AM_DEVREADWRITE("crtc", seibu_crtc_device, read, write)
 	AM_RANGE(0x100680, 0x100681) AM_WRITENOP // irq ack?
-	AM_RANGE(0x100700, 0x10071f) AM_READWRITE8(sound_comms_r, sound_comms_w, 0x00ff)
+	AM_RANGE(0x100700, 0x10071f) AM_DEVREADWRITE8_RSHIFT("seibu_sound", seibu_sound_device, main_r, main_w, 0x00ff, 1)
 	AM_RANGE(0x100740, 0x100741) AM_READ_PORT("DSW1")
 	AM_RANGE(0x100744, 0x100745) AM_READ_PORT("PLAYERS12")
 	AM_RANGE(0x100748, 0x100749) AM_READ_PORT("PLAYERS34")
@@ -224,7 +214,7 @@ static ADDRESS_MAP_START( heatbrl_map, AS_PROGRAM, 16, legionna_state )
 	AM_RANGE(0x100744, 0x100745) AM_READ_PORT("PLAYERS12")
 	AM_RANGE(0x100748, 0x100749) AM_READ_PORT("PLAYERS34")
 	AM_RANGE(0x10074c, 0x10074d) AM_READ_PORT("SYSTEM")
-	AM_RANGE(0x1007c0, 0x1007df) AM_READWRITE8(sound_comms_r, sound_comms_w, 0x00ff)
+	AM_RANGE(0x1007c0, 0x1007df) AM_DEVREADWRITE8_RSHIFT("seibu_sound", seibu_sound_device, main_r, main_w, 0x00ff, 1)
 	AM_RANGE(0x100800, 0x100fff) AM_RAM // _WRITE(legionna_background_w) AM_SHARE("back_data")
 	AM_RANGE(0x101000, 0x1017ff) AM_RAM // _WRITE(legionna_foreground_w) AM_SHARE("fore_data")
 	AM_RANGE(0x101800, 0x101fff) AM_RAM // _WRITE(legionna_midground_w) AM_SHARE("mid_data")
@@ -241,7 +231,7 @@ static ADDRESS_MAP_START( godzilla_map, AS_PROGRAM, 16, legionna_state )
 	AM_RANGE(0x100470, 0x100471) AM_WRITE(denjinmk_setgfxbank)
 	AM_RANGE(0x100600, 0x10064f) AM_DEVREADWRITE("crtc", seibu_crtc_device, read, write)
 	AM_RANGE(0x100680, 0x100681) AM_WRITENOP // irq ack?
-	AM_RANGE(0x100700, 0x10071f) AM_READWRITE8(sound_comms_r, sound_comms_w, 0x00ff)
+	AM_RANGE(0x100700, 0x10071f) AM_DEVREADWRITE8_RSHIFT("seibu_sound", seibu_sound_device, main_r, main_w, 0x00ff, 1)
 	AM_RANGE(0x100740, 0x100741) AM_READ_PORT("DSW1")
 	AM_RANGE(0x100744, 0x100745) AM_READ_PORT("PLAYERS12")
 	AM_RANGE(0x100748, 0x100749) AM_READ_PORT("PLAYERS34")
@@ -268,7 +258,7 @@ static ADDRESS_MAP_START( denjinmk_map, AS_PROGRAM, 16, legionna_state )
 	AM_RANGE(0x100470, 0x100471) AM_WRITE(denjinmk_setgfxbank)
 	AM_RANGE(0x100600, 0x10064f) AM_DEVREADWRITE("crtc", seibu_crtc_device, read, write)
 	AM_RANGE(0x100680, 0x100681) AM_WRITENOP // irq ack?
-	AM_RANGE(0x100700, 0x10071f) AM_READWRITE8(denjinmk_sound_comms_r, sound_comms_w, 0x00ff)
+	AM_RANGE(0x100700, 0x10071f) AM_READ8(denjinmk_sound_comms_r, 0xff) AM_DEVWRITE8_RSHIFT("seibu_sound", seibu_sound_device, main_w, 0x00ff, 1)
 	AM_RANGE(0x100740, 0x100741) AM_READ_PORT("DSW1")
 	AM_RANGE(0x100744, 0x100745) AM_READ_PORT("PLAYERS12")
 	AM_RANGE(0x100748, 0x100749) AM_READ_PORT("PLAYERS34")
@@ -294,7 +284,7 @@ static ADDRESS_MAP_START( grainbow_map, AS_PROGRAM, 16, legionna_state )
 	AM_RANGE(0x100480, 0x100487) AM_WRITE(grainbow_layer_config_w) // probably a COP feature
 	AM_RANGE(0x100600, 0x10064f) AM_DEVREADWRITE("crtc", seibu_crtc_device, read, write)
 	AM_RANGE(0x100680, 0x100681) AM_WRITENOP // irq ack?
-	AM_RANGE(0x100700, 0x10071f) AM_READWRITE8(sound_comms_r, sound_comms_w, 0x00ff)
+	AM_RANGE(0x100700, 0x10071f) AM_DEVREADWRITE8_RSHIFT("seibu_sound", seibu_sound_device, main_r, main_w, 0x00ff, 1)
 	AM_RANGE(0x100740, 0x100741) AM_READ_PORT("DSW1")
 	AM_RANGE(0x100744, 0x100745) AM_READ_PORT("PLAYERS12")
 	AM_RANGE(0x100748, 0x100749) AM_READ_PORT("PLAYERS34")
@@ -318,7 +308,7 @@ static ADDRESS_MAP_START( cupsoc_mem, AS_PROGRAM, 16, legionna_state )
 	AM_RANGE(0x100000, 0x1003ff) AM_RAM
 	AM_RANGE(0x100600, 0x10064f) AM_DEVREADWRITE("crtc", seibu_crtc_device, read, write)
 	AM_RANGE(0x100680, 0x100681) AM_WRITENOP // irq ack?
-	AM_RANGE(0x100700, 0x10071f) AM_READWRITE8(sound_comms_r, sound_comms_w, 0x00ff)
+	AM_RANGE(0x100700, 0x10071f) AM_DEVREADWRITE8_RSHIFT("seibu_sound", seibu_sound_device, main_r, main_w, 0x00ff, 1)
 	AM_RANGE(0x100740, 0x100741) AM_READ_PORT("DSW1")
 	AM_RANGE(0x100744, 0x100745) AM_READ_PORT("PLAYERS12")
 	AM_RANGE(0x100748, 0x100749) AM_READ_PORT("PLAYERS34")
@@ -350,7 +340,7 @@ static ADDRESS_MAP_START( cupsocs_mem, AS_PROGRAM, 16, legionna_state )
 	AM_RANGE(0x100708, 0x100709) AM_READ_PORT("PLAYERS34")
 	AM_RANGE(0x10070c, 0x10070d) AM_READ_PORT("SYSTEM")
 	AM_RANGE(0x10071c, 0x10071d) AM_READ_PORT("DSW2")
-	AM_RANGE(0x100740, 0x10075f) AM_READWRITE8(sound_comms_r, sound_comms_w, 0x00ff)
+	AM_RANGE(0x100740, 0x10075f) AM_DEVREADWRITE8_RSHIFT("seibu_sound", seibu_sound_device, main_r, main_w, 0x00ff, 1)
 	AM_RANGE(0x100800, 0x100fff) AM_RAM // _WRITE(legionna_background_w) AM_SHARE("back_data")
 	AM_RANGE(0x101000, 0x1017ff) AM_RAM // _WRITE(legionna_foreground_w) AM_SHARE("fore_data")
 	AM_RANGE(0x101800, 0x101fff) AM_RAM // _WRITE(legionna_midground_w) AM_SHARE("mid_data")

--- a/src/mame/drivers/r2dx_v33.cpp
+++ b/src/mame/drivers/r2dx_v33.cpp
@@ -478,7 +478,7 @@ static ADDRESS_MAP_START( nzeroteam_base_map, AS_PROGRAM, 16, r2dx_v33_state )
 
 //  AM_RANGE(0x00762, 0x00763) AM_READ(nzerotea_unknown_r)
 
-	AM_RANGE(0x00780, 0x0079f) AM_READWRITE8(sound_comms_r, sound_comms_w, 0x00ff)
+	AM_RANGE(0x00780, 0x0079f) AM_DEVREADWRITE8_RSHIFT("seibu_sound", seibu_sound_device, main_r, main_w, 0x00ff, 1)
 
 	AM_RANGE(0x00800, 0x00fff) AM_RAM
 	AM_RANGE(0x01000, 0x0bfff) AM_RAM

--- a/src/mame/drivers/raiden2.cpp
+++ b/src/mame/drivers/raiden2.cpp
@@ -792,16 +792,6 @@ MACHINE_RESET_MEMBER(raiden2_state,xsedae)
 	sprcpt_init();
 }
 
-READ8_MEMBER(raiden2_state::sound_comms_r)
-{
-	return m_seibu_sound->main_r(space, (offset >> 1) & 7);
-}
-
-WRITE8_MEMBER(raiden2_state::sound_comms_w)
-{
-	m_seibu_sound->main_w(space, (offset >> 1) & 7, data);
-}
-
 WRITE16_MEMBER(raiden2_state::raiden2_bank_w)
 {
 	if(ACCESSING_BITS_8_15) {
@@ -977,7 +967,7 @@ static ADDRESS_MAP_START( raiden2_mem, AS_PROGRAM, 16, raiden2_state )
 
 	AM_IMPORT_FROM( raiden2_cop_mem )
 
-	AM_RANGE(0x00700, 0x0071f) AM_READWRITE8(sound_comms_r, sound_comms_w, 0x00ff)
+	AM_RANGE(0x00700, 0x0071f) AM_DEVREADWRITE8_RSHIFT("seibu_sound", seibu_sound_device, main_r, main_w, 0x00ff, 1)
 
 	AM_RANGE(0x00740, 0x00741) AM_READ_PORT("DSW")
 	AM_RANGE(0x00744, 0x00745) AM_READ_PORT("P1_P2")
@@ -1018,7 +1008,7 @@ static ADDRESS_MAP_START( zeroteam_mem, AS_PROGRAM, 16, raiden2_state )
 
 	AM_IMPORT_FROM( raiden2_cop_mem )
 
-	AM_RANGE(0x00700, 0x0071f) AM_READWRITE8(sound_comms_r, sound_comms_w, 0x00ff)
+	AM_RANGE(0x00700, 0x0071f) AM_DEVREADWRITE8_RSHIFT("seibu_sound", seibu_sound_device, main_r, main_w, 0x00ff, 1)
 
 	AM_RANGE(0x00740, 0x00741) AM_READ_PORT("DSW")
 	AM_RANGE(0x00744, 0x00745) AM_READ_PORT("P1_P2")
@@ -1049,7 +1039,7 @@ static ADDRESS_MAP_START( xsedae_mem, AS_PROGRAM, 16, raiden2_state )
 
 	AM_IMPORT_FROM( raiden2_cop_mem )
 
-	AM_RANGE(0x00700, 0x0071f) AM_READWRITE8(sound_comms_r, sound_comms_w, 0x00ff)
+	AM_RANGE(0x00700, 0x0071f) AM_DEVREADWRITE8_RSHIFT("seibu_sound", seibu_sound_device, main_r, main_w, 0x00ff, 1)
 
 	AM_RANGE(0x00740, 0x00741) AM_READ_PORT("DSW")
 	AM_RANGE(0x00744, 0x00745) AM_READ_PORT("P1_P2")

--- a/src/mame/drivers/splash.cpp
+++ b/src/mame/drivers/splash.cpp
@@ -48,6 +48,7 @@ More notes about Funny Strip protection issues at the bottom of source file (DRI
 
 #include "cpu/z80/z80.h"
 #include "cpu/m68000/m68000.h"
+#include "machine/74259.h"
 #include "sound/2203intf.h"
 #include "sound/3812intf.h"
 #include "screen.h"
@@ -72,11 +73,6 @@ WRITE16_MEMBER(splash_state::roldf_sh_irqtrigger_w)
 
 	// give the z80 time to see it
 	space.device().execute().spin_until_time(attotime::from_usec(40));
-}
-
-WRITE8_MEMBER(splash_state::coin_w)
-{
-	m_outlatch->write_bit(offset >> 3, BIT(data, 0));
 }
 
 WRITE_LINE_MEMBER(splash_state::coin1_lockout_w)
@@ -106,7 +102,7 @@ static ADDRESS_MAP_START( splash_map, AS_PROGRAM, 16, splash_state )
 	AM_RANGE(0x840002, 0x840003) AM_READ_PORT("DSW2")
 	AM_RANGE(0x840004, 0x840005) AM_READ_PORT("P1")
 	AM_RANGE(0x840006, 0x840007) AM_READ_PORT("P2")
-	AM_RANGE(0x84000a, 0x84000b) AM_SELECT(0x000070) AM_WRITE8(coin_w, 0xff00)   /* Coin Counters + Coin Lockout */
+	AM_RANGE(0x84000a, 0x84000b) AM_SELECT(0x000070) AM_DEVWRITE8_RSHIFT("outlatch", ls259_device, write_d0, 0xff00, 3)
 	AM_RANGE(0x84000e, 0x84000f) AM_WRITE(splash_sh_irqtrigger_w)                       /* Sound command */
 	AM_RANGE(0x880000, 0x8817ff) AM_RAM_WRITE(vram_w) AM_SHARE("videoram")   /* Video RAM */
 	AM_RANGE(0x881800, 0x881803) AM_RAM AM_SHARE("vregs")                           /* Scroll registers */
@@ -179,7 +175,7 @@ static ADDRESS_MAP_START( roldfrog_map, AS_PROGRAM, 16, splash_state )
 	AM_RANGE(0x840002, 0x840003) AM_READ_PORT("DSW2")
 	AM_RANGE(0x840004, 0x840005) AM_READ_PORT("P1")
 	AM_RANGE(0x840006, 0x840007) AM_READ_PORT("P2")
-	AM_RANGE(0x84000a, 0x84000b) AM_SELECT(0x000070) AM_WRITE8(coin_w, 0xff00)   /* Coin Counters + Coin Lockout */
+	AM_RANGE(0x84000a, 0x84000b) AM_SELECT(0x000070) AM_DEVWRITE8_RSHIFT("outlatch", ls259_device, write_d0, 0xff00, 3)
 	AM_RANGE(0x84000e, 0x84000f) AM_WRITE(roldf_sh_irqtrigger_w)                        /* Sound command */
 	AM_RANGE(0x880000, 0x8817ff) AM_RAM_WRITE(vram_w) AM_SHARE("videoram")   /* Video RAM */
 	AM_RANGE(0x881800, 0x881803) AM_RAM AM_SHARE("vregs")                           /* Scroll registers */

--- a/src/mame/drivers/taito_l.cpp
+++ b/src/mame/drivers/taito_l.cpp
@@ -474,11 +474,6 @@ WRITE8_MEMBER(champwr_state::msm5205_volume_w)
 	m_msm->set_output_gain(0, data / 255.0);
 }
 
-READ8_MEMBER(horshoes_state::trackball_r)
-{
-	return m_upd4701->read_xy(space, offset >> 2);
-}
-
 
 static ADDRESS_MAP_START( common_banks_map, AS_PROGRAM, 8, taitol_state )
 	AM_RANGE(0x0000, 0x5fff) AM_ROM
@@ -662,7 +657,7 @@ static ADDRESS_MAP_START( horshoes_map, AS_PROGRAM, 8, horshoes_state )
 	AM_IMPORT_FROM(common_banks_map)
 	AM_RANGE(0x8000, 0x9fff) AM_RAM
 	AM_RANGE(0xa000, 0xa003) AM_READ(extport_select_and_ym2203_r) AM_DEVWRITE("ymsnd", ym2203_device, write)
-	AM_RANGE(0xa800, 0xa800) AM_SELECT(0x000c) AM_READ(trackball_r)
+	AM_RANGE(0xa800, 0xa800) AM_SELECT(0x000c) AM_DEVREAD_RSHIFT("upd4701", upd4701_device, read_xy, 2)
 	AM_RANGE(0xa802, 0xa802) AM_DEVREAD("upd4701", upd4701_device, reset_x)
 	AM_RANGE(0xa803, 0xa803) AM_DEVREAD("upd4701", upd4701_device, reset_y)
 	AM_RANGE(0xb801, 0xb801) AM_READNOP // Watchdog or interrupt ack

--- a/src/mame/drivers/thoop2.cpp
+++ b/src/mame/drivers/thoop2.cpp
@@ -21,6 +21,7 @@ Gaelco drivers.
 
 #include "cpu/m68000/m68000.h"
 #include "cpu/mcs51/mcs51.h"
+#include "machine/74259.h"
 #include "machine/watchdog.h"
 #include "sound/okim6295.h"
 
@@ -36,11 +37,6 @@ void thoop2_state::machine_start()
 WRITE8_MEMBER(thoop2_state::OKIM6295_bankswitch_w)
 {
 	membank("okibank")->set_entry(data & 0x0f);
-}
-
-WRITE8_MEMBER(thoop2_state::coin_w)
-{
-	m_outlatch->write_bit(offset >> 3, BIT(data, 0));
 }
 
 WRITE_LINE_MEMBER(thoop2_state::coin1_lockout_w)
@@ -93,7 +89,7 @@ static ADDRESS_MAP_START( thoop2_map, AS_PROGRAM, 16, thoop2_state )
 	AM_RANGE(0x700004, 0x700005) AM_READ_PORT("P1")
 	AM_RANGE(0x700006, 0x700007) AM_READ_PORT("P2")
 	AM_RANGE(0x700008, 0x700009) AM_READ_PORT("SYSTEM")
-	AM_RANGE(0x70000a, 0x70000b) AM_SELECT(0x000070) AM_WRITE8(coin_w, 0x00ff)          /* Coin Counters + Coin Lockout */
+	AM_RANGE(0x70000a, 0x70000b) AM_SELECT(0x000070) AM_DEVWRITE8_RSHIFT("outlatch", ls259_device, write_d0, 0x00ff, 3)
 	AM_RANGE(0x70000c, 0x70000d) AM_WRITE8(OKIM6295_bankswitch_w, 0x00ff)               /* OKI6295 bankswitch */
 	AM_RANGE(0x70000e, 0x70000f) AM_DEVREADWRITE8("oki", okim6295_device, read, write, 0x00ff)                  /* OKI6295 data register */
 	AM_RANGE(0xfe0000, 0xfe7fff) AM_RAM                                          /* Work RAM */

--- a/src/mame/drivers/timeplt.cpp
+++ b/src/mame/drivers/timeplt.cpp
@@ -53,6 +53,7 @@
 #include "audio/timeplt.h"
 
 #include "cpu/z80/z80.h"
+#include "machine/74259.h"
 #include "machine/gen_latch.h"
 #include "machine/watchdog.h"
 #include "sound/ay8910.h"
@@ -86,11 +87,6 @@ WRITE_LINE_MEMBER(timeplt_state::nmi_enable_w)
  *  I/O
  *
  *************************************/
-
-WRITE8_MEMBER(timeplt_state::mainlatch_w)
-{
-	m_mainlatch->write_d0(space, offset >> 1, data);
-}
 
 WRITE_LINE_MEMBER(timeplt_state::coin_counter_1_w)
 {
@@ -146,7 +142,7 @@ static ADDRESS_MAP_START( timeplt_main_map, AS_PROGRAM, 8, timeplt_state )
 	AM_RANGE(0xc000, 0xc000) AM_MIRROR(0x0cff) AM_READ(scanline_r) AM_DEVWRITE("soundlatch", generic_latch_8_device, write)
 	AM_RANGE(0xc200, 0xc200) AM_MIRROR(0x0cff) AM_READ_PORT("DSW1") AM_DEVWRITE("watchdog", watchdog_timer_device, reset_w)
 	AM_RANGE(0xc300, 0xc300) AM_MIRROR(0x0c9f) AM_READ_PORT("IN0")
-	AM_RANGE(0xc300, 0xc30f) AM_MIRROR(0x0cf0) AM_WRITE(mainlatch_w) // handler ignores low bit of offset
+	AM_RANGE(0xc300, 0xc30f) AM_MIRROR(0x0cf0) AM_DEVWRITE_RSHIFT("mainlatch", ls259_device, write_d0, 1)
 	AM_RANGE(0xc320, 0xc320) AM_MIRROR(0x0c9f) AM_READ_PORT("IN1")
 	AM_RANGE(0xc340, 0xc340) AM_MIRROR(0x0c9f) AM_READ_PORT("IN2")
 	AM_RANGE(0xc360, 0xc360) AM_MIRROR(0x0c9f) AM_READ_PORT("DSW0")

--- a/src/mame/drivers/wrally.cpp
+++ b/src/mame/drivers/wrally.cpp
@@ -131,6 +131,7 @@ The PCB has a layout that can either use the 4 rom set of I7, I9, I11 & I13 or l
 
 #include "cpu/m68000/m68000.h"
 #include "cpu/mcs51/mcs51.h"
+#include "machine/74259.h"
 #include "sound/okim6295.h"
 
 #include "screen.h"
@@ -153,7 +154,7 @@ static ADDRESS_MAP_START( wrally_map, AS_PROGRAM, 16, wrally_state )
 	AM_RANGE(0x700002, 0x700003) AM_READ_PORT("P1_P2")
 	AM_RANGE(0x700004, 0x700005) AM_READ_PORT("WHEEL")
 	AM_RANGE(0x700008, 0x700009) AM_READ_PORT("SYSTEM")
-	AM_RANGE(0x70000a, 0x70000b) AM_SELECT(0x000070) AM_WRITE8(latch_w, 0x00ff)
+	AM_RANGE(0x70000a, 0x70000b) AM_SELECT(0x000070) AM_DEVWRITE8_RSHIFT("outlatch", ls259_device, write_d0, 0x00ff, 3)
 	AM_RANGE(0x70000c, 0x70000d) AM_WRITE(okim6295_bankswitch_w)                                /* OKI6295 bankswitch */
 	AM_RANGE(0x70000e, 0x70000f) AM_DEVREADWRITE8("oki", okim6295_device, read, write, 0x00ff)  /* OKI6295 status/data register */
 	AM_RANGE(0xfec000, 0xfeffff) AM_RAM AM_SHARE("shareram")                                        /* Work RAM (shared with DS5002FP) */

--- a/src/mame/includes/equites.h
+++ b/src/mame/includes/equites.h
@@ -6,7 +6,6 @@
 
 *************************************************************************/
 
-#include "machine/74259.h"
 #include "machine/alpha8201.h"
 #include "machine/gen_latch.h"
 #include "sound/samples.h"
@@ -35,8 +34,7 @@ public:
 		m_msm(*this, "msm"),
 		m_dac_1(*this, "dac1"),
 		m_dac_2(*this, "dac2"),
-		m_soundlatch(*this, "soundlatch"),
-		m_mainlatch(*this, "mainlatch")
+		m_soundlatch(*this, "soundlatch")
 	{ }
 
 	/* memory pointers */
@@ -82,7 +80,6 @@ public:
 	required_device<dac_byte_interface> m_dac_1;
 	required_device<dac_byte_interface> m_dac_2;
 	required_device<generic_latch_8_device> m_soundlatch;
-	required_device<ls259_device> m_mainlatch;
 
 	DECLARE_WRITE8_MEMBER(equites_c0f8_w);
 	DECLARE_WRITE8_MEMBER(equites_cymbal_ctrl_w);

--- a/src/mame/includes/gaelco.h
+++ b/src/mame/includes/gaelco.h
@@ -6,7 +6,6 @@
 
 ***************************************************************************/
 
-#include "machine/74259.h"
 #include "machine/gen_latch.h"
 
 class gaelco_state : public driver_device
@@ -19,7 +18,6 @@ public:
 		m_palette(*this, "palette"),
 		m_audiocpu(*this, "audiocpu"),
 		m_soundlatch(*this, "soundlatch"),
-		m_outlatch(*this, "outlatch"),
 		m_videoram(*this, "videoram"),
 		m_vregs(*this, "vregs"),
 		m_spriteram(*this, "spriteram"),
@@ -31,7 +29,6 @@ public:
 	required_device<palette_device> m_palette;
 	optional_device<cpu_device> m_audiocpu;
 	optional_device<generic_latch_8_device> m_soundlatch;
-	optional_device<ls259_device> m_outlatch;
 
 	/* memory pointers */
 	required_shared_ptr<uint16_t> m_videoram;

--- a/src/mame/includes/gaelco3d.h
+++ b/src/mame/includes/gaelco3d.h
@@ -10,7 +10,6 @@
 
 #include "sound/dmadac.h"
 #include "video/poly.h"
-#include "machine/74259.h"
 #include "machine/eepromser.h"
 #include "machine/gaelco3d.h"
 #include "cpu/adsp2100/adsp2100.h"
@@ -70,8 +69,6 @@ public:
 		m_tms(*this, "tms"),
 		m_serial(*this, "serial"),
 		m_screen(*this, "screen"),
-		m_mainlatch(*this, "mainlatch"),
-		m_outlatch(*this, "outlatch"),
 		m_paletteram16(*this, "paletteram"),
 		m_paletteram32(*this, "paletteram"),
 		m_analog(*this, {"ANALOG0", "ANALOG1", "ANALOG2", "ANALOG3", "ANALOG4", "ANALOG5" })
@@ -88,8 +85,6 @@ public:
 	required_device<cpu_device> m_tms;
 	required_device<gaelco_serial_device> m_serial;
 	required_device<screen_device> m_screen;
-	required_device<ls259_device> m_mainlatch;
-	required_device<ls259_device> m_outlatch;
 	optional_shared_ptr<uint16_t> m_paletteram16;
 	optional_shared_ptr<uint32_t> m_paletteram32;
 	optional_ioport_array<6> m_analog;
@@ -139,10 +134,6 @@ public:
 	DECLARE_CUSTOM_INPUT_MEMBER(analog_bit_r);
 	DECLARE_WRITE_LINE_MEMBER(ser_irq);
 	DECLARE_READ16_MEMBER(eeprom_data_r);
-	DECLARE_WRITE8_MEMBER(mainlatch_68000_w);
-	DECLARE_WRITE8_MEMBER(outlatch_68000_w);
-	DECLARE_WRITE8_MEMBER(mainlatch_68020_w);
-	DECLARE_WRITE8_MEMBER(outlatch_68020_w);
 	DECLARE_DRIVER_INIT(gaelco3d);
 	virtual void machine_start() override;
 	virtual void machine_reset() override;

--- a/src/mame/includes/gridlee.h
+++ b/src/mame/includes/gridlee.h
@@ -8,7 +8,6 @@
 
 ***************************************************************************/
 
-#include "machine/74259.h"
 #include "sound/samples.h"
 #include "screen.h"
 
@@ -33,15 +32,13 @@ public:
 		m_videoram(*this, "videoram"),
 		m_maincpu(*this, "maincpu"),
 		m_screen(*this, "screen"),
-		m_palette(*this, "palette"),
-		m_latch(*this, "latch") { }
+		m_palette(*this, "palette") { }
 
 	required_shared_ptr<uint8_t> m_spriteram;
 	required_shared_ptr<uint8_t> m_videoram;
 	required_device<cpu_device> m_maincpu;
 	required_device<screen_device> m_screen;
 	required_device<palette_device> m_palette;
-	required_device<ls259_device> m_latch;
 
 	uint8_t m_last_analog_input[2];
 	uint8_t m_last_analog_output[2];

--- a/src/mame/includes/legionna.h
+++ b/src/mame/includes/legionna.h
@@ -59,9 +59,7 @@ public:
 	DECLARE_WRITE16_MEMBER(legionna_midground_w);
 	DECLARE_WRITE16_MEMBER(legionna_foreground_w);
 	DECLARE_WRITE16_MEMBER(legionna_text_w);
-	DECLARE_READ8_MEMBER(sound_comms_r);
 	DECLARE_READ8_MEMBER(denjinmk_sound_comms_r);
-	DECLARE_WRITE8_MEMBER(sound_comms_w);
 	DECLARE_WRITE16_MEMBER(denjinmk_setgfxbank);
 	DECLARE_WRITE16_MEMBER(heatbrl_setgfxbank);
 	DECLARE_WRITE16_MEMBER(grainbow_layer_config_w);

--- a/src/mame/includes/raiden2.h
+++ b/src/mame/includes/raiden2.h
@@ -83,9 +83,6 @@ public:
 	DECLARE_WRITE16_MEMBER( sprcpt_flags_1_w );
 	DECLARE_WRITE16_MEMBER( sprcpt_flags_2_w );
 
-	DECLARE_READ8_MEMBER( sound_comms_r );
-	DECLARE_WRITE8_MEMBER( sound_comms_w );
-
 	void common_reset();
 
 	static uint16_t const raiden_blended_colors[];

--- a/src/mame/includes/splash.h
+++ b/src/mame/includes/splash.h
@@ -1,7 +1,6 @@
 // license:BSD-3-Clause
 // copyright-holders:Manuel Abadia, David Haywood
 
-#include "machine/74259.h"
 #include "machine/eepromser.h"
 #include "machine/gen_latch.h"
 #include "sound/msm5205.h"
@@ -17,7 +16,6 @@ public:
 		m_gfxdecode(*this, "gfxdecode"),
 		m_palette(*this, "palette"),
 		m_soundlatch(*this, "soundlatch"),
-		m_outlatch(*this, "outlatch"),
 		m_pixelram(*this, "pixelram"),
 		m_videoram(*this, "videoram"),
 		m_vregs(*this, "vregs"),
@@ -32,7 +30,6 @@ public:
 	required_device<gfxdecode_device> m_gfxdecode;
 	required_device<palette_device> m_palette;
 	required_device<generic_latch_8_device> m_soundlatch;
-	optional_device<ls259_device> m_outlatch;
 
 	required_shared_ptr<uint16_t> m_pixelram;
 	required_shared_ptr<uint16_t> m_videoram;
@@ -57,7 +54,6 @@ public:
 
 	// common
 	DECLARE_WRITE16_MEMBER(vram_w);
-	DECLARE_WRITE8_MEMBER(coin_w);
 	DECLARE_WRITE_LINE_MEMBER(coin1_lockout_w);
 	DECLARE_WRITE_LINE_MEMBER(coin2_lockout_w);
 	DECLARE_WRITE_LINE_MEMBER(coin1_counter_w);

--- a/src/mame/includes/taito_l.h
+++ b/src/mame/includes/taito_l.h
@@ -226,15 +226,10 @@ class horshoes_state : public taitol_1cpu_state
 public:
 	horshoes_state(const machine_config &mconfig, device_type type, const char *tag)
 		: taitol_1cpu_state(mconfig, type, tag)
-		, m_upd4701(*this, "upd4701")
 	{
 	}
 
-	DECLARE_READ8_MEMBER(trackball_r);
 	DECLARE_WRITE8_MEMBER(bankg_w);
 
 	DECLARE_MACHINE_RESET(horshoes);
-
-protected:
-	required_device<upd4701_device> m_upd4701;
 };

--- a/src/mame/includes/thoop2.h
+++ b/src/mame/includes/thoop2.h
@@ -5,8 +5,6 @@
 
 #pragma once
 
-#include "machine/74259.h"
-
 class thoop2_state : public driver_device
 {
 public:
@@ -16,7 +14,6 @@ public:
 		m_maincpu(*this, "maincpu"),
 		m_gfxdecode(*this, "gfxdecode"),
 		m_palette(*this, "palette"),
-		m_outlatch(*this, "outlatch"),
 		m_videoram(*this, "videoram"),
 		m_vregs(*this, "vregs"),
 		m_spriteram(*this, "spriteram"),
@@ -24,7 +21,6 @@ public:
 	{ }
 
 	DECLARE_WRITE8_MEMBER(OKIM6295_bankswitch_w);
-	DECLARE_WRITE8_MEMBER(coin_w);
 	DECLARE_WRITE_LINE_MEMBER(coin1_lockout_w);
 	DECLARE_WRITE_LINE_MEMBER(coin2_lockout_w);
 	DECLARE_WRITE_LINE_MEMBER(coin1_counter_w);
@@ -53,7 +49,6 @@ private:
 	required_device<cpu_device> m_maincpu;
 	required_device<gfxdecode_device> m_gfxdecode;
 	required_device<palette_device> m_palette;
-	required_device<ls259_device> m_outlatch;
 
 	required_shared_ptr<uint16_t> m_videoram;
 	required_shared_ptr<uint16_t> m_vregs;

--- a/src/mame/includes/timeplt.h
+++ b/src/mame/includes/timeplt.h
@@ -6,7 +6,6 @@
 
 ***************************************************************************/
 
-#include "machine/74259.h"
 #include "sound/tc8830f.h"
 #include "screen.h"
 
@@ -20,7 +19,6 @@ public:
 		m_gfxdecode(*this, "gfxdecode"),
 		m_screen(*this, "screen"),
 		m_palette(*this, "palette"),
-		m_mainlatch(*this, "mainlatch"),
 		m_colorram(*this, "colorram"),
 		m_videoram(*this, "videoram"),
 		m_spriteram(*this, "spriteram"),
@@ -32,7 +30,6 @@ public:
 	required_device<gfxdecode_device> m_gfxdecode;
 	required_device<screen_device> m_screen;
 	required_device<palette_device> m_palette;
-	required_device<ls259_device> m_mainlatch;
 
 	/* memory pointers */
 	required_shared_ptr<uint8_t> m_colorram;

--- a/src/mame/includes/wrally.h
+++ b/src/mame/includes/wrally.h
@@ -5,8 +5,6 @@
 
 #pragma once
 
-#include "machine/74259.h"
-
 class wrally_state : public driver_device
 {
 public:
@@ -15,7 +13,6 @@ public:
 		m_maincpu(*this, "maincpu"),
 		m_gfxdecode(*this, "gfxdecode"),
 		m_palette(*this, "palette"),
-		m_outlatch(*this, "outlatch"),
 		m_videoram(*this, "videoram"),
 		m_vregs(*this, "vregs"),
 		m_spriteram(*this, "spriteram"),
@@ -29,7 +26,6 @@ public:
 	DECLARE_WRITE16_MEMBER(vram_w);
 	DECLARE_WRITE_LINE_MEMBER(flipscreen_w);
 	DECLARE_WRITE16_MEMBER(okim6295_bankswitch_w);
-	DECLARE_WRITE8_MEMBER(latch_w);
 	DECLARE_WRITE_LINE_MEMBER(coin1_counter_w);
 	DECLARE_WRITE_LINE_MEMBER(coin2_counter_w);
 	DECLARE_WRITE_LINE_MEMBER(coin1_lockout_w);
@@ -50,7 +46,6 @@ private:
 	required_device<cpu_device> m_maincpu;
 	required_device<gfxdecode_device> m_gfxdecode;
 	required_device<palette_device> m_palette;
-	required_device<ls259_device> m_outlatch;
 
 	required_shared_ptr<uint16_t> m_videoram;
 	required_shared_ptr<uint16_t> m_vregs;

--- a/src/mame/machine/wrally.cpp
+++ b/src/mame/machine/wrally.cpp
@@ -46,11 +46,6 @@ WRITE16_MEMBER(wrally_state::vram_w)
 	m_pant[(offset & 0x1fff) >> 12]->mark_tile_dirty(((offset << 1) & 0x1fff) >> 2);
 }
 
-WRITE8_MEMBER(wrally_state::latch_w)
-{
-	m_outlatch->write_bit(offset >> 3, BIT(data, 0));
-}
-
 WRITE_LINE_MEMBER(wrally_state::flipscreen_w)
 {
 	flip_screen_set(state);


### PR DESCRIPTION
These new macros make it easy to map devices addressed using higher address lines (which helps to reduce line loads on actual HW) without needing to set up custom handlers and associated device finders. The implementation should not impact the efficiency of the core memory system (which Olivier Galibert is trying to improve) since the semantic details are contained within C++11 lambdas.