### PR TITLE
Revert "qs1000.cpp : Convert set_irq, serial_in into WRITE_LINE_MEMBER"

### DIFF
--- a/src/devices/sound/qs1000.cpp
+++ b/src/devices/sound/qs1000.cpp
@@ -262,16 +262,20 @@ void qs1000_device::device_start()
 //-------------------------------------------------
 //  serial_in - send data to the chip
 //-------------------------------------------------
-WRITE_LINE_MEMBER(qs1000_device::serial_in)
+void qs1000_device::serial_in(uint8_t data)
 {
-	machine().scheduler().synchronize(timer_expired_delegate(FUNC(qs1000_device::serial_w), this), data);
+	m_serial_data_in = data;
+
+	// Signal to the CPU that data is available
+	m_cpu->set_input_line(MCS51_RX_LINE, ASSERT_LINE);
+	m_cpu->set_input_line(MCS51_RX_LINE, CLEAR_LINE);
 }
 
 
 //-------------------------------------------------
 //  set_irq - interrupt the internal CPU
 //-------------------------------------------------
-WRITE_LINE_MEMBER(qs1000_device::set_irq)
+void qs1000_device::set_irq(int state)
 {
 	// Signal to the CPU that data is available
 	m_cpu->set_input_line(MCS51_INT1_LINE, state ? ASSERT_LINE : CLEAR_LINE);
@@ -285,19 +289,6 @@ WRITE_LINE_MEMBER(qs1000_device::set_irq)
 READ8_MEMBER(qs1000_device::data_to_i8052)
 {
 	return m_serial_data_in;
-}
-
-
-//-------------------------------------------------
-//  serial_w - write serial data to the chip
-//-------------------------------------------------
-TIMER_CALLBACK_MEMBER(qs1000_device::serial_w)
-{
-	m_serial_data_in = param;
-
-	// Signal to the CPU that data is available
-	m_cpu->set_input_line(MCS51_RX_LINE, ASSERT_LINE);
-	m_cpu->set_input_line(MCS51_RX_LINE, CLEAR_LINE);
 }
 
 

--- a/src/devices/sound/qs1000.h
+++ b/src/devices/sound/qs1000.h
@@ -68,8 +68,8 @@ public:
 	//template <class Object> devcb_base &set_serial_w_callback(Object &&cb) { return m_serial_w_cb.set_callback(std::forward<Object>(cb)); }
 
 	// external
-	DECLARE_WRITE_LINE_MEMBER( serial_in );
-	DECLARE_WRITE_LINE_MEMBER( set_irq );
+	void serial_in(uint8_t data);
+	void set_irq(int state);
 
 	DECLARE_WRITE8_MEMBER( wave_w );
 
@@ -102,7 +102,6 @@ protected:
 	virtual void rom_bank_updated() override;
 
 private:
-	TIMER_CALLBACK_MEMBER( serial_w );
 	static constexpr unsigned QS1000_CHANNELS       = 32;
 	static constexpr offs_t   QS1000_ADDRESS_MASK   = 0x00ffffff;
 

--- a/src/mame/drivers/eolith16.cpp
+++ b/src/mame/drivers/eolith16.cpp
@@ -78,14 +78,14 @@ ADDRESS_MAP_START(eolith16_state::eolith16_map)
 	AM_RANGE(0x00000000, 0x001fffff) AM_RAM
 	AM_RANGE(0x50000000, 0x5000ffff) AM_READWRITE(vram_r, vram_w)
 	AM_RANGE(0x90000000, 0x9000002f) AM_WRITENOP //?
-	AM_RANGE(0xff000000, 0xff1fffff) AM_ROM AM_REGION("maindata", 0)
+	AM_RANGE(0xff000000, 0xff1fffff) AM_ROM AM_REGION("user2", 0)
 	AM_RANGE(0xffe40000, 0xffe40001) AM_DEVREADWRITE8("oki", okim6295_device, read, write, 0x00ff)
 	AM_RANGE(0xffe80000, 0xffe80001) AM_WRITE(eeprom_w)
 	AM_RANGE(0xffea0000, 0xffea0001) AM_READ(eolith16_custom_r)
 	AM_RANGE(0xffea0002, 0xffea0003) AM_READ_PORT("SYSTEM")
 	AM_RANGE(0xffec0000, 0xffec0001) AM_READNOP // not used?
 	AM_RANGE(0xffec0002, 0xffec0003) AM_READ_PORT("INPUTS")
-	AM_RANGE(0xfff80000, 0xffffffff) AM_ROM AM_REGION("maincpu", 0)
+	AM_RANGE(0xfff80000, 0xffffffff) AM_ROM AM_REGION("user1", 0)
 ADDRESS_MAP_END
 
 static INPUT_PORTS_START( eolith16 )
@@ -251,10 +251,10 @@ Notes:
 */
 
 ROM_START( klondkp )
-	ROM_REGION16_BE( 0x80000, "maincpu", 0 ) /* E1-16T program code */
+	ROM_REGION16_BE( 0x80000, "user1", 0 ) /* E1-16T program code */
 	ROM_LOAD( "kd.u5",  0x000000, 0x080000, CRC(591f0c73) SHA1(a9f338204c77a724fa6a6e08d78ca89bd5191aba) )
 
-	ROM_REGION16_BE( 0x200000, "maindata", 0 ) /* gfx data */
+	ROM_REGION16_BE( 0x200000, "user2", 0 ) /* gfx data */
 	ROM_LOAD16_WORD_SWAP( "kd.u31", 0x000000, 0x200000, CRC(e5dd12b5) SHA1(0a0cd75cbcdccce3575e5a58ba09c88452e1a5ee) )
 
 	ROM_REGION( 0x80000, "oki", 0 ) /* oki samples */

--- a/src/mame/drivers/ghosteo.cpp
+++ b/src/mame/drivers/ghosteo.cpp
@@ -88,15 +88,13 @@ class ghosteo_state : public driver_device
 {
 public:
 	ghosteo_state(const machine_config &mconfig, device_type type, const char *tag)
-		: driver_device(mconfig, type, tag)
-		, m_maincpu(*this, "maincpu")
-		, m_qs1000(*this, "qs1000")
-		, m_i2cmem(*this, "i2cmem")
-		, m_s3c2410(*this, "s3c2410")
-		, m_soundlatch(*this, "soundlatch")
-		, m_system_memory(*this, "systememory")
-		, m_flash(*this, "flash")
-	{ }
+		: driver_device(mconfig, type, tag),
+		m_maincpu(*this, "maincpu"),
+		m_qs1000(*this, "qs1000"),
+		m_i2cmem(*this, "i2cmem"),
+		m_s3c2410(*this, "s3c2410"),
+		m_soundlatch(*this, "soundlatch"),
+		m_system_memory(*this, "systememory") { }
 
 	required_device<cpu_device> m_maincpu;
 	required_device<qs1000_device> m_qs1000;
@@ -104,19 +102,22 @@ public:
 	required_device<s3c2410_device> m_s3c2410;
 	required_device<generic_latch_8_device> m_soundlatch;
 	required_shared_ptr<uint32_t> m_system_memory;
-	required_region_ptr<uint8_t> m_flash;
 
 	int m_security_count;
 	uint32_t m_bballoon_port[20];
 	struct nand_t m_nand;
 	DECLARE_READ32_MEMBER(bballoon_speedup_r);
 	DECLARE_READ32_MEMBER(touryuu_port_10000000_r);
+	DECLARE_WRITE32_MEMBER(soundlatch_w);
+
+	DECLARE_READ8_MEMBER(qs1000_p1_r);
 
 	DECLARE_WRITE8_MEMBER(qs1000_p1_w);
 	DECLARE_WRITE8_MEMBER(qs1000_p2_w);
 	DECLARE_WRITE8_MEMBER(qs1000_p3_w);
 
 	int m_rom_pagesize;
+	uint8_t* m_flash;
 	DECLARE_DRIVER_INIT(touryuu);
 	DECLARE_DRIVER_INIT(bballoon);
 	virtual void machine_start() override;
@@ -163,6 +164,11 @@ NAND Flash Controller (4KB internal buffer)
 24-ch external interrupts Controller (Wake-up source 16-ch)
 */
 
+READ8_MEMBER( ghosteo_state::qs1000_p1_r )
+{
+	return m_soundlatch->read(space, 0);
+}
+
 WRITE8_MEMBER( ghosteo_state::qs1000_p1_w )
 {
 }
@@ -180,7 +186,7 @@ WRITE8_MEMBER( ghosteo_state::qs1000_p3_w )
 	membank("qs1000:bank")->set_entry(data & 0x07);
 
 	if (!BIT(data, 5))
-		m_soundlatch->acknowledge_w(space, 0, !BIT(data, 5));
+		m_qs1000->set_irq(CLEAR_LINE);
 }
 
 
@@ -425,7 +431,7 @@ ADDRESS_MAP_START(ghosteo_state::bballoon_map)
 	AM_RANGE(0x10000000, 0x10000003) AM_READ_PORT("10000000")
 	AM_RANGE(0x10100000, 0x10100003) AM_READ_PORT("10100000")
 	AM_RANGE(0x10200000, 0x10200003) AM_READ_PORT("10200000")
-	AM_RANGE(0x10300000, 0x10300003) AM_DEVWRITE8("soundlatch", generic_latch_8_device, write, 0x000000ff).cswidth(32)
+	AM_RANGE(0x10300000, 0x10300003) AM_WRITE(soundlatch_w)
 	AM_RANGE(0x30000000, 0x31ffffff) AM_RAM AM_SHARE("systememory") AM_MIRROR(0x02000000)
 ADDRESS_MAP_END
 
@@ -433,7 +439,7 @@ ADDRESS_MAP_START(ghosteo_state::touryuu_map)
 	AM_RANGE(0x10000000, 0x10000003) AM_READ(touryuu_port_10000000_r)
 	AM_RANGE(0x10100000, 0x10100003) AM_READ_PORT("10100000")
 	AM_RANGE(0x10200000, 0x10200003) AM_READ_PORT("10200000")
-	AM_RANGE(0x10300000, 0x10300003) AM_DEVWRITE8("soundlatch", generic_latch_8_device, write, 0x000000ff).cswidth(32)
+	AM_RANGE(0x10300000, 0x10300003) AM_WRITE(soundlatch_w)
 	AM_RANGE(0x30000000, 0x31ffffff) AM_RAM AM_SHARE("systememory") AM_MIRROR(0x02000000)
 ADDRESS_MAP_END
 
@@ -588,8 +594,18 @@ READ32_MEMBER(ghosteo_state::bballoon_speedup_r)
 	return ret;
 }
 
