### PR TITLE
tms9900, tms9980a, tms9995: CRU addressing change

### DIFF
--- a/src/devices/bus/hexbus/hx5102.cpp
+++ b/src/devices/bus/hexbus/hx5102.cpp
@@ -121,8 +121,7 @@ void hx5102_device::memmap(address_map &map)
 */
 void hx5102_device::crumap(address_map &map)
 {
-	map(0x17e0>>4, 0x17fe>>4).r(FUNC(hx5102_device::cruread));
-	map(0x17e0>>1, 0x17fe>>1).w(FUNC(hx5102_device::cruwrite));
+	map(0x17e0, 0x17ff).rw(FUNC(hx5102_device::cruread), FUNC(hx5102_device::cruwrite));
 }
 
 hx5102_device::hx5102_device(const machine_config &mconfig, const char *tag, device_t *owner, uint32_t clock):
@@ -475,7 +474,7 @@ READ8_MEMBER(hx5102_device::cruread)
 
 	crubits |= ((ioport("HXDIP")->read())<<4);
 
-	return crubits;
+	return BIT(crubits, offset);
 }
 
 /*

--- a/src/devices/bus/ti99/gromport/cartridges.cpp
+++ b/src/devices/bus/ti99/gromport/cartridges.cpp
@@ -826,15 +826,11 @@ READ8Z_MEMBER(ti99_super_cartridge::crureadz)
 	//         SRL   R0,1        Restore Bank Number (optional)
 	//         RT
 
-	// Our implementation in MESS always gets 8 bits in one go. Also, the address
-	// is twice the bit number. That is, the offset value is always a multiple
-	// of 0x10.
-
 	if ((offset & 0xfff0) == 0x0800)
 	{
 		LOGMASKED(LOG_CRU, "CRU accessed at %04x\n", offset);
 		uint8_t val = 0x02 << (m_ram_page << 1);
-		*value = (val >> ((offset - 0x0800)>>1)) & 0xff;
+		*value = BIT(val, (offset & 0x000e) >> 1);
 	}
 }
 
@@ -1231,7 +1227,7 @@ READ8Z_MEMBER(ti99_pagedcru_cartridge::crureadz)
 		{
 			page = page-(bit/2);  // 4 page flags per 8 bits
 		}
-		*value = 1 << (page*2+1);
+		*value = (offset & 0x000e) == (page * 4 + 2) ? 1 : 0;
 	}
 }
 

--- a/src/devices/bus/ti99/internal/992board.cpp
+++ b/src/devices/bus/ti99/internal/992board.cpp
@@ -458,13 +458,13 @@ void io992_device::device_start()
 
 READ8_MEMBER(io992_device::cruread)
 {
-	int address = offset << 4;
+	int address = offset << 1;
 	uint8_t value = 0x7f;  // All Hexbus lines high
 	double inp = 0;
 	int i;
 	uint8_t bit = 1;
 
-	switch (address)
+	switch (address & 0xf800)
 	{
 	case 0xe000:
 		// CRU E000-E7fE: Keyboard
@@ -494,7 +494,7 @@ READ8_MEMBER(io992_device::cruread)
 
 	LOGMASKED(LOG_CRU, "CRU %04x ->  %02x\n", address, value);
 
-	return value;
+	return BIT(value, offset & 7);
 }
 
 WRITE8_MEMBER(io992_device::cruwrite)

--- a/src/devices/bus/ti99/peb/bwg.cpp
+++ b/src/devices/bus/ti99/peb/bwg.cpp
@@ -338,7 +338,7 @@ READ8Z_MEMBER(snug_bwg_device::crureadz)
 
 	if ((offset & 0xff00)==m_cru_base)
 	{
-		if ((offset & 0x00ff)==0)
+		if ((offset & 0x00f0)==0)
 		{
 			// Check what drives are not connected
 			reply = ((m_floppy[0] != nullptr)? 0 : 0x02)       // DSK1
@@ -355,7 +355,7 @@ READ8Z_MEMBER(snug_bwg_device::crureadz)
 			reply |= (m_dip34 << 6);
 
 			// Invert all
-			*value = ~reply;
+			*value = ~BIT(reply, (offset >> 1) & 7);
 		}
 		else
 			*value = 0;

--- a/src/devices/bus/ti99/peb/evpc.cpp
+++ b/src/devices/bus/ti99/peb/evpc.cpp
@@ -323,8 +323,9 @@ READ8Z_MEMBER(snug_enhanced_video_device::crureadz)
 	{
 		if ((offset & 0x00f0)==0) // offset 0 delivers bits 0-7 (address 00-0f)
 		{
-			*value = ~(ioport("EVPC-SW1")->read() | (ioport("EVPC-SW3")->read()<<2)
+			uint8_t p = ~(ioport("EVPC-SW1")->read() | (ioport("EVPC-SW3")->read()<<2)
 				| (ioport("EVPC-SW4")->read()<<3) | (ioport("EVPC-SW8")->read()<<7));
+			*value = BIT(p, (offset >> 1) & 7);
 		}
 	}
 }

--- a/src/devices/bus/ti99/peb/hfdc.cpp
+++ b/src/devices/bus/ti99/peb/hfdc.cpp
@@ -376,7 +376,7 @@ READ8Z_MEMBER(myarc_hfdc_device::crureadz)
 	uint8_t reply;
 	if ((offset & 0xff00)==m_cru_base)
 	{
-		if ((offset & 0x00ff)==0)  // CRU bits 0-7
+		if ((offset & 0x00f0)==0)  // CRU bits 0-7
 		{
 			if (m_see_switches)
 			{
@@ -390,7 +390,7 @@ READ8Z_MEMBER(myarc_hfdc_device::crureadz)
 				if (!m_motor_running) reply |= 0x04;
 				if (m_wait_for_hd1) reply |= 0x08;
 			}
-			*value = reply;
+			*value = BIT(reply, (offset >> 1) & 7);
 		}
 		else   // CRU bits 8+
 		{

--- a/src/devices/bus/ti99/peb/ti_fdc.cpp
+++ b/src/devices/bus/ti99/peb/ti_fdc.cpp
@@ -201,7 +201,7 @@ READ8Z_MEMBER(ti_fdc_device::crureadz)
 	if ((offset & 0xff00)==m_cru_base)
 	{
 		uint8_t reply = 0;
-		if ((offset & 0x07) == 0)
+		if ((offset & 0x0070) == 0)
 		{
 			// Selected drive
 			reply |= ((m_DSEL)<<1);
@@ -212,7 +212,7 @@ READ8Z_MEMBER(ti_fdc_device::crureadz)
 			// Selected side
 			if (m_SIDSEL==ASSERT_LINE) reply |= 0x80;
 		}
-		*value = reply;
+		*value = BIT(reply, (offset >> 1) & 0x07);
 		LOGMASKED(LOG_CRU, "Read CRU = %02x\n", *value);
 	}
 }

--- a/src/devices/bus/ti99/peb/ti_rs232.cpp
+++ b/src/devices/bus/ti99/peb/ti_rs232.cpp
@@ -254,17 +254,17 @@ READ8Z_MEMBER(ti_rs232_pio_device::crureadz)
 			if ((m_signals[0] & tms9902_device::CTS)!=0)    reply |= 0x20;
 			if ((m_signals[1] & tms9902_device::CTS)!=0)    reply |= 0x40;
 			if (m_led)                      reply |= 0x80;
-			*value = reply;
+			*value = BIT(reply, (offset>>1) & 7);
 			return;
 		}
 		if ((offset & 0x00c0)==0x0040)
 		{
-			*value = m_uart0->cruread(space, offset>>4, 0xff);
+			*value = m_uart0->cruread(space, offset>>1, 0xff);
 			return;
 		}
 		if ((offset & 0x00c0)==0x0080)
 		{
-			*value = m_uart1->cruread(space, offset>>4, 0xff);
+			*value = m_uart1->cruread(space, offset>>1, 0xff);
 			return;
 		}
 	}

--- a/src/devices/bus/ti99/peb/tn_ide.cpp
+++ b/src/devices/bus/ti99/peb/tn_ide.cpp
@@ -71,9 +71,7 @@ READ8Z_MEMBER(nouspikel_ide_interface_device::crureadz)
 	uint8_t reply = 0;
 	if ((offset & 0xff00)==m_cru_base)
 	{
-		int bit = (offset >> 4) & 7;
-
-		if (bit==0)
+		if ((offset & 0x0070) == 0)
 		{
 			reply = m_cru_register & 0x30;
 			reply |= 8; /* IDE bus IORDY always set */
@@ -84,7 +82,7 @@ READ8Z_MEMBER(nouspikel_ide_interface_device::crureadz)
 			if (!m_ata_irq)
 				reply |= 1;
 		}
-		*value = reply;
+		*value = BIT(reply, (offset >> 1) & 7);
 	}
 }
 

--- a/src/devices/bus/ti99/peb/tn_usbsm.cpp
+++ b/src/devices/bus/ti99/peb/tn_usbsm.cpp
@@ -93,9 +93,8 @@ READ8Z_MEMBER(nouspikel_usb_smartmedia_device::crureadz)
 	if ((offset & 0xff00)==m_cru_base)
 	{
 		uint8_t reply = 0;
-		offset &= 3;
 
-		if (offset == 0)
+		if ((offset & 0x0030) == 0)
 		{
 			// bit
 			// 0   >1x00   0: USB Host controller requests interrupt.
@@ -117,7 +116,7 @@ READ8Z_MEMBER(nouspikel_usb_smartmedia_device::crureadz)
 			else if (!m_smartmedia->is_protected())
 				reply |= 0x80;
 		}
-		*value = reply;
+		*value = BIT(reply, (offset >> 1) & 7);
 	}
 }
 

--- a/src/devices/bus/ti99x/990_dk.cpp
+++ b/src/devices/bus/ti99x/990_dk.cpp
@@ -709,19 +709,16 @@ READ8_MEMBER( fd800_legacy_device::cru_r )
 {
 	int reply = 0;
 
-	switch (offset)
+	offset &= 31;
+	if (offset < 16)
 	{
-	case 0:
-	case 1:
 		// receive buffer
-		reply = m_recv_buf >> (offset*8);
-		break;
-
-	case 2:
-	case 3:
+		reply = BIT(m_recv_buf, offset);
+	}
+	else
+	{
 		// status register
-		reply = m_stat_reg >> ((offset-2)*8);
-		break;
+		reply = BIT(m_stat_reg, offset - 16);
 	}
 
 	return reply;

--- a/src/devices/cpu/tms9900/tms9900.cpp
+++ b/src/devices/cpu/tms9900/tms9900.cpp
@@ -1625,11 +1625,24 @@ void tms99xx_device::register_write()
     idempotent (i.e. they must not change the state of the queried device).
 
     Read returns the number of consecutive CRU bits, with increasing CRU address
-    from the least significant to the most significant bit; right-aligned
+    from the least significant to the most significant bit; right-aligned (in
+    other words, little-endian as opposed to the big-endian order of memory words).
 
     There seems to be no handling of wait states during CRU operations on the
     TMS9900. The TMS9995, in contrast, respects wait states during the transmission
     of each single bit.
+
+    The current emulation of the CRU space involves a 1-bit address shift,
+    reflecting the one-to-one correspondence between CRU bits and words (not
+    bytes) in the lower part of the memory space. (On the TMS9980A and TMS9995,
+    CRUOUT is multiplexed with the least significant address line.) Thus, what
+    TI's documentation calls the software address (the R12 base value plus the
+    bit offset multiplied by 2) is used in address maps and CPU-side operations.
+    MAME's memory architecture automatically translates these to right-justified
+    hardware addresses in the process of decoding offsets for read/write handlers,
+    which is more typical of what peripheral devices expect. (Note also that
+    address spaces do not support data widths narrower than 8 bits, so these
+    handlers must specify 8-bit types despite only one bit being useful.)
 
     Usage of this method:
        CRU write: First bit is at rightmost position of m_value.

--- a/src/devices/cpu/tms9900/tms9995.h
+++ b/src/devices/cpu/tms9900/tms9995.h
@@ -245,8 +245,6 @@ private:
 	uint16_t  m_cru_address;
 	uint16_t  m_cru_value;
 	bool    m_cru_first_read;
-	int     m_cru_bits_left;
-	uint32_t  m_cru_read;
 
 	// CPU-internal CRU flags
 	bool    m_flag[16];

