### PR TITLE
ygv608: Namco Classic Collection vol.1 & 2 Graphics improvements

### DIFF
--- a/src/mame/video/ygv608.cpp
+++ b/src/mame/video/ygv608.cpp
@@ -970,6 +970,14 @@ inline void ygv608_device::draw_layer_roz(screen_device &screen, bitmap_ind16 &b
 	//int xc, yc;
 	//double r, alpha, sin_theta, cos_theta;
 	//const rectangle &visarea = screen.visible_area();
+	uint32_t sx, sy;
+
+	int ba_select = (source_tilemap == m_tilemap_A) ? 0 : 1;
+
+	sy = (int)m_scroll_data_table[ba_select][0x00] +
+		(((int)m_scroll_data_table[ba_select][0x01] & 0x0f ) << 8);
+	sx = (int)m_scroll_data_table[ba_select][0x80] +
+		(((int)m_scroll_data_table[ba_select][0x81] & 0x0f ) << 8);
 
 	if( m_zron == true )
 	{
@@ -982,8 +990,8 @@ inline void ygv608_device::draw_layer_roz(screen_device &screen, bitmap_ind16 &b
 		//cos_theta = (double)m_dx / (double)0x10000;
 
 		source_tilemap->draw_roz(screen, bitmap, cliprect,
-				m_ax, m_ay,
-				m_dx, m_dxy, m_dyx, m_dy, m_roz_wrap_disable == false, 0, 0 );
+				m_ax + (sx << 16), m_ay + (sy << 16),
+				m_dx, m_dyx, m_dxy, m_dy, m_roz_wrap_disable == false, 0, 0 );
 	}
 	else
 		source_tilemap->draw(screen, bitmap, cliprect, 0, 0 );

--- a/src/mame/video/ygv608.cpp
+++ b/src/mame/video/ygv608.cpp
@@ -512,25 +512,30 @@ TILE_GET_INFO_MEMBER( ygv608_device::get_tile_info_A_8 )
 
 		/* calculate page according to scroll data */
 		/* - assuming full-screen scroll only for now... */
-		sy = (int)m_scroll_data_table[0][translated_column] +
-			(((int)m_scroll_data_table[0][translated_column+1] & 0x0f ) << 8);
-		sx = (int)m_scroll_data_table[0][0x80] +
-			(((int)m_scroll_data_table[0][0x81] & 0x0f ) << 8);
+		if (m_v_div_size) {
+			page = 0;
+		}
+		else {
+			sy = (int)m_scroll_data_table[0][translated_column] +
+			   (((int)m_scroll_data_table[0][translated_column+1] & 0x0f ) << 8);
+			sx = (int)m_scroll_data_table[0][0x80] +
+			   (((int)m_scroll_data_table[0][0x81] & 0x0f ) << 8);
 
-		if (m_md == MD_2PLANE_16BIT)
-		{
-			page = ( ( sx + col * 8 ) % 1024 ) / 256;
-			page += ( ( ( sy + row * 8 ) % 2048 ) / 256 ) * 4;
-		}
-		else if (m_page_size)
-		{
-			page = ( ( sx + col * 8 ) % 2048 ) / 512;
-			page += ( ( ( sy + row * 8 ) % 2048 ) / 256 ) * 4;
-		}
-		else
-		{
-			page = ( ( sx + col * 8 ) % 2048 ) / 256;
-			page += ( ( ( sy + row * 8 ) % 2048 ) / 512 ) * 8;
+			if (m_md == MD_2PLANE_16BIT)
+			{
+				page = ( ( sx + col * 8 ) % 1024 ) / 256;
+				page += ( ( ( sy + row * 8 ) % 2048 ) / 256 ) * 4;
+			}
+			else if (m_page_size)
+			{
+				page = ( ( sx + col * 8 ) % 2048 ) / 512;
+				page += ( ( ( sy + row * 8 ) % 2048 ) / 256 ) * 4;
+			}
+			else
+			{
+				page = ( ( sx + col * 8 ) % 2048 ) / 256;
+				page += ( ( ( sy + row * 8 ) % 2048 ) / 512 ) * 8;
+			}
 		}
 
 		page &= 0x1f;
@@ -610,25 +615,30 @@ TILE_GET_INFO_MEMBER( ygv608_device::get_tile_info_B_8 )
 
 		/* calculate page according to scroll data */
 		/* - assuming full-screen scroll only for now... */
-		sy = (int)m_scroll_data_table[1][translated_column] +
-			(((int)m_scroll_data_table[1][translated_column+1] & 0x0f ) << 8);
-		sx = (int)m_scroll_data_table[1][0x80] +
-			(((int)m_scroll_data_table[1][0x81] & 0x0f ) << 8);
+		if (m_v_div_size) {
+			page = 0;
+		}
+		else {
+			sy = (int)m_scroll_data_table[1][translated_column] +
+			   (((int)m_scroll_data_table[1][translated_column+1] & 0x0f ) << 8);
+			sx = (int)m_scroll_data_table[1][0x80] +
+			   (((int)m_scroll_data_table[1][0x81] & 0x0f ) << 8);
 
-		if (m_md == MD_2PLANE_16BIT )
-		{
-			page = ( ( sx + col * 8 ) % 1024 ) / 256;
-			page += ( ( ( sy + row * 8 ) % 2048 ) / 256 ) * 4;
-		}
-		else if (m_page_size)
-		{
-			page = ( ( sx + col * 8 ) % 2048 ) / 512;
-			page += ( ( ( sy + row * 8 ) % 2048 ) / 256 ) * 4;
-		}
-		else
-		{
-			page = ( ( sx + col * 8 ) % 2048 ) / 256;
-			page += ( ( ( sy + row * 8 ) % 2048 ) / 512 ) * 8;
+			if (m_md == MD_2PLANE_16BIT)
+			{
+				page = ( ( sx + col * 8 ) % 1024 ) / 256;
+				page += ( ( ( sy + row * 8 ) % 2048 ) / 256 ) * 4;
+			}
+			else if (m_page_size)
+			{
+				page = ( ( sx + col * 8 ) % 2048 ) / 512;
+				page += ( ( ( sy + row * 8 ) % 2048 ) / 256 ) * 4;
+			}
+			else
+			{
+				page = ( ( sx + col * 8 ) % 2048 ) / 256;
+				page += ( ( ( sy + row * 8 ) % 2048 ) / 512 ) * 8;
+			}
 		}
 
 		page &= 0x1f;
@@ -706,21 +716,27 @@ TILE_GET_INFO_MEMBER( ygv608_device::get_tile_info_A_16 )
 
 	/* calculate page according to scroll data */
 	/* - assuming full-screen scroll only for now... */
-	sy = (int)m_scroll_data_table[0][translated_column] +
-			(((int)m_scroll_data_table[0][translated_column+1] & 0x0f ) << 8);
-	sx = (int)m_scroll_data_table[0][0x80] +
-			(((int)m_scroll_data_table[0][0x81] & 0x0f ) << 8);
-	if(m_md == MD_2PLANE_16BIT ) {
-		page = ( ( sx + col * 16 ) % 2048 ) / 512;
-		page += ( ( sy + row * 16 ) / 512 ) * 4;
-	}
-	else if (m_page_size) {
-		page = ( sx + col * 16 ) / 512;
-		page += ( ( sy + row * 16 ) / 1024 ) * 8;
+	if (m_v_div_size) {
+		page = 0;
 	}
 	else {
-		page = ( sx + col * 16 ) / 1024;
-		page += ( ( sy + row * 16 ) / 512 ) * 4;
+		sy = (int)m_scroll_data_table[0][translated_column] +
+		   (((int)m_scroll_data_table[0][translated_column+1] & 0x0f ) << 8);
+		sx = (int)m_scroll_data_table[0][0x80] +
+		   (((int)m_scroll_data_table[0][0x81] & 0x0f ) << 8);
+
+		if (m_md == MD_2PLANE_16BIT) {
+			page = ( ( sx + col * 16 ) % 2048 ) / 512;
+			page += ( ( sy + row * 16 ) / 512 ) * 4;
+		}
+		else if (m_page_size) {
+			page = ( sx + col * 16 ) / 512;
+			page += ( ( sy + row * 16 ) / 1024 ) * 8;
+		}
+		else {
+			page = ( sx + col * 16 ) / 1024;
+			page += ( ( sy + row * 16 ) / 512 ) * 4;
+		}
 	}
 
 	page &= 0x1f;
@@ -799,21 +815,27 @@ TILE_GET_INFO_MEMBER( ygv608_device::get_tile_info_B_16 )
 
 	/* calculate page according to scroll data */
 	/* - assuming full-screen scroll only for now... */
-	sy = (int)m_scroll_data_table[1][translated_column] +
-			(((int)m_scroll_data_table[1][translated_column+1] & 0x0f ) << 8);
-	sx = (int)m_scroll_data_table[1][0x80] +
-			(((int)m_scroll_data_table[1][0x81] & 0x0f ) << 8);
-	if(m_md == MD_2PLANE_16BIT ) {
-		page = ( ( sx + col * 16 ) % 2048 ) / 512;
-		page += ( ( sy + row * 16 ) / 512 ) * 4;
-	}
-	else if (m_page_size) {
-		page = ( sx + col * 16 ) / 512;
-		page += ( ( sy + row * 16 ) / 1024 ) * 8;
+	if (m_v_div_size) {
+		page = 0;
 	}
 	else {
-		page = ( sx + col * 16 ) / 1024;
-		page += ( ( sy + row * 16 ) / 512 ) * 4;
+		sy = (int)m_scroll_data_table[1][translated_column] +
+		   (((int)m_scroll_data_table[1][translated_column+1] & 0x0f ) << 8);
+		sx = (int)m_scroll_data_table[1][0x80] +
+		   (((int)m_scroll_data_table[1][0x81] & 0x0f ) << 8);
+
+		if (m_md == MD_2PLANE_16BIT) {
+			page = ( ( sx + col * 16 ) % 2048 ) / 512;
+			page += ( ( sy + row * 16 ) / 512 ) * 4;
+		}
+		else if (m_page_size) {
+			page = ( sx + col * 16 ) / 512;
+			page += ( ( sy + row * 16 ) / 1024 ) * 8;
+		}
+		else {
+			page = ( sx + col * 16 ) / 1024;
+			page += ( ( sy + row * 16 ) / 512 ) * 4;
+		}
 	}
 
 	page &= 0x1f;
@@ -982,9 +1004,9 @@ inline void ygv608_device::draw_layer_roz(screen_device &screen, bitmap_ind16 &b
 	int ba_select = (source_tilemap == m_tilemap_A) ? 0 : 1;
 
 	sy = (int)m_scroll_data_table[ba_select][0x00] +
-		(((int)m_scroll_data_table[ba_select][0x01] & 0x0f ) << 8);
+	   (((int)m_scroll_data_table[ba_select][0x01] & 0x0f ) << 8);
 	sx = (int)m_scroll_data_table[ba_select][0x80] +
-		(((int)m_scroll_data_table[ba_select][0x81] & 0x0f ) << 8);
+	   (((int)m_scroll_data_table[ba_select][0x81] & 0x0f ) << 8);
 
 	if( m_zron == true )
 	{
@@ -996,6 +1018,10 @@ inline void ygv608_device::draw_layer_roz(screen_device &screen, bitmap_ind16 &b
 		//sin_theta = (double)m_dyx / (double)0x10000;
 		//cos_theta = (double)m_dx / (double)0x10000;
 
+		if (m_v_div_size) {
+			sx = (sx & 0x1FF) ? (sx - 0x200) : 0;
+			sy = (sy & 0x1FF) ? (sy - 0x200) : 0;
+		}
 		source_tilemap->draw_roz(screen, bitmap, cliprect,
 				m_ax + (sx << 16), m_ay + (sy << 16),
 				m_dx, m_dyx, m_dxy, m_dy, m_roz_wrap_disable == false, 0, 0 );

--- a/src/mame/video/ygv608.cpp
+++ b/src/mame/video/ygv608.cpp
@@ -448,6 +448,13 @@ inline int ygv608_device::get_col_division(int raw_col)
 	return ((raw_col >> m_col_shift) * 2) & 0x7f;
 }
 
+inline int ygv608_device::get_row_division(int raw_row)
+{
+	if(m_h_div_size == 0)
+		return 0;
+
+	return (raw_row & (m_page_y/2 - 1)) * 2;
+}
 
 TILEMAP_MAPPER_MEMBER( ygv608_device::get_tile_offset )
 {
@@ -1102,30 +1109,17 @@ uint32_t ygv608_device::update_screen(screen_device &screen, bitmap_ind16 &bitma
 
 #ifdef _ENABLE_SCROLLX
 
-	if (m_h_div_size == 0) {
+	for( row=0; row<m_page_y; row++ )
+	{
+		int translated_row = get_row_division(row);
 
-		m_tilemap_B->set_scrollx(0,
-					( (int)m_scroll_data_table[1][0x80] +
-					( (int)m_scroll_data_table[1][0x81] << 8 ) ) );
-
-		m_tilemap_A->set_scrollx(0,
-					( (int)m_scroll_data_table[0][0x80] +
-					( (int)m_scroll_data_table[0][0x81] << 8 ) ) );
-
-	}
-	else {
-
-		for( row=0; row<m_page_y; row++ )
-		{
 		m_tilemap_B->set_scrollx(row,
-					( (int)m_scroll_data_table[1][0x80 + ((row & (m_page_y/2 - 1)) << 1)] +
-					( (int)m_scroll_data_table[1][0x81 + ((row & (m_page_y/2 - 1)) << 1)] << 8 ) ) );
+			( (int)m_scroll_data_table[1][translated_row+0x80] +
+			( (int)m_scroll_data_table[1][translated_row+0x81] << 8 ) ) );
 
 		m_tilemap_A->set_scrollx(row,
-					( (int)m_scroll_data_table[0][0x80 + ((row & (m_page_y/2 - 1)) << 1)] +
-					( (int)m_scroll_data_table[0][0x81 + ((row & (m_page_y/2 - 1)) << 1)] << 8 ) ) );
-		}
-
+			( (int)m_scroll_data_table[0][translated_row+0x80] +
+			( (int)m_scroll_data_table[0][translated_row+0x81] << 8 ) ) );
 	}
 
 #endif

--- a/src/mame/video/ygv608.h
+++ b/src/mame/video/ygv608.h
@@ -259,6 +259,7 @@ private:
 	void pattern_name_autoinc_check();  /**< check autoinc for tile pointers */
 	void pattern_mode_setup();      /**< refresh pattern mode at register 7/8 change*/
 	int get_col_division(int raw_col); /**< calculate column scroll */
+	int get_row_division(int raw_row); /**< calculate row scroll */
 
 	enum
 	{


### PR DESCRIPTION
This patch fixes rotzoom behavior used in Namco Classic Collection vol.1 & 2.
Verified against actual PCBs.

In NCV1 Xevious Arrangement, scrolling-by-row feature is used to draw and move UFOs in 'AREA 8'.
I think this is the only part where the feature is used (but I'm not sure whether the feature is used in other games on the boards).