### PR TITLE
debugger: add %c to logerror

### DIFF
--- a/src/emu/debug/debugcmd.cpp
+++ b/src/emu/debug/debugcmd.cpp
@@ -657,6 +657,18 @@ int debugger_commands::mini_printf(char *buffer, const char *format, int params,
 					param++;
 					params--;
 					break;
+				case 'C':
+				case 'c':
+					if (params == 0)
+					{
+						m_console.printf("Not enough parameters for format!\n");
+						return 0;
+					}
+					p += sprintf(p, "%c", char(*param));
+					param++;
+					params--;
+					break;
+
 			}
 		}
 


### PR DESCRIPTION
This is useful for catching putchar() like functions and printing
the written value to error.log.

On hp9k_3xx, i'm using this with the HP 300 test software, to log
test error messages that get printed on screen to error.log, so i
have the message directly after the debug messages from my driver.

Example:

wpset 0xfffe36be,80,w,1,{ logerror "%c", wpdata; g }