### PR TITLE
68k: fix pack instructions

### DIFF
--- a/src/devices/cpu/m68000/m68k_in.cpp
+++ b/src/devices/cpu/m68000/m68k_in.cpp
@@ -8185,9 +8185,9 @@ M68KMAKE_OP(pack, 16, mm, ay7)
 		uint32_t ea_src = EA_A7_PD_8();
 		uint32_t src = m68ki_read_8(ea_src);
 		ea_src = EA_A7_PD_8();
-		src = ((src << 8) | m68ki_read_8(ea_src)) + OPER_I_16();
+		src = (src | (m68ki_read_8(ea_src) << 8)) + OPER_I_16();
 
-		m68ki_write_8(EA_AX_PD_8(), ((src >> 8) & 0x000f) | ((src<<4) & 0x00f0));
+		m68ki_write_8(EA_AX_PD_8(), ((src >> 4) & 0x00f0) | (src & 0x00f));
 		return;
 	}
 	m68ki_exception_illegal();
@@ -8201,9 +8201,9 @@ M68KMAKE_OP(pack, 16, mm, axy7)
 		uint32_t ea_src = EA_A7_PD_8();
 		uint32_t src = m68ki_read_8(ea_src);
 		ea_src = EA_A7_PD_8();
-		src = ((src << 8) | m68ki_read_8(ea_src)) + OPER_I_16();
+		src = (src | (m68ki_read_8(ea_src) << 8)) + OPER_I_16();
 
-		m68ki_write_8(EA_A7_PD_8(), ((src >> 8) & 0x000f) | ((src<<4) & 0x00f0));
+		m68ki_write_8(EA_A7_PD_8(), ((src >> 4) & 0x00f0) | (src & 0x000f));
 		return;
 	}
 	m68ki_exception_illegal();
@@ -8218,9 +8218,9 @@ M68KMAKE_OP(pack, 16, mm, .)
 		uint32_t ea_src = EA_AY_PD_8();
 		uint32_t src = m68ki_read_8(ea_src);
 		ea_src = EA_AY_PD_8();
-		src = ((src << 8) | m68ki_read_8(ea_src)) + OPER_I_16();
+		src = (src | (m68ki_read_8(ea_src) << 8)) + OPER_I_16();
 
-		m68ki_write_8(EA_AX_PD_8(), ((src >> 8) & 0x000f) | ((src<<4) & 0x00f0));
+		m68ki_write_8(EA_AX_PD_8(), ((src >> 4) & 0x00f0) | (src & 0x000f));
 		return;
 	}
 	m68ki_exception_illegal();


### PR DESCRIPTION
The following test code from the 'HP9000/300 series mainframe tests'
fails:

lea bytes, a0
pack -(a0),-(a1), #$FEDC
move.b (a1),d0
cmbi.b #$E,d0
loop: bne.s loop

bytes: 0x41 0x42

It looks like most of the pack instructions have the byte order
wrong, but the pack dx,dy variant seems to have been fixed already.

Signed-off-by: Sven Schnelle <svens@stackframe.org>