### PR TITLE
Enable building on riscv64

### DIFF
--- a/makefile
+++ b/makefile
@@ -166,6 +166,12 @@ endif
 ifneq ($(filter powerpc,$(UNAME_P)),)
 PLATFORM := powerpc
 endif
+ifneq ($(filter riscv64%,$(UNAME_M)),)
+PLATFORM := riscv64
+endif
+ifneq ($(filter riscv64%,$(UNAME_P)),)
+PLATFORM := riscv64
+endif
 ifneq ($(filter mips64%,$(UNAME_M)),)
 ifeq ($(shell getconf LONG_BIT),64)
 PLATFORM := mips64

--- a/makefile
+++ b/makefile
@@ -349,6 +349,13 @@ ifndef NOASM
 endif
 endif
 
+ifeq ($(findstring riscv64,$(UNAME)),riscv64)
+ARCHITECTURE :=
+ifndef NOASM
+	NOASM := 1
+endif
+endif
+
 # Emscripten
 ifeq ($(findstring emcc,$(CC)),emcc)
 TARGETOS := asmjs

--- a/scripts/genie.lua
+++ b/scripts/genie.lua
@@ -1061,6 +1061,12 @@ if (_OPTIONS["PLATFORM"]=="arm64") then
 	}
 end
 
+if (_OPTIONS["PLATFORM"]=="riscv64") then
+	defines {
+		"PTR64=1",
+	}
+end
+
 if (_OPTIONS["PLATFORM"]=="mips64") then
 	defines {
 		"PTR64=1",


### PR DESCRIPTION
This patchset allows mame to build on riscv64:
http://fedora-riscv.tranquillity.se/koji/buildinfo?buildID=32386