### PR TITLE
nscsi: fix sense data if no cdrom in drive (nw)

### DIFF
--- a/src/devices/machine/nscsi_bus.h
+++ b/src/devices/machine/nscsi_bus.h
@@ -119,6 +119,30 @@ protected:
 		SS_QUEUE_FULL                    = 0x28
 	};
 
+	// SCSI sense keys
+	enum {
+		SK_NO_SENSE                      = 0x00,
+		SK_RECOVERED_ERROR               = 0x01,
+		SK_NOT_READY                     = 0x02,
+		SK_MEDIUM_ERROR                  = 0x03,
+		SK_HARDWARE_ERROR                = 0x04,
+		SK_ILLEGAL_REQUEST               = 0x05,
+		SK_UNIT_ATTENTION                = 0x06,
+		SK_DATA_PROTECT                  = 0x07,
+		SK_BLANK_CHECK                   = 0x08,
+		SK_VENDOR_SPECIFIC               = 0x09,
+		SK_COPY_ABORTED                  = 0x0a,
+		SK_ABORTED_COMMAND               = 0x0b,
+		SK_VOLUME_OVERFLOW               = 0x0d,
+		SK_MISCOMPARE                    = 0x0e,
+		SK_COMPLETED                     = 0x0f
+	};
+
+	// SCSI addtional sense code qualifiers
+	enum {
+		SK_ASC_MEDIUM_NOT_PRESENT       = 0x3a
+	};
+
 	// SCSI commands
 	static const char *const command_names[256];
 	enum {

--- a/src/devices/machine/nscsi_cd.cpp
+++ b/src/devices/machine/nscsi_cd.cpp
@@ -126,7 +126,7 @@ void nscsi_cdrom_device::scsi_put_data(int id, int pos, uint8_t data)
 
 void nscsi_cdrom_device::return_no_cd()
 {
-	sense(false, 3);
+	sense(false, SK_NOT_READY, SK_ASC_MEDIUM_NOT_PRESENT);
 	scsi_status_complete(SS_CHECK_CONDITION);
 }
 
@@ -142,7 +142,7 @@ void nscsi_cdrom_device::scsi_command()
 		cur_sector = -1;
 
 		// report unit attention condition
-		sense(false, 6);
+		sense(false, SK_UNIT_ATTENTION);
 		scsi_status_complete(SS_CHECK_CONDITION);
 		return;
 	}


### PR DESCRIPTION
We reported Medium error, which makes at least the HP9000/382 complain
about bad hardware during system search, and netbsd didn't like it either
and reported it during boot up. Change it to report 'Not ready, medium not
present.' This is what my Toshiba XM-5401B reports.