### PR TITLE
restore Super XaviX opcode table with correctly swapped opcodes

### DIFF
--- a/src/devices/cpu/m6502/dxavix2000.lst
+++ b/src/devices/cpu/m6502/dxavix2000.lst
@@ -6,15 +6,15 @@ bpl_rel     unh_imp     phx_imp     orapa_imp   unh_imp     unh_imp     unh_imp 
 jsr_adr     unh_imp     callf_xa3   andl0_acc   unh_imp     unh_imp     rol_zpg     andl1_acc   plp_imp     and_imm     rol_acc     andl2_acc   bit_aba     unh_imp     unh_imp     andl3_acc
 bmi_rel     unh_imp     plx_imp     andpa_imp   unh_imp     unh_imp     unh_imp     andpb_imp   sec_imp     unh_imp     unh_imp     lpa0_acc    unh_imp     unh_imp     rol_abx     lpb0_acc
 rti_xav_imp unh_imp     nop_imp     eorl0_acc   nop_imp     eor_zpg     lsr_zpg     eorl1_acc   pha_imp     eor_imm     lsr_acc     eorl2_acc   jmp_adr     unh_imp     lsr_aba     eorl3_acc
-unh_imp     eor_idy     phy_imp     eorpa_imp   nop_imp     unh_imp     unh_imp     eorpb_imp   cli_imp     eor_aby     unh_imp     spa1_acc    unh_imp     eor_abx     unh_imp     spb1_acc
-rts_imp     unh_imp     nop_imp     adcl0_acc   unh_imp     adc_zpg     ror_zpg     adcl1_acc   pla_imp     adc_imm     unh_imp     adcl2_acc   jmp_ind     unh_imp     unh_imp     adcl3_acc
-bvs_rel     adc_idy     ply_imp     adcpa_imp   unh_imp     unh_imp     unh_imp     adcpb_imp   sei_imp     unh_imp     unh_imp     lpa1_acc    unh_imp     unh_imp     unh_imp     lpb1_acc
+unh_imp     eor_idy     phy_imp     eorpa_imp   nop_imp     unh_imp     unh_imp     eorpb_imp   cli_imp     eor_aby     nop_imp     spa1_acc    unh_imp     eor_abx     unh_imp     spb1_acc
+rts_imp     unh_imp     nop_imp     adcl0_acc   nop_imp     adc_zpg     ror_zpg     adcl1_acc   pla_imp     adc_imm     unh_imp     adcl2_acc   jmp_ind     unh_imp     unh_imp     adcl3_acc
+bvs_rel     adc_idy     ply_imp     adcpa_imp   nop_imp     unh_imp     unh_imp     adcpb_imp   sei_imp     unh_imp     nop_imp     lpa1_acc    unh_imp     unh_imp     unh_imp     lpb1_acc
 retf_imp    unh_imp     unh_imp     stal0_acc   sty_zpg     sta_zpg     stx_zpg     stal1_acc   dey_imp     unh_imp     txa_imp     stal2_acc   unh_imp     sta_aba     stx_aba     stal3_acc
 bcc_rel     sta_idy     unh_imp     stapa_imp   unh_imp     unh_imp     stx_zpy     stapb_imp   tya_imp     sta_aby     txs_imp     spa2_acc    unh_imp     sta_abx     unh_imp     spb2_acc
 ldy_imm     unh_imp     ldx_imm     ldal0_acc   ldy_zpg     lda_zpg     ldx_zpg     ldal1_acc   tay_imp     lda_imm     tax_imp     ldal2_acc   unh_imp     lda_aba     ldx_aba     ldal3_acc
 bcs_rel     lda_idy     clrl_imp    ldapa_imp   unh_imp     unh_imp     ldx_zpy     ldapb_imp   clv_imp     lda_aby     tsx_imp     lpa2_acc    unh_imp     lda_abx     ldx_aby     lpb2_acc
-cpy_imm     unh_imp     unh_imp     cmpl0_acc   cpy_zpg     cmp_zpg     dec_zpg     cmpl1_acc   iny_imp     cmp_imm     dex_imp     cmpl2_acc   unh_imp     unh_imp     dec_aba     cmpl3_acc
-bne_rel     cmp_idy     unh_imp     cmppa_imp   nop_imp     unh_imp     unh_imp     cmppb_imp   unh_imp     cmp_aby     unh_imp     decpa_imp   unh_imp     unh_imp     dec_abx     decpb_imp
-cpx_imm     unh_imp     unh_imp     sbcl0_acc   cpx_zpg     sbc_zpg     inc_zpg     sbcl1_acc   inx_imp     sbc_imm     nop_imp     sbcl2_acc   unh_imp     unh_imp     unh_imp     sbcl3_acc
-beq_rel     unh_imp     unh_imp     sbcpa_imp   nop_imp     unh_imp     unh_imp     sbcpb_imp   unh_imp     unh_imp     unh_imp     incpa_imp   unh_imp     unh_imp     unh_imp     incpb_imp
+cpy_imm     unh_imp     decl_imp    cmpl0_acc   cpy_zpg     cmp_zpg     dec_zpg     cmpl1_acc   iny_imp     cmp_imm     dex_imp     cmpl2_acc   unh_imp     unh_imp     dec_aba     cmpl3_acc
+bne_rel     cmp_idy     notl_imp    cmppa_imp   nop_imp     unh_imp     unh_imp     cmppb_imp   unh_imp     cmp_aby     nop_imp     decpa_imp   unh_imp     unh_imp     dec_abx     decpb_imp
+cpx_imm     unh_imp     incl_imp    sbcl0_acc   cpx_zpg     sbc_zpg     inc_zpg     sbcl1_acc   inx_imp     sbc_imm     nop_imp     sbcl2_acc   unh_imp     unh_imp     unh_imp     sbcl3_acc
+beq_rel     unh_imp     negl_imp    sbcpa_imp   nop_imp     unh_imp     unh_imp     sbcpb_imp   unh_imp     unh_imp     nop_imp     incpa_imp   unh_imp     unh_imp     unh_imp     incpb_imp
 reset

--- a/src/devices/cpu/m6502/dxavix2000.lst
+++ b/src/devices/cpu/m6502/dxavix2000.lst
@@ -1,20 +1,20 @@
 # license:BSD-3-Clause
 # copyright-holders:David Haywood
 # Super XaviX (SSD 2000) - m6502 with custom opcodes
