### PR TITLE
pc9801_86.cpp: add stereo sound

### DIFF
--- a/src/devices/bus/cbus/pc9801_86.cpp
+++ b/src/devices/bus/cbus/pc9801_86.cpp
@@ -14,7 +14,6 @@
     - Test all pcm modes
     - Make volume work
     - Recording
-    - actual stereo sound routing (currently routes to ALL_OUTPUTS)
     - SpeakBoard: no idea about software that uses this, also board shows a single YM2608B?
       "-86 only supports ADPCM instead of PCM, while SpeakBoard has OPNA + 256 Kbit RAM"
       Sounds like a sound core flaw since OPNA requires a rom region in any case;
@@ -58,8 +57,10 @@ MACHINE_CONFIG_START(pc9801_86_device::pc9801_86_config)
 	//MCFG_AY8910_PORT_B_READ_CB(READ8(*this, pc9801_state, opn_portb_r))
 	//MCFG_AY8910_PORT_A_WRITE_CB(WRITE8(*this, pc9801_state, opn_porta_w))
 	MCFG_AY8910_PORT_B_WRITE_CB(WRITE8(*this, pc9801_86_device, opn_portb_w))
-	MCFG_SOUND_ROUTE(ALL_OUTPUTS, "lspeaker", 1.00)
-	MCFG_SOUND_ROUTE(ALL_OUTPUTS, "rspeaker", 1.00)
+	MCFG_SOUND_ROUTE(0, "lspeaker", 1.00)
+	MCFG_SOUND_ROUTE(0, "rspeaker", 1.00)
+	MCFG_SOUND_ROUTE(1, "lspeaker", 1.00)
+	MCFG_SOUND_ROUTE(2, "rspeaker", 1.00)
 
 	MCFG_DEVICE_ADD("ldac", DAC_16BIT_R2R_TWOS_COMPLEMENT, 0) MCFG_SOUND_ROUTE(ALL_OUTPUTS, "lspeaker", 1.0) // burr brown pcm61p
 	MCFG_DEVICE_ADD("rdac", DAC_16BIT_R2R_TWOS_COMPLEMENT, 0) MCFG_SOUND_ROUTE(ALL_OUTPUTS, "rspeaker", 1.0) // burr brown pcm61p
@@ -390,13 +391,17 @@ MACHINE_CONFIG_START(pc9801_speakboard_device::device_add_mconfig)
 
 	MCFG_DEVICE_MODIFY("opna")
 	MCFG_SOUND_ROUTES_RESET()
-	MCFG_SOUND_ROUTE(ALL_OUTPUTS, "lspeaker", 0.50)
-	MCFG_SOUND_ROUTE(ALL_OUTPUTS, "rspeaker", 0.50)
+	MCFG_SOUND_ROUTE(0, "lspeaker", 0.50)
+	MCFG_SOUND_ROUTE(0, "rspeaker", 0.50)
+	MCFG_SOUND_ROUTE(1, "lspeaker", 0.50)
+	MCFG_SOUND_ROUTE(2, "rspeaker", 0.50)
 
 	MCFG_DEVICE_ADD("opna_slave", YM2608, 7.987_MHz_XTAL)
 	MCFG_AY8910_OUTPUT_TYPE(0)
-	MCFG_SOUND_ROUTE(ALL_OUTPUTS, "lspeaker", 0.50)
-	MCFG_SOUND_ROUTE(ALL_OUTPUTS, "rspeaker", 0.50)
+	MCFG_SOUND_ROUTE(0, "lspeaker", 0.50)
+	MCFG_SOUND_ROUTE(0, "rspeaker", 0.50)
+	MCFG_SOUND_ROUTE(1, "lspeaker", 0.50)
+	MCFG_SOUND_ROUTE(2, "rspeaker", 0.50)
 MACHINE_CONFIG_END
 
 void pc9801_speakboard_device::device_start()


### PR DESCRIPTION
This change adds stereo sound routing for the FM/rhythm channels of the YM2608 on the PC-9801-86 and Speak Board cards (the PSG part is always mono).