### PR TITLE
restore tilemap offset to tumblep and chinatwn

### DIFF
--- a/src/mame/drivers/supbtime.cpp
+++ b/src/mame/drivers/supbtime.cpp
@@ -356,19 +356,19 @@ MACHINE_CONFIG_START(supbtime_state::supbtime)
 	MCFG_PALETTE_ADD("palette", 1024)
 	MCFG_PALETTE_FORMAT(xxxxBBBBGGGGRRRR)
 
-	MCFG_DEVICE_ADD("tilegen", DECO16IC, 0)
-	MCFG_DECO16IC_SPLIT(0)
-	MCFG_DECO16IC_PF1_SIZE(DECO_64x32)
-	MCFG_DECO16IC_PF2_SIZE(DECO_64x32)
-	MCFG_DECO16IC_PF1_TRANS_MASK(0x0f)
-	MCFG_DECO16IC_PF2_TRANS_MASK(0x0f)
-	MCFG_DECO16IC_PF1_COL_BANK(0x00)
-	MCFG_DECO16IC_PF2_COL_BANK(0x10)
-	MCFG_DECO16IC_PF1_COL_MASK(0x0f)
-	MCFG_DECO16IC_PF2_COL_MASK(0x0f)
-	MCFG_DECO16IC_PF12_8X8_BANK(0)
-	MCFG_DECO16IC_PF12_16X16_BANK(1)
-	MCFG_DECO16IC_GFXDECODE("gfxdecode")
+	DECO16IC(config, m_deco_tilegen, 0);
+	m_deco_tilegen->set_split(0);
+	m_deco_tilegen->set_pf1_size(DECO_64x32);
+	m_deco_tilegen->set_pf2_size(DECO_64x32);
+	m_deco_tilegen->set_pf1_trans_mask(0x0f);
+	m_deco_tilegen->set_pf2_trans_mask(0x0f);
+	m_deco_tilegen->set_pf1_col_bank(0x00);
+	m_deco_tilegen->set_pf2_col_bank(0x10);
+	m_deco_tilegen->set_pf1_col_mask(0x0f);
+	m_deco_tilegen->set_pf2_col_mask(0x0f);
+	m_deco_tilegen->set_pf12_8x8_bank(0);
+	m_deco_tilegen->set_pf12_16x16_bank(1);
+	m_deco_tilegen->set_gfxdecode_tag("gfxdecode");
 
 	MCFG_DEVICE_ADD("spritegen", DECO_SPRITE, 0)
 	MCFG_DECO_SPRITE_GFX_REGION(2)
@@ -393,6 +393,9 @@ MACHINE_CONFIG_START(supbtime_state::chinatwn)
 	supbtime(config);
 	MCFG_DEVICE_MODIFY("maincpu")
 	MCFG_DEVICE_PROGRAM_MAP(chinatwn_map)
+
+	MCFG_SCREEN_MODIFY("screen")
+	MCFG_SCREEN_UPDATE_DRIVER(supbtime_state, screen_update_chinatwn)
 MACHINE_CONFIG_END
 
 MACHINE_CONFIG_START(supbtime_state::tumblep)
@@ -436,8 +439,7 @@ ROM_START( supbtime )
 	ROM_LOAD("tg5.j1",  0x514, 0x104, CRC(21d02af7) SHA1(4b221a478cb3381e9551de770df7c491c5e59c90)) // PAL16L8
 ROM_END
 
-// is this actually a good dump?, there are no backgrounds ingame!
-ROM_START( supbtimea )
+ROM_START( supbtimea ) // this set has no backgrounds ingame for most stages, but has been verifeid as good on multiple PCBs, design choice
 	ROM_REGION( 0x40000, "maincpu", 0 )
 	ROM_LOAD16_BYTE("3.11f", 0x00000, 0x20000, CRC(98b5f263) SHA1(ee4b0d2fcdc95aba0e78d066bd6c4d553a902848))
 	ROM_LOAD16_BYTE("4.12f", 0x00001, 0x20000, CRC(937e68b9) SHA1(4779e150518b9014c2154f33d38767c6a7447334))

--- a/src/mame/includes/supbtime.h
+++ b/src/mame/includes/supbtime.h
@@ -42,6 +42,8 @@ public:
 private:
 	DECLARE_WRITE_LINE_MEMBER(vblank_w);
 	DECLARE_READ16_MEMBER(vblank_ack_r);
+	uint32_t screen_update_common(screen_device &screen, bitmap_ind16 &bitmap, const rectangle &cliprect, bool use_offsets);
+	uint32_t screen_update_chinatwn(screen_device &screen, bitmap_ind16 &bitmap, const rectangle &cliprect);
 	uint32_t screen_update_supbtime(screen_device &screen, bitmap_ind16 &bitmap, const rectangle &cliprect);
 	uint32_t screen_update_tumblep(screen_device &screen, bitmap_ind16 &bitmap, const rectangle &cliprect);
 