-brk_xav_imp unh_imp     unh_imp     unh_imp     unh_imp     ora_zpg     asl_zpg     unh_imp     php_imp     ora_imm     asl_acc     unh_imp     unh_imp     ora_aba     unh_imp     unh_imp
-bpl_rel     unh_imp     phx_imp     unh_imp     unh_imp     unh_imp     unh_imp     unh_imp     clc_imp     ora_aby     unh_imp     unh_imp     unh_imp     ora_abx     unh_imp     unh_imp
-jsr_adr     unh_imp     callf_xa3   unh_imp     unh_imp     unh_imp     rol_zpg     unh_imp     plp_imp     and_imm     rol_acc     unh_imp     bit_aba     unh_imp     unh_imp     unh_imp
-bmi_rel     unh_imp     plx_imp     unh_imp     unh_imp     unh_imp     unh_imp     unh_imp     sec_imp     unh_imp     unh_imp     unh_imp     unh_imp     unh_imp     rol_abx     unh_imp
-rti_xav_imp unh_imp     unh_imp     unh_imp     unh_imp     eor_zpg     lsr_zpg     unh_imp     pha_imp     eor_imm     lsr_acc     unh_imp     jmp_adr     unh_imp     lsr_aba     unh_imp
-unh_imp     eor_idy     phy_imp     unh_imp     unh_imp     unh_imp     unh_imp     unh_imp     cli_imp     eor_aby     unh_imp     unh_imp     unh_imp     eor_abx     unh_imp     unh_imp
-rts_imp     unh_imp     unh_imp     unh_imp     unh_imp     adc_zpg     ror_zpg     unh_imp     pla_imp     adc_imm     unh_imp     unh_imp     jmp_ind     unh_imp     unh_imp     unh_imp
-bvs_rel     adc_idy     ply_imp     unh_imp     unh_imp     unh_imp     unh_imp     unh_imp     sei_imp     unh_imp     unh_imp     unh_imp     unh_imp     unh_imp     unh_imp     unh_imp
-retf_imp    unh_imp     unh_imp     unh_imp     sty_zpg     sta_zpg     stx_zpg     unh_imp     dey_imp     unh_imp     txa_imp     unh_imp     unh_imp     sta_aba     stx_aba     unh_imp
-bcc_rel     sta_idy     unh_imp     unh_imp     unh_imp     unh_imp     stx_zpy     unh_imp     tya_imp     sta_aby     txs_imp     unh_imp     unh_imp     sta_abx     unh_imp     unh_imp
-ldy_imm     unh_imp     ldx_imm     unh_imp     ldy_zpg     lda_zpg     ldx_zpg     unh_imp     tay_imp     lda_imm     tax_imp     unh_imp     unh_imp     lda_aba     unh_imp     unh_imp
-bcs_rel     lda_idy     clr_acc     unh_imp     unh_imp     unh_imp     ldx_zpy     unh_imp     clv_imp     lda_aby     tsx_imp     unh_imp     unh_imp     lda_abx     ldx_aby     unh_imp
-cpy_imm     unh_imp     unh_imp     unh_imp     cpy_zpg     cmp_zpg     dec_zpg     unh_imp     iny_imp     cmp_imm     dex_imp     unh_imp     unh_imp     unh_imp     unh_imp     unh_imp
-bne_rel     cmp_idy     unh_imp     unh_imp     unh_imp     unh_imp     unh_imp     unh_imp     unh_imp     unh_imp     unh_imp     unh_imp     unh_imp     unh_imp     dec_abx     unh_imp
-cpx_imm     unh_imp     unh_imp     unh_imp     cpx_zpg     sbc_zpg     inc_zpg     unh_imp     inx_imp     sbc_imm     unh_imp     unh_imp     unh_imp     unh_imp     unh_imp     unh_imp
-beq_rel     unh_imp     unh_imp     unh_imp     unh_imp     unh_imp     unh_imp     unh_imp     unh_imp     unh_imp     unh_imp     unh_imp     unh_imp     unh_imp     unh_imp     unh_imp
+brk_xav_imp unh_imp     unh_imp     oral0_acc   unh_imp     ora_zpg     asl_zpg     oral1_acc   php_imp     ora_imm     asl_acc     oral2_acc   unh_imp     ora_aba     unh_imp     oral3_acc
+bpl_rel     unh_imp     phx_imp     orapa_imp   unh_imp     unh_imp     unh_imp     orapb_imp   clc_imp     ora_aby     unh_imp     spa0_acc    unh_imp     ora_abx     unh_imp     spb0_acc
+jsr_adr     unh_imp     callf_xa3   andl0_acc   unh_imp     unh_imp     rol_zpg     andl1_acc   plp_imp     and_imm     rol_acc     andl2_acc   bit_aba     unh_imp     unh_imp     andl3_acc
+bmi_rel     unh_imp     plx_imp     andpa_imp   unh_imp     unh_imp     unh_imp     andpb_imp   sec_imp     unh_imp     unh_imp     lpa0_acc    unh_imp     unh_imp     rol_abx     lpb0_acc
+rti_xav_imp unh_imp     nop_imp     eorl0_acc   nop_imp     eor_zpg     lsr_zpg     eorl1_acc   pha_imp     eor_imm     lsr_acc     eorl2_acc   jmp_adr     unh_imp     lsr_aba     eorl3_acc
+unh_imp     eor_idy     phy_imp     eorpa_imp   nop_imp     unh_imp     unh_imp     eorpb_imp   cli_imp     eor_aby     unh_imp     spa1_acc    unh_imp     eor_abx     unh_imp     spb1_acc
+rts_imp     unh_imp     nop_imp     adcl0_acc   unh_imp     adc_zpg     ror_zpg     adcl1_acc   pla_imp     adc_imm     unh_imp     adcl2_acc   jmp_ind     unh_imp     unh_imp     adcl3_acc
+bvs_rel     adc_idy     ply_imp     adcpa_imp   unh_imp     unh_imp     unh_imp     adcpb_imp   sei_imp     unh_imp     unh_imp     lpa1_acc    unh_imp     unh_imp     unh_imp     lpb1_acc
+retf_imp    unh_imp     unh_imp     stal0_acc   sty_zpg     sta_zpg     stx_zpg     stal1_acc   dey_imp     unh_imp     txa_imp     stal2_acc   unh_imp     sta_aba     stx_aba     stal3_acc
+bcc_rel     sta_idy     unh_imp     stapa_imp   unh_imp     unh_imp     stx_zpy     stapb_imp   tya_imp     sta_aby     txs_imp     spa2_acc    unh_imp     sta_abx     unh_imp     spb2_acc
+ldy_imm     unh_imp     ldx_imm     ldal0_acc   ldy_zpg     lda_zpg     ldx_zpg     ldal1_acc   tay_imp     lda_imm     tax_imp     ldal2_acc   unh_imp     lda_aba     ldx_aba     ldal3_acc
+bcs_rel     lda_idy     clrl_imp    ldapa_imp   unh_imp     unh_imp     ldx_zpy     ldapb_imp   clv_imp     lda_aby     tsx_imp     lpa2_acc    unh_imp     lda_abx     ldx_aby     lpb2_acc
+cpy_imm     unh_imp     unh_imp     cmpl0_acc   cpy_zpg     cmp_zpg     dec_zpg     cmpl1_acc   iny_imp     cmp_imm     dex_imp     cmpl2_acc   unh_imp     unh_imp     dec_aba     cmpl3_acc
+bne_rel     cmp_idy     unh_imp     cmppa_imp   nop_imp     unh_imp     unh_imp     cmppb_imp   unh_imp     cmp_aby     unh_imp     decpa_imp   unh_imp     unh_imp     dec_abx     decpb_imp
+cpx_imm     unh_imp     unh_imp     sbcl0_acc   cpx_zpg     sbc_zpg     inc_zpg     sbcl1_acc   inx_imp     sbc_imm     nop_imp     sbcl2_acc   unh_imp     unh_imp     unh_imp     sbcl3_acc
+beq_rel     unh_imp     unh_imp     sbcpa_imp   nop_imp     unh_imp     unh_imp     sbcpb_imp   unh_imp     unh_imp     unh_imp     incpa_imp   unh_imp     unh_imp     unh_imp     incpb_imp
 reset

