### PR TITLE
taitosnd.cpp : Remove unnecessary arguments in handlers, Defines, Use…

### DIFF
--- a/src/mame/audio/taitosnd.cpp
+++ b/src/mame/audio/taitosnd.cpp
@@ -26,10 +26,10 @@
 
 **********************************************************************************************/
 
-#define TC0140SYT_PORT01_FULL         (0x01)
-#define TC0140SYT_PORT23_FULL         (0x02)
-#define TC0140SYT_PORT01_FULL_MASTER  (0x04)
-#define TC0140SYT_PORT23_FULL_MASTER  (0x08)
+static constexpr u8 TC0140SYT_PORT01_FULL =        0x01;
+static constexpr u8 TC0140SYT_PORT23_FULL =        0x02;
+static constexpr u8 TC0140SYT_PORT01_FULL_MASTER = 0x04;
+static constexpr u8 TC0140SYT_PORT23_FULL_MASTER = 0x08;
 
 
 // device type definition
@@ -45,7 +45,7 @@ DEFINE_DEVICE_TYPE(PC060HA, pc060ha_device, "pc060ha", "Taito PC060HA CIU")
 //  tc0140syt_device - constructor
 //-------------------------------------------------
 
-tc0140syt_device::tc0140syt_device(const machine_config &mconfig, device_type type, const char *tag, device_t *owner, uint32_t clock)
+tc0140syt_device::tc0140syt_device(const machine_config &mconfig, device_type type, const char *tag, device_t *owner, u32 clock)
 	: device_t(mconfig, type, tag, owner, clock)
 	, m_mainmode(0)
 	, m_submode(0)
@@ -54,11 +54,11 @@ tc0140syt_device::tc0140syt_device(const machine_config &mconfig, device_type ty
 	, m_mastercpu(*this, finder_base::DUMMY_TAG)
 	, m_slavecpu(*this, finder_base::DUMMY_TAG)
 {
-	memset(m_slavedata, 0, sizeof(uint8_t)*4);
-	memset(m_masterdata, 0, sizeof(uint8_t)*4);
+	std::fill(std::begin(m_slavedata), std::end(m_slavedata), 0);
+	std::fill(std::begin(m_masterdata), std::end(m_masterdata), 0);
 }
 
-tc0140syt_device::tc0140syt_device(const machine_config &mconfig, const char *tag, device_t *owner, uint32_t clock)
+tc0140syt_device::tc0140syt_device(const machine_config &mconfig, const char *tag, device_t *owner, u32 clock)
 	: tc0140syt_device(mconfig, TC0140SYT, tag, owner, clock)
 {
 }
@@ -90,7 +90,7 @@ void tc0140syt_device::device_reset()
 	m_status = 0;
 	m_nmi_enabled = 0;
 
-	for (uint32_t i = 0; i < 4; i++)
+	for (u8 i = 0; i < 4; i++)
 	{
 		m_slavedata[i] = 0;
 		m_masterdata[i] = 0;
@@ -104,8 +104,8 @@ void tc0140syt_device::device_reset()
 
 void tc0140syt_device::update_nmi()
 {
-	uint32_t nmi_pending = m_status & (TC0140SYT_PORT23_FULL | TC0140SYT_PORT01_FULL);
-	uint32_t state = (nmi_pending && m_nmi_enabled) ? ASSERT_LINE : CLEAR_LINE;
+	u32 nmi_pending = m_status & (TC0140SYT_PORT23_FULL | TC0140SYT_PORT01_FULL);
+	u32 state = (nmi_pending && m_nmi_enabled) ? ASSERT_LINE : CLEAR_LINE;
 
 	m_slavecpu->set_input_line(INPUT_LINE_NMI, state);
 }
@@ -115,7 +115,7 @@ void tc0140syt_device::update_nmi()
 //  MASTER SIDE
 //-------------------------------------------------
 
-WRITE8_MEMBER( tc0140syt_device::master_port_w )
+void tc0140syt_device::master_port_w(u8 data)
 {
 	data &= 0x0f;
 	m_mainmode = data;
@@ -126,7 +126,7 @@ WRITE8_MEMBER( tc0140syt_device::master_port_w )
 	}
 }
 
-WRITE8_MEMBER( tc0140syt_device::master_comm_w )
+void tc0140syt_device::master_comm_w(u8 data)
 {
 	machine().scheduler().synchronize(); // let slavecpu catch up (after we return and the main cpu finishes what it's doing)
 	data &= 0x0f; /* this is important, otherwise ballbros won't work */
@@ -163,10 +163,10 @@ WRITE8_MEMBER( tc0140syt_device::master_comm_w )
 	}
 }
 
