### PR TITLE
ay8910.cpp : Updates

### DIFF
--- a/src/devices/bus/a2bus/a2arcadebd.cpp
+++ b/src/devices/bus/a2bus/a2arcadebd.cpp
@@ -97,7 +97,7 @@ uint8_t a2bus_arcboard_device::read_c0nx(uint8_t offset)
 			return m_tms->register_read();
 
 		case 6:
-			return m_ay->read_data();
+			return m_ay->data_r();
 	}
 
 	return 0xff;
@@ -118,11 +118,11 @@ void a2bus_arcboard_device::write_c0nx(uint8_t offset, uint8_t data)
 			break;
 
 		case 5:
-			m_ay->write_address(data);
+			m_ay->address_w(data);
 			break;
 
 		case 6:
-			m_ay->write_data(data);
+			m_ay->data_w(data);
 			break;
 	}
 }

--- a/src/devices/bus/a2bus/a2mockingboard.cpp
+++ b/src/devices/bus/a2bus/a2mockingboard.cpp
@@ -238,7 +238,7 @@ WRITE8_MEMBER( a2bus_ayboard_device::via1_out_b )
 {
 	if (!BIT(data, 2))
 	{
-		m_ay1->reset_w(space, 0, 0);
+		m_ay1->reset_w();
 	}
 	else
 	{
@@ -248,15 +248,15 @@ WRITE8_MEMBER( a2bus_ayboard_device::via1_out_b )
 				break;
 
 			case 1: // BDIR=0, BC1=1 (read PSG)
-				m_porta1 = m_ay1->read_data();
+				m_porta1 = m_ay1->data_r();
 				break;
 
 			case 2: // BDIR=1, BC1=0 (write PSG)
-				m_ay1->write_data(m_porta1);
+				m_ay1->data_w(m_porta1);
 				break;
 
 			case 3: // BDIR=1, BC1=1 (latch)
-				m_ay1->write_address(m_porta1);
+				m_ay1->address_w(m_porta1);
 				break;
 		}
 	}
@@ -266,10 +266,10 @@ WRITE8_MEMBER( a2bus_phasor_device::via1_out_b )
 {
 	if (!(data & 4))
 	{
-		m_ay1->reset_w(space, 0, 0);
+		m_ay1->reset_w();
 		if (m_native)
 		{
-			m_ay2->reset_w(space, 0, 0);
+			m_ay2->reset_w();
 		}
 	}
 	else
@@ -289,23 +289,23 @@ WRITE8_MEMBER( a2bus_phasor_device::via1_out_b )
 
 			case 1: // BDIR=0, BC1=1 (read PSG)
 				if (BIT(chip_sel, 0))
-					m_porta1 = m_ay1->read_data();
+					m_porta1 = m_ay1->data_r();
 				if (BIT(chip_sel, 1))
-					m_porta1 = m_ay2->read_data();
+					m_porta1 = m_ay2->data_r();
 				break;
 
 			case 2: // BDIR=1, BC1=0 (write PSG)
 				if (BIT(chip_sel, 0))
-					m_ay1->write_data(m_porta1);
+					m_ay1->data_w(m_porta1);
 				if (BIT(chip_sel, 1))
-					m_ay2->write_data(m_porta1);
+					m_ay2->data_w(m_porta1);
 				break;
 
 			case 3: // BDIR=1, BC1=1 (latch)
 				if (BIT(chip_sel, 0))
-					m_ay1->write_address(m_porta1);
+					m_ay1->address_w(m_porta1);
 				if (BIT(chip_sel, 1))
-					m_ay2->write_address(m_porta1);
+					m_ay2->address_w(m_porta1);
 				break;
 		}
 	}
@@ -320,7 +320,7 @@ WRITE8_MEMBER( a2bus_ayboard_device::via2_out_b )
 {
 	if (!BIT(data, 2))
 	{
-		m_ay2->reset_w(space, 0, 0);
+		m_ay2->reset_w();
 	}
 	else
 	{
@@ -330,15 +330,15 @@ WRITE8_MEMBER( a2bus_ayboard_device::via2_out_b )
 				break;
 
 			case 1: // BDIR=0, BC1=1 (read PSG)
-				m_porta2 = m_ay2->read_data();
+				m_porta2 = m_ay2->data_r();
 				break;
 
 			case 2: // BDIR=1, BC1=0 (write PSG)
-				m_ay2->write_data(m_porta2);
+				m_ay2->data_w(m_porta2);
 				break;
 
 			case 3: // BDIR=1, BC1=1 (latch)
-				m_ay2->write_data(m_porta2);
+				m_ay2->data_w(m_porta2);
 				break;
 		}
 	}
@@ -350,12 +350,12 @@ WRITE8_MEMBER( a2bus_phasor_device::via2_out_b )
 	{
 		if (m_native)
 		{
-			m_ay3->reset_w(space, 0, 0);
-			m_ay4->reset_w(space, 0, 0);
+			m_ay3->reset_w();
+			m_ay4->reset_w();
 		}
 		else
 		{
-			m_ay2->reset_w(space, 0, 0);
+			m_ay2->reset_w();
 		}
 	}
 	else
@@ -375,23 +375,23 @@ WRITE8_MEMBER( a2bus_phasor_device::via2_out_b )
 
 			case 1: // BDIR=0, BC1=1 (read PSG)
 				if (BIT(chip_sel, 0))
-					m_porta2 = m_ay3->read_data();
+					m_porta2 = m_ay3->data_r();
 				if (BIT(chip_sel, 1))
-					m_porta2 = m_ay4->read_data();
+					m_porta2 = m_ay4->data_r();
 				break;
 
 			case 2: // BDIR=1, BC1=0 (write PSG)
 				if (BIT(chip_sel, 0))
-					m_ay3->write_data(m_porta2);
+					m_ay3->data_w(m_porta2);
 				if (BIT(chip_sel, 1))
-					m_ay4->write_data(m_porta2);
+					m_ay4->data_w(m_porta2);
 				break;
 
 			case 3: // BDIR=1, BC1=1 (latch)
 				if (BIT(chip_sel, 0))
-					m_ay3->write_address(m_porta2);
+					m_ay3->address_w(m_porta2);
 				if (BIT(chip_sel, 1))
-					m_ay4->write_address(m_porta2);
+					m_ay4->address_w(m_porta2);
 				break;
 		}
 	}

--- a/src/devices/bus/a2bus/ssprite.cpp
+++ b/src/devices/bus/a2bus/ssprite.cpp
@@ -104,7 +104,7 @@ uint8_t a2bus_ssprite_device::read_c0nx(uint8_t offset)
 			return 0x1f | m_tms5220->status_r();
 		case 14:
 		case 15:
-			return m_ay->read_data();
+			return m_ay->data_r();
 	}
 
 	return 0xff;
@@ -125,11 +125,11 @@ void a2bus_ssprite_device::write_c0nx(uint8_t offset, uint8_t data)
 			break;
 		case 12:
 		case 13:
-			m_ay->write_data(data);
+			m_ay->data_w(data);
 			break;
 		case 14:
 		case 15:
-			m_ay->write_address(data);
+			m_ay->address_w(data);
 			break;
 	}
 }

--- a/src/devices/bus/cbus/pc9801_amd98.cpp
+++ b/src/devices/bus/cbus/pc9801_amd98.cpp
@@ -149,9 +149,9 @@ READ8_MEMBER(pc9801_amd98_device::read)
 	switch(offset)
 	{
 		case 2:
-			return m_ay1->data_r(space,0);
+			return m_ay1->data_r();
 		case 3:
-			return m_ay2->data_r(space,0);
+			return m_ay2->data_r();
 	}
 
 	printf("%02x\n",offset);
@@ -164,16 +164,16 @@ WRITE8_MEMBER(pc9801_amd98_device::write)
 	switch(offset)
 	{
 		case 0:
-			m_ay1->address_w(space,0,data);
+			m_ay1->address_w(data);
 			break;
 		case 1:
-			m_ay2->address_w(space,0,data);
+			m_ay2->address_w(data);
 			break;
 		case 2:
-			m_ay1->data_w(space,0,data);
+			m_ay1->data_w(data);
 			break;
 		case 3:
-			m_ay2->data_w(space,0,data);
+			m_ay2->data_w(data);
 			break;
 		default:
 			printf("%02x %02x\n",offset,data);
@@ -192,11 +192,11 @@ WRITE8_MEMBER(pc9801_amd98_device::ay3_data_latch_w)
 	{
 		case 0x47:
 			//printf("%02x addr\n",m_ay3_latch);
-			m_ay3->address_w(space,0,m_ay3_latch);
+			m_ay3->address_w(m_ay3_latch);
 			break;
 		case 0x43:
 			//printf("%02x data\n",m_ay3_latch);
-			m_ay3->data_w(space,0,m_ay3_latch);
+			m_ay3->data_w(m_ay3_latch);
 			break;
 	}
 }

--- a/src/devices/bus/coco/coco_ssc.cpp
+++ b/src/devices/bus/coco/coco_ssc.cpp
@@ -438,12 +438,12 @@ WRITE8_MEMBER(coco_ssc_device::ssc_port_c_w)
 	{
 		if( (data & (C_BDR|C_BC1)) == (C_BDR|C_BC1) ) /* BDIR = 1, BC1 = 1: latch address */
 		{
-			m_ay->address_w(space, 0, m_tms7000_portd);
+			m_ay->address_w(m_tms7000_portd);
 		}
 
 		if( ((data & C_BDR) == C_BDR) && ((data & C_BC1) == 0) ) /* BDIR = 1, BC1 = 0: write data */
 		{
-			m_ay->data_w(space, 0, m_tms7000_portd);
+			m_ay->data_w(m_tms7000_portd);
 		}
 	}
 
@@ -493,7 +493,7 @@ READ8_MEMBER(coco_ssc_device::ssc_port_d_r)
 	{
 		if( ((m_tms7000_portc & C_BDR) == 0) && ((m_tms7000_portc & C_BC1) == C_BC1) ) /* psg read data */
 		{
-			m_tms7000_portd = m_ay->data_r(space, 0);
+			m_tms7000_portd = m_ay->data_r();
 		}
 	}
 

--- a/src/devices/bus/coco/cococart.cpp
+++ b/src/devices/bus/coco/cococart.cpp
@@ -597,40 +597,6 @@ address_space &device_cococart_interface::cartridge_space()
 
 
 //-------------------------------------------------
-//  install_read_handler
-//-------------------------------------------------
-
-void device_cococart_interface::install_read_handler(uint16_t addrstart, uint16_t addrend, read8_delegate rhandler)
-{
-	address_space &space(cartridge_space());
-	space.install_read_handler(addrstart, addrend, rhandler);
-}
-
-
-//-------------------------------------------------
-//  install_write_handler
-//-------------------------------------------------
-
-void device_cococart_interface::install_write_handler(uint16_t addrstart, uint16_t addrend, write8_delegate whandler)
-{
-	address_space &space(cartridge_space());
-	space.install_write_handler(addrstart, addrend, whandler);
-}
-
-
-//-------------------------------------------------
-//  install_readwrite_handler
-//-------------------------------------------------
-
-void device_cococart_interface::install_readwrite_handler(uint16_t addrstart, uint16_t addrend, read8_delegate rhandler, write8_delegate whandler)
-{
-	address_space &space(cartridge_space());
-	space.install_read_handler(addrstart, addrend, rhandler);
-	space.install_write_handler(addrstart, addrend, whandler);
-}
-
-
-//-------------------------------------------------
 //  set_line_value
 //-------------------------------------------------
 

--- a/src/devices/bus/coco/cococart.h
+++ b/src/devices/bus/coco/cococart.h
@@ -187,9 +187,35 @@ protected:
 	// cartridges (e.g. - Orch-90, Multi-Pak interface) for their control registers, independently
 	// of the SCS or CTS lines
 	address_space &cartridge_space();
-	void install_read_handler(uint16_t addrstart, uint16_t addrend, read8_delegate rhandler);
-	void install_write_handler(uint16_t addrstart, uint16_t addrend, write8_delegate whandler);
-	void install_readwrite_handler(uint16_t addrstart, uint16_t addrend, read8_delegate rhandler, write8_delegate whandler);
+	template<typename R> void install_read_handler(u16 addrstart, u16 addrend, R rhandler)
+	{
+		address_space &space(cartridge_space());
+		space.install_read_handler(addrstart, addrend, rhandler);
+	}
+	template<typename W> void install_write_handler(u16 addrstart, u16 addrend, W whandler)
+	{
+		address_space &space(cartridge_space());
+		space.install_write_handler(addrstart, addrend, whandler);
+	}
+	template<typename R, typename W> void install_readwrite_handler(u16 addrstart, u16 addrend, R rhandler, W whandler)
+	{
+		address_space &space(cartridge_space());
+		space.install_read_handler(addrstart, addrend, rhandler);
+		space.install_write_handler(addrstart, addrend, whandler);
+	}
+
+	void install_read_handler(u16 addrstart, u16 addrend, read8_delegate rhandler) { install_read_handler<read8_delegate>(addrstart, addrend, rhandler); }
+	void install_write_handler(u16 addrstart, u16 addrend, write8_delegate whandler) { install_write_handler<write8_delegate>(addrstart, addrend, whandler); }
+	void install_read_handler(u16 addrstart, u16 addrend, read8m_delegate rhandler) { install_read_handler<read8m_delegate>(addrstart, addrend, rhandler); }
+	void install_write_handler(u16 addrstart, u16 addrend, write8m_delegate whandler) { install_write_handler<write8m_delegate>(addrstart, addrend, whandler); }
+	void install_read_handler(u16 addrstart, u16 addrend, read8s_delegate rhandler) { install_read_handler<read8s_delegate>(addrstart, addrend, rhandler); }
+	void install_write_handler(u16 addrstart, u16 addrend, write8s_delegate whandler) { install_write_handler<write8s_delegate>(addrstart, addrend, whandler); }
+	void install_read_handler(u16 addrstart, u16 addrend, read8sm_delegate rhandler) { install_read_handler<read8sm_delegate>(addrstart, addrend, rhandler); }
+	void install_write_handler(u16 addrstart, u16 addrend, write8sm_delegate whandler) { install_write_handler<write8sm_delegate>(addrstart, addrend, whandler); }
+	void install_read_handler(u16 addrstart, u16 addrend, read8mo_delegate rhandler) { install_read_handler<read8mo_delegate>(addrstart, addrend, rhandler); }
+	void install_write_handler(u16 addrstart, u16 addrend, write8mo_delegate whandler) { install_write_handler<write8mo_delegate>(addrstart, addrend, whandler); }
+	void install_read_handler(u16 addrstart, u16 addrend, read8smo_delegate rhandler) { install_read_handler<read8smo_delegate>(addrstart, addrend, rhandler); }
+	void install_write_handler(u16 addrstart, u16 addrend, write8smo_delegate whandler) { install_write_handler<write8smo_delegate>(addrstart, addrend, whandler); }
 
 	// setting line values
 	void set_line_value(cococart_slot_device::line line, cococart_slot_device::line_value value);

