### PR TITLE
Create common inline functions for parity checking (nw)

### DIFF
--- a/src/devices/cpu/alto2/a2mem.cpp
+++ b/src/devices/cpu/alto2/a2mem.cpp
@@ -290,19 +290,10 @@
  * @param val 32 bits
  * @return 1 for even parity, 0 for odd parity
  */
-static __inline uint8_t parity_even(uint32_t val)
-{
-	val -= ((val >> 1) & 0x55555555);
-	val = (((val >> 2) & 0x33333333) + (val & 0x33333333));
-	val = (((val >> 4) + val) & 0x0f0f0f0f);
-	val += (val >> 8);
-	val += (val >> 16);
-	// val now has number of 1 bits
-	return val & 1;
-}
+#define parity_even(val) (parity_32(val) ? 0 : 1)
 
 /** @brief Return odd parity of a (masked) 32 bit value. */
-#define parity_odd(val) (parity_even(val)^1)
+#define parity_odd(val) (parity_32(val) ? 1 : 0)
 
 /**
  * @brief Lookup table to convert a Hamming syndrome into a bit number to correct.

--- a/src/devices/cpu/i386/i386.cpp
+++ b/src/devices/cpu/i386/i386.cpp
@@ -139,7 +139,6 @@ device_memory_interface::space_config_vector i386_device::memory_space_config() 
 	};
 }
 
-int i386_parity_table[256];
 MODRM_TABLE i386_MODRM_table[256];
 
 #define FAULT(fault,error) {m_ext = 1; i386_trap_with_error(fault,0,0,error); return;}
@@ -3215,7 +3214,6 @@ void i386_device::i386_postload()
 
 void i386_device::i386_common_init()
 {
-	int i, j;
 	static const int regs8[8] = {AL,CL,DL,BL,AH,CH,DH,BH};
 	static const int regs16[8] = {AX,CX,DX,BX,SP,BP,SI,DI};
 	static const int regs32[8] = {EAX,ECX,EDX,EBX,ESP,EBP,ESI,EDI};
@@ -3224,16 +3222,8 @@ void i386_device::i386_common_init()
 
 	build_cycle_table();
 
-	for( i=0; i < 256; i++ ) {
-		int c=0;
-		for( j=0; j < 8; j++ ) {
-			if( i & (1 << j) )
-				c++;
-		}
-		i386_parity_table[i] = ~(c & 0x1) & 0x1;
-	}
-
-	for( i=0; i < 256; i++ ) {
+	for (int i = 0; i < 256; i++)
+	{
 		i386_MODRM_table[i].reg.b = regs8[(i >> 3) & 0x7];
 		i386_MODRM_table[i].reg.w = regs16[(i >> 3) & 0x7];
 		i386_MODRM_table[i].reg.d = regs32[(i >> 3) & 0x7];

--- a/src/devices/cpu/i386/i386priv.h
+++ b/src/devices/cpu/i386/i386priv.h
@@ -287,8 +287,6 @@ union MMX_REG {
 	int64_t  l;
 };
 
-extern int i386_parity_table[256];
-
 #define FAULT_THROW(fault,error) { throw (uint64_t)(fault | (uint64_t)error << 32); }
 #define PF_THROW(error) { m_cr[2] = address; FAULT_THROW(FAULT_PF,error); }
 
@@ -313,11 +311,11 @@ extern int i386_parity_table[256];
 #define SetSF(x)            (m_SF = (x))
 #define SetZF(x)            (m_ZF = (x))
 #define SetAF(x,y,z)        (m_AF = (((x) ^ ((y) ^ (z))) & 0x10) ? 1 : 0)
-#define SetPF(x)            (m_PF = i386_parity_table[(x) & 0xFF])
+#define SetPF(x)            (m_PF = parity_8((x) & 0xff) ? 0 : 1)
 
-#define SetSZPF8(x)         {m_ZF = ((uint8_t)(x)==0);  m_SF = ((x)&0x80) ? 1 : 0; m_PF = i386_parity_table[x & 0xFF]; }
-#define SetSZPF16(x)        {m_ZF = ((uint16_t)(x)==0);  m_SF = ((x)&0x8000) ? 1 : 0; m_PF = i386_parity_table[x & 0xFF]; }
-#define SetSZPF32(x)        {m_ZF = ((uint32_t)(x)==0);  m_SF = ((x)&0x80000000) ? 1 : 0; m_PF = i386_parity_table[x & 0xFF]; }
+#define SetSZPF8(x)         {m_ZF = ((uint8_t)(x)==0);  m_SF = ((x)&0x80) ? 1 : 0; m_PF = parity_8(x & 0xff) ? 0 : 1; }
+#define SetSZPF16(x)        {m_ZF = ((uint16_t)(x)==0);  m_SF = ((x)&0x8000) ? 1 : 0; m_PF = parity_8(x & 0xff) ? 0 : 1; }
+#define SetSZPF32(x)        {m_ZF = ((uint32_t)(x)==0);  m_SF = ((x)&0x80000000) ? 1 : 0; m_PF = parity_8(x & 0xff) ? 0 : 1; }
 
 #define MMX(n)              (*((MMX_REG *)(&m_x87_reg[(n)].low)))
 #define XMM(n)              m_sse_reg[(n)]

--- a/src/devices/cpu/i8008/i8008.cpp
+++ b/src/devices/cpu/i8008/i8008.cpp
@@ -95,27 +95,6 @@ void i8008_device::device_start()
 
 	for (int addrnum = 0; addrnum < 8; addrnum++)
 		state_add(I8008_ADDR1 + addrnum, string_format("ADDR%d", addrnum + 1).c_str(), m_ADDR[addrnum].w.l).mask(0xfff);
-
-	init_tables();
-}
-
-void i8008_device::init_tables (void)
-{
-	int i;
-	uint8_t p;
-	for (i = 0; i < 256; i++)
-	{
-		p = 0;
-		if (BIT(i,0)) p++;
-		if (BIT(i,1)) p++;
-		if (BIT(i,2)) p++;
-		if (BIT(i,3)) p++;
-		if (BIT(i,4)) p++;
-		if (BIT(i,5)) p++;
-		if (BIT(i,6)) p++;
-		if (BIT(i,7)) p++;
-		m_PARITY[i] = ((p&1) ? 0 : 1);
-	}
 }
 
 //-------------------------------------------------
@@ -669,7 +648,7 @@ inline void i8008_device::update_flags(uint8_t val)
 {
 	m_ZF = (val == 0) ? 1 : 0;
 	m_SF = (val & 0x80) ? 1 : 0;
-	m_PF = m_PARITY[val];
+	m_PF = parity_8(val) ? 0 : 1;
 }
 
 inline uint8_t i8008_device::do_condition(uint8_t val)

--- a/src/devices/cpu/i8008/i8008.h
+++ b/src/devices/cpu/i8008/i8008.h
@@ -61,7 +61,6 @@ protected:
 	uint16_t get_addr();
 	void illegal(uint8_t opcode);
 	void take_interrupt();
-	void init_tables(void);
 
 	int m_pc_pos; // PC position in ADDR
 	int m_icount;
@@ -81,8 +80,6 @@ protected:
 	uint8_t   m_flags; // temporary I/O only
 
 	uint8_t   m_irq_state;
-
-	uint8_t m_PARITY[256];
 
 	address_space *m_program;
 	address_space *m_io;

--- a/src/devices/cpu/i8085/i8085.cpp
+++ b/src/devices/cpu/i8085/i8085.cpp
@@ -887,28 +887,17 @@ void i8085a_cpu_device::execute_run()
 
 void i8085a_cpu_device::init_tables()
 {
-	uint8_t zs;
-	int i, p;
-	for (i = 0; i < 256; i++)
+	for (int i = 0; i < 256; i++)
 	{
 		/* cycles */
 		lut_cycles[i] = m_cputype?lut_cycles_8085[i]:lut_cycles_8080[i];
 
 		/* flags */
