### PR TITLE
fmtowns: implemented hsync read from cff86, later 4th Unit games now boot

### DIFF
--- a/src/mame/video/fmtowns.cpp
+++ b/src/mame/video/fmtowns.cpp
@@ -252,6 +252,8 @@ void towns_state::towns_update_kanji_offset()
 READ8_MEMBER( towns_state::towns_video_cff80_r )
 {
 	uint8_t* ROM = m_user->base();
+	uint8_t ret = 0;
+	uint16_t xpos;
 
 	switch(offset)
 	{
@@ -267,10 +269,13 @@ READ8_MEMBER( towns_state::towns_video_cff80_r )
 			else
 				return 0x00;
 		case 0x06:
+			ret |= 0x10;
+			xpos = machine().first_screen()->hpos();
+			if(xpos < m_video.towns_crtc_layerscr[0].max_x && xpos > m_video.towns_crtc_layerscr[0].min_x)
+				ret |= 0x80;
 			if(m_video.towns_vblank_flag != 0)
-				return 0x14;
-			else
-				return 0x10;
+				ret |= 0x04;
+			return ret;
 		case 0x16:  // Kanji character data
 			return ROM[(m_video.towns_kanji_offset << 1) + 0x180000];
 		case 0x17:  // Kanji character data

--- a/src/mame/video/fmtowns.cpp
+++ b/src/mame/video/fmtowns.cpp
@@ -127,7 +127,7 @@ void towns_state::towns_crtc_refresh_mode()
 	if(scr.max_x <= scr.min_x || scr.max_y <= scr.min_y)
 		return;
 
-	machine().first_screen()->configure(scr.max_x+1,scr.max_y+1,scr,HZ_TO_ATTOSECONDS(60));
+	m_screen->configure(scr.max_x+1,scr.max_y+1,scr,HZ_TO_ATTOSECONDS(60));
 }
 
 READ8_MEMBER( towns_state::towns_gfx_high_r )
@@ -270,7 +270,7 @@ READ8_MEMBER( towns_state::towns_video_cff80_r )
 				return 0x00;
 		case 0x06:
 			ret |= 0x10;
-			xpos = machine().first_screen()->hpos();
+			xpos = m_screen->hpos();
 			if(xpos < m_video.towns_crtc_layerscr[0].max_x && xpos > m_video.towns_crtc_layerscr[0].min_x)
 				ret |= 0x80;
 			if(m_video.towns_vblank_flag != 0)
@@ -376,8 +376,8 @@ READ8_MEMBER(towns_state::towns_video_440_r)
 			if(m_video.towns_crtc_sel == 30)
 			{
 				// check video position
-				xpos = machine().first_screen()->hpos();
-				ypos = machine().first_screen()->vpos();
+				xpos = m_screen->hpos();
+				ypos = m_screen->vpos();
 
 				if(xpos < (m_video.towns_crtc_reg[0] & 0xfe))
 					ret |= 0x02;
@@ -554,7 +554,7 @@ READ8_MEMBER(towns_state::towns_video_fd90_r)
 			return m_video.towns_degipal[offset-0x08];
 		case 0x10:  // "sub status register"
 			// check video position
-			xpos = machine().first_screen()->hpos();
+			xpos = m_screen->hpos();
 
 			if(xpos < m_video.towns_crtc_layerscr[0].max_x && xpos > m_video.towns_crtc_layerscr[0].min_x)
 				ret |= 0x02;
@@ -1503,7 +1503,7 @@ INTERRUPT_GEN_MEMBER(towns_state::towns_vsync_irq)
 	dev->ir3_w(1);  // IRQ11 = VSync
 	if(IRQ_LOG) logerror("PIC: IRQ11 (VSync) set high\n");
 	m_video.towns_vblank_flag = 1;
-	machine().scheduler().timer_set(machine().first_screen()->time_until_vblank_end(), timer_expired_delegate(FUNC(towns_state::towns_vblank_end),this), 0, (void*)dev);
+	machine().scheduler().timer_set(m_screen->time_until_vblank_end(), timer_expired_delegate(FUNC(towns_state::towns_vblank_end),this), 0, (void*)dev);
 	if(m_video.towns_tvram_enable)
 		draw_text_layer();
 	if(m_video.towns_sprite_reg[1] & 0x80)


### PR DESCRIPTION
Similar to PR #2999, the later games in the 4th Unit series (zero, dagain, merrygor, wyatt) were getting stuck waiting for the HSYNC flag from 0xcff86 (bit 7). With this change they run past the initial menu.

(this is largely copied from Barry's implementation for port 0xfda0, so credit goes to him)