### PR TITLE
First pass at prepping A2 softlist for splitting (nw)

### DIFF
--- a/hash/apple2.xml
+++ b/hash/apple2.xml
@@ -1139,7 +1139,7 @@
 	</software>
 
 	<software name="archon2">
-		<description>Archon II: Adept</description>
+		<description>Archon II: Adept (cracked)</description>
 		<year>1985</year>
 		<publisher>Electronic Arts</publisher>
 
@@ -1151,7 +1151,7 @@
 	</software>
 
 	<software name="archon">
-		<description>Archon</description>
+		<description>Archon (cracked)</description>
 		<year>1984</year>
 		<publisher>Electronic Arts</publisher>
 
@@ -1163,7 +1163,7 @@
 	</software>
 
 	<software name="artesian">
-		<description>Artesians</description>
+		<description>Artesians (cracked)</description>
 		<year>19??</year>
 		<publisher>Reno Soft</publisher>
 
@@ -1372,7 +1372,7 @@
 	</software>
 
 	<software name="baddudcr">
-		<description>Bad Dudes (crack)</description>
+		<description>Bad Dudes (cracked)</description>
 		<year>1988</year>
 		<publisher>Data East</publisher>
 
@@ -1418,7 +1418,7 @@
 	</software>
 
 	<software name="balpower">
-		<description>Balance of Power (crack)</description>
+		<description>Balance of Power (cracked)</description>
 		<year>1987</year>
 		<publisher>Mindscape</publisher>
 
@@ -1442,7 +1442,7 @@
 	</software>
 
 	<software name="banditcr">
-		<description>Bandits (crack)</description>
+		<description>Bandits (cracked)</description>
 		<year>1982</year>
 		<publisher>Sirius Software</publisher>
 
@@ -1605,7 +1605,7 @@
 	</software>
 
 	<software name="bardstl">
-		<description>The Bard's Tale (crack)</description>
+		<description>The Bard's Tale (cracked)</description>
 		<year>1985</year>
 		<publisher>Electronic Arts</publisher>
 
@@ -1632,7 +1632,7 @@
 	</software>
 
 	<software name="baron">
-		<description>Baron - The Real Estate Simulation (crack)</description>
+		<description>Baron - The Real Estate Simulation (cracked)</description>
 		<year>1983</year>
 		<publisher>Blue Chip</publisher>
 
@@ -1821,7 +1821,7 @@
 	</software>
 
 	<software name="batlsght">
-		<description>Battlesight (crack)</description>
+		<description>Battlesight (cracked)</description>
 		<year>1982</year>
 		<publisher>Versa Computing</publisher>
 
@@ -1891,7 +1891,7 @@
 	</software>
 
 	<software name="batlthcr">
-		<description>Battletech (crack)</description>
+		<description>Battletech (cracked)</description>
 		<year>1988</year>
 		<publisher>Infocom / Westwood</publisher>
 
@@ -1995,7 +1995,7 @@
 	</software>
 
 	<software name="bchh2cr">
-		<description>Beach-Head II (crack)</description>
+		<description>Beach-Head II (cracked)</description>
 		<year>1985</year>
 		<publisher>Access Software</publisher>
 
@@ -2007,7 +2007,7 @@
 	</software>
 
 	<software name="bchhdcr">
-		<description>Beach-Head (crack)</description>
+		<description>Beach-Head (cracked)</description>
 		<year>1985</year>
 		<publisher>Access Software</publisher>
 
@@ -2031,7 +2031,7 @@
 	</software>
 
 	<software name="bchldng">
-		<description>Beach Landing (crack)</description>
+		<description>Beach Landing (cracked)</description>
 		<year>1984</year>
 		<publisher>Optimum Resource</publisher>
 
@@ -2043,7 +2043,7 @@
 	</software>
 
 	<software name="bcstlwcr">
-		<description>Beyond Castle Wolfenstein (crack)</description>
+		<description>Beyond Castle Wolfenstein (cracked)</description>
 		<year>1984</year>
 		<publisher>Muse Software</publisher>
 
@@ -2055,7 +2055,7 @@
 	</software>
 
 	<software name="beastwar">
-		<description>Beast War (crack)</description>
+		<description>Beast War (cracked)</description>
 		<year>1985</year>
 		<publisher>Avalon Hill</publisher>
 
@@ -2066,8 +2066,8 @@
 		</part>
 	</software>
 
-	<software name="belwrtcr">
-		<description>Below the Root (crack)</description>
+	<software name="belwrt">
+		<description>Below the Root (cracked)</description>
 		<year>1985</year>
 		<publisher>Windham Classics</publisher>
 
@@ -2108,7 +2108,7 @@
 	</software>
 
 	<software name="berzapcr">
-		<description>Berzap! (crack)</description>
+		<description>Berzap! (cracked)</description>
 		<year>1984</year>
 		<publisher>Infinity Limited</publisher>
 
@@ -2132,7 +2132,7 @@
 	</software>
 
 	<software name="betedugv">
-		<description>La Bete du Gevaudan (crack)</description>
+		<description>La Bete du Gevaudan (cracked)</description>
 		<year>1985</year>
 		<publisher>Cil</publisher>
 
@@ -2190,7 +2190,7 @@
 	</software>
 
 	<software name="bilestod">
-		<description>The Bilestoad (crack)</description>
+		<description>The Bilestoad (cracked)</description>
 		<year>1982</year>
 		<publisher>Mangrove Earthshoe</publisher>
 
@@ -2202,7 +2202,7 @@
 	</software>
 
 	<software name="bismarck">
-		<description>Bismarck (crack)</description>
+		<description>Bismarck (cracked)</description>
 		<year>1987</year>
 		<publisher>Datasoft</publisher>
 
@@ -2214,7 +2214,7 @@
 	</software>
 
 	<software name="blackblt">
-		<description>Black Belt (crack)</description>
+		<description>Black Belt (cracked)</description>
 		<year>1984</year>
 		<publisher>Earthware</publisher>
 
@@ -2226,7 +2226,7 @@
 	</software>
 
 	<software name="bldkitcr">
-		<description>Boulder Dash Construction Kit (crack)</description>
+		<description>Boulder Dash Construction Kit (cracked)</description>
 		<year>1987</year>
 		<publisher>Epyx</publisher>
 
@@ -2238,7 +2238,7 @@
 	</software>
 
 	<software name="bldofbkp">
-		<description>The Blade of Blackpoole (crack)</description>
+		<description>The Blade of Blackpoole (cracked)</description>
 		<year>1982</year>
 		<publisher>Sirius Software</publisher>
 
@@ -2255,7 +2255,7 @@
 	</software>
 
 	<software name="bldqstcr">
-		<description>Blood Quest (crack)</description>
+		<description>Blood Quest (cracked)</description>
 		<year>19??</year>
 		<publisher>Questware</publisher>
 
@@ -2279,7 +2279,7 @@
 	</software>
 
 	<software name="bldrdscr">
-		<description>Boulder Dash (crack)</description>
+		<description>Boulder Dash (cracked)</description>
 		<year>1984</year>
 		<publisher>Microlab</publisher>
 
@@ -2303,7 +2303,7 @@
 	</software>
 
 	<software name="blkcldcr">
-		<description>The Black Cauldron (crack)</description>
+		<description>The Black Cauldron (cracked)</description>
 		<year>1985</year>
 		<publisher>Sierra On-Line / Walt Disney</publisher>
 
@@ -2347,7 +2347,7 @@
 	</software>
 
 	<software name="blkmgccr">
-		<description>Black Magic (crack)</description>
+		<description>Black Magic (cracked)</description>
 		<year>1987</year>
 		<publisher>Datasoft</publisher>
 
@@ -2407,7 +2407,7 @@
 	</software>
 
 	<software name="bnckmgcr">
-		<description>The Bouncing Kamungas (crack)</description>
+		<description>The Bouncing Kamungas (cracked)</description>
 		<year>1983</year>
 		<publisher>Penguin Software</publisher>
 
@@ -2431,7 +2431,7 @@
 	</software>
 
 	<software name="bolocr">
-		<description>Bolo (crack)</description>
+		<description>Bolo (cracked)</description>
 		<year>1982</year>
 		<publisher>Synergistic Software</publisher>
 
@@ -2496,7 +2496,7 @@
 	</software>
 
 	<software name="borgcr">
-		<description>Borg (crack)</description>
+		<description>Borg (cracked)</description>
 		<year>1981</year>
 		<publisher>Sirius Software</publisher>
 
@@ -2532,7 +2532,7 @@
 	</software>
 
 	<software name="bpgscr">
-		<description>Blue Powder, Grey Smoke (crack)</description>
+		<description>Blue Powder, Grey Smoke (cracked)</description>
 		<year>19??</year>
 		<publisher>Garde</publisher>
 
@@ -2561,7 +2561,7 @@
 	</software>
 
 	<software name="brclecr">
-		<description>Bruce Lee (crack)</description>
+		<description>Bruce Lee (cracked)</description>
 		<year>1984</year>
 		<publisher>Datasoft</publisher>
 
@@ -2585,7 +2585,7 @@
 	</software>
 
 	<software name="brdsdcra">
-		<description>Broadsides (crack)</description>
+		<description>Broadsides (cracked)</description>
 		<year>1983</year>
 		<publisher>Strategic Simulations, Inc.</publisher>
 
@@ -2822,7 +2822,7 @@
 	</software>
 
 	<software name="brpozcr">
-		<description>Buck Rogers - Planet of Zoom (crack)</description>
+		<description>Buck Rogers - Planet of Zoom (cracked)</description>
 		<year>1984</year>
 		<publisher>Sega</publisher>
 
@@ -2851,7 +2851,7 @@
 	</software>
 
 	<software name="brwdtmcr">
-		<description>Borrowed Time (crack)</description>
+		<description>Borrowed Time (cracked)</description>
 		<year>1985</year>
 		<publisher>Activision</publisher>
 
@@ -2909,7 +2909,7 @@
 	</software>
 
 	<software name="bublhdcr">
-		<description>Bubble-Head (crack)</description>
+		<description>Bubble-Head (cracked)</description>
 		<year>1983</year>
 		<publisher>Tellus Systems</publisher>
 
@@ -2993,7 +2993,7 @@
 	</software>
 
 	<software name="bypinbll">
-		<description>Beyond Pinball (crack)</description>
+		<description>Beyond Pinball (cracked)</description>
 		<year>1986</year>
 		<publisher>Dark Logic</publisher>
 
@@ -3208,7 +3208,7 @@
 	</software>
 
 	<software name="cartels">
-		<description>Cartels and Cutthroats (crack)</description>
+		<description>Cartels and Cutthroats (cracked)</description>
 		<year>1981</year>
 		<publisher>Strategic Studies Group</publisher>
 
@@ -3840,7 +3840,7 @@
 	</software>
 
 	<software name="conglcld">
-		<description>Conglomerates COllide</description>
+		<description>Conglomerates Collide</description>
 		<year>1981</year>
 		<publisher>Rockroy</publisher>
 
@@ -3852,7 +3852,7 @@
 	</software>
 
 	<software name="congobng">
-		<description>Congo Bongo</description>
+		<description>Congo Bongo (cracked)</description>
 		<year>1983</year>
 		<publisher>Sega</publisher>
 
@@ -4310,7 +4310,7 @@
 	</software>
 
 	<software name="cvrnsfrt">
-		<description>The Caverns of Freitag</description>
+		<description>The Caverns of Freitag (cracked)</description>
 		<year>1982</year>
 		<publisher>Muse Software</publisher>
 
@@ -4964,7 +4964,7 @@
 	</software>
 
 	<software name="hhmack">
-		<description>Hard Hat Mack</description>
+		<description>Hard Hat Mack (clean crack)</description>
 		<year>1983</year>
 		<publisher>Electronic Arts</publisher>
 
@@ -7691,9 +7691,9 @@
 	</software>
 
 	<software name="clasmate">
-		<description>ClassMate</description>
+		<description>ClassMate (clean crack)</description>
 		<year>1987</year>
-		<publisher>Davidson and Associates (clean crack)</publisher>
+		<publisher>Davidson and Associates</publisher>
 
 		<part name="flop1" interface="floppy_5_25">
 			<dataarea name="flop" size="143360">
@@ -7812,9 +7812,9 @@
 	</software>
 
 	<software name="creation">
-		<description>Creation</description>
+		<description>Creation (clean crack)</description>
 		<year>1988</year>
-		<publisher>Pelican Software (clean crack)</publisher>
+		<publisher>Pelican Software</publisher>
 
 		<part name="flop1" interface="floppy_5_25">
 			<dataarea name="flop" size="143360">

--- a/hash/apple2.xml
+++ b/hash/apple2.xml
@@ -622,7 +622,7 @@
 	</software>
 
 	<software name="alcazar">
-		<description>Alcazar the Forgotten Fortress (clean crack)</description>
+		<description>Alcazar the Forgotten Fortress (cleanly cracked)</description>
 		<year>1985</year>
 		<publisher>Activision</publisher>
 
@@ -651,7 +651,7 @@
 	</software>
 
 	<software name="aliens">
-		<description>Aliens (clean crack)</description>
+		<description>Aliens (cleanly cracked)</description>
 		<year>1986</year>
 		<publisher>Activision</publisher>
 
@@ -1006,7 +1006,7 @@
 	</software>
 
 	<software name="aztec">
-		<description>Aztec (clean crack)</description>
+		<description>Aztec (cleanly cracked)</description>
 		<year>1982</year>
 		<publisher>Datamost</publisher>
 
@@ -1100,7 +1100,7 @@
 	</software>
 
 	<software name="amchal">
-		<description>The American Challenge (clean crack)</description>
+		<description>The American Challenge (cleanly cracked)</description>
 		<year>1986</year>
 		<publisher>MIndscape</publisher>
 
@@ -1685,7 +1685,7 @@
 	</software>
 
 	<software name="batlches">
-		<description>Battle Chess (clean crack)</description>
+		<description>Battle Chess (cleanly cracked)</description>
 		<year>1990</year>
 		<publisher>Interplay</publisher>
 
@@ -1908,7 +1908,7 @@
 	</software>
 
 	<software name="batman">
