### PR TITLE
softlist: proposal for change to compatibility handling

### DIFF
--- a/hash/interpro.xml
+++ b/hash/interpro.xml
@@ -1,0 +1,230 @@
+<?xml version="1.0"?>
+<!DOCTYPE softwarelist SYSTEM "softwarelist.dtd">
+<softwarelist name="interpro" description="Intergraph InterPro software">
+
+  <!--
+    Intergraph distributed all InterPro software, including that from 3rd
+    parties, on CD-ROM disc sets. A base 4-CD set of system software
+    contains the CLIX operating system and other programs such as editors,
+    compilers and graphics tools. Additional sets were typically organised
+    according to lines of business such as "Plant and Building Solutions",
+    "Architecture, Engineering and Construction", etc., and contained
+    application software aimed at companies in those industries.
+
+    All CD-ROM software is installed using the DELTOOLS package, and the
+    "newprod" utility in particular. In some cases, valid load keys (serial
+    numbers) are required to decrypt the delivered software and enable it
+    to be installed. In addition, some software has other runtime licensing
+    which must be configured before the programs will operate.
+
+    Finally, there are two sets of floppy disks that can be created via the
+    REBUILD and DIAG products. The REBUILD floppy disks are used to boot the
+    initial blue screen utility which allows configuring the system and
+    preparing a hard disk for installation, and to initiate the installation
+    process. The DIAG disks are used to launch the full suite of system
+    hardware diagnostic routines, via the FDMDISK monitor.
+  -->
+
+  <software name="iss">
+		<description>Intergraph System Software</description>
+		<year>1999</year>
+		<publisher>Intergraph</publisher>
+
+		<info name="date" value="05-MAY-1999"/>
+
+		<!-- System Software Disc I#05-MAY-1999#050599#FMDA0320N -->
+		<part name="disc1" interface="cdrom">
+			<feature name="part_id" value="System Software Disc I" />
+			<diskarea name="cdrom">
+				<disk name="iss_050599_1" sha1="5d556b4df2dccdc681095fedcf836a5b0a7782a0" writeable="no" />
+			</diskarea>
+		</part>
+
+		<!-- System Software Disc II#05-MAY-1999#050599#FMDA0320N -->
+		<part name="disc2" interface="cdrom">
+			<feature name="part_id" value="System Software Disc II" />
+			<diskarea name="cdrom">
+				<disk name="iss_050599_2" sha1="3813db83871668eed97b43f2384b7e95a649598a" writeable="no" />
+			</diskarea>
+		</part>
+
+		<!-- System Software Disc III#05-MAY-1999#050599#FMDA0320N -->
+		<part name="disc3" interface="cdrom">
+			<feature name="part_id" value="System Software Disc III" />
+			<diskarea name="cdrom">
+				<disk name="iss_050599_3" sha1="c8b08cd45ef1614b3db1cd0fb8e6539e3bcc5725" writeable="no" />
+			</diskarea>
+		</part>
+
+		<!-- System Software Disc IV#05-MAY-1999#050599#FMDA0170B -->
+		<part name="disc4" interface="cdrom">
+			<feature name="part_id" value="System Software Disc IV" />
+			<diskarea name="cdrom">
+				<disk name="iss_050599_4" sha1="2681b4cd8d355b6abfcfebb1b40a6d8a5ef37fe9" writeable="no" />
+			</diskarea>
+		</part>
+  </software>
+
+  <!--
+    The REBUILD utility allows a set of system rebuild floppy disks to be
+    created from source binary data. When using the software, the user is
+    prompted to select from the following options, producing different
+    combinations of "boot" and "root" source data to be written to disk.
+
+      1)  125/32C/220/225 Systems     (80186 IOP and ROP Graphics)
+      2)  200/240 Systems             (80186 IOP and optional IFB Graphics)
+      3)  300/400/3000/4000 Systems   (80386 IOP and optional IFB Graphics)
+      4)  2000 Systems                (C300 Clipper IOP and optional MMG Graphics)
+      5)  6000 Systems                (C300 Clipper IOP and optional EDGE Graphics)
+      6)  2400 Systems                (C4T Clipper GTPLUS Graphics)
+      7)  6440/6480 Systems           (C4T Clipper EDGE Graphics)
+      8)  6400/6450 Systems           (C4T Clipper GTII Graphics)
+      9)  6640/6680 Systems           (C400 Clipper EDGE graphics)
+      10) 6600 Servers                (C400 Clipper Servers)
+      11) 6700/6800 Servers           (C400I Clipper Server)
+      12) 6740/6780/6840/6880 Systems (C400I Clipper EDGE graphics)
+      13) 6750/6850 Systems           (C400I Clipper GT graphics)
+      14) 2500/2700/2800 Systems      (C400I Clipper Servers)
+      15) 2530/2730/2830 Systems      (C400I Clipper GT graphics)
+
+    Ignoring the first 3 options which are unsupported in MAME at this point,
+    the remaining systems use one of 3 possible boot images: CLIPPER, C400 or
+    C400E.
+  -->
+
+	<software name="rebuild">
+		<description>Rebuild Floppies</description>
+		<year>1998</year>
+		<publisher>Intergraph</publisher>
+
+		<info name="product_id" value="SS01003AA-0706A" />
+		<info name="product_title" value="Rebuild Floppies" />
+		<info name="product_date" value="10-JAN-1998" />
+		<info name="product_name" value="REBUILD" />
+		<info name="product_version" value="07.06.00.09" />
+		<info name="product_class" value="System Nucleus" />
+
+		<!-- boot floppies for C300, C400E and C400 respectively -->
+		<part name="boot" interface="floppy_3_5">
+			<feature name="part_id" value="C300 Rebuild Boot Floppy" />
+			<feature name="compatibility" value="2000,2020,6000,6040" />
+			<dataarea name="flop" size="1474560">
+				<rom name="clipper.img" size="1474560" offset="0" crc="f182eb64" sha1="0e104e4db9f666ccc0d618b402666d90f025a3b4" />
+			</dataarea>
+		</part>
+		<part name="boot" interface="floppy_3_5">
+			<feature name="part_id" value="C400E Rebuild Boot Floppy" />
+			<feature name="compatibility" value="6600,6640,6680" />
+			<dataarea name="flop" size="1474560">
+				<rom name="c400e.img" size="1474560" offset="0" status="nodump" />
+			</dataarea>
+		</part>
+		<part name="boot" interface="floppy_3_5">
+			<feature name="part_id" value="C400 Rebuild Boot Floppy" />
+			<feature name="compatibility" value="2400,2430,6440,6480,6400,6450,6750,6850,6740,6780,6840,6880,6700,6800,2500,2700,2800,2530,2730,2830" />
+			<dataarea name="flop" size="1474560">
+				<rom name="c400.img" size="1474560" offset="0" crc="7e739d42" sha1="ca3f2244d1167553482cd73c59cea74e181f37c7" />
+			</dataarea>
+		</part>
+
+		<!-- root floppies for 2000 and 2020 systems -->
+		<part name="root2" interface="floppy_3_5">
+			<feature name="part_id" value="Rebuild Floppy #2/4" />
+			<feature name="compatibility" value="2000,2020"/>
+			<dataarea name="flop" size="1474560">
+				<rom name="root2.img" size="1474560" offset="0" crc="66ee95eb" sha1="9b6e316f4c038ef471a84a82e396376b361c970a" />
+			</dataarea>
+		</part>
+		<part name="root3" interface="floppy_3_5">
+			<feature name="part_id" value="Rebuild Floppy #3/4" />
+			<feature name="compatibility" value="2000,2020"/>
+			<dataarea name="flop" size="1474560">
+				<rom name="root3.img" size="1474560" offset="0" crc="de490556" sha1="882c46e193a5467b66ffe2cd0ac8518df087d112" />
+			</dataarea>
+		</part>
+		<part name="root4" interface="floppy_3_5">
+			<feature name="part_id" value="Rebuild Floppy #4/4" />
+			<feature name="compatibility" value="2000,2020"/>
+			<dataarea name="flop" size="1474560">
+				<rom name="root4.img" size="1474560" offset="0" crc="2b0e3f01" sha1="e191057117aee120301143f25d5446f55789009c" />
+			</dataarea>
+		</part>
+
+		<!-- root floppies for 2400 and 2430 systems -->
+		<part name="root2" interface="floppy_3_5">
+			<feature name="part_id" value="Rebuild Floppy #2/4" />
+			<feature name="compatibility" value="2000,2020"/>
+			<dataarea name="flop" size="1474560">
+				<rom name="root2.img" size="1474560" offset="0" crc="f6a7ba45" sha1="c810cec284f61921ab1ffffe5e71b291d0a295a6" />
+			</dataarea>
+		</part>
+		<part name="root3" interface="floppy_3_5">
+			<feature name="part_id" value="Rebuild Floppy #3/4" />
+			<feature name="compatibility" value="2400,2430"/>
+			<dataarea name="flop" size="1474560">
+				<rom name="root3.img" size="1474560" offset="0" crc="1659399b" sha1="9ad4b4492654e76f4d5284af15b0235553b63f46" />
+			</dataarea>
+		</part>
+		<part name="root4" interface="floppy_3_5">
+			<feature name="part_id" value="Rebuild Floppy #4/4" />
+			<feature name="compatibility" value="2400,2430"/>
+			<dataarea name="flop" size="1474560">
+				<rom name="root4.img" size="1474560" offset="0" crc="594b2c9c" sha1="b69812399b7b32abbe81d00945b0d96a27b04c19" />
+			</dataarea>
+		</part>
+
+	</software>
+
+  	<software name="diag">
+    	<description>Diagnostic Floppies</description>
+    	<year>1994</year>
+    	<publisher>Intergraph</publisher>
+
+		<info name="product_id" value="SS01086AA-0703A" />
+		<info name="product_title" value="Workstation/Server Diagnostics" />
+		<info name="product_date" value="30-MAR-1994" />
+		<info name="product_name" value="DIAG" />
+		<info name="product_version" value="07.03.15.00" />
+		<info name="product_class" value="Hardware Diagnostics" />
+
+		<!-- Turquoise systems have a single diagnostic floppy -->
+		<part name="boot" interface="floppy_3_5">
+			<feature name="part_id" value="Turqouise Diagnostic Floppy" />
+			<feature name="compatibility" value="2000,2020" />
+			<dataarea name="flop" size="1474560">
+				<rom name="turq.img" size="1474560" offset="0" crc="70e2980a" sha1="3fa2f0c54ef27e16e579563db9cd70b68e11e403" />
+			</dataarea>
+		</part>
+
+		<!-- Sapphire systems have a four-disk set of diagnostic floppies -->
+		<part name="boot" interface="floppy_3_5">
+			<feature name="part_id" value="Sapphire Diagnostic Floppy #1/4" />
+			<feature name="compatibility" value="2400,2430,6440,6480,6400,6450,6750,6850,6740,6780,6840,6880,6700,6800,2500,2700,2800,2530,2730,2830" />
+			<dataarea name="flop" size="1474560">
+				<rom name="sapphire.img" size="1474560" offset="0" crc="1721d7d1" sha1="fc25109c4c7b2d94d0fd55e7cebaa03e7177ad5e" />
+			</dataarea>
+		</part>
+		<part name="disk1" interface="floppy_3_5">
+			<feature name="part_id" value="Sapphire Diagnostic Floppy #2/4" />
+			<feature name="compatibility" value="2400,2430,6440,6480,6400,6450,6750,6850,6740,6780,6840,6880,6700,6800,2500,2700,2800,2530,2730,2830" />
+			<dataarea name="flop" size="1474560">
+				<rom name="sapphire1.img" size="1474560" offset="0" crc="e0db6354" sha1="75fb42ae87d78daaeac30390bef335419425da09" />
+			</dataarea>
+		</part>
+		<part name="disk2" interface="floppy_3_5">
+			<feature name="part_id" value="Sapphire Diagnostic Floppy #31/4" />
+			<feature name="compatibility" value="2400,2430,6440,6480,6400,6450,6750,6850,6740,6780,6840,6880,6700,6800,2500,2700,2800,2530,2730,2830" />
+			<dataarea name="flop" size="1474560">
+				<rom name="sapphire2.img" size="1474560" offset="0" crc="955065d1" sha1="6df92a7986a83d31e91189c8097b9b4f8d02960f" />
+			</dataarea>
+		</part>
+		<part name="disk3" interface="floppy_3_5">
+			<feature name="part_id" value="Sapphire Diagnostic Floppy #4/4" />
+			<feature name="compatibility" value="2400,2430,6440,6480,6400,6450,6750,6850,6740,6780,6840,6880,6700,6800,2500,2700,2800,2530,2730,2830" />
+			<dataarea name="flop" size="1474560">
+				<rom name="sapphire3.img" size="1474560" offset="0" crc="2f14fcb2" sha1="2d33087273c14597fc065e13d05e1ce9d1841704" />
+			</dataarea>
+		</part>
+	</software>
+
+</softwarelist>

