### PR TITLE
actually properly disable opwolf protection simulation, fix coin counters (nw)

### DIFF
--- a/src/mame/drivers/opwolf.cpp
+++ b/src/mame/drivers/opwolf.cpp
@@ -333,12 +333,10 @@ READ8_MEMBER(opwolf_state::z80_input2_r)
 
 WRITE8_MEMBER(opwolf_state::counters_w)
 {
-	//logerror("counters_w data=%2x\n",data );
-
 	machine().bookkeeping().coin_lockout_w(1, data & 0x80);
 	machine().bookkeeping().coin_lockout_w(0, data & 0x40);
-	machine().bookkeeping().coin_counter_w(1, data & 0x20);
-	machine().bookkeeping().coin_counter_w(0, data & 0x10);
+	machine().bookkeeping().coin_counter_w(1, ~data & 0x20);
+	machine().bookkeeping().coin_counter_w(0, ~data & 0x10);
 }
 
 /******************************************************
@@ -1157,7 +1155,7 @@ void opwolf_state::init_opwolf()
 
 	m_opwolf_region = rom[0x03fffe / 2] & 0xff;
 
-	opwolf_cchip_init();
+	//opwolf_cchip_init(); // start old simulation, including periodic timer
 
 	// World & US version have different gun offsets, presumably slightly different gun hardware
 	m_opwolf_gun_xoffs = 0xec - (rom[0x03ffb0 / 2] & 0xff);


### PR DESCRIPTION
previously it was calling
opwolf_cchip_init();

which called

	m_cchip_timer = timer_alloc(TIMER_CCHIP);
	m_cchip_timer->adjust(attotime::from_hz(60), 0, attotime::from_hz(60));

which in turn overrode some of the emulated behavior with the simulation (including coin counter writes)

this is why I personally think it's best to keep clean code, and remove the old simulations, leaving the old MAME versions as reference for them, but I don't feel it's my place to remove it.
