### PR TITLE
williams.cpp : Cleanups

### DIFF
--- a/src/mame/audio/williams.h
+++ b/src/mame/audio/williams.h
@@ -65,6 +65,8 @@ private:
 	required_device<pia6821_device> m_pia;
 	required_device<hc55516_device> m_hc55516;
 
+	required_memory_bank m_rombank;
+
 	// internal state
 	uint8_t m_talkback;
 
@@ -102,7 +104,7 @@ public:
 	void williams_narc_master_map(address_map &map);
 	void williams_narc_slave_map(address_map &map);
 
-	mc6809e_device *get_cpu() { return m_cpu0; }
+	mc6809e_device *get_cpu() { return m_cpu[0]; }
 
 protected:
 	// device-level overrides
@@ -121,9 +123,11 @@ private:
 	};
 
 	// devices
-	required_device<mc6809e_device> m_cpu0;
-	required_device<mc6809e_device> m_cpu1;
+	required_device_array<mc6809e_device, 2> m_cpu;
 	required_device<hc55516_device> m_hc55516;
+
+	required_memory_bank m_masterbank;
+	required_memory_bank m_slavebank;
 
 	// internal state
 	uint8_t m_latch;
@@ -176,6 +180,9 @@ protected:
 private:
 	// devices
 	required_device<mc6809e_device> m_cpu;
+
+	required_memory_bank m_rombank;
+	required_memory_bank m_okibank;
 
 	// internal state
 	uint8_t m_latch;

--- a/src/mame/drivers/williams.cpp
+++ b/src/mame/drivers/williams.cpp
@@ -504,6 +504,7 @@ Reference video: https://www.youtube.com/watch?v=R5OeC6Wc_yI
 #include "includes/williams.h"
 
 #include "machine/74157.h"
+#include "machine/input_merger.h"
 #include "machine/nvram.h"
 #include "sound/dac.h"
 #include "sound/volt_reg.h"
@@ -537,8 +538,8 @@ void williams_state::defender_bankc000_map(address_map &map)
 	map(0x0010, 0x001f).mirror(0x03e0).w(FUNC(williams_state::defender_video_control_w));
 	map(0x0400, 0x04ff).mirror(0x0300).ram().w(FUNC(williams_state::williams_cmos_w)).share("nvram");
 	map(0x0800, 0x0bff).r(FUNC(williams_state::williams_video_counter_r));
-	map(0x0c00, 0x0c03).mirror(0x03e0).rw(m_pia_1, FUNC(pia6821_device::read), FUNC(pia6821_device::write));
-	map(0x0c04, 0x0c07).mirror(0x03e0).rw(m_pia_0, FUNC(pia6821_device::read), FUNC(pia6821_device::write));
+	map(0x0c00, 0x0c03).mirror(0x03e0).rw(m_pia[1], FUNC(pia6821_device::read), FUNC(pia6821_device::write));
+	map(0x0c04, 0x0c07).mirror(0x03e0).rw(m_pia[0], FUNC(pia6821_device::read), FUNC(pia6821_device::write));
 	map(0x1000, 0x9fff).rom().region("maincpu", 0x10000);
 	map(0xa000, 0xffff).noprw();
 }
