### PR TITLE
realbrk.cpp: use priority mechanism

### DIFF
--- a/src/mame/includes/realbrk.h
+++ b/src/mame/includes/realbrk.h
@@ -84,7 +84,7 @@ private:
 
 	uint32_t screen_update(screen_device &screen, bitmap_ind16 &bitmap, const rectangle &cliprect);
 	uint32_t screen_update_dai2kaku(screen_device &screen, bitmap_ind16 &bitmap, const rectangle &cliprect);
-	template <bool Rotatable> void draw_sprites(bitmap_ind16 &bitmap,const rectangle &cliprect, int layer);
+	template <bool Rotatable> void draw_sprites(bitmap_ind16 &bitmap,const rectangle &cliprect, bitmap_ind8 &priority);
 
 	DECLARE_WRITE_LINE_MEMBER(vblank_irq);
 	void base_mem(address_map &map);


### PR DESCRIPTION
Using a pull request because I'm not quite sure how to approach this.  The multi-pass sprite drawing doesn't seem right, and it's relatively straightforward to assign priority masks based on the sprite attributes.  But I'm not sure what to do about the custom rotation code that draws via an intermediate bitmap.  Is there an equivalent to `copybitmap_trans` that can use priority?  Do I need to resort to iterating pixels?  Or is there a clean way to avoid the intermediate bitmap?