### PR TITLE
Add Systema TV Boy II

### DIFF
--- a/scripts/target/mame/mess.lua
+++ b/scripts/target/mame/mess.lua
@@ -1556,6 +1556,7 @@ files {
 
 createMESSProjects(_target, _subtarget, "atari")
 files {
+	MAME_DIR .. "src/mame/drivers/a2600.h",
 	MAME_DIR .. "src/mame/drivers/a2600.cpp",
 	MAME_DIR .. "src/mame/drivers/a7800.cpp",
 	MAME_DIR .. "src/mame/video/maria.cpp",

--- a/scripts/target/mame/mess.lua
+++ b/scripts/target/mame/mess.lua
@@ -1573,6 +1573,7 @@ files {
 	MAME_DIR .. "src/mame/audio/lynx.h",
 	MAME_DIR .. "src/mame/machine/lynx.cpp",
 	MAME_DIR .. "src/mame/drivers/pofo.cpp",
+	MAME_DIR .. "src/mame/drivers/tvboy.cpp",
 }
 
 createMESSProjects(_target, _subtarget, "att")

--- a/src/mame/drivers/a2600.cpp
+++ b/src/mame/drivers/a2600.cpp
@@ -12,94 +12,14 @@ TODO:
 
 // the new RIOT does not work with the SuperCharger
 // for example "mame64 a2600 scharger -cass offifrog" fails to load after playing the tape
-#define USE_NEW_RIOT 0
-
 
 #include "emu.h"
 
-#include "cpu/m6502/m6507.h"
-#include "sound/tiaintf.h"
-#include "video/tia.h"
-#include "bus/vcs/vcs_slot.h"
-#include "bus/vcs/rom.h"
-#include "bus/vcs/dpc.h"
-#include "bus/vcs/harmony_melody.h"
-#include "bus/vcs/scharger.h"
-#include "bus/vcs/compumat.h"
-#include "bus/vcs_ctrl/ctrl.h"
+#include "includes/a2600.h"
+
 #include "screen.h"
 #include "softlist.h"
 #include "speaker.h"
-
-
-#if USE_NEW_RIOT
-#include "machine/mos6530n.h"
-#else
-#include "machine/6532riot.h"
-#endif
-
-
-#define CONTROL1_TAG    "joyport1"
-#define CONTROL2_TAG    "joyport2"
-
-
-
-class a2600_state : public driver_device
-{
-public:
-	a2600_state(const machine_config &mconfig, device_type type, const char *tag)
-		: driver_device(mconfig, type, tag),
-		m_riot_ram(*this, "riot_ram"),
-		m_joy1(*this, CONTROL1_TAG),
-		m_joy2(*this, CONTROL2_TAG) ,
-		m_cart(*this, "cartslot"),
-		m_tia(*this, "tia_video"),
-		m_maincpu(*this, "maincpu"),
-		m_screen(*this, "screen"),
-		m_swb(*this, "SWB"),
-		m_riot(*this,"riot")
-	{ }
-
-	required_shared_ptr<uint8_t> m_riot_ram;
-	uint16_t m_current_screen_height;
-
-	DECLARE_MACHINE_START(a2600);
-	DECLARE_WRITE8_MEMBER(switch_A_w);
-	DECLARE_READ8_MEMBER(switch_A_r);
-	DECLARE_WRITE8_MEMBER(switch_B_w);
-	DECLARE_WRITE_LINE_MEMBER(irq_callback);
-	DECLARE_READ8_MEMBER(riot_input_port_8_r);
-	DECLARE_READ16_MEMBER(a2600_read_input_port);
-	DECLARE_READ8_MEMBER(a2600_get_databus_contents);
-	DECLARE_WRITE16_MEMBER(a2600_tia_vsync_callback);
-	DECLARE_WRITE16_MEMBER(a2600_tia_vsync_callback_pal);
-	DECLARE_WRITE8_MEMBER(cart_over_tia_w);
-	// investigate how the carts mapped here (Mapper JVP) interact with the RIOT device
-	DECLARE_READ8_MEMBER(cart_over_riot_r);
-	DECLARE_WRITE8_MEMBER(cart_over_riot_w);
-	DECLARE_READ8_MEMBER(cart_over_all_r);
-	DECLARE_WRITE8_MEMBER(cart_over_all_w);
-
-	void a2600p(machine_config &config);
-	void a2600(machine_config &config);
-	void a2600_cartslot(machine_config &config);
-protected:
-	required_device<vcs_control_port_device> m_joy1;
-	required_device<vcs_control_port_device> m_joy2;
-	required_device<vcs_cart_slot_device> m_cart;
-	required_device<tia_video_device> m_tia;
-
-	required_device<m6507_device> m_maincpu;
-	required_device<screen_device> m_screen;
-	required_ioport m_swb;
-#if USE_NEW_RIOT
-	required_device<mos6532_t> m_riot;
-#else
-	required_device<riot6532_device> m_riot;
-#endif
-
-};
-
 
 
 #define MASTER_CLOCK_NTSC   3579545

--- a/src/mame/drivers/tvboy.cpp
+++ b/src/mame/drivers/tvboy.cpp
@@ -1,0 +1,140 @@
+// license:BSD-3-Clause
+// copyright-holders:David Shah
+/***************************************************************************
+
+  Systema TV Boy Driver
+
+TODO:
+- Find, dump and add the other devices (TV Boy, Super TV Boy)
+- Add NTSC variant
+***************************************************************************/
+
+#include "emu.h"
+
+#include "includes/a2600.h"
+
+
+#define CONTROL1_TAG    "joyport1"
+#define CONTROL2_TAG    "joyport2"
+
+class tvboy_state : public a2600_state
+{
+public:
+  tvboy_state(const machine_config &mconfig, device_type type, const char *tag)
+    : a2600_state(mconfig, type, tag)
+    , m_crom(*this, "crom")
+		, m_bank0(*this, "bank0")
+		, m_rom(*this, "mainrom") {};
+  
+  DECLARE_WRITE8_MEMBER(bank_write);
+
+  void tvboyii(machine_config &config);
+  
+private:
+  required_device<address_map_bank_device> m_crom;
+  required_memory_bank m_bank0;
+  
+  required_region_ptr<uint8_t> m_rom;
+  
+  virtual void machine_start() override;
+  virtual void machine_reset() override;
+}
+
+void tvboy_state::machine_start() {
+  m_crom->set_bank(0);
+  m_bank0->configure_entries(0, 128, &m_rom[0x00000], 0x1000);
+}
+
+void tvboy_state::machine_reset() {
+  m_bank0->set_entry(0);
+}
+
+WRITE8_MEMBER(tvboy_state::bank_write) {
+  logerror("banking (?) write %04x, %02x\n", offset, data);
+}
+
+static ADDRESS_MAP_START(tvboy_mem, AS_PROGRAM, 8, tvboy_state ) // 6507 has 13-bit address space, 0x0000 - 0x1fff
+	AM_RANGE(0x0000, 0x007f) AM_MIRROR(0x0f00) AM_DEVREADWRITE("tia_video", tia_video_device, read, write)
+	AM_RANGE(0x0080, 0x00ff) AM_MIRROR(0x0d00) AM_RAM AM_SHARE("riot_ram")
+#if USE_NEW_RIOT
+	AM_RANGE(0x0280, 0x029f) AM_MIRROR(0x0d00) AM_DEVICE("riot", mos6532_t, io_map)
+#else
+	AM_RANGE(0x0280, 0x029f) AM_MIRROR(0x0d00) AM_DEVREADWRITE("riot", riot6532_device, read, write)
+#endif
+  AM_RANGE(0x1000, 0x1fff) AM_WRITE(bank_write)
+	AM_RANGE(0x1000, 0x1fff) AM_DEVICE("crom", address_map_bank_device, amap8)
+ADDRESS_MAP_END
+
+static ADDRESS_MAP_START( rom_map, AS_PROGRAM, 8, tvboy_state )
+	AM_RANGE(0x0000, 0x0fff) AM_ROMBANK("bank0")
+ADDRESS_MAP_END
+
+#define MASTER_CLOCK_PAL    3546894
+
+
+MACHINE_CONFIG_START(tvboy_state::tvboyii)
+	/* basic machine hardware */
+	MCFG_CPU_ADD("maincpu", M6507, MASTER_CLOCK_PAL / 3)
+	MCFG_CPU_PROGRAM_MAP(tvboy_mem)
+
+  MCFG_DEVICE_ADD("crom", ADDRESS_MAP_BANK, 0)
+	MCFG_DEVICE_PROGRAM_MAP(rom_map)
+	MCFG_ADDRESS_MAP_BANK_ENDIANNESS(ENDIANNESS_LITTLE)
+	MCFG_ADDRESS_MAP_BANK_DATA_WIDTH(8)
+	MCFG_ADDRESS_MAP_BANK_ADDR_WIDTH(12)
+	MCFG_ADDRESS_MAP_BANK_STRIDE(0x1000)
+  
+	MCFG_M6502_DISABLE_DIRECT()
+
+	MCFG_MACHINE_START_OVERRIDE(tvboy_state, tvboyii)
+
+	/* video hardware */
+	MCFG_DEVICE_ADD("tia_video", TIA_PAL_VIDEO, 0)
+	MCFG_TIA_READ_INPUT_PORT_CB(READ16(tvboy_state, a2600_read_input_port))
+	MCFG_TIA_DATABUS_CONTENTS_CB(READ8(tvboy_state, a2600_get_databus_contents))
+	MCFG_TIA_VSYNC_CB(WRITE16(tvboy_state, a2600_tia_vsync_callback_pal))
+
+
+	MCFG_SCREEN_ADD("screen", RASTER)
+	MCFG_SCREEN_RAW_PARAMS( MASTER_CLOCK_PAL, 228, 26, 26 + 160 + 16, 312, 32, 32 + 228 + 31 )
+	MCFG_SCREEN_UPDATE_DEVICE("tia_video", tia_video_device, screen_update)
+	MCFG_SCREEN_PALETTE("tia_video:palette")
+
+	/* sound hardware */
+	MCFG_SPEAKER_STANDARD_MONO("mono")
+	MCFG_SOUND_TIA_ADD("tia", MASTER_CLOCK_PAL/114)
+	MCFG_SOUND_ROUTE(ALL_OUTPUTS, "mono", 0.90)
+
+	/* devices */
+#if USE_NEW_RIOT
+	MCFG_DEVICE_ADD("riot", MOS6532n, MASTER_CLOCK_PAL / 3)
+	MCFG_MOS6530n_IN_PA_CB(READ8(tvboy_state, switch_A_r))
+	MCFG_MOS6530n_OUT_PA_CB(WRITE8(tvboy_state, switch_A_w))
+	MCFG_MOS6530n_IN_PB_CB(READ8(tvboy_state, riot_input_port_8_r))
+	MCFG_MOS6530n_OUT_PB_CB(WRITE8(tvboy_state, switch_B_w))
+	MCFG_MOS6530n_IRQ_CB(WRITELINE(tvboy_state, irq_callback))
+#else
+	MCFG_DEVICE_ADD("riot", RIOT6532, MASTER_CLOCK_PAL / 3)
+	MCFG_RIOT6532_IN_PA_CB(READ8(tvboy_state, switch_A_r))
+	MCFG_RIOT6532_OUT_PA_CB(WRITE8(tvboy_state, switch_A_w))
+	MCFG_RIOT6532_IN_PB_CB(READ8(tvboy_state, riot_input_port_8_r))
+	MCFG_RIOT6532_OUT_PB_CB(WRITE8(tvboy_state, switch_B_w))
+	MCFG_RIOT6532_IRQ_CB(WRITELINE(tvboy_state, irq_callback))
+#endif
+
+	MCFG_VCS_CONTROL_PORT_ADD(CONTROL1_TAG, vcs_control_port_devices, "joy")
+	MCFG_VCS_CONTROL_PORT_ADD(CONTROL2_TAG, vcs_control_port_devices, nullptr)
+  
+MACHINE_CONFIG_END
+
+ROM_START( tvboyii )
+	ROM_REGION( 0x2000, "maincpu", ROMREGION_ERASEFF )
+ROM_END
+
+ROM_START( tvboyii )
+	ROM_REGION( 0x80000, "mainrom", 0 )
+  ROM_LOAD( "HY23400P.bin", 0x00000, 0x800000, CRC(f8485173) SHA1(cafbaa0c5437f192cb4fb49f9a672846aa038870) )
+ROM_END
+
+/*    YEAR  NAME    PARENT  COMPAT  MACHINE INPUT  STATE        INIT    COMPANY     FULLNAME */
+CONS( 199?, tvboyii, a2600,      0, tvboyii,  a2600, tvboy_state, 0, "Systema", "TV Boy II (PAL)" , MACHINE_SUPPORTS_SAVE )

--- a/src/mame/drivers/tvboy.cpp
+++ b/src/mame/drivers/tvboy.cpp
@@ -30,18 +30,30 @@ public:
   DECLARE_WRITE8_MEMBER(bank_write);
 
   void tvboyii(machine_config &config);
-  
+  void supertvboy(machine_config &config);
+
 private:
   required_device<address_map_bank_device> m_crom;
   required_memory_bank m_bank0;
   
   required_region_ptr<uint8_t> m_rom;
   
+  virtual void machine_start() override;
   virtual void machine_start_tvboyii();
+  virtual void machine_start_supertvboy();
+
   virtual void machine_reset() override;
 };
 
 void tvboy_state::machine_start_tvboyii() {
+  machine_start();
+}
+
+void tvboy_state::machine_start_supertvboy() {
+  machine_start();
+}
+
+void tvboy_state::machine_start() {
   m_crom->set_bank(0);
   m_bank0->configure_entries(0, 128, &m_rom[0x00000], 0x1000);
 }
@@ -131,6 +143,9 @@ MACHINE_CONFIG_START(tvboy_state::tvboyii)
   
 MACHINE_CONFIG_END
 
+MACHINE_CONFIG_DERIVED(tvboy_state::supertvboy, tvboyii)
+MACHINE_CONFIG_END
+
 static INPUT_PORTS_START( tvboyii )
 	PORT_START("SWB")
 	PORT_BIT( 0x01, IP_ACTIVE_LOW, IPT_OTHER ) PORT_NAME("Reset Game") PORT_CODE(KEYCODE_2)
@@ -156,5 +171,15 @@ ROM_START( tvboyii )
   ROM_LOAD( "HY23400P.bin", 0x00000, 0x80000, CRC(f8485173) SHA1(cafbaa0c5437f192cb4fb49f9a672846aa038870) )
 ROM_END
 
+
+ROM_START( supertvboy )
+  ROM_REGION( 0x2000, "maincpu", ROMREGION_ERASEFF )
+
+	ROM_REGION( 0x80000, "mainrom", 0 )
+  ROM_LOAD( "supertvboy.bin", 0x00000, 0x80000, CRC(af2e73e8) SHA1(04b9ddc3b30b0e5b81b9f868d455e902a0151491) )
+ROM_END
+
+
 /*    YEAR  NAME    PARENT  COMPAT  MACHINE INPUT  STATE        INIT    COMPANY     FULLNAME */
-CONS( 199?, tvboyii, a2600,      0, tvboyii,  tvboyii, tvboy_state, 0, "Systema", "TV Boy II (PAL)" , MACHINE_SUPPORTS_SAVE )
+CONS( 199?, tvboyii,    a2600,      0, tvboyii,  tvboyii, tvboy_state, 0, "Systema", "TV Boy II (PAL)" , MACHINE_SUPPORTS_SAVE )
+CONS( 1995, supertvboy, a2600,      0, supertvboy,  tvboyii, tvboy_state, 0, "Akor", "Super TV Boy" , MACHINE_SUPPORTS_SAVE )

--- a/src/mame/includes/a2600.h
+++ b/src/mame/includes/a2600.h
@@ -1,0 +1,99 @@
+// license:BSD-3-Clause
+// copyright-holders:Nathan Woods, Wilbert Pol, David Shah
+/*****************************************************************************
+
+    a2600.h
+
+    Atari 2600
+
+ ****************************************************************************/
+
+#ifndef MAME_INCLUDES_A2600H
+#define MAME_INCLUDES_A2600H
+
+#pragma once
+
+#define USE_NEW_RIOT 0
+
+
+#define CONTROL1_TAG    "joyport1"
+#define CONTROL2_TAG    "joyport2"
+
+#include "cpu/m6502/m6507.h"
+#include "sound/tiaintf.h"
+#include "video/tia.h"
+#include "bus/vcs/vcs_slot.h"
+#include "bus/vcs/rom.h"
+#include "bus/vcs/dpc.h"
+#include "bus/vcs/harmony_melody.h"
+#include "bus/vcs/scharger.h"
+#include "bus/vcs/compumat.h"
+#include "bus/vcs_ctrl/ctrl.h"
+
+#if USE_NEW_RIOT
+#include "machine/mos6530n.h"
+#else
+#include "machine/6532riot.h"
+#endif
+
+
+class a2600_state : public driver_device
+{
+public:
+ a2600_state(const machine_config &mconfig, device_type type, const char *tag)
+   : driver_device(mconfig, type, tag),
+   m_riot_ram(*this, "riot_ram"),
+   m_joy1(*this, CONTROL1_TAG),
+   m_joy2(*this, CONTROL2_TAG) ,
+   m_cart(*this, "cartslot"),
+   m_tia(*this, "tia_video"),
+   m_maincpu(*this, "maincpu"),
+   m_screen(*this, "screen"),
+   m_swb(*this, "SWB"),
+   m_riot(*this,"riot")
+ { }
+
+ required_shared_ptr<uint8_t> m_riot_ram;
+ uint16_t m_current_screen_height;
+
+ DECLARE_MACHINE_START(a2600);
+ DECLARE_WRITE8_MEMBER(switch_A_w);
+ DECLARE_READ8_MEMBER(switch_A_r);
+ DECLARE_WRITE8_MEMBER(switch_B_w);
+ DECLARE_WRITE_LINE_MEMBER(irq_callback);
+ DECLARE_READ8_MEMBER(riot_input_port_8_r);
+ DECLARE_READ16_MEMBER(a2600_read_input_port);
+ DECLARE_READ8_MEMBER(a2600_get_databus_contents);
+ DECLARE_WRITE16_MEMBER(a2600_tia_vsync_callback);
+ DECLARE_WRITE16_MEMBER(a2600_tia_vsync_callback_pal);
+ DECLARE_WRITE8_MEMBER(cart_over_tia_w);
+ // investigate how the carts mapped here (Mapper JVP) interact with the RIOT device
+ DECLARE_READ8_MEMBER(cart_over_riot_r);
+ DECLARE_WRITE8_MEMBER(cart_over_riot_w);
+ DECLARE_READ8_MEMBER(cart_over_all_r);
+ DECLARE_WRITE8_MEMBER(cart_over_all_w);
+
+ void a2600p(machine_config &config);
+ void a2600(machine_config &config);
+ void a2600_cartslot(machine_config &config);
+protected:
+ required_device<vcs_control_port_device> m_joy1;
+ required_device<vcs_control_port_device> m_joy2;
+ optional_device<vcs_cart_slot_device> m_cart;
+ required_device<tia_video_device> m_tia;
+
+ required_device<m6507_device> m_maincpu;
+ required_device<screen_device> m_screen;
+ required_ioport m_swb;
+#if USE_NEW_RIOT
+ required_device<mos6532_t> m_riot;
+#else
+ required_device<riot6532_device> m_riot;
+#endif
+
+};
+
+
+#endif /* MAME_INCLUDES_A2600H */
+
+ 

--- a/src/mame/mame.lst
+++ b/src/mame/mame.lst
@@ -37346,6 +37346,7 @@ tv990                           // 1992? TeleVideo
 tv995                           // 1994 TeleVideo
 
 @source:tvboy.cpp
+supertvboy
 tvboyii                         //
 
 @source:tvc.cpp

--- a/src/mame/mame.lst
+++ b/src/mame/mame.lst
@@ -37345,6 +37345,9 @@ tv950                           //
 tv990                           // 1992? TeleVideo
 tv995                           // 1994 TeleVideo
 
+@source:tvboy.cpp
+tvboyii                         //
+
 @source:tvc.cpp
 tvc64                           //
 tvc64p                          //

--- a/src/mame/mess.flt
+++ b/src/mame/mess.flt
@@ -719,6 +719,7 @@ tv910.cpp
 tv912.cpp
 tv950.cpp
 tv990.cpp
+tvboy.cpp
 tvc.cpp
 tvgame.cpp
 tx0.cpp


### PR DESCRIPTION
The TV Boy II is a clone of the Atari 2600 with 126 built in games. This PR adds a driver for it, and also refactors the Atari 2600 driver a bit (creating a2600.h) so it can be added as a proper clone of the a2600 rather than a fake cartridge.