+WRITE32_MEMBER(ghosteo_state::soundlatch_w)
+{
+	m_soundlatch->write(space, 0, data);
+	m_qs1000->set_irq(ASSERT_LINE);
+
+	machine().scheduler().boost_interleave(attotime::zero, attotime::from_usec(100));
+}
+
 void ghosteo_state::machine_start()
 {
+	m_flash = (uint8_t *)memregion( "user1")->base();
+
 	// Set up the QS1000 program ROM banking, taking care not to overlap the internal RAM
 	machine().device("qs1000:cpu")->memory().space(AS_IO).install_read_bank(0x0100, 0xffff, "bank");
 	membank("qs1000:bank")->configure_entries(0, 8, memregion("qs1000:cpu")->base()+0x100, 0x10000);
@@ -638,12 +654,10 @@ MACHINE_CONFIG_START(ghosteo_state::ghosteo)
 	MCFG_SPEAKER_STANDARD_STEREO("lspeaker", "rspeaker")
 
 	MCFG_GENERIC_LATCH_8_ADD("soundlatch")
-	MCFG_GENERIC_LATCH_DATA_PENDING_CB(DEVWRITELINE("qs1000", qs1000_device, set_irq))
-	MCFG_GENERIC_LATCH_SEPARATE_ACKNOWLEDGE(true)
 
 	MCFG_SOUND_ADD("qs1000", QS1000, XTAL(24'000'000))
 	MCFG_QS1000_EXTERNAL_ROM(true)
-	MCFG_QS1000_IN_P1_CB(DEVREAD8("soundlatch", generic_latch_8_device, read))
+	MCFG_QS1000_IN_P1_CB(READ8(ghosteo_state, qs1000_p1_r))
 	MCFG_QS1000_OUT_P1_CB(WRITE8(ghosteo_state, qs1000_p1_w))
 	MCFG_QS1000_OUT_P2_CB(WRITE8(ghosteo_state, qs1000_p2_w))
 	MCFG_QS1000_OUT_P3_CB(WRITE8(ghosteo_state, qs1000_p3_w))
@@ -714,7 +728,7 @@ Notes:
 
 // The NAND dumps are missing the ECC data.  We calculate it on the fly, because the games require it, but really it should be dumped hence the 'BAD DUMP' flags
 ROM_START( bballoon )
-	ROM_REGION( 0x2000000, "flash", 0 ) /* ARM 32 bit code */
+	ROM_REGION( 0x2000000, "user1", 0 ) /* ARM 32 bit code */
 	ROM_LOAD( "flash.u1",     0x000000, 0x2000000, BAD_DUMP CRC(73285634) SHA1(4d0210c1bebdf3113a99978ffbcd77d6ee854168) ) // missing ECC data
 
 	// banked every 0x10000 bytes ?
@@ -727,7 +741,7 @@ ROM_START( bballoon )
 ROM_END
 
 ROM_START( hapytour ) /* Same hardware: GHOST Ver1.1 2003.03.28 */
-	ROM_REGION( 0x2000000, "flash", 0 ) /* ARM 32 bit code */
+	ROM_REGION( 0x2000000, "user1", 0 ) /* ARM 32 bit code */
 	ROM_LOAD( "flash.u1",     0x000000, 0x2000000, BAD_DUMP CRC(49deb7f9) SHA1(708a27d7177cf6261a49ded975c2bbb6c2427742) ) // missing ECC data
 
 	// banked every 0x10000 bytes ?
@@ -741,7 +755,7 @@ ROM_END
 
 
 ROM_START( touryuu )
-	ROM_REGION( 0x4200000, "flash", 0 ) /* ARM 32 bit code */
+	ROM_REGION( 0x4200000, "user1", 0 ) /* ARM 32 bit code */
 	ROM_LOAD( "u1.bin",     0x000000, 0x4200000, CRC(49b6856e) SHA1(639123d2fabac4e79c9315fb87f72b13f9ae8761) )
 
 	// banked every 0x10000 bytes ?

--- a/src/mame/drivers/vamphalf.cpp
+++ b/src/mame/drivers/vamphalf.cpp
@@ -63,7 +63,6 @@ TODO:
 #include "cpu/e132xs/e132xs.h"
 #include "cpu/mcs51/mcs51.h"
 #include "machine/eepromser.h"
-#include "machine/gen_latch.h"
 #include "machine/nvram.h"
 #include "sound/okim6295.h"
 #include "sound/qs1000.h"
@@ -76,29 +75,26 @@ class vamphalf_state : public driver_device
 {
 public:
 	vamphalf_state(const machine_config &mconfig, device_type type, const char *tag)
-		: driver_device(mconfig, type, tag)
-		, m_maincpu(*this, "maincpu")
-		, m_qs1000(*this, "qs1000")
-		, m_eeprom(*this, "eeprom")
-		, m_gfxdecode(*this, "gfxdecode")
-		, m_palette(*this, "palette")
-		, m_soundlatch(*this, "soundlatch")
-		, m_tiles(*this,"tiles")
-		, m_wram(*this,"wram")
-		, m_tiles32(*this,"tiles32")
-		, m_wram32(*this,"wram32")
-		, m_okiregion(*this, "oki%u", 1)
-		, m_okibank(*this,"okibank")
-	{
-		m_has_extra_gfx = 0;
-	}
+		: driver_device(mconfig, type, tag),
+			m_maincpu(*this, "maincpu"),
+			m_qs1000(*this, "qs1000"),
+			m_eeprom(*this, "eeprom"),
+			m_gfxdecode(*this, "gfxdecode"),
+			m_palette(*this, "palette"),
+			m_tiles(*this,"tiles"),
+			m_wram(*this,"wram"),
+			m_tiles32(*this,"tiles32"),
+			m_wram32(*this,"wram32"),
+			m_okiregion(*this, "oki%u", 1),
+			m_okibank(*this,"okibank") {
+			m_has_extra_gfx = 0;
+		}
 
 	required_device<cpu_device> m_maincpu;
 	optional_device<qs1000_device> m_qs1000;
 	required_device<eeprom_serial_93cxx_device> m_eeprom;
 	required_device<gfxdecode_device> m_gfxdecode;
 	required_device<palette_device> m_palette;
-	optional_device<generic_latch_8_device> m_soundlatch;
 
 	optional_shared_ptr<uint16_t> m_tiles;
 	optional_shared_ptr<uint16_t> m_wram;
@@ -119,6 +115,7 @@ public:
 	int m_semicom_prot_which;
 	uint16_t m_finalgdr_backupram_bank;
 	std::unique_ptr<uint8_t[]> m_finalgdr_backupram;
+	uint8_t m_qs1000_data;
 
 	DECLARE_WRITE16_MEMBER(flipscreen_w);
 	DECLARE_WRITE32_MEMBER(flipscreen32_w);
@@ -173,6 +170,9 @@ public:
 	DECLARE_WRITE32_MEMBER(aoh_oki_bank_w);
 	DECLARE_WRITE16_MEMBER(boonggab_oki_bank_w);
 	DECLARE_WRITE16_MEMBER(mrkicker_oki_bank_w);
+	DECLARE_WRITE32_MEMBER(wyvernwg_snd_w);
+	DECLARE_WRITE16_MEMBER(misncrft_snd_w);
+	DECLARE_READ8_MEMBER(qs1000_p1_r);
 	DECLARE_WRITE8_MEMBER(qs1000_p3_w);
 
 	virtual void video_start() override;
@@ -433,10 +433,30 @@ WRITE16_MEMBER(vamphalf_state::boonggab_lamps_w)
 }
 
 
+
+WRITE32_MEMBER( vamphalf_state::wyvernwg_snd_w )
+{
+	m_qs1000_data = data & 0xff;
+	m_qs1000->set_irq(ASSERT_LINE);
+	machine().scheduler().boost_interleave(attotime::zero, attotime::from_usec(100));
+}
+
+WRITE16_MEMBER( vamphalf_state::misncrft_snd_w )
+{
+	m_qs1000_data = data & 0xff;
+	m_qs1000->set_irq(ASSERT_LINE);
+	machine().scheduler().boost_interleave(attotime::zero, attotime::from_usec(100));
+}
+
+READ8_MEMBER( vamphalf_state::qs1000_p1_r )
+{
+	return m_qs1000_data;
+}
+
 WRITE8_MEMBER( vamphalf_state::qs1000_p3_w )
 {
 	if (!BIT(data, 5))
-		m_soundlatch->acknowledge_w(space, 0, !BIT(data, 5));
+		m_qs1000->set_irq(CLEAR_LINE);
 
 	membank("qs1000:data")->set_entry(data & 7);
 }
@@ -446,21 +466,21 @@ ADDRESS_MAP_START(vamphalf_state::common_map)
 	AM_RANGE(0x00000000, 0x001fffff) AM_RAM AM_SHARE("wram")
 	AM_RANGE(0x40000000, 0x4003ffff) AM_RAM AM_SHARE("tiles")
 	AM_RANGE(0x80000000, 0x8000ffff) AM_RAM_DEVWRITE("palette", palette_device, write16) AM_SHARE("palette")
-	AM_RANGE(0xfff00000, 0xffffffff) AM_ROM AM_REGION("maincpu",0)
+	AM_RANGE(0xfff00000, 0xffffffff) AM_ROM AM_REGION("user1",0)
 ADDRESS_MAP_END
 
 ADDRESS_MAP_START(vamphalf_state::common_32bit_map)
 	AM_RANGE(0x00000000, 0x001fffff) AM_RAM AM_SHARE("wram32")
 	AM_RANGE(0x40000000, 0x4003ffff) AM_RAM AM_SHARE("tiles32")
 	AM_RANGE(0x80000000, 0x8000ffff) AM_RAM_DEVWRITE("palette", palette_device, write32) AM_SHARE("palette")
-	AM_RANGE(0xfff00000, 0xffffffff) AM_ROM AM_REGION("maincpu",0)
+	AM_RANGE(0xfff00000, 0xffffffff) AM_ROM AM_REGION("user1",0)
 ADDRESS_MAP_END
 
 ADDRESS_MAP_START(vamphalf_state::yorijori_32bit_map)
 	AM_RANGE(0x00000000, 0x001fffff) AM_RAM AM_SHARE("wram32")
 	AM_RANGE(0x40000000, 0x4003ffff) AM_RAM AM_SHARE("tiles32")
 	AM_RANGE(0x80000000, 0x8000ffff) AM_RAM_DEVWRITE("palette", palette_device, write32) AM_SHARE("palette")
-	AM_RANGE(0xffe00000, 0xffffffff) AM_ROM AM_REGION("maincpu",0)
+	AM_RANGE(0xffe00000, 0xffffffff) AM_ROM AM_REGION("user1",0)
 ADDRESS_MAP_END
 
 ADDRESS_MAP_START(vamphalf_state::vamphalf_io)
@@ -480,7 +500,7 @@ ADDRESS_MAP_START(vamphalf_state::misncrft_io)
 	AM_RANGE(0x200, 0x203) AM_READ_PORT("P1_P2")
 	AM_RANGE(0x240, 0x243) AM_READ_PORT("SYSTEM")
 	AM_RANGE(0x3c0, 0x3c3) AM_WRITE(eeprom_w)
-	AM_RANGE(0x400, 0x403) AM_DEVWRITE8("soundlatch", generic_latch_8_device, write, 0x00ff).cswidth(16)
+	AM_RANGE(0x400, 0x403) AM_WRITE(misncrft_snd_w)
 	AM_RANGE(0x580, 0x583) AM_READ(eeprom_r)
 ADDRESS_MAP_END
 
@@ -517,7 +537,7 @@ ADDRESS_MAP_START(vamphalf_state::wyvernwg_io)
 	AM_RANGE(0x2000, 0x2003) AM_WRITE(flipscreen32_w)
 	AM_RANGE(0x2800, 0x2803) AM_READ_PORT("P1_P2")
 	AM_RANGE(0x3000, 0x3003) AM_READ_PORT("SYSTEM")
-	AM_RANGE(0x5400, 0x5403) AM_DEVWRITE8("soundlatch", generic_latch_8_device, write, 0x000000ff).cswidth(32)
+	AM_RANGE(0x5400, 0x5403) AM_WRITE(wyvernwg_snd_w)
 	AM_RANGE(0x7000, 0x7003) AM_WRITE(eeprom32_w)
 	AM_RANGE(0x7c00, 0x7c03) AM_READ(eeprom32_r)
 ADDRESS_MAP_END
@@ -585,13 +605,13 @@ ADDRESS_MAP_START(vamphalf_state::aoh_map)
 	AM_RANGE(0x80000000, 0x8000ffff) AM_RAM_DEVWRITE("palette", palette_device, write32) AM_SHARE("palette")
 	AM_RANGE(0x80210000, 0x80210003) AM_READ_PORT("SYSTEM")
 	AM_RANGE(0x80220000, 0x80220003) AM_READ_PORT("P1_P2")
-	AM_RANGE(0xffc00000, 0xffffffff) AM_ROM AM_REGION("maincpu",0)
+	AM_RANGE(0xffc00000, 0xffffffff) AM_ROM AM_REGION("user1",0)
 ADDRESS_MAP_END
 
 ADDRESS_MAP_START(vamphalf_state::aoh_io)
 	AM_RANGE(0x0480, 0x0483) AM_WRITE(eeprom32_w)
 	AM_RANGE(0x0620, 0x0623) AM_DEVREADWRITE8("oki2", okim6295_device, read, write, 0x0000ff00)
-	AM_RANGE(0x0660, 0x0663) AM_DEVREADWRITE8("oki1", okim6295_device, read, write, 0x0000ff00)
+	AM_RANGE(0x0660, 0x0663) AM_DEVREADWRITE8("oki_1", okim6295_device, read, write, 0x0000ff00)
 	AM_RANGE(0x0640, 0x0647) AM_DEVREADWRITE8("ymsnd", ym2151_device, read, write, 0x0000ff00)
 	AM_RANGE(0x0680, 0x0683) AM_WRITE(aoh_oki_bank_w)
 ADDRESS_MAP_END
@@ -1074,14 +1094,10 @@ MACHINE_CONFIG_END
 MACHINE_CONFIG_START(vamphalf_state::sound_qs1000)
 	/* sound hardware */
 	MCFG_SPEAKER_STANDARD_STEREO("lspeaker", "rspeaker")
-	
-	MCFG_GENERIC_LATCH_8_ADD("soundlatch")
-	MCFG_GENERIC_LATCH_DATA_PENDING_CB(DEVWRITELINE("qs1000", qs1000_device, set_irq))
-	MCFG_GENERIC_LATCH_SEPARATE_ACKNOWLEDGE(true)
 
 	MCFG_SOUND_ADD("qs1000", QS1000, XTAL(24'000'000))
 	MCFG_QS1000_EXTERNAL_ROM(true)
-	MCFG_QS1000_IN_P1_CB(DEVREAD8("soundlatch", generic_latch_8_device, read))
+	MCFG_QS1000_IN_P1_CB(READ8(vamphalf_state, qs1000_p1_r))
 	MCFG_QS1000_OUT_P3_CB(WRITE8(vamphalf_state, qs1000_p3_w))
 	MCFG_SOUND_ROUTE(0, "lspeaker", 1.0)
 	MCFG_SOUND_ROUTE(1, "rspeaker", 1.0)
@@ -1212,7 +1228,7 @@ MACHINE_CONFIG_START(vamphalf_state::aoh)
 	MCFG_SOUND_ROUTE(0, "lspeaker", 1.0)
 	MCFG_SOUND_ROUTE(1, "rspeaker", 1.0)
 
-	MCFG_OKIM6295_ADD("oki1", XTAL(32'000'000)/8, PIN7_HIGH) /* 4MHz */
+	MCFG_OKIM6295_ADD("oki_1", XTAL(32'000'000)/8, PIN7_HIGH) /* 4MHz */
 	MCFG_SOUND_ROUTE(ALL_OUTPUTS, "lspeaker", 1.0)
 	MCFG_SOUND_ROUTE(ALL_OUTPUTS, "rspeaker", 1.0)
 
@@ -1316,7 +1332,7 @@ B1 B2 B3: Push buttons for SERV, RESET, TEST
 */
 
 ROM_START( vamphalf )
-	ROM_REGION16_BE( 0x100000, "maincpu", ROMREGION_ERASE00 ) /* Hyperstone CPU Code */
+	ROM_REGION16_BE( 0x100000, "user1", ROMREGION_ERASE00 ) /* Hyperstone CPU Code */
 	/* 0 - 0x80000 empty */
 	ROM_LOAD( "prg.rom1", 0x80000, 0x80000, CRC(9b1fc6c5) SHA1(acf10a50d2119ac893b6cbd494911982a9352350) ) /* at 0x16554: Europe Version 1.1.0908 */
 
@@ -1331,7 +1347,7 @@ ROM_START( vamphalf )
 ROM_END
 
 ROM_START( vamphalfr1 )
-	ROM_REGION16_BE( 0x100000, "maincpu", ROMREGION_ERASE00 ) /* Hyperstone CPU Code */
+	ROM_REGION16_BE( 0x100000, "user1", ROMREGION_ERASE00 ) /* Hyperstone CPU Code */
 	/* 0 - 0x80000 empty */
 	ROM_LOAD( "ws1-01201.rom1", 0x80000, 0x80000, CRC(afa75c19) SHA1(5dac104d1b3c026b6fce4d1f9126c048ebb557ef) ) /* at 0x162B8: Europe Version 1.0.0903 */
 
@@ -1345,7 +1361,7 @@ ROM_END
 
 
 ROM_START( vamphalfk )
-	ROM_REGION16_BE( 0x100000, "maincpu", ROMREGION_ERASE00 ) /* Hyperstone CPU Code */
+	ROM_REGION16_BE( 0x100000, "user1", ROMREGION_ERASE00 ) /* Hyperstone CPU Code */
 	/* 0 - 0x80000 empty */
 	ROM_LOAD( "prom1", 0x80000, 0x80000, CRC(f05e8e96) SHA1(c860e65c811cbda2dc70300437430fb4239d3e2d) ) /* at 0x1653C: Korean Version 1.1.0908 */
 
@@ -1404,7 +1420,7 @@ Notes:
 */
 
 ROM_START( suplup ) /* version 4.0 / 990518 - also has 'Puzzle Bang Bang' title but it can't be selected */
-	ROM_REGION16_BE( 0x100000, "maincpu", ROMREGION_ERASE00 ) /* Hyperstone CPU Code */
+	ROM_REGION16_BE( 0x100000, "user1", ROMREGION_ERASE00 ) /* Hyperstone CPU Code */
 	ROM_LOAD( "suplup-rom1.bin", 0x00000, 0x80000, CRC(61fb2dbe) SHA1(21cb8f571b2479de6779b877b656d1ffe5b3516f) )
 	ROM_LOAD( "suplup-rom2.bin", 0x80000, 0x80000, CRC(0c176c57) SHA1(f103a1afc528c01cbc18639273ab797fb9afacb1) )
 
@@ -1422,7 +1438,7 @@ ROM_START( suplup ) /* version 4.0 / 990518 - also has 'Puzzle Bang Bang' title 
 ROM_END
 
 ROM_START( luplup ) /* version 3.0 / 990128 */
-	ROM_REGION16_BE( 0x100000, "maincpu", ROMREGION_ERASE00 ) /* Hyperstone CPU Code */
+	ROM_REGION16_BE( 0x100000, "user1", ROMREGION_ERASE00 ) /* Hyperstone CPU Code */
 	ROM_LOAD( "luplup-rom1.v30", 0x00000, 0x80000, CRC(9ea67f87) SHA1(73d16c056a8d64743181069a01559a43fee529a3) )
 	ROM_LOAD( "luplup-rom2.v30", 0x80000, 0x80000, CRC(99840155) SHA1(e208f8731c06b634e84fb73e04f6cdbb8b504b94) )
 
@@ -1441,7 +1457,7 @@ ROM_END
 
 
 ROM_START( luplup29 ) /* version 2.9 / 990108 */
-	ROM_REGION16_BE( 0x100000, "maincpu", ROMREGION_ERASE00 ) /* Hyperstone CPU Code */
+	ROM_REGION16_BE( 0x100000, "user1", ROMREGION_ERASE00 ) /* Hyperstone CPU Code */
 	ROM_LOAD( "luplup-rom1.v29", 0x00000, 0x80000, CRC(36a8b8c1) SHA1(fed3eb2d83adc1b071a12ce5d49d4cab0ca20cc7) )
 	ROM_LOAD( "luplup-rom2.v29", 0x80000, 0x80000, CRC(50dac70f) SHA1(0e313114a988cb633a89508fda17eb09023827a2) )
 
@@ -1457,7 +1473,7 @@ ROM_END
 
 
 ROM_START( puzlbang ) /* version 2.9 / 990108 - Korea only, cannot select title, language and limited selection of background choices, EI: censored  */
-	ROM_REGION16_BE( 0x100000, "maincpu", ROMREGION_ERASE00 ) /* Hyperstone CPU Code */
+	ROM_REGION16_BE( 0x100000, "user1", ROMREGION_ERASE00 ) /* Hyperstone CPU Code */
 	ROM_LOAD( "pbb-rom1.v29", 0x00000, 0x80000, CRC(eb829586) SHA1(1f8a6af7c51c715724f5a242f4e22f7f6fb1f0ee) )
 	ROM_LOAD( "pbb-rom2.v29", 0x80000, 0x80000, CRC(fb84c793) SHA1(a2d27caecdae457d12b48d88d19ce417f69507c6) )
 
@@ -1473,7 +1489,7 @@ ROM_END
 
 
 ROM_START( puzlbanga ) /* version 2.8 / 990106 - Korea only, cannot select title, language or change background selection, EI: censored */
-	ROM_REGION16_BE( 0x100000, "maincpu", ROMREGION_ERASE00 ) /* Hyperstone CPU Code */
+	ROM_REGION16_BE( 0x100000, "user1", ROMREGION_ERASE00 ) /* Hyperstone CPU Code */
 	ROM_LOAD( "pbb-rom1.v28", 0x00000, 0x80000, CRC(fd21c5ff) SHA1(bc6314bbb2495c140788025153c893d5fd00bdc1) )
 	ROM_LOAD( "pbb-rom2.v28", 0x80000, 0x80000, CRC(490ecaeb) SHA1(2b0f25e3d681ddf95b3c65754900c046b5b50b09) )
 
@@ -1544,7 +1560,7 @@ Measured Clocks:
 */
 
 ROM_START( jmpbreak ) /* Released February 1999 */
-	ROM_REGION16_BE( 0x100000, "maincpu", ROMREGION_ERASE00 ) /* Hyperstone CPU Code */
+	ROM_REGION16_BE( 0x100000, "user1", ROMREGION_ERASE00 ) /* Hyperstone CPU Code */
 	ROM_LOAD( "rom1.bin", 0x00000, 0x80000, CRC(7e237f7d) SHA1(042e672be34644311eefc7b998bcdf6a9ea2c28a) )
 	ROM_LOAD( "rom2.bin", 0x80000, 0x80000, CRC(c722f7be) SHA1(d8b3c6b5fd0942147e0a61169c3eb6334a3b5a40) )
 
@@ -1559,7 +1575,7 @@ ROM_START( jmpbreak ) /* Released February 1999 */
 ROM_END
 
 ROM_START( poosho ) /* Released November 1999 - Updated sequel to Jumping Break for Korean market */
-	ROM_REGION16_BE( 0x100000, "maincpu", ROMREGION_ERASE00 ) /* Hyperstone CPU Code */
+	ROM_REGION16_BE( 0x100000, "user1", ROMREGION_ERASE00 ) /* Hyperstone CPU Code */
 	ROM_LOAD( "rom1.bin", 0x00000, 0x80000, CRC(2072c120) SHA1(cf066cd277840fdbb7a854a052a80b2fbb582278) )
 	ROM_LOAD( "rom2.bin", 0x80000, 0x80000, CRC(80e70d7a) SHA1(cdafce4bfe7370978414a12aaf482e07a1c89ff8) )
 
@@ -1627,7 +1643,7 @@ ROMs:
 */
 
 ROM_START( mrdig )
-	ROM_REGION16_BE( 0x100000, "maincpu", ROMREGION_ERASE00 ) /* Hyperstone CPU Code */
+	ROM_REGION16_BE( 0x100000, "user1", ROMREGION_ERASE00 ) /* Hyperstone CPU Code */
 	ROM_LOAD( "rom1.bin", 0x00000, 0x80000, CRC(5b960320) SHA1(adf5499a39987041fc93e409bdb5fd07dacec4f9) )
 	ROM_LOAD( "rom2.bin", 0x80000, 0x80000, CRC(75d48b64) SHA1(c9c492fb9cabafcf0bc05f44bf80ee6df3c21a1b) )
 
@@ -1674,7 +1690,7 @@ F-E1-16-008
 */
 
 ROM_START( coolmini )
-	ROM_REGION16_BE( 0x100000, "maincpu", ROMREGION_ERASE00 ) /* Hyperstone CPU Code */
+	ROM_REGION16_BE( 0x100000, "user1", ROMREGION_ERASE00 ) /* Hyperstone CPU Code */
 	ROM_LOAD( "cm-rom1.040", 0x00000, 0x80000, CRC(9688fa98) SHA1(d5ebeb1407980072f689c3b3a5161263c7082e9a) )
 	ROM_LOAD( "cm-rom2.040", 0x80000, 0x80000, CRC(9d588fef) SHA1(7b6b0ba074c7fa0aecda2b55f411557b015522b6) )
 
@@ -1693,7 +1709,7 @@ ROM_START( coolmini )
 ROM_END
 
 ROM_START( coolminii )
-	ROM_REGION16_BE( 0x100000, "maincpu", ROMREGION_ERASE00 ) /* Hyperstone CPU Code */
+	ROM_REGION16_BE( 0x100000, "user1", ROMREGION_ERASE00 ) /* Hyperstone CPU Code */
 	ROM_LOAD( "cm-rom1.040", 0x00000, 0x80000, CRC(aa94bb86) SHA1(f1d75bf54b75f234cc872779c5b1ff6679778841) )
 	ROM_LOAD( "cm-rom2.040", 0x80000, 0x80000, CRC(be7d02c8) SHA1(4897f3c890dd66f94d7a29f7a73c59857e4af218) )
 
@@ -1765,7 +1781,7 @@ ROMs:
 */
 
 ROM_START( dquizgo2 )
-	ROM_REGION16_BE( 0x100000, "maincpu", ROMREGION_ERASE00 ) /* Hyperstone CPU Code */
+	ROM_REGION16_BE( 0x100000, "user1", ROMREGION_ERASE00 ) /* Hyperstone CPU Code */
 	ROM_LOAD( "rom1",         0x00000, 0x080000, CRC(81eef038) SHA1(9c925d1ef261ea85069925ccd1a5aeb939f55d5a) )
 	ROM_LOAD( "rom2",         0x80000, 0x080000, CRC(e8789d8a) SHA1(1ee26c26cc7024c5df9d0da630b326021ece9f41) )
 
@@ -1837,7 +1853,7 @@ ROMs:
 */
 
 ROM_START( dtfamily )
-	ROM_REGION16_BE( 0x100000, "maincpu", ROMREGION_ERASE00 ) /* Hyperstone CPU Code */
+	ROM_REGION16_BE( 0x100000, "user1", ROMREGION_ERASE00 ) /* Hyperstone CPU Code */
 	ROM_LOAD( "rom1",         0x00000, 0x080000, CRC(738636d2) SHA1(ba7906df99764ee7e1f505c319d364c64c605ff0) )
 	ROM_LOAD( "rom2",         0x80000, 0x080000, CRC(0953f5e4) SHA1(ee8b3c4f9c9301c9815747eab5435e006ec84ca1) )
 
@@ -1911,7 +1927,7 @@ ROMs:
 */
 
 ROM_START( toyland )
-	ROM_REGION16_BE( 0x100000, "maincpu", ROMREGION_ERASE00 ) /* Hyperstone CPU Code */
+	ROM_REGION16_BE( 0x100000, "user1", ROMREGION_ERASE00 ) /* Hyperstone CPU Code */
 	/* ROM1 empty */
 	ROM_LOAD( "rom2.bin",         0x80000, 0x080000, CRC(e3455002) SHA1(5ad7884f82fb125d70829accec02f238e7d9593c) )
 
@@ -1990,7 +2006,7 @@ ROM1 & ROM2 are both ST 27c4000D
 */
 
 ROM_START( wivernwg )
-	ROM_REGION32_BE( 0x100000, "maincpu", ROMREGION_ERASE00 ) /* Hyperstone CPU Code */
+	ROM_REGION32_BE( 0x100000, "user1", ROMREGION_ERASE00 ) /* Hyperstone CPU Code */
 	ROM_LOAD( "rom1", 0x000000, 0x080000, CRC(83eb9a36) SHA1(d9c3b2facf42c137abc2923bbaeae300964ca4a0) ) /* ST 27C4000D with no labels */
 	ROM_LOAD( "rom2", 0x080000, 0x080000, CRC(5d657055) SHA1(21baa81b80f28aec4a6be9eaf69709958bf2a129) )
 
@@ -2016,7 +2032,7 @@ ROM_START( wivernwg )
 ROM_END
 
 ROM_START( wyvernwg )
-	ROM_REGION32_BE( 0x100000, "maincpu", ROMREGION_ERASE00 ) /* Hyperstone CPU Code */
+	ROM_REGION32_BE( 0x100000, "user1", ROMREGION_ERASE00 ) /* Hyperstone CPU Code */
 	ROM_LOAD( "rom1.bin", 0x000000, 0x080000, CRC(66bf3a5c) SHA1(037d5e7a6ef6f5b4ac08a9c811498c668a9d2522) ) /* ST 27c4000D with no labels */
 	ROM_LOAD( "rom2.bin", 0x080000, 0x080000, CRC(fd9b5911) SHA1(a01e8c6e5a9009024af385268ba3ba90e1ebec50) )
 
@@ -2042,7 +2058,7 @@ ROM_START( wyvernwg )
 ROM_END
 
 ROM_START( wyvernwga )
-	ROM_REGION32_BE( 0x100000, "maincpu", ROMREGION_ERASE00 ) /* Hyperstone CPU Code */
+	ROM_REGION32_BE( 0x100000, "user1", ROMREGION_ERASE00 ) /* Hyperstone CPU Code */
 	ROM_LOAD( "rom1.rom", 0x000000, 0x080000, CRC(586881fd) SHA1(d335bbd91def8fa4935eb2375c9b00471a1f40eb) ) /* ST 27c4000D with no labels */
 	ROM_LOAD( "rom2.rom", 0x080000, 0x080000, CRC(938049ec) SHA1(cc10944c99ceb388dd4aafc93377c40540861d14) )
 
@@ -2114,7 +2130,7 @@ Notes:
 */
 
 ROM_START( misncrft ) /* Version 2.7 */
-	ROM_REGION16_BE( 0x100000, "maincpu", ROMREGION_ERASE00 ) /* Hyperstone CPU Code */
+	ROM_REGION16_BE( 0x100000, "user1", ROMREGION_ERASE00 ) /* Hyperstone CPU Code */
 	/* 0 - 0x80000 empty */
 	ROM_LOAD( "prg-rom2.bin", 0x80000, 0x80000, CRC(04d22da6) SHA1(1c5be430000a31f21204fb756fadf2523a546b8b) )
 
@@ -2139,7 +2155,7 @@ ROM_START( misncrft ) /* Version 2.7 */
 ROM_END
 
 ROM_START( misncrfta ) /* Version 2.4 */
-	ROM_REGION16_BE( 0x100000, "maincpu", ROMREGION_ERASE00 ) /* Hyperstone CPU Code */
+	ROM_REGION16_BE( 0x100000, "user1", ROMREGION_ERASE00 ) /* Hyperstone CPU Code */
 	/* 0 - 0x80000 empty */
 	ROM_LOAD( "prg-rom2.bin", 0x80000, 0x80000, CRC(059ae8c1) SHA1(2c72fcf560166cb17cd8ad665beae302832d551c) ) // sldh
 
@@ -2238,7 +2254,7 @@ ROMs:
 */
 
 ROM_START( yorijori )
-	ROM_REGION32_BE( 0x200000, "maincpu", ROMREGION_ERASE00 ) /* Hyperstone CPU Code */
+	ROM_REGION32_BE( 0x200000, "user1", ROMREGION_ERASE00 ) /* Hyperstone CPU Code */
 	ROM_LOAD( "prg1", 0x000000, 0x200000, CRC(0e04eb40) SHA1(0cec9dc91aaf9cf7c459c7baac200cf0fcfddc18) )
 
 	ROM_REGION( 0x080000, "qs1000:cpu", 0 ) /* QDSP (8052) Code */
@@ -2307,7 +2323,7 @@ VR1 is the volume adjust pot
 */
 
 ROM_START( finalgdr ) /* version 2.20.5915, Korea only */
-	ROM_REGION32_BE( 0x100000, "maincpu", ROMREGION_ERASE00 ) /* Hyperstone CPU Code */
+	ROM_REGION32_BE( 0x100000, "user1", ROMREGION_ERASE00 ) /* Hyperstone CPU Code */
 	/* rom0 empty */
 	ROM_LOAD( "rom1", 0x080000, 0x080000, CRC(45815931) SHA1(80ba7a366994e40a1f520ea18fad82e6b068b279) )
 
@@ -2415,7 +2431,7 @@ ROMs:
 */
 
 ROM_START( mrkickera )
-	ROM_REGION32_BE( 0x100000, "maincpu", ROMREGION_ERASE00 ) /* Hyperstone CPU Code */
+	ROM_REGION32_BE( 0x100000, "user1", ROMREGION_ERASE00 ) /* Hyperstone CPU Code */
 	/* rom0 empty */
 	ROM_LOAD( "2-semicom.rom1", 0x080000, 0x080000, CRC(d3da29ca) SHA1(b843c650096a1c6d50f99e354ec0c93eb4406c5b) ) /* SEMICOM-003b PCB */
 
@@ -2435,7 +2451,7 @@ ROM_START( mrkickera )
 ROM_END
 
 ROM_START( mrkicker )
-	ROM_REGION16_BE( 0x100000, "maincpu", ROMREGION_ERASE00 ) /* Hyperstone CPU Code */
+	ROM_REGION16_BE( 0x100000, "user1", ROMREGION_ERASE00 ) /* Hyperstone CPU Code */
 	/* rom1 empty */
 	ROM_LOAD( "3-semicom.rom2", 0x080000, 0x080000, CRC(3f7fa08b) SHA1(dbffd44d8387e6ed1a4b5ec85ccf64d69a108d88) ) /* F-E1-16-010 PCB */
 
@@ -2500,7 +2516,7 @@ Notes:
 */
 
 ROM_START( aoh )
-	ROM_REGION32_BE( 0x400000, "maincpu", ROMREGION_ERASE00 ) /* Hyperstone CPU Code */
+	ROM_REGION32_BE( 0x400000, "user1", ROMREGION_ERASE00 ) /* Hyperstone CPU Code */
 	ROM_LOAD16_WORD_SWAP( "rom1", 0x000000, 0x200000, CRC(2e55ff55) SHA1(b2b7605b87ee609dfbc7c21dfae0ef8d847019f0) )
 	ROM_LOAD16_WORD_SWAP( "rom2", 0x200000, 0x200000, CRC(50f8a409) SHA1(a8171b7cf59dd01de1e512ab21607b4f330f40b8) )
 
@@ -2514,7 +2530,7 @@ ROM_START( aoh )
 	ROM_LOAD32_WORD( "g08", 0x3000002, 0x800000, CRC(1fd08aa0) SHA1(376a91220cd6e63418b04d590b232bb1079a40c7) )
 	ROM_LOAD32_WORD( "g12", 0x3000000, 0x800000, CRC(e437b35f) SHA1(411d2926d619fba057476864f0e580f608830522) )
 
-	ROM_REGION( 0x40000, "oki1", 0 ) /* Oki Samples */
+	ROM_REGION( 0x40000, "oki_1", 0 ) /* Oki Samples */
 	ROM_LOAD( "rom3", 0x00000, 0x40000, CRC(db8cb455) SHA1(6723b4018208d554bd1bf1e0640b72d2f4f47302) )
 
 	/* $00000-$20000 stays the same in all sound banks, */
@@ -2531,7 +2547,7 @@ Taff System, 2001
 */
 
 ROM_START( boonggab )
-	ROM_REGION16_BE( 0x100000, "maincpu", ROMREGION_ERASE00 ) /* Hyperstone CPU Code */
+	ROM_REGION16_BE( 0x100000, "user1", ROMREGION_ERASE00 ) /* Hyperstone CPU Code */
 	/* rom2 empty */
 	/* rom3 empty */
 	ROM_LOAD( "2.rom0",       0x80000, 0x80000, CRC(3395541b) SHA1(4e822a52d6070bde232285e7ad8fbe74594bbf28) )
@@ -2955,6 +2971,8 @@ DRIVER_INIT_MEMBER(vamphalf_state,misncrft)
 	// Configure the QS1000 ROM banking. Care must be taken not to overlap the 256b internal RAM
 	machine().device("qs1000:cpu")->memory().space(AS_IO).install_read_bank(0x0100, 0xffff, "data");
 	membank("qs1000:data")->configure_entries(0, 16, memregion("qs1000:cpu")->base()+0x100, 0x8000-0x100);
+
+	save_item(NAME(m_qs1000_data));
 }
 
 DRIVER_INIT_MEMBER(vamphalf_state,coolmini)
