### PR TITLE
z80: Remove some MCFG_ macros. (nw)

### DIFF
--- a/src/devices/bus/a2bus/a2applicard.cpp
+++ b/src/devices/bus/a2bus/a2applicard.cpp
@@ -52,11 +52,12 @@ ROM_END
 //  device_add_mconfig - add device configuration
 //-------------------------------------------------
 
-MACHINE_CONFIG_START(a2bus_applicard_device::device_add_mconfig)
-	MCFG_DEVICE_ADD(Z80_TAG, Z80, 6000000) // Z80 runs at 6 MHz
-	MCFG_DEVICE_PROGRAM_MAP(z80_mem)
-	MCFG_DEVICE_IO_MAP(z80_io)
-MACHINE_CONFIG_END
+void a2bus_applicard_device::device_add_mconfig(machine_config &config)
+{
+	Z80(config, m_z80, 6000000); // Z80 runs at 6 MHz
+	m_z80->set_addrmap(AS_PROGRAM, &a2bus_applicard_device::z80_mem);
+	m_z80->set_addrmap(AS_IO, &a2bus_applicard_device::z80_io);
+}
 
 //-------------------------------------------------
 //  device_rom_region - device-specific ROMs

--- a/src/devices/bus/a2bus/a2softcard.cpp
+++ b/src/devices/bus/a2bus/a2softcard.cpp
@@ -37,10 +37,11 @@ void a2bus_softcard_device::z80_mem(address_map &map)
 //  device_add_mconfig - add device configuration
 //-------------------------------------------------
 
-MACHINE_CONFIG_START(a2bus_softcard_device::device_add_mconfig)
-	MCFG_DEVICE_ADD(Z80_TAG, Z80, 1021800*2)   // Z80 runs on double the Apple II's clock
-	MCFG_DEVICE_PROGRAM_MAP(z80_mem)
-MACHINE_CONFIG_END
+void a2bus_softcard_device::device_add_mconfig(machine_config &config)
+{
+	Z80(config, m_z80, 1021800*2);   // Z80 runs on double the Apple II's clock
+	m_z80->set_addrmap(AS_PROGRAM, &a2bus_softcard_device::z80_mem);
+}
 
 //**************************************************************************
 //  LIVE DEVICE

--- a/src/devices/bus/c64/cpm.cpp
+++ b/src/devices/bus/c64/cpm.cpp
@@ -60,11 +60,12 @@ void c64_cpm_cartridge_device::z80_io(address_map &map)
 //  device_add_mconfig - add device configuration
 //-------------------------------------------------
 
-MACHINE_CONFIG_START(c64_cpm_cartridge_device::device_add_mconfig)
-	MCFG_DEVICE_ADD(Z80_TAG, Z80, 3000000)
-	MCFG_DEVICE_PROGRAM_MAP(z80_mem)
-	MCFG_DEVICE_IO_MAP(z80_io)
-MACHINE_CONFIG_END
+void c64_cpm_cartridge_device::device_add_mconfig(machine_config &config)
+{
+	Z80(config, m_maincpu, 3000000);
+	m_maincpu->set_addrmap(AS_PROGRAM, &c64_cpm_cartridge_device::z80_mem);
+	m_maincpu->set_addrmap(AS_IO, &c64_cpm_cartridge_device::z80_io);
+}
 
 
 


### PR DESCRIPTION
Removes `MACHINE_CONFIG_START` macros.