### PR TITLE
new NOT WORKING ---  Disney Friends (JAKKS Pacific TV Game, Game-Key Ready) [Sean Riddle] + new Game-Key

### DIFF
--- a/hash/jakks_gamekey_dy.xml
+++ b/hash/jakks_gamekey_dy.xml
@@ -11,7 +11,7 @@
 	<software name="sbwlgoof" supported="no"> <!-- AT24C04 SEEPROM -->
 		<description>Sports Bowling &amp; Goofy's Underwater Adventure</description>
 		<year>2005</year>
-		<publisher>JAKKS Pacific</publisher>
+		<publisher>JAKKS Pacific / HotGen Ltd</publisher>
 		<part name="cart" interface="jakks_gamekey">
 			<dataarea name="rom" size="0x200000">
 				<rom name="dy_disneygkbowlinggoofy.bin" size="0x200000" crc="d2147aa4" sha1="0db986aac68868a2ff4936e93178da8c592ac81d" offset="0" />
@@ -23,7 +23,7 @@
 	<software name="stenfchs" supported="no"> <!-- AT24C04 SEEPROM -->
 		<description>Sports Tennis &amp; Face Chase</description>
 		<year>2005</year>
-		<publisher>JAKKS Pacific</publisher>
+		<publisher>JAKKS Pacific / HotGen Ltd</publisher>
 		<part name="cart" interface="jakks_gamekey">
 			<dataarea name="rom" size="0x200000">
 				<rom name="dy_disneygktennisfacechase.bin" size="0x200000" crc="ba37ccf2" sha1="c7204a0499b6949f3f70f0f5c042d353435406fb" offset="0" />
@@ -31,6 +31,16 @@
 		</part>
 	</software>
 	
-	<!-- There is another key with "Sports Tennis" "Face Chase" and "The Riches of Agrabah" which was sold as part of a 2-key + unit bundle -->
-
+	<!-- in debugger do "go fbdc" then "do r1 = ffff" (it checks for compatible base board using magic value / response on port a) -->
+	<software name="stenfcha" supported="no"> <!-- AT24C04 SEEPROM -->
+		<description>Sports Tennis &amp; Face Chase &amp; Riches of Agrabah</description>
+		<year>2005</year>
+		<publisher>JAKKS Pacific / HotGen Ltd</publisher>
+		<part name="cart" interface="jakks_gamekey">
+			<dataarea name="rom" size="0x200000">
+				<rom name="disneygktennisfaceagrabah.bin" size="0x200000" crc="f3fd0759" sha1="1272e7e34acfce5dbe55b39bff888f5dd16c63f9" offset="0" />
+			</dataarea>
+		</part>
+	</software>	
+	
 </softwarelist>

--- a/src/mame/drivers/vii.cpp
+++ b/src/mame/drivers/vii.cpp
@@ -163,6 +163,7 @@ public:
 
 	void jakks_gkr(machine_config &config);
 	void jakks_gkr_nk(machine_config &config);
+	void jakks_gkr_dy(machine_config &config);
 
 private:
 	virtual void machine_start() override;
@@ -871,8 +872,13 @@ void jakks_gkr_state::jakks_gkr_nk(machine_config &config)
 	jakks_gkr(config);
 
 	SOFTWARE_LIST(config, "jakks_gamekey_nk").set_original("jakks_gamekey_nk");
+}
 
-	SOFTWARE_LIST(config, "jakks_gamekey_dy").set_original("jakks_gamekey_dy"); // doesn't belong here, but there are no DY base games dumped yet so just ensure it isn't orphaned
+void jakks_gkr_state::jakks_gkr_dy(machine_config &config)
+{
+	jakks_gkr(config);
+
+	SOFTWARE_LIST(config, "jakks_gamekey_dy").set_original("jakks_gamekey_dy");
 }
 
 
@@ -967,6 +973,11 @@ ROM_END
 ROM_START( jak_dora )
 	ROM_REGION( 0x800000, "maincpu", ROMREGION_ERASE00 )
 	ROM_LOAD16_WORD_SWAP( "jakksdoragkr.bin", 0x000000, 0x200000, CRC(bcaa132d) SHA1(3894b980fbc4144731b2a7a94acebb29e30de67c) )
