### PR TITLE
scsp.cpp, aica.cpp Add input clocks

### DIFF
--- a/src/devices/sound/aica.cpp
+++ b/src/devices/sound/aica.cpp
@@ -505,24 +505,7 @@ void aica_device::Init()
 
 	m_ARTABLE[0]=m_DRTABLE[0]=0;    //Infinite time
 	m_ARTABLE[1]=m_DRTABLE[1]=0;    //Infinite time
-	for(i=2;i<64;++i)
-	{
-		double t,step,scale;
-		t=ARTimes[i];   //In ms
-		if(t!=0.0)
-		{
-			step=(1023*1000.0)/(44100.0*t);
-			scale=(double) (1<<EG_SHIFT);
-			m_ARTABLE[i]=(int) (step*scale);
-		}
-		else
-			m_ARTABLE[i]=1024<<EG_SHIFT;
-
-		t=DRTimes[i];   //In ms
-		step=(1023*1000.0)/(44100.0*t);
-		scale=(double) (1<<EG_SHIFT);
-		m_DRTABLE[i]=(int) (step*scale);
-	}
+	UpdateClock();
 
 	// make sure all the slots are off
 	for(i=0;i<64;++i)
@@ -535,8 +518,8 @@ void aica_device::Init()
 	}
 
 	AICALFO_Init();
-	m_buffertmpl=make_unique_clear<int32_t[]>(44100);
-	m_buffertmpr=make_unique_clear<int32_t[]>(44100);
+	m_buffertmpl.resize(m_rate, 0);
+	m_buffertmpr.resize(m_rate, 0);
 
 	// no "pend"
 	m_udata.data[0xa0/2] = 0;
@@ -544,6 +527,28 @@ void aica_device::Init()
 	m_TimCnt[0] = 0xffff;
 	m_TimCnt[1] = 0xffff;
 	m_TimCnt[2] = 0xffff;
+}
+
+void aica_device::UpdateClock()
+{
+	for(int i=2;i<64;++i)
+	{
+		double t,step,scale;
+		t=ARTimes[i];   //In ms
+		if(t!=0.0)
+		{
+			step=(1023*1000.0)/(double(m_rate)*t);
+			scale=(double) (1<<EG_SHIFT);
+			m_ARTABLE[i]=(int) (step*scale);
+		}
+		else
+			m_ARTABLE[i]=1024<<EG_SHIFT;
+
+		t=DRTimes[i];   //In ms
+		step=(1023*1000.0)/(double(m_rate)*t);
+		scale=(double) (1<<EG_SHIFT);
+		m_DRTABLE[i]=(int) (step*scale);
+	}
 }
 
 void aica_device::UpdateSlotReg(int s,int r)
@@ -675,10 +680,10 @@ void aica_device::UpdateReg(address_space &space, int reg)
 
 				if ((m_udata.data[0x90/2]&0xff) != 255)
 				{
-					time = (44100 / m_TimPris[0]) / (255-(m_udata.data[0x90/2]&0xff));
+					time = (clock() / m_TimPris[0]) / (255-(m_udata.data[0x90/2]&0xff));
 					if (time)
 					{
-						m_timerA->adjust(attotime::from_hz(time));
+						m_timerA->adjust(attotime::from_ticks(768, time));
 					}
 				}
 			}
@@ -694,10 +699,10 @@ void aica_device::UpdateReg(address_space &space, int reg)
 
 				if ((m_udata.data[0x94/2]&0xff) != 255)
 				{
-					time = (44100 / m_TimPris[1]) / (255-(m_udata.data[0x94/2]&0xff));
+					time = (clock() / m_TimPris[1]) / (255-(m_udata.data[0x94/2]&0xff));
 					if (time)
 					{
-						m_timerB->adjust(attotime::from_hz(time));
+						m_timerB->adjust(attotime::from_ticks(768, time));
 					}
 				}
 			}
@@ -713,10 +718,10 @@ void aica_device::UpdateReg(address_space &space, int reg)
 
 				if ((m_udata.data[0x98/2]&0xff) != 255)
 				{
-					time = (44100 / m_TimPris[2]) / (255-(m_udata.data[0x98/2]&0xff));
+					time = (clock() / m_TimPris[2]) / (255-(m_udata.data[0x98/2]&0xff));
 					if (time)
 					{
-						m_timerC->adjust(attotime::from_hz(time));
+						m_timerC->adjust(attotime::from_ticks(768, time));
 					}
 				}
 			}
