### PR TITLE
New WORKING machine

### DIFF
--- a/src/mame/drivers/nes_vt.cpp
+++ b/src/mame/drivers/nes_vt.cpp
@@ -1842,7 +1842,10 @@ CONS( 201?, cbrs8,      0,        0,  nes_vt,    nes_vt, nes_vt_state, empty_ini
 CONS( 200?, gprnrs1,    0,        0,  nes_vt,    nes_vt, nes_vt_state, empty_init, "<unknown>", "Game Prince RS-1", MACHINE_IMPERFECT_GRAPHICS )
 CONS( 200?, gprnrs16,   0,        0,  nes_vt,    nes_vt, nes_vt_state, empty_init, "<unknown>", "Game Prince RS-16", MACHINE_IMPERFECT_GRAPHICS )
 
-// Console has stereo output (dual RCA connectors)
+// Notes:
+// Console has stereo output (dual RCA connectors).
+// The original console shows a "Konami" banner on startup, but it seems to be missing on the emulation.
+// Also, it hangs when reset on a MAME debug build.
 CONS( 2001, ddrdismx,   0,        0,  nes_vt,    nes_vt, nes_vt_state, empty_init, "Disney", "Dance Dance Revolution Disney Mix", MACHINE_IMPERFECT_GRAPHICS )
 		
 // unsorted, these were all in nes.xml listed as ONE BUS systems

--- a/src/mame/drivers/nes_vt.cpp
+++ b/src/mame/drivers/nes_vt.cpp
@@ -1687,6 +1687,12 @@ ROM_START( sy888b )
 	ROM_REGION( 0x400000, "mainrom", 0 )
 	ROM_LOAD( "sy888b_f25q32.bin", 0x00000, 0x400000, CRC(a8298c33) SHA1(7112dd13d5fb5f9f9d496816758defd22773ec6e) )
 ROM_END
+
+ROM_START( ddrdismx )
+	ROM_REGION( 0x200000, "mainrom", 0 )
+	ROM_LOAD( "disney-ddr.bin", 0x00000, 0x200000, CRC(17fb3abb) SHA1(4d0eda4069ff46173468e579cdf9cc92b350146a) ) // 29LV160 Flash
+ROM_END
+
 #if 0
 ROM_START( mc_15kin1 )
 	ROM_REGION( 0x200000, "mainrom", 0 )
@@ -1835,6 +1841,10 @@ CONS( 201?, cbrs8,      0,        0,  nes_vt,    nes_vt, nes_vt_state, empty_ini
 
 CONS( 200?, gprnrs1,    0,        0,  nes_vt,    nes_vt, nes_vt_state, empty_init, "<unknown>", "Game Prince RS-1", MACHINE_IMPERFECT_GRAPHICS )
 CONS( 200?, gprnrs16,   0,        0,  nes_vt,    nes_vt, nes_vt_state, empty_init, "<unknown>", "Game Prince RS-16", MACHINE_IMPERFECT_GRAPHICS )
+
+// Console has stereo output (dual RCA connectors)
+CONS( 2001, ddrdismx,   0,        0,  nes_vt,    nes_vt, nes_vt_state, empty_init, "Disney", "Dance Dance Revolution Disney Mix", MACHINE_IMPERFECT_GRAPHICS )
+		
 // unsorted, these were all in nes.xml listed as ONE BUS systems
 CONS( 200?, mc_dg101,   0,        0,  nes_vt,    nes_vt, nes_vt_state, empty_init, "dreamGEAR", "dreamGEAR 101 in 1", MACHINE_IMPERFECT_GRAPHICS ) // dreamGear, but no enhanced games?
 CONS( 200?, mc_aa2,     0,        0,  nes_vt,    nes_vt, nes_vt_state, empty_init, "<unknown>", "100 in 1 Arcade Action II (AT-103)", MACHINE_IMPERFECT_GRAPHICS )

--- a/src/mame/mame.lst
+++ b/src/mame/mame.lst
@@ -30178,6 +30178,7 @@ mc_sam60
 vgtablet
 gprnrs1
 gprnrs16
+ddrdismix                       // (c) 2001 Disney
 vgpocket
 vgpmini
 sy889

--- a/src/mame/mame.lst
+++ b/src/mame/mame.lst
@@ -30178,7 +30178,7 @@ mc_sam60
 vgtablet
 gprnrs1
 gprnrs16
-ddrdismix                       // (c) 2001 Disney
+ddrdismx                        // (c) 2001 Disney
 vgpocket
 vgpmini
 sy889


### PR DESCRIPTION
---------------------------------
Dance Dance Revolution Disney Mix [zino, ClawGrip, The Dumping Union, Recreativas.org]

Notes: 
* The console has stereo output (via two RCA cables), but the driver outputs mono.
* I've marked the game as MACHINE_IMPERFECT_GRAPHICS as every other game on the driver, 
  but I see no graphical differences with the real game.
  I recorded a video of it: https://www.youtube.com/watch?v=PTmwcrRqufI
* The original console shows a "Konami" banner on startup, but it seems to be missing on the emulation.
* MAME crashes when the game is resetted (F3) on a MAME debug build.

