### PR TITLE
new NOT WORKING ClickStart [Sean Riddle, Clawgrip, TeamEurope] + a Software List for it

### DIFF
--- a/hash/clickstart_cart.xml
+++ b/hash/clickstart_cart.xml
@@ -1,0 +1,106 @@
+<?xml version="1.0"?>
+<!DOCTYPE softwarelist SYSTEM "softwarelist.dtd">
+
+<!--
+NOTE: These dumps might not be correct, haven't been able to work out how to calcualte the checksum listed at the start of some of them.
+-->
+
+<softwarelist name="clickstart_cart" description="LeapFrog ClickStart cartridges">
+
+	<software name="aniart" supported="no">
+		<description>Animal Art Studio</description>
+		<year>2007</year>
+		<publisher>LeapFrog</publisher>
+		<part name="cart" interface="clickstart_cart">
+			<feature name="u1" value="" /> <!-- EPOXY BLOB ROM -->
+			<dataarea name="rom" size="0x400000">
+				<rom name="500-12780-a - animal art studio (uk).bin" size="0x400000" crc="f1390fea" sha1="3ace0c1b1ffe883e2dda8976c24f47729df53191" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+	<software name="aniarts" cloneof="aniart" supported="no">
+		<description>Estudio de Arte Animal</description>
+		<year>2007</year>
+		<publisher>LeapFrog</publisher>
+		<part name="cart" interface="clickstart_cart">
+			<feature name="u1" value="" /> <!-- EPOXY BLOB ROM -->
+			<dataarea name="rom" size="0x400000">
+				<rom name="500-12887-a - estudio de arte animal (sp).bin" size="0x400000" crc="11920f3a" sha1="c6c1f153a6e17a31da1a079f2c8e0e57947d2ac9" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+	<software name="nemo" supported="no">
+		<description>Finding Nemo</description>
+		<year>2007</year>
+		<publisher>LeapFrog / Disney / Pixar</publisher>
+		<part name="cart" interface="clickstart_cart">
+			<feature name="u1" value="" /> <!-- EPOXY BLOB ROM -->
+			<dataarea name="rom" size="0x400000">
+				<rom name="500-12727-a - finding nemo (uk).bin" size="0x400000" crc="33e02256" sha1="caac98a66b714aa9addef42d31cd139fe138ea58" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+	<software name="toystor" supported="no">
+		<description>Toy Story (UK)</description>
+		<year>2007</year>
+		<publisher>LeapFrog / Disney / Pixar</publisher>
+		<part name="cart" interface="clickstart_cart">
+			<feature name="u1" value="" /> <!-- EPOXY BLOB ROM -->
+			<dataarea name="rom" size="0x400000">
+				<rom name="500-12728-a - toy story (uk).bin" size="0x400000" crc="9021fa2e" sha1="841be50a7f0eb4f633469b04928d3085874866dc" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+	
+	<software name="toystors" cloneof="toystor" supported="no">
+		<description>Toy Story (SP)</description>
+		<year>2007</year>
+		<publisher>LeapFrog</publisher>
+		<part name="cart" interface="clickstart_cart">
+			<feature name="u1" value="" /> <!-- EPOXY BLOB ROM -->
+			<dataarea name="rom" size="0x400000">
+				<rom name="500-12894-a - toy story (sp).bin" size="0x400000" crc="91a748f6" sha1="05da46b6ded3fee24bc1167395f8139647368b68" offset="0" />
+			</dataarea>
+		</part>
+	</software>	
+	
+	<software name="bobbuild" supported="no">
+		<description>Bob the Builder (UK)</description>
+		<year>2007</year>
+		<publisher>LeapFrog</publisher>
+		<part name="cart" interface="clickstart_cart">
+			<feature name="u1" value="" /> <!-- EPOXY BLOB ROM -->
+			<dataarea name="rom" size="0x400000">
+				<rom name="500-13084-a - bob the builder (uk).bin" size="0x400000" crc="387920df" sha1="ac071987f5389604f368ea0a59962a0c28f73a80" offset="0" />
+			</dataarea>
+		</part>
+	</software>	
+	
+	<software name="thomas" supported="no">
+		<description>Thomas &amp; Friends (UK)</description>
+		<year>2007</year>
+		<publisher>LeapFrog</publisher>
+		<part name="cart" interface="clickstart_cart">
+			<feature name="u1" value="" /> <!-- EPOXY BLOB ROM -->
+			<dataarea name="rom" size="0x400000">
+				<rom name="500-12781-a - thomas and friends (uk).bin" size="0x400000" crc="8485c99a" sha1="2a4899868f383b8a6e8cdc0e65dfed86222ff697" offset="0" />
+			</dataarea>
+		</part>
+	</software>	
+
+	<software name="dora" supported="no">
+		<description>Dora the Explorer (UK)</description>
+		<year>2007</year>
+		<publisher>LeapFrog</publisher>
+		<part name="cart" interface="clickstart_cart">
+			<feature name="u1" value="" /> <!-- EPOXY BLOB ROM -->
+			<dataarea name="rom" size="0x400000">
+				<rom name="500-12729-a - dora the explorer (uk).bin" size="0x400000" crc="e93bd91a" sha1="e4c9649becd6370d555c6475cb491ba78c54ad17" offset="0" />
+			</dataarea>
+		</part>
+	</software>	
+</softwarelist>
+