-		<description>Batman (clean crack)</description>
+		<description>Batman (cleanly cracked)</description>
 		<year>1988</year>
 		<publisher>Data East</publisher>
 
@@ -1937,7 +1937,7 @@
 	</software>
 
 	<software name="bbblocks">
-		<description>BASIC Building Blocks (clean crack)</description>
+		<description>BASIC Building Blocks (cleanly cracked)</description>
 		<year>1983</year>
 		<publisher>Micro Education</publisher>
 
@@ -2892,7 +2892,7 @@
 	</software>
 
 	<software name="bublbobl">
-		<description>Bubble Bobble (clean crack)</description>
+		<description>Bubble Bobble (cleanly cracked)</description>
 		<year>1988</year>
 		<publisher>Taito America / NovaLogic</publisher>
 
@@ -3726,7 +3726,7 @@
 	</software>
 
 	<software name="cntdsht">
-		<description>Countdown to Shutdown (clean crack)</description>
+		<description>Countdown to Shutdown (cleanly cracked)</description>
 		<year>1985</year>
 		<publisher>Activision</publisher>
 
@@ -3787,7 +3787,7 @@
 	</software>
 
 	<software name="cogito">
-		<description>Cogito! (clean crack)</description>
+		<description>Cogito! (cleanly cracked)</description>
 		<year>198??</year>
 		<publisher>Reader's Digest Software</publisher>
 
@@ -4016,7 +4016,7 @@
 	</software>
 
 	<software name="crismntn">
-		<description>Crisis Mountain (clean crack)</description>
+		<description>Crisis Mountain (cleanly cracked)</description>
 		<year>1982</year>
 		<publisher>Synergistic Software</publisher>
 
@@ -4591,7 +4591,7 @@
 	</software>
 
 	<software name="carmntime">
-		<description>Where in Time is Carmen Sandiego v1.1 (clean crack)</description>
+		<description>Where in Time is Carmen Sandiego v1.1 (cleanly cracked)</description>
 		<year>1989</year>
 		<publisher>Broderbund</publisher>
 
@@ -4618,7 +4618,7 @@
 	</software>
 
 	<software name="carmntime35">
-		<description>Where in Time is Carmen Sandiego v1.1 800K 3.5 disc (clean crack)</description>
+		<description>Where in Time is Carmen Sandiego v1.1 800K 3.5 disc (cleanly cracked)</description>
 		<year>1989</year>
 		<publisher>Broderbund</publisher>
 
@@ -4630,7 +4630,7 @@
 	</software>
 
 	<software name="carmntime10">
-		<description>Where in Time is Carmen Sandiego v1.0 (clean crack)</description>
+		<description>Where in Time is Carmen Sandiego v1.0 (cleanly cracked)</description>
 		<year>1989</year>
 		<publisher>Broderbund</publisher>
 
@@ -4768,7 +4768,7 @@
 	</software>
 
 	<software name="dmaster">
-		<description>Dungeon Master's Assistant (clean crack)</description>
+		<description>Dungeon Master's Assistant (cleanly cracked)</description>
 		<year>1988</year>
 		<publisher>SSI</publisher>
 
@@ -4898,7 +4898,7 @@
 	</software>
 
 	<software name="genesis">
-		<description>Genesis (clean crack)</description>
+		<description>Genesis (cleanly cracked)</description>
 		<!-- Original disk wouldn't boot on 65C02 or later -->
 		<year>1983</year>
 		<publisher>Datasoft / Design Labs</publisher>
@@ -4911,7 +4911,7 @@
 	</software>
 
 	<software name="gbust">
-		<description>Ghostbusters (clean crack)</description>
+		<description>Ghostbusters (cleanly cracked)</description>
 		<year>1984</year>
 		<publisher>Activision</publisher>
 
@@ -4952,7 +4952,7 @@
 	</software>
 
 	<software name="hardball">
-		<description>Hardball (clean crack)</description>
+		<description>Hardball (cleanly cracked)</description>
 		<year>1985</year>
 		<publisher>Accolade</publisher>
 
@@ -4964,7 +4964,7 @@
 	</software>
 
 	<software name="hhmack">
-		<description>Hard Hat Mack (clean crack)</description>
+		<description>Hard Hat Mack (cleanly cracked)</description>
 		<year>1983</year>
 		<publisher>Electronic Arts</publisher>
 
@@ -4976,7 +4976,7 @@
 	</software>
 
 	<software name="heist">
-		<description>The Heist (clean crack)</description>
+		<description>The Heist (cleanly cracked)</description>
 		<!-- High scores stored on disc, reset to AAA 5000, BBB 4000, CCC 3000, DDD 2000 & EEE 1000 -->
 		<year>1983</year>
 		<publisher>Microlab</publisher>
@@ -5168,7 +5168,7 @@
 	</software>
 
 	<software name="lawwest">
-		<description>Law of the West (clean crack)</description>
+		<description>Law of the West (cleanly cracked)</description>
 		<year>1985</year>
 		<publisher>Accolade</publisher>
 
@@ -5291,7 +5291,7 @@
 	</software>
 
 	<software name="masterlamp">
-		<description>Master of the Lamps (clean crack)</description>
+		<description>Master of the Lamps (cleanly cracked)</description>
 		<year>1985</year>
 		<publisher>Activision</publisher>
 
@@ -5383,7 +5383,7 @@
 	</software>
 
 	<software name="minr2049">
-		<description>Miner 2049er (clean crack)</description>
+		<description>Miner 2049er (cleanly cracked)</description>
 		<!-- High scores stored on disc, reset to AAA 5000, AAA 4000, AAA 3000, AAA 2000 & AAA 1000 -->
 		<year>1982</year>
 		<publisher>Micro Fun</publisher>
@@ -5420,7 +5420,7 @@
 	</software>
 
 	<software name="mrdo">
-		<description>Mr. Do (clean crack)</description>
+		<description>Mr. Do (cleanly cracked)</description>
 		<year>1983</year>
 		<publisher>Datasoft</publisher>
 
@@ -5432,7 +5432,7 @@
 	</software>
 
 	<software name="mspac">
-		<description>Ms. Pac Man (clean crack)</description>
+		<description>Ms. Pac Man (cleanly cracked)</description>
 		<year>1983</year>
 		<publisher>Atari</publisher>
 
@@ -5495,7 +5495,7 @@
 		<!-- Left & Right arrows or Paddle0 for controls - Select with "K" for keyboard / "P" for paddle -->
 		<!-- press SLASH "/" to fire with keyboard or use Button0 when using the paddle -->
 		<!-- "C" for continuous fire, SPACE BAR for shields, CRTL-S toggles sound on/off, ESC for pause  -->
-		<description>Nightmare Gallery (clean crack)</description>
+		<description>Nightmare Gallery (cleanly cracked)</description>
 		<year>1982</year>
 		<publisher>Synergistic Software</publisher>
 
@@ -5565,7 +5565,7 @@
 	</software>
 
 	<software name="pacman">
-		<description>Pac-Man - Atari (clean crack)</description>
+		<description>Pac-Man - Atari (cleanly cracked)</description>
 		<year>1983</year>
 		<publisher>Atari</publisher>
 
@@ -5577,7 +5577,7 @@
 	</software>
 
 	<software name="pacmand">
-		<description>Pac-Man - Datasoft (clean crack)</description>
+		<description>Pac-Man - Datasoft (cleanly cracked)</description>
 		<year>1983</year>
 		<publisher>Datasoft / Namco America</publisher>
 
@@ -5589,7 +5589,7 @@
 	</software>
 
 	<software name="pacmant">
-		<description>Pac-Man - Thunder Mountain (clean crack)</description>
+		<description>Pac-Man - Thunder Mountain (cleanly cracked)</description>
 		<year>1983</year>
 		<publisher>Thunder Mountain / Namco</publisher>
 
@@ -5601,7 +5601,7 @@
 	</software>
 
 	<software name="paperboy">
-		<description>Paperboy (clean crack)</description>
+		<description>Paperboy (cleanly cracked)</description>
 		<year>1986</year>
 		<publisher>Mindscape / Atari</publisher>
 
@@ -5613,7 +5613,7 @@
 	</software>
 
 	<software name="papermodels">
-		<description>Paper Models - The Christmas Kit (clean crack)</description>
+		<description>Paper Models - The Christmas Kit (cleanly cracked)</description>
 		<year>1986</year>
 		<publisher>Activision</publisher>
 
@@ -5625,7 +5625,7 @@
 	</software>
 
 	<software name="pigpen">
-		<description>Pigpen (clean crack)</description>
+		<description>Pigpen (cleanly cracked)</description>
 		<year>1982</year>
 		<publisher>Datamost / TMQ Software</publisher>
 
@@ -5649,7 +5649,7 @@
 	</software>
 
 	<software name="pipedream">
-		<description>Pipe Dream (clean crack)</description>
+		<description>Pipe Dream (cleanly cracked)</description>
 		<year>1990</year>
 		<publisher>Lucasfilm</publisher>
 
@@ -5754,7 +5754,7 @@
 	</software>
 
 	<software name="portal">
-		<description>Portal (clean crack)</description>
+		<description>Portal (cleanly cracked)</description>
 		<year>1986</year>
 		<publisher>Activision</publisher>
 
@@ -5781,7 +5781,7 @@
 	</software>
 
 	<software name="qix">
-		<description>Qix (clean crack)</description>
+		<description>Qix (cleanly cracked)</description>
 		<year>1989</year>
 		<publisher>Taito</publisher>
 
@@ -5793,7 +5793,7 @@
 	</software>
 
 	<software name="racter">
-		<description>Racter (clean crack)</description>
+		<description>Racter (cleanly cracked)</description>
 		<year>1985</year>
 		<publisher>Mindscape</publisher>
 
@@ -5805,7 +5805,7 @@
 	</software>
 
 	<software name="rambo">
-		<description>Rambo First Blood Part II (clean crack)</description>
+		<description>Rambo First Blood Part II (cleanly cracked)</description>
 		<year>1985</year>
 		<publisher>Mindscape / Angelsoft</publisher>
 
@@ -5817,7 +5817,7 @@
 	</software>
 
 	<software name="rampage">
-		<description>Rampage (clean crack)</description>
+		<description>Rampage (cleanly cracked)</description>
 		<year>1988</year>
 		<publisher>Activision</publisher>
 
@@ -5829,7 +5829,7 @@
 	</software>
 
 	<software name="renegade">
-		<description>Renegade (clean crack)</description>
+		<description>Renegade (cleanly cracked)</description>
 		<!-- ProDOS 8 based & hard drive compatable -->
 		<year>1988</year>
 		<publisher>Taito America / NovaLogic</publisher>
@@ -5977,7 +5977,7 @@
 	</software>
 
 	<software name="shanghai">
-		<description>Shanghai (clean crack)</description>
+		<description>Shanghai (cleanly cracked)</description>
 		<year>1986</year>
 		<publisher>Activision</publisher>
 
@@ -6069,7 +6069,7 @@
 	</software>
 
 	<software name="sneakers">
-		<description>Sneakers (clean crack)</description>
+		<description>Sneakers (cleanly cracked)</description>
 		<year>1981</year>
 		<publisher>Sirius Software</publisher>
 
@@ -6146,7 +6146,7 @@
 	</software>
 
 	<software name="spindizy">
-		<description>Spindizzy (clean crack)</description>
+		<description>Spindizzy (cleanly cracked)</description>
 		<year>1986</year>
 		<publisher>Activision</publisher>
 
@@ -6360,7 +6360,7 @@
 	</software>
 
 	<software name="tapper">
-		<description>Tapper (clean crack)</description>
+		<description>Tapper (cleanly cracked)</description>
 		<!-- Corrected rerip 09/19/2016 -->
 		<year>1983</year>
 		<publisher>Bally/Midway</publisher>
@@ -6456,7 +6456,7 @@
 	</software>
 
 	<software name="thief">
-		<description>Thief (clean crack)</description>
+		<description>Thief (cleanly cracked)</description>
 		<!-- Apple II clone of Berzerk arcade game by Bob Flanagan - Thief: "The damn things nearly killed me." -->
 		<!-- All files transfered from a highly protected DOS 3.2 disc to a PronoDOS disc -->
 		<!-- Also includes a single file BRUNable conversion of the game -->
@@ -6955,7 +6955,7 @@
 	</software>
 
 	<software name="xevious">
-		<description>Xevious (clean crack)</description>
+		<description>Xevious (cleanly cracked)</description>
 		<year>1983</year>
 		<publisher>Mindscape</publisher>
 
@@ -7045,7 +7045,7 @@
 <!-- 4am adds, A-E -->
 
 	<software name="123seqme">
-		<description>1-2-3 Sequence Me (clean crack)</description>
+		<description>1-2-3 Sequence Me (cleanly cracked)</description>
 		<year>1991</year>
 		<publisher>Sunburst</publisher>
 
@@ -7057,7 +7057,7 @@
 	</software>
 
 	<software name="acedect">
-		<description>Ace Detective (clean crack)</description>
+		<description>Ace Detective (cleanly cracked)</description>
 		<year>1987</year>
 		<publisher>Mindplay</publisher>
 
@@ -7074,7 +7074,7 @@
 	</software>
 
 	<software name="addsub1">
-		<description>Mathematics Courseware Series: Addition and Subtraction 1 (clean crack)</description>
+		<description>Mathematics Courseware Series: Addition and Subtraction 1 (cleanly cracked)</description>
 		<year>1985</year>
 		<publisher>Scott, Foresman and Company</publisher>
 
@@ -7086,7 +7086,7 @@
 	</software>
 
 	<software name="addsub2">
-		<description>Mathematics Courseware Series: Addition and Subtraction 2 (clean crack)</description>
+		<description>Mathematics Courseware Series: Addition and Subtraction 2 (cleanly cracked)</description>
 		<year>1985</year>
 		<publisher>Scott, Foresman and Company</publisher>
 
@@ -7098,7 +7098,7 @@
 	</software>
 
 	<software name="afrpiano">
-		<description>Alfred's Basic Piano Theory Software (clean crack)</description>
+		<description>Alfred's Basic Piano Theory Software (cleanly cracked)</description>
 		<year>1986</year>
 		<publisher>Alfred Publishing Company</publisher>
 