--- a/src/devices/bus/coco/dragon_jcbsnd.cpp
+++ b/src/devices/bus/coco/dragon_jcbsnd.cpp
@@ -53,8 +53,8 @@ dragon_jcbsnd_device::dragon_jcbsnd_device(const machine_config &mconfig, const 
 
 void dragon_jcbsnd_device::device_start()
 {
-	install_write_handler(0xfefe, 0xfefe, write8_delegate(FUNC(ay8910_device::address_w), (ay8910_device *)m_ay8910));
-	install_readwrite_handler(0xfeff, 0xfeff, read8_delegate(FUNC(ay8910_device::data_r), (ay8910_device *)m_ay8910), write8_delegate(FUNC(ay8910_device::data_w), (ay8910_device *)m_ay8910));
+	install_write_handler(0xfefe, 0xfefe, write8smo_delegate(FUNC(ay8910_device::address_w), (ay8910_device *)m_ay8910));
+	install_readwrite_handler(0xfeff, 0xfeff, read8smo_delegate(FUNC(ay8910_device::data_r), (ay8910_device *)m_ay8910), write8smo_delegate(FUNC(ay8910_device::data_w), (ay8910_device *)m_ay8910));
 
 	set_line_value(line::CART, line_value::Q);
 }

--- a/src/devices/bus/cpc/playcity.cpp
+++ b/src/devices/bus/cpc/playcity.cpp
@@ -99,32 +99,32 @@ WRITE8_MEMBER(cpc_playcity_device::ctc_w)
 
 WRITE8_MEMBER(cpc_playcity_device::ymz1_address_w)
 {
-	m_ymz1->address_w(space,offset,data);
+	m_ymz1->address_w(data);
 }
 
 WRITE8_MEMBER(cpc_playcity_device::ymz2_address_w)
 {
-	m_ymz2->address_w(space,offset,data);
+	m_ymz2->address_w(data);
 }
 
 WRITE8_MEMBER(cpc_playcity_device::ymz1_data_w)
 {
-	m_ymz1->data_w(space,offset,data);
+	m_ymz1->data_w(data);
 }
 
 WRITE8_MEMBER(cpc_playcity_device::ymz2_data_w)
 {
-	m_ymz2->data_w(space,offset,data);
+	m_ymz2->data_w(data);
 }
 
 READ8_MEMBER(cpc_playcity_device::ymz1_data_r)
 {
-	return m_ymz1->data_r(space,offset);
+	return m_ymz1->data_r();
 }
 
 READ8_MEMBER(cpc_playcity_device::ymz2_data_r)
 {
-	return m_ymz2->data_r(space,offset);
+	return m_ymz2->data_r();
 }
 
 void cpc_playcity_device::update_ymz_clock()

--- a/src/devices/bus/intv/ecs.cpp
+++ b/src/devices/bus/intv/ecs.cpp
@@ -167,7 +167,7 @@ READ16_MEMBER(intv_ecs_device::read_romf0)
 READ16_MEMBER(intv_ecs_device::read_ay)
 {
 	if (ACCESSING_BITS_0_7)
-		return m_snd->read(space, offset, mem_mask);
+		return m_snd->read(offset);
 	else
 		return 0xffff;
 }
@@ -179,7 +179,7 @@ READ16_MEMBER(intv_ecs_device::read_ay)
 WRITE16_MEMBER(intv_ecs_device::write_ay)
 {
 	if (ACCESSING_BITS_0_7)
-		return m_snd->write(space, offset, data, mem_mask);
+		return m_snd->write(offset, data);
 }
 
 

--- a/src/devices/bus/nes/sunsoft.cpp
+++ b/src/devices/bus/nes/sunsoft.cpp
@@ -585,10 +585,10 @@ WRITE8_MEMBER(nes_sunsoft_5_device::write_h)
 	switch (offset & 0x6000)
 	{
 		case 0x4000:
-			m_ym2149->address_w(space, 0, data & 0x0f);
+			m_ym2149->address_w(data & 0x0f);
 			break;
 		case 0x6000:
-			m_ym2149->data_w(space, 0, data);
+			m_ym2149->data_w(data);
 			break;
 		default:
 			fme7_write(space, offset, data, mem_mask);

--- a/src/devices/bus/spectrum/fuller.cpp
+++ b/src/devices/bus/spectrum/fuller.cpp
@@ -92,8 +92,8 @@ void spectrum_fuller_device::device_reset()
 {
 	m_exp->set_io_space(&io_space());
 
-	io_space().install_write_handler(0x3f, 0x3f, 0, 0xff00, 0, write8_delegate(FUNC(ay8910_device::address_w), m_psg.target()));
-	io_space().install_readwrite_handler(0x5f, 0x5f, 0, 0xff00, 0, read8_delegate(FUNC(ay8910_device::data_r), m_psg.target()), write8_delegate(FUNC(ay8910_device::data_w), m_psg.target()));
+	io_space().install_write_handler(0x3f, 0x3f, 0, 0xff00, 0, write8smo_delegate(FUNC(ay8910_device::address_w), m_psg.target()));
+	io_space().install_readwrite_handler(0x5f, 0x5f, 0, 0xff00, 0, read8smo_delegate(FUNC(ay8910_device::data_r), m_psg.target()), write8smo_delegate(FUNC(ay8910_device::data_w), m_psg.target()));
 	io_space().install_read_handler(0x7f, 0x7f, 0, 0xff00, 0, read8_delegate(FUNC(spectrum_fuller_device::joystick_r), this));
 }
 

--- a/src/devices/bus/spectrum/melodik.cpp
+++ b/src/devices/bus/spectrum/melodik.cpp
@@ -68,8 +68,8 @@ void spectrum_melodik_device::device_reset()
 {
 	m_exp->set_io_space(&io_space());
 
-	io_space().install_write_handler(0x8000, 0x8000, 0, 0x3ffd, 0, write8_delegate(FUNC(ay8910_device::address_w), m_psg.target()));
-	io_space().install_readwrite_handler(0xc000, 0xc000, 0, 0x3ffd, 0, read8_delegate(FUNC(ay8910_device::data_r), m_psg.target()), write8_delegate(FUNC(ay8910_device::data_w), m_psg.target()));
+	io_space().install_write_handler(0x8000, 0x8000, 0, 0x3ffd, 0, write8smo_delegate(FUNC(ay8910_device::address_w), m_psg.target()));
+	io_space().install_readwrite_handler(0xc000, 0xc000, 0, 0x3ffd, 0, read8smo_delegate(FUNC(ay8910_device::data_r), m_psg.target()), write8smo_delegate(FUNC(ay8910_device::data_w), m_psg.target()));
 }
 
 //**************************************************************************

--- a/src/devices/sound/ay8910.cpp
+++ b/src/devices/sound/ay8910.cpp
@@ -120,7 +120,7 @@
 
 /***************************************************************************
 
-  ay8910.c
+  ay8910.cpp
 
   Emulation of the AY-3-8910 / YM2149 sound chip.
 
@@ -785,7 +785,7 @@ static const ay8910_device::mosfet_param ay8910_mosfet_param =
  *
  *************************************/
 
-static inline void build_3D_table(double rl, const ay8910_device::ay_ym_param *par, const ay8910_device::ay_ym_param *par_env, int normalize, double factor, int zero_is_off, int32_t *tab)
+static inline void build_3D_table(double rl, const ay8910_device::ay_ym_param *par, const ay8910_device::ay_ym_param *par_env, int normalize, double factor, int zero_is_off, s32 *tab)
 {
 	double min = 10.0,  max = 0.0;
 
@@ -844,7 +844,7 @@ static inline void build_3D_table(double rl, const ay8910_device::ay_ym_param *p
 	/* for (e=0;e<16;e++) printf("%d %d\n",e<<10, tab[e<<10]); */
 }
 
-static inline void build_single_table(double rl, const ay8910_device::ay_ym_param *par, int normalize, int32_t *tab, int zero_is_off)
+static inline void build_single_table(double rl, const ay8910_device::ay_ym_param *par, int normalize, s32 *tab, int zero_is_off)
 {
 	int j;
 	double rt;
@@ -883,7 +883,7 @@ static inline void build_single_table(double rl, const ay8910_device::ay_ym_para
 
 }
 
-static inline void build_mosfet_resistor_table(const ay8910_device::mosfet_param &par, const double rd, int32_t *tab)
+static inline void build_mosfet_resistor_table(const ay8910_device::mosfet_param &par, const double rd, s32 *tab)
 {
 	int j;
 
@@ -907,7 +907,7 @@ static inline void build_mosfet_resistor_table(const ay8910_device::mosfet_param
 }
 
 
-uint16_t ay8910_device::mix_3D()
+u16 ay8910_device::mix_3D()
 {
 	int indx = 0, chan;
 
@@ -1262,7 +1262,7 @@ void ay8910_device::device_start()
 		m_streams = 1;
 	}
 
-	m_vol3d_table = make_unique_clear<int32_t[]>(8*32*32*32);
+	m_vol3d_table = make_unique_clear<s32[]>(8*32*32*32);
 
 	build_mixer_table();
 
@@ -1293,7 +1293,7 @@ void ay8910_device::ay8910_reset_ym()
 	m_count_env = 0;
 	m_prescale_noise = 0;
 	m_last_enable = -1;  /* force a write */
-	for (i = 0;i < AY_PORTA;i++)
+	for (i = 0; i < AY_PORTA; i++)
 		ay8910_write_reg(i,0);
 	m_ready = 1;
 #if ENABLE_REGISTER_TEST
@@ -1338,7 +1338,7 @@ void ay8910_device::device_clock_changed()
 	ay_set_clock(clock());
 }
 
-void ay8910_device::ay8910_write_ym(int addr, uint8_t data)
+void ay8910_device::ay8910_write_ym(int addr, u8 data)
 {
 	if (addr & 1)
 	{
@@ -1369,7 +1369,7 @@ void ay8910_device::ay8910_write_ym(int addr, uint8_t data)
 	}
 }
 
-uint8_t ay8910_device::ay8910_read_ym()
+u8 ay8910_device::ay8910_read_ym()
 {
 	device_type chip_type = type();
 	int r = m_register_latch;
@@ -1418,13 +1418,13 @@ uint8_t ay8910_device::ay8910_read_ym()
 	- YM2149: no anomaly
 	*/
 	if (chip_type == AY8910) {
-		const uint8_t mask[0x10]={
+		const u8 mask[0x10]={
 			0xff,0x0f,0xff,0x0f,0xff,0x0f,0x1f,0xff,0x1f,0x1f,0x1f,0xff,0xff,0x0f,0xff,0xff
 		};
 		return m_regs[r] & mask[r];
 	}
 	else if (chip_type == AY8914) {
-		const uint8_t mask[0x10]={
+		const u8 mask[0x10]={
 			0xff,0x0f,0xff,0x0f,0xff,0x0f,0x1f,0xff,0x3f,0x3f,0x3f,0xff,0xff,0x0f,0xff,0xff
 		};
 		return m_regs[r] & mask[r];
@@ -1454,74 +1454,69 @@ void ay8910_device::device_reset()
  *
  *************************************/
 
-READ8_MEMBER( ay8910_device::data_r )
-{
-	return ay8910_read_ym();
-}
-
-WRITE8_MEMBER( ay8910_device::address_w )
+void ay8910_device::address_w(u8 data)
 {
 #if ENABLE_REGISTER_TEST
 	return;
 #else
-	data_address_w(space, 1, data);
+	ay8910_write_ym(0, data);
 #endif
 }
 
-WRITE8_MEMBER( ay8910_device::data_w )
+void ay8910_device::data_w(u8 data)
 {
 #if ENABLE_REGISTER_TEST
 	return;
 #else
-	data_address_w(space, 0, data);
+	ay8910_write_ym(1, data);
 #endif
 }
 
 // here, BC1 is hooked up to A0 on the host and BC2 is hooked up to A1
-WRITE8_MEMBER( ay8910_device::write_bc1_bc2 )
+void ay8910_device::write_bc1_bc2(offs_t offset, u8 data)
 {
 	switch (offset & 3)
 	{
 	case 0: // latch address
-		address_w(space, 0, data);
+		address_w(data);
 		break;
 	case 1: // inactive
 		break;
 	case 2: // write to psg
-		data_w(space, 0, data);
+		data_w(data);
 		break;
 	case 3: // latch address
-		address_w(space, 0, data);
+		address_w(data);
 		break;
 	}
 }
 
-static const int mapping8914to8910[16] = { 0, 2, 4, 11, 1, 3, 5, 12, 7, 6, 13, 8, 9, 10, 14, 15 };
+static const u8 mapping8914to8910[16] = { 0, 2, 4, 11, 1, 3, 5, 12, 7, 6, 13, 8, 9, 10, 14, 15 };
 
-READ8_MEMBER( ay8914_device::read )
+u8 ay8914_device::read(offs_t offset)
 {
-	uint16_t rv;
-	address_w(space, 0, mapping8914to8910[offset & 0xf]);
-	rv = (uint16_t) data_r(space, 0);
+	u8 rv;
+	address_w(mapping8914to8910[offset & 0xf]);
+	rv = data_r();
 	return rv;
 }
 
-WRITE8_MEMBER( ay8914_device::write )
+void ay8914_device::write(offs_t offset, u8 data)
 {
-	address_w(space, 0, mapping8914to8910[offset & 0xf]);
-	data_w(space, 0, data & 0xff);
+	address_w(mapping8914to8910[offset & 0xf]);
+	data_w(data & 0xff);
 }
 
 
 
 DEFINE_DEVICE_TYPE(AY8910, ay8910_device, "ay8910", "AY-3-8910A PSG")
 
-ay8910_device::ay8910_device(const machine_config &mconfig, const char *tag, device_t *owner, uint32_t clock)
+ay8910_device::ay8910_device(const machine_config &mconfig, const char *tag, device_t *owner, u32 clock)
 	: ay8910_device(mconfig, AY8910, tag, owner, clock, PSG_TYPE_AY, 3, 2)
 {
 }
 
-ay8910_device::ay8910_device(const machine_config &mconfig, device_type type, const char *tag, device_t *owner, uint32_t clock,
+ay8910_device::ay8910_device(const machine_config &mconfig, device_type type, const char *tag, device_t *owner, u32 clock,
 								psg_type_t psg_type, int streams, int ioports)
 	: device_t(mconfig, type, tag, owner, clock),
 		device_sound_interface(mconfig, *this),
@@ -1589,7 +1584,7 @@ void ay8910_device::set_type(psg_type_t psg_type)
 
 DEFINE_DEVICE_TYPE(AY8912, ay8912_device, "ay8912", "AY-3-8912A PSG")
 
-ay8912_device::ay8912_device(const machine_config &mconfig, const char *tag, device_t *owner, uint32_t clock)
+ay8912_device::ay8912_device(const machine_config &mconfig, const char *tag, device_t *owner, u32 clock)
 	: ay8910_device(mconfig, AY8912, tag, owner, clock, PSG_TYPE_AY, 3, 1)
 {
 }
@@ -1597,7 +1592,7 @@ ay8912_device::ay8912_device(const machine_config &mconfig, const char *tag, dev
 
 DEFINE_DEVICE_TYPE(AY8913, ay8913_device, "ay8913", "AY-3-8913 PSG")
 
-ay8913_device::ay8913_device(const machine_config &mconfig, const char *tag, device_t *owner, uint32_t clock)
+ay8913_device::ay8913_device(const machine_config &mconfig, const char *tag, device_t *owner, u32 clock)
 	: ay8910_device(mconfig, AY8913, tag, owner, clock, PSG_TYPE_AY, 3, 0)
 {
 }
@@ -1605,7 +1600,7 @@ ay8913_device::ay8913_device(const machine_config &mconfig, const char *tag, dev
 
 DEFINE_DEVICE_TYPE(AY8914, ay8914_device, "ay8914", "AY-3-8914A PSG")
 
-ay8914_device::ay8914_device(const machine_config &mconfig, const char *tag, device_t *owner, uint32_t clock)
+ay8914_device::ay8914_device(const machine_config &mconfig, const char *tag, device_t *owner, u32 clock)
 	: ay8910_device(mconfig, AY8914, tag, owner, clock, PSG_TYPE_AY, 3, 2)
 {
 }
@@ -1613,7 +1608,7 @@ ay8914_device::ay8914_device(const machine_config &mconfig, const char *tag, dev
 
 DEFINE_DEVICE_TYPE(AY8930, ay8930_device, "ay8930", "AY8930 EPSG")
 
-ay8930_device::ay8930_device(const machine_config &mconfig, const char *tag, device_t *owner, uint32_t clock)
+ay8930_device::ay8930_device(const machine_config &mconfig, const char *tag, device_t *owner, u32 clock)
 	: ay8910_device(mconfig, AY8930, tag, owner, clock, PSG_TYPE_AY, 3, 2)
 {
 }
@@ -1621,7 +1616,7 @@ ay8930_device::ay8930_device(const machine_config &mconfig, const char *tag, dev
 
 DEFINE_DEVICE_TYPE(YM2149, ym2149_device, "ym2149", "YM2149 SSG")
 
-ym2149_device::ym2149_device(const machine_config &mconfig, const char *tag, device_t *owner, uint32_t clock)
+ym2149_device::ym2149_device(const machine_config &mconfig, const char *tag, device_t *owner, u32 clock)
 	: ay8910_device(mconfig, YM2149, tag, owner, clock, PSG_TYPE_YM, 3, 2)
 {
 }
@@ -1629,7 +1624,7 @@ ym2149_device::ym2149_device(const machine_config &mconfig, const char *tag, dev
 
 DEFINE_DEVICE_TYPE(YM3439, ym3439_device, "ym3439", "YM3439 SSGC")
 
-ym3439_device::ym3439_device(const machine_config &mconfig, const char *tag, device_t *owner, uint32_t clock)
+ym3439_device::ym3439_device(const machine_config &mconfig, const char *tag, device_t *owner, u32 clock)
 	: ay8910_device(mconfig, YM3439, tag, owner, clock, PSG_TYPE_YM, 3, 2)
 {
 }
@@ -1637,7 +1632,7 @@ ym3439_device::ym3439_device(const machine_config &mconfig, const char *tag, dev
 
 DEFINE_DEVICE_TYPE(YMZ284, ymz284_device, "ymz284", "YMZ284 SSGL")
 
-ymz284_device::ymz284_device(const machine_config &mconfig, const char *tag, device_t *owner, uint32_t clock)
+ymz284_device::ymz284_device(const machine_config &mconfig, const char *tag, device_t *owner, u32 clock)
 	: ay8910_device(mconfig, YMZ284, tag, owner, clock, PSG_TYPE_YM, 1, 0)
 {
 }
@@ -1645,7 +1640,7 @@ ymz284_device::ymz284_device(const machine_config &mconfig, const char *tag, dev
 
 DEFINE_DEVICE_TYPE(YMZ294, ymz294_device, "ymz294", "YMZ294 SSGLP")
 
-ymz294_device::ymz294_device(const machine_config &mconfig, const char *tag, device_t *owner, uint32_t clock)
+ymz294_device::ymz294_device(const machine_config &mconfig, const char *tag, device_t *owner, u32 clock)
 	: ay8910_device(mconfig, YMZ294, tag, owner, clock, PSG_TYPE_YM, 1, 0)
 {
 }

--- a/src/devices/sound/ay8910.h
+++ b/src/devices/sound/ay8910.h
@@ -62,7 +62,7 @@ public:
 	};
 
 	// construction/destruction
-	ay8910_device(const machine_config &mconfig, const char *tag, device_t *owner, uint32_t clock);
+	ay8910_device(const machine_config &mconfig, const char *tag, device_t *owner, u32 clock);
 
 	// configuration helpers
 	void set_flags(int flags) { m_flags = flags; }
@@ -73,24 +73,21 @@ public:
 	auto port_a_write_callback() { return m_port_a_write_cb.bind(); }
 	auto port_b_write_callback() { return m_port_b_write_cb.bind(); }
 
-	DECLARE_READ8_MEMBER( data_r );
-	DECLARE_WRITE8_MEMBER( address_w );
-	DECLARE_WRITE8_MEMBER( data_w );
-	u8 read_data() { return ay8910_read_ym(); }
-	void write_address(u8 data) { ay8910_write_ym(0, data); }
-	void write_data(u8 data) { ay8910_write_ym(1, data); }
+	u8 data_r() { return ay8910_read_ym(); }
+	void address_w(u8 data);
+	void data_w(u8 data);
 
 	/* /RES */
-	DECLARE_WRITE8_MEMBER( reset_w ) { ay8910_reset_ym(); }
+	void reset_w(u8 data = 0) { ay8910_reset_ym(); }
 
 	// use this when BC1 == A0; here, BC1=0 selects 'data' and BC1=1 selects 'latch address'
-	DECLARE_WRITE8_MEMBER( data_address_w ) { ay8910_write_ym(~offset & 1, data); } // note that directly connecting BC1 to A0 puts data on 0 and address on 1
+	void data_address_w(offs_t offset, u8 data) { ay8910_write_ym(~offset & 1, data); } // note that directly connecting BC1 to A0 puts data on 0 and address on 1
 
 	// use this when BC1 == !A0; here, BC1=0 selects 'latch address' and BC1=1 selects 'data'
-	DECLARE_WRITE8_MEMBER( address_data_w ) { ay8910_write_ym(offset & 1, data); }
+	void address_data_w(offs_t offset, u8 data) { ay8910_write_ym(offset & 1, data); }
 
 	// bc1=a0, bc2=a1
-	DECLARE_WRITE8_MEMBER(write_bc1_bc2);
+	void write_bc1_bc2(offs_t offset, u8 data);
 
 	void set_volume(int channel,int volume);
 	void ay_set_clock(int clock);
@@ -113,13 +110,10 @@ public:
 
 	// internal interface for PSG component of YM device
 	// FIXME: these should be private, but vector06 accesses them directly
-	void ay8910_write_ym(int addr, uint8_t data);
-	uint8_t ay8910_read_ym();
-	void ay8910_reset_ym();
 
 protected:
 	ay8910_device(const machine_config &mconfig, device_type type, const char *tag, device_t *owner,
-					uint32_t clock, psg_type_t psg_type, int streams, int ioports);
+					u32 clock, psg_type_t psg_type, int streams, int ioports);
 
 	// device-level overrides
 	virtual void device_start() override;
@@ -140,10 +134,14 @@ private:
 
 	// internal helpers
 	void set_type(psg_type_t psg_type);
-	inline uint16_t mix_3D();
+	inline u16 mix_3D();
 	void ay8910_write_reg(int r, int v);
 	void build_mixer_table();
 	void ay8910_statesave();
+
+	void ay8910_write_ym(int addr, u8 data);
+	u8 ay8910_read_ym();
+	void ay8910_reset_ym();
 
 	// internal state
 	psg_type_t m_type;
@@ -152,29 +150,29 @@ private:
 	int m_ready;
 	sound_stream *m_channel;
 	bool m_active;
-	int32_t m_register_latch;
-	uint8_t m_regs[16];
-	int32_t m_last_enable;
-	int32_t m_count[NUM_CHANNELS];
-	uint8_t m_output[NUM_CHANNELS];
-	uint8_t m_prescale_noise;
-	int32_t m_count_noise;
-	int32_t m_count_env;
-	int8_t m_env_step;
-	uint32_t m_env_volume;
-	uint8_t m_hold,m_alternate,m_attack,m_holding;
-	int32_t m_rng;
-	uint8_t m_mode;
-	uint8_t m_env_step_mask;
+	s32 m_register_latch;
+	u8 m_regs[16];
+	s32 m_last_enable;
+	s32 m_count[NUM_CHANNELS];
+	u8 m_output[NUM_CHANNELS];
+	u8 m_prescale_noise;
+	s32 m_count_noise;
+	s32 m_count_env;
+	s8 m_env_step;
+	u32 m_env_volume;
+	u8 m_hold,m_alternate,m_attack,m_holding;
+	s32 m_rng;
+	u8 m_mode;
+	u8 m_env_step_mask;
 	/* init parameters ... */
 	int m_step;
 	int m_zero_is_off;
-	uint8_t m_vol_enabled[NUM_CHANNELS];
+	u8 m_vol_enabled[NUM_CHANNELS];
 	const ay_ym_param *m_par;
 	const ay_ym_param *m_par_env;
-	int32_t m_vol_table[NUM_CHANNELS][16];
-	int32_t m_env_table[NUM_CHANNELS][32];
-	std::unique_ptr<int32_t[]> m_vol3d_table;
+	s32 m_vol_table[NUM_CHANNELS][16];
+	s32 m_env_table[NUM_CHANNELS][32];
+	std::unique_ptr<s32[]> m_vol3d_table;
 	int m_flags;          /* Flags */
 	int m_res_load[3];    /* Load on channel in ohms */
 	devcb_read8 m_port_a_read_cb;
@@ -188,7 +186,7 @@ DECLARE_DEVICE_TYPE(AY8910, ay8910_device)
 class ay8912_device : public ay8910_device
 {
 public:
-	ay8912_device(const machine_config &mconfig, const char *tag, device_t *owner, uint32_t clock);
+	ay8912_device(const machine_config &mconfig, const char *tag, device_t *owner, u32 clock);
 };
 
 DECLARE_DEVICE_TYPE(AY8912, ay8912_device)
@@ -196,7 +194,7 @@ DECLARE_DEVICE_TYPE(AY8912, ay8912_device)
 class ay8913_device : public ay8910_device
 {
 public:
-	ay8913_device(const machine_config &mconfig, const char *tag, device_t *owner, uint32_t clock);
+	ay8913_device(const machine_config &mconfig, const char *tag, device_t *owner, u32 clock);
 };
 
 DECLARE_DEVICE_TYPE(AY8913, ay8913_device)
@@ -204,11 +202,11 @@ DECLARE_DEVICE_TYPE(AY8913, ay8913_device)
 class ay8914_device : public ay8910_device
 {
 public:
-	ay8914_device(const machine_config &mconfig, const char *tag, device_t *owner, uint32_t clock);
+	ay8914_device(const machine_config &mconfig, const char *tag, device_t *owner, u32 clock);
 
 	/* AY8914 handlers needed due to different register map */
-	DECLARE_READ8_MEMBER( read );
-	DECLARE_WRITE8_MEMBER( write );
+	u8 read(offs_t offset);
+	void write(offs_t offset, u8 data);
 };
 
 DECLARE_DEVICE_TYPE(AY8914, ay8914_device)
@@ -216,7 +214,7 @@ DECLARE_DEVICE_TYPE(AY8914, ay8914_device)
 class ay8930_device : public ay8910_device
 {
 public:
-	ay8930_device(const machine_config &mconfig, const char *tag, device_t *owner, uint32_t clock);
+	ay8930_device(const machine_config &mconfig, const char *tag, device_t *owner, u32 clock);
 };
 
 DECLARE_DEVICE_TYPE(AY8930, ay8930_device)
@@ -224,7 +222,7 @@ DECLARE_DEVICE_TYPE(AY8930, ay8930_device)
 class ym2149_device : public ay8910_device
 {
 public:
-	ym2149_device(const machine_config &mconfig, const char *tag, device_t *owner, uint32_t clock);
+	ym2149_device(const machine_config &mconfig, const char *tag, device_t *owner, u32 clock);
 };
 
 DECLARE_DEVICE_TYPE(YM2149, ym2149_device)
@@ -232,7 +230,7 @@ DECLARE_DEVICE_TYPE(YM2149, ym2149_device)
 class ym3439_device : public ay8910_device
 {
 public:
-	ym3439_device(const machine_config &mconfig, const char *tag, device_t *owner, uint32_t clock);
+	ym3439_device(const machine_config &mconfig, const char *tag, device_t *owner, u32 clock);
 };
 
 DECLARE_DEVICE_TYPE(YM3439, ym3439_device)
@@ -240,7 +238,7 @@ DECLARE_DEVICE_TYPE(YM3439, ym3439_device)
 class ymz284_device : public ay8910_device
 {
 public:
-	ymz284_device(const machine_config &mconfig, const char *tag, device_t *owner, uint32_t clock);
+	ymz284_device(const machine_config &mconfig, const char *tag, device_t *owner, u32 clock);
 };
 
 DECLARE_DEVICE_TYPE(YMZ284, ymz284_device)
@@ -248,7 +246,7 @@ DECLARE_DEVICE_TYPE(YMZ284, ymz284_device)
 class ymz294_device : public ay8910_device
 {
 public:
-	ymz294_device(const machine_config &mconfig, const char *tag, device_t *owner, uint32_t clock);
+	ymz294_device(const machine_config &mconfig, const char *tag, device_t *owner, u32 clock);
 };
 
 DECLARE_DEVICE_TYPE(YMZ294, ymz294_device)

--- a/src/mame/audio/carnival.cpp
+++ b/src/mame/audio/carnival.cpp
@@ -162,9 +162,9 @@ void vicdual_state::carnival_psg_latch(address_space &space)
 	{
 		// BDIR W, BC1 selects address or data
 		if (m_psgBus & 2)
-			m_psg->address_w(space, 0, m_psgData);
+			m_psg->address_w(m_psgData);
 		else
-			m_psg->data_w(space, 0, m_psgData);
+			m_psg->data_w(m_psgData);
 	}
 }
 

--- a/src/mame/audio/gottlieb.cpp
+++ b/src/mame/audio/gottlieb.cpp
@@ -549,9 +549,9 @@ WRITE8_MEMBER( gottlieb_sound_r2_device::speech_control_w )
 			// bit 3 selects which of the two 8913 to enable
 			// bit 4 goes to the 8913 BC1 pin
 			if ((data & 0x08) != 0)
-				m_ay1->data_address_w(space, data >> 4, m_psg_latch);
+				m_ay1->data_address_w(data >> 4, m_psg_latch);
 			else
-				m_ay2->data_address_w(space, data >> 4, m_psg_latch);
+				m_ay2->data_address_w(data >> 4, m_psg_latch);
 		}
 	}
 	else
@@ -563,8 +563,8 @@ WRITE8_MEMBER( gottlieb_sound_r2_device::speech_control_w )
 		else
 		{
 			ay8913_device *ay = (data & 0x08) ? m_ay1 : m_ay2;
-			ay->address_w(space, 0, m_psg_latch);
-			ay->data_w(space, 0, m_psg_data_latch);
+			ay->address_w(m_psg_latch);
+			ay->data_w(m_psg_data_latch);
 		}
 	}
 

--- a/src/mame/audio/irem.cpp
+++ b/src/mame/audio/irem.cpp
@@ -123,17 +123,17 @@ WRITE8_MEMBER( irem_audio_device::m6803_port2_w )
 		{
 			/* PSG 0 or 1? */
 			if (m_port2 & 0x08)
-				m_ay_45M->address_w(space, 0, m_port1);
+				m_ay_45M->address_w(m_port1);
 			if (m_port2 & 0x10)
-				m_ay_45L->address_w(space, 0, m_port1);
+				m_ay_45L->address_w(m_port1);
 		}
 		else
 		{
 			/* PSG 0 or 1? */
 			if (m_port2 & 0x08)
-				m_ay_45M->data_w(space, 0, m_port1);
+				m_ay_45M->data_w(m_port1);
 			if (m_port2 & 0x10)
-				m_ay_45L->data_w(space, 0, m_port1);
+				m_ay_45L->data_w(m_port1);
 		}
 	}
 	m_port2 = data;
@@ -151,9 +151,9 @@ READ8_MEMBER( irem_audio_device::m6803_port1_r )
 {
 	/* PSG 0 or 1? */
 	if (m_port2 & 0x08)
-		return m_ay_45M->data_r(space, 0);
+		return m_ay_45M->data_r();
 	if (m_port2 & 0x10)
-		return m_ay_45L->data_r(space, 0);
+		return m_ay_45L->data_r();
 	return 0xff;
 }
 

--- a/src/mame/audio/redalert.cpp
+++ b/src/mame/audio/redalert.cpp
@@ -86,7 +86,7 @@ WRITE8_MEMBER(redalert_state::redalert_AY8910_w)
 
 		/* BC1=1, BDIR=0 : read from PSG */
 		case 0x01:
-			m_ay8910_latch_1 = m_ay8910->data_r(space, 0);
+			m_ay8910_latch_1 = m_ay8910->data_r();
 			break;
 
 		/* BC1=0, BDIR=1 : write to PSG */
@@ -94,7 +94,7 @@ WRITE8_MEMBER(redalert_state::redalert_AY8910_w)
 		case 0x02:
 		case 0x03:
 		default:
-			m_ay8910->data_address_w(space, data, m_ay8910_latch_2);
+			m_ay8910->data_address_w(data, m_ay8910_latch_2);
 			break;
 	}
 }
@@ -269,28 +269,28 @@ WRITE8_MEMBER(redalert_state::demoneye_ay8910_data_w)
 	{
 		case 0x00:
 			if (m_ay8910_latch_1 & 0x10)
-				m_ay[0]->data_w(space, 0, data);
+				m_ay[0]->data_w(data);
 
 			if (m_ay8910_latch_1 & 0x20)
-				m_ay[1]->data_w(space, 0, data);
+				m_ay[1]->data_w(data);
 
 			break;
 
 		case 0x01:
 			if (m_ay8910_latch_1 & 0x10)
-				m_ay8910_latch_2 = m_ay[0]->data_r(space, 0);
+				m_ay8910_latch_2 = m_ay[0]->data_r();
 
 			if (m_ay8910_latch_1 & 0x20)
-				m_ay8910_latch_2 = m_ay[1]->data_r(space, 0);
+				m_ay8910_latch_2 = m_ay[1]->data_r();
 
 			break;
 
 		case 0x03:
 			if (m_ay8910_latch_1 & 0x10)
-				m_ay[0]->address_w(space, 0, data);
+				m_ay[0]->address_w(data);
 
 			if (m_ay8910_latch_1 & 0x20)
-				m_ay[1]->address_w(space, 0, data);
+				m_ay[1]->address_w(data);
 
 			break;
 

--- a/src/mame/audio/zaccaria.cpp
+++ b/src/mame/audio/zaccaria.cpp
@@ -189,10 +189,10 @@ READ8_MEMBER(zac1b111xx_melody_base::melodypia_porta_r)
 	u8 data = 0xff;
 
 	if (0x01 == (control & 0x03))
-		data &= m_melodypsg1->data_r(space, 0);
+		data &= m_melodypsg1->data_r();
 
 	if (0x04 == (control & 0x0c))
-		data &= m_melodypsg2->data_r(space, 0);
+		data &= m_melodypsg2->data_r();
 
 	return data;
 }
@@ -202,19 +202,19 @@ WRITE8_MEMBER(zac1b111xx_melody_base::melodypia_porta_w)
 	u8 const control = m_melodypia->b_output();
 
 	if (control & 0x02)
-		m_melodypsg1->data_address_w(space, (control >> 0) & 0x01, data);
+		m_melodypsg1->data_address_w((control >> 0) & 0x01, data);
 
 	if (control & 0x08)
-		m_melodypsg2->data_address_w(space, (control >> 2) & 0x01, data);
+		m_melodypsg2->data_address_w((control >> 2) & 0x01, data);
 }
 
 WRITE8_MEMBER(zac1b111xx_melody_base::melodypia_portb_w)
 {
 	if (data & 0x02)
-		m_melodypsg1->data_address_w(space, (data >> 0) & 0x01, m_melodypia->a_output());
+		m_melodypsg1->data_address_w((data >> 0) & 0x01, m_melodypia->a_output());
 
 	if (data & 0x08)
-		m_melodypsg2->data_address_w(space, (data >> 2) & 0x01, m_melodypia->a_output());
+		m_melodypsg2->data_address_w((data >> 2) & 0x01, m_melodypia->a_output());
 }
 
 READ8_MEMBER(zac1b111xx_melody_base::melodypsg1_portb_r)

--- a/src/mame/drivers/4enraya.cpp
+++ b/src/mame/drivers/4enraya.cpp
@@ -178,12 +178,12 @@ WRITE8_MEMBER(_4enraya_state::sound_control_w)
 	{
 		case 0: case 3:
 			// latch address
-			m_ay->address_w(space, 0, m_soundlatch);
+			m_ay->address_w(m_soundlatch);
 			break;
 
 		case 2:
 			// write to psg
-			m_ay->data_w(space, 0, m_soundlatch);
+			m_ay->data_w(m_soundlatch);
 			break;
 
 		default:

--- a/src/mame/drivers/5clown.cpp
+++ b/src/mame/drivers/5clown.cpp
@@ -509,7 +509,7 @@ private:
 	DECLARE_WRITE8_MEMBER(trigsnd_w);
 	DECLARE_READ8_MEMBER(pia0_b_r);
 	DECLARE_READ8_MEMBER(pia1_b_r);
-	DECLARE_WRITE8_MEMBER(fclown_ay8910_w);
+	void fclown_ay8910_w(offs_t offset, u8 data);
 	TILE_GET_INFO_MEMBER(get_fclown_tile_info);
 	void _5clown_palette(palette_device &palette) const;
 	uint32_t screen_update_fclown(screen_device &screen, bitmap_ind16 &bitmap, const rectangle &cliprect);
@@ -714,10 +714,10 @@ WRITE8_MEMBER(_5clown_state::cpu_d800_w)
 *  AY3-8910 R/W Handlers        *
 ********************************/
 
-WRITE8_MEMBER(_5clown_state::fclown_ay8910_w)
+void _5clown_state::fclown_ay8910_w(offs_t offset, u8 data)
 {
-	m_ay8910->address_w(space, 0, offset);
-	m_ay8910->data_w(space, 0, data);
+	m_ay8910->address_w(offset);
+	m_ay8910->data_w(data);
 }
 
 
@@ -742,7 +742,7 @@ WRITE8_MEMBER(_5clown_state::snd_800_w)
 
 	if (m_snd_latch_0a02 == 0x00)
 	{
-		fclown_ay8910_w(space, m_ay8910_addr, m_snd_latch_0800);
+		fclown_ay8910_w(m_ay8910_addr, m_snd_latch_0800);
 	}
 }
 

--- a/src/mame/drivers/aristmk4.cpp
+++ b/src/mame/drivers/aristmk4.cpp
@@ -798,13 +798,13 @@ READ8_MEMBER(aristmk4_state::via_a_r)
 
 	if (m_ay8910_1&0x03) // SW1 read.
 	{
-		psg_ret = m_ay1->data_r(space, 0);
+		psg_ret = m_ay1->data_r();
 		//logerror("PSG porta ay1 returned %02X\n",psg_ret);
 	}
 
 	else if (m_ay8910_2&0x03) //i don't think we read anything from Port A on ay2, Can be removed once game works ok.
 	{
-		psg_ret = m_ay2->data_r(space, 0);
+		psg_ret = m_ay2->data_r();
 		//logerror("PSG porta ay2 returned %02X\n",psg_ret);
 	}
 	return psg_ret;
@@ -898,13 +898,13 @@ WRITE8_MEMBER(aristmk4_state::via_b_w)
 		break;
 	case 0x06:  //WRITE
 	{
-		m_ay1->data_w(space, 0 , m_psg_data);
+		m_ay1->data_w(m_psg_data);
 		//logerror("VIA Port A write data ay1: %02X\n",m_psg_data);
 		break;
 	}
 	case 0x07:  //LATCH Address (set register)
 	{
-		m_ay1->address_w(space, 0 , m_psg_data);
+		m_ay1->address_w(m_psg_data);
 		//logerror("VIA Port B write register ay1: %02X\n",m_psg_data);
 		break;
 	}
@@ -925,13 +925,13 @@ WRITE8_MEMBER(aristmk4_state::via_b_w)
 		break;
 	case 0x06:  //WRITE
 	{
-		m_ay2->data_w(space, 0, m_psg_data);
+		m_ay2->data_w(m_psg_data);
 		//logerror("VIA Port A write data ay2: %02X\n",m_psg_data);
 		break;
 	}
 	case 0x07:  //LATCH Address (set register)
 	{
-		m_ay2->address_w(space, 0, m_psg_data);
+		m_ay2->address_w(m_psg_data);
 		//logerror("VIA Port B write register ay2: %02X\n",m_psg_data);
 		break;
 	}

--- a/src/mame/drivers/attache.cpp
+++ b/src/mame/drivers/attache.cpp
@@ -506,7 +506,7 @@ READ8_MEMBER(attache_state::pio_portA_r)
 	switch(m_pio_select)
 	{
 	case PIO_SEL_8910_DATA:
-		ret = m_psg->data_r(space,0);
+		ret = m_psg->data_r();
 		logerror("PSG: data read %02x\n",ret);
 		break;
 	case PIO_SEL_5832_WRITE:
@@ -560,10 +560,10 @@ void attache_state::operation_strobe(address_space& space, uint8_t data)
 	switch(m_pio_select)
 	{
 	case PIO_SEL_8910_ADDR:
-		m_psg->address_w(space,0,data);
+		m_psg->address_w(data);
 		break;
 	case PIO_SEL_8910_DATA:
-		m_psg->data_w(space,0,data);
+		m_psg->data_w(data);
 		break;
 	case PIO_SEL_5832_WRITE:
 		m_rtc->cs_w(1);

--- a/src/mame/drivers/bitgraph.cpp
+++ b/src/mame/drivers/bitgraph.cpp
@@ -280,10 +280,10 @@ WRITE8_MEMBER(bitgraph_state::pia_pb_w)
 	switch (m_pia_b & 0x03)
 	{
 	case 2:
-		m_psg->data_w(space, 0, m_pia_a);
+		m_psg->data_w(m_pia_a);
 		break;
 	case 3:
-		m_psg->address_w(space, 0, m_pia_a);
+		m_psg->address_w(m_pia_a);
 		break;
 	}
 

--- a/src/mame/drivers/bogeyman.cpp
+++ b/src/mame/drivers/bogeyman.cpp
@@ -37,11 +37,11 @@ WRITE8_MEMBER(bogeyman_state::ay8910_control_w)
 
 	// bit 5 goes to 8910 #0 BDIR pin
 	if ((m_last_write & 0x20) == 0x20 && (data & 0x20) == 0x00)
-		m_ay1->data_address_w(space, m_last_write >> 4, m_psg_latch);
+		m_ay1->data_address_w(m_last_write >> 4, m_psg_latch);
 
 	// bit 7 goes to 8910 #1 BDIR pin
 	if ((m_last_write & 0x80) == 0x80 && (data & 0x80) == 0x00)
-		m_ay2->data_address_w(space, m_last_write >> 6, m_psg_latch);
+		m_ay2->data_address_w(m_last_write >> 6, m_psg_latch);
 
 	m_last_write = data;
 }

--- a/src/mame/drivers/centiped.cpp
+++ b/src/mame/drivers/centiped.cpp
@@ -761,14 +761,14 @@ void centiped_state::caterplr_map(address_map &map)
 
 WRITE8_MEMBER(centiped_state::caterplr_AY8910_w)
 {
-	m_aysnd->address_w(space, 0, offset);
-	m_aysnd->data_w(space, 0, data);
+	m_aysnd->address_w(offset);
+	m_aysnd->data_w(data);
 }
 
 READ8_MEMBER(centiped_state::caterplr_AY8910_r)
 {
-	m_aysnd->address_w(space, 0, offset);
-	return m_aysnd->data_r(space, 0);
+	m_aysnd->address_w(offset);
+	return m_aysnd->data_r();
 }
 
 

--- a/src/mame/drivers/chexx.cpp
+++ b/src/mame/drivers/chexx.cpp
@@ -261,12 +261,12 @@ WRITE8_MEMBER(faceoffh_state::ay_w)
 
 	if (m_ay_cmd == 0x00 && data == 0x03)
 	{
-		m_aysnd->address_w(space, offset, m_ay_data, mem_mask);
+		m_aysnd->address_w(m_ay_data);
 //      logerror("%s: AY addr = %02X\n", machine().describe_context(), m_ay_data);
 	}
 	else if (m_ay_cmd == 0x00 && data == 0x02)
 	{
-		m_aysnd->data_w(space, offset, m_ay_data, mem_mask);
+		m_aysnd->data_w(m_ay_data);
 //      logerror("%s: AY data = %02X\n", machine().describe_context(), m_ay_data);
 	}
 	m_ay_cmd = data;

--- a/src/mame/drivers/cidelsa.cpp
+++ b/src/mame/drivers/cidelsa.cpp
@@ -51,15 +51,15 @@ WRITE8_MEMBER( draco_state::sound_g_w )
 	switch (data)
 	{
 	case 0x01:
-		m_psg->data_w(space, 0, m_psg_latch);
+		m_psg->data_w(m_psg_latch);
 		break;
 
 	case 0x02:
-		m_psg_latch = m_psg->data_r(space, 0);
+		m_psg_latch = m_psg->data_r();
 		break;
 
 	case 0x03:
-		m_psg->address_w(space, 0, m_psg_latch);
+		m_psg->address_w(m_psg_latch);
 		break;
 	}
 }

--- a/src/mame/drivers/dogfgt.cpp
+++ b/src/mame/drivers/dogfgt.cpp
@@ -37,11 +37,11 @@ WRITE8_MEMBER(dogfgt_state::soundcontrol_w)
 {
 	/* bit 5 goes to 8910 #0 BDIR pin  */
 	if ((m_last_snd_ctrl & 0x20) == 0x20 && (data & 0x20) == 0x00)
-		m_ay[0]->data_address_w(space, m_last_snd_ctrl >> 4, m_soundlatch);
+		m_ay[0]->data_address_w(m_last_snd_ctrl >> 4, m_soundlatch);
 
 	/* bit 7 goes to 8910 #1 BDIR pin  */
 	if ((m_last_snd_ctrl & 0x80) == 0x80 && (data & 0x80) == 0x00)
-		m_ay[1]->data_address_w(space, m_last_snd_ctrl >> 6, m_soundlatch);
+		m_ay[1]->data_address_w(m_last_snd_ctrl >> 6, m_soundlatch);
 
 	m_last_snd_ctrl = data;
 }

--- a/src/mame/drivers/drw80pkr.cpp
+++ b/src/mame/drivers/drw80pkr.cpp
@@ -201,11 +201,11 @@ WRITE8_MEMBER(drw80pkr_state::io_w)
 
 		// ay8910 control port
 		if (m_p1 == 0xfc)
-			m_aysnd->address_w(space, 0, data);
+			m_aysnd->address_w(data);
 
 		// ay8910_write_port_0_w
 		if (m_p1 == 0xfe)
-			m_aysnd->data_w(space, 0, data);
+			m_aysnd->data_w(data);
 	}
 }
 

--- a/src/mame/drivers/dynadice.cpp
+++ b/src/mame/drivers/dynadice.cpp
@@ -119,10 +119,10 @@ WRITE8_MEMBER(dynadice_state::sound_control_w)
 
 */
 	if ((data & 7) == 7)
-		m_ay8910->address_w(space, 0, m_ay_data);
+		m_ay8910->address_w(m_ay_data);
 
 	if ((data & 7) == 6)
-		m_ay8910->data_w(space, 0, m_ay_data);
+		m_ay8910->data_w(m_ay_data);
 }
 
 

--- a/src/mame/drivers/ettrivia.cpp
+++ b/src/mame/drivers/ettrivia.cpp
@@ -138,20 +138,20 @@ WRITE8_MEMBER(ettrivia_state::b800_w)
 		/* special case to return the value written to 0xb000 */
 		/* does it reset the chips too ? */
 		case 0: break;
-		case 0xc4: m_b000_ret = m_ay[0]->data_r(space, 0);    break;
-		case 0x94: m_b000_ret = m_ay[1]->data_r(space, 0);    break;
-		case 0x86: m_b000_ret = m_ay[2]->data_r(space, 0);    break;
+		case 0xc4: m_b000_ret = m_ay[0]->data_r();    break;
+		case 0x94: m_b000_ret = m_ay[1]->data_r();    break;
+		case 0x86: m_b000_ret = m_ay[2]->data_r();    break;
 
 		case 0x80:
 			switch(m_b800_prev)
 			{
-				case 0xe0: m_ay[0]->address_w(space,0,m_b000_val);    break;
-				case 0x98: m_ay[1]->address_w(space,0,m_b000_val);    break;
-				case 0x83: m_ay[2]->address_w(space,0,m_b000_val);    break;
+				case 0xe0: m_ay[0]->address_w(m_b000_val);    break;
+				case 0x98: m_ay[1]->address_w(m_b000_val);    break;
+				case 0x83: m_ay[2]->address_w(m_b000_val);    break;
 
-				case 0xa0: m_ay[0]->data_w(space,0,m_b000_val);   break;
-				case 0x88: m_ay[1]->data_w(space,0,m_b000_val);   break;
-				case 0x81: m_ay[2]->data_w(space,0,m_b000_val);   break;
+				case 0xa0: m_ay[0]->data_w(m_b000_val);   break;
+				case 0x88: m_ay[1]->data_w(m_b000_val);   break;
+				case 0x81: m_ay[2]->data_w(m_b000_val);   break;
 
 			}
 		break;

--- a/src/mame/drivers/fireball.cpp
+++ b/src/mame/drivers/fireball.cpp
@@ -250,21 +250,21 @@ WRITE8_MEMBER(fireball_state::io_06_w)
 			//address_w
 			if (LOG_AY8912)
 				logerror("write to 0x06 bc1=1\n");
-			m_ay->address_w(space,0,to_ay_data );
+			m_ay->address_w(to_ay_data);
 			if (LOG_AY8912)
 				logerror("AY8912 address latch write=%02X\n",to_ay_data);
 		}else{
 			//data_w
 			if (LOG_AY8912)
 				logerror("write to 0x06 bc1=0\n");
-			m_ay->data_w(space,0,to_ay_data );
+			m_ay->data_w(to_ay_data);
 			if (LOG_AY8912)
 				logerror("AY8912 data write=%02X\n",to_ay_data);
 		}
 	}else{
 		if (LOG_AY8912)
 			logerror("write to 0x06 bdir=0\n");
-		ay_data=m_ay->data_r(space,0);
+		ay_data=m_ay->data_r();
 	}
 
 	m_p1_data=data;

--- a/src/mame/drivers/fm7.cpp
+++ b/src/mame/drivers/fm7.cpp
@@ -851,8 +851,6 @@ READ8_MEMBER(fm7_state::fm77av_boot_mode_r)
  */
 void fm7_state::fm7_update_psg()
 {
-	address_space &space = m_maincpu->space(AS_PROGRAM);
-
 	if(m_type == SYS_FM7)
 	{
 		switch(m_psg_regsel)
@@ -862,15 +860,15 @@ void fm7_state::fm7_update_psg()
 				break;
 			case 0x01:
 				// Data read
-				m_psg_data = m_psg->data_r(space, 0);
+				m_psg_data = m_psg->data_r();
 				break;
 			case 0x02:
 				// Data write
-				m_psg->data_w(space, 0,m_psg_data);
+				m_psg->data_w(m_psg_data);
 				break;
 			case 0x03:
 				// Address latch
-				m_psg->address_w(space, 0,m_psg_data);
+				m_psg->address_w(m_psg_data);
 				break;
 		}
 	}

--- a/src/mame/drivers/galaxian.cpp
+++ b/src/mame/drivers/galaxian.cpp
@@ -748,8 +748,8 @@ READ8_MEMBER(galaxian_state::konami_ay8910_r)
 {
 	/* the decoding here is very simplistic, and you can address both simultaneously */
 	uint8_t result = 0xff;
-	if (offset & 0x20) result &= m_ay8910[1]->data_r(space, 0);
-	if (offset & 0x80) result &= m_ay8910[0]->data_r(space, 0);
+	if (offset & 0x20) result &= m_ay8910[1]->data_r();
+	if (offset & 0x80) result &= m_ay8910[0]->data_r();
 	return result;
 }
 
@@ -759,14 +759,14 @@ WRITE8_MEMBER(galaxian_state::konami_ay8910_w)
 	/* AV 4,5 ==> AY8910 #2 */
 	/* the decoding here is very simplistic, and you can address two simultaneously */
 	if (offset & 0x10)
-		m_ay8910[1]->address_w(space, 0, data);
+		m_ay8910[1]->address_w(data);
 	else if (offset & 0x20)
-		m_ay8910[1]->data_w(space, 0, data);
+		m_ay8910[1]->data_w(data);
 	/* AV6,7 ==> AY8910 #1 */
 	if (offset & 0x40)
-		m_ay8910[0]->address_w(space, 0, data);
+		m_ay8910[0]->address_w(data);
 	else if (offset & 0x80)
-		m_ay8910[0]->data_w(space, 0, data);
+		m_ay8910[0]->data_w(data);
 }
 
 
