### PR TITLE
Orbatak year and manufacturer

### DIFF
--- a/src/mame/drivers/3do.cpp
+++ b/src/mame/drivers/3do.cpp
@@ -288,7 +288,7 @@ CONS( 1993, 3do_pal, 3do,    0,      _3do_pal,   3do,    _3do_state, empty_init,
 // Misc 3do Arcade games
 GAME( 1993, 3dobios, 0,       _3do,    3do,   _3do_state, empty_init, ROT0,     "The 3DO Company",      "3DO Bios",            MACHINE_NOT_WORKING | MACHINE_NO_SOUND | MACHINE_IS_BIOS_ROOT )
 
-GAME( 199?, orbatak, 3dobios, _3do,    3do,   _3do_state, empty_init, ROT0,     "<unknown>",            "Orbatak (prototype)", MACHINE_NOT_WORKING | MACHINE_NO_SOUND )
+GAME( 1995, orbatak, 3dobios, _3do,    3do,   _3do_state, empty_init, ROT0,     "American Laser Games", "Orbatak (prototype)", MACHINE_NOT_WORKING | MACHINE_NO_SOUND )
 // Beavis and Butthead (prototype)
 
 


### PR DESCRIPTION
"1995 American Laser Games" text at $2abeb4c in the extracted orbatak.chd CD-ROM.
Also Youtube video with year and manufacturer: https://www.youtube.com/watch?v=bdBO_ZSIqeE
Additionall infos: http://emuconsoleexploitnews.blogspot.com/2010/06/orbatak-cancelled-3do-arcade-game.html