### PR TITLE
pce_tourvision.xml: Cleaned the TourVisión softlist [ClawGrip]

### DIFF
--- a/hash/pce_tourvision.xml
+++ b/hash/pce_tourvision.xml
@@ -1,15 +1,18 @@
 <?xml version="1.0"?>
 <!DOCTYPE softwarelist SYSTEM "softwarelist.dtd">
-<softwarelist name="pce_tourvision" description="Tourvision (bootleg Arcade NEC PC-Engine) cartridges">
+<softwarelist name="pce_tourvision" description="TourVision (bootleg Arcade NEC PC-Engine) cartridges">
 
 <!--
 
 The 4×2 pins section on the edge connector (pins 1 to 8) are connected to a 74LS244 near each cart slot and
 are actually just being read as an IO port just like any other input.
-They form an 8 bit number which is the game ID, for example Override is: 00110101 – 53
-The Game ID is added as a feature on each game of the softwarelist (-1 is used when the ID is not known).
+They form an 8 bit number which is the game ID, for example Override is: 00110101b (53d) = 0x35h
+The Game ID is added as a feature on each game of the softwarelist (0xFF is used when the ID is not known).
+
+Unless noted, all games match the corresponding PCE HuCard dump.
 
     Games with unknown ID
+
 Armed-F
 Dragon Spirit
 Power League IV
@@ -18,7 +21,6 @@ Xevious
 
     Undumped games:
 
-Blodia (will be dumped soon)
 Blue Blink
 Boken Danshaku Don
 Chase HQ
@@ -30,11 +32,9 @@ Deep Blue
 Eternal City
 F1 Circus
 F1 Triple Battle
-Golf Boy (will be dumped soon)
 Hatris
 Heavy Unit
-Hani In The Sky
-Hani on the Road (will be dumped soon)
+Hanii in the Sky
 Kik Ball
 King Of Casino
 Klax
@@ -64,620 +64,584 @@ Strange Zone
 Taito Motor Bike
 Tales Of Monster Path
 Titan
-Time Cruise (will be dumped soon)
 TV Sports Football
 World Beach Volley
 World Court Tennis
 Zipang
 
     Rumored games:
