### PR TITLE
fmtowns: fix cdrom regressions

### DIFF
--- a/src/mame/drivers/fmtowns.cpp
+++ b/src/mame/drivers/fmtowns.cpp
@@ -1747,6 +1747,7 @@ READ8_MEMBER(towns_state::towns_cdrom_r)
 		case 0x01:  // command status
 			if(m_towns_cd.cmd_status_ptr >= 3)
 			{
+				m_towns_cd.status &= ~2;
 				// check for more status bytes
 				if(m_towns_cd.extra_status != 0)
 				{


### PR DESCRIPTION
This fixes a regression introduced with commit 81f44e1e968b559330a0c9cefebcef0868e1e9f4 that caused some games that were working previously (e.g. Emerald Dragon, several Cocktail Soft games, Indiana Jones and the Last Crusade) to fail to boot. 

Everything that Carl's commit fixed (e.g. Shadow of the Beast 2, Ultima IV/V, Loom, etc.) is also working, so hopefully this should make everyone happy.