### PR TITLE
unico.cpp : Variable cleanups

### DIFF
--- a/src/mame/drivers/unico.cpp
+++ b/src/mame/drivers/unico.cpp
@@ -47,7 +47,7 @@ Year + Game         PCB             Notes
                                 Burglar X
 ***************************************************************************/
 
-WRITE8_MEMBER(unico_state::burglarx_sound_bank_w)
+WRITE8_MEMBER(unico_state::burglarx_okibank_w)
 {
 	m_oki->set_rom_bank(data & 1);
 }
@@ -61,15 +61,15 @@ void unico_state::burglarx_map(address_map &map)
 	map(0x80001a, 0x80001b).portr("DSW1");
 	map(0x80001c, 0x80001d).portr("DSW2");
 	map(0x800030, 0x800031).nopw();                                                // ? 0
-	map(0x80010c, 0x800121).rw(FUNC(unico_state::unico_scroll_r), FUNC(unico_state::unico_scroll_w)).share("scroll");               // Scroll
+	map(0x80010c, 0x800121).rw(FUNC(unico_state::scroll_r), FUNC(unico_state::scroll_w)).share("scroll");               // Scroll
 	map(0x800189, 0x800189).rw(m_oki, FUNC(okim6295_device::read), FUNC(okim6295_device::write));  // Sound
 	map(0x80018a, 0x80018a).w("ymsnd", FUNC(ym3812_device::write_port_w));
 	map(0x80018c, 0x80018c).rw("ymsnd", FUNC(ym3812_device::status_port_r), FUNC(ym3812_device::control_port_w));
-	map(0x80018e, 0x80018e).w(FUNC(unico_state::burglarx_sound_bank_w));                    //
+	map(0x80018e, 0x80018e).w(FUNC(unico_state::burglarx_okibank_w));                    //
 	map(0x8001e0, 0x8001e1).nopw();                                                // IRQ Ack
-	map(0x904000, 0x90ffff).rw(FUNC(unico_state::unico_vram_r), FUNC(unico_state::unico_vram_w)).share("vram");         // Layers 1, 2, 0
+	map(0x904000, 0x90ffff).rw(FUNC(unico_state::vram_r), FUNC(unico_state::vram_w)).share("vram");         // Layers 1, 2, 0
 	map(0x920000, 0x923fff).ram();                                                     // ? 0
-	map(0x930000, 0x9307ff).rw(FUNC(unico_state::unico_spriteram_r), FUNC(unico_state::unico_spriteram_w)).share("spriteram");   // Sprites
+	map(0x930000, 0x9307ff).rw(FUNC(unico_state::spriteram_r), FUNC(unico_state::spriteram_w)).share("spriteram");   // Sprites
 	map(0x940000, 0x947fff).ram().w(m_palette, FUNC(palette_device::write16)).share("palette");   // Palette
 }
 
@@ -79,7 +79,7 @@ void unico_state::burglarx_map(address_map &map)
                                 Zero Point
 ***************************************************************************/
 
-WRITE8_MEMBER(zeropnt_state::zeropnt_sound_bank_w)
+WRITE8_MEMBER(zeropnt_state::okibank_leds_w)
 {
 	/* Banked sound samples. The 3rd quarter of the ROM
 	   contains garbage. Indeed, only banks 0&1 are used */
@@ -92,7 +92,7 @@ WRITE8_MEMBER(zeropnt_state::zeropnt_sound_bank_w)
 }
 
 /* Light Gun - need to wiggle the input slightly otherwise fire doesn't work */
-READ16_MEMBER(zeropnt_state::unico_gunx_0_msb_r)
+READ16_MEMBER(zeropnt_state::gunx_0_msb_r)
 {
 	int x=m_gun_axes[X0]->read();
 
@@ -103,7 +103,7 @@ READ16_MEMBER(zeropnt_state::unico_gunx_0_msb_r)
 	return ((x&0xff) ^ (m_screen->frame_number()&1))<<8;
 }
 
-READ16_MEMBER(zeropnt_state::unico_guny_0_msb_r)
+READ16_MEMBER(zeropnt_state::guny_0_msb_r)
 {
 	int y=m_gun_axes[Y0]->read();
 
@@ -112,7 +112,7 @@ READ16_MEMBER(zeropnt_state::unico_guny_0_msb_r)
 	return ((y&0xff) ^ (m_screen->frame_number()&1))<<8;
 }
 
-READ16_MEMBER(zeropnt_state::unico_gunx_1_msb_r)
+READ16_MEMBER(zeropnt_state::gunx_1_msb_r)
 {
 	int x=m_gun_axes[X1]->read();
 
@@ -123,7 +123,7 @@ READ16_MEMBER(zeropnt_state::unico_gunx_1_msb_r)
 	return ((x&0xff) ^ (m_screen->frame_number()&1))<<8;
 }
 
-READ16_MEMBER(zeropnt_state::unico_guny_1_msb_r)
+READ16_MEMBER(zeropnt_state::guny_1_msb_r)
 {
 	int y=m_gun_axes[Y1]->read();
 
@@ -140,19 +140,19 @@ void zeropnt_state::zeropnt_map(address_map &map)
 	map(0x800018, 0x800019).portr("INPUTS");
 	map(0x80001a, 0x80001b).portr("DSW1");
 	map(0x80001c, 0x80001d).portr("DSW2");
-	map(0x80010c, 0x800121).rw(FUNC(zeropnt_state::unico_scroll_r), FUNC(zeropnt_state::unico_scroll_w)).share("scroll");   // Scroll
-	map(0x800170, 0x800171).r(FUNC(zeropnt_state::unico_guny_0_msb_r));   // Light Guns
-	map(0x800174, 0x800175).r(FUNC(zeropnt_state::unico_gunx_0_msb_r));   //
-	map(0x800178, 0x800179).r(FUNC(zeropnt_state::unico_guny_1_msb_r));   //
-	map(0x80017c, 0x80017d).r(FUNC(zeropnt_state::unico_gunx_1_msb_r));   //
+	map(0x80010c, 0x800121).rw(FUNC(zeropnt_state::scroll_r), FUNC(zeropnt_state::scroll_w)).share("scroll");   // Scroll
+	map(0x800170, 0x800171).r(FUNC(zeropnt_state::guny_0_msb_r));   // Light Guns
+	map(0x800174, 0x800175).r(FUNC(zeropnt_state::gunx_0_msb_r));   //
+	map(0x800178, 0x800179).r(FUNC(zeropnt_state::guny_1_msb_r));   //
+	map(0x80017c, 0x80017d).r(FUNC(zeropnt_state::gunx_1_msb_r));   //
 	map(0x800189, 0x800189).rw("oki", FUNC(okim6295_device::read), FUNC(okim6295_device::write));   // Sound
 	map(0x80018a, 0x80018a).w("ymsnd", FUNC(ym3812_device::write_port_w));
 	map(0x80018c, 0x80018c).rw("ymsnd", FUNC(ym3812_device::status_port_r), FUNC(ym3812_device::control_port_w));
-	map(0x80018e, 0x80018e).w(FUNC(zeropnt_state::zeropnt_sound_bank_w));   //
+	map(0x80018e, 0x80018e).w(FUNC(zeropnt_state::okibank_leds_w));   //
 	map(0x8001e0, 0x8001e1).writeonly();   // ? IRQ Ack
-	map(0x904000, 0x90ffff).rw(FUNC(zeropnt_state::unico_vram_r), FUNC(zeropnt_state::unico_vram_w)).share("vram");     // Layers 1, 2, 0
+	map(0x904000, 0x90ffff).rw(FUNC(zeropnt_state::vram_r), FUNC(zeropnt_state::vram_w)).share("vram");     // Layers 1, 2, 0
 	map(0x920000, 0x923fff).ram(); // ? 0
-	map(0x930000, 0x9307ff).rw(FUNC(zeropnt_state::unico_spriteram_r), FUNC(zeropnt_state::unico_spriteram_w)).share("spriteram");   // Sprites
+	map(0x930000, 0x9307ff).rw(FUNC(zeropnt_state::spriteram_r), FUNC(zeropnt_state::spriteram_w)).share("spriteram");   // Sprites
 	map(0x940000, 0x947fff).ram().w(m_palette, FUNC(palette_device::write16)).share("palette");   // Palette
 }
 
