### PR TITLE
Relax constraints on address mirroring/global mask combinations. Mirr…

### DIFF
--- a/src/emu/addrmap.cpp
+++ b/src/emu/addrmap.cpp
@@ -677,6 +677,12 @@ void address_map::map_validity_check(validity_checker &valid, int spacenum) cons
 			osd_printf_error("In %s memory range %x-%x, start address is outside of the global address mask %x\n", spaceconfig.m_name, entry.m_addrstart, entry.m_addrend, globalmask);
 		if (entry.m_addrend & ~globalmask)
 			osd_printf_error("In %s memory range %x-%x, end address is outside of the global address mask %x\n", spaceconfig.m_name, entry.m_addrstart, entry.m_addrend, globalmask);
+		if (entry.m_addrmask & ~globalmask)
+			osd_printf_error("In %s range %x-%x mask %x mirror %x select %x, mask is outside of the global address mask %x, did you mean %x ?\n", spaceconfig.m_name, entry.m_addrstart, entry.m_addrend, entry.m_addrmask, entry.m_addrmirror, entry.m_addrselect, globalmask, entry.m_addrmask & globalmask);
+		if ((entry.m_addrmirror & ~globalmask) && (entry.m_addrmirror | globalmask) != 0xffffffff >> (32 - spaceconfig.m_addr_width))
+			osd_printf_error("In %s range %x-%x mask %x mirror %x select %x, mirror is outside of the global address mask %x, did you mean %x ?\n", spaceconfig.m_name, entry.m_addrstart, entry.m_addrend, entry.m_addrmask, entry.m_addrmirror, entry.m_addrselect, globalmask, entry.m_addrmirror & globalmask);
+		if (entry.m_addrselect & ~globalmask)
+			osd_printf_error("In %s range %x-%x mask %x mirror %x select %x, select is outside of the global address mask %x, did you mean %x ?\n", spaceconfig.m_name, entry.m_addrstart, entry.m_addrend, entry.m_addrmask, entry.m_addrmirror, entry.m_addrselect, globalmask, entry.m_addrselect & globalmask);
 
 		// look for misaligned entries
 		if (entry.m_read.m_type != AMH_NONE)

