### PR TITLE
gaelco2.cpp: Fix some "saltcrdi" ROM sizes (nw)

### DIFF
--- a/src/mame/drivers/gaelco2.cpp
+++ b/src/mame/drivers/gaelco2.cpp
@@ -514,10 +514,10 @@ ROM_START( saltcrdi ) // REF 970410
 	ROM_FILL(                              0x0220000, 0x0020000, 0x00 )         /* to decode GFX as 5bpp */
 
 	ROM_REGION( 0x0800, "iomcu", 0 ) // on IO board
-	ROM_LOAD( "st62t15c6",   0x0800, 0x1000, NO_DUMP ) // 2KBytes internal ROM
+	ROM_LOAD( "st62t15c6", 0x0000, 0x0800, NO_DUMP ) // 2KBytes internal ROM
 
-	ROM_REGION( 0x104, "pals", 0 )
-	ROM_LOAD( "6.pal16l8.u12",   0x0000, 0x104, NO_DUMP )
+	ROM_REGION( 0x0104, "pals", 0 )
+	ROM_LOAD( "6.pal16l8.u12", 0x0000, 0x0104, NO_DUMP )
 ROM_END
 
 

--- a/src/mame/drivers/gaelco2.cpp
+++ b/src/mame/drivers/gaelco2.cpp
@@ -513,11 +513,11 @@ ROM_START( saltcrdi ) // REF 970410
 	ROM_LOAD( "bi-41-bank1-27c1001.u41",   0x01a0000, 0x0020000, CRC(c4d24254) SHA1(e6ff7624e628dc6ace11a50b6ff89812844b52c5) )
 	ROM_FILL(                              0x0220000, 0x0020000, 0x00 )         /* to decode GFX as 5bpp */
 
-	ROM_REGION( 0x1000, "iomcu", 0 ) // on IO board
-	ROM_LOAD( "st62t15c6",   0x0000, 0x1000, NO_DUMP ) // size?
+	ROM_REGION( 0x0800, "iomcu", 0 ) // on IO board
+	ROM_LOAD( "st62t15c6",   0x0800, 0x1000, NO_DUMP ) // 2KBytes internal ROM
 
-	ROM_REGION( 0x100, "pals", 0 )
-	ROM_LOAD( "6.pal16l8.u12",   0x0000, 0x100, NO_DUMP ) // size?
+	ROM_REGION( 0x104, "pals", 0 )
+	ROM_LOAD( "6.pal16l8.u12",   0x0000, 0x104, NO_DUMP )
 ROM_END
 
 


### PR DESCRIPTION
Also, maybe we should remove the sound hardware mapping and add the MACHINE_NO_SOUND_HW flag, since the PCB has no sound hardware.