### PR TITLE
Document the Tecfri license Pinball Action set

### DIFF
--- a/src/mame/drivers/pbaction.cpp
+++ b/src/mame/drivers/pbaction.cpp
@@ -531,7 +531,7 @@ ROM_START( pbactiont )
 	ROM_REGION( 0x10000, "audiocpu", 0 )    /* 64k for sound board */
 	ROM_LOAD( "pba1.bin",     0x0000,  0x2000, CRC(8b69b933) SHA1(eb0762579d52ed9f5b1a002ffe7e517c59650e22) )
 
-	ROM_REGION( 0x10000, "cpu2", 0 )    /* 64k for a third Z80 (not emulated) */
+	ROM_REGION( 0x10000, "cpu2", 0 )    /* 64k for the 2xZ80 subboard (not emulated) */
 	ROM_LOAD( "pba17.bin",    0x0000,  0x4000, CRC(2734ae60) SHA1(4edcdfac1611c49c4f890609efbe8352b8161f8e) )
 
 	ROM_REGION( 0x06000, "fgchars", 0 )
@@ -551,7 +551,7 @@ ROM_START( pbactiont )
 	ROM_LOAD( "b-f7.bin",     0x04000, 0x2000, CRC(af6e9817) SHA1(56f47d25761b3850c49a3a81b5ea35f12bd77b14) )
 ROM_END
 
-READ8_MEMBER(pbaction_state::pbactio3_prot_kludge_r)
+READ8_MEMBER(pbaction_state::pbaction2_prot_kludge_r)
 {
 	/* on startup, the game expect this location to NOT act as RAM */
 	if (m_maincpu->pc() == 0xab80)
@@ -560,7 +560,7 @@ READ8_MEMBER(pbaction_state::pbactio3_prot_kludge_r)
 	return m_work_ram[0];
 }
 
-void pbaction_state::init_pbactio3()
+void pbaction_state::init_pbaction2()
 {
 	uint8_t *rom = memregion("maincpu")->base();
 
@@ -571,13 +571,13 @@ void pbaction_state::init_pbactio3()
 	}
 
 	/* install a protection (?) workaround */
-	m_maincpu->space(AS_PROGRAM).install_read_handler(0xc000, 0xc000, read8_delegate(FUNC(pbaction_state::pbactio3_prot_kludge_r),this) );
+	m_maincpu->space(AS_PROGRAM).install_read_handler(0xc000, 0xc000, read8_delegate(FUNC(pbaction_state::pbaction2_prot_kludge_r),this) );
 }
 
 
 // some of these are probably bootlegs
-GAME( 1985, pbaction,  0,        pbaction,  pbaction, pbaction_state, empty_init,    ROT90, "Tehkan",                  "Pinball Action (set 1)",            MACHINE_SUPPORTS_SAVE )
-GAME( 1985, pbaction2, pbaction, pbactionx, pbaction, pbaction_state, init_pbactio3, ROT90, "Tehkan",                  "Pinball Action (set 2, encrypted)", MACHINE_SUPPORTS_SAVE )
-GAME( 1985, pbaction3, pbaction, pbactionx, pbaction, pbaction_state, empty_init,    ROT90, "Tehkan",                  "Pinball Action (set 3, encrypted)", MACHINE_SUPPORTS_SAVE )
-GAME( 1985, pbaction4, pbaction, pbactionx, pbaction, pbaction_state, empty_init,    ROT90, "Tehkan",                  "Pinball Action (set 4, encrypted)", MACHINE_SUPPORTS_SAVE )
-GAME( 1985, pbactiont, pbaction, pbactiont, pbaction, pbaction_state, empty_init,    ROT90, "Tehkan (Tecfri license)", "Pinball Action (Tecfri license)",   MACHINE_SUPPORTS_SAVE )
+GAME( 1985, pbaction,  0,        pbaction,  pbaction, pbaction_state, empty_init,     ROT90, "Tehkan",                  "Pinball Action (set 1)",            MACHINE_SUPPORTS_SAVE )
+GAME( 1985, pbaction2, pbaction, pbactionx, pbaction, pbaction_state, init_pbaction2, ROT90, "Tehkan",                  "Pinball Action (set 2, encrypted)", MACHINE_SUPPORTS_SAVE )
+GAME( 1985, pbaction3, pbaction, pbactionx, pbaction, pbaction_state, empty_init,     ROT90, "Tehkan",                  "Pinball Action (set 3, encrypted)", MACHINE_SUPPORTS_SAVE )
+GAME( 1985, pbaction4, pbaction, pbactionx, pbaction, pbaction_state, empty_init,     ROT90, "Tehkan",                  "Pinball Action (set 4, encrypted)", MACHINE_SUPPORTS_SAVE )
+GAME( 1985, pbactiont, pbaction, pbactiont, pbaction, pbaction_state, empty_init,     ROT90, "Tehkan (Tecfri license)", "Pinball Action (Tecfri license)",   MACHINE_SUPPORTS_SAVE )

