### PR TITLE
XaviX - cheap hack to get epo_efdx to show a title screen + dumps of the remaining US e-kara carts

### DIFF
--- a/hash/ekara.xml
+++ b/hash/ekara.xml
@@ -400,7 +400,7 @@
 	-->
 	<software name="us_vol7">
 		<description>e-kara US Volume 7 (US-E007)</description>
-		<year>2000</year>
+		<year>2002</year>
 		<publisher>Takara</publisher>
 		<part name="cart" interface="ekara_cart">
 			<dataarea name="rom" size="0x100000">

--- a/hash/ekara.xml
+++ b/hash/ekara.xml
@@ -262,7 +262,7 @@
 	-->
 	<software name="us_vol1">
 		<description>e-kara US Volume 1 (US-E001)</description>
-		<year>2000</year>
+		<year>2001</year> <!-- 2000 shown on screen, 2001 on cart -->
 		<publisher>Takara</publisher>
 		<part name="cart" interface="ekara_cart">
 			<dataarea name="rom" size="0x100000">
@@ -285,7 +285,7 @@
 	-->
 	<software name="us_vol2">
 		<description>e-kara US Volume 2 (US-E002)</description>
-		<year>2000</year>
+		<year>2001</year> <!-- 2000 shown on screen, 2001 on cart -->
 		<publisher>Takara</publisher>
 		<part name="cart" interface="ekara_cart">
 			<dataarea name="rom" size="0x100000">
@@ -308,7 +308,7 @@
 	-->
 	<software name="us_vol3">
 		<description>e-kara US Volume 3 (US-E003)</description>
-		<year>2000</year>
+		<year>2001</year> <!-- 2000 shown on screen, 2001 on cart -->
 		<publisher>Takara</publisher>
 		<part name="cart" interface="ekara_cart">
 			<dataarea name="rom" size="0x100000">
@@ -331,7 +331,7 @@
 	-->
 	<software name="us_vol4">
 		<description>e-kara US Volume 4 (US-E004)</description>
-		<year>2000</year>
+		<year>2001</year> <!-- 2000 shown on screen, 2001 on cart -->
 		<publisher>Takara</publisher>
 		<part name="cart" interface="ekara_cart">
 			<dataarea name="rom" size="0x100000">
@@ -354,7 +354,7 @@
 	-->	
 	<software name="us_vol5">
 		<description>e-kara US Volume 5 (US-E005)</description>
-		<year>2000</year>
+		<year>2001</year> <!-- 2000 shown on screen, 2001 on cart -->
 		<publisher>Takara</publisher>
 		<part name="cart" interface="ekara_cart">
 			<dataarea name="rom" size="0x100000">
@@ -377,7 +377,7 @@
 	-->
 	<software name="us_vol6">
 		<description>e-kara US Volume 6 (US-E006)</description>
-		<year>2000</year>
+		<year>2001</year> <!-- 2000 shown on screen, 2001 on cart -->
 		<publisher>Takara</publisher>
 		<part name="cart" interface="ekara_cart">
 			<dataarea name="rom" size="0x100000">
@@ -400,7 +400,7 @@
 	-->
 	<software name="us_vol7">
 		<description>e-kara US Volume 7 (US-E007)</description>
-		<year>2002</year>
+		<year>2002</year> <!-- 2002 shown on screen, 2001 on cart -->
 		<publisher>Takara</publisher>
 		<part name="cart" interface="ekara_cart">
 			<dataarea name="rom" size="0x100000">
@@ -423,7 +423,7 @@
 	-->
 	<software name="us_vol8">
 		<description>e-kara US Volume 8 'No Boys Allowed' (US-E008)</description>
-		<year>2002</year>
+		<year>2002</year> <!-- 2002 shown on screen, 2001 on cart -->
 		<publisher>Takara</publisher>
 		<part name="cart" interface="ekara_cart">
 			<dataarea name="rom" size="0x100000">
