### PR TITLE
 new WORKING machines  (JAKKS stuff)

### DIFF
--- a/hash/jakks_gamekey_dy.xml
+++ b/hash/jakks_gamekey_dy.xml
@@ -12,7 +12,7 @@
 		<year>2005</year>
 		<publisher>JAKKS Pacific / HotGen Ltd</publisher>
 		<part name="cart" interface="jakks_gamekey">
-      <feature name="slot" value="rom_24lc04"/>
+			<feature name="slot" value="rom_24lc04"/>
 			<dataarea name="rom" size="0x800000">
 				<rom name="dy_disneygkbowlinggoofy.bin" size="0x200000" crc="d2147aa4" sha1="0db986aac68868a2ff4936e93178da8c592ac81d" offset="0" />
 				<rom size="0x200000" offset="0x200000" loadflag="reload" />
@@ -27,7 +27,7 @@
 		<year>2005</year>
 		<publisher>JAKKS Pacific / HotGen Ltd</publisher>
 		<part name="cart" interface="jakks_gamekey">
-      <feature name="slot" value="rom_24lc04"/>
+			<feature name="slot" value="rom_24lc04"/>
 			<dataarea name="rom" size="0x800000">
 				<rom name="dy_disneygktennisfacechase.bin" size="0x200000" crc="ba37ccf2" sha1="c7204a0499b6949f3f70f0f5c042d353435406fb" offset="0" />
 				<rom size="0x200000" offset="0x200000" loadflag="reload" />
@@ -42,8 +42,8 @@
 		<year>2005</year>
 		<publisher>JAKKS Pacific / HotGen Ltd</publisher>
 		<part name="cart" interface="jakks_gamekey">
+			<feature name="slot" value="rom_24lc04"/>
 			<dataarea name="rom" size="0x800000">
-      <feature name="slot" value="rom_24lc04"/>
 				<rom name="disneygktennisfaceagrabah.bin" size="0x200000" crc="f3fd0759" sha1="1272e7e34acfce5dbe55b39bff888f5dd16c63f9" offset="0" />
 				<rom size="0x200000" offset="0x200000" loadflag="reload" />
 				<rom size="0x200000" offset="0x400000" loadflag="reload" />

--- a/hash/jakks_gamekey_dy.xml
+++ b/hash/jakks_gamekey_dy.xml
@@ -12,6 +12,7 @@
 		<year>2005</year>
 		<publisher>JAKKS Pacific / HotGen Ltd</publisher>
 		<part name="cart" interface="jakks_gamekey">
+      <feature name="slot" value="rom_24lc04"/>
 			<dataarea name="rom" size="0x800000">
 				<rom name="dy_disneygkbowlinggoofy.bin" size="0x200000" crc="d2147aa4" sha1="0db986aac68868a2ff4936e93178da8c592ac81d" offset="0" />
 				<rom size="0x200000" offset="0x200000" loadflag="reload" />
@@ -26,6 +27,7 @@
 		<year>2005</year>
 		<publisher>JAKKS Pacific / HotGen Ltd</publisher>
 		<part name="cart" interface="jakks_gamekey">
+      <feature name="slot" value="rom_24lc04"/>
 			<dataarea name="rom" size="0x800000">
 				<rom name="dy_disneygktennisfacechase.bin" size="0x200000" crc="ba37ccf2" sha1="c7204a0499b6949f3f70f0f5c042d353435406fb" offset="0" />
 				<rom size="0x200000" offset="0x200000" loadflag="reload" />
@@ -41,6 +43,7 @@
 		<publisher>JAKKS Pacific / HotGen Ltd</publisher>
 		<part name="cart" interface="jakks_gamekey">
 			<dataarea name="rom" size="0x800000">
+      <feature name="slot" value="rom_24lc04"/>
 				<rom name="disneygktennisfaceagrabah.bin" size="0x200000" crc="f3fd0759" sha1="1272e7e34acfce5dbe55b39bff888f5dd16c63f9" offset="0" />
 				<rom size="0x200000" offset="0x200000" loadflag="reload" />
 				<rom size="0x200000" offset="0x400000" loadflag="reload" />

--- a/hash/jakks_gamekey_nm.xml
+++ b/hash/jakks_gamekey_nm.xml
@@ -6,7 +6,7 @@
 
 	<software name="nrxdig"> <!-- has SEEPROM -->
 		<description>New Rally X &amp; Dig Dug</description>
-		<publisher>JAKKS Pacific / HotGen Ltd</publisher>
+		<publisher>JAKKS Pacific Inc / Namco / HotGen Ltd</publisher>
 		<year>2005</year>
 		<part name="cart" interface="jakks_gamekey">
 			<feature name="slot" value="rom_24lc04"/>

--- a/hash/jakks_gamekey_nm.xml
+++ b/hash/jakks_gamekey_nm.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0"?>
+<!DOCTYPE softwarelist SYSTEM "softwarelist.dtd">
+<softwarelist name="jakks_gamekey_nm" description="JAKKS Pacific 'NM' Game Keys">
+
+	<!-- This list is for the 'NM' coded Game Keys, for Namco base systems (MS Pacman) -->
+
+	<software name="nrxdig"> <!-- has SEEPROM -->
+		<description>New Rally X &amp; Dig Dug</description>
+		<publisher>JAKKS Pacific / HotGen Ltd</publisher>
+		<year>2005</year>
+		<part name="cart" interface="jakks_gamekey">
+			<feature name="slot" value="rom_24lc04"/>
+			<dataarea name="rom" size="0x800000">
+				<rom name="jakksdigdugnewrallyxgk.bin" size="0x100000" crc="2a0e958a" sha1="2e09d87a8fdf115f13aaa8fd2c48f9eaf3c82bac" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+</softwarelist>

--- a/hash/jakks_gamekey_sw.xml
+++ b/hash/jakks_gamekey_sw.xml
@@ -12,6 +12,7 @@
 		<year>2005</year>
 		<publisher>JAKKS Pacific / Griptonite Games</publisher>
 		<part name="cart" interface="jakks_gamekey">
+      <feature name="slot" value="rom_24lc04"/>
 			<dataarea name="rom" size="0x800000">
 				<rom name="jakksswgkyodaturret.bin" size="0x200000" crc="78f663f6" sha1="375763e6b6ccf290d9a37f0d849f72bea7b25722" offset="0" />
 				<rom size="0x200000" offset="0x200000" loadflag="reload" />

--- a/hash/jakks_gamekey_sw.xml
+++ b/hash/jakks_gamekey_sw.xml
@@ -12,7 +12,7 @@
 		<year>2005</year>
 		<publisher>JAKKS Pacific / Griptonite Games</publisher>
 		<part name="cart" interface="jakks_gamekey">
-      <feature name="slot" value="rom_24lc04"/>
+			<feature name="slot" value="rom_24lc04"/>
 			<dataarea name="rom" size="0x800000">
 				<rom name="jakksswgkyodaturret.bin" size="0x200000" crc="78f663f6" sha1="375763e6b6ccf290d9a37f0d849f72bea7b25722" offset="0" />
 				<rom size="0x200000" offset="0x200000" loadflag="reload" />

--- a/scripts/src/bus.lua
+++ b/scripts/src/bus.lua
@@ -1305,6 +1305,19 @@ if (BUSES["ISBX"]~=null) then
 	}
 end
 
+---------------------------------------------------
+--
+--@src/devices/bus/jakks_gamekey/slot.h,BUSES["JAKKS_GAMEKEY"] = true
+---------------------------------------------------
+
+if (BUSES["JAKKS_GAMEKEY"]~=null) then
+	files {
+		MAME_DIR .. "src/devices/bus/jakks_gamekey/slot.cpp",
+		MAME_DIR .. "src/devices/bus/jakks_gamekey/slot.h",
+		MAME_DIR .. "src/devices/bus/jakks_gamekey/rom.cpp",
+		MAME_DIR .. "src/devices/bus/jakks_gamekey/rom.h",
+	}
+end
 
 ---------------------------------------------------
 --

--- a/scripts/target/mame/mess.lua
+++ b/scripts/target/mame/mess.lua
@@ -755,6 +755,7 @@ BUSES["INTV_CTRL"] = true
 BUSES["IQ151"] = true
 BUSES["ISA"] = true
 BUSES["ISBX"] = true
