### PR TITLE
Include cmath header for atan in std::

### DIFF
--- a/src/mame/video/xavix.cpp
+++ b/src/mame/video/xavix.cpp
@@ -7,6 +7,8 @@
 // #define VERBOSE 1
 #include "logmacro.h"
 
+#include <cmath>
+
 inline void xavix_state::set_data_address(int address, int bit)
 {
 	m_tmp_dataaddress = address;


### PR DESCRIPTION
This fixes a compilation on NetBSD where the compiler was complaining that atan is not in the std:: namespace.