@@ -1082,7 +1082,7 @@ READ8_MEMBER(galaxian_state::frogger_ay8910_r)
 {
 	/* the decoding here is very simplistic */
 	uint8_t result = 0xff;
-	if (offset & 0x40) result &= m_ay8910[0]->data_r(space, 0);
+	if (offset & 0x40) result &= m_ay8910[0]->data_r();
 	return result;
 }
 
@@ -1092,9 +1092,9 @@ WRITE8_MEMBER(galaxian_state::frogger_ay8910_w)
 	/* the decoding here is very simplistic */
 	/* AV6,7 ==> AY8910 #1 */
 	if (offset & 0x40)
-		m_ay8910[0]->data_w(space, 0, data);
+		m_ay8910[0]->data_w(data);
 	else if (offset & 0x80)
-		m_ay8910[0]->address_w(space, 0, data);
+		m_ay8910[0]->address_w(data);
 }
 
 
@@ -1167,9 +1167,9 @@ READ8_MEMBER(galaxian_state::scorpion_ay8910_r)
 {
 	/* the decoding here is very simplistic, and you can address both simultaneously */
 	uint8_t result = 0xff;
-	if (offset & 0x08) result &= m_ay8910[2]->data_r(space, 0);
-	if (offset & 0x20) result &= m_ay8910[1]->data_r(space, 0);
-	if (offset & 0x80) result &= m_ay8910[0]->data_r(space, 0);
+	if (offset & 0x08) result &= m_ay8910[2]->data_r();
+	if (offset & 0x20) result &= m_ay8910[1]->data_r();
+	if (offset & 0x80) result &= m_ay8910[0]->data_r();
 	return result;
 }
 
