### PR TITLE
Apple II clcracked updates (nw)

### DIFF
--- a/hash/apple2_flop_clcracked.xml
+++ b/hash/apple2_flop_clcracked.xml
@@ -34,7 +34,7 @@
 	</software>
 
 	<software name="2400ad">
-		<description>2400 A.D. (4am crack) side A</description>
+		<description>2400 A.D. (cleanly cracked)</description>
 		<year>1987</year>
 		<publisher>Origin Systems</publisher>
 		<info name="release" value="2018-09-23"/>
@@ -55,17 +55,24 @@
 		</part>
 	</software>
 
-	<software name="abnewv">
-		<description>A Brand New View (4am crack)</description>
-		<year>1987</year>
-		<publisher>D.C. Heath and Company</publisher>
-		<info name="release" value="2016-08-24"/>
+	<software name="acmasadv">
+		<description>A Christmas Adventure (cleanly cracked)</description>
+		<year>1984</year>
+		<publisher>Bitcards</publisher>
+		<info name="release" value="2019-01-15"/>
 		<sharedfeat name="compatibility" value="NEEDDATA" />
 		<!-- No compatibility data known at this time. -->
 
 		<part name="flop1" interface="floppy_5_25">
+			<feature name="part_id" value="Side A"/>
 			<dataarea name="flop" size="143360">
-			<rom name="a brand new view (4am crack).dsk" size="143360" crc="dcbee16d" sha1="1f5fba7748da446fb3c31845788e18905691baea" offset="0x0000" />
+				<rom name="a christmas adventure (4am crack) side a.dsk" size="143360" crc="460cd873" sha1="da5c2b4efac02f52107cce42cdd37a3d0bb96e0f" offset="0x0000" />
+			</dataarea>
+		</part>
+		<part name="flop2" interface="floppy_5_25">
+			<feature name="part_id" value="Side B"/>
+			<dataarea name="flop" size="143360">
+				<rom name="a christmas adventure (4am crack) side b.dsk" size="143360" crc="3b2c8ed4" sha1="385ae9a8d92e97395e5448433251c5d7b5e9d9e5" offset="0x0000" />
 			</dataarea>
 		</part>
 	</software>
@@ -74,6 +81,8 @@
 		<description>Alcazar the Forgotten Fortress (cleanly cracked)</description>
 		<year>1985</year>
 		<publisher>Activision</publisher>
+		<sharedfeat name="compatibility" value="NEEDDATA" />
+		<!-- No compatibility data known at this time. -->
 
 		<part name="flop1" interface="floppy_5_25">
 			<dataarea name="flop" size="143360">
@@ -86,6 +95,8 @@
 		<description>Aliens (cleanly cracked)</description>
 		<year>1986</year>
 		<publisher>Activision</publisher>
+		<sharedfeat name="compatibility" value="NEEDDATA" />
+		<!-- No compatibility data known at this time. -->
 
 		<part name="flop1" interface="floppy_5_25">
 			<feature name="part_id" value="Disk 1"/>
@@ -105,6 +116,8 @@
 		<description>Aztec (cleanly cracked)</description>
 		<year>1982</year>
 		<publisher>Datamost</publisher>
+		<sharedfeat name="compatibility" value="NEEDDATA" />
+		<!-- No compatibility data known at this time. -->
 
 		<part name="flop1" interface="floppy_5_25">
 			<dataarea name="flop" size="143360">
@@ -117,6 +130,8 @@
 		<description>The American Challenge (cleanly cracked)</description>
 		<year>1986</year>
 		<publisher>MIndscape</publisher>
+		<sharedfeat name="compatibility" value="NEEDDATA" />
+		<!-- No compatibility data known at this time. -->
 
 		<part name="flop1" interface="floppy_5_25">
 			<dataarea name="flop" size="143360">
@@ -129,6 +144,8 @@
 		<description>Battle Chess (cleanly cracked)</description>
 		<year>1990</year>
 		<publisher>Interplay</publisher>
+		<sharedfeat name="compatibility" value="NEEDDATA" />
+		<!-- No compatibility data known at this time. -->
 
 		<part name="flop1" interface="floppy_5_25">
 			<feature name="part_id" value="Side A"/>
@@ -148,6 +165,8 @@
 		<description>Batman (cleanly cracked)</description>
 		<year>1988</year>
 		<publisher>Data East</publisher>
+		<sharedfeat name="compatibility" value="NEEDDATA" />
+		<!-- No compatibility data known at this time. -->
 
 		<part name="flop1" interface="floppy_5_25">
 			<feature name="part_id" value="Side A"/>
@@ -167,6 +186,8 @@
 		<description>BASIC Building Blocks (cleanly cracked)</description>
 		<year>1983</year>
 		<publisher>Micro Education</publisher>
+		<sharedfeat name="compatibility" value="NEEDDATA" />
+		<!-- No compatibility data known at this time. -->
 
 		<part name="flop1" interface="floppy_5_25">
 			<feature name="part_id" value="Disk 1"/>
@@ -182,10 +203,27 @@
 		</part>
 	</software>
 
+	<software name="abnewv">
+		<description>A Brand New View (cleanly cracked)</description>
+		<year>1987</year>
+		<publisher>D.C. Heath and Company</publisher>
+		<info name="release" value="2016-08-24"/>
+		<sharedfeat name="compatibility" value="NEEDDATA" />
+		<!-- No compatibility data known at this time. -->
+
+		<part name="flop1" interface="floppy_5_25">
+			<dataarea name="flop" size="143360">
+			<rom name="a brand new view (4am crack).dsk" size="143360" crc="dcbee16d" sha1="1f5fba7748da446fb3c31845788e18905691baea" offset="0x0000" />
+			</dataarea>
+		</part>
+	</software>
+
 	<software name="bublbobl">
 		<description>Bubble Bobble (cleanly cracked)</description>
 		<year>1988</year>
 		<publisher>Taito America / NovaLogic</publisher>
+		<sharedfeat name="compatibility" value="NEEDDATA" />
+		<!-- No compatibility data known at this time. -->
 
 		<part name="flop1" interface="floppy_5_25">
 			<feature name="part_id" value="Disk 1"/>
@@ -205,6 +243,8 @@
 		<description>Countdown to Shutdown (cleanly cracked)</description>
 		<year>1985</year>
 		<publisher>Activision</publisher>
+		<sharedfeat name="compatibility" value="NEEDDATA" />
+		<!-- No compatibility data known at this time. -->
 
 		<part name="flop1" interface="floppy_5_25">
 			<dataarea name="flop" size="143360">
@@ -217,6 +257,8 @@
 		<description>Cogito! (cleanly cracked)</description>
 		<year>198??</year>
 		<publisher>Reader's Digest Software</publisher>
+		<sharedfeat name="compatibility" value="NEEDDATA" />
+		<!-- No compatibility data known at this time. -->
 
 		<part name="flop1" interface="floppy_5_25">
 			<dataarea name="flop" size="143360">
@@ -229,6 +271,8 @@
 		<description>Crisis Mountain (cleanly cracked)</description>
 		<year>1982</year>
 		<publisher>Synergistic Software</publisher>
+		<sharedfeat name="compatibility" value="NEEDDATA" />
+		<!-- No compatibility data known at this time. -->
 
 		<part name="flop1" interface="floppy_5_25">
 			<dataarea name="flop" size="143360">
@@ -241,6 +285,8 @@
 		<description>Where in Time is Carmen Sandiego v1.1 (cleanly cracked)</description>
 		<year>1989</year>
 		<publisher>Broderbund</publisher>
+		<sharedfeat name="compatibility" value="NEEDDATA" />
+		<!-- No compatibility data known at this time. -->
 
 		<part name="flop1" interface="floppy_5_25">
 			<feature name="part_id" value="Side A"/>
@@ -272,6 +318,8 @@
 		<description>Where in Time is Carmen Sandiego v1.1 800K 3.5 disc (cleanly cracked)</description>
 		<year>1989</year>
 		<publisher>Broderbund</publisher>
+		<sharedfeat name="compatibility" value="NEEDDATA" />
+		<!-- No compatibility data known at this time. -->
 
 		<part name="flop1" interface="floppy_3_5">
 			<dataarea name="flop" size="819264">
@@ -284,6 +332,8 @@
 		<description>Where in Time is Carmen Sandiego v1.0 (cleanly cracked)</description>
 		<year>1989</year>
 		<publisher>Broderbund</publisher>
+		<sharedfeat name="compatibility" value="NEEDDATA" />
+		<!-- No compatibility data known at this time. -->
 
 		<part name="flop1" interface="floppy_5_25">
 			<feature name="part_id" value="Side A"/>
@@ -315,6 +365,8 @@
 		<description>Dungeon Master's Assistant (cleanly cracked)</description>
 		<year>1988</year>
 		<publisher>SSI</publisher>
+		<sharedfeat name="compatibility" value="NEEDDATA" />
+		<!-- No compatibility data known at this time. -->
 
 		<part name="flop1" interface="floppy_5_25">
 			<feature name="part_id" value="Side A"/>
@@ -335,6 +387,8 @@
 		<!-- Original disk wouldn't boot on 65C02 or later -->
 		<year>1983</year>
 		<publisher>Datasoft / Design Labs</publisher>
+		<sharedfeat name="compatibility" value="NEEDDATA" />
+		<!-- No compatibility data known at this time. -->
 
 		<part name="flop1" interface="floppy_5_25">
 			<dataarea name="flop" size="143360">
@@ -347,6 +401,8 @@
 		<description>Ghostbusters (cleanly cracked)</description>
 		<year>1984</year>
 		<publisher>Activision</publisher>
+		<sharedfeat name="compatibility" value="NEEDDATA" />
+		<!-- No compatibility data known at this time. -->
 
 		<part name="flop1" interface="floppy_5_25">
 			<dataarea name="flop" size="143360">
@@ -359,6 +415,8 @@
 		<description>Hardball (cleanly cracked)</description>
 		<year>1985</year>
 		<publisher>Accolade</publisher>
+		<sharedfeat name="compatibility" value="NEEDDATA" />
+		<!-- No compatibility data known at this time. -->
 
 		<part name="flop1" interface="floppy_5_25">
 			<dataarea name="flop" size="143360">
@@ -371,6 +429,8 @@
 		<description>Hard Hat Mack (cleanly cracked)</description>
 		<year>1983</year>
 		<publisher>Electronic Arts</publisher>
+		<sharedfeat name="compatibility" value="NEEDDATA" />
+		<!-- No compatibility data known at this time. -->
 
 		<part name="flop1" interface="floppy_5_25">
 			<dataarea name="flop" size="143360">
@@ -384,6 +444,8 @@
 		<!-- High scores stored on disc, reset to AAA 5000, BBB 4000, CCC 3000, DDD 2000 & EEE 1000 -->
 		<year>1983</year>
 		<publisher>Microlab</publisher>
+		<sharedfeat name="compatibility" value="NEEDDATA" />
+		<!-- No compatibility data known at this time. -->
 
 		<part name="flop1" interface="floppy_5_25">
 			<dataarea name="flop" size="143360">
@@ -396,6 +458,8 @@
 		<description>Law of the West (cleanly cracked)</description>
 		<year>1985</year>
 		<publisher>Accolade</publisher>
+		<sharedfeat name="compatibility" value="NEEDDATA" />
+		<!-- No compatibility data known at this time. -->
 
 		<part name="flop1" interface="floppy_5_25">
 			<dataarea name="flop" size="143360">
@@ -408,6 +472,8 @@
 		<description>Master of the Lamps (cleanly cracked)</description>
 		<year>1985</year>
 		<publisher>Activision</publisher>
+		<sharedfeat name="compatibility" value="NEEDDATA" />
+		<!-- No compatibility data known at this time. -->
 
 		<part name="flop1" interface="floppy_5_25">
 			<dataarea name="flop" size="143360">
@@ -421,6 +487,8 @@
 		<!-- High scores stored on disc, reset to AAA 5000, AAA 4000, AAA 3000, AAA 2000 & AAA 1000 -->
 		<year>1982</year>
 		<publisher>Micro Fun</publisher>
+		<sharedfeat name="compatibility" value="NEEDDATA" />
+		<!-- No compatibility data known at this time. -->
 
 		<part name="flop1" interface="floppy_5_25">
 			<dataarea name="flop" size="143360">
@@ -433,6 +501,8 @@
 		<description>Mr. Do (cleanly cracked)</description>
 		<year>1983</year>
 		<publisher>Datasoft</publisher>
+		<sharedfeat name="compatibility" value="NEEDDATA" />
+		<!-- No compatibility data known at this time. -->
 
 		<part name="flop1" interface="floppy_5_25">
 			<dataarea name="flop" size="143360">
@@ -445,6 +515,8 @@
 		<description>Ms. Pac Man (cleanly cracked)</description>
 		<year>1983</year>
 		<publisher>Atari</publisher>
+		<sharedfeat name="compatibility" value="NEEDDATA" />
+		<!-- No compatibility data known at this time. -->
 
 		<part name="flop1" interface="floppy_5_25">
 			<dataarea name="flop" size="143360">
@@ -460,6 +532,8 @@
 		<description>Nightmare Gallery (cleanly cracked)</description>
 		<year>1982</year>
 		<publisher>Synergistic Software</publisher>
+		<sharedfeat name="compatibility" value="NEEDDATA" />
+		<!-- No compatibility data known at this time. -->
 
 		<part name="flop1" interface="floppy_5_25">
 			<dataarea name="flop" size="143360">
@@ -472,6 +546,8 @@
 		<description>Pac-Man - Atari (cleanly cracked)</description>
 		<year>1983</year>
 		<publisher>Atari</publisher>
+		<sharedfeat name="compatibility" value="NEEDDATA" />
+		<!-- No compatibility data known at this time. -->
 
 		<part name="flop1" interface="floppy_5_25">
 			<dataarea name="flop" size="143360">
@@ -484,6 +560,8 @@
 		<description>Pac-Man - Datasoft (cleanly cracked)</description>
 		<year>1983</year>
 		<publisher>Datasoft / Namco America</publisher>
+		<sharedfeat name="compatibility" value="NEEDDATA" />
+		<!-- No compatibility data known at this time. -->
 
 		<part name="flop1" interface="floppy_5_25">
 			<dataarea name="flop" size="143360">
@@ -496,6 +574,8 @@
 		<description>Pac-Man - Thunder Mountain (cleanly cracked)</description>
 		<year>1983</year>
 		<publisher>Thunder Mountain / Namco</publisher>
+		<sharedfeat name="compatibility" value="NEEDDATA" />
+		<!-- No compatibility data known at this time. -->
 
 		<part name="flop1" interface="floppy_5_25">
 			<dataarea name="flop" size="143360">
@@ -508,6 +588,8 @@
 		<description>Paperboy (cleanly cracked)</description>
 		<year>1986</year>
 		<publisher>Mindscape / Atari</publisher>
+		<sharedfeat name="compatibility" value="NEEDDATA" />
+		<!-- No compatibility data known at this time. -->
 
 		<part name="flop1" interface="floppy_5_25">
 			<dataarea name="flop" size="143360">
@@ -520,6 +602,8 @@
 		<description>Paper Models - The Christmas Kit (cleanly cracked)</description>
 		<year>1986</year>
 		<publisher>Activision</publisher>
+		<sharedfeat name="compatibility" value="NEEDDATA" />
+		<!-- No compatibility data known at this time. -->
 
 		<part name="flop1" interface="floppy_5_25">
 			<dataarea name="flop" size="143360">
@@ -532,6 +616,8 @@
 		<description>Pigpen (cleanly cracked)</description>
 		<year>1982</year>
 		<publisher>Datamost / TMQ Software</publisher>
+		<sharedfeat name="compatibility" value="NEEDDATA" />
+		<!-- No compatibility data known at this time. -->
 
 		<part name="flop1" interface="floppy_5_25">
 			<dataarea name="flop" size="143360">
@@ -544,6 +630,8 @@
 		<description>Pipe Dream (cleanly cracked)</description>
 		<year>1990</year>
 		<publisher>Lucasfilm</publisher>
+		<sharedfeat name="compatibility" value="NEEDDATA" />
+		<!-- No compatibility data known at this time. -->
 
 		<part name="flop1" interface="floppy_5_25">
 			<dataarea name="flop" size="143360">
@@ -556,6 +644,8 @@
 		<description>Portal (cleanly cracked)</description>
 		<year>1986</year>
 		<publisher>Activision</publisher>
+		<sharedfeat name="compatibility" value="NEEDDATA" />
+		<!-- No compatibility data known at this time. -->
 
 		<part name="flop1" interface="floppy_5_25">
 			<feature name="part_id" value="Disk 1"/>
@@ -587,6 +677,8 @@
 		<description>Qix (cleanly cracked)</description>
 		<year>1989</year>
 		<publisher>Taito</publisher>
+		<sharedfeat name="compatibility" value="NEEDDATA" />
+		<!-- No compatibility data known at this time. -->
 
 		<part name="flop1" interface="floppy_5_25">
 			<dataarea name="flop" size="143360">
@@ -599,6 +691,8 @@
 		<description>Racter (cleanly cracked)</description>
 		<year>1985</year>
 		<publisher>Mindscape</publisher>
+		<sharedfeat name="compatibility" value="NEEDDATA" />
+		<!-- No compatibility data known at this time. -->
 
 		<part name="flop1" interface="floppy_5_25">
 			<dataarea name="flop" size="143360">
@@ -611,6 +705,8 @@
 		<description>Rambo First Blood Part II (cleanly cracked)</description>
 		<year>1985</year>
 		<publisher>Mindscape / Angelsoft</publisher>
+		<sharedfeat name="compatibility" value="NEEDDATA" />
+		<!-- No compatibility data known at this time. -->
 
 		<part name="flop1" interface="floppy_5_25">
 			<dataarea name="flop" size="143360">
@@ -623,6 +719,8 @@
 		<description>Rampage (cleanly cracked)</description>
 		<year>1988</year>
 		<publisher>Activision</publisher>
+		<sharedfeat name="compatibility" value="NEEDDATA" />
+		<!-- No compatibility data known at this time. -->
 
 		<part name="flop1" interface="floppy_5_25">
 			<dataarea name="flop" size="143360">
@@ -636,6 +734,8 @@
 		<!-- ProDOS 8 based & hard drive compatable -->
 		<year>1988</year>
 		<publisher>Taito America / NovaLogic</publisher>
+		<sharedfeat name="compatibility" value="NEEDDATA" />
+		<!-- No compatibility data known at this time. -->
 
 		<part name="flop1" interface="floppy_5_25">
 			<feature name="part_id" value="Disk 1"/>
@@ -655,6 +755,8 @@
 		<description>Shanghai (cleanly cracked)</description>
 		<year>1986</year>
 		<publisher>Activision</publisher>
+		<sharedfeat name="compatibility" value="NEEDDATA" />
+		<!-- No compatibility data known at this time. -->
 
 		<part name="flop1" interface="floppy_5_25">
 			<dataarea name="flop" size="143360">
@@ -667,6 +769,8 @@
 		<description>Sneakers (cleanly cracked)</description>
 		<year>1981</year>
 		<publisher>Sirius Software</publisher>
+		<sharedfeat name="compatibility" value="NEEDDATA" />
+		<!-- No compatibility data known at this time. -->
 
 		<part name="flop1" interface="floppy_5_25">
 			<dataarea name="flop" size="143360">
@@ -679,6 +783,8 @@
 		<description>Spindizzy (cleanly cracked)</description>
 		<year>1986</year>
 		<publisher>Activision</publisher>
+		<sharedfeat name="compatibility" value="NEEDDATA" />
+		<!-- No compatibility data known at this time. -->
 
 		<part name="flop1" interface="floppy_5_25">
 			<dataarea name="flop" size="143360">
@@ -692,6 +798,8 @@
 		<!-- Corrected rerip 09/19/2016 -->
 		<year>1983</year>
 		<publisher>Bally/Midway</publisher>
+		<sharedfeat name="compatibility" value="NEEDDATA" />
+		<!-- No compatibility data known at this time. -->
 
 		<part name="flop1" interface="floppy_5_25">
 			<dataarea name="flop" size="143360">
@@ -707,6 +815,8 @@
 		<!-- Also includes a single file BRUNable conversion of the game -->
 		<year>1981</year>
 		<publisher>Datamost</publisher>
+		<sharedfeat name="compatibility" value="NEEDDATA" />
+		<!-- No compatibility data known at this time. -->
 
 		<part name="flop1" interface="floppy_5_25">
 			<dataarea name="flop" size="143360">
@@ -719,6 +829,8 @@
 		<description>Xevious (cleanly cracked)</description>
 		<year>1983</year>
 		<publisher>Mindscape</publisher>
+		<sharedfeat name="compatibility" value="NEEDDATA" />
+		<!-- No compatibility data known at this time. -->
 
 		<part name="flop1" interface="floppy_5_25">
 			<dataarea name="flop" size="143360">
@@ -731,6 +843,8 @@
 		<description>1-2-3 Sequence Me (cleanly cracked)</description>
 		<year>1991</year>
 		<publisher>Sunburst</publisher>
+		<sharedfeat name="compatibility" value="NEEDDATA" />
+		<!-- No compatibility data known at this time. -->
 
 		<part name="flop1" interface="floppy_5_25">
 			<dataarea name="flop" size="143360">
@@ -743,6 +857,8 @@
 		<description>Ace Detective (cleanly cracked)</description>
 		<year>1987</year>
 		<publisher>Mindplay</publisher>
+		<sharedfeat name="compatibility" value="NEEDDATA" />
+		<!-- No compatibility data known at this time. -->
 
 		<part name="flop1" interface="floppy_5_25">
 			<feature name="part_id" value="Side A"/>
@@ -758,10 +874,34 @@
 		</part>
 	</software>
 
+	<software name="acedetv2">
+		<description>Ace Detective revision 2 (cleanly cracked)</description>
+		<year>1987</year>
+		<publisher>Mindplay</publisher>
+		<info name="release" value="2015-07-24"/>
+		<sharedfeat name="compatibility" value="NEEDDATA" />
+		<!-- No compatibility data known at this time. -->
+
+		<part name="flop1" interface="floppy_5_25">
+			<feature name="part_id" value="Side A"/>
+			<dataarea name="flop" size="143360">
+				<rom name="ace detective revision 2 (4am crack) side a.dsk" size="143360" crc="8ca8d1f0" sha1="4ae31e83c0fdea4e27362c2cb16eb67c1a8757ec" offset="0x0000" />
+			</dataarea>
+		</part>
+		<part name="flop2" interface="floppy_5_25">
+			<feature name="part_id" value="Side B"/>
+			<dataarea name="flop" size="143360">
+				<rom name="ace detective revision 2 (4am crack) side b.dsk" size="143360" crc="e3a16f45" sha1="c5ffe33fac6919982ab1b24dbeed393ece532908" offset="0x0000" />
+			</dataarea>
+		</part>
+	</software>
+
 	<software name="addsub1">
 		<description>Mathematics Courseware Series: Addition and Subtraction 1 (cleanly cracked)</description>
 		<year>1985</year>
 		<publisher>Scott, Foresman and Company</publisher>
+		<sharedfeat name="compatibility" value="NEEDDATA" />
+		<!-- No compatibility data known at this time. -->
 
 		<part name="flop1" interface="floppy_5_25">
 			<dataarea name="flop" size="143360">
@@ -774,6 +914,8 @@
 		<description>Mathematics Courseware Series: Addition and Subtraction 2 (cleanly cracked)</description>
 		<year>1985</year>
 		<publisher>Scott, Foresman and Company</publisher>
+		<sharedfeat name="compatibility" value="NEEDDATA" />
+		<!-- No compatibility data known at this time. -->
 
 		<part name="flop1" interface="floppy_5_25">
 			<dataarea name="flop" size="143360">
@@ -786,6 +928,8 @@
 		<description>Alfred's Basic Piano Theory Software (cleanly cracked)</description>
 		<year>1986</year>
 		<publisher>Alfred Publishing Company</publisher>
+		<sharedfeat name="compatibility" value="NEEDDATA" />
+		<!-- No compatibility data known at this time. -->
 
 		<part name="flop1" interface="floppy_5_25">
 			<dataarea name="flop" size="143360">
@@ -798,6 +942,8 @@
 		<description>Agent USA (cleanly cracked)</description>
 		<year>1984</year>
 		<publisher>Scholastic</publisher>
+		<sharedfeat name="compatibility" value="NEEDDATA" />
+		<!-- No compatibility data known at this time. -->
 
 		<part name="flop1" interface="floppy_5_25">
 			<dataarea name="flop" size="143360">
@@ -810,6 +956,8 @@
 		<description>Alphabet Circus (cleanly cracked)</description>
 		<year>1984</year>
 		<publisher>NeoSoft</publisher>
+		<sharedfeat name="compatibility" value="NEEDDATA" />
+		<!-- No compatibility data known at this time. -->
 
 		<part name="flop1" interface="floppy_5_25">
 			<dataarea name="flop" size="143360">
@@ -822,6 +970,8 @@
 		<description>Alice in Wonderland (cleanly cracked)</description>
 		<year>1985</year>
 		<publisher>Windham Classics</publisher>
+		<sharedfeat name="compatibility" value="NEEDDATA" />
+		<!-- No compatibility data known at this time. -->
 
 		<part name="flop1" interface="floppy_5_25">
 			<feature name="part_id" value="Side A"/>
@@ -841,6 +991,8 @@
 		<description>Algebra 2 (cleanly cracked)</description>
 		<year>1982</year>
 		<publisher>Edu-Ware</publisher>
