### PR TITLE
i8275: fix thinko in previous commit; make Preset Counters command useful

### DIFF
--- a/src/devices/video/i8275.h
+++ b/src/devices/video/i8275.h
@@ -216,6 +216,7 @@ protected:
 	bool m_du;
 	bool m_dma_stop;
 	bool m_end_of_screen;
+	bool m_preset;
 
 	int m_cursor_blink;
 	int m_char_blink;


### PR DESCRIPTION
"Previous commit" is https://github.com/mamedev/mame/commit/f652d21e167265bded620fab397f142d18bd7b45 

Fixes visuals in tim100, hp64k.   No change to dwarfd, mikromik, rc702, zorba, and radio86 clones. 

rt1715, sm1800 and ipds don't actually hook up the 8275 to DMAC (no MCFG_I8275_DRQ_CALLBACK defined) so nothing should change for them either way.

I could not test trs80dt1.