### PR TITLE
Improve Namco C352 emulation

### DIFF
--- a/src/devices/sound/c352.cpp
+++ b/src/devices/sound/c352.cpp
@@ -74,18 +74,14 @@ void c352_device::fetch_sample(c352_voice_t* v)
 	}
 	else
 	{
-		int8_t s, s2;
+		int8_t s;
 
 		s = (int8_t)read_byte(v->pos);
 
-		v->sample = s<<8;
 		if(v->flags & C352_FLG_MULAW)
-		{
-			s2 = (s&0x7f)>>4;
-
-			v->sample = ((s2*s2)<<4) - (~(s2<<1)) * (s&0x0f);
-			v->sample = (s&0x80) ? (~v->sample)<<5 : v->sample<<5;
-		}
+			v->sample = m_mulawtab[s&0xff];
+		else
+			v->sample = s<<8;
 
 		uint16_t pos = v->pos&0xffff;
 
@@ -184,11 +180,11 @@ void c352_device::sound_stream_update(sound_stream &stream, stream_sample_t **in
 
 			// Left
 			out[0] += (((v->flags & C352_FLG_PHASEFL) ? -s : s) * v->curr_vol[0])>>8;
-			out[2] += (((v->flags & C352_FLG_PHASEFR) ? -s : s) * v->curr_vol[2])>>8;
+			out[2] += (((v->flags & C352_FLG_PHASERL) ? -s : s) * v->curr_vol[2])>>8;
 
 			// Right
-			out[1] += (((v->flags & C352_FLG_PHASERL) ? -s : s) * v->curr_vol[1])>>8;
-			out[3] += (((v->flags & C352_FLG_PHASERL) ? -s : s) * v->curr_vol[3])>>8;
+			out[1] += (((v->flags & C352_FLG_PHASEFR) ? -s : s) * v->curr_vol[1])>>8;
+			out[3] += (((v->flags & C352_FLG_PHASEFR) ? -s : s) * v->curr_vol[3])>>8;
 		}
 
 		*buffer_fl++ = (int16_t) (out[0]>>3);
@@ -255,7 +251,7 @@ void c352_device::write_reg16(unsigned long address, unsigned short val)
 	{
 		for(i=0;i<32;i++)
 		{
-			if((m_c352_v[i].flags & C352_FLG_KEYON))
+			if(m_c352_v[i].flags & C352_FLG_KEYON)
 			{
 				m_c352_v[i].pos = (m_c352_v[i].wave_bank<<16) | m_c352_v[i].wave_start;
 
@@ -269,7 +265,7 @@ void c352_device::write_reg16(unsigned long address, unsigned short val)
 				m_c352_v[i].curr_vol[0] = m_c352_v[i].curr_vol[1] = 0;
 				m_c352_v[i].curr_vol[2] = m_c352_v[i].curr_vol[3] = 0;
 			}
-			else if(m_c352_v[i].flags & C352_FLG_KEYOFF)
+			if(m_c352_v[i].flags & C352_FLG_KEYOFF)
 			{
 				m_c352_v[i].flags &= ~(C352_FLG_BUSY|C352_FLG_KEYOFF);
 				m_c352_v[i].counter = 0xffff;
@@ -295,6 +291,25 @@ void c352_device::device_start()
 
 	m_stream = machine().sound().stream_alloc(*this, 0, 4, m_sample_rate_base);
 
+	// generate mulaw table (Output similar to namco's VC emulator)
+	int j = 0;
+	for(int i=0;i<128;i++)
+	{
+		m_mulawtab[i] = j<<5;
+		if(i < 16)
+			j += 1;
+		else if(i < 24)
+			j += 2;
+		else if(i < 48)
+			j += 4;
+		else if(i < 100)
+			j += 8;
+		else
+			j += 16;
+	}
+	for(int i=0;i<128;i++)
+		m_mulawtab[i+128] = (~m_mulawtab[i])&0xffe0;
+	
 	// register save state info
 	for (i = 0; i < 32; i++)
 	{

--- a/src/devices/sound/c352.h
+++ b/src/devices/sound/c352.h
@@ -105,6 +105,8 @@ private:
 	int m_divider;
 
 	c352_voice_t m_c352_v[32];
+	
+	int16_t m_mulawtab[256];
 
 	uint16_t m_random;
 	uint16_t m_control; // control flags, purpose unknown.


### PR DESCRIPTION
- Change mulaw algorithm to match Namco's Wii VC emulator. This appears to be the original algorithm used in the hardware. The C352's mulaw algorithm is identical to the C219 (Which is currently not implemented in MAME, I will eventually fix that unless someone beats me to it)
- Fix static noise between fights in Tekken 3.
- Fix the order of the phase inversion flags.
