### PR TITLE
Disable setting the SDL_WINDOW_OPENGL extra flag if -video none

### DIFF
--- a/src/osd/sdl/window.cpp
+++ b/src/osd/sdl/window.cpp
@@ -694,7 +694,7 @@ int sdl_window_info::complete_create()
 	 *
 	 */
 	osd_printf_verbose("Enter sdl_info::create\n");
-	if (renderer().has_flags(osd_renderer::FLAG_NEEDS_OPENGL))
+	if (renderer().has_flags(osd_renderer::FLAG_NEEDS_OPENGL) && !video_config.novideo)
 	{
 		SDL_GL_SetAttribute( SDL_GL_DOUBLEBUFFER, 1 );
 


### PR DESCRIPTION
Disable setting the SDL_WINDOW_OPENGL extra flag if -video none is set.  This allows a true headless run when the environment variable SDL_VIDEODRIVER=dummy is set prior to mame/mess execution.