### PR TITLE
hng64 refactoring

### DIFF
--- a/src/mame/drivers/hng64.cpp
+++ b/src/mame/drivers/hng64.cpp
@@ -624,6 +624,24 @@ WRITE32_MEMBER(hng64_state::hng64_irqc_w)
   the 0x1074 address seems to be the same thing but for the network CPU
   0x20 is written to 0x1074 in the MIPS IRQ handlers that seem to be associated with communication (levels 0x09, 0x0a, 0x0b, 0x0c)
 
+
+  -----
+  the following notes are taken from the old 'fake IO' function, in reality it turned out that these 'commands' were not needed
+  with the real IO MCU hooked up, although we still use the 0x0c one as a hack in order to provide the 'm_no_machine_error_code' value
+  in order to bypass a startup check, in reality it looks like that should be written by the MCU after reading it via serial.
+
+  ---- OUTDATED NOTES ----
+
+  I'm not really convinced these are commands in this sense based on code analysis, probably just a non-standard way of controlling the lines
+
+	command table:
+	0x0b = ? mode input polling (sams64, bbust2, sams64_2 & roadedge) (*)
+	0x0c = cut down connections, treats the dualport to be normal RAM
+	0x11 = ? mode input polling (fatfurwa, xrally, buriki) (*)
+	0x20 = asks for MCU machine code (probably not, this is also written in the function after the TLCS870 requests an interrupt on the MIPS)
+
+	(*) 0x11 is followed by 0x0b if the latter is used, JVS-esque indirect/direct mode?
+  ----
 */
 
 READ32_MEMBER(hng64_state::hng64_sysregs_r)