--- a/src/devices/machine/tms9901.cpp
+++ b/src/devices/machine/tms9901.cpp
@@ -279,9 +279,9 @@ READ8_MEMBER( tms9901_device::read )
 {
 	int answer = 0;
 
-	offset &= 0x003;
+	offset &= 0x01f;
 
-	switch (offset)
+	switch (offset >> 3)
 	{
 	case 0:
 		if (m_clock_mode)
@@ -356,7 +356,7 @@ READ8_MEMBER( tms9901_device::read )
 		break;
 	}
 
-	return answer;
+	return BIT(answer, offset & 7);
 }
 
 /*

--- a/src/devices/machine/tms9902.cpp
+++ b/src/devices/machine/tms9902.cpp
@@ -482,44 +482,105 @@ READ8_MEMBER( tms9902_device::cruread )
 {
 	uint8_t answer = 0;
 
-	offset &= 0x0003;
-
-	switch (offset)
+	switch (offset & 31)
 	{
-	case 3: // Bits 31-24
-		if (m_INT) answer |= 0x80;
-		if (m_LDCTRL || m_LDIR || m_LRDR || m_LXDR || m_BRKON) answer |= 0x40;
-		if (m_DSCH) answer |= 0x20;
-		if (m_CTSin) answer |= 0x10;
-		if (m_DSRin) answer |= 0x08;
-		if (m_RTSout) answer |= 0x04;
-		if (m_TIMELP)  answer |= 0x02;
-		if (m_TIMERR)  answer |= 0x01;
+	case 31:
+		answer = m_INT;
 		break;
 
-	case 2: // Bits 23-16
-		if (m_XSRE) answer |= 0x80;
-		if (m_XBRE) answer |= 0x40;
-		if (m_RBRL) answer |= 0x20;
-		if (m_DSCH && m_DSCENB) answer |= 0x10;
-		if (m_TIMELP && m_TIMENB) answer |= 0x08;
-		if (m_XBRE && m_XBIENB) answer |= 0x02;
-		if (m_RBRL && m_RIENB) answer |= 0x01;
+	case 30:
+		answer = (m_LDCTRL || m_LDIR || m_LRDR || m_LXDR || m_BRKON);
 		break;
 
-	case 1: // Bits 15-8
-		if (m_RIN) answer |= 0x80;
-		if (m_RSBD) answer |= 0x40;
-		if (m_RFBD) answer |= 0x20;
-		if (m_RFER) answer |= 0x10;
-		if (m_ROVER) answer |= 0x08;
-		if (m_RPER) answer |= 0x04;
-		if (m_RPER || m_RFER || m_ROVER) answer |= 0x02;
+	case 29:
+		answer = m_DSCH;
 		break;
 
-	case 0: // Bits 7-0
-		LOGCRU("Reading received byte = %02x\n", m_RBR);
-		answer = m_RBR;
+	case 28:
+		answer = m_CTSin;
+		break;
+
+	case 27:
+		answer = m_DSRin;
+		break;
+
+	case 26:
+		answer = m_RTSout;
+		break;
+
+	case 25:
+		answer = m_TIMELP;
+		break;
+
+	case 24:
+		answer = m_TIMERR;
+		break;
+
+	case 23:
+		answer = m_XSRE;
+		break;
+
+	case 22:
+		answer = m_XBRE;
+		break;
+
+	case 21:
+		answer = m_RBRL;
+		break;
+
+	case 20:
+		answer = (m_DSCH && m_DSCENB);
+		break;
+
+	case 19:
+		answer = (m_TIMELP && m_TIMENB);
+		break;
+
+	case 17:
+		answer = (m_XBRE && m_XBIENB);
+		break;
+
+	case 16:
+		answer = (m_RBRL && m_RIENB);
+		break;
+
+	case 15:
+		answer = m_RIN;
+		break;
+
+	case 14:
+		answer = m_RSBD;
+		break;
+
+	case 13:
+		answer = m_RFBD;
+		break;
+
+	case 12:
+		answer = m_RFER;
+		break;
+
+	case 11:
+		answer = m_ROVER;
+		break;
+
+	case 10:
+		answer = m_RPER;
+		break;
+
+	case 9:
+		answer = (m_RPER || m_RFER || m_ROVER);
+		break;
+
+	case 7:
+	case 6:
+	case 5:
+	case 4:
+	case 3:
+	case 2:
+	case 1:
+	case 0:
+		answer = BIT(m_RBR, offset & 31);
 		break;
 	}
 	if (VERBOSE & LOG_DETAIL) LOGCRU("Reading flag bits %d - %d = %02x\n", ((offset+1)*8-1), offset*8, answer);

--- a/src/devices/machine/x2201.cpp
+++ b/src/devices/machine/x2201.cpp
@@ -128,17 +128,6 @@ u8 x2201_device::read(offs_t offset)
 
 
 //-------------------------------------------------
-//  read_byte - read 8 bits of data from RAM
-//  (FIXME: remove once CRU reads are 1-bit)
-//-------------------------------------------------
-
-u8 x2201_device::read_byte(offs_t offset)
-{
-	return m_ram[offset & 127];
-}
-
-
-//-------------------------------------------------
 //  write - write one bit of data to RAM
 //-------------------------------------------------
 

--- a/src/devices/machine/x2201.h
+++ b/src/devices/machine/x2201.h
@@ -38,7 +38,6 @@ public:
 
 	// read/write handlers
 	u8 read(offs_t offset);
-	u8 read_byte(offs_t offset); // hack
 	void write(offs_t offset, u8 data);
 
 	// control lines

--- a/src/emu/emumem.cpp
+++ b/src/emu/emumem.cpp
@@ -742,6 +742,13 @@ void memory_manager::allocate(device_memory_interface &memory)
 			// allocate one of the appropriate type
 			switch (spaceconfig->data_width() | (spaceconfig->addr_shift() + 4))
 			{
+				case  8|(4+1):
+					if (spaceconfig->endianness() == ENDIANNESS_LITTLE)
+						memory.allocate<address_space_specific<0,  1, ENDIANNESS_LITTLE>>(*this, spacenum);
+					else
+						memory.allocate<address_space_specific<0,  1, ENDIANNESS_BIG   >>(*this, spacenum);
+					break;
+
 				case  8|(4-0):
 					if (spaceconfig->endianness() == ENDIANNESS_LITTLE)
 						memory.allocate<address_space_specific<0,  0, ENDIANNESS_LITTLE>>(*this, spacenum);
@@ -2643,6 +2650,8 @@ template<int Width, int AddrShift, int Endian> memory_access_cache<Width, AddrSh
 }
 
 
+template class memory_access_cache<0,  1, ENDIANNESS_LITTLE>;
+template class memory_access_cache<0,  1, ENDIANNESS_BIG>;
 template class memory_access_cache<0,  0, ENDIANNESS_LITTLE>;
 template class memory_access_cache<0,  0, ENDIANNESS_BIG>;
 template class memory_access_cache<1,  3, ENDIANNESS_LITTLE>;

--- a/src/emu/emumem_hedp.cpp
+++ b/src/emu/emumem_hedp.cpp
@@ -170,6 +170,8 @@ template<int Width, int AddrShift, int Endian> std::string handler_entry_write_i
 
 
 
+template class handler_entry_read_delegate<0,  1, ENDIANNESS_LITTLE, read8_delegate>;
+template class handler_entry_read_delegate<0,  1, ENDIANNESS_BIG,    read8_delegate>;
 template class handler_entry_read_delegate<0,  0, ENDIANNESS_LITTLE, read8_delegate>;
 template class handler_entry_read_delegate<0,  0, ENDIANNESS_BIG,    read8_delegate>;
 template class handler_entry_read_delegate<1,  3, ENDIANNESS_LITTLE, read16_delegate>;
@@ -193,6 +195,8 @@ template class handler_entry_read_delegate<3, -2, ENDIANNESS_BIG,    read64_dele
 template class handler_entry_read_delegate<3, -3, ENDIANNESS_LITTLE, read64_delegate>;
 template class handler_entry_read_delegate<3, -3, ENDIANNESS_BIG,    read64_delegate>;
 
+template class handler_entry_read_delegate<0,  1, ENDIANNESS_LITTLE, read8m_delegate>;
+template class handler_entry_read_delegate<0,  1, ENDIANNESS_BIG,    read8m_delegate>;
 template class handler_entry_read_delegate<0,  0, ENDIANNESS_LITTLE, read8m_delegate>;
 template class handler_entry_read_delegate<0,  0, ENDIANNESS_BIG,    read8m_delegate>;
 template class handler_entry_read_delegate<1,  3, ENDIANNESS_LITTLE, read16m_delegate>;
@@ -216,6 +220,8 @@ template class handler_entry_read_delegate<3, -2, ENDIANNESS_BIG,    read64m_del
 template class handler_entry_read_delegate<3, -3, ENDIANNESS_LITTLE, read64m_delegate>;
 template class handler_entry_read_delegate<3, -3, ENDIANNESS_BIG,    read64m_delegate>;
 
+template class handler_entry_read_delegate<0,  1, ENDIANNESS_LITTLE, read8s_delegate>;
+template class handler_entry_read_delegate<0,  1, ENDIANNESS_BIG,    read8s_delegate>;
 template class handler_entry_read_delegate<0,  0, ENDIANNESS_LITTLE, read8s_delegate>;
 template class handler_entry_read_delegate<0,  0, ENDIANNESS_BIG,    read8s_delegate>;
 template class handler_entry_read_delegate<1,  3, ENDIANNESS_LITTLE, read16s_delegate>;
@@ -239,6 +245,8 @@ template class handler_entry_read_delegate<3, -2, ENDIANNESS_BIG,    read64s_del
 template class handler_entry_read_delegate<3, -3, ENDIANNESS_LITTLE, read64s_delegate>;
 template class handler_entry_read_delegate<3, -3, ENDIANNESS_BIG,    read64s_delegate>;
 
+template class handler_entry_read_delegate<0,  1, ENDIANNESS_LITTLE, read8sm_delegate>;
+template class handler_entry_read_delegate<0,  1, ENDIANNESS_BIG,    read8sm_delegate>;
 template class handler_entry_read_delegate<0,  0, ENDIANNESS_LITTLE, read8sm_delegate>;
 template class handler_entry_read_delegate<0,  0, ENDIANNESS_BIG,    read8sm_delegate>;
 template class handler_entry_read_delegate<1,  3, ENDIANNESS_LITTLE, read16sm_delegate>;
@@ -262,6 +270,8 @@ template class handler_entry_read_delegate<3, -2, ENDIANNESS_BIG,    read64sm_de
 template class handler_entry_read_delegate<3, -3, ENDIANNESS_LITTLE, read64sm_delegate>;
 template class handler_entry_read_delegate<3, -3, ENDIANNESS_BIG,    read64sm_delegate>;
 
+template class handler_entry_read_delegate<0,  1, ENDIANNESS_LITTLE, read8mo_delegate>;
+template class handler_entry_read_delegate<0,  1, ENDIANNESS_BIG,    read8mo_delegate>;
 template class handler_entry_read_delegate<0,  0, ENDIANNESS_LITTLE, read8mo_delegate>;
 template class handler_entry_read_delegate<0,  0, ENDIANNESS_BIG,    read8mo_delegate>;
 template class handler_entry_read_delegate<1,  3, ENDIANNESS_LITTLE, read16mo_delegate>;
@@ -285,6 +295,8 @@ template class handler_entry_read_delegate<3, -2, ENDIANNESS_BIG,    read64mo_de
 template class handler_entry_read_delegate<3, -3, ENDIANNESS_LITTLE, read64mo_delegate>;
 template class handler_entry_read_delegate<3, -3, ENDIANNESS_BIG,    read64mo_delegate>;
 
+template class handler_entry_read_delegate<0,  1, ENDIANNESS_LITTLE, read8smo_delegate>;
+template class handler_entry_read_delegate<0,  1, ENDIANNESS_BIG,    read8smo_delegate>;
 template class handler_entry_read_delegate<0,  0, ENDIANNESS_LITTLE, read8smo_delegate>;
 template class handler_entry_read_delegate<0,  0, ENDIANNESS_BIG,    read8smo_delegate>;
 template class handler_entry_read_delegate<1,  3, ENDIANNESS_LITTLE, read16smo_delegate>;
@@ -308,6 +320,8 @@ template class handler_entry_read_delegate<3, -2, ENDIANNESS_BIG,    read64smo_d
 template class handler_entry_read_delegate<3, -3, ENDIANNESS_LITTLE, read64smo_delegate>;
 template class handler_entry_read_delegate<3, -3, ENDIANNESS_BIG,    read64smo_delegate>;
 
+template class handler_entry_write_delegate<0,  1, ENDIANNESS_LITTLE, write8_delegate>;
+template class handler_entry_write_delegate<0,  1, ENDIANNESS_BIG,    write8_delegate>;
 template class handler_entry_write_delegate<0,  0, ENDIANNESS_LITTLE, write8_delegate>;
 template class handler_entry_write_delegate<0,  0, ENDIANNESS_BIG,    write8_delegate>;
 template class handler_entry_write_delegate<1,  3, ENDIANNESS_LITTLE, write16_delegate>;
@@ -331,6 +345,8 @@ template class handler_entry_write_delegate<3, -2, ENDIANNESS_BIG,    write64_de
 template class handler_entry_write_delegate<3, -3, ENDIANNESS_LITTLE, write64_delegate>;
 template class handler_entry_write_delegate<3, -3, ENDIANNESS_BIG,    write64_delegate>;
 
+template class handler_entry_write_delegate<0,  1, ENDIANNESS_LITTLE, write8m_delegate>;
+template class handler_entry_write_delegate<0,  1, ENDIANNESS_BIG,    write8m_delegate>;
 template class handler_entry_write_delegate<0,  0, ENDIANNESS_LITTLE, write8m_delegate>;
 template class handler_entry_write_delegate<0,  0, ENDIANNESS_BIG,    write8m_delegate>;
 template class handler_entry_write_delegate<1,  3, ENDIANNESS_LITTLE, write16m_delegate>;
@@ -354,6 +370,8 @@ template class handler_entry_write_delegate<3, -2, ENDIANNESS_BIG,    write64m_d
 template class handler_entry_write_delegate<3, -3, ENDIANNESS_LITTLE, write64m_delegate>;
 template class handler_entry_write_delegate<3, -3, ENDIANNESS_BIG,    write64m_delegate>;
 
+template class handler_entry_write_delegate<0,  1, ENDIANNESS_LITTLE, write8s_delegate>;
+template class handler_entry_write_delegate<0,  1, ENDIANNESS_BIG,    write8s_delegate>;
 template class handler_entry_write_delegate<0,  0, ENDIANNESS_LITTLE, write8s_delegate>;
 template class handler_entry_write_delegate<0,  0, ENDIANNESS_BIG,    write8s_delegate>;
 template class handler_entry_write_delegate<1,  3, ENDIANNESS_LITTLE, write16s_delegate>;
@@ -377,6 +395,8 @@ template class handler_entry_write_delegate<3, -2, ENDIANNESS_BIG,    write64s_d
 template class handler_entry_write_delegate<3, -3, ENDIANNESS_LITTLE, write64s_delegate>;
 template class handler_entry_write_delegate<3, -3, ENDIANNESS_BIG,    write64s_delegate>;
 
+template class handler_entry_write_delegate<0,  1, ENDIANNESS_LITTLE, write8sm_delegate>;
+template class handler_entry_write_delegate<0,  1, ENDIANNESS_BIG,    write8sm_delegate>;
 template class handler_entry_write_delegate<0,  0, ENDIANNESS_LITTLE, write8sm_delegate>;
 template class handler_entry_write_delegate<0,  0, ENDIANNESS_BIG,    write8sm_delegate>;
 template class handler_entry_write_delegate<1,  3, ENDIANNESS_LITTLE, write16sm_delegate>;
@@ -400,6 +420,8 @@ template class handler_entry_write_delegate<3, -2, ENDIANNESS_BIG,    write64sm_
 template class handler_entry_write_delegate<3, -3, ENDIANNESS_LITTLE, write64sm_delegate>;
 template class handler_entry_write_delegate<3, -3, ENDIANNESS_BIG,    write64sm_delegate>;
 
+template class handler_entry_write_delegate<0,  1, ENDIANNESS_LITTLE, write8mo_delegate>;
+template class handler_entry_write_delegate<0,  1, ENDIANNESS_BIG,    write8mo_delegate>;
 template class handler_entry_write_delegate<0,  0, ENDIANNESS_LITTLE, write8mo_delegate>;
 template class handler_entry_write_delegate<0,  0, ENDIANNESS_BIG,    write8mo_delegate>;
 template class handler_entry_write_delegate<1,  3, ENDIANNESS_LITTLE, write16mo_delegate>;
@@ -423,6 +445,8 @@ template class handler_entry_write_delegate<3, -2, ENDIANNESS_BIG,    write64mo_
 template class handler_entry_write_delegate<3, -3, ENDIANNESS_LITTLE, write64mo_delegate>;
 template class handler_entry_write_delegate<3, -3, ENDIANNESS_BIG,    write64mo_delegate>;
 
+template class handler_entry_write_delegate<0,  1, ENDIANNESS_LITTLE, write8smo_delegate>;
+template class handler_entry_write_delegate<0,  1, ENDIANNESS_BIG,    write8smo_delegate>;
 template class handler_entry_write_delegate<0,  0, ENDIANNESS_LITTLE, write8smo_delegate>;
 template class handler_entry_write_delegate<0,  0, ENDIANNESS_BIG,    write8smo_delegate>;
 template class handler_entry_write_delegate<1,  3, ENDIANNESS_LITTLE, write16smo_delegate>;
@@ -447,6 +471,8 @@ template class handler_entry_write_delegate<3, -3, ENDIANNESS_LITTLE, write64smo
 template class handler_entry_write_delegate<3, -3, ENDIANNESS_BIG,    write64smo_delegate>;
 
 
+template class handler_entry_read_ioport<0,  1, ENDIANNESS_LITTLE>;
+template class handler_entry_read_ioport<0,  1, ENDIANNESS_BIG>;
 template class handler_entry_read_ioport<0,  0, ENDIANNESS_LITTLE>;
 template class handler_entry_read_ioport<0,  0, ENDIANNESS_BIG>;
 template class handler_entry_read_ioport<1,  3, ENDIANNESS_LITTLE>;
@@ -470,6 +496,8 @@ template class handler_entry_read_ioport<3, -2, ENDIANNESS_BIG>;
 template class handler_entry_read_ioport<3, -3, ENDIANNESS_LITTLE>;
 template class handler_entry_read_ioport<3, -3, ENDIANNESS_BIG>;
 
+template class handler_entry_write_ioport<0,  1, ENDIANNESS_LITTLE>;
+template class handler_entry_write_ioport<0,  1, ENDIANNESS_BIG>;
 template class handler_entry_write_ioport<0,  0, ENDIANNESS_LITTLE>;
 template class handler_entry_write_ioport<0,  0, ENDIANNESS_BIG>;
 template class handler_entry_write_ioport<1,  3, ENDIANNESS_LITTLE>;

--- a/src/emu/emumem_hedr0.cpp
+++ b/src/emu/emumem_hedr0.cpp
@@ -5,6 +5,23 @@
 #include "emumem_hedr.ipp"
 
 
+template class handler_entry_read_dispatch< 1, 0,  1, ENDIANNESS_LITTLE>;
+template class handler_entry_read_dispatch< 1, 0,  1, ENDIANNESS_BIG>;
+template class handler_entry_read_dispatch< 2, 0,  1, ENDIANNESS_LITTLE>;
+template class handler_entry_read_dispatch< 2, 0,  1, ENDIANNESS_BIG>;
+template class handler_entry_read_dispatch< 3, 0,  1, ENDIANNESS_LITTLE>;
+template class handler_entry_read_dispatch< 3, 0,  1, ENDIANNESS_BIG>;
+template class handler_entry_read_dispatch< 4, 0,  1, ENDIANNESS_LITTLE>;
+template class handler_entry_read_dispatch< 4, 0,  1, ENDIANNESS_BIG>;
+template class handler_entry_read_dispatch< 5, 0,  1, ENDIANNESS_LITTLE>;
+template class handler_entry_read_dispatch< 5, 0,  1, ENDIANNESS_BIG>;
+template class handler_entry_read_dispatch< 6, 0,  1, ENDIANNESS_LITTLE>;
+template class handler_entry_read_dispatch< 6, 0,  1, ENDIANNESS_BIG>;
+template class handler_entry_read_dispatch< 7, 0,  1, ENDIANNESS_LITTLE>;
+template class handler_entry_read_dispatch< 7, 0,  1, ENDIANNESS_BIG>;
+template class handler_entry_read_dispatch< 8, 0,  1, ENDIANNESS_LITTLE>;
+template class handler_entry_read_dispatch< 8, 0,  1, ENDIANNESS_BIG>;
+
 template class handler_entry_read_dispatch< 1, 0,  0, ENDIANNESS_LITTLE>;
 template class handler_entry_read_dispatch< 1, 0,  0, ENDIANNESS_BIG>;
 template class handler_entry_read_dispatch< 2, 0,  0, ENDIANNESS_LITTLE>;

--- a/src/emu/emumem_hedr1.cpp
+++ b/src/emu/emumem_hedr1.cpp
@@ -4,6 +4,23 @@
 #include "emu.h"
 #include "emumem_hedr.ipp"
 
+template class handler_entry_read_dispatch< 9, 0,  1, ENDIANNESS_LITTLE>;
+template class handler_entry_read_dispatch< 9, 0,  1, ENDIANNESS_BIG>;
+template class handler_entry_read_dispatch<10, 0,  1, ENDIANNESS_LITTLE>;
+template class handler_entry_read_dispatch<10, 0,  1, ENDIANNESS_BIG>;
+template class handler_entry_read_dispatch<11, 0,  1, ENDIANNESS_LITTLE>;
+template class handler_entry_read_dispatch<11, 0,  1, ENDIANNESS_BIG>;
+template class handler_entry_read_dispatch<12, 0,  1, ENDIANNESS_LITTLE>;
+template class handler_entry_read_dispatch<12, 0,  1, ENDIANNESS_BIG>;
+template class handler_entry_read_dispatch<13, 0,  1, ENDIANNESS_LITTLE>;
+template class handler_entry_read_dispatch<13, 0,  1, ENDIANNESS_BIG>;
+template class handler_entry_read_dispatch<14, 0,  1, ENDIANNESS_LITTLE>;
+template class handler_entry_read_dispatch<14, 0,  1, ENDIANNESS_BIG>;
+template class handler_entry_read_dispatch<15, 0,  1, ENDIANNESS_LITTLE>;
+template class handler_entry_read_dispatch<15, 0,  1, ENDIANNESS_BIG>;
+template class handler_entry_read_dispatch<16, 0,  1, ENDIANNESS_LITTLE>;
+template class handler_entry_read_dispatch<16, 0,  1, ENDIANNESS_BIG>;
+
 template class handler_entry_read_dispatch< 9, 0,  0, ENDIANNESS_LITTLE>;
 template class handler_entry_read_dispatch< 9, 0,  0, ENDIANNESS_BIG>;
 template class handler_entry_read_dispatch<10, 0,  0, ENDIANNESS_LITTLE>;

--- a/src/emu/emumem_hedr2.cpp
+++ b/src/emu/emumem_hedr2.cpp
@@ -4,6 +4,23 @@
 #include "emu.h"
 #include "emumem_hedr.ipp"
 
+template class handler_entry_read_dispatch<17, 0,  1, ENDIANNESS_LITTLE>;
+template class handler_entry_read_dispatch<17, 0,  1, ENDIANNESS_BIG>;
+template class handler_entry_read_dispatch<18, 0,  1, ENDIANNESS_LITTLE>;
+template class handler_entry_read_dispatch<18, 0,  1, ENDIANNESS_BIG>;
+template class handler_entry_read_dispatch<19, 0,  1, ENDIANNESS_LITTLE>;
+template class handler_entry_read_dispatch<19, 0,  1, ENDIANNESS_BIG>;
+template class handler_entry_read_dispatch<20, 0,  1, ENDIANNESS_LITTLE>;
+template class handler_entry_read_dispatch<20, 0,  1, ENDIANNESS_BIG>;
+template class handler_entry_read_dispatch<21, 0,  1, ENDIANNESS_LITTLE>;
+template class handler_entry_read_dispatch<21, 0,  1, ENDIANNESS_BIG>;
+template class handler_entry_read_dispatch<22, 0,  1, ENDIANNESS_LITTLE>;
+template class handler_entry_read_dispatch<22, 0,  1, ENDIANNESS_BIG>;
+template class handler_entry_read_dispatch<23, 0,  1, ENDIANNESS_LITTLE>;
+template class handler_entry_read_dispatch<23, 0,  1, ENDIANNESS_BIG>;
+template class handler_entry_read_dispatch<24, 0,  1, ENDIANNESS_LITTLE>;
+template class handler_entry_read_dispatch<24, 0,  1, ENDIANNESS_BIG>;
+
 template class handler_entry_read_dispatch<17, 0,  0, ENDIANNESS_LITTLE>;
 template class handler_entry_read_dispatch<17, 0,  0, ENDIANNESS_BIG>;
 template class handler_entry_read_dispatch<18, 0,  0, ENDIANNESS_LITTLE>;

--- a/src/emu/emumem_hedr3.cpp
+++ b/src/emu/emumem_hedr3.cpp
@@ -5,6 +5,23 @@
 #include "emumem_hedr.ipp"
 
 
+template class handler_entry_read_dispatch<25, 0,  1, ENDIANNESS_LITTLE>;
+template class handler_entry_read_dispatch<25, 0,  1, ENDIANNESS_BIG>;
+template class handler_entry_read_dispatch<26, 0,  1, ENDIANNESS_LITTLE>;
+template class handler_entry_read_dispatch<26, 0,  1, ENDIANNESS_BIG>;
+template class handler_entry_read_dispatch<27, 0,  1, ENDIANNESS_LITTLE>;
+template class handler_entry_read_dispatch<27, 0,  1, ENDIANNESS_BIG>;
+template class handler_entry_read_dispatch<28, 0,  1, ENDIANNESS_LITTLE>;
+template class handler_entry_read_dispatch<28, 0,  1, ENDIANNESS_BIG>;
+template class handler_entry_read_dispatch<29, 0,  1, ENDIANNESS_LITTLE>;
+template class handler_entry_read_dispatch<29, 0,  1, ENDIANNESS_BIG>;
+template class handler_entry_read_dispatch<30, 0,  1, ENDIANNESS_LITTLE>;
+template class handler_entry_read_dispatch<30, 0,  1, ENDIANNESS_BIG>;
+template class handler_entry_read_dispatch<31, 0,  1, ENDIANNESS_LITTLE>;
+template class handler_entry_read_dispatch<31, 0,  1, ENDIANNESS_BIG>;
+template class handler_entry_read_dispatch<32, 0,  1, ENDIANNESS_LITTLE>;
+template class handler_entry_read_dispatch<32, 0,  1, ENDIANNESS_BIG>;
+
 template class handler_entry_read_dispatch<25, 0,  0, ENDIANNESS_LITTLE>;
 template class handler_entry_read_dispatch<25, 0,  0, ENDIANNESS_BIG>;
 template class handler_entry_read_dispatch<26, 0,  0, ENDIANNESS_LITTLE>;

--- a/src/emu/emumem_hedw0.cpp
+++ b/src/emu/emumem_hedw0.cpp
@@ -5,6 +5,23 @@
 #include "emumem_hedw.ipp"
 
 
+template class handler_entry_write_dispatch< 1, 0,  1, ENDIANNESS_LITTLE>;
+template class handler_entry_write_dispatch< 1, 0,  1, ENDIANNESS_BIG>;
+template class handler_entry_write_dispatch< 2, 0,  1, ENDIANNESS_LITTLE>;
+template class handler_entry_write_dispatch< 2, 0,  1, ENDIANNESS_BIG>;
+template class handler_entry_write_dispatch< 3, 0,  1, ENDIANNESS_LITTLE>;
+template class handler_entry_write_dispatch< 3, 0,  1, ENDIANNESS_BIG>;
+template class handler_entry_write_dispatch< 4, 0,  1, ENDIANNESS_LITTLE>;
+template class handler_entry_write_dispatch< 4, 0,  1, ENDIANNESS_BIG>;
+template class handler_entry_write_dispatch< 5, 0,  1, ENDIANNESS_LITTLE>;
+template class handler_entry_write_dispatch< 5, 0,  1, ENDIANNESS_BIG>;
+template class handler_entry_write_dispatch< 6, 0,  1, ENDIANNESS_LITTLE>;
+template class handler_entry_write_dispatch< 6, 0,  1, ENDIANNESS_BIG>;
+template class handler_entry_write_dispatch< 7, 0,  1, ENDIANNESS_LITTLE>;
+template class handler_entry_write_dispatch< 7, 0,  1, ENDIANNESS_BIG>;
+template class handler_entry_write_dispatch< 8, 0,  1, ENDIANNESS_LITTLE>;
+template class handler_entry_write_dispatch< 8, 0,  1, ENDIANNESS_BIG>;
+
 template class handler_entry_write_dispatch< 1, 0,  0, ENDIANNESS_LITTLE>;
 template class handler_entry_write_dispatch< 1, 0,  0, ENDIANNESS_BIG>;
 template class handler_entry_write_dispatch< 2, 0,  0, ENDIANNESS_LITTLE>;

--- a/src/emu/emumem_hedw1.cpp
+++ b/src/emu/emumem_hedw1.cpp
@@ -4,6 +4,23 @@
 #include "emu.h"
 #include "emumem_hedw.ipp"
 
+template class handler_entry_write_dispatch< 9, 0,  1, ENDIANNESS_LITTLE>;
+template class handler_entry_write_dispatch< 9, 0,  1, ENDIANNESS_BIG>;
+template class handler_entry_write_dispatch<10, 0,  1, ENDIANNESS_LITTLE>;
+template class handler_entry_write_dispatch<10, 0,  1, ENDIANNESS_BIG>;
+template class handler_entry_write_dispatch<11, 0,  1, ENDIANNESS_LITTLE>;
+template class handler_entry_write_dispatch<11, 0,  1, ENDIANNESS_BIG>;
+template class handler_entry_write_dispatch<12, 0,  1, ENDIANNESS_LITTLE>;
+template class handler_entry_write_dispatch<12, 0,  1, ENDIANNESS_BIG>;
+template class handler_entry_write_dispatch<13, 0,  1, ENDIANNESS_LITTLE>;
+template class handler_entry_write_dispatch<13, 0,  1, ENDIANNESS_BIG>;
+template class handler_entry_write_dispatch<14, 0,  1, ENDIANNESS_LITTLE>;
+template class handler_entry_write_dispatch<14, 0,  1, ENDIANNESS_BIG>;
+template class handler_entry_write_dispatch<15, 0,  1, ENDIANNESS_LITTLE>;
+template class handler_entry_write_dispatch<15, 0,  1, ENDIANNESS_BIG>;
+template class handler_entry_write_dispatch<16, 0,  1, ENDIANNESS_LITTLE>;
+template class handler_entry_write_dispatch<16, 0,  1, ENDIANNESS_BIG>;
+
 template class handler_entry_write_dispatch< 9, 0,  0, ENDIANNESS_LITTLE>;
 template class handler_entry_write_dispatch< 9, 0,  0, ENDIANNESS_BIG>;
 template class handler_entry_write_dispatch<10, 0,  0, ENDIANNESS_LITTLE>;

--- a/src/emu/emumem_hedw2.cpp
+++ b/src/emu/emumem_hedw2.cpp
@@ -4,6 +4,23 @@
 #include "emu.h"
 #include "emumem_hedw.ipp"
 
+template class handler_entry_write_dispatch<17, 0,  1, ENDIANNESS_LITTLE>;
+template class handler_entry_write_dispatch<17, 0,  1, ENDIANNESS_BIG>;
+template class handler_entry_write_dispatch<18, 0,  1, ENDIANNESS_LITTLE>;
+template class handler_entry_write_dispatch<18, 0,  1, ENDIANNESS_BIG>;
+template class handler_entry_write_dispatch<19, 0,  1, ENDIANNESS_LITTLE>;
+template class handler_entry_write_dispatch<19, 0,  1, ENDIANNESS_BIG>;
+template class handler_entry_write_dispatch<20, 0,  1, ENDIANNESS_LITTLE>;
+template class handler_entry_write_dispatch<20, 0,  1, ENDIANNESS_BIG>;
+template class handler_entry_write_dispatch<21, 0,  1, ENDIANNESS_LITTLE>;
+template class handler_entry_write_dispatch<21, 0,  1, ENDIANNESS_BIG>;
+template class handler_entry_write_dispatch<22, 0,  1, ENDIANNESS_LITTLE>;
+template class handler_entry_write_dispatch<22, 0,  1, ENDIANNESS_BIG>;
+template class handler_entry_write_dispatch<23, 0,  1, ENDIANNESS_LITTLE>;
+template class handler_entry_write_dispatch<23, 0,  1, ENDIANNESS_BIG>;
+template class handler_entry_write_dispatch<24, 0,  1, ENDIANNESS_LITTLE>;
+template class handler_entry_write_dispatch<24, 0,  1, ENDIANNESS_BIG>;
+
 template class handler_entry_write_dispatch<17, 0,  0, ENDIANNESS_LITTLE>;
 template class handler_entry_write_dispatch<17, 0,  0, ENDIANNESS_BIG>;
 template class handler_entry_write_dispatch<18, 0,  0, ENDIANNESS_LITTLE>;

--- a/src/emu/emumem_hedw3.cpp
+++ b/src/emu/emumem_hedw3.cpp
@@ -5,6 +5,23 @@
 #include "emumem_hedw.ipp"
 
 
+template class handler_entry_write_dispatch<25, 0,  1, ENDIANNESS_LITTLE>;
+template class handler_entry_write_dispatch<25, 0,  1, ENDIANNESS_BIG>;
+template class handler_entry_write_dispatch<26, 0,  1, ENDIANNESS_LITTLE>;
+template class handler_entry_write_dispatch<26, 0,  1, ENDIANNESS_BIG>;
+template class handler_entry_write_dispatch<27, 0,  1, ENDIANNESS_LITTLE>;
+template class handler_entry_write_dispatch<27, 0,  1, ENDIANNESS_BIG>;
+template class handler_entry_write_dispatch<28, 0,  1, ENDIANNESS_LITTLE>;
+template class handler_entry_write_dispatch<28, 0,  1, ENDIANNESS_BIG>;
+template class handler_entry_write_dispatch<29, 0,  1, ENDIANNESS_LITTLE>;
+template class handler_entry_write_dispatch<29, 0,  1, ENDIANNESS_BIG>;
+template class handler_entry_write_dispatch<30, 0,  1, ENDIANNESS_LITTLE>;
+template class handler_entry_write_dispatch<30, 0,  1, ENDIANNESS_BIG>;
+template class handler_entry_write_dispatch<31, 0,  1, ENDIANNESS_LITTLE>;
+template class handler_entry_write_dispatch<31, 0,  1, ENDIANNESS_BIG>;
+template class handler_entry_write_dispatch<32, 0,  1, ENDIANNESS_LITTLE>;
+template class handler_entry_write_dispatch<32, 0,  1, ENDIANNESS_BIG>;
+
 template class handler_entry_write_dispatch<25, 0,  0, ENDIANNESS_LITTLE>;
 template class handler_entry_write_dispatch<25, 0,  0, ENDIANNESS_BIG>;
 template class handler_entry_write_dispatch<26, 0,  0, ENDIANNESS_LITTLE>;

--- a/src/emu/emumem_hem.cpp
+++ b/src/emu/emumem_hem.cpp
@@ -95,6 +95,8 @@ template<int Width, int AddrShift, int Endian> std::string handler_entry_write_m
 
 
 
+template class handler_entry_read_memory<0,  1, ENDIANNESS_LITTLE>;
+template class handler_entry_read_memory<0,  1, ENDIANNESS_BIG>;
 template class handler_entry_read_memory<0,  0, ENDIANNESS_LITTLE>;
 template class handler_entry_read_memory<0,  0, ENDIANNESS_BIG>;
 template class handler_entry_read_memory<1,  3, ENDIANNESS_LITTLE>;
@@ -118,6 +120,8 @@ template class handler_entry_read_memory<3, -2, ENDIANNESS_BIG>;
 template class handler_entry_read_memory<3, -3, ENDIANNESS_LITTLE>;
 template class handler_entry_read_memory<3, -3, ENDIANNESS_BIG>;
 
+template class handler_entry_write_memory<0,  1, ENDIANNESS_LITTLE>;
+template class handler_entry_write_memory<0,  1, ENDIANNESS_BIG>;
 template class handler_entry_write_memory<0,  0, ENDIANNESS_LITTLE>;
 template class handler_entry_write_memory<0,  0, ENDIANNESS_BIG>;
 template class handler_entry_write_memory<1,  3, ENDIANNESS_LITTLE>;
@@ -142,6 +146,8 @@ template class handler_entry_write_memory<3, -3, ENDIANNESS_LITTLE>;
 template class handler_entry_write_memory<3, -3, ENDIANNESS_BIG>;
 
 
+template class handler_entry_read_memory_bank<0,  1, ENDIANNESS_LITTLE>;
+template class handler_entry_read_memory_bank<0,  1, ENDIANNESS_BIG>;
 template class handler_entry_read_memory_bank<0,  0, ENDIANNESS_LITTLE>;
 template class handler_entry_read_memory_bank<0,  0, ENDIANNESS_BIG>;
 template class handler_entry_read_memory_bank<1,  3, ENDIANNESS_LITTLE>;
@@ -165,6 +171,8 @@ template class handler_entry_read_memory_bank<3, -2, ENDIANNESS_BIG>;
 template class handler_entry_read_memory_bank<3, -3, ENDIANNESS_LITTLE>;
 template class handler_entry_read_memory_bank<3, -3, ENDIANNESS_BIG>;
 
+template class handler_entry_write_memory_bank<0,  1, ENDIANNESS_LITTLE>;
+template class handler_entry_write_memory_bank<0,  1, ENDIANNESS_BIG>;
 template class handler_entry_write_memory_bank<0,  0, ENDIANNESS_LITTLE>;
 template class handler_entry_write_memory_bank<0,  0, ENDIANNESS_BIG>;
 template class handler_entry_write_memory_bank<1,  3, ENDIANNESS_LITTLE>;

--- a/src/emu/emumem_hep.cpp
+++ b/src/emu/emumem_hep.cpp
@@ -50,6 +50,8 @@ template<int Width, int AddrShift, int Endian> void handler_entry_write_passthro
 		np->detach(handlers);
 }
 
+template class handler_entry_read_passthrough<0,  1, ENDIANNESS_LITTLE>;
+template class handler_entry_read_passthrough<0,  1, ENDIANNESS_BIG>;
 template class handler_entry_read_passthrough<0,  0, ENDIANNESS_LITTLE>;
 template class handler_entry_read_passthrough<0,  0, ENDIANNESS_BIG>;
 template class handler_entry_read_passthrough<1,  3, ENDIANNESS_LITTLE>;
@@ -73,6 +75,8 @@ template class handler_entry_read_passthrough<3, -2, ENDIANNESS_BIG>;
 template class handler_entry_read_passthrough<3, -3, ENDIANNESS_LITTLE>;
 template class handler_entry_read_passthrough<3, -3, ENDIANNESS_BIG>;
 
+template class handler_entry_write_passthrough<0,  1, ENDIANNESS_LITTLE>;
+template class handler_entry_write_passthrough<0,  1, ENDIANNESS_BIG>;
 template class handler_entry_write_passthrough<0,  0, ENDIANNESS_LITTLE>;
 template class handler_entry_write_passthrough<0,  0, ENDIANNESS_BIG>;
 template class handler_entry_write_passthrough<1,  3, ENDIANNESS_LITTLE>;

--- a/src/emu/emumem_het.cpp
+++ b/src/emu/emumem_het.cpp
@@ -42,6 +42,8 @@ template<int Width, int AddrShift, int Endian> handler_entry_write_tap<Width, Ad
 
 
 
+template class handler_entry_read_tap<0,  1, ENDIANNESS_LITTLE>;
+template class handler_entry_read_tap<0,  1, ENDIANNESS_BIG>;
 template class handler_entry_read_tap<0,  0, ENDIANNESS_LITTLE>;
 template class handler_entry_read_tap<0,  0, ENDIANNESS_BIG>;
 template class handler_entry_read_tap<1,  3, ENDIANNESS_LITTLE>;
@@ -65,6 +67,8 @@ template class handler_entry_read_tap<3, -2, ENDIANNESS_BIG>;
 template class handler_entry_read_tap<3, -3, ENDIANNESS_LITTLE>;
 template class handler_entry_read_tap<3, -3, ENDIANNESS_BIG>;
 
+template class handler_entry_write_tap<0,  1, ENDIANNESS_LITTLE>;
+template class handler_entry_write_tap<0,  1, ENDIANNESS_BIG>;
 template class handler_entry_write_tap<0,  0, ENDIANNESS_LITTLE>;
 template class handler_entry_write_tap<0,  0, ENDIANNESS_BIG>;
 template class handler_entry_write_tap<1,  3, ENDIANNESS_LITTLE>;

--- a/src/emu/emumem_heu.cpp
+++ b/src/emu/emumem_heu.cpp
@@ -230,6 +230,8 @@ template<int Width, int AddrShift, int Endian> std::string handler_entry_write_u
 }
 
 
+template class handler_entry_read_units<0,  1, ENDIANNESS_LITTLE>;
+template class handler_entry_read_units<0,  1, ENDIANNESS_BIG>;
 template class handler_entry_read_units<0,  0, ENDIANNESS_LITTLE>;
 template class handler_entry_read_units<0,  0, ENDIANNESS_BIG>;
 template class handler_entry_read_units<1,  3, ENDIANNESS_LITTLE>;
@@ -253,6 +255,8 @@ template class handler_entry_read_units<3, -2, ENDIANNESS_BIG>;
 template class handler_entry_read_units<3, -3, ENDIANNESS_LITTLE>;
 template class handler_entry_read_units<3, -3, ENDIANNESS_BIG>;
 
+template class handler_entry_write_units<0,  1, ENDIANNESS_LITTLE>;
+template class handler_entry_write_units<0,  1, ENDIANNESS_BIG>;
 template class handler_entry_write_units<0,  0, ENDIANNESS_LITTLE>;
 template class handler_entry_write_units<0,  0, ENDIANNESS_BIG>;
 template class handler_entry_write_units<1,  3, ENDIANNESS_LITTLE>;

--- a/src/emu/emumem_heun.cpp
+++ b/src/emu/emumem_heun.cpp
@@ -64,6 +64,8 @@ template<int Width, int AddrShift, int Endian> std::string handler_entry_write_n
 }
 
 
+template class handler_entry_read_unmapped<0,  1, ENDIANNESS_LITTLE>;
+template class handler_entry_read_unmapped<0,  1, ENDIANNESS_BIG>;
 template class handler_entry_read_unmapped<0,  0, ENDIANNESS_LITTLE>;
 template class handler_entry_read_unmapped<0,  0, ENDIANNESS_BIG>;
 template class handler_entry_read_unmapped<1,  3, ENDIANNESS_LITTLE>;
@@ -87,6 +89,8 @@ template class handler_entry_read_unmapped<3, -2, ENDIANNESS_BIG>;
 template class handler_entry_read_unmapped<3, -3, ENDIANNESS_LITTLE>;
 template class handler_entry_read_unmapped<3, -3, ENDIANNESS_BIG>;
 
+template class handler_entry_write_unmapped<0,  1, ENDIANNESS_LITTLE>;
+template class handler_entry_write_unmapped<0,  1, ENDIANNESS_BIG>;
 template class handler_entry_write_unmapped<0,  0, ENDIANNESS_LITTLE>;
 template class handler_entry_write_unmapped<0,  0, ENDIANNESS_BIG>;
 template class handler_entry_write_unmapped<1,  3, ENDIANNESS_LITTLE>;
@@ -111,6 +115,8 @@ template class handler_entry_write_unmapped<3, -3, ENDIANNESS_LITTLE>;
 template class handler_entry_write_unmapped<3, -3, ENDIANNESS_BIG>;
 
 
+template class handler_entry_read_nop<0,  1, ENDIANNESS_LITTLE>;
+template class handler_entry_read_nop<0,  1, ENDIANNESS_BIG>;
 template class handler_entry_read_nop<0,  0, ENDIANNESS_LITTLE>;
 template class handler_entry_read_nop<0,  0, ENDIANNESS_BIG>;
 template class handler_entry_read_nop<1,  3, ENDIANNESS_LITTLE>;
@@ -134,6 +140,8 @@ template class handler_entry_read_nop<3, -2, ENDIANNESS_BIG>;
 template class handler_entry_read_nop<3, -3, ENDIANNESS_LITTLE>;
 template class handler_entry_read_nop<3, -3, ENDIANNESS_BIG>;
 
+template class handler_entry_write_nop<0,  1, ENDIANNESS_LITTLE>;
+template class handler_entry_write_nop<0,  1, ENDIANNESS_BIG>;
 template class handler_entry_write_nop<0,  0, ENDIANNESS_LITTLE>;
 template class handler_entry_write_nop<0,  0, ENDIANNESS_BIG>;
 template class handler_entry_write_nop<1,  3, ENDIANNESS_LITTLE>;

--- a/src/mame/drivers/cortex.cpp
+++ b/src/mame/drivers/cortex.cpp
@@ -98,18 +98,15 @@ void cortex_state::mem_map(address_map &map)
 void cortex_state::io_map(address_map &map)
 {
 	map.unmap_value_high();
-	map(0x0000, 0x0007).mirror(0x18).w("control", FUNC(ls259_device::write_d0));
-	map(0x0000, 0x0000).r(FUNC(cortex_state::pio_r));
-	map(0x0001, 0x0001).r(FUNC(cortex_state::keyboard_r));
-	//AM_RANGE(0x0040, 0x005f) AM_DEVWRITE("uart1", tms9902_device, cruwrite) // RS232 (r12 = 80-bf)
-	//AM_RANGE(0x0008, 0x000b) AM_DEVREAD("uart1", tms9902_device, cruread) // RS232
-	//AM_RANGE(0x00c0, 0x00df) AM_DEVWRITE("uart2", tms9902_device, cruwrite) // Cassette (r12 = 180-1bf)
-	//AM_RANGE(0x0018, 0x001b) AM_DEVREAD("uart2", tms9902_device, cruread) // Cassette
-	//AM_RANGE(0x00e0, 0x00ff) AM_WRITE("dma", tms9911_device, write) // r12 = 1c0-1fe
-	//AM_RANGE(0x001c, 0x001f) AM_READ("dma", tms9911_device, read) // if reading is needed
-	//AM_RANGE(0x0400, 0x0407) AM_WRITE(cent_data_w) // r12 = 800-80e
-	//AM_RANGE(0x0408, 0x0408) AM_WRITE(cent_strobe_w) // r12 = 810
-	//AM_RANGE(0x0081, 0x0081) AM_READ(cent_stat_r) // CRU 409 (r12 = 812)
+	map(0x0000, 0x000f).mirror(0x30).w("control", FUNC(ls259_device::write_d0));
+	map(0x0000, 0x0007).r(FUNC(cortex_state::pio_r));
+	map(0x0008, 0x000f).r(FUNC(cortex_state::keyboard_r));
+	//map(0x0080, 0x00bf).rw("uart1", FUNC(tms9902_device::cruread), FUNC(tms9902_device::cruwrite)); // RS232 (r12 = 80-bf)
+	//map(0x0180, 0x01bf).rw("uart2", FUNC(tms9902_device::cruread), FUNC(tms9902_device::cruwrite)); // Cassette (r12 = 180-1bf)
+	//map(0x01c0, 0x01ff).rw("dma", FUNC(tms9911_device::read), FUNC(tms9911_device::write)); // r12 = 1c0-1fe
+	//map(0x0800, 0x080f).w(cortex_state::cent_data_w)); // r12 = 800-80e
+	//map(0x0810, 0x0811).w(FUNC(cortex_state::cent_strobe_w)); // r12 = 810
+	//map(0x0812, 0x0813).r(FUNC(cortex_state::cent_stat_r)); // CRU 409 (r12 = 812)
 }
 
 /* Input ports */
