### PR TITLE
scsp.cpp : Updates

### DIFF
--- a/src/devices/machine/stvcd.cpp
+++ b/src/devices/machine/stvcd.cpp
@@ -2,7 +2,7 @@
 // copyright-holders:Angelo Salese, R. Belmont
 /***************************************************************************
 
-  machine/stvcd.c - Sega Saturn and ST-V CD-ROM handling
+  machine/stvcd.cpp - Sega Saturn and ST-V CD-ROM handling
 
   Another tilt at the windmill in 2011 by R. Belmont.
 
@@ -70,6 +70,7 @@ DEFINE_DEVICE_TYPE(STVCD, stvcd_device, "stvcd", "Sega Saturn/ST-V CD Block HLE"
 
 stvcd_device::stvcd_device(const machine_config &mconfig, const char *tag, device_t *owner, uint32_t clock)
 	: device_t(mconfig, STVCD, tag, owner, clock)
+	, device_mixer_interface(mconfig, *this, 2)
 	, m_cdrom_image(*this, "cdrom")
 	, m_sector_timer(*this, "sector_timer")
 	, m_sh1_timer(*this, "sh1_cmd")
@@ -85,18 +86,12 @@ MACHINE_CONFIG_START(stvcd_device::device_add_mconfig)
 	MCFG_TIMER_DRIVER_ADD("sh1_cmd", stvcd_device, stv_sh1_sim)
 
 	MCFG_DEVICE_ADD("cdda", CDDA)
-	// FIXME: these outputs should not be hardcoded
-	MCFG_SOUND_ROUTE(0, ":lspeaker", 1.0)
-	MCFG_SOUND_ROUTE(1, ":rspeaker", 1.0)
+	MCFG_MIXER_ROUTE(0, *this, 1.0, 0)
+	MCFG_MIXER_ROUTE(1, *this, 1.0, 1)
 MACHINE_CONFIG_END
 
 void stvcd_device::device_start()
 {
-}
-
-READ16_MEMBER(stvcd_device::channel_volume_r)
-{
-	return m_cdda->get_channel_volume(offset);
 }
 
 int stvcd_device::get_timing_command(void)

--- a/src/devices/machine/stvcd.h
+++ b/src/devices/machine/stvcd.h
@@ -11,7 +11,7 @@
 #include "machine/timer.h"
 #include "sound/cdda.h"
 
-class stvcd_device : public device_t
+class stvcd_device : public device_t, public device_mixer_interface
 {
 	static constexpr unsigned MAX_FILTERS = 24;
 	static constexpr unsigned MAX_BLOCKS = 200;
@@ -22,8 +22,6 @@ public:
 
 	DECLARE_READ32_MEMBER(stvcd_r);
 	DECLARE_WRITE32_MEMBER(stvcd_w);
-
-	DECLARE_READ16_MEMBER(channel_volume_r);
 
 	void set_tray_open();
 	void set_tray_close();

--- a/src/devices/sound/scsp.h
+++ b/src/devices/sound/scsp.h
@@ -15,16 +15,6 @@
 				// driver code indicates should be 4, but sounds distorted then
 
 
-#define MCFG_SCSP_IRQ_CB(_devcb) \
-	downcast<scsp_device &>(*device).set_irq_callback(DEVCB_##_devcb);
-
-#define MCFG_SCSP_MAIN_IRQ_CB(_devcb) \
-	downcast<scsp_device &>(*device).set_main_irq_callback(DEVCB_##_devcb);
-
-#define MCFG_SCSP_EXTS_CB(_devcb) \
-	downcast<scsp_device &>(*device).set_exts_callback(DEVCB_##_devcb);
-
-
 class scsp_device : public device_t,
 	public device_sound_interface,
 	public device_rom_interface
@@ -32,12 +22,8 @@ class scsp_device : public device_t,
 public:
 	scsp_device(const machine_config &mconfig, const char *tag, device_t *owner, uint32_t clock = 22'579'200);
 
-	template <class Object> devcb_base &set_irq_callback(Object &&cb) { return m_irq_cb.set_callback(std::forward<Object>(cb)); }
-	template <class Object> devcb_base &set_main_irq_callback(Object &&cb) { return m_main_irq_cb.set_callback(std::forward<Object>(cb)); }
-	template <class Object> devcb_base &set_exts_callback(Object &&cb) { return m_exts_cb.set_callback(std::forward<Object>(cb)); }
 	auto irq_cb() { return m_irq_cb.bind(); }
 	auto main_irq_cb() { return m_main_irq_cb.bind(); }
-	auto exts_cb() { return m_exts_cb.bind(); }
 
 	// SCSP register access
 	DECLARE_READ16_MEMBER( read );
@@ -106,7 +92,6 @@ private:
 
 	devcb_write8       m_irq_cb;  /* irq callback */
 	devcb_write_line   m_main_irq_cb;
