### PR TITLE
Digger: Change manufacturer

### DIFF
--- a/src/mame/drivers/midyunit.cpp
+++ b/src/mame/drivers/midyunit.cpp
@@ -9,7 +9,7 @@
     and Aaron Giles
 
     Games supported (prototype and release versions):
-        * Narc
+        * NARC
         * Trog
         * Strike Force
         * Smash TV
@@ -20,7 +20,7 @@
         * Total Carnage
 
     Known bugs:
-        * when the Porsche spins in Narc, the wheels are missing for
+        * when the Porsche spins in NARC, the wheels are missing for
             a single frame (may be an original bug)
         * Terminator 2 freezes while playing the movies after destroying
             skynet. Currently we have a hack in which prevents the freeze,
@@ -3063,9 +3063,9 @@ ROM_END
  *
  *************************************/
 
-GAME( 1988, narc,       0,        zunit,                   narc,     midyunit_state, init_narc,     ROT0, "Williams", "Narc (rev 7.00)", MACHINE_SUPPORTS_SAVE )
-GAME( 1988, narc3,      narc,     zunit,                   narc,     midyunit_state, init_narc,     ROT0, "Williams", "Narc (rev 3.20)", MACHINE_SUPPORTS_SAVE )
-GAME( 1988, narc2,      narc,     zunit,                   narc,     midyunit_state, init_narc,     ROT0, "Williams", "Narc (rev 2.00)", MACHINE_SUPPORTS_SAVE )
+GAME( 1988, narc,       0,        zunit,                   narc,     midyunit_state, init_narc,     ROT0, "Williams", "NARC (rev 7.00)", MACHINE_SUPPORTS_SAVE )
+GAME( 1988, narc3,      narc,     zunit,                   narc,     midyunit_state, init_narc,     ROT0, "Williams", "NARC (rev 3.20)", MACHINE_SUPPORTS_SAVE )
+GAME( 1988, narc2,      narc,     zunit,                   narc,     midyunit_state, init_narc,     ROT0, "Williams", "NARC (rev 2.00)", MACHINE_SUPPORTS_SAVE )
 
 GAME( 1990, trog,       0,        yunit_cvsd_4bit_slow,    trog,     midyunit_state, init_trog,     ROT0, "Midway",   "Trog (rev LA5 03/29/91)", MACHINE_SUPPORTS_SAVE )
 GAME( 1990, trog4,      trog,     yunit_cvsd_4bit_slow,    trog,     midyunit_state, init_trog,     ROT0, "Midway",   "Trog (rev LA4 03/11/91)", MACHINE_SUPPORTS_SAVE )

--- a/src/mame/drivers/vicdual.cpp
+++ b/src/mame/drivers/vicdual.cpp
@@ -3909,7 +3909,7 @@ GAME( 1981, brdrlins,   brdrline, brdrline,  brdrline,  vicdual_state, empty_ini
 GAME( 1981, brdrlinb,   brdrline, brdrline,  brdrline,  vicdual_state, empty_init, ROT270, "bootleg (Karateco)", "Borderline (Karateco bootleg)", MACHINE_NO_SOUND | MACHINE_SUPPORTS_SAVE )
 GAME( 1981, brdrlinet,  brdrline, tranqgun,  tranqgun,  vicdual_state, empty_init, ROT270, "Sega", "Borderline (Tranquillizer Gun conversion)", MACHINE_NOT_WORKING | MACHINE_IMPERFECT_SOUND | MACHINE_SUPPORTS_SAVE ) // official factory conversion
 GAME( 198?, startrks,   0,        headons,   headons,   vicdual_state, empty_init, ROT0,   "bootleg (Sidam)", "Star Trek (Head On hardware)", MACHINE_IMPERFECT_SOUND | MACHINE_SUPPORTS_SAVE )
-GAME( 1980, digger,     0,        digger,    digger,    vicdual_state, empty_init, ROT270, "Sega", "Digger", MACHINE_NO_SOUND | MACHINE_SUPPORTS_SAVE )
+GAME( 1980, digger,     0,        digger,    digger,    vicdual_state, empty_init, ROT270, "Gremlin / Sega", "Digger", MACHINE_NO_SOUND | MACHINE_SUPPORTS_SAVE )
 GAME( 1981, pulsar,     0,        pulsar,    pulsar,    vicdual_state, empty_init, ROT270, "Sega", "Pulsar", MACHINE_IMPERFECT_SOUND | MACHINE_SUPPORTS_SAVE )
 GAME( 1979, heiankyo,   0,        heiankyo,  heiankyo,  vicdual_state, empty_init, ROT270, "Denki Onkyo", "Heiankyo Alien", MACHINE_NO_SOUND | MACHINE_SUPPORTS_SAVE )
 GAME( 19??, alphaho,    0,        alphaho,   alphaho,   vicdual_state, empty_init, ROT270, "Data East Corporation", "Alpha Fighter / Head On", MACHINE_WRONG_COLORS | MACHINE_NO_SOUND | MACHINE_SUPPORTS_SAVE )


### PR DESCRIPTION
Changed the manufacturer of Digger (1980) to "Gremlin / Sega".
Found the informations in the Digger rom 691.u20:

WRITTEN BY DAVID L. EVANS, 4535 TAFT AVENUE, LA MESA, CALIF. 92041 AND BEAT OUT ON THE KEYBOARD OF A NOVAL 765!
THANK YOU TERRY, BARBARA, CRAIG AND LARRY FOR SOME DEBUGGED SUBROUTINES...JUNE 25, 1980 GREMLIN/SEGA INC


Also Wikipedia says Gremlin/Sega: https://en.wikipedia.org/wiki/Heiankyo_Alien

Arcade versions
In 1980, a North American version titled Digger was created by Sega and Gremlin Industries, with minor changes in appearance.
