### PR TITLE
st0016 : Add object finder m_rom instead memregion(":maincpu")

### DIFF
--- a/src/mame/drivers/jclub2.cpp
+++ b/src/mame/drivers/jclub2.cpp
@@ -117,7 +117,7 @@ class common_state : public driver_device
 public:
 	common_state(const machine_config &mconfig, device_type type, const char *tag) :
 		driver_device(mconfig, type, tag),
-		m_gamecpu(*this, "gamecpu"),
+		m_maincpu(*this, "maincpu"),
 		m_eeprom(*this, "eeprom"),
 		m_hopper1(*this, "hopper1"), m_hopper2(*this, "hopper2"),
 		m_palette(*this, "palette"),
@@ -137,7 +137,7 @@ public:
 	TIMER_DEVICE_CALLBACK_MEMBER(scanline_irq);
 
 protected:
-	required_device<cpu_device> m_gamecpu;
+	required_device<cpu_device> m_maincpu;
 	required_device<eeprom_serial_93cxx_device> m_eeprom;
 	required_device<ticket_dispenser_device> m_hopper1, m_hopper2;
 	required_device<palette_device> m_palette;
@@ -180,8 +180,13 @@ class jclub2o_state : public jclub2_state
 {
 public:
 	jclub2o_state(const machine_config &mconfig, device_type type, const char *tag) :
-		jclub2_state(mconfig, type, tag)
+		jclub2_state(mconfig, type, tag),
+		m_soundcpu(*this, "soundcpu", 0),
+		m_soundbank(*this, "soundbank", 0)
 	{ }
+	
+	required_device<cpu_device> m_soundcpu;
+	required_memory_bank m_soundbank;
 
 	DECLARE_WRITE32_MEMBER(eeprom_s29290_w);
 
@@ -199,6 +204,8 @@ public:
 	DECLARE_WRITE32_MEMBER(cmd1_word_w);
 	DECLARE_WRITE32_MEMBER(cmd2_word_w);
 	DECLARE_READ32_MEMBER(cmd_stat_word_r);
+	
+	DECLARE_DRIVER_INIT(jclub2o);
 
 	void jclub2o(machine_config &config);
 	void jclub2o_map(address_map &map);
@@ -623,7 +630,7 @@ ADDRESS_MAP_END
 // common rombank? should go in machine/st0016 with larger address space exposed?
 WRITE8_MEMBER(jclub2o_state::st0016_rom_bank_w)
 {
-	membank("bank1")->set_base(memregion("maincpu")->base() + (data* 0x4000));
+	m_soundbank->set_entry(data & 0x1f);
 }
 
 READ8_MEMBER(jclub2o_state::cmd1_r)
@@ -656,7 +663,7 @@ WRITE8_MEMBER(jclub2o_state::cmd2_w)
 
 ADDRESS_MAP_START(jclub2o_state::st0016_mem)
 	AM_RANGE(0x0000, 0x7fff) AM_ROM
-	AM_RANGE(0x8000, 0xbfff) AM_ROMBANK("bank1")
+	AM_RANGE(0x8000, 0xbfff) AM_ROMBANK("soundbank")
 	AM_RANGE(0xe800, 0xe8ff) AM_RAM
 	//AM_RANGE(0xe900, 0xe9ff) // sound - internal
 	//AM_RANGE(0xec00, 0xec1f) AM_READ(st0016_character_ram_r) AM_WRITE(st0016_character_ram_w)
@@ -1108,22 +1115,22 @@ TIMER_DEVICE_CALLBACK_MEMBER(common_state::scanline_irq)
 	int scanline = param;
 
 	if (scanline == 248)
-		m_gamecpu->set_input_line(5, HOLD_LINE);
+		m_maincpu->set_input_line(5, HOLD_LINE);
 
 	if (scanline == 0)
-		m_gamecpu->set_input_line(3, HOLD_LINE);
+		m_maincpu->set_input_line(3, HOLD_LINE);
 
 	if (scanline == 128)
-		m_gamecpu->set_input_line(4, HOLD_LINE);
+		m_maincpu->set_input_line(4, HOLD_LINE);
 }
 
 // Older hardware (ST-0020 + ST-0016)
 MACHINE_CONFIG_START(jclub2o_state::jclub2o)
-	MCFG_CPU_ADD("gamecpu", M68EC020, 12000000)
+	MCFG_CPU_ADD("maincpu", M68EC020, 12000000)
 	MCFG_CPU_PROGRAM_MAP(jclub2o_map)
 	MCFG_TIMER_DRIVER_ADD_SCANLINE("scantimer", common_state, scanline_irq, "screen", 0, 1)
 
-	MCFG_CPU_ADD("maincpu",ST0016_CPU, 8000000)
+	MCFG_CPU_ADD("soundcpu",ST0016_CPU, 8000000)
 	MCFG_CPU_PROGRAM_MAP(st0016_mem)
 	MCFG_CPU_IO_MAP(st0016_io)
 	MCFG_CPU_VBLANK_INT_DRIVER("screen", jclub2o_state, irq0_line_hold)
@@ -1158,7 +1165,7 @@ MACHINE_CONFIG_END
 
 // Newer hardware (ST-0032)
 MACHINE_CONFIG_START(jclub2_state::jclub2)
-	MCFG_CPU_ADD("gamecpu", M68EC020, 12000000)
+	MCFG_CPU_ADD("maincpu", M68EC020, 12000000)
 	MCFG_CPU_PROGRAM_MAP(jclub2_map)
 	MCFG_TIMER_DRIVER_ADD_SCANLINE("scantimer", common_state, scanline_irq, "screen", 0, 1)
 
