### PR TITLE
rf5c68.cpp : Remove unnecessary arguments in handlers

### DIFF
--- a/src/devices/sound/rf5c68.cpp
+++ b/src/devices/sound/rf5c68.cpp
@@ -189,7 +189,7 @@ void rf5c68_device::sound_stream_update(sound_stream &stream, stream_sample_t **
 //    RF5C68 write register
 //-------------------------------------------------
 
-READ8_MEMBER( rf5c68_device::rf5c68_r )
+u8 rf5c68_device::rf5c68_r(offs_t offset)
 {
 	uint8_t shift;
 
@@ -201,7 +201,7 @@ READ8_MEMBER( rf5c68_device::rf5c68_r )
 	return (m_chan[(offset & 0x0e) >> 1].addr) >> (shift);
 }
 
-WRITE8_MEMBER( rf5c68_device::rf5c68_w )
+void rf5c68_device::rf5c68_w(offs_t offset, u8 data)
 {
 	pcm_channel &chan = m_chan[m_cbank];
 	int i;
@@ -266,7 +266,7 @@ WRITE8_MEMBER( rf5c68_device::rf5c68_w )
 //    RF5C68 read memory
 //-------------------------------------------------
 
-READ8_MEMBER( rf5c68_device::rf5c68_mem_r )
+u8 rf5c68_device::rf5c68_mem_r(offs_t offset)
 {
 	return m_cache->read_byte(m_wbank | offset);
 }
@@ -276,7 +276,7 @@ READ8_MEMBER( rf5c68_device::rf5c68_mem_r )
 //    RF5C68 write memory
 //-------------------------------------------------
 
-WRITE8_MEMBER( rf5c68_device::rf5c68_mem_w )
+void rf5c68_device::rf5c68_mem_w(offs_t offset, u8 data)
 {
 	m_data->write_byte(m_wbank | offset, data);
 }

--- a/src/devices/sound/rf5c68.h
+++ b/src/devices/sound/rf5c68.h
@@ -38,11 +38,11 @@ public:
 		set_end_callback(sample_end_cb_delegate(callback, name, nullptr, static_cast<FunctionClass *>(nullptr)));
 	}
 
-	DECLARE_READ8_MEMBER( rf5c68_r );
-	DECLARE_WRITE8_MEMBER( rf5c68_w );
+	u8 rf5c68_r(offs_t offset);
+	void rf5c68_w(offs_t offset, u8 data);
 
-	DECLARE_READ8_MEMBER( rf5c68_mem_r );
-	DECLARE_WRITE8_MEMBER( rf5c68_mem_w );
+	u8 rf5c68_mem_r(offs_t offset);
+	void rf5c68_mem_w(offs_t offset, u8 data);
 
 protected:
 	rf5c68_device(const machine_config &mconfig, device_type type, const char *tag, device_t *owner, u32 clock);

--- a/src/mame/drivers/megadriv.cpp
+++ b/src/mame/drivers/megadriv.cpp
@@ -750,6 +750,7 @@ MACHINE_CONFIG_START(md_cons_state::genesis_scd)
 
 	SEGA_SEGACD_US(config, m_segacd, 0);
 	m_segacd->set_palette("gen_vdp:palette");
+	m_segacd->set_hostcpu(m_maincpu);
 
 	CDROM(config, "cdrom").set_interface("scd_cdrom");
 
@@ -767,6 +768,7 @@ MACHINE_CONFIG_START(md_cons_state::md_scd)
 
 	SEGA_SEGACD_EUROPE(config, m_segacd, 0);
 	m_segacd->set_palette("gen_vdp:palette");
+	m_segacd->set_hostcpu(m_maincpu);
 
 	CDROM(config, "cdrom").set_interface("scd_cdrom");
 
@@ -784,6 +786,7 @@ MACHINE_CONFIG_START(md_cons_state::mdj_scd)
 
 	SEGA_SEGACD_JAPAN(config, m_segacd, 0);
 	m_segacd->set_palette("gen_vdp:palette");
+	m_segacd->set_hostcpu(m_maincpu);
 
 	CDROM(config, "cdrom").set_interface("scd_cdrom");
 
@@ -797,6 +800,7 @@ MACHINE_CONFIG_START(md_cons_state::genesis_32x_scd)
 
 	SEGA_SEGACD_US(config, m_segacd, 0);
 	m_segacd->set_palette("gen_vdp:palette");
+	m_segacd->set_hostcpu(m_maincpu);
 
 	CDROM(config, "cdrom").set_interface("scd_cdrom");
 
@@ -816,6 +820,7 @@ MACHINE_CONFIG_START(md_cons_state::md_32x_scd)
 
 	SEGA_SEGACD_EUROPE(config, m_segacd, 0);
 	m_segacd->set_palette("gen_vdp:palette");
+	m_segacd->set_hostcpu(m_maincpu);
 
 	CDROM(config, "cdrom").set_interface("scd_cdrom");
 
@@ -835,6 +840,7 @@ MACHINE_CONFIG_START(md_cons_state::mdj_32x_scd)
 
 	SEGA_SEGACD_JAPAN(config, m_segacd, 0);
 	m_segacd->set_palette("gen_vdp:palette");
+	m_segacd->set_hostcpu(m_maincpu);
 
 	CDROM(config, "cdrom").set_interface("scd_cdrom");
 

--- a/src/mame/machine/megacd.cpp
+++ b/src/mame/machine/megacd.cpp
@@ -292,18 +292,17 @@ static GFXDECODE_START( gfx_segacd )
 GFXDECODE_END
 
 
-MACHINE_CONFIG_START(sega_segacd_device::device_add_mconfig)
+void sega_segacd_device::device_add_mconfig(machine_config &config)
+{
+	M68000(config, m_scdcpu, SEGACD_CLOCK); /* 12.5 MHz */
+	m_scdcpu->set_addrmap(AS_PROGRAM, &sega_segacd_device::segacd_map);
+	m_scdcpu->set_irq_acknowledge_callback(device_irq_acknowledge_delegate(FUNC(sega_segacd_device::segacd_sub_int_callback),this));
 
-	MCFG_DEVICE_ADD("segacd_68k", M68000, SEGACD_CLOCK ) /* 12.5 MHz */
-	MCFG_DEVICE_PROGRAM_MAP(segacd_map)
-	MCFG_DEVICE_IRQ_ACKNOWLEDGE_DEVICE(DEVICE_SELF, sega_segacd_device, segacd_sub_int_callback)
-
-	MCFG_DEVICE_ADD("cdc", LC89510, 0) // cd controller
+	LC89510(config, "cdc", 0); // cd controller
 
 	// temporary until things are cleaned up
 	LC89510_TEMP(config, m_lc89510_temp, 0); // cd controller
 	m_lc89510_temp->set_cdc_do_dma_callback(FUNC(sega_segacd_device::SegaCD_CDC_Do_DMA), this); // hack
-
 
 	TIMER(config, m_stopwatch_timer).configure_generic(timer_device::expired_delegate()); //stopwatch timer
 	TIMER(config, m_stamp_timer).configure_generic(FUNC(sega_segacd_device::stamp_timer_callback));
@@ -312,30 +311,31 @@ MACHINE_CONFIG_START(sega_segacd_device::device_add_mconfig)
 
 	config.set_default_layout(layout_megacd);
 
-	MCFG_DEVICE_ADD("rfsnd", RF5C68, SEGACD_CLOCK) // RF5C164!
-	MCFG_SOUND_ROUTE( 0, ":lspeaker", 0.50 )
-	MCFG_SOUND_ROUTE( 1, ":rspeaker", 0.50 )
-	MCFG_DEVICE_ADDRESS_MAP(0, segacd_pcm_map)
+	RF5C68(config, m_rfsnd, SEGACD_CLOCK); // RF5C164!
+	m_rfsnd->add_route( 0, ":lspeaker", 0.50 );
+	m_rfsnd->add_route( 1, ":rspeaker", 0.50 );
+	m_rfsnd->set_addrmap(0, &sega_segacd_device::segacd_pcm_map);
 
 	NVRAM(config, "backupram", nvram_device::DEFAULT_ALL_0);
 
 	config.m_perfect_cpu_quantum = subtag("segacd_68k"); // perfect sync to the fastest cpu
-MACHINE_CONFIG_END
+}
 
 
 sega_segacd_device::sega_segacd_device(const machine_config &mconfig, device_type type, const char *tag, device_t *owner, uint32_t clock)
-	: device_t(mconfig, type, tag, owner, clock),
-		device_gfx_interface(mconfig, *this, gfx_segacd),
-		m_scdcpu(*this, "segacd_68k"),
-		m_rfsnd(*this, "rfsnd"),
-		m_lc89510_temp(*this, "tempcdc"),
-		m_stopwatch_timer(*this, "sw_timer"),
-		m_stamp_timer(*this, "stamp_timer"),
-		m_irq3_timer(*this, "irq3_timer"),
-		m_dma_timer(*this, "dma_timer"),
-		m_prgram(*this, "prgram"),
-		m_dataram(*this, "dataram"),
-		m_font_bits(*this, "font_bits")
+	: device_t(mconfig, type, tag, owner, clock)
+	, device_gfx_interface(mconfig, *this, gfx_segacd)
+	, m_scdcpu(*this, "segacd_68k")
+	, m_hostcpu(*this, finder_base::DUMMY_TAG)
+	, m_rfsnd(*this, "rfsnd")
+	, m_lc89510_temp(*this, "tempcdc")
+	, m_stopwatch_timer(*this, "sw_timer")
+	, m_stamp_timer(*this, "stamp_timer")
+	, m_irq3_timer(*this, "irq3_timer")
+	, m_dma_timer(*this, "dma_timer")
+	, m_prgram(*this, "prgram")
+	, m_dataram(*this, "dataram")
+	, m_font_bits(*this, "font_bits")
 {
 }
 
@@ -568,7 +568,7 @@ READ16_MEMBER( sega_segacd_device::scd_a12002_memory_mode_r )
 // RET = Return access (bit 1)
 
 
-WRITE8_MEMBER( sega_segacd_device::scd_a12002_memory_mode_w_8_15 )
+void sega_segacd_device::scd_a12002_memory_mode_w_8_15(u8 data)
 {
 	if (data & 0xff00)
 	{
@@ -579,7 +579,7 @@ WRITE8_MEMBER( sega_segacd_device::scd_a12002_memory_mode_w_8_15 )
 }
 
 
-WRITE8_MEMBER( sega_segacd_device::scd_a12002_memory_mode_w_0_7 )
+void sega_segacd_device::scd_a12002_memory_mode_w_0_7(u8 data)
 {
 	//printf("scd_a12002_memory_mode_w_0_7 %04x\n",data);
 
@@ -605,10 +605,10 @@ WRITE8_MEMBER( sega_segacd_device::scd_a12002_memory_mode_w_0_7 )
 WRITE16_MEMBER( sega_segacd_device::scd_a12002_memory_mode_w )
 {
 	if (ACCESSING_BITS_8_15)
-		scd_a12002_memory_mode_w_8_15(space, 0, data>>8, mem_mask>>8);
+		scd_a12002_memory_mode_w_8_15(data>>8);
 
 	if (ACCESSING_BITS_0_7)
-		scd_a12002_memory_mode_w_0_7(space, 0, data&0xff, mem_mask&0xff);
+		scd_a12002_memory_mode_w_0_7(data&0xff);
 }
 
 
@@ -627,14 +627,14 @@ READ16_MEMBER( sega_segacd_device::segacd_sub_memory_mode_r )
 }
 
 
-WRITE8_MEMBER( sega_segacd_device::segacd_sub_memory_mode_w_8_15 )
+void sega_segacd_device::segacd_sub_memory_mode_w_8_15(u8 data)
 {
 	/* setting write protect bits from sub-cpu has no effect? */
 }
 
 
 
-WRITE8_MEMBER( sega_segacd_device::segacd_sub_memory_mode_w_0_7 )
+void sega_segacd_device::segacd_sub_memory_mode_w_0_7(u8 data)
 {
 	segacd_memory_priority_mode = (data&0x0018)>>3;
 
@@ -696,10 +696,10 @@ WRITE16_MEMBER( sega_segacd_device::segacd_sub_memory_mode_w )
 
 
 	if (ACCESSING_BITS_8_15)
-		segacd_sub_memory_mode_w_8_15(space, 0, data>>8, mem_mask>>8);
+		segacd_sub_memory_mode_w_8_15(data>>8);
 
 	if (ACCESSING_BITS_0_7)
-		segacd_sub_memory_mode_w_0_7(space, 0, data&0xff, mem_mask&0xff);
+		segacd_sub_memory_mode_w_0_7(data&0xff);
 }
 
 
@@ -1724,7 +1724,7 @@ READ16_MEMBER( sega_segacd_device::font_converted_r )
 
 void sega_segacd_device::device_start()
 {
-	address_space& space = machine().device("maincpu")->memory().space(AS_PROGRAM);
+	address_space& space = m_hostcpu->space(AS_PROGRAM);
 
 	m_backupram.resize(0x2000);
 	subdevice<nvram_device>("backupram")->set_base(&m_backupram[0], 0x2000);
@@ -1852,7 +1852,6 @@ void sega_segacd_device::SegaCD_CDC_Do_DMA(int &dmacount, uint8_t *CDC_BUFFER, u
 	uint16_t *dest;
 	int srcoffset = 0;
 	int dstoffset = 0;
-	address_space& space = m_scdcpu->space(AS_PROGRAM);
 
 	bool PCM_DMA = false;
 
@@ -1890,8 +1889,8 @@ void sega_segacd_device::SegaCD_CDC_Do_DMA(int &dmacount, uint8_t *CDC_BUFFER, u
 
 		if (PCM_DMA)
 		{
-			m_rfsnd->rf5c68_mem_w(space, dstoffset & 0xfff, data >> 8);
-			m_rfsnd->rf5c68_mem_w(space, (dstoffset+1) & 0xfff, data);
+			m_rfsnd->rf5c68_mem_w(dstoffset & 0xfff, data >> 8);
+			m_rfsnd->rf5c68_mem_w((dstoffset+1) & 0xfff, data);
 		//  printf("PCM_DMA writing %04x %04x\n",0xff2000+(dstoffset*2), data);
 		}
 		else

--- a/src/mame/machine/megacd.h
+++ b/src/mame/machine/megacd.h
@@ -14,6 +14,8 @@
 class sega_segacd_device : public device_t, public device_gfx_interface
 {
 public:
+	template <typename T> void set_hostcpu(T &&tag) { m_hostcpu.set_tag(std::forward<T>(tag)); }
+
 	// set some variables at start, depending on region (shall be moved to a device interface?)
 	void set_framerate(int rate) { m_framerate = rate; }
 	void set_total_scanlines(int total) { m_base_total_scanlines = total; }     // this gets set at start only
@@ -25,12 +27,12 @@ public:
 	DECLARE_WRITE16_MEMBER( scd_a12000_halt_reset_w );
 	DECLARE_READ16_MEMBER( scd_a12000_halt_reset_r );
 	DECLARE_READ16_MEMBER( scd_a12002_memory_mode_r );
-	DECLARE_WRITE8_MEMBER( scd_a12002_memory_mode_w_8_15 );
-	DECLARE_WRITE8_MEMBER( scd_a12002_memory_mode_w_0_7 );
+	void scd_a12002_memory_mode_w_8_15(u8 data);
+	void scd_a12002_memory_mode_w_0_7(u8 data);
 	DECLARE_WRITE16_MEMBER( scd_a12002_memory_mode_w );
 	DECLARE_READ16_MEMBER( segacd_sub_memory_mode_r );
-	DECLARE_WRITE8_MEMBER( segacd_sub_memory_mode_w_8_15 );
-	DECLARE_WRITE8_MEMBER( segacd_sub_memory_mode_w_0_7 );
+	void segacd_sub_memory_mode_w_8_15(u8 data);
+	void segacd_sub_memory_mode_w_0_7(u8 data);
 	DECLARE_WRITE16_MEMBER( segacd_sub_memory_mode_w );
 
 	DECLARE_READ16_MEMBER( segacd_comms_flags_r );
@@ -105,6 +107,7 @@ protected:
 	virtual void device_add_mconfig(machine_config &config) override;
 
 	required_device<cpu_device> m_scdcpu;
+	required_device<cpu_device> m_hostcpu;
 	required_device<rf5c68_device> m_rfsnd;
 	required_device<lc89510_temp_device> m_lc89510_temp;
 	required_device<timer_device> m_stopwatch_timer;


### PR DESCRIPTION
megacd.cpp : Remove unnecessary arguments in some handlers, MCFGs, deprecated warning, nw