### PR TITLE
Correct Galaxian 3 - Theater 6 : Project Dragoon and Galaxian 3 - Theater 6 J2 : Attack of The Zolgear Years

### DIFF
--- a/src/mame/drivers/gal3.cpp
+++ b/src/mame/drivers/gal3.cpp
@@ -867,5 +867,5 @@ ROM_START( gal3 )
 ROM_END
 
 /*    YEAR,  NAME     PARENT, MACHINE, INPUT, STATE,      INIT, MONITOR, COMPANY, FULLNAME,                                   FLAGS */
-GAMEL( 199?, gal3,    0,      gal3,    gal3,  gal3_state, 0,    ROT0,    "Namco", "Galaxian 3 - Theater 6 : Project Dragoon", MACHINE_NOT_WORKING | MACHINE_NO_SOUND, layout_dualhsxs )
-//GAMEL( 199?, gal3zlgr,    0,        gal3,    gal3, driver_device,    0, ROT0,  "Namco", "Galaxian 3 - Theater 6 J2 : Attack of The Zolgear", MACHINE_NOT_WORKING | MACHINE_NO_SOUND, layout_dualhsxs )
+GAMEL( 1992, gal3,    0,      gal3,    gal3,  gal3_state, 0,    ROT0,    "Namco", "Galaxian 3 - Theater 6 : Project Dragoon", MACHINE_NOT_WORKING | MACHINE_NO_SOUND, layout_dualhsxs )
+//GAMEL( 1994, gal3zlgr,    0,        gal3,    gal3, driver_device,    0, ROT0,  "Namco", "Galaxian 3 - Theater 6 J2 : Attack of The Zolgear", MACHINE_NOT_WORKING | MACHINE_NO_SOUND, layout_dualhsxs )


### PR DESCRIPTION
Galaxian 3 - Theater 6 : Project Dragoon was released in December 1992 and Galaxian 3 - Theater 6 J2 : Attack of The Zolgear was released in July 1994 confirmed from Arcade TV Game List Kokunai - Kaigai Hen (1971 - 2005) at Page 53.

https://i.imgur.com/M5aDtWmr.png