### PR TITLE
i8214: check pending interrupts when ETLG and INTE lines change (nw)

### DIFF
--- a/src/devices/machine/i8214.cpp
+++ b/src/devices/machine/i8214.cpp
@@ -204,6 +204,8 @@ WRITE_LINE_MEMBER( i8214_device::etlg_w )
 	LOG("I8214 ETLG: %u\n", state);
 
 	m_etlg = state;
+
+	check_interrupt();
 }
 
 
@@ -216,4 +218,6 @@ WRITE_LINE_MEMBER( i8214_device::inte_w )
 	LOG("I8214 INTE: %u\n", state);
 
 	m_inte = state;
+
+	check_interrupt();
 }


### PR DESCRIPTION
This solves most of screen corruption in ms6102 (8275 sometimes happens to set IRQ while INTE=0 in 8214, so interrupt is ignored and never handled.)