+		<sharedfeat name="compatibility" value="NEEDDATA" />
+		<!-- No compatibility data known at this time. -->
 
 		<part name="flop1" interface="floppy_5_25">
 			<dataarea name="flop" size="143360">
@@ -854,6 +1006,8 @@
 		<year>1989</year>
 		<publisher>Davidson &amp; Associates, Inc.</publisher>
 		<info name="usage" value="Works with Apple II Mouse Card in slot 4: -sl4 mouse" />
+		<sharedfeat name="compatibility" value="NEEDDATA" />
+		<!-- No compatibility data known at this time. -->
 
 		<part name="flop1" interface="floppy_5_25">
 			<feature name="part_id" value="Program Disk Side 1"/>
@@ -885,6 +1039,8 @@
 		<description>Algernon (cleanly cracked)</description>
 		<year>1987</year>
 		<publisher>Sunburst</publisher>
+		<sharedfeat name="compatibility" value="NEEDDATA" />
+		<!-- No compatibility data known at this time. -->
 
 		<part name="flop1" interface="floppy_5_25">
 			<dataarea name="flop" size="143360">
@@ -897,6 +1053,8 @@
 		<description>Algebra, Volume 1 (cleanly cracked)</description>
 		<year>1984</year>
 		<publisher>Peachtree Software</publisher>
+		<sharedfeat name="compatibility" value="NEEDDATA" />
+		<!-- No compatibility data known at this time. -->
 
 		<part name="flop1" interface="floppy_5_25">
 			<dataarea name="flop" size="143360">
@@ -909,6 +1067,8 @@
 		<description>Alien Addition (cleanly cracked)</description>
 		<year>1982</year>
 		<publisher>Developmental Learning Materials</publisher>
+		<sharedfeat name="compatibility" value="NEEDDATA" />
+		<!-- No compatibility data known at this time. -->
 
 		<part name="flop1" interface="floppy_5_25">
 			<dataarea name="flop" size="143360">
@@ -921,6 +1081,8 @@
 		<description>American History Adventure (cleanly cracked)</description>
 		<year>1984</year>
 		<publisher>Queue Inc.</publisher>
+		<sharedfeat name="compatibility" value="NEEDDATA" />
+		<!-- No compatibility data known at this time. -->
 
 		<part name="flop1" interface="floppy_5_25">
 			<feature name="part_id" value="Disk 1"/>
@@ -940,6 +1102,8 @@
 		<description>Animal Kingdom (cleanly cracked)</description>
 		<year>1985</year>
 		<publisher>Unicorn Software</publisher>
+		<sharedfeat name="compatibility" value="NEEDDATA" />
+		<!-- No compatibility data known at this time. -->
 
 		<part name="flop1" interface="floppy_5_25">
 			<feature name="part_id" value="Side A"/>
@@ -960,6 +1124,8 @@
 		<year>1988</year>
 		<publisher>Taito America</publisher>
 		<info name="usage" value="Works with Apple II Mouse Card in slot 4: -sl4 mouse" />
+		<sharedfeat name="compatibility" value="NEEDDATA" />
+		<!-- No compatibility data known at this time. -->
 
 		<part name="flop1" interface="floppy_5_25">
 			<dataarea name="flop" size="143360">
@@ -972,6 +1138,8 @@
 		<description>BallBlazer (cleanly cracked)</description>
 		<year>1985</year>
 		<publisher>Lucasfilm Games</publisher>
+		<sharedfeat name="compatibility" value="NEEDDATA" />
+		<!-- No compatibility data known at this time. -->
 
 		<part name="flop1" interface="floppy_5_25">
 			<dataarea name="flop" size="143360">
@@ -984,6 +1152,8 @@
 		<description>Band Saw and Shaper Safety (cleanly cracked)</description>
 		<year>1986</year>
 		<publisher>Abraxas Basic Courseware</publisher>
+		<sharedfeat name="compatibility" value="NEEDDATA" />
+		<!-- No compatibility data known at this time. -->
 
 		<part name="flop1" interface="floppy_5_25">
 			<dataarea name="flop" size="143360">
@@ -996,6 +1166,8 @@
 		<description>Basic Math Facts and Games (cleanly cracked)</description>
 		<year>1981</year>
 		<publisher>Random House</publisher>
+		<sharedfeat name="compatibility" value="NEEDDATA" />
+		<!-- No compatibility data known at this time. -->
 
 		<part name="flop1" interface="floppy_5_25">
 			<dataarea name="flop" size="143360">
@@ -1008,6 +1180,8 @@
 		<description>Basic Vocabulary Builder Demo (cleanly cracked)</description>
 		<year>1984</year>
 		<publisher>National Textbook Company</publisher>
+		<sharedfeat name="compatibility" value="NEEDDATA" />
+		<!-- No compatibility data known at this time. -->
 
 		<part name="flop1" interface="floppy_5_25">
 			<dataarea name="flop" size="143360">
@@ -1020,6 +1194,8 @@
 		<description>Beer Run (cleanly cracked)</description>
 		<year>1981</year>
 		<publisher>Sirius Software</publisher>
+		<sharedfeat name="compatibility" value="NEEDDATA" />
+		<!-- No compatibility data known at this time. -->
 
 		<part name="flop1" interface="floppy_5_25">
 			<dataarea name="flop" size="143360">
@@ -1032,6 +1208,8 @@
 		<description>Big Book Maker (cleanly cracked)</description>
 		<year>1992</year>
 		<publisher>Pelican Software</publisher>
+		<sharedfeat name="compatibility" value="NEEDDATA" />
+		<!-- No compatibility data known at this time. -->
 
 		<part name="flop1" interface="floppy_5_25">
 			<feature name="part_id" value="Disk 1 Side A"/>
@@ -1063,6 +1241,8 @@
 		<description>Bingo Bugglebee Presents: Home Alone (cleanly cracked)</description>
 		<year>1985</year>
 		<publisher>Quest Learning Systems</publisher>
+		<sharedfeat name="compatibility" value="NEEDDATA" />
+		<!-- No compatibility data known at this time. -->
 
 		<part name="flop1" interface="floppy_5_25">
 			<dataarea name="flop" size="143360">
@@ -1075,6 +1255,8 @@
 		<description>Bingo Bugglebee Presents: Outdoor Safety (cleanly cracked)</description>
 		<year>1985</year>
 		<publisher>Quest Learning Systems</publisher>
+		<sharedfeat name="compatibility" value="NEEDDATA" />
+		<!-- No compatibility data known at this time. -->
 
 		<part name="flop1" interface="floppy_5_25">
 			<dataarea name="flop" size="143360">
@@ -1087,6 +1269,8 @@
 		<description>Binomial Multiplication (cleanly cracked)</description>
 		<year>1984</year>
 		<publisher>Mindscape</publisher>
+		<sharedfeat name="compatibility" value="NEEDDATA" />
+		<!-- No compatibility data known at this time. -->
 
 		<part name="flop1" interface="floppy_5_25">
 			<dataarea name="flop" size="143360">
@@ -1100,6 +1284,9 @@
 		<year>1985</year>
 		<publisher>Baudville</publisher>
 		<info name="usage" value="Works with Apple II Mouse Card in slot 4: -sl4 mouse" />
+		<sharedfeat name="compatibility" value="NEEDDATA" />
+		<!-- No compatibility data known at this time. -->
+
 		<part name="flop1" interface="floppy_5_25">
 			<dataarea name="flop" size="143360">
 				<rom name="blazing paddles (4am crack).dsk" size="143360" crc="db4aa57d" sha1="152cc04080e100822bf919879232d175c64e9610" offset="0x0000" />
@@ -1111,6 +1298,8 @@
 		<description>Bumble Games (cleanly cracked)</description>
 		<year>1982</year>
 		<publisher>The Learning Company</publisher>
+		<sharedfeat name="compatibility" value="NEEDDATA" />
+		<!-- No compatibility data known at this time. -->
 
 		<part name="flop1" interface="floppy_5_25">
 			<dataarea name="flop" size="143360">
@@ -1123,6 +1312,8 @@
 		<description>Boppie's Great Word Chase (cleanly cracked)</description>
 		<year>1985</year>
 		<publisher>Developmental Learning Materials</publisher>
+		<sharedfeat name="compatibility" value="NEEDDATA" />
+		<!-- No compatibility data known at this time. -->
 
 		<part name="flop1" interface="floppy_5_25">
 			<dataarea name="flop" size="143360">
@@ -1135,6 +1326,8 @@
 		<description>Bounce (cleanly cracked)</description>
 		<year>1988</year>
 		<publisher>Sunburst</publisher>
+		<sharedfeat name="compatibility" value="NEEDDATA" />
+		<!-- No compatibility data known at this time. -->
 
 		<part name="flop1" interface="floppy_5_25">
 			<dataarea name="flop" size="143360">
@@ -1147,6 +1340,8 @@
 		<description>Bridge 4.0 (cleanly cracked)</description>
 		<year>1983</year>
 		<publisher>Artworx</publisher>
+		<sharedfeat name="compatibility" value="NEEDDATA" />
+		<!-- No compatibility data known at this time. -->
 
 		<part name="flop1" interface="floppy_5_25">
 			<dataarea name="flop" size="143360">
@@ -1159,6 +1354,8 @@
 		<description>BurgerTime (cleanly cracked)</description>
 		<year>1982</year>
 		<publisher>Mattel Electronics</publisher>
+		<sharedfeat name="compatibility" value="NEEDDATA" />
+		<!-- No compatibility data known at this time. -->
 
 		<part name="flop1" interface="floppy_5_25">
 			<dataarea name="flop" size="143360">
@@ -1171,6 +1368,8 @@
 		<description>Battlezone (cleanly cracked)</description>
 		<year>1983</year>
 		<publisher>Atarisoft</publisher>
+		<sharedfeat name="compatibility" value="NEEDDATA" />
+		<!-- No compatibility data known at this time. -->
 
 		<part name="flop1" interface="floppy_5_25">
 			<dataarea name="flop" size="143360">
@@ -1183,6 +1382,8 @@
 		<description>California Games (cleanly cracked)</description>
 		<year>1987</year>
 		<publisher>Epyx</publisher>
+		<sharedfeat name="compatibility" value="NEEDDATA" />
+		<!-- No compatibility data known at this time. -->
 
 		<part name="flop1" interface="floppy_5_25">
 			<feature name="part_id" value="Side A"/>
@@ -1202,6 +1403,8 @@
 		<description>Calendar Skills (version 08.31.86) (cleanly cracked)</description>
 		<year>1986</year>
 		<publisher>Hartley Courseware, Inc.</publisher>
+		<sharedfeat name="compatibility" value="NEEDDATA" />
+		<!-- No compatibility data known at this time. -->
 
 		<part name="flop1" interface="floppy_5_25">
 			<dataarea name="flop" size="143360">
@@ -1214,6 +1417,8 @@
 		<description>Case of the Great Train Robbery (cleanly cracked)</description>
 		<year>1986</year>
 		<publisher>Troll Associates</publisher>
+		<sharedfeat name="compatibility" value="NEEDDATA" />
+		<!-- No compatibility data known at this time. -->
 
 		<part name="flop1" interface="floppy_5_25">
 			<dataarea name="flop" size="143360">
@@ -1226,6 +1431,8 @@
 		<description>Case of the Missing Chick (cleanly cracked)</description>
 		<year>1986</year>
 		<publisher>Troll Associates</publisher>
+		<sharedfeat name="compatibility" value="NEEDDATA" />
+		<!-- No compatibility data known at this time. -->
 
 		<part name="flop1" interface="floppy_5_25">
 			<dataarea name="flop" size="143360">
@@ -1238,6 +1445,8 @@
 		<description>Cat 'n Mouse (cleanly cracked)</description>
 		<year>1986</year>
 		<publisher>Mindplay</publisher>
+		<sharedfeat name="compatibility" value="NEEDDATA" />
+		<!-- No compatibility data known at this time. -->
 
 		<part name="flop1" interface="floppy_5_25">
 			<dataarea name="flop" size="143360">
@@ -1250,6 +1459,8 @@
 		<description>Centipede (cleanly cracked)</description>
 		<year>1983</year>
 		<publisher>Atarisoft</publisher>
+		<sharedfeat name="compatibility" value="NEEDDATA" />
+		<!-- No compatibility data known at this time. -->
 
 		<part name="flop1" interface="floppy_5_25">
 			<dataarea name="flop" size="143360">
@@ -1259,9 +1470,11 @@
 	</software>
 
 	<software name="cgotrspc">
-		<description>Curious George In Outer Space (cleanly cracked)</description>
+		<description>Curious George in Outer Space (cleanly cracked)</description>
 		<year>1989</year>
 		<publisher>Developmental Learning Materials</publisher>
+		<sharedfeat name="compatibility" value="NEEDDATA" />
+		<!-- No compatibility data known at this time. -->
 
 		<part name="flop1" interface="floppy_5_25">
 			<feature name="part_id" value="Side A"/>
@@ -1281,6 +1494,8 @@
 		<description>Curious George Goes Shopping (cleanly cracked)</description>
 		<year>1989</year>
 		<publisher>Developmental Learning Materials</publisher>
+		<sharedfeat name="compatibility" value="NEEDDATA" />
+		<!-- No compatibility data known at this time. -->
 
 		<part name="flop1" interface="floppy_5_25">
 			<feature name="part_id" value="Side A"/>
@@ -1300,6 +1515,8 @@
 		<description>Challenge Math (cleanly cracked)</description>
 		<year>1982</year>
 		<publisher>Sunburst</publisher>
+		<sharedfeat name="compatibility" value="NEEDDATA" />
+		<!-- No compatibility data known at this time. -->
 
 		<part name="flop1" interface="floppy_5_25">
 			<dataarea name="flop" size="143360">
@@ -1312,6 +1529,8 @@
 		<description>Charlie Brown's 1-2-3s (cleanly cracked)</description>
 		<year>1985</year>
 		<publisher>Random House</publisher>
+		<sharedfeat name="compatibility" value="NEEDDATA" />
+		<!-- No compatibility data known at this time. -->
 
 		<part name="flop1" interface="floppy_5_25">
 			<feature name="part_id" value="Side A"/>
@@ -1331,6 +1550,8 @@
 		<description>Charlie Brown's ABCs (cleanly cracked)</description>
 		<year>1984</year>
 		<publisher>Random House</publisher>
+		<sharedfeat name="compatibility" value="NEEDDATA" />
+		<!-- No compatibility data known at this time. -->
 
 		<part name="flop1" interface="floppy_5_25">
 			<feature name="part_id" value="Side A"/>
@@ -1350,6 +1571,8 @@
 		<description>Championship Lode Runner (cleanly cracked)</description>
 		<year>1984</year>
 		<publisher>Broderbund</publisher>
+		<sharedfeat name="compatibility" value="NEEDDATA" />
+		<!-- No compatibility data known at this time. -->
 
 		<part name="flop1" interface="floppy_5_25">
 			<dataarea name="flop" size="143360">
@@ -1362,6 +1585,8 @@
 		<description>Championship Wrestling (cleanly cracked)</description>
 		<year>1986</year>
 		<publisher>Epyx</publisher>
+		<sharedfeat name="compatibility" value="NEEDDATA" />
+		<!-- No compatibility data known at this time. -->
 
 		<part name="flop1" interface="floppy_5_25">
 			<feature name="part_id" value="Side A"/>
@@ -1381,6 +1606,8 @@
 		<description>Computer Laboratory for Calculus (cleanly cracked)</description>
 		<year>1985</year>
 		<publisher>The Math Lab</publisher>
+		<sharedfeat name="compatibility" value="NEEDDATA" />
+		<!-- No compatibility data known at this time. -->
 
 		<part name="flop1" interface="floppy_5_25">
 			<dataarea name="flop" size="143360">
@@ -1390,9 +1617,11 @@
 	</software>
 
 	<software name="clasanbk">
-		<description>Classifying Animals With Backbones (cleanly cracked)</description>
+		<description>Classifying Animals with Backbones (cleanly cracked)</description>
 		<year>1985</year>
 		<publisher>D.C. Heath and Company</publisher>
+		<sharedfeat name="compatibility" value="NEEDDATA" />
+		<!-- No compatibility data known at this time. -->
 
 		<part name="flop1" interface="floppy_5_25">
 			<dataarea name="flop" size="143360">
@@ -1405,6 +1634,8 @@
 		<description>ClassMate (cleanly cracked)</description>
 		<year>1987</year>
 		<publisher>Davidson and Associates</publisher>
+		<sharedfeat name="compatibility" value="NEEDDATA" />
+		<!-- No compatibility data known at this time. -->
 
 		<part name="flop1" interface="floppy_5_25">
 			<dataarea name="flop" size="143360">
@@ -1417,6 +1648,8 @@
 		<description>Computer Literacy: Introduction (cleanly cracked)</description>
 		<year>1982</year>
 		<publisher>Control Data Corporation</publisher>
+		<sharedfeat name="compatibility" value="NEEDDATA" />
+		<!-- No compatibility data known at this time. -->
 
 		<part name="flop1" interface="floppy_5_25">
 			<dataarea name="flop" size="143360">
@@ -1429,6 +1662,8 @@
 		<description>Color Me (cleanly cracked)</description>
 		<year>1985</year>
 		<publisher>Mindscape</publisher>
+		<sharedfeat name="compatibility" value="NEEDDATA" />
+		<!-- No compatibility data known at this time. -->
 
 		<part name="flop1" interface="floppy_5_25">
 			<dataarea name="flop" size="143360">
@@ -1465,6 +1700,8 @@
 		<description>Commando (cleanly cracked)</description>
 		<year>1987</year>
 		<publisher>Data East</publisher>
+		<sharedfeat name="compatibility" value="NEEDDATA" />
+		<!-- No compatibility data known at this time. -->
 
 		<part name="flop1" interface="floppy_5_25">
 			<dataarea name="flop" size="143360">
@@ -1477,6 +1714,8 @@
 		<description>Compu-Read 3.4 (cleanly cracked)</description>
 		<year>1982</year>
 		<publisher>Edu-Ware Services Inc.</publisher>
+		<sharedfeat name="compatibility" value="NEEDDATA" />
+		<!-- No compatibility data known at this time. -->
 
 		<part name="flop1" interface="floppy_5_25">
 			<dataarea name="flop" size="143360">
@@ -1489,6 +1728,8 @@
 		<description>Conan (cleanly cracked)</description>
 		<year>1984</year>
 		<publisher>DataSoft</publisher>
+		<sharedfeat name="compatibility" value="NEEDDATA" />
+		<!-- No compatibility data known at this time. -->
 
 		<part name="flop1" interface="floppy_5_25">
 			<feature name="part_id" value="Side A"/>
@@ -1508,6 +1749,8 @@
 		<description>Cotton Tales (cleanly cracked)</description>
 		<year>1987</year>
 		<publisher>Mindplay</publisher>
+		<sharedfeat name="compatibility" value="NEEDDATA" />
+		<!-- No compatibility data known at this time. -->
 
 		<part name="flop1" interface="floppy_5_25">
 			<dataarea name="flop" size="143360">
@@ -1520,6 +1763,8 @@
 		<description>Creature Creator (cleanly cracked)</description>
 		<year>1983</year>
 		<publisher>DesignWare</publisher>
+		<sharedfeat name="compatibility" value="NEEDDATA" />
+		<!-- No compatibility data known at this time. -->
 
 		<part name="flop1" interface="floppy_5_25">
 			<dataarea name="flop" size="143360">
@@ -1532,6 +1777,8 @@
 		<description>Creation (cleanly cracked)</description>
 		<year>1988</year>
 		<publisher>Pelican Software</publisher>
+		<sharedfeat name="compatibility" value="NEEDDATA" />
+		<!-- No compatibility data known at this time. -->
 
 		<part name="flop1" interface="floppy_5_25">
 			<feature name="part_id" value="Side A"/>
@@ -1551,6 +1798,8 @@
 		<description>Crumb Eater (cleanly cracked)</description>
 		<year>1983</year>
 		<publisher>Davka Corporation</publisher>
+		<sharedfeat name="compatibility" value="NEEDDATA" />
+		<!-- No compatibility data known at this time. -->
 
 		<part name="flop1" interface="floppy_5_25">
 			<dataarea name="flop" size="143360">
@@ -1563,6 +1812,8 @@
 		<description>Crypto Cube (cleanly cracked)</description>
 		<year>1983</year>
 		<publisher>DesignWare</publisher>
+		<sharedfeat name="compatibility" value="NEEDDATA" />
+		<!-- No compatibility data known at this time. -->
 
 		<part name="flop1" interface="floppy_5_25">
 			<dataarea name="flop" size="143360">
@@ -1575,6 +1826,8 @@
 		<description>Cause and Effect: What Makes It Happen? (cleanly cracked)</description>
 		<year>1988</year>
 		<publisher>Troll Associates</publisher>
+		<sharedfeat name="compatibility" value="NEEDDATA" />
+		<!-- No compatibility data known at this time. -->
 
 		<part name="flop1" interface="floppy_5_25">
 			<dataarea name="flop" size="143360">
@@ -1587,6 +1840,8 @@
 		<description>Death Sword (cleanly cracked)</description>
 		<year>1988</year>
 		<publisher>Epyx</publisher>
+		<sharedfeat name="compatibility" value="NEEDDATA" />
+		<!-- No compatibility data known at this time. -->
 
 		<part name="flop1" interface="floppy_5_25">
 			<dataarea name="flop" size="143360">
@@ -1599,6 +1854,8 @@
 		<description>Decimal Discovery (cleanly cracked)</description>
 		<year>1986</year>
 		<publisher>Developmental Learning Materials</publisher>
+		<sharedfeat name="compatibility" value="NEEDDATA" />
+		<!-- No compatibility data known at this time. -->
 
 		<part name="flop1" interface="floppy_5_25">
 			<dataarea name="flop" size="143360">
@@ -1611,6 +1868,8 @@
 		<description>Decimals (ver 3.0) (cleanly cracked)</description>
 		<year>1982</year>
 		<publisher>Edu-Ware</publisher>
+		<sharedfeat name="compatibility" value="NEEDDATA" />
+		<!-- No compatibility data known at this time. -->
 
 		<part name="flop1" interface="floppy_5_25">
 			<dataarea name="flop" size="143360">
@@ -1623,6 +1882,8 @@
 		<description>Defender (cleanly cracked)</description>
 		<year>1983</year>
 		<publisher>Atarisoft</publisher>
+		<sharedfeat name="compatibility" value="NEEDDATA" />
+		<!-- No compatibility data known at this time. -->
 
 		<part name="flop1" interface="floppy_5_25">
 			<dataarea name="flop" size="143360">
@@ -1635,6 +1896,8 @@
 		<description>Delta Drawing (cleanly cracked)</description>
 		<year>1982</year>
 		<publisher>Spinnaker</publisher>
+		<sharedfeat name="compatibility" value="NEEDDATA" />
+		<!-- No compatibility data known at this time. -->
 
 		<part name="flop1" interface="floppy_5_25">
 			<dataarea name="flop" size="143360">
@@ -1647,6 +1910,8 @@
 		<description>Dig Dug (Atarisoft) (cleanly cracked)</description>
 		<year>1983</year>
 		<publisher>Atarisoft</publisher>
+		<sharedfeat name="compatibility" value="NEEDDATA" />
+		<!-- No compatibility data known at this time. -->
 
 		<part name="flop1" interface="floppy_5_25">
 			<dataarea name="flop" size="143360">
@@ -1659,6 +1924,8 @@
 		<description>Dig Dug (Thunder Mountain) (cleanly cracked)</description>
 		<year>1983</year>
 		<publisher>Thunder Mountain</publisher>
+		<sharedfeat name="compatibility" value="NEEDDATA" />
+		<!-- No compatibility data known at this time. -->
 
 		<part name="flop1" interface="floppy_5_25">
 			<dataarea name="flop" size="143360">
@@ -1671,6 +1938,8 @@
 		<description>Dino Dig (cleanly cracked)</description>
 		<year>1992</year>
 		<publisher>Troll Associates</publisher>
+		<sharedfeat name="compatibility" value="NEEDDATA" />
+		<!-- No compatibility data known at this time. -->
 
 		<part name="flop1" interface="floppy_5_25">
 			<dataarea name="flop" size="143360">
@@ -1683,6 +1952,8 @@
 		<description>Dino Eggs (cleanly cracked)</description>
 		<year>1983</year>
 		<publisher>Micro Fun</publisher>
+		<sharedfeat name="compatibility" value="NEEDDATA" />
+		<!-- No compatibility data known at this time. -->
 
 		<part name="flop1" interface="floppy_5_25">
 			<dataarea name="flop" size="143360">
@@ -1695,6 +1966,8 @@
 		<description>Dinosaurs (cleanly cracked)</description>
 		<year>1984</year>
 		<publisher>Advanced Ideas, Inc.</publisher>
+		<sharedfeat name="compatibility" value="NEEDDATA" />
+		<!-- No compatibility data known at this time. -->
 
 		<part name="flop1" interface="floppy_5_25">
 			<dataarea name="flop" size="143360">
@@ -1707,6 +1980,8 @@
 		<description>Dive Bomber (cleanly cracked)</description>
 		<year>1988</year>
 		<publisher>Acme Animation, Inc.</publisher>
+		<sharedfeat name="compatibility" value="NEEDDATA" />
+		<!-- No compatibility data known at this time. -->
 
 		<part name="flop1" interface="floppy_5_25">
 			<dataarea name="flop" size="143360">
