### PR TITLE
Minor galaxian.cpp changes and fixes

### DIFF
--- a/src/mame/drivers/galaxian.cpp
+++ b/src/mame/drivers/galaxian.cpp
@@ -4602,7 +4602,7 @@ static INPUT_PORTS_START( mandingarf )
 	PORT_BIT( 0x08, IP_ACTIVE_HIGH, IPT_JOYSTICK_RIGHT ) PORT_4WAY
 	PORT_BIT( 0x10, IP_ACTIVE_HIGH, IPT_BUTTON1 )
 	PORT_BIT( 0x20, IP_ACTIVE_HIGH, IPT_JOYSTICK_DOWN ) PORT_4WAY
-	PORT_DIPNAME( 0x40, 0x40, DEF_STR( Unknown ) )
+	PORT_DIPNAME( 0x40, 0x40, DEF_STR( Unknown ) ) // unused?
 	PORT_DIPSETTING(    0x40, DEF_STR( Off ) )
 	PORT_DIPSETTING(    0x00, DEF_STR( On ) )
 	PORT_BIT( 0x80, IP_ACTIVE_HIGH, IPT_JOYSTICK_UP ) PORT_4WAY
@@ -4610,6 +4610,7 @@ static INPUT_PORTS_START( mandingarf )
 	PORT_START("IN1")
 	PORT_BIT( 0x01, IP_ACTIVE_HIGH, IPT_START1 )
 	PORT_BIT( 0x02, IP_ACTIVE_HIGH, IPT_START2 )
+	/* the rest appear to be unused, except for Lives? */
 	PORT_DIPNAME( 0x04, 0x04, DEF_STR( Unknown ) )
 	PORT_DIPSETTING(    0x04, DEF_STR( Off ) )
 	PORT_DIPSETTING(    0x00, DEF_STR( On ) )
@@ -4623,10 +4624,10 @@ static INPUT_PORTS_START( mandingarf )
 	PORT_DIPSETTING(    0x20, DEF_STR( Off ) )
 	PORT_DIPSETTING(    0x00, DEF_STR( On ) )
 	PORT_DIPNAME( 0xc0, 0x40, DEF_STR( Lives ) )
-	PORT_DIPSETTING(    0x00, "255 (Cheat)" )
-	PORT_DIPSETTING(    0x80, "4" )
-	PORT_DIPSETTING(    0x40, "3" )
 	PORT_DIPSETTING(    0xc0, "2" )
+	PORT_DIPSETTING(    0x40, "3" ) // skips the self test checks?
+	PORT_DIPSETTING(    0x80, "4" )
+	PORT_DIPSETTING(    0x00, "255 (Cheat)" ) // skips the self test checks?
 
 	/* these two are reversed for some reason... */
 	PORT_START("IN2")
@@ -4636,6 +4637,7 @@ static INPUT_PORTS_START( mandingarf )
 	PORT_DIPNAME( 0x04, 0x00, DEF_STR( Coinage ) )
 	PORT_DIPSETTING(    0x00, "A 1/1 B 1/6" )
 	PORT_DIPSETTING(    0x04, "A 2/1 B 1/3" )
+	/* the rest appear to be unused? */
 	PORT_DIPNAME( 0x08, 0x08, DEF_STR( Unknown ) )
 	PORT_DIPSETTING(    0x08, DEF_STR( Off ) )
 	PORT_DIPSETTING(    0x00, DEF_STR( On ) )
@@ -6230,20 +6232,6 @@ MACHINE_CONFIG_START(galaxian_state::turtles)
 MACHINE_CONFIG_END
 
 
-MACHINE_CONFIG_START(galaxian_state::turpins)
-	turtles(config);
-
-	// the ROMs came from a blister, so there aren't PCB infos available. Chip types and clocks are guessed.
-
-	/* alternate memory map */
-	MCFG_DEVICE_MODIFY("maincpu")
-	MCFG_DEVICE_PROGRAM_MAP(turpins_map)
-
-	MCFG_DEVICE_MODIFY("audiocpu")
-	MCFG_DEVICE_PROGRAM_MAP(turpins_sound_map)
-MACHINE_CONFIG_END
-
-
 MACHINE_CONFIG_START(galaxian_state::theend)
 	konami_base(config);
 	konami_sound_2x_ay8910(config);
@@ -6296,6 +6284,7 @@ MACHINE_CONFIG_START(galaxian_state::jungsub)
 	MCFG_SOUND_ROUTE(ALL_OUTPUTS, "speaker", 0.5)
 MACHINE_CONFIG_END
 
+
 MACHINE_CONFIG_START(galaxian_state::explorer) // Sidam 10800
 	sidam_bootleg_base(config);
 
@@ -6304,18 +6293,18 @@ MACHINE_CONFIG_START(galaxian_state::explorer) // Sidam 10800
 	MCFG_DEVICE_PROGRAM_MAP(explorer_map)
 
 	/* 2nd CPU to drive sound */
-	MCFG_DEVICE_ADD("audiocpu", Z80, 12_MHz_XTAL / 2 / 2 / 2)
+	MCFG_DEVICE_ADD("audiocpu", Z80, 12_MHz_XTAL / 2 / 2 / 2) /* clock not verified */
 	MCFG_DEVICE_PROGRAM_MAP(konami_sound_map)
 	MCFG_DEVICE_IO_MAP(konami_sound_portmap)
 
 	MCFG_GENERIC_LATCH_8_ADD("soundlatch")
 
 	/* sound hardware is a pair of AY-3-8912 */
-	MCFG_DEVICE_ADD("8910.0", AY8912, 12_MHz_XTAL / 2 / 2 / 2)
+	MCFG_DEVICE_ADD("8910.0", AY8912, 12_MHz_XTAL / 2 / 2 / 2) /* matches PCB, needs verification */
 	MCFG_AY8910_PORT_A_READ_CB(READ8(*this, galaxian_state, explorer_sound_latch_r))
 	MCFG_SOUND_ROUTE(ALL_OUTPUTS, "speaker", 0.25)
 
-	MCFG_DEVICE_ADD("8910.1", AY8912, 12_MHz_XTAL / 2 / 2 / 2)
+	MCFG_DEVICE_ADD("8910.1", AY8912, 12_MHz_XTAL / 2 / 2 / 2) /* matches PCB, needs verification */
 	MCFG_AY8910_PORT_A_READ_CB(READ8(*this, galaxian_state, konami_sound_timer_r))
 	MCFG_SOUND_ROUTE(ALL_OUTPUTS, "speaker", 0.25)
 MACHINE_CONFIG_END
@@ -6340,21 +6329,22 @@ MACHINE_CONFIG_START(galaxian_state::amigo2) // marked "AMI", but similar to abo
 	MCFG_DEVICE_PROGRAM_MAP(amigo2_map)
 
 	/* 2nd CPU to drive sound */
-	MCFG_DEVICE_ADD("audiocpu", Z80, 12_MHz_XTAL / 2 / 2 / 2)
+	MCFG_DEVICE_ADD("audiocpu", Z80, 12_MHz_XTAL / 2 / 2 / 2) /* clock not verified */
 	MCFG_DEVICE_PROGRAM_MAP(konami_sound_map)
 	MCFG_DEVICE_IO_MAP(konami_sound_portmap)
 
 	MCFG_GENERIC_LATCH_8_ADD("soundlatch")
 
 	/* sound hardware */
-	MCFG_DEVICE_ADD("8910.0", AY8910, 12_MHz_XTAL / 2 / 2 / 2)
+	MCFG_DEVICE_ADD("8910.0", AY8910, 12_MHz_XTAL / 2 / 2 / 2) /* matches PCB, needs verification */
 	MCFG_AY8910_PORT_A_READ_CB(READ8("soundlatch", generic_latch_8_device, read))
 	MCFG_AY8910_PORT_B_READ_CB(READ8(*this, galaxian_state, konami_sound_timer_r))
 	MCFG_SOUND_ROUTE(ALL_OUTPUTS, "speaker", 0.25)
 
-	MCFG_DEVICE_ADD("8910.1", AY8910, 12_MHz_XTAL / 2 / 2 / 2)
+	MCFG_DEVICE_ADD("8910.1", AY8910, 12_MHz_XTAL / 2 / 2 / 2) /* matches PCB, needs verification */
 	MCFG_SOUND_ROUTE(ALL_OUTPUTS, "speaker", 0.25)
 MACHINE_CONFIG_END
+
 
 MACHINE_CONFIG_START(galaxian_state::scorpion)
 	scramble_base(config);
@@ -6406,7 +6396,6 @@ MACHINE_CONFIG_START(galaxian_state::sfx)
 	MCFG_DEVICE_ADD("vref", VOLTAGE_REGULATOR, 0) MCFG_VOLTAGE_REGULATOR_OUTPUT(5.0)
 	MCFG_SOUND_ROUTE(0, "dac", 1.0, DAC_VREF_POS_INPUT) MCFG_SOUND_ROUTE(0, "dac", -1.0, DAC_VREF_NEG_INPUT)
 MACHINE_CONFIG_END
-
 
 MACHINE_CONFIG_START(galaxian_state::monsterz)
 	sfx(config);
@@ -6506,6 +6495,18 @@ MACHINE_CONFIG_START(galaxian_state::froggeram)
 	/* alternate memory map */
 	MCFG_DEVICE_MODIFY("maincpu")
 	MCFG_DEVICE_PROGRAM_MAP(froggeram_map)
+MACHINE_CONFIG_END
+
+
+MACHINE_CONFIG_START(galaxian_state::turpins) // the ROMs came from a blister, so there aren't PCB infos available. Chip types and clocks are guessed.
+	scobra(config);
+
+	/* alternate memory map */
+	MCFG_DEVICE_MODIFY("maincpu")
+	MCFG_DEVICE_PROGRAM_MAP(turpins_map)
+
+	MCFG_DEVICE_MODIFY("audiocpu")
+	MCFG_DEVICE_PROGRAM_MAP(turpins_sound_map)
 MACHINE_CONFIG_END
 
 