@@ -167,24 +167,24 @@ void zeropnt_state::zeropnt_oki_map(address_map &map)
                                 Zero Point 2
 ***************************************************************************/
 
-READ32_MEMBER(zeropnt2_state::zeropnt2_gunx_0_msb_r) { return (unico_gunx_0_msb_r(space,0,0xffff)-0x0800) << 16; }
-READ32_MEMBER(zeropnt2_state::zeropnt2_guny_0_msb_r) { return (unico_guny_0_msb_r(space,0,0xffff)+0x0800) << 16; }
-READ32_MEMBER(zeropnt2_state::zeropnt2_gunx_1_msb_r) { return (unico_gunx_1_msb_r(space,0,0xffff)-0x0800) << 16; }
-READ32_MEMBER(zeropnt2_state::zeropnt2_guny_1_msb_r) { return (unico_guny_1_msb_r(space,0,0xffff)+0x0800) << 16; }
+READ32_MEMBER(zeropnt2_state::zeropnt2_gunx_0_msb_r) { return (gunx_0_msb_r(space,0,0xffff)-0x0800) << 16; }
+READ32_MEMBER(zeropnt2_state::zeropnt2_guny_0_msb_r) { return (guny_0_msb_r(space,0,0xffff)+0x0800) << 16; }
+READ32_MEMBER(zeropnt2_state::zeropnt2_gunx_1_msb_r) { return (gunx_1_msb_r(space,0,0xffff)-0x0800) << 16; }
+READ32_MEMBER(zeropnt2_state::zeropnt2_guny_1_msb_r) { return (guny_1_msb_r(space,0,0xffff)+0x0800) << 16; }
 
-WRITE8_MEMBER(zeropnt2_state::zeropnt2_sound_bank_w)
+WRITE8_MEMBER(zeropnt2_state::zeropnt2_okibank)
 {
 	m_okibank->set_entry((data & 3) % 4);
 }
 
-WRITE8_MEMBER(zeropnt2_state::zeropnt2_leds_w)
+WRITE8_MEMBER(zeropnt2_state::leds_w)
 {
 	machine().bookkeeping().coin_counter_w(0,data & 0x01);
 	m_leds[0] = BIT(data, 7); // Start 1
 	m_leds[1] = BIT(data, 6); // Start 2
 }
 
-WRITE32_MEMBER(zeropnt2_state::zeropnt2_eeprom_w)
+WRITE32_MEMBER(zeropnt2_state::eeprom_w)
 {
 	if (data & ~0xfe00000)
 		logerror("%s - Unknown EEPROM bit written %04X\n",machine().describe_context(),data);
@@ -209,9 +209,9 @@ void zeropnt2_state::zeropnt2_map(address_map &map)
 	map(0x800025, 0x800025).rw("oki1", FUNC(okim6295_device::read), FUNC(okim6295_device::write));   // Sound
 	map(0x800028, 0x80002f).rw("ymsnd", FUNC(ym2151_device::read), FUNC(ym2151_device::write)).umask32(0x00ff0000);  //
 	map(0x800031, 0x800031).rw("oki2", FUNC(okim6295_device::read), FUNC(okim6295_device::write));   //
-	map(0x800034, 0x800034).w(FUNC(zeropnt2_state::zeropnt2_sound_bank_w));   //
-	map(0x800039, 0x800039).w(FUNC(zeropnt2_state::zeropnt2_leds_w));   // ?
-	map(0x80010c, 0x800123).rw(FUNC(zeropnt2_state::unico_scroll_r), FUNC(zeropnt2_state::unico_scroll_w)).share("scroll");   // Scroll
+	map(0x800034, 0x800034).w(FUNC(zeropnt2_state::zeropnt2_okibank));   //
+	map(0x800039, 0x800039).w(FUNC(zeropnt2_state::leds_w));   // ?
+	map(0x80010c, 0x800123).rw(FUNC(zeropnt2_state::scroll_r), FUNC(zeropnt2_state::scroll_w)).share("scroll");   // Scroll
 	map(0x800140, 0x800143).r(FUNC(zeropnt2_state::zeropnt2_guny_0_msb_r));   // Light Guns
 	map(0x800144, 0x800147).r(FUNC(zeropnt2_state::zeropnt2_gunx_0_msb_r));   //
 	map(0x800148, 0x80014b).r(FUNC(zeropnt2_state::zeropnt2_guny_1_msb_r));   //
@@ -220,10 +220,10 @@ void zeropnt2_state::zeropnt2_map(address_map &map)
 	map(0x800154, 0x800157).portr("DSW2");
 	map(0x80015c, 0x80015f).portr("BUTTONS");
 	map(0x8001e0, 0x8001e3).nopw();                                    // ? IRQ Ack
-	map(0x8001f0, 0x8001f3).w(FUNC(zeropnt2_state::zeropnt2_eeprom_w));                    // EEPROM
-	map(0x904000, 0x90ffff).rw(FUNC(zeropnt2_state::unico_vram_r), FUNC(zeropnt2_state::unico_vram_w)).share("vram");     // Layers 1, 2, 0
+	map(0x8001f0, 0x8001f3).w(FUNC(zeropnt2_state::eeprom_w));                    // EEPROM
+	map(0x904000, 0x90ffff).rw(FUNC(zeropnt2_state::vram_r), FUNC(zeropnt2_state::vram_w)).share("vram");     // Layers 1, 2, 0
 	map(0x920000, 0x923fff).ram();                                         // ? 0
-	map(0x930000, 0x9307ff).rw(FUNC(zeropnt2_state::unico_spriteram_r), FUNC(zeropnt2_state::unico_spriteram_w)).share("spriteram");   // Sprites
+	map(0x930000, 0x9307ff).rw(FUNC(zeropnt2_state::spriteram_r), FUNC(zeropnt2_state::spriteram_w)).share("spriteram");   // Sprites
 	map(0x940000, 0x947fff).ram().w(m_palette, FUNC(palette_device::write32)).share("palette");   // Palette
 	map(0xfe0000, 0xffffff).ram();                                         // RAM
 }
