### PR TITLE
dwarfd.cpp: fixed "gfx1" region size for pokeresp (nw)

### DIFF
--- a/src/mame/drivers/dwarfd.cpp
+++ b/src/mame/drivers/dwarfd.cpp
@@ -921,7 +921,7 @@ ROM_START( pokeresp )
 	ROM_LOAD( "electro.9j",         0x1000, 0x0800, CRC(a0ca4bb1) SHA1(815d7af5a10f64d1ea74c87ba3387cc3f68db729) )
 	ROM_LOAD( "electro.9h",         0x1800, 0x0800, CRC(d344d75a) SHA1(9ec4d15aa0a91544c1f5572d034009049a78598f) )
 
-	ROM_REGION16_LE( 0x2000, "gfx1", 0 )
+	ROM_REGION16_LE( 0x4000, "gfx1", 0 )
 	ROM_LOAD16_BYTE( "electro.6a",  0x0000, 0x0800, CRC(13b60985) SHA1(6a8b36a128ccffd6fae6a40a4deb88d612df4942) )
 	ROM_LOAD16_BYTE( "electro.6b",  0x1000, 0x0800, CRC(edbbdea7) SHA1(854624a2b7ea70eea929b0145b2ea0012baf8101) )
 	ROM_LOAD16_BYTE( "electro.6c",  0x0001, 0x0800, CRC(1fc1ab41) SHA1(0f8a57abedaadcf5f13523702b89b8782dedebc4) )