--- a/src/devices/cpu/m6502/dxavix2000.lst
+++ b/src/devices/cpu/m6502/dxavix2000.lst
@@ -1,20 +1,20 @@
 # license:BSD-3-Clause
 # copyright-holders:David Haywood
 # Super XaviX (SSD 2000) - m6502 with custom opcodes
-brk_xav_imp unh_imp     unh_imp     oral0_acc   unh_imp     ora_zpg     asl_zpg     oral1_acc   php_imp     ora_imm     asl_acc     oral2_acc   unh_imp     ora_aba     unh_imp     oral3_acc
-bpl_rel     unh_imp     phx_imp     orapa_imp   unh_imp     unh_imp     unh_imp     orapb_imp   clc_imp     ora_aby     unh_imp     spa0_acc    unh_imp     ora_abx     unh_imp     spb0_acc
-jsr_adr     unh_imp     callf_xa3   andl0_acc   unh_imp     unh_imp     rol_zpg     andl1_acc   plp_imp     and_imm     rol_acc     andl2_acc   bit_aba     unh_imp     unh_imp     andl3_acc
-bmi_rel     unh_imp     plx_imp     andpa_imp   unh_imp     unh_imp     unh_imp     andpb_imp   sec_imp     unh_imp     unh_imp     lpa0_acc    unh_imp     unh_imp     rol_abx     lpb0_acc
-rti_xav_imp unh_imp     nop_imp     eorl0_acc   nop_imp     eor_zpg     lsr_zpg     eorl1_acc   pha_imp     eor_imm     lsr_acc     eorl2_acc   jmp_adr     unh_imp     lsr_aba     eorl3_acc
-unh_imp     eor_idy     phy_imp     eorpa_imp   nop_imp     unh_imp     unh_imp     eorpb_imp   cli_imp     eor_aby     nop_imp     spa1_acc    unh_imp     eor_abx     unh_imp     spb1_acc
-rts_imp     unh_imp     nop_imp     adcl0_acc   nop_imp     adc_zpg     ror_zpg     adcl1_acc   pla_imp     adc_imm     unh_imp     adcl2_acc   jmp_ind     unh_imp     unh_imp     adcl3_acc
-bvs_rel     adc_idy     ply_imp     adcpa_imp   nop_imp     unh_imp     unh_imp     adcpb_imp   sei_imp     unh_imp     nop_imp     lpa1_acc    unh_imp     unh_imp     unh_imp     lpb1_acc
-retf_imp    unh_imp     unh_imp     stal0_acc   sty_zpg     sta_zpg     stx_zpg     stal1_acc   dey_imp     unh_imp     txa_imp     stal2_acc   unh_imp     sta_aba     stx_aba     stal3_acc
-bcc_rel     sta_idy     unh_imp     stapa_imp   unh_imp     unh_imp     stx_zpy     stapb_imp   tya_imp     sta_aby     txs_imp     spa2_acc    unh_imp     sta_abx     unh_imp     spb2_acc
-ldy_imm     unh_imp     ldx_imm     ldal0_acc   ldy_zpg     lda_zpg     ldx_zpg     ldal1_acc   tay_imp     lda_imm     tax_imp     ldal2_acc   unh_imp     lda_aba     ldx_aba     ldal3_acc
-bcs_rel     lda_idy     clrl_imp    ldapa_imp   unh_imp     unh_imp     ldx_zpy     ldapb_imp   clv_imp     lda_aby     tsx_imp     lpa2_acc    unh_imp     lda_abx     ldx_aby     lpb2_acc
-cpy_imm     unh_imp     decl_imp    cmpl0_acc   cpy_zpg     cmp_zpg     dec_zpg     cmpl1_acc   iny_imp     cmp_imm     dex_imp     cmpl2_acc   unh_imp     unh_imp     dec_aba     cmpl3_acc
-bne_rel     cmp_idy     notl_imp    cmppa_imp   nop_imp     unh_imp     unh_imp     cmppb_imp   unh_imp     cmp_aby     nop_imp     decpa_imp   unh_imp     unh_imp     dec_abx     decpb_imp
-cpx_imm     unh_imp     incl_imp    sbcl0_acc   cpx_zpg     sbc_zpg     inc_zpg     sbcl1_acc   inx_imp     sbc_imm     nop_imp     sbcl2_acc   unh_imp     unh_imp     unh_imp     sbcl3_acc
-beq_rel     unh_imp     negl_imp    sbcpa_imp   nop_imp     unh_imp     unh_imp     sbcpb_imp   unh_imp     unh_imp     nop_imp     incpa_imp   unh_imp     unh_imp     unh_imp     incpb_imp
+brk_xav_imp ora_idx     cmc_imp     oral0_acc   asr_zpg     ora_zpg     asl_zpg     oral1_acc   php_imp     ora_imm     asl_acc     oral2_acc   asr_aba     ora_aba     asl_aba     oral3_acc
+bpl_rel     ora_idy     phx_imp     orapa_imp   asr_zpx     ora_zpx     asl_zpx     orapb_imp   clc_imp     ora_aby     asr_acc     spa0_acc    asr_abx     ora_abx     asl_abx     spb0_acc
+jsr_adr     and_idx     callf_xa3   andl0_acc   bit_zpg     and_zpg     rol_zpg     andl1_acc   plp_imp     and_imm     rol_acc     andl2_acc   bit_aba     and_aba     rol_aba     andl3_acc
+bmi_rel     and_idy     plx_imp     andpa_imp   bit_zpx     and_zpx     rol_zpx     andpb_imp   sec_imp     and_aby     bit_imm     lpa0_acc    bit_abx     and_abx     rol_abx     lpb0_acc
+rti_xav_imp eor_idx     nop_imp     eorl0_acc   nop_imp     eor_zpg     lsr_zpg     eorl1_acc   pha_imp     eor_imm     lsr_acc     eorl2_acc   jmp_adr     eor_aba     lsr_aba     eorl3_acc
+bvc_rel     eor_idy     phy_imp     eorpa_imp   nop_imp     eor_zpx     lsr_zpx     eorpb_imp   cli_imp     eor_aby     nop_imp     spa1_acc    callf_aba   eor_abx     lsr_abx     spb1_acc
+rts_imp     adc_idx     nop_imp     adcl0_acc   nop_imp     adc_zpg     ror_zpg     adcl1_acc   pla_imp     adc_imm     ror_acc     adcl2_acc   jmp_ind     adc_aba     ror_aba     adcl3_acc
+bvs_rel     adc_idy     ply_imp     adcpa_imp   nop_imp     adc_zpx     ror_zpx     adcpb_imp   sei_imp     adc_aby     nop_imp     lpa1_acc    callf_ind   adc_abx     ror_abx     lpb1_acc
+retf_imp    sta_idx     stz_zpg     stal0_acc   sty_zpg     sta_zpg     stx_zpg     stal1_acc   dey_imp     sev_imp     txa_imp     stal2_acc   sty_aba     sta_aba     stx_aba     stal3_acc
+bcc_rel     sta_idy     stz_aba     stapa_imp   sty_zpx     sta_zpx     stx_zpy     stapb_imp   tya_imp     sta_aby     txs_imp     spa2_acc    sty_abx     sta_abx     stx_aby     spb2_acc
+ldy_imm     lda_idx     ldx_imm     ldal0_acc   ldy_zpg     lda_zpg     ldx_zpg     ldal1_acc   tay_imp     lda_imm     tax_imp     ldal2_acc   ldy_aba     lda_aba     ldx_aba     ldal3_acc
+bcs_rel     lda_idy     clrl_imp    ldapa_imp   ldy_zpx     lda_zpx     ldx_zpy     ldapb_imp   clv_imp     lda_aby     tsx_imp     lpa2_acc    ldy_abx     lda_abx     ldx_aby     lpb2_acc
+cpy_imm     cmp_idx     decl_imp    cmpl0_acc   cpy_zpg     cmp_zpg     dec_zpg     cmpl1_acc   iny_imp     cmp_imm     dex_imp     cmpl2_acc   cpy_aba     cmp_aba     dec_aba     cmpl3_acc
+bne_rel     cmp_idy     notl_imp    cmppa_imp   nop_imp     cmp_zpx     dec_zpx     cmppb_imp   cld_imp     cmp_aby     nop_imp     decpa_imp   nop_imp     cmp_abx     dec_abx     decpb_imp
+cpx_imm     sbc_idx     incl_imp    sbcl0_acc   cpx_zpg     sbc_zpg     inc_zpg     sbcl1_acc   inx_imp     sbc_imm     nop_imp     sbcl2_acc   cpx_aba     sbc_aba     inc_aba     sbcl3_acc
+beq_rel     sbc_idy     negl_imp    sbcpa_imp   nop_imp     sbc_zpx     inc_zpx     sbcpb_imp   sed_imp     sbc_aby     nop_imp     incpa_imp   nop_imp     sbc_abx     inc_abx     incpb_imp
 reset

