### PR TITLE
Added missing Kaypro models, distributed ROM files accordingly

### DIFF
--- a/src/mame/drivers/kaypro.cpp
+++ b/src/mame/drivers/kaypro.cpp
@@ -3,7 +3,7 @@
 /*************************************************************************************************
 
 
-    Kaypro 2/83 computer - the very first Kaypro II - 2 full size floppy drives.
+    The Kaypro 2/83 computer - the very first Kaypro II - 2 full height floppy drives.
     Each disk was single sided, and could hold 191k. The computer had 2x pio
     and 1x sio. One of the sio ports communicated with the keyboard with a coiled
     telephone cord, complete with modular plug on each end. The keyboard carries
@@ -23,17 +23,19 @@
       C: floppy
 
     ToDo:
-
-    - See about getting keyboard to work as a serial device.
-    - Need dump of 87C51 cpu in the keyboard.
+	- Find original Kaycomp ROMs
+    - Need dump of 87C51 cpu in a Kaypro II keyboard variant
 
     - Kaypro 2x, 4a: floppy not working "No operating system present on this disk"
     - Kaypro 10: Boots from floppy, but needs hard drive added.
-    - Kaypro 4p88: works as a normal Kaypro 4, extra hardware not done
+	- "Univeral"-ROM 81-478A: Boots, but fails with CP/M "BDOS Error on A:", was working until MAME v0190
+	- fix Kayplus 84 ROM screen corruption
+    - Kaypro iip88, 484p88: works as a normal Kaypro 4, extra hardware not done
     - Kaypro Robie: has twin 2.6MB 5.25 floppy drives which we don't support, no software available
+	- Handyman ROM is really an add-on board with 16K proprietory RAM
 
     - Hard Disk not emulated.
-      The controller is a WD1002 (original version, for Winchester drives).
+      The controller is a WD1002-HD0 (original version, for Winchester drives), HD is 10MB, e.g. Shugart 712
 
     - RTC type MM58167A to be added. Modem chips TMS99531, TMS99532 to be developed.
 
@@ -49,13 +51,12 @@
 #include "machine/clock.h"
 #include "machine/com8116.h"
 #include "machine/z80sio.h"
-#include "formats/kaypro_dsk.h"
 #include "screen.h"
 #include "softlist.h"
 #include "speaker.h"
 
 
-READ8_MEMBER( kaypro_state::kaypro2x_87_r ) { return 0x7f; }    /* to bypass unemulated HD controller */
+READ8_MEMBER( kaypro_state::kaypro484_87_r ) { return 0x7f; }    /* to bypass unemulated HD controller */
 
 /***********************************************************
 
@@ -80,7 +81,7 @@ static ADDRESS_MAP_START( kayproii_io, AS_IO, 8, kaypro_state )
 	AM_RANGE(0x1c, 0x1f) AM_DEVREADWRITE("z80pio_s", z80pio_device, read_alt, write_alt)
 ADDRESS_MAP_END
 
-static ADDRESS_MAP_START( kaypro2x_io, AS_IO, 8, kaypro_state )
+static ADDRESS_MAP_START( kaypro484_io, AS_IO, 8, kaypro_state )
 	ADDRESS_MAP_GLOBAL_MASK(0xff)
 	ADDRESS_MAP_UNMAP_HIGH
 	AM_RANGE(0x00, 0x03) AM_DEVWRITE("brg", com8116_device, str_w)
@@ -88,14 +89,14 @@ static ADDRESS_MAP_START( kaypro2x_io, AS_IO, 8, kaypro_state )
 	AM_RANGE(0x08, 0x0b) AM_DEVWRITE("brg", com8116_device, stt_w)
 	AM_RANGE(0x0c, 0x0f) AM_DEVREADWRITE("sio_2", z80sio_device, ba_cd_r, ba_cd_w)
 	AM_RANGE(0x10, 0x13) AM_DEVREADWRITE("fdc", fd1793_device, read, write)
-	AM_RANGE(0x14, 0x17) AM_READWRITE(kaypro2x_system_port_r,kaypro2x_system_port_w)
+	AM_RANGE(0x14, 0x17) AM_READWRITE(kaypro484_system_port_r,kaypro484_system_port_w)
 	AM_RANGE(0x18, 0x1b) AM_DEVWRITE("cent_data_out", output_latch_device, write)
-	AM_RANGE(0x1c, 0x1c) AM_READWRITE(kaypro2x_status_r,kaypro2x_index_w)
-	AM_RANGE(0x1d, 0x1d) AM_DEVREAD("crtc", mc6845_device, register_r) AM_WRITE(kaypro2x_register_w)
-	AM_RANGE(0x1f, 0x1f) AM_READWRITE(kaypro2x_videoram_r,kaypro2x_videoram_w)
+	AM_RANGE(0x1c, 0x1c) AM_READWRITE(kaypro484_status_r,kaypro484_index_w)
+	AM_RANGE(0x1d, 0x1d) AM_DEVREAD("crtc", mc6845_device, register_r) AM_WRITE(kaypro484_register_w)
+	AM_RANGE(0x1f, 0x1f) AM_READWRITE(kaypro484_videoram_r,kaypro484_videoram_w)
 
 	/* The below are not emulated */
-/*  AM_RANGE(0x20, 0x23) AM_DEVREADWRITE("z80pio", kaypro2x_pio_r, kaypro2x_pio_w) - for RTC and Modem
+/*  AM_RANGE(0x20, 0x23) AM_DEVREADWRITE("z80pio", kaypro484_pio_r, kaypro484_pio_w) - for RTC and Modem
     AM_RANGE(0x24, 0x27) communicate with MM58167A RTC. Modem uses TMS99531 and TMS99532 chips.
     AM_RANGE(0x80, 0x80) Hard drive controller card I/O port - 10MB hard drive only fitted to the Kaypro 10
     AM_RANGE(0x81, 0x81) Hard Drive READ error register, WRITE precomp
@@ -106,7 +107,7 @@ static ADDRESS_MAP_START( kaypro2x_io, AS_IO, 8, kaypro_state )
     AM_RANGE(0x86, 0x86) Hard Drive Size / Drive / Head register I/O
     AM_RANGE(0x87, 0x87) Hard Drive READ status register, WRITE command register */
 	AM_RANGE(0x20, 0x86) AM_NOP
-	AM_RANGE(0x87, 0x87) AM_READ(kaypro2x_87_r)
+	AM_RANGE(0x87, 0x87) AM_READ(kaypro484_87_r)
 ADDRESS_MAP_END
 
 
@@ -133,7 +134,7 @@ static const gfx_layout kayproii_charlayout =
 	8*8                 /* every char takes 8 bytes */
 };
 
-static const gfx_layout kaypro2x_charlayout =
+static const gfx_layout kaypro484_charlayout =
 {
 	8, 16,                  /* 8 x 16 characters */
 	256,                    /* 256 characters */
@@ -150,8 +151,8 @@ static GFXDECODE_START( kayproii )
 	GFXDECODE_ENTRY( "chargen", 0x0000, kayproii_charlayout, 0, 1 )
 GFXDECODE_END
 
-static GFXDECODE_START( kaypro2x )
-	GFXDECODE_ENTRY( "chargen", 0x0000, kaypro2x_charlayout, 0, 1 )
+static GFXDECODE_START( kaypro484 )
+	GFXDECODE_ENTRY( "chargen", 0x0000, kaypro484_charlayout, 0, 1 )
 GFXDECODE_END
 
 /***************************************************************
@@ -168,14 +169,12 @@ static const z80_daisy_config kayproii_daisy_chain[] =
 	{ nullptr }
 };
 
-static const z80_daisy_config kaypro2x_daisy_chain[] =
+static const z80_daisy_config kaypro484_daisy_chain[] =
 {
 	{ "sio_1" },        /* sio for RS232C and keyboard */
 	{ "sio_2" },        /* sio for serial printer and inbuilt modem */
 	{ nullptr }
 };
-
-
 
 
 /***********************************************************
@@ -184,16 +183,11 @@ static const z80_daisy_config kaypro2x_daisy_chain[] =
 
 ************************************************************/
 
