### PR TITLE
Add initial support for new VTxx handeld, SY-889

### DIFF
--- a/src/devices/video/ppu2c0x_vt.cpp
+++ b/src/devices/video/ppu2c0x_vt.cpp
@@ -41,7 +41,6 @@ READ8_MEMBER(ppu_vt03_device::palette_read)
 void ppu_vt03_device::set_new_pen(int i)
 {
 	uint16_t palval = (m_newpal[i&0x7f] & 0x3f) | ((m_newpal[(i&0x7f)+0x80] & 0x3f)<<6);
-
 	// &0x3f so we don't attempt to use any of the extended colours right now because
 	// I haven't managed to work out the format
 	m_palette->set_pen_indirect(i&0x7f,palval&0x3f);
@@ -312,15 +311,14 @@ WRITE8_MEMBER(ppu_vt03_device::write)
 	}
 	else
 	{
+		logerror("%s: write to reg 0x20%02x %02x\n", machine().describe_context(), offset, data);
 		switch (offset)
 		{
 		case 0x10:
-			logerror("%s: write to reg 0x2010 %02x\n", machine().describe_context(), data);
 			set_2010_reg(data);
 			break;
 
 		case 0x11:
-			logerror("%s: write to reg 0x2011 %02x\n", machine().describe_context(), data);
 			break;
 
 		case 0x12:

--- a/src/devices/video/ppu2c0x_vt.cpp
+++ b/src/devices/video/ppu2c0x_vt.cpp
@@ -40,10 +40,21 @@ READ8_MEMBER(ppu_vt03_device::palette_read)
 
 void ppu_vt03_device::set_new_pen(int i)
 {
-	uint16_t palval = (m_newpal[i&0x7f] & 0x3f) | ((m_newpal[(i&0x7f)+0x80] & 0x3f)<<6);
-	// &0x3f so we don't attempt to use any of the extended colours right now because
-	// I haven't managed to work out the format
-	m_palette->set_pen_indirect(i&0x7f,palval&0x3f);
+	if(m_pal_mode == PAL_MODE_NEW_RGB) {
+		
+		uint16_t rgbval = (m_newpal[i&0x7f] & 0xff) | ((m_newpal[(i&0x7f)+0x80] & 0xff)<<8);
+		logerror ("pal %d rgb %04x\n",i,rgbval);
+		uint8_t blue = (rgbval & 0x001f) << 3;
+		uint8_t green = (rgbval & 0x3e0) >> 2;
+		uint8_t red  = (rgbval & 0x7C00) >> 7;
+		m_palette->set_pen_color(i & 0x7f, rgb_t(red, green, blue));
+	} else {
+		uint16_t palval = (m_newpal[i&0x7f] & 0x3f) | ((m_newpal[(i&0x7f)+0x80] & 0x3f)<<6);
+		// &0x3f so we don't attempt to use any of the extended colours right now because
+		// I haven't managed to work out the format
+		m_palette->set_pen_indirect(i&0x7f,palval&0x3f);
+	}
+
 }
 
 WRITE8_MEMBER(ppu_vt03_device::palette_write)

--- a/src/devices/video/ppu2c0x_vt.cpp
+++ b/src/devices/video/ppu2c0x_vt.cpp
@@ -40,10 +40,8 @@ READ8_MEMBER(ppu_vt03_device::palette_read)
 
 void ppu_vt03_device::set_new_pen(int i)
 {
-	if(m_pal_mode == PAL_MODE_NEW_RGB) {
-		
+	if(m_pal_mode == PAL_MODE_NEW_RGB) {		
 		uint16_t rgbval = (m_newpal[i&0x7f] & 0xff) | ((m_newpal[(i&0x7f)+0x80] & 0xff)<<8);
-		logerror ("pal %d rgb %04x\n",i,rgbval);
 		uint8_t blue = (rgbval & 0x001f) << 3;
 		uint8_t green = (rgbval & 0x3e0) >> 2;
 		uint8_t red  = (rgbval & 0x7C00) >> 7;
@@ -110,12 +108,16 @@ void ppu_vt03_device::device_reset()
 
 	m_read_bg.resolve_safe(0);
 	m_read_sp.resolve_safe(0);
-
+	for (int i = 0;i < 0xff;i++)
+		m_newpal[i] = 0x0;
+	set_2010_reg(0x00);
+	set_2010_reg(0x80);
 	set_2010_reg(0x00);
 
 	// todo: what are the actual defaults for these?
 	for (int i = 0;i < 0x20;i++)
 		set_201x_reg(i, 0x00);
+	
 
 	m_read_bg4_bg3 = 0;
 	m_va34 = 0;

--- a/src/devices/video/ppu2c0x_vt.h
+++ b/src/devices/video/ppu2c0x_vt.h
@@ -25,13 +25,25 @@
 #define MCFG_PPU_VT03_READ_SP_CB(_devcb) \
 	devcb = &ppu_vt03_device::set_read_sp_callback(*device, DEVCB_##_devcb);
 
+#define MCFG_PPU_VT03_MODIFY MCFG_DEVICE_MODIFY
+
+#define MCFG_PPU_VT03_SET_PAL_MODE(pmode) \
+	ppu_vt03_device::set_palette_mode(*device, pmode);
+
+enum vtxx_pal_mode {
+	PAL_MODE_VT0x,
+	PAL_MODE_NEW_RGB,
+};
+
 class ppu_vt03_device : public ppu2c0x_device {
 public:
 	ppu_vt03_device(const machine_config &mconfig, const char *tag, device_t *owner, uint32_t clock);
 
 	template <class Object> static devcb_base &set_read_bg_callback(device_t &device, Object &&cb) { return downcast<ppu_vt03_device &>(device).m_read_bg.set_callback(std::forward<Object>(cb)); }
 	template <class Object> static devcb_base &set_read_sp_callback(device_t &device, Object &&cb) { return downcast<ppu_vt03_device &>(device).m_read_sp.set_callback(std::forward<Object>(cb)); }
-
+	
+	static void set_palette_mode(device_t &device, vtxx_pal_mode pmode) { downcast<ppu_vt03_device &>(device).m_pal_mode = pmode; }
+	
 	virtual DECLARE_READ8_MEMBER(read) override;
 	virtual DECLARE_WRITE8_MEMBER(write) override;
 	virtual DECLARE_READ8_MEMBER(palette_read) override;
@@ -73,7 +85,9 @@ private:
 	palette_device *m_palette;
 
 	uint8_t m_201x_regs[0x20];
-
+	
+	vtxx_pal_mode m_pal_mode = PAL_MODE_VT0x;
+	
 	void set_2010_reg(uint8_t data);
 
 	void set_new_pen(int i);

--- a/src/mame/drivers/nes_vt.cpp
+++ b/src/mame/drivers/nes_vt.cpp
@@ -326,10 +326,11 @@ void nes_vt_state::scanline_irq(int scanline, int vblank, int blanked)
 	{
 		m_timer_val--;
 
-		if (m_timer_val < 0)
+		if (m_timer_val < 1)
 		{
 			if (m_timer_irq_enabled)
 			{
+				logerror("scanline_irq %d\n", scanline);
 				irqstate = 1;
 			}
 		}
@@ -399,7 +400,8 @@ void nes_vt_state::machine_reset()
 	m_timer_irq_enabled = 0;
 	m_timer_running = 0;
 	m_timer_val = 0;
-
+	m_vdma_ctrl = 0;
+	
 	update_banks();
 }
 
@@ -764,12 +766,14 @@ WRITE8_MEMBER(nes_vt_state::vt_hh_sprite_dma_w)
 	logerror("vthh dma start ctrl=%02x addr=%04x\n", m_vdma_ctrl, src_addr);
 	for (int i = 0; i < length; i++)
 	{
+		
 		uint8_t spriteData = space.read_byte(src_addr + i);
 		if(dma_mode) {
 			space.write_byte(0x2007, spriteData);
 		} else {
 			space.write_byte(0x2004, spriteData);
 		}
+		if(((src_addr + i) & 0xFF) == length) break;
 	}
 
 	// should last (length * 4 - 1) CPU cycles.

--- a/src/mame/drivers/nes_vt.cpp
+++ b/src/mame/drivers/nes_vt.cpp
@@ -20,7 +20,13 @@
 
   VT16 - ?
   VT18 - ?
-
+	
+	Mystery handheld SoC, may or may not be VRT:
+		Uses SQI rather than parallel flash
+		Vaguely OneBus compatible but some registers different ($411C in particular)
+		Uses RGB format for palettes
+		Credit to NewRisingSun2 for much of the reverse engineering
+	
   (more)
 
   VT1682 - NOT compatible with NES, different video system, sound CPU (4x
@@ -867,6 +873,9 @@ static MACHINE_CONFIG_DERIVED( nes_vt_xx, nes_vt )
 	MCFG_CPU_PROGRAM_MAP(nes_vt_xx_map)
 MACHINE_CONFIG_END
 
+// New mystery handheld architecture, VTxx derived
+static MACHINE_CONFIG_DERIVED( nes_vt_hh, nes_vt_xx )
+MACHINE_CONFIG_END
 
 static INPUT_PORTS_START( nes_vt )
 INPUT_PORTS_END
@@ -1043,6 +1052,11 @@ ROM_START( vgpmini )
 	// there was a dump of a 'secure' area with this, but it was just the bottom 0x10000 bytes of the existing rom.
 ROM_END
 
+ROM_START( sy889 )
+	ROM_REGION( 0x800000, "mainrom", 0 )
+	ROM_LOAD( "sy889_w25q64.bin", 0x00000, 0x800000, CRC(fcdaa6fc) SHA1(0493747facf2172b8af22010851668bb18cbb3e4) )
+ROM_END
+
 // earlier version of vdogdemo
 CONS( 200?, vdogdeme,  0,  0,  nes_vt,    nes_vt, nes_vt_state,  0, "VRT", "V-Dog (prototype, earlier)", MACHINE_NOT_WORKING )
 
@@ -1067,7 +1081,8 @@ CONS( 200?, dgun2500,  0,  0,  nes_vt,    nes_vt, nes_vt_state,  0, "dreamGEAR",
 CONS( 2012, dgun2561,  0,  0,  nes_vt,    nes_vt, nes_vt_state,  0, "dreamGEAR", "dreamGEAR My Arcade Portable Gaming System (DGUN-2561)", MACHINE_NOT_WORKING )
 CONS( 200?, lexcyber,  0,  0,  nes_vt_xx, nes_vt, nes_vt_state,  0, "Lexibook", "Lexibook Compact Cyber Arcade", MACHINE_NOT_WORKING )
 
-// these seem to have custom CPU opcodes? looks similar to the above, has many of the same games, but isn't 100% valid 6502
+// these are VT1682 based and have scrambled CPU opcodes. Will need VT1682 CPU and PPU
+// to be emulated
 // (no visible tiles in ROM using standard decodes tho, might need moving out of here)
 CONS( 200?, ii8in1,    0,  0,  nes_vt,    nes_vt, nes_vt_state,  0, "Intec", "InterAct 8-in-1", MACHINE_NOT_WORKING )
 CONS( 200?, ii32in1,   0,  0,  nes_vt,    nes_vt, nes_vt_state,  0, "Intec", "InterAct 32-in-1", MACHINE_NOT_WORKING )
@@ -1105,4 +1120,4 @@ CONS( 200?, mc_8x6ss,   0,        0,  nes_vt,    nes_vt, nes_vt_state,  0, "<unk
 CONS( 2004, mc_dcat8,   0,        0,  nes_vt,    nes_vt, nes_vt_state,  0, "<unknown>", "100 in 1 (D-CAT8 8bit Console, set 1) (v5.01.11-frd, BL 20041217)", MACHINE_NOT_WORKING )
 CONS( 2004, mc_dcat8a,  mc_dcat8, 0,  nes_vt,    nes_vt, nes_vt_state,  0, "<unknown>", "100 in 1 (D-CAT8 8bit Console, set 2)", MACHINE_NOT_WORKING )
 
-
+CONS( 2017, sy889,  		0, 				0,  nes_vt_hh, nes_vt, nes_vt_state,  0, "SY Corp", 	"SY-889 300 in 1 Handheld", MACHINE_NOT_WORKING )

--- a/src/mame/drivers/nes_vt.cpp
+++ b/src/mame/drivers/nes_vt.cpp
@@ -121,7 +121,7 @@ private:
 	void scanline_irq(int scanline, int vblank, int blanked);
 	uint8_t m_410x[0xc];
 	
-	uint8_t vdma_ctrl;
+	uint8_t m_vdma_ctrl;
 	
 	int m_timer_irq_enabled;
 	int m_timer_running;
@@ -749,9 +749,9 @@ WRITE8_MEMBER(nes_vt_state::nes_vh_sprite_dma_w)
 
 WRITE8_MEMBER(nes_vt_state::vt_hh_sprite_dma_w)
 {
-	uint8_t dma_mode = vdma_ctrl & 0x01;
-	uint8_t dma_len  = (vdma_ctrl >> 1) & 0x07;
-	uint8_t src_nib_74 =  (vdma_ctrl >> 4) & 0x0F;
+	uint8_t dma_mode = m_vdma_ctrl & 0x01;
+	uint8_t dma_len  = (m_vdma_ctrl >> 1) & 0x07;
+	uint8_t src_nib_74 =  (m_vdma_ctrl >> 4) & 0x0F;
 	int length = 256;
 	switch(dma_len) {
 		case 0x0: length = 256; break;
@@ -761,7 +761,7 @@ WRITE8_MEMBER(nes_vt_state::vt_hh_sprite_dma_w)
 		case 0x7: length = 128; break;
 	}
 	uint16_t src_addr = (data << 8) | (src_nib_74 << 4);
-	logerror("vthh dma start ctrl=%02x addr=%04x\n", vdma_ctrl, src_addr);
+	logerror("vthh dma start ctrl=%02x addr=%04x\n", m_vdma_ctrl, src_addr);
 	for (int i = 0; i < length; i++)
 	{
 		uint8_t spriteData = space.read_byte(src_addr + i);
@@ -779,7 +779,7 @@ WRITE8_MEMBER(nes_vt_state::vt_hh_sprite_dma_w)
 
 WRITE8_MEMBER(nes_vt_state::vt03_4034_w)
 {
-	vdma_ctrl = data;
+	m_vdma_ctrl = data;
 }
 
 static ADDRESS_MAP_START( nes_vt_map, AS_PROGRAM, 8, nes_vt_state )
@@ -935,6 +935,8 @@ MACHINE_CONFIG_END
 static MACHINE_CONFIG_DERIVED( nes_vt_hh, nes_vt_xx )
 	MCFG_CPU_MODIFY("maincpu")
 	MCFG_CPU_PROGRAM_MAP(nes_vt_hh_map)
+	MCFG_PPU_VT03_MODIFY("ppu")
+	MCFG_PPU_VT03_SET_PAL_MODE(PAL_MODE_NEW_RGB);
 MACHINE_CONFIG_END
 
 static INPUT_PORTS_START( nes_vt )

--- a/src/mame/mame.lst
+++ b/src/mame/mame.lst
@@ -29773,6 +29773,7 @@ gprnrs1
 gprnrs16
 vgpocket
 vgpmini
+sy889
 
 @source:newbrain.cpp
 newbrain                        //
@@ -39233,4 +39234,3 @@ vgmplay
 @source:ldplayer.cpp
 simldv1000                      // Pioneer LD-V1000
 simpr8210                       // Pioneer PR-8210
-


### PR DESCRIPTION
This adds initial support for the SY-889 handheld I dumped recently, which uses some one of the VTxx enhanced-NES chips. The exact chipset is unknown and doesn't resemble any other VTxx system - as well as software differences, it uses QSPI flash instead of the parallel flash used by all other known VRT chipsets. Credit to NewRisingSun2 who helped with the reverse engineering.

At the moment the ROM will run, the colours are correct (the chipset uses a different palette format to the VT03, storing colours as RGB555), but there are serious graphical glitches on the intro and when the menu scrolls. Most of the games seem to run OK though. I think this is because of the scanline interrupt timing being off.

Reverse engineering thread: http://s4.zetaboards.com/PGC_Forums/topic/30178284/1/