### PR TITLE
6840: fix dual byte mode once again (nw)

### DIFF
--- a/src/devices/machine/6840ptm.h
+++ b/src/devices/machine/6840ptm.h
@@ -129,7 +129,7 @@ private:
 	static const char *const opmode[];
 
 	// set in dual 8 bit mode to indicate Output high time cycle
-	bool m_hightime;
+	bool m_hightime[3];
 };
 
 


### PR DESCRIPTION
Two problems in dual byte mode:

- the high time flag is the same for all counters
- high time flag is reset on each counter reload, but should
  only be reset if the timer is reload by the user.