### PR TITLE
Fixed m68000 makefile not respecting the VERBOSE build option

### DIFF
--- a/src/devices/cpu/m68000/makefile
+++ b/src/devices/cpu/m68000/makefile
@@ -8,7 +8,7 @@ ifeq ($(OS),os2)
 EXE := .exe
 endif
 
-ifndef verbose
+ifndef VERBOSE
   SILENT = @
 endif
 CC  = gcc


### PR DESCRIPTION
This commit fixes m68000 makefile ignoring the global makefile VERBOSE setting.