### PR TITLE
Set SO_REUSEADDR in posixsocket

### DIFF
--- a/src/osd/modules/file/posixsocket.cpp
+++ b/src/osd/modules/file/posixsocket.cpp
@@ -176,6 +176,14 @@ osd_file::error posix_open_socket(std::string const &path, std::uint32_t openfla
 		return errno_to_file_error(err);
 	}
 
+	if (::setsockopt(sock, SOL_SOCKET, SO_REUSEADDR, reinterpret_cast<const char *>(&flag), sizeof(flag)) < 0)
+	{
+		int const err = errno;
+		::close(sock);
+		return errno_to_file_error(err);
+	}
+
+
 	// listening socket support
 	if (openflags & OPEN_FLAG_CREATE)
 	{


### PR DESCRIPTION
Without it you have to wait until the socket is moved
out of the TIME_WAIT state, which can take quite a while.
This is pretty anoying when using mame with serial ports
forwarded via TCP.

Signed-off-by: Sven Schnelle <svens@stackframe.org>