### PR TITLE
Fixed a bug in gap detection of DC100 tape emulation

### DIFF
--- a/src/devices/machine/1ma6.cpp
+++ b/src/devices/machine/1ma6.cpp
@@ -142,7 +142,7 @@ READ8_MEMBER(hp_1ma6_device::reg_r)
 	case 0:
 		// Status register
 		update_tape_pos();
-		if (m_cmd_state == CMD_IDLE || !m_cartridge_in) {
+		if (m_cmd_state == CMD_IDLE) {
 			BIT_SET(m_status_reg , STS_READY_BIT);
 		} else if (m_cmd_state == CMD_STOPPING ||
 				   m_cmd_state == CMD_FAST_FWD_REV ||
@@ -291,7 +291,7 @@ void hp_1ma6_device::device_timer(emu_timer &timer, device_timer_id id, int para
 					}
 					LOG("WR T%u @ %d = %04x\n" , current_track() , m_rw_pos , m_next_word);
 					if (m_cartridge_in) {
-						m_image.write_word(current_track() , m_rw_pos , m_next_word , length);
+						m_image.write_word(current_track() , m_rw_pos , m_next_word , length , is_moving_fwd());
 						m_image_dirty = true;
 					}
 					if (is_moving_fwd()) {

--- a/src/lib/formats/hti_tape.h
+++ b/src/lib/formats/hti_tape.h
@@ -57,7 +57,7 @@ public:
 	static tape_pos_t next_hole(tape_pos_t pos , bool forward);
 
 	// Write a data word on tape
-	void write_word(unsigned track_no , tape_pos_t start , tape_word_t word , tape_pos_t& length);
+	void write_word(unsigned track_no , tape_pos_t start , tape_word_t word , tape_pos_t& length , bool forward = true);
 	// Write a gap on tape
 	void write_gap(unsigned track_no , tape_pos_t a , tape_pos_t b);
 


### PR DESCRIPTION
Hi,
this PR is for a small fix to DC100 cassette emulation (used in HP 9845 & 85 systems) to prevent false gap detections (which, in turn, prevent reading of tape).
Thanks.
--F.Ulivi
