### PR TITLE
mc68901 : fix TCDCR register

### DIFF
--- a/src/devices/machine/mc68901.cpp
+++ b/src/devices/machine/mc68901.cpp
@@ -789,7 +789,7 @@ void mc68901_device::register_w(offs_t offset, uint8_t data)
 		break;
 
 	case REGISTER_TCDCR:
-		m_tcdcr = data & 0x6f;
+		m_tcdcr = data & 0x77;
 
 		switch (m_tcdcr & 0x07)
 		{


### PR DESCRIPTION
bits 6-4 are used for timer C
bits 2-0 are used for timer D

https://www.nxp.com/docs/en/reference-manual/MC68901UM.pdf page 43
Signed-off-by: Nicolas PLANEL <nplanel@redhat.com>