@@ -575,7 +575,7 @@ MACHINE_CONFIG_START(unico_state::burglarx)
 	MCFG_SCREEN_VBLANK_TIME(ATTOSECONDS_IN_USEC(0))
 	MCFG_SCREEN_SIZE(384, 224)
 	MCFG_SCREEN_VISIBLE_AREA(0, 384-1, 0, 224-1)
-	MCFG_SCREEN_UPDATE_DRIVER(unico_state, screen_update_unico)
+	MCFG_SCREEN_UPDATE_DRIVER(unico_state, screen_update)
 	MCFG_SCREEN_PALETTE("palette")
 
 	MCFG_DEVICE_ADD("gfxdecode", GFXDECODE, "palette", gfx_unico)
@@ -620,7 +620,7 @@ MACHINE_CONFIG_START(zeropnt_state::zeropnt)
 	MCFG_SCREEN_VBLANK_TIME(ATTOSECONDS_IN_USEC(0))
 	MCFG_SCREEN_SIZE(384, 224)
 	MCFG_SCREEN_VISIBLE_AREA(0, 384-1, 0, 224-1)
-	MCFG_SCREEN_UPDATE_DRIVER(zeropnt_state, screen_update_unico)
+	MCFG_SCREEN_UPDATE_DRIVER(zeropnt_state, screen_update)
 	MCFG_SCREEN_PALETTE("palette")
 
 	MCFG_DEVICE_ADD("gfxdecode", GFXDECODE, "palette", gfx_unico)
@@ -668,7 +668,7 @@ MACHINE_CONFIG_START(zeropnt2_state::zeropnt2)
 	MCFG_SCREEN_VBLANK_TIME(ATTOSECONDS_IN_USEC(0))
 	MCFG_SCREEN_SIZE(384, 224)
 	MCFG_SCREEN_VISIBLE_AREA(0, 384-1, 0, 224-1)
-	MCFG_SCREEN_UPDATE_DRIVER(zeropnt2_state, screen_update_unico)
+	MCFG_SCREEN_UPDATE_DRIVER(zeropnt2_state, screen_update)
 	MCFG_SCREEN_PALETTE("palette")
 
 	MCFG_DEVICE_ADD("gfxdecode", GFXDECODE, "palette", gfx_unico)

--- a/src/mame/drivers/unico.cpp
+++ b/src/mame/drivers/unico.cpp
@@ -47,13 +47,9 @@ Year + Game         PCB             Notes
                                 Burglar X
 ***************************************************************************/
 
-WRITE16_MEMBER(unico_state::burglarx_sound_bank_w)
+WRITE8_MEMBER(unico_state::burglarx_sound_bank_w)
 {
-	if (ACCESSING_BITS_8_15)
-	{
-		int bank = (data >> 8 ) & 1;
-		m_oki->set_rom_bank(bank);
-	}
+	m_oki->set_rom_bank(data & 1);
 }
 
 void unico_state::burglarx_map(address_map &map)
@@ -65,16 +61,16 @@ void unico_state::burglarx_map(address_map &map)
 	map(0x80001a, 0x80001b).portr("DSW1");
 	map(0x80001c, 0x80001d).portr("DSW2");
 	map(0x800030, 0x800031).nopw();                                                // ? 0
-	map(0x80010c, 0x800121).rw(FUNC(unico_state::unico_scroll_r), FUNC(unico_state::unico_scroll_w));               // Scroll
+	map(0x80010c, 0x800121).rw(FUNC(unico_state::unico_scroll_r), FUNC(unico_state::unico_scroll_w)).share("scroll");               // Scroll
 	map(0x800189, 0x800189).rw(m_oki, FUNC(okim6295_device::read), FUNC(okim6295_device::write));  // Sound
 	map(0x80018a, 0x80018a).w("ymsnd", FUNC(ym3812_device::write_port_w));
 	map(0x80018c, 0x80018c).rw("ymsnd", FUNC(ym3812_device::status_port_r), FUNC(ym3812_device::control_port_w));
-	map(0x80018e, 0x80018f).w(FUNC(unico_state::burglarx_sound_bank_w));                    //
+	map(0x80018e, 0x80018e).w(FUNC(unico_state::burglarx_sound_bank_w));                    //
 	map(0x8001e0, 0x8001e1).nopw();                                                // IRQ Ack
-	map(0x904000, 0x90ffff).rw(FUNC(unico_state::unico_vram_r), FUNC(unico_state::unico_vram_w));         // Layers 1, 2, 0
+	map(0x904000, 0x90ffff).rw(FUNC(unico_state::unico_vram_r), FUNC(unico_state::unico_vram_w)).share("vram");         // Layers 1, 2, 0
 	map(0x920000, 0x923fff).ram();                                                     // ? 0
-	map(0x930000, 0x9307ff).rw(FUNC(unico_state::unico_spriteram_r), FUNC(unico_state::unico_spriteram_w));   // Sprites
-	map(0x940000, 0x947fff).ram().w(FUNC(unico_state::unico_palette_w)).share("paletteram");   // Palette
+	map(0x930000, 0x9307ff).rw(FUNC(unico_state::unico_spriteram_r), FUNC(unico_state::unico_spriteram_w)).share("spriteram");   // Sprites
+	map(0x940000, 0x947fff).ram().w(m_palette, FUNC(palette_device::write16)).share("palette");   // Palette
 }
 
 
@@ -83,22 +79,16 @@ void unico_state::burglarx_map(address_map &map)
                                 Zero Point
 ***************************************************************************/
 
