### PR TITLE
Overhaul commandline section of docs, includes index with linkable anchors.

### DIFF
--- a/docs/source/commandline/commandline-all.rst
+++ b/docs/source/commandline/commandline-all.rst
@@ -64,8 +64,14 @@ Note: By default, all the '**-list**' commands below write info to the screen. I
 
   **> filename**
 
-...where 'filename' is the textfile's path and name (e.g., c:\\mame\\list.txt).
+...where 'filename' is the textfile's path and name (e.g., list.txt).
 
+Example:
+
+|  **mame -listcrc puckman > list.txt**
+|
+| This creates (or overwrites if it's already there) list.txt and fills the file with the results of **-listcrc puckman**. In other words, the list of each ROM used in Puckman and the CRC for that ROM are written into that file.
+|
 
 .. _mame-commandline-listxml:
 
@@ -390,29 +396,43 @@ Core Search Path Options
 Core Output Directory Options
 -----------------------------
 
+.. _mame-commandline-cfgdirectory:
+
 **-cfg_directory** *<path>*
 
 	Specifies a single directory where configuration files are stored. Configuration files store user configurable settings that are read at startup and written when MAME exits. The default is 'cfg' (that is, a directory "cfg" in the same directory as the MAME executable). If this directory does not exist, it will be automatically created.
+
+.. _mame-commandline-nvramdirectory:
 
 **-nvram_directory** *<path>*
 
 	Specifies a single directory where NVRAM files are stored. NVRAM files store the contents of EEPROM and non-volatile RAM (NVRAM) for games which used this type of hardware. This data is read at startup and written when MAME exits. The default is 'nvram' (that is, a directory "nvram" in the same directory as the MAME executable). If this directory does not exist, it will be automatically created.
 
+.. _mame-commandline-inputdirectory:
+
 **-input_directory** *<path>*
 
 	Specifies a single directory where input recording files are stored. Input recordings are created via the -record option and played back via the -playback option. The default is 'inp' (that is, a directory	"inp" in the same directory as the MAME executable). If this directory does not exist, it will be automatically created.
+
+.. _mame-commandline-statedirectory:
 
 **-state_directory** *<path>*
 
 	Specifies a single directory where save state files are stored. Save state files are read and written either upon user request, or when using the -autosave option. The default is 'sta' (that is, a directory "sta" in the same directory as the MAME executable). If this directory does not exist, it will be  automatically created.
 
+.. _mame-commandline-snapshotdirectory:
+
 **-snapshot_directory** *<path>*
 
 	Specifies a single directory where screen snapshots are stored, when requested by the user. The default is 'snap' (that is, a directory "snap" in the same directory as the MAME executable). If this directory does not exist, it will be automatically created.
 
+.. _mame-commandline-diffdirectory:
+
 **-diff_directory** *<path>*
 
 	Specifies a single directory where hard drive differencing files are stored. Hard drive differencing files store any data that is written back to a hard disk image, in order to preserve the original image. The differencing files are created at startup when a game with a hard disk image. The default is 'diff' (that is, a directory "diff" in the same directory as the MAME executable). If this directory does not exist, it will be automatically created.
+
+.. _mame-commandline-commentdirectory:
 
 **-comment_directory** *<path>*
 

--- a/docs/source/commandline/commandline-all.rst
+++ b/docs/source/commandline/commandline-all.rst
@@ -710,21 +710,31 @@ Core Artwork Options
 Core Screen Options
 -------------------
 
+.. _mame-commandline-brightness:
+
 **-brightness** *<value>*
 
 	Controls the default brightness, or black level, of the game screens. This option does not affect the artwork or other parts of the display. Using the MAME UI, you can individually set the brightness for each game screen; this option controls the initial value for all visible game screens. The standard value is 1.0. Selecting lower values (down to 0.1) will produce a darkened display, while selecting higher values (up to 2.0) will give a brighter display. The default is *1.0*.
+
+.. _mame-commandline-contrast:
 
 **-contrast** *<value>*
 
 	Controls the contrast, or white level, of the game screens. This option does not affect the artwork or other parts of the display. Using the MAME UI, you can individually set the contrast for each game screen; this option controls the initial value for all visible game screens. The standard value is 1.0. Selecting lower values (down to 0.1) will produce a dimmer display, while selecting higher values (up to 2.0) will give a more saturated display. The default is *1.0*.
 
+.. _mame-commandline-gamma:
+
 **-gamma** *<value>*
 
 	Controls the gamma, which produces a potentially nonlinear black to white ramp, for the game screens. This option does not affect the artwork or other parts of the display. Using the MAME UI, you can individually set the gamma for each game screen; this option controls the initial value for all visible game screens. The standard value is 1.0, which gives a linear ramp from black to white. Selecting lower 	values (down to 0.1) will increase the nonlinearity toward black, while selecting higher values (up to 3.0) will push the nonlinearity toward white. The default is *1.0*.
 
+.. _mame-commandline-pausebrightness:
+
 **-pause_brightness** *<value>*
 
 	This controls the brightness level when MAME is paused. The default value is *0.65*.
+
+.. _mame-commandline-effect:
 
 **-effect** *<filename>*
 
@@ -735,13 +745,19 @@ Core Screen Options
 Core Vector Options
 -------------------
 
+.. _mame-commandline-noantialias:
+
 **-[no]antialias** / **-[no]aa**
 
 	Enables antialiased line rendering for vector games. The default is ON (*-antialias*).
 
+.. _mame-commandline-beam:
+
 **-beam** *<width>*
 
 	Sets the width of the vectors. This is a scaling factor against the standard vector width. A value of 1.0 will keep the default vector line width. Smaller values will reduce the width, and larger values will increase the width. The default is *1.0*.
+
+.. _mame-commandline-flicker:
 
 **-flicker** *<value>*
 
@@ -752,13 +768,19 @@ Core Vector Options
 Core Sound Options
 ------------------
 
+.. _mame-commandline-samplerate:
+
 **-samplerate** *<value>* / **-sr** *<value>*
 
 	Sets the audio sample rate. Smaller values (e.g. 11025) cause lower audio quality but faster emulation speed. Higher values (e.g. 48000) cause higher audio quality but slower emulation speed. The default is *48000*.
 
+.. _mame-commandline-nosamples:
+
 **-[no]samples**
 
 	Use samples if available. The default is ON (*-samples*).
+
+.. _mame-commandline-volume:
 
 **-volume** / **-vol** *<value>*
 
@@ -769,45 +791,67 @@ Core Sound Options
 Core Input Options
 ------------------
 
+.. _mame-commandline-nocoinlockout:
+
 **-[no]coin_lockout** / **-[no]coinlock**
 
 	Enables simulation of the "coin lockout" feature that is implemented on a number of game PCBs. It was up to the operator whether or not the coin lockout outputs were actually connected to the coin mechanisms. If this feature is enabled, then attempts to enter a coin while the lockout is active will fail and will display a popup message in the user interface (In debug mode). If this feature is disabled, the coin lockout signal will be ignored. The default is ON (*-coin_lockout*).
+
+.. _mame-commandline-ctrlr:
 
 **-ctrlr** *<controller>*
 
 	Enables support for special controllers. Configuration files are loaded from the ctrlrpath. They are in the same format as the .cfg files that are saved, but only control configuration data is read from the file. The default is NULL (no controller file).
 
+.. _mame-commandline-nomouse:
+
 **-[no]mouse**
 
 	Controls whether or not MAME makes use of mouse controllers. When this is enabled, you will likely be unable to use your mouse for other purposes until you exit or pause the game. The default is OFF (*-nomouse*).
+
+.. _mame-commandline-nojoystick:
 
 **-[no]joystick** / **-[no]joy**
 
 	Controls whether or not MAME makes use of joystick/gamepad controllers. When this is enabled, MAME will ask DirectInput about which controllers are connected. The default is OFF (*-nojoystick*).
 
+.. _mame-commandline-nolightgun:
+
 **-[no]lightgun** / **-[no]gun**
 
 	Controls whether or not MAME makes use of lightgun controllers. Note that most lightguns map to the mouse, so using -lightgun and -mouse together may produce strange results. The default is OFF (*-nolightgun*).
+
+.. _mame-commandline-nomultikeyboard:
 
 **-[no]multikeyboard** / **-[no]multikey**
 
 	Determines whether MAME differentiates between multiple keyboards. Some systems may report more than one keyboard; by default, the data from all of these keyboards is combined so that it looks like a single keyboard. Turning this option on will enable MAME to report keypresses	on different keyboards independently. The default is OFF (*-nomultikeyboard*).
 
+.. _mame-commandline-nomultimouse:
+
 **-[no]multimouse**
 
 	Determines whether MAME differentiates between multiple mice. Some systems may report more than one mouse device; by default, the data from all of these mice is combined so that it looks like a single mouse. Turning this option on will enable MAME to report mouse movement and button presses on different mice independently. The default is OFF (*-nomultimouse*).
+
+.. _mame-commandline-nosteadykey:
 
 **-[no]steadykey** / **-[no]steady**
 
 	Some games require two or more buttons to be pressed at exactly the same time to make special moves. Due to limitations in the keyboard hardware, it can be difficult or even impossible to accomplish that using the standard keyboard handling. This option selects a different handling that makes it easier to register simultaneous button presses, but has the disadvantage of making controls less responsive. The default is OFF (*-nosteadykey*)
 
+.. _mame-commandline-uiactive:
+
 **-[no]ui_active**
 
         Enable user interface on top of emulated keyboard (if present).  The default is OFF (*-noui_active*)
 
+.. _mame-commandline-nooffscreenreload:
+
 **-[no]offscreen_reload** / **-[no]reload**
 
 	Controls whether or not MAME treats a second button input from a lightgun as a reload signal. In this case, MAME will report the gun's position as (0,MAX) with the trigger held, which is equivalent to an	offscreen reload. This is only needed for games that required you to shoot offscreen to reload, and then only if your gun does not support off screen reloads. The default is OFF (*-nooffscreen_reload*).
+
+.. _mame-commandline-joystickmap:
 
 **-joystick_map** *<map>* / **-joymap** *<map>*
 
@@ -843,21 +887,31 @@ Core Input Options
 
 	The remaining three rows are also missing, so they are assumed to be the up/down mirrors of the first three rows, giving three final rows of 111222333.
 
+.. _mame-commandline-joystickdeadzone:
+
 **-joystick_deadzone** *<value>* / **-joy_deadzone** *<value>* / **-jdz** *<value>*
 
 	If you play with an analog joystick, the center can drift a little. joystick_deadzone tells how far along an axis you must move before the axis starts to change. This option expects a float in the range of 0.0 to 1.0. Where 0 is the center of the joystick and 1 is the outer limit. The default is *0.3*.
+
+.. _mame-commandline-joysticksaturation:
 
 **-joystick_saturation** *<value>* / **joy_saturation** *<value>* / **-jsat** *<value>*
 
 	If you play with an analog joystick, the ends can drift a little, and may not match in the +/- directions. joystick_saturation tells how far along an axis movement change will be accepted before it reaches the maximum range. This option expects a float in the range of 0.0 to 1.0, where 0 is the center of the joystick and 1 is the outer limit. The default is *0.85*.
 
+.. _mame-commandline-natural:
+
 **\-natural**
 
         Allows user to specify whether or not to use a natural keyboard or not. This allows you to start your game or system in a 'native' mode, depending on your region, allowing compatability for non-"QWERTY" style keyboards. The default is OFF (*-nonatural*)
 
+.. _mame-commandline-joystickcontradictory:
+
 **-joystick_contradictory**
 
         Enable contradictory direction digital joystick input at the same time such as **Left and Right** or **Up and Down** at the same time.  The default is OFF (*-nojoystick_contradictory*)
+
+.. _mame-commandline-coinimpulse:
 
 **-coin_impulse** *[n]*
 
@@ -868,19 +922,35 @@ Core Input Options
 Core Input Automatic Enable Options
 -----------------------------------
 
+.. _mame-commandline-paddledevice:
+
 **\-paddle_device**       enable (none|keyboard|mouse|lightgun|joystick) if a paddle control is present
+
+.. _mame-commandline-adstickdevice:
 
 **\-adstick_device**      enable (none|keyboard|mouse|lightgun|joystick) if an analog joystick control is present
 
+.. _mame-commandline-pedaldevice:
+
 **\-pedal_device**        enable (none|keyboard|mouse|lightgun|joystick) if a pedal control is present
+
+.. _mame-commandline-dialdevice:
 
 **\-dial_device**         enable (none|keyboard|mouse|lightgun|joystick) if a dial control is present
 
+.. _mame-commandline-trackballdevice:
+
 **\-trackball_device**    enable (none|keyboard|mouse|lightgun|joystick) if a trackball control is present
+
+.. _mame-commandline-lightgundevice:
 
 **\-lightgun_device**     enable (none|keyboard|mouse|lightgun|joystick) if a lightgun control is present
 
+.. _mame-commandline-positionaldevice:
+
 **\-positional_device**   enable (none|keyboard|mouse|lightgun|joystick) if a positional control is present
+
+.. _mame-commandline-mousedevice:
 
 **\-mouse_device**        enable (none|keyboard|mouse|lightgun|joystick) if a mouse control is present
 
@@ -891,25 +961,37 @@ Core Input Automatic Enable Options
 Debugging Options
 -----------------
 
+.. _mame-commandline-verbose:
+
 **-[no]verbose** / **-[no]v**
 
 	Displays internal diagnostic information. This information is very useful for debugging problems with your configuration. IMPORTANT: when reporting bugs, please run with **mame -verbose** and include the resulting information. The default is OFF (*-noverbose*).
+
+.. _mame-commandline-oslog:
 
 **-[no]oslog**
 
 	Output error.log data to the system debugger. The default is OFF (*-nooslog*).
 
+.. _mame-commandline-log:
+
 **-[no]log**
 
 	Creates a file called error.log which contains all of the internal log messages generated by the MAME core and game drivers. The default is OFF (*-nolog*).
+
+.. _mame-commandline-debug:
 
 **-[no]debug**
 
 	Activates the integrated debugger. By default, the debugger is entered by pressing the tilde (~) key during emulation. It is also entered immediately at startup. The default is OFF (*-nodebug*).
 
+.. _mame-commandline-debugscript:
+
 **-debugscript** *<filename>*
 
 	Specifies a file that contains a list of debugger commands to execute immediately upon startup. The default is NULL (*no commands*).
+
+.. _mame-commandline-updateinpause:
 
 **-[no]update_in_pause**
 
@@ -919,17 +1001,25 @@ Debugging Options
 Core Communication Options
 --------------------------
 
+.. _mame-commandline-commlocalhost:
+
 **-comm_localhost** *<string>*
 
 	Local address to bind to.  This can be a traditional xxx.xxx.xxx.xxx address or a string containing a resolvable hostname.  The default is value is "*0.0.0.0*"
+
+.. _mame-commandline-commlocalport:
 
 **-comm_localport** *<string>*
 
 	Local port to bind to.  This can be any traditional communications port as an unsigned 16-bit integer (0-65535).  The default value is "*15122*".
 
+.. _mame-commandline-commremotehost:
+
 **-comm_remotehost** *<string>*
 
 	Remote address to connect to.  This can be a traditional xxx.xxx.xxx.xxx address or a string containing a resolvable hostname.  The default is value is "*0.0.0.0*"
+
+.. _mame-commandline-commremoteport:
 
 **-comm_remoteport** *<string>*
 
@@ -940,48 +1030,72 @@ Core Communication Options
 Core Misc Options
 -----------------
 
+.. _mame-commandline-drc:
+
 **-[no]drc**
 	Enable DRC cpu core if available.  The default is ON (*-drc*).
+
+.. _mame-commandline-drcusec:
 
 **\-drc_use_c**
 
 	Force DRC use the C code backend.  The default is OFF (*-nodrc_use_c*).
 
+.. _mame-commandline-drcloguml:
+
 **\-drc_log_uml**
 
 	Write DRC UML disassembly log.  The default is OFF (*-nodrc_log_uml*).
+
+.. _mame-commandline-drclognative:
 
 **\-drc_log_native**
 
 	write DRC native disassembly log.  The default is OFF (*-nodrc_log_native*).
 
+.. _mame-commandline-bios:
+
 **-bios** *<biosname>*
 
 	Specifies the specific BIOS to use with the current game, for game systems that make use of a BIOS. The **-listxml** output will list all of the possible BIOS names for a game. The default is '*default*'.
+
+.. _mame-commandline-cheat:
 
 **-[no]cheat** / **-[no]c**
 
 	Activates the cheat menu with autofire options and other tricks from the cheat database, if present. The default is OFF (*-nocheat*).
 
+.. _mame-commandline-skipgameinfo:
+
 **-[no]skip_gameinfo**
 
 	Forces MAME to skip displaying the game info screen. The default is OFF (*-noskip_gameinfo*).
+
+.. _mame-commandline-uifont:
 
 **-uifont** *<fontname>*
 
 	Specifies the name of a font file to use for the UI font. If this font cannot be found or cannot be loaded, the system will fall back to its built-in UI font. On some platforms 'fontname' can be a system font name (TTF) instead of a (BDF) font file. The default is '*default*' (use the OSD-determined default font).
 
+.. _mame-commandline-ramsize:
+
 **-ramsize** *[n]*
 
 	Allows you to change the default RAM size (if supported by driver).
+
+.. _mame-commandline-confirmquit:
 
 **\-confirm_quit**
 
 	Display a Confirm Quit dialong to screen on exit, requiring one extra step to exit MAME.  The default is OFF (*-noconfirm_quit*).
 
+.. _mame-commandline-uimouse:
+
 **\-ui_mouse**
 
 	Displays a mouse cursor when using the built-in UI for MAME.  The default is (*-noui_mouse*).
+
+.. _mame-commandline-autobootcommand:
 
 **-autoboot_command** *"<command>"*
 
@@ -989,13 +1103,19 @@ Core Misc Options
 
 	Example:  -autoboot_command "load """$""",8,1\\n"
 
+.. _mame-commandline-autobootdelay:
+
 **-autoboot_delay** *[n]*
 
     Timer delay (in seconds) to trigger command execution on autoboot.
 
+.. _mame-commandline-autobootscript:
+
 **-autoboot_script** / **-script** *[filename.lua]*
 
     File containing scripting to execute after machine boot.
+
+.. _mame-commandline-language:
 
 **-language** *<language>*
 

--- a/docs/source/commandline/commandline-all.rst
+++ b/docs/source/commandline/commandline-all.rst
@@ -443,51 +443,75 @@ Core Output Directory Options
 Core State/Playback Options
 ---------------------------
 
+.. _mame-commandline-norewind:
+
 **-[no]rewind**
 
 	When enabled and emulation is paused, automatically creates a save state in memory every time a frame is advanced. Rewind save states can then be loaded consecutively by pressing the rewind single step shortcut key (*Left Shift + Tilde by default*). The default rewind value is OFF (-norewind).
 	
 	If debugger is in a 'break' state, a save state is instead created every time step in, step over, or step out occurs. In that mode, rewind save states can be loaded by executing the debugger 'rewind'(or 'rw') command.
 	
+.. _mame-commandline-rewindcapacity:
+
 **-rewind_capacity** *<value>*
 
 	Sets the rewind capacity value, in megabytes. It is the total amount of memory rewind savestates can occupy. When capacity is hit, old savestates get erased as new ones are captured. Setting capacity lower than the current savestate size disables rewind. Values below 0 are automatically clamped to 0.
+
+.. _mame-commandline-state:
 
 **-state** *<slot>*
 
 	Immediately after starting the specified game, will cause the save state in the specified <slot> to be loaded.
 
+.. _mame-commandline-noautosave:
+
 **-[no]autosave**
 
 	When enabled, automatically creates a save state file when exiting MAME and automatically attempts to reload it when later starting MAME with the same game. This only works for games that have explicitly enabled save state support in their driver. The default is OFF (-noautosave).
+
+.. _mame-commandline-playback:
 
 **-playback** / **-pb** *<filename>*
 
 	Specifies a file from which to play back a series of game inputs. Thisfeature does not work reliably for all games, but can be used to watch a previously recorded game session from start to finish. In order to make things consistent, you should only record and playback with all configuration (.cfg), NVRAM (.nv), and memory card files deleted. The default is NULL (no playback).
 
+.. _mame-commandline-exitafterplayback:
+
 **-exit_after_playback**
 
 	Tells MAME to exit after finishing playback of the input file.
+
+.. _mame-commandline-record:
 
 **-record** / **-rec** *<filename>*
 
 	Specifies a file to record all input from a game session. This can be used to record a game session for later playback. This feature does not work reliably for all games, but can be used to watch a previously recorded game session from start to finish. In order to make things consistent, you should only record and playback with all configuration (.cfg), NVRAM (.nv), and memory card files deleted. The default is NULL (no recording).
 
+.. _mame-commandline-recordtimecode:
+
 **-record_timecode**
 
 	Tells MAME to create a timecode file. It contains a line with elapsed times on each press of timecode shortcut key (*default is F12*). This option works only when recording mode is enabled (**-record** option). The file is saved in the *inp* folder. By default, no timecode file is saved.
+
+.. _mame-commandline-mngwrite:
 
 **-mngwrite** *<filename>*
 
 	Writes each video frame to the given <filename> in MNG format, producing an animation of the game session. Note that -mngwrite only writes video frames; it does not save any audio data. Use -wavwrite for that, and reassemble the audio/video using offline tools. The default is NULL (no recording).
 
+.. _mame-commandline-aviwrite:
+
 **-aviwrite** *<filename>*
 
 	Stream video and sound data to the given <filename> in AVI format, producing an animation of the game session complete with sound. The default is NULL (no recording).
 
+.. _mame-commandline-wavwrite:
+
 **-wavwrite** *<filename>*
 
 	Writes the final mixer output to the given <filename> in WAV format, producing an audio recording of the game session. The default is NULL (no recording).
+
+.. _mame-commandline-snapname:
 
 **-snapname** *<name>*
 
@@ -501,9 +525,13 @@ Core State/Playback Options
 	
 	A few examples: if you use 'mame robby -snapname foo/%g%i' snapshots will be saved as 'snaps\\foo\\robby0000.png' , 'snaps\\foo\\robby0001.png' and so on; if you use 'mame nes -cart robby -snapname %g/%d_cart' snapshots will be saved as 'snaps\\nes\\robby.png' ; if you use 'mame c64 -flop1 robby -snapname %g/%d_flop1/%i' snapshots will be saved as 'snaps\\c64\\robby\\0000.png'.
 
+.. _mame-commandline-snapsize:
+
 **-snapsize** *<width>x<height>*
 
 	Hard-codes the size for snapshots and movie recording. By default, MAME will create snapshots at the game's current resolution in raw pixels, and will create movies at the game's starting resolution in raw pixels. If you specify this option, then MAME will create both snapshots and movies at the size specified, and will bilinear filter the result. Note that this size does not automatically rotate if the game is vertically oriented. The default is '*auto*'.
+
+.. _mame-commandline-snapview:
 
 **-snapview** *<viewname>*
 
@@ -511,9 +539,13 @@ Core State/Playback Options
 	
 	For example, **-snapview native** will match the "Native (15:14)" view even though it is not a perfect match. <viewname> can also be 'auto', which selects the first view with all screens present. The default value is '*internal*'.
 
+.. _mame-commandline-nosnapbilinear:
+
 **-[no]snapbilinear**
 
 	Specify if the snapshot or movie should have bilinear filtering	applied.  Shutting this off can make a difference in some performance while recording video to a file.  The default is ON (*-snapbilinear*).
+
+.. _mame-commandline-statename:
 
 **-statename** *<name>*
 
@@ -527,6 +559,8 @@ Core State/Playback Options
 	
 	A few examples: if you use 'mame robby -statename foo/%g' save states will be stored inside 'sta\\foo\\robby\\' ; if you use 'mame nes -cart robby -statename %g/%d_cart' save states will be stored inside 'sta\\nes\\robby\\' ; if you use 'mame c64 -flop1 robby -statename %g/%d_flop1' save states will be stored inside 'sta\\c64\\robby\\'.
 
+.. _mame-commandline-noburnin:
+
 **-[no]burnin**
 
 	Tracks brightness of the screen during play and at the end of emulation generates a PNG that can be used to simulate burn-in effects on other games. The resulting PNG is created such that the least used-areas of the screen are fully white (since burned-in areas are darker, all other areas of the screen must be lightened a touch). 
@@ -538,29 +572,43 @@ Core State/Playback Options
 Core Performance Options
 ------------------------
 
+.. _mame-commandline-noautoframeskip:
+
 **-[no]autoframeskip** / **-[no]afs**
 
 	Automatically determines the frameskip level while you're playing the game, adjusting it constantly in a frantic attempt to keep the game running at full speed. Turning this on overrides the value you have set for -frameskip below. The default is OFF (*-noautoframeskip*).
+
+.. _mame-commandline-frameskip:
 
 **-frameskip** / **-fs** *<level>*
 
 	Specifies the frameskip value. This is the number of frames out of every 12 to drop when running. For example, if you say -frameskip 2, then MAME will display 10 out of every 12 frames. By skipping those frames, you may be able to get full speed in a game that requires more horsepower than your computer has. The default value is **-frameskip 0**, which skips no frames.
 
+.. _mame-commandline-secondstorun:
+
 **-seconds_to_run** / **-str** *<seconds>*
 
 	This option can be used for benchmarking and automated testing. It tells MAME to stop execution after a fixed number of seconds. By combining this with a fixed set of other command line options, you can set up a consistent environment for benchmarking MAME performance. In addition, upon exit, the **-str** option will write a screenshot called *final.png* to the game's snapshot directory.
+
+.. _mame-commandline-nothrottle:
 
 **-[no]throttle**
 
 	Configures the default thottling setting. When throttling is on, MAME attempts to keep the game running at the game's intended speed. When throttling is off, MAME runs the game as fast as it can. Note that the fastest speed is more often than not limited by your graphics card, especially for older games. The default is ON (*-throttle*).
 
+.. _mame-commandline-nosleep:
+
 **-[no]sleep**
 
 	Allows MAME to give time back to the system when running with -throttle. This allows other programs to have some CPU time, assuming that the game isn't taxing 100% of your CPU resources. This option can potentially cause hiccups in performance if other demanding programs are running. The default is ON (*-sleep*).
 
+.. _mame-commandline-speed:
+
 **-speed** *<factor>*
 
 	Changes the way MAME throttles gameplay such that the game runs at some multiplier of the original speed. A <factor> of 1.0 means to run the game at its normal speed. A <factor> of 0.5 means run at half speed, and a <factor> of 2.0 means run at 2x speed. Note that changing this value affects sound playback as well, which will scale in pitch accordingly. The internal resolution of the fraction is two decimalplaces, so a value of 1.002 is the same as 1.0. The default is 1.0.
+
+.. _mame-commandline-norefreshspeed:
 
 **-[no]refreshspeed** / **-[no]rs**
 
@@ -571,12 +619,17 @@ Core Performance Options
 Core Rotation Options
 ---------------------
 
+.. _mame-commandline-norotate:
+
 | **-[no]rotate**
 |
 |	Rotate the game to match its normal state (horizontal/vertical). This ensures that both vertically and horizontally oriented games show up correctly without the need to rotate your monitor. If you want to keep the game displaying 'raw' on the screen the way it would have in the arcade, turn this option OFF. The default is ON (*-rotate*).
 |
 |
 
+.. _mame-commandline-noror:
+
+.. _mame-commandline-norol:
 
 | **-[no]ror**
 | **-[no]rol**
@@ -586,6 +639,10 @@ Core Rotation Options
 |
 |
 
+.. _mame-commandline-noautoror:
+
+.. _mame-commandline-noautorol:
+
 
 | **-[no]autoror**
 | **-[no]autorol**
@@ -594,6 +651,10 @@ Core Rotation Options
 |	These options are designed for use with pivoting screens that only pivot in a single direction. If your screen only pivots clockwise, use -autorol to ensure that the game will fill the screen either horizontally or vertically in one of the directions you can handle. If your screen only pivots counter-clockwise, use **-autoror**.
 |
 |
+
+.. _mame-commandline-noflipx:
+
+.. _mame-commandline-noflipy:
 
 
 | **-[no]flipx**
@@ -608,25 +669,37 @@ Core Rotation Options
 Core Artwork Options
 --------------------
 
+.. _mame-commandline-noartworkcrop:
+
 **-[no]artwork_crop** / **-[no]artcrop**
 
 	Enable cropping of artwork to the game screen area only. This works best with -video gdi or -video d3d, and means that vertically oriented games running full screen can display their artwork to the left and right sides of the screen. This option can also be controlled via the Video Options menu in the user interface. The default is OFF (*-noartwork_crop*).
+
+.. _mame-commandline-nousebackdrops:
 
 **-[no]use_backdrops** / **-[no]backdrop**
 
 	Enables/disables the display of backdrops. The default is ON (*-use_backdrops*).
 
+.. _mame-commandline-nouseoverlays:
+
 **-[no]use_overlays** / **-[no]overlay**
 
 	Enables/disables the display of overlays. The default is ON (*-use_overlays*).
+
+.. _mame-commandline-nousebezels:
 
 **-[no]use_bezels** / **-[no]bezels**
 
 	Enables/disables the display of bezels. The default is ON (*-use_bezels*).
 
+.. _mame-commandline-nousecpanels:
+
 **-[no]use_cpanels** / **-[no]cpanels**
 
 	Enables/disables the display of control panels. The default is ON (*-use_cpanels*).
+
+.. _mame-commandline-nousemarquees:
 
 **-[no]use_marquees** / **-[no]marquees**
 

--- a/docs/source/commandline/commandline-all.rst
+++ b/docs/source/commandline/commandline-all.rst
@@ -9,9 +9,13 @@ This section contains configuration options that are applicable to *all* MAME su
 Core commands
 -------------
 
+.. _mame-commandline-help:
+
 **-help** / **-h** / **-?**
 
 	Displays current MAME version and copyright notice.
+
+.. _mame-commandline-validate:
 
 **-validate** / **-valid**
 
@@ -24,11 +28,15 @@ Core commands
 Configuration commands
 ----------------------
 
+.. _mame-commandline-createconfig:
+
 **-createconfig** / **-cc**
 
 	Creates the default mame.ini file. All the configuration options
 	(not commands) described below can be permanently changed by editing
 	this configuration file.
+
+.. _mame-commandline-showconfig:
 
 **-showconfig** / **-sc**
 
@@ -38,6 +46,8 @@ Configuration commands
 		**mame -showconfig >mame.ini**
 
 	is equivalent to **-createconfig**.
+
+.. _mame-commandline-showusage:
 
 **-showusage** / **-su**
 
@@ -52,51 +62,72 @@ Frontend commands
 
 Note: By default, all the '**-list**' commands below write info to the screen. If you wish to write the info to a textfile instead, add this to the end of your command:
 
-  > filename
+  **> filename**
 
 ...where 'filename' is the textfile's path and name (e.g., c:\\mame\\list.txt).
 
+
+.. _mame-commandline-listxml:
 
 **-listxml** / **-lx** [*<gamename|wildcard>*]
 
 	List comprehensive details for all of the supported games. The output is quite long, so it is usually better to redirect this into a file. The output is in XML format. By default all games are listed; however, you can limit this list by specifying a driver name or wildcard after the -listxml command.
 
+.. _mame-commandline-listfull:
+
 **-listfull** / **-ll** [*<gamename|wildcard>*]
 
 	Displays a list of game driver names and descriptions. By default all games are listed; however, you can limit this list by specifying a driver name or wildcard after the **-listfull** command.
+
+.. _mame-commandline-listsource:
 
 **-listsource** / **-ls** [<*gamename|wildcard>*]
 
 	Displays a list of drivers and the names of the source files their game drivers live in. Useful for finding which driver a game runs on in order to fix bugs. By default all games are listed; however, you	can limit this list by specifying a driver name or wildcard after the **-listsource** command.
 
+.. _mame-commandline-listclones:
+
 **-listclones** / **-lc** [<*gamename|wildcard*>]
 
 	Displays a list of clones. By default all clones are listed; however, you can limit this list by specifying a driver name or wildcard after the **-listsource** command.
+
+.. _mame-commandline-listbrothers:
 
 **-listbrothers** / **-lb** [<*gamename|wildcard*>]
 
 	Displays a list of '*brothers*', or rather, other sets which are located in the same sourcefile as the gamename searched for.
 
+.. _mame-commandline-listcrc:
+
 **-listcrc** [<*gamename|wildcard*>]
 
 	Displays a full list of CRCs of all ROM images referenced by all drivers within MAME.
+
+.. _mame-commandline-listroms:
 
 **-listroms** [<*gamename|wildcard*>]
 
 	Displays a list of ROM images referenced by the specified game.
 
+.. _mame-commandline-listsamples:
 
 **-listsamples** [<*gamename|wildcard*>]
 
 	Displays a list of samples referenced by the specified game.
 
+.. _mame-commandline-verifyroms:
+
 **-verifyroms** [<*gamename|wildcard*>]
 
 	Checks for invalid or missing ROM images. By default all drivers that have valid ZIP files or directories in the rompath are verified; however, you can limit this list by specifying a driver name or wildcard after the **-verifyroms** command.
 
+.. _mame-commandline-verifysamples:
+
 **-verifysamples** [<*gamename|wildcard*>]
 
 	Checks for invalid or missing samples. By default all drivers that have valid ZIP files or directories in the samplepath are verified;	however, you can limit this list by specifying a driver name or wildcard after the **-verifyroms** command.
+
+.. _mame-commandline-romident:
 
 **-romident** [*path\\to\\romstocheck.zip*]
 
@@ -107,9 +138,13 @@ Note: By default, all the '**-list**' commands below write info to the screen. I
 		* 8: means some files were identified
 		* 9: means no files were identified
 
+.. _mame-commandline-listdevices:
+
 **-listdevices** / **-ld** [<*gamename|wildcard*>]
 
         Displays a list of all devices known to be hooked up to a game.  The ":" is considered the game itself with the devices list being attached to give the user a better understanding of what the emulation is using.
+
+.. _mame-commandline-listslots:
 
 **-listslots** [<*gamename|wildcard*>]
 
@@ -117,21 +152,31 @@ Note: By default, all the '**-list**' commands below write info to the screen. I
 		
         The slot name (e.g. **ctrl1**) can be used from the command line (**-ctrl1** in this case) 
 
+.. _mame-commandline-listmedia:
+
 **-listmedia** / **-lm** [<*gamename|wildcard*>]
 
         List available media that the chosen game or system allows to be used.  This includes media types (cartridge, cassette, diskette and more) as well as common file extentions which are supported.
+
+.. _mame-commandline-listsoftware:
 
 **-listsoftware** [<*gamename|wildcard*>]
 
         Posts to screen all software lists which can be used by the entered gamename or system.  Note that this is simply a copy/paste of the .XML file which reside in the HASH folder which are allowed to be used.
 
+.. _mame-commandline-verifysoftware:
+
 **-verifysoftware** [<*gamename|wildcard*>]
 
 	Checks for invalid or missing ROM images in your software lists. By default all drivers that have valid ZIP files or directories in the rompath are verified; however, you can limit this list by specifying a specific driver name or wildcard after the -verifysoftware command.
 
+.. _mame-commandline-getsoftlist:
+
 **-getsoftlist** [<*gamename|wildcard*>]
 
         Posts to screen a specific software list which matches with the gamename provided.
+
+.. _mame-commandline-verifysoftlist:
 
 **-verifysoftlist** [softwarelistname]
 
@@ -143,17 +188,25 @@ Note: By default, all the '**-list**' commands below write info to the screen. I
 OSD related options
 -------------------
 
+.. _mame-commandline-uimodekey:
+
 **-uimodekey** [*keystring*]
 
 	Key used to toggle emulated keyboard on and off.  Default setting is *SCRLOCK*.
+
+.. _mame-commandline-uifontprovider:
 
 **\-uifontprovider**
 
 	Chooses provider for UI font:  win, none or auto.  Default setting is *AUTO*.
 
+.. _mame-commandline-menu:
+
 **\-menu**
 
 	Enables menu bar at the top of the MAME window, if available by UI implementation.  Default is *OFF*
+
+.. _mame-commandline-keyboardprovider:
 
 **\-keyboardprovider**
 
@@ -164,6 +217,8 @@ OSD related options
 	
 	The default is *auto*. On Windows, auto will try rawinput with fallback to dinput. On SDL, auto will default to sdl.
 	
+.. _mame-commandline-mouseprovider:
+
 **\-mouseprovider**
 
 	Chooses how MAME will get mouse input.
@@ -173,6 +228,8 @@ OSD related options
 	
 	The default is *auto*. On Windows, auto will try rawinput with fallback to dinput. On SDL, auto will default to sdl.
 
+.. _mame-commandline-lightgunprovider:
+
 **\-lightgunprovider**
 
 	Chooses how MAME will get light gun input.
@@ -181,6 +238,8 @@ OSD related options
 	On SDL, you can choose from: auto, x11 or none
 
 	The default is *auto*. On Windows, auto will try rawinput with fallback to win32, or none if it doesn't find any. On SDL/Linux, auto will default to x11, or none if it doesn't find any. On other SDL, auto will default to none.
+
+.. _mame-commandline-joystickprovider:
 
 **\-joystickprovider**
 

--- a/docs/source/commandline/commandline-all.rst
+++ b/docs/source/commandline/commandline-all.rst
@@ -614,6 +614,20 @@ Core Performance Options
 
 	Allows MAME to dynamically adjust the gameplay speed such that it does not exceed the slowest refresh rate for any targeted monitors in your system. Thus, if you have a 60Hz monitor and run a game that is actually designed to run at 60.6Hz, MAME will dynamically change the speed down to 99% in order to prevent sound hiccups or other undesirable side effects of running at a slower refresh rate. The default is OFF (*-norefreshspeed*).
 
+.. _mame-commandline-numprocessors:
+
+**-numprocessors** *<auto|value>* / **-np** *<auto|value>*
+
+	Specify the number of processors to use for work queues. Specifying "*auto*" will use the value reported by the system or environment variable **OSDPROCESSORS**. To avoid abuse, this value is internally limited to 4 times the number of processors reported by the system. The default is "*auto*".
+
+.. _mame-commandline-bench:
+
+**-bench** *[n]*
+
+        Benchmark for *[n]* number of emulated seconds; implies the command string:
+
+        **-str [n] -video none -sound none -nothrottle**
+
 
 
 Core Rotation Options
@@ -662,6 +676,174 @@ Core Rotation Options
 | 
 |
 |	Flip (mirror) the game screen either horizontally (-flipx) or vertically (-flipy). The flips are applied after the -rotate and -ror/-rol options are applied. The default for both of these options is OFF (*-noflipx -noflipy*).
+|
+|
+
+
+Core Video Options
+------------------
+
+.. _mame-commandline-video:
+
+**-video** *<bgfx|gdi|d3d|opengl|soft|none>*
+
+|
+|	Specifies which video subsystem to use for drawing. Options here depend on the operating system and whether this is an SDL-compiled version of MAME.
+|
+|	On Windows:
+|
+|	Using '**bgfx**' specifies the new hardware accelerated renderer.
+|   Using '**gdi**' here, tells MAME to render video using older standard Windows graphics drawing calls. This is the slowest but most compatible option on older versions of Windows.
+|   Using '**d3d**' tells MAME to use Direct3D for rendering. This produces the better quality output than gdi and enables additional rendering options. It is recommended if you have a semi-recent (2002+) video card or onboard Intel video of the HD3000 line or better. 
+|   Using '**none**' displays no windows and does no drawing. This is primarily present for doing CPU benchmarks without the overhead of the video system. The default is *d3d*.
+|
+|   On other platforms (including SDL on Windows):
+|
+|   Using '**opengl**' tells MAME to render video using OpenGL acceleration. This may not work on all platforms due to wildly varying quality of stack and drivers.
+|   Using '**soft**' uses software rendering for video output. This isn't as fast or as nice as OpenGL but will work on any platform.
+|
+|   Defaults:
+|
+|   The default on Windows is **d3d**.
+|   The default for Mac OS X is '*opengl*' because OS X is guaranteed to have a compliant OpenGL stack.
+|   The default on all other systems is '*soft*'.
+
+
+.. _mame-commandline-numscreens:
+
+**-numscreens** *<count>*
+
+	Tells MAME how many output windows to create. For most games, a single output window is all you need, but some games originally used multiple screens (*e.g. Darius, PlayChoice-10*). Each screen (up to 4) has its own independent settings for physical monitor, aspect ratio, resolution, and view, which can be set using the options below. The default is *1*.
+
+.. _mame-commandline-window:
+
+**-[no]window** / **-[no]w**
+
+	Run MAME in either a window or full screen. The default is OFF (*-nowindow*).
+
+.. _mame-commandline-maximize:
+
+**-[no]maximize** / **-[no]max**
+
+	Controls initial window size in windowed mode. If it is set on, the window will initially be set to the maximum supported size when you start MAME. If it is turned off, the window will start out at the smallest supported size. This option only has an effect when the -window option is used. The default is ON (*-maximize*).
+
+.. _mame-commandline-keepaspect:
+
+**-[no]keepaspect** / **-[no]ka**
+
+	Enables aspect ratio enforcement. When this option is on, the game's proper aspect ratio (generally 4:3 or 3:4) is enforced, so you get the game looking like it should. When running in a window with this option on, you can only resize the window to the proper aspect ratio, unless you are holding down the CONTROL key. By turning the option off, the aspect ratio is allowed to float. In full screen mode, this means that all games will stretch to the full screen size (even vertical games). In window mode, it means that you can freely resize the window without any constraints. The default is ON (*-keepaspect*).
+
+	The MAME team heavily suggests you leave this at default. Stretching games beyond their original aspect ratio will mangle the appearance of the game in ways that no filtering or HLSL can repair.
+
+.. _mame-commandline-waitvsync:
+
+**-[no]waitvsync**
+
+	Waits for the refresh period on your computer's monitor to finish before starting to draw video to your screen. If this option is off, MAME will just draw to the screen at any old time, even in the middle of a refresh cycle. This can cause "tearing" artifacts, where the top portion of the screen is out of sync with the bottom portion. Tearing is not noticeable on all games, and some people hate it more than others. However, if you turn this option on, you will waste more of your CPU cycles waiting for the proper time to draw, so you will see a performance hit. You should only need to turn this on in windowed mode. In full screen mode, it is only needed if **-triplebuffer** does not remove the tearing, in which case you should use **-notriplebuffer -waitvsync**. Note that this option does not work with **-video gdi** mode. The default is OFF (*-nowaitvsync*).
+
+	Note that SDL-based MAME support for this option depends entirely on your operating system and video drivers; in general it will not work in windowed mode so **-video opengl** and fullscreen give the greatest chance of success.
+
+.. _mame-commandline-syncrefresh:
+
+**-[no]syncrefresh**
+
+	Enables speed throttling only to the refresh of your monitor. This means that the game's actual refresh rate is ignored; however, the sound code still attempts to keep up with the game's original refresh rate, so you may encounter sound problems. This option is intended mainly for those who have tweaked their video card's settings to provide carefully matched refresh rate options. Note that this option does not work with -video gdi mode. The default is OFF (*-nosyncrefresh*).
+
+.. _mame-commandline-prescale:
+
+**-prescale** *<amount>*
+
+	Controls the size of the screen images when they are passed off to the graphics system for scaling. At the minimum setting of 1, the screen is rendered at its original resolution before being scaled. At higher settings, the screen is expanded by a factor of *<amount>* before being scaled. With **-video d3d**, this produces a less blurry image at the expense of some speed. The default is *1*.
+
+	This is supported with all video output types (bgfx, d3d, etc) on Windows and is **ONLY** supported with OpenGL on other platforms.
+
+.. _mame-commandline-filter:
+
+**-[no]filter** / **-[no]d3dfilter** / **-[no]flt**
+
+	Enable bilinear filtering on the game screen graphics. When disabled, point filtering is applied, which is crisper but leads to scaling artifacts. If you don't like the filtered look, you are probably better off increasing the *-prescale* value rather than turning off filtering altogether. The default is ON (*-filter*).
+
+	This is supported with all video output types (bgfx, d3d, etc) on Windows and is **ONLY** supported with OpenGL on other platforms.
+
+.. _mame-commandline-unevenstretch:
+
+**-[no]unevenstretch**
+
+	Allow non-integer stretch factors allowing for great window sizing flexability.  The default is ON. (*-unevenstretch*)
+
+
+Core Full Screen Options
+------------------------
+
+.. _mame-commandline-switchres:
+
+**-[no]switchres**
+
+	Enables resolution switching. This option is required for the **-resolution\*** options to switch resolutions in full screen mode. On modern video cards, there is little reason to switch resolutions unless you are trying to achieve the "exact" pixel resolutions of the original games, which requires significant tweaking. This option is also useful on LCD displays, since they run with a fixed resolution and switching resolutions on them is just silly. This option does not work with **-video gdi**. The default is OFF (*-noswitchres*).
+
+
+Core Per-Window Options
+-----------------------
+
+.. _mame-commandline-screen:
+
+NOTE:  **Multiple Screens may fail to work correctly on some Mac machines as of right now.**
+
+| **-screen** *<display>*
+| **-screen0** *<display>*
+| **-screen1** *<display>*
+| **-screen2** *<display>*
+| **-screen3** *<display>*
+|
+|	Specifies which physical monitor on your system you wish to have each window use by default. In order to use multiple windows, you must have increased the value of the **-numscreens** option. The name of each display in your system can be determined by running MAME with the -verbose option. The display names are typically in the format of: *\\\\.\\DISPLAYn*, where 'n' is a number from 1 to the number of connected monitors. The default value for these options is '*auto*', which means that the first window is placed on the first display, the second window on the second display, etc.
+|
+|	The **-screen0**, **-screen1**, **-screen2**, **-screen3** parameters apply to the specific window. The **-screen** parameter applies to all windows. The window-specific options override values from the all window option. 
+|
+|
+
+
+.. _mame-commandline-aspect:
+
+| **-aspect** *<width:height>* / **-screen_aspect** *<num:den>*
+| **-aspect0** *<width:height>*
+| **-aspect1** *<width:height>*
+| **-aspect2** *<width:height>*
+| **-aspect3** *<width:height>*
+|
+|
+|	Specifies the physical aspect ratio of the physical monitor for each window. In order to use multiple windows, you must have increased the value of the **-numscreens** option. The physical aspect ratio can be determined by measuring the width and height of the visible screen image and specifying them separated by a colon. The default value for these options is '*auto*', which means that MAME assumes the aspect ratio is proportional to the number of pixels in the desktop video mode for each monitor.
+|
+|	The **-aspect0**, **-aspect1**, **-aspect2**, **-aspect3** parameters apply to the specific window. The **-aspect** parameter applies to all windows. The window-specific options override values from the all window option.
+|
+|
+
+
+.. _mame-commandline-resolution:
+
+| **-resolution** *<widthxheight[@refresh]>* / **-r** *<widthxheight[@refresh]>*
+| **-resolution0** *<widthxheight[@refresh]>* / **-r0** *<widthxheight[@refresh]>*
+| **-resolution1** *<widthxheight[@refresh]>* / **-r1** *<widthxheight[@refresh]>*
+| **-resolution2** *<widthxheight[@refresh]>* / **-r2** *<widthxheight[@refresh]>*
+| **-resolution3** *<widthxheight[@refresh]>* / **-r3** *<widthxheight[@refresh]>*
+|
+|	Specifies an exact resolution to run in. In full screen mode, MAME will try to use the specific resolution you request. The width and height are required; the refresh rate is optional. If omitted or set to 0, MAME will determine the mode automatically. For example, **-resolution 640x480** will force 640x480 resolution, but MAME is free to choose the refresh rate. Similarly, **-resolution 0x0@60** will force a 60Hz refresh rate, but allows MAME to choose the resolution. The string "*auto*" is also supported, and is equivalent to *0x0@0*. In window mode, this resolution is used as a maximum size for the window. This option requires the **-switchres** option as well in order to actually enable resolution switching with **-video d3d**. The default value for these options is '*auto*'.
+|
+|	The **-resolution0**, **-resolution1**, **-resolution2**, **-resolution3** parameters apply to the specific window. The -resolution parameter applies to all windows. The window-specific options override values from the all window option.
+|
+|
+
+
+.. _mame-commandline-view:
+
+| **-view** *<viewname>*
+| **-view0** *<viewname>*
+| **-view1** *<viewname>*
+| **-view2** *<viewname>*
+| **-view3** *<viewname>*
+|
+|	Specifies the initial view setting for each window. The *<viewname>* does not need to be a perfect match; rather, it will select the first view whose name matches all the characters specified by *<viewname>*. For example, **-view native** will match the "*Native (15:14)*" view even though it is not a perfect match. The value '*auto*' is also supported, and requests that MAME perform a default selection. The default value for these options is '*auto*'.
+|
+|	The **-view0**, **-view1**, **-view2**, **-view3** parameters apply to the specific window. The **-view** parameter applies to all windows. The window-specific options override values from the all window option.
 |
 |
 
@@ -785,6 +967,18 @@ Core Sound Options
 **-volume** / **-vol** *<value>*
 
 	Sets the startup volume. It can later be changed with the user interface (see Keys section). The volume is an attenuation in dB: e.g., "**-volume -12**" will start with -12dB attenuation. The default is *0*.
+
+.. _mame-commandline-sound:
+
+**-sound** *<dsound|sdl|none>*
+
+	Specifies which sound subsystem to use. '*none*' disables sound altogether. The default is *dsound* on Windows and *sdl* on all other platforms..
+
+.. _mame-commandline-audiolatency:
+
+**-audio_latency** *<value>*
+
+	This controls the amount of latency built into the audio streaming. By default MAME tries to keep the DirectSound audio buffer between 1/5 and 2/5 full. On some systems, this is pushing it too close to the edge, and you get poor sound sometimes. The latency parameter controls the lower threshold. The default is *1* (meaning lower=1/5 and upper=2/5). Set it to 2 (**-audio_latency 2**) to keep the sound buffer between 2/5 and 3/5 full. If you crank it up to 4, you can *definitely* notice audio lag.
 
 
 
@@ -977,7 +1171,7 @@ Debugging Options
 
 **-[no]log**
 
-	Creates a file called error.log which contains all of the internal log messages generated by the MAME core and game drivers. The default is OFF (*-nolog*).
+	Creates a file called error.log which contains all of the internal log messages generated by the MAME core and game drivers. This can be used at the same time as -log to output the log data to both targets as well. The default is OFF (*-nolog*).
 
 .. _mame-commandline-debug:
 
@@ -996,6 +1190,12 @@ Debugging Options
 **-[no]update_in_pause**
 
 	Enables updating of the main screen bitmap while the game is paused. This means that the VIDEO_UPDATE callback will be called repeatedly during pause, which can be useful for debugging. The default is OFF (*-noupdate_in_pause*).
+
+.. _mame-commandline-watchdog:
+
+**-watchdog** *<duration>* / **-wdog** *<duration>*
+
+	Enables an internal watchdog timer that will automatically kill the MAME process if more than *<duration>* seconds passes without a frame update. Keep in mind that some games sit for a while during load time without updating the screen, so *<duration>* should be long enough to cover that. 10-30 seconds on a modern system should be plenty in general. By default there is no watchdog.
 
 
 Core Communication Options

--- a/docs/source/commandline/commandline-all.rst
+++ b/docs/source/commandline/commandline-all.rst
@@ -6,7 +6,7 @@ Universal Commandline Options
 
 This section contains configuration options that are applicable to *all* MAME sub-builds (both SDL and Windows native).
 
-Core commands
+Core Commands
 -------------
 
 .. _mame-commandline-help:
@@ -25,7 +25,7 @@ Core commands
 
 
 
-Configuration commands
+Configuration Commands
 ----------------------
 
 .. _mame-commandline-createconfig:
@@ -57,7 +57,7 @@ Configuration commands
 
 
 
-Frontend commands
+Frontend Commands
 -----------------
 
 Note: By default, all the '**-list**' commands below write info to the screen. If you wish to write the info to a textfile instead, add this to the end of your command:
@@ -185,7 +185,7 @@ Note: By default, all the '**-list**' commands below write info to the screen. I
 
 .. _osd-commandline-options:
 
-OSD related options
+OSD-related Options
 -------------------
 
 .. _mame-commandline-uimodekey:
@@ -254,12 +254,16 @@ OSD related options
 
 
 
-OSD CLI options
+OSD CLI Options
 ---------------
+
+.. _mame-commandline-listmidi:
 
 **\-listmidi**
 
     Create a list of available MIDI I/O devices for use with emulation.
+
+.. _mame-commandline-listnetwork:
 
 **\-listnetwork**
 
@@ -267,8 +271,10 @@ OSD CLI options
 
 
 
-OSD output options
+OSD Output Options
 ------------------
+
+.. _mame-commandline-output:
 
 **\-output**
 
@@ -280,8 +286,10 @@ OSD output options
 
 
 
-Configuration options
+Configuration Options
 ---------------------
+
+.. _mame-commandline-noreadconfig:
 
 **-[no]readconfig** / **-[no]rc**
 
@@ -308,48 +316,70 @@ Configuration options
 
 
 
-Core search path options
+Core Search Path Options
 ------------------------
+
+.. _mame-commandline-rompath:
 
 **-rompath** / **-rp** *<path>*
 
 	Specifies a list of paths within which to find ROM or hard disk images. Multiple paths can be specified by separating them with semicolons. The default is 'roms' (that is, a directory "roms" in the same directory as the MAME executable).
 
+.. _mame-commandline-hashpath:
+
 **-hashpath** *<path>*
 
 	Specifies a list of paths within which to find Software List HASH files. Multiple paths can be specified by separating them with semicolons. The default is 'hash' (that is, a directory "roms" in the same directory as the MAME executable).
+
+.. _mame-commandline-samplepath:
 
 **-samplepath** / **-sp** *<path>*
 
 	Specifies a list of paths within which to find sample files. Multiple paths can be specified by separating them with semicolons. The default is 'samples' (that is, a directory "samples" in the same directory as the MAME executable).
 
+.. _mame-commandline-artpath:
+
 **-artpath** *<path>* / **-artwork_directory** *<path>*
 
 	Specifies a list of paths within which to find artwork files. Multiple paths can be specified by separating them with semicolons. The default is 'artwork' (that is, a directory "artwork" in the same directory as the MAME executable).
+
+.. _mame-commandline-ctrlrpath:
 
 **-ctrlrpath** / **-ctrlr_directory** *<path>*
 
 	Specifies a list of paths within which to find controller-specific configuration files. Multiple paths can be specified by separating them with semicolons. The default is 'ctrlr' (that is, a directory "ctrlr" in the same directory as the MAME executable).
 
+.. _mame-commandline-inipath:
+
 **-inipath** *<path>*
 
 	Specifies a list of paths within which to find .INI files. Multiple paths can be specified by separating them with semicolons. The default is '.;ini' (that is, search in the current directory first, and then in the directory "ini" in the same directory as the MAME executable).
+
+.. _mame-commandline-fontpath:
 
 **-fontpath** *<path>*
 
 	Specifies a list of paths within which to find .BDF font files. Multiple paths can be specified by separating them with semicolons. The default is '.' (that is, search in the same directory as the MAME executable).
 
+.. _mame-commandline-cheatpath:
+
 **-cheatpath** *<path>*
 
     Specifies a list of paths within which to find .XML cheat files. Multiple paths can be specified by separating them with semicolons. The default is 'cheat' (that is, a folder called 'cheat' located in the same directory as the as the MAME executable).
+
+.. _mame-commandline-crosshairpath:
 
 **-crosshairpath** *<path>*
 
 	Specifies a list of paths within which to find crosshair files. Multiple paths can be specified by separating them with semicolons. The default is 'crsshair' (that is, a directory "crsshair" in the same directory as the MAME executable).  If the Crosshair is set to default in the menu, MAME will look for gamename\\cross#.png and then cross#.png in the specified crsshairpath, where # is the player number.  Failing that, MAME will use built-in default crosshairs.
 
+.. _mame-commandline-pluginspath:
+
 **-pluginspath** *<path>*
 
 	Specifies a list of paths within which to find Lua plugins for MAME.
+
+.. _mame-commandline-languagepath:
 
 **-languagepath** *<path>*
 
@@ -390,7 +420,7 @@ Core Output Directory Options
 
 
 
-Core state/playback options
+Core State/Playback Options
 ---------------------------
 
 **-[no]rewind**
@@ -485,7 +515,7 @@ Core state/playback options
 
 
 
-Core performance options
+Core Performance Options
 ------------------------
 
 **-[no]autoframeskip** / **-[no]afs**
@@ -518,7 +548,7 @@ Core performance options
 
 
 
-Core rotation options
+Core Rotation Options
 ---------------------
 
 | **-[no]rotate**
@@ -555,7 +585,7 @@ Core rotation options
 |
 
 
-Core artwork options
+Core Artwork Options
 --------------------
 
 **-[no]artwork_crop** / **-[no]artcrop**
@@ -584,7 +614,7 @@ Core artwork options
 
 
 
-Core screen options
+Core Screen Options
 -------------------
 
 **-brightness** *<value>*
@@ -609,7 +639,7 @@ Core screen options
 
 
 
-Core vector options
+Core Vector Options
 -------------------
 
 **-[no]antialias** / **-[no]aa**
@@ -626,7 +656,7 @@ Core vector options
 
 
 
-Core sound options
+Core Sound Options
 ------------------
 
 **-samplerate** *<value>* / **-sr** *<value>*
@@ -643,7 +673,7 @@ Core sound options
 
 
 
-Core input options
+Core Input Options
 ------------------
 
 **-[no]coin_lockout** / **-[no]coinlock**
@@ -710,7 +740,7 @@ Core input options
  | 777888999.777888999.777888999.444555666.444555666.444555666.111222333.111222333.111222333 |
  +-------------------------------------------------------------------------------------------+
  
-	However, this can be reduced using several shorthands supported by the <map> parameter. If information about a row is missing, then it is assumed that any missing data in columns 5-9 are left/right symmetric with data in columns 0-4; and any missing data in colums 0-4 is assumed to be copies of the previous data. The same logic applies to missing rows, except that up/down symmetry is assumed.
+	However, this can be reduced using several shorthands supported by the <map> parameter. If information about a row is missing, then it is assumed that any missing data in columns 5-9 are left/right symmetric with data in columns 0-4; and any missing data in columns 0-4 is assumed to be copies of the previous data. The same logic applies to missing rows, except that up/down symmetry is assumed.
 
 	By using these shorthands, the 81 character map can be simply specified by this 11 character string: 7778...4445
 
@@ -742,7 +772,7 @@ Core input options
 
 
 
-Core input automatic enable options
+Core Input Automatic Enable Options
 -----------------------------------
 
 **\-paddle_device**       enable (none|keyboard|mouse|lightgun|joystick) if a paddle control is present
@@ -765,7 +795,7 @@ Core input automatic enable options
 
 
 
-Debugging options
+Debugging Options
 -----------------
 
 **-[no]verbose** / **-[no]v**
@@ -793,7 +823,7 @@ Debugging options
 	Enables updating of the main screen bitmap while the game is paused. This means that the VIDEO_UPDATE callback will be called repeatedly during pause, which can be useful for debugging. The default is OFF (*-noupdate_in_pause*).
 
 
-Core communication options
+Core Communication Options
 --------------------------
 
 **-comm_localhost** *<string>*
@@ -814,7 +844,7 @@ Core communication options
 
 
 
-Core misc options
+Core Misc Options
 -----------------
 
 **-[no]drc**

--- a/docs/source/commandline/commandline-index.rst
+++ b/docs/source/commandline/commandline-index.rst
@@ -10,11 +10,13 @@ Universal Commandline Options
 
 This section contains configuration options that are applicable to *all* MAME sub-builds (both SDL and Windows native).
 
+
 Core Commands
 ~~~~~~~~~~~~~
 
 | :ref:`help <mame-commandline-help>`
 | :ref:`validate <mame-commandline-validate>`
+
 
 Configuration Commands
 ~~~~~~~~~~~~~~~~~~~~~~
@@ -22,6 +24,7 @@ Configuration Commands
 | :ref:`createconfig <mame-commandline-createconfig>`
 | :ref:`showconfig <mame-commandline-showconfig>`
 | :ref:`showusage <mame-commandline-showusage>`
+
 
 Frontend Commands
 ~~~~~~~~~~~~~~~~~
@@ -45,6 +48,7 @@ Frontend Commands
 | :ref:`getsoftlist <mame-commandline-getsoftlist>`
 | :ref:`verifysoftlist <mame-commandline-verifysoftlist>`
 
+
 OSD-related Options
 ~~~~~~~~~~~~~~~~~~~
 
@@ -56,21 +60,25 @@ OSD-related Options
 | :ref:`lightgunprovider <mame-commandline-lightgunprovider>`
 | :ref:`joystickprovider <mame-commandline-joystickprovider>`
 
+
 OSD CLI Options
 ~~~~~~~~~~~~~~~
 
 | :ref:`listmidi <mame-commandline-listmidi>`
 | :ref:`listnetwork <mame-commandline-listnetwork>`
 
+
 OSD Output Options
 ~~~~~~~~~~~~~~~~~~
 
 | :ref:`output <mame-commandline-output>`
 
+
 Configuration Options
 ~~~~~~~~~~~~~~~~~~~~~
 
 | :ref:`noreadconfig <mame-commandline-noreadconfig>`
+
 
 Core Search Path Options
 ~~~~~~~~~~~~~~~~~~~~~~~~
@@ -87,6 +95,7 @@ Core Search Path Options
 | :ref:`pluginspath <mame-commandline-pluginspath>`
 | :ref:`languagepath <mame-commandline-languagepath>`
 
+
 Core Output Directory Options
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
@@ -97,6 +106,7 @@ Core Output Directory Options
 | :ref:`snapshot_directory <mame-commandline-snapshotdirectory>`
 | :ref:`diff_directory <mame-commandline-diffdirectory>`
 | :ref:`comment_directory <mame-commandline-commentdirectory>`
+
 
 Core State/Playback Options
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -119,6 +129,7 @@ Core State/Playback Options
 | :ref:`statename <mame-commandline-statename>`
 | :ref:`[no]burnin <mame-commandline-noburnin>`
 
+
 Core Performance Options
 ~~~~~~~~~~~~~~~~~~~~~~~~
 
@@ -129,6 +140,9 @@ Core Performance Options
 | :ref:`[no]sleep <mame-commandline-nosleep>`
 | :ref:`speed <mame-commandline-speed>`
 | :ref:`[no]refreshspeed <mame-commandline-norefreshspeed>`
+| :ref:`numprocessors <mame-commandline-numprocessors>`
+| :ref:`bench <mame-commandline-bench>`
+
 
 Core Rotation Options
 ~~~~~~~~~~~~~~~~~~~~~
@@ -141,6 +155,37 @@ Core Rotation Options
 | :ref:`[no]flipx <mame-commandline-noflipx>`
 | :ref:`[no]flipy <mame-commandline-noflipy>`
 
+
+Core Video Options
+~~~~~~~~~~~~~~~~~~
+
+| :ref:`video <mame-commandline-video>`
+| :ref:`numscreens <mame-commandline-numscreens>`
+| :ref:`[no]window <mame-commandline-window>`
+| :ref:`[no]maximize <mame-commandline-maximize>`
+| :ref:`[no]keepaspect <mame-commandline-keepaspect>`
+| :ref:`[no]waitvsync <mame-commandline-waitvsync>`
+| :ref:`[no]syncrefresh <mame-commandline-syncrefresh>`
+| :ref:`prescale <mame-commandline-prescale>`
+| :ref:`[no]filter <mame-commandline-filter>`
+| :ref:`[no]unevenstretch <mame-commandline-unevenstretch>`
+
+
+Core Full Screen Options
+~~~~~~~~~~~~~~~~~~~~~~~~
+
+| :ref:`[no]switchres <mame-commandline-switchres>`
+
+
+Core Per-Window Video Options
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+| :ref:`screen <mame-commandline-screen>`
+| :ref:`aspect <mame-commandline-aspect>`
+| :ref:`resolution <mame-commandline-resolution>`
+| :ref:`view <mame-commandline-view>`
+
+
 Core Artwork Options
 ~~~~~~~~~~~~~~~~~~~~
 
@@ -151,6 +196,7 @@ Core Artwork Options
 | :ref:`[no]use_cpanels <mame-commandline-nousecpanels>`
 | :ref:`[no]use_marquees <mame-commandline-nousemarquees>`
 
+
 Core Screen Options
 ~~~~~~~~~~~~~~~~~~~
 
@@ -160,6 +206,7 @@ Core Screen Options
 | :ref:`pause_brightness <mame-commandline-pausebrightness>`
 | :ref:`effect <mame-commandline-effect>`
 
+
 Core Vector Options
 ~~~~~~~~~~~~~~~~~~~
 
@@ -167,12 +214,17 @@ Core Vector Options
 | :ref:`beam <mame-commandline-beam>`
 | :ref:`flicker <mame-commandline-flicker>`
 
+
 Core Sound Options
 ~~~~~~~~~~~~~~~~~~
+
 
 | :ref:`samplerate <mame-commandline-samplerate>`
 | :ref:`[no]samples <mame-commandline-nosamples>`
 | :ref:`volume <mame-commandline-volume>`
+| :ref:`sound <mame-commandline-sound>`
+| :ref:`audio_latency <mame-commandline-audiolatency>`
+
 
 Core Input Options
 ~~~~~~~~~~~~~~~~~~
@@ -217,6 +269,7 @@ Core Debugging Options
 | :ref:`[no]debug <mame-commandline-debug>`
 | :ref:`debugscript <mame-commandline-debugscript>`
 | :ref:`[no]update_in_pause <mame-commandline-updateinpause>`
+| :ref:`watchdog <mame-commandline-watchdog>`
 
 
 Core Communication Options
@@ -247,4 +300,101 @@ Core Misc Options
 | :ref:`autoboot_script <mame-commandline-autobootscript>`
 | :ref:`language <mame-commandline-language>`
 
+
+Windows-Specific Commandline Options
+------------------------------------
+
+Windows Debugging options
+~~~~~~~~~~~~~~~~~~~~~~~~~
+
+| :ref:`debugger_font <mame-wcommandline-debuggerfont>`
+| :ref:`debugger_font_size <mame-wcommandline-debuggerfontsize>`
+
+
+Windows Performance Options
+~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+| :ref:`priority <mame-wcommandline-priority>`
+| :ref:`profile <mame-wcommandline-profile>`
+
+
+Windows Full Screen Options
+~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+| :ref:`[no]triplebuffer <mame-wcommandline-triplebuffer>`
+| :ref:`full_screen_brightness <mame-wcommandline-fullscreenbrightness>`
+| :ref:`full_screen_contrast <mame-wcommandline-fullscreencontrast>`
+| :ref:`full_screen_gamma <mame-wcommandline-fullscreengamma>`
+
+
+Windows Input Device Options
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+| :ref:`[no]dual_lightgun <mame-wcommandline-duallightgun>`
+
+
+SDL-Specific Commandline Options
+--------------------------------
+
+This section contains configuration options that are specific to any build supported by SDL (including Windows where compiled as SDL instead of native).
+
+
+SDL Performance Options
+~~~~~~~~~~~~~~~~~~~~~~~
+
+| :ref:`sdlvideofps <mame-scommandline-sdlvideofps>`
+
+
+SDL Video Options
+~~~~~~~~~~~~~~~~~
+
+| :ref:`[no]centerh <mame-scommandline-centerh>`
+| :ref:`[no]centerv <mame-scommandline-centerv>`
+
+
+SDL Video Soft-Specific Options
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+| :ref:`scalemode <mame-scommandline-scalemode>`
+
+
+SDL Video OpenGL Debugging Options
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+| :ref:`[no]gl_forcepow2texture <mame-scommandline-glforcepow2texture>`
+| :ref:`[no]gl_notexturerect <mame-scommandline-glnotexturerect>`
+| :ref:`[no]gl_vbo <mame-scommandline-glvbo>`
+| :ref:`[no]gl_pbo <mame-scommandline-glpbo>`
+
+
+SDL Video OpenGL GLSL Options
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+| :ref:`gl_glsl <mame-scommandline-glglsl>`
+| :ref:`gl_glsl_filter <mame-scommandline-glglslfilter>`
+| :ref:`glsl_shader_mame[0-9] <mame-scommandline-glslshadermame>`
+| :ref:`glsl_shader_screen[0-9] <mame-scommandline-glslshaderscreen>`
+| :ref:`gl_glsl_vid_attr <mame-scommandline-glglslvidattr>`
+
+
+SDL Keyboard Mapping
+~~~~~~~~~~~~~~~~~~~~
+
+| :ref:`keymap <mame-scommandline-keymap>`
+| :ref:`keymap_file <mame-scommandline-keymapfile>`
+
+
+SDL Joystick Mapping
+~~~~~~~~~~~~~~~~~~~~
+
+| :ref:`joyidx <mame-scommandline-joyidx>`
+| :ref:`sixaxis <mame-scommandline-sixaxis>`
+
+
+SDL Low-level Driver Options
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+| :ref:`videodriver <mame-scommandline-videodriver>`
+| :ref:`audiodriver <mame-scommandline-audiodriver>`
+| :ref:`gl_lib <mame-scommandline-gllib>`
 

--- a/docs/source/commandline/commandline-index.rst
+++ b/docs/source/commandline/commandline-index.rst
@@ -90,3 +90,20 @@ Core Search Path Options
 Core Output Directory Options
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
+| :ref:`cfg_directory <mame-commandline-cfgdirectory>`
+| :ref:`nvram_directory <mame-commandline-nvramdirectory>`
+| :ref:`input_directory <mame-commandline-inputdirectory>`
+| :ref:`state_directory <mame-commandline-statedirectory>`
+| :ref:`snapshot_directory <mame-commandline-snapshotdirectory>`
+| :ref:`diff_directory <mame-commandline-diffdirectory>`
+| :ref:`comment_directory <mame-commandline-commentdirectory>`
+
+Core State/Playback Options
+~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+
+
+
+
+
+

--- a/docs/source/commandline/commandline-index.rst
+++ b/docs/source/commandline/commandline-index.rst
@@ -151,3 +151,100 @@ Core Artwork Options
 | :ref:`[no]use_cpanels <mame-commandline-nousecpanels>`
 | :ref:`[no]use_marquees <mame-commandline-nousemarquees>`
 
+Core Screen Options
+~~~~~~~~~~~~~~~~~~~
+
+| :ref:`brightness <mame-commandline-brightness>`
+| :ref:`contrast <mame-commandline-contrast>`
+| :ref:`gamma <mame-commandline-gamma>`
+| :ref:`pause_brightness <mame-commandline-pausebrightness>`
+| :ref:`effect <mame-commandline-effect>`
+
+Core Vector Options
+~~~~~~~~~~~~~~~~~~~
+
+| :ref:`[no]antialias <mame-commandline-noantialias>`
+| :ref:`beam <mame-commandline-beam>`
+| :ref:`flicker <mame-commandline-flicker>`
+
+Core Sound Options
+~~~~~~~~~~~~~~~~~~
+
+| :ref:`samplerate <mame-commandline-samplerate>`
+| :ref:`[no]samples <mame-commandline-nosamples>`
+| :ref:`volume <mame-commandline-volume>`
+
+Core Input Options
+~~~~~~~~~~~~~~~~~~
+
+| :ref:`[no]coin_lockout <mame-commandline-nocoinlockout>`
+| :ref:`ctrlr <mame-commandline-ctrlr>`
+| :ref:`[no]mouse <mame-commandline-nomouse>`
+| :ref:`[no]joystick <mame-commandline-nojoystick>`
+| :ref:`[no]lightgun <mame-commandline-nolightgun>`
+| :ref:`[no]multikeyboard <mame-commandline-nomultikeyboard>`
+| :ref:`[no]multimouse <mame-commandline-nomultimouse>`
+| :ref:`[no]steadykey <mame-commandline-nosteadykey>`
+| :ref:`[no]ui_active <mame-commandline-uiactive>`
+| :ref:`[no]offscreen_reload <mame-commandline-nooffscreenreload>`
+| :ref:`joystick_map <mame-commandline-joystickmap>`
+| :ref:`joystick_deadzone <mame-commandline-joystickdeadzone>`
+| :ref:`joystick_saturation <mame-commandline-joysticksaturation>`
+| :ref:`natural <mame-commandline-natural>`
+| :ref:`joystick_contradictory <mame-commandline-joystickcontradictory>`
+| :ref:`coin_impulse <mame-commandline-coinimpulse>`
+
+
+Core Input Automatic Enable Options
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+| :ref:`paddle_device <mame-commandline-paddledevice>`
+| :ref:`adstick_device <mame-commandline-adstickdevice>`
+| :ref:`pedal_device <mame-commandline-pedaldevice>`
+| :ref:`dial_device <mame-commandline-dialdevice>`
+| :ref:`trackball_device <mame-commandline-trackballdevice>`
+| :ref:`lightgun_device <mame-commandline-lightgundevice>`
+| :ref:`positional_device <mame-commandline-positionaldevice>`
+| :ref:`mouse_device <mame-commandline-mousedevice>`
+
+
+Core Debugging Options
+~~~~~~~~~~~~~~~~~~~~~~
+
+| :ref:`[no]verbose <mame-commandline-verbose>`
+| :ref:`[no]oslog <mame-commandline-oslog>`
+| :ref:`[no]log <mame-commandline-log>`
+| :ref:`[no]debug <mame-commandline-debug>`
+| :ref:`debugscript <mame-commandline-debugscript>`
+| :ref:`[no]update_in_pause <mame-commandline-updateinpause>`
+
+
+Core Communication Options
+~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+| :ref:`comm_localhost <mame-commandline-commlocalhost>`
+| :ref:`comm_localport <mame-commandline-commlocalport>`
+| :ref:`comm_remotehost <mame-commandline-commremotehost>`
+| :ref:`comm_remoteport <mame-commandline-commremoteport>`
+
+
+Core Misc Options
+~~~~~~~~~~~~~~~~~
+
+| :ref:`[no]drc <mame-commandline-drc>`
+| :ref:`drc_use_c <mame-commandline-drcusec>`
+| :ref:`drc_log_uml <mame-commandline-drcloguml>`
+| :ref:`drc_log_native <mame-commandline-drclognative>`
+| :ref:`bios <mame-commandline-bios>`
+| :ref:`[no]cheat <mame-commandline-cheat>`
+| :ref:`[no]skip_gameinfo <mame-commandline-skipgameinfo>`
+| :ref:`uifont <mame-commandline-uifont>`
+| :ref:`ramsize <mame-commandline-ramsize>`
+| :ref:`confirm_quit <mame-commandline-confirmquit>`
+| :ref:`ui_mouse <mame-commandline-uimouse>`
+| :ref:`autoboot_command <mame-commandline-autobootcommand>`
+| :ref:`autoboot_delay <mame-commandline-autobootdelay>`
+| :ref:`autoboot_script <mame-commandline-autobootscript>`
+| :ref:`language <mame-commandline-language>`
+
+

--- a/docs/source/commandline/commandline-index.rst
+++ b/docs/source/commandline/commandline-index.rst
@@ -101,9 +101,53 @@ Core Output Directory Options
 Core State/Playback Options
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
+| :ref:`[no]rewind / rewind<mame-commandline-norewind>`
+| :ref:`rewind_capacity <mame-commandline-rewindcapacity>`
+| :ref:`state <mame-commandline-state>`
+| :ref:`[no]autosave <mame-commandline-noautosave>`
+| :ref:`playback <mame-commandline-playback>`
+| :ref:`exit_after_playback <mame-commandline-exitafterplayback>`
+| :ref:`record <mame-commandline-record>`
+| :ref:`record_timecode <mame-commandline-recordtimecode>`
+| :ref:`mngwrite <mame-commandline-mngwrite>`
+| :ref:`aviwrite <mame-commandline-aviwrite>`
+| :ref:`wavwrite <mame-commandline-wavwrite>`
+| :ref:`snapname <mame-commandline-snapname>`
+| :ref:`snapsize <mame-commandline-snapsize>`
+| :ref:`snapview <mame-commandline-snapview>`
+| :ref:`[no]snapbilinear <mame-commandline-nosnapbilinear>`
+| :ref:`statename <mame-commandline-statename>`
+| :ref:`[no]burnin <mame-commandline-noburnin>`
 
+Core Performance Options
+~~~~~~~~~~~~~~~~~~~~~~~~
 
+| :ref:`[no]autoframeskip <mame-commandline-noautoframeskip>`
+| :ref:`frameskip <mame-commandline-frameskip>`
+| :ref:`seconds_to_run <mame-commandline-secondstorun>`
+| :ref:`[no]throttle <mame-commandline-nothrottle>`
+| :ref:`[no]sleep <mame-commandline-nosleep>`
+| :ref:`speed <mame-commandline-speed>`
+| :ref:`[no]refreshspeed <mame-commandline-norefreshspeed>`
 
+Core Rotation Options
+~~~~~~~~~~~~~~~~~~~~~
 
+| :ref:`[no]rotate <mame-commandline-norotate>`
+| :ref:`[no]ror <mame-commandline-noror>`
+| :ref:`[no]rol <mame-commandline-norol>`
+| :ref:`[no]autoror <mame-commandline-noautoror>`
+| :ref:`[no]autorol <mame-commandline-noautorol>`
+| :ref:`[no]flipx <mame-commandline-noflipx>`
+| :ref:`[no]flipy <mame-commandline-noflipy>`
 
+Core Artwork Options
+~~~~~~~~~~~~~~~~~~~~
+
+| :ref:`[no]artwork_crop <mame-commandline-noartworkcrop>`
+| :ref:`[no]use_backdrops <mame-commandline-nousebackdrops>`
+| :ref:`[no]use_overlays <mame-commandline-nouseoverlays>`
+| :ref:`[no]use_bezels <mame-commandline-nousebezels>`
+| :ref:`[no]use_cpanels <mame-commandline-nousecpanels>`
+| :ref:`[no]use_marquees <mame-commandline-nousemarquees>`
 

--- a/docs/source/commandline/commandline-index.rst
+++ b/docs/source/commandline/commandline-index.rst
@@ -1,0 +1,73 @@
+.. _index-commandline:
+
+Commandline Index
+=================
+
+This is a complete index of all commandline options and commands for MAME, suitable for quickly finding a given command.
+
+Universal Commandline Options
+-----------------------------
+
+This section contains configuration options that are applicable to *all* MAME sub-builds (both SDL and Windows native).
+
+Core commands
+~~~~~~~~~~~~~
+
+| :ref:`help <mame-commandline-help>`
+| :ref:`validate <mame-commandline-validate>`
+
+Configuration commands
+~~~~~~~~~~~~~~~~~~~~~~
+
+| :ref:`createconfig <mame-commandline-createconfig>`
+| :ref:`showconfig <mame-commandline-showconfig>`
+| :ref:`showusage <mame-commandline-showusage>`
+
+Frontend commands
+~~~~~~~~~~~~~~~~~
+
+| :ref:`listxml <mame-commandline-listxml>`
+| :ref:`listfull <mame-commandline-listfull>`
+| :ref:`listsource <mame-commandline-listsource>`
+| :ref:`listclones <mame-commandline-listclones>`
+| :ref:`listbrothers <mame-commandline-listbrothers>`
+| :ref:`listcrc <mame-commandline-listcrc>`
+| :ref:`listroms <mame-commandline-listroms>`
+| :ref:`listsamples <mame-commandline-listsamples>`
+| :ref:`verifyroms <mame-commandline-verifyroms>`
+| :ref:`verifysamples <mame-commandline-verifysamples>`
+| :ref:`romident <mame-commandline-romident>`
+| :ref:`listdevices <mame-commandline-listdevices>`
+| :ref:`listslots <mame-commandline-listslots>`
+| :ref:`listmedia <mame-commandline-listmedia>`
+| :ref:`listsoftware <mame-commandline-listsoftware>`
+| :ref:`verifysoftware <mame-commandline-verifysoftware>`
+| :ref:`getsoftlist <mame-commandline-getsoftlist>`
+| :ref:`verifysoftlist <mame-commandline-verifysoftlist>`
+
+OSD-related options
+~~~~~~~~~~~~~~~~~~~
+
+| :ref:`uimodekey <mame-commandline-uimodekey>`
+| :ref:`uifontprovider <mame-commandline-uifontprovider>`
+| :ref:`menu <mame-commandline-menu>`
+| :ref:`keyboardprovider <mame-commandline-keyboardprovider>`
+| :ref:`mouseprovider <mame-commandline-mouseprovider>`
+| :ref:`lightgunprovider <mame-commandline-lightgunprovider>`
+| :ref:`joystickprovider <mame-commandline-joystickprovider>`
+
+OSD CLI options
+~~~~~~~~~~~~~~~
+
+| :ref:`listxml <mame-commandline->`
+
+
+
+
+
+
+
+
+
+
+

--- a/docs/source/commandline/commandline-index.rst
+++ b/docs/source/commandline/commandline-index.rst
@@ -10,20 +10,20 @@ Universal Commandline Options
 
 This section contains configuration options that are applicable to *all* MAME sub-builds (both SDL and Windows native).
 
-Core commands
+Core Commands
 ~~~~~~~~~~~~~
 
 | :ref:`help <mame-commandline-help>`
 | :ref:`validate <mame-commandline-validate>`
 
-Configuration commands
+Configuration Commands
 ~~~~~~~~~~~~~~~~~~~~~~
 
 | :ref:`createconfig <mame-commandline-createconfig>`
 | :ref:`showconfig <mame-commandline-showconfig>`
 | :ref:`showusage <mame-commandline-showusage>`
 
-Frontend commands
+Frontend Commands
 ~~~~~~~~~~~~~~~~~
 
 | :ref:`listxml <mame-commandline-listxml>`
@@ -45,7 +45,7 @@ Frontend commands
 | :ref:`getsoftlist <mame-commandline-getsoftlist>`
 | :ref:`verifysoftlist <mame-commandline-verifysoftlist>`
 
-OSD-related options
+OSD-related Options
 ~~~~~~~~~~~~~~~~~~~
 
 | :ref:`uimodekey <mame-commandline-uimodekey>`
@@ -56,18 +56,37 @@ OSD-related options
 | :ref:`lightgunprovider <mame-commandline-lightgunprovider>`
 | :ref:`joystickprovider <mame-commandline-joystickprovider>`
 
-OSD CLI options
+OSD CLI Options
 ~~~~~~~~~~~~~~~
 
-| :ref:`listxml <mame-commandline->`
+| :ref:`listmidi <mame-commandline-listmidi>`
+| :ref:`listnetwork <mame-commandline-listnetwork>`
 
+OSD Output Options
+~~~~~~~~~~~~~~~~~~
 
+| :ref:`output <mame-commandline-output>`
 
+Configuration Options
+~~~~~~~~~~~~~~~~~~~~~
 
+| :ref:`noreadconfig <mame-commandline-noreadconfig>`
 
+Core Search Path Options
+~~~~~~~~~~~~~~~~~~~~~~~~
 
+| :ref:`rompath <mame-commandline-rompath>`
+| :ref:`hashpath <mame-commandline-hashpath>`
+| :ref:`samplepath <mame-commandline-samplepath>`
+| :ref:`artpath <mame-commandline-artpath>`
+| :ref:`ctrlrpath <mame-commandline-ctrlrpath>`
+| :ref:`inipath <mame-commandline-inipath>`
+| :ref:`fontpath <mame-commandline-fontpath>`
+| :ref:`cheatpath <mame-commandline-cheatpath>`
+| :ref:`crosshairpath <mame-commandline-crosshairpath>`
+| :ref:`pluginspath <mame-commandline-pluginspath>`
+| :ref:`languagepath <mame-commandline-languagepath>`
 
-
-
-
+Core Output Directory Options
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 

--- a/docs/source/commandline/index.rst
+++ b/docs/source/commandline/index.rst
@@ -7,3 +7,5 @@ MAME Commandline Usage and OS-Specific Configuration
 	commandline-all
 	windowsconfig
 	sdlconfig
+
+	commandline-index

--- a/docs/source/commandline/sdlconfig.rst
+++ b/docs/source/commandline/sdlconfig.rst
@@ -5,86 +5,37 @@ SDL-Specific Commandline Options
 This section contains configuration options that are specific to any build supported by SDL (including Windows where compiled as SDL instead of native).
 
 
-In addition to the keys described in config.txt, the following additional keys are defined for SDL-specific versions of MAME:
 
-
-
-Debugging options
------------------
-
-**-[no]oslog**
-
-	Outputs the error.log data to the stderr TTY channel (usually the command line window MAME was started in). This can be used at	the same time as *-log* to output the log data to both targets as well. Default is OFF (*-nooslog*).
-
-**-watchdog** *<duration>* / **-wdog** *<duration>*
-
-	Enables an internal watchdog timer that will automatically kill the MAME process if more than *<duration>* seconds passes without a frame update. Keep in mind that some games sit for a while during load time without updating the screen, so *<duration>* should be long enough to cover that. 10-30 seconds on a modern system should be plenty in general. By default there is no watchdog.
-
-
-
-Performance options
+Performance Options
 -------------------
 
-**-numprocessors** *<auto|value>* / **-np** *<auto|value>*
-
-	Specify the number of processors to use for work queues. Specifying	"*auto*" will use the value reported by the system or environment variable **OSDPROCESSORS**. To avoid abuse, this value is internally limited to 4 times the number of processors reported by the system. The default is "*auto*".
+.. _mame-scommandline-sdlvideofps:
 
 **-sdlvideofps**
 
 	Enable output of benchmark data on the SDL video subsystem, including your system's video driver, X server (if applicable), and OpenGL stack in **-video opengl** mode.
 
-**-bench** *[n]*
 
-	Benchmark for [n] number of emulated seconds; implies the command string: **-str [n] -video none -sound none -nothrottle**. Default is OFF (*-nobench*)
-
-
-
-Video options
+Video Options
 -------------
 
-**-video** *<soft|opengl|none>*
-
-	Specifies which video subsystem to use for drawing.  The default for Mac OS X is '*opengl*' because OS X is guaranteed to have a compliant OpenGL stack.  The default on all other systems is '*soft*'.
-
-**-numscreens** *<count>*
-
-	Tells MAME how many output windows to create. For most games, a single output window is all you need, but some games originally used multiple screens. Each screen (up to 4) has its own independent settings for physical monitor, aspect ratio, resolution, and view, which can be set using the options below. The default is 1. 
-
-**-[no]window** / **-[no]w**
-
-	Run MAME in either a window or full screen. The default is OFF (*-nowindow*).
-
-**-[no]maximize** / **-[no]max**
-
-	Controls initial window size in windowed mode. If it is set on, the window will initially be set to the maximum supported size when you start MAME. If it is turned off, the window will start out at the smallest supported size. This option only has an effect when the **-window** option is used. The default is ON (*-maximize*).
-
-**-[no]keepaspect** / **-[no]ka**
-
-	Enables aspect ratio enforcement. When this option is on, the game's proper aspect ratio (generally 4:3 or 3:4) is enforced, so you get the game looking like it should. When running in a window with this option on, you can only resize the window to the proper aspect ratio, unless you are holding down the CONTROL key. By turning the option off, the aspect ratio is allowed to float. In full screen mode, this means that all games will stretch to the full screen size (even vertical games). In window mode, it means that you can freely resize the window without any constraints. The default is ON (*-keepaspect*).
-
-**-[no]unevenstretch**
-
-	Allow non-integer stretch factors allowing for great window sizing flexability.  The default is ON. (*-unevenstretch*)
+.. _mame-scommandline-centerh:
 
 **-[no]centerh**
 
 	Center horizontally within the view area. Default is ON (*-centerh*).
 
+.. _mame-scommandline-centerv:
+
 **-[no]centerv**
 
 	Center vertically within the view area. Default is ON (*-centerv*).
 
-**-[no]waitvsync**
 
-	Waits for the refresh period on your computer's monitor to finish before starting to draw video to your screen. If this option is off, MAME will just draw to the screen at any old time, even in the middle of a refresh cycle. This can cause "tearing" artifacts, where the top portion of the screen is out of sync with the bottom portion. Tearing is not noticeable on all games, and some people hate it more than others. However, if you turn this option on, you will waste more of your CPU cycles waiting for the proper time to draw, so you will see a performance hit. You should only need to turn this on in windowed mode. In full screen mode, it is only needed if **-triplebuffer** does not remove the tearing, in which case you should use **-notriplebuffer -waitvsync.** Note that support for this option depends entirely on your operating system and video drivers; in general it will not work in windowed mode so **-video opengl** and fullscreen give the greatest chance of success. The default is OFF (*-nowaitvsync*).
-
-**-[no]syncrefresh**
-
-	Enables speed throttling only to the refresh of your monitor. This means that the game's actual refresh rate is ignored; however, the sound code still attempts to keep up with the game's original refresh rate, so you may encounter sound problems. This option is intended mainly for those who have tweaked their video card's settings to provide carefully matched refresh rate options. The default is OFF (*-nosyncrefresh*).
-
-
-Video soft-specific options
+Video Soft-Specific Options
 ---------------------------
+
+.. _mame-scommandline-scalemode:
 
 **-scalemode**
 
@@ -92,288 +43,144 @@ Video soft-specific options
 
 
 
-Video OpenGL-specific options
------------------------------
-
-**-[no]filter** / **-[no]flt**
-
-	Enable bilinear filtering on the game screen graphics. When disabled, point filtering is applied, which is crisper but leads to scaling artifacts. If you don't like the filtered look, you are probably better off increasing the **-prescale** value rather than turning off filtering altogether. The default is ON (*-filter*).
-
-**-prescale** *<amount>*
-
-	Controls the size of the screen images when they are passed off to the graphics system for scaling. At the minimum setting of 1, the screen is rendered at its original resolution before being scaled. At higher settings, the screen is expanded by a factor of *<amount>* before being scaled. This produces a less blurry image at the expense of some speed and also increases the effective resolution of non-screen elements such as artwork and fonts. The default is *1*.
-
-Video OpenGL debugging options
+Video OpenGL Debugging Options
 ------------------------------
 	
 These 4 options are for compatibility in **-video opengl**.  If you report rendering artifacts you may be asked to try messing with them by the devs, but normally they should be left at their defaults which results in the best possible video performance.	
+
+.. _mame-scommandline-glforcepow2texture:
 
 **-[no]gl_forcepow2texture**
 
 	Always use only power-of-2 sized textures (default *off*)
 	
+.. _mame-scommandline-glnotexturerect:
+
 **-[no]gl_notexturerect**
 
 	Don't use OpenGL GL_ARB_texture_rectangle (default *on*)
 
+.. _mame-scommandline-glvbo:
+
 **-[no]gl_vbo**
 
     Enable OpenGL VBO,  if available (default *on*)
+
+.. _mame-scommandline-glpbo:
 
 **-[no]gl_pbo**
 
     Enable OpenGL PBO,  if available (default *on*)
 
 
-Video OpenGL GLSL options
+Video OpenGL GLSL Options
 -------------------------
 	
+
+.. _mame-scommandline-glglsl:
 
 **-gl_glsl**
 
 	Enable OpenGL GLSL, if available (default *off*)
 
+.. _mame-scommandline-glglslfilter:
+
 **-gl_glsl_filter**
 
 	Enable OpenGL GLSL filtering instead of FF filtering -- *0-plain, 1-bilinear* (default is *1*)
 
-**-glsl_shader_mame0**
+.. _mame-scommandline-glslshadermame:
 
-	Custom OpenGL GLSL shader set MAME bitmap 0  [todo: better details on usage at some point. See http://forums.bannister.org/ubbthreads.php?ubb=showflat&Number=100988#Post100988 ]
+|
+| **-glsl_shader_mame0**
+| **-glsl_shader_mame1**
+| ...
+| **-glsl_shader_mame9**
+|
 
-**-glsl_shader_mame1**
+	Custom OpenGL GLSL shader set MAME bitmap in the provided slot (0-9); one can be applied to each slot.
 
-	Custom OpenGL GLSL shader set MAME bitmap 1
-
-**-glsl_shader_mame2**
-
-	Custom OpenGL GLSL shader set MAME bitmap 2
-
-**-glsl_shader_mame3**
-
-	Custom OpenGL GLSL shader set MAME bitmap 3
-
-**-glsl_shader_mame4**
-
-	Custom OpenGL GLSL shader set MAME bitmap 4
-
-**-glsl_shader_mame5**
-
-	Custom OpenGL GLSL shader set MAME bitmap 5
-
-**-glsl_shader_mame6**
-
-	Custom OpenGL GLSL shader set MAME bitmap 6
-
-**-glsl_shader_mame7**
-
-	Custom OpenGL GLSL shader set MAME bitmap 7
-
-**-glsl_shader_mame8**
-
-	Custom OpenGL GLSL shader set MAME bitmap 8
-
-**-glsl_shader_mame9**
-
-	Custom OpenGL GLSL shader set MAME bitmap 9
+	[todo: better details on usage at some point. See http://forums.bannister.org/ubbthreads.php?ubb=showflat&Number=100988#Post100988 ]
 
 
-**-glsl_shader_screen0**
 
-	Custom OpenGL GLSL shader screen bitmap 0
+.. _mame-scommandline-glslshaderscreen:
 
-**-glsl_shader_screen1**
+|
+| **-glsl_shader_screen0**
+| **-glsl_shader_screen1**
+| ...
+| **-glsl_shader_screen9**
+|
 
-	Custom OpenGL GLSL shader screen bitmap 1
+	Custom OpenGL GLSL shader screen bitmap in the provided slot (0-9).
 
-**-glsl_shader_screen2**
+	[todo: better details on usage at some point. See http://forums.bannister.org/ubbthreads.php?ubb=showflat&Number=100988#Post100988 ]
 
-	Custom OpenGL GLSL shader screen bitmap 2
 
-**-glsl_shader_screen3**
-
-	Custom OpenGL GLSL shader screen bitmap 3
-
-**-glsl_shader_screen4**
-
-	Custom OpenGL GLSL shader screen bitmap 4
-
-**-glsl_shader_screen5**
-
-	Custom OpenGL GLSL shader screen bitmap 5
-
-**-glsl_shader_screen6**
-
-	Custom OpenGL GLSL shader screen bitmap 6
-
-**-glsl_shader_screen7**
-
-	Custom OpenGL GLSL shader screen bitmap 7
-
-**-glsl_shader_screen8**
-
-	Custom OpenGL GLSL shader screen bitmap 8
-
-**-glsl_shader_screen9**
-
-	Custom OpenGL GLSL shader screen bitmap 9
+.. _mame-scommandline-glglslvidattr:
 
 **-gl_glsl_vid_attr**
 
 	Enable OpenGL GLSL handling of brightness and contrast. Better RGB game performance.  Default is *on*.
 
 
-
-Per-window options
-------------------
-
-NOTE:  **Multiple Screens may fail to work correctly on some Macintosh machines as of right now.**
-
-| **-screen** *<display>*
-| **-screen0** *<display>*
-| **-screen1** *<display>*
-| **-screen2** *<display>*
-| **-screen3** *<display>*
-|
-|	Specifies which physical monitor on your system you wish to have each window use by default. In order to use multiple windows, you must have increased the value of the **-numscreens** option. The name of each display in your system can be determined by running MAME with the -verbose option. The display names are typically in the format of a number from 1 to the number of connected monitors. The default value for these options is '*auto*', which means that the first window is placed on the first display, the second window on the second display, etc.
-|
-|	The **-screen0**, **-screen1**, **-screen2**, **-screen3** parameters apply to the specific window. The **-screen** parameter applies to all windows. The window-specific options override values from the all window option. 
-|
-|
-
-
-| **-aspect** *<width:height>* / **-screen_aspect** *<num:den>*
-| **-aspect0** *<width:height>*
-| **-aspect1** *<width:height>*
-| **-aspect2** *<width:height>*
-| **-aspect3** *<width:height>*
-|
-|
-|	Specifies the physical aspect ratio of the physical monitor for each window. In order to use multiple windows, you must have increased the value of the **-numscreens** option. The physical aspect ratio can be determined by measuring the width and height of the visible screen image and specifying them separated by a colon. The default value for these options is '*auto*', which means that MAME assumes the aspect ratio is proportional to the number of pixels in the desktop video mode for each monitor.
-|
-|	The **-aspect0**, **-aspect1**, **-aspect2**, **-aspect3** parameters apply to the specific window. The **-aspect** parameter applies to all windows. The window-specific options override values from the all window option.
-|
-|
-
-
-| **-resolution** *<widthxheight[@refresh]>* / **-r** *<widthxheight[@refresh]>*
-| **-resolution0** *<widthxheight[@refresh]>* / **-r0** *<widthxheight[@refresh]>*
-| **-resolution1** *<widthxheight[@refresh]>* / **-r1** *<widthxheight[@refresh]>*
-| **-resolution2** *<widthxheight[@refresh]>* / **-r2** *<widthxheight[@refresh]>*
-| **-resolution3** *<widthxheight[@refresh]>* / **-r3** *<widthxheight[@refresh]>*
-|
-|	Specifies an exact resolution to run in. In full screen mode, MAME will try to use the specific resolution you request. The width and height are required; the refresh rate is optional. If omitted or set to 0, MAME will determine the mode automatically. For example, **-resolution 640x480** will force 640x480 resolution, but MAME is free to choose the refresh rate. Similarly, **-resolution 0x0@60** will force a 60Hz refresh rate, but allows MAME to choose the resolution. The string "*auto*" is also supported, and is equivalent to *0x0@0*. In window mode, this resolution is used as a maximum size for the window. This option requires the **-switchres** option. The default value for these options is '*auto*'.
-|
-|	The **-resolution0**, **-resolution1**, **-resolution2**, **-resolution3** parameters apply to the specific window. The -resolution parameter applies to all windows. The window-specific options override values from the all window option.
-|
-|
-
-
-| **-view** *<viewname>*
-| **-view0** *<viewname>*
-| **-view1** *<viewname>*
-| **-view2** *<viewname>*
-| **-view3** *<viewname>*
-|
-|	Specifies the initial view setting for each window. The *<viewname>* does not need to be a perfect match; rather, it will select the first view whose name matches all the characters specified by *<viewname>*. For example, **-view native** will match the "*Native (15:14)*" view even though it is not a perfect match. The value '*auto*' is also supported, and requests that MAME perform a default selection. The default value for these options is '*auto*'.
-|
-|	The **-view0**, **-view1**, **-view2**, **-view3** parameters apply to the specific window. The **-view** parameter applies to all windows. The window-specific options override values from the all window option.
-|
-|
-
-
-
-Full screen options
--------------------
-
-**-[no]switchres**
-
-	Enables resolution switching. This option is required for the **-resolution\*** options to switch resolutions in full screen mode. On modern video cards, there is little reason to switch resolutions unless you are trying to achieve the "exact" pixel resolutions of the original games, which requires significant tweaking. This option is also useful on LCD displays, since they run with a fixed resolution and switching resolutions on them is just silly. The default is OFF (*-noswitchres*).
-
-
-Sound options
--------------
-
-**-sound** *<sdl|none>*
-
-	Specifies which sound subsystem to use. '*none*' disables sound altogether. The default is *sdl*.
-
-**-audio_latency** *<value>*
-
-	This controls the amount of latency built into the audio streaming. By default MAME tries to keep the audio buffer between 1/5 and 2/5 full. On some systems, this is pushing it too close to the edge, and you get poor sound sometimes. The latency parameter controls the lower threshold. The default is *1* (meaning lower=1/5 and upper=2/5). Set it to 2 (**-audio_latency 2**) to keep the sound buffer between 2/5 and 3/5 full. If you crank it up to 4, you can *definitely* notice audio lag.
-
-
 SDL Keyboard Mapping
 --------------------
+
+.. _mame-scommandline-keymap:
 
 **-keymap**
 
 	Enable keymap. Default is OFF (*-nokeymap*)
 
+.. _mame-scommandline-keymapfile:
+
 **-keymap_file** *<file>*
 	
 	Keymap Filename. Default is '*keymap.dat*'.
-
-**-uimodekey** *<key>*
-	
-	Key to toggle keyboard mode. Default is '*SCRLOCK*'
-
 
 
 SDL Joystick Mapping
 --------------------
 
-**-joy_idx1** *<name>*
+.. _mame-scommandline-joyidx:
 
-Name of joystick mapped to joystick #1, default is *auto*.
+|
+| **-joy_idx1** *<name>*
+| **-joy_idx2** *<name>*
+| ...
+| **-joy_idx8** *<name>*
+|
 
-**-joy_idx2** *<name>*
+Name of joystick mapped to a given joystick slot, default is *auto*.
 
-Name of joystick mapped to joystick #2, default is *auto*.
 
-**-joy_idx3** *<name>*
-
-Name of joystick mapped to joystick #3, default is *auto*.
-
-**-joy_idx4** *<name>*
-
-Name of joystick mapped to joystick #4, default is *auto*.
-
-**-joy_idx5** *<name>*
-
-Name of joystick mapped to joystick #5, default is *auto*.
-
-**-joy_idx6** *<name>*
-
-Name of joystick mapped to joystick #6, default is *auto*.
-
-**-joy_idx7** *<name>*
-
-Name of joystick mapped to joystick #7, default is *auto*.
-
-**-joy_idx8** *<name>*
-
-Name of joystick mapped to joystick #8, default is *auto*.
+.. _mame-scommandline-sixaxis:
 
 **-sixaxis**
 
-	Use special handling for PS3 Sixaxis controllers. Default is OFF (*-nosixaxis*)
+	Use special handling for PS3 SixAxis controllers. Default is OFF (*-nosixaxis*)
 
 
+SDL Low-level Driver Options
+~---------------------------
 
-SDL Lowlevel driver options
----------------------------
+.. _mame-scommandline-videodriver:
 
 **-videodriver** *<driver>*
 
 	SDL video driver to use ('x11', 'directfb', ... or '*auto*' for SDL default)
 
+.. _mame-scommandline-audiodriver:
+
 **-audiodriver** *<driver>*
 
 	SDL audio driver to use ('alsa', 'arts', ... or '*auto*' for SDL default)
 
+.. _mame-scommandline-gllib:
+
 **-gl_lib** *<driver>*
 
 	Alternative **libGL.so** to use; '*auto*' for system default
-
 

--- a/docs/source/commandline/windowsconfig.rst
+++ b/docs/source/commandline/windowsconfig.rst
@@ -8,167 +8,57 @@ This section contains configuration options that are specific to the native (non
 Debugging options
 -----------------
 
-**-[no]oslog**
-
-	Outputs the error.log data to the Windows debugger. This can be used at	the same time as -log to output the log data to both targets as well. Default is OFF (*-nooslog*).
-
-**-watchdog** *<duration>* / **-wdog** *<duration>*
-
-	Enables an internal watchdog timer that will automatically kill the MAME process if more than *<duration>* seconds passes without a frame update. Keep in mind that some games sit for a while during load time without updating the screen, so *<duration>* should be long enough to cover that. 10-30 seconds on a modern system should be plenty in general. By default there is no watchdog.
+.. _mame-wcommandline-debuggerfont:
 
 **-debugger_font** *<fontname>* / **-dfont** *<fontname>*
 
 	Specifies the name of the font to use for debugger windows. By default,	the font is Lucida Console.
+
+.. _mame-wcommandline-debuggerfontsize:
 
 **-debugger_font_size** *<points>* / **-dfontsize** *<points>*
 
 	Specifies the size of the font to use for debugger windows, in points. By default, this is set to 9pt.
 
 
-
 Performance options
 -------------------
+
+.. _mame-wcommandline-priority:
 
 **-priority** *<priority>*
 
 	Sets the thread priority for the MAME threads. By default the priority is left alone to guarantee proper cooperation with other applications. The valid range is -15 to 1, with 1 being the highest priority. The default is *0* (*NORMAL priority*).
 
-**-numprocessors** *<auto|value>* / **-np** *<auto|value>*
-
-	Specify the number of processors to use for work queues. Specifying "*auto*" will use the value reported by the system or environment variable **OSDPROCESSORS**. To avoid abuse, this value is internally limited to 4 times the number of processors reported by the system. The default is "*auto*".
+.. _mame-wcommandline-profile:
 
 **-profile** *[n]*
 
-        Enables profiling, specifying the stack depth of *[n]* to track.
+    Enables profiling, specifying the stack depth of *[n]* to track.
 
-**-bench** *[n]*
-
-        Benchmark for *[n]* number of emulated seconds; implies the command string:
-
-        **-str [n] -video none -sound none -nothrottle**
-
-
-
-Video options
--------------
-
-**-video** *<bgfx|gdi|d3d|none>*
-
-	Specifies which video subsystem to use for drawing. Using '*bgfx*' specifies the new hardware accelerated renderer. By specifying '*gdi*' here, you tell MAME to render video using older standard Windows graphics drawing calls. This is the slowest but most compatible option on older versions of Windows. Specifying '*d3d*' tells MAME to use Direct3D for rendering. This produces the highest quality output and enables all rendering options. It is recommended if you have a semi-recent (2002+) video card or onboard Intel video of the HD3000 line or better. The final option 'none' displays no windows and does no drawing. This is primarily present for doing CPU benchmarks without the overhead of the video system. The default is *d3d*.
-
-**-numscreens** *<count>*
-
-	Tells MAME how many output windows to create. For most games, a single output window is all you need, but some games originally used multiple screens (*e.g. Darius, PlayChoice-10*). Each screen (up to 4) has its own independent settings for physical monitor, aspect ratio, resolution, and view, which can be set using the options below. The default is *1*.
-
-**-[no]window** / **-[no]w**
-
-	Run MAME in either a window or full screen. The default is OFF (*-nowindow*).
-
-**-[no]maximize** / **-[no]max**
-
-	Controls initial window size in windowed mode. If it is set on, the window will initially be set to the maximum supported size when you start MAME. If it is turned off, the window will start out at the smallest supported size. This option only has an effect when the -window option is used. The default is ON (*-maximize*).
-
-**-[no]keepaspect** / **-[no]ka**
-
-	Enables aspect ratio enforcement. When this option is on, the game's proper aspect ratio (generally 4:3 or 3:4) is enforced, so you get the game looking like it should. When running in a window with this option on, you can only resize the window to the proper aspect ratio, unless you are holding down the CONTROL key. By turning the option off, the aspect ratio is allowed to float. In full screen mode, this means that all games will stretch to the full screen size (even vertical games). In window mode, it means that you can freely resize the window without any constraints. The default is ON (*-keepaspect*).
-
-	The MAME team heavily suggests you leave this at default. Stretching games beyond their original aspect ratio will mangle the appearance of the game in ways that no filtering or HLSL can repair.
-
-**-prescale** *<amount>*
-
-	Controls the size of the screen images when they are passed off to the graphics system for scaling. At the minimum setting of 1, the screen is rendered at its original resolution before being scaled. At higher settings, the screen is expanded by a factor of *<amount>* before being scaled. With **-video d3d**, this produces a less blurry image at the expense of some speed. The default is *1*. 
-
-**-[no]waitvsync**
-
-	Waits for the refresh period on your computer's monitor to finish before starting to draw video to your screen. If this option is off, MAME will just draw to the screen at any old time, even in the middle of a refresh cycle. This can cause "tearing" artifacts, where the top portion of the screen is out of sync with the bottom portion. Tearing is not noticeable on all games, and some people hate it more than others. However, if you turn this option on, you will waste more of your CPU cycles waiting for the proper time to draw, so you will see a performance hit. You should only need to turn this on in windowed mode. In full screen mode, it is only needed if **-triplebuffer** does not remove the tearing, in which case you should use **-notriplebuffer -waitvsync**. Note that this option does not work with **-video gdi** mode. The default is OFF (*-nowaitvsync*).
-
-**-[no]syncrefresh**
-
-	Enables speed throttling only to the refresh of your monitor. This means that the game's actual refresh rate is ignored; however, the sound code still attempts to keep up with the game's original refresh rate, so you may encounter sound problems. This option is intended mainly for those who have tweaked their video card's settings to provide carefully matched refresh rate options. Note that this option does not work with -video gdi mode. The default is OFF (*-nosyncrefresh*).
-
-
-Direct3D-specific options
--------------------------
-
-**-[no]filter** / **-[no]d3dfilter** / **-[no]flt**
-
-	Enable bilinear filtering on the game screen graphics. When disabled, point filtering is applied, which is crisper but leads to scaling artifacts. If you don't like the filtered look, you are probably better off increasing the *-prescale* value rather than turning off filtering altogether. The default is ON (*-filter*).
-
-
-
-Per-window options
-------------------
-
-| **-screen** *<display>*
-| **-screen0** *<display>*
-| **-screen1** *<display>*
-| **-screen2** *<display>*
-| **-screen3** *<display>*
-|
-|	Specifies which physical monitor on your system you wish to have each window use by default. In order to use multiple windows, you must have increased the value of the **-numscreens** option. The name of each display in your system can be determined by running MAME with the -verbose option. The display names are typically in the format of: *\\\\.\\DISPLAYn*, where 'n' is a number from 1 to the number of connected monitors. The default value for these options is '*auto*', which means that the first window is placed on the first display, the second window on the second display, etc.
-|
-|	The **-screen0**, **-screen1**, **-screen2**, **-screen3** parameters apply to the specific window. The **-screen** parameter applies to all windows. The window-specific options override values from the all window option. 
-|
-|
-
-
-| **-aspect** *<width:height>* / **-screen_aspect** *<num:den>*
-| **-aspect0** *<width:height>*
-| **-aspect1** *<width:height>*
-| **-aspect2** *<width:height>*
-| **-aspect3** *<width:height>*
-|
-|
-|	Specifies the physical aspect ratio of the physical monitor for each window. In order to use multiple windows, you must have increased the value of the **-numscreens** option. The physical aspect ratio can be determined by measuring the width and height of the visible screen image and specifying them separated by a colon. The default value for these options is '*auto*', which means that MAME assumes the aspect ratio is proportional to the number of pixels in the desktop video mode for each monitor.
-|
-|	The **-aspect0**, **-aspect1**, **-aspect2**, **-aspect3** parameters apply to the specific window. The **-aspect** parameter applies to all windows. The window-specific options override values from the all window option.
-|
-|
-
-
-| **-resolution** *<widthxheight[@refresh]>* / **-r** *<widthxheight[@refresh]>*
-| **-resolution0** *<widthxheight[@refresh]>* / **-r0** *<widthxheight[@refresh]>*
-| **-resolution1** *<widthxheight[@refresh]>* / **-r1** *<widthxheight[@refresh]>*
-| **-resolution2** *<widthxheight[@refresh]>* / **-r2** *<widthxheight[@refresh]>*
-| **-resolution3** *<widthxheight[@refresh]>* / **-r3** *<widthxheight[@refresh]>*
-|
-|	Specifies an exact resolution to run in. In full screen mode, MAME will try to use the specific resolution you request. The width and height are required; the refresh rate is optional. If omitted or set to 0, MAME will determine the mode automatically. For example, **-resolution 640x480** will force 640x480 resolution, but MAME is free to choose the refresh rate. Similarly, **-resolution 0x0@60** will force a 60Hz refresh rate, but allows MAME to choose the resolution. The string "*auto*" is also supported, and is equivalent to *0x0@0*. In window mode, this resolution is used as a maximum size for the window. This option requires the **-switchres** option as well in order to actually enable resolution switching with **-video d3d**. The default value for these options is '*auto*'.
-|
-|	The **-resolution0**, **-resolution1**, **-resolution2**, **-resolution3** parameters apply to the specific window. The -resolution parameter applies to all windows. The window-specific options override values from the all window option.
-|
-|
-
-
-| **-view** *<viewname>*
-| **-view0** *<viewname>*
-| **-view1** *<viewname>*
-| **-view2** *<viewname>*
-| **-view3** *<viewname>*
-|
-|	Specifies the initial view setting for each window. The *<viewname>* does not need to be a perfect match; rather, it will select the first view whose name matches all the characters specified by *<viewname>*. For example, **-view native** will match the "*Native (15:14)*" view even though it is not a perfect match. The value '*auto*' is also supported, and requests that MAME perform a default selection. The default value for these options is '*auto*'.
-|
-|	The **-view0**, **-view1**, **-view2**, **-view3** parameters apply to the specific window. The **-view** parameter applies to all windows. The window-specific options override values from the all window option.
-|
-|
 
 Full screen options
 -------------------
+
+.. _mame-wcommandline-triplebuffer:
 
 **-[no]triplebuffer** / **-[no]tb**
 
 	Enables or disables "triple buffering". Normally, MAME just draws directly to the screen, without any fancy buffering. But with this option enabled, MAME creates three buffers to draw to, and cycles between them in order. It attempts to keep things flowing such that one buffer is currently displayed, the second buffer is waiting to be displayed, and the third buffer is being drawn to. **-triplebuffer** will override **-waitvsync**, if the buffer is successfully created. This option does not work with **-video gdi**. The default is OFF (*-notriplebuffer*).
 
-**-[no]switchres**
-
-	Enables resolution switching. This option is required for the **-resolution\*** options to switch resolutions in full screen mode. On modern video cards, there is little reason to switch resolutions unless you are trying to achieve the "exact" pixel resolutions of the original games, which requires significant tweaking. This option is also useful on LCD displays, since they run with a fixed resolution and switching resolutions on them is just silly. This option does not work with **-video gdi**. The default is OFF (*-noswitchres*).
+.. _mame-wcommandline-fullscreenbrightness:
 
 **-full_screen_brightness** *<value>* / **-fsb** *<value>*
 
 	Controls the brightness, or black level, of the entire display. The standard value is 1.0. Selecting lower values (down to 0.1) will produce a darkened display, while selecting higher values (up to 2.0) will give a brighter display. Note that not all video cards have hardware to support this option. This option does not work with **-video gdi**. The default is *1.0*.
 
+.. _mame-wcommandline-fullscreencontrast:
+
 **-full_screen_contrast** *<value>* / **-fsc** *<value>*
 
 	Controls the contrast, or white level, of the entire display. The standard value is 1.0. Selecting lower values (down to 0.1) will produce a dimmer display, while selecting higher values (up to 2.0) will give a more saturated display. Note that not all video cards have hardware to support this option. This option does not work with **-video gdi**. The default is *1.0*.
+
+.. _mame-wcommandline-fullscreengamma:
 
 **-full_screen_gamma** *<value>* / **-fsg** *<value>*
 
@@ -176,22 +66,10 @@ Full screen options
 
 
 
-Sound options
--------------
-
-**-sound** *<dsound|sdl|none>*
-
-	Specifies which sound subsystem to use. '*none*' disables sound altogether. The default is *dsound*.
-
-
-**-audio_latency** *<value>*
-
-	This controls the amount of latency built into the audio streaming. By default MAME tries to keep the DirectSound audio buffer between 1/5 and 2/5 full. On some systems, this is pushing it too close to the edge, and you get poor sound sometimes. The latency parameter controls the lower threshold. The default is *1* (meaning lower=1/5 and upper=2/5). Set it to 2 (**-audio_latency 2**) to keep the sound buffer between 2/5 and 3/5 full. If you crank it up to 4, you can *definitely* notice audio lag.
-
-
-
 Input device options
 --------------------
+
+.. _mame-wcommandline-duallightgun:
 
 **-[no]dual_lightgun** / **-[no]dual**
 


### PR DESCRIPTION
This is a substantial overhaul of the old commandline section.

I found all options that were duplicated across SDL and Windows-specific sections and merged those with careful attention to note what parameters are valid per-OS.

Additionally added a new index page for commandline options that should be useful for providing support.

While I did do my absolute best to make sure no errors crept in, the sheer size of this means it's entirely possible I may have missed something. I didn't see anything obvious at a quick glance, in any case. As always, let me know and I'll do corrections as needed.