### PR TITLE
disable Hyperstone DRC across the board

### DIFF
--- a/src/mame/drivers/dgpix.cpp
+++ b/src/mame/drivers/dgpix.cpp
@@ -434,6 +434,7 @@ MACHINE_CONFIG_START(dgpix_state::dgpix)
 	MCFG_DEVICE_ADD("maincpu", E132XT, 20000000*4) /* 4x internal multiplier */
 	MCFG_DEVICE_PROGRAM_MAP(cpu_map)
 	MCFG_DEVICE_IO_MAP(io_map)
+	MCFG_CPU_FORCE_NO_DRC() // DRC FIXME: causes hangs after just over half an hour
 
 /*
     unknown 16bit sound cpu, embedded inside the KS0164 sound chip

--- a/src/mame/drivers/eolith.cpp
+++ b/src/mame/drivers/eolith.cpp
@@ -540,6 +540,8 @@ INPUT_PORTS_END
 MACHINE_CONFIG_START(eolith_state::eolith45)
 	MCFG_DEVICE_ADD("maincpu", E132N, 45000000)         /* 45 MHz */
 	MCFG_DEVICE_PROGRAM_MAP(eolith_map)
+	MCFG_CPU_FORCE_NO_DRC() // DRC FIXME: causes hangs after just over half an hour, causes service mode to be black screen in landbrk + clones.
+
 	MCFG_TIMER_DRIVER_ADD_SCANLINE("scantimer", eolith_state, eolith_speedup, "screen", 0, 1)
 
 	/* Sound CPU */

--- a/src/mame/drivers/eolith16.cpp
+++ b/src/mame/drivers/eolith16.cpp
@@ -162,6 +162,8 @@ PALETTE_INIT_MEMBER(eolith16_state,eolith16)
 MACHINE_CONFIG_START(eolith16_state::eolith16)
 	MCFG_DEVICE_ADD("maincpu", E116T, XTAL(60'000'000))        /* no internal multiplier */
 	MCFG_DEVICE_PROGRAM_MAP(eolith16_map)
+	MCFG_CPU_FORCE_NO_DRC() // DRC FIXME: causes hangs after just over half an hour
+
 	MCFG_TIMER_DRIVER_ADD_SCANLINE("scantimer", eolith16_state, eolith_speedup, "screen", 0, 1)
 
 	EEPROM_93C66_8BIT(config, "eeprom");

--- a/src/mame/drivers/f-32.cpp
+++ b/src/mame/drivers/f-32.cpp
@@ -174,6 +174,7 @@ MACHINE_CONFIG_START(mosaicf2_state::mosaicf2)
 	MCFG_DEVICE_PROGRAM_MAP(common_map)
 	MCFG_DEVICE_IO_MAP(mosaicf2_io)
 	MCFG_DEVICE_VBLANK_INT_DRIVER("screen", mosaicf2_state,  irq0_line_hold)
+	MCFG_CPU_FORCE_NO_DRC() // DRC FIXME: causes hangs after just over half an hour
 
 	EEPROM_93C46_16BIT(config, "eeprom")
 		.erase_time(attotime::from_usec(1))
@@ -253,6 +254,7 @@ MACHINE_CONFIG_START(mosaicf2_state::royalpk2)
 	MCFG_DEVICE_PROGRAM_MAP(royalpk2_map)
 	MCFG_DEVICE_IO_MAP(royalpk2_io)
 	MCFG_DEVICE_VBLANK_INT_DRIVER("screen", mosaicf2_state,  irq1_line_hold)
+	MCFG_CPU_FORCE_NO_DRC() // DRC FIXME: causes hangs after just over half an hour
 
 	EEPROM_93C46_16BIT(config, "eeprom")
 		.erase_time(attotime::from_usec(1))

--- a/src/mame/drivers/gstream.cpp
+++ b/src/mame/drivers/gstream.cpp
@@ -835,6 +835,7 @@ MACHINE_CONFIG_START(gstream_state::gstream)
 	MCFG_DEVICE_PROGRAM_MAP(gstream_32bit_map)
 	MCFG_DEVICE_IO_MAP(gstream_io)
 	MCFG_DEVICE_VBLANK_INT_DRIVER("screen", gstream_state,  irq0_line_hold)
