### PR TITLE
hp9k_3xx: fix RTC corruption

### DIFF
--- a/src/devices/bus/hp_dio/human_interface.cpp
+++ b/src/devices/bus/hp_dio/human_interface.cpp
@@ -138,6 +138,7 @@ void human_interface_device::device_reset()
 	m_ppoll_sc = 0;
 	m_gpib_irq_line = false;
 	m_kbd_nmi = false;
+	m_old_latch_enable = true;
 	m_rtc->cs1_w(ASSERT_LINE);
 	m_rtc->cs2_w(CLEAR_LINE);
 	m_rtc->write_w(CLEAR_LINE);


### PR DESCRIPTION
pre-init the latch clock variable to 1, so the first write to the latch
doesn't cause invalid data latched which would trigger an invalid write to
the RTC, causing an invalid time.