### PR TITLE
NOT FOR MERGE AND FOR REVIEW: investigating MT07116

### DIFF
--- a/src/emu/emumem.h
+++ b/src/emu/emumem.h
@@ -1786,6 +1786,7 @@ public:
 	// construction/destruction
 	memory_manager(running_machine &machine);
 	void initialize();
+	void bank_reattach();
 
 	// getters
 	running_machine &machine() const { return m_machine; }


### PR DESCRIPTION
https://mametesters.org/view.php?id=7116
I've been told it's better to open a PR, so here it is. As I wrote on MameTesters:
_I looked at superwng, which is an interesting case since it has only 2 banks and in a -str 20 run it only selects bank 0.
I tried hooking up a driver specific post_load to set the bank on every reload and, with great suprise, I discovered that it worked. With my very limited knowledge of the memory system, this seems to indicate that not only it isn't reloading the current entry, but that it lets it undefined (otherwise I can't understand how it could screw up with a game like superwng which only sets bank 0 for the first 20 seconds of run).
So I took the time to hack up a patch (attached) to restore emumem.cpp behaviour as close as possible to that before the commit mentioned in 'additional information' and sure enough it works. I tested it with 1942 also.
Maybe this small research can point at where to look for a real, forward moving solution._