### PR TITLE
cdp1879.cpp: fixed Coverity out-of-bounds warnings (nw)

### DIFF
--- a/src/devices/machine/cdp1879.cpp
+++ b/src/devices/machine/cdp1879.cpp
@@ -70,7 +70,7 @@ void cdp1879_device::device_timer(emu_timer &timer, device_timer_id id, int para
 
 	// comparator IRQ
 	bool new_state = true;
-	for (int i = R_CNT_SECONDS; i <= R_CNT_MONTH; i++)
+	for (int i = R_CNT_SECONDS; i <= R_CNT_HOURS; i++)
 	{
 		if(m_regs[i] != m_regs[i + 6])
 		{

--- a/src/devices/machine/cdp1879.h
+++ b/src/devices/machine/cdp1879.h
@@ -71,7 +71,7 @@ private:
 		R_ALM_HOURS
 	};
 
-	u8 m_regs[10];
+	u8 m_regs[11];
 	bool m_comparator_state;
 
 	// timers


### PR DESCRIPTION
- m_regs seems to be too small since R_CNT_HOURS is 4 and it will access m_regs at + 6 - so index 10 would be out of bounds
- device_timer() also checked the alarm latch for the months which is never written and doesn't exist according to the data sheet