### PR TITLE
video throttling: Sleep even when frameskipping

### DIFF
--- a/src/emu/video.cpp
+++ b/src/emu/video.cpp
@@ -1037,7 +1037,7 @@ osd_ticks_t video_manager::throttle_until_ticks(osd_ticks_t target_ticks)
 {
 	// we're allowed to sleep via the OSD code only if we're configured to do so
 	// and we're not frameskipping due to autoframeskip, or if we're paused
-	bool const allowed_to_sleep = (machine().options().sleep() && (!effective_autoframeskip() || effective_frameskip() == 0)) || machine().paused();
+	bool const allowed_to_sleep = machine().options().sleep() || machine().paused();
 
 	// loop until we reach our target
 	g_profiler.start(PROFILER_IDLE);


### PR DESCRIPTION
I do not expect this PR to be merged right away as there might be a good reason for the things being done the way they are.

But I find it pretty odd that the video throttling wouldn't sleep when the frameskip level isn't 0. It's not that we try to run as fast as possible since we just switch to busy waiting in this case. Moreover, if MAME is too slow because other processes on the system need some CPU time, it might be better to give some by actually sleeping. This should make the kernel scheduler less likely to preempt MAME when it's running useful code.

Although I didn't find a statistically significant improvement to the average frameskip level, it halve the number of resync on my old computer, making it feel smoother.

On 3 runs of 300 seconds of tgm2p with the current code I got 1201, 1310 and 1224 resync. With this patch I got 618, 472 and 746 resync.