### PR TITLE
fix MSVC (llvm toolset) compile (nw)

### DIFF
--- a/3rdparty/lzma/C/AesOpt.c
+++ b/3rdparty/lzma/C/AesOpt.c
@@ -6,7 +6,7 @@
 #include "CpuArch.h"
 
 #ifdef MY_CPU_X86_OR_AMD64
-#if _MSC_VER >= 1500
+#if _MSC_VER >= 1500 && !defined(__clang__)
 #define USE_INTEL_AES
 #endif
 #endif

--- a/3rdparty/portaudio/src/hostapi/dsound/pa_win_ds.c
+++ b/3rdparty/portaudio/src/hostapi/dsound/pa_win_ds.c
@@ -2917,7 +2917,7 @@ static PaError StartStream( PaStream *s )
 {
     PaError          result = paNoError;
     PaWinDsStream   *stream = (PaWinDsStream*)s;
-    HRESULT          hr;
+    HRESULT          hr = -1;
         
     stream->callbackResult = paContinue;
     PaUtil_ResetBufferProcessor( &stream->bufferProcessor );

--- a/3rdparty/portaudio/src/hostapi/wdmks/pa_win_wdmks.c
+++ b/3rdparty/portaudio/src/hostapi/wdmks/pa_win_wdmks.c
@@ -122,7 +122,7 @@ Default is to use the pin category.
 #define PA_WDMKS_USE_CATEGORY_FOR_PIN_NAMES  1
 #endif
 
-#ifdef __GNUC__
+#if defined(__GNUC__) || (defined(_MSC_VER) && defined(__clang__))
 #undef PA_LOGE_
 #define PA_LOGE_ PA_DEBUG(("%s {\n",__FUNCTION__))
 #undef PA_LOGL_
@@ -158,7 +158,7 @@ Default is to use the pin category.
 #define PA_THREAD_FUNC static DWORD WINAPI
 #endif
 
-#ifdef _MSC_VER
+#if defined(_MSC_VER) && !defined(__clang__)
 #define NOMMIDS
 #define DYNAMIC_GUID(data) {data}
 #define _NTRTL_ /* Turn off default definition of DEFINE_GUIDEX */

--- a/3rdparty/portaudio/src/hostapi/wmme/pa_win_wmme.c
+++ b/3rdparty/portaudio/src/hostapi/wmme/pa_win_wmme.c
@@ -2533,7 +2533,7 @@ static PaError OpenStream( struct PaUtilHostApiRepresentation *hostApi,
     {
         framesPerBufferProcessorCall = framesPerHostInputBuffer;
     }
-    else if( outputParameters )
+    else //if( outputParameters )
     {
         framesPerBufferProcessorCall = framesPerHostOutputBuffer;
     }

--- a/src/devices/cpu/alto2/a2ether.cpp
+++ b/src/devices/cpu/alto2/a2ether.cpp
@@ -522,7 +522,7 @@ void alto2_cpu_device::rx_breath_of_life(void* ptr, int32_t arg)
 		m_eth.rx_timer->adjust(attotime::from_seconds(m_eth.breath_of_life), 0);
 	} else {
 		// receive at a rate of 5.44us per word
-		m_eth.rx_timer->adjust(attotime::from_usec(5.44), arg);
+		m_eth.rx_timer->adjust(attotime::from_nsec(5440), arg);
 	}
 	eth_wakeup();
 }
@@ -557,10 +557,10 @@ void alto2_cpu_device::tx_packet(void* ptr, int32_t arg)
 		// the FIFO is empty now: clear the OBUSY and WLF flip flops
 		PUT_ETH_OBUSY(m_eth.status, 0);
 		PUT_ETH_WLF(m_eth.status, 0);
-		m_eth.tx_timer->adjust(attotime::from_usec(5.44), -1);
+		m_eth.tx_timer->adjust(attotime::from_nsec(5440), -1);
 	} else {
 		// transmit the next word after 5.44us
-		m_eth.tx_timer->adjust(attotime::from_usec(5.44), arg + 1);
+		m_eth.tx_timer->adjust(attotime::from_nsec(5440), arg + 1);
 	}
 	eth_wakeup();
 }