@@ -12318,15 +12319,12 @@ GAME( 1980, astrians,    galaxian, galaxian,   swarm,      galaxian_state, init_
 
 GAME( 19??, tst_galx,    galaxian, galaxian,   galaxian,   galaxian_state, init_galaxian,   ROT90,  "<unknown>", "Galaxian Test ROM", MACHINE_SUPPORTS_SAVE )
 
-
-
 /* other games on basic galaxian hardware */
 GAME( 1981, blkhole,     0,        galaxian,   blkhole,    galaxian_state, init_galaxian,   ROT90,  "TDS & MINTS", "Black Hole", MACHINE_SUPPORTS_SAVE )
 GAME( 1982, orbitron,    0,        galaxian,   orbitron,   galaxian_state, init_galaxian,   ROT270, "Comsoft (Signatron USA license)", "Orbitron", MACHINE_SUPPORTS_SAVE ) // there's a Comsoft copyright in one of the roms, and the gameplay is the same as Victory below
 GAME( 1980, luctoday,    0,        galaxian,   luctoday,   galaxian_state, init_galaxian,   ROT270, "Sigma", "Lucky Today", MACHINE_WRONG_COLORS | MACHINE_SUPPORTS_SAVE )
 GAME( 19??, chewing,     luctoday, galaxian,   luctoday,   galaxian_state, init_galaxian,   ROT90,  "<unknown>", "Chewing Gum", MACHINE_SUPPORTS_SAVE )
 GAME( 1982, catacomb,    0,        galaxian,   catacomb,   galaxian_state, init_galaxian,   ROT90,  "MTM Games", "Catacomb", MACHINE_WRONG_COLORS | MACHINE_SUPPORTS_SAVE )
-GAME( 19??, omegab,      theend,   galaxian,   omegab,     galaxian_state, init_galaxian,   ROT270, "bootleg?", "Omega (bootleg?)", MACHINE_SUPPORTS_SAVE )
 
 /* basic hardware + extra RAM */
 GAME( 1982, victoryc,    0,        galaxian,   victoryc,   galaxian_state, init_victoryc,   ROT270, "Comsoft", "Victory (Comsoft)", MACHINE_SUPPORTS_SAVE )
@@ -12377,7 +12375,6 @@ GAME( 1981, batman2,     phoenix,  galaxian,   batman2,    galaxian_state, init_
 GAME( 1983, ladybugg,    ladybug,  galaxian,   ladybugg,   galaxian_state, init_batman2,    ROT270, "bootleg", "Lady Bug (bootleg on Galaxian hardware)", MACHINE_SUPPORTS_SAVE )
 GAME( 1981, atlantisb,   atlantis, galaxian,   atlantib,   galaxian_state, init_galaxian,   ROT270, "bootleg", "Battle of Atlantis (bootleg)", MACHINE_SUPPORTS_SAVE ) // I don't know if this should have a starfield...
 GAME( 1982, tenspot,     0,        tenspot,    tenspot,    galaxian_state, init_tenspot,    ROT270, "Thomas Automatics", "Ten Spot", MACHINE_NOT_WORKING ) // work out how menu works
-
 
 /* separate tile/sprite ROMs, plus INT instead of NMI */
 GAME( 1984, devilfsg,    devilfsh, pacmanbl,   devilfsg,   galaxian_state, init_devilfsg,   ROT270, "Vision / Artic", "Devil Fish (Galaxian hardware, bootleg?)", MACHINE_SUPPORTS_SAVE )
@@ -12523,6 +12520,7 @@ GAME( 1982, mandingac,   amidar,   galaxian,   mandingarf, galaxian_state, init_
 GAME( 1980, theend,      0,        theend,     theend,     galaxian_state, init_theend,     ROT90,  "Konami", "The End", MACHINE_SUPPORTS_SAVE )
 GAME( 1980, theends,     theend,   theend,     theend,     galaxian_state, init_theend,     ROT90,  "Konami (Stern Electronics license)", "The End (Stern Electronics)", MACHINE_SUPPORTS_SAVE )
 GAME( 1981, takeoff,     theend,   takeoff,    explorer,   galaxian_state, init_explorer,   ROT90,  "bootleg (Sidam)", "Take Off (bootleg of The End)", MACHINE_WRONG_COLORS | MACHINE_SUPPORTS_SAVE ) // colors likely need bitswap<8> somewhere; needs different sound timer. reference: https://www.youtube.com/watch?v=iPYX3yJORTE
+GAME( 19??, omegab,      theend,   galaxian,   omegab,     galaxian_state, init_galaxian,   ROT270, "bootleg?", "Omega (The End bootleg? on Galaxian hardware)", MACHINE_SUPPORTS_SAVE )
 
 GAME( 1981, scramble,    0,        scramble,   scramble,   galaxian_state, init_scramble,   ROT90,  "Konami", "Scramble", MACHINE_SUPPORTS_SAVE )
 GAME( 1981, scrambles,   scramble, scramble,   scramble,   galaxian_state, init_scramble,   ROT90,  "Konami (Stern Electronics license)", "Scramble (Stern Electronics set 1)", MACHINE_SUPPORTS_SAVE )

--- a/src/mame/drivers/galaxian.cpp
+++ b/src/mame/drivers/galaxian.cpp
@@ -1931,7 +1931,7 @@ void galaxian_state::amigo2_map(address_map &map)
 	map(0x4003, 0x4003).mirror(0x2ffc).portr("IN3");
 	map(0x5000, 0x5000).mirror(0x2fff).w(FUNC(galaxian_state::konami_sound_control_w));
 	map(0x8000, 0x87ff).ram();
-	map(0x8800, 0x8bff).mirror(0x4700).ram().w(FUNC(galaxian_state::galaxian_videoram_w)).share("videoram");
+	map(0x8800, 0x8bff).mirror(0x4400).ram().w(FUNC(galaxian_state::galaxian_videoram_w)).share("videoram");
 	map(0x9000, 0x90ff).mirror(0x4700).ram().w(FUNC(galaxian_state::galaxian_objram_w)).share("spriteram");
 	map(0xa000, 0xa000).mirror(0x47c7).w(FUNC(galaxian_state::scramble_background_red_w));
 	map(0xa008, 0xa008).mirror(0x47c7).w(FUNC(galaxian_state::irq_enable_w));
@@ -2112,14 +2112,14 @@ WRITE8_MEMBER(galaxian_state::tenspot_unk_e000_w)
 void galaxian_state::tenspot_select_map(address_map &map)
 {
 	map.unmap_value_high();
-	map(0x0000, 0x07ff).rom();
-	map(0x2000, 0x23ff).ram();
-	map(0x4000, 0x4000).mirror(0x17ff).portr("SELECT2");
-	map(0x6000, 0x6000).mirror(0x17ff).w(FUNC(galaxian_state::tenspot_unk_6000_w));
-	map(0x8000, 0x8000).mirror(0x17ff).w(FUNC(galaxian_state::tenspot_unk_8000_w));
-	map(0xa000, 0xa03f).ram();
-	map(0xc000, 0xc000).mirror(0x17ff).portr("SELECT");
-	map(0xe000, 0xe000).mirror(0x17ff).w(FUNC(galaxian_state::tenspot_unk_e000_w));
+	map(0x0000, 0x07ff).mirror(0x1800).rom();
+	map(0x2000, 0x23ff).mirror(0x1c00).ram();
+	map(0x4000, 0x4000).mirror(0x1fff).portr("SELECT2");
+	map(0x6000, 0x6000).mirror(0x1fff).w(FUNC(galaxian_state::tenspot_unk_6000_w));
+	map(0x8000, 0x8000).mirror(0x1fff).w(FUNC(galaxian_state::tenspot_unk_8000_w));
+	map(0xa000, 0xa03f).mirror(0x1fc0).ram();
+	map(0xc000, 0xc000).mirror(0x1fff).portr("SELECT");
+	map(0xe000, 0xe000).mirror(0x1fff).w(FUNC(galaxian_state::tenspot_unk_e000_w));
 }
 
 
@@ -4594,6 +4594,66 @@ static INPUT_PORTS_START( amidars )
 INPUT_PORTS_END
 
 
+static INPUT_PORTS_START( mandingarf )
+	PORT_START("IN0")
+	PORT_BIT( 0x01, IP_ACTIVE_HIGH, IPT_COIN1 )
+	PORT_BIT( 0x02, IP_ACTIVE_HIGH, IPT_COIN2 )
+	PORT_BIT( 0x04, IP_ACTIVE_HIGH, IPT_JOYSTICK_LEFT ) PORT_4WAY
+	PORT_BIT( 0x08, IP_ACTIVE_HIGH, IPT_JOYSTICK_RIGHT ) PORT_4WAY
+	PORT_BIT( 0x10, IP_ACTIVE_HIGH, IPT_BUTTON1 )
+	PORT_BIT( 0x20, IP_ACTIVE_HIGH, IPT_JOYSTICK_DOWN ) PORT_4WAY
+	PORT_DIPNAME( 0x40, 0x40, DEF_STR( Unknown ) )
+	PORT_DIPSETTING(    0x40, DEF_STR( Off ) )
+	PORT_DIPSETTING(    0x00, DEF_STR( On ) )
+	PORT_BIT( 0x80, IP_ACTIVE_HIGH, IPT_JOYSTICK_UP ) PORT_4WAY
+
+	PORT_START("IN1")
+	PORT_BIT( 0x01, IP_ACTIVE_HIGH, IPT_START1 )
+	PORT_BIT( 0x02, IP_ACTIVE_HIGH, IPT_START2 )
+	PORT_DIPNAME( 0x04, 0x04, DEF_STR( Unknown ) )
+	PORT_DIPSETTING(    0x04, DEF_STR( Off ) )
+	PORT_DIPSETTING(    0x00, DEF_STR( On ) )
+	PORT_DIPNAME( 0x08, 0x08, DEF_STR( Unknown ) )
+	PORT_DIPSETTING(    0x08, DEF_STR( Off ) )
+	PORT_DIPSETTING(    0x00, DEF_STR( On ) )
+	PORT_DIPNAME( 0x10, 0x10, DEF_STR( Unknown ) )
+	PORT_DIPSETTING(    0x10, DEF_STR( Off ) )
+	PORT_DIPSETTING(    0x00, DEF_STR( On ) )
+	PORT_DIPNAME( 0x20, 0x20, DEF_STR( Unknown ) )
+	PORT_DIPSETTING(    0x20, DEF_STR( Off ) )
+	PORT_DIPSETTING(    0x00, DEF_STR( On ) )
+	PORT_DIPNAME( 0xc0, 0x40, DEF_STR( Lives ) )
+	PORT_DIPSETTING(    0x00, "255 (Cheat)" )
+	PORT_DIPSETTING(    0x80, "4" )
+	PORT_DIPSETTING(    0x40, "3" )
+	PORT_DIPSETTING(    0xc0, "2" )
+
+	/* these two are reversed for some reason... */
+	PORT_START("IN2")
+	PORT_DIPNAME( 0x02, 0x00, DEF_STR( Bonus_Life ) )
+	PORT_DIPSETTING(    0x00, "30000 70000" )
+	PORT_DIPSETTING(    0x02, "50000 80000" )
+	PORT_DIPNAME( 0x04, 0x00, DEF_STR( Coinage ) )
+	PORT_DIPSETTING(    0x00, "A 1/1 B 1/6" )
+	PORT_DIPSETTING(    0x04, "A 2/1 B 1/3" )
+	PORT_DIPNAME( 0x08, 0x08, DEF_STR( Unknown ) )
+	PORT_DIPSETTING(    0x08, DEF_STR( Off ) )
+	PORT_DIPSETTING(    0x00, DEF_STR( On ) )
+	PORT_DIPNAME( 0x10, 0x10, DEF_STR( Unknown ) )
+	PORT_DIPSETTING(    0x10, DEF_STR( Off ) )
+	PORT_DIPSETTING(    0x00, DEF_STR( On ) )
+	PORT_DIPNAME( 0x20, 0x20, DEF_STR( Unknown ) )
+	PORT_DIPSETTING(    0x20, DEF_STR( Off ) )
+	PORT_DIPSETTING(    0x00, DEF_STR( On ) )
+	PORT_DIPNAME( 0x40, 0x40, DEF_STR( Unknown ) )
+	PORT_DIPSETTING(    0x40, DEF_STR( Off ) )
+	PORT_DIPSETTING(    0x00, DEF_STR( On ) )
+	PORT_DIPNAME( 0x80, 0x80, DEF_STR( Unknown ) )
+	PORT_DIPSETTING(    0x80, DEF_STR( Off ) )
+	PORT_DIPSETTING(    0x00, DEF_STR( On ) )
+INPUT_PORTS_END
+
+
 static INPUT_PORTS_START( theend )
 	PORT_START("IN0")
 	PORT_BIT( 0x01, IP_ACTIVE_LOW, IPT_UNUSED )
@@ -6361,12 +6421,12 @@ MACHINE_CONFIG_START(galaxian_state::monsterz)
 	MCFG_I8255_OUT_PORTC_CB(WRITE8(*this, galaxian_state, monsterz_portc_1_w))
 
 	/* there are likely other differences too, but those can wait until after protection is sorted out */
-
 MACHINE_CONFIG_END
 
 
 MACHINE_CONFIG_START(galaxian_state::scobra)
 	scramble_base(config);
+
 	/* alternate memory map */
 	MCFG_DEVICE_MODIFY("maincpu")
 	MCFG_DEVICE_PROGRAM_MAP(scobra_map)
@@ -6768,11 +6828,13 @@ void galaxian_state::init_nolock()
 
 void galaxian_state::init_warofbug()
 {
+	address_space &space = m_maincpu->space(AS_PROGRAM);
+
 	/* typical bootleg galaxian configuration... */
 	init_nolock();
 
 	/* but with pin 15 at 2B cut off, to disable stars */
-	common_init(&galaxian_state::galaxian_draw_bullet, &galaxian_state::null_draw_background, nullptr, nullptr);
+	space.unmap_write(0x7004, 0x7004, 0x7f8); // in reality, the LS259 that controls it is intact
 }
 
 
@@ -6864,15 +6926,31 @@ void galaxian_state::init_victoryc()
 
 void galaxian_state::init_victorycb()
 {
-	init_galaxian();
-
 	address_space &space = m_maincpu->space(AS_PROGRAM);
 
-	/* needs a full 2k of RAM */
+	/* same as galaxian... */
+	init_galaxian();
+
+	/* ..but needs a full 2k of RAM */
 	space.install_ram(0x8000, 0x87ff);
 
 	/* disable the stars */
 	space.unmap_write(0x7004, 0x7004, 0x7f8);
+}
+
+
+void galaxian_state::init_mandingarf()
+{
+	address_space &space = m_maincpu->space(AS_PROGRAM);
+
+	/* same as galaxian... */
+	init_galaxian();
+
+	/* ...but needs a full 2k of RAM */
+	space.install_ram(0x4000, 0x47ff);
+
+	/* extend ROM */
+	space.install_rom(0xc000, 0xc7ff, memregion("maincpu")->base() + 0xc000);
 }
 
 /*************************************
@@ -7008,7 +7086,6 @@ void galaxian_state::init_tenspot()
 
 	space.install_read_handler(0x7000, 0x7000, read8_delegate(FUNC(galaxian_state::tenspot_dsw_read),this));
 }
-
 
 
 void galaxian_state::init_devilfsg()
@@ -7348,12 +7425,48 @@ void galaxian_state::init_theend()
 	space.unmap_write(0x6802, 0x6802, 0x7f8);
 }
 
-
 void galaxian_state::init_scramble()
 {
 	/* video extensions */
 	common_init(&galaxian_state::scramble_draw_bullet, &galaxian_state::scramble_draw_background, nullptr, nullptr);
 }
+
+void galaxian_state::init_mandinga()
+{
+	init_scramble();
+
+	/* watchdog is in a different location */
+	address_space &space = m_maincpu->space(AS_PROGRAM);
+
+	watchdog_timer_device *wdog = subdevice<watchdog_timer_device>("watchdog");
+	space.unmap_read(0x7000, 0x7000, 0x7ff);
+	space.install_read_handler(0x6800, 0x6800, 0, 0x7ff, 0, read8_delegate(FUNC(watchdog_timer_device::reset_r), wdog));
+}
+
+void galaxian_state::init_sfx()
+{
+	/* basic configuration */
+	common_init(&galaxian_state::scramble_draw_bullet, &galaxian_state::sfx_draw_background, &galaxian_state::upper_extend_tile_info, nullptr);
+	m_sfx_tilemap = true;
+
+	/* sound board has space for extra ROM */
+	m_audiocpu->space(AS_PROGRAM).install_read_bank(0x0000, 0x3fff, "bank1");
+	membank("bank1")->set_base(memregion("audiocpu")->base());
+}
+
+void galaxian_state::init_atlantis()
+{
+	address_space &space = m_maincpu->space(AS_PROGRAM);
+
+	/* video extensions */
+	common_init(&galaxian_state::scramble_draw_bullet, &galaxian_state::scramble_draw_background, nullptr, nullptr);
+
+	/* watchdog is at $7800? (or is it just disabled?) */
+	watchdog_timer_device *wdog = subdevice<watchdog_timer_device>("watchdog");
+	space.unmap_read(0x7000, 0x77ff);
+	space.install_read_handler(0x7800, 0x7800, 0, 0x7ff, 0, read8_delegate(FUNC(watchdog_timer_device::reset_r), wdog));
+}
+
 
 void galaxian_state::init_sidam()
 {
@@ -7375,45 +7488,6 @@ void galaxian_state::init_amigo2()
 	init_turtles();
 	init_sidam();
 }
-
-void galaxian_state::init_mandinga()
-{
-	init_scramble();
-
-	/* watchdog is in a different location */
-	address_space &space = m_maincpu->space(AS_PROGRAM);
-	watchdog_timer_device *wdog = subdevice<watchdog_timer_device>("watchdog");
-	space.unmap_read(0x7000, 0x7000, 0x7ff);
-	space.install_read_handler(0x6800, 0x6800, 0, 0x7ff, 0, read8_delegate(FUNC(watchdog_timer_device::reset_r), wdog));
-}
-
-void galaxian_state::init_sfx()
-{
-	/* basic configuration */
-	common_init(&galaxian_state::scramble_draw_bullet, &galaxian_state::sfx_draw_background, &galaxian_state::upper_extend_tile_info, nullptr);
-	m_sfx_tilemap = true;
-
-	/* sound board has space for extra ROM */
-	m_audiocpu->space(AS_PROGRAM).install_read_bank(0x0000, 0x3fff, "bank1");
-	membank("bank1")->set_base(memregion("audiocpu")->base());
-}
-
-
-void galaxian_state::init_atlantis()
-{
-	address_space &space = m_maincpu->space(AS_PROGRAM);
-
-	/* video extensions */
-	common_init(&galaxian_state::scramble_draw_bullet, &galaxian_state::scramble_draw_background, nullptr, nullptr);
-
-	/* watchdog is at $7800? (or is it just disabled?) */
-	watchdog_timer_device *wdog = subdevice<watchdog_timer_device>("watchdog");
-	space.unmap_read(0x7000, 0x77ff);
-	space.install_read_handler(0x7800, 0x7800, 0, 0x7ff, 0, read8_delegate(FUNC(watchdog_timer_device::reset_r), wdog));
-}
-
-
-
 
 
 void galaxian_state::init_scobra()
@@ -10918,8 +10992,8 @@ ROM_START( mandinga )
 	ROM_LOAD( "8.bin",        0x3800, 0x0800, CRC(049855ad) SHA1(b455e1ed0183559014722467b0f1c208b06167c3) ) // 2716
 
 	ROM_REGION( 0x10000, "audiocpu", 0 )
-	ROM_LOAD( "11.bin",       0x0000, 0x1000, BAD_DUMP CRC(8ca7b750) SHA1(4f4c2915503b85abe141d717fd254ee10c9da99e) ) // 2732; original was bad dump, but using rom from amidar due to first half being identical
-	ROM_LOAD( "12.bin",       0x1000, 0x1000, BAD_DUMP CRC(9b5bdc0a) SHA1(84d953618c8bf510d23b42232a856ac55f1baff5) ) // 2732; original was bad dump, but using rom from amidar due to first half being identical
+	ROM_LOAD( "11.bin",       0x0000, 0x1000, BAD_DUMP CRC(8ca7b750) SHA1(4f4c2915503b85abe141d717fd254ee10c9da99e) ) // 2732; original was bad dump, but using ROM from amidar due to first half being identical
+	ROM_LOAD( "12.bin",       0x1000, 0x1000, BAD_DUMP CRC(9b5bdc0a) SHA1(84d953618c8bf510d23b42232a856ac55f1baff5) ) // 2732; original was bad dump, but using ROM from amidar due to first half being identical
 
 	ROM_REGION( 0x1000, "gfx1", 0 )
 	ROM_LOAD( "9.bin",        0x0000, 0x0800, CRC(09ed5818) SHA1(69dce85228b2c9176d4be429f530410350a1c76c) ) // 2716
@@ -10927,6 +11001,46 @@ ROM_START( mandinga )
 
 	ROM_REGION( 0x0020, "proms", 0 )
 	ROM_LOAD( "6e.bin",       0x0000, 0x0020, CRC(4e3caeab) SHA1(a25083c3e36d28afdefe4af6e6d4f3155e303625) ) // 82s123
+ROM_END
+
+ROM_START( mandingarf )
+	ROM_REGION( 0x10000, "maincpu", 0 )
+	ROM_LOAD( "2716-mg1.bin",  0x0000, 0x0800, CRC(a684a494) SHA1(76885bb3bdab09f46c7daa25164a2fdaa744742f) ) // 2716
+	ROM_LOAD( "2716-mg2.bin",  0x0800, 0x0800, CRC(f4038373) SHA1(8823b9816fc4ea03b92e08776c13610980f5ea7a) ) // 2716
+	ROM_LOAD( "2716-mg3.bin",  0x1000, 0x0800, CRC(96842877) SHA1(043ce4ed2628a209ca21cc42516c02366cd9f1fa) ) // 2716
+	ROM_LOAD( "2716-mg4.bin",  0x1800, 0x0800, CRC(29873461) SHA1(7d0ee9a82f02163b4cc6a7097e88ae34e96ebf58) ) // 2716
+	ROM_LOAD( "2716-mg5.bin",  0x2000, 0x0800, CRC(400cf1bb) SHA1(06c891f7581b0c1036f6845ea847cd20b6f5dedc) ) // 2716
+	ROM_LOAD( "2716-mg6.bin",  0x2800, 0x0800, CRC(5382f7ed) SHA1(425ec2c2caf404fc8ab13ee38d6567413022e1a1) ) // 2716
+	ROM_LOAD( "2716-mg7.bin",  0x3000, 0x0800, CRC(e78d0c6d) SHA1(947ac20463384ca0721875954d59ec4ae15b0670) ) // 2716
+	ROM_LOAD( "2716-mg8.bin",  0x3800, 0x0800, CRC(8a4018ae) SHA1(9aba6f4527c59b0b016038236d5a6074e65966f6) ) // 2716
+	ROM_LOAD( "2716-mg11.bin", 0xc000, 0x0800, BAD_DUMP CRC(d8bf57e7) SHA1(421a0fa02fccbc52d460fafec6437bd2b7564056) ) // 2716(?), taken from mandingac
+
+	ROM_REGION( 0x1000, "gfx1", 0 )
+	ROM_LOAD( "2716-mg9.bin",  0x0000, 0x0800, CRC(2082ad0a) SHA1(c6014d9575e92adf09b0961c2158a779ebe940c4) ) // 2716
+	ROM_LOAD( "2716-mg10.bin", 0x0800, 0x0800, CRC(1891fc68) SHA1(6d03f5092fd73462c9d81c1a64e39120d9f10aea) ) // 2716
+
+	ROM_REGION( 0x0020, "proms", 0 )
+	ROM_LOAD( "6e.bin",        0x0000, 0x0020, BAD_DUMP CRC(4e3caeab) SHA1(a25083c3e36d28afdefe4af6e6d4f3155e303625) ) // not present, using mandinga PROM
+ROM_END
+
+ROM_START( mandingac )
+	ROM_REGION( 0x10000, "maincpu", 0 )
+	ROM_LOAD( "2716-4.bin",  0x0000, 0x0800, CRC(a684a494) SHA1(76885bb3bdab09f46c7daa25164a2fdaa744742f) ) // 2716
+	ROM_LOAD( "2716-3.bin",  0x0800, 0x0800, CRC(f4038373) SHA1(8823b9816fc4ea03b92e08776c13610980f5ea7a) ) // 2716
+	ROM_LOAD( "2716-1.bin",  0x1000, 0x0800, CRC(96842877) SHA1(043ce4ed2628a209ca21cc42516c02366cd9f1fa) ) // 2716
+	ROM_LOAD( "2716-9.bin",  0x1800, 0x0800, CRC(b69f9f71) SHA1(cb781d61a481c493e89605bc0edc6a092d8b4d56) ) // 2716
+	ROM_LOAD( "2716-8.bin",  0x2000, 0x0800, CRC(400cf1bb) SHA1(06c891f7581b0c1036f6845ea847cd20b6f5dedc) ) // 2716
+	ROM_LOAD( "2716-7.bin",  0x2800, 0x0800, CRC(5382f7ed) SHA1(425ec2c2caf404fc8ab13ee38d6567413022e1a1) ) // 2716
+	ROM_LOAD( "2716-6.bin",  0x3000, 0x0800, CRC(c4e63305) SHA1(e03aed5ad89305ffc243cff8ff147ec82419c7bc) ) // 2716
+	ROM_LOAD( "2716-5.bin",  0x3800, 0x0800, CRC(8a4018ae) SHA1(9aba6f4527c59b0b016038236d5a6074e65966f6) ) // 2716
+	ROM_LOAD( "2716-2.bin",  0xc000, 0x0800, CRC(d8bf57e7) SHA1(421a0fa02fccbc52d460fafec6437bd2b7564056) ) // 2716
+
+	ROM_REGION( 0x1000, "gfx1", 0 )
+	ROM_LOAD( "2716-10.bin", 0x0000, 0x0800, CRC(2082ad0a) SHA1(c6014d9575e92adf09b0961c2158a779ebe940c4) ) // 2716
+	ROM_LOAD( "2716-11.bin", 0x0800, 0x0800, CRC(1891fc68) SHA1(6d03f5092fd73462c9d81c1a64e39120d9f10aea) ) // 2716
+
+	ROM_REGION( 0x0020, "proms", 0 )
+	ROM_LOAD( "82s123.bin",  0x0000, 0x0020, CRC(4e3caeab) SHA1(a25083c3e36d28afdefe4af6e6d4f3155e303625) ) // 82s123
 ROM_END
 
 ROM_START( theend )
@@ -12209,7 +12323,7 @@ GAME( 19??, tst_galx,    galaxian, galaxian,   galaxian,   galaxian_state, init_
 /* other games on basic galaxian hardware */
 GAME( 1981, blkhole,     0,        galaxian,   blkhole,    galaxian_state, init_galaxian,   ROT90,  "TDS & MINTS", "Black Hole", MACHINE_SUPPORTS_SAVE )
 GAME( 1982, orbitron,    0,        galaxian,   orbitron,   galaxian_state, init_galaxian,   ROT270, "Comsoft (Signatron USA license)", "Orbitron", MACHINE_SUPPORTS_SAVE ) // there's a Comsoft copyright in one of the roms, and the gameplay is the same as Victory below
-GAME( 1980, luctoday,    0,        galaxian,   luctoday,   galaxian_state, init_galaxian,   ROT270, "Sigma", "Lucky Today",MACHINE_WRONG_COLORS | MACHINE_SUPPORTS_SAVE )
+GAME( 1980, luctoday,    0,        galaxian,   luctoday,   galaxian_state, init_galaxian,   ROT270, "Sigma", "Lucky Today", MACHINE_WRONG_COLORS | MACHINE_SUPPORTS_SAVE )
 GAME( 19??, chewing,     luctoday, galaxian,   luctoday,   galaxian_state, init_galaxian,   ROT90,  "<unknown>", "Chewing Gum", MACHINE_SUPPORTS_SAVE )
 GAME( 1982, catacomb,    0,        galaxian,   catacomb,   galaxian_state, init_galaxian,   ROT90,  "MTM Games", "Catacomb", MACHINE_WRONG_COLORS | MACHINE_SUPPORTS_SAVE )
 GAME( 19??, omegab,      theend,   galaxian,   omegab,     galaxian_state, init_galaxian,   ROT270, "bootleg?", "Omega (bootleg?)", MACHINE_SUPPORTS_SAVE )
@@ -12379,7 +12493,7 @@ GAME( 1981, frogf,       frogger,  frogf,      frogger,    galaxian_state, init_
 GAME( 1981, frogg,       frogger,  galaxian,   frogg,      galaxian_state, init_frogg,      ROT90,  "bootleg", "Frog (Galaxian hardware)", MACHINE_SUPPORTS_SAVE )
 GAME( 1981, froggrs,     frogger,  froggers,   frogger,    galaxian_state, init_froggrs,    ROT90,  "bootleg (Coin Music)", "Frogger (Scramble hardware)", MACHINE_SUPPORTS_SAVE )
 GAME( 1981, quaak,       frogger,  quaak,      frogger,    galaxian_state, init_quaak,      ROT90,  "bootleg", "Quaak (bootleg of Frogger)", MACHINE_SUPPORTS_SAVE ) // closest to Super Cobra hardware, presumably a bootleg from Germany (Quaak is the German frog sound)
-GAME( 1981, froggeram,   frogger,  froggeram,  froggeram,  galaxian_state, init_quaak,      ROT90,  "bootleg", "Frogger (bootleg on Amigo? hardware)", MACHINE_SUPPORTS_SAVE ) // meant to be Amigo hardware, but maybe a different bootleg than the one we have?
+GAME( 1981, froggeram,   frogger,  froggeram,  froggeram,  galaxian_state, init_quaak,      ROT90,  "bootleg", "Frogger (bootleg on Amigo? hardware)", MACHINE_SUPPORTS_SAVE ) // meant to be Amigo hardware, but is more like Quaak than any Amigo set
 
 
 /*
@@ -12401,13 +12515,14 @@ GAME( 1982, amidarb,     amidar,   turtles,    amidaru,    galaxian_state, init_
 GAME( 1982, amigo,       amidar,   turtles,    amidaru,    galaxian_state, init_turtles,    ROT90,  "bootleg", "Amigo (bootleg of Amidar, set 1)", MACHINE_SUPPORTS_SAVE )
 GAME( 1982, amigo2,      amidar,   amigo2,     amidaru,    galaxian_state, init_amigo2,     ROT90,  "bootleg", "Amigo (bootleg of Amidar, set 2)", MACHINE_SUPPORTS_SAVE | MACHINE_IMPERFECT_SOUND ) // sound timer might be different?
 GAME( 1982, amidars,     amidar,   scramble,   amidars,    galaxian_state, init_scramble,   ROT90,  "Konami", "Amidar (Scramble hardware)", MACHINE_SUPPORTS_SAVE )
-GAME( 1982, mandinga,    amidar,   scramble,   amidars,    galaxian_state, init_mandinga,   ROT90,  "bootleg (Artemi)", "Mandinga (bootleg of Amidar)", MACHINE_WRONG_COLORS | MACHINE_SUPPORTS_SAVE ) // colors need bitswap<8>, reference: http://www.youtube.com/watch?v=6uGK4AZxV2U
-
+GAME( 1982, mandinga,    amidar,   scramble,   amidars,    galaxian_state, init_mandinga,   ROT90,  "bootleg (Artemi)", "Mandinga (bootleg of Amidar)", MACHINE_WRONG_COLORS | MACHINE_SUPPORTS_SAVE ) // color PROM needs bitswap<8> on addressing, reference: http://www.youtube.com/watch?v=6uGK4AZxV2U
+GAME( 1982, mandingarf,  amidar,   galaxian,   mandingarf, galaxian_state, init_mandingarf, ROT90,  "bootleg (Recreativos Franco S.A.)", "Mandanga (bootleg of Mandinga on Galaxian hardware, set 1)", MACHINE_NO_COCKTAIL | MACHINE_WRONG_COLORS | MACHINE_SUPPORTS_SAVE ) // assume same issue as mandinga
+GAME( 1982, mandingac,   amidar,   galaxian,   mandingarf, galaxian_state, init_mandingarf, ROT90,  "bootleg (Centromatic)", "Mandanga (bootleg of Mandinga on Galaxian hardware, set 2)", MACHINE_NO_COCKTAIL | MACHINE_WRONG_COLORS | MACHINE_SUPPORTS_SAVE ) // assume same issue as mandinga
 
 /* The End/Scramble based hardware */
 GAME( 1980, theend,      0,        theend,     theend,     galaxian_state, init_theend,     ROT90,  "Konami", "The End", MACHINE_SUPPORTS_SAVE )
 GAME( 1980, theends,     theend,   theend,     theend,     galaxian_state, init_theend,     ROT90,  "Konami (Stern Electronics license)", "The End (Stern Electronics)", MACHINE_SUPPORTS_SAVE )
-GAME( 1981, takeoff,     theend,   takeoff,    explorer,   galaxian_state, init_explorer,   ROT90,  "bootleg (Sidam)", "Take Off (bootleg of The End)", MACHINE_WRONG_COLORS | MACHINE_SUPPORTS_SAVE ) // colors likely need bitswap<8>, needs different sound timer. reference: https://www.youtube.com/watch?v=iPYX3yJORTE
+GAME( 1981, takeoff,     theend,   takeoff,    explorer,   galaxian_state, init_explorer,   ROT90,  "bootleg (Sidam)", "Take Off (bootleg of The End)", MACHINE_WRONG_COLORS | MACHINE_SUPPORTS_SAVE ) // colors likely need bitswap<8> somewhere; needs different sound timer. reference: https://www.youtube.com/watch?v=iPYX3yJORTE
 
 GAME( 1981, scramble,    0,        scramble,   scramble,   galaxian_state, init_scramble,   ROT90,  "Konami", "Scramble", MACHINE_SUPPORTS_SAVE )
 GAME( 1981, scrambles,   scramble, scramble,   scramble,   galaxian_state, init_scramble,   ROT90,  "Konami (Stern Electronics license)", "Scramble (Stern Electronics set 1)", MACHINE_SUPPORTS_SAVE )

--- a/src/mame/drivers/galaxian.cpp
+++ b/src/mame/drivers/galaxian.cpp
@@ -10919,7 +10919,7 @@ ROM_START( mandinga )
 
 	ROM_REGION( 0x10000, "audiocpu", 0 )
 	ROM_LOAD( "11.bin",       0x0000, 0x1000, BAD_DUMP CRC(8ca7b750) SHA1(4f4c2915503b85abe141d717fd254ee10c9da99e) ) // 2732; original was bad dump, but using rom from amidar due to first half being identical
-	ROM_LOAD( "12.bin",       0x1000, 0x1000, BAD_DUMP CRC(9b5bdc0a) SHA1(8b58d7ec12ca569bb28e45b3ff78bd4b926aeb0a) ) // 2732; original was bad dump, but using rom from amidar due to first half being identical
+	ROM_LOAD( "12.bin",       0x1000, 0x1000, BAD_DUMP CRC(9b5bdc0a) SHA1(84d953618c8bf510d23b42232a856ac55f1baff5) ) // 2732; original was bad dump, but using rom from amidar due to first half being identical
 
 	ROM_REGION( 0x1000, "gfx1", 0 )
 	ROM_LOAD( "9.bin",        0x0000, 0x0800, CRC(09ed5818) SHA1(69dce85228b2c9176d4be429f530410350a1c76c) ) // 2716

--- a/src/mame/drivers/galaxold.cpp
+++ b/src/mame/drivers/galaxold.cpp
@@ -341,7 +341,7 @@ void galaxold_state::scramblb_map(address_map &map)
 	map(0x7000, 0x7000).portr("IN2");
 	map(0x7001, 0x7001).w(FUNC(galaxold_state::galaxold_nmi_enable_w));
 	map(0x7002, 0x7002).w(FUNC(galaxold_state::galaxold_coin_counter_w));
-	map(0x7003, 0x7003).w(FUNC(galaxold_state::scrambold_background_enable_w));
+	map(0x7003, 0x7003).nopw // background write, may not exist on hardware
 	map(0x7004, 0x7004).w(FUNC(galaxold_state::galaxold_stars_enable_w));
 	map(0x7006, 0x7006).w(FUNC(galaxold_state::galaxold_flip_screen_x_w));
 	map(0x7007, 0x7007).w(FUNC(galaxold_state::galaxold_flip_screen_y_w));
@@ -368,14 +368,15 @@ void galaxold_state::scramb_common_map(address_map &map)
 	map(0x5080, 0x50ff).ram();
 	map(0x5800, 0x5fff).r(FUNC(galaxold_state::scramb2_protection_r)); // must return 0x25
 	map(0x6000, 0x6007).r(FUNC(galaxold_state::scramb2_port0_r)); // reads from 8 addresses, 1 bit per address
+	map(0x6004, 0x6007).w("cust", FUNC(galaxian_sound_device::lfo_freq_w));
 	map(0x6800, 0x6807).r(FUNC(galaxold_state::scramb2_port1_r)); // reads from 8 addresses, 1 bit per address
 	map(0x6801, 0x6801).w(FUNC(galaxold_state::galaxold_nmi_enable_w));
+	map(0x6803, 0x6803).nopw // background write, may not exist on hardware
 	map(0x6804, 0x6804).w(FUNC(galaxold_state::galaxold_stars_enable_w));
 	map(0x6806, 0x6806).w(FUNC(galaxold_state::galaxold_flip_screen_x_w));
 	map(0x6807, 0x6807).w(FUNC(galaxold_state::galaxold_flip_screen_y_w));
 	map(0x7000, 0x7007).r("watchdog", FUNC(watchdog_timer_device::reset_r));
-	map(0x7006, 0x7006).nopw();
-	map(0x7007, 0x7007).nopw();
+	map(0x7000, 0x7007).w("cust", FUNC(galaxian_sound_device::sound_w));
 	map(0x7800, 0x7807).r(FUNC(galaxold_state::scramb2_port2_r)); // reads from 8 addresses, 1 bit per address
 	map(0x7800, 0x7800).w("cust", FUNC(galaxian_sound_device::pitch_w));
 }
@@ -422,15 +423,15 @@ void galaxold_state::scrambler_map(address_map &map)
 	map(0x6805, 0x6805).w("cust", FUNC(galaxian_sound_device::fire_enable_w));
 	map(0x6806, 0x6807).w("cust", FUNC(galaxian_sound_device::vol_w));
 	map(0x7000, 0x7000).portr("IN2").w(FUNC(galaxold_state::galaxold_nmi_enable_w));
-//  AM_RANGE(0x7001, 0x7001)
+// AM_RANGE(0x7001, 0x7001)
 	map(0x7002, 0x7002).w(FUNC(galaxold_state::galaxold_coin_counter_w));
-	map(0x7003, 0x7003).w(FUNC(galaxold_state::scrambold_background_enable_w));
+	map(0x7003, 0x7003).nopw // background write, may not exist on hardware
 	map(0x7004, 0x7004).w(FUNC(galaxold_state::galaxold_stars_enable_w));
 	map(0x7006, 0x7006).w(FUNC(galaxold_state::galaxold_flip_screen_x_w));
 	map(0x7007, 0x7007).w(FUNC(galaxold_state::galaxold_flip_screen_y_w));
 	map(0x7800, 0x7800).r("watchdog", FUNC(watchdog_timer_device::reset_r));
 	map(0x7800, 0x7800).w("cust", FUNC(galaxian_sound_device::pitch_w));
-//  AM_RANGE(0x8102, 0x8102) AM_READ(scramblb_protection_1_r)
+// AM_RANGE(0x8102, 0x8102) AM_READ(scramblb_protection_1_r)
 	map(0x8202, 0x8202).r(FUNC(galaxold_state::scrambler_protection_2_r));
 }
 
@@ -2344,13 +2345,6 @@ MACHINE_CONFIG_START(galaxold_state::scramblb)
 	/* basic machine hardware */
 	MCFG_DEVICE_MODIFY("maincpu")
 	MCFG_DEVICE_PROGRAM_MAP(scramblb_map)
-
-	/* video hardware */
-	MCFG_PALETTE_MODIFY("palette")
-	MCFG_PALETTE_ENTRIES(32+2+64+1)  /* 32 for the characters, 2 for the bullets, 64 for the stars, 1 for background */
-
-	MCFG_PALETTE_INIT_OWNER(galaxold_state,scrambold)
-	MCFG_VIDEO_START_OVERRIDE(galaxold_state,scrambold)
 MACHINE_CONFIG_END
 
 
@@ -2360,13 +2354,6 @@ MACHINE_CONFIG_START(galaxold_state::scramb2)
 	/* basic machine hardware */
 	MCFG_DEVICE_MODIFY("maincpu")
 	MCFG_DEVICE_PROGRAM_MAP(scramb2_map)
-
-	/* video hardware */
-	MCFG_PALETTE_MODIFY("palette")
-	MCFG_PALETTE_ENTRIES(32+2+64+1)  /* 32 for the characters, 2 for the bullets, 64 for the stars, 1 for background */
-
-	MCFG_PALETTE_INIT_OWNER(galaxold_state,scrambold)
-	MCFG_VIDEO_START_OVERRIDE(galaxold_state,scrambold)
 MACHINE_CONFIG_END
 
 MACHINE_CONFIG_START(galaxold_state::scramb3)
@@ -2383,13 +2370,6 @@ MACHINE_CONFIG_START(galaxold_state::scrambler)
 	/* basic machine hardware */
 	MCFG_DEVICE_MODIFY("maincpu")
 	MCFG_DEVICE_PROGRAM_MAP(scrambler_map)
-
-	/* video hardware */
-	MCFG_PALETTE_MODIFY("palette")
-	MCFG_PALETTE_ENTRIES(32+2+64+1)  /* 32 for the characters, 2 for the bullets, 64 for the stars, 1 for background */
-
-	MCFG_PALETTE_INIT_OWNER(galaxold_state,scrambold)
-	MCFG_VIDEO_START_OVERRIDE(galaxold_state,scrambold)
 MACHINE_CONFIG_END
 
 

--- a/src/mame/drivers/galaxold.cpp
+++ b/src/mame/drivers/galaxold.cpp
@@ -341,7 +341,7 @@ void galaxold_state::scramblb_map(address_map &map)
 	map(0x7000, 0x7000).portr("IN2");
 	map(0x7001, 0x7001).w(FUNC(galaxold_state::galaxold_nmi_enable_w));
 	map(0x7002, 0x7002).w(FUNC(galaxold_state::galaxold_coin_counter_w));
-	map(0x7003, 0x7003).nopw // background write, may not exist on hardware
+	map(0x7003, 0x7003).nopw(); // background color write, may not exist on hardware
 	map(0x7004, 0x7004).w(FUNC(galaxold_state::galaxold_stars_enable_w));
 	map(0x7006, 0x7006).w(FUNC(galaxold_state::galaxold_flip_screen_x_w));
 	map(0x7007, 0x7007).w(FUNC(galaxold_state::galaxold_flip_screen_y_w));
@@ -371,7 +371,7 @@ void galaxold_state::scramb_common_map(address_map &map)
 	map(0x6004, 0x6007).w("cust", FUNC(galaxian_sound_device::lfo_freq_w));
 	map(0x6800, 0x6807).r(FUNC(galaxold_state::scramb2_port1_r)); // reads from 8 addresses, 1 bit per address
 	map(0x6801, 0x6801).w(FUNC(galaxold_state::galaxold_nmi_enable_w));
-	map(0x6803, 0x6803).nopw // background write, may not exist on hardware
+	map(0x6803, 0x6803).nopw(); // background color write, does not exist
 	map(0x6804, 0x6804).w(FUNC(galaxold_state::galaxold_stars_enable_w));
 	map(0x6806, 0x6806).w(FUNC(galaxold_state::galaxold_flip_screen_x_w));
 	map(0x6807, 0x6807).w(FUNC(galaxold_state::galaxold_flip_screen_y_w));
@@ -423,15 +423,15 @@ void galaxold_state::scrambler_map(address_map &map)
 	map(0x6805, 0x6805).w("cust", FUNC(galaxian_sound_device::fire_enable_w));
 	map(0x6806, 0x6807).w("cust", FUNC(galaxian_sound_device::vol_w));
 	map(0x7000, 0x7000).portr("IN2").w(FUNC(galaxold_state::galaxold_nmi_enable_w));
-// AM_RANGE(0x7001, 0x7001)
+//  AM_RANGE(0x7001, 0x7001)
 	map(0x7002, 0x7002).w(FUNC(galaxold_state::galaxold_coin_counter_w));
-	map(0x7003, 0x7003).nopw // background write, may not exist on hardware
+	map(0x7003, 0x7003).nopw(); // background color write, may not exist
 	map(0x7004, 0x7004).w(FUNC(galaxold_state::galaxold_stars_enable_w));
 	map(0x7006, 0x7006).w(FUNC(galaxold_state::galaxold_flip_screen_x_w));
 	map(0x7007, 0x7007).w(FUNC(galaxold_state::galaxold_flip_screen_y_w));
 	map(0x7800, 0x7800).r("watchdog", FUNC(watchdog_timer_device::reset_r));
 	map(0x7800, 0x7800).w("cust", FUNC(galaxian_sound_device::pitch_w));
-// AM_RANGE(0x8102, 0x8102) AM_READ(scramblb_protection_1_r)
+//  AM_RANGE(0x8102, 0x8102) AM_READ(scramblb_protection_1_r)
 	map(0x8202, 0x8202).r(FUNC(galaxold_state::scrambler_protection_2_r));
 }
 

--- a/src/mame/drivers/scramble.cpp
+++ b/src/mame/drivers/scramble.cpp
@@ -253,9 +253,9 @@ void scramble_state::hunchbks_map(address_map &map)
 void scramble_state::mimonscr_map(address_map &map)
 {
 	map(0x0000, 0x3fff).rom();
-	map(0x4000, 0x43ff).rw(FUNC(scramble_state::galaxold_videoram_r), FUNC(scramble_state::galaxold_videoram_w)); /* mirror address?, probably not */
-	map(0x4400, 0x47ff).ram();
+	map(0x4000, 0x47ff).ram();
 	map(0x4800, 0x4bff).ram().w(FUNC(scramble_state::galaxold_videoram_w)).share("videoram");
+	map(0x4c00, 0x4fff).rw(FUNC(scramble_state::galaxold_videoram_r), FUNC(scramble_state::galaxold_videoram_w)); /* mirror address */
 	map(0x5000, 0x503f).ram().w(FUNC(scramble_state::galaxold_attributesram_w)).share("attributesram");
 	map(0x5040, 0x505f).ram().share("spriteram");
 	map(0x5060, 0x507f).ram().share("bulletsram");

--- a/src/mame/includes/galaxian.h
+++ b/src/mame/includes/galaxian.h
@@ -206,6 +206,7 @@ public:
 	void init_explorer();
 	void init_amigo2();
 	void init_mandinga();
+	void init_mandingarf();
 	void init_sfx();
 	void init_atlantis();
 	void init_scobra();

--- a/src/mame/includes/galaxian.h
+++ b/src/mame/includes/galaxian.h
@@ -16,27 +16,41 @@
 #include "emupal.h"
 #include "screen.h"
 
-/* we scale horizontally by 3 to render stars correctly */
-#define GALAXIAN_XSCALE         3
+namespace {
 
 /* master clocks */
-#define GALAXIAN_MASTER_CLOCK   (XTAL(18'432'000))
-#define GALAXIAN_PIXEL_CLOCK    (GALAXIAN_XSCALE*GALAXIAN_MASTER_CLOCK/3)
+static constexpr XTAL GALAXIAN_MASTER_CLOCK(18.432_MHz_XTAL);
+static constexpr XTAL KONAMI_SOUND_CLOCK(14.318181_MHz_XTAL);
+static constexpr XTAL SIDAM_MASTER_CLOCK(12_MHz_XTAL);
+
+/* we scale horizontally by 3 to render stars correctly */
+static constexpr int GALAXIAN_XSCALE = 3;
+/* the Sidam bootlegs have a 12 MHz XTAL instead */
+static constexpr int SIDAM_XSCALE    = 2;
+
+static constexpr XTAL GALAXIAN_PIXEL_CLOCK(GALAXIAN_XSCALE*GALAXIAN_MASTER_CLOCK / 3);
+static constexpr XTAL SIDAM_PIXEL_CLOCK(SIDAM_XSCALE*SIDAM_MASTER_CLOCK / 2);
 
 /* H counts from 128->511, HBLANK starts at 130 and ends at 250 */
 /* we normalize this here so that we count 0->383 with HBLANK */
 /* from 264-383 */
-#define GALAXIAN_HTOTAL         (384*GALAXIAN_XSCALE)
-#define GALAXIAN_HBEND          (0*GALAXIAN_XSCALE)
-//#define GALAXIAN_H0START      (6*GALAXIAN_XSCALE)
-//#define GALAXIAN_HBSTART      (264*GALAXIAN_XSCALE)
-#define GALAXIAN_H0START        (0*GALAXIAN_XSCALE)
-#define GALAXIAN_HBSTART        (256*GALAXIAN_XSCALE)
+static constexpr int GALAXIAN_HTOTAL  = (384 * GALAXIAN_XSCALE);
+static constexpr int GALAXIAN_HBEND   = (0 * GALAXIAN_XSCALE);
+//static constexpr int GALAXIAN_H0START = (6*GALAXIAN_XSCALE)
+//static constexpr int GALAXIAN_HBSTART = (264*GALAXIAN_XSCALE)
+static constexpr int GALAXIAN_H0START = (0 * GALAXIAN_XSCALE);
+static constexpr int GALAXIAN_HBSTART = (256 * GALAXIAN_XSCALE);
 
-#define GALAXIAN_VTOTAL         (264)
-#define GALAXIAN_VBEND          (16)
-#define GALAXIAN_VBSTART        (224+16)
+static constexpr int GALAXIAN_VTOTAL  = (264);
+static constexpr int GALAXIAN_VBEND   = (16);
+static constexpr int GALAXIAN_VBSTART = (224 + 16);
 
+static constexpr int SIDAM_HTOTAL     = (384 * SIDAM_XSCALE);
+static constexpr int SIDAM_HBEND      = (0 * SIDAM_XSCALE);
+static constexpr int SIDAM_H0START    = (0 * SIDAM_XSCALE);
+static constexpr int SIDAM_HBSTART    = (256 * SIDAM_XSCALE);
+
+} // anonymous namespace
 
 class galaxian_state : public driver_device
 {
@@ -81,7 +95,6 @@ public:
 	DECLARE_WRITE8_MEMBER(scramble_background_green_w);
 	DECLARE_WRITE8_MEMBER(scramble_background_blue_w);
 	DECLARE_WRITE8_MEMBER(galaxian_gfxbank_w);
-	DECLARE_CUSTOM_INPUT_MEMBER(scramble_protection_alt_r);
 	DECLARE_CUSTOM_INPUT_MEMBER(gmgalax_port_r);
 	DECLARE_CUSTOM_INPUT_MEMBER(azurian_port_r);
 	DECLARE_CUSTOM_INPUT_MEMBER(kingball_muxbit_r);
@@ -97,6 +110,9 @@ public:
 	DECLARE_WRITE8_MEMBER(konami_sound_filter_w);
 	DECLARE_READ8_MEMBER(theend_ppi8255_r);
 	DECLARE_WRITE8_MEMBER(theend_ppi8255_w);
+	DECLARE_WRITE8_MEMBER(theend_protection_w);
+	DECLARE_READ8_MEMBER(theend_protection_r);
+	DECLARE_CUSTOM_INPUT_MEMBER(theend_protection_alt_r);
 	DECLARE_WRITE8_MEMBER(explorer_sound_control_w);
 	DECLARE_READ8_MEMBER(sfx_sample_io_r);
 	DECLARE_WRITE8_MEMBER(sfx_sample_io_w);
@@ -144,8 +160,6 @@ public:
 	DECLARE_WRITE8_MEMBER(konami_portc_0_w);
 	DECLARE_WRITE8_MEMBER(konami_portc_1_w);
 	DECLARE_WRITE8_MEMBER(theend_coin_counter_w);
-	DECLARE_WRITE8_MEMBER(scramble_protection_w);
-	DECLARE_READ8_MEMBER(scramble_protection_r);
 	DECLARE_READ8_MEMBER(explorer_sound_latch_r);
 	DECLARE_WRITE8_MEMBER(sfx_sample_control_w);
 	DECLARE_WRITE8_MEMBER(monsterz_porta_1_w);
@@ -188,7 +202,9 @@ public:
 	void init_thepitm();
 	void init_theend();
 	void init_scramble();
+	void init_sidam();
 	void init_explorer();
+	void init_amigo2();
 	void init_mandinga();
 	void init_sfx();
 	void init_atlantis();
@@ -208,6 +224,7 @@ public:
 	void init_moonwar();
 	void init_ghostmun();
 	void init_froggrs();
+	void init_warofbug();
 	void init_warofbugg();
 	void init_jungsub();
 	void init_victoryc();
@@ -217,8 +234,8 @@ public:
 	DECLARE_PALETTE_INIT(moonwar);
 	void tenspot_set_game_bank(int bank, int from_game);
 	uint32_t screen_update_galaxian(screen_device &screen, bitmap_rgb32 &bitmap, const rectangle &cliprect);
-	INTERRUPT_GEN_MEMBER(interrupt_gen);
-	INTERRUPT_GEN_MEMBER(fakechange_interrupt_gen);
+	WRITE_LINE_MEMBER(vblank_interrupt_w);
+	WRITE_LINE_MEMBER(tenspot_interrupt_w);
 	TIMER_DEVICE_CALLBACK_MEMBER(checkmaj_irq0_gen);
 	TIMER_DEVICE_CALLBACK_MEMBER(scramble_stars_blink_timer);
 	TIMER_DEVICE_CALLBACK_MEMBER(timefgtr_scanline);
@@ -228,6 +245,7 @@ public:
 	void stars_init();
 	void stars_update_origin();
 	void stars_draw_row(bitmap_rgb32 &bitmap, int maxx, int y, uint32_t star_offs, uint8_t starmask);
+	void null_draw_background(bitmap_rgb32 &bitmap, const rectangle &cliprect);
 	void galaxian_draw_background(bitmap_rgb32 &bitmap, const rectangle &cliprect);
 	void background_draw_colorsplit(bitmap_rgb32 &bitmap, const rectangle &cliprect, rgb_t color, int split, int split_flipped);
 	void scramble_draw_stars(bitmap_rgb32 &bitmap, const rectangle &cliprect, int maxx);
@@ -235,8 +253,8 @@ public:
 	void anteater_draw_background(bitmap_rgb32 &bitmap, const rectangle &cliprect);
 	void jumpbug_draw_background(bitmap_rgb32 &bitmap, const rectangle &cliprect);
 	void turtles_draw_background(bitmap_rgb32 &bitmap, const rectangle &cliprect);
+	void sfx_draw_background(bitmap_rgb32 &bitmap, const rectangle &cliprect);
 	void frogger_draw_background(bitmap_rgb32 &bitmap, const rectangle &cliprect);
-	void quaak_draw_background(bitmap_rgb32 &bitmap, const rectangle &cliprect);
 	inline void galaxian_draw_pixel(bitmap_rgb32 &bitmap, const rectangle &cliprect, int y, int x, rgb_t color);
 	void galaxian_draw_bullet(bitmap_rgb32 &bitmap, const rectangle &cliprect, int offs, int x, int y);
 	void mshuttle_draw_bullet(bitmap_rgb32 &bitmap, const rectangle &cliprect, int offs, int x, int y);
@@ -275,6 +293,7 @@ public:
 	void common_init(galaxian_draw_bullet_func draw_bullet,galaxian_draw_background_func draw_background,
 					 galaxian_extend_tile_info_func extend_tile_info,galaxian_extend_sprite_info_func extend_sprite_info);
 	void galaxian_base(machine_config &config);
+	void sidam_bootleg_base(machine_config &config);
 	void konami_base(machine_config &config);
 	void konami_sound_1x_ay8910(machine_config &config);
 	void konami_sound_2x_ay8910(machine_config &config);
@@ -327,7 +346,6 @@ public:
 	void checkman_sound_map(address_map &map);
 	void checkman_sound_portmap(address_map &map);
 	void explorer_map(address_map &map);
-	void fantastc_map(address_map &map);
 	void frogf_map(address_map &map);
 	void frogger_map(address_map &map);
 	void frogger_sound_map(address_map &map);
@@ -360,7 +378,7 @@ public:
 	void takeoff_sound_portmap(address_map &map);
 	void tenspot_select_map(address_map &map);
 	void theend_map(address_map &map);
-	void timefgtr_map(address_map &map);
+	void fantastc_map(address_map &map);
 	void turpins_map(address_map &map);
 	void turpins_sound_map(address_map &map);
 	void turtles_map(address_map &map);
@@ -411,6 +429,8 @@ protected:
 	int m_irq_line;
 	int m_tenspot_current_game;
 	uint8_t m_frogger_adjust;
+	uint8_t m_x_scale;
+	uint8_t m_h0_start;
 	uint8_t m_sfx_tilemap;
 
 	galaxian_extend_tile_info_func m_extend_tile_info_ptr;

--- a/src/mame/mame.lst
+++ b/src/mame/mame.lst
@@ -13307,6 +13307,8 @@ losttomb                        // (c) 1982 Stern
 losttombh                       // (c) 1982 Stern
 luctoday                        // 1980 Sigma
 mandinga                        // bootleg (Artemi)
+mandingarf                      // bootleg (Recreativos Franco S.A.)
+mandingac                       // bootleg (Centromatic)
 mltiwars                        // bootleg (Gayton Games)
 monsterz                        // (c) 1982 Nihon (Arcade TV Game List - P.102, Left, 20 from top)
 moonal2                         // [1980] Nichibutsu

--- a/src/mame/video/galaxian.cpp
+++ b/src/mame/video/galaxian.cpp
@@ -379,13 +379,13 @@ void galaxian_state::video_start()
 	if (!m_sfx_tilemap)
 	{
 		/* normal galaxian hardware is row-based and individually scrolling columns */
-		m_bg_tilemap = &machine().tilemap().create(*m_gfxdecode, tilemap_get_info_delegate(FUNC(galaxian_state::bg_get_tile_info),this), TILEMAP_SCAN_ROWS, GALAXIAN_XSCALE*8,8, 32,32);
+		m_bg_tilemap = &machine().tilemap().create(*m_gfxdecode, tilemap_get_info_delegate(FUNC(galaxian_state::bg_get_tile_info),this), TILEMAP_SCAN_ROWS, m_x_scale*8,8, 32,32);
 		m_bg_tilemap->set_scroll_cols(32);
 	}
 	else
 	{
 		/* sfx hardware is column-based and individually scrolling rows */
-		m_bg_tilemap = &machine().tilemap().create(*m_gfxdecode, tilemap_get_info_delegate(FUNC(galaxian_state::bg_get_tile_info),this), TILEMAP_SCAN_COLS, GALAXIAN_XSCALE*8,8, 32,32);
+		m_bg_tilemap = &machine().tilemap().create(*m_gfxdecode, tilemap_get_info_delegate(FUNC(galaxian_state::bg_get_tile_info),this), TILEMAP_SCAN_COLS, m_x_scale*8,8, 32,32);
 		m_bg_tilemap->set_scroll_rows(32);
 	}
 	m_bg_tilemap->set_transparent_pen(0);
@@ -510,7 +510,7 @@ WRITE8_MEMBER(galaxian_state::galaxian_objram_w)
 			if (!m_sfx_tilemap)
 				m_bg_tilemap->set_scrolly(offset >> 1, data);
 			else
-				m_bg_tilemap->set_scrollx(offset >> 1, GALAXIAN_XSCALE*data);
+				m_bg_tilemap->set_scrollx(offset >> 1, m_x_scale*data);
 		}
 
 		/* odd entries control the color base for the row */
@@ -540,8 +540,8 @@ void galaxian_state::sprites_draw(bitmap_rgb32 &bitmap, const rectangle &cliprec
 
 	/* 16 of the 256 pixels of the sprites are hard-clipped at the line buffer */
 	/* according to the schematics, it should be the first 16 pixels */
-	clip.min_x = std::max(clip.min_x, (!m_flipscreen_x) * (16 + hoffset) * GALAXIAN_XSCALE);
-	clip.max_x = std::min(clip.max_x, (256 - m_flipscreen_x * (16 + hoffset)) * GALAXIAN_XSCALE - 1);
+	clip.min_x = std::max(clip.min_x, (!m_flipscreen_x) * (16 + hoffset) * m_x_scale);
+	clip.max_x = std::min(clip.max_x, (256 - m_flipscreen_x * (16 + hoffset)) * m_x_scale - 1);
 
 	/* The line buffer is only written if it contains a '0' currently; */
 	/* it is cleared during the visible area, and populated during HBLANK */
@@ -583,7 +583,7 @@ void galaxian_state::sprites_draw(bitmap_rgb32 &bitmap, const rectangle &cliprec
 				m_gfxdecode->gfx(1)->transpen(bitmap,clip,
 				code, color,
 				flipx, flipy,
-				GALAXIAN_H0START + GALAXIAN_XSCALE * sx, sy, 0);
+				m_h0_start + m_x_scale * sx, sy, 0);
 	}
 }
 
@@ -895,7 +895,7 @@ void galaxian_state::stars_draw_row(bitmap_rgb32 &bitmap, int maxx, int y, uint3
 		if (star_offs >= STAR_RNG_PERIOD)
 			star_offs = 0;
 		if (enable_star && (star & 0x80) != 0 && (star & starmask) != 0)
-			bitmap.pix32(y, GALAXIAN_XSCALE*x + 0) = m_star_color[star & 0x3f];
+			bitmap.pix32(y, m_x_scale*x + 0) = m_star_color[star & 0x3f];
 
 		/* second RNG clock: two pixels */
 		star = m_stars[star_offs++];
@@ -903,8 +903,8 @@ void galaxian_state::stars_draw_row(bitmap_rgb32 &bitmap, int maxx, int y, uint3
 			star_offs = 0;
 		if (enable_star && (star & 0x80) != 0 && (star & starmask) != 0)
 		{
-			bitmap.pix32(y, GALAXIAN_XSCALE*x + 1) = m_star_color[star & 0x3f];
-			bitmap.pix32(y, GALAXIAN_XSCALE*x + 2) = m_star_color[star & 0x3f];
+			bitmap.pix32(y, m_x_scale*x + 1) = m_star_color[star & 0x3f];
+			bitmap.pix32(y, m_x_scale*x + 2) = m_star_color[star & 0x3f];
 		}
 	}
 }
@@ -917,10 +917,17 @@ void galaxian_state::stars_draw_row(bitmap_rgb32 &bitmap, int maxx, int y, uint3
  *
  *************************************/
 
+void galaxian_state::null_draw_background(bitmap_rgb32 &bitmap, const rectangle &cliprect)
+{
+	/* erase the background to black */
+	bitmap.fill(rgb_t::black(), cliprect);
+}
+
+
 void galaxian_state::galaxian_draw_background(bitmap_rgb32 &bitmap, const rectangle &cliprect)
 {
 	/* erase the background to black first */
-	bitmap.fill(rgb_t::black(), cliprect);
+	null_draw_background(bitmap, cliprect);
 
 	/* update the star origin to the current frame */
 	stars_update_origin();
@@ -946,24 +953,24 @@ void galaxian_state::background_draw_colorsplit(bitmap_rgb32 &bitmap, const rect
 	if (m_flipscreen_x)
 	{
 		rectangle draw = cliprect;
-		draw.max_x = std::min(draw.max_x, split_flipped * GALAXIAN_XSCALE - 1);
+		draw.max_x = std::min(draw.max_x, split_flipped * m_x_scale - 1);
 		if (draw.min_x <= draw.max_x)
 			bitmap.fill(rgb_t::black(), draw);
 
 		draw = cliprect;
-		draw.min_x = std::max(draw.min_x, split_flipped * GALAXIAN_XSCALE);
+		draw.min_x = std::max(draw.min_x, split_flipped * m_x_scale);
 		if (draw.min_x <= draw.max_x)
 			bitmap.fill(color, draw);
 	}
 	else
 	{
 		rectangle draw = cliprect;
-		draw.max_x = std::min(draw.max_x, split * GALAXIAN_XSCALE - 1);
+		draw.max_x = std::min(draw.max_x, split * m_x_scale - 1);
 		if (draw.min_x <= draw.max_x)
 			bitmap.fill(color, draw);
 
 		draw = cliprect;
-		draw.min_x = std::max(draw.min_x, split * GALAXIAN_XSCALE);
+		draw.min_x = std::max(draw.min_x, split * m_x_scale);
 		if (draw.min_x <= draw.max_x)
 			bitmap.fill(rgb_t::black(), draw);
 	}
@@ -1033,7 +1040,7 @@ void galaxian_state::jumpbug_draw_background(bitmap_rgb32 &bitmap, const rectang
 		for (y = cliprect.min_y; y <= cliprect.max_y; y++)
 		{
 			uint32_t star_offs = m_star_rng_origin + y * 512;
-			stars_draw_row(bitmap, 240, y, star_offs, 0xff);
+			stars_draw_row(bitmap, 232, y, star_offs, 0xff); // verified on a real PCB
 		}
 	}
 }
@@ -1052,16 +1059,19 @@ void galaxian_state::turtles_draw_background(bitmap_rgb32 &bitmap, const rectang
 }
 
 
+void galaxian_state::sfx_draw_background(bitmap_rgb32 &bitmap, const rectangle &cliprect)
+{
+	/* current schematics are unreadable, assuming like Turtles */
+	bitmap.fill(rgb_t(m_background_red * 0x55, m_background_green * 0x47, m_background_blue * 0x55), cliprect);
+
+	scramble_draw_stars(bitmap, cliprect, 256);
+}
+
+
 void galaxian_state::frogger_draw_background(bitmap_rgb32 &bitmap, const rectangle &cliprect)
 {
 	/* according to schematics it is at 128+8; but it has been verified different on real machine.
 	Video proof: http://www.youtube.com/watch?v=ssr69mQf224 */
-	background_draw_colorsplit(bitmap, cliprect, rgb_t(0,0,0x47), 128, 128);
-}
-
-void galaxian_state::quaak_draw_background(bitmap_rgb32 &bitmap, const rectangle &cliprect)
-{
-	/* color split point verified on real machine */
 	background_draw_colorsplit(bitmap, cliprect, rgb_t(0,0,0x47), 128, 128);
 }
 
@@ -1071,13 +1081,13 @@ int galaxian_state::flip_and_clip(rectangle &draw, int xstart, int xend, const r
 	draw = cliprect;
 	if (!m_flipscreen_x)
 	{
-		draw.min_x = xstart * GALAXIAN_XSCALE;
-		draw.max_x = xend * GALAXIAN_XSCALE + (GALAXIAN_XSCALE - 1);
+		draw.min_x = xstart * m_x_scale;
+		draw.max_x = xend * m_x_scale + (m_x_scale - 1);
 	}
 	else
 	{
-		draw.min_x = (xend ^ 255) * GALAXIAN_XSCALE;
-		draw.max_x = (xstart ^ 255) * GALAXIAN_XSCALE + (GALAXIAN_XSCALE - 1);
+		draw.min_x = (xend ^ 255) * m_x_scale;
+		draw.max_x = (xstart ^ 255) * m_x_scale + (m_x_scale - 1);
 	}
 	draw &= cliprect;
 	return (draw.min_x <= draw.max_x);
@@ -1126,8 +1136,8 @@ inline void galaxian_state::galaxian_draw_pixel(bitmap_rgb32 &bitmap, const rect
 {
 	if (y >= cliprect.min_y && y <= cliprect.max_y)
 	{
-		x *= GALAXIAN_XSCALE;
-		x += GALAXIAN_H0START;
+		x *= m_x_scale;
+		x += m_h0_start;
 		if (x >= cliprect.min_x && x <= cliprect.max_x)
 			bitmap.pix32(y, x) = color;
 
@@ -1191,11 +1201,14 @@ void galaxian_state::scramble_draw_bullet(bitmap_rgb32 &bitmap, const rectangle 
 {
 	/*
 	    Scramble only has "shells", which begin displaying when the counter
-	    reaches $FA, and stop displaying one pixel clock layer. All shells are
-	    rendered as yellow.
+	    reaches $FA, and stop displaying two pixel clock layers, as verified
+	    on real hardware.
+
+	    All shells are rendered as yellow.
 	*/
-	x -= 6;
-	galaxian_draw_pixel(bitmap, cliprect, y, x, rgb_t(0xff,0xff,0x00));
+	x -= 4;
+	galaxian_draw_pixel(bitmap, cliprect, y, --x, rgb_t(0xff, 0xff, 0x00));
+	galaxian_draw_pixel(bitmap, cliprect, y, --x, rgb_t(0xff, 0xff, 0x00));
 }
 
 


### PR DESCRIPTION
The first part of a giant journey on the 0.2xx timeline that will consist of major changes to galaxian.cpp, eventually ending up with a complete migration of scramble.cpp, scobra.cpp, and galaxold.cpp to the new driver altogether. Any kind of feedback is welcome, especially considering how I don't know if how I handled changing the pixel clock scale in galaxian.cpp for Sidam bootlegs is acceptable.

This PR consists of minor commits to correct Take Off, Explorer, Amigo, Jump Bug, Scramble, Jungler on Scramble, The End, War of The Bugs, and Mandinga. Mostly copypasted from the commit logs:

- Correct sync in Take Off, Explorer, and set 2 of Amigo. Sidam bootlegs of Konami games have a 12MHz pixel clock with video being scaled by two pixels instead of 3.
- Correct Jump Bug background hardware behavior, as per real hardware. Stars actually show up until the 232nd pixel.
- Correct bullet behavior in Scramble. Shells are now two pixels long, and have been verified on real hardware.
- Fix(?) clocks on jungsub. The Subelectro 113 board has no XTALs, and I am assuming the CLK lines come from the pixel clock on the Konami L-1200-2 board.
- Various memory map corrections; most of them to add mirrors. These are mostly guesses, and are not precisely right. Feedback appreciated if you have corrections to make.
- War of Bugs and clones have stars disabled, and so does likely Explorer. War of the Bugs has a pin on LS366 '2B' cut off, but not the LS259 that controls it. Therefore, I have made a "null_draw_background" routine to reflect this instead of unmapping the write. It is unknown how stars work on Explorer and Take Off, but Take Off has no code to write to the star generator. So, I am going to imply that none of them have one altogether until I get real hardware verification.
- Given Take Off's hardware hierarchy, correct the year from 1980 to 1981 as a guess.
- Fix protection in The End and Scramble. theend now shows the HIT UFO screen after the CHANCE TIME round.
- Correct machine setup for Take Off, Explorer, and set 2 of Amigo. All are now correctly set up as per the 12 MHz pixel clock.
- Mark Explorer and set 2 of Amigo as MACHINE_IMPERFECT_SOUND. Explorer requires the same sound timer as Take Off, which I have no idea how it works. The latter probably has a similar case, although it might be different from Explorer.
- Mark Take Off as MACHINE_WRONG_COLORS. See the reference video for more; some colors that are purple with the default palette_init are green on real hardware.
- Fix sound in Mandinga by adding sound CPU ROMs from Amidar; mark them as BAD_DUMP. Chances that they may be different are unknown.
- Correct background hardware on SF-X and Monster Zero to now show stars and RGB backgrounds. Colors may not be correct, and the current schematics scans are not easy to read.
- Converted galaxian.cpp to use MCFG_SCREEN_VBLANK_CALLBACK.
- turpins is likely more derived from Super Cobra hardware than Scramble hardware. Change the set description to match this statement.
- Fix(?) video on Scramble on Galaxian bootlegs in galaxold.cpp to use regular video inits; also fix sound in scramb2 and scramb3 in galaxold.cpp. It is unlikely that any of the Scramble on Galaxian bootlegs have any changes related to video, and any writes to the background color generator may simply be leftovers. The top board on Hammy's scramb3 board does not show anything video related that maybe be questionable.

As for the constexpr pollution in the headers: I do acknowledge this, but sound/galaxian.cpp won't like it if I move them to the driver itself.