### PR TITLE
debugger: add command for go_exception (nw)

### DIFF
--- a/src/emu/debug/debugcmd.cpp
+++ b/src/emu/debug/debugcmd.cpp
@@ -156,6 +156,8 @@ debugger_commands::debugger_commands(running_machine& machine, debugger_cpu& cpu
 	m_console.register_command("gv",        CMDFLAG_NONE, 0, 0, 0, std::bind(&debugger_commands::execute_go_vblank, this, _1, _2));
 	m_console.register_command("gint",      CMDFLAG_NONE, 0, 0, 1, std::bind(&debugger_commands::execute_go_interrupt, this, _1, _2));
 	m_console.register_command("gi",        CMDFLAG_NONE, 0, 0, 1, std::bind(&debugger_commands::execute_go_interrupt, this, _1, _2));
+	m_console.register_command("gex",       CMDFLAG_NONE, 0, 0, 1, std::bind(&debugger_commands::execute_go_exception, this, _1, _2));
+	m_console.register_command("ge",        CMDFLAG_NONE, 0, 0, 1, std::bind(&debugger_commands::execute_go_exception, this, _1, _2));
 	m_console.register_command("gtime",     CMDFLAG_NONE, 0, 0, 1, std::bind(&debugger_commands::execute_go_time, this, _1, _2));
 	m_console.register_command("gt",        CMDFLAG_NONE, 0, 0, 1, std::bind(&debugger_commands::execute_go_time, this, _1, _2));
 	m_console.register_command("next",      CMDFLAG_NONE, 0, 0, 0, std::bind(&debugger_commands::execute_next, this, _1, _2));
@@ -863,6 +865,21 @@ void debugger_commands::execute_go_interrupt(int ref, const std::vector<std::str
 		return;
 
 	m_cpu.get_visible_cpu()->debug()->go_interrupt(irqline);
+}
+
+/*-------------------------------------------------
+    execute_go_exception - execute the goex command
+-------------------------------------------------*/
+
+void debugger_commands::execute_go_exception(int ref, const std::vector<std::string> &params)
+{
+	u64 exception = -1;
+
+	/* if we have a parameter, use it instead */
+	if (params.size() > 0 && !validate_number_parameter(params[0], exception))
+		return;
+
+	m_cpu.get_visible_cpu()->debug()->go_exception(exception);
 }
 
 

--- a/src/emu/debug/debugcmd.h
+++ b/src/emu/debug/debugcmd.h
@@ -106,6 +106,7 @@ private:
 	void execute_go(int ref, const std::vector<std::string> &params);
 	void execute_go_vblank(int ref, const std::vector<std::string> &params);
 	void execute_go_interrupt(int ref, const std::vector<std::string> &params);
+	void execute_go_exception(int ref, const std::vector<std::string> &params);
 	void execute_go_time(int ref, const std::vector<std::string> &params);
 	void execute_focus(int ref, const std::vector<std::string> &params);
 	void execute_ignore(int ref, const std::vector<std::string> &params);

--- a/src/emu/debug/debughlp.cpp
+++ b/src/emu/debug/debughlp.cpp
@@ -136,6 +136,7 @@ static const help_item static_help_list[] =
 		"  o[ver] [<count>=1] -- single steps over <count> instructions (F10)\n"
 		"  out -- single steps until the current subroutine/exception handler is exited (Shift-F11)\n"
 		"  g[o] [<address>] -- resumes execution, sets temp breakpoint at <address> (F5)\n"
+		"  ge[x] [<exception>] -- resumes execution, setting temp breakpoint if <exception> is raised\n"
 		"  gi[nt] [<irqline>] -- resumes execution, setting temp breakpoint if <irqline> is taken (F7)\n"
 		"  gt[ime] <milliseconds> -- resumes execution until the given delay has elapsed\n"
 		"  gv[blank] -- resumes execution, setting temp breakpoint on the next VBLANK (F8)\n"


### PR DESCRIPTION
The underlying implementation was already in place, but there was no command to access it, so this is fairly straightforward. I think the only contentious part might be the exact naming/syntax of the command itself, so feel free to adjust to suit taste. Functionality itself was verified and working nicely with InterPro.