### PR TITLE
apollo.h: Fix C2680 compiler error in Visual Studio

### DIFF
--- a/src/mame/includes/apollo.h
+++ b/src/mame/includes/apollo.h
@@ -36,6 +36,7 @@
 #include "bus/rs232/rs232.h"
 
 #include "diserial.h"
+#include "screen.h"
 
 #ifndef VERBOSE
 #define VERBOSE 0


### PR DESCRIPTION
This fixes the following compiler error:

```
1>c:\mame\src\emu\devfind.h(588): error C2680: 'screen_device *': invalid target type for dynamic_cast
1>c:\mame\src\emu\devfind.h(588): note: 'screen_device': class must be defined before using in a dynamic_cast
1>c:\mame\src\emu\devfind.h(580): note: while compiling class template member function 'bool device_finder<screen_device,true>::findit(bool)'
1>c:\mame\src\mame\includes\apollo.h(463): note: see reference to class template instantiation 'device_finder<screen_device,true>' being compiled
```