### PR TITLE
pc9801: fix blink attribute

### DIFF
--- a/src/mame/video/pc9801.cpp
+++ b/src/mame/video/pc9801.cpp
@@ -214,7 +214,7 @@ UPD7220_DRAW_TEXT_LINE_MEMBER( pc9801_state::hgdc_draw_text )
 						tile_data^=0xff;
 
 					if(blink && m_screen->frame_number() & 0x10)
-						tile_data^=0xff;
+						tile_data = 0;
 
 					if(yi >= char_size)
 						pen = -1;


### PR DESCRIPTION
This makes text with the "blink" attribute actually blink instead of inverting the colors every few frames. Verified on real hardware.

Fixes the lingering blinking tile after battles in Akatsuki no Bizantira, the inverted text in several CD-ROM installers, and possibly other things.