### PR TITLE
hp9k3xx/human_interface: add parallel poll logic

### DIFF
--- a/src/devices/bus/hp_dio/human_interface.cpp
+++ b/src/devices/bus/hp_dio/human_interface.cpp
@@ -80,6 +80,7 @@ void human_interface_device::device_add_mconfig(machine_config &config)
 	ieee488.srq_callback().set(m_tms9914, FUNC(tms9914_device::srq_w));
 	ieee488.atn_callback().set(m_tms9914, FUNC(tms9914_device::atn_w));
 	ieee488.ren_callback().set(m_tms9914, FUNC(tms9914_device::ren_w));
+	ieee488.dio_callback().set(FUNC(human_interface_device::ieee488_dio_w));
 
 	ieee488_slot_device &slot0(IEEE488_SLOT(config, "ieee0", 0));
 	hp_ieee488_devices(slot0);
@@ -113,7 +114,8 @@ human_interface_device::human_interface_device(const machine_config &mconfig, de
 	m_mlc(*this, "mlc"),
 	m_sound(*this, "sn76494"),
 	m_tms9914(*this, "tms9914"),
-	m_rtc(*this, "rtc")
+	m_rtc(*this, "rtc"),
+	m_ieee488(*this, IEEE488_TAG)
 {
 }
 
@@ -129,15 +131,20 @@ void human_interface_device::device_start()
 
 	save_item(NAME(m_hil_read));
 	save_item(NAME(m_kbd_nmi));
-	save_item(NAME(gpib_irq_line));
+	save_item(NAME(m_gpib_irq_line));
 	save_item(NAME(m_old_latch_enable));
 	save_item(NAME(m_hil_data));
 	save_item(NAME(m_latch_data));
 	save_item(NAME(m_rtc_data));
+	save_item(NAME(m_ppoll_mask));
+	save_item(NAME(m_ppoll_sc));
 }
 
 void human_interface_device::device_reset()
 {
+	m_ppoll_sc = 0;
+	m_gpib_irq_line = false;
+	m_kbd_nmi = false;
 	m_rtc->cs1_w(ASSERT_LINE);
 	m_rtc->cs2_w(CLEAR_LINE);
 	m_rtc->write_w(CLEAR_LINE);
@@ -151,10 +158,16 @@ WRITE_LINE_MEMBER(human_interface_device::reset_in)
 	if (state)
 		device_reset();
 }
+
+void human_interface_device::update_gpib_irq()
+{
+	irq3_out((m_gpib_irq_line || (m_ppoll_sc & PPOLL_IR)) ? ASSERT_LINE : CLEAR_LINE);
+}
+
 WRITE_LINE_MEMBER(human_interface_device::gpib_irq)
 {
-	gpib_irq_line = state;
-	irq3_out(state ? ASSERT_LINE : CLEAR_LINE);
+	m_gpib_irq_line = state;
+	update_gpib_irq();
 }
 
 WRITE_LINE_MEMBER(human_interface_device::gpib_dreq)
@@ -162,11 +175,46 @@ WRITE_LINE_MEMBER(human_interface_device::gpib_dreq)
 	dmar0_out(state);
 }
 
+WRITE8_MEMBER(human_interface_device::ieee488_dio_w)
+{
+	if ((m_ppoll_mask & ~data) && (m_ppoll_sc & PPOLL_IE)) {
+		LOG("%s: PPOLL triggered\n");
+		m_ieee488->host_atn_w(1);
+		m_ieee488->host_eoi_w(1);
+		m_ppoll_sc |= PPOLL_IR;
+		update_gpib_irq();
+	}
+}
+
 WRITE8_MEMBER(human_interface_device::gpib_w)
 {
 	if (offset & 0x08) {
 		m_tms9914->reg8_w(space, offset & 0x07, data);
 		return;
+	}
+
+	switch (offset) {
+	case 0:
+		device_reset();
+		break;
+
+	case 3:
+		m_ppoll_sc = data & PPOLL_IE;
+
+		if (!(data & PPOLL_IR)) {
+			m_ppoll_sc &= ~PPOLL_IR;
+			update_gpib_irq();
+		}
+
+		if (m_ppoll_sc & PPOLL_IE) {
+			LOG("%s: start parallel poll\n", __func__);
+			m_ieee488->host_atn_w(0);
+			m_ieee488->host_eoi_w(0);
+		}
+		break;
+	case 4:
+		m_ppoll_mask = data;
+		break;
 	}
 	LOG("gpib_w: %s %02X = %02X\n", machine().describe_context().c_str(), offset, data);
 }