@@ -1177,12 +1177,12 @@ READ8_MEMBER(galaxian_state::scorpion_ay8910_r)
 WRITE8_MEMBER(galaxian_state::scorpion_ay8910_w)
 {
 	/* the decoding here is very simplistic, and you can address all six simultaneously */
-	if (offset & 0x04) m_ay8910[2]->address_w(space, 0, data);
-	if (offset & 0x08) m_ay8910[2]->data_w(space, 0, data);
-	if (offset & 0x10) m_ay8910[1]->address_w(space, 0, data);
-	if (offset & 0x20) m_ay8910[1]->data_w(space, 0, data);
-	if (offset & 0x40) m_ay8910[0]->address_w(space, 0, data);
-	if (offset & 0x80) m_ay8910[0]->data_w(space, 0, data);
+	if (offset & 0x04) m_ay8910[2]->address_w(data);
+	if (offset & 0x08) m_ay8910[2]->data_w(data);
+	if (offset & 0x10) m_ay8910[1]->address_w(data);
+	if (offset & 0x20) m_ay8910[1]->data_w(data);
+	if (offset & 0x40) m_ay8910[0]->address_w(data);
+	if (offset & 0x80) m_ay8910[0]->data_w(data);
 }
 
 
@@ -1285,7 +1285,7 @@ WRITE8_MEMBER(galaxian_state::zigzag_ay8910_w)
 			/* bit 0 = WRITE */
 			/* bit 1 = C/D */
 			if ((offset & 1) != 0)
