### PR TITLE
c64_flop.xml - Add a few new dumps

### DIFF
--- a/hash/c64_flop.xml
+++ b/hash/c64_flop.xml
@@ -320,6 +320,23 @@
 		</part>
 	</software>
 
+	<!-- Flippy disks. The other side is for Atari 8-bit. -->
+	<software name="sargon3">
+		<description>Sargon III</description>
+		<year>1985</year>
+		<publisher>Hayden Software Company</publisher>
+		<part name="flop1" interface="floppy_5_25">
+			<dataarea name="flop" size="174848">
+				<rom name="sargon_iii.d64" size="174848" crc="b18720a1" sha1="4001e2ac78fda39df59508e66c2620d415c15214" offset="0" />
+			</dataarea>
+		</part>
+		<part name="flop2" interface="floppy_5_25">
+			<dataarea name="flop" size="174848">
+				<rom name="great_game_and_chess_problems_c64.d64" size="174848" crc="129fa72a" sha1="22e8709081125000b24ea2f3485e19e3af21ed4e" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
 	<software name="sthassle">
 		<description>Street Hassle</description>
 		<year>1987</year>

--- a/hash/c64_flop.xml
+++ b/hash/c64_flop.xml
@@ -185,6 +185,21 @@
 		</part>
 	</software>
 
+	<!-- Flippy disk. The other side is for Apple II. -->
+	<software name="jingldsk">
+		<description>JingleDisk - Holiday Musical Story with Computer Animation</description>
+		<year>1985</year>
+		<publisher>Thoughtware</publisher>
+		<info name="usage" value="Commodore: Load &quot;JINGLE&quot;,8,1 / Apple IIc and e: Self boots" />
+		<sharedfeat name="compatibility" value="NTSC,PAL"/>
+		<part name="flop1" interface="floppy_5_25">
+			<feature name="part_id" value="Operates on Commodore"/>
+			<dataarea name="flop" size="174848">
+				<rom name="jingledisk (commodore).d64" size="174848" crc="2fc6663a" sha1="e81dab6d22df694f9f38ef6c03aa2305a62df140" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
 	<software name="metaldst">
 		<description>Metal Dust</description>
 		<year>2012</year>

--- a/hash/c64_flop.xml
+++ b/hash/c64_flop.xml
@@ -51,6 +51,17 @@
 		</part>
 	</software>
 
+	<software name="bbudge">
+		<description>Bill Budge: Pinball Construction Set</description>
+		<year>1983</year>
+		<publisher>Electronic Arts</publisher>
+		<part name="flop1" interface="floppy_5_25">
+			<dataarea name="flop" size="174848">
+				<rom name="bill_budge.d64" size="174848" crc="d42c40b4" sha1="75b0a166b29e9ed3834c95acc1f263a084062f5f" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
 	<software name="bionicco">
 		<description>Bionic Commando</description>
 		<year>1988</year>


### PR DESCRIPTION
Three new dumps from original floppies.

Kryoflux RAW images are on archive.org
https://archive.org/details/BillBudgePinballConstructionSetCommodore64.7z
https://archive.org/details/JingleDiskHolidayMusicalStoryWithComputerAnimationCommodore64AndAppleIIc.7z
https://archive.org/details/Sargon3Commodore64AndAtari8bit.7z