### PR TITLE
mc146818: correct interrupt protocol (nw)

### DIFF
--- a/src/devices/machine/cs4031.cpp
+++ b/src/devices/machine/cs4031.cpp
@@ -147,7 +147,7 @@ MACHINE_CONFIG_START(cs4031_device::device_add_mconfig)
 	MCFG_PIT8253_OUT2_HANDLER(WRITELINE(*this, cs4031_device, ctc_out2_w))
 
 	MCFG_DS12885_ADD("rtc")
-	MCFG_MC146818_IRQ_HANDLER(WRITELINE(*this, cs4031_device, rtc_irq_w))
+	MCFG_MC146818_IRQ_HANDLER(WRITELINE("intc2", pic8259_device, ir0_w))
 	MCFG_MC146818_CENTURY_INDEX(0x32)
 MACHINE_CONFIG_END
 
@@ -431,11 +431,6 @@ READ8_MEMBER( cs4031_device::intc1_slave_ack_r )
 		return m_intc2->acknowledge();
 
 	return 0x00;
-}
-
-WRITE_LINE_MEMBER( cs4031_device::rtc_irq_w )
-{
-	m_intc2->ir0_w(state ? 0 : 1); // inverted?
 }
 
 WRITE_LINE_MEMBER( cs4031_device::iochck_w )

--- a/src/devices/machine/cs4031.h
+++ b/src/devices/machine/cs4031.h
@@ -276,7 +276,6 @@ private:
 	DECLARE_READ8_MEMBER( intc1_slave_ack_r );
 	DECLARE_WRITE_LINE_MEMBER( ctc_out1_w );
 	DECLARE_WRITE_LINE_MEMBER( ctc_out2_w );
-	DECLARE_WRITE_LINE_MEMBER( rtc_irq_w );
 };
 
 

--- a/src/devices/machine/mc146818.cpp
+++ b/src/devices/machine/mc146818.cpp
@@ -490,18 +490,17 @@ int mc146818_device::get_timer_bypass()
 
 void mc146818_device::update_irq()
 {
-	// IRQ line is active low
 	if (((m_data[REG_C] & REG_C_UF) && (m_data[REG_B] & REG_B_UIE)) ||
 		((m_data[REG_C] & REG_C_AF) && (m_data[REG_B] & REG_B_AIE)) ||
 		((m_data[REG_C] & REG_C_PF) && (m_data[REG_B] & REG_B_PIE)))
 	{
 		m_data[REG_C] |= REG_C_IRQF;
-		m_write_irq(CLEAR_LINE);
+		m_write_irq(ASSERT_LINE);
 	}
 	else
 	{
 		m_data[REG_C] &= ~REG_C_IRQF;
-		m_write_irq(ASSERT_LINE);
+		m_write_irq(CLEAR_LINE);
 	}
 }
 

--- a/src/devices/machine/wd7600.cpp
+++ b/src/devices/machine/wd7600.cpp
@@ -72,7 +72,7 @@ MACHINE_CONFIG_START(wd7600_device::device_add_mconfig)
 	MCFG_PIT8253_OUT2_HANDLER(WRITELINE(*this, wd7600_device, ctc_out2_w))
 
 	MCFG_DS12885_ADD("rtc")
-	MCFG_MC146818_IRQ_HANDLER(WRITELINE(*this, wd7600_device, rtc_irq_w))
+	MCFG_MC146818_IRQ_HANDLER(WRITELINE("intc2", pic8259_device, ir0_w))
 	MCFG_MC146818_CENTURY_INDEX(0x32)
 MACHINE_CONFIG_END
 
@@ -266,11 +266,6 @@ WRITE8_MEMBER( wd7600_device::rtc_w )
 	}
 
 	m_rtc->write(space, offset, data);
-}
-
-WRITE_LINE_MEMBER( wd7600_device::rtc_irq_w )
-{
-	m_pic2->ir0_w(state ? 0 : 1); // inverted?
 }
 
 READ8_MEMBER( wd7600_device::pic1_slave_ack_r )

