### PR TITLE
M1COMM: minor updates (nw)

### DIFF
--- a/src/mame/drivers/model1.cpp
+++ b/src/mame/drivers/model1.cpp
@@ -745,14 +745,13 @@ TIMER_DEVICE_CALLBACK_MEMBER(model1_state::model1_interrupt)
 
 	if (scanline == 384)
 	{
+		if (m_m1comm != nullptr)
+			m_m1comm->check_vint_irq();
 		irq_raise(1);
 	}
 	else if(scanline == 384/2)
 	{
 		irq_raise(m_sound_irq);
-
-		if (m_m1comm != nullptr)
-			m_m1comm->check_vint_irq();
 	}
 }
 

--- a/src/mame/machine/m1comm.cpp
+++ b/src/mame/machine/m1comm.cpp
@@ -67,7 +67,7 @@ void m1comm_device::m1comm_mem(address_map &map)
 {
 	map(0x0000, 0x7fff).rom();
 	map(0x8000, 0x9fff).ram();
-	map(0xc000, 0xffff).rw(this, FUNC(m1comm_device::share_r), FUNC(m1comm_device::share_w));
+	map(0xc000, 0xffff).mask(0x0fff).rw(this, FUNC(m1comm_device::share_r), FUNC(m1comm_device::share_w));
 }
 
 /*************************************
@@ -75,12 +75,11 @@ void m1comm_device::m1comm_mem(address_map &map)
  *************************************/
 void m1comm_device::m1comm_io(address_map &map)
 {
-	map.global_mask(0xff);
+	map.global_mask(0x7f);
 	map(0x00, 0x1f).rw(this, FUNC(m1comm_device::dlc_reg_r), FUNC(m1comm_device::dlc_reg_w));
 	map(0x20, 0x2f).rw(this, FUNC(m1comm_device::dma_reg_r), FUNC(m1comm_device::dma_reg_w));
-	map(0x40, 0x40).rw(this, FUNC(m1comm_device::syn_r), FUNC(m1comm_device::syn_w));
-	map(0x60, 0x60).rw(this, FUNC(m1comm_device::zfg_r), FUNC(m1comm_device::zfg_w));
-	map(0xff, 0xff).ram();
+	map(0x40, 0x5f).mask(0x01).rw(this, FUNC(m1comm_device::syn_r), FUNC(m1comm_device::syn_w));
+	map(0x60, 0x7f).mask(0x01).rw(this, FUNC(m1comm_device::zfg_r), FUNC(m1comm_device::zfg_w));
 }
 
 
@@ -520,7 +519,7 @@ void m1comm_device::comm_tick()
 
 			// update "ring buffer" if link established
 			// live relay does not send data
-			if (m_linkid != 0x00 && m_shared[5] != 0x00)
+			if (m_linkid != 0x00 && m_shared[4] != 0x00)
 			{
 				m_buffer[0] = m_linkid;
 				frameOffset = frameStart + (m_linkid * frameSize);


### PR DESCRIPTION
- VINT = VBLANK

- added memory and i/o masks
this fixes a possible buffer overflow if the z80 tries to access memory at d000-ffff

- ready-to-send flag is located at 0x0004, not 0x0005
this fixes wingwar getting stuck after link-up.