### PR TITLE
sys80: Add 50 Hz version with different timings

### DIFF
--- a/src/emu/xtal.cpp
+++ b/src/emu/xtal.cpp
@@ -146,6 +146,7 @@ const double XTAL::known_xtals[] = {
 	 10'137'600, /* 10.1376_MHz_XTAL       Wyse WY-100 */
 	 10'245'000, /* 10.245_MHz_XTAL        PES Speech box */
 	 10'380'000, /* 10.38_MHz_XTAL         Fairlight Q219 Lightpen/Graphics Card */
+	 10'480'000, /* 10.48_MHz_XTAL         System-80 (50 Hz) */
 	 10'500'000, /* 10.5_MHz_XTAL          Agat-7 */
 	 10'595'000, /* 10.595_MHz_XTAL        Mad Alien */
 	 10'644'500, /* 10.6445_MHz_XTAL       TRS-80 Model I */

--- a/src/mame/drivers/trs80.cpp
+++ b/src/mame/drivers/trs80.cpp
@@ -578,8 +578,16 @@ MACHINE_CONFIG_START(trs80_state::sys80)
 	MCFG_DEVICE_REMOVE("brg")
 MACHINE_CONFIG_END
 
-MACHINE_CONFIG_START(trs80_state::ht1080z)
+MACHINE_CONFIG_START(trs80_state::sys80p)
 	sys80(config);
+	MCFG_DEVICE_MODIFY("maincpu")
+	MCFG_DEVICE_CLOCK(10.48_MHz_XTAL / 6)
+	MCFG_DEVICE_MODIFY("screen")
+	MCFG_SCREEN_RAW_PARAMS(10.48_MHz_XTAL, 672, 0, 384, 312, 0, 192)
+MACHINE_CONFIG_END
+
+MACHINE_CONFIG_START(trs80_state::ht1080z)
+	sys80p(config);
 	MCFG_DEVICE_MODIFY("maincpu")
 	MCFG_DEVICE_IO_MAP(ht1080z_io)
 
@@ -697,6 +705,8 @@ ROM_START(sys80)
 	ROM_LOAD("trs80m1.chr",  0x0000, 0x0400, CRC(0033f2b9) SHA1(0d2cd4197d54e2e872b515bbfdaa98efe502eda7))
 ROM_END
 
+#define rom_sys80p rom_sys80
+
 
 ROM_START(lnw80)
 	ROM_REGION(0x3800, "maincpu",0)
@@ -759,7 +769,8 @@ void trs80_state::init_trs80l2()
 COMP( 1977, trs80,       0,        0,      trs80,    trs80,   trs80_state, init_trs80,    "Tandy Radio Shack",           "TRS-80 Model I (Level I Basic)",  0 )
 COMP( 1978, trs80l2,     0,        0,      model1,   trs80l2, trs80_state, init_trs80l2,  "Tandy Radio Shack",           "TRS-80 Model I (Level II Basic)", 0 )
 COMP( 1983, radionic,    trs80l2,  0,      radionic, trs80l2, trs80_state, init_trs80,    "Komtek",                      "Radionic",                        0 )
-COMP( 1980, sys80,       trs80l2,  0,      sys80,    sys80,   trs80_state, init_trs80l2,  "EACA Computers Ltd",          "System-80",                       0 )
+COMP( 1980, sys80,       trs80l2,  0,      sys80,    sys80,   trs80_state, init_trs80l2,  "EACA Computers Ltd",          "System-80 (60 Hz)",               0 )
+COMP( 1980, sys80p,      trs80l2,  0,      sys80p,   sys80,   trs80_state, init_trs80l2,  "EACA Computers Ltd",          "System-80 (50 Hz)",               0 )
 COMP( 1981, lnw80,       trs80l2,  0,      lnw80,    sys80,   trs80_state, init_trs80,    "LNW Research",                "LNW-80",                          0 )
 COMP( 1983, ht1080z,     trs80l2,  0,      ht1080z,  sys80,   trs80_state, init_trs80l2,  "Hiradastechnika Szovetkezet", "HT-1080Z Series I",               0 )
 COMP( 1984, ht1080z2,    trs80l2,  0,      ht1080z,  sys80,   trs80_state, init_trs80l2,  "Hiradastechnika Szovetkezet", "HT-1080Z Series II",              0 )

--- a/src/mame/includes/trs80.h
+++ b/src/mame/includes/trs80.h
@@ -56,6 +56,7 @@ public:
 	{ }
 
 	void sys80(machine_config &config);
+	void sys80p(machine_config &config);
 	void trs80(machine_config &config);
 	void lnw80(machine_config &config);
 	void radionic(machine_config &config);

--- a/src/mame/mame.lst
+++ b/src/mame/mame.lst
@@ -37945,6 +37945,7 @@ ht1080z2                        // Hradstechnika Szvetkezet HT-1080Z Series II
 lnw80                           // LNW Research LNW-80
 radionic                        // Radionic
 sys80                           // EACA System 80
+sys80p                          // EACA System 80
 trs80                           // TRS-80 Model I - Level I BASIC
 trs80l2                         // TRS-80 Model I - Level II BASIC
 


### PR DESCRIPTION
(nw) Note that "NTSC" and "PAL" would be misnomers for systems with monochrome video output and idiosyncratic line rates.

The 50 Hz timings have also been applied to the HT-1080Z (available documentation for which seems not particularly reliable).

I am submitting this as a PR to solicit input on the set name.