### PR TITLE
m68kdasm: fix ptest instruction (nw)

### DIFF
--- a/src/devices/cpu/m68000/m68kdasm.cpp
+++ b/src/devices/cpu/m68000/m68kdasm.cpp
@@ -3005,7 +3005,7 @@ std::string m68k_disassembler::d68851_p000()
 							fc_to_string(modes),
 							str,
 							(modes >> 10) & 7,
-							(modes >> 4) & 7);
+							(modes >> 5) & 7);
 		}
 		else
 		{


### PR DESCRIPTION
There's a slight error in the number of bits in the MC6830 Manual.