### PR TITLE
Removed Machine_IMPERFECT_SOUND for coolridr driver by sjy96525

### DIFF
--- a/src/mame/drivers/coolridr.cpp
+++ b/src/mame/drivers/coolridr.cpp
@@ -3447,5 +3447,5 @@ void coolridr_state::init_aquastge()
 	m_colbase = 0;
 }
 
-GAME(  1995, coolridr, 0, coolridr, coolridr, coolridr_state, init_coolridr, ROT0, "Sega", "Cool Riders", MACHINE_IMPERFECT_SOUND) // region is set in test mode, this set is for Japan, USA and Export (all regions)
+GAME(  1995, coolridr, 0, coolridr, coolridr, coolridr_state, init_coolridr, ROT0, "Sega", "Cool Riders", 0) // region is set in test mode, this set is for Japan, USA and Export (all regions)
 GAMEL( 1995, aquastge, 0, aquastge, aquastge, coolridr_state, init_aquastge, ROT0, "Sega", "Aqua Stage",  MACHINE_NOT_WORKING, layout_aquastge)


### PR DESCRIPTION
The driver used SCSP Sound chip, and scsp.h has imperfect sound flag.