-READ8_MEMBER( tc0140syt_device::master_comm_r )
+u8 tc0140syt_device::master_comm_r()
 {
 	machine().scheduler().synchronize(); // let slavecpu catch up (after we return and the main cpu finishes what it's doing)
-	uint8_t res = 0;
+	u8 res = 0;
 
 	switch (m_mainmode)
 	{
@@ -204,7 +204,7 @@ READ8_MEMBER( tc0140syt_device::master_comm_r )
 //  SLAVE SIDE
 //-------------------------------------------------
 
-WRITE8_MEMBER( tc0140syt_device::slave_port_w )
+void tc0140syt_device::slave_port_w(u8 data)
 {
 	data &= 0x0f;
 	m_submode = data;
@@ -215,7 +215,7 @@ WRITE8_MEMBER( tc0140syt_device::slave_port_w )
 	}
 }
 
-WRITE8_MEMBER( tc0140syt_device::slave_comm_w )
+void tc0140syt_device::slave_comm_w(u8 data)
 {
 	data &= 0x0f;
 
@@ -258,9 +258,9 @@ WRITE8_MEMBER( tc0140syt_device::slave_comm_w )
 	}
 }
 
-READ8_MEMBER( tc0140syt_device::slave_comm_r )
+u8 tc0140syt_device::slave_comm_r()
 {
-	uint8_t res = 0;
+	u8 res = 0;
 
 	switch (m_submode)
 	{
@@ -300,7 +300,7 @@ READ8_MEMBER( tc0140syt_device::slave_comm_r )
 //  pc060ha_device - constructor
 //-------------------------------------------------
 
-pc060ha_device::pc060ha_device(const machine_config &mconfig, const char *tag, device_t *owner, uint32_t clock)
+pc060ha_device::pc060ha_device(const machine_config &mconfig, const char *tag, device_t *owner, u32 clock)
 	: tc0140syt_device(mconfig, PC060HA, tag, owner, clock)
 {
 }

--- a/src/mame/audio/taitosnd.h
+++ b/src/mame/audio/taitosnd.h
@@ -13,23 +13,23 @@
 class tc0140syt_device : public device_t
 {
 public:
-	tc0140syt_device(const machine_config &mconfig, const char *tag, device_t *owner, uint32_t clock);
+	tc0140syt_device(const machine_config &mconfig, const char *tag, device_t *owner, u32 clock);
 
 	template <typename T> void set_master_tag(T &&tag) { m_mastercpu.set_tag(std::forward<T>(tag)); }
 	template <typename T> void set_slave_tag(T &&tag) { m_slavecpu.set_tag(std::forward<T>(tag)); }
 
 	// MASTER (4-bit bus) control functions
-	DECLARE_WRITE8_MEMBER( master_port_w );
-	DECLARE_WRITE8_MEMBER( master_comm_w );
-	DECLARE_READ8_MEMBER( master_comm_r );
+	void master_port_w(u8 data);
+	void master_comm_w(u8 data);
+	u8 master_comm_r();
 
 	// SLAVE (4-bit bus) control functions ONLY
-	DECLARE_WRITE8_MEMBER( slave_port_w );
-	DECLARE_READ8_MEMBER( slave_comm_r );
-	DECLARE_WRITE8_MEMBER( slave_comm_w );
+	void slave_port_w(u8 data);
+	u8 slave_comm_r();
+	void slave_comm_w(u8 data);
 
 protected:
-	tc0140syt_device(const machine_config &mconfig, device_type type, const char *tag, device_t *owner, uint32_t clock);
+	tc0140syt_device(const machine_config &mconfig, device_type type, const char *tag, device_t *owner, u32 clock);
 
 	// device-level overrides
 	virtual void device_start() override;
@@ -38,12 +38,12 @@ protected:
 private:
 	void update_nmi();
 
-	uint8_t     m_slavedata[4];  /* Data on master->slave port (4 nibbles) */
-	uint8_t     m_masterdata[4]; /* Data on slave->master port (4 nibbles) */
-	uint8_t     m_mainmode;      /* Access mode on master cpu side */
-	uint8_t     m_submode;       /* Access mode on slave cpu side */
-	uint8_t     m_status;        /* Status data */
-	uint8_t     m_nmi_enabled;   /* 1 if slave cpu has nmi's enabled */
+	u8     m_slavedata[4];  /* Data on master->slave port (4 nibbles) */
+	u8     m_masterdata[4]; /* Data on slave->master port (4 nibbles) */
+	u8     m_mainmode;      /* Access mode on master cpu side */
+	u8     m_submode;       /* Access mode on slave cpu side */
+	u8     m_status;        /* Status data */
+	u8     m_nmi_enabled;   /* 1 if slave cpu has nmi's enabled */
 
 	required_device<cpu_device> m_mastercpu;     /* this is the maincpu */
 	required_device<cpu_device> m_slavecpu;      /* this is the audiocpu */
@@ -54,7 +54,7 @@ private:
 class pc060ha_device : public tc0140syt_device
 {
 public:
-	pc060ha_device(const machine_config &mconfig, const char *tag, device_t *owner, uint32_t clock);
+	pc060ha_device(const machine_config &mconfig, const char *tag, device_t *owner, u32 clock);
 };
 
 DECLARE_DEVICE_TYPE(TC0140SYT, tc0140syt_device)

--- a/src/mame/drivers/ninjaw.cpp
+++ b/src/mame/drivers/ninjaw.cpp
@@ -348,7 +348,7 @@ WRITE16_MEMBER(ninjaw_state::cpua_ctrl_w)
 }
 
 
-WRITE8_MEMBER(ninjaw_state::coin_control_w)
+void ninjaw_state::coin_control_w(u8 data)
 {
 	machine().bookkeeping().coin_lockout_w(0, ~data & 0x01);
 	machine().bookkeeping().coin_lockout_w(1, ~data & 0x02);
@@ -361,36 +361,15 @@ WRITE8_MEMBER(ninjaw_state::coin_control_w)
             SOUND
 *****************************************/
 
-WRITE8_MEMBER(ninjaw_state::sound_bankswitch_w)
+void ninjaw_state::sound_bankswitch_w(u8 data)
 {
 	m_z80bank->set_entry(data & 7);
-}
-
-WRITE16_MEMBER(ninjaw_state::sound_w)
-{
-	if (offset == 0)
-		m_tc0140syt->master_port_w(space, 0, data & 0xff);
-	else if (offset == 1)
-		m_tc0140syt->master_comm_w(space, 0, data & 0xff);
-
-#ifdef MAME_DEBUG
-	if (data & 0xff00)
-		popmessage("sound_w to high byte: %04x", data);
-#endif
-}
-
-READ16_MEMBER(ninjaw_state::sound_r)
-{
-	if (offset == 1)
-		return ((m_tc0140syt->master_comm_r(space, 0) & 0xff));
-	else
-		return 0;
 }
 
 
 /**** sound pan control ****/
 
-WRITE8_MEMBER(ninjaw_state::pancontrol_w)
+void ninjaw_state::pancontrol_w(offs_t offset, u8 data)
 {
 	filter_volume_device *flt = nullptr;
 	offset &= 3;
@@ -426,7 +405,8 @@ void ninjaw_state::ninjaw_master_map(address_map &map)
 	map(0x0c0000, 0x0cffff).ram();                                                     /* main ram */
 	map(0x200000, 0x200003).rw("tc0040ioc", FUNC(tc0040ioc_device::read), FUNC(tc0040ioc_device::write)).umask16(0x00ff);
 	map(0x210000, 0x210001).w(FUNC(ninjaw_state::cpua_ctrl_w));
-	map(0x220000, 0x220003).rw(FUNC(ninjaw_state::sound_r), FUNC(ninjaw_state::sound_w));
+	map(0x220001, 0x220001).w(m_tc0140syt, FUNC(tc0140syt_device::master_port_w));
+	map(0x220003, 0x220003).rw(m_tc0140syt, FUNC(tc0140syt_device::master_comm_r), FUNC(tc0140syt_device::master_comm_w));
 	map(0x240000, 0x24ffff).ram().share("share1");
 	map(0x260000, 0x263fff).ram().share("spriteram");
 	map(0x280000, 0x293fff).r(m_tc0100scn[0], FUNC(tc0100scn_device::word_r)).w(FUNC(ninjaw_state::tc0100scn_triple_screen_w)); /* tilemaps (1st screen/all screens) */
@@ -462,7 +442,8 @@ void ninjaw_state::darius2_master_map(address_map &map)
 	map(0x0c0000, 0x0cffff).ram();                         /* main ram */
 	map(0x200000, 0x200003).rw("tc0040ioc", FUNC(tc0040ioc_device::read), FUNC(tc0040ioc_device::write)).umask16(0x00ff);
 	map(0x210000, 0x210001).w(FUNC(ninjaw_state::cpua_ctrl_w));
-	map(0x220000, 0x220003).rw(FUNC(ninjaw_state::sound_r), FUNC(ninjaw_state::sound_w));
+	map(0x220001, 0x220001).w(m_tc0140syt, FUNC(tc0140syt_device::master_port_w));
+	map(0x220003, 0x220003).rw(m_tc0140syt, FUNC(tc0140syt_device::master_comm_r), FUNC(tc0140syt_device::master_comm_w));
 	map(0x240000, 0x24ffff).ram().share("share1");
 	map(0x260000, 0x263fff).ram().share("spriteram");
 	map(0x280000, 0x293fff).r(m_tc0100scn[0], FUNC(tc0100scn_device::word_r)).w(FUNC(ninjaw_state::tc0100scn_triple_screen_w)); /* tilemaps (1st screen/all screens) */

--- a/src/mame/drivers/othunder.cpp
+++ b/src/mame/drivers/othunder.cpp
@@ -294,7 +294,7 @@ TODO:
                 INTERRUPTS
 ***********************************************************/
 
-WRITE16_MEMBER( othunder_state::irq_ack_w )
+void othunder_state::irq_ack_w(offs_t offset, u16 data)
 {
 	switch (offset)
 	{
@@ -329,7 +329,7 @@ The eeprom unlock command is different, and the write/clock/reset
 bits are different.
 ******************************************************************/
 
-WRITE8_MEMBER(othunder_state::eeprom_w)
+void othunder_state::eeprom_w(u8 data)
 {
 
 /*              0000000x    SOL-1 (gun solenoid)
@@ -353,7 +353,7 @@ WRITE8_MEMBER(othunder_state::eeprom_w)
 	m_eeprom->cs_write((data & 0x10) ? ASSERT_LINE : CLEAR_LINE);
 }
 
-WRITE8_MEMBER(othunder_state::coins_w)
+void othunder_state::coins_w(u8 data)
 {
 	machine().bookkeeping().coin_lockout_w(0, ~data & 0x01);
 	machine().bookkeeping().coin_lockout_w(1, ~data & 0x02);
@@ -366,28 +366,12 @@ WRITE8_MEMBER(othunder_state::coins_w)
             SOUND
 *****************************************/
 
-WRITE8_MEMBER(othunder_state::sound_bankswitch_w)
+void othunder_state::sound_bankswitch_w(u8 data)
 {
 	membank("z80bank")->set_entry(data & 3);
 }
 
-WRITE16_MEMBER(othunder_state::sound_w)
-{
-	if (offset == 0)
-		m_tc0140syt->master_port_w(space, 0, data & 0xff);
-	else if (offset == 1)
-		m_tc0140syt->master_comm_w(space, 0, data & 0xff);
-}
-
-READ16_MEMBER(othunder_state::sound_r)
-{
-	if (offset == 1)
-		return ((m_tc0140syt->master_comm_r(space, 0) & 0xff));
-	else
-		return 0;
-}
-
-WRITE8_MEMBER(othunder_state::tc0310fam_w)
+void othunder_state::tc0310fam_w(offs_t offset, u8 data)
 {
 	/* there are two TC0310FAM, one for CH1 and one for CH2 from the YM2610. The
 	   PSG output is routed to both chips. */
@@ -429,7 +413,8 @@ void othunder_state::othunder_map(address_map &map)
 	map(0x100000, 0x100007).rw(m_tc0110pcr, FUNC(tc0110pcr_device::word_r), FUNC(tc0110pcr_device::step1_rbswap_word_w));   /* palette */
 	map(0x200000, 0x20ffff).rw(m_tc0100scn, FUNC(tc0100scn_device::word_r), FUNC(tc0100scn_device::word_w));    /* tilemaps */
 	map(0x220000, 0x22000f).rw(m_tc0100scn, FUNC(tc0100scn_device::ctrl_word_r), FUNC(tc0100scn_device::ctrl_word_w));
-	map(0x300000, 0x300003).rw(FUNC(othunder_state::sound_r), FUNC(othunder_state::sound_w));
+	map(0x300001, 0x300001).w(m_tc0140syt, FUNC(tc0140syt_device::master_port_w));
+	map(0x300003, 0x300003).rw(m_tc0140syt, FUNC(tc0140syt_device::master_comm_r), FUNC(tc0140syt_device::master_comm_w));
 	map(0x400000, 0x4005ff).ram().share("spriteram");
 	map(0x500000, 0x500007).rw("adc", FUNC(adc0808_device::data_r), FUNC(adc0808_device::address_offset_start_w)).umask16(0x00ff);
 	map(0x600000, 0x600003).w(FUNC(othunder_state::irq_ack_w));

--- a/src/mame/drivers/slapshot.cpp
+++ b/src/mame/drivers/slapshot.cpp
@@ -135,7 +135,6 @@ Region byte at offset 0x031:
 
 #include "emu.h"
 #include "includes/slapshot.h"
-#include "audio/taitosnd.h"
 
 #include "cpu/m68000/m68000.h"
 #include "cpu/z80/z80.h"
@@ -187,7 +186,7 @@ READ16_MEMBER(slapshot_state::service_input_r)
 	}
 }
 
-WRITE8_MEMBER(slapshot_state::coin_control_w)
+void slapshot_state::coin_control_w(u8 data)
 {
 	machine().bookkeeping().coin_lockout_w(0, ~data & 0x01);
 	machine().bookkeeping().coin_lockout_w(1, ~data & 0x02);
@@ -199,32 +198,10 @@ WRITE8_MEMBER(slapshot_state::coin_control_w)
                 SOUND
 *****************************************************/
 
-WRITE8_MEMBER(slapshot_state::sound_bankswitch_w)
+void slapshot_state::sound_bankswitch_w(u8 data)
 {
 	membank("z80bank")->set_entry(data & 3);
 }
-
-WRITE16_MEMBER(slapshot_state::msb_sound_w)
-{
-	if (offset == 0)
-		m_tc0140syt->master_port_w(space, 0, (data >> 8) & 0xff);
-	else if (offset == 1)
-		m_tc0140syt->master_comm_w(space, 0, (data >> 8) & 0xff);
-
-#ifdef MAME_DEBUG
-	if (data & 0xff)
-		popmessage("taito_msb_sound_w to low byte: %04x",data);
-#endif
-}
-
-READ16_MEMBER(slapshot_state::msb_sound_r)
-{
-	if (offset == 1)
-		return ((m_tc0140syt->master_comm_r(space, 0) & 0xff) << 8);
-	else
-		return 0;
-}
-
 
 /***********************************************************
              MEMORY STRUCTURES
@@ -243,7 +220,8 @@ void slapshot_state::slapshot_map(address_map &map)
 	map(0xb00000, 0xb0001f).w(m_tc0360pri, FUNC(tc0360pri_device::write)).umask16(0xff00);  /* priority chip */
 	map(0xc00000, 0xc0000f).rw(m_tc0640fio, FUNC(tc0640fio_device::halfword_byteswap_r), FUNC(tc0640fio_device::halfword_byteswap_w));
 	map(0xc00020, 0xc0002f).r(FUNC(slapshot_state::service_input_r));  /* service mirror */
-	map(0xd00000, 0xd00003).rw(FUNC(slapshot_state::msb_sound_r), FUNC(slapshot_state::msb_sound_w));
+	map(0xd00000, 0xd00000).w(m_tc0140syt, FUNC(tc0140syt_device::master_port_w));
+	map(0xd00002, 0xd00002).rw(m_tc0140syt, FUNC(tc0140syt_device::master_comm_r), FUNC(tc0140syt_device::master_comm_w));
 }
 
 void slapshot_state::opwolf3_map(address_map &map)
@@ -259,7 +237,8 @@ void slapshot_state::opwolf3_map(address_map &map)
 	map(0xb00000, 0xb0001f).w(m_tc0360pri, FUNC(tc0360pri_device::write)).umask16(0xff00);  /* priority chip */
 	map(0xc00000, 0xc0000f).rw(m_tc0640fio, FUNC(tc0640fio_device::halfword_byteswap_r), FUNC(tc0640fio_device::halfword_byteswap_w));
 	map(0xc00020, 0xc0002f).r(FUNC(slapshot_state::service_input_r));   /* service mirror */
-	map(0xd00000, 0xd00003).rw(FUNC(slapshot_state::msb_sound_r), FUNC(slapshot_state::msb_sound_w));
+	map(0xd00000, 0xd00000).w(m_tc0140syt, FUNC(tc0140syt_device::master_port_w));
+	map(0xd00002, 0xd00002).rw(m_tc0140syt, FUNC(tc0140syt_device::master_comm_r), FUNC(tc0140syt_device::master_comm_w));
 	map(0xe00000, 0xe0000f).rw("adc", FUNC(adc0808_device::data_r), FUNC(adc0808_device::address_offset_start_w)).umask16(0xff00);
 //  map(0xe80000, 0xe80001) // gun recoil here?
 }
@@ -412,7 +391,7 @@ static const gfx_layout tilelayout =
 	128*8   /* every sprite takes 128 consecutive bytes */
 };
 
-static const gfx_layout slapshot_charlayout =
+static const gfx_layout charlayout =
 {
 	16,16,    /* 16*16 characters */
 	RGN_FRAC(1,1),
@@ -424,8 +403,8 @@ static const gfx_layout slapshot_charlayout =
 };
 
 static GFXDECODE_START( gfx_slapshot )
-	GFXDECODE_ENTRY( "gfx2", 0x0, tilelayout,  0, 256 ) /* sprite parts */
-	GFXDECODE_ENTRY( "gfx1", 0x0, slapshot_charlayout, 4096, 256 )    /* sprites & playfield */
+	GFXDECODE_ENTRY( "gfx2", 0x0, tilelayout,    0, 256 ) /* sprite parts */
+	GFXDECODE_ENTRY( "gfx1", 0x0, charlayout, 4096, 256 )    /* sprites & playfield */
 GFXDECODE_END
 
 

--- a/src/mame/drivers/warriorb.cpp
+++ b/src/mame/drivers/warriorb.cpp
@@ -159,7 +159,7 @@ Colscroll effects?
 #include "speaker.h"
 
 
-WRITE8_MEMBER(warriorb_state::coin_control_w)
+void warriorb_state::coin_control_w(u8 data)
 {
 	machine().bookkeeping().coin_lockout_w(0, ~data & 0x01);
 	machine().bookkeeping().coin_lockout_w(1, ~data & 0x02);
@@ -172,29 +172,13 @@ WRITE8_MEMBER(warriorb_state::coin_control_w)
                           SOUND
 ***********************************************************/
 
-WRITE8_MEMBER(warriorb_state::sound_bankswitch_w)
+void warriorb_state::sound_bankswitch_w(u8 data)
 {
 	m_z80bank->set_entry(data & 7);
 }
 
-WRITE16_MEMBER(warriorb_state::sound_w)
-{
-	if (offset == 0)
-		m_tc0140syt->master_port_w(space, 0, data & 0xff);
-	else if (offset == 1)
-		m_tc0140syt->master_comm_w(space, 0, data & 0xff);
-}
 
-READ16_MEMBER(warriorb_state::sound_r)
-{
-	if (offset == 1)
-		return ((m_tc0140syt->master_comm_r(space, 0) & 0xff));
-	else
-		return 0;
-}
-
-
-WRITE8_MEMBER(warriorb_state::pancontrol_w)
+void warriorb_state::pancontrol_w(offs_t offset, u8 data)
 {
 	filter_volume_device *flt = nullptr;
 	offset &= 3;
@@ -237,7 +221,8 @@ void warriorb_state::darius2d_map(address_map &map)
 	map(0x600000, 0x6013ff).ram().share("spriteram");
 	map(0x800000, 0x80000f).rw(m_tc0220ioc, FUNC(tc0220ioc_device::read), FUNC(tc0220ioc_device::write)).umask16(0x00ff);
 //  AM_RANGE(0x820000, 0x820001) AM_WRITENOP    // ???
-	map(0x830000, 0x830003).rw(FUNC(warriorb_state::sound_r), FUNC(warriorb_state::sound_w));
+	map(0x830001, 0x830001).w(m_tc0140syt, FUNC(tc0140syt_device::master_port_w));
+	map(0x830003, 0x830003).rw(m_tc0140syt, FUNC(tc0140syt_device::master_comm_r), FUNC(tc0140syt_device::master_comm_w));
 }
 
 void warriorb_state::warriorb_map(address_map &map)
@@ -253,7 +238,8 @@ void warriorb_state::warriorb_map(address_map &map)
 	map(0x600000, 0x6013ff).ram().share("spriteram");
 	map(0x800000, 0x80000f).rw(m_tc0510nio, FUNC(tc0510nio_device::read), FUNC(tc0510nio_device::write)).umask16(0x00ff);
 //  AM_RANGE(0x820000, 0x820001) AM_WRITENOP    // ? uses bits 0,2,3
-	map(0x830000, 0x830003).rw(FUNC(warriorb_state::sound_r), FUNC(warriorb_state::sound_w));
+	map(0x830001, 0x830001).w(m_tc0140syt, FUNC(tc0140syt_device::master_port_w));
+	map(0x830003, 0x830003).rw(m_tc0140syt, FUNC(tc0140syt_device::master_comm_r), FUNC(tc0140syt_device::master_comm_w));
 }
 
 /***************************************************************************/

--- a/src/mame/includes/ninjaw.h
+++ b/src/mame/includes/ninjaw.h
@@ -61,12 +61,10 @@ private:
 	uint16_t     m_cpua_ctrl;
 	int        m_pandata[4];
 
-	DECLARE_WRITE8_MEMBER(coin_control_w);
+	void coin_control_w(u8 data);
 	DECLARE_WRITE16_MEMBER(cpua_ctrl_w);
-	DECLARE_WRITE8_MEMBER(sound_bankswitch_w);
-	DECLARE_WRITE16_MEMBER(sound_w);
-	DECLARE_READ16_MEMBER(sound_r);
-	DECLARE_WRITE8_MEMBER(pancontrol_w);
+	void sound_bankswitch_w(u8 data);
+	void pancontrol_w(offs_t offset, u8 data);
 	DECLARE_WRITE16_MEMBER(tc0100scn_triple_screen_w);
 
 	virtual void machine_start() override;

--- a/src/mame/includes/othunder.h
+++ b/src/mame/includes/othunder.h
@@ -51,14 +51,12 @@ protected:
 private:
 	void draw_sprites(screen_device &screen, bitmap_ind16 &bitmap, const rectangle &cliprect, const int *primasks, int y_offs);
 
-	DECLARE_WRITE16_MEMBER(irq_ack_w);
-	DECLARE_WRITE8_MEMBER(eeprom_w);
-	DECLARE_WRITE8_MEMBER(coins_w);
+	void irq_ack_w(offs_t offset, u16 data);
+	void eeprom_w(u8 data);
+	void coins_w(u8 data);
 	DECLARE_WRITE_LINE_MEMBER(adc_eoc_w);
-	DECLARE_WRITE8_MEMBER(sound_bankswitch_w);
-	DECLARE_WRITE16_MEMBER(sound_w);
-	DECLARE_READ16_MEMBER(sound_r);
-	DECLARE_WRITE8_MEMBER(tc0310fam_w);
+	void sound_bankswitch_w(u8 data);
+	void tc0310fam_w(offs_t offset, u8 data);
 	uint32_t screen_update(screen_device &screen, bitmap_ind16 &bitmap, const rectangle &cliprect);
 	DECLARE_WRITE_LINE_MEMBER(vblank_w);
 

--- a/src/mame/includes/slapshot.h
+++ b/src/mame/includes/slapshot.h
@@ -87,10 +87,8 @@ private:
 
 	// generic
 	DECLARE_READ16_MEMBER(service_input_r);
-	DECLARE_WRITE8_MEMBER(sound_bankswitch_w);
-	DECLARE_WRITE16_MEMBER(msb_sound_w);
-	DECLARE_READ16_MEMBER(msb_sound_r);
-	DECLARE_WRITE8_MEMBER(coin_control_w);
+	void sound_bankswitch_w(u8 data);
+	void coin_control_w(u8 data);
 
 	uint32_t screen_update(screen_device &screen, bitmap_ind16 &bitmap, const rectangle &cliprect);
 	DECLARE_WRITE_LINE_MEMBER(screen_vblank_taito_no_buffer);

--- a/src/mame/includes/taito_z.h
+++ b/src/mame/includes/taito_z.h
@@ -116,12 +116,10 @@ private:
 	DECLARE_READ16_MEMBER(chasehq_motor_r);
 	DECLARE_WRITE16_MEMBER(chasehq_motor_w);
 	DECLARE_WRITE16_MEMBER(nightstr_motor_w);
-	DECLARE_WRITE8_MEMBER(coin_control_w);
+	void coin_control_w(u8 data);
 	DECLARE_READ16_MEMBER(aquajack_unknown_r);
-	DECLARE_WRITE8_MEMBER(sound_bankswitch_w);
-	DECLARE_WRITE16_MEMBER(taitoz_sound_w);
-	DECLARE_READ16_MEMBER(taitoz_sound_r);
-	DECLARE_WRITE8_MEMBER(taitoz_pancontrol);
+	void sound_bankswitch_w(u8 data);
+	void pancontrol_w(offs_t offset, u8 data);
 	DECLARE_READ16_MEMBER(sci_spriteframe_r);
 	DECLARE_WRITE16_MEMBER(sci_spriteframe_w);
 	DECLARE_WRITE16_MEMBER(contcirc_out_w);

--- a/src/mame/includes/warriorb.h
+++ b/src/mame/includes/warriorb.h
@@ -57,11 +57,9 @@ private:
 	/* misc */
 	int        m_pandata[4];
 
-	DECLARE_WRITE8_MEMBER(coin_control_w);
-	DECLARE_WRITE8_MEMBER(sound_bankswitch_w);
-	DECLARE_WRITE16_MEMBER(sound_w);
-	DECLARE_READ16_MEMBER(sound_r);
-	DECLARE_WRITE8_MEMBER(pancontrol_w);
+	void coin_control_w(u8 data);
+	void sound_bankswitch_w(u8 data);
+	void pancontrol_w(offs_t offset, u8 data);
 	DECLARE_WRITE16_MEMBER(tc0100scn_dual_screen_w);
 
 	virtual void machine_start() override;


### PR DESCRIPTION
… shorter type values

ninjaw.cpp, othunder.cpp, slapshot.cpp, taito_z.cpp, warriorb.cpp : Remove unnecessary handlers, unnecessary arguments in some handlers
taito_z.cpp : Minor naming fixing