### PR TITLE
pgm2: memcard reader now uses image_device stuff, cards can be inserted / removed and get saved [Metallic, David Haywood]

### DIFF
--- a/scripts/target/mame/arcade.lua
+++ b/scripts/target/mame/arcade.lua
@@ -1950,6 +1950,8 @@ files {
 	MAME_DIR .. "src/mame/drivers/pgm2.cpp",
 	MAME_DIR .. "src/mame/video/pgm2.cpp",
 	MAME_DIR .. "src/mame/includes/pgm2.h",
+	MAME_DIR .. "src/mame/machine/pgm2_memcard.cpp",
+	MAME_DIR .. "src/mame/machine/pgm2_memcard.h",
 	MAME_DIR .. "src/mame/drivers/pgm3.cpp",
 	MAME_DIR .. "src/mame/drivers/spoker.cpp",
 	MAME_DIR .. "src/mame/machine/igs036crypt.cpp",

--- a/src/mame/includes/pgm2.h
+++ b/src/mame/includes/pgm2.h
@@ -16,6 +16,7 @@
 #include "machine/nvram.h"
 #include "machine/timer.h"
 #include "machine/atmel_arm_aic.h"
+#include "machine/pgm2_memcard.h"
 
 class pgm2_state : public driver_device
 {
@@ -39,7 +40,11 @@ public:
 		m_sp_palette(*this, "sp_palette"),
 		m_bg_palette(*this, "bg_palette"),
 		m_tx_palette(*this, "tx_palette"),
-		m_mcu_timer(*this, "mcu_timer")
+		m_mcu_timer(*this, "mcu_timer"),
+		m_memcard0(*this, "memcard_p1"),
+		m_memcard1(*this, "memcard_p2"),
+		m_memcard2(*this, "memcard_p3"),
+		m_memcard3(*this, "memcard_p4")
 	{ }
 
 	DECLARE_READ32_MEMBER(unk_startup_r);
@@ -116,9 +121,7 @@ private:
 	uint32_t m_mcu_result0;
 	uint32_t m_mcu_result1;
 	uint8_t m_mcu_last_cmd;
-	void mcu_command(bool is_command);
-	uint8_t m_card_data[4][0x100];
-	bool m_have_card[4];
+	void mcu_command(address_space &space, bool is_command);
 
 	// devices
 	required_device<cpu_device> m_maincpu;
@@ -139,6 +142,13 @@ private:
 	required_device<palette_device> m_bg_palette;
 	required_device<palette_device> m_tx_palette;
 	required_device<timer_device> m_mcu_timer;
+
+	optional_device<pgm2_memcard_device> m_memcard0;
+	optional_device<pgm2_memcard_device> m_memcard1;
+	optional_device<pgm2_memcard_device> m_memcard2;
+	optional_device<pgm2_memcard_device> m_memcard3;
+	pgm2_memcard_device *m_memcard_device[4];
+
 };
 
 #endif

--- a/src/mame/machine/pgm2_memcard.cpp
+++ b/src/mame/machine/pgm2_memcard.cpp
@@ -1,0 +1,91 @@
+// license:BSD-3-Clause
+// copyright-holders:David Haywood, Miodrag Milanovic
+/*********************************************************************
+
+    pgm2_memcard.cpp
+
+    PGM2 Memory card functions.
+	(based on ng_memcard.cpp)
+
+*********************************************************************/
+
+#include "emu.h"
+#include "emuopts.h"
+
+#include "pgm2_memcard.h"
+
+
+// device type definition
+DEFINE_DEVICE_TYPE(PGM2_MEMCARD, pgm2_memcard_device, "pgm2_memcard", "PGM2 Memory Card")
+
+//-------------------------------------------------
+//  pgm2_memcard_device - constructor
+//-------------------------------------------------
+
+pgm2_memcard_device::pgm2_memcard_device(const machine_config &mconfig, const char *tag, device_t *owner, uint32_t clock)
+	: device_t(mconfig, PGM2_MEMCARD, tag, owner, clock)
+	, device_image_interface(mconfig, *this)
+{
+}
+
+
+//-------------------------------------------------
+//  device_start - device-specific startup
+//-------------------------------------------------
+
+void pgm2_memcard_device::device_start()
+{
+	save_item(NAME(m_memcard_data));
+}
+
+/*-------------------------------------------------
+    memcard_insert - insert an existing memory card
+    with the given index
+-------------------------------------------------*/
+
+image_init_result pgm2_memcard_device::call_load()
+{
+	if(length() != 0x100)
+		return image_init_result::FAIL;
+
+	fseek(0, SEEK_SET);
+	size_t ret = fread(m_memcard_data, 0x100);
+	if(ret != 0x100)
+		return image_init_result::FAIL;
+
+	return image_init_result::PASS;
+}
+
+void pgm2_memcard_device::call_unload()
+{
+	fseek(0, SEEK_SET);
+	fwrite(m_memcard_data, 0x100);
+}
+
+image_init_result pgm2_memcard_device::call_create(int format_type, util::option_resolution *format_options)
+{
+	// cards must contain valid defaults for each game / region or they don't work?
+	memory_region *rgn = memregion("^default_card");
+
+	if (!rgn)
+		return image_init_result::FAIL;
+
+	memcpy(m_memcard_data, rgn->base(), 0x100);
+
+	size_t ret = fwrite(m_memcard_data, 0x100);
+	if(ret != 0x100)
+		return image_init_result::FAIL;
+
+	return image_init_result::PASS;
+}
+
+
+READ8_MEMBER(pgm2_memcard_device::read)
+{
+	return m_memcard_data[offset];
+}
+
+WRITE8_MEMBER(pgm2_memcard_device::write)
+{
+	m_memcard_data[offset] = data;
+}

--- a/src/mame/machine/pgm2_memcard.h
+++ b/src/mame/machine/pgm2_memcard.h
@@ -1,0 +1,67 @@
+// license:BSD-3-Clause
+// copyright-holders:David Haywood, Miodrag Milanovic
+/*********************************************************************
+
+    pgm2_memcard.h
+
+    PGM2 Memory card functions.
+	(based on ng_memcard.h)
+
+*********************************************************************/
+#ifndef MAME_MACHINE_PGM2_MEMCARD_H
+#define MAME_MACHINE_PGM2_MEMCARD_H
+
+#pragma once
+
+
+//**************************************************************************
+//  INTERFACE CONFIGURATION MACROS
+//**************************************************************************
+
+#define MCFG_PGM2_MEMCARD_ADD(_tag) \
+	MCFG_DEVICE_ADD(_tag, PGM2_MEMCARD, 0)
+
+/***************************************************************************
+    FUNCTION PROTOTYPES
+***************************************************************************/
+
+// ======================> pgm2_memcard_device
+
+class pgm2_memcard_device :  public device_t,
+							public device_image_interface
+{
+public:
+	// construction/destruction
+	pgm2_memcard_device(const machine_config &mconfig, const char *tag, device_t *owner, uint32_t clock);
+
+	virtual iodevice_t image_type() const override { return IO_MEMCARD; }
+
+	virtual bool is_readable()  const override { return true; }
+	virtual bool is_writeable() const override { return true; }
+	virtual bool is_creatable() const override { return true; }
+	virtual bool must_be_loaded() const override { return false; }
+	virtual bool is_reset_on_load() const override { return false; }
+	virtual const char *file_extensions() const override { return "pg2,bin,mem"; }
+
+	virtual image_init_result call_load() override;
+	virtual void call_unload() override;
+	virtual image_init_result call_create(int format_type, util::option_resolution *format_options) override;
+
+	// device-level overrides
+	virtual void device_start() override;
+
+	DECLARE_READ8_MEMBER(read);
+	DECLARE_WRITE8_MEMBER(write);
+
+	/* returns the index of the current memory card, or -1 if none */
+	int present() { return is_loaded() ? 0 : -1; }
+private:
+	uint8_t m_memcard_data[0x100];
+};
+
+
+// device type definition
+DECLARE_DEVICE_TYPE(PGM2_MEMCARD, pgm2_memcard_device)
+
+
+#endif // MAME_MACHINE_PGM2_MEMCARD_H


### PR DESCRIPTION
promoted China set of Oriental Legend 2 to working
promoted Knights of Valour 2 New Legend to working

as each game/region requires a valid default card in order to save said cards are part of romset.

(there's probably a cleaner way to do the device finder stuff but I forgot and can't find reference)