-				m_ay8910[0]->data_address_w(space, offset >> 1, m_zigzag_ay8910_latch);
+				m_ay8910[0]->data_address_w(offset >> 1, m_zigzag_ay8910_latch);
 			break;
 
 		case 0x100:
@@ -1377,21 +1377,21 @@ WRITE8_MEMBER(galaxian_state::mshuttle_ay8910_cs_w)
 WRITE8_MEMBER(galaxian_state::mshuttle_ay8910_control_w)
 {
 	if (!m_mshuttle_ay8910_cs)
-		m_ay8910_cclimber->address_w(space, offset, data);
+		m_ay8910_cclimber->address_w(data);
 }
 
 
 WRITE8_MEMBER(galaxian_state::mshuttle_ay8910_data_w)
 {
 	if (!m_mshuttle_ay8910_cs)
-		m_ay8910_cclimber->data_w(space, offset, data);
+		m_ay8910_cclimber->data_w(data);
 }
 
 
 READ8_MEMBER(galaxian_state::mshuttle_ay8910_data_r)
 {
 	if (!m_mshuttle_ay8910_cs)
-		return m_ay8910_cclimber->data_r(space, offset);
+		return m_ay8910_cclimber->data_r();
 	return 0xff;
 }
 

--- a/src/mame/drivers/gamate.cpp
+++ b/src/mame/drivers/gamate.cpp
@@ -94,14 +94,14 @@ READ8_MEMBER( gamate_state::gamate_nmi_r )
 
 READ8_MEMBER(gamate_state::sound_r)
 {
-	m_ay->address_w(space, 0, offset);
-	return m_ay->data_r(space, 0);
+	m_ay->address_w(offset);
+	return m_ay->data_r();
 }
 
 WRITE8_MEMBER(gamate_state::sound_w)
 {
-	m_ay->address_w(space, 0, offset);
-	m_ay->data_w(space, 0, data);
+	m_ay->address_w(offset);
+	m_ay->data_w(data);
 }
 
 WRITE8_MEMBER(gamate_state::write_cart)

