### PR TITLE
psikyo.cpp : Cleanups / Updates

### DIFF
--- a/src/mame/drivers/psikyo.cpp
+++ b/src/mame/drivers/psikyo.cpp
@@ -107,19 +107,19 @@ CUSTOM_INPUT_MEMBER(psikyo_state::mcu_status_r)
 	return ret;
 }
 
-static const uint8_t s1945_table[256] = {
+static const u8 s1945_table[256] = {
 	0x00, 0x00, 0x64, 0xae, 0x00, 0x00, 0x26, 0x2c, 0x00, 0x00, 0x2c, 0xda, 0x00, 0x00, 0x2c, 0xbc,
 	0x00, 0x00, 0x2c, 0x9e, 0x00, 0x00, 0x2f, 0x0e, 0x00, 0x00, 0x31, 0x10, 0x00, 0x00, 0xc5, 0x1e,
 	0x00, 0x00, 0x32, 0x90, 0x00, 0x00, 0xac, 0x5c, 0x00, 0x00, 0x2b, 0xc0
 };
 
-static const uint8_t s1945a_table[256] = {
+static const u8 s1945a_table[256] = {
 	0x00, 0x00, 0x64, 0xbe, 0x00, 0x00, 0x26, 0x2c, 0x00, 0x00, 0x2c, 0xda, 0x00, 0x00, 0x2c, 0xbc,
 	0x00, 0x00, 0x2c, 0x9e, 0x00, 0x00, 0x2f, 0x0e, 0x00, 0x00, 0x31, 0x10, 0x00, 0x00, 0xc7, 0x2a,
 	0x00, 0x00, 0x32, 0x90, 0x00, 0x00, 0xad, 0x4c, 0x00, 0x00, 0x2b, 0xc0
 };
 
-static const uint8_t s1945j_table[256] = {
+static const u8 s1945j_table[256] = {
 	0x00, 0x00, 0x64, 0xb6, 0x00, 0x00, 0x26, 0x2c, 0x00, 0x00, 0x2c, 0xda, 0x00, 0x00, 0x2c, 0xbc,
 	0x00, 0x00, 0x2c, 0x9e, 0x00, 0x00, 0x2f, 0x0e, 0x00, 0x00, 0x31, 0x10, 0x00, 0x00, 0xc5, 0x92,
 	0x00, 0x00, 0x32, 0x90, 0x00, 0x00, 0xac, 0x64, 0x00, 0x00, 0x2b, 0xc0
@@ -148,8 +148,8 @@ WRITE32_MEMBER(psikyo_state::s1945_mcu_w)
 		m_s1945_mcu_direction = data;
 		break;
 	case 0x07:
-		psikyo_switch_banks(1, (data >> 6) & 3);
-		psikyo_switch_banks(0, (data >> 4) & 3);
+		switch_bgbanks(1, (data >> 6) & 3);
+		switch_bgbanks(0, (data >> 4) & 3);
 		m_s1945_mcu_bctrl = data;
 		break;
 	case 0x0b:
@@ -201,7 +201,7 @@ READ32_MEMBER(psikyo_state::s1945_mcu_r)
 	{
 	case 0:
 		{
-		uint32_t res;
+		u32 res;
 		if (m_s1945_mcu_control & 16)
 		{
 			res = m_s1945_mcu_latching & 4 ? 0x0000ff00 : m_s1945_mcu_latch1 << 8;
@@ -250,16 +250,16 @@ WRITE32_MEMBER(psikyo_state::vram_w)
 
 void psikyo_state::psikyo_map(address_map &map)
 {
-	map(0x000000, 0x0fffff).rom();                                                     // ROM (not all used)
+	map(0x000000, 0x0fffff).rom();                                                                 // ROM (not all used)
 	map(0x400000, 0x401fff).ram().share("spriteram");       // Sprites, buffered by two frames (list buffered + fb buffered)
 	map(0x600000, 0x601fff).ram().w(m_palette, FUNC(palette_device::write32)).share("palette");    // Palette
-	map(0x800000, 0x801fff).ram().w(FUNC(psikyo_state::vram_w<0>)).share("vram_0");       // Layer 0
-	map(0x802000, 0x803fff).ram().w(FUNC(psikyo_state::vram_w<1>)).share("vram_1");       // Layer 1
-	map(0x804000, 0x807fff).ram().share("vregs");                           // RAM + Vregs
-//  AM_RANGE(0xc00000, 0xc0000b) AM_READ(psikyo_input_r)                                    // Depends on board
-//  AM_RANGE(0xc00004, 0xc0000b) AM_WRITE(s1945_mcu_w)                                      // MCU on sh404
-//  AM_RANGE(0xc00010, 0xc00013) AM_WRITE(psikyo_soundlatch_w)                              // Depends on board
-	map(0xfe0000, 0xffffff).ram();                                                     // RAM
+	map(0x800000, 0x801fff).ram().w(FUNC(psikyo_state::vram_w<0>)).share("vram_0");                // Layer 0
+	map(0x802000, 0x803fff).ram().w(FUNC(psikyo_state::vram_w<1>)).share("vram_1");                // Layer 1
+	map(0x804000, 0x807fff).ram().share("vregs");                                                  // RAM + Vregs
+//  map(0xc00000, 0xc0000b).r(FUNC(psikyo_state::input_r));                                        // Depends on board
+//  map(0xc00004, 0xc0000b).w(FUNC(psikyo_state::s1945_mcu_w));                                    // MCU on sh404
+//  map(0xc00010, 0xc00013).w(m_soundlatch, FUNC(generic_latch_8_device::write));                  // Depends on board
+	map(0xfe0000, 0xffffff).ram();                                                                 // RAM
 }
 
 template<int Shift>
@@ -268,32 +268,11 @@ WRITE8_MEMBER(psikyo_state::sound_bankswitch_w)
 	m_audiobank->set_entry((data >> Shift) & 0x03);
 }
 
-READ32_MEMBER(psikyo_state::s1945bl_oki_r)
+WRITE8_MEMBER(psikyo_state::s1945bl_okibank_w)
 {
-	uint8_t dat = m_oki->read(space, 0);
-	return dat << 24;
-}
-
-WRITE32_MEMBER(psikyo_state::s1945bl_oki_w)
-{
-	if (ACCESSING_BITS_24_31)
-	{
-		m_oki->write(space, 0, data >> 24);
-	}
-
-	if (ACCESSING_BITS_16_23)
-	{
-		// not at all sure about this, it seems to write 0 too often
-		uint8_t bank = (data & 0x00ff0000) >> 16;
-		if (bank < 4)
-			m_okibank->set_entry(bank);
-	}
-
-	if (ACCESSING_BITS_8_15)
-		printf("ACCESSING_BITS_8_15 ?? %08x %08x\n", data & 0x0000ff00, mem_mask);
-
-	if (ACCESSING_BITS_0_7)
-		printf("ACCESSING_BITS_0_7 ?? %08x %08x\n", data & 0x000000ff, mem_mask);
+	// not at all sure about this, it seems to write 0 too often
+	if (data < 5)
+		m_okibank->set_entry(data);
 }
 
 void psikyo_state::s1945bl_oki_map(address_map &map)
@@ -304,19 +283,20 @@ void psikyo_state::s1945bl_oki_map(address_map &map)
 
 void psikyo_state::psikyo_bootleg_map(address_map &map)
 {
-	map(0x000000, 0x0fffff).rom();                                                     // ROM (not all used)
+	map(0x000000, 0x0fffff).rom();                                                                 // ROM (not all used)
 	map(0x200000, 0x200fff).ram().share("boot_spritebuf");              // RAM (it copies the spritelist here, the HW probably doesn't have automatic buffering like the originals?
 
 	map(0x400000, 0x401fff).ram().share("spriteram");       // Sprites, buffered by two frames (list buffered + fb buffered)
 	map(0x600000, 0x601fff).ram().w(m_palette, FUNC(palette_device::write32)).share("palette");    // Palette
-	map(0x800000, 0x801fff).ram().w(FUNC(psikyo_state::vram_w<0>)).share("vram_0");       // Layer 0
-	map(0x802000, 0x803fff).ram().w(FUNC(psikyo_state::vram_w<1>)).share("vram_1");       // Layer 1
-	map(0x804000, 0x807fff).ram().share("vregs");                               // RAM + Vregs
-	map(0xc00000, 0xc0000b).r(FUNC(psikyo_state::gunbird_input_r));                               // input ports
+	map(0x800000, 0x801fff).ram().w(FUNC(psikyo_state::vram_w<0>)).share("vram_0");                // Layer 0
+	map(0x802000, 0x803fff).ram().w(FUNC(psikyo_state::vram_w<1>)).share("vram_1");                // Layer 1
+	map(0x804000, 0x807fff).ram().share("vregs");                                                  // RAM + Vregs
+	map(0xc00000, 0xc0000b).r(FUNC(psikyo_state::gunbird_input_r));                                // input ports
 
-	map(0xc00018, 0xc0001b).rw(FUNC(psikyo_state::s1945bl_oki_r), FUNC(psikyo_state::s1945bl_oki_w));
+	map(0xc00018, 0xc00018).rw(m_oki, FUNC(okim6295_device::read), FUNC(okim6295_device::write));
+	map(0xc00019, 0xc00019).w(FUNC(psikyo_state::s1945bl_okibank_w));
 
-	map(0xfe0000, 0xffffff).ram();                                                     // RAM
+	map(0xfe0000, 0xffffff).ram();                                                                 // RAM
 
 }
 
@@ -1065,13 +1045,14 @@ void psikyo_state::sngkace(machine_config &config)
 	m_screen->set_vblank_time(ATTOSECONDS_IN_USEC(2500)); /* not accurate */  // we're using PORT_VBLANK
 	m_screen->set_size(320, 256);
 	m_screen->set_visarea(0, 320-1, 0, 256-32-1);
-	m_screen->set_screen_update(FUNC(psikyo_state::screen_update_psikyo));
-	m_screen->screen_vblank().set(FUNC(psikyo_state::screen_vblank_psikyo));
+	m_screen->set_screen_update(FUNC(psikyo_state::screen_update));
+	m_screen->screen_vblank().set(FUNC(psikyo_state::screen_vblank));
 	m_screen->set_palette(m_palette);
 
 	GFXDECODE(config, m_gfxdecode, m_palette, gfx_psikyo);
 	PALETTE(config, m_palette).set_format(palette_device::xRGB_555, 0x1000);
 
+	BUFFERED_SPRITERAM32(config, m_spriteram);
 	MCFG_VIDEO_START_OVERRIDE(psikyo_state,sngkace)
 
 	/* sound hardware */
@@ -1110,13 +1091,14 @@ void psikyo_state::gunbird(machine_config &config)
 	m_screen->set_vblank_time(ATTOSECONDS_IN_USEC(2500)); /* not accurate */  // we're using PORT_VBLANK
 	m_screen->set_size(320, 256);
 	m_screen->set_visarea(0, 320-1, 0, 256-32-1);
-	m_screen->set_screen_update(FUNC(psikyo_state::screen_update_psikyo));
-	m_screen->screen_vblank().set(FUNC(psikyo_state::screen_vblank_psikyo));
+	m_screen->set_screen_update(FUNC(psikyo_state::screen_update));
+	m_screen->screen_vblank().set(FUNC(psikyo_state::screen_vblank));
 	m_screen->set_palette(m_palette);
 
 	GFXDECODE(config, m_gfxdecode, m_palette, gfx_psikyo);
 	PALETTE(config, m_palette).set_format(palette_device::xRGB_555, 0x1000);
 
+	BUFFERED_SPRITERAM32(config, m_spriteram);
 	MCFG_VIDEO_START_OVERRIDE(psikyo_state,psikyo)
 
 	/* sound hardware */
@@ -1150,13 +1132,14 @@ void psikyo_state::s1945bl(machine_config &config) /* Bootleg hardware based on 
 	m_screen->set_vblank_time(ATTOSECONDS_IN_USEC(2500)); /* not accurate */  // we're using PORT_VBLANK
 	m_screen->set_size(320, 256);
 	m_screen->set_visarea(0, 320-1, 0, 256-32-1);
-	m_screen->set_screen_update(FUNC(psikyo_state::screen_update_psikyo_bootleg));
-	m_screen->screen_vblank().set(FUNC(psikyo_state::screen_vblank_psikyo));
+	m_screen->set_screen_update(FUNC(psikyo_state::screen_update_bootleg));
+	m_screen->screen_vblank().set(FUNC(psikyo_state::screen_vblank_bootleg));
 	m_screen->set_palette(m_palette);
 
 	GFXDECODE(config, m_gfxdecode, m_palette, gfx_psikyo);
 	PALETTE(config, m_palette).set_format(palette_device::xRGB_555, 0x1000);
 
+	BUFFERED_SPRITERAM32(config, m_spriteram);
 	MCFG_VIDEO_START_OVERRIDE(psikyo_state,psikyo)
 
 	/* sound hardware */
@@ -1192,13 +1175,14 @@ void psikyo_state::s1945(machine_config &config)
 	m_screen->set_vblank_time(ATTOSECONDS_IN_USEC(2500)); /* not accurate */  // we're using PORT_VBLANK
 	m_screen->set_size(320, 256);
 	m_screen->set_visarea(0, 320-1, 0, 256-32-1);
-	m_screen->set_screen_update(FUNC(psikyo_state::screen_update_psikyo));
-	m_screen->screen_vblank().set(FUNC(psikyo_state::screen_vblank_psikyo));
+	m_screen->set_screen_update(FUNC(psikyo_state::screen_update));
+	m_screen->screen_vblank().set(FUNC(psikyo_state::screen_vblank));
 	m_screen->set_palette(m_palette);
 
 	GFXDECODE(config, m_gfxdecode, m_palette, gfx_psikyo);
 	PALETTE(config, m_palette).set_format(palette_device::xRGB_555, 0x1000);
 
+	BUFFERED_SPRITERAM32(config, m_spriteram);
 	MCFG_VIDEO_START_OVERRIDE(psikyo_state,psikyo)
 
 	/* sound hardware */
@@ -1847,7 +1831,7 @@ ROM_END
 void psikyo_state::init_sngkace()
 {
 	{
-		uint8_t *RAM = memregion("ymsnd")->base();
+		u8 *RAM = memregion("ymsnd")->base();
 		int len = memregion("ymsnd")->bytes();
 
 		/* Bit 6&7 of the samples are swapped. Naughty, naughty... */
@@ -1858,7 +1842,7 @@ void psikyo_state::init_sngkace()
 		}
 	}
 
-	m_ka302c_banking = 0; // SH201B doesn't have any gfx banking
+	m_ka302c_banking = false; // SH201B doesn't have any gfx banking
 
 	/* setup audiocpu banks */
 	m_audiobank->configure_entries(0, 4, memregion("audiocpu")->base(), 0x8000);
@@ -1867,7 +1851,7 @@ void psikyo_state::init_sngkace()
 #if 0
 	if (!strcmp(machine().system().name,"sngkace"))
 	{
-		uint8_t *ROM  =   memregion("maincpu")->base();
+		u8 *ROM  =   memregion("maincpu")->base();
 		ROM[0x995] = 0x4e;
 		ROM[0x994] = 0x71;
 		ROM[0x997] = 0x4e;
@@ -1877,7 +1861,7 @@ void psikyo_state::init_sngkace()
 #endif
 }
 
-void psikyo_state::s1945_mcu_init(  )
+void psikyo_state::s1945_mcu_init()
 {
 	m_s1945_mcu_direction = 0x00;
 	m_s1945_mcu_inlatch = 0xff;
@@ -1905,7 +1889,7 @@ void psikyo_state::init_tengai()
 	s1945_mcu_init();
 	m_s1945_mcu_table = nullptr;
 
-	m_ka302c_banking = 0; // Banking is controlled by mcu
+	m_ka302c_banking = false; // Banking is controlled by mcu
 
 	/* setup audiocpu banks */
 	/* The banked rom is seen at 8200-ffff, so the last 0x200 bytes of the rom not reachable. */
@@ -1914,7 +1898,7 @@ void psikyo_state::init_tengai()
 
 void psikyo_state::init_gunbird()
 {
-	m_ka302c_banking = 1;
+	m_ka302c_banking = true;
 
 	/* setup audiocpu banks */
 	/* The banked rom is seen at 8200-ffff, so the last 0x200 bytes of the rom not reachable. */
@@ -1927,7 +1911,7 @@ void psikyo_state::init_s1945()
 	s1945_mcu_init();
 	m_s1945_mcu_table = s1945_table;
 
-	m_ka302c_banking = 0; // Banking is controlled by mcu
+	m_ka302c_banking = false; // Banking is controlled by mcu
 
 	/* setup audiocpu banks */
 	/* The banked rom is seen at 8200-ffff, so the last 0x200 bytes of the rom not reachable. */
@@ -1939,7 +1923,7 @@ void psikyo_state::init_s1945a()
 	s1945_mcu_init();
 	m_s1945_mcu_table = s1945a_table;
 
-	m_ka302c_banking = 0; // Banking is controlled by mcu
+	m_ka302c_banking = false; // Banking is controlled by mcu
 
 	/* setup audiocpu banks */
 	/* The banked rom is seen at 8200-ffff, so the last 0x200 bytes of the rom not reachable. */
@@ -1951,7 +1935,7 @@ void psikyo_state::init_s1945j()
 	s1945_mcu_init();
 	m_s1945_mcu_table = s1945j_table;
 
-	m_ka302c_banking = 0; // Banking is controlled by mcu
+	m_ka302c_banking = false; // Banking is controlled by mcu
 
 	/* setup audiocpu banks */
 	/* The banked rom is seen at 8200-ffff, so the last 0x200 bytes of the rom not reachable. */
@@ -1960,9 +1944,9 @@ void psikyo_state::init_s1945j()
 
 void psikyo_state::init_s1945bl()
 {
-	m_ka302c_banking = 1;
+	m_ka302c_banking = true;
 
-	m_okibank->configure_entries(0, 4, memregion("oki")->base() + 0x30000, 0x10000);
+	m_okibank->configure_entries(0, 5, memregion("oki")->base() + 0x30000, 0x10000);
 	m_okibank->set_entry(0);
 }
 

--- a/src/mame/includes/psikyo.h
+++ b/src/mame/includes/psikyo.h
@@ -11,6 +11,7 @@
 #pragma once
 
 #include "machine/gen_latch.h"
+#include "video/bufsprite.h"
 #include "sound/okim6295.h"
 #include "emupal.h"
 #include "screen.h"
@@ -22,7 +23,6 @@ class psikyo_state : public driver_device
 public:
 	psikyo_state(const machine_config &mconfig, device_type type, const char *tag)
 		: driver_device(mconfig, type, tag)
-		, m_spriteram(*this, "spriteram")
 		, m_vram(*this, "vram_%u", 0)
 		, m_vregs(*this, "vregs")
 		, m_bootleg_spritebuffer(*this, "boot_spritebuf")
@@ -39,8 +39,9 @@ public:
 		, m_gfxdecode(*this, "gfxdecode")
 		, m_screen(*this, "screen")
 		, m_palette(*this, "palette")
+		, m_spriteram(*this, "spriteram")
 	{
-		std::fill(std::begin(m_old_linescroll), std::end(m_old_linescroll), 0);
+		std::fill(std::begin(m_old_linescroll), std::end(m_old_linescroll), ~u32(0));
 	}
 
 	void sngkace(machine_config &config);
@@ -62,11 +63,9 @@ public:
 
 private:
 	/* memory pointers */
-	required_shared_ptr<uint32_t> m_spriteram;
-	required_shared_ptr_array<uint32_t, 2> m_vram;
-	required_shared_ptr<uint32_t> m_vregs;
-	optional_shared_ptr<uint32_t> m_bootleg_spritebuffer;
-	std::unique_ptr<uint32_t[]>       m_spritebuf[2];
+	required_shared_ptr_array<u32, 2> m_vram;
+	required_shared_ptr<u32> m_vregs;
+	optional_shared_ptr<u32> m_bootleg_spritebuffer;
 
 	required_memory_region m_spritelut;
 	optional_memory_bank m_audiobank;
@@ -76,32 +75,44 @@ private:
 	optional_ioport m_in_coin;
 
 	/* video-related */
-	tilemap_t        *m_tilemap[2][4];
-	int            m_tilemap_bank[2];
-	int            m_ka302c_banking;
-	int            m_old_linescroll[2];
+	struct sprite_t
+	{
+		u8 gfx;
+		u32 code,color;
+		bool flipx,flipy;
+		s32 x,y;
+		u32 zoomx,zoomy;
+		u32 primask;
+	};
+
+	tilemap_t   *m_tilemap[2][4];
+	u8          m_tilemap_bank[2];
+	bool        m_ka302c_banking;
+	u32         m_old_linescroll[2];
+	std::unique_ptr<sprite_t[]> m_spritelist;
+	struct sprite_t *m_sprite_ptr_pre;
+	u16         m_sprite_ctrl;
 
 	/* game-specific */
 	// 1945 MCU
-	int            m_mcu_status;
-	uint8_t          m_s1945_mcu_direction;
-	uint8_t          m_s1945_mcu_latch1;
-	uint8_t          m_s1945_mcu_latch2;
-	uint8_t          m_s1945_mcu_inlatch;
-	uint8_t          m_s1945_mcu_index;
-	uint8_t          m_s1945_mcu_latching;
-	uint8_t          m_s1945_mcu_mode;
-	uint8_t          m_s1945_mcu_control;
-	uint8_t          m_s1945_mcu_bctrl;
-	const uint8_t    *m_s1945_mcu_table;
+	int         m_mcu_status;
+	u8          m_s1945_mcu_direction;
+	u8          m_s1945_mcu_latch1;
+	u8          m_s1945_mcu_latch2;
+	u8          m_s1945_mcu_inlatch;
+	u8          m_s1945_mcu_index;
+	u8          m_s1945_mcu_latching;
+	u8          m_s1945_mcu_mode;
+	u8          m_s1945_mcu_control;
+	u8          m_s1945_mcu_bctrl;
+	const u8    *m_s1945_mcu_table;
 
 	DECLARE_READ32_MEMBER(sngkace_input_r);
 	DECLARE_READ32_MEMBER(gunbird_input_r);
 	DECLARE_WRITE32_MEMBER(s1945_mcu_w);
 	DECLARE_READ32_MEMBER(s1945_mcu_r);
 	DECLARE_READ32_MEMBER(s1945_input_r);
-	DECLARE_READ32_MEMBER(s1945bl_oki_r);
-	DECLARE_WRITE32_MEMBER(s1945bl_oki_w);
+	DECLARE_WRITE8_MEMBER(s1945bl_okibank_w);
 	template<int Shift> DECLARE_WRITE8_MEMBER(sound_bankswitch_w);
 	template<int Layer> DECLARE_WRITE32_MEMBER(vram_w);
 
@@ -110,14 +121,16 @@ private:
 	virtual void machine_reset() override;
 	DECLARE_VIDEO_START(sngkace);
 	DECLARE_VIDEO_START(psikyo);
-	uint32_t screen_update_psikyo(screen_device &screen, bitmap_ind16 &bitmap, const rectangle &cliprect);
-	uint32_t screen_update_psikyo_bootleg(screen_device &screen, bitmap_ind16 &bitmap, const rectangle &cliprect);
-	DECLARE_WRITE_LINE_MEMBER(screen_vblank_psikyo);
-	void psikyo_switch_banks( int tmap, int bank );
-	void draw_sprites( screen_device &screen, bitmap_ind16 &bitmap, const rectangle &cliprect, int trans_pen );
-	void draw_sprites_bootleg( screen_device &screen, bitmap_ind16 &bitmap, const rectangle &cliprect, int trans_pen );
-	int tilemap_width( int size );
-	void s1945_mcu_init(  );
+	u32 screen_update(screen_device &screen, bitmap_ind16 &bitmap, const rectangle &cliprect);
+	u32 screen_update_bootleg(screen_device &screen, bitmap_ind16 &bitmap, const rectangle &cliprect);
+	DECLARE_WRITE_LINE_MEMBER(screen_vblank);
+	DECLARE_WRITE_LINE_MEMBER(screen_vblank_bootleg);
+	void switch_bgbanks(u8 tmap, u8 bank);
+	void draw_sprites(screen_device &screen, bitmap_ind16 &bitmap, const rectangle &cliprect);
+	void get_sprites();
+	void get_sprites_bootleg();
+	u16 tilemap_width(u8 size);
+	void s1945_mcu_init();
 
 	/* devices */
 	required_device<cpu_device> m_maincpu;
@@ -127,6 +140,7 @@ private:
 	required_device<gfxdecode_device> m_gfxdecode;
 	required_device<screen_device> m_screen;
 	required_device<palette_device> m_palette;
+	required_device<buffered_spriteram32_device> m_spriteram;
 
 	void gunbird_map(address_map &map);
 	void gunbird_sound_io_map(address_map &map);

--- a/src/mame/video/psikyo.cpp
+++ b/src/mame/video/psikyo.cpp
@@ -76,14 +76,14 @@ Offset:
 template<int Layer>
 TILE_GET_INFO_MEMBER(psikyo_state::get_tile_info)
 {
-	uint16_t code = ((uint16_t *)m_vram[Layer].target())[BYTE_XOR_BE(tile_index)];
+	u16 code = ((u16 *)m_vram[Layer].target())[BYTE_XOR_BE(tile_index)];
 	SET_TILE_INFO_MEMBER(1,
 			(code & 0x1fff) + 0x2000 * m_tilemap_bank[Layer],
 			((code >> 13) & 7) + (Layer * 0x40),
 			0);
 }
 
-void psikyo_state::psikyo_switch_banks( int tmap, int bank )
+void psikyo_state::switch_bgbanks(u8 tmap, u8 bank)
 {
 	if (bank != m_tilemap_bank[tmap])
 	{
@@ -96,6 +96,8 @@ void psikyo_state::psikyo_switch_banks( int tmap, int bank )
 
 VIDEO_START_MEMBER(psikyo_state,psikyo)
 {
+	m_spritelist = std::make_unique<sprite_t[]>(0x800/2*8*8);
+	m_sprite_ptr_pre = m_spritelist.get();
 	/* The Hardware is Capable of Changing the Dimensions of the Tilemaps, its safer to create
 	   the various sized tilemaps now as opposed to later */
 
@@ -110,21 +112,16 @@ VIDEO_START_MEMBER(psikyo_state,psikyo)
 			m_tilemap[layer][size]->set_scroll_cols(1);
 		}
 	}
-
-	m_spritebuf[0] = std::make_unique<uint32_t[]>(0x2000 / 4);
-	m_spritebuf[1] = std::make_unique<uint32_t[]>(0x2000 / 4);
-
-	save_pointer(NAME(m_spritebuf[0]), 0x2000 / 4, 0);
-	save_pointer(NAME(m_spritebuf[1]), 0x2000 / 4, 1);
 	save_item(NAME(m_old_linescroll));
+	save_item(NAME(m_sprite_ctrl));
 }
 
 VIDEO_START_MEMBER(psikyo_state,sngkace)
 {
 	VIDEO_START_CALL_MEMBER( psikyo );
 
-	psikyo_switch_banks(0, 0); // sngkace / samuraia don't use banking
-	psikyo_switch_banks(1, 1); // They share "gfx2" to save memory on other boards
+	switch_bgbanks(0, 0); // sngkace / samuraia don't use banking
+	switch_bgbanks(1, 1); // They share "gfx2" to save memory on other boards
 }
 
 
@@ -173,62 +170,53 @@ Note:   Not all sprites are displayed: in the top part of spriteram
 
 ***************************************************************************/
 
-void psikyo_state::draw_sprites( screen_device &screen, bitmap_ind16 &bitmap, const rectangle &cliprect, int trans_pen )
+void psikyo_state::get_sprites()
 {
 	/* tile layers 0 & 1 have priorities 1 & 2 */
+	m_sprite_ctrl = m_spriteram->buffer()[0x1ffe / 4] & 0xffff;
 	static const int pri[] = { 0, 0xfc, 0xff, 0xff };
-	int offs;
-	uint16_t *spritelist = (uint16_t *)(m_spritebuf[1].get() + 0x1800 / 4);
-	uint8_t *TILES = m_spritelut->base();    // Sprites LUT
-	int TILES_LEN = m_spritelut->bytes();
+	const u16 *spritelist = (u16 *)(m_spriteram->buffer() + 0x1800 / 4);
+	const u8 *TILES = m_spritelut->base();    // Sprites LUT
+	u32 const TILES_LEN = m_spritelut->bytes();
 
-	int width = m_screen->width();
-	int height = m_screen->height();
+	u16 const width = m_screen->width();
+	u16 const height = m_screen->height();
 
 	/* Exit if sprites are disabled */
-	if (spritelist[BYTE_XOR_BE((0x800 - 2) / 2)] & 1)   return;
+	m_sprite_ptr_pre = m_spritelist.get();
+	if (m_sprite_ctrl & 1)
+		return;
 
 	/* Look for "end of sprites" marker in the sprites list */
-	for (offs = 0/2 ; offs < (0x800 - 2)/2 ; offs += 2/2)   // skip last "sprite"
+	for (int offs = 0/2 ; offs < (0x800 - 2)/2 ; offs += 2/2)   // skip last "sprite"
 	{
-		uint16_t sprite = spritelist[BYTE_XOR_BE(offs)];
-		if (sprite == 0xffff)
-			break;
-	}
-
-	offs -= 2/2;
-
-	//  fprintf(stderr, "\n");
-	for ( ; offs >= 0/2 ; offs -= 2/2)
-	{
-		uint32_t *source;
-		int sprite;
-
-		int x, y, attr, code, flipx, flipy, nx, ny, zoomx, zoomy;
-		int dx, dy, xstart, ystart, xend, yend, xinc, yinc;
+		int xstart, ystart, xend, yend, xinc, yinc;
 
 		/* Get next entry in the list */
-		sprite = spritelist[BYTE_XOR_BE(offs)];
+		u16 sprite = spritelist[BYTE_XOR_BE(offs)];
+
+		if (sprite == 0xffff)
+			break;
 
 		sprite %= 0x300;
-		source = &m_spritebuf[1][sprite * 8 / 4];
+		const u32 *source = &m_spriteram->buffer()[sprite * 8 / 4];
 
 		/* Draw this sprite */
 
-		y   =   source[0 / 4] >> 16;
-		x   =   source[0 / 4] & 0xffff;
-		attr    =   source[4 / 4] >> 16;
-		code    =   source[4 / 4] & 0x1ffff;
+		s32 y          =   source[0 / 4] >> 16;
+		s32 x          =   source[0 / 4] & 0xffff;
+		u16 const attr =   source[4 / 4] >> 16;
+		u32 code       =   source[4 / 4] & 0x1ffff;
 
-		flipx   =   attr & 0x4000;
-		flipy   =   attr & 0x8000;
+		int flipx      =   attr & 0x4000;
+		int flipy      =   attr & 0x8000;
 
-		zoomx   =   ((x & 0xf000) >> 12);
-		zoomy   =   ((y & 0xf000) >> 12);
-		nx  =   ((x & 0x0e00) >> 9) + 1;
-		ny  =   ((y & 0x0e00) >> 9) + 1;
-		x   =   ((x & 0x01ff));
-		y   =   ((y & 0x00ff)) - (y & 0x100);
+		u32 zoomx      =   ((x & 0xf000) >> 12);
+		u32 zoomy      =   ((y & 0xf000) >> 12);
+		u8 const nx    =   ((x & 0x0e00) >> 9) + 1;
+		u8 const ny    =   ((y & 0x0e00) >> 9) + 1;
+		x              =   ((x & 0x01ff));
+		y              =   ((y & 0x00ff)) - (y & 0x100);
 
 		/* 180-1ff are negative coordinates. Note that $80 pixels is
 		   the maximum extent of a sprite, which can therefore be moved
@@ -256,29 +244,32 @@ void psikyo_state::draw_sprites( screen_device &screen, bitmap_ind16 &bitmap, co
 		if (flipy)  { ystart = ny - 1;  yend = -1;   yinc = -1; }
 		else        { ystart = 0;       yend = ny;   yinc = +1; }
 
-		for (dy = ystart; dy != yend; dy += yinc)
+		for (int dy = ystart; dy != yend; dy += yinc)
 		{
-			for (dx = xstart; dx != xend; dx += xinc)
+			for (int dx = xstart; dx != xend; dx += xinc)
 			{
-				int addr = (code * 2) & (TILES_LEN - 1);
+				u32 const addr = (code * 2) & (TILES_LEN - 1);
 
+				m_sprite_ptr_pre->gfx = 0;
+				m_sprite_ptr_pre->code = TILES[addr+1] * 256 + TILES[addr];
+				m_sprite_ptr_pre->color = attr >> 8;
+				m_sprite_ptr_pre->flipx = flipx;
+				m_sprite_ptr_pre->flipy = flipy;
 				if (zoomx == 32 && zoomy == 32)
-					m_gfxdecode->gfx(0)->prio_transpen(bitmap,cliprect,
-							TILES[addr+1] * 256 + TILES[addr],
-							attr >> 8,
-							flipx, flipy,
-							x + dx * 16, y + dy * 16,
-							screen.priority(),
-							pri[(attr & 0xc0) >> 6],trans_pen);
+				{
+					m_sprite_ptr_pre->x = x + dx * 16;
+					m_sprite_ptr_pre->y = y + dy * 16;
+				}
 				else
-					m_gfxdecode->gfx(0)->prio_zoom_transpen(bitmap,cliprect,
-								TILES[addr+1] * 256 + TILES[addr],
-								attr >> 8,
-								flipx, flipy,
-								x + (dx * zoomx) / 2, y + (dy * zoomy) / 2,
-								zoomx << 11,zoomy << 11,
-								screen.priority(),pri[(attr & 0xc0) >> 6],trans_pen);
+				{
+					m_sprite_ptr_pre->x = x + (dx * zoomx) / 2;
+					m_sprite_ptr_pre->y = y + (dy * zoomy) / 2;
+				}
+				m_sprite_ptr_pre->zoomx = zoomx << 11;
+				m_sprite_ptr_pre->zoomy = zoomy << 11;
+				m_sprite_ptr_pre->primask = pri[(attr & 0xc0) >> 6];
 
+				m_sprite_ptr_pre++;
 				code++;
 			}
 		}
@@ -290,63 +281,53 @@ void psikyo_state::draw_sprites( screen_device &screen, bitmap_ind16 &bitmap, co
 // until I work out why it makes a partial copy of the sprite list, and how best to apply it
 // sprite placement of the explosion graphic seems incorrect compared to the original sets? (no / different zoom support?)
 // it might be a problem with the actual bootleg
-void psikyo_state::draw_sprites_bootleg( screen_device &screen, bitmap_ind16 &bitmap, const rectangle &cliprect, int trans_pen )
+void psikyo_state::get_sprites_bootleg()
 {
 	/* tile layers 0 & 1 have priorities 1 & 2 */
+	m_sprite_ctrl = m_spriteram->buffer()[0x1ffe / 4] & 0xffff;
 	static const int pri[] = { 0, 0xfc, 0xff, 0xff };
-	int offs;
-	uint16_t *spritelist = (uint16_t *)(m_spritebuf[1].get()+ 0x1800 / 4);
-	uint8_t *TILES = m_spritelut->base();    // Sprites LUT
-	int TILES_LEN = m_spritelut->bytes();
+	const u16 *spritelist = (u16 *)(m_spriteram->buffer() + 0x1800 / 4);
+	const u8 *TILES = m_spritelut->base();    // Sprites LUT
+	u32 const TILES_LEN = m_spritelut->bytes();
 
-	int width = m_screen->width();
-	int height = m_screen->height();
+	u16 const width = m_screen->width();
+	u16 const height = m_screen->height();
 
 	/* Exit if sprites are disabled */
-	if (spritelist[BYTE_XOR_BE((0x800 - 2) / 2)] & 1)
+	m_sprite_ptr_pre = m_spritelist.get();
+	if (m_sprite_ctrl & 1)
 		return;
 
 	/* Look for "end of sprites" marker in the sprites list */
-	for (offs = 0/2 ; offs < (0x800 - 2)/2 ; offs += 2/2)   // skip last "sprite"
+	for (int offs = 0/2 ; offs < (0x800 - 2)/2 ; offs += 2/2)   // skip last "sprite"
 	{
-		uint16_t sprite = spritelist[BYTE_XOR_BE(offs)];
-		if (sprite == 0xffff)
-			break;
-	}
-
-	offs -= 2/2;
-
-	//  fprintf(stderr, "\n");
-	for ( ; offs >= 0/2 ; offs -= 2/2)
-	{
-		uint32_t *source;
-		int sprite;
-
-		int x, y, attr, code, flipx, flipy, nx, ny, zoomx, zoomy;
-		int dx, dy, xstart, ystart, xend, yend, xinc, yinc;
+		int xstart, ystart, xend, yend, xinc, yinc;
 
 		/* Get next entry in the list */
-		sprite = spritelist[BYTE_XOR_BE(offs)];
+		u16 sprite = spritelist[BYTE_XOR_BE(offs)];
+
+		if (sprite == 0xffff)
+			break;
 
 		sprite %= 0x300;
-		source = &m_spritebuf[1][sprite * 8 / 4];
+		const u32 *source = &m_spriteram->buffer()[sprite * 8 / 4];
 
 		/* Draw this sprite */
 
-		y   =   source[0] >> 16;
-		x   =   source[0] & 0xffff;
-		attr    =   source[1] >> 16;
-		code    =   source[1] & 0x1ffff;
+		s32 y          =   source[0 / 4] >> 16;
+		s32 x          =   source[0 / 4] & 0xffff;
+		u16 const attr =   source[4 / 4] >> 16;
+		u32 code       =   source[4 / 4] & 0x1ffff;
 
-		flipx   =   attr & 0x4000;
-		flipy   =   attr & 0x8000;
+		int flipx      =   attr & 0x4000;
+		int flipy      =   attr & 0x8000;
 
-		zoomx   =   ((x & 0xf000) >> 12);
-		zoomy   =   ((y & 0xf000) >> 12);
-		nx  =   ((x & 0x0e00) >> 9) + 1;
-		ny  =   ((y & 0x0e00) >> 9) + 1;
-		x   =   ((x & 0x01ff));
-		y   =   ((y & 0x00ff)) - (y & 0x100);
+		u32 zoomx      =   ((x & 0xf000) >> 12);
+		u32 zoomy      =   ((y & 0xf000) >> 12);
+		u8 const nx    =   ((x & 0x0e00) >> 9) + 1;
+		u8 const ny    =   ((y & 0x0e00) >> 9) + 1;
+		x              =   ((x & 0x01ff));
+		y              =   ((y & 0x00ff)) - (y & 0x100);
 
 		/* 180-1ff are negative coordinates. Note that $80 pixels is
 		   the maximum extent of a sprite, which can therefore be moved
@@ -375,38 +356,67 @@ void psikyo_state::draw_sprites_bootleg( screen_device &screen, bitmap_ind16 &bi
 		if (flipy)  { ystart = ny - 1;  yend = -1;   yinc = -1; }
 		else        { ystart = 0;       yend = ny;   yinc = +1; }
 
-		for (dy = ystart; dy != yend; dy += yinc)
+		for (int dy = ystart; dy != yend; dy += yinc)
 		{
-			for (dx = xstart; dx != xend; dx += xinc)
+			for (int dx = xstart; dx != xend; dx += xinc)
 			{
-				int addr = (code * 2) & (TILES_LEN-1);
+				u32 const addr = (code * 2) & (TILES_LEN-1);
 
+				m_sprite_ptr_pre->gfx = 0;
+				m_sprite_ptr_pre->code = TILES[addr+1] * 256 + TILES[addr];
+				m_sprite_ptr_pre->color = attr >> 8;
+				m_sprite_ptr_pre->flipx = flipx;
+				m_sprite_ptr_pre->flipy = flipy;
 				if (zoomx == 32 && zoomy == 32)
-					m_gfxdecode->gfx(0)->prio_transpen(bitmap,cliprect,
-							TILES[addr+1] * 256 + TILES[addr],
-							attr >> 8,
-							flipx, flipy,
-							x + dx * 16, y + dy * 16,
-							screen.priority(),
-							pri[(attr & 0xc0) >> 6],trans_pen);
+				{
+					m_sprite_ptr_pre->x = x + dx * 16;
+					m_sprite_ptr_pre->y = y + dy * 16;
+				}
 				else
-					m_gfxdecode->gfx(0)->prio_zoom_transpen(bitmap,cliprect,
-								TILES[addr+1] * 256 + TILES[addr],
-								attr >> 8,
-								flipx, flipy,
-								x + (dx * zoomx) / 2, y + (dy * zoomy) / 2,
-								zoomx << 11,zoomy << 11,
-								screen.priority(),pri[(attr & 0xc0) >> 6],trans_pen);
+				{
+					m_sprite_ptr_pre->x = x + (dx * zoomx) / 2;
+					m_sprite_ptr_pre->y = y + (dy * zoomy) / 2;
+				}
+				m_sprite_ptr_pre->zoomx = zoomx << 11;
+				m_sprite_ptr_pre->zoomy = zoomy << 11;
+				m_sprite_ptr_pre->primask = pri[(attr & 0xc0) >> 6];
 
+				m_sprite_ptr_pre++;
 				code++;
 			}
 		}
 	}
 }
 
+void psikyo_state::draw_sprites(screen_device &screen, bitmap_ind16 &bitmap, const rectangle &cliprect)
+{
+	struct sprite_t *sprite_ptr = m_sprite_ptr_pre;
 
+	while (sprite_ptr != m_spritelist.get())
+	{
+		sprite_ptr--;
 
-
+		if (sprite_ptr->zoomx == 0x10000 && sprite_ptr->zoomy == 0x10000)
+		{
+			m_gfxdecode->gfx(sprite_ptr->gfx)->prio_transpen(bitmap,cliprect,
+				sprite_ptr->code,
+				sprite_ptr->color,
+				sprite_ptr->flipx,sprite_ptr->flipy,
+				sprite_ptr->x,sprite_ptr->y,
+				screen.priority(),sprite_ptr->primask,(m_sprite_ctrl & 4 ? 0 : 15));
+		}
+		else
+		{
+			m_gfxdecode->gfx(sprite_ptr->gfx)->prio_zoom_transpen(bitmap,cliprect,
+				sprite_ptr->code,
+				sprite_ptr->color,
+				sprite_ptr->flipx,sprite_ptr->flipy,
+				sprite_ptr->x,sprite_ptr->y,
+				sprite_ptr->zoomx,sprite_ptr->zoomy,
+				screen.priority(),sprite_ptr->primask,(m_sprite_ctrl & 4 ? 0 : 15));
+		}
+	}
+}
 
 /***************************************************************************
 
@@ -414,21 +424,20 @@ void psikyo_state::draw_sprites_bootleg( screen_device &screen, bitmap_ind16 &bi
 
 ***************************************************************************/
 
-int psikyo_state::tilemap_width( int size )
+u16 psikyo_state::tilemap_width(u8 size)
 {
 	return (0x80 * 16) >> size;
 }
 
-uint32_t psikyo_state::screen_update_psikyo(screen_device &screen, bitmap_ind16 &bitmap, const rectangle &cliprect)
+u32 psikyo_state::screen_update(screen_device &screen, bitmap_ind16 &bitmap, const rectangle &cliprect)
 {
-	uint16_t bgpen = 0;
+	u16 bgpen = 0;
 	int i, layers_ctrl = -1;
 
-	uint32_t tmsize[2];
+	u32 tmsize[2];
 
-	uint32_t scrollx[2]{ m_vregs[0x406 / 4], m_vregs[0x40e / 4] }, scrolly[2]{ m_vregs[0x402 / 4], m_vregs[0x40a / 4] };
-	uint32_t layer_ctrl[2]{ m_vregs[0x412 / 4], m_vregs[0x416 / 4] };
-	uint32_t spr_ctrl = m_spritebuf[1][0x1ffe / 4];
+	u32 scrollx[2]{ m_vregs[0x406 / 4], m_vregs[0x40e / 4] }, scrolly[2]{ m_vregs[0x402 / 4], m_vregs[0x40a / 4] };
+	u32 layer_ctrl[2]{ m_vregs[0x412 / 4], m_vregs[0x416 / 4] };
 
 	tilemap_t *tmptilemap[2];
 
@@ -468,15 +477,15 @@ uint32_t psikyo_state::screen_update_psikyo(screen_device &screen, bitmap_ind16 
 		/* For gfx banking for s1945jn/gunbird/btlkroad */
 		if (m_ka302c_banking)
 		{
-			psikyo_switch_banks(layer, (layer_ctrl[layer] & 0x400) >> 10);
+			switch_bgbanks(layer, (layer_ctrl[layer] & 0x400) >> 10);
 		}
 
 		switch ((layer_ctrl[layer] & 0x00c0) >> 6)
 		{
-		case 0: tmsize[layer] = 1;    break;
-		case 1: tmsize[layer] = 2;    break;
-		case 2: tmsize[layer] = 3;    break;
-		default:tmsize[layer] = 0;    break;
+		case 0:  tmsize[layer] = 1;    break;
+		case 1:  tmsize[layer] = 2;    break;
+		case 2:  tmsize[layer] = 3;    break;
+		default: tmsize[layer] = 0;    break;
 		}
 
 		tmptilemap[layer] = m_tilemap[layer][tmsize[layer]];
@@ -499,7 +508,7 @@ uint32_t psikyo_state::screen_update_psikyo(screen_device &screen, bitmap_ind16 
 			}
 			for (i = 0; i < 256; i++)   /* 256 screen lines */
 			{
-				int x0 = ((uint16_t *)m_vregs.target())[BYTE_XOR_BE((layer * 0x200)/2 + (i >> tile_rowscroll))];
+				int x0 = ((u16 *)m_vregs.target())[BYTE_XOR_BE((layer * 0x200)/2 + (i >> tile_rowscroll))];
 				tmptilemap[layer]->set_scrollx(
 				(i + scrolly[layer]) % (tilemap_width(tmsize[layer])),
 				scrollx[layer] + x0 );
@@ -539,7 +548,7 @@ uint32_t psikyo_state::screen_update_psikyo(screen_device &screen, bitmap_ind16 
 		tmptilemap[1]->draw(screen, bitmap, cliprect, layer_ctrl[1] & 2 ? TILEMAP_DRAW_OPAQUE : 0, 2);
 
 	if (layers_ctrl & 4)
-		draw_sprites(screen, bitmap, cliprect, (spr_ctrl & 4 ? 0 : 15));
+		draw_sprites(screen, bitmap, cliprect);
 
 	return 0;
 }
@@ -552,16 +561,15 @@ uint32_t psikyo_state::screen_update_psikyo(screen_device &screen, bitmap_ind16 
 
 */
 
-uint32_t psikyo_state::screen_update_psikyo_bootleg(screen_device &screen, bitmap_ind16 &bitmap, const rectangle &cliprect)
+u32 psikyo_state::screen_update_bootleg(screen_device &screen, bitmap_ind16 &bitmap, const rectangle &cliprect)
 {
-	uint16_t bgpen = 0;
+	u16 bgpen = 0;
 	int i, layers_ctrl = -1;
 
-	uint32_t tmsize[2];
+	u32 tmsize[2];
 
-	uint32_t scrollx[2]{ m_vregs[0x406 / 4], m_vregs[0x40e / 4] }, scrolly[2]{ m_vregs[0x402 / 4], m_vregs[0x40a / 4] };
-	uint32_t layer_ctrl[2]{ m_vregs[0x412 / 4], m_vregs[0x416 / 4] };
-	uint32_t spr_ctrl = m_spritebuf[1][0x1ffe / 4];
+	u32 scrollx[2]{ m_vregs[0x406 / 4], m_vregs[0x40e / 4] }, scrolly[2]{ m_vregs[0x402 / 4], m_vregs[0x40a / 4] };
+	u32 layer_ctrl[2]{ m_vregs[0x412 / 4], m_vregs[0x416 / 4] };
 
 	tilemap_t *tmptilemap[2];
 
@@ -601,15 +609,15 @@ uint32_t psikyo_state::screen_update_psikyo_bootleg(screen_device &screen, bitma
 		/* For gfx banking for s1945jn/gunbird/btlkroad */
 		if (m_ka302c_banking)
 		{
-			psikyo_switch_banks(layer, (layer_ctrl[layer] & 0x400) >> 10);
+			switch_bgbanks(layer, (layer_ctrl[layer] & 0x400) >> 10);
 		}
 
 		switch ((layer_ctrl[layer] & 0x00c0) >> 6)
 		{
-		case 0: tmsize[layer] = 1;    break;
-		case 1: tmsize[layer] = 2;    break;
-		case 2: tmsize[layer] = 3;    break;
-		default:    tmsize[layer] = 0;    break;
+		case 0:  tmsize[layer] = 1;    break;
+		case 1:  tmsize[layer] = 2;    break;
+		case 2:  tmsize[layer] = 3;    break;
+		default: tmsize[layer] = 0;    break;
 		}
 
 		tmptilemap[layer] = m_tilemap[layer][tmsize[layer]];
@@ -633,7 +641,7 @@ uint32_t psikyo_state::screen_update_psikyo_bootleg(screen_device &screen, bitma
 			}
 			for (i = 0; i < 256; i++)   /* 256 screen lines */
 			{
-				int x0 = ((uint16_t *)m_vregs.target())[BYTE_XOR_BE((layer * 0x200)/2 + (i >> tile_rowscroll))];
+				int x0 = ((u16 *)m_vregs.target())[BYTE_XOR_BE((layer * 0x200)/2 + (i >> tile_rowscroll))];
 				tmptilemap[layer]->set_scrollx(
 				(i + scrolly[layer]) % (tilemap_width(tmsize[layer])),
 				scrollx[layer] + x0 );
@@ -673,18 +681,28 @@ uint32_t psikyo_state::screen_update_psikyo_bootleg(screen_device &screen, bitma
 		tmptilemap[1]->draw(screen, bitmap, cliprect, layer_ctrl[1] & 2 ? TILEMAP_DRAW_OPAQUE : 0, 2);
 
 	if (layers_ctrl & 4)
-		draw_sprites_bootleg(screen, bitmap, cliprect, (spr_ctrl & 4 ? 0 : 15));
+		draw_sprites(screen, bitmap, cliprect);
 
 	return 0;
 }
 
 
-WRITE_LINE_MEMBER(psikyo_state::screen_vblank_psikyo)
+WRITE_LINE_MEMBER(psikyo_state::screen_vblank)
 {
 	// rising edge
 	if (state)
 	{
-		memcpy(m_spritebuf[1].get(), m_spritebuf[0].get(), 0x2000);
-		memcpy(m_spritebuf[0].get(), m_spriteram, 0x2000);
+		get_sprites();
+		m_spriteram->copy();
+	}
+}
+
+WRITE_LINE_MEMBER(psikyo_state::screen_vblank_bootleg)
+{
+	// rising edge
+	if (state)
+	{
+		get_sprites_bootleg(); // TODO : it's seems differ?
+		m_spriteram->copy();
 	}
 }


### PR DESCRIPTION
Use Correct / Shorter type values, Fix some spacing, Use buffered_spriteram32_device for sprite ram, Minor fix naming, Correct buffered spritelist behavior, Fix s1945bl OKI bankswitching, Reduce unnecessary ACCESSING_BITs, Add notes (remain for bootleg differs)