### PR TITLE
Fix canonical command line option.

### DIFF
--- a/src/emu/emuopts.cpp
+++ b/src/emu/emuopts.cpp
@@ -389,9 +389,9 @@ namespace
 		if (!same_name)
 			result.push_back(image.brief_instance_name());
 
-		if (strcmp(image.device_typename(image.image_type()), image.instance_name().c_str()) == 0)
+		if( image.instance_name() != image.cannonical_instance_name() )
 		{
-			result.push_back(image.instance_name() + "1");
+			result.push_back(image.cannonical_instance_name());
 			if (!same_name)
 				result.push_back(image.brief_instance_name() + "1");
 		}


### PR DESCRIPTION
I found a bug in the handling of command line media options.

When adding a second serial port (null_modem) to the CoCo drivers, the user interface (and -listmedia) reported the media options as bitbanger1 and bitbanger2. This is correct.

But the command line would not recognize the option bitbanger1. The switches exposed were bitbanger and bitbanger2. This seemed to be an error.

I found the problem in emuopts.cpp, get_full_option_names(). It was adding the canonical name for the first option only if the image_type() matched the instance_name(). 

In the case of a cartridge port, this would compare "cartridge" with "cartridge". It would then construct the canonical name "cartridge1" and make it available to the command line.

In the case of serial ports the function compared "bitbanger" to "serial". And it would not add "bitbanger1" to the command line option.

I changed the function to test the canonical name to the non-canonical name. If they are the same (for example cartridge2) it will not add a redundant name to the command line options.

But if they are not the same (for example: "cartridge") it will use the supplied canonical name for the command line option.