@@ -3031,6 +3049,7 @@ DRIVER_INIT_MEMBER(vamphalf_state,wyvernwg)
 	machine().device("qs1000:cpu")->memory().space(AS_IO).install_read_bank(0x0100, 0xffff, "data");
 	membank("qs1000:data")->configure_entries(0, 16, memregion("qs1000:cpu")->base()+0x100, 0x8000-0x100);
 
+	save_item(NAME(m_qs1000_data));
 	save_item(NAME(m_semicom_prot_idx));
 	save_item(NAME(m_semicom_prot_which));
 }
@@ -3046,7 +3065,7 @@ DRIVER_INIT_MEMBER(vamphalf_state,yorijori)
 	m_semicom_prot_data[0] = 2;
 	m_semicom_prot_data[1] = 1;
 
-//  uint8_t *romx = (uint8_t *)memregion("maincpu")->base();
+//  uint8_t *romx = (uint8_t *)memregion("user1")->base();
 	// prevent code dying after a trap 33 by patching it out, why?
 //  romx[BYTE4_XOR_BE(0x8ff0)] = 3;
 //  romx[BYTE4_XOR_BE(0x8ff1)] = 0;
@@ -3054,6 +3073,8 @@ DRIVER_INIT_MEMBER(vamphalf_state,yorijori)
 	// Configure the QS1000 ROM banking. Care must be taken not to overlap the 256b internal RAM
 	machine().device("qs1000:cpu")->memory().space(AS_IO).install_read_bank(0x0100, 0xffff, "data");
 	membank("qs1000:data")->configure_entries(0, 16, memregion("qs1000:cpu")->base()+0x100, 0x8000-0x100);