-WRITE16_MEMBER(zeropnt_state::zeropnt_sound_bank_w)
+WRITE8_MEMBER(zeropnt_state::zeropnt_sound_bank_w)
 {
-	if (ACCESSING_BITS_8_15)
-	{
-		/* Banked sound samples. The 3rd quarter of the ROM
-		   contains garbage. Indeed, only banks 0&1 are used */
+	/* Banked sound samples. The 3rd quarter of the ROM
+	   contains garbage. Indeed, only banks 0&1 are used */
 
-		int bank = (data >> 8 ) & 1;
-		uint8_t *dst  = memregion("oki")->base();
-		uint8_t *src  = dst + 0x80000 + 0x20000 + 0x20000 * bank;
-		memcpy(dst + 0x20000, src, 0x20000);
+	m_okibank->set_entry(data & 1);
 
-		machine().bookkeeping().coin_counter_w(0,data & 0x1000);
-		m_leds[0] = BIT(data, 11); // Start 1
-		m_leds[1] = BIT(data, 10); // Start 2
-	}
+	machine().bookkeeping().coin_counter_w(0,data & 0x10);
+	m_leds[0] = BIT(data, 3); // Start 1
+	m_leds[1] = BIT(data, 2); // Start 2
 }
 
 /* Light Gun - need to wiggle the input slightly otherwise fire doesn't work */
@@ -150,7 +140,7 @@ void zeropnt_state::zeropnt_map(address_map &map)
 	map(0x800018, 0x800019).portr("INPUTS");
 	map(0x80001a, 0x80001b).portr("DSW1");
 	map(0x80001c, 0x80001d).portr("DSW2");
-	map(0x80010c, 0x800121).rw(FUNC(zeropnt_state::unico_scroll_r), FUNC(zeropnt_state::unico_scroll_w));   // Scroll
+	map(0x80010c, 0x800121).rw(FUNC(zeropnt_state::unico_scroll_r), FUNC(zeropnt_state::unico_scroll_w)).share("scroll");   // Scroll
 	map(0x800170, 0x800171).r(FUNC(zeropnt_state::unico_guny_0_msb_r));   // Light Guns
 	map(0x800174, 0x800175).r(FUNC(zeropnt_state::unico_gunx_0_msb_r));   //
 	map(0x800178, 0x800179).r(FUNC(zeropnt_state::unico_guny_1_msb_r));   //
@@ -158,12 +148,18 @@ void zeropnt_state::zeropnt_map(address_map &map)
 	map(0x800189, 0x800189).rw("oki", FUNC(okim6295_device::read), FUNC(okim6295_device::write));   // Sound
 	map(0x80018a, 0x80018a).w("ymsnd", FUNC(ym3812_device::write_port_w));
 	map(0x80018c, 0x80018c).rw("ymsnd", FUNC(ym3812_device::status_port_r), FUNC(ym3812_device::control_port_w));
-	map(0x80018e, 0x80018f).w(FUNC(zeropnt_state::zeropnt_sound_bank_w));   //
+	map(0x80018e, 0x80018e).w(FUNC(zeropnt_state::zeropnt_sound_bank_w));   //
 	map(0x8001e0, 0x8001e1).writeonly();   // ? IRQ Ack
-	map(0x904000, 0x90ffff).rw(FUNC(zeropnt_state::unico_vram_r), FUNC(zeropnt_state::unico_vram_w));     // Layers 1, 2, 0
+	map(0x904000, 0x90ffff).rw(FUNC(zeropnt_state::unico_vram_r), FUNC(zeropnt_state::unico_vram_w)).share("vram");     // Layers 1, 2, 0
 	map(0x920000, 0x923fff).ram(); // ? 0
-	map(0x930000, 0x9307ff).rw(FUNC(zeropnt_state::unico_spriteram_r), FUNC(zeropnt_state::unico_spriteram_w));   // Sprites
-	map(0x940000, 0x947fff).ram().w(FUNC(zeropnt_state::unico_palette_w)).share("paletteram");   // Palette
+	map(0x930000, 0x9307ff).rw(FUNC(zeropnt_state::unico_spriteram_r), FUNC(zeropnt_state::unico_spriteram_w)).share("spriteram");   // Sprites
+	map(0x940000, 0x947fff).ram().w(m_palette, FUNC(palette_device::write16)).share("palette");   // Palette
+}
+
+void zeropnt_state::zeropnt_oki_map(address_map &map)
+{
+	map(0x00000, 0x1ffff).rom();
+	map(0x20000, 0x3ffff).bankr("okibank");
 }
 
 
