### PR TITLE
ncr5390: several small but important changes (nw)

### DIFF
--- a/src/devices/machine/ncr5390.h
+++ b/src/devices/machine/ncr5390.h
@@ -172,6 +172,7 @@ protected:
 		CD_SELECT_ATN_STOP = 0x43,
 		CD_ENABLE_SEL      = 0x44,
 		CD_DISABLE_SEL     = 0x45,
+		CD_SELECT_ATN3     = 0x46, // 53c90a
 		CT_SEND_MSG        = 0x20,
 		CT_SEND_STATUS     = 0x21,
 		CT_SEND_DATA       = 0x22,
@@ -183,11 +184,13 @@ protected:
 		CT_RECV_CMD        = 0x29,
 		CT_RECV_DATA       = 0x2a,
 		CT_RECV_CMD_SEQ    = 0x2b,
+		CT_ABORT_DMA       = 0x04, // 53c90a
 		CI_XFER            = 0x10,
 		CI_COMPLETE        = 0x11,
 		CI_MSG_ACCEPT      = 0x12,
 		CI_PAD             = 0x18,
-		CI_SET_ATN         = 0x1a
+		CI_SET_ATN         = 0x1a,
+		CI_RESET_ATN       = 0x1b, // 53c90a
 	};
 
 	enum { DMA_NONE, DMA_IN, DMA_OUT };
@@ -215,7 +218,7 @@ protected:
 
 	void start_command();
 	void step(bool timeout);
-	bool check_valid_command(uint8_t cmd);
+	virtual bool check_valid_command(uint8_t cmd);
 	int derive_msg_size(uint8_t msg_id);
 	void function_complete();
 	void function_bus_complete();
@@ -262,6 +265,8 @@ protected:
 
 	virtual void device_start() override;
 	void reset_soft();
+
+	virtual bool check_valid_command(uint8_t cmd) override;
 
 	// 53c90a uses a previously reserved bit as an interrupt flag
 	enum {


### PR DESCRIPTION
These changes work with InterPro, but haven't been tested on other machines. Despite this, I'm reasonably confident they are all correct according to the observed behaviour and the documentation.

* don't wait for REQ after initiator complete with NACK
* wait until fifo empty during dma out before command complete
* make sure drq is always cleared on bus/function complete
* reset happens immediately
* always clear TC0 when counter reloaded
* check valid commands separately for 5390 and 5390a
* handle 5390a initiator set attention command
* use logmacro for logging