### PR TITLE
Override and fallback options for artwork

### DIFF
--- a/src/emu/emuopts.cpp
+++ b/src/emu/emuopts.cpp
@@ -116,6 +116,8 @@ const options_entry emu_options::s_option_entries[] =
 	{ OPTION_USE_BEZELS ";bezel",                        "1",         OPTION_BOOLEAN,    "enable bezels if artwork is enabled and available" },
 	{ OPTION_USE_CPANELS ";cpanel",                      "1",         OPTION_BOOLEAN,    "enable cpanels if artwork is enabled and available" },
 	{ OPTION_USE_MARQUEES ";marquee",                    "1",         OPTION_BOOLEAN,    "enable marquees if artwork is enabled and available" },
+	{ OPTION_FALLBACK_ARTWORK,                           nullptr,     OPTION_STRING,     "fallback artwork if no external artwork or internal driver layout defined" },
+	{ OPTION_OVERRIDE_ARTWORK,                           nullptr,     OPTION_STRING,     "override artwork for external artwork and internal driver layout" },
 
 	// screen options
 	{ nullptr,                                           nullptr,     OPTION_HEADER,     "CORE SCREEN OPTIONS" },

--- a/src/emu/emuopts.h
+++ b/src/emu/emuopts.h
@@ -100,6 +100,8 @@
 #define OPTION_USE_BEZELS           "use_bezels"
 #define OPTION_USE_CPANELS          "use_cpanels"
 #define OPTION_USE_MARQUEES         "use_marquees"
+#define OPTION_FALLBACK_ARTWORK     "fallback_artwork"
+#define OPTION_OVERRIDE_ARTWORK     "override_artwork"
 
 // core screen options
 #define OPTION_BRIGHTNESS           "brightness"
@@ -376,6 +378,8 @@ public:
 	bool use_bezels() const { return bool_value(OPTION_USE_BEZELS); }
 	bool use_cpanels() const { return bool_value(OPTION_USE_CPANELS); }
 	bool use_marquees() const { return bool_value(OPTION_USE_MARQUEES); }
+	const char *fallback_artwork() const { return value(OPTION_FALLBACK_ARTWORK); }
+	const char *override_artwork() const { return value(OPTION_OVERRIDE_ARTWORK); }
 
 	// core screen options
 	float brightness() const { return float_value(OPTION_BRIGHTNESS); }