@@ -446,7 +446,7 @@
 	-->	
 	<software name="us_vol9">
 		<description>e-kara US Volume 9 'No Boys Allowed' (US-E009)</description>
-		<year>2002</year>
+		<year>2002</year> <!-- 2002 shown on screen, 2001 on cart -->
 		<publisher>Takara</publisher>
 		<part name="cart" interface="ekara_cart">
 			<dataarea name="rom" size="0x100000">

--- a/hash/ekara.xml
+++ b/hash/ekara.xml
@@ -317,6 +317,98 @@
 		</part>
 	</software>		
 	
+	<!-- e-kara US Volume 4 (US-E004)
+	1.  "Can't Buy Me Love"   The Beatles
+	2.  "A Hard Day's Night"  The Beatles
+	3.  "Ticket To Ride"      The Beatles
+	4.  "Yesterday"           The Beatles
+	5.  "Help"                The Beatles
+	6.  "Michelle"            The Beatles
+	7.  "Yellow Submarine"    The Beatles
+	8.  "All My Loving"       The Beatles
+	9.  "Drive My Car"        The Beatles
+	10. "We Can Work It Out"  The Beatles
+	-->
+	<software name="us_vol4">
+		<description>e-kara US Volume 4 (US-E004)</description>
+		<year>2000</year>
+		<publisher>Takara</publisher>
+		<part name="cart" interface="ekara_cart">
+			<dataarea name="rom" size="0x100000">
+				<rom name="us-e004.u1" size="0x100000" crc="790822e9" sha1="cc5806fdc79f777a42980d6825c92837b07fd80d" offset="0" />
+			</dataarea>
+		</part>
+	</software>		
+
+	<!-- e-kara US Volume 5 (US-E005)
+	1.  "Lucy In the Sky With Diamonds"  The Beatles
+	2.  "All You Need Is Love"           The Beatles
+	3.  "Hello Goodbye"                  The Beatles
+	4.  "Hey Jude"                       The Beatles
+	5.  "Ob-La-Di, Ob-La-Da"             The Beatles
+	6.  "Get Back"                       The Beatles
+	7.  "Come Together"                  The Beatles
+	8.  "Oh! Darling"                    The Beatles
+	9.  "Let It Be"                      The Beatles
+	10. "The Long And Winding Road"      The Beatles
+	-->	
+	<software name="us_vol5">
+		<description>e-kara US Volume 5 (US-E005)</description>
+		<year>2000</year>
+		<publisher>Takara</publisher>
+		<part name="cart" interface="ekara_cart">
+			<dataarea name="rom" size="0x100000">
+				<rom name="us-e005.u1" size="0x100000" crc="edf1e4ce" sha1="7e5e3116f62897ae023c84842036f24b19c926cc" offset="0" />
+			</dataarea>
+		</part>
+	</software>		
+	
+	<!-- e-kara US Volume 6 (US-E006)
+	1.  "Survivor (Album Version)"             Destiny's Child
+	2.  "Jumpin', Jumpin'"                     Destiny's Child
+	3.  "I Turn To You"                        Christina Aguilera
+    4.  "As Long As You're Loving Me"          Vitamin C
+	5.  "Body II Body"                         Samantha Mumba
+	6.  "Love Don't Cost a Thing"              Jennifer Lopez
+	7.  "Again"                                Janet Jackson
+    8.  "If I Fall You're Going Down With Me"  Dixie Chicks
+	9.  "Can't Fight The Moonlight"            LeAnn Rimes
+	10. "American Pie (Album Version)"         Madonna 
+	-->
+	<software name="us_vol6">
+		<description>e-kara US Volume 6 (US-E006)</description>
+		<year>2000</year>
+		<publisher>Takara</publisher>
+		<part name="cart" interface="ekara_cart">
+			<dataarea name="rom" size="0x100000">
+				<rom name="us-e006.u1" size="0x100000" crc="e9aaca2f" sha1="983086f068ee38b970c01d2304e757148474aee3" offset="0" />
+			</dataarea>
+		</part>
+	</software>			
+	
+	<!-- e-kara US Volume 7 (US-E007)
+	1.  "Show Me The Meaning of Being Lonely"  Backstreet Boys
+	2.  "Lucky"                                Britney Spears
+	3.  "When It's Over"                       Sugar Ray
+	4.  "Bootylicious"                         Destiny's Child
+	5.  "Nobody Wants to be Lonely"            Ricky Martin & Christina Aguilera
+	6.  "Breathe"                              Faith Hill
+	7.  "It's Gonna Be Me"                     *N Sync
+	8.  "Don't Think I'm Not"                  Kandi
+    9.  "Lady Marmalade"                       Christina Aguilera, Lik'Kim, Mya & Pink
+    10. "God Bless The U.S.A."                 Lee Greenwood 
+	-->
+	<software name="us_vol7">
+		<description>e-kara US Volume 7 (US-E007)</description>
+		<year>2000</year>
+		<publisher>Takara</publisher>
+		<part name="cart" interface="ekara_cart">
+			<dataarea name="rom" size="0x100000">
+				<rom name="us-e007.u1" size="0x100000" crc="b7f5ca53" sha1="84af6d96512de96dbab03c236b3416b2e604f753" offset="0" />
+			</dataarea>
+		</part>
+	</software>		
+	
 	<!-- e-kara US Volume 8 'No Boys Allowed' (US-E008)
 	1.  "I'm A Slave 4 U"           Britney Spears
 	2.  "Stronger"                  Britney Spears