@@ -125,12 +122,26 @@ INPUT_PORTS_END
 
 READ8_MEMBER( cortex_state::pio_r )
 {
-	return (m_kbd_ack ? 0x20 : 0) | (m_vdp_int ? 0x40 : 0) | m_io_dsw->read() | 0x93;
+	switch (offset)
+	{
+	case 5:
+		return m_kbd_ack;
+
+	case 6:
+		return m_vdp_int;
+
+	case 2:
+	case 3:
+		return BIT(m_io_dsw->read(), offset);
+
+	default:
+		return 1;
+	}
 }
 
 READ8_MEMBER( cortex_state::keyboard_r )
 {
-	return m_term_data;
+	return BIT(m_term_data, offset);
 }
 
 WRITE_LINE_MEMBER( cortex_state::keyboard_ack_w )

--- a/src/mame/drivers/cosmic.cpp
+++ b/src/mame/drivers/cosmic.cpp
@@ -340,7 +340,15 @@ READ8_MEMBER(cosmic_state::cosmica_pixel_clock_r)
 READ8_MEMBER(cosmic_state::cosmicg_port_0_r)
 {
 	/* The top four address lines from the CRTC are bits 0-3 */
-	return (m_in_ports[0]->read() & 0xf0) | ((m_screen->vpos() & 0xf0) >> 4);
+	if (offset >= 4)
+		return BIT(m_in_ports[0]->read(), offset);
+	else
+		return BIT(m_screen->vpos(), offset + 4);
+}
+
+READ8_MEMBER(cosmic_state::cosmicg_port_1_r)
+{
+	return BIT(m_in_ports[1]->read(), offset);
 }
 
 READ8_MEMBER(cosmic_state::magspot_coinage_dip_r)
