### PR TITLE
m68000: fix rw bit in address error frame (nw)

### DIFF
--- a/src/devices/cpu/m68000/m68kcpu.cpp
+++ b/src/devices/cpu/m68000/m68kcpu.cpp
@@ -1519,12 +1519,12 @@ void m68000_base_device::set_reset_callback(write_line_delegate callback)
 }
 
 // fault_addr = address to indicate fault at
-// rw = 0 for read, 1 for write
+// rw = 1 for read, 0 for write
 // fc = 3-bit function code of access (usually you'd just put what m68k_get_fc() returns here)
 void m68000_base_device::set_buserror_details(uint32_t fault_addr, uint8_t rw, uint8_t fc)
 {
 	m_aerr_address = fault_addr;
-	m_aerr_write_mode = rw;
+	m_aerr_write_mode = (rw << 4);
 	m_aerr_fc = fc;
 	m_mmu_tmp_buserror_address = fault_addr; // Hack for x68030
 }

--- a/src/mame/drivers/hp9k_3xx.cpp
+++ b/src/mame/drivers/hp9k_3xx.cpp
@@ -283,13 +283,13 @@ void hp9k3xx_state::add_dio32_bus(machine_config &config)
 	dio32.irq7_out_cb().set(FUNC(hp9k3xx_state::dio_irq7_w));
 }
 
-void hp9k3xx_state::set_bus_error(uint32_t address, bool write, uint16_t mem_mask)
+void hp9k3xx_state::set_bus_error(uint32_t address, bool rw, uint16_t mem_mask)
 {
 	if (m_bus_error)
 		return;
 
 	m_bus_error = true;
-	m_maincpu->set_buserror_details(address, write, m_maincpu->get_fc());
+	m_maincpu->set_buserror_details(address, rw, m_maincpu->get_fc());
 	m_maincpu->set_input_line(M68K_LINE_BUSERROR, ASSERT_LINE);
 	m_bus_error_timer->adjust(m_maincpu->cycles_to_attotime(16)); // let rmw cycles complete
 }