@@ -7110,7 +7110,7 @@
 	</software>
 
 	<software name="agentusa">
-		<description>Agent USA (clean crack)</description>
+		<description>Agent USA (cleanly cracked)</description>
 		<year>1984</year>
 		<publisher>Scholastic</publisher>
 
@@ -7122,7 +7122,7 @@
 	</software>
 
 	<software name="alcircus">
-		<description>Alphabet Circus (clean crack)</description>
+		<description>Alphabet Circus (cleanly cracked)</description>
 		<year>1984</year>
 		<publisher>NeoSoft</publisher>
 
@@ -7134,7 +7134,7 @@
 	</software>
 
 	<software name="alcwndrl">
-		<description>Alice in Wonderland (clean crack)</description>
+		<description>Alice in Wonderland (cleanly cracked)</description>
 		<year>1985</year>
 		<publisher>Windham Classics</publisher>
 
@@ -7151,7 +7151,7 @@
 	</software>
 
 	<software name="algebra2">
-		<description>Algebra 2 (clean crack)</description>
+		<description>Algebra 2 (cleanly cracked)</description>
 		<year>1982</year>
 		<publisher>Edu-Ware</publisher>
 
@@ -7163,7 +7163,7 @@
 	</software>
 
 	<software name="algeplus">
-		<description>Alge-Blaster Plus! (clean crack)</description>
+		<description>Alge-Blaster Plus! (cleanly cracked)</description>
 		<year>1989</year>
 		<publisher>Davidson &amp; Associates, Inc.</publisher>
 		<info name="usage" value="Works with Apple II Mouse Card in slot 4: -sl4 mouse" />
@@ -7191,7 +7191,7 @@
 	</software>
 
 	<software name="algernon">
-		<description>Algernon (clean crack)</description>
+		<description>Algernon (cleanly cracked)</description>
 		<year>1987</year>
 		<publisher>Sunburst</publisher>
 
@@ -7203,7 +7203,7 @@
 	</software>
 
 	<software name="algevol1">
-		<description>Algebra, Volume 1 (clean crack)</description>
+		<description>Algebra, Volume 1 (cleanly cracked)</description>
 		<year>1984</year>
 		<publisher>Peachtree Software</publisher>
 
@@ -7215,7 +7215,7 @@
 	</software>
 
 	<software name="alienadd">
-		<description>Alien Addition (clean crack)</description>
+		<description>Alien Addition (cleanly cracked)</description>
 		<year>1982</year>
 		<publisher>Developmental Learning Materials</publisher>
 
@@ -7227,7 +7227,7 @@
 	</software>
 
 	<software name="amhisadv">
-		<description>American History Adventure (clean crack)</description>
+		<description>American History Adventure (cleanly cracked)</description>
 		<year>1984</year>
 		<publisher>Queue Inc.</publisher>
 
@@ -7244,7 +7244,7 @@
 	</software>
 
 	<software name="animkngd">
-		<description>Animal Kingdom (clean crack)</description>
+		<description>Animal Kingdom (cleanly cracked)</description>
 		<year>1985</year>
 		<publisher>Unicorn Software</publisher>
 
@@ -7261,7 +7261,7 @@
 	</software>
 
 	<software name="arkanoid">
-		<description>Arkanoid (clean crack)</description>
+		<description>Arkanoid (cleanly cracked)</description>
 		<year>1988</year>
 		<publisher>Taito America</publisher>
 		<info name="usage" value="Works with Apple II Mouse Card in slot 4: -sl4 mouse" />
@@ -7274,7 +7274,7 @@
 	</software>
 
 	<software name="ballblzr">
-		<description>BallBlazer (clean crack)</description>
+		<description>BallBlazer (cleanly cracked)</description>
 		<year>1985</year>
 		<publisher>Lucasfilm Games</publisher>
 
@@ -7286,7 +7286,7 @@
 	</software>
 
 	<software name="bandsaw">
-		<description>Band Saw and Shaper Safety (clean crack)</description>
+		<description>Band Saw and Shaper Safety (cleanly cracked)</description>
 		<year>1986</year>
 		<publisher>Abraxas Basic Courseware</publisher>
 
@@ -7298,7 +7298,7 @@
 	</software>
 
 	<software name="basmathf">
-		<description>Basic Math Facts and Games (clean crack)</description>
+		<description>Basic Math Facts and Games (cleanly cracked)</description>
 		<year>1981</year>
 		<publisher>Random House</publisher>
 
@@ -7310,7 +7310,7 @@
 	</software>
 
 	<software name="basvocb">
-		<description>Basic Vocabulary Builder Demo (clean crack)</description>
+		<description>Basic Vocabulary Builder Demo (cleanly cracked)</description>
 		<year>1984</year>
 		<publisher>National Textbook Company</publisher>
 
@@ -7322,7 +7322,7 @@
 	</software>
 
 	<software name="beerrun">
-		<description>Beer Run (clean crack)</description>
+		<description>Beer Run (cleanly cracked)</description>
 		<year>1981</year>
 		<publisher>Sirius Software</publisher>
 
@@ -7334,7 +7334,7 @@
 	</software>
 
 	<software name="bigbkmkr">
-		<description>Big Book Maker (clean crack)</description>
+		<description>Big Book Maker (cleanly cracked)</description>
 		<year>1992</year>
 		<publisher>Pelican Software</publisher>
 
@@ -7361,7 +7361,7 @@
 	</software>
 
 	<software name="bingoha">
-		<description>Bingo Bugglebee Presents: Home Alone (clean crack)</description>
+		<description>Bingo Bugglebee Presents: Home Alone (cleanly cracked)</description>
 		<year>1985</year>
 		<publisher>Quest Learning Systems</publisher>
 
@@ -7373,7 +7373,7 @@
 	</software>
 
 	<software name="bingoos">
-		<description>Bingo Bugglebee Presents: Outdoor Safety (clean crack)</description>
+		<description>Bingo Bugglebee Presents: Outdoor Safety (cleanly cracked)</description>
 		<year>1985</year>
 		<publisher>Quest Learning Systems</publisher>
 
@@ -7385,7 +7385,7 @@
 	</software>
 
 	<software name="binomult">
-		<description>Binomial Multiplication (clean crack)</description>
+		<description>Binomial Multiplication (cleanly cracked)</description>
 		<year>1984</year>
 		<publisher>Mindscape</publisher>
 
@@ -7397,7 +7397,7 @@
 	</software>
 
 	<software name="blzpdls">
-		<description>Blazing Paddles (clean crack)</description>
+		<description>Blazing Paddles (cleanly cracked)</description>
 		<year>1985</year>
 		<publisher>Baudville</publisher>
 		<info name="usage" value="Works with Apple II Mouse Card in slot 4: -sl4 mouse" />
@@ -7409,7 +7409,7 @@
 	</software>
 
 	<software name="bmblgmes">
-		<description>Bumble Games (clean crack)</description>
+		<description>Bumble Games (cleanly cracked)</description>
 		<year>1982</year>
 		<publisher>The Learning Company</publisher>
 
@@ -7421,7 +7421,7 @@
 	</software>
 
 	<software name="bopgwdc">
-		<description>Boppie's Great Word Chase (clean crack)</description>
+		<description>Boppie's Great Word Chase (cleanly cracked)</description>
 		<year>1985</year>
 		<publisher>Developmental Learning Materials</publisher>
 
@@ -7433,7 +7433,7 @@
 	</software>
 
 	<software name="bounce">
-		<description>Bounce (clean crack)</description>
+		<description>Bounce (cleanly cracked)</description>
 		<year>1988</year>
 		<publisher>Sunburst</publisher>
 
@@ -7445,7 +7445,7 @@
 	</software>
 
 	<software name="bridge40">
-		<description>Bridge 4.0 (clean crack)</description>
+		<description>Bridge 4.0 (cleanly cracked)</description>
 		<year>1983</year>
 		<publisher>Artworx</publisher>
 
@@ -7457,7 +7457,7 @@
 	</software>
 
 	<software name="btime">
-		<description>BurgerTime (clean crack)</description>
+		<description>BurgerTime (cleanly cracked)</description>
 		<year>1982</year>
 		<publisher>Mattel Electronics</publisher>
 
@@ -7469,7 +7469,7 @@
 	</software>
 
 	<software name="bzone">
-		<description>Battlezone (clean crack)</description>
+		<description>Battlezone (cleanly cracked)</description>
 		<year>1983</year>
 		<publisher>Atarisoft</publisher>
 
@@ -7481,7 +7481,7 @@
 	</software>
 
 	<software name="calgames">
-		<description>California Games (clean crack)</description>
+		<description>California Games (cleanly cracked)</description>
 		<year>1987</year>
 		<publisher>Epyx</publisher>
 
@@ -7498,7 +7498,7 @@
 	</software>
 
 	<software name="calskils">
-		<description>Calendar Skills (version 08.31.86) (clean crack)</description>
+		<description>Calendar Skills (version 08.31.86) (cleanly cracked)</description>
 		<year>1986</year>
 		<publisher>Hartley Courseware, Inc.</publisher>
 
@@ -7510,7 +7510,7 @@
 	</software>
 
 	<software name="casegtr">
-		<description>Case of the Great Train Robbery (clean crack)</description>
+		<description>Case of the Great Train Robbery (cleanly cracked)</description>
 		<year>1986</year>
 		<publisher>Troll Associates</publisher>
 
@@ -7522,7 +7522,7 @@
 	</software>
 
 	<software name="casemisc">
-		<description>Case of the Missing Chick (clean crack)</description>
+		<description>Case of the Missing Chick (cleanly cracked)</description>
 		<year>1986</year>
 		<publisher>Troll Associates</publisher>
 
@@ -7534,7 +7534,7 @@
 	</software>
 
 	<software name="catmouse">
-		<description>Cat 'n Mouse (clean crack)</description>
+		<description>Cat 'n Mouse (cleanly cracked)</description>
 		<year>1986</year>
 		<publisher>Mindplay</publisher>
 
@@ -7546,7 +7546,7 @@
 	</software>
 
 	<software name="centiped">
-		<description>Centipede (clean crack)</description>
+		<description>Centipede (cleanly cracked)</description>
 		<year>1983</year>
 		<publisher>Atarisoft</publisher>
 
@@ -7558,7 +7558,7 @@
 	</software>
 
 	<software name="cgotrspc">
-		<description>Curious George In Outer Space (clean crack)</description>
+		<description>Curious George In Outer Space (cleanly cracked)</description>
 		<year>1989</year>
 		<publisher>Developmental Learning Materials</publisher>
 
@@ -7575,7 +7575,7 @@
 	</software>
 
 	<software name="cgshopng">
-		<description>Curious George Goes Shopping (clean crack)</description>
+		<description>Curious George Goes Shopping (cleanly cracked)</description>
 		<year>1989</year>
 		<publisher>Developmental Learning Materials</publisher>
 
@@ -7592,7 +7592,7 @@
 	</software>
 
 	<software name="chalmath">
-		<description>Challenge Math (clean crack)</description>
+		<description>Challenge Math (cleanly cracked)</description>
 		<year>1982</year>
 		<publisher>Sunburst</publisher>
 
@@ -7604,7 +7604,7 @@
 	</software>
 
 	<software name="chbr123">
-		<description>Charlie Brown's 1-2-3s (clean crack)</description>
+		<description>Charlie Brown's 1-2-3s (cleanly cracked)</description>
 		<year>1985</year>
 		<publisher>Random House</publisher>
 
@@ -7621,7 +7621,7 @@
 	</software>
 
 	<software name="chbrabc">
-		<description>Charlie Brown's ABCs (clean crack)</description>
+		<description>Charlie Brown's ABCs (cleanly cracked)</description>
 		<year>1984</year>
 		<publisher>Random House</publisher>
 
@@ -7638,7 +7638,7 @@
 	</software>
 
 	<software name="chldrnr">
-		<description>Championship Lode Runner (clean crack)</description>
+		<description>Championship Lode Runner (cleanly cracked)</description>
 		<year>1984</year>
 		<publisher>Broderbund</publisher>
 
@@ -7650,7 +7650,7 @@
 	</software>
 
 	<software name="chwrest">
-		<description>Championship Wrestling (clean crack)</description>
+		<description>Championship Wrestling (cleanly cracked)</description>
 		<year>1986</year>
 		<publisher>Epyx</publisher>
 
@@ -7667,7 +7667,7 @@
 	</software>
 
 	<software name="clabcalc">
-		<description>Computer Laboratory for Calculus (clean crack)</description>
+		<description>Computer Laboratory for Calculus (cleanly cracked)</description>
 		<year>1985</year>
 		<publisher>The Math Lab</publisher>
 
@@ -7679,7 +7679,7 @@
 	</software>
 
 	<software name="clasanbk">
-		<description>Classifying Animals With Backbones (clean crack)</description>
+		<description>Classifying Animals With Backbones (cleanly cracked)</description>
 		<year>1985</year>
 		<publisher>D.C. Heath and Company</publisher>
 
@@ -7691,7 +7691,7 @@
 	</software>
 
 	<software name="clasmate">
-		<description>ClassMate (clean crack)</description>
+		<description>ClassMate (cleanly cracked)</description>
 		<year>1987</year>
 		<publisher>Davidson and Associates</publisher>
 
@@ -7703,7 +7703,7 @@
 	</software>
 
 	<software name="cltrcy">
-		<description>Computer Literacy: Introduction (clean crack)</description>
+		<description>Computer Literacy: Introduction (cleanly cracked)</description>
 		<year>1982</year>
 		<publisher>Control Data Corporation</publisher>
 
@@ -7715,7 +7715,7 @@
 	</software>
 
 	<software name="colorme">
-		<description>Color Me (clean crack)</description>
+		<description>Color Me (cleanly cracked)</description>
 		<year>1985</year>
 		<publisher>Mindscape</publisher>
 
@@ -7747,7 +7747,7 @@
 	</software>
 
 	<software name="commando">
-		<description>Commando (clean crack)</description>
+		<description>Commando (cleanly cracked)</description>
 		<year>1987</year>
 		<publisher>Data East</publisher>
 
@@ -7759,7 +7759,7 @@
 	</software>
 
 	<software name="compread">