--- a/src/mame/audio/xavix.cpp
+++ b/src/mame/audio/xavix.cpp
@@ -4,7 +4,7 @@
 #include "emu.h"
 #include "includes/xavix.h"
 
-#define VERBOSE 1
+// #define VERBOSE 1
 #include "logmacro.h"
 
 // 16 stereo voices?

--- a/src/mame/drivers/xavix.cpp
+++ b/src/mame/drivers/xavix.cpp
@@ -1076,13 +1076,13 @@ ROM_END
 
 /* XaviX hardware titles */
 
-CONS( 2006, taitons1,  0,          0,  xavix_i2c_24lc04,  namcons2, xavix_i2c_state, init_xavix,    "Bandai / SSD Company LTD / Taito", "Let's! TV Play Classic - Taito Nostalgia 1", MACHINE_NOT_WORKING | MACHINE_IMPERFECT_GRAPHICS | MACHINE_NO_SOUND )
+CONS( 2006, taitons1,  0,          0,  xavix_i2c_24lc04,  namcons2, xavix_i2c_state, init_xavix,    "Bandai / SSD Company LTD / Taito", "Let's! TV Play Classic - Taito Nostalgia 1 (Japan)", MACHINE_NOT_WORKING | MACHINE_IMPERFECT_GRAPHICS | MACHINE_NO_SOUND )
 
-CONS( 2006, taitons2,  0,          0,  xavix_i2c_24lc04,  namcons2, xavix_i2c_state, init_xavix,    "Bandai / SSD Company LTD / Taito", "Let's! TV Play Classic - Taito Nostalgia 2", MACHINE_NOT_WORKING | MACHINE_IMPERFECT_GRAPHICS | MACHINE_NO_SOUND )
+CONS( 2006, taitons2,  0,          0,  xavix_i2c_24lc04,  namcons2, xavix_i2c_state, init_xavix,    "Bandai / SSD Company LTD / Taito", "Let's! TV Play Classic - Taito Nostalgia 2 (Japan)", MACHINE_NOT_WORKING | MACHINE_IMPERFECT_GRAPHICS | MACHINE_NO_SOUND )
 
