### PR TITLE
Trigger a fatal error when console was asked but the console plugin not found.

### DIFF
--- a/src/frontend/mame/mame.cpp
+++ b/src/frontend/mame/mame.cpp
@@ -161,7 +161,7 @@ void mame_machine_manager::start_luaengine()
 		}
 		else
 		{
-			osd_printf_error("**Console plugin not found. LUA Console will not start**\n");
+			fatalerror("Console plugin not found.\n");
 		}
 	}
 

--- a/src/frontend/mame/mame.cpp
+++ b/src/frontend/mame/mame.cpp
@@ -155,7 +155,14 @@ void mame_machine_manager::start_luaengine()
 	}
 	if (options().console())
 	{
-		m_plugins->set_value("console", "1", OPTION_PRIORITY_CMDLINE);
+		if (m_plugins->exists(OPTION_CONSOLE))
+		{
+			m_plugins->set_value(OPTION_CONSOLE, "1", OPTION_PRIORITY_CMDLINE);
+		}
+		else
+		{
+			osd_printf_error("**Console plugin not found. LUA Console will not start**\n");
+		}
 	}
 
 	m_lua->initialize();


### PR DESCRIPTION
In absence of the console plugin, the option entry was not found in m_plugins, making the set_value() crash when deferencing the result of get_entry().

Instead, an error message is logged telling the plugin is not found.