@@ -1193,7 +1200,7 @@ MACHINE_CONFIG_END
 
 
 MACHINE_CONFIG_START(darkhors_state::darkhors)
-	MCFG_CPU_ADD("gamecpu", M68EC020, 12000000) // 36MHz/3 ??
+	MCFG_CPU_ADD("maincpu", M68EC020, 12000000) // 36MHz/3 ??
 	MCFG_CPU_PROGRAM_MAP(darkhors_map)
 	MCFG_TIMER_DRIVER_ADD_SCANLINE("scantimer", common_state, scanline_irq, "screen", 0, 1)
 
@@ -1270,14 +1277,13 @@ Provided to you by Belgium Dump Team Gerald (COY) on 18/01/2007.
 
 ***************************************************************************/
 
-// Not the main cpu, but "maincpu" is hardcoded in machine/st0016.cpp
 #define JCLUB2O_SOUND_ROMS \
-	ROM_REGION( 0x80000, "maincpu", 0 ) /* z80 core (used for sound) */ \
+	ROM_REGION( 0x80000, "soundcpu", 0 ) /* z80 core (used for sound) */ \
 	ROM_LOAD( "sx006-04.u87", 0x00000, 0x80000, CRC(a87adedd) SHA1(1cd5af2d03738fff2230b46241659179467c828c) )  /* SoundDriverV1.26 */
 
 ROM_START( jclub2v100 )
 	JCLUB2O_SOUND_ROMS
-	ROM_REGION( 0x280000, "gamecpu", 0 )
+	ROM_REGION( 0x280000, "maincpu", 0 )
 	ROM_LOAD16_WORD_SWAP( "sx006a-01.u26", 0x000000, 0x200000, CRC(55e249bc) SHA1(ed0f066ed17f047760b712cbbfba1a62d4b452ba) ) // v1.00 (1994 ' ' 100,  5 OCT. 1994)
 	ROM_FILL(                              0x200000, 0x080000, 0xff) // no upgrade rom
 
@@ -1288,7 +1294,7 @@ ROM_END
 
 ROM_START( jclub2v101 )
 	JCLUB2O_SOUND_ROMS
-	ROM_REGION( 0x280000, "gamecpu", 0 )
+	ROM_REGION( 0x280000, "maincpu", 0 )
 	ROM_LOAD16_WORD_SWAP( "sx006b-01.u26", 0x000000, 0x200000, CRC(f730dded) SHA1(efb966dcb98440a072d4825ef2788c85acdfd103) ) // v1.01 (1995 A 101, 20 FEB. 1995)
 	ROM_FILL(                              0x200000, 0x080000, 0xff) // no upgrade rom
 
@@ -1299,7 +1305,7 @@ ROM_END
 
 ROM_START( jclub2v110 )
 	JCLUB2O_SOUND_ROMS
-	ROM_REGION( 0x280000, "gamecpu", 0 )
+	ROM_REGION( 0x280000, "maincpu", 0 )
 	ROM_LOAD16_WORD_SWAP( "sx006b-01.u26", 0x000000, 0x200000, CRC(f730dded) SHA1(efb966dcb98440a072d4825ef2788c85acdfd103) ) // v1.01  (1995 A   101, 20 FEB. 1995)
 	ROM_LOAD16_WORD_SWAP( "jc2-110x.u27",  0x200000, 0x080000, CRC(03aa6882) SHA1(e0343bc77a19994ddafa614891663b40e1476332) ) // v1.10X (1996 2/3 110,  5 MAY. 1996)
 
@@ -1310,7 +1316,7 @@ ROM_END
 
 ROM_START( jclub2v112 )
 	JCLUB2O_SOUND_ROMS
-	ROM_REGION( 0x280000, "gamecpu", 0 )
+	ROM_REGION( 0x280000, "maincpu", 0 )
 	ROM_LOAD16_WORD_SWAP( "sx006b-01.u26", 0x000000, 0x200000, CRC(f730dded) SHA1(efb966dcb98440a072d4825ef2788c85acdfd103) ) // v1.01  (1995 A   101, 20 FEB. 1995)
 	ROM_LOAD16_WORD_SWAP( "jc2-112x.u27",  0x200000, 0x080000, CRC(e1ab93bd) SHA1(78b618b3f7819bd5351ebf949f328fec7795cec9) ) // v1.12X (1996 4/5 112,  3 JUN. 1996)
 
@@ -1321,7 +1327,7 @@ ROM_END
 
 ROM_START( jclub2v203 )
 	JCLUB2O_SOUND_ROMS
-	ROM_REGION( 0x280000, "gamecpu", 0 )
+	ROM_REGION( 0x280000, "maincpu", 0 )
 	ROM_LOAD16_WORD_SWAP( "sx006b-01.u26", 0x000000, 0x200000, CRC(f730dded) SHA1(efb966dcb98440a072d4825ef2788c85acdfd103) ) // v1.01  (1995 A 101, 20 FEB. 1995)
 	ROM_LOAD16_WORD_SWAP( "203x-rom1.u27", 0x200000, 0x080000, CRC(7446ed3e) SHA1(b0936e42549280e2965159270429c4fdacba114a) ) // v2.03X (1997 6 203, 26 MAR. 1997) Release Candidate
 
@@ -1376,7 +1382,7 @@ Provided to you by Belgium Dump Team Gerald (COY) on 18/01/2007.
 
 ROM_START( jclub2v200 )
 	JCLUB2_OTHER_ROMS
