### PR TITLE
added FALLTHROUGH macro to mitigate Coverity ""missing break in switc…

### DIFF
--- a/src/devices/cpu/h8/h8make.py
+++ b/src/devices/cpu/h8/h8make.py
@@ -82,6 +82,7 @@ def save_partial_one(f, t, name, source):
     for line in source:
         if has_memory(line):
             print("\tif(icount <= bcount) { inst_substate = %d; return; }" % substate, file=f)
+            print("\tFALLTHROUGH", file=f)
             print("case %d:;" % substate, file=f)
             print(line, file=f)
             substate += 1

--- a/src/devices/cpu/m6502/m6502make.py
+++ b/src/devices/cpu/m6502/m6502make.py
@@ -102,6 +102,7 @@ case %(substate)s:;
 
 PARTIAL_MEMORY="""\
 \tif(icount == 0) { inst_substate = %(substate)s; return; }
+\tFALLTHROUGH
 case %(substate)s:
 %(ins)s
 \ticount--;

--- a/src/osd/osdcomm.h
+++ b/src/osd/osdcomm.h
@@ -41,6 +41,11 @@
 #define UNEXPECTED(exp)         __builtin_expect(!!(exp), 0)
 #define EXPECTED(exp)           __builtin_expect(!!(exp), 1)
 #define RESTRICT                __restrict__
+#if defined(__clang__) && __clang__ == 1
+#define FALLTHROUGH             [[clang::fallthrough]];
+#else
+#define FALLTHROUGH             [[gnu::fallthrough]];
+#endif
 #else
 #define ATTR_UNUSED
 #define ATTR_PRINTF(x,y)
@@ -51,6 +56,7 @@
 #define UNEXPECTED(exp)         (exp)
 #define EXPECTED(exp)           (exp)
 #define RESTRICT
+#define FALLTHROUGH             // fallthrough
 #endif
 
 


### PR DESCRIPTION
…h" warnings (nw)

use it in h8 and m6502 code generators

This should get rid of over 2000 Coverity warnings in the generated code and allows us to mitigate other such warnings as well as using the -Wimplicit-fallthrough compiler warning.