### PR TITLE
m52: improvements to alpha1v (promoted to working)

### DIFF
--- a/src/mame/drivers/m52.cpp
+++ b/src/mame/drivers/m52.cpp
@@ -473,15 +473,15 @@ ROM_START(mpatrol)
 	ROM_LOAD("mp-s1.1a", 0x7000, 0x1000, CRC(561d3108) SHA1(4998c68a9e9a8002251fa8f07aa1082444a9dc80))
 
 	ROM_REGION(0x2000, "tx", 0)
-	ROM_LOAD("mpe-5.3e", 0x0000, 0x1000, CRC(e3ee7f75) SHA1(b03d0d56150d3e9da4a4c871338097b4f450b649))       /* chars */
+	ROM_LOAD("mpe-5.3e", 0x0000, 0x1000, CRC(e3ee7f75) SHA1(b03d0d56150d3e9da4a4c871338097b4f450b649))
 	ROM_LOAD("mpe-4.3f", 0x1000, 0x1000, CRC(cca6d023) SHA1(fecb3059fb09897a096add9452b50aec55c07545))
 
 	ROM_REGION(0x2000, "sp", 0)
-	ROM_LOAD("mpb-2.3m", 0x0000, 0x1000, CRC(707ace5e) SHA1(93c682e13e74bce29ced3a87bffb29569c114c3b))       /* sprites */
+	ROM_LOAD("mpb-2.3m", 0x0000, 0x1000, CRC(707ace5e) SHA1(93c682e13e74bce29ced3a87bffb29569c114c3b))
 	ROM_LOAD("mpb-1.3n", 0x1000, 0x1000, CRC(9b72133a) SHA1(1393ef92ae1ad58a4b62ca1660c0793d30a8b5e2))
 
 	ROM_REGION(0x1000, "bg0", 0)
-	ROM_LOAD("mpe-1.3l", 0x0000, 0x1000, CRC(c46a7f72) SHA1(8bb7c9acaf6833fb6c0575b015991b873a305a84))       /* background graphics */
+	ROM_LOAD("mpe-1.3l", 0x0000, 0x1000, CRC(c46a7f72) SHA1(8bb7c9acaf6833fb6c0575b015991b873a305a84))
 
 	ROM_REGION(0x1000, "bg1", 0)
 	ROM_LOAD("mpe-2.3k", 0x0000, 0x1000, CRC(c7aa1fb0) SHA1(14c6c76e1d0db2c0745e5d6d33ea6945fac8e9ee))
@@ -493,13 +493,13 @@ ROM_START(mpatrol)
 	ROM_LOAD("mpc-4.2a", 0x0000, 0x0200, CRC(07f99284) SHA1(dfc52958f2520e1ce4446dd4c84c91413bbacf76))
 
 	ROM_REGION(0x0020, "bg_pal", 0)
-	ROM_LOAD("mpc-3.1m", 0x0000, 0x0020, CRC(6a57eff2) SHA1(2d1c12dab5915da2ccd466e39436c88be434d634)) /* background palette */
+	ROM_LOAD("mpc-3.1m", 0x0000, 0x0020, CRC(6a57eff2) SHA1(2d1c12dab5915da2ccd466e39436c88be434d634))
 
 	ROM_REGION(0x0020, "spr_pal", 0)
-	ROM_LOAD("mpc-1.1f", 0x0000, 0x0020, CRC(26979b13) SHA1(8c41a8cce4f3384c392a9f7a223a50d7be0e14a5)) /* sprite palette */
+	ROM_LOAD("mpc-1.1f", 0x0000, 0x0020, CRC(26979b13) SHA1(8c41a8cce4f3384c392a9f7a223a50d7be0e14a5))
 
 	ROM_REGION(0x0100, "spr_clut", 0)
-	ROM_LOAD("mpc-2.2h", 0x0000, 0x0100, CRC(7ae4cd97) SHA1(bc0662fac82ffe65f02092d912b2c2b0c7a8ac2b)) /* sprite lookup table */
+	ROM_LOAD("mpc-2.2h", 0x0000, 0x0100, CRC(7ae4cd97) SHA1(bc0662fac82ffe65f02092d912b2c2b0c7a8ac2b))
 ROM_END
 
 ROM_START(mpatrolw)
@@ -513,15 +513,15 @@ ROM_START(mpatrolw)
 	ROM_LOAD("mp-s1.1a", 0x7000, 0x1000, CRC(561d3108) SHA1(4998c68a9e9a8002251fa8f07aa1082444a9dc80))
 
 	ROM_REGION(0x2000, "tx", 0)
-	ROM_LOAD("mpe-5w.3e", 0x0000, 0x1000, CRC(f56e01fe) SHA1(93f582d63b9cd5c6dca207aa57b213c939cdda1d))       /* chars */
+	ROM_LOAD("mpe-5w.3e", 0x0000, 0x1000, CRC(f56e01fe) SHA1(93f582d63b9cd5c6dca207aa57b213c939cdda1d))
 	ROM_LOAD("mpe-4w.3f", 0x1000, 0x1000, CRC(caaba2d9) SHA1(7016a26c2d01e3209749598e993cd8ce91f12c88))
 
 	ROM_REGION(0x2000, "sp", 0)
-	ROM_LOAD("mpb-2.3m", 0x0000, 0x1000, CRC(707ace5e) SHA1(93c682e13e74bce29ced3a87bffb29569c114c3b))       /* sprites */
+	ROM_LOAD("mpb-2.3m", 0x0000, 0x1000, CRC(707ace5e) SHA1(93c682e13e74bce29ced3a87bffb29569c114c3b))
 	ROM_LOAD("mpb-1.3n", 0x1000, 0x1000, CRC(9b72133a) SHA1(1393ef92ae1ad58a4b62ca1660c0793d30a8b5e2))
 
 	ROM_REGION(0x1000, "bg0", 0)
-	ROM_LOAD("mpe-1.3l", 0x0000, 0x1000, CRC(c46a7f72) SHA1(8bb7c9acaf6833fb6c0575b015991b873a305a84))       /* background graphics */
+	ROM_LOAD("mpe-1.3l", 0x0000, 0x1000, CRC(c46a7f72) SHA1(8bb7c9acaf6833fb6c0575b015991b873a305a84))
 
 	ROM_REGION(0x1000, "bg1", 0)
 	ROM_LOAD("mpe-2.3k", 0x0000, 0x1000, CRC(c7aa1fb0) SHA1(14c6c76e1d0db2c0745e5d6d33ea6945fac8e9ee))
@@ -533,13 +533,13 @@ ROM_START(mpatrolw)
 	ROM_LOAD("mpc-4a.2a", 0x0000, 0x0200, CRC(cb0a5ff3) SHA1(d3f88b4e0c4858abac8b52105656ecece0cf4df9))
 
 	ROM_REGION(0x0020, "bg_pal", 0)
-	ROM_LOAD("mpc-3.1m", 0x0000, 0x0020, CRC(6a57eff2) SHA1(2d1c12dab5915da2ccd466e39436c88be434d634)) /* background palette */
+	ROM_LOAD("mpc-3.1m", 0x0000, 0x0020, CRC(6a57eff2) SHA1(2d1c12dab5915da2ccd466e39436c88be434d634))
 
 	ROM_REGION(0x0020, "spr_pal", 0)
-	ROM_LOAD("mpc-1.1f", 0x0000, 0x0020, CRC(26979b13) SHA1(8c41a8cce4f3384c392a9f7a223a50d7be0e14a5)) /* sprite palette */
+	ROM_LOAD("mpc-1.1f", 0x0000, 0x0020, CRC(26979b13) SHA1(8c41a8cce4f3384c392a9f7a223a50d7be0e14a5))
 
 	ROM_REGION(0x0100, "spr_clut", 0)
-	ROM_LOAD("mpc-2.2h", 0x0000, 0x0100, CRC(7ae4cd97) SHA1(bc0662fac82ffe65f02092d912b2c2b0c7a8ac2b)) /* sprite lookup table */
+	ROM_LOAD("mpc-2.2h", 0x0000, 0x0100, CRC(7ae4cd97) SHA1(bc0662fac82ffe65f02092d912b2c2b0c7a8ac2b))
 ROM_END
 
 ROM_START(mranger)
@@ -553,15 +553,15 @@ ROM_START(mranger)
 	ROM_LOAD("mp-s1.1a", 0x7000, 0x1000, CRC(561d3108) SHA1(4998c68a9e9a8002251fa8f07aa1082444a9dc80))
 
 	ROM_REGION(0x2000, "tx", 0)
-	ROM_LOAD("mpe-5.3e", 0x0000, 0x1000, CRC(e3ee7f75) SHA1(b03d0d56150d3e9da4a4c871338097b4f450b649))       /* chars */
+	ROM_LOAD("mpe-5.3e", 0x0000, 0x1000, CRC(e3ee7f75) SHA1(b03d0d56150d3e9da4a4c871338097b4f450b649))
 	ROM_LOAD("mpe-4.3f", 0x1000, 0x1000, CRC(cca6d023) SHA1(fecb3059fb09897a096add9452b50aec55c07545))
 
 	ROM_REGION(0x2000, "sp", 0)
-	ROM_LOAD("mpb-2.3m", 0x0000, 0x1000, CRC(707ace5e) SHA1(93c682e13e74bce29ced3a87bffb29569c114c3b))       /* sprites */
+	ROM_LOAD("mpb-2.3m", 0x0000, 0x1000, CRC(707ace5e) SHA1(93c682e13e74bce29ced3a87bffb29569c114c3b))
 	ROM_LOAD("mpb-1.3n", 0x1000, 0x1000, CRC(9b72133a) SHA1(1393ef92ae1ad58a4b62ca1660c0793d30a8b5e2))
 
 	ROM_REGION(0x1000, "bg0", 0)
-	ROM_LOAD("mpe-1.3l", 0x0000, 0x1000, CRC(c46a7f72) SHA1(8bb7c9acaf6833fb6c0575b015991b873a305a84))       /* background graphics */
+	ROM_LOAD("mpe-1.3l", 0x0000, 0x1000, CRC(c46a7f72) SHA1(8bb7c9acaf6833fb6c0575b015991b873a305a84))
 
 	ROM_REGION(0x1000, "bg1", 0)
 	ROM_LOAD("mpe-2.3k", 0x0000, 0x1000, CRC(c7aa1fb0) SHA1(14c6c76e1d0db2c0745e5d6d33ea6945fac8e9ee))
@@ -573,13 +573,13 @@ ROM_START(mranger)
 	ROM_LOAD("mpc-4.2a", 0x0000, 0x0200, CRC(07f99284) SHA1(dfc52958f2520e1ce4446dd4c84c91413bbacf76))
 
 	ROM_REGION(0x0020, "bg_pal", 0)
-	ROM_LOAD("mpc-3.1m", 0x0000, 0x0020, CRC(6a57eff2) SHA1(2d1c12dab5915da2ccd466e39436c88be434d634)) /* background palette */
+	ROM_LOAD("mpc-3.1m", 0x0000, 0x0020, CRC(6a57eff2) SHA1(2d1c12dab5915da2ccd466e39436c88be434d634))
 
 	ROM_REGION(0x0020, "spr_pal", 0)
-	ROM_LOAD("mpc-1.1f", 0x0000, 0x0020, CRC(26979b13) SHA1(8c41a8cce4f3384c392a9f7a223a50d7be0e14a5)) /* sprite palette */
+	ROM_LOAD("mpc-1.1f", 0x0000, 0x0020, CRC(26979b13) SHA1(8c41a8cce4f3384c392a9f7a223a50d7be0e14a5))
 
 	ROM_REGION(0x0100, "spr_clut", 0)
-	ROM_LOAD("mpc-2.2h", 0x0000, 0x0100, CRC(7ae4cd97) SHA1(bc0662fac82ffe65f02092d912b2c2b0c7a8ac2b)) /* sprite lookup table */
+	ROM_LOAD("mpc-2.2h", 0x0000, 0x0100, CRC(7ae4cd97) SHA1(bc0662fac82ffe65f02092d912b2c2b0c7a8ac2b))
 ROM_END
 
 
@@ -597,7 +597,7 @@ ROM_START(alpha1v)
 	ROM_LOAD("1-a1", 0x7000, 0x1000, CRC(9e07fdd5) SHA1(ed4f462fcfe91fa8e88bfeaaba0a0c11fa0b4601))
 
 	ROM_REGION(0x2000, "tx", 0)
-	ROM_LOAD("14-e3", 0x0000, 0x1000, CRC(cf00c737) SHA1(415e90289039cac4d04cb1d559f1378ca6a32132))       /* chars */
+	ROM_LOAD("14-e3", 0x0000, 0x1000, CRC(cf00c737) SHA1(415e90289039cac4d04cb1d559f1378ca6a32132))
 	ROM_LOAD("13-f3", 0x1000, 0x1000, CRC(4b799229) SHA1(42cbdcf787b08b041d30504d699a12c378224933))
 
 	ROM_REGION(0x3000, "sp", 0) // 3bpp (mpatrol is 2bpp)
