### PR TITLE
Fix Acorn SL names so they show in the right position in front-ends.

### DIFF
--- a/hash/bbc_flop_32016.xml
+++ b/hash/bbc_flop_32016.xml
@@ -1,14 +1,14 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE softwarelist SYSTEM "softwarelist.dtd">
 
-<!-- BBC Micro - 32016 Co-Processor Discs -->
+<!-- Acorn ABC - 32016 Co-Processor Discs -->
 
 <!-- Loading Instructions:
 
       Hold down the SHIFT key and press and release the BREAK key.
 -->
 
-<softwarelist name="bbc_flop_32016" description="32016 Co-Processor Discs">
+<softwarelist name="bbc_flop_32016" description="Acorn ABC 32016 Co-Processor discs">
 
 	<software name="panos11" cloneof="panos14" supported="no">
 		<description>PanOS Version 1.10 System Disks</description>

--- a/hash/bbc_flop_6502.xml
+++ b/hash/bbc_flop_6502.xml
@@ -1,14 +1,14 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE softwarelist SYSTEM "softwarelist.dtd">
 
-<!-- BBC Micro - 6502 2nd Processor Discs -->
+<!-- Acorn BBC Micro - 6502 2nd Processor Discs -->
 
 <!-- Loading Instructions:
 
       Hold down the SHIFT key and press and release the BREAK key.
 -->
 
-<softwarelist name="bbc_flop_6502" description="6502 2nd Processor Discs">
+<softwarelist name="bbc_flop_6502" description="Acorn BBC Master 6502 2nd Processor discs">
 
 	<software name="6502dev">
 		<description>6502 Development Package</description>

--- a/hash/bbc_flop_65c102.xml
+++ b/hash/bbc_flop_65c102.xml
@@ -1,14 +1,14 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE softwarelist SYSTEM "softwarelist.dtd">
 
-<!-- BBC Micro - 65C102 Co-Processor Discs -->
+<!-- Acorn BBC Micro - 65C102 Co-Processor Discs -->
 
 <!-- Loading Instructions:
 
       Hold down the SHIFT key and press and release the BREAK key.
 -->
 
-<softwarelist name="bbc_flop_65c102" description="65C102 Co-Processor Discs">
+<softwarelist name="bbc_flop_65c102" description="Acorn BBC Master 65C102 Co-Processor discs">
 
 	<software name="coprosup">
 		<description>65C102 Co-Processor Support Disc</description>

--- a/hash/bbc_flop_80186.xml
+++ b/hash/bbc_flop_80186.xml
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE softwarelist SYSTEM "softwarelist.dtd">
 
-<!-- BBC Micro - 80186 Co-Processor Discs -->
+<!-- Acorn BBC Master - 80186 Co-Processor Discs -->
 
-<softwarelist name="bbc_flop_80186" description="80186 Co-Processor Discs">
+<softwarelist name="bbc_flop_80186" description="Acorn BBC Master 80186 Co-Processor discs">
 
 	<software name="m512sys">
 		<description>BBC Master 512 System Discs</description>

--- a/hash/bbca_cass.xml
+++ b/hash/bbca_cass.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <!DOCTYPE softwarelist SYSTEM "softwarelist.dtd">
 
-<!-- BBC Micro Model A Tapes -->
+<!-- Acorn BBC Micro Model A Tapes -->
 
 <!-- I believe all the Cassette images here are original, so some may require the manuals for additional copy protection. -->
 
@@ -12,7 +12,7 @@
 
 <!-- This list was compiled from the archive at http://www.stairwaytohell.com/. Additional titles will be added as they are made available at http://stardot.org.uk/ forum. -->
 
-<softwarelist name="bbca_cass" description="BBC Micro Model A cassettes">
+<softwarelist name="bbca_cass" description="Acorn BBC Micro Model A cassettes">
 
 	<!-- Games -->
 

