### PR TITLE
Use boolean not bool for libjpeg functions

### DIFF
--- a/src/emu/rendutil.cpp
+++ b/src/emu/rendutil.cpp
@@ -577,7 +577,7 @@ void render_load_jpeg(bitmap_argb32 &bitmap, emu_file &file, const char *dirname
 	jpeg_mem_src(&cinfo, jpg_buffer.get(), jpg_size);
 
 	// read JPEG header and start decompression
-	jpeg_read_header(&cinfo, true);
+	jpeg_read_header(&cinfo, TRUE);
 	jpeg_start_decompress(&cinfo);
 
 	// allocates the destination bitmap


### PR DESCRIPTION
Use boolean `TRUE` instead of bool `true` for libjpeg functions. Fixes build failure:

```
../../../../../src/emu/rendutil.cpp:580:2: error: no matching function for call to 'jpeg_read_header'
        jpeg_read_header(&cinfo, true);
        ^~~~~~~~~~~~~~~~
In file included from ../../../../../src/emu/rendutil.cpp:16:
/opt/local/include/jpeglib.h:1039:13: note: candidate function not viable: no known conversion from 'bool' to 'boolean' for 2nd argument
EXTERN(int) jpeg_read_header JPP((j_decompress_ptr cinfo,
            ^
```