### PR TITLE
New NOT_WORKING software list additions

### DIFF
--- a/hash/vsmile_cd.xml
+++ b/hash/vsmile_cd.xml
@@ -29,45 +29,52 @@ ________________________________________________________________________________
      | 80-093025(FR)   | Les Indestructibles - Les Indestructibles à la Rescousse
  *** | 80-093027(SP)   | Los Increíbles - Misión Increíble
 __________________________________________________________________________________________
- *** | 80-093040(US)   | Nickelodeon SpongeBob Squarepants - Idea Sponge
-     | 80-093044(GE)   | Nickelodeon SpongeBob - Ein Schwamm voller Ideen
+ *** | 80-093040(US)   | Nickelodeon SpongeBob Squarepants - Idea Sponge [Needs revision checking]
+ *** | 80-093040(US)   | Nickelodeon SpongeBob Squarepants - Idea Sponge (Rev. 1)
+ *** | 80-093040(US)   | Nickelodeon SpongeBob Squarepants - Idea Sponge (Rev. 2)
+ *** | 80-093044(GE)   | Nick SpongeBob Schwammkopf - Ein Schwamm voller Ideen
      | 80-093045(FR)   | Nickelodeon Bob L'éponge - Une Idée Spongieuse
  *** | 80-093047(SP)   | Nickelodeon Bob Esponja - Misión Esponja
 __________________________________________________________________________________________
- *** | 80-093060(US)   | The Amazing Spider-Man - Countdown to Doom
+ *** | 80-093060(US)   | The Amazing Spider-Man - Countdown to Doom (Rev. 1)
+ *** | 80-093060(US)   | The Amazing Spider-Man - Countdown to Doom (Rev. 2)
  *** | 80-093064(GE)   | Spider-Man - Angriff der Super-Schurken
      | 80-093065(FR)   | Spider-Man - Course-poursuite A Manhattan
  *** | 80-093067(SP)   | El Asombroso Spider-Man - Persecución en la Ciudad
 __________________________________________________________________________________________
- *** | 80-093080(US)   | Scooby-Doo! - Ancient Adventure
+ *** | 80-093080(US)   | Scooby-Doo! - Ancient Adventure (Rev. 1)
      | 80-093083(UK)   | Scooby-Doo! - Ancient Adventure
-     | 80-093084(GE)   | Scooby-Doo! - ????? (no EAN found, but should have been released)
+     | 80-093084(GE)   | Scooby-Doo! - ????? [no EAN found, but should have been released]
      | 80-093085(FR)   | Scooby-Doo! - Les Civilisations Perdues
  *** | 80-093087(SP)   | Scooby-Doo: Viaje al Pasado
 __________________________________________________________________________________________
- *** | 80-093100(US)   | Cars - In The Fast Lane
- *** | 80-093104(GE)   | Cars - Auf der Aeberholspur
-     | 80-093105(FR)   | Cars - À Fond la Caisse!
- *** | 80-093107(SP)   | Cars - El Carril Rápido
+ *** | 80-093100(US)   | Disney/Pixar Cars - In The Fast Lane
+ *** | 80-093100(US)   | Disney/Pixar Cars - In The Fast Lane (Rev. 1)
+ *** | 80-093100(US)   | Disney/Pixar Cars - In The Fast Lane (Rev. 3)
+ *** | 80-093104(GE)   | Disney/Pixar Cars - Auf der Aeberholspur
+     | 80-093105(FR)   | Disney/Pixar Cars - À Fond la Caisse!
+ *** | 80-093107(SP)   | Disney/Pixar Cars - El Carril Rápido
 __________________________________________________________________________________________
- *** | 80-093120(US)   | Wacky Race on Jumpin' Bean Island
+ *** | 80-093120(US)   | Wacky Race on Jumpin' Bean Island (Rev. 2)
+ *** | 80-093120(US)   | Wacky Race on Jumpin' Bean Island (Rev. 3)
+ *** | 80-093123(UK)   | Wacky Race on Jumpin' Bean Island
  *** | 80-093124(GE)   | Das verrückte Rennen der Hüpf-Bohnel Insel
- *** | 80-093127(SP)   | Carrera Loca - En La Isla de las Vainas Fritas
+ *** | 80-093127(SP)   | Carrera Loca en la Isla de las Vainas Fritas
 __________________________________________________________________________________________
  *** | 80-093140(US)   | Shrek The Third - The Search for Arthur
