### PR TITLE
imgtool: fix parsing options with enum values

### DIFF
--- a/src/tools/imgtool/main.cpp
+++ b/src/tools/imgtool/main.cpp
@@ -106,7 +106,23 @@ static int parse_options(int argc, char *argv[], int minunnamed, int maxunnamed,
 				if (i < minunnamed)
 					goto error; /* Too few unnamed */
 
-				resolution->find(name)->set_value(value);
+				util::option_resolution::entry *entry = resolution->find(name);
+				if (entry->option_type() == util::option_guide::entry::option_type::ENUM_BEGIN)
+				{
+					const util::option_guide::entry *enum_value;
+					for (enum_value = entry->enum_value_begin(); enum_value != entry->enum_value_end(); enum_value++)
+					{
+						if (!strcmp (enum_value->identifier(), value))
+						{
+							entry->set_value(enum_value->parameter());
+							break;
+						}
+					}
+					if (enum_value ==  entry->enum_value_end())
+						goto error;
+				}
+				else
+					entry->set_value(value);
 			}
 		}
 	}


### PR DESCRIPTION
When parsing an enumerated option, we should use the parameter of the
enumerated value, as an integer, instead of the raw identifier as a
string. The behaviour probably changed around commit b60879e595, but
modules still expect the old behaviour.