@@ -176,25 +172,16 @@ READ32_MEMBER(zeropnt2_state::zeropnt2_guny_0_msb_r) { return (unico_guny_0_msb_
 READ32_MEMBER(zeropnt2_state::zeropnt2_gunx_1_msb_r) { return (unico_gunx_1_msb_r(space,0,0xffff)-0x0800) << 16; }
 READ32_MEMBER(zeropnt2_state::zeropnt2_guny_1_msb_r) { return (unico_guny_1_msb_r(space,0,0xffff)+0x0800) << 16; }
 
-WRITE32_MEMBER(zeropnt2_state::zeropnt2_sound_bank_w)
+WRITE8_MEMBER(zeropnt2_state::zeropnt2_sound_bank_w)
 {
-	if (ACCESSING_BITS_24_31)
-	{
-		int bank = ((data >> 24) & 3) % 4;
-		uint8_t *dst  = memregion("oki1")->base();
-		uint8_t *src  = dst + 0x80000 + 0x20000 + 0x20000 * bank;
-		memcpy(dst + 0x20000, src, 0x20000);
-	}
+	m_okibank->set_entry((data & 3) % 4);
 }
 
-WRITE32_MEMBER(zeropnt2_state::zeropnt2_leds_w)
+WRITE8_MEMBER(zeropnt2_state::zeropnt2_leds_w)
 {
-	if (ACCESSING_BITS_16_23)
-	{
-		machine().bookkeeping().coin_counter_w(0,data & 0x00010000);
-		m_leds[0] = BIT(data, 23); // Start 1
-		m_leds[1] = BIT(data, 22); // Start 2
-	}
+	machine().bookkeeping().coin_counter_w(0,data & 0x01);
+	m_leds[0] = BIT(data, 7); // Start 1
+	m_leds[1] = BIT(data, 6); // Start 2
 }
 
 WRITE32_MEMBER(zeropnt2_state::zeropnt2_eeprom_w)
@@ -222,9 +209,9 @@ void zeropnt2_state::zeropnt2_map(address_map &map)
 	map(0x800025, 0x800025).rw("oki1", FUNC(okim6295_device::read), FUNC(okim6295_device::write));   // Sound
 	map(0x800028, 0x80002f).rw("ymsnd", FUNC(ym2151_device::read), FUNC(ym2151_device::write)).umask32(0x00ff0000);  //
 	map(0x800031, 0x800031).rw("oki2", FUNC(okim6295_device::read), FUNC(okim6295_device::write));   //
-	map(0x800034, 0x800037).w(FUNC(zeropnt2_state::zeropnt2_sound_bank_w));   //
-	map(0x800038, 0x80003b).w(FUNC(zeropnt2_state::zeropnt2_leds_w));   // ?
-	map(0x80010c, 0x800123).rw(FUNC(zeropnt2_state::unico_scroll_r), FUNC(zeropnt2_state::unico_scroll_w));   // Scroll
+	map(0x800034, 0x800034).w(FUNC(zeropnt2_state::zeropnt2_sound_bank_w));   //
+	map(0x800039, 0x800039).w(FUNC(zeropnt2_state::zeropnt2_leds_w));   // ?
+	map(0x80010c, 0x800123).rw(FUNC(zeropnt2_state::unico_scroll_r), FUNC(zeropnt2_state::unico_scroll_w)).share("scroll");   // Scroll
 	map(0x800140, 0x800143).r(FUNC(zeropnt2_state::zeropnt2_guny_0_msb_r));   // Light Guns
 	map(0x800144, 0x800147).r(FUNC(zeropnt2_state::zeropnt2_gunx_0_msb_r));   //
 	map(0x800148, 0x80014b).r(FUNC(zeropnt2_state::zeropnt2_guny_1_msb_r));   //
@@ -234,10 +221,10 @@ void zeropnt2_state::zeropnt2_map(address_map &map)
 	map(0x80015c, 0x80015f).portr("BUTTONS");
 	map(0x8001e0, 0x8001e3).nopw();                                    // ? IRQ Ack
 	map(0x8001f0, 0x8001f3).w(FUNC(zeropnt2_state::zeropnt2_eeprom_w));                    // EEPROM
-	map(0x904000, 0x90ffff).rw(FUNC(zeropnt2_state::unico_vram_r), FUNC(zeropnt2_state::unico_vram_w));     // Layers 1, 2, 0
+	map(0x904000, 0x90ffff).rw(FUNC(zeropnt2_state::unico_vram_r), FUNC(zeropnt2_state::unico_vram_w)).share("vram");     // Layers 1, 2, 0
 	map(0x920000, 0x923fff).ram();                                         // ? 0
-	map(0x930000, 0x9307ff).rw(FUNC(zeropnt2_state::unico_spriteram_r), FUNC(zeropnt2_state::unico_spriteram_w));   // Sprites
-	map(0x940000, 0x947fff).ram().w(FUNC(zeropnt2_state::unico_palette32_w)).share("paletteram"); // Palette
+	map(0x930000, 0x9307ff).rw(FUNC(zeropnt2_state::unico_spriteram_r), FUNC(zeropnt2_state::unico_spriteram_w)).share("spriteram");   // Sprites
+	map(0x940000, 0x947fff).ram().w(m_palette, FUNC(palette_device::write32)).share("palette");   // Palette
 	map(0xfe0000, 0xffffff).ram();                                         // RAM
 }
 
@@ -593,6 +580,7 @@ MACHINE_CONFIG_START(unico_state::burglarx)
 
 	MCFG_DEVICE_ADD("gfxdecode", GFXDECODE, "palette", gfx_unico)
 	MCFG_PALETTE_ADD("palette", 8192)
+	MCFG_PALETTE_FORMAT_CLASS(4, unico_state, unico_R6G6B6X)
 
 	/* sound hardware */
 	SPEAKER(config, "lspeaker").front_left();
@@ -613,6 +601,12 @@ MACHINE_CONFIG_END
                                 Zero Point
 ***************************************************************************/
 
+void zeropnt_state::machine_start()
+{
+	unico_state::machine_start();
+	m_okibank->configure_entries(0, 4, memregion("oki")->base() + 0x20000, 0x20000);
+}
+
 MACHINE_CONFIG_START(zeropnt_state::zeropnt)
 
 	/* basic machine hardware */
@@ -631,6 +625,7 @@ MACHINE_CONFIG_START(zeropnt_state::zeropnt)
 
 	MCFG_DEVICE_ADD("gfxdecode", GFXDECODE, "palette", gfx_unico)
 	MCFG_PALETTE_ADD("palette", 8192)
+	MCFG_PALETTE_FORMAT_CLASS(4, zeropnt_state, unico_R6G6B6X)
 
 	/* sound hardware */
 	SPEAKER(config, "lspeaker").front_left();
@@ -641,6 +636,7 @@ MACHINE_CONFIG_START(zeropnt_state::zeropnt)
 	MCFG_SOUND_ROUTE(ALL_OUTPUTS, "rspeaker", 0.40)
 
 	MCFG_DEVICE_ADD("oki", OKIM6295, 32_MHz_XTAL/32, okim6295_device::PIN7_HIGH) // clock frequency & pin 7 not verified
+	MCFG_DEVICE_ADDRESS_MAP(0, zeropnt_oki_map)
 	MCFG_SOUND_ROUTE(ALL_OUTPUTS, "lspeaker", 0.80)
 	MCFG_SOUND_ROUTE(ALL_OUTPUTS, "rspeaker", 0.80)
 MACHINE_CONFIG_END
@@ -650,6 +646,12 @@ MACHINE_CONFIG_END
 /***************************************************************************
                                 Zero Point 2
 ***************************************************************************/
+
+void zeropnt2_state::machine_start()
+{
+	unico_state::machine_start();
+	m_okibank->configure_entries(0, 4, memregion("oki1")->base() + 0x20000, 0x20000);
+}
 
 MACHINE_CONFIG_START(zeropnt2_state::zeropnt2)
 
@@ -671,6 +673,7 @@ MACHINE_CONFIG_START(zeropnt2_state::zeropnt2)
 
 	MCFG_DEVICE_ADD("gfxdecode", GFXDECODE, "palette", gfx_unico)
 	MCFG_PALETTE_ADD("palette", 8192)
+	MCFG_PALETTE_FORMAT_CLASS(4, zeropnt2_state, unico_R6G6B6X)
 
 	/* sound hardware */
 	SPEAKER(config, "lspeaker").front_left();
@@ -681,6 +684,7 @@ MACHINE_CONFIG_START(zeropnt2_state::zeropnt2)
 	MCFG_SOUND_ROUTE(1, "rspeaker", 0.70)
 
 	MCFG_DEVICE_ADD("oki1", OKIM6295, 32_MHz_XTAL/32, okim6295_device::PIN7_HIGH) // clock frequency & pin 7 not verified
+	MCFG_DEVICE_ADDRESS_MAP(0, zeropnt_oki_map)
 	MCFG_SOUND_ROUTE(ALL_OUTPUTS, "lspeaker", 0.40)
 	MCFG_SOUND_ROUTE(ALL_OUTPUTS, "rspeaker", 0.40)
 
@@ -796,7 +800,6 @@ ROM_START( zeropnt )
 
 	ROM_REGION( 0x80000 * 2, "oki", 0 ) /* Samples */
 	ROM_LOAD( "unico_1.rom1", 0x000000, 0x080000, CRC(fd2384fa) SHA1(8ae83665fe952c5d03bd62d2abb507c351cf0fb5) )
-	ROM_RELOAD(               0x080000, 0x080000 )
 ROM_END
 
 
@@ -819,7 +822,6 @@ ROM_START( zeropnta )
 
 	ROM_REGION( 0x80000 * 2, "oki", 0 ) /* Samples */
 	ROM_LOAD( "unico_1.rom1", 0x000000, 0x080000, CRC(fd2384fa) SHA1(8ae83665fe952c5d03bd62d2abb507c351cf0fb5) )
-	ROM_RELOAD(               0x080000, 0x080000 )
 ROM_END
 
 
@@ -842,7 +844,6 @@ ROM_START( zeropntj )
 
 	ROM_REGION( 0x80000 * 2, "oki", 0 ) /* Samples */
 	ROM_LOAD( "unico_1.rom1", 0x000000, 0x080000, CRC(fd2384fa) SHA1(8ae83665fe952c5d03bd62d2abb507c351cf0fb5) )
-	ROM_RELOAD(               0x080000, 0x080000 )
 ROM_END
 
 /***************************************************************************
@@ -1026,7 +1027,6 @@ ROM_START( zeropnt2 )
 
 	ROM_REGION( 0x80000 * 2, "oki1", 0 )    /* Samples */
 	ROM_LOAD( "uzp2-1.bin", 0x000000, 0x080000, CRC(ed0966ed) SHA1(a43b9c493f94d1fb11e1b189caaf37d3d792c730) )
-	ROM_RELOAD(             0x080000, 0x080000 )
 
 	ROM_REGION( 0x40000, "oki2", 0 )    /* Samples */
 	ROM_LOAD( "uzp2-2.bin", 0x000000, 0x040000, CRC(db8cb455) SHA1(6723b4018208d554bd1bf1e0640b72d2f4f47302) )

--- a/src/mame/drivers/unico.cpp
+++ b/src/mame/drivers/unico.cpp
@@ -79,7 +79,7 @@ void unico_state::burglarx_map(address_map &map)
                                 Zero Point
 ***************************************************************************/
 
-WRITE8_MEMBER(zeropnt_state::okibank_leds_w)
+WRITE8_MEMBER(zeropnt_state::zeropnt_okibank_leds_w)
 {
 	/* Banked sound samples. The 3rd quarter of the ROM
 	   contains garbage. Indeed, only banks 0&1 are used */
@@ -148,7 +148,7 @@ void zeropnt_state::zeropnt_map(address_map &map)
 	map(0x800189, 0x800189).rw("oki", FUNC(okim6295_device::read), FUNC(okim6295_device::write));   // Sound
 	map(0x80018a, 0x80018a).w("ymsnd", FUNC(ym3812_device::write_port_w));
 	map(0x80018c, 0x80018c).rw("ymsnd", FUNC(ym3812_device::status_port_r), FUNC(ym3812_device::control_port_w));
-	map(0x80018e, 0x80018e).w(FUNC(zeropnt_state::okibank_leds_w));   //
+	map(0x80018e, 0x80018e).w(FUNC(zeropnt_state::zeropnt_okibank_leds_w));   //
 	map(0x8001e0, 0x8001e1).writeonly();   // ? IRQ Ack
 	map(0x904000, 0x90ffff).rw(FUNC(zeropnt_state::vram_r), FUNC(zeropnt_state::vram_w)).share("vram");     // Layers 1, 2, 0
 	map(0x920000, 0x923fff).ram(); // ? 0

--- a/src/mame/includes/unico.h
+++ b/src/mame/includes/unico.h
@@ -17,16 +17,18 @@ public:
 		driver_device(mconfig, type, tag),
 		m_palette(*this, "palette"),
 		m_leds(*this, "led%u", 0U),
+		m_vram(*this, "vram", 0),
+		m_scroll(*this, "scroll", 0),
+		m_spriteram(*this, "spriteram", 0),
 		m_maincpu(*this, "maincpu"),
 		m_oki(*this, "oki"),
-		m_gfxdecode(*this, "gfxdecode"),
-		m_generic_paletteram_16(*this, "paletteram")
+		m_gfxdecode(*this, "gfxdecode")
 	{ }
 
 	void burglarx(machine_config &config);
 
 protected:
-	DECLARE_WRITE16_MEMBER(unico_palette_w);
+	DECLARE_PALETTE_DECODER(unico_R6G6B6X);
 	DECLARE_READ16_MEMBER(unico_vram_r);
 	DECLARE_WRITE16_MEMBER(unico_vram_w);
 	DECLARE_READ16_MEMBER(unico_scroll_r);
@@ -34,7 +36,7 @@ protected:
 	DECLARE_READ16_MEMBER(unico_spriteram_r);
 	DECLARE_WRITE16_MEMBER(unico_spriteram_w);
 
-	DECLARE_WRITE16_MEMBER(burglarx_sound_bank_w);
+	DECLARE_WRITE8_MEMBER(burglarx_sound_bank_w);
 	TILE_GET_INFO_MEMBER(get_tile_info);
 	virtual void machine_start() override;
 	virtual void video_start() override;
@@ -47,17 +49,16 @@ protected:
 	output_finder<2> m_leds;
 
 private:
-	std::unique_ptr<uint16_t[]> m_vram;
-	std::unique_ptr<uint16_t[]> m_scroll;
+	required_shared_ptr<uint16_t> m_vram;
+	required_shared_ptr<uint16_t> m_scroll;
 	tilemap_t *m_tilemap[3];
 	int m_sprites_scrolldx;
 	int m_sprites_scrolldy;
-	std::unique_ptr<uint16_t[]> m_spriteram;
+	required_shared_ptr<uint16_t> m_spriteram;
 
 	required_device<cpu_device> m_maincpu;
 	optional_device<okim6295_device> m_oki;
 	required_device<gfxdecode_device> m_gfxdecode;
-	optional_shared_ptr<uint16_t> m_generic_paletteram_16;
 };
 
 class zeropnt_state : public unico_state
@@ -65,6 +66,7 @@ class zeropnt_state : public unico_state
 public:
 	zeropnt_state(const machine_config &mconfig, device_type type, const char *tag) :
 		unico_state(mconfig, type, tag),
+		m_okibank(*this, "okibank"),
 		m_screen(*this, "screen"),
 		m_gun_axes(*this, { "Y0", "X0", "Y1", "X1" })
 	{ }
@@ -72,13 +74,18 @@ public:
 	void zeropnt(machine_config &config);
 
 protected:
-	DECLARE_WRITE16_MEMBER(zeropnt_sound_bank_w);
+	virtual void machine_start() override;
+
+	DECLARE_WRITE8_MEMBER(zeropnt_sound_bank_w);
 	DECLARE_READ16_MEMBER(unico_gunx_0_msb_r);
 	DECLARE_READ16_MEMBER(unico_guny_0_msb_r);
 	DECLARE_READ16_MEMBER(unico_gunx_1_msb_r);
 	DECLARE_READ16_MEMBER(unico_guny_1_msb_r);
 
+	required_memory_bank m_okibank;
+
 	void zeropnt_map(address_map &map);
+	void zeropnt_oki_map(address_map &map);
 
 private:
 	enum { Y0, X0, Y1, X1 }; // gun axis indices
@@ -92,20 +99,20 @@ class zeropnt2_state : public zeropnt_state
 public:
 	zeropnt2_state(const machine_config &mconfig, device_type type, const char *tag) :
 		zeropnt_state(mconfig, type, tag),
-		m_eeprom(*this, "eeprom"),
-		m_generic_paletteram_32(*this, "paletteram")
+		m_eeprom(*this, "eeprom")
 	{ }
 
 	void zeropnt2(machine_config &config);
 
 protected:
-	DECLARE_WRITE32_MEMBER(unico_palette32_w);
+	virtual void machine_start() override;
+
 	DECLARE_READ32_MEMBER(zeropnt2_gunx_0_msb_r);
 	DECLARE_READ32_MEMBER(zeropnt2_guny_0_msb_r);
 	DECLARE_READ32_MEMBER(zeropnt2_gunx_1_msb_r);
 	DECLARE_READ32_MEMBER(zeropnt2_guny_1_msb_r);
-	DECLARE_WRITE32_MEMBER(zeropnt2_sound_bank_w);
-	DECLARE_WRITE32_MEMBER(zeropnt2_leds_w);
+	DECLARE_WRITE8_MEMBER(zeropnt2_sound_bank_w);
+	DECLARE_WRITE8_MEMBER(zeropnt2_leds_w);
 
 	DECLARE_WRITE32_MEMBER(zeropnt2_eeprom_w);
 
@@ -113,7 +120,6 @@ protected:
 
 private:
 	required_device<eeprom_serial_93cxx_device> m_eeprom;
-	required_shared_ptr<uint32_t> m_generic_paletteram_32;
 };
 
 #endif // MAME_INCLUDES_UNICO_H