@@ -415,10 +423,10 @@ void cosmic_state::cosmicg_map(address_map &map)
 
 void cosmic_state::cosmicg_io_map(address_map &map)
 {
-	map(0x00, 0x00).r(FUNC(cosmic_state::cosmicg_port_0_r));
-	map(0x01, 0x01).portr("IN1");
-	map(0x00, 0x15).w(FUNC(cosmic_state::cosmicg_output_w));
-	map(0x16, 0x17).w(FUNC(cosmic_state::cosmic_color_register_w));
+	map(0x0000, 0x000f).r(FUNC(cosmic_state::cosmicg_port_0_r));
+	map(0x0010, 0x001f).r(FUNC(cosmic_state::cosmicg_port_1_r));
+	map(0x0000, 0x002b).w(FUNC(cosmic_state::cosmicg_output_w));
+	map(0x002c, 0x002f).w(FUNC(cosmic_state::cosmic_color_register_w));
 }
 
 

--- a/src/mame/drivers/evmbug.cpp
+++ b/src/mame/drivers/evmbug.cpp
@@ -59,10 +59,8 @@ void evmbug_state::mem_map(address_map &map)
 void evmbug_state::io_map(address_map &map)
 {
 	map.unmap_value_high();
-	//AM_RANGE(0x0000, 0x0003) AM_DEVREAD("uart1", tms9902_device, cruread)
-	//AM_RANGE(0x0000, 0x001f) AM_DEVWRITE("uart1", tms9902_device, cruwrite)
-	map(0x0000, 0x0003).r(FUNC(evmbug_state::rs232_r));
-	map(0x0000, 0x001f).w(FUNC(evmbug_state::rs232_w));
+	//map(0x0000, 0x003f).rw("uart1", FUNC(tms9902_device::cruread), FUNC(tms9902_device::cruwrite));
+	map(0x0000, 0x003f).rw(FUNC(evmbug_state::rs232_r), FUNC(evmbug_state::rs232_w));
 }
 
 /* Input ports */