+	MCFG_CPU_FORCE_NO_DRC() // DRC FIXME: causes hangs after just over half an hour
 
 
 	NVRAM(config, "nvram", nvram_device::DEFAULT_ALL_1);
@@ -868,6 +869,7 @@ MACHINE_CONFIG_START(gstream_state::x2222)
 	MCFG_DEVICE_PROGRAM_MAP(x2222_32bit_map)
 	MCFG_DEVICE_IO_MAP(x2222_io)
 	MCFG_DEVICE_VBLANK_INT_DRIVER("screen", gstream_state,  irq0_line_hold)
+	MCFG_CPU_FORCE_NO_DRC() // DRC FIXME: causes hangs after just over half an hour
 
 //  NVRAM(config, "nvram", nvram_device::DEFAULT_ALL_1);
 

--- a/src/mame/drivers/limenko.cpp
+++ b/src/mame/drivers/limenko.cpp
@@ -710,6 +710,7 @@ MACHINE_CONFIG_START(limenko_state::limenko)
 	MCFG_DEVICE_PROGRAM_MAP(limenko_map)
 	MCFG_DEVICE_IO_MAP(limenko_io_map)
 	MCFG_DEVICE_VBLANK_INT_DRIVER("screen", limenko_state,  irq0_line_hold)
+	MCFG_CPU_FORCE_NO_DRC() // DRC FIXME: causes hangs after just over half an hour
 
 	EEPROM_93C46_16BIT(config, "eeprom");
 
@@ -749,6 +750,7 @@ MACHINE_CONFIG_START(limenko_state::spotty)
 	MCFG_DEVICE_PROGRAM_MAP(spotty_map)
 	MCFG_DEVICE_IO_MAP(spotty_io_map)
 	MCFG_DEVICE_VBLANK_INT_DRIVER("screen", limenko_state,  irq0_line_hold)
+	MCFG_CPU_FORCE_NO_DRC() // DRC FIXME: causes hangs after just over half an hour
 
 	MCFG_DEVICE_ADD("audiocpu", AT89C4051, 4000000)    /* 4 MHz */
 	MCFG_MCS51_PORT_P1_IN_CB(READ8(*this, limenko_state, spotty_sound_r))

--- a/src/mame/drivers/mjsenpu.cpp
+++ b/src/mame/drivers/mjsenpu.cpp
@@ -470,6 +470,7 @@ MACHINE_CONFIG_START(mjsenpu_state::mjsenpu)
 	MCFG_DEVICE_PROGRAM_MAP(mjsenpu_32bit_map)
 	MCFG_DEVICE_IO_MAP(mjsenpu_io)
 	MCFG_DEVICE_VBLANK_INT_DRIVER("screen", mjsenpu_state,  irq0_line_hold)
+	MCFG_CPU_FORCE_NO_DRC() // DRC FIXME: causes hangs after just over half an hour
 
 	NVRAM(config, "nvram", nvram_device::DEFAULT_ALL_1);
 

--- a/src/mame/drivers/pasha2.cpp
+++ b/src/mame/drivers/pasha2.cpp
@@ -405,6 +405,7 @@ MACHINE_CONFIG_START(pasha2_state::pasha2)
 	MCFG_DEVICE_PROGRAM_MAP(pasha2_map)
 	MCFG_DEVICE_IO_MAP(pasha2_io)
 	MCFG_DEVICE_VBLANK_INT_DRIVER("screen", pasha2_state,  irq0_line_hold)
+	MCFG_CPU_FORCE_NO_DRC() // DRC FIXME: causes hangs after just over half an hour
 
 	MCFG_DEVICE_ADD("audiocpu", AT89C52, 12000000)     /* clock from docs */
 	/* TODO : ports are unimplemented; P0,P1,P2,P3 and Serial Port Used */

--- a/src/mame/drivers/vamphalf.cpp
+++ b/src/mame/drivers/vamphalf.cpp
@@ -1109,6 +1109,7 @@ MACHINE_CONFIG_START(vamphalf_state::common)
 	MCFG_DEVICE_ADD("maincpu", E116T, 50000000)    /* 50 MHz */
 	MCFG_DEVICE_PROGRAM_MAP(common_map)
 	MCFG_DEVICE_VBLANK_INT_DRIVER("screen", vamphalf_state,  irq1_line_hold)