--- a/src/mame/includes/unico.h
+++ b/src/mame/includes/unico.h
@@ -29,19 +29,19 @@ public:
 
 protected:
 	DECLARE_PALETTE_DECODER(unico_R6G6B6X);
-	DECLARE_READ16_MEMBER(unico_vram_r);
-	DECLARE_WRITE16_MEMBER(unico_vram_w);
-	DECLARE_READ16_MEMBER(unico_scroll_r);
-	DECLARE_WRITE16_MEMBER(unico_scroll_w);
-	DECLARE_READ16_MEMBER(unico_spriteram_r);
-	DECLARE_WRITE16_MEMBER(unico_spriteram_w);
+	DECLARE_READ16_MEMBER(vram_r);
+	DECLARE_WRITE16_MEMBER(vram_w);
+	DECLARE_READ16_MEMBER(scroll_r);
+	DECLARE_WRITE16_MEMBER(scroll_w);
+	DECLARE_READ16_MEMBER(spriteram_r);
+	DECLARE_WRITE16_MEMBER(spriteram_w);
 
-	DECLARE_WRITE8_MEMBER(burglarx_sound_bank_w);
+	DECLARE_WRITE8_MEMBER(burglarx_okibank_w);
 	TILE_GET_INFO_MEMBER(get_tile_info);
 	virtual void machine_start() override;
 	virtual void video_start() override;
