### PR TITLE
Added 'Sideline'

### DIFF
--- a/hash/ibm5170_cdrom.xml
+++ b/hash/ibm5170_cdrom.xml
@@ -26,8 +26,8 @@
 	<software name="sideline" supported="partial">
 		<description>Sideline</description>
 		<year>1996</year>
-		<publisher>EMAG</publisher>
-		<info name="version" value="1.0"/ >
+		<publisher>EMAG Soft</publisher>
+		<info name="version" value="1.20"/ >
 		<part name="cdrom" interface="cdrom">
 			<feature name="disk_label" value="Sideline" />
 			<diskarea name="cdrom">

--- a/hash/ibm5170_cdrom.xml
+++ b/hash/ibm5170_cdrom.xml
@@ -23,7 +23,7 @@
 		</part>
 	</software>
 	
-	<software name="sideline" supported="partial">
+	<software name="sideline">
 		<description>Sideline</description>
 		<year>1996</year>
 		<publisher>EMAG Soft</publisher>

--- a/hash/ibm5170_cdrom.xml
+++ b/hash/ibm5170_cdrom.xml
@@ -22,6 +22,19 @@
 			</diskarea>
 		</part>
 	</software>
+	
+	<software name="sideline" supported="partial">
+		<description>Sideline</description>
+		<year>1996</year>
+		<publisher>EMAG</publisher>
+		<info name="version" value="1.0"/ >
+		<part name="cdrom" interface="cdrom">
+			<feature name="disk_label" value="Sideline" />
+			<diskarea name="cdrom">
+				<disk name="sideline" sha1="2926390df55f17d1c472deb1ddeed428829af4e4" />
+			</diskarea>			
+		</part>
+	</software>
 
 	<software name="ultrasnd" supported="partial">
 		<!-- includes Gravis UltraSound (GUS) Installation - V4.11 -->


### PR DESCRIPTION
Added 'Sideline', probably the best sidescrolling shoot 'em up for DOS, and also one of the most obscure.
The game has been declared freeware. More info here > http://sideline.ghegs.com/

I've converted the bin/cue to a chd which can be downloaded here > http://www.mediafire.com/file/pd1utz71px292bs/sideline.chd

Some extra info:
To run the game, you'll need to run INSTALL.BAT on the disc first. Next run SNDSETUP from the installation directory to configure sound cards.
To play, run MAIN.EXE from the disc.