### PR TITLE
General CoCo Cartridge Fixes

### DIFF
--- a/src/devices/bus/coco/coco_pak.cpp
+++ b/src/devices/bus/coco/coco_pak.cpp
@@ -199,7 +199,7 @@ uint8_t *coco_pak_banked_device::get_cart_base()
 
 uint32_t coco_pak_banked_device::get_cart_size()
 {
-	return 0x4000;
+	return 0x20000;
 }
 
 //-------------------------------------------------

--- a/src/mame/machine/6883sam.cpp
+++ b/src/mame/machine/6883sam.cpp
@@ -156,6 +156,9 @@ void sam6883_device::configure_bank(int bank, uint8_t *memory, uint32_t memory_s
 	/* if we're configuring a bank that never changes, update it now */
 	switch(bank)
 	{
+		case 3:
+			m_space_C000.point(m_banks[3], m_banks[3].m_memory_offset);
+			break;
 		case 4:
 			m_space_FF00.point(m_banks[4], 0x0000);
 			break;

--- a/src/mame/machine/coco_vhd.cpp
+++ b/src/mame/machine/coco_vhd.cpp
@@ -48,7 +48,7 @@
     CONSTANTS
 ***************************************************************************/
 
-#define VERBOSE 1
+#define VERBOSE 0
 
 #define VHDSTATUS_OK                    0x00
 #define VHDSTATUS_NO_VHD_ATTACHED       0x02

--- a/src/mame/video/gime.cpp
+++ b/src/mame/video/gime.cpp
@@ -86,6 +86,7 @@
 
 
 
+
 //**************************************************************************
 //  CONSTANTS
 //**************************************************************************
@@ -97,6 +98,7 @@
 #define LOG_INT_MASKING         0
 #define LOG_GIME                0
 #define LOG_TIMER               0
+#define LOG_PALETTE             0
 
 
 
@@ -552,11 +554,14 @@ void gime_device::update_memory(int bank)
 		// we're in ROM
 		static const uint8_t rom_map[4][4] =
 		{
-			{ 0, 1, 6, 7 },
-			{ 0, 1, 6, 7 },
+			{ 0, 1, 4, 5 },
+			{ 0, 1, 4, 5 },
 			{ 0, 1, 2, 3 },
-			{ 4, 5, 6, 7 }
+			{ 6, 7, 4, 5 }
 		};
+
+		// Pin ROM page to MMU slot
+		block = (block & 0xfc) | (bank & 0x03);
 
 		// look up the block in the ROM map
 		block = rom_map[m_gime_registers[0] & 3][(block & 0x3F) - 0x3C];
@@ -1004,6 +1009,10 @@ inline void gime_device::write_mmu_register(offs_t offset, uint8_t data)
 inline void gime_device::write_palette_register(offs_t offset, uint8_t data)
 {
 	offset &= 0x0F;
+
+	// perform logging
+	if (LOG_PALETTE)
+		logerror("%s: CoCo3 Palette: $%04x <== $%02x\n", describe_context(), offset + 0xffB0, data);
 
 	/* has this entry changed? */
 	if (m_palette_rotated[m_palette_rotated_position][offset] != data)


### PR DESCRIPTION
This fixes Zumwalt bank switching implemented in cartridges when used with all the CoCos.
This fixes the 32k external cartridge ROM mode on the CoCo 3. (Issue #2746)
Software lists are not broken, but they are also not required. If you map in the right hardware with the right ROM it will work.