### PR TITLE
misc small fixes (btime.cpp note, nightmare.cpp defaults)

### DIFF
--- a/src/devices/machine/sda2006.cpp
+++ b/src/devices/machine/sda2006.cpp
@@ -36,7 +36,16 @@ DEFINE_DEVICE_TYPE(SDA2006, sda2006_device, "sda2006", "SDA2006 EEPROM")
 sda2006_device::sda2006_device(const machine_config &mconfig, const char *tag, device_t *owner, uint32_t clock)
 	: device_t(mconfig, SDA2006, tag, owner, clock)
 	, device_nvram_interface(mconfig, *this)
-	, m_latch(0),  m_current_address(0), m_eeprom_state(),m_read_stream_pos(0),m_is_end_o_stream(false), m_write_stream_length(0), m_write_stream(0), m_write_state(0), m_clock_state (0)
+	, m_latch(0)
+	, m_current_address(0)
+	, m_eeprom_state()
+	, m_read_stream_pos(0)
+	, m_is_end_o_stream(false)
+	, m_write_stream_length(0)
+	, m_write_stream(0)
+	, m_write_state(0)
+	, m_clock_state(0)
+	, m_region(*this, DEVICE_SELF)
 {
 }
 
@@ -80,7 +89,6 @@ void sda2006_device::device_reset()
 	m_read_stream_pos = 0;
 	m_eeprom_state = EEPROM_WRITE;
 	m_clock_state = 0;
-
 }
 
 //-------------------------------------------------
@@ -90,6 +98,13 @@ void sda2006_device::device_reset()
 
 void sda2006_device::nvram_default()
 {
+	// region always wins
+	if (m_region.found())
+	{
+		memcpy(m_eeprom_data, m_region->base(), EEPROM_CAPACITY);
+		return;
+	}
+
 	for (auto & elem : m_eeprom_data)
 		elem = 0xffff;
 }

--- a/src/devices/machine/sda2006.h
+++ b/src/devices/machine/sda2006.h
@@ -9,18 +9,18 @@
 
 // sda2006_device
 
-class sda2006_device :   public device_t,
-							public device_nvram_interface
+class sda2006_device : public device_t,
+	public device_nvram_interface
 {
 public:
 	// construction/destruction
 	sda2006_device(const machine_config &mconfig, const char *tag, device_t *owner, uint32_t clock = 0);
 
 	// I/O operations
-	DECLARE_READ_LINE_MEMBER( read_data );
-	DECLARE_WRITE_LINE_MEMBER( write_data );
-	DECLARE_WRITE_LINE_MEMBER( write_clock );
-	DECLARE_WRITE_LINE_MEMBER( write_enable );
+	DECLARE_READ_LINE_MEMBER(read_data);
+	DECLARE_WRITE_LINE_MEMBER(write_data);
+	DECLARE_WRITE_LINE_MEMBER(write_clock);
+	DECLARE_WRITE_LINE_MEMBER(write_enable);
 
 protected:
 	// device-level overrides
@@ -38,19 +38,18 @@ private:
 		EEPROM_WRITE
 	};
 
-	 uint8_t m_latch;
-	 uint8_t m_current_address;
-	 uint32_t m_eeprom_state;
-	 uint8_t m_read_stream_pos;
-	 bool m_is_end_o_stream;
-	 uint8_t m_write_stream_length;
- 	 uint32_t m_write_stream;
-	 uint8_t m_write_state;
-	 uint8_t m_clock_state;
-	
-	 
-	 
-	 uint16_t m_eeprom_data[0x20];
+	uint8_t m_latch;
+	uint8_t m_current_address;
+	uint32_t m_eeprom_state;
+	uint8_t m_read_stream_pos;
+	bool m_is_end_o_stream;
+	uint8_t m_write_stream_length;
+	uint32_t m_write_stream;
+	uint8_t m_write_state;
+	uint8_t m_clock_state;
+
+	optional_memory_region      m_region;
+	uint16_t m_eeprom_data[0x20];
 };
 
 

--- a/src/mame/drivers/btime.cpp
+++ b/src/mame/drivers/btime.cpp
@@ -2002,8 +2002,10 @@ void btime_state::init_zoar()
 
 	/* At location 0xD50A is what looks like an undocumented opcode. I tried
 	   implementing it given what opcode 0x23 should do, but it still didn't
-	   work in demo mode. So this could be another protection or a bad ROM read.
-	   I'm NOPing it out for now. */
+	   work in demo mode, this could be another protection.
+
+	   The ROM has been confirmed as good on multiple working PCBs, so this
+	   isn't a bitrot issue */
 	memset(&rom[0xd50a],0xea,8);
 
 	m_audio_nmi_enable_type = AUDIO_ENABLE_AY8910;
@@ -2016,7 +2018,11 @@ void btime_state::init_tisland()
 	/* At location 0xa2b6 there's a strange RLA followed by a BPL that reads from an
 	   unmapped area that causes the game to fail in several circumstances.On the Cassette
 	   version the RLA (33) is in reality a BIT (24),so I'm guessing that there's something
-	   wrong going on in the encryption scheme.*/
+	   wrong going on in the encryption scheme.
+	   
+	   There are other locations with similar problems. These ROMs have NOT yet been
+	   confirmed on multiple PCBs, so this could still be a bad dump.
+	   */
 	memset(&rom[0xa2b6],0x24,1);
 
 	m_audio_nmi_enable_type = AUDIO_ENABLE_DIRECT;

--- a/src/mame/drivers/nightmare.cpp
+++ b/src/mame/drivers/nightmare.cpp
@@ -170,7 +170,7 @@
 
   
   Sound Board:
-  
+  (also used on some Pinball machines)
 
   IC9, EFO 90503 (seems a remarked TMS5220, speech synthesizer IC).
 
@@ -201,7 +201,7 @@
   - Verify video mixing (Press F2 to enter service mode, then press 1 + 2 to continue
     to settings screen. There's diagnostic color pattern at the top of screen)
   - Add sound hardware (ROM is missing)
-
+  - Quitting MAME while in service mode settings screen will invalidate settings
 
 ******************************************************************************/
 
@@ -476,6 +476,9 @@ ROM_START( nightmare )
 
 	ROM_REGION( 0x10000, "cdp1802_sound", 0 ) 
 	ROM_LOAD( "sound.bin",    0x0000, 0x4000, NO_DUMP )
+
+	ROM_REGION( 0x40, "eeprom", 0 ) 
+	ROM_LOAD( "eeprom", 0x00, 0x40, CRC(7824e1f8) SHA1(2ccac62b4e8abcb2b3d66fa4025947fea184664e) )
 ROM_END
 
-GAME( 1982, nightmare, 0,        nightmare, nightmare,   nightmare_state,   empty_init, ROT90, "E.F.O.", "Nightmare", MACHINE_NO_SOUND | MACHINE_SUPPORTS_SAVE | MACHINE_NO_COCKTAIL )
+GAME( 1982, nightmare, 0,        nightmare, nightmare,   nightmare_state,   empty_init, ROT90, "E.F.O.", "Nightmare (Spain)", MACHINE_NO_SOUND | MACHINE_SUPPORTS_SAVE | MACHINE_NO_COCKTAIL )


### PR DESCRIPTION
updated comment about Zoar, it's not a bad dump, was confirmed as good by Joe Magiera

added 'default' support to the eeprom device used by Nightmare (just reused the code from nvram.cpp) and gave it a default, as otherwise it boots to invalid settings giving you a random number of lives, weird coinage, invalid bonus life value etc.

also marked Nightmare as (Spain) as the export version is not dumped, and this is in Spanish.