### PR TITLE
dumped internal IGS036 rom for Oriental Legend 2 [Morten Shearman Kirkegaard and Peter Wilhelmsen]

### DIFF
--- a/src/devices/cpu/arm7/arm7.cpp
+++ b/src/devices/cpu/arm7/arm7.cpp
@@ -53,6 +53,7 @@ DEFINE_DEVICE_TYPE(ARM920T,  arm920t_cpu_device,  "arm920t",  "ARM920T")
 DEFINE_DEVICE_TYPE(ARM946ES, arm946es_cpu_device, "arm946es", "ARM946ES")
 DEFINE_DEVICE_TYPE(PXA255,   pxa255_cpu_device,   "pxa255",   "Intel XScale PXA255")
 DEFINE_DEVICE_TYPE(SA1110,   sa1110_cpu_device,   "sa1110",   "Intel StrongARM SA-1110")
+DEFINE_DEVICE_TYPE(IGS036,   igs036_cpu_device,   "igs036",   "IGS036")
 
 arm7_cpu_device::arm7_cpu_device(const machine_config &mconfig, const char *tag, device_t *owner, uint32_t clock)
 	: arm7_cpu_device(mconfig, ARM7, tag, owner, clock, 4, ARCHFLAG_T, ENDIANNESS_LITTLE)
@@ -174,6 +175,13 @@ sa1110_cpu_device::sa1110_cpu_device(const machine_config &mconfig, const char *
 			   | ARM9_COPRO_ID_PART_SA1110
 			   | ARM9_COPRO_ID_STEP_SA1110_A0;
 }
+
+// unknown configuration
+igs036_cpu_device::igs036_cpu_device(const machine_config &mconfig, const char *tag, device_t *owner, uint32_t clock)
+	: arm9_cpu_device(mconfig, IGS036, tag, owner, clock, 5, ARCHFLAG_T | ARCHFLAG_E, ENDIANNESS_LITTLE)
+{
+}
+
 
 device_memory_interface::space_config_vector arm7_cpu_device::memory_space_config() const
 {
@@ -1222,6 +1230,13 @@ WRITE32_MEMBER( arm7_cpu_device::arm7_rt_w_callback )
 	}
 }
 
+WRITE32_MEMBER(igs036_cpu_device::arm7_rt_w_callback)
+{
+	arm7_cpu_device::arm7_rt_w_callback(space, offset, data, mem_mask);
+	/* disable the MMU for now, it doesn't seem to set up valid mappings
+	   so could be entirely different here */
+	COPRO_CTRL &= ~COPRO_CTRL_MMU_EN;
+}
 
 void arm7_cpu_device::arm7_dt_r_callback(uint32_t insn, uint32_t *prn)
 {

--- a/src/devices/cpu/arm7/arm7.h
+++ b/src/devices/cpu/arm7/arm7.h
@@ -230,7 +230,7 @@ protected:
 	// Coprocessor support
 	DECLARE_WRITE32_MEMBER( arm7_do_callback );
 	DECLARE_READ32_MEMBER( arm7_rt_r_callback );
-	DECLARE_WRITE32_MEMBER( arm7_rt_w_callback );
+	virtual DECLARE_WRITE32_MEMBER( arm7_rt_w_callback );
 	void arm7_dt_r_callback(uint32_t insn, uint32_t *prn);
 	void arm7_dt_w_callback(uint32_t insn, uint32_t *prn);
 
@@ -620,6 +620,14 @@ public:
 	sa1110_cpu_device(const machine_config &mconfig, const char *tag, device_t *owner, uint32_t clock);
 };
 
+class igs036_cpu_device : public arm9_cpu_device
+{
+public:
+	// construction/destruction
+	igs036_cpu_device(const machine_config &mconfig, const char *tag, device_t *owner, uint32_t clock);
+	virtual DECLARE_WRITE32_MEMBER( arm7_rt_w_callback ) override;
+};
+
 
 DECLARE_DEVICE_TYPE(ARM7,     arm7_cpu_device)
 DECLARE_DEVICE_TYPE(ARM7_BE,  arm7_be_cpu_device)
@@ -629,5 +637,6 @@ DECLARE_DEVICE_TYPE(ARM920T,  arm920t_cpu_device)
 DECLARE_DEVICE_TYPE(ARM946ES, arm946es_cpu_device)
 DECLARE_DEVICE_TYPE(PXA255,   pxa255_cpu_device)
 DECLARE_DEVICE_TYPE(SA1110,   sa1110_cpu_device)
+DECLARE_DEVICE_TYPE(IGS036,   igs036_cpu_device)
 
 #endif // MAME_CPU_ARM7_ARM7_H

--- a/src/devices/cpu/arm7/arm7thmb.cpp
+++ b/src/devices/cpu/arm7/arm7thmb.cpp
@@ -1557,18 +1557,21 @@ void arm7_cpu_device::tg0e_0(uint32_t pc, uint32_t op)
 
 void arm7_cpu_device::tg0e_1(uint32_t pc, uint32_t op)
 {
+	/* BLX (LO) */
+
 	uint32_t addr = GetRegister(14);
 	addr += (op & THUMB_BLOP_OFFS) << 1;
 	addr &= 0xfffffffc;
-	SetRegister(14, (R15 + 4) | 1);
+	SetRegister(14, (R15 + 2) | 1);
 	R15 = addr;
 	set_cpsr(GET_CPSR & ~T_MASK);
 }
 
-	/* BL */
 
 void arm7_cpu_device::tg0f_0(uint32_t pc, uint32_t op)
 {
+	/* BL (HI) */
+
 	uint32_t addr = (op & THUMB_BLOP_OFFS) << 12;
 	if (addr & (1 << 22))
 	{
@@ -1581,6 +1584,8 @@ void arm7_cpu_device::tg0f_0(uint32_t pc, uint32_t op)
 
 void arm7_cpu_device::tg0f_1(uint32_t pc, uint32_t op) /* BL */
 {
+	/* BL (LO) */
+
 	uint32_t addr = GetRegister(14) & ~1;
 	addr += (op & THUMB_BLOP_OFFS) << 1;
 	SetRegister(14, (R15 + 2) | 1);


### PR DESCRIPTION
dumped internal IGS036 rom for Oriental Legend 2 [Morten Shearman Kirkegaard and Peter Wilhelmsen]
started adding some devices to the driver to support it [David Haywood]
derived IGS036 type in ARM7/9 core, because it seems like mmu could be different, and there are probably other internal devices [David Haywood]
fixed(?) BLX (LO) thumb opcode in ARM7/9 core, was storing a return address that skipped the following opcode [David Haywood]

I think there might still be ARM9 issues.