### PR TITLE
Added color overlay to Yosaku To Donbei

### DIFF
--- a/src/mame/drivers/8080bw.cpp
+++ b/src/mame/drivers/8080bw.cpp
@@ -207,6 +207,7 @@
 #include "gunchamp.lh"
 #include "shuttlei.lh"
 #include "spacecom.lh"
+#include "yosakdon.lh"
 
 
 /*******************************************************/
@@ -4989,6 +4990,8 @@ ROM_START( yosakdon )
 	ROM_LOAD( "yd5.bin",      0x1400, 0x0400, CRC(38804ff1) SHA1(9b7527b9d2b106355f0c8df46666b1e3f286b2e3) )
 	ROM_LOAD( "yd6.bin",      0x1800, 0x0400, CRC(988d2362) SHA1(deaf864b4e287cbc2585c2a11343b1ae82e15463) )
 	ROM_LOAD( "yd7.bin",      0x1c00, 0x0400, CRC(2744e68b) SHA1(5ad5a7a615d36f57b6d560425e035c15e25e9005) )
+
+	/* No proms, only colour overlay */
 ROM_END
 
 ROM_START( yosakdona )
@@ -5000,6 +5003,8 @@ ROM_START( yosakdona )
 	ROM_LOAD( "yosaku5",      0x1400, 0x0400, CRC(ae422a43) SHA1(5219680f9d6c5d984b29167f85106fa375856121) )
 	ROM_LOAD( "yosaku6",      0x1800, 0x0400, CRC(26b24a12) SHA1(387589fa4027d41b6fb06555661d4f92fe2f990c) )
 	ROM_LOAD( "yosaku7",      0x1c00, 0x0400, CRC(878d5a18) SHA1(6adc8763d5644602eed7fe6d9186a48be105aace) )
+
+	/* No proms, only colour overlay */
 ROM_END
 
 ROM_START( indianbt )
