### PR TITLE
devfind.h: Attempt at solving the use-after-free problem (nw)

### DIFF
--- a/src/devices/bus/interpro/sr/sr.h
+++ b/src/devices/bus/interpro/sr/sr.h
@@ -164,9 +164,6 @@ class cbus_card_device_base : public device_cbus_card_interface
 protected:
 	cbus_card_device_base(const machine_config &mconfig, device_t &device, const char *idprom_region = "idprom");
 
-public:
-	const char *tag() { return device().tag(); }
-
 protected:
 	virtual void map(address_map &map) override;
 
@@ -307,9 +304,6 @@ class srx_card_device_base : public device_srx_card_interface
 {
 protected:
 	srx_card_device_base(const machine_config &mconfig, device_t &device, const char *idprom_region = "idprom");
-
-public:
-	const char *tag() { return device().tag(); }
 
 protected:
 	virtual void map(address_map &map) override;

--- a/src/emu/devfind.h
+++ b/src/emu/devfind.h
@@ -520,12 +520,14 @@ public:
 	/// \brief Set search tag
 	///
 	/// Allows search tag to be changed after construction.  Note that
-	/// this must be done before resolution time to take effect.  Note
-	/// that this binds to a particular instance, so the device must not
-	/// be removed or replaced, as it will cause a use-after-free when
-	/// resolving objects.
+	/// this must be done before resolution time to take effect.
 	/// \param [in] object Object to refer to.
-	void set_tag(DeviceClass &object) { set_tag(object, DEVICE_SELF); }
+	void set_tag(DeviceClass &object)
+	{
+		device_t &device = object;
+		set_tag(*device.subdevice(":"), device.tag());
+		*this = object;
+	}
 
 	/// \brief Set target during configuration
 	///


### PR DESCRIPTION
Note that the ugly subdevice(":") call is due to machine_config being an incomplete type here.