### PR TITLE
Added comments and EuroPC II and EuroXT variants, corrected RAM 

### DIFF
--- a/src/mame/drivers/europc.cpp
+++ b/src/mame/drivers/europc.cpp
@@ -1,7 +1,33 @@
 // license:BSD-3-Clause
 // copyright-holders:Wilbert Pol
-#include "emu.h"
+// comments and BIOS versions:rfka01
+/*****************************************************************************************************
+*
+* Schneider Rundfunkwerke AG Euro PC and Euro PC II driver
+*
+* Manuals and BIOS files: ftp://ftp.cpcszene.de/pub/Computer/Schneider_PC/EuroPC_XT/
+*
+* Euro PC: Computer and floppy drive integrated into the keyboard, 8088, 512K RAM, there was an upgrade card for the ISA slot that took it to 640K, single ISA slot
+           FD360 external 360K 5.25" DS DD floppy, FD720 external 720K 3,5" DS DD floppy, HD-20 external harddisk, internal graphics card is CGA or Hercules, 64KB VRAM
+* Euro PC II: like Euro PC, socket for 8087, 768K RAM on board, driver on Schneider DOS disk allowed the portion over 640K to be used as extended memory or ramdisk.
+* Euro XT: conventional desktop, specs like Euro PC II, two ISA slots on a riser card, 102 key seperate keyboard, internal XT-IDE 20MB harddisk, connector for FD360 and FD720 was retained
+*
+* Only BIOS versions >2.06 are supported so far because of changes in the memory management, according to https://www.forum64.de/index.php?thread/43066-schneider-euro-pc-i-ii-xt-welche-bios-version-habt-ihr/
+* BIOS version 2.04 has been encountered, but is not available online
+*
+* To get rid of the BIOS error messages when you first start the system, enter the BIOS with Ctrl-Alt-Esc, match the RAM size to your settings in MAME, set the CPU speed to 9.54MHz
+* and the graphics adapter to Color/Graphics 80, internal graphics off
+*
+* To-Do: * An external 20MB harddisk (Schneider HD20) can be added to the PC and PC II. This is a XT IDE drive. The BIOSs contain their own copy of the WD XT IDE BIOS that can be activated from the BIOS setup menu.
+*          (load debug, then g=f000:a000 to enter formatter routine)
+*		 * emulate internal graphics, but AGA is not quite the correct choice for the standard graphics adapter (it's a Commodore standard), as the Schneiders are only capable of switching between Hercules and CGA modes.
+*        * The PC 2 and XT have 768K of memory that can be configured from the BIOS setup as 640K, 640K+128K EMS and 512K+256K EMS. The EMS options are not visible in our emulation and loading the EMS driver fails. 
+*   	   See http://forum.classic-computing.de/index.php?page=Thread&threadID=8380 for screenshots.
+*        * use correct AT style keyboard for XT
+*
+*****************************************************************************************************/
 
+#include "emu.h"
 #include "cpu/i86/i86.h"
 #include "bus/isa/aga.h"
 #include "machine/genpc.h"
@@ -486,6 +512,7 @@ static MACHINE_CONFIG_START( cfg_builtin_720K )
 	MCFG_SLOT_DEFAULT_OPTION("")
 MACHINE_CONFIG_END
 
+//Euro PC
 static MACHINE_CONFIG_START( europc )
 	MCFG_CPU_ADD("maincpu", I8088, 4772720*2)
 	MCFG_CPU_PROGRAM_MAP(europc_map)
@@ -496,27 +523,73 @@ static MACHINE_CONFIG_START( europc )
 
 	MCFG_ISA8_SLOT_ADD("mb:isa", "isa1", pc_isa8_cards, "aga", false)
 	MCFG_ISA8_SLOT_ADD("mb:isa", "isa2", pc_isa8_cards, "lpt", false)
+	MCFG_SLOT_FIXED(true)
 	MCFG_ISA8_SLOT_ADD("mb:isa", "isa3", pc_isa8_cards, "com", false)
+	MCFG_SLOT_FIXED(true)
 	MCFG_ISA8_SLOT_ADD("mb:isa", "isa4", pc_isa8_cards, "fdc_xt", false)
 	MCFG_SLOT_OPTION_MACHINE_CONFIG("fdc_xt", cfg_builtin_720K)
-
+	MCFG_SLOT_FIXED(true)
 	MCFG_PC_KEYB_ADD("pc_keyboard", DEVWRITELINE("mb:pic8259", pic8259_device, ir1_w))
 
 	MCFG_NVRAM_ADD_0FILL("nvram");
 
 	/* internal ram */
 	MCFG_RAM_ADD(RAM_TAG)
-	MCFG_RAM_DEFAULT_SIZE("640K")
-	MCFG_RAM_EXTRA_OPTIONS("64K, 128K, 256K, 512K")
+	MCFG_RAM_DEFAULT_SIZE("512K")
+	MCFG_RAM_EXTRA_OPTIONS("256K, 640K") // Machine came with 512K standard, 640K via expansion card, but BIOS offers 256K as well
 
 	/* software lists */
 	MCFG_SOFTWARE_LIST_ADD("disk_list", "ibm5150")
 MACHINE_CONFIG_END
 