@@ -674,17 +692,7 @@ READ8_MEMBER(hng64_state::hng64_dualport_r)
 {
 	LOG("%s: dualport R %04x\n", machine().describe_context(), offset);
 
-	/*
-	I'm not really convinced these are commands in this sense based on code analysis, probably just a non-standard way of controlling the lines
-
-	command table:
-	0x0b = ? mode input polling (sams64, bbust2, sams64_2 & roadedge) (*)
-	0x0c = cut down connections, treats the dualport to be normal RAM
-	0x11 = ? mode input polling (fatfurwa, xrally, buriki) (*)
-	0x20 = asks for MCU machine code (probably not, this is also written in the function after the TLCS870 requests an interrupt on the MIPS)
-
-	(*) 0x11 is followed by 0x0b if the latter is used, JVS-esque indirect/direct mode?
-	*/
+	// hack, this should just be put in ram at 0x600 by the MCU.
 	if (!(m_mcu_en == 0x0c))
 	{
 		switch (offset)

--- a/src/mame/drivers/hng64.cpp
+++ b/src/mame/drivers/hng64.cpp
@@ -683,10 +683,8 @@ WRITE32_MEMBER(hng64_state::hng64_sysregs_w)
 
 
 /**************************************
-* MCU simulation / hacks
+* MIPS side Dual Port RAM hookup for MCU
 **************************************/
-
-// real IO MCU only has 8 multiplexed 8-bit digital input ports, so some of these fake inputs are probably processed representations of the same thing
 
 READ8_MEMBER(hng64_state::hng64_dualport_r)
 {

--- a/src/mame/drivers/hng64.cpp
+++ b/src/mame/drivers/hng64.cpp
@@ -727,7 +727,8 @@ Beast Busters 2 outputs (all at offset == 0x1c):
 	the MIPS (at least in Fatal Fury) uploads this data to shared RAM prior to the call.
 
 	need to work out what triggers the interrupt, as a write to 0 wouldn't as the Dual Port RAM interrupts
-	are on addresses 0x7fe and 0x7ff
+	are on addresses 0x7fe and 0x7ff (we're using an address near the system regs, based on code analysis
+	it seems correct, see hng64_mips_to_iomcu_irq_w )
 */
 
 WRITE8_MEMBER(hng64_state::hng64_dualport_w)

--- a/src/mame/drivers/hng64.cpp
+++ b/src/mame/drivers/hng64.cpp
@@ -614,13 +614,25 @@ WRITE32_MEMBER(hng64_state::hng64_irqc_w)
 	}
 }
 
+/*
+  These 'sysregs' seem to be multiple sets of the same thing
+  (based on xrally)
+
+  the 0x1084 addresses appear to be related to the IO MCU, but neither sending commands to the MCU, not controlling lines directly
+  0x20 is written to 0x1084 in the MIPS IRQ handlers for the IO MCU (both 0x11 and 0x17 irq levels)
+
+  the 0x1074 address seems to be the same thing but for the network CPU
+  0x20 is written to 0x1074 in the MIPS IRQ handlers that seem to be associated with communication (levels 0x09, 0x0a, 0x0b, 0x0c)
+
+*/
+
 READ32_MEMBER(hng64_state::hng64_sysregs_r)
 {
 	//LOG("%s: hng64_sysregs_r (%04x) (%08x)\n", machine().describe_context(), offset * 4, mem_mask);
 
 	switch(offset*4)
 	{
-		case 0x001c: return machine().rand(); // hng64 hangs on start-up if zero.
+		case 0x001c: return 0x00000000; // 0x00000040 must not be set or games won't boot
 		//case 0x106c:
 		//case 0x107c:
 		case 0x1084:

--- a/src/mame/drivers/hng64.cpp
+++ b/src/mame/drivers/hng64.cpp
@@ -824,10 +824,10 @@ void hng64_state::hng_map(address_map &map)
 	map(0x1f7021c4, 0x1f7021c7).w(FUNC(hng64_state::hng64_mips_to_iomcu_irq_w));
 
 	// SRAM.  Coin data, Player Statistics, etc.
-	map(0x1F800000, 0x1F803fff).ram().share("nvram");
+	map(0x1f800000, 0x1f803fff).ram().share("nvram");
 
 	// Dualport RAM (shared with IO MCU)
-	map(0x1F808000, 0x1F8087ff).rw(FUNC(hng64_state::hng64_dualport_r), FUNC(hng64_state::hng64_dualport_w)).umask32(0xffffffff);
+	map(0x1f808000, 0x1f8087ff).rw(FUNC(hng64_state::hng64_dualport_r), FUNC(hng64_state::hng64_dualport_w)).umask32(0xffffffff);
 
 	// BIOS ROM
 	map(0x1fc00000, 0x1fc7ffff).nopw().rom().region("user1", 0).share("rombase");

--- a/src/mame/includes/hng64.h
+++ b/src/mame/includes/hng64.h
@@ -277,7 +277,11 @@ private:
 	DECLARE_READ8_MEMBER(hng64_com_share_mips_r);
 	DECLARE_READ32_MEMBER(hng64_sysregs_r);
 	DECLARE_WRITE32_MEMBER(hng64_sysregs_w);
-	
+	DECLARE_READ32_MEMBER(hng64_rtc_r);
+	DECLARE_WRITE32_MEMBER(hng64_rtc_w);
+
+	DECLARE_WRITE32_MEMBER(hng64_mips_to_iomcu_irq_w);
+
 	DECLARE_READ8_MEMBER(fake_io_r);
 	DECLARE_READ8_MEMBER(hng64_dualport_r);
 	DECLARE_WRITE8_MEMBER(hng64_dualport_w);

--- a/src/mame/includes/hng64.h
+++ b/src/mame/includes/hng64.h
@@ -280,6 +280,9 @@ private:
 	DECLARE_READ32_MEMBER(hng64_rtc_r);
 	DECLARE_WRITE32_MEMBER(hng64_rtc_w);
 
+	DECLARE_READ32_MEMBER(hng64_dmac_r);
+	DECLARE_WRITE32_MEMBER(hng64_dmac_w);
+
 	DECLARE_WRITE32_MEMBER(hng64_mips_to_iomcu_irq_w);
 
 	DECLARE_READ8_MEMBER(fake_io_r);

--- a/src/mame/includes/hng64.h
+++ b/src/mame/includes/hng64.h
@@ -279,13 +279,12 @@ private:
 	DECLARE_WRITE32_MEMBER(hng64_sysregs_w);
 	DECLARE_READ32_MEMBER(hng64_rtc_r);
 	DECLARE_WRITE32_MEMBER(hng64_rtc_w);
-
 	DECLARE_READ32_MEMBER(hng64_dmac_r);
 	DECLARE_WRITE32_MEMBER(hng64_dmac_w);
-
+	DECLARE_READ32_MEMBER(hng64_irqc_r);
+	DECLARE_WRITE32_MEMBER(hng64_irqc_w);
 	DECLARE_WRITE32_MEMBER(hng64_mips_to_iomcu_irq_w);
 
-	DECLARE_READ8_MEMBER(fake_io_r);
 	DECLARE_READ8_MEMBER(hng64_dualport_r);
 	DECLARE_WRITE8_MEMBER(hng64_dualport_w);
 


### PR DESCRIPTION
mainly splitting peripheral handlers up a bit rather than having them all in one switch case.
