### PR TITLE
m107.cpp : Updates/Cleanups

### DIFF
--- a/src/mame/drivers/m107.cpp
+++ b/src/mame/drivers/m107.cpp
@@ -31,11 +31,11 @@ confirmed for m107 games as well.
 
 #include "cpu/nec/nec.h"
 #include "cpu/nec/v25.h"
+#include "machine/gen_latch.h"
 #include "machine/irem_cpu.h"
 #include "sound/ym2151.h"
 #include "sound/iremga20.h"
 #include "speaker.h"
-
 
 /*****************************************************************************/
 
@@ -73,7 +73,6 @@ TIMER_DEVICE_CALLBACK_MEMBER(m107_state::scanline_interrupt)
 }
 
 
-
 /*****************************************************************************/
 
 WRITE8_MEMBER(m107_state::coincounter_w)
@@ -84,7 +83,7 @@ WRITE8_MEMBER(m107_state::coincounter_w)
 
 WRITE8_MEMBER(m107_state::bankswitch_w)
 {
-	membank("bank1")->set_entry((data & 0x06) >> 1);
+	m_mainbank->set_entry((data & 0x06) >> 1);
 	if (data & 0xf9)
 		logerror("%05x: bankswitch %04x\n", m_maincpu->pc(), data);
 }
@@ -98,13 +97,26 @@ WRITE16_MEMBER(m107_state::sound_reset_w)
 
 void m107_state::main_map(address_map &map)
 {
-	map(0x00000, 0x9ffff).rom();
-	map(0xa0000, 0xbffff).bankr("bank1");
 	map(0xd0000, 0xdffff).ram().w(FUNC(m107_state::vram_w)).share("vram_data");
 	map(0xe0000, 0xeffff).ram(); /* System ram */
 	map(0xf8000, 0xf8fff).ram().share("spriteram");
 	map(0xf9000, 0xf9fff).ram().w(m_palette, FUNC(palette_device::write16)).share("palette");
 	map(0xffff0, 0xfffff).rom().region("maincpu", 0x7fff0);
+}
+
+// Not bankswitched
+void m107_state::firebarr_map(address_map &map)
+{
+	map(0x00000, 0xbffff).rom();
+	main_map(map);
+}
+
+// Bankswitched
+void m107_state::dsoccr94_map(address_map &map)
+{
+	map(0x00000, 0x9ffff).rom();
+	map(0xa0000, 0xbffff).bankr("mainbank");
+	main_map(map);
 }
 
 void m107_state::main_portmap(address_map &map)
@@ -114,7 +126,7 @@ void m107_state::main_portmap(address_map &map)
 	map(0x04, 0x05).portr("DSW");
 	map(0x06, 0x07).portr("P3_P4");
 	map(0x08, 0x08).r("soundlatch2", FUNC(generic_latch_8_device::read));   // answer from sound CPU
-	map(0x00, 0x00).w(m_soundlatch, FUNC(generic_latch_8_device::write));
+	map(0x00, 0x00).w("soundlatch", FUNC(generic_latch_8_device::write));
 	map(0x02, 0x02).w(FUNC(m107_state::coincounter_w));
 	map(0x04, 0x05).nopw(); /* ??? 0008 */
 	map(0x40, 0x43).rw(m_upd71059c, FUNC(pic8259_device::read), FUNC(pic8259_device::write)).umask16(0x00ff);
@@ -145,6 +157,7 @@ WRITE16_MEMBER(m107_state::wpksoc_output_w)
 void m107_state::wpksoc_map(address_map &map)
 {
 	main_map(map);
+	map(0x00000, 0x7ffff).rom();
 	map(0xf0000, 0xf0001).portr("WPK_DSW0");
 	map(0xf0002, 0xf0003).portr("WPK_DSW1");
 	map(0xf0004, 0xf0005).portr("WPK_DSW2");
@@ -166,7 +179,7 @@ void m107_state::sound_map(address_map &map)
 	map(0xa0000, 0xa3fff).ram();
 	map(0xa8000, 0xa803f).rw("irem", FUNC(iremga20_device::irem_ga20_r), FUNC(iremga20_device::irem_ga20_w)).umask16(0x00ff);
 	map(0xa8040, 0xa8043).rw("ymsnd", FUNC(ym2151_device::read), FUNC(ym2151_device::write)).umask16(0x00ff);
-	map(0xa8044, 0xa8044).rw(m_soundlatch, FUNC(generic_latch_8_device::read), FUNC(generic_latch_8_device::acknowledge_w));
+	map(0xa8044, 0xa8044).rw("soundlatch", FUNC(generic_latch_8_device::read), FUNC(generic_latch_8_device::acknowledge_w));
 	map(0xa8046, 0xa8046).w("soundlatch2", FUNC(generic_latch_8_device::write));
 	map(0xffff0, 0xfffff).rom().region("soundcpu", 0x1fff0);
 }