--- a/src/mame/drivers/pbaction.cpp
+++ b/src/mame/drivers/pbaction.cpp
@@ -31,7 +31,34 @@ e800      command for the sound CPU
 
 
 Notes:
-- pbactio2 has a ROM for a third Z80, not emulated, function unknown
+- pbactiont (Tecfri) has a ROM on a small subboard with two Z80, not hooked up:
+
+ 2-pin conn   12-pin conn
+____||________||||||||||||____________________
+|   ||                       _______________  |
+|                            |Z8430A PS     | |
+|                            |______________| |
+|                              _____________  |
+|                              |TMM2016BP-10| |
+|                              |____________| |
+|               __________   _______________  |
+|               |74HCT273 |  |ROM17 D27128D | |
+|                            |______________| |
+|           _________     __________________  |
+|           |74LS139|     |MK3880N-4 Z80 CPU| |
+|                         |_________________| |
+|           _________     __________________  |
+|           |74HCT259     |MK3880N-4 Z80 CPU| |
+|                         |_________________| |
+|                      _________  _________   |
+|                      |74LS00P | |74LS32P |  |
+|                                             |
+|____________________________TECFRI S.A.______|
+
+This subboard controls a vertical board panel with three 7-seg displays (like on a real pinball),
+one for player 1 (7 digits), another for player 2 (7 digits) and the third for game scores (with
+three goups: two digits - one digit - two digits).
+
 
 
 Stephh's notes (based on the game Z80 code and some tests) :
@@ -140,7 +167,7 @@ void pbaction_state::pbaction_sound_map(address_map &map)
 	map(0xffff, 0xffff).w(FUNC(pbaction_state::sound_irq_ack_w));
 }
 
