### PR TITLE
sms/gamegear misc fixes [Enik Land]

### DIFF
--- a/hash/sms.xml
+++ b/hash/sms.xml
@@ -3547,6 +3547,7 @@
 		<year>1993</year>
 		<publisher>Sieco</publisher>
 		<part name="cart" interface="sms_cart">
+			<feature name="slot" value="korean" />
 			<dataarea name="rom" size="524288">
 				<rom name="jang pung ii (kr).bin" size="524288" crc="929222c4" sha1="10a5095513efebae3d045b217caa7a520e66f26f" offset="000000" />
 			</dataarea>
@@ -6803,6 +6804,12 @@
 		<publisher>Virgin Interactive</publisher>
 		<info name="serial" value="MK-27025-50"/>
 		<part name="cart" interface="sms_cart">
+			<!-- PCB info based on elotrolado.net forum:
+			https://www.elotrolado.net/hilo_hilo-oficial-dossier-completo-de-sega-master-system_2197710_s60
+			-->
+			<feature name="pcb" value="171-6339A" />
+			<feature name="ic1" value="MPR-14831-F" />
+			<feature name="ic2" value="KM62256BLP-10L" /> <!-- 32768 * 8 bit CMOS Static RAM -->
 			<dataarea name="rom" size="262144">
 				<rom name="terminator, the (europe).bin" size="262144" crc="edc5c012" sha1="eaf733d385e61526b90c1b194bf605078d43e2d3" offset="000000" />
 			</dataarea>

--- a/src/devices/bus/sega8/rom.cpp
+++ b/src/devices/bus/sega8/rom.cpp
@@ -250,6 +250,7 @@ void sega8_4pak_device::device_start()
 void sega8_4pak_device::device_reset()
 {
 	memset(m_reg, 0, sizeof(m_reg));
+	memset(m_rom_bank_base, 0, sizeof(m_rom_bank_base));
 }
 
 

--- a/src/devices/bus/sms_ctrl/multitap.cpp
+++ b/src/devices/bus/sms_ctrl/multitap.cpp
@@ -17,7 +17,7 @@
 //  DEVICE DEFINITIONS
 //**************************************************************************
 
-DEFINE_DEVICE_TYPE(SMS_MULTITAP, sms_multitap_device, "sms_multitap", "Sega SMS Multitap")
+DEFINE_DEVICE_TYPE(SMS_MULTITAP, sms_multitap_device, "sms_multitap", "Furrtek SMS Multitap")
 
 
 //**************************************************************************

--- a/src/mame/drivers/sms.cpp
+++ b/src/mame/drivers/sms.cpp
@@ -279,7 +279,7 @@ static ADDRESS_MAP_START( sms_mem, AS_PROGRAM, 8, sms_state )
 	AM_RANGE(0x0000, 0x3fff) AM_READ(read_0000)
 	AM_RANGE(0x4000, 0x7fff) AM_READ(read_4000)
 	AM_RANGE(0x8000, 0xbfff) AM_READ(read_8000)
-	AM_RANGE(0xc000, 0xfff7) AM_READWRITE(read_ram, write_ram)
+	AM_RANGE(0xc000, 0xfffb) AM_READWRITE(read_ram, write_ram)
 	AM_RANGE(0xfffc, 0xffff) AM_READWRITE(sms_mapper_r, sms_mapper_w)       /* Bankswitch control */
 ADDRESS_MAP_END
 
@@ -1109,8 +1109,8 @@ ROM_START(gamegear)
 	ROM_FILL(0x0000, 0x4000, 0x00)
 
 	ROM_REGION(0x0400, "user1", 0)
-	ROM_SYSTEM_BIOS( 0, "none", "No BIOS" ) /* gamegear */
-	ROM_SYSTEM_BIOS( 1, "majesco", "Majesco BIOS" ) /* gamg */
+	ROM_SYSTEM_BIOS( 0, "none", "No BIOS" )
+	ROM_SYSTEM_BIOS( 1, "majesco", "Majesco BIOS" )
 	ROMX_LOAD("majbios.rom", 0x0000, 0x0400, CRC(0ebea9d4) SHA1(914aa165e3d879f060be77870d345b60cfeb4ede), ROM_BIOS(2))
 ROM_END
 

--- a/src/mame/machine/sms.cpp
+++ b/src/mame/machine/sms.cpp
@@ -331,7 +331,7 @@ READ8_MEMBER(sms_state::sms_input_port_dc_r)
 	else
 	{
 		// Return if the I/O chip is disabled (1). This check isn't performed
-		// for the Game Gear because has no effect on it (even in SMS mode?).
+		// for the Game Gear because has no effect on it, even in SMS mode.
 		if (m_mem_ctrl_reg & IO_CHIP)
 			return 0xff;
 	}
@@ -376,7 +376,7 @@ READ8_MEMBER(sms_state::sms_input_port_dd_r)
 	else
 	{
 		// Return if the I/O chip is disabled (1). This check isn't performed
-		// for the Game Gear because has no effect on it (even in SMS mode?).
+		// for the Game Gear because has no effect on it, even in SMS mode.
 		if (m_mem_ctrl_reg & IO_CHIP)
 			return 0xff;
 	}


### PR DESCRIPTION
- correct author of the SMS multipad device hardware.
- upper addresses of the SMS2/GG memory map unused by devices need to be mapped to RAM (fixes 'shero' GG game).
- add PCB info for 'termntr' and fix mapper of 'jangpun2', entries of the SMS software list.
- fix a soft reset bug in the mapper code for the '4pak' entry of the SMS software list.
- remove two obsolete comments from the period when MESS didn't supported BIOS selection.
- change two comments to document that player inputs on GG aren't disabled even in SMS mode.