-	ROM_REGION( 0x280000, "gamecpu", 0 )
+	ROM_REGION( 0x280000, "maincpu", 0 )
 	ROM_LOAD16_WORD_SWAP( "m88-01.u38", 0x000000, 0x200000, CRC(84476b68) SHA1(1014d23d3cebbfa9aa3bfb90505529989a8eedfa) ) // v2.00 (1996 Z 200 , 27 SEP. 1996)
 	ROM_FILL(                           0x200000, 0x080000, 0xff) // no upgrade rom
 
@@ -1387,7 +1393,7 @@ ROM_END
 
 ROM_START( jclub2v201 )
 	JCLUB2_OTHER_ROMS
-	ROM_REGION( 0x280000, "gamecpu", 0 )
+	ROM_REGION( 0x280000, "maincpu", 0 )
 	ROM_LOAD16_WORD_SWAP( "m88-01.u38", 0x000000, 0x200000, CRC(84476b68) SHA1(1014d23d3cebbfa9aa3bfb90505529989a8eedfa) ) // v2.00  (1996 Z 200 , 27 SEP. 1996)
 	ROM_LOAD16_WORD_SWAP( "z201x.u39",  0x200000, 0x080000, CRC(1fb79c16) SHA1(c8914f7dfc17c412f6ca756f8eb6d6a35e3b6214) ) // v2.01X (1996 Z 201 , 20 NOV. 1996)
 
@@ -1398,7 +1404,7 @@ ROM_END
 
 ROM_START( jclub2v204 )
 	JCLUB2_OTHER_ROMS
-	ROM_REGION( 0x280000, "gamecpu", 0 )
+	ROM_REGION( 0x280000, "maincpu", 0 )
 	ROM_LOAD16_WORD_SWAP( "m88-01a.u38", 0x000000, 0x200000, CRC(c1243e1c) SHA1(2a5857738b8950daf77ddaa8304b765f809f8241) ) // v2.04 (1997 Z 2040, 30 APR. 1997)
 	ROM_FILL(                            0x200000, 0x080000, 0xff) // no upgrade rom
 
@@ -1409,7 +1415,7 @@ ROM_END
 
 ROM_START( jclub2v205 )
 	JCLUB2_OTHER_ROMS
-	ROM_REGION( 0x280000, "gamecpu", 0 )
+	ROM_REGION( 0x280000, "maincpu", 0 )
 	ROM_LOAD16_WORD_SWAP( "m88-01b.u38", 0x000000, 0x200000, CRC(f1054c69) SHA1(be6d92653f0d3cc0a36a2ff0798043f4a95439bc) ) // v2.05 (1997 Z 2050, 21 JUL. 1997)
 	ROM_FILL(                            0x200000, 0x080000, 0xff) // no upgrade rom
 
@@ -1420,7 +1426,7 @@ ROM_END
 
 ROM_START( jclub2v220 )
 	JCLUB2_OTHER_ROMS
-	ROM_REGION( 0x280000, "gamecpu", ROMREGION_ERASEFF )
+	ROM_REGION( 0x280000, "maincpu", ROMREGION_ERASEFF )
 	ROM_LOAD16_WORD_SWAP( "m88-01b.u38", 0x000000, 0x200000, CRC(f1054c69) SHA1(be6d92653f0d3cc0a36a2ff0798043f4a95439bc) ) // v2.05  (1997 Z 2050, 21 JUL. 1997)
 	ROM_LOAD16_WORD_SWAP( "m88-03d.u39", 0x200000, 0x080000, CRC(723dd22b) SHA1(0ca622e0dd315f29e72dd9b82fb419d306ec5df8) ) // v2.20X (1997 Z 2201, 14 APR. 1998)
 
@@ -1466,7 +1472,7 @@ A bootleg of Jockey Club II on inferior hardware
 ***************************************************************************/
 
 ROM_START( darkhors )
-	ROM_REGION( 0x100000, "gamecpu", 0 ) // 68EC020 code
+	ROM_REGION( 0x100000, "maincpu", 0 ) // 68EC020 code
 	ROM_LOAD32_WORD_SWAP( "prg2", 0x00000, 0x80000, CRC(f2ec5818) SHA1(326937a331496880f517f41b0b8ab54e55fd7af7) ) // 27 JUN. 1997
 	ROM_LOAD32_WORD_SWAP( "prg1", 0x00002, 0x80000, CRC(b80f8f59) SHA1(abc26dd8b36da0d510978364febe385f69fb317f) )
 
@@ -1495,6 +1501,11 @@ ROM_END
 
 ***************************************************************************/
 
