### PR TITLE
Added basic stub layout with drive LEDs

### DIFF
--- a/src/mame/drivers/kdt6.cpp
+++ b/src/mame/drivers/kdt6.cpp
@@ -29,6 +29,7 @@
 #include "screen.h"
 #include "speaker.h"
 #include "softlist.h"
+#include "kdt6.lh"
 
 
 //**************************************************************************
@@ -618,6 +619,7 @@ static MACHINE_CONFIG_START( psi98 )
 	MCFG_SCREEN_UPDATE_DRIVER(kdt6_state, screen_update)
 
 	MCFG_PALETTE_ADD_MONOCHROME("palette")
+	MCFG_DEFAULT_LAYOUT(layout_kdt6)
 
 	MCFG_MC6845_ADD("crtc", MC6845, "screen", XTAL_13_5168MHz / 8)
 	MCFG_MC6845_SHOW_BORDER_AREA(false)

--- a/src/mame/layout/kdt6.lay
+++ b/src/mame/layout/kdt6.lay
@@ -1,0 +1,41 @@
+<?xml version="1.0"?>
+<mamelayout version="2">
+	<element name="driveled" defstate="0">
+		<rect state="1">
+			<color red="0.75" green="0.0" blue="0.0" />
+		</rect>
+		<rect state="0">
+			<color red="0.20" green="0.0" blue="0.0" />
+		</rect>
+	</element>
+
+	<element name="DRIVE0">
+		<text string="A">
+			<color red="1.0" green="1.0" blue="1.0" />
+		</text>
+	</element>
+	<element name="DRIVE1">
+		<text string="B">
+			<color red="1.0" green="1.0" blue="1.0" />
+		</text>
+	</element>
+	
+	<view name="Default Layout">
+		<screen index="0">
+			<bounds x="61" y="0" width="1024" height="768" />
+		</screen>
+		<bezel name="drive0_led" element="driveled">
+			<bounds x="15" y="3" width="10" height="10" />
+		</bezel>
+		<bezel name="drive1_led" element="driveled">
+			<bounds x="15" y="18" width="10" height="10" />
+		</bezel>
+			<bezel name="label20" element="DRIVE0">
+			<bounds x="0" y="0" width="15" height="16" />
+		</bezel>
+		<bezel name="label21" element="DRIVE1">
+			<bounds x="0" y="14" width="15" height="16" />
+		</bezel>
+		
+	</view>
+</mamelayout>


### PR DESCRIPTION
A more elaborate layout with a photo bezel and properly positioned drive LEDs is available.