### PR TITLE
m68kfpu: add (d16,An) addr mode to WRITE_EA_FPE()

### DIFF
--- a/src/devices/cpu/m68000/m68kfpu.hxx
+++ b/src/devices/cpu/m68000/m68kfpu.hxx
@@ -1119,6 +1119,13 @@ void WRITE_EA_FPE(int ea, floatx80 fpr)
 			break;
 		}
 
+		case 5:     // (d16,An)
+		{
+			uint32_t ea = EA_AY_DI_32();
+			store_extended_float80(ea, fpr);
+			break;
+		}
+
 		case 7:
 		{
 			switch (reg)


### PR DESCRIPTION
required by netbsd ps command, which utilizes the FPU.