### PR TITLE
NSCSI: disable debug

### DIFF
--- a/src/devices/machine/nscsi_bus.cpp
+++ b/src/devices/machine/nscsi_bus.cpp
@@ -9,7 +9,7 @@
 #define LOG_DATA    (1U << 3)
 
 //#define VERBOSE (LOG_GENERAL | LOG_STATE | LOG_CONTROL | LOG_DATA)
-#define VERBOSE (LOG_GENERAL)
+#define VERBOSE 0
 
 #include "logmacro.h"
 

--- a/src/devices/machine/nscsi_cd.cpp
+++ b/src/devices/machine/nscsi_cd.cpp
@@ -3,7 +3,7 @@
 #include "emu.h"
 #include "machine/nscsi_cd.h"
 
-#define VERBOSE 1
+#define VERBOSE 0
 #include "logmacro.h"
 
 DEFINE_DEVICE_TYPE(NSCSI_CDROM, nscsi_cdrom_device, "scsi_cdrom", "SCSI CD-ROM")

--- a/src/devices/machine/nscsi_hd.cpp
+++ b/src/devices/machine/nscsi_hd.cpp
@@ -8,7 +8,7 @@
 #define LOG_COMMAND (1U << 1)
 #define LOG_DATA    (1U << 2)
 
-#define VERBOSE (LOG_GENERAL)
+#define VERBOSE 0
 
 #include "logmacro.h"
 


### PR DESCRIPTION
The default debug settings are filling up error.log pretty quick
when booting SCSI machines like hp9k_3xx. Disable debug in the
default settings, it can still be enabled if some dev/user wants
to debug NSCSI.