### PR TITLE
New driver : HP 3478A Digital Multimeter

### DIFF
--- a/scripts/target/mame/mess.lua
+++ b/scripts/target/mame/mess.lua
@@ -3757,6 +3757,7 @@ files {
 	MAME_DIR .. "src/mame/drivers/harriet.cpp",
 	MAME_DIR .. "src/mame/drivers/hazeltin.cpp",
 	MAME_DIR .. "src/mame/drivers/hazl1420.cpp",
+	MAME_DIR .. "src/mame/drivers/hp3478a.cpp",
 	MAME_DIR .. "src/mame/drivers/hprot1.cpp",
 	MAME_DIR .. "src/mame/drivers/hpz80unk.cpp",
 	MAME_DIR .. "src/mame/drivers/ht68k.cpp",

--- a/src/emu/xtal.cpp
+++ b/src/emu/xtal.cpp
@@ -110,6 +110,7 @@ const double XTAL::known_xtals[] = {
 	  5'626'000, /* 5.626_MHz_XTAL         RCA CDP1869 PAL dot clock */
 	  5'670'000, /* 5.67_MHz_XTAL          RCA CDP1869 NTSC dot clock */
 	  5'714'300, /* 5.7143_MHz_XTAL        Cidelsa Destroyer, TeleVideo serial keyboards */
+	  5'856'000, /* 5.856_MHz_XTAL         HP 3478A Multimeter */
 	  5'911'000, /* 5.911_MHz_XTAL         Philips Videopac Plus G7400 */
 	  5'990'400, /* 5.9904_MHz_XTAL        Luxor ABC 800 keyboard (Keytronic custom part #48-300-008 is equivalent) */
 	  6'000'000, /* 6_MHz_XTAL             American Poker II, Taito SJ System */

--- a/src/mame/drivers/hp3478a.cpp
+++ b/src/mame/drivers/hp3478a.cpp
@@ -10,15 +10,14 @@
 * Some of this will probably be applicable to HP 3468A units too.
 *
 * Current status : runs, AD LINK ERROR on stock ROM due to unimplemented AD link
-* - patching the AD comms, we get to a mostly functional state
+* - patching the AD comms, we get to a mostly functional state (for patch examples,
+*	see https://github.com/fenugrec/hp3478a_rompatch )
 * - pressing Shift+Sgl to force a 'test/reset' gets the firmware in an endless loop, not sure why.
 *
 *
 * TODO next level
-* * annunciators
-* * DIP switches
 * * do something for analog CPU serial link (not quite uart), or dump+emulate CPU
-* * better display render and layout (show button subtext)
+* * better display render and layout (annunciators + show button subtext)
 *
 * TODO level 9000
 * * Connect this with the existing i8291.cpp driver
@@ -152,13 +151,6 @@ WRITE8_MEMBER( hp3478a_state::p2write )
 	}
 
 	p2_oldstate = data;
-}
-
-
-READ8_MEMBER( hp3478a_state::dipread )
-{
-	logerror("dip read unimpl\n");
-	return 0;
 }
 
 
@@ -497,7 +489,7 @@ void hp3478a_state::io_bank(address_map &map)
 	map.unmap_value_high();
 	map(0x000, 0x0ff).ram().region("nvram", 0).share("nvram").w(FUNC(hp3478a_state::nvwrite));
 	map(0x100, 0x107).ram().share("gpibregs");	//XXX TODO : connect to i8291.cpp
-	map(0x200, 0x2ff).r(FUNC(hp3478a_state::dipread));
+	map(0x200, 0x2ff).portr("DIP");
 }
 
 
@@ -537,6 +529,48 @@ static INPUT_PORTS_START( hp3478a )
 	PORT_CONFNAME(1, 0, "CAL")
 	PORT_CONFSETTING(0x00, "disabled")
 	PORT_CONFSETTING(0x01, "enabled")
+
+	PORT_START("DIP")
+	PORT_DIPNAME( 0x1f, 0x17, "HP-IB Bus Address" ) PORT_DIPLOCATION("DIP:1,2,3,4,5")
+	PORT_DIPSETTING(    0x00, "0" )
+	PORT_DIPSETTING(    0x01, "1" )
+	PORT_DIPSETTING(    0x02, "2" )
+	PORT_DIPSETTING(    0x03, "3" )
+	PORT_DIPSETTING(    0x04, "4" )
+	PORT_DIPSETTING(    0x05, "5" )
+	PORT_DIPSETTING(    0x06, "6" )
+	PORT_DIPSETTING(    0x07, "7" )
+	PORT_DIPSETTING(    0x08, "8" )
+	PORT_DIPSETTING(    0x09, "9" )
+	PORT_DIPSETTING(    0x0a, "10" )
+	PORT_DIPSETTING(    0x0b, "11" )
+	PORT_DIPSETTING(    0x0c, "12" )
+	PORT_DIPSETTING(    0x0d, "13" )
+	PORT_DIPSETTING(    0x0e, "14" )
+	PORT_DIPSETTING(    0x0f, "15" )
+	PORT_DIPSETTING(    0x10, "16" )
+	PORT_DIPSETTING(    0x11, "17" )
+	PORT_DIPSETTING(    0x12, "18" )
+	PORT_DIPSETTING(    0x13, "19" )
+	PORT_DIPSETTING(    0x14, "20" )
+	PORT_DIPSETTING(    0x15, "21" )
+	PORT_DIPSETTING(    0x16, "22" )
+	PORT_DIPSETTING(    0x17, "23" )
+	PORT_DIPSETTING(    0x18, "24" )
+	PORT_DIPSETTING(    0x19, "25" )
+	PORT_DIPSETTING(    0x1a, "26" )
+	PORT_DIPSETTING(    0x1b, "27" )
+	PORT_DIPSETTING(    0x1c, "28" )
+	PORT_DIPSETTING(    0x1d, "29" )
+	PORT_DIPSETTING(    0x1e, "30" )
+	PORT_DIPSETTING(    0x1f, "31" )
+	PORT_DIPNAME( 0x20, 0x00, "PWR ON SRQ" ) PORT_DIPLOCATION("DIP:6")
+	PORT_DIPSETTING(    0x00, "Disabled" )
+	PORT_DIPSETTING(    0x20, "Enabled" )
+	//0x40 unused
+	PORT_DIPNAME( 0x80, 0x00, "50/60Hz AC" ) PORT_DIPLOCATION("DIP:8")
+	PORT_DIPSETTING(    0x00, "60Hz" )
+	PORT_DIPSETTING(    0x80, "50Hz" )
 
 INPUT_PORTS_END
 