@@ -1719,6 +1994,8 @@
 		<description>Donkey Kong (cleanly cracked)</description>
 		<year>1983</year>
 		<publisher>Atarisoft</publisher>
+		<sharedfeat name="compatibility" value="NEEDDATA" />
+		<!-- No compatibility data known at this time. -->
 
 		<part name="flop1" interface="floppy_5_25">
 			<dataarea name="flop" size="143360">
@@ -1731,6 +2008,8 @@
 		<description>Dunzhin (cleanly cracked)</description>
 		<year>1982</year>
 		<publisher>Screenplay</publisher>
+		<sharedfeat name="compatibility" value="NEEDDATA" />
+		<!-- No compatibility data known at this time. -->
 
 		<part name="flop1" interface="floppy_5_25">
 			<dataarea name="flop" size="143360">
@@ -1743,6 +2022,8 @@
 		<description>Dyno-Quest (cleanly cracked)</description>
 		<year>1984</year>
 		<publisher>Mindplay</publisher>
+		<sharedfeat name="compatibility" value="NEEDDATA" />
+		<!-- No compatibility data known at this time. -->
 
 		<part name="flop1" interface="floppy_5_25">
 			<dataarea name="flop" size="143360">
@@ -1755,6 +2036,8 @@
 		<description>Design Your Own Home: Architectural Design (cleanly cracked)</description>
 		<year>1984</year>
 		<publisher>Avant-Garde Publishing Corp.</publisher>
+		<sharedfeat name="compatibility" value="NEEDDATA" />
+		<!-- No compatibility data known at this time. -->
 
 		<part name="flop1" interface="floppy_5_25">
 			<feature name="part_id" value="Program disk (no mouse)"/>
@@ -1780,6 +2063,8 @@
 		<description>Design Your Own Home: Architectural (cleanly cracked)</description>
 		<year>1983</year>
 		<publisher>Avant-Garde Publishing Corp.</publisher>
+		<sharedfeat name="compatibility" value="NEEDDATA" />
+		<!-- No compatibility data known at this time. -->
 
 		<part name="flop1" interface="floppy_5_25">
 			<dataarea name="flop" size="143360">
@@ -1792,6 +2077,8 @@
 		<description>Design Your Own Home: Interior Design (cleanly cracked)</description>
 		<year>1986</year>
 		<publisher>Avant-Garde Publishing Corp.</publisher>
+		<sharedfeat name="compatibility" value="NEEDDATA" />
+		<!-- No compatibility data known at this time. -->
 
 		<part name="flop1" interface="floppy_5_25">
 			<feature name="part_id" value="Program disk (no mouse)"/>
@@ -1817,6 +2104,8 @@
 		<description>Easy as ABC (cleanly cracked)</description>
 		<year>1984</year>
 		<publisher>Springboard Software</publisher>
+		<sharedfeat name="compatibility" value="NEEDDATA" />
+		<!-- No compatibility data known at this time. -->
 
 		<part name="flop1" interface="floppy_5_25">
 			<dataarea name="flop" size="143360">
@@ -1829,6 +2118,8 @@
 		<description>Easy Reader Demo (cleanly cracked)</description>
 		<year>1983</year>
 		<publisher>American Educational Computer, Inc.</publisher>
+		<sharedfeat name="compatibility" value="NEEDDATA" />
+		<!-- No compatibility data known at this time. -->
 
 		<part name="flop1" interface="floppy_5_25">
 			<feature name="part_id" value="Disk 1"/>
@@ -1860,6 +2151,8 @@
 		<description>Easy Street (cleanly cracked)</description>
 		<year>1988</year>
 		<publisher>Mindplay</publisher>
+		<sharedfeat name="compatibility" value="NEEDDATA" />
+		<!-- No compatibility data known at this time. -->
 
 		<part name="flop1" interface="floppy_5_25">
 			<dataarea name="flop" size="143360">
@@ -1873,6 +2166,8 @@
 		<year>1986</year>
 		<publisher>Polarware</publisher>
 		<info name="usage" value="Works with Apple II Mouse Card in slot 4: -sl4 mouse" />
+		<sharedfeat name="compatibility" value="NEEDDATA" />
+		<!-- No compatibility data known at this time. -->
 
 		<part name="flop1" interface="floppy_5_25">
 			<dataarea name="flop" size="143360">
@@ -1885,6 +2180,8 @@
 		<description>Edu-Calc (cleanly cracked)</description>
 		<year>1985</year>
 		<publisher>Grolier</publisher>
+		<sharedfeat name="compatibility" value="NEEDDATA" />
+		<!-- No compatibility data known at this time. -->
 
 		<part name="flop1" interface="floppy_5_25">
 			<feature name="part_id" value="Side A"/>
@@ -1901,9 +2198,11 @@
 	</software>
 
 	<software name="egyc">
-		<description>Early Games For Young Children (cleanly cracked)</description>
+		<description>Early Games for Young Children (cleanly cracked)</description>
 		<year>1982</year>
 		<publisher>Springboard</publisher>
+		<sharedfeat name="compatibility" value="NEEDDATA" />
+		<!-- No compatibility data known at this time. -->
 
 		<part name="flop1" interface="floppy_5_25">
 			<dataarea name="flop" size="143360">
@@ -1913,9 +2212,11 @@
 	</software>
 
 	<software name="euronat">
-		<description>European Nations And Locations (cleanly cracked)</description>
+		<description>European Nations and Locations (cleanly cracked)</description>
 		<year>1985</year>
 		<publisher>DesignWare, Inc.</publisher>
+		<sharedfeat name="compatibility" value="NEEDDATA" />
+		<!-- No compatibility data known at this time. -->
 
 		<part name="flop1" interface="floppy_5_25">
 			<dataarea name="flop" size="143360">
@@ -1928,6 +2229,8 @@
 		<description>Exploring Science: Temperature (cleanly cracked)</description>
 		<year>1988</year>
 		<publisher>Sunburst</publisher>
+		<sharedfeat name="compatibility" value="NEEDDATA" />
+		<!-- No compatibility data known at this time. -->
 
 		<part name="flop1" interface="floppy_5_25">
 			<dataarea name="flop" size="143360">
@@ -1940,6 +2243,8 @@
 		<description>First Degree Linear Equations (cleanly cracked)</description>
 		<year>1984</year>
 		<publisher>Mindscape</publisher>
+		<sharedfeat name="compatibility" value="NEEDDATA" />
+		<!-- No compatibility data known at this time. -->
 
 		<part name="flop1" interface="floppy_5_25">
 			<dataarea name="flop" size="143360">
@@ -1952,6 +2257,8 @@
 		<description>Facemaker (cleanly cracked)</description>
 		<year>1982</year>
 		<publisher>Spinnaker</publisher>
+		<sharedfeat name="compatibility" value="NEEDDATA" />
+		<!-- No compatibility data known at this time. -->
 
 		<part name="flop1" interface="floppy_5_25">
 			<dataarea name="flop" size="143360">
@@ -1964,6 +2271,8 @@
 		<description>Falcons (cleanly cracked)</description>
 		<year>1981</year>
 		<publisher>Piccadilly Software</publisher>
+		<sharedfeat name="compatibility" value="NEEDDATA" />
+		<!-- No compatibility data known at this time. -->
 
 		<part name="flop1" interface="floppy_5_25">
 			<dataarea name="flop" size="143360">
@@ -1976,6 +2285,8 @@
 		<description>Professor Davensteev's Fantasy Land (Red Level) (cleanly cracked)</description>
 		<year>1983</year>
 		<publisher>Learning Well / Methods &amp; Solutions</publisher>
+		<sharedfeat name="compatibility" value="NEEDDATA" />
+		<!-- No compatibility data known at this time. -->
 
 		<part name="flop1" interface="floppy_5_25">
 			<dataarea name="flop" size="143360">
@@ -1988,6 +2299,8 @@
 		<description>Factoring Algebraic Expressions (cleanly cracked)</description>
 		<year>1984</year>
 		<publisher>Mindscape</publisher>
+		<sharedfeat name="compatibility" value="NEEDDATA" />
+		<!-- No compatibility data known at this time. -->
 
 		<part name="flop1" interface="floppy_5_25">
 			<dataarea name="flop" size="143360">
@@ -2000,6 +2313,8 @@
 		<description>Financial Facts (cleanly cracked)</description>
 		<year>1981</year>
 		<publisher>Advanced Operating Systems</publisher>
+		<sharedfeat name="compatibility" value="NEEDDATA" />
+		<!-- No compatibility data known at this time. -->
 
 		<part name="flop1" interface="floppy_5_25">
 			<dataarea name="flop" size="143360">
@@ -2012,6 +2327,8 @@
 		<description>Flash Spell Helicopter (cleanly cracked)</description>
 		<year>1983</year>
 		<publisher>Microcomputer Workships Courseware</publisher>
+		<sharedfeat name="compatibility" value="NEEDDATA" />
+		<!-- No compatibility data known at this time. -->
 
 		<part name="flop1" interface="floppy_5_25">
 			<dataarea name="flop" size="143360">
@@ -2024,6 +2341,8 @@
 		<description>Flying Colors (cleanly cracked)</description>
 		<year>1983</year>
 		<publisher>The Computer Colorworks</publisher>
+		<sharedfeat name="compatibility" value="NEEDDATA" />
+		<!-- No compatibility data known at this time. -->
 
 		<part name="flop1" interface="floppy_5_25">
 			<dataarea name="flop" size="143360">
@@ -2033,9 +2352,11 @@
 	</software>
 
 	<software name="forcemtn">
-		<description>Force And Motion (cleanly cracked)</description>
+		<description>Force and Motion (cleanly cracked)</description>
 		<year>1990</year>
 		<publisher>Queue, Inc.</publisher>
+		<sharedfeat name="compatibility" value="NEEDDATA" />
+		<!-- No compatibility data known at this time. -->
 
 		<part name="flop1" interface="floppy_5_25">
 			<feature name="part_id" value="Disk 1"/>
@@ -2055,6 +2376,8 @@
 		<description>FOR Your NEXT Adventure: FOR-NEXT Loops (cleanly cracked)</description>
 		<year>1985</year>
 		<publisher>Sunburst</publisher>
+		<sharedfeat name="compatibility" value="NEEDDATA" />
+		<!-- No compatibility data known at this time. -->
 
 		<part name="flop1" interface="floppy_5_25">
 			<dataarea name="flop" size="143360">
@@ -2067,6 +2390,8 @@
 		<description>Fraction-oids (cleanly cracked)</description>
 		<year>1989</year>
 		<publisher>Mindplay</publisher>
+		<sharedfeat name="compatibility" value="NEEDDATA" />
+		<!-- No compatibility data known at this time. -->
 
 		<part name="flop1" interface="floppy_5_25">
 			<dataarea name="flop" size="143360">
@@ -2079,6 +2404,8 @@
 		<description>Fractions II (cleanly cracked)</description>
 		<year>1987</year>
 		<publisher>Silver Burdett Company</publisher>
+		<sharedfeat name="compatibility" value="NEEDDATA" />
+		<!-- No compatibility data known at this time. -->
 
 		<part name="flop1" interface="floppy_5_25">
 			<dataarea name="flop" size="143360">
@@ -2091,6 +2418,8 @@
 		<description>Fraction Tutorial (cleanly cracked)</description>
 		<year>19??</year>
 		<publisher>Opportunities For Learning</publisher>
+		<sharedfeat name="compatibility" value="NEEDDATA" />
+		<!-- No compatibility data known at this time. -->
 
 		<part name="flop1" interface="floppy_5_25">
 			<feature name="part_id" value="Side A"/>
@@ -2110,6 +2439,8 @@
 		<description>Freddy's Puzzling Adventures (cleanly cracked)</description>
 		<year>1984</year>
 		<publisher>Developmental Learning Materials</publisher>
+		<sharedfeat name="compatibility" value="NEEDDATA" />
+		<!-- No compatibility data known at this time. -->
 
 		<part name="flop1" interface="floppy_5_25">
 			<dataarea name="flop" size="143360">
@@ -2122,6 +2453,8 @@
 		<description>French Vocabulary Builder (cleanly cracked)</description>
 		<year>1982</year>
 		<publisher>Control Data Corporation</publisher>
+		<sharedfeat name="compatibility" value="NEEDDATA" />
+		<!-- No compatibility data known at this time. -->
 
 		<part name="flop1" interface="floppy_5_25">
 			<dataarea name="flop" size="143360">
@@ -2134,6 +2467,8 @@
 		<description>Frogs, Dogs, Kittens, and Kids 1 (cleanly cracked)</description>
 		<year>1988</year>
 		<publisher>Hartley Courseware</publisher>
+		<sharedfeat name="compatibility" value="NEEDDATA" />
+		<!-- No compatibility data known at this time. -->
 
 		<part name="flop1" interface="floppy_5_25">
 			<feature name="part_id" value="Disk 1"/>
@@ -2159,6 +2494,8 @@
 		<description>Frogger II: Threedeep (cleanly cracked)</description>
 		<year>1984</year>
 		<publisher>Sega Enterprises Inc.</publisher>
+		<sharedfeat name="compatibility" value="NEEDDATA" />
+		<!-- No compatibility data known at this time. -->
 
 		<part name="flop1" interface="floppy_5_25">
 			<dataarea name="flop" size="143360">
@@ -2171,6 +2508,8 @@
 		<description>Frogger (cleanly cracked)</description>
 		<year>1981</year>
 		<publisher>Sierra On-Line</publisher>
+		<sharedfeat name="compatibility" value="NEEDDATA" />
+		<!-- No compatibility data known at this time. -->
 
 		<part name="flop1" interface="floppy_5_25">
 			<dataarea name="flop" size="143360">
@@ -2183,6 +2522,8 @@
 		<description>Frog Jump Ordering Numbers (cleanly cracked)</description>
 		<year>1985</year>
 		<publisher>Scott, Foresman and Company</publisher>
+		<sharedfeat name="compatibility" value="NEEDDATA" />
+		<!-- No compatibility data known at this time. -->
 
 		<part name="flop1" interface="floppy_5_25">
 			<dataarea name="flop" size="143360">
@@ -2195,6 +2536,8 @@
 		<description>Galaxian (Atarisoft) (cleanly cracked)</description>
 		<year>1983</year>
 		<publisher>Atarisoft</publisher>
+		<sharedfeat name="compatibility" value="NEEDDATA" />
+		<!-- No compatibility data known at this time. -->
 
 		<part name="flop1" interface="floppy_5_25">
 			<dataarea name="flop" size="143360">
@@ -2207,6 +2550,8 @@
 		<description>Galaxian (Thunder Mountain) (cleanly cracked)</description>
 		<year>1983</year>
 		<publisher>Thunder Mountain</publisher>
+		<sharedfeat name="compatibility" value="NEEDDATA" />
+		<!-- No compatibility data known at this time. -->
 
 		<part name="flop1" interface="floppy_5_25">
 			<dataarea name="flop" size="143360">
@@ -2219,6 +2564,8 @@
 		<description>Garfield Eat Your Words (cleanly cracked)</description>
 		<year>1985</year>
 		<publisher>Random House</publisher>
+		<sharedfeat name="compatibility" value="NEEDDATA" />
+		<!-- No compatibility data known at this time. -->
 
 		<part name="flop1" interface="floppy_5_25">
 			<feature name="part_id" value="Side A"/>
@@ -2238,6 +2585,8 @@
 		<description>Gene Machine (version 2.0) (cleanly cracked)</description>
 		<year>1983</year>
 		<publisher>HRM Software</publisher>
+		<sharedfeat name="compatibility" value="NEEDDATA" />
+		<!-- No compatibility data known at this time. -->
 
 		<part name="flop1" interface="floppy_5_25">
 			<dataarea name="flop" size="143360">
@@ -2250,6 +2599,8 @@
 		<description>Gertrude's Secrets (version 1.2) (cleanly cracked)</description>
 		<year>1982</year>
 		<publisher>The Learning Company</publisher>
+		<sharedfeat name="compatibility" value="NEEDDATA" />
+		<!-- No compatibility data known at this time. -->
 
 		<part name="flop1" interface="floppy_5_25">
 			<dataarea name="flop" size="143360">
@@ -2262,6 +2613,8 @@
 		<description>Grammar Gremlins (cleanly cracked)</description>
 		<year>1986</year>
 		<publisher>Davidson &amp; Associates, Inc.</publisher>
+		<sharedfeat name="compatibility" value="NEEDDATA" />
+		<!-- No compatibility data known at this time. -->
 
 		<part name="flop1" interface="floppy_5_25">
 			<feature name="part_id" value="Side A"/>
@@ -2281,6 +2634,8 @@
 		<description>Grammar Mastery II (cleanly cracked)</description>
 		<year>1987</year>
 		<publisher>American Language Academy</publisher>
+		<sharedfeat name="compatibility" value="NEEDDATA" />
+		<!-- No compatibility data known at this time. -->
 
 		<part name="flop1" interface="floppy_5_25">
 			<feature name="part_id" value="Disk A-1"/>
@@ -2390,6 +2745,8 @@
 		<description>Greeting Card Maker (cleanly cracked)</description>
 		<year>1986</year>
 		<publisher>Activision</publisher>
+		<sharedfeat name="compatibility" value="NEEDDATA" />
+		<!-- No compatibility data known at this time. -->
 
 		<part name="flop1" interface="floppy_5_25">
 			<dataarea name="flop" size="143360">
@@ -2402,6 +2759,8 @@
 		<description>Gremlins (cleanly cracked)</description>
 		<year>1984</year>
 		<publisher>Atarisoft</publisher>
+		<sharedfeat name="compatibility" value="NEEDDATA" />
+		<!-- No compatibility data known at this time. -->
 
 		<part name="flop1" interface="floppy_5_25">
 			<dataarea name="flop" size="143360">
@@ -2414,6 +2773,8 @@
 		<description>Graphing Linear Functions (cleanly cracked)</description>
 		<year>1984</year>
 		<publisher>Microcomputer Workshops Courseware</publisher>
+		<sharedfeat name="compatibility" value="NEEDDATA" />
+		<!-- No compatibility data known at this time. -->
 
 		<part name="flop1" interface="floppy_5_25">
 			<dataarea name="flop" size="143360">
@@ -2426,6 +2787,8 @@
 		<description>Gulf Strike (cleanly cracked)</description>
 		<year>1985</year>
 		<publisher>The Avalon Hill Game Company</publisher>
+		<sharedfeat name="compatibility" value="NEEDDATA" />
+		<!-- No compatibility data known at this time. -->
 
 		<part name="flop1" interface="floppy_5_25">
 			<dataarea name="flop" size="143360">
@@ -2439,6 +2802,8 @@
 		<!-- Corrected image 09/24/2016 -->
 		<year>1983</year>
 		<publisher>Broderbund</publisher>
+		<sharedfeat name="compatibility" value="NEEDDATA" />
+		<!-- No compatibility data known at this time. -->
 
 		<part name="flop1" interface="floppy_5_25">
 			<dataarea name="flop" size="143360">
@@ -2451,6 +2816,8 @@
 		<description>Heredity Dog (cleanly cracked)</description>
 		<year>1983</year>
 		<publisher>HRM Software</publisher>
+		<sharedfeat name="compatibility" value="NEEDDATA" />
+		<!-- No compatibility data known at this time. -->
 
 		<part name="flop1" interface="floppy_5_25">
 			<dataarea name="flop" size="143360">
@@ -2463,6 +2830,8 @@
 		<description>Hey Diddle Diddle (cleanly cracked)</description>
 		<year>1983</year>
 		<publisher>Spinnaker</publisher>
+		<sharedfeat name="compatibility" value="NEEDDATA" />
+		<!-- No compatibility data known at this time. -->
 
 		<part name="flop1" interface="floppy_5_25">
 			<dataarea name="flop" size="143360">
@@ -2475,6 +2844,8 @@
 		<description>Homework Helper: Writing (cleanly cracked)</description>
 		<year>1985</year>
 		<publisher>Spinnaker</publisher>
+		<sharedfeat name="compatibility" value="NEEDDATA" />
+		<!-- No compatibility data known at this time. -->
 
 		<part name="flop1" interface="floppy_5_25">
 			<feature name="part_id" value="Side A"/>
@@ -2518,6 +2889,8 @@
 		<description>Homework Writer (cleanly cracked)</description>
 		<year>1988</year>
 		<publisher>Scholastic, Inc.</publisher>
+		<sharedfeat name="compatibility" value="NEEDDATA" />
+		<!-- No compatibility data known at this time. -->
 
 		<part name="flop1" interface="floppy_5_25">
 			<feature name="part_id" value="Side A"/>
@@ -2537,6 +2910,8 @@
 		<description>House-A-Fire! (cleanly cracked)</description>
 		<year>1988</year>
 		<publisher>Decision Development Co</publisher>
+		<sharedfeat name="compatibility" value="NEEDDATA" />
+		<!-- No compatibility data known at this time. -->
 
 		<part name="flop1" interface="floppy_5_25">
 			<feature name="part_id" value="Side A"/>
@@ -2556,6 +2931,8 @@
 		<description>How The West Was One + Three x Four (cleanly cracked)</description>
 		<year>1987</year>
 		<publisher>Sunburst</publisher>
+		<sharedfeat name="compatibility" value="NEEDDATA" />
+		<!-- No compatibility data known at this time. -->
 
 		<part name="flop1" interface="floppy_5_25">
 			<dataarea name="flop" size="143360">
@@ -2568,6 +2945,8 @@
 		<description>Impossible Mission II (cleanly cracked)</description>
 		<year>1988</year>
 		<publisher>Epyx</publisher>
+		<sharedfeat name="compatibility" value="NEEDDATA" />
+		<!-- No compatibility data known at this time. -->
 
 		<part name="flop1" interface="floppy_5_25">
 			<feature name="part_id" value="Side A"/>
@@ -2584,9 +2963,11 @@
 	</software>
 
 	<software name="invscmth">
-		<description>Investigating Secondary Mathematics With Computers (cleanly cracked)</description>
+		<description>Investigating Secondary Mathematics with Computers (cleanly cracked)</description>
 		<year>1985</year>
 		<publisher>University of Massachusetts</publisher>
+		<sharedfeat name="compatibility" value="NEEDDATA" />
+		<!-- No compatibility data known at this time. -->
 
 		<part name="flop1" interface="floppy_5_25">
 			<feature name="part_id" value="Side A"/>
@@ -2603,9 +2984,11 @@
 	</software>
 
 	<software name="jackbnst">
-		<description>Jack And The Beanstalk (cleanly cracked)</description>
+		<description>Jack and the Beanstalk (cleanly cracked)</description>
 		<year>1985</year>
 		<publisher>HRM Software</publisher>
+		<sharedfeat name="compatibility" value="NEEDDATA" />
+		<!-- No compatibility data known at this time. -->
 
 		<part name="flop1" interface="floppy_5_25">
 			<dataarea name="flop" size="143360">
@@ -2618,6 +3001,8 @@
 		<description>Jumping Math Flash (cleanly cracked)</description>
 		<year>1988</year>
 		<publisher>Mindscape</publisher>
+		<sharedfeat name="compatibility" value="NEEDDATA" />
+		<!-- No compatibility data known at this time. -->
 
 		<part name="flop1" interface="floppy_5_25">
 			<dataarea name="flop" size="143360">
@@ -2630,6 +3015,8 @@
 		<description>Jumpman (cleanly cracked)</description>
 		<year>1983</year>
 		<publisher>Epyx</publisher>
+		<sharedfeat name="compatibility" value="NEEDDATA" />
+		<!-- No compatibility data known at this time. -->
 
 		<part name="flop1" interface="floppy_5_25">
 			<feature name="part_id" value="Side A"/>
@@ -2649,6 +3036,8 @@
 		<description>Jungle Hunt (cleanly cracked)</description>
 		<year>1984</year>
 		<publisher>Atarisoft</publisher>
+		<sharedfeat name="compatibility" value="NEEDDATA" />
+		<!-- No compatibility data known at this time. -->
 
 		<part name="flop1" interface="floppy_5_25">
 			<dataarea name="flop" size="143360">
@@ -2661,6 +3050,8 @@
 		<description>Ken Uston's Professional Blackjack (v1.23) (cleanly cracked)</description>
 		<year>1983</year>
 		<publisher>Intelligent Statements, Inc.</publisher>
+		<sharedfeat name="compatibility" value="NEEDDATA" />
+		<!-- No compatibility data known at this time. -->
 
 		<part name="flop1" interface="floppy_5_25">
 			<dataarea name="flop" size="143360">
@@ -2670,9 +3061,11 @@
 	</software>
 
 	<software name="kidskeys">
-		<description>Kids On Keys (cleanly cracked)</description>
+		<description>Kids on Keys (cleanly cracked)</description>
 		<year>1983</year>
 		<publisher>Spinnaker</publisher>
+		<sharedfeat name="compatibility" value="NEEDDATA" />
+		<!-- No compatibility data known at this time. -->
 
 		<part name="flop1" interface="floppy_5_25">
 			<dataarea name="flop" size="143360">
@@ -2685,6 +3078,8 @@
 		<description>Kindercomp (cleanly cracked)</description>
 		<year>1983</year>
 		<publisher>Spinnaker</publisher>
+		<sharedfeat name="compatibility" value="NEEDDATA" />
+		<!-- No compatibility data known at this time. -->
 
 		<part name="flop1" interface="floppy_5_25">
 			<dataarea name="flop" size="143360">
@@ -2694,9 +3089,11 @@
 	</software>
 
 	<software name="kittenkf">