+
+	save_item(NAME(m_qs1000_data));
 }
 
 DRIVER_INIT_MEMBER(vamphalf_state,finalgdr)

--- a/src/mame/drivers/vegaeo.cpp
+++ b/src/mame/drivers/vegaeo.cpp
@@ -18,6 +18,7 @@
 
 #include "cpu/e132xs/e132xs.h"
 #include "machine/at28c16.h"
+#include "machine/gen_latch.h"
 #include "sound/qs1000.h"
 #include "speaker.h"
 
@@ -26,8 +27,10 @@ class vegaeo_state : public eolith_state
 {
 public:
 	vegaeo_state(const machine_config &mconfig, device_type type, const char *tag)
-		: eolith_state(mconfig, type, tag) { }
+		: eolith_state(mconfig, type, tag),
+		m_soundlatch(*this, "soundlatch") { }
 
+	required_device<generic_latch_8_device> m_soundlatch;
 
 	std::unique_ptr<uint32_t[]> m_vega_vram;
 	uint8_t m_vega_vbuffer;
@@ -36,6 +39,8 @@ public:
 	DECLARE_READ32_MEMBER(vega_vram_r);
 	DECLARE_WRITE32_MEMBER(vega_misc_w);
 	DECLARE_READ32_MEMBER(vegaeo_custom_read);
+	DECLARE_WRITE32_MEMBER(soundlatch_w);
+	DECLARE_READ8_MEMBER(qs1000_p1_r);
 	DECLARE_WRITE8_MEMBER(qs1000_p1_w);
 	DECLARE_WRITE8_MEMBER(qs1000_p2_w);
 	DECLARE_WRITE8_MEMBER(qs1000_p3_w);
@@ -47,6 +52,11 @@ public:
 	void vega(machine_config &config);
 	void vega_map(address_map &map);
 };
