### PR TITLE
ncr5390: dma fixes again (nw)

### DIFF
--- a/src/devices/machine/ncr5390.cpp
+++ b/src/devices/machine/ncr5390.cpp
@@ -510,16 +510,16 @@ void ncr5390_device::step(bool timeout)
 		break;
 
 	case INIT_XFR_FUNCTION_COMPLETE:
-		// wait for dma transfer to complete
-		if (dma_command && !(status & S_TC0))
+		// wait for dma transfer to complete or fifo to drain
+		if (dma_command && !(status & S_TC0) && fifo_pos)
 			break;
 
 		function_complete();
 		break;
 
 	case INIT_XFR_BUS_COMPLETE:
-		// wait for dma transfer to complete
-		if (dma_command && !(status & S_TC0))
+		// wait for dma transfer to complete or fifo to drain
+		if (dma_command && !(status & S_TC0) && fifo_pos)
 			break;
 
 		bus_complete();
@@ -987,7 +987,7 @@ WRITE8_MEMBER(ncr5390_device::clock_w)
 void ncr5390_device::dma_set(int dir)
 {
 	dma_dir = dir;
-	if(dma_dir == DMA_OUT && fifo_pos != 16 && tcounter > fifo_pos)
+	if(dma_dir == DMA_OUT && fifo_pos != 16 && ((tcounter > fifo_pos) || !tcounter))
 		drq_set();
 }
 


### PR DESCRIPTION
After reversing myself on this several times before, I hope I've now finally got it right.
* function/bus complete should proceed when the fifo is empty, to allow devices to send less data than indicated in the transfer count
* raise drq when tcounter = 0 (meaning 65536 bytes)