### PR TITLE
Some legacy floppy fixes and cleanups

### DIFF
--- a/src/devices/imagedev/flopdrv.cpp
+++ b/src/devices/imagedev/flopdrv.cpp
@@ -498,7 +498,7 @@ legacy_floppy_image_device *floppy_get_device_by_type(running_machine &machine,i
 	int cnt = 0;
 	for (i=0;i<4;i++) {
 		legacy_floppy_image_device *disk = floppy_get_device(machine,i);
-		if (disk->floppy_get_drive_type()==ftype) {
+		if (disk && disk->floppy_get_drive_type()==ftype) {
 			if (cnt==drive) {
 				return disk;
 			}
@@ -523,7 +523,7 @@ int floppy_get_drive_by_type(legacy_floppy_image_device *image,int ftype)
 	int i,drive =0;
 	for (i=0;i<4;i++) {
 		legacy_floppy_image_device *disk = floppy_get_device(image->machine(),i);
-		if (disk->floppy_get_drive_type()==ftype) {
+		if (disk && disk->floppy_get_drive_type()==ftype) {
 			if (image==disk) {
 				return drive;
 			}

--- a/src/devices/imagedev/flopdrv.cpp
+++ b/src/devices/imagedev/flopdrv.cpp
@@ -510,7 +510,7 @@ legacy_floppy_image_device *floppy_get_device_by_type(running_machine &machine,i
 
 int floppy_get_drive(device_t *image)
 {
-	int drive =0;
+	int drive = -1;
 	if (strcmp(image->tag(), ":" FLOPPY_0) == 0) drive = 0;
 	if (strcmp(image->tag(), ":" FLOPPY_1) == 0) drive = 1;
 	if (strcmp(image->tag(), ":" FLOPPY_2) == 0) drive = 2;
@@ -530,7 +530,7 @@ int floppy_get_drive_by_type(legacy_floppy_image_device *image,int ftype)
 			drive++;
 		}
 	}
-	return drive;
+	return -1;
 }
 
 int floppy_get_count(running_machine &machine)
@@ -718,7 +718,7 @@ legacy_floppy_image_device::legacy_floppy_image_device(const machine_config &mco
 		m_wpt(0),
 		m_rdy(0),
 		m_dskchg(0),
-		m_drive_id(0),
+		m_drive_id(-1),
 		m_active(0),
 		m_config(nullptr),
 		m_flags(0),

--- a/src/devices/imagedev/flopdrv.cpp
+++ b/src/devices/imagedev/flopdrv.cpp
@@ -508,7 +508,7 @@ legacy_floppy_image_device *floppy_get_device_by_type(running_machine &machine,i
 	return nullptr;
 }
 
-int floppy_get_drive(device_t *image)
+static int floppy_get_drive(device_t *image)
 {
 	int drive = -1;
 	if (strcmp(image->tag(), ":" FLOPPY_0) == 0) drive = 0;

--- a/src/devices/imagedev/flopdrv.h
+++ b/src/devices/imagedev/flopdrv.h
@@ -233,7 +233,6 @@ DECLARE_DEVICE_TYPE(LEGACY_FLOPPY, legacy_floppy_image_device)
 
 legacy_floppy_image_device *floppy_get_device(running_machine &machine,int drive);
 legacy_floppy_image_device *floppy_get_device_by_type(running_machine &machine,int ftype,int drive);
-int floppy_get_drive(device_t *image);
 int floppy_get_drive_by_type(legacy_floppy_image_device *image,int ftype);
 int floppy_get_count(running_machine &machine);
 

--- a/src/mame/machine/thomflop.cpp
+++ b/src/mame/machine/thomflop.cpp
@@ -992,7 +992,7 @@ int thomson_state::thmfc_floppy_find_sector( chrn_id* dst )
 	}
 
 	thmfc1->stat0 = THMFC1_STAT0_CRC_ERROR | THMFC1_STAT0_FINISHED;
-	LOG (( "thmfc_floppy_find_sector: sector not found drive=%i track=%i sector=%i\n", floppy_get_drive(img), thmfc1->track, thmfc1->sector ));
+	LOG (( "thmfc_floppy_find_sector: sector not found drive=%s track=%i sector=%i\n", img->tag(), thmfc1->track, thmfc1->sector ));
 	return 0;
 }
 


### PR DESCRIPTION
When the legacy floppy code is used for lookups and the tags are not the expected ones it will default to the first drive.
Since atarifdc has the drives below the "fdc" the generic lookup function could not be used. Making a copy of this is definitely ugly, but this is legacy code anyways and it fixes it. There's also some other drivers with legacy floppy support that did it this way.