-		<description>Kittens, Kids, And A Frog (version 01.11.85) (cleanly cracked)</description>
+		<description>Kittens, Kids, and a Frog (version 01.11.85) (cleanly cracked)</description>
 		<year>1985</year>
 		<publisher>Hartley Courseware, Inc.</publisher>
+		<sharedfeat name="compatibility" value="NEEDDATA" />
+		<!-- No compatibility data known at this time. -->
 
 		<part name="flop1" interface="floppy_5_25">
 			<feature name="part_id" value="Disk 1"/>
@@ -2716,6 +3113,8 @@
 		<description>Knowledge Master World History 1 (cleanly cracked)</description>
 		<year>1987</year>
 		<publisher>Academic Hallmarks</publisher>
+		<sharedfeat name="compatibility" value="NEEDDATA" />
+		<!-- No compatibility data known at this time. -->
 
 		<part name="flop1" interface="floppy_5_25">
 			<dataarea name="flop" size="143360">
@@ -2728,6 +3127,8 @@
 		<description>Krell's Logo (cleanly cracked)</description>
 		<year>1981</year>
 		<publisher>Krell</publisher>
+		<sharedfeat name="compatibility" value="NEEDDATA" />
+		<!-- No compatibility data known at this time. -->
 
 		<part name="flop1" interface="floppy_5_25">
 			<dataarea name="flop" size="143360">
@@ -2736,14 +3137,51 @@
 		</part>
 	</software>
 
+	<software name="thaddsub">
+		<description>A Treasure Hunt of Facts (clealy cracked) - addition and subtraction</description>
+		<year>1984</year>
+		<publisher>Josten Learning Systems</publisher>
+		<sharedfeat name="compatibility" value="NEEDDATA" />
+		<!-- No compatibility data known at this time. -->
+
+		<part name="flop1" interface="floppy_5_25">
+			<feature name="part_id" value="Disk 1"/>
+				<dataarea name="flop" size="143360">
+			<rom name="a treasure hunt of facts (4am crack) disk 1 - addition and subtraction.dsk" size="143360" crc="1549243e" sha1="60a8e419d93f1e7fb36ac3d6479a9c565d5fba18" offset="0x0000" />
+			</dataarea>
+		</part>
+		<part name="flop2" interface="floppy_5_25">
+			<feature name="part_id" value="Disk 2"/>
+				<dataarea name="flop" size="143360">
+			<rom name="a treasure hunt of facts (4am crack) disk 2 - multiplication and division.dsk" size="143360" crc="74a85cc3" sha1="45ad62fff8e7c4110ab0ec0dbacf147b734ee848" offset="0x0000" />
+			</dataarea>
+		</part>
+	</software>
+
 	<software name="viewkill">
-		<description>James Bond 007 In: A View To A Kill (cleanly cracked)</description>
+		<description>James Bond 007 in: A View to a Kill (cleanly cracked)</description>
 		<year>1985</year>
 		<publisher>Mindscape</publisher>
+		<info name="release" value="2016-03-06"/>
 
 		<part name="flop1" interface="floppy_5_25">
 			<dataarea name="flop" size="143360">
 				<rom name="james bond 007 in a view to a kill (4am crack).dsk" size="143360" crc="578c98cb" sha1="60fbf677d59b7a61d1f9d14deed1d0a50ccf9a92" offset="0x0000" />
+			</dataarea>
+		</part>
+	</software>
+
+	<software name="wrnktime">
+		<description>A Newbery Adventure - A Wrinkle in Time (cleanly cracked)</description>
+		<year>1986</year>
+		<publisher>Sunburst Communications</publisher>
+		<info name="release" value="2016-03-06"/>
+		<sharedfeat name="compatibility" value="NEEDDATA" />
+		<!-- No compatibility data known at this time. -->
+
+		<part name="flop1" interface="floppy_5_25">
+			<dataarea name="flop" size="143360">
+				<rom name="a newbery adventure - a wrinkle in time (4am crack).dsk" size="143360" crc="76275127" sha1="8134d7e6c74917c1ab16abe33005b55eb0d53e25" offset="0x0000" />
 			</dataarea>
 		</part>
 	</software>

--- a/hash/apple2_flop_clcracked.xml
+++ b/hash/apple2_flop_clcracked.xml
@@ -1,8 +1,74 @@
 <?xml version="1.0"?>
 <!DOCTYPE softwarelist SYSTEM "softwarelist.dtd">
-<!-- As of 02/07/2019, this still needs to be re-sorted. -->
 
 <softwarelist name="apple2_flop_clcracked" description="Apple II cleanly cracked 5.25 disks">
+
+	<software name="101mword">
+		<description>101 Misused Words (cleanly cracked)</description>
+		<year>1983</year>
+		<publisher>Learning Seed Company</publisher>
+		<info name="release" value="2016-04-12"/>
+		<sharedfeat name="compatibility" value="NEEDDATA" />
+		<!-- No compatibility data known at this time. -->
+
+		<part name="flop1" interface="floppy_5_25">
+			<dataarea name="flop" size="143360">
+				<rom name="101 misused words (4am crack).dsk" size="143360" crc="49662c0d" sha1="b71a873630ef10333695890ab66a7bd80a9ef06e" offset="0x0000" />
+			</dataarea>
+		</part>
+	</software>
+
+	<software name="123dmult">
+		<description>1-2-3 Digit Multiplication (cleanly cracked)</description>
+		<year>1986</year>
+		<publisher>Microcomputer Workshops</publisher>
+		<info name="release" value="2017-04-30"/>
+		<sharedfeat name="compatibility" value="NEEDDATA" />
+		<!-- No compatibility data known at this time. -->
+
+		<part name="flop1" interface="floppy_5_25">
+			<dataarea name="flop" size="143360">
+				<rom name="1-2-3 digit multiplication (4am crack).dsk" size="143360" crc="78461261" sha1="c8b8e76295be278b0faa2a10c255b3c3f7b7468c" offset="0x0000" />
+			</dataarea>
+		</part>
+	</software>
+
+	<software name="2400ad">
+		<description>2400 A.D. (4am crack) side A</description>
+		<year>1987</year>
+		<publisher>Origin Systems</publisher>
+		<info name="release" value="2018-09-23"/>
+		<sharedfeat name="compatibility" value="NEEDDATA" />
+		<!-- No compatibility data known at this time. -->
+
+		<part name="flop1" interface="floppy_5_25">
+			<feature name="part_id" value="Side A"/>
+			<dataarea name="flop" size="143360">
+				<rom name="2400 a.d. (4am crack) side a.dsk" size="143360" crc="b213865f" sha1="6f32418850fa522019233743e19ceac5bd961c95" offset="0x0000" />
+			</dataarea>
+		</part>
+		<part name="flop2" interface="floppy_5_25">
+			<feature name="part_id" value="Side B"/>
+			<dataarea name="flop" size="143360">
+				<rom name="2400 a.d. (4am crack) side b.dsk" size="143360" crc="30248b30" sha1="6154a819e207104af57b262c950fa225a8b0d1a1" offset="0x0000" />
+			</dataarea>
+		</part>
+	</software>
+
+	<software name="abnewv">
+		<description>A Brand New View (4am crack)</description>
+		<year>1987</year>
+		<publisher>D.C. Heath and Company</publisher>
+		<info name="release" value="2016-08-24"/>
+		<sharedfeat name="compatibility" value="NEEDDATA" />
+		<!-- No compatibility data known at this time. -->
+
+		<part name="flop1" interface="floppy_5_25">
+			<dataarea name="flop" size="143360">
+			<rom name="a brand new view (4am crack).dsk" size="143360" crc="dcbee16d" sha1="1f5fba7748da446fb3c31845788e18905691baea" offset="0x0000" />
+			</dataarea>
+		</part>
+	</software>
 
 	<software name="alcazar">
 		<description>Alcazar the Forgotten Fortress (cleanly cracked)</description>
@@ -22,11 +88,13 @@
 		<publisher>Activision</publisher>
 
 		<part name="flop1" interface="floppy_5_25">
+			<feature name="part_id" value="Disk 1"/>
 			<dataarea name="flop" size="143360">
 				<rom name="aliens (1986)(activision)(disk 1 of 2)(clean crack).dsk" size="143360" crc="bf0f7f72" sha1="d77b4d92ce266c75c4d7f08b85e507529e0afc68" offset="0x0000" />
 			</dataarea>
 		</part>
 		<part name="flop2" interface="floppy_5_25">
+			<feature name="part_id" value="Disk 2"/>
 			<dataarea name="flop" size="143360">
 				<rom name="aliens (1986)(activision)(disk 2 of 2)(clean crack).dsk" size="143360" crc="001325b2" sha1="077d7e3d9fb920b6f7cfc69381eb447f44ce0713" offset="0x0000" />
 			</dataarea>
@@ -63,11 +131,13 @@
 		<publisher>Interplay</publisher>
 
 		<part name="flop1" interface="floppy_5_25">
+			<feature name="part_id" value="Side A"/>
 			<dataarea name="flop1" size="143360">
 				<rom name="battle chess side a (1990)(interplay)(trex crack).dsk" size="143360" crc="a81e4ae5" sha1="5b0e79fa0d4257a4855864c9324840cc1a41284e" offset="0x0000" />
 			</dataarea>
 		</part>
 		<part name="flop2" interface="floppy_5_25">
+			<feature name="part_id" value="Side B"/>
 			<dataarea name="flop1" size="143360">
 				<rom name="battle chess side b (1990)(interplay)(trex crack)[unk filesys].dsk" size="143360" crc="54359fd3" sha1="19b3ed795c9827f580df77f559ad02eca55455b9" offset="0x0000" />
 			</dataarea>
@@ -80,11 +150,13 @@
 		<publisher>Data East</publisher>
 
 		<part name="flop1" interface="floppy_5_25">
+			<feature name="part_id" value="Side A"/>
 			<dataarea name="flop1" size="143360">
 				<rom name="batman (1988)(data east)(side a)(4am crack).dsk" size="143360" crc="d8ddda60" sha1="456ced865c6a7f74af89e2bc1fbad0bde44fb55d" offset="0x0000" />
 			</dataarea>
 		</part>
 		<part name="flop2" interface="floppy_5_25">
+			<feature name="part_id" value="Side B"/>
 			<dataarea name="flop1" size="143360">
 				<rom name="batman (1988)(data east)(side b)(4am crack).dsk" size="143360" crc="0aebbb48" sha1="97888412b36e2f65725a8177c46cb1d5f2a9e083" offset="0x0000" />
 			</dataarea>
@@ -97,11 +169,13 @@
 		<publisher>Micro Education</publisher>
 
 		<part name="flop1" interface="floppy_5_25">
+			<feature name="part_id" value="Disk 1"/>
 			<dataarea name="flop1" size="143360">
 				<rom name="basic building blocks (1983)(micro education)(disk 1)(4am crack).dsk" size="143360" crc="a1752e9a" sha1="cfdd011756427b782935732446c27cb1caa6b8a1" offset="0x0000" />
 			</dataarea>
 		</part>
 		<part name="flop2" interface="floppy_5_25">
+			<feature name="part_id" value="Disk 2"/>
 			<dataarea name="flop1" size="143360">
 				<rom name="basic building blocks (1983)(micro education)(disk 2)(4am crack).dsk" size="143360" crc="a51a3503" sha1="98b6d27d0da675c2f5d351340cd56f2d8d807eba" offset="0x0000" />
 			</dataarea>
@@ -114,11 +188,13 @@
 		<publisher>Taito America / NovaLogic</publisher>
 
 		<part name="flop1" interface="floppy_5_25">
+			<feature name="part_id" value="Disk 1"/>
 			<dataarea name="flop1" size="143360">
 				<rom name="bubble bobble disk 1 of 2 (1988)(taito america - novalogic)(trex crack).dsk" size="143360" crc="2af0a5d4" sha1="4810c07e9514d6d3a49ee9babee7497103428d43" offset="0x0000" />
 			</dataarea>
 		</part>
 		<part name="flop2" interface="floppy_5_25">
+			<feature name="part_id" value="Disk 2"/>
 			<dataarea name="flop1" size="143360">
 				<rom name="bubble bobble disk 2 of 2 (1988)(taito america - novalogic)(trex crack).dsk" size="143360" crc="ac056c8d" sha1="0f30fb98d37e91f166d0c8c6b328e898cdf37ec1" offset="0x0000" />
 			</dataarea>
@@ -167,21 +243,25 @@
 		<publisher>Broderbund</publisher>
 
 		<part name="flop1" interface="floppy_5_25">
+			<feature name="part_id" value="Side A"/>
 			<dataarea name="flop" size="143360">
 				<rom name="where in time is carmen sandiego v1.1 side a (1989)(broderbund)(trex crack).dsk" size="143360" crc="9d391061" sha1="32f18c02974e0a915e3ac74abe10ec9cf5f67533" offset="0x0000" />
 			</dataarea>
 		</part>
 		<part name="flop2" interface="floppy_5_25">
+			<feature name="part_id" value="Side B"/>
 			<dataarea name="flop" size="143360">
 				<rom name="where in time is carmen sandiego v1.1 side b (1989)(broderbund)(trex crack).dsk" size="143360" crc="33e65f76" sha1="8995ca7786b6a70d68b8305625e65a534c15d435" offset="0x0000" />
 			</dataarea>
 		</part>
 		<part name="flop3" interface="floppy_5_25">
+			<feature name="part_id" value="Side C"/>
 			<dataarea name="flop" size="143360">
 				<rom name="where in time is carmen sandiego v1.1 side c (1989)(broderbund)(trex crack).dsk" size="143360" crc="15942fc0" sha1="03189fdefa100e64c0ad9ba38804bab7508f9881" offset="0x0000" />
 			</dataarea>
 		</part>
 		<part name="flop4" interface="floppy_5_25">
+			<feature name="part_id" value="Side D"/>
 			<dataarea name="flop" size="143360">
 				<rom name="where in time is carmen sandiego v1.1 side d (1989)(broderbund)(trex crack).dsk" size="143360" crc="704551a0" sha1="469ef6f3be3919cd904c63d37d6e8d46e895ab31" offset="0x0000" />
 			</dataarea>
@@ -206,21 +286,25 @@
 		<publisher>Broderbund</publisher>
 
 		<part name="flop1" interface="floppy_5_25">
+			<feature name="part_id" value="Side A"/>
 			<dataarea name="flop" size="143360">
 				<rom name="where in time is carmen sandiego v1.0 (4am crack) side a.dsk" size="143360" crc="cd3da2a7" sha1="21a9fc7220c84ffec91b4e76b28dc8b514ab56a3" offset="0x0000" />
 			</dataarea>
 		</part>
 		<part name="flop2" interface="floppy_5_25">
+			<feature name="part_id" value="Side B"/>
 			<dataarea name="flop" size="143360">
 				<rom name="where in time is carmen sandiego v1.0 (4am crack) side b.dsk" size="143360" crc="3bad4b59" sha1="7e84dc0db9e964db44692fa340b6c6828f83bfe6" offset="0x0000" />
 			</dataarea>
 		</part>
 		<part name="flop3" interface="floppy_5_25">
+			<feature name="part_id" value="Side C"/>
 			<dataarea name="flop" size="143360">
 				<rom name="where in time is carmen sandiego v1.0 (4am crack) side c.dsk" size="143360" crc="650735af" sha1="aecf8b17bb26e73036100ac648e5eddede12fe91" offset="0x0000" />
 			</dataarea>
 		</part>
 		<part name="flop4" interface="floppy_5_25">
+			<feature name="part_id" value="Side D"/>
 			<dataarea name="flop" size="143360">
 				<rom name="where in time is carmen sandiego v1.0 (4am crack) side d.dsk" size="143360" crc="3c7643ca" sha1="8a6a168f25b4698465b89db9546d9b35489fe042" offset="0x0000" />
 			</dataarea>
@@ -233,11 +317,13 @@
 		<publisher>SSI</publisher>
 
 		<part name="flop1" interface="floppy_5_25">
+			<feature name="part_id" value="Side A"/>
 			<dataarea name="flop1" size="143360">
 				<rom name="dungeon master's assistant side a (1988)(ssi)(trex crack)[rdos].dsk" size="143360" crc="14904b40" sha1="9a8953ed45bb36f340b13db1eb6d75a26e498815" offset="0x0000" />
 			</dataarea>
 		</part>
 		<part name="flop2" interface="floppy_5_25">
+			<feature name="part_id" value="Side B"/>
 			<dataarea name="flop1" size="143360">
 				<rom name="dungeon master's assistant side b (1988)(ssi)(trex crack)[rdos].dsk" size="143360" crc="fafa454c" sha1="169ec625b5d72f6c624534e4c031915a0e36c82d" offset="0x0000" />
 			</dataarea>
@@ -472,21 +558,25 @@
 		<publisher>Activision</publisher>
 
 		<part name="flop1" interface="floppy_5_25">
+			<feature name="part_id" value="Disk 1"/>
 			<dataarea name="flop" size="143360">
 				<rom name="portal disk 1 of 4 (1986)(activision)(trex crack).dsk" size="143360" crc="5f90a84a" sha1="1fcc3990b5680d47ee5a87fd0dac8266433e7a7d" offset="0x0000" />
 			</dataarea>
 		</part>
 		<part name="flop2" interface="floppy_5_25">
+			<feature name="part_id" value="Disk 2"/>
 			<dataarea name="flop" size="143360">
 				<rom name="portal disk 2 of 4 (1986)(activision)(trex crack).dsk" size="143360" crc="56038539" sha1="e2f98196e977a60d088948d5689a254c831b78d5" offset="0x0000" />
 			</dataarea>
 		</part>
 		<part name="flop3" interface="floppy_5_25">
+			<feature name="part_id" value="Disk 3"/>
 			<dataarea name="flop" size="143360">
 				<rom name="portal disk 3 of 4 (1986)(activision)(trex crack).dsk" size="143360" crc="43fa124b" sha1="96e8eb50e1f7c5608f0e5c21c8510f950f475340" offset="0x0000" />
 			</dataarea>
 		</part>
 		<part name="flop4" interface="floppy_5_25">
+			<feature name="part_id" value="Disk 4"/>
 			<dataarea name="flop" size="143360">
 				<rom name="portal disk 4 of 4 (1986)(activision)(trex crack).dsk" size="143360" crc="0cc78e02" sha1="ea7f178de04fe64aa62ed25df5e64aa405ee13b5" offset="0x0000" />
 			</dataarea>
@@ -548,11 +638,13 @@
 		<publisher>Taito America / NovaLogic</publisher>
 
 		<part name="flop1" interface="floppy_5_25">
+			<feature name="part_id" value="Disk 1"/>
 			<dataarea name="flop1" size="143360">
 				<rom name="renegade disk 1 of 2 (1988)(taito america - novalogic)(trex crack).dsk" size="143360" crc="9d480dec" sha1="bca268ad1859c8cfd214496c3195b88362a31502" offset="0x0000" />
 			</dataarea>
 		</part>
 		<part name="flop2" interface="floppy_5_25">
+			<feature name="part_id" value="Disk 2"/>
 			<dataarea name="flop1" size="143360">
 				<rom name="renegade disk 2 of 2 (1988)(taito america - novalogic)(trex crack).dsk" size="143360" crc="c01e6c75" sha1="b4b789285ee0c06315ffb216c413414c09a7756a" offset="0x0000" />
 			</dataarea>
@@ -653,11 +745,13 @@
 		<publisher>Mindplay</publisher>
 
 		<part name="flop1" interface="floppy_5_25">
+			<feature name="part_id" value="Side A"/>
 			<dataarea name="flop" size="143360">
 				<rom name="ace detective (4am crack) side a.dsk" size="143360" crc="1ed89d6f" sha1="065673511e9c48d24c0e92dfdb5ed617c3f5cf62" offset="0x0000" />
 			</dataarea>
 		</part>
 		<part name="flop2" interface="floppy_5_25">
+			<feature name="part_id" value="Side B"/>
 			<dataarea name="flop" size="143360">
 				<rom name="ace detective (4am crack) side b.dsk" size="143360" crc="e3a16f45" sha1="c5ffe33fac6919982ab1b24dbeed393ece532908" offset="0x0000" />
 			</dataarea>
@@ -730,11 +824,13 @@
 		<publisher>Windham Classics</publisher>
 
 		<part name="flop1" interface="floppy_5_25">
+			<feature name="part_id" value="Side A"/>
 			<dataarea name="flop" size="143360">
 				<rom name="alice in wonderland (4am crack) side a.dsk" size="143360" crc="46d03565" sha1="bf3ea2cdf0c5fb63aff9686605c2cae84774c62f" offset="0x0000" />
 			</dataarea>
 		</part>
 		<part name="flop2" interface="floppy_5_25">
+			<feature name="part_id" value="Side B"/>
 			<dataarea name="flop" size="143360">
 				<rom name="alice in wonderland (4am crack) side b.dsk" size="143360" crc="f03e007e" sha1="fd960bf392beaa9f081ff36a9f621cd1ce5e3c92" offset="0x0000" />
 			</dataarea>
@@ -760,21 +856,25 @@
 		<info name="usage" value="Works with Apple II Mouse Card in slot 4: -sl4 mouse" />
 
 		<part name="flop1" interface="floppy_5_25">
+			<feature name="part_id" value="Program Disk Side 1"/>
 			<dataarea name="flop" size="143360">
 				<rom name="alge-blaster plus (4am crack) program disk side 1.dsk" size="143360" crc="e8d890c7" sha1="e2dbdde612c1da4543d79a6a8bd793a9a3501320" offset="0x0000" />
 			</dataarea>
 		</part>
 		<part name="flop2" interface="floppy_5_25">
+			<feature name="part_id" value="Program Disk Side 2"/>
 			<dataarea name="flop" size="143360">
 				<rom name="alge-blaster plus (4am crack) program disk side 2.dsk" size="143360" crc="90c22d74" sha1="75d3c345e93dfe177ae4e2c5cd85bd770bead924" offset="0x0000" />
 			</dataarea>
 		</part>
 		<part name="flop3" interface="floppy_5_25">
+			<feature name="part_id" value="Data Disk Side 1"/>
 			<dataarea name="flop" size="143360">
 				<rom name="alge-blaster plus (4am crack) data disk side 1.dsk" size="143360" crc="cbd1a613" sha1="fde73dbad3ede97e2e1758b2f20fcf42e5756c5d" offset="0x0000" />
 			</dataarea>
 		</part>
 		<part name="flop4" interface="floppy_5_25">
+			<feature name="part_id" value="Data Disk Side 2"/>
 			<dataarea name="flop" size="143360">
 				<rom name="alge-blaster plus (4am crack) data disk side 2.dsk" size="143360" crc="8d94d796" sha1="8716509d1e68ad38f269d411b6c67838d4e9c4e8" offset="0x0000" />
 			</dataarea>
@@ -823,11 +923,13 @@
 		<publisher>Queue Inc.</publisher>
 
 		<part name="flop1" interface="floppy_5_25">
+			<feature name="part_id" value="Disk 1"/>
 			<dataarea name="flop" size="143360">
 				<rom name="american history adventure (4am crack) disk 1.dsk" size="143360" crc="ebed5630" sha1="e022f2c9d398128df5b01b67bdb03e1935307bc0" offset="0x0000" />
 			</dataarea>
 		</part>
 		<part name="flop2" interface="floppy_5_25">
+			<feature name="part_id" value="Disk 2"/>
 			<dataarea name="flop" size="143360">
 				<rom name="american history adventure (4am crack) disk 2.dsk" size="143360" crc="fdac8698" sha1="efb8b395b6c508d5a5eb2caa0d34a89a2eb2c54f" offset="0x0000" />
 			</dataarea>
@@ -840,11 +942,13 @@
 		<publisher>Unicorn Software</publisher>
 
 		<part name="flop1" interface="floppy_5_25">
+			<feature name="part_id" value="Side A"/>
 			<dataarea name="flop" size="143360">
 				<rom name="animal kingdom (4am crack) side a.dsk" size="143360" crc="ccd3005b" sha1="9255e54d15b405b360f340c811cd71f70ae33945" offset="0x0000" />
 			</dataarea>
 		</part>
 		<part name="flop2" interface="floppy_5_25">
+			<feature name="part_id" value="Side B"/>
 			<dataarea name="flop" size="143360">
 				<rom name="animal kingdom (4am crack) side b.dsk" size="143360" crc="98b5bc0f" sha1="c50c55c2fffc2e37c3d3319b4e8eb0c04c282beb" offset="0x0000" />
 			</dataarea>
@@ -930,21 +1034,25 @@
 		<publisher>Pelican Software</publisher>
 
 		<part name="flop1" interface="floppy_5_25">
+			<feature name="part_id" value="Disk 1 Side A"/>
 			<dataarea name="flop" size="143360">
 				<rom name="big book maker (4am crack) disk 1 side a.dsk" size="143360" crc="3f18085e" sha1="b69bdab8c4840a0922ac65b765bc3d20a38cfbd1" offset="0x0000" />
 			</dataarea>
 		</part>
 		<part name="flop2" interface="floppy_5_25">
+			<feature name="part_id" value="Disk 1 Side B"/>
 			<dataarea name="flop" size="143360">
 				<rom name="big book maker (4am crack) disk 1 side b.dsk" size="143360" crc="1142180f" sha1="cc8cd090bb644c31ec7229a0d79f135cc9e7f732" offset="0x0000" />
 			</dataarea>
 		</part>
 		<part name="flop3" interface="floppy_5_25">
