### PR TITLE
irrmaze.lay: added color lamps, accuracy improvements

### DIFF
--- a/src/mame/layout/irrmaze.lay
+++ b/src/mame/layout/irrmaze.lay
@@ -21,6 +21,11 @@ copyright-holders:Vas Crabb
 		<rect><color red="0.5" green="0" blue="0" /></rect>
 	</element>
 
+	<element name="colorlamp">
+		<rect state="0"><color red="0.4" green="0" blue="0" /></rect>
+		<rect state="1"><color red="1" green="0.1" blue="0.25" /></rect>
+	</element>
+	
 	<element name="timerlamp">
 		<disk state="0"><color red="0.3" green="0" blue="0" /></disk>
 		<disk state="1"><color red="1" green="0.3" blue="0.1" /></disk>
@@ -46,41 +51,43 @@ copyright-holders:Vas Crabb
 	</element>
 
 	<element name="trackball">
-		<disk state="0"><color red="0.6" green="0" blue="0" /></disk>
-		<disk state="1"><color red="0.8" green="0.7" blue="0.1" /></disk>
+		<disk state="0"><color red="0.5" green="0" blue="0" /></disk>
+		<disk state="1"><color red="1" green="0.1" blue="0.25" /></disk>
 	</element>
 
 	<element name="redbtn">
-		<disk state="0"><color red="0.7" green="0" blue="0" /></disk>
-		<disk state="1"><color red="0.35" green="0" blue="0" /></disk>
+		<disk state="0"><color red="0.5" green="0" blue="0" /></disk>
+		<disk state="1"><color red="0.8" green="0" blue="0" /></disk>
 	</element>
 
 	<element name="bluebtn">
-		<disk state="0"><color red="0.2" green="0.5" blue="1" /></disk>
-		<disk state="1"><color red="0.1" green="0.25" blue="0.5" /></disk>
+		<disk state="0"><color red="0.1" green="0.3" blue="0.8" /></disk>
+		<disk state="1"><color red="0.15" green="0.6" blue="1" /></disk>
 	</element>
 
 	<view name="Cabinet Lamps">
-		<screen index="0"><bounds x="4.5" y="4.5" width="14" height="10.5" /></screen>
+		<screen index="0"><bounds x="3.5" y="4.4" width="16" height="12" /></screen>
 
-		<bezel element="marquee"><bounds x="0" y="0" width="23" height="2" /></bezel>
-		<bezel element="timerlamp" name="sit0"><bounds x="2" y="0.25" width="1" height="1" /></bezel>
-		<bezel element="timerlamp" name="sit1"><bounds x="4" y="0.25" width="1" height="1" /></bezel>
-		<bezel element="timerlamp" name="sit2"><bounds x="6" y="0.25" width="1" height="1" /></bezel>
-		<bezel element="timerlamp" name="sit3"><bounds x="8" y="0.25" width="1" height="1" /></bezel>
-		<bezel element="timerlamp" name="sit4"><bounds x="10" y="0.25" width="1" height="1" /></bezel>
-		<bezel element="timerlamp" name="sit5"><bounds x="12" y="0.25" width="1" height="1" /></bezel>
-		<bezel element="timerlamp" name="sit6"><bounds x="14" y="0.25" width="1" height="1" /></bezel>
-		<bezel element="timerlamp" name="sit7"><bounds x="16" y="0.25" width="1" height="1" /></bezel>
-		<bezel element="timerlamp" name="sit8"><bounds x="18" y="0.25" width="1" height="1" /></bezel>
-		<bezel element="timerlamp" name="sit9"><bounds x="20" y="0.25" width="1" height="1" /></bezel>
+		<bezel element="marquee"><bounds x="0" y="0" width="23" height="2.5" /></bezel>
+		<bezel element="colorlamp" name="sit13"><bounds x="0" y="0" width="11.5" height="1" /></bezel>
+		<bezel element="colorlamp" name="sit12"><bounds x="11.5" y="0" width="11.5" height="1" /></bezel>		
+		<bezel element="timerlamp" name="sit9"><bounds x="2" y="1.25" width="1" height="1" /></bezel>
+		<bezel element="timerlamp" name="sit8"><bounds x="4" y="1.25" width="1" height="1" /></bezel>
+		<bezel element="timerlamp" name="sit7"><bounds x="6" y="1.25" width="1" height="1" /></bezel>
+		<bezel element="timerlamp" name="sit6"><bounds x="8" y="1.25" width="1" height="1" /></bezel>
+		<bezel element="timerlamp" name="sit5"><bounds x="10" y="1.25" width="1" height="1" /></bezel>
+		<bezel element="timerlamp" name="sit4"><bounds x="12" y="1.25" width="1" height="1" /></bezel>
+		<bezel element="timerlamp" name="sit3"><bounds x="14" y="1.25" width="1" height="1" /></bezel>
+		<bezel element="timerlamp" name="sit2"><bounds x="16" y="1.25" width="1" height="1" /></bezel>
+		<bezel element="timerlamp" name="sit1"><bounds x="18" y="1.25" width="1" height="1" /></bezel>
+		<bezel element="timerlamp" name="sit0"><bounds x="20" y="1.25" width="1" height="1" /></bezel>
 
-		<bezel element="flashstick" name="sit14"><bounds x="0.75" y="6.5" width="1.5" height="6" /></bezel>
+		<bezel element="flashstick" name="sit14"><bounds x="0.75" y="6.5" width="1.5" height="5.5" /></bezel>
 		<bezel element="sidelamp" name="sit11"><bounds x="0.5" y="12.5" width="2" height="4.5" /></bezel>
-		<bezel element="flashstick" name="sit14"><bounds x="20.75" y="6.5" width="1.5" height="6" /></bezel>
+		<bezel element="flashstick" name="sit14"><bounds x="20.75" y="6.5" width="1.5" height="5.5" /></bezel>
 		<bezel element="sidelamp" name="sit11"><bounds x="20.5" y="12.5" width="2" height="4.5" /></bezel>
-		<bezel element="flashgrille" name="sit14"><bounds x="7" y="17.25" width="2.5" height="2.5" /></bezel>
-		<bezel element="flashgrille" name="sit14"><bounds x="13.5" y="17.25" width="2.5" height="2.5" /></bezel>
+		<bezel element="flashgrille" name="sit14"><bounds x="7" y="17.25" width="3" height="2.5" /></bezel>
+		<bezel element="flashgrille" name="sit14"><bounds x="13" y="17.25" width="3" height="2.5" /></bezel>
 
 		<cpanel element="cpanel"><bounds x="4.5" y="20" width="14" height="7" /></cpanel>
 		<cpanel element="trackball" name="sit10"><bounds x="10" y="22" width="3" height="3" /></cpanel>


### PR DESCRIPTION
- Added color lamps. On the real cabinet, these are behind the marquee.
- Fixed timer lamp order. They now follow the order of the test menu and match recorded footage.
- Changed size of screen, and most lamps to better match the real cabinet.
- Changed CPO button/trackball color to better match the real controls.