### PR TITLE
Fix Lode Runner SG1000/SC-3000 ROM image detection

### DIFF
--- a/src/devices/bus/sega8/sega8_slot.cpp
+++ b/src/devices/bus/sega8/sega8_slot.cpp
@@ -561,6 +561,10 @@ int sega8_cart_slot_device::get_cart_type(const uint8_t *ROM, uint32_t len) cons
 		}
 	}
 
+	// Lode Runner Japan Europe
+	if (len == 0x8000 && !strncmp((const char *)&ROM[0x226c], "LICENSEDFROMBRODERBUND@SOFTWARE@INC", 35))
+		type = SEGA8_BASE_ROM;
+
 	// Terebi Oekaki (TV Draw)
 	if (len >= 0x13b3 + 7 && !strncmp((const char *)&ROM[0x13b3], "annakmn", 7))
 		type = SEGA8_TEREBIOEKAKI;


### PR DESCRIPTION
At least on Fedora Linux 27, the following happened when not using
XML-files:

mame sc3000 -window -cart /usr/share/mame/roms/sc3000/mpr-5998.ic1
Ignoring MAME exception: Unknown slot option 'codemasters' in slot 'slot'
Unknown slot option 'codemasters' in slot 'slot'

I suppose that was because Lode Runner ROM image was not correctly
detected. This patch adds a special case to detect Lode Runner
(Japan, Europe).