### PR TITLE
imagetek_i4100.cpp : Updates, Minor cleanups, Remove MCFGs

### DIFF
--- a/src/devices/video/imagetek_i4100.cpp
+++ b/src/devices/video/imagetek_i4100.cpp
@@ -72,6 +72,51 @@
 //  GLOBAL VARIABLES
 //**************************************************************************
 
+/***************************************************************************
+                            Graphics Layouts
+***************************************************************************/
+
+/* 8x8x4 tiles */
+static const gfx_layout layout_8x8x4 =
+{
+	8,8,
+	RGN_FRAC(1,1),
+	4,
+	{ STEP4(0,1) },
+	{ 4*1,4*0, 4*3,4*2, 4*5,4*4, 4*7,4*6 },
+	{ STEP8(0,4*8) },
+	4*8*8
+};
+
+/* 8x8x8 tiles for later games */
+static GFXLAYOUT_RAW( layout_8x8x8, 8, 8, 8*8, 32*8 )
+
+/* 16x16x4 tiles for later games */
+static const gfx_layout layout_16x16x4 =
+{
+	16,16,
+	RGN_FRAC(1,1),
+	4,
+	{ STEP4(0,1) },
+	{ 4*1,4*0, 4*3,4*2, 4*5,4*4, 4*7,4*6, 4*9,4*8, 4*11,4*10, 4*13,4*12, 4*15,4*14 },
+	{ STEP16(0,4*16) },
+	4*8*8
+};
+
+/* 16x16x8 tiles for later games */
+static GFXLAYOUT_RAW( layout_16x16x8, 16, 16, 16*8, 32*8 )
+
+GFXDECODE_START( imagetek_i4100_device::gfxinfo )
+	GFXDECODE_DEVICE( DEVICE_SELF, 0, layout_8x8x4,    0x0, 0x100 ) // [0] 4 Bit Tiles
+GFXDECODE_END
+
+GFXDECODE_START( imagetek_i4100_device::gfxinfo_ext )
+	GFXDECODE_DEVICE( DEVICE_SELF, 0, layout_8x8x4,    0x0, 0x100 ) // [0] 4 Bit Tiles
+	GFXDECODE_DEVICE( DEVICE_SELF, 0, layout_8x8x8,    0x0,  0x10 ) // [1] 8 Bit Tiles
+	GFXDECODE_DEVICE( DEVICE_SELF, 0, layout_16x16x4,  0x0, 0x100 ) // [2] 4 Bit Tiles 16x16
+	GFXDECODE_DEVICE( DEVICE_SELF, 0, layout_16x16x8,  0x0,  0x10 ) // [3] 8 Bit Tiles 16x16
+GFXDECODE_END
+
 // device type definition
 DEFINE_DEVICE_TYPE(I4100, imagetek_i4100_device, "i4100", "Imagetek I4100 052 VDP")
 DEFINE_DEVICE_TYPE(I4220, imagetek_i4220_device, "i4220", "Imagetek I4220 071 VDP")
@@ -84,7 +129,7 @@ void imagetek_i4100_device::map(address_map &map)
 	map(0x40000, 0x5ffff).rw(FUNC(imagetek_i4100_device::vram_2_r), FUNC(imagetek_i4100_device::vram_2_w)).share("vram_2");
 	map(0x60000, 0x6ffff).r(FUNC(imagetek_i4100_device::gfxrom_r));
 	map(0x70000, 0x71fff).rw(FUNC(imagetek_i4100_device::scratchram_r), FUNC(imagetek_i4100_device::scratchram_w)).share("scratchram"); // unknown, maybe palette
-	map(0x72000, 0x73fff).rw("palette", FUNC(palette_device::read16), FUNC(palette_device::write16)).share("palette");
+	map(0x72000, 0x73fff).rw(m_palette, FUNC(palette_device::read16), FUNC(palette_device::write16)).share("palette");
 	map(0x74000, 0x74fff).rw(FUNC(imagetek_i4100_device::spriteram_r), FUNC(imagetek_i4100_device::spriteram_w)).share("spriteram");
 	map(0x75000, 0x75fff).rw(FUNC(imagetek_i4100_device::rmw_vram_0_r), FUNC(imagetek_i4100_device::rmw_vram_0_w));
 	map(0x76000, 0x76fff).rw(FUNC(imagetek_i4100_device::rmw_vram_1_r), FUNC(imagetek_i4100_device::rmw_vram_1_w));
@@ -120,7 +165,7 @@ void imagetek_i4220_device::v2_map(address_map &map)
 	map(0x40000, 0x5ffff).rw(FUNC(imagetek_i4220_device::vram_2_r), FUNC(imagetek_i4220_device::vram_2_w)).share("vram_2");
 	map(0x60000, 0x6ffff).r(FUNC(imagetek_i4220_device::gfxrom_r));
 	map(0x70000, 0x71fff).rw(FUNC(imagetek_i4220_device::scratchram_r), FUNC(imagetek_i4220_device::scratchram_w)).share("scratchram"); // unknown, maybe palette
-	map(0x72000, 0x73fff).rw("palette", FUNC(palette_device::read16), FUNC(palette_device::write16)).share("palette");
+	map(0x72000, 0x73fff).rw(m_palette, FUNC(palette_device::read16), FUNC(palette_device::write16)).share("palette");
 	map(0x74000, 0x74fff).rw(FUNC(imagetek_i4220_device::spriteram_r), FUNC(imagetek_i4220_device::spriteram_w)).share("spriteram");
 	map(0x75000, 0x75fff).rw(FUNC(imagetek_i4220_device::rmw_vram_0_r), FUNC(imagetek_i4220_device::rmw_vram_0_w));
 	map(0x76000, 0x76fff).rw(FUNC(imagetek_i4220_device::rmw_vram_1_r), FUNC(imagetek_i4220_device::rmw_vram_1_w));
@@ -166,7 +211,7 @@ void imagetek_i4300_device::v3_map(address_map &map)
 	map(0x40000, 0x5ffff).rw(FUNC(imagetek_i4300_device::vram_2_r), FUNC(imagetek_i4300_device::vram_2_w)).share("vram_2");
 	map(0x60000, 0x6ffff).r(FUNC(imagetek_i4300_device::gfxrom_r));
 	map(0x70000, 0x71fff).rw(FUNC(imagetek_i4300_device::scratchram_r), FUNC(imagetek_i4300_device::scratchram_w)).share("scratchram"); // unknown, maybe palette
-	map(0x72000, 0x73fff).rw("palette", FUNC(palette_device::read16), FUNC(palette_device::write16)).share("palette");
+	map(0x72000, 0x73fff).rw(m_palette, FUNC(palette_device::read16), FUNC(palette_device::write16)).share("palette");
 	map(0x74000, 0x74fff).rw(FUNC(imagetek_i4300_device::spriteram_r), FUNC(imagetek_i4300_device::spriteram_w)).share("spriteram");
 	map(0x75000, 0x75fff).rw(FUNC(imagetek_i4300_device::rmw_vram_0_r), FUNC(imagetek_i4300_device::rmw_vram_0_w));
 	map(0x76000, 0x76fff).rw(FUNC(imagetek_i4300_device::rmw_vram_1_r), FUNC(imagetek_i4300_device::rmw_vram_1_w));
@@ -207,6 +252,7 @@ void imagetek_i4300_device::v3_map(address_map &map)
 
 imagetek_i4100_device::imagetek_i4100_device(const machine_config &mconfig, device_type type, const char *tag, device_t *owner, uint32_t clock, bool has_ext_tiles)
 	: device_t(mconfig, type, tag, owner, clock)
+	, device_gfx_interface(mconfig, *this, has_ext_tiles ? gfxinfo_ext : gfxinfo, "palette")
 	, device_video_interface(mconfig, *this)
 	, m_vram_0(*this, "vram_0")
 	, m_vram_1(*this, "vram_1")
