### PR TITLE
seta001 - don't draw sprite 0

### DIFF
--- a/src/mame/video/seta001.cpp
+++ b/src/mame/video/seta001.cpp
@@ -341,8 +341,10 @@ void seta001_device::draw_foreground( screen_device &screen, bitmap_ind16 &bitma
 
 	int const max_y = screen.height();
 
-	/* Draw up to 512 sprites, mjyuugi has glitches if you draw them all.. */
-	for (i = m_spritelimit; i >= 0; i--)
+	/* Draw up to 512 sprites, mjyuugi has glitches if you draw them all.. 
+	   jjsquawk has an invalid tile if you draw sprite 0, other games seem to leave it unused, has another meaning?
+	*/
+	for (i = m_spritelimit; i > 0; i--)
 	{
 		int code, color, sx, sy, flipx, flipy;
 


### PR DESCRIPTION
this fixes the bad sprite in the bottom left of jjsquawk

this probably needs a regression run of everything using the device to make sure nothing goes missing.

it also doesn't address the garbage sprite in the corner of chukatai, or the flickering garbage in jpopnics (although that isn't true original hardware, but bootleg, so could differ)

there are still some hacks in how things are handled in this source, so I'd consider this fix to be speculative.