### PR TITLE
debugger: add 'gp' command

### DIFF
--- a/src/devices/cpu/m68000/m68kcpu.h
+++ b/src/devices/cpu/m68000/m68kcpu.h
@@ -1009,12 +1009,17 @@ inline void m68ki_branch_32(uint32_t offset)
  */
 inline void m68ki_set_s_flag(uint32_t value)
 {
+	uint32_t old_s_flag = m_s_flag;
 	/* Backup the old stack pointer */
 	REG_SP_BASE()[m_s_flag | ((m_s_flag>>1) & m_m_flag)] = REG_SP();
 	/* Set the S flag */
 	m_s_flag = value;
 	/* Set the new stack pointer */
 	REG_SP() = REG_SP_BASE()[m_s_flag | ((m_s_flag>>1) & m_m_flag)];
+	if ((old_s_flag ^ m_s_flag) & SFLAG_SET)
+	{
+		debugger_privilege_hook();
+	}
 }
 
 /* Set the S and M flags and change the active stack pointer.
@@ -1022,6 +1027,7 @@ inline void m68ki_set_s_flag(uint32_t value)
  */
 inline void m68ki_set_sm_flag(uint32_t value)
 {
+	uint32_t old_s_flag = m_s_flag;
 	/* Backup the old stack pointer */
 	REG_SP_BASE()[m_s_flag | ((m_s_flag >> 1) & m_m_flag)] = REG_SP();
 	/* Set the S and M flags */
@@ -1029,14 +1035,23 @@ inline void m68ki_set_sm_flag(uint32_t value)
 	m_m_flag = value & MFLAG_SET;
 	/* Set the new stack pointer */
 	REG_SP() = REG_SP_BASE()[m_s_flag | ((m_s_flag>>1) & m_m_flag)];
+	if ((old_s_flag ^ m_s_flag) & SFLAG_SET)
+	{
+		debugger_privilege_hook();
+	}
 }
 
 /* Set the S and M flags.  Don't touch the stack pointer. */
 inline void m68ki_set_sm_flag_nosp(uint32_t value)
 {
+	uint32_t old_s_flag = m_s_flag;
 	/* Set the S and M flags */
 	m_s_flag = value & SFLAG_SET;
 	m_m_flag = value & MFLAG_SET;
+	if ((old_s_flag ^ m_s_flag) & SFLAG_SET)
+	{
+		debugger_privilege_hook();
+	}
 }
 
 

--- a/src/emu/debug/debugcmd.cpp
+++ b/src/emu/debug/debugcmd.cpp
@@ -160,6 +160,7 @@ debugger_commands::debugger_commands(running_machine& machine, debugger_cpu& cpu
 	m_console.register_command("ge",        CMDFLAG_NONE, 0, 0, 1, std::bind(&debugger_commands::execute_go_exception, this, _1, _2));
 	m_console.register_command("gtime",     CMDFLAG_NONE, 0, 0, 1, std::bind(&debugger_commands::execute_go_time, this, _1, _2));
 	m_console.register_command("gt",        CMDFLAG_NONE, 0, 0, 1, std::bind(&debugger_commands::execute_go_time, this, _1, _2));
+	m_console.register_command("gp",        CMDFLAG_NONE, 0, 0, 1, std::bind(&debugger_commands::execute_go_privilege, this, _1, _2));
 	m_console.register_command("next",      CMDFLAG_NONE, 0, 0, 0, std::bind(&debugger_commands::execute_next, this, _1, _2));
 	m_console.register_command("n",         CMDFLAG_NONE, 0, 0, 0, std::bind(&debugger_commands::execute_next, this, _1, _2));
 	m_console.register_command("focus",     CMDFLAG_NONE, 0, 1, 1, std::bind(&debugger_commands::execute_focus, this, _1, _2));
@@ -898,6 +899,19 @@ void debugger_commands::execute_go_time(int ref, const std::vector<std::string> 
 	m_cpu.get_visible_cpu()->debug()->go_milliseconds(milliseconds);
 }
 
+
+
+/*-------------------------------------------------
+    execute_go_privilege - execute the gp command
+-------------------------------------------------*/
+void debugger_commands::execute_go_privilege(int ref, const std::vector<std::string> &params)
+{
+	parsed_expression condition(&m_cpu.get_visible_cpu()->debug()->symtable());
+	if (params.size() > 0 && !debug_command_parameter_expression(params[0], condition))
+		return;
+
+	m_cpu.get_visible_cpu()->debug()->go_privilege((condition.is_empty()) ? "1" : condition.original_string());
+}
 
 /*-------------------------------------------------
     execute_next - execute the next command

--- a/src/emu/debug/debugcmd.h
+++ b/src/emu/debug/debugcmd.h
@@ -108,6 +108,7 @@ private:
 	void execute_go_interrupt(int ref, const std::vector<std::string> &params);
 	void execute_go_exception(int ref, const std::vector<std::string> &params);
 	void execute_go_time(int ref, const std::vector<std::string> &params);
+	void execute_go_privilege(int ref, const std::vector<std::string> &params);
 	void execute_focus(int ref, const std::vector<std::string> &params);
 	void execute_ignore(int ref, const std::vector<std::string> &params);
 	void execute_observe(int ref, const std::vector<std::string> &params);

--- a/src/emu/diexec.h
+++ b/src/emu/diexec.h
@@ -275,6 +275,12 @@ protected:
 			device().debug()->exception_hook(exception);
 	}
 
+	void debugger_privilege_hook()
+	{
+		if (device().machine().debug_flags & DEBUG_FLAG_ENABLED)
+			device().debug()->privilege_hook();
+	}
+
 private:
 	// internal information about the state of inputs
 	class device_input


### PR DESCRIPTION
gp 'go privilege' starts execution until the privilege mode
changes. This can be used to break on task switches. I.e on m68k,
one could do:

gp { ~sr & 0x2000 && crp_aptr == 0x1234567 }

which would execute until the privilege mode changes to user mode and
the CPU root pointer is 0x1234567.

for cpu code, all that is needed to make this work is calling
debugger_privilege_hook() when the execution level changes.