-	devcb_read16       m_exts_cb;
 
 	union
 	{
@@ -162,6 +147,8 @@ private:
 
 	stream_sample_t *m_bufferl;
 	stream_sample_t *m_bufferr;
+	stream_sample_t *m_exts0;
+	stream_sample_t *m_exts1;
 
 	int m_length;
 

--- a/src/devices/sound/scspdsp.cpp
+++ b/src/devices/sound/scspdsp.cpp
@@ -162,7 +162,7 @@ void SCSPDSP::Step()
 		else if (IRA <= 0x2F)
 			INPUTS = MIXS[IRA - 0x20] << 4;  //MIXS is 20 bit
 		else if (IRA <= 0x31)
-			INPUTS = 0;
+			INPUTS = EXTS[IRA - 0x30] << 8;  //EXTS is 16 bit 
 		else
 			return;
 

--- a/src/mame/drivers/model2.cpp
+++ b/src/mame/drivers/model2.cpp
@@ -4,7 +4,7 @@
     Sega Model 2: i960KB + (5x TGP) or (2x SHARC) or (2x TGPx4)
     System 24 tilemaps
     Custom Sega/Lockheed-Martin rasterization hardware
-    (68000 + YM3834 + 2x MultiPCM) or (68000 + SCSP)
+    (68000 + YM3438 + 2x MultiPCM) or (68000 + SCSP)
 
     Hardware and protection reverse-engineering and general assistance by ElSemi.
     MAME driver by R. Belmont, Olivier Galibert, ElSemi and Angelo Salese.
@@ -2449,17 +2449,17 @@ MACHINE_CONFIG_START(model2_state::model2_screen)
 MACHINE_CONFIG_END
 
 MACHINE_CONFIG_START(model2_state::model2_scsp)
-	MCFG_DEVICE_ADD("audiocpu", M68000, 12000000)
+	MCFG_DEVICE_ADD("audiocpu", M68000, 45158000/4) // SCSP Clock / 2
 	MCFG_DEVICE_PROGRAM_MAP(model2_snd)
 
 	SPEAKER(config, "lspeaker").front_left();
 	SPEAKER(config, "rspeaker").front_right();
 
-	MCFG_DEVICE_ADD("scsp", SCSP)
-	MCFG_DEVICE_ADDRESS_MAP(0, scsp_map)
-	MCFG_SCSP_IRQ_CB(WRITE8(*this, model2_state,scsp_irq))
-	MCFG_SOUND_ROUTE(0, "lspeaker", 2.0)
-	MCFG_SOUND_ROUTE(0, "rspeaker", 2.0)
+	SCSP(config, m_scsp, 45158000/2); // 45.158MHz XTAL at Video board(Model 2A-CRX)
+	m_scsp->set_addrmap(0, &model2_state::scsp_map);
+	m_scsp->irq_cb().set(FUNC(model2_state::scsp_irq));
+	m_scsp->add_route(0, "lspeaker", 1.0);
+	m_scsp->add_route(1, "rspeaker", 1.0);
 
 	I8251(config, m_uart, 8000000); // uPD71051C, clock unknown
 //  m_uart->rxrdy_handler().set(FUNC(model2_state::sound_ready_w));

--- a/src/mame/drivers/model3.cpp
+++ b/src/mame/drivers/model3.cpp
@@ -6023,7 +6023,7 @@ void model3_state::add_cpu_166mhz(machine_config &config)
 
 void model3_state::add_base_devices(machine_config &config)
 {
-	M68000(config, m_audiocpu, 12000000);
+	M68000(config, m_audiocpu, 45158000/4); // SCSP Clock / 2
 	m_audiocpu->set_addrmap(AS_PROGRAM, &model3_state::model3_snd);
 
 	EEPROM_93C46_16BIT(config, m_eeprom);
@@ -6044,16 +6044,16 @@ void model3_state::add_base_devices(machine_config &config)
 	SPEAKER(config, "lspeaker").front_left();
 	SPEAKER(config, "rspeaker").front_right();
 
-	SCSP(config, m_scsp1);
+	SCSP(config, m_scsp1, 45158000/2); // 45.158 MHz XTAL
 	m_scsp1->set_addrmap(0, &model3_state::scsp1_map);
 	m_scsp1->irq_cb().set(FUNC(model3_state::scsp_irq));
-	m_scsp1->add_route(0, "lspeaker", 2.0);
-	m_scsp1->add_route(0, "rspeaker", 2.0);
+	m_scsp1->add_route(0, "lspeaker", 1.0);
+	m_scsp1->add_route(1, "rspeaker", 1.0);
 
-	scsp_device &scsp2(SCSP(config, "scsp2"));
+	scsp_device &scsp2(SCSP(config, "scsp2", 45158000/2));
 	scsp2.set_addrmap(0, &model3_state::scsp2_map);
-	scsp2.add_route(0, "lspeaker", 2.0);
-	scsp2.add_route(0, "rspeaker", 2.0);
+	scsp2.add_route(0, "lspeaker", 1.0);
+	scsp2.add_route(1, "rspeaker", 1.0);
 }
 
 void model3_state::add_scsi_devices(machine_config &config)

--- a/src/mame/drivers/saturn.cpp
+++ b/src/mame/drivers/saturn.cpp
@@ -846,17 +846,16 @@ MACHINE_CONFIG_START(sat_console_state::saturn)
 	SPEAKER(config, "lspeaker").front_left();
 	SPEAKER(config, "rspeaker").front_right();
 
-	MCFG_DEVICE_ADD(m_scsp, SCSP)
-	MCFG_DEVICE_ADDRESS_MAP(0, scsp_mem)
-	MCFG_SCSP_IRQ_CB(WRITE8(*this, saturn_state, scsp_irq))
-	MCFG_SCSP_MAIN_IRQ_CB(WRITELINE(m_scu, sega_scu_device, sound_req_w))
-	MCFG_SCSP_EXTS_CB(READ16("stvcd", stvcd_device, channel_volume_r))
-	MCFG_SOUND_ROUTE(0, "lspeaker", 1.0)
-	MCFG_SOUND_ROUTE(1, "rspeaker", 1.0)
+	SCSP(config, m_scsp, 8467200*8/3); // 8.4672 MHz EXTCLK * 8 / 3 = 22.5792 MHz
+	m_scsp->set_addrmap(0, &sat_console_state::scsp_mem);
+	m_scsp->irq_cb().set(FUNC(saturn_state::scsp_irq));
+	m_scsp->main_irq_cb().set(m_scu, FUNC(sega_scu_device::sound_req_w));
+	m_scsp->add_route(0, "lspeaker", 1.0);
+	m_scsp->add_route(1, "rspeaker", 1.0);
 
 	MCFG_DEVICE_ADD("stvcd", STVCD, 0)
-	//MCFG_SOUND_ROUTE(0, "lspeaker", 1.0)
-	//MCFG_SOUND_ROUTE(1, "rspeaker", 1.0)
+	MCFG_SOUND_ROUTE(0, "scsp", 1.0, 0)
+	MCFG_SOUND_ROUTE(1, "scsp", 1.0, 1)
 
 	MCFG_SATURN_CONTROL_PORT_ADD("ctrl1", saturn_controls, "joypad")
 	MCFG_SATURN_CONTROL_PORT_ADD("ctrl2", saturn_controls, "joypad")

--- a/src/mame/drivers/stv.cpp
+++ b/src/mame/drivers/stv.cpp
@@ -1176,12 +1176,12 @@ MACHINE_CONFIG_START(stv_state::stv)
 	SPEAKER(config, "lspeaker").front_left();
 	SPEAKER(config, "rspeaker").front_right();
 
-	MCFG_DEVICE_ADD("scsp", SCSP)
-	MCFG_DEVICE_ADDRESS_MAP(0, scsp_mem)
-	MCFG_SCSP_IRQ_CB(WRITE8(*this, saturn_state, scsp_irq))
-	MCFG_SCSP_MAIN_IRQ_CB(WRITELINE("scu", sega_scu_device, sound_req_w))
-	MCFG_SOUND_ROUTE(0, "lspeaker", 1.0)
-	MCFG_SOUND_ROUTE(1, "rspeaker", 1.0)
+	SCSP(config, m_scsp, 22579200); // TODO : Unknown clock, divider
+	m_scsp->set_addrmap(0, &stv_state::scsp_mem);
+	m_scsp->irq_cb().set(FUNC(saturn_state::scsp_irq));
+	m_scsp->main_irq_cb().set(m_scu, FUNC(sega_scu_device::sound_req_w));
+	m_scsp->add_route(0, "lspeaker", 1.0);
+	m_scsp->add_route(1, "rspeaker", 1.0);
 MACHINE_CONFIG_END
 
 MACHINE_CONFIG_START(stv_state::stv_5881)
@@ -1199,11 +1199,8 @@ MACHINE_CONFIG_START(stv_state::stvcd)
 	MCFG_DEVICE_PROGRAM_MAP(stvcd_mem)
 
 	MCFG_DEVICE_ADD("stvcd", STVCD, 0)
-	//MCFG_SOUND_ROUTE(0, "lspeaker", 1.0)
-	//MCFG_SOUND_ROUTE(1, "rspeaker", 1.0)
-
-	MCFG_DEVICE_MODIFY("scsp")
-	MCFG_SCSP_EXTS_CB(READ16("stvcd", stvcd_device, channel_volume_r))
+	MCFG_SOUND_ROUTE(0, "scsp", 1.0, 0)
+	MCFG_SOUND_ROUTE(1, "scsp", 1.0, 1)
 MACHINE_CONFIG_END
 
 


### PR DESCRIPTION
Implement EXTS Mixing, DAC18B, Remove MCFGs, Reduce machine().device
coolridr.cpp : Make screen update routine related to cliprect, Minor reduce duplicate
coolridr.cpp, model2, model3 : Correct SCSP / Sound CPU clock/Sound output balance, Add notes
saturn.cpp, stv.cpp : Correct SCSP clock, Add notes
stvcd.cpp : Add device_mixer_interface related to SCSP EXTS