### PR TITLE
tlcs870 CPU fixes

### DIFF
--- a/src/devices/cpu/tlcs870/tlcs870.cpp
+++ b/src/devices/cpu/tlcs870/tlcs870.cpp
@@ -955,7 +955,7 @@ void tlcs870_device::take_interrupt(int priority)
 
 	uint16_t vector = RM16(0xffe0 + ((15-priority)*2));
 
-	WM16(m_sp.d - 1, get_PSW());
+	WM8(m_sp.d, get_PSW());
 	WM16(m_sp.d - 2, m_addr);
 	m_sp.d -= 3;
 
@@ -1107,6 +1107,10 @@ void tlcs870_device::state_import(const device_state_entry &entry)
 	case DEBUGGER_REG_HL:
 		set_reg16(REG_HL, m_debugger_temp);
 		break;
+
+	case DEBUGGER_REG_RB:
+		m_RBS = m_debugger_temp;
+		break;
 	}
 }
 
@@ -1163,6 +1167,10 @@ void tlcs870_device::state_export(const device_state_entry &entry)
 		m_debugger_temp = get_reg16(REG_HL);
 		break;
 
+	case DEBUGGER_REG_RB:
+		m_debugger_temp = m_RBS;
+		break;
+
 	}
 }
 
@@ -1190,6 +1198,7 @@ void tlcs870_device::device_start()
 	state_add(DEBUGGER_REG_DE, "DE", m_debugger_temp).callimport().callexport().formatstr("%04X");
 	state_add(DEBUGGER_REG_HL, "HL", m_debugger_temp).callimport().callexport().formatstr("%04X");
 
+	state_add(DEBUGGER_REG_RB, "RB", m_debugger_temp).callimport().callexport().formatstr("%01X");
 
 	state_add(STATE_GENPC, "GENPC", m_pc.w.l).formatstr("%04X");
 	state_add(STATE_GENPCBASE, "CURPC", m_prvpc.w.l).formatstr("%04X").noshow();

--- a/src/devices/cpu/tlcs870/tlcs870.h
+++ b/src/devices/cpu/tlcs870/tlcs870.h
@@ -126,7 +126,8 @@ private:
 		DEBUGGER_REG_WA,
 		DEBUGGER_REG_BC,
 		DEBUGGER_REG_DE,
-		DEBUGGER_REG_HL
+		DEBUGGER_REG_HL,
+		DEBUGGER_REG_RB
 	};
 
 	enum _conditions

--- a/src/devices/cpu/tlcs870/tlcs870_ops.cpp
+++ b/src/devices/cpu/tlcs870/tlcs870_ops.cpp
@@ -208,7 +208,7 @@ void tlcs870_device::do_RETI(const uint8_t opbyte0)
 
 	m_sp.d += 3;
 	m_addr = RM16(m_sp.d - 2);
-	set_PSW(RM8(m_sp.d - 1));
+	set_PSW(RM8(m_sp.d));
 
 	// Interrupts always get reenabled after a RETI.  The RETN behavior is different
 	m_EIR |= 1;


### PR DESCRIPTION
fix silly PSW trashing on interrupts, allow Register Bank to be shown in debugger

code now gets to the 'main loop' (starts at C3E0, jumps back there once it hits C6A3) and continues to execute that loop once it arrives there.