### PR TITLE
mpatrol: Improved graphics problems

### DIFF
--- a/src/mame/includes/m52.h
+++ b/src/mame/includes/m52.h
@@ -50,6 +50,7 @@ private:
 	DECLARE_PALETTE_INIT(m52);
 	uint32_t screen_update_m52(screen_device &screen, bitmap_ind16 &bitmap, const rectangle &cliprect);
 	void draw_background(bitmap_ind16 &bitmap, const rectangle &cliprect, int xpos, int ypos, int image);
+	void draw_sprites(bitmap_ind16 &bitmap, const rectangle &cliprect, int initoffs);
 	required_device<cpu_device> m_maincpu;
 	required_device<gfxdecode_device> m_gfxdecode;
 	required_device<screen_device> m_screen;


### PR DESCRIPTION
- Sprite priority is incorrect.
- Position of the background (distant mountains, hills, and cityscape) is different from the real hardware.
- Cross-hatch test pattern is incorrect.
- Flip screen is incorrect.

Title
![title](http://i.imgur.com/l1Z32tb.png)

Sprite
![sprite_a](http://i.imgur.com/TIh0KCL.png)
![sprite_b](http://i.imgur.com/5Qk8LlA.png)

Cross-hatch
![crosshatch](http://i.imgur.com/fGDw6kX.png)

Flip screen
![flip](http://i.imgur.com/Tti5BsU.png)

Real hardware
![real_title](http://i.imgur.com/o2cbB6Y.jpg)
http://youtu.be/F3_q-AN4AQM