-FLOPPY_FORMATS_MEMBER( kaypro_state::kayproii_floppy_formats )
-	FLOPPY_KAYPROII_FORMAT
-FLOPPY_FORMATS_END
-
-FLOPPY_FORMATS_MEMBER( kaypro_state::kaypro2x_floppy_formats )
-	FLOPPY_KAYPRO2X_FORMAT
-FLOPPY_FORMATS_END
 
 static SLOT_INTERFACE_START( kaypro_floppies )
-	SLOT_INTERFACE( "525qd", FLOPPY_525_DD )
+	SLOT_INTERFACE( "525ssdd", FLOPPY_525_SSDD )
+	SLOT_INTERFACE( "525dd", FLOPPY_525_DD )
+	SLOT_INTERFACE( "525qd", FLOPPY_525_QD )
 SLOT_INTERFACE_END
 
 
@@ -268,27 +262,32 @@ static MACHINE_CONFIG_START( kayproii )
 	MCFG_WD_FDC_INTRQ_CALLBACK(WRITELINE(kaypro_state, fdc_intrq_w))
 	MCFG_WD_FDC_DRQ_CALLBACK(WRITELINE(kaypro_state, fdc_drq_w))
 	MCFG_WD_FDC_FORCE_READY
-	MCFG_FLOPPY_DRIVE_ADD("fdc:0", kaypro_floppies, "525qd", kaypro_state::kayproii_floppy_formats)
+	MCFG_FLOPPY_DRIVE_ADD("fdc:0", kaypro_floppies, "525ssdd", floppy_image_device::default_floppy_formats)
 	MCFG_FLOPPY_DRIVE_SOUND(true)
-	MCFG_FLOPPY_DRIVE_ADD("fdc:1", kaypro_floppies, "525qd", kaypro_state::kayproii_floppy_formats)
+	MCFG_FLOPPY_DRIVE_ADD("fdc:1", kaypro_floppies, "525ssdd", floppy_image_device::default_floppy_formats)
 	MCFG_FLOPPY_DRIVE_SOUND(true)
 	MCFG_SOFTWARE_LIST_ADD("flop_list","kayproii")
 MACHINE_CONFIG_END
 
-static MACHINE_CONFIG_DERIVED( kaypro4, kayproii )
+static MACHINE_CONFIG_DERIVED( kayproiv, kayproii )
 	MCFG_DEVICE_REMOVE("z80pio_s")
 	MCFG_DEVICE_ADD("z80pio_s", Z80PIO, 2500000)
 	MCFG_Z80PIO_OUT_INT_CB(INPUTLINE("maincpu", INPUT_LINE_IRQ0))
 	MCFG_Z80PIO_IN_PA_CB(READ8(kaypro_state, pio_system_r))
-	MCFG_Z80PIO_OUT_PA_CB(WRITE8(kaypro_state, kaypro4_pio_system_w))
+	MCFG_Z80PIO_OUT_PA_CB(WRITE8(kaypro_state, kayproiv_pio_system_w))
+	MCFG_DEVICE_REMOVE("fdc:0")
+	MCFG_DEVICE_REMOVE("fdc:1")
+	MCFG_FLOPPY_DRIVE_ADD("fdc:0", kaypro_floppies, "525dd", floppy_image_device::default_floppy_formats)
+	MCFG_FLOPPY_DRIVE_SOUND(true)
+	MCFG_FLOPPY_DRIVE_ADD("fdc:1", kaypro_floppies, "525dd", floppy_image_device::default_floppy_formats)	
 MACHINE_CONFIG_END
 
-static MACHINE_CONFIG_START( kaypro2x )
+static MACHINE_CONFIG_START( kaypro484 )
 	/* basic machine hardware */
 	MCFG_CPU_ADD("maincpu", Z80, XTAL_16MHz / 4)
 	MCFG_CPU_PROGRAM_MAP(kaypro_map)
-	MCFG_CPU_IO_MAP(kaypro2x_io)
-	MCFG_Z80_DAISY_CHAIN(kaypro2x_daisy_chain)
+	MCFG_CPU_IO_MAP(kaypro484_io)
+	MCFG_Z80_DAISY_CHAIN(kaypro484_daisy_chain)
 
 	MCFG_MACHINE_RESET_OVERRIDE(kaypro_state, kaypro )
 
@@ -299,9 +298,9 @@ static MACHINE_CONFIG_START( kaypro2x )
 	MCFG_SCREEN_SIZE(80*8, 25*16)
 	MCFG_SCREEN_VISIBLE_AREA(0,80*8-1,0,25*16-1)
 	MCFG_VIDEO_START_OVERRIDE(kaypro_state, kaypro )
-	MCFG_SCREEN_UPDATE_DRIVER(kaypro_state, screen_update_kaypro2x)
+	MCFG_SCREEN_UPDATE_DRIVER(kaypro_state, screen_update_kaypro484)
 
-	MCFG_GFXDECODE_ADD("gfxdecode", "palette", kaypro2x)
+	MCFG_GFXDECODE_ADD("gfxdecode", "palette", kaypro484)
 	MCFG_PALETTE_ADD("palette", 3)
 	MCFG_PALETTE_INIT_OWNER(kaypro_state, kaypro)
 
@@ -314,7 +313,7 @@ static MACHINE_CONFIG_START( kaypro2x )
 	MCFG_MC6845_ADD("crtc", MC6845, "screen", 2000000) /* comes out of ULA - needs to be measured */
 	MCFG_MC6845_SHOW_BORDER_AREA(false)
 	MCFG_MC6845_CHAR_WIDTH(7)
-	MCFG_MC6845_UPDATE_ROW_CB(kaypro_state, kaypro2x_update_row)
+	MCFG_MC6845_UPDATE_ROW_CB(kaypro_state, kaypro484_update_row)
 
 	MCFG_QUICKLOAD_ADD("quickload", kaypro_state, kaypro, "com,cpm", 3)
 
@@ -362,18 +361,31 @@ static MACHINE_CONFIG_START( kaypro2x )
 	MCFG_WD_FDC_INTRQ_CALLBACK(WRITELINE(kaypro_state, fdc_intrq_w))
 	MCFG_WD_FDC_DRQ_CALLBACK(WRITELINE(kaypro_state, fdc_drq_w))
 	MCFG_WD_FDC_FORCE_READY
-	MCFG_FLOPPY_DRIVE_ADD("fdc:0", kaypro_floppies, "525qd", kaypro_state::kaypro2x_floppy_formats)
+	MCFG_FLOPPY_DRIVE_ADD("fdc:0", kaypro_floppies, "525dd", floppy_image_device::default_floppy_formats)
 	MCFG_FLOPPY_DRIVE_SOUND(true)
-	MCFG_FLOPPY_DRIVE_ADD("fdc:1", kaypro_floppies, "525qd", kaypro_state::kaypro2x_floppy_formats)
+	MCFG_FLOPPY_DRIVE_ADD("fdc:1", kaypro_floppies, "525dd", floppy_image_device::default_floppy_formats)
 	MCFG_FLOPPY_DRIVE_SOUND(true)
 MACHINE_CONFIG_END
 
-static MACHINE_CONFIG_DERIVED( kaypro10, kaypro2x )
+static MACHINE_CONFIG_DERIVED( kaypro10, kaypro484 )
 	MCFG_DEVICE_REMOVE("fdc:1")  // only has 1 floppy drive
 	// need to add hard drive & controller
 MACHINE_CONFIG_END
 
-static MACHINE_CONFIG_DERIVED( omni2, kaypro4 )
+static MACHINE_CONFIG_DERIVED( kaypronew2, kaypro484 )
+	MCFG_DEVICE_REMOVE("fdc:1")  // only has 1 floppy drive
+MACHINE_CONFIG_END
+
+static MACHINE_CONFIG_DERIVED( kaypro284, kaypro484 )
+	MCFG_DEVICE_REMOVE("fdc:0")
+	MCFG_DEVICE_REMOVE("fdc:1")
+	MCFG_FLOPPY_DRIVE_ADD("fdc:0", kaypro_floppies, "525ssdd", floppy_image_device::default_floppy_formats)
+	MCFG_FLOPPY_DRIVE_SOUND(true)
+	MCFG_FLOPPY_DRIVE_ADD("fdc:1", kaypro_floppies, "525ssdd", floppy_image_device::default_floppy_formats)
+	MCFG_FLOPPY_DRIVE_SOUND(true)
+MACHINE_CONFIG_END
+
+static MACHINE_CONFIG_DERIVED( omni2, kayproiv )
 	MCFG_SCREEN_MODIFY("screen")
 	MCFG_SCREEN_UPDATE_DRIVER(kaypro_state, screen_update_omni2)
 MACHINE_CONFIG_END