+
+READ8_MEMBER( vegaeo_state::qs1000_p1_r )
+{
+	return m_soundlatch->read(space, 0);
+}
 
 WRITE8_MEMBER( vegaeo_state::qs1000_p1_w )
 {
@@ -65,7 +75,7 @@ WRITE8_MEMBER( vegaeo_state::qs1000_p3_w )
 	membank("qs1000:bank")->set_entry(data & 0x07);
 
 	if (!BIT(data, 5))
-		m_soundlatch->acknowledge_w(space, 0, !BIT(data, 5));
+		m_qs1000->set_irq(CLEAR_LINE);
 }
 
 WRITE32_MEMBER(vegaeo_state::vega_vram_w)
@@ -117,6 +127,14 @@ READ32_MEMBER(vegaeo_state::vegaeo_custom_read)
 	return ioport("SYSTEM")->read();
 }
 
+WRITE32_MEMBER(vegaeo_state::soundlatch_w)
+{
+	m_soundlatch->write(space, 0, data);
+	m_qs1000->set_irq(ASSERT_LINE);
+
+	machine().scheduler().boost_interleave(attotime::zero, attotime::from_usec(100));
+}
+
 
 ADDRESS_MAP_START(vegaeo_state::vega_map)
 	AM_RANGE(0x00000000, 0x001fffff) AM_RAM
