### PR TITLE
topcat: fix window move (nw)

### DIFF
--- a/src/devices/video/topcat.cpp
+++ b/src/devices/video/topcat.cpp
@@ -75,10 +75,10 @@ READ16_MEMBER(topcat_device::vram_r)
 	uint16_t ret = 0;
 
 	if (mem_mask & m_plane_mask)
-		ret |= m_vram[offset*2+1] ? m_plane_mask : 0;
+		ret |= m_vram[offset*2+1] & m_plane_mask;
 
 	if (mem_mask & m_plane_mask << 8)
-		ret |= m_vram[offset*2] ? m_plane_mask << 8 : 0;
+		ret |= (m_vram[offset*2] & m_plane_mask) << 8;
 	//LOG("%s: %04X: %04X (mask %04X)\n", __FUNCTION__, offset, ret, mem_mask);
 	return ret;
 }
@@ -386,10 +386,12 @@ WRITE16_MEMBER(topcat_device::ctrl_w)
 		update_int();
 		break;
 	case TOPCAT_REG_START_WMOVE:
-		window_move();
-		if (m_unknown_reg4a) {
-			m_wmove_intrq = m_plane_mask << 8;
-			update_int();
+		if (data & (m_plane_mask << 8)) {
+			window_move();
+			if (m_unknown_reg4a) {
+				m_wmove_intrq = m_plane_mask << 8;
+				update_int();
+			}
 		}
 		break;
 	case TOPCAT_REG_ENABLE_BLINK_PLANES:


### PR DESCRIPTION
Plane bitmap check was missing, so a window move was always started on all
planes. This was mostly visible in Pascal workstation, where text color was
brown instead of white, and HP VUE also showed broken colors.