@@ -399,47 +411,162 @@ DRIVER_INIT_MEMBER( kaypro_state, kaypro )
 
 /* The detested bios "universal rom" is part number 81-478 */
 
+// Kaypro II
 ROM_START(kayproii)
-	/* The board could take a 2716 or 2732 */
+	/* The original board could take a 2716 or 2732 */
 	ROM_REGION(0x4000, "roms",0)
-	ROM_SYSTEM_BIOS( 0, "149", "149")
+	ROM_SYSTEM_BIOS( 0, "149", "81-149 for Kaypro Bd. 81-110")
 	ROMX_LOAD("81-149.u47",   0x0000, 0x0800, CRC(28264bc1) SHA1(a12afb11a538fc0217e569bc29633d5270dfa51b), ROM_BIOS(1) )
-	ROM_SYSTEM_BIOS( 1, "149b", "149B")
+	ROM_SYSTEM_BIOS( 1, "149b", "81-149B for Kaypro Bd. 81-110")
 	ROMX_LOAD("81-149b.u47",  0x0000, 0x0800, CRC(c008549e) SHA1(b9346a16f5f9ffb6bb0eb1766c348b74056485a8), ROM_BIOS(2) )
-	ROM_SYSTEM_BIOS( 2, "149c", "149C")
+	ROM_SYSTEM_BIOS( 2, "149c", "81-149C for Kaypro Bd. 81-110")
 	ROMX_LOAD("81-149c.u47",  0x0000, 0x0800, CRC(1272aa65) SHA1(027fee2f5f17ba71a4738f00188e132e326536ff), ROM_BIOS(3) )
-
-	ROM_REGION(0x10000, "rambank", ROMREGION_ERASEFF)
-
-	ROM_REGION(0x0800, "chargen", ROMREGION_INVERT)
-	ROM_LOAD("81-146.u43",   0x0000, 0x0800, CRC(4cc7d206) SHA1(5cb880083b94bd8220aac1f87d537db7cfeb9013) )
-
-	// random roms for unknown kaypro computers, to be checked
-	ROM_REGION(0x20000, "user1", 0)
-	ROM_LOAD( "x.bin",        0x0000, 0x0fff, CRC(01e2e7b2) SHA1(fc2f8dc8a077d0c89a74463328efa1c444662d88) )
-	ROM_LOAD( "81-x015.rom",  0x1000, 0x2000, CRC(94645e5e) SHA1(9a6e0ec3f54e23b6768c6e39b43314c7726927df) )
-	ROM_LOAD( "884max.rom",   0x3000, 0x2000, CRC(97b28ad2) SHA1(d6bc2125f41e3879cda96d64be22d4256b5cc822) )
-	ROM_LOAD( "kplus83.rom",  0x5000, 0x2000, CRC(5e9b817d) SHA1(26ea875ee3659a964cbded4ed0c82a3af42db64b) )
-	ROM_LOAD( "kplus84.rom",  0x7000, 0x2000, CRC(4551905a) SHA1(48f0964edfad05b214810ae5595638245c30e5c0) )
-	ROM_LOAD( "rom19ee.bin",  0x9000, 0x0fee, CRC(c3515bd0) SHA1(48a0a43c164e4d3e75e8e916498421ef616943cf) )
-	ROM_LOAD( "handyman.bin", 0xa000, 0x8000, CRC(f020d82c) SHA1(576a6608270d4ec7cf814c9de46ecf4e2869d30a) )
-	ROM_LOAD( "advent-turbo.bin", 0x12000, 0x2000, CRC(0ec6d39a) SHA1(8c2a92b8642e144452c28300bf50a00a11a060cd) ) // for kayproii
-ROM_END
-
-ROM_START(kaypro4)
-	ROM_REGION(0x4000, "roms",0)
-	ROM_LOAD("81-232.u47",   0x0000, 0x1000, CRC(4918fb91) SHA1(cd9f45cc3546bcaad7254b92c5d501c40e2ef0b2) )
-
+	ROM_SYSTEM_BIOS( 3, "232", "81-232 for Kaypro Bd. 81-240")
+	ROMX_LOAD("81-232.u47",   0x0000, 0x1000, CRC(4918fb91) SHA1(cd9f45cc3546bcaad7254b92c5d501c40e2ef0b2), ROM_BIOS(4) )
+	ROM_SYSTEM_BIOS( 4, "roadrunner", "Highland Microkit Roadrunner 1.5")
+	ROMX_LOAD("kaypro_ii_roadrunner_1_5.bin",  0x0000, 0x1000, CRC(ca11357d) SHA1(8e8a6d6e0d31d1051db9a24601f12a3b4639b3bb), ROM_BIOS(5) ) // does not boot here but originally comes from a II
+	ROM_SYSTEM_BIOS( 5, "turbo", "Advent Turbo ROM")
+	ROMX_LOAD("trom34_3.rom",  0x0000, 0x1000, CRC(908a4c0e) SHA1(6e220479715a812d9116b0927a9ff2792f82b2a7), ROM_BIOS(6) )
+	ROM_SYSTEM_BIOS( 6, "kplus83", "MICROCode Consulting KayPLUS 83")
+	ROMX_LOAD("kplus83.rom",  0x0000, 0x2000, CRC(5e9b817d) SHA1(26ea875ee3659a964cbded4ed0c82a3af42db64b), ROM_BIOS(7) )
+	ROM_SYSTEM_BIOS( 7, "pro8v3", "MicroCornucopia_Pro8_V3.3")
+	ROMX_LOAD("pro8-3.rom",  0x0000, 0x1000, CRC(f2d4c598) SHA1(269b2fddeb98db3e5eba2056ff250dff72b0561e), ROM_BIOS(8) )
 	ROM_REGION(0x10000, "rambank", ROMREGION_ERASEFF)
 
 	ROM_REGION(0x0800, "chargen", ROMREGION_INVERT)
 	ROM_LOAD("81-146.u43",   0x0000, 0x0800, CRC(4cc7d206) SHA1(5cb880083b94bd8220aac1f87d537db7cfeb9013) )
 ROM_END
 
-ROM_START(kaypro4p88) // "KAYPRO-88" board has 128k or 256k of its own ram on it
+// Kaypro IV (or 4'83)
+ROM_START(kayproiv)
 	ROM_REGION(0x4000, "roms",0)
-	ROM_LOAD("81-232.u47",   0x0000, 0x1000, CRC(4918fb91) SHA1(cd9f45cc3546bcaad7254b92c5d501c40e2ef0b2) )
+	ROM_SYSTEM_BIOS( 0, "232", "81-232 for Kaypro Bd. 81-240")
+	ROMX_LOAD("81-232.u47",   0x0000, 0x1000, CRC(4918fb91) SHA1(cd9f45cc3546bcaad7254b92c5d501c40e2ef0b2), ROM_BIOS(1) )
+	ROM_SYSTEM_BIOS( 1, "roadrunner", "Highland Microkit Roadrunner 1.5")
+	ROMX_LOAD("kaypro_ii_roadrunner_1_5.bin",  0x0000, 0x1000, CRC(ca11357d) SHA1(8e8a6d6e0d31d1051db9a24601f12a3b4639b3bb), ROM_BIOS(2) )
+	ROM_SYSTEM_BIOS( 2, "turbo", "Advent Turbo ROM")
+	ROMX_LOAD("trom34_3.rom",  0x0000, 0x1000, CRC(908a4c0e) SHA1(6e220479715a812d9116b0927a9ff2792f82b2a7), ROM_BIOS(3) )
+	ROM_SYSTEM_BIOS( 3, "kplus83", "MICROCode Consulting KayPLUS 83")
+	ROMX_LOAD("kplus83.rom",  0x0000, 0x2000, CRC(5e9b817d) SHA1(26ea875ee3659a964cbded4ed0c82a3af42db64b), ROM_BIOS(4) )
+	ROM_SYSTEM_BIOS( 4, "pro8v3", "MicroCornucopia_Pro8_V3.3")
+	ROMX_LOAD("pro8-3.rom",  0x0000, 0x1000, CRC(f2d4c598) SHA1(269b2fddeb98db3e5eba2056ff250dff72b0561e), ROM_BIOS(5) )
+	ROM_REGION(0x10000, "rambank", ROMREGION_ERASEFF)
 
