### PR TITLE
fmtowns: fix kanji offset calculation

### DIFF
--- a/src/mame/video/fmtowns.cpp
+++ b/src/mame/video/fmtowns.cpp
@@ -228,11 +228,11 @@ void towns_state::towns_update_kanji_offset()
 	}
 	else if(m_video.towns_kanji_code_h < 0x70)
 	{
-		m_video.towns_kanji_offset = ((m_video.towns_kanji_code_l & 0x1f) << 4)
-							+ (((m_video.towns_kanji_code_l - 0x20) & 0x60) << 8)
-							+ ((m_video.towns_kanji_code_h & 0x0f) << 9)
+		m_video.towns_kanji_offset = (((m_video.towns_kanji_code_l & 0x1f) << 5)
+							+ (((m_video.towns_kanji_code_l - 0x20) & 0x60) << 9)
+							+ ((m_video.towns_kanji_code_h & 0x0f) << 10)
 							+ (((m_video.towns_kanji_code_h - 0x30) & 0x70) * 0xc00)
-							+ 0x8000;
+							+ 0x8000) >> 1;
 	}
 	else
 	{
@@ -243,6 +243,7 @@ void towns_state::towns_update_kanji_offset()
 							| 0x38000;
 	}
 }
+
 
 READ8_MEMBER( towns_state::towns_video_cff80_r )
 {


### PR DESCRIPTION
The kanji characters currently displayed using the fixed ROM font (mainly the boot messages) are wrong. This fixes the offset calculation so the appropriate characters are displayed, e.g.:

ディスクエラーが発生しました (a disk error has occurred) instead of ディスクエラーが遣宛しました (gibberish)
システム読み込み中です (the system is loading) instead of システム局み扶み恰です (gibberish)

And so on.