### PR TITLE
Fix compilation errors with -Og

### DIFF
--- a/scripts/src/3rdparty.lua
+++ b/scripts/src/3rdparty.lua
@@ -203,6 +203,9 @@ buildoptions {
 }
 
 configuration { }
+buildoptions {
+	"-Wno-error=maybe-uninitialized"
+}
 defines {
 	"SOFTFLOAT_ROUND_ODD",
 	"INLINE_LEVEL=5",

--- a/src/lib/util/png.cpp
+++ b/src/lib/util/png.cpp
@@ -705,7 +705,7 @@ public:
 		{
 			// read a chunk
 			std::unique_ptr<std::uint8_t []> chunk_data;
-			std::uint32_t chunk_type, chunk_length;
+			std::uint32_t chunk_type = 0, chunk_length;
 			error = read_chunk(fp, chunk_data, chunk_type, chunk_length);
 			if (PNGERR_NONE == error)
 			{


### PR DESCRIPTION
When compiling with the option `-Og` (or with the make option `OPTIMIZE=g`), g++ emit an error about some variables that may be used uninitializes. It appear that with `-Og`, GCC's static analyzer falls into that spot where it is smart enough to detect that the variable is conditionally initialized, but not smart enough to realize it is only used when initialized.