### PR TITLE
dynax.cpp: (tenkai) fix credits lost after exiting the game.

### DIFF
--- a/src/mame/drivers/dynax.cpp
+++ b/src/mame/drivers/dynax.cpp
@@ -1259,8 +1259,7 @@ WRITE8_MEMBER(dynax_state::tenkai_blit_romregion_w)
 
 static ADDRESS_MAP_START( tenkai_map, AS_PROGRAM, 8, dynax_state )
 	AM_RANGE(  0x0000,  0x5fff ) AM_ROM
-	AM_RANGE(  0x6000,  0x6fff ) AM_RAM
-	AM_RANGE(  0x7000,  0x7fff ) AM_RAM AM_SHARE("nvram")
+	AM_RANGE(  0x6000,  0x7fff ) AM_RAM AM_SHARE("nvram")
 	AM_RANGE(  0x8000,  0xffff ) AM_DEVICE("bankdev", address_map_bank_device, amap8)
 	AM_RANGE( 0x10000, 0x10000 ) AM_DEVREAD("aysnd", ay8910_device, data_r)       // AY8910
 	AM_RANGE( 0x10008, 0x10008 ) AM_DEVWRITE("aysnd", ay8910_device, data_w) //


### PR DESCRIPTION
The game checks for the the string "A WARNING.IF YOU COPY OUR ITEMS,WE REVENGE BY ALL MEANS." at address 0x6E17, and will reset everything if the string does not match when the game starts.

In the current implementation only 0x7000-0x7fff is saved as nvram after exiting the game, which will cause the string to be lost.

I'm not sure what the exact nvram address is, but at least this works.