### PR TITLE
fcrash.cpp: fixed m_sprite_base for punipic (nw)

### DIFF
--- a/src/mame/drivers/fcrash.cpp
+++ b/src/mame/drivers/fcrash.cpp
@@ -2354,7 +2354,7 @@ MACHINE_START_MEMBER(cps_state, punipic)
 	m_layer_mask_reg[3] = 0x0a;
 	m_layer_scroll1x_offset = 0x46; // text
 	m_layer_scroll3x_offset = 0x46; // green patch in the park
-	m_sprite_base = 0x000;
+	m_sprite_base = 0x1000;
 	m_sprite_list_end_marker = 0x8000;
 	m_sprite_x_offset = 0;
 }


### PR DESCRIPTION
´´´
==173199==ERROR: AddressSanitizer: heap-buffer-overflow on address 0x62900084d1fe at pc 0x00000186c8f5 bp 0x7ffcb5643500 sp 0x7ffcb56434f8
READ of size 2 at 0x62900084d1fe thread T0
    #0 0x186c8f4 in cps_state::fcrash_render_sprites(screen_device&, bitmap_ind16&, rectangle const&) /mnt/mame/build/projects/sdl/mame/gmake-linux-clang/../../../../../src/mame/drivers/fcrash.cpp:505:7
    #1 0x186df0a in fcrash_render_layer /mnt/mame/build/projects/sdl/mame/gmake-linux-clang/../../../../../src/mame/drivers/fcrash.cpp:535:4
    #2 0x186df0a in cps_state::screen_update_fcrash(screen_device&, bitmap_ind16&, rectangle const&) /mnt/mame/build/projects/sdl/mame/gmake-linux-clang/../../../../../src/mame/drivers/fcrash.cpp:655
    #3 0xe7ac132 in operator() /mnt/mame/build/projects/sdl/mame/gmake-linux-clang/../../../../../src/lib/util/delegate.h:544:11
    #4 0xe7ac132 in screen_device::update_partial(int) /mnt/mame/build/projects/sdl/mame/gmake-linux-clang/../../../../../src/emu/screen.cpp:1219
    #5 0xe833c67 in video_manager::finish_screen_updates() /mnt/mame/build/projects/sdl/mame/gmake-linux-clang/../../../../../src/emu/video.cpp:694:10
    #6 0xe8332a0 in video_manager::frame_update(bool) /mnt/mame/build/projects/sdl/mame/gmake-linux-clang/../../../../../src/emu/video.cpp:208:27
    #7 0xe7aa719 in screen_device::vblank_begin() /mnt/mame/build/projects/sdl/mame/gmake-linux-clang/../../../../../src/emu/screen.cpp:1524:21
    #8 0xe7a9c7c in screen_device::device_timer(emu_timer&, unsigned int, int, void*) /mnt/mame/build/projects/sdl/mame/gmake-linux-clang/../../../../../src/emu/screen.cpp:997:4
    #9 0xe795168 in timer_expired /mnt/mame/build/projects/sdl/mame/gmake-linux-clang/../../../../../src/emu/device.h:520:83
    #10 0xe795168 in device_scheduler::execute_timers() /mnt/mame/build/projects/sdl/mame/gmake-linux-clang/../../../../../src/emu/schedule.cpp:906
    #11 0xe78ea0f in device_scheduler::timeslice() /mnt/mame/build/projects/sdl/mame/gmake-linux-clang/../../../../../src/emu/schedule.cpp:530:2
    #12 0xe6a324b in running_machine::run(bool) /mnt/mame/build/projects/sdl/mame/gmake-linux-clang/../../../../../src/emu/machine.cpp:357:17
    #13 0x8cd10e0 in mame_machine_manager::execute() /mnt/mame/build/projects/sdl/mame/gmake-linux-clang/../../../../../src/frontend/mame/mame.cpp:236:19
    #14 0x8e1e0d3 in cli_frontend::start_execution(mame_machine_manager*, std::vector<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, std::allocator<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > > > const&) /mnt/mame/build/projects/sdl/mame/gmake-linux-clang/../../../../../src/frontend/mame/clifront.cpp:257:22
    #15 0x8e20ee0 in cli_frontend::execute(std::vector<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, std::allocator<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > > >&) /mnt/mame/build/projects/sdl/mame/gmake-linux-clang/../../../../../src/frontend/mame/clifront.cpp:273:3
    #16 0x8cd3717 in emulator_info::start_frontend(emu_options&, osd_interface&, std::vector<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, std::allocator<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > > >&) /mnt/mame/build/projects/sdl/mame/gmake-linux-clang/../../../../../src/frontend/mame/mame.cpp:336:18
    #17 0x8acddf2 in main /mnt/mame/build/projects/sdl/mame/gmake-linux-clang/../../../../../src/osd/sdl/sdlmain.cpp:216:9
    #18 0x7f99c80d082f in __libc_start_main /build/glibc-bfm8X4/glibc-2.23/csu/../csu/libc-start.c:291
    #19 0x1431838 in _start (/mnt/mame/mame64_as+0x1431838)