--- a/src/emu/emumem.cpp
+++ b/src/emu/emumem.cpp
@@ -2043,8 +2043,6 @@ void address_space::check_optimize_all(const char *function, int width, offs_t a
 
 	if (addrmask & ~m_addrmask)
 		fatalerror("%s: In range %x-%x mask %x mirror %x select %x, mask is outside of the global address mask %x, did you mean %x ?\n", function, addrstart, addrend, addrmask, addrmirror, addrselect, m_addrmask, addrmask & m_addrmask);
-	if (addrmirror & ~m_addrmask)
-		fatalerror("%s: In range %x-%x mask %x mirror %x select %x, mirror is outside of the global address mask %x, did you mean %x ?\n", function, addrstart, addrend, addrmask, addrmirror, addrselect, m_addrmask, addrmirror & m_addrmask);
 	if (addrselect & ~m_addrmask)
 		fatalerror("%s: In range %x-%x mask %x mirror %x select %x, select is outside of the global address mask %x, did you mean %x ?\n", function, addrstart, addrend, addrmask, addrmirror, addrselect, m_addrmask, addrselect & m_addrmask);
 	if (addrmask & ~changing_bits)
@@ -2108,7 +2106,7 @@ void address_space::check_optimize_all(const char *function, int width, offs_t a
 	nstart = addrstart;
 	nend = addrend;
 	nmask = (addrmask ? addrmask : changing_bits) | addrselect;
-	nmirror = addrmirror | addrselect;
+	nmirror = (addrmirror & m_addrmask) | addrselect;
 	if(nmirror && !(nstart & changing_bits) && !((~nend) & changing_bits)) {
 		// If the range covers the a complete power-of-two zone, it is
 		// possible to remove 1 bits from the mirror, pushing the end

--- a/src/mame/drivers/ddenlovr.cpp
+++ b/src/mame/drivers/ddenlovr.cpp
@@ -2289,27 +2289,29 @@ void ddenlovr_state::quizchq_map(address_map &map)
 
 void ddenlovr_state::quizchq_portmap(address_map &map)
 {
-	map(0x00, 0x01).mirror(0xff00).w(this, FUNC(ddenlovr_state::ddenlovr_blitter_w));
-	map(0x03, 0x03).mirror(0xff00).r(this, FUNC(ddenlovr_state::rongrong_gfxrom_r));
+	map.global_mask(0xff);
 
-	map(0x20, 0x20).mirror(0xff00).w(this, FUNC(ddenlovr_state::ddenlovr_select2_w));
-	map(0x22, 0x23).mirror(0xff00).r(this, FUNC(ddenlovr_state::rongrong_input2_r));
+	map(0x00, 0x01).w(this, FUNC(ddenlovr_state::ddenlovr_blitter_w));
+	map(0x03, 0x03).r(this, FUNC(ddenlovr_state::rongrong_gfxrom_r));
 
-	map(0x40, 0x40).mirror(0xff00).rw(m_oki, FUNC(okim6295_device::read), FUNC(okim6295_device::write));
-	map(0x60, 0x61).mirror(0xff00).w("ym2413", FUNC(ym2413_device::write));
+	map(0x20, 0x20).w(this, FUNC(ddenlovr_state::ddenlovr_select2_w));
+	map(0x22, 0x23).r(this, FUNC(ddenlovr_state::rongrong_input2_r));
 
-	map(0x80, 0x83).mirror(0xff00).w(this, FUNC(ddenlovr_state::ddenlovr_palette_base_w));
-	map(0x84, 0x87).mirror(0xff00).w(this, FUNC(ddenlovr_state::ddenlovr_palette_mask_w));
-	map(0x88, 0x8b).mirror(0xff00).w(this, FUNC(ddenlovr_state::ddenlovr_transparency_pen_w));
-	map(0x8c, 0x8f).mirror(0xff00).w(this, FUNC(ddenlovr_state::ddenlovr_transparency_mask_w));
-	map(0x94, 0x94).mirror(0xff00).w(this, FUNC(ddenlovr_state::ddenlovr_bgcolor_w));
-	map(0x95, 0x95).mirror(0xff00).w(this, FUNC(ddenlovr_state::ddenlovr_priority_w));
-	map(0x96, 0x96).mirror(0xff00).w(this, FUNC(ddenlovr_state::ddenlovr_layer_enable_w));
-	map(0x98, 0x98).mirror(0xff00).r(this, FUNC(ddenlovr_state::unk_r));                         // ? must be 78 on startup
+	map(0x40, 0x40).rw(m_oki, FUNC(okim6295_device::read), FUNC(okim6295_device::write));
+	map(0x60, 0x61).w("ym2413", FUNC(ym2413_device::write));
 
-	map(0xa0, 0xaf).mirror(0xff00).rw("rtc", FUNC(msm6242_device::read), FUNC(msm6242_device::write));
-	map(0xc0, 0xc0).mirror(0xff00).w(this, FUNC(ddenlovr_state::quizchq_oki_bank_w));
-	map(0xc2, 0xc2).mirror(0xff00).nopw();                        // enables palette RAM at 8000
+	map(0x80, 0x83).w(this, FUNC(ddenlovr_state::ddenlovr_palette_base_w));
+	map(0x84, 0x87).w(this, FUNC(ddenlovr_state::ddenlovr_palette_mask_w));
+	map(0x88, 0x8b).w(this, FUNC(ddenlovr_state::ddenlovr_transparency_pen_w));
+	map(0x8c, 0x8f).w(this, FUNC(ddenlovr_state::ddenlovr_transparency_mask_w));
+	map(0x94, 0x94).w(this, FUNC(ddenlovr_state::ddenlovr_bgcolor_w));
+	map(0x95, 0x95).w(this, FUNC(ddenlovr_state::ddenlovr_priority_w));
+	map(0x96, 0x96).w(this, FUNC(ddenlovr_state::ddenlovr_layer_enable_w));
+	map(0x98, 0x98).r(this, FUNC(ddenlovr_state::unk_r));                         // ? must be 78 on startup
+
+	map(0xa0, 0xaf).rw("rtc", FUNC(msm6242_device::read), FUNC(msm6242_device::write));
+	map(0xc0, 0xc0).w(this, FUNC(ddenlovr_state::quizchq_oki_bank_w));
+	map(0xc2, 0xc2).nopw();                        // enables palette RAM at 8000
 }
 
 
@@ -2325,25 +2327,27 @@ void ddenlovr_state::rongrong_map(address_map &map)
 
 void ddenlovr_state::rongrong_portmap(address_map &map)
 {
-	map(0x00, 0x01).mirror(0xff00).w(this, FUNC(ddenlovr_state::ddenlovr_blitter_w));
-	map(0x03, 0x03).mirror(0xff00).r(this, FUNC(ddenlovr_state::rongrong_gfxrom_r));
+	map.global_mask(0xff);
 
-	map(0x20, 0x2f).mirror(0xff00).rw("rtc", FUNC(msm6242_device::read), FUNC(msm6242_device::write));
-	map(0x40, 0x40).mirror(0xff00).rw(m_oki, FUNC(okim6295_device::read), FUNC(okim6295_device::write));
-	map(0x60, 0x61).mirror(0xff00).w("ym2413", FUNC(ym2413_device::write));
+	map(0x00, 0x01).w(this, FUNC(ddenlovr_state::ddenlovr_blitter_w));
+	map(0x03, 0x03).r(this, FUNC(ddenlovr_state::rongrong_gfxrom_r));
 
-	map(0x80, 0x83).mirror(0xff00).w(this, FUNC(ddenlovr_state::ddenlovr_palette_base_w));
-	map(0x84, 0x87).mirror(0xff00).w(this, FUNC(ddenlovr_state::ddenlovr_palette_mask_w));
-	map(0x88, 0x8b).mirror(0xff00).w(this, FUNC(ddenlovr_state::ddenlovr_transparency_pen_w));
-	map(0x8c, 0x8f).mirror(0xff00).w(this, FUNC(ddenlovr_state::ddenlovr_transparency_mask_w));
-	map(0x94, 0x94).mirror(0xff00).w(this, FUNC(ddenlovr_state::ddenlovr_bgcolor_w));
-	map(0x95, 0x95).mirror(0xff00).w(this, FUNC(ddenlovr_state::ddenlovr_priority_w));
-	map(0x96, 0x96).mirror(0xff00).w(this, FUNC(ddenlovr_state::ddenlovr_layer_enable_w));
-	map(0x98, 0x98).mirror(0xff00).r(this, FUNC(ddenlovr_state::unk_r));                                 // ? must be 78 on startup
+	map(0x20, 0x2f).rw("rtc", FUNC(msm6242_device::read), FUNC(msm6242_device::write));
+	map(0x40, 0x40).rw(m_oki, FUNC(okim6295_device::read), FUNC(okim6295_device::write));
+	map(0x60, 0x61).w("ym2413", FUNC(ym2413_device::write));
 
-	map(0xa0, 0xa0).mirror(0xff00).w(this, FUNC(ddenlovr_state::ddenlovr_select2_w));
-	map(0xa2, 0xa3).mirror(0xff00).r(this, FUNC(ddenlovr_state::rongrong_input2_r));
-	map(0xc2, 0xc2).mirror(0xff00).nopw();                                    // enables palette RAM at f000, and protection device at f705/f706/f601
+	map(0x80, 0x83).w(this, FUNC(ddenlovr_state::ddenlovr_palette_base_w));
+	map(0x84, 0x87).w(this, FUNC(ddenlovr_state::ddenlovr_palette_mask_w));
+	map(0x88, 0x8b).w(this, FUNC(ddenlovr_state::ddenlovr_transparency_pen_w));
+	map(0x8c, 0x8f).w(this, FUNC(ddenlovr_state::ddenlovr_transparency_mask_w));
+	map(0x94, 0x94).w(this, FUNC(ddenlovr_state::ddenlovr_bgcolor_w));
+	map(0x95, 0x95).w(this, FUNC(ddenlovr_state::ddenlovr_priority_w));
+	map(0x96, 0x96).w(this, FUNC(ddenlovr_state::ddenlovr_layer_enable_w));
+	map(0x98, 0x98).r(this, FUNC(ddenlovr_state::unk_r));                                 // ? must be 78 on startup
+
+	map(0xa0, 0xa0).w(this, FUNC(ddenlovr_state::ddenlovr_select2_w));
+	map(0xa2, 0xa3).r(this, FUNC(ddenlovr_state::rongrong_input2_r));
+	map(0xc2, 0xc2).nopw();                                    // enables palette RAM at f000, and protection device at f705/f706/f601
 }
 /*
 1e input select,1c input read
@@ -2587,30 +2591,31 @@ WRITE8_MEMBER(ddenlovr_state::funkyfig_lockout_w)
 
 void ddenlovr_state::funkyfig_portmap(address_map &map)
 {
-	map(0x00, 0x00).mirror(0xff00).rw(m_oki, FUNC(okim6295_device::read), FUNC(okim6295_device::write));   // Sound
-	map(0x01, 0x01).mirror(0xff00).w(this, FUNC(ddenlovr_state::mmpanic_leds_w));       // Leds
-	map(0x02, 0x02).mirror(0xff00).w(m_soundlatch, FUNC(generic_latch_8_device::write));
-	map(0x04, 0x04).mirror(0xff00).r(this, FUNC(ddenlovr_state::funkyfig_busy_r));
-	map(0x20, 0x21).mirror(0xff00).w(this, FUNC(ddenlovr_state::funkyfig_blitter_w));
-	map(0x23, 0x23).mirror(0xff00).r(this, FUNC(ddenlovr_state::rongrong_gfxrom_r));     // Video Chip
-	map(0x40, 0x4f).mirror(0xff00).rw("rtc", FUNC(msm6242_device::read), FUNC(msm6242_device::write));
+	map.global_mask(0xff);
+	map(0x00, 0x00).rw(m_oki, FUNC(okim6295_device::read), FUNC(okim6295_device::write));   // Sound
+	map(0x01, 0x01).w(this, FUNC(ddenlovr_state::mmpanic_leds_w));       // Leds
+	map(0x02, 0x02).w(m_soundlatch, FUNC(generic_latch_8_device::write));
+	map(0x04, 0x04).r(this, FUNC(ddenlovr_state::funkyfig_busy_r));
+	map(0x20, 0x21).w(this, FUNC(ddenlovr_state::funkyfig_blitter_w));
+	map(0x23, 0x23).r(this, FUNC(ddenlovr_state::rongrong_gfxrom_r));     // Video Chip
+	map(0x40, 0x4f).rw("rtc", FUNC(msm6242_device::read), FUNC(msm6242_device::write));
 
 	// Layers 0-3:
-	map(0x60, 0x63).mirror(0xff00).w(this, FUNC(ddenlovr_state::ddenlovr_palette_base_w));
-	map(0x64, 0x67).mirror(0xff00).w(this, FUNC(ddenlovr_state::ddenlovr_palette_mask_w));
-	map(0x68, 0x6b).mirror(0xff00).w(this, FUNC(ddenlovr_state::ddenlovr_transparency_pen_w));
-	map(0x6c, 0x6f).mirror(0xff00).w(this, FUNC(ddenlovr_state::ddenlovr_transparency_mask_w));
-	map(0x74, 0x74).mirror(0xff00).w(this, FUNC(ddenlovr_state::ddenlovr_bgcolor_w));
-	map(0x75, 0x75).mirror(0xff00).w(this, FUNC(ddenlovr_state::ddenlovr_priority_w));
-	map(0x76, 0x76).mirror(0xff00).w(this, FUNC(ddenlovr_state::ddenlovr_layer_enable_w));
-	map(0x78, 0x78).mirror(0xff00).r(this, FUNC(ddenlovr_state::unk_r));                 // ? must be 78 on startup
+	map(0x60, 0x63).w(this, FUNC(ddenlovr_state::ddenlovr_palette_base_w));
+	map(0x64, 0x67).w(this, FUNC(ddenlovr_state::ddenlovr_palette_mask_w));
+	map(0x68, 0x6b).w(this, FUNC(ddenlovr_state::ddenlovr_transparency_pen_w));
+	map(0x6c, 0x6f).w(this, FUNC(ddenlovr_state::ddenlovr_transparency_mask_w));
+	map(0x74, 0x74).w(this, FUNC(ddenlovr_state::ddenlovr_bgcolor_w));
+	map(0x75, 0x75).w(this, FUNC(ddenlovr_state::ddenlovr_priority_w));
+	map(0x76, 0x76).w(this, FUNC(ddenlovr_state::ddenlovr_layer_enable_w));
+	map(0x78, 0x78).r(this, FUNC(ddenlovr_state::unk_r));                 // ? must be 78 on startup
 
-	map(0x80, 0x80).mirror(0xff00).w(this, FUNC(ddenlovr_state::ddenlovr_select2_w));
-	map(0x81, 0x81).mirror(0xff00).w(this, FUNC(ddenlovr_state::funkyfig_lockout_w));
-	map(0x82, 0x82).mirror(0xff00).r(this, FUNC(ddenlovr_state::funkyfig_coin_r));
-	map(0x83, 0x83).mirror(0xff00).r(this, FUNC(ddenlovr_state::funkyfig_key_r));
+	map(0x80, 0x80).w(this, FUNC(ddenlovr_state::ddenlovr_select2_w));
+	map(0x81, 0x81).w(this, FUNC(ddenlovr_state::funkyfig_lockout_w));
+	map(0x82, 0x82).r(this, FUNC(ddenlovr_state::funkyfig_coin_r));
+	map(0x83, 0x83).r(this, FUNC(ddenlovr_state::funkyfig_key_r));
 
-	map(0xa2, 0xa2).mirror(0xff00).w(this, FUNC(ddenlovr_state::mmpanic_leds2_w));
+	map(0xa2, 0xa2).w(this, FUNC(ddenlovr_state::mmpanic_leds2_w));
 }
 
 
@@ -3037,38 +3042,40 @@ READ8_MEMBER(ddenlovr_state::mjschuka_protection_r)
 
 void ddenlovr_state::mjschuka_portmap(address_map &map)
 {
-	map(0x00, 0x0f).mirror(0xff00).rw("rtc", FUNC(msm6242_device::read), FUNC(msm6242_device::write));
+	map.global_mask(0xff);
 
-	map(0x20, 0x23).mirror(0xff00).w(this, FUNC(ddenlovr_state::ddenlovr_palette_base_w));
-	map(0x24, 0x27).mirror(0xff00).w(this, FUNC(ddenlovr_state::ddenlovr_palette_mask_w));
-	map(0x28, 0x2b).mirror(0xff00).w(this, FUNC(ddenlovr_state::ddenlovr_transparency_pen_w));
-	map(0x2c, 0x2f).mirror(0xff00).w(this, FUNC(ddenlovr_state::ddenlovr_transparency_mask_w));
-	map(0x34, 0x34).mirror(0xff00).w(this, FUNC(ddenlovr_state::ddenlovr_bgcolor_w));
-	map(0x35, 0x35).mirror(0xff00).w(this, FUNC(ddenlovr_state::ddenlovr_priority_w));
-	map(0x36, 0x36).mirror(0xff00).w(this, FUNC(ddenlovr_state::ddenlovr_layer_enable_w));
-	map(0x38, 0x38).mirror(0xff00).nopr();         // ? ack or watchdog
+	map(0x00, 0x0f).rw("rtc", FUNC(msm6242_device::read), FUNC(msm6242_device::write));
 
-	map(0x40, 0x41).mirror(0xff00).w(this, FUNC(ddenlovr_state::ddenlovr_blitter_w));
-	map(0x43, 0x43).mirror(0xff00).r(this, FUNC(ddenlovr_state::rongrong_gfxrom_r));
-	map(0x50, 0x50).mirror(0xff00).w(this, FUNC(ddenlovr_state::mjflove_okibank_w));
+	map(0x20, 0x23).w(this, FUNC(ddenlovr_state::ddenlovr_palette_base_w));
+	map(0x24, 0x27).w(this, FUNC(ddenlovr_state::ddenlovr_palette_mask_w));
+	map(0x28, 0x2b).w(this, FUNC(ddenlovr_state::ddenlovr_transparency_pen_w));
+	map(0x2c, 0x2f).w(this, FUNC(ddenlovr_state::ddenlovr_transparency_mask_w));
+	map(0x34, 0x34).w(this, FUNC(ddenlovr_state::ddenlovr_bgcolor_w));
+	map(0x35, 0x35).w(this, FUNC(ddenlovr_state::ddenlovr_priority_w));
+	map(0x36, 0x36).w(this, FUNC(ddenlovr_state::ddenlovr_layer_enable_w));
+	map(0x38, 0x38).nopr();         // ? ack or watchdog
 
-	map(0x54, 0x54).mirror(0xff00).rw(this, FUNC(ddenlovr_state::mjschuka_protection_r), FUNC(ddenlovr_state::mjschuka_protection_w));
+	map(0x40, 0x41).w(this, FUNC(ddenlovr_state::ddenlovr_blitter_w));
+	map(0x43, 0x43).r(this, FUNC(ddenlovr_state::rongrong_gfxrom_r));
+	map(0x50, 0x50).w(this, FUNC(ddenlovr_state::mjflove_okibank_w));
+
+	map(0x54, 0x54).rw(this, FUNC(ddenlovr_state::mjschuka_protection_r), FUNC(ddenlovr_state::mjschuka_protection_w));
 	// 58 writes ? (0/1)
-	map(0x5c, 0x5c).mirror(0xff00).r(this, FUNC(ddenlovr_state::hanakanz_rand_r));
+	map(0x5c, 0x5c).r(this, FUNC(ddenlovr_state::hanakanz_rand_r));
 
-	map(0x60, 0x60).mirror(0xff00).w(this, FUNC(ddenlovr_state::sryudens_coincounter_w));
-	map(0x61, 0x61).mirror(0xff00).w(this, FUNC(ddenlovr_state::hanakanz_keyb_w));
-	map(0x62, 0x62).mirror(0xff00).portr("SYSTEM");
-	map(0x63, 0x64).mirror(0xff00).r(this, FUNC(ddenlovr_state::sryudens_keyb_r));
+	map(0x60, 0x60).w(this, FUNC(ddenlovr_state::sryudens_coincounter_w));
+	map(0x61, 0x61).w(this, FUNC(ddenlovr_state::hanakanz_keyb_w));
+	map(0x62, 0x62).portr("SYSTEM");
+	map(0x63, 0x64).r(this, FUNC(ddenlovr_state::sryudens_keyb_r));
 
-	map(0x68, 0x68).mirror(0xff00).portr("DSW1");
-	map(0x69, 0x69).mirror(0xff00).portr("DSW2");
-	map(0x6a, 0x6a).mirror(0xff00).portr("DSW3");
-	map(0x6b, 0x6b).mirror(0xff00).portr("DSW4");
-	map(0x6c, 0x6c).mirror(0xff00).portr("DSW5");     // DSW 1-4 high bits
-	map(0x70, 0x71).mirror(0xff00).w("aysnd", FUNC(ay8910_device::address_data_w));
-	map(0x74, 0x74).mirror(0xff00).rw(m_oki, FUNC(okim6295_device::read), FUNC(okim6295_device::write));
-	map(0x78, 0x79).mirror(0xff00).w("ym2413", FUNC(ym2413_device::write));
+	map(0x68, 0x68).portr("DSW1");
+	map(0x69, 0x69).portr("DSW2");
+	map(0x6a, 0x6a).portr("DSW3");
+	map(0x6b, 0x6b).portr("DSW4");
+	map(0x6c, 0x6c).portr("DSW5");     // DSW 1-4 high bits
+	map(0x70, 0x71).w("aysnd", FUNC(ay8910_device::address_data_w));
+	map(0x74, 0x74).rw(m_oki, FUNC(okim6295_device::read), FUNC(okim6295_device::write));
+	map(0x78, 0x79).w("ym2413", FUNC(ym2413_device::write));
 }
 
 
@@ -3169,28 +3176,29 @@ WRITE_LINE_MEMBER(ddenlovr_state::mjmyster_blitter_irq)
 
 void ddenlovr_state::mjmyster_portmap(address_map &map)
 {
-	map(0x00, 0x01).mirror(0xff00).w(this, FUNC(ddenlovr_state::ddenlovr_blitter_w));
-	map(0x03, 0x03).mirror(0xff00).r(this, FUNC(ddenlovr_state::rongrong_gfxrom_r));
-	map(0x20, 0x20).mirror(0xff00).w(this, FUNC(ddenlovr_state::mjmyster_select2_w));
-	map(0x21, 0x21).mirror(0xff00).w(this, FUNC(ddenlovr_state::mjmyster_coincounter_w));
-	map(0x22, 0x22).mirror(0xff00).r(this, FUNC(ddenlovr_state::mjmyster_coins_r));
-	map(0x23, 0x23).mirror(0xff00).r(this, FUNC(ddenlovr_state::mjmyster_keyb_r));
-	map(0x40, 0x40).mirror(0xff00).rw(m_oki, FUNC(okim6295_device::read), FUNC(okim6295_device::write));
-	map(0x42, 0x43).mirror(0xff00).w("ym2413", FUNC(ym2413_device::write));
-	map(0x44, 0x44).mirror(0xff00).r("aysnd", FUNC(ay8910_device::data_r));
-	map(0x46, 0x46).mirror(0xff00).w("aysnd", FUNC(ay8910_device::data_w));
-	map(0x48, 0x48).mirror(0xff00).w("aysnd", FUNC(ay8910_device::address_w));
-	map(0x60, 0x6f).mirror(0xff00).rw("rtc", FUNC(msm6242_device::read), FUNC(msm6242_device::write));
-	map(0x80, 0x83).mirror(0xff00).w(this, FUNC(ddenlovr_state::ddenlovr_palette_base_w));
-	map(0x84, 0x87).mirror(0xff00).w(this, FUNC(ddenlovr_state::ddenlovr_palette_mask_w));
-	map(0x88, 0x8b).mirror(0xff00).w(this, FUNC(ddenlovr_state::ddenlovr_transparency_pen_w));
-	map(0x8c, 0x8f).mirror(0xff00).w(this, FUNC(ddenlovr_state::ddenlovr_transparency_mask_w));
-	map(0x94, 0x94).mirror(0xff00).w(this, FUNC(ddenlovr_state::ddenlovr_bgcolor_w));
-	map(0x95, 0x95).mirror(0xff00).w(this, FUNC(ddenlovr_state::ddenlovr_priority_w));
-	map(0x96, 0x96).mirror(0xff00).w(this, FUNC(ddenlovr_state::ddenlovr_layer_enable_w));
-	map(0x98, 0x98).mirror(0xff00).r(this, FUNC(ddenlovr_state::unk_r));                         // ? must be 78 on startup
-	map(0xc2, 0xc2).mirror(0xff00).r(this, FUNC(ddenlovr_state::hanakanz_rand_r));
-	map(0xc3, 0xc3).mirror(0xff00).r(this, FUNC(ddenlovr_state::mjmyster_dsw_r));
+	map.global_mask(0xff);
+	map(0x00, 0x01).w(this, FUNC(ddenlovr_state::ddenlovr_blitter_w));
+	map(0x03, 0x03).r(this, FUNC(ddenlovr_state::rongrong_gfxrom_r));
+	map(0x20, 0x20).w(this, FUNC(ddenlovr_state::mjmyster_select2_w));
+	map(0x21, 0x21).w(this, FUNC(ddenlovr_state::mjmyster_coincounter_w));
+	map(0x22, 0x22).r(this, FUNC(ddenlovr_state::mjmyster_coins_r));
+	map(0x23, 0x23).r(this, FUNC(ddenlovr_state::mjmyster_keyb_r));
+	map(0x40, 0x40).rw(m_oki, FUNC(okim6295_device::read), FUNC(okim6295_device::write));
+	map(0x42, 0x43).w("ym2413", FUNC(ym2413_device::write));
+	map(0x44, 0x44).r("aysnd", FUNC(ay8910_device::data_r));
+	map(0x46, 0x46).w("aysnd", FUNC(ay8910_device::data_w));
+	map(0x48, 0x48).w("aysnd", FUNC(ay8910_device::address_w));
+	map(0x60, 0x6f).rw("rtc", FUNC(msm6242_device::read), FUNC(msm6242_device::write));
+	map(0x80, 0x83).w(this, FUNC(ddenlovr_state::ddenlovr_palette_base_w));
+	map(0x84, 0x87).w(this, FUNC(ddenlovr_state::ddenlovr_palette_mask_w));
+	map(0x88, 0x8b).w(this, FUNC(ddenlovr_state::ddenlovr_transparency_pen_w));
+	map(0x8c, 0x8f).w(this, FUNC(ddenlovr_state::ddenlovr_transparency_mask_w));
+	map(0x94, 0x94).w(this, FUNC(ddenlovr_state::ddenlovr_bgcolor_w));
+	map(0x95, 0x95).w(this, FUNC(ddenlovr_state::ddenlovr_priority_w));
+	map(0x96, 0x96).w(this, FUNC(ddenlovr_state::ddenlovr_layer_enable_w));
+	map(0x98, 0x98).r(this, FUNC(ddenlovr_state::unk_r));                         // ? must be 78 on startup
+	map(0xc2, 0xc2).r(this, FUNC(ddenlovr_state::hanakanz_rand_r));
+	map(0xc3, 0xc3).r(this, FUNC(ddenlovr_state::mjmyster_dsw_r));
 }
 
 /***************************************************************************
@@ -3338,26 +3346,27 @@ WRITE8_MEMBER(ddenlovr_state::hginga_blitter_w)
 
 void ddenlovr_state::hginga_portmap(address_map &map)
 {
-	map(0x00, 0x01).mirror(0xff00).w(this, FUNC(ddenlovr_state::hginga_blitter_w));
-	map(0x03, 0x03).mirror(0xff00).r(this, FUNC(ddenlovr_state::rongrong_gfxrom_r));
-	map(0x22, 0x23).mirror(0xff00).w("ym2413", FUNC(ym2413_device::write));
-	map(0x24, 0x24).mirror(0xff00).r("aysnd", FUNC(ay8910_device::data_r));
-	map(0x26, 0x26).mirror(0xff00).w("aysnd", FUNC(ay8910_device::data_w));
-	map(0x28, 0x28).mirror(0xff00).w("aysnd", FUNC(ay8910_device::address_w));
-	map(0x40, 0x40).mirror(0xff00).w(this, FUNC(ddenlovr_state::hginga_input_w));
-	map(0x41, 0x41).mirror(0xff00).w(this, FUNC(ddenlovr_state::hginga_coins_w));
-	map(0x42, 0x42).mirror(0xff00).r(this, FUNC(ddenlovr_state::hginga_coins_r));
-	map(0x43, 0x43).mirror(0xff00).r(this, FUNC(ddenlovr_state::hginga_input_r));
-	map(0x60, 0x6f).mirror(0xff00).rw("rtc", FUNC(msm6242_device::read), FUNC(msm6242_device::write));
-	map(0x80, 0x80).mirror(0xff00).w(this, FUNC(ddenlovr_state::hginga_80_w));
-	map(0xa0, 0xa3).mirror(0xff00).w(this, FUNC(ddenlovr_state::ddenlovr_palette_base_w));
-	map(0xa4, 0xa7).mirror(0xff00).w(this, FUNC(ddenlovr_state::ddenlovr_palette_mask_w));
-	map(0xa8, 0xab).mirror(0xff00).w(this, FUNC(ddenlovr_state::ddenlovr_transparency_pen_w));
-	map(0xac, 0xaf).mirror(0xff00).w(this, FUNC(ddenlovr_state::ddenlovr_transparency_mask_w));
-	map(0xb4, 0xb4).mirror(0xff00).w(this, FUNC(ddenlovr_state::ddenlovr_bgcolor_w));
-	map(0xb5, 0xb5).mirror(0xff00).w(this, FUNC(ddenlovr_state::ddenlovr_priority_w));
-	map(0xb6, 0xb6).mirror(0xff00).w(this, FUNC(ddenlovr_state::ddenlovr_layer_enable_w));
-	map(0xb8, 0xb8).mirror(0xff00).r(this, FUNC(ddenlovr_state::unk_r)); // ? must be 78 on startup
+	map.global_mask(0xff);
+	map(0x00, 0x01).w(this, FUNC(ddenlovr_state::hginga_blitter_w));
+	map(0x03, 0x03).r(this, FUNC(ddenlovr_state::rongrong_gfxrom_r));
+	map(0x22, 0x23).w("ym2413", FUNC(ym2413_device::write));
+	map(0x24, 0x24).r("aysnd", FUNC(ay8910_device::data_r));
+	map(0x26, 0x26).w("aysnd", FUNC(ay8910_device::data_w));
+	map(0x28, 0x28).w("aysnd", FUNC(ay8910_device::address_w));
+	map(0x40, 0x40).w(this, FUNC(ddenlovr_state::hginga_input_w));
+	map(0x41, 0x41).w(this, FUNC(ddenlovr_state::hginga_coins_w));
+	map(0x42, 0x42).r(this, FUNC(ddenlovr_state::hginga_coins_r));
+	map(0x43, 0x43).r(this, FUNC(ddenlovr_state::hginga_input_r));
+	map(0x60, 0x6f).rw("rtc", FUNC(msm6242_device::read), FUNC(msm6242_device::write));
+	map(0x80, 0x80).w(this, FUNC(ddenlovr_state::hginga_80_w));
+	map(0xa0, 0xa3).w(this, FUNC(ddenlovr_state::ddenlovr_palette_base_w));
+	map(0xa4, 0xa7).w(this, FUNC(ddenlovr_state::ddenlovr_palette_mask_w));
+	map(0xa8, 0xab).w(this, FUNC(ddenlovr_state::ddenlovr_transparency_pen_w));
+	map(0xac, 0xaf).w(this, FUNC(ddenlovr_state::ddenlovr_transparency_mask_w));
+	map(0xb4, 0xb4).w(this, FUNC(ddenlovr_state::ddenlovr_bgcolor_w));
+	map(0xb5, 0xb5).w(this, FUNC(ddenlovr_state::ddenlovr_priority_w));
+	map(0xb6, 0xb6).w(this, FUNC(ddenlovr_state::ddenlovr_layer_enable_w));
+	map(0xb8, 0xb8).r(this, FUNC(ddenlovr_state::unk_r)); // ? must be 78 on startup
 }
 
 
@@ -3447,26 +3456,27 @@ void ddenlovr_state::hgokou_map(address_map &map)
 
 void ddenlovr_state::hgokou_portmap(address_map &map)
 {
-	map(0x00, 0x01).mirror(0xff00).w(this, FUNC(ddenlovr_state::hginga_blitter_w));
-	map(0x03, 0x03).mirror(0xff00).r(this, FUNC(ddenlovr_state::rongrong_gfxrom_r));
-	map(0x20, 0x2f).mirror(0xff00).rw("rtc", FUNC(msm6242_device::read), FUNC(msm6242_device::write));
-	map(0x40, 0x43).mirror(0xff00).w(this, FUNC(ddenlovr_state::ddenlovr_palette_base_w));
-	map(0x44, 0x47).mirror(0xff00).w(this, FUNC(ddenlovr_state::ddenlovr_palette_mask_w));
-	map(0x48, 0x4b).mirror(0xff00).w(this, FUNC(ddenlovr_state::ddenlovr_transparency_pen_w));
-	map(0x4c, 0x4f).mirror(0xff00).w(this, FUNC(ddenlovr_state::ddenlovr_transparency_mask_w));
-	map(0x54, 0x54).mirror(0xff00).w(this, FUNC(ddenlovr_state::ddenlovr_bgcolor_w));
-	map(0x55, 0x55).mirror(0xff00).w(this, FUNC(ddenlovr_state::ddenlovr_priority_w));
-	map(0x56, 0x56).mirror(0xff00).w(this, FUNC(ddenlovr_state::ddenlovr_layer_enable_w));
-	map(0x58, 0x58).mirror(0xff00).r(this, FUNC(ddenlovr_state::unk_r));                                 // ? must be 78 on startup
-	map(0x60, 0x60).mirror(0xff00).w(this, FUNC(ddenlovr_state::hgokou_dsw_sel_w));
-	map(0x61, 0x61).mirror(0xff00).w(this, FUNC(ddenlovr_state::hgokou_input_w));
-	map(0x62, 0x62).mirror(0xff00).r(this, FUNC(ddenlovr_state::hgokou_input_r));
-	map(0x80, 0x80).mirror(0xff00).rw(m_oki, FUNC(okim6295_device::read), FUNC(okim6295_device::write));
-	map(0x82, 0x83).mirror(0xff00).w("ym2413", FUNC(ym2413_device::write));
-	map(0x84, 0x84).mirror(0xff00).r("aysnd", FUNC(ay8910_device::data_r));
-	map(0x86, 0x86).mirror(0xff00).w("aysnd", FUNC(ay8910_device::data_w));
-	map(0x88, 0x88).mirror(0xff00).w("aysnd", FUNC(ay8910_device::address_w));
-	map(0xb0, 0xb0).mirror(0xff00).r(this, FUNC(ddenlovr_state::hanakanz_rand_r));
+	map.global_mask(0xff);
+	map(0x00, 0x01).w(this, FUNC(ddenlovr_state::hginga_blitter_w));
+	map(0x03, 0x03).r(this, FUNC(ddenlovr_state::rongrong_gfxrom_r));
+	map(0x20, 0x2f).rw("rtc", FUNC(msm6242_device::read), FUNC(msm6242_device::write));
+	map(0x40, 0x43).w(this, FUNC(ddenlovr_state::ddenlovr_palette_base_w));
+	map(0x44, 0x47).w(this, FUNC(ddenlovr_state::ddenlovr_palette_mask_w));
+	map(0x48, 0x4b).w(this, FUNC(ddenlovr_state::ddenlovr_transparency_pen_w));
+	map(0x4c, 0x4f).w(this, FUNC(ddenlovr_state::ddenlovr_transparency_mask_w));
+	map(0x54, 0x54).w(this, FUNC(ddenlovr_state::ddenlovr_bgcolor_w));
+	map(0x55, 0x55).w(this, FUNC(ddenlovr_state::ddenlovr_priority_w));
+	map(0x56, 0x56).w(this, FUNC(ddenlovr_state::ddenlovr_layer_enable_w));
+	map(0x58, 0x58).r(this, FUNC(ddenlovr_state::unk_r));                                 // ? must be 78 on startup
+	map(0x60, 0x60).w(this, FUNC(ddenlovr_state::hgokou_dsw_sel_w));
+	map(0x61, 0x61).w(this, FUNC(ddenlovr_state::hgokou_input_w));
+	map(0x62, 0x62).r(this, FUNC(ddenlovr_state::hgokou_input_r));
+	map(0x80, 0x80).rw(m_oki, FUNC(okim6295_device::read), FUNC(okim6295_device::write));
+	map(0x82, 0x83).w("ym2413", FUNC(ym2413_device::write));
+	map(0x84, 0x84).r("aysnd", FUNC(ay8910_device::data_r));
+	map(0x86, 0x86).w("aysnd", FUNC(ay8910_device::data_w));
+	map(0x88, 0x88).w("aysnd", FUNC(ay8910_device::address_w));
+	map(0xb0, 0xb0).r(this, FUNC(ddenlovr_state::hanakanz_rand_r));
 }
 
 
@@ -3500,27 +3510,28 @@ READ8_MEMBER(ddenlovr_state::hgokbang_input_r)
 
 void ddenlovr_state::hgokbang_portmap(address_map &map)
 {
-	map(0x00, 0x01).mirror(0xff00).w(this, FUNC(ddenlovr_state::hginga_blitter_w));
-	map(0x03, 0x03).mirror(0xff00).r(this, FUNC(ddenlovr_state::rongrong_gfxrom_r));
-	map(0x20, 0x20).mirror(0xff00).rw(m_oki, FUNC(okim6295_device::read), FUNC(okim6295_device::write));
-	map(0x22, 0x23).mirror(0xff00).w("ym2413", FUNC(ym2413_device::write));
-	map(0x24, 0x24).mirror(0xff00).r("aysnd", FUNC(ay8910_device::data_r));
-	map(0x26, 0x26).mirror(0xff00).w("aysnd", FUNC(ay8910_device::data_w));
-	map(0x28, 0x28).mirror(0xff00).w("aysnd", FUNC(ay8910_device::address_w));
-	map(0x40, 0x40).mirror(0xff00).w(this, FUNC(ddenlovr_state::hgokou_dsw_sel_w));
-	map(0x41, 0x41).mirror(0xff00).w(this, FUNC(ddenlovr_state::hgokou_input_w));
-	map(0x42, 0x42).mirror(0xff00).r(this, FUNC(ddenlovr_state::hgokou_input_r));
-	map(0x43, 0x43).mirror(0xff00).r(this, FUNC(ddenlovr_state::hgokbang_input_r));
-	map(0x60, 0x6f).mirror(0xff00).rw("rtc", FUNC(msm6242_device::read), FUNC(msm6242_device::write));
-	map(0xa0, 0xa3).mirror(0xff00).w(this, FUNC(ddenlovr_state::ddenlovr_palette_base_w));
-	map(0xa4, 0xa7).mirror(0xff00).w(this, FUNC(ddenlovr_state::ddenlovr_palette_mask_w));
-	map(0xa8, 0xab).mirror(0xff00).w(this, FUNC(ddenlovr_state::ddenlovr_transparency_pen_w));
-	map(0xac, 0xaf).mirror(0xff00).w(this, FUNC(ddenlovr_state::ddenlovr_transparency_mask_w));
-	map(0xb4, 0xb4).mirror(0xff00).w(this, FUNC(ddenlovr_state::ddenlovr_bgcolor_w));
-	map(0xb5, 0xb5).mirror(0xff00).w(this, FUNC(ddenlovr_state::ddenlovr_priority_w));
-	map(0xb6, 0xb6).mirror(0xff00).w(this, FUNC(ddenlovr_state::ddenlovr_layer_enable_w));
-	map(0xb8, 0xb8).mirror(0xff00).r(this, FUNC(ddenlovr_state::unk_r));                                 // ? must be 78 on startup
-	map(0xe0, 0xe0).mirror(0xff00).r(this, FUNC(ddenlovr_state::hanakanz_rand_r));
+	map.global_mask(0xff);
+	map(0x00, 0x01).w(this, FUNC(ddenlovr_state::hginga_blitter_w));
+	map(0x03, 0x03).r(this, FUNC(ddenlovr_state::rongrong_gfxrom_r));
+	map(0x20, 0x20).rw(m_oki, FUNC(okim6295_device::read), FUNC(okim6295_device::write));
+	map(0x22, 0x23).w("ym2413", FUNC(ym2413_device::write));
+	map(0x24, 0x24).r("aysnd", FUNC(ay8910_device::data_r));
+	map(0x26, 0x26).w("aysnd", FUNC(ay8910_device::data_w));
+	map(0x28, 0x28).w("aysnd", FUNC(ay8910_device::address_w));
+	map(0x40, 0x40).w(this, FUNC(ddenlovr_state::hgokou_dsw_sel_w));
+	map(0x41, 0x41).w(this, FUNC(ddenlovr_state::hgokou_input_w));
+	map(0x42, 0x42).r(this, FUNC(ddenlovr_state::hgokou_input_r));
+	map(0x43, 0x43).r(this, FUNC(ddenlovr_state::hgokbang_input_r));
+	map(0x60, 0x6f).rw("rtc", FUNC(msm6242_device::read), FUNC(msm6242_device::write));
+	map(0xa0, 0xa3).w(this, FUNC(ddenlovr_state::ddenlovr_palette_base_w));
+	map(0xa4, 0xa7).w(this, FUNC(ddenlovr_state::ddenlovr_palette_mask_w));
+	map(0xa8, 0xab).w(this, FUNC(ddenlovr_state::ddenlovr_transparency_pen_w));
+	map(0xac, 0xaf).w(this, FUNC(ddenlovr_state::ddenlovr_transparency_mask_w));
+	map(0xb4, 0xb4).w(this, FUNC(ddenlovr_state::ddenlovr_bgcolor_w));
+	map(0xb5, 0xb5).w(this, FUNC(ddenlovr_state::ddenlovr_priority_w));
+	map(0xb6, 0xb6).w(this, FUNC(ddenlovr_state::ddenlovr_layer_enable_w));
+	map(0xb8, 0xb8).r(this, FUNC(ddenlovr_state::unk_r));                                 // ? must be 78 on startup
+	map(0xe0, 0xe0).r(this, FUNC(ddenlovr_state::hanakanz_rand_r));
 }
 
 
@@ -3588,22 +3599,23 @@ void ddenlovr_state::hparadis_map(address_map &map)
 
 void ddenlovr_state::hparadis_portmap(address_map &map)
 {
-	map(0x00, 0x01).mirror(0xff00).w(this, FUNC(ddenlovr_state::ddenlovr_blitter_w));
-	map(0x03, 0x03).mirror(0xff00).r(this, FUNC(ddenlovr_state::rongrong_gfxrom_r));
-	map(0x40, 0x40).mirror(0xff00).rw(m_oki, FUNC(okim6295_device::read), FUNC(okim6295_device::write));
-	map(0x60, 0x61).mirror(0xff00).w("ym2413", FUNC(ym2413_device::write));
-	map(0x80, 0x83).mirror(0xff00).w(this, FUNC(ddenlovr_state::ddenlovr_palette_base_w));
-	map(0x84, 0x87).mirror(0xff00).w(this, FUNC(ddenlovr_state::ddenlovr_palette_mask_w));
-	map(0x88, 0x8b).mirror(0xff00).w(this, FUNC(ddenlovr_state::ddenlovr_transparency_pen_w));
-	map(0x8c, 0x8f).mirror(0xff00).w(this, FUNC(ddenlovr_state::ddenlovr_transparency_mask_w));
-	map(0x94, 0x94).mirror(0xff00).w(this, FUNC(ddenlovr_state::ddenlovr_bgcolor_w));
-	map(0x95, 0x95).mirror(0xff00).w(this, FUNC(ddenlovr_state::ddenlovr_priority_w));
-	map(0x96, 0x96).mirror(0xff00).w(this, FUNC(ddenlovr_state::ddenlovr_layer_enable_w));
-	map(0x98, 0x98).mirror(0xff00).r(this, FUNC(ddenlovr_state::unk_r)); // ? must be 78 on startup
-	map(0xa0, 0xa0).mirror(0xff00).w(this, FUNC(ddenlovr_state::hginga_input_w));
-	map(0xa1, 0xa1).mirror(0xff00).w(this, FUNC(ddenlovr_state::hparadis_coin_w));
-	map(0xa2, 0xa3).mirror(0xff00).r(this, FUNC(ddenlovr_state::hparadis_input_r));
-	map(0xc2, 0xc2).mirror(0xff00).nopw();    // enables palette RAM at c000
+	map.global_mask(0xff);
+	map(0x00, 0x01).w(this, FUNC(ddenlovr_state::ddenlovr_blitter_w));
+	map(0x03, 0x03).r(this, FUNC(ddenlovr_state::rongrong_gfxrom_r));
+	map(0x40, 0x40).rw(m_oki, FUNC(okim6295_device::read), FUNC(okim6295_device::write));
+	map(0x60, 0x61).w("ym2413", FUNC(ym2413_device::write));
+	map(0x80, 0x83).w(this, FUNC(ddenlovr_state::ddenlovr_palette_base_w));
+	map(0x84, 0x87).w(this, FUNC(ddenlovr_state::ddenlovr_palette_mask_w));
+	map(0x88, 0x8b).w(this, FUNC(ddenlovr_state::ddenlovr_transparency_pen_w));
+	map(0x8c, 0x8f).w(this, FUNC(ddenlovr_state::ddenlovr_transparency_mask_w));
+	map(0x94, 0x94).w(this, FUNC(ddenlovr_state::ddenlovr_bgcolor_w));
+	map(0x95, 0x95).w(this, FUNC(ddenlovr_state::ddenlovr_priority_w));
+	map(0x96, 0x96).w(this, FUNC(ddenlovr_state::ddenlovr_layer_enable_w));
+	map(0x98, 0x98).r(this, FUNC(ddenlovr_state::unk_r)); // ? must be 78 on startup
+	map(0xa0, 0xa0).w(this, FUNC(ddenlovr_state::hginga_input_w));
+	map(0xa1, 0xa1).w(this, FUNC(ddenlovr_state::hparadis_coin_w));
+	map(0xa2, 0xa3).r(this, FUNC(ddenlovr_state::hparadis_input_r));
+	map(0xc2, 0xc2).nopw();    // enables palette RAM at c000
 }
 
 
@@ -3628,28 +3640,29 @@ READ8_MEMBER(ddenlovr_state::mjmywrld_coins_r)
 
 void ddenlovr_state::mjmywrld_portmap(address_map &map)
 {
-	map(0x00, 0x01).mirror(0xff00).w(this, FUNC(ddenlovr_state::ddenlovr_blitter_w));
-	map(0x03, 0x03).mirror(0xff00).r(this, FUNC(ddenlovr_state::rongrong_gfxrom_r));
-	map(0x20, 0x20).mirror(0xff00).w(this, FUNC(ddenlovr_state::mjmyster_select2_w));
-	map(0x21, 0x21).mirror(0xff00).w(this, FUNC(ddenlovr_state::mjmyster_coincounter_w));
-	map(0x22, 0x22).mirror(0xff00).r(this, FUNC(ddenlovr_state::mjmywrld_coins_r));
-	map(0x23, 0x23).mirror(0xff00).r(this, FUNC(ddenlovr_state::mjmyster_keyb_r));
-	map(0x40, 0x40).mirror(0xff00).rw(m_oki, FUNC(okim6295_device::read), FUNC(okim6295_device::write));
-	map(0x42, 0x43).mirror(0xff00).w("ym2413", FUNC(ym2413_device::write));
-	map(0x44, 0x44).mirror(0xff00).r("aysnd", FUNC(ay8910_device::data_r));
-	map(0x46, 0x46).mirror(0xff00).w("aysnd", FUNC(ay8910_device::data_w));
-	map(0x48, 0x48).mirror(0xff00).w("aysnd", FUNC(ay8910_device::address_w));
-	map(0x60, 0x6f).mirror(0xff00).rw("rtc", FUNC(msm6242_device::read), FUNC(msm6242_device::write));
-	map(0x80, 0x83).mirror(0xff00).w(this, FUNC(ddenlovr_state::ddenlovr_palette_base_w));
-	map(0x84, 0x87).mirror(0xff00).w(this, FUNC(ddenlovr_state::ddenlovr_palette_mask_w));
-	map(0x88, 0x8b).mirror(0xff00).w(this, FUNC(ddenlovr_state::ddenlovr_transparency_pen_w));
-	map(0x8c, 0x8f).mirror(0xff00).w(this, FUNC(ddenlovr_state::ddenlovr_transparency_mask_w));
-	map(0x94, 0x94).mirror(0xff00).w(this, FUNC(ddenlovr_state::ddenlovr_bgcolor_w));
-	map(0x95, 0x95).mirror(0xff00).w(this, FUNC(ddenlovr_state::ddenlovr_priority_w));
-	map(0x96, 0x96).mirror(0xff00).w(this, FUNC(ddenlovr_state::ddenlovr_layer_enable_w));
-	map(0x98, 0x98).mirror(0xff00).r(this, FUNC(ddenlovr_state::unk_r)); // ? must be 78 on startup
-	map(0xc0, 0xc0).mirror(0xff00).r(this, FUNC(ddenlovr_state::hanakanz_rand_r));
-	map(0xe0, 0xe0).mirror(0xff00).r(this, FUNC(ddenlovr_state::mjmyster_dsw_r));
+	map.global_mask(0xff);
+	map(0x00, 0x01).w(this, FUNC(ddenlovr_state::ddenlovr_blitter_w));
+	map(0x03, 0x03).r(this, FUNC(ddenlovr_state::rongrong_gfxrom_r));
+	map(0x20, 0x20).w(this, FUNC(ddenlovr_state::mjmyster_select2_w));
+	map(0x21, 0x21).w(this, FUNC(ddenlovr_state::mjmyster_coincounter_w));
+	map(0x22, 0x22).r(this, FUNC(ddenlovr_state::mjmywrld_coins_r));
+	map(0x23, 0x23).r(this, FUNC(ddenlovr_state::mjmyster_keyb_r));
+	map(0x40, 0x40).rw(m_oki, FUNC(okim6295_device::read), FUNC(okim6295_device::write));
+	map(0x42, 0x43).w("ym2413", FUNC(ym2413_device::write));
+	map(0x44, 0x44).r("aysnd", FUNC(ay8910_device::data_r));
+	map(0x46, 0x46).w("aysnd", FUNC(ay8910_device::data_w));
+	map(0x48, 0x48).w("aysnd", FUNC(ay8910_device::address_w));
+	map(0x60, 0x6f).rw("rtc", FUNC(msm6242_device::read), FUNC(msm6242_device::write));
+	map(0x80, 0x83).w(this, FUNC(ddenlovr_state::ddenlovr_palette_base_w));
+	map(0x84, 0x87).w(this, FUNC(ddenlovr_state::ddenlovr_palette_mask_w));
+	map(0x88, 0x8b).w(this, FUNC(ddenlovr_state::ddenlovr_transparency_pen_w));
+	map(0x8c, 0x8f).w(this, FUNC(ddenlovr_state::ddenlovr_transparency_mask_w));
+	map(0x94, 0x94).w(this, FUNC(ddenlovr_state::ddenlovr_bgcolor_w));
+	map(0x95, 0x95).w(this, FUNC(ddenlovr_state::ddenlovr_priority_w));
+	map(0x96, 0x96).w(this, FUNC(ddenlovr_state::ddenlovr_layer_enable_w));
+	map(0x98, 0x98).r(this, FUNC(ddenlovr_state::unk_r)); // ? must be 78 on startup
+	map(0xc0, 0xc0).r(this, FUNC(ddenlovr_state::hanakanz_rand_r));
+	map(0xe0, 0xe0).r(this, FUNC(ddenlovr_state::mjmyster_dsw_r));
 }
 
 
@@ -3990,31 +4003,32 @@ WRITE8_MEMBER(ddenlovr_state::sryudens_rambank_w)
 
 void ddenlovr_state::sryudens_portmap(address_map &map)
 {
-	map(0x00, 0x00).mirror(0xff00).rw(m_oki, FUNC(okim6295_device::read), FUNC(okim6295_device::write));
-	map(0x02, 0x03).mirror(0xff00).w("ym2413", FUNC(ym2413_device::write));
-	map(0x04, 0x05).mirror(0xff00).w("aysnd", FUNC(ay8910_device::address_data_w));
-	map(0x20, 0x23).mirror(0xff00).w(this, FUNC(ddenlovr_state::ddenlovr_palette_base_w));
-	map(0x24, 0x27).mirror(0xff00).w(this, FUNC(ddenlovr_state::ddenlovr_palette_mask_w));
-	map(0x28, 0x2b).mirror(0xff00).w(this, FUNC(ddenlovr_state::ddenlovr_transparency_pen_w));
-	map(0x2c, 0x2f).mirror(0xff00).w(this, FUNC(ddenlovr_state::ddenlovr_transparency_mask_w));
-	map(0x34, 0x34).mirror(0xff00).w(this, FUNC(ddenlovr_state::ddenlovr_bgcolor_w));
-	map(0x35, 0x35).mirror(0xff00).w(this, FUNC(ddenlovr_state::ddenlovr_priority_w));
-	map(0x36, 0x36).mirror(0xff00).w(this, FUNC(ddenlovr_state::ddenlovr_layer_enable_w));
-	map(0x38, 0x38).mirror(0xff00).nopr();         // ? ack or watchdog
-	map(0x40, 0x41).mirror(0xff00).w(this, FUNC(ddenlovr_state::ddenlovr_blitter_w));
-	map(0x43, 0x43).mirror(0xff00).r(this, FUNC(ddenlovr_state::rongrong_gfxrom_r));
-	map(0x50, 0x50).mirror(0xff00).r(this, FUNC(ddenlovr_state::hanakanz_rand_r));
-	map(0x70, 0x70).mirror(0xff00).w(this, FUNC(ddenlovr_state::quizchq_oki_bank_w));
-	map(0x80, 0x8f).mirror(0xff00).rw("rtc", FUNC(msm6242_device::read), FUNC(msm6242_device::write));
-	map(0x90, 0x90).mirror(0xff00).portr("DSW1");
-	map(0x91, 0x91).mirror(0xff00).portr("DSW2");
-	map(0x92, 0x92).mirror(0xff00).portr("DSW4");
-	map(0x93, 0x93).mirror(0xff00).portr("DSW3");
-	map(0x94, 0x94).mirror(0xff00).portr("DSWTOP");
-	map(0x98, 0x98).mirror(0xff00).w(this, FUNC(ddenlovr_state::sryudens_coincounter_w));
-	map(0x99, 0x99).mirror(0xff00).w(this, FUNC(ddenlovr_state::hanakanz_keyb_w));
-	map(0x9a, 0x9a).mirror(0xff00).portr("SYSTEM");
-	map(0x9b, 0x9c).mirror(0xff00).r(this, FUNC(ddenlovr_state::sryudens_keyb_r));
+	map.global_mask(0xff);
+	map(0x00, 0x00).rw(m_oki, FUNC(okim6295_device::read), FUNC(okim6295_device::write));
+	map(0x02, 0x03).w("ym2413", FUNC(ym2413_device::write));
+	map(0x04, 0x05).w("aysnd", FUNC(ay8910_device::address_data_w));
+	map(0x20, 0x23).w(this, FUNC(ddenlovr_state::ddenlovr_palette_base_w));
+	map(0x24, 0x27).w(this, FUNC(ddenlovr_state::ddenlovr_palette_mask_w));
+	map(0x28, 0x2b).w(this, FUNC(ddenlovr_state::ddenlovr_transparency_pen_w));
+	map(0x2c, 0x2f).w(this, FUNC(ddenlovr_state::ddenlovr_transparency_mask_w));
+	map(0x34, 0x34).w(this, FUNC(ddenlovr_state::ddenlovr_bgcolor_w));
+	map(0x35, 0x35).w(this, FUNC(ddenlovr_state::ddenlovr_priority_w));
+	map(0x36, 0x36).w(this, FUNC(ddenlovr_state::ddenlovr_layer_enable_w));
+	map(0x38, 0x38).nopr();         // ? ack or watchdog
+	map(0x40, 0x41).w(this, FUNC(ddenlovr_state::ddenlovr_blitter_w));
+	map(0x43, 0x43).r(this, FUNC(ddenlovr_state::rongrong_gfxrom_r));
+	map(0x50, 0x50).r(this, FUNC(ddenlovr_state::hanakanz_rand_r));
+	map(0x70, 0x70).w(this, FUNC(ddenlovr_state::quizchq_oki_bank_w));
+	map(0x80, 0x8f).rw("rtc", FUNC(msm6242_device::read), FUNC(msm6242_device::write));
+	map(0x90, 0x90).portr("DSW1");
+	map(0x91, 0x91).portr("DSW2");
+	map(0x92, 0x92).portr("DSW4");
+	map(0x93, 0x93).portr("DSW3");
+	map(0x94, 0x94).portr("DSWTOP");
+	map(0x98, 0x98).w(this, FUNC(ddenlovr_state::sryudens_coincounter_w));
+	map(0x99, 0x99).w(this, FUNC(ddenlovr_state::hanakanz_keyb_w));
+	map(0x9a, 0x9a).portr("SYSTEM");
+	map(0x9b, 0x9c).r(this, FUNC(ddenlovr_state::sryudens_keyb_r));
 }
 
 
@@ -4051,32 +4065,33 @@ void ddenlovr_state::janshinp_map(address_map &map)
 
 void ddenlovr_state::janshinp_portmap(address_map &map)
 {
-	map(0x00, 0x00).mirror(0xff00).portr("DSW1");
-	map(0x01, 0x01).mirror(0xff00).portr("DSW2");
-	map(0x02, 0x02).mirror(0xff00).portr("DSW4");
-	map(0x03, 0x03).mirror(0xff00).portr("DSW3");
-	map(0x04, 0x04).mirror(0xff00).portr("DSWTOP");
-	map(0x08, 0x08).mirror(0xff00).w(this, FUNC(ddenlovr_state::janshinp_coincounter_w));
-	map(0x09, 0x09).mirror(0xff00).w(this, FUNC(ddenlovr_state::hanakanz_keyb_w));
-	map(0x0a, 0x0a).mirror(0xff00).portr("SYSTEM");
-	map(0x0b, 0x0c).mirror(0xff00).r(this, FUNC(ddenlovr_state::sryudens_keyb_r));
-	map(0x20, 0x23).mirror(0xff00).w(this, FUNC(ddenlovr_state::ddenlovr_palette_base_w));
-	map(0x24, 0x27).mirror(0xff00).w(this, FUNC(ddenlovr_state::ddenlovr_palette_mask_w));
-	map(0x28, 0x2b).mirror(0xff00).w(this, FUNC(ddenlovr_state::ddenlovr_transparency_pen_w));
-	map(0x2c, 0x2f).mirror(0xff00).w(this, FUNC(ddenlovr_state::ddenlovr_transparency_mask_w));
-	map(0x34, 0x34).mirror(0xff00).w(this, FUNC(ddenlovr_state::ddenlovr_bgcolor_w));
-	map(0x35, 0x35).mirror(0xff00).w(this, FUNC(ddenlovr_state::ddenlovr_priority_w));
-	map(0x36, 0x36).mirror(0xff00).w(this, FUNC(ddenlovr_state::ddenlovr_layer_enable_w));
-	map(0x38, 0x38).mirror(0xff00).nopr();         // ? ack or watchdog
-	map(0x40, 0x41).mirror(0xff00).w(this, FUNC(ddenlovr_state::ddenlovr_blitter_w));
-	map(0x43, 0x43).mirror(0xff00).r(this, FUNC(ddenlovr_state::rongrong_gfxrom_r));
-	map(0x50, 0x5f).mirror(0xff00).rw("rtc", FUNC(msm6242_device::read), FUNC(msm6242_device::write));
-	map(0x60, 0x60).mirror(0xff00).r(this, FUNC(ddenlovr_state::hanakanz_rand_r));
-	map(0x70, 0x70).mirror(0xff00).w(this, FUNC(ddenlovr_state::quizchq_oki_bank_w));
-	map(0x80, 0x80).mirror(0xff00).ram();
-	map(0x90, 0x90).mirror(0xff00).rw(m_oki, FUNC(okim6295_device::read), FUNC(okim6295_device::write));
-	map(0x92, 0x93).mirror(0xff00).w("ym2413", FUNC(ym2413_device::write));
-	map(0x94, 0x95).mirror(0xff00).w("aysnd", FUNC(ay8910_device::address_data_w));
+	map.global_mask(0xff);
+	map(0x00, 0x00).portr("DSW1");
+	map(0x01, 0x01).portr("DSW2");
+	map(0x02, 0x02).portr("DSW4");
+	map(0x03, 0x03).portr("DSW3");
+	map(0x04, 0x04).portr("DSWTOP");
+	map(0x08, 0x08).w(this, FUNC(ddenlovr_state::janshinp_coincounter_w));
+	map(0x09, 0x09).w(this, FUNC(ddenlovr_state::hanakanz_keyb_w));
+	map(0x0a, 0x0a).portr("SYSTEM");
+	map(0x0b, 0x0c).r(this, FUNC(ddenlovr_state::sryudens_keyb_r));
+	map(0x20, 0x23).w(this, FUNC(ddenlovr_state::ddenlovr_palette_base_w));
+	map(0x24, 0x27).w(this, FUNC(ddenlovr_state::ddenlovr_palette_mask_w));
+	map(0x28, 0x2b).w(this, FUNC(ddenlovr_state::ddenlovr_transparency_pen_w));
+	map(0x2c, 0x2f).w(this, FUNC(ddenlovr_state::ddenlovr_transparency_mask_w));
+	map(0x34, 0x34).w(this, FUNC(ddenlovr_state::ddenlovr_bgcolor_w));
+	map(0x35, 0x35).w(this, FUNC(ddenlovr_state::ddenlovr_priority_w));
+	map(0x36, 0x36).w(this, FUNC(ddenlovr_state::ddenlovr_layer_enable_w));
+	map(0x38, 0x38).nopr();         // ? ack or watchdog
+	map(0x40, 0x41).w(this, FUNC(ddenlovr_state::ddenlovr_blitter_w));
+	map(0x43, 0x43).r(this, FUNC(ddenlovr_state::rongrong_gfxrom_r));
+	map(0x50, 0x5f).rw("rtc", FUNC(msm6242_device::read), FUNC(msm6242_device::write));
+	map(0x60, 0x60).r(this, FUNC(ddenlovr_state::hanakanz_rand_r));
+	map(0x70, 0x70).w(this, FUNC(ddenlovr_state::quizchq_oki_bank_w));
+	map(0x80, 0x80).ram();
+	map(0x90, 0x90).rw(m_oki, FUNC(okim6295_device::read), FUNC(okim6295_device::write));
+	map(0x92, 0x93).w("ym2413", FUNC(ym2413_device::write));
+	map(0x94, 0x95).w("aysnd", FUNC(ay8910_device::address_data_w));
 }
 
 
@@ -4136,28 +4151,29 @@ void ddenlovr_state::seljan2_map(address_map &map)
 
 void ddenlovr_state::seljan2_portmap(address_map &map)
 {
-	map(0x00, 0x0f).mirror(0xff00).rw("rtc", FUNC(msm6242_device::read), FUNC(msm6242_device::write));
-	map(0x20, 0x23).mirror(0xff00).w(this, FUNC(ddenlovr_state::ddenlovr_palette_base_w));
-	map(0x24, 0x27).mirror(0xff00).w(this, FUNC(ddenlovr_state::ddenlovr_palette_mask_w));
-	map(0x28, 0x2b).mirror(0xff00).w(this, FUNC(ddenlovr_state::ddenlovr_transparency_pen_w));
-	map(0x2c, 0x2f).mirror(0xff00).w(this, FUNC(ddenlovr_state::ddenlovr_transparency_mask_w));
-	map(0x34, 0x34).mirror(0xff00).w(this, FUNC(ddenlovr_state::ddenlovr_bgcolor_w));
-	map(0x35, 0x35).mirror(0xff00).w(this, FUNC(ddenlovr_state::ddenlovr_priority_w));
-	map(0x36, 0x36).mirror(0xff00).w(this, FUNC(ddenlovr_state::ddenlovr_layer_enable_w));
-	map(0x38, 0x38).mirror(0xff00).nopr();         // ? ack or watchdog
-	map(0x40, 0x41).mirror(0xff00).w(this, FUNC(ddenlovr_state::ddenlovr_blitter_w));
-	map(0x43, 0x43).mirror(0xff00).r(this, FUNC(ddenlovr_state::rongrong_gfxrom_r));
-	map(0x50, 0x51).mirror(0xff00).w("ym2413", FUNC(ym2413_device::write));
-	map(0x54, 0x54).mirror(0xff00).rw(m_oki, FUNC(okim6295_device::read), FUNC(okim6295_device::write));
-	map(0x58, 0x58).mirror(0xff00).w("aysnd", FUNC(ay8910_device::address_w));
-	map(0x5c, 0x5c).mirror(0xff00).rw("aysnd", FUNC(ay8910_device::data_r), FUNC(ay8910_device::data_w));   // dsw
-	map(0x60, 0x60).mirror(0xff00).nopr().w(this, FUNC(ddenlovr_state::sryudens_rambank_w));    // ? ack on RTC int
-	map(0x70, 0x70).mirror(0xff00).w(this, FUNC(ddenlovr_state::seljan2_rombank_w));
-	map(0x80, 0x80).mirror(0xff00).portr("SYSTEM").w(this, FUNC(ddenlovr_state::seljan2_palette_enab_w));    // writes: 1 = palette RAM at b000, 0 = ROM
-	map(0x84, 0x84).mirror(0xff00).r(this, FUNC(ddenlovr_state::daimyojn_keyb1_r));
-	map(0x88, 0x88).mirror(0xff00).r(this, FUNC(ddenlovr_state::daimyojn_keyb2_r));
-	map(0x90, 0x90).mirror(0xff00).w(this, FUNC(ddenlovr_state::quizchq_oki_bank_w));
-	map(0xa0, 0xa0).mirror(0xff00).r(this, FUNC(ddenlovr_state::hanakanz_rand_r));
+	map.global_mask(0xff);
+	map(0x00, 0x0f).rw("rtc", FUNC(msm6242_device::read), FUNC(msm6242_device::write));
+	map(0x20, 0x23).w(this, FUNC(ddenlovr_state::ddenlovr_palette_base_w));
+	map(0x24, 0x27).w(this, FUNC(ddenlovr_state::ddenlovr_palette_mask_w));
+	map(0x28, 0x2b).w(this, FUNC(ddenlovr_state::ddenlovr_transparency_pen_w));
+	map(0x2c, 0x2f).w(this, FUNC(ddenlovr_state::ddenlovr_transparency_mask_w));
+	map(0x34, 0x34).w(this, FUNC(ddenlovr_state::ddenlovr_bgcolor_w));
+	map(0x35, 0x35).w(this, FUNC(ddenlovr_state::ddenlovr_priority_w));
+	map(0x36, 0x36).w(this, FUNC(ddenlovr_state::ddenlovr_layer_enable_w));
+	map(0x38, 0x38).nopr();         // ? ack or watchdog
+	map(0x40, 0x41).w(this, FUNC(ddenlovr_state::ddenlovr_blitter_w));
+	map(0x43, 0x43).r(this, FUNC(ddenlovr_state::rongrong_gfxrom_r));
+	map(0x50, 0x51).w("ym2413", FUNC(ym2413_device::write));
+	map(0x54, 0x54).rw(m_oki, FUNC(okim6295_device::read), FUNC(okim6295_device::write));
+	map(0x58, 0x58).w("aysnd", FUNC(ay8910_device::address_w));
+	map(0x5c, 0x5c).rw("aysnd", FUNC(ay8910_device::data_r), FUNC(ay8910_device::data_w));   // dsw
+	map(0x60, 0x60).nopr().w(this, FUNC(ddenlovr_state::sryudens_rambank_w));    // ? ack on RTC int
+	map(0x70, 0x70).w(this, FUNC(ddenlovr_state::seljan2_rombank_w));
+	map(0x80, 0x80).portr("SYSTEM").w(this, FUNC(ddenlovr_state::seljan2_palette_enab_w));    // writes: 1 = palette RAM at b000, 0 = ROM
+	map(0x84, 0x84).r(this, FUNC(ddenlovr_state::daimyojn_keyb1_r));
+	map(0x88, 0x88).r(this, FUNC(ddenlovr_state::daimyojn_keyb2_r));
+	map(0x90, 0x90).w(this, FUNC(ddenlovr_state::quizchq_oki_bank_w));
+	map(0xa0, 0xa0).r(this, FUNC(ddenlovr_state::hanakanz_rand_r));
 }
 
 

--- a/src/mame/drivers/dynax.cpp
+++ b/src/mame/drivers/dynax.cpp
@@ -964,63 +964,63 @@ READ8_MEMBER(dynax_state::mjelctrn_dsw_r)
 
 void dynax_state::mjelctrn_io_map(address_map &map)
 {
-	//ADDRESS_MAP_GLOBAL_MASK(0xff)
-	map(0x00, 0x00).mirror(0xff00).w(this, FUNC(dynax_state::adpcm_reset_w));  // MSM5205 reset
-	map(0x02, 0x02).mirror(0xff00).w(this, FUNC(dynax_state::adpcm_data_w));           // MSM5205 data
-	map(0x04, 0x05).mirror(0xff00).w("ym2413", FUNC(ym2413_device::write));        //
-	map(0x08, 0x08).mirror(0xff00).w("aysnd", FUNC(ay8912_device::data_w));   // AY8912
-	map(0x0a, 0x0a).mirror(0xff00).w("aysnd", FUNC(ay8912_device::address_w));    //
-//  AM_RANGE( 0x20, 0x20 ) AM_MIRROR(0xff00) AM_WRITENOP   // CRT Controller
-//  AM_RANGE( 0x21, 0x21 ) AM_MIRROR(0xff00) AM_WRITENOP   // CRT Controller
-	map(0x40, 0x47).mirror(0xff00).w("outlatch", FUNC(ls259_device::write_d0));
-	map(0x60, 0x60).mirror(0xff00).w(this, FUNC(dynax_state::dynax_extra_scrollx_w));  // screen scroll X
-	map(0x62, 0x62).mirror(0xff00).w(this, FUNC(dynax_state::dynax_extra_scrolly_w));  // screen scroll Y
-//  AM_RANGE( 0x64, 0x64 ) AM_MIRROR(0xff00) AM_WRITE(dynax_extra_scrollx_w)      // screen scroll X
-//  AM_RANGE( 0x66, 0x66 ) AM_MIRROR(0xff00) AM_WRITE(dynax_extra_scrolly_w)      // screen scroll Y
-	map(0x6a, 0x6a).mirror(0xff00).w(this, FUNC(dynax_state::hnoridur_rombank_w));     // BANK ROM Select
-	map(0x80, 0x80).mirror(0xff00).w(this, FUNC(dynax_state::hanamai_keyboard_w));     // keyboard row select
-	map(0x81, 0x81).mirror(0xff00).portr("COINS");            // Coins
-	map(0x82, 0x82).mirror(0xff00).r(this, FUNC(dynax_state::mjelctrn_keyboard_1_r));       // P2
-	map(0x83, 0x83).mirror(0xff00).r(this, FUNC(dynax_state::hanamai_keyboard_0_r));        // P1
-	map(0x84, 0x84).mirror(0xff00).r(this, FUNC(dynax_state::mjelctrn_dsw_r));          // DSW8 x 4
-	map(0x85, 0x85).mirror(0xff00).portr("SW1");              // DSW2
-	map(0xa1, 0xa7).mirror(0xff00).w(this, FUNC(dynax_state::dynax_blitter_rev2_w));       // Blitter
-	map(0xc0, 0xc7).mirror(0xff00).w(m_mainlatch, FUNC(ls259_device::write_d0));
-	map(0xe0, 0xe0).mirror(0xff00).w(this, FUNC(dynax_state::dynax_blit_pen_w));       // Destination Pen
-	map(0xe1, 0xe1).mirror(0xff00).w(this, FUNC(dynax_state::dynax_blit_dest_w));      // Destination Layer
-	map(0xe2, 0xe2).mirror(0xff00).w(this, FUNC(dynax_state::dynax_blit_palette01_w)); // Layers Palettes
-	map(0xe3, 0xe3).mirror(0xff00).w(this, FUNC(dynax_state::dynax_blit_palette23_w)); //
-	map(0xe4, 0xe4).mirror(0xff00).w(this, FUNC(dynax_state::hanamai_priority_w));     // layer priority and enable
-	map(0xe5, 0xe5).mirror(0xff00).w(this, FUNC(dynax_state::dynax_blit_backpen_w));       // Background Color
-	map(0xe6, 0xe6).mirror(0xff00).w(this, FUNC(dynax_state::yarunara_blit_romregion_w));  // Blitter ROM bank
-	map(0xe7, 0xe7).mirror(0xff00).w(this, FUNC(dynax_state::hnoridur_palbank_w));
+	map.global_mask(0xff);
+	map(0x00, 0x00).w(this, FUNC(dynax_state::adpcm_reset_w));  // MSM5205 reset
+	map(0x02, 0x02).w(this, FUNC(dynax_state::adpcm_data_w));           // MSM5205 data
+	map(0x04, 0x05).w("ym2413", FUNC(ym2413_device::write));        //
+	map(0x08, 0x08).w("aysnd", FUNC(ay8912_device::data_w));   // AY8912
+	map(0x0a, 0x0a).w("aysnd", FUNC(ay8912_device::address_w));    //
+//  AM_RANGE( 0x20, 0x20 ) AM_WRITENOP   // CRT Controller
+//  AM_RANGE( 0x21, 0x21 ) AM_WRITENOP   // CRT Controller
+	map(0x40, 0x47).w("outlatch", FUNC(ls259_device::write_d0));
+	map(0x60, 0x60).w(this, FUNC(dynax_state::dynax_extra_scrollx_w));  // screen scroll X
+	map(0x62, 0x62).w(this, FUNC(dynax_state::dynax_extra_scrolly_w));  // screen scroll Y
+//  AM_RANGE( 0x64, 0x64 ) AM_WRITE(dynax_extra_scrollx_w)      // screen scroll X
+//  AM_RANGE( 0x66, 0x66 ) AM_WRITE(dynax_extra_scrolly_w)      // screen scroll Y
+	map(0x6a, 0x6a).w(this, FUNC(dynax_state::hnoridur_rombank_w));     // BANK ROM Select
+	map(0x80, 0x80).w(this, FUNC(dynax_state::hanamai_keyboard_w));     // keyboard row select
+	map(0x81, 0x81).portr("COINS");            // Coins
+	map(0x82, 0x82).r(this, FUNC(dynax_state::mjelctrn_keyboard_1_r));       // P2
+	map(0x83, 0x83).r(this, FUNC(dynax_state::hanamai_keyboard_0_r));        // P1
+	map(0x84, 0x84).r(this, FUNC(dynax_state::mjelctrn_dsw_r));          // DSW8 x 4
+	map(0x85, 0x85).portr("SW1");              // DSW2
+	map(0xa1, 0xa7).w(this, FUNC(dynax_state::dynax_blitter_rev2_w));       // Blitter
+	map(0xc0, 0xc7).w(m_mainlatch, FUNC(ls259_device::write_d0));
+	map(0xe0, 0xe0).w(this, FUNC(dynax_state::dynax_blit_pen_w));       // Destination Pen
+	map(0xe1, 0xe1).w(this, FUNC(dynax_state::dynax_blit_dest_w));      // Destination Layer
+	map(0xe2, 0xe2).w(this, FUNC(dynax_state::dynax_blit_palette01_w)); // Layers Palettes
+	map(0xe3, 0xe3).w(this, FUNC(dynax_state::dynax_blit_palette23_w)); //
+	map(0xe4, 0xe4).w(this, FUNC(dynax_state::hanamai_priority_w));     // layer priority and enable
+	map(0xe5, 0xe5).w(this, FUNC(dynax_state::dynax_blit_backpen_w));       // Background Color
+	map(0xe6, 0xe6).w(this, FUNC(dynax_state::yarunara_blit_romregion_w));  // Blitter ROM bank
+	map(0xe7, 0xe7).w(this, FUNC(dynax_state::hnoridur_palbank_w));
 }
 
 void dynax_state::mjembase_io_map(address_map &map)
 {
-	//ADDRESS_MAP_GLOBAL_MASK(0xff)
-	map(0x04, 0x05).mirror(0xff00).w("ym2413", FUNC(ym2413_device::write));       //
-	map(0x06, 0x06).mirror(0xff00).r("aysnd", FUNC(ay8912_device::data_r));        // AY8912, dsw0
-	map(0x08, 0x08).mirror(0xff00).w("aysnd", FUNC(ay8912_device::data_w));       //
-	map(0x0a, 0x0a).mirror(0xff00).w("aysnd", FUNC(ay8912_device::address_w));    //
-	map(0x20, 0x20).mirror(0xff00).w(this, FUNC(dynax_state::hanamai_keyboard_w));         // keyboard row select
-	map(0x21, 0x21).mirror(0xff00).portr("COINS");                // Coins
-	map(0x22, 0x22).mirror(0xff00).r(this, FUNC(dynax_state::mjelctrn_keyboard_1_r));       // P2
-	map(0x23, 0x23).mirror(0xff00).r(this, FUNC(dynax_state::hanamai_keyboard_0_r));        // P1
-	map(0x24, 0x24).mirror(0xff00).portr("DSW3");
-//  AM_RANGE( 0x40, 0x40 ) AM_MIRROR(0xff00) AM_WRITENOP   // CRT Controller
-//  AM_RANGE( 0x41, 0x41 ) AM_MIRROR(0xff00) AM_WRITENOP   // CRT Controller
-	map(0x61, 0x67).mirror(0xff00).w(this, FUNC(dynax_state::dynax_blitter_rev2_w));       // Blitter
-	map(0x80, 0x87).mirror(0xff00).w(m_mainlatch, FUNC(ls259_device::write_d0));
-	map(0xa0, 0xa0).mirror(0xff00).w(this, FUNC(dynax_state::hnoridur_rombank_w));         // BANK ROM Select
-	map(0xc0, 0xc0).mirror(0xff00).w(this, FUNC(dynax_state::dynax_blit_pen_w));           // Destination Pen
-	map(0xc1, 0xc1).mirror(0xff00).w(this, FUNC(dynax_state::mjembase_blit_dest_w));       // Destination Layer
-	map(0xc2, 0xc2).mirror(0xff00).w(this, FUNC(dynax_state::dynax_blit_palette01_w));     // Layers Palettes
-	map(0xc3, 0xc3).mirror(0xff00).w(this, FUNC(dynax_state::mjembase_blit_palette23_w));  //
-	map(0xc4, 0xc4).mirror(0xff00).w(this, FUNC(dynax_state::mjembase_priority_w));        // layer priority and enable
-	map(0xc5, 0xc5).mirror(0xff00).w(this, FUNC(dynax_state::dynax_blit_backpen_w));       // Background Color
-	map(0xc6, 0xc6).mirror(0xff00).w(this, FUNC(dynax_state::yarunara_blit_romregion_w));  // Blitter ROM bank
-	map(0xc7, 0xc7).mirror(0xff00).w(this, FUNC(dynax_state::hnoridur_palbank_w));
+	map.global_mask(0xff);
+	map(0x04, 0x05).w("ym2413", FUNC(ym2413_device::write));       //
+	map(0x06, 0x06).r("aysnd", FUNC(ay8912_device::data_r));        // AY8912, dsw0
+	map(0x08, 0x08).w("aysnd", FUNC(ay8912_device::data_w));       //
+	map(0x0a, 0x0a).w("aysnd", FUNC(ay8912_device::address_w));    //
+	map(0x20, 0x20).w(this, FUNC(dynax_state::hanamai_keyboard_w));         // keyboard row select
+	map(0x21, 0x21).portr("COINS");                // Coins
+	map(0x22, 0x22).r(this, FUNC(dynax_state::mjelctrn_keyboard_1_r));       // P2
+	map(0x23, 0x23).r(this, FUNC(dynax_state::hanamai_keyboard_0_r));        // P1
+	map(0x24, 0x24).portr("DSW3");
+//  AM_RANGE( 0x40, 0x40 ) AM_WRITENOP   // CRT Controller
+//  AM_RANGE( 0x41, 0x41 ) AM_WRITENOP   // CRT Controller
+	map(0x61, 0x67).w(this, FUNC(dynax_state::dynax_blitter_rev2_w));       // Blitter
+	map(0x80, 0x87).w(m_mainlatch, FUNC(ls259_device::write_d0));
+	map(0xa0, 0xa0).w(this, FUNC(dynax_state::hnoridur_rombank_w));         // BANK ROM Select
+	map(0xc0, 0xc0).w(this, FUNC(dynax_state::dynax_blit_pen_w));           // Destination Pen
+	map(0xc1, 0xc1).w(this, FUNC(dynax_state::mjembase_blit_dest_w));       // Destination Layer
+	map(0xc2, 0xc2).w(this, FUNC(dynax_state::dynax_blit_palette01_w));     // Layers Palettes
+	map(0xc3, 0xc3).w(this, FUNC(dynax_state::mjembase_blit_palette23_w));  //
+	map(0xc4, 0xc4).w(this, FUNC(dynax_state::mjembase_priority_w));        // layer priority and enable
+	map(0xc5, 0xc5).w(this, FUNC(dynax_state::dynax_blit_backpen_w));       // Background Color
+	map(0xc6, 0xc6).w(this, FUNC(dynax_state::yarunara_blit_romregion_w));  // Blitter ROM bank
+	map(0xc7, 0xc7).w(this, FUNC(dynax_state::hnoridur_palbank_w));
 }
 
 

--- a/src/mame/drivers/royalmah.cpp
+++ b/src/mame/drivers/royalmah.cpp
@@ -1010,15 +1010,16 @@ WRITE8_MEMBER(royalmah_state::janptr96_coin_counter_w)
 
 void royalmah_state::janptr96_iomap(address_map &map)
 {
-	map(0x00, 0x00).mirror(0xff00).w(this, FUNC(royalmah_state::janptr96_rombank_w));    // BANK ROM Select
-	map(0x20, 0x20).mirror(0xff00).rw(this, FUNC(royalmah_state::janptr96_unknown_r), FUNC(royalmah_state::janptr96_rambank_w));
-	map(0x50, 0x50).mirror(0xff00).w(this, FUNC(royalmah_state::mjderngr_palbank_w));
-	map(0x60, 0x6f).mirror(0xff00).rw(m_rtc, FUNC(msm6242_device::read), FUNC(msm6242_device::write));
-	map(0x81, 0x81).mirror(0xff00).r(m_ay, FUNC(ay8910_device::data_r));
-	map(0x82, 0x83).mirror(0xff00).w(m_ay, FUNC(ay8910_device::data_address_w));
-	map(0x93, 0x93).mirror(0xff00).w(this, FUNC(royalmah_state::input_port_select_w));
-	map(0xd8, 0xd8).mirror(0xff00).w(this, FUNC(royalmah_state::janptr96_coin_counter_w));
-	map(0xd9, 0xd9).mirror(0xff00).portr("SYSTEM").nopw(); // second input select?
+	map.global_mask(0xff);
+	map(0x00, 0x00).w(this, FUNC(royalmah_state::janptr96_rombank_w));    // BANK ROM Select
+	map(0x20, 0x20).rw(this, FUNC(royalmah_state::janptr96_unknown_r), FUNC(royalmah_state::janptr96_rambank_w));
+	map(0x50, 0x50).w(this, FUNC(royalmah_state::mjderngr_palbank_w));
+	map(0x60, 0x6f).rw(m_rtc, FUNC(msm6242_device::read), FUNC(msm6242_device::write));
+	map(0x81, 0x81).r(m_ay, FUNC(ay8910_device::data_r));
+	map(0x82, 0x83).w(m_ay, FUNC(ay8910_device::data_address_w));
+	map(0x93, 0x93).w(this, FUNC(royalmah_state::input_port_select_w));
+	map(0xd8, 0xd8).w(this, FUNC(royalmah_state::janptr96_coin_counter_w));
+	map(0xd9, 0xd9).portr("SYSTEM").nopw(); // second input select?
 }
 
 /****************************************************************************


### PR DESCRIPTION
…or bits are now allowed to fall outside the driver-specified global mask, though memory map validation requires that they cover the entire masked-out portions of the address space if any do.

This change is intended to expedite debugging of software written for the TMPZ84C015 or similar Z80-based controllers which use 8-bit I/O addressing for the on-chip peripherals but may use either 8-bit or 16-bit addressing externally.

Submitted as a PR to allow OG a chance to object. :-)