+			<feature name="part_id" value="Disk 2 Side A"/>
 			<dataarea name="flop" size="143360">
 				<rom name="big book maker (4am crack) disk 2 side a.dsk" size="143360" crc="b13c5630" sha1="8b6771472e2f977b5dc30d48ba8cbf8680b635a4" offset="0x0000" />
 			</dataarea>
 		</part>
 		<part name="flop4" interface="floppy_5_25">
+			<feature name="part_id" value="Disk 2 Side B"/>
 			<dataarea name="flop" size="143360">
 				<rom name="big book maker (4am crack) disk 2 side b.dsk" size="143360" crc="b75798e9" sha1="1c25c3a721a731cb9bedc01da8d3440eac2db099" offset="0x0000" />
 			</dataarea>
@@ -1077,11 +1185,13 @@
 		<publisher>Epyx</publisher>
 
 		<part name="flop1" interface="floppy_5_25">
+			<feature name="part_id" value="Side A"/>
 			<dataarea name="flop" size="143360">
 				<rom name="california games (4am crack) side a.dsk" size="143360" crc="284f014d" sha1="97a5a792a936e13131ae37c3bdd32369d1eea8c0" offset="0x0000" />
 			</dataarea>
 		</part>
 		<part name="flop2" interface="floppy_5_25">
+			<feature name="part_id" value="Side B"/>
 			<dataarea name="flop" size="143360">
 				<rom name="california games (4am crack) side b.dsk" size="143360" crc="45e24a4e" sha1="4a649cf48658f1150477bc712070acf40994d21e" offset="0x0000" />
 			</dataarea>
@@ -1154,11 +1264,13 @@
 		<publisher>Developmental Learning Materials</publisher>
 
 		<part name="flop1" interface="floppy_5_25">
+			<feature name="part_id" value="Side A"/>
 			<dataarea name="flop" size="143360">
 				<rom name="curious george in outer space (4am crack) side a.dsk" size="143360" crc="4b80d3bf" sha1="1f81407c343b9683fc9d0c6e4c5400b0ef17bc52" offset="0x0000" />
 			</dataarea>
 		</part>
 		<part name="flop2" interface="floppy_5_25">
+			<feature name="part_id" value="Side B"/>
 			<dataarea name="flop" size="143360">
 				<rom name="curious george in outer space (4am crack) side b.dsk" size="143360" crc="4da9d944" sha1="5f222458fc9b9fbc73946dea4d0ae80a14ffafc9" offset="0x0000" />
 			</dataarea>
@@ -1171,11 +1283,13 @@
 		<publisher>Developmental Learning Materials</publisher>
 
 		<part name="flop1" interface="floppy_5_25">
+			<feature name="part_id" value="Side A"/>
 			<dataarea name="flop" size="143360">
 				<rom name="curious george goes shopping (4am crack) side a.dsk" size="143360" crc="5ad866e9" sha1="b4e384105be03c792d30ed32e72459781ce99676" offset="0x0000" />
 			</dataarea>
 		</part>
 		<part name="flop2" interface="floppy_5_25">
+			<feature name="part_id" value="Side B"/>
 			<dataarea name="flop" size="143360">
 				<rom name="curious george goes shopping (4am crack) side b.dsk" size="143360" crc="972d8958" sha1="70a81aa46b819ac438988ed696c78f70f7c1c010" offset="0x0000" />
 			</dataarea>
@@ -1200,11 +1314,13 @@
 		<publisher>Random House</publisher>
 
 		<part name="flop1" interface="floppy_5_25">
+			<feature name="part_id" value="Side A"/>
 			<dataarea name="flop" size="143360">
 				<rom name="charlie brown's 1-2-3s (4am crack) side a.dsk" size="143360" crc="22ff5067" sha1="5b09390b3c438284f9ea534ee755fe57899dabc4" offset="0x0000" />
 			</dataarea>
 		</part>
 		<part name="flop2" interface="floppy_5_25">
+			<feature name="part_id" value="Side B"/>
 			<dataarea name="flop" size="143360">
 				<rom name="charlie brown's 1-2-3s (4am crack) side b.dsk" size="143360" crc="7ea28429" sha1="5d5f985d2fc3d899f1a6b6cf16448c387a677c41" offset="0x0000" />
 			</dataarea>
@@ -1217,11 +1333,13 @@
 		<publisher>Random House</publisher>
 
 		<part name="flop1" interface="floppy_5_25">
+			<feature name="part_id" value="Side A"/>
 			<dataarea name="flop" size="143360">
 				<rom name="charlie brown's abc's (4am crack) side a.dsk" size="143360" crc="d727b6f6" sha1="1af44fa21e611564ab3929aec753cc4e160d8b80" offset="0x0000" />
 			</dataarea>
 		</part>
 		<part name="flop2" interface="floppy_5_25">
+			<feature name="part_id" value="Side B"/>
 			<dataarea name="flop" size="143360">
 				<rom name="charlie brown's abc's (4am crack) side b.dsk" size="143360" crc="5bb8d11e" sha1="d394b12ad488c50e69c07367c7bd55b07d3aed6d" offset="0x0000" />
 			</dataarea>
@@ -1246,11 +1364,13 @@
 		<publisher>Epyx</publisher>
 
 		<part name="flop1" interface="floppy_5_25">
+			<feature name="part_id" value="Side A"/>
 			<dataarea name="flop" size="143360">
 				<rom name="championship wrestling (4am crack) side a.dsk" size="143360" crc="9b562e29" sha1="8b7ff536b52238ea0ee048d0ef98c72c159b1a54" offset="0x0000" />
 			</dataarea>
 		</part>
 		<part name="flop2" interface="floppy_5_25">
+			<feature name="part_id" value="Side B"/>
 			<dataarea name="flop" size="143360">
 				<rom name="championship wrestling (4am crack) side b.dsk" size="143360" crc="5e513adf" sha1="76946879b72976b6477a0ffa68c8a9a677c3550b" offset="0x0000" />
 			</dataarea>
@@ -1316,21 +1436,25 @@
 			</dataarea>
 		</part>
 		<part name="flop2" interface="floppy_5_25">
+			<feature name="part_id" value="Picture Disk - Hugga Bunch - Side A"/>
 			<dataarea name="flop" size="143360">
 				<rom name="colorme (4am crack) picture disk - hugga bunch - side a.dsk" size="143360" crc="6afeb028" sha1="206788a5ad07b1d7e7d5dabe936d4bb1c1608a2b" offset="0x0000" />
 			</dataarea>
 		</part>
 		<part name="flop3" interface="floppy_5_25">
+			<feature name="part_id" value="Picture Disk - Hugga Bunch - Side B"/>
 			<dataarea name="flop" size="143360">
 				<rom name="colorme (4am crack) picture disk - hugga bunch - side b.dsk" size="143360" crc="227c37ce" sha1="18e1f544389770a6a74d97c585e2a7e6a8a5674c" offset="0x0000" />
 			</dataarea>
 		</part>
 		<part name="flop4" interface="floppy_5_25">
+			<feature name="part_id" value="Picture Disk - Tink Tonk - Side A"/>
 			<dataarea name="flop" size="143360">
 				<rom name="colorme (4am crack) picture disk - tink tonk - side a.dsk" size="143360" crc="8444dd7f" sha1="14cb015848ec215f928484db6bc5d9abb4693c56" offset="0x0000" />
 			</dataarea>
 		</part>
 		<part name="flop5" interface="floppy_5_25">
+			<feature name="part_id" value="Picture Disk - Tink Tonk - Side B"/>
 			<dataarea name="flop" size="143360">
 				<rom name="colorme (4am crack) picture disk - tink tonk - side b.dsk" size="143360" crc="6afeb028" sha1="206788a5ad07b1d7e7d5dabe936d4bb1c1608a2b" offset="0x0000" />
 			</dataarea>
@@ -1367,11 +1491,13 @@
 		<publisher>DataSoft</publisher>
 
 		<part name="flop1" interface="floppy_5_25">
+			<feature name="part_id" value="Side A"/>
 			<dataarea name="flop" size="143360">
 				<rom name="conan (4am crack) side a.dsk" size="143360" crc="59ab412d" sha1="7b867eb234ebf0026a810609ab676a80eb6b1792" offset="0x0000" />
 			</dataarea>
 		</part>
 		<part name="flop2" interface="floppy_5_25">
+			<feature name="part_id" value="Side B"/>
 			<dataarea name="flop" size="143360">
 				<rom name="conan (4am crack) side b.dsk" size="143360" crc="8b11dd5a" sha1="62cb3e0c28deab25e35484f9aefa47e07b5f9dec" offset="0x0000" />
 			</dataarea>
@@ -1408,11 +1534,13 @@
 		<publisher>Pelican Software</publisher>
 
 		<part name="flop1" interface="floppy_5_25">
+			<feature name="part_id" value="Side A"/>
 			<dataarea name="flop" size="143360">
 				<rom name="creation (4am crack) side a.dsk" size="143360" crc="24686294" sha1="f103a1bb993cfe484baccc0b2fd51d569c5429b8" offset="0x0000" />
 			</dataarea>
 		</part>
 		<part name="flop2" interface="floppy_5_25">
+			<feature name="part_id" value="Side B"/>
 			<dataarea name="flop" size="143360">
 				<rom name="creation (4am crack) side b.dsk" size="143360" crc="52b81661" sha1="435881b4f3f75fc7317fbccf10690c653c9cade1" offset="0x0000" />
 			</dataarea>
@@ -1629,16 +1757,19 @@
 		<publisher>Avant-Garde Publishing Corp.</publisher>
 
 		<part name="flop1" interface="floppy_5_25">
+			<feature name="part_id" value="Program disk (no mouse)"/>
 			<dataarea name="flop" size="143360">
 				<rom name="design your own home - architectural design (4am crack) disk 1 - program disk without mouse support.dsk" size="143360" crc="7a636e73" sha1="cc5db5f4babe23b6949e4649dcb4b064db26f8a2" offset="0x0000" />
 			</dataarea>
 		</part>
 		<part name="flop2" interface="floppy_5_25">
+			<feature name="part_id" value="Program disk (mouse support)"/>
 			<dataarea name="flop" size="143360">
 				<rom name="design your own home - architectural design (4am crack) disk 2 - program disk with mouse support.dsk" size="143360" crc="a560a7fe" sha1="2cc71bcc086775800cd523e759956604be7f8be2" offset="0x0000" />
 			</dataarea>
 		</part>
 		<part name="flop3" interface="floppy_5_25">
+			<feature name="part_id" value="Data Disk"/>
 			<dataarea name="flop" size="143360">
 				<rom name="design your own home - architectural design (4am crack) disk 3 - data disk.dsk" size="143360" crc="6181b68e" sha1="fad415f43ce90278ad8ed5e1e8118316e0542fc2" offset="0x0000" />
 			</dataarea>
@@ -1663,16 +1794,19 @@
 		<publisher>Avant-Garde Publishing Corp.</publisher>
 
 		<part name="flop1" interface="floppy_5_25">
+			<feature name="part_id" value="Program disk (no mouse)"/>
 			<dataarea name="flop" size="143360">
 				<rom name="design your own home (4am crack) disk 1 - program disk without mouse support.dsk" size="143360" crc="74ca0ac3" sha1="80e4d88fb2e8042faeefc053b9af25e6a3aec87d" offset="0x0000" />
 			</dataarea>
 		</part>
 		<part name="flop2" interface="floppy_5_25">
+			<feature name="part_id" value="Program disk (mouse support)"/>
 			<dataarea name="flop" size="143360">
 				<rom name="design your own home (4am crack) disk 2 - program disk with mouse support.dsk" size="143360" crc="f68d0486" sha1="7ee505ad27631520237691ce07a996ef0eae5976" offset="0x0000" />
 			</dataarea>
 		</part>
 		<part name="flop3" interface="floppy_5_25">
+			<feature name="part_id" value="Data Disk"/>
 			<dataarea name="flop" size="143360">
 				<rom name="design your own home (4am crack) disk 3 - data disk.dsk" size="143360" crc="3b6b6514" sha1="c6ceba63f3707fe91d7aacd521961dd815171eb4" offset="0x0000" />
 			</dataarea>
@@ -1697,21 +1831,25 @@
 		<publisher>American Educational Computer, Inc.</publisher>
 
 		<part name="flop1" interface="floppy_5_25">
+			<feature name="part_id" value="Disk 1"/>
 			<dataarea name="flop" size="143360">
 				<rom name="easy reader demo (4am crack) disk 1.dsk" size="143360" crc="bfecd940" sha1="f08cc5a4e7e6f59ed9c07ae6fa9597ee1db97c2b" offset="0x0000" />
 			</dataarea>
 		</part>
 		<part name="flop2" interface="floppy_5_25">
+			<feature name="part_id" value="Disk 2"/>
 			<dataarea name="flop" size="143360">
 				<rom name="easy reader demo (4am crack) disk 2.dsk" size="143360" crc="a235a2db" sha1="ca8e12d10437d09bd8f3ffe90e3ffd56d3865233" offset="0x0000" />
 			</dataarea>
 		</part>
 		<part name="flop3" interface="floppy_5_25">
+			<feature name="part_id" value="Disk 3"/>
 			<dataarea name="flop" size="143360">
 				<rom name="easy reader demo (4am crack) disk 3.dsk" size="143360" crc="81b665db" sha1="ccd6f29a9a12def13602bde6ddd40cc0d9015cc9" offset="0x0000" />
 			</dataarea>
 		</part>
 		<part name="flop4" interface="floppy_5_25">
+			<feature name="part_id" value="Disk 4"/>
 			<dataarea name="flop" size="143360">
 				<rom name="easy reader demo (4am crack) disk 4.dsk" size="143360" crc="ee0f7dfe" sha1="b346068156741b5585aa1b5b1565f0745238bf52" offset="0x0000" />
 			</dataarea>
@@ -1749,11 +1887,13 @@
 		<publisher>Grolier</publisher>
 
 		<part name="flop1" interface="floppy_5_25">
+			<feature name="part_id" value="Side A"/>
 			<dataarea name="flop" size="143360">
 				<rom name="educalc (4am crack) side a.dsk" size="143360" crc="60a6cbb6" sha1="dbc1c97e26cf0387eb454adb340b990637f20d48" offset="0x0000" />
 			</dataarea>
 		</part>
 		<part name="flop2" interface="floppy_5_25">
+			<feature name="part_id" value="Side B"/>
 			<dataarea name="flop" size="143360">
 				<rom name="educalc (4am crack) side b.dsk" size="143360" crc="b01b103a" sha1="62884243c3dc97a53d6e0608cac7323ba7287b1a" offset="0x0000" />
 			</dataarea>
@@ -1898,11 +2038,13 @@
 		<publisher>Queue, Inc.</publisher>
 
 		<part name="flop1" interface="floppy_5_25">
+			<feature name="part_id" value="Disk 1"/>
 			<dataarea name="flop" size="143360">
 				<rom name="force and motion (4am crack) disk 1.dsk" size="143360" crc="a338ba73" sha1="4ddb1788cd67f4f85ebbac4995f9817a1334f6cf" offset="0x0000" />
 			</dataarea>
 		</part>
 		<part name="flop2" interface="floppy_5_25">
+			<feature name="part_id" value="Disk 2"/>
 			<dataarea name="flop" size="143360">
 				<rom name="force and motion (4am crack) disk 2.dsk" size="143360" crc="4a1e54f2" sha1="8a1863172a8e782425b14c3f09995e9dfb444024" offset="0x0000" />
 			</dataarea>
@@ -1951,11 +2093,13 @@
 		<publisher>Opportunities For Learning</publisher>
 
 		<part name="flop1" interface="floppy_5_25">
+			<feature name="part_id" value="Side A"/>
 			<dataarea name="flop" size="143360">
 				<rom name="fraction tutorial (4am crack) side a.dsk" size="143360" crc="e9e24530" sha1="2524d748c108220ac1c4907193d3444fbf457707" offset="0x0000" />
 			</dataarea>
 		</part>
 		<part name="flop2" interface="floppy_5_25">
+			<feature name="part_id" value="Side B"/>
 			<dataarea name="flop" size="143360">
 				<rom name="fraction tutorial (4am crack) side b.dsk" size="143360" crc="fc980274" sha1="58f3349216f3463c49bfa8738d0e7ebbde249fcf" offset="0x0000" />
 			</dataarea>
@@ -1992,16 +2136,19 @@
 		<publisher>Hartley Courseware</publisher>
 
 		<part name="flop1" interface="floppy_5_25">
+			<feature name="part_id" value="Disk 1"/>
 			<dataarea name="flop" size="143360">
 				<rom name="frogs, dogs, kittens, and kids 1 (4am crack) disk 1.dsk" size="143360" crc="ab28d4d3" sha1="4d2644e78bb8ef4d6df9ae808861c9c5e5e91a5e" offset="0x0000" />
 			</dataarea>
 		</part>
 		<part name="flop2" interface="floppy_5_25">
+			<feature name="part_id" value="Disk 2"/>
 			<dataarea name="flop" size="143360">
 				<rom name="frogs, dogs, kittens, and kids 1 (4am crack) disk 2.dsk" size="143360" crc="6e24da32" sha1="4076f55cb2563df30b2c4f75a9bece77e54cffd6" offset="0x0000" />
 			</dataarea>
 		</part>
 		<part name="flop3" interface="floppy_5_25">
+			<feature name="part_id" value="Disk 3"/>
 			<dataarea name="flop" size="143360">
 				<rom name="frogs, dogs, kittens, and kids 1 (4am crack) disk 3.dsk" size="143360" crc="c156dc96" sha1="9965dc051410c7c8b907550dd4b65bbdca07b331" offset="0x0000" />
 			</dataarea>
@@ -2074,11 +2221,13 @@
 		<publisher>Random House</publisher>
 
 		<part name="flop1" interface="floppy_5_25">
+			<feature name="part_id" value="Side A"/>
 			<dataarea name="flop" size="143360">
 				<rom name="garfield eat your words (4am crack) side a.dsk" size="143360" crc="7509dff7" sha1="56dd7fdee9a9d9092d25cd933c9f029687c85d13" offset="0x0000" />
 			</dataarea>
 		</part>
 		<part name="flop2" interface="floppy_5_25">
+			<feature name="part_id" value="Side B"/>
 			<dataarea name="flop" size="143360">
 				<rom name="garfield eat your words (4am crack) side b.dsk" size="143360" crc="655c5f4c" sha1="9e28deb94582d1789a3a46d793b53af591d977ee" offset="0x0000" />
 			</dataarea>
@@ -2115,11 +2264,13 @@
 		<publisher>Davidson &amp; Associates, Inc.</publisher>
 
 		<part name="flop1" interface="floppy_5_25">
+			<feature name="part_id" value="Side A"/>
 			<dataarea name="flop" size="143360">
 				<rom name="grammar gremlins (4am crack) side a.dsk" size="143360" crc="6c8489fa" sha1="38428a2f090900660fa4ff581e770004b71ad801" offset="0x0000" />
 			</dataarea>
 		</part>
 		<part name="flop2" interface="floppy_5_25">
+			<feature name="part_id" value="Side B"/>
 			<dataarea name="flop" size="143360">
 				<rom name="grammar gremlins (4am crack) side b.dsk" size="143360" crc="b07ee7b3" sha1="0c4171e8a85bd5627a8c3a25da4c29cc68c2038b" offset="0x0000" />
 			</dataarea>
@@ -2132,86 +2283,103 @@
 		<publisher>American Language Academy</publisher>
 
 		<part name="flop1" interface="floppy_5_25">
+			<feature name="part_id" value="Disk A-1"/>
 			<dataarea name="flop" size="143360">
 				<rom name="grammar mastery ii (4am crack) disk a-1.dsk" size="143360" crc="3d53eb4f" sha1="e85c7999c214c488c9bdc2d74f024ccbbda8b1a4" offset="0x0000" />
 			</dataarea>
 		</part>
 		<part name="flop2" interface="floppy_5_25">
+			<feature name="part_id" value="Disk A-2"/>
 			<dataarea name="flop" size="143360">
 				<rom name="grammar mastery ii (4am crack) disk a-2.dsk" size="143360" crc="62861308" sha1="efdf35fb331e1ea76bf3febb74b98f1aa9072a3d" offset="0x0000" />
 			</dataarea>
 		</part>
 		<part name="flop3" interface="floppy_5_25">
+			<feature name="part_id" value="Disk A-4"/>
 			<dataarea name="flop" size="143360">
 				<rom name="grammar mastery ii (4am crack) disk a-4.dsk" size="143360" crc="0b7db6d7" sha1="64017e68302426b20e2d60c723370fb125bb597f" offset="0x0000" />
 			</dataarea>
 		</part>
 		<part name="flop4" interface="floppy_5_25">
+			<feature name="part_id" value="Disk A-5"/>
 			<dataarea name="flop" size="143360">
 				<rom name="grammar mastery ii (4am crack) disk a-5.dsk" size="143360" crc="e3e18574" sha1="4c7f7138f3640955ae2f44f0b3c384b1baf5ef87" offset="0x0000" />
 			</dataarea>
 		</part>
 		<part name="flop5" interface="floppy_5_25">
+			<feature name="part_id" value="Disk A-6"/>
 			<dataarea name="flop" size="143360">
 				<rom name="grammar mastery ii (4am crack) disk a-6.dsk" size="143360" crc="35b2b8c5" sha1="34004d39f76ba327b290db7774848087811686a2" offset="0x0000" />
 			</dataarea>
 		</part>
 		<part name="flop6" interface="floppy_5_25">
+			<feature name="part_id" value="Disk B-1"/>
 			<dataarea name="flop" size="143360">
 				<rom name="grammar mastery ii (4am crack) disk b-1.dsk" size="143360" crc="8631e8c0" sha1="a0df701d842885ab5efa1f0263ed3adfd8ffab71" offset="0x0000" />
 			</dataarea>
 		</part>
 		<part name="flop7" interface="floppy_5_25">
+			<feature name="part_id" value="Disk B-2"/>
 			<dataarea name="flop" size="143360">
 				<rom name="grammar mastery ii (4am crack) disk b-2.dsk" size="143360" crc="8393c99d" sha1="c4e685db3617bbc813eed22ca2154a10af8c2c31" offset="0x0000" />
 			</dataarea>
 		</part>
 		<part name="flop8" interface="floppy_5_25">
+			<feature name="part_id" value="Disk B-3"/>
 			<dataarea name="flop" size="143360">
 				<rom name="grammar mastery ii (4am crack) disk b-3.dsk" size="143360" crc="60906690" sha1="bf46683255c2cabd11faf78d0fc7f1758053fb72" offset="0x0000" />
 			</dataarea>
 		</part>
 		<part name="flop9" interface="floppy_5_25">
+			<feature name="part_id" value="Disk B-4"/>
 			<dataarea name="flop" size="143360">
 				<rom name="grammar mastery ii (4am crack) disk b-4.dsk" size="143360" crc="119a3936" sha1="dfea07eaf3b869b7c9f3eb04aafcbfe6b688e7fd" offset="0x0000" />
 			</dataarea>
 		</part>
 		<part name="flop10" interface="floppy_5_25">
+			<feature name="part_id" value="Disk B-5"/>
 			<dataarea name="flop" size="143360">
 				<rom name="grammar mastery ii (4am crack) disk b-5.dsk" size="143360" crc="930a0f64" sha1="438af9967691d15a2ffc7e8698d2cc2bb8d74b52" offset="0x0000" />
 			</dataarea>
 		</part>
 		<part name="flop11" interface="floppy_5_25">
+			<feature name="part_id" value="Disk B-6"/>
 			<dataarea name="flop" size="143360">
 				<rom name="grammar mastery ii (4am crack) disk b-6.dsk" size="143360" crc="285997e9" sha1="bac4010cbf9a79730358941248eed02198f968e5" offset="0x0000" />
 			</dataarea>
 		</part>
 		<part name="flop12" interface="floppy_5_25">
+			<feature name="part_id" value="Disk C-1"/>
 			<dataarea name="flop" size="143360">
 				<rom name="grammar mastery ii (4am crack) disk c-1.dsk" size="143360" crc="1f1be2d0" sha1="42950035862d42b3f26ce35bc8c260e4c4785406" offset="0x0000" />
 			</dataarea>
 		</part>
 		<part name="flop13" interface="floppy_5_25">
+			<feature name="part_id" value="Disk C-2"/>
 			<dataarea name="flop" size="143360">
 				<rom name="grammar mastery ii (4am crack) disk c-2.dsk" size="143360" crc="907f27a0" sha1="b3835d8cc4224d8e32c18b79737b3f4a5a647d4d" offset="0x0000" />
 			</dataarea>
 		</part>
 		<part name="flop14" interface="floppy_5_25">
+			<feature name="part_id" value="Disk C-3"/>
 			<dataarea name="flop" size="143360">
 				<rom name="grammar mastery ii (4am crack) disk c-3.dsk" size="143360" crc="e86de7e2" sha1="1df2d1d7335415fde97fc2c2078c8fee05ce79cc" offset="0x0000" />
 			</dataarea>
 		</part>
 		<part name="flop15" interface="floppy_5_25">
+			<feature name="part_id" value="Disk C-4"/>
 			<dataarea name="flop" size="143360">
 				<rom name="grammar mastery ii (4am crack) disk c-4.dsk" size="143360" crc="e13a724f" sha1="57c2814e87fbcfcfc4b83f348b18b8bc52c5d60d" offset="0x0000" />
 			</dataarea>
 		</part>
 		<part name="flop16" interface="floppy_5_25">