@@ -621,13 +621,13 @@ ROM_START(alpha1v)
 	ROM_LOAD("63s481-a2", 0x0000, 0x0200, CRC(58678ea8) SHA1(b13a78a5bca8ad5bdec1293512b53654768a7a7a))
 
 	ROM_REGION(0x0020, "bg_pal", 0)
-	ROM_LOAD("18s030-m1", 0x0000, 0x0020, CRC(6a57eff2) SHA1(2d1c12dab5915da2ccd466e39436c88be434d634)) /* background palette */
+	ROM_LOAD("18s030-m1", 0x0000, 0x0020, CRC(6a57eff2) SHA1(2d1c12dab5915da2ccd466e39436c88be434d634))
 
 	ROM_REGION(0x0020, "spr_pal", 0)
-	ROM_LOAD("mb7051-f1", 0x0000, 0x0020, CRC(d8bdd0df) SHA1(ca522428927911808214d319af314f601497ded4)) /* sprite palette */
+	ROM_LOAD("mb7051-f1", 0x0000, 0x0020, CRC(d8bdd0df) SHA1(ca522428927911808214d319af314f601497ded4))
 
 	ROM_REGION(0x0100, "spr_clut", 0)
-	ROM_LOAD("mb7052-h2", 0x0000, 0x0100, CRC(ce9f0ef9) SHA1(3afb94ed033f272983bbed22a59856df7824ef8a)) /* sprite lookup table */
+	ROM_LOAD("mb7052-h2", 0x0000, 0x0100, CRC(ce9f0ef9) SHA1(3afb94ed033f272983bbed22a59856df7824ef8a))
 ROM_END
 
 

--- a/src/mame/drivers/m52.cpp
+++ b/src/mame/drivers/m52.cpp
@@ -319,9 +319,9 @@ static const gfx_layout charlayout =
 static const gfx_layout spritelayout =
 {
 	16,16,
-	RGN_FRAC(1,2),
-	2,
-	{ RGN_FRAC(0,2), RGN_FRAC(1,2) },
+	RGN_FRAC(1,3),
+	3,
+	{ RGN_FRAC(2,3), RGN_FRAC(0,3), RGN_FRAC(1,3) },
 	{ STEP8(0,1), STEP8(16 * 8,1) },
 	{ STEP16(0,8) },
 	32 * 8
@@ -380,20 +380,8 @@ static GFXDECODE_START(gfx_m52_bg)
 	GFXDECODE_ENTRY("bg2", 0x0000, bgcharlayout, 2 * 4, 1)
 GFXDECODE_END
 
-static const gfx_layout spritelayout3bpp =
-{
-	16,16,
-	RGN_FRAC(1,3),
-	3,
-	{ RGN_FRAC(0,3), RGN_FRAC(1,3), RGN_FRAC(2,3) },
-	{ STEP8(0,1), STEP8(16 * 8,1) },
-	{ STEP16(0,8) },
-	32 * 8
-};
 
-static GFXDECODE_START(gfx_m52_alpha1v_sp)
-	GFXDECODE_ENTRY("sp", 0x0000, spritelayout3bpp, 0, 16)
-GFXDECODE_END
+
 
 /*************************************
 *
@@ -419,7 +407,7 @@ MACHINE_CONFIG_START(m52_state::m52)
 	MCFG_DEVICE_VBLANK_INT_DRIVER("screen", m52_state, irq0_line_hold)
 
 	/* video hardware */
-	MCFG_PALETTE_ADD("sp_palette", 16 * 4)
+	MCFG_PALETTE_ADD("sp_palette", 256)
 	MCFG_PALETTE_INDIRECT_ENTRIES(32)
 	MCFG_DEVICE_ADD("sp_gfxdecode", GFXDECODE, "sp_palette", gfx_m52_sp)
 
@@ -450,8 +438,6 @@ MACHINE_CONFIG_START(m52_alpha1v_state::alpha1v)
 	MCFG_SCREEN_MODIFY("screen")
 	MCFG_SCREEN_RAW_PARAMS(MASTER_CLOCK / 3, 384, 136, 376, 282, 16, 272)
 
-	MCFG_DEVICE_REPLACE("sp_gfxdecode", GFXDECODE, "sp_palette", gfx_m52_alpha1v_sp)
-
 MACHINE_CONFIG_END
 
 
@@ -476,7 +462,8 @@ ROM_START(mpatrol)
 	ROM_LOAD("mpe-5.3e", 0x0000, 0x1000, CRC(e3ee7f75) SHA1(b03d0d56150d3e9da4a4c871338097b4f450b649))
 	ROM_LOAD("mpe-4.3f", 0x1000, 0x1000, CRC(cca6d023) SHA1(fecb3059fb09897a096add9452b50aec55c07545))
 
-	ROM_REGION(0x2000, "sp", 0)
+	/* 0x2000-0x2fff is intentionally left as 0x00 fill, unused bitplane */
+	ROM_REGION(0x3000, "sp", ROMREGION_ERASE00)
 	ROM_LOAD("mpb-2.3m", 0x0000, 0x1000, CRC(707ace5e) SHA1(93c682e13e74bce29ced3a87bffb29569c114c3b))
 	ROM_LOAD("mpb-1.3n", 0x1000, 0x1000, CRC(9b72133a) SHA1(1393ef92ae1ad58a4b62ca1660c0793d30a8b5e2))
 
@@ -517,7 +504,8 @@ ROM_START(mpatrolw)
 	ROM_LOAD("mpe-5w.3e", 0x0000, 0x1000, CRC(f56e01fe) SHA1(93f582d63b9cd5c6dca207aa57b213c939cdda1d))
 	ROM_LOAD("mpe-4w.3f", 0x1000, 0x1000, CRC(caaba2d9) SHA1(7016a26c2d01e3209749598e993cd8ce91f12c88))
 
-	ROM_REGION(0x2000, "sp", 0)
+	/* 0x2000-0x2fff is intentionally left as 0x00 fill, unused bitplane */
+	ROM_REGION(0x3000, "sp", ROMREGION_ERASE00)
 	ROM_LOAD("mpb-2.3m", 0x0000, 0x1000, CRC(707ace5e) SHA1(93c682e13e74bce29ced3a87bffb29569c114c3b))
 	ROM_LOAD("mpb-1.3n", 0x1000, 0x1000, CRC(9b72133a) SHA1(1393ef92ae1ad58a4b62ca1660c0793d30a8b5e2))
 
@@ -558,7 +546,8 @@ ROM_START(mranger)
 	ROM_LOAD("mpe-5.3e", 0x0000, 0x1000, CRC(e3ee7f75) SHA1(b03d0d56150d3e9da4a4c871338097b4f450b649))
 	ROM_LOAD("mpe-4.3f", 0x1000, 0x1000, CRC(cca6d023) SHA1(fecb3059fb09897a096add9452b50aec55c07545))
 
-	ROM_REGION(0x2000, "sp", 0)
+	/* 0x2000-0x2fff is intentionally left as 0x00 fill, unused bitplane */
+	ROM_REGION(0x3000, "sp", ROMREGION_ERASE00)
 	ROM_LOAD("mpb-2.3m", 0x0000, 0x1000, CRC(707ace5e) SHA1(93c682e13e74bce29ced3a87bffb29569c114c3b))
 	ROM_LOAD("mpb-1.3n", 0x1000, 0x1000, CRC(9b72133a) SHA1(1393ef92ae1ad58a4b62ca1660c0793d30a8b5e2))
 
@@ -618,6 +607,7 @@ ROM_START(alpha1v)
 	ROM_LOAD("10-lm3", 0x1000, 0x1000, CRC(9dde3a75) SHA1(293d093485be19bfb20685d76a08ac78e24062bf))
 
 	ROM_REGION(0x2000, "bg2", ROMREGION_ERASEFF)
+	// unused layer
 
 	ROM_REGION(0x0200, "tx_pal", 0)
 	ROM_LOAD("63s481-a2", 0x0000, 0x0200, CRC(58678ea8) SHA1(b13a78a5bca8ad5bdec1293512b53654768a7a7a))

--- a/src/mame/drivers/m52.cpp
+++ b/src/mame/drivers/m52.cpp
@@ -50,9 +50,7 @@
 #include "includes/iremipt.h"
 #include "includes/m52.h"
 
-
 #define MASTER_CLOCK        XTAL(18'432'000)
-
 
 /*************************************
  *
@@ -66,7 +64,7 @@ void m52_state::main_map(address_map &map)
 	map(0x8000, 0x83ff).ram().w(FUNC(m52_state::m52_videoram_w)).share("videoram");
 	map(0x8400, 0x87ff).ram().w(FUNC(m52_state::m52_colorram_w)).share("colorram");
 	map(0x8800, 0x8800).mirror(0x07ff).r(FUNC(m52_state::m52_protection_r));
-	map(0xc800, 0xcbff).mirror(0x0400).writeonly().share("spriteram");
+	map(0xc800, 0xcbff).mirror(0x0400).writeonly().share("spriteram"); // only 0x100 of this used by video code?
 	map(0xd000, 0xd000).mirror(0x07fc).w("irem_audio", FUNC(irem_audio_device::cmd_w));
 	map(0xd001, 0xd001).mirror(0x07fc).w(FUNC(m52_state::m52_flipscreen_w));   /* + coin counters */
 	map(0xd000, 0xd000).mirror(0x07f8).portr("IN0");
@@ -78,15 +76,15 @@ void m52_state::main_map(address_map &map)
 }
 
 
-void m52_state::alpha1v_map(address_map &map)
+void m52_alpha1v_state::alpha1v_map(address_map &map)
 {
 	map(0x0000, 0x6fff).rom();
 	map(0x8000, 0x83ff).ram().w(FUNC(m52_state::m52_videoram_w)).share("videoram");
 	map(0x8400, 0x87ff).ram().w(FUNC(m52_state::m52_colorram_w)).share("colorram");
 	map(0x8800, 0x8800).mirror(0x07ff).r(FUNC(m52_state::m52_protection_r)); // result is ignored
-	map(0xc800, 0xc9ff).writeonly().share("spriteram"); // bigger or mirrored?
+	map(0xc800, 0xc9ff).writeonly().share("spriteram");
 	map(0xd000, 0xd000).portr("IN0").w("irem_audio", FUNC(irem_audio_device::cmd_w));
-	map(0xd001, 0xd001).portr("IN1").w(FUNC(m52_state::alpha1v_flipscreen_w));
+	map(0xd001, 0xd001).portr("IN1").w(FUNC(m52_alpha1v_state::alpha1v_flipscreen_w));
 	map(0xd002, 0xd002).portr("IN2");
 	map(0xd003, 0xd003).portr("DSW1");
 	map(0xd004, 0xd004).portr("DSW2");
@@ -104,7 +102,6 @@ void m52_state::main_portmap(address_map &map)
 	map(0xa0, 0xa0).mirror(0x1f).w(FUNC(m52_state::m52_bg2ypos_w));
 	map(0xc0, 0xc0).mirror(0x1f).w(FUNC(m52_state::m52_bgcontrol_w));
 }
-
 
 
 /*************************************
@@ -302,12 +299,11 @@ static INPUT_PORTS_START( alpha1v )
 INPUT_PORTS_END
 
 
-
 /*************************************
- *
- *  Graphics layouts
- *
- *************************************/
+*
+*  Graphics layouts
+*
+*************************************/
 
 static const gfx_layout charlayout =
 {
@@ -317,7 +313,7 @@ static const gfx_layout charlayout =
 	{ RGN_FRAC(0,2), RGN_FRAC(1,2) },
 	{ STEP8(0,1) },
 	{ STEP8(0,8) },
-	8*8
+	8 * 8
 };
 
 static const gfx_layout spritelayout =
@@ -326,9 +322,9 @@ static const gfx_layout spritelayout =
 	RGN_FRAC(1,2),
 	2,
 	{ RGN_FRAC(0,2), RGN_FRAC(1,2) },
-	{ STEP8(0,1), STEP8(16*8,1) },
+	{ STEP8(0,1), STEP8(16 * 8,1) },
 	{ STEP16(0,8) },
-	32*8
+	32 * 8
 };
 
 static const uint32_t bgcharlayout_xoffset[256] =
@@ -370,25 +366,40 @@ static const gfx_layout bgcharlayout =
 };
 
 
-static GFXDECODE_START( gfx_m52_sp )
-	GFXDECODE_ENTRY( "gfx2", 0x0000, spritelayout,          0,  16 )
+static GFXDECODE_START(gfx_m52_sp)
+	GFXDECODE_ENTRY("sp", 0x0000, spritelayout, 0, 16)
 GFXDECODE_END
 