-		<description>Compu-Read 3.4 (clean crack)</description>
+		<description>Compu-Read 3.4 (cleanly cracked)</description>
 		<year>1982</year>
 		<publisher>Edu-Ware Services Inc.</publisher>
 
@@ -7771,7 +7771,7 @@
 	</software>
 
 	<software name="conan">
-		<description>Conan (clean crack)</description>
+		<description>Conan (cleanly cracked)</description>
 		<year>1984</year>
 		<publisher>DataSoft</publisher>
 
@@ -7788,7 +7788,7 @@
 	</software>
 
 	<software name="cotntale">
-		<description>Cotton Tales (clean crack)</description>
+		<description>Cotton Tales (cleanly cracked)</description>
 		<year>1987</year>
 		<publisher>Mindplay</publisher>
 
@@ -7800,7 +7800,7 @@
 	</software>
 
 	<software name="crcreate">
-		<description>Creature Creator (clean crack)</description>
+		<description>Creature Creator (cleanly cracked)</description>
 		<year>1983</year>
 		<publisher>DesignWare</publisher>
 
@@ -7812,7 +7812,7 @@
 	</software>
 
 	<software name="creation">
-		<description>Creation (clean crack)</description>
+		<description>Creation (cleanly cracked)</description>
 		<year>1988</year>
 		<publisher>Pelican Software</publisher>
 
@@ -7829,7 +7829,7 @@
 	</software>
 
 	<software name="crumbetr">
-		<description>Crumb Eater (clean crack)</description>
+		<description>Crumb Eater (cleanly cracked)</description>
 		<year>1983</year>
 		<publisher>Davka Corporation</publisher>
 
@@ -7841,7 +7841,7 @@
 	</software>
 
 	<software name="cryptcbe">
-		<description>Crypto Cube (clean crack)</description>
+		<description>Crypto Cube (cleanly cracked)</description>
 		<year>1983</year>
 		<publisher>DesignWare</publisher>
 
@@ -7853,7 +7853,7 @@
 	</software>
 
 	<software name="cseefft">
-		<description>Cause and Effect: What Makes It Happen? (clean crack)</description>
+		<description>Cause and Effect: What Makes It Happen? (cleanly cracked)</description>
 		<year>1988</year>
 		<publisher>Troll Associates</publisher>
 
@@ -7865,7 +7865,7 @@
 	</software>
 
 	<software name="deathswd">
-		<description>Death Sword (clean crack)</description>
+		<description>Death Sword (cleanly cracked)</description>
 		<year>1988</year>
 		<publisher>Epyx</publisher>
 
@@ -7877,7 +7877,7 @@
 	</software>
 
 	<software name="decdisc">
-		<description>Decimal Discovery (clean crack)</description>
+		<description>Decimal Discovery (cleanly cracked)</description>
 		<year>1986</year>
 		<publisher>Developmental Learning Materials</publisher>
 
@@ -7889,7 +7889,7 @@
 	</software>
 
 	<software name="decimals">
-		<description>Decimals (ver 3.0) (clean crack)</description>
+		<description>Decimals (ver 3.0) (cleanly cracked)</description>
 		<year>1982</year>
 		<publisher>Edu-Ware</publisher>
 
@@ -7901,7 +7901,7 @@
 	</software>
 
 	<software name="defender">
-		<description>Defender (clean crack)</description>
+		<description>Defender (cleanly cracked)</description>
 		<year>1983</year>
 		<publisher>Atarisoft</publisher>
 
@@ -7913,7 +7913,7 @@
 	</software>
 
 	<software name="deltadrw">
-		<description>Delta Drawing (clean crack)</description>
+		<description>Delta Drawing (cleanly cracked)</description>
 		<year>1982</year>
 		<publisher>Spinnaker</publisher>
 
@@ -7925,7 +7925,7 @@
 	</software>
 
 	<software name="digduga">
-		<description>Dig Dug (Atarisoft) (clean crack)</description>
+		<description>Dig Dug (Atarisoft) (cleanly cracked)</description>
 		<year>1983</year>
 		<publisher>Atarisoft</publisher>
 
@@ -7937,7 +7937,7 @@
 	</software>
 
 	<software name="digdug">
-		<description>Dig Dug (Thunder Mountain) (clean crack)</description>
+		<description>Dig Dug (Thunder Mountain) (cleanly cracked)</description>
 		<year>1983</year>
 		<publisher>Thunder Mountain</publisher>
 
@@ -7949,7 +7949,7 @@
 	</software>
 
 	<software name="dinodig">
-		<description>Dino Dig (clean crack)</description>
+		<description>Dino Dig (cleanly cracked)</description>
 		<year>1992</year>
 		<publisher>Troll Associates</publisher>
 
@@ -7961,7 +7961,7 @@
 	</software>
 
 	<software name="dinoeggs">
-		<description>Dino Eggs (clean crack)</description>
+		<description>Dino Eggs (cleanly cracked)</description>
 		<year>1983</year>
 		<publisher>Micro Fun</publisher>
 
@@ -7973,7 +7973,7 @@
 	</software>
 
 	<software name="dinosars">
-		<description>Dinosaurs (clean crack)</description>
+		<description>Dinosaurs (cleanly cracked)</description>
 		<year>1984</year>
 		<publisher>Advanced Ideas, Inc.</publisher>
 
@@ -7985,7 +7985,7 @@
 	</software>
 
 	<software name="divebmbr">
-		<description>Dive Bomber (clean crack)</description>
+		<description>Dive Bomber (cleanly cracked)</description>
 		<year>1988</year>
 		<publisher>Acme Animation, Inc.</publisher>
 
@@ -7997,7 +7997,7 @@
 	</software>
 
 	<software name="dkong">
-		<description>Donkey Kong (clean crack)</description>
+		<description>Donkey Kong (cleanly cracked)</description>
 		<year>1983</year>
 		<publisher>Atarisoft</publisher>
 
@@ -8009,7 +8009,7 @@
 	</software>
 
 	<software name="dunzhin">
-		<description>Dunzhin (clean crack)</description>
+		<description>Dunzhin (cleanly cracked)</description>
 		<year>1982</year>
 		<publisher>Screenplay</publisher>
 
@@ -8021,7 +8021,7 @@
 	</software>
 
 	<software name="dynoqst">
-		<description>Dyno-Quest (clean crack)</description>
+		<description>Dyno-Quest (cleanly cracked)</description>
 		<year>1984</year>
 		<publisher>Mindplay</publisher>
 
@@ -8033,7 +8033,7 @@
 	</software>
 
 	<software name="dyohachd">
-		<description>Design Your Own Home: Architectural Design (clean crack)</description>
+		<description>Design Your Own Home: Architectural Design (cleanly cracked)</description>
 		<year>1984</year>
 		<publisher>Avant-Garde Publishing Corp.</publisher>
 
@@ -8055,7 +8055,7 @@
 	</software>
 
 	<software name="dyoharch">
-		<description>Design Your Own Home: Architectural (clean crack)</description>
+		<description>Design Your Own Home: Architectural (cleanly cracked)</description>
 		<year>1983</year>
 		<publisher>Avant-Garde Publishing Corp.</publisher>
 
@@ -8067,7 +8067,7 @@
 	</software>
 
 	<software name="dyoh">
-		<description>Design Your Own Home: Interior Design (clean crack)</description>
+		<description>Design Your Own Home: Interior Design (cleanly cracked)</description>
 		<year>1986</year>
 		<publisher>Avant-Garde Publishing Corp.</publisher>
 
@@ -8089,7 +8089,7 @@
 	</software>
 
 	<software name="easyabc">
-		<description>Easy as ABC (clean crack)</description>
+		<description>Easy as ABC (cleanly cracked)</description>
 		<year>1984</year>
 		<publisher>Springboard Software</publisher>
 
@@ -8101,7 +8101,7 @@
 	</software>
 
 	<software name="easyrddm">
-		<description>Easy Reader Demo (clean crack)</description>
+		<description>Easy Reader Demo (cleanly cracked)</description>
 		<year>1983</year>
 		<publisher>American Educational Computer, Inc.</publisher>
 
@@ -8128,7 +8128,7 @@
 	</software>
 
 	<software name="easystr">
-		<description>Easy Street (clean crack)</description>
+		<description>Easy Street (cleanly cracked)</description>
 		<year>1988</year>
 		<publisher>Mindplay</publisher>
 
@@ -8140,7 +8140,7 @@
 	</software>
 
 	<software name="ecryfarm">
-		<description>Electric Crayon Fun On The Farm (clean crack)</description>
+		<description>Electric Crayon Fun On The Farm (cleanly cracked)</description>
 		<year>1986</year>
 		<publisher>Polarware</publisher>
 		<info name="usage" value="Works with Apple II Mouse Card in slot 4: -sl4 mouse" />
@@ -8153,7 +8153,7 @@
 	</software>
 
 	<software name="educalc">
-		<description>Edu-Calc (clean crack)</description>
+		<description>Edu-Calc (cleanly cracked)</description>
 		<year>1985</year>
 		<publisher>Grolier</publisher>
 
@@ -8170,7 +8170,7 @@
 	</software>
 
 	<software name="egyc">
-		<description>Early Games For Young Children (clean crack)</description>
+		<description>Early Games For Young Children (cleanly cracked)</description>
 		<year>1982</year>
 		<publisher>Springboard</publisher>
 
@@ -8182,7 +8182,7 @@
 	</software>
 
 	<software name="euronat">
-		<description>European Nations And Locations (clean crack)</description>
+		<description>European Nations And Locations (cleanly cracked)</description>
 		<year>1985</year>
 		<publisher>DesignWare, Inc.</publisher>
 
@@ -8194,7 +8194,7 @@
 	</software>
 
 	<software name="expsctmp">
-		<description>Exploring Science: Temperature (clean crack)</description>
+		<description>Exploring Science: Temperature (cleanly cracked)</description>
 		<year>1988</year>
 		<publisher>Sunburst</publisher>
 
@@ -8208,7 +8208,7 @@
 <!-- end 4am adds, A-E -->
 <!-- 4am adds, F-L -->
 	<software name="1stdegle">
-		<description>First Degree Linear Equations (clean crack)</description>
+		<description>First Degree Linear Equations (cleanly cracked)</description>
 		<year>1984</year>
 		<publisher>Mindscape</publisher>
 
@@ -8220,7 +8220,7 @@
 	</software>
 
 	<software name="facemkr">
-		<description>Facemaker (clean crack)</description>
+		<description>Facemaker (cleanly cracked)</description>
 		<year>1982</year>
 		<publisher>Spinnaker</publisher>
 
@@ -8232,7 +8232,7 @@
 	</software>
 
 	<software name="falcons">
-		<description>Falcons (clean crack)</description>
+		<description>Falcons (cleanly cracked)</description>
 		<year>1981</year>
 		<publisher>Piccadilly Software</publisher>
 
@@ -8244,7 +8244,7 @@
 	</software>
 
 	<software name="fantlrd">
-		<description>Professor Davensteev's Fantasy Land (Red Level) (clean crack)</description>
+		<description>Professor Davensteev's Fantasy Land (Red Level) (cleanly cracked)</description>
 		<year>1983</year>
 		<publisher>Learning Well / Methods &amp; Solutions</publisher>
 
@@ -8256,7 +8256,7 @@
 	</software>
 
 	<software name="fctalgex">
-		<description>Factoring Algebraic Expressions (clean crack)</description>
+		<description>Factoring Algebraic Expressions (cleanly cracked)</description>
 		<year>1984</year>
 		<publisher>Mindscape</publisher>
 
@@ -8268,7 +8268,7 @@
 	</software>
 
 	<software name="finfacts">
-		<description>Financial Facts (clean crack)</description>
+		<description>Financial Facts (cleanly cracked)</description>
 		<year>1981</year>
 		<publisher>Advanced Operating Systems</publisher>
 
@@ -8280,7 +8280,7 @@
 	</software>
 
 	<software name="flshsphc">
-		<description>Flash Spell Helicopter (clean crack)</description>
+		<description>Flash Spell Helicopter (cleanly cracked)</description>
 		<year>1983</year>
 		<publisher>Microcomputer Workships Courseware</publisher>
 
@@ -8292,7 +8292,7 @@
 	</software>
 
 	<software name="flycolor">
-		<description>Flying Colors (clean crack)</description>
+		<description>Flying Colors (cleanly cracked)</description>
 		<year>1983</year>
 		<publisher>The Computer Colorworks</publisher>
 
@@ -8304,7 +8304,7 @@
 	</software>
 
 	<software name="forcemtn">
-		<description>Force And Motion (clean crack)</description>
+		<description>Force And Motion (cleanly cracked)</description>
 		<year>1990</year>
 		<publisher>Queue, Inc.</publisher>
 
@@ -8321,7 +8321,7 @@
 	</software>
 
 	<software name="fornext">
-		<description>FOR Your NEXT Adventure: FOR-NEXT Loops (clean crack)</description>
+		<description>FOR Your NEXT Adventure: FOR-NEXT Loops (cleanly cracked)</description>
 		<year>1985</year>
 		<publisher>Sunburst</publisher>
 
@@ -8333,7 +8333,7 @@
 	</software>
 
 	<software name="frctnoid">
-		<description>Fraction-oids (clean crack)</description>
+		<description>Fraction-oids (cleanly cracked)</description>
 		<year>1989</year>
 		<publisher>Mindplay</publisher>
 
@@ -8345,7 +8345,7 @@
 	</software>
 
 	<software name="frctns2">
-		<description>Fractions II (clean crack)</description>
+		<description>Fractions II (cleanly cracked)</description>
 		<year>1987</year>
 		<publisher>Silver Burdett Company</publisher>
 
@@ -8357,7 +8357,7 @@
 	</software>
 
 	<software name="frctntut">
-		<description>Fraction Tutorial (clean crack)</description>
+		<description>Fraction Tutorial (cleanly cracked)</description>
 		<year>19??</year>
 		<publisher>Opportunities For Learning</publisher>
 
@@ -8374,7 +8374,7 @@
 	</software>
 
 	<software name="fredpzad">
