### PR TITLE
dsk_dsk.cpp: Avoid to use uninitialized booleans

### DIFF
--- a/src/lib/formats/dsk_dsk.cpp
+++ b/src/lib/formats/dsk_dsk.cpp
@@ -420,10 +420,8 @@ bool dsk_format::load(io_generic *io, uint32_t form_factor, floppy_image *image)
 				else
 					sects[j].actual_size = 128 << tr.sector_size_code;
 
-				if (sector.fdc_status_reg2 & 0x40)
-					sects[j].deleted = 1;
-				if ((sector.fdc_status_reg1 & 0x20) || (sector.fdc_status_reg2 & 0x20))
-					sects[j].bad_crc = 1;
+				sects[j].deleted = (sector.fdc_status_reg2 & 0x40);
+				sects[j].bad_crc = ((sector.fdc_status_reg1 & 0x20) || (sector.fdc_status_reg2 & 0x20));
 
 				if(!(sector.fdc_status_reg1 & 0x04)) {
 					sects[j].data = sect_data + sdatapos;


### PR DESCRIPTION
Fix MameTesters #07134.
Thanks to Klez for testing.