+DRIVER_INIT_MEMBER(jclub2o_state,jclub2o)
+{
+	m_soundbank->configure_entries(0, 32, memregion("soundcpu")->base(), 0x4000);
+}
+
 DRIVER_INIT_MEMBER(darkhors_state,darkhors)
 {
 	// the dumped eeprom bytes are in a different order to how MAME expects them to be!?
@@ -1515,11 +1526,11 @@ DRIVER_INIT_MEMBER(darkhors_state,darkhors)
 
 
 // Older hardware (ST-0020 + ST-0016)
-GAME( 1994, jclub2v100, jclub2v112, jclub2o,  jclub2v100, jclub2o_state,  0,        ROT0, "Seta",    "Jockey Club II (v1.00, older hardware)",                MACHINE_IMPERFECT_GRAPHICS )
-GAME( 1995, jclub2v101, jclub2v112, jclub2o,  jclub2v100, jclub2o_state,  0,        ROT0, "Seta",    "Jockey Club II (v1.01, older hardware)",                MACHINE_IMPERFECT_GRAPHICS )
-GAME( 1996, jclub2v110, jclub2v112, jclub2o,  jclub2v100, jclub2o_state,  0,        ROT0, "Seta",    "Jockey Club II (v1.10X, older hardware)",               MACHINE_IMPERFECT_GRAPHICS )
-GAME( 1996, jclub2v112, 0,          jclub2o,  jclub2v112, jclub2o_state,  0,        ROT0, "Seta",    "Jockey Club II (v1.12X, older hardware)",               MACHINE_IMPERFECT_GRAPHICS )
-GAME( 1997, jclub2v203, jclub2v112, jclub2o,  jclub2v112, jclub2o_state,  0,        ROT0, "Seta",    "Jockey Club II (v2.03X RC, older hardware, prototype)", MACHINE_IMPERFECT_GRAPHICS )
+GAME( 1994, jclub2v100, jclub2v112, jclub2o,  jclub2v100, jclub2o_state,  jclub2o,  ROT0, "Seta",    "Jockey Club II (v1.00, older hardware)",                MACHINE_IMPERFECT_GRAPHICS )
+GAME( 1995, jclub2v101, jclub2v112, jclub2o,  jclub2v100, jclub2o_state,  jclub2o,  ROT0, "Seta",    "Jockey Club II (v1.01, older hardware)",                MACHINE_IMPERFECT_GRAPHICS )
+GAME( 1996, jclub2v110, jclub2v112, jclub2o,  jclub2v100, jclub2o_state,  jclub2o,  ROT0, "Seta",    "Jockey Club II (v1.10X, older hardware)",               MACHINE_IMPERFECT_GRAPHICS )
+GAME( 1996, jclub2v112, 0,          jclub2o,  jclub2v112, jclub2o_state,  jclub2o,  ROT0, "Seta",    "Jockey Club II (v1.12X, older hardware)",               MACHINE_IMPERFECT_GRAPHICS )
+GAME( 1997, jclub2v203, jclub2v112, jclub2o,  jclub2v112, jclub2o_state,  jclub2o,  ROT0, "Seta",    "Jockey Club II (v2.03X RC, older hardware, prototype)", MACHINE_IMPERFECT_GRAPHICS )
 // Newer hardware (ST-0032)
 GAME( 1996, jclub2v200, jclub2v112, jclub2,   jclub2v112, jclub2_state,   0,        ROT0, "Seta",    "Jockey Club II (v2.00, newer hardware)",                MACHINE_IMPERFECT_GRAPHICS | MACHINE_NO_SOUND )
 GAME( 1996, jclub2v201, jclub2v112, jclub2,   jclub2v112, jclub2_state,   0,        ROT0, "Seta",    "Jockey Club II (v2.01X, newer hardware)",               MACHINE_IMPERFECT_GRAPHICS | MACHINE_NO_SOUND )

--- a/src/mame/drivers/macs.cpp
+++ b/src/mame/drivers/macs.cpp
@@ -72,7 +72,9 @@ public:
 			m_ram2(*this, "ram2"),
 			m_maincpu(*this,"maincpu"),
 			m_cart1(*this, "slot_a"),
-			m_cart2(*this, "slot_b")
+			m_cart2(*this, "slot_b"),
+			m_rombank(*this, "rombank%u", 1),
+			m_rambank(*this, "rambank%u", 1)
 			{ }
 
 	uint8_t m_mux_data;
@@ -97,6 +99,9 @@ public:
 	optional_device<st0016_cpu_device> m_maincpu;
 	optional_device<generic_slot_device> m_cart1;
 	optional_device<generic_slot_device> m_cart2;
+	
+	required_memory_bank_array<2> m_rombank;
+	required_memory_bank_array<2> m_rambank;
 
 	void macs(machine_config &config);
 	void macs_io(address_map &map);
@@ -106,8 +111,8 @@ public:
 
 
 ADDRESS_MAP_START(macs_state::macs_mem)
-	AM_RANGE(0x0000, 0x7fff) AM_ROMBANK("bank4")
-	AM_RANGE(0x8000, 0xbfff) AM_ROMBANK("bank1")
+	AM_RANGE(0x0000, 0x7fff) AM_ROMBANK("rombank1")
+	AM_RANGE(0x8000, 0xbfff) AM_ROMBANK("rombank2")
 	//AM_RANGE(0xc000, 0xcfff) AM_READ(st0016_sprite_ram_r) AM_WRITE(st0016_sprite_ram_w)
 	//AM_RANGE(0xd000, 0xdfff) AM_READ(st0016_sprite2_ram_r) AM_WRITE(st0016_sprite2_ram_w)
 	AM_RANGE(0xe000, 0xe7ff) AM_RAM /* work ram ? */
@@ -115,13 +120,13 @@ ADDRESS_MAP_START(macs_state::macs_mem)
 	//AM_RANGE(0xe900, 0xe9ff) // sound - internal
 	//AM_RANGE(0xea00, 0xebff) AM_READ(st0016_palette_ram_r) AM_WRITE(st0016_palette_ram_w)
 	//AM_RANGE(0xec00, 0xec1f) AM_READ(st0016_character_ram_r) AM_WRITE(st0016_character_ram_w)
-	AM_RANGE(0xf000, 0xf7ff) AM_RAMBANK("bank3") /* common /backup ram ?*/
-	AM_RANGE(0xf800, 0xffff) AM_RAMBANK("bank2") /* common /backup ram ?*/
+	AM_RANGE(0xf000, 0xf7ff) AM_RAMBANK("rambank1") /* common /backup ram ?*/
+	AM_RANGE(0xf800, 0xffff) AM_RAMBANK("rambank2") /* common /backup ram ?*/
 ADDRESS_MAP_END
 
 WRITE8_MEMBER(macs_state::rambank_w)
 {
-	membank("bank3")->set_entry(2 + (data & 1));
+	m_rambank[0]->set_entry(2 + (data & 1));
 }
 
 READ8_MEMBER(macs_state::macs_input_r)
@@ -159,7 +164,7 @@ READ8_MEMBER(macs_state::macs_input_r)
 
 WRITE8_MEMBER(macs_state::macs_rom_bank_w)
 {
-	membank("bank1")->set_entry(m_cart_bank * 0x100 + data);
+	m_rombank[1]->set_entry(m_cart_bank * 0x100 + data);
 }
 
 WRITE8_MEMBER(macs_state::macs_output_w)
@@ -178,13 +183,13 @@ WRITE8_MEMBER(macs_state::macs_output_w)
 			/* FIXME: dunno if this RAM bank is right, DASM tracking made on the POST
 			    screens indicates that there's just one RAM bank, but then MACS2 games
 			    locks up. */
-			membank("bank3")->set_entry(BIT(data, 5));
+			m_rambank[0]->set_entry(BIT(data, 5));
 
 			m_cart_bank = (data & 0xc) >> 2;
-			membank("bank4")->set_entry(m_cart_bank * 0x100);
+			m_rombank[0]->set_entry(m_cart_bank * 0x100);
 		}
 
