### PR TITLE
funybubl.cpp : Update/Cleanups

### DIFF
--- a/src/mame/drivers/funybubl.cpp
+++ b/src/mame/drivers/funybubl.cpp
@@ -58,48 +58,47 @@ Note: SW2, SW3 & SW4 not populated
 #include "speaker.h"
 
 
-WRITE8_MEMBER(funybubl_state::funybubl_vidram_bank_w)
+WRITE8_MEMBER(funybubl_state::vidram_bank_w)
 {
-	membank("bank1")->set_entry(data & 1);
+	m_vrambank->set_bank(data & 1);
 }
 
-WRITE8_MEMBER(funybubl_state::funybubl_cpurombank_w)
+WRITE8_MEMBER(funybubl_state::cpurombank_w)
 {
-	membank("bank2")->set_entry(data & 0x3f);   // should we add a check that (data&0x3f) < #banks?
+	m_mainbank->set_entry(data & 0x3f);   // should we add a check that (data&0x3f) < #banks?
 }
 
-
-WRITE8_MEMBER(funybubl_state::funybubl_soundcommand_w)
+WRITE8_MEMBER(funybubl_state::oki_bank_w)
 {
-	m_soundlatch->write(space, 0, data);
-	m_audiocpu->set_input_line(0, HOLD_LINE);
-}
-
-WRITE8_MEMBER(funybubl_state::funybubl_oki_bank_sw)
-{
-	m_oki->set_rom_bank(data & 1);
+	m_okibank->set_entry(data & 1);
 }
 
 
 void funybubl_state::funybubl_map(address_map &map)
 {
 	map(0x0000, 0x7fff).rom();
-	map(0x8000, 0xbfff).bankr("bank2"); // banked port 1?
-	map(0xc400, 0xcfff).ram().w(FUNC(funybubl_state::funybubl_paldatawrite)).share("paletteram"); // palette
-	map(0xd000, 0xdfff).bankrw("bank1"); // banked port 0?
+	map(0x8000, 0xbfff).bankr("mainbank"); // banked port 1?
+	map(0xc400, 0xcfff).ram().w(m_palette, FUNC(palette_device::write8)).share("palette"); // palette
+	map(0xd000, 0xdfff).m(m_vrambank, FUNC(address_map_bank_device::amap8)); // banked port 0?
 	map(0xe000, 0xffff).ram();
 }
 
 void funybubl_state::io_map(address_map &map)
 {
 	map.global_mask(0xff);
-	map(0x00, 0x00).portr("SYSTEM").w(FUNC(funybubl_state::funybubl_vidram_bank_w));    // vidram bank
-	map(0x01, 0x01).portr("P1").w(FUNC(funybubl_state::funybubl_cpurombank_w));     // rom bank?
+	map(0x00, 0x00).portr("SYSTEM").w(FUNC(funybubl_state::vidram_bank_w));    // vidram bank
+	map(0x01, 0x01).portr("P1").w(FUNC(funybubl_state::cpurombank_w));     // rom bank?
 	map(0x02, 0x02).portr("P2");
-	map(0x03, 0x03).portr("DSW").w(FUNC(funybubl_state::funybubl_soundcommand_w));
+	map(0x03, 0x03).portr("DSW").w(m_soundlatch, FUNC(generic_latch_8_device::write));
 	map(0x06, 0x06).nopr();     /* Nothing is done with the data read */
 	map(0x06, 0x06).nopw();        /* Written directly after IO port 0 */
 	map(0x07, 0x07).nopw();        /* Reset something on startup - Sound CPU ?? */
+}
+
+void funybubl_state::vrambank_map(address_map &map)
+{
+	map(0x0000, 0x0fff).ram().w(FUNC(funybubl_state::tilemap_w)).share("tilemapram");
+	map(0x1000, 0x1fff).ram().share("spriteram");
 }
 
 /* Sound CPU */