-static GFXDECODE_START( gfx_m52_tx )
-	GFXDECODE_ENTRY( "gfx1", 0x0000, charlayout,                0, 128 )
+static GFXDECODE_START(gfx_m52_tx)
+	GFXDECODE_ENTRY("tx", 0x0000, charlayout, 0, 128)
 GFXDECODE_END
 
-static GFXDECODE_START( gfx_m52_bg )
-	GFXDECODE_ENTRY( "gfx3", 0x0000, bgcharlayout, 0*4,   1 )
-	GFXDECODE_ENTRY( "gfx4", 0x0000, bgcharlayout, 1*4,   1 )
-	GFXDECODE_ENTRY( "gfx5", 0x0000, bgcharlayout, 2*4,   1 )
+static GFXDECODE_START(gfx_m52_bg)
+	GFXDECODE_ENTRY("bg0", 0x0000, bgcharlayout, 0 * 4, 1)
+	GFXDECODE_ENTRY("bg1", 0x0000, bgcharlayout, 1 * 4, 1)
+	GFXDECODE_ENTRY("bg2", 0x0000, bgcharlayout, 2 * 4, 1)
+GFXDECODE_END
+
+static const gfx_layout spritelayout3bpp =
+{
+	16,16,
+	RGN_FRAC(1,3),
+	3,
+	{ RGN_FRAC(0,3), RGN_FRAC(1,3), RGN_FRAC(2,3) },
+	{ STEP8(0,1), STEP8(16 * 8,1) },
+	{ STEP16(0,8) },
+	32 * 8
+};
+
+static GFXDECODE_START(gfx_m52_alpha1v_sp)
+	GFXDECODE_ENTRY("sp", 0x0000, spritelayout3bpp, 0, 16)
 GFXDECODE_END
 
 /*************************************
- *
- *  Machine drivers
- *
- *************************************/
+*
+*  Machine drivers
+*
+*************************************/
 
 void m52_state::machine_reset()
 {
@@ -402,27 +413,25 @@ void m52_state::machine_reset()
 MACHINE_CONFIG_START(m52_state::m52)
 
 	/* basic machine hardware */
-	MCFG_DEVICE_ADD("maincpu", Z80, MASTER_CLOCK/6)
+	MCFG_DEVICE_ADD("maincpu", Z80, MASTER_CLOCK / 6)
 	MCFG_DEVICE_PROGRAM_MAP(main_map)
 	MCFG_DEVICE_IO_MAP(main_portmap)
-	MCFG_DEVICE_VBLANK_INT_DRIVER("screen", m52_state,  irq0_line_hold)
+	MCFG_DEVICE_VBLANK_INT_DRIVER("screen", m52_state, irq0_line_hold)
 
 	/* video hardware */
-
-	MCFG_PALETTE_ADD("sp_palette", 16*4)
+	MCFG_PALETTE_ADD("sp_palette", 16 * 4)
 	MCFG_PALETTE_INDIRECT_ENTRIES(32)
 	MCFG_DEVICE_ADD("sp_gfxdecode", GFXDECODE, "sp_palette", gfx_m52_sp)
 
 	MCFG_PALETTE_ADD("tx_palette", 512)
 	MCFG_DEVICE_ADD("tx_gfxdecode", GFXDECODE, "tx_palette", gfx_m52_tx)
 
-	MCFG_PALETTE_ADD("bg_palette", 3*4)
+	MCFG_PALETTE_ADD("bg_palette", 3 * 4)
 	MCFG_PALETTE_INDIRECT_ENTRIES(32)
 	MCFG_DEVICE_ADD("bg_gfxdecode", GFXDECODE, "bg_palette", gfx_m52_bg)
 
-
 	MCFG_SCREEN_ADD("screen", RASTER)
-	MCFG_SCREEN_RAW_PARAMS(MASTER_CLOCK/3, 384, 136, 376, 282, 22, 274)
+	MCFG_SCREEN_RAW_PARAMS(MASTER_CLOCK / 3, 384, 136, 376, 282, 22, 274)
 	MCFG_SCREEN_UPDATE_DRIVER(m52_state, screen_update_m52)
 
 	/* sound hardware */
@@ -432,200 +441,204 @@ MACHINE_CONFIG_START(m52_state::m52)
 MACHINE_CONFIG_END
 
 
-MACHINE_CONFIG_START(m52_state::alpha1v)
+MACHINE_CONFIG_START(m52_alpha1v_state::alpha1v)
 	m52(config);
 
 	/* basic machine hardware */
 	MCFG_DEVICE_MODIFY("maincpu")
 	MCFG_DEVICE_PROGRAM_MAP(alpha1v_map)
 	MCFG_SCREEN_MODIFY("screen")
-	MCFG_SCREEN_RAW_PARAMS(MASTER_CLOCK/3, 384, 136, 376, 282, 16, 272)
+	MCFG_SCREEN_RAW_PARAMS(MASTER_CLOCK / 3, 384, 136, 376, 282, 16, 272)
+
+	MCFG_DEVICE_REPLACE("sp_gfxdecode", GFXDECODE, "sp_palette", gfx_m52_alpha1v_sp)
+
 MACHINE_CONFIG_END
 
 
 
 /*************************************
- *
- *  ROM definitions
- *
- *************************************/
+*
+*  ROM definitions
+*
+*************************************/
 
-ROM_START( mpatrol )
-	ROM_REGION( 0x10000, "maincpu", 0 )
-	ROM_LOAD( "mpa-1.3m",      0x0000, 0x1000, CRC(5873a860) SHA1(8c03726d6e049c3edbc277440184e31679f78258) )
-	ROM_LOAD( "mpa-2.3l",      0x1000, 0x1000, CRC(f4b85974) SHA1(dfb2efb57378a20af6f20569f4360cde95596f93) )
-	ROM_LOAD( "mpa-3.3k",      0x2000, 0x1000, CRC(2e1a598c) SHA1(112c3c9678db8a8540a8df3708020c87fd10c91b) )
-	ROM_LOAD( "mpa-4.3j",      0x3000, 0x1000, CRC(dd05b587) SHA1(727961b0dafa4a96b580d51013336db2a18aff1e) )
+ROM_START(mpatrol)
+	ROM_REGION(0x10000, "maincpu", 0)
+	ROM_LOAD("mpa-1.3m", 0x0000, 0x1000, CRC(5873a860) SHA1(8c03726d6e049c3edbc277440184e31679f78258))
+	ROM_LOAD("mpa-2.3l", 0x1000, 0x1000, CRC(f4b85974) SHA1(dfb2efb57378a20af6f20569f4360cde95596f93))
+	ROM_LOAD("mpa-3.3k", 0x2000, 0x1000, CRC(2e1a598c) SHA1(112c3c9678db8a8540a8df3708020c87fd10c91b))
+	ROM_LOAD("mpa-4.3j", 0x3000, 0x1000, CRC(dd05b587) SHA1(727961b0dafa4a96b580d51013336db2a18aff1e))
 
-	ROM_REGION( 0x8000, "irem_audio:iremsound", 0 )
-	ROM_LOAD( "mp-s1.1a",     0x7000, 0x1000, CRC(561d3108) SHA1(4998c68a9e9a8002251fa8f07aa1082444a9dc80) )
+	ROM_REGION(0x8000, "irem_audio:iremsound", 0)
+	ROM_LOAD("mp-s1.1a", 0x7000, 0x1000, CRC(561d3108) SHA1(4998c68a9e9a8002251fa8f07aa1082444a9dc80))
 
-	ROM_REGION( 0x2000, "gfx1", 0 )
-	ROM_LOAD( "mpe-5.3e",     0x0000, 0x1000, CRC(e3ee7f75) SHA1(b03d0d56150d3e9da4a4c871338097b4f450b649) )       /* chars */
-	ROM_LOAD( "mpe-4.3f",     0x1000, 0x1000, CRC(cca6d023) SHA1(fecb3059fb09897a096add9452b50aec55c07545) )
+	ROM_REGION(0x2000, "tx", 0)
+	ROM_LOAD("mpe-5.3e", 0x0000, 0x1000, CRC(e3ee7f75) SHA1(b03d0d56150d3e9da4a4c871338097b4f450b649))       /* chars */
+	ROM_LOAD("mpe-4.3f", 0x1000, 0x1000, CRC(cca6d023) SHA1(fecb3059fb09897a096add9452b50aec55c07545))
 
-	ROM_REGION( 0x2000, "gfx2", 0 )
-	ROM_LOAD( "mpb-2.3m",     0x0000, 0x1000, CRC(707ace5e) SHA1(93c682e13e74bce29ced3a87bffb29569c114c3b) )       /* sprites */
-	ROM_LOAD( "mpb-1.3n",     0x1000, 0x1000, CRC(9b72133a) SHA1(1393ef92ae1ad58a4b62ca1660c0793d30a8b5e2) )
+	ROM_REGION(0x2000, "sp", 0)
+	ROM_LOAD("mpb-2.3m", 0x0000, 0x1000, CRC(707ace5e) SHA1(93c682e13e74bce29ced3a87bffb29569c114c3b))       /* sprites */
+	ROM_LOAD("mpb-1.3n", 0x1000, 0x1000, CRC(9b72133a) SHA1(1393ef92ae1ad58a4b62ca1660c0793d30a8b5e2))
 
-	ROM_REGION( 0x1000, "gfx3", 0 )
-	ROM_LOAD( "mpe-1.3l",     0x0000, 0x1000, CRC(c46a7f72) SHA1(8bb7c9acaf6833fb6c0575b015991b873a305a84) )       /* background graphics */
+	ROM_REGION(0x1000, "bg0", 0)
+	ROM_LOAD("mpe-1.3l", 0x0000, 0x1000, CRC(c46a7f72) SHA1(8bb7c9acaf6833fb6c0575b015991b873a305a84))       /* background graphics */
 
-	ROM_REGION( 0x1000, "gfx4", 0 )
-	ROM_LOAD( "mpe-2.3k",     0x0000, 0x1000, CRC(c7aa1fb0) SHA1(14c6c76e1d0db2c0745e5d6d33ea6945fac8e9ee) )
+	ROM_REGION(0x1000, "bg1", 0)
+	ROM_LOAD("mpe-2.3k", 0x0000, 0x1000, CRC(c7aa1fb0) SHA1(14c6c76e1d0db2c0745e5d6d33ea6945fac8e9ee))
 
-	ROM_REGION( 0x1000, "gfx5", 0 )
-	ROM_LOAD( "mpe-3.3h",     0x0000, 0x1000, CRC(a0919392) SHA1(8a090cb8d483a3d67c7360058e3fdd70e151cd62) )
+	ROM_REGION(0x1000, "bg2", 0)
+	ROM_LOAD("mpe-3.3h", 0x0000, 0x1000, CRC(a0919392) SHA1(8a090cb8d483a3d67c7360058e3fdd70e151cd62))
 
-	ROM_REGION( 0x0200, "tx_pal", 0 )
-	ROM_LOAD( "mpc-4.2a",     0x0000, 0x0200, CRC(07f99284) SHA1(dfc52958f2520e1ce4446dd4c84c91413bbacf76) )
-	
-	ROM_REGION( 0x0020, "bg_pal", 0 )
-	ROM_LOAD( "mpc-3.1m",     0x0000, 0x0020, CRC(6a57eff2) SHA1(2d1c12dab5915da2ccd466e39436c88be434d634) ) /* background palette */
+	ROM_REGION(0x0200, "tx_pal", 0)
+	ROM_LOAD("mpc-4.2a", 0x0000, 0x0200, CRC(07f99284) SHA1(dfc52958f2520e1ce4446dd4c84c91413bbacf76))
 
-	ROM_REGION( 0x0020, "spr_pal", 0 )
-	ROM_LOAD( "mpc-1.1f",     0x0000, 0x0020, CRC(26979b13) SHA1(8c41a8cce4f3384c392a9f7a223a50d7be0e14a5) ) /* sprite palette */
+	ROM_REGION(0x0020, "bg_pal", 0)
+	ROM_LOAD("mpc-3.1m", 0x0000, 0x0020, CRC(6a57eff2) SHA1(2d1c12dab5915da2ccd466e39436c88be434d634)) /* background palette */
 
-	ROM_REGION( 0x0100, "spr_clut", 0 )
-	ROM_LOAD( "mpc-2.2h",     0x0000, 0x0100, CRC(7ae4cd97) SHA1(bc0662fac82ffe65f02092d912b2c2b0c7a8ac2b) ) /* sprite lookup table */
+	ROM_REGION(0x0020, "spr_pal", 0)
+	ROM_LOAD("mpc-1.1f", 0x0000, 0x0020, CRC(26979b13) SHA1(8c41a8cce4f3384c392a9f7a223a50d7be0e14a5)) /* sprite palette */
+
+	ROM_REGION(0x0100, "spr_clut", 0)
+	ROM_LOAD("mpc-2.2h", 0x0000, 0x0100, CRC(7ae4cd97) SHA1(bc0662fac82ffe65f02092d912b2c2b0c7a8ac2b)) /* sprite lookup table */
 ROM_END
 
-ROM_START( mpatrolw )
-	ROM_REGION( 0x10000, "maincpu", 0 )
-	ROM_LOAD( "mpa-1w.3m",    0x0000, 0x1000, CRC(baa1a1d4) SHA1(7968a7f221e7f4c9c81ddc8de17f6568e17b9ea8) )
-	ROM_LOAD( "mpa-2w.3l",    0x1000, 0x1000, CRC(52459e51) SHA1(ae685b7848baa1b87a3f2bce97356286171e16d4) )
-	ROM_LOAD( "mpa-3w.3k",    0x2000, 0x1000, CRC(9b249fe5) SHA1(c01e0d572c4c163f3cf4b2aa9f4246427811b78d) )
-	ROM_LOAD( "mpa-4w.3j",    0x3000, 0x1000, CRC(fee76972) SHA1(c3166b027f89f61964ead804d3c2da387454c4c2) )
+ROM_START(mpatrolw)
+	ROM_REGION(0x10000, "maincpu", 0)
+	ROM_LOAD("mpa-1w.3m", 0x0000, 0x1000, CRC(baa1a1d4) SHA1(7968a7f221e7f4c9c81ddc8de17f6568e17b9ea8))
+	ROM_LOAD("mpa-2w.3l", 0x1000, 0x1000, CRC(52459e51) SHA1(ae685b7848baa1b87a3f2bce97356286171e16d4))
+	ROM_LOAD("mpa-3w.3k", 0x2000, 0x1000, CRC(9b249fe5) SHA1(c01e0d572c4c163f3cf4b2aa9f4246427811b78d))
+	ROM_LOAD("mpa-4w.3j", 0x3000, 0x1000, CRC(fee76972) SHA1(c3166b027f89f61964ead804d3c2da387454c4c2))
 
-	ROM_REGION( 0x8000, "irem_audio:iremsound", 0 )
-	ROM_LOAD( "mp-s1.1a",     0x7000, 0x1000, CRC(561d3108) SHA1(4998c68a9e9a8002251fa8f07aa1082444a9dc80) )
+	ROM_REGION(0x8000, "irem_audio:iremsound", 0)
+	ROM_LOAD("mp-s1.1a", 0x7000, 0x1000, CRC(561d3108) SHA1(4998c68a9e9a8002251fa8f07aa1082444a9dc80))
 
-	ROM_REGION( 0x2000, "gfx1", 0 )
-	ROM_LOAD( "mpe-5w.3e",    0x0000, 0x1000, CRC(f56e01fe) SHA1(93f582d63b9cd5c6dca207aa57b213c939cdda1d) )       /* chars */
-	ROM_LOAD( "mpe-4w.3f",    0x1000, 0x1000, CRC(caaba2d9) SHA1(7016a26c2d01e3209749598e993cd8ce91f12c88) )
+	ROM_REGION(0x2000, "tx", 0)
+	ROM_LOAD("mpe-5w.3e", 0x0000, 0x1000, CRC(f56e01fe) SHA1(93f582d63b9cd5c6dca207aa57b213c939cdda1d))       /* chars */
+	ROM_LOAD("mpe-4w.3f", 0x1000, 0x1000, CRC(caaba2d9) SHA1(7016a26c2d01e3209749598e993cd8ce91f12c88))
 
-	ROM_REGION( 0x2000, "gfx2", 0 )
-	ROM_LOAD( "mpb-2.3m",     0x0000, 0x1000, CRC(707ace5e) SHA1(93c682e13e74bce29ced3a87bffb29569c114c3b) )       /* sprites */
-	ROM_LOAD( "mpb-1.3n",     0x1000, 0x1000, CRC(9b72133a) SHA1(1393ef92ae1ad58a4b62ca1660c0793d30a8b5e2) )
+	ROM_REGION(0x2000, "sp", 0)
+	ROM_LOAD("mpb-2.3m", 0x0000, 0x1000, CRC(707ace5e) SHA1(93c682e13e74bce29ced3a87bffb29569c114c3b))       /* sprites */
+	ROM_LOAD("mpb-1.3n", 0x1000, 0x1000, CRC(9b72133a) SHA1(1393ef92ae1ad58a4b62ca1660c0793d30a8b5e2))
 
-	ROM_REGION( 0x1000, "gfx3", 0 )
-	ROM_LOAD( "mpe-1.3l",     0x0000, 0x1000, CRC(c46a7f72) SHA1(8bb7c9acaf6833fb6c0575b015991b873a305a84) )       /* background graphics */
+	ROM_REGION(0x1000, "bg0", 0)
+	ROM_LOAD("mpe-1.3l", 0x0000, 0x1000, CRC(c46a7f72) SHA1(8bb7c9acaf6833fb6c0575b015991b873a305a84))       /* background graphics */
 
-	ROM_REGION( 0x1000, "gfx4", 0 )
-	ROM_LOAD( "mpe-2.3k",     0x0000, 0x1000, CRC(c7aa1fb0) SHA1(14c6c76e1d0db2c0745e5d6d33ea6945fac8e9ee) )
+	ROM_REGION(0x1000, "bg1", 0)
+	ROM_LOAD("mpe-2.3k", 0x0000, 0x1000, CRC(c7aa1fb0) SHA1(14c6c76e1d0db2c0745e5d6d33ea6945fac8e9ee))
 
-	ROM_REGION( 0x1000, "gfx5", 0 )
-	ROM_LOAD( "mpe-3.3h",     0x0000, 0x1000, CRC(a0919392) SHA1(8a090cb8d483a3d67c7360058e3fdd70e151cd62) )
+	ROM_REGION(0x1000, "bg2", 0)
+	ROM_LOAD("mpe-3.3h", 0x0000, 0x1000, CRC(a0919392) SHA1(8a090cb8d483a3d67c7360058e3fdd70e151cd62))
 
-	ROM_REGION( 0x0200, "tx_pal", 0 )
-	ROM_LOAD( "mpc-4a.2a",    0x0000, 0x0200, CRC(cb0a5ff3) SHA1(d3f88b4e0c4858abac8b52105656ecece0cf4df9) )
+	ROM_REGION(0x0200, "tx_pal", 0)
+	ROM_LOAD("mpc-4a.2a", 0x0000, 0x0200, CRC(cb0a5ff3) SHA1(d3f88b4e0c4858abac8b52105656ecece0cf4df9))
 
-	ROM_REGION( 0x0020, "bg_pal", 0 )
-	ROM_LOAD( "mpc-3.1m",     0x0000, 0x0020, CRC(6a57eff2) SHA1(2d1c12dab5915da2ccd466e39436c88be434d634) ) /* background palette */
+	ROM_REGION(0x0020, "bg_pal", 0)
+	ROM_LOAD("mpc-3.1m", 0x0000, 0x0020, CRC(6a57eff2) SHA1(2d1c12dab5915da2ccd466e39436c88be434d634)) /* background palette */
 
-	ROM_REGION( 0x0020, "spr_pal", 0 )
-	ROM_LOAD( "mpc-1.1f",     0x0000, 0x0020, CRC(26979b13) SHA1(8c41a8cce4f3384c392a9f7a223a50d7be0e14a5) ) /* sprite palette */
+	ROM_REGION(0x0020, "spr_pal", 0)
+	ROM_LOAD("mpc-1.1f", 0x0000, 0x0020, CRC(26979b13) SHA1(8c41a8cce4f3384c392a9f7a223a50d7be0e14a5)) /* sprite palette */
 
-	ROM_REGION( 0x0100, "spr_clut", 0 )
-	ROM_LOAD( "mpc-2.2h",     0x0000, 0x0100, CRC(7ae4cd97) SHA1(bc0662fac82ffe65f02092d912b2c2b0c7a8ac2b) ) /* sprite lookup table */
+	ROM_REGION(0x0100, "spr_clut", 0)
+	ROM_LOAD("mpc-2.2h", 0x0000, 0x0100, CRC(7ae4cd97) SHA1(bc0662fac82ffe65f02092d912b2c2b0c7a8ac2b)) /* sprite lookup table */
 ROM_END
 
-ROM_START( mranger )
-	ROM_REGION( 0x10000, "maincpu", 0 )
-	ROM_LOAD( "mpa-1.3m",      0x0000, 0x1000, CRC(5873a860) SHA1(8c03726d6e049c3edbc277440184e31679f78258) )
-	ROM_LOAD( "mra-2.3l",      0x1000, 0x1000, CRC(217dd431) SHA1(7b81f854209afc1fd3df11b7375f36de6bc4a7c3) )
-	ROM_LOAD( "mra-3.3k",      0x2000, 0x1000, CRC(9f0af7b2) SHA1(3daaec15b0d3bc30723ebb14b50f66f288f0d096) )
-	ROM_LOAD( "mra-4.3j",      0x3000, 0x1000, CRC(7fe8e2cd) SHA1(4ffad9c7a9360999b213b790c6c76cc79c8e49d5) )
+ROM_START(mranger)
+	ROM_REGION(0x10000, "maincpu", 0)
+	ROM_LOAD("mpa-1.3m", 0x0000, 0x1000, CRC(5873a860) SHA1(8c03726d6e049c3edbc277440184e31679f78258))
+	ROM_LOAD("mra-2.3l", 0x1000, 0x1000, CRC(217dd431) SHA1(7b81f854209afc1fd3df11b7375f36de6bc4a7c3))
+	ROM_LOAD("mra-3.3k", 0x2000, 0x1000, CRC(9f0af7b2) SHA1(3daaec15b0d3bc30723ebb14b50f66f288f0d096))
+	ROM_LOAD("mra-4.3j", 0x3000, 0x1000, CRC(7fe8e2cd) SHA1(4ffad9c7a9360999b213b790c6c76cc79c8e49d5))
 
-	ROM_REGION( 0x8000, "irem_audio:iremsound", 0 )
-	ROM_LOAD( "mp-s1.1a",     0x7000, 0x1000, CRC(561d3108) SHA1(4998c68a9e9a8002251fa8f07aa1082444a9dc80) )
+	ROM_REGION(0x8000, "irem_audio:iremsound", 0)
+	ROM_LOAD("mp-s1.1a", 0x7000, 0x1000, CRC(561d3108) SHA1(4998c68a9e9a8002251fa8f07aa1082444a9dc80))
 
-	ROM_REGION( 0x2000, "gfx1", 0 )
-	ROM_LOAD( "mpe-5.3e",     0x0000, 0x1000, CRC(e3ee7f75) SHA1(b03d0d56150d3e9da4a4c871338097b4f450b649) )       /* chars */
-	ROM_LOAD( "mpe-4.3f",     0x1000, 0x1000, CRC(cca6d023) SHA1(fecb3059fb09897a096add9452b50aec55c07545) )
+	ROM_REGION(0x2000, "tx", 0)
+	ROM_LOAD("mpe-5.3e", 0x0000, 0x1000, CRC(e3ee7f75) SHA1(b03d0d56150d3e9da4a4c871338097b4f450b649))       /* chars */
+	ROM_LOAD("mpe-4.3f", 0x1000, 0x1000, CRC(cca6d023) SHA1(fecb3059fb09897a096add9452b50aec55c07545))
 
-	ROM_REGION( 0x2000, "gfx2", 0 )
-	ROM_LOAD( "mpb-2.3m",     0x0000, 0x1000, CRC(707ace5e) SHA1(93c682e13e74bce29ced3a87bffb29569c114c3b) )       /* sprites */
-	ROM_LOAD( "mpb-1.3n",     0x1000, 0x1000, CRC(9b72133a) SHA1(1393ef92ae1ad58a4b62ca1660c0793d30a8b5e2) )
+	ROM_REGION(0x2000, "sp", 0)
+	ROM_LOAD("mpb-2.3m", 0x0000, 0x1000, CRC(707ace5e) SHA1(93c682e13e74bce29ced3a87bffb29569c114c3b))       /* sprites */
+	ROM_LOAD("mpb-1.3n", 0x1000, 0x1000, CRC(9b72133a) SHA1(1393ef92ae1ad58a4b62ca1660c0793d30a8b5e2))
 
-	ROM_REGION( 0x1000, "gfx3", 0 )
-	ROM_LOAD( "mpe-1.3l",     0x0000, 0x1000, CRC(c46a7f72) SHA1(8bb7c9acaf6833fb6c0575b015991b873a305a84) )       /* background graphics */
+	ROM_REGION(0x1000, "bg0", 0)
+	ROM_LOAD("mpe-1.3l", 0x0000, 0x1000, CRC(c46a7f72) SHA1(8bb7c9acaf6833fb6c0575b015991b873a305a84))       /* background graphics */
 
-	ROM_REGION( 0x1000, "gfx4", 0 )
-	ROM_LOAD( "mpe-2.3k",     0x0000, 0x1000, CRC(c7aa1fb0) SHA1(14c6c76e1d0db2c0745e5d6d33ea6945fac8e9ee) )
+	ROM_REGION(0x1000, "bg1", 0)
+	ROM_LOAD("mpe-2.3k", 0x0000, 0x1000, CRC(c7aa1fb0) SHA1(14c6c76e1d0db2c0745e5d6d33ea6945fac8e9ee))
 
-	ROM_REGION( 0x1000, "gfx5", 0 )
-	ROM_LOAD( "mpe-3.3h",     0x0000, 0x1000, CRC(a0919392) SHA1(8a090cb8d483a3d67c7360058e3fdd70e151cd62) )
+	ROM_REGION(0x1000, "bg2", 0)
+	ROM_LOAD("mpe-3.3h", 0x0000, 0x1000, CRC(a0919392) SHA1(8a090cb8d483a3d67c7360058e3fdd70e151cd62))
 
-	ROM_REGION( 0x0200, "tx_pal", 0 )
-	ROM_LOAD( "mpc-4.2a",     0x0000, 0x0200, CRC(07f99284) SHA1(dfc52958f2520e1ce4446dd4c84c91413bbacf76) )
+	ROM_REGION(0x0200, "tx_pal", 0)
+	ROM_LOAD("mpc-4.2a", 0x0000, 0x0200, CRC(07f99284) SHA1(dfc52958f2520e1ce4446dd4c84c91413bbacf76))
 
-	ROM_REGION( 0x0020, "bg_pal", 0 )
-	ROM_LOAD( "mpc-3.1m",     0x0000, 0x0020, CRC(6a57eff2) SHA1(2d1c12dab5915da2ccd466e39436c88be434d634) ) /* background palette */
+	ROM_REGION(0x0020, "bg_pal", 0)
+	ROM_LOAD("mpc-3.1m", 0x0000, 0x0020, CRC(6a57eff2) SHA1(2d1c12dab5915da2ccd466e39436c88be434d634)) /* background palette */
 
-	ROM_REGION( 0x0020, "spr_pal", 0 )
-	ROM_LOAD( "mpc-1.1f",     0x0000, 0x0020, CRC(26979b13) SHA1(8c41a8cce4f3384c392a9f7a223a50d7be0e14a5) ) /* sprite palette */
+	ROM_REGION(0x0020, "spr_pal", 0)
+	ROM_LOAD("mpc-1.1f", 0x0000, 0x0020, CRC(26979b13) SHA1(8c41a8cce4f3384c392a9f7a223a50d7be0e14a5)) /* sprite palette */
 
-	ROM_REGION( 0x0100, "spr_clut", 0 )
-	ROM_LOAD( "mpc-2.2h",     0x0000, 0x0100, CRC(7ae4cd97) SHA1(bc0662fac82ffe65f02092d912b2c2b0c7a8ac2b) ) /* sprite lookup table */
+	ROM_REGION(0x0100, "spr_clut", 0)
+	ROM_LOAD("mpc-2.2h", 0x0000, 0x0100, CRC(7ae4cd97) SHA1(bc0662fac82ffe65f02092d912b2c2b0c7a8ac2b)) /* sprite lookup table */
 ROM_END
 
 
-ROM_START( alpha1v )
-	ROM_REGION( 0x10000, "maincpu", 0 )
-	ROM_LOAD( "2-m3",      0x0000, 0x1000, CRC(3a679d34) SHA1(1a54a43070c56dc91d4d258f29e29613bb309f1c) )
-	ROM_LOAD( "3-l3",      0x1000, 0x1000, CRC(2f09df64) SHA1(e91602e9e41ad24dd1d7f384ed81b9bdaadd03e1) )
-	ROM_LOAD( "4-k3",      0x2000, 0x1000, CRC(64fb9c8a) SHA1(735fd00cc42193a417e6cde75f12b4cf2e804942) )
-	ROM_LOAD( "5-j3",      0x3000, 0x1000, CRC(d1643d18) SHA1(7c794b82e17e2ba0a6237e3fc20d8314f6c2481c) )
-	ROM_LOAD( "6-h3",      0x4000, 0x1000, CRC(cf34ab51) SHA1(3696da71e2bc7edd1ee7aeaac87be5386608c09e) )
-	ROM_LOAD( "7-f3",      0x5000, 0x1000, CRC(99db9781) SHA1(a56a675cc4cbc9681bfe8052f51f19336eb2a0a6) )
-	ROM_LOAD( "7a e3",     0x6000, 0x1000, CRC(3b0b4b0d) SHA1(0d8eea1e2db269943611289b3490a578ee347f85) )
+ROM_START(alpha1v)
+	ROM_REGION(0x10000, "maincpu", 0)
+	ROM_LOAD("2-m3",  0x0000, 0x1000, CRC(3a679d34) SHA1(1a54a43070c56dc91d4d258f29e29613bb309f1c))
+	ROM_LOAD("3-l3",  0x1000, 0x1000, CRC(2f09df64) SHA1(e91602e9e41ad24dd1d7f384ed81b9bdaadd03e1))
+	ROM_LOAD("4-k3",  0x2000, 0x1000, CRC(64fb9c8a) SHA1(735fd00cc42193a417e6cde75f12b4cf2e804942))
+	ROM_LOAD("5-j3",  0x3000, 0x1000, CRC(d1643d18) SHA1(7c794b82e17e2ba0a6237e3fc20d8314f6c2481c))
+	ROM_LOAD("6-h3",  0x4000, 0x1000, CRC(cf34ab51) SHA1(3696da71e2bc7edd1ee7aeaac87be5386608c09e))
+	ROM_LOAD("7-f3",  0x5000, 0x1000, CRC(99db9781) SHA1(a56a675cc4cbc9681bfe8052f51f19336eb2a0a6))
+	ROM_LOAD("7a e3", 0x6000, 0x1000, CRC(3b0b4b0d) SHA1(0d8eea1e2db269943611289b3490a578ee347f85))
 
-	ROM_REGION( 0x8000, "irem_audio:iremsound", 0 )
-	ROM_LOAD( "1-a1",      0x7000, 0x1000, CRC(9e07fdd5) SHA1(ed4f462fcfe91fa8e88bfeaaba0a0c11fa0b4601) )
+	ROM_REGION(0x8000, "irem_audio:iremsound", 0)
+	ROM_LOAD("1-a1", 0x7000, 0x1000, CRC(9e07fdd5) SHA1(ed4f462fcfe91fa8e88bfeaaba0a0c11fa0b4601))
 
-	ROM_REGION( 0x2000, "gfx1", 0 )
-	ROM_LOAD( "14-e3",     0x0000, 0x1000, CRC(cf00c737) SHA1(415e90289039cac4d04cb1d559f1378ca6a32132) )       /* chars */
-	ROM_LOAD( "13-f3",     0x1000, 0x1000, CRC(4b799229) SHA1(42cbdcf787b08b041d30504d699a12c378224933) )
+	ROM_REGION(0x2000, "tx", 0)
+	ROM_LOAD("14-e3", 0x0000, 0x1000, CRC(cf00c737) SHA1(415e90289039cac4d04cb1d559f1378ca6a32132))       /* chars */
+	ROM_LOAD("13-f3", 0x1000, 0x1000, CRC(4b799229) SHA1(42cbdcf787b08b041d30504d699a12c378224933))
 
-	ROM_REGION( 0x3000, "gfx2", 0 ) // 3bpp? (mpatrol is 2bpp..)
-	ROM_LOAD( "15-n3",     0x0000, 0x1000, CRC(dc26df76) SHA1(dd1cff7935f5559f9d1b440e02d5e5aa521b0054) )
-	ROM_LOAD( "16-l3",     0x1000, 0x1000, CRC(39b9863b) SHA1(da9da9a1066188f050c422dfed1bbbd3ba612ccc) )
-	ROM_LOAD( "17-k3",     0x2000, 0x1000, CRC(cfd90773) SHA1(052e126888b6de636db9c521a090699c282b620b) )
+	ROM_REGION(0x3000, "sp", 0) // 3bpp (mpatrol is 2bpp)
+	ROM_LOAD("15-n3", 0x0000, 0x1000, CRC(dc26df76) SHA1(dd1cff7935f5559f9d1b440e02d5e5aa521b0054))
+	ROM_LOAD("16-l3", 0x1000, 0x1000, CRC(39b9863b) SHA1(da9da9a1066188f050c422dfed1bbbd3ba612ccc))
+	ROM_LOAD("17-k3", 0x2000, 0x1000, CRC(cfd90773) SHA1(052e126888b6de636db9c521a090699c282b620b))
 
 	/* all the background roms just contain stars.. */
-	ROM_REGION( 0x1000, "gfx3", 0 )
-	ROM_LOAD( "11-k3",     0x0000, 0x1000, CRC(7659440a) SHA1(2efd27c82913513dd03e799f1ed3c10b0863677d) ) // these two match..
-	ROM_LOAD( "12-jh3",    0x0000, 0x1000, CRC(7659440a) SHA1(2efd27c82913513dd03e799f1ed3c10b0863677d) )
+	/* all the background roms just contain stars.. */
+	ROM_REGION(0x1000, "bg0", 0)
+	ROM_LOAD("11-k3", 0x0000, 0x1000, CRC(7659440a) SHA1(2efd27c82913513dd03e799f1ed3c10b0863677d)) // why are there 2 copies of the this BG rom?
+	ROM_LOAD("12-jh3", 0x0000, 0x1000, CRC(7659440a) SHA1(2efd27c82913513dd03e799f1ed3c10b0863677d))
 
-	ROM_REGION( 0x1000, "gfx4", 0 )
-	ROM_LOAD( "9-n3",     0x0000, 0x1000, CRC(0fdb7d13) SHA1(e828254a4f94df633d338b5772719276d41c6b7f) )
+	ROM_REGION(0x1000, "bg1", 0)
+	ROM_LOAD("9-n3", 0x0000, 0x1000, CRC(0fdb7d13) SHA1(e828254a4f94df633d338b5772719276d41c6b7f))
 
-	ROM_REGION( 0x1000, "gfx5", 0 )
-	ROM_LOAD( "10-lm3",     0x0000, 0x1000, CRC(9dde3a75) SHA1(293d093485be19bfb20685d76a08ac78e24062bf) )
+	ROM_REGION(0x1000, "bg2", 0)
+	ROM_LOAD("10-lm3", 0x0000, 0x1000, CRC(9dde3a75) SHA1(293d093485be19bfb20685d76a08ac78e24062bf))
 
-	ROM_REGION( 0x0200, "tx_pal", 0 )
-	ROM_LOAD( "63s481-a2",     0x0000, 0x0200, CRC(58678ea8) SHA1(b13a78a5bca8ad5bdec1293512b53654768a7a7a) )
+	ROM_REGION(0x0200, "tx_pal", 0)
+	ROM_LOAD("63s481-a2", 0x0000, 0x0200, CRC(58678ea8) SHA1(b13a78a5bca8ad5bdec1293512b53654768a7a7a))
 
-	ROM_REGION( 0x0020, "bg_pal", 0 )
-	ROM_LOAD( "18s030-m1",     0x0000, 0x0020, CRC(6a57eff2) SHA1(2d1c12dab5915da2ccd466e39436c88be434d634) ) /* background palette */
+	ROM_REGION(0x0020, "bg_pal", 0)
+	ROM_LOAD("18s030-m1", 0x0000, 0x0020, CRC(6a57eff2) SHA1(2d1c12dab5915da2ccd466e39436c88be434d634)) /* background palette */
 
-	ROM_REGION( 0x0020, "spr_pal", 0 )
-	ROM_LOAD( "mb7051-f1",     0x0000, 0x0020, CRC(d8bdd0df) SHA1(ca522428927911808214d319af314f601497ded4) ) /* sprite palette */
+	ROM_REGION(0x0020, "spr_pal", 0)
+	ROM_LOAD("mb7051-f1", 0x0000, 0x0020, CRC(d8bdd0df) SHA1(ca522428927911808214d319af314f601497ded4)) /* sprite palette */
 
-	ROM_REGION( 0x0100, "spr_clut", 0 )
-	ROM_LOAD( "mb7052-h2",     0x0000, 0x0100, CRC(ce9f0ef9) SHA1(3afb94ed033f272983bbed22a59856df7824ef8a) ) /* sprite lookup table */
+	ROM_REGION(0x0100, "spr_clut", 0)
+	ROM_LOAD("mb7052-h2", 0x0000, 0x0100, CRC(ce9f0ef9) SHA1(3afb94ed033f272983bbed22a59856df7824ef8a)) /* sprite lookup table */
 ROM_END
-
 
 
 /*************************************
- *
- *  Game drivers
- *
- *************************************/
+*
+*  Game drivers
+*
+*************************************/
 
-GAME( 1982, mpatrol,  0,       m52,     mpatrol,  m52_state, empty_init, ROT0, "Irem", "Moon Patrol",                                  MACHINE_SUPPORTS_SAVE )
-GAME( 1982, mpatrolw, mpatrol, m52,     mpatrolw, m52_state, empty_init, ROT0, "Irem (Williams license)", "Moon Patrol (Williams)",    MACHINE_SUPPORTS_SAVE ) // USA
-GAME( 1982, mranger,  mpatrol, m52,     mpatrol,  m52_state, empty_init, ROT0, "bootleg", "Moon Ranger (bootleg of Moon Patrol)",      MACHINE_SUPPORTS_SAVE ) // Italy
-GAME( 1988, alpha1v,  0,       alpha1v, alpha1v,  m52_state, empty_init, ROT0, "Vision Electronics", "Alpha One (Vision Electronics)", MACHINE_NOT_WORKING | MACHINE_NO_SOUND | MACHINE_SUPPORTS_SAVE )
+GAME(1982, mpatrol,  0,       m52,     mpatrol,  m52_state,         empty_init, ROT0, "Irem",                    "Moon Patrol", MACHINE_SUPPORTS_SAVE)
+GAME(1982, mpatrolw, mpatrol, m52,     mpatrolw, m52_state,         empty_init, ROT0, "Irem (Williams license)", "Moon Patrol (Williams)", MACHINE_SUPPORTS_SAVE) // USA
+GAME(1982, mranger,  mpatrol, m52,     mpatrol,  m52_state,         empty_init, ROT0, "bootleg",                 "Moon Ranger (bootleg of Moon Patrol)", MACHINE_SUPPORTS_SAVE) // Italy
+
+GAME(1988, alpha1v,  0,       alpha1v, alpha1v,  m52_alpha1v_state, empty_init, ROT0, "Vision Electronics",      "Alpha One (Vision Electronics)", MACHINE_NOT_WORKING | MACHINE_SUPPORTS_SAVE)

--- a/src/mame/drivers/m52.cpp
+++ b/src/mame/drivers/m52.cpp
@@ -606,7 +606,6 @@ ROM_START(alpha1v)
 	ROM_LOAD("17-k3", 0x2000, 0x1000, CRC(cfd90773) SHA1(052e126888b6de636db9c521a090699c282b620b))
 
 	/* all the background roms just contain stars.. */
-	/* all the background roms just contain stars.. */
 	ROM_REGION(0x1000, "bg0", 0)
 	ROM_LOAD("11-k3", 0x0000, 0x1000, CRC(7659440a) SHA1(2efd27c82913513dd03e799f1ed3c10b0863677d)) // why are there 2 copies of the this BG rom?
 	ROM_LOAD("12-jh3", 0x0000, 0x1000, CRC(7659440a) SHA1(2efd27c82913513dd03e799f1ed3c10b0863677d))

--- a/src/mame/drivers/m52.cpp
+++ b/src/mame/drivers/m52.cpp
@@ -633,4 +633,4 @@ GAME(1982, mpatrol,  0,       m52,     mpatrol,  m52_state,         empty_init, 
 GAME(1982, mpatrolw, mpatrol, m52,     mpatrolw, m52_state,         empty_init, ROT0, "Irem (Williams license)", "Moon Patrol (Williams)", MACHINE_SUPPORTS_SAVE) // USA
 GAME(1982, mranger,  mpatrol, m52,     mpatrol,  m52_state,         empty_init, ROT0, "bootleg",                 "Moon Ranger (bootleg of Moon Patrol)", MACHINE_SUPPORTS_SAVE) // Italy
 
-GAME(1988, alpha1v,  0,       alpha1v, alpha1v,  m52_alpha1v_state, empty_init, ROT0, "Vision Electronics",      "Alpha One (Vision Electronics)", MACHINE_NOT_WORKING | MACHINE_SUPPORTS_SAVE)
+GAME(1988, alpha1v,  0,       alpha1v, alpha1v,  m52_alpha1v_state, empty_init, ROT0, "Vision Electronics",      "Alpha One (Vision Electronics)", MACHINE_SUPPORTS_SAVE)

--- a/src/mame/drivers/m52.cpp
+++ b/src/mame/drivers/m52.cpp
@@ -347,14 +347,14 @@ static const uint32_t bgcharlayout_xoffset[256] =
 	STEP4(0x1e0,1), STEP4(0x1e8,1), STEP4(0x1f0,1), STEP4(0x1f8,1)
 };
 
-static const uint32_t bgcharlayout_yoffset[64] =
+static const uint32_t bgcharlayout_yoffset[128] =
 {
-	STEP32(0x0000,0x200), STEP32(0x4000,0x200)
+	STEP32(0x0000,0x200), STEP32(0x4000,0x200), STEP32(0x8000,0x200), STEP32(0xc000,0x200)
 };
 
 static const gfx_layout bgcharlayout =
 {
-	256, 64, /* 256x64 image format */
+	256, 128, /* 256x64 image format */
 	1,       /* 1 image */
 	2,       /* 2 bits per pixel */
 	{ 4, 0 },       /* the two bitplanes for 4 pixels are packed into one byte */
@@ -480,13 +480,14 @@ ROM_START(mpatrol)
 	ROM_LOAD("mpb-2.3m", 0x0000, 0x1000, CRC(707ace5e) SHA1(93c682e13e74bce29ced3a87bffb29569c114c3b))
 	ROM_LOAD("mpb-1.3n", 0x1000, 0x1000, CRC(9b72133a) SHA1(1393ef92ae1ad58a4b62ca1660c0793d30a8b5e2))
 
-	ROM_REGION(0x1000, "bg0", 0)
+	/* 0x1000-01fff is intentionally left as 0xff fill for the bg regions */
+	ROM_REGION(0x2000, "bg0", ROMREGION_ERASEFF)
 	ROM_LOAD("mpe-1.3l", 0x0000, 0x1000, CRC(c46a7f72) SHA1(8bb7c9acaf6833fb6c0575b015991b873a305a84))
 
-	ROM_REGION(0x1000, "bg1", 0)
+	ROM_REGION(0x2000, "bg1", ROMREGION_ERASEFF)
 	ROM_LOAD("mpe-2.3k", 0x0000, 0x1000, CRC(c7aa1fb0) SHA1(14c6c76e1d0db2c0745e5d6d33ea6945fac8e9ee))
 
-	ROM_REGION(0x1000, "bg2", 0)
+	ROM_REGION(0x2000, "bg2", ROMREGION_ERASEFF)
 	ROM_LOAD("mpe-3.3h", 0x0000, 0x1000, CRC(a0919392) SHA1(8a090cb8d483a3d67c7360058e3fdd70e151cd62))
 
 	ROM_REGION(0x0200, "tx_pal", 0)
@@ -520,13 +521,14 @@ ROM_START(mpatrolw)
 	ROM_LOAD("mpb-2.3m", 0x0000, 0x1000, CRC(707ace5e) SHA1(93c682e13e74bce29ced3a87bffb29569c114c3b))
 	ROM_LOAD("mpb-1.3n", 0x1000, 0x1000, CRC(9b72133a) SHA1(1393ef92ae1ad58a4b62ca1660c0793d30a8b5e2))
 
-	ROM_REGION(0x1000, "bg0", 0)
+	/* 0x1000-01fff is intentionally left as 0xff fill for the bg regions */
+	ROM_REGION(0x2000, "bg0", ROMREGION_ERASEFF)
 	ROM_LOAD("mpe-1.3l", 0x0000, 0x1000, CRC(c46a7f72) SHA1(8bb7c9acaf6833fb6c0575b015991b873a305a84))
 
-	ROM_REGION(0x1000, "bg1", 0)
+	ROM_REGION(0x2000, "bg1", ROMREGION_ERASEFF)
 	ROM_LOAD("mpe-2.3k", 0x0000, 0x1000, CRC(c7aa1fb0) SHA1(14c6c76e1d0db2c0745e5d6d33ea6945fac8e9ee))
 
-	ROM_REGION(0x1000, "bg2", 0)
+	ROM_REGION(0x2000, "bg2", ROMREGION_ERASEFF)
 	ROM_LOAD("mpe-3.3h", 0x0000, 0x1000, CRC(a0919392) SHA1(8a090cb8d483a3d67c7360058e3fdd70e151cd62))
 
 	ROM_REGION(0x0200, "tx_pal", 0)
@@ -560,13 +562,14 @@ ROM_START(mranger)
 	ROM_LOAD("mpb-2.3m", 0x0000, 0x1000, CRC(707ace5e) SHA1(93c682e13e74bce29ced3a87bffb29569c114c3b))
 	ROM_LOAD("mpb-1.3n", 0x1000, 0x1000, CRC(9b72133a) SHA1(1393ef92ae1ad58a4b62ca1660c0793d30a8b5e2))
 
-	ROM_REGION(0x1000, "bg0", 0)
+	/* 0x1000-01fff is intentionally left as 0xff fill for the bg regions */
+	ROM_REGION(0x2000, "bg0", ROMREGION_ERASEFF)
 	ROM_LOAD("mpe-1.3l", 0x0000, 0x1000, CRC(c46a7f72) SHA1(8bb7c9acaf6833fb6c0575b015991b873a305a84))
 
-	ROM_REGION(0x1000, "bg1", 0)
+	ROM_REGION(0x2000, "bg1", ROMREGION_ERASEFF)
 	ROM_LOAD("mpe-2.3k", 0x0000, 0x1000, CRC(c7aa1fb0) SHA1(14c6c76e1d0db2c0745e5d6d33ea6945fac8e9ee))
 
-	ROM_REGION(0x1000, "bg2", 0)
+	ROM_REGION(0x2000, "bg2", ROMREGION_ERASEFF)
 	ROM_LOAD("mpe-3.3h", 0x0000, 0x1000, CRC(a0919392) SHA1(8a090cb8d483a3d67c7360058e3fdd70e151cd62))
 
 	ROM_REGION(0x0200, "tx_pal", 0)
@@ -605,16 +608,16 @@ ROM_START(alpha1v)
 	ROM_LOAD("16-l3", 0x1000, 0x1000, CRC(39b9863b) SHA1(da9da9a1066188f050c422dfed1bbbd3ba612ccc))
 	ROM_LOAD("17-k3", 0x2000, 0x1000, CRC(cfd90773) SHA1(052e126888b6de636db9c521a090699c282b620b))
 
-	/* all the background roms just contain stars.. */
-	ROM_REGION(0x1000, "bg0", 0)
-	ROM_LOAD("11-k3", 0x0000, 0x1000, CRC(7659440a) SHA1(2efd27c82913513dd03e799f1ed3c10b0863677d)) // why are there 2 copies of the this BG rom?
-	ROM_LOAD("12-jh3", 0x0000, 0x1000, CRC(7659440a) SHA1(2efd27c82913513dd03e799f1ed3c10b0863677d))
+	/* all the background roms just contain stars, looks like it wants 2x128 px high images, instead of 3x64, arrangement unclear */
+	ROM_REGION(0x2000, "bg0", ROMREGION_ERASEFF)
+	ROM_LOAD("11-k3",  0x0000, 0x1000, CRC(7659440a) SHA1(2efd27c82913513dd03e799f1ed3c10b0863677d)) // rom is duplicated
+	ROM_LOAD("12-jh3", 0x1000, 0x1000, CRC(7659440a) SHA1(2efd27c82913513dd03e799f1ed3c10b0863677d))
 
-	ROM_REGION(0x1000, "bg1", 0)
-	ROM_LOAD("9-n3", 0x0000, 0x1000, CRC(0fdb7d13) SHA1(e828254a4f94df633d338b5772719276d41c6b7f))
+	ROM_REGION(0x2000, "bg1", ROMREGION_ERASEFF)
+	ROM_LOAD("9-n3",   0x0000, 0x1000, CRC(0fdb7d13) SHA1(e828254a4f94df633d338b5772719276d41c6b7f))
+	ROM_LOAD("10-lm3", 0x1000, 0x1000, CRC(9dde3a75) SHA1(293d093485be19bfb20685d76a08ac78e24062bf))
 
-	ROM_REGION(0x1000, "bg2", 0)
-	ROM_LOAD("10-lm3", 0x0000, 0x1000, CRC(9dde3a75) SHA1(293d093485be19bfb20685d76a08ac78e24062bf))
+	ROM_REGION(0x2000, "bg2", ROMREGION_ERASEFF)
 
 	ROM_REGION(0x0200, "tx_pal", 0)
 	ROM_LOAD("63s481-a2", 0x0000, 0x0200, CRC(58678ea8) SHA1(b13a78a5bca8ad5bdec1293512b53654768a7a7a))

--- a/src/mame/drivers/m52.cpp
+++ b/src/mame/drivers/m52.cpp
@@ -370,15 +370,19 @@ static const gfx_layout bgcharlayout =
 };
 
 
-static GFXDECODE_START( gfx_m52 )
-	GFXDECODE_ENTRY( "gfx1", 0x0000, charlayout,                0, 128 )
-	GFXDECODE_ENTRY( "gfx2", 0x0000, spritelayout,          128*4,  16 )
-	GFXDECODE_ENTRY( "gfx3", 0x0000, bgcharlayout, 128*4+16*4+0*4,   1 )
-	GFXDECODE_ENTRY( "gfx4", 0x0000, bgcharlayout, 128*4+16*4+1*4,   1 )
-	GFXDECODE_ENTRY( "gfx5", 0x0000, bgcharlayout, 128*4+16*4+2*4,   1 )
+static GFXDECODE_START( gfx_m52_sp )
+	GFXDECODE_ENTRY( "gfx2", 0x0000, spritelayout,          0,  16 )
 GFXDECODE_END
 
+static GFXDECODE_START( gfx_m52_tx )
+	GFXDECODE_ENTRY( "gfx1", 0x0000, charlayout,                0, 128 )
+GFXDECODE_END
 
+static GFXDECODE_START( gfx_m52_bg )
+	GFXDECODE_ENTRY( "gfx3", 0x0000, bgcharlayout, 0*4,   1 )
+	GFXDECODE_ENTRY( "gfx4", 0x0000, bgcharlayout, 1*4,   1 )
+	GFXDECODE_ENTRY( "gfx5", 0x0000, bgcharlayout, 2*4,   1 )
+GFXDECODE_END
 
 /*************************************
  *
@@ -404,15 +408,22 @@ MACHINE_CONFIG_START(m52_state::m52)
 	MCFG_DEVICE_VBLANK_INT_DRIVER("screen", m52_state,  irq0_line_hold)
 
 	/* video hardware */
-	MCFG_DEVICE_ADD("gfxdecode", GFXDECODE, "palette", gfx_m52)
-	MCFG_PALETTE_ADD("palette", 128*4+16*4+3*4)
-	MCFG_PALETTE_INDIRECT_ENTRIES(512+32+32)
-	MCFG_PALETTE_INIT_OWNER(m52_state, m52)
+
+	MCFG_PALETTE_ADD("sp_palette", 16*4)
+	MCFG_PALETTE_INDIRECT_ENTRIES(32)
+	MCFG_DEVICE_ADD("sp_gfxdecode", GFXDECODE, "sp_palette", gfx_m52_sp)
+
+	MCFG_PALETTE_ADD("tx_palette", 512)
+	MCFG_DEVICE_ADD("tx_gfxdecode", GFXDECODE, "tx_palette", gfx_m52_tx)
+
+	MCFG_PALETTE_ADD("bg_palette", 3*4)
+	MCFG_PALETTE_INDIRECT_ENTRIES(32)
+	MCFG_DEVICE_ADD("bg_gfxdecode", GFXDECODE, "bg_palette", gfx_m52_bg)
+
 
 	MCFG_SCREEN_ADD("screen", RASTER)
 	MCFG_SCREEN_RAW_PARAMS(MASTER_CLOCK/3, 384, 136, 376, 282, 22, 274)
 	MCFG_SCREEN_UPDATE_DRIVER(m52_state, screen_update_m52)
-	MCFG_SCREEN_PALETTE("palette")
 
 	/* sound hardware */
 	//m52_sound_c_audio(config);
@@ -466,11 +477,17 @@ ROM_START( mpatrol )
 	ROM_REGION( 0x1000, "gfx5", 0 )
 	ROM_LOAD( "mpe-3.3h",     0x0000, 0x1000, CRC(a0919392) SHA1(8a090cb8d483a3d67c7360058e3fdd70e151cd62) )
 
-	ROM_REGION( 0x0340, "proms", 0 )
+	ROM_REGION( 0x0200, "tx_pal", 0 )
 	ROM_LOAD( "mpc-4.2a",     0x0000, 0x0200, CRC(07f99284) SHA1(dfc52958f2520e1ce4446dd4c84c91413bbacf76) )
-	ROM_LOAD( "mpc-3.1m",     0x0200, 0x0020, CRC(6a57eff2) SHA1(2d1c12dab5915da2ccd466e39436c88be434d634) ) /* background palette */
-	ROM_LOAD( "mpc-1.1f",     0x0220, 0x0020, CRC(26979b13) SHA1(8c41a8cce4f3384c392a9f7a223a50d7be0e14a5) ) /* sprite palette */
-	ROM_LOAD( "mpc-2.2h",     0x0240, 0x0100, CRC(7ae4cd97) SHA1(bc0662fac82ffe65f02092d912b2c2b0c7a8ac2b) ) /* sprite lookup table */
+	
+	ROM_REGION( 0x0020, "bg_pal", 0 )
+	ROM_LOAD( "mpc-3.1m",     0x0000, 0x0020, CRC(6a57eff2) SHA1(2d1c12dab5915da2ccd466e39436c88be434d634) ) /* background palette */
+
+	ROM_REGION( 0x0020, "spr_pal", 0 )
+	ROM_LOAD( "mpc-1.1f",     0x0000, 0x0020, CRC(26979b13) SHA1(8c41a8cce4f3384c392a9f7a223a50d7be0e14a5) ) /* sprite palette */
+
+	ROM_REGION( 0x0100, "spr_clut", 0 )
+	ROM_LOAD( "mpc-2.2h",     0x0000, 0x0100, CRC(7ae4cd97) SHA1(bc0662fac82ffe65f02092d912b2c2b0c7a8ac2b) ) /* sprite lookup table */
 ROM_END
 
 ROM_START( mpatrolw )
@@ -500,11 +517,17 @@ ROM_START( mpatrolw )
 	ROM_REGION( 0x1000, "gfx5", 0 )
 	ROM_LOAD( "mpe-3.3h",     0x0000, 0x1000, CRC(a0919392) SHA1(8a090cb8d483a3d67c7360058e3fdd70e151cd62) )
 
-	ROM_REGION( 0x0340, "proms", 0 )
+	ROM_REGION( 0x0200, "tx_pal", 0 )
 	ROM_LOAD( "mpc-4a.2a",    0x0000, 0x0200, CRC(cb0a5ff3) SHA1(d3f88b4e0c4858abac8b52105656ecece0cf4df9) )
-	ROM_LOAD( "mpc-3.1m",     0x0200, 0x0020, CRC(6a57eff2) SHA1(2d1c12dab5915da2ccd466e39436c88be434d634) ) /* background palette */
-	ROM_LOAD( "mpc-1.1f",     0x0220, 0x0020, CRC(26979b13) SHA1(8c41a8cce4f3384c392a9f7a223a50d7be0e14a5) ) /* sprite palette */
-	ROM_LOAD( "mpc-2.2h",     0x0240, 0x0100, CRC(7ae4cd97) SHA1(bc0662fac82ffe65f02092d912b2c2b0c7a8ac2b) ) /* sprite lookup table */
+
+	ROM_REGION( 0x0020, "bg_pal", 0 )
+	ROM_LOAD( "mpc-3.1m",     0x0000, 0x0020, CRC(6a57eff2) SHA1(2d1c12dab5915da2ccd466e39436c88be434d634) ) /* background palette */
+
+	ROM_REGION( 0x0020, "spr_pal", 0 )
+	ROM_LOAD( "mpc-1.1f",     0x0000, 0x0020, CRC(26979b13) SHA1(8c41a8cce4f3384c392a9f7a223a50d7be0e14a5) ) /* sprite palette */
+
+	ROM_REGION( 0x0100, "spr_clut", 0 )
+	ROM_LOAD( "mpc-2.2h",     0x0000, 0x0100, CRC(7ae4cd97) SHA1(bc0662fac82ffe65f02092d912b2c2b0c7a8ac2b) ) /* sprite lookup table */
 ROM_END
 
 ROM_START( mranger )
@@ -534,11 +557,17 @@ ROM_START( mranger )
 	ROM_REGION( 0x1000, "gfx5", 0 )
 	ROM_LOAD( "mpe-3.3h",     0x0000, 0x1000, CRC(a0919392) SHA1(8a090cb8d483a3d67c7360058e3fdd70e151cd62) )
 
-	ROM_REGION( 0x0340, "proms", 0 )
+	ROM_REGION( 0x0200, "tx_pal", 0 )
 	ROM_LOAD( "mpc-4.2a",     0x0000, 0x0200, CRC(07f99284) SHA1(dfc52958f2520e1ce4446dd4c84c91413bbacf76) )
-	ROM_LOAD( "mpc-3.1m",     0x0200, 0x0020, CRC(6a57eff2) SHA1(2d1c12dab5915da2ccd466e39436c88be434d634) ) /* background palette */
-	ROM_LOAD( "mpc-1.1f",     0x0220, 0x0020, CRC(26979b13) SHA1(8c41a8cce4f3384c392a9f7a223a50d7be0e14a5) ) /* sprite palette */
-	ROM_LOAD( "mpc-2.2h",     0x0240, 0x0100, CRC(7ae4cd97) SHA1(bc0662fac82ffe65f02092d912b2c2b0c7a8ac2b) ) /* sprite lookup table */
+
+	ROM_REGION( 0x0020, "bg_pal", 0 )
+	ROM_LOAD( "mpc-3.1m",     0x0000, 0x0020, CRC(6a57eff2) SHA1(2d1c12dab5915da2ccd466e39436c88be434d634) ) /* background palette */
+
+	ROM_REGION( 0x0020, "spr_pal", 0 )
+	ROM_LOAD( "mpc-1.1f",     0x0000, 0x0020, CRC(26979b13) SHA1(8c41a8cce4f3384c392a9f7a223a50d7be0e14a5) ) /* sprite palette */
+
+	ROM_REGION( 0x0100, "spr_clut", 0 )
+	ROM_LOAD( "mpc-2.2h",     0x0000, 0x0100, CRC(7ae4cd97) SHA1(bc0662fac82ffe65f02092d912b2c2b0c7a8ac2b) ) /* sprite lookup table */
 ROM_END
 
 
@@ -575,11 +604,17 @@ ROM_START( alpha1v )
 	ROM_REGION( 0x1000, "gfx5", 0 )
 	ROM_LOAD( "10-lm3",     0x0000, 0x1000, CRC(9dde3a75) SHA1(293d093485be19bfb20685d76a08ac78e24062bf) )
 
-	ROM_REGION( 0x0340, "proms", 0 )
+	ROM_REGION( 0x0200, "tx_pal", 0 )
 	ROM_LOAD( "63s481-a2",     0x0000, 0x0200, CRC(58678ea8) SHA1(b13a78a5bca8ad5bdec1293512b53654768a7a7a) )
-	ROM_LOAD( "18s030-m1",     0x0200, 0x0020, CRC(6a57eff2) SHA1(2d1c12dab5915da2ccd466e39436c88be434d634) ) /* background palette */
-	ROM_LOAD( "mb7051-f1",     0x0220, 0x0020, CRC(d8bdd0df) SHA1(ca522428927911808214d319af314f601497ded4) ) /* sprite palette */
-	ROM_LOAD( "mb7052-h2",     0x0240, 0x0100, CRC(ce9f0ef9) SHA1(3afb94ed033f272983bbed22a59856df7824ef8a) ) /* sprite lookup table */
+
+	ROM_REGION( 0x0020, "bg_pal", 0 )
+	ROM_LOAD( "18s030-m1",     0x0000, 0x0020, CRC(6a57eff2) SHA1(2d1c12dab5915da2ccd466e39436c88be434d634) ) /* background palette */
+
+	ROM_REGION( 0x0020, "spr_pal", 0 )
+	ROM_LOAD( "mb7051-f1",     0x0000, 0x0020, CRC(d8bdd0df) SHA1(ca522428927911808214d319af314f601497ded4) ) /* sprite palette */
+
+	ROM_REGION( 0x0100, "spr_clut", 0 )
+	ROM_LOAD( "mb7052-h2",     0x0000, 0x0100, CRC(ce9f0ef9) SHA1(3afb94ed033f272983bbed22a59856df7824ef8a) ) /* sprite lookup table */
 ROM_END
 
 

--- a/src/mame/includes/m52.h
+++ b/src/mame/includes/m52.h
@@ -23,7 +23,21 @@ public:
 	{ }
 
 	void m52(machine_config &config);
-	void alpha1v(machine_config &config);
+
+	DECLARE_WRITE8_MEMBER(m52_videoram_w);
+	DECLARE_WRITE8_MEMBER(m52_colorram_w);
+	DECLARE_READ8_MEMBER(m52_protection_r);
+
+protected:
+	virtual void video_start() override;
+	virtual DECLARE_WRITE8_MEMBER(m52_scroll_w);
+
+	/* board mod changes? */
+	int m_spritelimit;
+	bool m_sprites_3bpp;
+	bool m_do_bg_fills;
+
+	tilemap_t*             m_tx_tilemap;
 
 private:
 	/* memory pointers */
@@ -32,27 +46,21 @@ private:
 	optional_shared_ptr<uint8_t> m_spriteram;
 
 	/* video-related */
-	tilemap_t*             m_tx_tilemap;
 	uint8_t                m_bg1xpos;
 	uint8_t                m_bg1ypos;
 	uint8_t                m_bg2xpos;
 	uint8_t                m_bg2ypos;
 	uint8_t                m_bgcontrol;
-	DECLARE_WRITE8_MEMBER(m52_scroll_w);
-	DECLARE_WRITE8_MEMBER(m52_videoram_w);
-	DECLARE_WRITE8_MEMBER(m52_colorram_w);
-	DECLARE_READ8_MEMBER(m52_protection_r);
 	DECLARE_WRITE8_MEMBER(m52_bg1ypos_w);
 	DECLARE_WRITE8_MEMBER(m52_bg1xpos_w);
 	DECLARE_WRITE8_MEMBER(m52_bg2xpos_w);
 	DECLARE_WRITE8_MEMBER(m52_bg2ypos_w);
 	DECLARE_WRITE8_MEMBER(m52_bgcontrol_w);
 	DECLARE_WRITE8_MEMBER(m52_flipscreen_w);
-	DECLARE_WRITE8_MEMBER(alpha1v_flipscreen_w);
 	TILE_GET_INFO_MEMBER(get_tile_info);
 	virtual void machine_reset() override;
-	virtual void video_start() override;
 	void init_palette();
+	void init_sprite_palette(const int *resistances_3, const int *resistances_2, double *weights_r, double *weights_g, double *weights_b, double scale);
 	uint32_t screen_update_m52(screen_device &screen, bitmap_rgb32 &bitmap, const rectangle &cliprect);
 	void draw_background(bitmap_rgb32 &bitmap, const rectangle &cliprect, int xpos, int ypos, int image);
 	void draw_sprites(bitmap_rgb32 &bitmap, const rectangle &cliprect, int initoffs);
@@ -64,7 +72,24 @@ private:
 	required_device<palette_device> m_sp_palette;
 	required_device<palette_device> m_tx_palette;
 	required_device<palette_device> m_bg_palette;
-	void alpha1v_map(address_map &map);
 	void main_map(address_map &map);
 	void main_portmap(address_map &map);
+};
+
+class m52_alpha1v_state : public m52_state
+{
+public:
+	m52_alpha1v_state(const machine_config &mconfig, device_type type, const char *tag)
+		: m52_state(mconfig, type, tag)
+	{ }
+
+	void alpha1v(machine_config &config);
+
+	void alpha1v_map(address_map &map);
+
+protected:
+	virtual void video_start() override;
+	virtual DECLARE_WRITE8_MEMBER(m52_scroll_w) override;
+	DECLARE_WRITE8_MEMBER(alpha1v_flipscreen_w);
+
 };