@@ -553,11 +554,11 @@ void williams_state::defender_bankc000_map(address_map &map)
 
 void williams_state::williams_map(address_map &map)
 {
-	map(0x0000, 0x8fff).bankr("bank1").writeonly().share("videoram");
+	map(0x0000, 0x8fff).bankr("mainbank").writeonly().share("videoram");
 	map(0x9000, 0xbfff).ram();
 	map(0xc000, 0xc00f).mirror(0x03f0).writeonly().share("paletteram");
-	map(0xc804, 0xc807).mirror(0x00f0).rw(m_pia_0, FUNC(pia6821_device::read), FUNC(pia6821_device::write));
-	map(0xc80c, 0xc80f).mirror(0x00f0).rw(m_pia_1, FUNC(pia6821_device::read), FUNC(pia6821_device::write));
+	map(0xc804, 0xc807).mirror(0x00f0).rw(m_pia[0], FUNC(pia6821_device::read), FUNC(pia6821_device::write));
+	map(0xc80c, 0xc80f).mirror(0x00f0).rw(m_pia[1], FUNC(pia6821_device::read), FUNC(pia6821_device::write));
 	map(0xc900, 0xc9ff).w(FUNC(williams_state::williams_vram_select_w));
 	map(0xca00, 0xca07).mirror(0x00f8).w(FUNC(williams_state::williams_blitter_w));
 	map(0xcb00, 0xcbff).r(FUNC(williams_state::williams_video_counter_r));
@@ -576,11 +577,11 @@ void williams_state::williams_map(address_map &map)
 
 void williams_state::sinistar_map(address_map &map)
 {
-	map(0x0000, 0x8fff).bankr("bank1").writeonly().share("videoram");
+	map(0x0000, 0x8fff).bankr("mainbank").writeonly().share("videoram");
 	map(0x9000, 0xbfff).ram();
 	map(0xc000, 0xc00f).mirror(0x03f0).writeonly().share("paletteram");
-	map(0xc804, 0xc807).mirror(0x00f0).rw(m_pia_0, FUNC(pia6821_device::read), FUNC(pia6821_device::write));
-	map(0xc80c, 0xc80f).mirror(0x00f0).rw(m_pia_1, FUNC(pia6821_device::read), FUNC(pia6821_device::write));
+	map(0xc804, 0xc807).mirror(0x00f0).rw(m_pia[0], FUNC(pia6821_device::read), FUNC(pia6821_device::write));
+	map(0xc80c, 0xc80f).mirror(0x00f0).rw(m_pia[1], FUNC(pia6821_device::read), FUNC(pia6821_device::write));
 	map(0xc900, 0xc9ff).w(FUNC(williams_state::sinistar_vram_select_w));
 	map(0xca00, 0xca07).mirror(0x00f8).w(FUNC(williams_state::williams_blitter_w));
 	map(0xcb00, 0xcbff).r(FUNC(williams_state::williams_video_counter_r));
@@ -594,21 +595,41 @@ void williams_state::sinistar_map(address_map &map)
 
 /*************************************
  *
+ *  Speed Ball memory handlers
+ *
+ *************************************/
+
+void spdball_state::spdball_map(address_map &map)
+{
+	williams_map(map);
+	/* install extra input handlers */
+	map(0xc800, 0xc800).portr("AN0");
+	map(0xc801, 0xc801).portr("AN1");
+	map(0xc802, 0xc802).portr("AN2");
+	map(0xc803, 0xc803).portr("AN3");
+	/* add a third PIA */
+	map(0xc808, 0xc80b).mirror(0x00f0).rw(m_pia[3], FUNC(pia6821_device::read), FUNC(pia6821_device::write));
+}
+
+
+
+/*************************************
+ *
  *  Blaster memory handlers
  *
  *************************************/
 
 void blaster_state::blaster_map(address_map &map)
 {
-	map(0x0000, 0x3fff).bankr("bank1").writeonly().share("videoram");
-	map(0x4000, 0x8fff).bankr("bank2").writeonly();
+	map(0x0000, 0x3fff).bankr("mainbank").writeonly().share("videoram");
+	map(0x4000, 0x8fff).bankr("blaster_bankb").writeonly();
 	map(0x9000, 0xbaff).ram();
 	map(0xbb00, 0xbbff).ram().share("blaster_pal0");
 	map(0xbc00, 0xbcff).ram().share("blaster_scan");
 	map(0xbd00, 0xbfff).ram();
 	map(0xc000, 0xc00f).mirror(0x03f0).writeonly().share("paletteram");
-	map(0xc804, 0xc807).mirror(0x00f0).rw(m_pia_0, FUNC(pia6821_device::read), FUNC(pia6821_device::write));
-	map(0xc80c, 0xc80f).mirror(0x00f0).rw(m_pia_1, FUNC(pia6821_device::read), FUNC(pia6821_device::write));
+	map(0xc804, 0xc807).mirror(0x00f0).rw(m_pia[0], FUNC(pia6821_device::read), FUNC(pia6821_device::write));
+	map(0xc80c, 0xc80f).mirror(0x00f0).rw(m_pia[1], FUNC(pia6821_device::read), FUNC(pia6821_device::write));
 	map(0xc900, 0xc93f).w(FUNC(blaster_state::blaster_vram_select_w));
 	map(0xc940, 0xc97f).w(FUNC(blaster_state::blaster_remap_select_w));
 	map(0xc980, 0xc9bf).w(FUNC(blaster_state::blaster_bank_select_w));
@@ -631,14 +652,14 @@ void blaster_state::blaster_map(address_map &map)
 void williams2_state::williams2_common_map(address_map &map)
 {
 	map(0x0000, 0xbfff).ram().share("videoram");
-	map(0x0000, 0x7fff).bankr("bank1");
+	map(0x0000, 0x7fff).bankr("mainbank");
 	map(0x8000, 0x87ff).m(m_bank8000, FUNC(address_map_bank_device::amap8));
 	map(0xc000, 0xc7ff).ram().w(FUNC(williams2_state::williams2_tileram_w)).share("williams2_tile");
 	map(0xc800, 0xc87f).w(FUNC(williams2_state::williams2_bank_select_w));
 	map(0xc880, 0xc887).mirror(0x0078).w(FUNC(williams2_state::williams_blitter_w));
 	map(0xc900, 0xc97f).w(FUNC(williams2_state::williams2_watchdog_reset_w));
-	map(0xc980, 0xc983).mirror(0x0070).rw(m_pia_1, FUNC(pia6821_device::read), FUNC(pia6821_device::write));
-	map(0xc984, 0xc987).mirror(0x0070).rw(m_pia_0, FUNC(pia6821_device::read), FUNC(pia6821_device::write));
+	map(0xc980, 0xc983).mirror(0x0070).rw(m_pia[1], FUNC(pia6821_device::read), FUNC(pia6821_device::write));
+	map(0xc984, 0xc987).mirror(0x0070).rw(m_pia[0], FUNC(pia6821_device::read), FUNC(pia6821_device::write));
 	map(0xc98c, 0xc98f).mirror(0x0070).w(FUNC(williams2_state::williams2_7segment_w));
 	map(0xcb00, 0xcb1f).w(FUNC(williams2_state::williams2_fg_select_w));
 	map(0xcb20, 0xcb3f).w(FUNC(williams2_state::williams2_bg_select_w));
@@ -684,7 +705,7 @@ void williams2_state::williams2_d000_rom_map(address_map &map)
 void williams_state::defender_sound_map(address_map &map)
 {
 	map(0x0000, 0x007f).ram();     /* internal RAM */
-	map(0x0400, 0x0403).mirror(0x8000).rw(m_pia_2, FUNC(pia6821_device::read), FUNC(pia6821_device::write));
+	map(0x0400, 0x0403).mirror(0x8000).rw(m_pia[2], FUNC(pia6821_device::read), FUNC(pia6821_device::write));
 	map(0xb000, 0xffff).rom();
 }
 
@@ -693,7 +714,7 @@ void williams_state::sound_map(address_map &map)
 {
 	map(0x0000, 0x007f).ram();     /* internal RAM */
 	map(0x0080, 0x00ff).ram();     /* MC6810 RAM */
-	map(0x0400, 0x0403).mirror(0x8000).rw(m_pia_2, FUNC(pia6821_device::read), FUNC(pia6821_device::write));
+	map(0x0400, 0x0403).mirror(0x8000).rw(m_pia[2], FUNC(pia6821_device::read), FUNC(pia6821_device::write));
 	map(0xb000, 0xffff).rom();
 }
 
@@ -702,7 +723,7 @@ void blaster_state::sound_map_b(address_map &map)
 {
 	map(0x0000, 0x007f).ram();     /* internal RAM */
 	map(0x0080, 0x00ff).ram();     /* MC6810 RAM */
-	map(0x0400, 0x0403).mirror(0x8000).rw(m_pia_2b, FUNC(pia6821_device::read), FUNC(pia6821_device::write));
+	map(0x0400, 0x0403).mirror(0x8000).rw(m_pia[3], FUNC(pia6821_device::read), FUNC(pia6821_device::write));
 	map(0xb000, 0xffff).rom();
 }
 
@@ -718,7 +739,7 @@ void williams2_state::williams2_sound_map(address_map &map)
 {
 	map(0x0000, 0x007f).ram();     /* internal RAM */
 	map(0x0080, 0x00ff).ram();     /* MC6810 RAM */
-	map(0x2000, 0x2003).mirror(0x1ffc).rw(m_pia_2, FUNC(pia6821_device::read), FUNC(pia6821_device::write));
+	map(0x2000, 0x2003).mirror(0x1ffc).rw(m_pia[2], FUNC(pia6821_device::read), FUNC(pia6821_device::write));
 	map(0xe000, 0xffff).rom();
 }
 
@@ -1445,7 +1466,7 @@ static const gfx_layout williams2_layout =
 		0+2*8+RGN_FRAC(0,3), 4+2*8+RGN_FRAC(0,3), 0+2*8+RGN_FRAC(1,3), 4+2*8+RGN_FRAC(1,3), 0+2*8+RGN_FRAC(2,3), 4+2*8+RGN_FRAC(2,3),
 		0+3*8+RGN_FRAC(0,3), 4+3*8+RGN_FRAC(0,3), 0+3*8+RGN_FRAC(1,3), 4+3*8+RGN_FRAC(1,3), 0+3*8+RGN_FRAC(2,3), 4+3*8+RGN_FRAC(2,3)
 	},
-	{ 0*8, 4*8, 8*8, 12*8, 16*8, 20*8, 24*8, 28*8, 32*8, 36*8, 40*8, 44*8, 48*8, 52*8, 56*8, 60*8 },
+	{ STEP16(0,4*8) },
 	4*16*8
 };
 
@@ -1490,6 +1511,9 @@ MACHINE_CONFIG_START(williams_state::williams)
 
 	MCFG_VIDEO_START_OVERRIDE(williams_state,williams)
 
+	MCFG_PALETTE_ADD("palette", 256)
+	MCFG_PALETTE_INIT_OWNER(williams_state,williams)
+
 	/* sound hardware */
 	SPEAKER(config, "speaker").front_center();
 	MCFG_DEVICE_ADD("dac", MC1408, 0) MCFG_SOUND_ROUTE(ALL_OUTPUTS, "speaker", 0.25) // mc1408.ic6
@@ -1497,20 +1521,26 @@ MACHINE_CONFIG_START(williams_state::williams)
 	MCFG_SOUND_ROUTE(0, "dac", 1.0, DAC_VREF_POS_INPUT) MCFG_SOUND_ROUTE(0, "dac", -1.0, DAC_VREF_NEG_INPUT)
 
 	/* pia */
-	MCFG_DEVICE_ADD(m_pia_0, PIA6821, 0)
+	MCFG_INPUT_MERGER_ANY_HIGH("mainirq")
+	MCFG_INPUT_MERGER_OUTPUT_HANDLER(INPUTLINE("maincpu", M6809_IRQ_LINE))
+
+	MCFG_INPUT_MERGER_ANY_HIGH("soundirq")
+	MCFG_INPUT_MERGER_OUTPUT_HANDLER(INPUTLINE("soundcpu", M6808_IRQ_LINE))
+
+	MCFG_DEVICE_ADD(m_pia[0], PIA6821, 0)
 	MCFG_PIA_READPA_HANDLER(IOPORT("IN0"))
 	MCFG_PIA_READPB_HANDLER(IOPORT("IN1"))
 
-	MCFG_DEVICE_ADD(m_pia_1, PIA6821, 0)
+	MCFG_DEVICE_ADD(m_pia[1], PIA6821, 0)
 	MCFG_PIA_READPA_HANDLER(IOPORT("IN2"))
 	MCFG_PIA_WRITEPB_HANDLER(WRITE8(*this, williams_state, williams_snd_cmd_w))
-	MCFG_PIA_IRQA_HANDLER(WRITELINE(*this, williams_state, williams_main_irq))
-	MCFG_PIA_IRQB_HANDLER(WRITELINE(*this, williams_state, williams_main_irq))
+	MCFG_PIA_IRQA_HANDLER(WRITELINE("mainirq", input_merger_any_high_device, in_w<0>))
+	MCFG_PIA_IRQB_HANDLER(WRITELINE("mainirq", input_merger_any_high_device, in_w<1>))
 
-	MCFG_DEVICE_ADD(m_pia_2, PIA6821, 0)
+	MCFG_DEVICE_ADD(m_pia[2], PIA6821, 0)
 	MCFG_PIA_WRITEPA_HANDLER(WRITE8("dac", dac_byte_interface, data_w))
-	MCFG_PIA_IRQA_HANDLER(WRITELINE(*this, williams_state,williams_snd_irq))
-	MCFG_PIA_IRQB_HANDLER(WRITELINE(*this, williams_state,williams_snd_irq))
+	MCFG_PIA_IRQA_HANDLER(WRITELINE("soundirq", input_merger_any_high_device, in_w<0>))
+	MCFG_PIA_IRQB_HANDLER(WRITELINE("soundirq", input_merger_any_high_device, in_w<1>))
 MACHINE_CONFIG_END
 
 
@@ -1577,6 +1607,8 @@ MACHINE_CONFIG_START(spdball_state::spdball)
 	williams(config);
 
 	/* basic machine hardware */
+	MCFG_DEVICE_MODIFY("maincpu")
+	MCFG_DEVICE_PROGRAM_MAP(spdball_map)
 
 	/* pia */
 	MCFG_DEVICE_ADD("pia_3", PIA6821, 0)
@@ -1692,16 +1724,19 @@ MACHINE_CONFIG_START(blaster_state::blaster)
 	MCFG_74157_A_IN_CB(IOPORT("INP1"))
 	MCFG_74157_B_IN_CB(IOPORT("INP2"))
 
+	MCFG_INPUT_MERGER_ANY_HIGH("soundirq_b")
+	MCFG_INPUT_MERGER_OUTPUT_HANDLER(INPUTLINE("soundcpu_b", M6808_IRQ_LINE))
+
 	MCFG_DEVICE_MODIFY("pia_1")
 	MCFG_PIA_WRITEPB_HANDLER(WRITE8(*this, blaster_state, blaster_snd_cmd_w))
 
 	MCFG_DEVICE_MODIFY("pia_2")
 	MCFG_PIA_WRITEPA_HANDLER(WRITE8("ldac", dac_byte_interface, data_w))
 
-	MCFG_DEVICE_ADD("pia_2b", PIA6821, 0)
+	MCFG_DEVICE_ADD("pia_3", PIA6821, 0)
 	MCFG_PIA_WRITEPA_HANDLER(WRITE8("rdac", dac_byte_interface, data_w))
-	MCFG_PIA_IRQA_HANDLER(WRITELINE(*this, blaster_state,williams_snd_irq_b))
-	MCFG_PIA_IRQB_HANDLER(WRITELINE(*this, blaster_state,williams_snd_irq_b))
+	MCFG_PIA_IRQA_HANDLER(WRITELINE("soundirq_b", input_merger_any_high_device, in_w<0>))
+	MCFG_PIA_IRQB_HANDLER(WRITELINE("soundirq_b", input_merger_any_high_device, in_w<1>))
 
 	/* sound hardware */
 	MCFG_DEVICE_REMOVE("speaker")
@@ -1764,6 +1799,12 @@ MACHINE_CONFIG_START(williams2_state::williams2)
 	MCFG_SOUND_ROUTE(0, "dac", 1.0, DAC_VREF_POS_INPUT) MCFG_SOUND_ROUTE(0, "dac", -1.0, DAC_VREF_NEG_INPUT)
 
 	/* pia */
+	MCFG_INPUT_MERGER_ANY_HIGH("mainirq")
+	MCFG_INPUT_MERGER_OUTPUT_HANDLER(INPUTLINE("maincpu", M6809_IRQ_LINE))
+
+	MCFG_INPUT_MERGER_ANY_HIGH("soundirq")
+	MCFG_INPUT_MERGER_OUTPUT_HANDLER(INPUTLINE("soundcpu", M6808_IRQ_LINE))
+
 	MCFG_DEVICE_ADD("pia_0", PIA6821, 0)
 	MCFG_PIA_READPA_HANDLER(IOPORT("IN0"))
 	MCFG_PIA_READPB_HANDLER(IOPORT("IN1"))
@@ -1772,15 +1813,15 @@ MACHINE_CONFIG_START(williams2_state::williams2)
 	MCFG_PIA_READPA_HANDLER(IOPORT("IN2"))
 	MCFG_PIA_WRITEPB_HANDLER(WRITE8(*this, williams2_state,williams2_snd_cmd_w))
 	MCFG_PIA_CB2_HANDLER(WRITELINE("pia_2", pia6821_device, ca1_w))
-	MCFG_PIA_IRQA_HANDLER(WRITELINE(*this, williams_state,williams_main_irq))
-	MCFG_PIA_IRQB_HANDLER(WRITELINE(*this, williams_state,williams_main_irq))
+	MCFG_PIA_IRQA_HANDLER(WRITELINE("mainirq", input_merger_any_high_device, in_w<0>))
+	MCFG_PIA_IRQB_HANDLER(WRITELINE("mainirq", input_merger_any_high_device, in_w<1>))
 
 	MCFG_DEVICE_ADD("pia_2", PIA6821, 0)
 	MCFG_PIA_WRITEPA_HANDLER(WRITE8("pia_1", pia6821_device, portb_w))
 	MCFG_PIA_WRITEPB_HANDLER(WRITE8("dac", dac_byte_interface, data_w))
 	MCFG_PIA_CA2_HANDLER(WRITELINE("pia_1", pia6821_device, cb1_w))
-	MCFG_PIA_IRQA_HANDLER(WRITELINE(*this, williams_state,williams_snd_irq))
-	MCFG_PIA_IRQB_HANDLER(WRITELINE(*this, williams_state,williams_snd_irq))
+	MCFG_PIA_IRQA_HANDLER(WRITELINE("soundirq", input_merger_any_high_device, in_w<0>))
+	MCFG_PIA_IRQB_HANDLER(WRITELINE("soundirq", input_merger_any_high_device, in_w<1>))
 MACHINE_CONFIG_END
 
 
@@ -1803,12 +1844,12 @@ MACHINE_CONFIG_START(williams2_state::mysticm)
 
 	/* pia */
 	MCFG_DEVICE_MODIFY("pia_0")
-	MCFG_PIA_IRQA_HANDLER(WRITELINE(*this, williams_state,williams_main_firq))
-	MCFG_PIA_IRQB_HANDLER(WRITELINE(*this, williams2_state,mysticm_main_irq))
+	MCFG_PIA_IRQA_HANDLER(INPUTLINE("maincpu", M6809_FIRQ_LINE))
+	MCFG_PIA_IRQB_HANDLER(WRITELINE("mainirq", input_merger_any_high_device, in_w<0>))
 
 	MCFG_DEVICE_MODIFY("pia_1")
-	MCFG_PIA_IRQA_HANDLER(WRITELINE(*this, williams2_state,mysticm_main_irq))
-	MCFG_PIA_IRQB_HANDLER(WRITELINE(*this, williams2_state,mysticm_main_irq))
+	MCFG_PIA_IRQA_HANDLER(WRITELINE("mainirq", input_merger_any_high_device, in_w<1>))
+	MCFG_PIA_IRQB_HANDLER(WRITELINE("mainirq", input_merger_any_high_device, in_w<2>))
 MACHINE_CONFIG_END
 
 
@@ -1824,12 +1865,12 @@ MACHINE_CONFIG_START(tshoot_state::tshoot)
 	MCFG_PIA_READPA_HANDLER(READ8("mux", ls157_x2_device, output_r))
 	MCFG_PIA_WRITEPB_HANDLER(WRITE8(*this, tshoot_state, lamp_w))
 	MCFG_PIA_CA2_HANDLER(WRITELINE("mux", ls157_x2_device, select_w))
-	MCFG_PIA_IRQA_HANDLER(WRITELINE(*this, williams2_state,tshoot_main_irq))
-	MCFG_PIA_IRQB_HANDLER(WRITELINE(*this, williams2_state,tshoot_main_irq))
+	MCFG_PIA_IRQA_HANDLER(WRITELINE("mainirq", input_merger_any_high_device, in_w<0>))
+	MCFG_PIA_IRQB_HANDLER(WRITELINE("mainirq", input_merger_any_high_device, in_w<1>))
 
 	MCFG_DEVICE_MODIFY("pia_1")
-	MCFG_PIA_IRQA_HANDLER(WRITELINE(*this, williams2_state,tshoot_main_irq))
-	MCFG_PIA_IRQB_HANDLER(WRITELINE(*this, williams2_state,tshoot_main_irq))
+	MCFG_PIA_IRQA_HANDLER(WRITELINE("mainirq", input_merger_any_high_device, in_w<2>))
+	MCFG_PIA_IRQB_HANDLER(WRITELINE("mainirq", input_merger_any_high_device, in_w<3>))
 
 	MCFG_DEVICE_MODIFY("pia_2")
 	MCFG_PIA_CB2_HANDLER(WRITELINE(*this, tshoot_state, maxvol_w))
@@ -1864,8 +1905,8 @@ MACHINE_CONFIG_START(joust2_state::joust2)
 	MCFG_PIA_WRITEPB_HANDLER(WRITE8(*this, joust2_state,joust2_snd_cmd_w))
 	MCFG_PIA_CA2_HANDLER(WRITELINE(*this, joust2_state,joust2_pia_3_cb1_w))
 	MCFG_PIA_CB2_HANDLER(WRITELINE("pia_2", pia6821_device, ca1_w))
-	MCFG_PIA_IRQA_HANDLER(WRITELINE(*this, williams_state,williams_main_irq))
-	MCFG_PIA_IRQB_HANDLER(WRITELINE(*this, williams_state,williams_main_irq))
+	MCFG_PIA_IRQA_HANDLER(WRITELINE("mainirq", input_merger_any_high_device, in_w<0>))
+	MCFG_PIA_IRQB_HANDLER(WRITELINE("mainirq", input_merger_any_high_device, in_w<1>))
 
 	MCFG_DEVICE_ADD("mux", LS157, 0)
 	MCFG_74157_A_IN_CB(IOPORT("INP1"))
@@ -3242,15 +3283,6 @@ void blaster_state::init_blaster()
 void spdball_state::driver_init()
 {
 	CONFIGURE_BLITTER(WILLIAMS_BLITTER_SC1, 0xc000);
-
-	/* add a third PIA */
-	m_maincpu->space(AS_PROGRAM).install_readwrite_handler(0xc808, 0xc80b, read8_delegate(FUNC(pia6821_device::read), (pia6821_device*)m_pia_3), write8_delegate(FUNC(pia6821_device::write), (pia6821_device*)m_pia_3));
-
-	/* install extra input handlers */
-	m_maincpu->space(AS_PROGRAM).install_read_port(0xc800, 0xc800, "AN0");
-	m_maincpu->space(AS_PROGRAM).install_read_port(0xc801, 0xc801, "AN1");
-	m_maincpu->space(AS_PROGRAM).install_read_port(0xc802, 0xc802, "AN2");
-	m_maincpu->space(AS_PROGRAM).install_read_port(0xc803, 0xc803, "AN3");
 }
 
 

--- a/src/mame/drivers/williams.cpp
+++ b/src/mame/drivers/williams.cpp
@@ -1860,6 +1860,8 @@ MACHINE_CONFIG_START(tshoot_state::tshoot)
 	MCFG_DEVICE_MODIFY("maincpu")
 	MCFG_DEVICE_PROGRAM_MAP(williams2_d000_rom_map)
 
+	MCFG_MACHINE_START_OVERRIDE(tshoot_state,tshoot)
+
 	/* pia */
 	MCFG_DEVICE_MODIFY("pia_0")
 	MCFG_PIA_READPA_HANDLER(READ8("mux", ls157_x2_device, output_r))

--- a/src/mame/includes/williams.h
+++ b/src/mame/includes/williams.h
@@ -22,20 +22,19 @@
 class williams_state : public driver_device
 {
 public:
-	williams_state(const machine_config &mconfig, device_type type, const char *tag)
-		: driver_device(mconfig, type, tag),
+	williams_state(const machine_config &mconfig, device_type type, const char *tag) :
+		driver_device(mconfig, type, tag),
 		m_nvram(*this, "nvram"),
 		m_videoram(*this, "videoram"),
+		m_mainbank(*this, "mainbank"),
 		m_maincpu(*this, "maincpu"),
 		m_soundcpu(*this, "soundcpu"),
 		m_bankc000(*this, "bankc000"),
 		m_watchdog(*this, "watchdog"),
 		m_screen(*this, "screen"),
 		m_palette(*this, "palette"),
-		m_generic_paletteram_8(*this, "paletteram"),
-		m_pia_0(*this, "pia_0"),
-		m_pia_1(*this, "pia_1"),
-		m_pia_2(*this, "pia_2") { }
+		m_paletteram(*this, "paletteram"),
+		m_pia(*this, "pia_%u", 0U) { }
 
 	enum
 	{
@@ -52,6 +51,7 @@ public:
 
 	required_shared_ptr<uint8_t> m_nvram;
 	required_shared_ptr<uint8_t> m_videoram;
+	optional_memory_bank m_mainbank;
 	uint8_t *m_mayday_protection;
 	uint8_t m_blitter_config;
 	uint16_t m_blitter_clip_address;
@@ -99,16 +99,12 @@ public:
 	DECLARE_WRITE8_MEMBER(playball_snd_cmd_w);
 	DECLARE_READ8_MEMBER(williams_49way_port_0_r);
 	DECLARE_WRITE_LINE_MEMBER(lottofun_coin_lock_w);
+	DECLARE_PALETTE_INIT(williams);
 
 	void state_save_register();
-	void create_palette_lookup();
 	void blitter_init(int blitter_config, const uint8_t *remap_prom);
 	inline void blit_pixel(address_space &space, int dstaddr, int srcdata, int controlbyte);
 	int blitter_core(address_space &space, int sstart, int dstart, int w, int h, int data);
-
-	DECLARE_WRITE_LINE_MEMBER(williams_main_irq);
-	DECLARE_WRITE_LINE_MEMBER(williams_main_firq);
-	DECLARE_WRITE_LINE_MEMBER(williams_snd_irq);
 
 	required_device<cpu_device> m_maincpu;
 	required_device<cpu_device> m_soundcpu;
@@ -116,10 +112,8 @@ public:
 	required_device<watchdog_timer_device> m_watchdog;
 	required_device<screen_device> m_screen;
 	optional_device<palette_device> m_palette;
-	optional_shared_ptr<uint8_t> m_generic_paletteram_8;
-	required_device<pia6821_device> m_pia_0;
-	required_device<pia6821_device> m_pia_1;
-	required_device<pia6821_device> m_pia_2;
+	optional_shared_ptr<uint8_t> m_paletteram;
+	optional_device_array<pia6821_device, 4> m_pia;
 	void playball(machine_config &config);
 	void defender(machine_config &config);
 	void sinistar(machine_config &config);
@@ -138,34 +132,29 @@ public:
 class spdball_state : public williams_state
 {
 public:
-	spdball_state(const machine_config &mconfig, device_type type, const char *tag)
-		: williams_state(mconfig, type, tag)
-		, m_pia_3(*this, "pia_3")
-	{
-	}
+	spdball_state(const machine_config &mconfig, device_type type, const char *tag) :
+		williams_state(mconfig, type, tag) { }
 
 	void driver_init() override;
 
 	void spdball(machine_config &config);
-
-protected:
-	required_device<pia6821_device> m_pia_3;
+	void spdball_map(address_map &map);
 };
 
 class blaster_state : public williams_state
 {
 public:
-	blaster_state(const machine_config &mconfig, device_type type, const char *tag)
-		: williams_state(mconfig, type, tag),
+	blaster_state(const machine_config &mconfig, device_type type, const char *tag) :
+		williams_state(mconfig, type, tag),
 		m_soundcpu_b(*this, "soundcpu_b"),
-		m_pia_2b(*this, "pia_2b"),
 		m_blaster_palette_0(*this, "blaster_pal0"),
-		m_blaster_scanline_control(*this, "blaster_scan") { }
+		m_blaster_scanline_control(*this, "blaster_scan"),
+		m_blaster_bankb(*this, "blaster_bankb") { }
 
 	optional_device<cpu_device> m_soundcpu_b;
-	optional_device<pia6821_device> m_pia_2b;
 	required_shared_ptr<uint8_t> m_blaster_palette_0;
 	required_shared_ptr<uint8_t> m_blaster_scanline_control;
+	optional_memory_bank m_blaster_bankb;
 
 	rgb_t m_blaster_color0;
 	uint8_t m_blaster_video_control;
@@ -178,7 +167,6 @@ public:
 	DECLARE_WRITE8_MEMBER(blaster_video_control_w);
 	TIMER_CALLBACK_MEMBER(blaster_deferred_snd_cmd_w);
 	DECLARE_WRITE8_MEMBER(blaster_snd_cmd_w);
-	DECLARE_WRITE_LINE_MEMBER(williams_snd_irq_b);
 
 	void init_blaster();
 	DECLARE_MACHINE_START(blaster);
@@ -226,8 +214,6 @@ public:
 	TIMER_DEVICE_CALLBACK_MEMBER(williams2_endscreen_callback);
 	TIMER_CALLBACK_MEMBER(williams2_deferred_snd_cmd_w);
 	DECLARE_WRITE8_MEMBER(williams2_snd_cmd_w);
-	DECLARE_WRITE_LINE_MEMBER(mysticm_main_irq);
-	DECLARE_WRITE_LINE_MEMBER(tshoot_main_irq);
 
 	void init_mysticm();
 	void init_tshoot();

--- a/src/mame/includes/williams.h
+++ b/src/mame/includes/williams.h
@@ -236,17 +236,27 @@ public:
 class tshoot_state : public williams2_state
 {
 public:
-	tshoot_state(const machine_config &mconfig, device_type type, const char *tag)
-		: williams2_state(mconfig, type, tag),
-		m_gun(*this, {"GUNX", "GUNY"}) { }
+	tshoot_state(const machine_config &mconfig, device_type type, const char *tag) :
+		williams2_state(mconfig, type, tag),
+		m_gun(*this, {"GUNX", "GUNY"}),
+		m_grenade_lamp(*this, "Grenade_lamp"),
+		m_gun_lamp(*this, "Gun_lamp"),
+		m_p1_gun_recoil(*this, "Player1_Gun_Recoil"),
+		m_feather_blower(*this, "Feather_Blower") { }
 
 	DECLARE_CUSTOM_INPUT_MEMBER(gun_r);
 	DECLARE_WRITE_LINE_MEMBER(maxvol_w);
 	DECLARE_WRITE8_MEMBER(lamp_w);
 
+	DECLARE_MACHINE_START(tshoot);
+
 	void tshoot(machine_config &config);
 private:
 	required_ioport_array<2> m_gun;
+	output_finder<> m_grenade_lamp;
+	output_finder<> m_gun_lamp;
+	output_finder<> m_p1_gun_recoil;
+	output_finder<> m_feather_blower;
 };
 
 class joust2_state : public williams2_state

--- a/src/mame/machine/williams.cpp
+++ b/src/mame/machine/williams.cpp
@@ -25,7 +25,7 @@ TIMER_DEVICE_CALLBACK_MEMBER(williams_state::williams_va11_callback)
 		return;
 
 	/* the IRQ signal comes into CB1, and is set to VA11 */
-	m_pia_1->cb1_w(BIT(scanline, 5));
+	m_pia[1]->cb1_w(BIT(scanline, 5));
 }
 
 
@@ -34,67 +34,8 @@ TIMER_DEVICE_CALLBACK_MEMBER(williams_state::williams_count240_callback)
 	int scanline = param;
 
 	// the COUNT240 signal comes into CA1, and is set to the logical AND of VA10-VA13
-	m_pia_1->ca1_w(scanline >= 240 ? 1 : 0);
+	m_pia[1]->ca1_w(scanline >= 240 ? 1 : 0);
 }
-
-
-WRITE_LINE_MEMBER(williams_state::williams_main_irq)
-{
-	int combined_state = m_pia_1->irq_a_state() | m_pia_1->irq_b_state();
-
-	/* IRQ to the main CPU */
-	m_maincpu->set_input_line(M6809_IRQ_LINE, combined_state ? ASSERT_LINE : CLEAR_LINE);
-}
-
-
-WRITE_LINE_MEMBER(williams_state::williams_main_firq)
-{
-	/* FIRQ to the main CPU */
-	m_maincpu->set_input_line(M6809_FIRQ_LINE, state ? ASSERT_LINE : CLEAR_LINE);
-}
-
-
-WRITE_LINE_MEMBER(williams_state::williams_snd_irq)
-{
-	int combined_state = m_pia_2->irq_a_state() | m_pia_2->irq_b_state();
-
-	/* IRQ to the sound CPU */
-	m_soundcpu->set_input_line(M6808_IRQ_LINE, combined_state ? ASSERT_LINE : CLEAR_LINE);
-}
-/* Same as above, but for second sound board */
-WRITE_LINE_MEMBER(blaster_state::williams_snd_irq_b)
-{
-	int combined_state = m_pia_2b->irq_a_state() | m_pia_2b->irq_b_state();
-
-	/* IRQ to the sound CPU */
-	m_soundcpu_b->set_input_line(M6808_IRQ_LINE, combined_state ? ASSERT_LINE : CLEAR_LINE);
-}
-
-
-
-/*************************************
- *
- *  Newer Williams interrupts
- *
- *************************************/
-
-WRITE_LINE_MEMBER(williams2_state::mysticm_main_irq)
-{
-	int combined_state = m_pia_0->irq_b_state() | m_pia_1->irq_a_state() | m_pia_1->irq_b_state();
-
-	/* IRQ to the main CPU */
-	m_maincpu->set_input_line(M6809_IRQ_LINE, combined_state ? ASSERT_LINE : CLEAR_LINE);
-}
-
-
-WRITE_LINE_MEMBER(williams2_state::tshoot_main_irq)
-{
-	int combined_state = m_pia_0->irq_a_state() | m_pia_0->irq_b_state() | m_pia_1->irq_a_state() | m_pia_1->irq_b_state();
-
-	/* IRQ to the main CPU */
-	m_maincpu->set_input_line(M6809_IRQ_LINE, combined_state ? ASSERT_LINE : CLEAR_LINE);
-}
-
 
 
 /*************************************
@@ -106,8 +47,8 @@ WRITE_LINE_MEMBER(williams2_state::tshoot_main_irq)
 MACHINE_START_MEMBER(williams_state,williams_common)
 {
 	/* configure the memory bank */
-	membank("bank1")->configure_entry(1, memregion("maincpu")->base() + 0x10000);
-	membank("bank1")->configure_entry(0, m_videoram);
+	m_mainbank->configure_entry(1, memregion("maincpu")->base() + 0x10000);
+	m_mainbank->configure_entry(0, m_videoram);
 }
 
 
@@ -131,8 +72,8 @@ TIMER_DEVICE_CALLBACK_MEMBER(williams2_state::williams2_va11_callback)
 		return;
 
 	// the IRQ signal comes into CB1, and is set to VA11
-	m_pia_0->cb1_w(BIT(scanline, 5));
-	m_pia_1->ca1_w(BIT(scanline, 5));
+	m_pia[0]->cb1_w(BIT(scanline, 5));
+	m_pia[1]->ca1_w(BIT(scanline, 5));
 }
 
 
@@ -141,7 +82,7 @@ TIMER_DEVICE_CALLBACK_MEMBER(williams2_state::williams2_endscreen_callback)
 	int scanline = param;
 
 	// the /ENDSCREEN signal comes into CA1
-	m_pia_0->ca1_w(scanline >= 254 ? 0 : 1);
+	m_pia[0]->ca1_w(scanline >= 254 ? 0 : 1);
 }
 
 
