### PR TITLE
c6280.cpp : Fix LFO

### DIFF
--- a/src/devices/sound/c6280.cpp
+++ b/src/devices/sound/c6280.cpp
@@ -130,7 +130,7 @@ void c6280_device::sound_stream_update(sound_stream &stream, stream_sample_t **i
 							m_channel[1].m_counter &= 0x1FFFF;
 							lfo_data = m_channel[1].m_waveform[lfooffset];
 							if (m_lfo_control & 3)
-								step += ((lfo_data - 16) << ((m_lfo_control-1)+1)); // verified from patent, TODO : same in real hardware?
+								step += ((lfo_data - 16) << ((m_lfo_control-1)<<1)); // verified from patent, TODO : same in real hardware?
 
 							offset = (m_channel[0].m_counter >> 12) & 0x1F;
 							m_channel[0].m_counter += m_wave_freq_tab[step & 0xfff];


### PR DESCRIPTION
<<1 is same at patent, not +1 (reference:https://patents.google.com/patent/US4924744A/)