### PR TITLE
z180: fixed Z180_RCR_REFW; support Wait State Generator (DCNTL)

### DIFF
--- a/src/devices/cpu/z180/z180.h
+++ b/src/devices/cpu/z180/z180.h
@@ -202,6 +202,9 @@ private:
 	static const opcode_func s_z180ops[6][0x100];
 
 	inline void z180_mmu();
+	inline u8 RM(offs_t addr);
+	inline u8 IN(u16 port);
+	inline void OUT(u16 port, u8 value);
 	inline void RM16( offs_t addr, PAIR *r );
 	inline void WM16( offs_t addr, PAIR *r );
 	inline uint8_t ROP();

--- a/src/devices/cpu/z180/z180ops.h
+++ b/src/devices/cpu/z180/z180ops.h
@@ -22,17 +22,27 @@
 /***************************************************************
  * Input a byte from given I/O port
  ***************************************************************/
-#define IN(port)                                                \
-	(((port ^ IO_IOCR) & 0xffc0) == 0) ?                        \
-		z180_readcontrol(port) : m_iospace->read_byte(port)
+inline u8 z180_device::IN(u16 port)
+{
+	if(((port ^ IO_IOCR) & 0xffc0) == 0)
+		return z180_readcontrol(port);
+	m_extra_cycles += ((IO_DCNTL & (Z180_DCNTL_IWI1 | Z180_DCNTL_IWI0)) >> 4) + 1; // external I/O wait states
+	return m_iospace->read_byte(port);
+}
 
 /***************************************************************
  * Output a byte to given I/O port
  ***************************************************************/
-#define OUT(port,value)                                         \
-	if (((port ^ IO_IOCR) & 0xffc0) == 0)                       \
-		z180_writecontrol(port,value);                          \
-	else m_iospace->write_byte(port,value)
+inline void z180_device::OUT(u16 port, u8 value)
+{
+	if (((port ^ IO_IOCR) & 0xffc0) == 0) {
+		z180_writecontrol(port,value);
+	} else
+	{
+		m_extra_cycles += ((IO_DCNTL & (Z180_DCNTL_IWI1 | Z180_DCNTL_IWI0)) >> 4) + 1; // external I/O wait states
+		m_iospace->write_byte(port, value);
+	}
+}
 
 /***************************************************************
  * MMU calculate the memory management lookup table
@@ -68,12 +78,16 @@ void z180_device::z180_mmu()
 /***************************************************************
  * Read a byte from given memory location
  ***************************************************************/
-#define RM(addr) m_program->read_byte(MMU_REMAP_ADDR(addr))
+inline u8 z180_device::RM(offs_t addr)
+{
+	m_extra_cycles += IO_DCNTL >> 6; // memory wait states
+	return m_program->read_byte(MMU_REMAP_ADDR(addr));
+}
 
 /***************************************************************
  * Write a byte to given memory location
  ***************************************************************/
-#define WM(addr,value) m_program->write_byte(MMU_REMAP_ADDR(addr),value)
+#define WM(addr,value) m_extra_cycles += IO_DCNTL >> 6; /* memory wait states */ m_program->write_byte(MMU_REMAP_ADDR(addr),value)
 
 /***************************************************************
  * Read a word from given memory location
@@ -102,6 +116,7 @@ uint8_t z180_device::ROP()
 {
 	offs_t addr = _PCD;
 	_PC++;
+	m_extra_cycles += IO_DCNTL >> 6; // memory wait states
 	return m_odirect->read_byte(MMU_REMAP_ADDR(addr));
 }
 
@@ -115,6 +130,7 @@ uint8_t z180_device::ARG()
 {
 	offs_t addr = _PCD;
 	_PC++;
+	m_extra_cycles += IO_DCNTL >> 6; // memory wait states
 	return m_direct->read_byte(MMU_REMAP_ADDR(addr));
 }
 
@@ -122,6 +138,7 @@ uint32_t z180_device::ARG16()
 {
 	offs_t addr = _PCD;
 	_PC += 2;
+	m_extra_cycles += (IO_DCNTL >> 6) * 2; // memory wait states
 	return m_direct->read_byte(MMU_REMAP_ADDR(addr)) | (m_direct->read_byte(MMU_REMAP_ADDR(addr+1)) << 8);
 }
 


### PR DESCRIPTION
the definition of Z180_RCR_REFW had a copy/paste error.
added support for the Z180 internal Wait State Generator to the cycle-timing bringing it in line with real hardware.
Still missing: Dynamic RAM Refresh Control timing