### PR TITLE
info.cpp: Adjust indent of condition.

### DIFF
--- a/src/frontend/mame/info.cpp
+++ b/src/frontend/mame/info.cpp
@@ -108,7 +108,7 @@ const char info_xml_creator::s_dtd_string[] =
 "\t\t\t<!ATTLIST display vbstart CDATA #IMPLIED>\n"
 "\t\t<!ELEMENT sound EMPTY>\n"
 "\t\t\t<!ATTLIST sound channels CDATA #REQUIRED>\n"
-"\t\t\t<!ELEMENT condition EMPTY>\n"
+"\t\t<!ELEMENT condition EMPTY>\n"
 "\t\t\t<!ATTLIST condition tag CDATA #REQUIRED>\n"
 "\t\t\t<!ATTLIST condition mask CDATA #REQUIRED>\n"
 "\t\t\t<!ATTLIST condition relation (eq|ne|gt|le|lt|ge) #REQUIRED>\n"


### PR DESCRIPTION
It currently looks like condition is an orphaned child of sound when it has no relation to it.