--- a/hash/bbcb_cass.xml
+++ b/hash/bbcb_cass.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <!DOCTYPE softwarelist SYSTEM "softwarelist.dtd">
 
-<!-- BBC Micro Model B Tapes -->
+<!-- Acorn BBC Micro Model B Tapes -->
 
 <!-- I believe all the Cassette images here are original, so some require the manuals for additional copy protection -->
 
@@ -14,7 +14,7 @@
 
 <!-- This list was compiled from the archive at http://www.stairwaytohell.com/. Additional titles will be added as they are made available at http://stardot.org.uk/ forum. -->
 
-<softwarelist name="bbcb_cass" description="BBC Micro Model B cassettes">
+<softwarelist name="bbcb_cass" description="Acorn BBC Micro Model B cassettes">
 
 	<!-- Games -->
 

--- a/hash/bbcb_cass_de.xml
+++ b/hash/bbcb_cass_de.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <!DOCTYPE softwarelist SYSTEM "softwarelist.dtd">
 
-<!-- BBC Micro Model B (German) Tapes -->
+<!-- Acorn BBC Micro Model B (German) Tapes -->
 
 <!-- I believe all the Cassette images here are original, so some require the manuals for additional copy protection -->
 
@@ -12,7 +12,7 @@
       To start/stop the tape you must use the MAME UI, so you'll have to turn full keyboard mode off with Scroll Lock, then navigate the menus, turning Scroll Lock back on when you're finished.
 -->
 
-<softwarelist name="bbcb_cass_de" description="BBC Micro Model B (German) cassettes">
+<softwarelist name="bbcb_cass_de" description="Acorn BBC Micro Model B (German) cassettes">
 
 	<!-- Games -->
 

--- a/hash/bbcb_flop.xml
+++ b/hash/bbcb_flop.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE softwarelist SYSTEM "softwarelist.dtd">
 
-<!-- BBC Micro Model B Disks -->
+<!-- Acorn BBC Micro Model B Disks -->
 
 <!-- Loading Instructions:
 
@@ -13,7 +13,7 @@
 <!-- All images in this list contain no protection, they are either deprotected disc images or transferred from cassette. Some may never have been protected and will be marked if known. -->
 
 
-<softwarelist name="bbcb_flop" description="BBC Micro Model B disks">
+<softwarelist name="bbcb_flop" description="Acorn BBC Micro Model B disks">
 
 	<!-- Games -->
 

--- a/hash/bbcb_flop_orig.xml
+++ b/hash/bbcb_flop_orig.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE softwarelist SYSTEM "softwarelist.dtd">
 
-<!-- BBC Micro Model B Original Disks -->
+<!-- Acorn BBC Micro Model B Original Disks -->
 
 <!-- Loading Instructions:
 
@@ -12,7 +12,7 @@
 
 <!-- All images in this list were created from original discs, most contain copy protection. -->
 
-<softwarelist name="bbcb_flop_orig" description="BBC Micro Model B Original disks">
+<softwarelist name="bbcb_flop_orig" description="Acorn BBC Micro Model B Original disks">
 
 	<!-- Games -->
 

--- a/hash/bbcb_flop_us.xml
+++ b/hash/bbcb_flop_us.xml
@@ -1,14 +1,14 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE softwarelist SYSTEM "softwarelist.dtd">
 
-<!-- BBC Micro Model B (US) Disks -->
+<!-- Acorn BBC Micro Model B (US) Disks -->
 
 <!-- Loading Instructions:
 
       Hold down the SHIFT key and press and release the BREAK key.
 -->
 
-<softwarelist name="bbcb_flop_us" description="BBC Micro Model B (US) disks">
+<softwarelist name="bbcb_flop_us" description="Acorn BBC Micro Model B (US) disks">
 
 	<software name="intrutil">
 		<description>Introductory and Utilities Disk</description>

