### PR TITLE
ygv608.cpp: Fix 'COLOR TEST' in ND-1 self test

### DIFF
--- a/src/mame/video/ygv608.cpp
+++ b/src/mame/video/ygv608.cpp
@@ -1103,7 +1103,7 @@ uint32_t ygv608_device::update_screen(screen_device &screen, bitmap_ind16 &bitma
 			m_tilemap_A = m_tilemap_A_cache_16[index];
 		m_tilemap_A->mark_all_dirty();
 
-		m_tilemap_A->set_transparent_pen(0);
+		m_tilemap_A->set_transparent_pen(m_border_color);
 
 		if (m_h_div_size == 0) {
 			m_tilemap_A->set_scroll_cols(m_page_x);

--- a/src/mame/video/ygv608.cpp
+++ b/src/mame/video/ygv608.cpp
@@ -1260,7 +1260,7 @@ READ8_MEMBER( ygv608_device::pattern_name_table_r )
 {
 	int pn = 0;
 
-	switch (p0_state_r)
+	switch (p0_state)
 	{
 		case 0:
 			/* Are we reading from plane B? */
@@ -1283,7 +1283,7 @@ READ8_MEMBER( ygv608_device::pattern_name_table_r )
 			"mode = %d, pgs = %d (%dx%d)\n"
 			"pattern_name_base_r = %d\n"
 			"pnx = %d, pny = %d, pny_shift = %d, bits16 = %d\n",
-			p0_state_r,
+			p0_state,
 			pn, m_md, m_page_size,
 			m_page_x, m_page_y,
 			pattern_name_base_r,
@@ -1292,14 +1292,14 @@ READ8_MEMBER( ygv608_device::pattern_name_table_r )
 		pn = 0;
 	}
 
-	p0_state_r++;
+	p0_state++;
 	if (m_md == MD_2PLANE_8BIT )
-		p0_state_r++;
+		p0_state++;
 
-	if (p0_state_r == 2)
+	if (p0_state == 2)
 	{
 		pattern_name_autoinc_check();
-		p0_state_r = 0;
+		p0_state = 0;
 		pattern_name_base_r = 0;
 	}
 
@@ -1398,7 +1398,7 @@ WRITE8_MEMBER(ygv608_device::pattern_name_table_w)
 {
 	int pn = 0;
 
-	switch (p0_state_w)
+	switch (p0_state)
 	{
 		case 0:
 			/* Are we reading from plane B? */
@@ -1417,11 +1417,11 @@ WRITE8_MEMBER(ygv608_device::pattern_name_table_w)
 
 	if (pn > 4095)
 	{
-		logerror( "attempt (%d) to read pattern name %d\n"
+		logerror( "attempt (%d) to write pattern name %d\n"
 			"mode = %d, pgs = %d (%dx%d)\n"
 			"pattern_name_base_w = %d\n"
 			"pnx = %d, pny = %d, pny_shift = %d, bits16 = %d\n",
-			p0_state_w,
+			p0_state,
 			pn, m_md, m_page_size,
 			m_page_x, m_page_y,
 			pattern_name_base_w,
@@ -1432,14 +1432,14 @@ WRITE8_MEMBER(ygv608_device::pattern_name_table_w)
 
 	m_pattern_name_table[pn] = data;
 
-	p0_state_w++;
+	p0_state++;
 	if (m_md == MD_2PLANE_8BIT )
-		p0_state_w++;
+		p0_state++;
 
-	if (p0_state_w == 2)
+	if (p0_state == 2)
 	{
 		pattern_name_autoinc_check();
-		p0_state_w = 0;
+		p0_state = 0;
 		pattern_name_base_w = 0;
 	}
 }
@@ -1830,8 +1830,7 @@ WRITE8_MEMBER( ygv608_device::screen_ctrl_7_w )
 	m_na8_mask = ((m_flip == true) ? 0x03 : 0x0f );
 
 	// changing mode resets the pattern name table states (Mappy Arrange)
-	p0_state_w = 0;
-	p0_state_r = 0;
+	p0_state = 0;
 	pattern_mode_setup();
 // TODO: add dot clock into CRTC
 //  screen_configure();

--- a/src/mame/video/ygv608.h
+++ b/src/mame/video/ygv608.h
@@ -176,8 +176,9 @@ private:
 	uint8_t m_tilemap_resize; // tilemap requires resize
 
 	/* These were statically allocated in the r/w routines */
-	int p0_state_r,m_color_state_r;
-	int p0_state_w,m_color_state_w;
+	int m_color_state_r;
+	int m_color_state_w;
+	int p0_state;
 	int pattern_name_base_r,pattern_name_base_w;     /* pattern name table base address */
 
 	// === new variable handling starts here ===


### PR DESCRIPTION
A few printf shows R#13(m_border_color) is written when entering ND-1 self test.
It's just a guesswork, but this change fixes 'COLOR TEST' screen in test mode.