### PR TITLE
fmtowns: fixed mouse cursor moving on its own in Data West games

### DIFF
--- a/src/mame/drivers/fmtowns.cpp
+++ b/src/mame/drivers/fmtowns.cpp
@@ -985,6 +985,7 @@ READ8_MEMBER(towns_state::towns_padport_r)
 					break;
 				case MOUSE_START:
 				case MOUSE_SYNC:
+					break;
 				default:
 					if(m_towns_mouse_output < MOUSE_Y_LOW)
 						ret |= 0x0f;
@@ -1072,6 +1073,7 @@ READ8_MEMBER(towns_state::towns_padport_r)
 					break;
 				case MOUSE_START:
 				case MOUSE_SYNC:
+					break;
 				default:
 					if(m_towns_mouse_output < MOUSE_Y_LOW)
 						ret |= 0x0f;


### PR DESCRIPTION
This change fixes a bug that caused the mouse cursor to move downwards on its own in some Data West games (Misty, Psychic Detective series, The 4th Unit series). These games seem to poll the mouse port in a peculiar way that caused the reads to return 0x0f sometimes even if the user wasn't moving the mouse.

It doesn't break anything in other games or in TownsOS / Windows, as far as I have tested.