--- a/src/devices/cpu/m6502/oxavix2000.lst
+++ b/src/devices/cpu/m6502/oxavix2000.lst
@@ -2,11 +2,6 @@
 # copyright-holders:David Haywood
 # xavix2000 opcodes (Super XaviX)
 
-unh_imp
-	fatalerror("unhandled opcode %02x%04x: %02x\n", m_codebank, PPC, inst_state);
-	read_pc_noinc();
-	prefetch();
-
 phy_imp
 	read_pc_noinc();
 	write(SP, Y);
@@ -36,279 +31,427 @@ ply_imp
 	prefetch();
 
 clrl_imp
+	fatalerror("unhandled opcode %02x%04x: %02x\n", m_codebank, PPC, inst_state);
 	read_pc_noinc();
 	m_l = 0;
 	prefetch();
 
 decl_imp
+	fatalerror("unhandled opcode %02x%04x: %02x\n", m_codebank, PPC, inst_state);
 	read_pc_noinc();
 	prefetch();
 
 notl_imp
+	fatalerror("unhandled opcode %02x%04x: %02x\n", m_codebank, PPC, inst_state);
 	read_pc_noinc();
 	prefetch();
 
 incl_imp
+	fatalerror("unhandled opcode %02x%04x: %02x\n", m_codebank, PPC, inst_state);
 	read_pc_noinc();
 	prefetch();
 
 negl_imp
+	fatalerror("unhandled opcode %02x%04x: %02x\n", m_codebank, PPC, inst_state);
 	read_pc_noinc();
 	prefetch();
 
 oral0_acc
+	fatalerror("unhandled opcode %02x%04x: %02x\n", m_codebank, PPC, inst_state);
 	read_pc_noinc();
 	prefetch();
 
 oral1_acc
+	fatalerror("unhandled opcode %02x%04x: %02x\n", m_codebank, PPC, inst_state);
 	read_pc_noinc();
 	prefetch();
 
 oral2_acc
+	fatalerror("unhandled opcode %02x%04x: %02x\n", m_codebank, PPC, inst_state);
 	read_pc_noinc();
 	prefetch();
 
 oral3_acc
+	fatalerror("unhandled opcode %02x%04x: %02x\n", m_codebank, PPC, inst_state);
 	read_pc_noinc();
 	prefetch();
 
 andl0_acc
+	fatalerror("unhandled opcode %02x%04x: %02x\n", m_codebank, PPC, inst_state);
 	read_pc_noinc();
 	prefetch();
 
 andl1_acc