+			<feature name="part_id" value="Disk C-5"/>
 			<dataarea name="flop" size="143360">
 				<rom name="grammar mastery ii (4am crack) disk c-5.dsk" size="143360" crc="84f65fd3" sha1="91831d0762420e4c7e5033bcbc763b2b43370840" offset="0x0000" />
 			</dataarea>
 		</part>
 		<part name="flop17" interface="floppy_5_25">
+			<feature name="part_id" value="Disk C-6"/>
 			<dataarea name="flop" size="143360">
 				<rom name="grammar mastery ii (4am crack) disk c-6.dsk" size="143360" crc="1cbb4327" sha1="ed9a040d0ee4d20056daf43a1d039b6998c1e5f7" offset="0x0000" />
 			</dataarea>
@@ -2309,31 +2477,37 @@
 		<publisher>Spinnaker</publisher>
 
 		<part name="flop1" interface="floppy_5_25">
+			<feature name="part_id" value="Side A"/>
 			<dataarea name="flop" size="143360">
 				<rom name="homework helper writing (4am crack) side a.dsk" size="143360" crc="ba414e13" sha1="969b9b1e9274ff408ed1943386fb404558347d20" offset="0x0000" />
 			</dataarea>
 		</part>
 		<part name="flop2" interface="floppy_5_25">
+			<feature name="part_id" value="Side B"/>
 			<dataarea name="flop" size="143360">
 				<rom name="homework helper writing (4am crack) side b.dsk" size="143360" crc="cadc35d1" sha1="14333181c3377b99119afd8b0b78bc76dec9ef58" offset="0x0000" />
 			</dataarea>
 		</part>
 		<part name="flop3" interface="floppy_5_25">
+			<feature name="part_id" value="Side C"/>
 			<dataarea name="flop" size="143360">
 				<rom name="homework helper writing (4am crack) side c.dsk" size="143360" crc="ed3408a7" sha1="bcd388c678ec6ed88ee17c44aee8e964e29c8320" offset="0x0000" />
 			</dataarea>
 		</part>
 		<part name="flop4" interface="floppy_5_25">
+			<feature name="part_id" value="Side D"/>
 			<dataarea name="flop" size="143360">
 				<rom name="homework helper writing (4am crack) side d.dsk" size="143360" crc="480fe9b8" sha1="da63ce365fe39fec470494e0d8a7c2dfa5603e2e" offset="0x0000" />
 			</dataarea>
 		</part>
 		<part name="flop5" interface="floppy_5_25">
+			<feature name="part_id" value="Side E"/>
 			<dataarea name="flop" size="143360">
 				<rom name="homework helper writing (4am crack) side e.dsk" size="143360" crc="283dcd8b" sha1="42452afe600f86154347eeba2c9fc556519ee9ff" offset="0x0000" />
 			</dataarea>
 		</part>
 		<part name="flop6" interface="floppy_5_25">
+			<feature name="part_id" value="Side F"/>
 			<dataarea name="flop" size="143360">
 				<rom name="homework helper writing (4am crack) side f.dsk" size="143360" crc="769ebeee" sha1="82f0379fec113421d2bba8ac95e929a20918ffab" offset="0x0000" />
 			</dataarea>
@@ -2346,11 +2520,13 @@
 		<publisher>Scholastic, Inc.</publisher>
 
 		<part name="flop1" interface="floppy_5_25">
+			<feature name="part_id" value="Side A"/>
 			<dataarea name="flop" size="143360">
 				<rom name="homework writer (4am crack) side a.dsk" size="143360" crc="9f679792" sha1="b4a8db1ec71e52049f5f06f51cc4587b2022c4e3" offset="0x0000" />
 			</dataarea>
 		</part>
 		<part name="flop2" interface="floppy_5_25">
+			<feature name="part_id" value="Side B"/>
 			<dataarea name="flop" size="143360">
 				<rom name="homework writer (4am crack) side b.dsk" size="143360" crc="aeb2abe1" sha1="786f32a81eada81297f0c93c5525bdede2a7ffbe" offset="0x0000" />
 			</dataarea>
@@ -2363,11 +2539,13 @@
 		<publisher>Decision Development Co</publisher>
 
 		<part name="flop1" interface="floppy_5_25">
+			<feature name="part_id" value="Side A"/>
 			<dataarea name="flop" size="143360">
 				<rom name="house-a-fire (4am crack) side a.dsk" size="143360" crc="86f910e6" sha1="33c07bc9096be166c055e7ab792c2bd66f9f4114" offset="0x0000" />
 			</dataarea>
 		</part>
 		<part name="flop2" interface="floppy_5_25">
+			<feature name="part_id" value="Side B"/>
 			<dataarea name="flop" size="143360">
 				<rom name="house-a-fire (4am crack) side b.dsk" size="143360" crc="41bbc599" sha1="7f1b2789cda668de2f583bead3a8fc03aedcd157" offset="0x0000" />
 			</dataarea>
@@ -2392,11 +2570,13 @@
 		<publisher>Epyx</publisher>
 
 		<part name="flop1" interface="floppy_5_25">
+			<feature name="part_id" value="Side A"/>
 			<dataarea name="flop" size="143360">
 				<rom name="impossible mission ii (4am crack) side a.dsk" size="143360" crc="a219d468" sha1="98a1aa883ad0a46ee30f043d431138ec4382d205" offset="0x0000" />
 			</dataarea>
 		</part>
 		<part name="flop2" interface="floppy_5_25">
+			<feature name="part_id" value="Side B"/>
 			<dataarea name="flop" size="143360">
 				<rom name="impossible mission ii (4am crack) side b.dsk" size="143360" crc="7968cf85" sha1="b4853d27a3b3aee986f4c4ea5b8f908a9423c782" offset="0x0000" />
 			</dataarea>
@@ -2409,11 +2589,13 @@
 		<publisher>University of Massachusetts</publisher>
 
 		<part name="flop1" interface="floppy_5_25">
+			<feature name="part_id" value="Side A"/>
 			<dataarea name="flop" size="143360">
 				<rom name="investigating secondary mathematics with computers (4am crack) side a.dsk" size="143360" crc="8cf2e9bc" sha1="d32d449515fa0ac526135d677ee75b3c19f281dc" offset="0x0000" />
 			</dataarea>
 		</part>
 		<part name="flop2" interface="floppy_5_25">
+			<feature name="part_id" value="Side B"/>
 			<dataarea name="flop" size="143360">
 				<rom name="investigating secondary mathematics with computers (4am crack) side b.dsk" size="143360" crc="217fd3bb" sha1="8bc60eb6bbe8b46921c4942bdcb6df44159b2471" offset="0x0000" />
 			</dataarea>
@@ -2450,11 +2632,13 @@
 		<publisher>Epyx</publisher>
 
 		<part name="flop1" interface="floppy_5_25">
+			<feature name="part_id" value="Side A"/>
 			<dataarea name="flop" size="143360">
 				<rom name="jumpman (4am crack) side a.dsk" size="143360" crc="4f291aa3" sha1="1c43eac018c0a04e70177cf413d7b20b4eaa3a89" offset="0x0000" />
 			</dataarea>
 		</part>
 		<part name="flop2" interface="floppy_5_25">
+			<feature name="part_id" value="Side B"/>
 			<dataarea name="flop" size="143360">
 				<rom name="jumpman (4am crack) side b.dsk" size="143360" crc="90312d4c" sha1="0ba7c41afbb31c93e4dc602da12cf577876dbc2c" offset="0x0000" />
 			</dataarea>
@@ -2515,11 +2699,13 @@
 		<publisher>Hartley Courseware, Inc.</publisher>
 
 		<part name="flop1" interface="floppy_5_25">
+			<feature name="part_id" value="Disk 1"/>
 			<dataarea name="flop" size="143360">
 				<rom name="kittens, kids, and a frog (4am crack) disk 1.dsk" size="143360" crc="8c27a9ce" sha1="487e3ffae06831e594c8f1d6212ef9e3c1421476" offset="0x0000" />
 			</dataarea>
 		</part>
 		<part name="flop2" interface="floppy_5_25">
+			<feature name="part_id" value="Disk 2"/>
 			<dataarea name="flop" size="143360">
 				<rom name="kittens, kids, and a frog (4am crack) disk 2.dsk" size="143360" crc="6982459d" sha1="1c0fa745487f156229c494955508a1591d6d376b" offset="0x0000" />
 			</dataarea>

--- a/hash/apple2_flop_clcracked.xml
+++ b/hash/apple2_flop_clcracked.xml
@@ -8,7 +8,6 @@
 		<year>1983</year>
 		<publisher>Learning Seed Company</publisher>
 		<info name="release" value="2016-04-12"/>
-		<sharedfeat name="compatibility" value="NEEDDATA" />
 		<!-- No compatibility data known at this time. -->
 
 		<part name="flop1" interface="floppy_5_25">
@@ -23,7 +22,6 @@
 		<year>1986</year>
 		<publisher>Microcomputer Workshops</publisher>
 		<info name="release" value="2017-04-30"/>
-		<sharedfeat name="compatibility" value="NEEDDATA" />
 		<!-- No compatibility data known at this time. -->
 
 		<part name="flop1" interface="floppy_5_25">
@@ -38,7 +36,6 @@
 		<year>1987</year>
 		<publisher>Origin Systems</publisher>
 		<info name="release" value="2018-09-23"/>
-		<sharedfeat name="compatibility" value="NEEDDATA" />
 		<!-- No compatibility data known at this time. -->
 
 		<part name="flop1" interface="floppy_5_25">
@@ -60,7 +57,6 @@
 		<year>1984</year>
 		<publisher>Bitcards</publisher>
 		<info name="release" value="2019-01-15"/>
-		<sharedfeat name="compatibility" value="NEEDDATA" />
 		<!-- No compatibility data known at this time. -->
 
 		<part name="flop1" interface="floppy_5_25">
@@ -81,7 +77,6 @@
 		<description>Alcazar the Forgotten Fortress (cleanly cracked)</description>
 		<year>1985</year>
 		<publisher>Activision</publisher>
-		<sharedfeat name="compatibility" value="NEEDDATA" />
 		<!-- No compatibility data known at this time. -->
 
 		<part name="flop1" interface="floppy_5_25">
@@ -95,7 +90,6 @@
 		<description>Aliens (cleanly cracked)</description>
 		<year>1986</year>
 		<publisher>Activision</publisher>
-		<sharedfeat name="compatibility" value="NEEDDATA" />
 		<!-- No compatibility data known at this time. -->
 
 		<part name="flop1" interface="floppy_5_25">
@@ -116,7 +110,6 @@
 		<description>Aztec (cleanly cracked)</description>
 		<year>1982</year>
 		<publisher>Datamost</publisher>
-		<sharedfeat name="compatibility" value="NEEDDATA" />
 		<!-- No compatibility data known at this time. -->
 
 		<part name="flop1" interface="floppy_5_25">
@@ -130,7 +123,6 @@
 		<description>The American Challenge (cleanly cracked)</description>
 		<year>1986</year>
 		<publisher>MIndscape</publisher>
-		<sharedfeat name="compatibility" value="NEEDDATA" />
 		<!-- No compatibility data known at this time. -->
 
 		<part name="flop1" interface="floppy_5_25">
@@ -144,7 +136,6 @@
 		<description>Battle Chess (cleanly cracked)</description>
 		<year>1990</year>
 		<publisher>Interplay</publisher>
-		<sharedfeat name="compatibility" value="NEEDDATA" />
 		<!-- No compatibility data known at this time. -->
 
 		<part name="flop1" interface="floppy_5_25">
@@ -165,7 +156,6 @@
 		<description>Batman (cleanly cracked)</description>
 		<year>1988</year>
 		<publisher>Data East</publisher>
-		<sharedfeat name="compatibility" value="NEEDDATA" />
 		<!-- No compatibility data known at this time. -->
 
 		<part name="flop1" interface="floppy_5_25">
@@ -186,7 +176,6 @@
 		<description>BASIC Building Blocks (cleanly cracked)</description>
 		<year>1983</year>
 		<publisher>Micro Education</publisher>
-		<sharedfeat name="compatibility" value="NEEDDATA" />
 		<!-- No compatibility data known at this time. -->
 
 		<part name="flop1" interface="floppy_5_25">
@@ -208,7 +197,6 @@
 		<year>1987</year>
 		<publisher>D.C. Heath and Company</publisher>
 		<info name="release" value="2016-08-24"/>
-		<sharedfeat name="compatibility" value="NEEDDATA" />
 		<!-- No compatibility data known at this time. -->
 
 		<part name="flop1" interface="floppy_5_25">
@@ -222,7 +210,6 @@
 		<description>Bubble Bobble (cleanly cracked)</description>
 		<year>1988</year>
 		<publisher>Taito America / NovaLogic</publisher>
-		<sharedfeat name="compatibility" value="NEEDDATA" />
 		<!-- No compatibility data known at this time. -->
 
 		<part name="flop1" interface="floppy_5_25">
@@ -243,7 +230,6 @@
 		<description>Countdown to Shutdown (cleanly cracked)</description>
 		<year>1985</year>
 		<publisher>Activision</publisher>
-		<sharedfeat name="compatibility" value="NEEDDATA" />
 		<!-- No compatibility data known at this time. -->
 
 		<part name="flop1" interface="floppy_5_25">
@@ -257,7 +243,6 @@
 		<description>Cogito! (cleanly cracked)</description>
 		<year>198??</year>
 		<publisher>Reader's Digest Software</publisher>
-		<sharedfeat name="compatibility" value="NEEDDATA" />
 		<!-- No compatibility data known at this time. -->
 
 		<part name="flop1" interface="floppy_5_25">
@@ -271,7 +256,6 @@
 		<description>Crisis Mountain (cleanly cracked)</description>
 		<year>1982</year>
 		<publisher>Synergistic Software</publisher>
-		<sharedfeat name="compatibility" value="NEEDDATA" />
 		<!-- No compatibility data known at this time. -->
 
 		<part name="flop1" interface="floppy_5_25">
@@ -285,7 +269,6 @@
 		<description>Where in Time is Carmen Sandiego v1.1 (cleanly cracked)</description>
 		<year>1989</year>
 		<publisher>Broderbund</publisher>
-		<sharedfeat name="compatibility" value="NEEDDATA" />
 		<!-- No compatibility data known at this time. -->
 
 		<part name="flop1" interface="floppy_5_25">
@@ -318,7 +301,6 @@
 		<description>Where in Time is Carmen Sandiego v1.1 800K 3.5 disc (cleanly cracked)</description>
 		<year>1989</year>
 		<publisher>Broderbund</publisher>
-		<sharedfeat name="compatibility" value="NEEDDATA" />
 		<!-- No compatibility data known at this time. -->
 
 		<part name="flop1" interface="floppy_3_5">
@@ -332,7 +314,6 @@
 		<description>Where in Time is Carmen Sandiego v1.0 (cleanly cracked)</description>
 		<year>1989</year>
 		<publisher>Broderbund</publisher>
-		<sharedfeat name="compatibility" value="NEEDDATA" />
 		<!-- No compatibility data known at this time. -->
 
 		<part name="flop1" interface="floppy_5_25">
@@ -365,7 +346,6 @@
 		<description>Dungeon Master's Assistant (cleanly cracked)</description>
 		<year>1988</year>
 		<publisher>SSI</publisher>
-		<sharedfeat name="compatibility" value="NEEDDATA" />
 		<!-- No compatibility data known at this time. -->
 
 		<part name="flop1" interface="floppy_5_25">
@@ -387,7 +367,6 @@
 		<!-- Original disk wouldn't boot on 65C02 or later -->
 		<year>1983</year>
 		<publisher>Datasoft / Design Labs</publisher>
-		<sharedfeat name="compatibility" value="NEEDDATA" />
 		<!-- No compatibility data known at this time. -->
 
 		<part name="flop1" interface="floppy_5_25">
@@ -401,7 +380,6 @@
 		<description>Ghostbusters (cleanly cracked)</description>
 		<year>1984</year>
 		<publisher>Activision</publisher>
-		<sharedfeat name="compatibility" value="NEEDDATA" />
 		<!-- No compatibility data known at this time. -->
 
 		<part name="flop1" interface="floppy_5_25">
@@ -415,7 +393,6 @@
 		<description>Hardball (cleanly cracked)</description>
 		<year>1985</year>
 		<publisher>Accolade</publisher>
-		<sharedfeat name="compatibility" value="NEEDDATA" />
 		<!-- No compatibility data known at this time. -->
 
 		<part name="flop1" interface="floppy_5_25">
@@ -429,7 +406,6 @@
 		<description>Hard Hat Mack (cleanly cracked)</description>
 		<year>1983</year>
 		<publisher>Electronic Arts</publisher>
-		<sharedfeat name="compatibility" value="NEEDDATA" />
 		<!-- No compatibility data known at this time. -->
 
 		<part name="flop1" interface="floppy_5_25">
@@ -444,7 +420,6 @@
 		<!-- High scores stored on disc, reset to AAA 5000, BBB 4000, CCC 3000, DDD 2000 & EEE 1000 -->
 		<year>1983</year>
 		<publisher>Microlab</publisher>
-		<sharedfeat name="compatibility" value="NEEDDATA" />
 		<!-- No compatibility data known at this time. -->
 
 		<part name="flop1" interface="floppy_5_25">
@@ -458,7 +433,6 @@
 		<description>Law of the West (cleanly cracked)</description>
 		<year>1985</year>
 		<publisher>Accolade</publisher>
-		<sharedfeat name="compatibility" value="NEEDDATA" />
 		<!-- No compatibility data known at this time. -->
 
 		<part name="flop1" interface="floppy_5_25">
@@ -472,7 +446,6 @@
 		<description>Master of the Lamps (cleanly cracked)</description>
 		<year>1985</year>
 		<publisher>Activision</publisher>
-		<sharedfeat name="compatibility" value="NEEDDATA" />
 		<!-- No compatibility data known at this time. -->
 
 		<part name="flop1" interface="floppy_5_25">
@@ -487,7 +460,6 @@
 		<!-- High scores stored on disc, reset to AAA 5000, AAA 4000, AAA 3000, AAA 2000 & AAA 1000 -->
 		<year>1982</year>
 		<publisher>Micro Fun</publisher>
-		<sharedfeat name="compatibility" value="NEEDDATA" />
 		<!-- No compatibility data known at this time. -->
 
 		<part name="flop1" interface="floppy_5_25">
@@ -501,7 +473,6 @@
 		<description>Mr. Do (cleanly cracked)</description>
 		<year>1983</year>
 		<publisher>Datasoft</publisher>
-		<sharedfeat name="compatibility" value="NEEDDATA" />
 		<!-- No compatibility data known at this time. -->
 
 		<part name="flop1" interface="floppy_5_25">
@@ -515,7 +486,6 @@
 		<description>Ms. Pac Man (cleanly cracked)</description>
 		<year>1983</year>
 		<publisher>Atari</publisher>
-		<sharedfeat name="compatibility" value="NEEDDATA" />
 		<!-- No compatibility data known at this time. -->
 
 		<part name="flop1" interface="floppy_5_25">
@@ -532,7 +502,6 @@
 		<description>Nightmare Gallery (cleanly cracked)</description>
 		<year>1982</year>
 		<publisher>Synergistic Software</publisher>
-		<sharedfeat name="compatibility" value="NEEDDATA" />
 		<!-- No compatibility data known at this time. -->
 
 		<part name="flop1" interface="floppy_5_25">
@@ -546,7 +515,6 @@
 		<description>Pac-Man - Atari (cleanly cracked)</description>
 		<year>1983</year>
 		<publisher>Atari</publisher>
-		<sharedfeat name="compatibility" value="NEEDDATA" />
 		<!-- No compatibility data known at this time. -->
 
 		<part name="flop1" interface="floppy_5_25">
@@ -560,7 +528,6 @@
 		<description>Pac-Man - Datasoft (cleanly cracked)</description>
 		<year>1983</year>
 		<publisher>Datasoft / Namco America</publisher>
-		<sharedfeat name="compatibility" value="NEEDDATA" />
 		<!-- No compatibility data known at this time. -->
 
 		<part name="flop1" interface="floppy_5_25">
@@ -574,7 +541,6 @@
 		<description>Pac-Man - Thunder Mountain (cleanly cracked)</description>
 		<year>1983</year>
 		<publisher>Thunder Mountain / Namco</publisher>
-		<sharedfeat name="compatibility" value="NEEDDATA" />
 		<!-- No compatibility data known at this time. -->
 
 		<part name="flop1" interface="floppy_5_25">
@@ -588,7 +554,6 @@
 		<description>Paperboy (cleanly cracked)</description>
 		<year>1986</year>
 		<publisher>Mindscape / Atari</publisher>
-		<sharedfeat name="compatibility" value="NEEDDATA" />
 		<!-- No compatibility data known at this time. -->
 
 		<part name="flop1" interface="floppy_5_25">
@@ -602,7 +567,6 @@
 		<description>Paper Models - The Christmas Kit (cleanly cracked)</description>
 		<year>1986</year>
 		<publisher>Activision</publisher>
-		<sharedfeat name="compatibility" value="NEEDDATA" />
 		<!-- No compatibility data known at this time. -->
 
 		<part name="flop1" interface="floppy_5_25">
@@ -616,7 +580,6 @@
 		<description>Pigpen (cleanly cracked)</description>
 		<year>1982</year>
 		<publisher>Datamost / TMQ Software</publisher>
-		<sharedfeat name="compatibility" value="NEEDDATA" />
 		<!-- No compatibility data known at this time. -->
 
 		<part name="flop1" interface="floppy_5_25">
@@ -630,7 +593,6 @@
 		<description>Pipe Dream (cleanly cracked)</description>
 		<year>1990</year>
 		<publisher>Lucasfilm</publisher>
-		<sharedfeat name="compatibility" value="NEEDDATA" />
 		<!-- No compatibility data known at this time. -->
 
 		<part name="flop1" interface="floppy_5_25">
@@ -644,7 +606,6 @@
 		<description>Portal (cleanly cracked)</description>
 		<year>1986</year>
 		<publisher>Activision</publisher>
-		<sharedfeat name="compatibility" value="NEEDDATA" />
 		<!-- No compatibility data known at this time. -->
 
 		<part name="flop1" interface="floppy_5_25">
@@ -677,7 +638,6 @@
 		<description>Qix (cleanly cracked)</description>
 		<year>1989</year>
 		<publisher>Taito</publisher>
-		<sharedfeat name="compatibility" value="NEEDDATA" />
 		<!-- No compatibility data known at this time. -->
 
 		<part name="flop1" interface="floppy_5_25">
@@ -691,7 +651,6 @@
 		<description>Racter (cleanly cracked)</description>
 		<year>1985</year>
 		<publisher>Mindscape</publisher>
-		<sharedfeat name="compatibility" value="NEEDDATA" />
 		<!-- No compatibility data known at this time. -->
 
 		<part name="flop1" interface="floppy_5_25">
@@ -705,7 +664,6 @@
 		<description>Rambo First Blood Part II (cleanly cracked)</description>
 		<year>1985</year>
 		<publisher>Mindscape / Angelsoft</publisher>
-		<sharedfeat name="compatibility" value="NEEDDATA" />
 		<!-- No compatibility data known at this time. -->
 
 		<part name="flop1" interface="floppy_5_25">
@@ -719,7 +677,6 @@
 		<description>Rampage (cleanly cracked)</description>
 		<year>1988</year>
 		<publisher>Activision</publisher>
-		<sharedfeat name="compatibility" value="NEEDDATA" />
 		<!-- No compatibility data known at this time. -->
 
 		<part name="flop1" interface="floppy_5_25">
@@ -734,7 +691,6 @@
 		<!-- ProDOS 8 based & hard drive compatable -->
 		<year>1988</year>
 		<publisher>Taito America / NovaLogic</publisher>
-		<sharedfeat name="compatibility" value="NEEDDATA" />
 		<!-- No compatibility data known at this time. -->
 
 		<part name="flop1" interface="floppy_5_25">
@@ -755,7 +711,6 @@
 		<description>Shanghai (cleanly cracked)</description>
 		<year>1986</year>
 		<publisher>Activision</publisher>
-		<sharedfeat name="compatibility" value="NEEDDATA" />
 		<!-- No compatibility data known at this time. -->
 
 		<part name="flop1" interface="floppy_5_25">
@@ -769,7 +724,6 @@
 		<description>Sneakers (cleanly cracked)</description>
 		<year>1981</year>
 		<publisher>Sirius Software</publisher>
-		<sharedfeat name="compatibility" value="NEEDDATA" />
 		<!-- No compatibility data known at this time. -->
 
 		<part name="flop1" interface="floppy_5_25">
@@ -783,7 +737,6 @@
 		<description>Spindizzy (cleanly cracked)</description>
 		<year>1986</year>
 		<publisher>Activision</publisher>
-		<sharedfeat name="compatibility" value="NEEDDATA" />
 		<!-- No compatibility data known at this time. -->
 
 		<part name="flop1" interface="floppy_5_25">
@@ -798,7 +751,6 @@
 		<!-- Corrected rerip 09/19/2016 -->
 		<year>1983</year>
 		<publisher>Bally/Midway</publisher>
-		<sharedfeat name="compatibility" value="NEEDDATA" />
 		<!-- No compatibility data known at this time. -->
 
 		<part name="flop1" interface="floppy_5_25">