+	ROM_REGION(0x0800, "chargen", ROMREGION_INVERT)
+	ROM_LOAD("81-146.u43",   0x0000, 0x0800, CRC(4cc7d206) SHA1(5cb880083b94bd8220aac1f87d537db7cfeb9013) )
+ROM_END
+
+// Kaypro 10, '83 model, hard disk cable connector in the middle of the mainboard, no space for modem or RTC
+ROM_START(kaypro10)
+	ROM_REGION(0x4000, "roms",0)
+	ROM_SYSTEM_BIOS( 0, "188", "V1.9 for Kaypro Bd. 81-180")
+	ROMX_LOAD("81-188.u42",   0x0000, 0x1000, CRC(6cbd6aa0) SHA1(47004f8c6e17407e4f8d613c9520f9316716d9e2), ROM_BIOS(1) )
+	ROM_SYSTEM_BIOS( 1, "x", "V1.7")
+	ROMX_LOAD("x.bin",        0x0000, 0x0fff, BAD_DUMP CRC(01e2e7b2) SHA1(fc2f8dc8a077d0c89a74463328efa1c444662d88), ROM_BIOS(2) )
+	ROM_SYSTEM_BIOS( 2, "turbo", "Advent Turbo ROM")
+	ROMX_LOAD("trom34.rom",   0x0000, 0x2000, CRC(0ec6d39a) SHA1(8c2a92b8642e144452c28300bf50a00a11a060cd), ROM_BIOS(3) )
+	ROM_SYSTEM_BIOS( 3, "kplus83", "MICROCode Consulting KayPLUS 83")
+	ROMX_LOAD("kplus83.rom",  0x0000, 0x2000, CRC(5e9b817d) SHA1(26ea875ee3659a964cbded4ed0c82a3af42db64b), ROM_BIOS(4) )	
+	ROM_REGION(0x10000, "rambank", ROMREGION_ERASEFF)
+
+	ROM_REGION(0x1000, "chargen",0)
+	ROM_LOAD("81-187.u31",   0x0000, 0x1000, CRC(5f72da5b) SHA1(8a597000cce1a7e184abfb7bebcb564c6bf24fb7) )
+ROM_END
+
+// Kaypro 10, '84 model, hard disk cable on the right hand side of the mainboard
+ROM_START(kaypro1084)
+	ROM_REGION(0x4000, "roms",0)
+	ROM_SYSTEM_BIOS( 0, "302", "V1.9E for Kaypro Bd. 81-181")
+	ROMX_LOAD("81-302.u42",   0x0000, 0x1000, CRC(3f9bee20) SHA1(b29114a199e70afe46511119b77a662e97b093a0), ROM_BIOS(1) )
+	ROM_SYSTEM_BIOS( 1, "1.9ee", "V1.9ee")
+	ROMX_LOAD("rom19ee.bin",  0x0000, 0x0fee, BAD_DUMP CRC(c3515bd0) SHA1(48a0a43c164e4d3e75e8e916498421ef616943cf), ROM_BIOS(2) )	
+	ROM_SYSTEM_BIOS( 2, "277", "V1.9E(F)")
+	ROMX_LOAD("81-277.u42",   0x0000, 0x1000, CRC(e4e1831f) SHA1(1de31ed532a461ace7a4abad1f6647eeddceb3e7), ROM_BIOS(3) )
+	ROM_SYSTEM_BIOS( 3, "478", "V2.01 for Kaypro Bd. 81-582 (universal)")
+	ROMX_LOAD("81-478.u42",   0x0000, 0x2000, CRC(de618380) SHA1(c8d6312e6eeb62a53e741f1ff3b878bdcb7b5aaa), ROM_BIOS(4) )
+	ROM_SYSTEM_BIOS( 4, "turbo", "Advent Turbo ROM")
+	ROMX_LOAD("trom34.rom",   0x0000, 0x2000, CRC(0ec6d39a) SHA1(8c2a92b8642e144452c28300bf50a00a11a060cd), ROM_BIOS(5) )
+	ROM_SYSTEM_BIOS( 5, "kplus", "MICROCode Consulting KayPLUS 84")
+	ROMX_LOAD("kplus84.rom",   0x0000, 0x2000, CRC(4551905a) SHA1(48f0964edfad05b214810ae5595638245c30e5c0), ROM_BIOS(6) )
+	
+	ROM_REGION(0x10000, "rambank", ROMREGION_ERASEFF)
+
+	ROM_REGION(0x1000, "chargen",0)
+	ROM_LOAD("81-187.u31",   0x0000, 0x1000, CRC(5f72da5b) SHA1(8a597000cce1a7e184abfb7bebcb564c6bf24fb7) )
+ROM_END
+
+ROM_START(kaypro484) // later renamed in 2X (or 2X MTC to signify the inclusion of Modem and RTC in comparison with the "old" 2X)
+	ROM_REGION(0x4000, "roms",0)
+	ROM_SYSTEM_BIOS( 0, "292a", "81-292a for Kaypro Bd. 81-184")
+	ROMX_LOAD("81-292a.u34",  0x0000, 0x1000, CRC(241f27a5) SHA1(82711289d19e9b165e35324da010466d225e503a), ROM_BIOS(1) )
+	ROM_SYSTEM_BIOS( 1, "turbo", "Advent Turbo ROM")
+	ROMX_LOAD("trom34.rom",   0x0000, 0x2000, CRC(0ec6d39a) SHA1(8c2a92b8642e144452c28300bf50a00a11a060cd), ROM_BIOS(2) )
+	ROM_SYSTEM_BIOS( 2, "kplus", "MICROCode Consulting KayPLUS 84")
+	ROMX_LOAD("kplus84.rom",   0x0000, 0x2000, CRC(4551905a) SHA1(48f0964edfad05b214810ae5595638245c30e5c0), ROM_BIOS(3) )
+	ROM_SYSTEM_BIOS( 3, "pro884", "MicroCornucopia pro884 SuperMax 2.7")
+	ROMX_LOAD("pro884mx.rom",   0x0000, 0x2000, CRC(febc6f51) SHA1(1f009aa9b7c9a3eddd0ee6ea7321a1c47c3e9807), ROM_BIOS(4) )
+	ROM_SYSTEM_BIOS( 4, "pro8v5", "MicroCornucopia Pro8 V5")
+	ROMX_LOAD("pro884v5.rom",  0x0000, 0x2000, CRC(fe0051b1) SHA1(cac429154d40e21174ae05ceb0017b62473cdebd), ROM_BIOS(5) )
+	
+	ROM_REGION(0x10000, "rambank", ROMREGION_ERASEFF)
+
+	ROM_REGION(0x1000, "chargen",0)
+	ROM_LOAD("81-235.u9",    0x0000, 0x1000, CRC(5f72da5b) SHA1(8a597000cce1a7e184abfb7bebcb564c6bf24fb7) )
+ROM_END
+
+ // Kaypro 2'84, like the 4'84, but two single sided drives, no RTC, no modem
+ROM_START(kaypro284)
+	ROM_REGION(0x4000, "roms",0)
+	ROM_SYSTEM_BIOS( 0, "292a", "81-292a for Kaypro Bd. 81-184")
+	ROMX_LOAD("81-292a.u34",  0x0000, 0x1000, CRC(241f27a5) SHA1(82711289d19e9b165e35324da010466d225e503a), ROM_BIOS(1) )
+	ROM_SYSTEM_BIOS( 1, "turbo", "Advent Turbo ROM")
+	ROMX_LOAD("trom34.rom",   0x0000, 0x2000, CRC(0ec6d39a) SHA1(8c2a92b8642e144452c28300bf50a00a11a060cd), ROM_BIOS(2) )
+	ROM_SYSTEM_BIOS( 2, "kplus", "MICROCode Consulting KayPLUS 84")
+	ROMX_LOAD("kplus84.rom",   0x0000, 0x2000, CRC(4551905a) SHA1(48f0964edfad05b214810ae5595638245c30e5c0), ROM_BIOS(3) )
+	ROM_SYSTEM_BIOS( 3, "pro884", "MicroCornucopia pro884 SuperMax 2.7")
+	ROMX_LOAD("pro884mx.rom",   0x0000, 0x2000, CRC(febc6f51) SHA1(1f009aa9b7c9a3eddd0ee6ea7321a1c47c3e9807), ROM_BIOS(4) )
+	ROM_SYSTEM_BIOS( 4, "pro8v5", "MicroCornucopia Pro8 V5")
+	ROMX_LOAD("pro884v5.rom",  0x0000, 0x2000, CRC(fe0051b1) SHA1(cac429154d40e21174ae05ceb0017b62473cdebd), ROM_BIOS(5) )
+	
+	ROM_REGION(0x10000, "rambank", ROMREGION_ERASEFF)
+
+	ROM_REGION(0x1000, "chargen",0)
+	ROM_LOAD("81-235.u9",    0x0000, 0x1000, CRC(5f72da5b) SHA1(8a597000cce1a7e184abfb7bebcb564c6bf24fb7) )
+ROM_END
+
+// Kaypro 2X, a 4'84 without modem and RTC, later the 4'84 is renamed 2X, this fully decked out variant is called 2X MTC
+ROM_START(kaypro2x) 
+	ROM_REGION(0x8000, "roms",0)
+	ROM_SYSTEM_BIOS( 0, "292a", "81-292a for Kaypro Bd. 81-184")
+	ROMX_LOAD("81-292a.u34",  0x0000, 0x1000, CRC(241f27a5) SHA1(82711289d19e9b165e35324da010466d225e503a), ROM_BIOS(1) )
+	ROM_SYSTEM_BIOS( 1, "292", "V2.00 (early universal)" )
+	ROMX_LOAD("81-292.u34",   0x0000, 0x2000, CRC(5eb69aec) SHA1(525f955ca002976e2e30ac7ee37e4a54f279fe96), ROM_BIOS(2) )
+	ROM_SYSTEM_BIOS( 2, "478", "V2.01 for Kaypro Bd. 81-580 (universal)")
+	ROMX_LOAD("81-478.u42",   0x0000, 0x2000, CRC(de618380) SHA1(c8d6312e6eeb62a53e741f1ff3b878bdcb7b5aaa), ROM_BIOS(3) )
+	ROM_SYSTEM_BIOS( 3, "turbo", "Advent Turbo ROM")
+	ROMX_LOAD("trom34.rom",   0x0000, 0x2000, CRC(0ec6d39a) SHA1(8c2a92b8642e144452c28300bf50a00a11a060cd), ROM_BIOS(4) )
+	ROM_SYSTEM_BIOS( 4, "kplus", "MICROCode Consulting KayPLUS 84")
+	ROMX_LOAD("kplus84.rom",   0x0000, 0x2000, CRC(4551905a) SHA1(48f0964edfad05b214810ae5595638245c30e5c0), ROM_BIOS(5) )
+	ROM_SYSTEM_BIOS( 5, "pro884", "MicroCornucopia pro884 SuperMax 2.7")
+	ROMX_LOAD("pro884mx.rom",   0x0000, 0x2000, CRC(febc6f51) SHA1(1f009aa9b7c9a3eddd0ee6ea7321a1c47c3e9807), ROM_BIOS(6) )
+	ROM_SYSTEM_BIOS( 6, "pro8v5", "MicroCornucopia Pro8 V5")
+	ROMX_LOAD("pro884v5.rom",  0x0000, 0x2000, CRC(fe0051b1) SHA1(cac429154d40e21174ae05ceb0017b62473cdebd), ROM_BIOS(7) )
+	ROM_SYSTEM_BIOS( 7, "handyman", "Hitech Research Handyman")																// http://content.thetechnickel.com/misc/kaypro-handyman/kaypro-4-plus-88-06.jpg
+	ROMX_LOAD( "handyman.bin", 0x0000, 0x8000, CRC(f020d82c) SHA1(576a6608270d4ec7cf814c9de46ecf4e2869d30a), ROM_BIOS(8) )	// fits any classic Kaypro, needs its own 16K RAM
+
+	ROM_REGION(0x10000, "rambank", ROMREGION_ERASEFF)
+
+	ROM_REGION(0x1000, "chargen",0)
+	ROM_LOAD("81-235.u9",    0x0000, 0x1000, CRC(5f72da5b) SHA1(8a597000cce1a7e184abfb7bebcb564c6bf24fb7) )
+ROM_END
+
+// Kaypro II'84 plus 88, the "KAYPRO-88" board has 128k or 256k of its own ram on it, it's a factory installed SWP CoPower 88
+ROM_START(kayproiip88)
+	ROM_REGION(0x4000, "roms",0)
+	ROM_SYSTEM_BIOS( 0, "232", "81-232 for Kaypro Bd. 81-240")
+	ROMX_LOAD("81-232.u47",   0x0000, 0x1000, CRC(4918fb91) SHA1(cd9f45cc3546bcaad7254b92c5d501c40e2ef0b2), ROM_BIOS(1) )
+	ROM_SYSTEM_BIOS( 1, "kplus83", "MICROCode Consulting KayPLUS 83")
+	ROMX_LOAD("kplus83.rom",  0x0000, 0x2000, CRC(5e9b817d) SHA1(26ea875ee3659a964cbded4ed0c82a3af42db64b), ROM_BIOS(2) )
 	ROM_REGION(0x10000, "rambank", ROMREGION_ERASEFF)
 
 	ROM_REGION(0x0800, "chargen", ROMREGION_INVERT)
