### PR TITLE
seta.cpp : Various updates

### DIFF
--- a/src/devices/sound/x1_010.cpp
+++ b/src/devices/sound/x1_010.cpp
@@ -91,7 +91,6 @@ x1_010_device::x1_010_device(const machine_config &mconfig, const char *tag, dev
 	, device_sound_interface(mconfig, *this)
 	, device_rom_interface(mconfig, *this, 20)
 	, m_rate(0)
-	, m_xor(0)
 	, m_stream(nullptr)
 	, m_sound_enable(0)
 	, m_reg(nullptr)
@@ -165,17 +164,14 @@ void x1_010_device::enable_w(int data)
 
 /* Use these for 8 bit CPUs */
 
-
-READ8_MEMBER( x1_010_device::read )
+u8 x1_010_device::read(offs_t offset)
 {
-	offset ^= m_xor;
 	return m_reg[offset];
 }
 
-WRITE8_MEMBER( x1_010_device::write )
+void x1_010_device::write(offs_t offset, u8 data)
 {
 	int channel, reg;
-	offset ^= m_xor;
 
 	channel = offset/sizeof(X1_010_CHANNEL);
 	reg     = offset%sizeof(X1_010_CHANNEL);
@@ -192,20 +188,20 @@ WRITE8_MEMBER( x1_010_device::write )
 
 /* Use these for 16 bit CPUs */
 
-READ16_MEMBER( x1_010_device::word_r )
+u16 x1_010_device::word_r(offs_t offset)
 {
 	uint16_t  ret;
 
 	ret = m_HI_WORD_BUF[offset]<<8;
-	ret += (read( space, offset )&0xff);
+	ret += (read( offset )&0xff);
 	LOG_REGISTER_READ("%s: Read X1-010 Offset:%04X Data:%04X\n", machine().describe_context(), offset, ret);
 	return ret;
 }
 
-WRITE16_MEMBER( x1_010_device::word_w )
+void x1_010_device::word_w(offs_t offset, u16 data)
 {
 	m_HI_WORD_BUF[offset] = (data>>8)&0xff;
-	write( space, offset, data&0xff );
+	write( offset, data&0xff );
 	LOG_REGISTER_WRITE("%s: Write X1-010 Offset:%04X Data:%04X\n", machine().describe_context(), offset, data);
 }
 

--- a/src/devices/sound/x1_010.h
+++ b/src/devices/sound/x1_010.h
@@ -10,14 +10,11 @@ class x1_010_device : public device_t, public device_sound_interface, public dev
 public:
 	x1_010_device(const machine_config &mconfig, const char *tag, device_t *owner, uint32_t clock);
 
-	// configuration
-	void set_address_xor(int addr) { m_xor = addr; }
+	u8 read(offs_t offset);
+	void write(offs_t offset, u8 data);
 
-	DECLARE_READ8_MEMBER ( read );
-	DECLARE_WRITE8_MEMBER( write );
-
-	DECLARE_READ16_MEMBER ( word_r );
-	DECLARE_WRITE16_MEMBER( word_w );
+	u16 word_r(offs_t offset);
+	void word_w(offs_t offset, u16 data);
 
 	void enable_w(int data);
 
@@ -39,7 +36,6 @@ private:
 
 	/* Variables only used here */
 	int m_rate;                              // Output sampling rate (Hz)
-	int m_xor;                               // address XOR
 	sound_stream *  m_stream;                // Stream handle
 	int m_sound_enable;                      // sound output enable/disable
 	std::unique_ptr<uint8_t[]>   m_reg;                 // X1-010 Register & wave form area
@@ -51,8 +47,5 @@ private:
 };
 
 DECLARE_DEVICE_TYPE(X1_010, x1_010_device)
-
-#define MCFG_X1_010_ADDRESS_XOR(_addr) \
-	downcast<x1_010_device &>(*device).set_address_xor(_addr);
 
 #endif // MAME_SOUND_X1_010_H

--- a/src/mame/drivers/seta.cpp
+++ b/src/mame/drivers/seta.cpp
@@ -1763,7 +1763,7 @@ void seta_state::calibr50_map(address_map &map)
 {
 	map(0x000000, 0x09ffff).rom();                             // ROM
 	map(0x100000, 0x100001).r(FUNC(seta_state::ipl2_ack_r));
-	map(0x200000, 0x200fff).ram();                             // NVRAM
+	map(0x200000, 0x200fff).ram().share("nvram");              // NVRAM (battery backed)
 	map(0x300000, 0x300001).rw(FUNC(seta_state::ipl1_ack_r), FUNC(seta_state::ipl1_ack_w));
 	map(0x400000, 0x400001).r("watchdog", FUNC(watchdog_timer_device::reset16_r));
 	map(0x500000, 0x500001).nopw();                        // ?
@@ -1831,7 +1831,7 @@ WRITE8_MEMBER(seta_state::usclssic_lockout_w)
 		machine().tilemap().mark_all_dirty();
 	m_tiles_offset = tiles_offset;
 
-	seta_coin_lockout_w(space, 0, data);
+	seta_coin_lockout_w(data);
 }
 
 
@@ -3417,15 +3417,15 @@ void jockeyc_state::inttoote_map(address_map &map)
 
 ***************************************************************************/
 
-WRITE8_MEMBER(seta_state::sub_bankswitch_w)
+void seta_state::sub_bankswitch_w(u8 data)
 {
 	m_subbank->set_entry(data >> 4);
 }
 
-WRITE8_MEMBER(seta_state::sub_bankswitch_lockout_w)
+void seta_state::sub_bankswitch_lockout_w(u8 data)
 {
-	m_subbank->set_entry(data >> 4);
-	seta_coin_lockout_w(space, 0, data);
+	sub_bankswitch_w(data);
+	seta_coin_lockout_w(data);
 }
 
 
@@ -3528,7 +3528,7 @@ MACHINE_RESET_MEMBER(seta_state,calibr50)
 WRITE8_MEMBER(seta_state::calibr50_sub_bankswitch_w)
 {
 	// Bits 7-4: BK3-BK0
-	sub_bankswitch_w(space, 0, data);
+	sub_bankswitch_w(data);
 
 	// Bit 3: NMICLR
 	if (!BIT(data, 3))
@@ -3539,6 +3539,7 @@ WRITE8_MEMBER(seta_state::calibr50_sub_bankswitch_w)
 		m_subcpu->set_input_line(0, CLEAR_LINE);
 
 	// Bit 1: PCMMUTE
+	m_x1->set_output_gain(ALL_OUTPUTS, BIT(data, 0) ? 0.0f : 1.0f);
 }
 
 WRITE8_MEMBER(seta_state::calibr50_soundlatch2_w)
@@ -3549,7 +3550,9 @@ WRITE8_MEMBER(seta_state::calibr50_soundlatch2_w)
 
 void seta_state::calibr50_sub_map(address_map &map)
 {
-	map(0x0000, 0x1fff).rw(m_x1, FUNC(x1_010_device::read), FUNC(x1_010_device::write)); // Sound
+	map(0x0000, 0x1fff).lrw8("x1_soundram_rw",
+								 [this](offs_t offset) { return m_x1->read(offset ^ 0x1000); },
+								 [this](offs_t offset, u8 data) { m_x1->write(offset ^ 0x1000, data); }); // Sound
 	map(0x4000, 0x4000).r("soundlatch1", FUNC(generic_latch_8_device::read));             // From Main CPU
 	map(0x4000, 0x4000).w(FUNC(seta_state::calibr50_sub_bankswitch_w));        // Bankswitching
 	map(0x8000, 0xbfff).bankr("subbank");                        // Banked ROM
@@ -7927,7 +7930,7 @@ MACHINE_CONFIG_START(seta_state::twineagl)
 
 	/* video hardware */
 	MCFG_SCREEN_ADD("screen", RASTER)
-	MCFG_SCREEN_REFRESH_RATE(60)
+	MCFG_SCREEN_REFRESH_RATE(57.42) // Possibly lower than 60Hz, Correct?
 	MCFG_SCREEN_VBLANK_TIME(ATTOSECONDS_IN_USEC(0))
 	MCFG_SCREEN_SIZE(64*8, 32*8)
 	MCFG_SCREEN_VISIBLE_AREA(0*8, 48*8-1, 1*8, 31*8-1)
@@ -8030,6 +8033,7 @@ MACHINE_CONFIG_START(seta_state::usclssic)
 	MCFG_DEVICE_ADD("maincpu", M68000, 16000000/2) /* 8 MHz */
 	MCFG_DEVICE_PROGRAM_MAP(usclssic_map)
 	MCFG_TIMER_DRIVER_ADD_SCANLINE("scantimer", seta_state, calibr50_interrupt, "screen", 0, 1)
+
 	MCFG_WATCHDOG_ADD("watchdog")
 
 	MCFG_DEVICE_ADD("sub", M65C02, 16000000/8) /* 2 MHz */
@@ -8077,7 +8081,6 @@ MACHINE_CONFIG_START(seta_state::usclssic)
 	MCFG_GENERIC_LATCH_SEPARATE_ACKNOWLEDGE(true)
 
 	MCFG_DEVICE_ADD("x1snd", X1_010, 16000000)   /* 16 MHz */
-	MCFG_X1_010_ADDRESS_XOR(0x1000)
 	MCFG_SOUND_ROUTE(ALL_OUTPUTS, "mono", 1.0)
 MACHINE_CONFIG_END
 
@@ -8097,7 +8100,10 @@ MACHINE_CONFIG_START(seta_state::calibr50)
 	MCFG_DEVICE_ADD("maincpu", M68000, XTAL(16'000'000)/2) /* verified on pcb */
 	MCFG_DEVICE_PROGRAM_MAP(calibr50_map)
 	MCFG_TIMER_DRIVER_ADD_SCANLINE("scantimer", seta_state, calibr50_interrupt, "screen", 0, 1)
+
 	MCFG_WATCHDOG_ADD("watchdog")
+
+	MCFG_NVRAM_ADD_0FILL("nvram")
 
 	MCFG_DEVICE_ADD("sub", M65C02, XTAL(16'000'000)/8) /* verified on pcb */
 	MCFG_DEVICE_PROGRAM_MAP(calibr50_sub_map)
@@ -8137,7 +8143,6 @@ MACHINE_CONFIG_START(seta_state::calibr50)
 	MCFG_GENERIC_LATCH_8_ADD("soundlatch2")
 
 	MCFG_DEVICE_ADD("x1snd", X1_010, 16000000)   /* 16 MHz */
-	MCFG_X1_010_ADDRESS_XOR(0x1000)
 	MCFG_SOUND_ROUTE(ALL_OUTPUTS, "mono", 0.50)
 MACHINE_CONFIG_END
 
@@ -12112,7 +12117,7 @@ GAME( 1989, downtownp, downtown, downtown,  downtown,  seta_state,     init_down
 
 GAME( 1989, usclssic,  0,        usclssic,  usclssic,  seta_state,     init_bank6502,  ROT270, "Seta",                      "U.S. Classic" , 0) // Country/License: DSW
 
-GAME( 1989, calibr50,  0,        calibr50,  calibr50,  seta_state,     init_bank6502,  ROT270, "Athena / Seta",             "Caliber 50" , 0) // Country/License: DSW
+GAME( 1989, calibr50,  0,        calibr50,  calibr50,  seta_state,     init_bank6502,  ROT270, "Athena / Seta",             "Caliber 50 (Ver. 1.01)" , 0) // Country/License: DSW
 
 GAME( 1989, arbalest,  0,        metafox,   arbalest,  seta_state,     init_arbalest,  ROT270, "Seta",                      "Arbalester" , 0) // Country/License: DSW
 

--- a/src/mame/includes/seta.h
+++ b/src/mame/includes/seta.h
@@ -214,8 +214,8 @@ protected:
 	uint16_t m_kiwame_row_select;
 
 	DECLARE_READ16_MEMBER(metafox_protection_r);
-	DECLARE_WRITE8_MEMBER(seta_coin_counter_w);
-	DECLARE_WRITE8_MEMBER(seta_coin_lockout_w);
+	void seta_coin_counter_w(u8 data);
+	void seta_coin_lockout_w(u8 data);
 	DECLARE_WRITE8_MEMBER(seta_vregs_w);
 	template<int Layer> DECLARE_WRITE16_MEMBER(vram_w);
 	DECLARE_WRITE16_MEMBER(twineagl_tilebank_w);
@@ -242,8 +242,8 @@ protected:
 	DECLARE_WRITE8_MEMBER(utoukond_sound_control_w);
 	DECLARE_READ16_MEMBER(pairlove_prot_r);
 	DECLARE_WRITE16_MEMBER(pairlove_prot_w);
-	DECLARE_WRITE8_MEMBER(sub_bankswitch_w);
-	DECLARE_WRITE8_MEMBER(sub_bankswitch_lockout_w);
+	void sub_bankswitch_w(u8 data);
+	void sub_bankswitch_lockout_w(u8 data);
 	DECLARE_READ8_MEMBER(ff_r);
 	DECLARE_READ8_MEMBER(downtown_ip_r);
 	DECLARE_WRITE8_MEMBER(calibr50_sub_bankswitch_w);

--- a/src/mame/video/seta.cpp
+++ b/src/mame/video/seta.cpp
@@ -227,7 +227,7 @@ static const game_offset game_offsets[] =
         ---- ---0     Coin #0 Counter     */
 
 // some games haven't the coin lockout device (blandia, eightfrc, extdwnhl, gundhara, kamenrid, magspeed, sokonuke, zingzip, zombraid)
-WRITE8_MEMBER(seta_state::seta_coin_counter_w)
+void seta_state::seta_coin_counter_w(u8 data)
 {
 	machine().bookkeeping().coin_counter_w(0, BIT(data, 0));
 	machine().bookkeeping().coin_counter_w(1, BIT(data, 1));
@@ -236,9 +236,9 @@ WRITE8_MEMBER(seta_state::seta_coin_counter_w)
 		m_x1->enable_w(BIT(data, 6));
 }
 
-WRITE8_MEMBER(seta_state::seta_coin_lockout_w)
+void seta_state::seta_coin_lockout_w(u8 data)
 {
-	seta_coin_counter_w(space, 0, data);
+	seta_coin_counter_w(data);
 
 	machine().bookkeeping().coin_lockout_w(0, !BIT(data, 2));
 	machine().bookkeeping().coin_lockout_w(1, !BIT(data, 3));


### PR DESCRIPTION
Convert X1-010 Address xor into lrw8
Simpler handlers
Implement calibr50 PCMMUTE, NVRAM
Currently dumped calibr50 is ver 1.01(Shown at regional warning screen), Correct this
Fix twineagl music(timing is related to screen framerate)

x1_010.cpp : Simpler handlers