@@ -108,11 +107,16 @@ void funybubl_state::sound_map(address_map &map)
 {
 	map(0x0000, 0x7fff).rom();
 	map(0x8000, 0x87ff).ram();
-	map(0x9000, 0x9000).w(FUNC(funybubl_state::funybubl_oki_bank_sw));
+	map(0x9000, 0x9000).w(FUNC(funybubl_state::oki_bank_w));
 	map(0x9800, 0x9800).rw(m_oki, FUNC(okim6295_device::read), FUNC(okim6295_device::write));
 	map(0xa000, 0xa000).r(m_soundlatch, FUNC(generic_latch_8_device::read));
 }
 
+void funybubl_state::oki_map(address_map &map)
+{
+	map(0x00000, 0x1ffff).rom();
+	map(0x20000, 0x3ffff).bankr("okibank");
+}
 
 
 static INPUT_PORTS_START( funybubl )
@@ -174,48 +178,42 @@ INPUT_PORTS_END
 
 
 
-static const gfx_layout tiles16x16x8_1_layout =
+static const gfx_layout layout_8x8x8 =
 {
 	8,8,
 	RGN_FRAC(1,8),
 	8,
-	{ RGN_FRAC(3,8),RGN_FRAC(2,8),RGN_FRAC(1,8),RGN_FRAC(0,8),RGN_FRAC(7,8),RGN_FRAC(6,8),RGN_FRAC(5,8), RGN_FRAC(4,8) },
-	{ 0, 1, 2,  3,  4, 5, 6, 7 },
-	{ 0*8, 1*8, 2*8, 3*8, 4*8, 5*8, 6*8, 7*8 },
+	{ RGN_FRAC(3,8), RGN_FRAC(2,8), RGN_FRAC(1,8), RGN_FRAC(0,8), RGN_FRAC(7,8), RGN_FRAC(6,8), RGN_FRAC(5,8), RGN_FRAC(4,8) },
+	{ STEP8(0,1) },
+	{ STEP8(0,8) },
 	8*8
 };
 
-static const gfx_layout tiles16x16x8_2_layout =
+static const gfx_layout layout_16x16x8 =
 {
 	16,16,
 	RGN_FRAC(1,4),
 	8,
 	{ RGN_FRAC(3,4)+4,RGN_FRAC(3,4)+0, RGN_FRAC(2,4)+4, RGN_FRAC(2,4)+0, RGN_FRAC(1,4)+4, RGN_FRAC(1,4)+0, RGN_FRAC(0,4)+4, RGN_FRAC(0,4)+0  },
-	{ 0, 1,2,3, 8,9,10,11, 256,257,258,259, 264,265,266,267},
-	{ 0*16, 1*16, 2*16, 3*16, 4*16, 5*16, 6*16, 7*16,
-		8*16, 9*16,10*16,11*16,12*16,13*16,14*16,15*16 },
+	{ STEP4(0,1), STEP4(4*2,1), STEP4(16*4*2*2,1), STEP4(16*4*2*2+4*2,1) },
+	{ STEP16(0,4*2*2) },
 	32*16
 };
 
 
 static GFXDECODE_START( gfx_funybubl )
-	GFXDECODE_ENTRY( "gfx1", 0, tiles16x16x8_1_layout, 0, 16 )
-	GFXDECODE_ENTRY( "gfx2", 0, tiles16x16x8_2_layout, 0, 16 )
+	GFXDECODE_ENTRY( "gfx1", 0, layout_8x8x8,   0x100, 2 )
+	GFXDECODE_ENTRY( "gfx2", 0, layout_16x16x8, 0x000, 1 )
 GFXDECODE_END
 
 
 
 void funybubl_state::machine_start()
 {
-	uint8_t *ROM = memregion("maincpu")->base();
+	m_mainbank->configure_entries(0, 0x10, memregion("maincpu")->base(), 0x4000);
+	m_okibank->configure_entries(0, 2, memregion("oki")->base() + 0x20000, 0x20000);
 
-
-	save_item(NAME(m_banked_vram));
-
-	membank("bank1")->configure_entries(0, 2, &m_banked_vram[0x0000], 0x1000);
-	membank("bank2")->configure_entries(0, 0x10, ROM, 0x4000);
-
-	membank("bank1")->set_entry(0);
+	m_vrambank->set_bank(0);
 }
 
 