+	MCFG_CPU_FORCE_NO_DRC() // DRC FIXME: causes hangs after just over half an hour
 
 	// various games require fast timing to save settings, probably because our Hyperstone core timings are incorrect
 	EEPROM_93C46_16BIT(config, "eeprom")
@@ -1189,6 +1190,7 @@ MACHINE_CONFIG_START(vamphalf_qdsp_state::misncrft)
 	MCFG_DEVICE_PROGRAM_MAP(common_map)
 	MCFG_DEVICE_IO_MAP(misncrft_io)
 	MCFG_DEVICE_VBLANK_INT_DRIVER("screen", vamphalf_state,  irq1_line_hold)
+	MCFG_CPU_FORCE_NO_DRC() // DRC FIXME: causes hangs after just over half an hour
 
 	sound_qs1000(config);
 MACHINE_CONFIG_END
@@ -1250,6 +1252,7 @@ MACHINE_CONFIG_START(vamphalf_state::mrdig)
 	MCFG_DEVICE_MODIFY("maincpu")
 	MCFG_DEVICE_IO_MAP(mrdig_io)
 	MCFG_DEVICE_VBLANK_INT_DRIVER("screen", vamphalf_state,  irq1_line_hold)
+	MCFG_CPU_FORCE_NO_DRC() // DRC FIXME: causes hangs after just over half an hour
 
 	sound_ym_oki(config);
 MACHINE_CONFIG_END
@@ -1260,6 +1263,8 @@ MACHINE_CONFIG_START(vamphalf_qdsp_state::wyvernwg)
 	MCFG_DEVICE_PROGRAM_MAP(common_32bit_map)
 	MCFG_DEVICE_IO_MAP(wyvernwg_io)
 	MCFG_DEVICE_VBLANK_INT_DRIVER("screen", vamphalf_state,  irq1_line_hold)
+	MCFG_CPU_FORCE_NO_DRC() // DRC FIXME: causes hangs after just over half an hour
+
 
 	sound_qs1000(config);
 MACHINE_CONFIG_END
@@ -1270,6 +1275,7 @@ MACHINE_CONFIG_START(vamphalf_nvram_state::finalgdr)
 	MCFG_DEVICE_PROGRAM_MAP(common_32bit_map)
 	MCFG_DEVICE_IO_MAP(finalgdr_io)
 	MCFG_DEVICE_VBLANK_INT_DRIVER("screen", vamphalf_state,  irq1_line_hold)
+	MCFG_CPU_FORCE_NO_DRC() // DRC FIXME: causes hangs after just over half an hour
 
 	NVRAM(config, "nvram", nvram_device::DEFAULT_ALL_0);
 
@@ -1282,6 +1288,7 @@ MACHINE_CONFIG_START(vamphalf_nvram_state::mrkickera)
 	MCFG_DEVICE_PROGRAM_MAP(common_32bit_map)
 	MCFG_DEVICE_IO_MAP(mrkickera_io)
 	MCFG_DEVICE_VBLANK_INT_DRIVER("screen", vamphalf_state,  irq1_line_hold)
+	MCFG_CPU_FORCE_NO_DRC() // DRC FIXME: causes hangs after just over half an hour
 
 	NVRAM(config, "nvram", nvram_device::DEFAULT_ALL_0);
 
@@ -1295,6 +1302,7 @@ MACHINE_CONFIG_START(vamphalf_state::aoh)
 	MCFG_DEVICE_PROGRAM_MAP(aoh_map)
 	MCFG_DEVICE_IO_MAP(aoh_io)
 	MCFG_DEVICE_VBLANK_INT_DRIVER("screen", vamphalf_state,  irq1_line_hold)
+	MCFG_CPU_FORCE_NO_DRC() // DRC FIXME: causes hangs after just over half an hour
 
 	EEPROM_93C46_16BIT(config, "eeprom");
 
@@ -1341,6 +1349,7 @@ MACHINE_CONFIG_START(vamphalf_qdsp_state::yorijori)
 	MCFG_DEVICE_PROGRAM_MAP(yorijori_32bit_map)
 	MCFG_DEVICE_IO_MAP(yorijori_io)
 	MCFG_DEVICE_VBLANK_INT_DRIVER("screen", vamphalf_state,  irq1_line_hold)
+	MCFG_CPU_FORCE_NO_DRC() // DRC FIXME: causes hangs after just over half an hour
 
 	sound_qs1000(config);
 MACHINE_CONFIG_END

