### PR TITLE
pgm2.cpp, pgm2_memcard.cpp : Cleanups, Updates

### DIFF
--- a/src/mame/drivers/pgm2.cpp
+++ b/src/mame/drivers/pgm2.cpp
@@ -1272,7 +1272,7 @@ static void sprite_colour_decode(u16* rom, int len)
 
 READ32_MEMBER(pgm2_state::orleg2_speedup_r)
 {
-	int pc = m_maincpu->pc();
+	u32 const pc = m_maincpu->pc();
 	if ((pc == 0x1002faec) || (pc == 0x1002f9b8))
 	{
 		if ((m_mainram[0x20114 / 4] == 0x00) && (m_mainram[0x20118 / 4] == 0x00))
@@ -1288,7 +1288,7 @@ READ32_MEMBER(pgm2_state::orleg2_speedup_r)
 
 READ32_MEMBER(pgm2_state::kov2nl_speedup_r)
 {
-	int pc = m_maincpu->pc();
+	u32 const pc = m_maincpu->pc();
 
 	if ((pc == 0x10053a94) || (pc == 0x1005332c) || (pc == 0x1005327c))
 	{
@@ -1307,7 +1307,7 @@ READ32_MEMBER(pgm2_state::kov2nl_speedup_r)
 
 READ32_MEMBER(pgm2_state::kof98umh_speedup_r)
 {
-	int pc = m_maincpu->pc();
+	u32 const pc = m_maincpu->pc();
 
 	if (pc == 0x100028f6)
 	{
@@ -1326,7 +1326,7 @@ READ32_MEMBER(pgm2_state::kof98umh_speedup_r)
 
 READ32_MEMBER(pgm2_state::kov3_speedup_r)
 {
-	int pc = m_maincpu->pc();
+	u32 const pc = m_maincpu->pc();
 
 	if ((pc == 0x1000729a) || (pc == 0x1000729e))
 	{
@@ -1348,7 +1348,7 @@ READ32_MEMBER(pgm2_state::kov3_speedup_r)
 
 READ32_MEMBER(pgm2_state::ddpdojt_speedup_r)
 {
-	int pc = m_maincpu->pc();
+	u32 const pc = m_maincpu->pc();
 
 	if (pc == 0x10001a7e)
 	{
@@ -1367,7 +1367,7 @@ READ32_MEMBER(pgm2_state::ddpdojt_speedup_r)
 
 READ32_MEMBER(pgm2_state::ddpdojt_speedup2_r)
 {
-	int pc = m_maincpu->pc();
+	u32 const pc = m_maincpu->pc();
 
 	if (pc == 0x1008fefe || pc == 0x1008fbe8)
 	{

--- a/src/mame/drivers/pgm2.cpp
+++ b/src/mame/drivers/pgm2.cpp
@@ -882,17 +882,17 @@ void pgm2_state::pgm2_ramrom(machine_config &config)
 
 #define ORLEG2_INTERNAL_CHINA \
 	ROM_REGION( 0x04000, "maincpu", 0 ) \
-	ROM_LOAD( "xyj2_cn.igs036", 0x00000000, 0x0004000, CRC(bcce7641) SHA1(c3b5cf6e9f6eae09b6785314777a52b34c3c7657) ) \
+	ROM_LOAD( "xyj2_cn.igs036", 0x00000000, 0x0004000, CRC(bcce7641) SHA1(c3b5cf6e9f6eae09b6785314777a52b34c3c7657) ) /* Core V100 China */ \
 	ROM_REGION( 0x108, "default_card", 0 ) \
 	ROM_LOAD( "blank_orleg2_china_card.pg2", 0x000, 0x108, CRC(dc29556f) SHA1(2335cc7af25d4dd9763c6944d3f0eb50276de80a) )
 
 #define ORLEG2_INTERNAL_OVERSEAS \
 	ROM_REGION( 0x04000, "maincpu", 0 ) \
-	ROM_LOAD( "ol2_fa.igs036", 0x00000000, 0x0004000, CRC(cc4d398a) SHA1(c50bcc81f02cd5aa8ad157d73209dc53bdedc023) )
+	ROM_LOAD( "ol2_fa.igs036", 0x00000000, 0x0004000, CRC(cc4d398a) SHA1(c50bcc81f02cd5aa8ad157d73209dc53bdedc023) ) // Core V100 Oversea
 
 #define ORLEG2_INTERNAL_JAPAN \
 	ROM_REGION( 0x04000, "maincpu", 0 ) \
-	ROM_LOAD( "ol2_a10.igs036", 0x00000000, 0x0004000, CRC(69375284) SHA1(a120c6a3d8d7898cc3ca508abea78e5e54090c66) )
+	ROM_LOAD( "ol2_a10.igs036", 0x00000000, 0x0004000, CRC(69375284) SHA1(a120c6a3d8d7898cc3ca508abea78e5e54090c66) ) // Core V100 Japan
 
 ROM_START( orleg2 )
 	ORLEG2_INTERNAL_OVERSEAS
@@ -988,7 +988,7 @@ ROM_END
 // Region 0x00 - China
 #define KOV2NL_INTERNAL_CHINA \
 	ROM_REGION( 0x04000, "maincpu", 0 ) \
-	ROM_LOAD( "gsyx_igs036_china.rom", 0x00000000, 0x0004000, CRC(e09fe4ce) SHA1(c0cac64ef8727cbe79d503ec4df66ddb6f2c925e) ) \
+	ROM_LOAD( "gsyx_igs036_china.rom", 0x00000000, 0x0004000, CRC(e09fe4ce) SHA1(c0cac64ef8727cbe79d503ec4df66ddb6f2c925e) ) /* Core V100 China */ \
 	ROM_REGION( 0x108, "default_card", 0 ) \
 	ROM_LOAD( "blank_gsyx_china.pg2", 0x000, 0x108, CRC(02842ae8) SHA1(a6cda633b09a706039a79b73db2c258094826f85) )
 
@@ -1008,7 +1008,7 @@ ROM_END
 // Region 0x05 - Overseas
 #define KOV2NL_INTERNAL_OVERSEA \
 	ROM_REGION( 0x04000, "maincpu", 0 ) \
-	ROM_LOAD( "kov2nl_igs036_oversea.rom", 0x00000000, 0x0004000, CRC(25ec60cd) SHA1(7dd12d2bc642bfa79520676fe5de458ce7d08ef6) ) \
+	ROM_LOAD( "kov2nl_igs036_oversea.rom", 0x00000000, 0x0004000, CRC(25ec60cd) SHA1(7dd12d2bc642bfa79520676fe5de458ce7d08ef6) ) /* Core V100 oversea */ \
 	ROM_REGION( 0x108, "default_card", 0 ) \
 	ROM_LOAD( "blank_kov2nl_overseas_card.pg2", 0x000, 0x108, CRC(1155f01f) SHA1(60f7bed1461b362a3da687503cd72ed2d5e96f30) )
 
@@ -1117,7 +1117,7 @@ ROM_END
 
 #define KOV3_INTERNAL_CHINA \
 	ROM_REGION( 0x04000, "maincpu", 0 ) \
-	ROM_LOAD( "kov3_igs036_china.rom", 0x00000000, 0x0004000, CRC(c7d33764) SHA1(5cd48f876e637d60391d39ac6e40bf243300cc75) ) \
+	ROM_LOAD( "kov3_igs036_china.rom", 0x00000000, 0x0004000, CRC(c7d33764) SHA1(5cd48f876e637d60391d39ac6e40bf243300cc75) ) /* Core V100 China */ \
 	ROM_REGION( 0x108, "default_card", 0 ) \
 	ROM_LOAD( "blank_kov3_china_card.pg2", 0x000, 0x108, CRC(bd5a968f) SHA1(b9045eb70e02afda7810431c592208053d863980) )
 
@@ -1197,7 +1197,7 @@ all others:         SPANSION S99-50070
 
 ROM_START( kof98umh )
 	ROM_REGION( 0x04000, "maincpu", 0 )
-	ROM_LOAD( "kof98umh_internal_rom.bin",       0x00000000, 0x0004000, CRC(3ed2e50f) SHA1(35310045d375d9dda36c325e35257123a7b5b8c7) )
+	ROM_LOAD( "kof98umh_internal_rom.bin",       0x00000000, 0x0004000, CRC(3ed2e50f) SHA1(35310045d375d9dda36c325e35257123a7b5b8c7) ) // Core V100 China
 
 	ROM_REGION( 0x1000000, "mainrom", 0 )
 	ROM_LOAD( "kof98umh_v100cn.u4",        0x00000000, 0x1000000, CRC(2ea91e3b) SHA1(5a586bb99cc4f1b02e0db462d5aff721512e0640) ) // V100 09-08-23 17:52:03

--- a/src/mame/includes/pgm2.h
+++ b/src/mame/includes/pgm2.h
@@ -19,10 +19,10 @@
 
 struct kov3_module_key
 {
-	uint8_t key[8];
-	uint8_t sum[8];
-	uint32_t addr_xor; // 22bit
-	uint16_t data_xor;
+	u8 key[8];
+	u8 sum[8];
+	u32 addr_xor; // 22bit
+	u16 data_xor;
 };
 
 class pgm2_state : public driver_device
@@ -51,9 +51,29 @@ public:
 		m_bg_palette(*this, "bg_palette"),
 		m_tx_palette(*this, "tx_palette"),
 		m_mcu_timer(*this, "mcu_timer"),
-		m_memcard(*this, "memcard_p%u", 1U)
+		m_memcard(*this, "memcard_p%u", 1U),
+		m_mainrom(*this, "mainrom")
 	{ }
 
+	void init_kov2nl();
+	void init_orleg2();
+	void init_ddpdojt();
+	void init_kov3();
+	void init_kov3_104();
+	void init_kov3_102();
+	void init_kov3_101();
+	void init_kov3_100();
+	void init_kof98umh();
+
+	void pgm2_ramrom(machine_config &config);
+	void pgm2_lores(machine_config &config);
+	void pgm2(machine_config &config);
+	void pgm2_hires(machine_config &config);
+	void pgm2_map(address_map &map);
+	void pgm2_module_rom_map(address_map &map);
+	void pgm2_ram_rom_map(address_map &map);
+	void pgm2_rom_map(address_map &map);
+private:
 	DECLARE_READ32_MEMBER(unk_startup_r);
 	DECLARE_READ32_MEMBER(rtc_r);
 	DECLARE_READ32_MEMBER(mcu_r);
@@ -71,9 +91,9 @@ public:
 	DECLARE_READ32_MEMBER(pio_pdsr_r);
 	DECLARE_WRITE16_MEMBER(module_rom_w);
 	DECLARE_READ16_MEMBER(module_rom_r);
-	DECLARE_READ_LINE_MEMBER(module_data_r);
-	DECLARE_WRITE_LINE_MEMBER(module_data_w);
-	DECLARE_WRITE_LINE_MEMBER(module_clk_w);
+	int module_data_r();
+	void module_data_w(int state);
+	void module_clk_w(int state);
 
 	DECLARE_READ32_MEMBER(orleg2_speedup_r);
 	DECLARE_READ32_MEMBER(kov2nl_speedup_r);
@@ -87,112 +107,89 @@ public:
 	DECLARE_WRITE32_MEMBER(encryption_do_w);
 	DECLARE_WRITE32_MEMBER(sprite_encryption_w);
 
-	void init_kov2nl();
-	void init_orleg2();
-	void init_ddpdojt();
-	void init_kov3();
-	void init_kov3_104();
-	void init_kov3_102();
-	void init_kov3_101();
-	void init_kov3_100();
-	void init_kof98umh();
-
-	uint32_t screen_update_pgm2(screen_device &screen, bitmap_rgb32 &bitmap, const rectangle &cliprect);
-	DECLARE_WRITE_LINE_MEMBER(screen_vblank_pgm2);
-	DECLARE_WRITE_LINE_MEMBER(irq);
-
-	INTERRUPT_GEN_MEMBER(igs_interrupt);
-	TIMER_DEVICE_CALLBACK_MEMBER(igs_interrupt2);
-
-	void pgm2_ramrom(machine_config &config);
-	void pgm2_lores(machine_config &config);
-	void pgm2(machine_config &config);
-	void pgm2_hires(machine_config &config);
-	void pgm2_map(address_map &map);
-	void pgm2_module_rom_map(address_map &map);
-	void pgm2_ram_rom_map(address_map &map);
-	void pgm2_rom_map(address_map &map);
-private:
 	virtual void machine_start() override;
 	virtual void machine_reset() override;
 	virtual void video_start() override;
+	virtual void device_post_load() override;
 
 	TILE_GET_INFO_MEMBER(get_fg_tile_info);
 	TILE_GET_INFO_MEMBER(get_bg_tile_info);
 
-	void decrypt_kov3_module(uint32_t addrxor, uint16_t dataxor);
+	u32 screen_update(screen_device &screen, bitmap_rgb32 &bitmap, const rectangle &cliprect);
+	DECLARE_WRITE_LINE_MEMBER(screen_vblank);
+	DECLARE_WRITE_LINE_MEMBER(irq);
+
+	TIMER_DEVICE_CALLBACK_MEMBER(mcu_interrupt);
+
+	void decrypt_kov3_module(u32 addrxor, u16 dataxor);
 
 	tilemap_t    *m_fg_tilemap;
 	tilemap_t    *m_bg_tilemap;
 
-	std::unique_ptr<uint32_t[]>     m_spritebufferram; // buffered spriteram
+	std::unique_ptr<u32[]>     m_spritebufferram; // buffered spriteram
 
-	bitmap_ind16 m_sprite_bitmap;
-
-	void skip_sprite_chunk(int &palette_offset, uint32_t maskdata, int reverse);
-	void draw_sprite_pixel(const rectangle &cliprect, int palette_offset, int realx, int realy, int pal);
-	void draw_sprite_chunk(const rectangle &cliprect, int &palette_offset, int x, int realy, int sizex, int xdraw, int pal, uint32_t maskdata, uint32_t zoomx_bits, int repeats, int &realxdraw, int realdraw_inc, int palette_inc);
-	void draw_sprite_line(const rectangle &cliprect, int &mask_offset, int &palette_offset, int x, int realy, int flipx, int reverse, int sizex, int pal, int zoomybit, int zoomx_bits, int xrepeats);
-	void draw_sprites(screen_device &screen, const rectangle &cliprect, uint32_t* spriteram);
-	void copy_sprites_from_bitmap(screen_device &screen, bitmap_rgb32 &bitmap, const rectangle &cliprect, int pri);
-
-	uint32_t m_sprites_mask_mask;
-	uint32_t m_sprites_colour_mask;
+	void skip_sprite_chunk(u32 &palette_offset, u32 maskdata, bool reverse);
+	void draw_sprite_pixel(bitmap_rgb32 &bitmap, const rectangle &cliprect, u32 palette_offset, s16 realx, s16 realy, u16 pal, u8 pri);
+	void draw_sprite_chunk(bitmap_rgb32 &bitmap, const rectangle &cliprect, u32 &palette_offset, s16 x, s16 realy,
+			u16 sizex, int xdraw, u16 pal, u32 maskdata, u32 zoomx_bits, u8 repeats, s16 &realxdraw, s8 realdraw_inc, s8 palette_inc, u8 pri);
+	void draw_sprite_line(bitmap_rgb32 &bitmap, const rectangle &cliprect, u32 &mask_offset, u32 &palette_offset, s16 x, s16 realy,
+			bool flipx, bool reverse, u16 sizex, u16 pal, u8 zoomybit, u32 zoomx_bits, u8 xrepeats, u8 pri);
+	void draw_sprites(bitmap_rgb32 &bitmap, const rectangle &cliprect, u32* spriteram);
 
 	void common_encryption_init();
-	uint8_t m_encryption_table[0x100];
-	int m_has_decrypted;    // so we only do it once.
-	int m_has_decrypted_kov3_module;
-	uint32_t m_spritekey;
-	uint32_t m_realspritekey;
-	int m_sprite_predecrypted;
+	u8 m_encryption_table[0x100];
+	bool m_has_decrypted;    // so we only do it once.
+	bool m_has_decrypted_kov3_module;
+	u32 m_spritekey;
+	u32 m_realspritekey;
+	bool m_sprite_predecrypted;
 
-	uint8_t m_shareram[0x100];
-	uint16_t m_share_bank;
-	uint32_t m_mcu_regs[8];
-	uint32_t m_mcu_result0;
-	uint32_t m_mcu_result1;
-	uint8_t m_mcu_last_cmd;
-	void mcu_command(address_space &space, bool is_command);
+	u8 m_shareram[0x100];
+	u16 m_share_bank;
+	u32 m_mcu_regs[8];
+	u32 m_mcu_result0;
+	u32 m_mcu_result1;
+	u8 m_mcu_last_cmd;
+	void mcu_command(bool is_command);
 
-	std::vector<uint8_t> m_encrypted_copy;
+	std::vector<u8> m_encrypted_copy;
 
-	uint32_t pio_out_data;
+	u32 m_pio_out_data;
 	const kov3_module_key *module_key;
 	bool module_sum_read;
-	uint32_t module_in_latch;
-	uint32_t module_out_latch;
+	u32 module_in_latch;
+	u32 module_out_latch;
 	int module_prev_state;
 	int module_clk_cnt;
-	uint8_t module_rcv_buf[10];
-	uint8_t module_send_buf[9];
-
-	void postload();
+	u8 module_rcv_buf[10];
+	u8 module_send_buf[9];
 
 	// devices
 	required_device<cpu_device> m_maincpu;
 	required_device<screen_device> m_screen;
-	required_shared_ptr<uint32_t> m_lineram;
-	required_shared_ptr<uint32_t> m_sp_zoom;
-	required_shared_ptr<uint32_t> m_mainram;
-	optional_shared_ptr<uint32_t> m_romboard_ram;
-	required_shared_ptr<uint32_t> m_fg_videoram;
-	required_shared_ptr<uint32_t> m_bg_videoram;
-	required_shared_ptr<uint32_t> m_sp_videoram;
-	required_shared_ptr<uint32_t> m_bgscroll;
-	required_shared_ptr<uint32_t> m_fgscroll;
-	required_shared_ptr<uint32_t> m_vidmode;
+	required_shared_ptr<u32> m_lineram;
+	required_shared_ptr<u32> m_sp_zoom;
+	required_shared_ptr<u32> m_mainram;
+	optional_shared_ptr<u32> m_romboard_ram;
+	required_shared_ptr<u32> m_fg_videoram;
+	required_shared_ptr<u32> m_bg_videoram;
+	required_shared_ptr<u32> m_sp_videoram;
+	required_shared_ptr<u32> m_bgscroll;
+	required_shared_ptr<u32> m_fgscroll;
+	required_shared_ptr<u32> m_vidmode;
 	required_device<gfxdecode_device> m_gfxdecode2;
 	required_device<gfxdecode_device> m_gfxdecode3;
 	required_device<arm_aic_device> m_arm_aic;
-	required_region_ptr<uint8_t> m_sprites_mask;
-	required_region_ptr<uint8_t> m_sprites_colour;
+	required_region_ptr<u8> m_sprites_mask;
+	required_region_ptr<u8> m_sprites_colour;
 	required_device<palette_device> m_sp_palette;
 	required_device<palette_device> m_bg_palette;
 	required_device<palette_device> m_tx_palette;
 	required_device<timer_device> m_mcu_timer;
 
 	optional_device_array<pgm2_memcard_device, 4> m_memcard;
+
+	required_memory_region m_mainrom;
 };
 
 #endif

--- a/src/mame/machine/pgm2_memcard.cpp
+++ b/src/mame/machine/pgm2_memcard.cpp
@@ -45,7 +45,7 @@ void pgm2_memcard_device::device_start()
 
 image_init_result pgm2_memcard_device::call_load()
 {
-	authenticated = false;
+	m_authenticated = false;
 	if(length() != 0x108)
 		return image_init_result::FAIL;
 
@@ -65,7 +65,7 @@ image_init_result pgm2_memcard_device::call_load()
 
 void pgm2_memcard_device::call_unload()
 {
-	authenticated = false;
+	m_authenticated = false;
 	fseek(0, SEEK_SET);
 	fwrite(m_memcard_data, 0x100);
 	fwrite(m_protection_data, 4);
@@ -74,7 +74,7 @@ void pgm2_memcard_device::call_unload()
 
 image_init_result pgm2_memcard_device::call_create(int format_type, util::option_resolution *format_options)
 {
-	authenticated = false;
+	m_authenticated = false;
 	// cards must contain valid defaults for each game / region or they don't work?
 	memory_region *rgn = memregion("^default_card");
 
@@ -92,16 +92,16 @@ image_init_result pgm2_memcard_device::call_create(int format_type, util::option
 	return image_init_result::PASS;
 }
 
-void pgm2_memcard_device::auth(uint8_t p1, uint8_t p2, uint8_t p3)
+void pgm2_memcard_device::auth(u8 p1, u8 p2, u8 p3)
 {
 	if (m_security_data[0] & 7)
 	{
 		if (m_security_data[1] == p1 && m_security_data[2] == p2 && m_security_data[3] == p3) {
-			authenticated = true;
+			m_authenticated = true;
 			m_security_data[0] = 7;
 		}
 		else {
-			authenticated = false;
+			m_authenticated = false;
 			m_security_data[0] >>= 1; // hacky
 			if (m_security_data[0] & 7)
 				popmessage("Wrong IC Card password !!!\n");
@@ -111,39 +111,39 @@ void pgm2_memcard_device::auth(uint8_t p1, uint8_t p2, uint8_t p3)
 	}
 }
 
-READ8_MEMBER(pgm2_memcard_device::read)
+u8 pgm2_memcard_device::read(offs_t offset)
 {
 	return m_memcard_data[offset];
 }
 
-WRITE8_MEMBER(pgm2_memcard_device::write)
+void pgm2_memcard_device::write(offs_t offset, u8 data)
 {
-	if (authenticated && (offset >= 0x20 || (m_protection_data[offset>>3] & (1 <<(offset & 7)))))
+	if (m_authenticated && (offset >= 0x20 || (m_protection_data[offset>>3] & (1 <<(offset & 7)))))
 	{
 		m_memcard_data[offset] = data;
 	}
 }
 
-READ8_MEMBER(pgm2_memcard_device::read_prot)
+u8 pgm2_memcard_device::read_prot(offs_t offset)
 {
 	return m_protection_data[offset];
 }
 
-WRITE8_MEMBER(pgm2_memcard_device::write_prot)
+void pgm2_memcard_device::write_prot(offs_t offset, u8 data)
 {
-	if (authenticated)
+	if (m_authenticated)
 		m_protection_data[offset] &= data;
 }
 
-READ8_MEMBER(pgm2_memcard_device::read_sec)
+u8 pgm2_memcard_device::read_sec(offs_t offset)
 {
-	if (!authenticated)
+	if (!m_authenticated)
 		return 0xff; // guess
 	return m_security_data[offset];
 }
 
-WRITE8_MEMBER(pgm2_memcard_device::write_sec)
+void pgm2_memcard_device::write_sec(offs_t offset, u8 data)
 {
-	if (authenticated)
+	if (m_authenticated)
 		m_security_data[offset] = data;
 }

--- a/src/mame/machine/pgm2_memcard.h
+++ b/src/mame/machine/pgm2_memcard.h
@@ -43,21 +43,21 @@ public:
 	// device-level overrides
 	virtual void device_start() override;
 
-	DECLARE_READ8_MEMBER(read);
-	DECLARE_WRITE8_MEMBER(write);
-	DECLARE_READ8_MEMBER(read_prot);
-	DECLARE_WRITE8_MEMBER(write_prot);
-	DECLARE_READ8_MEMBER(read_sec);
-	DECLARE_WRITE8_MEMBER(write_sec);
-	void auth(uint8_t p1, uint8_t p2, uint8_t p3);
+	u8 read(offs_t offset);
+	void write(offs_t offset, u8 data);
+	u8 read_prot(offs_t offset);
+	void write_prot(offs_t offset, u8 data);
+	u8 read_sec(offs_t offset);
+	void write_sec(offs_t offset, u8 data);
+	void auth(u8 p1, u8 p2, u8 p3);
 
 	/* returns the index of the current memory card, or -1 if none */
 	int present() { return is_loaded() ? 0 : -1; }
 private:
-	uint8_t m_memcard_data[0x100];
-	uint8_t m_protection_data[4];
-	uint8_t m_security_data[4];
-	bool authenticated;
+	u8 m_memcard_data[0x100];
+	u8 m_protection_data[4];
+	u8 m_security_data[4];
+	bool m_authenticated;
 };
 
 

--- a/src/mame/video/pgm2.cpp
+++ b/src/mame/video/pgm2.cpp
@@ -4,31 +4,40 @@
 #include "emu.h"
 #include "includes/pgm2.h"
 
-inline void pgm2_state::draw_sprite_pixel(const rectangle &cliprect, int palette_offset, int realx, int realy, int pal)
+inline void pgm2_state::draw_sprite_pixel(bitmap_rgb32 &bitmap, const rectangle &cliprect, u32 palette_offset, s16 realx, s16 realy, u16 pal, u8 pri)
 {
 	if (cliprect.contains(realx, realy))
 	{
-		uint16_t pix = m_sprites_colour[palette_offset] & 0x3f; // there are some stray 0xff bytes in some roms, so mask
-		uint16_t pendat = pix + (pal * 0x40);
-		uint16_t* dstptr_bitmap = &m_sprite_bitmap.pix16(realy);
-		dstptr_bitmap[realx] = pendat;
+		u8 *dstpri = &m_screen->priority().pix8(realy);
+		if ((dstpri[realx] & 1) == 0)
+		{
+			if (!pri || ((dstpri[realx] & 2) == 0))
+			{
+				u16 const pix = m_sprites_colour[palette_offset] & 0x3f; // there are some stray 0xff bytes in some roms, so mask
+				u16 const pendat = pix + (pal * 0x40);
+				u32* dstptr_bitmap = &bitmap.pix32(realy);
+				dstptr_bitmap[realx] = m_sp_palette->pen(pendat);
+				dstpri[realx] |= 1;
+			}
+		}
 	}
 }
 
-inline void pgm2_state::draw_sprite_chunk(const rectangle &cliprect, int &palette_offset, int x, int realy, int sizex, int xdraw, int pal, uint32_t maskdata, uint32_t zoomx_bits, int repeats, int &realxdraw, int realdraw_inc, int palette_inc)
+inline void pgm2_state::draw_sprite_chunk(bitmap_rgb32 &bitmap, const rectangle &cliprect, u32 &palette_offset, s16 x, s16 realy,
+		u16 sizex, int xdraw, u16 pal, u32 maskdata, u32 zoomx_bits, u8 repeats, s16 &realxdraw, s8 realdraw_inc, s8 palette_inc, u8 pri)
 {
 	for (int xchunk = 0; xchunk < 32; xchunk++)
 	{
-		int pix, xzoombit;
+		u8 pix, xzoombit;
 		if (palette_inc == -1)
 		{
-			pix = (maskdata >> xchunk) & 1;
-			xzoombit = (zoomx_bits >> xchunk) & 1;
+			pix = BIT(maskdata, xchunk);
+			xzoombit = BIT(zoomx_bits, xchunk);
 		}
 		else
 		{
-			pix = (maskdata >> (31 - xchunk)) & 1;
-			xzoombit = (zoomx_bits >> (31 - xchunk)) & 1;
+			pix = BIT(maskdata, 31 - xchunk);
+			xzoombit = BIT(zoomx_bits, 31 - xchunk);
 		}
 
 		if (pix)
@@ -38,26 +47,26 @@ inline void pgm2_state::draw_sprite_chunk(const rectangle &cliprect, int &palett
 				// draw it the base number of times
 				for (int i = 0; i < repeats; i++)
 				{
-					draw_sprite_pixel(cliprect, palette_offset, x + realxdraw, realy, pal);
+					draw_sprite_pixel(bitmap, cliprect, palette_offset, x + realxdraw, realy, pal, pri);
 					realxdraw += realdraw_inc;
 				}
 
 				// draw it again if zoom bit is set
 				if (xzoombit)
 				{
-					draw_sprite_pixel(cliprect, palette_offset, x + realxdraw, realy, pal);
+					draw_sprite_pixel(bitmap, cliprect, palette_offset, x + realxdraw, realy, pal, pri);
 					realxdraw += realdraw_inc;
 				}
 
 				palette_offset += palette_inc;
-				palette_offset &= m_sprites_colour_mask;
+				palette_offset &= m_sprites_colour.mask();
 			}
 			else // shrink
 			{
-				if (xzoombit) draw_sprite_pixel(cliprect, palette_offset, x + realxdraw, realy, pal);
+				if (xzoombit) draw_sprite_pixel(bitmap, cliprect, palette_offset, x + realxdraw, realy, pal, pri);
 
 				palette_offset += palette_inc;
-				palette_offset &= m_sprites_colour_mask;
+				palette_offset &= m_sprites_colour.mask();
 
 				if (xzoombit) realxdraw += realdraw_inc;
 
@@ -86,33 +95,34 @@ inline void pgm2_state::draw_sprite_chunk(const rectangle &cliprect, int &palett
 
 }
 
-inline void pgm2_state::skip_sprite_chunk(int &palette_offset, uint32_t maskdata, int reverse)
+inline void pgm2_state::skip_sprite_chunk(u32 &palette_offset, u32 maskdata, bool reverse)
 {
-	int bits = population_count_32(maskdata);
+	s32 bits = population_count_32(maskdata);
 
 	if (!reverse)
 	{
-		palette_offset+=bits;
+		palette_offset += bits;
 	}
 	else
 	{
-		palette_offset-=bits;
+		palette_offset -= bits;
 	}
 
-	palette_offset &= m_sprites_colour_mask;
+	palette_offset &= m_sprites_colour.mask();
 
 }
 
-inline void pgm2_state::draw_sprite_line(const rectangle &cliprect, int &mask_offset, int &palette_offset, int x, int realy, int flipx, int reverse, int sizex, int pal, int zoomybit, int zoomx_bits, int xrepeats)
+inline void pgm2_state::draw_sprite_line(bitmap_rgb32 &bitmap, const rectangle &cliprect, u32 &mask_offset, u32 &palette_offset, s16 x, s16 realy,
+		bool flipx, bool reverse, u16 sizex, u16 pal, u8 zoomybit, u32 zoomx_bits, u8 xrepeats, u8 pri)
 {
-	int realxdraw = 0;
+	s16 realxdraw = 0;
 
 	if (flipx ^ reverse)
 		realxdraw = (population_count_32(zoomx_bits) * sizex) - 1;
 
 	for (int xdraw = 0; xdraw < sizex; xdraw++)
 	{
-		uint32_t maskdata = m_sprites_mask[mask_offset + 0] << 24;
+		u32 maskdata = m_sprites_mask[mask_offset + 0] << 24;
 		maskdata |= m_sprites_mask[mask_offset + 1] << 16;
 		maskdata |= m_sprites_mask[mask_offset + 2] << 8;
 		maskdata |= m_sprites_mask[mask_offset + 3] << 0;
@@ -128,36 +138,32 @@ inline void pgm2_state::draw_sprite_line(const rectangle &cliprect, int &mask_of
 			mask_offset += 4;
 		}
 
-
-		mask_offset &= m_sprites_mask_mask;
+		mask_offset &= m_sprites_mask.mask();
 
 		if (zoomybit)
 		{
 			if (!flipx)
 			{
-				if (!reverse) draw_sprite_chunk(cliprect, palette_offset, x, realy, sizex, xdraw, pal, maskdata, zoomx_bits, xrepeats, realxdraw, 1, 1);
-				else draw_sprite_chunk(cliprect, palette_offset, x, realy, sizex, xdraw, pal, maskdata, zoomx_bits, xrepeats, realxdraw, -1, -1);
+				if (!reverse) draw_sprite_chunk(bitmap, cliprect, palette_offset, x, realy, sizex, xdraw, pal, maskdata, zoomx_bits, xrepeats, realxdraw, 1, 1, pri);
+				else draw_sprite_chunk(bitmap, cliprect, palette_offset, x, realy, sizex, xdraw, pal, maskdata, zoomx_bits, xrepeats, realxdraw, -1, -1, pri);
 			}
 			else
 			{
-				if (!reverse) draw_sprite_chunk(cliprect, palette_offset, x, realy, sizex, xdraw, pal, maskdata, zoomx_bits, xrepeats, realxdraw, -1, 1);
-				else draw_sprite_chunk(cliprect, palette_offset, x, realy, sizex, xdraw, pal, maskdata, zoomx_bits, xrepeats, realxdraw, 1, -1);
-
+				if (!reverse) draw_sprite_chunk(bitmap, cliprect, palette_offset, x, realy, sizex, xdraw, pal, maskdata, zoomx_bits, xrepeats, realxdraw, -1, 1, pri);
+				else draw_sprite_chunk(bitmap, cliprect, palette_offset, x, realy, sizex, xdraw, pal, maskdata, zoomx_bits, xrepeats, realxdraw, 1, -1, pri);
 			}
 		}
 		else skip_sprite_chunk(palette_offset, maskdata, reverse);
 	}
 }
 
-void pgm2_state::draw_sprites(screen_device &screen, const rectangle &cliprect, uint32_t* spriteram)
+void pgm2_state::draw_sprites(bitmap_rgb32 &bitmap, const rectangle &cliprect, u32* spriteram)
 {
-	m_sprite_bitmap.fill(0x8000, cliprect);
+	s32 endoflist = -1;
 
-	int endoflist = -1;
+	//logerror("frame\n");
 
-	//printf("frame\n");
-
-	for (int i = 0; i < 0x2000 / 4; i += 4)
+	for (int i = 0; i < m_sp_videoram.bytes() / 4; i += 4)
 	{
 		if (spriteram[i + 2] & 0x80000000)
 		{
@@ -166,47 +172,47 @@ void pgm2_state::draw_sprites(screen_device &screen, const rectangle &cliprect, 
 		}
 	}
 
-	if (endoflist != -1)
+	if (endoflist > 0)
 	{
-		for (int i = 0; i < endoflist - 2; i += 4)
+		for (int i = endoflist - 4; i >= 0; i -= 4)
 		{
-			//printf("sprite with %08x %08x %08x %08x\n", spriteram[i + 0], spriteram[i + 1], spriteram[i + 2], spriteram[i + 3]);
+			//logerror("sprite with %08x %08x %08x %08x\n", spriteram[i + 0], spriteram[i + 1], spriteram[i + 2], spriteram[i + 3]);
 
-			int x = (spriteram[i + 0] & 0x000007ff) >> 0;
-			int y = (spriteram[i + 0] & 0x003ff800) >> 11;
-			int pal = (spriteram[i + 0] & 0x0fc00000) >> 22;
-			int pri = (spriteram[i + 0] & 0x80000000) >> 31;
+			s16 x = (spriteram[i + 0] & 0x000007ff) >> 0;
+			s16 y = (spriteram[i + 0] & 0x003ff800) >> 11;
+			u16 pal = (spriteram[i + 0] & 0x0fc00000) >> 22;
+			u8 const pri = (spriteram[i + 0] & 0x80000000) >> 31;
 
-			int unk0 = (spriteram[i + 0] & 0x30000000) >> 0;
+			u32 const unk0 = (spriteram[i + 0] & 0x30000000) >> 0;
 
 			// kov3 uses this in places (eg. horsemen special move heads) and shops when it can only possibly mean 'disable'
 			// it is also used in places on kov2nl and orleg2, often the 'power up' effects surrounding your character to create an on/off flicker each frame
-			int disable = (spriteram[i + 0] & 0x40000000) >> 30;
+			bool disable = (spriteram[i + 0] & 0x40000000) >> 30;
 			if (disable) continue;
 
-			int sizex = (spriteram[i + 1] & 0x0000003f) >> 0;
-			int sizey = (spriteram[i + 1] & 0x00007fc0) >> 6;
-			int flipx = (spriteram[i + 1] & 0x00800000) >> 23;
-			int reverse = (spriteram[i + 1] & 0x80000000) >> 31; // more of a 'reverse entire drawing' flag than y-flip, but used for that purpose
-			int zoomx = (spriteram[i + 1] & 0x007f0000) >> 16;
-			int zoomy = (spriteram[i + 1] & 0x7f000000) >> 24;
-			int unk1 = (spriteram[i + 1] & 0x00008000) >> 0;
+			u16 const sizex = (spriteram[i + 1] & 0x0000003f) >> 0;
+			u16 const sizey = (spriteram[i + 1] & 0x00007fc0) >> 6;
+			bool const flipx = (spriteram[i + 1] & 0x00800000) >> 23;
+			bool const reverse = (spriteram[i + 1] & 0x80000000) >> 31; // more of a 'reverse entire drawing' flag than y-flip, but used for that purpose
+			u8 const zoomx = (spriteram[i + 1] & 0x007f0000) >> 16;
+			u8 const zoomy = (spriteram[i + 1] & 0x7f000000) >> 24;
+			u32 const unk1 = (spriteram[i + 1] & 0x00008000) >> 0;
 
 			if (unk0 || unk1)
 			{
 				//popmessage("sprite rendering unused bits set unk0 %08x unk1 %08x\n", unk0, unk1);
 			}
 
-			int mask_offset = (spriteram[i + 2] << 1);
-			int palette_offset = (spriteram[i + 3]);
+			u32 mask_offset = (spriteram[i + 2] << 1);
+			u32 palette_offset = (spriteram[i + 3]);
 
 			// use all the bits of zoom to lookup, probably why the table is copied 4x in RAM
-			uint32_t zoomy_bits = m_sp_zoom[zoomy];
-			uint32_t zoomx_bits = m_sp_zoom[zoomx];
+			u32 const zoomy_bits = m_sp_zoom[zoomy];
+			u32 const zoomx_bits = m_sp_zoom[zoomx];
 
 			// but use these bits as the scale factor
-			int xrepeats = (zoomx & 0x60)>>5;
-			int yrepeats = (zoomy & 0x60)>>5;
+			u8 const xrepeats = (zoomx & 0x60)>>5;
+			u8 const yrepeats = (zoomy & 0x60)>>5;
 
 			if (x & 0x400) x -= 0x800;
 			if (y & 0x400) y -= 0x800;
@@ -214,21 +220,19 @@ void pgm2_state::draw_sprites(screen_device &screen, const rectangle &cliprect, 
 			if (reverse)
 				mask_offset -= 2;
 
-			mask_offset &= m_sprites_mask_mask;
-			palette_offset &= m_sprites_colour_mask;
+			mask_offset &= m_sprites_mask.mask();
+			palette_offset &= m_sprites_colour.mask();
 
-			pal |= (pri << 6); // encode priority with the palette for manual mixing later
+			s16 realy = y;
 
-			int realy = y;
-
-			int sourceline = 0;
+			s16 sourceline = 0;
 			for (int ydraw = 0; ydraw < sizey; sourceline++)
 			{
-				int zoomy_bit = (zoomy_bits >> (sourceline & 0x1f)) & 1;
+				u8 zoomy_bit = BIT(zoomy_bits, sourceline & 0x1f);
 
 				// store these for when we need to draw a line twice
-				uint32_t pre_palette_offset = palette_offset;
-				uint32_t pre_mask_offset = mask_offset;
+				u32 const pre_palette_offset = palette_offset;
+				u32 const pre_mask_offset = mask_offset;
 
 				if (yrepeats != 0) // grow
 				{
@@ -237,7 +241,7 @@ void pgm2_state::draw_sprites(screen_device &screen, const rectangle &cliprect, 
 						// draw it the base number of times
 						palette_offset = pre_palette_offset;
 						mask_offset = pre_mask_offset;
-						draw_sprite_line(cliprect, mask_offset, palette_offset, x, realy, flipx, reverse, sizex, pal, 1, zoomx_bits, xrepeats);
+						draw_sprite_line(bitmap, cliprect, mask_offset, palette_offset, x, realy, flipx, reverse, sizex, pal, 1, zoomx_bits, xrepeats, pri);
 						realy++;
 					}
 
@@ -245,7 +249,7 @@ void pgm2_state::draw_sprites(screen_device &screen, const rectangle &cliprect, 
 					{
 						palette_offset = pre_palette_offset;
 						mask_offset = pre_mask_offset;
-						draw_sprite_line(cliprect, mask_offset, palette_offset, x, realy, flipx, reverse, sizex, pal, 1, zoomx_bits, xrepeats);
+						draw_sprite_line(bitmap, cliprect, mask_offset, palette_offset, x, realy, flipx, reverse, sizex, pal, 1, zoomx_bits, xrepeats, pri);
 						realy++;
 					}
 
@@ -253,7 +257,7 @@ void pgm2_state::draw_sprites(screen_device &screen, const rectangle &cliprect, 
 				}
 				else // shrink
 				{
-					draw_sprite_line(cliprect, mask_offset, palette_offset, x, realy, flipx, reverse, sizex, pal, 1, zoomx_bits, xrepeats);
+					draw_sprite_line(bitmap, cliprect, mask_offset, palette_offset, x, realy, flipx, reverse, sizex, pal, 1, zoomx_bits, xrepeats, pri);
 
 					if (zoomy_bit)
 					{
@@ -266,38 +270,11 @@ void pgm2_state::draw_sprites(screen_device &screen, const rectangle &cliprect, 
 	}
 }
 
-void pgm2_state::copy_sprites_from_bitmap(screen_device &screen, bitmap_rgb32 &bitmap, const rectangle &cliprect, int pri)
+u32 pgm2_state::screen_update(screen_device &screen, bitmap_rgb32 &bitmap, const rectangle &cliprect)
 {
-	pri <<= 12;
+	u32 const mode = m_vidmode[0] & 0x00030000; // other bits not used?
 
-	const pen_t *paldata = m_sp_palette->pens();
-	uint16_t* srcptr_bitmap;
-	uint32_t* dstptr_bitmap;
-
-	for (int y = cliprect.min_y; y <= cliprect.max_y; y++)
-	{
-		srcptr_bitmap = &m_sprite_bitmap.pix16(y);
-		dstptr_bitmap = &bitmap.pix32(y);
-
-		for (int x = cliprect.min_x; x <= cliprect.max_x; x++)
-		{
-			uint16_t pix = srcptr_bitmap[x];
-
-			if (pix != 0x8000)
-			{
-				if ((pix&0x1000) == pri)
-					dstptr_bitmap[x] = paldata[pix & 0xfff];
-			}
-		}
-
-	}
-}
-
-uint32_t pgm2_state::screen_update_pgm2(screen_device &screen, bitmap_rgb32 &bitmap, const rectangle &cliprect)
-{
-	int mode = m_vidmode[0] & 0x00030000; // other bits not used?
-
-	switch (mode>>16)
+	switch (mode >> 16)
 	{
 		default:
 		case 0x00: m_screen->set_visible_area(0, 320 - 1, 0, 240 - 1); break;
@@ -309,34 +286,30 @@ uint32_t pgm2_state::screen_update_pgm2(screen_device &screen, bitmap_rgb32 &bit
 	m_fg_tilemap->set_scrolly(0, m_fgscroll[0] >> 16);
 	m_bg_tilemap->set_scrolly(0, (m_bgscroll[0x0/4] & 0xffff0000)>>16 );
 
-	for (int y = 0; y <= cliprect.max_y; y++)
+	for (s16 y = cliprect.top(); y <= cliprect.bottom(); y++)
 	{
-		uint16_t linescroll = (y & 1) ? ((m_lineram[(y >> 1)] & 0xffff0000) >> 16) : (m_lineram[(y >> 1)] & 0x0000ffff);
+		u16 const linescroll = (y & 1) ? ((m_lineram[(y >> 1)] & 0xffff0000) >> 16) : (m_lineram[(y >> 1)] & 0x0000ffff);
 		m_bg_tilemap->set_scrollx((y + ((m_bgscroll[0x0 / 4] & 0xffff0000) >> 16)) & 0x3ff, ((m_bgscroll[0x0 / 4] & 0x0000ffff) >> 0) + linescroll);
 	}
 
 	const pen_t *paldata = m_bg_palette->pens();
 
 	bitmap.fill(paldata[0], cliprect); // are there any places bg pen is showing so we know what it should be?
+	m_screen->priority().fill(0, cliprect);
 
-	draw_sprites(screen, cliprect, m_spritebufferram.get());
-
-	copy_sprites_from_bitmap(screen, bitmap, cliprect, 1);
-
-	m_bg_tilemap->draw(screen, bitmap, cliprect, 0, 0);
-
-	copy_sprites_from_bitmap(screen, bitmap, cliprect, 0);
-
+	m_bg_tilemap->draw(screen, bitmap, cliprect, 0, 2);
+	draw_sprites(bitmap, cliprect, m_spritebufferram.get());
 	m_fg_tilemap->draw(screen, bitmap, cliprect, 0, 0);
 	return 0;
 }
 
-WRITE_LINE_MEMBER(pgm2_state::screen_vblank_pgm2)
+WRITE_LINE_MEMBER(pgm2_state::screen_vblank)
 {
 	// rising edge
 	if (state)
 	{
 		memcpy(m_spritebufferram.get(), m_sp_videoram, 0x2000);
+		m_arm_aic->set_irq(12, ASSERT_LINE);
 	}
 }
 
@@ -348,9 +321,9 @@ WRITE32_MEMBER(pgm2_state::fg_videoram_w)
 
 TILE_GET_INFO_MEMBER(pgm2_state::get_fg_tile_info)
 {
-	int tileno = (m_fg_videoram[tile_index] & 0x0003ffff) >> 0;
-	int colour = (m_fg_videoram[tile_index] & 0x007c0000) >> 18; // 5 bits
-	int flipxy = (m_fg_videoram[tile_index] & 0x01800000) >> 23;
+	u32 const tileno = (m_fg_videoram[tile_index] & 0x0003ffff) >> 0;
+	u8 const colour  = (m_fg_videoram[tile_index] & 0x007c0000) >> 18; // 5 bits
+	u8 const flipxy  = (m_fg_videoram[tile_index] & 0x01800000) >> 23;
 
 	SET_TILE_INFO_MEMBER(0, tileno, colour, TILE_FLIPXY(flipxy));
 }
@@ -363,9 +336,9 @@ WRITE32_MEMBER(pgm2_state::bg_videoram_w)
 
 TILE_GET_INFO_MEMBER(pgm2_state::get_bg_tile_info)
 {
-	int tileno = (m_bg_videoram[tile_index] & 0x0003ffff) >> 0;
-	int colour = (m_bg_videoram[tile_index] & 0x003c0000) >> 18; // 4 bits
-	int flipxy = (m_bg_videoram[tile_index] & 0x01800000) >> 23;
+	u32 const tileno = (m_bg_videoram[tile_index] & 0x0003ffff) >> 0;
+	u8 const colour  = (m_bg_videoram[tile_index] & 0x003c0000) >> 18; // 4 bits
+	u8 const flipxy  = (m_bg_videoram[tile_index] & 0x01800000) >> 23;
 
 	SET_TILE_INFO_MEMBER(0, tileno, colour, TILE_FLIPXY(flipxy));
 }
@@ -379,13 +352,8 @@ void pgm2_state::video_start()
 	m_bg_tilemap->set_transparent_pen(0);
 	m_bg_tilemap->set_scroll_rows(32 * 32);
 
-	m_spritebufferram = make_unique_clear<uint32_t[]>(0x2000 / 4);
-
-	m_screen->register_screen_bitmap(m_sprite_bitmap);
+	m_spritebufferram = make_unique_clear<u32[]>(0x2000 / 4);
 
 	save_pointer(NAME(m_spritebufferram), 0x2000 / 4);
-
-	m_sprites_mask_mask = memregion("sprites_mask")->bytes() - 1;
-	m_sprites_colour_mask = memregion("sprites_colour")->bytes() - 1;
 }
 


### PR DESCRIPTION
pgm2.cpp : Do single-pass sprite drawing (uses screen.priority), Remove unused routine/values, Add notes, Shorter type values, Move most of things into private:, Make decrypt rom size related to ROM board integreated RAM size when RAM exists in ROM board, Add input name, Remove machine().save().register_postload, Reduce runtime tag lookups, Remove MCFGs, Remove unnecessary arguments, Simplified gfxdecode, Fix RAM test fail (ddpdojt, kov98umh, kov3)
pgm2_memcard.cpp : Shorter type values, Fix naming, Remove unnecessary arguments