+	fatalerror("unhandled opcode %02x%04x: %02x\n", m_codebank, PPC, inst_state);
 	read_pc_noinc();
 	prefetch();
 
 andl2_acc
+	fatalerror("unhandled opcode %02x%04x: %02x\n", m_codebank, PPC, inst_state);
 	read_pc_noinc();
 	prefetch();
 
 andl3_acc
+	fatalerror("unhandled opcode %02x%04x: %02x\n", m_codebank, PPC, inst_state);
 	read_pc_noinc();
 	prefetch();
 
 eorl0_acc
+	fatalerror("unhandled opcode %02x%04x: %02x\n", m_codebank, PPC, inst_state);
 	read_pc_noinc();
 	prefetch();
 
 eorl1_acc
+	fatalerror("unhandled opcode %02x%04x: %02x\n", m_codebank, PPC, inst_state);
 	read_pc_noinc();
 	prefetch();
 
 eorl2_acc
+	fatalerror("unhandled opcode %02x%04x: %02x\n", m_codebank, PPC, inst_state);
 	read_pc_noinc();
 	prefetch();
 
 eorl3_acc
+	fatalerror("unhandled opcode %02x%04x: %02x\n", m_codebank, PPC, inst_state);
 	read_pc_noinc();
 	prefetch();
 
 adcl0_acc
+	fatalerror("unhandled opcode %02x%04x: %02x\n", m_codebank, PPC, inst_state);
 	read_pc_noinc();
 	prefetch();
 
 adcl1_acc
+	fatalerror("unhandled opcode %02x%04x: %02x\n", m_codebank, PPC, inst_state);
 	read_pc_noinc();
 	prefetch();
 
 adcl2_acc
+	fatalerror("unhandled opcode %02x%04x: %02x\n", m_codebank, PPC, inst_state);
 	read_pc_noinc();
 	prefetch();
 
 adcl3_acc
+	fatalerror("unhandled opcode %02x%04x: %02x\n", m_codebank, PPC, inst_state);
 	read_pc_noinc();
 	prefetch();
 	
 stal0_acc
+	fatalerror("unhandled opcode %02x%04x: %02x\n", m_codebank, PPC, inst_state);
 	read_pc_noinc();
 	prefetch();
 
 stal1_acc
+	fatalerror("unhandled opcode %02x%04x: %02x\n", m_codebank, PPC, inst_state);
 	read_pc_noinc();
 	prefetch();
 
 stal2_acc
+	fatalerror("unhandled opcode %02x%04x: %02x\n", m_codebank, PPC, inst_state);
 	read_pc_noinc();
 	prefetch();
 
 stal3_acc
+	fatalerror("unhandled opcode %02x%04x: %02x\n", m_codebank, PPC, inst_state);
 	read_pc_noinc();
 	prefetch();
 
 ldal0_acc
+	fatalerror("unhandled opcode %02x%04x: %02x\n", m_codebank, PPC, inst_state);
 	read_pc_noinc();
 	prefetch();
 
 ldal1_acc
+	fatalerror("unhandled opcode %02x%04x: %02x\n", m_codebank, PPC, inst_state);
 	read_pc_noinc();
 	prefetch();
 
 ldal2_acc
+	fatalerror("unhandled opcode %02x%04x: %02x\n", m_codebank, PPC, inst_state);
 	read_pc_noinc();
 	prefetch();
 
 ldal3_acc
+	fatalerror("unhandled opcode %02x%04x: %02x\n", m_codebank, PPC, inst_state);
 	read_pc_noinc();
 	prefetch();
 
 cmpl0_acc
+	fatalerror("unhandled opcode %02x%04x: %02x\n", m_codebank, PPC, inst_state);
 	read_pc_noinc();
 	prefetch();
 
 cmpl1_acc
+	fatalerror("unhandled opcode %02x%04x: %02x\n", m_codebank, PPC, inst_state);
 	read_pc_noinc();
 	prefetch();
 
 cmpl2_acc
+	fatalerror("unhandled opcode %02x%04x: %02x\n", m_codebank, PPC, inst_state);
 	read_pc_noinc();
 	prefetch();
 
 cmpl3_acc
+	fatalerror("unhandled opcode %02x%04x: %02x\n", m_codebank, PPC, inst_state);
 	read_pc_noinc();
 	prefetch();
 
 sbcl0_acc
+	fatalerror("unhandled opcode %02x%04x: %02x\n", m_codebank, PPC, inst_state);
 	read_pc_noinc();
 	prefetch();
 
 sbcl1_acc
+	fatalerror("unhandled opcode %02x%04x: %02x\n", m_codebank, PPC, inst_state);
 	read_pc_noinc();
 	prefetch();
 
 sbcl2_acc
+	fatalerror("unhandled opcode %02x%04x: %02x\n", m_codebank, PPC, inst_state);
 	read_pc_noinc();
 	prefetch();
 
 sbcl3_acc
+	fatalerror("unhandled opcode %02x%04x: %02x\n", m_codebank, PPC, inst_state);
 	read_pc_noinc();
 	prefetch();
 
 spa0_acc
+	fatalerror("unhandled opcode %02x%04x: %02x\n", m_codebank, PPC, inst_state);
 	read_pc_noinc();
 	prefetch();
 
 lpa0_acc
+	fatalerror("unhandled opcode %02x%04x: %02x\n", m_codebank, PPC, inst_state);
 	read_pc_noinc();
 	prefetch();
 
 spa1_acc
+	fatalerror("unhandled opcode %02x%04x: %02x\n", m_codebank, PPC, inst_state);
 	read_pc_noinc();
 	prefetch();
 
 lpa1_acc
+	fatalerror("unhandled opcode %02x%04x: %02x\n", m_codebank, PPC, inst_state);
 	read_pc_noinc();
 	prefetch();
 	
 spa2_acc
+	fatalerror("unhandled opcode %02x%04x: %02x\n", m_codebank, PPC, inst_state);
 	read_pc_noinc();
 	prefetch();
 
 lpa2_acc
+	fatalerror("unhandled opcode %02x%04x: %02x\n", m_codebank, PPC, inst_state);
 	read_pc_noinc();
 	prefetch();
 
 spb0_acc
+	fatalerror("unhandled opcode %02x%04x: %02x\n", m_codebank, PPC, inst_state);
 	read_pc_noinc();
 	prefetch();
 
 lpb0_acc
+	fatalerror("unhandled opcode %02x%04x: %02x\n", m_codebank, PPC, inst_state);
 	read_pc_noinc();
 	prefetch();
 
 spb1_acc
