### PR TITLE
tzx_cass.cpp: 1ms pause is always required

### DIFF
--- a/src/lib/formats/tzx_cas.cpp
+++ b/src/lib/formats/tzx_cas.cpp
@@ -282,13 +282,15 @@ static int tzx_cas_handle_block( int16_t **buffer, const uint8_t *bytes, int pau
 		}
 	}
 	/* pause */
-	if (pause > 0)
-	{
-		int start_pause_samples = millisec_to_samplecount(1);
-		int rest_pause_samples = millisec_to_samplecount(pause - 1);
+	int start_pause_samples = millisec_to_samplecount(1);
 
-		tzx_output_wave(buffer, start_pause_samples);
-		size += start_pause_samples;
+	tzx_output_wave(buffer, start_pause_samples);
+	size += start_pause_samples;
+	
+	if (pause > 0)
+	{		
+		int rest_pause_samples = millisec_to_samplecount(pause - 1);
+		
 		wave_data = WAVE_LOW;
 		tzx_output_wave(buffer, rest_pause_samples);
 		size += rest_pause_samples;


### PR DESCRIPTION
Not only when pause from block is greater than zero .
Otherwise the last pulse is not terminated properly in some cases.