@@ -71,16 +69,19 @@ INPUT_PORTS_END
 
 READ8_MEMBER( evmbug_state::rs232_r )
 {
-	if (offset == 0)
-		return m_term_data;
-	else
-	if (offset == 2)
-		return (m_rbrl ? 0x20 : 0) | 0xc0;
-	else
+	if (offset < 8)
+		return BIT(m_term_data, offset);
+	else if (offset == 21)
+		return m_rbrl;
+	else if (offset == 22 || offset == 23)
+		return 1;
+	else if (offset == 15)
 	{
 		m_rin ^= 1;
-		return m_rin << 7;
+		return m_rin;
 	}
+	else
+		return 0;
 }
 
 WRITE8_MEMBER( evmbug_state::rs232_w )

--- a/src/mame/drivers/geneve.cpp
+++ b/src/mame/drivers/geneve.cpp
@@ -306,11 +306,8 @@ void geneve_state::memmap_setoffset(address_map &map)
 */
 void geneve_state::crumap(address_map &map)
 {
-	map(0x0000, 0x0fff).r(FUNC(geneve_state::cruread));
-	map(0x0000, 0x0003).r(m_tms9901, FUNC(tms9901_device::read));
-
-	map(0x0000, 0x7fff).w(FUNC(geneve_state::cruwrite));
-	map(0x0000, 0x001f).w(m_tms9901, FUNC(tms9901_device::write));
+	map(0x0000, 0xffff).rw(FUNC(geneve_state::cruread), FUNC(geneve_state::cruwrite));
+	map(0x0000, 0x003f).rw(m_tms9901, FUNC(tms9901_device::read), FUNC(tms9901_device::write));
 }
 
 static INPUT_PORTS_START(geneve_common)
