### PR TITLE
new WORKING clones - Maniac Square (unprotected, Version 1.0, Checksum 66B1, 960419/1 PCB) [f205v]

### DIFF
--- a/src/mame/includes/gaelco2.h
+++ b/src/mame/includes/gaelco2.h
@@ -60,6 +60,7 @@ public:
 	void alighunt_d5002fp(machine_config &config);
 	void snowboar(machine_config &config);
 	void maniacsq(machine_config &config);
+	void maniacsqs(machine_config &config);
 	void touchgo_d5002fp(machine_config &config);
 protected:
 	required_device<m68000_device> m_maincpu;

--- a/src/mame/mame.lst
+++ b/src/mame/mame.lst
@@ -13009,6 +13009,7 @@ play2000a                       // (c) 1999 - Ref ???
 maniacsq                        // (c) 1996 - Ref 940411
 maniacsqa                       // (c) 1996 - Ref 940411
 maniacsqu                       // (c) 1996 - Ref 940411 - (unprotected)
+maniacsqs                       // (c) 1996 - Ref 960419/1
 snowboar                        // (c) 1996 - Ref 960419/1
 snowboara                       // (c) 1996 - Ref 960419/1
 touchgo                         // (c) 1995 - Ref 950906


### PR DESCRIPTION
as expected this version lets you set the game options in service mode rather than using dipswitches as the PCB has none.