### PR TITLE
Fixed MC6840 PTM handling in Xenophobe

### DIFF
--- a/src/mame/drivers/mcr68.cpp
+++ b/src/mame/drivers/mcr68.cpp
@@ -1495,6 +1495,9 @@ void mcr68_state::init_xenophob()
 
 	/* install control port handler */
 	m_maincpu->space(AS_PROGRAM).install_write_handler(0x0c0000, 0x0cffff, write16_delegate(FUNC(mcr68_state::xenophobe_control_w),this));
+
+	/* 6840 is mapped to the lower 8 bits */
+	m_maincpu->space(AS_PROGRAM).install_readwrite_handler(0x0a0000, 0x0a000f, read8_delegate(FUNC(ptm6840_device::read), &(*m_ptm)), write8_delegate(FUNC(ptm6840_device::write), &(*m_ptm)), 0x00ff);
 }
 
 


### PR DESCRIPTION
Xenophobe (Bally Midway 1987) hangs since MAME 0.200 at start with a red screen.
A M68000 "Bit Test" of address $a0003 fails now.

00A67A: btst    #$1, $a0003.l   <---- Bit Test
00A682: beq     $a7bc
00A7BC: rte


before


00A67A: btst    #$1, $a0003.l   <---- Bit Test
00A682: beq     $a7bc
00A686: bclr    #$7, $6005c.l
.
.
.


Address $a0003 is for the MC6840 PTM timing (see mcr68_map)

void mcr68_state::mcr68_map(address_map &map)
{
.
.
	map(0x0a0000, 0x0a000f).rw(m_ptm, FUNC(ptm6840_device::read), FUNC(ptm6840_device::write)).umask16(0xff00);
.
.
}


The MC6840 PTM has been changed in MAME 0.200:
https://git.redump.net/mame/commit/src/devices/machine/6840ptm.h?id=c3fb11c2c98a5c28ece6a27093a0f9def350ac64


Now Xenophobe needs like the game Blasted a correct read/write handler for the MC6840 PTM (see source change!).
"Bit Test" now working.