--- a/src/mame/includes/m52.h
+++ b/src/mame/includes/m52.h
@@ -34,7 +34,6 @@ protected:
 
 	/* board mod changes? */
 	int m_spritelimit;
-	bool m_sprites_3bpp;
 	bool m_do_bg_fills;
 
 	tilemap_t*             m_tx_tilemap;

--- a/src/mame/includes/m52.h
+++ b/src/mame/includes/m52.h
@@ -13,9 +13,14 @@ public:
 		m_colorram(*this, "colorram"),
 		m_spriteram(*this, "spriteram"),
 		m_maincpu(*this, "maincpu"),
-		m_gfxdecode(*this, "gfxdecode"),
+		m_sp_gfxdecode(*this, "sp_gfxdecode"),
+		m_tx_gfxdecode(*this, "tx_gfxdecode"),
+		m_bg_gfxdecode(*this, "bg_gfxdecode"),
 		m_screen(*this, "screen"),
-		m_palette(*this, "palette") { }
+		m_sp_palette(*this, "sp_palette"),
+		m_tx_palette(*this, "tx_palette"),
+		m_bg_palette(*this, "bg_palette")
+	{ }
 
 	void m52(machine_config &config);
 	void alpha1v(machine_config &config);
@@ -27,7 +32,7 @@ private:
 	optional_shared_ptr<uint8_t> m_spriteram;
 
 	/* video-related */
