### PR TITLE
Updated description of ROM PAC Cartridge Software

### DIFF
--- a/hash/sorcerer_cart.xml
+++ b/hash/sorcerer_cart.xml
@@ -9,6 +9,7 @@ Compiled by K1W1 (thanks to Robbbert)
 
 The Exidy Sorcerer was the first computer to use cartridge software and Exidy used 8 Track music cartridges to encase the ROM Pacs.
 The Exidy Systems, Inc. Product Description dated June 1981 lists six ROM PAC's of which the first four listed below are known to exist.
+However only three of these contain software as the EPROM Pac was simply an empty Pac into which the user could insert 4 of their own EPROM's.
 
 EPROM Pac		DP 2001
 Standard BASIC Pac	DP 2002

--- a/hash/sorcerer_cart.xml
+++ b/hash/sorcerer_cart.xml
@@ -8,7 +8,14 @@ Compiled by K1W1 (thanks to Robbbert)
 <!--
 
 The Exidy Sorcerer was the first computer to use cartridge software and Exidy used 8 Track music cartridges to encase the ROM Pacs.
-Four cartridges were made for this computer one of which was a hardware device, the "EPROM Burner Pac (DP 2001)".
+The Exidy Systems, Inc. Product Description dated June 1981 lists six ROM PAC's of which the first four listed below are known to exist.
+
+EPROM Pac		DP 2001
+Standard BASIC Pac	DP 2002
+Development Pac		DP 2003
+Word Processor Pac	DP 2004
+Auto Program Load Pac	DP 2005
+Terminal Pac		DP 2006
 
 -->
 


### PR DESCRIPTION
Corrected description of the EPROM Pac as an EPROM burner as it was simply an empty Pac into which the user could insert 4 of their own EPROM's.
Added, for the sake of completeness, the Auto Program Load Pac and the Terminal Pac described in Exidy trade literature.