### PR TITLE
new machines marked as NOT WORKING

### DIFF
--- a/src/mame/drivers/neogeo.cpp
+++ b/src/mame/drivers/neogeo.cpp
@@ -6702,6 +6702,41 @@ ROM_START( mslug )
 ROM_END
 
 /****************************************
+  Nazca development cartridge, purpose unknown
+
+  MVS-TEMP (Program ROMs, also a HD64180SCP10, no S1 ROM)
+  TENP0 SND (tiny board with only M1 ROM)
+****************************************/
+
+ROM_START( mvstemp )
+	ROM_REGION( 0x200000, "cslot1:maincpu", ROMREGION_BE|ROMREGION_16BIT )
+	ROM_LOAD16_BYTE( "mvs-ph", 0x00000, 0x10000, CRC(c461c209) SHA1(baeb27b0c4cc05d0a692325687208d47933ae841))
+	ROM_LOAD16_BYTE( "mvs-pl", 0x00001, 0x10000, CRC(f82c3595) SHA1(5af628377d445e1494e695bbb45795d65f3a42e7) )
+
+	ROM_REGION( 0x20000, "cslot1:fixed", ROMREGION_ERASE00 )
+	// No S1 data (no position for it)
+
+	ROM_REGION( 0x20000, "fixedbios", 0 )
+	ROM_LOAD( "sfix.sfix", 0x000000, 0x20000, CRC(c2ea0cfd) SHA1(fd4a618cdcdbf849374f0a50dd8efe9dbab706c3) ) // BIOS
+	ROM_Y_ZOOM
+
+	NEO_BIOS_AUDIO_64K( "s-800h", CRC(307fffb2) SHA1(0a7a21c2f1a1f245de59d588f20b5ffea522a949) ) 
+
+	ROM_REGION( 0x200000, "cslot1:hd64180", 0 ) // HD64180SCP10 program, not hooked up
+	ROM_LOAD( "mvs64p", 0x000000, 0x10000, CRC(42a1d73a) SHA1(cb82a73f087ed6ca936dbe36a0a85451e63c9c8c) )
+
+	ROM_REGION( 0x117, "cslot1:pld", 0 )
+	ROM_LOAD( "ic6.bin",  0x000, 0x117, CRC(7e3da063) SHA1(2778932f8d4c48101c728e2f1906e54f8d73ff90) )
+	ROM_LOAD( "ic12.bin", 0x000, 0x117, CRC(b4f3c5ae) SHA1(61a1cda077c6998f0427922b1d229ef05e65e6ee) )	
+
+	ROM_REGION( 0x800000, "cslot1:ymsnd", ROMREGION_ERASE00 )
+	// No V data (no positions for it)
+
+	ROM_REGION( 0x1000000, "cslot1:sprites", ROMREGION_ERASE00 )
+	// No C data (no positions for it)
+ROM_END
+
+/****************************************
  ID-0202
  . ??M-202
  NEO-MVS PROG 4096 / NEO-MVS CHA 42G-2
@@ -11812,6 +11847,7 @@ GAME( 1991, bakatono,   neogeo,   neogeo_mj, neogeo_mj, mvs_led_state, empty_ini
 // Nazca (later acquired by SNK)
 GAME( 1996, turfmast,   neogeo,   neobase,   neogeo,    mvs_led_state, empty_init, ROT0, "Nazca", "Neo Turf Masters / Big Tournament Golf", MACHINE_SUPPORTS_SAVE )
 GAME( 1996, mslug,      neogeo,   neobase,   neogeo,    mvs_led_state, empty_init, ROT0, "Nazca", "Metal Slug - Super Vehicle-001", MACHINE_SUPPORTS_SAVE )
+GAME( 199?, mvstemp,    neogeo,   neobase,   neogeo,    mvs_led_state, empty_init, ROT0, "Nazca", "MVS-TEMP 'SubSystem Ver1.4' (Nazca development board)", MACHINE_NOT_WORKING )
 
 // NMK
 GAME( 1994, zedblade,   neogeo,   neobase,   neogeo,    mvs_led_state, empty_init, ROT0, "NMK", "Zed Blade / Operation Ragnarok", MACHINE_SUPPORTS_SAVE )

--- a/src/mame/mame.lst
+++ b/src/mame/mame.lst
@@ -29939,6 +29939,7 @@ minasan                         // 0027 (c) 1990 Monolith Corp.
 moshougi                        // 0203 (c) 1995 ADK / SNK
 ms4plus                         // bootleg
 ms5plus                         // bootleg
+mvstemp							// development board
 mslug                           // 0201 (c) 1996 Nazca
 mslug2                          // 0241 (c) 1998 SNK
 mslug2t                         // bootleg


### PR DESCRIPTION
MVS-TEMP 'SubSystem Ver1.4' (Nazca development board) [Brian Hargrove]

we don't really know what this was used for, or what to even call it, these are the pictures of it that he uploaded to his twitter account
http://mamedev.emulab.it/haze/reference/withcase.jpg
http://mamedev.emulab.it/haze/reference/prgboard_side1.jpg
http://mamedev.emulab.it/haze/reference/prgboard_side2.jpg
http://mamedev.emulab.it/haze/reference/m1board_side1.jpg
http://mamedev.emulab.it/haze/reference/m1board_side2.jpg
http://mamedev.emulab.it/haze/reference/m1board_side2_close.jpg

it's likely meant to be used with some PC-side software or something.