### PR TITLE
fmtowns: fix horizontal wrap for bitmap layers

### DIFF
--- a/src/mame/video/fmtowns.cpp
+++ b/src/mame/video/fmtowns.cpp
@@ -1041,7 +1041,7 @@ void towns_state::towns_crtc_draw_scan_layer_hicolour(bitmap_rgb32 &bitmap,const
 		linesize = m_video.towns_crtc_reg[24] * 4;
 	
 	// TODO: figure out how to wrap when there are sprites on layer 1
-	auto wrap = [layer,sprites_enabled,linesize](int line, uint32_t off)->bool
+	auto wrap = [layer,sprites_enabled,linesize](int line, uint32_t off)->int
 	{
 		return ((layer == 0 || !sprites_enabled) && off >= (line * linesize) && off - (line * linesize) >= linesize);
 	};
@@ -1250,7 +1250,7 @@ void towns_state::towns_crtc_draw_scan_layer_256(bitmap_rgb32 &bitmap,const rect
 		linesize = m_video.towns_crtc_reg[24] * 8;
 
 	// TODO: figure out how to wrap when there are sprites on layer 1
-	auto wrap = [layer,sprites_enabled,linesize](int line, uint32_t off)->bool
+	auto wrap = [layer,sprites_enabled,linesize](int line, uint32_t off)->int
 	{
 		return ((layer == 0 || !sprites_enabled) && off >= (line * linesize) && off - (line * linesize) >= linesize);
 	};
@@ -1403,7 +1403,7 @@ void towns_state::towns_crtc_draw_scan_layer_16(bitmap_rgb32 &bitmap,const recta
 		linesize = m_video.towns_crtc_reg[24] * 4;
 	
 	// TODO: figure out how to wrap when there are sprites on layer 1
-	auto wrap = [layer,sprites_enabled,linesize](int line, uint32_t off)->bool
+	auto wrap = [layer,sprites_enabled,linesize](int line, uint32_t off)->int
 	{
 		return ((layer == 0 || !sprites_enabled) && off >= (line * linesize) && off - (line * linesize) >= linesize);
 	};

--- a/src/mame/video/fmtowns.cpp
+++ b/src/mame/video/fmtowns.cpp
@@ -1033,11 +1033,18 @@ void towns_state::towns_crtc_draw_scan_layer_hicolour(bitmap_rgb32 &bitmap,const
 	int hzoom = 1;
 	int linesize;
 	uint32_t scroll;
+	bool sprites_enabled = (m_video.towns_sprite_reg[1] & 0x80) >> 7;
 
 	if(layer == 0)
 		linesize = m_video.towns_crtc_reg[20] * 4;
 	else
 		linesize = m_video.towns_crtc_reg[24] * 4;
+	
+	// TODO: figure out how to wrap when there are sprites on layer 1
+	auto wrap = [layer,sprites_enabled,linesize](int line, uint32_t off)->bool
+	{
+		return ((layer == 0 || !sprites_enabled) && off >= (line * linesize) && off - (line * linesize) >= linesize);
+	};
 
 	if(m_video.towns_display_page_sel != 0)
 		off = 0x20000;
@@ -1108,11 +1115,7 @@ void towns_state::towns_crtc_draw_scan_layer_hicolour(bitmap_rgb32 &bitmap,const
 				off &= 0x3ffff;  // 2 layers
 			else
 				off &= 0x7ffff;  // 1 layer
-			// TODO: figure out how to wrap when there are sprites on layer 1
-			if ((layer == 0 || !(m_video.towns_sprite_reg[1] & 0x80)) && off >= (line * linesize) && off - (line * linesize) >= linesize)
-				colour = (m_towns_gfxvram[off+(layer*0x40000)-linesize+1] << 8) | m_towns_gfxvram[off+(layer*0x40000)-linesize];
-			else
-				colour = (m_towns_gfxvram[off+(layer*0x40000)+1] << 8) | m_towns_gfxvram[off+(layer*0x40000)];
+			colour = (m_towns_gfxvram[off+(layer*0x40000)-(wrap(line,off)*linesize)+1] << 8) | m_towns_gfxvram[off+(layer*0x40000)-(wrap(line,off)*linesize)];
 			if(colour < 0x8000)
 			{
 				bitmap.pix32(scanline, x) =
@@ -1136,11 +1139,7 @@ void towns_state::towns_crtc_draw_scan_layer_hicolour(bitmap_rgb32 &bitmap,const
 				off &= 0x3ffff;  // 2 layers
 			else
 				off &= 0x7ffff;  // 1 layer
-			// TODO: figure out how to wrap when there are sprites on layer 1
-			if ((layer == 0 || !(m_video.towns_sprite_reg[1] & 0x80)) && off >= (line * linesize) && off - (line * linesize) >= linesize)
-				colour = (m_towns_gfxvram[off+(layer*0x40000)-linesize+1] << 8) | m_towns_gfxvram[off+(layer*0x40000)-linesize];
-			else
-				colour = (m_towns_gfxvram[off+(layer*0x40000)+1] << 8) | m_towns_gfxvram[off+(layer*0x40000)];
+			colour = (m_towns_gfxvram[off+(layer*0x40000)-(wrap(line,off)*linesize)+1] << 8) | m_towns_gfxvram[off+(layer*0x40000)-(wrap(line,off)*linesize)];
 			if(colour < 0x8000)
 			{
 				bitmap.pix32(scanline, x) =
@@ -1168,11 +1167,7 @@ void towns_state::towns_crtc_draw_scan_layer_hicolour(bitmap_rgb32 &bitmap,const
 				off &= 0x3ffff;  // 2 layers
 			else
 				off &= 0x7ffff;  // 1 layer
-			// TODO: figure out how to wrap when there are sprites on layer 1
-			if ((layer == 0 || !(m_video.towns_sprite_reg[1] & 0x80)) && off >= (line * linesize) && off - (line * linesize) >= linesize)
-				colour = (m_towns_gfxvram[off+(layer*0x40000)-linesize+1] << 8) | m_towns_gfxvram[off+(layer*0x40000)-linesize];
-			else
-				colour = (m_towns_gfxvram[off+(layer*0x40000)+1] << 8) | m_towns_gfxvram[off+(layer*0x40000)];
+			colour = (m_towns_gfxvram[off+(layer*0x40000)-(wrap(line,off)*linesize)+1] << 8) | m_towns_gfxvram[off+(layer*0x40000)-(wrap(line,off)*linesize)];
 			if(colour < 0x8000)
 			{
 				bitmap.pix32(scanline, x) =
@@ -1204,11 +1199,7 @@ void towns_state::towns_crtc_draw_scan_layer_hicolour(bitmap_rgb32 &bitmap,const
 				off &= 0x3ffff;  // 2 layers
 			else
 				off &= 0x7ffff;  // 1 layer
-			// TODO: figure out how to wrap when there are sprites on layer 1
-			if ((layer == 0 || !(m_video.towns_sprite_reg[1] & 0x80)) && off >= (line * linesize) && off - (line * linesize) >= linesize)
-				colour = (m_towns_gfxvram[off+(layer*0x40000)-linesize+1] << 8) | m_towns_gfxvram[off+(layer*0x40000)-linesize];
-			else
-				colour = (m_towns_gfxvram[off+(layer*0x40000)+1] << 8) | m_towns_gfxvram[off+(layer*0x40000)];
+			colour = (m_towns_gfxvram[off+(layer*0x40000)-(wrap(line,off)*linesize)+1] << 8) | m_towns_gfxvram[off+(layer*0x40000)-(wrap(line,off)*linesize)];
 			if(colour < 0x8000)
 			{
 				bitmap.pix32(scanline, x) =
@@ -1245,6 +1236,7 @@ void towns_state::towns_crtc_draw_scan_layer_256(bitmap_rgb32 &bitmap,const rect
 	int hzoom = 1;
 	int linesize;
 	uint32_t scroll;
+	bool sprites_enabled = (m_video.towns_sprite_reg[1] & 0x80) >> 7;
 
 	if(m_video.towns_display_page_sel != 0)
 		off = 0x20000;
@@ -1257,6 +1249,12 @@ void towns_state::towns_crtc_draw_scan_layer_256(bitmap_rgb32 &bitmap,const rect
 	else
 		linesize = m_video.towns_crtc_reg[24] * 8;
 
+	// TODO: figure out how to wrap when there are sprites on layer 1
+	auto wrap = [layer,sprites_enabled,linesize](int line, uint32_t off)->bool
+	{
+		return ((layer == 0 || !sprites_enabled) && off >= (line * linesize) && off - (line * linesize) >= linesize);
+	};
+	
 	if(layer != 0)
 	{
 		if(!(m_video.towns_video_reg[0] & 0x10))
@@ -1294,11 +1292,7 @@ void towns_state::towns_crtc_draw_scan_layer_256(bitmap_rgb32 &bitmap,const rect
 				off &= 0x3ffff;  // 2 layers
 			else
 				off &= 0x7ffff;  // 1 layer
-			// TODO: figure out how to wrap when there are sprites on layer 1
-			if ((layer == 0 || !(m_video.towns_sprite_reg[1] & 0x80)) && off >= (line * linesize) && off - (line * linesize) >= linesize)
-				colour = m_towns_gfxvram[off+(layer*0x40000)-linesize];
-			else
-				colour = m_towns_gfxvram[off+(layer*0x40000)];
+			colour = m_towns_gfxvram[off+(layer*0x40000)-(wrap(line,off)*linesize)];
 			if(colour != 0)
 			{
 				bitmap.pix32(scanline, x) = m_palette->pen(colour);
@@ -1315,11 +1309,7 @@ void towns_state::towns_crtc_draw_scan_layer_256(bitmap_rgb32 &bitmap,const rect
 				off &= 0x3ffff;  // 2 layers
 			else
 				off &= 0x7ffff;  // 1 layer
-			// TODO: figure out how to wrap when there are sprites on layer 1
-			if ((layer == 0 || !(m_video.towns_sprite_reg[1] & 0x80)) && off >= (line * linesize) && off - (line * linesize) >= linesize)
-				colour = m_towns_gfxvram[off+(layer*0x40000)-linesize];
-			else
-				colour = m_towns_gfxvram[off+(layer*0x40000)+1];
+			colour = m_towns_gfxvram[off+(layer*0x40000)-(wrap(line,off)*linesize)];
 			if(colour != 0)
 			{
 				bitmap.pix32(scanline, x) = m_palette->pen(colour);
@@ -1337,11 +1327,7 @@ void towns_state::towns_crtc_draw_scan_layer_256(bitmap_rgb32 &bitmap,const rect
 				off &= 0x3ffff;  // 2 layers
 			else
 				off &= 0x7ffff;  // 1 layer
-			// TODO: figure out how to wrap when there are sprites on layer 1
-			if ((layer == 0 || !(m_video.towns_sprite_reg[1] & 0x80)) && off >= (line * linesize) && off - (line * linesize) >= linesize)
-				colour = m_towns_gfxvram[off+(layer*0x40000)-linesize];
-			else
-				colour = m_towns_gfxvram[off+(layer*0x40000)+1];
+			colour = m_towns_gfxvram[off+(layer*0x40000)-(wrap(line,off)*linesize)];
 			if(colour != 0)
 			{
 				bitmap.pix32(scanline, x) = m_palette->pen(colour);
@@ -1360,11 +1346,7 @@ void towns_state::towns_crtc_draw_scan_layer_256(bitmap_rgb32 &bitmap,const rect
 				off &= 0x3ffff;  // 2 layers
 			else
 				off &= 0x7ffff;  // 1 layer
-			// TODO: figure out how to wrap when there are sprites on layer 1
-			if ((layer == 0 || !(m_video.towns_sprite_reg[1] & 0x80)) && off >= (line * linesize) && off - (line * linesize) >= linesize)
-				colour = m_towns_gfxvram[off+(layer*0x40000)-linesize];
-			else
-				colour = m_towns_gfxvram[off+(layer*0x40000)+1];
+			colour = m_towns_gfxvram[off+(layer*0x40000)-(wrap(line,off)*linesize)];
 			if(colour != 0)
 			{
 				bitmap.pix32(scanline, x) = m_palette->pen(colour);
@@ -1384,11 +1366,7 @@ void towns_state::towns_crtc_draw_scan_layer_256(bitmap_rgb32 &bitmap,const rect
 				off &= 0x3ffff;  // 2 layers
 			else
 				off &= 0x7ffff;  // 1 layer
-			// TODO: figure out how to wrap when there are sprites on layer 1
-			if ((layer == 0 || !(m_video.towns_sprite_reg[1] & 0x80)) && off >= (line * linesize) && off - (line * linesize) >= linesize)
-				colour = m_towns_gfxvram[off+(layer*0x40000)-linesize];
-			else
-				colour = m_towns_gfxvram[off+(layer*0x40000)+1];
+			colour = m_towns_gfxvram[off+(layer*0x40000)-(wrap(line,off)*linesize)];
 			if(colour != 0)
 			{
 				bitmap.pix32(scanline, x) = m_palette->pen(colour);
@@ -1410,6 +1388,7 @@ void towns_state::towns_crtc_draw_scan_layer_16(bitmap_rgb32 &bitmap,const recta
 	int hzoom = 1;
 	int linesize;
 	uint32_t scroll;
+	bool sprites_enabled = (m_video.towns_sprite_reg[1] & 0x80) >> 7;
 	palette_device* pal = (layer == 0) ? m_palette16_0 : m_palette16_1;
 
 	if(m_video.towns_display_page_sel != 0)
@@ -1422,6 +1401,12 @@ void towns_state::towns_crtc_draw_scan_layer_16(bitmap_rgb32 &bitmap,const recta
 		linesize = m_video.towns_crtc_reg[20] * 4;
 	else
 		linesize = m_video.towns_crtc_reg[24] * 4;
+	
+	// TODO: figure out how to wrap when there are sprites on layer 1
+	auto wrap = [layer,sprites_enabled,linesize](int line, uint32_t off)->bool
+	{
+		return ((layer == 0 || !sprites_enabled) && off >= (line * linesize) && off - (line * linesize) >= linesize);
+	};
 
 	if(layer != 0)
 	{
@@ -1460,20 +1445,12 @@ void towns_state::towns_crtc_draw_scan_layer_16(bitmap_rgb32 &bitmap,const recta
 				off &= 0x3ffff;  // 2 layers
 			else
 				off &= 0x7ffff;  // 1 layer
-			// TODO: figure out how to wrap when there are sprites on layer 1
-			if ((layer == 0 || !(m_video.towns_sprite_reg[1] & 0x80)) && off >= (line * linesize) && off - (line * linesize) >= linesize)
-				colour = m_towns_gfxvram[off+(layer*0x40000)-linesize] >> 4;
-			else
-				colour = m_towns_gfxvram[off+(layer*0x40000)] >> 4;
+			colour = m_towns_gfxvram[off+(layer*0x40000)-(wrap(line,off)*linesize)] >> 4;
 			if(colour != 0)
 			{
 				bitmap.pix32(scanline, x+1) = pal->pen(colour);
 			}
-			// TODO: figure out how to wrap when there are sprites on layer 1
-			if ((layer == 0 || !(m_video.towns_sprite_reg[1] & 0x80)) && off >= (line * linesize) && off - (line * linesize) >= linesize)
-				colour = m_towns_gfxvram[off+(layer*0x40000)-linesize] & 0x0f;
-			else
-				colour = m_towns_gfxvram[off+(layer*0x40000)] & 0x0f;
+			colour = m_towns_gfxvram[off+(layer*0x40000)-(wrap(line,off)*linesize)] & 0x0f;
 			if(colour != 0)
 			{
 				bitmap.pix32(scanline, x) = pal->pen(colour);
@@ -1490,21 +1467,13 @@ void towns_state::towns_crtc_draw_scan_layer_16(bitmap_rgb32 &bitmap,const recta
 				off &= 0x3ffff;  // 2 layers
 			else
 				off &= 0x7ffff;  // 1 layer
-			// TODO: figure out how to wrap when there are sprites on layer 1
-			if ((layer == 0 || !(m_video.towns_sprite_reg[1] & 0x80)) && off >= (line * linesize) && off - (line * linesize) >= linesize)
-				colour = m_towns_gfxvram[off+(layer*0x40000)-linesize] >> 4;
-			else
-				colour = m_towns_gfxvram[off+(layer*0x40000)] >> 4;
+			colour = m_towns_gfxvram[off+(layer*0x40000)-(wrap(line,off)*linesize)] >> 4;
 			if(colour != 0)
 			{
 				bitmap.pix32(scanline, x+2) = pal->pen(colour);
 				bitmap.pix32(scanline, x+3) = pal->pen(colour);
 			}
-			// TODO: figure out how to wrap when there are sprites on layer 1
-			if ((layer == 0 || !(m_video.towns_sprite_reg[1] & 0x80)) && off >= (line * linesize) && off - (line * linesize) >= linesize)
-				colour = m_towns_gfxvram[off+(layer*0x40000)-linesize] & 0x0f;
-			else
-				colour = m_towns_gfxvram[off+(layer*0x40000)] & 0x0f;
+			colour = m_towns_gfxvram[off+(layer*0x40000)-(wrap(line,off)*linesize)] & 0x0f;
 			if(colour != 0)
 			{
 				bitmap.pix32(scanline, x) = pal->pen(colour);
@@ -1522,22 +1491,14 @@ void towns_state::towns_crtc_draw_scan_layer_16(bitmap_rgb32 &bitmap,const recta
 				off &= 0x3ffff;  // 2 layers
 			else
 				off &= 0x7ffff;  // 1 layer
-			// TODO: figure out how to wrap when there are sprites on layer 1
-			if ((layer == 0 || !(m_video.towns_sprite_reg[1] & 0x80)) && off >= (line * linesize) && off - (line * linesize) >= linesize)
-				colour = m_towns_gfxvram[off+(layer*0x40000)-linesize] >> 4;
-			else
-				colour = m_towns_gfxvram[off+(layer*0x40000)] >> 4;
+			colour = m_towns_gfxvram[off+(layer*0x40000)-(wrap(line,off)*linesize)] >> 4;
 			if(colour != 0)
 			{
 				bitmap.pix32(scanline, x+3) = pal->pen(colour);
 				bitmap.pix32(scanline, x+4) = pal->pen(colour);
 				bitmap.pix32(scanline, x+5) = pal->pen(colour);
 			}
-			// TODO: figure out how to wrap when there are sprites on layer 1
-			if ((layer == 0 || !(m_video.towns_sprite_reg[1] & 0x80)) && off >= (line * linesize) && off - (line * linesize) >= linesize)
-				colour = m_towns_gfxvram[off+(layer*0x40000)-linesize] & 0x0f;
-			else
-				colour = m_towns_gfxvram[off+(layer*0x40000)] & 0x0f;
+			colour = m_towns_gfxvram[off+(layer*0x40000)-(wrap(line,off)*linesize)] & 0x0f;
 			if(colour != 0)
 			{
 				bitmap.pix32(scanline, x) = pal->pen(colour);
@@ -1556,11 +1517,7 @@ void towns_state::towns_crtc_draw_scan_layer_16(bitmap_rgb32 &bitmap,const recta
 				off &= 0x3ffff;  // 2 layers
 			else
 				off &= 0x7ffff;  // 1 layer
-			// TODO: figure out how to wrap when there are sprites on layer 1
-			if ((layer == 0 || !(m_video.towns_sprite_reg[1] & 0x80)) && off >= (line * linesize) && off - (line * linesize) >= linesize)
-				colour = m_towns_gfxvram[off+(layer*0x40000)-linesize] >> 4;
-			else
-				colour = m_towns_gfxvram[off+(layer*0x40000)] >> 4;
+			colour = m_towns_gfxvram[off+(layer*0x40000)-(wrap(line,off)*linesize)] >> 4;
 			if(colour != 0)
 			{
 				bitmap.pix32(scanline, x+4) = pal->pen(colour);
@@ -1568,11 +1525,7 @@ void towns_state::towns_crtc_draw_scan_layer_16(bitmap_rgb32 &bitmap,const recta
 				bitmap.pix32(scanline, x+6) = pal->pen(colour);
 				bitmap.pix32(scanline, x+7) = pal->pen(colour);
 			}
-			// TODO: figure out how to wrap when there are sprites on layer 1
-			if ((layer == 0 || !(m_video.towns_sprite_reg[1] & 0x80)) && off >= (line * linesize) && off - (line * linesize) >= linesize)
-				colour = m_towns_gfxvram[off+(layer*0x40000)-linesize] & 0x0f;
-			else
-				colour = m_towns_gfxvram[off+(layer*0x40000)] & 0x0f;
+			colour = m_towns_gfxvram[off+(layer*0x40000)-(wrap(line,off)*linesize)] & 0x0f;
 			if(colour != 0)
 			{
 				bitmap.pix32(scanline, x) = pal->pen(colour);
@@ -1592,11 +1545,7 @@ void towns_state::towns_crtc_draw_scan_layer_16(bitmap_rgb32 &bitmap,const recta
 				off &= 0x3ffff;  // 2 layers
 			else
 				off &= 0x7ffff;  // 1 layer
-			// TODO: figure out how to wrap when there are sprites on layer 1
-			if ((layer == 0 || !(m_video.towns_sprite_reg[1] & 0x80)) && off >= (line * linesize) && off - (line * linesize) >= linesize)
-				colour = m_towns_gfxvram[off+(layer*0x40000)-linesize] >> 4;
-			else
-				colour = m_towns_gfxvram[off+(layer*0x40000)] >> 4;
+			colour = m_towns_gfxvram[off+(layer*0x40000)-(wrap(line,off)*linesize)] >> 4;
 			if(colour != 0)
 			{
 				bitmap.pix32(scanline, x+5) = pal->pen(colour);
@@ -1605,11 +1554,7 @@ void towns_state::towns_crtc_draw_scan_layer_16(bitmap_rgb32 &bitmap,const recta
 				bitmap.pix32(scanline, x+8) = pal->pen(colour);
 				bitmap.pix32(scanline, x+9) = pal->pen(colour);
 			}
-			// TODO: figure out how to wrap when there are sprites on layer 1
-			if ((layer == 0 || !(m_video.towns_sprite_reg[1] & 0x80)) && off >= (line * linesize) && off - (line * linesize) >= linesize)
-				colour = m_towns_gfxvram[off+(layer*0x40000)-linesize] & 0x0f;
-			else
-				colour = m_towns_gfxvram[off+(layer*0x40000)] & 0x0f;
+			colour = m_towns_gfxvram[off+(layer*0x40000)-(wrap(line,off)*linesize)] & 0x0f;
 			if(colour != 0)
 			{
 				bitmap.pix32(scanline, x) = pal->pen(colour);

--- a/src/mame/video/fmtowns.cpp
+++ b/src/mame/video/fmtowns.cpp
@@ -903,9 +903,9 @@ void towns_state::render_sprite_16(uint32_t poffset, uint16_t x, uint16_t y, boo
 	{
 		ystart = y;
 		if (yhalfsize)
-			yend = y+16;
-		else
 			yend = y+8;
+		else
+			yend = y+16;
 		ydir = 1;
 	}
 	xstart &= 0x1ff;
@@ -1084,7 +1084,11 @@ void towns_state::towns_crtc_draw_scan_layer_hicolour(bitmap_rgb32 &bitmap,const
 			else
 				off &= 0x7ffff;  // 1 layer
 
-			colour = (m_towns_gfxvram[off+(layer*0x40000)+1] << 8) | m_towns_gfxvram[off+(layer*0x40000)];
+			// TODO: figure out how to wrap when there are sprites on layer 1
+			if ((layer == 0 || !(m_video.towns_sprite_reg[1] & 0x80)) && off >= (line * linesize) && off - (line * linesize) >= linesize)
+				colour = (m_towns_gfxvram[off+(layer*0x40000)-linesize+1] << 8) | m_towns_gfxvram[off+(layer*0x40000)-linesize];
+			else
+				colour = (m_towns_gfxvram[off+(layer*0x40000)+1] << 8) | m_towns_gfxvram[off+(layer*0x40000)];
 			if(colour < 0x8000)
 			{
 				bitmap.pix32(scanline, x) =
@@ -1104,7 +1108,11 @@ void towns_state::towns_crtc_draw_scan_layer_hicolour(bitmap_rgb32 &bitmap,const
 				off &= 0x3ffff;  // 2 layers
 			else
 				off &= 0x7ffff;  // 1 layer
-			colour = (m_towns_gfxvram[off+(layer*0x40000)+1] << 8) | m_towns_gfxvram[off+(layer*0x40000)];
+			// TODO: figure out how to wrap when there are sprites on layer 1
+			if ((layer == 0 || !(m_video.towns_sprite_reg[1] & 0x80)) && off >= (line * linesize) && off - (line * linesize) >= linesize)
+				colour = (m_towns_gfxvram[off+(layer*0x40000)-linesize+1] << 8) | m_towns_gfxvram[off+(layer*0x40000)-linesize];
+			else
+				colour = (m_towns_gfxvram[off+(layer*0x40000)+1] << 8) | m_towns_gfxvram[off+(layer*0x40000)];
 			if(colour < 0x8000)
 			{
 				bitmap.pix32(scanline, x) =
@@ -1128,7 +1136,11 @@ void towns_state::towns_crtc_draw_scan_layer_hicolour(bitmap_rgb32 &bitmap,const
 				off &= 0x3ffff;  // 2 layers
 			else
 				off &= 0x7ffff;  // 1 layer
-			colour = (m_towns_gfxvram[off+(layer*0x40000)+1] << 8) | m_towns_gfxvram[off+(layer*0x40000)];
+			// TODO: figure out how to wrap when there are sprites on layer 1
+			if ((layer == 0 || !(m_video.towns_sprite_reg[1] & 0x80)) && off >= (line * linesize) && off - (line * linesize) >= linesize)
+				colour = (m_towns_gfxvram[off+(layer*0x40000)-linesize+1] << 8) | m_towns_gfxvram[off+(layer*0x40000)-linesize];
+			else
+				colour = (m_towns_gfxvram[off+(layer*0x40000)+1] << 8) | m_towns_gfxvram[off+(layer*0x40000)];
 			if(colour < 0x8000)
 			{
 				bitmap.pix32(scanline, x) =
@@ -1156,7 +1168,11 @@ void towns_state::towns_crtc_draw_scan_layer_hicolour(bitmap_rgb32 &bitmap,const
 				off &= 0x3ffff;  // 2 layers
 			else
 				off &= 0x7ffff;  // 1 layer
-			colour = (m_towns_gfxvram[off+(layer*0x40000)+1] << 8) | m_towns_gfxvram[off+(layer*0x40000)];
+			// TODO: figure out how to wrap when there are sprites on layer 1
+			if ((layer == 0 || !(m_video.towns_sprite_reg[1] & 0x80)) && off >= (line * linesize) && off - (line * linesize) >= linesize)
+				colour = (m_towns_gfxvram[off+(layer*0x40000)-linesize+1] << 8) | m_towns_gfxvram[off+(layer*0x40000)-linesize];
+			else
+				colour = (m_towns_gfxvram[off+(layer*0x40000)+1] << 8) | m_towns_gfxvram[off+(layer*0x40000)];
 			if(colour < 0x8000)
 			{
 				bitmap.pix32(scanline, x) =
@@ -1188,7 +1204,11 @@ void towns_state::towns_crtc_draw_scan_layer_hicolour(bitmap_rgb32 &bitmap,const
 				off &= 0x3ffff;  // 2 layers
 			else
 				off &= 0x7ffff;  // 1 layer
-			colour = (m_towns_gfxvram[off+(layer*0x40000)+1] << 8) | m_towns_gfxvram[off+(layer*0x40000)];
+			// TODO: figure out how to wrap when there are sprites on layer 1
+			if ((layer == 0 || !(m_video.towns_sprite_reg[1] & 0x80)) && off >= (line * linesize) && off - (line * linesize) >= linesize)
+				colour = (m_towns_gfxvram[off+(layer*0x40000)-linesize+1] << 8) | m_towns_gfxvram[off+(layer*0x40000)-linesize];
+			else
+				colour = (m_towns_gfxvram[off+(layer*0x40000)+1] << 8) | m_towns_gfxvram[off+(layer*0x40000)];
 			if(colour < 0x8000)
 			{
 				bitmap.pix32(scanline, x) =
@@ -1274,7 +1294,11 @@ void towns_state::towns_crtc_draw_scan_layer_256(bitmap_rgb32 &bitmap,const rect
 				off &= 0x3ffff;  // 2 layers
 			else
 				off &= 0x7ffff;  // 1 layer
-			colour = m_towns_gfxvram[off+(layer*0x40000)];
+			// TODO: figure out how to wrap when there are sprites on layer 1
+			if ((layer == 0 || !(m_video.towns_sprite_reg[1] & 0x80)) && off >= (line * linesize) && off - (line * linesize) >= linesize)
+				colour = m_towns_gfxvram[off+(layer*0x40000)-linesize];
+			else
+				colour = m_towns_gfxvram[off+(layer*0x40000)];
 			if(colour != 0)
 			{
 				bitmap.pix32(scanline, x) = m_palette->pen(colour);
@@ -1291,7 +1315,11 @@ void towns_state::towns_crtc_draw_scan_layer_256(bitmap_rgb32 &bitmap,const rect
 				off &= 0x3ffff;  // 2 layers
 			else
 				off &= 0x7ffff;  // 1 layer
-			colour = m_towns_gfxvram[off+(layer*0x40000)+1];
+			// TODO: figure out how to wrap when there are sprites on layer 1
+			if ((layer == 0 || !(m_video.towns_sprite_reg[1] & 0x80)) && off >= (line * linesize) && off - (line * linesize) >= linesize)
+				colour = m_towns_gfxvram[off+(layer*0x40000)-linesize];
+			else
+				colour = m_towns_gfxvram[off+(layer*0x40000)+1];
 			if(colour != 0)
 			{
 				bitmap.pix32(scanline, x) = m_palette->pen(colour);
@@ -1309,7 +1337,11 @@ void towns_state::towns_crtc_draw_scan_layer_256(bitmap_rgb32 &bitmap,const rect
 				off &= 0x3ffff;  // 2 layers
 			else
 				off &= 0x7ffff;  // 1 layer
-			colour = m_towns_gfxvram[off+(layer*0x40000)+1];
+			// TODO: figure out how to wrap when there are sprites on layer 1
+			if ((layer == 0 || !(m_video.towns_sprite_reg[1] & 0x80)) && off >= (line * linesize) && off - (line * linesize) >= linesize)
+				colour = m_towns_gfxvram[off+(layer*0x40000)-linesize];
+			else
+				colour = m_towns_gfxvram[off+(layer*0x40000)+1];
 			if(colour != 0)
 			{
 				bitmap.pix32(scanline, x) = m_palette->pen(colour);
@@ -1328,7 +1360,11 @@ void towns_state::towns_crtc_draw_scan_layer_256(bitmap_rgb32 &bitmap,const rect
 				off &= 0x3ffff;  // 2 layers
 			else
 				off &= 0x7ffff;  // 1 layer
-			colour = m_towns_gfxvram[off+(layer*0x40000)+1];
+			// TODO: figure out how to wrap when there are sprites on layer 1
+			if ((layer == 0 || !(m_video.towns_sprite_reg[1] & 0x80)) && off >= (line * linesize) && off - (line * linesize) >= linesize)
+				colour = m_towns_gfxvram[off+(layer*0x40000)-linesize];
+			else
+				colour = m_towns_gfxvram[off+(layer*0x40000)+1];
 			if(colour != 0)
 			{
 				bitmap.pix32(scanline, x) = m_palette->pen(colour);
@@ -1348,7 +1384,11 @@ void towns_state::towns_crtc_draw_scan_layer_256(bitmap_rgb32 &bitmap,const rect
 				off &= 0x3ffff;  // 2 layers
 			else
 				off &= 0x7ffff;  // 1 layer
-			colour = m_towns_gfxvram[off+(layer*0x40000)+1];
+			// TODO: figure out how to wrap when there are sprites on layer 1
+			if ((layer == 0 || !(m_video.towns_sprite_reg[1] & 0x80)) && off >= (line * linesize) && off - (line * linesize) >= linesize)
+				colour = m_towns_gfxvram[off+(layer*0x40000)-linesize];
+			else
+				colour = m_towns_gfxvram[off+(layer*0x40000)+1];
 			if(colour != 0)
 			{
 				bitmap.pix32(scanline, x) = m_palette->pen(colour);
@@ -1420,12 +1460,20 @@ void towns_state::towns_crtc_draw_scan_layer_16(bitmap_rgb32 &bitmap,const recta
 				off &= 0x3ffff;  // 2 layers
 			else
 				off &= 0x7ffff;  // 1 layer
-			colour = m_towns_gfxvram[off+(layer*0x40000)] >> 4;
+			// TODO: figure out how to wrap when there are sprites on layer 1
+			if ((layer == 0 || !(m_video.towns_sprite_reg[1] & 0x80)) && off >= (line * linesize) && off - (line * linesize) >= linesize)
+				colour = m_towns_gfxvram[off+(layer*0x40000)-linesize] >> 4;
+			else
+				colour = m_towns_gfxvram[off+(layer*0x40000)] >> 4;
 			if(colour != 0)
 			{
 				bitmap.pix32(scanline, x+1) = pal->pen(colour);
 			}
-			colour = m_towns_gfxvram[off+(layer*0x40000)] & 0x0f;
+			// TODO: figure out how to wrap when there are sprites on layer 1
+			if ((layer == 0 || !(m_video.towns_sprite_reg[1] & 0x80)) && off >= (line * linesize) && off - (line * linesize) >= linesize)
+				colour = m_towns_gfxvram[off+(layer*0x40000)-linesize] & 0x0f;
+			else
+				colour = m_towns_gfxvram[off+(layer*0x40000)] & 0x0f;
 			if(colour != 0)
 			{
 				bitmap.pix32(scanline, x) = pal->pen(colour);
@@ -1442,13 +1490,21 @@ void towns_state::towns_crtc_draw_scan_layer_16(bitmap_rgb32 &bitmap,const recta
 				off &= 0x3ffff;  // 2 layers
 			else
 				off &= 0x7ffff;  // 1 layer
-			colour = m_towns_gfxvram[off+(layer*0x40000)] >> 4;
+			// TODO: figure out how to wrap when there are sprites on layer 1
+			if ((layer == 0 || !(m_video.towns_sprite_reg[1] & 0x80)) && off >= (line * linesize) && off - (line * linesize) >= linesize)
+				colour = m_towns_gfxvram[off+(layer*0x40000)-linesize] >> 4;
+			else
+				colour = m_towns_gfxvram[off+(layer*0x40000)] >> 4;
 			if(colour != 0)
 			{
 				bitmap.pix32(scanline, x+2) = pal->pen(colour);
 				bitmap.pix32(scanline, x+3) = pal->pen(colour);
 			}
-			colour = m_towns_gfxvram[off+(layer*0x40000)] & 0x0f;
+			// TODO: figure out how to wrap when there are sprites on layer 1
+			if ((layer == 0 || !(m_video.towns_sprite_reg[1] & 0x80)) && off >= (line * linesize) && off - (line * linesize) >= linesize)
+				colour = m_towns_gfxvram[off+(layer*0x40000)-linesize] & 0x0f;
+			else
+				colour = m_towns_gfxvram[off+(layer*0x40000)] & 0x0f;
 			if(colour != 0)
 			{
 				bitmap.pix32(scanline, x) = pal->pen(colour);
@@ -1466,14 +1522,22 @@ void towns_state::towns_crtc_draw_scan_layer_16(bitmap_rgb32 &bitmap,const recta
 				off &= 0x3ffff;  // 2 layers
 			else
 				off &= 0x7ffff;  // 1 layer
-			colour = m_towns_gfxvram[off+(layer*0x40000)] >> 4;
+			// TODO: figure out how to wrap when there are sprites on layer 1
+			if ((layer == 0 || !(m_video.towns_sprite_reg[1] & 0x80)) && off >= (line * linesize) && off - (line * linesize) >= linesize)
+				colour = m_towns_gfxvram[off+(layer*0x40000)-linesize] >> 4;
+			else
+				colour = m_towns_gfxvram[off+(layer*0x40000)] >> 4;
 			if(colour != 0)
 			{
 				bitmap.pix32(scanline, x+3) = pal->pen(colour);
 				bitmap.pix32(scanline, x+4) = pal->pen(colour);
 				bitmap.pix32(scanline, x+5) = pal->pen(colour);
 			}
-			colour = m_towns_gfxvram[off+(layer*0x40000)] & 0x0f;
+			// TODO: figure out how to wrap when there are sprites on layer 1
+			if ((layer == 0 || !(m_video.towns_sprite_reg[1] & 0x80)) && off >= (line * linesize) && off - (line * linesize) >= linesize)
+				colour = m_towns_gfxvram[off+(layer*0x40000)-linesize] & 0x0f;
+			else
+				colour = m_towns_gfxvram[off+(layer*0x40000)] & 0x0f;
 			if(colour != 0)
 			{
 				bitmap.pix32(scanline, x) = pal->pen(colour);
@@ -1492,7 +1556,11 @@ void towns_state::towns_crtc_draw_scan_layer_16(bitmap_rgb32 &bitmap,const recta
 				off &= 0x3ffff;  // 2 layers
 			else
 				off &= 0x7ffff;  // 1 layer
-			colour = m_towns_gfxvram[off+(layer*0x40000)] >> 4;
+			// TODO: figure out how to wrap when there are sprites on layer 1
+			if ((layer == 0 || !(m_video.towns_sprite_reg[1] & 0x80)) && off >= (line * linesize) && off - (line * linesize) >= linesize)
+				colour = m_towns_gfxvram[off+(layer*0x40000)-linesize] >> 4;
+			else
+				colour = m_towns_gfxvram[off+(layer*0x40000)] >> 4;
 			if(colour != 0)
 			{
 				bitmap.pix32(scanline, x+4) = pal->pen(colour);
@@ -1500,7 +1568,11 @@ void towns_state::towns_crtc_draw_scan_layer_16(bitmap_rgb32 &bitmap,const recta
 				bitmap.pix32(scanline, x+6) = pal->pen(colour);
 				bitmap.pix32(scanline, x+7) = pal->pen(colour);
 			}
-			colour = m_towns_gfxvram[off+(layer*0x40000)] & 0x0f;
+			// TODO: figure out how to wrap when there are sprites on layer 1
+			if ((layer == 0 || !(m_video.towns_sprite_reg[1] & 0x80)) && off >= (line * linesize) && off - (line * linesize) >= linesize)
+				colour = m_towns_gfxvram[off+(layer*0x40000)-linesize] & 0x0f;
+			else
+				colour = m_towns_gfxvram[off+(layer*0x40000)] & 0x0f;
 			if(colour != 0)
 			{
 				bitmap.pix32(scanline, x) = pal->pen(colour);
@@ -1520,7 +1592,11 @@ void towns_state::towns_crtc_draw_scan_layer_16(bitmap_rgb32 &bitmap,const recta
 				off &= 0x3ffff;  // 2 layers
 			else
 				off &= 0x7ffff;  // 1 layer
-			colour = m_towns_gfxvram[off+(layer*0x40000)] >> 4;
+			// TODO: figure out how to wrap when there are sprites on layer 1
+			if ((layer == 0 || !(m_video.towns_sprite_reg[1] & 0x80)) && off >= (line * linesize) && off - (line * linesize) >= linesize)
+				colour = m_towns_gfxvram[off+(layer*0x40000)-linesize] >> 4;
+			else
+				colour = m_towns_gfxvram[off+(layer*0x40000)] >> 4;
 			if(colour != 0)
 			{
 				bitmap.pix32(scanline, x+5) = pal->pen(colour);
@@ -1529,7 +1605,11 @@ void towns_state::towns_crtc_draw_scan_layer_16(bitmap_rgb32 &bitmap,const recta
 				bitmap.pix32(scanline, x+8) = pal->pen(colour);
 				bitmap.pix32(scanline, x+9) = pal->pen(colour);
 			}
-			colour = m_towns_gfxvram[off+(layer*0x40000)] & 0x0f;
+			// TODO: figure out how to wrap when there are sprites on layer 1
+			if ((layer == 0 || !(m_video.towns_sprite_reg[1] & 0x80)) && off >= (line * linesize) && off - (line * linesize) >= linesize)
+				colour = m_towns_gfxvram[off+(layer*0x40000)-linesize] & 0x0f;
+			else
+				colour = m_towns_gfxvram[off+(layer*0x40000)] & 0x0f;
 			if(colour != 0)
 			{
 				bitmap.pix32(scanline, x) = pal->pen(colour);


### PR DESCRIPTION
This change improves wrapping when the screen scrolls horizontally past the end of a bitmap layer, by going back to the start of the same line instead of continuing to the next. It's not a perfect solution because it still doesn't work 100% properly for these two cases:

- Combined horizontal + vertical scrolling
- Layer 1, when sprites are present

But for now it fixes 1-line screen "splits" in games like:

- The New Zealand Story (only in some instances, when there isn't vertical scrolling)
- All LucasArts adventure games
- Rayxanber

And probably more.

Also, this PR includes a fix for a regression in 16-bit sprite rendering that was accidentally introduced with PR #2921.