### PR TITLE
HP1LL3: more improvements

### DIFF
--- a/src/devices/video/hp1ll3.h
+++ b/src/devices/video/hp1ll3.h
@@ -25,6 +25,10 @@ public:
 	// construction/destruction
 	hp1ll3_device(const machine_config &mconfig, const char *tag, device_t *owner, uint32_t clock);
 
+	// Configuration
+	// Set VRAM size (in kw). Parameter must be <= 128 and it must be a power of 2.
+	void set_vram_size(unsigned kw) { m_vram_size = kw * 1024; }
+
 	DECLARE_READ8_MEMBER(read);
 	DECLARE_WRITE8_MEMBER(write);
 
@@ -50,6 +54,7 @@ private:
 
 	uint16_t get_pix_addr(uint16_t x, uint16_t y) const;
 	inline void point(int x, int y, bool pix, const uint16_t masks[]);
+	void get_font(uint16_t& font_data, uint16_t& font_height) const;
 	void label(uint8_t chr, int width);
 	void line(int x_from, int y_from, int x_to, int y_to);
 	void wr_video(uint16_t addr, uint16_t v);
@@ -69,19 +74,22 @@ private:
 	void draw_cursor_sprite();
 	void set_pen_pos(Point p);
 	void set_sprite_pos(Point p);
+	void disable_cursor();
+	void disable_sprite();
 	Rectangle get_window() const;
 	Rectangle get_screen() const;
+	void get_hv_timing(bool vertical, unsigned& total, unsigned& active) const;
 	void apply_conf();
 
 	uint16_t m_conf[11], m_input[2], m_io_word;
-	int m_io_ptr, m_memory_ptr;
+	int m_rd_ptr, m_wr_ptr, m_memory_ptr;
 	int m_command, m_horiz_pix_total, m_vert_pix_total;
 
 	uint16_t m_sad;
 	uint16_t m_org;
 	uint16_t m_dad;
 	uint16_t m_rr;
-	uint16_t m_fad, m_fontdata, m_fontheight;
+	uint16_t m_fad;
 	uint16_t m_udl;
 
 	bool m_enable_video, m_enable_cursor, m_enable_sprite;
@@ -94,6 +102,7 @@ private:
 		uint16_t width, height, org_x, org_y;
 	} m_window;
 	std::unique_ptr<uint16_t[]> m_videoram;
+	unsigned m_vram_size;
 	uint16_t m_ram_addr_mask;
 	uint16_t m_rw_win_x, m_rw_win_y;
 

--- a/src/mame/drivers/hp_ipc.cpp
+++ b/src/mame/drivers/hp_ipc.cpp
@@ -387,6 +387,7 @@ public:
 		, m_bankdev(*this, "bankdev")
 		, m_fdc(*this, "fdc")
 		, m_ram(*this, RAM_TAG)
+		, m_gpu(*this , "gpu")
 		, m_screen(*this, "screen")
 	{ }
 
@@ -431,6 +432,7 @@ private:
 	required_device<address_map_bank_device> m_bankdev;
 	required_device<wd2797_device> m_fdc;
 	required_device<ram_device> m_ram;
+	required_device<hp1ll3_device> m_gpu;
 	required_device<screen_device> m_screen;
 
 	uint32_t m_mmu[4], m_lowest_ram_addr;
@@ -485,7 +487,7 @@ void hp_ipc_state::hp_ipc_mem_inner_base(address_map &map)
 	map(0x1000000, 0x17FFFFF).rw(FUNC(hp_ipc_state::ram_r), FUNC(hp_ipc_state::ram_w));
 	map(0x1800000, 0x187FFFF).rom().region("maincpu", 0);
 	map(0x1E00000, 0x1E0FFFF).rw(FUNC(hp_ipc_state::mmu_r), FUNC(hp_ipc_state::mmu_w));
-	map(0x1E20000, 0x1E2000F).rw("gpu", FUNC(hp1ll3_device::read), FUNC(hp1ll3_device::write)).umask16(0x00ff);
+	map(0x1E20000, 0x1E2000F).rw(m_gpu, FUNC(hp1ll3_device::read), FUNC(hp1ll3_device::write)).umask16(0x00ff);
 	map(0x1E40000, 0x1E4002F).rw("rtc", FUNC(mm58167_device::read), FUNC(mm58167_device::write)).umask16(0x00ff);
 
 // supervisor mode
@@ -495,7 +497,7 @@ void hp_ipc_state::hp_ipc_mem_inner_base(address_map &map)
 	map(0x0600000, 0x060FFFF).rw(FUNC(hp_ipc_state::mmu_r), FUNC(hp_ipc_state::mmu_w));
 	map(0x0610000, 0x0610007).rw(FUNC(hp_ipc_state::floppy_id_r), FUNC(hp_ipc_state::floppy_id_w)).umask16(0x00ff);
 	map(0x0610008, 0x061000F).rw(m_fdc, FUNC(wd2797_device::read), FUNC(wd2797_device::write)).umask16(0x00ff);