@@ -218,13 +264,13 @@ imagetek_i4100_device::imagetek_i4100_device(const machine_config &mconfig, devi
 	, m_window(*this, "windowregs")
 	, m_scroll(*this, "scrollregs")
 	, m_palette(*this, "palette")
-	, m_gfxdecode(*this, finder_base::DUMMY_TAG)
-	, m_gfxrom(*this, "^gfx1")
+	, m_gfxrom(*this, DEVICE_SELF)
 	, m_blit_irq_cb(*this)
 	, m_support_8bpp( has_ext_tiles )
 	, m_support_16x16( has_ext_tiles )
 	, m_tilemap_scrolldx{0, 0, 0}
 	, m_tilemap_scrolldy{0, 0, 0}
+	, m_spriteram_buffered(false)
 {
 }
 
@@ -249,11 +295,11 @@ imagetek_i4300_device::imagetek_i4300_device(const machine_config &mconfig, cons
 //  configuration addiitons
 //-------------------------------------------------
 
-MACHINE_CONFIG_START(imagetek_i4100_device::device_add_mconfig)
-	MCFG_PALETTE_ADD("palette", 0x1000)
-	MCFG_PALETTE_FORMAT(GGGGGRRRRRBBBBBx)
-MACHINE_CONFIG_END
-
+void imagetek_i4100_device::device_add_mconfig(machine_config &config)
+{
+	PALETTE(config, m_palette, 0x1000).set_format(PALETTE_FORMAT_GGGGGRRRRRBBBBBx);
+	BUFFERED_SPRITERAM16(config, m_spriteram);
+}
 
 //-------------------------------------------------
 //  device_start - device-specific startup
@@ -281,9 +327,6 @@ void imagetek_i4100_device::expand_gfx1()
 
 void imagetek_i4100_device::device_start()
 {
-	if(!m_gfxdecode->started())
-		throw device_missing_dependencies();
-
 	m_inited_hack = false;
 	save_item(NAME(m_rombank));
 	save_item(NAME(m_crtc_unlock));
@@ -362,8 +405,8 @@ WRITE16_MEMBER(imagetek_i4100_device::rmw_vram_2_w){ COMBINE_DATA(&m_vram_2[RMW_
 
 READ16_MEMBER(imagetek_i4100_device::scratchram_r ) { return m_scratchram[offset]; }
 WRITE16_MEMBER(imagetek_i4100_device::scratchram_w ) { COMBINE_DATA(&m_scratchram[offset]); }
-READ16_MEMBER(imagetek_i4100_device::spriteram_r ) { return m_spriteram[offset]; }
-WRITE16_MEMBER(imagetek_i4100_device::spriteram_w ) { COMBINE_DATA(&m_spriteram[offset]); }
+READ16_MEMBER(imagetek_i4100_device::spriteram_r ) { return m_spriteram->live()[offset]; }
+WRITE16_MEMBER(imagetek_i4100_device::spriteram_w ) { COMBINE_DATA(&m_spriteram->live()[offset]); }
 READ16_MEMBER(imagetek_i4100_device::tiletable_r ) { return m_tiletable[offset]; }
 WRITE16_MEMBER(imagetek_i4100_device::tiletable_w ) { COMBINE_DATA(&m_tiletable[offset]); }
 
@@ -655,7 +698,7 @@ WRITE16_MEMBER( imagetek_i4100_device::blitter_w )
 
 	if (offset == 0x0c / 2)
 	{
-		//uint8_t *src     = memregion("gfx1")->base();
+		//uint8_t *src     = memregion(DEVICE_SELF)->base();
 
 		uint32_t tmap     = (m_blitter_regs[0x00 / 2] << 16) + m_blitter_regs[0x02 / 2];
 		uint32_t src_offs = (m_blitter_regs[0x04 / 2] << 16) + m_blitter_regs[0x06 / 2];
@@ -776,6 +819,133 @@ WRITE16_MEMBER( imagetek_i4100_device::blitter_w )
  *
  ***************************************************************************/
 
+void imagetek_i4100_device::draw_spritegfx(screen_device &screen, bitmap_ind16 &bitmap, const rectangle &clip,
+							uint32_t const gfxstart, uint16_t const width, uint16_t const height,
+							uint16_t color, int const flipx, int const flipy, int sx, int sy,
+							uint32_t const scale, uint8_t const prival )
+{
+	if (!scale) return;
+	uint8_t trans;
+	bool const is_8bpp = (m_support_8bpp == true && color == 0xf) ? true : false;  /* 8bpp */
+
+	if (is_8bpp)
+	{
+		trans = 0xff;
+		color = 0;
+		/* Bounds checking */
+		if ((gfxstart + width * height - 1) >= m_gfxrom.bytes())
+			return;
+	}
+	else
+	{
+		trans = 0xf;
+		color <<= 4;
+		/* Bounds checking */
+		if ((gfxstart + width / 2 * height - 1) >= m_gfxrom.bytes())
+			return;
+	}
+
+	if (bitmap.bpp() == 16)
+	{
+		const pen_t *pal = &m_palette->pen((m_sprite_color_code & 0x0f) << 8);
+		const uint8_t *source_base;
+		if (is_8bpp)
+			source_base = &m_gfxrom[gfxstart % m_gfxrom.bytes()];
+		else
+			source_base = &m_expanded_gfx1[(gfxstart % m_gfxrom.bytes()) << 1];
+
+		int const sprite_screen_height = (scale * height + 0x8000) >> 16;
+		int const sprite_screen_width = (scale * width + 0x8000) >> 16;
+		if (sprite_screen_width && sprite_screen_height)
+		{
+			/* compute sprite increment per screen pixel */
+			int dx = (width << 16) / sprite_screen_width;
+			int dy = (height << 16) / sprite_screen_height;
+
+			int ex = sx + sprite_screen_width;
+			int ey = sy + sprite_screen_height;
+
+			int x_index_base;
+			int y_index;
+
+			if (flipx)
+			{
+				x_index_base = (sprite_screen_width - 1) * dx;
+				dx = -dx;
+			}
+			else
+			{
+				x_index_base = 0;
+			}
+
+			if (flipy)
+			{
+				y_index = (sprite_screen_height - 1) * dy;
+				dy = -dy;
+			}
+			else
+			{
+				y_index = 0;
+			}
+
+			if (sx < clip.min_x)
+			{ /* clip left */
+				int pixels = clip.min_x - sx;
+				sx += pixels;
+				x_index_base += pixels * dx;
+			}
+			if (sy < clip.min_y)
+			{ /* clip top */
+				int pixels = clip.min_y - sy;
+				sy += pixels;
+				y_index += pixels * dy;
+			}
+			if (ex > clip.max_x + 1)
+			{ /* clip right */
+				int pixels = ex - clip.max_x - 1;
+				ex -= pixels;
+			}
+			if (ey > clip.max_y + 1)
+			{ /* clip bottom */
+				int pixels = ey - clip.max_y - 1;
+				ey -= pixels;
+			}
+
+			if (ex > sx)
+			{ /* skip if inner loop doesn't draw anything */
+				int y;
+				bitmap_ind8 &priority_bitmap = screen.priority();
+				if (priority_bitmap.valid())
+				{
+					for (y = sy; y < ey; y++)
+					{
+						const uint8_t *source = source_base + (y_index >> 16) * width;
+						uint16_t *dest = &bitmap.pix16(y);
+						uint8_t *pri = &priority_bitmap.pix8(y);
+						int x, x_index = x_index_base;
+						{
+							for (x = sx; x < ex; x++)
+							{
+								uint8_t const c = source[x_index >> 16];
+
+								if (c != trans)
+								{
+									if (pri[x] <= prival)
+										dest[x] = pal[color + c];
+
+									pri[x] = 0xff;
+								}
+								x_index += dx;
+							}
+							y_index += dy;
+						}
+					}
+				}
+			}
+		}
+	}
+}
+
  /***************************************************************************
 
 
@@ -806,22 +976,24 @@ WRITE16_MEMBER( imagetek_i4100_device::blitter_w )
 
 void imagetek_i4100_device::draw_sprites( screen_device &screen, bitmap_ind16 &bitmap, const rectangle &cliprect )
 {
-	uint8_t *base_gfx4 = m_expanded_gfx1.get();
-	uint8_t *base_gfx8 = m_gfxrom;
-	uint32_t gfx_size = m_gfxrom_size;
+	int max_x = (m_screen_xoffset + 1) * 2;
+	int max_y = (m_screen_yoffset + 1) * 2;
+	int m_sprite_xoffs = m_sprite_xoffset - (m_screen_xoffset + 1);
+	int m_sprite_yoffs = m_sprite_yoffset - (m_screen_yoffset + 1);
 
-	int max_x = (m_screen_xoffset+1)*2;
-	int max_y = (m_screen_yoffset+1)*2;
-	int m_sprite_xoffs = m_sprite_xoffset - (m_screen_xoffset+1);
-	int m_sprite_yoffs = m_sprite_yoffset - (m_screen_yoffset+1);
-
-	int max_sprites = m_spriteram.bytes() / 8;
+	int max_sprites = m_spriteram->bytes() / 8;
 	int sprites     = m_sprite_count % max_sprites;
 
-	int color_start = (m_sprite_color_code & 0x0f) << 4;
-
-	int i, j, pri;
-	static const int primask[4] = { 0x0000, 0xff00, 0xff00 | 0xf0f0, 0xff00 | 0xf0f0 | 0xcccc };
+	// Exponential zoom table extracted from daitoride
+	static const uint16_t zoomtable[0x40] =
+	{   0xAAC,0x800,0x668,0x554,0x494,0x400,0x390,0x334,
+		0x2E8,0x2AC,0x278,0x248,0x224,0x200,0x1E0,0x1C8,
+		0x1B0,0x198,0x188,0x174,0x164,0x154,0x148,0x13C,
+		0x130,0x124,0x11C,0x110,0x108,0x100,0x0F8,0x0F0,
+		0x0EC,0x0E4,0x0DC,0x0D8,0x0D4,0x0CC,0x0C8,0x0C4,
+		0x0C0,0x0BC,0x0B8,0x0B4,0x0B0,0x0AC,0x0A8,0x0A4,
+		0x0A0,0x09C,0x098,0x094,0x090,0x08C,0x088,0x080,
+		0x078,0x070,0x068,0x060,0x058,0x050,0x048,0x040 };
 
 	uint16_t *src;
 	int inc;
@@ -829,34 +1001,23 @@ void imagetek_i4100_device::draw_sprites( screen_device &screen, bitmap_ind16 &b
 	if (sprites == 0)
 		return;
 
-	for (i = 0; i < 0x20; i++)
+	for (int i = 0; i < 0x20; i++)
 	{
 		if (!(m_sprite_priority & 0x8000))
 		{
-			src = m_spriteram + (sprites - 1) * (8 / 2);
+			src = (m_spriteram_buffered ? m_spriteram->buffer() : m_spriteram->live()) + (sprites - 1) * (8 / 2);
 			inc = -(8 / 2);
-		} else {
-			src = m_spriteram;
+		}
+		else
+		{
+			src = (m_spriteram_buffered ? m_spriteram->buffer() : m_spriteram->live());
 			inc = (8 / 2);
 		}
 
-		for (j = 0; j < sprites; j++)
+		for (int j = 0; j < sprites; j++)
 		{
-			int x, y, attr, code, color, flipx, flipy, zoom, curr_pri, width, height;
-
-			// Exponential zoom table extracted from daitoride
-			static const int zoomtable[0x40] =
-			{   0xAAC,0x800,0x668,0x554,0x494,0x400,0x390,0x334,
-				0x2E8,0x2AC,0x278,0x248,0x224,0x200,0x1E0,0x1C8,
-				0x1B0,0x198,0x188,0x174,0x164,0x154,0x148,0x13C,
-				0x130,0x124,0x11C,0x110,0x108,0x100,0x0F8,0x0F0,
-				0x0EC,0x0E4,0x0DC,0x0D8,0x0D4,0x0CC,0x0C8,0x0C4,
-				0x0C0,0x0BC,0x0B8,0x0B4,0x0B0,0x0AC,0x0A8,0x0A4,
-				0x0A0,0x09C,0x098,0x094,0x090,0x08C,0x088,0x080,
-				0x078,0x070,0x068,0x060,0x058,0x050,0x048,0x040 };
-
-			x = src[0];
-			curr_pri = (x & 0xf800) >> 11;
+			int x = src[0];
+			int const curr_pri = (x & 0xf800) >> 11;
 
 			if ((curr_pri == 0x1f) || (curr_pri != i))
 			{
@@ -864,7 +1025,7 @@ void imagetek_i4100_device::draw_sprites( screen_device &screen, bitmap_ind16 &b
 				continue;
 			}
 
-			pri = (m_sprite_priority & 0x0300) >> 8;
+			uint8_t pri = (m_sprite_priority & 0x0300) >> 8;
 
 			if (!(m_sprite_priority & 0x8000))
 			{
@@ -872,23 +1033,23 @@ void imagetek_i4100_device::draw_sprites( screen_device &screen, bitmap_ind16 &b
 					pri = (m_sprite_priority & 0x0c00) >> 10;
 			}
 
-			y     = src[1];
-			attr  = src[2];
-			code  = src[3];
+			int y               = src[1];
+			uint16_t const attr = src[2];
+			uint16_t const code = src[3];
 
-			flipx =  attr & 0x8000;
-			flipy =  attr & 0x4000;
-			color = (attr & 0xf0) >> 4;
+			int flipx            = attr & 0x8000;
+			int flipy            = attr & 0x4000;
+			uint16_t const color = (attr & 0xf0) >> 4;
 
-			zoom = zoomtable[(y & 0xfc00) >> 10] << (16 - 8);
+			uint32_t const zoom = zoomtable[(y & 0xfc00) >> 10] << (16 - 8);
 
 			x = (x & 0x07ff) - m_sprite_xoffs;
 			y = (y & 0x03ff) - m_sprite_yoffs;
 
-			width  = (((attr >> 11) & 0x7) + 1) * 8;
-			height = (((attr >>  8) & 0x7) + 1) * 8;
+			int const width  = (((attr >> 11) & 0x7) + 1) * 8;
+			int const height = (((attr >>  8) & 0x7) + 1) * 8;
 
-			uint32_t gfxstart = (8 * 8 * 4 / 8) * (((attr & 0x000f) << 16) + code);
+			uint32_t const gfxstart = (8 * 8 * 4 / 8) * (((attr & 0x000f) << 16) + code);
 
 			if (m_screen_flip)
 			{
@@ -896,38 +1057,7 @@ void imagetek_i4100_device::draw_sprites( screen_device &screen, bitmap_ind16 &b
 				flipy = !flipy;     y = max_y - y - height;
 			}
 
-			if (m_support_8bpp == true && color == 0xf)  /* 8bpp */
-			{
-				/* Bounds checking */
-				if ((gfxstart + width * height - 1) >= gfx_size)
-					continue;
-
-				gfx_element gfx(m_palette, base_gfx8 + gfxstart, width, height, width, m_palette->entries(), 0, 256);
-
-				gfx.prio_zoom_transpen(bitmap,cliprect,
-								0,
-								color_start >> 4,
-								flipx, flipy,
-								x, y,
-								zoom, zoom,
-								screen.priority(),primask[pri], 255);
-			}
-			else
-			{
-				/* Bounds checking */
-				if ((gfxstart + width / 2 * height - 1) >= gfx_size)
-					continue;
-
-				gfx_element gfx(m_palette, base_gfx4 + 2 * gfxstart, width, height, width, m_palette->entries(),0, 16);
-
-				gfx.prio_zoom_transpen(bitmap,cliprect,
-								0,
-								color + color_start,
-								flipx, flipy,
-								x, y,
-								zoom, zoom,
-								screen.priority(),primask[pri], 15);
-			}
+			draw_spritegfx(screen, bitmap, cliprect, gfxstart, width, height, color, flipx, flipy, x, y, zoom, 3 - pri);
 
 			src += inc;
 		}
@@ -935,14 +1065,11 @@ void imagetek_i4100_device::draw_sprites( screen_device &screen, bitmap_ind16 &b
 }
 
 
- inline uint8_t imagetek_i4100_device::get_tile_pix( uint16_t code, uint8_t x, uint8_t y, bool big, uint16_t *pix )
+ inline uint8_t imagetek_i4100_device::get_tile_pix( uint16_t code, uint8_t x, uint8_t y, bool const big, uint16_t *pix )
 {
-	int table_index;
-	uint32_t tile;
-
 	// Use code as an index into the tiles set table
-	table_index = ((code & 0x1ff0) >> 4) * 2;
-	tile = (m_tiletable[table_index + 0] << 16) + m_tiletable[table_index + 1];
+	int table_index = (code & 0x1ff0) >> 3;
+	uint32_t tile = (m_tiletable[table_index] << 16) + m_tiletable[table_index | 1];
 
 	if (code & 0x8000) // Special: draw a tile of a single color (i.e. not from the gfx ROMs)
 	{
@@ -955,9 +1082,9 @@ void imagetek_i4100_device::draw_sprites( screen_device &screen, bitmap_ind16 &b
 	}
 	else if (((tile & 0x00f00000) == 0x00f00000) && (m_support_8bpp == true)) /* draw tile as 8bpp (e.g. balcube bg) */
 	{
-		gfx_element *gfx1 = m_gfxdecode->gfx(big?3:1);
-		uint32_t tile2 = big ? ((tile & 0xfffff) + 8*(code & 0xf)) :
-								((tile & 0xfffff) + 2*(code & 0xf));
+		gfx_element *gfx1 = gfx(big ? 3 : 1);
+		uint32_t tile2 = big ? ((tile & 0xfffff) + ((code & 0xf) << 3)) :
+								((tile & 0xfffff) + ((code & 0xf) << 1));
 		const uint8_t* data;
 		uint8_t flipxy = (code & 0x6000) >> 13;
 
@@ -972,13 +1099,13 @@ void imagetek_i4100_device::draw_sprites( screen_device &screen, bitmap_ind16 &b
 		switch (flipxy)
 		{
 			default:
-			case 0x0: *pix = data[(y              * (big?16:8)) + x];              break;
-			case 0x1: *pix = data[(((big?15:7)-y) * (big?16:8)) + x];              break;
-			case 0x2: *pix = data[(y              * (big?16:8)) + ((big?15:7)-x)]; break;
-			case 0x3: *pix = data[(((big?15:7)-y) * (big?16:8)) + ((big?15:7)-x)]; break;
+			case 0x0: *pix = data[(y                    * (big ? 16 : 8)) + x];                    break;
+			case 0x1: *pix = data[(((big ? 15 : 7) - y) * (big ? 16 : 8)) + x];                    break;
+			case 0x2: *pix = data[(y                    * (big ? 16 : 8)) + ((big ? 15 : 7) - x)]; break;
+			case 0x3: *pix = data[(((big ? 15 : 7) - y) * (big ? 16 : 8)) + ((big ? 15 : 7) - x)]; break;
 		}
 
-		*pix |= ((tile & 0x0f000000) >> 24) * 0x100;
+		*pix |= (tile & 0x0f000000) >> 16;
 
 		if ((*pix & 0xff) != 0xff)
 			return 1;
@@ -987,9 +1114,9 @@ void imagetek_i4100_device::draw_sprites( screen_device &screen, bitmap_ind16 &b
 	}
 	else
 	{
-		gfx_element *gfx1 = m_gfxdecode->gfx(big?2:0);
-		uint32_t tile2 = big ? ((tile & 0xfffff) + 4*(code & 0xf)) :
-								((tile & 0xfffff) +   (code & 0xf));
+		gfx_element *gfx1 = gfx(big ? 2 : 0);
+		uint32_t tile2 = big ? ((tile & 0xfffff) + ((code & 0xf) << 2)) :
+								((tile & 0xfffff) + (code & 0xf));
 		const uint8_t* data;
 		uint8_t flipxy = (code & 0x6000) >> 13;
 
@@ -1004,13 +1131,13 @@ void imagetek_i4100_device::draw_sprites( screen_device &screen, bitmap_ind16 &b
 		switch (flipxy)
 		{
 			default:
-			case 0x0: *pix = data[(y              * (big?16:8)) + x];             break;
-			case 0x1: *pix = data[(((big?15:7)-y) * (big?16:8)) + x];             break;
-			case 0x2: *pix = data[(y              * (big?16:8)) + ((big?15:7)-x)]; break;
-			case 0x3: *pix = data[(((big?15:7)-y) * (big?16:8)) + ((big?15:7)-x)]; break;
+			case 0x0: *pix = data[(y                    * (big ? 16 : 8)) + x];                    break;
+			case 0x1: *pix = data[(((big ? 15 : 7) - y) * (big ? 16 : 8)) + x];                    break;
+			case 0x2: *pix = data[(y                    * (big ? 16 : 8)) + ((big ? 15 : 7) - x)]; break;
+			case 0x3: *pix = data[(((big ? 15 : 7) - y) * (big ? 16 : 8)) + ((big ? 15 : 7) - x)]; break;
 		}
 
-		*pix |= (((tile & 0x0ff00000) >> 20)) * 0x10;
+		*pix |= (tile & 0x0ff00000) >> 16;
 
 		if ((*pix & 0xf) != 0xf)
 			return 1;
@@ -1039,8 +1166,8 @@ void imagetek_i4100_device::draw_sprites( screen_device &screen, bitmap_ind16 &b
 
 ***************************************************************************/
 
-void imagetek_i4100_device::draw_tilemap( screen_device &screen, bitmap_ind16 &bitmap, const rectangle &cliprect, uint32_t flags, uint32_t pcode,
-							int sx, int sy, int wx, int wy, bool big, uint16_t *tilemapram, int layer )
+void imagetek_i4100_device::draw_tilemap( screen_device &screen, bitmap_ind16 &bitmap, const rectangle &cliprect, uint32_t flags, uint32_t const pcode,
+							int sx, int sy, int wx, int wy, bool const big, uint16_t const *tilemapram, int const layer )
 {
 	int y;
 
@@ -1066,7 +1193,7 @@ void imagetek_i4100_device::draw_tilemap( screen_device &screen, bitmap_ind16 &b
 	if (dx != 0)
 	{
 		min_x = 0;
-		max_x = scrwidth-1;
+		max_x = scrwidth - 1;
 	}
 	else
 	{
@@ -1077,7 +1204,7 @@ void imagetek_i4100_device::draw_tilemap( screen_device &screen, bitmap_ind16 &b
 	if (dy != 0)
 	{
 		min_y = 0;
-		max_y = scrheight-1;
+		max_y = scrheight - 1;
 	}
 	else
 	{
@@ -1087,11 +1214,11 @@ void imagetek_i4100_device::draw_tilemap( screen_device &screen, bitmap_ind16 &b
 
 	for (y = min_y; y <= max_y; y++)
 	{
-		int scrolly = (sy+y-wy)&(windowheight-1);
+		int scrolly = (sy + y - wy) & (windowheight - 1);
 		int x;
 		uint16_t *dst;
 		uint8_t *priority_baseaddr;
-		int srcline = (wy+scrolly)&(height-1);
+		int srcline = (wy + scrolly) & (height - 1);
 		int srctilerow = srcline >> (big ? 4 : 3);
 
 		if (!m_screen_flip)
@@ -1101,15 +1228,15 @@ void imagetek_i4100_device::draw_tilemap( screen_device &screen, bitmap_ind16 &b
 
 			for (x = min_x; x <= max_x; x++)
 			{
-				int scrollx = (sx+x-wx)&(windowwidth-1);
-				int srccol = (wx+scrollx)&(width-1);
+				int scrollx = (sx + x - wx) & (windowwidth - 1);
+				int srccol = (wx + scrollx) & (width - 1);
 				int srctilecol = srccol >> (big ? 4 : 3);
 				int tileoffs = srctilecol + srctilerow * BIG_NX;
 
 				uint16_t dat = 0;
 
 				uint16_t tile = tilemapram[tileoffs];
-				uint8_t draw = get_tile_pix(tile, big ? (srccol&0xf) : (srccol&0x7), big ? (srcline&0xf) : (srcline&0x7), big, &dat);
+				uint8_t draw = get_tile_pix(tile, big ? (srccol & 0xf) : (srccol & 0x7), big ? (srcline & 0xf) : (srcline & 0x7), big, &dat);
 
 				if (draw)
 				{
@@ -1125,15 +1252,15 @@ void imagetek_i4100_device::draw_tilemap( screen_device &screen, bitmap_ind16 &b
 
 			for (x = min_x; x <= max_x; x++)
 			{
-				int scrollx = (sx+x-wx)&(windowwidth-1);
-				int srccol = (wx+scrollx)&(width-1);
+				int scrollx = (sx + x - wx) & (windowwidth-1);
+				int srccol = (wx + scrollx) & (width - 1);
 				int srctilecol = srccol >> (big ? 4 : 3);
 				int tileoffs = srctilecol + srctilerow * BIG_NX;
 
 				uint16_t dat = 0;
 
 				uint16_t tile = tilemapram[tileoffs];
-				uint8_t draw = get_tile_pix(tile, big ? (srccol&0xf) : (srccol&0x7), big ? (srcline&0xf) : (srcline&0x7), big, &dat);
+				uint8_t draw = get_tile_pix(tile, big ? (srccol & 0xf) : (srccol & 0x7), big ? (srcline & 0xf) : (srcline & 0x7), big, &dat);
 
 				if (draw)
 				{
@@ -1166,9 +1293,9 @@ void imagetek_i4100_device::draw_layers( screen_device &screen, bitmap_ind16 &bi
 				case 2: tilemapram = m_vram_2;   break;
 			}
 
-			bool big = (m_support_16x16 && m_layer_tile_select[layer]) == 1;
+			bool const big = (m_support_16x16 && m_layer_tile_select[layer]) == 1;
 
-			draw_tilemap(screen, bitmap, cliprect, 0, 1 << (3 - pri), sx, sy, wx, wy, big, tilemapram, layer);
+			draw_tilemap(screen, bitmap, cliprect, 0, 3 - pri, sx, sy, wx, wy, big, tilemapram, layer);
 		}
 	}
 }
@@ -1189,4 +1316,15 @@ uint32_t imagetek_i4100_device::screen_update(screen_device &screen, bitmap_ind1
 	draw_sprites(screen, bitmap, cliprect);
 
 	return 0;
+}
+
+WRITE_LINE_MEMBER(imagetek_i4100_device::screen_eof)
+{
+	if (state)
+	{
+		if (!m_spriteram_buffered)
+			return;
+
+		m_spriteram->copy();
+	}
 }

--- a/src/mame/drivers/hyprduel.cpp
+++ b/src/mame/drivers/hyprduel.cpp
@@ -72,8 +72,8 @@ public:
 	void init_hyprduel();
 
 private:
-	DECLARE_READ16_MEMBER(irq_cause_r);
-	DECLARE_WRITE16_MEMBER(irq_cause_w);
+	DECLARE_READ8_MEMBER(irq_cause_r);
+	DECLARE_WRITE8_MEMBER(irq_cause_w);
 	DECLARE_WRITE16_MEMBER(subcpu_control_w);
 	DECLARE_READ16_MEMBER(hyprduel_cpusync_trigger1_r);
 	DECLARE_WRITE16_MEMBER(hyprduel_cpusync_trigger1_w);
@@ -149,22 +149,19 @@ TIMER_DEVICE_CALLBACK_MEMBER(hyprduel_state::interrupt)
 	update_irq_state();
 }
 
-READ16_MEMBER(hyprduel_state::irq_cause_r)
+READ8_MEMBER(hyprduel_state::irq_cause_r)
 {
 	return m_requested_int;
 }
 
-WRITE16_MEMBER(hyprduel_state::irq_cause_w)
+WRITE8_MEMBER(hyprduel_state::irq_cause_w)
 {
-	if (ACCESSING_BITS_0_7)
-	{
-		if (data == m_int_num)
-			m_requested_int &= ~(m_int_num & ~*m_irq_enable);
-		else
-			m_requested_int &= ~(data & *m_irq_enable);
+	if (data == m_int_num)
+		m_requested_int &= ~(m_int_num & ~*m_irq_enable);
+	else
+		m_requested_int &= ~(data & *m_irq_enable);
 
-		update_irq_state();
-	}
+	update_irq_state();
 }
 
 
@@ -264,7 +261,7 @@ void hyprduel_state::hyprduel_map(address_map &map)
 {
 	map(0x000000, 0x07ffff).rom();
 	map(0x400000, 0x47ffff).m(m_vdp, FUNC(imagetek_i4220_device::v2_map));
-	map(0x4788a2, 0x4788a3).rw(FUNC(hyprduel_state::irq_cause_r), FUNC(hyprduel_state::irq_cause_w));   /* IRQ Cause,Acknowledge */
+	map(0x4788a3, 0x4788a3).rw(FUNC(hyprduel_state::irq_cause_r), FUNC(hyprduel_state::irq_cause_w));   /* IRQ Cause,Acknowledge */
 	map(0x4788a4, 0x4788a5).ram().share("irq_enable");      /* IRQ Enable */
 	map(0x800000, 0x800001).w(FUNC(hyprduel_state::subcpu_control_w));
 	map(0xc00000, 0xc07fff).ram().share("sharedram1");
@@ -296,7 +293,7 @@ void hyprduel_state::magerror_map(address_map &map)
 	map(0x000000, 0x07ffff).rom();
 	map(0x400000, 0x400001).w(FUNC(hyprduel_state::subcpu_control_w));
 	map(0x800000, 0x87ffff).m(m_vdp, FUNC(imagetek_i4220_device::v2_map));
-	map(0x8788a2, 0x8788a3).rw(FUNC(hyprduel_state::irq_cause_r), FUNC(hyprduel_state::irq_cause_w));   /* IRQ Cause, Acknowledge */
+	map(0x8788a3, 0x8788a3).rw(FUNC(hyprduel_state::irq_cause_r), FUNC(hyprduel_state::irq_cause_w));   /* IRQ Cause, Acknowledge */
 	map(0x8788a4, 0x8788a5).ram().share("irq_enable");      /* IRQ Enable */
 	map(0xc00000, 0xc1ffff).ram().share("sharedram1");
 	map(0xe00000, 0xe00001).portr("SERVICE").nopw();
@@ -410,47 +407,6 @@ static INPUT_PORTS_START( magerror )
 INPUT_PORTS_END
 
 /***************************************************************************
-                            Graphics Layouts
-***************************************************************************/
-
-/* 8x8x4 tiles */
-static const gfx_layout layout_8x8x4 =
-{
-	8,8,
-	RGN_FRAC(1,1),
-	4,
-	{ STEP4(0,1) },
-	{ 4*1,4*0, 4*3,4*2, 4*5,4*4, 4*7,4*6 },
-	{ STEP8(0,4*8) },
-	4*8*8
-};
-
-/* 8x8x8 tiles for later games */
-static GFXLAYOUT_RAW( layout_8x8x8, 8, 8, 8*8, 32*8 )
-
-/* 16x16x4 tiles for later games */
-static const gfx_layout layout_16x16x4 =
-{
-	16,16,
-	RGN_FRAC(1,1),
-	4,
-	{ STEP4(0,1) },
-	{ 4*1,4*0, 4*3,4*2, 4*5,4*4, 4*7,4*6, 4*9,4*8, 4*11,4*10, 4*13,4*12, 4*15,4*14 },
-	{ STEP16(0,4*16) },
-	4*8*8
-};
-
-/* 16x16x8 tiles for later games */
-static GFXLAYOUT_RAW( layout_16x16x8, 16, 16, 16*8, 32*8 )
-
-static GFXDECODE_START( gfx_i4220 )
-	GFXDECODE_ENTRY( "gfx1", 0, layout_8x8x4,    0x0, 0x100 ) // [0] 4 Bit Tiles
-	GFXDECODE_ENTRY( "gfx1", 0, layout_8x8x8,    0x0,  0x10 ) // [1] 8 Bit Tiles
-	GFXDECODE_ENTRY( "gfx1", 0, layout_16x16x4,  0x0, 0x100 ) // [2] 4 Bit Tiles 16x16
-	GFXDECODE_ENTRY( "gfx1", 0, layout_16x16x8,  0x0,  0x10 ) // [3] 8 Bit Tiles 16x16
-GFXDECODE_END
-
-/***************************************************************************
                                 Machine Drivers
 ***************************************************************************/
 
@@ -477,9 +433,8 @@ MACHINE_START_MEMBER(hyprduel_state,hyprduel)
 }
 
 MACHINE_CONFIG_START(hyprduel_state::i4220_config)
-	MCFG_DEVICE_ADD("vdp", I4220, XTAL(26'666'000))
-	MCFG_I4100_GFXDECODE("gfxdecode")
-	MCFG_I4100_BLITTER_END_CALLBACK(WRITELINE(*this, hyprduel_state,vdp_blit_end_w))
+	I4220(config, m_vdp, XTAL(26'666'000));
+	m_vdp->blit_irq_cb().set(FUNC(hyprduel_state::vdp_blit_end_w));
 
 	MCFG_SCREEN_ADD("screen", RASTER)
 	MCFG_SCREEN_VIDEO_ATTRIBUTES(VIDEO_UPDATE_SCANLINE)
@@ -488,9 +443,8 @@ MACHINE_CONFIG_START(hyprduel_state::i4220_config)
 	MCFG_SCREEN_SIZE(320, 224)
 	MCFG_SCREEN_VISIBLE_AREA(0, 320-1, FIRST_VISIBLE_LINE, LAST_VISIBLE_LINE)
 	MCFG_SCREEN_UPDATE_DEVICE("vdp", imagetek_i4100_device, screen_update)
+	MCFG_SCREEN_VBLANK_CALLBACK(WRITELINE("vdp", imagetek_i4100_device, screen_eof))
 	MCFG_SCREEN_PALETTE(":vdp:palette")
-
-	MCFG_DEVICE_ADD("gfxdecode", GFXDECODE, ":vdp:palette", gfx_i4220)
 MACHINE_CONFIG_END
 
 MACHINE_CONFIG_START(hyprduel_state::hyprduel)
@@ -555,7 +509,7 @@ ROM_START( hyprduel )
 	ROM_LOAD16_BYTE( "24.u24", 0x000000, 0x40000, CRC(c7402722) SHA1(e385676cdcee65a3ddf07791d82a1fe83ba1b3e2) ) /* Also silk screened as position 10 */
 	ROM_LOAD16_BYTE( "23.u23", 0x000001, 0x40000, CRC(d8297c2b) SHA1(2e23c5b1784d0a465c0c0dc3ca28505689a8b16c) ) /* Also silk screened as position  9 */
 
-	ROM_REGION( 0x400000, "gfx1", 0 )   /* Gfx + Prg + Data (Addressable by CPU & Blitter) */
+	ROM_REGION( 0x400000, "vdp", 0 )   /* Gfx + Prg + Data (Addressable by CPU & Blitter) */
 	ROMX_LOAD( "ts_hyper-1.u74", 0x000000, 0x100000, CRC(4b3b2d3c) SHA1(5e9e8ec853f71aeff3910b93dadbaeae2b61717b) , ROM_GROUPWORD | ROM_SKIP(6) )
 	ROMX_LOAD( "ts_hyper-2.u75", 0x000002, 0x100000, CRC(dc230116) SHA1(a3c447657d8499764f52c81382961f425c56037b) , ROM_GROUPWORD | ROM_SKIP(6) )
 	ROMX_LOAD( "ts_hyper-3.u76", 0x000004, 0x100000, CRC(2d770dd0) SHA1(27f9e7f67e96210d3710ab4f940c5d7ae13f8bbf) , ROM_GROUPWORD | ROM_SKIP(6) )
@@ -570,7 +524,7 @@ ROM_START( hyprduel2 )
 	ROM_LOAD16_BYTE( "24a.u24", 0x000000, 0x40000, CRC(2458f91d) SHA1(c75c7bccc84738e29b35667793491a1213aea1da) ) /* Also silk screened as position 10 */
 	ROM_LOAD16_BYTE( "23a.u23", 0x000001, 0x40000, CRC(98aedfca) SHA1(42028e57ac79473cde683be2100b953ff3b2b345) ) /* Also silk screened as position  9 */
 
-	ROM_REGION( 0x400000, "gfx1", 0 )   /* Gfx + Prg + Data (Addressable by CPU & Blitter) */
+	ROM_REGION( 0x400000, "vdp", 0 )   /* Gfx + Prg + Data (Addressable by CPU & Blitter) */
 	ROMX_LOAD( "ts_hyper-1.u74", 0x000000, 0x100000, CRC(4b3b2d3c) SHA1(5e9e8ec853f71aeff3910b93dadbaeae2b61717b) , ROM_GROUPWORD | ROM_SKIP(6) )
 	ROMX_LOAD( "ts_hyper-2.u75", 0x000002, 0x100000, CRC(dc230116) SHA1(a3c447657d8499764f52c81382961f425c56037b) , ROM_GROUPWORD | ROM_SKIP(6) )
 	ROMX_LOAD( "ts_hyper-3.u76", 0x000004, 0x100000, CRC(2d770dd0) SHA1(27f9e7f67e96210d3710ab4f940c5d7ae13f8bbf) , ROM_GROUPWORD | ROM_SKIP(6) )
@@ -585,7 +539,7 @@ ROM_START( magerror )
 	ROM_LOAD16_BYTE( "24.u24", 0x000000, 0x40000, CRC(5e78027f) SHA1(053374942bc545a92cc6f6ab6784c4626e4ec9e1) ) /* Also silk screened as position 10 */
 	ROM_LOAD16_BYTE( "23.u23", 0x000001, 0x40000, CRC(7271ec70) SHA1(bd7666390b70821f90ba976a3afe3194fb119478) ) /* Also silk screened as position  9 */
 
-	ROM_REGION( 0x400000, "gfx1", 0 )   /* Gfx + Prg + Data (Addressable by CPU & Blitter) */
+	ROM_REGION( 0x400000, "vdp", 0 )   /* Gfx + Prg + Data (Addressable by CPU & Blitter) */
 	ROMX_LOAD( "mr93046-02.u74", 0x000000, 0x100000, CRC(f7ba06fb) SHA1(e1407b0d03863f434b68183c01e8547612e5c5fd) , ROM_GROUPWORD | ROM_SKIP(6) )
 	ROMX_LOAD( "mr93046-04.u75", 0x000002, 0x100000, CRC(8c114d15) SHA1(4eb1f82e7992deb126633287cb4fd2a6d215346c) , ROM_GROUPWORD | ROM_SKIP(6) )
 	ROMX_LOAD( "mr93046-01.u76", 0x000004, 0x100000, CRC(6cc3b928) SHA1(f19d0add314867bfb7dcefe8e7a2d50a84530df7) , ROM_GROUPWORD | ROM_SKIP(6) )

--- a/src/mame/drivers/metro.cpp
+++ b/src/mame/drivers/metro.cpp
@@ -103,6 +103,8 @@ driver modified by Hau
 #include "sound/ymf278b.h"
 #include "speaker.h"
 
+#include <algorithm>
+
 /***************************************************************************
 
 
@@ -111,7 +113,7 @@ driver modified by Hau
 
 ***************************************************************************/
 
-READ16_MEMBER(metro_state::metro_irq_cause_r)
+u8 metro_state::irq_cause_r(offs_t offset)
 {
 	/* interrupt cause, used by
 
@@ -130,7 +132,7 @@ READ16_MEMBER(metro_state::metro_irq_cause_r)
 
 	*/
 
-	uint16_t res = 0;
+	uint8_t res = 0;
 	for (int i = 0; i < 8; i++)
 		res |= (m_requested_int[i] << i);
 
@@ -141,10 +143,8 @@ READ16_MEMBER(metro_state::metro_irq_cause_r)
 /* Update the IRQ state based on all possible causes */
 void metro_state::update_irq_state()
 {
-	address_space &space = m_maincpu->space(AS_PROGRAM);
-
 	/*  Get the pending IRQs (only the enabled ones, e.g. where irq_enable is *0*)  */
-	uint16_t irq = metro_irq_cause_r(space, 0, 0xffff) & ~*m_irq_enable;
+	uint8_t irq = irq_cause_r(0) & ~*m_irq_enable;
 
 	if (m_irq_line == -1)    /* mouja, gakusai, gakusai2, dokyusei, dokyusp */
 	{
@@ -162,7 +162,7 @@ void metro_state::update_irq_state()
 	else
 	{
 		/*  This is for games where every IRQ source generates the same IRQ level. The interrupt service routine
-		    then reads the actual source by peeking a register (metro_irq_cause_r) */
+		    then reads the actual source by peeking a register (irq_cause_r) */
 
 		int irq_state = (irq ? ASSERT_LINE : CLEAR_LINE);
 		m_maincpu->set_input_line(m_irq_line, irq_state);
@@ -171,24 +171,21 @@ void metro_state::update_irq_state()
 
 
 /* For games that supply an *IRQ Vector* on the data bus */
-IRQ_CALLBACK_MEMBER(metro_state::metro_irq_callback)
+IRQ_CALLBACK_MEMBER(metro_state::irq_callback)
 {
 	// logerror("%s: irq callback returns %04X\n", device.machine().describe_context(), m_irq_vectors[int_level]);
 	return m_irq_vectors[irqline] & 0xff;
 }
 
 
-WRITE16_MEMBER(metro_state::metro_irq_cause_w)
+void metro_state::irq_cause_w(offs_t offset, u8 data)
 {
 	//if (data & ~0x15) logerror("CPU #0 PC %06X : unknown bits of irqcause written: %04X\n", m_maincpu->pc(), data);
 
-	if (ACCESSING_BITS_0_7)
-	{
-		data &= ~*m_irq_enable;
+	data &= ~*m_irq_enable;
 
-		for (int i = 0; i < 8; i++)
-			if (BIT(data, i)) m_requested_int[i] = 0;
-	}
+	for (int i = 0; i < 8; i++)
+		if (BIT(data, i)) m_requested_int[i] = 0;
 
 	update_irq_state();
 }
@@ -209,16 +206,19 @@ void metro_state::device_timer(emu_timer &timer, device_timer_id id, int param, 
 	}
 }
 
-WRITE_LINE_MEMBER(metro_state::metro_vblank_irq)
+WRITE_LINE_MEMBER(metro_state::vblank_irq)
 {
 	if (state)
 	{
 		m_requested_int[m_vblank_bit] = 1;
 		update_irq_state();
+		if (m_vdp) m_vdp->screen_eof(state);
+		if (m_vdp2) m_vdp2->screen_eof(state);
+		if (m_vdp3) m_vdp3->screen_eof(state);
 	}
 }
 
-INTERRUPT_GEN_MEMBER(metro_state::metro_periodic_interrupt)
+INTERRUPT_GEN_MEMBER(metro_state::periodic_interrupt)
 {
 	m_requested_int[4] = 1;
 	update_irq_state();
@@ -255,6 +255,9 @@ WRITE_LINE_MEMBER(metro_state::karatour_vblank_irq)
 		m_requested_int[5] = 1;
 
 		update_irq_state();
+		if (m_vdp) m_vdp->screen_eof(state);
+		if (m_vdp2) m_vdp2->screen_eof(state);
+		if (m_vdp3) m_vdp3->screen_eof(state);
 	}
 }
 
@@ -273,6 +276,9 @@ WRITE_LINE_MEMBER(metro_state::puzzlet_vblank_irq)
 		m_requested_int[5] = 1;
 
 		update_irq_state();
+		if (m_vdp) m_vdp->screen_eof(state);
+		if (m_vdp2) m_vdp2->screen_eof(state);
+		if (m_vdp3) m_vdp3->screen_eof(state);
 	}
 }
 
@@ -284,7 +290,7 @@ WRITE_LINE_MEMBER(metro_state::puzzlet_vblank_irq)
 
 ***************************************************************************/
 
-READ_LINE_MEMBER(metro_state::metro_rxd_r)
+READ_LINE_MEMBER(metro_state::rxd_r)
 {
 	address_space &space = m_maincpu->space(AS_PROGRAM);
 	uint8_t data = m_soundlatch->read(space, 0);
@@ -295,19 +301,16 @@ READ_LINE_MEMBER(metro_state::metro_rxd_r)
 
 }
 
-WRITE16_MEMBER(metro_state::metro_soundlatch_w)
+WRITE8_MEMBER(metro_state::soundlatch_w)
 {
-	if (ACCESSING_BITS_0_7)
-	{
-		m_soundlatch->write(space, 0, data & 0xff);
-		m_audiocpu->pulse_input_line(INPUT_LINE_NMI, attotime::zero); // seen metro_rxd_r
-		m_maincpu->spin_until_interrupt();
-		m_busy_sndcpu = 1;
-	}
+	m_soundlatch->write(space, 0, data & 0xff);
+	m_audiocpu->pulse_input_line(INPUT_LINE_NMI, attotime::zero); // seen rxd_r
+	m_maincpu->spin_until_interrupt();
+	m_busy_sndcpu = 1;
 }
 
 
-READ16_MEMBER(metro_state::metro_soundstatus_r)
+READ8_MEMBER(metro_state::soundstatus_r)
 {
 	return (m_busy_sndcpu ? 0x00 : 0x01);
 }
@@ -317,35 +320,29 @@ CUSTOM_INPUT_MEMBER(metro_state::custom_soundstatus_r)
 	return (m_busy_sndcpu ? 0x01 : 0x00);
 }
 
-WRITE16_MEMBER(metro_state::metro_soundstatus_w)
+WRITE8_MEMBER(metro_state::soundstatus_w)
 {
-	if (ACCESSING_BITS_0_7)
-		m_soundstatus = data & 0x01;
+	m_soundstatus = data & 0x01;
+}
+
+template<int Mask>
+WRITE8_MEMBER(metro_state::upd7810_rombank_w)
+{
+	m_audiobank->set_entry((data >> 4) & Mask);
 }
 
 
-WRITE8_MEMBER(metro_state::metro_sound_rombank_w)
-{
-	m_audiobank->set_entry((data >> 4) & 0x03);
-}
-
-WRITE8_MEMBER(metro_state::daitorid_sound_rombank_w)
-{
-	m_audiobank->set_entry((data >> 4) & 0x07);
-}
-
-
-READ8_MEMBER(metro_state::metro_porta_r)
+READ8_MEMBER(metro_state::upd7810_porta_r)
 {
 	return m_porta;
 }
 
-WRITE8_MEMBER(metro_state::metro_porta_w)
+WRITE8_MEMBER(metro_state::upd7810_porta_w)
 {
 	m_porta = data;
 }
 
-WRITE8_MEMBER(metro_state::metro_portb_w)
+WRITE8_MEMBER(metro_state::upd7810_portb_w)
 {
 	/* port B layout:
 	   7 !clock latch for message to main CPU
@@ -451,19 +448,17 @@ WRITE8_MEMBER(metro_state::daitorid_portb_w)
 
 ***************************************************************************/
 
-WRITE16_MEMBER(metro_state::metro_coin_lockout_1word_w)
+WRITE8_MEMBER(metro_state::coin_lockout_1word_w)
 {
-	if (ACCESSING_BITS_0_7)
-	{
-		machine().bookkeeping().coin_counter_w(0, data & 1);
-		machine().bookkeeping().coin_counter_w(1, data & 2);
-	}
+	machine().bookkeeping().coin_counter_w(0, BIT(data, 0));
+	machine().bookkeeping().coin_counter_w(1, BIT(data, 1));
+
 	if (data & ~3)  logerror("CPU #0 PC %06X : unknown bits of coin lockout written: %04X\n", m_maincpu->pc(), data);
 }
 
 // value written doesn't matter, also each counted coin gets reported after one full second.
 // TODO: maybe the counter also controls lockout?
-WRITE16_MEMBER(metro_state::metro_coin_lockout_4words_w)
+WRITE16_MEMBER(metro_state::coin_lockout_4words_w)
 {
 	machine().bookkeeping().coin_counter_w((offset >> 1) & 1, offset & 1);
 //  machine().bookkeeping().coin_lockout_w((offset >> 1) & 1, offset & 1);
@@ -492,7 +487,7 @@ WRITE_LINE_MEMBER(metro_state::vdp_blit_end_w)
 */
 
 
-void metro_state::metro_sound_map(address_map &map)
+void metro_state::upd7810_map(address_map &map)
 {
 	map(0x0000, 0x3fff).rom();         /* External ROM */
 	map(0x4000, 0x7fff).bankr("audiobank");    /* External ROM (Banked) */
@@ -553,9 +548,9 @@ void metro_state::balcube_map(address_map &map)
 	map(0x500000, 0x500001).portr("IN0");                                // Inputs
 	map(0x500002, 0x500003).portr("IN1");                                //
 	map(0x500006, 0x500007).nopr();                                         //
-	map(0x500002, 0x500009).w(FUNC(metro_state::metro_coin_lockout_4words_w));              // Coin Lockout
+	map(0x500002, 0x500009).w(FUNC(metro_state::coin_lockout_4words_w));              // Coin Lockout
 	map(0x600000, 0x67ffff).m(m_vdp2, FUNC(imagetek_i4220_device::v2_map));
-	map(0x6788a2, 0x6788a3).rw(FUNC(metro_state::metro_irq_cause_r), FUNC(metro_state::metro_irq_cause_w)); // IRQ Cause / IRQ Acknowledge
+	map(0x6788a3, 0x6788a3).rw(FUNC(metro_state::irq_cause_r), FUNC(metro_state::irq_cause_w)); // IRQ Cause / IRQ Acknowledge
 	map(0x6788a4, 0x6788a5).writeonly().share("irq_enable");                // IRQ Enable
 	map(0xf00000, 0xf0ffff).ram().mirror(0x0f0000);                         // RAM (mirrored)
 }
@@ -570,12 +565,12 @@ void metro_state::daitoa_map(address_map &map)
 {
 	map(0x000000, 0x07ffff).rom();                                             // ROM
 	map(0x100000, 0x17ffff).m(m_vdp2, FUNC(imagetek_i4220_device::v2_map));
-	map(0x1788a2, 0x1788a3).rw(FUNC(metro_state::metro_irq_cause_r), FUNC(metro_state::metro_irq_cause_w)); // IRQ Cause / IRQ Acknowledge
+	map(0x1788a3, 0x1788a3).rw(FUNC(metro_state::irq_cause_r), FUNC(metro_state::irq_cause_w)); // IRQ Cause / IRQ Acknowledge
 	map(0x1788a4, 0x1788a5).writeonly().share("irq_enable");                // IRQ Enable
 	map(0x200000, 0x200001).portr("IN0");                                // Inputs
 	map(0x200002, 0x200003).portr("IN1");                                //
 	map(0x200006, 0x200007).nopr();                                         //
-	map(0x200002, 0x200009).w(FUNC(metro_state::metro_coin_lockout_4words_w));              // Coin Lockout
+	map(0x200002, 0x200009).w(FUNC(metro_state::coin_lockout_4words_w));              // Coin Lockout
 	map(0x300000, 0x31ffff).r(FUNC(metro_state::balcube_dsw_r));                             // DSW x 3
 	map(0x400001, 0x400001).r("ymf", FUNC(ymf278b_device::read));   // Sound
 	map(0x400000, 0x40000b).w("ymf", FUNC(ymf278b_device::write)).umask16(0x00ff); // Sound
@@ -596,9 +591,9 @@ void metro_state::bangball_map(address_map &map)
 	map(0xd00000, 0xd00001).portr("IN0");                                // Inputs
 	map(0xd00002, 0xd00003).portr("IN1");                                //
 	map(0xd00006, 0xd00007).nopr();                                         //
-	map(0xd00002, 0xd00009).w(FUNC(metro_state::metro_coin_lockout_4words_w));              // Coin Lockout
+	map(0xd00002, 0xd00009).w(FUNC(metro_state::coin_lockout_4words_w));              // Coin Lockout
 	map(0xe00000, 0xe7ffff).m(m_vdp2, FUNC(imagetek_i4220_device::v2_map));
-	map(0xe788a2, 0xe788a3).rw(FUNC(metro_state::metro_irq_cause_r), FUNC(metro_state::metro_irq_cause_w)); // IRQ Cause / IRQ Acknowledge
+	map(0xe788a3, 0xe788a3).rw(FUNC(metro_state::irq_cause_r), FUNC(metro_state::irq_cause_w)); // IRQ Cause / IRQ Acknowledge
 	map(0xe788a4, 0xe788a5).writeonly().share("irq_enable");                // IRQ Enable
 	map(0xf00000, 0xf0ffff).ram().mirror(0x0f0000);                         // RAM (mirrored)
 }
@@ -612,13 +607,13 @@ void metro_state::batlbubl_map(address_map &map)
 {
 	map(0x000000, 0x0fffff).rom();                                             // ROM
 	map(0x100000, 0x17ffff).m(m_vdp2, FUNC(imagetek_i4220_device::v2_map));
-	map(0x1788a2, 0x1788a3).rw(FUNC(metro_state::metro_irq_cause_r), FUNC(metro_state::metro_irq_cause_w));  // IRQ Cause / IRQ Acknowledge
+	map(0x1788a3, 0x1788a3).rw(FUNC(metro_state::irq_cause_r), FUNC(metro_state::irq_cause_w));  // IRQ Cause / IRQ Acknowledge
 	map(0x1788a4, 0x1788a5).writeonly().share("irq_enable");                // IRQ Enable
 	map(0x200000, 0x200001).portr("IN1");                                // Inputs
 	map(0x200002, 0x200003).portr("DSW0");                               //
 	map(0x200004, 0x200005).portr("IN0");                                //
 	map(0x200006, 0x200007).portr("IN2");                                //
-	map(0x200002, 0x200009).w(FUNC(metro_state::metro_coin_lockout_4words_w));              // Coin Lockout
+	map(0x200002, 0x200009).w(FUNC(metro_state::coin_lockout_4words_w));              // Coin Lockout
 	map(0x300000, 0x31ffff).r(FUNC(metro_state::balcube_dsw_r));                             // read but ignored?
 	map(0x400001, 0x400001).r("ymf", FUNC(ymf278b_device::read));   // Sound
 	map(0x400000, 0x40000b).w("ymf", FUNC(ymf278b_device::write)).umask16(0x00ff); //
@@ -634,12 +629,12 @@ void metro_state::msgogo_map(address_map &map)
 {
 	map(0x000000, 0x07ffff).rom();                                             // ROM
 	map(0x100000, 0x17ffff).m(m_vdp2, FUNC(imagetek_i4220_device::v2_map));
-	map(0x1788a2, 0x1788a3).rw(FUNC(metro_state::metro_irq_cause_r), FUNC(metro_state::metro_irq_cause_w));  // IRQ Cause / IRQ Acknowledge
+	map(0x1788a3, 0x1788a3).rw(FUNC(metro_state::irq_cause_r), FUNC(metro_state::irq_cause_w));  // IRQ Cause / IRQ Acknowledge
 	map(0x1788a4, 0x1788a5).writeonly().share("irq_enable");                // IRQ Enable
 	map(0x200000, 0x200001).portr("COINS");                              // Inputs
 	map(0x200002, 0x200003).portr("JOYS");                               //
 	map(0x200006, 0x200007).nopr();                                         //
-	map(0x200002, 0x200009).w(FUNC(metro_state::metro_coin_lockout_4words_w));              // Coin Lockout
+	map(0x200002, 0x200009).w(FUNC(metro_state::coin_lockout_4words_w));              // Coin Lockout
 	map(0x300000, 0x31ffff).r(FUNC(metro_state::balcube_dsw_r));                             // 3 x DSW
 	map(0x400001, 0x400001).r("ymf", FUNC(ymf278b_device::read));   // Sound
 	map(0x400000, 0x40000b).w("ymf", FUNC(ymf278b_device::write)).umask16(0x00ff); //
@@ -654,15 +649,16 @@ void metro_state::daitorid_map(address_map &map)
 {
 	map(0x000000, 0x03ffff).rom();                                             // ROM
 	map(0x400000, 0x47ffff).m(m_vdp2, FUNC(imagetek_i4220_device::v2_map));
-	map(0x4788a2, 0x4788a3).rw(FUNC(metro_state::metro_irq_cause_r), FUNC(metro_state::metro_irq_cause_w)); // IRQ Cause / IRQ Acknowledge
+	map(0x4788a3, 0x4788a3).rw(FUNC(metro_state::irq_cause_r), FUNC(metro_state::irq_cause_w)); // IRQ Cause / IRQ Acknowledge
 	map(0x4788a4, 0x4788a5).writeonly().share("irq_enable");                // IRQ Enable
-	map(0x4788a8, 0x4788a9).w(FUNC(metro_state::metro_soundlatch_w));                       // To Sound CPU
+	map(0x4788a9, 0x4788a9).w(FUNC(metro_state::soundlatch_w));                       // To Sound CPU
 	map(0x800000, 0x80ffff).ram().mirror(0x0f0000);                         // RAM (mirrored)
-	map(0xc00000, 0xc00001).portr("IN0").w(FUNC(metro_state::metro_soundstatus_w));  // To Sound CPU
+	map(0xc00000, 0xc00001).portr("IN0");
+	map(0xc00001, 0xc00001).w(FUNC(metro_state::soundstatus_w));  // To Sound CPU
 	map(0xc00002, 0xc00003).portr("IN1");                                //
 	map(0xc00004, 0xc00005).portr("DSW0");                               //
 	map(0xc00006, 0xc00007).portr("IN2");                                //
-	map(0xc00002, 0xc00009).w(FUNC(metro_state::metro_coin_lockout_4words_w));              // Coin Lockout
+	map(0xc00002, 0xc00009).w(FUNC(metro_state::coin_lockout_4words_w));              // Coin Lockout
 }
 
 
@@ -675,14 +671,15 @@ void metro_state::dharma_map(address_map &map)
 	map(0x000000, 0x03ffff).rom();                                             // ROM
 	map(0x400000, 0x40ffff).ram().mirror(0x0f0000);                         // RAM (mirrored)
 	map(0x800000, 0x87ffff).m(m_vdp2, FUNC(imagetek_i4220_device::v2_map));
-	map(0x8788a2, 0x8788a3).rw(FUNC(metro_state::metro_irq_cause_r), FUNC(metro_state::metro_irq_cause_w)); // IRQ Cause / IRQ Acknowledge
+	map(0x8788a3, 0x8788a3).rw(FUNC(metro_state::irq_cause_r), FUNC(metro_state::irq_cause_w)); // IRQ Cause / IRQ Acknowledge
 	map(0x8788a4, 0x8788a5).writeonly().share("irq_enable");                // IRQ Enable
-	map(0x8788a8, 0x8788a9).w(FUNC(metro_state::metro_soundlatch_w));                       // To Sound CPU
-	map(0xc00000, 0xc00001).portr("IN0").w(FUNC(metro_state::metro_soundstatus_w));  // To Sound CPU
+	map(0x8788a9, 0x8788a9).w(FUNC(metro_state::soundlatch_w));                       // To Sound CPU
+	map(0xc00000, 0xc00001).portr("IN0");
+	map(0xc00001, 0xc00001).w(FUNC(metro_state::soundstatus_w));  // To Sound CPU
 	map(0xc00002, 0xc00003).portr("IN1");                                //
 	map(0xc00004, 0xc00005).portr("DSW0");                               //
 	map(0xc00006, 0xc00007).portr("IN2");                                //
-	map(0xc00002, 0xc00009).w(FUNC(metro_state::metro_coin_lockout_4words_w));              // Coin Lockout
+	map(0xc00002, 0xc00009).w(FUNC(metro_state::coin_lockout_4words_w));              // Coin Lockout
 }
 
 
@@ -693,17 +690,17 @@ void metro_state::dharma_map(address_map &map)
 void metro_state::karatour_map(address_map &map)
 {
 	map(0x000000, 0x07ffff).rom();                                             // ROM
-	map(0x400000, 0x400001).rw(FUNC(metro_state::metro_soundstatus_r), FUNC(metro_state::metro_soundstatus_w)); // From Sound CPU
+	map(0x400001, 0x400001).rw(FUNC(metro_state::soundstatus_r), FUNC(metro_state::soundstatus_w)); // From Sound CPU
 	map(0x400002, 0x400003).portr("IN0");                                // Inputs
-	map(0x400002, 0x400003).w(FUNC(metro_state::metro_coin_lockout_1word_w));               // Coin Lockout
+	map(0x400003, 0x400003).w(FUNC(metro_state::coin_lockout_1word_w));               // Coin Lockout
 	map(0x400004, 0x400005).portr("IN1");                                //
 	map(0x400006, 0x400007).portr("DSW0");                               //
 	map(0x40000a, 0x40000b).portr("DSW1");                               //
 	map(0x40000c, 0x40000d).portr("IN2");                                //
 	map(0x800000, 0x87ffff).m(m_vdp, FUNC(imagetek_i4100_device::map));
-	map(0x8788a2, 0x8788a3).rw(FUNC(metro_state::metro_irq_cause_r), FUNC(metro_state::metro_irq_cause_w)); // IRQ Cause / IRQ Acknowledge
+	map(0x8788a3, 0x8788a3).rw(FUNC(metro_state::irq_cause_r), FUNC(metro_state::irq_cause_w)); // IRQ Cause / IRQ Acknowledge
 	map(0x8788a4, 0x8788a5).writeonly().share("irq_enable");                // IRQ Enable
-	map(0x8788a8, 0x8788a9).w(FUNC(metro_state::metro_soundlatch_w));                       // To Sound CPU
+	map(0x8788a9, 0x8788a9).w(FUNC(metro_state::soundlatch_w));                       // To Sound CPU
 	map(0xf00000, 0xf0ffff).ram().mirror(0x0f0000);                         // RAM (mirrored)
 }
 
@@ -719,13 +716,14 @@ void metro_state::kokushi_map(address_map &map)
 	map(0x000000, 0x07ffff).rom();                                             // ROM
 	map(0x700000, 0x70ffff).ram().mirror(0x0f0000);                         // RAM (mirrored)
 	map(0x800000, 0x87ffff).m(m_vdp2, FUNC(imagetek_i4220_device::v2_map));
-	map(0x8788a2, 0x8788a3).rw(FUNC(metro_state::metro_irq_cause_r), FUNC(metro_state::metro_irq_cause_w)); // IRQ Cause /  IRQ Acknowledge
+	map(0x8788a3, 0x8788a3).rw(FUNC(metro_state::irq_cause_r), FUNC(metro_state::irq_cause_w)); // IRQ Cause /  IRQ Acknowledge
 	map(0x8788a4, 0x8788a5).writeonly().share("irq_enable");                // IRQ Enable
-	map(0x8788a8, 0x8788a9).w(FUNC(metro_state::metro_soundlatch_w));                       // To Sound CPU
-	map(0xc00000, 0xc00001).portr("IN0").w(FUNC(metro_state::metro_soundstatus_w));  // To Sound CPU
+	map(0x8788a9, 0x8788a9).w(FUNC(metro_state::soundlatch_w));                       // To Sound CPU
+	map(0xc00000, 0xc00001).portr("IN0");
+	map(0xc00001, 0xc00001).w(FUNC(metro_state::soundstatus_w));  // To Sound CPU
 	map(0xc00002, 0xc00003).portr("IN1");                                // Inputs
 	map(0xc00004, 0xc00005).portr("DSW0");                               //
-	map(0xc00002, 0xc00009).w(FUNC(metro_state::metro_coin_lockout_4words_w));              // Coin Lockout
+	map(0xc00002, 0xc00009).w(FUNC(metro_state::coin_lockout_4words_w));              // Coin Lockout
 }
 
 
@@ -738,11 +736,11 @@ void metro_state::lastfort_map(address_map &map)
 	map(0x000000, 0x03ffff).rom();                                             // ROM
 	map(0x400000, 0x40ffff).ram().mirror(0x0f0000);                         // RAM (mirrored)
 	map(0x800000, 0x87ffff).m(m_vdp, FUNC(imagetek_i4100_device::map));
-	map(0x8788a2, 0x8788a3).rw(FUNC(metro_state::metro_irq_cause_r), FUNC(metro_state::metro_irq_cause_w)); // IRQ Cause / IRQ Acknowledge
+	map(0x8788a3, 0x8788a3).rw(FUNC(metro_state::irq_cause_r), FUNC(metro_state::irq_cause_w)); // IRQ Cause / IRQ Acknowledge
 	map(0x8788a4, 0x8788a5).writeonly().share("irq_enable");                // IRQ Enable
-	map(0x8788a8, 0x8788a9).w(FUNC(metro_state::metro_soundlatch_w));                       // To Sound CPU
-	map(0xc00000, 0xc00001).rw(FUNC(metro_state::metro_soundstatus_r), FUNC(metro_state::metro_soundstatus_w)); // From / To Sound CPU
-	map(0xc00002, 0xc00003).w(FUNC(metro_state::metro_coin_lockout_1word_w));               // Coin Lockout
+	map(0x8788a9, 0x8788a9).w(FUNC(metro_state::soundlatch_w));                       // To Sound CPU
+	map(0xc00001, 0xc00001).rw(FUNC(metro_state::soundstatus_r), FUNC(metro_state::soundstatus_w)); // From / To Sound CPU
+	map(0xc00003, 0xc00003).w(FUNC(metro_state::coin_lockout_1word_w));               // Coin Lockout
 	map(0xc00004, 0xc00005).portr("IN0");                                // Inputs
 	map(0xc00006, 0xc00007).portr("IN1");                                //
 	map(0xc00008, 0xc00009).portr("IN2");                                //
@@ -757,17 +755,17 @@ void metro_state::lastfort_map(address_map &map)
 void metro_state::lastforg_map(address_map &map)
 {
 	map(0x000000, 0x03ffff).rom();                                             // ROM
-	map(0x400000, 0x400001).rw(FUNC(metro_state::metro_soundstatus_r), FUNC(metro_state::metro_soundstatus_w)); // From / To Sound CPU
+	map(0x400001, 0x400001).rw(FUNC(metro_state::soundstatus_r), FUNC(metro_state::soundstatus_w)); // From / To Sound CPU
 	map(0x400002, 0x400003).portr("IN0");                                // Inputs
-	map(0x400002, 0x400003).w(FUNC(metro_state::metro_coin_lockout_1word_w));               // Coin Lockout
+	map(0x400003, 0x400003).w(FUNC(metro_state::coin_lockout_1word_w));               // Coin Lockout
 	map(0x400004, 0x400005).portr("IN1");                                //
 	map(0x400006, 0x400007).portr("DSW0");                               //
 	map(0x40000a, 0x40000b).portr("DSW1");                               //
 	map(0x40000c, 0x40000d).portr("IN2");                                //
 	map(0x880000, 0x8fffff).m(m_vdp, FUNC(imagetek_i4100_device::map));
-	map(0x8f88a2, 0x8f88a3).rw(FUNC(metro_state::metro_irq_cause_r), FUNC(metro_state::metro_irq_cause_w)); // IRQ Cause / IRQ Acknowledge
+	map(0x8f88a3, 0x8f88a3).rw(FUNC(metro_state::irq_cause_r), FUNC(metro_state::irq_cause_w)); // IRQ Cause / IRQ Acknowledge
 	map(0x8f88a4, 0x8f88a5).writeonly().share("irq_enable");                // IRQ Enable
-	map(0x8f88a8, 0x8f88a9).w(FUNC(metro_state::metro_soundlatch_w));                       // To Sound CPU
+	map(0x8f88a9, 0x8f88a9).w(FUNC(metro_state::soundlatch_w));                       // To Sound CPU
 	map(0xc00000, 0xc0ffff).ram().mirror(0x0f0000);                         // RAM (mirrored)
 }
 
@@ -831,7 +829,7 @@ void metro_state::gakusai_map(address_map &map)
 	map(0x278810, 0x27881f).writeonly().share("irq_levels");                // IRQ Levels
 	map(0x278820, 0x27882f).writeonly().share("irq_vectors");               // IRQ Vectors
 	map(0x278830, 0x278831).writeonly().share("irq_enable");                // IRQ Enable
-	map(0x278832, 0x278833).rw(FUNC(metro_state::metro_irq_cause_r), FUNC(metro_state::metro_irq_cause_w)); // IRQ Cause / IRQ Acknowledge
+	map(0x278833, 0x278833).rw(FUNC(metro_state::irq_cause_r), FUNC(metro_state::irq_cause_w)); // IRQ Cause / IRQ Acknowledge
 	map(0x278836, 0x278837).nopr().w("watchdog", FUNC(watchdog_timer_device::reset16_w));
 	map(0x278880, 0x278881).r(FUNC(metro_state::gakusai_input_r));                           // Inputs
 	map(0x278882, 0x278883).portr("IN0");                                //
@@ -857,7 +855,7 @@ void metro_state::gakusai2_map(address_map &map)
 	map(0x678810, 0x67881f).writeonly().share("irq_levels");                // IRQ Levels
 	map(0x678820, 0x67882f).writeonly().share("irq_vectors");               // IRQ Vectors
 	map(0x678830, 0x678831).writeonly().share("irq_enable");                // IRQ Enable
-	map(0x678832, 0x678833).rw(FUNC(metro_state::metro_irq_cause_r), FUNC(metro_state::metro_irq_cause_w));  // IRQ Cause / IRQ Acknowledge
+	map(0x678833, 0x678833).rw(FUNC(metro_state::irq_cause_r), FUNC(metro_state::irq_cause_w));  // IRQ Cause / IRQ Acknowledge
 	map(0x678836, 0x678837).nopr().w("watchdog", FUNC(watchdog_timer_device::reset16_w));
 	map(0x678880, 0x678881).r(FUNC(metro_state::gakusai_input_r));                           // Inputs
 	map(0x678882, 0x678883).portr("IN0");                                //
@@ -908,7 +906,7 @@ void metro_state::dokyusp_map(address_map &map)
 	map(0x278810, 0x27881f).writeonly().share("irq_levels");                // IRQ Levels
 	map(0x278820, 0x27882f).writeonly().share("irq_vectors");               // IRQ Vectors
 	map(0x278830, 0x278831).writeonly().share("irq_enable");                // IRQ Enable
-	map(0x278832, 0x278833).rw(FUNC(metro_state::metro_irq_cause_r), FUNC(metro_state::metro_irq_cause_w));  // IRQ Cause / IRQ Acknowledge
+	map(0x278833, 0x278833).rw(FUNC(metro_state::irq_cause_r), FUNC(metro_state::irq_cause_w));  // IRQ Cause / IRQ Acknowledge
 	map(0x278836, 0x278837).w("watchdog", FUNC(watchdog_timer_device::reset16_w));
 	map(0x278880, 0x278881).r(FUNC(metro_state::gakusai_input_r));                           // Inputs
 	map(0x278882, 0x278883).portr("IN0");                                //
@@ -934,8 +932,8 @@ void metro_state::dokyusei_map(address_map &map)
 	map(0x478810, 0x47881f).writeonly().share("irq_levels");                // IRQ Levels
 	map(0x478820, 0x47882f).writeonly().share("irq_vectors");               // IRQ Vectors
 	map(0x478830, 0x478831).writeonly().share("irq_enable");                // IRQ Enable
-//  AM_RANGE(0x478832, 0x478833) AM_READ(metro_irq_cause_r)                         // IRQ Cause
-	map(0x478832, 0x478833).w(FUNC(metro_state::metro_irq_cause_w));                        // IRQ Acknowledge
+//  map(0x478833, 0x478833).rw(FUNC(metro_state::irq_cause_r), FUNC(metro_state::irq_cause_w))                        // IRQ Cause
+	map(0x478833, 0x478833).w(FUNC(metro_state::irq_cause_w));                        // IRQ Acknowledge
 	map(0x478836, 0x478837).nopw();                                        // ? watchdog ?
 	map(0x478880, 0x478881).r(FUNC(metro_state::gakusai_input_r));                           // Inputs
 	map(0x478882, 0x478883).portr("IN0");                                //
@@ -959,11 +957,12 @@ void metro_state::pangpoms_map(address_map &map)
 {
 	map(0x000000, 0x03ffff).rom();                                             // ROM
 	map(0x400000, 0x47ffff).m(m_vdp, FUNC(imagetek_i4100_device::map));
-	map(0x4788a2, 0x4788a3).rw(FUNC(metro_state::metro_irq_cause_r), FUNC(metro_state::metro_irq_cause_w));  // IRQ Cause / IRQ Acknowledge
+	map(0x4788a3, 0x4788a3).rw(FUNC(metro_state::irq_cause_r), FUNC(metro_state::irq_cause_w));  // IRQ Cause / IRQ Acknowledge
 	map(0x4788a4, 0x4788a5).writeonly().share("irq_enable");                // IRQ Enable
-	map(0x4788a8, 0x4788a9).w(FUNC(metro_state::metro_soundlatch_w));                       // To Sound CPU
-	map(0x800000, 0x800001).rw(FUNC(metro_state::metro_soundstatus_r), FUNC(metro_state::metro_soundstatus_w));  // From / To Sound CPU
-	map(0x800002, 0x800003).nopr().w(FUNC(metro_state::metro_coin_lockout_1word_w));    // Coin Lockout
+	map(0x4788a9, 0x4788a9).w(FUNC(metro_state::soundlatch_w));                       // To Sound CPU
+	map(0x800001, 0x800001).rw(FUNC(metro_state::soundstatus_r), FUNC(metro_state::soundstatus_w));  // From / To Sound CPU
+	map(0x800002, 0x800003).nopr();
+	map(0x800003, 0x800003).w(FUNC(metro_state::coin_lockout_1word_w));    // Coin Lockout
 	map(0x800004, 0x800005).portr("IN0");                                // Inputs
 	map(0x800006, 0x800007).portr("IN1");                                //
 	map(0x800008, 0x800009).portr("IN2");                                //
@@ -982,15 +981,16 @@ void metro_state::poitto_map(address_map &map)
 {
 	map(0x000000, 0x03ffff).rom();                                             // ROM
 	map(0x400000, 0x40ffff).ram().mirror(0x0f0000);                         // RAM (mirrored)
-	map(0x800000, 0x800001).portr("IN0").w(FUNC(metro_state::metro_soundstatus_w));  // To Sound CPU
+	map(0x800000, 0x800001).portr("IN0");
+	map(0x800001, 0x800001).w(FUNC(metro_state::soundstatus_w));  // To Sound CPU
 	map(0x800002, 0x800003).portr("IN1");                                //
 	map(0x800004, 0x800005).portr("DSW0");                               //
 	map(0x800006, 0x800007).portr("IN2");                                //
-	map(0x800002, 0x800009).w(FUNC(metro_state::metro_coin_lockout_4words_w));              // Coin Lockout
+	map(0x800002, 0x800009).w(FUNC(metro_state::coin_lockout_4words_w));              // Coin Lockout
 	map(0xc00000, 0xc7ffff).m(m_vdp, FUNC(imagetek_i4100_device::map));
-	map(0xc788a2, 0xc788a3).rw(FUNC(metro_state::metro_irq_cause_r), FUNC(metro_state::metro_irq_cause_w));  // IRQ Cause / IRQ Acknowledge
+	map(0xc788a3, 0xc788a3).rw(FUNC(metro_state::irq_cause_r), FUNC(metro_state::irq_cause_w));  // IRQ Cause / IRQ Acknowledge
 	map(0xc788a4, 0xc788a5).writeonly().share("irq_enable");                // IRQ Enable
-	map(0xc788a8, 0xc788a9).w(FUNC(metro_state::metro_soundlatch_w));                       // To Sound CPU
+	map(0xc788a9, 0xc788a9).w(FUNC(metro_state::soundlatch_w));                       // To Sound CPU
 }
 
 
@@ -1001,8 +1001,9 @@ void metro_state::poitto_map(address_map &map)
 void metro_state::skyalert_map(address_map &map)
 {
 	map(0x000000, 0x03ffff).rom();                                             // ROM
-	map(0x400000, 0x400001).rw(FUNC(metro_state::metro_soundstatus_r), FUNC(metro_state::metro_soundstatus_w));  // From / To Sound CPU
-	map(0x400002, 0x400003).nopr().w(FUNC(metro_state::metro_coin_lockout_1word_w));    // Coin Lockout
+	map(0x400001, 0x400001).rw(FUNC(metro_state::soundstatus_r), FUNC(metro_state::soundstatus_w));  // From / To Sound CPU
+	map(0x400002, 0x400003).nopr();
+	map(0x400003, 0x400003).w(FUNC(metro_state::coin_lockout_1word_w));    // Coin Lockout
 	map(0x400004, 0x400005).portr("IN0");                                // Inputs
 	map(0x400006, 0x400007).portr("IN1");                                //
 	map(0x400008, 0x400009).portr("IN2");                                //
@@ -1010,9 +1011,9 @@ void metro_state::skyalert_map(address_map &map)
 	map(0x40000c, 0x40000d).portr("DSW1");                               //
 	map(0x40000e, 0x40000f).portr("IN3");                                //
 	map(0x800000, 0x87ffff).m(m_vdp, FUNC(imagetek_i4100_device::map));
-	map(0x8788a2, 0x8788a3).rw(FUNC(metro_state::metro_irq_cause_r), FUNC(metro_state::metro_irq_cause_w));  // IRQ Cause / IRQ Acknowledge
+	map(0x8788a3, 0x8788a3).rw(FUNC(metro_state::irq_cause_r), FUNC(metro_state::irq_cause_w));  // IRQ Cause / IRQ Acknowledge
 	map(0x8788a4, 0x8788a5).writeonly().share("irq_enable");                // IRQ Enable
-	map(0x8788a8, 0x8788a9).w(FUNC(metro_state::metro_soundlatch_w));                       // To Sound CPU
+	map(0x8788a9, 0x8788a9).w(FUNC(metro_state::soundlatch_w));                       // To Sound CPU
 	map(0xc00000, 0xc0ffff).ram().mirror(0x0f0000);                         // RAM (mirrored)
 }
 
@@ -1024,16 +1025,17 @@ void metro_state::skyalert_map(address_map &map)
 void metro_state::pururun_map(address_map &map)
 {
 	map(0x000000, 0x07ffff).rom();                                             // ROM
-	map(0x400000, 0x400001).portr("IN0").w(FUNC(metro_state::metro_soundstatus_w));  // To Sound CPU
+	map(0x400000, 0x400001).portr("IN0");
+	map(0x400001, 0x400001).w(FUNC(metro_state::soundstatus_w));  // To Sound CPU
 	map(0x400002, 0x400003).portr("IN1");                                //
 	map(0x400004, 0x400005).portr("DSW0");                               //
 	map(0x400006, 0x400007).portr("IN2");                                //
-	map(0x400002, 0x400009).w(FUNC(metro_state::metro_coin_lockout_4words_w));              // Coin Lockout
+	map(0x400002, 0x400009).w(FUNC(metro_state::coin_lockout_4words_w));              // Coin Lockout
 	map(0x800000, 0x80ffff).ram().mirror(0x0f0000);                         // RAM (mirrored)
 	map(0xc00000, 0xc7ffff).m(m_vdp2, FUNC(imagetek_i4220_device::v2_map));
-	map(0xc788a2, 0xc788a3).rw(FUNC(metro_state::metro_irq_cause_r), FUNC(metro_state::metro_irq_cause_w));  // IRQ Cause / IRQ Acknowledge
+	map(0xc788a3, 0xc788a3).rw(FUNC(metro_state::irq_cause_r), FUNC(metro_state::irq_cause_w));  // IRQ Cause / IRQ Acknowledge
 	map(0xc788a4, 0xc788a5).writeonly().share("irq_enable");                // IRQ Enable
-	map(0xc788a8, 0xc788a9).w(FUNC(metro_state::metro_soundlatch_w));                       // To Sound CPU
+	map(0xc788a9, 0xc788a9).w(FUNC(metro_state::soundlatch_w));                       // To Sound CPU
 }
 
 
@@ -1045,15 +1047,16 @@ void metro_state::toride2g_map(address_map &map)
 {
 	map(0x000000, 0x07ffff).rom();                                             // ROM
 	map(0x400000, 0x40ffff).ram().mirror(0x0f0000);                         // RAM (mirrored)
-	map(0x800000, 0x800001).portr("IN0").w(FUNC(metro_state::metro_soundstatus_w));  // Watchdog (R)? / To Sound CPU (W)
+	map(0x800000, 0x800001).portr("IN0");  // Watchdog?
+	map(0x800001, 0x800001).w(FUNC(metro_state::soundstatus_w));  // To Sound CPU
 	map(0x800002, 0x800003).portr("IN1");                                //
 	map(0x800004, 0x800005).portr("DSW0");                               //
 	map(0x800006, 0x800007).portr("IN2");                                //
-	map(0x800002, 0x800009).w(FUNC(metro_state::metro_coin_lockout_4words_w));              // Coin Lockout
+	map(0x800002, 0x800009).w(FUNC(metro_state::coin_lockout_4words_w));              // Coin Lockout
 	map(0xc00000, 0xc7ffff).m(m_vdp2, FUNC(imagetek_i4220_device::v2_map));
-	map(0xc788a2, 0xc788a3).rw(FUNC(metro_state::metro_irq_cause_r), FUNC(metro_state::metro_irq_cause_w)); // IRQ Cause / IRQ Acknowledge
+	map(0xc788a3, 0xc788a3).rw(FUNC(metro_state::irq_cause_r), FUNC(metro_state::irq_cause_w)); // IRQ Cause / IRQ Acknowledge
 	map(0xc788a4, 0xc788a5).writeonly().share("irq_enable");                // IRQ Enable
-	map(0xc788a8, 0xc788a9).w(FUNC(metro_state::metro_soundlatch_w));                       // To Sound CPU
+	map(0xc788a9, 0xc788a9).w(FUNC(metro_state::soundlatch_w));                       // To Sound CPU
 }
 
 
@@ -1085,10 +1088,10 @@ void metro_state::blzntrnd_map(address_map &map)
 {
 	map(0x000000, 0x1fffff).rom();                                             // ROM
 	map(0x200000, 0x27ffff).m(m_vdp2, FUNC(imagetek_i4220_device::v2_map));
-	map(0x2788a2, 0x2788a3).rw(FUNC(metro_state::metro_irq_cause_r), FUNC(metro_state::metro_irq_cause_w));  // IRQ Cause / IRQ Acknowledge
+	map(0x2788a3, 0x2788a3).rw(FUNC(metro_state::irq_cause_r), FUNC(metro_state::irq_cause_w));  // IRQ Cause / IRQ Acknowledge
 	map(0x2788a4, 0x2788a5).writeonly().share("irq_enable");                // IRQ Enable
 
-	map(0x400000, 0x43ffff).ram().w(FUNC(metro_state::metro_k053936_w)).share("k053936_ram");  // 053936
+	map(0x400000, 0x43ffff).ram().w(FUNC(metro_state::k053936_w)).share("k053936_ram");  // 053936
 	map(0x500000, 0x500fff).w(m_k053936, FUNC(k053936_device::linectrl_w));      // 053936 line control
 	map(0x600000, 0x60001f).w(m_k053936, FUNC(k053936_device::ctrl_w));          // 053936 control
 
@@ -1118,7 +1121,7 @@ void metro_state::mouja_map(address_map &map)
 	map(0x478810, 0x47881f).writeonly().share("irq_levels");                // IRQ Levels
 	map(0x478820, 0x47882f).writeonly().share("irq_vectors");               // IRQ Vectors
 	map(0x478830, 0x478831).writeonly().share("irq_enable");                // IRQ Enable
-	map(0x478832, 0x478833).rw(FUNC(metro_state::metro_irq_cause_r), FUNC(metro_state::metro_irq_cause_w));  // IRQ Cause / IRQ Acknowledge
+	map(0x478833, 0x478833).rw(FUNC(metro_state::irq_cause_r), FUNC(metro_state::irq_cause_w));  // IRQ Cause / IRQ Acknowledge
 	map(0x478834, 0x478835).w(FUNC(metro_state::mouja_irq_timer_ctrl_w));                   // IRQ set timer count
 	map(0x478836, 0x478837).w("watchdog", FUNC(watchdog_timer_device::reset16_w));
 	map(0x478880, 0x478881).portr("IN0");                                // Inputs
@@ -1234,7 +1237,7 @@ void metro_state::puzzlet_map(address_map &map)
 
 	// TODO: !!! i4300 !!!
 	map(0x700000, 0x77ffff).m(m_vdp2, FUNC(imagetek_i4220_device::v2_map));
-	map(0x7788a2, 0x7788a3).w(FUNC(metro_state::metro_irq_cause_w));                            // IRQ Cause
+	map(0x7788a3, 0x7788a3).w(FUNC(metro_state::irq_cause_w));                            // IRQ Cause
 	map(0x7788a4, 0x7788a5).w(FUNC(metro_state::puzzlet_irq_enable_w)).share("irq_enable");  // IRQ Enable
 
 	map(0x7f2000, 0x7f3fff).ram();
@@ -1243,7 +1246,7 @@ void metro_state::puzzlet_map(address_map &map)
 	map(0x7f8884, 0x7f8885).portr("DSW0");
 	map(0x7f8886, 0x7f8887).portr("DSW0");
 
-	map(0x7f88a2, 0x7f88a3).r(FUNC(metro_state::metro_irq_cause_r));                         // IRQ Cause
+	map(0x7f88a2, 0x7f88a3).r(FUNC(metro_state::irq_cause_r));                         // IRQ Cause
 }
 
 
@@ -1302,7 +1305,7 @@ void metro_state::vmetal_map(address_map &map)
 {
 	map(0x000000, 0x0fffff).rom();                                             // ROM
 	map(0x100000, 0x17ffff).m(m_vdp2, FUNC(imagetek_i4220_device::v2_map));
-	map(0x1788a2, 0x1788a3).rw(FUNC(metro_state::metro_irq_cause_r), FUNC(metro_state::metro_irq_cause_w)); // IRQ Cause / IRQ Acknowledge
+	map(0x1788a3, 0x1788a3).rw(FUNC(metro_state::irq_cause_r), FUNC(metro_state::irq_cause_w)); // IRQ Cause / IRQ Acknowledge
 	map(0x1788a4, 0x1788a5).writeonly().share("irq_enable");                // IRQ Enable
 	map(0x200000, 0x200001).portr("P1_P2");
 	map(0x200001, 0x200001).w(FUNC(metro_state::vmetal_control_w));
@@ -2939,36 +2942,6 @@ INPUT_PORTS_END
 ***************************************************************************/
 
 
-/* 8x8x4 tiles */
-static const gfx_layout layout_8x8x4 =
-{
-	8,8,
-	RGN_FRAC(1,1),
-	4,
-	{ STEP4(0,1) },
-	{ 4*1,4*0, 4*3,4*2, 4*5,4*4, 4*7,4*6 },
-	{ STEP8(0,4*8) },
-	4*8*8
-};
-
-/* 8x8x8 tiles for later games */
-static GFXLAYOUT_RAW( layout_8x8x8, 8, 8, 8*8, 32*8 )
-
-/* 16x16x4 tiles for later games */
-static const gfx_layout layout_16x16x4 =
-{
-	16,16,
-	RGN_FRAC(1,1),
-	4,
-	{ STEP4(0,1) },
-	{ 4*1,4*0, 4*3,4*2, 4*5,4*4, 4*7,4*6, 4*9,4*8, 4*11,4*10, 4*13,4*12, 4*15,4*14 },
-	{ STEP16(0,4*16) },
-	4*8*8
-};
-
-/* 16x16x8 tiles for later games */
-static GFXLAYOUT_RAW( layout_16x16x8, 16, 16, 16*8, 32*8 )
-
 static const gfx_layout layout_053936 =
 {
 	8,8,
@@ -2991,39 +2964,12 @@ static const gfx_layout layout_053936_16 =
 	8*8*8*4
 };
 
-static GFXDECODE_START( gfx_i4100 )
-	GFXDECODE_ENTRY( "gfx1", 0, layout_8x8x4,    0x0, 0x100 ) // [0] 4 Bit Tiles
-GFXDECODE_END
-
-static GFXDECODE_START( gfx_i4220 )
-	GFXDECODE_ENTRY( "gfx1", 0, layout_8x8x4,    0x0, 0x100 ) // [0] 4 Bit Tiles
-	GFXDECODE_ENTRY( "gfx1", 0, layout_8x8x8,    0x0,  0x10 ) // [1] 8 Bit Tiles
-	GFXDECODE_ENTRY( "gfx1", 0, layout_16x16x4,  0x0, 0x100 ) // [2] 4 Bit Tiles 16x16
-	GFXDECODE_ENTRY( "gfx1", 0, layout_16x16x8,  0x0,  0x10 ) // [3] 8 Bit Tiles 16x16
-GFXDECODE_END
-
 static GFXDECODE_START( gfx_blzntrnd )
-	GFXDECODE_ENTRY( "gfx1", 0, layout_8x8x4,    0x0, 0x100 ) // [0] 4 Bit Tiles
-	GFXDECODE_ENTRY( "gfx1", 0, layout_8x8x8,    0x0,  0x10 ) // [1] 8 Bit Tiles
-	GFXDECODE_ENTRY( "gfx1", 0, layout_16x16x4,  0x0, 0x100 ) // [2] 4 Bit Tiles 16x16
-	GFXDECODE_ENTRY( "gfx1", 0, layout_16x16x8,  0x0,  0x10 ) // [3] 8 Bit Tiles 16x16
-	GFXDECODE_ENTRY( "gfx2", 0, layout_053936,   0x0,  0x10 ) // [4] 053936 Tiles
+	GFXDECODE_ENTRY( "gfx2", 0, layout_053936,    0x0, 0x10 ) // [0] 053936 Tiles
 GFXDECODE_END
 
 static GFXDECODE_START( gfx_gstrik2 )
-	GFXDECODE_ENTRY( "gfx1", 0, layout_8x8x4,    0x0, 0x100 ) // [0] 4 Bit Tiles
-	GFXDECODE_ENTRY( "gfx1", 0, layout_8x8x8,    0x0,  0x10 ) // [1] 8 Bit Tiles
-	GFXDECODE_ENTRY( "gfx1", 0, layout_16x16x4,  0x0, 0x100 ) // [2] 4 Bit Tiles 16x16
-	GFXDECODE_ENTRY( "gfx1", 0, layout_16x16x8,  0x0,  0x10 ) // [3] 8 Bit Tiles 16x16
-	GFXDECODE_ENTRY( "gfx2", 0, layout_053936_16,0x0,  0x10 ) // [4] 053936 Tiles
-GFXDECODE_END
-
-// same as i4220:
-static GFXDECODE_START( gfx_i4300 )
-	GFXDECODE_ENTRY( "gfx1", 0, layout_8x8x4,    0x0, 0x100 ) // [0] 4 Bit Tiles
-	GFXDECODE_ENTRY( "gfx1", 0, layout_8x8x8,    0x0,  0x10 ) // [1] 8 Bit Tiles
-	GFXDECODE_ENTRY( "gfx1", 0, layout_16x16x4,  0x0, 0x100 ) // [2] 4 Bit Tiles 16x16
-	GFXDECODE_ENTRY( "gfx1", 0, layout_16x16x8,  0x0,  0x10 ) // [3] 8 Bit Tiles 16x16
+	GFXDECODE_ENTRY( "gfx2", 0, layout_053936_16, 0x0, 0x10 ) // [0] 053936 Tiles
 GFXDECODE_END
 
 
@@ -3049,9 +2995,8 @@ void metro_state::machine_start()
 }
 
 MACHINE_CONFIG_START(metro_state::i4100_config)
-	MCFG_DEVICE_ADD("vdp", I4100, 26.666_MHz_XTAL)
-	MCFG_I4100_GFXDECODE("gfxdecode")
-	MCFG_I4100_BLITTER_END_CALLBACK(WRITELINE(*this, metro_state,vdp_blit_end_w))
+	I4100(config, m_vdp, 26.666_MHz_XTAL);
+	m_vdp->blit_irq_cb().set(FUNC(metro_state::vdp_blit_end_w));
 
 	MCFG_SCREEN_ADD("screen", RASTER)
 	MCFG_SCREEN_REFRESH_RATE(58.2328) // VSync 58.2328Hz, HSync 15.32kHz
@@ -3060,14 +3005,11 @@ MACHINE_CONFIG_START(metro_state::i4100_config)
 	MCFG_SCREEN_VISIBLE_AREA(0, 320-1, 0, 240-1)
 	MCFG_SCREEN_UPDATE_DEVICE("vdp", imagetek_i4100_device, screen_update)
 	MCFG_SCREEN_PALETTE("vdp:palette")
-
-	MCFG_DEVICE_ADD("gfxdecode", GFXDECODE, "vdp:palette", gfx_i4100)
 MACHINE_CONFIG_END
 
 MACHINE_CONFIG_START(metro_state::i4220_config)
-	MCFG_DEVICE_ADD("vdp2", I4220, 26.666_MHz_XTAL)
-	MCFG_I4100_GFXDECODE("gfxdecode")
-	MCFG_I4100_BLITTER_END_CALLBACK(WRITELINE(*this, metro_state,vdp_blit_end_w))
+	I4220(config, m_vdp2, 26.666_MHz_XTAL);
+	m_vdp2->blit_irq_cb().set(FUNC(metro_state::vdp_blit_end_w));
 
 	MCFG_SCREEN_ADD("screen", RASTER)
 	MCFG_SCREEN_REFRESH_RATE(58.2328) // VSync 58.2328Hz, HSync 15.32kHz
@@ -3076,14 +3018,11 @@ MACHINE_CONFIG_START(metro_state::i4220_config)
 	MCFG_SCREEN_VISIBLE_AREA(0, 320-1, 0, 224-1)
 	MCFG_SCREEN_UPDATE_DEVICE("vdp2", imagetek_i4100_device, screen_update)
 	MCFG_SCREEN_PALETTE("vdp2:palette")
-
-	MCFG_DEVICE_ADD("gfxdecode", GFXDECODE, "vdp2:palette", gfx_i4220)
 MACHINE_CONFIG_END
 
 MACHINE_CONFIG_START(metro_state::i4300_config)
-	MCFG_DEVICE_ADD("vdp3", I4300, 26.666_MHz_XTAL)
-	MCFG_I4100_GFXDECODE("gfxdecode")
-	MCFG_I4100_BLITTER_END_CALLBACK(WRITELINE(*this, metro_state,vdp_blit_end_w))
+	I4300(config, m_vdp3, 26.666_MHz_XTAL);
+	m_vdp3->blit_irq_cb().set(FUNC(metro_state::vdp_blit_end_w));
 
 	MCFG_SCREEN_ADD("screen", RASTER)
 	MCFG_SCREEN_REFRESH_RATE(58.2328) // VSync 58.2328Hz, HSync 15.32kHz
@@ -3092,8 +3031,6 @@ MACHINE_CONFIG_START(metro_state::i4300_config)
 	MCFG_SCREEN_VISIBLE_AREA(0, 320-1, 0, 224-1)
 	MCFG_SCREEN_UPDATE_DEVICE("vdp3", imagetek_i4100_device, screen_update)
 	MCFG_SCREEN_PALETTE("vdp3:palette")
-
-	MCFG_DEVICE_ADD("gfxdecode", GFXDECODE, "vdp3:palette", gfx_i4300)
 MACHINE_CONFIG_END
 
 // TODO: these comes from the CRTC inside the i4100
@@ -3143,15 +3080,14 @@ MACHINE_CONFIG_START(metro_state::msgogo)
 	/* basic machine hardware */
 	MCFG_DEVICE_ADD("maincpu", M68000, 16_MHz_XTAL)
 	MCFG_DEVICE_PROGRAM_MAP(msgogo_map)
-	MCFG_DEVICE_PERIODIC_INT_DRIVER(metro_state, metro_periodic_interrupt,  60) // ?
+	MCFG_DEVICE_PERIODIC_INT_DRIVER(metro_state, periodic_interrupt,  60) // ?
 
 	/* video hardware */
 	i4220_config(config);
-	MCFG_DEVICE_MODIFY("vdp2")
-	MCFG_I4100_TILEMAP_XOFFSETS(-2,-2,-2)
+	m_vdp2->set_tmap_xoffsets(-2,-2,-2);
 
 	MCFG_DEVICE_MODIFY("screen")
-	MCFG_SCREEN_VBLANK_CALLBACK(WRITELINE(*this, metro_state, metro_vblank_irq)) // timing is off, shaking sprites in intro
+	MCFG_SCREEN_VBLANK_CALLBACK(WRITELINE(*this, metro_state, vblank_irq)) // timing is off, shaking sprites in intro
 
 	/* sound hardware */
 	SPEAKER(config, "mono").front_center();
@@ -3166,20 +3102,20 @@ MACHINE_CONFIG_START(metro_state::balcube)
 	msgogo(config);
 	MCFG_DEVICE_MODIFY("maincpu")
 	MCFG_DEVICE_PROGRAM_MAP(balcube_map)
-	MCFG_DEVICE_PERIODIC_INT_DRIVER(metro_state, metro_periodic_interrupt,  8*60) // ?
+	MCFG_DEVICE_PERIODIC_INT_DRIVER(metro_state, periodic_interrupt,  8*60) // ?
 
 	MCFG_DEVICE_MODIFY("screen")
-	MCFG_SCREEN_VBLANK_CALLBACK(WRITELINE(*this, metro_state, metro_vblank_irq))
+	MCFG_SCREEN_VBLANK_CALLBACK(WRITELINE(*this, metro_state, vblank_irq))
 MACHINE_CONFIG_END
 
 MACHINE_CONFIG_START(metro_state::daitoa)
 	msgogo(config);
 	MCFG_DEVICE_MODIFY("maincpu")
 	MCFG_DEVICE_PROGRAM_MAP(daitoa_map)
-	MCFG_DEVICE_PERIODIC_INT_DRIVER(metro_state, metro_periodic_interrupt,  8*60) // ?
+	MCFG_DEVICE_PERIODIC_INT_DRIVER(metro_state, periodic_interrupt,  8*60) // ?
 
 	MCFG_DEVICE_MODIFY("screen")
-	MCFG_SCREEN_VBLANK_CALLBACK(WRITELINE(*this, metro_state, metro_vblank_irq))
+	MCFG_SCREEN_VBLANK_CALLBACK(WRITELINE(*this, metro_state, vblank_irq))
 MACHINE_CONFIG_END
 
 MACHINE_CONFIG_START(metro_state::bangball)
@@ -3212,23 +3148,23 @@ MACHINE_CONFIG_END
 void metro_state::metro_upd7810_sound(machine_config &config)
 {
 	upd7810_device &upd(UPD7810(config, m_audiocpu, 24_MHz_XTAL/2));
-	upd.rxd_func().set(FUNC(metro_state::metro_rxd_r));
-	upd.set_addrmap(AS_PROGRAM, &metro_state::metro_sound_map);
-	upd.pa_in_cb().set(FUNC(metro_state::metro_porta_r));
-	upd.pa_out_cb().set(FUNC(metro_state::metro_porta_w));
-	upd.pb_out_cb().set(FUNC(metro_state::metro_portb_w));
-	upd.pc_out_cb().set(FUNC(metro_state::metro_sound_rombank_w));
+	upd.rxd_func().set(FUNC(metro_state::rxd_r));
+	upd.set_addrmap(AS_PROGRAM, &metro_state::upd7810_map);
+	upd.pa_in_cb().set(FUNC(metro_state::upd7810_porta_r));
+	upd.pa_out_cb().set(FUNC(metro_state::upd7810_porta_w));
+	upd.pb_out_cb().set(FUNC(metro_state::upd7810_portb_w));
+	upd.pc_out_cb().set(FUNC(metro_state::upd7810_rombank_w<0x03>));
 }
 
 void metro_state::daitorid_upd7810_sound(machine_config &config)
 {
 	upd7810_device &upd(UPD7810(config, m_audiocpu, 12_MHz_XTAL));
-	upd.rxd_func().set(FUNC(metro_state::metro_rxd_r));
-	upd.set_addrmap(AS_PROGRAM, &metro_state::metro_sound_map);
-	upd.pa_in_cb().set(FUNC(metro_state::metro_porta_r));
-	upd.pa_out_cb().set(FUNC(metro_state::metro_porta_w));
+	upd.rxd_func().set(FUNC(metro_state::rxd_r));
+	upd.set_addrmap(AS_PROGRAM, &metro_state::upd7810_map);
+	upd.pa_in_cb().set(FUNC(metro_state::upd7810_porta_r));
+	upd.pa_out_cb().set(FUNC(metro_state::upd7810_porta_w));
 	upd.pb_out_cb().set(FUNC(metro_state::daitorid_portb_w));
-	upd.pc_out_cb().set(FUNC(metro_state::daitorid_sound_rombank_w));
+	upd.pc_out_cb().set(FUNC(metro_state::upd7810_rombank_w<0x07>));
 }
 
 
@@ -3237,17 +3173,16 @@ MACHINE_CONFIG_START(metro_state::daitorid)
 	/* basic machine hardware */
 	MCFG_DEVICE_ADD("maincpu", M68000, 32_MHz_XTAL/2)
 	MCFG_DEVICE_PROGRAM_MAP(daitorid_map)
-	MCFG_DEVICE_PERIODIC_INT_DRIVER(metro_state, metro_periodic_interrupt,  8*60) // ?
+	MCFG_DEVICE_PERIODIC_INT_DRIVER(metro_state, periodic_interrupt,  8*60) // ?
 
 	daitorid_upd7810_sound(config);
 
 	/* video hardware */
 	i4220_config(config);
-	MCFG_DEVICE_MODIFY("vdp2")
-	MCFG_I4100_TILEMAP_XOFFSETS(-2,-2,-2)
+	m_vdp2->set_tmap_xoffsets(-2,-2,-2);
 
 	MCFG_DEVICE_MODIFY("screen")
-	MCFG_SCREEN_VBLANK_CALLBACK(WRITELINE(*this, metro_state, metro_vblank_irq))
+	MCFG_SCREEN_VBLANK_CALLBACK(WRITELINE(*this, metro_state, vblank_irq))
 
 	/* sound hardware */
 	SPEAKER(config, "mono").front_center();
@@ -3279,7 +3214,7 @@ MACHINE_CONFIG_START(metro_state::dharma)
 	/* basic machine hardware */
 	MCFG_DEVICE_ADD("maincpu", M68000, 24_MHz_XTAL/2)
 	MCFG_DEVICE_PROGRAM_MAP(dharma_map)
-	MCFG_DEVICE_PERIODIC_INT_DRIVER(metro_state, metro_periodic_interrupt,  8*60) // ?
+	MCFG_DEVICE_PERIODIC_INT_DRIVER(metro_state, periodic_interrupt,  8*60) // ?
 
 	metro_upd7810_sound(config);
 
@@ -3287,7 +3222,7 @@ MACHINE_CONFIG_START(metro_state::dharma)
 	i4220_config(config);
 
 	MCFG_DEVICE_MODIFY("screen")
-	MCFG_SCREEN_VBLANK_CALLBACK(WRITELINE(*this, metro_state, metro_vblank_irq))
+	MCFG_SCREEN_VBLANK_CALLBACK(WRITELINE(*this, metro_state, vblank_irq))
 
 	/* sound hardware */
 	SPEAKER(config, "mono").front_center();
@@ -3306,7 +3241,7 @@ MACHINE_CONFIG_START(metro_state::karatour)
 	/* basic machine hardware */
 	MCFG_DEVICE_ADD("maincpu", M68000, 24_MHz_XTAL/2)
 	MCFG_DEVICE_PROGRAM_MAP(karatour_map)
-	MCFG_DEVICE_PERIODIC_INT_DRIVER(metro_state, metro_periodic_interrupt,  8*60) // ?
+	MCFG_DEVICE_PERIODIC_INT_DRIVER(metro_state, periodic_interrupt,  8*60) // ?
 
 	metro_upd7810_sound(config);
 
@@ -3334,7 +3269,7 @@ MACHINE_CONFIG_START(metro_state::sankokushi)
 	/* basic machine hardware */
 	MCFG_DEVICE_ADD("maincpu", M68000, 24_MHz_XTAL/2)
 	MCFG_DEVICE_PROGRAM_MAP(kokushi_map)
-	MCFG_DEVICE_PERIODIC_INT_DRIVER(metro_state, metro_periodic_interrupt,  8*60) // ?
+	MCFG_DEVICE_PERIODIC_INT_DRIVER(metro_state, periodic_interrupt,  8*60) // ?
 
 	metro_upd7810_sound(config);
 
@@ -3362,7 +3297,7 @@ MACHINE_CONFIG_START(metro_state::lastfort)
 	/* basic machine hardware */
 	MCFG_DEVICE_ADD("maincpu", M68000, 24_MHz_XTAL/2)
 	MCFG_DEVICE_PROGRAM_MAP(lastfort_map)
-	MCFG_DEVICE_PERIODIC_INT_DRIVER(metro_state, metro_periodic_interrupt,  8*60) // ?
+	MCFG_DEVICE_PERIODIC_INT_DRIVER(metro_state, periodic_interrupt,  8*60) // ?
 
 	metro_upd7810_sound(config);
 
@@ -3370,7 +3305,7 @@ MACHINE_CONFIG_START(metro_state::lastfort)
 	i4100_config_360x224(config);
 
 	MCFG_DEVICE_MODIFY("screen")
-	MCFG_SCREEN_VBLANK_CALLBACK(WRITELINE(*this, metro_state, metro_vblank_irq))
+	MCFG_SCREEN_VBLANK_CALLBACK(WRITELINE(*this, metro_state, vblank_irq))
 
 	/* sound hardware */
 	SPEAKER(config, "mono").front_center();
@@ -3389,7 +3324,7 @@ MACHINE_CONFIG_START(metro_state::lastforg)
 	/* basic machine hardware */
 	MCFG_DEVICE_ADD("maincpu", M68000, 24_MHz_XTAL/2)
 	MCFG_DEVICE_PROGRAM_MAP(lastforg_map)
-	MCFG_DEVICE_PERIODIC_INT_DRIVER(metro_state, metro_periodic_interrupt,  8*60) // ?
+	MCFG_DEVICE_PERIODIC_INT_DRIVER(metro_state, periodic_interrupt,  8*60) // ?
 
 	metro_upd7810_sound(config);
 
@@ -3415,13 +3350,13 @@ MACHINE_CONFIG_START(metro_state::dokyusei)
 	/* basic machine hardware */
 	MCFG_DEVICE_ADD("maincpu", M68000, 16_MHz_XTAL)
 	MCFG_DEVICE_PROGRAM_MAP(dokyusei_map)
-	MCFG_DEVICE_IRQ_ACKNOWLEDGE_DRIVER(metro_state,metro_irq_callback)
+	MCFG_DEVICE_IRQ_ACKNOWLEDGE_DRIVER(metro_state,irq_callback)
 
 	/* video hardware */
 	i4300_config(config);
 
 	MCFG_DEVICE_MODIFY("screen")
-	MCFG_SCREEN_VBLANK_CALLBACK(WRITELINE(*this, metro_state, metro_vblank_irq))
+	MCFG_SCREEN_VBLANK_CALLBACK(WRITELINE(*this, metro_state, vblank_irq))
 
 	/* sound hardware */
 	SPEAKER(config, "mono").front_center();
@@ -3438,7 +3373,7 @@ MACHINE_CONFIG_START(metro_state::dokyusp)
 	/* basic machine hardware */
 	MCFG_DEVICE_ADD("maincpu", M68000, 32_MHz_XTAL/2)
 	MCFG_DEVICE_PROGRAM_MAP(dokyusp_map)
-	MCFG_DEVICE_IRQ_ACKNOWLEDGE_DRIVER(metro_state,metro_irq_callback)
+	MCFG_DEVICE_IRQ_ACKNOWLEDGE_DRIVER(metro_state,irq_callback)
 
 	EEPROM_93C46_16BIT(config, "eeprom");
 
@@ -3448,7 +3383,7 @@ MACHINE_CONFIG_START(metro_state::dokyusp)
 	i4300_config_384x224(config);
 
 	MCFG_DEVICE_MODIFY("screen")
-	MCFG_SCREEN_VBLANK_CALLBACK(WRITELINE(*this, metro_state, metro_vblank_irq))
+	MCFG_SCREEN_VBLANK_CALLBACK(WRITELINE(*this, metro_state, vblank_irq))
 
 	/* sound hardware */
 	SPEAKER(config, "mono").front_center();
@@ -3466,7 +3401,7 @@ MACHINE_CONFIG_START(metro_state::gakusai)
 	/* basic machine hardware */
 	MCFG_DEVICE_ADD("maincpu", M68000, 16000000) /* 26.6660MHz/2?, OSCs listed are 26.6660MHz & 3.579545MHz */
 	MCFG_DEVICE_PROGRAM_MAP(gakusai_map)
-	MCFG_DEVICE_IRQ_ACKNOWLEDGE_DRIVER(metro_state,metro_irq_callback)
+	MCFG_DEVICE_IRQ_ACKNOWLEDGE_DRIVER(metro_state,irq_callback)
 
 	EEPROM_93C46_16BIT(config, "eeprom");
 
@@ -3476,7 +3411,7 @@ MACHINE_CONFIG_START(metro_state::gakusai)
 	i4300_config_320x240(config);
 
 	MCFG_DEVICE_MODIFY("screen")
-	MCFG_SCREEN_VBLANK_CALLBACK(WRITELINE(*this, metro_state, metro_vblank_irq))
+	MCFG_SCREEN_VBLANK_CALLBACK(WRITELINE(*this, metro_state, vblank_irq))
 
 	/* sound hardware */
 	SPEAKER(config, "mono").front_center();
@@ -3495,7 +3430,7 @@ MACHINE_CONFIG_START(metro_state::gakusai2)
 	MCFG_DEVICE_ADD("maincpu", M68000, 16000000) /* 26.6660MHz/2?, OSCs listed are 26.6660MHz & 3.579545MHz */
 	MCFG_DEVICE_PROGRAM_MAP(gakusai2_map)
 
-	MCFG_DEVICE_IRQ_ACKNOWLEDGE_DRIVER(metro_state,metro_irq_callback)
+	MCFG_DEVICE_IRQ_ACKNOWLEDGE_DRIVER(metro_state,irq_callback)
 
 	EEPROM_93C46_16BIT(config, "eeprom");
 
@@ -3505,7 +3440,7 @@ MACHINE_CONFIG_START(metro_state::gakusai2)
 	i4300_config_320x240(config);
 
 	MCFG_DEVICE_MODIFY("screen")
-	MCFG_SCREEN_VBLANK_CALLBACK(WRITELINE(*this, metro_state, metro_vblank_irq))
+	MCFG_SCREEN_VBLANK_CALLBACK(WRITELINE(*this, metro_state, vblank_irq))
 
 	/* sound hardware */
 	SPEAKER(config, "mono").front_center();
@@ -3523,7 +3458,7 @@ MACHINE_CONFIG_START(metro_state::pangpoms)
 	/* basic machine hardware */
 	MCFG_DEVICE_ADD("maincpu", M68000, 24_MHz_XTAL/2)
 	MCFG_DEVICE_PROGRAM_MAP(pangpoms_map)
-	MCFG_DEVICE_PERIODIC_INT_DRIVER(metro_state, metro_periodic_interrupt,  8*60) // ?
+	MCFG_DEVICE_PERIODIC_INT_DRIVER(metro_state, periodic_interrupt,  8*60) // ?
 
 	metro_upd7810_sound(config);
 
@@ -3531,7 +3466,7 @@ MACHINE_CONFIG_START(metro_state::pangpoms)
 	i4100_config_360x224(config);
 
 	MCFG_DEVICE_MODIFY("screen")
-	MCFG_SCREEN_VBLANK_CALLBACK(WRITELINE(*this, metro_state, metro_vblank_irq))
+	MCFG_SCREEN_VBLANK_CALLBACK(WRITELINE(*this, metro_state, vblank_irq))
 
 	/* sound hardware */
 	SPEAKER(config, "mono").front_center();
@@ -3551,7 +3486,7 @@ MACHINE_CONFIG_START(metro_state::poitto)
 	/* basic machine hardware */
 	MCFG_DEVICE_ADD("maincpu", M68000, 24_MHz_XTAL/2)
 	MCFG_DEVICE_PROGRAM_MAP(poitto_map)
-	MCFG_DEVICE_PERIODIC_INT_DRIVER(metro_state, metro_periodic_interrupt,  8*60) // ?
+	MCFG_DEVICE_PERIODIC_INT_DRIVER(metro_state, periodic_interrupt,  8*60) // ?
 
 	metro_upd7810_sound(config);
 
@@ -3559,7 +3494,7 @@ MACHINE_CONFIG_START(metro_state::poitto)
 	i4100_config_360x224(config);
 
 	MCFG_DEVICE_MODIFY("screen")
-	MCFG_SCREEN_VBLANK_CALLBACK(WRITELINE(*this, metro_state, metro_vblank_irq))
+	MCFG_SCREEN_VBLANK_CALLBACK(WRITELINE(*this, metro_state, vblank_irq))
 
 	/* sound hardware */
 	SPEAKER(config, "mono").front_center();
@@ -3579,7 +3514,7 @@ MACHINE_CONFIG_START(metro_state::pururun)
 	/* basic machine hardware */
 	MCFG_DEVICE_ADD("maincpu", M68000, 24_MHz_XTAL/2)       /* Not confirmed */
 	MCFG_DEVICE_PROGRAM_MAP(pururun_map)
-	MCFG_DEVICE_PERIODIC_INT_DRIVER(metro_state, metro_periodic_interrupt,  8*60) // ?
+	MCFG_DEVICE_PERIODIC_INT_DRIVER(metro_state, periodic_interrupt,  8*60) // ?
 
 	daitorid_upd7810_sound(config);
 
@@ -3587,7 +3522,7 @@ MACHINE_CONFIG_START(metro_state::pururun)
 	i4220_config(config);
 
 	MCFG_DEVICE_MODIFY("screen")
-	MCFG_SCREEN_VBLANK_CALLBACK(WRITELINE(*this, metro_state, metro_vblank_irq))
+	MCFG_SCREEN_VBLANK_CALLBACK(WRITELINE(*this, metro_state, vblank_irq))
 
 	/* sound hardware */
 	SPEAKER(config, "mono").front_center();
@@ -3608,14 +3543,14 @@ MACHINE_CONFIG_START(metro_state::skyalert)
 	/* basic machine hardware */
 	MCFG_DEVICE_ADD("maincpu", M68000, 24_MHz_XTAL/2)
 	MCFG_DEVICE_PROGRAM_MAP(skyalert_map)
-	MCFG_DEVICE_PERIODIC_INT_DRIVER(metro_state, metro_periodic_interrupt,  8*60) // ?
+	MCFG_DEVICE_PERIODIC_INT_DRIVER(metro_state, periodic_interrupt,  8*60) // ?
 
 	metro_upd7810_sound(config);
 
 	i4100_config_360x224(config);
 
 	MCFG_DEVICE_MODIFY("screen")
-	MCFG_SCREEN_VBLANK_CALLBACK(WRITELINE(*this, metro_state, metro_vblank_irq))
+	MCFG_SCREEN_VBLANK_CALLBACK(WRITELINE(*this, metro_state, vblank_irq))
 
 	/* sound hardware */
 	SPEAKER(config, "mono").front_center();
@@ -3635,7 +3570,7 @@ MACHINE_CONFIG_START(metro_state::toride2g)
 	/* basic machine hardware */
 	MCFG_DEVICE_ADD("maincpu", M68000, 24_MHz_XTAL/2)
 	MCFG_DEVICE_PROGRAM_MAP(toride2g_map)
-	MCFG_DEVICE_PERIODIC_INT_DRIVER(metro_state, metro_periodic_interrupt,  8*60) // ?
+	MCFG_DEVICE_PERIODIC_INT_DRIVER(metro_state, periodic_interrupt,  8*60) // ?
 
 	metro_upd7810_sound(config);
 
@@ -3643,7 +3578,7 @@ MACHINE_CONFIG_START(metro_state::toride2g)
 	i4220_config(config);
 
 	MCFG_DEVICE_MODIFY("screen")
-	MCFG_SCREEN_VBLANK_CALLBACK(WRITELINE(*this, metro_state, metro_vblank_irq))
+	MCFG_SCREEN_VBLANK_CALLBACK(WRITELINE(*this, metro_state, vblank_irq))
 
 	/* sound hardware */
 	SPEAKER(config, "mono").front_center();
@@ -3663,7 +3598,7 @@ MACHINE_CONFIG_START(metro_state::mouja)
 	/* basic machine hardware */
 	MCFG_DEVICE_ADD("maincpu", M68000, 16_MHz_XTAL)
 	MCFG_DEVICE_PROGRAM_MAP(mouja_map)
-	MCFG_DEVICE_IRQ_ACKNOWLEDGE_DRIVER(metro_state,metro_irq_callback)
+	MCFG_DEVICE_IRQ_ACKNOWLEDGE_DRIVER(metro_state,irq_callback)
 
 	WATCHDOG_TIMER(config, "watchdog");
 
@@ -3671,7 +3606,7 @@ MACHINE_CONFIG_START(metro_state::mouja)
 	i4300_config(config);
 
 	MCFG_DEVICE_MODIFY("screen")
-	MCFG_SCREEN_VBLANK_CALLBACK(WRITELINE(*this, metro_state, metro_vblank_irq))
+	MCFG_SCREEN_VBLANK_CALLBACK(WRITELINE(*this, metro_state, vblank_irq))
 
 	/* sound hardware */
 	SPEAKER(config, "mono").front_center();
@@ -3689,17 +3624,16 @@ MACHINE_CONFIG_START(metro_state::vmetal)
 	/* basic machine hardware */
 	MCFG_DEVICE_ADD("maincpu", M68000, 16_MHz_XTAL)
 	MCFG_DEVICE_PROGRAM_MAP(vmetal_map)
-	MCFG_DEVICE_PERIODIC_INT_DRIVER(metro_state, metro_periodic_interrupt,  8*60) // ?
+	MCFG_DEVICE_PERIODIC_INT_DRIVER(metro_state, periodic_interrupt,  8*60) // ?
 
 	/* video hardware */
 	i4220_config_304x224(config);
 
 	MCFG_DEVICE_MODIFY("screen")
-	MCFG_SCREEN_VBLANK_CALLBACK(WRITELINE(*this, metro_state, metro_vblank_irq))
+	MCFG_SCREEN_VBLANK_CALLBACK(WRITELINE(*this, metro_state, vblank_irq))
 
-	MCFG_DEVICE_MODIFY("vdp2")
-	MCFG_I4100_TILEMAP_XOFFSETS(-16,-16,-16)
-	MCFG_I4100_TILEMAP_YOFFSETS(-16,-16,-16)
+	m_vdp2->set_tmap_xoffsets(-16,-16,-16);
+	m_vdp2->set_tmap_yoffsets(-16,-16,-16);
 
 	/* sound hardware */
 	SPEAKER(config, "mono").front_center();
@@ -3724,16 +3658,16 @@ MACHINE_CONFIG_START(metro_state::blzntrnd)
 	/* basic machine hardware */
 	MCFG_DEVICE_ADD("maincpu", M68000, 16_MHz_XTAL)
 	MCFG_DEVICE_PROGRAM_MAP(blzntrnd_map)
-	MCFG_DEVICE_PERIODIC_INT_DRIVER(metro_state, metro_periodic_interrupt,  8*60) // ?
+	MCFG_DEVICE_PERIODIC_INT_DRIVER(metro_state, periodic_interrupt,  8*60) // ?
 
 	MCFG_DEVICE_ADD("audiocpu", Z80, 16_MHz_XTAL/2)
 	MCFG_DEVICE_PROGRAM_MAP(blzntrnd_sound_map)
 	MCFG_DEVICE_IO_MAP(blzntrnd_sound_io_map)
 
 	/* video hardware */
-	MCFG_DEVICE_ADD("vdp2", I4220, 26.666_MHz_XTAL)
-	MCFG_I4100_GFXDECODE("gfxdecode")
-	MCFG_I4100_BLITTER_END_CALLBACK(WRITELINE(*this, metro_state,vdp_blit_end_w))
+	I4220(config, m_vdp2, 26.666_MHz_XTAL);
+	m_vdp2->blit_irq_cb().set(FUNC(metro_state::vdp_blit_end_w));
+	m_vdp2->set_spriteram_buffered(true); // sprites are 1 frame delayed
 
 	MCFG_SCREEN_ADD("screen", RASTER)
 	MCFG_SCREEN_REFRESH_RATE(58.2328) // VSync 58.2328Hz, HSync 15.32kHz
@@ -3775,8 +3709,7 @@ MACHINE_CONFIG_START(metro_state::gstrik2)
 	MCFG_DEVICE_MODIFY("k053936")
 	MCFG_K053936_OFFSETS(-77, -19)
 
-	MCFG_DEVICE_MODIFY("vdp2")
-	MCFG_I4100_TILEMAP_XOFFSETS(0,-8,0)
+	m_vdp2->set_tmap_xoffsets(0,-8,0);
 
 	// HUM-003 PCB Configuration : Mono output only
 	MCFG_DEVICE_REMOVE("lspeaker")
@@ -3785,9 +3718,9 @@ MACHINE_CONFIG_START(metro_state::gstrik2)
 
 	MCFG_DEVICE_REPLACE("ymsnd", YM2610, 16_MHz_XTAL/2)
 	MCFG_YM2610_IRQ_HANDLER(INPUTLINE("audiocpu", 0))
-	MCFG_SOUND_ROUTE(0, "mono", 0.25)
-	MCFG_SOUND_ROUTE(1, "mono", 1.0)
-	MCFG_SOUND_ROUTE(2, "mono", 1.0)
+	MCFG_SOUND_ROUTE(0, "mono", 0.5)
+	MCFG_SOUND_ROUTE(1, "mono", 0.5)
+	MCFG_SOUND_ROUTE(2, "mono", 0.5)
 MACHINE_CONFIG_END
 
 
@@ -3863,7 +3796,7 @@ ROM_START( balcube )
 	ROM_LOAD16_BYTE( "bal-cube_06.6", 0x000000, 0x040000, CRC(c400f84d) SHA1(416eb82ec1201d24d9d964191a5a1792c9445923) ) /* Silkscreened 6 and U18 */
 	ROM_LOAD16_BYTE( "bal-cube_05.5", 0x000001, 0x040000, CRC(15313e3f) SHA1(10a8702016f223194dc91875b4736253fd47dbb8) ) /* Silkscreened 5 and U19 */
 
-	ROM_REGION( 0x400000, "gfx1", 0 )   /* Gfx + Data (Addressable by CPU & Blitter) */
+	ROM_REGION( 0x400000, "vdp2", 0 )   /* Gfx + Data (Addressable by CPU & Blitter) */
 	ROMX_LOAD( "bal-cube_02.2", 0x000000, 0x080000, CRC(492ca8f0) SHA1(478336a462a2bfc288cf91262314f5767f8c707d) , ROM_GROUPWORD | ROM_SKIP(6)) /* Silkscreened 2 and U30 */
 	ROMX_LOAD( "bal-cube_04.4", 0x000002, 0x080000, CRC(d1acda2c) SHA1(f58015302af6c864523d48bdf8f8a4383b69fa9d) , ROM_GROUPWORD | ROM_SKIP(6)) /* Silkscreened 4 and U29 */
 	ROMX_LOAD( "bal-cube_01.1", 0x000004, 0x080000, CRC(0ea3d161) SHA1(63ae430a19e777ce82b41ab02baef3bb224c7557) , ROM_GROUPWORD | ROM_SKIP(6)) /* Silkscreened 1 and U28 */
@@ -3946,7 +3879,7 @@ ROM_START( bangball )
 	ROM_LOAD16_BYTE( "b-ball_j_rom@006.u18", 0x000000, 0x040000, CRC(0e4124bc) SHA1(f5cd762df4e822ab5c8dba6f276b3366895235d1) ) /* Silkscreened 6 and U18 */
 	ROM_LOAD16_BYTE( "b-ball_j_rom@005.u19", 0x000001, 0x040000, CRC(3fa08587) SHA1(8fdafdde5e77d077b5cd8f94f97b5430fe062936) ) /* Silkscreened 5 and U19 */
 
-	ROM_REGION( 0x400000, "gfx1", 0 )   /* Gfx + Data (Addressable by CPU & Blitter) */
+	ROM_REGION( 0x400000, "vdp2", 0 )   /* Gfx + Data (Addressable by CPU & Blitter) */
 	ROMX_LOAD( "bp963a_u30.u30", 0x000000, 0x100000, CRC(b0ca8e39) SHA1(f2eb1d07cd10050c234f0b418146c742b496f196) , ROM_GROUPWORD | ROM_SKIP(6)) /* Silkscreened 2 and U30 */
 	ROMX_LOAD( "bp963a_u29.u29", 0x000002, 0x100000, CRC(d934468f) SHA1(b93353bf2302b68a297d71fc9d91dc55c1cccce4) , ROM_GROUPWORD | ROM_SKIP(6)) /* Silkscreened 4 and U29 */
 	ROMX_LOAD( "bp963a_u28.u28", 0x000004, 0x100000, CRC(96d03c6a) SHA1(6257585721291e5a5ce311c2873c9e1e1dac2fc6) , ROM_GROUPWORD | ROM_SKIP(6)) /* Silkscreened 1 and U28 */
@@ -3962,7 +3895,7 @@ ROM_START( batlbubl )
 	ROM_LOAD16_WORD_SWAP( "lm-01.u11", 0x000000, 0x080000, CRC(1d562807) SHA1(3e5dbe6f4b04aa9e01b7b8938d0b46d4862054bf) )
 	ROM_LOAD16_WORD_SWAP( "lm-02.u12", 0x080000, 0x080000, CRC(852e4750) SHA1(d8b703ba65d0f267eba07f160b13dbe0f5ac40c2) )
 
-	ROM_REGION( 0x800000, "gfx1", 0 )   /* Gfx + Data (Addressable by CPU & Blitter) */
+	ROM_REGION( 0x800000, "vdp2", 0 )   /* Gfx + Data (Addressable by CPU & Blitter) */
 	ROMX_LOAD( "lm-07.u30", 0x000000, 0x200000, CRC(03d9dfd8) SHA1(33c96f1b0fa28c6e46b2d2c0a62dfe0306139e09) , ROM_GROUPWORD | ROM_SKIP(6))
 	ROMX_LOAD( "lm-06.u29", 0x000002, 0x200000, CRC(5efb905b) SHA1(c3f5d781941225c17d37473e2e0ed84875cebace) , ROM_GROUPWORD | ROM_SKIP(6))
 	ROMX_LOAD( "lm-05.u28", 0x000004, 0x200000, CRC(e53ba59f) SHA1(d82749c04d776fbf9e5cc44a23d2bfafe073fafa) , ROM_GROUPWORD | ROM_SKIP(6))
@@ -3998,7 +3931,7 @@ ROM_START( blzntrnd )
 	ROM_REGION( 0x20000, "audiocpu", 0 )    /* Z80 */
 	ROM_LOAD( "rom5.bin", 0x00000, 0x20000, CRC(7e90b774) SHA1(abd0eda9eababa1f7ab17a2f60534dcebda33c9c) )
 
-	ROM_REGION( 0x1800000, "gfx1", 0 )  /* Gfx + Data (Addressable by CPU & Blitter) */
+	ROM_REGION( 0x1800000, "vdp2", 0 )  /* Gfx + Data (Addressable by CPU & Blitter) */
 	ROMX_LOAD( "rom142.bin", 0x0000000, 0x200000, CRC(a7200598) SHA1(f8168a94abc380308901303a69cbd15097019797) , ROM_GROUPWORD | ROM_SKIP(6))
 	ROMX_LOAD( "rom186.bin", 0x0000002, 0x200000, CRC(6ee28ea7) SHA1(b33bcbf16423999135d96a62bf25c6ff23031f2a) , ROM_GROUPWORD | ROM_SKIP(6))
 	ROMX_LOAD( "rom131.bin", 0x0000004, 0x200000, CRC(c77e75d3) SHA1(8ad716d4e37d6efe478a8e49feb4e68283310890) , ROM_GROUPWORD | ROM_SKIP(6))
@@ -4081,7 +4014,7 @@ ROM_START( gstrik2 )
 	ROM_REGION( 0x20000, "audiocpu", 0 )    /* Z80 */
 	ROM_LOAD( "sprg.30", 0x00000, 0x20000, CRC(aeef6045) SHA1(61b8c89ca495d3aac79e53413a85dd203db816f3) )
 
-	ROM_REGION( 0x1000000, "gfx1", 0 )  /* Gfx + Data (Addressable by CPU & Blitter) */
+	ROM_REGION( 0x1000000, "vdp2", 0 )  /* Gfx + Data (Addressable by CPU & Blitter) */
 	ROMX_LOAD( "chr0.80", 0x0000000, 0x200000, CRC(f63a52a9) SHA1(1ad52bb3a051eaffe8fb6ba49d4fc1d0b6144156) , ROM_GROUPWORD | ROM_SKIP(6))
 	ROMX_LOAD( "chr1.79", 0x0000002, 0x200000, CRC(4110c184) SHA1(90ccb3d50eff7a655336cfa9c072f7213589e64c) , ROM_GROUPWORD | ROM_SKIP(6))
 	ROMX_LOAD( "chr2.78", 0x0000004, 0x200000, CRC(ddb4b9ee) SHA1(0e2c151c3690b9c3d298dda8842e283660d37386) , ROM_GROUPWORD | ROM_SKIP(6))
@@ -4121,7 +4054,7 @@ ROM_START( gstrik2j )
 	ROM_REGION( 0x20000, "audiocpu", 0 )    /* Z80 */
 	ROM_LOAD( "sprg.30", 0x00000, 0x20000, CRC(aeef6045) SHA1(61b8c89ca495d3aac79e53413a85dd203db816f3) )
 
-	ROM_REGION( 0x1000000, "gfx1", 0 )  /* Gfx + Data (Addressable by CPU & Blitter) */
+	ROM_REGION( 0x1000000, "vdp2", 0 )  /* Gfx + Data (Addressable by CPU & Blitter) */
 	ROMX_LOAD( "chr0.80", 0x0000000, 0x200000, CRC(f63a52a9) SHA1(1ad52bb3a051eaffe8fb6ba49d4fc1d0b6144156) , ROM_GROUPWORD | ROM_SKIP(6))
 	ROMX_LOAD( "chr1.79", 0x0000002, 0x200000, CRC(4110c184) SHA1(90ccb3d50eff7a655336cfa9c072f7213589e64c) , ROM_GROUPWORD | ROM_SKIP(6))
 	ROMX_LOAD( "chr2.78", 0x0000004, 0x200000, CRC(ddb4b9ee) SHA1(0e2c151c3690b9c3d298dda8842e283660d37386) , ROM_GROUPWORD | ROM_SKIP(6))
@@ -4208,7 +4141,7 @@ ROM_START( daitorid )
 	ROM_REGION( 0x20000, "audiocpu", 0 )       /* NEC78C10 Code */
 	ROM_LOAD( "dt-ja-8.3h", 0x000000, 0x020000, CRC(0351ad5b) SHA1(942c1cbb52bf2933aea4209335c1bc4cdd1cc3dd) )
 
-	ROM_REGION( 0x200000, "gfx1", 0 )   /* Gfx + Data (Addressable by CPU & Blitter) */
+	ROM_REGION( 0x200000, "vdp2", 0 )   /* Gfx + Data (Addressable by CPU & Blitter) */
 	ROMX_LOAD( "dt-ja-2.14h", 0x000000, 0x080000, CRC(56881062) SHA1(150a8f043e61b28c22d0f898aea61853d1accddc) , ROM_GROUPWORD | ROM_SKIP(6))
 	ROMX_LOAD( "dt-ja-4.18h", 0x000002, 0x080000, CRC(85522e3b) SHA1(2c6e7c8ad01d39843669ef1afe7a0843ea6c107c) , ROM_GROUPWORD | ROM_SKIP(6))
 	ROMX_LOAD( "dt-ja-1.12h", 0x000004, 0x080000, CRC(2a220bf2) SHA1(553dea2ab42d845b2e91930219fe8df026748642) , ROM_GROUPWORD | ROM_SKIP(6))
@@ -4223,7 +4156,7 @@ ROM_START( daitorida )
 	ROM_LOAD16_BYTE( "dt_ja-6.6", 0x000000, 0x040000, CRC(c753954e) SHA1(f895c776ec6e2da063d3fbf9630f4812ba7bc455) ) /* Silkscreened 6 and U18 */
 	ROM_LOAD16_BYTE( "dt_ja-5.5", 0x000001, 0x040000, CRC(c4340290) SHA1(6748572a8733d88a1dd03604628e3d0e90171cf0) ) /* Silkscreened 5 and U19 */
 
-	ROM_REGION( 0x200000, "gfx1", 0 )   /* Gfx + Data (Addressable by CPU & Blitter) */
+	ROM_REGION( 0x200000, "vdp2", 0 )   /* Gfx + Data (Addressable by CPU & Blitter) */
 	ROMX_LOAD( "dt_ja-2.2", 0x000000, 0x080000, CRC(6a262249) SHA1(93b58825a454403d568e7d9a3b4d998322d0baef) , ROM_GROUPWORD | ROM_SKIP(6)) /* Silkscreened 2 and U30 */
 	ROMX_LOAD( "dt_ja-4.4", 0x000002, 0x080000, CRC(cdcef57a) SHA1(4b386f5ebde1ab6866bbbe528e43b813eba99237) , ROM_GROUPWORD | ROM_SKIP(6)) /* Silkscreened 4 and U29 */
 	ROMX_LOAD( "dt_ja-1.1", 0x000004, 0x080000, CRC(a6ccb1d2) SHA1(87570b8d82af0529c054b3038b3d3e9aa550ce6a) , ROM_GROUPWORD | ROM_SKIP(6)) /* Silkscreened 1 and U28 */
@@ -4283,7 +4216,7 @@ ROM_START( dharma )
 	ROM_REGION( 0x20000, "audiocpu", 0 )       /* NEC78C10 Code */
 	ROM_LOAD( "dd__wa-8.u9", 0x000000, 0x020000, CRC(af7ebc4c) SHA1(6abf0036346da10be56932f9674f8c250a3ea592) ) // (c)1992 Imagetek (11xxxxxxxxxxxxxxx = 0xFF) // == dd_ja-8
 
-	ROM_REGION( 0x200000, "gfx1", 0 )   /* Gfx + Data (Addressable by CPU & Blitter) */
+	ROM_REGION( 0x200000, "vdp2", 0 )   /* Gfx + Data (Addressable by CPU & Blitter) */
 	ROMX_LOAD( "dd__wa-2.u4",  0x000000, 0x080000, CRC(2c67a5c8) SHA1(777d5f64446004bbb6dafee610ad9a1ff262349d) , ROM_GROUPWORD | ROM_SKIP(6))
 	ROMX_LOAD( "dd__wa-4.u5",  0x000002, 0x080000, CRC(36ca7848) SHA1(278788727193ae65ed012d230a4e5966c07afe9e) , ROM_GROUPWORD | ROM_SKIP(6))
 	ROMX_LOAD( "dd__wa-1.u10", 0x000004, 0x080000, CRC(d8034574) SHA1(a9bf29ae980033dfaae43b6ab46f850744020d92) , ROM_GROUPWORD | ROM_SKIP(6))
@@ -4301,7 +4234,7 @@ ROM_START( dharmaj )
 	ROM_REGION( 0x20000, "audiocpu", 0 )       /* NEC78C10 Code */
 	ROM_LOAD( "dd_ja-8", 0x000000, 0x020000, CRC(af7ebc4c) SHA1(6abf0036346da10be56932f9674f8c250a3ea592) ) // (c)1992 Imagetek (11xxxxxxxxxxxxxxx = 0xFF)
 
-	ROM_REGION( 0x200000, "gfx1", 0 )   /* Gfx + Data (Addressable by CPU & Blitter) */
+	ROM_REGION( 0x200000, "vdp2", 0 )   /* Gfx + Data (Addressable by CPU & Blitter) */
 	ROMX_LOAD( "dd_jb-2", 0x000000, 0x080000, CRC(2c07c29b) SHA1(26244145139df1ffe2b6ec25a32e5009da6a5aba) , ROM_GROUPWORD | ROM_SKIP(6))
 	ROMX_LOAD( "dd_jb-4", 0x000002, 0x080000, CRC(fe15538e) SHA1(a52ac04656783611ec5d5af01b18e22254decc0c) , ROM_GROUPWORD | ROM_SKIP(6))
 	ROMX_LOAD( "dd_jb-1", 0x000004, 0x080000, CRC(e6ca9bf6) SHA1(0379250303eb6895a4dda080da8bf031d055ce8e) , ROM_GROUPWORD | ROM_SKIP(6))
@@ -4319,7 +4252,7 @@ ROM_START( dharmak )
 	ROM_REGION( 0x20000, "audiocpu", 0 )       /* NEC78C10 Code */
 	ROM_LOAD( "8.bin", 0x000000, 0x020000, CRC(d0e0a8e2) SHA1(99a3142589a1763ba162ed5b1b6c44961a5aaabc) )   // (c)1992 Imagetek (11xxxxxxxxxxxxxxx = 0xFF)
 
-	ROM_REGION( 0x200000, "gfx1", 0 )   /* Gfx + Data (Addressable by CPU & Blitter) */ /* note, these are bitswapped, see init */
+	ROM_REGION( 0x200000, "vdp2", 0 )   /* Gfx + Data (Addressable by CPU & Blitter) */ /* note, these are bitswapped, see init */
 	ROMX_LOAD( "2.bin", 0x000000, 0x080000, CRC(3cc0bb6c) SHA1(aaa063fa748e0f6fe3c07f2dfb510c1b69ea92af) , ROM_GROUPWORD | ROM_SKIP(6))
 	ROMX_LOAD( "4.bin", 0x000002, 0x080000, CRC(2cdcdf91) SHA1(44da8eac822a89e9c07bfd28720ec0b566d19b44) , ROM_GROUPWORD | ROM_SKIP(6))
 	ROMX_LOAD( "1.bin", 0x000004, 0x080000, CRC(312ee2ec) SHA1(73ea401e4615eb9ad5f42be9c75ca4550c3a4668) , ROM_GROUPWORD | ROM_SKIP(6))
@@ -4383,7 +4316,7 @@ ROM_START( gunmast )
 	ROM_REGION( 0x20000, "audiocpu", 0 )       /* NEC78C10 Code */
 	ROM_LOAD( "gmja-8.3i", 0x000000, 0x020000, CRC(ab4bcc56) SHA1(9ef91e14d0974f30c874a12370ddd04ee8ab6d5d) )   // (c)1992 Imagetek (11xxxxxxxxxxxxxxx = 0xFF)
 
-	ROM_REGION( 0x200000, "gfx1", 0 )   /* Gfx + Data (Addressable by CPU & Blitter) */
+	ROM_REGION( 0x200000, "vdp2", 0 )   /* Gfx + Data (Addressable by CPU & Blitter) */
 	ROMX_LOAD( "gmja-2.14i", 0x000000, 0x080000, CRC(bc9acd54) SHA1(e6154cc5e8e33b38f56a0055dd0a51aa6adc4f9c) , ROM_GROUPWORD | ROM_SKIP(6))
 	ROMX_LOAD( "gmja-4.18i", 0x000002, 0x080000, CRC(f2d72d90) SHA1(575a01999e4608d1503904ba22310413b680b2b9) , ROM_GROUPWORD | ROM_SKIP(6))
 	ROMX_LOAD( "gmja-1.12i", 0x000004, 0x080000, CRC(336d0a90) SHA1(39ff59ba13e21f2a8488e5dc2d44cf2c50f7c4fb) , ROM_GROUPWORD | ROM_SKIP(6))
@@ -4459,7 +4392,7 @@ ROM_START( karatour )
 	ROM_REGION( 0x20000, "audiocpu", 0 )       /* NEC78C10 Code */
 	ROM_LOAD( "kt001.1i", 0x000000, 0x020000, CRC(1dd2008c) SHA1(488b6f5d15bdbc069ee2cd6d7a0980a228d2f790) )    // 11xxxxxxxxxxxxxxx = 0xFF
 
-	ROM_REGION( 0x400000, "gfx1", 0 )   /* Gfx + Data (Addressable by CPU & Blitter) */
+	ROM_REGION( 0x400000, "vdp", 0 )   /* Gfx + Data (Addressable by CPU & Blitter) */
 	ROMX_LOAD( "361a04.15f", 0x000000, 0x100000, CRC(f6bf20a5) SHA1(cb4cb249eb1c106fe7ef0ace735c0cc3106f1ab7) , ROM_GROUPWORD | ROM_SKIP(6))
 	ROMX_LOAD( "361a07.17d", 0x000002, 0x100000, CRC(794cc1c0) SHA1(ecfdec5874a95846c0fb7966fdd1da625d85531f) , ROM_GROUPWORD | ROM_SKIP(6))
 	ROMX_LOAD( "361a05.17f", 0x000004, 0x100000, CRC(ea9c11fc) SHA1(176c4419cfe13ff019654a93cd7b0befa238bbc3) , ROM_GROUPWORD | ROM_SKIP(6))
@@ -4477,7 +4410,7 @@ ROM_START( karatourj )
 	ROM_REGION( 0x20000, "audiocpu", 0 )       /* NEC78C10 Code */
 	ROM_LOAD( "kt001.1i", 0x000000, 0x020000, CRC(1dd2008c) SHA1(488b6f5d15bdbc069ee2cd6d7a0980a228d2f790) )    // 11xxxxxxxxxxxxxxx = 0xFF
 
-	ROM_REGION( 0x400000, "gfx1", 0 )   /* Gfx + Data (Addressable by CPU & Blitter) */
+	ROM_REGION( 0x400000, "vdp", 0 )   /* Gfx + Data (Addressable by CPU & Blitter) */
 	ROMX_LOAD( "361a04.15f", 0x000000, 0x100000, CRC(f6bf20a5) SHA1(cb4cb249eb1c106fe7ef0ace735c0cc3106f1ab7) , ROM_GROUPWORD | ROM_SKIP(6))
 	ROMX_LOAD( "361a07.17d", 0x000002, 0x100000, CRC(794cc1c0) SHA1(ecfdec5874a95846c0fb7966fdd1da625d85531f) , ROM_GROUPWORD | ROM_SKIP(6))
 	ROMX_LOAD( "361a05.17f", 0x000004, 0x100000, CRC(ea9c11fc) SHA1(176c4419cfe13ff019654a93cd7b0befa238bbc3) , ROM_GROUPWORD | ROM_SKIP(6))
@@ -4523,7 +4456,7 @@ ROM_START( ladykill )
 	ROM_REGION( 0x20000, "audiocpu", 0 )       /* NEC78C10 Code */
 	ROM_LOAD( "e1.1i", 0x000000, 0x020000, CRC(a4d95cfb) SHA1(2fd8a5cbb0dc289bd5294519dbd5369bfb4c2d4d) )   // 11xxxxxxxxxxxxxxx = 0xFF
 
-	ROM_REGION( 0x400000, "gfx1", 0 )   /* Gfx + Data (Addressable by CPU & Blitter) */
+	ROM_REGION( 0x400000, "vdp", 0 )   /* Gfx + Data (Addressable by CPU & Blitter) */
 	ROMX_LOAD( "ladyj-4.15f", 0x000000, 0x100000, CRC(65e5906c) SHA1(cc3918c2094ca819ec4043055564e1dbff4a4750) , ROM_GROUPWORD | ROM_SKIP(6))
 	ROMX_LOAD( "ladyj-7.17d", 0x000002, 0x100000, CRC(56bd64a5) SHA1(911272078b0fd375111f5d1463945c2075c19e40) , ROM_GROUPWORD | ROM_SKIP(6))
 	ROMX_LOAD( "ladyj-5.17f", 0x000004, 0x100000, CRC(a81ffaa3) SHA1(5c161b0ef33f1bab077e9a2eb2d3432825729e83) , ROM_GROUPWORD | ROM_SKIP(6))
@@ -4549,7 +4482,7 @@ ROM_START( moegonta )
 	ROM_REGION( 0x20000, "audiocpu", 0 )       /* NEC78C10 Code */
 	ROM_LOAD( "e1.1i", 0x000000, 0x020000, CRC(a4d95cfb) SHA1(2fd8a5cbb0dc289bd5294519dbd5369bfb4c2d4d) )   // 11xxxxxxxxxxxxxxx = 0xFF
 
-	ROM_REGION( 0x400000, "gfx1", 0 )   /* Gfx + Data (Addressable by CPU & Blitter) */
+	ROM_REGION( 0x400000, "vdp", 0 )   /* Gfx + Data (Addressable by CPU & Blitter) */
 	ROMX_LOAD( "ladyj-4.15f", 0x000000, 0x100000, CRC(65e5906c) SHA1(cc3918c2094ca819ec4043055564e1dbff4a4750) , ROM_GROUPWORD | ROM_SKIP(6))
 	ROMX_LOAD( "ladyj-7.17d", 0x000002, 0x100000, CRC(56bd64a5) SHA1(911272078b0fd375111f5d1463945c2075c19e40) , ROM_GROUPWORD | ROM_SKIP(6))
 	ROMX_LOAD( "ladyj-5.17f", 0x000004, 0x100000, CRC(a81ffaa3) SHA1(5c161b0ef33f1bab077e9a2eb2d3432825729e83) , ROM_GROUPWORD | ROM_SKIP(6))
@@ -4604,7 +4537,7 @@ ROM_START( lastfort )
 	ROM_REGION( 0x20000, "audiocpu", 0 )       /* NEC78C10 Code */
 	ROM_LOAD( "tr_jb12", 0x000000, 0x020000, CRC(8a8f5fef) SHA1(530b4966ec058cd80a2fc5f9e961239ce59d0b89) ) // (c)1992 Imagetek (11xxxxxxxxxxxxxxx = 0xFF)
 
-	ROM_REGION( 0x100000, "gfx1", 0 )   /* Gfx + Data (Addressable by CPU & Blitter) */
+	ROM_REGION( 0x100000, "vdp", 0 )   /* Gfx + Data (Addressable by CPU & Blitter) */
 	ROMX_LOAD( "tr_jc02", 0x000000, 0x020000, CRC(db3c5b79) SHA1(337f4c547a6267f317415cbc78cdac41574b1024) , ROM_SKIP(7))
 	ROMX_LOAD( "tr_jc04", 0x000001, 0x020000, CRC(f8ab2f9b) SHA1(bfbbd5ec2bc039b8eaef92467c2e7fd3b425b477) , ROM_SKIP(7))
 	ROMX_LOAD( "tr_jc06", 0x000002, 0x020000, CRC(47a7f397) SHA1(1d2b11b95ce81ca66713457283464d6d85753e4b) , ROM_SKIP(7))
@@ -4626,7 +4559,7 @@ ROM_START( lastfortk )
 	ROM_REGION( 0x20000, "audiocpu", 0 )       /* NEC78C10 Code */
 	ROM_LOAD( "tr_jb12", 0x000000, 0x020000, CRC(8a8f5fef) SHA1(530b4966ec058cd80a2fc5f9e961239ce59d0b89) ) // (c)1992 Imagetek (11xxxxxxxxxxxxxxx = 0xFF)
 
-	ROM_REGION( 0x200000, "gfx1", 0 )   /* Gfx + Data (Addressable by CPU & Blitter) */
+	ROM_REGION( 0x200000, "vdp", 0 )   /* Gfx + Data (Addressable by CPU & Blitter) */
 	ROMX_LOAD( "7i-2",  0x000000, 0x040000, CRC(d1fe8d7b) SHA1(88b1973ebb47b91a49f6b4f722c9cc33e5330694) , ROM_SKIP(7))
 	ROMX_LOAD( "10i-4", 0x000001, 0x040000, CRC(058126d4) SHA1(985177556c8545e6a65a41083246b31509de7130) , ROM_SKIP(7))
 	ROMX_LOAD( "13i-6", 0x000002, 0x040000, CRC(39a9dea2) SHA1(9f8067cff15be93771d42b3776ee7ca1b7c61798) , ROM_SKIP(7))
@@ -4648,7 +4581,7 @@ ROM_START( lastfortg ) /* German version on PCB VG460-(A) */
 	ROM_REGION( 0x20000, "audiocpu", 0 )       /* NEC78C10 Code */
 	ROM_LOAD( "tr_ma01.1i",  0x000000, 0x020000,  CRC(8a8f5fef) SHA1(530b4966ec058cd80a2fc5f9e961239ce59d0b89) ) /* Same as parent set, but different label */
 
-	ROM_REGION( 0x200000, "gfx1", 0 )   /* Gfx + Data (Addressable by CPU & Blitter) */
+	ROM_REGION( 0x200000, "vdp", 0 )   /* Gfx + Data (Addressable by CPU & Blitter) */
 	ROMX_LOAD( "tr_ma04.15f", 0x000000, 0x080000, CRC(5feafc6f) SHA1(eb50905eb0d25eb342e08d591907f79b5eadff43) , ROM_GROUPWORD | ROM_SKIP(6))
 	ROMX_LOAD( "tr_ma07.17d", 0x000002, 0x080000, CRC(7519d569) SHA1(c88932a19a48d45a19b777113a4719b18f42a297) , ROM_GROUPWORD | ROM_SKIP(6))
 	ROMX_LOAD( "tr_ma05.17f", 0x000004, 0x080000, CRC(5d917ba5) SHA1(34fc72924fa2877c1038d7f61b22f7667af01e9f) , ROM_GROUPWORD | ROM_SKIP(6))
@@ -4680,7 +4613,7 @@ ROM_START( lastforte )
 	ROM_REGION( 0x20000, "audiocpu", 0 )       /* NEC78C10 Code */
 	ROM_LOAD( "tr_jb12", 0x000000, 0x020000, CRC(8a8f5fef) SHA1(530b4966ec058cd80a2fc5f9e961239ce59d0b89) ) // (c)1992 Imagetek (11xxxxxxxxxxxxxxx = 0xFF)
 
-	ROM_REGION( 0x100000, "gfx1", 0 )   /* Gfx + Data (Addressable by CPU & Blitter) */
+	ROM_REGION( 0x100000, "vdp", 0 )   /* Gfx + Data (Addressable by CPU & Blitter) */
 	ROMX_LOAD( "tr_ha02", 0x000000, 0x020000, CRC(11cfbc84) SHA1(fb7005be7678564713b5480569f2cdab6c36f029) , ROM_SKIP(7))
 	ROMX_LOAD( "tr_ha04", 0x000001, 0x020000, CRC(32bf9c26) SHA1(9d16eca8810d1823726dc9c047504bd24f2a55f7) , ROM_SKIP(7))
 	ROMX_LOAD( "tr_ha06", 0x000002, 0x020000, CRC(16937977) SHA1(768bb6b1c9b90b2eedc9dbb19c8e9fa8f4265f17) , ROM_SKIP(7))
@@ -4702,7 +4635,7 @@ ROM_START( lastfortea )
 	ROM_REGION( 0x20000, "audiocpu", 0 )       /* NEC78C10 Code */
 	ROM_LOAD( "tr_jb12", 0x000000, 0x020000, CRC(8a8f5fef) SHA1(530b4966ec058cd80a2fc5f9e961239ce59d0b89) ) // (c)1992 Imagetek (11xxxxxxxxxxxxxxx = 0xFF)
 
-	ROM_REGION( 0x100000, "gfx1", 0 )   /* Gfx + Data (Addressable by CPU & Blitter) */
+	ROM_REGION( 0x100000, "vdp", 0 )   /* Gfx + Data (Addressable by CPU & Blitter) */
 	ROMX_LOAD( "tr_ha02", 0x000000, 0x020000, CRC(11cfbc84) SHA1(fb7005be7678564713b5480569f2cdab6c36f029) , ROM_SKIP(7))
 	ROMX_LOAD( "tr_ha04", 0x000001, 0x020000, CRC(32bf9c26) SHA1(9d16eca8810d1823726dc9c047504bd24f2a55f7) , ROM_SKIP(7))
 	ROMX_LOAD( "tr_ha06", 0x000002, 0x020000, CRC(16937977) SHA1(768bb6b1c9b90b2eedc9dbb19c8e9fa8f4265f17) , ROM_SKIP(7))
@@ -4737,7 +4670,7 @@ ROM_START( dokyusei )
 	ROM_LOAD16_BYTE( "330_a06.bin", 0x000000, 0x020000, CRC(36157c2e) SHA1(f855175143caf476dcbee5a8aaec802a8fdb64fa) )
 	ROM_LOAD16_BYTE( "330_a05.bin", 0x000001, 0x020000, CRC(177f50d2) SHA1(2298411152553041b907d9243aaa7983ca21c946) )
 
-	ROM_REGION( 0x800000, "gfx1", 0 )   /* Gfx + Data (Addressable by CPU & Blitter) */
+	ROM_REGION( 0x800000, "vdp3", 0 )   /* Gfx + Data (Addressable by CPU & Blitter) */
 	ROMX_LOAD( "2.bin", 0x000000, 0x200000, CRC(075bface) SHA1(7f0e47ebdc37a1fc09b072cb8e0f38258a702a3d) , ROM_GROUPWORD | ROM_SKIP(6))
 	ROMX_LOAD( "4.bin", 0x000002, 0x200000, CRC(bc631438) SHA1(da3ef24d94e69197e3c69e4fd2b716162c275278) , ROM_GROUPWORD | ROM_SKIP(6))
 	ROMX_LOAD( "1.bin", 0x000004, 0x200000, CRC(4566c29b) SHA1(3216e21d898855cbb0ad328e6d45f3726d95b099) , ROM_GROUPWORD | ROM_SKIP(6))
@@ -4770,7 +4703,7 @@ ROM_START( dokyusp )
 	ROM_LOAD16_BYTE( "6.bin", 0x000000, 0x020000, CRC(01729b7f) SHA1(42a60f034ee5d5c2a42856b97d0d4c499b24627b) )
 	ROM_LOAD16_BYTE( "5.bin", 0x000001, 0x020000, CRC(57770776) SHA1(15093886f2fe49443e8d7541903714de0a14aa0b) )
 
-	ROM_REGION( 0x1000000, "gfx1", 0 )  /* Gfx + Data (Addressable by CPU & Blitter) */
+	ROM_REGION( 0x1000000, "vdp3", 0 )  /* Gfx + Data (Addressable by CPU & Blitter) */
 	ROMX_LOAD( "2l.bin", 0x0000000, 0x400000, CRC(4bed184d) SHA1(12bdb00030d19c2c9fb2120ed6b267a7982c213a) , ROM_GROUPWORD | ROM_SKIP(6))
 	ROMX_LOAD( "4l.bin", 0x0000002, 0x400000, CRC(2ee468e6) SHA1(ced58fdd8b5c99ce3f09cece2e05d7fcf4c7f786) , ROM_GROUPWORD | ROM_SKIP(6))
 	ROMX_LOAD( "1l.bin", 0x0000004, 0x400000, CRC(510ace14) SHA1(f5f1f46f4d8d150dd9e17083f32e9b45938c1dad) , ROM_GROUPWORD | ROM_SKIP(6))
@@ -4806,7 +4739,7 @@ ROM_START( gakusai )
 	ROM_LOAD16_BYTE( "6.bin", 0x000000, 0x040000, CRC(6f8ab082) SHA1(18caf49a0c65f831d375f089f27b8570b094f029) )
 	ROM_LOAD16_BYTE( "5.bin", 0x000001, 0x040000, CRC(010176c4) SHA1(48fcea18c02c1426a699a636f44b21cf7625e8a0) )
 
-	ROM_REGION( 0x2000000, "gfx1", 0 )  /* Gfx + Data (Addressable by CPU & Blitter) */
+	ROM_REGION( 0x2000000, "vdp3", 0 )  /* Gfx + Data (Addressable by CPU & Blitter) */
 	ROMX_LOAD( "2l.bin", 0x0000000, 0x400000, CRC(45dfb5c7) SHA1(04338d695bd6973fd7d7286a8da563250ae4f71b) , ROM_GROUPWORD | ROM_SKIP(6))
 	ROMX_LOAD( "4l.bin", 0x0000002, 0x400000, CRC(7ab64f49) SHA1(e4d9a7bf97635b41fe632b3542eee1f609db080a) , ROM_GROUPWORD | ROM_SKIP(6))
 	ROMX_LOAD( "1l.bin", 0x0000004, 0x400000, CRC(75093421) SHA1(cfe549e24abfedd740ead30cab235df494e9f45d) , ROM_GROUPWORD | ROM_SKIP(6))
@@ -4843,7 +4776,7 @@ ROM_START( gakusai2 )
 	ROM_LOAD16_BYTE( "mg2a06.bin", 0x000000, 0x020000, CRC(8b006dd4) SHA1(893ec0e7c367d79bc99e65ab8abd0d290f2ede58) )
 	ROM_LOAD16_BYTE( "mg2a05.bin", 0x000001, 0x020000, CRC(7702b9ac) SHA1(09d0c11fa2c9ed9cde365cb1ff215d55e39b7734) )
 
-	ROM_REGION( 0x2000000, "gfx1", 0 )  /* Gfx + Data (Addressable by CPU & Blitter) */
+	ROM_REGION( 0x2000000, "vdp3", 0 )  /* Gfx + Data (Addressable by CPU & Blitter) */
 	ROMX_LOAD( "mg22l.bin", 0x0000000, 0x400000, CRC(28366708) SHA1(56fccee126916cc301678a205dfe629efefb79db) , ROM_GROUPWORD | ROM_SKIP(6))
 	ROMX_LOAD( "mg24l.bin", 0x0000002, 0x400000, CRC(9e003bb0) SHA1(aa73cc0e79732fd6826c89671b179cb3189571e0) , ROM_GROUPWORD | ROM_SKIP(6))
 	ROMX_LOAD( "mg21l.bin", 0x0000004, 0x400000, CRC(3827098d) SHA1(dda9fb6c56c4408802d54c5975fb9470ca2e1d34) , ROM_GROUPWORD | ROM_SKIP(6))
@@ -4898,7 +4831,7 @@ ROM_START( mouja )
 	ROM_LOAD16_BYTE( "10.u38", 0x000000, 0x040000, CRC(f9742b69) SHA1(f8c6508b227403a82413ceeb0651922759d7e0f4) ) /* Silkscreened U38 and 10 */
 	ROM_LOAD16_BYTE( "9.u39",  0x000001, 0x040000, CRC(dc77216f) SHA1(3b73d29f4e8e385f45f2abfb38eaffc2d8406948) ) /* Silkscreened U39 and 9 */
 
-	ROM_REGION( 0x400000, "gfx1", 0 )   /* Gfx + Data (Addressable by CPU & Blitter) */
+	ROM_REGION( 0x400000, "vdp3", 0 )   /* Gfx + Data (Addressable by CPU & Blitter) */
 	ROMX_LOAD( "lh53882c.u6", 0x000000, 0x100000, CRC(c4dd3194) SHA1(c9c88a8d2046224957b35de14763aa4bdf0d407f) , ROM_GROUPWORD | ROM_SKIP(6)) /* Silkscreened U6 and 42 */
 	ROMX_LOAD( "lh53882e.u5", 0x000002, 0x100000, CRC(09530f9d) SHA1(03f2ec5ea694266808d245abe7f688de0ef6d853) , ROM_GROUPWORD | ROM_SKIP(6)) /* Silkscreened U5 and 86 */
 	ROMX_LOAD( "lh53882b.u4", 0x000004, 0x100000, CRC(5dd7a7b2) SHA1(b0347e8951b29356a7d945b906d93c40b9abc19c) , ROM_GROUPWORD | ROM_SKIP(6)) /* Silkscreened U4 and 31 */
@@ -4952,7 +4885,7 @@ ROM_START( msgogo )
 	ROM_LOAD16_BYTE( "ms_wa-6.6", 0x000000, 0x040000, CRC(986acac8) SHA1(97c24f5b730aa811951db4c7e9c894c0701c58fd) ) /* Silkscreened 6 and U18 */
 	ROM_LOAD16_BYTE( "ms_wa-5.5", 0x000001, 0x040000, CRC(746d9f99) SHA1(6e3e34dfb67fecc93213fe040465eccd88575822) ) /* Silkscreened 5 and U19 */
 
-	ROM_REGION( 0x200000, "gfx1", 0 )   /* Gfx + Data (Addressable by CPU & Blitter) */
+	ROM_REGION( 0x200000, "vdp2", 0 )   /* Gfx + Data (Addressable by CPU & Blitter) */
 	ROMX_LOAD( "ms_wa-2.2", 0x000000, 0x080000, CRC(0d36c2b9) SHA1(3fd6631ad657c73e7e6bfdff9d9caf5ab044bdeb), ROM_GROUPWORD | ROM_SKIP(6)) /* Silkscreened 2 and U30 */
 	ROMX_LOAD( "ms_wa-4.4", 0x000002, 0x080000, CRC(fd387126) SHA1(a2f82a66b098a97d8f245e3c2f96c31c63642fec), ROM_GROUPWORD | ROM_SKIP(6)) /* Silkscreened 4 and U29 */
 	ROMX_LOAD( "ms_ja-1.1", 0x000004, 0x080000, CRC(8ec4e81d) SHA1(46947ad2941af154f91e47acee281302a12e3aa5), ROM_GROUPWORD | ROM_SKIP(6)) /* Silkscreened 1 and U28 */
@@ -4986,7 +4919,7 @@ ROM_START( pangpoms )
 	ROM_REGION( 0x20000, "audiocpu", 0 )       /* NEC78C10 Code */
 	ROM_LOAD( "ppoms12.bin", 0x000000, 0x020000, CRC(a749357b) SHA1(1555f565c301c5be7c49fc44a004b5c0cb3777c6) )
 
-	ROM_REGION( 0x100000, "gfx1", 0 )   /* Gfx + Data (Addressable by CPU & Blitter) */
+	ROM_REGION( 0x100000, "vdp", 0 )   /* Gfx + Data (Addressable by CPU & Blitter) */
 	ROMX_LOAD( "ppoms02.bin", 0x000000, 0x020000, CRC(88f902f7) SHA1(12ea58d7c000b629ccdceec3dedc2747a63b84be) , ROM_SKIP(7))
 	ROMX_LOAD( "ppoms04.bin", 0x000001, 0x020000, CRC(9190c2a0) SHA1(a7399cc2dea5a963e7c930e426915e8eb3552213) , ROM_SKIP(7))
 	ROMX_LOAD( "ppoms06.bin", 0x000002, 0x020000, CRC(ed15c93d) SHA1(95072e7d1def0d8e97946a612b90ce078c64aed2) , ROM_SKIP(7))
@@ -5008,7 +4941,7 @@ ROM_START( pangpomsm )
 	ROM_REGION( 0x20000, "audiocpu", 0 )       /* NEC78C10 Code */
 	ROM_LOAD( "ppoms12.bin", 0x000000, 0x020000, CRC(a749357b) SHA1(1555f565c301c5be7c49fc44a004b5c0cb3777c6) )
 
-	ROM_REGION( 0x100000, "gfx1", 0 )   /* Gfx + Data (Addressable by CPU & Blitter) */
+	ROM_REGION( 0x100000, "vdp", 0 )   /* Gfx + Data (Addressable by CPU & Blitter) */
 	ROMX_LOAD( "ppoms02.bin", 0x000000, 0x020000, CRC(88f902f7) SHA1(12ea58d7c000b629ccdceec3dedc2747a63b84be) , ROM_SKIP(7))
 	ROMX_LOAD( "pj.e04",      0x000001, 0x020000, CRC(54bf2f10) SHA1(2f0f18984e336f226457295d375a73bcf86cef31) , ROM_SKIP(7))
 	ROMX_LOAD( "pj.e06",      0x000002, 0x020000, CRC(c8b6347d) SHA1(7090e44dc7032432795b6fb6bc166bf4de159685) , ROM_SKIP(7))
@@ -5062,7 +4995,7 @@ ROM_START( poitto )
 	ROM_REGION( 0x20000, "audiocpu", 0 )       /* NEC78C10 Code */
 	ROM_LOAD( "pt-jc08.3i", 0x000000, 0x020000, CRC(f32d386a) SHA1(655c561aec1112d88c1b94725e932059e5d1d5a8) )  // 1xxxxxxxxxxxxxxxx = 0xFF
 
-	ROM_REGION( 0x200000, "gfx1", 0 )   /* Gfx + Data (Addressable by CPU & Blitter) */
+	ROM_REGION( 0x200000, "vdp", 0 )   /* Gfx + Data (Addressable by CPU & Blitter) */
 	ROMX_LOAD( "pt-2.15i", 0x000000, 0x080000, CRC(05d15d01) SHA1(24405908fb8207228cd3419657e0be49e413f152) , ROM_GROUPWORD | ROM_SKIP(6))
 	ROMX_LOAD( "pt-4.19i", 0x000002, 0x080000, CRC(8a39edb5) SHA1(1d860e0a1b975a93907d5bb0704e3bad383bbda7) , ROM_GROUPWORD | ROM_SKIP(6))
 	ROMX_LOAD( "pt-1.13i", 0x000004, 0x080000, CRC(ea6e2289) SHA1(2c939b32d2bf155bb5c8bd979dadcf4f75e178b0) , ROM_GROUPWORD | ROM_SKIP(6))
@@ -5123,7 +5056,7 @@ ROM_START( puzzlet )
 	ROM_REGION( 0x200, "z86e02", 0 )    /* Zilog Z8 family 8-bit MCU */
 	ROM_LOAD( "z86e02.mcu", 0x000, 0x200, CRC(399fa417) SHA1(f6c57020ea394c858742759050bf4f4b2f1e1fc5) )
 
-	ROM_REGION( 0x400000, "gfx1", 0 )   /* Gfx + Data (Addressable by CPU & Blitter) */
+	ROM_REGION( 0x400000, "vdp2", 0 )   /* Gfx + Data (Addressable by CPU & Blitter) */
 	ROMX_LOAD( "cg2.u2", 0x000000, 0x200000, CRC(7720f2d8) SHA1(8e0ccd1e8efe00df909327aefdb1e23e50487524), ROM_GROUPWORD | ROM_SKIP(2))
 	ROMX_LOAD( "cg3.u1", 0x000002, 0x200000, CRC(77d39d12) SHA1(4bb339e479f0425931cff4eef3a6bc6ad1fac1f5), ROM_GROUPWORD | ROM_SKIP(2))
 
@@ -5162,7 +5095,7 @@ ROM_START( puzzli )
 	ROM_REGION( 0x20000, "audiocpu", 0 )       /* NEC78C10 Code */
 	ROM_LOAD( "pz_jb8.3i", 0x000000, 0x020000, CRC(c652da32) SHA1(907eba5103373ca6204f9d62c426ccdeef0a3791) )
 
-	ROM_REGION( 0x200000, "gfx1", 0 )   /* Gfx + Data (Addressable by CPU & Blitter) */
+	ROM_REGION( 0x200000, "vdp2", 0 )   /* Gfx + Data (Addressable by CPU & Blitter) */
 	ROMX_LOAD( "pz_jb2.14i", 0x000000, 0x080000, CRC(0c0997d4) SHA1(922d8553ef505f65238e5cc77b45861a80022d75) , ROM_GROUPWORD | ROM_SKIP(6))
 	ROMX_LOAD( "pz_jb4.18i", 0x000002, 0x080000, CRC(576bc5c2) SHA1(08c10e0a3356ee1f79b78eff92395d8b18e43485) , ROM_GROUPWORD | ROM_SKIP(6))
 	ROMX_LOAD( "pz_jb1.12i", 0x000004, 0x080000, CRC(29f01eb3) SHA1(1a56f0b8efb599ae4f3cd0a4f0b6a6152ea6b117) , ROM_GROUPWORD | ROM_SKIP(6))
@@ -5192,7 +5125,7 @@ ROM_START( 3kokushi )
 	ROM_REGION( 0x20000, "audiocpu", 0 )       /* NEC78C10 Code */
 	ROM_LOAD( "8.3i", 0x000000, 0x020000, CRC(f56cca45) SHA1(4739b83b0b3a4235fac10def3d26b0bd190eb12a) )    // (c)1992 Imagetek (11xxxxxxxxxxxxxxx = 0xFF)
 
-	ROM_REGION( 0x200000, "gfx1", 0 )   /* Gfx + Data (Addressable by CPU & Blitter) */
+	ROM_REGION( 0x200000, "vdp2", 0 )   /* Gfx + Data (Addressable by CPU & Blitter) */
 	ROMX_LOAD( "2.14i", 0x000000, 0x080000, CRC(291f8149) SHA1(82f460517543ef544c21a81e51987fb2f5c6273d) , ROM_GROUPWORD | ROM_SKIP(6))
 	ROMX_LOAD( "4.18i", 0x000002, 0x080000, CRC(9317c359) SHA1(9756757fb5d2b298a2b1917a131f391ef0e31fb9) , ROM_GROUPWORD | ROM_SKIP(6))
 	ROMX_LOAD( "1.12i", 0x000004, 0x080000, CRC(d5495759) SHA1(9cbcb48915ec44a8026d88d96ab391e118e89df5) , ROM_GROUPWORD | ROM_SKIP(6))
@@ -5242,7 +5175,7 @@ ROM_START( pururun )
 	ROM_REGION( 0x20000, "audiocpu", 0 )       /* NEC78C10 Code */
 	ROM_LOAD( "pu9-19-8.3i", 0x000000, 0x020000, CRC(edc3830b) SHA1(13ee759d10711218465f6d7155e9c443a82b323c) )
 
-	ROM_REGION( 0x200000, "gfx1", 0 )   /* Gfx + Data (Addressable by CPU & Blitter) */
+	ROM_REGION( 0x200000, "vdp2", 0 )   /* Gfx + Data (Addressable by CPU & Blitter) */
 	ROMX_LOAD( "pu9-19-2.14i", 0x000000, 0x080000, CRC(21550b26) SHA1(cb2a2f672cdca84def2fac8d325b7a80a1e9bfc0) , ROM_GROUPWORD | ROM_SKIP(6))
 	ROMX_LOAD( "pu9-19-4.18i", 0x000002, 0x080000, CRC(3f3e216d) SHA1(9881e07d5ee237b7134e2ddcf9a9887a1d7f3b4c) , ROM_GROUPWORD | ROM_SKIP(6))
 	ROMX_LOAD( "pu9-19-1.12i", 0x000004, 0x080000, CRC(7e83a75f) SHA1(9f516bbfc4ca8a8e857ebf7a19c37d7f026695a6) , ROM_GROUPWORD | ROM_SKIP(6))
@@ -5296,7 +5229,7 @@ ROM_START( skyalert )
 	ROM_REGION( 0x20000, "audiocpu", 0 )       /* NEC78C10 Code */
 	ROM_LOAD( "sa_b_12.bin", 0x000000, 0x020000, CRC(f358175d) SHA1(781d0f846217aa71e3c6d73c1d63bd87d1fa6b48) ) // (c)1992 Imagetek (1xxxxxxxxxxxxxxxx = 0xFF)
 
-	ROM_REGION( 0x200000, "gfx1", 0 )   /* Gfx + Data (Addressable by CPU & Blitter) */
+	ROM_REGION( 0x200000, "vdp", 0 )   /* Gfx + Data (Addressable by CPU & Blitter) */
 	ROMX_LOAD( "sa_a_02.bin", 0x000000, 0x040000, CRC(f4f81d41) SHA1(85e587b4fda71fa5b944b0ac158d36c00e290f5f) , ROM_SKIP(7))
 	ROMX_LOAD( "sa_a_04.bin", 0x000001, 0x040000, CRC(7d071e7e) SHA1(24b9b0cb7e9f719259b0444ee896bdc1ad79a28d) , ROM_SKIP(7))
 	ROMX_LOAD( "sa_a_06.bin", 0x000002, 0x040000, CRC(77e4d5e1) SHA1(420e5aaf187e297b371830ebd5787675cff6177b) , ROM_SKIP(7))
@@ -5350,7 +5283,7 @@ ROM_START( toride2g )
 	ROM_REGION( 0x20000, "audiocpu", 0 )       /* NEC78C10 Code */
 	ROM_LOAD( "tr2aja-8.3i", 0x000000, 0x020000, CRC(fdd29146) SHA1(8e996e1afd33f16d35ebf5a40829feb3e92f781f) )
 
-	ROM_REGION( 0x200000, "gfx1", 0 )   /* Gfx + Data (Addressable by CPU & Blitter) */
+	ROM_REGION( 0x200000, "vdp2", 0 )   /* Gfx + Data (Addressable by CPU & Blitter) */
 	ROMX_LOAD( "tr2aja-2.14i", 0x000000, 0x080000, CRC(5c73f629) SHA1(b38b7ee213bcc0dd5e4c339a8f9f2fdd81ede6ad) , ROM_GROUPWORD | ROM_SKIP(6))
 	ROMX_LOAD( "tr2aja-4.18i", 0x000002, 0x080000, CRC(67ebaf1b) SHA1(a0c5f253cc33620251fb58ef6f1647453d778462) , ROM_GROUPWORD | ROM_SKIP(6))
 	ROMX_LOAD( "tr2aja-1.12i", 0x000004, 0x080000, CRC(96245a5c) SHA1(524990c88a08648de6f330652fc5c02a27e1325c) , ROM_GROUPWORD | ROM_SKIP(6))
@@ -5368,7 +5301,7 @@ ROM_START( toride2gg )
 	ROM_REGION( 0x20000, "audiocpu", 0 )       /* NEC78C10 Code */
 	ROM_LOAD( "tr2_jb-8.3i", 0x000000, 0x020000, CRC(0168f46f) SHA1(01bf4cc425d72936897c3c572f6c0b1366fe4041) )
 
-	ROM_REGION( 0x200000, "gfx1", 0 )   /* Gfx + Data (Addressable by CPU & Blitter) */
+	ROM_REGION( 0x200000, "vdp2", 0 )   /* Gfx + Data (Addressable by CPU & Blitter) */
 	ROMX_LOAD( "trii_gb_2.14i", 0x000000, 0x080000, CRC(5949e65f) SHA1(f51ff9590904e691b9ec91b22d3c52bf579deaff) , ROM_GROUPWORD | ROM_SKIP(6))
 	ROMX_LOAD( "trii_gb_4.18i", 0x000002, 0x080000, CRC(adc84c7b) SHA1(fe0f2b6e3c586c427701e43fdd4827c8b183b42a) , ROM_GROUPWORD | ROM_SKIP(6))
 	ROMX_LOAD( "trii_gb_1.12i", 0x000004, 0x080000, CRC(bcf30944) SHA1(c36fbffa6062a2443a47d8faf83baa903529ee97) , ROM_GROUPWORD | ROM_SKIP(6))
@@ -5422,7 +5355,7 @@ ROM_START( toride2gk )
 	ROM_REGION( 0x20000, "audiocpu", 0 )       /* NEC78C10 Code */
 	ROM_LOAD( "8", 0x00000, 0x20000, CRC(fdd29146) SHA1(8e996e1afd33f16d35ebf5a40829feb3e92f781f) )
 
-	ROM_REGION( 0x200000, "gfx1", 0 )   /* Gfx + Data (Addressable by CPU & Blitter) */
+	ROM_REGION( 0x200000, "vdp2", 0 )   /* Gfx + Data (Addressable by CPU & Blitter) */
 	ROMX_LOAD( "2", 0x00000, 0x80000, CRC(5e7fb9db) SHA1(37094ea750be8605bd2130d0d5ce5f9c43b0cc77), ROM_GROUPWORD | ROM_SKIP(6))
 	ROMX_LOAD( "4", 0x00002, 0x80000, CRC(558c03e7) SHA1(f7fa5aa9eacd8953d998d9b05d5f03e65056bd78), ROM_GROUPWORD | ROM_SKIP(6))
 	ROMX_LOAD( "1", 0x00004, 0x80000, CRC(5e819ccd) SHA1(b1d4e800bac0f55286317d2a39c2b245d87a3e50), ROM_GROUPWORD | ROM_SKIP(6))
@@ -5440,7 +5373,7 @@ ROM_START( toride2j )
 	ROM_REGION( 0x20000, "audiocpu", 0 )       /* NEC78C10 Code */
 	ROM_LOAD( "tr2_jb-8.3i", 0x000000, 0x020000, CRC(0168f46f) SHA1(01bf4cc425d72936897c3c572f6c0b1366fe4041) )
 
-	ROM_REGION( 0x200000, "gfx1", 0 )   /* Gfx + Data (Addressable by CPU & Blitter) */
+	ROM_REGION( 0x200000, "vdp2", 0 )   /* Gfx + Data (Addressable by CPU & Blitter) */
 	ROMX_LOAD( "tr2_jb-2.14i", 0x000000, 0x080000, CRC(b31754dc) SHA1(be2423bafbf07c93c3d222e907190b44616014f0) , ROM_GROUPWORD | ROM_SKIP(6))
 	ROMX_LOAD( "tr2_jb-4.18i", 0x000002, 0x080000, CRC(a855c3fa) SHA1(eca3e235256df7e6ae66ecbe43bc0edb974af503) , ROM_GROUPWORD | ROM_SKIP(6))
 	ROMX_LOAD( "tr2_jb-1.12i", 0x000004, 0x080000, CRC(856f40b7) SHA1(99aca5472b991cd08e9c2128ffdd40675a3b968d) , ROM_GROUPWORD | ROM_SKIP(6))
@@ -5508,7 +5441,7 @@ ROM_START( vmetal )
 	ROM_LOAD16_BYTE( "6b.u18", 0x00000, 0x80000, CRC(4eb939d5) SHA1(741ab05043fc3bd886162d878630e45da9359718) )
 	ROM_LOAD16_BYTE( "5b.u19", 0x00001, 0x80000, CRC(4933ac6c) SHA1(1a3303e32fcb08854d4d6e13f36ca99d92aed4cc) )
 
-	ROM_REGION( 0x800000, "gfx1", 0 )
+	ROM_REGION( 0x800000, "vdp2", 0 )
 	ROMX_LOAD( "2.u31", 0x000000, 0x200000, CRC(b36f8d60) SHA1(1676859d0fee4eb9897ce1601a2c9fd9a6dc4a43), ROM_GROUPWORD | ROM_SKIP(6))
 	ROMX_LOAD( "4.u30", 0x000002, 0x200000, CRC(5a25a49c) SHA1(c30781202ec882e1ec6adfb560b0a1075b3cce55), ROM_GROUPWORD | ROM_SKIP(6))
 	ROMX_LOAD( "1.u29", 0x000004, 0x200000, CRC(b470c168) SHA1(c30462dc134da1e71a94b36ef96ecd65c325b07e), ROM_GROUPWORD | ROM_SKIP(6))
@@ -5527,7 +5460,7 @@ ROM_START( vmetaln )
 	ROM_LOAD16_BYTE( "vm6.bin", 0x00000, 0x80000, CRC(cb292ab1) SHA1(41fdfe67e6cb848542fd5aa0dfde3b1936bb3a28) )
 	ROM_LOAD16_BYTE( "vm5.bin", 0x00001, 0x80000, CRC(43ef844e) SHA1(c673f34fcc9e406282c9008795b52d01a240099a) )
 
-	ROM_REGION( 0x800000, "gfx1", 0 )
+	ROM_REGION( 0x800000, "vdp2", 0 )
 	ROMX_LOAD( "2.u31", 0x000000, 0x200000, CRC(b36f8d60) SHA1(1676859d0fee4eb9897ce1601a2c9fd9a6dc4a43), ROM_GROUPWORD | ROM_SKIP(6))
 	ROMX_LOAD( "4.u30", 0x000002, 0x200000, CRC(5a25a49c) SHA1(c30781202ec882e1ec6adfb560b0a1075b3cce55), ROM_GROUPWORD | ROM_SKIP(6))
 	ROMX_LOAD( "1.u29", 0x000004, 0x200000, CRC(b470c168) SHA1(c30462dc134da1e71a94b36ef96ecd65c325b07e), ROM_GROUPWORD | ROM_SKIP(6))
@@ -5552,7 +5485,7 @@ ROM_END
 
 void metro_state::metro_common(  )
 {
-	memset(m_requested_int, 0, ARRAY_LENGTH(m_requested_int));
+	std::fill(std::begin(m_requested_int), std::end(m_requested_int), 0);
 	m_vblank_bit = 0;
 	m_blitter_bit = 2;
 	m_irq_line = 2;
@@ -5586,8 +5519,8 @@ void metro_state::init_karatour()
 /* Unscramble the GFX ROMs */
 void metro_state::init_balcube()
 {
-	uint8_t *ROM         = memregion("gfx1")->base();
-	const unsigned len = memregion("gfx1")->bytes();
+	uint8_t *ROM       = memregion("vdp2")->base();
+	const unsigned len = memregion("vdp2")->bytes();
 
 	for (unsigned i = 0; i < len; i+=2)
 	{
@@ -5601,7 +5534,7 @@ void metro_state::init_balcube()
 
 void metro_state::init_dharmak()
 {
-	uint8_t *src = memregion( "gfx1" )->base();
+	uint8_t *src = memregion("vdp2")->base();
 	for (int i = 0; i < 0x200000; i += 4)
 	{
 		uint8_t dat = src[i + 1];
@@ -5674,7 +5607,7 @@ void metro_state::init_lastfortg()
 
 // VG420 / VG460
 GAME( 1992, karatour,  0,        karatour,  karatour,   metro_state, init_karatour, ROT0,   "Mitchell",                                        "The Karate Tournament", MACHINE_SUPPORTS_SAVE )
-GAME( 1992, karatourj, karatour, karatour,  karatour,   metro_state, init_karatour, ROT0,   "Mitchell",                                        "The Karate Tournament (Japan)", MACHINE_SUPPORTS_SAVE )
+GAME( 1992, karatourj, karatour, karatour,  karatour,   metro_state, init_karatour, ROT0,   "Mitchell",                                        "Chatan Yarakuu Shanku - The Karate Tournament (Japan)", MACHINE_SUPPORTS_SAVE )
 GAME( 1992, pangpoms,  0,        pangpoms,  pangpoms,   metro_state, init_metro,    ROT0,   "Metro",                                           "Pang Pom's", MACHINE_SUPPORTS_SAVE )
 GAME( 1992, pangpomsm, pangpoms, pangpoms,  pangpoms,   metro_state, init_metro,    ROT0,   "Metro (Mitchell license)",                        "Pang Pom's (Mitchell)", MACHINE_SUPPORTS_SAVE )
 GAME( 1992, skyalert,  0,        skyalert,  skyalert,   metro_state, init_metro,    ROT270, "Metro",                                           "Sky Alert", MACHINE_SUPPORTS_SAVE )

--- a/src/mame/includes/metro.h
+++ b/src/mame/includes/metro.h
@@ -104,26 +104,25 @@ private:
 		TIMER_MOUJA_IRQ
 	};
 
-	DECLARE_READ16_MEMBER(metro_irq_cause_r);
-	DECLARE_WRITE16_MEMBER(metro_irq_cause_w);
+	u8 irq_cause_r(offs_t offset);
+	void irq_cause_w(offs_t offset, u8 data);
 	DECLARE_WRITE16_MEMBER(mouja_irq_timer_ctrl_w);
-	DECLARE_WRITE16_MEMBER(metro_soundlatch_w);
-	DECLARE_READ16_MEMBER(metro_soundstatus_r);
-	DECLARE_WRITE16_MEMBER(metro_soundstatus_w);
-	DECLARE_WRITE8_MEMBER(metro_sound_rombank_w);
-	DECLARE_WRITE8_MEMBER(daitorid_sound_rombank_w);
-	DECLARE_READ8_MEMBER(metro_porta_r);
-	DECLARE_WRITE8_MEMBER(metro_porta_w);
-	DECLARE_WRITE8_MEMBER(metro_portb_w);
+	DECLARE_WRITE8_MEMBER(soundlatch_w);
+	DECLARE_READ8_MEMBER(soundstatus_r);
+	DECLARE_WRITE8_MEMBER(soundstatus_w);
+	template<int Mask> DECLARE_WRITE8_MEMBER(upd7810_rombank_w);
+	DECLARE_READ8_MEMBER(upd7810_porta_r);
+	DECLARE_WRITE8_MEMBER(upd7810_porta_w);
+	DECLARE_WRITE8_MEMBER(upd7810_portb_w);
 	DECLARE_WRITE8_MEMBER(daitorid_portb_w);
-	DECLARE_WRITE16_MEMBER(metro_coin_lockout_1word_w);
-	DECLARE_WRITE16_MEMBER(metro_coin_lockout_4words_w);
+	DECLARE_WRITE8_MEMBER(coin_lockout_1word_w);
+	DECLARE_WRITE16_MEMBER(coin_lockout_4words_w);
 	DECLARE_READ16_MEMBER(balcube_dsw_r);
 	DECLARE_READ16_MEMBER(gakusai_input_r);
 	DECLARE_WRITE8_MEMBER(blzntrnd_sh_bankswitch_w);
 	DECLARE_WRITE16_MEMBER(puzzlet_irq_enable_w);
 	DECLARE_WRITE16_MEMBER(puzzlet_portb_w);
-	DECLARE_WRITE16_MEMBER(metro_k053936_w);
+	DECLARE_WRITE16_MEMBER(k053936_w);
 	DECLARE_WRITE8_MEMBER(gakusai_oki_bank_hi_w);
 	DECLARE_WRITE8_MEMBER(gakusai_oki_bank_lo_w);
 	DECLARE_READ8_MEMBER(gakusai_eeprom_r);
@@ -139,19 +138,19 @@ private:
 	DECLARE_WRITE8_MEMBER(es8712_reset_w);
 	DECLARE_WRITE_LINE_MEMBER(vmetal_es8712_irq);
 
-	TILE_GET_INFO_MEMBER(metro_k053936_get_tile_info);
-	TILE_GET_INFO_MEMBER(metro_k053936_gstrik2_get_tile_info);
+	TILE_GET_INFO_MEMBER(k053936_get_tile_info);
+	TILE_GET_INFO_MEMBER(k053936_gstrik2_get_tile_info);
 	TILEMAP_MAPPER_MEMBER(tilemap_scan_gstrik2);
 	DECLARE_VIDEO_START(blzntrnd);
 	DECLARE_VIDEO_START(gstrik2);
 	uint32_t screen_update_psac_vdp2_mix(screen_device &screen, bitmap_ind16 &bitmap, const rectangle &cliprect);
-	DECLARE_WRITE_LINE_MEMBER(metro_vblank_irq);
-	INTERRUPT_GEN_MEMBER(metro_periodic_interrupt);
+	DECLARE_WRITE_LINE_MEMBER(vblank_irq);
+	INTERRUPT_GEN_MEMBER(periodic_interrupt);
 	TIMER_DEVICE_CALLBACK_MEMBER(bangball_scanline);
 	DECLARE_WRITE_LINE_MEMBER(karatour_vblank_irq);
 	DECLARE_WRITE_LINE_MEMBER(puzzlet_vblank_irq);
-	IRQ_CALLBACK_MEMBER(metro_irq_callback);
-	DECLARE_READ_LINE_MEMBER(metro_rxd_r);
+	IRQ_CALLBACK_MEMBER(irq_callback);
+	DECLARE_READ_LINE_MEMBER(rxd_r);
 
 	void balcube_map(address_map &map);
 	void bangball_map(address_map &map);
@@ -170,7 +169,7 @@ private:
 	void kokushi_map(address_map &map);
 	void lastforg_map(address_map &map);
 	void lastfort_map(address_map &map);
-	void metro_sound_map(address_map &map);
+	void upd7810_map(address_map &map);
 	void mouja_map(address_map &map);
 	void mouja_okimap(address_map &map);
 	void msgogo_map(address_map &map);
@@ -199,7 +198,7 @@ private:
 
 	optional_device<k053936_device> m_k053936;
 	optional_device<eeprom_serial_93cxx_device> m_eeprom;
-	required_device<gfxdecode_device> m_gfxdecode;
+	optional_device<gfxdecode_device> m_gfxdecode;
 	required_device<screen_device> m_screen;
 	optional_device<generic_latch_8_device> m_soundlatch;
 

--- a/src/mame/video/metro.cpp
+++ b/src/mame/video/metro.cpp
@@ -10,27 +10,27 @@
 #include "emu.h"
 #include "includes/metro.h"
 
-TILE_GET_INFO_MEMBER(metro_state::metro_k053936_get_tile_info)
+TILE_GET_INFO_MEMBER(metro_state::k053936_get_tile_info)
 {
 	int code = m_k053936_ram[tile_index];
 
-	SET_TILE_INFO_MEMBER(4,
+	SET_TILE_INFO_MEMBER(0,
 			code & 0x7fff,
 			0xe,
 			0);
 }
 
-TILE_GET_INFO_MEMBER(metro_state::metro_k053936_gstrik2_get_tile_info)
+TILE_GET_INFO_MEMBER(metro_state::k053936_gstrik2_get_tile_info)
 {
 	int code = m_k053936_ram[tile_index];
 
-	SET_TILE_INFO_MEMBER(4,
+	SET_TILE_INFO_MEMBER(0,
 			(code & 0x7fff)>>2,
 			0xe,
 			0);
 }
 
-WRITE16_MEMBER(metro_state::metro_k053936_w)
+WRITE16_MEMBER(metro_state::k053936_w)
 {
 	COMBINE_DATA(&m_k053936_ram[offset]);
 	m_k053936_tilemap->mark_tile_dirty(offset);
@@ -39,26 +39,19 @@ WRITE16_MEMBER(metro_state::metro_k053936_w)
 TILEMAP_MAPPER_MEMBER(metro_state::tilemap_scan_gstrik2)
 {
 	/* logical (col,row) -> memory offset */
-	int val;
-
-	val = (row & 0x3f) * (256 * 2) + (col * 2);
-
-	if (row & 0x40) val += 1;
-	if (row & 0x80) val += 256;
-
-	return val;
+	return ((row & 0x40) >> 6) | (col << 1) | ((row & 0x80) << 1) | ((row & 0x3f) << 9);
 }
 
 VIDEO_START_MEMBER(metro_state,blzntrnd)
 {
-	m_k053936_tilemap = &machine().tilemap().create(*m_gfxdecode, tilemap_get_info_delegate(FUNC(metro_state::metro_k053936_get_tile_info),this), TILEMAP_SCAN_ROWS, 8, 8, 256, 512);
+	m_k053936_tilemap = &machine().tilemap().create(*m_gfxdecode, tilemap_get_info_delegate(FUNC(metro_state::k053936_get_tile_info),this), TILEMAP_SCAN_ROWS, 8, 8, 256, 512);
 
 	m_screen->register_screen_bitmap(m_vdp_bitmap);
 }
 
 VIDEO_START_MEMBER(metro_state,gstrik2)
 {
-	m_k053936_tilemap = &machine().tilemap().create(*m_gfxdecode, tilemap_get_info_delegate(FUNC(metro_state::metro_k053936_gstrik2_get_tile_info),this), tilemap_mapper_delegate(FUNC(metro_state::tilemap_scan_gstrik2),this), 16, 16, 128, 256);
+	m_k053936_tilemap = &machine().tilemap().create(*m_gfxdecode, tilemap_get_info_delegate(FUNC(metro_state::k053936_gstrik2_get_tile_info),this), tilemap_mapper_delegate(FUNC(metro_state::tilemap_scan_gstrik2),this), 16, 16, 128, 256);
 
 	m_screen->register_screen_bitmap(m_vdp_bitmap);
 }


### PR DESCRIPTION
Add support for buffered sprites, Cleanup sprite drawing routine, Internalize gfxdecode(All driver shared same gfxdecodes)
hyprduel.cpp : Cleanup ACCESSING_BITS
metro.cpp : Fix namings, Cleanup ACCESSING_BITS, Duplicates, Unnecessary address_space arguments, Fix sprite lags for blzntrnd/gstrik2, Fix metadata(Japanese title) for karatourj, Add notes