### PR TITLE
Fix output pins in Dual 8 bit mode (nw)

### DIFF
--- a/src/devices/machine/6840ptm.cpp
+++ b/src/devices/machine/6840ptm.cpp
@@ -118,6 +118,7 @@ void ptm6840_device::device_start()
 	save_item(NAME(m_external_clock));
 	save_item(NAME(m_counter));
 	save_item(NAME(m_latch));
+	save_item(NAME(m_hightime));
 }
 
 
@@ -135,6 +136,7 @@ void ptm6840_device::device_reset()
 	m_status_read_since_int = 0;
 	m_irq                   = 0;
 	m_t3_scaler             = 0;
+	m_hightime              = false;
 	for (int i = 0; i < 3; i++)
 	{
 		m_counter[i] = 0xffff;
@@ -183,7 +185,7 @@ void ptm6840_device::subtract_from_counter(int counter, int count)
 			msb--;
 
 			// If MSB goes less than zero, we've expired
-			if (msb < 0)
+			if ((msb == 0 && !m_hightime) || (msb < 0 && m_hightime))
 			{
 				timeout(counter);
 				msb = (m_latch[counter] >> 8) + 1;
@@ -218,12 +220,19 @@ void ptm6840_device::subtract_from_counter(int counter, int count)
 
 	if (m_enabled[counter])
 	{
-		attotime duration = attotime::from_hz(clk) * m_counter[counter];
+		int clks = m_counter[counter];
+		if (m_control_reg[counter] & COUNT_MODE_8BIT)
+		{
+			/* In dual 8 bit mode, let the counter fire when MSB == 0 */
+			m_hightime = !(clks & 0xff00);
+			clks &= 0xff00;
+		}
+
+		attotime duration = attotime::from_hz(clk) * clks;
 		if (counter == 2)
 		{
 			duration *= m_t3_divisor;
 		}
-
 		m_timer[counter]->adjust(duration);
 	}
 }
@@ -340,7 +349,7 @@ void ptm6840_device::reload_count(int idx)
 
 	// Copy the latched value in
 	m_counter[idx] = m_latch[idx];
-
+	m_hightime = false;
 	// If reset is held, don't start counting
 	if (m_control_reg[0] & RESET_TIMERS)
 		return;
@@ -361,7 +370,10 @@ void ptm6840_device::reload_count(int idx)
 	int count = m_counter[idx];
 	if (m_control_reg[idx] & COUNT_MODE_8BIT)
 	{
-		count = ((count >> 8) + 1) * ((count & 0xff) + 1);
+		if (m_hightime)
+			count = 0xff;
+		else
+			count = ((count >> 8) + 1) * ((count & 0xff) + 1);
 	}
 	else
 	{
@@ -509,6 +521,7 @@ WRITE8_MEMBER( ptm6840_device::write )
 					{
 						m_timer[i]->enable(false);
 						m_enabled[i] = 0;
+						m_hightime = false;
 					}
 				}
 				// Releasing reset
@@ -584,9 +597,15 @@ void ptm6840_device::timeout(int idx)
 		{
 			case 0:
 			case 2:
-				m_output[idx] = m_output[idx] ^ 1;
-				LOG("**ptm6840 t%d output %d **\n", idx + 1, m_output[idx]);
-				m_out_cb[idx](m_output[idx]);
+				if (m_control_reg[idx] & COUNT_MODE_8BIT) {
+					m_hightime ^= true;
+					m_output[idx] = m_hightime;
+					m_out_cb[idx](m_output[idx]);
+				} else {
+					m_output[idx] = m_output[idx] ^ 1;
+					m_out_cb[idx](m_output[idx]);
+				}
+				LOG("%6.6f: **ptm6840 t%d output %d **\n", machine().time().as_double(), idx + 1, m_output[idx]);
 				break;
 
 			case 4:

--- a/src/devices/machine/6840ptm.h
+++ b/src/devices/machine/6840ptm.h
@@ -127,6 +127,9 @@ private:
 	uint16_t m_counter[3];
 
 	static const char *const opmode[];
+
+	// set in dual 8 bit mode to indicate Output high time cycle
+	bool m_hightime;
 };
 
 


### PR DESCRIPTION
In Dual 8 bit mode the output isn't inverted on
every TC, instead it's low until the count reaches 0xff, and
high afterwards.