### PR TITLE
68k: fix carry flag clear in divs instruction

### DIFF
--- a/src/devices/cpu/m68000/m68k_in.cpp
+++ b/src/devices/cpu/m68000/m68k_in.cpp
@@ -4612,6 +4612,7 @@ M68KMAKE_OP(divu, 16, ., d)
 
 	if(src != 0)
 	{
+		m_c_flag = CFLAG_CLEAR;
 		uint32_t quotient = *r_dst / src;
 		uint32_t remainder = *r_dst % src;
 
@@ -4620,7 +4621,6 @@ M68KMAKE_OP(divu, 16, ., d)
 			m_not_z_flag = quotient;
 			m_n_flag = NFLAG_16(quotient);
 			m_v_flag = VFLAG_CLEAR;
-			m_c_flag = CFLAG_CLEAR;
 			*r_dst = MASK_OUT_ABOVE_32(MASK_OUT_ABOVE_16(quotient) | (remainder << 16));
 			return;
 		}
@@ -4638,6 +4638,7 @@ M68KMAKE_OP(divu, 16, ., .)
 
 	if(src != 0)
 	{
+		m_c_flag = CFLAG_CLEAR;
 		uint32_t quotient = *r_dst / src;
 		uint32_t remainder = *r_dst % src;
 
@@ -4646,7 +4647,6 @@ M68KMAKE_OP(divu, 16, ., .)
 			m_not_z_flag = quotient;
 			m_n_flag = NFLAG_16(quotient);
 			m_v_flag = VFLAG_CLEAR;
-			m_c_flag = CFLAG_CLEAR;
 			*r_dst = MASK_OUT_ABOVE_32(MASK_OUT_ABOVE_16(quotient) | (remainder << 16));
 			return;
 		}

--- a/src/devices/cpu/m68000/m68k_in.cpp
+++ b/src/devices/cpu/m68000/m68k_in.cpp
@@ -4540,12 +4540,12 @@ M68KMAKE_OP(divs, 16, ., d)
 
 	if(src != 0)
 	{
+		m_c_flag = CFLAG_CLEAR;
 		if((uint32_t)*r_dst == 0x80000000 && src == -1)
 		{
 			m_not_z_flag = 0;
 			m_n_flag = NFLAG_CLEAR;
 			m_v_flag = VFLAG_CLEAR;
-			m_c_flag = CFLAG_CLEAR;
 			*r_dst = 0;
 			return;
 		}
@@ -4558,7 +4558,6 @@ M68KMAKE_OP(divs, 16, ., d)
 			m_not_z_flag = quotient;
 			m_n_flag = NFLAG_16(quotient);
 			m_v_flag = VFLAG_CLEAR;
-			m_c_flag = CFLAG_CLEAR;
 			*r_dst = MASK_OUT_ABOVE_32(MASK_OUT_ABOVE_16(quotient) | (remainder << 16));
 			return;
 		}
@@ -4578,12 +4577,12 @@ M68KMAKE_OP(divs, 16, ., .)
 
 	if(src != 0)
 	{
+		m_c_flag = CFLAG_CLEAR;
 		if((uint32_t)*r_dst == 0x80000000 && src == -1)
 		{
 			m_not_z_flag = 0;
 			m_n_flag = NFLAG_CLEAR;
 			m_v_flag = VFLAG_CLEAR;
-			m_c_flag = CFLAG_CLEAR;
 			*r_dst = 0;
 			return;
 		}
@@ -4596,7 +4595,6 @@ M68KMAKE_OP(divs, 16, ., .)
 			m_not_z_flag = quotient;
 			m_n_flag = NFLAG_16(quotient);
 			m_v_flag = VFLAG_CLEAR;
-			m_c_flag = CFLAG_CLEAR;
 			*r_dst = MASK_OUT_ABOVE_32(MASK_OUT_ABOVE_16(quotient) | (remainder << 16));
 			return;
 		}


### PR DESCRIPTION
I was debugging why the 'HP9000/300 mainframe tests' where hanging on hp9k_3xx.
Debugger showed the following code:

move.l (a2)+, d0
move.l (a2)+, d1
move d6, ccr
divs.w d0,d1
loop: bcs.s loop

Clearly this tests whether the carry flag is cleared - the Motorola Reference
Manual says it's always cleared. However, in our implementation, it's not
cleared on overflow.

You can reproduce this with latest mame: ./mame64 -flop1 300test -debug