+ROM_END
+
+ROM_START( jak_disf )
+	ROM_REGION( 0x800000, "maincpu", ROMREGION_ERASE00 )
+	ROM_LOAD16_WORD_SWAP( "disneyfriendsgkr.bin", 0x000000, 0x200000, CRC(77bca50b) SHA1(6e0f4fd229ee11eac721b5dbe79cf9002d3dbd64) )
 ROM_END
 
 ROM_START( jak_sdoo )
@@ -1167,17 +1178,18 @@ CONS( 2010, wirels60, 0, 0, wireless60, wirels60, spg2xx_game_state, empty_init,
 CONS( 2004, jak_batm, 0, 0, jakks, batman, spg2xx_game_state, empty_init, "JAKKS Pacific Inc / HotGen Ltd", "The Batman (JAKKS Pacific TV Game)",          MACHINE_IMPERFECT_SOUND | MACHINE_IMPERFECT_GRAPHICS )
 CONS( 2008, jak_wall, 0, 0, walle, walle,  spg2xx_game_state, empty_init, "JAKKS Pacific Inc / HotGen Ltd", "Wall-E (JAKKS Pacific TV Game)",              MACHINE_IMPERFECT_SOUND | MACHINE_IMPERFECT_GRAPHICS )
 
-// 'Game-Key-Ready' JAKKS games (these can also take per-game specific expansion cartridges, although not all games had them released)
-CONS( 2005, jak_wwe,  0, 0, jakks_gkr,    jak_gkr,jakks_gkr_state, empty_init, "JAKKS Pacific Inc / HotGen Ltd",          "WWE (JAKKS Pacific TV Game)",            MACHINE_IMPERFECT_SOUND | MACHINE_IMPERFECT_GRAPHICS ) // WW (no game-keys released)
-CONS( 2005, jak_fan4, 0, 0, jakks_gkr,    jak_gkr,jakks_gkr_state, empty_init, "JAKKS Pacific Inc / Digital Eclipse",     "Fantastic Four (JAKKS Pacific TV Game)", MACHINE_IMPERFECT_SOUND | MACHINE_IMPERFECT_GRAPHICS ) // F4 (no game-keys released)
-CONS( 2005, jak_just, 0, 0, jakks_gkr,    jak_gkr,jakks_gkr_state, empty_init, "JAKKS Pacific Inc / Taniko",              "Justice League (JAKKS Pacific TV Game)", MACHINE_NOT_WORKING | MACHINE_IMPERFECT_SOUND | MACHINE_IMPERFECT_GRAPHICS ) // DC (no game-keys released)
-CONS( 2005, jak_dora, 0, 0, jakks_gkr_nk, jak_gkr,jakks_gkr_state, empty_init, "JAKKS Pacific Inc / Handheld Games",      "Dora the Explorer (JAKKS Pacific TV Game)", MACHINE_NOT_WORKING | MACHINE_IMPERFECT_SOUND | MACHINE_IMPERFECT_GRAPHICS ) // uses NK keys (same as Nicktoons & Spongebob) (3+ released)
-CONS( 2005, jak_sdoo, 0, 0, jakks_gkr,    jak_gkr,jakks_gkr_state, empty_init, "JAKKS Pacific Inc / Jolliford Management","Scooby-Doo! and the Mystery of the Castle (JAKKS Pacific TV Game)", MACHINE_NOT_WORKING | MACHINE_IMPERFECT_SOUND | MACHINE_IMPERFECT_GRAPHICS ) //  SD (no game-keys released)
+// 'Game-Key Ready' JAKKS games (these can also take per-game specific expansion cartridges, although not all games had them released)  Some of these were available in versions without Game-Key ports, it is unconfirmed if code was the same unless otherwise stated
+CONS( 2005, jak_wwe,  0, 0, jakks_gkr,    jak_gkr,jakks_gkr_state, empty_init, "JAKKS Pacific Inc / HotGen Ltd",          "WWE (JAKKS Pacific TV Game, Game-Key Ready)",            MACHINE_IMPERFECT_SOUND | MACHINE_IMPERFECT_GRAPHICS ) // WW (no game-keys released)
+CONS( 2005, jak_fan4, 0, 0, jakks_gkr,    jak_gkr,jakks_gkr_state, empty_init, "JAKKS Pacific Inc / Digital Eclipse",     "Fantastic Four (JAKKS Pacific TV Game, Game-Key Ready)", MACHINE_IMPERFECT_SOUND | MACHINE_IMPERFECT_GRAPHICS ) // F4 (no game-keys released)
+CONS( 2005, jak_just, 0, 0, jakks_gkr,    jak_gkr,jakks_gkr_state, empty_init, "JAKKS Pacific Inc / Taniko",              "Justice League (JAKKS Pacific TV Game, Game-Key Ready)", MACHINE_NOT_WORKING | MACHINE_IMPERFECT_SOUND | MACHINE_IMPERFECT_GRAPHICS ) // DC (no game-keys released)
+CONS( 2005, jak_dora, 0, 0, jakks_gkr_nk, jak_gkr,jakks_gkr_state, empty_init, "JAKKS Pacific Inc / Handheld Games",      "Dora the Explorer (JAKKS Pacific TV Game, Game-Key Ready)", MACHINE_NOT_WORKING | MACHINE_IMPERFECT_SOUND | MACHINE_IMPERFECT_GRAPHICS ) // uses NK keys (same as Nicktoons & Spongebob) (3+ released)
+CONS( 2005, jak_sdoo, 0, 0, jakks_gkr,    jak_gkr,jakks_gkr_state, empty_init, "JAKKS Pacific Inc / Jolliford Management","Scooby-Doo! and the Mystery of the Castle (JAKKS Pacific TV Game, Game-Key Ready)", MACHINE_NOT_WORKING | MACHINE_IMPERFECT_SOUND | MACHINE_IMPERFECT_GRAPHICS ) //  SD (no game-keys released)
+CONS( 2005, jak_disf, 0, 0, jakks_gkr_dy, jak_gkr,jakks_gkr_state, empty_init, "JAKKS Pacific Inc / HotGen Ltd",          "Disney Friends (JAKKS Pacific TV Game, Game-Key Ready)", MACHINE_NOT_WORKING | MACHINE_IMPERFECT_SOUND | MACHINE_IMPERFECT_GRAPHICS ) // uses DY keys (3 released)
+
 // Nicktoons                                   NK (3? keys available) (same keys as Dora the Explorer)
 // SpongeBob SquarePants: The Fry Cook Games   NK (3? keys available)  ^^
 // Namco Ms. Pac-Man                           NM (3 keys available [Dig Dug, New Rally-X], [Rally-X, Pac-Man, Bosconian], [Pac-Man, Bosconian])
 // Star Wars                                   SW (1 key available)
-// Disney                                      DY (3? keys available)
 // Disney Princess                             DP (? keys available)
 // Spider-Man                                  MV (1? key available)
 

--- a/src/mame/mame.lst
+++ b/src/mame/mame.lst
@@ -38568,6 +38568,7 @@ jak_wwe                         //
 jak_fan4                        //
 jak_just                        //
 jak_dora                        //
+jak_disf                        //
 jak_sdoo                        //
 vii                             // KenSingTon / Jungle Soft / Siatronics Vii
 wrlshunt                        // Wireless: Hunting Video Game System


### PR DESCRIPTION
new NOT WORKING
---
Disney Friends (JAKKS Pacific TV Game, Game-Key Ready) [Sean Riddle]

new NOT WORKING Software List entries
---
 jakks_gamekey_dy:stenfcha Sports Tennis & Face Chase & Riches of Agrabah

This confirms that the '3 game' versions of the JAKKS Game Keys (usually sold as part of bundles) are different code to the '2 game' versions, not some soft unlock.