### PR TITLE
eeprom: don't check endianness (nw)

### DIFF
--- a/src/devices/machine/eeprom.cpp
+++ b/src/devices/machine/eeprom.cpp
@@ -258,8 +258,8 @@ void eeprom_base_device::nvram_default()
 			fatalerror("eeprom region '%s' wrong size (expected size = 0x%X)\n", tag(), eeprom_bytes);
 		if (m_data_bits == 8 && m_region->bytewidth() != 1)
 			fatalerror("eeprom region '%s' needs to be an 8-bit region\n", tag());
-		if (m_data_bits == 16 && (m_region->bytewidth() != 2 || m_region->endianness() != ENDIANNESS_BIG))
-			fatalerror("eeprom region '%s' needs to be a 16-bit big-endian region\n", tag());
+		if (m_data_bits == 16 && m_region->bytewidth() != 2)
+			fatalerror("eeprom region '%s' needs to be a 16-bit region\n", tag());
 		osd_printf_verbose("Loading data from EEPROM region '%s'\n", tag());
 
 		memcpy(&m_data[0], m_region->base(), eeprom_bytes);


### PR DESCRIPTION
I don't know why this check for endianness is here, but I don't believe it's appropriate.