+BUSES["JAKKS_GAMEKEY"] = true
 BUSES["HP_OPTROM"] = true
 BUSES["HP80_OPTROM"] = true
 BUSES["HP80_IO"] = true

--- a/src/devices/bus/jakks_gamekey/rom.cpp
+++ b/src/devices/bus/jakks_gamekey/rom.cpp
@@ -1,0 +1,110 @@
+// license:BSD-3-Clause
+// copyright-holders:David Haywood
+
+#include "emu.h"
+#include "rom.h"
+
+//-------------------------------------------------
+//  jakks_gamekey_rom_device - constructor
+//-------------------------------------------------
+
+DEFINE_DEVICE_TYPE(JAKKS_GAMEKEY_ROM_PLAIN,         jakks_gamekey_rom_plain_device,       "jakks_gamekey_rom_plain",        "JAKKS Pacific GameKey")
+DEFINE_DEVICE_TYPE(JAKKS_GAMEKEY_ROM_I2C_BASE,      jakks_gamekey_rom_i2c_base_device,    "jakks_gamekey_rom_i2c_base",     "JAKKS Pacific GameKey with I2C")
+DEFINE_DEVICE_TYPE(JAKKS_GAMEKEY_ROM_I2C_24LC04,    jakks_gamekey_rom_i2c_24lc04_device,  "jakks_gamekey_rom_i2c_24lc04",   "JAKKS Pacific GameKey with I2C 24LC04")
+
+
+jakks_gamekey_rom_plain_device::jakks_gamekey_rom_plain_device(const machine_config &mconfig, device_type type, const char *tag, device_t *owner, uint32_t clock) :
+	device_t(mconfig, type, tag, owner, clock), device_jakks_gamekey_interface(mconfig, *this)
+{
+}
+
+jakks_gamekey_rom_plain_device::jakks_gamekey_rom_plain_device(const machine_config &mconfig, const char *tag, device_t *owner, uint32_t clock) :
+	jakks_gamekey_rom_plain_device(mconfig, JAKKS_GAMEKEY_ROM_PLAIN, tag, owner, clock)
+{
+}
+
+jakks_gamekey_rom_i2c_base_device::jakks_gamekey_rom_i2c_base_device(const machine_config &mconfig, device_type type, const char *tag, device_t *owner, uint32_t clock) :
+	jakks_gamekey_rom_plain_device(mconfig, type, tag, owner, clock),
+	m_i2cmem(*this, "i2cmem")
+{
+}
+
+jakks_gamekey_rom_i2c_base_device::jakks_gamekey_rom_i2c_base_device(const machine_config &mconfig, const char *tag, device_t *owner, uint32_t clock) :
+	jakks_gamekey_rom_i2c_base_device(mconfig, JAKKS_GAMEKEY_ROM_I2C_BASE, tag, owner, clock)
+{
+}
+
+jakks_gamekey_rom_i2c_24lc04_device::jakks_gamekey_rom_i2c_24lc04_device(const machine_config &mconfig, const char *tag, device_t *owner, uint32_t clock) :
+	jakks_gamekey_rom_i2c_base_device(mconfig, JAKKS_GAMEKEY_ROM_I2C_24LC04, tag, owner, clock)
+{
+}
+
+/*-------------------------------------------------
+ mapper specific handlers
+ -------------------------------------------------*/
+
+// plain
+
+READ16_MEMBER(jakks_gamekey_rom_plain_device::read_cart)
+{
+	return read_rom(space, offset, mem_mask);
+}
+
+READ16_MEMBER(jakks_gamekey_rom_plain_device::read_rom)
+{
+	return m_rom[offset & (m_rom_size-1)];
+}
+
+WRITE16_MEMBER(jakks_gamekey_rom_plain_device::write_cart)
+{
+	write_rom(space, offset, data, mem_mask);
+}
+
+WRITE16_MEMBER(jakks_gamekey_rom_plain_device::write_rom)
+{
+	logerror("jakks_gamekey_rom_plain_device::write_rom %08x %02x\n", offset, data);
+}
+
+// i2c base
+
+WRITE16_MEMBER(jakks_gamekey_rom_i2c_base_device::write_rom)
+{
+	logerror("jakks_gamekey_rom_i2c_base_device::write_rom %08x %02x\n", offset, data);
+}
+
+READ16_MEMBER(jakks_gamekey_rom_i2c_base_device::read_rom)
+{
+	return m_rom[offset & (m_rom_size - 1)];
+}
+
+uint8_t jakks_gamekey_rom_i2c_base_device::read_cart_seeprom(void)
+{
+	logerror("jakks_gamekey_rom_i2c_base_device::read_cart_seeprom\n");
+
+	return m_i2cmem->read_sda();
+}
+
+WRITE16_MEMBER(jakks_gamekey_rom_i2c_base_device::write_cart_seeprom)
+{
+	if (BIT(mem_mask, 1))
+		m_i2cmem->write_scl(BIT(data, 1));
+	if (BIT(mem_mask, 0))
+		m_i2cmem->write_sda(BIT(data, 0));
+}
+
+// i2c 24lc04
+
+MACHINE_CONFIG_START(jakks_gamekey_rom_i2c_24lc04_device::device_add_mconfig)
+	I2CMEM(config, "i2cmem", 0)/*.set_page_size(16)*/.set_data_size(0x200); // 24LC04
+MACHINE_CONFIG_END
+
+
+/*-------------------------------------------------
+ slot interface
+ -------------------------------------------------*/
+
+void jakks_gamekey(device_slot_interface &device)
+{
+	device.option_add_internal("plain",       JAKKS_GAMEKEY_ROM_PLAIN);
+	device.option_add_internal("rom_24lc04",  JAKKS_GAMEKEY_ROM_I2C_24LC04);
+}

--- a/src/devices/bus/jakks_gamekey/rom.h
+++ b/src/devices/bus/jakks_gamekey/rom.h
@@ -1,0 +1,77 @@
+// license:BSD-3-Clause
+// copyright-holders:David Haywood
+#ifndef MAME_BUS_JAKKS_GAMEKEY_ROM_H
+#define MAME_BUS_JAKKS_GAMEKEY_ROM_H
+
+#pragma once
+
+#include "slot.h"
+#include "machine/i2cmem.h"
+
+// ======================> jakks_gamekey_rom_plain_device
+
+class jakks_gamekey_rom_plain_device : public device_t,
+						public device_jakks_gamekey_interface
+{
+public:
+	// construction/destruction
+	jakks_gamekey_rom_plain_device(const machine_config &mconfig, const char *tag, device_t *owner, uint32_t clock);
+
+	// reading and writing
+	virtual DECLARE_READ16_MEMBER(read_cart) override;
+	virtual DECLARE_WRITE16_MEMBER(write_cart) override;
+
+	virtual uint8_t read_cart_seeprom(void) override { return 1; };
+	virtual DECLARE_WRITE16_MEMBER(write_cart_seeprom) override { };
+
+	virtual READ16_MEMBER(read_rom);
+	virtual WRITE16_MEMBER(write_rom);
+
+protected:
+	jakks_gamekey_rom_plain_device(const machine_config &mconfig, device_type type, const char *tag, device_t *owner, uint32_t clock);
+
+	// device-level overrides
+	virtual void device_start() override { }
+	virtual void device_reset() override { }
+};
+
+// ======================> jakks_gamekey_rom_i2c_base_device
+
+class jakks_gamekey_rom_i2c_base_device : public jakks_gamekey_rom_plain_device
+{
+public:
+	// construction/destruction
+	jakks_gamekey_rom_i2c_base_device(const machine_config &mconfig, const char *tag, device_t *owner, uint32_t clock);
+
+protected:
+	jakks_gamekey_rom_i2c_base_device(const machine_config &mconfig, device_type type, const char *tag, device_t *owner, uint32_t clock);
+
+	// reading and writing
+	virtual READ16_MEMBER(read_rom) override;
+	virtual WRITE16_MEMBER(write_rom) override;
+
+	optional_device<i2cmem_device> m_i2cmem;
+
+	virtual uint8_t read_cart_seeprom(void) override;
+	virtual DECLARE_WRITE16_MEMBER(write_cart_seeprom) override;
+};
+
+
+// ======================> jakks_gamekey_rom_i2c_24lc04_device
+
+class jakks_gamekey_rom_i2c_24lc04_device : public jakks_gamekey_rom_i2c_base_device
+{
+public:
+	// construction/destruction
+	jakks_gamekey_rom_i2c_24lc04_device(const machine_config &mconfig, const char *tag, device_t *owner, uint32_t clock);
+
+protected:
+	virtual void device_add_mconfig(machine_config &config) override;
+};
+
+// device type definition
+DECLARE_DEVICE_TYPE(JAKKS_GAMEKEY_ROM_PLAIN,       jakks_gamekey_rom_plain_device)
+DECLARE_DEVICE_TYPE(JAKKS_GAMEKEY_ROM_I2C_BASE,    jakks_gamekey_rom_i2c_base_device)
+DECLARE_DEVICE_TYPE(JAKKS_GAMEKEY_ROM_I2C_24LC04,  jakks_gamekey_rom_i2c_24lc04_device)
+
+#endif // MAME_BUS_JAKKS_GAMEKEY_ROM_H