-		zs = 0;
+		uint8_t zs = 0;
 		if (i==0) zs |= ZF;
 		if (i&128) zs |= SF;
-		p = 0;
-		if (i&1) ++p;
-		if (i&2) ++p;
-		if (i&4) ++p;
-		if (i&8) ++p;
-		if (i&16) ++p;
-		if (i&32) ++p;
-		if (i&64) ++p;
-		if (i&128) ++p;
 		ZS[i] = zs;
-		ZSP[i] = zs | ((p&1) ? 0 : PF);
+		ZSP[i] = zs | (parity_8(i) ? 0 : PF);
 	}
 }
 

--- a/src/devices/cpu/i86/i86.cpp
+++ b/src/devices/cpu/i86/i86.cpp
@@ -324,17 +324,6 @@ i8086_common_cpu_device::i8086_common_cpu_device(const machine_config &mconfig, 
 {
 	static const BREGS reg_name[8]={ AL, CL, DL, BL, AH, CH, DH, BH };
 
-	/* Set up parity lookup table. */
-	for (uint16_t i = 0;i < 256; i++)
-	{
-		uint16_t c = 0;
-		for (uint16_t j = i; j > 0; j >>= 1)
-		{
-			if (j & 1) c++;
-		}
-		m_parity_table[i] = !(c & 1);
-	}
-
 	for (uint16_t i = 0; i < 256; i++)
 	{
 		m_Mod_RM.reg.b[i] = reg_name[(i & 0x38) >> 3];

--- a/src/devices/cpu/i86/i86.h
+++ b/src/devices/cpu/i86/i86.h
@@ -335,7 +335,6 @@ protected:
 	uint32_t  m_pc;
 
 	// Lookup tables
-	uint8_t m_parity_table[256];
 	struct {
 		struct {
 			int w[256];

--- a/src/devices/cpu/i86/i86inline.h
+++ b/src/devices/cpu/i86/i86inline.h
@@ -5,7 +5,7 @@
 #define CF      (m_CarryVal!=0)
 #define SF      (m_SignVal<0)
 #define ZF      (m_ZeroVal==0)
-#define PF      m_parity_table[(uint8_t)m_ParityVal]
+#define PF      !parity_8(m_ParityVal)
 #define AF      (m_AuxVal!=0)
 #define OF      (m_OverVal!=0)
 

--- a/src/devices/cpu/mcs51/mcs51.cpp
+++ b/src/devices/cpu/mcs51/mcs51.cpp
@@ -844,16 +844,7 @@ void mcs51_cpu_device::pop_pc()
 void mcs51_cpu_device::set_parity()
 {
 	//This flag will be set when the accumulator contains an odd # of bits set..
-	uint8_t p = 0;
-	int i;
-	uint8_t a = ACC;
-
-	for (i=0; i<8; i++) {       //Test for each of the 8 bits in the ACC!
-		p ^= (a & 1);
-		a = (a >> 1);
-	}
-
-	SET_P(p & 1);
+	SET_P(parity_8(ACC));
 }
 
 uint8_t mcs51_cpu_device::bit_address_r(uint8_t offset)

--- a/src/devices/cpu/nec/nec.cpp
+++ b/src/devices/cpu/nec/nec.cpp
@@ -233,8 +233,6 @@ uint16_t nec_common_device::fetchword()
 #include "necea.h"
 #include "necmodrm.h"
 
-static uint8_t parity_table[256];
-
 uint8_t nec_common_device::fetchop()
 {
 	prefetch();
@@ -357,25 +355,16 @@ void nec_common_device::execute_set_input(int irqline, int state)
 
 void nec_common_device::device_start()
 {
-	unsigned int i, j, c;
-
 	static const WREGS wreg_name[8]={ AW, CW, DW, BW, SP, BP, IX, IY };
 	static const BREGS breg_name[8]={ AL, CL, DL, BL, AH, CH, DH, BH };
 
-	for (i = 0; i < 256; i++)
-	{
-		for (j = i, c = 0; j > 0; j >>= 1)
-			if (j & 1) c++;
-		parity_table[i] = !(c & 1);
-	}
-
-	for (i = 0; i < 256; i++)
+	for (int i = 0; i < 256; i++)
 	{
 		Mod_RM.reg.b[i] = breg_name[(i & 0x38) >> 3];
 		Mod_RM.reg.w[i] = wreg_name[(i & 0x38) >> 3];
 	}
 
-	for (i = 0xc0; i < 0x100; i++)
+	for (int i = 0xc0; i < 0x100; i++)
 	{
 		Mod_RM.RM.w[i] = wreg_name[i & 7];
 		Mod_RM.RM.b[i] = breg_name[i & 7];

--- a/src/devices/cpu/nec/necpriv.h
+++ b/src/devices/cpu/nec/necpriv.h
@@ -46,7 +46,7 @@ enum BREGS {
 #define CF      (m_CarryVal!=0)
 #define SF      (m_SignVal<0)
 #define ZF      (m_ZeroVal==0)
-#define PF      parity_table[(BYTE)m_ParityVal]
+#define PF      !parity_8(m_ParityVal)
 #define AF      (m_AuxVal!=0)
 #define OF      (m_OverVal!=0)
 

--- a/src/devices/cpu/nec/v25.cpp
+++ b/src/devices/cpu/nec/v25.cpp
@@ -154,8 +154,6 @@ uint16_t v25_common_device::fetchword()
 #include "necea.h"
 #include "necmodrm.h"
 
-static uint8_t parity_table[256];
-
 uint8_t v25_common_device::fetchop()
 {
 	uint8_t ret;
@@ -426,25 +424,16 @@ offs_t v25_common_device::disasm_disassemble(std::ostream &stream, offs_t pc, co
 
 void v25_common_device::device_start()
 {
-	unsigned int i, j, c;
-
 	static const WREGS wreg_name[8]={ AW, CW, DW, BW, SP, BP, IX, IY };
 	static const BREGS breg_name[8]={ AL, CL, DL, BL, AH, CH, DH, BH };
 
-	for (i = 0; i < 256; i++)
-	{
-		for (j = i, c = 0; j > 0; j >>= 1)
-			if (j & 1) c++;
-		parity_table[i] = !(c & 1);
-	}
-
-	for (i = 0; i < 256; i++)
+	for (int i = 0; i < 256; i++)
 	{
 		Mod_RM.reg.b[i] = breg_name[(i & 0x38) >> 3];
 		Mod_RM.reg.w[i] = wreg_name[(i & 0x38) >> 3];
 	}
 
-	for (i = 0xc0; i < 0x100; i++)
+	for (int i = 0xc0; i < 0x100; i++)
 	{
 		Mod_RM.RM.w[i] = wreg_name[i & 7];
 		Mod_RM.RM.b[i] = breg_name[i & 7];
@@ -459,7 +448,7 @@ void v25_common_device::device_start()
 	m_EO = 0;
 	m_E16 = 0;
 
-	for (i = 0; i < 4; i++)
+	for (int i = 0; i < 4; i++)
 		m_timers[i] = machine().scheduler().timer_alloc(timer_expired_delegate(FUNC(v25_common_device::v25_timer_callback),this));
 
 	save_item(NAME(m_ram.w));

--- a/src/devices/cpu/nec/v25priv.h
+++ b/src/devices/cpu/nec/v25priv.h
@@ -102,7 +102,7 @@ enum BREGS {
 #define CF      (m_CarryVal!=0)
 #define SF      (m_SignVal<0)
 #define ZF      (m_ZeroVal==0)
-#define PF      parity_table[(BYTE)m_ParityVal]
+#define PF      !parity_8(m_ParityVal)
 #define AF      (m_AuxVal!=0)
 #define OF      (m_OverVal!=0)
 #define RB      (m_RBW >> 4)

--- a/src/devices/cpu/upd7810/upd7810.cpp
+++ b/src/devices/cpu/upd7810/upd7810.cpp
@@ -951,8 +951,8 @@ void upd7810_device::upd7810_write_TXB()
 	m_txbuf = 1;
 }
 
-#define PAR7(n) ((((n)>>6)^((n)>>5)^((n)>>4)^((n)>>3)^((n)>>2)^((n)>>1)^((n)))&1)
-#define PAR8(n) ((((n)>>7)^((n)>>6)^((n)>>5)^((n)>>4)^((n)>>3)^((n)>>2)^((n)>>1)^((n)))&1)
+#define PAR7(n) (parity_8(n & 0x7f) ? 1 : 0)
+#define PAR8(n) (parity_8(n) ? 1 : 0)
 
 void upd7810_device::upd7810_sio_output()
 {

--- a/src/devices/cpu/v30mz/v30mz.cpp
+++ b/src/devices/cpu/v30mz/v30mz.cpp
@@ -75,7 +75,7 @@ enum BREGS {
 #define CF      (m_CarryVal!=0)
 #define SF      (m_SignVal<0)
 #define ZF      (m_ZeroVal==0)
-#define PF      m_parity_table[(uint8_t)m_ParityVal]
+#define PF      !parity_8(m_ParityVal)
 #define AF      (m_AuxVal!=0)
 #define OF      (m_OverVal!=0)
 #define MD      (m_MF!=0)
@@ -107,17 +107,6 @@ v30mz_cpu_device::v30mz_cpu_device(const machine_config &mconfig, const char *ta
 	, m_pc(0)
 {
 	static const BREGS reg_name[8]={ AL, CL, DL, BL, AH, CH, DH, BH };
-
-	/* Set up parity lookup table. */
-	for (uint16_t i = 0;i < 256; i++)
-	{
-		uint16_t c = 0;
-		for (uint16_t j = i; j > 0; j >>= 1)
-		{
-			if (j & 1) c++;
-		}
-		m_parity_table[i] = !(c & 1);
-	}
 
 	for (uint16_t i = 0; i < 256; i++)
 	{

--- a/src/devices/cpu/v30mz/v30mz.h
+++ b/src/devices/cpu/v30mz/v30mz.h
@@ -208,7 +208,6 @@ protected:
 	uint32_t  m_pc;
 
 	// Lookup tables
-	uint8_t m_parity_table[256];
 	struct {
 		struct {
 			int w[256];

--- a/src/devices/cpu/z180/z180.cpp
+++ b/src/devices/cpu/z180/z180.cpp
@@ -1922,7 +1922,6 @@ void z180_device::z180_write_iolines(uint32_t data)
 
 void z180_device::device_start()
 {
-	int i, p;
 	int oldval, newval, val;
 	uint8_t *padd, *padc, *psub, *psbc;
 
@@ -1976,22 +1975,13 @@ void z180_device::device_start()
 			psbc++;
 		}
 	}
-	for (i = 0; i < 256; i++)
+	for (int i = 0; i < 256; i++)
 	{
-		p = 0;
-		if( i&0x01 ) ++p;
-		if( i&0x02 ) ++p;
-		if( i&0x04 ) ++p;
-		if( i&0x08 ) ++p;
-		if( i&0x10 ) ++p;
-		if( i&0x20 ) ++p;
-		if( i&0x40 ) ++p;
-		if( i&0x80 ) ++p;
 		SZ[i] = i ? i & SF : ZF;
 		SZ[i] |= (i & (YF | XF));       /* undocumented flag bits 5+3 */
 		SZ_BIT[i] = i ? i & SF : ZF | PF;
 		SZ_BIT[i] |= (i & (YF | XF));   /* undocumented flag bits 5+3 */
-		SZP[i] = SZ[i] | ((p & 1) ? 0 : PF);
+		SZP[i] = SZ[i] | (parity_8(i) ? 0 : PF);
 		SZHV_inc[i] = SZ[i];
 		if( i == 0x80 ) SZHV_inc[i] |= VF;
 		if( (i & 0x0f) == 0x00 ) SZHV_inc[i] |= HF;

--- a/src/devices/cpu/z80/z80.cpp
+++ b/src/devices/cpu/z80/z80.cpp
@@ -3319,20 +3319,11 @@ void z80_device::device_start()
 
 		for (int i = 0; i < 256; i++)
 		{
-			int p = 0;
-			if( i&0x01 ) ++p;
-			if( i&0x02 ) ++p;
-			if( i&0x04 ) ++p;
-			if( i&0x08 ) ++p;
-			if( i&0x10 ) ++p;
-			if( i&0x20 ) ++p;
-			if( i&0x40 ) ++p;
-			if( i&0x80 ) ++p;
 			SZ[i] = i ? i & SF : ZF;
 			SZ[i] |= (i & (YF | XF));       /* undocumented flag bits 5+3 */
 			SZ_BIT[i] = i ? i & SF : ZF | PF;
 			SZ_BIT[i] |= (i & (YF | XF));   /* undocumented flag bits 5+3 */
-			SZP[i] = SZ[i] | ((p & 1) ? 0 : PF);
+			SZP[i] = SZ[i] | (parity_8(i) ? 0 : PF);
 			SZHV_inc[i] = SZ[i];
 			if( i == 0x80 ) SZHV_inc[i] |= VF;
 			if( (i & 0x0f) == 0x00 ) SZHV_inc[i] |= HF;

--- a/src/devices/cpu/z8000/z8000tbl.hxx
+++ b/src/devices/cpu/z8000/z8000tbl.hxx
@@ -547,7 +547,7 @@ void z8002_device::init_tables()
 	for (i = 0; i < 256; i++)
 		z8000_zsp[i] = ((i == 0) ? F_Z : 0) |
 						((i & 128) ? F_S : 0) |
-						((((i>>7)^(i>>6)^(i>>5)^(i>>4)^(i>>3)^(i>>2)^(i>>1)^i) & 1) ? 0 : F_PV);
+						(parity_8(i) ? 0 : F_PV);
 
 	/* first set all 64K opcodes to invalid */
 	for (i = 0; i < 0x10000; i++)

--- a/src/emu/diserial.cpp
+++ b/src/emu/diserial.cpp
@@ -35,21 +35,6 @@ device_serial_interface::device_serial_interface(const machine_config &mconfig, 
 	m_tra_clock_state(false),
 	m_rcv_clock_state(false)
 {
-	/* if sum of all bits in the byte is even, then the data
-	has even parity, otherwise it has odd parity */
-	for (int i=0; i<256; i++)
-	{
-		int sum = 0;
-		int data = i;
-
-		for (int b=0; b<8; b++)
-		{
-			sum+=data & 0x01;
-			data = data>>1;
-		}
-
-		m_serial_parity_table[i] = sum & 0x01;
-	}
 }
 
 device_serial_interface::~device_serial_interface()
@@ -317,7 +302,7 @@ void device_serial_interface::receive_register_extract()
 		case PARITY_EVEN:
 		{
 			/* compute parity for received bits */
-			//computed_parity = serial_helper_get_parity(data);
+			//computed_parity = parity_8(data);
 
 			if (m_df_parity == PARITY_ODD)
 			{
@@ -405,7 +390,7 @@ void device_serial_interface::transmit_register_setup(u8 data_byte)
 			/* get parity */
 			/* if parity = 0, data has even parity - i.e. there is an even number of one bits in the data */
 			/* if parity = 1, data has odd parity - i.e. there is an odd number of one bits in the data */
-			parity = serial_helper_get_parity(data_byte);
+			parity = parity_8(data_byte);
 			break;
 		case PARITY_MARK:
 			parity = 1;

--- a/src/emu/diserial.h
+++ b/src/emu/diserial.h
@@ -105,8 +105,6 @@ protected:
 	void transmit_register_setup(u8 data_byte);
 	u8 transmit_register_get_data_bit();
 
-	u8 serial_helper_get_parity(u8 data) { return m_serial_parity_table[data]; }
-
 	bool is_receive_register_full();
 	bool is_transmit_register_empty();
 	bool is_receive_register_synchronized() const { return m_rcv_flags & RECEIVE_REGISTER_SYNCHRONISED; }
@@ -133,8 +131,6 @@ protected:
 private:
 	TIMER_CALLBACK_MEMBER(rcv_clock) { rx_clock_w(!m_rcv_clock_state); }
 	TIMER_CALLBACK_MEMBER(tra_clock) { tx_clock_w(!m_tra_clock_state); }
-
-	u8 m_serial_parity_table[256];
 
 	// Data frame
 	// number of start bits

--- a/src/osd/eminline.h
+++ b/src/osd/eminline.h
@@ -46,14 +46,14 @@
 #endif // !defined(MAME_NOASM)
 
 
-/***************************************************************************
-    INLINE MATH FUNCTIONS
-***************************************************************************/
+//**************************************************************************
+//  INLINE MATH FUNCTIONS
+//**************************************************************************
 
-/*-------------------------------------------------
-    mul_32x32 - perform a signed 32 bit x 32 bit
-    multiply and return the full 64 bit result
--------------------------------------------------*/
+//-------------------------------------------------
+//  mul_32x32 - perform a signed 32 bit x 32 bit
+//  multiply and return the full 64 bit result
+//-------------------------------------------------
 
 #ifndef mul_32x32
 inline int64_t mul_32x32(int32_t a, int32_t b)
@@ -63,11 +63,11 @@ inline int64_t mul_32x32(int32_t a, int32_t b)
 #endif
 
 
-/*-------------------------------------------------
-    mulu_32x32 - perform an unsigned 32 bit x
-    32 bit multiply and return the full 64 bit
-    result
--------------------------------------------------*/
+//-------------------------------------------------
+//  mulu_32x32 - perform an unsigned 32 bit x
+//  32 bit multiply and return the full 64 bit
+//  result
+//-------------------------------------------------
 
 #ifndef mulu_32x32
 inline uint64_t mulu_32x32(uint32_t a, uint32_t b)
@@ -77,11 +77,11 @@ inline uint64_t mulu_32x32(uint32_t a, uint32_t b)
 #endif
 
 
-/*-------------------------------------------------
-    mul_32x32_hi - perform a signed 32 bit x 32 bit
-    multiply and return the upper 32 bits of the
-    result
--------------------------------------------------*/
+//-------------------------------------------------
+//  mul_32x32_hi - perform a signed 32 bit x 32 bit
+//  multiply and return the upper 32 bits of the
+//  result
+//-------------------------------------------------
 
 #ifndef mul_32x32_hi
 inline int32_t mul_32x32_hi(int32_t a, int32_t b)
@@ -91,11 +91,11 @@ inline int32_t mul_32x32_hi(int32_t a, int32_t b)
 #endif
 
 
-/*-------------------------------------------------
-    mulu_32x32_hi - perform an unsigned 32 bit x
-    32 bit multiply and return the upper 32 bits
-    of the result
--------------------------------------------------*/
+//-------------------------------------------------
+//  mulu_32x32_hi - perform an unsigned 32 bit x
+//  32 bit multiply and return the upper 32 bits
+//  of the result
+//-------------------------------------------------
 
 #ifndef mulu_32x32_hi
 inline uint32_t mulu_32x32_hi(uint32_t a, uint32_t b)
@@ -105,12 +105,12 @@ inline uint32_t mulu_32x32_hi(uint32_t a, uint32_t b)
 #endif
 
 
-/*-------------------------------------------------
-    mul_32x32_shift - perform a signed 32 bit x
-    32 bit multiply and shift the result by the
-    given number of bits before truncating the
-    result to 32 bits
--------------------------------------------------*/
+//-------------------------------------------------
+//  mul_32x32_shift - perform a signed 32 bit x
+//  32 bit multiply and shift the result by the
+//  given number of bits before truncating the
+//  result to 32 bits
+//-------------------------------------------------
 
 #ifndef mul_32x32_shift
 inline int32_t mul_32x32_shift(int32_t a, int32_t b, uint8_t shift)
@@ -120,12 +120,12 @@ inline int32_t mul_32x32_shift(int32_t a, int32_t b, uint8_t shift)
 #endif
 
 
-/*-------------------------------------------------
-    mulu_32x32_shift - perform an unsigned 32 bit x
-    32 bit multiply and shift the result by the
-    given number of bits before truncating the
-    result to 32 bits
--------------------------------------------------*/
+//-------------------------------------------------
+//  mulu_32x32_shift - perform an unsigned 32 bit x
+//  32 bit multiply and shift the result by the
+//  given number of bits before truncating the
+//  result to 32 bits
+//-------------------------------------------------
 
 #ifndef mulu_32x32_shift
 inline uint32_t mulu_32x32_shift(uint32_t a, uint32_t b, uint8_t shift)
@@ -135,10 +135,10 @@ inline uint32_t mulu_32x32_shift(uint32_t a, uint32_t b, uint8_t shift)
 #endif
 
 
-/*-------------------------------------------------
-    div_64x32 - perform a signed 64 bit x 32 bit
-    divide and return the 32 bit quotient
--------------------------------------------------*/
+//-------------------------------------------------
+//  div_64x32 - perform a signed 64 bit x 32 bit
+//  divide and return the 32 bit quotient
+//-------------------------------------------------
 
 #ifndef div_64x32
 inline int32_t div_64x32(int64_t a, int32_t b)
@@ -148,10 +148,10 @@ inline int32_t div_64x32(int64_t a, int32_t b)
 #endif
 
 
-/*-------------------------------------------------
-    divu_64x32 - perform an unsigned 64 bit x 32 bit
-    divide and return the 32 bit quotient
--------------------------------------------------*/
+//-------------------------------------------------
+//  divu_64x32 - perform an unsigned 64 bit x 32 bit
+//  divide and return the 32 bit quotient
+//-------------------------------------------------
 
 #ifndef divu_64x32
 inline uint32_t divu_64x32(uint64_t a, uint32_t b)
@@ -161,11 +161,11 @@ inline uint32_t divu_64x32(uint64_t a, uint32_t b)
 #endif
 
 
-/*-------------------------------------------------
-    div_64x32_rem - perform a signed 64 bit x 32
-    bit divide and return the 32 bit quotient and
-    32 bit remainder
--------------------------------------------------*/
+//-------------------------------------------------
+//  div_64x32_rem - perform a signed 64 bit x 32
+//  bit divide and return the 32 bit quotient and
+//  32 bit remainder
+//-------------------------------------------------
 
 #ifndef div_64x32_rem
 inline int32_t div_64x32_rem(int64_t a, int32_t b, int32_t *remainder)
@@ -177,11 +177,11 @@ inline int32_t div_64x32_rem(int64_t a, int32_t b, int32_t *remainder)
 #endif
 
 
-/*-------------------------------------------------
-    divu_64x32_rem - perform an unsigned 64 bit x
-    32 bit divide and return the 32 bit quotient
-    and 32 bit remainder
--------------------------------------------------*/
+//-------------------------------------------------
+//  divu_64x32_rem - perform an unsigned 64 bit x
+//  32 bit divide and return the 32 bit quotient
+//  and 32 bit remainder
+//-------------------------------------------------
 
 #ifndef divu_64x32_rem
 inline uint32_t divu_64x32_rem(uint64_t a, uint32_t b, uint32_t *remainder)
@@ -193,11 +193,11 @@ inline uint32_t divu_64x32_rem(uint64_t a, uint32_t b, uint32_t *remainder)
 #endif
 
 
-/*-------------------------------------------------
-    div_32x32_shift - perform a signed divide of
-    two 32 bit values, shifting the first before
-    division, and returning the 32 bit quotient
--------------------------------------------------*/
+//-------------------------------------------------
+//  div_32x32_shift - perform a signed divide of
+//  two 32 bit values, shifting the first before
+//  division, and returning the 32 bit quotient
+//-------------------------------------------------
 
 #ifndef div_32x32_shift
 inline int32_t div_32x32_shift(int32_t a, int32_t b, uint8_t shift)
@@ -207,11 +207,11 @@ inline int32_t div_32x32_shift(int32_t a, int32_t b, uint8_t shift)
 #endif
 
 
-/*-------------------------------------------------
-    divu_32x32_shift - perform an unsigned divide of
-    two 32 bit values, shifting the first before
-    division, and returning the 32 bit quotient
--------------------------------------------------*/
+//-------------------------------------------------
+//  divu_32x32_shift - perform an unsigned divide of
+//  two 32 bit values, shifting the first before
+//  division, and returning the 32 bit quotient
+//-------------------------------------------------
 
 #ifndef divu_32x32_shift
 inline uint32_t divu_32x32_shift(uint32_t a, uint32_t b, uint8_t shift)
@@ -221,10 +221,10 @@ inline uint32_t divu_32x32_shift(uint32_t a, uint32_t b, uint8_t shift)
 #endif
 
 
-/*-------------------------------------------------
-    mod_64x32 - perform a signed 64 bit x 32 bit
-    divide and return the 32 bit remainder
--------------------------------------------------*/
+//-------------------------------------------------
+//  mod_64x32 - perform a signed 64 bit x 32 bit
+//  divide and return the 32 bit remainder
+//-------------------------------------------------
 
 #ifndef mod_64x32
 inline int32_t mod_64x32(int64_t a, int32_t b)
@@ -234,10 +234,10 @@ inline int32_t mod_64x32(int64_t a, int32_t b)
 #endif
 
 
-/*-------------------------------------------------
-    modu_64x32 - perform an unsigned 64 bit x 32 bit
-    divide and return the 32 bit remainder
--------------------------------------------------*/
+//-------------------------------------------------
+//  modu_64x32 - perform an unsigned 64 bit x 32 bit
+//  divide and return the 32 bit remainder
+//-------------------------------------------------
 
 #ifndef modu_64x32
 inline uint32_t modu_64x32(uint64_t a, uint32_t b)
@@ -247,10 +247,10 @@ inline uint32_t modu_64x32(uint64_t a, uint32_t b)
 #endif
 
 
-/*-------------------------------------------------
-    recip_approx - compute an approximate floating
-    point reciprocal
--------------------------------------------------*/
+//-------------------------------------------------
+//  recip_approx - compute an approximate floating
+//  point reciprocal
+//-------------------------------------------------
 
 #ifndef recip_approx
 inline float recip_approx(float value)
@@ -261,14 +261,14 @@ inline float recip_approx(float value)
 
 
 
-/***************************************************************************
-    INLINE BIT MANIPULATION FUNCTIONS
-***************************************************************************/
+//**************************************************************************
+//  INLINE BIT MANIPULATION FUNCTIONS
+//**************************************************************************
 
-/*-------------------------------------------------
-    count_leading_zeros - return the number of
-    leading zero bits in a 32-bit value
--------------------------------------------------*/
+//-------------------------------------------------
+//  count_leading_zeros - return the number of
+//  leading zero bits in a 32-bit value
+//-------------------------------------------------
 
 #ifndef count_leading_zeros
 inline uint8_t count_leading_zeros(uint32_t val)
@@ -280,10 +280,10 @@ inline uint8_t count_leading_zeros(uint32_t val)
 #endif
 
 
-/*-------------------------------------------------
-    count_leading_ones - return the number of
-    leading one bits in a 32-bit value
--------------------------------------------------*/
+//-------------------------------------------------
+//  count_leading_ones - return the number of
+//  leading one bits in a 32-bit value
+//-------------------------------------------------
 
 #ifndef count_leading_ones
 inline uint8_t count_leading_ones(uint32_t val)
@@ -295,10 +295,61 @@ inline uint8_t count_leading_ones(uint32_t val)
 #endif
 
 
-/*-------------------------------------------------
-    population_count_32 - return the number of
-    one bits in a 32-bit value
--------------------------------------------------*/
+//-------------------------------------------------
+//  parity_8 - check the parity of a 8-bit value
+//  and return true for odd or false for even
+//-------------------------------------------------
+
+#ifndef parity_8
+inline bool parity_8(uint8_t data)
+{
+	data ^= data >> 4;
+	data ^= data >> 2;
+	data ^= data >> 1;
+	return (data & 1) != 0;
+}
+#endif
+
+
+//-------------------------------------------------
+//  parity_16 - check the parity of a 16-bit value
+//  and return true for odd or false for even
+//-------------------------------------------------
+
+#ifndef parity_16
+inline bool parity_16(uint16_t data)
+{
+	data ^= data >> 8;
+	data ^= data >> 4;
+	data ^= data >> 2;
+	data ^= data >> 1;
+	return (data & 1) != 0;
+}
+#endif
+
+
+//-------------------------------------------------
+//  parity_32 - check the parity of a 16-bit value
+//  and return true for odd or false for even
+//-------------------------------------------------
+
+#ifndef parity_32
+inline bool parity_32(uint32_t data)
+{
+	data ^= data >> 16;
+	data ^= data >> 8;
+	data ^= data >> 4;
+	data ^= data >> 2;
+	data ^= data >> 1;
+	return (data & 1) != 0;
+}
+#endif
+
+
+//-------------------------------------------------
+//  population_count_32 - return the number of
+//  one bits in a 32-bit value
+//-------------------------------------------------
 
 #ifndef population_count_32
 #if defined(__NetBSD__)
@@ -326,10 +377,10 @@ inline unsigned population_count_32(uint32_t val)
 #endif
 
 
-/*-------------------------------------------------
-    population_count_64 - return the number of
-    one bits in a 64-bit value
--------------------------------------------------*/
+//-------------------------------------------------
+//  population_count_64 - return the number of
+//  one bits in a 64-bit value
+//-------------------------------------------------
 
 #ifndef population_count_64
 #if defined(__NetBSD__)


### PR DESCRIPTION
I have not tested whether the half-shift/XOR approach adopted here is actually slower or faster than the table lookup method that several CPU cores and diserial were using. (CPUs using lookup tables to determine parity along with other condition flags still do so.) At least it seems better than the naive approach of shifting out every single bit, which was also being used.