--- a/src/devices/machine/wd7600.h
+++ b/src/devices/machine/wd7600.h
@@ -134,7 +134,6 @@ protected:
 	virtual void device_add_mconfig(machine_config &config) override;
 
 private:
-	DECLARE_WRITE_LINE_MEMBER(rtc_irq_w);
 	DECLARE_WRITE_LINE_MEMBER( pic1_int_w ) { m_write_intr(state); }
 	DECLARE_READ8_MEMBER( pic1_slave_ack_r );
 	DECLARE_WRITE_LINE_MEMBER( ctc_out1_w );

--- a/src/mame/drivers/apollo.cpp
+++ b/src/mame/drivers/apollo.cpp
@@ -1128,6 +1128,10 @@ MACHINE_CONFIG_START(apollo_state::dn3000)
 	MCFG_RAM_MODIFY("messram")
 	MCFG_RAM_DEFAULT_SIZE("8M")
 	MCFG_RAM_EXTRA_OPTIONS("4M")
+
+	// FIXME: is this interrupt really only connected on DN3000?
+	MCFG_DEVICE_MODIFY(APOLLO_RTC_TAG)
+	MCFG_MC146818_IRQ_HANDLER(WRITELINE(*this, apollo_state, apollo_rtc_irq_function))
 MACHINE_CONFIG_END
 
 MACHINE_CONFIG_START(apollo_state::dsp3000)

--- a/src/mame/drivers/micronic.cpp
+++ b/src/mame/drivers/micronic.cpp
@@ -346,7 +346,7 @@ void micronic_state::machine_reset()
 
 WRITE_LINE_MEMBER( micronic_state::mc146818_irq )
 {
-	m_maincpu->set_input_line(0, !state ? HOLD_LINE : CLEAR_LINE);
+	m_maincpu->set_input_line(0, state ? HOLD_LINE : CLEAR_LINE);
 }
 
 

--- a/src/mame/drivers/octopus.cpp
+++ b/src/mame/drivers/octopus.cpp
@@ -942,7 +942,7 @@ MACHINE_CONFIG_START(octopus_state::octopus)
 	MCFG_I8255_OUT_PORTC_CB(WRITE8(*this, octopus_state,gpo_w))
 
 	MCFG_DEVICE_ADD("rtc", MC146818, 32.768_kHz_XTAL)
-	MCFG_MC146818_IRQ_HANDLER(WRITELINE("pic_slave",pic8259_device, ir2_w)) MCFG_DEVCB_INVERT
+	MCFG_MC146818_IRQ_HANDLER(WRITELINE("pic_slave",pic8259_device, ir2_w))
 
 	// Keyboard UART
 	MCFG_DEVICE_ADD("keyboard", I8251, 0)

--- a/src/mame/includes/apollo.h
+++ b/src/mame/includes/apollo.h
@@ -224,6 +224,7 @@ public:
 	DECLARE_WRITE_LINE_MEMBER( apollo_ptm_irq_function );
 	DECLARE_WRITE_LINE_MEMBER( apollo_ptm_timer_tick );
 	DECLARE_READ8_MEMBER( apollo_pic8259_get_slave_ack );
+	DECLARE_WRITE_LINE_MEMBER( apollo_rtc_irq_function );
 
 	DECLARE_READ8_MEMBER(pc_dma8237_0_dack_r);
 	DECLARE_READ8_MEMBER(pc_dma8237_1_dack_r);
@@ -247,7 +248,6 @@ public:
 	DECLARE_WRITE_LINE_MEMBER(pc_dack5_w);
 	DECLARE_WRITE_LINE_MEMBER(pc_dack6_w);
 	DECLARE_WRITE_LINE_MEMBER(pc_dack7_w);
-	TIMER_CALLBACK_MEMBER( apollo_rtc_timer );
 
 	void apollo_pic_set_irq_line(int irq, int state);
 	void select_dma_channel(int channel, bool state);
@@ -283,7 +283,6 @@ private:
 	uint8_t sio_output_data;
 	int m_dma_channel;
 	bool m_cur_eop;
