### PR TITLE
Update docs w.r.t. sound

### DIFF
--- a/docs/man/mame.6
+++ b/docs/man/mame.6
@@ -905,8 +905,8 @@ Split full screen image across monitors. Default is OFF (\-nouseallheads).
 .SS Sound options
 .\" *******************************************************
 .TP
-.B \-[no]sound
-Enable or disable sound altogether. The default is ON (\-sound).
+.B \-sound \fIvalue
+Specifies which sound subsystem to use. 'none' disables sound altogether. The default value is 'auto' (\-sound).
 .TP
 .B \-samplerate, \-srf \fIvalue
 Sets the audio sample rate. Smaller values (e.g. 11025) cause lower
@@ -927,9 +927,9 @@ Sets the startup volume. It can later be changed with the user interface
 .TP
 .B \-audio_latency \fIvalue
 This controls the amount of latency built into the audio streaming.
-The latency parameter controls the lower threshold. The default is 1
-(meaning lower=1/5 and upper=2/5). Set it to 2 (\-audio_latency 2) to keep
-the sound buffer between 2/5 and 3/5 full. If you crank it up to 4,
+The latency parameter controls the lower threshold. The default is 2
+(meaning lower=2/5 and upper=3/5). Set it to 1 (\-audio_latency 1) to keep
+the sound buffer between 1/5 and 2/5 full. If you crank it up to 4,
 you can definitely notice the lag.
 .\"
 .\" *******************************************************

--- a/docs/man/mame.6
+++ b/docs/man/mame.6
@@ -905,7 +905,7 @@ Split full screen image across monitors. Default is OFF (\-nouseallheads).
 .SS Sound options
 .\" *******************************************************
 .TP
-.B \-sound \fIvalue
+.B \-sound \fIauto\fR|\fIdsound\fR|\fIsdl\fR|\fIcoreaudio\fR|\fIxaudio\fR|\fIportaudio\fR|\fInone
 Specifies which sound subsystem to use. 'none' disables sound altogether. The default value is 'auto' (\-sound).
 .TP
 .B \-samplerate, \-srf \fIvalue

--- a/docs/man/mame.6
+++ b/docs/man/mame.6
@@ -927,9 +927,9 @@ Sets the startup volume. It can later be changed with the user interface
 .TP
 .B \-audio_latency \fIvalue
 This controls the amount of latency built into the audio streaming.
-The latency parameter controls the lower threshold. The default is 2
-(meaning lower=2/5 and upper=3/5). Set it to 1 (\-audio_latency 1) to keep
-the sound buffer between 1/5 and 2/5 full. If you crank it up to 4,
+The latency parameter controls the lower threshold. The default is 1
+(meaning lower=1/5 and upper=2/5). Set it to 2 (\-audio_latency 2) to keep
+the sound buffer between 2/5 and 3/5 full. If you crank it up to 4,
 you can definitely notice the lag.
 .\"
 .\" *******************************************************

--- a/docs/source/commandline/commandline-all.rst
+++ b/docs/source/commandline/commandline-all.rst
@@ -1121,7 +1121,7 @@ Core Sound Options
 
 **-audio_latency** *<value>*
 
-	This controls the amount of latency built into the audio streaming. By default MAME tries to keep the DirectSound audio buffer between 1/5 and 2/5 full. On some systems, this is pushing it too close to the edge, and you get poor sound sometimes. The latency parameter controls the lower threshold. The default is *1* (meaning lower=1/5 and upper=2/5). Set it to 2 (**-audio_latency 2**) to keep the sound buffer between 2/5 and 3/5 full. If you crank it up to 4, you can *definitely* notice audio lag.
+	This controls the amount of latency built into the audio streaming. By default MAME tries to keep the DirectSound audio buffer between 2/5 and 3/5 full. On some systems, this is pushing it too close to the edge, and you get poor sound sometimes. The latency parameter controls the lower threshold. The default is *2* (meaning lower=2/5 and upper=3/5). Set it to 1 (**-audio_latency 1**) to keep the sound buffer between 1/5 and 2/5 full. If you crank it up to 4, you can *definitely* notice audio lag.
 
 
 

--- a/docs/source/commandline/commandline-all.rst
+++ b/docs/source/commandline/commandline-all.rst
@@ -1121,7 +1121,7 @@ Core Sound Options
 
 **-audio_latency** *<value>*
 
-	This controls the amount of latency built into the audio streaming. By default MAME tries to keep the DirectSound audio buffer between 2/5 and 3/5 full. On some systems, this is pushing it too close to the edge, and you get poor sound sometimes. The latency parameter controls the lower threshold. The default is *2* (meaning lower=2/5 and upper=3/5). Set it to 1 (**-audio_latency 1**) to keep the sound buffer between 1/5 and 2/5 full. If you crank it up to 4, you can *definitely* notice audio lag.
+	This controls the amount of latency built into the audio streaming. By default MAME tries to keep the DirectSound audio buffer between 1/5 and 2/5 full. On some systems, this is pushing it too close to the edge, and you get poor sound sometimes. The latency parameter controls the lower threshold. The default is *1* (meaning lower=1/5 and upper=2/5). Set it to 2 (**-audio_latency 2**) to keep the sound buffer between 2/5 and 3/5 full. If you crank it up to 4, you can *definitely* notice audio lag.
 
 
 


### PR DESCRIPTION
The `-nosound` option does not work and judging from https://github.com/mamedev/mame/blob/cd3b77121fa7fdd0540515f9ee471724987680d5/src/osd/modules/lib/osdobj_common.cpp#L128, the default value for `audio_latency` is actually `2` not `1`. This patch updates the docs to reflect that.