@@ -434,7 +431,7 @@ WRITE8_MEMBER ( geneve_state::cruwrite )
 READ8_MEMBER( geneve_state::cruread )
 {
 	uint8_t value = 0;
-	int addroff = offset << 4;
+	uint16_t addroff = offset << 1;
 
 	// Single step
 	// 13c0 - 13fe: 0001 0011 11xx xxx0

--- a/src/mame/drivers/jpmmps.cpp
+++ b/src/mame/drivers/jpmmps.cpp
@@ -184,19 +184,19 @@ void jpmmps_state::jpmmps_map(address_map &map)
 
 void jpmmps_state::jpmmps_io_map(address_map &map)
 {
-	map.global_mask(0xff);
-	map(0x0000, 0x001f).rw(UART_IC5, FUNC(tms9902_device::cruread), FUNC(tms9902_device::cruwrite));
+	map.global_mask(0x1ff);
+	map(0x0000, 0x003f).rw(UART_IC5, FUNC(tms9902_device::cruread), FUNC(tms9902_device::cruwrite));
 
-//  AM_RANGE(0x0020, 0x0020) // power fail
-//  AM_RANGE(0x0021, 0x0021) // wd timeout
-//  AM_RANGE(0x0022, 0x0022) // invalid access
-//  AM_RANGE(0x0023, 0x0023) // clear down
+//  AM_RANGE(0x0040, 0x0041) // power fail
+//  AM_RANGE(0x0042, 0x0043) // wd timeout
+//  AM_RANGE(0x0044, 0x0045) // invalid access
+//  AM_RANGE(0x0046, 0x0047) // clear down
 
-//  AM_RANGE(0x0026, 0x0026) // uart4 int
-//  AM_RANGE(0x0027, 0x0027) // uart2 int
+//  AM_RANGE(0x004c, 0x004d) // uart4 int
+//  AM_RANGE(0x004e, 0x004f) // uart2 int
 
-	map(0x0040, 0x005f).rw(UART_IC10, FUNC(tms9902_device::cruread), FUNC(tms9902_device::cruwrite));
-	map(0x0060, 0x0067).w("mainlatch", FUNC(ls259_device::write_d0));
+	map(0x0080, 0x00bf).rw(UART_IC10, FUNC(tms9902_device::cruread), FUNC(tms9902_device::cruwrite));
+	map(0x00c0, 0x00cf).w("mainlatch", FUNC(ls259_device::write_d0));
 }
 
 

--- a/src/mame/drivers/jpms80.cpp
+++ b/src/mame/drivers/jpms80.cpp
@@ -101,21 +101,21 @@ void jpms80_state::jpms80_map(address_map &map)
 
 void jpms80_state::jpms80_io_map(address_map &map)
 {
-	map.global_mask(0x1ff);
+	map.global_mask(0x3ff);
 //  AM_RANGE(0x0000, 0x001f) // I/O & Optic (in)
-	map(0x0000, 0x0007).w("outlatch0", FUNC(ls259_device::write_d0));
-	map(0x0008, 0x000f).w("outlatch1", FUNC(ls259_device::write_d0));
-	map(0x0010, 0x0017).w("outlatch2", FUNC(ls259_device::write_d0));
-	map(0x0018, 0x001f).w("outlatch3", FUNC(ls259_device::write_d0));
-	map(0x0020, 0x0027).w("outlatch4", FUNC(ls259_device::write_d0));
-	map(0x0028, 0x002f).w("outlatch5", FUNC(ls259_device::write_d0));
-	map(0x0030, 0x0037).w("outlatch6", FUNC(ls259_device::write_d0));
-	map(0x0038, 0x003f).w("outlatch7", FUNC(ls259_device::write_d0));
-	map(0x0040, 0x0047).w("outlatch8", FUNC(ls259_device::write_d0));
-	map(0x0048, 0x004f).w("outlatch9", FUNC(ls259_device::write_d0));
-	map(0x0050, 0x0057).w("outlatch10", FUNC(ls259_device::write_d0));
-//  AM_RANGE(0x0140, 0x015f) // AY
-	map(0x01e0, 0x01ff).rw(m_acc, FUNC(tms9902_device::cruread), FUNC(tms9902_device::cruwrite));
+	map(0x0000, 0x000f).w("outlatch0", FUNC(ls259_device::write_d0));
+	map(0x0010, 0x001f).w("outlatch1", FUNC(ls259_device::write_d0));
+	map(0x0020, 0x002f).w("outlatch2", FUNC(ls259_device::write_d0));
+	map(0x0030, 0x003f).w("outlatch3", FUNC(ls259_device::write_d0));
+	map(0x0040, 0x004f).w("outlatch4", FUNC(ls259_device::write_d0));
+	map(0x0050, 0x005f).w("outlatch5", FUNC(ls259_device::write_d0));
+	map(0x0060, 0x006f).w("outlatch6", FUNC(ls259_device::write_d0));
+	map(0x0070, 0x007f).w("outlatch7", FUNC(ls259_device::write_d0));
+	map(0x0080, 0x008f).w("outlatch8", FUNC(ls259_device::write_d0));
+	map(0x0090, 0x009f).w("outlatch9", FUNC(ls259_device::write_d0));
+	map(0x00a0, 0x00af).w("outlatch10", FUNC(ls259_device::write_d0));
+//  AM_RANGE(0x0380, 0x03bf) // AY
+	map(0x03c0, 0x03ff).rw(m_acc, FUNC(tms9902_device::cruread), FUNC(tms9902_device::cruwrite));
 //  Lamps, Meters etc. can move around
 }
 

--- a/src/mame/drivers/jubilee.cpp
+++ b/src/mame/drivers/jubilee.cpp
@@ -569,19 +569,19 @@ READ8_MEMBER(jubilee_state::mux_port_r)
 {
 	switch( mux_sel )
 	{
-		case 0x01: return ioport("IN0")->read();
-		case 0x02: return ioport("IN1")->read();    /* muxed credits input is here! */
-		case 0x03: return ioport("IN2")->read();
+		case 0x01: return BIT(ioport("IN0")->read(), offset);
+		case 0x02: return BIT(ioport("IN1")->read(), offset);    /* muxed credits input is here! */
+		case 0x03: return BIT(ioport("IN2")->read(), offset);
 	}
 
-	return 0xff;
+	return 1;
 }
 
 
 void jubilee_state::jubileep_cru_map(address_map &map)
 {
-	map(0x00c8, 0x00c8).r(FUNC(jubilee_state::mux_port_r));    /* multiplexed input port */
-	map(0x0000, 0x07ff).w(FUNC(jubilee_state::unk_w));
+	map(0x0c80, 0x0c8f).r(FUNC(jubilee_state::mux_port_r));    /* multiplexed input port */
+	map(0x0000, 0x0fff).w(FUNC(jubilee_state::unk_w));
 }
 
 /* I/O byte R/W

--- a/src/mame/drivers/jvh.cpp
+++ b/src/mame/drivers/jvh.cpp
@@ -49,28 +49,28 @@ void jvh_state::jvh_map(address_map &map)
 
 void jvh_state::escape_io(address_map &map)
 {
-	//AM_RANGE(0x01, 0x02) AM_READ(sw1_r)
-	//AM_RANGE(0x03, 0x05) AM_READ(dip_r)
-	//AM_RANGE(0x06, 0x07) AM_READ(sw6_r)
-	//AM_RANGE(0x10, 0x15) AM_WRITE(snd_w)
-	//AM_RANGE(0x16, 0x16) AM_WRITE(latch_w)
-	//AM_RANGE(0x17, 0x19) AM_WRITE(out1a_w)
-	//AM_RANGE(0x1a, 0x1a) AM_WRITE(enable_w)
-	//AM_RANGE(0x1b, 0x1f) AM_WRITE(out1b_w)
-	//AM_RANGE(0x20, 0x27) AM_WRITE(out2a_w)
-	//AM_RANGE(0x28, 0x2f) AM_WRITE(out2b_w)
-	//AM_RANGE(0x30, 0x37) AM_WRITE(out3a_w)
-	//AM_RANGE(0x3e, 0x3e) AM_WRITE(irq_enable)
-	//AM_RANGE(0x3f, 0x3f) AM_WRITE(zc_enable)
-	//AM_RANGE(0x40, 0x47) AM_WRITE(digit_w)
-	//AM_RANGE(0x48, 0x4b) AM_WRITE(bcd_w)
-	//AM_RANGE(0x4c, 0x50) AM_WRITE(panel_w)
-	//AM_RANGE(0x51, 0x55) AM_WRITE(col_w)
-	//AM_RANGE(0x58, 0x5f) AM_WRITE(out5b_w)
-	//AM_RANGE(0x60, 0x67) AM_WRITE(out6a_w)
-	//AM_RANGE(0x68, 0x6f) AM_WRITE(out6b_w)
-	//AM_RANGE(0x70, 0x74) AM_WRITE(out7a_w)
-	//AM_RANGE(0x75, 0x7f) AM_WRITE(sol_w)
+	//map(0x0010, 0x002f).r(FUNC(jvh_state::sw1_r));
+	//map(0x0030, 0x005f).r(FUNC(jvh_state::dip_r));
+	//map(0x0060, 0x007f).r(FUNC(jvh_state::sw6_r));
+	//map(0x0020, 0x002b).w(FUNC(jvh_state::snd_w));
+	//map(0x002c, 0x002d).w(FUNC(jvh_state::latch_w));
+	//map(0x002e, 0x0033).w(FUNC(jvh_state::out1a_w));
+	//map(0x0034, 0x0035).w(FUNC(jvh_state::enable_w));
+	//map(0x0036, 0x003f).w(FUNC(jvh_state::out1b_w));
+	//map(0x0040, 0x004f).w(FUNC(jvh_state::out2a_w));
+	//map(0x0050, 0x005f).w(FUNC(jvh_state::out2b_w));
+	//map(0x0060, 0x006f).w(FUNC(jvh_state::out3a_w));
+	//map(0x007c, 0x007d).w(FUNC(jvh_state::irq_enable));
+	//map(0x007e, 0x007f).w(FUNC(jvh_state::zc_enable));
+	//map(0x0080, 0x008f).w(FUNC(jvh_state::digit_w));
+	//map(0x0090, 0x0097).w(FUNC(jvh_state::bcd_w));
+	//map(0x0098, 0x00a1).w(FUNC(jvh_state::panel_w));
+	//map(0x00a2, 0x00ab).w(FUNC(jvh_state::col_w));
+	//map(0x00b0, 0x00bf).w(FUNC(jvh_state::out5b_w));
+	//map(0x00c0, 0x00cf).w(FUNC(jvh_state::out6a_w));
+	//map(0x00d0, 0x00df).w(FUNC(jvh_state::out6b_w));
+	//map(0x00e0, 0x00e9).w(FUNC(jvh_state::out7a_w));
+	//map(0x00ea, 0x00ff).w(FUNC(jvh_state::sol_w));
 }
 
 void jvh_state::movmastr_io(address_map &map)

--- a/src/mame/drivers/looping.cpp
+++ b/src/mame/drivers/looping.cpp
@@ -567,7 +567,7 @@ void looping_state::looping_map(address_map &map)
 
 void looping_state::looping_io_map(address_map &map)
 {
-	map(0x400, 0x407).w("mainlatch", FUNC(ls259_device::write_d0));
+	map(0x0800, 0x080f).w("mainlatch", FUNC(ls259_device::write_d0));
 }
 
 
@@ -587,8 +587,8 @@ void looping_state::looping_sound_map(address_map &map)
 
 void looping_state::looping_sound_io_map(address_map &map)
 {
-	map(0x000, 0x007).w("sen0", FUNC(ls259_device::write_d0));
-	map(0x008, 0x00f).w("sen1", FUNC(ls259_device::write_d0));
+	map(0x0000, 0x000f).w("sen0", FUNC(ls259_device::write_d0));
+	map(0x0010, 0x001f).w("sen1", FUNC(ls259_device::write_d0));
 }
 
 

--- a/src/mame/drivers/nsm.cpp
+++ b/src/mame/drivers/nsm.cpp
@@ -65,18 +65,18 @@ void nsm_state::nsm_map(address_map &map)
 void nsm_state::nsm_io_map(address_map &map)
 {
 	// 00-71 selected by IC600 (74LS151)
-	map(0x0000, 0x0001).r(FUNC(nsm_state::ff_r)); // 5v supply
-	map(0x0010, 0x0011).nopr(); // antenna
-	map(0x0020, 0x0021).nopr(); // reset circuit
-	map(0x0030, 0x0031).r(FUNC(nsm_state::ff_r)); // service plug
-	map(0x0040, 0x0041).r(FUNC(nsm_state::ff_r)); // service plug
-	map(0x0050, 0x0051).r(FUNC(nsm_state::ff_r)); // test of internal battery
-	map(0x0060, 0x0061).r(FUNC(nsm_state::ff_r)); // sum of analog outputs of ay2
-	//AM_RANGE(0x0070, 0x0071) AM_READNOP // serial data in
-	map(0x0f70, 0x0f7d).nopw();
-	map(0x0fe4, 0x0fff).nopr();
-	map(0x7fb0, 0x7fbf).w(FUNC(nsm_state::cru_w));
-	map(0x7fd0, 0x7fd1).w(FUNC(nsm_state::oe_w));
+	map(0x0000, 0x001f).r(FUNC(nsm_state::ff_r)); // 5v supply
+	map(0x0100, 0x011f).nopr(); // antenna
+	map(0x0200, 0x021f).nopr(); // reset circuit
+	map(0x0300, 0x031f).r(FUNC(nsm_state::ff_r)); // service plug
+	map(0x0400, 0x041f).r(FUNC(nsm_state::ff_r)); // service plug
+	map(0x0500, 0x051f).r(FUNC(nsm_state::ff_r)); // test of internal battery
+	map(0x0600, 0x061f).r(FUNC(nsm_state::ff_r)); // sum of analog outputs of ay2
+	//map(0x0700, 0x071f).nopr(); // serial data in
+	map(0x1ee0, 0x1efb).nopw();
+	map(0xfe40, 0xfff0).nopr();
+	map(0xff60, 0xff7f).w(FUNC(nsm_state::cru_w));
+	map(0xffa0, 0xffa3).w(FUNC(nsm_state::oe_w));
 }
 
 static INPUT_PORTS_START( nsm )

--- a/src/mame/drivers/nsmpoker.cpp
+++ b/src/mame/drivers/nsmpoker.cpp
@@ -175,7 +175,7 @@ INTERRUPT_GEN_MEMBER(nsmpoker_state::nsmpoker_interrupt)
 
 READ8_MEMBER(nsmpoker_state::debug_r)
 {
-	return machine().rand() & 0xff;
+	return BIT(machine().rand(), offset);
 }
 
 
@@ -194,8 +194,8 @@ void nsmpoker_state::nsmpoker_map(address_map &map)
 
 void nsmpoker_state::nsmpoker_portmap(address_map &map)
 {
-	map.global_mask(0xff);
-	map(0xf0, 0xf0).r(FUNC(nsmpoker_state::debug_r));   // kind of trap at beginning
+	map.global_mask(0xfff);
+	map(0xf00, 0xf0f).r(FUNC(nsmpoker_state::debug_r));   // kind of trap at beginning
 }
 
 /* I/O byte R/W

--- a/src/mame/drivers/pachifev.cpp
+++ b/src/mame/drivers/pachifev.cpp
@@ -167,7 +167,7 @@ void pachifev_state::pachifev_map(address_map &map)
 
 void pachifev_state::pachifev_cru(address_map &map)
 {
-	map(0x000, 0x000).r(FUNC(pachifev_state::controls_r));
+	map(0x0000, 0x0001).r(FUNC(pachifev_state::controls_r));
 }
 
 

--- a/src/mame/drivers/si5500.cpp
+++ b/src/mame/drivers/si5500.cpp
@@ -41,7 +41,7 @@ private:
 	u8 gpibpsi_input_r(offs_t offset);
 	DECLARE_WRITE_LINE_MEMBER(gpibc_we_w);
 	DECLARE_WRITE_LINE_MEMBER(gpibc_dbin_w);
-	u8 keypad_r();
+	u8 keypad_r(offs_t offset);
 
 	void mem_map(address_map &map);
 	void cru_map(address_map &map);
@@ -106,15 +106,13 @@ WRITE_LINE_MEMBER(si5500_state::gpibc_dbin_w)
 	}
 }
 
-u8 si5500_state::keypad_r()
+u8 si5500_state::keypad_r(offs_t offset)
 {
-	u8 result = 0xff;
-
 	for (int n = 0; n < 4; n++)
 		if (!BIT(m_keyplatch->output_state(), n))
-			result &= m_keypad[n]->read();
-
-	return result;
+			if (!BIT(m_keypad[n]->read(), offset))
+				return 0;
+	return 1;
 }
 
 void si5500_state::mem_map(address_map &map)
@@ -125,28 +123,19 @@ void si5500_state::mem_map(address_map &map)
 
 void si5500_state::cru_map(address_map &map)
 {
-	// MAME currently has incompatible addressing for CRU reads and writes
-	map(0x00, 0x03).r(m_mainpsi, FUNC(tms9901_device::read));
-	map(0x08, 0x0b).r("acc", FUNC(tms9902_device::cruread));
-	map(0x0c, 0x0f).r("adpsi", FUNC(tms9901_device::read));
-	map(0x16, 0x16).nopr();
-	map(0x17, 0x17).r(FUNC(si5500_state::keypad_r));
-	map(0x40, 0x43).r("nvrpsi", FUNC(tms9901_device::read));
-	map(0x44, 0x47).r(m_gpibpsi, FUNC(tms9901_device::read));
-	map(0x80, 0xff).r("novram", FUNC(x2201_device::read_byte));
-
-	map(0x000, 0x01f).w(m_mainpsi, FUNC(tms9901_device::write));
-	map(0x040, 0x05f).w("acc", FUNC(tms9902_device::cruwrite));
-	map(0x060, 0x07f).w("adpsi", FUNC(tms9901_device::write));
-	map(0x080, 0x087).w("outlatch1", FUNC(ls259_device::write_d0));
-	map(0x088, 0x08f).w("outlatch2", FUNC(ls259_device::write_d0));
-	map(0x090, 0x097).w("outlatch3", FUNC(ls259_device::write_d0));
-	map(0x0a0, 0x0a7).w("outlatch4", FUNC(ls259_device::write_d0));
-	map(0x0a8, 0x0af).w("outlatch5", FUNC(ls259_device::write_d0));
-	map(0x0b0, 0x0bf).w(m_keyplatch, FUNC(ls259_device::write_d0));
-	map(0x200, 0x21f).w("nvrpsi", FUNC(tms9901_device::write));
-	map(0x220, 0x23f).w(m_gpibpsi, FUNC(tms9901_device::write));
-	map(0x400, 0x7ff).w("novram", FUNC(x2201_device::write));
+	map(0x0000, 0x003f).rw(m_mainpsi, FUNC(tms9901_device::read), FUNC(tms9901_device::write));
+	map(0x0080, 0x00bf).rw("acc", FUNC(tms9902_device::cruread), FUNC(tms9902_device::cruwrite));
+	map(0x00c0, 0x00ff).rw("adpsi", FUNC(tms9901_device::read), FUNC(tms9901_device::write));
+	map(0x0100, 0x010f).w("outlatch1", FUNC(ls259_device::write_d0));
+	map(0x0110, 0x011f).w("outlatch2", FUNC(ls259_device::write_d0));
+	map(0x0120, 0x012f).w("outlatch3", FUNC(ls259_device::write_d0));
+	map(0x0140, 0x014f).w("outlatch4", FUNC(ls259_device::write_d0));
+	map(0x0150, 0x015f).w("outlatch5", FUNC(ls259_device::write_d0));
+	map(0x0160, 0x016f).w(m_keyplatch, FUNC(ls259_device::write_d0)).nopr();
+	map(0x0170, 0x017f).r(FUNC(si5500_state::keypad_r));
+	map(0x0400, 0x043f).rw("nvrpsi", FUNC(tms9901_device::read), FUNC(tms9901_device::write));
+	map(0x0440, 0x047f).rw(m_gpibpsi, FUNC(tms9901_device::read), FUNC(tms9901_device::write));
+	map(0x0800, 0x0fff).rw("novram", FUNC(x2201_device::read), FUNC(x2201_device::write));
 }
 
 static INPUT_PORTS_START(si5500)

--- a/src/mame/drivers/supertnk.cpp
+++ b/src/mame/drivers/supertnk.cpp
@@ -346,8 +346,8 @@ void supertnk_state::supertnk_map(address_map &map)
 
 void supertnk_state::supertnk_io_map(address_map &map)
 {
-	map(0x0000, 0x0000).nopw();
-	map(0x0400, 0x0407).w("outlatch", FUNC(ls259_device::write_d0));
+	map(0x0000, 0x0001).nopw();
+	map(0x0800, 0x080f).w("outlatch", FUNC(ls259_device::write_d0));
 }
 
 

--- a/src/mame/drivers/ti990_4.cpp
+++ b/src/mame/drivers/ti990_4.cpp
@@ -115,8 +115,8 @@ void ti990_4_state::device_timer(emu_timer &timer, device_timer_id id, int param
 
 READ8_MEMBER( ti990_4_state::panel_read )
 {
-	if (offset == 1)
-		return 0x48;
+	if (offset == 11 || offset == 14)
+		return 1;
 
 	return 0;
 }
@@ -227,47 +227,37 @@ void ti990_4_state::memmap(address_map &map)
 /*
     CRU map
 
-    0x000-0xF7F: user devices
-    0xF80-0xF9F: CRU interrupt + expansion control
-    0xFA0-0xFAF: TILINE coupler interrupt control
-    0xFB0-0xFCF: reserved
-    0xFD0-0xFDF: memory mapping and memory protect
-    0xFE0-0xFEF: internal interrupt control
-    0xFF0-0xFFF: front panel
+    0x0000-0x1EFF: user devices
+    0x1F00-0x1F3F: CRU interrupt + expansion control
+    0x1F40-0x1F5F: TILINE coupler interrupt control
+    0x1F60-0x1F9F: reserved
+    0x1FA0-0x1FBF: memory mapping and memory protect
+    0x1FC0-0x1FDF: internal interrupt control
+    0x1FF0-0x1FFF: front panel
 
     Default user map:
-    0x000-0x00f: 733 ASR (int 6)
-    0x010-0x01f: PROM programmer (wired to int 15, unused)
-    0x020-0x02f: 804 card reader (int 4)
-    0x030-0x03f: line printer (wired to int 14, unused)
-    0x040-0x05f: FD800 floppy controller (int 7)
-    0x060-0x07f: VDT1 (int 3 - wired to int 11, unused)
-    0x080-0x09f: VDT2, or CRU expansion (int ??? - wired to int 10, unused)
-    0x0a0-0x0bf: VDT3 (int ??? - wired to int 9, unused)
+    0x0000-0x001f: 733 ASR (int 6)
+    0x0020-0x003f: PROM programmer (wired to int 15, unused)
+    0x0040-0x005f: 804 card reader (int 4)
+    0x0060-0x007f: line printer (wired to int 14, unused)
+    0x0080-0x00bf: FD800 floppy controller (int 7)
+    0x00c0-0x00ff: VDT1 (int 3 - wired to int 11, unused)
+    0x0100-0x013f: VDT2, or CRU expansion (int ??? - wired to int 10, unused)
+    0x0140-0x017f: VDT3 (int ??? - wired to int 9, unused)
 */
 
 void ti990_4_state::crumap(address_map &map)
 {
-	map(0x00, 0x01).r("asr733", FUNC(asr733_device::cru_r));
-	map(0x00, 0x0f).w("asr733", FUNC(asr733_device::cru_w));
-
-	map(0x08, 0x0b).r(m_fd800, FUNC(fd800_legacy_device::cru_r));
-	map(0x40, 0x5f).w(m_fd800, FUNC(fd800_legacy_device::cru_w));
-
-	map(0x1fe, 0x1ff).r(FUNC(ti990_4_state::panel_read));
-	map(0xff0, 0xfff).w(FUNC(ti990_4_state::panel_write));
+	map(0x0000, 0x001f).rw("asr733", FUNC(asr733_device::cru_r), FUNC(asr733_device::cru_w));
+	map(0x0080, 0x00bf).rw(m_fd800, FUNC(fd800_legacy_device::cru_r), FUNC(fd800_legacy_device::cru_w));
+	map(0x1fe0, 0x1fff).rw(FUNC(ti990_4_state::panel_read), FUNC(ti990_4_state::panel_write));
 }
 
 void ti990_4_state::crumap_v(address_map &map)
 {
-	map(0x10, 0x11).r("vdt911", FUNC(vdt911_device::cru_r));
-	map(0x80, 0x8f).w("vdt911", FUNC(vdt911_device::cru_w));
-
-	map(0x08, 0x0b).r(m_fd800, FUNC(fd800_legacy_device::cru_r));
-	map(0x40, 0x5f).w(m_fd800, FUNC(fd800_legacy_device::cru_w));
-
-	map(0x1fe, 0x1ff).r(FUNC(ti990_4_state::panel_read));
-	map(0xff0, 0xfff).w(FUNC(ti990_4_state::panel_write));
+	map(0x0080, 0x00bf).rw(m_fd800, FUNC(fd800_legacy_device::cru_r), FUNC(fd800_legacy_device::cru_w));
+	map(0x0100, 0x011f).rw("vdt911", FUNC(vdt911_device::cru_r), FUNC(vdt911_device::cru_w));
+	map(0x1fe0, 0x1fff).rw(FUNC(ti990_4_state::panel_read), FUNC(ti990_4_state::panel_write));
 }
 
 

--- a/src/mame/drivers/ti99_2.cpp
+++ b/src/mame/drivers/ti99_2.cpp
@@ -275,18 +275,13 @@ void ti99_2_state::memmap(address_map &map)
 
 /*
     CRU map - see description above
-    Note that the CRU address space has only even numbers, and the
-    read addresses in the emulation gather 8 bits in one go, so the address
-    is the bit number times 16.
 */
 void ti99_2_state::crumap(address_map &map)
 {
-	map(0x0000, 0x0fff).r(m_io992, FUNC(bus::ti99::internal::io992_device::cruread));
-	map(0x0000, 0x7fff).w(m_io992, FUNC(bus::ti99::internal::io992_device::cruwrite));
+	map(0x0000, 0xffff).rw(m_io992, FUNC(bus::ti99::internal::io992_device::cruread), FUNC(bus::ti99::internal::io992_device::cruwrite));
 
 	// Mirror of CPU-internal flags (1ee0-1efe). Don't read. Write is OK.
-	map(0x01ee, 0x01ef).nopr();
-	map(0x0f70, 0x0f7f).w(FUNC(ti99_2_state::intflag_write));
+	map(0x1ee0, 0x1eff).nopr().w(FUNC(ti99_2_state::intflag_write));
 }
 
 /*

--- a/src/mame/drivers/ti99_4p.cpp
+++ b/src/mame/drivers/ti99_4p.cpp
@@ -309,11 +309,8 @@ void ti99_4p_state::memmap_setoffset(address_map &map)
 
 void ti99_4p_state::crumap(address_map &map)
 {
-	map(0x0000, 0x01ff).r(FUNC(ti99_4p_state::cruread));
-	map(0x0000, 0x003f).r(m_tms9901, FUNC(tms9901_device::read));
-
-	map(0x0000, 0x0fff).w(FUNC(ti99_4p_state::cruwrite));
-	map(0x0000, 0x01ff).w(m_tms9901, FUNC(tms9901_device::write));
+	map(0x0000, 0x1fff).rw(FUNC(ti99_4p_state::cruread), FUNC(ti99_4p_state::cruwrite));
+	map(0x0000, 0x03ff).rw(m_tms9901, FUNC(tms9901_device::read), FUNC(tms9901_device::write));
 }
 
 /*

--- a/src/mame/drivers/ti99_4x.cpp
+++ b/src/mame/drivers/ti99_4x.cpp
@@ -249,25 +249,11 @@ void ti99_4x_state::memmap_setoffset(address_map &map)
     The TMS9901 is incompletely decoded
     ---0 00xx xxcc ccc0
     causing 16 mirrors (0000, 0040, 0080, 00c0, ... , 03c0)
-
-    Reading is done by transfering 8 successive bits, so addresses refer to
-    8 bit groups; writing, however, is done using output lines. The CRU base
-    address in the ti99 systems is twice the bit address:
-
-    (base=0, bit=0x10) == (base=0x20,bit=0)
-
-    Read: 0000 - 003f translates to base addresses 0000 - 03fe
-          0000 - 01ff is the complete CRU address space 0000 - 1ffe (for TMS9900)
-
-    Write:0000 - 01ff corresponds to bit 0 of base address 0000 - 03fe
 */
 void ti99_4x_state::crumap(address_map &map)
 {
-	map(0x0000, 0x01ff).r(FUNC(ti99_4x_state::cruread));
-	map(0x0000, 0x0003).mirror(0x003c).r(m_tms9901, FUNC(tms9901_device::read));
-
-	map(0x0000, 0x0fff).w(FUNC(ti99_4x_state::cruwrite));
-	map(0x0000, 0x001f).mirror(0x01e0).w(m_tms9901, FUNC(tms9901_device::write));
+	map(0x0000, 0x1fff).rw(FUNC(ti99_4x_state::cruread), FUNC(ti99_4x_state::cruwrite));
+	map(0x0000, 0x003f).mirror(0x03c0).rw(m_tms9901, FUNC(tms9901_device::read), FUNC(tms9901_device::write));
 }
 
 
@@ -419,15 +405,14 @@ INPUT_PORTS_END
 
 READ8_MEMBER( ti99_4x_state::cruread )
 {
-	LOGMASKED(LOG_CRUREAD, "read access to CRU address %04x\n", offset << 4);
+	LOGMASKED(LOG_CRUREAD, "read access to CRU address %04x\n", offset << 1);
 	uint8_t value = 0;
 
 	// Let the gromport (not in the QI version) and the p-box behind the I/O port
 	// decide whether they want to change the value at the CRU address
-	// Also, we translate the bit addresses to base addresses
 
-	if (m_model != MODEL_4QI) m_gromport->crureadz(space, offset<<4, &value);
-	m_ioport->crureadz(space, offset<<4, &value);
+	if (m_model != MODEL_4QI) m_gromport->crureadz(space, offset<<1, &value);
+	m_ioport->crureadz(space, offset<<1, &value);
 
 	return value;
 }

--- a/src/mame/drivers/ti99_8.cpp
+++ b/src/mame/drivers/ti99_8.cpp
@@ -327,11 +327,8 @@ void ti99_8_state::memmap_setoffset(address_map &map)
 
 void ti99_8_state::crumap(address_map &map)
 {
-	map(0x0000, 0x02ff).r(FUNC(ti99_8_state::cruread));
-	map(0x0000, 0x0003).r(m_tms9901, FUNC(tms9901_device::read));
-
-	map(0x0000, 0x17ff).w(FUNC(ti99_8_state::cruwrite));
-	map(0x0000, 0x001f).w(m_tms9901, FUNC(tms9901_device::write));
+	map(0x0000, 0x2fff).rw(FUNC(ti99_8_state::cruread), FUNC(ti99_8_state::cruwrite));
+	map(0x0000, 0x003f).rw(m_tms9901, FUNC(tms9901_device::read), FUNC(tms9901_device::write));
 }
 
 /* ti99/8 : 54-key keyboard */
@@ -439,17 +436,16 @@ INPUT_PORTS_END
 
 READ8_MEMBER( ti99_8_state::cruread )
 {
-	LOGMASKED(LOG_CRUREAD, "read access to CRU address %04x\n", offset << 4);
+	LOGMASKED(LOG_CRUREAD, "read access to CRU address %04x\n", offset);
 	uint8_t value = 0;
 
 	// Let the mapper, the gromport, and the p-box decide whether they want
 	// to change the value at the CRU address
-	// Also, we translate the bit addresses to base addresses
-	m_mainboard->crureadz(space, offset<<4, &value);
-	m_gromport->crureadz(space, offset<<4, &value);
-	m_ioport->crureadz(space, offset<<4, &value);
+	m_mainboard->crureadz(space, offset<<1, &value);
+	m_gromport->crureadz(space, offset<<1, &value);
+	m_ioport->crureadz(space, offset<<1, &value);
 
-	LOGMASKED(LOG_CRU, "CRU %04x -> %02x\n", offset<<4, value);
+	LOGMASKED(LOG_CRU, "CRU %04x -> %x\n", offset<<1, value);
 	return value;
 }
 

--- a/src/mame/drivers/tm990189.cpp
+++ b/src/mame/drivers/tm990189.cpp
@@ -812,13 +812,9 @@ void tm990189_state::tm990_189_v_memmap(address_map &map)
 
 void tm990189_state::tm990_189_cru_map(address_map &map)
 {
-	map(0x0000, 0x003f).r(m_tms9901_usr, FUNC(tms9901_device::read));      /* user I/O tms9901 */
-	map(0x0040, 0x006f).r(m_tms9901_sys, FUNC(tms9901_device::read));      /* system I/O tms9901 */
-	map(0x0080, 0x00cf).r(m_tms9902, FUNC(tms9902_device::cruread));     /* optional tms9902 */
-
-	map(0x0000, 0x01ff).w(m_tms9901_usr, FUNC(tms9901_device::write));    /* user I/O tms9901 */
-	map(0x0200, 0x03ff).w(m_tms9901_sys, FUNC(tms9901_device::write));    /* system I/O tms9901 */
-	map(0x0400, 0x05ff).w(m_tms9902, FUNC(tms9902_device::cruwrite));   /* optional tms9902 */
+	map(0x0000, 0x03ff).rw(m_tms9901_usr, FUNC(tms9901_device::read), FUNC(tms9901_device::write));    /* user I/O tms9901 */
+	map(0x0400, 0x07ff).rw(m_tms9901_sys, FUNC(tms9901_device::read), FUNC(tms9901_device::write));    /* system I/O tms9901 */
+	map(0x0800, 0x0bff).rw(m_tms9902, FUNC(tms9902_device::cruread), FUNC(tms9902_device::cruwrite));   /* optional tms9902 */
 }
 
 void tm990189_state::tm990_189(machine_config &config)

--- a/src/mame/drivers/tmspoker.cpp
+++ b/src/mame/drivers/tmspoker.cpp
@@ -355,7 +355,7 @@ READ8_MEMBER(tmspoker_state::unk_r)
 
 void tmspoker_state::tmspoker_cru_map(address_map &map)
 {
-	map(0x0000, 0x07ff).r(FUNC(tmspoker_state::unk_r));
+	map(0x0000, 0x7fff).r(FUNC(tmspoker_state::unk_r));
 }
 
 /* I/O byte R/W

--- a/src/mame/drivers/tutor.cpp
+++ b/src/mame/drivers/tutor.cpp
@@ -296,17 +296,17 @@ READ8_MEMBER( tutor_state::key_r )
 	char port[12];
 	uint8_t value;
 
-	snprintf(port, ARRAY_LENGTH(port), "LINE%d", offset);
+	snprintf(port, ARRAY_LENGTH(port), "LINE%d", offset >> 3);
 	value = ioport(port)->read();
 
 	/* hack for ports overlapping with joystick */
-	if (offset == 4 || offset == 5)
+	if (offset >= 32 && offset < 48)
 	{
-		snprintf(port, ARRAY_LENGTH(port), "LINE%d_alt", offset);
+		snprintf(port, ARRAY_LENGTH(port), "LINE%d_alt", offset >> 3);
 		value |= ioport(port)->read();
 	}
 
-	return value;
+	return BIT(value, offset & 7);
 }
 
 