-CONS( 2006, namcons1,  0,          0,  xavix_i2c_24lc04,  namcons2, xavix_i2c_state, init_xavix,    "Bandai / SSD Company LTD / Namco", "Let's! TV Play Classic - Namco Nostalgia 1", MACHINE_NOT_WORKING | MACHINE_IMPERFECT_GRAPHICS | MACHINE_NO_SOUND )
+CONS( 2006, namcons1,  0,          0,  xavix_i2c_24lc04,  namcons2, xavix_i2c_state, init_xavix,    "Bandai / SSD Company LTD / Namco", "Let's! TV Play Classic - Namco Nostalgia 1 (Japan)", MACHINE_NOT_WORKING | MACHINE_IMPERFECT_GRAPHICS | MACHINE_NO_SOUND )
 
-CONS( 2006, namcons2,  0,          0,  xavix_i2c_24lc04,  namcons2, xavix_i2c_state, init_xavix,    "Bandai / SSD Company LTD / Namco", "Let's! TV Play Classic - Namco Nostalgia 2", MACHINE_NOT_WORKING | MACHINE_IMPERFECT_GRAPHICS | MACHINE_NO_SOUND )
+CONS( 2006, namcons2,  0,          0,  xavix_i2c_24lc04,  namcons2, xavix_i2c_state, init_xavix,    "Bandai / SSD Company LTD / Namco", "Let's! TV Play Classic - Namco Nostalgia 2 (Japan)", MACHINE_NOT_WORKING | MACHINE_IMPERFECT_GRAPHICS | MACHINE_NO_SOUND )
 
 CONS( 2000, rad_ping,  0,          0,  xavix,  rad_ping, xavix_state, init_xavix,    "Radica / SSD Company LTD / Simmer Technology", "Play TV Ping Pong (NTSC)", MACHINE_NOT_WORKING | MACHINE_IMPERFECT_GRAPHICS | MACHINE_NO_SOUND ) // "Simmer Technology" is also known as "Hummer Technology Co., Ltd"
 CONS( 2000, rad_pingp, rad_ping,   0,  xavixp, rad_pingp,xavix_state, init_xavix,    "Radica / SSD Company LTD / Simmer Technology", "ConnecTV Table Tennis (PAL)", MACHINE_NOT_WORKING | MACHINE_IMPERFECT_GRAPHICS | MACHINE_NO_SOUND )