-		membank("bank2")->set_entry(BIT(data, 5));
+		m_rambank[1]->set_entry(BIT(data, 5));
 		break;
 		case 2: m_mux_data = data; break;
 
@@ -649,21 +654,21 @@ static const uint8_t ramdata[160]=
 
 MACHINE_START_MEMBER(macs_state,macs)
 {
-	membank("bank1")->configure_entries(0  , 256, memregion("maincpu")->base(), 0x4000);
-	membank("bank1")->configure_entries(256, 256, m_cart1->get_rom_base(), 0x4000);
-	membank("bank1")->configure_entries(512, 256, m_cart2->get_rom_base(), 0x4000);
-	membank("bank1")->set_entry(0);
+	m_rombank[0]->configure_entries(0  , 256, memregion("maincpu")->base(), 0x4000);
+	m_rombank[0]->configure_entries(256, 256, m_cart1->get_rom_base(), 0x4000);
+	m_rombank[0]->configure_entries(512, 256, m_cart2->get_rom_base(), 0x4000);
+	m_rombank[0]->set_entry(0);
 
-	membank("bank2")->configure_entries(0, 2, m_ram1.get() + 0x2000, 0x800);
-	membank("bank2")->set_entry(0);
+	m_rombank[1]->configure_entries(0  , 256, memregion("maincpu")->base(), 0x4000);
+	m_rombank[1]->configure_entries(256, 256, m_cart1->get_rom_base(), 0x4000);
+	m_rombank[1]->configure_entries(512, 256, m_cart2->get_rom_base(), 0x4000);
+	m_rombank[1]->set_entry(0);
 
-	membank("bank3")->configure_entries(0, 4, m_ram1.get(), 0x800);
-	membank("bank3")->set_entry(2);
+	m_rambank[0]->configure_entries(0, 4, m_ram1.get(), 0x800);
+	m_rambank[0]->set_entry(2);
 
-	membank("bank4")->configure_entries(0  , 256, memregion("maincpu")->base(), 0x4000);
-	membank("bank4")->configure_entries(256, 256, m_cart1->get_rom_base(), 0x4000);
-	membank("bank4")->configure_entries(512, 256, m_cart2->get_rom_base(), 0x4000);
-	membank("bank4")->set_entry(0);
+	m_rambank[1]->configure_entries(0, 2, m_ram1.get() + 0x2000, 0x800);
+	m_rambank[1]->set_entry(0);
 }
 
 MACHINE_RESET_MEMBER(macs_state,macs)

--- a/src/mame/drivers/simple_st0016.cpp
+++ b/src/mame/drivers/simple_st0016.cpp
@@ -35,12 +35,12 @@ Dips verified for Neratte Chu (nratechu) from manual
 
 void st0016_state::machine_start()
 {
-	membank("bank1")->configure_entries(0, 256, memregion("maincpu")->base(), 0x4000);
+	m_mainbank->configure_entries(0, 256, memregion("maincpu")->base(), 0x4000);
 }
 
 ADDRESS_MAP_START(st0016_state::st0016_mem)
 	AM_RANGE(0x0000, 0x7fff) AM_ROM
-	AM_RANGE(0x8000, 0xbfff) AM_ROMBANK("bank1")
+	AM_RANGE(0x8000, 0xbfff) AM_ROMBANK("mainbank")
 	AM_RANGE(0xe000, 0xe7ff) AM_RAM
 	AM_RANGE(0xe800, 0xe87f) AM_RAM /* common ram */
 	AM_RANGE(0xf000, 0xffff) AM_RAM /* work ram */
@@ -83,7 +83,7 @@ WRITE8_MEMBER(st0016_state::mux_select_w)
 
 WRITE8_MEMBER(st0016_state::st0016_rom_bank_w)
 {
-	membank("bank1")->set_entry(data);
+	m_mainbank->set_entry(data);
 	// st0016_rom_bank = data;
 }
 

--- a/src/mame/drivers/speglsht.cpp
+++ b/src/mame/drivers/speglsht.cpp
@@ -108,26 +108,35 @@ Notes:
 #include "emu.h"
 #include "machine/st0016.h"
 #include "cpu/mips/r3000.h"
