### PR TITLE
pacland.cpp: Changed to approach real hardware behavior

### DIFF
--- a/src/mame/includes/pacland.h
+++ b/src/mame/includes/pacland.h
@@ -40,8 +40,7 @@ public:
 	tilemap_t *m_bg_tilemap;
 	tilemap_t *m_fg_tilemap;
 	bitmap_ind16 m_fg_bitmap;
-	bitmap_ind16 m_sprite1_bitmap;
-	bitmap_ind16 m_sprite2_bitmap;
+	bitmap_ind16 m_sprite_bitmap;
 	std::unique_ptr<uint32_t[]> m_transmask[3];
 	uint16_t m_scroll0;
 	uint16_t m_scroll1;


### PR DESCRIPTION
Currently, when drawing the topmost-sprites, only draw non-transparent pixels of fg, but originally it is correct to draw the whole screen.
However, it is necessary to keep sprite-sprite priorities intact.

I think that approached the real hardware behavior.
Also, I was able to reduce unnecessary bitmap memory area.