### PR TITLE
Linux X11 Input: Fix lightgun support

### DIFF
--- a/src/osd/modules/input/input_x11.cpp
+++ b/src/osd/modules/input/input_x11.cpp
@@ -401,7 +401,23 @@ public:
 		else if (xevent.type == button_press_type || xevent.type == button_release_type)
 		{
 			XDeviceButtonEvent *button = reinterpret_cast<XDeviceButtonEvent *>(&xevent);
-			lightgun.buttons[button->button] = (xevent.type == button_press_type) ? 0x80 : 0;
+
+			/*
+			 * SDL/X11 Number the buttons 1,2,3, while windows and other parts of MAME
+			 * like offscreen_reload expect 0,2,1. Transpose buttons 2 and 3, and then
+			 * -1 the button number to align the numbering schemes.
+			*/
+			int button_number = button->button;
+			switch (button_number)
+			{
+				case 2:
+					button_number = 3;
+					break;
+				case 3:
+					button_number = 2;
+					break;
+			}
+			lightgun.buttons[button_number - 1] = (xevent.type == button_press_type) ? 0x80 : 0;
 		}
 	}
 


### PR DESCRIPTION
SDL/X11 number mouse/lighgun buttons 1,2,3, while windows and other parts of
MAME like offscreen_reload expect 0,2,1. Transpose buttons 2 and 3, and then
-1 the button number to align the numbering schemes.

This fixes lightgun support on Linux - tested with an Ultimarc AimTrak and
the following config:

    lightgun                  1
    lightgun_device           lightgun
    lightgunprovider          x11
    lightgun_index1           "Ultimarc Ultimarc"
    offscreen_reload          1

Note: MAME must be compiled with XInput support:

    make -j10 NO_USE_XINPUT=0

Fixes bug #4695

With these changes, Lightguns on linux are perfectly accurate (well, as accurate as the gun itself allows... I miss real lightguns ;))