### PR TITLE
fix cam900 damage in fuukifg2 / fg3 from May

### DIFF
--- a/src/mame/video/fuukifg2.cpp
+++ b/src/mame/video/fuukifg2.cpp
@@ -129,7 +129,7 @@ void fuuki16_state::video_start()
 /* Wrapper to handle bg and bg2 ttogether */
 void fuuki16_state::draw_layer( screen_device &screen, bitmap_ind16 &bitmap, const rectangle &cliprect, int i, int flag, int pri )
 {
-	int buffer = (m_vregs[0x1e / 2] & 0x40);
+	int buffer = (m_vregs[0x1e / 2] & 0x40) >> 6;
 
 	switch( i )
 	{

--- a/src/mame/video/fuukifg3.cpp
+++ b/src/mame/video/fuukifg3.cpp
@@ -123,7 +123,7 @@ void fuuki32_state::video_start()
 /* Wrapper to handle bg and bg2 ttogether */
 void fuuki32_state::draw_layer( screen_device &screen, bitmap_ind16 &bitmap, const rectangle &cliprect, int i, int flag, int pri )
 {
-	int buffer = ((m_vregs[0x1e / 4] & 0x0000ffff) & 0x40);
+	int buffer = ((m_vregs[0x1e / 4] & 0x0000ffff) & 0x40) >> 6;
 
 	switch( i )
 	{


### PR DESCRIPTION
prevents MAME from crashing trying to access tilemap[0x42] instead of tilemap[0x3]