-	uint32_t screen_update_unico(screen_device &screen, bitmap_ind16 &bitmap, const rectangle &cliprect);
-	void unico_draw_sprites(screen_device &screen, bitmap_ind16 &bitmap,const rectangle &cliprect);
+	uint32_t screen_update(screen_device &screen, bitmap_ind16 &bitmap, const rectangle &cliprect);
+	void draw_sprites(screen_device &screen, bitmap_ind16 &bitmap,const rectangle &cliprect);
 
 	void burglarx_map(address_map &map);
 
@@ -76,11 +76,11 @@ public:
 protected:
 	virtual void machine_start() override;
 
-	DECLARE_WRITE8_MEMBER(zeropnt_sound_bank_w);
-	DECLARE_READ16_MEMBER(unico_gunx_0_msb_r);
-	DECLARE_READ16_MEMBER(unico_guny_0_msb_r);
-	DECLARE_READ16_MEMBER(unico_gunx_1_msb_r);
-	DECLARE_READ16_MEMBER(unico_guny_1_msb_r);
+	DECLARE_WRITE8_MEMBER(zeropnt_okibank_leds_w);
+	DECLARE_READ16_MEMBER(gunx_0_msb_r);
+	DECLARE_READ16_MEMBER(guny_0_msb_r);
+	DECLARE_READ16_MEMBER(gunx_1_msb_r);
+	DECLARE_READ16_MEMBER(guny_1_msb_r);
 
 	required_memory_bank m_okibank;
 
@@ -111,10 +111,10 @@ protected:
 	DECLARE_READ32_MEMBER(zeropnt2_guny_0_msb_r);
 	DECLARE_READ32_MEMBER(zeropnt2_gunx_1_msb_r);
 	DECLARE_READ32_MEMBER(zeropnt2_guny_1_msb_r);
-	DECLARE_WRITE8_MEMBER(zeropnt2_sound_bank_w);
-	DECLARE_WRITE8_MEMBER(zeropnt2_leds_w);
+	DECLARE_WRITE8_MEMBER(zeropnt2_okibank);
+	DECLARE_WRITE8_MEMBER(leds_w);
 
-	DECLARE_WRITE32_MEMBER(zeropnt2_eeprom_w);
+	DECLARE_WRITE32_MEMBER(eeprom_w);
 
 	void zeropnt2_map(address_map &map);
 

--- a/src/mame/video/unico.cpp
+++ b/src/mame/video/unico.cpp
@@ -53,27 +53,14 @@ Note:   if MAME_DEBUG is defined, pressing Z with:
 
 ***************************************************************************/
 
-WRITE16_MEMBER(unico_state::unico_palette_w)
+PALETTE_DECODER_MEMBER(unico_state, unico_R6G6B6X)
 {
-	uint16_t data1, data2;
-	COMBINE_DATA(&m_generic_paletteram_16[offset]);
-	data1 = m_generic_paletteram_16[offset & ~1];
-	data2 = m_generic_paletteram_16[offset |  1];
-	m_palette->set_pen_color( offset/2,
-			(data1 >> 8) & 0xFC,
-			(data1 >> 0) & 0xFC,
-			(data2 >> 8) & 0xFC );
-}
+	int const red   = (raw >> 24) & 0xFC;
+	int const green = (raw >> 16) & 0xFC;
+	int const blue  = (raw >>  8) & 0xFC;
 
-WRITE32_MEMBER(zeropnt2_state::unico_palette32_w)
-{
-	uint32_t rgb0 = COMBINE_DATA(&m_generic_paletteram_32[offset]);
-	m_palette->set_pen_color( offset,
-			(rgb0 >> 24) & 0xFC,
-			(rgb0 >> 16) & 0xFC,
-			(rgb0 >>  8) & 0xFC );
+	return rgb_t(red, green, blue);
 }