@@ -124,11 +142,11 @@ ADDRESS_MAP_START(vegaeo_state::vega_map)
 	AM_RANGE(0xfc000000, 0xfc0000ff) AM_DEVREADWRITE8("at28c16", at28c16_device, read, write, 0x000000ff)
 	AM_RANGE(0xfc200000, 0xfc2003ff) AM_DEVREADWRITE16("palette", palette_device, read16, write16, 0x0000ffff) AM_SHARE("palette")
 	AM_RANGE(0xfc400000, 0xfc40005b) AM_WRITENOP // crt registers ?
-	AM_RANGE(0xfc600000, 0xfc600003) AM_DEVWRITE8("soundlatch", generic_latch_8_device, write, 0x000000ff).cswidth(32)
+	AM_RANGE(0xfc600000, 0xfc600003) AM_WRITE(soundlatch_w)
 	AM_RANGE(0xfca00000, 0xfca00003) AM_WRITE(vega_misc_w)
 	AM_RANGE(0xfcc00000, 0xfcc00003) AM_READ(vegaeo_custom_read)
 	AM_RANGE(0xfce00000, 0xfce00003) AM_READ_PORT("P1_P2")
-	AM_RANGE(0xfd000000, 0xfeffffff) AM_ROM AM_REGION("maindata", 0)
+	AM_RANGE(0xfd000000, 0xfeffffff) AM_ROM AM_REGION("user1", 0)
 	AM_RANGE(0xfff80000, 0xffffffff) AM_ROM AM_REGION("maincpu", 0)
 ADDRESS_MAP_END
 