@@ -600,8 +600,8 @@ void tutor_state::pyuutajr_mem(address_map &map)
 
 void tutor_state::tutor_io(address_map &map)
 {
-	map(0xec0, 0xec7).r(FUNC(tutor_state::key_r));               /*keyboard interface*/
-	map(0xed0, 0xed0).r(FUNC(tutor_state::tutor_cassette_r));        /*cassette interface*/
+	map(0xec00, 0xec7f).r(FUNC(tutor_state::key_r));               /*keyboard interface*/
+	map(0xed00, 0xed01).r(FUNC(tutor_state::tutor_cassette_r));        /*cassette interface*/
 }
 
 /* tutor keyboard: 56 keys

--- a/src/mame/includes/cosmic.h
+++ b/src/mame/includes/cosmic.h
@@ -75,6 +75,7 @@ public:
 	DECLARE_WRITE8_MEMBER(dac_w);
 	DECLARE_READ8_MEMBER(cosmica_pixel_clock_r);
 	DECLARE_READ8_MEMBER(cosmicg_port_0_r);
+	DECLARE_READ8_MEMBER(cosmicg_port_1_r);
 	DECLARE_READ8_MEMBER(magspot_coinage_dip_r);
 	DECLARE_READ8_MEMBER(nomnlnd_port_0_1_r);
 	DECLARE_WRITE8_MEMBER(flip_screen_w);

--- a/src/mame/video/733_asr.cpp
+++ b/src/mame/video/733_asr.cpp
@@ -315,7 +315,7 @@ READ8_MEMBER( asr733_device::cru_r )
 {
 	int reply = 0;
 
-	switch (offset)
+	switch (offset >> 3)
 	{
 	case 0:
 		/* receive buffer */
