### PR TITLE
pacland: sprites bugfix

### DIFF
--- a/src/mame/includes/pacland.h
+++ b/src/mame/includes/pacland.h
@@ -40,7 +40,8 @@ public:
 	tilemap_t *m_bg_tilemap;
 	tilemap_t *m_fg_tilemap;
 	bitmap_ind16 m_fg_bitmap;
-	bitmap_ind16 m_sprite_bitmap;
+	bitmap_ind16 m_sprite1_bitmap;
+	bitmap_ind16 m_sprite2_bitmap;
 	std::unique_ptr<uint32_t[]> m_transmask[3];
 	uint16_t m_scroll0;
 	uint16_t m_scroll1;

--- a/src/mame/video/pacland.cpp
+++ b/src/mame/video/pacland.cpp
@@ -382,18 +382,7 @@ uint32_t pacland_state::screen_update(screen_device &screen, bitmap_ind16 &bitma
 	/* draw sprites with regular transparency */
 	m_sprite1_bitmap.fill(0, cliprect);
 	draw_sprites(screen, m_sprite1_bitmap, cliprect, flip, 1);
-	for (int y = cliprect.min_y; y <= cliprect.max_y; y++)
-	{
-		uint16_t *src = &m_sprite1_bitmap.pix16(y);
-		uint16_t *dst = &bitmap.pix16(y);
-
-		for (int x = cliprect.min_x; x <= cliprect.max_x; x++)
-		{
-			uint16_t pix = src[x];
-			if (pix != 0)
-				dst[x] = pix;
-		}
-	}
+	copybitmap_trans(bitmap, m_sprite1_bitmap, 0, 0, 0, 0, cliprect, 0);
 
 	/* draw high priority fg tiles */
 	draw_fg(screen, bitmap, cliprect, 1);


### PR DESCRIPTION
Fixed the difference with real hardware:
- fixed: incomplete priority of sprites on fg
- fixed: sprites could not be displayed at the bottom of the screen