--- a/src/mame/drivers/vamphalf.cpp
+++ b/src/mame/drivers/vamphalf.cpp
@@ -3567,7 +3567,7 @@ GAME( 1999, poosho,     0,        jmpbreak,  common,   vamphalf_state,      init
 
 GAME( 1999, newxpang,   0,        newxpang,  common,   vamphalf_state,      init_newxpang,  ROT0,   "F2 System",                     "New Cross Pang" , MACHINE_SUPPORTS_SAVE )
 
-GAME( 1999, worldadv,   0,        worldadv,  common,   vamphalf_state,      init_worldadv,  ROT0,   "Logic / F2 System",             "World Adventure" , MACHINE_SUPPORTS_SAVE )
+GAME( 1999, worldadv,   0,        worldadv,  common,   vamphalf_state,      init_worldadv,  ROT0,   "Logic / F2 System",             "World Adventure" , MACHINE_SUPPORTS_SAVE | MACHINE_NOT_WORKING ) // game starts to stall for several seconds at a time after it's been running for a certain amount of time, not DRC related
 
 GAME( 1999, suplup,     0,        suplup,    common,   vamphalf_state,      init_suplup,    ROT0,   "Omega System",                  "Super Lup Lup Puzzle / Zhuan Zhuan Puzzle (version 4.0 / 990518)" , MACHINE_SUPPORTS_SAVE )
 GAME( 1999, luplup,     suplup,   suplup,    common,   vamphalf_state,      init_luplup,    ROT0,   "Omega System",                  "Lup Lup Puzzle / Zhuan Zhuan Puzzle (version 3.0 / 990128)", MACHINE_SUPPORTS_SAVE )
@@ -3582,8 +3582,8 @@ GAME( 1999, vamphalfk,  vamphalf, vamphalf,  common,   vamphalf_state,      init
 
 GAME( 2000, dquizgo2,   0,        coolmini,  common,   vamphalf_state,      init_dquizgo2,  ROT0,   "SemiCom",                       "Date Quiz Go Go Episode 2" , MACHINE_SUPPORTS_SAVE )
 
-GAME( 2000, misncrft,   0,        misncrft,  common,   vamphalf_qdsp_state, init_misncrft,  ROT90,  "Sun",                           "Mission Craft (version 2.7)", MACHINE_IMPERFECT_SOUND | MACHINE_SUPPORTS_SAVE )
-GAME( 2000, misncrfta,  misncrft, misncrft,  common,   vamphalf_qdsp_state, init_misncrft,  ROT90,  "Sun",                           "Mission Craft (version 2.4)", MACHINE_IMPERFECT_SOUND | MACHINE_SUPPORTS_SAVE )
+GAME( 2000, misncrft,   0,        misncrft,  common,   vamphalf_qdsp_state, init_misncrft,  ROT90,  "Sun",                           "Mission Craft (version 2.7)", MACHINE_IMPERFECT_SOUND | MACHINE_SUPPORTS_SAVE | MACHINE_NOT_WORKING ) // game starts to stall for several seconds at a time after it's been running for a certain amount of time (you can usually complete 1 loop), not DRC related
+GAME( 2000, misncrfta,  misncrft, misncrft,  common,   vamphalf_qdsp_state, init_misncrft,  ROT90,  "Sun",                           "Mission Craft (version 2.4)", MACHINE_IMPERFECT_SOUND | MACHINE_SUPPORTS_SAVE | MACHINE_NOT_WORKING )
 
 GAME( 2000, mrdig,      0,        mrdig,     common,   vamphalf_state,      init_mrdig,     ROT0,   "Sun",                           "Mr. Dig", MACHINE_SUPPORTS_SAVE )
 
@@ -3596,9 +3596,9 @@ GAME( 2001, mrkickera,  mrkicker, mrkickera, finalgdr, vamphalf_nvram_state,init
 
 GAME( 2001, toyland,    0,        coolmini,  common,   vamphalf_state,      init_toyland,   ROT0,   "SemiCom",                       "Toy Land Adventure", MACHINE_SUPPORTS_SAVE )
 
-GAME( 2001, wivernwg,   0,        wyvernwg,  common,   vamphalf_qdsp_state, init_wyvernwg,  ROT270, "SemiCom",                       "Wivern Wings", MACHINE_IMPERFECT_SOUND | MACHINE_SUPPORTS_SAVE )
-GAME( 2001, wyvernwg,   wivernwg, wyvernwg,  common,   vamphalf_qdsp_state, init_wyvernwg,  ROT270, "SemiCom (Game Vision license)", "Wyvern Wings (set 1)", MACHINE_IMPERFECT_SOUND | MACHINE_SUPPORTS_SAVE )
-GAME( 2001, wyvernwga,  wivernwg, wyvernwg,  common,   vamphalf_qdsp_state, init_wyvernwg,  ROT270, "SemiCom (Game Vision license)", "Wyvern Wings (set 2)", MACHINE_IMPERFECT_SOUND | MACHINE_SUPPORTS_SAVE )
+GAME( 2001, wivernwg,   0,        wyvernwg,  common,   vamphalf_qdsp_state, init_wyvernwg,  ROT270, "SemiCom",                       "Wivern Wings", MACHINE_IMPERFECT_SOUND | MACHINE_SUPPORTS_SAVE | MACHINE_UNEMULATED_PROTECTION ) // gives a protection error after a certain number of plays / coins?
+GAME( 2001, wyvernwg,   wivernwg, wyvernwg,  common,   vamphalf_qdsp_state, init_wyvernwg,  ROT270, "SemiCom (Game Vision license)", "Wyvern Wings (set 1)", MACHINE_IMPERFECT_SOUND | MACHINE_SUPPORTS_SAVE | MACHINE_UNEMULATED_PROTECTION  )
+GAME( 2001, wyvernwga,  wivernwg, wyvernwg,  common,   vamphalf_qdsp_state, init_wyvernwg,  ROT270, "SemiCom (Game Vision license)", "Wyvern Wings (set 2)", MACHINE_IMPERFECT_SOUND | MACHINE_SUPPORTS_SAVE | MACHINE_UNEMULATED_PROTECTION  )
 
 GAME( 2001, aoh,        0,        aoh,       aoh,      vamphalf_state,      init_aoh,       ROT0,   "Unico",                         "Age Of Heroes - Silkroad 2 (v0.63 - 2001/02/07)", MACHINE_SUPPORTS_SAVE )
 

--- a/src/mame/drivers/vegaeo.cpp
+++ b/src/mame/drivers/vegaeo.cpp
@@ -176,6 +176,8 @@ uint32_t vegaeo_state::screen_update_vega(screen_device &screen, bitmap_ind16 &b
 MACHINE_CONFIG_START(vegaeo_state::vega)
 	MCFG_DEVICE_ADD("maincpu", GMS30C2132, XTAL(55'000'000))
 	MCFG_DEVICE_PROGRAM_MAP(vega_map)
+	MCFG_CPU_FORCE_NO_DRC() // DRC FIXME: causes hangs after just over half an hour
+
 	MCFG_TIMER_DRIVER_ADD_SCANLINE("scantimer", vegaeo_state, eolith_speedup, "screen", 0, 1)
 
 	MCFG_DEVICE_ADD("at28c16", AT28C16, 0)


### PR DESCRIPTION
I've put off creating this request for a while because I was hoping it would get fixed, however as it's been broken for most of the year, and is one of the largest regressions of the year I'm pushing this so that we don't end the year with a major regression still in play.

At this point I've had some rather irate reports for the majority of the Hyperstone drivers, the most recent report being LordBBH with Super Bubble 2003 in the middle of his MAME roulette stream.  Reports range from hanging after half an hour to around an hour in some cases so I'm going to assume it affects everything just within a different timeframe for some cases.  If there are any cases confirmed not to have issues they can be reenabled (hence disabling it per-driver)

This is the worst kind of bug for users because
a) It happens by default (there is an option to disable DRC from the commandline, but not obvious you'd need it until it's too late, and only then if you know the cause of the issue)
b) It happens after 30 mins to an hour, and at that point a user has invested significant time into a game, which was seemingly working fine and is not tagged as broken

https://mametesters.org/view.php?id=7005
https://mametesters.org/view.php?id=6985

In addition to this I've demoted World Adventure and Mission Craft as NOT WORKING as they have s similar, but not identical (although possible related) issue after a certain amount of time even with the non-DRC code (they don't hang outright, but start to run very slowly)  I've also tagged Wyvern Wings as unemulated protection because there's something that kicks in after a certain number of coins.  Neither of these is a regression, just correction of flags.