@@ -186,13 +234,21 @@ READ8_MEMBER(human_interface_device::gpib_r)
 		break;
 	case 1:
 		/* Int control */
-		data = 0x80 | (gpib_irq_line ? 0x40 : 0);
+		data = 0x80 | (m_gpib_irq_line ? 0x40 : 0);
 		break;
 	case 2:
 		/* Address */
 		data = (m_tms9914->cont_r() ? 0x0 : 0x40) | 0x81;
 		if (m_kbd_nmi)
 			data |= 0x04;
+		break;
+	case 3:
+		/* Parallel poll status/control */
+		data = m_ppoll_sc;
+		break;
+	case 4:
+		/* Parallel poll mask */
+		data = m_ppoll_mask;
 		break;
 	}
 	LOG("gpib_r: %s %02X = %02X\n", machine().describe_context().c_str(), offset, data);

--- a/src/devices/bus/hp_dio/human_interface.h
+++ b/src/devices/bus/hp_dio/human_interface.h
@@ -13,7 +13,7 @@
 #include "sound/sn76496.h"
 #include "bus/hp_hil/hp_hil.h"
 #include "bus/hp_hil/hil_devices.h"
-
+#include "bus/ieee488/ieee488.h"
 namespace bus {
 	namespace hp_dio {
 class human_interface_device :
@@ -43,6 +43,7 @@ private:
 	/* GPIB */
 	DECLARE_READ8_MEMBER(gpib_r);
 	DECLARE_WRITE8_MEMBER(gpib_w);
+	DECLARE_WRITE8_MEMBER(ieee488_dio_w);
 
 	DECLARE_WRITE_LINE_MEMBER(gpib_irq);
 	DECLARE_WRITE_LINE_MEMBER(gpib_dreq);
@@ -57,12 +58,14 @@ private:
 
 	void dmack_w_in(int channel, uint8_t data) override;
 	uint8_t dmack_r_in(int channel) override;
+	void update_gpib_irq();
 
 	required_device<i8042_device> m_iocpu;
 	required_device<hp_hil_mlc_device> m_mlc;
 	required_device<sn76494_device> m_sound;
 	required_device<tms9914_device> m_tms9914;
 	required_device<msm58321_device> m_rtc;
+	required_device<ieee488_device> m_ieee488;
 
 	void iocpu_map(address_map &map);
 
@@ -73,17 +76,20 @@ private:
 	static constexpr uint8_t KBD_RESET = 0x40;
 	static constexpr uint8_t SN76494_EN = 0x80;
 
+	static constexpr uint8_t PPOLL_IE = 0x80;
+	static constexpr uint8_t PPOLL_IR = 0x40;
+
 	bool m_hil_read;
 	bool m_kbd_nmi;
 
-	bool gpib_irq_line;
+	bool m_gpib_irq_line;
 	bool m_old_latch_enable;
 
 	uint8_t m_hil_data;
 	uint8_t m_latch_data;
 	uint8_t m_rtc_data;
-
-
+	uint8_t m_ppoll_sc;
+	uint8_t m_ppoll_mask;
 };
 }
 }


### PR DESCRIPTION
This makes the HP-UX 9 installer properly work with GPIB. Without
this patch it will hang ages during detection of GPIB devices. With
this patch i was able to successfully install HP-UX on hp9k_3xx.