@@ -230,6 +228,7 @@ MACHINE_CONFIG_START(funybubl_state::funybubl)
 	MCFG_DEVICE_ADD("audiocpu", Z80,8000000/2)      /* 4 MHz?? */
 	MCFG_DEVICE_PROGRAM_MAP(sound_map)
 
+	ADDRESS_MAP_BANK(config, m_vrambank).set_map(&funybubl_state::vrambank_map).set_options(ENDIANNESS_LITTLE, 8, 13, 0x1000);
 
 	/* video hardware */
 	MCFG_SCREEN_ADD("screen", RASTER)
@@ -238,19 +237,21 @@ MACHINE_CONFIG_START(funybubl_state::funybubl)
 	MCFG_SCREEN_SIZE(512, 256)
 	MCFG_SCREEN_VISIBLE_AREA(12*8, 512-12*8-1, 16, 256-16-1)
 //  MCFG_SCREEN_VISIBLE_AREA(0*8, 512-1, 0, 256-1)
-	MCFG_SCREEN_UPDATE_DRIVER(funybubl_state, screen_update_funybubl)
+	MCFG_SCREEN_UPDATE_DRIVER(funybubl_state, screen_update)
 	MCFG_SCREEN_PALETTE("palette")
 
 	MCFG_DEVICE_ADD("gfxdecode", GFXDECODE, "palette", gfx_funybubl)
-	MCFG_PALETTE_ADD("palette", 0x400)
-
+	MCFG_PALETTE_ADD("palette", 0xc00/4)
+	MCFG_PALETTE_FORMAT_CLASS(4, funybubl_state, funybubl_R6B6G6)
 
 	/* sound hardware */
 	SPEAKER(config, "mono").front_center();
 
 	MCFG_GENERIC_LATCH_8_ADD("soundlatch")
+	MCFG_GENERIC_LATCH_DATA_PENDING_CB(INPUTLINE("audiocpu", 0))
 
-	MCFG_DEVICE_ADD("oki", OKIM6295, 1056000, okim6295_device::PIN7_HIGH) // clock frequency & pin 7 not verified
+	MCFG_DEVICE_ADD("oki", OKIM6295, 8000000/8, okim6295_device::PIN7_HIGH) // clock frequency & pin 7 not verified
+	MCFG_DEVICE_ADDRESS_MAP(0, oki_map)
 	MCFG_SOUND_ROUTE(ALL_OUTPUTS, "mono", 1.0)
 MACHINE_CONFIG_END
 
@@ -281,9 +282,7 @@ ROM_START( funybubl )
 
 	ROM_REGION( 0x80000, "oki", 0 )
 	ROM_LOAD( "b.su12", 0x00000,  0x20000, CRC(a2d780f4) SHA1(bebba3db21ab9ddde8c6f19db3b67c869df582eb) ) /* Same as below, different label */
-	ROM_RELOAD(         0x40000,  0x20000 )
-	ROM_LOAD( "c.su13", 0x20000,  0x20000, CRC(1f7e9269) SHA1(5c16b49a4e94aec7606d088c2d45a77842ab565b) ) /* Same as below, different label */
-	ROM_CONTINUE(       0x60000,  0x20000 )
+	ROM_LOAD( "c.su13", 0x20000,  0x40000, CRC(1f7e9269) SHA1(5c16b49a4e94aec7606d088c2d45a77842ab565b) ) /* Same as below, different label */
 ROM_END
 
 ROM_START( funybublc )
@@ -311,9 +310,7 @@ ROM_START( funybublc )
 
 	ROM_REGION( 0x80000, "oki", 0 )
 	ROM_LOAD( "3.su12", 0x00000,  0x20000, CRC(a2d780f4) SHA1(bebba3db21ab9ddde8c6f19db3b67c869df582eb) )
-	ROM_RELOAD(         0x40000,  0x20000 )
-	ROM_LOAD( "4.su13", 0x20000,  0x20000, CRC(1f7e9269) SHA1(5c16b49a4e94aec7606d088c2d45a77842ab565b) )
-	ROM_CONTINUE(       0x60000,  0x20000 )
+	ROM_LOAD( "4.su13", 0x20000,  0x40000, CRC(1f7e9269) SHA1(5c16b49a4e94aec7606d088c2d45a77842ab565b) )
 ROM_END
 
 

