### PR TITLE
Drews Revenge set 2 is a clone

### DIFF
--- a/src/mame/drivers/norautp.cpp
+++ b/src/mame/drivers/norautp.cpp
@@ -3670,7 +3670,7 @@ GAME(  1983, gtipoker, 0,       dphl,     norautp, norautp_state, empty_init, RO
 GAME(  1983, gtipokra, 0,       dphla,    norautp, norautp_state, empty_init, ROT0, "GTI Inc",                     "GTI Poker? (SMS hardware)",        MACHINE_NOT_WORKING )
 GAME(  1983, smshilo,  0,       dphla,    norautp, norautp_state, empty_init, ROT0, "SMS Manufacturing Corp.",     "HI-LO Double Up Joker Poker",      MACHINE_NOT_WORKING )
 GAME(  1986, drhl,     0,       drhl,     norautp, norautp_state, empty_init, ROT0, "Drews Inc.",                  "Drews Revenge (v.2.89, set 1)",    MACHINE_NOT_WORKING )
-GAME(  1986, drhla,    0,       drhl,     norautp, norautp_state, empty_init, ROT0, "Drews Inc.",                  "Drews Revenge (v.2.89, set 2)",    MACHINE_NOT_WORKING )
+GAME(  1986, drhla,    drhl,    drhl,     norautp, norautp_state, empty_init, ROT0, "Drews Inc.",                  "Drews Revenge (v.2.89, set 2)",    MACHINE_NOT_WORKING )
 GAME(  1982, ssjkrpkr, 0,       ssjkrpkr, norautp, norautp_state, init_ssa,   ROT0, "Southern Systems & Assembly", "Southern Systems Joker Poker",     MACHINE_NOT_WORKING )
 
 /* The following one also has a custom 68705 MCU */


### PR DESCRIPTION
Drews Revenge (v.2.89, set 2) is a clone of Drews Revenge (v.2.89, set 1).
I compared both DASMs and they have only different JUMP addresses.
Download the DASMs files with instructions on how to compare them
with the awesome WDiff program:
http://www.mameworld.info/mameinfo/download/Drews Revenge (set 1 and 2)-DASM.7z