### PR TITLE
interpro: headless configuration working

### DIFF
--- a/hash/interpro.xml
+++ b/hash/interpro.xml
@@ -172,6 +172,29 @@
 			</dataarea>
 		</part>
 
+		<!-- rebuild root floppies for 6000 and 6040 systems -->
+		<part name="60x0_root2" interface="floppy_3_5">
+			<feature name="part_id" value="Rebuild Floppy #2/4" />
+			<feature name="compatibility" value="6000,6040"/>
+			<dataarea name="flop" size="1474560">
+				<rom name="60x0_root2.img" size="1474560" offset="0" crc="7ca8534b" sha1="bffb0eda4a8cdbe2e910b94ec64629cd9dc95095" />
+			</dataarea>
+		</part>
+		<part name="60x0_root3" interface="floppy_3_5">
+			<feature name="part_id" value="Rebuild Floppy #3/4" />
+			<feature name="compatibility" value="6000,6040"/>
+			<dataarea name="flop" size="1474560">
+				<rom name="60x0_root3.img" size="1474560" offset="0" crc="2723ee4d" sha1="80dd7c43e40fd3437cf897b4c15c0b9c644a0644" />
+			</dataarea>
+		</part>
+		<part name="60x0_root4" interface="floppy_3_5">
+			<feature name="part_id" value="Rebuild Floppy #4/4" />
+			<feature name="compatibility" value="6000,6040"/>
+			<dataarea name="flop" size="1474560">
+				<rom name="60x0_root4.img" size="1474560" offset="0" crc="27764477" sha1="be89a8ba99aebe99b0bddc914b62c0ac106b56cc" />
+			</dataarea>
+		</part>
+
 		<!-- TODO: root floppy images for all other systems -->
 	</software>
 

--- a/src/devices/machine/z80scc.cpp
+++ b/src/devices/machine/z80scc.cpp
@@ -2834,11 +2834,11 @@ WRITE_LINE_MEMBER( z80scc_channel::sync_w )
 	LOGSYNC("\"%s\": %c : SYNC %u\n", owner()->tag(), 'A' + m_index, state);
 
 	/*
-	* The /SYNC pin is a general purpose input whose state is reported in the
-	* Sync/Hunt bit in RR0. If the crystal oscillator is enabled, this pin is
-	* not available and the Sync/Hunt bit is forced to 0. Otherwise, the /SYNC
-	* pin may be used to carry the Ring Indicator signal.
-	*/
+	 * The /SYNC pin is a general purpose input whose state is reported in the
+	 * Sync/Hunt bit in RR0. If the crystal oscillator is enabled, this pin is
+	 * not available and the Sync/Hunt bit is forced to 0. Otherwise, the /SYNC
+	 * pin may be used to carry the Ring Indicator signal.
+	 */
 	if (!(m_wr11 & WR11_RCVCLK_TYPE))
 	{
 		// check for state change

--- a/src/devices/machine/z80scc.cpp
+++ b/src/devices/machine/z80scc.cpp
@@ -2125,6 +2125,8 @@ void z80scc_channel::do_sccreg_wr5(uint8_t data)
 		update_serial();
 		safe_transmit_register_reset();
 		update_rts(); // Will also update DTR accordingly
+
+		check_waitrequest();
 	}
 }
 
@@ -3109,7 +3111,7 @@ void z80scc_channel::check_waitrequest()
 	// if dma request function is enabled
 	if (m_wr1 & WR1_WREQ_FUNCTION)
 	{
-		// assert /W//REQ if transmit buffer is empty, clear if it's not
-		m_uart->m_out_wreq_cb[m_index]((m_rr0 & RR0_TX_BUFFER_EMPTY) ? ASSERT_LINE : CLEAR_LINE);
+		// assert /W//REQ if transmit buffer is empty and transmitter is enabled
+		m_uart->m_out_wreq_cb[m_index](((m_rr0 & RR0_TX_BUFFER_EMPTY) && (m_wr5 & WR5_TX_ENABLE)) ? 0 : 1);
 	}
 }

--- a/src/mame/includes/interpro.h
+++ b/src/mame/includes/interpro.h
@@ -140,8 +140,7 @@ public:
 	DECLARE_FLOPPY_FORMATS(floppy_formats);
 
 	void ioga(machine_config &config);
-	void interpro_scc1(machine_config &config);
-	void interpro_scc2(machine_config &config);
+	void interpro_serial(machine_config &config);
 	void interpro(machine_config &config);
 	static void interpro_scsi_adapter(device_t *device);
 	static void interpro_cdrom(device_t *device);

--- a/src/mame/machine/interpro_ioga.h
+++ b/src/mame/machine/interpro_ioga.h
@@ -296,12 +296,18 @@ private:
 	u32 dma_r(address_space &space, offs_t offset, u32 mem_mask, dma_channel channel) const;
 	void dma_w(address_space &space, offs_t offset, u32 data, u32 mem_mask, dma_channel channel);
 
-	enum serial_dma_ctrl_mask
+	enum serial_dma_ctrl_mask : u32
 	{
-		SDMA_COUNT   = 0x0000ffff,
+		SDMA_COUNT   = 0x000000ff,
+		SDMA_TAG     = 0x0000ff00, // bus tag?
+
 		SDMA_TCZERO  = 0x00200000,
-		SDMA_SEND    = 0x04000000, // transfer from memory to device
-		SDMA_CONTROL = 0xffff0000,
+
+		SDMA_WRITE   = 0x01000000, // transfer from memory to device
+		SDMA_ENABLE  = 0x02000000,
+		SDMA_0400    = 0x04000000,
+
+		SDMA_1000    = 0x10000000, // set on Sapphire systems?
 	};
 	u32 serial_dma_addr_r(address_space &space, offs_t offset, u32 mem_mask, int channel) const { return m_serial_dma_channel[channel].address; }
 	void serial_dma_addr_w(address_space &space, offs_t offset, u32 data, u32 mem_mask, int channel);


### PR DESCRIPTION
These fixes enable booting and CLIX installation on headless InterServe systems (InterPro systems without graphics) using a VT100 or VT220 compatible terminal on serial port 2 (0 for ip6000). It's now possible to install and boot CLIX on the ip6000 system, as this works around the issues with the incomplete graphics hardware support in the driver.
* interpro: tidy serial configuration, add missing control lines
* interpro_ioga: fix serial dma
* z80scc: update /WREQ when transmitter is enabled/disabled, use 0 for assert state of active low output
* softlist: added 60x0 CLIX root floppies