-	tilemap_t*             m_bg_tilemap;
+	tilemap_t*             m_tx_tilemap;
 	uint8_t                m_bg1xpos;
 	uint8_t                m_bg1ypos;
 	uint8_t                m_bg2xpos;
@@ -47,14 +52,18 @@ private:
 	TILE_GET_INFO_MEMBER(get_tile_info);
 	virtual void machine_reset() override;
 	virtual void video_start() override;
-	DECLARE_PALETTE_INIT(m52);
-	uint32_t screen_update_m52(screen_device &screen, bitmap_ind16 &bitmap, const rectangle &cliprect);
-	void draw_background(bitmap_ind16 &bitmap, const rectangle &cliprect, int xpos, int ypos, int image);
-	void draw_sprites(bitmap_ind16 &bitmap, const rectangle &cliprect, int initoffs);
+	void init_palette();
+	uint32_t screen_update_m52(screen_device &screen, bitmap_rgb32 &bitmap, const rectangle &cliprect);
+	void draw_background(bitmap_rgb32 &bitmap, const rectangle &cliprect, int xpos, int ypos, int image);
+	void draw_sprites(bitmap_rgb32 &bitmap, const rectangle &cliprect, int initoffs);
 	required_device<cpu_device> m_maincpu;
-	required_device<gfxdecode_device> m_gfxdecode;
+	required_device<gfxdecode_device> m_sp_gfxdecode;
+	required_device<gfxdecode_device> m_tx_gfxdecode;
+	required_device<gfxdecode_device> m_bg_gfxdecode;
 	required_device<screen_device> m_screen;