--- a/src/mame/includes/funybubl.h
+++ b/src/mame/includes/funybubl.h
@@ -1,6 +1,7 @@
 // license:BSD-3-Clause
 // copyright-holders:David Haywood
 
+#include "machine/bankdev.h"
 #include "machine/gen_latch.h"
 #include "sound/okim6295.h"
 #include "emupal.h"
@@ -8,21 +9,32 @@
 class funybubl_state : public driver_device
 {
 public:
-	funybubl_state(const machine_config &mconfig, device_type type, const char *tag)
-		: driver_device(mconfig, type, tag),
-		m_paletteram(*this, "paletteram"),
+	funybubl_state(const machine_config &mconfig, device_type type, const char *tag) :
+		driver_device(mconfig, type, tag),
+		m_tilemapram(*this, "tilemapram"),
+		m_spriteram(*this, "spriteram"),
+		m_mainbank(*this, "mainbank"),
+		m_okibank(*this, "okibank"),
 		m_maincpu(*this, "maincpu"),
 		m_audiocpu(*this, "audiocpu"),
 		m_oki(*this, "oki"),
 		m_gfxdecode(*this, "gfxdecode"),
 		m_palette(*this, "palette"),
-		m_soundlatch(*this, "soundlatch") { }
+		m_soundlatch(*this, "soundlatch"),
+		m_vrambank(*this, "vrambank") { }
 
 	void funybubl(machine_config &config);
 
 private:
 	/* memory pointers */
-	required_shared_ptr<uint8_t> m_paletteram;
+	required_shared_ptr<uint8_t> m_tilemapram;
+	required_shared_ptr<uint8_t> m_spriteram;
+
+	required_memory_bank m_mainbank;
+	required_memory_bank m_okibank;
+
+	/* video-related */
+	tilemap_t     *m_tilemap;
 
 	/* devices */
 	required_device<cpu_device> m_maincpu;
@@ -31,19 +43,24 @@ private:
 	required_device<gfxdecode_device> m_gfxdecode;
 	required_device<palette_device> m_palette;
 	required_device<generic_latch_8_device> m_soundlatch;
+	required_device<address_map_bank_device> m_vrambank;
 
 	/* memory */
-	uint8_t      m_banked_vram[0x2000];
-	DECLARE_WRITE8_MEMBER(funybubl_vidram_bank_w);
-	DECLARE_WRITE8_MEMBER(funybubl_cpurombank_w);
-	DECLARE_WRITE8_MEMBER(funybubl_soundcommand_w);
-	DECLARE_WRITE8_MEMBER(funybubl_paldatawrite);
-	DECLARE_WRITE8_MEMBER(funybubl_oki_bank_sw);
+	DECLARE_WRITE8_MEMBER(vidram_bank_w);
+	DECLARE_WRITE8_MEMBER(cpurombank_w);
+	DECLARE_WRITE8_MEMBER(oki_bank_w);
+
+	DECLARE_PALETTE_DECODER(funybubl_R6B6G6);
+	DECLARE_WRITE8_MEMBER(tilemap_w);
+	TILE_GET_INFO_MEMBER(get_tile_info);
+
 	virtual void machine_start() override;
 	virtual void video_start() override;
-	uint32_t screen_update_funybubl(screen_device &screen, bitmap_ind16 &bitmap, const rectangle &cliprect);
+	uint32_t screen_update(screen_device &screen, bitmap_ind16 &bitmap, const rectangle &cliprect);
 	void draw_sprites( bitmap_ind16 &bitmap, const rectangle &cliprect );
 	void funybubl_map(address_map &map);
 	void io_map(address_map &map);
+	void oki_map(address_map &map);
 	void sound_map(address_map &map);
+	void vrambank_map(address_map &map);
 };

--- a/src/mame/video/funybubl.cpp
+++ b/src/mame/video/funybubl.cpp
@@ -10,31 +10,35 @@ todo - convert to tilemap
 #include "emu.h"
 #include "includes/funybubl.h"
 
