### PR TITLE
Fix main interrupt flag.

### DIFF
--- a/src/devices/machine/mc146818.cpp
+++ b/src/devices/machine/mc146818.cpp
@@ -489,7 +489,7 @@ void mc146818_device::update_irq()
 	}
 	else
 	{
-		m_data[REG_C] &= REG_C_IRQF;
+		m_data[REG_C] &= ~REG_C_IRQF;
 		m_write_irq(ASSERT_LINE);
 	}
 }


### PR DESCRIPTION
Bit masking error : The flag wasn't cleared properly and others flags are corrupted.