@@ -1416,6 +1421,7 @@ void aica_device::sound_stream_update(sound_stream &stream, stream_sample_t **in
 
 void aica_device::device_start()
 {
+	m_rate = clock() / 768;
 	// init the emulation
 	Init();
 
@@ -1423,7 +1429,7 @@ void aica_device::device_start()
 	m_irq_cb.resolve_safe();
 	m_main_irq_cb.resolve_safe();
 
-	m_stream = machine().sound().stream_alloc(*this, 0, 2, 44100);
+	m_stream = machine().sound().stream_alloc(*this, 0, 2, m_rate);
 
 	// save state
 	save_item(NAME(m_IrqTimA));
@@ -1438,6 +1444,27 @@ void aica_device::device_start()
 	save_item(NAME(m_RPANTABLE),0x20000);
 	save_item(NAME(m_TimPris),3);
 	save_item(NAME(m_TimCnt),3);
+}
+
+//-------------------------------------------------
+//  device_clock_changed - called if the clock
+//  changes
+//-------------------------------------------------
+
+void aica_device::device_clock_changed()
+{
+	int old_rate = m_rate;
+	m_rate = clock() / 768;
+	if (m_rate != old_rate)
+	{
+		UpdateClock();
+		if (m_rate > old_rate)
+		{
+			m_buffertmpl.resize(m_rate,0);
+			m_buffertmpr.resize(m_rate,0);
+		}
+		m_stream->set_sample_rate(m_rate);
+	}
 }
 
 void aica_device::set_ram_base(void *base, int size)
@@ -1496,8 +1523,7 @@ aica_device::aica_device(const machine_config &mconfig, const char *tag, device_
 		m_AICARAM_LENGTH(0),
 		m_RAM_MASK(0),
 		m_RAM_MASK16(0),
-		m_buffertmpl(nullptr),
-		m_buffertmpr(nullptr),
+		m_rate(0),
 		m_IrqTimA(0),
 		m_IrqTimBC(0),
 		m_IrqMidi(0),
@@ -1649,7 +1675,7 @@ signed int aica_device::AICAALFO_Step(AICA_LFO_t *LFO)
 
 void aica_device::AICALFO_ComputeStep(AICA_LFO_t *LFO,uint32_t LFOF,uint32_t LFOWS,uint32_t LFOS,int ALFO)
 {
-	float step=(float) LFOFreq[LFOF]*256.0f/(float)44100.0f;
+	float step=(float) LFOFreq[LFOF]*256.0f/((float)((double)clock()/768.0));
 	LFO->phase_step=(unsigned int) ((float) (1<<LFO_SHIFT)*step);
 	if(ALFO)
 	{

--- a/src/devices/sound/aica.h
+++ b/src/devices/sound/aica.h
@@ -51,6 +51,7 @@ public:
 protected:
 	// device-level overrides
 	virtual void device_start() override;
+	virtual void device_clock_changed() override;
 
 	// sound stream update overrides
 	virtual void sound_stream_update(sound_stream &stream, stream_sample_t **inputs, stream_sample_t **outputs, int samples) override;
@@ -137,6 +138,7 @@ private:
 	inline int32_t UpdateSlot(AICA_SLOT *slot);
 	void DoMasterSamples(int nsamples);
 	void aica_exec_dma(address_space &space);
+	void UpdateClock();
 
 
 	void AICALFO_Init();
@@ -165,8 +167,9 @@ private:
 	uint32_t m_AICARAM_LENGTH, m_RAM_MASK, m_RAM_MASK16;
 	sound_stream * m_stream;
 
-	std::unique_ptr<int32_t[]> m_buffertmpl;
-	std::unique_ptr<int32_t[]> m_buffertmpr;
+	std::vector<int32_t> m_buffertmpl;
+	std::vector<int32_t> m_buffertmpr;
+	int m_rate;
 
 	uint32_t m_IrqTimA;
 	uint32_t m_IrqTimBC;

--- a/src/devices/sound/scsp.h
+++ b/src/devices/sound/scsp.h
@@ -52,6 +52,7 @@ public:
 protected:
 	// device-level overrides
 	virtual void device_start() override;
+	virtual void device_clock_changed() override;
 
 	// sound stream update overrides
 	virtual void sound_stream_update(sound_stream &stream, stream_sample_t **inputs, stream_sample_t **outputs, int samples) override;
@@ -127,8 +128,9 @@ private:
 	char m_Master;
 	sound_stream * m_stream;
 
-	std::unique_ptr<int32_t[]> m_buffertmpl;
-	std::unique_ptr<int32_t[]> m_buffertmpr;
+	std::vector<int32_t> m_buffertmpl;
+	std::vector<int32_t> m_buffertmpr;
+	int m_rate;
 
 	uint32_t m_IrqTimA;
 	uint32_t m_IrqTimBC;
@@ -146,6 +148,7 @@ private:
 	int m_TimPris[3];
 	int m_TimCnt[3];
 
+	void UpdateClock();
 	// timers
 	emu_timer *m_timerA, *m_timerB, *m_timerC;
 
@@ -205,6 +208,7 @@ private:
 	uint16_t r16(address_space &space, uint32_t addr);
 	inline int32_t UpdateSlot(SCSP_SLOT *slot);
 	void DoMasterSamples(int nsamples);
+	void UpdateClock();
 
 	//LFO
 	void LFO_Init();

--- a/src/emu/xtal.cpp
+++ b/src/emu/xtal.cpp
@@ -244,6 +244,7 @@ const double XTAL::known_xtals[] = {
 	 22'118'400, /* 22.1184_MHz_XTAL       Amusco Poker */
 	 22'321'000, /* 22.321_MHz_XTAL        Apple LaserWriter II NT */
 	 22'464'000, /* 22.464_MHz_XTAL        CIT-101 132-column display clock */
+	 22'579'200, /* 22.5792_MHz_XTAL       Sega SCSP (44100 * 512) */
 	 22'656'000, /* 22.656_MHz_XTAL        Super Pinball Action (~1440x NTSC line rate) */
 	 22'896'000, /* 22.896_MHz_XTAL        DEC VT220 132-column display clock */
 	 23'814'000, /* 23.814_MHz_XTAL        TeleVideo TVI-912, 920 & 950 */

--- a/src/mame/drivers/coolridr.cpp
+++ b/src/mame/drivers/coolridr.cpp
@@ -3310,16 +3310,16 @@ MACHINE_CONFIG_START(coolridr_state::coolridr)
 	MCFG_DEFAULT_LAYOUT(layout_dualhsxs)
 
 	MCFG_SPEAKER_STANDARD_STEREO("lspeaker", "rspeaker")
-	MCFG_DEVICE_ADD("scsp1", SCSP)
+	MCFG_DEVICE_ADD("scsp1", SCSP, 22.5792_MHz_XTAL) // TODO : verify clock; guessed
 	MCFG_SCSP_IRQ_CB(WRITE8(*this, coolridr_state, scsp_irq))
 	MCFG_SCSP_MAIN_IRQ_CB(WRITELINE(*this, coolridr_state, scsp1_to_sh1_irq))
 	MCFG_SOUND_ROUTE(0, "lspeaker", 1.0)
-	MCFG_SOUND_ROUTE(0, "rspeaker", 1.0)
+	MCFG_SOUND_ROUTE(1, "rspeaker", 1.0)
 
-	MCFG_DEVICE_ADD("scsp2", SCSP)
+	MCFG_DEVICE_ADD("scsp2", SCSP, 22.5792_MHz_XTAL) // TODO : verify clock; guessed
 	MCFG_SCSP_MAIN_IRQ_CB(WRITELINE(*this, coolridr_state, scsp2_to_sh1_irq))
 	MCFG_SOUND_ROUTE(0, "lspeaker", 1.0)
-	MCFG_SOUND_ROUTE(0, "rspeaker", 1.0)
+	MCFG_SOUND_ROUTE(1, "rspeaker", 1.0)
 MACHINE_CONFIG_END
 
 MACHINE_CONFIG_START(coolridr_state::aquastge)

--- a/src/mame/drivers/dccons.cpp
+++ b/src/mame/drivers/dccons.cpp
@@ -619,12 +619,12 @@ MACHINE_CONFIG_START(dc_cons_state::dc)
 	MCFG_POWERVR2_ADD("powervr2", WRITE8(*this, dc_state, pvr_irq))
 
 	MCFG_SPEAKER_STANDARD_STEREO("lspeaker", "rspeaker")
-	MCFG_DEVICE_ADD("aica", AICA, 0)
+	MCFG_DEVICE_ADD("aica", AICA, 33.8688_MHz_XTAL)
 	MCFG_AICA_MASTER
 	MCFG_AICA_IRQ_CB(WRITELINE(*this, dc_state, aica_irq))
 	MCFG_AICA_MAIN_IRQ_CB(WRITELINE(*this, dc_state, sh4_aica_irq))
 	MCFG_SOUND_ROUTE(0, "lspeaker", 1.0)
-	MCFG_SOUND_ROUTE(0, "rspeaker", 1.0)
+	MCFG_SOUND_ROUTE(1, "rspeaker", 1.0)
 
 	MCFG_AICARTC_ADD("aicartc", XTAL(32'768))
 

--- a/src/mame/drivers/hikaru.cpp
+++ b/src/mame/drivers/hikaru.cpp
@@ -526,9 +526,13 @@ MACHINE_CONFIG_START(hikaru_state::hikaru)
 
 
 //  MCFG_SPEAKER_STANDARD_STEREO("lspeaker", "rspeaker")
-//  MCFG_DEVICE_ADD("aica", AICA, 0)
+//  MCFG_DEVICE_ADD("aica_1", AICA, 33.8688_MHz_XTAL)
 //  MCFG_SOUND_ROUTE(0, "lspeaker", 2.0)
-//  MCFG_SOUND_ROUTE(0, "rspeaker", 2.0)
+//  MCFG_SOUND_ROUTE(1, "rspeaker", 2.0)
+//	second AICA on external sound board
+//  MCFG_DEVICE_ADD("aica_2", AICA, 33.8688_MHz_XTAL)
+//  MCFG_SOUND_ROUTE(0, "lspeaker", 2.0)
+//  MCFG_SOUND_ROUTE(1, "rspeaker", 2.0)
 MACHINE_CONFIG_END
 
 

--- a/src/mame/drivers/model2.cpp
+++ b/src/mame/drivers/model2.cpp
@@ -2401,10 +2401,10 @@ MACHINE_CONFIG_START(model2_state::model2_scsp)
 
 	MCFG_SPEAKER_STANDARD_STEREO("lspeaker", "rspeaker")
 
-	MCFG_DEVICE_ADD("scsp", SCSP)
+	MCFG_DEVICE_ADD("scsp", SCSP, 22.5792_MHz_XTAL) // TODO : verify clock; guessed // verified from Model 2A Video board
 	MCFG_SCSP_IRQ_CB(WRITE8(*this, model2_state,scsp_irq))
 	MCFG_SOUND_ROUTE(0, "lspeaker", 2.0)
-	MCFG_SOUND_ROUTE(0, "rspeaker", 2.0)
+	MCFG_SOUND_ROUTE(1, "rspeaker", 2.0)
 
 	MCFG_DEVICE_ADD("uart", I8251, 8000000) // uPD71051C, clock unknown
 //  MCFG_I8251_RXRDY_HANDLER(WRITELINE(*this, model2_state, sound_ready_w))

--- a/src/mame/drivers/model3.cpp
+++ b/src/mame/drivers/model3.cpp
@@ -5775,14 +5775,14 @@ MACHINE_CONFIG_START(model3_state::model3_10)
 
 
 	MCFG_SPEAKER_STANDARD_STEREO("lspeaker", "rspeaker")
-	MCFG_DEVICE_ADD("scsp1", SCSP)
+	MCFG_DEVICE_ADD("scsp1", SCSP, 22.5792_MHz_XTAL) // TODO : verify clock; guessed
 	MCFG_SCSP_IRQ_CB(WRITE8(*this, model3_state, scsp_irq))
 	MCFG_SOUND_ROUTE(0, "lspeaker", 2.0)
-	MCFG_SOUND_ROUTE(0, "rspeaker", 2.0)
+	MCFG_SOUND_ROUTE(1, "rspeaker", 2.0)
 
-	MCFG_DEVICE_ADD("scsp2", SCSP)
+	MCFG_DEVICE_ADD("scsp2", SCSP, 22.5792_MHz_XTAL) // TODO : verify clock; guessed
 	MCFG_SOUND_ROUTE(0, "lspeaker", 2.0)
-	MCFG_SOUND_ROUTE(0, "rspeaker", 2.0)
+	MCFG_SOUND_ROUTE(1, "rspeaker", 2.0)
 
 	MCFG_DEVICE_ADD("scsi", SCSI_PORT, 0)
 
@@ -5809,7 +5809,6 @@ MACHINE_CONFIG_START(model3_state::model3_15)
 	MCFG_NVRAM_ADD_1FILL("backup")
 	MCFG_DEVICE_ADD("rtc", RTC72421, XTAL(32'768)) // internal oscillator
 
-
 	MCFG_SCREEN_ADD("screen", RASTER)
 	MCFG_SCREEN_REFRESH_RATE(60)
 	MCFG_SCREEN_VISIBLE_AREA(0, 495, 0, 383)
@@ -5819,16 +5818,15 @@ MACHINE_CONFIG_START(model3_state::model3_15)
 	MCFG_PALETTE_ADD_RRRRRGGGGGBBBBB("palette")
 	MCFG_GFXDECODE_ADD("gfxdecode", "palette", empty)
 
-
 	MCFG_SPEAKER_STANDARD_STEREO("lspeaker", "rspeaker")
-	MCFG_DEVICE_ADD("scsp1", SCSP)
+	MCFG_DEVICE_ADD("scsp1", SCSP, 22.5792_MHz_XTAL) // TODO : verify clock; guessed
 	MCFG_SCSP_IRQ_CB(WRITE8(*this, model3_state, scsp_irq))
 	MCFG_SOUND_ROUTE(0, "lspeaker", 2.0)
-	MCFG_SOUND_ROUTE(0, "rspeaker", 2.0)
+	MCFG_SOUND_ROUTE(1, "rspeaker", 2.0)
 
-	MCFG_DEVICE_ADD("scsp2", SCSP)
+	MCFG_DEVICE_ADD("scsp2", SCSP, 22.5792_MHz_XTAL) // TODO : verify clock; guessed
 	MCFG_SOUND_ROUTE(0, "lspeaker", 2.0)
-	MCFG_SOUND_ROUTE(0, "rspeaker", 2.0)
+	MCFG_SOUND_ROUTE(1, "rspeaker", 2.0)
 
 	MCFG_DEVICE_ADD("scsi", SCSI_PORT, 0)
 
@@ -5883,14 +5881,14 @@ MACHINE_CONFIG_START(model3_state::model3_20)
 
 
 	MCFG_SPEAKER_STANDARD_STEREO("lspeaker", "rspeaker")
-	MCFG_DEVICE_ADD("scsp1", SCSP)
+	MCFG_DEVICE_ADD("scsp1", SCSP, 22.5792_MHz_XTAL) // TODO : verify clock; guessed
 	MCFG_SCSP_IRQ_CB(WRITE8(*this, model3_state, scsp_irq))
 	MCFG_SOUND_ROUTE(0, "lspeaker", 2.0)
-	MCFG_SOUND_ROUTE(0, "rspeaker", 2.0)
+	MCFG_SOUND_ROUTE(1, "rspeaker", 2.0)
 
-	MCFG_DEVICE_ADD("scsp2", SCSP)
+	MCFG_DEVICE_ADD("scsp2", SCSP, 22.5792_MHz_XTAL) // TODO : verify clock; guessed
 	MCFG_SOUND_ROUTE(0, "lspeaker", 2.0)
-	MCFG_SOUND_ROUTE(0, "rspeaker", 2.0)
+	MCFG_SOUND_ROUTE(1, "rspeaker", 2.0)
 
 	MCFG_M3COMM_ADD("comm_board")
 MACHINE_CONFIG_END
@@ -5947,14 +5945,14 @@ MACHINE_CONFIG_START(model3_state::model3_21)
 	MCFG_GFXDECODE_ADD("gfxdecode", "palette", empty)
 
 	MCFG_SPEAKER_STANDARD_STEREO("lspeaker", "rspeaker")
-	MCFG_DEVICE_ADD("scsp1", SCSP)
+	MCFG_DEVICE_ADD("scsp1", SCSP, 22.5792_MHz_XTAL) // TODO : verify clock; guessed
 	MCFG_SCSP_IRQ_CB(WRITE8(*this, model3_state, scsp_irq))
 	MCFG_SOUND_ROUTE(0, "lspeaker", 2.0)
-	MCFG_SOUND_ROUTE(0, "rspeaker", 2.0)
+	MCFG_SOUND_ROUTE(1, "rspeaker", 2.0)
 
-	MCFG_DEVICE_ADD("scsp2", SCSP)
+	MCFG_DEVICE_ADD("scsp2", SCSP, 22.5792_MHz_XTAL) // TODO : verify clock; guessed
 	MCFG_SOUND_ROUTE(0, "lspeaker", 2.0)
-	MCFG_SOUND_ROUTE(0, "rspeaker", 2.0)
+	MCFG_SOUND_ROUTE(1, "rspeaker", 2.0)
 
 	MCFG_M3COMM_ADD("comm_board")
 MACHINE_CONFIG_END

--- a/src/mame/drivers/naomi.cpp
+++ b/src/mame/drivers/naomi.cpp
@@ -2702,7 +2702,7 @@ MACHINE_CONFIG_START(dc_state::naomi_aw_base)
 	MCFG_POWERVR2_ADD("powervr2", WRITE8(*this, dc_state, pvr_irq))
 
 	MCFG_SPEAKER_STANDARD_STEREO("lspeaker", "rspeaker")
-	MCFG_DEVICE_ADD("aica", AICA, 0)
+	MCFG_DEVICE_ADD("aica", AICA, 33.8688_MHz_XTAL)
 	MCFG_AICA_MASTER
 	MCFG_AICA_IRQ_CB(WRITELINE(*this, dc_state, aica_irq))
 	MCFG_AICA_MAIN_IRQ_CB(WRITELINE(*this, dc_state, sh4_aica_irq))

--- a/src/mame/drivers/saturn.cpp
+++ b/src/mame/drivers/saturn.cpp
@@ -838,7 +838,7 @@ MACHINE_CONFIG_START(sat_console_state::saturn)
 
 	MCFG_SPEAKER_STANDARD_STEREO("lspeaker", "rspeaker")
 
-	MCFG_DEVICE_ADD("scsp", SCSP)
+	MCFG_DEVICE_ADD("scsp", SCSP, 22.5792_MHz_XTAL) // TODO : verify clock; guessed
 	MCFG_SCSP_IRQ_CB(WRITE8(*this, saturn_state, scsp_irq))
 	MCFG_SCSP_MAIN_IRQ_CB(WRITELINE("scu", sega_scu_device, sound_req_w))
 	MCFG_SCSP_EXTS_CB(READ16("stvcd", stvcd_device, channel_volume_r))

--- a/src/mame/drivers/stv.cpp
+++ b/src/mame/drivers/stv.cpp
@@ -1115,7 +1115,7 @@ MACHINE_CONFIG_START(stv_state::stv)
 
 	MCFG_SPEAKER_STANDARD_STEREO("lspeaker", "rspeaker")
 
-	MCFG_DEVICE_ADD("scsp", SCSP)
+	MCFG_DEVICE_ADD("scsp", SCSP, 22.5792_MHz_XTAL) // TODO : verify clock; guessed
 	MCFG_SCSP_IRQ_CB(WRITE8(*this, saturn_state, scsp_irq))
 	MCFG_SCSP_MAIN_IRQ_CB(WRITELINE("scu", sega_scu_device, sound_req_w))
 	MCFG_SOUND_ROUTE(0, "lspeaker", 1.0)


### PR DESCRIPTION
scsp.cpp, aica.cpp : Add input clock (standard is 22.5792MHz, 33.8688MHz) for related to output rate, Convert m_buffertmp* into std::vector because it's related to output rate, Add device_clock_changed

coolridr.cpp, model2.cpp, dccons.cpp, hikaru.cpp : Fix output route because chip and machine both supports stereo output(or just typo and copy-paste errors?)
saturn.cpp, stv.cpp, coolridr.cpp, model3.cpp, model2.cpp, hikaru.cpp : Add notes