### PR TITLE
m68k: fix another nbcd mistake

### DIFF
--- a/src/devices/cpu/m68000/m68k_in.cpp
+++ b/src/devices/cpu/m68000/m68k_in.cpp
@@ -7610,7 +7610,7 @@ M68KMAKE_OP(mull, 32, ., .)
 M68KMAKE_OP(nbcd, 8, ., d)
 {
 	uint32_t* r_dst = &DY(mc68kcpu);
-	uint32_t dst = *r_dst;
+	uint32_t dst = MASK_OUT_ABOVE_8(*r_dst);
 	uint32_t res = -dst - XFLAG_1(mc68kcpu);
 
 	if(res != 0)


### PR DESCRIPTION
Verified on 68000 with an updated bcd-verifier:
https://github.com/flamewing/68k-bcd-verifier/pull/1
Megadrive ROM:
http://notaz.gp2x.de/md/rel/bcd-verifier-u1.zip