-
 
 /***************************************************************************
 
@@ -102,9 +89,8 @@ READ16_MEMBER(unico_state::unico_vram_r) { return m_vram[offset]; }
 
 WRITE16_MEMBER(unico_state::unico_vram_w)
 {
-	uint16_t *vram = m_vram.get();
 	int tile = ((offset / 0x2000) + 1) % 3;
-	COMBINE_DATA(&vram[offset]);
+	COMBINE_DATA(&m_vram[offset]);
 	m_tilemap[tile]->mark_tile_dirty((offset & 0x1fff)/2);
 }
 
@@ -113,7 +99,6 @@ READ16_MEMBER(unico_state::unico_scroll_r) { return m_scroll[offset]; }
 WRITE16_MEMBER(unico_state::unico_scroll_w) { COMBINE_DATA(&m_scroll[offset]); }
 READ16_MEMBER(unico_state::unico_spriteram_r) { return m_spriteram[offset]; }
 WRITE16_MEMBER(unico_state::unico_spriteram_w)  { COMBINE_DATA(&m_spriteram[offset]); }
-
 
 
 /***************************************************************************
@@ -127,14 +112,6 @@ WRITE16_MEMBER(unico_state::unico_spriteram_w)  { COMBINE_DATA(&m_spriteram[offs
 
 void unico_state::video_start()
 {
-	m_vram   = make_unique_clear<uint16_t[]>(0xc000 / 2);
-	m_scroll = make_unique_clear<uint16_t[]>(0x18 / 2);
-	m_spriteram = make_unique_clear<uint16_t[]>(0x800 / 2);
-
-	save_pointer(NAME(m_vram), 0xc000/2);
-	save_pointer(NAME(m_scroll), 0x18/2);
-	save_pointer(NAME(m_spriteram), 0x800/2);
-
 	m_tilemap[0] = &machine().tilemap().create(
 			*m_gfxdecode, tilemap_get_info_delegate(FUNC(unico_state::get_tile_info),this),TILEMAP_SCAN_ROWS,
 			16,16,  0x40, 0x40);
@@ -168,8 +145,6 @@ void unico_state::video_start()
 }
 
 
-
-
 /***************************************************************************
 
                                 Sprites Drawing
@@ -194,7 +169,6 @@ void unico_state::video_start()
 
 void unico_state::unico_draw_sprites(screen_device &screen, bitmap_ind16 &bitmap,const rectangle &cliprect)
 {
-	uint16_t *spriteram16 = m_spriteram.get();
 	int offs;
 
 	/* Draw them backwards, for pdrawgfx */
@@ -202,10 +176,10 @@ void unico_state::unico_draw_sprites(screen_device &screen, bitmap_ind16 &bitmap
 	{
 		int x, startx, endx, incx;
 
-		int sx          =   spriteram16[ offs + 0 ];
-		int sy          =   spriteram16[ offs + 1 ];
-		int code        =   spriteram16[ offs + 2 ];
-		int attr        =   spriteram16[ offs + 3 ];
+		int sx          =   m_spriteram[ offs + 0 ];
+		int sy          =   m_spriteram[ offs + 1 ];
+		int code        =   m_spriteram[ offs + 2 ];
+		int attr        =   m_spriteram[ offs + 3 ];
 
 		int flipx       =   attr & 0x020;
 		int flipy       =   attr & 0x040;   // not sure

--- a/src/mame/video/unico.cpp
+++ b/src/mame/video/unico.cpp
@@ -85,9 +85,9 @@ TILE_GET_INFO_MEMBER(unico_state::get_tile_info)
 	SET_TILE_INFO_MEMBER(1, code, attr & 0x1f, TILE_FLIPYX( attr >> 5 ));
 }
 
-READ16_MEMBER(unico_state::unico_vram_r) { return m_vram[offset]; }
+READ16_MEMBER(unico_state::vram_r) { return m_vram[offset]; }
 
-WRITE16_MEMBER(unico_state::unico_vram_w)
+WRITE16_MEMBER(unico_state::vram_w)
 {
 	int tile = ((offset / 0x2000) + 1) % 3;
 	COMBINE_DATA(&m_vram[offset]);
@@ -95,10 +95,10 @@ WRITE16_MEMBER(unico_state::unico_vram_w)
 }
 
 
-READ16_MEMBER(unico_state::unico_scroll_r) { return m_scroll[offset]; }
-WRITE16_MEMBER(unico_state::unico_scroll_w) { COMBINE_DATA(&m_scroll[offset]); }
-READ16_MEMBER(unico_state::unico_spriteram_r) { return m_spriteram[offset]; }
-WRITE16_MEMBER(unico_state::unico_spriteram_w)  { COMBINE_DATA(&m_spriteram[offset]); }
+READ16_MEMBER(unico_state::scroll_r) { return m_scroll[offset]; }
+WRITE16_MEMBER(unico_state::scroll_w) { COMBINE_DATA(&m_scroll[offset]); }
+READ16_MEMBER(unico_state::spriteram_r) { return m_spriteram[offset]; }
+WRITE16_MEMBER(unico_state::spriteram_w)  { COMBINE_DATA(&m_spriteram[offset]); }
 
 
 /***************************************************************************
@@ -167,7 +167,7 @@ void unico_state::video_start()
 
 ***************************************************************************/
 
-void unico_state::unico_draw_sprites(screen_device &screen, bitmap_ind16 &bitmap,const rectangle &cliprect)
+void unico_state::draw_sprites(screen_device &screen, bitmap_ind16 &bitmap,const rectangle &cliprect)
 {
 	int offs;
 
@@ -229,7 +229,7 @@ void unico_state::unico_draw_sprites(screen_device &screen, bitmap_ind16 &bitmap
 
 ***************************************************************************/
 
-uint32_t unico_state::screen_update_unico(screen_device &screen, bitmap_ind16 &bitmap, const rectangle &cliprect)
+uint32_t unico_state::screen_update(screen_device &screen, bitmap_ind16 &bitmap, const rectangle &cliprect)
 {
 	int layers_ctrl = -1;
 
@@ -263,7 +263,7 @@ if ( machine().input().code_pressed(KEYCODE_Z) || machine().input().code_pressed
 	if (layers_ctrl & 4)    m_tilemap[2]->draw(screen, bitmap, cliprect, 0,4);
 
 	/* Sprites are drawn last, using pdrawgfx */
-	if (layers_ctrl & 8)    unico_draw_sprites(screen,bitmap,cliprect);
+	if (layers_ctrl & 8)    draw_sprites(screen,bitmap,cliprect);
 
 	return 0;
 }


### PR DESCRIPTION
Convert video RAMs into shared_ptrs, Reduce runtime tag lookups, Some ACCESSING_BITS Cleanups, PALETTE_DECODER for palette