### PR TITLE
1942.cpp: More macro cleanup. (nw)

### DIFF
--- a/src/mame/drivers/1942.cpp
+++ b/src/mame/drivers/1942.cpp
@@ -61,17 +61,6 @@ correctly.
 
 ***************************************************************************/
 
-/* 12mhz OSC */
-#define MASTER_CLOCK      (XTAL(12'000'000))
-#define MAIN_CPU_CLOCK      (MASTER_CLOCK/3)
-#define SOUND_CPU_CLOCK     (MASTER_CLOCK/4)
-#define AUDIO_CLOCK     (MASTER_CLOCK/8)
-/* 20mhz OSC - both Z80s are 4 MHz */
-#define MASTER_CLOCK_1942P     (XTAL(20'000'000))
-#define MAIN_CPU_CLOCK_1942P      (MASTER_CLOCK_1942P/5)
-#define SOUND_CPU_CLOCK_1942P     (MASTER_CLOCK_1942P/5)
-#define AUDIO_CLOCK_1942P     (MASTER_CLOCK_1942P/16)
-
 #include "emu.h"
 #include "includes/1942.h"
 
@@ -82,6 +71,21 @@ correctly.
 #include "speaker.h"
 
 #include "netlist/devices/net_lib.h"
+
+namespace {
+
+/* 12mhz OSC */
+constexpr XTAL MASTER_CLOCK(12_MHz_XTAL);
+constexpr XTAL MAIN_CPU_CLOCK(MASTER_CLOCK/3);
+constexpr XTAL SOUND_CPU_CLOCK(MASTER_CLOCK/4);
+constexpr XTAL AUDIO_CLOCK(MASTER_CLOCK/8);
+/* 20mhz OSC - both Z80s are 4 MHz */
+constexpr XTAL MASTER_CLOCK_1942P(20_MHz_XTAL);
+constexpr XTAL MAIN_CPU_CLOCK_1942P(MASTER_CLOCK_1942P/5);
+constexpr XTAL SOUND_CPU_CLOCK_1942P(MASTER_CLOCK_1942P/5);
+constexpr XTAL AUDIO_CLOCK_1942P(MASTER_CLOCK_1942P/16);
+
+} // anonymous namespace
 
 #define NLFILT(RA, R1, C1, R2) \
 	NET_C(RA.1, V5)             \
@@ -589,7 +593,7 @@ MACHINE_CONFIG_START(_1942_state::_1942)
 	/* sound hardware */
 	SPEAKER(config, "mono").front_center();
 
-	MCFG_GENERIC_LATCH_8_ADD("soundlatch")
+	GENERIC_LATCH_8(config, m_soundlatch);
 
 	MCFG_DEVICE_ADD("ay1", AY8910, AUDIO_CLOCK)  /* 1.5 MHz */
 	MCFG_AY8910_OUTPUT_TYPE(AY8910_RESISTOR_OUTPUT)
@@ -659,13 +663,11 @@ MACHINE_CONFIG_START(_1942p_state::_1942p)
 	/* sound hardware */
 	SPEAKER(config, "mono").front_center();
 
-	MCFG_GENERIC_LATCH_8_ADD("soundlatch")
-	MCFG_GENERIC_LATCH_DATA_PENDING_CB(INPUTLINE("audiocpu", INPUT_LINE_NMI))
+	GENERIC_LATCH_8(config, m_soundlatch);
+	m_soundlatch->data_pending_callback().set_inputline(m_audiocpu, INPUT_LINE_NMI);
 
-	MCFG_DEVICE_ADD("ay1", AY8910, AUDIO_CLOCK_1942P) /* 1.25 MHz - verified on PCB */
-	MCFG_SOUND_ROUTE(ALL_OUTPUTS, "mono", 0.25)
-	MCFG_DEVICE_ADD("ay2", AY8910, AUDIO_CLOCK_1942P) /* 1.25 MHz - verified on PCB */
-	MCFG_SOUND_ROUTE(ALL_OUTPUTS, "mono", 0.25)
+	AY8910(config, "ay1", AUDIO_CLOCK_1942P).add_route(ALL_OUTPUTS, "mono", 0.25); // 1.25 MHz - verified on PCB
+	AY8910(config, "ay2", AUDIO_CLOCK_1942P).add_route(ALL_OUTPUTS, "mono", 0.25); // 1.25 MHz - verified on PCB
 MACHINE_CONFIG_END
 
 


### PR DESCRIPTION
- Remove a few more `MCFG_` macros .

- Use `constexpr` instead of defining macro constants.