### PR TITLE
powervr2.cpp: implement opaque polygons

### DIFF
--- a/src/mame/video/powervr2.h
+++ b/src/mame/video/powervr2.h
@@ -112,16 +112,48 @@ public:
 		texinfo ti;
 	};
 
-	struct receiveddata {
-		vert verts[65536];
-		strip strips[65536];
+	static const unsigned MAX_VERTS = 65536;
+	static const unsigned MAX_STRIPS = 65536;
 
-		int verts_size, strips_size;
+	/*
+	 * There are five polygon lists:
+	 *
+	 * Opaque
+	 * Punch-through polygon
+	 * Opaque/punch-through modifier volume
+	 * Translucent
+	 * Translucent modifier volume
+	 *
+	 * They are rendered in that order.  List indices are are three bits, so
+	 * technically there are 8 polygon lists, but only the first 5 are valid.
+	 */
+	enum {
+		DISPLAY_LIST_OPAQUE,
+		DISPLAY_LIST_OPAQUE_MOD,
+		DISPLAY_LIST_TRANS,
+		DISPLAY_LIST_TRANS_MOD,
+		DISPLAY_LIST_PUNCH_THROUGH,
+		DISPLAY_LIST_LAST,
+
+		DISPLAY_LIST_COUNT,
+
+		DISPLAY_LIST_NONE = -1
+	};
+
+	struct poly_group {
+		strip strips[MAX_STRIPS];
+		int strips_size;
+	};
+
+	struct receiveddata {
+		vert verts[MAX_VERTS];
+		struct poly_group groups[DISPLAY_LIST_COUNT];
 		uint32_t ispbase;
 		uint32_t fbwsof1;
 		uint32_t fbwsof2;
 		int busy;
 		int valid;
+		int verts_size;
 	};
 
 	enum {
@@ -500,6 +532,7 @@ private:
 
 	void sort_vertices(const vert *v, int *i0, int *i1, int *i2);
 	void render_tri(bitmap_rgb32 &bitmap, texinfo *ti, const vert *v);
+	void render_group_to_accumulation_buffer(bitmap_rgb32 &bitmap, const rectangle &cliprect, int group_no);
 	void render_to_accumulation_buffer(bitmap_rgb32 &bitmap, const rectangle &cliprect);
 	void pvr_accumulationbuffer_to_framebuffer(address_space &space, int x, int y);
 	void pvr_drawframebuffer(bitmap_rgb32 &bitmap,const rectangle &cliprect);

--- a/src/mame/video/powervr2.h
+++ b/src/mame/video/powervr2.h
@@ -501,7 +501,7 @@ private:
 	uint32_t tex_r_default(texinfo *t, float x, float y);
 	void tex_get_info(texinfo *t);
 
-	template <pix_sample_fn sample_fn>
+	template <pix_sample_fn sample_fn, int group_no>
 		inline void render_hline(bitmap_rgb32 &bitmap, texinfo *ti,
 									int y, float xl, float xr,
 									float ul, float ur, float vl, float vr,
@@ -509,7 +509,7 @@ private:
 									float const bl[4], float const br[4],
 									float const offl[4], float const offr[4]);
 
-	template <pix_sample_fn sample_fn>
+	template <pix_sample_fn sample_fn, int group_no>
 		inline void render_span(bitmap_rgb32 &bitmap, texinfo *ti,
 								float y0, float y1,
 								float xl, float xr,
@@ -525,14 +525,18 @@ private:
 								float const dbldy[4], float const dbrdy[4],
 								float const doldy[4], float const dordy[4]);
 
-	template <pix_sample_fn sample_fn>
+	template <pix_sample_fn sample_fn, int group_no>
 		inline void render_tri_sorted(bitmap_rgb32 &bitmap, texinfo *ti,
 										const vert *v0,
 										const vert *v1, const vert *v2);
 
+	template <int group_no>
+		void render_tri(bitmap_rgb32 &bitmap, texinfo *ti, const vert *v);
+
+	template <int group_no>
+		void render_group_to_accumulation_buffer(bitmap_rgb32 &bitmap, const rectangle &cliprect);
+
 	void sort_vertices(const vert *v, int *i0, int *i1, int *i2);
-	void render_tri(bitmap_rgb32 &bitmap, texinfo *ti, const vert *v);
-	void render_group_to_accumulation_buffer(bitmap_rgb32 &bitmap, const rectangle &cliprect, int group_no);
 	void render_to_accumulation_buffer(bitmap_rgb32 &bitmap, const rectangle &cliprect);
 	void pvr_accumulationbuffer_to_framebuffer(address_space &space, int x, int y);
 	void pvr_drawframebuffer(bitmap_rgb32 &bitmap,const rectangle &cliprect);


### PR DESCRIPTION
PowerVR 2 treats opaque polygons as a separate class of polygon from transparent polygons.  Pixels rasterized from opaque polygons are always completely opaque regardless of what their alpha values are.

This PR resolves missing graphics in games which render opaque polygons with non-opaque alpha values.

There's also a third class of polygon called punch-through, which supports transparency but not blending (so every pixel is either entirely opaque or entirely transparent).  Those haven't been implemented, and are still being treated as if they were transparent polygons.

Before:
![0001](https://user-images.githubusercontent.com/3129682/45261895-41de1900-b3bf-11e8-8c83-a4980011fe67.png)
After:
![0000](https://user-images.githubusercontent.com/3129682/45261896-4a365400-b3bf-11e8-9576-33988b1caba5.png)

Before:
![0007](https://user-images.githubusercontent.com/3129682/45261897-528e8f00-b3bf-11e8-95be-13946af59831.png)
After:
![0001](https://user-images.githubusercontent.com/3129682/45261899-5d492400-b3bf-11e8-83fc-90c3a3817732.png)
