### PR TITLE
A small improvement/bug fix in HP1LL3 GPU driver

### DIFF
--- a/src/devices/video/hp1ll3.h
+++ b/src/devices/video/hp1ll3.h
@@ -105,6 +105,7 @@ private:
 	unsigned m_vram_size;
 	uint16_t m_ram_addr_mask;
 	uint16_t m_rw_win_x, m_rw_win_y;
+	uint8_t m_rw_win_off;
 
 	bool m_busy;
 


### PR DESCRIPTION
Hi,

this PR adds the implementation of bit offset in RDWIN/WRWIN GPU commands. This addition fixes an annoying "double cursor" defect in rendered video.
I've also added a table of GPU commands for reference.
Thanks.
--F.Ulivi