--- a/src/mame/drivers/goldnpkr.cpp
+++ b/src/mame/drivers/goldnpkr.cpp
@@ -1696,11 +1696,11 @@ WRITE8_MEMBER(goldnpkr_state::wcfalcon_snd_w)
 {
 	if (wcfalcon_flag == 0)
 	{
-		m_ay8910->data_address_w(space, 0, data);
+		m_ay8910->data_address_w(0, data);
 	}
 	else
 	{
-		m_ay8910->data_address_w(space, 1, data);
+		m_ay8910->data_address_w(1, data);
 	}
 
 	wcfalcon_flag = wcfalcon_flag ^ 1;

--- a/src/mame/drivers/gsword.cpp
+++ b/src/mame/drivers/gsword.cpp
@@ -318,12 +318,12 @@ void gsword_state_base::machine_reset()
 
 WRITE8_MEMBER(gsword_state_base::ay8910_control_port_0_w)
 {
-	m_ay0->address_w(space,offset,data);
+	m_ay0->address_w(data);
 	m_fake8910_0 = data;
 }
 WRITE8_MEMBER(gsword_state_base::ay8910_control_port_1_w)
 {
-	m_ay1->address_w(space,offset,data);
+	m_ay1->address_w(data);
 	m_fake8910_1 = data;
 }
 

--- a/src/mame/drivers/icecold.cpp
+++ b/src/mame/drivers/icecold.cpp
@@ -265,9 +265,9 @@ READ8_MEMBER( icecold_state::kbd_r )
 WRITE8_MEMBER( icecold_state::snd_ctrl_w )
 {
 	if (m_ay_ctrl & ~data & 0x04)
-		m_ay8910[0]->data_address_w(space, m_ay_ctrl & 0x01, m_sound_latch);
+		m_ay8910[0]->data_address_w(m_ay_ctrl & 0x01, m_sound_latch);
 	if (m_ay_ctrl & ~data & 0x20)
-		m_ay8910[1]->data_address_w(space, (m_ay_ctrl>>3) & 0x01, m_sound_latch);
+		m_ay8910[1]->data_address_w((m_ay_ctrl>>3) & 0x01, m_sound_latch);
 
 	m_ay_ctrl = data;
 }
@@ -280,9 +280,9 @@ WRITE8_MEMBER( icecold_state::ay_w )
 READ8_MEMBER( icecold_state::ay_r )
 {
 	if (m_ay_ctrl & 0x02)
-		return m_ay8910[0]->data_r(space, 0);
+		return m_ay8910[0]->data_r();
 	if (m_ay_ctrl & 0x10)
-		return m_ay8910[1]->data_r(space, 0);
+		return m_ay8910[1]->data_r();
 
 	return 0;
 }

--- a/src/mame/drivers/kaneko16.cpp
+++ b/src/mame/drivers/kaneko16.cpp
@@ -159,8 +159,8 @@ template<int Chip>
 READ16_MEMBER(kaneko16_state::kaneko16_ay_YM2149_r)
 {
 	/* Each 2149 register is mapped to a different address */
-	m_ym2149[Chip]->address_w(space,0,offset);
-	return m_ym2149[Chip]->data_r(space,0);
+	m_ym2149[Chip]->address_w(offset);
+	return m_ym2149[Chip]->data_r();
 }
 
 
@@ -168,10 +168,10 @@ template<int Chip>
 WRITE16_MEMBER(kaneko16_state::kaneko16_ay_YM2149_w)
 {
 	/* Each 2149 register is mapped to a different address */
-	m_ym2149[Chip]->address_w(space,0,offset);
+	m_ym2149[Chip]->address_w(offset);
 	/* The registers are mapped to odd addresses, except one! */
-	if (ACCESSING_BITS_0_7) m_ym2149[Chip]->data_w(space,0, data       & 0xff);
-	else                m_ym2149[Chip]->data_w(space,0,(data >> 8) & 0xff);
+	if (ACCESSING_BITS_0_7) m_ym2149[Chip]->data_w( data       & 0xff);
+	else                m_ym2149[Chip]->data_w((data >> 8) & 0xff);
 }
 
 template<int Mask>

--- a/src/mame/drivers/kchamp.cpp
+++ b/src/mame/drivers/kchamp.cpp
@@ -92,11 +92,11 @@ WRITE_LINE_MEMBER(kchamp_state::sound_reset_w)
 	{
 		m_ay[0]->reset();
 		m_ay[1]->reset();
-		sound_control_w(machine().dummy_space(), 0, 0);
+		sound_control_w(0);
 	}
 }
 
-WRITE8_MEMBER(kchamp_state::sound_control_w)
+void kchamp_state::sound_control_w(u8 data)
 {
 	m_msm->reset_w(!(data & 1));
 	m_sound_nmi_enable = ((data >> 1) & 1);

--- a/src/mame/drivers/kncljoe.cpp
+++ b/src/mame/drivers/kncljoe.cpp
@@ -77,7 +77,7 @@ WRITE8_MEMBER(kncljoe_state::m6803_port2_w)
 	{
 		/* control or data port? */
 		if (m_port2 & 0x08)
-			m_ay8910->data_address_w(space, m_port2 >> 2, m_port1);
+			m_ay8910->data_address_w(m_port2 >> 2, m_port1);
 	}
 	m_port2 = data;
 }
@@ -85,7 +85,7 @@ WRITE8_MEMBER(kncljoe_state::m6803_port2_w)
 READ8_MEMBER(kncljoe_state::m6803_port1_r)
 {
 	if (m_port2 & 0x08)
-		return m_ay8910->data_r(space, 0);
+		return m_ay8910->data_r();
 	return 0xff;
 }
 

--- a/src/mame/drivers/m63.cpp
+++ b/src/mame/drivers/m63.cpp
@@ -413,13 +413,13 @@ WRITE8_MEMBER(m63_state::snd_irq_w)
 WRITE8_MEMBER(m63_state::snddata_w)
 {
 	if ((m_p2 & 0xf0) == 0xe0)
-		m_ay1->address_w(space, 0, offset);
+		m_ay1->address_w(offset);
 	else if ((m_p2 & 0xf0) == 0xa0)
-		m_ay1->data_w(space, 0, offset);
+		m_ay1->data_w(offset);
 	else if (m_ay2 != nullptr && (m_p1 & 0xe0) == 0x60)
-		m_ay2->address_w(space, 0, offset);
+		m_ay2->address_w(offset);
 	else if (m_ay2 != nullptr && (m_p1 & 0xe0) == 0x40)
-			m_ay2->data_w(space, 0, offset);
+			m_ay2->data_w(offset);
 	else if ((m_p2 & 0xf0) == 0x70 )
 		m_sound_status = offset;
 }

--- a/src/mame/drivers/mephistp.cpp
+++ b/src/mame/drivers/mephistp.cpp
@@ -87,9 +87,9 @@ WRITE8_MEMBER(mephisto_pinball_state::t0_t1_w)
 void mephisto_pinball_state::ay8910_update()
 {
 	if (m_ay8910_bdir)
-		m_aysnd->data_address_w(machine().dummy_space(), m_ay8910_bc1, m_ay8910_data);
+		m_aysnd->data_address_w(m_ay8910_bc1, m_ay8910_data);
 	else if (m_ay8910_bc1)
-		m_ay8910_data = m_aysnd->data_r(machine().dummy_space(), 0);
+		m_ay8910_data = m_aysnd->data_r();
 }
 
 WRITE8_MEMBER(mephisto_pinball_state::ay8910_columns_w)

--- a/src/mame/drivers/mermaid.cpp
+++ b/src/mame/drivers/mermaid.cpp
@@ -128,14 +128,14 @@ Stephh's notes (based on the games Z80 code and some tests) :
 
 WRITE8_MEMBER(mermaid_state::mermaid_ay8910_write_port_w)
 {
-	if (m_ay8910_enable[0]) m_ay8910[0]->data_w(space, offset, data);
-	if (m_ay8910_enable[1]) m_ay8910[1]->data_w(space, offset, data);
+	if (m_ay8910_enable[0]) m_ay8910[0]->data_w(data);
+	if (m_ay8910_enable[1]) m_ay8910[1]->data_w(data);
 }
 
 WRITE8_MEMBER(mermaid_state::mermaid_ay8910_control_port_w)
 {
-	if (m_ay8910_enable[0]) m_ay8910[0]->address_w(space, offset, data);
-	if (m_ay8910_enable[1]) m_ay8910[1]->address_w(space, offset, data);
+	if (m_ay8910_enable[0]) m_ay8910[0]->address_w(data);
+	if (m_ay8910_enable[1]) m_ay8910[1]->address_w(data);
 }
 
 

--- a/src/mame/drivers/mgavegas.cpp
+++ b/src/mame/drivers/mgavegas.cpp
@@ -292,7 +292,7 @@ uint8_t ret=0;
 	switch (offset&0x03)
 	{
 		case 1: //bdir=0    BC1=1
-				ret=m_ay->data_r(space,0);
+				ret=m_ay->data_r();
 				break;
 		default:
 				if (LOG_AY8910)
@@ -313,10 +313,10 @@ WRITE8_MEMBER(mgavegas_state::w_a0)
 	switch (offset&0x03)
 	{
 		case 0: //bdir=1    bc1=1
-				m_ay->address_w(space,0,data );
+				m_ay->address_w(data);
 				break;
 		case 2: //bdir=1    bc1=0
-				m_ay->data_w(space,0,data );
+				m_ay->data_w(data);
 				break;
 /*
         case 1: //bdir=0    bc1=1

--- a/src/mame/drivers/mirax.cpp
+++ b/src/mame/drivers/mirax.cpp
@@ -277,14 +277,14 @@ WRITE8_MEMBER(mirax_state::audio_w)
 
 WRITE8_MEMBER(mirax_state::ay1_sel)
 {
-	m_ay[0]->address_w(space,0,m_nAyCtrl);
-	m_ay[0]->data_w(space,0,data);
+	m_ay[0]->address_w(m_nAyCtrl);
+	m_ay[0]->data_w(data);
 }
 
 WRITE8_MEMBER(mirax_state::ay2_sel)
 {
-	m_ay[1]->address_w(space,0,m_nAyCtrl);
-	m_ay[1]->data_w(space,0,data);
+	m_ay[1]->address_w(m_nAyCtrl);
+	m_ay[1]->data_w(data);
 }
 
 WRITE_LINE_MEMBER(mirax_state::nmi_mask_w)

--- a/src/mame/drivers/multi8.cpp
+++ b/src/mame/drivers/multi8.cpp
@@ -278,8 +278,8 @@ WRITE8_MEMBER( multi8_state::pal_w )
 	}
 }
 
-READ8_MEMBER(multi8_state::ay8912_0_r){ return m_aysnd->data_r(space, 0); }
-READ8_MEMBER(multi8_state::ay8912_1_r){ return m_aysnd->data_r(space, 1); }
+READ8_MEMBER(multi8_state::ay8912_0_r){ return m_aysnd->data_r(); }
+READ8_MEMBER(multi8_state::ay8912_1_r){ return m_aysnd->data_r(); }
 
 READ8_MEMBER( multi8_state::kanji_r )
 {

--- a/src/mame/drivers/munchmo.cpp
+++ b/src/mame/drivers/munchmo.cpp
@@ -75,13 +75,13 @@ WRITE8_MEMBER(munchmo_state::sound_nmi_ack_w)
 
 READ8_MEMBER(munchmo_state::ay1reset_r)
 {
-	m_ay8910[0]->reset_w(space, 0, 0);
+	m_ay8910[0]->reset_w();
 	return 0;
 }
 
 READ8_MEMBER(munchmo_state::ay2reset_r)
 {
-	m_ay8910[1]->reset_w(space, 0, 0);
+	m_ay8910[1]->reset_w();
 	return 0;
 }
 

--- a/src/mame/drivers/mystston.cpp
+++ b/src/mame/drivers/mystston.cpp
@@ -79,14 +79,14 @@ WRITE8_MEMBER(mystston_state::mystston_ay8910_select_w)
 	if (((*m_ay8910_select & 0x20) == 0x20) && ((data & 0x20) == 0x00))
 	{
 		/* bit 4 goes to the 8910 #0 BC1 pin */
-		m_ay8910[0]->data_address_w(space, *m_ay8910_select >> 4, *m_ay8910_data);
+		m_ay8910[0]->data_address_w(*m_ay8910_select >> 4, *m_ay8910_data);
 	}
 
 	/* bit 7 goes to 8910 #1 BDIR pin */
 	if (((*m_ay8910_select & 0x80) == 0x80) && ((data & 0x80) == 0x00))
 	{
 		/* bit 6 goes to the 8910 #1 BC1 pin */
-		m_ay8910[1]->data_address_w(space, *m_ay8910_select >> 6, *m_ay8910_data);
+		m_ay8910[1]->data_address_w(*m_ay8910_select >> 6, *m_ay8910_data);
 	}
 
 	*m_ay8910_select = data;

--- a/src/mame/drivers/oric.cpp
+++ b/src/mame/drivers/oric.cpp
@@ -307,11 +307,11 @@ void oric_state::update_psg(address_space &space)
 {
 	if(m_via_ca2)
 		if(m_via_cb2)
-			m_psg->address_w(space, 0, m_via_a);
+			m_psg->address_w(m_via_a);
 		else
-			m_via->write_pa(space, 0, m_psg->data_r(space, 0));
+			m_via->write_pa(space, 0, m_psg->data_r());
 	else if(m_via_cb2)
-		m_psg->data_w(space, 0, m_via_a);
+		m_psg->data_w(m_via_a);
 }
 
 void oric_state::update_irq()

--- a/src/mame/drivers/othello.cpp
+++ b/src/mame/drivers/othello.cpp
@@ -251,14 +251,14 @@ WRITE8_MEMBER(othello_state::ack_w)
 
 WRITE8_MEMBER(othello_state::ay_address_w)
 {
-	if (m_ay_select & 1) m_ay[0]->address_w(space, 0, data);
-	if (m_ay_select & 2) m_ay[1]->address_w(space, 0, data);
+	if (m_ay_select & 1) m_ay[0]->address_w(data);
+	if (m_ay_select & 2) m_ay[1]->address_w(data);
 }
 
 WRITE8_MEMBER(othello_state::ay_data_w)
 {
-	if (m_ay_select & 1) m_ay[0]->data_w(space, 0, data);
-	if (m_ay_select & 2) m_ay[1]->data_w(space, 0, data);
+	if (m_ay_select & 1) m_ay[0]->data_w(data);
+	if (m_ay_select & 2) m_ay[1]->data_w(data);
 }
 
 void othello_state::audio_map(address_map &map)

--- a/src/mame/drivers/play_2.cpp
+++ b/src/mame/drivers/play_2.cpp
@@ -324,15 +324,15 @@ WRITE8_MEMBER( play_2_state::sound_g_w )
 	switch (data)
 	{
 	case 0x01:
-		m_aysnd1->data_w(space, 0, m_psg_latch);
+		m_aysnd1->data_w(m_psg_latch);
 		break;
 
 	case 0x02:
-		m_psg_latch = m_aysnd1->data_r(space, 0);
+		m_psg_latch = m_aysnd1->data_r();
 		break;
 
 	case 0x03:
-		m_aysnd1->address_w(space, 0, m_psg_latch);
+		m_aysnd1->address_w(m_psg_latch);
 		break;
 	}
 }

