### PR TITLE
HP9000/300: disable DMA controller workaround

### DIFF
--- a/src/mame/drivers/hp9k_3xx.cpp
+++ b/src/mame/drivers/hp9k_3xx.cpp
@@ -149,8 +149,6 @@ static ADDRESS_MAP_START(hp9k3xx_common, AS_PROGRAM, 32, hp9k3xx_state)
 
 	AM_RANGE(0x00428000, 0x00428003) AM_DEVREADWRITE8(IOCPU_TAG, upi41_cpu_device, upi41_master_r, upi41_master_w, 0x00ff00ff)
 
-	AM_RANGE(0x00500000, 0x0050000f) AM_RAM // this is sufficient to pass the DMA test for now
-
 	AM_RANGE(0x00510000, 0x00510003) AM_READWRITE(buserror_r, buserror_w)   // no "Alpha display"
 	AM_RANGE(0x00538000, 0x00538003) AM_READWRITE(buserror_r, buserror_w)   // no "Graphics"
 	AM_RANGE(0x005c0000, 0x005c0003) AM_READWRITE(buserror_r, buserror_w)   // no add-on FP coprocessor


### PR DESCRIPTION
Faking the DMA register set with RAM makes the 'Failed' message
go away, but makes the ROM use DMA functionality even if there's
none. Seen this while working on HPIB support which tries to transfer
data via DMA and fails. When disabling the DMA hack the ROM falls
back to PIO mode.

Signed-off-by: Sven Schnelle <svens@stackframe.org>