-	emu_timer *m_dn3000_timer;
 };
 
 /*----------- machine/apollo_config.c -----------*/

--- a/src/mame/machine/at.cpp
+++ b/src/mame/machine/at.cpp
@@ -130,7 +130,7 @@ MACHINE_CONFIG_START(at_mb_device::device_add_mconfig)
 	MCFG_ISA_OUT_DRQ7_CB(WRITELINE("dma8237_2", am9517a_device, dreq3_w))
 
 	MCFG_DEVICE_ADD("rtc", MC146818, 32.768_kHz_XTAL)
-	MCFG_MC146818_IRQ_HANDLER(WRITELINE("pic8259_slave", pic8259_device, ir0_w)) MCFG_DEVCB_INVERT
+	MCFG_MC146818_IRQ_HANDLER(WRITELINE("pic8259_slave", pic8259_device, ir0_w))
 	MCFG_MC146818_CENTURY_INDEX(0x32)
 
 	/* sound hardware */

--- a/src/mame/machine/interpro_ioga.h
+++ b/src/mame/machine/interpro_ioga.h
@@ -134,8 +134,7 @@ public:
 	DECLARE_WRITE_LINE_MEMBER(ir6_w) { set_int_line(INT_HARD_EX, IRQ_VB, state); }
 	DECLARE_WRITE_LINE_MEMBER(ir7_w) { set_int_line(INT_HARD_EX, IRQ_9, state); }
 	DECLARE_WRITE_LINE_MEMBER(ir8_w) { set_int_line(INT_HARD_EX, IRQ_CBUS3, state); }
-	// FIXME: mc146818 inverts the normal irq state convention
-	DECLARE_WRITE_LINE_MEMBER(ir9_w) { set_int_line(INT_HARD_EX, IRQ_RTC, !state); }
+	DECLARE_WRITE_LINE_MEMBER(ir9_w) { set_int_line(INT_HARD_EX, IRQ_RTC, state); }
 	DECLARE_WRITE_LINE_MEMBER(ir10_w) { set_int_line(INT_HARD_EX, IRQ_60HZ, state); }
 	DECLARE_WRITE_LINE_MEMBER(ir11_w) { set_int_line(INT_HARD_EX, IRQ_SERIAL, state); }
 	DECLARE_WRITE_LINE_MEMBER(ir12_w) { set_int_line(INT_HARD_EX, IRQ_ETHERNET, state); }


### PR DESCRIPTION
This change makes the MC146818/DS128x devices match the ASSERT_LINE/CLEAR_LINE protocol used by almost all other devices, removing an unexpected surprise. The devices are fairly widely used, so I've tried to review all the references and check if they're affected. A surprising number of systems appear to have the interrupt hooked up, but were not accounting for the inversion, so this change might possibly correct some existing behaviour if the interrupt is actually being triggered.

The following were modified to remove workarounds:
* src/devices/machine/cs4031: removed inversion
* src/devices/machine/wd7600: removed inversion
* src/mame/drivers/apollo: hooked up interrupt
* src/mame/drivers/micronic: removed inversion
* src/mame/drivers/octopus: removed inversion
* src/mame/machine/apollo: removed timer workaround
* src/mame/machine/at: removed inversion
* src/mame/machine/interpro_ioga: removed inversion

The behaviour of the following will change:
* src/devices/bus/econet/e01.cpp
* src/devices/bus/electron/cart/click.cpp
* src/devices/bus/lpci/southbridge.cpp
* src/devices/machine/fdc37c93x.cpp
* src/devices/machine/sis85c496.cpp
* src/mame/drivers/at.cpp
* src/mame/drivers/calchase.cpp
* src/mame/drivers/hotstuff.cpp
* src/mame/drivers/hx20.cpp
* src/mame/drivers/mbee.cpp
* src/mame/drivers/mtouchxl.cpp
* src/mame/drivers/pc1512.cpp
* src/mame/drivers/pcat_dyn.cpp
* src/mame/drivers/pcd.cpp
* src/mame/drivers/qx10.cpp
* src/mame/drivers/su2000.cpp
* src/mame/machine/pcshare.cpp