### PR TITLE
mc6845.cpp: Reset line counter only when VTotal is zero

### DIFF
--- a/src/devices/video/mc6845.cpp
+++ b/src/devices/video/mc6845.cpp
@@ -582,7 +582,7 @@ void mc6845_device::recompute_parameters(bool postload)
 		m_hsync_off_pos = hsync_off_pos;
 		m_vsync_on_pos = vsync_on_pos;
 		m_vsync_off_pos = vsync_off_pos;
-		if (!postload) // set m_line_counter to 0 on normal operation, but not on postload
+		if ((m_vert_char_total == 0) && (!postload)) // Do not set m_line_counter to 0 on postload
 			m_line_counter = 0;
 	}
 }


### PR DESCRIPTION
Fixes MameTesters #06854 and #06997