-		<description>Freddy's Puzzling Adventures (clean crack)</description>
+		<description>Freddy's Puzzling Adventures (cleanly cracked)</description>
 		<year>1984</year>
 		<publisher>Developmental Learning Materials</publisher>
 
@@ -8386,7 +8386,7 @@
 	</software>
 
 	<software name="frenchvb">
-		<description>French Vocabulary Builder (clean crack)</description>
+		<description>French Vocabulary Builder (cleanly cracked)</description>
 		<year>1982</year>
 		<publisher>Control Data Corporation</publisher>
 
@@ -8398,7 +8398,7 @@
 	</software>
 
 	<software name="frogdog">
-		<description>Frogs, Dogs, Kittens, and Kids 1 (clean crack)</description>
+		<description>Frogs, Dogs, Kittens, and Kids 1 (cleanly cracked)</description>
 		<year>1988</year>
 		<publisher>Hartley Courseware</publisher>
 
@@ -8420,7 +8420,7 @@
 	</software>
 
 	<software name="frogger2">
-		<description>Frogger II: Threedeep (clean crack)</description>
+		<description>Frogger II: Threedeep (cleanly cracked)</description>
 		<year>1984</year>
 		<publisher>Sega Enterprises Inc.</publisher>
 
@@ -8432,7 +8432,7 @@
 	</software>
 
 	<software name="frogger">
-		<description>Frogger (clean crack)</description>
+		<description>Frogger (cleanly cracked)</description>
 		<year>1981</year>
 		<publisher>Sierra On-Line</publisher>
 
@@ -8444,7 +8444,7 @@
 	</software>
 
 	<software name="frogjon">
-		<description>Frog Jump Ordering Numbers (clean crack)</description>
+		<description>Frog Jump Ordering Numbers (cleanly cracked)</description>
 		<year>1985</year>
 		<publisher>Scott, Foresman and Company</publisher>
 
@@ -8456,7 +8456,7 @@
 	</software>
 
 	<software name="galaxat">
-		<description>Galaxian (Atarisoft) (clean crack)</description>
+		<description>Galaxian (Atarisoft) (cleanly cracked)</description>
 		<year>1983</year>
 		<publisher>Atarisoft</publisher>
 
@@ -8468,7 +8468,7 @@
 	</software>
 
 	<software name="galaxian">
-		<description>Galaxian (Thunder Mountain) (clean crack)</description>
+		<description>Galaxian (Thunder Mountain) (cleanly cracked)</description>
 		<year>1983</year>
 		<publisher>Thunder Mountain</publisher>
 
@@ -8480,7 +8480,7 @@
 	</software>
 
 	<software name="garfleyw">
-		<description>Garfield Eat Your Words (clean crack)</description>
+		<description>Garfield Eat Your Words (cleanly cracked)</description>
 		<year>1985</year>
 		<publisher>Random House</publisher>
 
@@ -8497,7 +8497,7 @@
 	</software>
 
 	<software name="genemach">
-		<description>Gene Machine (version 2.0) (clean crack)</description>
+		<description>Gene Machine (version 2.0) (cleanly cracked)</description>
 		<year>1983</year>
 		<publisher>HRM Software</publisher>
 
@@ -8509,7 +8509,7 @@
 	</software>
 
 	<software name="gertrude">
-		<description>Gertrude's Secrets (version 1.2) (clean crack)</description>
+		<description>Gertrude's Secrets (version 1.2) (cleanly cracked)</description>
 		<year>1982</year>
 		<publisher>The Learning Company</publisher>
 
@@ -8521,7 +8521,7 @@
 	</software>
 
 	<software name="gramgrem">
-		<description>Grammar Gremlins (clean crack)</description>
+		<description>Grammar Gremlins (cleanly cracked)</description>
 		<year>1986</year>
 		<publisher>Davidson &amp; Associates, Inc.</publisher>
 
@@ -8538,7 +8538,7 @@
 	</software>
 
 	<software name="grammst2">
-		<description>Grammar Mastery II (clean crack)</description>
+		<description>Grammar Mastery II (cleanly cracked)</description>
 		<year>1987</year>
 		<publisher>American Language Academy</publisher>
 
@@ -8630,7 +8630,7 @@
 	</software>
 
 	<software name="greetcrd">
-		<description>Greeting Card Maker (clean crack)</description>
+		<description>Greeting Card Maker (cleanly cracked)</description>
 		<year>1986</year>
 		<publisher>Activision</publisher>
 
@@ -8642,7 +8642,7 @@
 	</software>
 
 	<software name="gremlins">
-		<description>Gremlins (clean crack)</description>
+		<description>Gremlins (cleanly cracked)</description>
 		<year>1984</year>
 		<publisher>Atarisoft</publisher>
 
@@ -8654,7 +8654,7 @@
 	</software>
 
 	<software name="grphlnfc">
-		<description>Graphing Linear Functions (clean crack)</description>
+		<description>Graphing Linear Functions (cleanly cracked)</description>
 		<year>1984</year>
 		<publisher>Microcomputer Workshops Courseware</publisher>
 
@@ -8666,7 +8666,7 @@
 	</software>
 
 	<software name="gulfstrk">
-		<description>Gulf Strike (clean crack)</description>
+		<description>Gulf Strike (cleanly cracked)</description>
 		<year>1985</year>
 		<publisher>The Avalon Hill Game Company</publisher>
 
@@ -8678,7 +8678,7 @@
 	</software>
 
 	<software name="gumball">
-		<description>Gumball (clean crack)</description>
+		<description>Gumball (cleanly cracked)</description>
 		<!-- Corrected image 09/24/2016 -->
 		<year>1983</year>
 		<publisher>Broderbund</publisher>
@@ -8691,7 +8691,7 @@
 	</software>
 
 	<software name="heredog">
-		<description>Heredity Dog (clean crack)</description>
+		<description>Heredity Dog (cleanly cracked)</description>
 		<year>1983</year>
 		<publisher>HRM Software</publisher>
 
@@ -8703,7 +8703,7 @@
 	</software>
 
 	<software name="heydidle">
-		<description>Hey Diddle Diddle (clean crack)</description>
+		<description>Hey Diddle Diddle (cleanly cracked)</description>
 		<year>1983</year>
 		<publisher>Spinnaker</publisher>
 
@@ -8715,7 +8715,7 @@
 	</software>
 
 	<software name="homehlpr">
-		<description>Homework Helper: Writing (clean crack)</description>
+		<description>Homework Helper: Writing (cleanly cracked)</description>
 		<year>1985</year>
 		<publisher>Spinnaker</publisher>
 
@@ -8752,7 +8752,7 @@
 	</software>
 
 	<software name="homewrtr">
-		<description>Homework Writer (clean crack)</description>
+		<description>Homework Writer (cleanly cracked)</description>
 		<year>1988</year>
 		<publisher>Scholastic, Inc.</publisher>
 
@@ -8769,7 +8769,7 @@
 	</software>
 
 	<software name="housefir">
-		<description>House-A-Fire! (clean crack)</description>
+		<description>House-A-Fire! (cleanly cracked)</description>
 		<year>1988</year>
 		<publisher>Decision Development Co</publisher>
 
@@ -8786,7 +8786,7 @@
 	</software>
 
 	<software name="howwest">
-		<description>How The West Was One + Three x Four (clean crack)</description>
+		<description>How The West Was One + Three x Four (cleanly cracked)</description>
 		<year>1987</year>
 		<publisher>Sunburst</publisher>
 
@@ -8798,7 +8798,7 @@
 	</software>
 
 	<software name="impmiss2">
-		<description>Impossible Mission II (clean crack)</description>
+		<description>Impossible Mission II (cleanly cracked)</description>
 		<year>1988</year>
 		<publisher>Epyx</publisher>
 
@@ -8815,7 +8815,7 @@
 	</software>
 
 	<software name="invscmth">
-		<description>Investigating Secondary Mathematics With Computers (clean crack)</description>
+		<description>Investigating Secondary Mathematics With Computers (cleanly cracked)</description>
 		<year>1985</year>
 		<publisher>University of Massachusetts</publisher>
 
@@ -8832,7 +8832,7 @@
 	</software>
 
 	<software name="jackbnst">
-		<description>Jack And The Beanstalk (clean crack)</description>
+		<description>Jack And The Beanstalk (cleanly cracked)</description>
 		<year>1985</year>
 		<publisher>HRM Software</publisher>
 
@@ -8844,7 +8844,7 @@
 	</software>
 
 	<software name="jmpmthfl">
-		<description>Jumping Math Flash (clean crack)</description>
+		<description>Jumping Math Flash (cleanly cracked)</description>
 		<year>1988</year>
 		<publisher>Mindscape</publisher>
 
@@ -8856,7 +8856,7 @@
 	</software>
 
 	<software name="jumpman">
-		<description>Jumpman (clean crack)</description>
+		<description>Jumpman (cleanly cracked)</description>
 		<year>1983</year>
 		<publisher>Epyx</publisher>
 
@@ -8873,7 +8873,7 @@
 	</software>
 
 	<software name="junghunt">
-		<description>Jungle Hunt (clean crack)</description>
+		<description>Jungle Hunt (cleanly cracked)</description>
 		<year>1984</year>
 		<publisher>Atarisoft</publisher>
 
@@ -8885,7 +8885,7 @@
 	</software>
 
 	<software name="kenuston">
-		<description>Ken Uston's Professional Blackjack (v1.23) (clean crack)</description>
+		<description>Ken Uston's Professional Blackjack (v1.23) (cleanly cracked)</description>
 		<year>1983</year>
 		<publisher>Intelligent Statements, Inc.</publisher>
 
@@ -8897,7 +8897,7 @@
 	</software>
 
 	<software name="kidskeys">
-		<description>Kids On Keys (clean crack)</description>
+		<description>Kids On Keys (cleanly cracked)</description>
 		<year>1983</year>
 		<publisher>Spinnaker</publisher>
 
@@ -8909,7 +8909,7 @@
 	</software>
 
 	<software name="kindrcmp">
-		<description>Kindercomp (clean crack)</description>
+		<description>Kindercomp (cleanly cracked)</description>
 		<year>1983</year>
 		<publisher>Spinnaker</publisher>
 
@@ -8921,7 +8921,7 @@
 	</software>
 
 	<software name="kittenkf">
-		<description>Kittens, Kids, And A Frog (version 01.11.85) (clean crack)</description>
+		<description>Kittens, Kids, And A Frog (version 01.11.85) (cleanly cracked)</description>
 		<year>1985</year>
 		<publisher>Hartley Courseware, Inc.</publisher>
 
@@ -8938,7 +8938,7 @@
 	</software>
 
 	<software name="kmwldhis">
-		<description>Knowledge Master World History 1 (clean crack)</description>
+		<description>Knowledge Master World History 1 (cleanly cracked)</description>
 		<year>1987</year>
 		<publisher>Academic Hallmarks</publisher>
 
@@ -8950,7 +8950,7 @@
 	</software>
 
 	<software name="krelllgo">
-		<description>Krell's Logo (clean crack)</description>
+		<description>Krell's Logo (cleanly cracked)</description>
 		<year>1981</year>
 		<publisher>Krell</publisher>
 
@@ -8962,7 +8962,7 @@
 	</software>
 
 	<software name="viewkill">
-		<description>James Bond 007 In: A View To A Kill (clean crack)</description>
+		<description>James Bond 007 In: A View To A Kill (cleanly cracked)</description>
 		<year>1985</year>
 		<publisher>Mindscape</publisher>
 

--- a/hash/apple2_flop_orig.xml
+++ b/hash/apple2_flop_orig.xml
@@ -3,7 +3,7 @@
 
 <softwarelist name="apple2_flop_orig" description="Apple II 5.25 Original disks">
 
-  <software name="agusawoz">
+  <software name="agentusa">
     <description>Agent USA</description>
     <year>1984</year>
     <publisher>Scholastic</publisher>
@@ -18,7 +18,7 @@
     </part>
   </software>
 
-  <software name="arhrtwoz">
+  <software name="airheart">
     <description>Airheart</description>
     <year>1986</year>
     <publisher>Broderbund Software</publisher>
@@ -33,7 +33,7 @@
     </part>
   </software>
 
-  <software name="aambhwoz">
+  <software name="alambush">
     <description>Alien Ambush</description>
     <year>1981</year>
     <publisher>Micro Distributors</publisher>
@@ -48,7 +48,7 @@
     </part>
   </software>
 
-  <software name="ankhwoz">
+  <software name="ankh">
     <description>Ankh</description>
     <year>1983</year>
     <publisher>Datamost</publisher>
@@ -63,7 +63,7 @@
     </part>
   </software>
 
-  <software name="apcspwoz">
+  <software name="aplcdspd">
     <description>Apple Cider Spider</description>
     <year>1983</year>
     <publisher>Sierra On-Line</publisher>
@@ -78,7 +78,7 @@
     </part>
   </software>
 
-  <software name="agalxwoz">
+  <software name="agalxian">
     <description>Apple Galaxian</description>
     <year>1980</year>
     <publisher>Broderbund Software</publisher>
@@ -93,7 +93,7 @@
     </part>
   </software>
 
-  <software name="aquatwoz">
+  <software name="aquatron">
     <description>Aquatron</description>
     <year>1983</year>
     <publisher>Sierra On-Line</publisher>
@@ -108,7 +108,7 @@
     </part>
   </software>
 
-  <software name="archnwoz">
+  <software name="archon">
     <description>Archon: The Light and The Dark</description>
     <year>1984</year>
     <publisher>Electronic Arts</publisher>
@@ -123,7 +123,7 @@
     </part>
   </software>
 
-  <software name="ardyawoz">
+  <software name="ardyardv">
     <description>Ardy the Aardvark</description>
     <year>1983</year>
     <publisher>Datamost</publisher>
@@ -138,7 +138,7 @@
     </part>
   </software>
 
-  <software name="autobwoz">
+  <software name="autobahn">
     <description>Autobahn</description>
     <year>1981</year>
     <publisher>Sirius Software</publisher>
@@ -153,7 +153,7 @@
     </part>
   </software>
 
-  <software name="axisawoz">
+  <software name="axisassn">
     <description>Axis Assassin</description>
     <year>1982</year>
     <publisher>Electronic Arts</publisher>
@@ -168,7 +168,7 @@
     </part>
   </software>
 
