### PR TITLE
typo fixes to a couple alt_title lines

### DIFF
--- a/hash/nes.xml
+++ b/hash/nes.xml
@@ -6301,7 +6301,7 @@
 		<publisher>Vic Tokai</publisher>
 		<info name="serial" value="VIC-CF"/>
 		<info name="release" value="19870730"/>
-		<info name="alt_title" value="チェスター・フィールド  箱・説明書無し"/>
+		<info name="alt_title" value="チェスター・フィールド 暗黒神への挑戦"/>
 		<part name="cart" interface="nes_cart">
 			<feature name="slot" value="uxrom" />
 			<feature name="pcb" value="HVC-UNROM" />
@@ -6758,7 +6758,7 @@
 		<publisher>Toho</publisher>
 		<info name="serial" value="THF-TU"/>
 		<info name="release" value="19870314"/>
-		<info name="alt_title" value="タッチ ミステリー・オブトライアングル"/>
+		<info name="alt_title" value="タッチ ミステリー・オブ・トライアングル"/>
 		<part name="cart" interface="nes_cart">
 			<feature name="slot" value="uxrom" />
 			<feature name="pcb" value="HVC-UNROM" />


### PR DESCRIPTION
"chestfld" alt_title must have been incorrectly copied from a sales listing as the subtitle read "without box or instructions".  Replaced with correct subtitle.
Added an extra dot to "touch" subtitle to match what is printed on the instruction manual.  The box cover only shows one dot but this is due to the line break after the word "of".  In Japanese orthography the dots are certainly optional but mixing the dots and no-dots in the same phrase looks awkward.