@@ -155,8 +96,8 @@ TIMER_DEVICE_CALLBACK_MEMBER(williams2_state::williams2_endscreen_callback)
 MACHINE_START_MEMBER(williams2_state,williams2)
 {
 	/* configure memory banks */
-	membank("bank1")->configure_entries(1, 4, memregion("maincpu")->base() + 0x10000, 0x10000);
-	membank("bank1")->configure_entry(0, m_videoram);
+	m_mainbank->configure_entries(1, 4, memregion("maincpu")->base() + 0x10000, 0x10000);
+	m_mainbank->configure_entry(0, m_videoram);
 	membank("vram8000")->set_base(&m_videoram[0x8000]);
 }
 
@@ -178,7 +119,7 @@ MACHINE_RESET_MEMBER(williams2_state,williams2)
 WRITE8_MEMBER(williams_state::williams_vram_select_w)
 {
 	/* VRAM/ROM banking from bit 0 */
-	membank("bank1")->set_entry(data & 0x01);
+	m_mainbank->set_entry(data & 0x01);
 
 	/* cocktail flip from bit 1 */
 	m_cocktail = data & 0x02;
@@ -192,20 +133,20 @@ WRITE8_MEMBER(williams2_state::williams2_bank_select_w)
 	{
 		/* page 0 is video ram */
 		case 0:
-			membank("bank1")->set_entry(0);
+			m_mainbank->set_entry(0);
 			m_bank8000->set_bank(0);
 			break;
 
 		/* pages 1 and 2 are ROM */
 		case 1:
 		case 2:
-			membank("bank1")->set_entry(1 + ((data & 6) >> 1));
+			m_mainbank->set_entry(1 + ((data & 6) >> 1));
 			m_bank8000->set_bank(0);
 			break;
 
 		/* page 3 accesses palette RAM; the remaining areas are as if page 1 ROM was selected */
 		case 3:
-			membank("bank1")->set_entry(1 + ((data & 4) >> 1));
+			m_mainbank->set_entry(1 + ((data & 4) >> 1));
 			m_bank8000->set_bank(1);
 			break;
 	}
@@ -221,8 +162,8 @@ WRITE8_MEMBER(williams2_state::williams2_bank_select_w)
 
 TIMER_CALLBACK_MEMBER(williams_state::williams_deferred_snd_cmd_w)
 {
-	m_pia_2->write_portb(param);
-	m_pia_2->cb1_w((param == 0xff) ? 0 : 1);
+	m_pia[2]->write_portb(param);
+	m_pia[2]->cb1_w((param == 0xff) ? 0 : 1);
 }
 
 WRITE8_MEMBER(williams_state::williams_snd_cmd_w)
@@ -238,7 +179,7 @@ WRITE8_MEMBER(williams_state::playball_snd_cmd_w)
 
 TIMER_CALLBACK_MEMBER(williams2_state::williams2_deferred_snd_cmd_w)
 {
-	m_pia_2->write_porta(param);
+	m_pia[2]->write_porta(param);
 }
 
 WRITE8_MEMBER(williams2_state::williams2_snd_cmd_w)
@@ -440,11 +381,11 @@ WRITE8_MEMBER(williams_state::sinistar_vram_select_w)
 MACHINE_START_MEMBER(blaster_state,blaster)
 {
 	/* banking is different for blaster */
-	membank("bank1")->configure_entries(1, 16, memregion("maincpu")->base() + 0x18000, 0x4000);
-	membank("bank1")->configure_entry(0, m_videoram);
+	m_mainbank->configure_entries(1, 16, memregion("maincpu")->base() + 0x18000, 0x4000);
+	m_mainbank->configure_entry(0, m_videoram);
 
-	membank("bank2")->configure_entries(1, 16, memregion("maincpu")->base() + 0x10000, 0x0000);
-	membank("bank2")->configure_entry(0, &m_videoram[0x4000]);
+	m_blaster_bankb->configure_entries(1, 16, memregion("maincpu")->base() + 0x10000, 0x0000);
+	m_blaster_bankb->configure_entry(0, &m_videoram[0x4000]);
 
 	/* register for save states */
 	save_item(NAME(m_vram_bank));
@@ -454,8 +395,8 @@ MACHINE_START_MEMBER(blaster_state,blaster)
 
 inline void blaster_state::update_blaster_banking()
 {
-	membank("bank1")->set_entry(m_vram_bank * (m_rom_bank + 1));
-	membank("bank2")->set_entry(m_vram_bank * (m_rom_bank + 1));
+	m_mainbank->set_entry(m_vram_bank * (m_rom_bank + 1));
+	m_blaster_bankb->set_entry(m_vram_bank * (m_rom_bank + 1));
 }
 
 
@@ -485,8 +426,8 @@ TIMER_CALLBACK_MEMBER(blaster_state::blaster_deferred_snd_cmd_w)
 	uint8_t l_data = param | 0x80;
 	uint8_t r_data = (param >> 1 & 0x40) | (param & 0x3f) | 0x80;
 
-	m_pia_2->write_portb(l_data); m_pia_2->cb1_w((l_data == 0xff) ? 0 : 1);
-	m_pia_2b->write_portb(r_data); m_pia_2b->cb1_w((r_data == 0xff) ? 0 : 1);
+	m_pia[2]->write_portb(l_data); m_pia[2]->cb1_w((l_data == 0xff) ? 0 : 1);
+	m_pia[3]->write_portb(r_data); m_pia[3]->cb1_w((r_data == 0xff) ? 0 : 1);
 }
 
 
@@ -565,7 +506,7 @@ MACHINE_RESET_MEMBER(joust2_state,joust2)
 
 TIMER_CALLBACK_MEMBER(joust2_state::joust2_deferred_snd_cmd_w)
 {
-	m_pia_2->write_porta(param & 0xff);
+	m_pia[2]->write_porta(param & 0xff);
 }
 
 

--- a/src/mame/machine/williams.cpp
+++ b/src/mame/machine/williams.cpp
@@ -457,6 +457,16 @@ WRITE_LINE_MEMBER(williams_state::lottofun_coin_lock_w)
  *
  *************************************/
 
+MACHINE_START_MEMBER(tshoot_state,tshoot)
+{
+	MACHINE_START_CALL_MEMBER(williams2);
+	m_grenade_lamp.resolve();
+	m_gun_lamp.resolve();
+	m_p1_gun_recoil.resolve();
+	m_feather_blower.resolve();
+}
+
+
 CUSTOM_INPUT_MEMBER(tshoot_state::gun_r)
 {
 	int data = m_gun[(uintptr_t)param]->read();
@@ -474,13 +484,13 @@ WRITE_LINE_MEMBER(tshoot_state::maxvol_w)
 WRITE8_MEMBER(tshoot_state::lamp_w)
 {
 	/* set the grenade lamp */
-	output().set_value("Grenade_lamp", (~data & 0x4)>>2 );
+	m_grenade_lamp   = BIT(~data, 2);
 	/* set the gun lamp */
-	output().set_value("Gun_lamp", (~data & 0x8)>>3 );
+	m_gun_lamp       = BIT(~data, 3);
 	/* gun coil */
-	output().set_value("Player1_Gun_Recoil", (data & 0x10)>>4 );
+	m_p1_gun_recoil  = BIT(data, 4);
 	/* feather coil */
-	output().set_value("Feather_Blower", (data & 0x20)>>5 );
+	m_feather_blower = BIT(data, 5);
 }
 
 


### PR DESCRIPTION
williams.cpp : Reduce runtime tag lookups, Add input_merger for interrupts, Reduce duplicates, Fix naming, Device'd palette for williams_state/blaster_state games, Split spdball Address map

audio/williams.cpp : Reduce runtime tag lookups, Cleanup duplicates