### PR TITLE
hp9k_3xx: fix HIL clock frequency (nw)

### DIFF
--- a/src/mame/drivers/hp9k_3xx.cpp
+++ b/src/mame/drivers/hp9k_3xx.cpp
@@ -470,7 +470,7 @@ MACHINE_CONFIG_START(hp9k3xx_state::hp9k300)
 	MCFG_MCS48_PORT_P1_IN_CB(READ8(*this, hp9k3xx_state, iocpu_port1_r))
 	MCFG_MCS48_PORT_T0_IN_CB(READ8(*this, hp9k3xx_state, iocpu_test0_r))
 
-	MCFG_DEVICE_ADD(m_mlc, HP_HIL_MLC, XTAL(15'920'000)/2)
+	MCFG_DEVICE_ADD(m_mlc, HP_HIL_MLC, XTAL(8'000'000))
 	MCFG_HP_HIL_SLOT_ADD(MLC_TAG, "hil1", hp_hil_devices, "hp_46021a")
 
 	MCFG_DEVICE_ADD(PTM6840_TAG, PTM6840, 250000) // from oscillator module next to the 6840


### PR DESCRIPTION
The clock frequency is actually 8MHz.