+	fatalerror("unhandled opcode %02x%04x: %02x\n", m_codebank, PPC, inst_state);
 	read_pc_noinc();
 	prefetch();
 
 lpb1_acc
+	fatalerror("unhandled opcode %02x%04x: %02x\n", m_codebank, PPC, inst_state);
 	read_pc_noinc();
 	prefetch();
 
 spb2_acc
+	fatalerror("unhandled opcode %02x%04x: %02x\n", m_codebank, PPC, inst_state);
 	read_pc_noinc();
 	prefetch();
 
 lpb2_acc
+	fatalerror("unhandled opcode %02x%04x: %02x\n", m_codebank, PPC, inst_state);
 	read_pc_noinc();
 	prefetch();
 
 incpa_imp
+	fatalerror("unhandled opcode %02x%04x: %02x\n", m_codebank, PPC, inst_state);
 	read_pc_noinc();
 	prefetch();
 
 incpb_imp
+	fatalerror("unhandled opcode %02x%04x: %02x\n", m_codebank, PPC, inst_state);
 	read_pc_noinc();
 	prefetch();
 
 decpa_imp
+	fatalerror("unhandled opcode %02x%04x: %02x\n", m_codebank, PPC, inst_state);
 	read_pc_noinc();
 	prefetch();
 
 decpb_imp
+	fatalerror("unhandled opcode %02x%04x: %02x\n", m_codebank, PPC, inst_state);
 	read_pc_noinc();
 	prefetch();
 
 orapa_imp
+	fatalerror("unhandled opcode %02x%04x: %02x\n", m_codebank, PPC, inst_state);
 	read_pc_noinc();
 	prefetch();
 
 andpa_imp
+	fatalerror("unhandled opcode %02x%04x: %02x\n", m_codebank, PPC, inst_state);
 	read_pc_noinc();
 	prefetch();
 
 eorpa_imp
+	fatalerror("unhandled opcode %02x%04x: %02x\n", m_codebank, PPC, inst_state);
 	read_pc_noinc();
 	prefetch();
 
 adcpa_imp
+	fatalerror("unhandled opcode %02x%04x: %02x\n", m_codebank, PPC, inst_state);
 	read_pc_noinc();
 	prefetch();
 
 stapa_imp
+	fatalerror("unhandled opcode %02x%04x: %02x\n", m_codebank, PPC, inst_state);
 	read_pc_noinc();
 	prefetch();
 
 ldapa_imp
+	fatalerror("unhandled opcode %02x%04x: %02x\n", m_codebank, PPC, inst_state);
 	read_pc_noinc();
 	prefetch();
 
 cmppa_imp
+	fatalerror("unhandled opcode %02x%04x: %02x\n", m_codebank, PPC, inst_state);
 	read_pc_noinc();
 	prefetch();
 
 sbcpa_imp
+	fatalerror("unhandled opcode %02x%04x: %02x\n", m_codebank, PPC, inst_state);
 	read_pc_noinc();
 	prefetch();
 	
 orapb_imp
+	fatalerror("unhandled opcode %02x%04x: %02x\n", m_codebank, PPC, inst_state);
 	read_pc_noinc();
 	prefetch();
 
 andpb_imp
+	fatalerror("unhandled opcode %02x%04x: %02x\n", m_codebank, PPC, inst_state);
 	read_pc_noinc();
 	prefetch();
 
 eorpb_imp
+	fatalerror("unhandled opcode %02x%04x: %02x\n", m_codebank, PPC, inst_state);
 	read_pc_noinc();
 	prefetch();
 
 adcpb_imp
+	fatalerror("unhandled opcode %02x%04x: %02x\n", m_codebank, PPC, inst_state);
 	read_pc_noinc();
 	prefetch();
 
 stapb_imp
+	fatalerror("unhandled opcode %02x%04x: %02x\n", m_codebank, PPC, inst_state);
 	read_pc_noinc();
 	prefetch();
 
 ldapb_imp
+	fatalerror("unhandled opcode %02x%04x: %02x\n", m_codebank, PPC, inst_state);
 	read_pc_noinc();
 	prefetch();
 
 cmppb_imp
+	fatalerror("unhandled opcode %02x%04x: %02x\n", m_codebank, PPC, inst_state);
 	read_pc_noinc();
 	prefetch();
 
 sbcpb_imp
+	fatalerror("unhandled opcode %02x%04x: %02x\n", m_codebank, PPC, inst_state);
 	read_pc_noinc();
 	prefetch();
 
+stx_aby
+	fatalerror("unhandled opcode %02x%04x: %02x\n", m_codebank, PPC, inst_state);
+	read_pc_noinc();
+	prefetch();
+
+sty_abx
+	fatalerror("unhandled opcode %02x%04x: %02x\n", m_codebank, PPC, inst_state);
+	read_pc_noinc();
+	prefetch();
+
+stz_zpg
+	fatalerror("unhandled opcode %02x%04x: %02x\n", m_codebank, PPC, inst_state);
+	read_pc_noinc();
+	prefetch();
+
+stz_aba
+	fatalerror("unhandled opcode %02x%04x: %02x\n", m_codebank, PPC, inst_state);
+	read_pc_noinc();
+	prefetch();
+
+bit_zpx
+	fatalerror("unhandled opcode %02x%04x: %02x\n", m_codebank, PPC, inst_state);
+	read_pc_noinc();
+	prefetch();
+
+bit_abx
+	fatalerror("unhandled opcode %02x%04x: %02x\n", m_codebank, PPC, inst_state);
+	read_pc_noinc();
+	prefetch();
+
+bit_imm
+	fatalerror("unhandled opcode %02x%04x: %02x\n", m_codebank, PPC, inst_state);
+	read_pc_noinc();
+	prefetch();
+
+asr_zpg
+	fatalerror("unhandled opcode %02x%04x: %02x\n", m_codebank, PPC, inst_state);
+	read_pc_noinc();
+	prefetch();
+
+asr_aba
+	fatalerror("unhandled opcode %02x%04x: %02x\n", m_codebank, PPC, inst_state);
+	read_pc_noinc();
+	prefetch();
+
+asr_zpx
+	fatalerror("unhandled opcode %02x%04x: %02x\n", m_codebank, PPC, inst_state);
+	read_pc_noinc();
+	prefetch();
+
+asr_acc
+	fatalerror("unhandled opcode %02x%04x: %02x\n", m_codebank, PPC, inst_state);
+	read_pc_noinc();
+	prefetch();
+
+asr_abx
+	fatalerror("unhandled opcode %02x%04x: %02x\n", m_codebank, PPC, inst_state);
+	read_pc_noinc();
+	prefetch();
+
+cmc_imp
+	fatalerror("unhandled opcode %02x%04x: %02x\n", m_codebank, PPC, inst_state);
+	read_pc_noinc();
+	prefetch();
+
+sev_imp
+	fatalerror("unhandled opcode %02x%04x: %02x\n", m_codebank, PPC, inst_state);
+	read_pc_noinc();
+	prefetch();
+
+callf_aba
+	fatalerror("unhandled opcode %02x%04x: %02x\n", m_codebank, PPC, inst_state);
+	read_pc_noinc();
+	prefetch();
+
+callf_ind
+	fatalerror("unhandled opcode %02x%04x: %02x\n", m_codebank, PPC, inst_state);
+	read_pc_noinc();
+	prefetch();