@@ -227,12 +245,10 @@ MACHINE_CONFIG_START(vegaeo_state::vega)
 	MCFG_SPEAKER_STANDARD_STEREO("lspeaker", "rspeaker")
 
 	MCFG_GENERIC_LATCH_8_ADD("soundlatch")
-	MCFG_GENERIC_LATCH_DATA_PENDING_CB(DEVWRITELINE("qs1000", qs1000_device, set_irq))
-	MCFG_GENERIC_LATCH_SEPARATE_ACKNOWLEDGE(true)
 
 	MCFG_SOUND_ADD("qs1000", QS1000, XTAL(24'000'000))
 	MCFG_QS1000_EXTERNAL_ROM(true)
-	MCFG_QS1000_IN_P1_CB(DEVREAD8("soundlatch", generic_latch_8_device, read))
+	MCFG_QS1000_IN_P1_CB(READ8(vegaeo_state, qs1000_p1_r))
 	MCFG_QS1000_OUT_P1_CB(WRITE8(vegaeo_state, qs1000_p1_w))
 	MCFG_QS1000_OUT_P2_CB(WRITE8(vegaeo_state, qs1000_p2_w))
 	MCFG_QS1000_OUT_P3_CB(WRITE8(vegaeo_state, qs1000_p3_w))