@@ -815,7 +767,6 @@
 		<!-- Also includes a single file BRUNable conversion of the game -->
 		<year>1981</year>
 		<publisher>Datamost</publisher>
-		<sharedfeat name="compatibility" value="NEEDDATA" />
 		<!-- No compatibility data known at this time. -->
 
 		<part name="flop1" interface="floppy_5_25">
@@ -829,7 +780,6 @@
 		<description>Xevious (cleanly cracked)</description>
 		<year>1983</year>
 		<publisher>Mindscape</publisher>
-		<sharedfeat name="compatibility" value="NEEDDATA" />
 		<!-- No compatibility data known at this time. -->
 
 		<part name="flop1" interface="floppy_5_25">
@@ -843,7 +793,6 @@
 		<description>1-2-3 Sequence Me (cleanly cracked)</description>
 		<year>1991</year>
 		<publisher>Sunburst</publisher>
-		<sharedfeat name="compatibility" value="NEEDDATA" />
 		<!-- No compatibility data known at this time. -->
 
 		<part name="flop1" interface="floppy_5_25">
@@ -857,7 +806,6 @@
 		<description>Ace Detective (cleanly cracked)</description>
 		<year>1987</year>
 		<publisher>Mindplay</publisher>
-		<sharedfeat name="compatibility" value="NEEDDATA" />
 		<!-- No compatibility data known at this time. -->
 
 		<part name="flop1" interface="floppy_5_25">
@@ -879,7 +827,6 @@
 		<year>1987</year>
 		<publisher>Mindplay</publisher>
 		<info name="release" value="2015-07-24"/>
-		<sharedfeat name="compatibility" value="NEEDDATA" />
 		<!-- No compatibility data known at this time. -->
 
 		<part name="flop1" interface="floppy_5_25">
@@ -900,7 +847,6 @@
 		<description>Mathematics Courseware Series: Addition and Subtraction 1 (cleanly cracked)</description>
 		<year>1985</year>
 		<publisher>Scott, Foresman and Company</publisher>
-		<sharedfeat name="compatibility" value="NEEDDATA" />
 		<!-- No compatibility data known at this time. -->
 
 		<part name="flop1" interface="floppy_5_25">
@@ -914,7 +860,6 @@
 		<description>Mathematics Courseware Series: Addition and Subtraction 2 (cleanly cracked)</description>
 		<year>1985</year>
 		<publisher>Scott, Foresman and Company</publisher>
-		<sharedfeat name="compatibility" value="NEEDDATA" />
 		<!-- No compatibility data known at this time. -->
 
 		<part name="flop1" interface="floppy_5_25">
@@ -928,7 +873,6 @@
 		<description>Alfred's Basic Piano Theory Software (cleanly cracked)</description>
 		<year>1986</year>
 		<publisher>Alfred Publishing Company</publisher>
-		<sharedfeat name="compatibility" value="NEEDDATA" />
 		<!-- No compatibility data known at this time. -->
 
 		<part name="flop1" interface="floppy_5_25">
@@ -942,7 +886,6 @@
 		<description>Agent USA (cleanly cracked)</description>
 		<year>1984</year>
 		<publisher>Scholastic</publisher>
-		<sharedfeat name="compatibility" value="NEEDDATA" />
 		<!-- No compatibility data known at this time. -->
 
 		<part name="flop1" interface="floppy_5_25">
@@ -956,7 +899,6 @@
 		<description>Alphabet Circus (cleanly cracked)</description>
 		<year>1984</year>
 		<publisher>NeoSoft</publisher>
-		<sharedfeat name="compatibility" value="NEEDDATA" />
 		<!-- No compatibility data known at this time. -->
 
 		<part name="flop1" interface="floppy_5_25">
@@ -970,7 +912,6 @@
 		<description>Alice in Wonderland (cleanly cracked)</description>
 		<year>1985</year>
 		<publisher>Windham Classics</publisher>
-		<sharedfeat name="compatibility" value="NEEDDATA" />
 		<!-- No compatibility data known at this time. -->
 
 		<part name="flop1" interface="floppy_5_25">
@@ -991,7 +932,6 @@
 		<description>Algebra 2 (cleanly cracked)</description>
 		<year>1982</year>
 		<publisher>Edu-Ware</publisher>
-		<sharedfeat name="compatibility" value="NEEDDATA" />
 		<!-- No compatibility data known at this time. -->
 
 		<part name="flop1" interface="floppy_5_25">
@@ -1006,7 +946,6 @@
 		<year>1989</year>
 		<publisher>Davidson &amp; Associates, Inc.</publisher>
 		<info name="usage" value="Works with Apple II Mouse Card in slot 4: -sl4 mouse" />
-		<sharedfeat name="compatibility" value="NEEDDATA" />
 		<!-- No compatibility data known at this time. -->
 
 		<part name="flop1" interface="floppy_5_25">
@@ -1039,7 +978,6 @@
 		<description>Algernon (cleanly cracked)</description>
 		<year>1987</year>
 		<publisher>Sunburst</publisher>
-		<sharedfeat name="compatibility" value="NEEDDATA" />
 		<!-- No compatibility data known at this time. -->
 
 		<part name="flop1" interface="floppy_5_25">
@@ -1053,7 +991,6 @@
 		<description>Algebra, Volume 1 (cleanly cracked)</description>
 		<year>1984</year>
 		<publisher>Peachtree Software</publisher>
-		<sharedfeat name="compatibility" value="NEEDDATA" />
 		<!-- No compatibility data known at this time. -->
 
 		<part name="flop1" interface="floppy_5_25">
@@ -1067,7 +1004,6 @@
 		<description>Alien Addition (cleanly cracked)</description>
 		<year>1982</year>
 		<publisher>Developmental Learning Materials</publisher>
-		<sharedfeat name="compatibility" value="NEEDDATA" />
 		<!-- No compatibility data known at this time. -->
 
 		<part name="flop1" interface="floppy_5_25">
@@ -1081,7 +1017,6 @@
 		<description>American History Adventure (cleanly cracked)</description>
 		<year>1984</year>
 		<publisher>Queue Inc.</publisher>
-		<sharedfeat name="compatibility" value="NEEDDATA" />
 		<!-- No compatibility data known at this time. -->
 
 		<part name="flop1" interface="floppy_5_25">
@@ -1102,7 +1037,6 @@
 		<description>Animal Kingdom (cleanly cracked)</description>
 		<year>1985</year>
 		<publisher>Unicorn Software</publisher>
-		<sharedfeat name="compatibility" value="NEEDDATA" />
 		<!-- No compatibility data known at this time. -->
 
 		<part name="flop1" interface="floppy_5_25">
@@ -1124,7 +1058,6 @@
 		<year>1988</year>
 		<publisher>Taito America</publisher>
 		<info name="usage" value="Works with Apple II Mouse Card in slot 4: -sl4 mouse" />
-		<sharedfeat name="compatibility" value="NEEDDATA" />
 		<!-- No compatibility data known at this time. -->
 
 		<part name="flop1" interface="floppy_5_25">
@@ -1138,7 +1071,6 @@
 		<description>BallBlazer (cleanly cracked)</description>
 		<year>1985</year>
 		<publisher>Lucasfilm Games</publisher>
-		<sharedfeat name="compatibility" value="NEEDDATA" />
 		<!-- No compatibility data known at this time. -->
 
 		<part name="flop1" interface="floppy_5_25">
@@ -1152,7 +1084,6 @@
 		<description>Band Saw and Shaper Safety (cleanly cracked)</description>
 		<year>1986</year>
 		<publisher>Abraxas Basic Courseware</publisher>
-		<sharedfeat name="compatibility" value="NEEDDATA" />
 		<!-- No compatibility data known at this time. -->
 
 		<part name="flop1" interface="floppy_5_25">
@@ -1166,7 +1097,6 @@
 		<description>Basic Math Facts and Games (cleanly cracked)</description>
 		<year>1981</year>
 		<publisher>Random House</publisher>
-		<sharedfeat name="compatibility" value="NEEDDATA" />
 		<!-- No compatibility data known at this time. -->
 
 		<part name="flop1" interface="floppy_5_25">
@@ -1180,7 +1110,6 @@
 		<description>Basic Vocabulary Builder Demo (cleanly cracked)</description>
 		<year>1984</year>
 		<publisher>National Textbook Company</publisher>
-		<sharedfeat name="compatibility" value="NEEDDATA" />
 		<!-- No compatibility data known at this time. -->
 
 		<part name="flop1" interface="floppy_5_25">
@@ -1194,7 +1123,6 @@
 		<description>Beer Run (cleanly cracked)</description>
 		<year>1981</year>
 		<publisher>Sirius Software</publisher>
-		<sharedfeat name="compatibility" value="NEEDDATA" />
 		<!-- No compatibility data known at this time. -->
 
 		<part name="flop1" interface="floppy_5_25">
@@ -1208,7 +1136,6 @@
 		<description>Big Book Maker (cleanly cracked)</description>
 		<year>1992</year>
 		<publisher>Pelican Software</publisher>
-		<sharedfeat name="compatibility" value="NEEDDATA" />
 		<!-- No compatibility data known at this time. -->
 
 		<part name="flop1" interface="floppy_5_25">
@@ -1241,7 +1168,6 @@
 		<description>Bingo Bugglebee Presents: Home Alone (cleanly cracked)</description>
 		<year>1985</year>
 		<publisher>Quest Learning Systems</publisher>
-		<sharedfeat name="compatibility" value="NEEDDATA" />
 		<!-- No compatibility data known at this time. -->
 
 		<part name="flop1" interface="floppy_5_25">
@@ -1255,7 +1181,6 @@
 		<description>Bingo Bugglebee Presents: Outdoor Safety (cleanly cracked)</description>
 		<year>1985</year>
 		<publisher>Quest Learning Systems</publisher>
-		<sharedfeat name="compatibility" value="NEEDDATA" />
 		<!-- No compatibility data known at this time. -->
 
 		<part name="flop1" interface="floppy_5_25">
@@ -1269,7 +1194,6 @@
 		<description>Binomial Multiplication (cleanly cracked)</description>
 		<year>1984</year>
 		<publisher>Mindscape</publisher>
-		<sharedfeat name="compatibility" value="NEEDDATA" />
 		<!-- No compatibility data known at this time. -->
 
 		<part name="flop1" interface="floppy_5_25">
@@ -1284,7 +1208,6 @@
 		<year>1985</year>
 		<publisher>Baudville</publisher>
 		<info name="usage" value="Works with Apple II Mouse Card in slot 4: -sl4 mouse" />
-		<sharedfeat name="compatibility" value="NEEDDATA" />
 		<!-- No compatibility data known at this time. -->
 
 		<part name="flop1" interface="floppy_5_25">
@@ -1298,7 +1221,6 @@
 		<description>Bumble Games (cleanly cracked)</description>
 		<year>1982</year>
 		<publisher>The Learning Company</publisher>
-		<sharedfeat name="compatibility" value="NEEDDATA" />
 		<!-- No compatibility data known at this time. -->
 
 		<part name="flop1" interface="floppy_5_25">
@@ -1312,7 +1234,6 @@
 		<description>Boppie's Great Word Chase (cleanly cracked)</description>
 		<year>1985</year>
 		<publisher>Developmental Learning Materials</publisher>
-		<sharedfeat name="compatibility" value="NEEDDATA" />
 		<!-- No compatibility data known at this time. -->
 
 		<part name="flop1" interface="floppy_5_25">
@@ -1326,7 +1247,6 @@
 		<description>Bounce (cleanly cracked)</description>
 		<year>1988</year>
 		<publisher>Sunburst</publisher>
-		<sharedfeat name="compatibility" value="NEEDDATA" />
 		<!-- No compatibility data known at this time. -->
 
 		<part name="flop1" interface="floppy_5_25">
@@ -1340,7 +1260,6 @@
 		<description>Bridge 4.0 (cleanly cracked)</description>
 		<year>1983</year>
 		<publisher>Artworx</publisher>
-		<sharedfeat name="compatibility" value="NEEDDATA" />
 		<!-- No compatibility data known at this time. -->
 
 		<part name="flop1" interface="floppy_5_25">
@@ -1354,7 +1273,6 @@
 		<description>BurgerTime (cleanly cracked)</description>
 		<year>1982</year>
 		<publisher>Mattel Electronics</publisher>
-		<sharedfeat name="compatibility" value="NEEDDATA" />
 		<!-- No compatibility data known at this time. -->
 
 		<part name="flop1" interface="floppy_5_25">
@@ -1368,7 +1286,6 @@
 		<description>Battlezone (cleanly cracked)</description>
 		<year>1983</year>
 		<publisher>Atarisoft</publisher>
-		<sharedfeat name="compatibility" value="NEEDDATA" />
 		<!-- No compatibility data known at this time. -->
 
 		<part name="flop1" interface="floppy_5_25">
@@ -1382,7 +1299,6 @@
 		<description>California Games (cleanly cracked)</description>
 		<year>1987</year>
 		<publisher>Epyx</publisher>
-		<sharedfeat name="compatibility" value="NEEDDATA" />
 		<!-- No compatibility data known at this time. -->
 
 		<part name="flop1" interface="floppy_5_25">
@@ -1403,7 +1319,6 @@
 		<description>Calendar Skills (version 08.31.86) (cleanly cracked)</description>
 		<year>1986</year>
 		<publisher>Hartley Courseware, Inc.</publisher>
-		<sharedfeat name="compatibility" value="NEEDDATA" />
 		<!-- No compatibility data known at this time. -->
 
 		<part name="flop1" interface="floppy_5_25">
@@ -1417,7 +1332,6 @@
 		<description>Case of the Great Train Robbery (cleanly cracked)</description>
 		<year>1986</year>
 		<publisher>Troll Associates</publisher>
-		<sharedfeat name="compatibility" value="NEEDDATA" />
 		<!-- No compatibility data known at this time. -->
 
 		<part name="flop1" interface="floppy_5_25">
@@ -1431,7 +1345,6 @@
 		<description>Case of the Missing Chick (cleanly cracked)</description>
 		<year>1986</year>
 		<publisher>Troll Associates</publisher>
-		<sharedfeat name="compatibility" value="NEEDDATA" />
 		<!-- No compatibility data known at this time. -->
 
 		<part name="flop1" interface="floppy_5_25">
@@ -1445,7 +1358,6 @@
 		<description>Cat 'n Mouse (cleanly cracked)</description>
 		<year>1986</year>
 		<publisher>Mindplay</publisher>
-		<sharedfeat name="compatibility" value="NEEDDATA" />
 		<!-- No compatibility data known at this time. -->
 
 		<part name="flop1" interface="floppy_5_25">
@@ -1459,7 +1371,6 @@
 		<description>Centipede (cleanly cracked)</description>
 		<year>1983</year>
 		<publisher>Atarisoft</publisher>
-		<sharedfeat name="compatibility" value="NEEDDATA" />
 		<!-- No compatibility data known at this time. -->
 
 		<part name="flop1" interface="floppy_5_25">
@@ -1473,7 +1384,6 @@
 		<description>Curious George in Outer Space (cleanly cracked)</description>
 		<year>1989</year>
 		<publisher>Developmental Learning Materials</publisher>
-		<sharedfeat name="compatibility" value="NEEDDATA" />
 		<!-- No compatibility data known at this time. -->
 
 		<part name="flop1" interface="floppy_5_25">
@@ -1494,7 +1404,6 @@
 		<description>Curious George Goes Shopping (cleanly cracked)</description>
 		<year>1989</year>
 		<publisher>Developmental Learning Materials</publisher>
-		<sharedfeat name="compatibility" value="NEEDDATA" />
 		<!-- No compatibility data known at this time. -->
 
 		<part name="flop1" interface="floppy_5_25">
@@ -1515,7 +1424,6 @@
 		<description>Challenge Math (cleanly cracked)</description>
 		<year>1982</year>
 		<publisher>Sunburst</publisher>
-		<sharedfeat name="compatibility" value="NEEDDATA" />
 		<!-- No compatibility data known at this time. -->
 
 		<part name="flop1" interface="floppy_5_25">
@@ -1529,7 +1437,6 @@
 		<description>Charlie Brown's 1-2-3s (cleanly cracked)</description>
 		<year>1985</year>
 		<publisher>Random House</publisher>
-		<sharedfeat name="compatibility" value="NEEDDATA" />
 		<!-- No compatibility data known at this time. -->
 
 		<part name="flop1" interface="floppy_5_25">
@@ -1550,7 +1457,6 @@
 		<description>Charlie Brown's ABCs (cleanly cracked)</description>
 		<year>1984</year>
 		<publisher>Random House</publisher>
-		<sharedfeat name="compatibility" value="NEEDDATA" />
 		<!-- No compatibility data known at this time. -->
 
 		<part name="flop1" interface="floppy_5_25">
@@ -1571,7 +1477,6 @@
 		<description>Championship Lode Runner (cleanly cracked)</description>
 		<year>1984</year>
 		<publisher>Broderbund</publisher>
-		<sharedfeat name="compatibility" value="NEEDDATA" />
 		<!-- No compatibility data known at this time. -->
 
 		<part name="flop1" interface="floppy_5_25">
@@ -1585,7 +1490,6 @@
 		<description>Championship Wrestling (cleanly cracked)</description>
 		<year>1986</year>
 		<publisher>Epyx</publisher>
-		<sharedfeat name="compatibility" value="NEEDDATA" />
 		<!-- No compatibility data known at this time. -->
 
 		<part name="flop1" interface="floppy_5_25">
@@ -1606,7 +1510,6 @@
 		<description>Computer Laboratory for Calculus (cleanly cracked)</description>
 		<year>1985</year>
 		<publisher>The Math Lab</publisher>
-		<sharedfeat name="compatibility" value="NEEDDATA" />
 		<!-- No compatibility data known at this time. -->
 
 		<part name="flop1" interface="floppy_5_25">
@@ -1620,7 +1523,6 @@
 		<description>Classifying Animals with Backbones (cleanly cracked)</description>
 		<year>1985</year>
 		<publisher>D.C. Heath and Company</publisher>
-		<sharedfeat name="compatibility" value="NEEDDATA" />
 		<!-- No compatibility data known at this time. -->
 
 		<part name="flop1" interface="floppy_5_25">
@@ -1634,7 +1536,6 @@
 		<description>ClassMate (cleanly cracked)</description>
 		<year>1987</year>
 		<publisher>Davidson and Associates</publisher>
-		<sharedfeat name="compatibility" value="NEEDDATA" />
 		<!-- No compatibility data known at this time. -->
 
 		<part name="flop1" interface="floppy_5_25">
@@ -1648,7 +1549,6 @@
 		<description>Computer Literacy: Introduction (cleanly cracked)</description>
 		<year>1982</year>
 		<publisher>Control Data Corporation</publisher>
-		<sharedfeat name="compatibility" value="NEEDDATA" />
 		<!-- No compatibility data known at this time. -->
 
 		<part name="flop1" interface="floppy_5_25">
@@ -1662,7 +1562,6 @@
 		<description>Color Me (cleanly cracked)</description>
 		<year>1985</year>
 		<publisher>Mindscape</publisher>
-		<sharedfeat name="compatibility" value="NEEDDATA" />
 		<!-- No compatibility data known at this time. -->
 
 		<part name="flop1" interface="floppy_5_25">
@@ -1700,7 +1599,6 @@
 		<description>Commando (cleanly cracked)</description>
 		<year>1987</year>
 		<publisher>Data East</publisher>
-		<sharedfeat name="compatibility" value="NEEDDATA" />
 		<!-- No compatibility data known at this time. -->
 
 		<part name="flop1" interface="floppy_5_25">
@@ -1714,7 +1612,6 @@
 		<description>Compu-Read 3.4 (cleanly cracked)</description>
 		<year>1982</year>
 		<publisher>Edu-Ware Services Inc.</publisher>
-		<sharedfeat name="compatibility" value="NEEDDATA" />
 		<!-- No compatibility data known at this time. -->
 
 		<part name="flop1" interface="floppy_5_25">
@@ -1728,7 +1625,6 @@
 		<description>Conan (cleanly cracked)</description>
 		<year>1984</year>
 		<publisher>DataSoft</publisher>
-		<sharedfeat name="compatibility" value="NEEDDATA" />
 		<!-- No compatibility data known at this time. -->
 
 		<part name="flop1" interface="floppy_5_25">
@@ -1749,7 +1645,6 @@
 		<description>Cotton Tales (cleanly cracked)</description>
 		<year>1987</year>
 		<publisher>Mindplay</publisher>
-		<sharedfeat name="compatibility" value="NEEDDATA" />
 		<!-- No compatibility data known at this time. -->
 
 		<part name="flop1" interface="floppy_5_25">
@@ -1763,7 +1658,6 @@
 		<description>Creature Creator (cleanly cracked)</description>
 		<year>1983</year>
 		<publisher>DesignWare</publisher>
-		<sharedfeat name="compatibility" value="NEEDDATA" />
 		<!-- No compatibility data known at this time. -->
 
 		<part name="flop1" interface="floppy_5_25">
@@ -1777,7 +1671,6 @@
 		<description>Creation (cleanly cracked)</description>
 		<year>1988</year>
 		<publisher>Pelican Software</publisher>
-		<sharedfeat name="compatibility" value="NEEDDATA" />
 		<!-- No compatibility data known at this time. -->
 
 		<part name="flop1" interface="floppy_5_25">
@@ -1798,7 +1691,6 @@
 		<description>Crumb Eater (cleanly cracked)</description>
 		<year>1983</year>
 		<publisher>Davka Corporation</publisher>
-		<sharedfeat name="compatibility" value="NEEDDATA" />
 		<!-- No compatibility data known at this time. -->
 
 		<part name="flop1" interface="floppy_5_25">
@@ -1812,7 +1704,6 @@
 		<description>Crypto Cube (cleanly cracked)</description>
 		<year>1983</year>
 		<publisher>DesignWare</publisher>
-		<sharedfeat name="compatibility" value="NEEDDATA" />
 		<!-- No compatibility data known at this time. -->
 
 		<part name="flop1" interface="floppy_5_25">
@@ -1826,7 +1717,6 @@
 		<description>Cause and Effect: What Makes It Happen? (cleanly cracked)</description>
 		<year>1988</year>
 		<publisher>Troll Associates</publisher>
-		<sharedfeat name="compatibility" value="NEEDDATA" />
 		<!-- No compatibility data known at this time. -->
 
 		<part name="flop1" interface="floppy_5_25">
@@ -1840,7 +1730,6 @@
 		<description>Death Sword (cleanly cracked)</description>
 		<year>1988</year>
 		<publisher>Epyx</publisher>
-		<sharedfeat name="compatibility" value="NEEDDATA" />
 		<!-- No compatibility data known at this time. -->
 
 		<part name="flop1" interface="floppy_5_25">
@@ -1854,7 +1743,6 @@
 		<description>Decimal Discovery (cleanly cracked)</description>
 		<year>1986</year>
 		<publisher>Developmental Learning Materials</publisher>
-		<sharedfeat name="compatibility" value="NEEDDATA" />
 		<!-- No compatibility data known at this time. -->
 
 		<part name="flop1" interface="floppy_5_25">
@@ -1868,7 +1756,6 @@
 		<description>Decimals (ver 3.0) (cleanly cracked)</description>
 		<year>1982</year>
 		<publisher>Edu-Ware</publisher>
-		<sharedfeat name="compatibility" value="NEEDDATA" />
 		<!-- No compatibility data known at this time. -->
 
 		<part name="flop1" interface="floppy_5_25">
@@ -1882,7 +1769,6 @@
 		<description>Defender (cleanly cracked)</description>
 		<year>1983</year>
 		<publisher>Atarisoft</publisher>
-		<sharedfeat name="compatibility" value="NEEDDATA" />
 		<!-- No compatibility data known at this time. -->
 
 		<part name="flop1" interface="floppy_5_25">
@@ -1896,7 +1782,6 @@
 		<description>Delta Drawing (cleanly cracked)</description>
 		<year>1982</year>
 		<publisher>Spinnaker</publisher>
-		<sharedfeat name="compatibility" value="NEEDDATA" />
 		<!-- No compatibility data known at this time. -->
 
 		<part name="flop1" interface="floppy_5_25">
@@ -1910,7 +1795,6 @@
 		<description>Dig Dug (Atarisoft) (cleanly cracked)</description>
 		<year>1983</year>
 		<publisher>Atarisoft</publisher>
-		<sharedfeat name="compatibility" value="NEEDDATA" />
 		<!-- No compatibility data known at this time. -->
 
 		<part name="flop1" interface="floppy_5_25">
@@ -1924,7 +1808,6 @@
 		<description>Dig Dug (Thunder Mountain) (cleanly cracked)</description>
 		<year>1983</year>
 		<publisher>Thunder Mountain</publisher>
-		<sharedfeat name="compatibility" value="NEEDDATA" />
 		<!-- No compatibility data known at this time. -->
 
 		<part name="flop1" interface="floppy_5_25">
@@ -1938,7 +1821,6 @@
 		<description>Dino Dig (cleanly cracked)</description>
 		<year>1992</year>
 		<publisher>Troll Associates</publisher>
-		<sharedfeat name="compatibility" value="NEEDDATA" />
 		<!-- No compatibility data known at this time. -->
 
 		<part name="flop1" interface="floppy_5_25">
@@ -1952,7 +1834,6 @@
 		<description>Dino Eggs (cleanly cracked)</description>
 		<year>1983</year>
 		<publisher>Micro Fun</publisher>
-		<sharedfeat name="compatibility" value="NEEDDATA" />
 		<!-- No compatibility data known at this time. -->
 
 		<part name="flop1" interface="floppy_5_25">