@@ -721,7 +734,7 @@ MACHINE_CONFIG_START(m107_state::firebarr)
 
 	/* basic machine hardware */
 	MCFG_DEVICE_ADD("maincpu", V33, XTAL(28'000'000)/2)    /* NEC V33, 28MHz clock */
-	MCFG_DEVICE_PROGRAM_MAP(main_map)
+	MCFG_DEVICE_PROGRAM_MAP(firebarr_map)
 	MCFG_DEVICE_IO_MAP(main_portmap)
 	MCFG_DEVICE_IRQ_ACKNOWLEDGE_DEVICE("upd71059c", pic8259_device, inta_cb)
 
@@ -735,6 +748,8 @@ MACHINE_CONFIG_START(m107_state::firebarr)
 	MCFG_TIMER_DRIVER_ADD_SCANLINE("scantimer", m107_state, scanline_interrupt, "screen", 0, 1)
 
 	/* video hardware */
+	MCFG_DEVICE_ADD("spriteram", BUFFERED_SPRITERAM16)
+
 	MCFG_SCREEN_ADD("screen", RASTER)
 	MCFG_SCREEN_REFRESH_RATE(60)
 	MCFG_SCREEN_VBLANK_TIME(ATTOSECONDS_IN_USEC(2500) /* not accurate */)
@@ -775,6 +790,7 @@ MACHINE_CONFIG_START(m107_state::dsoccr94)
 	/* basic machine hardware */
 	MCFG_DEVICE_MODIFY("maincpu")
 	MCFG_DEVICE_CLOCK(20000000/2)  /* NEC V33, Could be 28MHz clock? */
+	MCFG_DEVICE_PROGRAM_MAP(dsoccr94_map)
 	MCFG_DEVICE_IO_MAP(dsoccr94_io_map)
 
 	MCFG_DEVICE_MODIFY("soundcpu")
@@ -827,7 +843,7 @@ ROM_START( airass )
 	ROM_LOAD( "w49.020", 0x200000, 0x100000, CRC(17b5caf2) SHA1(df38f9a625226c96ac921182ef975e598d9bc245) ) /* IC13 */
 	ROM_LOAD( "w50.030", 0x300000, 0x100000, CRC(63e4bec3) SHA1(252b4493e1bc368021389e65295036523c401ad4) ) /* IC14 */
 
-	ROM_REGION( 0x40000, "user1", 0 )   /* sprite tables */
+	ROM_REGION( 0x40000, "sprtable", 0 )   /* sprite tables */
 	ROM_LOAD16_BYTE( "f4-b-drh-.drh", 0x000001, 0x20000, CRC(12001372) SHA1(a5346d8a741cd1a93aa289562bb56d2fc40c1bbb) ) /* IC10 */
 	ROM_LOAD16_BYTE( "f4-b-drl-.drl", 0x000000, 0x20000, CRC(08cb7533) SHA1(9e0d8f8498bddfa1c6135abbab4465e9eeb033fe) ) /* IC1  */
 
@@ -862,7 +878,7 @@ ROM_START( firebarr )
 	ROM_LOAD16_BYTE( "f4-030.030", 0x300000, 0x80000, CRC(7e7b30cd) SHA1(eca9d2a5d9f9deebb565456018126bc37a1de1d8) ) /* IC14 */
 	ROM_LOAD16_BYTE( "f4-031.031", 0x300001, 0x80000, CRC(83ac56c5) SHA1(47e1063c71d5570fecf8591c2cb7c74fd45199f5) ) /* IC5  */
 
-	ROM_REGION( 0x40000, "user1", 0 )   /* sprite tables */
+	ROM_REGION( 0x40000, "sprtable", 0 )   /* sprite tables */
 	ROM_LOAD16_BYTE( "f4-b-drh-.drh", 0x000001, 0x20000, CRC(12001372) SHA1(a5346d8a741cd1a93aa289562bb56d2fc40c1bbb) ) /* IC10 */
 	ROM_LOAD16_BYTE( "f4-b-drl-.drl", 0x000000, 0x20000, CRC(08cb7533) SHA1(9e0d8f8498bddfa1c6135abbab4465e9eeb033fe) ) /* IC1  */
 
@@ -990,25 +1006,21 @@ ROM_END
 
 void m107_state::init_firebarr()
 {
-	uint8_t *ROM = memregion("maincpu")->base();
-
-	membank("bank1")->set_base(&ROM[0xa0000]);
-
 	m_spritesystem = 1;
+}
+
+void m107_state::init_wpksoc()
+{
+	m_spritesystem = 0;
 }
 
 void m107_state::init_dsoccr94()
 {
 	uint8_t *ROM = memregion("maincpu")->base();
 
-	membank("bank1")->configure_entries(0, 4, &ROM[0x80000], 0x20000);
+	m_mainbank->configure_entries(0, 4, &ROM[0x80000], 0x20000);
 
-	m_spritesystem = 0;
-}
-
-void m107_state::init_wpksoc()
-{
-	m_spritesystem = 0;
+	init_wpksoc();
 }
 
 /***************************************************************************/