0x62900084d1fe is located 2 bytes to the left of 16384-byte region [0x62900084d200,0x629000851200)
allocated by thread T0 here:
    #0 0x14fd8a2 in operator new[](unsigned long) /opt/media/clang_nightly/llvm/utils/release/final/llvm.src/projects/compiler-rt/lib/asan/asan_new_delete.cc:95:3
    #1 0x18705f7 in make_unique<unsigned short []> /usr/lib/gcc/x86_64-linux-gnu/5.4.0/../../../../include/c++/5.4.0/bits/unique_ptr.h:771:30
    #2 0x18705f7 in cps_state::init_dinopic() /mnt/mame/build/projects/sdl/mame/gmake-linux-clang/../../../../../src/mame/drivers/fcrash.cpp:2255
    #3 0x1870981 in cps_state::init_punipic() /mnt/mame/build/projects/sdl/mame/gmake-linux-clang/../../../../../src/mame/drivers/fcrash.cpp:2542:2
    #4 0x183b344 in game_driver::driver_init_helper_impl<cps_state>::invoke(game_driver::driver_init_helper const&, running_machine&) /mnt/mame/build/projects/sdl/mame/gmake-linux-clang/../../../../../src/emu/emu.h:119:3
    #5 0xe1f0c75 in operator() /mnt/mame/build/projects/sdl/mame/gmake-linux-clang/../../../../../src/emu/gamedrv.h:107:53
    #6 0xe1f0c75 in driver_device::device_start() /mnt/mame/build/projects/sdl/mame/gmake-linux-clang/../../../../../src/emu/driver.cpp:204
    #7 0xe0e345d in device_t::start() /mnt/mame/build/projects/sdl/mame/gmake-linux-clang/../../../../../src/emu/device.cpp:489:2
    #8 0xe6a1f65 in running_machine::start_all_devices() /mnt/mame/build/projects/sdl/mame/gmake-linux-clang/../../../../../src/emu/machine.cpp:1040:13
    #9 0xe6a005d in running_machine::start() /mnt/mame/build/projects/sdl/mame/gmake-linux-clang/../../../../../src/emu/machine.cpp:265:2
    #10 0xe6a2a41 in running_machine::run(bool) /mnt/mame/build/projects/sdl/mame/gmake-linux-clang/../../../../../src/emu/machine.cpp:310:3
    #11 0x8cd10e0 in mame_machine_manager::execute() /mnt/mame/build/projects/sdl/mame/gmake-linux-clang/../../../../../src/frontend/mame/mame.cpp:236:19
    #12 0x8e1e0d3 in cli_frontend::start_execution(mame_machine_manager*, std::vector<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, std::allocator<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > > > const&) /mnt/mame/build/projects/sdl/mame/gmake-linux-clang/../../../../../src/frontend/mame/clifront.cpp:257:22
    #13 0x8e20ee0 in cli_frontend::execute(std::vector<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, std::allocator<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > > >&) /mnt/mame/build/projects/sdl/mame/gmake-linux-clang/../../../../../src/frontend/mame/clifront.cpp:273:3
    #14 0x8cd3717 in emulator_info::start_frontend(emu_options&, osd_interface&, std::vector<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, std::allocator<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > > >&) /mnt/mame/build/projects/sdl/mame/gmake-linux-clang/../../../../../src/frontend/mame/mame.cpp:336:18
    #15 0x8acddf2 in main /mnt/mame/build/projects/sdl/mame/gmake-linux-clang/../../../../../src/osd/sdl/sdlmain.cpp:216:9
    #16 0x7f99c80d082f in __libc_start_main /build/glibc-bfm8X4/glibc-2.23/csu/../csu/libc-start.c:291

SUMMARY: AddressSanitizer: heap-buffer-overflow /mnt/mame/build/projects/sdl/mame/gmake-linux-clang/../../../../../src/mame/drivers/fcrash.cpp:505:7 in cps_state::fcrash_render_sprites(screen_device&, bitmap_ind16&, rectangle const&)
Shadow bytes around the buggy address:
  0x0c52801019e0: fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa
  0x0c52801019f0: fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa
  0x0c5280101a00: fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa
  0x0c5280101a10: fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa
  0x0c5280101a20: fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa
=>0x0c5280101a30: fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa[fa]
  0x0c5280101a40: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
  0x0c5280101a50: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
  0x0c5280101a60: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
  0x0c5280101a70: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
  0x0c5280101a80: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
Shadow byte legend (one shadow byte represents 8 application bytes):
  Addressable:           00
  Partially addressable: 01 02 03 04 05 06 07 
  Heap left redzone:       fa
  Freed heap region:       fd
  Stack left redzone:      f1
  Stack mid redzone:       f2
  Stack right redzone:     f3
  Stack after return:      f5
  Stack use after scope:   f8
  Global redzone:          f9
  Global init order:       f6
  Poisoned by user:        f7
  Container overflow:      fc
  Array cookie:            ac
  Intra object redzone:    bb
  ASan internal:           fe
  Left alloca redzone:     ca
  Right alloca redzone:    cb
´´´