--- a/hash/clickstart_cart.xml
+++ b/hash/clickstart_cart.xml
@@ -1,9 +1,7 @@
 <?xml version="1.0"?>
 <!DOCTYPE softwarelist SYSTEM "softwarelist.dtd">
 
-<!--
-NOTE: These dumps might not be correct, haven't been able to work out how to calcualte the checksum listed at the start of some of them.
--->
+<!-- It is unclear how to calculate the checksum that's stored as ASCII at the start of some of these, however there is a secondary checksum in a footer area at the end that works out correctly, so the ROMs should be good -->
 
 <softwarelist name="clickstart_cart" description="LeapFrog ClickStart cartridges">
 

--- a/scripts/target/mame/mess.lua
+++ b/scripts/target/mame/mess.lua
@@ -3616,6 +3616,7 @@ files {
 	MAME_DIR .. "src/mame/audio/socrates.h",
 	MAME_DIR .. "src/mame/drivers/inteladv.cpp",
 	MAME_DIR .. "src/mame/drivers/vsmile.cpp",
+	MAME_DIR .. "src/mame/drivers/clickstart.cpp",
 }
 
 createMESSProjects(_target, _subtarget, "wang")

--- a/src/devices/machine/spg2xx.cpp
+++ b/src/devices/machine/spg2xx.cpp
@@ -942,6 +942,9 @@ READ16_MEMBER(spg2xx_device::io_r)
 		LOGMASKED(LOG_UART, "io_r: UART Rx FIFO Control = %04x\n", val);
 		break;
 
+	case 0x51: // unknown, polled by ClickStart cartridges ( clikstrt )
+		return 0x8000;
+
 	case 0x59: // I2C Status
 		LOGMASKED(LOG_I2C, "io_r: I2C Status = %04x\n", val);
 		break;

