### PR TITLE
chdman: Patch to allow chdman to access physical drives on Windows 10

### DIFF
--- a/src/osd/modules/file/winfile.cpp
+++ b/src/osd/modules/file/winfile.cpp
@@ -185,6 +185,7 @@ osd_file::error osd_file::open(std::string const &orig_path, uint32_t openflags,
 	{
 		disposition = (!is_path_to_physical_drive(path.c_str()) && (openflags & OPEN_FLAG_CREATE)) ? CREATE_ALWAYS : OPEN_EXISTING;
 		access = (openflags & OPEN_FLAG_READ) ? (GENERIC_READ | GENERIC_WRITE) : GENERIC_WRITE;
+		if (is_path_to_physical_drive(path.c_str())) access |= GENERIC_READ;
 		sharemode = FILE_SHARE_READ;
 	}
 	else if (openflags & OPEN_FLAG_READ)
@@ -230,7 +231,23 @@ osd_file::error osd_file::open(std::string const &orig_path, uint32_t openflags,
 
 	// get the file size
 	DWORD upper, lower;
-	lower = GetFileSize(h, &upper);
+	if (is_path_to_physical_drive(path.c_str())) {
+
+		GET_LENGTH_INFORMATION gli;
+		DWORD ret;
+		int getsize = DeviceIoControl(h, IOCTL_DISK_GET_LENGTH_INFO, 0, 0, &gli, sizeof(gli), &ret, 0);
+		if (getsize==0) {
+			upper = 0;
+			lower = INVALID_FILE_SIZE;
+		}
+		else {
+			lower = gli.Length.LowPart;
+			upper = gli.Length.HighPart;
+		}
+	}
+	else {
+		lower = GetFileSize(h, &upper);
+	}
 	if (INVALID_FILE_SIZE == lower)
 	{
 		DWORD const err = GetLastError();


### PR DESCRIPTION
Provided as a potential fix for physical drive access using chdman in Windows 10.  There may be cleaner/better methods.
This patch allows chdman to access a physical drive in Windows 10 from an elevated command prompt.
This has been tested with extracthd and createhd commands in Windows 10 Professional.
This should be tested on other windows systems as well.
