### PR TITLE
fmtowns: correct scrolling in 16-bit color mode

### DIFF
--- a/src/mame/video/fmtowns.cpp
+++ b/src/mame/video/fmtowns.cpp
@@ -959,7 +959,7 @@ void towns_state::towns_crtc_draw_scan_layer_hicolour(bitmap_rgb32 &bitmap,const
 			off += scroll;
 		}
 		hzoom = ((m_video.towns_crtc_reg[27] & 0x0f00) >> 8) + 1;
-		off += (m_video.towns_crtc_reg[11] - m_video.towns_crtc_reg[22]) / hzoom;
+		off += (m_video.towns_crtc_reg[11] - m_video.towns_crtc_reg[22]) * (hzoom * 2);
 	}
 	else
 	{
@@ -971,7 +971,7 @@ void towns_state::towns_crtc_draw_scan_layer_hicolour(bitmap_rgb32 &bitmap,const
 			off += scroll;
 		}
 		hzoom = (m_video.towns_crtc_reg[27] & 0x000f) + 1;
-		off += (m_video.towns_crtc_reg[9] - m_video.towns_crtc_reg[18]) / hzoom;
+		off += (m_video.towns_crtc_reg[9] - m_video.towns_crtc_reg[18]) * (hzoom * 2);
 	}
 
 	off += line * linesize;


### PR DESCRIPTION
Final fix for scrolling / positioning issues (hopefully). Fixes Psychic Detective Vol. 5.