@@ -328,7 +328,7 @@ READ8_MEMBER( asr733_device::cru_r )
 		break;
 	}
 
-	return reply;
+	return BIT(reply, offset & 7);
 }
 
 /*

--- a/src/mame/video/911_vdt.cpp
+++ b/src/mame/video/911_vdt.cpp
@@ -280,11 +280,11 @@ READ8_MEMBER( vdt911_device::cru_r )
 {
 	int reply=0;
 
-	offset &= 0x1;
+	offset &= 0xf;
 
 	if (!m_word_select)
 	{   /* select word 0 */
-		switch (offset)
+		switch (offset >> 3)
 		{
 		case 0:
 			reply = m_display_RAM[m_cursor_address];
@@ -299,7 +299,7 @@ READ8_MEMBER( vdt911_device::cru_r )
 	}
 	else
 	{   /* select word 1 */
-		switch (offset)
+		switch (offset >> 3)
 		{
 		case 0:
 			reply = m_cursor_address & 0xff;
@@ -321,7 +321,7 @@ READ8_MEMBER( vdt911_device::cru_r )
 		}
 	}
 
-	return reply;
+	return BIT(reply, offset & 3);
 }
 
 /*


### PR DESCRIPTION
- Shift all CRU addresses by 1 in memory maps. This makes CRU addressing more consistent with both register values and external address lines. (CRUOUT is multiplexed with the lowest address line on the 8-bit bus versions.)
- Addressing for CRU read accesses is now the same as it has been for CRU write accesses: one address for each bit. This simplifies the CPU cores (which were already emulating bit access times), though it means some read handlers now have to do some additional work.