--- a/src/devices/cpu/m6502/oxavix2000.lst
+++ b/src/devices/cpu/m6502/oxavix2000.lst
@@ -7,12 +7,6 @@ unh_imp
 	read_pc_noinc();
 	prefetch();
 
-clr_acc
-	read_pc_noinc();
-	A = 0;
-	set_nz(A);
-	prefetch();
-
 phy_imp
 	read_pc_noinc();
 	write(SP, Y);
@@ -40,3 +34,265 @@ ply_imp
 	Y = read(SP);
 	set_nz(Y);
 	prefetch();
+
+clrl_imp
+	read_pc_noinc();
+	m_l = 0;
+	prefetch();
+
+oral0_acc
+	read_pc_noinc();
+	prefetch();
+
+oral1_acc
+	read_pc_noinc();
+	prefetch();
+
+oral2_acc
+	read_pc_noinc();
+	prefetch();
+
+oral3_acc
+	read_pc_noinc();
+	prefetch();
+
+andl0_acc
+	read_pc_noinc();
+	prefetch();
+
+andl1_acc
+	read_pc_noinc();
+	prefetch();
+
+andl2_acc
+	read_pc_noinc();
+	prefetch();
+
+andl3_acc
+	read_pc_noinc();
+	prefetch();
+
+eorl0_acc
+	read_pc_noinc();
+	prefetch();
+
+eorl1_acc
+	read_pc_noinc();
+	prefetch();
+
+eorl2_acc
+	read_pc_noinc();
+	prefetch();
+
+eorl3_acc
+	read_pc_noinc();
+	prefetch();
+
+adcl0_acc
+	read_pc_noinc();
+	prefetch();
+
+adcl1_acc
+	read_pc_noinc();
+	prefetch();
+
+adcl2_acc
+	read_pc_noinc();
+	prefetch();
+
+adcl3_acc
+	read_pc_noinc();
+	prefetch();
+	
+stal0_acc
+	read_pc_noinc();
+	prefetch();
+
+stal1_acc
+	read_pc_noinc();
+	prefetch();
+
+stal2_acc
+	read_pc_noinc();
+	prefetch();
+
+stal3_acc
+	read_pc_noinc();
+	prefetch();
+
+ldal0_acc
+	read_pc_noinc();
+	prefetch();
+
+ldal1_acc
+	read_pc_noinc();
+	prefetch();
+
+ldal2_acc
+	read_pc_noinc();
+	prefetch();
+
+ldal3_acc
+	read_pc_noinc();
+	prefetch();
+
+cmpl0_acc
+	read_pc_noinc();
+	prefetch();
+
+cmpl1_acc
+	read_pc_noinc();
+	prefetch();
+
+cmpl2_acc
+	read_pc_noinc();
+	prefetch();
+
+cmpl3_acc
+	read_pc_noinc();
+	prefetch();
+
+sbcl0_acc
+	read_pc_noinc();
+	prefetch();
+
+sbcl1_acc
+	read_pc_noinc();
+	prefetch();
+
+sbcl2_acc
+	read_pc_noinc();
+	prefetch();
+
+sbcl3_acc
+	read_pc_noinc();
+	prefetch();
+
+spa0_acc
+	read_pc_noinc();
+	prefetch();
+
+lpa0_acc
+	read_pc_noinc();
+	prefetch();
+
+spa1_acc
+	read_pc_noinc();
+	prefetch();
+
+lpa1_acc
+	read_pc_noinc();
+	prefetch();
+	
+spa2_acc
+	read_pc_noinc();
+	prefetch();
+
+lpa2_acc
+	read_pc_noinc();
+	prefetch();
+
+spb0_acc
+	read_pc_noinc();
+	prefetch();
+
+lpb0_acc
+	read_pc_noinc();
+	prefetch();
+
+spb1_acc
+	read_pc_noinc();
+	prefetch();
+
+lpb1_acc
+	read_pc_noinc();
+	prefetch();
+
+spb2_acc
+	read_pc_noinc();
+	prefetch();
+
+lpb2_acc
+	read_pc_noinc();
+	prefetch();
+
+incpa_imp
+	read_pc_noinc();
+	prefetch();
+
+incpb_imp
+	read_pc_noinc();
+	prefetch();
+
+decpa_imp
+	read_pc_noinc();
+	prefetch();
+
+decpb_imp
+	read_pc_noinc();
+	prefetch();
+
+orapa_imp
+	read_pc_noinc();
+	prefetch();
+
+andpa_imp
+	read_pc_noinc();
+	prefetch();
+
+eorpa_imp
+	read_pc_noinc();
+	prefetch();
+
+adcpa_imp
+	read_pc_noinc();
+	prefetch();
+
+stapa_imp
+	read_pc_noinc();
+	prefetch();
+
+ldapa_imp
+	read_pc_noinc();
+	prefetch();
+
+cmppa_imp
+	read_pc_noinc();
+	prefetch();
+
+sbcpa_imp
+	read_pc_noinc();
+	prefetch();
+	
+orapb_imp
+	read_pc_noinc();
+	prefetch();
+
+andpb_imp
+	read_pc_noinc();
+	prefetch();
+
+eorpb_imp
+	read_pc_noinc();
+	prefetch();
+
+adcpb_imp
+	read_pc_noinc();
+	prefetch();
+
+stapb_imp
+	read_pc_noinc();
+	prefetch();
+
+ldapb_imp
+	read_pc_noinc();
+	prefetch();
+
+cmppb_imp
+	read_pc_noinc();
+	prefetch();
+
+sbcpb_imp
+	read_pc_noinc();
+	prefetch();
+

--- a/src/devices/cpu/m6502/oxavix2000.lst
+++ b/src/devices/cpu/m6502/oxavix2000.lst
@@ -40,6 +40,22 @@ clrl_imp
 	m_l = 0;
 	prefetch();
 
