### PR TITLE
Removed reference to VG-5000µ default faulty ROM (CRC a6998ff8)

### DIFF
--- a/src/mame/drivers/vg5k.cpp
+++ b/src/mame/drivers/vg5k.cpp
@@ -12,8 +12,7 @@
     05/2009 Skeleton driver.
 
     Known issues:
-    - 1200 bauds cassette don't works
-    - BASIC games hangs in default BIOS but works in alternative version
+     - 1200 bauds cassette don't works
 
     Informations ( see the very informative http://vg5k.free.fr/ ):
      - Variants: Radiola VG5000 and Schneider VG5000
@@ -415,14 +414,12 @@ MACHINE_CONFIG_END
 ROM_START( vg5k )
 	ROM_REGION( 0x10000, "maincpu", ROMREGION_ERASEFF )
 	ROM_SYSTEM_BIOS(0, "v11", "BASIC v1.1")
-	ROMX_LOAD( "vg5k11.bin",  0x0000, 0x4000, CRC(a6998ff8) SHA1(881ba594be0a721a999378312aea0c3c1c7b2b58), ROM_BIOS(1) )           // dumped from a Radiola VG-5000
-	ROM_SYSTEM_BIOS(1, "v11a", "BASIC v1.1 (alt)")
-	ROMX_LOAD( "vg5k11a.bin", 0x0000, 0x4000, BAD_DUMP CRC(a6f4a0ea) SHA1(58eccce33cc21fc17bc83921018f531b8001eda3), ROM_BIOS(2) )  // from dcvg5k
-	ROM_SYSTEM_BIOS(2, "v10", "BASIC v1.0")
-	ROMX_LOAD( "vg5k10.bin", 0x0000, 0x4000, BAD_DUMP CRC(57983260) SHA1(5ad1787a6a597b5c3eedb7c3704b649faa9be4ca), ROM_BIOS(3) )
+	ROMX_LOAD( "vg5k11.bin", 0x0000, 0x4000, CRC(a6f4a0ea) SHA1(58eccce33cc21fc17bc83921018f531b8001eda3), ROM_BIOS(1) )  // dumped from a Philips VG-5000.
+	ROM_SYSTEM_BIOS(1, "v10", "BASIC v1.0")
+	ROMX_LOAD( "vg5k10.bin", 0x0000, 0x4000, BAD_DUMP CRC(57983260) SHA1(5ad1787a6a597b5c3eedb7c3704b649faa9be4ca), ROM_BIOS(2) )
 
 	ROM_REGION( 0x4000, "ef9345", 0 )
-	ROM_LOAD( "charset.rom", 0x0000, 0x2000, BAD_DUMP CRC(b2f49eb3) SHA1(d0ef530be33bfc296314e7152302d95fdf9520fc) )            // from dcvg5k
+	ROM_LOAD( "charset.rom", 0x0000, 0x2000, BAD_DUMP CRC(b2f49eb3) SHA1(d0ef530be33bfc296314e7152302d95fdf9520fc) )                // from dcvg5k
 ROM_END
 
 /* Driver */


### PR DESCRIPTION
making the"alternate" (CRC 57983260) the correct one.

- ROM was dumped from a Philips VG-5000µ and compared to
  the "alternate" (CRC 57983260) version to find it was the same.
- Analyze of the (CRC a6998ff8) and why it is faulty and useless to keep:
  - Address $1000: correct instruction is DI ($F3) at start of boot;
                   in faulty ROM, the instruction is INC BC ($03), which makes
                   no sense here.
  - Address $2000: this is the start of the table pointing to BASIC
                   instructions. It is matched with the table at $209e
                   containing the keywords. The first keyword (END) will
                   cause the first address to be decoded (at $2519 to $2525)
                   and executed. Correct address is $2f3a, address found
                   in the faulty ROM is $2f00, thus preventing END instruction
                   to work.
  - Address $3000: this part is the code for the NEXT instruction, starting
                   at $2fe4. The faulty ROM at $3000 causes a CALL $CE02,
                   which is out of the memory range and leads to reboot with
                   no RAM extension. With RAM extension, as the ROM is copied
                   during the memory test at boot, it causes a Syntax Error.
                   The correct byte at $3000 is $03, leading to a
                   CALL $0302, which is correct.