### PR DESCRIPTION
```
==170595==ERROR: AddressSanitizer: heap-buffer-overflow on address 0x625000144900 at pc 0x0000052d9e04 bp 0x7ffc0eb67660 sp 0x7ffc0eb67658
READ of size 2 at 0x625000144900 thread T0
    #0 0x52d9e03 in dwarfd_state::init_dwarfd() /mnt/mame/build/projects/sdl/mame/gmake-linux-clang/../../../../../src/mame/drivers/dwarfd.cpp:1063:21
    #1 0x52de574 in game_driver::driver_init_helper_impl<dwarfd_state>::invoke(game_driver::driver_init_helper const&, running_machine&) /mnt/mame/build/projects/sdl/mame/gmake-linux-clang/../../../../../src/emu/emu.h:119:3
    #2 0xe1f0c75 in operator() /mnt/mame/build/projects/sdl/mame/gmake-linux-clang/../../../../../src/emu/gamedrv.h:107:53
    #3 0xe1f0c75 in driver_device::device_start() /mnt/mame/build/projects/sdl/mame/gmake-linux-clang/../../../../../src/emu/driver.cpp:204
    #4 0xe0e345d in device_t::start() /mnt/mame/build/projects/sdl/mame/gmake-linux-clang/../../../../../src/emu/device.cpp:489:2
    #5 0xe6a1f65 in running_machine::start_all_devices() /mnt/mame/build/projects/sdl/mame/gmake-linux-clang/../../../../../src/emu/machine.cpp:1040:13
    #6 0xe6a005d in running_machine::start() /mnt/mame/build/projects/sdl/mame/gmake-linux-clang/../../../../../src/emu/machine.cpp:265:2
    #7 0xe6a2a41 in running_machine::run(bool) /mnt/mame/build/projects/sdl/mame/gmake-linux-clang/../../../../../src/emu/machine.cpp:310:3
    #8 0x8cd10e0 in mame_machine_manager::execute() /mnt/mame/build/projects/sdl/mame/gmake-linux-clang/../../../../../src/frontend/mame/mame.cpp:236:19
    #9 0x8e1e0d3 in cli_frontend::start_execution(mame_machine_manager*, std::vector<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, std::allocator<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > > > const&) /mnt/mame/build/projects/sdl/mame/gmake-linux-clang/../../../../../src/frontend/mame/clifront.cpp:257:22
    #10 0x8e20ee0 in cli_frontend::execute(std::vector<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, std::allocator<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > > >&) /mnt/mame/build/projects/sdl/mame/gmake-linux-clang/../../../../../src/frontend/mame/clifront.cpp:273:3
    #11 0x8cd3717 in emulator_info::start_frontend(emu_options&, osd_interface&, std::vector<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, std::allocator<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > > >&) /mnt/mame/build/projects/sdl/mame/gmake-linux-clang/../../../../../src/frontend/mame/mame.cpp:336:18
    #12 0x8acddf2 in main /mnt/mame/build/projects/sdl/mame/gmake-linux-clang/../../../../../src/osd/sdl/sdlmain.cpp:216:9
    #13 0x7f5a27f2b82f in __libc_start_main /build/glibc-bfm8X4/glibc-2.23/csu/../csu/libc-start.c:291
    #14 0x1431838 in _start (/mnt/mame/mame64_as+0x1431838)

0x625000144900 is located 0 bytes to the right of 8192-byte region [0x625000142900,0x625000144900)
allocated by thread T0 here:
    #0 0x14fd722 in operator new(unsigned long) /opt/media/clang_nightly/llvm/utils/release/final/llvm.src/projects/compiler-rt/lib/asan/asan_new_delete.cc:92:3
    #1 0xe227b44 in allocate /usr/lib/gcc/x86_64-linux-gnu/5.4.0/../../../../include/c++/5.4.0/ext/new_allocator.h:104:27
    #2 0xe227b44 in allocate /usr/lib/gcc/x86_64-linux-gnu/5.4.0/../../../../include/c++/5.4.0/bits/alloc_traits.h:491
    #3 0xe227b44 in _M_allocate /usr/lib/gcc/x86_64-linux-gnu/5.4.0/../../../../include/c++/5.4.0/bits/stl_vector.h:170
    #4 0xe227b44 in _M_create_storage /usr/lib/gcc/x86_64-linux-gnu/5.4.0/../../../../include/c++/5.4.0/bits/stl_vector.h:185
    #5 0xe227b44 in _Vector_base /usr/lib/gcc/x86_64-linux-gnu/5.4.0/../../../../include/c++/5.4.0/bits/stl_vector.h:136
    #6 0xe227b44 in vector /usr/lib/gcc/x86_64-linux-gnu/5.4.0/../../../../include/c++/5.4.0/bits/stl_vector.h:278
    #7 0xe227b44 in memory_region::memory_region(running_machine&, char const*, unsigned int, unsigned char, endianness_t) /mnt/mame/build/projects/sdl/mame/gmake-linux-clang/../../../../../src/emu/emumem.cpp:4453
    #8 0xe1f8c6a in make_unique<memory_region, running_machine &, const char *&, unsigned int &, unsigned char &, endianness_t &> /usr/lib/gcc/x86_64-linux-gnu/5.4.0/../../../../include/c++/5.4.0/bits/unique_ptr.h:765:34
    #9 0xe1f8c6a in memory_manager::region_alloc(char const*, unsigned int, unsigned char, endianness_t) /mnt/mame/build/projects/sdl/mame/gmake-linux-clang/../../../../../src/emu/emumem.cpp:1882
    #10 0xe7691fd in rom_load_manager::process_region_list() /mnt/mame/build/projects/sdl/mame/gmake-linux-clang/../../../../../src/emu/romload.cpp:1443:35
    #11 0xe76b8ef in rom_load_manager::rom_load_manager(running_machine&) /mnt/mame/build/projects/sdl/mame/gmake-linux-clang/../../../../../src/emu/romload.cpp:1533:2
    #12 0xe69f947 in make_unique_clear<rom_load_manager, running_machine &> /mnt/mame/build/projects/sdl/mame/gmake-linux-clang/../../../../../src/lib/util/corealloc.h:74:38
    #13 0xe69f947 in running_machine::start() /mnt/mame/build/projects/sdl/mame/gmake-linux-clang/../../../../../src/emu/machine.cpp:238
    #14 0xe6a2a41 in running_machine::run(bool) /mnt/mame/build/projects/sdl/mame/gmake-linux-clang/../../../../../src/emu/machine.cpp:310:3
    #15 0x8cd10e0 in mame_machine_manager::execute() /mnt/mame/build/projects/sdl/mame/gmake-linux-clang/../../../../../src/frontend/mame/mame.cpp:236:19
    #16 0x8e1e0d3 in cli_frontend::start_execution(mame_machine_manager*, std::vector<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, std::allocator<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > > > const&) /mnt/mame/build/projects/sdl/mame/gmake-linux-clang/../../../../../src/frontend/mame/clifront.cpp:257:22
    #17 0x8e20ee0 in cli_frontend::execute(std::vector<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, std::allocator<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > > >&) /mnt/mame/build/projects/sdl/mame/gmake-linux-clang/../../../../../src/frontend/mame/clifront.cpp:273:3
    #18 0x8cd3717 in emulator_info::start_frontend(emu_options&, osd_interface&, std::vector<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, std::allocator<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > > >&) /mnt/mame/build/projects/sdl/mame/gmake-linux-clang/../../../../../src/frontend/mame/mame.cpp:336:18
    #19 0x8acddf2 in main /mnt/mame/build/projects/sdl/mame/gmake-linux-clang/../../../../../src/osd/sdl/sdlmain.cpp:216:9
    #20 0x7f5a27f2b82f in __libc_start_main /build/glibc-bfm8X4/glibc-2.23/csu/../csu/libc-start.c:291

SUMMARY: AddressSanitizer: heap-buffer-overflow /mnt/mame/build/projects/sdl/mame/gmake-linux-clang/../../../../../src/mame/drivers/dwarfd.cpp:1063:21 in dwarfd_state::init_dwarfd()
Shadow bytes around the buggy address:
  0x0c4a800208d0: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
  0x0c4a800208e0: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
  0x0c4a800208f0: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
  0x0c4a80020900: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
  0x0c4a80020910: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
=>0x0c4a80020920:[fa]fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa
  0x0c4a80020930: fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa
  0x0c4a80020940: fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa
  0x0c4a80020950: fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa
  0x0c4a80020960: fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa
  0x0c4a80020970: fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa
Shadow byte legend (one shadow byte represents 8 application bytes):
  Addressable:           00
  Partially addressable: 01 02 03 04 05 06 07 
  Heap left redzone:       fa
  Freed heap region:       fd
  Stack left redzone:      f1
  Stack mid redzone:       f2
  Stack right redzone:     f3
  Stack after return:      f5
  Stack use after scope:   f8
  Global redzone:          f9
  Global init order:       f6
  Poisoned by user:        f7
  Container overflow:      fc
  Array cookie:            ac
  Intra object redzone:    bb
  ASan internal:           fe
  Left alloca redzone:     ca
  Right alloca redzone:    cb 
```