--- a/src/emu/diimage.h
+++ b/src/emu/diimage.h
@@ -267,7 +267,7 @@ protected:
 
 	bool image_checkhash();
 
-	const software_part *find_software_item(const std::string &identifier, bool restrict_to_interface, software_list_device **device = nullptr) const;
+	const software_part *find_software_item(const std::string &identifier, bool restrict_to_interface, bool restrict_to_filter, software_list_device **device = nullptr) const;
 	std::string software_get_default_slot(const char *default_card_slot) const;
 
 	void add_format(std::unique_ptr<image_device_format> &&format);

--- a/src/emu/emuopts.cpp
+++ b/src/emu/emuopts.cpp
@@ -921,7 +921,7 @@ emu_options::software_options emu_options::evaluate_initial_softlist_options(con
 						for (const software_part &swpart : swinfo->parts())
 						{
 							// only load compatible software this way
-							if (swlistdev.is_compatible(swpart) == SOFTWARE_IS_COMPATIBLE)
+							if (swpart.is_compatible(swlistdev.filter()) == SOFTWARE_IS_COMPATIBLE)
 							{
 								// we need to find a mountable image slot, but we need to ensure it is a slot
 								// for which we have not already distributed a part to

--- a/src/emu/softlist.h
+++ b/src/emu/softlist.h
@@ -29,6 +29,12 @@
 #define SOFTWARE_SUPPORTED_PARTIAL  1
 #define SOFTWARE_SUPPORTED_NO       2
 
+enum software_compatibility
+{
+	SOFTWARE_IS_COMPATIBLE,
+	SOFTWARE_IS_INCOMPATIBLE,
+	SOFTWARE_NOT_COMPATIBLE
+};
 
 //**************************************************************************
 //  TYPE DEFINITIONS
@@ -86,6 +92,7 @@ public:
 
 	// helpers
 	bool matches_interface(const char *interface) const;
+	software_compatibility is_compatible(const char *filter) const;
 	const char *feature(const std::string &feature_name) const;
 
 private:
@@ -126,7 +133,7 @@ public:
 	const std::list<software_part> &parts() const { return m_partdata; }
 
 	// additional operations
-	const software_part *find_part(const std::string &part_name, const char *interface = nullptr) const;
+	const software_part *find_part(const std::string &part_name, const char *interface = nullptr, const char *filter = nullptr) const;
 	bool has_multiple_parts(const char *interface) const;
 
 private:

--- a/src/emu/softlist_dev.cpp
+++ b/src/emu/softlist_dev.cpp
@@ -148,7 +148,7 @@ void software_list_device::find_approx_matches(const std::string &name, int matc
 	{
 		for (const software_part &swpart : swinfo.parts())
 		{
-			if ((interface == nullptr || swpart.matches_interface(interface)) && is_compatible(swpart) == SOFTWARE_IS_COMPATIBLE)
+			if ((interface == nullptr || swpart.matches_interface(interface)) && swpart.is_compatible(filter()) == SOFTWARE_IS_COMPATIBLE)
 			{
 				// pick the best match between driver name and description
 				int longpenalty = driver_list::penalty_compare(name.c_str(), swinfo.longname().c_str());
@@ -321,56 +321,6 @@ void software_list_device::parse()
 	// indicate that we've been parsed
 	m_parsed = true;
 }
-
-
-//-------------------------------------------------
-//  is_compatible - determine if we are compatible
-//  with the given software_list_device
-//-------------------------------------------------
-
-software_compatibility software_list_device::is_compatible(const software_part &swpart) const
-{
-	// get the softlist filter; if null, assume compatible
-	if (m_filter == nullptr)
-		return SOFTWARE_IS_COMPATIBLE;
-
-	// copy the comma-delimited string and ensure it ends with a final comma
-	std::string filt = std::string(m_filter).append(",");
-
-	// get the incompatibility filter and test against it first if it exists
-	const char *incompatibility = swpart.feature("incompatibility");
-	if (incompatibility != nullptr)
-	{
-		// copy the comma-delimited string and ensure it ends with a final comma
-		std::string incomp = std::string(incompatibility).append(",");
-
-		// iterate over filter items and see if they exist in the list; if so, it's incompatible
-		for (int start = 0, end = filt.find_first_of(',', start); end != -1; start = end + 1, end = filt.find_first_of(',', start))
-		{
-			std::string token(filt, start, end - start + 1);
-			if (incomp.find(token) != -1)
-				return SOFTWARE_IS_INCOMPATIBLE;
-		}
-	}
-
-	// get the compatibility feature; if null, assume compatible
-	const char *compatibility = swpart.feature("compatibility");
-	if (compatibility == nullptr)
-		return SOFTWARE_IS_COMPATIBLE;
-
-	// copy the comma-delimited string and ensure it ends with a final comma
-	std::string comp = std::string(compatibility).append(",");
-
-	// iterate over filter items and see if they exist in the compatibility list; if so, it's compatible
-	for (int start = 0, end = filt.find_first_of(',', start); end != -1; start = end + 1, end = filt.find_first_of(',', start))
-	{
-		std::string token(filt, start, end - start + 1);
-		if (comp.find(token) != -1)
-			return SOFTWARE_IS_COMPATIBLE;
-	}
-	return SOFTWARE_NOT_COMPATIBLE;
-}
-
 
 //-------------------------------------------------
 //  find_mountable_image - find an image interface

--- a/src/emu/softlist_dev.h
+++ b/src/emu/softlist_dev.h
@@ -31,14 +31,6 @@ enum softlist_type
 	SOFTWARE_LIST_COMPATIBLE_SYSTEM
 };
 
-enum software_compatibility
-{
-	SOFTWARE_IS_COMPATIBLE,
-	SOFTWARE_IS_INCOMPATIBLE,
-	SOFTWARE_NOT_COMPATIBLE
-};
-
-
 //**************************************************************************
 //  MACROS
 //**************************************************************************
@@ -154,7 +146,6 @@ public:
 	const software_info *find(const std::string &look_for);
 	void find_approx_matches(const std::string &name, int matches, const software_info **list, const char *interface);
 	void release();
-	software_compatibility is_compatible(const software_part &part) const;
 
 	// static helpers
 	static software_list_device *find_by_name(const machine_config &mconfig, const std::string &name);

--- a/src/frontend/mame/ui/imgcntrl.cpp
+++ b/src/frontend/mame/ui/imgcntrl.cpp
@@ -195,7 +195,7 @@ void menu_control_device_image::handle()
 
 	case START_OTHER_PART:
 		m_submenu_result.swparts = menu_software_parts::result::INVALID;
-		menu::stack_push<menu_software_parts>(ui(), container(), m_swi, m_swp->interface().c_str(), &m_swp, true, m_submenu_result.swparts);
+		menu::stack_push<menu_software_parts>(ui(), container(), m_sld, m_swi, m_swp->interface().c_str(), &m_swp, true, m_submenu_result.swparts);
 		m_state = SELECT_OTHER_PART;
 		break;
 
@@ -218,7 +218,7 @@ void menu_control_device_image::handle()
 		{
 			m_submenu_result.swparts = menu_software_parts::result::INVALID;
 			m_swp = nullptr;
-			menu::stack_push<menu_software_parts>(ui(), container(), m_swi, m_image.image_interface(), &m_swp, false, m_submenu_result.swparts);
+			menu::stack_push<menu_software_parts>(ui(), container(), m_sld, m_swi, m_image.image_interface(), &m_swp, false, m_submenu_result.swparts);
 			m_state = SELECT_ONE_PART;
 		}
 		else

--- a/src/frontend/mame/ui/imgcntrl.cpp
+++ b/src/frontend/mame/ui/imgcntrl.cpp
@@ -195,7 +195,7 @@ void menu_control_device_image::handle()
 
 	case START_OTHER_PART:
 		m_submenu_result.swparts = menu_software_parts::result::INVALID;
-		menu::stack_push<menu_software_parts>(ui(), container(), m_sld, m_swi, m_swp->interface().c_str(), &m_swp, true, m_submenu_result.swparts);
+		menu::stack_push<menu_software_parts>(ui(), container(), m_swi, m_swp->interface().c_str(), m_sld->filter(), &m_swp, true, m_submenu_result.swparts);
 		m_state = SELECT_OTHER_PART;
 		break;
 
@@ -218,7 +218,7 @@ void menu_control_device_image::handle()
 		{
 			m_submenu_result.swparts = menu_software_parts::result::INVALID;
 			m_swp = nullptr;
-			menu::stack_push<menu_software_parts>(ui(), container(), m_sld, m_swi, m_image.image_interface(), &m_swp, false, m_submenu_result.swparts);
+			menu::stack_push<menu_software_parts>(ui(), container(), m_swi, m_image.image_interface(), m_sld->filter(), &m_swp, false, m_submenu_result.swparts);
 			m_state = SELECT_ONE_PART;
 		}
 		else

--- a/src/frontend/mame/ui/selsoft.cpp
+++ b/src/frontend/mame/ui/selsoft.cpp
@@ -317,7 +317,7 @@ void menu_select_software::build_software_list()
 		for (const software_info &swinfo : swlist.get_info())
 		{
 			const software_part &part = swinfo.parts().front();
-			if (swlist.is_compatible(part) == SOFTWARE_IS_COMPATIBLE)
+			if (part.is_compatible(swlist.filter()) == SOFTWARE_IS_COMPATIBLE)
 			{
 				const char *instance_name = nullptr;
 				const char *type_name = nullptr;

--- a/src/frontend/mame/ui/swlist.cpp
+++ b/src/frontend/mame/ui/swlist.cpp
@@ -49,10 +49,11 @@ static bool is_valid_softlist_part_char(char32_t ch)
 //  ctor
 //-------------------------------------------------
 
-menu_software_parts::menu_software_parts(mame_ui_manager &mui, render_container &container, const software_info *info, const char *interface, const software_part **part, bool other_opt, result &result)
+menu_software_parts::menu_software_parts(mame_ui_manager &mui, render_container &container, const software_list_device *swlist, const software_info *info, const char *interface, const software_part **part, bool other_opt, result &result)
 	: menu(mui, container),
 		m_result(result)
 {
+	m_swlist = swlist;
 	m_info = info;
 	m_interface = interface;
 	m_selected_part = part;
@@ -96,7 +97,7 @@ void menu_software_parts::populate(float &customtop, float &custombottom)
 
 	for (const software_part &swpart : m_info->parts())
 	{
-		if (swpart.matches_interface(m_interface))
+		if (swpart.matches_interface(m_interface) && swpart.is_compatible(m_swlist->filter()) == SOFTWARE_IS_COMPATIBLE)
 		{
 			software_part_menu_entry *entry = (software_part_menu_entry *) m_pool_alloc(sizeof(*entry));
 			// check if the available parts have specific part_id to be displayed (e.g. "Map Disc", "Bonus Disc", etc.)
@@ -189,7 +190,7 @@ void menu_software_list::append_software_entry(const software_info &swinfo)
 	// check if at least one of the parts has the correct interface and add a menu entry only in this case
 	for (const software_part &swpart : swinfo.parts())
 	{
-		if (swpart.matches_interface(m_interface) && m_swlist->is_compatible(swpart) == SOFTWARE_IS_COMPATIBLE)
+		if (swpart.matches_interface(m_interface) && swpart.is_compatible(m_swlist->filter()) == SOFTWARE_IS_COMPATIBLE)
 		{
 			entry_updated = true;
 			entry.short_name.assign(swinfo.shortname());

--- a/src/frontend/mame/ui/swlist.cpp
+++ b/src/frontend/mame/ui/swlist.cpp
@@ -49,13 +49,13 @@ static bool is_valid_softlist_part_char(char32_t ch)
 //  ctor
 //-------------------------------------------------
 
-menu_software_parts::menu_software_parts(mame_ui_manager &mui, render_container &container, const software_list_device *swlist, const software_info *info, const char *interface, const software_part **part, bool other_opt, result &result)
+menu_software_parts::menu_software_parts(mame_ui_manager &mui, render_container &container, const software_info *info, const char *interface, const char *filter, const software_part **part, bool other_opt, result &result)
 	: menu(mui, container),
 		m_result(result)
 {
-	m_swlist = swlist;
 	m_info = info;
 	m_interface = interface;
+	m_filter = filter;
 	m_selected_part = part;
 	m_other_opt = other_opt;
 }
@@ -97,7 +97,7 @@ void menu_software_parts::populate(float &customtop, float &custombottom)
 
 	for (const software_part &swpart : m_info->parts())
 	{
-		if (swpart.matches_interface(m_interface) && swpart.is_compatible(m_swlist->filter()) == SOFTWARE_IS_COMPATIBLE)
+		if (swpart.matches_interface(m_interface) && swpart.is_compatible(m_filter) == SOFTWARE_IS_COMPATIBLE)
 		{
 			software_part_menu_entry *entry = (software_part_menu_entry *) m_pool_alloc(sizeof(*entry));
 			// check if the available parts have specific part_id to be displayed (e.g. "Map Disc", "Bonus Disc", etc.)

--- a/src/frontend/mame/ui/swlist.h
+++ b/src/frontend/mame/ui/swlist.h
@@ -29,7 +29,7 @@ public:
 		ENTRY
 	};
 
-	menu_software_parts(mame_ui_manager &mui, render_container &container, const software_list_device *swlist, const software_info *info, const char *interface, const software_part **part, bool other_opt, result &result);
+	menu_software_parts(mame_ui_manager &mui, render_container &container, const software_info *info, const char *interface, const char *filter, const software_part **part, bool other_opt, result &result);
 	virtual ~menu_software_parts() override;
 
 private:
@@ -42,9 +42,9 @@ private:
 	virtual void handle() override;
 
 	// variables
-	const software_list_device *m_swlist;
 	const software_info *   m_info;
 	const char *            m_interface;
+	const char *			m_filter;
 	const software_part **  m_selected_part;
 	bool                    m_other_opt;
 	result &                m_result;

--- a/src/frontend/mame/ui/swlist.h
+++ b/src/frontend/mame/ui/swlist.h
@@ -29,7 +29,7 @@ public:
 		ENTRY
 	};
 
-	menu_software_parts(mame_ui_manager &mui, render_container &container, const software_info *info, const char *interface, const software_part **part, bool other_opt, result &result);
+	menu_software_parts(mame_ui_manager &mui, render_container &container, const software_list_device *swlist, const software_info *info, const char *interface, const software_part **part, bool other_opt, result &result);
 	virtual ~menu_software_parts() override;
 
 private:
@@ -42,6 +42,7 @@ private:
 	virtual void handle() override;
 
 	// variables
+	const software_list_device *m_swlist;
 	const software_info *   m_info;
 	const char *            m_interface;
 	const software_part **  m_selected_part;

--- a/src/osd/modules/debugger/win/consolewininfo.cpp
+++ b/src/osd/modules/debugger/win/consolewininfo.cpp
@@ -548,20 +548,22 @@ bool consolewin_info::get_softlist_info(device_image_interface *img)
 	{
 		for (const software_info &swinfo : swlist.get_info())
 		{
-			const software_part &part = swinfo.parts().front();
-			if (part.is_compatible(swlist.filter()) == SOFTWARE_IS_COMPATIBLE)
+			for (const software_part &part : swinfo.parts())
 			{
-				for (device_image_interface &image : image_interface_iterator(machine().root_device()))
+				if (part.is_compatible(swlist.filter()) == SOFTWARE_IS_COMPATIBLE)
 				{
-					if (!image.user_loadable())
-						continue;
-					if (!has_software && (opt_name == image.instance_name()))
+					for (device_image_interface &image : image_interface_iterator(machine().root_device()))
 					{
-						const char *interface = image.image_interface();
-						if (interface && part.matches_interface(interface))
+						if (!image.user_loadable())
+							continue;
+						if (!has_software && (opt_name == image.instance_name()))
 						{
-							sl_dir = "\\" + swlist.list_name();
-							has_software = true;
+							const char *interface = image.image_interface();
+							if (interface && part.matches_interface(interface))
+							{
+								sl_dir = "\\" + swlist.list_name();
+								has_software = true;
+							}
 						}
 					}
 				}

--- a/src/osd/modules/debugger/win/consolewininfo.cpp
+++ b/src/osd/modules/debugger/win/consolewininfo.cpp
@@ -549,7 +549,7 @@ bool consolewin_info::get_softlist_info(device_image_interface *img)
 		for (const software_info &swinfo : swlist.get_info())
 		{
 			const software_part &part = swinfo.parts().front();
-			if (swlist.is_compatible(part) == SOFTWARE_IS_COMPATIBLE)
+			if (part.is_compatible(swlist.filter()) == SOFTWARE_IS_COMPATIBLE)
 			{
 				for (device_image_interface &image : image_interface_iterator(machine().root_device()))
 				{


### PR DESCRIPTION
This PR is intended only to provoke some discussion/feedback, it's almost certainly not ready to be merged.

What
--
The general idea is to apply softlist compatibility checking at the individual part level, rather than at the software item level. The current implementation allows multiple parts under a single software item to have different compatibility feature settings, but doesn't honour this when it comes to using the menu to select a new part from the menu. It also doesn't use the features to disambiguate the command line when multiple parts have the same name.

Why
--
The InterPro REBUILD and DIAG software products essentially consist of a bunch of floppy images which are intended to be written to disk and used to either reinstall the operating system, or to run system diagnostics respectively. There are multiple alternative sets of these images, which are intended to be used with different system models in the family. I wanted to achieve two things:

1. Show only compatible software parts under the in-emulation menu; and
2. Have MAME disambiguate between multiple parts using the same name, when the compatibility features vary.

To clarify the latter, using interpro.xml as the example softlist, I want to be able to do something like this:

    mame ip2000 -flop1 interpro:rebuild:boot
and

    mame ip2400 -flop1 interpro:rebuild:boot

and have MAME figure out which of several "boot" parts should be selected based on the compatibility filter. Currently, MAME simply selects the first matching part (and displays a warning if it's not compatible), so the only solution is to uniquely name each part, or duplicate and uniquely name each software item. To my way of thinking, this is inconsistent with the way the roughly equivalent interface checking/filtering is done, and with the fact that the compatibility feature is tied to each part (or explicitly shared between parts).

Changes
--
* moved `is_compatible()` from `software_list_device` to `software_part`
* modified `device_image_interface::find_software_item()` to apply the `software_list_device` filter
* modified `menu_software_parts::populate()` to apply the `software_list_device` filter
* modified `menu_select_software::build_software_list()` and `consolewin_info::get_softlist_info()` to check all parts for compatibility instead of just the first

Thoughts
--
1. Passing the softlist filter into the software list in order to find an appropriate part does not seem to be especially worse than the existing logic which does very similar things with the interface, although it does bother me that the menu and image loading classes seem to be doing some of the things I would actually expect the software list class(es) to be doing.
2. I'm not sure of the general "incompatibility" policy we're trying to achieve - do we want to allow users to override/force the use of incompatible software, or are we trying to protect them from themselves (when the compatibility features have been set, which implies some degree of attention to detail)?
3. This doesn't improve the scenario where media for two incompatible systems is bundled into a single software package (e.g. both Windows & Mac floppy disks in a single box), but I don't think it makes it any worse, and solving this probably requires a rethink of the approach to compatibility in general (that is, making compatibility a first class feature, and tying it to real architectural features rather than this meta-data matching approach).
4. I'm almost certain I've overlooked some places impacted by this change, as I don't know this part of the code base very well; as I said at the beginning, I'm really just soliciting feedback at this point.