-	map(0x0620000, 0x0620007).rw("gpu", FUNC(hp1ll3_device::read), FUNC(hp1ll3_device::write)).umask16(0x00ff);
+	map(0x0620000, 0x0620007).rw(m_gpu, FUNC(hp1ll3_device::read), FUNC(hp1ll3_device::write)).umask16(0x00ff);
 	map(0x0630000, 0x063FFFF).mask(0xf).rw("hpib" , FUNC(tms9914_device::reg8_r) , FUNC(tms9914_device::reg8_w)).umask16(0x00ff);
 	map(0x0640000, 0x064002F).rw("rtc", FUNC(mm58167_device::read), FUNC(mm58167_device::write)).umask16(0x00ff);
 	map(0x0660000, 0x06600FF).rw("mlc", FUNC(hp_hil_mlc_device::read), FUNC(hp_hil_mlc_device::write)).umask16(0x00ff);  // 'caravan', scrn/caravan.h
@@ -738,7 +740,7 @@ MACHINE_CONFIG_START(hp_ipc_state::hp_ipc_base)
 	MCFG_DEVICE_ADD("maincpu", M68000, 15.92_MHz_XTAL / 2)
 	MCFG_DEVICE_PROGRAM_MAP(hp_ipc_mem_outer)
 
-	HP1LL3(config , "gpu" , 24_MHz_XTAL / 8).set_screen("screen");
+	HP1LL3(config , m_gpu , 24_MHz_XTAL / 8).set_screen("screen");
 
 	// XXX actual clock is 1MHz; remove this workaround (and change 2000 to 100 in hp_ipc_dsk.cpp)
 	// XXX when floppy code correctly handles 600 rpm drives.
@@ -794,6 +796,9 @@ MACHINE_CONFIG_START(hp_ipc_state::hp_ipc)
 	MCFG_ADDRESS_MAP_BANK_DATA_WIDTH(16)
 	MCFG_ADDRESS_MAP_BANK_STRIDE(0x1000000)
 
+	// 16kw/32kb video RAM
+	m_gpu->set_vram_size(16);
+
 	// horizontal time = 60 us (min)
 	// ver.refresh period = ~300 us
 	// ver.period = 16.7ms (~60 hz)
@@ -817,12 +822,16 @@ MACHINE_CONFIG_START(hp_ipc_state::hp9808a)
 	MCFG_ADDRESS_MAP_BANK_DATA_WIDTH(16)
 	MCFG_ADDRESS_MAP_BANK_STRIDE(0x1000000)
 
-	MCFG_SCREEN_ADD_MONOCHROME("screen", LCD, rgb_t::amber()) // actually a kind of EL display
-	MCFG_SCREEN_UPDATE_DEVICE("gpu", hp1ll3_device, screen_update)
-	MCFG_SCREEN_RAW_PARAMS(6_MHz_XTAL * 2, 720, 0, 640, 480, 0, 400)
-	MCFG_SCREEN_VBLANK_CALLBACK(WRITELINE("mlc", hp_hil_mlc_device, ap_w))
+	// 64kw/128kb video RAM
+	m_gpu->set_vram_size(64);
 
-	MCFG_SCREEN_PALETTE("palette")
+	SCREEN(config , m_screen , SCREEN_TYPE_LCD);
+	m_screen->set_color(rgb_t::amber()); // actually a kind of EL display
+	m_screen->set_screen_update("gpu" , FUNC(hp1ll3_device::screen_update));
+	m_screen->set_raw(6_MHz_XTAL * 2 , 880 , 0 , 640 , 425 , 0 , 400);
+	m_screen->screen_vblank().set("mlc", FUNC(hp_hil_mlc_device::ap_w)); // XXX actually it's driven by 555 (U59)
+	m_screen->set_palette("palette");
+
 	MCFG_PALETTE_ADD_MONOCHROME("palette")
 MACHINE_CONFIG_END
 


### PR DESCRIPTION
Hi,

this PR has a few more improvements to HP1LL3 GPU. The main features I added are:
+ Configurable VRAM size (as HP-9807 & 9808 have different amounts of VRAM)
+ Auto-configuration of video size & timing
+ Some minor commands used by diagnostic code.

The GPU emulation can now pass both diagnostic tests (in the diagnostic disc & the "diagb" ROM).
As for the regressions in video appearance reported by Tafoid I think that I fully addressed them.
Hopefully this time I was more consistent with the original coding style.. sorry about last PR.

Thanks.
--F.Ulivi