@@ -722,7 +722,7 @@ void alto2_cpu_device::f2_late_eodfct()
 	uint8_t a49 = m_ether_a49[16 * m_eth.fifo_wr + m_eth.fifo_rd];
 	if (0 == BF(a49)) {
 		m_task_wakeup &= ~(1 << task_ether);
-		m_eth.tx_timer->adjust(attotime::from_usec(5.44), 0);
+		m_eth.tx_timer->adjust(attotime::from_nsec(5440), 0);
 	}
 }
 
@@ -774,7 +774,7 @@ void alto2_cpu_device::f2_late_eefct()
 	PUT_ETH_OBUSY(m_eth.status, 1);
 	PUT_ETH_OEOT(m_eth.status, 1);
 	// end transmitting the packet
-	m_eth.tx_timer->adjust(attotime::from_usec(5.44), -1);
+	m_eth.tx_timer->adjust(attotime::from_nsec(5440), -1);
 	eth_wakeup();
 }
 

--- a/src/devices/machine/diablo_hd.cpp
+++ b/src/devices/machine/diablo_hd.cpp
@@ -1324,11 +1324,9 @@ void diablo_hd_device::device_start()
 void diablo_hd_device::device_reset()
 {
 	// free previous page cache
-	if (m_cache) {
-		for (int page = 0; page < m_pages; page++)
-			if (m_cache[page])
-				m_cache[page] = nullptr;
-	}
+	for (int page = 0; page < m_pages; page++)
+		if (m_cache[page])
+			m_cache[page] = nullptr;
 	// free previous bits cache
 	if (m_bits) {
 		for (int page = 0; page < m_pages; page++)

--- a/src/devices/video/ef9345.cpp
+++ b/src/devices/video/ef9345.cpp
@@ -212,7 +212,7 @@ void ef9345_device::device_timer(emu_timer &timer, device_timer_id id, int param
 void ef9345_device::set_busy_flag(int period)
 {
 	m_bf = 1;
-	m_busy_timer->adjust(attotime::from_usec(period));
+	m_busy_timer->adjust(attotime::from_nsec(period));
 }
 
 // draw a char in 40 char line mode
@@ -753,7 +753,7 @@ void ef9345_device::ef9345_exec(uint8_t cmd)
 	{
 		case 0x00:  //KRF: R1,R2,R3->ram
 		case 0x01:  //KRF: R1,R2,R3->ram + increment
-			set_busy_flag(4);
+			set_busy_flag(4000);
 			m_videoram->write_byte(a, m_registers[1]);
 			m_videoram->write_byte(a + 0x0800, m_registers[2]);
 			m_videoram->write_byte(a + 0x1000, m_registers[3]);
@@ -761,14 +761,14 @@ void ef9345_device::ef9345_exec(uint8_t cmd)
 			break;
 		case 0x02:  //KRG: R1,R2->ram
 		case 0x03:  //KRG: R1,R2->ram + increment
-			set_busy_flag(5.5);
+			set_busy_flag(5500);
 			m_videoram->write_byte(a, m_registers[1]);
 			m_videoram->write_byte(a + 0x0800, m_registers[2]);
 			if (cmd&1) inc_x(7);
 			break;
 		case 0x08:  //KRF: ram->R1,R2,R3
 		case 0x09:  //KRF: ram->R1,R2,R3 + increment
-			set_busy_flag(7.5);
+			set_busy_flag(7500);
 			m_registers[1] = m_videoram->read_byte(a);
 			m_registers[2] = m_videoram->read_byte(a + 0x0800);
 			m_registers[3] = m_videoram->read_byte(a + 0x1000);
@@ -776,14 +776,14 @@ void ef9345_device::ef9345_exec(uint8_t cmd)
 			break;
 		case 0x0a:  //KRG: ram->R1,R2
 		case 0x0b:  //KRG: ram->R1,R2 + increment
-			set_busy_flag(7.5);
+			set_busy_flag(7500);
 			m_registers[1] = m_videoram->read_byte(a);
 			m_registers[2] = m_videoram->read_byte(a + 0x0800);
 			if (cmd&1) inc_x(7);
 			break;
 		case 0x30:  //OCT: R1->RAM, main pointer
 		case 0x31:  //OCT: R1->RAM, main pointer + inc
-			set_busy_flag(4);
+			set_busy_flag(4000);
 			m_videoram->write_byte(indexram(7), m_registers[1]);
 
 			if (cmd&1)
@@ -795,7 +795,7 @@ void ef9345_device::ef9345_exec(uint8_t cmd)
 			break;
 		case 0x34:  //OCT: R1->RAM, aux pointer
 		case 0x35:  //OCT: R1->RAM, aux pointer + inc
-			set_busy_flag(4);
+			set_busy_flag(4000);
 			m_videoram->write_byte(indexram(5), m_registers[1]);
 
 			if (cmd&1)
@@ -803,7 +803,7 @@ void ef9345_device::ef9345_exec(uint8_t cmd)
 			break;
 		case 0x38:  //OCT: RAM->R1, main pointer
 		case 0x39:  //OCT: RAM->R1, main pointer + inc
-			set_busy_flag(4.5);
+			set_busy_flag(4500);
 			m_registers[1] = m_videoram->read_byte(indexram(7));
 
 			if (cmd&1)
@@ -816,7 +816,7 @@ void ef9345_device::ef9345_exec(uint8_t cmd)
 			break;
 		case 0x3c:  //OCT: RAM->R1, aux pointer
 		case 0x3d:  //OCT: RAM->R1, aux pointer + inc
-			set_busy_flag(4.5);
+			set_busy_flag(4500);
 			m_registers[1] = m_videoram->read_byte(indexram(5));
 
 			if (cmd&1)
@@ -824,7 +824,7 @@ void ef9345_device::ef9345_exec(uint8_t cmd)
 			break;
 		case 0x50:  //KRL: 80 uint8_t - 12 bits write
 		case 0x51:  //KRL: 80 uint8_t - 12 bits write + inc
-			set_busy_flag(12.5);
+			set_busy_flag(12500);
 			m_videoram->write_byte(a, m_registers[1]);
 			switch((a / 0x0800) & 1)
 			{
@@ -850,7 +850,7 @@ void ef9345_device::ef9345_exec(uint8_t cmd)
 			break;
 		case 0x58:  //KRL: 80 uint8_t - 12 bits read
 		case 0x59:  //KRL: 80 uint8_t - 12 bits read + inc
-			set_busy_flag(11.5);
+			set_busy_flag(11500);
 			m_registers[1] = m_videoram->read_byte(a);
 			switch((a / 0x0800) & 1)
 			{
@@ -879,7 +879,7 @@ void ef9345_device::ef9345_exec(uint8_t cmd)
 		case 0x83:  //IND: R1->PAT
 		case 0x84:  //IND: R1->DOR
 		case 0x87:  //IND: R1->ROR
-			set_busy_flag(2);
+			set_busy_flag(2000);
 			switch(cmd&7)
 			{
 				case 1:     m_tgs = m_registers[1]; break;
@@ -897,7 +897,7 @@ void ef9345_device::ef9345_exec(uint8_t cmd)
 		case 0x8b:  //IND: PAT->R1
 		case 0x8c:  //IND: DOR->R1
 		case 0x8f:  //IND: ROR->R1
-			set_busy_flag(3.5);
+			set_busy_flag(3500);
 			switch(cmd&7)
 			{
 				case 0:     m_registers[1] = m_charset[indexrom(7) & 0x1fff]; break;
@@ -915,7 +915,7 @@ void ef9345_device::ef9345_exec(uint8_t cmd)
 		case 0x99:  //VSM: vertical sync mask set
 			break;
 		case 0xb0:  //INY: increment Y
-			set_busy_flag(2);
+			set_busy_flag(2000);
 			inc_y(6);
 			m_state &= 0x8f;  //reset S4(LXa), S5(LXm), S6(Al)
 			break;
@@ -936,7 +936,7 @@ void ef9345_device::ef9345_exec(uint8_t cmd)
 			uint8_t n = (cmd>>4) - 0x0c;
 			uint8_t r1 = (cmd&0x04) ? 7 : 5;
 			uint8_t r2 = (cmd&0x04) ? 5 : 7;
-			int busy = 2;
+			int busy = 2000;
 
 			for(i = 0; i < 1280; i++)
 			{
@@ -959,7 +959,7 @@ void ef9345_device::ef9345_exec(uint8_t cmd)
 					inc_y(6);
 				}
 
-				busy += 4 * n;
+				busy += 4000 * n;
 			}
 			m_state &= 0x8f;  //reset S4(LXa), S5(LXm), S6(Al)
 			set_busy_flag(busy);
@@ -994,7 +994,7 @@ void ef9345_device::update_scanline(uint16_t scanline)
 	if (scanline == 250)
 		m_state &= 0xfb;
 
-	set_busy_flag(104);
+	set_busy_flag(104000);
 
 	if (m_char_mode == MODE12x80 || m_char_mode == MODE8x80)
 	{

--- a/src/frontend/mame/ui/videoopt.cpp
+++ b/src/frontend/mame/ui/videoopt.cpp
@@ -75,7 +75,7 @@ void menu_video_options::handle()
 	const event *menu_event = process(0);
 	if (menu_event != nullptr && menu_event->itemref != nullptr)
 	{
-		switch ((uintptr_t)menu_event->itemref)
+		switch ((intptr_t)menu_event->itemref)
 		{
 			/* rotate adds rotation depending on the direction */
 			case VIDEO_ITEM_ROTATE:

--- a/src/lib/formats/apridisk.cpp
+++ b/src/lib/formats/apridisk.cpp
@@ -60,7 +60,7 @@ bool apridisk_format::load(io_generic *io, uint32_t form_factor, floppy_image *i
 		uint8_t sector_header[16];
 		io_generic_read(io, sector_header, file_offset, 16);
 
-		uint32_t type = pick_integer_le(&sector_header, 0, 4);
+		int32_t type = pick_integer_le(&sector_header, 0, 4);
 		uint16_t compression = pick_integer_le(&sector_header, 4, 2);
 		uint16_t header_size = pick_integer_le(&sector_header, 6, 2);
 		uint32_t data_size = pick_integer_le(&sector_header, 8, 4);

--- a/src/mame/drivers/by17.cpp
+++ b/src/mame/drivers/by17.cpp
@@ -837,7 +837,7 @@ TIMER_DEVICE_CALLBACK_MEMBER( by17_state::u11_timer )
     -+                          +---+
 */
 
-	m_display_refresh_timer->adjust(attotime::from_msec(2.85));
+	m_display_refresh_timer->adjust(attotime::from_usec(2850));
 
 	m_u11_ca1 = true;
 	m_pia_u11->ca1_w(m_u11_ca1);

--- a/src/mame/drivers/by35.cpp
+++ b/src/mame/drivers/by35.cpp
@@ -898,7 +898,7 @@ TIMER_DEVICE_CALLBACK_MEMBER( by35_state::u11_timer )
     -+                          +---+
 */
 
-	m_display_refresh_timer->adjust(attotime::from_msec(2.85));
+	m_display_refresh_timer->adjust(attotime::from_usec(2850));
 
 	m_u11_ca1 = true;
 	m_pia_u11->ca1_w(m_u11_ca1);

--- a/src/mame/drivers/nokia_3310.cpp
+++ b/src/mame/drivers/nokia_3310.cpp
@@ -262,7 +262,7 @@ void noki3310_state::machine_reset()
 	m_timer_fiq8->adjust(attotime::from_hz(1000), 0, attotime::from_hz(1000));
 
 	// simulate power-on input
-	if (machine().system().name && (machine().system().name[4] == '8' || machine().system().name[4] == '5'))
+	if (machine().system().name[4] == '8' || machine().system().name[4] == '5')
 		m_power_on = ~0x10;
 	else
 		m_power_on = ~0x02;

--- a/src/mame/drivers/truco.cpp
+++ b/src/mame/drivers/truco.cpp
@@ -424,7 +424,7 @@ MACHINE_CONFIG_START(truco_state::truco)
 	MCFG_DEVICE_PROGRAM_MAP(main_map)
 	MCFG_DEVICE_VBLANK_INT_DRIVER("screen", truco_state,  interrupt)
 
-	WATCHDOG_TIMER(config, m_watchdog).set_time(attotime::from_seconds(1.6));    /* 1.6 seconds */
+	WATCHDOG_TIMER(config, m_watchdog).set_time(attotime::from_msec(1600));    /* 1.6 seconds */
 
 	pia6821_device &pia(PIA6821(config, "pia0", 0));
 	pia.readpa_handler().set_ioport("P1");

--- a/src/mame/machine/cuda.cpp
+++ b/src/mame/machine/cuda.cpp
@@ -297,10 +297,10 @@ WRITE8_MEMBER( cuda_device::timer_ctrl_w )
 {
 	static const attotime rates[4][5] =
 	{
-		{ attotime::from_seconds(1), attotime::from_msec(31.3f), attotime::from_msec(15.6f), attotime::from_msec(7.8f), attotime::from_msec(3.9f) },
-		{ attotime::from_seconds(2), attotime::from_msec(62.5f), attotime::from_msec(31.3f), attotime::from_msec(15.6f), attotime::from_msec(7.8f) },
-		{ attotime::from_seconds(4), attotime::from_msec(125.0f), attotime::from_msec(62.5f), attotime::from_msec(31.3f), attotime::from_msec(15.6f) },
-		{ attotime::from_seconds(8), attotime::from_msec(250.0f), attotime::from_msec(125.1f), attotime::from_msec(62.5f), attotime::from_msec(31.3f) },
+		{ attotime::from_seconds(1), attotime::from_usec(31300), attotime::from_usec(15600), attotime::from_usec(7800), attotime::from_usec(3900) },
+		{ attotime::from_seconds(2), attotime::from_usec(62500), attotime::from_usec(31300), attotime::from_usec(15600), attotime::from_usec(7800) },
+		{ attotime::from_seconds(4), attotime::from_usec(125000), attotime::from_usec(62500), attotime::from_usec(31300), attotime::from_usec(15600) },
+		{ attotime::from_seconds(8), attotime::from_usec(250000), attotime::from_usec(125100), attotime::from_usec(62500), attotime::from_usec(31300) },
 	};
 
 //    printf("%02x to timer control (PC=%x)\n", data, m_maincpu->pc());

--- a/src/mame/video/3dom2_te.cpp
+++ b/src/mame/video/3dom2_te.cpp
@@ -3053,9 +3053,9 @@ uint8_t m2_te_device::alu_calc(uint16_t a, uint16_t b)
 			switch (j)
 			{
 				case 0: cinv |= (cntl & 1);         break;
-				case 1: cinv |= (cntl & 2) && 1;    break;
-				case 2: cinv |= (cntl & 4) && 1;    break;
-				case 3: cinv |= (cntl & 8) && 1;    break;
+				case 1: cinv |= ((cntl & 2) != 0);  break;
+				case 2: cinv |= ((cntl & 4) != 0);  break;
+				case 3: cinv |= ((cntl & 8) != 0);  break;
 			}
 
 			cinv <<= 1;


### PR DESCRIPTION
- conditionally uninitialised variables in PortAudio;
- floats passed to attotime;
- unsigned->signed enums (this one is technically still wrong)