### PR TITLE
nscsi_cd: Add new nscsi_cdrom_device derived type for SGI systems

### DIFF
--- a/src/devices/machine/nscsi_bus.cpp
+++ b/src/devices/machine/nscsi_bus.cpp
@@ -442,7 +442,7 @@ void nscsi_full_device::step(bool timeout)
 			break;
 		}
 
-		if(command_done()) {
+		if(scsi_command_done(scsi_cmdbuf[0], data_buffer_pos)) {
 			scsi_cmdsize = data_buffer_pos;
 			scsi_bus->ctrl_wait(scsi_refid, 0, S_ACK);
 			scsi_command();
@@ -509,18 +509,17 @@ void nscsi_full_device::target_send_buffer_byte()
 	target_send_byte(scsi_get_data(data_buffer_id, data_buffer_pos++));
 }
 
-bool nscsi_full_device::command_done()
+bool nscsi_full_device::scsi_command_done(uint8_t command, uint8_t length)
 {
-	if(!data_buffer_pos)
+	if(!length)
 		return false;
-	uint8_t h = scsi_cmdbuf[0];
-	switch(h >> 5) {
-	case 0: return data_buffer_pos == 6;
-	case 1: return data_buffer_pos == 10;
-	case 2: return data_buffer_pos == 10;
+	switch(command >> 5) {
+	case 0: return length == 6;
+	case 1: return length == 10;
+	case 2: return length == 10;
 	case 3: return true;
 	case 4: return true;
-	case 5: return data_buffer_pos == 12;
+	case 5: return length == 12;
 	case 6: return true;
 	case 7: return true;
 	}

--- a/src/devices/machine/nscsi_bus.h
+++ b/src/devices/machine/nscsi_bus.h
@@ -308,6 +308,7 @@ protected:
 
 	virtual void scsi_message();
 	virtual void scsi_command();
+	virtual bool scsi_command_done(uint8_t command, uint8_t length);
 
 	void scsi_unknown_command();
 	void scsi_status_complete(uint8_t st);
@@ -448,7 +449,6 @@ private:
 	void target_recv_byte();
 	void target_send_byte(uint8_t val);
 	void target_send_buffer_byte();
-	bool command_done();
 };
 
 

--- a/src/devices/machine/nscsi_cd.h
+++ b/src/devices/machine/nscsi_cd.h
@@ -57,6 +57,16 @@ private:
 	static int to_msf(int frame);
 };
 
+class nscsi_cdrom_sgi_device : public nscsi_cdrom_device
+{
+public:
+	nscsi_cdrom_sgi_device(const machine_config &mconfig, const char *tag, device_t *owner, uint32_t clock = 0);
+
+protected:
+	virtual void scsi_command() override;
+	virtual bool scsi_command_done(uint8_t command, uint8_t length) override;
+};
+
 class nscsi_dec_rrd45_device : public nscsi_cdrom_device
 {
 public:
@@ -94,6 +104,7 @@ public:
 };
 
 DECLARE_DEVICE_TYPE(NSCSI_CDROM, nscsi_cdrom_device)
+DECLARE_DEVICE_TYPE(NSCSI_CDROM_SGI, nscsi_cdrom_sgi_device)
 DECLARE_DEVICE_TYPE(NSCSI_RRD45, nscsi_dec_rrd45_device)
 DECLARE_DEVICE_TYPE(NSCSI_XM3301, nscsi_toshiba_xm3301_device)
 DECLARE_DEVICE_TYPE(NSCSI_XM5301SUN, nscsi_toshiba_xm5301_sun_device)

--- a/src/mame/drivers/indy_indigo2.cpp
+++ b/src/mame/drivers/indy_indigo2.cpp
@@ -200,7 +200,7 @@ void ip22_state::wd33c93(device_t *device)
 
 void ip22_state::scsi_devices(device_slot_interface &device)
 {
-	device.option_add("cdrom", NSCSI_CDROM);
+	device.option_add("cdrom", NSCSI_CDROM_SGI);
 	device.option_add("harddisk", NSCSI_HARDDISK);
 	//device.set_option_machine_config("cdrom", cdrom_config);
 }

--- a/src/mame/machine/hpc1.cpp
+++ b/src/mame/machine/hpc1.cpp
@@ -123,7 +123,7 @@ void hpc1_device::indigo_mice(device_slot_interface &device)
 
 void hpc1_device::scsi_devices(device_slot_interface &device)
 {
-	device.option_add("cdrom", NSCSI_CDROM);
+	device.option_add("cdrom", NSCSI_CDROM_SGI);
 	device.option_add("harddisk", NSCSI_HARDDISK);
 }
 


### PR DESCRIPTION
Some versions of IRIX will always send an SGI vendor specific SCSI command to the CDROM, so we need some specialization to acknowledge this command.