-	required_device<palette_device> m_palette;
+	required_device<palette_device> m_sp_palette;
+	required_device<palette_device> m_tx_palette;
+	required_device<palette_device> m_bg_palette;
 	void alpha1v_map(address_map &map);
 	void main_map(address_map &map);
 	void main_portmap(address_map &map);

--- a/src/mame/video/m52.cpp
+++ b/src/mame/video/m52.cpp
@@ -81,7 +81,6 @@ void m52_state::init_palette()
 	init_sprite_palette(resistances_3, resistances_2, weights_r, weights_g, weights_b, scale);
 }
 
-// this might need to differ for alpha1v due to 3bpp sprites
 void m52_state::init_sprite_palette(const int *resistances_3, const int *resistances_2, double *weights_r, double *weights_g, double *weights_b, double scale)
 {
 	const uint8_t *sprite_pal = memregion("spr_pal")->base();
@@ -105,9 +104,9 @@ void m52_state::init_sprite_palette(const int *resistances_3, const int *resista
 	}
 
 	/* sprite lookup table */
-	for (int i = 0; i < 16 * 4; i++)
+	for (int i = 0; i < 256; i++)
 	{
-		uint8_t promval = sprite_table[(i & 3) | ((i & ~3) << 1)];
+		uint8_t promval = sprite_table[i];
 		m_sp_palette->set_pen_indirect(i, promval);
 	}
 }
