### PR TITLE
fmtowns: implement sprite rotation

### DIFF
--- a/src/mame/includes/fmtowns.h
+++ b/src/mame/includes/fmtowns.h
@@ -372,8 +372,8 @@ public:
 	void towns_crtc_refresh_mode();
 	void towns_update_kanji_offset();
 	void towns_update_palette();
-	void render_sprite_4(uint32_t poffset, uint32_t coffset, uint16_t x, uint16_t y, bool xflip, bool yflip, bool xhalfsize, bool yhalfsize, const rectangle* rect);
-	void render_sprite_16(uint32_t poffset, uint16_t x, uint16_t y, bool xflip, bool yflip, bool xhalfsize, bool yhalfsize, const rectangle* rect);
+	void render_sprite_4(uint32_t poffset, uint32_t coffset, uint16_t x, uint16_t y, bool xflip, bool yflip, bool xhalfsize, bool yhalfsize, bool rotation, const rectangle* rect);
+	void render_sprite_16(uint32_t poffset, uint16_t x, uint16_t y, bool xflip, bool yflip, bool xhalfsize, bool yhalfsize, bool rotation, const rectangle* rect);
 	void draw_sprites(const rectangle* rect);
 	void towns_crtc_draw_scan_layer_hicolour(bitmap_rgb32 &bitmap,const rectangle* rect,int layer,int line,int scanline);
 	void towns_crtc_draw_scan_layer_256(bitmap_rgb32 &bitmap,const rectangle* rect,int layer,int line,int scanline);


### PR DESCRIPTION
This change implements sprite attribute bit 14. This swaps the X and Y coordinates and allows for sprite rotation in 90 degree increments, by combining it with the mirroring bits.

Fixes most (but not all) graphical glitches in After Burner 1 and 3.

As with the half-size attributes, rotation of 16-bit color sprites is untested as I haven't found any test cases yet.