--- a/src/mame/drivers/hp3478a.cpp
+++ b/src/mame/drivers/hp3478a.cpp
@@ -1,0 +1,119 @@
+// license:BSD-3-Clause
+// copyright-holders:fenugrec
+/******************************************************************************
+* HP 3478A Digital Multimeter
+*
+* Emulating test equipment is not very meaningful except for developping ROM patches.
+* This aims to be the minimal emulation sufficient to run the UI (keypad and display).
+* Ideally, faking ADC readings could be useful too.
+*
+* Some of this will probably be applicable to HP 3468A units too.
+*
+* Current status : hahahaaa
+*
+* the TODO list is longer than the code here
+*
+
+**** Hardware details (refer to service manual for schematics)
+Main CPU : i8039 , no internal ROM
+Analog (floating) CPU : i8049, internal ROM (never dumped ?)
+ROM : 2764 (64kbit, org 8kB) . Stores calibration data
+RAM : 5101 , 256 * 4bit
+GPIB:  i8291
+
+
+Main cpu I/O ports:
+Port1
+P14-P17 : keypad out (cols)
+P10-P13 : keypad in (rows)
+
+P20 : disp.clk1
+P21 : !CS for GPIB, and disp.IWA
+P22 : !CS for DIPswitch; disp.ISA (for instructions)
+P23 = !OE for RAM ; disp.sync (enable instruction)
+P24 = disp.PWO	(enable)
+P25 = disp.clk2
+
+P26 : address bit12 ! (0x1000) => hardware banking
+P27 : data out thru isol, to analog CPU
+T1 : data in thru isol (opcodes jt1 / jnt1)
+*/
+
+#include "emu.h"
+#include "includes/hp3478a.h"
+
+#include "cpu/mcs48/mcs48.h"
+
+#define CPU_CLOCK       XTAL(5'856'000)
+
+//XXX
+#undef DEBUG_FIFO
+#undef DEBUG_SERIAL_CB
+#undef DEBUG_PORTS
+
+WRITE8_MEMBER( hp3478a_state::port1_w )
+{
+#ifdef DEBUG_PORTS
+	logerror("port1 write: %02X\n", data);
+#endif
+}
+
+READ8_MEMBER( hp3478a_state::port1_r )
+{
+	uint8_t data = 0;
+#ifdef DEBUG_PORTS
+	logerror("port1 read: 0x%02X\n", data);
+#endif
+	return data;
+}
+
+void hp3478a_state::machine_start() {
+}
+
+/******************************************************************************
+ Address Maps
+******************************************************************************/
+
+void hp3478a_state::i8039_map(address_map &map)
+{
+	map(0x0000, 0x0fff).rom(); /* 27C64 ROM */
+	// AM_RANGE(0x2000, 0x3fff) AM_RAM /* 6164 8k SRAM, not populated */
+}
+
+void hp3478a_state::i8039_io(address_map &map)
+{
+	map.global_mask(0xff);
+//XXX	map(0x1, 0x1).rw(FUNC(hp3478a_state::port1_r), FUNC(hp3478a_state::port1_w)); /* tms5220 reads and writes */
+}
+
+/******************************************************************************
+ Input Ports
+******************************************************************************/
+static INPUT_PORTS_START( hp3478a )
+INPUT_PORTS_END
+
+/******************************************************************************
+ Machine Drivers
+******************************************************************************/
+MACHINE_CONFIG_START(hp3478a_state::hp3478a)
+	/* basic machine hardware */
+	MCFG_DEVICE_ADD("maincpu", I8039, CPU_CLOCK)
+	MCFG_DEVICE_PROGRAM_MAP(i8039_map)
+	MCFG_DEVICE_IO_MAP(i8039_io)
+
+MACHINE_CONFIG_END
+
+/******************************************************************************
+ ROM Definitions
+******************************************************************************/
+ROM_START( hp3478a )
+	ROM_REGION( 0x2000, "maincpu", 0 )
+	//ROM_LOAD("rom_dc118.bin", 0, 0x2000, CRC(7e65cdf6) SHA1(bd665cf7e07e63f825b2353c8322ed8a4376b3bd))	//main CPU ROM, can match other datecodes too
+ROM_END
+
+/******************************************************************************
+ Drivers
+******************************************************************************/
+
+//    YEAR  NAME  PARENT  COMPAT  MACHINE  INPUT  CLASS      INIT        COMPANY                        FULLNAME             FLAGS
+COMP( 1983, hp3478a,  0,      0,  hp3478a, hp3478a,hp3478a_state, empty_init, "HP", "HP 3478A Multimeter", MACHINE_IS_INCOMPLETE | MACHINE_NO_SOUND_HW | MACHINE_TYPE_OTHER)

--- a/src/mame/drivers/hp3478a.cpp
+++ b/src/mame/drivers/hp3478a.cpp
@@ -32,6 +32,9 @@ Analog (floating) CPU : i8049, internal ROM (never dumped ?)
 ROM : 2764 (64kbit, org 8kB) . Stores calibration data
 RAM : 5101 , 256 * 4bit
 GPIB:  i8291
+Display : unknown; similar protocol for HP 3457A documented on
+	http://www.eevblog.com/forum/projects/led-display-for-hp-3457a-multimeter-i-did-it-)/25/
+
 
 
 Main cpu I/O ports:
@@ -65,13 +68,24 @@ T1 : data in thru isol, from analog CPU (opcodes jt1 / jnt1)
 #define DIPSWITCH_CS P22
 #define GPIB_CS P21
 
+#define DISP_PWO P24
+#define DISP_SYNC P23
+#define DISP_ISA P22
+#define DISP_IWA P21
+#define DISP_CK1 P20
+	//don't care about CK2 since it's supposed to be a delayed copy of CK1
+#define DISP_MASK (DISP_PWO | DISP_SYNC | DISP_ISA | DISP_IWA | DISP_CK1)	//used for edge detection
+
 
 /**** optional debug outputs, must be before #include */
 #define DEBUG_PORTS (LOG_GENERAL << 1)
 #define DEBUG_BANKING (LOG_GENERAL << 2)
 #define DEBUG_BUS (LOG_GENERAL << 3)
+#define DEBUG_KEYPAD (LOG_GENERAL << 4)
+#define DEBUG_LCD (LOG_GENERAL << 5)	//low level
+#define DEBUG_LCD2 (LOG_GENERAL << 6)
 
-#define VERBOSE (DEBUG_BUS)
+#define VERBOSE (DEBUG_LCD2)
 
 #include "logmacro.h"
 
@@ -86,7 +100,7 @@ WRITE8_MEMBER( hp3478a_state::p1write )
 
 READ8_MEMBER( hp3478a_state::p1read )
 {
-	uint8_t data = 0;
+	uint8_t data = m_maincpu->p1_r();
 	LOGMASKED(DEBUG_PORTS, "port1 read: 0x%02X\n", data);
 	return data;
 }