-
+#include <algorithm>
 
 class speglsht_state : public driver_device
 {
 public:
 	speglsht_state(const machine_config &mconfig, device_type type, const char *tag)
 		: driver_device(mconfig, type, tag),
+			m_palette(*this, "palette"),
+			m_maincpu(*this,"maincpu"),
+			m_subcpu(*this, "sub"),
 			m_shared(*this, "shared"),
 			m_framebuffer(*this, "framebuffer"),
 			m_cop_ram(*this, "cop_ram"),
-			m_palette(*this, "palette"),
-			m_maincpu(*this,"maincpu"),
-			m_subcpu(*this, "sub")
+			m_st0016_bank(*this, "st0016_bank")
 			{ }
+			
+	required_device<palette_device> m_palette;
+	required_device<st0016_cpu_device> m_maincpu;
+	required_device<cpu_device> m_subcpu;
 
 	required_shared_ptr<uint8_t> m_shared;
 	required_shared_ptr<uint32_t> m_framebuffer;
-	uint32_t m_videoreg;
-	std::unique_ptr<bitmap_ind16> m_bitmap;
 	required_shared_ptr<uint32_t> m_cop_ram;
+
+	required_memory_bank m_st0016_bank;
+
+	std::unique_ptr<bitmap_ind16> m_bitmap;
+	uint32_t m_videoreg;
+
 	DECLARE_READ32_MEMBER(shared_r);
 	DECLARE_WRITE32_MEMBER(shared_w);
 	DECLARE_WRITE32_MEMBER(videoreg_w);
@@ -139,9 +148,6 @@ public:
 	virtual void machine_start() override;
 	DECLARE_VIDEO_START(speglsht);
 	uint32_t screen_update_speglsht(screen_device &screen, bitmap_rgb32 &bitmap, const rectangle &cliprect);
-	required_device<palette_device> m_palette;
-	required_device<st0016_cpu_device> m_maincpu;
-	required_device<cpu_device> m_subcpu;
 
 	DECLARE_WRITE8_MEMBER(st0016_rom_bank_w);
 	void speglsht(machine_config &config);
@@ -153,7 +159,7 @@ public:
 
 ADDRESS_MAP_START(speglsht_state::st0016_mem)
 	AM_RANGE(0x0000, 0x7fff) AM_ROM
-	AM_RANGE(0x8000, 0xbfff) AM_ROMBANK("bank1")
+	AM_RANGE(0x8000, 0xbfff) AM_ROMBANK("st0016_bank")
 	//AM_RANGE(0xc000, 0xcfff) AM_READ(st0016_sprite_ram_r) AM_WRITE(st0016_sprite_ram_w)
 	//AM_RANGE(0xd000, 0xdfff) AM_READ(st0016_sprite2_ram_r) AM_WRITE(st0016_sprite2_ram_w)
 	AM_RANGE(0xe000, 0xe7ff) AM_RAM
@@ -166,13 +172,13 @@ ADDRESS_MAP_END
 
 void speglsht_state::machine_start()
 {
-	membank("bank1")->configure_entries(0, 256, memregion("maincpu")->base(), 0x4000);
+	m_st0016_bank->configure_entries(0, 256, memregion("maincpu")->base(), 0x4000);
 }
 
 // common rombank? should go in machine/st0016 with larger address space exposed?
 WRITE8_MEMBER(speglsht_state::st0016_rom_bank_w)
 {
-	membank("bank1")->set_entry(data);
+	m_st0016_bank->set_entry(data);
 }
 
 
@@ -349,7 +355,7 @@ GFXDECODE_END
 
 MACHINE_RESET_MEMBER(speglsht_state,speglsht)
 {
-	memset(m_shared,0,0x1000);
+	std::fill(&m_shared[0],&m_shared[m_shared.bytes()],0);
 }
 
 VIDEO_START_MEMBER(speglsht_state,speglsht)

--- a/src/mame/drivers/srmp5.cpp
+++ b/src/mame/drivers/srmp5.cpp
@@ -36,8 +36,6 @@ This is not a bug (real machine behaves the same).
 */
 
 
-// this uploads a charset for the st0016, but never a palette, seems to be for sound only?
-
 #include "emu.h"
 #include "machine/st0016.h"
 #include "cpu/mips/r3000.h"
@@ -70,19 +68,22 @@ public:
 		: driver_device(mconfig, type, tag)
 		, m_gfxdecode(*this, "gfxdecode")
 		, m_palette(*this, "palette")
-		, m_maincpu(*this,"maincpu")
-		, m_subcpu(*this, "sub")
+		, m_maincpu(*this, "maincpu")
+		, m_soundcpu(*this,"soundcpu")
 		, m_chrrom(*this, "chr")
+		, m_soundbank(*this, "soundbank")
 		, m_keys(*this, "KEY.%u", 0)
 		, m_chrbank(0)
 	{
 	}
 	required_device<gfxdecode_device> m_gfxdecode;
 	required_device<palette_device> m_palette;
-	required_device<st0016_cpu_device> m_maincpu;
-	required_device<cpu_device> m_subcpu;
+	required_device<cpu_device> m_maincpu;
+	required_device<st0016_cpu_device> m_soundcpu;
 
 	required_region_ptr<uint16_t> m_chrrom;
+
+	required_memory_bank m_soundbank;
 
 	required_ioport_array<4> m_keys;
 
@@ -98,7 +99,7 @@ public:
 
 	uint32_t m_vidregs[0x120 / 4];
 #ifdef DEBUG_CHAR
-	uint8_t m_tileduty[0x2000];
+	std::unique_ptr<uint8_t[]> m_tileduty;
 #endif
 	DECLARE_WRITE32_MEMBER(bank_w);
 	DECLARE_READ32_MEMBER(tileram_r);
@@ -247,7 +248,7 @@ uint32_t srmp5_state::screen_update_srmp5(screen_device &screen, bitmap_rgb32 &b
 
 void srmp5_state::machine_start()
 {
-	membank("bank1")->configure_entries(0, 256, memregion("maincpu")->base(), 0x4000);
+	m_soundbank->configure_entries(0, 256, memregion("soundcpu")->base(), 0x4000);
 
 	save_item(NAME(m_input_select));
 	save_item(NAME(m_cmd1));
@@ -256,6 +257,9 @@ void srmp5_state::machine_start()
 	save_item(NAME(m_chrbank));
 	save_pointer(NAME(m_tileram.get()), 0x100000/2);
 	save_pointer(NAME(m_sprram.get()), 0x80000/2);
+#ifdef DEBUG_CHAR
+	save_pointer(NAME(m_tileduty.get()), 0x2000);
+#endif
 	save_item(NAME(m_vidregs));
 }
 
@@ -354,7 +358,7 @@ WRITE32_MEMBER(srmp5_state::srmp5_vidregs_w)
 
 READ32_MEMBER(srmp5_state::irq_ack_clear)
 {
-	m_subcpu->set_input_line(R3000_IRQ4, CLEAR_LINE);
+	m_maincpu->set_input_line(R3000_IRQ4, CLEAR_LINE);
 	return 0;
 }
 
@@ -382,7 +386,7 @@ ADDRESS_MAP_START(srmp5_state::srmp5_mem)
 	AM_RANGE(0x0a180000, 0x0a18011f) AM_READWRITE(srmp5_vidregs_r, srmp5_vidregs_w)
 	AM_RANGE(0x0a180000, 0x0a180003) AM_READNOP // write 0x00000400
 	AM_RANGE(0x0a200000, 0x0a3fffff) AM_READWRITE(tileram_r, tileram_w)
-	AM_RANGE(0x0fc00000, 0x0fdfffff) AM_MIRROR(0x10000000) AM_ROM AM_REGION("sub", 0)
+	AM_RANGE(0x0fc00000, 0x0fdfffff) AM_MIRROR(0x10000000) AM_ROM AM_REGION("maincpu", 0)
 
 	AM_RANGE(0x1eff0000, 0x1eff001f) AM_WRITEONLY
 	AM_RANGE(0x1eff003c, 0x1eff003f) AM_READ(irq_ack_clear)
@@ -390,7 +394,7 @@ ADDRESS_MAP_END
 
 ADDRESS_MAP_START(srmp5_state::st0016_mem)
 	AM_RANGE(0x0000, 0x7fff) AM_ROM
-	AM_RANGE(0x8000, 0xbfff) AM_ROMBANK("bank1")
+	AM_RANGE(0x8000, 0xbfff) AM_ROMBANK("soundbank")
 	//AM_RANGE(0xe900, 0xe9ff) // sound - internal
 	//AM_RANGE(0xec00, 0xec1f) AM_READ(st0016_character_ram_r) AM_WRITE(st0016_character_ram_w)
 	AM_RANGE(0xf000, 0xffff) AM_RAM
@@ -415,7 +419,7 @@ READ8_MEMBER(srmp5_state::cmd_stat8_r)
 // common rombank? should go in machine/st0016 with larger address space exposed?
 WRITE8_MEMBER(srmp5_state::st0016_rom_bank_w)
 {
-	membank("bank1")->set_entry(data);
+	m_soundbank->set_entry(data);
 }
 
 
@@ -558,15 +562,15 @@ GFXDECODE_END
 MACHINE_CONFIG_START(srmp5_state::srmp5)
 
 	/* basic machine hardware */
-	MCFG_CPU_ADD("maincpu",ST0016_CPU,8000000)
-	MCFG_CPU_PROGRAM_MAP(st0016_mem)
-	MCFG_CPU_IO_MAP(st0016_io)
-	MCFG_CPU_VBLANK_INT_DRIVER("screen", srmp5_state,  irq0_line_hold)
-
-	MCFG_CPU_ADD("sub", R3051, 25000000)
+	MCFG_CPU_ADD("maincpu", R3051, 25000000)
 	MCFG_R3000_ENDIANNESS(ENDIANNESS_LITTLE)
 	MCFG_CPU_PROGRAM_MAP(srmp5_mem)
 	MCFG_CPU_VBLANK_INT_DRIVER("screen", srmp5_state,  irq4_line_assert)
+	
+	MCFG_CPU_ADD("soundcpu",ST0016_CPU,8000000)
+	MCFG_CPU_PROGRAM_MAP(st0016_mem)
+	MCFG_CPU_IO_MAP(st0016_io)
+	MCFG_CPU_VBLANK_INT_DRIVER("screen", srmp5_state,  irq0_line_hold)
 
 	MCFG_QUANTUM_TIME(attotime::from_hz(6000))
 
@@ -588,15 +592,15 @@ MACHINE_CONFIG_START(srmp5_state::srmp5)
 MACHINE_CONFIG_END
 
 ROM_START( srmp5 )
-	ROM_REGION( 0x400000, "maincpu", 0 )
-	ROM_LOAD( "sx008-08.bin",   0x000000, 0x200000,   CRC(d4ac54f4) SHA1(c3dc76cd71485796a0b6a960294ea96eae8c946e) )
-	ROM_LOAD( "sx008-09.bin",   0x200000, 0x200000,   CRC(5a3e6560) SHA1(92ea398f3c5e3035869f0ca5dfe7b05c90095318) )
-
-	ROM_REGION( 0x200000, "sub", 0 ) // "PRG00" - "PRG03"
+	ROM_REGION( 0x200000, "maincpu", 0 ) // "PRG00" - "PRG03"
 	ROM_LOAD32_BYTE( "sx008-11.bin",   0x00000, 0x80000,   CRC(ca15ff45) SHA1(5ee610e0bb835568c36898210a6f8394902d5b54) )
 	ROM_LOAD32_BYTE( "sx008-12.bin",   0x00001, 0x80000,   CRC(43e9bb98) SHA1(e46dd98d2e1babfa12ddf2fa9b31377e8691d3a1) )
 	ROM_LOAD32_BYTE( "sx008-13.bin",   0x00002, 0x80000,   CRC(0af475e8) SHA1(24cddffa0f8c81832ae8870823d772e3b7493194) )
 	ROM_LOAD32_BYTE( "sx008-14.bin",   0x00003, 0x80000,   CRC(b5c55120) SHA1(0a41351c9563b2c6a00709189a917757bd6e0a24) )
+	
+	ROM_REGION( 0x400000, "soundcpu", 0 ) // SoundDriverV1.26
+	ROM_LOAD( "sx008-08.bin",   0x000000, 0x200000,   CRC(d4ac54f4) SHA1(c3dc76cd71485796a0b6a960294ea96eae8c946e) )
+	ROM_LOAD( "sx008-09.bin",   0x200000, 0x200000,   CRC(5a3e6560) SHA1(92ea398f3c5e3035869f0ca5dfe7b05c90095318) )
 
 	ROM_REGION16_LE( 0x1000000, "chr",0) // "CHR00" - "CHR06"
 	ROM_LOAD( "sx008-01.bin",   0x000000, 0x200000,   CRC(82dabf48) SHA1(c53e9ed0056c431eab13ab362936c25d3cc5abba) )
@@ -614,12 +618,12 @@ ROM_END
 
 DRIVER_INIT_MEMBER(srmp5_state,srmp5)
 {
-	m_maincpu->set_st0016_game_flag(9);
+	m_soundcpu->set_st0016_game_flag(9);
 
 	m_tileram = std::make_unique<uint16_t[]>(0x100000/2);
 	m_sprram  = std::make_unique<uint16_t[]>(0x080000/2);
 #ifdef DEBUG_CHAR
-	memset(m_tileduty, 1, 0x2000);
+	m_tileduty= make_unique_clear<uint8_t[]>(0x2000);
 #endif
 }
 

--- a/src/mame/includes/simple_st0016.h
+++ b/src/mame/includes/simple_st0016.h
@@ -12,13 +12,19 @@ public:
 		: driver_device(mconfig, type, tag),
 		m_maincpu(*this,"maincpu"),
 		m_subcpu(*this, "sub"),
-		m_screen(*this, "screen")
+		m_screen(*this, "screen"),
+		m_mainbank(*this, "mainbank")
 	{ }
 
 	int mux_port;
 	// uint32_t m_st0016_rom_bank;
 
-	optional_device<st0016_cpu_device> m_maincpu;
+	required_device<st0016_cpu_device> m_maincpu;
+	optional_device<cpu_device> m_subcpu;
+	required_device<screen_device> m_screen;
+
+	required_memory_bank m_mainbank;
+
 	DECLARE_READ8_MEMBER(mux_r);
 	DECLARE_WRITE8_MEMBER(mux_select_w);
 	DECLARE_READ32_MEMBER(latch32_r);
@@ -35,8 +41,6 @@ public:
 	DECLARE_VIDEO_START(st0016);
 	uint32_t screen_update_st0016(screen_device &screen, bitmap_ind16 &bitmap, const rectangle &cliprect);
 	TIMER_DEVICE_CALLBACK_MEMBER(st0016_int);
-	optional_device<cpu_device> m_subcpu;
-	required_device<screen_device> m_screen;
 	void st0016(machine_config &config);
 	void renju(machine_config &config);
 	void mayjinsn(machine_config &config);

--- a/src/mame/machine/st0016.cpp
+++ b/src/mame/machine/st0016.cpp
@@ -42,6 +42,7 @@ st0016_cpu_device::st0016_cpu_device(const machine_config &mconfig, const char *
 		m_io_space_config("io", ENDIANNESS_LITTLE, 8, 16, 0, address_map_constructor(FUNC(st0016_cpu_device::st0016_cpu_internal_io_map), this)),
 		m_space_config("regs", ENDIANNESS_LITTLE, 8, 16, 0, address_map_constructor(FUNC(st0016_cpu_device::st0016_cpu_internal_map), this)),
 		m_screen(*this, ":screen"),
+		m_rom(*this, DEVICE_SELF),
 		m_game_flag(-1)
 {
 	for (auto & elem : st0016_vregs)
@@ -301,8 +302,8 @@ WRITE8_MEMBER(st0016_cpu_device::st0016_vregs_w)
 		uint32_t length=((st0016_vregs[0xa6]|(st0016_vregs[0xa7]<<8)|((st0016_vregs[0xa8]&0x1f)<<16))+1)<<1;
 
 
-		uint32_t srclen = (memregion(":maincpu")->bytes());
-		uint8_t *mem = memregion(":maincpu")->base();
+		uint32_t srclen = (m_rom->bytes());
+		uint8_t *mem = m_rom->base();
 
 		int xfer_offs = m_dma_offset;
 		if (!m_dma_offs_cb.isnull())

--- a/src/mame/machine/st0016.h
+++ b/src/mame/machine/st0016.h
@@ -96,6 +96,7 @@ protected:
 	virtual space_config_vector memory_space_config() const override;
 
 	required_device<screen_device> m_screen;
+	required_memory_region m_rom;
 
 private:
 	uint8_t m_dma_offset;


### PR DESCRIPTION
jclub2, srmp5: Accurate tags for what CPUs actually handling, configurated ST0016 ROM Bankswitching(jclub2)
macs, simple_st0016, speglsht : Minor cleanup bankswitching