@@ -449,66 +576,35 @@ ROM_START(kaypro4p88) // "KAYPRO-88" board has 128k or 256k of its own ram on it
 	ROM_LOAD("81-356.u29",   0x0000, 0x1000, CRC(948556db) SHA1(6e779866d099cc0dc8c6369bdfb37a923ac448a4) )
 ROM_END
 
-ROM_START(omni2)
+// Kaypro 4'84 plus 88, the "KAYPRO-88" board has 128k or 256k of its own ram on it, it's a factory installed SWP CoPower 88
+ROM_START(kaypro484p88) 
 	ROM_REGION(0x4000, "roms",0)
-	ROM_LOAD("omni2.u47",    0x0000, 0x1000, CRC(2883f9e0) SHA1(d98c784e62853582d298bf7ca84c75872847ac9b) )
-
-	ROM_REGION(0x10000, "rambank", ROMREGION_ERASEFF)
-
-	ROM_REGION(0x0800, "chargen", ROMREGION_INVERT)
-	ROM_LOAD("omni2.u43",    0x0000, 0x0800, CRC(049b3381) SHA1(46f1d4f038747ba9048b075dc617361be088f82a) )
-ROM_END
-
-ROM_START(omni4)
-	ROM_REGION(0x4000, "roms",0)
-	ROM_LOAD("omni4.u34",    0x0000, 0x2000, CRC(f24e8521) SHA1(374f2e2b791a807f103744a22c9c8f3af55f1033) )
-
-	ROM_REGION(0x10000, "rambank", ROMREGION_ERASEFF)
-
-	ROM_REGION(0x1000, "chargen", 0)
-	ROM_LOAD("omni4.u9",    0x0000, 0x1000, CRC(579665a6) SHA1(261fcdc5a44821de9484340cbe429110400140b4) )
-ROM_END
-
-ROM_START(kaypro2x)
-	ROM_REGION(0x4000, "roms",0)
-	ROM_SYSTEM_BIOS( 0, "292", "292")
-	ROMX_LOAD("81-292.u34",   0x0000, 0x2000, CRC(5eb69aec) SHA1(525f955ca002976e2e30ac7ee37e4a54f279fe96), ROM_BIOS(1) )
-	ROM_SYSTEM_BIOS( 1, "292a", "292A")
-	ROMX_LOAD("81-292a.u34",  0x0000, 0x1000, CRC(241f27a5) SHA1(82711289d19e9b165e35324da010466d225e503a), ROM_BIOS(2) )
-
+	ROM_SYSTEM_BIOS( 0, "292a", "292A")
+	ROMX_LOAD("81-292a.u34",  0x0000, 0x1000, CRC(241f27a5) SHA1(82711289d19e9b165e35324da010466d225e503a), ROM_BIOS(1) )
+	ROM_SYSTEM_BIOS( 1, "kplus", "MICROCode Consulting KayPLUS 84")
+	ROMX_LOAD("kplus84.rom",   0x0000, 0x2000, CRC(4551905a) SHA1(48f0964edfad05b214810ae5595638245c30e5c0), ROM_BIOS(2) )
+	
 	ROM_REGION(0x10000, "rambank", ROMREGION_ERASEFF)
 
 	ROM_REGION(0x1000, "chargen",0)
 	ROM_LOAD("81-235.u9",    0x0000, 0x1000, CRC(5f72da5b) SHA1(8a597000cce1a7e184abfb7bebcb564c6bf24fb7) )
 ROM_END
 