@@ -297,14 +297,14 @@ void hp9k3xx_state::set_bus_error(uint32_t address, bool write, uint16_t mem_mas
 READ16_MEMBER(hp9k3xx_state::buserror16_r)
 {
 	if (!machine().side_effects_disabled())
-		set_bus_error((offset << 1) & 0xFFFFFF, false, mem_mask);
+		set_bus_error((offset << 1) & 0xFFFFFF, true, mem_mask);
 	return 0xffff;
 }
 
 WRITE16_MEMBER(hp9k3xx_state::buserror16_w)
 {
 	if (!machine().side_effects_disabled())
-		set_bus_error((offset << 1) & 0xFFFFFF, true, mem_mask);
+		set_bus_error((offset << 1) & 0xFFFFFF, false, mem_mask);
 }
 
 READ32_MEMBER(hp9k3xx_state::buserror_r)

--- a/src/mame/drivers/hp_ipc.cpp
+++ b/src/mame/drivers/hp_ipc.cpp
@@ -457,7 +457,7 @@ void hp_ipc_state::device_timer(emu_timer &timer, device_timer_id id, int param,
 	m_bus_error = false;
 }
 
-void hp_ipc_state::set_bus_error(uint32_t address, bool write, uint16_t mem_mask)
+void hp_ipc_state::set_bus_error(uint32_t address, bool rw, uint16_t mem_mask)
 {
 	if (m_bus_error)
 	{
@@ -468,7 +468,7 @@ void hp_ipc_state::set_bus_error(uint32_t address, bool write, uint16_t mem_mask
 		address++;
 	}
 	m_bus_error = true;
-	m_maincpu->set_buserror_details(address, write, m_maincpu->get_fc());
+	m_maincpu->set_buserror_details(address, rw, m_maincpu->get_fc());
 	m_maincpu->set_input_line(M68K_LINE_BUSERROR, ASSERT_LINE);
 	m_bus_error_timer->adjust(m_maincpu->cycles_to_attotime(16)); // let rmw cycles complete
 }
@@ -562,14 +562,14 @@ WRITE16_MEMBER(hp_ipc_state::mem_w)
 
 READ16_MEMBER(hp_ipc_state::trap_r)
 {
-	if (!machine().side_effects_disabled()) set_bus_error((offset << 1) & 0xFFFFFF, 0, mem_mask);
+	if (!machine().side_effects_disabled()) set_bus_error((offset << 1) & 0xFFFFFF, true, mem_mask);
 
 	return 0xffff;
 }
 
 WRITE16_MEMBER(hp_ipc_state::trap_w)
 {
-	if (!machine().side_effects_disabled()) set_bus_error((offset << 1) & 0xFFFFFF, 1, mem_mask);
+	if (!machine().side_effects_disabled()) set_bus_error((offset << 1) & 0xFFFFFF, false, mem_mask);
 }
 
 

--- a/src/mame/drivers/wicat.cpp
+++ b/src/mame/drivers/wicat.cpp
@@ -392,7 +392,7 @@ READ16_MEMBER( wicat_state::invalid_r )
 {
 	if(!machine().side_effects_disabled())
 	{
-		m_maincpu->set_buserror_details(0x300000+offset*2-2,0,m_maincpu->get_fc());
+		m_maincpu->set_buserror_details(0x300000+offset*2-2,true,m_maincpu->get_fc());
 		m_maincpu->set_input_line(M68K_LINE_BUSERROR, ASSERT_LINE);
 		m_maincpu->set_input_line(M68K_LINE_BUSERROR, CLEAR_LINE);
 	}
@@ -403,7 +403,7 @@ WRITE16_MEMBER( wicat_state::invalid_w )
 {
 	if(!machine().side_effects_disabled())
 	{
-		m_maincpu->set_buserror_details(0x300000+offset*2-2,1,m_maincpu->get_fc());
+		m_maincpu->set_buserror_details(0x300000+offset*2-2,false,m_maincpu->get_fc());
 		m_maincpu->set_input_line(M68K_LINE_BUSERROR, ASSERT_LINE);
 		m_maincpu->set_input_line(M68K_LINE_BUSERROR, CLEAR_LINE);
 	}

--- a/src/mame/drivers/x68k.cpp
+++ b/src/mame/drivers/x68k.cpp
@@ -935,14 +935,14 @@ TIMER_CALLBACK_MEMBER(x68k_state::bus_error)
 	m_bus_error = false;
 }
 
-void x68k_state::set_bus_error(uint32_t address, bool write, uint16_t mem_mask)
+void x68k_state::set_bus_error(uint32_t address, bool rw, uint16_t mem_mask)
 {
 	if(m_bus_error)
 		return;
 	if(!ACCESSING_BITS_8_15)
 		address++;
 	m_bus_error = true;
-	m_maincpu->set_buserror_details(address, write, m_maincpu->get_fc());
+	m_maincpu->set_buserror_details(address, rw, m_maincpu->get_fc());
 	m_maincpu->set_input_line(M68K_LINE_BUSERROR, ASSERT_LINE);
 	m_maincpu->set_input_line(M68K_LINE_BUSERROR, CLEAR_LINE);
 	m_bus_error_timer->adjust(m_maincpu->cycles_to_attotime(16)); // let rmw cycles complete
@@ -954,7 +954,7 @@ READ16_MEMBER(x68k_state::rom0_r)
 	/* this location contains the address of some expansion device ROM, if no ROM exists,
 	   then access causes a bus error */
 	if((m_options->read() & 0x02) && !machine().side_effects_disabled())
-		set_bus_error((offset << 1) + 0xbffffc, 0, mem_mask);
+		set_bus_error((offset << 1) + 0xbffffc, true, mem_mask);
 	return 0xff;
 }
 
@@ -963,7 +963,7 @@ WRITE16_MEMBER(x68k_state::rom0_w)
 	/* this location contains the address of some expansion device ROM, if no ROM exists,
 	   then access causes a bus error */
 	if((m_options->read() & 0x02) && !machine().side_effects_disabled())
-		set_bus_error((offset << 1) + 0xbffffc, 1, mem_mask);
+		set_bus_error((offset << 1) + 0xbffffc, false, mem_mask);
 }
 
 READ16_MEMBER(x68k_state::emptyram_r)


### PR DESCRIPTION
RW bit actually means 1 = read, 0 = write. It was also not
shifted in m68000_base_device::set_buserror_details(), thus overwriting the LSB of FC.