-     | 80-093143(UK)   | Shrek The Third - The Search for Arthur
+ *** | 80-093143(UK)   | Shrek The Third - The Search for Arthur
  *** | 80-093144(GE)   | Shrek Der Dritte - Die Suche nach Arthus
      | 80-093145(FR)   | Shrek Le Troisième - L'aventure D'Arthur
  *** | 80-093147(SP)   | Shrek Tercero - ¿Dónde está Arturo?
 __________________________________________________________________________________________
- *** | 80-093160(US)   | Bratz - The Secret Necklace
+ *** | 80-093160(US)   | Bratz - Fashion Pixiez - The Secret Necklace
      | 80-093165(FR)   | Bratz
  *** | 80-093167(SP)   | Bratz - El Misterio del Collar
 __________________________________________________________________________________________
-     | 80-093180(US)   | Marvel Heroes (according to VTech site, can't confirm)
+     | 80-093180(US)   | Marvel Heroes [according to VTech site, can't confirm]
 __________________________________________________________________________________________
-     | 80-093200(US)   | Ratatouille (according to VTech site, can't confirm)
-     | 80-093204(GE)   | Multisports
+     | 80-093200(US)   | Ratatouille [according to VTech site, can't confirm]
+ *** | 80-093204(GE)   | Multisports
 __________________________________________________________________________________________
      | 80-093220(US)   | National Geographic Kids
 __________________________________________________________________________________________
@@ -90,13 +97,33 @@ ________________________________________________________________________________
 		 <rom name="amazing spider-man, the - countdown to doom (us).img" size="377178480" crc="8b81146a" sha1="eb1627908b34bedfab60d61088d5ff67069ffb48" />
 		 <rom name="amazing spider-man, the - countdown to doom (us).sub" size="15395040" crc="cdece136" sha1="0d03f2a97d5d92079525a940630a7affc5e60a10" />
 		 -->
-		<description>The Amazing Spider-Man - Countdown to Doom (USA)</description>
+		<description>The Amazing Spider-Man - Countdown to Doom (USA, Rev. 1)</description>
 		<year>200?</year>
 		<publisher>VTech</publisher>
 		<info name="serial" value="80-093060" />
 		<part name="cdrom" interface="vsmile_vdisk">
 			<diskarea name="cdrom">
 				<disk name="093060_001" sha1="89f5072904114211890604dd6693ee70d787996b"/>
+			</diskarea>
+		</part>
+	</software>
+
+	<!--
+	Internal Serial: 0ID_93060_002
+	Volume Label: 93060_002
+	Blue cartridge
+	Sticker on the cartridge: 641 ○○●○
+	Barcode: 0 50803 93060 8
+	Ring 1: "* 59-93060-000-000 *", "ifpi LQ24", "IFPI 9QK3", "59-93060-000"
+	-->
+	<software name="spidermnr2" cloneof="spidermn" supported="no">
+		<description>The Amazing Spider-Man - Countdown to Doom (USA, Rev. 2)</description>
+		<year>200?</year>
+		<publisher>VTech</publisher>
+		<info name="serial" value="80-093060" />
+		<part name="cdrom" interface="vsmile_vdisk">
+			<diskarea name="cdrom">
+				<disk name="093060_002" sha1="79fbb95a0c313097d09199a0ff9d0648436afff5"/>
 			</diskarea>
 		</part>
 	</software>
@@ -124,7 +151,7 @@ ________________________________________________________________________________
 	Blue cartridge
 	Sticker on the cartridge: 730 ○○○○
 	Barcode: 3417768930673
-	Ring 1: "59-93067-000-001*",  "IFPI 0949",  "59-93067-000-001"
+	Ring 1: "59-93067-000-001*", "IFPI 0949", "59-93067-000-001"
 	Ring 2: "07/07/07 &minus;&minus; 149550 &minus;&minus; A", "IFPI LQ35"
 	-->
 	<software name="spidermns" cloneof="spidermn" supported="no">
@@ -162,7 +189,7 @@ ________________________________________________________________________________
 	Volume Label: 93167_000
 	Orange cartridge
 	Sticker on the cartridge: P ○○○○
-	Ring 1: "59-093147-000-001*",  "IFPI 0926",  "59-93167-000-001"
+	Ring 1: "59-093147-000-001*", "IFPI 0926", "59-93167-000-001"
 	Ring 2: "03/17/08 &minus;&minus; 157050 &minus;&minus; A", "IFPI LQ35"
 	-->
 	<software name="bratzs" cloneof="bratz" supported="no">
@@ -177,20 +204,62 @@ ________________________________________________________________________________
 		</part>
 	</software>
 
+	<!--
+	Internal Serial: 0ID_93100_000
+	Volume Label: 93100_000
+	Orange cartridge
+	Sticker on the cartridge: 646 ○○○○
+	Barcode: 0 50803 93100 1
+	Ring 1: "59-93100-000-000*", "ifpi LQ24", "IFPI 9QK3, IFPI 9QM3", "59-93100-000-000"
+	-->
 	<software name="cars" supported="no">
-		<!--
-		 Original files:
-		 <rom name="disney - pixar cars - in the fast lane (us).ccd" size="754" crc="741b37b3" sha1="f63cd8f1da67beec1decbf3983f0ecc1de8af95d" />
-		 <rom name="disney - pixar cars - in the fast lane (us).cue" size="962" crc="f9383e9e" sha1="a5cffb68bc0177828f5a3d9b3158739450f2baa3" />
-		 <rom name="disney - pixar cars - in the fast lane (us).img" size="506249184" crc="33b3b437" sha1="b7522abe11f1dab3e5adc56ae4cdc2c9f9957a3a" />
-		 <rom name="disney - pixar cars - in the fast lane (us).sub" size="20663232" crc="450daa44" sha1="c96a38c5a4cc8d1cad4c3a1f0d33cc68c3f0ad08" />
-		 -->
-		<description>Disney Pixar Cars - In the Fast Lane (USA)</description>
+		<description>Disney/Pixar Cars - In the Fast Lane (USA)</description>
 		<year>200?</year>
 		<publisher>VTech</publisher>
+		<info name="serial" value="80-093100" />
 		<part name="cdrom" interface="vsmile_vdisk">
 			<diskarea name="cdrom">
-				<disk name="093100" sha1="b90f3a4752d3326639ba95c1c38fd7ac161e9a1a"/>
+				<disk name="093100_000" sha1="47edbad81f59bc0cebd51bc7e51137ca949890de"/>
+			</diskarea>
+		</part>
+	</software>
+
+	<!--
+	Internal Serial: 0ID_93100_001
+	Volume Label: 93100_001
+	Orange cartridge
+	Sticker on the cartridge: 725 ○●○○
+	Barcode: 0 50803 93100 1
+	Ring 1: "*59-93100-001-000", "ifpi LQ24", "IFPI 9QH8", "59-93100-000-000"
+	-->
+	<software name="carsr1" cloneof="cars" supported="no">
+		<description>Disney/Pixar Cars - In the Fast Lane (USA, Rev. 1)</description>
+		<year>200?</year>
+		<publisher>VTech</publisher>
+		<info name="serial" value="80-093100" />
+		<part name="cdrom" interface="vsmile_vdisk">
+			<diskarea name="cdrom">
+				<disk name="093100_001" sha1="584bf1cdd17e33ab8f729f27e47426aa0ab2789a" />
+			</diskarea>
+		</part>
+	</software>
+
+	<!--
+	Internal Serial: 0ID_93100_003
+	Volume Label: 93100_003
+	Orange cartridge
+	Sticker on the cartridge: 725 ○●○○
+	Barcode: 0 50803 93100 1
+	Ring 1: "*59-93100-000-000*", "ifpi LQ24", "IFPI 9QK3", "59-93100-000-000"
+	-->
+	<software name="carsr3" cloneof="cars" supported="no">
+		<description>Disney/Pixar Cars - In the Fast Lane (USA, Rev. 3)</description>
+		<year>200?</year>
+		<publisher>VTech</publisher>
+		<info name="serial" value="80-093100" />
+		<part name="cdrom" interface="vsmile_vdisk">
+			<diskarea name="cdrom">
+				<disk name="093100_003" sha1="138f0203d1279b6656b1eeb7cc61705c2f728845" />
 			</diskarea>
 		</part>
 	</software>
@@ -373,7 +442,7 @@ ________________________________________________________________________________
 		 <rom name="scooby-doo! ancient adventure (us).img" size="638582112" crc="d6d3c531" sha1="24e753c394d8a6d9aed462be4c0c2b41dd6e79e6" />
 		 <rom name="scooby-doo! ancient adventure (us).sub" size="26064576" crc="72632c94" sha1="36fb895c8e8a224f028788e5f5e86f39562a7b2c" />
 		 -->
-		<description>Scooby-Doo! Ancient Adventure (USA)</description>
+		<description>Scooby-Doo! Ancient Adventure (USA, Rev. 1)</description>
 		<year>200?</year>
 		<publisher>VTech</publisher>
 		<info name="serial" value="80-093080" />
@@ -423,6 +492,24 @@ ________________________________________________________________________________
 		</part>
 	</software>
 
+	<!--
+	Internal Serial: 0ID_93143_000
+	Volume Label: 93143_000
+	Purple cartridge
+	Ring 1: "59-93143-000-001*", "IFPI LQ35", "IFPI 0931", "59-93143-000-001"
+	-->
+	<software name="shrek3uk" cloneof="shrek3" supported="no">
+		<description>Shrek the Third - The Search for Arthur (UK)</description>
+		<year>200?</year>
+		<publisher>VTech</publisher>
+		<info name="serial" value="80-093143" />
+		<part name="cdrom" interface="vsmile_vdisk">
+			<diskarea name="cdrom">
+				<disk name="093143_000" sha1="8f1294e2b862bb5803757149c33ca3564054231e" />
+			</diskarea>
+		</part>
+	</software>
+
 	<software name="shrek3g" cloneof="shrek3" supported="no">
 		<!--
 		Original files (from TeamEurope)
@@ -460,6 +547,7 @@ ________________________________________________________________________________
 		</part>
 	</software>
 
+	<!-- Needs checking what revision it is. -->
 	<software name="spongeis" supported="no">
 		<!--
 		 Original files:
@@ -478,6 +566,62 @@ ________________________________________________________________________________
 		</part>
 	</software>
 
+	<!--
+	Internal Serial: 0ID_93040_000
+	Volume Label: 93040_001
+	Blue cartridge
+	Sticker on the cartridge: 633 ○●○○
+	Ring 1: "*59-93040-000-000", "IFPI LQ50", "IFPI 9QH8", "59-93040-000"
+	-->
+	<software name="spongeisr1" cloneof="spongeis" supported="no">
+		<description>Nickelodeon SpongeBob Squarepants - Idea Sponge (USA, Rev. 1)</description>
+		<year>200?</year>
+		<publisher>VTech</publisher>
+		<info name="serial" value="80-093040" />
+		<part name="cdrom" interface="vsmile_vdisk">
+			<diskarea name="cdrom">
+				<disk name="093040_001" sha1="feabc1d3eac7045fb4c0ef29c1a137d7a5c07619"/>
+			</diskarea>
+		</part>
+	</software>
+
+	<!--
+	Internal Serial: 0ID_93040_000
+	Volume Label: 93040_002
+	Blue cartridge
+	Sticker on the cartridge: 637 ○○●○, 644 ○○●○
+	Ring 1: "*59-93040-000-000*", "IFPI LQ17", "IFPI 9QH8", "59-93040-000"
+	Ring 2: "*59-93040-000-000*", "IFPI LQ24", "IFPI 9QH8", "59-93040-000"
+	-->
+	<software name="spongeisr2" cloneof="spongeis" supported="no">
+		<description>Nickelodeon SpongeBob Squarepants - Idea Sponge (USA, Rev. 1)</description>
+		<year>200?</year>
+		<publisher>VTech</publisher>
+		<info name="serial" value="80-093040" />
+		<part name="cdrom" interface="vsmile_vdisk">
+			<diskarea name="cdrom">
+				<disk name="093040_002" sha1="22e5d08eeb01d660e9662c3663c5b1b26a2e57fb"/>
+			</diskarea>
+		</part>
+	</software>
+
+	<!--
+	Internal Serial: 0ID_93044_000
+	Volume Label: 93044_000
+	Ring 1: "59-93044-000-001*", "IFPI 0907", "59-93044-000-001"
+	Ring 2: "07/07/07 &minus;&minus; 149551 &minus;&minus; A", "IFPI LQ35"
+	-->
+	<software name="spongeisg" cloneof="spongeis" supported="no">
+		<description>Nick SpongeBob Schwammkopf: Ein Schwamm voller Ideen (Ger)</description>
+		<year>200?</year>
+		<publisher>VTech</publisher>
+		<info name="serial" value="80-093044" />
+		<part name="cdrom" interface="vsmile_vdisk">
+			<diskarea name="cdrom">
+				<disk name="093044_000" sha1="8edf7d8398bcc7e26144044801fc72155230c65f"/>
+			</diskarea>
+		</part>
+	</software>
 
 	<!--
 	Internal Serial: 0ID_93047_000
@@ -500,8 +644,27 @@ ________________________________________________________________________________
 		</part>
 	</software>
 
+	<!--
+	Internal Serial: 0ID_93120_002
+	Volume Label: 93120_002
+	Blue cartridge
+	Sticker on the cartridge: 634 ○○●○
+	Ring 1: "*59-93120-000-000*", "IFPI LQ50", "IFPI 9QH8", "59-93120-000"
+	-->
+	<software name="wackyracr2" supported="no">
+		<description>Wacky Race on Jumpin' Bean Island (USA, Rev. 2)</description>
+		<year>200?</year>
+		<publisher>VTech</publisher>
+		<info name="serial" value="80-93120" />
+		<part name="cdrom" interface="vsmile_vdisk">
+			<diskarea name="cdrom">
+				<disk name="093120_002" sha1="84f658c990f6c69754092aa4d9314ebee7026c6a"/>
+			</diskarea>
+		</part>
+	</software>
+
 	<!-- disk mounted as 93120_003 -->
-	<software name="wackyrac" supported="no">
+	<software name="wackyracr3" cloneof="wackyracr2" supported="no">
 		<!--
 		 Original files: unsure, maybe the following
 		 <rom name="wacky race on jumpin' bean island (console 80-70010) (us).ccd" size="754" crc="d6a6247e" sha1="86ff6701988f4f163816d80f9094a61fda61290e" />
@@ -509,7 +672,7 @@ ________________________________________________________________________________
 		 <rom name="wacky race on jumpin' bean island (console 80-70010) (us).img" size="394752624" crc="6af8435e" sha1="b643d8fd3f0f46459d2313e2c256bc6b5f33fd54" />
 		 <rom name="wacky race on jumpin' bean island (console 80-70010) (us).sub" size="16112352" crc="f2f1b667" sha1="d4321d7d6ed2c4bae699d1e06752c893dac0af1c" />
 		 -->
-		<description>Wacky Race on Jumpin' Bean Island (USA)</description>
+		<description>Wacky Race on Jumpin' Bean Island (USA, Rev. 3)</description>
 		<year>200?</year>
 		<publisher>VTech</publisher>
 		<info name="serial" value="093120_003" />
@@ -520,7 +683,26 @@ ________________________________________________________________________________
 		</part>
 	</software>
 
-	<software name="wackyracg" cloneof="wackyrac" supported="no">
+	<!--
+	Internal Serial: 0ID_93123_000
+	Volume Label: 93123_000
+	Purple cartridge
+	Sticker on the cartridge: 717 ○○○○
+	Ring 1: "59-93123-000-000*", "IFPI LQ17", "IFPI 9QK3", "59-93123-000-000"
+	-->
+	<software name="wackyracuk" cloneof="wackyracr2" supported="no">
+		<description>Wacky Race on Jumpin' Bean Island (UK)</description>
+		<year>200?</year>
+		<publisher>VTech</publisher>
+		<info name="serial" value="80-93123" />
+		<part name="cdrom" interface="vsmile_vdisk">
+			<diskarea name="cdrom">
+				<disk name="093123_000" sha1="430b54111c22fdf12b10bc7d04c2b097f9f97f6f"/>
+			</diskarea>
+		</part>
+	</software>
+
+	<software name="wackyracg" cloneof="wackyracr2" supported="no">
 		<!--
 		Original files (from TeamEurope)
 		<rom name="93124_000.bin" size="457901472" crc="92a0ebe0" sha1="a3a8e54d5f12094bfc0c89954987cc793d83d3f9" />
@@ -544,7 +726,7 @@ ________________________________________________________________________________
 	Ring 1: "59-93127-000-001*", "IFPI 0946", "59-93-107-000-001"
 	Ring 2: "07/12/07 &minus;&minus; 149610 &minus;&minus; A", "IFPI LQ35"
 	-->
-	<software name="wackyracs" cloneof="wackyrac" supported="no">
+	<software name="wackyracs" cloneof="wackyracr2" supported="no">
 		<description>Carrera Loca en la Isla de las Vainas Fritas (Spa)</description>
 		<year>200?</year>
 		<publisher>VTech</publisher>


### PR DESCRIPTION
vsmile_cd.xml: Nickelodeon SpongeBob Squarepants - Idea Sponge (USA Rev. 1), Nickelodeon SpongeBob Squarepants - Idea Sponge (USA Rev. 2), Nick SpongeBob Schwammkopf - Ein Schwamm voller Ideen (Ger), The Amazing Spider-Man - Countdown to Doom (USA, Rev. 2), Disney/Pixar Cars - In The Fast Lane (USA Rev. 1), Disney/Pixar Cars - In The Fast Lane (USA Rev. 3), Wacky Race on Jumpin' Bean Island (USA Rev. 2), Wacky Race on Jumpin' Bean Island (UK), Shrek The Third - The Search for Arthur (UK) [redump.org, ClawGrip]

Also replaced the CloneCD dump from "Disney/Pixar Cars - In the Fast Lane (USA)" with a verified image from redump.org (CloneCD is not fully supported by CHD)