@@ -168,7 +167,6 @@ void m52_state::video_start()
 	save_item(NAME(m_bgcontrol));
 
 	m_spritelimit = 0x100-4;
-	m_sprites_3bpp = false;
 	m_do_bg_fills = true;
 }
 
@@ -178,7 +176,6 @@ void m52_alpha1v_state::video_start()
 
 	// is the limit really just higher anyway or is this a board mod?
 	m_spritelimit = 0x200-4;
-	m_sprites_3bpp = true;
 	m_do_bg_fills = false; // or you get solid green areas below the stars bg image.  does the doubled up tilemap ROM maybe mean double height instead?
 
 	// the scrolling orange powerups 'orbs' are a single tile in the tilemap, your ship is huge, it is unclear where the hitboxes are meant to be
@@ -402,10 +399,6 @@ void m52_state::draw_sprites(bitmap_rgb32 &bitmap, const rectangle &cliprect, in
 		int flipy = m_spriteram[offs + 1] & 0x80;
 		int code = m_spriteram[offs + 2];
 		int sx = m_spriteram[offs + 3];
-
-		// hack until we work out the proper decoding for the 3bpp sprites, might need palette shift after that
-		if (m_sprites_3bpp)
-			color = 1;
 
 		/* sprites from offsets $00-$7F are processed in the upper half of the frame */
 		/* sprites from offsets $80-$FF are processed in the lower half of the frame */

--- a/src/mame/video/m52.cpp
+++ b/src/mame/video/m52.cpp
@@ -181,7 +181,7 @@ void m52_alpha1v_state::video_start()
 	m_sprites_3bpp = true;
 	m_do_bg_fills = false; // or you get solid green areas below the stars bg image.  does the doubled up tilemap ROM maybe mean double height instead?
 
-	// the scrolling powerups are a single tile in the tilemap, your ship is huge, it is unclear where the hitboxes are meant to be
+	// the scrolling orange powerups 'orbs' are a single tile in the tilemap, your ship is huge, it is unclear where the hitboxes are meant to be
 	// using the same value as mpatrol puts the collision at the very back of your ship, and causes draw-in issues on the tilemap
 	// maybe the sprite positioning is incorrect instead?
 	//m_tx_tilemap->set_scrolldx(127+8, 127-8);

--- a/src/mame/video/m52.cpp
+++ b/src/mame/video/m52.cpp
@@ -10,7 +10,7 @@
 #include "video/resnet.h"
 #include "includes/m52.h"
 
-#define BGHEIGHT 64
+#define BGHEIGHT 128
 
 
 /*************************************
@@ -182,8 +182,8 @@ void m52_alpha1v_state::video_start()
 	m_do_bg_fills = false; // or you get solid green areas below the stars bg image.  does the doubled up tilemap ROM maybe mean double height instead?
 
 	// the scrolling orange powerups 'orbs' are a single tile in the tilemap, your ship is huge, it is unclear where the hitboxes are meant to be
-	// using the same value as mpatrol puts the collision at the very back of your ship, and causes draw-in issues on the tilemap
-	// maybe the sprite positioning is incorrect instead?
+	// using the same value as mpatrol puts the collision at the very back of your ship
+	// maybe the sprite positioning is incorrect instead or this is just how the game is designed
 	//m_tx_tilemap->set_scrolldx(127+8, 127-8);
 }
 
@@ -462,10 +462,10 @@ uint32_t m52_state::screen_update_m52(screen_device &screen, bitmap_rgb32 &bitma
 		if (!(m_bgcontrol & 0x10))
 			draw_background(bitmap, cliprect, m_bg2xpos, m_bg2ypos, 0); /* distant mountains */
 
+		// only one of these be drawn at once (they share the same scroll register) (alpha1v leaves everything enabled)
 		if (!(m_bgcontrol & 0x02))
 			draw_background(bitmap, cliprect, m_bg1xpos, m_bg1ypos, 1); /* hills */
-
-		if (!(m_bgcontrol & 0x04))
+		else if (!(m_bgcontrol & 0x04))
 			draw_background(bitmap, cliprect, m_bg1xpos, m_bg1ypos, 2); /* cityscape */
 	}
 

