### PR TITLE
M1COMM: small fixes

### DIFF
--- a/src/devices/machine/mb89374.cpp
+++ b/src/devices/machine/mb89374.cpp
@@ -1,0 +1,566 @@
+// license:BSD-3-Clause
+// copyright-holders:Ariane Fugmann
+/**
+    MB89374
+
+    Fujitsu
+    Data Link Controller
+
+ **/
+
+#include "emu.h"
+#include "emuopts.h"
+#include "mb89374.h"
+
+//**************************************************************************
+//  LIVE DEVICE
+//**************************************************************************
+
+// device type definition
+DEFINE_DEVICE_TYPE(MB89374, mb89374_device, "mb89374", "MB89374 Data Link Controller")
+
+
+enum
+{
+	REGISTER_SMR0 = 0x00,
+	REGISTER_SMR1,
+	REGISTER_SMR2,
+	REGISTER_CHRR0,
+	REGISTER_CHRR1,
+
+	REGISTER_MSR = 0x06,
+	REGISTER_MCR,
+	REGISTER_RXSR0,
+	REGISTER_RXSR1,
+	REGISTER_RXCR,
+	REGISTER_RXIER,
+	REGISTER_TXSR,
+	REGISTER_TXCR,
+	REGISTER_TXIER,
+	REGISTER_SDR,
+	REGISTER_TXBCR0,
+	REGISTER_TXBCR1,
+	REGISTER_TXFR0,
+	REGISTER_TXFR1,
+	REGISTER_SMR3,
+	REGISTER_PORTR,
+	REGISTER_REQR,
+	REGISTER_MASKR,
+	REGISTER_B1PSR,
+	REGISTER_B1PCR,
+	REGISTER_BG1DR,
+
+	REGISTER_B2SR = 0x1c,
+	REGISTER_B2CR,
+	REGISTER_BG2DR
+};
+
+#define SMR0_MASK     0xf0
+
+#define SMR1_MASK     0xe3
+
+#define MSR_MASK      0x80
+
+#define MCR_MASK      0x14
+
+#define RXSR1_MASK    0x08
+
+#define RXCR_MASK     0x7c
+#define RXCR_HUNT     BIT(m_rxcr, 1)
+#define RXCR_RXE      BIT(m_rxcr, 7)
+
+#define TXSR_MASK     0x60
+#define TXSR_TXRDY    BIT(m_txsr, 0)
+#define TXSR_TXEND    BIT(m_txsr, 4)
+
+#define TXCR_TXRST    BIT(m_txcr, 3)
+#define TXCR_TXE      BIT(m_txcr, 7)
+
+#define TXIER_MASK    0x60
+
+#define TXFR1_MASK    0x70
+
+#define SMR3_MASK     0x80
+
+#define REQR_MASK     0x38
+
+#define MASKR_MASK    0x38
+#define MASKR_MRXDRQ  BIT(m_maskr, 6)
+#define MASKR_MTXDRQ  BIT(m_maskr, 7)
+
+#define B1PSR_MASK    0xfc
+
+#define B2SR_MASK     0xfe
+
+//-------------------------------------------------
+//  mb89374_device - constructor
+//-------------------------------------------------
+
+mb89374_device::mb89374_device( const machine_config &mconfig, const char *tag, device_t *owner, uint32_t clock )
+	: device_t(mconfig, MB89374, tag, owner, clock),
+	device_execute_interface(mconfig, *this),
+	m_icount(0),
+	m_out_irq_cb(*this),
+	m_out_po0_cb(*this),
+	m_out_po1_cb(*this),
+	m_out_po2_cb(*this),
+	m_out_po3_cb(*this),
+	m_line_rx(OPEN_FLAG_WRITE | OPEN_FLAG_CREATE ),
+	m_line_tx(OPEN_FLAG_READ)
+{
+	// prepare localhost "filename"
+	m_localhost[0] = 0;
+	strcat(m_localhost, "socket.");
+	strcat(m_localhost, mconfig.options().comm_localhost());
+	strcat(m_localhost, ":");
+	strcat(m_localhost, mconfig.options().comm_localport());
+
+	// prepare remotehost "filename"
+	m_remotehost[0] = 0;
+	strcat(m_remotehost, "socket.");
+	strcat(m_remotehost, mconfig.options().comm_remotehost());
+	strcat(m_remotehost, ":");
+	strcat(m_remotehost, mconfig.options().comm_remoteport());
+}
+
+
+//-------------------------------------------------
+//  device_start - device-specific startup
+//------------------------------------------------
+
+void mb89374_device::device_start()
+{
+	// set our instruction counter
+	m_icountptr = &m_icount;
+
+	// resolve callbacks
+	m_out_irq_cb.resolve_safe();
+	m_out_po0_cb.resolve_safe();
+	m_out_po1_cb.resolve_safe();
+	m_out_po2_cb.resolve_safe();
+	m_out_po3_cb.resolve_safe();
+}
+
+
+//-------------------------------------------------
+//  device_reset - device-specific reset
+//-------------------------------------------------
+
+void mb89374_device::device_reset()
+{
+	m_smr0   = SMR0_MASK;
+	m_smr1   = SMR1_MASK;
+	m_smr2   = 0x00;
+	m_chrr0  = 0x00;
+	m_chrr1  = 0x00;
+	m_msr    = MSR_MASK;
+	m_mcr    = MCR_MASK;
+	m_rxsr0  = 0x00;
+	m_rxsr1  = RXSR1_MASK;
+	m_rxcr   = RXCR_MASK;
+	m_rxier  = 0x00;
+	m_txsr   = TXSR_MASK;
+	m_txcr   = 0x00;
+	m_txier  = TXIER_MASK;
+	m_sdr    = 0x00;
+	m_txbcr0 = 0x00;
+	m_txbcr1 = 0x00;
+	m_txfr0  = 0x00;
+	m_txfr1  = TXFR1_MASK;
+	m_smr3   = SMR3_MASK;
+	m_portr  = 0x00;
+	m_reqr   = REQR_MASK;
+	m_maskr  = MASKR_MASK;
+	m_b1psr  = B1PSR_MASK;
+	m_b1pcr  = 0x00;
+	m_bg1dr  = 0x00;
+	m_b2sr   = B2SR_MASK;
+	m_b2cr   = 0x00;
+	m_bg2dr  = 0x00;
+
+	set_irq(0);
+	set_po0(0);
+	set_po1(0);
+	set_po2(0);
+	set_po3(0);
+
+	m_rx_length = 0x0000;
+	m_rx_offset = 0x0000;
+
+	m_tx_offset = 0x0000;
+}
+
+
+//-------------------------------------------------
+//  execute_run -
+//-------------------------------------------------
+
+void mb89374_device::execute_run()
+{
+	while (m_icount > 0)
+	{
+		m_icount--;
+	}
+	checkSocket();
+}
+
+
+//-------------------------------------------------
+//  read - handler for register reading
+//-------------------------------------------------
+
+READ8_MEMBER(mb89374_device::read)
+{
+	uint8_t data = 0xff;
+	switch (offset & 0x1f)
+	{
+		case REGISTER_RXSR0:
+			data = m_rxsr0;
+			break;
+			
+		case REGISTER_RXSR1:
+			data = m_rxsr1;
+			break;
+
+		case REGISTER_TXSR:
+			data = m_txsr;
+			break;
+
+		case REGISTER_SDR:
+			m_sdr = rxRead();
+			data = m_sdr;
+			break;
+
+		case REGISTER_PORTR:
+			data = m_portr;
+			break;
+
+		default:
+			logerror("MB89374 unimplemented register read @%02X\n", offset);
+	}
+	//osd_printf_verbose("MB89374 read @%02X = %02X\n", offset, data);
+	return data;
+}
+
+
+//-------------------------------------------------
+//  write - handler for register writing
+//-------------------------------------------------
+
+WRITE8_MEMBER(mb89374_device::write)
+{
+	switch (offset & 0x1f)
+	{
+		case REGISTER_SMR2:
+			m_smr2 = data;
+			break;
+
+		case REGISTER_MCR:
+			m_mcr = data | MCR_MASK;
+			break;
+
+		case REGISTER_RXCR:
+			m_rxcr = data | RXCR_MASK;
+			if (RXCR_HUNT)
+				rxReset();
+			break;
+
+		case REGISTER_TXSR:
+			m_txsr = data | TXSR_MASK;
+			txReset();
+			break;
+
+		case REGISTER_TXCR:
+			m_txcr = data;
+			if (TXCR_TXRST)
+				txReset();
+			break;
+
+		case REGISTER_TXIER:
+			m_txier = data | TXIER_MASK;
+			break;
+
+		case REGISTER_SMR3:
+			m_smr3 = data | SMR3_MASK;
+			break;
+
+		case REGISTER_PORTR:
+			m_portr = data;
+			break;
+
+		case REGISTER_MASKR:
+			m_maskr = data | MASKR_MASK;
+			//osd_printf_verbose("MB89374 MASKR_MTXDRQ = %02X\n", MASKR_MTXDRQ);
+			//osd_printf_verbose("MB89374 TXCR_TXE = %02X\n", TXCR_TXE);
+			set_po2((!MASKR_MTXDRQ && TXCR_TXE) ? 1 : 0);
+			break;
+
+		default:
+			logerror("MB89374 unimplemented register write @%02X = %02X\n", offset, data);
+	}
+	//osd_printf_verbose("MB89374 write @%02X = %02X\n", offset, data);
+}
+
+
+//-------------------------------------------------
+//  pi0_w - handler for RxCI#/PI0
+//-------------------------------------------------
+
+WRITE_LINE_MEMBER(mb89374_device::pi0_w)
+{
+	m_pi0 = state;
+	//osd_printf_verbose("MB89374 pi0_w %02x\n", state );
+}
+
+
+//-------------------------------------------------
+//  pi1_w - handler for TxCI#/PI1
+//-------------------------------------------------
+
+WRITE_LINE_MEMBER(mb89374_device::pi1_w)
+{
+	m_pi1 = state;
+	//osd_printf_verbose("MB89374 pi1_w %02x\n", state );
+}
+
+
+//-------------------------------------------------
+//  pi2_w - handler for TxDACK#/PI2
+//-------------------------------------------------
+
+WRITE_LINE_MEMBER(mb89374_device::pi2_w)
+{
+	m_pi2 = state;
+	//osd_printf_verbose("MB89374 pi2_w %02x\n", state );
+}
+
+
+//-------------------------------------------------
+//  pi3_w - handler for RxDACK#/PI3
+//-------------------------------------------------
+
+WRITE_LINE_MEMBER(mb89374_device::pi3_w)
+{
+	m_pi3 = state;
+	//osd_printf_verbose("MB89374 pi3_w %02x\n", state );
+}
+
+
+//-------------------------------------------------
+//  ci_w - handler for TxLAST#/CI#
+//-------------------------------------------------
+
+WRITE_LINE_MEMBER(mb89374_device::ci_w)
+{
+	m_ci = state;
+	//osd_printf_verbose("MB89374 ci_w %02x\n", state );
+	if (m_ci == 1 && m_pi2 == 0)
+	{
+		txComplete();
+	}
+
+}
+
+
+//-------------------------------------------------
+//  read - handler for dma reading (rx buffer)
+//-------------------------------------------------
+
+READ8_MEMBER(mb89374_device::dma_r)
+{
+	uint8_t data = rxRead();
+	osd_printf_verbose("MB89374 dma_r %02X\n", data);
+	if (m_rx_offset == m_rx_length)
+		set_po3(0); // transfer finished; release dma
+	return data;
+}
+
+
+//-------------------------------------------------
+//  write - handler for dma writing (tx buffer)
+//-------------------------------------------------
+
+WRITE8_MEMBER(mb89374_device::dma_w)
+{
+	txWrite(data);
+}
+
+
+//**************************************************************************
+//  buffer logic
+//**************************************************************************
+
+void mb89374_device::rxReset()
+{
+	m_rx_length = 0;
+	m_rx_offset = 0;
+	m_rxsr0 = 0x06; // RXIDL | DIDL
+}
+
+uint8_t mb89374_device::rxRead()
+{
+	uint8_t data = m_rx_buffer[m_rx_offset];
+	m_rx_offset++;
+	if (m_rx_offset == m_rx_length)
+		m_rxsr0 | 0x40; // EOF
+	if (m_rx_offset >= m_rx_length)
+		rxReset();
+	osd_printf_verbose("MB89374 rxRead %02X\n", data);
+	return data;
+}
+
+void mb89374_device::txReset()
+{
+	m_tx_offset = 0;
+	m_txsr |= 0x05;
+	osd_printf_verbose("MB89374 txReset\n");
+}
+
+void mb89374_device::txWrite(uint8_t data)
+{
+	//osd_printf_verbose("MB89374 txWrite %02X\n", data);
+	m_tx_buffer[m_tx_offset] = data;
+	m_tx_offset++;
+	m_txsr = 0x6b;
+
+	// prevent overflow
+	if (m_tx_offset >= 0x0f00)
+		m_tx_offset = 0x0eff;
+}
+
+void mb89374_device::txComplete()
+{
+	if (m_tx_offset > 0)
+	{
+		osd_printf_verbose("MB89374 txComplete - got %d bytes\n", m_tx_offset);
+		if ((m_line_rx.is_open()) && (m_line_tx.is_open()))
+		{
+			m_socket_buffer[0x00] = m_tx_offset & 0xff;
+			m_socket_buffer[0x01] = (m_tx_offset >> 8) & 0xff;
+			for (int i = 0x00 ; i < m_tx_offset ; i++)
+			{
+				m_socket_buffer[i + 2] = m_tx_buffer[i];
+			}
+			m_line_tx.write(m_socket_buffer, m_tx_offset + 2);
+		}
+	}
+
+	m_txsr = 0x6f;
+
+	txReset();
+}
+
+void mb89374_device::checkSocket()
+{
+	// check rx socket
+	if (!m_line_rx.is_open())
+	{
+		osd_printf_verbose("MB89374 listen on %s\n", m_localhost);
+		m_line_rx.open(m_localhost);
+	}
+
+	// check tx socket
+	if (!m_line_tx.is_open())
+	{
+		osd_printf_verbose("MB89374 connect to %s\n", m_remotehost);
+		m_line_tx.open(m_remotehost);
+	}
+
+	if ((m_line_rx.is_open()) && (m_line_tx.is_open()))
+	{
+		if (m_rx_length == 0)
+		{
+			bool rxEnabled = (!MASKR_MRXDRQ && RXCR_RXE);
+			if (rxEnabled)
+			{
+				int recv = m_line_rx.read(m_socket_buffer, 0x2);
+				if (recv != 0)
+				{
+					if (recv == 2)
+						m_rx_length = m_socket_buffer[0x01] << 8 | m_socket_buffer[0x00];
+					else
+					{
+						m_rx_length = m_socket_buffer[0x00];
+						while (m_line_rx.read(m_socket_buffer, 0x1) == 0) {}
+						m_rx_length |= m_socket_buffer[0x00] << 8;
+					}
+					osd_printf_verbose("MB89374 read size of %d\n", m_rx_length);
+
+					int offset = 0;
+					int togo = m_rx_length;
+					while (togo > 0)
+					{
+						recv = m_line_rx.read(m_socket_buffer, togo);
+						//osd_printf_verbose("MB89374 read %d bytes\n", recv);
+						for (int i = 0x00 ; i < recv ; i++)
+						{
+							m_rx_buffer[offset] = m_tx_buffer[i];
+							offset++;
+						}
+						togo -= recv;
+					}
+
+					m_rx_offset = 0;
+					m_rxsr0 = 0x01; // RXRDY
+					if (m_rx_offset == m_rx_length)
+						m_rxsr0 |= 0x40; // EOF
+					m_rxsr1 = 0xc8;
+					set_po3(rxEnabled ? 1 : 0);
+				}
+			}
+		}
+	}
+}
+
+//**************************************************************************
+//  INLINE HELPERS
+//**************************************************************************
+
+inline void mb89374_device::set_irq(int state)
+{
+	if (m_irq != state)
+	{
+		m_out_irq_cb(state);
+		m_irq = state;
+	}
+}
+
+inline void mb89374_device::set_po0(int state)
+{
+	if (m_po0 != state)
+	{
+		m_out_po0_cb(state);
+		m_po0 = state;
+		//osd_printf_verbose("MB89374 m_po0 %02x\n", state );
+	}
+}
+
+inline void mb89374_device::set_po1(int state)
+{
+	if (m_po1 != state)
+	{
+		set_po1(state);
+		m_po1 = state;
+		//osd_printf_verbose("MB89374 m_po1 %02x\n", state );
+	}
+}
+
+inline void mb89374_device::set_po2(int state)
+{
+	if (m_po2 != state)
+	{
+		m_out_po2_cb(state);
+		m_po2 = state;
+		//osd_printf_verbose("MB89374 m_po2 %02x\n", state );
+	}
+}
+
+inline void mb89374_device::set_po3(int state)
+{
+	if (m_po3 != state)
+	{
+		m_out_po3_cb(state);
+		m_po3 = state;
+		//osd_printf_verbose("MB89374 m_po3 %02x\n", state );
+	}
+}

