### PR TITLE
Bugfix/via6522

### DIFF
--- a/src/devices/machine/6522via.cpp
+++ b/src/devices/machine/6522via.cpp
@@ -463,7 +463,7 @@ void via6522_device::device_timer(emu_timer &timer, device_timer_id id, int para
 			{
 				if (SI_O2_CONTROL(m_acr) || SO_O2_CONTROL(m_acr))
 				{
-					m_shift_timer->adjust(clocks_to_attotime(1) / 2);
+					m_shift_timer->adjust(clocks_to_attotime(1));
 				}
 				else if (SO_T2_RATE(m_acr) || SO_T2_CONTROL(m_acr) || SI_T2_CONTROL(m_acr))
 				{

--- a/src/mame/video/vectrex.cpp
+++ b/src/mame/video/vectrex.cpp
@@ -6,7 +6,7 @@
 #include "cpu/m6809/m6809.h"
 
 
-#define ANALOG_DELAY 7800
+#define ANALOG_DELAY 8500
 
 #define INT_PER_CLOCK 550
 


### PR DESCRIPTION
When shifting out at system clock rate, CB1 inverts every clock cycle. This fixes vectrex text width (mametesters 07050). Accurate timing measurements on a real via/vectrex would be needed to fix this properly.