+//Euro PC II
+static MACHINE_CONFIG_DERIVED ( europc2, europc )
+	MCFG_DEVICE_MODIFY(RAM_TAG)
+	MCFG_RAM_DEFAULT_SIZE("768K") // could be configured by the BIOS as 640K, 640K+128K EMS or 512K+256K EMS
+MACHINE_CONFIG_END
+
+//Euro XT
+static MACHINE_CONFIG_DERIVED ( euroxt, europc )
+	MCFG_DEVICE_MODIFY(RAM_TAG)
+	MCFG_RAM_DEFAULT_SIZE("768K")
+	MCFG_DEVICE_MODIFY("isa2")
+	MCFG_SLOT_DEFAULT_OPTION(nullptr)
+	MCFG_ISA8_SLOT_ADD("mb:isa", "isa5", pc_isa8_cards, "xtide", false)
+	MCFG_SLOT_FIXED(true)
+	MCFG_ISA8_SLOT_ADD("mb:isa", "isa6", pc_isa8_cards, "lpt", false)
+	MCFG_SLOT_FIXED(true)
+MACHINE_CONFIG_END
+
 ROM_START( europc )
 	ROM_REGION(0x10000,"bios", 0)
 	// hdd bios integrated!
-	ROM_LOAD("50145", 0x8000, 0x8000, CRC(1775a11d) SHA1(54430d4d0462860860397487c9c109e6f70db8e3)) // V2.07
+	ROM_SYSTEM_BIOS( 0, "v2.06", "EuroPC v2.06" )
+	ROMX_LOAD("bios_v2.06.bin", 0x8000, 0x8000, CRC(0a25a2eb) SHA1(d35f2f483d56b1eff558586e1d33d82f7efed639), ROM_BIOS(1))
+	ROM_SYSTEM_BIOS( 1, "v2.06b", "EuroPC v2.06b" )
+	ROMX_LOAD("bios_v2.06b.bin", 0x8000, 0x8000, CRC(05d8a4c2) SHA1(52c6fd22fb739e29a1f0aa3c96ede79cdc659f72), ROM_BIOS(2))
+	ROM_SYSTEM_BIOS( 2, "v2.07", "EuroPC v2.07" )
+	ROMX_LOAD("50145", 0x8000, 0x8000, CRC(1775a11d) SHA1(54430d4d0462860860397487c9c109e6f70db8e3), ROM_BIOS(3))
+	ROM_SYSTEM_BIOS( 3, "v2.08", "EuroPC v2.08" )
+	ROMX_LOAD("bios_v2.08a.bin", 0x8000, 0x8000, CRC(a7048349) SHA1(c2a0af7276c2ff6925abe5a5edef09c5a84106f2), ROM_BIOS(4))
+	ROM_SYSTEM_BIOS( 4, "v2.08a", "EuroPC v2.08a" )
+	ROMX_LOAD("bios_v2.08a.bin", 0x8000, 0x8000, CRC(872520b7) SHA1(9c94d33c0d454fab7bcd0c4516b50f1c3c6a30b8), ROM_BIOS(5))
+	// ROM_SYSTEM_BIOS( 5, "v2.05", "EuroPC v2.05" )
+	// ROMX_LOAD("bios_2.05.bin", 0x8000, 0x8000, CRC(372ceed6) SHA1(bb3d3957a22422f98be2225bdc47705bcab96f56), ROM_BIOS(6)) // does not work, see comment section
 ROM_END
 
+ROM_START( europc2 )
+	ROM_REGION(0x10000,"bios", 0)
+	// hdd bios integrated!
+	ROM_LOAD("europcii_bios_v3.01_500145.bin", 0x8000, 0x8000, CRC(ecca89c8) SHA1(802b89babdf0ab0a0a9c21d1234e529c8386d6fb))
+ROM_END
+
+ROM_START( euroxt )
+	ROM_REGION(0x10000,"bios", 0)
+	// hdd bios integrated!
+	ROM_LOAD("euroxt_bios_v1.01.bin", 0x8000, 0x8000, CRC(1e1fe931) SHA1(bb7cae224d66ae48045f323ecb9ad59bf49ed0a2))
+ROM_END
+
+//    YEAR  NAME        PARENT      COMPAT      MACHINE     INPUT   STATE                INIT        COMPANY              FULLNAME        FLAGS
 COMP( 1988, europc,     ibm5150,    0,          europc,     europc, europc_pc_state,     europc,     "Schneider Rdf. AG", "EURO PC", MACHINE_NOT_WORKING)
+COMP( 198?, europc2,    ibm5150,    0,         europc2,     europc, europc_pc_state,     europc,     "Schneider Rdf. AG", "EURO PC II", MACHINE_NOT_WORKING)
+COMP( 198?, euroxt,     ibm5150,    0,          euroxt,     europc, europc_pc_state,     europc,     "Schneider Rdf. AG", "EURO XT", MACHINE_NOT_WORKING)

--- a/src/mame/mame.lst
+++ b/src/mame/mame.lst
@@ -12251,6 +12251,8 @@ waveterm                        //
 
 @source:europc.cpp
 europc                          // 1988 Schneider Euro PC (CGA or Hercules)
+europc2							// 1989 Schneider Euro PC II
+euroxt							// Schneider Euro XT
 
 @source:eva.cpp
 eva11                           //


### PR DESCRIPTION
size on EuroPC and slot configuration. EMS memory doesn't work on EuroPC II and XT (should be able to be configured from the BIOS, but options don't show up, DOS EMS driver doesn't load).