-Parasol Stars - often been mentioned, but still not confirmed, for Tourvision. For now it's been added from its NEC PC-Engine dump, which it would be likely identical.
+
+Parasol Stars
+
+    Bad dumps?
+
+Most 384KBytes HuCards do not match with their corresponding TourVisión dumps. On those TourVisión dumps, the first 512KBytes are different
+from the second 512KBytes half (but then, each 512KBytes chunk have two identical 256KBytes halves.
+
 -->
 
-	<!--1943 Kai -->
+<!-- 0x40000 matches PCE tnzs -->
+
 	<software name="1943kai">
-		<description>1943 Kai (Tourvision PCE bootleg)</description>
+		<description>1943 Kai (TourVision PCE bootleg)</description>
 		<year>1991</year>
-		<publisher>bootleg (Tourvision) / Capcom / Naxat Soft</publisher>
+		<publisher>bootleg (TourVision) / Naxat</publisher>
+		<info name="alt_title" value="1943改"/>
 		<part name="cart" interface="tourvision_cart">
-			<feature name="id" value="65"/>
+			<feature name="id" value="0x41"/>
 			<dataarea name="rom" size="524288">
-		<!-- verified identical -->
 				<rom name="1943 kai (japan).pce" size="524288" crc="fde08d6d" sha1="3ac86354155ca01859c53e2f2287a715cd3fca13" offset="000000" />
 			</dataarea>
 		</part>
 	</software>
 
-
-	<!--Adventure Island -->
 	<software name="advislnd">
-		<description>Adventure Island (Tourvision PCE bootleg)</description>
+		<description>Adventure Island (TourVision PCE bootleg)</description>
 		<year>1991</year>
-		<publisher>bootleg (Tourvision) / Hudson Soft</publisher>
+		<publisher>bootleg (TourVision) / Hudson</publisher>
+		<info name="alt_title" value="アドベンチャーアイランド"/>
 		<part name="cart" interface="tourvision_cart">
-			<feature name="id" value="64"/>
-			<dataarea name="rom" size="1048576">
-		<!-- 0x40000 matches PCE advislnd -->
-				<rom name="adventure_island.bin" size="1048576" crc="5d57f1c7" sha1="e4becb5175c0ca945f86fa199bb94cbd2399bd2d" offset="000000" />
+			<feature name="id" value="0x40"/>
+			<dataarea name="rom" size="262144">
+				<rom name="adventure island (japan).pce" size="262144" crc="8e71d4f3" sha1="01ad5bbd7316740409e01917c19494cb26173ff5" offset="000000" />
 			</dataarea>
 		</part>
 	</software>
 
-
-	<!--Aero Blasters - Hudson / Kaneko -->
 	<software name="aeroblst">
-		<description>Aero Blasters (Tourvision PCE bootleg)</description>
+		<description>Aero Blasters (TourVision PCE bootleg)</description>
 		<year>1990</year>
-		<publisher>bootleg (Tourvision) / Inter State / Kaneko / Hudson Soft</publisher>
+		<publisher>bootleg (TourVision) / Hudson</publisher>
+		<info name="alt_title" value="エアロブラスターズ"/>
 		<part name="cart" interface="tourvision_cart">
-			<feature name="id" value="32"/>
+			<feature name="id" value="0x20"/>
 			<dataarea name="rom" size="524288">
-		<!-- verified identical -->
 				<rom name="aero blasters (japan).pce" size="524288" crc="25be2b81" sha1="748ec92246140565d95f6fb727de6167227b85d3" offset="000000" />
 			</dataarea>
 		</part>
 	</software>
 
-
-	<!--After Burner -->
 	<software name="aburner2">
-		<description>After Burner (Tourvision PCE bootleg)</description>
+		<description>After Burner (TourVision PCE bootleg)</description>
 		<year>1990</year>
-		<publisher>bootleg (Tourvision) / Sega / Nec Avenue</publisher>
+		<publisher>bootleg (TourVision) / NEC Avenue</publisher>
+		<info name="alt_title" value="アフターバーナーII"/>
 		<part name="cart" interface="tourvision_cart">
-			<feature name="id" value="46"/>
+			<feature name="id" value="0x2e"/>
 			<dataarea name="rom" size="524288">
-		<!-- verified identical -->
 				<rom name="after burner ii (japan).pce" size="524288" crc="ca72a828" sha1="50b9d22fe5179aee5cb95022472714ef8483841f" offset="000000" />
 			</dataarea>
 		</part>
 	</software>
 
-
-	<!--Alice In Wonderland -->
 	<software name="alice">
-		<description>Alice In Wonderland (Tourvision PCE bootleg)</description>
+		<description>Alice In Wonderland (TourVision PCE bootleg)</description>
 		<year>1990</year>
-		<publisher>bootleg (Tourvision) / Face</publisher>
+		<publisher>bootleg (TourVision) / Face</publisher>
+		<info name="alt_title" value="不思議の夢のアリス"/>
 		<part name="cart" interface="tourvision_cart">
-			<feature name="id" value="61"/>
+			<feature name="id" value="0x3d"/>
 			<dataarea name="rom" size="1048576">
-		<!-- 0x40000 matches PCE alice -->
+		<!-- NOT identical to the set in the PCE list, left unsplitted for reference -->
 				<rom name="alice_in_wonderland.bin" size="1048576" crc="d1e941ef" sha1="7ca02fee191a270df29764e3eca1f93bd996622b" offset="000000" />
 			</dataarea>
 		</part>
 	</software>
 
-
-	<!--Ankoku Densetsu -->
 	<software name="ankoku">
-		<description>Ankoku Densetsu (Tourvision PCE bootleg)</description>
+		<description>Ankoku Densetsu (TourVision PCE bootleg)</description>
 		<year>1990</year>
-		<publisher>bootleg (Tourvision) / Victor Interactive Software</publisher>
+		<publisher>bootleg (TourVision) / Victor Interactive Software</publisher>
+		<info name="alt_title" value="暗黒伝説"/>
 		<part name="cart" interface="tourvision_cart">
-			<feature name="id" value="33"/>
-			<dataarea name="rom" size="1048576">
-		<!-- 0x40000 matches PCE ankoku -->
-				<rom name="ankoku_densetsu.tv" size="1048576" crc="274d6a9b" sha1="88c8493883eab3dac530dd70675d58b883a49e2e" offset="000000" />
+			<feature name="id" value="0x21"/>
+			<dataarea name="rom" size="262144">
+				<rom name="ankoku densetsu (japan).pce" size="262144" crc="cacc06fb" sha1="b6ae249f0a4954df6e53c21ba81646ecbc7c2945" offset="000000" />
 			</dataarea>
 		</part>
 	</software>
 
-
-	<!--Armed-F -->
 	<software name="armedf">
-		<description>Armed-F (Tourvision PCE bootleg)</description>
+		<description>Armed-F (TourVision PCE bootleg)</description>
 		<year>1990</year>
-		<publisher>bootleg (Tourvision) / Nichibutsu / Big Don</publisher>
+		<publisher>bootleg (TourVision) / Pack-In-Video</publisher>
+		<info name="alt_title" value="FORMATION アームドF"/>
 		<part name="cart" interface="tourvision_cart">
-			<feature name="id" value="-1"/> <!-- Possible IDs: 4,5,15,18,24,31,40,61,75,76,77,78,101,111,114,120,127,136 (medium both delays) -->
+			<feature name="id" value="0xff"/> <!-- Possible IDs: 4,5,15,18,24,31,40,61,75,76,77,78,101,111,114,120,127,136 (medium both delays) -->
 			<dataarea name="rom" size="262144">
-		<!-- verified identical -->
 				<rom name="armed formation f (japan).pce" size="262144" crc="20ef87fd" sha1="a326c9cece6f14b82629c4c79b34df819b022dce" offset="000000" />
 			</dataarea>
 		</part>
 	</software>
 
-
-	<!--Ballistix -->
 	<software name="ballistx">
-		<description>Ballistix (Tourvision PCE bootleg)</description>
+		<description>Ballistix (TourVision PCE bootleg)</description>
 		<year>1991</year>
-		<publisher>bootleg (Tourvision) / Psygnosis / Coconuts Japan</publisher>
+		<publisher>bootleg (TourVision) / Coconuts Japan</publisher>
+		<info name="alt_title" value="バリスティックス"/>
 		<part name="cart" interface="tourvision_cart">
-			<feature name="id" value="186"/>
+			<feature name="id" value="0xba"/>
 			<dataarea name="rom" size="262144">
-		<!-- verified identical -->
 				<rom name="ballistix (japan).pce" size="262144" crc="8acfc8aa" sha1="e687abeb0f94e85fafa52e92b0beb82542f0c368" offset="000000" />
 			</dataarea>
 		</part>
 	</software>
 
-
-	<!--Barunba -->
 	<software name="barunba">
-		<description>Barunba (Tourvision PCE bootleg)</description>
+		<description>Barunba (TourVision PCE bootleg)</description>
 		<year>1989</year>
-		<publisher>bootleg (Tourvision) / Zap / Namcot</publisher>
+		<publisher>bootleg (TourVision) / Namcot</publisher>
+		<info name="alt_title" value="バルンバ"/>
 		<part name="cart" interface="tourvision_cart">
-			<feature name="id" value="39"/>
-			<dataarea name="rom" size="1048576">
-		<!-- 0x80000 matches PCE barnuba -->
-				<rom name="barunba.bin" size="1048576" crc="1498678e" sha1="8a8e25617425dce2ad66a545b48652d307c91be0" offset="000000" />
+			<feature name="id" value="0x27"/>
+			<dataarea name="rom" size="524288">
+				<rom name="barunba (japan).pce" size="524288" crc="4a3df3ca" sha1="5f110864af252462e144aa01a7a6ecb88d2a4eb1" offset="000000" />
 			</dataarea>
 		</part>
 	</software>
 
-
-	<!--Batman -->
 	<software name="batman">
-		<description>Batman (Tourvision PCE bootleg)</description>
+		<description>Batman (TourVision PCE bootleg)</description>
 		<year>1990</year>
-		<publisher>bootleg (Tourvision) / Sunsoft</publisher>
+		<publisher>bootleg (TourVision) / Sunsoft</publisher>
+		<info name="alt_title" value="バットマン"/>
 		<part name="cart" interface="tourvision_cart">
-			<feature name="id" value="30"/>
+			<feature name="id" value="0x1e"/>
 			<dataarea name="rom" size="1048576">
-		<!-- 0x40000 matches PCE batman -->
+		<!-- NOT identical to the set in the PCE list, left unsplitted for reference -->
 				<rom name="batman.tv" size="1048576" crc="e282f730" sha1="599a7a13cbc2f8d6726407ef3e261cca5d66511f" offset="000000" />
 			</dataarea>
 		</part>
 	</software>
 
-
-	<!--Be Ball -->
 	<software name="beballa">
-		<description>Be Ball (alt) (Tourvision PCE bootleg)</description>
+		<description>Be Ball (alt) (TourVision PCE bootleg)</description>
 		<year>1990</year>
-		<publisher>bootleg (Tourvision) / Hudson Soft</publisher>
+		<publisher>bootleg (TourVision) / Hudson</publisher>
+		<info name="alt_title" value="ビーボール"/>
 		<part name="cart" interface="tourvision_cart">
-			<feature name="id" value="93"/>
+			<feature name="id" value="0x5d"/>
 			<dataarea name="rom" size="262144">
-		<!-- byte at 0xBCD is changed 0x05 -> 0x02 -->
+		<!-- NOT identical to the set in the PCE list, byte at 0xBCD is changed from 0x05 (PCE) to 0x02 (TV)-->
 				<rom name="tourv_be_ball_alt.pce" size="262144" crc="261f1013" sha1="55d8815a4a432e587fc7483b63b73114fe40e710" offset="000000" />
 			</dataarea>
 		</part>
 	</software>
 
-
-	<!--Bomberman -->
-	<software name="bombman">
-		<description>Bomberman (Tourvision PCE bootleg)</description>
-		<year>1990</year>
-		<publisher>bootleg (Tourvision) / Hudson Soft</publisher>
+	<software name="blodia">
+		<description>Blodia (TourVision PCE bootleg)</description>
+		<year>1989</year>
+		<publisher>bootleg (TourVision) / Hudson</publisher>
+		<info name="alt_title" value="ブロディア"/>
 		<part name="cart" interface="tourvision_cart">
-			<feature name="id" value="71"/>
+			<feature name="id" value="0x07"/>
+			<dataarea name="rom" size="131072">
+				<rom name="blodia (japan).pce" size="131072" crc="958bcd09" sha1="bcb3070f617059c9d0d781ece2aee9ae74951f6a" offset="000000" />
+			</dataarea>
+		</part>
+	</software>
+
+	<software name="bombman">
+		<description>Bomberman (TourVision PCE bootleg)</description>
+		<year>1990</year>
+		<publisher>bootleg (TourVision) / Hudson</publisher>
+		<info name="alt_title" value="ボンバーマン"/>
+		<part name="cart" interface="tourvision_cart">
+			<feature name="id" value="0x47"/>
 			<dataarea name="rom" size="262144">
-		<!-- verified identical -->
 				<rom name="bomberman (japan).pce" size="262144" crc="9abb4d1f" sha1="738bbced47d87cd438d7972eba58c08f5c031a74" offset="000000" />
 			</dataarea>
 		</part>
 	</software>
 
-
-	<!--Bomberman 93 -->
 	<software name="bombmn93">
-		<description>Bomberman 93 (Tourvision PCE bootleg)</description>
+		<description>Bomberman '93 (TourVision PCE bootleg)</description>
 		<year>1992</year>
-		<publisher>bootleg (Tourvision) / Hudson Soft</publisher>
+		<publisher>bootleg (TourVision) / Hudson</publisher>
+		<info name="alt_title" value="ボンバーマン'93"/>
 		<part name="cart" interface="tourvision_cart">
-			<feature name="id" value="204"/>
-			<dataarea name="rom" size="1048576">
-		<!-- 0x80000 matches PCE bombmn93 -->
-				<rom name="bomberman_93.tv" size="1048576" crc="6772c687" sha1="2ff79046baa19ea0bf1fd362b81f487c1e1d7382" offset="000000" />
+			<feature name="id" value="0xcc"/>
+			<dataarea name="rom" size="524288">
+				<rom name="bomberman '93 (japan).pce" size="524288" crc="b300c5d0" sha1="64131aeb6753bffde2910d641c73b56108874320" offset="000000" />
 			</dataarea>
 		</part>
 	</software>
 
-
 	<software name="bullfght">
-		<description>Bull Fight - Ring no Haja (Tourvision PCE bootleg)</description>
+		<description>Bull Fight - Ring no Haja (TourVision PCE bootleg)</description>
 		<year>1989</year>
-		<publisher>bootleg (Tourvision) / Cream</publisher>
+		<publisher>bootleg (TourVision) / Cream</publisher>
+		<info name="alt_title" value="ブルファイト リングの覇者"/>
 		<part name="cart" interface="tourvision_cart">
-			<feature name="id" value="185"/>
+			<feature name="id" value="0xb9"/>
 			<dataarea name="rom" size="393216">
-		<!-- verified identical -->
 				<rom name="bull fight - ring no haja (japan).pce" size="393216" crc="5c4d1991" sha1="6cd94e6209da2939752ab6b1c2d46e5b48c8e0cb" offset="000000" />
 			</dataarea>
 		</part>
 	</software>
 
-
-	<!--Burning Angels -->
 	<software name="burnangl">
-		<description>Burning Angels (Tourvision PCE bootleg)</description>
+		<description>Burning Angels (TourVision PCE bootleg)</description>
 		<year>1990</year>
-		<publisher>bootleg (Tourvision) / Naxat</publisher>
+		<publisher>bootleg (TourVision) / Naxat</publisher>
+		<info name="alt_title" value="バーニングエンジェル"/>
 		<part name="cart" interface="tourvision_cart">
-			<feature name="id" value="49"/>
+			<feature name="id" value="0x31"/>
 			<dataarea name="rom" size="1048576">
-		<!-- 0x40000 matches PCE burnangl -->
+		<!-- NOT identical to the set in the PCE list, left unsplitted for reference -->
 				<rom name="burning_angels.tv" size="1048576" crc="a776ff9d" sha1="ea0dd87090f8e4eceac59df8495fcc10f325afe5" offset="000000" />
 			</dataarea>
 		</part>
 	</software>
 
-
-	<!--Cadash -->
 	<software name="cadash">
-		<description>Cadash (Tourvision PCE bootleg)</description>
+		<description>Cadash (TourVision PCE bootleg)</description>
 		<year>1991</year>
-		<publisher>bootleg (Tourvision) / Taito</publisher>
+		<publisher>bootleg (TourVision) / Taito</publisher>
+		<info name="alt_title" value="カダッシュ"/>
 		<part name="cart" interface="tourvision_cart">
-			<feature name="id" value="203"/>
+			<feature name="id" value="0xcb"/>
 			<dataarea name="rom" size="1048576">
-		<!-- 0x40000 matches PCE cadash -->
+		<!-- NOT identical to the set in the PCE list, left unsplitted for reference -->
 				<rom name="cadash.tv" size="1048576" crc="3611c4cf" sha1="68dab560b0c8123ec334df4e7db4af64dd92ff60" offset="000000" />
 			</dataarea>
 		</part>
 	</software>
 
-
-	<!--Chozetsurinjin Beraboh Man (Super Foolist Man) -->
+	<!--Super Foolist Man -->
 	<software name="bravoman">
-		<description>Chouzetsu Rinjin - Bravoman (Tourvision PCE bootleg)</description>
+		<description>Chouzetsu Rinjin - Bravoman (TourVision PCE bootleg)</description>
 		<year>1990</year>
-		<publisher>bootleg (Tourvision) / Namco / Namcot</publisher>
+		<publisher>bootleg (TourVision) / Namcot</publisher>
+		<info name="alt_title" value="超絶倫人ベラボーマン"/>
 		<part name="cart" interface="tourvision_cart">
-			<feature name="id" value="27"/>
+			<feature name="id" value="0x1b"/>
 			<dataarea name="rom" size="524288">
-		<!-- verified identical -->
 				<rom name="chouzetsu rinjin - bravoman (japan).pce" size="524288" crc="0df57c90" sha1="9abb7d96a4dba96a26f7073ea06cb8b2deb24a43" offset="000000" />
 			</dataarea>
 		</part>
 	</software>
 
-
-	<!--Chuka Taisen -->
 	<software name="chukatai">
-		<description>Chuka Taisen (Tourvision PCE bootleg)</description>
+		<description>Chuka Taisen (TourVision PCE bootleg)</description>
 		<year>1992</year>
-		<publisher>bootleg (Tourvision) / Taito Corporation</publisher>
+		<publisher>bootleg (TourVision) / Taito</publisher>
+		<info name="alt_title" value="極楽!中華大仙"/>
 		<part name="cart" interface="tourvision_cart">
-			<feature name="id" value="37"/>
+			<feature name="id" value="0x25"/>
 			<dataarea name="rom" size="393216">
-		<!-- verified identical -->
 				<rom name="gokuraku! chuuka taisen (japan).pce" size="393216" crc="e749a22c" sha1="b58e94e3e0c778e678c5d08c708ac4e37bedbbe3" offset="000000" />
 			</dataarea>
 		</part>
 	</software>
 
-
-	<!--Columns - Telenet Japan -->
 	<software name="columns">
-		<description>Columns (Tourvision PCE bootleg)</description>
+		<description>Columns (TourVision PCE bootleg)</description>
 		<year>1991</year>
-		<publisher>bootleg (Tourvision) / Telenet Japan</publisher>
+		<publisher>bootleg (TourVision) / Nihon Telenet</publisher>
+		<info name="alt_title" value="コラムス"/>
 		<part name="cart" interface="tourvision_cart">
-			<feature name="id" value="90"/>
+			<feature name="id" value="0x5a"/>
 			<dataarea name="rom" size="131072">
-		<!-- verified identical -->
 				<rom name="columns (japan).pce" size="131072" crc="99f7a572" sha1="238f9ee6cc80b31c5c93a4f43281e690200bdea3" offset="000000" />
 			</dataarea>
 		</part>
 	</software>
 
-
-	<!--Coryoon -->
 	<software name="coryoon">
-		<description>Coryoon - Child of Dragon (Tourvision PCE bootleg)</description>
+		<description>Coryoon - Child of Dragon (TourVision PCE bootleg)</description>
 		<year>1991</year>
-		<publisher>bootleg (Tourvision) / Naxat Soft</publisher>
+		<publisher>bootleg (TourVision) / Naxat</publisher>
+		<info name="alt_title" value="コリューン"/>
 		<part name="cart" interface="tourvision_cart">
 			<feature name="id" value="43"/>
 			<dataarea name="rom" size="524288">
-		<!-- verified identical -->
 				<rom name="coryoon - child of dragon (japan).pce" size="524288" crc="b4d29e3b" sha1="709595f04defcc55181f7502a0065e4c22d5fb19" offset="000000" />
 			</dataarea>
 		</part>
 	</software>
 
-
-	<!--Cyber Core -->
 	<software name="cybrcore">
-		<description>Cyber Core (Tourvision PCE bootleg)</description>
+		<description>Cyber Core (TourVision PCE bootleg)</description>
 		<year>1990</year>
-		<publisher>bootleg (Tourvision) / IGS</publisher>
+		<publisher>bootleg (TourVision) / IGS</publisher>
+		<info name="alt_title" value="サイバーコア"/>
 		<part name="cart" interface="tourvision_cart">
-			<feature name="id" value="13"/>
+			<feature name="id" value="0x0d"/>
 			<dataarea name="rom" size="1048576">
-		<!-- 0x40000 the same of PCE - cybrcore -->
+		<!-- NOT identical to the set in the PCE list, left unsplitted for reference -->
 				<rom name="cyber_core.bin" size="1048576" crc="e1bfac8f" sha1="8c346edf8251710a3dcddf4bd1f870de0661e5c9" offset="000000" />
 			</dataarea>
 		</part>
 	</software>
 
-
-	<!--Daisenpu -->
 	<software name="daisenpu">
-		<description>Daisenpu (Tourvision PCE bootleg)</description>
+		<description>Daisenpu (TourVision PCE bootleg)</description>
 		<year>1990</year>
-		<publisher>bootleg (Tourvision) / Toaplan / Nec Avenue</publisher>
+		<publisher>bootleg (TourVision) / NEC Avenue</publisher>
+		<info name="alt_title" value="大旋風"/>
 		<part name="cart" interface="tourvision_cart">
-			<feature name="id" value="3"/>
+			<feature name="id" value="0x03"/>
 			<dataarea name="rom" size="524288">
-		<!-- verified identical -->
 				<rom name="dai senpu (japan).pce" size="524288" crc="9107bcc8" sha1="81f8c8f01530bb3d22e2dd463202d0e26e7faf24" offset="000000" />
 			</dataarea>
 		</part>
 	</software>
 
-
-	<!--Dead Moon -->
 	<software name="deadmoon">
-		<description>Dead Moon (Tourvision PCE bootleg)</description>
+		<description>Dead Moon (TourVision PCE bootleg)</description>
 		<year>1991</year>
-		<publisher>bootleg (Tourvision) / T.S.S</publisher>
+		<publisher>bootleg (TourVision) / T.S.S</publisher>
+		<info name="alt_title" value="デッドムーン 月世界の悪夢"/>
 		<part name="cart" interface="tourvision_cart">
-			<feature name="id" value="55"/>
+			<feature name="id" value="0x37"/>
 			<dataarea name="rom" size="524288">
-		<!-- verified identical -->
 				<rom name="dead moon (japan).pce" size="524288" crc="56739bc7" sha1="d86ba171b459c286243306407311d85d013a2833" offset="000000" />
 			</dataarea>
 		</part>
 	</software>
 
-
-	<!--Devil Crash -->
 	<software name="devlcrsh">
-		<description>Devil Crash (Tourvision PCE bootleg)</description>
+		<description>Devil Crash - Naxat Pinball (TourVision PCE bootleg)</description>
 		<year>1990</year>
-		<publisher>bootleg (Tourvision) / Naxat / Red</publisher>
+		<publisher>bootleg (TourVision) / Naxat</publisher>
+		<info name="alt_title" value="デビルクラッシュ ナグザットピンボール"/>
 		<part name="cart" interface="tourvision_cart">
-			<feature name="id" value="47"/>
+			<feature name="id" value="0x2f"/>
 			<dataarea name="rom" size="393216">
-		<!-- verified identical -->
 				<rom name="devil crash - naxat pinball (japan).pce" size="393216" crc="4ec81a80" sha1="808638c33e110285d0d9415bc046b94a84b02c6a" offset="000000" />
 			</dataarea>
 		</part>
 	</software>
 
-
-	<!--Die Hard -->
 	<software name="diehard">
-		<description>Die Hard (Tourvision PCE bootleg)</description>
+		<description>Die Hard (TourVision PCE bootleg)</description>
 		<year>1990</year>
-		<publisher>bootleg (Tourvision) / Pack In Video / Nihon Busson Co.,Ltd</publisher>
+		<publisher>bootleg (TourVision) / Pack In Video</publisher>
+		<info name="alt_title" value="ダイハード"/>
 		<part name="cart" interface="tourvision_cart">
-			<feature name="id" value="73"/>
-			<dataarea name="rom" size="1048576">
-		<!-- 0x80000 matches PCE diehard -->
-				<rom name="die_hard.tv" size="1048576" crc="5cd0556e" sha1="605a963d024aca1f51f343349948d15fc3ef9954" offset="000000" />
+			<feature name="id" value="0x49"/>
+			<dataarea name="rom" size="524288">
+				<rom name="die hard (japan).pce" size="524288" crc="1b5b1cb1" sha1="96aeca126bb6ac0ca0df5ee260a8a1ee25f44d6d" offset="000000" />
 			</dataarea>
 		</part>
 	</software>
 
-
 	<!--Dodge Ball -->
 	<software name="nekdodge">
-		<description>Dodge Ball (Tourvision PCE bootleg)</description>
+		<description>Nekketsu Koukou Dodgeball Bu - PC Bangai Hen (TourVision PCE bootleg)</description>
 		<year>1990</year>
-		<publisher>bootleg (Tourvision) / Technos Japan Corp / Naxat Soft</publisher>
+		<publisher>bootleg (TourVision) / Naxat</publisher>
+		<info name="alt_title" value="熱血高校ドッジボール部 PC番外編"/>
 		<part name="cart" interface="tourvision_cart">
-			<feature name="id" value="194"/>
+			<feature name="id" value="0xc2"/>
 			<dataarea name="rom" size="262144">
-		<!-- verified identical -->
 				<rom name="nekketsu koukou dodgeball bu - pc bangai hen (japan).pce" size="262144" crc="65fdb863" sha1="582121ade819254da31fd8867c30e60195589a9a" offset="000000" />
 			</dataarea>
 		</part>
 	</software>
 
-
-	<!--Doraemon Meikyuu Daisakusen -->
 	<software name="dorams">
-		<description>Doraemon Meikyuu Dai Sakusen (Tourvision PCE bootleg)</description>
+		<description>Doraemon - Meikyuu Dai Sakusen (TourVision PCE bootleg)</description>
 		<year>1989</year>
-		<publisher>bootleg (Tourvision) / Fujiko-Shogakukan-TV Asahi / Hudson Soft</publisher>
+		<publisher>bootleg (TourVision) / Hudson</publisher>
 		<part name="cart" interface="tourvision_cart">
-			<feature name="id" value="20"/>
+			<feature name="id" value="0x14"/>
 			<dataarea name="rom" size="262144">
-		<!-- verified identical -->
 				<rom name="doraemon - meikyuu dai sakusen (japan).pce" size="262144" crc="dc760a07" sha1="81769dc4e2e669f6ae98872d22c52ac290530a28" offset="000000" />
 			</dataarea>
 		</part>
 	</software>
 
-	<!--Doraemon - Nobita no Dorabian Night -->
 	<software name="dorandn">
-		<description>Doraemon - Nobita no Dorabian Night (Tourvision PCE bootleg)</description>
+		<description>Doraemon - Nobita no Dorabian Night (TourVision PCE bootleg)</description>
 		<year>1991</year>
-		<publisher>bootleg (Tourvision) / Fujiko-Shogakukan-TV Asahi / Hudson Soft</publisher>
+		<publisher>bootleg (TourVision) / Hudson</publisher>
+		<info name="alt_title" value="ドラえもん のび太のドラビアンナイト"/>
 		<part name="cart" interface="tourvision_cart">
-			<feature name="id" value="43"/>
-			<dataarea name="rom" size="1048576">
-		<!-- 0x80000 matches PCE dorandn -->
-				<rom name="doreamon-nobitas_dorabian_night.tv" size="1048576" crc="716b1229" sha1="aaaf21cb511d07a0091ed560f3b426a3ba8950c5" offset="000000" />
+			<feature name="id" value="0x2b"/>
+			<dataarea name="rom" size="524288">
+				<rom name="doraemon - nobita no dorabian night (japan).pce" size="524288" crc="013a747f" sha1="feea7cb74d4e256eb75ab46fcfc40c21743d5487" offset="000000" />
 			</dataarea>
 		</part>
 	</software>
 
-	<!--Down Load -->
 	<software name="download">
-		<description>Down Load (Tourvision PCE bootleg)</description>
+		<description>Down Load (TourVision PCE bootleg)</description>
 		<year>1990</year>
-		<publisher>bootleg (Tourvision) / NEC Avenue</publisher>
+		<publisher>bootleg (TourVision) / NEC Avenue</publisher>
+		<info name="alt_title" value="ダウンロード"/>
 		<part name="cart" interface="tourvision_cart">
-			<feature name="id" value="43"/>
-			<dataarea name="rom" size="1048576">
-		<!-- 0x80000 matches PCE download -->
-				<rom name="down_load.bin" size="1048576" crc="cd4e0142" sha1="8324e0699c41c5af524889a9df2f4d45d8683d4e" offset="000000" />
+			<feature name="id" value="0x2b"/>
+			<dataarea name="rom" size="524288">
+				<rom name="download (japan).pce" size="524288" crc="85101c20" sha1="847bd22cccdf929def8fc348b973faee2688e648" offset="000000" />
 			</dataarea>
 		</part>
 	</software>
 
-
-	<!--Dragon Egg! -->
 	<software name="dragnegg" supported="no">
-		<description>Dragon Egg! (Tourvision PCE bootleg)</description>
+		<description>Dragon Egg! (TourVision PCE bootleg)</description>
 		<year>1991</year>
-		<publisher>bootleg (Tourvision) / Masaya</publisher>
+		<publisher>bootleg (TourVision) / Masiya</publisher>
+		<info name="alt_title" value="どらごんEGG!"/>
 		<part name="cart" interface="tourvision_cart">
-			<feature name="id" value="98"/>
-			<dataarea name="rom" size="1048576">
-		<!-- 0x80000 matches PCE dragnegg -->
-				<rom name="dragon_egg.tv" size="1048576" crc="fa24bc20" sha1="d6da2f5c95bb25d15918e01de951bbf35de9de7b" offset="000000" />
+			<feature name="id" value="0x62"/>
+			<dataarea name="rom" size="524288">
+				<rom name="dragon egg! (japan).pce" size="524288" crc="442405d5" sha1="56c69f24b542fea72cc753ddf0e4bb23974adbdf" offset="000000" />
 			</dataarea>
 		</part>
 	</software>
-
 
 	<software name="dsaber">
-		<description>Dragon Saber - After Story of Dragon Spirit (Tourvision PCE bootleg)</description>
+		<description>Dragon Saber - After Story of Dragon Spirit (TourVision PCE bootleg)</description>
 		<year>1991</year>
-		<publisher>bootleg (Tourvision) / Namcot</publisher>
+		<publisher>bootleg (TourVision) / Namcot</publisher>
+		<info name="alt_title" value="ドラゴンセイバー"/>
 		<part name="cart" interface="tourvision_cart">
-			<feature name="id" value="65"/>
+			<feature name="id" value="0x41"/>
 			<dataarea name="rom" size="524288">
-		<!-- verified identical -->
 				<rom name="dragon saber - after story of dragon spirit (japan).pce" size="524288" crc="3219849c" sha1="6d94cd3e27dbe1694229f7f006dc821be4764aa2" offset="000000" />
 			</dataarea>
 		</part>
 	</software>
 
-
-	<!--Dragon Spirit -->
 	<software name="dspirit">
-		<description>Dragon Spirit (Tourvision PCE bootleg)</description>
+		<description>Dragon Spirit (TourVision PCE bootleg)</description>
 		<year>1988</year>
-		<publisher>bootleg (Tourvision) / Namcot</publisher>
+		<publisher>bootleg (TourVision) / Namcot</publisher>
+		<info name="alt_title" value="ドラゴンスピリット"/>
 		<part name="cart" interface="tourvision_cart">
-			<feature name="id" value="-1"/> <!-- Possible IDs: 4,5,15,18,24,31,40,61,75,76,77,78,101,111,114,120,127,136 (long final delay short initial one) -->
+			<feature name="id" value="0xff"/> <!-- Possible IDs: 4,5,15,18,24,31,40,61,75,76,77,78,101,111,114,120,127,136 (long final delay short initial one) -->
 			<dataarea name="rom" size="262144">
-		<!-- verified identical -->
 				<rom name="dragon spirit (japan).pce" size="262144" crc="01a76935" sha1="09b037fde801b71d1ff343c40ff5a58372b9a514" offset="000000" />
 			</dataarea>
 		</part>
 	</software>
 
-
-	<!--Drop Rock Hora Hora -->
 	<software name="droprock">
-		<description>Drop Rock Hora Hora (Tourvision PCE bootleg)</description>
+		<description>Drop Rock Hora Hora (TourVision PCE bootleg)</description>
 		<year>1990</year>
-		<publisher>bootleg (Tourvision) / Data East</publisher>
+		<publisher>bootleg (TourVision) / Data East</publisher>
+		<info name="alt_title" value="ドロップロック ほらホラ"/>
 		<part name="cart" interface="tourvision_cart">
-			<feature name="id" value="12"/>
-			<dataarea name="rom" size="1048576">
-		<!-- 0x40000 matches PCE droprock -->
-				<rom name="drop_rock_hora_hora.bin" size="1048576" crc="66cf9db8" sha1="66d1d916a6f13a52ca164fda740fb532386992be" offset="000000" />
+			<feature name="id" value="0x0c"/>
+			<dataarea name="rom" size="262144">
+				<rom name="drop rock hora hora (japan).pce" size="262144" crc="67ec5ec4" sha1="b1b28d6dac76c3e3547f0a5a695110fd506643e0" offset="000000" />
 			</dataarea>
 		</part>
 	</software>
 
-
-	<!--
-	Dungeon Explorer TourVision cart - Hudson / Atlus
-	Notes:
-	-Cart's A18 line (pin 32) seems not connected to anything.
-	-->
 	<software name="dungexpl">
-		<description>Dungeon Explorer (Tourvision PCE bootleg)</description>
+		<description>Dungeon Explorer (TourVision PCE bootleg)</description>
 		<year>1989</year>
-		<publisher>bootleg (Tourvision) / Atlus Ltd. / Hudson Soft</publisher>
+		<publisher>bootleg (TourVision) / Hudson</publisher>
+		<info name="alt_title" value="ダンジョン エクスプローラー"/>
 		<part name="cart" interface="tourvision_cart">
-			<feature name="id" value="209"/>
+			<feature name="id" value="0xd1"/>
 			<dataarea name="rom" size="393216">
-		<!-- verified identical -->
 				<rom name="dungeon explorer (japan).pce" size="393216" crc="1b1a80a2" sha1="77caece9655a0e14330884673ffb41ff2bb625c4" offset="000000" />
 			</dataarea>
 		</part>
 	</software>
 
-
-	<!--Fighting Run -->
 	<software name="fightrun">
-		<description>Fighting Run (Tourvision PCE bootleg)</description>
+		<description>Fighting Run (TourVision PCE bootleg)</description>
 		<year>1991</year>
-		<publisher>bootleg (Tourvision) / Nichibutsu</publisher>
+		<publisher>bootleg (TourVision) / Nihon Bussan</publisher>
+		<info name="alt_title" value="ファイティングラン"/>
 		<part name="cart" interface="tourvision_cart">
-			<feature name="id" value="195"/>
-			<dataarea name="rom" size="1048576">
-		<!-- 0x80000 matches PCE fightrun -->
-				<rom name="fighting_run.bin" size="1048576" crc="004bba0a" sha1="9f3933eeb60fcd95d05db093156bce65dc4a82fd" offset="000000" />
+			<feature name="id" value="0xc3"/>
+			<dataarea name="rom" size="524288">
+				<rom name="fighting run (japan).pce" size="524288" crc="1828d2e5" sha1="fdd2962412b401cd2d72a85ddb516071468bd9ff" offset="000000" />
 			</dataarea>
 		</part>
 	</software>
 
-
-	<!--Final Blaster -->
 	<software name="finlblst">
-		<description>Final Blaster (Tourvision PCE bootleg)</description>
+		<description>Final Blaster (TourVision PCE bootleg)</description>
 		<year>1990</year>
-		<publisher>bootleg (Tourvision) / Namco / Namcot</publisher>
+		<publisher>bootleg (TourVision) / Namcot</publisher>
+		<info name="alt_title" value="ファイナルブラスター"/>
 		<part name="cart" interface="tourvision_cart">
-			<feature name="id" value="29"/>
+			<feature name="id" value="0x1d"/>
 			<dataarea name="rom" size="393216">
-		<!-- verified identical -->
 				<rom name="final blaster (japan).pce" size="393216" crc="c90971ba" sha1="4a013fde3938ceaacf38fcc4f56828d1292142d0" offset="000000" />
 			</dataarea>
 		</part>
 	</software>
 
-
-	<!--Final Lap Twin - Namco -->
 	<software name="finallap">
-		<description>Final Lap Twin (Tourvision PCE bootleg)</description>
+		<description>Final Lap Twin (TourVision PCE bootleg)</description>
 		<year>1989</year>
-		<publisher>bootleg (Tourvision) / Namco Ltd. / Namcot</publisher>
+		<publisher>bootleg (TourVision) / Namcot</publisher>
+		<info name="alt_title" value="ファイナルラップ・ツイン"/>
 		<part name="cart" interface="tourvision_cart">
-			<feature name="id" value="79"/>
+			<feature name="id" value="0x4f"/>
 			<dataarea name="rom" size="393216">
-		<!-- verified identical -->
 				<rom name="final lap twin (japan).pce" size="393216" crc="c8c084e3" sha1="ad695b7d1fb8bac7d9e13045bf229dba98d56a71" offset="000000" />
 			</dataarea>
 		</part>
 	</software>
 
-
-	<!--Final Match Tennis -->
 	<software name="finalmt">
-		<description>Final Match Tennis (Tourvision PCE bootleg)</description>
+		<description>Final Match Tennis (TourVision PCE bootleg)</description>
 		<year>1991</year>
-		<publisher>bootleg (Tourvision) / Human</publisher>
+		<publisher>bootleg (TourVision) / Human</publisher>
+		<info name="alt_title" value="ファイナルマッチテニス"/>
 		<part name="cart" interface="tourvision_cart">
-			<feature name="id" value="62"/>
+			<feature name="id" value="0x3e"/>
 			<dataarea name="rom" size="262144">
-		<!-- verified identical -->
 				<rom name="final match tennis (japan).pce" size="262144" crc="560d2305" sha1="e3a97b468d0a6c94effde70bf331dc4b3d90b166" offset="000000" />
 			</dataarea>
 		</part>
 	</software>
 
-	<!--Final Soldier -->
 	<software name="finalsol">
-		<description>Final Soldier (Tourvision PCE bootleg)</description>
+		<description>Final Soldier (TourVision PCE bootleg)</description>
 		<year>1991</year>
-		<publisher>bootleg (Tourvision) / Hudson</publisher>
+		<publisher>bootleg (TourVision) / Hudson</publisher>
+		<info name="alt_title" value="ファイナルソルジャー"/>
 		<part name="cart" interface="tourvision_cart">
-			<feature name="id" value="45"/>
-			<dataarea name="rom" size="1048576">
-				<rom name="final_soldier.bin" size="1048576" crc="bf28530b" sha1="fe9b487ab0fb5adc83d23d66c0ccb6dde6b77fbd" offset="000000" />
+			<feature name="id" value="0x2d"/>
+			<dataarea name="rom" size="524288">
+				<rom name="final soldier (japan).pce" size="524288" crc="af2dd2af" sha1="ce89c6ea5d9eb36a642742ecad9c35c16b761c49" offset="000000" />
 			</dataarea>
 		</part>
 	</software>
 
-	<!--Formation Soccer - Human Cup ' 90 - Human -->
 	<software name="fsoccr90">
-		<description>Formation Soccer - Human Cup '90 (Tourvision PCE bootleg)</description>
+		<description>Formation Soccer - Human Cup '90 (TourVision PCE bootleg)</description>
 		<year>1990</year>
-		<publisher>bootleg (Tourvision) / Human</publisher>
+		<publisher>bootleg (TourVision) / Human</publisher>
+		<info name="alt_title" value="フォーメーション・サッカー ヒューマンカップ'90"/>
 		<part name="cart" interface="tourvision_cart">
-			<feature name="id" value="1"/>
+			<feature name="id" value="0x01"/>
 			<dataarea name="rom" size="262144">
-		<!-- verified identical -->
 				<rom name="formation soccer - human cup '90 (japan).pce" size="262144" crc="85a1e7b6" sha1="d53db608475ca26ff81837dc43b40726bd0440a5" offset="000000" />
 			</dataarea>
 		</part>
 	</software>
 
-
-	<!--Gomola Speed - Human -->
-	<software name="gomolaa">
-		<description>Gomola Speed (alt) (Tourvision PCE bootleg)</description>
-		<year>1990</year>
-		<publisher>bootleg (Tourvision) / Human</publisher>
+	<software name="ganbgolf">
+		<description>Ganbare! Golf Boys (TourVision PCE bootleg)</description>
+		<year>1989</year>
+		<publisher>bootleg (TourVision) / NCS</publisher>
+		<info name="alt_title" value="がんばれ!ゴルフボーイズ"/>
 		<part name="cart" interface="tourvision_cart">
-			<feature name="id" value="27"/>
+			<feature name="id" value="0x43"/>
+			<dataarea name="rom" size="262144">
+				<rom name="ganbare! golf boys (japan).pce" size="262144" crc="27a4d11a" sha1="69794e5af0d2ec1a5bf6122c64fd5bc43092ae04" offset="000000" />
+			</dataarea>
+		</part>
+	</software>
+
+	<software name="gomolaa">
+		<description>Gomola Speed (alt) (TourVision PCE bootleg)</description>
+		<year>1990</year>
+		<publisher>bootleg (TourVision) / UPL</publisher>
+		<info name="alt_title" value="ゴモラスピード"/>
+		<part name="cart" interface="tourvision_cart">
+			<feature name="id" value="0x1b"/>
 			<dataarea name="rom" size="393216">
 		<!-- NOT identical to the set in the PCE list, alt revison? -->
 				<rom name="gomolaa.pce" size="393216" crc="4bd38f17" sha1="fe4b08fb0cd9d0a53726c2709db3e31fbeae1213" offset="000000" />
@@ -685,1057 +649,930 @@ Parasol Stars - often been mentioned, but still not confirmed, for Tourvision. F
 		</part>
 	</software>
 
-
-	<!--Gradius -->
 	<software name="gradius">
-		<description>Gradius (Tourvision PCE bootleg)</description>
+		<description>Gradius (TourVision PCE bootleg)</description>
 		<year>1991</year>
-		<publisher>bootleg (Tourvision) / Konami</publisher>
+		<publisher>bootleg (TourVision) / Konami</publisher>
+		<info name="alt_title" value="グラディウス"/>
 		<part name="cart" interface="tourvision_cart">
-			<feature name="id" value="187"/>
-			<dataarea name="rom" size="1048576">
-		<!-- 0x40000 matches PCE gradius -->
-				<rom name="gradius.tv" size="1048576" crc="8b39af37" sha1="62dc116918ded85325ff65c470818418e73516ed" offset="000000" />
+			<feature name="id" value="0xbb"/>
+			<dataarea name="rom" size="262144">
+				<rom name="gradius (japan).pce" size="262144" crc="0517da65" sha1="338f62b6d57f30b1850c32f5ae0d8c26c761974b" offset="000000" />
 			</dataarea>
 		</part>
 	</software>
 
-
-	<!--Gunhed -->
 	<software name="gunhed">
-		<description>GunHed (Tourvision PCE bootleg)</description>
+		<description>GunHed (TourVision PCE bootleg)</description>
 		<year>1989</year>
-		<publisher>bootleg (Tourvision) / Hudson / Toho Sunrise</publisher>
+		<publisher>bootleg (TourVision) / Hudson</publisher>
+		<info name="alt_title" value="ガンヘッド"/>
 		<part name="cart" interface="tourvision_cart">
-			<feature name="id" value="148"/>
+			<feature name="id" value="0x94"/>
 			<dataarea name="rom" size="393216">
-		<!-- verified identical -->
 				<rom name="gunhed (japan).pce" size="393216" crc="a17d4d7e" sha1="0107d93ff5d10325092d45e6bfd21e8130efeed7" offset="000000" />
 			</dataarea>
 		</part>
 	</software>
 
 
-	<!--Hana Taka Daka (Super Long Nose Goblin) -->
+	<!--Super Long Nose Goblin -->
 	<software name="hanataka">
-		<description>Hana Taaka Daka!? (Tourvision PCE bootleg)</description>
+		<description>Hana Taaka Daka!? (TourVision PCE bootleg)</description>
 		<year>1991</year>
-		<publisher>bootleg (Tourvision) / Taito Corporation</publisher>
+		<publisher>bootleg (TourVision) / Taito</publisher>
+		<info name="alt_title" value="はなたーかだか!?"/>
 		<part name="cart" interface="tourvision_cart">
-			<feature name="id" value="6"/>
+			<feature name="id" value="0x06"/>
 			<dataarea name="rom" size="524288">
-		<!-- verified identical -->
 				<rom name="hana taaka daka! (japan).pce" size="524288" crc="ba4d0dd4" sha1="664ccd11372b04739e388fb921ac507eb71986cd" offset="000000" />
 			</dataarea>
 		</part>
 	</software>
 
-
-	<!--Hit The Ice -->
-	<software name="hitice">
-		<description>Hit The Ice (Tourvision PCE bootleg)</description>
-		<year>1991</year>
-		<publisher>bootleg (Tourvision) / Williams / Taito Corporation</publisher>
+	<software name="haniirod">
+		<description>Hanii on the Road (TourVision PCE bootleg)</description> <!-- The cart was hand-labeled as "Money in the Sky II" -->
+		<year>1990</year>
+		<publisher>bootleg (TourVision) / Face</publisher>
+		<info name="alt_title" value="はにい・おんざ・ろおど"/>
 		<part name="cart" interface="tourvision_cart">
-			<feature name="id" value="97"/>
+			<feature name="id" value="0x53"/>
 			<dataarea name="rom" size="1048576">
-		<!-- 0x40000 matches PCE hitice -->
+		<!-- NOT identical to the set in the PCE list, the first 512Kbytes are different
+		from the second 512KB half (but then, each 512KBytes chunk have two identical 256Kbytes halves. -->
+				<rom name="hanii_on_the_road.tv" size="1048576" crc="f21c0c39" sha1="bc31811a3b1fe84e8f1c0cb1b4cf98d1af911040" offset="000000" />
+			</dataarea>
+		</part>
+	</software>
+
+	<software name="hitice">
+		<description>Hit the Ice - VHL - The Official Video Hockey League (TourVision PCE bootleg)</description>
+		<year>1991</year>
+		<publisher>bootleg (TourVision) / Taito</publisher>
+		<info name="alt_title" value="ヒット ジ アイス"/>
+		<part name="cart" interface="tourvision_cart">
+			<feature name="id" value="0x61"/>
+			<dataarea name="rom" size="1048576">
+		<!-- NOT identical to the set in the PCE list, left unsplitted for reference -->
 				<rom name="hit_the_ice.tv" size="1048576" crc="a0929d2b" sha1="26607a76cade818bd0d1daf2d0bfddfecd18f187" offset="000000" />
 			</dataarea>
 		</part>
 	</software>
 
-
-	<!--Image Fight -->
 	<software name="imagefgt">
-		<description>Image Fight (Tourvision PCE bootleg)</description>
+		<description>Image Fight (TourVision PCE bootleg)</description>
 		<year>1990</year>
-		<publisher>bootleg (Tourvision) / Irem</publisher>
+		<publisher>bootleg (TourVision) / Irem</publisher>
+		<info name="alt_title" value="イメージファイト"/>
 		<part name="cart" interface="tourvision_cart">
-			<feature name="id" value="99"/>
-			<dataarea name="rom" size="1048576">
-		<!-- 0x80000 matches PCE imagefgt -->
-				<rom name="image_fight.bin" size="1048576" crc="ad6a4eb1" sha1="b802f718a3a199f9257e19b7044482cc05c1c7a6" offset="000000" />
+			<feature name="id" value="0x63"/>
+			<dataarea name="rom" size="524288">
+				<rom name="image fight (japan).pce" size="524288" crc="a80c565f" sha1="4f2256e49cc71613a6b35d224be706ee95df17b9" offset="000000" />
 			</dataarea>
 		</part>
 	</software>
 
-
-	<!--Jackie Chan - Hudson -->
 	<software name="jchan">
-		<description>Jackie Chan (Tourvision PCE bootleg)</description>
+		<description>Jackie Chan (TourVision PCE bootleg)</description>
 		<year>1991</year>
-		<publisher>bootleg (Tourvision) / Hudson Soft</publisher>
+		<publisher>bootleg (TourVision) / Hudson</publisher>
+		<info name="alt_title" value="ジャッキーチェン"/>
 		<part name="cart" interface="tourvision_cart">
-			<feature name="id" value="54"/>
+			<feature name="id" value="0x36"/>
 			<dataarea name="rom" size="524288">
-		<!-- verified identical -->
 				<rom name="jackie chan (japan).pce" size="524288" crc="c6fa6373" sha1="44c9ce3b37ca9c5edfe840f78485048e2bd1bf41" offset="000000" />
 			</dataarea>
 		</part>
 	</software>
 
-
-	<!--Jinmu Densho -->
 	<software name="jinmu">
-		<description>Jinmu Denshou (Tourvision PCE bootleg)</description>
+		<description>Jinmu Denshou (TourVision PCE bootleg)</description>
 		<year>1989</year>
-		<publisher>bootleg (Tourvision) / Big Club / Wolf Team</publisher>
+		<publisher>bootleg (TourVision) / Big Club</publisher>
+		<info name="alt_title" value="神武伝承"/>
 		<part name="cart" interface="tourvision_cart">
-			<feature name="id" value="19"/>
+			<feature name="id" value="0x13"/>
 			<dataarea name="rom" size="524288">
-		<!-- verified identical -->
 				<rom name="jinmu denshou (japan).pce" size="524288" crc="c150637a" sha1="e38d6d83120301a7befa7f496f1a93768060032d" offset="000000" />
 			</dataarea>
 		</part>
 	</software>
 
-
-	<!--Kato Chan &amp; Ken Chan -->
 	<software name="katochan">
-		<description>Kato Chan &amp; Ken Chan (Tourvision PCE bootleg)</description>
+		<description>Kato Chan &amp; Ken Chan (TourVision PCE bootleg)</description>
 		<year>1990</year>
-		<publisher>bootleg (Tourvision) / Hudson</publisher>
+		<publisher>bootleg (TourVision) / Hudson</publisher>
+		<info name="alt_title" value="カトちゃんケンちゃん"/>
 		<part name="cart" interface="tourvision_cart">
-			<feature name="id" value="42"/>
-			<dataarea name="rom" size="1048576">
-		<!-- 0x40000 matches PCE katochan -->
-				<rom name="kato_ken.bin" size="1048576" crc="47993b98" sha1="1febf57b96df7649675b944df01cec48daa4e12c" offset="000000" />
+			<feature name="id" value="0x2a"/>
+			<dataarea name="rom" size="262144">
+				<rom name="kato chan &amp; ken chan (japan).pce" size="262144" crc="6069c5e7" sha1="1381c15587891083f7cde3b1224fcc6df45bc914" offset="000000" />
 			</dataarea>
 		</part>
 	</software>
 
-
-	<!--Kiki Kaikai -->
 	<software name="kikikai">
-		<description>Kiki Kaikai (Tourvision PCE bootleg)</description>
+		<description>Kiki Kaikai (TourVision PCE bootleg)</description>
 		<year>1990</year>
-		<publisher>bootleg (Tourvision) / Taito</publisher>
+		<publisher>bootleg (TourVision) / Taito</publisher>
+		<info name="alt_title" value="奇々怪界"/>
 		<part name="cart" interface="tourvision_cart">
-			<feature name="id" value="120"/>
+			<feature name="id" value="0x78"/>
 			<dataarea name="rom" size="393216">
-		<!-- verified identical -->
 				<rom name="kiki kaikai (japan).pce" size="393216" crc="c0cb5add" sha1="8dc4fce4beca91f51f123acf8f1cc659ed58d312" offset="000000" />
 			</dataarea>
 		</part>
 	</software>
 
-
-	<!--Knight Rider Special -->
 	<software name="knightrs">
-		<description>Knight Rider Special (Tourvision PCE bootleg)</description>
+		<description>Knight Rider Special (TourVision PCE bootleg)</description>
 		<year>1994</year>
-		<publisher>bootleg (Tourvision) / Pack In Video</publisher>
+		<publisher>bootleg (TourVision) / Pack In Video</publisher>
+		<info name="alt_title" value="ナイトライダースペシャル"/>
 		<part name="cart" interface="tourvision_cart">
-			<feature name="id" value="193"/>
-			<dataarea name="rom" size="1048576">
-		<!-- 0x40000 matches PCE knightrs -->
-				<rom name="knight_rider.tv" size="1048576" crc="dc926ef5" sha1="c0d9452e3468c46e6f45c40d634ae448f21531d3" offset="000000" />
+			<feature name="id" value="0xc1"/>
+			<dataarea name="rom" size="262144">
+				<rom name="knight rider special (japan).pce" size="262144" crc="c614116c" sha1="d2dbbd8b55b80d41e32a3907fcdafa985b60abe4" offset="000000" />
 			</dataarea>
 		</part>
 	</software>
 
-
-	<!--Legend of Hero Tonma -->
 	<software name="loht">
-		<description>Legend of Hero Tonma (Tourvision PCE bootleg)</description>
+		<description>Legend of Hero Tonma (TourVision PCE bootleg)</description>
 		<year>1991</year>
-		<publisher>bootleg (Tourvision) / IREM Corp</publisher>
+		<publisher>bootleg (TourVision) / Irem</publisher>
+		<info name="alt_title" value="レジェンド・オブ・ヒーロー・トンマ"/>
 		<part name="cart" interface="tourvision_cart">
-			<feature name="id" value="56"/>
+			<feature name="id" value="0x38"/>
 			<dataarea name="rom" size="524288">
-		<!-- verified identical -->
 				<rom name="legend of hero tonma (japan).pce" size="524288" crc="c28b0d8a" sha1="352e91337db64bc7edd788e4ccb9c240c7040898" offset="000000" />
 			</dataarea>
 		</part>
 	</software>
 
-
-	<!--Makyo Densetsu - The Legendary Axe - Victor Musical Industries, Inc. -->
 	<software name="makyoden">
-		<description>Makyou Densetsu - The Legendary Axe (Tourvision PCE bootleg)</description>
+		<description>Makyou Densetsu - The Legendary Axe (TourVision PCE bootleg)</description>
 		<year>1988</year>
-		<publisher>bootleg (Tourvision) / Victor Musical Industries, Inc.</publisher>
+		<publisher>bootleg (TourVision) / Victor Interactive Software</publisher>
+		<info name="alt_title" value="魔境伝説"/>
 		<part name="cart" interface="tourvision_cart">
-			<feature name="id" value="40"/>
+			<feature name="id" value="0x28"/>
 			<dataarea name="rom" size="262144">
-		<!-- verified identical -->
 				<rom name="makyou densetsu (japan).pce" size="262144" crc="d4c5af46" sha1="7e1b1f52222663e9e98973fdb3cf67879122b617" offset="000000" />
 			</dataarea>
 		</part>
 	</software>
 
-
-	<!--Mesopotamia -->
 	<software name="mesopot">
-		<description>Mesopotamia (Tourvision PCE bootleg)</description>
+		<description>Mesopotamia (TourVision PCE bootleg)</description>
 		<year>1991</year>
-		<publisher>bootleg (Tourvision) / Atlus</publisher>
+		<publisher>bootleg (TourVision) / Atlus</publisher>
+		<info name="alt_title" value="メソポタミア"/>
 		<part name="cart" interface="tourvision_cart">
-			<feature name="id" value="197"/>
-			<dataarea name="rom" size="1048576">
-		<!-- 0x80000 matches PCE mesopot -->
-				<rom name="mesopotamia.bin" size="1048576" crc="ea8af850" sha1="1b50db3fadc0b635527fd047cfede556b1de3547" offset="000000" />
+			<feature name="id" value="0xc5"/>
+			<dataarea name="rom" size="524288">
+				<rom name="mesopotamia (japan).pce" size="524288" crc="e87190f1" sha1="70186b4d823a48aae09ed7e2bc8e16edfcaf4335" offset="000000" />
 			</dataarea>
 		</part>
 	</software>
 
-
-	<!--Mizubaku Daibouken Liquid Kids -->
+	<!--Liquid Kids -->
 	<software name="mizubaku">
-		<description>Mizubaku Daibouken Liquid Kids (Tourvision PCE bootleg)</description>
+		<description>Mizubaku Dai Bouken (TourVision PCE bootleg)</description>
 		<year>1992</year>
-		<publisher>bootleg (Tourvision) / Taito Corporation</publisher>
+		<publisher>bootleg (TourVision) / Taito</publisher>
+		<info name="alt_title" value="ミズバク大冒険"/>
 		<part name="cart" interface="tourvision_cart">
-			<feature name="id" value="10"/>
+			<feature name="id" value="0x0a"/>
 			<dataarea name="rom" size="524288">
-		<!-- verified identical -->
 				<rom name="mizubaku dai bouken (japan).pce" size="524288" crc="b2ef558d" sha1="6e99a1982b6e2b0b9fb82f1d30270620917e1b92" offset="000000" />
 			</dataarea>
 		</part>
 	</software>
 
-
-	<!--Mr Heli -->
 	<software name="mrheli">
-		<description>Mr. Heli no Daibouken (Tourvision PCE bootleg)</description>
+		<description>Mr. Heli no Daibouken (TourVision PCE bootleg)</description>
 		<year>1989</year>
-		<publisher>bootleg (Tourvision) / IREM Corp</publisher>
+		<publisher>bootleg (TourVision) / Irem</publisher>
+		<info name="alt_title" value="ミスターヘリの大冒険"/>
 		<part name="cart" interface="tourvision_cart">
-			<feature name="id" value="23"/>
+			<feature name="id" value="0x17"/>
 			<dataarea name="rom" size="524288">
-		<!-- verified identical -->
 				<rom name="mr. heli no daibouken (japan).pce" size="524288" crc="2cb92290" sha1="df6346583d7169ffdec03925c9b15d3e4f066079" offset="000000" />
 			</dataarea>
 		</part>
 	</software>
 
-
-	<!--Ninja Ryukenden -->
 	<software name="nryukend">
-		<description>Ninja Ryukenden (Tourvision PCE bootleg)</description>
+		<description>Ninja Ryukenden (TourVision PCE bootleg)</description>
 		<year>1992</year>
-		<publisher>bootleg (Tourvision) / Tecmo / Hudson Soft</publisher>
+		<publisher>bootleg (TourVision) / Hudson</publisher>
+		<info name="alt_title" value="忍者龍剣伝"/>
 		<part name="cart" interface="tourvision_cart">
-			<feature name="id" value="10"/>
+			<feature name="id" value="0x0a"/>
 			<dataarea name="rom" size="524288">
-		<!-- verified identical -->
 				<rom name="ninja ryuuken den (japan).pce" size="524288" crc="67573bac" sha1="7f6a088424f849fc80f883d19533c031305d9616" offset="000000" />
 			</dataarea>
 		</part>
 	</software>
 
-
-	<!--Operation Wolf -->
 	<software name="opwolf">
-		<description>Operation Wolf (Tourvision PCE bootleg)</description>
+		<description>Operation Wolf (TourVision PCE bootleg)</description>
 		<year>1990</year>
-		<publisher>bootleg (Tourvision) / Taito / Nec Avenue</publisher>
+		<publisher>bootleg (TourVision) / NEC Avenue</publisher>
+		<info name="alt_title" value="オペレーション ウルフ"/>
 		<part name="cart" interface="tourvision_cart">
-			<feature name="id" value="26"/>
+			<feature name="id" value="0x1a"/>
 			<dataarea name="rom" size="524288">
-		<!-- verified identical -->
 				<rom name="operation wolf (japan).pce" size="524288" crc="ff898f87" sha1="da2a28e2961fa295c4b8f55bd5a6ce6f1c58beb7" offset="000000" />
 			</dataarea>
 		</part>
 	</software>
 
-
-	<!--Ordyne -->
 	<software name="ordyne">
-		<description>Ordyne (Tourvision PCE bootleg)</description>
+		<description>Ordyne (TourVision PCE bootleg)</description>
 		<year>1991</year>
-		<publisher>bootleg (Tourvision) / Namco</publisher>
+		<publisher>bootleg (TourVision) / Namcot</publisher>
+		<info name="alt_title" value="オーダイン"/>
 		<part name="cart" interface="tourvision_cart">
-			<feature name="id" value="94"/>
-			<dataarea name="rom" size="1048576">
-		<!-- 0x80000 matches PCE ordyne -->
-				<rom name="ordyne.bin" size="1048576" crc="885363ed" sha1="2e66a3ba7575fd68df10e50b6833088d2fe220eb" offset="000000" />
+			<feature name="id" value="0x5e"/>
+			<dataarea name="rom" size="524288">
+				<rom name="ordyne (japan).pce" size="524288" crc="8c565cb6" sha1="6b1e419c77f72d3588b52343989727b5a069df3a" offset="000000" />
 			</dataarea>
 		</part>
 	</software>
 
-
-	<!--Outrun -->
 	<software name="outrun">
-		<description>Out Run (Tourvision PCE bootleg)</description>
+		<description>Out Run (TourVision PCE bootleg)</description>
 		<year>1990</year>
-		<publisher>bootleg (Tourvision) / Sega / Nec Avenue</publisher>
+		<publisher>bootleg (TourVision) / NEC Avenue</publisher>
+		<info name="alt_title" value="アウトラン"/>
 		<part name="cart" interface="tourvision_cart">
-			<feature name="id" value="38"/>
+			<feature name="id" value="0x26"/>
 			<dataarea name="rom" size="1048576">
-		<!-- 50000-5000F: FF 10 10 00 1C F9 0F F8 0F 87 FF 3F 0F 4F 00 2E - PCE Dump -->
-		<!-- 50000-5000F: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 - Tourvision -->
-		<!-- otherwise 0x80000 idential -->
+		<!-- NOT identical to the set in the PCE list
+		50000-5000F: FF 10 10 00 1C F9 0F F8 0F 87 FF 3F 0F 4F 00 2E - PCE Dump
+		50000-5000F: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 - Tourvision
+		otherwise 0x80000 identical -->
 				<rom name="outrun.bin" size="1048576" crc="ef866d6e" sha1="f414d8fcacb6f055f2b3fd9eb1723921d98d11cc" offset="000000" />
 			</dataarea>
 		</part>
 	</software>
 
-
-	<!--Override -->
 	<software name="override">
-		<description>Override (Tourvision PCE bootleg)</description>
+		<description>Override (TourVision PCE bootleg)</description>
 		<year>1990</year>
-		<publisher>bootleg (Tourvision) / Sting / Data East Corporation</publisher>
+		<publisher>bootleg (TourVision) / Data East</publisher>
+		<info name="alt_title" value="オーバーライド"/>
 		<part name="cart" interface="tourvision_cart">
-			<feature name="id" value="53"/>
+			<feature name="id" value="0x35"/>
 			<dataarea name="rom" size="262144">
-		<!-- verified identical -->
 				<rom name="override (japan).pce" size="262144" crc="b74ec562" sha1="9da08c896e02b67257521b948c2fa5bc55724c0d" offset="000000" />
 			</dataarea>
 		</part>
 	</software>
 
-
-	<!--Pac-Land -->
 	<software name="pacland">
-		<description>Pac-Land (Tourvision PCE bootleg)</description>
+		<description>Pac-Land (TourVision PCE bootleg)</description>
 		<year>1989</year>
-		<publisher>bootleg (Tourvision) / Namco / Namcot</publisher>
+		<publisher>bootleg (TourVision) / Namcot</publisher>
+		<info name="alt_title" value="パックランド"/>
 		<part name="cart" interface="tourvision_cart">
-			<feature name="id" value="16"/>
+			<feature name="id" value="0x10"/>
 			<dataarea name="rom" size="262144">
-		<!-- verified identical -->
 				<rom name="pac-land (japan).pce" size="262144" crc="14fad3ba" sha1="fc0166da82ed3cf4a4e06fc6c73fd3184ba8bb3b" offset="000000" />
 			</dataarea>
 		</part>
 	</software>
 
-
-	<!--PC Genjin Punkic Cyborg -->
 	<software name="pcdenj">
-		<description>PC Denjin Punkic Cyborg (Tourvision PCE bootleg)</description>
+		<description>PC Denjin - Punkic Cyborg (TourVision PCE bootleg)</description>
 		<year>1992</year>
-		<publisher>bootleg (Tourvision) / Hudson Soft / Red</publisher>
+		<publisher>bootleg (TourVision) / Hudson</publisher>
+		<info name="alt_title" value="PC電人 PUNKIC CYBORGS"/>
 		<part name="cart" interface="tourvision_cart">
-			<feature name="id" value="201"/>
+			<feature name="id" value="0xc9"/>
 			<dataarea name="rom" size="524288">
-		<!-- verified identical -->
 				<rom name="pc denjin - punkic cyborgs (japan).pce" size="524288" crc="740491c2" sha1="7713236070c2d5252faa651b6a8b7726cadb9bf4" offset="000000" />
 			</dataarea>
 		</part>
 	</software>
 
-
-	<!--PC Genjin - Pithecanthropus Computerurus -->
 	<software name="pcgenj">
-		<description>PC Genjin - Pithecanthropus Computerurus (Tourvision PCE bootleg)</description>
+		<description>PC Genjin - Pithecanthropus Computerurus (TourVision PCE bootleg)</description>
 		<year>1989</year>
-		<publisher>bootleg (Tourvision) / Hudson</publisher>
+		<publisher>bootleg (TourVision) / Hudson</publisher>
+		<info name="alt_title" value="PC原人"/>
 		<part name="cart" interface="tourvision_cart">
-			<feature name="id" value="8"/>
+			<feature name="id" value="0x08"/>
 			<dataarea name="rom" size="1048576">
+		<!-- NOT identical to the set in the PCE list, left unsplitted for reference -->
 				<rom name="pc_genjin.bin" size="1048576" crc="eecd176f" sha1="b24e7501e0aa9e8ba8759f9bb32452f42d7688cd" offset="000000" />
 			</dataarea>
 		</part>
 	</software>
 
-
-	<!--PC Genjin 2 - Hudson -->
 	<software name="pcgenj2">
-		<description>PC Genjin 2 - Pithecanthropus Computerurus (Tourvision PCE bootleg)</description>
+		<description>PC Genjin 2 - Pithecanthropus Computerurus (TourVision PCE bootleg)</description>
 		<year>1991</year>
-		<publisher>bootleg (Tourvision) / Hudson Soft / Red</publisher>
+		<publisher>bootleg (TourVision) / Hudson</publisher>
+		<info name="alt_title" value="PC原人2"/>
 		<part name="cart" interface="tourvision_cart">
-			<feature name="id" value="84"/>
+			<feature name="id" value="0x54"/>
 			<dataarea name="rom" size="524288">
-		<!-- verified identical -->
 				<rom name="pc genjin 2 - pithecanthropus computerurus (japan).pce" size="524288" crc="3028f7ca" sha1="ef2b10e9bd35428bff3d67b9f77dd3ff50d91f2e" offset="000000" />
 			</dataarea>
 		</part>
 	</software>
 
-
-	<!--Power Drift -->
 	<software name="pdrift">
-		<description>Power Drift (Tourvision PCE bootleg)</description>
+		<description>Power Drift (TourVision PCE bootleg)</description>
 		<year>1990</year>
-		<publisher>bootleg (Tourvision) / Sega / Asmik Corporation</publisher>
+		<publisher>bootleg (TourVision) / Asmik</publisher>
+		<info name="alt_title" value="パワードリフト"/>
 		<part name="cart" interface="tourvision_cart">
-			<feature name="id" value="200"/>
+			<feature name="id" value="0xc8"/>
 			<dataarea name="rom" size="524288">
-		<!-- verified identical -->
 				<rom name="power drift (japan).pce" size="524288" crc="25e0f6e9" sha1="1ffe1111a570b0cca256a356965fd6cdf7bcf2e9" offset="000000" />
 			</dataarea>
 		</part>
 	</software>
 
-
-	<!--Power 11 - Hudson -->
 	<software name="power11">
-		<description>Power Eleven (Tourvision PCE bootleg)</description>
+		<description>Power Eleven (TourVision PCE bootleg)</description>
 		<year>1991</year>
-		<publisher>bootleg (Tourvision) / Hudson Soft</publisher>
+		<publisher>bootleg (TourVision) / Hudson</publisher>
+		<info name="alt_title" value="パワーイレブン"/>
 		<part name="cart" interface="tourvision_cart">
-			<feature name="id" value="83"/>
+			<feature name="id" value="0x53"/>
 			<dataarea name="rom" size="393216">
-		<!-- verified identical -->
 				<rom name="power eleven (japan).pce" size="393216" crc="3e647d8b" sha1="f132948117d3135ec8d5d74eaac8d965e6676fb4" offset="000000" />
 			</dataarea>
 		</part>
 	</software>
 
-
-	<!--
-	Power League IV - Hudson
-	Notes:
-	-1st and 2nd halfs are identical, left unsplit for reference.
-	-Cart's A19 line seems not connected to anything.
-	-CRC of split ROM ("30cc3563") matches the common PC Engine Hu-Card ROM dump.
-	-->
 	<software name="pleag4">
-		<description>Power League IV (Tourvision PCE bootleg)</description>
+		<description>Power League IV (TourVision PCE bootleg)</description>
 		<year>1991</year>
-		<publisher>bootleg (Tourvision) / Hudson Soft</publisher>
+		<publisher>bootleg (TourVision) / Hudson</publisher>
+		<info name="alt_title" value="パワーリーグ4"/>
 		<part name="cart" interface="tourvision_cart">
-			<feature name="id" value="-1"/>
+			<feature name="id" value="0xff"/>
 			<dataarea name="rom" size="524288">
-		<!-- verified identical -->
 				<rom name="power league iv (japan).pce" size="524288" crc="30cc3563" sha1="a21825a19bef0a4d7847f72b4a00acd74a53ebb8" offset="000000" />
 			</dataarea>
 		</part>
 	</software>
 
-
-	<!--Power Sports -->
 	<software name="psports">
-		<description>Power Sports (Tourvision PCE bootleg)</description>
+		<description>Power Sports (TourVision PCE bootleg)</description>
 		<year>1992</year>
-		<publisher>bootleg (Tourvision) / Hudson</publisher>
+		<publisher>bootleg (TourVision) / Hudson</publisher>
+		<info name="alt_title" value="パワースポーツ"/>
 		<part name="cart" interface="tourvision_cart">
-			<feature name="id" value="199"/>
-			<dataarea name="rom" size="1048576">
-		<!-- 0x80000 matches PCE psports -->
-				<rom name="power_sports.bin" size="1048576" crc="6e38b029" sha1="17d70f2bb0bb1d13dc4b5a9f1605e69707e9335d" offset="000000" />
+			<feature name="id" value="0xc7"/>
+			<dataarea name="rom" size="524288">
+				<rom name="power sports (japan).pce" size="524288" crc="29eec024" sha1="dfb30bc069e97c72f051fc0ab237607187d4a52e" offset="000000" />
 			</dataarea>
 		</part>
 	</software>
 
-
-	<!--Power Tennis -->
 	<software name="ptennis" supported="partial">
-		<description>Power Tennis (Tourvision PCE bootleg)</description>
+		<description>Power Tennis (TourVision PCE bootleg)</description>
 		<year>1993</year>
-		<publisher>bootleg (Tourvision) / Hudson Soft</publisher>
+		<publisher>bootleg (TourVision) / Hudson</publisher>
+		<info name="alt_title" value="パワーテニス"/>
 		<part name="cart" interface="tourvision_cart">
-			<feature name="id" value="183"/>
-			<dataarea name="rom" size="1048576">
-		<!-- 0x80000 matches PCE ptennis -->
-				<rom name="power_tennis.bin" size="1048576" crc="dd67515a" sha1="968b7066286ec6f055aa8a21c8e65439ebd9d7ad" offset="000000" />
+			<feature name="id" value="0xb7"/>
+			<dataarea name="rom" size="524288">
+				<rom name="power tennis (japan).pce" size="524288" crc="8def5aa1" sha1="eef562022a9399586dd4278d7877e408c19b47dd" offset="000000" />
 			</dataarea>
 		</part>
 	</software>
 
-
-	<!--Pro Yakyuu World Stadium '91 -->
 	<software name="proyak91">
-		<description>Pro Yakyuu World Stadium '91 (Tourvision PCE bootleg)</description>
+		<description>Pro Yakyuu World Stadium '91 (TourVision PCE bootleg)</description>
 		<year>1991</year>
-		<publisher>bootleg (Tourvision) / Namco / Namcot</publisher>
+		<publisher>bootleg (TourVision) / Namcot</publisher>
+                <info name="alt_title" value="プロ野球 ワールドスタジアム'91"/>
 		<part name="cart" interface="tourvision_cart">
-			<feature name="id" value="192"/>
+			<feature name="id" value="0xc0"/>
 			<dataarea name="rom" size="262144">
-		<!-- verified identical -->
 				<rom name="pro yakyuu world stadium '91 (japan).pce" size="262144" crc="66b167a9" sha1="6b76e9cc10a812c15631450b617ea3719fdcdc16" offset="000000" />
 			</dataarea>
 		</part>
 	</software>
 
-
-	<!--Psycho Chaser -->
 	<software name="psychas">
-		<description>Psycho Chaser (Tourvision PCE bootleg)</description>
+		<description>Psycho Chaser (TourVision PCE bootleg)</description>
 		<year>1990</year>
-		<publisher>bootleg (Tourvision) / Naxat Soft</publisher>
+		<publisher>bootleg (TourVision) / Naxat</publisher>
+		<info name="alt_title" value="サイコチェイサー"/>
 		<part name="cart" interface="tourvision_cart">
-			<feature name="id" value="14"/>
+			<feature name="id" value="0x0e"/>
 			<dataarea name="rom" size="262144">
-		<!-- verified identical -->
 				<rom name="psycho chaser (japan).pce" size="262144" crc="03883ee8" sha1="753fc6f1aa16770c87cc12967a43e951a7b1ec83" offset="000000" />
 			</dataarea>
 		</part>
 	</software>
 
-
-	<!--Puzzle Boy -->
 	<software name="puzzlboy">
-		<description>Puzzle Boy (Tourvision PCE bootleg)</description>
+		<description>Puzzle Boy (TourVision PCE bootleg)</description>
 		<year>1991</year>
-		<publisher>bootleg (Tourvision) / Atlus / Telenet Japan</publisher>
+		<publisher>bootleg (TourVision) / Nihon Telenet</publisher>
+                <info name="alt_title" value="パズルボーイ"/>
 		<part name="cart" interface="tourvision_cart">
-			<feature name="id" value="57"/>
+			<feature name="id" value="0x39"/>
 			<dataarea name="rom" size="262144">
-		<!-- verified identical -->
 				<rom name="puzzle boy (japan).pce" size="262144" crc="faa6e187" sha1="f3d87e780683cd1873287069f4758581bb848935" offset="000000" />
 			</dataarea>
 		</part>
 	</software>
 
-
-	<!--Puzznic -->
 	<software name="puzznic">
-		<description>Puzznic (Tourvision PCE bootleg)</description>
+		<description>Puzznic (TourVision PCE bootleg)</description>
 		<year>1990</year>
-		<publisher>bootleg (Tourvision) / Taito</publisher>
+		<publisher>bootleg (TourVision) / Taito</publisher>
+                <info name="alt_title" value="パズニック"/>
 		<part name="cart" interface="tourvision_cart">
-			<feature name="id" value="69"/>
-			<dataarea name="rom" size="1048576">
+			<feature name="id" value="0x45"/>
+			<dataarea name="rom" size="262144">
 		<!-- 0x40000 matches PCE puzznic -->
-				<rom name="puzznic.bin" size="1048576" crc="1e73808a" sha1="fa7f56426aad9b05dea0df4ddd78c2cb0fa399aa" offset="000000" />
+				<rom name="puzznic (japan).pce" size="262144" crc="965c95b3" sha1="3906d644f5901e6d2e732cbd0a6dd0d38a29486b" offset="000000" />
 			</dataarea>
 		</part>
 	</software>
 
-
-	<!--Raiden -->
 	<software name="raiden">
-		<description>Raiden (Tourvision PCE bootleg)</description>
+		<description>Raiden (TourVision PCE bootleg)</description>
 		<year>1991</year>
-		<publisher>bootleg (Tourvision) / Seibu Kaihatsu inc / Hudson Soft</publisher>
+		<publisher>bootleg (TourVision) / Hudson</publisher>
+		<info name="alt_title" value="雷電"/>
 		<part name="cart" interface="tourvision_cart">
-			<feature name="id" value="111"/>
+			<feature name="id" value="0x6f"/>
 			<dataarea name="rom" size="786432">
-		<!-- verified identical -->
 				<rom name="raiden (japan).pce" size="786432" crc="850829f2" sha1="cef25446294884053442a4214434d7d97319ddca" offset="000000" />
 			</dataarea>
 		</part>
 	</software>
 
-
-	<!--
-	Rastan Saga II Tourvision cart - Taito
-	Notes:
-	-Cart's A18 line seems not connected to anything.
-	-->
 	<software name="rastan2">
-		<description>Rastan Saga II (Tourvision PCE bootleg)</description>
+		<description>Rastan Saga II (TourVision PCE bootleg)</description>
 		<year>1990</year>
-		<publisher>bootleg (Tourvision) / Taito Corporation</publisher>
+		<publisher>bootleg (TourVision) / Taito</publisher>
+		<info name="alt_title" value="ラスタン・サーガII"/>
 		<part name="cart" interface="tourvision_cart">
-			<feature name="id" value="33"/>
+			<feature name="id" value="0x21"/>
 			<dataarea name="rom" size="393216">
-		<!-- verified identical -->
 				<rom name="rastan saga ii (japan).pce" size="393216" crc="00c38e69" sha1="cf06ba4d1bd31ebd69f0415ae52848f752ec8f6b" offset="000000" />
 			</dataarea>
 		</part>
 	</software>
 
-
-	<!--R-Type II -->
 	<software name="rtypep2a">
-		<description>R-Type II (hack, no copyright string) (Tourvision PCE bootleg)</description>
+		<description>R-Type II (hack, no copyright string) (TourVision PCE bootleg)</description>
 		<year>1991</year>
-		<publisher>bootleg (Tourvision) / IREM Corp</publisher>
+		<publisher>bootleg (TourVision) / IREM Corp</publisher>
 		<part name="cart" interface="tourvision_cart">
-			<feature name="id" value="61"/>
+			<feature name="id" value="0x3d"/>
 			<dataarea name="rom" size="262144">
-		<!-- NOT identical to pce list, copyright strings have been erased -->
+		<!-- NOT identical to the set in the PCE list, copyright strings have been erased -->
 				<rom name="tourv_r-type_ii_hacked.pce" size="262144" crc="ae65fe80" sha1="1a6c6f5bd017f23ab9d00a9385986ddf498f9a82" offset="000000" />
 			</dataarea>
 		</part>
 	</software>
 
-
-	<!--Saiga No Nindou - Ninja Spirit -->
-	<software name="saigonin">
-		<description>Saigo no Nindou - Ninja Spirit (Tourvision PCE bootleg)</description>
+	<software name="sdragon">
+		<description>Tenseiryuu - Saint Dragon (TourVision PCE bootleg)</description>
 		<year>1990</year>
-		<publisher>bootleg (Tourvision) / IREM Corp</publisher>
+		<publisher>bootleg (TourVision) / Irem</publisher>
+		<info name="alt_title" value="天聖龍"/>
 		<part name="cart" interface="tourvision_cart">
-			<feature name="id" value="44"/>
+			<feature name="id" value="0x24"/>
+			<dataarea name="rom" size="1048576">
+		<!-- NOT identical to the set in the PCE list, left unsplitted for reference -->
+				<rom name="saint_dragon.bin" size="1048576" crc="492231a9" sha1="b8bfd18bde2398b07a693c86d21a14cd9627f0c8" offset="000000" />
+			</dataarea>
+		</part>
+	</software>
+
+	<software name="saigonin">
+		<description>Saigo no Nindou - Ninja Spirit (TourVision PCE bootleg)</description>
+		<year>1990</year>
+		<publisher>bootleg (TourVision) / Irem</publisher>
+		<info name="alt_title" value="最後の忍道 NINJA SPIRIT"/>
+		<part name="cart" interface="tourvision_cart">
+			<feature name="id" value="0x2c"/>
 			<dataarea name="rom" size="524288">
-		<!-- verified identical -->
 				<rom name="saigo no nindou - ninja spirit (japan).pce" size="524288" crc="0590a156" sha1="14fc48758d658413f952a0b4f9465137164bdacc" offset="000000" />
 			</dataarea>
 		</part>
 	</software>
 
-
-	<!--Salamander -->
 	<software name="salamand">
-		<description>Salamander (Tourvision PCE bootleg)</description>
+		<description>Salamander (TourVision PCE bootleg)</description>
 		<year>1991</year>
-		<publisher>bootleg (Tourvision) / Konami</publisher>
+		<publisher>bootleg (TourVision) / Konami</publisher>
+		<info name="alt_title" value="沙羅曼蛇"/>
 		<part name="cart" interface="tourvision_cart">
-			<feature name="id" value="184"/>
+			<feature name="id" value="0xb8"/>
 			<dataarea name="rom" size="262144">
-		<!-- verified identical -->
 				<rom name="salamander (japan).pce" size="262144" crc="faecce20" sha1="a24e3a4ff36ec9fffd5ea1f4c6b526f61f842584" offset="000000" />
 			</dataarea>
 		</part>
 	</software>
 
-
-	<!--Shinobi -->
 	<software name="shinobi">
-		<description>Shinobi (Tourvision PCE bootleg)</description>
+		<description>Shinobi (TourVision PCE bootleg)</description>
 		<year>1989</year>
-		<publisher>bootleg (Tourvision) / Sega / Asmik Corporation</publisher>
+		<publisher>bootleg (TourVision) / Asmik</publisher>
+		<info name="alt_title" value="忍"/>
 		<part name="cart" interface="tourvision_cart">
-			<feature name="id" value="5"/>
+			<feature name="id" value="0x05"/>
 			<dataarea name="rom" size="393216">
-		<!-- verified identical -->
 				<rom name="shinobi (japan).pce" size="393216" crc="bc655cf3" sha1="c219f8477dc2b34b53c25a419332595835d1f5ec" offset="000000" />
 			</dataarea>
 		</part>
 	</software>
 
-
-	<!--Side arms -->
 	<software name="sidearms">
-		<description>Side Arms (Tourvision PCE bootleg)</description>
+		<description>Side Arms - Hyper Dyne (TourVision PCE bootleg)</description>
 		<year>1989</year>
-		<publisher>bootleg (Tourvision) / Capcom / Nec Avenue</publisher>
+		<publisher>bootleg (TourVision) / NEC</publisher>
+		<info name="alt_title" value="サイドアーム"/>
 		<part name="cart" interface="tourvision_cart">
-			<feature name="id" value="2"/>
+			<feature name="id" value="0x02"/>
 			<dataarea name="rom" size="262144">
-		<!-- verified identical -->
 				<rom name="sidearms - hyper dyne (japan).pce" size="262144" crc="e5e7b8b7" sha1="b732b3485bd8841d3571221170b04b7f699e9109" offset="000000" />
 			</dataarea>
 		</part>
 	</software>
 
-
-	<!--Skweek -->
 	<software name="skweek">
-		<description>Skweek (Tourvision PCE bootleg)</description>
+		<description>Skweek (TourVision PCE bootleg)</description>
 		<year>1991</year>
-		<publisher>bootleg (Tourvision) / Victor Musical Industries, Inc.</publisher>
+		<publisher>bootleg (TourVision) / Victor Interactive Software</publisher>
+		<info name="alt_title" value="スクウィーク"/>
 		<part name="cart" interface="tourvision_cart">
-			<feature name="id" value="89"/>
+			<feature name="id" value="0x59"/>
 			<dataarea name="rom" size="262144">
-		<!-- verified identical -->
 				<rom name="skweek (japan).pce" size="262144" crc="4d539c9f" sha1="3436b48a9c748269f6ae65e40c9115a27321d440" offset="000000" />
 			</dataarea>
 		</part>
 	</software>
 
-
-	<!--Sokoban World -->
 	<software name="sokoban">
-		<description>Sokoban World (Tourvision PCE bootleg)</description>
+		<description>Sokoban World (TourVision PCE bootleg)</description>
 		<year>1990</year>
-		<publisher>bootleg (Tourvision) / Media Rings Corp.</publisher>
+		<publisher>bootleg (TourVision) / Media Rings Corporation</publisher>
+		<info name="alt_title" value="倉庫番ワールド"/>
 		<part name="cart" interface="tourvision_cart">
-			<feature name="id" value="66"/>
-			<dataarea name="rom" size="1048576">
-		<!-- 0x20000 matches PCE sokoban -->
-				<rom name="sokoban_world.bin" size="1048576" crc="97e966ec" sha1="3002c88d776849ed065d142458048d390140ed96" offset="000000" />
+			<feature name="id" value="0x42"/>
+			<dataarea name="rom" size="131072">
+				<rom name="soukoban world (japan).pce" size="131072" crc="fb37ddc4" sha1="89899202fe2a7607f9e5f2ab1b29280f3d7d5aef" offset="000000" />
 			</dataarea>
 		</part>
 	</software>
 
-
-	<!--Soldier Blade -->
 	<software name="soldblad">
-		<description>Soldier Blade  (Tourvision PCE bootleg)</description>
+		<description>Soldier Blade  (TourVision PCE bootleg)</description>
 		<year>1992</year>
-		<publisher>bootleg (Tourvision) / Hudson Soft</publisher>
+		<publisher>bootleg (TourVision) / Hudson</publisher>
+		<info name="alt_title" value="ソルジャーブレイド"/>
 		<part name="cart" interface="tourvision_cart">
-			<feature name="id" value="23"/>
-			<dataarea name="rom" size="1048576">
-		<!-- 0x80000 matches PCE soldblad -->
-				<rom name="soldier_blade.bin" size="1048576" crc="99d53041" sha1="51c02df6d9666459a0f7cfdcd84b29e3be856460" offset="000000" />
+			<feature name="id" value="0x17"/>
+			<dataarea name="rom" size="524288">
+				<rom name="soldier blade (japan).pce" size="524288" crc="8420b12b" sha1="bb6259ecfee3cc28ddbf1b1c1416f281ecccbe31" offset="000000" />
 			</dataarea>
 		</part>
 	</software>
 
-
-	<!--Son Son II -->
 	<software name="sonson2">
-		<description>Son Son II (Tourvision PCE bootleg)</description>
+		<description>Son Son II (TourVision PCE bootleg)</description>
 		<year>1989</year>
-		<publisher>bootleg (Tourvision) / Capcom / Nec Avenue</publisher>
+		<publisher>bootleg (TourVision) / NEC</publisher>
+		<info name="alt_title" value="ソンソンII"/>
 		<part name="cart" interface="tourvision_cart">
-			<feature name="id" value="80"/>
+			<feature name="id" value="0x50"/>
 			<dataarea name="rom" size="262144">
-		<!-- verified identical -->
 				<rom name="son son ii (japan).pce" size="262144" crc="d7921df2" sha1="51aa9b47aa5f68102989885a1b92bb6b563ffe3a" offset="000000" />
 			</dataarea>
 		</part>
 	</software>
 
-
-	<!--
-	Special Criminal Investigation (SCI) - Taito
-	Notes:
-	-1st and 2nd halfs are identical, left unsplit for reference.
-	-Cart's A19 line seems not connected to anything.
-	-CRC of split ROM ("09a0bfcc") matches the common English language PC Engine Hu-Card ROM dump.
-	-->
 	<software name="sci">
-		<description>Special Criminal Investigation (Tourvision PCE bootleg)</description>
+		<description>Special Criminal Investigation (TourVision PCE bootleg)</description>
 		<year>1991</year>
-		<publisher>bootleg (Tourvision) / Taito Corporation</publisher>
+		<publisher>bootleg (TourVision) / Taito</publisher>
 		<part name="cart" interface="tourvision_cart">
-			<feature name="id" value="58"/>
+			<feature name="id" value="0x3a"/>
 			<dataarea name="rom" size="524288">
-		<!-- verified identical -->
 				<rom name="special criminal investigation (japan).pce" size="524288" crc="09a0bfcc" sha1="8d18aea811d752d24cc00f20d2c6ced67df1efa9" offset="000000" />
 			</dataarea>
 		</part>
 	</software>
 
-
-	<!--Spin Pair -->
 	<software name="spinpair">
-		<description>Spin Pair (Tourvision PCE bootleg)</description>
+		<description>Spin Pair (TourVision PCE bootleg)</description>
 		<year>1990</year>
-		<publisher>bootleg (Tourvision) / Hudson Soft</publisher>
+		<publisher>bootleg (TourVision) / Media Rings Corporation</publisher>
+		<info name="alt_title" value="スピンペア"/>
 		<part name="cart" interface="tourvision_cart">
-			<feature name="id" value="50"/>
-			<dataarea name="rom" size="1048576">
-		<!-- 0x40000 matches PCE spinpair -->
-				<rom name="spin_pair.bin" size="1048576" crc="a2d2d0a1" sha1="4590e9c46c830d051a04efb40088fbb99109402c" offset="000000" />
+			<feature name="id" value="0x32"/>
+			<dataarea name="rom" size="262144">
+				<rom name="spin pair (japan).pce" size="262144" crc="1c6ff459" sha1="a903a3e3a55b1fd9064efa668bcea53055c12682" offset="000000" />
 			</dataarea>
 		</part>
 	</software>
 
-	<!--Splatterhouse -->
 	<software name="splatth">
-		<description>Splatterhouse (Tourvision PCE bootleg)</description>
+		<description>Splatterhouse (TourVision PCE bootleg)</description>
 		<year>1990</year>
-		<publisher>bootleg (Tourvision) / Namcot</publisher>
+		<publisher>bootleg (TourVision) / Namcot</publisher>
+		<info name="alt_title" value="スプラッターハウス"/>
 		<part name="cart" interface="tourvision_cart">
-			<feature name="id" value="148"/>
-			<dataarea name="rom" size="1048576">
-				<rom name="splatterhouse.bin" size="1048576" crc="be8e8c4c" sha1="f8a65d95a68735e7549838c845befcf07483876c" offset="000000" />
+			<feature name="id" value="0x94"/>
+			<dataarea name="rom" size="524288">
+				<rom name="splatterhouse (japan).pce" size="524288" crc="6b319457" sha1="b0bdbb7729d775496581dc3141c4447614aaac46" offset="000000" />
 			</dataarea>
 		</part>
 	</software>
 
-	<!--Super Star Soldier - Hudson / Kaneko -->
 	<software name="sssoldr">
-		<description>Super Star Soldier (Tourvision PCE bootleg)</description>
+		<description>Super Star Soldier (TourVision PCE bootleg)</description>
 		<year>1990</year>
-		<publisher>bootleg (Tourvision) / Inter State / Kaneko / Hudson Soft</publisher>
+		<publisher>bootleg (TourVision) / Hudson</publisher>
+		<info name="alt_title" value="スーパースターソルジャー"/>
 		<part name="cart" interface="tourvision_cart">
-			<feature name="id" value="42"/>
+			<feature name="id" value="0x2a"/>
 			<dataarea name="rom" size="524288">
-		<!-- verified identical -->
 				<rom name="super star soldier (japan).pce" size="524288" crc="5d0e3105" sha1="4220516a17bc32a3f68ed51ef2af63e496e79f7d" offset="000000" />
 			</dataarea>
 		</part>
 	</software>
 
 
-	<!--Super Volley ball - Video System -->
 	<software name="svolley">
-		<description>Super Volley ball (Tourvision PCE bootleg)</description>
+		<description>Super Volley ball (TourVision PCE bootleg)</description>
 		<year>1990</year>
-		<publisher>bootleg (Tourvision) / Video System</publisher>
+		<publisher>bootleg (TourVision) / Video System</publisher>
+		<info name="alt_title" value="スーパーバレーボール"/>
 		<part name="cart" interface="tourvision_cart">
-			<feature name="id" value="9"/>
+			<feature name="id" value="0x09"/>
 			<dataarea name="rom" size="262144">
-		<!-- verified identical -->
-		<!-- 1MB Original Dump - super_volley_ball.bin - 8a32a1ca - 80144fb4035415eb9b2c67d78d55757ed0d641a1 -->
 				<rom name="super volleyball (japan).pce" size="262144" crc="ce2e4f9f" sha1="46dd4acebe25de38f28e56cf149b24b42f3aef31" offset="000000" />
 			</dataarea>
 		</part>
 	</software>
 
-
-	<!--Tatsujin -->
 	<software name="tatsujin">
-		<description>Tatsujin (Tourvision PCE bootleg)</description>
+		<description>Tatsujin (TourVision PCE bootleg)</description>
 		<year>1992</year>
-		<publisher>bootleg (Tourvision) / Toaplan Co Ltd / Taito Corporation</publisher>
+		<publisher>bootleg (TourVision) / Taito</publisher>
+		<info name="alt_title" value="タツジン"/>
 		<part name="cart" interface="tourvision_cart">
-			<feature name="id" value="31"/>
+			<feature name="id" value="0x1f"/>
 			<dataarea name="rom" size="524288">
-		<!-- verified identical -->
 				<rom name="tatsujin (japan).pce" size="524288" crc="a6088275" sha1="dda768075fbf8c0624e2c1f217b1092513b1c942" offset="000000" />
 			</dataarea>
 		</part>
 	</software>
 
-	<software name="sdragon">
-		<description>Tenseiryuu - Saint Dragon (Tourvision PCE bootleg)</description>
-		<year>1990</year>
-		<publisher>bootleg (Tourvision) / Irem</publisher>
-		<part name="cart" interface="tourvision_cart">
-			<feature name="id" value="36"/>
-			<dataarea name="rom" size="1048576">
-				<rom name="saint_dragon.bin" size="1048576" crc="492231a9" sha1="b8bfd18bde2398b07a693c86d21a14cd9627f0c8" offset="000000" />
-			</dataarea>
-		</part>
-	</software>
-
-	<!--Terra Cresta II -->
 	<software name="terracr2">
-		<description>Terra Cresta II (Tourvision PCE bootleg)</description>
+		<description>Terra Cresta II (TourVision PCE bootleg)</description>
 		<year>1992</year>
-		<publisher>bootleg (Tourvision) / Nichibutsu / Nihon Bussan Co., Ltd</publisher>
+		<publisher>bootleg (TourVision) / Nihon Bussan</publisher>
+		<info name="alt_title" value="テラクレスタII マンドラーの逆襲"/>
 		<part name="cart" interface="tourvision_cart">
-			<feature name="id" value="27"/>
+			<feature name="id" value="0x1b"/>
 			<dataarea name="rom" size="524288">
-		<!-- verified identical -->
 				<rom name="terra cresta ii - mandoraa no gyakushuu (japan).pce" size="524288" crc="1b2d0077" sha1="c58d3ea8df6cb518349d431d6b3d6fd2c14898ec" offset="000000" />
 			</dataarea>
 		</part>
 	</software>
 
-
-	<!--The NewZealand Story -->
 	<software name="tnzs">
-		<description>The NewZealand Story (Tourvision PCE bootleg)</description>
+		<description>The NewZealand Story (TourVision PCE bootleg)</description>
 		<year>1990</year>
-		<publisher>bootleg (Tourvision) / Taito</publisher>
+		<publisher>bootleg (TourVision) / Taito</publisher>
+		<info name="alt_title" value="ニュージーランドストーリー"/>
 		<part name="cart" interface="tourvision_cart">
-			<feature name="id" value="11"/>
+			<feature name="id" value="0x0b"/>
 			<dataarea name="rom" size="1048576">
-		<!-- 0x40000 matches PCE tnzs -->
+		<!-- NOT identical to the set in the PCE list, left unsplitted for reference -->
 				<rom name="the_newzealand_story.bin" size="1048576" crc="53b25bf6" sha1="5f04cdbd37df84d20692d05f72fb4e28f0d3f79d" offset="000000" />
 			</dataarea>
 		</part>
 	</software>
 
-
-	<!--
-	Thunder Blade Tourvision cart - Sega / NEC Avenue
-	Notes:
-	-1st and 2nd halfs are identical, left unsplit for reference.
-	-Cart's A19 line seems not connected to anything.
-	-CRC of split ROM ("DDC3E809") matches the common PC Engine Hu-Card ROM dump.
-	-->
 	<software name="tblade">
-		<description>Thunder Blade (Tourvision PCE bootleg)</description>
+		<description>Thunder Blade (TourVision PCE bootleg)</description>
 		<year>1990</year>
-		<publisher>bootleg (Tourvision) / Sega / NEC Avenue</publisher>
+		<publisher>bootleg (TourVision) / NEC Avenue</publisher>
+		<info name="alt_title" value="サンダーブレード"/>
 		<part name="cart" interface="tourvision_cart">
-			<feature name="id" value="34"/>
+			<feature name="id" value="0x22"/>
 			<dataarea name="rom" size="524288">
-		<!-- verified identical -->
 				<rom name="thunder blade (japan).pce" size="524288" crc="ddc3e809" sha1="553f8026dd68e85cd17855adbf920b3971acfdc4" offset="000000" />
 			</dataarea>
 		</part>
 	</software>
 
-
-	<!--Toilet Kids -->
-	<software name="toiletk">
-		<description>Toilet Kids (Tourvision PCE bootleg)</description>
-		<year>1992</year>
-		<publisher>bootleg (Tourvision) / Media Rings Corporation</publisher>
+	<software name="timcrus2">
+		<description>Time Cruise II (TourVision PCE bootleg)</description>
+		<year>1991</year>
+		<publisher>bootleg (TourVision) / Face</publisher>
+		<info name="alt_title" value="タイムクルーズII"/>
 		<part name="cart" interface="tourvision_cart">
-			<feature name="id" value="196"/>
-			<dataarea name="rom" size="1048576">
-		<!-- 0x80000 matches PCE toiletk -->
-				<rom name="toilet_kids.tv" size="1048576" crc="662a8960" sha1="4ecba190795ddb94eae2eaea1c18e782a3c45fda" offset="000000" />
+			<feature name="id" value="0x2a"/>
+			<dataarea name="rom" size="524288">
+				<rom name="time cruise ii (japan).pce" size="524288" crc="cfec1d6a" sha1="84bf83124a77ff67aaa0ea3f34ad9edbb755454d" offset="000000" />
 			</dataarea>
 		</part>
 	</software>
 
-
-	<!--Tora e no Michi (Tiger Road) -->
-	<software name="toramich">
-		<description>Tora e no Michi (Tourvision PCE bootleg)</description>
-		<year>1990</year>
-		<publisher>bootleg (Tourvision) / Victor Entertainment</publisher>
+	<software name="toiletk">
+		<description>Toilet Kids (TourVision PCE bootleg)</description>
+		<year>1992</year>
+		<publisher>bootleg (TourVision) / Media Rings Corporation</publisher>
+		<info name="alt_title" value="トイレキッズ"/>
 		<part name="cart" interface="tourvision_cart">
-			<feature name="id" value="10"/>
+			<feature name="id" value="0xc4"/>
+			<dataarea name="rom" size="524288">
+				<rom name="toilet kids (japan).pce" size="524288" crc="53b7784b" sha1="1148ec489899928592212ceac61c83cbc67751cb" offset="000000" />
+			</dataarea>
+		</part>
+	</software>
+
+	<!--Tiger Road -->
+	<software name="toramich">
+		<description>Tora e no Michi (TourVision PCE bootleg)</description>
+		<year>1990</year>
+		<publisher>bootleg (TourVision) / Victor Entertainment</publisher>
+		<info name="alt_title" value="虎への道"/>
+		<part name="cart" interface="tourvision_cart">
+			<feature name="id" value="0x0a"/>
 			<dataarea name="rom" size="1048576">
+		<!-- NOT identical to the set in the PCE list, left unsplitted for reference -->
 				<rom name="tiger_road.bin" size="1048576" crc="5e55f35c" sha1="942c8e9e8923acf7ef2ba8878879251621e48408" offset="000000" />
 			</dataarea>
 		</part>
 	</software>
 
-
-	<!--Toy Shop Boys -->
 	<software name="toyshopb">
-		<description>Toy Shop Boys (Tourvision PCE bootleg)</description>
+		<description>Toy Shop Boys (TourVision PCE bootleg)</description>
 		<year>1990</year>
-		<publisher>bootleg (Tourvision) / Victor Musical Industries, Inc.</publisher>
+		<publisher>bootleg (TourVision) / Victor Musical Industries, Inc.</publisher>
+		<info name="alt_title" value="トイ・ショップ・ボーイズ"/>
 		<part name="cart" interface="tourvision_cart">
-			<feature name="id" value="51"/>
+			<feature name="id" value="0x33"/>
 			<dataarea name="rom" size="262144">
-		<!-- verified identical -->
 				<rom name="toy shop boys (japan).pce" size="262144" crc="97c5ee9a" sha1="d552223399ff54c3664a5a06fc620ffb717cea57" offset="000000" />
 			</dataarea>
 		</part>
 	</software>
 
-
-	<!--Tricky -->
 	<software name="tricky">
-		<description>Tricky (Tourvision PCE bootleg)</description>
+		<description>Tricky (TourVision PCE bootleg)</description>
 		<year>1990</year>
-		<publisher>bootleg (Tourvision) / Taito</publisher>
+		<publisher>bootleg (TourVision) / IGS</publisher>
+		<info name="alt_title" value="トリッキー"/>
 		<part name="cart" interface="tourvision_cart">
-			<feature name="id" value="42"/>
-			<dataarea name="rom" size="1048576">
-		<!-- 0x40000 matches PCE tricky -->
-				<rom name="tricky.bin" size="1048576" crc="9fee2fcd" sha1="ed6fb947aa4758b74d584e71d0720dc217c1af41" offset="000000" />
+			<feature name="id" value="0x2a"/>
+			<dataarea name="rom" size="262144">
+				<rom name="tricky (japan).pce" size="262144" crc="3aea2f8f" sha1="009e0ea4203bab968cea3cd9428c633ce2c5c26e" offset="000000" />
 			</dataarea>
 		</part>
 	</software>
 
-
-	<!--
-	USA Pro Basketball - Aicom
-	Notes:
-	-4 identical 256KB parts, left unsplit for reference.
-	-Cart's A19 and A18 lines seems not connected to anything.
-	-CRC of split ROM ("1CAD4B7F") matches the common PC Engine Hu-Card ROM dump.
-	-->
 	<software name="usaprobs">
-		<description>USA Pro Basketball (Tourvision PCE bootleg)</description>
+		<description>USA Pro Basketball (TourVision PCE bootleg)</description>
 		<year>1989</year>
-		<publisher>bootleg (Tourvision) / Aicom Corporation</publisher>
+		<publisher>bootleg (TourVision) / Aicom</publisher>
+		<info name="alt_title" value="USAプロバスケットボール"/>
 		<part name="cart" interface="tourvision_cart">
-			<feature name="id" value="206"/>
+			<feature name="id" value="0xce"/>
 			<dataarea name="rom" size="262144">
-		<!-- verified identical -->
 				<rom name="usa pro basketball (japan).pce" size="262144" crc="1cad4b7f" sha1="62f3e0c56d22c015bea15fe04cd16fae380fefcd" offset="000000" />
 			</dataarea>
 		</part>
 	</software>
 
-
-	<!--Veigues -->
 	<software name="veigues">
-		<description>Veigues - Tactical Gladiator (Tourvision PCE bootleg)</description>
+		<description>Veigues - Tactical Gladiator (TourVision PCE bootleg)</description>
 		<year>1990</year>
-		<publisher>bootleg (Tourvision) / Victor Musical Industries, Inc.</publisher>
+		<publisher>bootleg (TourVision) / Victor Entertainment</publisher>
+		<info name="alt_title" value="ヴェイグスTACTICAL GLADIATOR"/>
 		<part name="cart" interface="tourvision_cart">
-			<feature name="id" value="40"/>
+			<feature name="id" value="0x28"/>
 			<dataarea name="rom" size="393216">
-		<!-- verified identical -->
 				<rom name="veigues - tactical gladiator (japan).pce" size="393216" crc="04188c5c" sha1="da66c085ecbb317cb160cb192142a3d2c044f26f" offset="000000" />
 			</dataarea>
 		</part>
 	</software>
 
-
-	<!--Vigilante -->
 	<software name="vigilant">
-		<description>Vigilante (Tourvision PCE bootleg)</description>
+		<description>Vigilante (TourVision PCE bootleg)</description>
 		<year>1988</year>
-		<publisher>bootleg (Tourvision) / Irem</publisher>
+		<publisher>bootleg (TourVision) / Irem</publisher>
+		<info name="alt_title" value="ビジランテ"/>
 		<part name="cart" interface="tourvision_cart">
-			<feature name="id" value="8"/>
+			<feature name="id" value="0x08"/>
 			<dataarea name="rom" size="1048576">
-		<!-- 0x40000 matches PCE vigilant -->
+		<!-- NOT identical to the set in the PCE list, left unsplitted for reference -->
 				<rom name="vigilante.bin" size="1048576" crc="00eaafcc" sha1="a082ef8ba1ffb9abc8296eadba1e9e70ba7b6812" offset="000000" />
 			</dataarea>
 		</part>
 	</software>
 
-
-	<!--Violent Soldier -->
 	<software name="violents">
-		<description>Violent Soldier (Tourvision PCE bootleg)</description>
+		<description>Violent Soldier (TourVision PCE bootleg)</description>
 		<year>1990</year>
-		<publisher>bootleg (Tourvision) / IGS</publisher>
+		<publisher>bootleg (TourVision) / IGS</publisher>
+		<info name="alt_title" value="バイオレント・ソルジャー"/>
 		<part name="cart" interface="tourvision_cart">
-			<feature name="id" value="-1"/>
+			<feature name="id" value="0xff"/>
 			<dataarea name="rom" size="1048576">
+		<!-- NOT identical to the set in the PCE list, left unsplitted for reference -->
 				<rom name="violent_soldier.bin" size="1048576" crc="66bbea83" sha1="b60d507eb5d5069f0e8a52308a35459b44ee5b9e" offset="000000" />
 			</dataarea>
 		</part>
 	</software>
 
-
-	<!--Volfied - Taito -->
 	<software name="volfied">
-		<description>Volfied (Tourvision PCE bootleg)</description>
+		<description>Volfied (TourVision PCE bootleg)</description>
 		<year>1989</year>
-		<publisher>bootleg (Tourvision) / Taito Corporation</publisher>
+		<publisher>bootleg (TourVision) / Taito</publisher>
+		<info name="alt_title" value="ヴォルフィード"/>
 		<part name="cart" interface="tourvision_cart">
-			<feature name="id" value="68"/>
+			<feature name="id" value="0x44"/>
 			<dataarea name="rom" size="393216">
-		<!-- verified identical -->
 				<rom name="volfied (japan).pce" size="393216" crc="ad226f30" sha1="0ecee557815b93fc37f2f5675c2c01c77ef8569e" offset="000000" />
 			</dataarea>
 		</part>
 	</software>
 
-
-	<!--Majin Eiyuu Den Wataru -->
 	<software name="wataru">
-		<description>Majin Eiyuu Den Wataru (Tourvision PCE bootleg)</description>
+		<description>Majin Eiyuu Den Wataru (TourVision PCE bootleg)</description>
 		<year>1988</year>
-		<publisher>bootleg (Tourvision) / Hudson Soft</publisher>
+		<publisher>bootleg (TourVision) / Hudson</publisher>
+		<info name="alt_title" value="魔神英雄伝ワタル"/>
 		<part name="cart" interface="tourvision_cart">
-			<feature name="id" value="27"/>
-			<dataarea name="rom" size="1048576">
-		<!-- 0x40000 matches PCE wataru -->
-				<rom name="mashin_eiyuden_wataru.tv" size="1048576" crc="13a96308" sha1="03b8bc737c9cc27ec8153ad997515fe211a17b7d" offset="000000" />
+			<feature name="id" value="0x1b"/>
+			<dataarea name="rom" size="262144">
+				<rom name="majin eiyuu den wataru (japan).pce" size="262144" crc="2f8935aa" sha1="59db3e9d69cf34f76b6cb599d6c4fe6999162532" offset="000000" />
 			</dataarea>
 		</part>
 	</software>
 
-
-	<!--Winning Shot -->
 	<software name="winshot">
-		<description>Winning Shot (Tourvision PCE bootleg)</description>
+		<description>Winning Shot (TourVision PCE bootleg)</description>
 		<year>1989</year>
-		<publisher>bootleg (Tourvision) / Data East Corp.</publisher>
+		<publisher>bootleg (TourVision) / Data East</publisher>
+		<info name="alt_title" value="ウィニングショット"/>
 		<part name="cart" interface="tourvision_cart">
-			<feature name="id" value="21"/>
+			<feature name="id" value="0x15"/>
 			<dataarea name="rom" size="262144">
-		<!-- verified identical -->
 				<rom name="winning shot (japan).pce" size="262144" crc="9b5ebc58" sha1="039ff38e6221b4b7722144e85dc7c84873d7efe6" offset="000000" />
 			</dataarea>
 		</part>
 	</software>
 
-
-	<!--World Jockey -->
 	<software name="wjockey">
-		<description>World Jockey (Tourvision PCE bootleg)</description>
+		<description>World Jockey (TourVision PCE bootleg)</description>
 		<year>1991</year>
-		<publisher>bootleg (Tourvision) / Namcot</publisher>
+		<publisher>bootleg (TourVision) / Namcot</publisher>
+		<info name="alt_title" value="ワールドジョッキー"/>
 		<part name="cart" interface="tourvision_cart">
-			<feature name="id" value="202"/>
-			<dataarea name="rom" size="1048576">
-		<!-- 0x40000 matches PCE wjockey -->
-				<rom name="world_jockey.tv" size="1048576" crc="3021c245" sha1="e1301b69effd2c179b59810cd0791f75754b601a" offset="000000" />
+			<feature name="id" value="0xca"/>
+			<dataarea name="rom" size="262144">
+				<rom name="world jockey (japan).pce" size="262144" crc="a9ab2954" sha1="9fdeb0c34ea8b8d2a09aeb476435ef9d92e75573" offset="000000" />
 			</dataarea>
 		</part>
 	</software>
 
-
-	<!--W-Ring -->
 	<software name="wring">
-		<description>W-Ring - The Double Rings (Tourvision PCE bootleg)</description>
+		<description>W-Ring - The Double Rings (TourVision PCE bootleg)</description>
 		<year>1990</year>
-		<publisher>bootleg (Tourvision) / Naxat Soft</publisher>
+		<publisher>bootleg (TourVision) / Naxat</publisher>
+		<info name="alt_title" value="ダブルリング"/>
 		<part name="cart" interface="tourvision_cart">
-			<feature name="id" value="28"/>
+			<feature name="id" value="0x1c"/>
 			<dataarea name="rom" size="393216">
-		<!-- verified identical -->
 				<rom name="w-ring - the double rings (japan).pce" size="393216" crc="be990010" sha1="95d0a95ce9f08da3f096cfdc654ba5dfeb794add" offset="000000" />
 			</dataarea>
 		</part>
 	</software>
 
-
-	<!--Xevious -->
 	<software name="xevious">
-		<description>Xevious (Tourvision PCE bootleg)</description>
+		<description>Xevious - Fardraut Densetsu (TourVision PCE bootleg)</description>
 		<year>1990</year>
-		<publisher>bootleg (Tourvision) / Namco Ltd. / Namcot</publisher>
+		<publisher>bootleg (TourVision) / Namcot</publisher>
+		<info name="alt_title" value="ゼビウスファードラウト伝説"/>
 		<part name="cart" interface="tourvision_cart">
-			<feature name="id" value="-1"/>
+			<feature name="id" value="0xff"/>
 			<dataarea name="rom" size="262144">
-		<!-- verified identical -->
 				<rom name="xevious - fardraut densetsu (japan).pce" size="262144" crc="f8f85eec" sha1="13da0500ace1957d0748b11dfaae68e40e71230e" offset="000000" />
-			</dataarea>
-		</part>
-	</software>
-
-
-	<software name="parasol">
-		<description>Parasol Stars - The Story of Bubble Bobble III (Tourvision PCE bootleg)</description>
-		<year>1991</year>
-		<publisher>bootleg (Tourvision) / Taito</publisher>
-		<part name="cart" interface="tourvision_cart">
-			<feature name="id" value="-1"/>
-			<dataarea name="rom" size="393216">
-		<!-- NOT dumped from an actual Tourvision cart yet, hence bad_dump, but we know it exists, and it's likely identical. -->
-				<rom name="parasol stars - the story of bubble bobble iii (japan).pce" status="baddump" size="393216" crc="51e86451" sha1="94a4c4b16435b043b0b985af446d8767602f5041" offset="000000" />
 			</dataarea>
 		</part>
 	</software>


### PR DESCRIPTION
* Unified publisher names with the PCE softlist, where it's just publisher, not developer or copyright holder (taken from the serial prefix).
* Changed carts IDs to hexa.
* Trimmed the ROM when the splitted data matches the PCE HuCard dump (on the PCE softlist).
* When it's the same, unified the ROM name with the PCE softlist.
* Marked the TourVisión dumps that do not fully match any known PCE ROM.
* Fixed some ROM area sizes.
* Added "alt_title" info.
* Removed Parasol Stars (rumored, but not actually dumped).