--- a/src/emu/render.cpp
+++ b/src/emu/render.cpp
@@ -1574,47 +1574,80 @@ void render_target::update_layer_config()
 
 void render_target::load_layout_files(const internal_layout *layoutfile, bool singlefile)
 {
-	bool have_default = false;
+	bool have_default  = false;
+	bool have_artwork  = false;
+	bool have_override = false;
 
 	// if there's an explicit file, load that first
 	const char *basename = m_manager.machine().basename();
 	if (layoutfile)
-		have_default |= load_layout_file(basename, layoutfile);
+		have_artwork |= load_layout_file(basename, layoutfile);
 
 	// if we're only loading this file, we know our final result
 	if (singlefile)
 		return;
 
-	// if override_artwork defined, load that and return
+	// if override_artwork defined, load that and skip artwork other than default
 	if (m_manager.machine().options().override_artwork())
 	{
 		if (load_layout_file(m_manager.machine().options().override_artwork(), m_manager.machine().options().override_artwork()))
-			return;
+			have_override |= true;
 		if (load_layout_file(m_manager.machine().options().override_artwork(), "default"))
-			return;
+			have_override |= true;
 	}
 
-	// try to load a file based on the driver name
 	const game_driver &system = m_manager.machine().system();
-	if (!load_layout_file(basename, system.name))
-		have_default |= load_layout_file(basename, "default");
-	else
-		have_default |= true;
 
-	// if a default view has been specified, use that as a fallback
-	if (system.default_layout != nullptr)
-		have_default |= load_layout_file(nullptr, system.default_layout);
-	if (m_manager.machine().config().m_default_layout != nullptr)
-		have_default |= load_layout_file(nullptr, m_manager.machine().config().m_default_layout);
+	// Skip if override_artwork has found artwork
+	if (!have_override)
+	{
 
-	// try to load another file based on the parent driver name
-	int cloneof = driver_list::clone(system);
-	if (cloneof != -1) {
-		if (!load_layout_file(driver_list::driver(cloneof).name, driver_list::driver(cloneof).name))
-			have_default |= load_layout_file(driver_list::driver(cloneof).name, "default");
+		// try to load a file based on the driver name
+		if (!load_layout_file(basename, system.name))
+			have_artwork |= load_layout_file(basename, "default");
 		else
-			have_default |= true;
+			have_artwork |= true;
+
+		// if a default view has been specified, use that as a fallback
+		if (system.default_layout != nullptr)
+			have_default |= load_layout_file(nullptr, system.default_layout);
+		if (m_manager.machine().config().m_default_layout != nullptr)
+			have_default |= load_layout_file(nullptr, m_manager.machine().config().m_default_layout);
+
+		// try to load another file based on the parent driver name
+		int cloneof = driver_list::clone(system);
+		if (cloneof != -1)
+		{
+			if (!load_layout_file(driver_list::driver(cloneof).name, driver_list::driver(cloneof).name))
+				have_artwork |= load_layout_file(driver_list::driver(cloneof).name, "default");
+			else
+				have_artwork |= true;
+		}
+
+		// Check the parent of the parent to cover bios based artwork
+		if (cloneof != -1) {
+			const game_driver &clone(driver_list::driver(cloneof));
+			int cloneofclone = driver_list::clone(clone);
+			if (cloneofclone != -1 && cloneofclone != cloneof)
+			{
+				if (!load_layout_file(driver_list::driver(cloneofclone).name, driver_list::driver(cloneofclone).name))
+					have_artwork |= load_layout_file(driver_list::driver(cloneofclone).name, "default");
+				else
+					have_artwork |= true;
+			}
+		}
+
+		// Use fallback artwork if defined and no artwork has been found yet
+		if (!have_artwork && m_manager.machine().options().fallback_artwork())
+		{
+			if (!load_layout_file(m_manager.machine().options().fallback_artwork(), m_manager.machine().options().fallback_artwork()))
+				have_artwork |= load_layout_file(m_manager.machine().options().fallback_artwork(), "default");
+			else
+				have_artwork |= true;
+		}
+
 	}
+
 	screen_device_iterator iter(m_manager.machine().root_device());
 	unsigned const screens = iter.count();
 
@@ -1629,29 +1662,7 @@ void render_target::load_layout_files(const internal_layout *layoutfile, bool si
 			throw emu_fatalerror("Couldn't parse default layout??");
 	}
 
-	// Check the parent of the parent to cover bios based artwork
-	if (cloneof != -1) {
-		const game_driver &clone(driver_list::driver(cloneof));
-		int cloneofclone = driver_list::clone(clone);
-		if (cloneofclone != -1 && cloneofclone != cloneof)
-		{
-			if (!load_layout_file(driver_list::driver(cloneofclone).name, driver_list::driver(cloneofclone).name))
-				have_default |= load_layout_file(driver_list::driver(cloneofclone).name, "default");
-			else
-				have_default |= true;
-		}
-	}
-
-	// Use fallback artwork if defined and no artwork has been found yet
-	if (m_manager.machine().options().fallback_artwork())
-	{
-		if (!load_layout_file(m_manager.machine().options().fallback_artwork(), m_manager.machine().options().fallback_artwork()))
-			have_default |= load_layout_file(m_manager.machine().options().fallback_artwork(), "default");
-		else
-			have_default |= true;
-	}
-
-	if (!have_default)
+	if (!have_default && !have_artwork)
 	{
 		if (screens == 0)
 		{

--- a/src/emu/render.cpp
+++ b/src/emu/render.cpp
@@ -1651,12 +1651,6 @@ void render_target::load_layout_files(const internal_layout *layoutfile, bool si
 			have_default |= true;
 	}
 
-	// if a default view has been specified, use that as a fallback
-	if (system.default_layout != nullptr)
-		have_default |= load_layout_file(nullptr, system.default_layout);
-	if (m_manager.machine().config().m_default_layout != nullptr)
-		have_default |= load_layout_file(nullptr, m_manager.machine().config().m_default_layout);
-
 	if (!have_default)
 	{
 		if (screens == 0)

--- a/src/emu/render.cpp
+++ b/src/emu/render.cpp
@@ -1591,9 +1591,9 @@ void render_target::load_layout_files(const internal_layout *layoutfile, bool si
 	if (m_manager.machine().options().override_artwork())
 	{
 		if (load_layout_file(m_manager.machine().options().override_artwork(), m_manager.machine().options().override_artwork()))
-			have_override |= true;
-		if (load_layout_file(m_manager.machine().options().override_artwork(), "default"))
-			have_override |= true;
+			have_override = true;
+		else if (load_layout_file(m_manager.machine().options().override_artwork(), "default"))
+			have_override = true;
 	}
 
 	const game_driver &system = m_manager.machine().system();
@@ -1606,7 +1606,7 @@ void render_target::load_layout_files(const internal_layout *layoutfile, bool si
 		if (!load_layout_file(basename, system.name))
 			have_artwork |= load_layout_file(basename, "default");
 		else
-			have_artwork |= true;
+			have_artwork = true;
 
 		// if a default view has been specified, use that as a fallback
 		if (system.default_layout != nullptr)
@@ -1621,7 +1621,7 @@ void render_target::load_layout_files(const internal_layout *layoutfile, bool si
 			if (!load_layout_file(driver_list::driver(cloneof).name, driver_list::driver(cloneof).name))
 				have_artwork |= load_layout_file(driver_list::driver(cloneof).name, "default");
 			else
-				have_artwork |= true;
+				have_artwork = true;
 		}
 
 		// Check the parent of the parent to cover bios based artwork
@@ -1633,7 +1633,7 @@ void render_target::load_layout_files(const internal_layout *layoutfile, bool si
 				if (!load_layout_file(driver_list::driver(cloneofclone).name, driver_list::driver(cloneofclone).name))
 					have_artwork |= load_layout_file(driver_list::driver(cloneofclone).name, "default");
 				else
-					have_artwork |= true;
+					have_artwork = true;
 			}
 		}
 
@@ -1643,7 +1643,7 @@ void render_target::load_layout_files(const internal_layout *layoutfile, bool si
 			if (!load_layout_file(m_manager.machine().options().fallback_artwork(), m_manager.machine().options().fallback_artwork()))
 				have_artwork |= load_layout_file(m_manager.machine().options().fallback_artwork(), "default");
 			else
-				have_artwork |= true;
+				have_artwork = true;
 		}
 
 	}


### PR DESCRIPTION
I've added a override_artwork and fallback_artwork to the MAME options. This will allow a user to override (no other artwork is loaded) the artwork or provide a fallback scenario for artwork. In discussion on the forum, the following order was agreed upon:
- If -override_artwork set: load override artwork, and return when successful
- Load explicit file, return when single file is set (UNCHANGED)
- Load driver name (UNCHANGED)
- Load internal default views (UNCHANGED)
- Load parent driver (UNCHANGED)
- Load parent of parent (will find bios artwork, e.g. neogeo for clones of neogeo games)
- If -fallback_artwork set: load fallback artwork
- For single screen: load internal horizont or vertical (UNCHANGED)
- If no layout has been found, load internal defaults based on number of screens (0, 2, 3, 4) (UNCHANGED)

As this is to be my first contribution to this MAME repository, please be gentle but firm. :) I would like to learn as much as possible, so any and all improvement suggestions are welcome.