-ROM_START(kaypro4a) // same as kaypro2x ??
+// Kaypro New 2, no modem, no RTC, single DS/DD disk drive
+ROM_START(kaypronew2)
 	ROM_REGION(0x4000, "roms",0)
-	ROM_LOAD("81-292.u34",   0x0000, 0x2000, CRC(5eb69aec) SHA1(525f955ca002976e2e30ac7ee37e4a54f279fe96) )
-
+	ROM_SYSTEM_BIOS( 0, "478", "V2.01 for Kaypro Bd. 81-294 (universal")
+	ROMX_LOAD("81-478.u42",   0x0000, 0x2000, CRC(de618380) SHA1(c8d6312e6eeb62a53e741f1ff3b878bdcb7b5aaa), ROM_BIOS(1) )
+	ROM_SYSTEM_BIOS( 1, "kplus", "MICROCode Consulting KayPLUS 84")
+	ROMX_LOAD("kplus84.rom",   0x0000, 0x2000, CRC(4551905a) SHA1(48f0964edfad05b214810ae5595638245c30e5c0), ROM_BIOS(2) )
+	
 	ROM_REGION(0x10000, "rambank", ROMREGION_ERASEFF)
 
 	ROM_REGION(0x1000, "chargen",0)
 	ROM_LOAD("81-235.u9",    0x0000, 0x1000, CRC(5f72da5b) SHA1(8a597000cce1a7e184abfb7bebcb564c6bf24fb7) )
 ROM_END
 
-ROM_START(kaypro10)
-	ROM_REGION(0x4000, "roms",0)
-	ROM_SYSTEM_BIOS( 0, "302", "V1.9E")
-	ROMX_LOAD("81-302.u42",   0x0000, 0x1000, CRC(3f9bee20) SHA1(b29114a199e70afe46511119b77a662e97b093a0), ROM_BIOS(1) )
-	ROM_SYSTEM_BIOS( 1, "188", "V1.9")
-	ROMX_LOAD("81-188.u42",   0x0000, 0x1000, CRC(6cbd6aa0) SHA1(47004f8c6e17407e4f8d613c9520f9316716d9e2), ROM_BIOS(2) )
-	ROM_SYSTEM_BIOS( 2, "277", "V1.9E(F)")
-	ROMX_LOAD("81-277.u42",   0x0000, 0x1000, CRC(e4e1831f) SHA1(1de31ed532a461ace7a4abad1f6647eeddceb3e7), ROM_BIOS(3) )
-	ROM_SYSTEM_BIOS( 3, "478", "V2.01")
-	ROMX_LOAD("81-478.u42",   0x0000, 0x2000, CRC(de618380) SHA1(c8d6312e6eeb62a53e741f1ff3b878bdcb7b5aaa), ROM_BIOS(4) )
-
-	ROM_REGION(0x10000, "rambank", ROMREGION_ERASEFF)
-
-	ROM_REGION(0x1000, "chargen",0)
-	ROM_LOAD("81-187.u31",   0x0000, 0x1000, CRC(5f72da5b) SHA1(8a597000cce1a7e184abfb7bebcb564c6bf24fb7) )
-ROM_END
-
+// "Desktop" PC with two high density, 2.8MB floppy disk drivers over the monitor
 ROM_START(robie)
 	ROM_REGION(0x4000, "roms",0)
 	ROM_SYSTEM_BIOS( 0, "326", "V1.7R")
@@ -522,14 +618,69 @@ ROM_START(robie)
 	ROM_LOAD("81-235.u9",    0x0000, 0x1000, CRC(5f72da5b) SHA1(8a597000cce1a7e184abfb7bebcb564c6bf24fb7) )
 ROM_END
 
