### PR TITLE
Video throttling: Additive oversleeping

### DIFF
--- a/src/emu/video.cpp
+++ b/src/emu/video.cpp
@@ -1045,7 +1045,11 @@ osd_ticks_t video_manager::throttle_until_ticks(osd_ticks_t target_ticks)
 	while (current_ticks < target_ticks)
 	{
 		// compute how much time to sleep for, taking into account the average oversleep
-		osd_ticks_t const delta = (target_ticks - current_ticks) * 1000 / (1000 + m_average_oversleep);
+		osd_ticks_t delta = target_ticks - current_ticks;
+		if (delta > m_average_oversleep / 1000)
+			delta -= m_average_oversleep / 1000;
+		else
+			delta = 0;
 
 		// see if we can sleep
 		bool const slept = allowed_to_sleep && delta;
@@ -1062,8 +1066,8 @@ osd_ticks_t video_manager::throttle_until_ticks(osd_ticks_t target_ticks)
 			osd_ticks_t const actual_ticks = new_ticks - current_ticks;
 			if (actual_ticks > delta)
 			{
-				// take 90% of the previous average plus 10% of the new value
-				osd_ticks_t const oversleep_milliticks = 1000 * (actual_ticks - delta) / delta;
+				// take 99% of the previous average plus 1% of the new value
+				osd_ticks_t const oversleep_milliticks = 1000 * (actual_ticks - delta);
 				m_average_oversleep = (m_average_oversleep * 99 + oversleep_milliticks) / 100;
 
 				if (LOG_THROTTLE)


### PR DESCRIPTION
There might be a good reason for the code being the way it is. If so, feel free to discard this PR.

Currently, the video throttling code compensate for oversleep by multiplying the wanted sleep time by some averaged oversleep value. Which seems a bit weird to me.

Here is a plot of how much the SDL OSD oversleep with respect to the sleep duration requested. Each dot is a call to `osd_sleep`, the x coordinate is the argument to `osd_sleep`, the y coordinate is the measured duration. The overlseep duration clearly seems to be independant from the requested sleep duration.

![oversleep](https://user-images.githubusercontent.com/6136274/52817831-58db1280-30a5-11e9-8b51-70f85d492d59.png)

Here is a plot of how long `osd_sleep` lasts with the multiplicative correction (`actual_ticks`) vs. how long we want it to last (`current_ticks - target_ticks`).

![oversleep-multiplicative](https://user-images.githubusercontent.com/6136274/52818984-72318e00-30a8-11e9-8603-1a2adc89302d.png)

It almost always undersleep (then loop and sleep again), but oversleep for small durations because of the additive oversleep. The longer the target sleep time, the more it undersleep. Suggesting the multiplicative correction is not very good.

And here is the same plot with the patch I propose here. Most of the time, it neither oversleep or undersleep.
![oversleep-additive](https://user-images.githubusercontent.com/6136274/52819317-52e73080-30a9-11e9-810d-61c28d0b8a24.png)