-void pbaction_state::pbaction2_sound_map(address_map &map)
+void pbaction_state::pbactiont_sound_map(address_map &map)
 {
 	map(0x0000, 0x1fff).rom();
 	map(0x4000, 0x47ff).ram();
@@ -363,15 +390,15 @@ MACHINE_CONFIG_START(pbaction_state::pbaction)
 	MCFG_SOUND_ROUTE(ALL_OUTPUTS, "mono", 0.25)
 MACHINE_CONFIG_END
 
-MACHINE_CONFIG_START(pbaction_state::pbaction2)
+MACHINE_CONFIG_START(pbaction_state::pbactiont)
 	pbaction(config);
 
-	m_audiocpu->set_addrmap(AS_PROGRAM, &pbaction_state::pbaction2_sound_map);
+	m_audiocpu->set_addrmap(AS_PROGRAM, &pbaction_state::pbactiont_sound_map);
 	m_audiocpu->irqack_cb().set(FUNC(pbaction_state::sound_irq_clear));
 MACHINE_CONFIG_END
 
 MACHINE_CONFIG_START(pbaction_state::pbactionx)
-	pbaction2(config);
+	pbactiont(config);
 	MCFG_DEVICE_REPLACE("maincpu", SEGA_315_5128, 4_MHz_XTAL)
 	MCFG_DEVICE_PROGRAM_MAP(pbaction_map)
 	MCFG_DEVICE_OPCODES_MAP(decrypted_opcodes_map)
@@ -412,37 +439,7 @@ ROM_START( pbaction )
 	ROM_LOAD( "b-f7.bin",     0x04000, 0x2000, CRC(af6e9817) SHA1(56f47d25761b3850c49a3a81b5ea35f12bd77b14) )
 ROM_END
 
-
 ROM_START( pbaction2 )
-	ROM_REGION( 0x10000, "maincpu", 0 )
-	ROM_LOAD( "pba16.bin",     0x0000, 0x4000, CRC(4a239ebd) SHA1(74e6da0485ac78093b4f09953fa3accb14bc3e43) )
-	ROM_LOAD( "pba15.bin",     0x4000, 0x4000, CRC(3afef03a) SHA1(dec714415d2fd00c9021171a48f6c94b40888ae8) )
-	ROM_LOAD( "pba14.bin",     0x8000, 0x2000, CRC(c0a98c8a) SHA1(442f37af31db13fd98602dd7f9eeae5529da0f44) )
-
-	ROM_REGION( 0x10000, "audiocpu", 0 )    /* 64k for sound board */
-	ROM_LOAD( "pba1.bin",     0x0000,  0x2000, CRC(8b69b933) SHA1(eb0762579d52ed9f5b1a002ffe7e517c59650e22) )
-
-	ROM_REGION( 0x10000, "cpu2", 0 )    /* 64k for a third Z80 (not emulated) */
-	ROM_LOAD( "pba17.bin",    0x0000,  0x4000, CRC(2734ae60) SHA1(4edcdfac1611c49c4f890609efbe8352b8161f8e) )
-
-	ROM_REGION( 0x06000, "fgchars", 0 )
-	ROM_LOAD( "a-s6.bin",     0x00000, 0x2000, CRC(9a74a8e1) SHA1(bd27439b91f41db3fd7eedb44e828d61b793bda0) )
-	ROM_LOAD( "a-s7.bin",     0x02000, 0x2000, CRC(5ca6ad3c) SHA1(7c8eff087f18cc2ff0572ea45e681a3a1ec94fad) )
-	ROM_LOAD( "a-s8.bin",     0x04000, 0x2000, CRC(9f00b757) SHA1(74b6d926b8f456c8d0101f0232c5d3662423b396) )
-
-	ROM_REGION( 0x10000, "bgchars", 0 )
-	ROM_LOAD( "a-j5.bin",     0x00000, 0x4000, CRC(21efe866) SHA1(0c0a05a26d793ba98b0f421d464ff4b1d301ff9e) )
-	ROM_LOAD( "a-j6.bin",     0x04000, 0x4000, CRC(7f984c80) SHA1(18795ecbcd2da94f1cfcce5559d652388d1b8bc0) )
-	ROM_LOAD( "a-j7.bin",     0x08000, 0x4000, CRC(df69e51b) SHA1(52ab15c63332f0fa98884fa9adc8d35b93c939c4) )
-	ROM_LOAD( "a-j8.bin",     0x0c000, 0x4000, CRC(0094cb8b) SHA1(58f48d24903b797e8451bf231f9e8df621685d9f) )
-
-	ROM_REGION( 0x06000, "sprites", 0 )
-	ROM_LOAD( "b-c7.bin",     0x00000, 0x2000, CRC(d1795ef5) SHA1(69ad8e419e340d2f548468ed7838102789b978da) )
-	ROM_LOAD( "b-d7.bin",     0x02000, 0x2000, CRC(f28df203) SHA1(060f70ed6386c808303a488c97691257681bd8f3) )
-	ROM_LOAD( "b-f7.bin",     0x04000, 0x2000, CRC(af6e9817) SHA1(56f47d25761b3850c49a3a81b5ea35f12bd77b14) )
-ROM_END
-
-ROM_START( pbaction3 )
 	ROM_REGION( 0xc000, "maincpu", 0 )
 	ROM_LOAD( "14.bin",     0x0000, 0x4000, CRC(f17a62eb) SHA1(8dabfc0ad127c154c0293a65df32d52d57dd9755) )
 	ROM_LOAD( "12.bin",     0x4000, 0x4000, CRC(ec3c64c6) SHA1(6130b80606d717f95e219316c2d3fa0a1980ea1d) )
@@ -468,7 +465,7 @@ ROM_START( pbaction3 )
 	ROM_LOAD( "b-f7.bin",     0x04000, 0x2000, CRC(af6e9817) SHA1(56f47d25761b3850c49a3a81b5ea35f12bd77b14) )
 ROM_END
 
-ROM_START( pbaction4 )
+ROM_START( pbaction3 )
 	ROM_REGION( 0xc000, "maincpu", 0 )
 	ROM_LOAD( "pinball_09.bin",     0x0000, 0x4000, CRC(c8e81ece) SHA1(04eafbd79263225f6c6fb5f04951b54179144f17) )
 	ROM_IGNORE(0x4000)
@@ -498,7 +495,7 @@ ROM_START( pbaction4 )
 	ROM_LOAD( "pinball_12.bin",     0x04000, 0x2000, CRC(af6e9817) SHA1(56f47d25761b3850c49a3a81b5ea35f12bd77b14) )
 ROM_END
 
-ROM_START( pbaction5 )
+ROM_START( pbaction4 )
 	ROM_REGION( 0xc000, "maincpu", 0 )
 	ROM_LOAD( "p16.bin",     0x0000, 0x4000, CRC(ad20b360) SHA1(91e3cdceb1c170580d926b2ed8359c3100f71b11) )
 	ROM_LOAD( "c15.bin",     0x4000, 0x4000, CRC(057acfe3) SHA1(49c184d7caea0c0e9f0d0e163f2ef42bb9aebf16) )
@@ -522,6 +519,36 @@ ROM_START( pbaction5 )
 	ROM_LOAD( "p11.bin",     0x00000, 0x2000, CRC(d1795ef5) SHA1(69ad8e419e340d2f548468ed7838102789b978da) )
 	ROM_LOAD( "p12.bin",     0x02000, 0x2000, CRC(f28df203) SHA1(060f70ed6386c808303a488c97691257681bd8f3) )
 	ROM_LOAD( "p13.bin",     0x04000, 0x2000, CRC(af6e9817) SHA1(56f47d25761b3850c49a3a81b5ea35f12bd77b14) )
+ROM_END
+
+// PCB has Tehkan logo (6001-1A/1B) and also "Fabricado por Tecfri S.A. Made in Spain"
+ROM_START( pbactiont )
+	ROM_REGION( 0x10000, "maincpu", 0 )
+	ROM_LOAD( "pba16.bin",     0x0000, 0x4000, CRC(4a239ebd) SHA1(74e6da0485ac78093b4f09953fa3accb14bc3e43) )
+	ROM_LOAD( "pba15.bin",     0x4000, 0x4000, CRC(3afef03a) SHA1(dec714415d2fd00c9021171a48f6c94b40888ae8) )
+	ROM_LOAD( "pba14.bin",     0x8000, 0x2000, CRC(c0a98c8a) SHA1(442f37af31db13fd98602dd7f9eeae5529da0f44) )
+
+	ROM_REGION( 0x10000, "audiocpu", 0 )    /* 64k for sound board */
+	ROM_LOAD( "pba1.bin",     0x0000,  0x2000, CRC(8b69b933) SHA1(eb0762579d52ed9f5b1a002ffe7e517c59650e22) )
+
+	ROM_REGION( 0x10000, "cpu2", 0 )    /* 64k for a third Z80 (not emulated) */
+	ROM_LOAD( "pba17.bin",    0x0000,  0x4000, CRC(2734ae60) SHA1(4edcdfac1611c49c4f890609efbe8352b8161f8e) )
+
+	ROM_REGION( 0x06000, "fgchars", 0 )
+	ROM_LOAD( "a-s6.bin",     0x00000, 0x2000, CRC(9a74a8e1) SHA1(bd27439b91f41db3fd7eedb44e828d61b793bda0) )
+	ROM_LOAD( "a-s7.bin",     0x02000, 0x2000, CRC(5ca6ad3c) SHA1(7c8eff087f18cc2ff0572ea45e681a3a1ec94fad) )
+	ROM_LOAD( "a-s8.bin",     0x04000, 0x2000, CRC(9f00b757) SHA1(74b6d926b8f456c8d0101f0232c5d3662423b396) )
+
+	ROM_REGION( 0x10000, "bgchars", 0 )
+	ROM_LOAD( "a-j5.bin",     0x00000, 0x4000, CRC(21efe866) SHA1(0c0a05a26d793ba98b0f421d464ff4b1d301ff9e) )
+	ROM_LOAD( "a-j6.bin",     0x04000, 0x4000, CRC(7f984c80) SHA1(18795ecbcd2da94f1cfcce5559d652388d1b8bc0) )
+	ROM_LOAD( "a-j7.bin",     0x08000, 0x4000, CRC(df69e51b) SHA1(52ab15c63332f0fa98884fa9adc8d35b93c939c4) )
+	ROM_LOAD( "a-j8.bin",     0x0c000, 0x4000, CRC(0094cb8b) SHA1(58f48d24903b797e8451bf231f9e8df621685d9f) )
+
+	ROM_REGION( 0x06000, "sprites", 0 )
+	ROM_LOAD( "b-c7.bin",     0x00000, 0x2000, CRC(d1795ef5) SHA1(69ad8e419e340d2f548468ed7838102789b978da) )
+	ROM_LOAD( "b-d7.bin",     0x02000, 0x2000, CRC(f28df203) SHA1(060f70ed6386c808303a488c97691257681bd8f3) )
+	ROM_LOAD( "b-f7.bin",     0x04000, 0x2000, CRC(af6e9817) SHA1(56f47d25761b3850c49a3a81b5ea35f12bd77b14) )
 ROM_END
 
 READ8_MEMBER(pbaction_state::pbactio3_prot_kludge_r)
@@ -549,8 +576,8 @@ void pbaction_state::init_pbactio3()
 
 
 // some of these are probably bootlegs
-GAME( 1985, pbaction,  0,        pbaction,  pbaction, pbaction_state, empty_init,    ROT90, "Tehkan", "Pinball Action (set 1)",            MACHINE_SUPPORTS_SAVE )
-GAME( 1985, pbaction2, pbaction, pbaction2, pbaction, pbaction_state, empty_init,    ROT90, "Tehkan", "Pinball Action (set 2)",            MACHINE_SUPPORTS_SAVE )
-GAME( 1985, pbaction3, pbaction, pbactionx, pbaction, pbaction_state, init_pbactio3, ROT90, "Tehkan", "Pinball Action (set 3, encrypted)", MACHINE_SUPPORTS_SAVE )
-GAME( 1985, pbaction4, pbaction, pbactionx, pbaction, pbaction_state, empty_init,    ROT90, "Tehkan", "Pinball Action (set 4, encrypted)", MACHINE_SUPPORTS_SAVE )
-GAME( 1985, pbaction5, pbaction, pbactionx, pbaction, pbaction_state, empty_init,    ROT90, "Tehkan", "Pinball Action (set 5, encrypted)", MACHINE_SUPPORTS_SAVE )
+GAME( 1985, pbaction,  0,        pbaction,  pbaction, pbaction_state, empty_init,    ROT90, "Tehkan",                  "Pinball Action (set 1)",            MACHINE_SUPPORTS_SAVE )
+GAME( 1985, pbaction2, pbaction, pbactionx, pbaction, pbaction_state, init_pbactio3, ROT90, "Tehkan",                  "Pinball Action (set 2, encrypted)", MACHINE_SUPPORTS_SAVE )
+GAME( 1985, pbaction3, pbaction, pbactionx, pbaction, pbaction_state, empty_init,    ROT90, "Tehkan",                  "Pinball Action (set 3, encrypted)", MACHINE_SUPPORTS_SAVE )
+GAME( 1985, pbaction4, pbaction, pbactionx, pbaction, pbaction_state, empty_init,    ROT90, "Tehkan",                  "Pinball Action (set 4, encrypted)", MACHINE_SUPPORTS_SAVE )
+GAME( 1985, pbactiont, pbaction, pbactiont, pbaction, pbaction_state, empty_init,    ROT90, "Tehkan (Tecfri license)", "Pinball Action (Tecfri license)",   MACHINE_SUPPORTS_SAVE )

--- a/src/mame/includes/pbaction.h
+++ b/src/mame/includes/pbaction.h
@@ -77,11 +77,11 @@ public:
 	DECLARE_WRITE_LINE_MEMBER(sound_irq_clear);
 	void draw_sprites( bitmap_ind16 &bitmap, const rectangle &cliprect );
 	void pbaction(machine_config &config);
-	void pbaction2(machine_config &config);
+	void pbactiont(machine_config &config);
 	void pbactionx(machine_config &config);
 	void decrypted_opcodes_map(address_map &map);
 	void pbaction_map(address_map &map);
 	void pbaction_sound_io_map(address_map &map);
 	void pbaction_sound_map(address_map &map);
-	void pbaction2_sound_map(address_map &map);
+	void pbactiont_sound_map(address_map &map);
 };

