### PR TITLE
debugger: make save/load support virtual memory (nw)

### DIFF
--- a/src/emu/debug/debugcmd.cpp
+++ b/src/emu/debug/debugcmd.cpp
@@ -1802,29 +1802,37 @@ void debugger_commands::execute_save(int ref, const std::vector<std::string> &pa
 	case -3:
 		for (offs_t i = offset; i != endoffset; i++)
 		{
-			u64 data = space->read_qword(i);
+			offs_t curaddr = i;
+			u64 data = space->device().memory().translate(space->spacenum(), TRANSLATE_READ_DEBUG, curaddr) ?
+				space->read_qword(curaddr) : space->unmap();
 			fwrite(&data, 8, 1, f);
 		}
 		break;
 	case -2:
 		for (offs_t i = offset; i != endoffset; i++)
 		{
-			u32 data = space->read_dword(i);
+			offs_t curaddr = i;
+			u32 data = space->device().memory().translate(space->spacenum(), TRANSLATE_READ_DEBUG, curaddr) ?
+				space->read_dword(curaddr) : space->unmap();
 			fwrite(&data, 4, 1, f);
 		}
 		break;
 	case -1:
 		for (offs_t i = offset; i != endoffset; i++)
 		{
-			u16 byte = space->read_word(i);
-			fwrite(&byte, 2, 1, f);
+			offs_t curaddr = i;
+			u16 data = space->device().memory().translate(space->spacenum(), TRANSLATE_READ_DEBUG, curaddr) ?
+				space->read_word(curaddr) : space->unmap();
+			fwrite(&data, 2, 1, f);
 		}
 		break;
 	case  0:
 		for (offs_t i = offset; i != endoffset; i++)
 		{
-			u8 byte = space->read_byte(i);
-			fwrite(&byte, 1, 1, f);
+			offs_t curaddr = i;
+			u8 data = space->device().memory().translate(space->spacenum(), TRANSLATE_READ_DEBUG, curaddr) ?
+				space->read_byte(curaddr) : space->unmap();
+			fwrite(&data, 1, 1, f);
 		}
 		break;
 	case  3:
@@ -1832,8 +1840,10 @@ void debugger_commands::execute_save(int ref, const std::vector<std::string> &pa
 		endoffset &= ~15;
 		for (offs_t i = offset; i != endoffset; i+=16)
 		{
-			u16 byte = space->read_word(i >> 4);
-			fwrite(&byte, 2, 1, f);
+			offs_t curaddr = i >> 4;
+			u16 data = space->device().memory().translate(space->spacenum(), TRANSLATE_READ_DEBUG, curaddr) ?
+				space->read_word(curaddr) : space->unmap();
+			fwrite(&data, 2, 1, f);
 		}
 		break;
 	}
@@ -1892,37 +1902,41 @@ void debugger_commands::execute_load(int ref, const std::vector<std::string> &pa
 	case -3:
 		for (i = offset; f.good() && (i <= endoffset || endoffset == offset - 1); i++)
 		{
+			offs_t curaddr = i;
 			u64 data;
 			f.read((char *)&data, 8);
-			if (f)
-				space->write_qword(i, data);
+			if (f && space->device().memory().translate(space->spacenum(), TRANSLATE_WRITE_DEBUG, curaddr))
+				space->write_qword(curaddr, data);
 		}
 		break;
 	case -2:
 		for (i = offset; f.good() && (i <= endoffset || endoffset == offset - 1); i++)
 		{
+			offs_t curaddr = i;
 			u32 data;
 			f.read((char *)&data, 4);
-			if (f)
-				space->write_dword(i, data);
+			if (f && space->device().memory().translate(space->spacenum(), TRANSLATE_WRITE_DEBUG, curaddr))
+				space->write_dword(curaddr, data);
 		}
 		break;
 	case -1:
 		for (i = offset; f.good() && (i <= endoffset || endoffset == offset - 1); i++)
 		{
+			offs_t curaddr = i;
 			u16 data;
 			f.read((char *)&data, 2);
-			if (f)
-				space->write_word(i, data);
+			if (f && space->device().memory().translate(space->spacenum(), TRANSLATE_WRITE_DEBUG, curaddr))
+				space->write_word(curaddr, data);
 		}
 		break;
 	case  0:
 		for (i = offset; f.good() && (i <= endoffset || endoffset == offset - 1); i++)
 		{
+			offs_t curaddr = i;
 			u8 data;
 			f.read((char *)&data, 1);
-			if (f)
-				space->write_byte(i, data);
+			if (f && space->device().memory().translate(space->spacenum(), TRANSLATE_WRITE_DEBUG, curaddr))
+				space->write_byte(curaddr, data);
 		}
 		break;
 	case  3:
@@ -1930,10 +1944,11 @@ void debugger_commands::execute_load(int ref, const std::vector<std::string> &pa
 		endoffset &= ~15;
 		for (i = offset; f.good() && (i <= endoffset || endoffset == offset - 16); i+=16)
 		{
+			offs_t curaddr = i >> 4;
 			u16 data;
 			f.read((char *)&data, 2);
-			if (f)
-				space->write_word(i >> 4, data);
+			if (f && space->device().memory().translate(space->spacenum(), TRANSLATE_WRITE_DEBUG, curaddr))
+				space->write_word(curaddr, data);
 		}
 		break;
 	}


### PR DESCRIPTION
This makes these commands useful and consistent with dump in a virtual memory environment. One minor issue is what to do with save for an unmapped memory address: the approach taken here is to write the space.unmap() value, which seems the least harmful. On load, unmapped addresses are not written to, meaning that save/load with a constant address map work as expected.