### PR TITLE
i8255: in read_pc(), also return data from output latch, take 2 (nw)

### DIFF
--- a/src/devices/machine/i8255.cpp
+++ b/src/devices/machine/i8255.cpp
@@ -478,6 +478,11 @@ uint8_t i8255_device::read_pc()
 	{
 		// read data from port
 		data |= m_in_pc_cb(0) & mask;
+		if (port_c_upper_mode() == MODE_OUTPUT)
+		{
+			// read data from output latch
+			data |= m_output[PORT_C] & 0xf0;
+		}
 	}
 
 	return data;


### PR DESCRIPTION
Tafoid has tested (-str 10) each affected machine, and it shows no wavdata or snapshot differences (outside of those which display changing dates).