--- a/src/devices/bus/jakks_gamekey/slot.cpp
+++ b/src/devices/bus/jakks_gamekey/slot.cpp
@@ -1,0 +1,237 @@
+// license:BSD-3-Clause
+// copyright-holders:David Haywood
+
+#include "emu.h"
+#include "slot.h"
+
+//**************************************************************************
+//  GLOBAL VARIABLES
+//**************************************************************************
+
+DEFINE_DEVICE_TYPE(JAKKS_GAMEKEY_SLOT, jakks_gamekey_slot_device, "jakks_gamekey_slot", "JAKKS Pacific Gamekey Slot")
+
+//**************************************************************************
+//    JAKKS GAMEKEY cartridges Interface
+//**************************************************************************
+
+//-------------------------------------------------
+//  device_jakks_gamekey_interface - constructor
+//-------------------------------------------------
+
+device_jakks_gamekey_interface::device_jakks_gamekey_interface(const machine_config &mconfig, device_t &device)
+	: device_slot_card_interface(mconfig, device),
+		m_rom(nullptr),
+		m_rom_size(0)
+{
+}
+
+
+//-------------------------------------------------
+//  ~device_jakks_gamekey_interface - destructor
+//-------------------------------------------------
+
+device_jakks_gamekey_interface::~device_jakks_gamekey_interface()
+{
+}
+
+//-------------------------------------------------
+//  rom_alloc - alloc the space for the cart
+//-------------------------------------------------
+
+void device_jakks_gamekey_interface::rom_alloc(uint32_t size, const char *tag)
+{
+	if (m_rom == nullptr)
+	{
+		m_rom = device().machine().memory().region_alloc(std::string(tag).append(JAKKSSLOT_ROM_REGION_TAG).c_str(), size, 1, ENDIANNESS_BIG)->base();
+		m_rom_size = size;
+	}
+}
+
+//**************************************************************************
+//  LIVE DEVICE
+//**************************************************************************
+
+//-------------------------------------------------
+//  jakks_gamekey_slot_device - constructor
+//-------------------------------------------------
+jakks_gamekey_slot_device::jakks_gamekey_slot_device(const machine_config &mconfig, const char *tag, device_t *owner, uint32_t clock) :
+	device_t(mconfig, JAKKS_GAMEKEY_SLOT, tag, owner, clock),
+	device_image_interface(mconfig, *this),
+	device_slot_interface(mconfig, *this),
+	m_type(JAKKS_GAMEKEY_PLAIN),
+	m_cart(nullptr)
+{
+}
+
+//-------------------------------------------------
+//  jakks_gamekey_slot_device - destructor
+//-------------------------------------------------
+
+jakks_gamekey_slot_device::~jakks_gamekey_slot_device()
+{
+}
+
+//-------------------------------------------------
+//  device_start - device-specific startup
+//-------------------------------------------------
+
+void jakks_gamekey_slot_device::device_start()
+{
+	m_cart = dynamic_cast<device_jakks_gamekey_interface *>(get_card_device());
+}
+
+//-------------------------------------------------
+//  JAKKS GAMEKEY PCB
+//-------------------------------------------------
+
+struct jakks_gamekey_slot
+{
+	int                     pcb_id;
+	const char              *slot_option;
+};
+
+// Here, we take the feature attribute from .xml (i.e. the PCB name) and we assign a unique ID to it
+static const jakks_gamekey_slot slot_list[] =
+{
+	{ JAKKS_GAMEKEY_PLAIN,       "plain" },
+	{ JAKKS_GAMEKEY_I2C_BASE,    "i2c_base" },
+	{ JAKKS_GAMEKEY_I2C_24LC04,  "rom_24lc04" },
+};
+
+static int jakks_gamekey_get_pcb_id(const char *slot)
+{
+	for (auto & elem : slot_list)
+	{
+		if (!core_stricmp(elem.slot_option, slot))
+			return elem.pcb_id;
+	}
+
+	return 0;
+}
+
+static const char *jakks_gamekey_get_slot(int type)
+{
+	for (auto & elem : slot_list)
+	{
+		if (elem.pcb_id == type)
+			return elem.slot_option;
+	}
+
+	return "plain";
+}
+
+
+/*-------------------------------------------------
+ call load
+ -------------------------------------------------*/
+
+image_init_result jakks_gamekey_slot_device::call_load()
+{
+	if (m_cart)
+	{
+		uint8_t *ROM;
+		uint32_t len = !loaded_through_softlist() ? length() : get_software_region_length("rom");
+
+		m_cart->rom_alloc(len, tag());
+
+		ROM = m_cart->get_rom_base();
+
+		if (!loaded_through_softlist())
+			fread(ROM, len);
+		else
+			memcpy(ROM, get_software_region("rom"), len);
+
+		if (!loaded_through_softlist())
+		{
+			// attempt to detect cart type without softlist assistance
+			m_type = get_cart_type(ROM, len);
+		}
+		else
+		{
+			// or for softlist loading, use the type specified
+			const char *pcb_name = get_feature("slot");
+			if (pcb_name)
+				m_type = jakks_gamekey_get_pcb_id(pcb_name);
+		}
+
+		return image_init_result::PASS;
+	}
+
+	return image_init_result::PASS;
+}
+
+
+/*-------------------------------------------------
+ get_cart_type - code to detect cart type from
+ fullpath
+ -------------------------------------------------*/
+
+int jakks_gamekey_slot_device::get_cart_type(const uint8_t *ROM, uint32_t len)
+{
+	// without code analysis we have no way of knowing.
+	int type = JAKKS_GAMEKEY_PLAIN;
+	return type;
+}
+
+
+/*-------------------------------------------------
+ get default card software
+ -------------------------------------------------*/
+
+std::string jakks_gamekey_slot_device::get_default_card_software(get_default_card_software_hook &hook) const
+{
+	if (hook.image_file())
+	{
+		const char *slot_string;
+		uint32_t len = hook.image_file()->size();
+		std::vector<uint8_t> rom(len);
+		int type;
+
+		hook.image_file()->read(&rom[0], len);
+
+		type = get_cart_type(&rom[0], len);
+		slot_string = jakks_gamekey_get_slot(type);
+
+		printf("type: %s\n", slot_string);
+
+		return std::string(slot_string);
+	}
+
+	return software_get_default_slot("plain");
+}
+
+/*-------------------------------------------------
+ read
+ -------------------------------------------------*/
+
+READ16_MEMBER(jakks_gamekey_slot_device::read_cart)
+{
+	return m_cart->read_cart(space, offset);
+}
+
+/*-------------------------------------------------
+ write
+ -------------------------------------------------*/
+
+WRITE16_MEMBER(jakks_gamekey_slot_device::write_cart)
+{
+	m_cart->write_cart(space, offset, data);
+}
+
+/*-------------------------------------------------
+ read seeprom
+ -------------------------------------------------*/
+
+uint8_t jakks_gamekey_slot_device::read_cart_seeprom(void)
+{
+	return m_cart->read_cart_seeprom();
+}
+
+/*-------------------------------------------------
+ write seeprom
+ -------------------------------------------------*/
+
+WRITE16_MEMBER(jakks_gamekey_slot_device::write_cart_seeprom)
+{
+	m_cart->write_cart_seeprom(space, offset, data);
+}

