### PR TITLE
Fix typos (nw)

### DIFF
--- a/src/mame/drivers/storio.cpp
+++ b/src/mame/drivers/storio.cpp
@@ -2,7 +2,7 @@
 // copyright-holders:David Haywood
 /******************************************************************************
 
-	V.Tech Storio and V.Tech V.Reader
+	VTech Storio and VTech V.Reader
 	Main processor: Nuvoton W55FA9363SDN (ARM926EJ-S CPU core)
 		http://www.dingsung.com.cn/download/n32905/1507301944.pdf
 
@@ -112,60 +112,60 @@ void vtech_storio_state::vtech_storio(machine_config &config)
 
 // BIOS is 1 GBIT (128M × 8 BIT) CMOS NAND EEPROM (Toshiba TC58NVG0S3ETA00)
 
-// ROM image from V.Tech, not padded to the real ROM size
+// ROM image from VTech, not padded to the real ROM size
 ROM_START( vreader )
 	ROM_REGION( 0x038e906c, "maincpu", ROMREGION_ERASEFF )
 	ROM_LOAD( "useng-pack_20111017.bin", 0x000000, 0x038e906c, CRC(add3f7e5) SHA1(43ecfb0ba3c98c5852f93ed620021697167aa156) )
 ROM_END
 
-// ROM image from V.Tech, not padded to the real ROM size
+// ROM image from VTech, not padded to the real ROM size
 ROM_START( vreadercaen )
 	ROM_REGION( 0x038e906c, "maincpu", ROMREGION_ERASEFF )
 	ROM_LOAD( "caeng-pack_20111017.bin", 0x000000, 0x038e906c, CRC(0b64caf3) SHA1(79648e2b315c59f60aaf8cb8806fdbe773e484a2) )
 ROM_END
 
-// ROM image from V.Tech, not padded to the real ROM size
+// ROM image from VTech, not padded to the real ROM size
 ROM_START( vreadercafr )
 	ROM_REGION( 0x037d93a6, "maincpu", ROMREGION_ERASEFF )
 	ROM_LOAD( "cafre-pack_20111017.bin", 0x000000, 0x037d93a6, CRC(d3e0039c) SHA1(3d69f4afcf56ba40261bba0af335680c3c05b319) )
 ROM_END
 
-// ROM image from V.Tech, not padded to the real ROM size
+// ROM image from VTech, not padded to the real ROM size
 ROM_START( storio )
 	ROM_REGION( 0x01bf3dcb, "maincpu", ROMREGION_ERASEFF )
 	ROM_LOAD( "gbeng-pack_20111017.bin", 0x000000, 0x01bf3dcb, CRC(b0962d2c) SHA1(4f316cbcc87ae24022568a358ac94c7b4cac39a6) )
 ROM_END
 
-// ROM image from V.Tech, not padded to the real ROM size
+// ROM image from VTech, not padded to the real ROM size
 ROM_START( storiode )
 	ROM_REGION( 0x03740a0d, "maincpu", ROMREGION_ERASEFF )
 	ROM_LOAD( "deger-pack_20111017.bin", 0x000000, 0x03740a0d, CRC(548c8882) SHA1(e64474be082bd3ae3c365c6c766b2ec5081f3ebd) )
 ROM_END
 
-// ROM image from V.Tech, not padded to the real ROM size
+// ROM image from VTech, not padded to the real ROM size
 ROM_START( storioes )
 	ROM_REGION( 0x03c62bfc, "maincpu", ROMREGION_ERASEFF )
 	ROM_LOAD( "esspa-pack_20111017.bin", 0x000000, 0x03c62bfc, CRC(fe9b78f9) SHA1(c114a8f82799861a0cca432ee145e436aca5f400) )
 ROM_END
 
-// ROM image from V.Tech, not padded to the real ROM size
+// ROM image from VTech, not padded to the real ROM size
 ROM_START( storiofr )
 	ROM_REGION( 0x038c2a19, "maincpu", ROMREGION_ERASEFF )
 	ROM_LOAD( "frfre-pack_20111017.bin", 0x000000, 0x038c2a19, CRC(f3d87f50) SHA1(240ddebd4cb1c4be24afb4da35c65ddf64628034) )
 ROM_END
 
-// ROM image from V.Tech, not padded to the real ROM size
+// ROM image from VTech, not padded to the real ROM size
 ROM_START( storionl )
 	ROM_REGION( 0x03af81c6, "maincpu", ROMREGION_ERASEFF )
 	ROM_LOAD( "nldut-pack_20111017.bin", 0x000000, 0x03af81c6, CRC(6cfac599) SHA1(d16b45fd287c9d823bde13b88eb6c8158ac2b475) )
 ROM_END
 
 //    year, name,         parent,  compat, machine,      input,        class,              init,       company,  fullname,                             flags
-CONS( 2011, vreader,      0,       0,      vtech_storio, vtech_storio, vtech_storio_state, empty_init, "V.Tech", "V.Reader (US, English, 2011-10-17)", MACHINE_IS_SKELETON )
-CONS( 2011, vreadercaen,  vreader, 0,      vtech_storio, vtech_storio, vtech_storio_state, empty_init, "V.Tech", "V.Reader (CA, English, 2011-10-17)", MACHINE_IS_SKELETON )
-CONS( 2011, vreadercafr,  vreader, 0,      vtech_storio, vtech_storio, vtech_storio_state, empty_init, "V.Tech", "V.Reader (CA, French, 2011-10-17)",  MACHINE_IS_SKELETON )
-CONS( 2011, storio,       vreader, 0,      vtech_storio, vtech_storio, vtech_storio_state, empty_init, "V.Tech", "Storio (GB, English, 2011-10-17)",   MACHINE_IS_SKELETON )
-CONS( 2011, storiode,     vreader, 0,      vtech_storio, vtech_storio, vtech_storio_state, empty_init, "V.Tech", "Storio (DE, German, 2011-10-17)",    MACHINE_IS_SKELETON )
-CONS( 2011, storioes,     vreader, 0,      vtech_storio, vtech_storio, vtech_storio_state, empty_init, "V.Tech", "Storio (ES, Spanish, 2011-10-17)",   MACHINE_IS_SKELETON )
-CONS( 2011, storiofr,     vreader, 0,      vtech_storio, vtech_storio, vtech_storio_state, empty_init, "V.Tech", "Storio (FR, French, 2011-10-17)",    MACHINE_IS_SKELETON )
-CONS( 2011, storionl,     vreader, 0,      vtech_storio, vtech_storio, vtech_storio_state, empty_init, "V.Tech", "Storio (NL, Dutch, 2011-10-17)",     MACHINE_IS_SKELETON )
+CONS( 2011, vreader,      0,       0,      vtech_storio, vtech_storio, vtech_storio_state, empty_init, "VTech", "V.Reader (US, English, 2011-10-17)", MACHINE_IS_SKELETON )
+CONS( 2011, vreadercaen,  vreader, 0,      vtech_storio, vtech_storio, vtech_storio_state, empty_init, "VTech", "V.Reader (CA, English, 2011-10-17)", MACHINE_IS_SKELETON )
+CONS( 2011, vreadercafr,  vreader, 0,      vtech_storio, vtech_storio, vtech_storio_state, empty_init, "VTech", "V.Reader (CA, French, 2011-10-17)",  MACHINE_IS_SKELETON )
+CONS( 2011, storio,       vreader, 0,      vtech_storio, vtech_storio, vtech_storio_state, empty_init, "VTech", "Storio (GB, English, 2011-10-17)",   MACHINE_IS_SKELETON )
+CONS( 2011, storiode,     vreader, 0,      vtech_storio, vtech_storio, vtech_storio_state, empty_init, "VTech", "Storio (DE, German, 2011-10-17)",    MACHINE_IS_SKELETON )
+CONS( 2011, storioes,     vreader, 0,      vtech_storio, vtech_storio, vtech_storio_state, empty_init, "VTech", "Storio (ES, Spanish, 2011-10-17)",   MACHINE_IS_SKELETON )
+CONS( 2011, storiofr,     vreader, 0,      vtech_storio, vtech_storio, vtech_storio_state, empty_init, "VTech", "Storio (FR, French, 2011-10-17)",    MACHINE_IS_SKELETON )
+CONS( 2011, storionl,     vreader, 0,      vtech_storio, vtech_storio, vtech_storio_state, empty_init, "VTech", "Storio (NL, Dutch, 2011-10-17)",     MACHINE_IS_SKELETON )


### PR DESCRIPTION
Use "VTech" instead of "V.Tech" like on the other drivers.