@@ -5259,8 +5264,8 @@ GAME( 1979, ozmawarsmr,  ozmawars, invaders,  ozmawars,  mw8080bw_state, empty_i
 GAME( 1979, spaceph,     ozmawars, invaders,  spaceph,   mw8080bw_state, empty_init,    ROT270, "bootleg? (Zilec Games)", "Space Phantoms (bootleg of Ozma Wars)", MACHINE_SUPPORTS_SAVE )
 GAME( 1979, solfight,    ozmawars, invaders,  ozmawars,  mw8080bw_state, empty_init,    ROT270, "bootleg", "Solar Fight (bootleg of Ozma Wars)", MACHINE_SUPPORTS_SAVE )
 
-GAME( 1979, yosakdon,    0,        yosakdon,  yosakdon,  _8080bw_state,  empty_init,    ROT270, "Wing", "Yosaku To Donbei (set 1)", MACHINE_SUPPORTS_SAVE | MACHINE_IMPERFECT_SOUND )
-GAME( 1979, yosakdona,   yosakdon, yosakdon,  yosakdon,  _8080bw_state,  empty_init,    ROT270, "Wing", "Yosaku To Donbei (set 2)", MACHINE_SUPPORTS_SAVE | MACHINE_IMPERFECT_SOUND )
+GAMEL( 1979,yosakdon,    0,        yosakdon,  yosakdon,  _8080bw_state,  empty_init,    ROT270, "Wing", "Yosaku To Donbei (set 1)", MACHINE_SUPPORTS_SAVE | MACHINE_IMPERFECT_SOUND, layout_yosakdon )
+GAMEL( 1979,yosakdona,   yosakdon, yosakdon,  yosakdon,  _8080bw_state,  empty_init,    ROT270, "Wing", "Yosaku To Donbei (set 2)", MACHINE_SUPPORTS_SAVE | MACHINE_IMPERFECT_SOUND, layout_yosakdon )
 
 GAMEL(1979, shuttlei,    0,        shuttlei,  shuttlei,  _8080bw_state,  empty_init,    ROT270, "Omori Electric Co., Ltd.", "Shuttle Invader", MACHINE_SUPPORTS_SAVE | MACHINE_IMPERFECT_SOUND, layout_shuttlei )
 

--- a/src/mame/layout/yosakdon.lay
+++ b/src/mame/layout/yosakdon.lay
@@ -1,0 +1,82 @@
+<?xml version="1.0"?>
+<mamelayout version="2">
+	<element name="overlay">
+		<rect>
+			<bounds left="0" top="0" right="74" bottom="16" />
+			<color red="0.125" green="1.0" blue="1.0" />
+		</rect>
+		<rect>
+			<bounds left="75" top="0" right="146" bottom="16" />
+			<color red="0.25" green="1.0" blue="0.2" />
+		</rect>
+		<rect>
+			<bounds left="147" top="0" right="224" bottom="16" />
+			<color red="1.0" green="0.125" blue="1.0" />
+		</rect>
+		<rect>
+			<bounds left="0" top="17" right="74" bottom="32" />
+			<color red="1.0" green="1.0" blue="1.0" />
+		</rect>
+		<rect>
+			<bounds left="75" top="17" right="146" bottom="32" />
+			<color red="0.25" green="1.0" blue="0.2" />
+		</rect>
+		<rect>
+			<bounds left="147" top="17" right="224" bottom="32" />
+			<color red="1.0" green="1.0" blue="1.0" />
+		</rect>
+		<rect>
+			<bounds left="0" top="33" right="224" bottom="56" />
+			<color red="0.25" green="1.0" blue="0.2" />
+		</rect>
+		<rect>
+			<bounds left="0" top="57" right="224" bottom="96" />
+			<color red="0.52" green="0.74" blue="0.97" />
+		</rect>
+		<rect>
+			<bounds left="0" top="96" right="224" bottom="127" />
+			<color red="0.125" green="1.0" blue="1.0" />
+		</rect>
+		<rect>
+			<bounds left="0" top="128" right="224" bottom="159" />
+			<color red="1.0" green="0.9" blue="0.1" />
+		</rect>
+		<rect>
+			<bounds left="0" top="160" right="224" bottom="191" />
+			<color red="1.0" green="0.125" blue="1.0" />
+		</rect>
+		<rect>
+			<bounds left="0" top="191" right="224" bottom="215" />
+			<color red="1.0" green="0.25" blue="0.25" />
+		</rect>
+		<rect>
+			<bounds left="0" top="216" right="224" bottom="231" />
+			<color red="0.125" green="1.0" blue="1.0" />
+		</rect>
+		<rect>
+			<bounds left="0" top="232" right="224" bottom="239" />
+			<color red="1.0" green="0.25" blue="0.25" />
+		</rect>
+		<rect>
+			<bounds left="0" top="240" right="130" bottom="259" />
+			<color red="0.125" green="1.0" blue="1.0" />
+		</rect>
+		<rect>
+			<bounds left="131" top="240" right="186" bottom="259" />
+			<color red="1.0" green="1.0" blue="0.125" />
+		</rect>
+		<rect>
+			<bounds left="187" top="240" right="224" bottom="259" />
+			<color red="0.125" green="1.0" blue="1.0" />
+		</rect>
+	</element>
+
+	<view name="Color_Overlay">
+		<screen index="0">
+			<bounds x="0" y="0" width="3" height="4" />
+		</screen>
+		<overlay element="overlay">
+			<bounds x="0" y="0" width="3" height="4" />
+		</overlay>
+	</view>
+</mamelayout>


### PR DESCRIPTION
I use this YouTube video: https://youtu.be/3jVR50cqXCM found by MetalGod (https://mametesters.org/view.php?id=7126)
and several screenshots of yosakdon from MAME 0.36b16 to get the color position in the picture.
Example: http://www.mameworld.info/mameinfo/download/yosakdon-MAME_036b16.png