+decl_imp
+	read_pc_noinc();
+	prefetch();
+
+notl_imp
+	read_pc_noinc();
+	prefetch();
+
+incl_imp
+	read_pc_noinc();
+	prefetch();
+
+negl_imp
+	read_pc_noinc();
+	prefetch();
+
 oral0_acc
 	read_pc_noinc();
 	prefetch();

--- a/src/devices/cpu/m6502/xavix2000.cpp
+++ b/src/devices/cpu/m6502/xavix2000.cpp
@@ -26,6 +26,7 @@
     meaning for one specific function on startup
 
 	this just seems to be some very buggy checksum code where the games don't even care about the result...
+	(actually it looks like some games might be using it as a PRNG seed?)
 
 	a is 80 when entering here?
 

--- a/src/devices/cpu/m6502/xavix2000.h
+++ b/src/devices/cpu/m6502/xavix2000.h
@@ -25,8 +25,7 @@ public:
 
 #define O(o) void o ## _full(); void o ## _partial()
 
-	// xaviv opcodes
-	O(unh_imp);
+	// Super XaviX opcodes
 
 	O(phx_imp); // 12
 	O(phy_imp); // 52
@@ -116,6 +115,28 @@ public:
 	O(ldapb_imp); // (lda ($PB), y) ?
 	O(cmppb_imp); // (cmp ($PB), y) ?
 	O(sbcpb_imp); // (sbc ($PB), y) ?
+
+	O(stx_aby);
+	O(sty_abx);
+
+	O(stz_aba);
+	O(stz_zpg);
+
+	O(bit_zpx);
+	O(bit_abx);
+	O(bit_imm);
+
+	O(asr_zpg);
+	O(asr_aba);
+	O(asr_zpx);
+	O(asr_acc);
+	O(asr_abx);
+
+	O(cmc_imp);
+	O(sev_imp);
+
+	O(callf_aba);
+	O(callf_ind);
 
 #undef O
 

--- a/src/devices/cpu/m6502/xavix2000.h
+++ b/src/devices/cpu/m6502/xavix2000.h
@@ -33,9 +33,91 @@ public:
 	O(plx_imp); // 32
 	O(ply_imp); // 72
 
-	O(clr_acc); // b2
+	O(clrl_imp); // b2
+	
+	O(oral0_acc);
+	O(oral1_acc);
+	O(oral2_acc);
+	O(oral3_acc);
+
+	O(andl0_acc);
+	O(andl1_acc);
+	O(andl2_acc);
+	O(andl3_acc);
+
+	O(eorl0_acc);
+	O(eorl1_acc);
+	O(eorl2_acc);
+	O(eorl3_acc);
+
+	O(adcl0_acc);
+	O(adcl1_acc);
+	O(adcl2_acc);
+	O(adcl3_acc);
+	
+	O(stal0_acc);
+	O(stal1_acc);
+	O(stal2_acc);
+	O(stal3_acc);
+
+	O(ldal0_acc);
+	O(ldal1_acc);
+	O(ldal2_acc);
+	O(ldal3_acc);
+
+	O(cmpl0_acc);
+	O(cmpl1_acc);
+	O(cmpl2_acc);
+	O(cmpl3_acc);
+
+	O(sbcl0_acc);
+	O(sbcl1_acc);
+	O(sbcl2_acc);
+	O(sbcl3_acc);
+
+	O(spa2_acc); // Store accumulator in 24-bit address register PA MSB (Bank bit)
+	O(lpa2_acc); // Load accumulator from 24-bit address register PA MSB (Bank bit)
+	O(spa0_acc); // Store accumulator in 24-bit address register PA LSB (Low 8 bits of address)
+	O(lpa0_acc); // Load accumulator from 24-bit address register PA LSB (Low 8 bits of address)
+	O(spa1_acc); // Store accumulator in 24-bit address register PA MID (High 8 bits of address)
+	O(lpa1_acc); // Load accumulator from 24-bit address register PA MID (High 8 bits of address)
+
+	O(spb2_acc); // Store accumulator in 24-bit address register PB MSB (Bank bit)
+	O(lpb2_acc); // Load accumulator from 24-bit address register PB MSB (Bank bit)
+	O(spb0_acc); // Store accumulator in 24-bit address register PB LSB (Low 8 bits of address)
+	O(lpb0_acc); // Load accumulator from 24-bit address register PB LSB (Low 8 bits of address)
+	O(spb1_acc); // Store accumulator in 24-bit address register PB MID (High 8 bits of address)
+	O(lpb1_acc); // Load accumulator from 24-bit address register PB MID (High 8 bits of address)
+
+	O(incpa_imp);
+	O(decpa_imp);
+
+	O(incpb_imp);
+	O(decpb_imp);
+
+	O(orapa_imp); // (ora ($PA), y) ?
+	O(andpa_imp); // (and ($PA), y) ?
+	O(eorpa_imp); // (eor ($PA), y) ?
+	O(adcpa_imp); // (adc ($PA), y) ?
+	O(stapa_imp); // (sta ($PA), y) ?
+	O(ldapa_imp); // (lda ($PA), y) ?
+	O(cmppa_imp); // (cmp ($PA), y) ?
+	O(sbcpa_imp); // (sbc ($PA), y) ?
+
+	O(orapb_imp); // (ora ($PB), y) ?
+	O(andpb_imp); // (and ($PB), y) ?
+	O(eorpb_imp); // (eor ($PB), y) ?
+	O(adcpb_imp); // (adc ($PB), y) ?
+	O(stapb_imp); // (sta ($PB), y) ?
+	O(ldapb_imp); // (lda ($PB), y) ?
+	O(cmppb_imp); // (cmp ($PB), y) ?
+	O(sbcpb_imp); // (sbc ($PB), y) ?
 
 #undef O
+
+	uint32_t m_l; // 32-bit register?
+	uint32_t m_pa; // 24-bit address register?
+	uint32_t m_pb; // ^
 
 };
 

--- a/src/devices/cpu/m6502/xavix2000.h
+++ b/src/devices/cpu/m6502/xavix2000.h
@@ -34,7 +34,11 @@ public:
 	O(ply_imp); // 72
 
 	O(clrl_imp); // b2
-	
+	O(decl_imp); // c2
+	O(notl_imp); // d2
+	O(incl_imp); // e2
+	O(negl_imp); // f2
+
 	O(oral0_acc);
 	O(oral1_acc);
 	O(oral2_acc);


### PR DESCRIPTION
(it borrows quite a few mapping / ideas from the 65816 but does things differently, so stubby handlers for now)