@@ -290,7 +306,7 @@ ROM_START( crazywar )
 	ROM_REGION( 0x80000, "maincpu", 0 ) /* Hyperstone CPU Code */
 	ROM_LOAD( "u7",         0x00000, 0x80000, CRC(697c2505) SHA1(c787007f05d2ddf1706e15e9d9ef9b2479708f12) )
 
-	ROM_REGION32_BE( 0x2000000, "maindata", ROMREGION_ERASE00 ) /* Game Data - banked ROM, swapping necessary */
+	ROM_REGION32_BE( 0x2000000, "user1", ROMREGION_ERASE00 ) /* Game Data - banked ROM, swapping necessary */
 	ROM_LOAD32_WORD_SWAP( "00", 0x0000000, 0x200000, CRC(fbb917ae) SHA1(1fd975cda06b3cb748503b7c8009e6184b46af3f) )
 	ROM_LOAD32_WORD_SWAP( "01", 0x0000002, 0x200000, CRC(59308556) SHA1(bc8c28531fca009be5b7b3b1a4a9b3ebcc9d3c3a) )
 	ROM_LOAD32_WORD_SWAP( "02", 0x0400000, 0x200000, CRC(34813167) SHA1(d04c71164b36af78425dcd637e60aee45c39a1ba) )

--- a/src/mame/includes/eolith.h
+++ b/src/mame/includes/eolith.h
@@ -2,7 +2,6 @@
 // copyright-holders:Tomasz Slanina,Pierpaolo Prazzoli
 
 #include "cpu/mcs51/mcs51.h"
-#include "machine/gen_latch.h"
 #include "machine/timer.h"
 #include "sound/qs1000.h"
 #include "screen.h"
@@ -11,34 +10,36 @@ class eolith_state : public driver_device
 {
 public:
 	eolith_state(const machine_config &mconfig, device_type type, const char *tag)
-		: driver_device(mconfig, type, tag)
-		, m_eepromoutport(*this, "EEPROMOUT")
-		, m_qs1000(*this, "qs1000")
-		, m_maincpu(*this, "maincpu")
-		, m_soundcpu(*this, "soundcpu")
-		, m_screen(*this, "screen")
-		, m_palette(*this, "palette")
-		, m_soundlatch(*this, "soundlatch")
-		, m_in0(*this, "IN0")
-		, m_penx1port(*this, "PEN_X_P1")
-		, m_peny1port(*this, "PEN_Y_P1")
-		, m_penx2port(*this, "PEN_X_P2")
-		, m_peny2port(*this, "PEN_Y_P2")
-		, m_sndbank(*this, "sound_bank")
-	{ }
+		:   driver_device(mconfig, type, tag),
+			m_eepromoutport(*this, "EEPROMOUT"),
+			m_qs1000(*this, "qs1000"),
+			m_maincpu(*this, "maincpu"),
+			m_soundcpu(*this, "soundcpu"),
+			m_screen(*this, "screen"),
+			m_palette(*this, "palette"),
+			m_in0(*this, "IN0"),
+			m_penx1port(*this, "PEN_X_P1"),
+			m_peny1port(*this, "PEN_Y_P1"),
+			m_penx2port(*this, "PEN_X_P2"),
+			m_peny2port(*this, "PEN_Y_P2"),
+			m_sndbank(*this, "sound_bank")
+		{ }
 
 	DECLARE_CUSTOM_INPUT_MEMBER(eolith_speedup_getvblank);
 	DECLARE_CUSTOM_INPUT_MEMBER(stealsee_speedup_getvblank);
 
 	DECLARE_READ32_MEMBER(eolith_custom_r);
 	DECLARE_WRITE32_MEMBER(systemcontrol_w);
+	DECLARE_WRITE32_MEMBER(sound_w);
 	DECLARE_READ32_MEMBER(hidctch3_pen1_r);
 	DECLARE_READ32_MEMBER(hidctch3_pen2_r);
 	DECLARE_WRITE32_MEMBER(eolith_vram_w);
 	DECLARE_READ32_MEMBER(eolith_vram_r);
+	DECLARE_READ8_MEMBER(sound_cmd_r);
 	DECLARE_WRITE8_MEMBER(sound_p1_w);
 	DECLARE_READ8_MEMBER(qs1000_p1_r);
 	DECLARE_WRITE8_MEMBER(qs1000_p1_w);
+	DECLARE_WRITE8_MEMBER(soundcpu_to_qs1000);
 
 	DECLARE_DRIVER_INIT(eolith);
 	DECLARE_DRIVER_INIT(landbrk);
@@ -75,7 +76,6 @@ private:
 	optional_device<i8032_device> m_soundcpu;
 	required_device<screen_device> m_screen;
 	required_device<palette_device> m_palette;
-	optional_device<generic_latch_8_device> m_soundlatch;
 
 	optional_ioport m_in0; // klondkp doesn't have it
 	optional_ioport m_penx1port;


### PR DESCRIPTION
Reverts mamedev/mame#3294

This breaks stuff because the MCS51 doesn't have proper emulated serial at the moment - it's still using hacked read8/write8.  Fixing the MCS51 serial is probably going to require changing the CPU core to work at S-cycle level.