### PR TITLE
Soreike! Anpanman Popcorn Factory year Confirmed as 1992.

### DIFF
--- a/src/mame/drivers/segac2.cpp
+++ b/src/mame/drivers/segac2.cpp
@@ -2559,7 +2559,7 @@ GAME( 1994, tantrbl3,  tantr,    segac,  ichir, segac2_state,    tantr,    ROT0,
 GAME( 1992, wwmarine,   0,       segac2, wwmarine, segac2_state, bloxeedc, ROT0,   "Sega", "Waku Waku Marine", 0 )
 
 // not really sure how this should hook up, things like the 'sold out' flags could be mechanical sensors, or from another MCU / CPU board in the actual popcorn part of the machine?
-GAME( 199?, anpanman,   0,       segac2, anpanman, segac2_state, bloxeedc, ROT0,   "Sega", "Soreike! Anpanman Popcorn Factory (Rev B)", MACHINE_MECHANICAL ) // 'Mechanical' part isn't emulated
+GAME( 1992, anpanman,   0,       segac2, anpanman, segac2_state, bloxeedc, ROT0,   "Sega", "Soreike! Anpanman Popcorn Factory (Rev B)", MACHINE_MECHANICAL ) // 'Mechanical' part isn't emulated
 GAME( 1993, sonicpop,   0,       segac2, sonicpop, segac2_state, bloxeedc, ROT0,   "Sega", "SegaSonic Popcorn Shop (Rev B)", MACHINE_MECHANICAL ) // region DSW for USA / Export / Japan, still speaks Japanese tho.  'Mechanical' part isn't emulated
 
 GAME( 1993, sonicfgt,  0,        segac2, systemc_generic, segac2_state, bloxeedc, ROT0,   "Sega", "Sega Sonic Cosmo Fighter", 0 )


### PR DESCRIPTION
Soreike! Anpanman Popcorn Factory year found on SEGA and kidstube website.
https://sega.jp/business/news/0807/
http://kidstube.jp/2017/11/14/%e3%80%90%e8%b2%b4%e9%87%8d%e3%81%aa%e5%88%9d%e4%bb%a3%e3%80%91%e3%81%9d%e3%82%8c%e3%81%84%e3%81%91%ef%bc%81%e3%82%a2%e3%83%b3%e3%83%91%e3%83%b3%e3%83%9e%e3%83%b3-%e3%83%9d%e3%83%83%e3%83%97%e3%82%b3/