@@ -1966,7 +1847,6 @@
 		<description>Dinosaurs (cleanly cracked)</description>
 		<year>1984</year>
 		<publisher>Advanced Ideas, Inc.</publisher>
-		<sharedfeat name="compatibility" value="NEEDDATA" />
 		<!-- No compatibility data known at this time. -->
 
 		<part name="flop1" interface="floppy_5_25">
@@ -1980,7 +1860,6 @@
 		<description>Dive Bomber (cleanly cracked)</description>
 		<year>1988</year>
 		<publisher>Acme Animation, Inc.</publisher>
-		<sharedfeat name="compatibility" value="NEEDDATA" />
 		<!-- No compatibility data known at this time. -->
 
 		<part name="flop1" interface="floppy_5_25">
@@ -1994,7 +1873,6 @@
 		<description>Donkey Kong (cleanly cracked)</description>
 		<year>1983</year>
 		<publisher>Atarisoft</publisher>
-		<sharedfeat name="compatibility" value="NEEDDATA" />
 		<!-- No compatibility data known at this time. -->
 
 		<part name="flop1" interface="floppy_5_25">
@@ -2008,7 +1886,6 @@
 		<description>Dunzhin (cleanly cracked)</description>
 		<year>1982</year>
 		<publisher>Screenplay</publisher>
-		<sharedfeat name="compatibility" value="NEEDDATA" />
 		<!-- No compatibility data known at this time. -->
 
 		<part name="flop1" interface="floppy_5_25">
@@ -2022,7 +1899,6 @@
 		<description>Dyno-Quest (cleanly cracked)</description>
 		<year>1984</year>
 		<publisher>Mindplay</publisher>
-		<sharedfeat name="compatibility" value="NEEDDATA" />
 		<!-- No compatibility data known at this time. -->
 
 		<part name="flop1" interface="floppy_5_25">
@@ -2036,7 +1912,6 @@
 		<description>Design Your Own Home: Architectural Design (cleanly cracked)</description>
 		<year>1984</year>
 		<publisher>Avant-Garde Publishing Corp.</publisher>
-		<sharedfeat name="compatibility" value="NEEDDATA" />
 		<!-- No compatibility data known at this time. -->
 
 		<part name="flop1" interface="floppy_5_25">
@@ -2063,7 +1938,6 @@
 		<description>Design Your Own Home: Architectural (cleanly cracked)</description>
 		<year>1983</year>
 		<publisher>Avant-Garde Publishing Corp.</publisher>
-		<sharedfeat name="compatibility" value="NEEDDATA" />
 		<!-- No compatibility data known at this time. -->
 
 		<part name="flop1" interface="floppy_5_25">
@@ -2077,7 +1951,6 @@
 		<description>Design Your Own Home: Interior Design (cleanly cracked)</description>
 		<year>1986</year>
 		<publisher>Avant-Garde Publishing Corp.</publisher>
-		<sharedfeat name="compatibility" value="NEEDDATA" />
 		<!-- No compatibility data known at this time. -->
 
 		<part name="flop1" interface="floppy_5_25">
@@ -2104,7 +1977,6 @@
 		<description>Easy as ABC (cleanly cracked)</description>
 		<year>1984</year>
 		<publisher>Springboard Software</publisher>
-		<sharedfeat name="compatibility" value="NEEDDATA" />
 		<!-- No compatibility data known at this time. -->
 
 		<part name="flop1" interface="floppy_5_25">
@@ -2118,7 +1990,6 @@
 		<description>Easy Reader Demo (cleanly cracked)</description>
 		<year>1983</year>
 		<publisher>American Educational Computer, Inc.</publisher>
-		<sharedfeat name="compatibility" value="NEEDDATA" />
 		<!-- No compatibility data known at this time. -->
 
 		<part name="flop1" interface="floppy_5_25">
@@ -2151,7 +2022,6 @@
 		<description>Easy Street (cleanly cracked)</description>
 		<year>1988</year>
 		<publisher>Mindplay</publisher>
-		<sharedfeat name="compatibility" value="NEEDDATA" />
 		<!-- No compatibility data known at this time. -->
 
 		<part name="flop1" interface="floppy_5_25">
@@ -2166,7 +2036,6 @@
 		<year>1986</year>
 		<publisher>Polarware</publisher>
 		<info name="usage" value="Works with Apple II Mouse Card in slot 4: -sl4 mouse" />
-		<sharedfeat name="compatibility" value="NEEDDATA" />
 		<!-- No compatibility data known at this time. -->
 
 		<part name="flop1" interface="floppy_5_25">
@@ -2180,7 +2049,6 @@
 		<description>Edu-Calc (cleanly cracked)</description>
 		<year>1985</year>
 		<publisher>Grolier</publisher>
-		<sharedfeat name="compatibility" value="NEEDDATA" />
 		<!-- No compatibility data known at this time. -->
 
 		<part name="flop1" interface="floppy_5_25">
@@ -2201,7 +2069,6 @@
 		<description>Early Games for Young Children (cleanly cracked)</description>
 		<year>1982</year>
 		<publisher>Springboard</publisher>
-		<sharedfeat name="compatibility" value="NEEDDATA" />
 		<!-- No compatibility data known at this time. -->
 
 		<part name="flop1" interface="floppy_5_25">
@@ -2215,7 +2082,6 @@
 		<description>European Nations and Locations (cleanly cracked)</description>
 		<year>1985</year>
 		<publisher>DesignWare, Inc.</publisher>
-		<sharedfeat name="compatibility" value="NEEDDATA" />
 		<!-- No compatibility data known at this time. -->
 
 		<part name="flop1" interface="floppy_5_25">
@@ -2229,7 +2095,6 @@
 		<description>Exploring Science: Temperature (cleanly cracked)</description>
 		<year>1988</year>
 		<publisher>Sunburst</publisher>
-		<sharedfeat name="compatibility" value="NEEDDATA" />
 		<!-- No compatibility data known at this time. -->
 
 		<part name="flop1" interface="floppy_5_25">
@@ -2243,7 +2108,6 @@
 		<description>First Degree Linear Equations (cleanly cracked)</description>
 		<year>1984</year>
 		<publisher>Mindscape</publisher>
-		<sharedfeat name="compatibility" value="NEEDDATA" />
 		<!-- No compatibility data known at this time. -->
 
 		<part name="flop1" interface="floppy_5_25">
@@ -2257,7 +2121,6 @@
 		<description>Facemaker (cleanly cracked)</description>
 		<year>1982</year>
 		<publisher>Spinnaker</publisher>
-		<sharedfeat name="compatibility" value="NEEDDATA" />
 		<!-- No compatibility data known at this time. -->
 
 		<part name="flop1" interface="floppy_5_25">
@@ -2271,7 +2134,6 @@
 		<description>Falcons (cleanly cracked)</description>
 		<year>1981</year>
 		<publisher>Piccadilly Software</publisher>
-		<sharedfeat name="compatibility" value="NEEDDATA" />
 		<!-- No compatibility data known at this time. -->
 
 		<part name="flop1" interface="floppy_5_25">
@@ -2285,7 +2147,6 @@
 		<description>Professor Davensteev's Fantasy Land (Red Level) (cleanly cracked)</description>
 		<year>1983</year>
 		<publisher>Learning Well / Methods &amp; Solutions</publisher>
-		<sharedfeat name="compatibility" value="NEEDDATA" />
 		<!-- No compatibility data known at this time. -->
 
 		<part name="flop1" interface="floppy_5_25">
@@ -2299,7 +2160,6 @@
 		<description>Factoring Algebraic Expressions (cleanly cracked)</description>
 		<year>1984</year>
 		<publisher>Mindscape</publisher>
-		<sharedfeat name="compatibility" value="NEEDDATA" />
 		<!-- No compatibility data known at this time. -->
 
 		<part name="flop1" interface="floppy_5_25">
@@ -2313,7 +2173,6 @@
 		<description>Financial Facts (cleanly cracked)</description>
 		<year>1981</year>
 		<publisher>Advanced Operating Systems</publisher>
-		<sharedfeat name="compatibility" value="NEEDDATA" />
 		<!-- No compatibility data known at this time. -->
 
 		<part name="flop1" interface="floppy_5_25">
@@ -2327,7 +2186,6 @@
 		<description>Flash Spell Helicopter (cleanly cracked)</description>
 		<year>1983</year>
 		<publisher>Microcomputer Workships Courseware</publisher>
-		<sharedfeat name="compatibility" value="NEEDDATA" />
 		<!-- No compatibility data known at this time. -->
 
 		<part name="flop1" interface="floppy_5_25">
@@ -2341,7 +2199,6 @@
 		<description>Flying Colors (cleanly cracked)</description>
 		<year>1983</year>
 		<publisher>The Computer Colorworks</publisher>
-		<sharedfeat name="compatibility" value="NEEDDATA" />
 		<!-- No compatibility data known at this time. -->
 
 		<part name="flop1" interface="floppy_5_25">
@@ -2355,7 +2212,6 @@
 		<description>Force and Motion (cleanly cracked)</description>
 		<year>1990</year>
 		<publisher>Queue, Inc.</publisher>
-		<sharedfeat name="compatibility" value="NEEDDATA" />
 		<!-- No compatibility data known at this time. -->
 
 		<part name="flop1" interface="floppy_5_25">
@@ -2376,7 +2232,6 @@
 		<description>FOR Your NEXT Adventure: FOR-NEXT Loops (cleanly cracked)</description>
 		<year>1985</year>
 		<publisher>Sunburst</publisher>
-		<sharedfeat name="compatibility" value="NEEDDATA" />
 		<!-- No compatibility data known at this time. -->
 
 		<part name="flop1" interface="floppy_5_25">
@@ -2390,7 +2245,6 @@
 		<description>Fraction-oids (cleanly cracked)</description>
 		<year>1989</year>
 		<publisher>Mindplay</publisher>
-		<sharedfeat name="compatibility" value="NEEDDATA" />
 		<!-- No compatibility data known at this time. -->
 
 		<part name="flop1" interface="floppy_5_25">
@@ -2404,7 +2258,6 @@
 		<description>Fractions II (cleanly cracked)</description>
 		<year>1987</year>
 		<publisher>Silver Burdett Company</publisher>
-		<sharedfeat name="compatibility" value="NEEDDATA" />
 		<!-- No compatibility data known at this time. -->
 
 		<part name="flop1" interface="floppy_5_25">
@@ -2418,7 +2271,6 @@
 		<description>Fraction Tutorial (cleanly cracked)</description>
 		<year>19??</year>
 		<publisher>Opportunities For Learning</publisher>
-		<sharedfeat name="compatibility" value="NEEDDATA" />
 		<!-- No compatibility data known at this time. -->
 
 		<part name="flop1" interface="floppy_5_25">
@@ -2439,7 +2291,6 @@
 		<description>Freddy's Puzzling Adventures (cleanly cracked)</description>
 		<year>1984</year>
 		<publisher>Developmental Learning Materials</publisher>
-		<sharedfeat name="compatibility" value="NEEDDATA" />
 		<!-- No compatibility data known at this time. -->
 
 		<part name="flop1" interface="floppy_5_25">
@@ -2453,7 +2304,6 @@
 		<description>French Vocabulary Builder (cleanly cracked)</description>
 		<year>1982</year>
 		<publisher>Control Data Corporation</publisher>
-		<sharedfeat name="compatibility" value="NEEDDATA" />
 		<!-- No compatibility data known at this time. -->
 
 		<part name="flop1" interface="floppy_5_25">
@@ -2467,7 +2317,6 @@
 		<description>Frogs, Dogs, Kittens, and Kids 1 (cleanly cracked)</description>
 		<year>1988</year>
 		<publisher>Hartley Courseware</publisher>
-		<sharedfeat name="compatibility" value="NEEDDATA" />
 		<!-- No compatibility data known at this time. -->
 
 		<part name="flop1" interface="floppy_5_25">
@@ -2494,7 +2343,6 @@
 		<description>Frogger II: Threedeep (cleanly cracked)</description>
 		<year>1984</year>
 		<publisher>Sega Enterprises Inc.</publisher>
-		<sharedfeat name="compatibility" value="NEEDDATA" />
 		<!-- No compatibility data known at this time. -->
 
 		<part name="flop1" interface="floppy_5_25">
@@ -2508,7 +2356,6 @@
 		<description>Frogger (cleanly cracked)</description>
 		<year>1981</year>
 		<publisher>Sierra On-Line</publisher>
-		<sharedfeat name="compatibility" value="NEEDDATA" />
 		<!-- No compatibility data known at this time. -->
 
 		<part name="flop1" interface="floppy_5_25">
@@ -2522,7 +2369,6 @@
 		<description>Frog Jump Ordering Numbers (cleanly cracked)</description>
 		<year>1985</year>
 		<publisher>Scott, Foresman and Company</publisher>
-		<sharedfeat name="compatibility" value="NEEDDATA" />
 		<!-- No compatibility data known at this time. -->
 
 		<part name="flop1" interface="floppy_5_25">
@@ -2536,7 +2382,6 @@
 		<description>Galaxian (Atarisoft) (cleanly cracked)</description>
 		<year>1983</year>
 		<publisher>Atarisoft</publisher>
-		<sharedfeat name="compatibility" value="NEEDDATA" />
 		<!-- No compatibility data known at this time. -->
 
 		<part name="flop1" interface="floppy_5_25">
@@ -2550,7 +2395,6 @@
 		<description>Galaxian (Thunder Mountain) (cleanly cracked)</description>
 		<year>1983</year>
 		<publisher>Thunder Mountain</publisher>
-		<sharedfeat name="compatibility" value="NEEDDATA" />
 		<!-- No compatibility data known at this time. -->
 
 		<part name="flop1" interface="floppy_5_25">
@@ -2564,7 +2408,6 @@
 		<description>Garfield Eat Your Words (cleanly cracked)</description>
 		<year>1985</year>
 		<publisher>Random House</publisher>
-		<sharedfeat name="compatibility" value="NEEDDATA" />
 		<!-- No compatibility data known at this time. -->
 
 		<part name="flop1" interface="floppy_5_25">
@@ -2585,7 +2428,6 @@
 		<description>Gene Machine (version 2.0) (cleanly cracked)</description>
 		<year>1983</year>
 		<publisher>HRM Software</publisher>
-		<sharedfeat name="compatibility" value="NEEDDATA" />
 		<!-- No compatibility data known at this time. -->
 
 		<part name="flop1" interface="floppy_5_25">
@@ -2599,7 +2441,6 @@
 		<description>Gertrude's Secrets (version 1.2) (cleanly cracked)</description>
 		<year>1982</year>
 		<publisher>The Learning Company</publisher>
-		<sharedfeat name="compatibility" value="NEEDDATA" />
 		<!-- No compatibility data known at this time. -->
 
 		<part name="flop1" interface="floppy_5_25">
@@ -2613,7 +2454,6 @@
 		<description>Grammar Gremlins (cleanly cracked)</description>
 		<year>1986</year>
 		<publisher>Davidson &amp; Associates, Inc.</publisher>
-		<sharedfeat name="compatibility" value="NEEDDATA" />
 		<!-- No compatibility data known at this time. -->
 
 		<part name="flop1" interface="floppy_5_25">
@@ -2634,7 +2474,6 @@
 		<description>Grammar Mastery II (cleanly cracked)</description>
 		<year>1987</year>
 		<publisher>American Language Academy</publisher>
-		<sharedfeat name="compatibility" value="NEEDDATA" />
 		<!-- No compatibility data known at this time. -->
 
 		<part name="flop1" interface="floppy_5_25">
@@ -2745,7 +2584,6 @@
 		<description>Greeting Card Maker (cleanly cracked)</description>
 		<year>1986</year>
 		<publisher>Activision</publisher>
-		<sharedfeat name="compatibility" value="NEEDDATA" />
 		<!-- No compatibility data known at this time. -->
 
 		<part name="flop1" interface="floppy_5_25">
@@ -2759,7 +2597,6 @@
 		<description>Gremlins (cleanly cracked)</description>
 		<year>1984</year>
 		<publisher>Atarisoft</publisher>
-		<sharedfeat name="compatibility" value="NEEDDATA" />
 		<!-- No compatibility data known at this time. -->
 
 		<part name="flop1" interface="floppy_5_25">
@@ -2773,7 +2610,6 @@
 		<description>Graphing Linear Functions (cleanly cracked)</description>
 		<year>1984</year>
 		<publisher>Microcomputer Workshops Courseware</publisher>
-		<sharedfeat name="compatibility" value="NEEDDATA" />
 		<!-- No compatibility data known at this time. -->
 
 		<part name="flop1" interface="floppy_5_25">
@@ -2787,7 +2623,6 @@
 		<description>Gulf Strike (cleanly cracked)</description>
 		<year>1985</year>
 		<publisher>The Avalon Hill Game Company</publisher>
-		<sharedfeat name="compatibility" value="NEEDDATA" />
 		<!-- No compatibility data known at this time. -->
 
 		<part name="flop1" interface="floppy_5_25">
@@ -2802,7 +2637,6 @@
 		<!-- Corrected image 09/24/2016 -->
 		<year>1983</year>
 		<publisher>Broderbund</publisher>
-		<sharedfeat name="compatibility" value="NEEDDATA" />
 		<!-- No compatibility data known at this time. -->
 
 		<part name="flop1" interface="floppy_5_25">
@@ -2816,7 +2650,6 @@
 		<description>Heredity Dog (cleanly cracked)</description>
 		<year>1983</year>
 		<publisher>HRM Software</publisher>
-		<sharedfeat name="compatibility" value="NEEDDATA" />
 		<!-- No compatibility data known at this time. -->
 
 		<part name="flop1" interface="floppy_5_25">
@@ -2830,7 +2663,6 @@
 		<description>Hey Diddle Diddle (cleanly cracked)</description>
 		<year>1983</year>
 		<publisher>Spinnaker</publisher>
-		<sharedfeat name="compatibility" value="NEEDDATA" />
 		<!-- No compatibility data known at this time. -->
 
 		<part name="flop1" interface="floppy_5_25">
@@ -2844,7 +2676,6 @@
 		<description>Homework Helper: Writing (cleanly cracked)</description>
 		<year>1985</year>
 		<publisher>Spinnaker</publisher>
-		<sharedfeat name="compatibility" value="NEEDDATA" />
 		<!-- No compatibility data known at this time. -->
 
 		<part name="flop1" interface="floppy_5_25">
@@ -2889,7 +2720,6 @@
 		<description>Homework Writer (cleanly cracked)</description>
 		<year>1988</year>
 		<publisher>Scholastic, Inc.</publisher>
-		<sharedfeat name="compatibility" value="NEEDDATA" />
 		<!-- No compatibility data known at this time. -->
 
 		<part name="flop1" interface="floppy_5_25">
@@ -2910,7 +2740,6 @@
 		<description>House-A-Fire! (cleanly cracked)</description>
 		<year>1988</year>
 		<publisher>Decision Development Co</publisher>
-		<sharedfeat name="compatibility" value="NEEDDATA" />
 		<!-- No compatibility data known at this time. -->
 
 		<part name="flop1" interface="floppy_5_25">
@@ -2931,7 +2760,6 @@
 		<description>How The West Was One + Three x Four (cleanly cracked)</description>
 		<year>1987</year>
 		<publisher>Sunburst</publisher>
-		<sharedfeat name="compatibility" value="NEEDDATA" />
 		<!-- No compatibility data known at this time. -->
 
 		<part name="flop1" interface="floppy_5_25">
@@ -2945,7 +2773,6 @@
 		<description>Impossible Mission II (cleanly cracked)</description>
 		<year>1988</year>
 		<publisher>Epyx</publisher>
-		<sharedfeat name="compatibility" value="NEEDDATA" />
 		<!-- No compatibility data known at this time. -->
 
 		<part name="flop1" interface="floppy_5_25">
@@ -2966,7 +2793,6 @@
 		<description>Investigating Secondary Mathematics with Computers (cleanly cracked)</description>
 		<year>1985</year>
 		<publisher>University of Massachusetts</publisher>
-		<sharedfeat name="compatibility" value="NEEDDATA" />
 		<!-- No compatibility data known at this time. -->
 
 		<part name="flop1" interface="floppy_5_25">
@@ -2987,7 +2813,6 @@
 		<description>Jack and the Beanstalk (cleanly cracked)</description>
 		<year>1985</year>
 		<publisher>HRM Software</publisher>
-		<sharedfeat name="compatibility" value="NEEDDATA" />
 		<!-- No compatibility data known at this time. -->
 
 		<part name="flop1" interface="floppy_5_25">
@@ -3001,7 +2826,6 @@
 		<description>Jumping Math Flash (cleanly cracked)</description>
 		<year>1988</year>
 		<publisher>Mindscape</publisher>
-		<sharedfeat name="compatibility" value="NEEDDATA" />
 		<!-- No compatibility data known at this time. -->
 
 		<part name="flop1" interface="floppy_5_25">
@@ -3015,7 +2839,6 @@
 		<description>Jumpman (cleanly cracked)</description>
 		<year>1983</year>
 		<publisher>Epyx</publisher>
-		<sharedfeat name="compatibility" value="NEEDDATA" />
 		<!-- No compatibility data known at this time. -->
 
 		<part name="flop1" interface="floppy_5_25">
@@ -3036,7 +2859,6 @@
 		<description>Jungle Hunt (cleanly cracked)</description>
 		<year>1984</year>
 		<publisher>Atarisoft</publisher>
-		<sharedfeat name="compatibility" value="NEEDDATA" />
 		<!-- No compatibility data known at this time. -->
 
 		<part name="flop1" interface="floppy_5_25">
@@ -3050,7 +2872,6 @@
 		<description>Ken Uston's Professional Blackjack (v1.23) (cleanly cracked)</description>
 		<year>1983</year>
 		<publisher>Intelligent Statements, Inc.</publisher>
-		<sharedfeat name="compatibility" value="NEEDDATA" />
 		<!-- No compatibility data known at this time. -->
 
 		<part name="flop1" interface="floppy_5_25">
@@ -3064,7 +2885,6 @@
 		<description>Kids on Keys (cleanly cracked)</description>
 		<year>1983</year>
 		<publisher>Spinnaker</publisher>
-		<sharedfeat name="compatibility" value="NEEDDATA" />
 		<!-- No compatibility data known at this time. -->
 
 		<part name="flop1" interface="floppy_5_25">
@@ -3078,7 +2898,6 @@
 		<description>Kindercomp (cleanly cracked)</description>
 		<year>1983</year>
 		<publisher>Spinnaker</publisher>
-		<sharedfeat name="compatibility" value="NEEDDATA" />
 		<!-- No compatibility data known at this time. -->
 
 		<part name="flop1" interface="floppy_5_25">
@@ -3092,7 +2911,6 @@
 		<description>Kittens, Kids, and a Frog (version 01.11.85) (cleanly cracked)</description>
 		<year>1985</year>
 		<publisher>Hartley Courseware, Inc.</publisher>
-		<sharedfeat name="compatibility" value="NEEDDATA" />
 		<!-- No compatibility data known at this time. -->
 
 		<part name="flop1" interface="floppy_5_25">
@@ -3113,7 +2931,6 @@
 		<description>Knowledge Master World History 1 (cleanly cracked)</description>
 		<year>1987</year>
 		<publisher>Academic Hallmarks</publisher>
-		<sharedfeat name="compatibility" value="NEEDDATA" />
 		<!-- No compatibility data known at this time. -->
 
 		<part name="flop1" interface="floppy_5_25">
@@ -3127,7 +2944,6 @@
 		<description>Krell's Logo (cleanly cracked)</description>
 		<year>1981</year>
 		<publisher>Krell</publisher>
-		<sharedfeat name="compatibility" value="NEEDDATA" />
 		<!-- No compatibility data known at this time. -->
 
 		<part name="flop1" interface="floppy_5_25">
@@ -3141,7 +2957,6 @@
 		<description>A Treasure Hunt of Facts (clealy cracked) - addition and subtraction</description>
 		<year>1984</year>
 		<publisher>Josten Learning Systems</publisher>
-		<sharedfeat name="compatibility" value="NEEDDATA" />
 		<!-- No compatibility data known at this time. -->
 
 		<part name="flop1" interface="floppy_5_25">
@@ -3176,7 +2991,6 @@
 		<year>1986</year>
 		<publisher>Sunburst Communications</publisher>
 		<info name="release" value="2016-03-06"/>
-		<sharedfeat name="compatibility" value="NEEDDATA" />
 		<!-- No compatibility data known at this time. -->
 
 		<part name="flop1" interface="floppy_5_25">

--- a/src/mame/machine/sgi.cpp
+++ b/src/mame/machine/sgi.cpp
@@ -576,7 +576,7 @@ WRITE32_MEMBER( sgi_mc_device::write )
 	case 0x0168/4:
 		LOGMASKED(LOG_WRITES | LOG_DMA, "%s: DMA Control Write: %08x & %08x\n", machine().describe_context(), data, mem_mask);
 		m_dma_control = data;
-		if (!BIT(m_dma_control, 4))
+		if (!BIT(m_dma_control, 4) && m_hpc3)
 		{
 			m_hpc3->lower_local_irq(3, 1 << 4);
 		}


### PR DESCRIPTION
* Added some clean cracks.
* Fixed casing and names in a number of places.
* Added placeholder compatibility.

Additionally, should have finally fixed (once and for all, hopefully) the tab-spaces conversion that MULTIPLE of my text editors were hiding from me.