### PR TITLE
fmtowns: fix vsync flag read from port cff86, Birdy Soft games now boot

### DIFF
--- a/src/mame/video/fmtowns.cpp
+++ b/src/mame/video/fmtowns.cpp
@@ -268,9 +268,9 @@ READ8_MEMBER( towns_state::towns_video_cff80_r )
 				return 0x00;
 		case 0x06:
 			if(m_video.towns_vblank_flag != 0)
-				return 0x10;
+				return 0x14;
 			else
-				return 0x00;
+				return 0x10;
 		case 0x16:  // Kanji character data
 			return ROM[(m_video.towns_kanji_offset << 1) + 0x180000];
 		case 0x17:  // Kanji character data


### PR DESCRIPTION
According to the FM Towns Technical Databook, when reading from port 0xcff86, bit 4 should always be set and bit 2 is the VSYNC flag. With this change, Birdy Soft games (cal, myeyes, beast3...) boot instead of getting stuck in a loop waiting for the flag.