### PR TITLE
coco_cart.xml: flagged banked games as not supported, causing an alert

### DIFF
--- a/hash/coco_cart.xml
+++ b/hash/coco_cart.xml
@@ -929,7 +929,7 @@ Compiled by K1W1 and Cowering (from GoodCoCo)
 		</part>
 	</software>
 
-	<software name="mindroll">
+	<software name="mindroll" supported="no">
 	<!-- This cartridge contains the CoCo 1/2 & the CoCo 3 versions  -->
 		<description>Mind-Roll</description>
 		<year>1988</year>
@@ -1069,7 +1069,7 @@ Compiled by K1W1 and Cowering (from GoodCoCo)
 		</part>
 	</software>
 
-	<software name="predator">
+	<software name="predator" supported="no">
 		<description>Predator</description>
 		<year>1989</year>
 		<publisher>Tandy</publisher>
@@ -1151,7 +1151,7 @@ Compiled by K1W1 and Cowering (from GoodCoCo)
 		</part>
 	</software>
 
-	<software name="robocop">
+	<software name="robocop" supported="no">
 		<description>RoboCop</description>
 		<year>1988</year>
 		<publisher>Tandy</publisher>


### PR DESCRIPTION
There are some code written to support banked games but there is no link to the softlist. I guess the interface="coco_cart" should be changed to interface="coco_banked_cart" and there is some code needed to make that connection. This assumes however that all banked games are using the same technique or we need to map carts to more unique drivers. Looks like @tlindner has started something here :)