-/*    YEAR  NAME        PARENT    COMPAT  MACHINE   INPUT   CLASS         INIT    COMPANY                FULLNAME */
-COMP( 1982, kayproii,   0,        0,      kayproii, kaypro, kaypro_state, kaypro, "Non Linear Systems",  "Kaypro II - 2/83" , 0 )
-COMP( 1983, kaypro4,    kayproii, 0,      kaypro4,  kaypro, kaypro_state, kaypro, "Non Linear Systems",  "Kaypro 4 - 4/83" , 0 ) // model 81-004
-COMP( 1983, kaypro4p88, kayproii, 0,      kaypro4,  kaypro, kaypro_state, kaypro, "Non Linear Systems",  "Kaypro 4 plus88 - 4/83" , MACHINE_NOT_WORKING ) // model 81-004 with an added 8088 daughterboard and rom
-COMP( 198?, omni2,      kayproii, 0,      omni2,    kaypro, kaypro_state, kaypro, "Non Linear Systems",  "Omni II Logic Analyzer" , 0 )
-COMP( 198?, omni4,      kaypro2x, 0,      kaypro2x, kaypro, kaypro_state, kaypro, "Omni Logic Inc.",     "Omni 4 Logic Analyzer" , MACHINE_NOT_WORKING )
-COMP( 1984, kaypro2x,   0,        0,      kaypro2x, kaypro, kaypro_state, kaypro, "Non Linear Systems",  "Kaypro 2x" , MACHINE_NOT_WORKING ) // model 81-025
-COMP( 1984, kaypro4a,   kaypro2x, 0,      kaypro2x, kaypro, kaypro_state, kaypro, "Non Linear Systems",  "Kaypro 4 - 4/84" , MACHINE_NOT_WORKING ) // model 81-015
-// Kaypro 4/84 plus 88 goes here, model 81-015 with an added 8088 daughterboard and rom
-COMP( 1983, kaypro10,   0,        0,      kaypro10, kaypro, kaypro_state, kaypro, "Non Linear Systems",  "Kaypro 10" , MACHINE_NOT_WORKING ) // model 81-005
-COMP( 1984, robie,      0,        0,      kaypro2x, kaypro, kaypro_state, kaypro, "Non Linear Systems",  "Kaypro Robie" , MACHINE_NOT_WORKING )
+// Kaypro 4X, a Robie in the standard portable Kaypro enclosure
+ROM_START(kaypro4x)
+	ROM_REGION(0x4000, "roms",0)
+	ROM_LOAD("81-326.u34",   0x0000, 0x2000, CRC(7f0c3f68) SHA1(54b088a1b2200f9df4b9b347bbefb0115f3a4976) )
+
+	ROM_REGION(0x10000, "rambank", ROMREGION_ERASEFF)
+
+	ROM_REGION(0x1000, "chargen",0)
+	ROM_LOAD("81-235.u9",    0x0000, 0x1000, CRC(5f72da5b) SHA1(8a597000cce1a7e184abfb7bebcb564c6bf24fb7) )
+ROM_END
+
+// Kaypro 1, equivalent to "old" 2X, before 4'84 became 2X
+ROM_START(kaypro1)
+	ROM_REGION(0x4000, "roms",0)
+	ROM_SYSTEM_BIOS( 0, "478", "V2.01 for Kaypro Bd. 81-294 (universal")
+	ROMX_LOAD("81-478.u42",   0x0000, 0x2000, CRC(de618380) SHA1(c8d6312e6eeb62a53e741f1ff3b878bdcb7b5aaa), ROM_BIOS(1) )
+	ROM_SYSTEM_BIOS( 1, "turbo", "Advent Turbo ROM")
+	ROMX_LOAD("trom34.rom",   0x0000, 0x2000, CRC(0ec6d39a) SHA1(8c2a92b8642e144452c28300bf50a00a11a060cd), ROM_BIOS(2) )
+	ROM_SYSTEM_BIOS( 2, "kplus", "MICROCode Consulting KayPLUS 84")
+	ROMX_LOAD("kplus84.rom",   0x0000, 0x2000, CRC(4551905a) SHA1(48f0964edfad05b214810ae5595638245c30e5c0), ROM_BIOS(3) )
+
+	ROM_REGION(0x10000, "rambank", ROMREGION_ERASEFF)
+
+	ROM_REGION(0x1000, "chargen",0)
+	ROM_LOAD("81-235.u9",    0x0000, 0x1000, CRC(5f72da5b) SHA1(8a597000cce1a7e184abfb7bebcb564c6bf24fb7) )
+ROM_END
+
+// Omni II logic analyzer
+ROM_START(omni2)
+	ROM_REGION(0x4000, "roms",0)
+	ROM_LOAD("omni2.u47",    0x0000, 0x1000, CRC(2883f9e0) SHA1(d98c784e62853582d298bf7ca84c75872847ac9b) )
+
+	ROM_REGION(0x10000, "rambank", ROMREGION_ERASEFF)
+
+	ROM_REGION(0x0800, "chargen", ROMREGION_INVERT)
+	ROM_LOAD("omni2.u43",    0x0000, 0x0800, CRC(049b3381) SHA1(46f1d4f038747ba9048b075dc617361be088f82a) )
+ROM_END
+
+// Omni 4 logic analyzer
+ROM_START(omni4)
+	ROM_REGION(0x4000, "roms",0)
+	ROM_LOAD("omni4.u34",    0x0000, 0x2000, CRC(f24e8521) SHA1(374f2e2b791a807f103744a22c9c8f3af55f1033) )
+
+	ROM_REGION(0x10000, "rambank", ROMREGION_ERASEFF)
+
+	ROM_REGION(0x1000, "chargen", 0)
+	ROM_LOAD("omni4.u9",    0x0000, 0x1000, CRC(579665a6) SHA1(261fcdc5a44821de9484340cbe429110400140b4) )
+ROM_END
+
+
+/*    YEAR  NAME		 PARENT		COMPAT  MACHINE    INPUT   CLASS         INIT    COMPANY                FULLNAME */
+COMP( 1982, kayproii,    0,         0,      kayproii,  kaypro, kaypro_state, kaypro, "Non Linear Systems",  "Kaypro II - 2/83" , 0 )
+COMP( 1983, kayproiv,    kayproii,  0,      kayproiv,  kaypro, kaypro_state, kaypro, "Non Linear Systems",  "Kaypro IV - 4/83" , 0 ) // model 81-004
+COMP( 1983, kaypro10,	 0,			0,      kaypro10,  kaypro, kaypro_state, kaypro, "Non Linear Systems",  "Kaypro 10 - 1983", 0 )
+COMP( 1983, kayproiip88, kayproii,  0,      kayproii,  kaypro, kaypro_state, kaypro, "Non Linear Systems",  "Kaypro 4 plus88 - 4/83" , MACHINE_NOT_WORKING ) // model 81-004 with an added 8088 daughterboard and rom
+COMP( 1984, kaypro484,   0,         0,      kaypro484, kaypro, kaypro_state, kaypro, "Non Linear Systems",  "Kaypro 4/84" , MACHINE_NOT_WORKING ) // model 81-015
+COMP( 1984, kaypro284,   kaypro484, 0,      kaypro284, kaypro, kaypro_state, kaypro, "Non Linear Systems",  "Kaypro 2/84" , MACHINE_NOT_WORKING ) // model 81-015
+COMP( 1984, kaypro484p88,kaypro484, 0,      kaypro484, kaypro, kaypro_state, kaypro, "Non Linear Systems",  "Kaypro 4/84 plus88", MACHINE_NOT_WORKING ) // model 81-015 with an added 8088 daughterboard and rom
+COMP( 1984, kaypro1084,  kaypro10,  0,      kaypro10,  kaypro, kaypro_state, kaypro, "Non Linear Systems",  "Kaypro 10" , MACHINE_NOT_WORKING ) // model 81-005
+COMP( 1984, robie,       0,         0,      kaypro484, kaypro, kaypro_state, kaypro, "Non Linear Systems",  "Kaypro Robie" , MACHINE_NOT_WORKING )
+COMP( 1985, kaypro2x,    kaypro484, 0,      kaypro484, kaypro, kaypro_state, kaypro, "Non Linear Systems",  "Kaypro 2x" , MACHINE_NOT_WORKING ) // model 81-025
+COMP( 1985, kaypronew2,	 0,			0,		kaypronew2,kaypro, kaypro_state, kaypro, "Non Linear Systems",  "Kaypro New 2", MACHINE_NOT_WORKING )
+COMP( 1985, kaypro4x,    robie,		0,      kaypro484, kaypro, kaypro_state, kaypro, "Non Linear Systems",  "Kaypro 4x" , MACHINE_NOT_WORKING )
+COMP( 1986, kaypro1,	 kaypro484,	0,		kaypro484, kaypro, kaypro_state, kaypro, "Non Linear Systems",  "Kaypro 1", MACHINE_NOT_WORKING )
+COMP( 198?, omni2,       kayproii,  0,      omni2,     kaypro, kaypro_state, kaypro, "Non Linear Systems",  "Omni II Logic Analyzer" , 0 )
+COMP( 198?, omni4,       kaypro484, 0,      kaypro484, kaypro, kaypro_state, kaypro, "Omni Logic Inc.",     "Omni 4 Logic Analyzer" , MACHINE_NOT_WORKING )

--- a/src/mame/includes/kaypro.h
+++ b/src/mame/includes/kaypro.h
@@ -38,17 +38,17 @@ public:
 	{}
 
 	DECLARE_WRITE_LINE_MEMBER(write_centronics_busy);
-	DECLARE_READ8_MEMBER(kaypro2x_87_r);
-	DECLARE_READ8_MEMBER(kaypro2x_system_port_r);
-	DECLARE_READ8_MEMBER(kaypro2x_status_r);
-	DECLARE_READ8_MEMBER(kaypro2x_videoram_r);
-	DECLARE_WRITE8_MEMBER(kaypro2x_system_port_w);
-	DECLARE_WRITE8_MEMBER(kaypro2x_index_w);
-	DECLARE_WRITE8_MEMBER(kaypro2x_register_w);
-	DECLARE_WRITE8_MEMBER(kaypro2x_videoram_w);
+	DECLARE_READ8_MEMBER(kaypro484_87_r);
+	DECLARE_READ8_MEMBER(kaypro484_system_port_r);
+	DECLARE_READ8_MEMBER(kaypro484_status_r);
+	DECLARE_READ8_MEMBER(kaypro484_videoram_r);
+	DECLARE_WRITE8_MEMBER(kaypro484_system_port_w);
+	DECLARE_WRITE8_MEMBER(kaypro484_index_w);
+	DECLARE_WRITE8_MEMBER(kaypro484_register_w);
+	DECLARE_WRITE8_MEMBER(kaypro484_videoram_w);
 	DECLARE_READ8_MEMBER(pio_system_r);
 	DECLARE_WRITE8_MEMBER(kayproii_pio_system_w);
-	DECLARE_WRITE8_MEMBER(kaypro4_pio_system_w);
+	DECLARE_WRITE8_MEMBER(kayproiv_pio_system_w);
 	DECLARE_WRITE_LINE_MEMBER(fdc_intrq_w);
 	DECLARE_WRITE_LINE_MEMBER(fdc_drq_w);
 	DECLARE_READ8_MEMBER(kaypro_videoram_r);
@@ -58,12 +58,10 @@ public:
 	DECLARE_VIDEO_START(kaypro);
 	DECLARE_PALETTE_INIT(kaypro);
 	DECLARE_DRIVER_INIT(kaypro);
