### PR TITLE
Fixed gfx loading in Eyes (bootleg set 1)

### DIFF
--- a/src/mame/drivers/pacman.cpp
+++ b/src/mame/drivers/pacman.cpp
@@ -5876,7 +5876,7 @@ ROM_START( eyesb )
 	ROM_LOAD( "11.bin",          0x1800, 0x0800, CRC(aaa7a537) SHA1(571d981ed2aad62d7c7f2798e9084228d45523d4) )
 
 	ROM_REGION( 0x0120, "proms", 0 )
-	ROM_LOAD( "7051.bin",        0x0000, 0x0020, BAD_DUMP CRC(0dad2ccb) SHA1(f42c5ee7084e5702b5b0c8c1d86b0a41a6e1821d) ) // 3x bytes bad
+	ROM_LOAD( "7051.bin",        0x0000, 0x0020, CRC(2c3cc909) SHA1(32d68d4cfdf9f3e7351353428d268c763e809c63) ) // fixed 3x bytes with inverse second half
 	ROM_LOAD( "7051-3.bin",      0x0020, 0x0100, CRC(d8d78829) SHA1(19820d1651423210083a087fb70ebea73ad34951) )
 
 	ROM_REGION( 0x0200, "namco", 0 )    /* sound PROMs */

--- a/src/mame/drivers/pacman.cpp
+++ b/src/mame/drivers/pacman.cpp
@@ -5871,12 +5871,12 @@ ROM_START( eyesb )
 
 	ROM_REGION( 0x2000, "gfx1", 0 )
 	ROM_LOAD( "9.bin",           0x0000, 0x0800, CRC(342c0653) SHA1(d07e3d4528b72e54a1b5dbed009cce765a5a086f) )
-	ROM_LOAD( "11.bin",          0x0800, 0x0800, CRC(aaa7a537) SHA1(571d981ed2aad62d7c7f2798e9084228d45523d4) )
+	ROM_LOAD( "12.bin",          0x0800, 0x0800, CRC(99af4b30) SHA1(6a0939ff2fa7ae39a960dd4d9f9b7c01f57647c5) )
 	ROM_LOAD( "10.bin",          0x1000, 0x0800, CRC(b247b82c) SHA1(8c10a8ef5e79b0b5fefad6eb77bfa68a0ca18035) )
-	ROM_LOAD( "12.bin",          0x1800, 0x0800, CRC(99af4b30) SHA1(6a0939ff2fa7ae39a960dd4d9f9b7c01f57647c5) )
+	ROM_LOAD( "11.bin",          0x1800, 0x0800, CRC(aaa7a537) SHA1(571d981ed2aad62d7c7f2798e9084228d45523d4) )
 
 	ROM_REGION( 0x0120, "proms", 0 )
-	ROM_LOAD( "7051.bin",        0x0000, 0x0020, CRC(0dad2ccb) SHA1(f42c5ee7084e5702b5b0c8c1d86b0a41a6e1821d) )
+	ROM_LOAD( "7051.bin",        0x0000, 0x0020, BAD_DUMP CRC(2fc650bd) SHA1(8d0268dee78e47c712202b0ec4f1f51109b1f2a5) ) // bad dump, taken from parent
 	ROM_LOAD( "7051-3.bin",      0x0020, 0x0100, CRC(d8d78829) SHA1(19820d1651423210083a087fb70ebea73ad34951) )
 
 	ROM_REGION( 0x0200, "namco", 0 )    /* sound PROMs */

--- a/src/mame/drivers/pacman.cpp
+++ b/src/mame/drivers/pacman.cpp
@@ -5876,7 +5876,7 @@ ROM_START( eyesb )
 	ROM_LOAD( "11.bin",          0x1800, 0x0800, CRC(aaa7a537) SHA1(571d981ed2aad62d7c7f2798e9084228d45523d4) )
 
 	ROM_REGION( 0x0120, "proms", 0 )
-	ROM_LOAD( "7051.bin",        0x0000, 0x0020, BAD_DUMP CRC(2fc650bd) SHA1(8d0268dee78e47c712202b0ec4f1f51109b1f2a5) ) // bad dump, taken from parent
+	ROM_LOAD( "7051.bin",        0x0000, 0x0020, BAD_DUMP CRC(0dad2ccb) SHA1(f42c5ee7084e5702b5b0c8c1d86b0a41a6e1821d) ) // 3x bytes bad
 	ROM_LOAD( "7051-3.bin",      0x0020, 0x0100, CRC(d8d78829) SHA1(19820d1651423210083a087fb70ebea73ad34951) )
 
 	ROM_REGION( 0x0200, "namco", 0 )    /* sound PROMs */


### PR DESCRIPTION
The gfx loading in clone Eyes (bootleg set 1) is not correct.

ROM_REGION( 0x2000, "gfx1", 0 )
ROM_LOAD( "9.bin",           0x0000, 0x0800, CRC(342c0653) SHA1(d07e3d4528b72e54a1b5dbed009cce765a5a086f) )
ROM_LOAD( "11.bin",          0x0800, 0x0800, CRC(aaa7a537) SHA1(571d981ed2aad62d7c7f2798e9084228d45523d4) )
ROM_LOAD( "10.bin",          0x1000, 0x0800, CRC(b247b82c) SHA1(8c10a8ef5e79b0b5fefad6eb77bfa68a0ca18035) )
ROM_LOAD( "12.bin",          0x1800, 0x0800, CRC(99af4b30) SHA1(6a0939ff2fa7ae39a960dd4d9f9b7c01f57647c5) )

Roms 9.bin + 11.bin are not rom "d5" and 10.bin + 12.bin are not rom "e5" of Eyes (US set 1)!


Eyes (US set 1):
ROM_REGION( 0x2000, "gfx1", 0 )
ROM_LOAD( "d5",           0x0000, 0x1000, CRC(d6af0030) SHA1(652b779533e3f00e81cc102b78d367d503b06f33) )
ROM_LOAD( "e5",           0x1000, 0x1000, CRC(a42b5201) SHA1(2e5cede3b6039c7bd5230de27d02aaa3f35a7b64) )




The color PROM 7051.bin from eyesb is a bad dump. 3x bytes of the first 16 bytes are missing bit7 and
the last bytes from 17-32 are not zero bytes (overdump). 

00 07 66 EF 00 F8 EA 6F 00 3F 00 C9 38 AA AF F6 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00    (82s123.7f from eyes )
00 07 66 6F 00 78 6A 6F 00 3F 00 C9 38 AA AF F6 FF F8 99 10 FF 07 15 90 FF C0 FF 36 C7 55 50 09    ( 7051.bin from eyesb)
-- -- -- XX -- XX XX -- -- -- -- -- -- -- -- -- ?? ?? ?? ?? ?? ?? ?? ?? ?? ?? ?? ?? ?? ?? ?? ??


EF  1110 1111
6F  0110 1111 = missing bit7 (bitrotten)

F8  1111 1000
78  0111 1000

EA  1110 1010
6A  0110 1010


I did replaced the color prom with the one from Eyes (US set 1). Marked it as BAD DUMP!
Now the colors and gfx are correct!