### PR TITLE
fmtowns: fix missing pixels in single-layer modes

### DIFF
--- a/src/mame/includes/fmtowns.h
+++ b/src/mame/includes/fmtowns.h
@@ -378,7 +378,7 @@ public:
 	void render_sprite_16(uint32_t poffset, uint16_t x, uint16_t y, bool xflip, bool yflip, bool xhalfsize, bool yhalfsize, bool rotation, const rectangle* rect);
 	void draw_sprites(const rectangle* rect);
 	void towns_crtc_draw_scan_layer_hicolour(bitmap_rgb32 &bitmap,const rectangle* rect,int layer,int line,int scanline);
-	void towns_crtc_draw_scan_layer_256(bitmap_rgb32 &bitmap,const rectangle* rect,int layer,int line,int scanline);
+	void towns_crtc_draw_scan_layer_256(bitmap_rgb32 &bitmap,const rectangle* rect,int line,int scanline);
 	void towns_crtc_draw_scan_layer_16(bitmap_rgb32 &bitmap,const rectangle* rect,int layer,int line,int scanline);
 	void towns_crtc_draw_layer(bitmap_rgb32 &bitmap,const rectangle* rect,int layer);
 	void render_text_char(uint8_t x, uint8_t y, uint8_t ascii, uint16_t jis, uint8_t attr);


### PR DESCRIPTION
This change fixes two issues that only happen with software that uses the single-layer mode (PMODE bit = 0).

- In 16-bit color mode, if pixels in VRAM have the alpha bit enabled, it's ignored by the video hardware and drawn to the screen anyway. This fixes the character dialogue in the Towns port of Hatchake Ayayo-san Pro-68k.

- 256-color mode can only be enabled as a single layer, so pixels with palette index 0 aren't transparent and need to be drawn. This fixes black "spots" in Yami no Ketsuzoku and wrong colors in the Genocide Square FMVs. 

Along with this, I have simplified the towns_crtc_draw_scan_layer_256 function by removing the layer 1 drawing code (which is never executed).