### PR TITLE
util::fifo.queue_length() (nw)

### DIFF
--- a/src/lib/util/coretmpl.h
+++ b/src/lib/util/coretmpl.h
@@ -885,6 +885,17 @@ public:
 	bool full() const { return !m_empty && (m_head == m_tail); }
 	bool empty() const { return m_empty; }
 
+	// number of currently enqueued elements
+	std::size_t queue_length() const
+	{
+		if (m_empty)
+			return 0;
+
+		auto const distance = std::distance(m_head, m_tail);
+
+		return (distance > 0) ? distance : (N + distance);
+	}
+
 	void enqueue(T const &v)
 	{
 		if (WriteWrap || m_empty || (m_head != m_tail))


### PR DESCRIPTION
Not 100% confident about the variable type, and there may still be some debate over the function name (trying to avoid confusion with the length of the container, or with the number of empty slots), so appreciate review/comments.