--- a/src/mame/includes/pbaction.h
+++ b/src/mame/includes/pbaction.h
@@ -58,14 +58,14 @@ public:
 	DECLARE_WRITE8_MEMBER(nmi_mask_w);
 	DECLARE_READ8_MEMBER(sound_data_r);
 	DECLARE_WRITE8_MEMBER(sound_irq_ack_w);
-	DECLARE_READ8_MEMBER(pbactio3_prot_kludge_r);
+	DECLARE_READ8_MEMBER(pbaction2_prot_kludge_r);
 	DECLARE_WRITE8_MEMBER(pbaction_videoram_w);
 	DECLARE_WRITE8_MEMBER(pbaction_colorram_w);
 	DECLARE_WRITE8_MEMBER(pbaction_videoram2_w);
 	DECLARE_WRITE8_MEMBER(pbaction_colorram2_w);
 	DECLARE_WRITE8_MEMBER(pbaction_scroll_w);
 	DECLARE_WRITE8_MEMBER(pbaction_flipscreen_w);
-	void init_pbactio3();
+	void init_pbaction2();
 	TILE_GET_INFO_MEMBER(get_bg_tile_info);
 	TILE_GET_INFO_MEMBER(get_fg_tile_info);
 	virtual void machine_start() override;

--- a/src/mame/mame.lst
+++ b/src/mame/mame.lst
@@ -30900,7 +30900,7 @@ pbaction                        // (c) 1985 Tehkan
 pbaction2                       // (c) 1985 Tehkan
 pbaction3                       // (c) 1985 Tehkan
 pbaction4                       // (c) 1985 Tehkan
-pbaction5                       // (c) 1985 Tehkan
+pbactiont                       // (c) 1985 Tehkan (Tecfri license)
 
 @source:pc.cpp
 ataripc1                        // Atari PC1


### PR DESCRIPTION
The "pbaction2" set was a Tecfri licensed game.
The Tecfri variant included an additional subboard (previously dumped, but documented as "function unknown") for controlling an external vertical scores board with 7-sements diplays (like on a real Pinball).

I've renamed "pbaction2" to ""pbactiont", an accordingly:
"pbaction3" -> "pbaction2"
"pbaction4" -> "pbaction3"

More info about the extra Tecfri subboard (Spanish):
https://petacos.forumcommunity.net/?t=60710482
http://www.recreativas.org/pinball-action-1025-tecfri