--- a/src/mame/drivers/popper.cpp
+++ b/src/mame/drivers/popper.cpp
@@ -479,7 +479,7 @@ WRITE8_MEMBER( popper_state::ay1_w )
 		m_ay[1]->reset();
 	}
 
-	m_ay[0]->write_bc1_bc2(space, offset, data);
+	m_ay[0]->write_bc1_bc2(offset, data);
 }
 
 

--- a/src/mame/drivers/proconn.cpp
+++ b/src/mame/drivers/proconn.cpp
@@ -59,7 +59,7 @@ public:
 	void init_proconn();
 
 private:
-	template <unsigned N> DECLARE_WRITE8_MEMBER( ay_w ) { m_ay->address_data_w(space, N, data); }
+	template <unsigned N> DECLARE_WRITE8_MEMBER( ay_w ) { m_ay->address_data_w(N, data); }
 
 	template <unsigned N> DECLARE_WRITE8_MEMBER( ctc_w ) { m_z80ctc->write(space, N, data); }
 
@@ -70,8 +70,6 @@ private:
 	template <unsigned N> DECLARE_WRITE8_MEMBER( pio3_w ) { m_z80pio[2]->write(space, N, data); }
 	template <unsigned N> DECLARE_WRITE8_MEMBER( pio4_w ) { m_z80pio[3]->write(space, N, data); }
 	template <unsigned N> DECLARE_WRITE8_MEMBER( pio5_w ) { m_z80pio[4]->write(space, N, data); }
-
-	template <unsigned N> DECLARE_READ8_MEMBER( ay_r ) { return m_ay->data_r(space, N); }
 
 	template <unsigned N> DECLARE_READ8_MEMBER( ctc_r ) { return m_z80ctc->read(space, N); }
 
@@ -176,7 +174,7 @@ void proconn_state::proconn_portmap(address_map &map)
 	map(0x03fe, 0x03fe).rw(FUNC(proconn_state::ctc_r<3>), FUNC(proconn_state::ctc_w<3>));
 
 	// ay (meters connected to it?)
-	map(0x00fd, 0x00fd).rw(FUNC(proconn_state::ay_r<0>), FUNC(proconn_state::ay_w<0>));
+	map(0x00fd, 0x00fd).r(m_ay, FUNC(ay8910_device::data_r)).w(FUNC(proconn_state::ay_w<0>));
 	map(0x00fc, 0x00fc).w(FUNC(proconn_state::ay_w<1>));
 
 	// ??

--- a/src/mame/drivers/r2dtank.cpp
+++ b/src/mame/drivers/r2dtank.cpp
@@ -201,10 +201,10 @@ READ8_MEMBER(r2dtank_state::AY8910_port_r)
 	uint8_t ret = 0;
 
 	if (m_AY8910_selected & 0x08)
-		ret = m_ay1->data_r(space, 0);
+		ret = m_ay1->data_r();
 
 	if (m_AY8910_selected & 0x10)
-		ret = m_ay2->data_r(space, 0);
+		ret = m_ay2->data_r();
 
 	return ret;
 }
@@ -213,10 +213,10 @@ READ8_MEMBER(r2dtank_state::AY8910_port_r)
 WRITE8_MEMBER(r2dtank_state::AY8910_port_w)
 {
 	if (m_AY8910_selected & 0x08)
-		m_ay1->data_address_w(space, m_AY8910_selected >> 2, data);
+		m_ay1->data_address_w(m_AY8910_selected >> 2, data);
 
 	if (m_AY8910_selected & 0x10)
-		m_ay2->data_address_w(space, m_AY8910_selected >> 2, data);
+		m_ay2->data_address_w(m_AY8910_selected >> 2, data);
 }
 
 

--- a/src/mame/drivers/ron.cpp
+++ b/src/mame/drivers/ron.cpp
@@ -451,9 +451,9 @@ WRITE8_MEMBER(ron_state::audio_p1_w)
 	//machine().debug_break();
 
 	if(m_ay_address_sel == true)
-		m_ay->address_w(space, 0, data);
+		m_ay->address_w(data);
 	else
-		m_ay->data_w(space, 0, data);
+		m_ay->data_w(data);
 }
 
 WRITE8_MEMBER(ron_state::audio_p2_w)

--- a/src/mame/drivers/royalmah.cpp
+++ b/src/mame/drivers/royalmah.cpp
@@ -1074,7 +1074,7 @@ READ8_MEMBER(royalmah_state::mjifb_rom_io_r)
 	{
 		case 0x8000:    return ioport("DSW4")->read();      // dsw 4
 		case 0x8200:    return ioport("DSW3")->read();      // dsw 3
-		case 0x9001:    return m_ay->data_r(space, 0);   // inputs
+		case 0x9001:    return m_ay->data_r();              // inputs
 		case 0x9011:    return ioport("SYSTEM")->read();
 	}
 
@@ -1095,8 +1095,8 @@ WRITE8_MEMBER(royalmah_state::mjifb_rom_io_w)
 	switch(offset)
 	{
 		case 0x8e00:    m_palette_base = data & 0x1f;   return;
-		case 0x9002:    m_ay->data_w(space,0,data);          return;
-		case 0x9003:    m_ay->address_w(space,0,data);       return;
+		case 0x9002:    m_ay->data_w(data);             return;
+		case 0x9003:    m_ay->address_w(data);          return;
 		case 0x9010:
 			mjifb_coin_counter_w(space,0,data);
 			return;
@@ -1173,7 +1173,7 @@ READ8_MEMBER(royalmah_state::mjdejavu_rom_io_r)
 	{
 		case 0x8000:    return ioport("DSW2")->read();      // dsw 2
 		case 0x8001:    return ioport("DSW1")->read();      // dsw 1
-		case 0x9001:    return m_ay->data_r(space, 0);   // inputs
+		case 0x9001:    return m_ay->data_r();              // inputs
 		case 0x9011:    return ioport("SYSTEM")->read();
 	}
 
@@ -1192,10 +1192,10 @@ WRITE8_MEMBER(royalmah_state::mjdejavu_rom_io_w)
 	offset += 0x8000;
 	switch(offset)
 	{
-		case 0x8802:    m_palette_base = data & 0x1f;                   return;
-		case 0x9002:    m_ay->data_w(space,0,data);      return;
-		case 0x9003:    m_ay->address_w(space,0,data);   return;
-		case 0x9010:    janptr96_coin_counter_w(space,0,data);     return;
+		case 0x8802:    m_palette_base = data & 0x1f;           return;
+		case 0x9002:    m_ay->data_w(data);                     return;
+		case 0x9003:    m_ay->address_w(data);                  return;
+		case 0x9010:    janptr96_coin_counter_w(space,0,data);  return;
 		case 0x9011:    input_port_select_w(space,0,data);      return;
 		case 0x9013:
 //          if (data)   popmessage("%02x",data);

--- a/src/mame/drivers/segag80v.cpp
+++ b/src/mame/drivers/segag80v.cpp
@@ -1350,7 +1350,7 @@ void segag80v_state::init_zektor()
 	/* configure sound */
 	iospace.install_write_handler(0x38, 0x38, write8_delegate(FUNC(speech_sound_device::data_w), (speech_sound_device*)m_speech));
 	iospace.install_write_handler(0x3b, 0x3b, write8_delegate(FUNC(speech_sound_device::control_w), (speech_sound_device*)m_speech));
-	iospace.install_write_handler(0x3c, 0x3d, write8_delegate(FUNC(ay8912_device::address_data_w), (ay8912_device*)m_aysnd));
+	iospace.install_write_handler(0x3c, 0x3d, write8sm_delegate(FUNC(ay8912_device::address_data_w), (ay8912_device*)m_aysnd));
 	iospace.install_write_handler(0x3e, 0x3e, write8_delegate(FUNC(segag80v_state::zektor1_sh_w),this));
 	iospace.install_write_handler(0x3f, 0x3f, write8_delegate(FUNC(segag80v_state::zektor2_sh_w),this));
 

--- a/src/mame/drivers/skeetsht.cpp
+++ b/src/mame/drivers/skeetsht.cpp
@@ -178,9 +178,9 @@ WRITE8_MEMBER(skeetsht_state::hc11_porta_w)
 WRITE8_MEMBER(skeetsht_state::ay8910_w)
 {
 	if (m_ay_sel)
-		m_ay->data_w(space, 0, data);
+		m_ay->data_w(data);
 	else
-		m_ay->address_w(space, 0, data);
+		m_ay->address_w(data);
 }
 
 

--- a/src/mame/drivers/spc1500.cpp
+++ b/src/mame/drivers/spc1500.cpp
@@ -648,8 +648,8 @@ WRITE8_MEMBER( spc1500_state::double_w)
 		if (offset < 0x1900) { crtc_w(space, offset, data); } else
 		if (offset < 0x1a00) {} else
 		if (offset < 0x1b00) { m_pio->write(offset, data); } else
-		if (offset < 0x1c00) { m_sound->data_w(space, offset, data);} else
-		if (offset < 0x1d00) { m_sound->address_w(space, offset, data);} else
+		if (offset < 0x1c00) { m_sound->data_w(data);} else
+		if (offset < 0x1d00) { m_sound->address_w(data);} else
 		if (offset < 0x1e00) { romsel(space, offset, data);} else
 		if (offset < 0x1f00) { ramsel(space, offset, data);} else
 		if (offset < 0x2000) {} else
@@ -675,7 +675,7 @@ READ8_MEMBER( spc1500_state::io_r)
 	if (offset < 0x1900) { return crtc_r(space, offset); } else
 	if (offset < 0x1a00) { return keyboard_r(space, offset); } else
 	if (offset < 0x1b00) { return m_pio->read(offset); } else
-	if (offset < 0x1c00) { return m_sound->data_r(space, offset); } else
+	if (offset < 0x1c00) { return m_sound->data_r(); } else
 	if (offset < 0x2000) {} else
 	if (offset < 0x10000){
 		if (offset < 0x4000)

--- a/src/mame/drivers/superqix.cpp
+++ b/src/mame/drivers/superqix.cpp
@@ -289,7 +289,7 @@ TIMER_CALLBACK_MEMBER(superqix_state::mcu_port3_w_cb)
 
 TIMER_CALLBACK_MEMBER(superqix_state::z80_ay1_sync_address_w_cb)
 {
-	m_ay1->address_w(m_maincpu->space(AS_PROGRAM), 0, param, 0xff);
+	m_ay1->address_w(param);
 }
 
 

--- a/src/mame/drivers/supstarf.cpp
+++ b/src/mame/drivers/supstarf.cpp
@@ -89,8 +89,8 @@ READ8_MEMBER(supstarf_state::psg_latch_r)
 	{
 		if (m_pcs[d])
 		{
-			m_psg[d]->address_w(space, 0, offset);
-			result &= m_psg[d]->data_r(space, 0);
+			m_psg[d]->address_w(offset);
+			result &= m_psg[d]->data_r();
 		}
 	}
 
@@ -106,8 +106,8 @@ WRITE8_MEMBER(supstarf_state::psg_latch_w)
 	{
 		if (m_pcs[d])
 		{
-			m_psg[d]->address_w(space, 0, offset);
-			m_psg[d]->data_w(space, 0, data);
+			m_psg[d]->address_w(offset);
+			m_psg[d]->data_w(data);
 		}
 	}
 

--- a/src/mame/drivers/tiki100.cpp
+++ b/src/mame/drivers/tiki100.cpp
@@ -113,7 +113,7 @@ READ8_MEMBER( tiki100_state::iorq_r )
 		switch (offset & 0x03)
 		{
 		case 3:
-			data = m_psg->data_r(space, 0);
+			data = m_psg->data_r();
 			break;
 		}
 		break;
@@ -160,11 +160,11 @@ WRITE8_MEMBER( tiki100_state::iorq_w )
 			break;
 
 		case 2:
-			m_psg->address_w(space, 0, data);
+			m_psg->address_w(data);
 			break;
 
 		case 3:
-			m_psg->data_w(space, 0, data);
+			m_psg->data_w(data);
 			break;
 		}
 		break;

--- a/src/mame/drivers/vega.cpp
+++ b/src/mame/drivers/vega.cpp
@@ -194,7 +194,7 @@ WRITE8_MEMBER(vega_state::extern_w)
 		case 1: /* 04-07 */
 		{
 			/* AY 3-8910 */
-			m_ay8910->address_w(space, 0, offset);
+			m_ay8910->address_w(offset);
 		}
 		break;
 
@@ -322,7 +322,7 @@ READ8_MEMBER(vega_state::extern_r)
 		case 1: /* 04-07 */
 		{
 			/* AY 3-8910 */
-			m_ay8910->data_w(space, 0, offset);
+			m_ay8910->data_w(offset);
 			return 0xff;//mame_rand(machine);
 		}
 

--- a/src/mame/drivers/videopkr.cpp
+++ b/src/mame/drivers/videopkr.cpp
@@ -911,11 +911,11 @@ WRITE8_MEMBER(videopkr_state::baby_sound_p3_w)
 		case 0x00:  break;
 		case 0x01:  break;
 		case 0x02:  break;
-		case 0x03:  m_aysnd->data_w(space, 1, m_sbp0); break;
+		case 0x03:  m_aysnd->data_w(m_sbp0); break;
 		case 0x04:  break;
-		case 0x05:  m_sbp0 = m_aysnd->data_r(space, m_sbp0); break;
+		case 0x05:  m_sbp0 = m_aysnd->data_r(); break;
 		case 0x06:  break;
-		case 0x07:  m_aysnd->address_w(space, 0, m_sbp0); break;
+		case 0x07:  m_aysnd->address_w(m_sbp0); break;
 	}
 }
 