-  <software name="aztecwoz">
+  <software name="aztec">
     <description>Aztec</description>
     <year>1982</year>
     <publisher>Datamost</publisher>
@@ -183,7 +183,7 @@
     </part>
   </software>
 
-  <software name="bdudewoz">
+  <software name="baddudes">
     <description>Bad Dudes</description>
     <year>1988</year>
     <publisher>Data East USA</publisher>
@@ -206,7 +206,7 @@
     </part>
   </software>
 
-  <software name="blblzwoz">
+  <software name="ballblaz">
     <description>Ballblazer</description>
     <year>1985</year>
     <publisher>Epyx</publisher>
@@ -221,7 +221,7 @@
     </part>
   </software>
 
-  <software name="batmnwoz">
+  <software name="batman">
     <description>Batman: The Caped Crusader</description>
     <year>1985</year>
     <publisher>Data East USA</publisher>
@@ -243,7 +243,7 @@
     </part>
   </software>
 
-  <software name="bcqftwoz">
+  <software name="bcqft">
     <description>BC's Quest for Tires</description>
     <year>1983</year>
     <publisher>Sierra On-Line</publisher>
@@ -258,7 +258,7 @@
     </part>
   </software>
 
-  <software name="bellhpwz">
+  <software name="bellhop">
     <description>Bellhop</description>
     <year>1982</year>
     <publisher>Hayden Book Company</publisher>
@@ -273,7 +273,7 @@
     </part>
   </software>
 
-  <software name="belrtwoz">
+  <software name="belwrt">
     <description>Below the Root</description>
     <year>1984</year>
     <publisher>Hayden Book Company</publisher>
@@ -295,7 +295,7 @@
     </part>
   </software>
 
-  <software name="tbilewoz">
+  <software name="bilestod">
     <description>The Bilestoad</description>
     <year>1983</year>
     <publisher>Datamost</publisher>
@@ -310,7 +310,7 @@
     </part>
   </software>
 
-  <software name="bgbatwoz">
+  <software name="bugbattl">
     <description>Bug Battle</description>
     <year>1982</year>
     <publisher>United Software of America</publisher>
@@ -325,7 +325,7 @@
     </part>
   </software>
 
-  <software name="cbbltwoz">
+  <software name="canbalbz">
     <description>Cannonball Blitz</description>
     <year>1982</year>
     <publisher>On-Line Systems</publisher>
@@ -340,7 +340,7 @@
     </part>
   </software>
 
-  <software name="cavocwoz">
+  <software name="cvrncsto">
     <description>Caverns of Callisto</description>
     <year>1983</year>
     <publisher>Origin Systems</publisher>
@@ -355,7 +355,7 @@
     </part>
   </software>
 
-  <software name="czerowoz">
+  <software name="ceilzero">
     <description>Ceiling Zero</description>
     <year>1981</year>
     <publisher>Turnkey Software</publisher>
@@ -370,7 +370,7 @@
     </part>
   </software>
 
-  <software name="centiwoz">
+  <software name="centiped">
     <description>Centipede</description>
     <year>1983</year>
     <publisher>Atarisoft</publisher>
@@ -385,7 +385,7 @@
     </part>
   </software>
 
-  <software name="comndowz">
+  <software name="commando">
     <description>Commando</description>
     <year>1987</year>
     <publisher>Data East USA</publisher>
@@ -400,7 +400,7 @@
     </part>
   </software>
 
-  <software name="cbongwoz">
+  <software name="congobng">
     <description>Congo Bongo</description>
     <year>1987</year>
     <publisher>SEGA Enterprises</publisher>
@@ -415,7 +415,7 @@
     </part>
   </software>
 
-  <software name="conqwwoz">
+  <software name="cnqwrlds">
     <description>Conquering Worlds</description>
     <year>1983</year>
     <publisher>Datamost</publisher>
@@ -430,7 +430,7 @@
     </part>
   </software>
 
-  <software name="coptswoz">
+  <software name="cptsrbrs">
     <description>Copts and Robbers</description>
     <year>1981</year>
     <publisher>Sirius Software</publisher>
@@ -445,7 +445,7 @@
     </part>
   </software>
 
-  <software name="cfairwoz">
+  <software name="counfair">
     <description>County Fair</description>
     <year>1981</year>
     <publisher>Datamost</publisher>
@@ -460,7 +460,7 @@
     </part>
   </software>
 
-  <software name="cmazewoz">
+  <software name="crmazey">
     <description>Crazy Mazey</description>
     <year>1982</year>
     <publisher>Datamost</publisher>
@@ -475,7 +475,7 @@
     </part>
   </software>
 
-  <software name="crismwoz">
+  <software name="crismntn">
     <description>Crisis Mountain</description>
     <year>1982</year>
     <publisher>Micro Fun</publisher>
@@ -490,7 +490,7 @@
     </part>
   </software>
 
-  <software name="crosfwoz">
+  <software name="crosfire">
     <description>Crossfire</description>
     <year>1981</year>
     <publisher>On-Line Systems</publisher>
@@ -505,7 +505,7 @@
     </part>
   </software>
 
-  <software name="cubitwoz">
+  <software name="cubit">
     <description>Cubit</description>
     <year>1983</year>
     <publisher>Micromax</publisher>
@@ -520,7 +520,7 @@
     </part>
   </software>
 
-  <software name="cstrkwoz">
+  <software name="cybrstrk">
     <description>Cyber Strike</description>
     <year>1980</year>
     <publisher>Sirius Software</publisher>
@@ -535,7 +535,7 @@
     </part>
   </software>
 
-  <software name="tdambwoz">
+  <software name="dambstrs">
     <description>The Dam Busters</description>
     <year>1985</year>
     <publisher>Accolade</publisher>
@@ -550,7 +550,7 @@
     </part>
   </software>
 
-  <software name="dswrdwoz">
+  <software name="deathswd">
     <description>Death Sword</description>
     <year>1987</year>
     <publisher>Epyx</publisher>
@@ -565,7 +565,22 @@
     </part>
   </software>
 
-  <software name="dstrywoz">
+  <software name="stargate">
+    <description>Defender II: Stargate</description>
+    <year>1983</year>
+    <publisher>Atarisoft</publisher>
+    <info name="release" value="2019-01-13"/>
+    <sharedfeat name="compatibility" value="A2,A2P,A2E,A2EE,A2C,A2GS" />
+    <!-- It runs on any Apple II with 48K. -->
+
+    <part name="flop1" interface="floppy_5_25">
+      <dataarea name="flop" size="233447">
+        <rom name="stargate.woz" size="233447" crc="379d894d" sha1="56d17415d622395bddbe7200adde32f4ad63b208" offset="0x0000" />
+      </dataarea>
+    </part>
+  </software>
+
+  <software name="destroyr">
     <description>Destroyer</description>
     <year>1986</year>
     <publisher>Epyx</publisher>
@@ -580,7 +595,7 @@
     </part>
   </software>
 
-  <software name="deggswoz">
+  <software name="dinoeggs">
     <description>Dino Eggs</description>
     <year>1983</year>
     <publisher>Micro Fun</publisher>
@@ -595,7 +610,7 @@
     </part>
   </software>
 
-  <software name="dbombwoz">
+  <software name="divebmbr">
     <description>Dive Bomber</description>
     <year>1988</year>
     <publisher>Epyx</publisher>
@@ -610,7 +625,7 @@
     </part>
   </software>
 
-  <software name="dkongwoz">
+  <software name="dkong">
     <description>Donkey Kong</description>
     <year>1983</year>
     <publisher>Atarisoft</publisher>
@@ -625,7 +640,7 @@
     </part>
   </software>
 
-  <software name="drolwoz">
+  <software name="drol">
     <description>Drol</description>
     <year>1983</year>
     <publisher>Broderbund Software</publisher>
@@ -640,7 +655,7 @@
     </part>
   </software>
 
-  <software name="dbeetwoz">
+  <software name="dungbeet">
     <description>Dung Beetles</description>
     <year>1982</year>
     <publisher>Datasoft</publisher>
@@ -655,7 +670,7 @@
     </part>
   </software>
 
-  <software name="teidowoz">
+  <software name="teidolon">
     <description>The Eidolon</description>
     <year>1985</year>
     <publisher>Epyx</publisher>
@@ -670,7 +685,7 @@
     </part>
   </software>
 
-  <software name="epochwoz">
+  <software name="epoch">
     <description>Epoch</description>
     <year>1981</year>
     <publisher>Sirius Software</publisher>
@@ -685,7 +700,7 @@
     </part>
   </software>
 
-  <software name="flcnswoz">
+  <software name="falcons">
     <description>Falcons</description>
     <year>1981</year>
     <publisher>Piccadilly Software</publisher>
@@ -701,7 +716,7 @@
   </software>
 
 
-  <software name="fnghtwoz">
+  <software name="fnight">
     <description>Fight Night</description>
     <year>1985</year>
     <publisher>Accolade</publisher>
@@ -716,7 +731,7 @@
     </part>
   </software>
 
-  <software name="fs2v20wz">
+  <software name="fs2v20">
     <description>Flight Simulator II (v2.0)</description>
     <year>1985</year>
     <publisher>Accolade</publisher>
@@ -731,7 +746,7 @@
     </part>
   </software>
 
-  <software name="floutwoz">
+  <software name="flipout">
     <description>Flip Out</description>
     <year>1982</year>
     <publisher>Sirius Software</publisher>
@@ -761,7 +776,7 @@
     </part>
   </software>
 
-  <software name="f1rcrwoz">
+  <software name="f1racer">
     <description>Formula 1 Racer</description>
     <year>1983</year>
     <publisher>Gentry Software</publisher>
@@ -776,7 +791,7 @@
     </part>
   </software>
 
-  <software name="ffallwoz">
+  <software name="freefall">
     <description>Free Fall</description>
     <year>1982</year>
     <publisher>Sirius Software</publisher>
@@ -791,7 +806,7 @@
     </part>
   </software>
 
-  <software name="frogrwoz">
+  <software name="frogger">
     <description>Frogger</description>
     <year>1981</year>
     <publisher>Sierra On-Line</publisher>
@@ -808,8 +823,8 @@
     </part>
   </software>
 
-  <software name="frog2woz">
-    <description>Frogger II</description>
+  <software name="frogger2">
+    <description>Frogger II: Threedeep</description>
     <year>1984</year>
     <publisher>SEGA Enterprises</publisher>
     <info name="release" value="2018-12-21"/>
@@ -823,7 +838,7 @@
     </part>
   </software>
 
-  <software name="gijoewoz">
+  <software name="gijoe">
     <description>G.I. Joe</description>
     <year>1985</year>
     <publisher>Epyx</publisher>
@@ -845,7 +860,7 @@
     </part>
   </software>
 
-  <software name="tgsewoz">
+  <software name="tgsumed">
     <description>The Games - Summer Edition</description>
     <year>1988</year>
     <publisher>Epyx</publisher>
@@ -881,7 +896,7 @@
     </part>
   </software>
 
-  <software name="gatowoz">
+  <software name="gato">
     <description>GATO</description>
     <year>1985</year>
     <publisher>Spectrum Holobyte</publisher>
@@ -896,7 +911,7 @@
     </part>
   </software>
 
-  <software name="gdrftwoz">
+  <software name="gendrift">
     <description>Genetic Drift</description>
     <year>1981</year>
     <publisher>Broderbund Software</publisher>
@@ -913,7 +928,7 @@
     </part>
   </software>
 
-  <software name="gbblrwoz">
+  <software name="gobbler">
     <description>Gobbler</description>
     <year>1981</year>
     <publisher>On-Line Systems</publisher>
@@ -928,7 +943,7 @@
     </part>
   </software>
 
-  <software name="gooniewz">
+  <software name="goonies">
     <description>The Goonies</description>
     <year>1985</year>
     <publisher>Datasoft</publisher>
@@ -943,7 +958,7 @@
     </part>
   </software>
 
-  <software name="gumblwoz">
+  <software name="gumball">
     <description>Gumball</description>
     <year>1983</year>
     <publisher>Broderbund Software</publisher>
@@ -958,7 +973,7 @@
     </part>
   </software>
 
-  <software name="heistwoz">
+  <software name="heist">
     <description>The Heist</description>
     <year>1983</year>
     <publisher>Micro Fun</publisher>
@@ -973,7 +988,7 @@
     </part>
   </software>
 
-  <software name="herowoz">
+  <software name="hero">
     <description>HERO - Helicopter Emergency Rescue Operation</description>
     <year>1983</year>
     <publisher>Activision</publisher>
@@ -988,7 +1003,7 @@
     </part>
   </software>
 
-  <software name="hadrnwoz">
+  <software name="hadron">
     <description>Hadron</description>
     <year>1981</year>
     <publisher>Sirius Software</publisher>
@@ -1003,7 +1018,7 @@
     </part>
   </software>
 
-  <software name="hhmackwz">
+  <software name="hhmack">
     <description>Hard Hat Mack</description>
     <year>1983</year>
     <publisher>Electronic Arts</publisher>
@@ -1017,7 +1032,7 @@
     </part>
   </software>
 
-  <software name="hrdblwoz">
+  <software name="hardball">
     <description>Hardball</description>
     <year>1985</year>
     <publisher>Accolade</publisher>
@@ -1032,7 +1047,7 @@
     </part>
   </software>
 
-  <software name="hedonwoz">
+  <software name="headon">
     <description>Head On</description>
     <year>1980</year>
     <publisher>California Pacific Computers</publisher>
@@ -1047,7 +1062,7 @@
     </part>
   </software>
 
-  <software name="hghrswoz">
+  <software name="highrise">
     <description>High Rise</description>
     <year>1983</year>
     <publisher>Micro Fun</publisher>
@@ -1062,7 +1077,7 @@
     </part>
   </software>
 
-  <software name="ikariwoz">
+  <software name="ikari">
     <description>Ikari Warriors</description>
     <year>1983</year>
     <publisher>Data East USA</publisher>
@@ -1084,7 +1099,7 @@
     </part>
   </software>
 
-  <software name="ik2vrwoz">
+  <software name="victroad">
     <description>Ikari Warriors 2: Victory Road</description>
     <year>1981</year>
     <publisher>Sirius Software</publisher>
