### PR TITLE
MultiPCM: fix banking, allow for 512 samples

### DIFF
--- a/src/devices/sound/multipcm.h
+++ b/src/devices/sound/multipcm.h
@@ -15,7 +15,8 @@ public:
 	DECLARE_WRITE8_MEMBER( write );
 	DECLARE_READ8_MEMBER( read );
 
-	void set_bank(uint32_t leftoffs, uint32_t rightoffs);
+	void set_sega_bank_1m(uint8_t bank);
+	void set_sega_bank_512k(uint8_t low_bank, uint8_t high_bank);
 
 protected:
 	// device-level overrides
@@ -96,8 +97,9 @@ private:
 	slot_t *m_slots;
 	uint32_t m_cur_slot;
 	uint32_t m_address;
-	uint32_t m_bank_right;
-	uint32_t m_bank_left;
+	bool m_sega_banking;
+	uint32_t m_sega_bank0;
+	uint32_t m_sega_bank1;
 	float m_rate;
 
 	uint32_t *m_attack_step;

--- a/src/mame/audio/segam1audio.cpp
+++ b/src/mame/audio/segam1audio.cpp
@@ -120,12 +120,12 @@ void segam1audio_device::device_reset()
 
 WRITE16_MEMBER(segam1audio_device::m1_snd_mpcm_bnk1_w)
 {
-	m_multipcm_1->set_bank(0x100000 * (data & 3), 0x100000 * (data & 3));
+	m_multipcm_1->set_sega_bank_1m(data & 3);
 }
 
 WRITE16_MEMBER(segam1audio_device::m1_snd_mpcm_bnk2_w)
 {
-	m_multipcm_2->set_bank(0x100000 * (data & 3), 0x100000 * (data & 3));
+	m_multipcm_2->set_sega_bank_1m(data & 3);
 }
 
 WRITE_LINE_MEMBER(segam1audio_device::write_txd)

--- a/src/mame/drivers/segas32.cpp
+++ b/src/mame/drivers/segas32.cpp
@@ -1081,13 +1081,13 @@ WRITE8_MEMBER(segas32_state::sound_bank_hi_w)
 
 WRITE8_MEMBER(segas32_state::multipcm_bank_w)
 {
-	m_multipcm->set_bank(0x80000 * ((data >> 3) & 7), 0x80000 * (data & 7));
+	m_multipcm->set_sega_bank_512k(data & 7, (data >> 3) & 7);
 }
 
 
 WRITE8_MEMBER(segas32_state::scross_bank_w)
 {
-	m_multipcm->set_bank(0x80000 * (data & 7), 0x80000 * (data & 7));
+	m_multipcm->set_sega_bank_512k(data & 7, data & 7);
 }
 
 

--- a/src/mame/drivers/vgmplay.cpp
+++ b/src/mame/drivers/vgmplay.cpp
@@ -1243,7 +1243,10 @@ WRITE8_MEMBER(vgmplay_state::multipcm_bank_lo_a_w)
 	if (offset & 2)
 		m_multipcma_bank_r = (m_multipcma_bank_r & 0xff00) | data;
 
-	m_multipcma->set_bank(m_multipcma_bank_l << 16, m_multipcma_bank_r << 16);
+	if (m_multipcma_bank_l == m_multipcma_bank_r)
+		m_multipcma->set_sega_bank_1m(m_multipcma_bank_r >> 4);
+	else
+		m_multipcma->set_sega_bank_512k(m_multipcma_bank_r >> 3, m_multipcma_bank_l >> 3);
 }
 
 WRITE8_MEMBER(vgmplay_state::multipcm_bank_hi_b_w)
@@ -1261,7 +1264,10 @@ WRITE8_MEMBER(vgmplay_state::multipcm_bank_lo_b_w)
 	if (offset & 2)
 		m_multipcmb_bank_r = (m_multipcmb_bank_r & 0xff00) | data;
 
-	m_multipcmb->set_bank(m_multipcmb_bank_l << 16, m_multipcmb_bank_r << 16);
+	if (m_multipcmb_bank_l == m_multipcmb_bank_r)
+		m_multipcmb->set_sega_bank_1m(m_multipcmb_bank_r >> 4);
+	else
+		m_multipcmb->set_sega_bank_512k(m_multipcmb_bank_r >> 3, m_multipcmb_bank_l >> 3);
 }
 
 static INPUT_PORTS_START( vgmplay )


### PR DESCRIPTION
The current implementation of the banking system used by Sega Multi 32 and Sega Model 1 machines is pretty hackish and uses the panning setting to decide what bank to use.

After some investigation I came up with a better solution that seems to work as intended:

For Sega Multi 32, the 1 MiB that is bankable is divided into 2 banks of 512 KiB each. OutRunners confirms this - for the first screen it uses samples 0-255, which use the first bank; for the second screen samples 256-512 are used, which use the second bank according to the ROM's sample table.

The Sega Model 1 sound board apparently uses a single 1 MiB bank.