--- a/src/mame/drivers/clickstart.cpp
+++ b/src/mame/drivers/clickstart.cpp
@@ -1,0 +1,155 @@
+// license:BSD-3-Clause
+// copyright-holders:Ryan Holtz, David Haywood
+/******************************************************************************
+
+    Leapfrog Clickstart Emulation
+	
+    Status:
+
+        Calls to unmapped space
+
+		Some games have Checksums listed in the header area that appear to be
+		 like the byte checksums on the Radica games in vii.cpp, however the
+		 calculation doesn't add up correctly.  There is also a checksum in
+		 a footer area at the end of the ROM that does add up correctly in
+		 all cases except for the system BIOS, needless to say this is
+		 confusing.  The ROM carts are marked for 4MByte ROMs at least so
+		 the sizes SHOULD be correct.
+
+		What type of SPG is this?
+
+*******************************************************************************/
+
+#include "emu.h"
+
+#include "bus/generic/slot.h"
+#include "bus/generic/carts.h"
+
+#include "cpu/unsp/unsp.h"
+
+#include "machine/spg2xx.h"
+
+#include "screen.h"
+#include "softlist.h"
+#include "speaker.h"
+
+class clickstart_state : public driver_device
+{
+public:
+	clickstart_state(const machine_config &mconfig, device_type type, const char *tag)
+		: driver_device(mconfig, type, tag)
+		, m_maincpu(*this, "maincpu")
+		, m_screen(*this, "screen")
+		, m_spg(*this, "spg")
+		, m_cart(*this, "cartslot")
+		, m_system_region(*this, "maincpu")
+		, m_cart_region(nullptr)
+	{ }
+
+	void clickstart(machine_config &config);
+
+private:
+	virtual void machine_start() override;
+	virtual void machine_reset() override;
+
+	void mem_map(address_map &map);
+
+	DECLARE_DEVICE_IMAGE_LOAD_MEMBER(cart);
+
+	DECLARE_READ16_MEMBER(rom_r);
+
+	DECLARE_READ16_MEMBER(unk9a90_r)
+	{
+		// HACK: return a RET so that out of bounds calls go back to where they came from
+		return 0x9a90;
+	};
+
+	required_device<cpu_device> m_maincpu;
+	required_device<screen_device> m_screen;
+	required_device<spg2xx_device> m_spg;
+	required_device<generic_slot_device> m_cart;
+	required_memory_region m_system_region;
+	memory_region *m_cart_region;
+};
+
+
+void clickstart_state::machine_start()
+{
+	// if there's a cart, override the standard mapping
+	if (m_cart && m_cart->exists())
+	{
+		std::string region_tag;
+		m_cart_region = memregion(region_tag.assign(m_cart->tag()).append(GENERIC_ROM_REGION_TAG).c_str());
+	}
+}
+
+void clickstart_state::machine_reset()
+{
+}
+
+DEVICE_IMAGE_LOAD_MEMBER(clickstart_state, cart)
+{
+	uint32_t size = m_cart->common_get_size("rom");
+
+	m_cart->rom_alloc(size, GENERIC_ROM16_WIDTH, ENDIANNESS_LITTLE);
+	m_cart->common_load_rom(m_cart->get_rom_base(), size, "rom");
+
+	return image_init_result::PASS;
+}
+
+READ16_MEMBER(clickstart_state::rom_r)
+{
+	if (m_cart->exists())
+		return ((uint16_t*)m_cart_region->base())[offset];
+	else
+		return ((uint16_t*)m_system_region->base())[offset];
+}
+
+void clickstart_state::mem_map(address_map &map)
+{
+	map(0x000000, 0x1fffff).r(FUNC(clickstart_state::rom_r));
+	map(0x200000, 0x3fffff).r(FUNC(clickstart_state::unk9a90_r)); // HACK, code jumps here in several places, is this a customized CPU with internal ROM area?
+
+	map(0x000000, 0x003fff).m(m_spg, FUNC(spg2xx_device::map));
+}
+
+static INPUT_PORTS_START( clickstart )
+INPUT_PORTS_END
+
+// There is a SEEPROM on the motherboard (type?)
+
+void clickstart_state::clickstart(machine_config &config)
+{
+	UNSP(config, m_maincpu, XTAL(27'000'000));
+	m_maincpu->set_addrmap(AS_PROGRAM, &clickstart_state::mem_map);
+
+	SCREEN(config, m_screen, SCREEN_TYPE_RASTER);
+	m_screen->set_refresh_hz(60);
+	m_screen->set_size(320, 262);
+	m_screen->set_visarea(0, 320-1, 0, 240-1);
+	m_screen->set_screen_update("spg", FUNC(spg2xx_device::screen_update));
+	m_screen->screen_vblank().set(m_spg, FUNC(spg2xx_device::vblank));
+
+	SPEAKER(config, "lspeaker").front_left();
+	SPEAKER(config, "rspeaker").front_right();
+
+	SPG24X(config, m_spg, XTAL(27'000'000), m_maincpu, m_screen);
+	m_spg->add_route(ALL_OUTPUTS, "lspeaker", 0.5);
+	m_spg->add_route(ALL_OUTPUTS, "rspeaker", 0.5);
+
+	GENERIC_CARTSLOT(config, m_cart, generic_plain_slot, "clickstart_cart");
+	m_cart->set_width(GENERIC_ROM16_WIDTH);
+	m_cart->set_device_load(device_image_load_delegate(&clickstart_state::device_image_load_cart, this));
+
+	SOFTWARE_LIST(config, "cart_list").set_original("clickstart_cart");
+}
+
+ROM_START( clikstrt )
+	ROM_REGION( 0x400000, "maincpu", ROMREGION_ERASEFF )
+	ROM_LOAD( "clickstartbios.bin", 0x000000, 0x400000, CRC(1d84d88d) SHA1(ea400136449254f0905a14193c6dc573d24413d1) )
+
+	// is there more missing BIOS data? CPU internal ROM?
+ROM_END
+
+// year, name, parent, compat, machine, input, class, init, company, fullname, flags
+CONS( 2007, clikstrt,  0,      0, clickstart,  clickstart, clickstart_state, empty_init, "LeapFrog Enterprises", "ClickStart",      MACHINE_IMPERFECT_SOUND | MACHINE_IMPERFECT_GRAPHICS | MACHINE_NOT_WORKING )

