### PR TITLE
Revert "hp9k3xx: call reset() instead of manually resetting subdevice…

### DIFF
--- a/src/devices/bus/hp_dio/human_interface.cpp
+++ b/src/devices/bus/hp_dio/human_interface.cpp
@@ -146,12 +146,13 @@ void human_interface_device::device_reset()
 	m_rtc->write_w(CLEAR_LINE);
 	m_rtc->read_w(CLEAR_LINE);
 	m_rtc->cs2_w(CLEAR_LINE);
+	m_iocpu->reset();
 }
 
 WRITE_LINE_MEMBER(human_interface_device::reset_in)
 {
 	if (state)
-		reset();
+		device_reset();
 }
 
 void human_interface_device::update_gpib_irq()
@@ -199,7 +200,7 @@ WRITE8_MEMBER(human_interface_device::gpib_w)
 
 	switch (offset) {
 	case 0:
-		reset();
+		device_reset();
 		break;
 
 	case 1:


### PR DESCRIPTION
…s (nw)"

This reverts commit eb3f890729de41001c1e2aa3e720a8c175e15ba0.

Calling reset() recursively on the device chain doesn't work as this also resets the IEEE488 bus, which doesn't happen on real hardware. This breaks booting HP BASIC, as BASIC doesn't expect the floppy drive doing a reset.