--- a/src/mame/includes/kchamp.h
+++ b/src/mame/includes/kchamp.h
@@ -77,7 +77,7 @@ private:
 	DECLARE_WRITE8_MEMBER(kchamp_videoram_w);
 	DECLARE_WRITE8_MEMBER(kchamp_colorram_w);
 	DECLARE_WRITE_LINE_MEMBER(flipscreen_w);
-	DECLARE_WRITE8_MEMBER(sound_control_w);
+	void sound_control_w(u8 data);
 	TILE_GET_INFO_MEMBER(get_bg_tile_info);
 	virtual void machine_reset() override;
 	virtual void video_start() override;

--- a/src/mame/machine/amstrad.cpp
+++ b/src/mame/machine/amstrad.cpp
@@ -505,9 +505,9 @@ void amstrad_state::amstrad_plus_dma_parse(int channel)
 	{
 	case 0x0000:  // Load PSG register
 		{
-			m_ay->address_w(generic_space(), 0, (command & 0x0f00) >> 8);
-			m_ay->data_w(generic_space(), 0, command & 0x00ff);
-			m_ay->address_w(generic_space(), 0, m_prev_reg);
+			m_ay->address_w((command & 0x0f00) >> 8);
+			m_ay->data_w(command & 0x00ff);
+			m_ay->address_w(m_prev_reg);
 		}
 		logerror("DMA %i: LOAD %i, %i\n",channel,(command & 0x0f00) >> 8, command & 0x00ff);
 		break;
@@ -2303,11 +2303,11 @@ void amstrad_state::amstrad_handle_snapshot(unsigned char *pSnapshot)
 	/* PSG */
 	for (i=0; i<16; i++)
 	{
-		m_ay->address_w(space, 0, i);
-		m_ay->data_w(space, 0, pSnapshot[0x05b + i] & 0x0ff);
+		m_ay->address_w(i);
+		m_ay->data_w(pSnapshot[0x05b + i] & 0x0ff);
 	}
 
-	m_ay->address_w(space, 0, pSnapshot[0x05a]);
+	m_ay->address_w(pSnapshot[0x05a]);
 
 	{
 		int MemSize;
@@ -2511,12 +2511,12 @@ void amstrad_state::update_psg()
 		} break;
 	case 1:
 		{/* b6 = 1 ? : Read from selected PSG register and make the register data available to PPI Port A */
-			m_ppi_port_inputs[amstrad_ppi_PortA] = m_ay->data_r(space, 0);
+			m_ppi_port_inputs[amstrad_ppi_PortA] = m_ay->data_r();
 		}
 		break;
 	case 2:
 		{/* b7 = 1 ? : Write to selected PSG register and write data to PPI Port A */
-			m_ay->data_w(space, 0, m_ppi_port_outputs[amstrad_ppi_PortA]);
+			m_ay->data_w(m_ppi_port_outputs[amstrad_ppi_PortA]);
 		}
 		break;
 	case 3:
@@ -2524,7 +2524,7 @@ void amstrad_state::update_psg()
 			/* ignore if an invalid PSG register is selected, usually when the PPI port directions are changed after selecting the PSG register */
 			if(m_ppi_port_outputs[amstrad_ppi_PortA] <= 15)
 			{
-				m_ay->address_w(space, 0, m_ppi_port_outputs[amstrad_ppi_PortA]);
+				m_ay->address_w(m_ppi_port_outputs[amstrad_ppi_PortA]);
 				m_prev_reg = m_ppi_port_outputs[amstrad_ppi_PortA];
 			}
 		}

--- a/src/mame/machine/dgnalpha.cpp
+++ b/src/mame/machine/dgnalpha.cpp
@@ -239,13 +239,13 @@ WRITE8_MEMBER( dragon_alpha_state::pia2_pa_w )
 		case 0x00:      /* Inactive, do nothing */
 			break;
 		case 0x01:      /* Write to selected port */
-			m_ay8912->data_w(space, 0, m_pia_2->b_output());
+			m_ay8912->data_w(m_pia_2->b_output());
 			break;
 		case 0x02:      /* Read from selected port */
-			m_pia_2->write_portb(m_ay8912->data_r(space, 0));
+			m_pia_2->write_portb(m_ay8912->data_r());
 			break;
 		case 0x03:      /* Select port to write to */
-			m_ay8912->address_w(space, 0, m_pia_2->b_output());
+			m_ay8912->address_w(m_pia_2->b_output());
 			break;
 	}
 }

--- a/src/mame/machine/leland.cpp
+++ b/src/mame/machine/leland.cpp
@@ -1103,10 +1103,10 @@ READ8_MEMBER(leland_state::leland_master_input_r)
 		case 0x03:  /* /IGID */
 		case 0x13:
 			if (m_ay8910)
-				result &= m_ay8910->data_r(space, 0);
+				result &= m_ay8910->data_r();
 
 			if (m_ay8912)
-				result &= m_ay8912->data_r(space, 0);
+				result &= m_ay8912->data_r();
 			break;
 
 		case 0x10:  /* /GIN0 */
@@ -1146,10 +1146,10 @@ WRITE8_MEMBER(leland_state::leland_master_output_w)
 		case 0x0a:  /* /OGIA */
 		case 0x0b:  /* /OGID */
 			if (m_ay8910)
-				m_ay8910->address_data_w(space, offset - 0x0a, data);
+				m_ay8910->address_data_w(offset - 0x0a, data);
 
 			if (m_ay8912)
-				m_ay8912->address_data_w(space, offset - 0x0a, data);
+				m_ay8912->address_data_w(offset - 0x0a, data);
 			break;
 
 		case 0x0c:  /* /BKXL */

--- a/src/mame/machine/microtan.cpp
+++ b/src/mame/machine/microtan.cpp
@@ -770,15 +770,15 @@ void microtan_state::snapshot_copy(uint8_t *snapshot_buff, int snapshot_size)
 		/* first set of AY8910 registers */
 		for (int i = 0; i < 16; i++ )
 		{
-			m_ay8910[0]->address_w(generic_space(), 0, i);
-			m_ay8910[0]->data_w(generic_space(), 0, snapshot_buff[base++]);
+			m_ay8910[0]->address_w(i);
+			m_ay8910[0]->data_w(snapshot_buff[base++]);
 		}
 
 		/* second set of AY8910 registers */
 		for (int i = 0; i < 16; i++ )
 		{
-			m_ay8910[0]->address_w(generic_space(), 0, i);
-			m_ay8910[0]->data_w(generic_space(), 0, snapshot_buff[base++]);
+			m_ay8910[0]->address_w(i);
+			m_ay8910[0]->data_w(snapshot_buff[base++]);
 		}
 
 		for (int i = 0; i < 32*16; i++)

--- a/src/mame/machine/mpu4.cpp
+++ b/src/mame/machine/mpu4.cpp
@@ -1114,14 +1114,14 @@ void mpu4_state::update_ay(device_t *device)
 
 		case 0x02:
 			/* CA2 = 0 CB2 = 1? : Write to selected PSG register and write data to Port A */
-			m_ay8913->data_w(generic_space(), 0, m_pia6->a_output());
+			m_ay8913->data_w(m_pia6->a_output());
 			LOG(("AY Chip Write \n"));
 			break;
 
 		case 0x03:
 			/* CA2 = 1 CB2 = 1? : The register will now be selected and the user can read from or write to it.
 			The register will remain selected until another is chosen.*/
-			m_ay8913->address_w(generic_space(), 0, m_pia6->a_output());
+			m_ay8913->address_w(m_pia6->a_output());
 			LOG(("AY Chip Select \n"));
 			break;
 

--- a/src/mame/machine/orion.cpp
+++ b/src/mame/machine/orion.cpp
@@ -357,7 +357,7 @@ READ8_MEMBER(orion_state::orionz80_io_r)
 {
 	if (offset == 0xFFFD)
 	{
-		return m_ay8912->data_r(space, 0);
+		return m_ay8912->data_r();
 	}
 	return 0xff;
 }
@@ -375,10 +375,10 @@ WRITE8_MEMBER(orion_state::orionz80_io_w)
 	}
 	switch(offset)
 	{
-		case 0xfffd : m_ay8912->address_w(space, 0, data);
+		case 0xfffd : m_ay8912->address_w(data);
 						break;
 		case 0xbffd :
-		case 0xbefd : m_ay8912->data_w(space, 0, data);
+		case 0xbefd : m_ay8912->data_w(data);
 						break;
 	}
 }
@@ -548,7 +548,7 @@ READ8_MEMBER(orion_state::orionpro_io_r)
 	}
 	if (offset == 0xFFFD)
 	{
-		return m_ay8912->data_r(space, 0);
+		return m_ay8912->data_r();
 	}
 	return 0xff;
 }
@@ -586,10 +586,10 @@ WRITE8_MEMBER(orion_state::orionpro_io_w)
 	}
 	switch(offset)
 	{
-		case 0xfffd : m_ay8912->address_w(space, 0, data);
+		case 0xfffd : m_ay8912->address_w(data);
 						break;
 		case 0xbffd :
-		case 0xbefd : m_ay8912->data_w(space, 0, data);
+		case 0xbefd : m_ay8912->data_w(data);
 						break;
 	}
 }

--- a/src/mame/machine/spec_snqk.cpp
+++ b/src/mame/machine/spec_snqk.cpp
@@ -2323,10 +2323,10 @@ void spectrum_state::setup_z80(uint8_t *snapdata, uint32_t snapsize)
 			// Only set up sound registers for 128K machine or TS2068!
 			for (i = 0; i < 16; i++)
 			{
-				ay8912->address_w(generic_space(), 0, i);
-				ay8912->data_w(generic_space(), 0, snapdata[39 + i]);
+				ay8912->address_w(i);
+				ay8912->data_w(snapdata[39 + i]);
 			}
-			ay8912->address_w(generic_space(), 0, snapdata[38]);
+			ay8912->address_w(snapdata[38]);
 		}
 
 		pSource = snapdata + header_size;

--- a/src/mame/machine/vector06.cpp
+++ b/src/mame/machine/vector06.cpp
@@ -74,7 +74,7 @@ READ8_MEMBER( vector06_state::vector06_romdisk_portb_r )
 	if ((m_romdisk_msb & 0x80) && m_cart->exists() && addr < m_cart->get_rom_size())
 		return m_cart->read_rom(space, addr);
 	else
-		return m_ay->read_data();
+		return m_ay->data_r();
 }
 
 WRITE8_MEMBER(vector06_state::vector06_romdisk_portb_w)
@@ -90,7 +90,7 @@ WRITE8_MEMBER( vector06_state::vector06_romdisk_porta_w )
 WRITE8_MEMBER( vector06_state::vector06_romdisk_portc_w )
 {
 	if (data & 4)
-		m_ay->address_data_w(space, (data >> 1) & 1, m_aylatch);
+		m_ay->address_data_w((data >> 1) & 1, m_aylatch);
 	m_romdisk_msb = data;
 }
 

--- a/src/mame/machine/vectrex.cpp
+++ b/src/mame/machine/vectrex.cpp
@@ -205,7 +205,7 @@ READ8_MEMBER(vectrex_base_state::vectrex_via_pa_r)
 	if ((!(m_via_out[PORTB] & 0x10)) && (m_via_out[PORTB] & 0x08))
 		/* BDIR inactive, we can read the PSG. BC1 has to be active. */
 	{
-		m_via_out[PORTA] = m_ay8912->data_r(space, 0)
+		m_via_out[PORTA] = m_ay8912->data_r()
 			& ~(m_imager_pinlevel & 0x80);
 	}
 	return m_via_out[PORTA];

--- a/src/mame/video/vectrex.cpp
+++ b/src/mame/video/vectrex.cpp
@@ -345,9 +345,9 @@ WRITE8_MEMBER(vectrex_base_state::v_via_pb_w)
 	if (data & 0x10)
 	{
 		if (data & 0x08) /* BC1 (do we select a reg or write it ?) */
-			m_ay8912->address_w(space, 0, m_via_out[PORTA]);
+			m_ay8912->address_w(m_via_out[PORTA]);
 		else
-			m_ay8912->data_w(space, 0, m_via_out[PORTA]);
+			m_ay8912->data_w(m_via_out[PORTA]);
 	}
 
 	if (!(data & 0x1) && (m_via_out[PORTB] & 0x1))


### PR DESCRIPTION
Use shorter / correct type values, Remove unnecessary arguments in handlers, Duplicates
device/bus/coco/cococart.cpp : Allow various types of delegates for install handler
5clown.cpp : Remove unnecessary arguments in some handler
kchamp.cpp : Remove unnecessary arguments in some handler