@@ -1106,7 +1121,7 @@
     </part>
   </software>
 
-<software name="igrprwoz">
+<software name="igprix">
     <description>International Gran Prix</description>
     <year>1982</year>
     <publisher>MUSE Software</publisher>
@@ -1121,7 +1136,7 @@
     </part>
   </software>
 
-  <software name="jwbrkwoz">
+  <software name="jawbrekr">
     <description>Jawbreaker</description>
     <year>1981</year>
     <publisher>On-Line Systems</publisher>
@@ -1136,7 +1151,7 @@
     </part>
   </software>
 
-  <software name="jwbk2woz">
+  <software name="jawbrkr2">
     <description>Jawbreaker ][</description>
     <year>1982</year>
     <publisher>Sierra On-Line</publisher>
@@ -1153,7 +1168,7 @@
     </part>
   </software>
 
-  <software name="tjetwoz">
+  <software name="thejet">
     <description>The Jet</description>
     <year>1986</year>
     <publisher>subLOGIC</publisher>
@@ -1168,7 +1183,7 @@
     </part>
   </software>
 
-  <software name="joustwoz">
+  <software name="joust">
     <description>Joust</description>
     <year>1983</year>
     <publisher>Atarisoft</publisher>
@@ -1183,7 +1198,7 @@
     </part>
   </software>
 
-  <software name="1on1woz">
+  <software name="1on1">
     <description>Julius Erving and Larry Bird Go One on One</description>
     <year>1983</year>
     <publisher>Electronic Arts</publisher>
@@ -1198,7 +1213,7 @@
     </part>
   </software>
 
-  <software name="jhuntwoz">
+  <software name="junghunt">
     <description>Jungle Hunt</description>
     <year>1984</year>
     <publisher>Atarisoft</publisher>
@@ -1213,7 +1228,7 @@
     </part>
   </software>
 
-  <software name="kchmpwoz">
+  <software name="krtechm">
     <description>Karate Champ</description>
     <year>1985</year>
     <publisher>Data East</publisher>
@@ -1228,7 +1243,7 @@
     </part>
   </software>
 
-  <software name="krtkawoz">
+  <software name="karateka">
     <description>Karateka</description>
     <year>1984</year>
     <publisher>Broderbund Software</publisher>
@@ -1252,7 +1267,7 @@
     </part>
   </software>
 
-  <software name="kdnkiwoz">
+  <software name="kidniki">
     <description>Kid Niki</description>
     <year>1987</year>
     <publisher>Data East</publisher>
@@ -1274,7 +1289,7 @@
     </part>
   </software>
 
-  <software name="kngfmwoz">
+  <software name="kungfum">
     <description>Kung Fu Master</description>
     <year>1985</year>
     <publisher>Data East</publisher>
@@ -1289,7 +1304,7 @@
     </part>
   </software>
 
-  <software name="lacrkwoz">
+  <software name="lacrkdwn">
     <description>L.A. Crackdown</description>
     <year>1988</year>
     <publisher>Epyx</publisher>
@@ -1311,7 +1326,7 @@
     </part>
   </software>
 
-  <software name="lsttwoz">
+  <software name="losttomb">
     <description>Lost Tomb</description>
     <year>1984</year>
     <publisher>Datasoft</publisher>
@@ -1326,7 +1341,7 @@
     </part>
   </software>
 
-  <software name="maradwoz">
+  <software name="marauder">
     <description>Marauder</description>
     <year>1982</year>
     <publisher>On-Line Systems</publisher>
@@ -1341,7 +1356,7 @@
     </part>
   </software>
 
-  <software name="mmadnwoz">
+  <software name="marble">
     <description>Marble Madness</description>
     <year>1986</year>
     <publisher>Electronic Arts</publisher>
@@ -1363,7 +1378,7 @@
     </part>
   </software>
 
-  <software name="mrscswoz">
+  <software name="marscars">
     <description>Mars Cars</description>
     <year>1982</year>
     <publisher>Datamost</publisher>
@@ -1378,7 +1393,7 @@
     </part>
   </software>
 
-  <software name="matznwoz">
+  <software name="matezone">
     <description>Mating Zone</description>
     <year>1982</year>
     <publisher>Datamost</publisher>
@@ -1393,7 +1408,7 @@
     </part>
   </software>
 
-  <software name="mgabtwoz">
+  <software name="megabots">
     <description>Megabots</description>
     <year>1986</year>
     <publisher>Neosoft</publisher>
@@ -1408,8 +1423,8 @@
     </part>
   </software>
 
-  <software name="mamgcwoz">
-    <description>Might_and_Magic_-_Disk_A</description>
+  <software name="mightmg1">
+    <description>Might and Magic</description>
     <year>1986</year>
     <publisher>New World Computing</publisher>
     <info name="release" value="2018-09-08"/>
@@ -1442,7 +1457,7 @@
     </part>
   </software>
 
-  <software name="m2049woz">
+  <software name="minr2049">
     <description>Miner 2049er</description>
     <year>1982</year>
     <publisher>Micro Fun</publisher>
@@ -1457,7 +1472,7 @@
     </part>
   </software>
 
-  <software name="minitwoz">
+  <software name="minitman">
     <description>Minit Man</description>
     <year>1983</year>
     <publisher>Penguin Software</publisher>
@@ -1472,7 +1487,7 @@
     </part>
   </software>
 
-  <software name="impm2woz">
+  <software name="impmiss2">
     <description>Impossible Mission II</description>
     <year>1988</year>
     <publisher>Epyx</publisher>
@@ -1494,7 +1509,7 @@
     </part>
   </software>
 
-  <software name="mnmunwoz">
+  <software name="mnymunch">
     <description>Money Muncher</description>
     <year>1982</year>
     <publisher>Datamost</publisher>
@@ -1509,7 +1524,7 @@
     </part>
   </software>
 
-  <software name="mnstswoz">
+  <software name="mnstsmsh">
     <description>Monster Smash</description>
     <year>1983</year>
     <publisher>Datamost</publisher>
@@ -1524,8 +1539,8 @@
     </part>
   </software>
 
-  <software name="montrwoz">
-    <description>Montezumas Revenge</description>
+  <software name="monterev">
+    <description>Montezuma's Revenge</description>
     <year>1984</year>
     <publisher>Parker Brothers</publisher>
     <info name="release" value="2019-01-04"/>
@@ -1539,7 +1554,7 @@
     </part>
   </software>
 
-  <software name="mpatrwoz">
+  <software name="mpatrol">
     <description>Moon Patrol</description>
     <year>1983</year>
     <publisher>Atarisoft</publisher>
@@ -1554,7 +1569,7 @@
     </part>
   </software>
 
-  <software name="movimwoz">
+  <software name="movimons">
     <description>The Movie Monster Game</description>
     <year>1986</year>
     <publisher>Epyx</publisher>
@@ -1576,7 +1591,7 @@
     </part>
   </software>
 
-  <software name="mrrobtwz">
+  <software name="mrrobot">
     <description>Mr. Robot and his Robot Factory</description>
     <year>1984</year>
     <publisher>Datamost</publisher>
@@ -1591,7 +1606,7 @@
     </part>
   </software>
 
-  <software name="mspcmwoz">
+  <software name="mspac">
     <description>Ms. Pac-Man</description>
     <year>1983</year>
     <publisher>Atarisoft</publisher>
@@ -1606,7 +1621,7 @@
     </part>
   </software>
 
-  <software name="nmpinwoz">
+  <software name="nightmsn">
     <description>Night Mission Pinball</description>
     <year>1982</year>
     <publisher>subLOGIC</publisher>
@@ -1621,7 +1636,7 @@
     </part>
   </software>
 
-  <software name="nstlkwoz">
+  <software name="nstalker">
     <description>Night Stalker</description>
     <year>1982</year>
     <publisher>Mattel Electronics</publisher>
@@ -1636,7 +1651,7 @@
     </part>
   </software>
 
-  <software name="orbtnwoz">
+  <software name="orbitron">
     <description>Orbitron</description>
     <year>1981</year>
     <publisher>Sirius Software</publisher>
@@ -1652,7 +1667,7 @@
     </part>
   </software>
 
-  <software name="ormsnewoz">
+  <software name="ormine">
     <description>O'Riley's Mine</description>
     <year>1981</year>
     <publisher>Datasoft</publisher>
@@ -1667,7 +1682,7 @@
     </part>
   </software>
 
-  <software name="opstwoz">
+  <software name="outpost">
     <description>Outpost</description>
     <year>1981</year>
     <publisher>Sirius Software</publisher>
@@ -1682,7 +1697,7 @@
     </part>
   </software>
 
-  <software name="pprboywz">
+  <software name="paperboy">
     <description>Paperboy</description>
     <year>1988</year>
     <publisher>Mindscape</publisher>
@@ -1697,7 +1712,7 @@
     </part>
   </software>
 
-  <software name="ppatrwoz">
+  <software name="pestpatr">
     <description>Pest Patrol</description>
     <year>1982</year>
     <publisher>Sierra On-Line</publisher>
@@ -1713,7 +1728,7 @@
     </part>
   </software>
 
-  <software name="phan5woz">
+  <software name="phantom5">
     <description>Phantoms Five</description>
     <year>1980</year>
     <publisher>Sirius Software</publisher>
@@ -1728,7 +1743,7 @@
     </part>
   </software>
 
-  <software name="pparawoz">
+  <software name="pparanoi">
     <description>Picnic Paranoia</description>
     <year>1982</year>
     <publisher>Synapse Software</publisher>
@@ -1743,7 +1758,7 @@
     </part>
   </software>
 
-  <software name="pfal2woz">
+  <software name="pitfall2">
     <description>Pitfall II: Lost Caverns</description>
     <year>1984</year>
     <publisher>Activision</publisher>
@@ -1758,7 +1773,7 @@
     </part>
   </software>
 
-  <software name="pstp2woz">
+  <software name="pitstop2">
     <description>Pitstop II</description>
     <year>1984</year>
     <publisher>Epyx</publisher>
@@ -1773,7 +1788,7 @@
     </part>
   </software>
 
-  <software name="plnr10wz">
+  <software name="plnflr10">
     <description>Planetfall (r10)</description>
     <year>1988</year>
     <publisher>Infocom</publisher>
@@ -1796,7 +1811,7 @@
     </part>
   </software>
 
-  <software name="plsmnwoz">
+  <software name="plasmnia">
     <description>Plasmania</description>
     <year>1983</year>
     <publisher>Sirius Software</publisher>
@@ -1811,7 +1826,7 @@
     </part>
   </software>
 
-  <software name="pltnwoz">
+  <software name="platoon">
     <description>Platoon</description>
     <year>1988</year>
     <publisher>Data East USA</publisher>
@@ -1833,7 +1848,7 @@
     </part>
   </software>
 
-  <software name="pool15wz">
+  <software name="pool15">
     <description>Pool 1.5</description>
     <year>1981</year>
     <publisher>Innovative Design Software, Inc.</publisher>
@@ -1848,7 +1863,7 @@
     </part>
   </software>
 
-  <software name="pyanwoz">
+  <software name="pooyan">
     <description>Pooyan</description>
     <year>1984</year>
     <publisher>Datasoft</publisher>
@@ -1863,7 +1878,7 @@
     </part>
   </software>
 
-  <software name="propwoz">
+  <software name="pop">
     <description>Prince of Persia</description>
     <year>1989</year>
     <publisher>Broderbund</publisher>
@@ -1885,7 +1900,7 @@
     </part>
   </software>
 
-  <software name="qixwoz">
+  <software name="qix">
     <description>Qix</description>
     <year>1989</year>
     <publisher>Taito America</publisher>
@@ -1900,7 +1915,7 @@
     </part>
   </software>
 
-  <software name="radwrwoz">
+  <software name="radwarr">
     <description>Rad Warrior</description>
     <year>1987</year>
     <publisher>Epyx</publisher>
@@ -1915,7 +1930,7 @@
     </part>
   </software>
 
-  <software name="rmpagewz">
+  <software name="rampage">
     <description>Rampage</description>
     <year>1988</year>
     <publisher>Activision</publisher>
@@ -1930,7 +1945,7 @@
     </part>
   </software>
 
-  <software name="rstblwoz">
+  <software name="rstrblst">
     <description>Raster Blaster</description>
     <year>1981</year>
     <publisher>BudgeCo</publisher>
@@ -1947,7 +1962,7 @@
     </part>
   </software>
 
-  <software name="redalwoz">
+  <software name="redalert">
     <description>Red Alert</description>
     <year>1981</year>
     <publisher>Broderbund</publisher>
@@ -1964,7 +1979,7 @@
     </part>
   </software>
 
-  <software name="reptwoz">
+  <software name="repton">
     <description>Repton</description>
     <year>1982</year>
     <publisher>Sirius Software</publisher>
@@ -1979,7 +1994,7 @@
     </part>
   </software>
 
-  <software name="rescrwoz">
+  <software name="rescraid">
     <description>Rescue Raiders</description>
     <year>1984</year>
     <publisher>Sir-Tech</publisher>
@@ -1994,7 +2009,7 @@
     </part>
   </software>
 
-  <software name="robocwoz">
+  <software name="robocop">
     <description>RoboCop</description>
     <year>1988</year>
     <publisher>Data East USA</publisher>
@@ -2016,7 +2031,7 @@
     </part>
   </software>
 
-  <software name="r2084woz">
+  <software name="robotron">
     <description>Robotron 2084</description>
     <year>1983</year>
     <publisher>Atarisoft</publisher>
@@ -2031,7 +2046,7 @@
     </part>
   </software>
 
-  <software name="raboutwz">
+  <software name="rabout">
     <description>Roundabout</description>
     <year>1983</year>
     <publisher>Datamost</publisher>
@@ -2046,7 +2061,7 @@
     </part>
   </software>
 
-  <software name="sabotwoz">
+  <software name="sabotage">
     <description>Sabotage</description>
     <year>1981</year>
     <publisher>On-Line Systems</publisher>
@@ -2061,7 +2076,7 @@
     </part>
   </software>
 
-  <software name="slghtwoz">
+  <software name="sammyltf">
     <description>Sammy Lightfoot</description>
     <year>1983</year>
     <publisher>Sierra On-Line</publisher>
@@ -2076,7 +2091,7 @@
     </part>
   </software>
 
-  <software name="sarg3woz">
+  <software name="sargon3">
     <description>Sargon III</description>
     <year>1983</year>
     <publisher>Hayden Book Company</publisher>
@@ -2091,7 +2106,7 @@
     </part>
   </software>
 
-  <software name="seadrgwz">
+  <software name="seadragn">
     <description>Sea Dragon</description>
     <year>1982</year>
     <publisher>Adventure International</publisher>
@@ -2106,7 +2121,7 @@
     </part>
   </software>
 
-  <software name="shuflwoz">
+  <software name="shuflbrd">
     <description>Shuffleboard</description>
     <year>1981</year>
     <publisher>IDSI</publisher>
@@ -2121,7 +2136,7 @@
     </part>
   </software>
 
-  <software name="skyfwoz">
+  <software name="skyfox">
     <description>Skyfox</description>
     <year>1984</year>
     <publisher>Electronic Arts</publisher>
@@ -2136,7 +2151,7 @@
     </part>
   </software>
 
-  <software name="snacatwz">
+  <software name="snackatk">
     <description>Snack Attack</description>
     <year>1981</year>
     <publisher>Datamost</publisher>
@@ -2151,7 +2166,7 @@
     </part>
   </software>
 
-  <software name="snkbywoz">
+  <software name="snakebyt">
     <description>Snake Byte</description>
     <year>1981</year>
     <publisher>Sirius Software</publisher>
@@ -2166,7 +2181,7 @@
     </part>
   </software>
 
-  <software name="snkrswoz">
+  <software name="sneakers">
     <description>Sneakers</description>
     <year>1981</year>
     <publisher>Sirius Software</publisher>
@@ -2182,7 +2197,7 @@
   </software>
 
 
-  <software name="seggswoz">
+  <software name="spaceggs">
     <description>Space Eggs</description>
     <year>1981</year>
     <publisher>Sirius Software</publisher>
@@ -2199,7 +2214,7 @@
     </part>
   </software>
 
-  <software name="spqkswoz">
+  <software name="spquarks">
     <description>Space Quarks</description>
     <year>1981</year>
     <publisher>Broderbund Software</publisher>
@@ -2216,7 +2231,7 @@
     </part>
   </software>
 
-  <software name="spchgwoz">
+  <software name="sparechg">
     <description>Spare Change</description>
     <year>1983</year>
     <publisher>Broderbund Software</publisher>
@@ -2231,7 +2246,7 @@
     </part>
   </software>
 
-  <software name="spbotwoz">
+  <software name="spidrbot">
     <description>Spiderbot</description>
     <year>1988</year>
     <publisher>Epyx</publisher>
@@ -2246,7 +2261,7 @@
     </part>
   </software>
 
-  <software name="spindwoz">
+  <software name="spindizy">
     <description>Spindizzy</description>
     <year>1986</year>
     <publisher>Activision</publisher>
@@ -2261,7 +2276,7 @@
     </part>
   </software>
 
-  <software name="spyhtwoz">
+  <software name="spyhunt">
     <description>Spy Hunter</description>
     <year>1983</year>
     <publisher>Bally Midway</publisher>
@@ -2276,7 +2291,7 @@
     </part>
   </software>
 
-  <software name="spysbwoz">
+  <software name="spysback">
     <description>The Spy Strikes Back</description>
     <year>1983</year>
     <publisher>Penguin Software</publisher>
@@ -2291,7 +2306,7 @@
     </part>
   </software>
 
-  <software name="svs3wz">
+  <software name="spyvspy3">
     <description>Spy vs Spy III: Arctic Antics</description>
     <year>1983</year>
     <publisher>Bally Midway</publisher>
@@ -2306,7 +2321,7 @@
     </part>
   </software>
 
-  <software name="sdemswoz">
+  <software name="spydemis">
     <description>Spy's Demise</description>
     <year>1982</year>
     <publisher>Penguin</publisher>
@@ -2321,7 +2336,7 @@
     </part>
   </software>
 
-  <software name="stcrzwoz">
+  <software name="starcrsr">
     <description>Star Cruiser</description>
     <year>1980</year>
     <publisher>Sirius Software</publisher>
@@ -2336,7 +2351,7 @@
     </part>
   </software>
 
-  <software name="sthfwoz">
+  <software name="starthf">
     <description>Star Thief</description>
     <year>1981</year>
     <publisher>Cavalier Computer</publisher>
@@ -2351,22 +2366,7 @@
     </part>
   </software>
 
-  <software name="stargwoz">
-    <description>Stargate</description>
-    <year>1983</year>
-    <publisher>Atarisoft</publisher>
-    <info name="release" value="2019-01-13"/>
-    <sharedfeat name="compatibility" value="A2,A2P,A2E,A2EE,A2C,A2GS" />
-    <!-- It runs on any Apple II with 48K. -->
-
-    <part name="flop1" interface="floppy_5_25">
-      <dataarea name="flop" size="233447">
-        <rom name="stargate.woz" size="233447" crc="379d894d" sha1="56d17415d622395bddbe7200adde32f4ad63b208" offset="0x0000" />
-      </dataarea>
-    </part>
-  </software>
-
-  <software name="stel7woz">
+  <software name="stellar7">
     <description>Stellar 7</description>
     <year>1984</year>
     <publisher>Penguin Software</publisher>
@@ -2381,7 +2381,7 @@
     </part>
   </software>
 
-  <software name="ssbsewoz">
+  <software name="ssbaseb">
     <description>Street Sports Baseball</description>
     <year>1987</year>
     <publisher>Epyx</publisher>
@@ -2396,7 +2396,7 @@
     </part>
   </software>
 
-  <software name="ssbskwoz">
+  <software name="ssbasket">
     <description>Street Sports Basketball</description>
     <year>1987</year>
     <publisher>Epyx</publisher>
@@ -2418,7 +2418,7 @@
     </part>
   </software>
 
-  <software name="ssfotwoz">
+  <software name="ssfootb">
     <description>Street Sports Football</description>
     <year>1988</year>
     <publisher>Epyx</publisher>
@@ -2440,7 +2440,7 @@
     </part>
   </software>
 
-  <software name="ssscwoz">
+  <software name="sssoccer">
     <description>Street Sports Soccer</description>
     <year>1988</year>
     <publisher>Epyx</publisher>
@@ -2455,7 +2455,7 @@
     </part>
   </software>
 
-  <software name="sbatswoz">
+  <software name="subatsim">
     <description>Sub Battle Simulator</description>
     <year>1986</year>
     <publisher>Epyx</publisher>
@@ -2477,7 +2477,7 @@
     </part>
   </software>
 
-  <software name="suicwoz">
+  <software name="suicide">
     <description>Suicide</description>
     <year>1981</year>
     <publisher>Piccadilly Software</publisher>
@@ -2492,7 +2492,7 @@
     </part>
   </software>
 
-  <software name="smgmewoz">
+  <software name="sumrgame">
     <description>Summer Games</description>
     <year>1984</year>
     <publisher>Epyx</publisher>
@@ -2514,7 +2514,7 @@
     </part>
   </software>
 
-  <software name="swfrwoz">
+  <software name="swfrobin">
     <description>Swiss Family Robinson</description>
     <year>1984</year>
     <publisher>Windham Classics</publisher>
@@ -2529,7 +2529,7 @@
     </part>
   </software>
 
-  <software name="ttwrswoz">
+  <software name="ttwrestl">
     <description>Tag Team Wrestling</description>
     <year>1986</year>
     <publisher>Data East USA</publisher>
@@ -2544,7 +2544,7 @@
     </part>
   </software>
 
-  <software name="toatwoz">
+  <software name="apshaitr">
     <description>Temple of Apshai Trilogy</description>
     <year>1985</year>
     <publisher>Epyx</publisher>
@@ -2560,7 +2560,7 @@
     </part>
   </software>
 
-  <software name="testdr">
+  <software name="testdrv">
     <description>Test Drive</description>
     <year>1985</year>
     <publisher>Accolade</publisher>
@@ -2582,7 +2582,7 @@
     </part>
   </software>
 
-  <software name="tetrwoz">
+  <software name="tetr128k">
     <description>Tetris (128K)</description>
     <year>1987</year>
     <publisher>Spectrum HoloByte</publisher>
@@ -2598,7 +2598,7 @@
     </part>
   </software>
 
-  <software name="thartwoz">
+  <software name="thartunn">
     <description>Tharolian Tunnels</description>
     <year>1982</year>
     <publisher>Datamost</publisher>
@@ -2613,7 +2613,7 @@
     </part>
   </software>
 
-  <software name="thunbwoz">
+  <software name="thunbomb">
     <description>Thunder Bombs</description>
     <year>1982</year>
     <publisher>Penguin Software</publisher>
@@ -2628,7 +2628,7 @@
     </part>
   </software>
 
-  <software name="thuncwoz">
+  <software name="thunchop">
     <description>Thunderchopper</description>
     <year>1987</year>
     <publisher>ActionSoft</publisher>
@@ -2643,7 +2643,7 @@
     </part>
   </software>
 
-  <software name="tomahwoz">
+  <software name="tomahawk">
     <description>Tomahawk</description>
     <year>1987</year>
     <publisher>Datasoft</publisher>
@@ -2658,7 +2658,7 @@
     </part>
   </software>
 
-  <software name="trshtwoz">
+  <software name="tricksht">
     <description>Trick Shot</description>
     <year>1981</year>
     <publisher>IDSI</publisher>
@@ -2680,7 +2680,7 @@
     </part>
   </software>
 
-  <software name="tubw2woz">
+  <software name="tubeway2">
     <description>Tubeway II</description>
     <year>1982</year>
     <publisher>Datamost</publisher>
@@ -2695,7 +2695,7 @@
     </part>
   </software>
 
-  <software name="twerpswz">
+  <software name="twerps">
     <description>Twerps</description>
     <year>1981</year>
     <publisher>Sirius Software</publisher>
@@ -2710,7 +2710,7 @@
     </part>
   </software>
 
-  <software name="ult4woz">
+  <software name="ultima4">
     <description>Ultima IV: Quest of the Avatar</description>
     <year>1985</year>
     <publisher>Origin Systems</publisher>
@@ -2744,7 +2744,7 @@
     </part>
   </software>
 
-  <software name="ult5woz">
+  <software name="ultima5">
     <description>Ultima V: Warriors of Destiny</description>
     <year>1988</year>
     <publisher>Origin Systems</publisher>
@@ -2802,7 +2802,7 @@
     </part>
   </software>
 
-  <software name="upndnwoz">
+  <software name="upndown">
     <description>Up 'N Down</description>
     <year>1981</year>
     <publisher>Bally Midway</publisher>
@@ -2817,7 +2817,7 @@
     </part>
   </software>
 
-  <software name="vindwoz">
+  <software name="vindicat">
     <description>Vindicator</description>
     <year>1983</year>
     <publisher>H.A.L. Labs</publisher>
@@ -2832,7 +2832,7 @@
     </part>
   </software>
 
-  <software name="wavynwoz">
+  <software name="wavynavy">
     <description>Wavy Navy</description>
     <year>1982</year>
     <publisher>Sirius Software</publisher>
@@ -2847,7 +2847,7 @@
     </part>
   </software>
 
-  <software name="wayoutwz">
+  <software name="wayout">
     <description>Wayout</description>
     <year>1982</year>
     <publisher>Sirius Software</publisher>
@@ -2862,7 +2862,7 @@
     </part>
   </software>
 
-  <software name="crmusawz">
+  <software name="carmnusa">
     <description>Where in the USA is Carmen Sandiego</description>
     <year>1986</year>
     <publisher>Broderbund</publisher>
@@ -2884,7 +2884,7 @@
     </part>
   </software>
 
-  <software name="woffwoz">
+  <software name="wof">
     <description>Wings of Fury</description>
     <year>1987</year>
     <publisher>Broderbund</publisher>
@@ -2906,7 +2906,7 @@
     </part>
   </software>
 
-  <software name="wshr23wz">
+  <software name="wishbr23">
     <description>Wishbringer (r23)</description>
     <year>1988</year>
     <publisher>Infocom</publisher>
@@ -2929,7 +2929,7 @@
     </part>
   </software>
 
-  <software name="wkchpwoz">
+  <software name="wkchamp">
     <description>World Karate Championship</description>
     <year>1986</year>
     <publisher>Epyx</publisher>
@@ -2944,7 +2944,7 @@
     </part>
   </software>
 
-  <software name="wgbbgwoz">
+  <software name="wgbbg">
     <description>The World's Greatest Baseball Game</description>
     <year>1984</year>
     <publisher>Epyx</publisher>
@@ -2959,7 +2959,7 @@
     </part>
   </software>
 
-  <software name="wgfbgwoz">
+  <software name="wgfbg">
     <description>The World's Greatest Football Game</description>
     <year>1985</year>
     <publisher>Epyx</publisher>
@@ -2981,7 +2981,7 @@
     </part>
   </software>
 
-  <software name="xeviwoz">
+  <software name="xevious">
     <description>Xevious</description>
     <year>1984</year>
     <publisher>Mindscape</publisher>
@@ -2996,7 +2996,7 @@
     </part>
   </software>
 
-  <software name="zendarwz">
+  <software name="zendar">
     <description>Zendar</description>
     <year>1982</year>
     <publisher>subLOGIC</publisher>
@@ -3011,7 +3011,7 @@
     </part>
   </software>
 
-  <software name="zorrowoz">
+  <software name="zorro">
     <description>Zorro</description>
     <year>1985</year>
     <publisher>Datasoft</publisher>


### PR DESCRIPTION
- Adjusted (crack) to (cracked) in A2 main softlist. (They're not cracks, they're cracked software.)
- Caught a few cleanly cracked entries that weren't tagged such and added (cleanly cracked) to those.
- Adjusted Originals list to match existing A2 list where both lists have the same software.
- Adjusted names to remove woz/wz reference.

This should be the last adjustment for this month's release outside of any additional 4AM WOZ dumps that show up. After 0.206 I'll look into splitting the softlist up into clean cracks and other content.