@@ -95,15 +109,23 @@ WRITE8_MEMBER( hp3478a_state::p2write )
 {
 	LOGMASKED(DEBUG_PORTS, "port2 write: %02X\n", data);
 
-	/* inefficient ? calls set_entry on every P2 write. Should maybe do "if oldstate != newstate" ? */
-	if (data & A12_PIN) {
-		m_bank0->set_entry(1);
-		LOGMASKED(DEBUG_BANKING, "changed to bank1\n");
-	} else {
-		m_bank0->set_entry(0);
-		LOGMASKED(DEBUG_BANKING, "changed to bank0\n");
+	if ((p2_oldstate ^ data) & A12_PIN) {
+		/* A12 pin state changed */
+		if (data & A12_PIN) {
+			m_bank0->set_entry(1);
+			LOGMASKED(DEBUG_BANKING, "changed to bank1\n");
+		} else {
+			m_bank0->set_entry(0);
+			LOGMASKED(DEBUG_BANKING, "changed to bank0\n");
+		}
 	}
 
+	if ((p2_oldstate ^ data) & DISP_MASK) {
+		/* display signals changed */
+		lcd_interface(data);
+	}
+
+	p2_oldstate = data;
 }
 
 /** external bus read callback
@@ -179,13 +201,206 @@ WRITE8_MEMBER( hp3478a_state::buswrite )
 }
 
 
+/* Yuck. Emulate serial LCD module interface. don't really want to make a separate driver for this...
+ * The protocol is common to many HP products of the era. Some sources have the instruction words written as 10-bit
+ * words, but it would appear more consistent (and matches the intent guessed from the disassembled functions)
+ * that they are actually 8-bit bytes. The 2-bit difference is a "bogus" 2 clock cycles for when SYNC or PWO changes ?
+ *
+*/
+
+/** copy data in shiftreg to the high nibble of each digit in chrbuf */
+static void lcd_update_hinib(uint8_t *chrbuf, uint64_t shiftreg)
+{
+	int i;
+	for (i=11; i >= 0; i--) {
+		chrbuf[i] &= 0x0F;
+		chrbuf[i] |= (shiftreg & 0x0F) << 4;
+		shiftreg >>= 4;
+	}
+}
+
+/** copy data in shiftreg to the low nibble of each digit in chrbuf */
+static void lcd_update_lonib(uint8_t *chrbuf, uint64_t shiftreg)
+{
+	int i;
+	for (i=11; i >= 0; i--) {
+		chrbuf[i] &= 0xF0;
+		chrbuf[i] |= (shiftreg & 0x0F);
+		shiftreg >>= 4;
+	}
+}
+
+/** map LCD char buffer to ASCII
+ *
+ * discards extra bits
+ */
+static void lcd_map_ascii(uint8_t *chrbuf, uint8_t *sbuf)
+{
+	int i;
+	for (i=0; i < 12; i++) {
+		sbuf[i] = (chrbuf[i] & 0x3F)+ 0x40;
+	}
+	sbuf[12] = 0;
+}
+
+// ISA command bytes
+#define DISP_ISA_WANNUN 0xBC	//annunciators
+#define DISP_ISA_WA 0x0A	//low nibbles
+#define DISP_ISA_WB 0x1A	//hi nib
+#define DISP_ISA_WC 0x2A	// "extended bit" ?
+
+void hp3478a_state::lcd_interface(uint8_t p2new)
+{
+	bool pwo_state, sync_state, isa_state, iwa_state;
+
+	pwo_state = p2new & DISP_PWO;
+	sync_state = p2new	 & DISP_SYNC;
+	isa_state = p2new & DISP_ISA;
+	iwa_state = p2new & DISP_IWA;
+
+	if (!((p2new ^ p2_oldstate) & DISP_CK1)) {
+		// no clock edge : boring.
+		//LOGMASKED(DEBUG_LCD, "LCD : pwo(%d), sync(%d), isa(%d), iwa(%d)\n",
+		//		pwo_state, sync_state, isa_state, iwa_state);
+		return;
+	}
+
+	if (!(p2new & DISP_CK1)) {
+		//neg edge
+		return;
+	}
+
+	// CK1 clock positive edge
+	if (!pwo_state) {
+		//not selected, reset everything.
+		LOGMASKED(DEBUG_LCD, "LCD : state=IDLE, PWO deselected, %d stray bits(0x...%02X)\n",lcd_bitcount, lcd_bitbuf & 0xFF);
+		m_lcdstate = lcd_state::IDLE;
+		lcd_bitcount = 0;
+		lcd_bitbuf = 0;
+		return;
+	}
+	switch (m_lcdstate) {
+		case lcd_state::IDLE:
+			lcd_want = 8;
+			m_lcdstate = lcd_state::SYNC_SKIP;
+			break;
+		case lcd_state::SYNC_SKIP:
+			// if SYNC changed, we need to ignore two clock pulses.
+			lcd_bitcount++;
+			if (lcd_bitcount < 1) {
+				break;
+			}
+			lcd_bitcount = 0;
+			lcd_bitbuf = 0;
+			if (sync_state) {
+				m_lcdstate = lcd_state::SELECTED_ISA;
+				lcd_want = 8;
+				LOGMASKED(DEBUG_LCD, "LCD : state=SELECTED_ISA\n");
+			} else {
+				//don't touch lcd_want since it was possibly set in the ISA stage
+				m_lcdstate = lcd_state::SELECTED_IWA;
+				LOGMASKED(DEBUG_LCD, "LCD : state=SELECTED_IWA, want %d\n", lcd_want);
+			}
+			break;
+		case lcd_state::SELECTED_ISA:
+			if (!sync_state) {
+				m_lcdstate = lcd_state::SYNC_SKIP;
+				if (lcd_bitcount) {
+					LOGMASKED(DEBUG_LCD, "LCD : ISA->IWA, %d stray bits (0x%0X)\n", lcd_bitcount, lcd_bitbuf);
+				} else {
+					LOGMASKED(DEBUG_LCD, "LCD : ISA->IWA\n");
+				}
+				lcd_bitcount = 0;
+				lcd_bitbuf = 0;
+				break;
+			}
+			lcd_bitbuf |= (isa_state << lcd_bitcount);
+			lcd_bitcount++;
+			if (lcd_bitcount == lcd_want) {
+				LOGMASKED(DEBUG_LCD, "LCD : Instruction 0x%02X\n", lcd_bitbuf & 0xFF);
+				//shouldn't get extra bits, but we have nothing better to do so just reset the shiftreg.
+				lcd_bitcount = 0;
+				switch (lcd_bitbuf & 0xFF) {
+				case DISP_ISA_WANNUN:
+					lcd_want = 44;
+					m_lcdiwa = lcd_iwatype::ANNUNS;
+					break;
+				case DISP_ISA_WA:
+					lcd_want = 100;	//no, doesn't fit in a uint64, but only the first 36 bits are significant.
+					m_lcdiwa = lcd_iwatype::REG_A;
+					break;
+				case DISP_ISA_WB:
+					lcd_want = 100;
+					m_lcdiwa = lcd_iwatype::REG_B;
+					break;
+				case DISP_ISA_WC:
+					lcd_want = 44;
+					m_lcdiwa = lcd_iwatype::REG_C;
+					break;
+				default:
+					lcd_want = 44;
+					m_lcdiwa = lcd_iwatype::DISCARD;
+					break;
+				}
+				lcd_bitbuf = 0;
+			}
+			break;
+		case lcd_state::SELECTED_IWA:
+			if (sync_state) {
+				m_lcdstate = lcd_state::SYNC_SKIP;
+				if (lcd_bitcount) {
+					LOGMASKED(DEBUG_LCD, "LCD : IWA->ISA, %d stray bits (0x%I64X)\n", lcd_bitcount, lcd_bitbuf);
+				} else {
+					LOGMASKED(DEBUG_LCD, "LCD : IWA->ISA\n");
+				}
+				lcd_bitcount = 0;
+				lcd_bitbuf = 0;
+				break;
+			}
+			if (lcd_bitcount <= 0x3F) {
+				//clamp to bit 63;
+				lcd_bitbuf |= ((uint64_t) iwa_state << lcd_bitcount);
+			}
+			lcd_bitcount++;
+			if (lcd_bitcount != lcd_want) {
+				break;
+			}
+			LOGMASKED(DEBUG_LCD, "LCD : data 0x%I64X\n", lcd_bitbuf);
+			switch (m_lcdiwa) {
+			case lcd_iwatype::ANNUNS:
+				LOGMASKED(DEBUG_LCD2, "LCD : write annuns 0x%02X\n", lcd_bitbuf & 0xFF);
+				break;
+			case lcd_iwatype::REG_A:
+				LOGMASKED(DEBUG_LCD2, "LCD : write reg A (lonib)\n");
+				lcd_update_lonib(lcd_chrbuf, lcd_bitbuf);
+				lcd_map_ascii(lcd_chrbuf, lcd_text);
+				LOGMASKED(DEBUG_LCD2, "LCD text: %s\n", (char *) lcd_text);
+				break;
+			case lcd_iwatype::REG_B:
+				LOGMASKED(DEBUG_LCD2, "LCD : write reg B (hinib) %I64X\n", lcd_bitbuf);
+				lcd_update_hinib(lcd_chrbuf, lcd_bitbuf);
+				lcd_map_ascii(lcd_chrbuf, lcd_text);
+				LOGMASKED(DEBUG_LCD2, "LCD text: %s\n", (char *) lcd_text);
+				break;
+			default:
+				//discard
+				break;
+			}
+			//shouldn't get extra bits, but we have nothing better to do so just reset the shiftreg.
+			lcd_bitcount = 0;
+			lcd_bitbuf = 0;
+			break;	//case SELECTED_IWA
+	}
+
+	return;
+}
 
 
 
 
 
-
-void hp3478a_state::machine_start() {
+void hp3478a_state::machine_start()
+{
 	m_bank0->configure_entries(0, 2, memregion("maincpu")->base(), 0x1000);
 }
 

--- a/src/mame/includes/hp3478a.h
+++ b/src/mame/includes/hp3478a.h
@@ -41,9 +41,11 @@ protected:
 	virtual void machine_start() override;
 	//virtual void machine_reset() override;	//not needed?
 
-	DECLARE_WRITE8_MEMBER(port1_w);
-	DECLARE_READ8_MEMBER(port1_r);
+	DECLARE_WRITE8_MEMBER(p1write);
+	DECLARE_READ8_MEMBER(p1read);
 	DECLARE_WRITE8_MEMBER(p2write);
+	DECLARE_READ8_MEMBER(busread);
+	DECLARE_WRITE8_MEMBER(buswrite);
 
 	required_device<i8039_device> m_maincpu;
 	required_memory_bank m_bank0;

--- a/src/mame/includes/hp3478a.h
+++ b/src/mame/includes/hp3478a.h
@@ -14,6 +14,7 @@
 #include "cpu/mcs48/mcs48.h"
 #include "machine/bankdev.h"
 #include "machine/nvram.h"
+#include "machine/watchdog.h"
 
 /* port pin/bit defs */
 #define P20	(1 << 0)
@@ -35,6 +36,7 @@ public:
 		, m_maincpu(*this, "maincpu")
 		, m_nvram(*this, "nvram")
 		, m_nvram_raw(*this, "nvram")
+		, m_watchdog(*this, "watchdog")
 		, m_bank0(*this, "bank0")
 		, m_iobank(*this, "iobank")
 		, m_keypad(*this, "COL.%u", 0)
@@ -49,6 +51,7 @@ protected:
 	//virtual void machine_reset() override;	//not needed?
 
 	DECLARE_READ8_MEMBER(p1read);
+	DECLARE_WRITE8_MEMBER(p1write);
 	DECLARE_WRITE8_MEMBER(p2write);
 	DECLARE_WRITE8_MEMBER(nvwrite);
 
@@ -59,6 +62,7 @@ protected:
 	required_device<i8039_device> m_maincpu;
 	required_device<nvram_device> m_nvram;
 	required_shared_ptr<uint8_t> m_nvram_raw;
+	required_device<watchdog_timer_device> m_watchdog;
 	required_memory_bank m_bank0;
 	required_device<address_map_bank_device> m_iobank;
 	required_ioport_array<4> m_keypad;
@@ -91,6 +95,7 @@ protected:
 	uint32_t lcd_segdata[12];
 
 	uint8_t p2_oldstate;	//used to detect edges on Port2 IO pins. Should be saveable ?
+	uint8_t p1_oldstate;	//for P17 edge detection (WDT reset)
 
 };
 

--- a/src/mame/includes/hp3478a.h
+++ b/src/mame/includes/hp3478a.h
@@ -12,6 +12,8 @@
 #define MAME_INCLUDES_HP3478A_H
 
 #include "cpu/mcs48/mcs48.h"
+#include "machine/bankdev.h"
+#include "machine/nvram.h"
 
 /* port pin/bit defs */
 #define P20	(1 << 0)
@@ -29,15 +31,15 @@ class hp3478a_state : public driver_device
 {
 public:
 	hp3478a_state(const machine_config &mconfig, device_type type, const char *tag)
-		: driver_device(mconfig, type, tag),
-		m_maincpu(*this, "maincpu"),
-		m_bank0(*this, "bank0")
+		: driver_device(mconfig, type, tag)
+		, m_maincpu(*this, "maincpu")
+		, m_nvram(*this, "nvram")
+		, m_bank0(*this, "bank0")
+		, m_iobank(*this, "iobank")
 	{
 	}
 
 	void hp3478a(machine_config &config);
-	void i8039_io(address_map &map);
-	void i8039_map(address_map &map);
 
 protected:
 	virtual void machine_start() override;
@@ -48,9 +50,16 @@ protected:
 	DECLARE_WRITE8_MEMBER(p2write);
 	DECLARE_READ8_MEMBER(busread);
 	DECLARE_WRITE8_MEMBER(buswrite);
+	DECLARE_READ8_MEMBER(dipread);
+
+	void io_bank(address_map &map);
+	void i8039_io(address_map &map);
+	void i8039_map(address_map &map);
 
 	required_device<i8039_device> m_maincpu;
+	required_device<nvram_device> m_nvram;
 	required_memory_bank m_bank0;
+	required_device<address_map_bank_device> m_iobank;
 
 	/////////////// stuff for internal LCD emulation
 	// could be split to a separate driver ?

--- a/src/mame/includes/hp3478a.h
+++ b/src/mame/includes/hp3478a.h
@@ -36,6 +36,7 @@ public:
 		, m_nvram(*this, "nvram")
 		, m_bank0(*this, "bank0")
 		, m_iobank(*this, "iobank")
+		, m_keypad(*this, "COL.%u", 0)
 	{
 	}
 
@@ -45,11 +46,8 @@ protected:
 	virtual void machine_start() override;
 	//virtual void machine_reset() override;	//not needed?
 
-	DECLARE_WRITE8_MEMBER(p1write);
 	DECLARE_READ8_MEMBER(p1read);
 	DECLARE_WRITE8_MEMBER(p2write);
-	DECLARE_READ8_MEMBER(busread);
-	DECLARE_WRITE8_MEMBER(buswrite);
 	DECLARE_READ8_MEMBER(dipread);
 
 	void io_bank(address_map &map);
@@ -60,6 +58,7 @@ protected:
 	required_device<nvram_device> m_nvram;
 	required_memory_bank m_bank0;
 	required_device<address_map_bank_device> m_iobank;
+	required_ioport_array<4> m_keypad;
 
 	/////////////// stuff for internal LCD emulation
 	// could be split to a separate driver ?

--- a/src/mame/includes/hp3478a.h
+++ b/src/mame/includes/hp3478a.h
@@ -23,6 +23,8 @@
 #define P26	(1 << 6)
 #define P27	(1 << 7)
 
+#define VFD_TAG     "vfd"
+
 class hp3478a_state : public driver_device
 {
 public:
@@ -51,7 +53,11 @@ protected:
 	required_memory_bank m_bank0;
 
 	/////////////// stuff for internal LCD emulation
+	// could be split to a separate driver ?
+	std::unique_ptr<output_finder<16> > m_outputs;
+
 	void lcd_interface(uint8_t p2new);
+	void lcd_map_chars(void);
 	uint8_t lcd_bitcount;
 	uint8_t lcd_want;
 	uint64_t lcd_bitbuf;
@@ -70,6 +76,7 @@ protected:
 	} m_lcdiwa;
 	uint8_t lcd_chrbuf[12];	//raw digits (not ASCII)
 	uint8_t lcd_text[13];	//mapped to ASCII
+	uint32_t lcd_segdata[12];
 
 	uint8_t p2_oldstate;	//used to detect edges on Port2 IO pins. Should be saveable ?
 

--- a/src/mame/includes/hp3478a.h
+++ b/src/mame/includes/hp3478a.h
@@ -50,7 +50,6 @@ protected:
 
 	DECLARE_READ8_MEMBER(p1read);
 	DECLARE_WRITE8_MEMBER(p2write);
-	DECLARE_READ8_MEMBER(dipread);
 	DECLARE_WRITE8_MEMBER(nvwrite);
 
 	void io_bank(address_map &map);

--- a/src/mame/includes/hp3478a.h
+++ b/src/mame/includes/hp3478a.h
@@ -50,6 +50,29 @@ protected:
 	required_device<i8039_device> m_maincpu;
 	required_memory_bank m_bank0;
 
+	/////////////// stuff for internal LCD emulation
+	void lcd_interface(uint8_t p2new);
+	uint8_t lcd_bitcount;
+	uint8_t lcd_want;
+	uint64_t lcd_bitbuf;
+	enum class lcd_state : uint8_t {
+		IDLE,
+		SYNC_SKIP,
+		SELECTED_ISA,
+		SELECTED_IWA
+	} m_lcdstate;
+	enum class lcd_iwatype : uint8_t {
+		ANNUNS,
+		REG_A,
+		REG_B,
+		REG_C,
+		DISCARD
+	} m_lcdiwa;
+	uint8_t lcd_chrbuf[12];	//raw digits (not ASCII)
+	uint8_t lcd_text[13];	//mapped to ASCII
+
+	uint8_t p2_oldstate;	//used to detect edges on Port2 IO pins. Should be saveable ?
+
 };
 
 

--- a/src/mame/includes/hp3478a.h
+++ b/src/mame/includes/hp3478a.h
@@ -1,0 +1,41 @@
+// license:BSD-3-Clause
+// copyright-holders:fenugrec
+/***************************************************************************
+ HP 3478A Digital Multimeter
+
+ XXX Not sure why I need this file, can this all go in hp3478a.cpp ?
+****************************************************************************/
+
+#pragma once
+
+#ifndef MAME_INCLUDES_HP3478A_H
+#define MAME_INCLUDES_HP3478A_H
+
+#include "cpu/mcs48/mcs48.h"
+
+
+class hp3478a_state : public driver_device
+{
+public:
+	hp3478a_state(const machine_config &mconfig, device_type type, const char *tag)
+		: driver_device(mconfig, type, tag),
+		m_maincpu(*this, "maincpu")
+	{
+	}
+
+	void hp3478a(machine_config &config);
+	void i8039_io(address_map &map);
+	void i8039_map(address_map &map);
+
+protected:
+	virtual void machine_start() override;
+	//virtual void machine_reset() override;	//not needed?
+
+	DECLARE_WRITE8_MEMBER(port1_w);
+	DECLARE_READ8_MEMBER(port1_r);
+
+	required_device<i8039_device> m_maincpu;
+};
+
+
+#endif // MAME_INCLUDES_HP3478A_H

--- a/src/mame/includes/hp3478a.h
+++ b/src/mame/includes/hp3478a.h
@@ -13,13 +13,23 @@
 
 #include "cpu/mcs48/mcs48.h"
 
+/* port pin/bit defs */
+#define P20	(1 << 0)
+#define P21	(1 << 1)
+#define P22	(1 << 2)
+#define P23	(1 << 3)
+#define P24	(1 << 4)
+#define P25	(1 << 5)
+#define P26	(1 << 6)
+#define P27	(1 << 7)
 
 class hp3478a_state : public driver_device
 {
 public:
 	hp3478a_state(const machine_config &mconfig, device_type type, const char *tag)
 		: driver_device(mconfig, type, tag),
-		m_maincpu(*this, "maincpu")
+		m_maincpu(*this, "maincpu"),
+		m_bank0(*this, "bank0")
 	{
 	}
 
@@ -33,8 +43,11 @@ protected:
 
 	DECLARE_WRITE8_MEMBER(port1_w);
 	DECLARE_READ8_MEMBER(port1_r);
+	DECLARE_WRITE8_MEMBER(p2write);
 
 	required_device<i8039_device> m_maincpu;
+	required_memory_bank m_bank0;
+
 };
 
 

--- a/src/mame/includes/hp3478a.h
+++ b/src/mame/includes/hp3478a.h
@@ -34,9 +34,11 @@ public:
 		: driver_device(mconfig, type, tag)
 		, m_maincpu(*this, "maincpu")
 		, m_nvram(*this, "nvram")
+		, m_nvram_raw(*this, "nvram")
 		, m_bank0(*this, "bank0")
 		, m_iobank(*this, "iobank")
 		, m_keypad(*this, "COL.%u", 0)
+		, m_calenable(*this, "CAL_EN")
 	{
 	}
 
@@ -49,6 +51,7 @@ protected:
 	DECLARE_READ8_MEMBER(p1read);
 	DECLARE_WRITE8_MEMBER(p2write);
 	DECLARE_READ8_MEMBER(dipread);
+	DECLARE_WRITE8_MEMBER(nvwrite);
 
 	void io_bank(address_map &map);
 	void i8039_io(address_map &map);
@@ -56,9 +59,11 @@ protected:
 
 	required_device<i8039_device> m_maincpu;
 	required_device<nvram_device> m_nvram;
+	required_shared_ptr<uint8_t> m_nvram_raw;
 	required_memory_bank m_bank0;
 	required_device<address_map_bank_device> m_iobank;
 	required_ioport_array<4> m_keypad;
+	required_ioport m_calenable;
 
 	/////////////// stuff for internal LCD emulation
 	// could be split to a separate driver ?

--- a/src/mame/layout/hp3478a.lay
+++ b/src/mame/layout/hp3478a.lay
@@ -1,0 +1,152 @@
+<?xml version="1.0"?>
+<!-- loosely based on tranz330.lay -->
+<!-- note, the led16seg renderer is hardcoded to have OFF segments darker than ON, which is good for LEDs but not LCDs. -->
+<!-- TODO : fix that -->
+<!-- TODO : add button subtext for shifted functions -->
+<!-- TODO : make buttons clickable ?  all the COL / input stuff is wrong-->
+<mamelayout version="2">
+	<element name="vfd0"><led16segsc><color red="0.8" green="0.8" blue="0.8" /></led16segsc></element>
+
+	<element name="front"><rect><color red="0.6" green="0.63" blue="0.65" /></rect></element>
+	<element name="vfd_back"><rect><color red="0.29" green="0.33" blue="0.32" /></rect></element>
+	<element name="button_digit_back"><rect><color red="0.75" green="0.75" blue="0.75" /></rect></element>
+
+	<element name="hl" defstate="0">
+		<text string="">
+			<bounds x="0.0" y="0.0" width="1.0" height="1.0" />
+			<color red="0.0" green="0.0" blue="0.0" />
+		</text>
+		<rect state="1">
+			<bounds x="0.0" y="0.0" width="1.0" height="1.0" />
+			<color red="0.0" green="0.0" blue="0.0" />
+		</rect>
+	</element>
+
+	<element name="button_dcv_text">
+		<rect><color red="0.75" green="0.75" blue="0.75" /></rect>
+		<text string="DCV"><color red="0.0" green="0.0" blue="0.0" /></text>
+	</element>
+	<element name="button_acv_text">
+		<rect><color red="0.75" green="0.75" blue="0.75" /></rect>
+		<text string="ACV"><color red="0.0" green="0.0" blue="0.0" /></text>
+	</element>
+	<element name="button_2w_text">
+		<rect><color red="0.75" green="0.75" blue="0.75" /></rect>
+		<text string="2W"><color red="0.0" green="0.0" blue="0.0" /></text>
+	</element>
+	<element name="button_4w_text">
+		<rect><color red="0.75" green="0.75" blue="0.75" /></rect>
+		<text string="4W"><color red="0.0" green="0.0" blue="0.0" /></text>
+	</element>
+	<element name="button_dca_text">
+		<rect><color red="0.75" green="0.75" blue="0.75" /></rect>
+		<text string="DCA"><color red="0.0" green="0.0" blue="0.0" /></text>
+	</element>
+	<element name="button_aca_text">
+		<rect><color red="0.75" green="0.75" blue="0.75" /></rect>
+		<text string="ACA"><color red="0.0" green="0.0" blue="0.0" /></text>
+	</element>
+	<element name="button_shift_text">
+		<rect><color red="0.3" green="0.35" blue="0.85" /></rect>
+		<text string=""><color red="0.0" green="0.0" blue="0.0" /></text>
+	</element>
+	<element name="button_auto_text">
+		<rect><color red="0.75" green="0.75" blue="0.75" /></rect>
+		<text string="AUTO"><color red="0.0" green="0.0" blue="0.0" /></text>
+	</element>
+	<element name="button_up_text">
+		<rect><color red="0.75" green="0.75" blue="0.75" /></rect>
+		<text string="UP"><color red="0.0" green="0.0" blue="0.0" /></text>
+	</element>
+	<element name="button_dn_text">
+		<rect><color red="0.75" green="0.75" blue="0.75" /></rect>
+		<text string="DN"><color red="0.0" green="0.0" blue="0.0" /></text>
+	</element>
+	<element name="button_int_text">
+		<rect><color red="0.75" green="0.75" blue="0.75" /></rect>
+		<text string="INT"><color red="0.0" green="0.0" blue="0.0" /></text>
+	</element>
+	<element name="button_sgl_text">
+		<rect><color red="0.75" green="0.75" blue="0.75" /></rect>
+		<text string="SGL"><color red="0.0" green="0.0" blue="0.0" /></text>
+	</element>
+	<element name="button_srq_text">
+		<rect><color red="0.75" green="0.75" blue="0.75" /></rect>
+		<text string="SRQ"><color red="0.0" green="0.0" blue="0.0" /></text>
+	</element>
+	<element name="button_local_text">
+		<rect><color red="0.75" green="0.75" blue="0.75" /></rect>
+		<text string="LCL"><color red="0.0" green="0.0" blue="0.0" /></text>
+	</element>
+
+
+	<view name="Internal Layout">
+		<backdrop name="case_bg"      element="front">            <bounds x=" 0" y=" 0" width="126" height="70"/></backdrop>
+		<!-- 2 rows of 7 buttons , but electrical switch matrix is different -->
+		<backdrop name="button_dcv"     element="button_digit_back"><bounds x="5" y="35" width="10" height="10"/></backdrop>
+		<backdrop name="button_acv"     element="button_digit_back"><bounds x="20" y="35" width="10" height="10"/></backdrop>
+		<backdrop name="button_2w"     element="button_digit_back"><bounds x="35" y="35" width="10" height="10"/></backdrop>
+		<backdrop name="button_4w"     element="button_digit_back"><bounds x="50" y="35" width="10" height="10"/></backdrop>
+		<backdrop name="button_dca"     element="button_digit_back"><bounds x="65" y="35" width="10" height="10"/></backdrop>
+		<backdrop name="button_aca"     element="button_digit_back"><bounds x="80" y="35" width="10" height="10"/></backdrop>
+		<backdrop name="button_shift" element="button_digit_back"><bounds x="95" y="35" width="10" height="10"/></backdrop>
+
+		<backdrop name="button_auto"     element="button_digit_back"><bounds x="5" y="50" width="10" height="10"/></backdrop>
+		<backdrop name="button_up"     element="button_digit_back"><bounds x="20" y="50" width="10" height="10"/></backdrop>
+		<backdrop name="button_dn"     element="button_digit_back"><bounds x="35" y="50" width="10" height="10"/></backdrop>
+		<backdrop name="button_int"     element="button_digit_back"><bounds x="50" y="50" width="10" height="10"/></backdrop>
+		<backdrop name="button_sgl"     element="button_digit_back"><bounds x="65" y="50" width="10" height="10"/></backdrop>
+		<backdrop name="button_srq"     element="button_digit_back"><bounds x="80" y="50" width="10" height="10"/></backdrop>
+		<backdrop name="button_local"     element="button_digit_back"><bounds x="95" y="50" width="10" height="10"/></backdrop>
+
+		<backdrop name="vfd_backdrop" element="vfd_back">         <bounds x="0" y="0" width="126" height="32"/></backdrop>
+
+		<bezel name="vfd0"  element="vfd0" state="0"><bounds x=" 9" y="9" width="9" height="14"/></bezel>
+		<bezel name="vfd1"  element="vfd0" state="0"><bounds x="18" y="9" width="9" height="14"/></bezel>
+		<bezel name="vfd2"  element="vfd0" state="0"><bounds x="27" y="9" width="9" height="14"/></bezel>
+		<bezel name="vfd3"  element="vfd0" state="0"><bounds x="36" y="9" width="9" height="14"/></bezel>
+		<bezel name="vfd4"  element="vfd0" state="0"><bounds x="45" y="9" width="9" height="14"/></bezel>
+		<bezel name="vfd5"  element="vfd0" state="0"><bounds x="54" y="9" width="9" height="14"/></bezel>
+		<bezel name="vfd6"  element="vfd0" state="0"><bounds x="63" y="9" width="9" height="14"/></bezel>
+		<bezel name="vfd7"  element="vfd0" state="0"><bounds x="72" y="9" width="9" height="14"/></bezel>
+		<bezel name="vfd8"  element="vfd0" state="0"><bounds x="81" y="9" width="9" height="14"/></bezel>
+		<bezel name="vfd9"  element="vfd0" state="0"><bounds x="90" y="9" width="9" height="14"/></bezel>
+		<bezel name="vfd10" element="vfd0" state="0"><bounds x="99" y="9" width="9" height="14"/></bezel>
+		<bezel name="vfd11" element="vfd0" state="0"><bounds x="108" y="9" width="9" height="14"/></bezel>
+
+		<bezel name="button_dcv_text1"     element="button_dcv_text">    <bounds x="5" y="37" width="10" height="8"/></bezel>
+		<bezel name="button_acv_text1"     element="button_acv_text">    <bounds x="20" y="37" width="10" height="8"/></bezel>
+		<bezel name="button_2w_text1"     element="button_2w_text">    <bounds x="35" y="37" width="10" height="8"/></bezel>
+		<bezel name="button_4w_text1"     element="button_4w_text">    <bounds x="50" y="37" width="10" height="8"/></bezel>
+		<bezel name="button_dca_text1"     element="button_dca_text">    <bounds x="65" y="37" width="10" height="8"/></bezel>
+		<bezel name="button_aca_text1"     element="button_aca_text">    <bounds x="80" y="37" width="10" height="8"/></bezel>
+		<bezel name="button_shift_text1" element="button_shift_text"><bounds x="95" y="35" width="10" height="10"/></bezel>
+
+		<bezel name="button_auto_text1"     element="button_auto_text">    <bounds x="5" y="52" width="10" height="8"/></bezel>
+		<bezel name="button_up_text1"     element="button_up_text">    <bounds x="20" y="52" width="10" height="8"/></bezel>
+		<bezel name="button_dn_text1"     element="button_dn_text">    <bounds x="35" y="52" width="10" height="8"/></bezel>
+		<bezel name="button_int_text1"     element="button_int_text">    <bounds x="50" y="52" width="10" height="8"/></bezel>
+		<bezel name="button_sgl_text1"     element="button_sgl_text">    <bounds x="65" y="52" width="10" height="8"/></bezel>
+		<bezel name="button_srq_text1"     element="button_srq_text">    <bounds x="80" y="52" width="10" height="8"/></bezel>
+		<bezel name="button_local_text1"     element="button_local_text">    <bounds x="95" y="52" width="10" height="8"/></bezel>
+
+
+<!-- all this is wrong -->
+		<bezel element="hl" inputtag="COL.0" inputmask="0x01"><bounds x="5" y="52" width="21" height="21" /><color alpha="0.2" /></bezel>
+		<bezel element="hl" inputtag="COL.0" inputmask="0x02"><bounds x="20" y="86" width="21" height="21" /><color alpha="0.2" /></bezel>
+		<bezel element="hl" inputtag="COL.0" inputmask="0x04"><bounds x="35" y="120" width="21" height="21" /><color alpha="0.2" /></bezel>
+		<bezel element="hl" inputtag="COL.0" inputmask="0x08"><bounds x="50" y="154" width="21" height="21" /><color alpha="0.2" /></bezel>
+		<bezel element="hl" inputtag="COL.1" inputmask="0x01"><bounds x="65" y="52" width="21" height="21" /><color alpha="0.2" /></bezel>
+		<bezel element="hl" inputtag="COL.1" inputmask="0x02"><bounds x="80" y="86" width="21" height="21" /><color alpha="0.2" /></bezel>
+		<bezel element="hl" inputtag="COL.1" inputmask="0x04"><bounds x="85" y="120" width="21" height="21" /><color alpha="0.2" /></bezel>
+		<bezel element="hl" inputtag="COL.1" inputmask="0x08"><bounds x="54" y="154" width="21" height="21" /><color alpha="0.2" /></bezel>
+		<bezel element="hl" inputtag="COL.2" inputmask="0x01"><bounds x="88" y="52" width="21" height="21" /><color alpha="0.2" /></bezel>
+		<bezel element="hl" inputtag="COL.2" inputmask="0x02"><bounds x="88" y="86" width="21" height="21" /><color alpha="0.2" /></bezel>
+		<bezel element="hl" inputtag="COL.2" inputmask="0x04"><bounds x="88" y="120" width="21" height="21" /><color alpha="0.2" /></bezel>
+		<bezel element="hl" inputtag="COL.2" inputmask="0x08"><bounds x="88" y="154" width="21" height="21" /><color alpha="0.2" /></bezel>
+		<bezel element="hl" inputtag="COL.3" inputmask="0x01"><bounds x="122" y="52" width="21" height="21" /><color alpha="0.2" /></bezel>
+		<bezel element="hl" inputtag="COL.3" inputmask="0x02"><bounds x="122" y="86" width="21" height="21" /><color alpha="0.2" /></bezel>
+		<bezel element="hl" inputtag="COL.3" inputmask="0x04"><bounds x="122" y="120" width="21" height="21" /><color alpha="0.2" /></bezel>
+		<bezel element="hl" inputtag="COL.3" inputmask="0x08"><bounds x="122" y="154" width="21" height="21" /><color alpha="0.2" /></bezel>
+	</view>
+</mamelayout>

--- a/src/mame/layout/hp3478a.lay
+++ b/src/mame/layout/hp3478a.lay
@@ -18,7 +18,7 @@
 		</text>
 		<rect state="1">
 			<bounds x="0.0" y="0.0" width="1.0" height="1.0" />
-			<color red="0.0" green="0.0" blue="0.0" />
+			<color red="0.0" green="0.0" blue="0.5" />
 		</rect>
 	</element>
 
@@ -131,22 +131,26 @@
 		<bezel name="button_local_text1"     element="button_local_text">    <bounds x="95" y="52" width="10" height="8"/></bezel>
 
 
-<!-- all this is wrong -->
-		<bezel element="hl" inputtag="COL.0" inputmask="0x01"><bounds x="5" y="52" width="21" height="21" /><color alpha="0.2" /></bezel>
-		<bezel element="hl" inputtag="COL.0" inputmask="0x02"><bounds x="20" y="86" width="21" height="21" /><color alpha="0.2" /></bezel>
-		<bezel element="hl" inputtag="COL.0" inputmask="0x04"><bounds x="35" y="120" width="21" height="21" /><color alpha="0.2" /></bezel>
-		<bezel element="hl" inputtag="COL.0" inputmask="0x08"><bounds x="50" y="154" width="21" height="21" /><color alpha="0.2" /></bezel>
-		<bezel element="hl" inputtag="COL.1" inputmask="0x01"><bounds x="65" y="52" width="21" height="21" /><color alpha="0.2" /></bezel>
-		<bezel element="hl" inputtag="COL.1" inputmask="0x02"><bounds x="80" y="86" width="21" height="21" /><color alpha="0.2" /></bezel>
-		<bezel element="hl" inputtag="COL.1" inputmask="0x04"><bounds x="85" y="120" width="21" height="21" /><color alpha="0.2" /></bezel>
-		<bezel element="hl" inputtag="COL.1" inputmask="0x08"><bounds x="54" y="154" width="21" height="21" /><color alpha="0.2" /></bezel>
-		<bezel element="hl" inputtag="COL.2" inputmask="0x01"><bounds x="88" y="52" width="21" height="21" /><color alpha="0.2" /></bezel>
-		<bezel element="hl" inputtag="COL.2" inputmask="0x02"><bounds x="88" y="86" width="21" height="21" /><color alpha="0.2" /></bezel>
-		<bezel element="hl" inputtag="COL.2" inputmask="0x04"><bounds x="88" y="120" width="21" height="21" /><color alpha="0.2" /></bezel>
-		<bezel element="hl" inputtag="COL.2" inputmask="0x08"><bounds x="88" y="154" width="21" height="21" /><color alpha="0.2" /></bezel>
-		<bezel element="hl" inputtag="COL.3" inputmask="0x01"><bounds x="122" y="52" width="21" height="21" /><color alpha="0.2" /></bezel>
-		<bezel element="hl" inputtag="COL.3" inputmask="0x02"><bounds x="122" y="86" width="21" height="21" /><color alpha="0.2" /></bezel>
-		<bezel element="hl" inputtag="COL.3" inputmask="0x04"><bounds x="122" y="120" width="21" height="21" /><color alpha="0.2" /></bezel>
-		<bezel element="hl" inputtag="COL.3" inputmask="0x08"><bounds x="122" y="154" width="21" height="21" /><color alpha="0.2" /></bezel>
+<!-- to match the schematics, we consider Col.0-3 to be driven by P14-17. The value in "inputmask" is the one read as "p1 & 0x0F", i.e. P13-P10. -->
+<!--	col.0 : (nc)|shift|ACA|DCA
+		col.1 : 4W|2W|ACV|DCV
+		col.2 : int|dn|up|auto
+		col.3 : (nc)|loc|srq|sgl -->
+		<bezel element="hl" inputtag="COL.0" inputmask="0x01"><bounds x="65" y="35" width="10" height="10" /><color alpha="0.2" /></bezel>
+		<bezel element="hl" inputtag="COL.0" inputmask="0x02"><bounds x="80" y="35" width="10" height="10" /><color alpha="0.2" /></bezel>
+		<bezel element="hl" inputtag="COL.0" inputmask="0x04"><bounds x="95" y="35" width="10" height="10" /><color alpha="0.2" /></bezel>
+		<!--bezel element="hl" inputtag="COL.0" inputmask="0x08"><bounds x="" y="54" width="10" height="10" /><color alpha="0.2" /></bezel -->
+		<bezel element="hl" inputtag="COL.1" inputmask="0x01"><bounds x="5" y="35" width="10" height="10" /><color alpha="0.2" /></bezel>
+		<bezel element="hl" inputtag="COL.1" inputmask="0x02"><bounds x="20" y="35" width="10" height="10" /><color alpha="0.2" /></bezel>
+		<bezel element="hl" inputtag="COL.1" inputmask="0x04"><bounds x="35" y="35" width="10" height="10" /><color alpha="0.2" /></bezel>
+		<bezel element="hl" inputtag="COL.1" inputmask="0x08"><bounds x="50" y="35" width="10" height="10" /><color alpha="0.2" /></bezel>
+		<bezel element="hl" inputtag="COL.2" inputmask="0x01"><bounds x="5" y="50" width="10" height="10" /><color alpha="0.2" /></bezel>
+		<bezel element="hl" inputtag="COL.2" inputmask="0x02"><bounds x="20" y="50" width="10" height="10" /><color alpha="0.2" /></bezel>
+		<bezel element="hl" inputtag="COL.2" inputmask="0x04"><bounds x="35" y="50" width="10" height="10" /><color alpha="0.2" /></bezel>
+		<bezel element="hl" inputtag="COL.2" inputmask="0x08"><bounds x="50" y="50" width="10" height="10" /><color alpha="0.2" /></bezel>
+		<bezel element="hl" inputtag="COL.3" inputmask="0x01"><bounds x="65" y="50" width="10" height="10" /><color alpha="0.2" /></bezel>
+		<bezel element="hl" inputtag="COL.3" inputmask="0x02"><bounds x="80" y="50" width="10" height="10" /><color alpha="0.2" /></bezel>
+		<bezel element="hl" inputtag="COL.3" inputmask="0x04"><bounds x="95" y="50" width="10" height="10" /><color alpha="0.2" /></bezel>
+		<!--bezel element="hl" inputtag="COL.3" inputmask="0x08"><bounds x="" y="5" width="10" height="10" /><color alpha="0.2" /></bezel -->
 	</view>
 </mamelayout>

--- a/src/mame/mame.lst
+++ b/src/mame/mame.lst
@@ -15310,6 +15310,9 @@ hp2622a                         //
 @source:hp2640.cpp
 hp2645                          //
 
+@source:hp3478a.cpp
+hp3478a                         //
+
 @source:hp48.cpp
 hp38g                           //
 hp39g                           //


### PR DESCRIPTION
This adds a driver for the HP 3478A DMM. Those units are reasonably well documented with full service manual and schematics. Additionally, I have published my annotated disassembly of a common firmware dump in another repo.

Emulation is subjectively ~ 80% complete and mostly accurate. It's going to be simpler listing what isn't implemented, or broken:

- Analog-side CPU (8048), never dumped (to my knowledge). Its presence can be faked to some extent by patching a handful of bytes in the stock ROM.
- i8291 HP-IB (IEEE488) interface
- LCD "annunciators" not rendered
- LCD charset has 3 unverified characters (flagged in the source code).

I don't plan on adding major features to this driver, but I hope I've commented and written the code in such a way that the "door is open" should someone be interested.

As it stands I've rebased on the latest head but I can squash / rebase as required.
[edit - added commit to implement watchdog reset]