### PR TITLE
pc9801_86.cpp: fix PSG regression

### DIFF
--- a/src/devices/bus/cbus/pc9801_86.cpp
+++ b/src/devices/bus/cbus/pc9801_86.cpp
@@ -52,6 +52,7 @@ MACHINE_CONFIG_START(pc9801_86_device::pc9801_86_config)
 	SPEAKER(config, "rspeaker").front_right();
 	YM2608(config, m_opna, 7.987_MHz_XTAL);
 	m_opna->irq_handler().set(FUNC(pc9801_86_device::sound_irq));
+	m_opna->set_flags(AY8910_SINGLE_OUTPUT);
 	m_opna->port_a_read_callback().set(FUNC(pc9801_86_device::opn_porta_r));
 	//m_opna->port_b_read_callback().set(FUNC(pc8801_state::opn_portb_r));
 	//m_opna->port_a_write_callback().set(FUNC(pc8801_state::opn_porta_w));
@@ -396,6 +397,7 @@ void pc9801_speakboard_device::device_add_mconfig(machine_config &config)
 	m_opna->add_route(2, "rspeaker", 0.50);
 
 	YM2608(config, m_opna_slave, 7.987_MHz_XTAL);
+	m_opna_slave->set_flags(AY8910_SINGLE_OUTPUT);
 	m_opna_slave->add_route(0, "lspeaker", 0.50);
 	m_opna_slave->add_route(0, "rspeaker", 0.50);
 	m_opna_slave->add_route(1, "lspeaker", 0.50);


### PR DESCRIPTION
This change fixes a regression introduced with the MCFG removal (commit cc59e2123eaa5e6c5c71317d28b55f425bb6a333) that caused the PSG part of the YM2608 to sound extremely loud compared to the rest of the channels.