### PR TITLE
tms9914: improved emulation

### DIFF
--- a/src/devices/machine/tms9914.h
+++ b/src/devices/machine/tms9914.h
@@ -275,6 +275,7 @@ private:
 	bool listener_reset() const;
 	bool talker_reset() const;
 	bool controller_reset() const;
+	bool sh_active() const;
 	void update_fsm();
 	bool is_my_address(uint8_t addr);
 	void do_LAF();


### PR DESCRIPTION
Hi,

this PR is for a small change to tms9914 emulation. This change allows the HPIB test in IPC diagnostic ROM to pass.
HPIB test can be started by running IPC with "diagb" BIOS option. Once the screen has filled with messages from the RAM test, press F1 to interrupt the test sequence, then press F4 to run the HPIB test.
Thanks.
--F.Ulivi
