### PR TITLE
6840ptm: fix divide by 8 mode

### DIFF
--- a/src/devices/machine/6840ptm.cpp
+++ b/src/devices/machine/6840ptm.cpp
@@ -307,6 +307,10 @@ uint16_t ptm6840_device::compute_counter( int counter ) const
 	else
 	{
 		clk = m_external_clock[counter];
+		if (counter == 2)
+		{
+			clk /= m_t3_divisor;
+		}
 		LOG("Timer #%d external clock freq %f \n", counter + 1, clk);
 	}
 	// See how many are left


### PR DESCRIPTION
In divide by 8 mode the value computed in compute_counter()
is wrong because the function doesn't divide the clock before
the calculation.

Signed-off-by: Sven Schnelle <svens@stackframe.org>