### PR TITLE
tms9914: latch EOI flag until next byte is sent

### DIFF
--- a/src/devices/machine/tms9914.h
+++ b/src/devices/machine/tms9914.h
@@ -303,6 +303,7 @@ private:
 	void update_ifc();
 	void update_ren();
 	void set_accrq(bool state);
+	bool m_next_eoi;
 };
 
 // device type definition


### PR DESCRIPTION
hp9000/300 sends FEOI directly after the data register write,
before the byte is actually transmitted. This leads to the current
byte being sent out with EOI set, instead of the last one.