-	DECLARE_FLOPPY_FORMATS(kayproii_floppy_formats);
-	DECLARE_FLOPPY_FORMATS(kaypro2x_floppy_formats);
 	uint32_t screen_update_kayproii(screen_device &screen, bitmap_ind16 &bitmap, const rectangle &cliprect);
-	uint32_t screen_update_kaypro2x(screen_device &screen, bitmap_rgb32 &bitmap, const rectangle &cliprect);
+	uint32_t screen_update_kaypro484(screen_device &screen, bitmap_rgb32 &bitmap, const rectangle &cliprect);
 	uint32_t screen_update_omni2(screen_device &screen, bitmap_ind16 &bitmap, const rectangle &cliprect);
-	MC6845_UPDATE_ROW(kaypro2x_update_row);
+	MC6845_UPDATE_ROW(kaypro484_update_row);
 	DECLARE_QUICKLOAD_LOAD_MEMBER(kaypro);
 
 private:

--- a/src/mame/machine/kaypro.cpp
+++ b/src/mame/machine/kaypro.cpp
@@ -72,7 +72,7 @@ WRITE8_MEMBER( kaypro_state::kayproii_pio_system_w )
 	m_system_port = data;
 }
 
-WRITE8_MEMBER( kaypro_state::kaypro4_pio_system_w )
+WRITE8_MEMBER( kaypro_state::kayproiv_pio_system_w )
 {
 	kayproii_pio_system_w(space, offset, data);
 
@@ -82,19 +82,19 @@ WRITE8_MEMBER( kaypro_state::kaypro4_pio_system_w )
 
 /***********************************************************
 
-    KAYPRO2X SYSTEM PORT
+    KAYPRO484 SYSTEM PORT
 
     The PIOs were replaced by a few standard 74xx chips
 
 ************************************************************/
 
-READ8_MEMBER( kaypro_state::kaypro2x_system_port_r )
+READ8_MEMBER( kaypro_state::kaypro484_system_port_r )
 {
 	uint8_t data = m_centronics_busy << 6;
 	return (m_system_port & 0xbf) | data;
 }
 
-WRITE8_MEMBER( kaypro_state::kaypro2x_system_port_w )
+WRITE8_MEMBER( kaypro_state::kaypro484_system_port_w )
 {
 /*  d7 bank select
     d6 alternate character set (write only)
@@ -138,7 +138,7 @@ WRITE8_MEMBER( kaypro_state::kaypro2x_system_port_w )
 
     SIO
 
-    On Kaypro2x, Channel B on both SIOs is hardwired to 300 baud.
+    On Kaypro484, Channel B on both SIOs is hardwired to 300 baud.
 
     Both devices on sio2 (printer and modem) are not emulated.
 

--- a/src/mame/mame.lst
+++ b/src/mame/mame.lst
@@ -17147,12 +17147,18 @@ wndrplnt                        // (c) 1987 Data East Corporation (Japan)
 kas89                           // 1989, SFC S.R.L.
 
 @source:kaypro.cpp
-kaypro10                        // Kaypro 10
-kaypro2x                        // Kaypro 2 - 2/84
-kaypro4                         // Kaypro 4 - 4/83
-kaypro4a                        // Kaypro 4 - 4/84
-kaypro4p88                      // Kaypro 4 - 4/83 w/plus88 board installed
+kaypro1							// Kaypro 1
+kaypro10						// Kaypro 10/83
+kaypro1084                      // Kaypro 10/84
+kaypro2x                        // Kaypro 2x
+kaypro4x                        // Kaypro 4x
+kaypro284						// Kaypro 2 - 2/84
+kaypro484                       // Kaypro 4 - 4/84
+kayproiip88                     // Kaypro II - 4/83 w/plus88 board installed
+kaypro484p88                    // Kaypro 4/84 - 4/84 w/plus88 board installed
 kayproii                        // Kaypro II - 2/83
+kayproiv						// Kaypro IV - 4/83
+kaypronew2						// Kaypro new 2
 omni2                           // Omni II
 omni4                           // Omni 4
 robie                           // Kaypro Robie

--- a/src/mame/video/kaypro.cpp
+++ b/src/mame/video/kaypro.cpp
@@ -115,14 +115,14 @@ uint32_t kaypro_state::screen_update_omni2(screen_device &screen, bitmap_ind16 &
 	return 0;
 }
 
-uint32_t kaypro_state::screen_update_kaypro2x(screen_device &screen, bitmap_rgb32 &bitmap, const rectangle &cliprect)
+uint32_t kaypro_state::screen_update_kaypro484(screen_device &screen, bitmap_rgb32 &bitmap, const rectangle &cliprect)
 {
 	m_framecnt++;
 	m_crtc->screen_update(screen, bitmap, cliprect);
 	return 0;
 }
 
-/* bit 6 of kaypro2x_system_port selects alternate characters (A12 on character generator rom).
+/* bit 6 of kaypro484_system_port selects alternate characters (A12 on character generator rom).
     The diagram specifies a 2732 with 28 pins, and more address pins. Possibly a 2764 or 27128.
     Since our dump only goes up to A11, the alternate character set doesn't exist.
 
@@ -135,7 +135,7 @@ uint32_t kaypro_state::screen_update_kaypro2x(screen_device &screen, bitmap_rgb3
     Not sure how the attributes interact, for example does an underline blink? */
 
 
-MC6845_UPDATE_ROW( kaypro_state::kaypro2x_update_row )
+MC6845_UPDATE_ROW( kaypro_state::kaypro484_update_row )
 {
 	const rgb_t *palette = m_palette->palette()->entry_list_raw();
 	uint32_t *p = &bitmap.pix32(y);
@@ -253,20 +253,20 @@ void kaypro_state::mc6845_screen_configure()
 
 /**************************** I/O PORTS *****************************************************************/
 
-READ8_MEMBER( kaypro_state::kaypro2x_status_r )
+READ8_MEMBER( kaypro_state::kaypro484_status_r )
 {
 /* Need bit 7 high or computer hangs */
 
 	return 0x80 | m_crtc->register_r(space, 0);
 }
 
-WRITE8_MEMBER( kaypro_state::kaypro2x_index_w )
+WRITE8_MEMBER( kaypro_state::kaypro484_index_w )
 {
 	m_mc6845_ind = data & 0x1f;
 	m_crtc->address_w( space, 0, data );
 }
 
-WRITE8_MEMBER( kaypro_state::kaypro2x_register_w )
+WRITE8_MEMBER( kaypro_state::kaypro484_register_w )
 {
 	static const uint8_t mcmask[32]={0xff,0xff,0xff,0x0f,0x7f,0x1f,0x7f,0x7f,3,0x1f,0x7f,0x1f,0x3f,0xff,0x3f,0xff,0,0};
 
@@ -297,12 +297,12 @@ WRITE8_MEMBER( kaypro_state::kaypro_videoram_w )
 	m_p_videoram[offset] = data;
 }
 
-READ8_MEMBER( kaypro_state::kaypro2x_videoram_r )
+READ8_MEMBER( kaypro_state::kaypro484_videoram_r )
 {
 	return m_p_videoram[m_mc6845_video_address];
 }
 
-WRITE8_MEMBER( kaypro_state::kaypro2x_videoram_w )
+WRITE8_MEMBER( kaypro_state::kaypro484_videoram_w )
 {
 	m_p_videoram[m_mc6845_video_address] = data;
 }


### PR DESCRIPTION
- renamed kaypro4 to kayproiv (cf. boot message) and kaypro4a to kaypro484
- make Kaypro use standard disk formats, if this is approved, kaypro_dsk.cpp and .h can be removed
- added kaypro1084, kaypro1, kaypro4x, kaypro284 and kaypronew2 as well as II plus 88
- made kaypro484 the parent for the later non-10/non-Robie machines
- made the 4 plus 88 a '84 generation machine in keeping with adverts of the time and photographic evidence - the plus 88 board is a CoPower 88 from SWP and could also be bought indepentently
- distributed ROMs evenly, and marked dumps bad where appropriate
- put handyman ROM into kaypro2x, this ROM can be added to all other Kaypro drivers once it's got its own 16K RAM added and connected
- Kaypro is SS/DD or DS/DD, offer DS/QD as option, it was supported by third party ROMs
