### PR TITLE
i960.cpp: support for burst mode stalling save and restore [Angelo Salese]

### DIFF
--- a/src/devices/cpu/i960/i960.h
+++ b/src/devices/cpu/i960/i960.h
@@ -73,8 +73,12 @@ public:
 	// on the real hardware (e.g. Model 2's interrupt control registers)
 	void i960_noburst() { m_bursting = 0; }
 
-	void i960_stall() { m_IP = m_PIP; }
-
+	void i960_stall() 
+	{ 
+		m_stalled = true;
+		m_IP = m_PIP;
+	}
+	
 protected:
 	enum { I960_RCACHE_SIZE = 4 };
 
@@ -100,6 +104,16 @@ protected:
 	virtual util::disasm_interface *create_disassembler() override;
 
 private:
+	void i960_stall_save(uint32_t t1, uint32_t t2, int index, int size, bool disp);
+
+	struct {
+		uint32_t t1,t2;
+		int index,size;
+		bool special;
+		bool disp;
+	}m_stall;
+	bool m_stalled;
+
 	address_space_config m_program_config;
 
 	uint32_t m_r[0x20];
@@ -161,6 +175,7 @@ private:
 	void fxx(uint32_t opcode, int mask);
 	void test(uint32_t opcode, int mask);
 	void execute_op(uint32_t opcode);
+	void execute_stall_op(uint32_t opcode);
 	void take_interrupt(int vector, int lvl);
 	void check_irqs();
 	void do_call(uint32_t adr, int type, uint32_t stack);

--- a/src/devices/cpu/i960/i960.h
+++ b/src/devices/cpu/i960/i960.h
@@ -104,14 +104,13 @@ protected:
 	virtual util::disasm_interface *create_disassembler() override;
 
 private:
-	void i960_stall_save(uint32_t t1, uint32_t t2, int index, int size, bool disp);
+	void burst_stall_save(uint32_t t1, uint32_t t2, int index, int size);
 
 	struct {
 		uint32_t t1,t2;
 		int index,size;
-		bool special;
-		bool disp;
-	}m_stall;
+		bool burst_mode;
+	}m_stall_state;
 	bool m_stalled;
 
 	address_space_config m_program_config;
@@ -175,7 +174,7 @@ private:
 	void fxx(uint32_t opcode, int mask);
 	void test(uint32_t opcode, int mask);
 	void execute_op(uint32_t opcode);
-	void execute_stall_op(uint32_t opcode);
+	void execute_burst_stall_op(uint32_t opcode);
 	void take_interrupt(int vector, int lvl);
 	void check_irqs();
 	void do_call(uint32_t adr, int type, uint32_t stack);

