### PR TITLE
315_5124.cpp updates

### DIFF
--- a/src/devices/video/315_5124.cpp
+++ b/src/devices/video/315_5124.cpp
@@ -670,7 +670,7 @@ void sega315_5124_device::check_pending_flags()
 		m_pending_status &= ~STATUS_SPROVR;
 		m_status |= STATUS_SPROVR;
 		// copy and reset the pending bits that were based on the number
-		// of the sprite that collided.
+		// of the first sprite that overflowed.
 		m_status &= m_pending_status | (STATUS_VINT | STATUS_SPROVR | STATUS_SPRCOL);
 		m_pending_status |= ~(STATUS_VINT | STATUS_SPROVR | STATUS_SPRCOL);
 	}

--- a/src/devices/video/315_5124.cpp
+++ b/src/devices/video/315_5124.cpp
@@ -613,7 +613,7 @@ void sega315_5124_device::process_line_timer()
 
 READ8_MEMBER( sega315_5124_device::data_read )
 {
-	/* Return read buffer contents */
+	/* Return data buffer contents */
 	const uint8_t temp = m_buffer;
 
 	/* Clear pending write flag */
@@ -669,6 +669,8 @@ void sega315_5124_device::check_pending_flags()
 	{
 		m_pending_status &= ~STATUS_SPROVR;
 		m_status |= STATUS_SPROVR;
+		// copy and reset the pending bits that were based on the number
+		// of the sprite that collided.
 		m_status &= m_pending_status | (STATUS_VINT | STATUS_SPROVR | STATUS_SPRCOL);
 		m_pending_status |= ~(STATUS_VINT | STATUS_SPROVR | STATUS_SPRCOL);
 	}
@@ -912,7 +914,7 @@ void sega315_5124_device::draw_column0_x_scroll_mode4(int *line_buffer, int *pri
 {
 	// To draw the leftmost column when it is incomplete on screen due to
 	// scrolling, Sega Master System has a weird behaviour to select which
-	// palette will be selected to obtain the color in entry 0, that depends
+	// palette will be used to obtain the color in entry 0, that depends
 	// on the content of sprite 0.
 	// This implementation mimics the behaviour of the Emulicious emulator,
 	// seen with the test ROM provided by sverx here:

--- a/src/devices/video/315_5124.h
+++ b/src/devices/video/315_5124.h
@@ -23,7 +23,7 @@
 
 DECLARE_DEVICE_TYPE(SEGA315_5124, sega315_5124_device)      /* aka SMS1 vdp */
 DECLARE_DEVICE_TYPE(SEGA315_5246, sega315_5246_device)      /* aka SMS2 vdp */
-DECLARE_DEVICE_TYPE(SEGA315_5378, sega315_5378_device)      /* aka Gamegear vdp */
+DECLARE_DEVICE_TYPE(SEGA315_5377, sega315_5377_device)      /* aka Gamegear (2 ASIC version) vdp */
 
 
 class sega315_5124_device : public device_t,
@@ -52,6 +52,7 @@ public:
 
 	// construction/destruction
 	sega315_5124_device(const machine_config &mconfig, const char *tag, device_t *owner, uint32_t clock);
+	sega315_5124_device(const machine_config &mconfig, device_type type, const char *tag, device_t *owner, uint32_t clock, uint8_t cram_size, uint8_t palette_offset, bool supports_224_240, int max_sprite_zoom_hcount, int max_sprite_zoom_vcount, bool sprcol_is_fixed_pos, const uint8_t *line_timing);
 
 	void set_signal_type(bool is_pal) { m_is_pal = is_pal; }
 
@@ -59,10 +60,10 @@ public:
 	template <class Object> devcb_base &set_csync_callback(Object &&cb) { return m_csync_cb.set_callback(std::forward<Object>(cb)); }
 	template <class Object> devcb_base &set_pause_callback(Object &&cb) { return m_pause_cb.set_callback(std::forward<Object>(cb)); }
 
-	DECLARE_READ8_MEMBER( vram_read );
-	DECLARE_WRITE8_MEMBER( vram_write );
-	DECLARE_READ8_MEMBER( register_read );
-	DECLARE_WRITE8_MEMBER( register_write );
+	DECLARE_READ8_MEMBER( data_read );
+	DECLARE_WRITE8_MEMBER( data_write );
+	DECLARE_READ8_MEMBER( control_read );
+	DECLARE_WRITE8_MEMBER( control_write );
 	DECLARE_READ8_MEMBER( vcount_read );
 	DECLARE_READ8_MEMBER( hcount_read );
 
@@ -82,11 +83,9 @@ public:
 
 	void sega315_5124(address_map &map);
 protected:
-	static constexpr unsigned SEGA315_5378_CRAM_SIZE        = 0x40; /* 32 colors x 2 bytes per color = 64 bytes */
+	static constexpr unsigned SEGA315_5377_CRAM_SIZE        = 0x40; /* 32 colors x 2 bytes per color = 64 bytes */
 	static constexpr unsigned SEGA315_5124_CRAM_SIZE        = 0x20; /* 32 colors x 1 bytes per color = 32 bytes */
 
-
-	sega315_5124_device(const machine_config &mconfig, device_type type, const char *tag, device_t *owner, uint32_t clock, uint8_t cram_size, uint8_t palette_offset, bool supports_224_240);
 
 	// device-level overrides
 	virtual void device_start() override;
@@ -100,15 +99,21 @@ protected:
 	void set_frame_timing();
 	virtual void update_palette();
 	virtual void cram_write(uint8_t data);
+	virtual void load_vram_addr(uint8_t data);
+	virtual bool data_port_write_loads_data_buffer() { return false; };
 	virtual void draw_scanline(int pixel_offset_x, int pixel_plot_y, int line);
 	virtual void blit_scanline(int *line_buffer, int *priority_selected, int pixel_offset_x, int pixel_plot_y, int line);
-	virtual uint16_t get_name_table_row(int row);
+	virtual uint16_t mode4_name_table_row(int row);
+	virtual uint16_t mode4_sprite_attributes_addr(uint16_t base);
+	virtual uint8_t mode4_sprite_tile_mask(uint8_t tile_number);
 	void process_line_timer();
 	void select_sprites(int line);
 	void draw_scanline_mode4(int *line_buffer, int *priority_selected, int line);
 	void draw_sprites_mode4(int *line_buffer, int *priority_selected, int line);
 	void draw_sprites_tms9918_mode(int *line_buffer, int line);
+	void draw_scanline_mode3(int *line_buffer, int line);
 	void draw_scanline_mode2(int *line_buffer, int line);
+	void draw_scanline_mode1(int *line_buffer, int line);
 	void draw_scanline_mode0(int *line_buffer, int line);
 	void check_pending_flags();
 
@@ -123,10 +128,13 @@ protected:
 	uint16_t           m_addr;                     /* Contents of internal VDP address register */
 	const uint8_t      m_cram_size;                /* CRAM size */
 	uint8_t            m_cram_mask;                /* Mask to switch between SMS and GG CRAM sizes */
-	int              m_cram_dirty;               /* Have there been any changes to the CRAM area */
-	int              m_pending_reg_write;
-	int              m_pending_sprcol_x;
+	bool               m_cram_dirty;               /* Have there been any changes to the CRAM area */
+	bool               m_hint_occurred;
+	bool               m_pending_hint;
+	bool               m_pending_control_write;
+	int                m_pending_sprcol_x;
 	uint8_t            m_buffer;
+	uint8_t            m_control_write_data_latch;
 	bool             m_sega315_5124_compatibility_mode;    /* when true, GG VDP behaves as SMS VDP */
 	int              m_irq_state;                /* The status of the IRQ line of the VDP */
 	int              m_vdp_mode;                 /* Current mode of the VDP: 0,1,2,3,4 */
@@ -134,12 +142,14 @@ protected:
 	int              m_draw_time;
 	uint8_t            m_line_counter;
 	uint8_t            m_hcounter;
-	uint8_t            m_CRAM[SEGA315_5378_CRAM_SIZE];  /* CRAM */
+	uint8_t            m_CRAM[SEGA315_5377_CRAM_SIZE];  /* CRAM */
 	const uint8_t      *m_frame_timing;
+	const uint8_t      *m_line_timing;
 	bitmap_rgb32     m_tmpbitmap;
 	bitmap_ind8      m_y1_bitmap;
 	const uint8_t      m_palette_offset;
 	const bool       m_supports_224_240;
+	const bool       m_sprcol_is_fixed_pos;
 	bool             m_display_disabled;
 	uint16_t           m_sprite_base;
 	uint16_t           m_sprite_pattern_line[8];
@@ -148,7 +158,9 @@ protected:
 	uint8_t            m_sprite_flags[8];
 	int              m_sprite_count;
 	int              m_sprite_height;
-	int              m_sprite_zoom;
+	int              m_sprite_zoom_scale;
+	int              m_max_sprite_zoom_hcount;
+	int              m_max_sprite_zoom_vcount;
 	int              m_current_palette[32];
 	bool             m_is_pal;             /* false = NTSC, true = PAL */
 	devcb_write_line m_int_cb;       /* Interrupt callback function */
@@ -183,16 +195,21 @@ class sega315_5246_device : public sega315_5124_device
 {
 public:
 	sega315_5246_device(const machine_config &mconfig, const char *tag, device_t *owner, uint32_t clock);
+	sega315_5246_device(const machine_config &mconfig, device_type type, const char *tag, device_t *owner, uint32_t clock, uint8_t cram_size, uint8_t palette_offset, bool supports_224_240, int max_sprite_zoom_hcount, int max_sprite_zoom_vcount, bool sprcol_is_fixed_pos, const uint8_t *line_timing);
 
 protected:
-	virtual uint16_t get_name_table_row(int row) override;
+	virtual void load_vram_addr(uint8_t data) override;
+	virtual bool data_port_write_loads_data_buffer() override { return true; };
+	virtual uint16_t mode4_name_table_row(int row) override;
+	virtual uint16_t mode4_sprite_attributes_addr(uint16_t base) override;
+	virtual uint8_t mode4_sprite_tile_mask(uint8_t tile_number) override;
 };
 
 
-class sega315_5378_device : public sega315_5124_device
+class sega315_5377_device : public sega315_5246_device
 {
 public:
-	sega315_5378_device(const machine_config &mconfig, const char *tag, device_t *owner, uint32_t clock);
+	sega315_5377_device(const machine_config &mconfig, const char *tag, device_t *owner, uint32_t clock);
 
 	virtual void set_sega315_5124_compatibility_mode(bool sega315_5124_compatibility_mode) override;
 
@@ -203,10 +220,9 @@ protected:
 	virtual void update_palette() override;
 	virtual void cram_write(uint8_t data) override;
 	virtual void blit_scanline( int *line_buffer, int *priority_selected, int pixel_offset_x, int pixel_plot_y, int line ) override;
-	virtual uint16_t get_name_table_row(int row) override;
 
 private:
-	DECLARE_PALETTE_INIT( sega315_5378 );
+	DECLARE_PALETTE_INIT( sega315_5377 );
 };
 
 
@@ -244,11 +260,12 @@ private:
 	downcast<sega315_5246_device &>(*device).set_pause_callback(DEVCB_##_devcb);
 
 
-#define MCFG_SEGA315_5378_SET_SCREEN MCFG_VIDEO_SET_SCREEN
+#define MCFG_SEGA315_5377_SET_SCREEN MCFG_VIDEO_SET_SCREEN
 
-#define MCFG_SEGA315_5378_IS_PAL(_bool) \
-	downcast<sega315_5378_device &>(*device).set_signal_type(_bool);
+#define MCFG_SEGA315_5377_IS_PAL(_bool) \
+	downcast<sega315_5377_device &>(*device).set_signal_type(_bool);
 
+<<<<<<< HEAD
 #define MCFG_SEGA315_5378_INT_CB(_devcb) \
 	downcast<sega315_5378_device &>(*device).set_int_callback(DEVCB_##_devcb);
 
@@ -257,6 +274,16 @@ private:
 
 #define MCFG_SEGA315_5378_PAUSE_CB(_devcb) \
 	downcast<sega315_5378_device &>(*device).set_pause_callback(DEVCB_##_devcb);
+=======
+#define MCFG_SEGA315_5377_INT_CB(_devcb) \
+	downcast<sega315_5377_device &>(*device).set_int_callback(DEVCB_##_devcb);
+
+#define MCFG_SEGA315_5377_CSYNC_CB(_devcb) \
+	downcast<sega315_5377_device &>(*device).set_csync_callback(DEVCB_##_devcb);
+
+#define MCFG_SEGA315_5377_PAUSE_CB(_devcb) \
+	downcast<sega315_5377_device &>(*device).set_pause_callback(DEVCB_##_devcb);
+>>>>>>> 6db16bcc7e... 315_5124.cpp updates
 
 
 #endif // MAME_VIDEO_315_5124_H

--- a/src/devices/video/315_5124.h
+++ b/src/devices/video/315_5124.h
@@ -289,16 +289,6 @@ protected:
 #define MCFG_SEGA315_5377_IS_PAL(_bool) \
 	downcast<sega315_5377_device &>(*device).set_signal_type(_bool);
 
-<<<<<<< HEAD
-#define MCFG_SEGA315_5378_INT_CB(_devcb) \
-	downcast<sega315_5378_device &>(*device).set_int_callback(DEVCB_##_devcb);
-
-#define MCFG_SEGA315_5378_CSYNC_CB(_devcb) \
-	downcast<sega315_5378_device &>(*device).set_csync_callback(DEVCB_##_devcb);
-
-#define MCFG_SEGA315_5378_PAUSE_CB(_devcb) \
-	downcast<sega315_5378_device &>(*device).set_pause_callback(DEVCB_##_devcb);
-=======
 #define MCFG_SEGA315_5377_INT_CB(_devcb) \
 	downcast<sega315_5377_device &>(*device).set_int_callback(DEVCB_##_devcb);
 
@@ -307,7 +297,6 @@ protected:
 
 #define MCFG_SEGA315_5377_PAUSE_CB(_devcb) \
 	downcast<sega315_5377_device &>(*device).set_pause_callback(DEVCB_##_devcb);
->>>>>>> 6db16bcc7e... 315_5124.cpp updates
 
 
 #endif // MAME_VIDEO_315_5124_H

--- a/src/devices/video/315_5313.cpp
+++ b/src/devices/video/315_5313.cpp
@@ -142,7 +142,7 @@
 #define MEGADRIVE_REG17_DMATYPE         ((m_regs[0x17]&0xc0)>>6)
 #define MEGADRIVE_REG17_UNUSED          ((m_regs[0x17]&0x3f)>>0)
 
-static constexpr uint8_t line_315_5124[8] = {
+static constexpr uint8_t line_315_5313_mode4[8] = {
 			  26 /* VINT_HPOS */
 			, 26 /* VINT_FLAG_HPOS */
 			, 27 /* HINT_HPOS */
@@ -159,7 +159,8 @@ static constexpr uint8_t line_315_5124[8] = {
 DEFINE_DEVICE_TYPE(SEGA315_5313, sega315_5313_device, "sega315_5313", "Sega 315-5313 Megadrive VDP")
 
 sega315_5313_device::sega315_5313_device(const machine_config &mconfig, const char *tag, device_t *owner, uint32_t clock)
-	: sega315_5124_device(mconfig, SEGA315_5313, tag, owner, clock, SEGA315_5124_CRAM_SIZE, 0, false, 0, 0, true, line_315_5124)
+	// mode 4 support, for SMS compatibility, is implemented in 315_5124.cpp
+	: sega315_5313_mode4_device(mconfig, SEGA315_5313, tag, owner, clock, SEGA315_5124_CRAM_SIZE, 0x00, 0x1f, 0, 0, line_315_5313_mode4)
 	, device_mixer_interface(mconfig, *this, 2)
 	, m_render_bitmap(nullptr)
 	, m_render_line(nullptr)
@@ -332,7 +333,7 @@ void sega315_5313_device::device_start()
 
 	m_space68k = &m_cpu68k->space();
 
-	sega315_5124_device::device_start();
+	sega315_5313_mode4_device::device_start();
 }
 
 void sega315_5313_device::device_reset()
@@ -354,7 +355,7 @@ void sega315_5313_device::device_reset()
 	m_vblank_flag = 0;
 	m_total_scanlines = 262;
 
-	sega315_5124_device::device_reset();
+	sega315_5313_mode4_device::device_reset();
 }
 
 void sega315_5313_device::device_reset_old()

--- a/src/devices/video/315_5313.cpp
+++ b/src/devices/video/315_5313.cpp
@@ -142,6 +142,16 @@
 #define MEGADRIVE_REG17_DMATYPE         ((m_regs[0x17]&0xc0)>>6)
 #define MEGADRIVE_REG17_UNUSED          ((m_regs[0x17]&0x3f)>>0)
 
+static constexpr uint8_t line_315_5124[8] = {
+			  26 /* VINT_HPOS */
+			, 26 /* VINT_FLAG_HPOS */
+			, 27 /* HINT_HPOS */
+			, 28 /* NMI_HPOS, not verified */
+			, 25 /* XSCROLL_HPOS */
+			, 28 /* VCOUNT_CHANGE_HPOS */
+			, 26 /* SPROVR_HPOS */
+			, 37 /* SPRCOL_BASEHPOS */
+		};
 
 #define MAX_HPOSITION 480
 
@@ -149,7 +159,7 @@
 DEFINE_DEVICE_TYPE(SEGA315_5313, sega315_5313_device, "sega315_5313", "Sega 315-5313 Megadrive VDP")
 
 sega315_5313_device::sega315_5313_device(const machine_config &mconfig, const char *tag, device_t *owner, uint32_t clock)
-	: sega315_5124_device(mconfig, SEGA315_5313, tag, owner, clock, SEGA315_5124_CRAM_SIZE, 0, true)
+	: sega315_5124_device(mconfig, SEGA315_5313, tag, owner, clock, SEGA315_5124_CRAM_SIZE, 0, false, 0, 0, true, line_315_5124)
 	, device_mixer_interface(mconfig, *this, 2)
 	, m_render_bitmap(nullptr)
 	, m_render_line(nullptr)

--- a/src/devices/video/315_5313.h
+++ b/src/devices/video/315_5313.h
@@ -51,7 +51,7 @@
 	downcast<sega315_5313_device &>(*device).set_md_32x_scanline_helper(sega315_5313_device::md_32x_scanline_helper_delegate(&_class::_method, #_class "::" #_method, this));
 
 
-class sega315_5313_device : public sega315_5124_device, public device_mixer_interface
+class sega315_5313_device : public sega315_5313_mode4_device, public device_mixer_interface
 {
 public:
 	template <typename T>

--- a/src/mame/drivers/megaplay.cpp
+++ b/src/mame/drivers/megaplay.cpp
@@ -620,8 +620,8 @@ void mplay_state::megaplay_bios_io_map(address_map &map)
 	map(0x7f, 0x7f).w("sn2", FUNC(sn76496_device::command_w));
 
 	map(0x40, 0x41).mirror(0x3e).r(FUNC(mplay_state::vdp1_count_r));
-	map(0x80, 0x80).mirror(0x3e).rw(m_vdp1, FUNC(sega315_5124_device::vram_read), FUNC(sega315_5124_device::vram_write));
-	map(0x81, 0x81).mirror(0x3e).rw(m_vdp1, FUNC(sega315_5124_device::register_read), FUNC(sega315_5124_device::register_write));
+	map(0x80, 0x80).mirror(0x3e).rw(m_vdp1, FUNC(sega315_5124_device::data_read), FUNC(sega315_5124_device::data_write));
+	map(0x81, 0x81).mirror(0x3e).rw(m_vdp1, FUNC(sega315_5124_device::control_read), FUNC(sega315_5124_device::control_write));
 }
 
 

--- a/src/mame/drivers/megatech.cpp
+++ b/src/mame/drivers/megatech.cpp
@@ -395,8 +395,8 @@ void mtech_state::set_genz80_as_sms()
 	// ports
 	io.install_read_handler      (0x40, 0x41, 0, 0x3e, 0, read8_delegate(FUNC(mtech_state::sms_count_r),this));
 	io.install_write_handler     (0x40, 0x41, 0, 0x3e, 0, write8_delegate(FUNC(mtech_state::sms_sn_w),this));
-	io.install_readwrite_handler (0x80, 0x80, 0, 0x3e, 0, read8_delegate(FUNC(sega315_5124_device::vram_read),(sega315_5124_device *)m_vdp), write8_delegate(FUNC(sega315_5124_device::vram_write),(sega315_5124_device *)m_vdp));
-	io.install_readwrite_handler (0x81, 0x81, 0, 0x3e, 0, read8_delegate(FUNC(sega315_5124_device::register_read),(sega315_5124_device *)m_vdp), write8_delegate(FUNC(sega315_5124_device::register_write),(sega315_5124_device *)m_vdp));
+	io.install_readwrite_handler (0x80, 0x80, 0, 0x3e, 0, read8_delegate(FUNC(sega315_5124_device::data_read),(sega315_5124_device *)m_vdp), write8_delegate(FUNC(sega315_5124_device::data_write),(sega315_5124_device *)m_vdp));
+	io.install_readwrite_handler (0x81, 0x81, 0, 0x3e, 0, read8_delegate(FUNC(sega315_5124_device::control_read),(sega315_5124_device *)m_vdp), write8_delegate(FUNC(sega315_5124_device::control_write),(sega315_5124_device *)m_vdp));
 
 	io.install_read_handler      (0x10, 0x10, read8_delegate(FUNC(mtech_state::sms_ioport_dd_r),this)); // super tetris
 
@@ -595,8 +595,8 @@ void mtech_state::megatech_bios_portmap(address_map &map)
 	map(0x7f, 0x7f).w(FUNC(mtech_state::bios_port_7f_w));
 
 	map(0x40, 0x41).mirror(0x3e).r(FUNC(mtech_state::vdp1_count_r));
-	map(0x80, 0x80).mirror(0x3e).rw(m_vdp1, FUNC(sega315_5124_device::vram_read), FUNC(sega315_5124_device::vram_write));
-	map(0x81, 0x81).mirror(0x3e).rw(m_vdp1, FUNC(sega315_5124_device::register_read), FUNC(sega315_5124_device::register_write));
+	map(0x80, 0x80).mirror(0x3e).rw(m_vdp1, FUNC(sega315_5124_device::data_read), FUNC(sega315_5124_device::data_write));
+	map(0x81, 0x81).mirror(0x3e).rw(m_vdp1, FUNC(sega315_5124_device::control_read), FUNC(sega315_5124_device::control_write));
 
 	map(0xdc, 0xdd).r(FUNC(mtech_state::bios_joypad_r));  // player inputs
 }

--- a/src/mame/drivers/segae.cpp
+++ b/src/mame/drivers/segae.cpp
@@ -412,10 +412,10 @@ void systeme_state::io_map(address_map &map)
 	map(0x7b, 0x7b).w("sn1", FUNC(segapsg_device::command_w));
 	map(0x7e, 0x7f).w("sn2", FUNC(segapsg_device::command_w));
 	map(0x7e, 0x7e).r(m_vdp1, FUNC(sega315_5124_device::vcount_read));
-	map(0xba, 0xba).rw(m_vdp1, FUNC(sega315_5124_device::vram_read), FUNC(sega315_5124_device::vram_write));
-	map(0xbb, 0xbb).rw(m_vdp1, FUNC(sega315_5124_device::register_read), FUNC(sega315_5124_device::register_write));
-	map(0xbe, 0xbe).rw(m_vdp2, FUNC(sega315_5124_device::vram_read), FUNC(sega315_5124_device::vram_write));
-	map(0xbf, 0xbf).rw(m_vdp2, FUNC(sega315_5124_device::register_read), FUNC(sega315_5124_device::register_write));
+	map(0xba, 0xba).rw(m_vdp1, FUNC(sega315_5124_device::data_read), FUNC(sega315_5124_device::data_write));
+	map(0xbb, 0xbb).rw(m_vdp1, FUNC(sega315_5124_device::control_read), FUNC(sega315_5124_device::control_write));
+	map(0xbe, 0xbe).rw(m_vdp2, FUNC(sega315_5124_device::data_read), FUNC(sega315_5124_device::data_write));
+	map(0xbf, 0xbf).rw(m_vdp2, FUNC(sega315_5124_device::control_read), FUNC(sega315_5124_device::control_write));
 	map(0xe0, 0xe0).portr("e0");
 	map(0xe1, 0xe1).portr("e1");
 	map(0xe2, 0xe2).portr("e2");

--- a/src/mame/drivers/sms.cpp
+++ b/src/mame/drivers/sms.cpp
@@ -302,8 +302,8 @@ void sms_state::sg1000m3_io(address_map &map)
 	map.global_mask(0xff);
 	map.unmap_value_high();
 	map(0x40, 0x7f).rw(FUNC(sms_state::sms_count_r), FUNC(sms_state::sms_psg_w));
-	map(0x80, 0x80).mirror(0x3e).rw(m_vdp, FUNC(sega315_5124_device::vram_read), FUNC(sega315_5124_device::vram_write));
-	map(0x81, 0x81).mirror(0x3e).rw(m_vdp, FUNC(sega315_5124_device::register_read), FUNC(sega315_5124_device::register_write));
+	map(0x80, 0x80).mirror(0x3e).rw(m_vdp, FUNC(sega315_5124_device::data_read), FUNC(sega315_5124_device::data_write));
+	map(0x81, 0x81).mirror(0x3e).rw(m_vdp, FUNC(sega315_5124_device::control_read), FUNC(sega315_5124_device::control_write));
 	map(0xc0, 0xc7).mirror(0x38).rw(FUNC(sms_state::sg1000m3_peripheral_r), FUNC(sms_state::sg1000m3_peripheral_w));
 }
 
@@ -314,8 +314,8 @@ void sms_state::sms_io(address_map &map)
 	map(0x00, 0x00).mirror(0x3e).w(FUNC(sms_state::sms_mem_control_w));
 	map(0x01, 0x01).mirror(0x3e).w(FUNC(sms_state::sms_io_control_w));
 	map(0x40, 0x7f).rw(FUNC(sms_state::sms_count_r), FUNC(sms_state::sms_psg_w));
-	map(0x80, 0x80).mirror(0x3e).rw(m_vdp, FUNC(sega315_5124_device::vram_read), FUNC(sega315_5124_device::vram_write));
-	map(0x81, 0x81).mirror(0x3e).rw(m_vdp, FUNC(sega315_5124_device::register_read), FUNC(sega315_5124_device::register_write));
+	map(0x80, 0x80).mirror(0x3e).rw(m_vdp, FUNC(sega315_5124_device::data_read), FUNC(sega315_5124_device::data_write));
+	map(0x81, 0x81).mirror(0x3e).rw(m_vdp, FUNC(sega315_5124_device::control_read), FUNC(sega315_5124_device::control_write));
 	map(0xc0, 0xc0).mirror(0x3e).r(FUNC(sms_state::sms_input_port_dc_r));
 	map(0xc1, 0xc1).mirror(0x3e).r(FUNC(sms_state::sms_input_port_dd_r));
 }
@@ -332,8 +332,8 @@ void sms_state::smskr_io(address_map &map)
 	map(0x3e, 0x3e).w(FUNC(sms_state::sms_mem_control_w));
 	map(0x3f, 0x3f).w(FUNC(sms_state::sms_io_control_w));
 	map(0x40, 0x7f).rw(FUNC(sms_state::sms_count_r), FUNC(sms_state::sms_psg_w));
-	map(0x80, 0x80).mirror(0x3e).rw(m_vdp, FUNC(sega315_5124_device::vram_read), FUNC(sega315_5124_device::vram_write));
-	map(0x81, 0x81).mirror(0x3e).rw(m_vdp, FUNC(sega315_5124_device::register_read), FUNC(sega315_5124_device::register_write));
+	map(0x80, 0x80).mirror(0x3e).rw(m_vdp, FUNC(sega315_5124_device::data_read), FUNC(sega315_5124_device::data_write));
+	map(0x81, 0x81).mirror(0x3e).rw(m_vdp, FUNC(sega315_5124_device::control_read), FUNC(sega315_5124_device::control_write));
 	map(0xc0, 0xc0).mirror(0x3e).r(FUNC(sms_state::sms_input_port_dc_r));
 	map(0xc1, 0xc1).mirror(0x3e).r(FUNC(sms_state::sms_input_port_dd_r));
 }
@@ -348,8 +348,8 @@ void sms_state::smsj_io(address_map &map)
 	map(0x3e, 0x3e).w(FUNC(sms_state::sms_mem_control_w));
 	map(0x3f, 0x3f).w(FUNC(sms_state::sms_io_control_w));
 	map(0x40, 0x7f).rw(FUNC(sms_state::sms_count_r), FUNC(sms_state::sms_psg_w));
-	map(0x80, 0x80).mirror(0x3e).rw(m_vdp, FUNC(sega315_5124_device::vram_read), FUNC(sega315_5124_device::vram_write));
-	map(0x81, 0x81).mirror(0x3e).rw(m_vdp, FUNC(sega315_5124_device::register_read), FUNC(sega315_5124_device::register_write));
+	map(0x80, 0x80).mirror(0x3e).rw(m_vdp, FUNC(sega315_5124_device::data_read), FUNC(sega315_5124_device::data_write));
+	map(0x81, 0x81).mirror(0x3e).rw(m_vdp, FUNC(sega315_5124_device::control_read), FUNC(sega315_5124_device::control_write));
 	map(0xc0, 0xc0).r(FUNC(sms_state::sms_input_port_dc_r));
 	map(0xc1, 0xc1).r(FUNC(sms_state::sms_input_port_dd_r));
 	map(0xdc, 0xdc).r(FUNC(sms_state::sms_input_port_dc_r));
@@ -372,8 +372,8 @@ void sms_state::gg_io(address_map &map)
 	map(0x3e, 0x3e).w(FUNC(sms_state::sms_mem_control_w));
 	map(0x3f, 0x3f).w(FUNC(sms_state::sms_io_control_w));
 	map(0x40, 0x7f).rw(FUNC(sms_state::sms_count_r), FUNC(sms_state::gg_psg_w));
-	map(0x80, 0x80).mirror(0x3e).rw(m_vdp, FUNC(sega315_5124_device::vram_read), FUNC(sega315_5124_device::vram_write));
-	map(0x81, 0x81).mirror(0x3e).rw(m_vdp, FUNC(sega315_5124_device::register_read), FUNC(sega315_5124_device::register_write));
+	map(0x80, 0x80).mirror(0x3e).rw(m_vdp, FUNC(sega315_5124_device::data_read), FUNC(sega315_5124_device::data_write));
+	map(0x81, 0x81).mirror(0x3e).rw(m_vdp, FUNC(sega315_5124_device::control_read), FUNC(sega315_5124_device::control_write));
 	map(0xc0, 0xc0).r(FUNC(sms_state::sms_input_port_dc_r));
 	map(0xc1, 0xc1).r(FUNC(sms_state::sms_input_port_dd_r));
 	map(0xdc, 0xdc).r(FUNC(sms_state::sms_input_port_dc_r));
@@ -992,11 +992,12 @@ MACHINE_CONFIG_START(sms_state::gamegear)
 	MCFG_VIDEO_START_OVERRIDE(sms_state,gamegear)
 	MCFG_VIDEO_RESET_OVERRIDE(sms_state,gamegear)
 
-	MCFG_DEVICE_ADD("sms_vdp", SEGA315_5378, 0)
-	MCFG_SEGA315_5378_SET_SCREEN("screen")
-	MCFG_SEGA315_5378_IS_PAL(false)
-	MCFG_SEGA315_5378_INT_CB(INPUTLINE("maincpu", 0))
-	MCFG_SEGA315_5378_PAUSE_CB(WRITELINE(*this, sms_state, sms_pause_callback))
+	/* VDP chip of the Gamegear 2 ASIC version */
+	MCFG_DEVICE_ADD("sms_vdp", SEGA315_5377, 0)
+	MCFG_SEGA315_5377_SET_SCREEN("screen")
+	MCFG_SEGA315_5377_IS_PAL(false)
+	MCFG_SEGA315_5377_INT_CB(INPUTLINE("maincpu", 0))
+	MCFG_SEGA315_5377_PAUSE_CB(WRITELINE(*this, sms_state, sms_pause_callback))
 
 	/* sound hardware */
 	SPEAKER(config, "lspeaker").front_left();

--- a/src/mame/drivers/sms_bootleg.cpp
+++ b/src/mame/drivers/sms_bootleg.cpp
@@ -265,8 +265,8 @@ void smsbootleg_state::sms_supergame_io(address_map &map)
 	map(0x18, 0x18).w(FUNC(smsbootleg_state::port18_w));
 
 	map(0x40, 0x7f).rw(FUNC(smsbootleg_state::sms_count_r), FUNC(smsbootleg_state::sms_psg_w));
-	map(0x80, 0x80).mirror(0x3e).rw(m_vdp, FUNC(sega315_5124_device::vram_read), FUNC(sega315_5124_device::vram_write));
-	map(0x81, 0x81).mirror(0x3e).rw(m_vdp, FUNC(sega315_5124_device::register_read), FUNC(sega315_5124_device::register_write));
+	map(0x80, 0x80).mirror(0x3e).rw(m_vdp, FUNC(sega315_5124_device::data_read), FUNC(sega315_5124_device::data_write));
+	map(0x81, 0x81).mirror(0x3e).rw(m_vdp, FUNC(sega315_5124_device::control_read), FUNC(sega315_5124_device::control_write));
 
 	map(0xdc, 0xdc).portr("IN2");
 }


### PR DESCRIPTION
- Rename GG VDP from sega315_5378 to sega315_5377 to match maintenance manual
- Created a sega315_5313_mode4_device class to emulate some specific 315-5313 behavior in mode 4
- Derivate sega315_5377 (GG) and sega315_5313_mode4 (MD) from sega315_5246 (SMS2) instead sega315_5124 (SMS1)
- Emulate some specific sega315_5377 timings verified on hardware
- Emulate some sega315_5313_mode4 timings and behavior verified with Flubba's VDP Test
- Emulate bits of the status register for the number of the first sprite that overflows
- Emulate sprite zoom limit of sega315_5124 and sega315_5313 VDPs
- Fix inaccurate scrolling reproduced with Charles' scrolling test
- Improve leftmost column color behaviour in mode 4 when fine scroll is applied
- Implement display modes 1 (text) and 3 (multicolor)
- Rename vram_write()/vram_read() to data_write()/data_read()
- Rename register_write()/register_read() to control_write()/control_read()
- Use "const" and the "BIT" macro where appropriate