--- a/src/mame/video/m52.cpp
+++ b/src/mame/video/m52.cpp
@@ -212,6 +212,8 @@ WRITE8_MEMBER(m52_alpha1v_state::m52_scroll_w)
 /*
    alpha1v must have some board mod to invert scroll register use, as it expects only the first block to remain static
    the scrolling powerups are part of the tx layer!
+
+   TODO: check if this configuration works with Moon Patrol, maybe the schematics were read incorrectly?
 */
 	m_tx_tilemap->set_scrollx(0,  255);
 	m_tx_tilemap->set_scrollx(1, -(data + 1));


### PR DESCRIPTION
It's meant to be a conversion, or at least was given to us that way, but it disagreed with certain things about the way the existing mpatorl driver worked.  I think some of these things were optimizations in the mpatrol driver to save memory back in the day.

it's a Kyle Hodgetts abomination, so without reference material it's very difficult to work out how things should be, eg. the power orbs you collect are part of the text tilemap, which must scroll, but with the scroll offsets and sprite positioning we have they only collide with the very back of your huge ship,  I think this is correct however.

It seems to expect double height background images, which strongly suggests that moon patrol should have this too, and is simply not populating the lower half, hence the 'solid colour' pull-up.  I've modified the driver to support this.

The game also has 3bpp sprites instead of 2bpp, the existing Moon Patrol sprite CLUT decode looks like it's been kludged to work with 2bpp instead of 3bpp, strongly suggesting that the board supports 3bpp and Moon Patrol just didn't use it, again leaving areas unpopulated.  This has been adjusted, removing the kludge and treating Moon Patrol sprites as 3bpp with 2bpp used.

As part of driver cleanups this also splits the palette/gfx etc. into multiple decodes and splits the PROMs into multiple named regions rather than kludging them all into one (this made it easier to work out the above, and also makes it easier to see in the F4 viewer which palettes etc. belong to which elements)

Overall this makes it look somewhat more like a game, but as mentioned without reference material it's difficult to know how this should look / play.  I've marked it as working because I think most of the badness is just from the game.