### PR TITLE
Fix several bugs in the IDE HDD code to make MS-DOS 6.22's Setup happy.

### DIFF
--- a/src/devices/machine/idehd.cpp
+++ b/src/devices/machine/idehd.cpp
@@ -385,8 +385,8 @@ attotime ata_mass_storage_device::seek_time()
 		return attotime::zero;
 
 	uint32_t new_lba = lba_address();
-	uint16_t old_cylinder = m_cur_lba / sectors_per_cylinder;
-	uint16_t new_cylinder = new_lba / sectors_per_cylinder;
+	int16_t old_cylinder = m_cur_lba / sectors_per_cylinder;
+	int16_t new_cylinder = new_lba / sectors_per_cylinder;
 	uint16_t diff = abs(old_cylinder - new_cylinder);
 
 	m_cur_lba = new_lba;
@@ -394,7 +394,7 @@ attotime ata_mass_storage_device::seek_time()
 	if (diff == 0)
 		return TIME_BETWEEN_SECTORS;
 
-	attotime seek_time = ((TIME_FULL_STROKE_SEEK - TIME_PER_ROTATION) * m_num_cylinders) / diff;
+	attotime seek_time = ((TIME_FULL_STROKE_SEEK - TIME_PER_ROTATION) * diff) / m_num_cylinders;
 
 	return seek_time + TIME_AVERAGE_ROTATIONAL_LATENCY;
 }

--- a/src/devices/machine/idehd.cpp
+++ b/src/devices/machine/idehd.cpp
@@ -379,15 +379,15 @@ void ata_mass_storage_device::security_error()
 
 attotime ata_mass_storage_device::seek_time()
 {
-	int sectors_per_cylinder =  m_num_heads * m_num_sectors;
+	uint32_t sectors_per_cylinder =  m_num_heads * m_num_sectors;
 
 	if (sectors_per_cylinder == 0 || m_num_cylinders == 0)
 		return attotime::zero;
 
-	int new_lba = lba_address();
-	int old_cylinder = m_cur_lba / sectors_per_cylinder;
-	int new_cylinder = new_lba / sectors_per_cylinder;
-	int diff = abs(old_cylinder - new_cylinder);
+	uint32_t new_lba = lba_address();
+	uint16_t old_cylinder = m_cur_lba / sectors_per_cylinder;
+	uint16_t new_cylinder = new_lba / sectors_per_cylinder;
+	uint16_t diff = abs(old_cylinder - new_cylinder);
 
 	m_cur_lba = new_lba;
 
@@ -435,7 +435,7 @@ void ata_mass_storage_device::fill_buffer()
 
 void ata_mass_storage_device::finished_read()
 {
-	int lba = lba_address(), read_status;
+	uint32_t lba = lba_address(), read_status;
 
 	set_dasp(CLEAR_LINE);
 
@@ -569,7 +569,7 @@ void ata_mass_storage_device::process_buffer()
 
 void ata_mass_storage_device::finished_write()
 {
-	int lba = lba_address(), count;
+	uint32_t lba = lba_address(), count;
 
 	set_dasp(CLEAR_LINE);
 

--- a/src/devices/machine/idehd.cpp
+++ b/src/devices/machine/idehd.cpp
@@ -394,7 +394,7 @@ attotime ata_mass_storage_device::seek_time()
 	if (diff == 0)
 		return TIME_BETWEEN_SECTORS;
 
-	attotime seek_time = ((TIME_FULL_STROKE_SEEK - TIME_PER_ROTATION) * diff) / m_num_cylinders;
+	attotime seek_time = (TIME_FULL_STROKE_SEEK * diff) / m_num_cylinders;
 
 	return seek_time + TIME_AVERAGE_ROTATIONAL_LATENCY;
 }

--- a/src/devices/machine/idehd.cpp
+++ b/src/devices/machine/idehd.cpp
@@ -394,7 +394,7 @@ attotime ata_mass_storage_device::seek_time()
 	if (diff == 0)
 		return TIME_BETWEEN_SECTORS;
 
-	attotime seek_time = (TIME_FULL_STROKE_SEEK * diff) / m_num_cylinders;
+	attotime seek_time = ((TIME_FULL_STROKE_SEEK - TIME_PER_ROTATION) * m_num_cylinders) / diff;
 
 	return seek_time + TIME_AVERAGE_ROTATIONAL_LATENCY;
 }


### PR DESCRIPTION
This seek time calculation **looks** correct, as it seems to generally mean that bigger hard drives need more time to format, instead of needing less time to format like they do in master, which is usually true of real hard drives as well. I'm honestly surprised that the `TIME_PER_ROTATION` constant wasn't used in the master version of this code. Anyway, this formula should hopefully bring MUCH more faithful timings.