-
-WRITE8_MEMBER(funybubl_state::funybubl_paldatawrite)
+PALETTE_DECODER_MEMBER(funybubl_state, funybubl_R6B6G6)
 {
-	int colchanged ;
-	uint32_t coldat;
-
-	m_paletteram[offset] = data;
-	colchanged = offset >> 2;
-	coldat = m_paletteram[colchanged * 4] | (m_paletteram[colchanged * 4 + 1] << 8) |
-			(m_paletteram[colchanged * 4 + 2] << 16) | (m_paletteram[colchanged * 4 + 3] << 24);
-
-	m_palette->set_pen_color(colchanged, pal6bit(coldat >> 12), pal6bit(coldat >> 0), pal6bit(coldat >> 6));
+	return rgb_t(pal6bit(raw >> 12), pal6bit(raw >>  0), pal6bit(raw >>  6));
 }
 
+WRITE8_MEMBER(funybubl_state::tilemap_w)
+{
+	COMBINE_DATA(&m_tilemapram[offset]);
+	m_tilemap->mark_tile_dirty(offset>>1);
+}
+
+TILE_GET_INFO_MEMBER(funybubl_state::get_tile_info)
+{
+	uint16_t const code = m_tilemapram[tile_index << 1] | (m_tilemapram[(tile_index << 1) | 1] << 8);
+	SET_TILE_INFO_MEMBER(0, code & 0x7fff, BIT(code, 15), 0);
+}
 
 void funybubl_state::video_start()
 {
+	m_tilemap = &machine().tilemap().create(*m_gfxdecode, tilemap_get_info_delegate(FUNC(funybubl_state::get_tile_info),this),TILEMAP_SCAN_ROWS, 8, 8, 64, 32);
+	m_tilemap->set_transparent_pen(0);
 }
 
 void funybubl_state::draw_sprites( bitmap_ind16 &bitmap, const rectangle &cliprect )
 {
-	uint8_t *source = &m_banked_vram[0x2000 - 0x20];
-	uint8_t *finish = source - 0x1000;
+	uint8_t *source = &m_spriteram[0x1000 - 0x20];
+	uint8_t *finish = m_spriteram;
 
-	while (source > finish)
+	while (source >= finish)
 	{
 		int xpos, ypos, tile;
 
@@ -73,25 +77,11 @@ void funybubl_state::draw_sprites( bitmap_ind16 &bitmap, const rectangle &clipre
 }
 
 
-uint32_t funybubl_state::screen_update_funybubl(screen_device &screen, bitmap_ind16 &bitmap, const rectangle &cliprect)
+uint32_t funybubl_state::screen_update(screen_device &screen, bitmap_ind16 &bitmap, const rectangle &cliprect)
 {
-	int x, y, offs;
-	offs = 0;
-
 	bitmap.fill(m_palette->black_pen(), cliprect);
 
-	/* tilemap .. convert it .. banking makes it slightly more annoying but still easy */
-	for (y = 0; y < 32; y++)
-	{
-		for (x = 0; x< 64; x++)
-		{
-			int data;
-
-			data = m_banked_vram[offs] | (m_banked_vram[offs + 1] << 8);
-			m_gfxdecode->gfx(0)->transpen(bitmap,cliprect, data & 0x7fff, (data & 0x8000) ? 2 : 1, 0, 0, x*8, y*8, 0);
-			offs += 2;
-		}
-	}
+	m_tilemap->draw(screen, bitmap, cliprect, 0, 0);
 
 	draw_sprites(bitmap, cliprect);
 
@@ -103,7 +93,7 @@ uint32_t funybubl_state::screen_update_funybubl(screen_device &screen, bitmap_in
 		fp = fopen("funnybubsprites", "w+b");
 		if (fp)
 		{
-			fwrite(&m_banked_vram[0x1000], 0x1000, 1, fp);
+			fwrite(&m_spriteram[0], 0x1000, 1, fp);
 			fclose(fp);
 		}
 	}


### PR DESCRIPTION
Cleanup naming, Convert tilemap, Add address_map_bank_device for banked vram, Cleanup OKI banking, Fix OKI clock related to On-PCB XTAL, Add palette decoder member for palette, Cleanup/fix naming, Fix palette entry, Reduce runtime tag lookups