### PR TITLE
Correct command heading case and adjustments to expressions (NW)

### DIFF
--- a/docs/source/debugger/annotation.rst
+++ b/docs/source/debugger/annotation.rst
@@ -15,7 +15,7 @@ You can also type **help <command>** for further details on each command in the 
 
  .. _debugger-command-comadd:
 
-Comadd
+comadd
 ------
 
 |  **comadd[//] <address>,<comment>**
@@ -35,7 +35,7 @@ Comadd
 
  .. _debugger-command-comdelete:
 
-Comdelete
+comdelete
 ---------
 
 |  **comdelete**
@@ -51,7 +51,7 @@ Comdelete
 
  .. _debugger-command-comsave:
 
-Comsave
+comsave
 -------
 
 |  **comsave**
@@ -67,7 +67,7 @@ Comsave
 
  .. _debugger-command-comlist:
 
-Comlist
+comlist
 -------
 
 |  **comlist**
@@ -83,7 +83,7 @@ Comlist
 
  .. _debugger-command-commit:
 
-Commit
+commit
 ------
 
 |  **commit[/*] <address>,<comment>**

--- a/docs/source/debugger/breakpoint.rst
+++ b/docs/source/debugger/breakpoint.rst
@@ -15,7 +15,7 @@ You can also type **help <command>** for further details on each command in the 
 
  .. _debugger-command-bpset:
 
-Bpset
+bpset
 -----
 
 |  **bp[set] <address>[,<condition>[,<action>]]**
@@ -51,7 +51,7 @@ Bpset
 
  .. _debugger-command-bpclear:
 
-Bpclear
+bpclear
 -------
 
 |  **bpclear [<bpnum>]**
@@ -73,7 +73,7 @@ Bpclear
 
  .. _debugger-command-bpdisable:
 
-Bpdisable
+bpdisable
 ---------
 
 |  **bpdisable [<bpnum>]**
@@ -95,7 +95,7 @@ Bpdisable
 
  .. _debugger-command-bpenable:
 
-Bpenable
+bpenable
 --------
 
 |  **bpenable [<bpnum>]**
@@ -117,7 +117,7 @@ Bpenable
 
  .. _debugger-command-bplist:
 
-Bplist
+bplist
 ------
 
 |  **bplist**

--- a/docs/source/debugger/cheats.rst
+++ b/docs/source/debugger/cheats.rst
@@ -15,7 +15,7 @@ You can also type **help <command>** for further details on each command in the 
 
  .. _debugger-command-cheatinit:
 
-Cheatinit
+cheatinit
 ---------
 
 |  **cheatinit [<sign><width><swap>,[<address>,<length>[,<cpu>]]]**
@@ -47,7 +47,7 @@ Cheatinit
 
  .. _debugger-command-cheatrange:
 
-Cheatrange
+cheatrange
 ----------
 
 |  **cheatrange <address>,<length>**
@@ -67,7 +67,7 @@ Cheatrange
 
  .. _debugger-command-cheatnext:
 
-Cheatnext
+cheatnext
 ---------
 
 |  **cheatnext <condition>[,<comparisonvalue>]**
@@ -145,7 +145,7 @@ Cheatnext
 
  .. _debugger-command-cheatnextf:
 
-Cheatnextf
+cheatnextf
 ----------
 
 |  **cheatnextf <condition>[,<comparisonvalue>]**
@@ -224,7 +224,7 @@ Cheatnextf
 
  .. _debugger-command-cheatlist:
 
-Cheatlist
+cheatlist
 ---------
 
 |  **cheatlist [<filename>]**
@@ -247,7 +247,7 @@ Cheatlist
 
  .. _debugger-command-cheatundo:
 
-Cheatundo
+cheatundo
 ---------
 
 |  **cheatundo**

--- a/docs/source/debugger/execution.rst
+++ b/docs/source/debugger/execution.rst
@@ -24,7 +24,7 @@ You can also type **help <command>** for further details on each command in the 
 
  .. _debugger-command-step:
 
-Step
+step
 ----
 
 |  **s[tep] [<count>=1]**
@@ -46,7 +46,7 @@ Step
 
  .. _debugger-command-over:
 
-Over
+over
 ----
 
 |  **o[ver] [<count>=1]**
@@ -70,7 +70,7 @@ Over
 
  .. _debugger-command-out:
 
-Out
+out
 ---
 
 |  **out**
@@ -90,7 +90,7 @@ Out
 
  .. _debugger-command-go:
 
-Go
+go
 --
 
 |  **g[o] [<address>]**
@@ -112,7 +112,7 @@ Go
 
  .. _debugger-command-gvblank:
 
-Gvblank
+gvblank
 -------
 
 |  **gv[blank]**
@@ -130,7 +130,7 @@ Gvblank
 
  .. _debugger-command-gint:
 
-Gint
+gint
 ----
 
 |  **gi[nt] [<irqline>]**
@@ -152,7 +152,7 @@ Gint
 
  .. _debugger-command-gtime:
 
-Gtime
+gtime
 -----
 
 |  **gt[ime] <milliseconds>**
@@ -170,7 +170,7 @@ Gtime
 
  .. _debugger-command-next:
 
-Next
+next
 ----
 
 |  **n[ext]**
@@ -182,7 +182,7 @@ Next
 
  .. _debugger-command-focus:
 
-Focus
+focus
 -----
 
 |  **focus <cpu>**
@@ -200,7 +200,7 @@ Focus
 
  .. _debugger-command-ignore:
 
-Ignore
+ignore
 ------
 
 |  **ignore [<cpu>[,<cpu>[,...]]]**
@@ -226,7 +226,7 @@ Ignore
 
  .. _debugger-command-observe:
 
-Observe
+observe
 -------
 
 |  **observe [<cpu>[,<cpu>[,...]]]**
@@ -252,7 +252,7 @@ Observe
 
  .. _debugger-command-trace:
 
-Trace
+trace
 -----
 
 |  **trace {<filename>|OFF}[,<cpu>[,[noloop|logerror][,<action>]]]**
@@ -307,7 +307,7 @@ Trace
 
  .. _debugger-command-traceover:
 
-Traceover
+traceover
 ---------
 
 |  **traceover {<filename>|OFF}[,<cpu>[,<detectloops>[,<action>]]]**
@@ -350,7 +350,7 @@ Traceover
 
  .. _debugger-command-traceflush:
 
-Traceflush
+traceflush
 ----------
 
 |  **traceflush**

--- a/docs/source/debugger/expressions.rst
+++ b/docs/source/debugger/expressions.rst
@@ -29,8 +29,16 @@ Expressions can be used anywhere a numeric parameter is expected. The syntax for
 Differences from C Behaviors
 ----------------------------
 
-First, all math is performed on full 64-bit unsigned values, so things like a < 0 won't work as expected. 
-Second, the logical operators && and || do not have short-circuit properties -- both halves are always evaluated. 
-Finally, the new memory operators work like this: 
-| b@<addr> refers to the byte read from <addr>. 
-| Similarly, w@ refers to a word in memory, d@ refers to a dword in memory, and q@ refers to a qword in memory. The memory operators can be used as both lvalues and rvalues, so you can write b@100 = ff to store a byte in memory. By default these operators read from the program memory space, but you can override that by prefixing them with a 'd' or an 'i'. So dw@300 refers to data memory word at address 300 and id@400 refers to an I/O memory dword at address 400.
+
+- First, all math is performed on full 64-bit unsigned values, so things like a < 0 won't work as expected. 
+
+- Second, the logical operators && and || do not have short-circuit properties -- both halves are always evaluated. 
+
+- Finally, the new memory operators work like this:
+
+  - b@<addr> refers to the byte read from <addr>. 
+
+  - Similarly, w@ refers to a word in memory, d@ refers to a dword in memory, and q@ refers to a qword in memory.
+  
+    The memory operators can be used as both lvalues and rvalues, so you can write b\@100 = ff to store a byte in memory. By default these operators read from the program memory space, but you can override that by prefixing them with a 'd' or an 'i'. So dw\@300 refers to data memory word at address 300 and id\@400 refers to an I/O memory dword at address 400.
+

--- a/docs/source/debugger/general.rst
+++ b/docs/source/debugger/general.rst
@@ -29,7 +29,7 @@ You can also type **help <command>** for further details on each command in the 
 
  .. _debugger-command-do:
 
-Do
+do
 --
 
 |  **do <expression>**
@@ -46,7 +46,7 @@ Do
 
  .. _debugger-command-symlist:
 
-Symlist
+symlist
 -------
 
 |  **symlist [<cpu>]**
@@ -68,7 +68,7 @@ Symlist
 
  .. _debugger-command-softreset:
  
-Softreset
+softreset
 ---------
 
 |  **softreset**
@@ -86,7 +86,7 @@ Softreset
 
  .. _debugger-command-hardreset:
  
-Hardreset
+hardreset
 ---------
 
 |  **hardreset**
@@ -104,7 +104,7 @@ Hardreset
 
  .. _debugger-command-print:
 
-Print
+print
 -----
 
 |  **print <item>[,...]**
@@ -126,7 +126,7 @@ Print
 
  .. _debugger-command-printf:
  
-Printf
+printf
 ------
 
 |  **printf <format>[,<item>[,...]]**
@@ -153,7 +153,7 @@ Printf
 
  .. _debugger-command-logerror:
  
-Logerror
+logerror
 --------
 
 |  **logerror <format>[,<item>[,...]]**
@@ -180,7 +180,7 @@ Logerror
 
  .. _debugger-command-tracelog:
 
-Tracelog
+tracelog
 --------
 
 |  **tracelog <format>[,<item>[,...]]**
@@ -202,7 +202,7 @@ Tracelog
 
  .. _debugger-command-tracesym:
 
-Tracesym
+tracesym
 --------
 
 |  **tracesym <item>[,...]**
@@ -224,7 +224,7 @@ Tracesym
 
  .. _debugger-command-trackpc:
 
-Trackpc
+trackpc
 -------
 
 |  **trackpc [<bool>,<cpu>,<bool>]**
@@ -246,7 +246,7 @@ Trackpc
 
  .. _debugger-command-trackmem:
 
-Trackmem
+trackmem
 --------
 
 |  **trackmem [<bool>,<cpu>,<bool>]**
@@ -268,7 +268,7 @@ Trackmem
 
  .. _debugger-command-pcatmem:
 
-Pcatmem
+pcatmem
 -------
 
 |  **pcatmem(p/d/i) <address>[,<cpu>]**
@@ -290,7 +290,7 @@ Pcatmem
 
  .. _debugger-command-rewind:
  
-Rewind
+rewind
 ------
 
 |  **rewind[rw]**
@@ -302,7 +302,7 @@ Rewind
 
  .. _debugger-command-statesave:
 
-Statesave
+statesave
 ---------
 
 |  **statesave[ss] <filename>**
@@ -320,7 +320,7 @@ Statesave
 
  .. _debugger-command-stateload:
 
-Stateload
+stateload
 ---------
 
 |  **stateload[sl] <filename>**
@@ -338,7 +338,7 @@ Stateload
 
  .. _debugger-command-snap:
 
-Snap
+snap
 ----
 
 |  **snap [[<filename>], <scrnum>]**
@@ -360,7 +360,7 @@ Snap
 
  .. _debugger-command-source:
 
-Source
+source
 ------
 
 |  **source <filename>**
@@ -378,7 +378,7 @@ Source
 
  .. _debugger-command-quit:
 
-Quit
+quit
 ----
 
 |  **quit**

--- a/docs/source/debugger/image.rst
+++ b/docs/source/debugger/image.rst
@@ -13,7 +13,7 @@ You can also type **help <command>** for further details on each command in the 
 
  .. _debugger-command-images:
 
-Images
+images
 ------
 
 |  **images**
@@ -29,7 +29,7 @@ Images
 
  .. _debugger-command-mount:
 
-Mount
+mount
 -----
 
 |  **mount <device>,<filename>**
@@ -47,7 +47,7 @@ Mount
 
  .. _debugger-command-unmount:
 
-Unmount
+unmount
 -------
 
 |  **unmount <device>**

--- a/docs/source/debugger/memory.rst
+++ b/docs/source/debugger/memory.rst
@@ -18,7 +18,7 @@ You can also type **help <command>** for further details on each command in the 
 
  .. _debugger-command-dasm:
 
-Dasm
+dasm
 ----
 
 |  **dasm <filename>,<address>,<length>[,<opcodes>[,<cpu>]]**
@@ -40,7 +40,7 @@ Dasm
 
  .. _debugger-command-find:
 
-Find
+find
 ----
 
 |  **f[ind][{d|i}] <address>,<length>[,<data>[,...]]**
@@ -66,7 +66,7 @@ Find
 
  .. _debugger-command-dump:
 
-Dump
+dump
 ----
 
 |  **dump[{d|i}] <filename>,<address>,<length>[,<size>[,<ascii>[,<cpu>]]]**
@@ -94,7 +94,7 @@ Dump
 
  .. _debugger-command-save:
 
-Save
+save
 ----
 
 |  **save[{d|i}] <filename>,<address>,<length>[,<cpu>]**
@@ -120,7 +120,7 @@ Save
 
  .. _debugger-command-load:
 
-Load
+load
 ----
 
 |  **load[{d|i}] <filename>,<address>[,<length>,<cpu>]**
@@ -149,7 +149,7 @@ Load
 
  .. _debugger-command-map:
 
-Map
+map
 ---
 
 |  **map[{d|i}] <address>**
@@ -164,5 +164,4 @@ Map
 | Gives physical address and bank for logical address 152d0 in program memory
 |
 | Back to :ref:`debugger-memory-list`
-
 

--- a/docs/source/debugger/registerpoints.rst
+++ b/docs/source/debugger/registerpoints.rst
@@ -16,7 +16,7 @@ You can also type **help <command>** for further details on each command in the 
 
  .. _debugger-command-rpset:
 
-Rpset
+rpset
 -----
 
 |  **rp[set] {<condition>}[,<action>]]**
@@ -44,7 +44,7 @@ Rpset
 
  .. _debugger-command-rpclear:
 
-Rpclear
+rpclear
 -------
 
 |  **rpclear [<rpnum>]**
@@ -66,7 +66,7 @@ Rpclear
 
  .. _debugger-command-rpdisable:
 
-Rpdisable
+rpdisable
 ---------
 
 |  **rpdisable [<rpnum>]**
@@ -88,7 +88,7 @@ Rpdisable
 
  .. _debugger-command-rpenable:
 
-Rpenable
+rpenable
 --------
 
 |  **rpenable [<rpnum>]**
@@ -110,7 +110,7 @@ Rpenable
 
  .. _debugger-command-rplist:
 
-Rplist
+rplist
 ------
 
 |  **rplist**

--- a/docs/source/debugger/watchpoint.rst
+++ b/docs/source/debugger/watchpoint.rst
@@ -14,7 +14,7 @@ You can also type **help <command>** for further details on each command in the 
 
  .. _debugger-command-wpset:
 
-Wpset
+wpset
 -----
 
 |  **wp[{d|i}][set] <address>,<length>,<type>[,<condition>[,<action>]]**
@@ -51,7 +51,7 @@ Wpset
 
  .. _debugger-command-wpclear:
 
-Wpclear
+wpclear
 -------
 
 |  **wpclear [<wpnum>]**
@@ -73,7 +73,7 @@ Wpclear
 
  .. _debugger-command-wpdisable:
 
-Wpdisable
+wpdisable
 ---------
 
 |  **wpdisable [<wpnum>]**
@@ -95,7 +95,7 @@ Wpdisable
 
  .. _debugger-command-wpenable:
 
-Wpenable
+wpenable
 --------
 
 |  **wpenable [<wpnum>]**
@@ -117,7 +117,7 @@ Wpenable
 
  .. _debugger-command-wplist:
 
-Wplist
+wplist
 ------
 
 |  **wplist**


### PR DESCRIPTION
Per request, adjust case of commands.

Additional small tweaks to the expressions section as well.