--- a/src/mame/video/deco16ic.cpp
+++ b/src/mame/video/deco16ic.cpp
@@ -560,7 +560,7 @@ void deco16ic_device::pf12_set_gfxbank( int small, int big )
 	m_pf12_8x8_gfx_bank = small;
 }
 
-/* stoneage has broken scroll registers */
+/* stoneage has broken scroll registers, original tumble pop expects a 1 pixel offset */
 void deco16ic_device::set_scrolldx( int tmap, int size, int dx, int dx_if_flipped )
 {
 	switch (tmap)

--- a/src/mame/video/supbtime.cpp
+++ b/src/mame/video/supbtime.cpp
@@ -6,13 +6,16 @@
 
     Video mixing
 
+	- are there priority registers / bits in the sprites that would allow
+	  this to be collapsed further?
+
 ***************************************************************************/
 
 #include "emu.h"
 #include "includes/supbtime.h"
 
-// End sequence uses rowscroll '98 c0' on pf1 (jmp to 1d61a on supbtimej)
-uint32_t supbtime_state::screen_update_supbtime(screen_device &screen, bitmap_ind16 &bitmap, const rectangle &cliprect)
+
+uint32_t supbtime_state::screen_update_common(screen_device &screen, bitmap_ind16 &bitmap, const rectangle &cliprect, bool use_offsets)
 {
 	address_space &space = machine().dummy_space();
 	uint16_t flip = m_deco_tilegen->pf_control_r(space, 0, 0xffff);
@@ -23,6 +26,23 @@ uint32_t supbtime_state::screen_update_supbtime(screen_device &screen, bitmap_in
 
 	bitmap.fill(768, cliprect);
 
+	if (use_offsets)
+	{
+		// chinatwn and tumblep are verified as needing a 1 pixel offset on the tilemaps to match original hardware (supbtime appears to not want them)
+		m_deco_tilegen->set_scrolldx(0, 0, 1, -1);
+		m_deco_tilegen->set_scrolldx(0, 1, 1, -1);
+		m_deco_tilegen->set_scrolldx(1, 0, 1, -1);
+		m_deco_tilegen->set_scrolldx(1, 1, 1, -1);
+	}
+
+	return 0;
+}
+
+// End sequence uses rowscroll '98 c0' on pf1 (jmp to 1d61a on supbtimej)
+uint32_t supbtime_state::screen_update_supbtime(screen_device &screen, bitmap_ind16 &bitmap, const rectangle &cliprect)
+{
+	screen_update_common(screen, bitmap, cliprect, false);
+
 	m_deco_tilegen->tilemap_2_draw(screen, bitmap, cliprect, 0, 0);
 	m_sprgen->draw_sprites(bitmap, cliprect, m_spriteram, 0x400);
 	m_deco_tilegen->tilemap_1_draw(screen, bitmap, cliprect, 0, 0);
@@ -30,18 +50,20 @@ uint32_t supbtime_state::screen_update_supbtime(screen_device &screen, bitmap_in
 	return 0;
 }
 
-// Tumblepop is one of few games to take advantage of the playfields ability
-// to switch between 8*8 tiles and 16*16 tiles.
+uint32_t supbtime_state::screen_update_chinatwn(screen_device &screen, bitmap_ind16 &bitmap, const rectangle &cliprect)
+{
+	screen_update_common(screen, bitmap, cliprect, true);
+
+	m_deco_tilegen->tilemap_2_draw(screen, bitmap, cliprect, 0, 0);
+	m_sprgen->draw_sprites(bitmap, cliprect, m_spriteram, 0x400);
+	m_deco_tilegen->tilemap_1_draw(screen, bitmap, cliprect, 0, 0);
+
+	return 0;
+}
+
 uint32_t supbtime_state::screen_update_tumblep(screen_device &screen, bitmap_ind16 &bitmap, const rectangle &cliprect)
 {
-	address_space &space = machine().dummy_space();
-	uint16_t flip = m_deco_tilegen->pf_control_r(space, 0, 0xffff);
-
-	flip_screen_set(BIT(flip, 7));
-	m_sprgen->set_flip_screen(BIT(flip, 7));
-	m_deco_tilegen->pf_update(m_pf_rowscroll[0], m_pf_rowscroll[1]);
-
-	bitmap.fill(256+512, cliprect); // not verified
+	screen_update_common(screen, bitmap, cliprect, true);
 
 	m_deco_tilegen->tilemap_2_draw(screen, bitmap, cliprect, TILEMAP_DRAW_OPAQUE, 0);
 	m_deco_tilegen->tilemap_1_draw(screen, bitmap, cliprect, 0, 0);


### PR DESCRIPTION
they were lost when the driver was merged with supbtime (verified with hardware videos)