--- a/src/mame/drivers/clickstart.cpp
+++ b/src/mame/drivers/clickstart.cpp
@@ -59,6 +59,11 @@ private:
 
 	DECLARE_READ16_MEMBER(rom_r);
 
+	DECLARE_READ16_MEMBER(portc_r)
+	{
+		return machine().rand();
+	};
+
 	required_device<cpu_device> m_maincpu;
 	required_device<screen_device> m_screen;
 	required_device<spg2xx_device> m_spg;
@@ -134,6 +139,7 @@ void clickstart_state::clickstart(machine_config &config)
 	SPEAKER(config, "rspeaker").front_right();
 
 	SPG24X(config, m_spg, XTAL(27'000'000), m_maincpu, m_screen);
+	m_spg->portc_in().set(FUNC(clickstart_state::portc_r));
 	m_spg->add_route(ALL_OUTPUTS, "lspeaker", 0.5);
 	m_spg->add_route(ALL_OUTPUTS, "rspeaker", 0.5);
 
@@ -150,4 +156,4 @@ ROM_START( clikstrt )
 ROM_END
 
 // year, name, parent, compat, machine, input, class, init, company, fullname, flags
-CONS( 2007, clikstrt,  0,      0, clickstart,  clickstart, clickstart_state, empty_init, "LeapFrog Enterprises", "ClickStart",      MACHINE_IMPERFECT_SOUND | MACHINE_IMPERFECT_GRAPHICS | MACHINE_NOT_WORKING )
+CONS( 2007, clikstrt,  0,      0, clickstart,  clickstart, clickstart_state, empty_init, "LeapFrog Enterprises", "ClickStart",      MACHINE_IMPERFECT_SOUND | MACHINE_IMPERFECT_GRAPHICS | MACHINE_NOT_WORKING ) // 'My First Computer' tagline

--- a/src/mame/mame.lst
+++ b/src/mame/mame.lst
@@ -9872,6 +9872,9 @@ clayshoo                        // [1979 Allied Leisure]
 @source:clcd.cpp
 clcd                            // Commodore LCD
 
+@source:clickstart.cpp
+clikstrt                        // (c) 2007 LeapFrog Enterprises
+
 @source:cliffhgr.cpp
 cliffhgr                        // (c) 1983
 cliffhgra                       // (c) 1983


### PR DESCRIPTION
seems to be something missing, jumps to outside of code area, maybe secondary small internal ROM of CPU.  I did think the dumps were half size for various reasons, but there is a checksum in the footer of each one that matches the data (even if another checksum in the header for some of them we can't match)  Possible BIOS is wrong tho as that checksum in the footer doesn't match by quite a significant amount.

most games show something just by putting a 'RET' opcode in the upper areas it attempts to jump to.

Ryan credited in driver since it's more or less just a stripped down copy of vsmile.cpp