### PR TITLE
m68kmmu: split m68881_ops() into subfunctions

### DIFF
--- a/src/devices/cpu/m68000/m68k_in.cpp
+++ b/src/devices/cpu/m68000/m68k_in.cpp
@@ -8258,7 +8258,7 @@ M68KMAKE_OP(pmmu, 32, ., .)
 {
 	if ((CPU_TYPE_IS_EC020_PLUS()) && (m_has_pmmu))
 	{
-		m68881_mmu_ops();
+		m68851_mmu_ops();
 	}
 	else
 	{


### PR DESCRIPTION
Makes it easier to maintain. Should not introduce any functional change.