### PR TITLE
New amiga dumps

### DIFF
--- a/hash/amiga_apps.xml
+++ b/hash/amiga_apps.xml
@@ -42,7 +42,6 @@
 		</part>
 	</software>
 	
-	<!-- Seems to be using some sort of copy protection or possibly dumped from a faulty disk. -->
 	<software name ="deskbudg">
 		<description>Desktop Budget (Sv)</description>
 		<year>1989</year>
@@ -122,7 +121,7 @@
 		<part name="flop1" interface="floppy_3_5">
 			<feature name="part_id" value="SuperDuper 2.02" />
 			<dataarea name="flop" size="901120">
-				<rom name="superduper 2.02.adf" size="901120" crc="fba10303" sha1="281945a469e0e791ab63c7c4cb5b8ffbb1663095" offset="0"/>
+				<rom name="superduper 2.02.adf" size="901120" crc="fba10303" sha1="281945a469e0e791ab63c7c4cb5b8ffbb1663095" status="baddump" offset="0"/>
 			</dataarea>
 		</part>
 	</software>

--- a/hash/amiga_apps.xml
+++ b/hash/amiga_apps.xml
@@ -15,6 +15,19 @@
 			</dataarea>
 		</part>
 	</software>
+	
+	<!--  -->
+	<software name="appetisv" cloneof="appetide">
+		<description>Amiga Appetizer (Sv)</description>
+		<year>1989</year>
+		<publisher>Gold Disk</publisher>
+		<part name="flop1" interface="floppy_3_5">
+			<feature name="part_id" value="Amiga Appetizer (Sv)" />
+			<dataarea name="flop" size="901120">
+				<rom name="amiga appetizer (sv).adf" size="901120" crc="8be0554b" sha1="0bba0914ea63c8e1c69e55ae502df6add2244d22" offset="0"/>
+			</dataarea>
+		</part>
+	</software>
 
 	<software name="dast11de">
 		<!-- Part of the Amiga Magic Pack -->
@@ -26,6 +39,19 @@
 			<feature name="part_id" value="Datastore 1.1 (De)" />
 			<dataarea name="flop" size="901120">
 				<rom name="datastore11_de.adf" size="901120" crc="8fc8bb62" sha1="05cc8175f2218532ad35b8fbb6c724b4bd0d9c3d" offset="0"/>
+			</dataarea>
+		</part>
+	</software>
+	
+	<!-- Seems to be using some sort of copy protection or possibly dumped from a faulty disk. -->
+	<software name ="deskbudg">
+		<description>Desktop Budget (Sv)</description>
+		<year>1989</year>
+		<publisher>Gold Disk</publisher>
+		<part name="flop1" interface="floppy_3_5">
+			<feature name="part_id" value="Desktop Budget (Sv)" />
+			<dataarea name="flop" size="901120">
+				<rom name="desktop budget (swe).adf" size="901120" crc="d16bca57" sha1="ff650ffb504ffe21ff6fb884f5a1904ddcb47912" status="baddump" offset="0"/>
 			</dataarea>
 		</part>
 	</software>
@@ -86,6 +112,18 @@
 			<feature name="part_id" value="Simplex Tools 2 - RAP!TOP!COP! (De)" />
 			<dataarea name="flop" size="901120">
 				<rom name="simplex_tools_2.adf" size="901120" crc="9d211a17" sha1="a1021a34f6f95adc38021a24aed59300d6a211e6" offset="0"/>
+			</dataarea>
+		</part>
+	</software>
+	
+	<software name ="suprdupr">
+		<description>SuperDuper 2.02</description>
+		<year>19??</year>
+		<publisher>Amitech Denmark</publisher>
+		<part name="flop1" interface="floppy_3_5">
+			<feature name="part_id" value="SuperDuper 2.02" />
+			<dataarea name="flop" size="901120">
+				<rom name="superduper 2.02.adf" size="901120" crc="fba10303" sha1="281945a469e0e791ab63c7c4cb5b8ffbb1663095" offset="0"/>
 			</dataarea>
 		</part>
 	</software>

