### PR TITLE
ppc64le fixes

### DIFF
--- a/3rdparty/bx/include/bx/platform.h
+++ b/3rdparty/bx/include/bx/platform.h
@@ -133,8 +133,14 @@
 #endif //
 
 #if BX_CPU_PPC
-#	undef  BX_CPU_ENDIAN_BIG
-#	define BX_CPU_ENDIAN_BIG 1
+// _LITTLE_ENDIAN exists on ppc64le.
+#	if _LITTLE_ENDIAN
+#		undef  BX_CPU_ENDIAN_LITTLE
+#		define BX_CPU_ENDIAN_LITTLE 1
+#	else
+#		undef  BX_CPU_ENDIAN_BIG
+#		define BX_CPU_ENDIAN_BIG 1
+#	endif
 #else
 #	undef  BX_CPU_ENDIAN_LITTLE
 #	define BX_CPU_ENDIAN_LITTLE 1

--- a/makefile
+++ b/makefile
@@ -394,6 +394,12 @@ BIGENDIAN := 1
 endif
 endif # BIGENDIAN
 
+# Work around an issue with long doubles on ppc64 (#3157)
+ifneq (,$(findstring ppc64,$(UNAME)))
+ARCHOPTS_C += -mlong-double-64
+ARCHOPTS_CXX += -mlong-double-64
+endif
+
 ifndef PYTHON_EXECUTABLE
 PYTHON := python
 else


### PR DESCRIPTION
This works around #3157 and also adds another fix for a compilation error with `3rdparty/bx` (which doesn't know what little-endian PowerPC is). Although tested on `ppc64le` it should fix `ppc64` as well.