### PR TITLE
EuroPC: Added first and last known BIOS versions

### DIFF
--- a/src/mame/drivers/europc.cpp
+++ b/src/mame/drivers/europc.cpp
@@ -13,6 +13,7 @@
 * Euro XT: conventional desktop, specs like Euro PC II, two ISA slots on a riser card, 102 key seperate keyboard, internal XT-IDE 20MB harddisk, connector for FD360 and FD720 was retained
 *
 * Only BIOS versions >2.06 are supported so far because of changes in the memory management, according to https://www.forum64.de/index.php?thread/43066-schneider-euro-pc-i-ii-xt-welche-bios-version-habt-ihr/
+* Versions 2.04 and 2.05 only show a single dash on the top left of the screen.
 *
 * To get rid of the BIOS error messages when you first start the system, enter the BIOS with Ctrl-Alt-Esc, match the RAM size to your settings in MAME, set the CPU speed to 9.54MHz
 * and the graphics adapter to Color/Graphics 80, internal graphics off

--- a/src/mame/drivers/europc.cpp
+++ b/src/mame/drivers/europc.cpp
@@ -13,7 +13,6 @@
 * Euro XT: conventional desktop, specs like Euro PC II, two ISA slots on a riser card, 102 key seperate keyboard, internal XT-IDE 20MB harddisk, connector for FD360 and FD720 was retained
 *
 * Only BIOS versions >2.06 are supported so far because of changes in the memory management, according to https://www.forum64.de/index.php?thread/43066-schneider-euro-pc-i-ii-xt-welche-bios-version-habt-ihr/
-* BIOS version 2.04 has been encountered, but is not available online
 *
 * To get rid of the BIOS error messages when you first start the system, enter the BIOS with Ctrl-Alt-Esc, match the RAM size to your settings in MAME, set the CPU speed to 9.54MHz
 * and the graphics adapter to Color/Graphics 80, internal graphics off
@@ -24,6 +23,7 @@
 *        * The PC 2 and XT have 768K of memory that can be configured from the BIOS setup as 640K, 640K+128K EMS and 512K+256K EMS. The EMS options are not visible in our emulation and loading the EMS driver fails.
 *          See http://forum.classic-computing.de/index.php?page=Thread&threadID=8380 for screenshots.
 *        * use correct AT style keyboard for XT
+*        * make BIOS versions v2.04 and v2.05 work
 *
 *****************************************************************************************************/
 
@@ -573,9 +573,13 @@ ROM_START( europc )
 	ROMX_LOAD("bios_v2.08.bin", 0x8000, 0x8000, CRC(a7048349) SHA1(c2a0af7276c2ff6925abe5a5edef09c5a84106f2), ROM_BIOS(4))
 	ROM_SYSTEM_BIOS( 4, "v2.08a", "EuroPC v2.08a" )
 	ROMX_LOAD("bios_v2.08a.bin", 0x8000, 0x8000, CRC(872520b7) SHA1(9c94d33c0d454fab7bcd0c4516b50f1c3c6a30b8), ROM_BIOS(5))
-	// ROM_SYSTEM_BIOS( 5, "v2.05", "EuroPC v2.05" )
-	// ROMX_LOAD("bios_2.05.bin", 0x8000, 0x8000, CRC(372ceed6) SHA1(bb3d3957a22422f98be2225bdc47705bcab96f56), ROM_BIOS(6)) // does not work, see comment section
-ROM_END
+	ROM_SYSTEM_BIOS( 5, "v2.08b", "EuroPC v2.08b" )
+ 	ROMX_LOAD("bios_v2.08b.bin", 0x8000, 0x8000, CRC(668c0d19) SHA1(69412e58e0ed1d141e633f094af91ec5f7ae064b), ROM_BIOS(6))
+ 	ROM_SYSTEM_BIOS( 6, "v2.04", "EuroPC v2.04" )
+ 	ROMX_LOAD("bios_v2.04.bin", 0x8000, 0x8000, CRC(e623967c) SHA1(5196b14018da1f3198e2950af0e6eab41425f556), ROM_BIOS(7))
+ 	ROM_SYSTEM_BIOS( 7, "v2.05", "EuroPC v2.05" )
+ 	ROMX_LOAD("bios_2.05.bin", 0x8000, 0x8000, CRC(372ceed6) SHA1(bb3d3957a22422f98be2225bdc47705bcab96f56), ROM_BIOS(8)) // v2.04 and v2.05 don't work yet, , see comment section
+ ROM_END
 
 ROM_START( europc2 )
 	ROM_REGION(0x10000,"bios", 0)


### PR DESCRIPTION
I never saw an earlier or later BIOS version mentioned for the original EuroPC in a discussion thread.
The 2.04 (and also the 2.05 that is already in MAME) don't work for now because according to one site memory management has been changed afterwards. They just show a dash on the top left of the screen.