### PR TITLE
deco32.cpp : Cleanups

### DIFF
--- a/src/mame/drivers/deco32.cpp
+++ b/src/mame/drivers/deco32.cpp
@@ -1037,7 +1037,7 @@ WRITE32_MEMBER( nslasher_state::tattass_control_w )
 				int i;
 				logerror("Eprom reset (bit count %d): ", m_read_bit_count);
 				for (i = 0; i < m_buf_ptr; i++)
-					logerror("%s", BIT(m_buffer, m_buf_ptr - i) ? "1" : "0");
+					logerror("%s", BIT(m_buffer, m_buf_ptr - 1 - i) ? "1" : "0");
 				logerror("\n");
 
 			}

--- a/src/mame/includes/deco32.h
+++ b/src/mame/includes/deco32.h
@@ -38,7 +38,7 @@ public:
 		, m_soundlatch(*this, "soundlatch")
 		, m_maincpu(*this, "maincpu")
 		, m_pf_rowscroll32(*this, "pf%u_rowscroll32", 1)
-		, m_generic_paletteram_32(*this, "paletteram")
+		, m_paletteram(*this, "paletteram")
 	{ }
 
 	DECLARE_WRITE8_MEMBER(sound_bankswitch_w);
@@ -63,7 +63,7 @@ protected:
 	template<int Chip> DECLARE_READ32_MEMBER(spriteram_r);
 	template<int Chip> DECLARE_WRITE32_MEMBER(spriteram_w);
 	template<int Chip> DECLARE_WRITE32_MEMBER(buffer_spriteram_w);
-	DECLARE_WRITE32_MEMBER(pri_w);
+	void pri_w(u32 data, u32 mem_mask);
 
 	// all but captaven
 	DECLARE_WRITE32_MEMBER(buffered_palette_w);
@@ -100,7 +100,7 @@ private:
 
 	// we use the pointers below to store a 32-bit copy..
 	required_shared_ptr_array<uint32_t, 4> m_pf_rowscroll32;
-	optional_shared_ptr<uint32_t> m_generic_paletteram_32;
+	optional_shared_ptr<uint32_t> m_paletteram;
 };
 
 class captaven_state : public deco32_state
@@ -121,11 +121,11 @@ private:
 	DECLARE_READ8_MEMBER(captaven_dsw3_r);
 	DECLARE_READ8_MEMBER(captaven_soundcpu_status_r);
 
-	DECLARE_VIDEO_START(captaven);
+	virtual void video_start() override;
 
-	uint32_t screen_update_captaven(screen_device &screen, bitmap_ind16 &bitmap, const rectangle &cliprect);
+	uint32_t screen_update(screen_device &screen, bitmap_ind16 &bitmap, const rectangle &cliprect);
 
-	DECO16IC_BANK_CB_MEMBER(captaven_bank_callback);
+	DECO16IC_BANK_CB_MEMBER(bank_callback);
 	DECOSPR_PRIORITY_CB_MEMBER(captaven_pri_callback);
 
 	void captaven_map(address_map &map);
@@ -150,11 +150,11 @@ private:
 	DECLARE_READ16_MEMBER(fghthist_in1_r);
 	DECLARE_READ32_MEMBER(unk_status_r);
 
-	DECLARE_VIDEO_START(fghthist);
+	virtual void video_start() override;
 
-	uint32_t screen_update_fghthist(screen_device &screen, bitmap_rgb32 &bitmap, const rectangle &cliprect);
+	uint32_t screen_update(screen_device &screen, bitmap_rgb32 &bitmap, const rectangle &cliprect);
 
-	DECO16IC_BANK_CB_MEMBER(fghthist_bank_callback);
+	DECO16IC_BANK_CB_MEMBER(bank_callback);
 
 	void fghthist_map(address_map &map);
 	void fghthsta_memmap(address_map &map);
@@ -184,12 +184,12 @@ private:
 	DECLARE_WRITE_LINE_MEMBER(tattass_sound_irq_w);
 	DECLARE_READ16_MEMBER(nslasher_debug_r);
 
-	DECLARE_VIDEO_START(nslasher);
+	virtual void video_start() override;
 
-	uint32_t screen_update_nslasher(screen_device &screen, bitmap_rgb32 &bitmap, const rectangle &cliprect);
+	uint32_t screen_update(screen_device &screen, bitmap_rgb32 &bitmap, const rectangle &cliprect);
 
 	DECLARE_READ16_MEMBER(port_b_tattass);
-	DECO16IC_BANK_CB_MEMBER(tattass_bank_callback);
+	DECO16IC_BANK_CB_MEMBER(bank_callback);
 
 	void nslasher_map(address_map &map);
 	void tattass_map(address_map &map);
@@ -199,12 +199,12 @@ private:
 	std::unique_ptr<bitmap_ind16> m_tilemap_alpha_bitmap;
 
 	int m_tattass_eprom_bit;
-	int m_lastClock;
-	char m_buffer[32];
-	int m_bufPtr;
-	int m_pendingCommand;
-	int m_readBitCount;
-	int m_byteAddr;
+	int m_last_clock;
+	uint32_t m_buffer;
+	int m_buf_ptr;
+	int m_pending_command;
+	int m_read_bit_count;
+	int m_byte_addr;
 };
 
 class dragngun_state : public deco32_state
@@ -262,10 +262,10 @@ private:
 	DECLARE_WRITE8_MEMBER(lockload_okibank_lo_w);
 	DECLARE_WRITE8_MEMBER(lockload_okibank_hi_w); // lockload
 
-	DECLARE_VIDEO_START(dragngun);
+	virtual void video_start() override;
 	void dragngun_init_common();
 
-	uint32_t screen_update_dragngun(screen_device &screen, bitmap_rgb32 &bitmap, const rectangle &cliprect);
+	uint32_t screen_update(screen_device &screen, bitmap_rgb32 &bitmap, const rectangle &cliprect);
 
 	DECO16IC_BANK_CB_MEMBER(bank_1_callback);
 	DECO16IC_BANK_CB_MEMBER(bank_2_callback);


### PR DESCRIPTION
Fix spacing, Move tilegen configurations into video_start, Remove VIDEO_START_MEMBER, Fix namings, Cleanup duplicates in gfxdecode, Reduce unnecessary address_space arguments, Reduce unnecessary arrays, Fix tattass* metadata related to date in ROM/RAM check screen