### PR TITLE
[thomson] added undocumented video mode

### DIFF
--- a/src/mame/includes/thomson.h
+++ b/src/mame/includes/thomson.h
@@ -181,6 +181,7 @@ public:
 	void overlay_scandraw_16( uint8_t* vram, uint16_t* dst, uint16_t* pal, int org, int len );
 	void overlayhalf_scandraw_16( uint8_t* vram, uint16_t* dst, uint16_t* pal, int org, int len );
 	void overlay3_scandraw_16( uint8_t* vram, uint16_t* dst, uint16_t* pal, int org, int len );
+	void bitmap16alt_scandraw_16( uint8_t* vram, uint16_t* dst, uint16_t* pal, int org, int len );
 	void to770_scandraw_8( uint8_t* vram, uint16_t* dst, uint16_t* pal, int org, int len );
 	void mo5_scandraw_8( uint8_t* vram, uint16_t* dst, uint16_t* pal, int org, int len );
 	void mo5alt_scandraw_8( uint8_t* vram, uint16_t* dst, uint16_t* pal, int org, int len );
@@ -196,6 +197,7 @@ public:
 	void overlay_scandraw_8( uint8_t* vram, uint16_t* dst, uint16_t* pal, int org, int len );
 	void overlayhalf_scandraw_8( uint8_t* vram, uint16_t* dst, uint16_t* pal, int org, int len );
 	void overlay3_scandraw_8( uint8_t* vram, uint16_t* dst, uint16_t* pal, int org, int len );
+	void bitmap16alt_scandraw_8( uint8_t* vram, uint16_t* dst, uint16_t* pal, int org, int len );
 
 private:
 	DECLARE_FLOPPY_FORMATS(cd90_640_formats);
@@ -690,7 +692,8 @@ private:
 #define THOM_VMODE_BITMAP4_ALT_HALF 12
 #define THOM_VMODE_MO5_ALT    13
 #define THOM_VMODE_OVERLAY_HALF     14
-#define THOM_VMODE_NB         15
+#define THOM_VMODE_BITMAP16_ALT 15
+#define THOM_VMODE_NB         16
 
 
 class to7_io_line_device : public device_t

--- a/src/mame/machine/thomson.cpp
+++ b/src/mame/machine/thomson.cpp
@@ -1714,7 +1714,7 @@ void thomson_state::to9_set_video_mode( uint8_t data, int style )
 		break;
 
 		// undocumented, but tested on a real TO8D
-		case 0x20: thom_set_video_mode( THOM_VMODE_MO5_ALT );     break;
+        case 0x20: thom_set_video_mode( THOM_VMODE_MO5_ALT );     break;
 
 	case 0x21: thom_set_video_mode( THOM_VMODE_BITMAP4 );     break;
 
@@ -1743,6 +1743,9 @@ void thomson_state::to9_set_video_mode( uint8_t data, int style )
 
 	case 0x3f: thom_set_video_mode( THOM_VMODE_OVERLAY3 );    break;
 
+                // undocumented variant enconding for bitmap16
+        case 0x5b: thom_set_video_mode( THOM_VMODE_BITMAP16_ALT ); break;
+          
 	default:
 		logerror( "to9_set_video_mode: unknown mode $%02X tr=%i phi=%i mod=%i\n", data, (data >> 5) & 3, (data >> 3) & 2, data & 7 );
 	}

--- a/src/mame/video/thomson.cpp
+++ b/src/mame/video/thomson.cpp
@@ -568,6 +568,42 @@ UPDATE_LOW( bitmap16 )
 END_UPDATE
 
 
+/* 160x200, 16-colors, no constraint, alternate encoding, undocumented, tested */
+
+static const unsigned tbl_bit16[4][4] = {
+        {  0,  2,  8, 10 },
+        {  1,  3,  9, 11 },
+        {  4,  6, 12, 14 },
+        {  5,  7, 13, 15 }
+};
+
+UPDATE_HI( bitmap16alt )
+{
+        unsigned p0 = tbl_bit16[ramb >> 6][rama >> 6];
+        unsigned p1 = tbl_bit16[(ramb >> 4) & 3][(rama >> 4) & 3];
+        unsigned p2 = tbl_bit16[(ramb >> 2) & 3][(rama >> 2) & 3];
+        unsigned p3 = tbl_bit16[ramb & 3][rama & 3];
+	dst[ 0] = dst[ 1] = dst[ 2] = dst[ 3] = pal[ p0 ];
+	dst[ 4] = dst[ 5] = dst[ 6] = dst[ 7] = pal[ p1 ];
+	dst[ 8] = dst[ 9] = dst[10] = dst[11] = pal[ p2 ];
+	dst[12] = dst[13] = dst[14] = dst[15] = pal[ p3 ];
+}
+END_UPDATE
+
+UPDATE_LOW( bitmap16alt )
+{
+        unsigned p0 = tbl_bit16[ramb >> 6][rama >> 6];
+        unsigned p1 = tbl_bit16[(ramb >> 4) & 3][(rama >> 4) & 3];
+        unsigned p2 = tbl_bit16[(ramb >> 2) & 3][(rama >> 2) & 3];
+        unsigned p3 = tbl_bit16[ramb & 3][rama & 3];
+	dst[0] = dst[1] = pal[ p0 ];
+	dst[2] = dst[3] = pal[ p1 ];
+	dst[4] = dst[5] = pal[ p2 ];
+	dst[6] = dst[7] = pal[ p3 ];
+}
+END_UPDATE
+
+
 
 /* 640x200 (80 text column), 2-colors, no constraint */
 
@@ -785,7 +821,8 @@ static const thom_scandraw thom_scandraw_funcs[THOM_VMODE_NB][2] =
 	FUN(to770),    FUN(mo5),    FUN(bitmap4), FUN(bitmap4alt),  FUN(mode80),
 	FUN(bitmap16), FUN(page1),  FUN(page2),   FUN(overlay),     FUN(overlay3),
 	FUN(to9), FUN(mode80_to9),
-		FUN(bitmap4althalf), FUN(mo5alt), FUN(overlayhalf),
+        FUN(bitmap4althalf), FUN(mo5alt), FUN(overlayhalf),
+        FUN(bitmap16alt)
 };
 
 


### PR DESCRIPTION
This PR adds a new undocumented video mode for the Thomson TO8 8-bit computer (ant the other Thomson computers using the same video chipset). 
The mode has been tested on a real TO8.