--- a/src/devices/machine/mb89374.h
+++ b/src/devices/machine/mb89374.h
@@ -1,0 +1,176 @@
+// license:BSD-3-Clause
+// copyright-holders:Ariane Fugmann
+/*
+MB89374
+
+Fujitsu
+Data Link Controller
+
+                _____   _____
+       CLK   1 |*    \_/     | 42  Vcc
+   FORMAT#   2 |             | 41  RxDACK#/PI3
+    RESET#   3 |             | 40  TxDACK#/PI2
+   RD#/DS#   4 |             | 39  RxDRQ/PO3
+ WR#/R/W#    5 |             | 38  TxDRQ/PO2
+       CS#   6 |             | 37  IRQT
+        A4   7 |             | 36  Vss
+        A3   8 |             | 35  IRQ
+        A2   9 |             | 34  FD#/DTR#
+        A1  10 |   MB89374   | 33  SCLK/DSR#
+        A0  11 |             | 32  TxLAST#/CI#
+       Vss  12 |             | 31  TxCI#/PI1
+        D7  13 |             | 30  TxCO#/PO1
+        D6  14 |             | 29  TxD
+        D5  15 |             | 28  RxD
+        D4  16 |             | 27  RxCI#/PI0
+        D3  17 |             | 26  RxCO#/PO0
+        D2  18 |             | 25  DCD#
+        D1  19 |             | 24  CTS#
+        D0  20 |             | 23  TCLK
+       Vss  21 |_____________| 22  LOC#/RTS#
+*/
+
+#ifndef MAME_MACHINE_MB89374_H
+#define MAME_MACHINE_MB89374_H
+
+#pragma once
+
+
+//**************************************************************************
+//  DEVICE CONFIGURATION MACROS
+//**************************************************************************
+
+#define MCFG_MB89374_IRQ_CB(_devcb) \
+	devcb = &downcast<mb89374_device &>(*device).set_out_irq_callback(DEVCB_##_devcb);
+
+#define MCFG_MB89374_PO0_CB(_devcb) \
+	devcb = &downcast<mb89374_device &>(*device).set_out_po0_callback(DEVCB_##_devcb);
+
+#define MCFG_MB89374_PO1_CB(_devcb) \
+	devcb = &downcast<mb89374_device &>(*device).set_out_po1_callback(DEVCB_##_devcb);
+
+#define MCFG_MB89374_PO2_CB(_devcb) \
+	devcb = &downcast<mb89374_device &>(*device).set_out_po2_callback(DEVCB_##_devcb);
+
+#define MCFG_MB89374_PO3_CB(_devcb) \
+	devcb = &downcast<mb89374_device &>(*device).set_out_po3_callback(DEVCB_##_devcb);
+
+
+class mb89374_device : public device_t,
+                       public device_execute_interface
+{
+public:
+	// construction/destruction
+	mb89374_device(const machine_config &mconfig, const char *tag, device_t *owner, uint32_t clock);
+
+	template <class Object> devcb_base &set_out_irq_callback(Object &&cb) { return m_out_irq_cb.set_callback(std::forward<Object>(cb)); }
+	template <class Object> devcb_base &set_out_po0_callback(Object &&cb) { return m_out_po0_cb.set_callback(std::forward<Object>(cb)); }
+	template <class Object> devcb_base &set_out_po1_callback(Object &&cb) { return m_out_po1_cb.set_callback(std::forward<Object>(cb)); }
+	template <class Object> devcb_base &set_out_po2_callback(Object &&cb) { return m_out_po2_cb.set_callback(std::forward<Object>(cb)); }
+	template <class Object> devcb_base &set_out_po3_callback(Object &&cb) { return m_out_po3_cb.set_callback(std::forward<Object>(cb)); }
+
+	// read/write handlers
+	DECLARE_READ8_MEMBER( read );
+	DECLARE_WRITE8_MEMBER( write );
+
+	DECLARE_WRITE_LINE_MEMBER( pi0_w );
+	DECLARE_WRITE_LINE_MEMBER( pi1_w );
+	DECLARE_WRITE_LINE_MEMBER( pi2_w );
+	DECLARE_WRITE_LINE_MEMBER( pi3_w );
+
+	DECLARE_WRITE_LINE_MEMBER( ci_w );
+
+	DECLARE_READ8_MEMBER( dma_r );
+	DECLARE_WRITE8_MEMBER( dma_w );
+
+protected:
+	// device-level overrides
+	virtual void device_start() override;
+	virtual void device_reset() override;
+	virtual void execute_run() override;
+
+	int m_icount;
+
+private:
+	// internal state
+	inline void set_irq(int state);
+	inline void set_po0(int state);
+	inline void set_po1(int state);
+	inline void set_po2(int state);
+	inline void set_po3(int state);
+
+	devcb_write_line   m_out_irq_cb;
+	devcb_write_line   m_out_po0_cb;
+	devcb_write_line   m_out_po1_cb;
+	devcb_write_line   m_out_po2_cb;
+	devcb_write_line   m_out_po3_cb;
+
+	// pins
+	int m_irq;
+	int m_po0;
+	int m_po1;
+	int m_po2;
+	int m_po3;
+	int m_pi0;
+	int m_pi1;
+	int m_pi2;
+	int m_pi3;
+	int m_ci;
+
+	// registers
+	uint8_t m_smr0;
+	uint8_t m_smr1;
+	uint8_t m_smr2;
+	uint8_t m_chrr0;
+	uint8_t m_chrr1;
+	uint8_t m_msr;
+	uint8_t m_mcr;
+	uint8_t m_rxsr0;
+	uint8_t m_rxsr1;
+	uint8_t m_rxcr;
+	uint8_t m_rxier;
+	uint8_t m_txsr;
+	uint8_t m_txcr;
+	uint8_t m_txier;
+	uint8_t m_sdr;
+	uint8_t m_txbcr0;
+	uint8_t m_txbcr1;
+	uint8_t m_txfr0;
+	uint8_t m_txfr1;
+	uint8_t m_smr3;
+	uint8_t m_portr;
+	uint8_t m_reqr;
+	uint8_t m_maskr;
+	uint8_t m_b1psr;
+	uint8_t m_b1pcr;
+	uint8_t m_bg1dr;
+	uint8_t m_b2sr;
+	uint8_t m_b2cr;
+	uint8_t m_bg2dr;
+
+	// 4k buffers (not in hardware)
+	uint16_t m_rx_length;
+	uint16_t m_rx_offset;
+	uint8_t  m_rx_buffer[0x1000];
+	void rxReset();
+	uint8_t rxRead();
+
+	uint16_t m_tx_offset;
+	uint8_t  m_tx_buffer[0x1000];
+	void txReset();
+	void txWrite(uint8_t data);
+	void txComplete();
+
+	emu_file m_line_rx;       // rx line - can be either differential, simple serial or toslink
+	emu_file m_line_tx;       // tx line - is differential, simple serial and toslink
+	char m_localhost[256];
+	char m_remotehost[256];
+	uint8_t  m_socket_buffer[0x1000];
+	void checkSocket();
+};
+
+
+// device type definition
+DECLARE_DEVICE_TYPE(MB89374, mb89374_device)
+
+#endif // MAME_MACHINE_MB89374_H

--- a/src/mame/drivers/model1.cpp
+++ b/src/mame/drivers/model1.cpp
@@ -745,14 +745,13 @@ TIMER_DEVICE_CALLBACK_MEMBER(model1_state::model1_interrupt)
 
 	if (scanline == 384)
 	{
+		if (m_m1comm != nullptr)
+			m_m1comm->check_vint_irq();
 		irq_raise(1);
 	}
 	else if(scanline == 384/2)
 	{
 		irq_raise(m_sound_irq);
-
-		if (m_m1comm != nullptr)
-			m_m1comm->check_vint_irq();
 	}
 }
 

--- a/src/mame/machine/m1comm.cpp
+++ b/src/mame/machine/m1comm.cpp
@@ -67,7 +67,7 @@ void m1comm_device::m1comm_mem(address_map &map)
 {
 	map(0x0000, 0x7fff).rom();
 	map(0x8000, 0x9fff).ram();
-	map(0xc000, 0xffff).rw(this, FUNC(m1comm_device::share_r), FUNC(m1comm_device::share_w));
+	map(0xc000, 0xffff).mask(0x1000).rw(this, FUNC(m1comm_device::share_r), FUNC(m1comm_device::share_w));
 }
 
 /*************************************
@@ -75,12 +75,11 @@ void m1comm_device::m1comm_mem(address_map &map)
  *************************************/
 void m1comm_device::m1comm_io(address_map &map)
 {
-	map.global_mask(0xff);
+	map.global_mask(0x7f);
 	map(0x00, 0x1f).rw(this, FUNC(m1comm_device::dlc_reg_r), FUNC(m1comm_device::dlc_reg_w));
 	map(0x20, 0x2f).rw(this, FUNC(m1comm_device::dma_reg_r), FUNC(m1comm_device::dma_reg_w));
-	map(0x40, 0x40).rw(this, FUNC(m1comm_device::syn_r), FUNC(m1comm_device::syn_w));
-	map(0x60, 0x60).rw(this, FUNC(m1comm_device::zfg_r), FUNC(m1comm_device::zfg_w));
-	map(0xff, 0xff).ram();
+	map(0x40, 0x40).mask(0x01).rw(this, FUNC(m1comm_device::syn_r), FUNC(m1comm_device::syn_w));
+	map(0x60, 0x60).mask(0x01).rw(this, FUNC(m1comm_device::zfg_r), FUNC(m1comm_device::zfg_w));
 }
 
 

--- a/src/mame/machine/m1comm.cpp
+++ b/src/mame/machine/m1comm.cpp
@@ -520,7 +520,7 @@ void m1comm_device::comm_tick()
 
 			// update "ring buffer" if link established
 			// live relay does not send data
-			if (m_linkid != 0x00 && m_shared[5] != 0x00)
+			if (m_linkid != 0x00 && m_shared[4] != 0x00)
 			{
 				m_buffer[0] = m_linkid;
 				frameOffset = frameStart + (m_linkid * frameSize);

--- a/src/mame/machine/m1comm.cpp
+++ b/src/mame/machine/m1comm.cpp
@@ -78,8 +78,8 @@ void m1comm_device::m1comm_io(address_map &map)
 	map.global_mask(0x7f);
 	map(0x00, 0x1f).rw(this, FUNC(m1comm_device::dlc_reg_r), FUNC(m1comm_device::dlc_reg_w));
 	map(0x20, 0x2f).rw(this, FUNC(m1comm_device::dma_reg_r), FUNC(m1comm_device::dma_reg_w));
-	map(0x40, 0x40).mask(0x01).rw(this, FUNC(m1comm_device::syn_r), FUNC(m1comm_device::syn_w));
-	map(0x60, 0x60).mask(0x01).rw(this, FUNC(m1comm_device::zfg_r), FUNC(m1comm_device::zfg_w));
+	map(0x40, 0x5f).mask(0x01).rw(this, FUNC(m1comm_device::syn_r), FUNC(m1comm_device::syn_w));
+	map(0x60, 0x7f).mask(0x01).rw(this, FUNC(m1comm_device::zfg_r), FUNC(m1comm_device::zfg_w));
 }
 
 

--- a/src/mame/machine/m1comm.cpp
+++ b/src/mame/machine/m1comm.cpp
@@ -67,7 +67,7 @@ void m1comm_device::m1comm_mem(address_map &map)
 {
 	map(0x0000, 0x7fff).rom();
 	map(0x8000, 0x9fff).ram();
-	map(0xc000, 0xffff).mask(0x1000).rw(this, FUNC(m1comm_device::share_r), FUNC(m1comm_device::share_w));
+	map(0xc000, 0xffff).mask(0x0fff).rw(this, FUNC(m1comm_device::share_r), FUNC(m1comm_device::share_w));
 }
 
 /*************************************


### PR DESCRIPTION
- VINT = VBLANK

- added memory and i/o masks
this fixes a possible buffer overflow if the z80 tries to access memory at d000-ffff

- ready-to-send flag is located at 0x0004, not 0x0005
this fixes wingwar getting stuck after link-up.