--- a/src/devices/bus/jakks_gamekey/slot.h
+++ b/src/devices/bus/jakks_gamekey/slot.h
@@ -1,0 +1,119 @@
+// license:BSD-3-Clause
+// copyright-holders:David Haywood
+#ifndef MAME_BUS_JAKKS_GAMEKEY_SLOT_H
+#define MAME_BUS_JAKKS_GAMEKEY_SLOT_H
+
+#pragma once
+
+#include "softlist_dev.h"
+
+/***************************************************************************
+ TYPE DEFINITIONS
+ ***************************************************************************/
+
+/* PCB */
+enum
+{
+	JAKKS_GAMEKEY_PLAIN = 0,
+	JAKKS_GAMEKEY_I2C_BASE,
+	JAKKS_GAMEKEY_I2C_24LC04,
+};
+
+// ======================> device_jakks_gamekey_interface
+
+class device_jakks_gamekey_interface : public device_slot_card_interface
+{
+public:
+	// construction/destruction
+	virtual ~device_jakks_gamekey_interface();
+
+	// reading and writing
+	virtual DECLARE_READ16_MEMBER(read_cart) { return 0xffff; }
+	virtual DECLARE_WRITE16_MEMBER(write_cart) { }
+
+	virtual uint8_t read_cart_seeprom(void) { return 1; }
+	virtual DECLARE_WRITE16_MEMBER(write_cart_seeprom) { }
+
+	void rom_alloc(uint32_t size, const char *tag);
+	uint8_t* get_rom_base() { return m_rom; }
+	uint32_t get_rom_size() { return m_rom_size; }
+
+protected:
+	device_jakks_gamekey_interface(const machine_config &mconfig, device_t &device);
+
+	// internal state
+	uint8_t *m_rom;
+	uint32_t m_rom_size;
+};
+
+// ======================> jakks_gamekey_slot_device
+
+class jakks_gamekey_slot_device : public device_t,
+								public device_image_interface,
+								public device_slot_interface
+{
+public:
+	// construction/destruction
+	jakks_gamekey_slot_device(const machine_config &mconfig, const char *tag, device_t *owner, uint32_t clock);
+
+	template <typename T>
+	jakks_gamekey_slot_device(const machine_config &mconfig, const char *tag, device_t *owner, uint32_t clock, T &&opts, const char *dflt)
+		: jakks_gamekey_slot_device(mconfig, tag, owner, clock)
+	{
+		option_reset();
+		opts(*this);
+		set_default_option(dflt);
+		set_fixed(false);
+	}
+
+	virtual ~jakks_gamekey_slot_device();
+
+	// image-level overrides
+	virtual image_init_result call_load() override;
+	virtual void call_unload() override {}
+	virtual const software_list_loader &get_software_list_loader() const override { return rom_software_list_loader::instance(); }
+
+	int get_type() { return m_type; }
+	static int get_cart_type(const uint8_t *ROM, uint32_t len);
+
+	virtual iodevice_t image_type() const override { return IO_CARTSLOT; }
+	virtual bool is_readable()  const override { return 1; }
+	virtual bool is_writeable() const override { return 0; }
+	virtual bool is_creatable() const override { return 0; }
+	virtual bool must_be_loaded() const override { return 0; }
+	virtual bool is_reset_on_load() const override { return 1; }
+	virtual const char *image_interface() const override { return "jakks_gamekey"; }
+	virtual const char *file_extensions() const override { return "bin,u1"; }
+
+	// slot interface overrides
+	virtual std::string get_default_card_software(get_default_card_software_hook &hook) const override;
+
+	// reading and writing
+	virtual DECLARE_READ16_MEMBER(read_cart);
+	virtual DECLARE_WRITE16_MEMBER(write_cart);
+
+	virtual uint8_t read_cart_seeprom(void);
+	virtual DECLARE_WRITE16_MEMBER(write_cart_seeprom);
+
+	bool has_cart() { return m_cart ? true : false; }
+
+protected:
+	// device-level overrides
+	virtual void device_start() override;
+
+	int m_type;
+	device_jakks_gamekey_interface*       m_cart;
+};
+
+// device type definition
+DECLARE_DEVICE_TYPE(JAKKS_GAMEKEY_SLOT, jakks_gamekey_slot_device)
+
+/***************************************************************************
+ DEVICE CONFIGURATION MACROS
+ ***************************************************************************/
+
+#define JAKKSSLOT_ROM_REGION_TAG ":cart:rom"
+
+void jakks_gamekey(device_slot_interface &device);
+
+#endif // MAME_BUS_JAKKS_GAMEKEY_SLOT_H