--- a/hash/amiga_apps.xml
+++ b/hash/amiga_apps.xml
@@ -42,14 +42,14 @@
 		</part>
 	</software>
 	
-	<software name ="deskbudg">
+	<software name="deskbudg">
 		<description>Desktop Budget (Sv)</description>
 		<year>1989</year>
 		<publisher>Gold Disk</publisher>
 		<part name="flop1" interface="floppy_3_5">
 			<feature name="part_id" value="Desktop Budget (Sv)" />
 			<dataarea name="flop" size="901120">
-				<rom name="desktop budget (swe).adf" size="901120" crc="d16bca57" sha1="ff650ffb504ffe21ff6fb884f5a1904ddcb47912" status="baddump" offset="0"/>
+				<rom name="desktop budget (swe).adf" size="901120" crc="d9c1fab6" sha1="ff650ffb504ffe21ff6fb884f5a1904ddcb47912" offset="0"/>
 			</dataarea>
 		</part>
 	</software>
@@ -63,7 +63,7 @@
 			<!-- Verified dump -->
 			<feature name="part_id" value="Organiser 1.1 (De)" />
 			<dataarea name="flop" size="901120">
-				<rom name="organiser11_de.adf" size="901120" crc="0d8ac3ec" sha1="ce0453c1a48a648c968e84a9afe6bfb939d3817c" offset="0"/>
+				<rom name="organiser11_de.adf" size="901120" crc="0d8ac3ec" sha1="013b152b9aa7eff0263d54b85bb107f77b4c4245" offset="0"/>
 			</dataarea>
 		</part>
 	</software>

--- a/hash/amiga_apps.xml
+++ b/hash/amiga_apps.xml
@@ -16,7 +16,6 @@
 		</part>
 	</software>
 	
-	<!--  -->
 	<software name="appetisv" cloneof="appetide">
 		<description>Amiga Appetizer (Sv)</description>
 		<year>1989</year>

--- a/hash/amiga_hardware.xml
+++ b/hash/amiga_hardware.xml
@@ -43,14 +43,15 @@
 		</part>
 	</software>
 
+	<!-- P/N: 317734-04 -->
 	<software name="a590_seagate" cloneof="a590">
-		<description>A590 Setup Disk (Seagate Harddisk)</description>
-		<year>1990</year>
+		<description>A590 Setup Disk 1.23 (Seagate Harddisk)</description>
+		<year>1988</year>
 		<publisher>Commodore</publisher>
 		<part name="flop1" interface="floppy_3_5">
-			<feature name="part_id" value="A590 Setup Disk (Seagate Harddisk)" />
+			<feature name="part_id" value="A590 Setup Disk 1.23 (Seagate Harddisk)" />
 			<dataarea name="flop" size="901120">
-				<rom name="317734-04_a590_seagate.adf" size="901120" status="nodump" offset="0"/>
+				<rom name="317734-04_a590_seagate.adf" size="901120" crc="7f1623a7" sha1="1f3e20206eb83f60745e19538de3123089c8da24" offset="0"/>
 			</dataarea>
 		</part>
 	</software>


### PR DESCRIPTION
I'm separating out all hardware from [#3324](https://github.com/mamedev/mame/pull/3324) so as to make it easier for it to progress.

These are the new Amiga dumps. At least one disk seem to be bad. If anyone can check out the Kryoflux archives below to find the problem (copy protection? faulty disk?) that'd be great :smile_cat: 

https://archive.org/details/590SetupDiskSeagateHarddiskAmiga.7z
https://archive.org/details/AmigaAppetizerAmiga.7z
https://archive.org/details/DesktopBudgetAmiga.7z
https://archive.org/details/SuperDuperAmiga.7z