--- a/src/mame/drivers/model2.cpp
+++ b/src/mame/drivers/model2.cpp
@@ -234,6 +234,8 @@ uint32_t model2_state::copro_fifoout_pop(address_space &space,uint32_t offset, u
 {
 	uint32_t r;
 
+	m_maincpu->i960_noburst();
+	
 	if (m_copro_fifoout_num == 0)
 	{
 		/* Reading from empty FIFO causes the i960 to enter wait state */
@@ -242,7 +244,7 @@ uint32_t model2_state::copro_fifoout_pop(address_space &space,uint32_t offset, u
 		/* spin the main cpu and let the TGP catch up */
 		// TODO: Daytona needs a much shorter spin time (like 25 usecs), but that breaks other games even moreso
 		// @seealso http://www.mameworld.info/ubbthreads/showflat.php?Cat=&Number=358069&page=&view=&sb=5&o=&vc=1
-		m_maincpu->spin_until_time(attotime::from_usec(100));
+		m_maincpu->spin_until_time(attotime::from_usec(25));
 
 		return 0;
 	}

--- a/src/mame/drivers/model2.cpp
+++ b/src/mame/drivers/model2.cpp
@@ -1980,6 +1980,15 @@ static INPUT_PORTS_START( skytargt )
 	MODEL2_PLAYER_INPUTS(2, BUTTON1, BUTTON2, BUTTON3, BUTTON4)
 INPUT_PORTS_END
 
+static INPUT_PORTS_START( dynabb )
+	PORT_INCLUDE(model2)
+
+	PORT_START("ANA0")
+	PORT_BIT(0xff, 0x00, IPT_PEDAL) PORT_SENSITIVITY(100) PORT_KEYDELTA(50) PORT_PLAYER(1) PORT_NAME("P1 Bat Swing")
+
+	PORT_START("ANA1")
+	PORT_BIT(0xff, 0x00, IPT_PEDAL2) PORT_SENSITIVITY(100) PORT_KEYDELTA(50) PORT_PLAYER(2) PORT_NAME("P2 Bat Swing")
+INPUT_PORTS_END
 
 TIMER_DEVICE_CALLBACK_MEMBER(model2_state::model2_interrupt)
 {
@@ -6065,8 +6074,8 @@ GAME( 1996, lastbrnxu, lastbrnx, model2b,      model2,  model2_state, 0,        
 GAME( 1996, lastbrnxj, lastbrnx, model2b,      model2,  model2_state, 0,        ROT0, "Sega",   "Last Bronx (Japan, Revision A)", MACHINE_NOT_WORKING|MACHINE_IMPERFECT_GRAPHICS )
 GAME( 1996, doa,              0, model2b_0229, model2,  model2_state, doa,      ROT0, "Sega",   "Dead or Alive (Model 2B, Revision B)", MACHINE_NOT_WORKING|MACHINE_IMPERFECT_GRAPHICS )
 GAME( 1996, sgt24h,           0, indy500,      srallyc, model2_state, sgt24h,   ROT0, "Jaleco", "Super GT 24h", MACHINE_NOT_WORKING|MACHINE_IMPERFECT_GRAPHICS )
-GAME( 1996, dynabb,           0, model2b,      model2,  model2_state, 0,        ROT0, "Sega",   "Dynamite Baseball", MACHINE_NOT_WORKING|MACHINE_IMPERFECT_GRAPHICS )
-GAME( 1997, dynabb97,         0, model2b,      model2,  model2_state, 0,        ROT0, "Sega",   "Dynamite Baseball 97 (Revision A)", MACHINE_NOT_WORKING|MACHINE_IMPERFECT_GRAPHICS )
+GAME( 1996, dynabb,           0, model2b,      dynabb,  model2_state, 0,        ROT0, "Sega",   "Dynamite Baseball", MACHINE_NOT_WORKING|MACHINE_IMPERFECT_GRAPHICS )
+GAME( 1997, dynabb97,         0, model2b,      dynabb,  model2_state, 0,        ROT0, "Sega",   "Dynamite Baseball 97 (Revision A)", MACHINE_NOT_WORKING|MACHINE_IMPERFECT_GRAPHICS )
 GAME( 1997, overrevb,   overrev, indy500,      srallyc, model2_state, 0,        ROT0, "Jaleco", "Over Rev (Model 2B, Revision B)", MACHINE_NOT_WORKING|MACHINE_IMPERFECT_GRAPHICS )
 GAME( 1997, zerogun,          0, model2b_5881, model2,  model2_state, zerogun,  ROT0, "Psikyo", "Zero Gunner (Export, Model 2B)", MACHINE_NOT_WORKING|MACHINE_IMPERFECT_GRAPHICS )
 GAME( 1997, zerogunj,   zerogun, model2b_5881, model2,  model2_state, zerogun,  ROT0, "Psikyo", "Zero Gunner (Japan, Model 2B)", MACHINE_NOT_WORKING|MACHINE_IMPERFECT_GRAPHICS )


### PR DESCRIPTION
* This fixes stalls in several Sega Model 2 games, these are Virtua Fighter 2, MotorRaid, Virtua Cop 2, Dynamite Cop, Dynamite Baseball, Dynamite Baseball '97, Fighting Vipers and Indy 500