--- a/src/devices/machine/spg2xx.cpp
+++ b/src/devices/machine/spg2xx.cpp
@@ -66,6 +66,7 @@ DEFINE_DEVICE_TYPE(SPG28X, spg28x_device, "spg28x", "SPG280-series System-on-a-C
 spg2xx_device::spg2xx_device(const machine_config &mconfig, device_type type, const char *tag, device_t *owner, uint32_t clock)
 	: device_t(mconfig, type, tag, owner, clock)
 	, device_sound_interface(mconfig, *this)
+	, m_rowscrolloffset(15)
 	, m_porta_out(*this)
 	, m_portb_out(*this)
 	, m_portc_out(*this)
@@ -359,7 +360,7 @@ void spg2xx_device::blit(const rectangle &cliprect, uint32_t line, uint32_t xoff
 		bits &= 0xffff;
 
 		if (RowScroll)
-			xx -= (int16_t)m_scrollram[yy + 15];
+			xx -= (int16_t)m_scrollram[(yy + m_rowscrolloffset) & 0x1ff];
 
 		xx &= 0x01ff;
 		if (xx >= 0x01c0)

--- a/src/devices/machine/spg2xx.h
+++ b/src/devices/machine/spg2xx.h
@@ -44,6 +44,7 @@ public:
 	spg2xx_device(const machine_config &mconfig, device_type type, const char *tag, device_t *owner, uint32_t clock);
 
 	void set_pal(bool pal) { m_pal_flag = pal ? 1 : 0; }
+	void set_rowscroll_offset(int offset) { m_rowscrolloffset = offset; }
 
 	void map(address_map &map);
 
@@ -498,6 +499,7 @@ protected:
 
 	uint16_t m_video_regs[0x100];
 	uint32_t m_sprite_limit;
+	int m_rowscrolloffset; // auto racing in 'zone60' minigames needs this to be 15, the JAKKS games (Star Wars Revenge of the sith - Gunship Battle, Wheel of Fortune, Namco Ms. Pac-Man 5-in-1 Pole Position) need it to be 0, where does it come from?
 	uint16_t m_pal_flag;
 
 	devcb_write16 m_porta_out;

--- a/src/mame/drivers/vii.cpp
+++ b/src/mame/drivers/vii.cpp
@@ -511,7 +511,11 @@ static INPUT_PORTS_START( jak_nm )
 
 	PORT_START("P3")
 	PORT_BIT( 0x0001, IP_ACTIVE_HIGH, IPT_CUSTOM ) PORT_CUSTOM_MEMBER(DEVICE_SELF, jakks_gkr_state,i2c_gkr_r, nullptr)
-	PORT_BIT( 0xfffe, IP_ACTIVE_HIGH, IPT_UNUSED )
+	PORT_BIT( 0x0002, IP_ACTIVE_HIGH, IPT_UNUSED )
+	PORT_BIT( 0x0004, IP_ACTIVE_HIGH, IPT_UNUSED )
+	PORT_BIT( 0x0008, IP_ACTIVE_LOW, IPT_UNKNOWN ) // PAL/NTSC flag? music speed changes in Mappy
+	PORT_BIT( 0xfff0, IP_ACTIVE_HIGH, IPT_UNUSED )
+
 
 	PORT_START("DIALX") // for Pole Position, joystick can be twisted like a dial/wheel (limited?) (check range)
 	PORT_BIT(0x0fff, 0x0000, IPT_AD_STICK_X ) PORT_SENSITIVITY(100) PORT_KEYDELTA(100) PORT_MINMAX(0x00,0x0fff)

--- a/src/mame/drivers/vii.cpp
+++ b/src/mame/drivers/vii.cpp
@@ -176,6 +176,7 @@ public:
 	void jakks_gkr_dp(machine_config &config);
 	void jakks_gkr_sw(machine_config &config);
 	void jakks_gkr_nm(machine_config &config);
+	void jakks_gkr_wf(machine_config &config);
 
 	DECLARE_CUSTOM_INPUT_MEMBER(i2c_gkr_r);
 
@@ -520,6 +521,29 @@ static INPUT_PORTS_START( jak_nm )
 
 	PORT_START("DIALX") // for Pole Position, joystick can be twisted like a dial/wheel (limited?) (check range)
 	PORT_BIT(0x0fff, 0x0000, IPT_AD_STICK_X ) PORT_SENSITIVITY(100) PORT_KEYDELTA(100) PORT_MINMAX(0x00,0x0fff)
+INPUT_PORTS_END
+
+static INPUT_PORTS_START( jak_wf )
+	PORT_START("P1")
+	PORT_BIT( 0x8000, IP_ACTIVE_HIGH, IPT_JOYSTICK_UP )    PORT_PLAYER(1)
+	PORT_BIT( 0x4000, IP_ACTIVE_HIGH, IPT_JOYSTICK_DOWN )  PORT_PLAYER(1)
+	PORT_BIT( 0x2000, IP_ACTIVE_HIGH, IPT_JOYSTICK_LEFT )  PORT_PLAYER(1)
+	PORT_BIT( 0x1000, IP_ACTIVE_HIGH, IPT_JOYSTICK_RIGHT ) PORT_PLAYER(1)
+	PORT_BIT( 0x0800, IP_ACTIVE_HIGH, IPT_BUTTON1 )
+	PORT_BIT( 0x0400, IP_ACTIVE_HIGH, IPT_BUTTON2 )
+	PORT_BIT( 0x0200, IP_ACTIVE_HIGH, IPT_BUTTON3 )
+
+	PORT_START("P3")
+	PORT_BIT( 0x0001, IP_ACTIVE_HIGH, IPT_CUSTOM ) PORT_CUSTOM_MEMBER(DEVICE_SELF, jakks_gkr_state,i2c_gkr_r, nullptr)
+	PORT_BIT( 0xfffe, IP_ACTIVE_HIGH, IPT_UNUSED )
+
+	/* on real unit you can spin the wheel (and must make sure it completes a full circle, or you lose your turn) instead of pressing 'B' for a random spin but where does it map?
+	PORT_START("DIALX")
+	PORT_BIT(0x0fff, 0x0000, IPT_AD_STICK_X ) PORT_SENSITIVITY(100) PORT_KEYDELTA(100) PORT_MINMAX(0x00,0x0fff)
+
+	PORT_START("DIALY")
+	PORT_BIT(0x0fff, 0x0000, IPT_AD_STICK_Y ) PORT_SENSITIVITY(100) PORT_KEYDELTA(100) PORT_MINMAX(0x00,0x0fff)
+	*/
 INPUT_PORTS_END
 
 static INPUT_PORTS_START( jak_gkr )
@@ -1072,6 +1096,15 @@ void jakks_gkr_state::jakks_gkr_nm(machine_config &config)
 	SOFTWARE_LIST(config, "jakks_gamekey_nm").set_original("jakks_gamekey_nm");
 }
 
+void jakks_gkr_state::jakks_gkr_wf(machine_config &config)
+{
+	jakks_gkr(config);
+	m_maincpu->set_addrmap(AS_PROGRAM, &jakks_gkr_state::mem_map_1m);
+	//m_spg->adc_in<0>().set_ioport("DIALX"); // wheel does not seem to map here
+	//m_spg->adc_in<1>().set_ioport("DIALY");
+	//SOFTWARE_LIST(config, "jakks_gamekey_wf").set_original("jakks_gamekey_wf"); // no game keys were released
+}
+
 
 void spg2xx_game_state::walle(machine_config &config)
 {
@@ -1164,6 +1197,11 @@ ROM_END
 ROM_START( jak_dora )
 	ROM_REGION( 0x800000, "maincpu", ROMREGION_ERASE00 )
 	ROM_LOAD16_WORD_SWAP( "jakksdoragkr.bin", 0x000000, 0x200000, CRC(bcaa132d) SHA1(3894b980fbc4144731b2a7a94acebb29e30de67c) )
+ROM_END
+
+ROM_START( jak_wof )
+	ROM_REGION( 0x800000, "maincpu", ROMREGION_ERASE00 )
+	ROM_LOAD16_WORD_SWAP( "jakkswheeloffortunegkr.bin", 0x000000, 0x200000, CRC(6a879620) SHA1(95478764a61741569041c2299528f6464651d593) )
 ROM_END
 
 ROM_START( jak_disf )
@@ -1403,6 +1441,7 @@ CONS( 2005, jak_disp, 0, 0, jakks_gkr_dp, jak_disp, jakks_gkr_state, empty_init,
 CONS( 2005, jak_sith, 0, 0, jakks_gkr_sw, jak_sith, jakks_gkr_state, empty_init, "JAKKS Pacific Inc / Griptonite Games",    "Star Wars - Revenge of the Sith (JAKKS Pacific TV Game, Game-Key Ready)", MACHINE_IMPERFECT_SOUND | MACHINE_IMPERFECT_GRAPHICS ) // uses SW keys (1 released)
 CONS( 2005, jak_dbz,  0, 0, jakks_gkr_1m, jak_gkr,  jakks_gkr_state, empty_init, "JAKKS Pacific Inc / Handheld Games",      "Dragon Ball Z (JAKKS Pacific TV Game, Game-Key Ready)", MACHINE_IMPERFECT_SOUND | MACHINE_IMPERFECT_GRAPHICS ) // DB (no game-keys released, 1 in development but cancelled)
 CONS( 2004, jak_mpac, 0, 0, jakks_gkr_nm, jak_nm,   jakks_gkr_state, empty_init, "JAKKS Pacific Inc / Namco / HotGen Ltd",  "Ms. Pac-Man 5-in-1 (Ms. Pac-Man, Pole Position, Galaga, Xevious, Mappy) (JAKKS Pacific TV Game, Game-Key Ready)", MACHINE_IMPERFECT_SOUND | MACHINE_IMPERFECT_GRAPHICS ) // uses NM (3 keys available [Dig Dug, New Rally-X], [Rally-X, Pac-Man, Bosconian], [Pac-Man, Bosconian])
+CONS( 2005, jak_wof,  0, 0, jakks_gkr_wf, jak_wf,   jakks_gkr_state, empty_init, "JAKKS Pacific Inc / HotGen Ltd",          "Wheel of Fortune (JAKKS Pacific TV Game, Game-Key Ready)", MACHINE_NOT_WORKING | MACHINE_IMPERFECT_SOUND | MACHINE_IMPERFECT_GRAPHICS ) // uses WF lkeys (no game-keys released)
 
 // Nicktoons                                   NK (3 keys available) (same keys as Dora the Explorer)
 // SpongeBob SquarePants: The Fry Cook Games   NK (3 keys available)  ^^                
@@ -1410,8 +1449,7 @@ CONS( 2004, jak_mpac, 0, 0, jakks_gkr_nm, jak_nm,   jakks_gkr_state, empty_init,
 
 // no keys released for the following, some were in development but cancelled
 // Capcom 3-in-1                               CC (no game-keys released)
-// Care Bears                                  CB (no game-keys released)
-// Wheel of Fortune                            WF (no game-keys released)
+// Care Bears                                  CB (no game-keys released)                           
 // Winnie the Pooh                             WP (no game-keys released)
 
 // Radica TV games

--- a/src/mame/drivers/vii.cpp
+++ b/src/mame/drivers/vii.cpp
@@ -1043,6 +1043,8 @@ void jakks_gkr_state::jakks_gkr(machine_config &config)
 	//m_spg->portb_in().set_ioport("P2");
 	m_spg->portc_out().set(FUNC(jakks_gkr_state::gkr_portc_w));
 
+	m_spg-> set_rowscroll_offset(0);
+
 	JAKKS_GAMEKEY_SLOT(config, m_cart, 0, jakks_gamekey, nullptr);
 }
 
@@ -1441,7 +1443,7 @@ CONS( 2005, jak_disp, 0, 0, jakks_gkr_dp, jak_disp, jakks_gkr_state, empty_init,
 CONS( 2005, jak_sith, 0, 0, jakks_gkr_sw, jak_sith, jakks_gkr_state, empty_init, "JAKKS Pacific Inc / Griptonite Games",    "Star Wars - Revenge of the Sith (JAKKS Pacific TV Game, Game-Key Ready)", MACHINE_IMPERFECT_SOUND | MACHINE_IMPERFECT_GRAPHICS ) // uses SW keys (1 released)
 CONS( 2005, jak_dbz,  0, 0, jakks_gkr_1m, jak_gkr,  jakks_gkr_state, empty_init, "JAKKS Pacific Inc / Handheld Games",      "Dragon Ball Z (JAKKS Pacific TV Game, Game-Key Ready)", MACHINE_IMPERFECT_SOUND | MACHINE_IMPERFECT_GRAPHICS ) // DB (no game-keys released, 1 in development but cancelled)
 CONS( 2004, jak_mpac, 0, 0, jakks_gkr_nm, jak_nm,   jakks_gkr_state, empty_init, "JAKKS Pacific Inc / Namco / HotGen Ltd",  "Ms. Pac-Man 5-in-1 (Ms. Pac-Man, Pole Position, Galaga, Xevious, Mappy) (JAKKS Pacific TV Game, Game-Key Ready)", MACHINE_IMPERFECT_SOUND | MACHINE_IMPERFECT_GRAPHICS ) // uses NM (3 keys available [Dig Dug, New Rally-X], [Rally-X, Pac-Man, Bosconian], [Pac-Man, Bosconian])
-CONS( 2005, jak_wof,  0, 0, jakks_gkr_wf, jak_wf,   jakks_gkr_state, empty_init, "JAKKS Pacific Inc / HotGen Ltd",          "Wheel of Fortune (JAKKS Pacific TV Game, Game-Key Ready)", MACHINE_NOT_WORKING | MACHINE_IMPERFECT_SOUND | MACHINE_IMPERFECT_GRAPHICS ) // uses WF lkeys (no game-keys released)
+CONS( 2005, jak_wof,  0, 0, jakks_gkr_wf, jak_wf,   jakks_gkr_state, empty_init, "JAKKS Pacific Inc / HotGen Ltd",          "Wheel of Fortune (JAKKS Pacific TV Game, Game-Key Ready)",  MACHINE_IMPERFECT_SOUND | MACHINE_IMPERFECT_GRAPHICS ) // uses WF keys (no game-keys released)  analog wheel not emulated
 
 // Nicktoons                                   NK (3 keys available) (same keys as Dora the Explorer)
 // SpongeBob SquarePants: The Fry Cook Games   NK (3 keys available)  ^^                

--- a/src/mame/drivers/vii.cpp
+++ b/src/mame/drivers/vii.cpp
@@ -174,6 +174,7 @@ public:
 	void jakks_gkr_nk(machine_config &config);
 	void jakks_gkr_dy(machine_config &config);
 	void jakks_gkr_sw(machine_config &config);
+	void jakks_gkr_nm(machine_config &config);
 
 	DECLARE_CUSTOM_INPUT_MEMBER(i2c_gkr_r);
 
@@ -496,6 +497,24 @@ static INPUT_PORTS_START( jak_sith )
 
 	PORT_START("JOYY")
 	PORT_BIT(0x0fff, 0x0000, IPT_AD_STICK_Y) PORT_SENSITIVITY(100) PORT_KEYDELTA(100) PORT_MINMAX(0x00,0x0fff)
+INPUT_PORTS_END
+
+static INPUT_PORTS_START( jak_nm )
+	PORT_START("P1")
+	PORT_BIT( 0x8000, IP_ACTIVE_HIGH, IPT_JOYSTICK_UP )    PORT_PLAYER(1)
+	PORT_BIT( 0x4000, IP_ACTIVE_HIGH, IPT_JOYSTICK_DOWN )  PORT_PLAYER(1)
+	PORT_BIT( 0x2000, IP_ACTIVE_HIGH, IPT_JOYSTICK_LEFT )  PORT_PLAYER(1)
+	PORT_BIT( 0x1000, IP_ACTIVE_HIGH, IPT_JOYSTICK_RIGHT ) PORT_PLAYER(1)
+	PORT_BIT( 0x0800, IP_ACTIVE_HIGH, IPT_BUTTON2 )
+	PORT_BIT( 0x0400, IP_ACTIVE_HIGH, IPT_BUTTON3 ) PORT_NAME("Menu")
+	PORT_BIT( 0x0200, IP_ACTIVE_HIGH, IPT_BUTTON1 )
+
+	PORT_START("P3")
+	PORT_BIT( 0x0001, IP_ACTIVE_HIGH, IPT_CUSTOM ) PORT_CUSTOM_MEMBER(DEVICE_SELF, jakks_gkr_state,i2c_gkr_r, nullptr)
+	PORT_BIT( 0xfffe, IP_ACTIVE_HIGH, IPT_UNUSED )
+
+	PORT_START("DIALX") // for Pole Position, joystick can be twisted like a dial/wheel (limited?) (check range)
+	PORT_BIT(0x0fff, 0x0000, IPT_AD_STICK_X ) PORT_SENSITIVITY(100) PORT_KEYDELTA(100) PORT_MINMAX(0x00,0x0fff)
 INPUT_PORTS_END
 
 static INPUT_PORTS_START( jak_gkr )
@@ -1013,6 +1032,14 @@ void jakks_gkr_state::jakks_gkr_sw(machine_config &config)
 	SOFTWARE_LIST(config, "jakks_gamekey_sw").set_original("jakks_gamekey_sw");
 }
 
+void jakks_gkr_state::jakks_gkr_nm(machine_config &config)
+{
+	jakks_gkr(config);
+	m_maincpu->set_addrmap(AS_PROGRAM, &jakks_gkr_state::mem_map_1m);
+	m_spg->adc_in<0>().set_ioport("DIALX");
+	SOFTWARE_LIST(config, "jakks_gamekey_nm").set_original("jakks_gamekey_nm");
+}
+
 
 void spg2xx_game_state::walle(machine_config &config)
 {
@@ -1110,6 +1137,11 @@ ROM_END
 ROM_START( jak_disf )
 	ROM_REGION( 0x800000, "maincpu", ROMREGION_ERASE00 )
 	ROM_LOAD16_WORD_SWAP( "disneyfriendsgkr.bin", 0x000000, 0x200000, CRC(77bca50b) SHA1(6e0f4fd229ee11eac721b5dbe79cf9002d3dbd64) )
+ROM_END
+
+ROM_START( jak_mpac )
+	ROM_REGION( 0x800000, "maincpu", ROMREGION_ERASE00 )
+	ROM_LOAD16_WORD_SWAP( "jakksmspacmangkr.bin", 0x000000, 0x100000, CRC(cab40f77) SHA1(30731acc461150d96aafa7a0451cfb1a25264678) )
 ROM_END
 
 ROM_START( jak_sdoo )
@@ -1331,12 +1363,12 @@ CONS( 2005, jak_sdoo, 0, 0, jakks_gkr_2m, jak_gkr,  jakks_gkr_state, empty_init,
 CONS( 2005, jak_disf, 0, 0, jakks_gkr_dy, jak_gkr,  jakks_gkr_state, empty_init, "JAKKS Pacific Inc / HotGen Ltd",          "Disney Friends (JAKKS Pacific TV Game, Game-Key Ready)", MACHINE_NOT_WORKING | MACHINE_IMPERFECT_SOUND | MACHINE_IMPERFECT_GRAPHICS ) // uses DY keys (3 released)
 CONS( 2005, jak_sith, 0, 0, jakks_gkr_sw, jak_sith, jakks_gkr_state, empty_init, "JAKKS Pacific Inc / Griptonite Games",    "Star Wars - Revenge of the Sith (JAKKS Pacific TV Game, Game-Key Ready)", MACHINE_IMPERFECT_SOUND | MACHINE_IMPERFECT_GRAPHICS ) // uses SW keys (1 released)
 CONS( 2005, jak_dbz,  0, 0, jakks_gkr_1m, jak_gkr,  jakks_gkr_state, empty_init, "JAKKS Pacific Inc / Handheld Games",      "Dragon Ball Z (JAKKS Pacific TV Game, Game-Key Ready)", MACHINE_IMPERFECT_SOUND | MACHINE_IMPERFECT_GRAPHICS ) // DB (no game-keys released, 1 in development but cancelled)
+CONS( 2004, jak_mpac, 0, 0, jakks_gkr_nm, jak_nm,   jakks_gkr_state, empty_init, "JAKKS Pacific Inc / Namco / HotGen Ltd",  "Ms. Pac-Man 5-in-1 (Ms. Pac-Man, Pole Position, Galaga, Xevious, Mappy) (JAKKS Pacific TV Game, Game-Key Ready)", MACHINE_IMPERFECT_SOUND | MACHINE_IMPERFECT_GRAPHICS ) // uses NM (3 keys available [Dig Dug, New Rally-X], [Rally-X, Pac-Man, Bosconian], [Pac-Man, Bosconian])
 
-// Nicktoons                                   NK (3? keys available) (same keys as Dora the Explorer)
-// SpongeBob SquarePants: The Fry Cook Games   NK (3? keys available)  ^^
-// Namco Ms. Pac-Man                           NM (3 keys available [Dig Dug, New Rally-X], [Rally-X, Pac-Man, Bosconian], [Pac-Man, Bosconian])
-// Disney Princess                             DP (? keys available)
-// Spider-Man                                  MV (1? key available)
+// Nicktoons                                   NK (3 keys available) (same keys as Dora the Explorer)
+// SpongeBob SquarePants: The Fry Cook Games   NK (3 keys available)  ^^
+// Disney Princess                             DP (1 key available)
+// Spider-Man                                  MV (1 key available)
 
 // no keys released for the following, some were in development but cancelled
 // Capcom 3-in-1                               CC (no game-keys released)

--- a/src/mame/drivers/vii.cpp
+++ b/src/mame/drivers/vii.cpp
@@ -529,9 +529,12 @@ static INPUT_PORTS_START( jak_wf )
 	PORT_BIT( 0x4000, IP_ACTIVE_HIGH, IPT_JOYSTICK_DOWN )  PORT_PLAYER(1)
 	PORT_BIT( 0x2000, IP_ACTIVE_HIGH, IPT_JOYSTICK_LEFT )  PORT_PLAYER(1)
 	PORT_BIT( 0x1000, IP_ACTIVE_HIGH, IPT_JOYSTICK_RIGHT ) PORT_PLAYER(1)
-	PORT_BIT( 0x0800, IP_ACTIVE_HIGH, IPT_BUTTON1 )
-	PORT_BIT( 0x0400, IP_ACTIVE_HIGH, IPT_BUTTON2 )
-	PORT_BIT( 0x0200, IP_ACTIVE_HIGH, IPT_BUTTON3 )
+	PORT_BIT( 0x0800, IP_ACTIVE_HIGH, IPT_BUTTON1 ) PORT_NAME("A")
+	PORT_BIT( 0x0400, IP_ACTIVE_HIGH, IPT_BUTTON2 ) PORT_NAME("B")
+	PORT_BIT( 0x0200, IP_ACTIVE_HIGH, IPT_UNUSED )
+	PORT_BIT( 0x01c0, IP_ACTIVE_HIGH, IPT_UNUSED )
+	PORT_BIT( 0x0020, IP_ACTIVE_HIGH, IPT_BUTTON3 ) PORT_NAME("Menu")
+	PORT_BIT( 0x001f, IP_ACTIVE_HIGH, IPT_UNUSED )
 
 	PORT_START("P3")
 	PORT_BIT( 0x0001, IP_ACTIVE_HIGH, IPT_CUSTOM ) PORT_CUSTOM_MEMBER(DEVICE_SELF, jakks_gkr_state,i2c_gkr_r, nullptr)
@@ -1444,6 +1447,7 @@ CONS( 2005, jak_sith, 0, 0, jakks_gkr_sw, jak_sith, jakks_gkr_state, empty_init,
 CONS( 2005, jak_dbz,  0, 0, jakks_gkr_1m, jak_gkr,  jakks_gkr_state, empty_init, "JAKKS Pacific Inc / Handheld Games",      "Dragon Ball Z (JAKKS Pacific TV Game, Game-Key Ready)", MACHINE_IMPERFECT_SOUND | MACHINE_IMPERFECT_GRAPHICS ) // DB (no game-keys released, 1 in development but cancelled)
 CONS( 2004, jak_mpac, 0, 0, jakks_gkr_nm, jak_nm,   jakks_gkr_state, empty_init, "JAKKS Pacific Inc / Namco / HotGen Ltd",  "Ms. Pac-Man 5-in-1 (Ms. Pac-Man, Pole Position, Galaga, Xevious, Mappy) (JAKKS Pacific TV Game, Game-Key Ready)", MACHINE_IMPERFECT_SOUND | MACHINE_IMPERFECT_GRAPHICS ) // uses NM (3 keys available [Dig Dug, New Rally-X], [Rally-X, Pac-Man, Bosconian], [Pac-Man, Bosconian])
 CONS( 2005, jak_wof,  0, 0, jakks_gkr_wf, jak_wf,   jakks_gkr_state, empty_init, "JAKKS Pacific Inc / HotGen Ltd",          "Wheel of Fortune (JAKKS Pacific TV Game, Game-Key Ready)",  MACHINE_IMPERFECT_SOUND | MACHINE_IMPERFECT_GRAPHICS ) // uses WF keys (no game-keys released)  analog wheel not emulated
+// There is a 'Second Edition' version of Wheel of Fortune with a Gold case, GameKey port removed, and a '2' over the usual Game Key Ready logo, it is not yet verified to be the same code.
 
 // Nicktoons                                   NK (3 keys available) (same keys as Dora the Explorer)
 // SpongeBob SquarePants: The Fry Cook Games   NK (3 keys available)  ^^                

--- a/src/mame/drivers/vii.cpp
+++ b/src/mame/drivers/vii.cpp
@@ -173,6 +173,7 @@ public:
 	void jakks_gkr_2m(machine_config &config);
 	void jakks_gkr_nk(machine_config &config);
 	void jakks_gkr_dy(machine_config &config);
+	void jakks_gkr_dp(machine_config &config);
 	void jakks_gkr_sw(machine_config &config);
 	void jakks_gkr_nm(machine_config &config);
 
@@ -580,6 +581,26 @@ static INPUT_PORTS_START( jak_gkr )
 	PORT_DIPSETTING(      0x8000, DEF_STR( Off ) )
 	PORT_DIPSETTING(      0x0000, DEF_STR( On ) )
 INPUT_PORTS_END
+
+static INPUT_PORTS_START( jak_disp )
+	PORT_START("P1")
+	PORT_BIT( 0x8000, IP_ACTIVE_HIGH, IPT_JOYSTICK_UP )    PORT_PLAYER(1)
+	PORT_BIT( 0x4000, IP_ACTIVE_HIGH, IPT_JOYSTICK_DOWN )  PORT_PLAYER(1)
+	PORT_BIT( 0x2000, IP_ACTIVE_HIGH, IPT_JOYSTICK_LEFT )  PORT_PLAYER(1)
+	PORT_BIT( 0x1000, IP_ACTIVE_HIGH, IPT_JOYSTICK_RIGHT ) PORT_PLAYER(1)
+	PORT_BIT( 0x0800, IP_ACTIVE_HIGH, IPT_UNUSED )
+	PORT_BIT( 0x0400, IP_ACTIVE_HIGH, IPT_UNUSED )
+	PORT_BIT( 0x0200, IP_ACTIVE_HIGH, IPT_BUTTON1 )
+	PORT_BIT( 0x0100, IP_ACTIVE_HIGH, IPT_BUTTON2 )
+	PORT_BIT( 0x00c0, IP_ACTIVE_HIGH, IPT_UNUSED )
+	PORT_BIT( 0x0020, IP_ACTIVE_HIGH, IPT_BUTTON3 ) PORT_NAME("Start / Menu / Pause")
+	PORT_BIT( 0x001f, IP_ACTIVE_HIGH, IPT_UNUSED )
+
+	PORT_START("P3")
+	PORT_BIT( 0x0001, IP_ACTIVE_HIGH, IPT_CUSTOM ) PORT_CUSTOM_MEMBER(DEVICE_SELF, jakks_gkr_state,i2c_gkr_r, nullptr)
+	PORT_BIT( 0xfffe, IP_ACTIVE_HIGH, IPT_UNUSED )
+INPUT_PORTS_END
+
 
 
 static INPUT_PORTS_START( wirels60 )
@@ -1027,6 +1048,13 @@ void jakks_gkr_state::jakks_gkr_dy(machine_config &config)
 	SOFTWARE_LIST(config, "jakks_gamekey_dy").set_original("jakks_gamekey_dy");
 }
 
+void jakks_gkr_state::jakks_gkr_dp(machine_config &config)
+{
+	jakks_gkr(config);
+	m_maincpu->set_addrmap(AS_PROGRAM, &jakks_gkr_state::mem_map_1m);
+	//SOFTWARE_LIST(config, "jakks_gamekey_dp").set_original("jakks_gamekey_dp");
+}
+
 void jakks_gkr_state::jakks_gkr_sw(machine_config &config)
 {
 	jakks_gkr(config);
@@ -1141,6 +1169,11 @@ ROM_END
 ROM_START( jak_disf )
 	ROM_REGION( 0x800000, "maincpu", ROMREGION_ERASE00 )
 	ROM_LOAD16_WORD_SWAP( "disneyfriendsgkr.bin", 0x000000, 0x200000, CRC(77bca50b) SHA1(6e0f4fd229ee11eac721b5dbe79cf9002d3dbd64) )
+ROM_END
+
+ROM_START( jak_disp )
+	ROM_REGION( 0x800000, "maincpu", ROMREGION_ERASE00 )
+	ROM_LOAD16_WORD_SWAP( "jakksdisneyprincessgkr.bin", 0x000000, 0x200000, CRC(e26003ce) SHA1(ee15243281df6f09b96185c34582d7091604c954) )
 ROM_END
 
 ROM_START( jak_mpac )
@@ -1365,13 +1398,14 @@ CONS( 2005, jak_dora, 0, 0, jakks_gkr_nk, jak_gkr,  jakks_gkr_state, empty_init,
 // there is also a Dora the Explorer 'Race to Play Park' which is also a GameKeyReady unit with NK code, and different games - the upper part of this one is blue.
 CONS( 2005, jak_sdoo, 0, 0, jakks_gkr_2m, jak_gkr,  jakks_gkr_state, empty_init, "JAKKS Pacific Inc / Jolliford Management","Scooby-Doo! and the Mystery of the Castle (JAKKS Pacific TV Game, Game-Key Ready)", MACHINE_NOT_WORKING | MACHINE_IMPERFECT_SOUND | MACHINE_IMPERFECT_GRAPHICS ) //  SD (no game-keys released)
 CONS( 2005, jak_disf, 0, 0, jakks_gkr_dy, jak_gkr,  jakks_gkr_state, empty_init, "JAKKS Pacific Inc / HotGen Ltd",          "Disney Friends (JAKKS Pacific TV Game, Game-Key Ready)", MACHINE_NOT_WORKING | MACHINE_IMPERFECT_SOUND | MACHINE_IMPERFECT_GRAPHICS ) // uses DY keys (3 released)
+CONS( 2005, jak_disp, 0, 0, jakks_gkr_dp, jak_disp, jakks_gkr_state, empty_init, "JAKKS Pacific Inc / 5000ft, Inc",         "Disney Princess (JAKKS Pacific TV Game, Game-Key Ready)", MACHINE_IMPERFECT_SOUND | MACHINE_IMPERFECT_GRAPHICS ) // uses DP keys (1 key released)
+// There seems to be a second game called 'Disney Princesses' with a 'board game' style front end as well as the minigames, also GKR, see https://www.youtube.com/watch?v=w9p5TI029bQ  The one we have is https://www.youtube.com/watch?v=9ppPKVbpoMs  the physical package seems identical.
 CONS( 2005, jak_sith, 0, 0, jakks_gkr_sw, jak_sith, jakks_gkr_state, empty_init, "JAKKS Pacific Inc / Griptonite Games",    "Star Wars - Revenge of the Sith (JAKKS Pacific TV Game, Game-Key Ready)", MACHINE_IMPERFECT_SOUND | MACHINE_IMPERFECT_GRAPHICS ) // uses SW keys (1 released)
 CONS( 2005, jak_dbz,  0, 0, jakks_gkr_1m, jak_gkr,  jakks_gkr_state, empty_init, "JAKKS Pacific Inc / Handheld Games",      "Dragon Ball Z (JAKKS Pacific TV Game, Game-Key Ready)", MACHINE_IMPERFECT_SOUND | MACHINE_IMPERFECT_GRAPHICS ) // DB (no game-keys released, 1 in development but cancelled)
 CONS( 2004, jak_mpac, 0, 0, jakks_gkr_nm, jak_nm,   jakks_gkr_state, empty_init, "JAKKS Pacific Inc / Namco / HotGen Ltd",  "Ms. Pac-Man 5-in-1 (Ms. Pac-Man, Pole Position, Galaga, Xevious, Mappy) (JAKKS Pacific TV Game, Game-Key Ready)", MACHINE_IMPERFECT_SOUND | MACHINE_IMPERFECT_GRAPHICS ) // uses NM (3 keys available [Dig Dug, New Rally-X], [Rally-X, Pac-Man, Bosconian], [Pac-Man, Bosconian])
 
 // Nicktoons                                   NK (3 keys available) (same keys as Dora the Explorer)
-// SpongeBob SquarePants: The Fry Cook Games   NK (3 keys available)  ^^
-// Disney Princess                             DP (1 key available)
+// SpongeBob SquarePants: The Fry Cook Games   NK (3 keys available)  ^^                
 // Spider-Man                                  MV (1 key available)
 
 // no keys released for the following, some were in development but cancelled

--- a/src/mame/mame.lst
+++ b/src/mame/mame.lst
@@ -38667,6 +38667,7 @@ jak_fan4                        //
 jak_just                        //
 jak_dora                        //
 jak_disf                        //
+jak_disp                        //
 jak_sith                        //
 jak_sdoo                        //
 jak_dbz                         //

--- a/src/mame/mame.lst
+++ b/src/mame/mame.lst
@@ -38672,6 +38672,7 @@ jak_sith                        //
 jak_sdoo                        //
 jak_dbz                         //
 jak_mpac                        //
+jak_wof                         //
 vii                             // KenSingTon / Jungle Soft / Siatronics Vii
 wrlshunt                        // Wireless: Hunting Video Game System
 wirels60                        // Wireless 60

--- a/src/mame/mame.lst
+++ b/src/mame/mame.lst
@@ -38670,6 +38670,7 @@ jak_disf                        //
 jak_sith                        //
 jak_sdoo                        //
 jak_dbz                         //
+jak_mpac                        //
 vii                             // KenSingTon / Jungle Soft / Siatronics Vii
 wrlshunt                        // Wireless: Hunting Video Game System
 wirels60                        // Wireless 60


### PR DESCRIPTION
new WORKING machines
---
Ms. Pac-Man 5-in-1 (Ms. Pac-Man, Pole Position, Galaga, Xevious, Mappy) (JAKKS Pacific TV Game, Game-Key Ready) [Sean Riddle, Peter Wilhelmsen, 20 external donators]
Disney Princess (JAKKS Pacific TV Game, Game-Key Ready) [Sean Riddle, 20 external donators]
Wheel of Fortune (JAKKS Pacific TV Game, Game-Key Ready) [Sean Riddle, 20 external donators]

new WORKING Software List entries
---
jakks_gamekey_nm:nrxdig New Rally X & Dig Dug  [Sean Riddle, Peter Wilhelmsen, 20 external donators]

Namco stuff is playable aside from sound issues (weirdly once certain games save the score, eg. Galaga, a sound channel gets lost)

Wheel of Fortune analog wheel isn't emulated, but it's an optional thing, you can just press B to spin.

also make the game keys actually save to the seeprom on the game key, not the system one.