@@ -1096,7 +1096,7 @@ CONS( 200?, rad_boxp,  rad_box,    0,  xavixp, rad_boxp, xavix_state, init_xavix
 CONS( 200?, rad_crdn,  0,          0,  xavix,  rad_crdn, xavix_state, init_xavix,    "Radica / SSD Company LTD",                     "Play TV Card Night (NTSC)", MACHINE_NOT_WORKING | MACHINE_IMPERFECT_GRAPHICS | MACHINE_NO_SOUND)
 CONS( 200?, rad_crdnp, rad_crdn,   0,  xavixp, rad_crdnp,xavix_state, init_xavix,    "Radica / SSD Company LTD",                     "ConnecTV Card Night (PAL)", MACHINE_NOT_WORKING | MACHINE_IMPERFECT_GRAPHICS | MACHINE_NO_SOUND)
 
-CONS( 2002, rad_bb2,   0,          0,  xavix,  rad_bb2,  xavix_state, init_xavix,    "Radica / SSD Company LTD",                     "Play TV Baseball 2", MACHINE_NOT_WORKING | MACHINE_IMPERFECT_GRAPHICS | MACHINE_NO_SOUND ) // contains string "Radica RBB2 V1.0"
+CONS( 2002, rad_bb2,   0,          0,  xavix,  rad_bb2,  xavix_state, init_xavix,    "Radica / SSD Company LTD",                     "Play TV Baseball 2 (NTSC)", MACHINE_NOT_WORKING | MACHINE_IMPERFECT_GRAPHICS | MACHINE_NO_SOUND ) // contains string "Radica RBB2 V1.0"
 
 CONS( 2001, rad_bass,  0,          0,  xavix,  rad_bass, xavix_state, init_xavix,    "Radica / SSD Company LTD",                     "Play TV Bass Fishin' (NTSC)", MACHINE_NOT_WORKING | MACHINE_IMPERFECT_GRAPHICS | MACHINE_NO_SOUND)
 CONS( 2001, rad_bassp, rad_bass,   0,  xavixp, rad_bassp,xavix_state, init_xavix,    "Radica / SSD Company LTD",                     "ConnecTV Bass Fishin' (PAL)", MACHINE_NOT_WORKING | MACHINE_IMPERFECT_GRAPHICS | MACHINE_NO_SOUND)
@@ -1109,13 +1109,13 @@ CONS( 2003, rad_madf,  0,          0,  xavix_madfb,  rad_fb,    xavix_madfb_stat
 
 CONS( 200?, rad_fb,    0,          0,  xavix_madfb,  rad_fb,    xavix_madfb_state, init_xavix,    "Radica / SSD Company LTD",                     "Play TV Football (NTSC)", MACHINE_NOT_WORKING | MACHINE_IMPERFECT_GRAPHICS | MACHINE_NO_SOUND) // USA only release? doesn't change logo for PAL.
 
-CONS( 200?, rad_rh,    0,          0,  xavix,  rad_rh,   xavix_state, init_xavix,    "Radioa / Fisher-Price / SSD Company LTD",      "Play TV Rescue Heroes", MACHINE_NOT_WORKING | MACHINE_IMPERFECT_GRAPHICS | MACHINE_NO_SOUND)
+CONS( 200?, rad_rh,    0,          0,  xavix,  rad_rh,   xavix_state, init_xavix,    "Radioa / Fisher-Price / SSD Company LTD",      "Play TV Rescue Heroes (NTSC)", MACHINE_NOT_WORKING | MACHINE_IMPERFECT_GRAPHICS | MACHINE_NO_SOUND)
 
-CONS( 200?, epo_efdx,  0,          0,  xavix_i2c_24c08,  xavix,    xavix_i2c_state, init_xavix,    "Epoch / SSD Company LTD",                      "Excite Fishing DX (Japan)", MACHINE_NOT_WORKING | MACHINE_IMPERFECT_GRAPHICS | MACHINE_NO_SOUND)
+CONS( 200?, epo_efdx,  0,          0,  xavix_i2c_24c08,  xavix,    xavix_i2c_state, init_epo_efdx,    "Epoch / SSD Company LTD",                      "Excite Fishing DX (Japan)", MACHINE_NOT_WORKING | MACHINE_IMPERFECT_GRAPHICS | MACHINE_NO_SOUND)
 
-CONS( 200?, has_wamg,  0,          0,  xavix,  xavix,    xavix_state, init_xavix,    "Hasbro / Milton Bradley / SSD Company LTD",    "TV Wild Adventure Mini Golf", MACHINE_NOT_WORKING | MACHINE_IMPERFECT_GRAPHICS | MACHINE_NO_SOUND)
+CONS( 200?, has_wamg,  0,          0,  xavix,  xavix,    xavix_state, init_xavix,    "Hasbro / Milton Bradley / SSD Company LTD",    "TV Wild Adventure Mini Golf (NTSC)", MACHINE_NOT_WORKING | MACHINE_IMPERFECT_GRAPHICS | MACHINE_NO_SOUND)
 
-CONS( 200?, ekara,    0,          0,  xavix_ekara,  ekara,    xavix_ekara_state, init_xavix,    "Takara / Hasbro / SSD Company LTD",   "e-kara (US?)", MACHINE_NOT_WORKING | MACHINE_IMPERFECT_GRAPHICS | MACHINE_NO_SOUND|MACHINE_IS_BIOS_ROOT)
+CONS( 200?, ekara,    0,          0,  xavix_ekara,  ekara,    xavix_ekara_state, init_xavix,    "Takara / Hasbro / SSD Company LTD",   "e-kara (NTSC)", MACHINE_NOT_WORKING | MACHINE_IMPERFECT_GRAPHICS | MACHINE_NO_SOUND|MACHINE_IS_BIOS_ROOT)
 
 /* SuperXaviX hardware titles */
 

--- a/src/mame/includes/xavix.h
+++ b/src/mame/includes/xavix.h
@@ -68,8 +68,8 @@ public:
 		: driver_device(mconfig, type, tag),
 		m_in0(*this, "IN0"),
 		m_in1(*this, "IN1"),
-		m_sprite_xhigh_ignore_hack(true),
 		m_maincpu(*this, "maincpu"),
+		m_sprite_xhigh_ignore_hack(true),
 		m_screen(*this, "screen"),
 		m_mainram(*this, "mainram"),
 		m_fragment_sprite(*this, "fragment_sprite"),
@@ -113,6 +113,7 @@ protected:
 	virtual void write_io1(uint8_t data, uint8_t direction);
 	required_ioport m_in0;
 	required_ioport m_in1;
+	required_device<xavix_device> m_maincpu;
 
 private:
 
@@ -405,7 +406,6 @@ private:
 	DECLARE_READ8_MEMBER(mult_param_r);
 	DECLARE_WRITE8_MEMBER(mult_param_w);
 
-	required_device<xavix_device> m_maincpu;
 	required_device<screen_device> m_screen;
 	
 	void update_irqs();
@@ -514,7 +514,9 @@ class xavix_i2c_state : public xavix_state
 public:
 	xavix_i2c_state(const machine_config &mconfig, device_type type, const char *tag)
 		: xavix_state(mconfig, type, tag),
-		m_i2cmem(*this, "i2cmem")
+		m_i2cmem(*this, "i2cmem"),
+		hackaddress1(-1),
+		hackaddress2(-1)
 	{ }
 
 	void xavix_i2c_24lc04(machine_config &config);
@@ -523,11 +525,21 @@ public:
 	void xavix2000_i2c_24c04(machine_config &config);
 	void xavix2000_i2c_24c02(machine_config &config);
 
+	void init_epo_efdx()
+	{
+		init_xavix();
+		hackaddress1 = 0x958a;
+		hackaddress2 = 0x8524;
+	}
 protected:
 	virtual uint8_t read_io1(uint8_t direction) override;
 	virtual void write_io1(uint8_t data, uint8_t direction) override;
 
 	required_device<i2cmem_device> m_i2cmem;
+
+private:
+	int hackaddress1;
+	int hackaddress2;
 };
 
 class xavix_i2c_lotr_state : public xavix_i2c_state

--- a/src/mame/machine/xavix.cpp
+++ b/src/mame/machine/xavix.cpp
@@ -410,6 +410,13 @@ uint8_t xavix_i2c_state::read_io1(uint8_t direction)
 
 void xavix_i2c_state::write_io1(uint8_t data, uint8_t direction)
 {
+	// ignore these writes so that epo_edfx can send read requests to the ee-prom and doesn't just report an error
+	// TODO: check if these writes shouldn't be happening (the first is a direct write, the 2nd is from a port direction change)
+	//  or if the i2cmem code is oversensitive, or if something else is missing to reset the state
+	if (hackaddress1 != -1)
+		if ((m_maincpu->pc() == hackaddress1) || (m_maincpu->pc() == hackaddress2))
+			return;
+
 	if (direction & 0x08)
 	{
 		m_i2cmem->write_sda((data & 0x08) >> 3);


### PR DESCRIPTION
hopefully this makes it easier for me to trace why the i2cmem hookup fails, and if it's due to code execution problems causing the unwanted writes, if the device should be less sensitive to them, or if there's an error in the driver hookup.

still not entirely sure the game is happy with what it gets this way, but it's something to work with.