--- a/src/mame/includes/m107.h
+++ b/src/mame/includes/m107.h
@@ -6,15 +6,15 @@
 
 *************************************************************************/
 
-#include "machine/gen_latch.h"
 #include "machine/pic8259.h"
 #include "machine/timer.h"
+#include "video/bufsprite.h"
 #include "screen.h"
 
 struct pf_layer_info
 {
 	tilemap_t *     tmap;
-	uint16_t          vram_base;
+	uint16_t        vram_base;
 };
 
 class m107_state : public driver_device
@@ -28,10 +28,10 @@ public:
 		, m_screen(*this, "screen")
 		, m_palette(*this, "palette")
 		, m_upd71059c(*this, "upd71059c")
-		, m_soundlatch(*this, "soundlatch")
 		, m_spriteram(*this, "spriteram")
 		, m_vram_data(*this, "vram_data")
-		, m_user1_ptr(*this, "user1")
+		, m_sprtable_rom(*this, "sprtable")
+		, m_mainbank(*this, "mainbank")
 	{
 	}
 
@@ -41,11 +41,12 @@ public:
 	required_device<screen_device> m_screen;
 	required_device<palette_device> m_palette;
 	required_device<pic8259_device> m_upd71059c;
-	required_device<generic_latch_8_device> m_soundlatch;
+	required_device<buffered_spriteram16_device> m_spriteram;
 
-	required_shared_ptr<uint16_t> m_spriteram;
 	required_shared_ptr<uint16_t> m_vram_data;
-	optional_region_ptr<uint8_t> m_user1_ptr;
+	optional_region_ptr<uint8_t> m_sprtable_rom;
+
+	optional_memory_bank m_mainbank;
 
 	// driver init
 	uint8_t m_spritesystem;
@@ -54,7 +55,6 @@ public:
 	uint16_t m_raster_irq_position;
 	pf_layer_info m_pf_layer[4];
 	uint16_t m_control[0x10];
-	std::unique_ptr<uint16_t[]> m_buffered_spriteram;
 
 	DECLARE_WRITE8_MEMBER(coincounter_w);
 	DECLARE_WRITE8_MEMBER(bankswitch_w);
@@ -84,6 +84,8 @@ public:
 	void firebarr(machine_config &config);
 	void dsoccr94(machine_config &config);
 	void dsoccr94_io_map(address_map &map);
+	void dsoccr94_map(address_map &map);
+	void firebarr_map(address_map &map);
 	void main_map(address_map &map);
 	void main_portmap(address_map &map);
 	void sound_map(address_map &map);

--- a/src/mame/video/m107.cpp
+++ b/src/mame/video/m107.cpp
@@ -143,12 +143,9 @@ void m107_state::video_start()
 			layer->tmap->set_transparent_pen(0);
 	}
 
-	m_buffered_spriteram = make_unique_clear<uint16_t[]>(0x1000/2);
-
 	save_item(NAME(m_sprite_display));
 	save_item(NAME(m_raster_irq_position));
 	save_item(NAME(m_control));
-	save_pointer(NAME(m_buffered_spriteram.get()), 0x1000/2);
 
 	for (int i = 0; i < 4; i++)
 	{
@@ -160,9 +157,9 @@ void m107_state::video_start()
 
 void m107_state::draw_sprites(screen_device &screen, bitmap_ind16 &bitmap, const rectangle &cliprect)
 {
-	uint16_t *spriteram = m_buffered_spriteram.get();
+	const uint16_t *spriteram = m_spriteram->buffer();
 	int offs;
-	uint8_t *rom = m_user1_ptr;
+	const uint8_t *rom = m_sprtable_rom;
 
 	for (offs = 0;offs < 0x800;offs += 4)
 	{
@@ -223,7 +220,7 @@ void m107_state::draw_sprites(screen_device &screen, bitmap_ind16 &bitmap, const
 
 			if (rom[rom_offs+1] || rom[rom_offs+3] || rom[rom_offs+5] || rom[rom_offs+7])
 			{
-				while (rom_offs < 0x40000)  /* safety check */
+				while (rom_offs < m_sprtable_rom.length())  /* safety check */
 				{
 					/*
 					[1]
@@ -385,7 +382,7 @@ WRITE16_MEMBER(m107_state::spritebuffer_w)
 //      logerror("%s: buffered spriteram\n",m_maincpu->pc());
 		m_sprite_display    = (!(data & 0x1000));
 
-		memcpy(m_buffered_spriteram.get(), m_spriteram, 0x1000);
+		m_spriteram->copy();
 	}
 }
 


### PR DESCRIPTION
Add buffered_spriteram16_device for buffered spriteram, Minor cleanups, Split address map/machine configs related to ROM size/bankswitch