### PR TITLE
i8275: handle invisible field attributes and "end of row - stop dma" …

### DIFF
--- a/src/devices/video/i8275.h
+++ b/src/devices/video/i8275.h
@@ -197,6 +197,7 @@ protected:
 	uint8_t m_fifo[2][16];
 	int m_buffer_idx;
 	int m_fifo_idx;
+	int m_dma_idx;
 	bool m_fifo_next;
 	int m_buffer_dma;
 


### PR DESCRIPTION
…special code better; honor Video Enable bit.

Fixes MT05764.  No visual change on mikromik, tim100, zorba, and radio86 clones.