--- a/hash/bbcbc.xml
+++ b/hash/bbcbc.xml
@@ -1,7 +1,9 @@
 <?xml version="1.0"?>
 <!DOCTYPE softwarelist SYSTEM "softwarelist.dtd">
-<!-- The BBC Bridge Companion only used a cartridge slot for software -->
-<softwarelist name="bbcbc" description="BBC Bridge Companion cartridges">
+
+<!-- The Acorn BBC Bridge Companion only used a cartridge slot for software -->
+
+<softwarelist name="bbcbc" description="Acorn BBC Bridge Companion cartridges">
 	<software name="advbidng">
 		<description>Advanced Bidding</description>
 		<year>198?</year>

--- a/hash/bbcm_cart.xml
+++ b/hash/bbcm_cart.xml
@@ -1,14 +1,14 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE softwarelist SYSTEM "softwarelist.dtd">
 
-<!-- BBC Master ROM Cartridges -->
+<!-- Acorn BBC Master ROM Cartridges -->
 
 <!-- Loading Instructions:
 
       Hold down the SHIFT key and SPACEbar and press and release the BREAK key.
 -->
 
-<softwarelist name="bbcm_cart" description="BBC Master cartridges">
+<softwarelist name="bbcm_cart" description="Acorn BBC Master cartridges">
 
 	<software name="demo">
 		<description>BBC Master Demonstration Cartridge</description>

--- a/hash/bbcm_cass.xml
+++ b/hash/bbcm_cass.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <!DOCTYPE softwarelist SYSTEM "softwarelist.dtd">
 
-<!-- BBC Master Tapes -->
+<!-- Acorn BBC Master Tapes -->
 
 <!-- I believe all the Cassette images here are original, so some may require the manuals for additional copy protection. -->
 
@@ -12,7 +12,7 @@
       To start/stop the tape you must use the MESS menus, so you'll have to turn full keyboard mode off with Scroll Lock, then navigate the menus, turning Scroll Lock back on when you're finished.
 -->
 
-<softwarelist name="bbcm_cass" description="BBC Master cassettes">
+<softwarelist name="bbcm_cass" description="Acorn BBC Master cassettes">
 
 	<!-- Games -->
 

--- a/hash/bbcm_flop.xml
+++ b/hash/bbcm_flop.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE softwarelist SYSTEM "softwarelist.dtd">
 
-<!-- BBC Master Disks -->
+<!-- Acorn BBC Master Disks -->
 
 <!-- Loading Instructions:
 
@@ -12,7 +12,7 @@
       - MFM requires ADFS (A and BREAK)
 -->
 
-<softwarelist name="bbcm_flop" description="BBC Master disks">
+<softwarelist name="bbcm_flop" description="Acorn BBC Master disks">
 
 	<software name="welcomem">
 		<description>Welcome &amp; Utilities Disc</description>

--- a/hash/bbcmc_flop.xml
+++ b/hash/bbcmc_flop.xml
@@ -1,14 +1,14 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE softwarelist SYSTEM "softwarelist.dtd">
 
-<!-- BBC Master Compact Disks -->
+<!-- Acorn BBC Master Compact Disks -->
 
 <!-- Loading Instructions:
 
       Hold down the SHIFT key and press and release the BREAK key.
 -->
 
-<softwarelist name="bbcmc_flop" description="BBC Master Compact disks">
+<softwarelist name="bbcmc_flop" description="Acorn BBC Master Compact disks">
 
 	<software name="alps24">
 		<description>ALPS - Adventure Language Programming System</description>


### PR DESCRIPTION
In MAME it is customary to write computer names (machine names) without any brand at the beginning. For example: **Playstation** and not **Sony Playstation**. However, in SLs the brand name at the beginning is customary and I think it makes sense so SL appear in the right position in front-ends.

In this PR I have fixed some Acorn BBC/ABC SL names. If PR is accepted and merged then I will correct some other SL names (Sinclair, etc.).