### PR TITLE
ymz280b : Add device_rom_interface instead external memory handlers

### DIFF
--- a/src/devices/sound/ymz280b.cpp
+++ b/src/devices/sound/ymz280b.cpp
@@ -56,25 +56,6 @@ static constexpr int index_scale[8] = { 0x0e6, 0x0e6, 0x0e6, 0x0e6, 0x133, 0x199
 static int diff_lookup[16];
 
 
-uint8_t ymz280b_device::ymz280b_read_memory(uint32_t offset)
-{
-	if (m_ext_read_handler.isnull())
-	{
-		if (offset < m_mem_size)
-			return m_mem_base[offset];
-
-		/* 16MB chip limit (shouldn't happen) */
-		else if (offset > 0xffffff)
-			return m_mem_base[offset & 0xffffff];
-
-		else
-			return 0;
-	}
-	else
-		return m_ext_read_handler(offset);
-}
-
-
 void ymz280b_device::update_irq_state()
 {
 	int irq_bits = m_status_register & m_irq_mask;
@@ -198,7 +179,7 @@ int ymz280b_device::generate_adpcm(struct YMZ280BVoice *voice, int16_t *buffer, 
 		while (samples)
 		{
 			/* compute the new amplitude and update the current step */
-			val = ymz280b_read_memory(position / 2) >> ((~position & 1) << 2);
+			val = read_byte(position / 2) >> ((~position & 1) << 2);
 			signal += (step * diff_lookup[val & 15]) / 8;
 
 			/* clamp to the maximum */
@@ -235,7 +216,7 @@ int ymz280b_device::generate_adpcm(struct YMZ280BVoice *voice, int16_t *buffer, 
 		while (samples)
 		{
 			/* compute the new amplitude and update the current step */
-			val = ymz280b_read_memory(position / 2) >> ((~position & 1) << 2);
+			val = read_byte(position / 2) >> ((~position & 1) << 2);
 			signal += (step * diff_lookup[val & 15]) / 8;
 
 			/* clamp to the maximum */
@@ -308,7 +289,7 @@ int ymz280b_device::generate_pcm8(struct YMZ280BVoice *voice, int16_t *buffer, i
 		while (samples)
 		{
 			/* fetch the current value */
-			val = ymz280b_read_memory(position / 2);
+			val = read_byte(position / 2);
 
 			/* output to the buffer, scaling by the volume */
 			*buffer++ = (int8_t)val * 256;
@@ -331,7 +312,7 @@ int ymz280b_device::generate_pcm8(struct YMZ280BVoice *voice, int16_t *buffer, i
 		while (samples)
 		{
 			/* fetch the current value */
-			val = ymz280b_read_memory(position / 2);
+			val = read_byte(position / 2);
 
 			/* output to the buffer, scaling by the volume */
 			*buffer++ = (int8_t)val * 256;
@@ -378,7 +359,7 @@ int ymz280b_device::generate_pcm16(struct YMZ280BVoice *voice, int16_t *buffer, 
 		while (samples)
 		{
 			/* fetch the current value */
-			val = (int16_t)((ymz280b_read_memory(position / 2 + 1) << 8) + ymz280b_read_memory(position / 2 + 0));
+			val = (int16_t)((read_byte(position / 2 + 1) << 8) + read_byte(position / 2 + 0));
 
 			/* output to the buffer, scaling by the volume */
 			*buffer++ = val;
@@ -401,7 +382,7 @@ int ymz280b_device::generate_pcm16(struct YMZ280BVoice *voice, int16_t *buffer, 
 		while (samples)
 		{
 			/* fetch the current value */
-			val = (int16_t)((ymz280b_read_memory(position / 2 + 1) << 8) + ymz280b_read_memory(position / 2 + 0));
+			val = (int16_t)((read_byte(position / 2 + 1) << 8) + read_byte(position / 2 + 0));
 
 			/* output to the buffer, scaling by the volume */
 			*buffer++ = val;
@@ -583,14 +564,6 @@ void ymz280b_device::device_start()
 	m_master_clock = (double)clock() / 384.0;
 	m_irq_handler.resolve();
 
-	memory_region *region = memregion(DEVICE_SELF);
-	if (region != nullptr)
-	{
-		/* Some systems (e.g. Konami Firebeat) have a YMZ280B on-board that isn't hooked up to ROM, so be safe. */
-		m_mem_base = region->base();
-		m_mem_size = region->bytes();
-	}
-
 	for (int i = 0; i < 8; i++)
 	{
 		m_voice[i].timer = timer_alloc(i);
@@ -691,6 +664,12 @@ void ymz280b_device::device_clock_changed()
 {
 	m_master_clock = (double)clock() / 384.0;
 	m_stream->set_sample_rate(INTERNAL_SAMPLE_RATE);
+}
+
+
+void ymz280b_device::rom_bank_updated()
+{
+	m_stream->update();
 }
 
 
@@ -831,16 +810,13 @@ void ymz280b_device::write_to_register(int data)
 			case 0x86:      /* ROM readback / RAM write (low) -> update latch */
 				m_ext_mem_address = m_ext_mem_address_hi | m_ext_mem_address_mid | data;
 				if (m_ext_mem_enable)
-					m_ext_readlatch = ymz280b_read_memory(m_ext_mem_address);
+					m_ext_readlatch = read_byte(m_ext_mem_address);
 				break;
 
 			case 0x87:      /* RAM write */
 				if (m_ext_mem_enable)
 				{
-					if (!m_ext_write_handler.isnull())
-						m_ext_write_handler(m_ext_mem_address, data);
-					else
-						logerror("YMZ280B attempted RAM write to %X\n", m_ext_mem_address);
+					space(0).write_byte(m_ext_mem_address, data);
 					m_ext_mem_address = (m_ext_mem_address + 1) & 0xffffff;
 				}
 				break;
@@ -911,7 +887,7 @@ int ymz280b_device::compute_status()
 
 /**********************************************************************************************
 
-     ymz280b_r/ymz280b_w -- handle external accesses
+     read/write -- handle external accesses
 
 ***********************************************************************************************/
 
@@ -924,7 +900,7 @@ READ8_MEMBER( ymz280b_device::read )
 
 		/* read from external memory */
 		uint8_t ret = m_ext_readlatch;
-		m_ext_readlatch = ymz280b_read_memory(m_ext_mem_address);
+		m_ext_readlatch = read_byte(m_ext_mem_address);
 		m_ext_mem_address = (m_ext_mem_address + 1) & 0xffffff;
 		return ret;
 	}
@@ -952,6 +928,7 @@ DEFINE_DEVICE_TYPE(YMZ280B, ymz280b_device, "ymz280b", "Yamaha YMZ280B PCMD8")
 ymz280b_device::ymz280b_device(const machine_config &mconfig, const char *tag, device_t *owner, uint32_t clock)
 	: device_t(mconfig, YMZ280B, tag, owner, clock)
 	, device_sound_interface(mconfig, *this)
+	, device_rom_interface(mconfig, *this, 24)
 	, m_current_register(0)
 	, m_status_register(0)
 	, m_irq_state(0)
@@ -964,8 +941,6 @@ ymz280b_device::ymz280b_device(const machine_config &mconfig, const char *tag, d
 	, m_ext_mem_address_mid(0)
 	, m_ext_mem_address(0)
 	, m_irq_handler(*this)
-	, m_ext_read_handler(*this)
-	, m_ext_write_handler(*this)
 {
 	memset(m_voice, 0, sizeof(m_voice));
 }

--- a/src/devices/sound/ymz280b.cpp
+++ b/src/devices/sound/ymz280b.cpp
@@ -554,9 +554,6 @@ void ymz280b_device::sound_stream_update(sound_stream &stream, stream_sample_t *
 
 void ymz280b_device::device_start()
 {
-	m_ext_read_handler.resolve();
-	m_ext_write_handler.resolve();
-
 	/* compute ADPCM tables */
 	compute_tables();
 

--- a/src/devices/sound/ymz280b.h
+++ b/src/devices/sound/ymz280b.h
@@ -18,21 +18,13 @@
 #define MCFG_YMZ280B_IRQ_HANDLER(_devcb) \
 	devcb = &ymz280b_device::set_irq_handler(*device, DEVCB_##_devcb);
 
-#define MCFG_YMZ280B_EXT_READ_HANDLER(_devcb) \
-	devcb = &ymz280b_device::set_ext_read_handler(*device, DEVCB_##_devcb);
-
-#define MCFG_YMZ280B_EXT_WRITE_HANDLER(_devcb) \
-	devcb = &ymz280b_device::set_ext_write_handler(*device, DEVCB_##_devcb);
-
-class ymz280b_device : public device_t, public device_sound_interface
+class ymz280b_device : public device_t, public device_sound_interface, public device_rom_interface
 {
 public:
 	ymz280b_device(const machine_config &mconfig, const char *tag, device_t *owner, uint32_t clock);
 
 	// static configuration helpers
 	template <class Object> static devcb_base &set_irq_handler(device_t &device, Object &&cb) { return downcast<ymz280b_device &>(device).m_irq_handler.set_callback(std::forward<Object>(cb)); }
-	template <class Object> static devcb_base &set_ext_read_handler(device_t &device, Object &&cb) { return downcast<ymz280b_device &>(device).m_ext_read_handler.set_callback(std::forward<Object>(cb)); }
-	template <class Object> static devcb_base &set_ext_write_handler(device_t &device, Object &&cb) { return downcast<ymz280b_device &>(device).m_ext_write_handler.set_callback(std::forward<Object>(cb)); }
 
 	DECLARE_READ8_MEMBER( read );
 	DECLARE_WRITE8_MEMBER( write );
@@ -47,6 +39,9 @@ protected:
 
 	// sound stream update overrides
 	virtual void sound_stream_update(sound_stream &stream, stream_sample_t **inputs, stream_sample_t **outputs, int samples) override;
+
+	// device_rom_interface overrides
+	virtual void rom_bank_updated() override;
 
 private:
 	/* struct describing a single playing ADPCM voice */
@@ -86,7 +81,6 @@ private:
 		emu_timer *timer;
 	};
 
-	uint8_t ymz280b_read_memory(uint32_t offset);
 	void update_irq_state();
 	void update_step(struct YMZ280BVoice *voice);
 	void update_volumes(struct YMZ280BVoice *voice);
@@ -112,12 +106,8 @@ private:
 	uint32_t m_ext_mem_address;         /* where the CPU can read the ROM */
 
 	devcb_write_line m_irq_handler;  /* IRQ callback */
-	devcb_read8 m_ext_read_handler;  /* external RAM read handler */
-	devcb_write8 m_ext_write_handler;/* external RAM write handler */
 
 	double m_master_clock;            /* master clock frequency */
-	uint8_t *m_mem_base;                /* pointer to the base of external memory */
-	uint32_t m_mem_size;
 	sound_stream *m_stream;           /* which stream are we using */
 	std::unique_ptr<int16_t[]> m_scratch;
 #if YMZ280B_MAKE_WAVS

--- a/src/mame/drivers/vgmplay.cpp
+++ b/src/mame/drivers/vgmplay.cpp
@@ -201,6 +201,7 @@ public:
 	void segapcm_map(address_map &map);
 	void soundchips16_map(address_map &map);
 	void soundchips_map(address_map &map);
+	void ymz280b_map(address_map &map);
 private:
 	std::vector<uint8_t> m_file_data;
 	required_device<bitbanger_device> m_file;
@@ -1569,6 +1570,10 @@ ADDRESS_MAP_START(vgmplay_state::qsound_map)
 	AM_RANGE(0, 0xffffff) AM_DEVREAD("vgmplay", vgmplay_device, qsound_rom_r)
 ADDRESS_MAP_END
 
+ADDRESS_MAP_START(vgmplay_state::ymz280b_map)
+	AM_RANGE(0, 0xffffff) AM_DEVREAD("vgmplay", vgmplay_device, ymz280b_rom_r)
+ADDRESS_MAP_END
+
 ADDRESS_MAP_START(vgmplay_state::nescpu_map)
 	AM_RANGE(0, 0xffff) AM_RAM AM_SHARE("nesapu_ram")
 ADDRESS_MAP_END
@@ -1705,7 +1710,7 @@ MACHINE_CONFIG_START(vgmplay_state::vgmplay)
 	MCFG_SOUND_ROUTE(1, "rspeaker", 1)
 
 	MCFG_SOUND_ADD("ymz280b", YMZ280B, 16934400)
-	MCFG_YMZ280B_EXT_READ_HANDLER(DEVREAD8("vgmplay", vgmplay_device, ymz280b_rom_r))
+	MCFG_DEVICE_ADDRESS_MAP(0, ymz280b_map)
 	MCFG_SOUND_ROUTE(0, "lspeaker", 1)
 	MCFG_SOUND_ROUTE(1, "rspeaker", 1)
 


### PR DESCRIPTION
firebeat.cpp : Minor cleanups, Split main CPU memory maps related for number of allocated gcu chips in PCB