### PR TITLE
specpls3_flop.xml: DSKs from latest TOSEC DATs

### DIFF
--- a/hash/specpls3_flop.xml
+++ b/hash/specpls3_flop.xml
@@ -1671,7 +1671,7 @@
 	Below is a selection of (most of) the DSK files featured in the TOSEC DAT files which, according to Lady Eklipse, include all files that were in TOSEC and all files from www.worldofspectrum.org which were never in TOSEC before. Which file and update they come from is commented for each entry, so that they can be consulted.
 
 	Files removed:
-		- Files marked as "bad dumps" which have a "good" parent set.
+		- Files marked as "bad dumps" which already have a good parent set.
 		- Trained games, except for a "cheat version" of Neighbours which may have come from the original developers.
 		- 80-track (3.5'') disk images.
 		- Files generated with the ZXZVM interpreter.
@@ -2983,7 +2983,7 @@
 	</software>
 
 <!-- From "Sinclair ZX Spectrum - Compilations - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
-	<software name="2x1mot">
+	<software name="2x1motfa">
 		<description>2 Por 1: Motor Massacre + Final Assault</description>
 		<year>1989</year>
 		<publisher>Erbe</publisher>
@@ -3002,9 +3002,9 @@
 	</software>
 
 <!-- From "Sinclair ZX Spectrum - Compilations - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
-	<software name="2x1pla">
-		<description>2 Por 1: Platoon + Arkanoid - Revenge of Doh</description>
-		<year>19??</year>
+	<software name="2x1plar2">
+		<description>2 por 1: Platoon + Arkanoid II: Revenge of Doh</description>
+		<year>1989</year>
 		<publisher>Erbe</publisher>
 		<part name="flop1" interface="floppy_3">
 			<feature name="part_id" value="Side A: Platoon"/>
@@ -3013,7 +3013,7 @@
 			</dataarea>
 		</part>
 		<part name="flop2" interface="floppy_3">
-			<feature name="part_id" value="Side B: Arkanoid - Revenge of Doh"/>
+			<feature name="part_id" value="Side B: Arkanoid II: Revenge of Doh"/>
 			<dataarea name="flop" size="58624">
 				<rom name="2 por 1 - platoon + arkanoid - revenge of doh (19xx)(erbe)(es)(en)(side b).dsk" size="58624" crc="dd6d244f" sha1="e714cb3e224264c86ef27d46f78897f5c147f8ee" offset="0" />
 			</dataarea>
@@ -3021,7 +3021,26 @@
 	</software>
 
 <!-- From "Sinclair ZX Spectrum - Compilations - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
-	<software name="2x1ren">
+	<software name="2x1plar2a" cloneof="2x1plar2">
+		<description>2 por 1: Platoon + Arkanoid II: Revenge of Doh (alt)</description>
+		<year>1989</year>
+		<publisher>Erbe</publisher>
+		<part name="flop1" interface="floppy_3">
+			<feature name="part_id" value="Side A: Platoon"/>
+			<dataarea name="flop" size="194816">
+				<rom name="2 por 1 - platoon (1989)(erbe).dsk" size="194816" crc="0341da38" sha1="ced84b0c722d3b7ca87727003c1d825f0bb723e9" offset="0" />
+			</dataarea>
+		</part>
+		<part name="flop1" interface="floppy_3">
+			<feature name="part_id" value="Side B: Arkanoid II: Revenge of Doh"/>
+			<dataarea name="flop" size="58624">
+				<rom name="2 por 1 - arkanoid ii - revenge of doh (1989)(erbe).dsk" size="58624" crc="671b73b3" sha1="56d72c852be3ab2547d348b92fe96dc6cfa4c095" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Compilations - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="2x1rentr">
 		<description>2 Por 1: Renegade + Target Renegade</description>
 		<year>1988</year>
 		<publisher>Erbe</publisher>
@@ -3040,7 +3059,7 @@
 	</software>
 
 <!-- From "Sinclair ZX Spectrum - Compilations - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
-	<software name="2x1sil">
+	<software name="2x1silmm">
 		<description>2 Por 1: Silent Shadow + Mad Mix Game</description>
 		<year>1988</year>
 		<publisher>Erbe</publisher>
@@ -3059,7 +3078,27 @@
 	</software>
 
 <!-- From "Sinclair ZX Spectrum - Compilations - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
-	<software name="2x1tec">
+	<software name="2x1silmma" cloneof="2x1silmm">
+		<description>2 Por 1: Silent Shadow + Mad Mix Game (alt)</description>
+		<year>1988</year>
+		<publisher>Erbe</publisher>
+		<part name="flop1" interface="floppy_3">
+			<feature name="part_id" value="Side A: Silent Shadow"/>
+			<dataarea name="flop" size="194816">
+				<rom name="2 por 1 - silent shadow (1988)(erbe)(es).dsk" size="194816" crc="e308222a" sha1="3512aba07e8087b3b3b22952f30133c057f92897" offset="0" />
+			</dataarea>
+		</part>
+		<part name="flop1" interface="floppy_3">
+			<feature name="part_id" value="Side B: Mad Mix Game"/>
+			<dataarea name="flop" size="194816">
+				<rom name="2 por 1 - mad mix game (1988)(erbe)(es).dsk" size="194816" crc="c530fc92" sha1="3ba4cae93aded2a468e8b424dd46f1b05f7b18bd" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+
+<!-- From "Sinclair ZX Spectrum - Compilations - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="2x1tecmm">
 		<description>2 Por 1: Techno Cop + Mickey Mouse</description>
 		<year>1988</year>
 		<publisher>Erbe</publisher>
@@ -3078,7 +3117,7 @@
 	</software>
 
 <!-- From "Sinclair ZX Spectrum - Compilations - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
-	<software name="2x1the">
+	<software name="2x1tdmun">
 		<description>2 Por 1: The Deep + The Muncher</description>
 		<year>1989</year>
 		<publisher>Erbe</publisher>
@@ -3097,7 +3136,7 @@
 	</software>
 
 <!-- From "Sinclair ZX Spectrum - Compilations - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
-	<software name="2x1thu">
+	<software name="2x1tblc2">
 		<description>2 Por 1: Thunder Blade + Cybernoid II</description>
 		<year>1988</year>
 		<publisher>Erbe</publisher>
@@ -3116,7 +3155,7 @@
 	</software>
 
 <!-- From "Sinclair ZX Spectrum - Compilations - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
-	<software name="2x1ven">
+	<software name="2x1vsbns">
 		<description>2 Por 1: MASK III: VENOM Strikes Back + North Star</description>
 		<year>1989</year>
 		<publisher>Erbe</publisher>
@@ -3135,7 +3174,7 @@
 	</software>
 
 <!-- From "Sinclair ZX Spectrum - Compilations - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
-	<software name="2x1capit">
+	<software name="2x1csmnv">
 		<description>2 X 1: Capitan Sevilla + Meganova</description>
 		<year>1988</year>
 		<publisher>Dinamic</publisher>
@@ -3154,7 +3193,7 @@
 	</software>
 
 <!-- From "Sinclair ZX Spectrum - Compilations - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
-	<software name="2x1corsa">
+	<software name="2x1cormz">
 		<description>2 X 1: Corsarios + Mutan Zone</description>
 		<year>1989</year>
 		<publisher>Opera Soft</publisher>
@@ -3173,7 +3212,7 @@
 	</software>
 
 <!-- From "Sinclair ZX Spectrum - Compilations - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
-	<software name="2x1donqu">
+	<software name="2x1quimc">
 		<description>2 X 1: Don Quijote + Mega-Corp</description>
 		<year>1987</year>
 		<publisher>Dinamic</publisher>
@@ -3190,45 +3229,6 @@
 			</dataarea>
 		</part>
 	</software>
-
-<!-- From "Sinclair ZX Spectrum - Compilations - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
-	<software name="2x1pla">
-		<description>2 por 1: Platoon + Arkanoid II: Revenge of Doh</description>
-		<year>1989</year>
-		<publisher>Erbe</publisher>
-		<part name="flop1" interface="floppy_3">
-			<feature name="part_id" value="Side A: Platoon"/>
-			<dataarea name="flop" size="194816">
-				<rom name="2 por 1 - platoon (1989)(erbe).dsk" size="194816" crc="0341da38" sha1="ced84b0c722d3b7ca87727003c1d825f0bb723e9" offset="0" />
-			</dataarea>
-		</part>
-		<part name="flop1" interface="floppy_3">
-			<feature name="part_id" value="Side B: Arkanoid II: Revenge of Doh"/>
-			<dataarea name="flop" size="58624">
-				<rom name="2 por 1 - arkanoid ii - revenge of doh (1989)(erbe).dsk" size="58624" crc="671b73b3" sha1="56d72c852be3ab2547d348b92fe96dc6cfa4c095" offset="0" />
-			</dataarea>
-		</part>
-	</software>
-
-<!-- From "Sinclair ZX Spectrum - Compilations - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
-	<software name="2x1sil">
-		<description>2 por 1: Silent Shadow + Mad Mix Game</description>
-		<year>1988</year>
-		<publisher>Erbe</publisher>
-		<part name="flop1" interface="floppy_3">
-			<feature name="part_id" value="Side A: Silent Shadow"/>
-			<dataarea name="flop" size="194816">
-				<rom name="2 por 1 - silent shadow (1988)(erbe)(es).dsk" size="194816" crc="e308222a" sha1="3512aba07e8087b3b3b22952f30133c057f92897" offset="0" />
-			</dataarea>
-		</part>
-		<part name="flop1" interface="floppy_3">
-			<feature name="part_id" value="Side B: Mad Mix Game"/>
-			<dataarea name="flop" size="194816">
-				<rom name="2 por 1 - mad mix game (1988)(erbe)(es).dsk" size="194816" crc="c530fc92" sha1="3ba4cae93aded2a468e8b424dd46f1b05f7b18bd" offset="0" />
-			</dataarea>
-		</part>
-	</software>
-
 
 <!-- From "Sinclair ZX Spectrum - Compilations - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
 	<software name="20gamepa">
@@ -3956,19 +3956,6 @@
 			<feature name="part_id" value="Side B"/>
 			<dataarea name="flop" size="219648">
 				<rom name="command performance (1989)(u.s. gold)(side b).dsk" size="219648" crc="89841c5e" sha1="e4aaac3e4291239b5d2debc89b939b3ff09e4c66" offset="0" />
-			</dataarea>
-		</part>
-	</software>
-
-<!-- From "Sinclair ZX Spectrum - Compilations - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
-	<software name="comoltri">
-		<description>Complex Oldfield Trilogy</description>
-		<year>2011</year>
-		<publisher>&lt;homebrew&gt;</publisher>
-		<info name="author" value="Ignacio Prini Garcia"/>
-		<part name="flop1" interface="floppy_3">
-			<dataarea name="flop" size="194816">
-				<rom name="complex oldfield trilogy (2011)(garcia, ignacio prini)(es)(en).dsk" size="194816" crc="5de10460" sha1="e5121150239f6feae731c4b249bb31fc202a0056" offset="0" />
 			</dataarea>
 		</part>
 	</software>
@@ -7188,8 +7175,8 @@
 	</software>
 
 <!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
-	<software name="abadcrim">
-		<description>La Abadia del Crimen</description>
+	<software name="abadcrima" cloneof="abadcrim">
+		<description>La Abadia del Crimen (alt)</description>
 		<year>1988</year>
 		<publisher>MCM</publisher>
 		<part name="flop1" interface="floppy_3">
@@ -7868,7 +7855,7 @@
 
 <!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
 	<!-- May be the same edition as the IPF -->
-	<software name="badlands" cloneof="badlands">
+	<software name="badlandsa" cloneof="badlands">
 		<description>Badlands (alt)</description>
 		<year>1990</year>
 		<publisher>Domark</publisher>
@@ -8140,7 +8127,7 @@
 	</software>
 
 <!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
-	<!-- According to World of Spectrum, this image came from a dual-system Spectrum/Amstrad release (Side A: Spectrum, Side B: Amstrad) -->
+	<!-- This image came from a dual-system Spectrum/Amstrad release (Side A: Spectrum, Side B: Amstrad) -->
 	<software name="bestialw">
 		<description>Bestial Warrior</description>
 		<year>1989</year>
@@ -8153,7 +8140,7 @@
 	</software>
 
 <!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
-	<!-- According to World of Spectrum, this image came from a dual-system Spectrum/Amstrad release (Side A: Spectrum, Side B: Amstrad) -->
+	<!-- This image came from a dual-system Spectrum/Amstrad release (Side A: Spectrum, Side B: Amstrad) -->
 <!--
 	<software name="bestialw">
 		<description>Bestial Warrior (rerelease)</description>
@@ -13379,33 +13366,6 @@
 			</dataarea>
 		</part>
 	</software>
-
-<!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
-	<!-- According to World of Spectrum, this image came from a dual-system Spectrum/Amstrad release (Side A: Spectrum, Side B: Amstrad) -->
-	<software name="navymovespa" cloneof="navymove">
-		<description>Navy Moves (Spanish) (alt)</description>
-		<year>1988</year>
-		<publisher>Dinamic</publisher>
-		<part name="flop1" interface="floppy_3">
-			<dataarea name="flop" size="166400">
-				<rom name="navy moves + army moves (1988)(dinamic)(es)(side a).dsk" size="166400" crc="65a30aca" sha1="e7ba54851e45d717a9205b0219a0dde16a30028e" offset="0" />
-			</dataarea>
-		</part>
-	</software>
-
-<!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
-	<!-- According to World of Spectrum, this image came from a dual-system Spectrum/Amstrad release (Side A: Spectrum, Side B: Amstrad) -->
-<!--
-	<software name="navymove">
-		<description>Navy Moves</description>
-		<year>1988</year>
-		<publisher>Dinamic</publisher>
-		<part name="flop1" interface="floppy_3">
-			<dataarea name="flop" size="214784">
-				<rom name="navy moves (1988)(dinamic)(es)(en)(side b).dsk" size="214784" crc="c32323a2" sha1="da30c11411368b22474b032f39e8f8b968f7903b" offset="0" />
-			</dataarea>
-		</part>
--->
 
 <!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
 	<software name="navyseal">
@@ -19490,5 +19450,584 @@
 		</part>
 	</software>
 
-	
+
+<!-- Below is a selection of disk images from the backlog of SPA2. -->
+
+	<software name="2x1fhpha">
+		<description>2 X 1: Phantis + Freddy Hardest</description>
+		<year>1987</year>
+		<publisher>Dinamic</publisher>
+		<part name="flop1" interface="floppy_3">
+			<feature name="part_id" value="Side A: Freddy Hardest"/>
+			<dataarea name="flop" size = "109568">
+				<rom name="2x1 - Freddy Hardest + Phantis - Side 1.dsk" size="109568" crc="407577a2" sha1="69a82cd67d523a5f8d970cfaa73d09c2d509c6b0" offset="0"/>
+			</dataarea>
+		</part>
+		<part name="flop2" interface="floppy_3">
+			<feature name="part_id" value="Side B: Phantis"/>
+			<dataarea name="flop" size = "109568">
+				<rom name="2x1 - Freddy Hardest + Phantis - Side 2.dsk" size="109568" crc="b46d7b33" sha1="7043d384ec2cef8ffca6d2af4f81cfe563d328b9" offset="0"/>
+			</dataarea>
+		</part>
+	</software>
+
+	<software name="2x1huntg">
+		<description>2 X 1: Hundra + Turbo Girl</description>
+		<year>1988</year>
+		<publisher>Dinamic</publisher>
+		<part name="flop1" interface="floppy_3">
+			<feature name="part_id" value="Side A: Hundra"/>
+			<dataarea name="flop" size = "59097">
+				<rom name="2x1 - Hundra + Turbo Girl - Side 1.dsk" size="59097" crc="87cb996f" sha1="2bfd84fc1d7ffe3453f7fe7b1338567ecc653ecf" offset="0"/>
+			</dataarea>
+		</part>
+		<part name="flop2" interface="floppy_3">
+			<feature name="part_id" value="Side B: Turbo Girl"/>
+			<dataarea name="flop" size = "59097">
+				<rom name="2x1 - Hundra + Turbo Girl - Side 2.dsk" size="59097" crc="8a8892e4" sha1="b81a1ddaf5f47cbb0c091aac8dd69a9e651c2788" offset="0"/>
+			</dataarea>
+		</part>
+	</software>
+
+	<software name="abadcrim">
+		<description>La Abadia del Crimen</description>
+		<year>1988</year>
+		<publisher>Opera Soft</publisher>
+		<part name="flop1" interface="floppy_3">
+			<feature name="part_id" value="Side A"/>
+			<dataarea name="flop" size = "191744">
+				<rom name="Abadia del Crimen, La - Side A (Opera Soft).dsk" size="191744" crc="b39e6efb" sha1="7d84706254c7b472e9b778bf55e1894e19bbd161" offset="0"/>
+			</dataarea>
+		</part>
+		<part name="flop2" interface="floppy_3">
+			<feature name="part_id" value="Side B"/>
+			<dataarea name="flop" size = "102400">
+				<rom name="Abadia del Crimen, La - Side B (Opera Soft).dsk" size="102400" crc="a73c0154" sha1="637f791ac9f1ef61d3c7afa4b4ee6ff5cfad22b7" offset="0"/>
+			</dataarea>
+		</part>
+	</software>
+
+	<software name="ausgamessp">
+		<description>Australian Games (Spain)</description>
+		<year>1990</year>
+		<publisher>Erbe</publisher>
+		<part name="flop1" interface="floppy_3">
+			<feature name="part_id" value="Side A"/>
+			<dataarea name="flop" size = "194816">
+				<rom name="Australian Games - Side A [recovered].dsk" size="194816" crc="a3d813cc" sha1="70edcad46b89d7f96710bc0dcda86f6fc1ee1c7d" offset="0"/>
+			</dataarea>
+		</part>
+		<part name="flop2" interface="floppy_3">
+			<feature name="part_id" value="Side B"/>
+			<dataarea name="flop" size = "195635">
+				<rom name="Australian Games - Side B.dsk" size="195635" crc="6ace009c" sha1="3208ed5cb7e2a7d865f57b43efc80110144714fd" offset="0"/>
+			</dataarea>
+		</part>
+	</software>
+
+	<software name="badlandssp" cloneof="badlands">
+		<description>Badlands (Spain)</description>
+		<year>1990</year>
+		<publisher>Erbe</publisher>
+		<part name="flop1" interface="floppy_3">
+			<dataarea name="flop" size = "97995">
+				<rom name="Badlands.dsk" size="97995" crc="44ae6f1e" sha1="683489b807cced8c290f8274e428df56d3535cd1" offset="0"/>
+			</dataarea>
+		</part>
+	</software>
+
+	<software name="buggyboysp" cloneof="buggyboy">
+		<description>Buggy Boy (Spain)</description>
+		<year>1988</year>
+		<publisher>MCM</publisher>
+		<part name="flop1" interface="floppy_3">
+			<dataarea name="flop" size = "195635">
+				<rom name="Buggy Boy.dsk" size="195635" crc="c37afecb" sha1="19550826617711dd2d8c0d17421b6f5266a44cd1" offset="0"/>
+			</dataarea>
+		</part>
+	</software>
+
+	<software name="clschss4sp" cloneof="clschss4">
+		<description>Colossus Chess 4 (Spain)</description>
+		<year>1986</year>
+		<publisher>Proein</publisher>
+		<part name="flop1" interface="floppy_3">
+			<dataarea name="flop" size = "194816">
+				<rom name="Colossus 4 Chess (Proein).dsk" size="194816" crc="6fc03840" sha1="462dbf4f71e984448de7638ade421eb9355a4bc7" offset="0"/>
+			</dataarea>
+		</part>
+	</software>
+
+	<software name="comarcav">
+		<description>Comic, Arcade &amp; Aventura</description>
+		<year>1991</year>
+		<publisher>Dro Soft</publisher>
+		<part name="flop1" interface="floppy_3">
+			<feature name="part_id" value="Side A: Capitan Trueno, Freddy Hardest"/>
+			<dataarea name="flop" size = "166817">
+				<rom name="Comic, Arcade &amp; Aventura - Disk 1 Side 1.dsk" size="166817" crc="926eafa7" sha1="73401bac1b1c0b2c5e7b1f164378bf1bd83de99a" offset="0"/>
+			</dataarea>
+		</part>
+		<part name="flop2" interface="floppy_3">
+			<feature name="part_id" value="Side B: Cozumel, Cosmic Sheriff"/>
+			<dataarea name="flop" size = "146815">
+				<rom name="Comic, Arcade &amp; Aventura - Disk 1 Side 2.dsk" size="146815" crc="f3aa29d1" sha1="e64bd9a87a81dd273751d6dca1a1e413d9018fa1" offset="0"/>
+			</dataarea>
+		</part>
+	</software>
+
+	<software name="ddarecol">
+		<description>Dan Dare Collection</description>
+		<year>1988</year>
+		<publisher>Dro Soft</publisher>
+		<part name="flop1" interface="floppy_3">
+			<dataarea name="flop" size = "194816">
+				<rom name="Dan Dare Collection (DroSoft).dsk" size="194816" crc="8692a7cc" sha1="e4154ad57856025ccadbacc512b15280f8032fc2" offset="0"/>
+			</dataarea>
+		</part>
+	</software>
+
+	<software name="Drazen Petrovic Basket (Erbe)">
+		<description>Drazen Petrovic Basket</description>
+		<year>1989</year>
+		<publisher>Erbe</publisher>
+		<part name="flop1" interface="floppy_3">
+			<dataarea name="flop" size = "73216">
+				<rom name="Drazen Petrovic Basket (Erbe).DSK" size="73216" crc="17eeb154" sha1="4e0b0edd771ad5dc622c449a73bae1b0a11e4789" offset="0"/>
+			</dataarea>
+		</part>
+	</software>
+
+	<software name="equipoags">
+		<description>El Equipo A (Gunstick)</description>
+		<year>1988</year>
+		<publisher>Zafiro Software Division</publisher>
+		<part name="flop1" interface="floppy_3">
+			<feature name="part_id" value="Side A"/>
+			<dataarea name="flop" size = "88231">
+				<rom name="El Equipo A (Gunstick) (+3 disk) - Side A.dsk" size="88231" crc="f3cde48e" sha1="b08d6940bbf5138332c60a7e469e08f5942ac21a" offset="0"/>
+			</dataarea>
+		</part>
+		<part name="flop2" interface="floppy_3">
+			<feature name="part_id" value="Side B"/>
+			<dataarea name="flop" size = "88231">
+				<rom name="El Equipo A (Gunstick) (+3 disk) - Side B.dsk" size="88231" crc="b2724fe4" sha1="b7fa9ed67106a2cbc3c6d6bbd3f407181df57ee6" offset="0"/>
+			</dataarea>
+		</part>
+	</software>
+
+	<software name="esanchvib" cloneof="esanchvi">
+		<description>Emilio Sanchez Vicario Grand Slam (alt 2)</description>
+		<year>1990</year>
+		<publisher>Zigurat</publisher>
+		<part name="flop1" interface="floppy_3">
+			<dataarea name="flop" size = "58939">
+				<rom name="Emilio Sanchez Vicario Grand Slam.dsk" size="58939" crc="5640d214" sha1="6c033e39e84822a6fbf9c6ee61125693c8f86d3b" offset="0"/>
+			</dataarea>
+		</part>
+	</software>
+
+	<software name="epromsp" cloneof="eprom">
+		<description>Escape from the Planet of the Robot Monsters (Spain)</description>
+		<year>1990</year>
+		<publisher>Erbe</publisher>
+		<part name="flop1" interface="floppy_3">
+			<dataarea name="flop" size = "194816">
+				<rom name="Escape from the planet of the robot monsters (Erbe).dsk" size="194816" crc="0bb41cee" sha1="689e11d47ba487499ba952f0ef401deed4a1be13" offset="0"/>
+			</dataarea>
+		</part>
+	</software>
+
+	<software name="frntiers">
+		<description>Frontiers</description>
+		<year>1988</year>
+		<publisher>Zafiro Software Division</publisher>
+		<part name="flop1" interface="floppy_3">
+			<dataarea name="flop" size = "68352">
+				<rom name="Frontiers.dsk" size="68352" crc="c30725b1" sha1="7b934e7009aa8b0f98dbe2e2402490a8ad092a36" offset="0"/>
+			</dataarea>
+		</part>
+	</software>
+
+	<software name="genghisk">
+		<description>Genghis Khan</description>
+		<year>1991</year>
+		<publisher>Positive</publisher>
+		<part name="flop1" interface="floppy_3">
+			<dataarea name="flop" size = "195631">
+				<rom name="Genghis Khan.dsk" size="195631" crc="5a4d422d" sha1="2f281f133682ead554bb0d5970f450d37222c6dd" offset="0"/>
+			</dataarea>
+		</part>
+	</software>
+
+	<software name="goldnaxespa" cloneof="goldnaxe">
+		<description>Golden Axe (Spain) (alt)</description>
+		<year>1990</year>
+		<publisher>MCM</publisher>
+		<part name="flop1" interface="floppy_3">
+			<feature name="part_id" value="Side A"/>
+			<dataarea name="flop" size = "166599">
+				<rom name="Golden Axe (MCM) - Side A.dsk" size="166599" crc="dd172644" sha1="80c46698ac2362ab22236c874b53d09ca8734e8e" offset="0"/>
+			</dataarea>
+		</part>
+		<part name="flop2" interface="floppy_3">
+			<feature name="part_id" value="Side B"/>
+			<dataarea name="flop" size = "195635">
+				<rom name="Golden Axe (MCM) - Side B.dsk" size="195635" crc="11794666" sha1="aa8c971971305ba1d4795deae7f586f474618927" offset="0"/>
+			</dataarea>
+		</part>
+	</software>
+
+	<software name="gunshipsp" cloneof="gunship">
+		<description>Gunship (Spain)</description>
+		<year>1987</year>
+		<publisher>Erbe</publisher>
+		<part name="flop1" interface="floppy_3">
+			<feature name="part_id" value="Side A"/>
+			<dataarea name="flop" size = "151040">
+				<rom name="Gun Ship - Side A (Erbe Software).dsk" size="151040" crc="c67f9066" sha1="bd04390e5a92ed8b629bdcd18fe143ea64641f07" offset="0"/>
+			</dataarea>
+		</part>
+		<part name="flop2" interface="floppy_3">
+			<feature name="part_id" value="Side B"/>
+			<dataarea name="flop" size = "151040">
+				<rom name="Gun Ship - Side B (Erbe Software).dsk" size="151040" crc="f58a0381" sha1="d6c8d7f3a81a7182f925c978b67128b759114b31" offset="0"/>
+			</dataarea>
+		</part>
+	</software>
+
+	<software name="highstelsp">
+		<description>High Steel (Spain)</description>
+		<year>1989</year>
+		<publisher>Erbe</publisher>
+		<part name="flop1" interface="floppy_3">
+			<dataarea name="flop" size = "58624">
+				<rom name="High Steel (Erbe Software).dsk" size="58624" crc="39f355cc" sha1="79cc8da772100bf639af90efbd85d10735cbd7e0" offset="0"/>
+			</dataarea>
+		</part>
+	</software>
+
+	<software name="italia90sp" cloneof="italia90">
+		<description>Italia '90 - World Cup Soccer (Spain)</description>
+		<year>1989</year>
+		<publisher>Dro Soft</publisher>
+		<part name="flop1" interface="floppy_3">
+			<dataarea name="flop" size = "54057">
+				<rom name="Italia 90 World Cup (Dro Soft).dsk" size="54057" crc="77966d03" sha1="cffb4a625bf3ad849c2fecaa0bcad2e4a6e97908" offset="0"/>
+			</dataarea>
+		</part>
+	</software>
+
+	<software name="kromguer">
+		<description>Krom El Guerrero</description>
+		<year>1989</year>
+		<publisher>OMK Software</publisher>
+		<part name="flop1" interface="floppy_3">
+			<dataarea name="flop" size = "195635">
+				<rom name="Krom El Guerrero.dsk" size="195635" crc="c6704f88" sha1="fd07e61a903a5611d222d9a5637a26be03dadb98" offset="0"/>
+			</dataarea>
+		</part>
+	</software>
+
+	<software name="los40v5">
+		<description>Los 40 Principales Vol. 4</description>
+		<year>1987</year>
+		<publisher>Erbe</publisher>
+		<part name="flop1" interface="floppy_3">
+			<feature name="part_id" value="Side A: Rambo + Krakout"/>
+			<dataarea name="flop" size="194816">
+				<rom name="Los 40 Principales Vol. 04 - Side 1.dsk" size="194816" crc="2026cb1d" sha1="842f580040b5e2bbb86bcc64a8a4b6e0f24a53ee" offset="0" />
+			</dataarea>
+		</part>
+		<part name="flop2" interface="floppy_3">
+			<feature name="part_id" value="Side B: Firelord + Turbo Esprit"/>
+			<dataarea name="flop" size="194816">
+				<rom name="Los 40 Principales Vol. 04 - Side 2.dsk" size="194816" crc="d8f8e041" sha1="1c0cac61dbd90758fad83e6153304e0c79fc0b6b" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+	<software name="inhumano">
+		<description>Los Inhumanos</description>
+		<year>1990</year>
+		<publisher>Delta Software</publisher>
+		<part name="flop1" interface="floppy_3">
+			<dataarea name="flop" size = "194816">
+				<rom name="Los inhumanos.dsk" size="194816" crc="7e873c78" sha1="9c2c25d561839fc0779f015b6b3088d3a32ee945" offset="0"/>
+			</dataarea>
+		</part>
+	</software>
+
+	<software name="tempsagr">
+		<description>Los Templos Sagrados</description>
+		<year>1991</year>
+		<publisher>Aventuras AD</publisher>
+		<part name="flop1" interface="floppy_3">
+			<feature name="part_id" value="Side A"/>
+			<dataarea name="flop" size = "102877">
+				<rom name="Los Templos Sagrados - Side 1.dsk" size="102877" crc="33990559" sha1="fb4ab19cd49d0280c2cfff02a8325d5aa46019dd" offset="0"/>
+			</dataarea>
+		</part>
+		<part name="flop2" interface="floppy_3">
+			<feature name="part_id" value="Side B"/>
+			<dataarea name="flop" size = "256">
+				<rom name="Los Templos Sagrados - Side 2.dsk" size="256" crc="b9a10e7d" sha1="e2501fcc4e35c8dc7a2d4dc6b46c1ca7da51846e" offset="0"/>
+			</dataarea>
+		</part>
+	</software>
+
+	<software name="mntbkrcr">
+	<!-- Unrelated to Zeppelin's game with the same title -->
+		<description>Mountain Bike Racer</description>
+		<year>1990</year>
+		<publisher>Positive</publisher>
+		<part name="flop1" interface="floppy_3">
+			<dataarea name="flop" size = "194816">
+				<rom name="Mountain Bike Racer.dsk" size="194816" crc="5372df44" sha1="2c4fb2de3506544ecbafb8548db4f3efd8b77272" offset="0"/>
+			</dataarea>
+		</part>
+	</software>
+
+	<software name="narcsp" cloneof="narc">
+	<!-- This dump of Side A has been manually fixed, a new untampered one may be needed for verification. -->
+		<description>NARC (Spain)</description>
+		<year>1990</year>
+		<publisher>Erbe</publisher>
+		<part name="flop1" interface="floppy_3">
+			<feature name="part_id" value="Side A"/>
+			<dataarea name="flop" size = "226048">
+				<rom name="Narc - Side 1 (Erbe) [corregido].dsk" size="226048" crc="b2979f21" sha1="823b6e45197c40924b16cf4d61c1ace03cc035a3" offset="0"/>
+			</dataarea>
+		</part>
+		<part name="flop2" interface="floppy_3">
+			<feature name="part_id" value="Side B"/>
+			<dataarea name="flop" size = "216195">
+				<rom name="Narc - Side 2 (Erbe).dsk" size="216195" crc="4306cf83" sha1="a50870504147907fb6474f3dfc5b114de76f5265" offset="0"/>
+			</dataarea>
+		</part>
+	</software>
+
+	<!-- This image came from a dual-system Spectrum/Amstrad release (Side A: Spectrum, Side B: Amstrad) -->
+	<!-- Dump made with SAMdisk -->
+	<software name="navymovespa" cloneof="navymove">
+		<description>Navy Moves (Spanish) (alt)</description>
+		<year>1988</year>
+		<publisher>Dinamic</publisher>
+		<part name="flop1" interface="floppy_3">
+			<dataarea name="flop" size="166817">
+				<rom name="Navy Moves (Doble Edición) (side A).dsk" size="166817" crc="718149f4" sha1="5018740f71bc2ae08343f4040590cfa2550333bf" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<!-- This image came from a dual-system Spectrum/Amstrad release (Side A: Spectrum, Side B: Amstrad) -->
+	<!-- Dump made with CPDRead -->
+<!--
+	<software name="navymove">
+		<description>Navy Moves</description>
+		<year>1988</year>
+		<publisher>Dinamic</publisher>
+		<part name="flop1" interface="floppy_3">
+			<dataarea name="flop" size="214784">
+				<rom name="navy moves (1988)(dinamic)(es)(en)(side b).dsk" size="214784" crc="c32323a2" sha1="da30c11411368b22474b032f39e8f8b968f7903b" offset="0" />
+			</dataarea>
+		</part>
+-->
+
+	<software name="ninjawarsp" cloneof="ninjawar">
+		<description>The Ninja Warriors (Spain)</description>
+		<year>1990</year>
+		<publisher>Dro Soft</publisher>
+		<part name="flop1" interface="floppy_3">
+			<dataarea name="flop" size = "195635">
+				<rom name="Ninja Warriors.dsk" size="195635" crc="ee1fdc62" sha1="fa92665ce2324c00bbca1ca6ac0c0376c8de0a70" offset="0"/>
+			</dataarea>
+		</part>
+	</software>
+
+	<software name="powrmagc">
+		<description>Power Magic</description>
+		<year>1990</year>
+		<publisher>Zigurat</publisher>
+		<part name="flop1" interface="floppy_3">
+			<dataarea name="flop" size = "63488">
+				<rom name="Power Magic.dsk" size="63488" crc="2a0017e0" sha1="1a6bdbbef1a1e22176a492b228b508a982db29ee" offset="0"/>
+			</dataarea>
+		</part>
+	</software>
+
+	<software name="rbislandsp" cloneof="rbisland">
+		<description>Rainbow Islands (Spain)</description>
+		<year>1990</year>
+		<publisher>Erbe</publisher>
+		<part name="flop1" interface="floppy_3">
+			<dataarea name="flop" size = "176107">
+				<rom name="Rainbow Islands (Erbe Software).dsk" size="176107" crc="8011bfaa" sha1="28356ae9a4df3144248cae45c0a1b7fd812f8fb0" offset="0"/>
+			</dataarea>
+		</part>
+	</software>
+
+	<software name="bttf3spa" cloneof="bttf3">
+		<description>Regreso al Futuro - Parte III (alt)</description>
+		<year>1991</year>
+		<publisher>MCM</publisher>
+		<part name="flop1" interface="floppy_3">
+			<feature name="part_id" value="Side A"/>
+			<dataarea name="flop" size = "195635">
+				<rom name="Regreso al Futuro III (MCM Software) - Side A.dsk" size="195635" crc="a8007375" sha1="eae8467742d20fb8f8e50fc90efda0d612ab8ad6" offset="0"/>
+			</dataarea>
+		</part>
+		<part name="flop2" interface="floppy_3">
+			<feature name="part_id" value="Side B"/>
+			<dataarea name="flop" size = "195635">
+				<rom name="Regreso al Futuro III (MCM Software) - Side B.dsk" size="195635" crc="b0c00514" sha1="81e48d09e18da1e4e66addd09899ba9a6b835d5d" offset="0"/>
+			</dataarea>
+		</part>
+	</software>
+
+	<software name="rescatlac" cloneof="rescatla">
+	<!-- This dump of Side A has been manually fixed, a new untampered one may be needed for verification. -->
+		<description>Rescate Atlantida (alt 3)</description>
+		<year>1989</year>
+		<publisher>Dinamic</publisher>
+		<part name="flop1" interface="floppy_3">
+			<feature name="part_id" value="Side A"/>
+			<dataarea name="flop" size = "150659">
+				<rom name="Rescate Atlantida - Side 1 [restaurada].dsk" size="150659" crc="b4ba8c14" sha1="e10d4fc6f2fe250dfda0cbd491b136cd99c3a1c7" offset="0"/>
+			</dataarea>
+		</part>
+		<part name="flop2" interface="floppy_3">
+			<feature name="part_id" value="Side B"/>
+			<dataarea name="flop" size = "256">
+				<rom name="Rescate Atlantida - Side 2.dsk" size="256" crc="b9a10e7d" sha1="e2501fcc4e35c8dc7a2d4dc6b46c1ca7da51846e" offset="0"/>
+			</dataarea>
+		</part>
+	</software>
+
+	<software name="ringwarssp">
+		<description>Ring Wars (Spain)</description>
+		<year>1989</year>
+		<publisher>MCM</publisher>
+		<part name="flop1" interface="floppy_3">
+			<dataarea name="flop" size = "189952">
+				<rom name="Ring Wars.dsk" size="189952" crc="2dd821c4" sha1="e662b7d4b6915078901caadc8028b0b2acdc8a06" offset="0"/>
+			</dataarea>
+		</part>
+	</software>
+
+	<software name="simuhitssp">
+	<!-- No good dump known of Side B, but Side A seems to include everything. -->
+		<description>Simulation Hits (Spain)</description>
+		<year>1989</year>
+		<publisher>Proein</publisher>
+		<part name="flop1" interface="floppy_3">
+			<dataarea name="flop" size = "200517">
+				<rom name="Simulation Hits - Side 1 (Proein).dsk" size="200517" crc="ddeb37da" sha1="25d6beb79a898ffa503551556cd4ccaa20f7f0a5" offset="0"/>
+			</dataarea>
+		</part>
+	</software>
+
+	<software name="sincp3mb">
+		<description>Sinclair Plus 3</description>
+		<year>1988</year>
+		<publisher>Microbyte</publisher>
+		<info name="usage" value="Disk has no autorun menu, requires loading each game from Basic." />
+		<part name="flop1" interface="floppy_3">
+			<feature name="part_id" value="Side A"/>
+			<dataarea name="flop" size = "195631">
+				<rom name="Sinclair Plus3 (Microbyte) [side 1].dsk" size="195631" crc="d258b440" sha1="13aa8569e898632ea861015ae97c7029f0ee5b9f" offset="0"/>
+			</dataarea>
+		</part>
+		<part name="flop2" interface="floppy_3">
+			<feature name="part_id" value="Side B"/>
+			<dataarea name="flop" size = "195631">
+				<rom name="Sinclair Plus3 (Microbyte) [side 2].dsk" size="195631" crc="b1c4812d" sha1="ad50f3ba0fb76e712452f9b2edda215b5096f487" offset="0"/>
+			</dataarea>
+		</part>
+	</software>
+
+	<software name="sootlandgs">
+		<description>Sootland (Gunstick)</description>
+		<year>1988</year>
+		<publisher>Zafiro Software Division</publisher>
+		<part name="flop1" interface="floppy_3">
+			<dataarea name="flop" size = "194816">
+				<rom name="Sootland (Gunstick).dsk" size="194816" crc="d5092b88" sha1="c27377c1127cbb00fded1e0144dadaf9490c9147" offset="0"/>
+			</dataarea>
+		</part>
+	</software>
+
+	<software name="prayoftw">
+	<!-- Game recovered from the original developer's archives -->
+		<description>The Prayer Of The Warrior</description>
+		<year>1992</year>
+		<publisher>Zigurat</publisher>
+		<part name="flop1" interface="floppy_3">
+			<feature name="part_id" value="Side A"/>
+			<dataarea name="flop" size = "194816">
+				<rom name="The Prayer Of The Warrior (Side A).dsk" size="194816" crc="5803cde3" sha1="dd4fe59bc4f9d1a9775052701dcd1eeeb6c8df28" offset="0"/>
+			</dataarea>
+		</part>
+		<part name="flop2" interface="floppy_3">
+			<feature name="part_id" value="Side B"/>
+			<dataarea name="flop" size = "194816">
+				<rom name="The Prayer Of The Warrior (Side B).dsk" size="194816" crc="3c20e2b1" sha1="465607845b537cec16d3e15b43a6db65297b04fa" offset="0"/>
+			</dataarea>
+		</part>
+	</software>
+
+	<software name="prayoftwa" cloneof="prayoftw">
+	<!-- Modified version of the game which includes both loads in one side of the disc. -->
+		<description>The Prayer of the Warrior (alt)</description>
+		<year></year>
+		<publisher></publisher>
+		<part name="flop1" interface="floppy_3">
+			<dataarea name="flop" size = "194816">
+				<rom name="The Prayer of the Warrior (Zup).dsk" size="194816" crc="f9b00ee9" sha1="f18303f4295f1127c8e499ce197d6a17397cd70a" offset="0"/>
+			</dataarea>
+		</part>
+	</software>
+
+	<software name="toiacidg">
+		<description>Toi Acid Game</description>
+		<year>1989</year>
+		<publisher>Iber</publisher>
+		<part name="flop1" interface="floppy_3">
+			<feature name="part_id" value="Side A"/>
+			<dataarea name="flop" size = "194816">
+				<rom name="Toi Acid Game - Side A.dsk" size="194816" crc="ee353414" sha1="32c80288e8b69e65747bc6dbfb095e6314b192a5" offset="0"/>
+			</dataarea>
+		</part>
+		<part name="flop2" interface="floppy_3">
+			<feature name="part_id" value="Side B"/>
+			<dataarea name="flop" size = "194816">
+				<rom name="Toi Acid Game - Side B.dsk" size="194816" crc="a891a7d3" sha1="3b2c869c90624be050ecebb401067fdcabd48246" offset="0"/>
+			</dataarea>
+		</part>
+	</software>
+
+	<software name="toobinspa" cloneof="toobin">
+		<description>Toobin' (Spain) (alt)</description>
+		<year>1989</year>
+		<publisher>Erbe</publisher>
+		<part name="flop1" interface="floppy_3">
+			<dataarea name="flop" size = "122405">
+				<rom name="Toobin (Erbe).dsk" size="122405" crc="19c5e569" sha1="3eb3eecaf23e4ef5bd3ca5761eccf9aad1fa60b7" offset="0"/>
+			</dataarea>
+		</part>
+	</software>
+
+	<software name="trainetnsp">
+		<description>The Train: Escape to Normandy (Spain)</description>
+		<year>1988</year>
+		<publisher>Dro Soft</publisher>
+		<part name="flop1" interface="floppy_3">
+			<dataarea name="flop" size = "63821">
+				<rom name="Train - Escape to Normandy, The (Dro).dsk" size="63821" crc="b6cc7106" sha1="e9d88fceee7592bae3dbf255da27c66aa25279b9" offset="0"/>
+			</dataarea>
+		</part>
+	</software>
+
+
 </softwarelist>

--- a/hash/specpls3_flop.xml
+++ b/hash/specpls3_flop.xml
@@ -3709,7 +3709,7 @@
 	<software name="acextra3">
 		<description>Arcade Extravaganza Disk 3</description>
 		<year>1988</year>
-		<publisher>Alternative</publisher>
+		<publisher>Alternative Software</publisher>
 		<part name="flop1" interface="floppy_3">
 			<dataarea name="flop" size="194816">
 				<rom name="arcade extravaganza disk 3 (1988)(alternative).dsk" size="194816" crc="e421ac09" sha1="5d8fce028a7793d3ecf84086244a9fb77104cc94" offset="0" />
@@ -3883,7 +3883,7 @@
 	<software name="cartcap3">
 		<description>Cartoon Capers Disk 3</description>
 		<year>1988</year>
-		<publisher>Alternative</publisher>
+		<publisher>Alternative Software</publisher>
 		<part name="flop1" interface="floppy_3">
 			<dataarea name="flop" size="194816">
 				<rom name="cartoon capers disk 3 (1988)(alternative).dsk" size="194816" crc="bd43f24b" sha1="a5a5f52b283f84d7dfa2d904712a1d25ba75dcb8" offset="0" />
@@ -5233,8 +5233,9 @@
 	</software>
 
 <!-- From "Sinclair ZX Spectrum - Compilations - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
-	<software name="magkntri">
-		<description>Magic Knight Trilogy</description>
+	<!-- May be the same edition as the IPF -->
+	<software name="mknitrila" cloneof="mknitril">
+		<description>Magic Knight Trilogy (alt)</description>
 		<year>1988</year>
 		<publisher>Mastertronic</publisher>
 		<part name="flop1" interface="floppy_3">
@@ -5746,8 +5747,9 @@
 	</software>
 
 <!-- From "Sinclair ZX Spectrum - Compilations - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
-	<software name="pirat3p3">
-		<description>Pirate 3 +3</description>
+	<!-- May be the same edition as the IPF -->
+	<software name="pirate33a" cloneof="pirate33">
+		<description>Pirate 3 +3 (alt)</description>
 		<year>1987</year>
 		<publisher>Pirate</publisher>
 		<part name="flop1" interface="floppy_3">
@@ -5853,7 +5855,7 @@
 	</software>
 
 <!-- From "Sinclair ZX Spectrum - Compilations - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
-	<software name="plus3pac">
+	<software name="plus3pad">
 		<description>Plus 3 Pack (Dinamic)</description>
 		<year>1988</year>
 		<publisher>Dinamic Software</publisher>
@@ -6046,10 +6048,11 @@
 	</software>
 
 <!-- From "Sinclair ZX Spectrum - Compilations - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
-	<software name="shootac2">
-		<description>Shootacular Disk 2</description>
+	<!-- May be the same edition as the IPF -->
+	<software name="shootdska" cloneof="shootdsk">
+		<description>Shootacular Disk 2 (alt)</description>
 		<year>1988</year>
-		<publisher>Alternative</publisher>
+		<publisher>Alternative Software</publisher>
 		<part name="flop1" interface="floppy_3">
 			<dataarea name="flop" size="195328">
 				<rom name="shootacular disk 2 (1988)(alternative).dsk" size="195328" crc="ce79b362" sha1="2eef6ecdc55ebb3fb5bd2550470b8435cdab4c07" offset="0" />
@@ -6245,10 +6248,11 @@
 	</software>
 
 <!-- From "Sinclair ZX Spectrum - Compilations - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
-	<software name="sportac1">
-		<description>Sportacular Disk 1</description>
+	<!-- May be the same edition as the IPF -->
+	<software name="sportdska" cloneof="sportdsk">
+		<description>Sportacular Disk 1 (alt)</description>
 		<year>1988</year>
-		<publisher>Alternative</publisher>
+		<publisher>Alternative Software</publisher>
 		<part name="flop1" interface="floppy_3">
 			<dataarea name="flop" size="194816">
 				<rom name="sportacular disk 1 - soccer boss + olympic spectacular + indoor soccer (1988)(alternative).dsk" size="194816" crc="d42b8502" sha1="7299f66abbe1f01b02b43274a8ca9e3dabe56a7f" offset="0" />
@@ -6314,8 +6318,9 @@
 	</software>
 
 <!-- From "Sinclair ZX Spectrum - Compilations - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
-	<software name="suncompu">
-		<description>The Sun Computer Crosswords Volume 1</description>
+	<!-- May be the same edition as the IPF -->
+	<software name="sunxworda" cloneof="sunxword">
+		<description>The Sun Computer Crosswords Volume 1 (alt)</description>
 		<year>1988</year>
 		<publisher>Akom</publisher>
 		<part name="flop1" interface="floppy_3">
@@ -6345,7 +6350,7 @@
 	</software>
 
 <!-- From "Sinclair ZX Spectrum - Compilations - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
-	<software name="supremec">
+	<software name="suprecss">
 		<description>Supreme Challenge: Soccer Spectacular</description>
 		<year>1989</year>
 		<publisher>Beau-Jolly</publisher>
@@ -11620,7 +11625,7 @@
 	</software>
 
 <!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
-	<software name="ikariwara" alt="ikariwar">
+	<software name="ikariwara" cloneof="ikariwar">
 		<description>Ikari Warriors (alt)</description>
 		<year>1988</year>
 		<publisher>Elite Systems</publisher>
@@ -11944,7 +11949,7 @@
 	</software>
 
 <!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
-	<software name="jadestona" cloneof="jadeston">>
+	<software name="jadestona" cloneof="jadeston">
 		<description>The Jade Stone (alt)</description>
 		<year>1987</year>
 		<publisher>Zenobi Software</publisher>
@@ -13537,7 +13542,7 @@
 <!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
 	<software name="ninjawarsp" cloneof="ninjawar">
 		<description>The Ninja Warriors (Spa)</description>
-		<year>1989</year>
+		<year>1990</year>
 		<publisher>Dro Soft</publisher>
 		<part name="flop1" interface="floppy_3">
 			<dataarea name="flop" size="194816">
@@ -13883,7 +13888,7 @@
 
 <!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
 	<!-- May be the same edition as the IPF -->
-	<software name="p47thuna" cloneof="p47thun">>
+	<software name="p47thuna" cloneof="p47thun">
 		<description>P-47 Thunderbolt (alt)</description>
 		<year>1990</year>
 		<publisher>Firebird Software</publisher>
@@ -14254,8 +14259,8 @@
 	</software>
 
 <!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
-	<software name="protenntsp" cloneof="protennt">>
-		<description>Pro Tennis Tour</description>
+	<software name="protenntsp" cloneof="protennt">
+		<description>Pro Tennis Tour (Spa)</description>
 		<year>1990</year>
 		<publisher>MCM Software</publisher>
 		<part name="flop1" interface="floppy_3">
@@ -14267,7 +14272,7 @@
 
 <!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
 	<!-- May be the same edition as the IPF -->
-	<software name="protennta" cloneof="protennt">>
+	<software name="protennta" cloneof="protennt">
 		<description>Pro Tennis Tour (alt)</description>
 		<year>1990</year>
 		<publisher>Ubi Soft</publisher>
@@ -14849,7 +14854,7 @@
 <!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
 	<!-- May be the same edition as the IPF -->
 	<software name="rungaunta" cloneof="rungaunt">
-		<description>Run the Gauntlet</description>
+		<description>Run the Gauntlet (alt)</description>
 		<year>1989</year>
 		<publisher>Ocean Software</publisher>
 		<part name="flop1" interface="floppy_3">
@@ -14910,7 +14915,7 @@
 <!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
 	<!-- May be the same edition as the IPF -->
 	<software name="saintgrva" cloneof="saintgrv">
-		<description>Saint &amp; Greavsie</description>
+		<description>Saint &amp; Greavsie (alt)</description>
 		<year>1989</year>
 		<publisher>Grandslam Entertainments</publisher>
 		<part name="flop1" interface="floppy_3">
@@ -15087,7 +15092,7 @@
 	</software>
 
 <!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
-	<software name="setotaisde" cloneof="setotais">>
+	<software name="setotaisde" cloneof="setotais">
 		<description>Seto Taisho vs Yokai (German, Spanish)</description>
 		<year>2016</year>
 		<publisher>Alessandro Grussu</publisher>
@@ -15111,7 +15116,7 @@
 	</software>
 
 <!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
-	<software name="setotaisfr" cloneof="setotais">>
+	<software name="setotaisfr" cloneof="setotais">
 		<description>Seto Taisho vs Yokai (French, Portuguese)</description>
 		<year>2016</year>
 		<publisher>Alessandro Grussu</publisher>
@@ -15296,7 +15301,7 @@
 	</software>
 
 <!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
-	<software name="silkwormsp" cloneofe="silkworm">>
+	<software name="silkwormsp" cloneof="silkworm">
 		<description>Silkworm (Spa)</description>
 		<year>1989</year>
 		<publisher>Erbe Software</publisher>
@@ -15308,7 +15313,7 @@
 	</software>
 
 <!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
-	<software name="silkwormspa" cloneofe="silkworm">>
+	<software name="silkwormspa" cloneof="silkworm">
 		<description>Silkworm (Spa) (alt)</description>
 		<year>1989</year>
 		<publisher>Erbe Software</publisher>
@@ -15320,7 +15325,7 @@
 	</software>
 
 <!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
-	<software name="silkwormspb" cloneofe="silkworm">>
+	<software name="silkwormspb" cloneof="silkworm">
 		<description>Silkworm (Spa) (alt 2)</description>
 		<year>1989</year>
 		<publisher>Erbe Software</publisher>
@@ -15542,8 +15547,9 @@
 	</software>
 
 <!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
-	<software name="soldiero">
-		<description>Soldier of Light</description>
+	<!-- May be the same edition as the IPF -->
+	<software name="soldlghta" cloneof="soldlght">
+		<description>Soldier of Light (alt)</description>
 		<year>1988</year>
 		<publisher>ACE</publisher>
 		<part name="flop1" interface="floppy_3">
@@ -15554,9 +15560,8 @@
 	</software>
 
 <!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
-	<!-- May be the same edition as the IPF -->
-	<software name="soldlghta" cloneof="soldlght">
-		<description>Soldier of Light (alt)</description>
+	<software name="soldlghtsp" cloneof="soldlght">
+		<description>Soldier of Light (Spa)</description>
 		<year>1988</year>
 		<publisher>Dro Soft</publisher>
 		<part name="flop1" interface="floppy_3">
@@ -15593,7 +15598,7 @@
 <!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
 	<!-- May be the same edition as the IPF -->
 	<software name="spacecrsa" cloneof="spacecrs">
-		<description>Space Crusade</description>
+		<description>Space Crusade (alt)</description>
 		<year>1992</year>
 		<publisher>Gremlin Graphics Software</publisher>
 		<part name="flop1" interface="floppy_3">
@@ -16046,6 +16051,7 @@
 	</software>
 
 <!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<!-- May be the same edition as the IPF -->
 	<software name="ssinva" cloneof="ssinv">
 		<description>Super Space Invaders (alt)</description>
 		<year>1991</year>
@@ -16058,6 +16064,7 @@
 	</software>
 
 <!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<!-- May be the same edition as the IPF -->
 	<software name="ssinvb" cloneof="ssinv">
 		<description>Super Space Invaders (alt 2)</description>
 		<year>1991</year>
@@ -16070,6 +16077,7 @@
 	</software>
 
 <!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<!-- May be the same edition as the IPF -->
 	<software name="ssinvc" cloneof="ssinv">
 		<description>Super Space Invaders (alt 3)</description>
 		<year>1991</year>
@@ -16082,8 +16090,9 @@
 	</software>
 
 <!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
-	<software name="superspa">
-		<description>Super Space Invaders</description>
+	<!-- May be the same edition as the IPF -->
+	<software name="ssinvd" cloneof="ssinv">
+		<description>Super Space Invaders (alt 4)</description>
 		<year>1991</year>
 		<publisher>Domark</publisher>
 		<part name="flop1" interface="floppy_3">
@@ -17458,8 +17467,8 @@
 	</software>
 
 <!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
-	<software name="warinmid">
-		<description>War in Middle Earth</description>
+	<software name="warmidlesp" cloneof="warmidle">
+		<description>War in Middle Earth (Spa)</description>
 		<year>1989</year>
 		<publisher>Dro Soft</publisher>
 		<part name="flop1" interface="floppy_3">
@@ -17472,7 +17481,7 @@
 <!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
 	<!-- May be the same edition as the IPF -->
 	<software name="warmidlea" cloneof="warmidle">
-		<description>War in Middle Earth</description>
+		<description>War in Middle Earth (alt)</description>
 		<year>1989</year>
 		<publisher>Melbourne House</publisher>
 		<part name="flop1" interface="floppy_3">
@@ -17502,8 +17511,8 @@
 	</software>
 
 <!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
-	<software name="welltris">
-		<description>Welltris</description>
+	<software name="welltrissp">
+		<description>Welltris (Spa)</description>
 		<year>1991</year>
 		<publisher>Erbe Software</publisher>
 		<part name="flop1" interface="floppy_3">
@@ -19687,8 +19696,8 @@
 		</part>
 	</software>
 
-	<software name="italia90sp" cloneof="italia90">
-		<description>Italia '90 - World Cup Soccer (Spa)</description>
+	<software name="italia90spb" cloneof="italia90">
+		<description>Mundial de Futbol Italia '90 (alt 2)</description>
 		<year>1989</year>
 		<publisher>Dro Soft</publisher>
 		<part name="flop1" interface="floppy_3">
@@ -19709,7 +19718,7 @@
 		</part>
 	</software>
 
-	<software name="los40v5">
+	<software name="los40v4">
 		<description>Los 40 Principales Vol. 4</description>
 		<year>1987</year>
 		<publisher>Erbe Software</publisher>
@@ -19806,8 +19815,8 @@
 		</part>
 	</software>
 
-	<software name="ninjawarsp" cloneof="ninjawar">
-		<description>The Ninja Warriors (Spa)</description>
+	<software name="ninjawarspa" cloneof="ninjawar">
+		<description>The Ninja Warriors (Spa) (alt)</description>
 		<year>1990</year>
 		<publisher>Dro Soft</publisher>
 		<part name="flop1" interface="floppy_3">

--- a/hash/specpls3_flop.xml
+++ b/hash/specpls3_flop.xml
@@ -14469,18 +14469,6 @@
 	</software>
 
 <!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
-	<software name="recvives">
-		<description>Recopilacion Vives</description>
-		<year>19??</year>
-		<publisher>&lt;unknown&gt;</publisher>
-		<part name="flop1" interface="floppy_3">
-			<dataarea name="flop" size="194816">
-				<rom name="recopilacion vives (19xx)(-)(es).dsk" size="194816" crc="7e3ae000" sha1="a0a4de3585943f143b559986e837ab34068e6e67" offset="0" />
-			</dataarea>
-		</part>
-	</software>
-
-<!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
 	<software name="redheatsp" cloneof="redheat">
 		<description>Red Heat (Spa)</description>
 		<year>1989</year>

--- a/hash/specpls3_flop.xml
+++ b/hash/specpls3_flop.xml
@@ -10747,7 +10747,7 @@
 
 <!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
 	<!-- May be the same edition as the IPF -->
-	<software name="linekskla" cloneof name="linekskl">
+	<software name="linekskla" cloneof="linekskl">
 		<description>Gary Lineker's Super Skills (alt)</description>
 		<year>1988</year>
 		<publisher>Gremlin Graphics Software</publisher>

--- a/hash/specpls3_flop.xml
+++ b/hash/specpls3_flop.xml
@@ -430,7 +430,7 @@
 		<!-- SPS (CAPS) release 3510 -->
 		<description>Four Smash Hits From Hewson</description>
 		<year>198?</year>
-		<publisher>Hewson</publisher>
+		<publisher>Hewson Consultants</publisher>
 
 		<part name="flop1" interface="floppy_3">
 			<dataarea name="flop" size="238800">
@@ -2462,7 +2462,7 @@
 
 <!-- From "Sinclair ZX Spectrum - Applications - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
 	<software name="pawes" cloneof="paw">
-		<description>Professional Adventure Writer (Spanish)</description>
+		<description>Professional Adventure Writer (Spa)</description>
 		<year>1986</year>
 		<publisher>Aventuras AD</publisher>
 		<part name="flop1" interface="floppy_3">
@@ -2711,7 +2711,7 @@
 
 <!-- From "Sinclair ZX Spectrum - Applications - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
 	<software name="tasworp3sp" cloneof="tasworp3">
-		<description>Tasword Plus Three (Spanish)</description>
+		<description>Tasword Plus Three (Spa)</description>
 		<year>1987</year>
 		<publisher>Tasman</publisher>
 		<part name="flop1" interface="floppy_3">
@@ -2967,7 +2967,7 @@
 	<software name="2x1chqin">
 		<description>2 Por 1: Chase H.Q. + Indiana Jones y la Ultima Cruzada</description>
 		<year>1989</year>
-		<publisher>Erbe</publisher>
+		<publisher>Erbe Software</publisher>
 		<part name="flop1" interface="floppy_3">
 			<feature name="part_id" value="Side A: Chase H.Q."/>
 			<dataarea name="flop" size="185088">
@@ -2986,7 +2986,7 @@
 	<software name="2x1motfa">
 		<description>2 Por 1: Motor Massacre + Final Assault</description>
 		<year>1989</year>
-		<publisher>Erbe</publisher>
+		<publisher>Erbe Software</publisher>
 		<part name="flop1" interface="floppy_3">
 			<feature name="part_id" value="Side A: Motor Massacre"/>
 			<dataarea name="flop" size="108032">
@@ -3005,7 +3005,7 @@
 	<software name="2x1plar2">
 		<description>2 por 1: Platoon + Arkanoid II: Revenge of Doh</description>
 		<year>1989</year>
-		<publisher>Erbe</publisher>
+		<publisher>Erbe Software</publisher>
 		<part name="flop1" interface="floppy_3">
 			<feature name="part_id" value="Side A: Platoon"/>
 			<dataarea name="flop" size="194816">
@@ -3024,7 +3024,7 @@
 	<software name="2x1plar2a" cloneof="2x1plar2">
 		<description>2 por 1: Platoon + Arkanoid II: Revenge of Doh (alt)</description>
 		<year>1989</year>
-		<publisher>Erbe</publisher>
+		<publisher>Erbe Software</publisher>
 		<part name="flop1" interface="floppy_3">
 			<feature name="part_id" value="Side A: Platoon"/>
 			<dataarea name="flop" size="194816">
@@ -3043,7 +3043,7 @@
 	<software name="2x1rentr">
 		<description>2 Por 1: Renegade + Target Renegade</description>
 		<year>1988</year>
-		<publisher>Erbe</publisher>
+		<publisher>Erbe Software</publisher>
 		<part name="flop1" interface="floppy_3">
 			<feature name="part_id" value="Side A: Renegade"/>
 			<dataarea name="flop" size="73472">
@@ -3062,7 +3062,7 @@
 	<software name="2x1silmm">
 		<description>2 Por 1: Silent Shadow + Mad Mix Game</description>
 		<year>1988</year>
-		<publisher>Erbe</publisher>
+		<publisher>Erbe Software</publisher>
 		<part name="flop1" interface="floppy_3">
 			<feature name="part_id" value="Side A: Silent Shadow"/>
 			<dataarea name="flop" size="194816">
@@ -3081,7 +3081,7 @@
 	<software name="2x1silmma" cloneof="2x1silmm">
 		<description>2 Por 1: Silent Shadow + Mad Mix Game (alt)</description>
 		<year>1988</year>
-		<publisher>Erbe</publisher>
+		<publisher>Erbe Software</publisher>
 		<part name="flop1" interface="floppy_3">
 			<feature name="part_id" value="Side A: Silent Shadow"/>
 			<dataarea name="flop" size="194816">
@@ -3101,7 +3101,7 @@
 	<software name="2x1tecmm">
 		<description>2 Por 1: Techno Cop + Mickey Mouse</description>
 		<year>1988</year>
-		<publisher>Erbe</publisher>
+		<publisher>Erbe Software</publisher>
 		<part name="flop1" interface="floppy_3">
 			<feature name="part_id" value="Side A: Techno Cop"/>
 			<dataarea name="flop" size="224512">
@@ -3120,7 +3120,7 @@
 	<software name="2x1tdmun">
 		<description>2 Por 1: The Deep + The Muncher</description>
 		<year>1989</year>
-		<publisher>Erbe</publisher>
+		<publisher>Erbe Software</publisher>
 		<part name="flop1" interface="floppy_3">
 			<feature name="part_id" value="Side A: The Deep"/>
 			<dataarea name="flop" size="213760">
@@ -3139,7 +3139,7 @@
 	<software name="2x1tblc2">
 		<description>2 Por 1: Thunder Blade + Cybernoid II</description>
 		<year>1988</year>
-		<publisher>Erbe</publisher>
+		<publisher>Erbe Software</publisher>
 		<part name="flop1" interface="floppy_3">
 			<feature name="part_id" value="Side A: Thunder Blade"/>
 			<dataarea name="flop" size="194816">
@@ -3158,7 +3158,7 @@
 	<software name="2x1vsbns">
 		<description>2 Por 1: MASK III: VENOM Strikes Back + North Star</description>
 		<year>1989</year>
-		<publisher>Erbe</publisher>
+		<publisher>Erbe Software</publisher>
 		<part name="flop1" interface="floppy_3">
 			<feature name="part_id" value="Side A: MASK III: VENOM Strikes Back"/>
 			<dataarea name="flop" size="173824">
@@ -3177,7 +3177,7 @@
 	<software name="2x1csmnv">
 		<description>2 X 1: Capitan Sevilla + Meganova</description>
 		<year>1988</year>
-		<publisher>Dinamic</publisher>
+		<publisher>Dinamic Software</publisher>
 		<part name="flop1" interface="floppy_3">
 			<feature name="part_id" value="Side A: Capitan Sevilla"/>
 			<dataarea name="flop" size="112640">
@@ -3215,7 +3215,7 @@
 	<software name="2x1quimc">
 		<description>2 X 1: Don Quijote + Mega-Corp</description>
 		<year>1987</year>
-		<publisher>Dinamic</publisher>
+		<publisher>Dinamic Software</publisher>
 		<part name="flop1" interface="floppy_3">
 			<feature name="part_id" value="Side A: Don Quijote"/>
 			<dataarea name="flop" size="109568">
@@ -3303,7 +3303,7 @@
 	<software name="los40v1">
 		<description>Los 40 Principales Vol. 1</description>
 		<year>1987</year>
-		<publisher>Erbe</publisher>
+		<publisher>Erbe Software</publisher>
 		<part name="flop1" interface="floppy_3">
 			<feature name="part_id" value="Side A: Batman + Thanatos"/>
 			<dataarea name="flop" size="194816">
@@ -3322,7 +3322,7 @@
 	<software name="los40v1a" cloneof="los40v1">
 		<description>Los 40 Principales Vol. 1 (alt)</description>
 		<year>1987</year>
-		<publisher>Erbe</publisher>
+		<publisher>Erbe Software</publisher>
 		<part name="flop1" interface="floppy_3">
 			<feature name="part_id" value="Side A: Batman + Thanatos"/>
 			<dataarea name="flop" size="194816">
@@ -3341,7 +3341,7 @@
 	<software name="los40v10">
 		<description>Los 40 Principales Vol. 10</description>
 		<year>1987</year>
-		<publisher>Erbe</publisher>
+		<publisher>Erbe Software</publisher>
 		<part name="flop1" interface="floppy_3">
 			<feature name="part_id" value="Side A: Super Soccer + Ramon Rodriguez"/>
 			<dataarea name="flop" size="194816">
@@ -3360,7 +3360,7 @@
 	<software name="los40v10a" cloneof="los40v10">
 		<description>Los 40 Principales Vol. 10 (alt)</description>
 		<year>1987</year>
-		<publisher>Erbe</publisher>
+		<publisher>Erbe Software</publisher>
 		<part name="flop1" interface="floppy_3">
 			<feature name="part_id" value="Side A: Super Soccer + Ramon Rodriguez"/>
 			<dataarea name="flop" size="194816">
@@ -3379,7 +3379,7 @@
 	<software name="los40v2">
 		<description>Los 40 Principales Vol. 2</description>
 		<year>1987</year>
-		<publisher>Erbe</publisher>
+		<publisher>Erbe Software</publisher>
 		<part name="flop1" interface="floppy_3">
 			<feature name="part_id" value="Side A: The Great Escape + Zorro"/>
 			<dataarea name="flop" size="194816">
@@ -3398,7 +3398,7 @@
 	<software name="los40v3">
 		<description>Los 40 Principales Vol. 3</description>
 		<year>1987</year>
-		<publisher>Erbe</publisher>
+		<publisher>Erbe Software</publisher>
 		<part name="flop1" interface="floppy_3">
 			<feature name="part_id" value="Side A: Arkanoid + Nightmare Rally"/>
 			<dataarea name="flop" size="194816">
@@ -3417,7 +3417,7 @@
 	<software name="los40v3a" cloneof="los40v3">
 		<description>Los 40 Principales Vol. 3 (alt)</description>
 		<year>1987</year>
-		<publisher>Erbe</publisher>
+		<publisher>Erbe Software</publisher>
 		<part name="flop1" interface="floppy_3">
 			<feature name="part_id" value="Side A: Arkanoid + Nightmare Rally"/>
 			<dataarea name="flop" size="194816">
@@ -3436,7 +3436,7 @@
 	<software name="los40v5">
 		<description>Los 40 Principales Vol. 5</description>
 		<year>1987</year>
-		<publisher>Erbe</publisher>
+		<publisher>Erbe Software</publisher>
 		<part name="flop1" interface="floppy_3">
 			<feature name="part_id" value="Side A: Kung-Fu Master + Three Weeks in Paradise"/>
 			<dataarea name="flop" size="194816">
@@ -3455,7 +3455,7 @@
 	<software name="los40v6">
 		<description>Los 40 Principales Vol. 6</description>
 		<year>1987</year>
-		<publisher>Erbe</publisher>
+		<publisher>Erbe Software</publisher>
 		<part name="flop1" interface="floppy_3">
 			<feature name="part_id" value="Side A: Rocky + Survivor"/>
 			<dataarea name="flop" size="194816">
@@ -3475,7 +3475,7 @@
 	<software name="los40v6a" cloneof="los40v6">
 		<description>Los 40 Principales Vol. 6 (alt)</description>
 		<year>1987</year>
-		<publisher>Erbe</publisher>
+		<publisher>Erbe Software</publisher>
 		<part name="flop1" interface="floppy_3">
 			<feature name="part_id" value="Side A: Rocky + Survivor"/>
 			<dataarea name="flop" size="194816">
@@ -3494,7 +3494,7 @@
 	<software name="los40v7">
 		<description>Los 40 Principales Vol. 7</description>
 		<year>1987</year>
-		<publisher>Erbe</publisher>
+		<publisher>Erbe Software</publisher>
 		<part name="flop1" interface="floppy_3">
 			<feature name="part_id" value="Side A: Saboteur 2 + Las Tres Luces de Glaurung"/>
 			<dataarea name="flop" size="194816">
@@ -3513,7 +3513,7 @@
 	<software name="los40v8">
 		<description>Los 40 Principales Vol. 8</description>
 		<year>1987</year>
-		<publisher>Erbe</publisher>
+		<publisher>Erbe Software</publisher>
 		<part name="flop1" interface="floppy_3">
 			<feature name="part_id" value="Side A: Barbarian + Cauldron II"/>
 			<dataarea name="flop" size="194816">
@@ -3532,7 +3532,7 @@
 	<software name="los40v8a" cloneof="los40v8">
 		<description>Los 40 Principales Vol. 8 (alt)</description>
 		<year>1987</year>
-		<publisher>Erbe</publisher>
+		<publisher>Erbe Software</publisher>
 		<part name="flop1" interface="floppy_3">
 			<feature name="part_id" value="Side A: Barbarian + Cauldron II"/>
 			<dataarea name="flop" size="194816">
@@ -3551,7 +3551,7 @@
 	<software name="los40v8b" cloneof="los40v8">
 		<description>Los 40 Principales Vol. 8 (alt 2)</description>
 		<year>1987</year>
-		<publisher>Erbe</publisher>
+		<publisher>Erbe Software</publisher>
 		<part name="flop1" interface="floppy_3">
 			<feature name="part_id" value="Side A: Barbarian + Cauldron II"/>
 			<dataarea name="flop" size="194816">
@@ -3570,7 +3570,7 @@
 	<software name="los40v9">
 		<description>Los 40 Principales Vol. 9</description>
 		<year>1987</year>
-		<publisher>Erbe</publisher>
+		<publisher>Erbe Software</publisher>
 		<part name="flop1" interface="floppy_3">
 			<feature name="part_id" value="Side A: Uridium + Uchi Mata"/>
 			<dataarea name="flop" size="194816">
@@ -3895,7 +3895,7 @@
 	<software name="chartbus">
 		<description>Chartbusters</description>
 		<year>19??</year>
-		<publisher>Ocean</publisher>
+		<publisher>Ocean Software</publisher>
 		<part name="flop1" interface="floppy_3">
 			<feature name="part_id" value="Side A: Cobra + Mutants + Green Beret"/>
 			<dataarea name="flop" size="194560">
@@ -3914,7 +3914,7 @@
 	<software name="clasgam4">
 		<description>Classic Games 4</description>
 		<year>1989</year>
-		<publisher>CP</publisher>
+		<publisher>CP Software</publisher>
 		<part name="flop1" interface="floppy_3">
 			<dataarea name="flop" size="194816">
 				<rom name="classic games 4 (1989)(cp).dsk" size="194816" crc="c2c629e1" sha1="20a45c48006b88ca85800a1f8a6d8c38381e35d7" offset="0" />
@@ -3926,7 +3926,7 @@
 	<software name="colexdin">
 		<description>Coleccion de Exitos Dinamic</description>
 		<year>1988</year>
-		<publisher>Dinamic</publisher>
+		<publisher>Dinamic Software</publisher>
 		<part name="flop1" interface="floppy_3">
 			<feature name="part_id" value="Side A: Army Moves + Game Over + Camelot Warriors + Nonamed"/>
 			<dataarea name="flop" size="214784">
@@ -3991,7 +3991,7 @@
 			</dataarea>
 		</part>
 		<part name="flop2" interface="floppy_3">
-			<feature name="part_id" value="Side B: Headliner + Typeliner & Font Editor"/>
+			<feature name="part_id" value="Side B: Headliner + Typeliner &amp; Font Editor"/>
 			<dataarea name="flop" size="194816">
 				<rom name="dtp pack (1988)(p.c.g. computer)(side b).dsk" size="194816" crc="b3f9e13d" sha1="af4ebdf3ebcf3c7143fac4740bf4f9b90894e440" offset="0" />
 			</dataarea>
@@ -4071,7 +4071,7 @@
 	<software name="dinamic5">
 		<description>Dinamic 5 Aniversario</description>
 		<year>1989</year>
-		<publisher>Dinamic</publisher>
+		<publisher>Dinamic Software</publisher>
 		<part name="flop1" interface="floppy_3">
 			<feature name="part_id" value="Disk 1, Side A: Los Pajaros de Bangkok + Mega-Corp"/>
 			<dataarea name="flop" size="214784">
@@ -4102,7 +4102,7 @@
 	<software name="dinamic5a" cloneof="dinamic5">
 		<description>Dinamic 5 Aniversario (alt)</description>
 		<year>1989</year>
-		<publisher>Dinamic</publisher>
+		<publisher>Dinamic Software</publisher>
 		<part name="flop1" interface="floppy_3">
 			<feature name="part_id" value="Disk 1, Side A: Los Pajaros de Bangkok + Mega-Corp"/>
 			<dataarea name="flop" size="214784">
@@ -4197,7 +4197,7 @@
 	<software name="erbe88">
 		<description>Erbe 88</description>
 		<year>1988</year>
-		<publisher>Erbe</publisher>
+		<publisher>Erbe Software</publisher>
 		<part name="flop1" interface="floppy_3">
 			<feature name="part_id" value="Disk 1, Side A: Chicago 30's + Coliseum"/>
 			<dataarea name="flop" size="194816">
@@ -4228,7 +4228,7 @@
 	<software name="erbe88a" cloneof="erbe88">
 		<description>Erbe 88 (alt)</description>
 		<year>1988</year>
-		<publisher>Erbe</publisher>
+		<publisher>Erbe Software</publisher>
 		<part name="flop1" interface="floppy_3">
 			<feature name="part_id" value="Disk 1, Side A: Chicago 30's + Coliseum"/>
 			<dataarea name="flop" size="116992">
@@ -4259,7 +4259,7 @@
 	<software name="erbe88b" cloneof="erbe88">
 		<description>Erbe 88 (alt 2)</description>
 		<year>1988</year>
-		<publisher>Erbe</publisher>
+		<publisher>Erbe Software</publisher>
 		<part name="flop1" interface="floppy_3">
 		<!-- Side missing from dump, using same as parent set -->
 			<feature name="part_id" value="Disk 1, Side A: Chicago 30's + Coliseum"/>
@@ -4450,7 +4450,7 @@
 	<software name="gsandmat">
 		<description>Game, Set and Match</description>
 		<year>1987</year>
-		<publisher>Ocean</publisher>
+		<publisher>Ocean Software</publisher>
 		<part name="flop1" interface="floppy_3">
 			<feature name="part_id" value="Side A: GBA Championship Basketball + Super Soccer + World Series Baseball"/>
 			<dataarea name="flop" size="194560">
@@ -5141,7 +5141,7 @@
 	<software name="liveammo">
 		<description>Live Ammo</description>
 		<year>1987</year>
-		<publisher>Ocean</publisher>
+		<publisher>Ocean Software</publisher>
 		<part name="flop1" interface="floppy_3">
 			<feature name="part_id" value="Side A: Green Beret + Top Gun + Rambo"/>
 			<dataarea name="flop" size="194560">
@@ -5160,7 +5160,7 @@
 	<software name="liveammoa" cloneof="liveammo">
 		<description>Live Ammo - Green Beret + Top Gun + Rambo (alt)</description>
 		<year>1987</year>
-		<publisher>Ocean</publisher>
+		<publisher>Ocean Software</publisher>
 		<part name="flop1" interface="floppy_3">
 			<feature name="part_id" value="Side A: Green Beret + Top Gun + Rambo"/>
 			<dataarea name="flop" size="194560">
@@ -5179,7 +5179,7 @@
 	<software name="lomejdin">
 		<description>Lo Mejor de Dinamic</description>
 		<year>1988</year>
-		<publisher>Dinamic</publisher>
+		<publisher>Dinamic Software</publisher>
 		<part name="flop1" interface="floppy_3">
 			<feature name="part_id" value="Side A: Game Over + Freddy Hardest + Fernando Martin Basket Master"/>
 			<dataarea name="flop" size="209408">
@@ -5255,7 +5255,7 @@
 	<software name="magnsevn">
 		<description>The Magnificent Seven</description>
 		<year>1987</year>
-		<publisher>Ocean</publisher>
+		<publisher>Ocean Software</publisher>
 		<part name="flop1" interface="floppy_3">
 			<feature name="part_id" value="Side A: Wizball + Arkanoid + Yie Ar Kung-Fu + Short Circuit"/>
 			<dataarea name="flop" size="215291">
@@ -5324,7 +5324,7 @@
 	<software name="megabox">
 		<description>Mega Box</description>
 		<year>1991</year>
-		<publisher>Dinamic</publisher>
+		<publisher>Dinamic Software</publisher>
 		<part name="flop1" interface="floppy_3">
 			<feature name="part_id" value="Disk 1, Side A: Narco Police"/>
 			<dataarea name="flop" size="131584">
@@ -5356,7 +5356,7 @@
 	<software name="metalact">
 		<description>Metal Action</description>
 		<year>1990</year>
-		<publisher>Dinamic</publisher>
+		<publisher>Dinamic Software</publisher>
 		<part name="flop1" interface="floppy_3">
 			<feature name="part_id" value="Side A: After the War + La Aventura Original + Satan I"/>
 			<dataarea name="flop" size="214784">
@@ -5457,7 +5457,7 @@
 	<software name="multispo">
 		<description>Multi Sports</description>
 		<year>1991</year>
-		<publisher>Dinamic</publisher>
+		<publisher>Dinamic Software</publisher>
 		<part name="flop1" interface="floppy_3">
 			<feature name="part_id" value="Side A: Basket Master + Aspar GP Master + Simulador Profesional de Tenis"/>
 			<dataarea name="flop" size="144896">
@@ -5680,7 +5680,7 @@
 	<software name="packrsp3">
 		<description>Pack Regalo Sinclair +3</description>
 		<year>1988</year>
-		<publisher>Dinamic</publisher>
+		<publisher>Dinamic Software</publisher>
 		<part name="flop1" interface="floppy_3">
 			<feature name="part_id" value="Side A: Game Over + Phantomas 1 + Phantomas 2"/>
 			<dataarea name="flop" size="187904">
@@ -5699,7 +5699,7 @@
 	<software name="packrsp3a" cloneof="packrsp3">
 		<description>Pack Regalo Sinclair +3 (alt)</description>
 		<year>1988</year>
-		<publisher>Dinamic</publisher>
+		<publisher>Dinamic Software</publisher>
 		<part name="flop1" interface="floppy_3">
 			<feature name="part_id" value="Side A: Game Over + Phantomas 1 + Phantomas 2"/>
 			<dataarea name="flop" size="187904">
@@ -5837,7 +5837,7 @@
 	<software name="plus3pac">
 		<description>Plus 3 Pack</description>
 		<year>1987</year>
-		<publisher>Gremlin Graphics</publisher>
+		<publisher>Gremlin Graphics Software</publisher>
 		<part name="flop1" interface="floppy_3">
 			<feature name="part_id" value="Side A: Krakout + Future Knight"/>
 			<dataarea name="flop" size="174848">
@@ -5856,7 +5856,7 @@
 	<software name="plus3pac">
 		<description>Plus 3 Pack (Dinamic)</description>
 		<year>1988</year>
-		<publisher>Dinamic</publisher>
+		<publisher>Dinamic Software</publisher>
 		<part name="flop1" interface="floppy_3">
 			<feature name="part_id" value="Side A: Game Over + Fernando Martin Basket Master"/>
 			<dataarea name="flop" size="144384">
@@ -5913,7 +5913,7 @@
 	<software name="powerspo">
 		<description>Powersports</description>
 		<year>1991</year>
-		<publisher>Zigurat</publisher>
+		<publisher>Zigurat Software</publisher>
 		<part name="flop1" interface="floppy_3">
 			<feature name="part_id" value="Side A: Carlos Sainz + Paris-Dakar"/>
 			<dataarea name="flop" size="194816">
@@ -5982,7 +5982,7 @@
 	<software name="reptonmn">
 		<description>Repton Mania</description>
 		<year>1989</year>
-		<publisher>Superior</publisher>
+		<publisher>Superior Software</publisher>
 		<part name="flop1" interface="floppy_3">
 			<dataarea name="flop" size="254720">
 				<rom name="repton mania - repton 1 + 2 (1989)(superior).dsk" size="254720" crc="2ed24adb" sha1="c452b252272ba4ebb7c509c6a7358b867df94c64" offset="0" />
@@ -6390,7 +6390,7 @@
 
 <!-- From "Sinclair ZX Spectrum - Compilations - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
 	<software name="tntdomrksp" cloneof="tntdomrk">
-		<description>TNT (Spain)</description>
+		<description>TNT (Spa)</description>
 		<year>1991</year>
 		<publisher>Dro Soft</publisher>
 		<part name="flop1" interface="floppy_3">
@@ -6504,7 +6504,7 @@
 	<software name="atodamaq">
 		<description>A Toda Maquina</description>
 		<year>1989</year>
-		<publisher>Erbe</publisher>
+		<publisher>Erbe Software</publisher>
 		<part name="flop1" interface="floppy_3">
 			<feature name="part_id" value="Side A: Dragon Ninja + Afterburner"/>
 			<dataarea name="flop" size="261120">
@@ -6562,7 +6562,7 @@
 	<software name="totalerb">
 		<description>Total</description>
 		<year>1989</year>
-		<publisher>Erbe</publisher>
+		<publisher>Erbe Software</publisher>
 		<part name="flop1" interface="floppy_3">
 			<feature name="part_id" value="Side A: Platoon + Arkanoid II: Revenge of Doh + Combat School"/>
 			<dataarea name="flop" size="215296">
@@ -6600,7 +6600,7 @@
 	<software name="vitamina">
 		<description>Vitaminas</description>
 		<year>1989</year>
-		<publisher>Erbe</publisher>
+		<publisher>Erbe Software</publisher>
 		<part name="flop1" interface="floppy_3">
 			<feature name="part_id" value="Side A: Street Fighter + Bionic Commando (loader) + Road Blasters + 1943"/>
 			<dataarea name="flop" size="198656">
@@ -6619,7 +6619,7 @@
 	<software name="watchamp">
 		<description>We Are the Champions</description>
 		<year>1988</year>
-		<publisher>Ocean</publisher>
+		<publisher>Ocean Software</publisher>
 		<part name="flop1" interface="floppy_3">
 			<feature name="part_id" value="Side A: International Karate+ + Renegade"/>
 			<dataarea name="flop" size="214784">
@@ -7164,7 +7164,7 @@
 
 <!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
 	<software name="atfsp" cloneof="atf">
-		<description>ATF - Advanced Tactical Fighter (Spain)</description>
+		<description>ATF - Advanced Tactical Fighter (Spa)</description>
 		<year>1988</year>
 		<publisher>Zafiro Software Division</publisher>
 		<part name="flop1" interface="floppy_3">
@@ -7226,9 +7226,9 @@
 
 <!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
 	<software name="tiebreaksp" cloneof="tiebreak">
-		<description>Adidas Championship Tie-Break (Spain)</description>
+		<description>Adidas Championship Tie-Break (Spa)</description>
 		<year>1990</year>
-		<publisher>Erbe</publisher>
+		<publisher>Erbe Software</publisher>
 		<part name="flop1" interface="floppy_3">
 			<dataarea name="flop" size="73216">
 				<rom name="adidas championship tie-break (1990)(erbe)(es)(en)[re-release].dsk" size="73216" crc="dd6cd54d" sha1="bd915b96fe9fa36c17c3f92f2bbc954720567867" offset="0" />
@@ -7241,7 +7241,7 @@
 	<software name="tiebreaka" cloneof="tiebreak">
 		<description>Adidas Championship Tie-Break (alt)</description>
 		<year>1990</year>
-		<publisher>Ocean</publisher>
+		<publisher>Ocean Software</publisher>
 		<part name="flop1" interface="floppy_3">
 			<dataarea name="flop" size="196352">
 				<rom name="adidas championship tie-break (1990)(ocean).dsk" size="196352" crc="c5a7238c" sha1="815ca74726a688d0878303bfd7558b5f82c17388" offset="0" />
@@ -7253,7 +7253,7 @@
 	<software name="afterwar">
 		<description>After the War</description>
 		<year>1989</year>
-		<publisher>Dinamic</publisher>
+		<publisher>Dinamic Software</publisher>
 		<part name="flop1" interface="floppy_3">
 			<dataarea name="flop" size="118016">
 				<rom name="after the war (1989)(dinamic)(es)(en).dsk" size="118016" crc="cb90314d" sha1="970d0ef6ec0223be59b46298e91be212bdeceda1" offset="0" />
@@ -7263,9 +7263,9 @@
 
 <!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
 	<software name="afterwarsp" cloneof="afterwar">
-		<description>After the War (Spain)</description>
+		<description>After the War (Spa)</description>
 		<year>1989</year>
-		<publisher>Dinamic</publisher>
+		<publisher>Dinamic Software</publisher>
 		<part name="flop1" interface="floppy_3">
 			<dataarea name="flop" size="166400">
 				<rom name="after the war (1989)(dinamic)(es).dsk" size="166400" crc="3dabca4d" sha1="202216a662531fa8c5fba654aac78d91c6db0f4c" offset="0" />
@@ -7376,9 +7376,9 @@
 
 <!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
 	<software name="astormsp" cloneof="astorm">
-		<description>Alien Storm (Spain)</description>
+		<description>Alien Storm (Spa)</description>
 		<year>1991</year>
-		<publisher>Erbe</publisher>
+		<publisher>Erbe Software</publisher>
 		<part name="flop1" interface="floppy_3">
 			<dataarea name="flop" size="255232">
 				<rom name="alien storm (1991)(erbe)(es)(en)[re-release].dsk" size="255232" crc="deea5c29" sha1="fce55879436faff99fb58de3bdc3b52ee7e15e17" offset="0" />
@@ -7412,7 +7412,7 @@
 
 <!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
 	<software name="aliensynsp" cloneof="aliensyn">
-		<description>Alien Syndrome (Spain)</description>
+		<description>Alien Syndrome (Spa)</description>
 		<year>1988</year>
 		<publisher>Dro Soft</publisher>
 		<part name="flop1" interface="floppy_3">
@@ -7493,7 +7493,7 @@
 
 <!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
 	<software name="amnes102sp" cloneof="amnes102">
-		<description>Amnesia v1.02 (Spanish)</description>
+		<description>Amnesia v1.02 (Spa)</description>
 		<year>2015</year>
 		<publisher>Huelvy</publisher>
 		<part name="flop1" interface="floppy_3">
@@ -7628,7 +7628,7 @@
 	<software name="arturaa" cloneof="artura">
 		<description>Artura (alt)</description>
 		<year>1989</year>
-		<publisher>Gremlin Graphics</publisher>
+		<publisher>Gremlin Graphics Software</publisher>
 		<part name="flop1" interface="floppy_3">
 			<feature name="part_id" value="Side A"/>
 			<dataarea name="flop" size="194816">
@@ -7660,7 +7660,7 @@
 	<software name="aspargpm">
 		<description>Aspar GP Master</description>
 		<year>1988</year>
-		<publisher>Dinamic</publisher>
+		<publisher>Dinamic Software</publisher>
 		<part name="flop1" interface="floppy_3">
 			<feature name="part_id" value="Side A"/>
 			<dataarea name="flop" size="58880">
@@ -7679,7 +7679,7 @@
 	<software name="aspargpmsp" cloneof="aspargpm">
 		<description>Aspar GP Master (alt)</description>
 		<year>1988</year>
-		<publisher>Dinamic</publisher>
+		<publisher>Dinamic Software</publisher>
 		<part name="flop1" interface="floppy_3">
 			<dataarea name="flop" size="58880">
 				<rom name="aspar gp master (1988)(dinamic)(es).dsk" size="58880" crc="8c452eea" sha1="1618afa3986147ee842af394198ea662de76f6a9" offset="0" />
@@ -7691,7 +7691,7 @@
 	<software name="amc">
 		<description>Astro Marine Corps</description>
 		<year>1989</year>
-		<publisher>Dinamic</publisher>
+		<publisher>Dinamic Software</publisher>
 		<part name="flop1" interface="floppy_3">
 			<dataarea name="flop" size="128768">
 				<rom name="astro marine corps (1989)(dinamic)(es)[aka amc].dsk" size="128768" crc="49da31a0" sha1="045a8026457cebe101fa76c856654812e4830c3f" offset="0" />
@@ -7715,7 +7715,7 @@
 	<software name="autocras">
 		<description>Autocrash</description>
 		<year>1991</year>
-		<publisher>Zigurat</publisher>
+		<publisher>Zigurat Software</publisher>
 		<part name="flop1" interface="floppy_3">
 			<dataarea name="flop" size="63488">
 				<rom name="autocrash (1991)(zigurat)(es).dsk" size="63488" crc="9d26fed0" sha1="1aea386a6243646e3dfce6bce6d013e6e86a6ca3" offset="0" />
@@ -7892,9 +7892,9 @@
 
 <!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
 	<software name="barbari2sp" cloneof="barbari2">
-		<description>Barbarian II - The Dungeon of Drax (Spain)</description>
+		<description>Barbarian II - The Dungeon of Drax (Spa)</description>
 		<year>1988</year>
-		<publisher>Erbe</publisher>
+		<publisher>Erbe Software</publisher>
 		<part name="flop1" interface="floppy_3">
 			<dataarea name="flop" size="144384">
 				<rom name="barbarian ii - the dungeon of drax (1988)(erbe)(es)(en)[re-release].dsk" size="144384" crc="8ba96bd6" sha1="aed9c7159d67af12e649f6a4b7f69c767ed38f94" offset="0" />
@@ -7961,7 +7961,7 @@
 	<software name="batmancc">
 		<description>Batman - The Caped Crusader</description>
 		<year>1988</year>
-		<publisher>Ocean</publisher>
+		<publisher>Ocean Software</publisher>
 		<part name="flop1" interface="floppy_3">
 			<dataarea name="flop" size="123392">
 				<rom name="batman - the caped crusader (1988)(ocean).dsk" size="123392" crc="91bfb255" sha1="004538f2c6b9258c301a5c232075d7d762f444a9" offset="0" />
@@ -7973,7 +7973,7 @@
 	<software name="batmantm">
 		<description>Batman - The Movie</description>
 		<year>1989</year>
-		<publisher>Ocean</publisher>
+		<publisher>Ocean Software</publisher>
 		<part name="flop1" interface="floppy_3">
 			<dataarea name="flop" size="194816">
 				<rom name="batman - the movie (1989)(ocean).dsk" size="194816" crc="31da53d6" sha1="50a94f8a0261fc4661af6fc791f684ed1737c9ba" offset="0" />
@@ -7985,7 +7985,7 @@
 	<software name="batmantma" cloneof="batmantm">
 		<description>Batman - The Movie (alt)</description>
 		<year>1989</year>
-		<publisher>Ocean</publisher>
+		<publisher>Ocean Software</publisher>
 		<part name="flop1" interface="floppy_3">
 			<dataarea name="flop" size="152576">
 				<rom name="batman - the movie (1989)(ocean)[a].dsk" size="152576" crc="a4db4011" sha1="e56a88a1837d8ad02c64ddd786ff8ece1d064087" offset="0" />
@@ -7997,7 +7997,7 @@
 	<software name="batmantmb" cloneof="batmantm">
 		<description>Batman - The Movie (alt 2)</description>
 		<year>1989</year>
-		<publisher>Ocean</publisher>
+		<publisher>Ocean Software</publisher>
 		<part name="flop1" interface="floppy_3">
 			<dataarea name="flop" size="194816">
 				<rom name="batman - the movie (1989)(ocean)[a2].dsk" size="194816" crc="111bd6db" sha1="2920d5ea39b487bd1c8713cf8117752ecc7a12a3" offset="0" />
@@ -8007,9 +8007,9 @@
 
 <!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
 	<software name="batmantmspa" cloneof="batmantm">
-		<description>Batman - The Movie (Spain) (alt)</description>
+		<description>Batman - The Movie (Spa) (alt)</description>
 		<year>1989</year>
-		<publisher>Erbe</publisher>
+		<publisher>Erbe Software</publisher>
 		<part name="flop1" interface="floppy_3">
 			<dataarea name="flop" size="185088">
 				<rom name="batman - the movie (1989)(erbe)(es)(en)[a][re-release].dsk" size="185088" crc="d07587bc" sha1="94918c10f53710577cc86c3e3b89b37fec6577f9" offset="0" />
@@ -8019,9 +8019,9 @@
 
 <!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
 	<software name="batmantmsp" cloneof="batmantm">
-		<description>Batman - The Movie (Spain)</description>
+		<description>Batman - The Movie (Spa)</description>
 		<year>1989</year>
-		<publisher>Erbe</publisher>
+		<publisher>Erbe Software</publisher>
 		<part name="flop1" interface="floppy_3">
 			<dataarea name="flop" size="185088">
 				<rom name="batman - the movie (1989)(erbe)(es)(en)[re-release].dsk" size="185088" crc="42936386" sha1="75b4ea3e5659f5d39b115abf795ff8175dc0ae06" offset="0" />
@@ -8033,7 +8033,7 @@
 	<software name="beachvol">
 		<description>Beach Volley</description>
 		<year>1989</year>
-		<publisher>Erbe</publisher>
+		<publisher>Erbe Software</publisher>
 		<part name="flop1" interface="floppy_3">
 			<dataarea name="flop" size="97536">
 				<rom name="beach volley (1989)(erbe)(es)(en)[re-release].dsk" size="97536" crc="f8c13542" sha1="93673eaec3f66e8e14461e94d55cbb69b944f171" offset="0" />
@@ -8055,9 +8055,9 @@
 
 <!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
 	<software name="bedlamsp" cloneof="bedlam">
-		<description>Bedlam (Spain)</description>
+		<description>Bedlam (Spa)</description>
 		<year>1988</year>
-		<publisher>Erbe</publisher>
+		<publisher>Erbe Software</publisher>
 		<part name="flop1" interface="floppy_3">
 			<dataarea name="flop" size="194816">
 				<rom name="bedlam (1988)(erbe)(es)(en)[re-release].dsk" size="194816" crc="4f8f724b" sha1="c93e9de8363fbd4b48c9aa23095af34b4e42a940" offset="0" />
@@ -8117,7 +8117,7 @@
 	<software name="bestialwgs" cloneof="bestialw">
 		<description>Bestial Warrior (Gun Stick)</description>
 		<year>1989</year>
-		<publisher>Dinamic</publisher>
+		<publisher>Dinamic Software</publisher>
 		<info name="usage" value="Requires Gun Stick light gun"/>
 		<part name="flop1" interface="floppy_3">
 			<dataarea name="flop" size="75008">
@@ -8131,7 +8131,7 @@
 	<software name="bestialw">
 		<description>Bestial Warrior</description>
 		<year>1989</year>
-		<publisher>Dinamic</publisher>
+		<publisher>Dinamic Software</publisher>
 		<part name="flop1" interface="floppy_3">
 			<dataarea name="flop" size="80384">
 				<rom name="bestial warrior (1989)(dinamic)(es)[a].dsk" size="80384" crc="208235f6" sha1="50d9a3bb79b82deb6c08253cfbffa460bb8abaa2" offset="0" />
@@ -8145,7 +8145,7 @@
 	<software name="bestialw">
 		<description>Bestial Warrior (rerelease)</description>
 		<year>1989</year>
-		<publisher>Dinamic</publisher>
+		<publisher>Dinamic Software</publisher>
 		<part name="flop1" interface="floppy_3">
 			<dataarea name="flop" size="91136">
 				<rom name="bestial warrior (1989)(dinamic)(es)(side b).dsk" size="91136" crc="3fd882c2" sha1="977204c72ef1b1643e33516ffe904b35ad87c826" offset="0" />
@@ -8182,7 +8182,7 @@
 
 <!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
 	<software name="bticepalsp" cloneof="bticepal">
-		<description>Beyond the Ice Palace (Spain)</description>
+		<description>Beyond the Ice Palace (Spa)</description>
 		<year>1988</year>
 		<publisher>MCM</publisher>
 		<part name="flop1" interface="floppy_3">
@@ -8362,7 +8362,7 @@
 	<software name="brdgpgal">
 		<description>Bridge Player Galactica</description>
 		<year>1989</year>
-		<publisher>CP</publisher>
+		<publisher>CP Software</publisher>
 		<part name="flop1" interface="floppy_3">
 			<dataarea name="flop" size="194816">
 				<rom name="bridge player galactica (1989)(cp).dsk" size="194816" crc="be950646" sha1="b921a28c699b1e785b613ac8a7e5fb2ee0fcf6ba" offset="0" />
@@ -8396,7 +8396,7 @@
 
 <!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
 	<software name="bbrg" cloneof="bbrg">
-		<description>Buffalo Bill's Wild West Show (Spain)</description>
+		<description>Buffalo Bill's Wild West Show (Spa)</description>
 		<year>1989</year>
 		<publisher>System 4</publisher>
 		<part name="flop1" interface="floppy_3">
@@ -8447,7 +8447,7 @@
 	<software name="buggyran">
 		<description>Buggy Ranger</description>
 		<year>1990</year>
-		<publisher>Dinamic</publisher>
+		<publisher>Dinamic Software</publisher>
 		<part name="flop1" interface="floppy_3">
 			<dataarea name="flop" size="64256">
 				<rom name="buggy ranger (1990)(dinamic)(es).dsk" size="64256" crc="8b7ece82" sha1="fba219989f6d81a249a92deee818762d017c9b37" offset="0" />
@@ -8484,7 +8484,7 @@
 	<software name="butchilla" cloneof="butchill">
 		<description>Butcher Hill (alt)</description>
 		<year>1989</year>
-		<publisher>Gremlin Graphics</publisher>
+		<publisher>Gremlin Graphics Software</publisher>
 		<part name="flop1" interface="floppy_3">
 			<dataarea name="flop" size="194816">
 				<rom name="butcher hill (1989)(gremlin graphics).dsk" size="194816" crc="43d9764d" sha1="cdc2d744c058bb8f788ecf7c46a127db486dc915" offset="0" />
@@ -8496,7 +8496,7 @@
 	<software name="byfairme">
 		<description>By Fair Means...or Foul</description>
 		<year>1989</year>
-		<publisher>Superior</publisher>
+		<publisher>Superior Software</publisher>
 		<part name="flop1" interface="floppy_3">
 			<dataarea name="flop" size="214784">
 				<rom name="by fair means...or foul (1989)(superior).dsk" size="214784" crc="6d191978" sha1="9bc03db30b5825be2b65c8e3b2be112f6b5c5ffb" offset="0" />
@@ -8506,9 +8506,9 @@
 
 <!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
 	<software name="cabalsp" cloneof="cabal">
-		<description>Cabal (Spain)</description>
+		<description>Cabal (Spa)</description>
 		<year>1989</year>
-		<publisher>Erbe</publisher>
+		<publisher>Erbe Software</publisher>
 		<part name="flop1" interface="floppy_3">
 			<dataarea name="flop" size="185088">
 				<rom name="cabal (1989)(erbe)(es)(en)[re-release].dsk" size="185088" crc="64cd1c52" sha1="eaff4e540200b432387ad8159b9ebfd2fda37deb" offset="0" />
@@ -8520,7 +8520,7 @@
 	<software name="cabal">
 		<description>Cabal</description>
 		<year>1989</year>
-		<publisher>Ocean</publisher>
+		<publisher>Ocean Software</publisher>
 		<part name="flop1" interface="floppy_3">
 			<dataarea name="flop" size="164352">
 				<rom name="cabal (1989)(ocean).dsk" size="164352" crc="12a62acc" sha1="e021057ade1a87dc0f429f505af97f587295478a" offset="0" />
@@ -8556,7 +8556,7 @@
 	<software name="cpsevill">
 		<description>Capitan Sevilla</description>
 		<year>1988</year>
-		<publisher>Dinamic</publisher>
+		<publisher>Dinamic Software</publisher>
 		<part name="flop1" interface="floppy_3">
 			<dataarea name="flop" size="175360">
 				<rom name="capitan sevilla (1988)(dinamic)(es).dsk" size="175360" crc="e7a740da" sha1="5b00d1bea69edd2b9ea7069aae5bd6467528be0d" offset="0" />
@@ -8568,7 +8568,7 @@
 	<software name="cptrueno">
 		<description>El Capitan Trueno</description>
 		<year>1990</year>
-		<publisher>Dinamic</publisher>
+		<publisher>Dinamic Software</publisher>
 		<part name="flop1" interface="floppy_3">
 			<dataarea name="flop" size="107264">
 				<rom name="capitan trueno, el (1990)(dinamic)(es).dsk" size="107264" crc="ae4033aa" sha1="ebfba4e9b058aec5d123d5c5d00d8ed6e325ce72" offset="0" />
@@ -8629,7 +8629,7 @@
 	<software name="csainz">
 		<description>Carlos Sainz - Campeonato del Mundo de Rallies</description>
 		<year>1990</year>
-		<publisher>Zigurat</publisher>
+		<publisher>Zigurat Software</publisher>
 		<part name="flop1" interface="floppy_3">
 			<dataarea name="flop" size="58624">
 				<rom name="carlos sainz - campeonato del mundo de rallies (1990)(zigurat)(es).dsk" size="58624" crc="69b938d9" sha1="8c78ff2f741668a9d583598bd0d71ae3c94ec054" offset="0" />
@@ -8664,9 +8664,9 @@
 
 <!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
 	<software name="castlmassp" cloneof="castlmas">
-		<description>Castle Master (Spanish)</description>
+		<description>Castle Master (Spa)</description>
 		<year>1990</year>
-		<publisher>Erbe</publisher>
+		<publisher>Erbe Software</publisher>
 		<part name="flop1" interface="floppy_3">
 			<dataarea name="flop" size="68352">
 				<rom name="castle master (1990)(erbe)(es)[re-release].dsk" size="68352" crc="a6e15f9f" sha1="adb6fa50b973e23868e2ecdbada09894e39835a2" offset="0" />
@@ -8712,7 +8712,7 @@
 
 <!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
 	<software name="cvaniasisp" cloneof="cvaniasi">
-		<description>Castlevania - Spectral Interlude (Spanish)</description>
+		<description>Castlevania - Spectral Interlude (Spa)</description>
 		<year>2015</year>
 		<publisher>Rewind Team</publisher>
 		<part name="flop1" interface="floppy_3">
@@ -8828,7 +8828,7 @@
 			<feature name="part_id" value="Side B"/>
 	<!-- Side B image shared with other master disks from Zeppelin Games. Verified at World of Spectrum. -->
 			<dataarea name="flop" size="256">
-				<rom name="championship run (1991)(zeppelin games)(side b)[master disk backup][re-release].dsk" size="256" crc="56947af2" sha1="40428c770d847a0fd1fd005b6cf1d03a34672d98" offset="0" />
+				<rom name="zeppelin games master disk side b.dsk" size="256" crc="56947af2" sha1="40428c770d847a0fd1fd005b6cf1d03a34672d98" offset="0" />
 			</dataarea>
 		</part>
 	</software>
@@ -8848,7 +8848,7 @@
 			<feature name="part_id" value="Side B"/>
 	<!-- Side B image shared with other master disks from Zeppelin Games. Verified at World of Spectrum. -->
 			<dataarea name="flop" size="256">
-				<rom name="championship run (1991)(zeppelin games)(side b)[master disk backup][re-release].dsk" size="256" crc="56947af2" sha1="40428c770d847a0fd1fd005b6cf1d03a34672d98" offset="0" />
+				<rom name="zeppelin games master disk side b.dsk" size="256" crc="56947af2" sha1="40428c770d847a0fd1fd005b6cf1d03a34672d98" offset="0" />
 			</dataarea>
 		</part>
 	</software>
@@ -8881,9 +8881,9 @@
 
 <!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
 	<software name="chasehqsp" cloneof="chasehq">
-		<description>Chase H.Q. (Spain)</description>
+		<description>Chase H.Q. (Spa)</description>
 		<year>1989</year>
-		<publisher>Erbe</publisher>
+		<publisher>Erbe Software</publisher>
 		<part name="flop1" interface="floppy_3">
 			<dataarea name="flop" size="185088">
 				<rom name="chase h.q. (1989)(erbe)(es)(en)[re-release].dsk" size="185088" crc="317e46d5" sha1="66de397575284efb76a08ef63dbe5db41be03249" offset="0" />
@@ -8895,7 +8895,7 @@
 	<software name="chasehq">
 		<description>Chase H.Q.</description>
 		<year>1989</year>
-		<publisher>Ocean</publisher>
+		<publisher>Ocean Software</publisher>
 		<part name="flop1" interface="floppy_3">
 			<dataarea name="flop" size="168192">
 				<rom name="chase h.q. (1989)(ocean).dsk" size="168192" crc="9c56fc47" sha1="1347cb84b7b232da4a587c573ba893cf171c6df3" offset="0" />
@@ -8905,9 +8905,9 @@
 
 <!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
 	<software name="chasehq2sp" cloneof="chasehq2">
-		<description>Chase H.Q. II - Special Criminal Investigation (Spain)</description>
+		<description>Chase H.Q. II - Special Criminal Investigation (Spa)</description>
 		<year>1990</year>
-		<publisher>Erbe</publisher>
+		<publisher>Erbe Software</publisher>
 		<part name="flop1" interface="floppy_3">
 			<dataarea name="flop" size="146176">
 				<rom name="chase h.q. ii - special criminal investigation (1990)(erbe)(es)(en)[re-release].dsk" size="146176" crc="5b451c6e" sha1="58101ac75972e690b13eb7665d0ae245c47cefab" offset="0" />
@@ -8919,7 +8919,7 @@
 	<software name="chasehq2">
 		<description>Chase H.Q. II - Special Criminal Investigations</description>
 		<year>1990</year>
-		<publisher>Ocean</publisher>
+		<publisher>Ocean Software</publisher>
 		<part name="flop1" interface="floppy_3">
 			<dataarea name="flop" size="127232">
 				<rom name="chase h.q. ii - special criminal investigations (1990)(ocean).dsk" size="127232" crc="3b77b2ad" sha1="82ca5734e13e42347f3c6ca182049d45d5cc6bad" offset="0" />
@@ -9048,7 +9048,7 @@
 	<software name="clckch89">
 		<description>Clock Chess '89</description>
 		<year>1989</year>
-		<publisher>CP</publisher>
+		<publisher>CP Software</publisher>
 		<part name="flop1" interface="floppy_3">
 			<dataarea name="flop" size="194816">
 				<rom name="clock chess '89 (1989)(cp).dsk" size="194816" crc="32467893" sha1="a6b698715f6c413dd3f1910d6dff8720e3643aa8" offset="0" />
@@ -9058,7 +9058,7 @@
 
 <!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
 	<software name="clckch89sp" cloneof="clckch89">
-		<description>Clock Chess '89 (Spain)</description>
+		<description>Clock Chess '89 (Spa)</description>
 		<year>1989</year>
 		<publisher>System 4</publisher>
 		<part name="flop1" interface="floppy_3">
@@ -9141,7 +9141,7 @@
 	<software name="cmquatro">
 		<description>Comando Quatro</description>
 		<year>1989</year>
-		<publisher>Zigurat</publisher>
+		<publisher>Zigurat Software</publisher>
 		<part name="flop1" interface="floppy_3">
 			<dataarea name="flop" size="68352">
 				<rom name="comando quatro (1989)(zigurat)(es).dsk" size="68352" crc="1f253875" sha1="ba4c1ba3e604bb35bb1ef91a855b993833f090e7" offset="0" />
@@ -9153,7 +9153,7 @@
 	<software name="comtracr">
 		<description>Comando Tracer</description>
 		<year>1989</year>
-		<publisher>Dinamic</publisher>
+		<publisher>Dinamic Software</publisher>
 		<part name="flop1" interface="floppy_3">
 			<dataarea name="flop" size="75008">
 				<rom name="comando tracer (1989)(dinamic)(es).dsk" size="75008" crc="985c2136" sha1="be76783bd8429b9f3ec2cd8702e7419b1c632ee6" offset="0" />
@@ -9166,7 +9166,7 @@
 	<software name="combatsg">
 		<description>Combat School + Gryzor Preview</description>
 		<year>1987</year>
-		<publisher>Ocean</publisher>
+		<publisher>Ocean Software</publisher>
 		<part name="flop1" interface="floppy_3">
 			<dataarea name="flop" size="214784">
 				<rom name="combat school + gryzor preview (1987)(ocean).dsk" size="214784" crc="2996f5e8" sha1="0dc0e1340835d35071a5a2873346462faa07233d" offset="0" />
@@ -9176,7 +9176,7 @@
 
 <!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
 	<software name="contcircsp" cloneof="contcirc">
-		<description>Continental Circus (Spain)</description>
+		<description>Continental Circus (Spa)</description>
 		<year>1989</year>
 		<publisher>Dro Soft</publisher>
 		<part name="flop1" interface="floppy_3">
@@ -9253,7 +9253,7 @@
 	<software name="cosmicsh">
 		<description>Cosmic Sheriff</description>
 		<year>1990</year>
-		<publisher>Dinamic</publisher>
+		<publisher>Dinamic Software</publisher>
 		<part name="flop1" interface="floppy_3">
 			<dataarea name="flop" size="101888">
 				<rom name="cosmic sheriff (1990)(dinamic)(es).dsk" size="101888" crc="98a9e2ff" sha1="93de281cb9c787633c86448d1e0a0ba0cd3001c8" offset="0" />
@@ -9349,7 +9349,7 @@
 	<software name="currojim">
 		<description>Curro Jimenez</description>
 		<year>1989</year>
-		<publisher>Zigurat</publisher>
+		<publisher>Zigurat Software</publisher>
 		<part name="flop1" interface="floppy_3">
 			<dataarea name="flop" size="73216">
 				<rom name="curro jimenez (1989)(zigurat)(es).dsk" size="73216" crc="0e92a03c" sha1="c5de62cfdd369a8a13c685aa54595087c61f9a74" offset="0" />
@@ -9422,7 +9422,7 @@
 
 <!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
 	<software name="thecyclesp" cloneof="thecycle">
-		<description>The Cycles (Spain)</description>
+		<description>The Cycles (Spa)</description>
 		<year>1989</year>
 		<publisher>Dro Soft</publisher>
 		<part name="flop1" interface="floppy_3">
@@ -9436,7 +9436,7 @@
 	<software name="daleytoc">
 		<description>Daley Thompson's Olympic Challenge</description>
 		<year>1988</year>
-		<publisher>Ocean</publisher>
+		<publisher>Ocean Software</publisher>
 		<part name="flop1" interface="floppy_3">
 			<dataarea name="flop" size="220160">
 				<rom name="daley thompson's olympic challenge (1988)(ocean)[aka daley thompson '88].dsk" size="220160" crc="5d0ed5ac" sha1="ff4726f3e2b4281fb251526f876c74a7a0ac132c" offset="0" />
@@ -9493,7 +9493,7 @@
 	<software name="darkfusna" cloneof="darkfusn">
 		<description>Dark Fusion (alt)</description>
 		<year>1988</year>
-		<publisher>Gremlin Graphics</publisher>
+		<publisher>Gremlin Graphics Software</publisher>
 		<part name="flop1" interface="floppy_3">
 			<dataarea name="flop" size="219136">
 				<rom name="dark fusion (1988)(gremlin graphics).dsk" size="219136" crc="bcc16b2e" sha1="e4802f43c53db059cce6a398056fb0823c8c2a52" offset="0" />
@@ -9527,7 +9527,7 @@
 
 <!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
 	<software name="darksidesp" cloneof="darkside">
-		<description>Dark Side (Spain)</description>
+		<description>Dark Side (Spa)</description>
 		<year>1988</year>
 		<publisher>System 4</publisher>
 		<part name="flop1" interface="floppy_3">
@@ -9565,7 +9565,7 @@
 	<software name="deawish3">
 		<description>Death Wish 3</description>
 		<year>1987</year>
-		<publisher>Gremlin Graphics</publisher>
+		<publisher>Gremlin Graphics Software</publisher>
 		<part name="flop1" interface="floppy_3">
 			<dataarea name="flop" size="194816">
 				<rom name="death wish 3 (1987)(gremlin graphics).dsk" size="194816" crc="43f7fd6d" sha1="07fc65dd723143b183280074cdb2f786427b0f5e" offset="0" />
@@ -9577,7 +9577,7 @@
 	<software name="deawish3a" cloneof="deawish3">
 		<description>Death Wish 3 (alt)</description>
 		<year>1987</year>
-		<publisher>Gremlin Graphics</publisher>
+		<publisher>Gremlin Graphics Software</publisher>
 		<part name="flop1" interface="floppy_3">
 			<dataarea name="flop" size="194816">
 				<rom name="death wish 3 (1987)(gremlin graphics)[a].dsk" size="194816" crc="668d8e22" sha1="500e9e2746f1e914052465b56597b2a77a1389d5" offset="0" />
@@ -9589,7 +9589,7 @@
 	<software name="deawish3b" cloneof="deawish3">
 		<description>Death Wish 3 (alt 2)</description>
 		<year>1987</year>
-		<publisher>Gremlin Graphics</publisher>
+		<publisher>Gremlin Graphics Software</publisher>
 		<part name="flop1" interface="floppy_3">
 			<dataarea name="flop" size="194816">
 				<rom name="death wish 3 (1987)(gremlin graphics)[a2].dsk" size="194816" crc="c0b36014" sha1="cf4cdcd8cc6bcd090e639679818a66fa73944550" offset="0" />
@@ -9651,7 +9651,7 @@
 	<software name="deflektra" cloneof="deflektr">
 		<description>Deflektor (alt)</description>
 		<year>1987</year>
-		<publisher>Gremlin Graphics</publisher>
+		<publisher>Gremlin Graphics Software</publisher>
 		<part name="flop1" interface="floppy_3">
 			<dataarea name="flop" size="174848">
 				<rom name="deflektor (1987)(gremlin graphics).dsk" size="174848" crc="63929c07" sha1="adc7f9ba5f9bbded9a60f104b51973ff1808a94f" offset="0" />
@@ -9663,7 +9663,7 @@
 	<software name="totrecalsp" cloneof="totrecal">
 		<description>Desafio Total</description>
 		<year>1991</year>
-		<publisher>Erbe</publisher>
+		<publisher>Erbe Software</publisher>
 		<part name="flop1" interface="floppy_3">
 			<dataarea name="flop" size="151040">
 				<rom name="desafio total (1991)(erbe)(es)(en)[aka total recall][re-release].dsk" size="151040" crc="341d1500" sha1="793d902be2b432531b8e901750ca301a16e0675d" offset="0" />
@@ -9709,7 +9709,7 @@
 
 <!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
 	<software name="dominatrsp" cloneof="dominatr">
-		<description>Dominator (Spain)</description>
+		<description>Dominator (Spa)</description>
 		<year>1989</year>
 		<publisher>MCM</publisher>
 		<part name="flop1" interface="floppy_3">
@@ -9734,7 +9734,7 @@
 
 <!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
 	<software name="ddragonsp" cloneof="ddragon">
-		<description>Double Dragon (Spain)</description>
+		<description>Double Dragon (Spa)</description>
 		<year>1989</year>
 		<publisher>Dro Soft</publisher>
 		<part name="flop1" interface="floppy_3">
@@ -9810,9 +9810,9 @@
 
 <!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
 	<software name="baddudessp" cloneof="baddudes">
-		<description>Dragon Ninja (Spain)</description>
+		<description>Dragon Ninja (Spa)</description>
 		<year>1988</year>
-		<publisher>Erbe</publisher>
+		<publisher>Erbe Software</publisher>
 		<part name="flop1" interface="floppy_3">
 			<dataarea name="flop" size="135680">
 				<rom name="dragon ninja (1988)(erbe)(es)(en)[re-release].dsk" size="135680" crc="13338cd1" sha1="8b6703803bf4afe5fd7de30fdabab4ffcccbb0ac" offset="0" />
@@ -9836,7 +9836,7 @@
 	<software name="drakkar">
 		<description>Drakkar</description>
 		<year>1989</year>
-		<publisher>Delta Software S.L.</publisher>
+		<publisher>Delta Software</publisher>
 		<part name="flop1" interface="floppy_3">
 			<dataarea name="flop" size="102400">
 				<rom name="drakkar (1989)(delta software s.l.)(es)[aka drakar].dsk" size="102400" crc="816c2a6d" sha1="4d7eaf60c528cfae76a79de655da4732f151f8b2" offset="0" />
@@ -9944,7 +9944,7 @@
 	<software name="emotion">
 		<description>E-motion</description>
 		<year>1990</year>
-		<publisher>Erbe</publisher>
+		<publisher>Erbe Software</publisher>
 		<part name="flop1" interface="floppy_3">
 			<dataarea name="flop" size="78080">
 				<rom name="e-motion (1990)(erbe)(es)(en)[re-release].dsk" size="78080" crc="216e6ce4" sha1="96f573de05900cd43a3351c031cf8eeb3b16f1f8" offset="0" />
@@ -10029,7 +10029,7 @@
 	<software name="eliminat">
 		<description>Eliminator</description>
 		<year>1988</year>
-		<publisher>Erbe</publisher>
+		<publisher>Erbe Software</publisher>
 		<part name="flop1" interface="floppy_3">
 			<dataarea name="flop" size="52992">
 				<rom name="eliminator (1988)(erbe)(es)(en)[re-release].dsk" size="52992" crc="d14edabd" sha1="d375b03df6b0fcf137a57580f572c6fc2c56cb22" offset="0" />
@@ -10089,7 +10089,7 @@
 	<software name="esanchvi">
 		<description>Emilio Sanchez Vicario Grand Slam</description>
 		<year>1990</year>
-		<publisher>Zigurat</publisher>
+		<publisher>Zigurat Software</publisher>
 		<part name="flop1" interface="floppy_3">
 			<dataarea name="flop" size="58624">
 				<rom name="emilio sanchez vicario grand slam (1990)(zigurat)(es).dsk" size="58624" crc="c048d1f6" sha1="2bee364efe14224fba67057635970d7ebbf24a94" offset="0" />
@@ -10101,7 +10101,7 @@
 	<software name="esanchvia" cloneof="esanchvi">
 		<description>Emilio Sanchez Vicario Grand Slam (alt)</description>
 		<year>1990</year>
-		<publisher>Zigurat</publisher>
+		<publisher>Zigurat Software</publisher>
 		<part name="flop1" interface="floppy_3">
 			<dataarea name="flop" size="58624">
 				<rom name="emilio sanchez vicario grand slam (1990)(zigurat)(es)[a].dsk" size="58624" crc="09b82d36" sha1="78c5f01c0d0af55813a4eb69495f430a338d39e9" offset="0" />
@@ -10187,7 +10187,7 @@
 	<software name="espionaga" cloneof="espionag">
 		<description>Espionage (alt)</description>
 		<year>1988</year>
-		<publisher>Grandslam</publisher>
+		<publisher>Grandslam Entertainments</publisher>
 		<info name="usage" value="Requires manual for password protection"/>
 		<part name="flop1" interface="floppy_3">
 			<dataarea name="flop" size="78080">
@@ -10236,7 +10236,7 @@
 	<software name="f1">
 		<description>F-1</description>
 		<year>1991</year>
-		<publisher>Zigurat</publisher>
+		<publisher>Zigurat Software</publisher>
 		<part name="flop1" interface="floppy_3">
 			<dataarea name="flop" size="58624">
 				<rom name="f-1 (1991)(zigurat)(es)[aka formula 1 g.p. simulator].dsk" size="58624" crc="0aa6b65d" sha1="671fd441c1efeae1e78f7ecbe78990d590e45179" offset="0" />
@@ -10248,7 +10248,7 @@
 	<software name="f15strik">
 		<description>F-15 Strike Eagle</description>
 		<year>1990</year>
-		<publisher>Erbe</publisher>
+		<publisher>Erbe Software</publisher>
 		<part name="flop1" interface="floppy_3">
 			<dataarea name="flop" size="48896">
 				<rom name="f-15 strike eagle (1990)(erbe)(es)(en).dsk" size="48896" crc="23150627" sha1="2f9f70218a77982f01a4dc12436a1cf90cc6da4c" offset="0" />
@@ -10310,7 +10310,7 @@
 	<software name="fmbasket">
 		<description>Fernando Martin Basket Master</description>
 		<year>1987</year>
-		<publisher>Dinamic</publisher>
+		<publisher>Dinamic Software</publisher>
 		<part name="flop1" interface="floppy_3">
 			<dataarea name="flop" size="61696">
 				<rom name="fernando martin basket master (1987)(dinamic)(es).dsk" size="61696" crc="72b4c4a7" sha1="d051b2fa332e4a043be9db87a5fabf865a7280fb" offset="0" />
@@ -10398,7 +10398,7 @@
 	<software name="fireflya" cloneof="firefly">
 		<description>Firefly (alt)</description>
 		<year>1988</year>
-		<publisher>Ocean</publisher>
+		<publisher>Ocean Software</publisher>
 		<part name="flop1" interface="floppy_3">
 			<dataarea name="flop" size="214784">
 				<rom name="firefly (1988)(ocean).dsk" size="214784" crc="ea47b03f" sha1="e0f89ccf21303bee7fa8121b82e92b5827d288c6" offset="0" />
@@ -10529,7 +10529,7 @@
 	<software name="foty2a" cloneof="foty2">
 		<description>Footballer of the Year 2 (alt)</description>
 		<year>1989</year>
-		<publisher>Gremlin Graphics</publisher>
+		<publisher>Gremlin Graphics Software</publisher>
 		<part name="flop1" interface="floppy_3">
 			<dataarea name="flop" size="255232">
 				<rom name="footballer of the year 2 (1989)(gremlin graphics).dsk" size="255232" crc="ed6b20ca" sha1="e9e349e01090b6323036cbe476e2197d3999e598" offset="0" />
@@ -10601,7 +10601,7 @@
 	<software name="fredhams">
 		<description>Freddy Hardest en Manhattan Sur</description>
 		<year>1989</year>
-		<publisher>Dinamic</publisher>
+		<publisher>Dinamic Software</publisher>
 		<part name="flop1" interface="floppy_3">
 			<dataarea name="flop" size="69632">
 				<rom name="freddy hardest en manhattan sur (1989)(dinamic)(es)[aka freddy hardest in south manhattan].dsk" size="69632" crc="421fbbe2" sha1="fd35f4b9f7c2525eed5dff0958d74732a1a46a1b" offset="0" />
@@ -10672,9 +10672,9 @@
 
 <!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
 	<software name="glocr360sp" cloneof="glocr360">
-		<description>G-LOC (Spain)</description>
+		<description>G-LOC (Spa)</description>
 		<year>1992</year>
-		<publisher>Erbe</publisher>
+		<publisher>Erbe Software</publisher>
 		<part name="flop1" interface="floppy_3">
 			<dataarea name="flop" size="127232">
 				<rom name="g-loc (1992)(erbe)(es)(en)[re-release].dsk" size="127232" crc="49e92c72" sha1="2b72df02d48e33984ed7e07ea064d6cf76cedbfe" offset="0" />
@@ -10750,7 +10750,7 @@
 	<software name="linekskla" cloneof name="linekskl">
 		<description>Gary Lineker's Super Skills (alt)</description>
 		<year>1988</year>
-		<publisher>Gremlin Graphics</publisher>
+		<publisher>Gremlin Graphics Software</publisher>
 		<part name="flop1" interface="floppy_3">
 			<dataarea name="flop" size="194816">
 				<rom name="gary lineker's super skills (1988)(gremlin graphics).dsk" size="194816" crc="0383082c" sha1="3d62fbab0784ee24e2d624d84f4607ba39556879" offset="0" />
@@ -10763,7 +10763,7 @@
 	<software name="lineksssa" cloneof="lineksss">
 		<description>Gary Lineker's Super Star Soccer (alt)</description>
 		<year>1987</year>
-		<publisher>Gremlin Graphics</publisher>
+		<publisher>Gremlin Graphics Software</publisher>
 		<part name="flop1" interface="floppy_3">
 			<dataarea name="flop" size="174848">
 				<rom name="gary lineker's super star soccer (1987)(gremlin graphics).dsk" size="174848" crc="5ad471d4" sha1="9dfb8be61451f07184a1570dc0c42a290f884e75" offset="0" />
@@ -10776,7 +10776,7 @@
 	<software name="lineksssb" cloneof="lineksss">
 		<description>Gary Lineker's Super Star Soccer (alt 2)</description>
 		<year>1987</year>
-		<publisher>Gremlin Graphics</publisher>
+		<publisher>Gremlin Graphics Software</publisher>
 		<part name="flop1" interface="floppy_3">
 			<dataarea name="flop" size="174848">
 				<rom name="gary lineker's super star soccer (1987)(gremlin graphics)[a].dsk" size="174848" crc="33b7cea7" sha1="5147ecbc3eddb6bcada1f4516ca0139087b96851" offset="0" />
@@ -10827,7 +10827,7 @@
 	<software name="gaunt3">
 		<description>Gauntlet III - The Final Quest</description>
 		<year>1991</year>
-		<publisher>Erbe</publisher>
+		<publisher>Erbe Software</publisher>
 		<part name="flop1" interface="floppy_3">
 			<feature name="part_id" value="Side A"/>
 			<dataarea name="flop" size="255232">
@@ -10857,7 +10857,7 @@
 
 <!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
 	<software name="gazzasp" cloneof="gazza">
-		<description>Gazza's Super Soccer (Spain)</description>
+		<description>Gazza's Super Soccer (Spa)</description>
 		<year>1990</year>
 		<publisher>Proein Soft Line</publisher>
 		<part name="flop1" interface="floppy_3">
@@ -10900,9 +10900,9 @@
 
 <!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
 	<software name="ghoulssp" cloneof="ghouls">
-		<description>Ghouls 'n' Ghosts (Spain)</description>
+		<description>Ghouls 'n' Ghosts (Spa)</description>
 		<year>1989</year>
-		<publisher>Erbe</publisher>
+		<publisher>Erbe Software</publisher>
 		<part name="flop1" interface="floppy_3">
 			<dataarea name="flop" size="255232">
 				<rom name="ghouls 'n' ghosts (1989)(erbe)(es)(en)[re-release].dsk" size="255232" crc="0e2116f3" sha1="7872f08c3ed59f1a0fe25c47483588ddaacff99e" offset="0" />
@@ -10987,7 +10987,7 @@
 
 <!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
 	<software name="goldnaxesp" cloneof="goldnaxe">
-		<description>Golden Axe (Spain)</description>
+		<description>Golden Axe (Spa)</description>
 		<year>1990</year>
 		<publisher>MCM</publisher>
 		<part name="flop1" interface="floppy_3">
@@ -11100,7 +11100,7 @@
 	<software name="hudsonhasp">
 		<description>El Gran Halcon</description>
 		<year>1991</year>
-		<publisher>Erbe</publisher>
+		<publisher>Erbe Software</publisher>
 		<part name="flop1" interface="floppy_3">
 			<dataarea name="flop" size="146176">
 				<rom name="gran halcon, el (1991)(erbe)(es)(en)[aka hudson hawk][re-release].dsk" size="146176" crc="9bcc8c2b" sha1="df35fafcb381b0d02eb04baf6926b61ac83f0581" offset="0" />
@@ -11112,7 +11112,7 @@
 	<software name="gryzor">
 		<description>Gryzor</description>
 		<year>1987</year>
-		<publisher>Ocean</publisher>
+		<publisher>Ocean Software</publisher>
 		<part name="flop1" interface="floppy_3">
 			<dataarea name="flop" size="194816">
 				<rom name="gryzor (1987)(ocean).dsk" size="194816" crc="c237d67d" sha1="1ffb3dac932ab7b84cd9d06ed4a88312680026e9" offset="0" />
@@ -11226,7 +11226,7 @@
 	<software name="hatea" cloneof="hate">
 		<description>H.A.T.E. - Hostile All Terrain Encounter (alt)</description>
 		<year>1989</year>
-		<publisher>Gremlin Graphics</publisher>
+		<publisher>Gremlin Graphics Software</publisher>
 		<part name="flop1" interface="floppy_3">
 			<dataarea name="flop" size="219136">
 				<rom name="h.a.t.e. (1989)(gremlin graphics)[aka hostile all terrain encounter].dsk" size="219136" crc="c77d0383" sha1="60c22e50e0827fa2d8ee63fe496cd2e47046ba5a" offset="0" />
@@ -11248,9 +11248,9 @@
 
 <!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
 	<software name="harddrivsp" cloneof="harddriv">
-		<description>Hard Drivin' (Spain)</description>
+		<description>Hard Drivin' (Spa)</description>
 		<year>1989</year>
-		<publisher>Erbe</publisher>
+		<publisher>Erbe Software</publisher>
 		<part name="flop1" interface="floppy_3">
 			<dataarea name="flop" size="63488">
 				<rom name="hard drivin' (1989)(erbe)(es)(en)[re-release].dsk" size="63488" crc="e6f85a75" sha1="4e9a802f657b7fc04a02b0e0877830c582105ccf" offset="0" />
@@ -11325,7 +11325,7 @@
 	<software name="heroqsta" cloneof="heroqst">
 		<description>Hero Quest (alt)</description>
 		<year>1991</year>
-		<publisher>Gremlin Graphics</publisher>
+		<publisher>Gremlin Graphics Software</publisher>
 		<part name="flop1" interface="floppy_3">
 			<dataarea name="flop" size="194816">
 				<rom name="hero quest (1991)(gremlin graphics).dsk" size="194816" crc="ab30a1d0" sha1="915dde45e84df561fea89b8b4c3cea6892ca85c1" offset="0" />
@@ -11338,7 +11338,7 @@
 	<software name="heroqstb" cloneof="heroqst">
 		<description>Hero Quest (alt 2)</description>
 		<year>1991</year>
-		<publisher>Gremlin Graphics</publisher>
+		<publisher>Gremlin Graphics Software</publisher>
 		<part name="flop1" interface="floppy_3">
 			<dataarea name="flop" size="194816">
 				<rom name="hero quest (1991)(gremlin graphics)[a].dsk" size="194816" crc="758aca42" sha1="1646d3fc7ad3719351cc9be38f3a7e714d9d866f" offset="0" />
@@ -11351,7 +11351,7 @@
 	<software name="heroqstc" cloneof="heroqst">
 		<description>Hero Quest (alt 3)</description>
 		<year>1991</year>
-		<publisher>Gremlin Graphics</publisher>
+		<publisher>Gremlin Graphics Software</publisher>
 		<part name="flop1" interface="floppy_3">
 			<dataarea name="flop" size="194816">
 				<rom name="hero quest (1991)(gremlin graphics)[a2].dsk" size="194816" crc="dec047e7" sha1="94dae34b89d72eed5e05f64a85f86aeac4ae8827" offset="0" />
@@ -11364,7 +11364,7 @@
 	<software name="heroqstd" cloneof="heroqst">
 		<description>Hero Quest (alt 4)</description>
 		<year>1991</year>
-		<publisher>Gremlin Graphics</publisher>
+		<publisher>Gremlin Graphics Software</publisher>
 		<part name="flop1" interface="floppy_3">
 			<dataarea name="flop" size="199680">
 				<rom name="hero quest (1991)(gremlin graphics)[a3].dsk" size="199680" crc="ceb5f071" sha1="1033f9307c145f34d8bc6d0fb8f8c7e581165588" offset="0" />
@@ -11376,7 +11376,7 @@
 	<software name="heroque2">
 		<description>Hero Quest - Return of the Witch Lord</description>
 		<year>1991</year>
-		<publisher>Gremlin Graphics</publisher>
+		<publisher>Gremlin Graphics Software</publisher>
 		<part name="flop1" interface="floppy_3">
 			<dataarea name="flop" size="194816">
 				<rom name="hero quest - return of the witch lord (1991)(gremlin graphics).dsk" size="194816" crc="e11de839" sha1="6e72c9ffdfcefc98f26be651d6af9897f42c1826" offset="0" />
@@ -11388,7 +11388,7 @@
 	<software name="heroque2a" cloneof="heroque2">
 		<description>Hero Quest - Return of the Witch Lord (alt)</description>
 		<year>1991</year>
-		<publisher>Gremlin Graphics</publisher>
+		<publisher>Gremlin Graphics Software</publisher>
 		<part name="flop1" interface="floppy_3">
 			<dataarea name="flop" size="194816">
 				<rom name="hero quest - return of the witch lord (1991)(gremlin graphics)[a].dsk" size="194816" crc="4ed5a340" sha1="71954827b51a39b4a682f94198026adf9f6f9205" offset="0" />
@@ -11400,7 +11400,7 @@
 	<software name="heroque2b" cloneof="heroque2">
 		<description>Hero Quest - Return of the Witch Lord (alt 2)</description>
 		<year>1991</year>
-		<publisher>Gremlin Graphics</publisher>
+		<publisher>Gremlin Graphics Software</publisher>
 		<part name="flop1" interface="floppy_3">
 			<dataarea name="flop" size="194816">
 				<rom name="hero quest - return of the witch lord (1991)(gremlin graphics)[a2].dsk" size="194816" crc="86da0a2e" sha1="003e63884fb0a6dffcab7de701fad9df3206b4b5" offset="0" />
@@ -11412,7 +11412,7 @@
 	<software name="heroque2c" cloneof="heroque2">
 		<description>Hero Quest - Return of the Witch Lord (alt 3)</description>
 		<year>1991</year>
-		<publisher>Gremlin Graphics</publisher>
+		<publisher>Gremlin Graphics Software</publisher>
 		<part name="flop1" interface="floppy_3">
 			<dataarea name="flop" size="199680">
 				<rom name="hero quest - return of the witch lord (1991)(gremlin graphics)[a3].dsk" size="199680" crc="cdac513e" sha1="c20215ef636d6c2f92a5af5a87a8c2e8ce8be774" offset="0" />
@@ -11434,9 +11434,9 @@
 
 <!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
 	<software name="herolancsp" cloneof="herolanc">
-		<description>Heroes of the Lance (Spain)</description>
+		<description>Heroes of the Lance (Spa)</description>
 		<year>1988</year>
-		<publisher>Erbe</publisher>
+		<publisher>Erbe Software</publisher>
 		<part name="flop1" interface="floppy_3">
 			<dataarea name="flop" size="194816">
 				<rom name="heroes of the lance (1988)(erbe)(es)(en)[re-release].dsk" size="194816" crc="99cc6af8" sha1="afd6e3b1ae18888ed999d690a9373a0f7778c7a5" offset="0" />
@@ -11495,9 +11495,9 @@
 
 <!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
 	<software name="hostagessp" cloneof="hostages">
-		<description>Hostages (Spain)</description>
+		<description>Hostages (Spa)</description>
 		<year>1990</year>
-		<publisher>Erbe</publisher>
+		<publisher>Erbe Software</publisher>
 		<part name="flop1" interface="floppy_3">
 			<feature name="part_id" value="Side A"/>
 			<dataarea name="flop" size="174848">
@@ -11654,9 +11654,9 @@
 
 <!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
 	<software name="impossamsp" cloneof="impossam">
-		<description>Impossamole (Spain)</description>
+		<description>Impossamole (Spa)</description>
 		<year>1990</year>
-		<publisher>Erbe</publisher>
+		<publisher>Erbe Software</publisher>
 		<part name="flop1" interface="floppy_3">
 			<dataarea name="flop" size="214784">
 				<rom name="impossamole (1990)(erbe)(es)(en)[re-release].dsk" size="214784" crc="4e9a963d" sha1="1f0723d701dbaad0c57a47e0bde0ff79d5a58dd1" offset="0" />
@@ -11668,7 +11668,7 @@
 	<software name="impossam">
 		<description>Impossamole</description>
 		<year>1990</year>
-		<publisher>Gremlin Graphics</publisher>
+		<publisher>Gremlin Graphics Software</publisher>
 		<part name="flop1" interface="floppy_3">
 			<dataarea name="flop" size="214784">
 				<rom name="impossamole (1990)(gremlin graphics).dsk" size="214784" crc="04ece926" sha1="dd49acee739bf6629420813275271305f8b48db2" offset="0" />
@@ -11680,7 +11680,7 @@
 	<software name="indy3sp">
 		<description>Indiana Jones y la Ultima Cruzada</description>
 		<year>1989</year>
-		<publisher>Erbe</publisher>
+		<publisher>Erbe Software</publisher>
 		<part name="flop1" interface="floppy_3">
 			<dataarea name="flop" size="194816">
 				<rom name="indiana jones y la ultima cruzada (1989)(erbe)(es)(en)[aka indiana jones and the last crusade][re-release].dsk" size="194816" crc="e2de5128" sha1="e0c5862105818b5d88fe5543f04ddc67f45be587" offset="0" />
@@ -11835,7 +11835,7 @@
 	<software name="untouchasp" cloneof="untoucha">
 		<description>Los Intocables</description>
 		<year>1989</year>
-		<publisher>Erbe</publisher>
+		<publisher>Erbe Software</publisher>
 		<part name="flop1" interface="floppy_3">
 			<feature name="part_id" value="Side A"/>
 			<dataarea name="flop" size="39168">
@@ -11900,7 +11900,7 @@
 	<software name="italy90sp">
 		<description>Italia 1990</description>
 		<year>1990</year>
-		<publisher>Erbe</publisher>
+		<publisher>Erbe Software</publisher>
 		<part name="flop1" interface="floppy_3">
 			<dataarea name="flop" size="80896">
 				<rom name="italia 1990 (1990)(erbe)(es)(en)[aka italy 1990][re-release].dsk" size="80896" crc="c682f692" sha1="682b9a4e2c93700635507aaeeaac92ce4a0bfb2f" offset="0" />
@@ -12086,7 +12086,7 @@
 	<software name="junglewa">
 		<description>Jungle Warrior</description>
 		<year>1990</year>
-		<publisher>Zigurat</publisher>
+		<publisher>Zigurat Software</publisher>
 		<part name="flop1" interface="floppy_3">
 			<dataarea name="flop" size="63488">
 				<rom name="jungle warrior (1990)(zigurat)(es).dsk" size="63488" crc="3ca364a1" sha1="5cbaa05e1994dab8b18a9d9a126296d00a9bda66" offset="0" />
@@ -12179,7 +12179,7 @@
 	<software name="klax">
 		<description>Klax</description>
 		<year>1990</year>
-		<publisher>Erbe</publisher>
+		<publisher>Erbe Software</publisher>
 		<part name="flop1" interface="floppy_3">
 			<dataarea name="flop" size="146176">
 				<rom name="klax (1990)(erbe)(es)(en)[re-release].dsk" size="146176" crc="125e3c32" sha1="5148844e91af58b41f1b0867584d16dc4c52203c" offset="0" />
@@ -12420,9 +12420,9 @@
 
 <!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
 	<software name="lightcorsp" cloneof="lightcor">
-		<description>The Light Corridor (Spain)</description>
+		<description>The Light Corridor (Spa)</description>
 		<year>1991</year>
-		<publisher>Erbe</publisher>
+		<publisher>Erbe Software</publisher>
 		<part name="flop1" interface="floppy_3">
 			<dataarea name="flop" size="194816">
 				<rom name="light corridor, the (1991)(erbe)(es)(en)[re-release].dsk" size="194816" crc="9b575adf" sha1="5022b6e27edcc1072fda6bc516652b09e11c9277" offset="0" />
@@ -12432,9 +12432,9 @@
 
 <!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
 	<software name="lightcorspa" cloneof="lightcor">
-		<description>The Light Corridor (Spain) (alt)</description>
+		<description>The Light Corridor (Spa) (alt)</description>
 		<year>1991</year>
-		<publisher>Erbe</publisher>
+		<publisher>Erbe Software</publisher>
 		<part name="flop1" interface="floppy_3">
 			<dataarea name="flop" size="194816">
 				<rom name="light corridor, the (1991)(erbe)(es)(en)[a][re-release].dsk" size="194816" crc="fb7dbaf8" sha1="681888333e367e1673b6d1afad9d65880bb2125d" offset="0" />
@@ -12604,9 +12604,9 @@
 
 <!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
 	<software name="lotussp" cloneof="lotus">
-		<description>Lotus Esprit Turbo Challenge (Spain)</description>
+		<description>Lotus Esprit Turbo Challenge (Spa)</description>
 		<year>1990</year>
-		<publisher>Erbe</publisher>
+		<publisher>Erbe Software</publisher>
 		<part name="flop1" interface="floppy_3">
 			<dataarea name="flop" size="199680">
 				<rom name="lotus esprit turbo challenge (1990)(erbe)(es)(en)[re-release].dsk" size="199680" crc="f187be6b" sha1="da097b93b3f0b1e86b7842272a45afea4899e878" offset="0" />
@@ -12619,7 +12619,7 @@
 	<software name="lotusa" cloneof="lotus">
 		<description>Lotus Esprit Turbo Challenge (alt)</description>
 		<year>1990</year>
-		<publisher>Gremlin Graphics</publisher>
+		<publisher>Gremlin Graphics Software</publisher>
 		<part name="flop1" interface="floppy_3">
 			<dataarea name="flop" size="199680">
 				<rom name="lotus esprit turbo challenge (1990)(gremlin graphics).dsk" size="199680" crc="e923e142" sha1="ee13b432dfc4ed546e18404f6a87390904b05de9" offset="0" />
@@ -12632,7 +12632,7 @@
 	<software name="mask3a" cloneof="mask3">
 		<description>Mask III - Venom Strikes Back (alt)</description>
 		<year>1988</year>
-		<publisher>Gremlin Graphics</publisher>
+		<publisher>Gremlin Graphics Software</publisher>
 		<part name="flop1" interface="floppy_3">
 			<dataarea name="flop" size="174848">
 				<rom name="mask iii - venom strikes back (1988)(gremlin graphics).dsk" size="174848" crc="8b33e09b" sha1="91884a8317c4a1db2d06e7683f6e5d7ee93e68c2" offset="0" />
@@ -12721,7 +12721,7 @@
 
 <!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
 	<software name="manchunisp" cloneof="manchuni">
-		<description>Manchester United (Spain)</description>
+		<description>Manchester United (Spa)</description>
 		<year>1990</year>
 		<publisher>System 4</publisher>
 		<part name="flop1" interface="floppy_3">
@@ -12767,7 +12767,7 @@
 	<software name="mastersa" cloneof="masters">
 		<description>Masters of the Universe - The Movie (alt)</description>
 		<year>1987</year>
-		<publisher>Gremlin Graphics</publisher>
+		<publisher>Gremlin Graphics Software</publisher>
 		<part name="flop1" interface="floppy_3">
 			<dataarea name="flop" size="174848">
 				<rom name="masters of the universe - the movie (1987)(gremlin graphics).dsk" size="174848" crc="2f9a0bdb" sha1="e7c580e989076026cded8688e70e264ab36ece19" offset="0" />
@@ -12779,7 +12779,7 @@
 	<software name="matchda2a" cloneof="matchda2">
 		<description>Match Day II (alt)</description>
 		<year>1987</year>
-		<publisher>Ocean</publisher>
+		<publisher>Ocean Software</publisher>
 		<part name="flop1" interface="floppy_3">
 			<dataarea name="flop" size="214784">
 				<rom name="match day ii (1987)(ocean).dsk" size="214784" crc="bf33c550" sha1="a07e166575814e59f3b4a95ea9617de6bec7525a" offset="0" />
@@ -12791,7 +12791,7 @@
 	<software name="matchda2">
 		<description>Match Day II</description>
 		<year>1987</year>
-		<publisher>Ocean</publisher>
+		<publisher>Ocean Software</publisher>
 		<part name="flop1" interface="floppy_3">
 			<dataarea name="flop" size="208384">
 				<rom name="match day ii (1987)(ocean)[a].dsk" size="208384" crc="584f511d" sha1="50bf8521cc8b86af9d2307f0af6d2441707cf82e" offset="0" />
@@ -12822,7 +12822,7 @@
 	<software name="megaphx">
 		<description>Mega Phoenix</description>
 		<year>1991</year>
-		<publisher>Dinamic</publisher>
+		<publisher>Dinamic Software</publisher>
 		<part name="flop1" interface="floppy_3">
 			<dataarea name="flop" size="61952">
 				<rom name="mega phoenix (1991)(dinamic)(es)(en).dsk" size="61952" crc="c0b40920" sha1="794b2904af91cb3cc9ab90b755d0585a5575db96" offset="0" />
@@ -12896,7 +12896,7 @@
 	<software name="mickey" cloneof="mickey">
 		<description>Mickey Mouse - The Computer Game (alt)</description>
 		<year>1988</year>
-		<publisher>Gremlin Graphics</publisher>
+		<publisher>Gremlin Graphics Software</publisher>
 		<part name="flop1" interface="floppy_3">
 			<dataarea name="flop" size="174848">
 				<rom name="mickey mouse - the computer game (1988)(gremlin graphics).dsk" size="174848" crc="7ffc722d" sha1="29a312a7d1c5a9bc90c6e747c05d6a28947a0b11" offset="0" />
@@ -12964,9 +12964,9 @@
 
 <!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
 	<software name="micpsoccsp" cloneof="micpsocc">
-		<description>MicroProse Soccer (Spain)</description>
+		<description>MicroProse Soccer (Spa)</description>
 		<year>1990</year>
-		<publisher>Erbe</publisher>
+		<publisher>Erbe Software</publisher>
 		<part name="flop1" interface="floppy_3">
 			<feature name="part_id" value="Side A"/>
 			<dataarea name="flop" size="126720">
@@ -12983,9 +12983,9 @@
 
 <!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
 	<software name="midressp" cloneof="midres">
-		<description>Midnight Resistance (Spain)</description>
+		<description>Midnight Resistance (Spa)</description>
 		<year>1990</year>
-		<publisher>Erbe</publisher>
+		<publisher>Erbe Software</publisher>
 		<part name="flop1" interface="floppy_3">
 			<dataarea name="flop" size="155904">
 				<rom name="midnight resistance (1990)(erbe)(es)(en)[re-release].dsk" size="155904" crc="f76b30d2" sha1="55c8124f6fc372eaae8c83d42a0dbfec8331aa23" offset="0" />
@@ -12997,7 +12997,7 @@
 	<software name="midresa" cloneof="midres">
 		<description>Midnight Resistance (alt)</description>
 		<year>1990</year>
-		<publisher>Ocean</publisher>
+		<publisher>Ocean Software</publisher>
 		<part name="flop1" interface="floppy_3">
 			<dataarea name="flop" size="194816">
 				<rom name="midnight resistance (1990)(ocean).dsk" size="194816" crc="bebed342" sha1="ed5067b98d17085961e4079630f78a8cae1c2e6b" offset="0" />
@@ -13009,7 +13009,7 @@
 	<software name="midresb" cloneof="midres">
 		<description>Midnight Resistance (alt 2)</description>
 		<year>1990</year>
-		<publisher>Ocean</publisher>
+		<publisher>Ocean Software</publisher>
 		<part name="flop1" interface="floppy_3">
 			<dataarea name="flop" size="133120">
 				<rom name="midnight resistance (1990)(ocean)[a].dsk" size="133120" crc="cd5e36f6" sha1="4264fe3752d41250bb506a4e55d05ee609fbe89b" offset="0" />
@@ -13040,7 +13040,7 @@
 	<software name="mikegunn">
 		<description>Mike Gunner</description>
 		<year>1988</year>
-		<publisher>Dinamic</publisher>
+		<publisher>Dinamic Software</publisher>
 		<info name="usage" value="Requires Gun Stick lightgun"/>
 		<part name="flop1" interface="floppy_3">
 			<dataarea name="flop" size="48128">
@@ -13090,7 +13090,7 @@
 	<software name="moonwalk">
 		<description>Moonwalker</description>
 		<year>1989</year>
-		<publisher>Erbe</publisher>
+		<publisher>Erbe Software</publisher>
 		<part name="flop1" interface="floppy_3">
 			<dataarea name="flop" size="175360">
 				<rom name="moonwalker (1989)(erbe)(es)(en)[re-release].dsk" size="175360" crc="39947fe4" sha1="101558c1c2d1eaa6cceb0e577ea5e592a9b5d77f" offset="0" />
@@ -13200,7 +13200,7 @@
 	<software name="themunch">
 		<description>The Muncher Eats Chewits</description>
 		<year>1988</year>
-		<publisher>Gremlin Graphics</publisher>
+		<publisher>Gremlin Graphics Software</publisher>
 		<part name="flop1" interface="floppy_3">
 			<dataarea name="flop" size="219136">
 				<rom name="muncher eats chewits, the (1988)(gremlin graphics)[aka t-wrecks].dsk" size="219136" crc="270a56fa" sha1="783a340ffcc78cee07e51953272467302277e459" offset="0" />
@@ -13315,7 +13315,7 @@
 	<software name="narc">
 		<description>NARC</description>
 		<year>1990</year>
-		<publisher>Ocean</publisher>
+		<publisher>Ocean Software</publisher>
 		<part name="flop1" interface="floppy_3">
 			<feature name="part_id" value="Side A"/>
 			<dataarea name="flop" size="472832">
@@ -13334,7 +13334,7 @@
 	<software name="narcopol">
 		<description>Narco Police</description>
 		<year>1990</year>
-		<publisher>Dinamic</publisher>
+		<publisher>Dinamic Software</publisher>
 		<part name="flop1" interface="floppy_3">
 			<dataarea name="flop" size="131584">
 				<rom name="narco police (1990)(dinamic)(es)(en).dsk" size="131584" crc="732da12d" sha1="856417a7c4902b5a88398dadf8528aab4527880d" offset="0" />
@@ -13345,9 +13345,9 @@
 <!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
 <!-- Spanish version includes Army Moves as a bonus. -->
 	<software name="navymovesp" cloneof="navymove">
-		<description>Navy Moves (Spanish)</description>
+		<description>Navy Moves (Spa)</description>
 		<year>1988</year>
-		<publisher>Dinamic</publisher>
+		<publisher>Dinamic Software</publisher>
 		<part name="flop1" interface="floppy_3">
 			<dataarea name="flop" size="166400">
 				<rom name="navy moves + army moves (1988)(dinamic)(es).dsk" size="166400" crc="ac230638" sha1="6eb9dd96efe181d0d9f09698501f5fb3f4d77a10" offset="0" />
@@ -13371,7 +13371,7 @@
 	<software name="navyseal">
 		<description>Navy SEALs</description>
 		<year>1991</year>
-		<publisher>Erbe</publisher>
+		<publisher>Erbe Software</publisher>
 		<part name="flop1" interface="floppy_3">
 			<feature name="part_id" value="Side A"/>
 			<dataarea name="flop" size="155904">
@@ -13401,7 +13401,7 @@
 			<feature name="part_id" value="Side B"/>
 	<!-- Side B image shared with other master disks from Zeppelin Games. Verified at World of Spectrum. -->
 			<dataarea name="flop" size="256">
-				<rom name="championship run (1991)(zeppelin games)(side b)[master disk backup][re-release].dsk" size="256" crc="56947af2" sha1="40428c770d847a0fd1fd005b6cf1d03a34672d98" offset="0" />
+				<rom name="zeppelin games master disk side b.dsk" size="256" crc="56947af2" sha1="40428c770d847a0fd1fd005b6cf1d03a34672d98" offset="0" />
 			</dataarea>
 		</part>
 	</software>
@@ -13452,9 +13452,9 @@
 
 <!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
 	<software name="tnzssp" cloneof="tnzs">
-		<description>The New Zealand Story (Spain)</description>
+		<description>The New Zealand Story (Spa)</description>
 		<year>1989</year>
-		<publisher>Erbe</publisher>
+		<publisher>Erbe Software</publisher>
 		<part name="flop1" interface="floppy_3">
 			<feature name="part_id" value="Side A"/>
 			<dataarea name="flop" size="68352">
@@ -13473,7 +13473,7 @@
 	<software name="tnzs">
 		<description>The New Zealand Story</description>
 		<year>1989</year>
-		<publisher>Ocean</publisher>
+		<publisher>Ocean Software</publisher>
 		<part name="flop1" interface="floppy_3">
 			<feature name="part_id" value="Side A"/>
 			<dataarea name="flop" size="62720">
@@ -13504,7 +13504,7 @@
 	<software name="nightbre">
 		<description>Night Breed - The Action Game</description>
 		<year>1990</year>
-		<publisher>Ocean</publisher>
+		<publisher>Ocean Software</publisher>
 		<part name="flop1" interface="floppy_3">
 			<dataarea name="flop" size="389376">
 				<rom name="night breed - the action game (1990)(ocean).dsk" size="389376" crc="8e6cd752" sha1="c4a2ff13a02ae7b6bbf3b2ff6a79b391c0198853" offset="0" />
@@ -13535,7 +13535,7 @@
 	<software name="nighraid">
 		<description>Night Raider</description>
 		<year>1988</year>
-		<publisher>Gremlin Graphics</publisher>
+		<publisher>Gremlin Graphics Software</publisher>
 		<part name="flop1" interface="floppy_3">
 			<dataarea name="flop" size="174848">
 				<rom name="night raider (1988)(gremlin graphics).dsk" size="174848" crc="0d889fc6" sha1="bb06295dae9be9ebf460e170d3672351aaa83438" offset="0" />
@@ -13545,7 +13545,7 @@
 
 <!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
 	<software name="ninjawarsp" cloneof="ninjawar">
-		<description>The Ninja Warriors (Spain)</description>
+		<description>The Ninja Warriors (Spa)</description>
 		<year>1989</year>
 		<publisher>Dro Soft</publisher>
 		<part name="flop1" interface="floppy_3">
@@ -13648,7 +13648,7 @@
 	<software name="northstra" cloneof="northstr">
 		<description>North Star (alt)</description>
 		<year>1988</year>
-		<publisher>Gremlin Graphics</publisher>
+		<publisher>Gremlin Graphics Software</publisher>
 		<part name="flop1" interface="floppy_3">
 			<dataarea name="flop" size="174848">
 				<rom name="north star (1988)(gremlin graphics).dsk" size="174848" crc="2472f3ba" sha1="0704862da03f1e09f822412f18fea05e74112239" offset="0" />
@@ -13660,7 +13660,7 @@
 	<software name="northstrb" cloneof="northstr">
 		<description>North Star (alt 2)</description>
 		<year>1988</year>
-		<publisher>Gremlin Graphics</publisher>
+		<publisher>Gremlin Graphics Software</publisher>
 		<part name="flop1" interface="floppy_3">
 			<dataarea name="flop" size="162048">
 				<rom name="north star (1988)(gremlin graphics)[a].dsk" size="162048" crc="17fe7830" sha1="0af689b80ddbc79a4c62c97b1dc7ee4918b54172" offset="0" />
@@ -13670,7 +13670,7 @@
 
 <!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
 	<software name="oblitersp" cloneof="obliter">
-		<description>Obliterator (Spain)</description>
+		<description>Obliterator (Spa)</description>
 		<year>1989</year>
 		<publisher>Dro Soft</publisher>
 		<part name="flop1" interface="floppy_3">
@@ -13701,9 +13701,9 @@
 
 <!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
 	<software name="othundersp" cloneof="othunder">
-		<description>Operation Thunderbolt (Spain)</description>
+		<description>Operation Thunderbolt (Spa)</description>
 		<year>1989</year>
-		<publisher>Erbe</publisher>
+		<publisher>Erbe Software</publisher>
 		<part name="flop1" interface="floppy_3">
 			<feature name="part_id" value="Side A"/>
 			<dataarea name="flop" size="48896">
@@ -13722,7 +13722,7 @@
 	<software name="othunder">
 		<description>Operation Thunderbolt</description>
 		<year>1989</year>
-		<publisher>Ocean</publisher>
+		<publisher>Ocean Software</publisher>
 		<part name="flop1" interface="floppy_3">
 			<feature name="part_id" value="Side A"/>
 			<dataarea name="flop" size="128256">
@@ -13739,9 +13739,9 @@
 
 <!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
 	<software name="opwolfsp" cloneof="opwolf">
-		<description>Operation Wolf (Spain)</description>
+		<description>Operation Wolf (Spa)</description>
 		<year>1988</year>
-		<publisher>Erbe</publisher>
+		<publisher>Erbe Software</publisher>
 		<part name="flop1" interface="floppy_3">
 			<dataarea name="flop" size="194816">
 				<rom name="operation wolf (1988)(erbe)(es)(en)[re-release].dsk" size="194816" crc="937ab39f" sha1="6d9bfdd66290b424300bdf57266a24d5e2b85750" offset="0" />
@@ -13753,7 +13753,7 @@
 	<software name="opwolf">
 		<description>Operation Wolf</description>
 		<year>1988</year>
-		<publisher>Ocean</publisher>
+		<publisher>Ocean Software</publisher>
 		<part name="flop1" interface="floppy_3">
 			<dataarea name="flop" size="194816">
 				<rom name="operation wolf (1988)(ocean).dsk" size="194816" crc="8fb0ea8d" sha1="3fb8835bba7eeb68ff5ce3ab3dd950f7a33f71a6" offset="0" />
@@ -13765,7 +13765,7 @@
 	<software name="opwolfa" cloneof="opwolf">
 		<description>Operation Wolf (alt)</description>
 		<year>1988</year>
-		<publisher>Ocean</publisher>
+		<publisher>Ocean Software</publisher>
 		<part name="flop1" interface="floppy_3">
 			<dataarea name="flop" size="150272">
 				<rom name="operation wolf (1988)(ocean)[a].dsk" size="150272" crc="79031b22" sha1="6c0cf20992922bf114f7a1a59c967a32c670fea1" offset="0" />
@@ -13777,7 +13777,7 @@
 	<software name="opwolfb" cloneof="opwolf">
 		<description>Operation Wolf (alt 2)</description>
 		<year>1988</year>
-		<publisher>Ocean</publisher>
+		<publisher>Ocean Software</publisher>
 		<part name="flop1" interface="floppy_3">
 			<dataarea name="flop" size="194816">
 				<rom name="operation wolf (1988)(ocean)[a2].dsk" size="194816" crc="7c713a26" sha1="b971311ee8938b3c5bf2937fc4cac8a6dbfd0572" offset="0" />
@@ -13799,7 +13799,7 @@
 
 <!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
 	<software name="origamessp" cloneof="origames">
-		<description>Oriental Games (Spain)</description>
+		<description>Oriental Games (Spa)</description>
 		<year>1990</year>
 		<publisher>MCM</publisher>
 		<part name="flop1" interface="floppy_3">
@@ -13880,7 +13880,7 @@
 
 <!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
 	<software name="overlandsp" cloneof="overland">
-		<description>Overlander (Spain)</description>
+		<description>Overlander (Spa)</description>
 		<year>1988</year>
 		<publisher>MCM</publisher>
 		<part name="flop1" interface="floppy_3">
@@ -13933,7 +13933,7 @@
 	<software name="pacmania">
 		<description>Pac-Mania</description>
 		<year>1988</year>
-		<publisher>Grandslam</publisher>
+		<publisher>Grandslam Entertainments</publisher>
 		<part name="flop1" interface="floppy_3">
 			<dataarea name="flop" size="195328">
 				<rom name="pac-mania (1988)(grandslam).dsk" size="195328" crc="88f5506b" sha1="827c95935dd3a1dd919989fc6d7a0efa4e5aebc1" offset="0" />
@@ -13943,9 +13943,9 @@
 
 <!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
 	<software name="pangsp" cloneof="pang">
-		<description>Pang (Spain)</description>
+		<description>Pang (Spa)</description>
 		<year>1990</year>
-		<publisher>Erbe</publisher>
+		<publisher>Erbe Software</publisher>
 		<part name="flop1" interface="floppy_3">
 			<dataarea name="flop" size="194816">
 				<rom name="pang (1990)(erbe)(es)(en)[re-release].dsk" size="194816" crc="8407042b" sha1="8cf020876ba5d66995fa5752dd6c036913135f23" offset="0" />
@@ -13957,7 +13957,7 @@
 	<software name="panga" cloneof="pang">
 		<description>Pang (alt)</description>
 		<year>1990</year>
-		<publisher>Ocean</publisher>
+		<publisher>Ocean Software</publisher>
 		<part name="flop1" interface="floppy_3">
 			<dataarea name="flop" size="173312">
 				<rom name="pang (1990)(ocean).dsk" size="173312" crc="28b7f247" sha1="3ba6421683859545be99d43c06a1fb887a60f80f" offset="0" />
@@ -13988,7 +13988,7 @@
 	<software name="parisdak">
 		<description>Paris-Dakar</description>
 		<year>1988</year>
-		<publisher>Zigurat</publisher>
+		<publisher>Zigurat Software</publisher>
 		<part name="flop1" interface="floppy_3">
 			<dataarea name="flop" size="87808">
 				<rom name="paris-dakar (1988)(zigurat)(es).dsk" size="87808" crc="2a06e40a" sha1="8d210174ddd8f21404943b7509f101edaa37b90b" offset="0" />
@@ -14011,7 +14011,7 @@
 
 <!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
 	<software name="passshtsp" cloneof="passsht">
-		<description>Passing Shot (Spain)</description>
+		<description>Passing Shot (Spa)</description>
 		<year>1989</year>
 		<publisher>MCM</publisher>
 		<part name="flop1" interface="floppy_3">
@@ -14075,7 +14075,7 @@
 	<software name="lospajbk">
 		<description>Pepe Carvalho en los Pajaros de Bangkok</description>
 		<year>1988</year>
-		<publisher>Dinamic</publisher>
+		<publisher>Dinamic Software</publisher>
 		<part name="flop1" interface="floppy_3">
 			<dataarea name="flop" size="112640">
 				<rom name="pepe carvalho en los pajaros de bangkok (1988)(dinamic)(es).dsk" size="112640" crc="eaf66708" sha1="5723b9cca75f13917254ba2efb720be6dc3843ad" offset="0" />
@@ -14159,7 +14159,7 @@
 	<software name="pictionasp" cloneof="pictiona">
 		<description>Pictionary - El juego en el que todos pintan</description>
 		<year>1989</year>
-		<publisher>Erbe</publisher>
+		<publisher>Erbe Software</publisher>
 		<part name="flop1" interface="floppy_3">
 			<dataarea name="flop" size="180224">
 				<rom name="pictionary (1989)(erbe)(es)[re-release].dsk" size="180224" crc="6ad3cefb" sha1="299e4e31ae07102b2d84e1858d9346b1b38d2099" offset="0" />
@@ -14216,7 +14216,7 @@
 	<software name="platoona" cloneof="platoon">
 		<description>Platoon (alt)</description>
 		<year>1988</year>
-		<publisher>Ocean</publisher>
+		<publisher>Ocean Software</publisher>
 		<part name="flop1" interface="floppy_3">
 			<dataarea name="flop" size="131072">
 				<rom name="platoon (1988)(ocean).dsk" size="131072" crc="45dc4898" sha1="a19824ab2b59ab29d31d6cb56851e0bcc3c4138b" offset="0" />
@@ -14460,7 +14460,7 @@
 	<software name="rbislanda" cloneof="rbisland">
 		<description>Rainbow Islands (alt)</description>
 		<year>1990</year>
-		<publisher>Ocean</publisher>
+		<publisher>Ocean Software</publisher>
 		<part name="flop1" interface="floppy_3">
 			<dataarea name="flop" size="175360">
 				<rom name="rainbow islands - the story of bubble bobble 2 (1990)(ocean).dsk" size="175360" crc="8409c9ed" sha1="db9bf5bd455ac679142d5727226e9685aeebb1f5" offset="0" />
@@ -14482,9 +14482,9 @@
 
 <!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
 	<software name="redheatsp" cloneof="redheat">
-		<description>Red Heat (Spain)</description>
+		<description>Red Heat (Spa)</description>
 		<year>1989</year>
-		<publisher>Erbe</publisher>
+		<publisher>Erbe Software</publisher>
 		<part name="flop1" interface="floppy_3">
 			<dataarea name="flop" size="175360">
 				<rom name="red heat (1989)(erbe)(es)(en)[re-release].dsk" size="175360" crc="59b14ef2" sha1="19fccf544fb00c9767c8472684d936effa76fca6" offset="0" />
@@ -14496,7 +14496,7 @@
 	<software name="redheat">
 		<description>Red Heat</description>
 		<year>1989</year>
-		<publisher>Ocean</publisher>
+		<publisher>Ocean Software</publisher>
 		<part name="flop1" interface="floppy_3">
 			<dataarea name="flop" size="157184">
 				<rom name="red heat (1989)(ocean).dsk" size="157184" crc="2be37cbe" sha1="75c53860247c0af7c81337519f25f84ed8700dd2" offset="0" />
@@ -14554,7 +14554,7 @@
 	<software name="rescatla">
 		<description>Rescate Atlantida</description>
 		<year>1989</year>
-		<publisher>Dinamic</publisher>
+		<publisher>Dinamic Software</publisher>
 		<part name="flop1" interface="floppy_3">
 			<feature name="part_id" value="Side A"/>
 			<dataarea name="flop" size="150272">
@@ -14573,7 +14573,7 @@
 	<software name="rescatlaa" cloneof="rescatla">
 		<description>Rescate Atlantida (alt)</description>
 		<year>1989</year>
-		<publisher>Dinamic</publisher>
+		<publisher>Dinamic Software</publisher>
 		<part name="flop1" interface="floppy_3">
 			<dataarea name="flop" size="214784">
 				<rom name="rescate atlantida (1989)(dinamic)(es).dsk" size="214784" crc="176a12e4" sha1="4c71b572b282007732fb6a4ff617369c68f8c1ab" offset="0" />
@@ -14585,7 +14585,7 @@
 	<software name="rescatlab" cloneof="rescatla">
 		<description>Rescate Atlantida (alt 2)</description>
 		<year>1989</year>
-		<publisher>Dinamic</publisher>
+		<publisher>Dinamic Software</publisher>
 		<part name="flop1" interface="floppy_3">
 			<dataarea name="flop" size="214784">
 				<rom name="rescate atlantida (1989)(dinamic)(es)[a].dsk" size="214784" crc="b259c19e" sha1="1dda1d59b8fafa91ca3fe15df6f5aada24d85cd5" offset="0" />
@@ -14607,9 +14607,9 @@
 
 <!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
 	<software name="jedisp" cloneof="jedi">
-		<description>Star Wars - Return of the Jedi (Spain)</description>
+		<description>Star Wars - Return of the Jedi (Spa)</description>
 		<year>1989</year>
-		<publisher>Erbe</publisher>
+		<publisher>Erbe Software</publisher>
 		<part name="flop1" interface="floppy_3">
 			<dataarea name="flop" size="68352">
 				<rom name="return of the jedi (1989)(erbe)(es)(en)[re-release].dsk" size="68352" crc="c0f1f626" sha1="f4cb6a5bd15f7e6c3b35678f2da31b9a332d11b1" offset="0" />
@@ -14619,9 +14619,9 @@
 
 <!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
 	<software name="jedispa" cloneof="jedi">
-		<description>Star Wars - Return of the Jedi (Spain) (alt)</description>
+		<description>Star Wars - Return of the Jedi (Spa) (alt)</description>
 		<year>1989</year>
-		<publisher>Erbe</publisher>
+		<publisher>Erbe Software</publisher>
 		<part name="flop1" interface="floppy_3">
 			<dataarea name="flop" size="136448">
 				<rom name="return of the jedi (1989)(erbe)(es)(en)[a][re-release].dsk" size="136448" crc="c5cdb566" sha1="6befbc050becec8e084b1dec01d1c59487192cd0" offset="0" />
@@ -14699,9 +14699,9 @@
 
 <!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
 	<software name="roadblst" cloneof="roadblst">
-		<description>Road Blasters (Spain)</description>
+		<description>Road Blasters (Spa)</description>
 		<year>1988</year>
-		<publisher>Erbe</publisher>
+		<publisher>Erbe Software</publisher>
 		<part name="flop1" interface="floppy_3">
 			<dataarea name="flop" size="214784">
 				<rom name="road blasters (1988)(erbe)(es)(en)[re-release].dsk" size="214784" crc="5966a1bc" sha1="59df737d0dd64fe5c8a6973b1c88efca1892f80a" offset="0" />
@@ -14726,7 +14726,7 @@
 	<software name="robocop">
 		<description>Robocop</description>
 		<year>1988</year>
-		<publisher>Ocean</publisher>
+		<publisher>Ocean Software</publisher>
 		<part name="flop1" interface="floppy_3">
 			<dataarea name="flop" size="134144">
 				<rom name="robocop (1988)(ocean).dsk" size="134144" crc="545558f7" sha1="ad1e7ed55d62d8eec7bae80904f73be7f5ffd59e" offset="0" />
@@ -14738,7 +14738,7 @@
 	<software name="robocopa" cloneof="robocop">
 		<description>Robocop (alt)</description>
 		<year>1988</year>
-		<publisher>Ocean</publisher>
+		<publisher>Ocean Software</publisher>
 		<part name="flop1" interface="floppy_3">
 			<dataarea name="flop" size="128768">
 				<rom name="robocop (1988)(ocean)[a].dsk" size="128768" crc="c3218b5c" sha1="f56181f60553f4ac00631f8720b713bd42490a85" offset="0" />
@@ -14748,9 +14748,9 @@
 
 <!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
 	<software name="robocop2sp" cloneof="robocop2">
-		<description>Robocop 2 (Spain)</description>
+		<description>Robocop 2 (Spa)</description>
 		<year>1990</year>
-		<publisher>Erbe</publisher>
+		<publisher>Erbe Software</publisher>
 		<part name="flop1" interface="floppy_3">
 			<dataarea name="flop" size="160768">
 				<rom name="robocop 2 (1990)(erbe)(es)(en)[re-release].dsk" size="160768" crc="93b27353" sha1="78047deee2d869dbe4554617e385aa2c0998ac48" offset="0" />
@@ -14763,7 +14763,7 @@
 	<software name="robocop2a" cloneof="robocop2">
 		<description>Robocop 2 (alt)</description>
 		<year>1990</year>
-		<publisher>Ocean</publisher>
+		<publisher>Ocean Software</publisher>
 		<part name="flop1" interface="floppy_3">
 			<dataarea name="flop" size="225536">
 				<rom name="robocop 2 (1990)(ocean).dsk" size="225536" crc="afa8626e" sha1="eaf866424fa3d2b0ea006a970d3fd475147040ac" offset="0" />
@@ -14776,7 +14776,7 @@
 	<software name="robocop2b" cloneof="robocop2">
 		<description>Robocop 2 (alt 2)</description>
 		<year>1990</year>
-		<publisher>Ocean</publisher>
+		<publisher>Ocean Software</publisher>
 		<part name="flop1" interface="floppy_3">
 			<dataarea name="flop" size="225536">
 				<rom name="robocop 2 (1990)(ocean)[a].dsk" size="225536" crc="d3298f36" sha1="e7815e2062f98883759629dd4a0cda36862f1961" offset="0" />
@@ -14872,7 +14872,7 @@
 	<software name="rungaunta" cloneof="rungaunt">
 		<description>Run the Gauntlet</description>
 		<year>1989</year>
-		<publisher>Ocean</publisher>
+		<publisher>Ocean Software</publisher>
 		<part name="flop1" interface="floppy_3">
 			<dataarea name="flop" size="174848">
 				<rom name="run the gauntlet (1989)(ocean).dsk" size="174848" crc="908cd12d" sha1="bc74b1f45b05e3e5a0f93e186aeb9e938d469d0f" offset="0" />
@@ -14933,7 +14933,7 @@
 	<software name="saintgrva" cloneof="saintgrv">
 		<description>Saint &amp; Greavsie</description>
 		<year>1989</year>
-		<publisher>Grandslam</publisher>
+		<publisher>Grandslam Entertainments</publisher>
 		<part name="flop1" interface="floppy_3">
 			<dataarea name="flop" size="220160">
 				<rom name="saint and greavsie (1989)(grandslam).dsk" size="220160" crc="5152c80b" sha1="5175ce4e09020f840dddd7da345b9c0b4eb30af6" offset="0" />
@@ -14980,7 +14980,7 @@
 			<feature name="part_id" value="Side B"/>
 	<!-- Side B image shared with other master disks from Zeppelin Games. Verified at World of Spectrum. -->
 			<dataarea name="flop" size="256">
-				<rom name="championship run (1991)(zeppelin games)(side b)[master disk backup][re-release].dsk" size="256" crc="56947af2" sha1="40428c770d847a0fd1fd005b6cf1d03a34672d98" offset="0" />
+				<rom name="zeppelin games master disk side b.dsk" size="256" crc="56947af2" sha1="40428c770d847a0fd1fd005b6cf1d03a34672d98" offset="0" />
 			</dataarea>
 		</part>
 	</software>
@@ -14989,7 +14989,7 @@
 	<software name="satan">
 		<description>Satan</description>
 		<year>1989</year>
-		<publisher>Dinamic</publisher>
+		<publisher>Dinamic Software</publisher>
 		<part name="flop1" interface="floppy_3">
 			<dataarea name="flop" size="107264">
 				<rom name="satan (1989)(dinamic)(es).dsk" size="107264" crc="82642bef" sha1="344dd36d44076d079d8a62b678a8f4139a274526" offset="0" />
@@ -15051,7 +15051,7 @@
 	<software name="sspirits">
 		<description>Scramble Spirits</description>
 		<year>1990</year>
-		<publisher>Grandslam</publisher>
+		<publisher>Grandslam Entertainments</publisher>
 		<part name="flop1" interface="floppy_3">
 			<dataarea name="flop" size="194816">
 				<rom name="scramble spirits (1990)(grandslam).dsk" size="194816" crc="28617137" sha1="b1898340c7eadb2bf29417aaf8006792277c09f8" offset="0" />
@@ -15075,7 +15075,7 @@
 	<software name="sendasal">
 		<description>Senda Salvaje</description>
 		<year>1990</year>
-		<publisher>Zigurat</publisher>
+		<publisher>Zigurat Software</publisher>
 		<part name="flop1" interface="floppy_3">
 			<dataarea name="flop" size="102400">
 				<rom name="senda salvaje (1990)(zigurat)(es).dsk" size="102400" crc="54f0d03f" sha1="a334fc0d768554e29e678017d90cff53adba1ab6" offset="0" />
@@ -15159,7 +15159,7 @@
 	<software name="shdancer">
 		<description>Shadow Dancer</description>
 		<year>1991</year>
-		<publisher>Erbe</publisher>
+		<publisher>Erbe Software</publisher>
 		<part name="flop1" interface="floppy_3">
 			<feature name="part_id" value="Side A"/>
 			<dataarea name="flop" size="165632">
@@ -15178,7 +15178,7 @@
 	<software name="shadoww">
 		<description>Shadow Warriors</description>
 		<year>1990</year>
-		<publisher>Ocean</publisher>
+		<publisher>Ocean Software</publisher>
 		<part name="flop1" interface="floppy_3">
 			<dataarea name="flop" size="208640">
 				<rom name="shadow warriors (1990)(ocean).dsk" size="208640" crc="4d0a3727" sha1="ae8c3160465f6b021355fa83997ae2a90c0ef649" offset="0" />
@@ -15188,9 +15188,9 @@
 
 <!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
 	<software name="sotbeastsp" cloneof="sotbeast">
-		<description>Shadow of the Beast (Spain)</description>
+		<description>Shadow of the Beast (Spa)</description>
 		<year>1990</year>
-		<publisher>Erbe</publisher>
+		<publisher>Erbe Software</publisher>
 		<part name="flop1" interface="floppy_3">
 			<feature name="part_id" value="Side A"/>
 			<dataarea name="flop" size="44288">
@@ -15209,7 +15209,7 @@
 	<software name="sotbeast">
 		<description>Shadow of the Beast</description>
 		<year>1990</year>
-		<publisher>Gremlin Graphics</publisher>
+		<publisher>Gremlin Graphics Software</publisher>
 		<part name="flop1" interface="floppy_3">
 			<feature name="part_id" value="Side A"/>
 			<dataarea name="flop" size="174848">
@@ -15251,7 +15251,7 @@
 			<feature name="part_id" value="Side B"/>
 	<!-- Side B image shared with other master disks from Zeppelin Games. Verified at World of Spectrum. -->
 			<dataarea name="flop" size="256">
-				<rom name="championship run (1991)(zeppelin games)(side b)[master disk backup][re-release].dsk" size="256" crc="56947af2" sha1="40428c770d847a0fd1fd005b6cf1d03a34672d98" offset="0" />
+				<rom name="zeppelin games master disk side b.dsk" size="256" crc="56947af2" sha1="40428c770d847a0fd1fd005b6cf1d03a34672d98" offset="0" />
 			</dataarea>
 		</part>
 	</software>
@@ -15270,7 +15270,7 @@
 
 <!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
 	<software name="shinobisp" cloneof="shinobi">
-		<description>Shinobi (Spain)</description>
+		<description>Shinobi (Spa)</description>
 		<year>1989</year>
 		<publisher>Dro Soft</publisher>
 		<part name="flop1" interface="floppy_3">
@@ -15318,9 +15318,9 @@
 
 <!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
 	<software name="silkwormsp" cloneofe="silkworm">>
-		<description>Silkworm (Spain)</description>
+		<description>Silkworm (Spa)</description>
 		<year>1989</year>
-		<publisher>Erbe</publisher>
+		<publisher>Erbe Software</publisher>
 		<part name="flop1" interface="floppy_3">
 			<dataarea name="flop" size="68352">
 				<rom name="silkworm (1989)(erbe)(es)(en)[re-release].dsk" size="68352" crc="1f3bb8ca" sha1="aeb2576b0f616e920145f3e4575e188d84f578db" offset="0" />
@@ -15330,9 +15330,9 @@
 
 <!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
 	<software name="silkwormspa" cloneofe="silkworm">>
-		<description>Silkworm (Spain) (alt)</description>
+		<description>Silkworm (Spa) (alt)</description>
 		<year>1989</year>
-		<publisher>Erbe</publisher>
+		<publisher>Erbe Software</publisher>
 		<part name="flop1" interface="floppy_3">
 			<dataarea name="flop" size="68352">
 				<rom name="silkworm (1989)(erbe)(es)(en)[a][re-release].dsk" size="68352" crc="1a5a1dac" sha1="cbe96a6d5448f6d0681599abfd48aaed372917ee" offset="0" />
@@ -15342,9 +15342,9 @@
 
 <!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
 	<software name="silkwormspb" cloneofe="silkworm">>
-		<description>Silkworm (Spain) (alt 2)</description>
+		<description>Silkworm (Spa) (alt 2)</description>
 		<year>1989</year>
-		<publisher>Erbe</publisher>
+		<publisher>Erbe Software</publisher>
 		<part name="flop1" interface="floppy_3">
 			<dataarea name="flop" size="67328">
 				<rom name="silkworm (1989)(erbe)(es)(en)[a2][re-release].dsk" size="67328" crc="e3321b40" sha1="f54c7d1851a1acaf867e747f801a595934eeb0af" offset="0" />
@@ -15381,7 +15381,7 @@
 	<software name="bartvssm">
 		<description>The Simpsons - Bart vs. the Space Mutants</description>
 		<year>1991</year>
-		<publisher>Erbe</publisher>
+		<publisher>Erbe Software</publisher>
 		<part name="flop1" interface="floppy_3">
 			<feature name="part_id" value="Side A"/>
 			<dataarea name="flop" size="216320">
@@ -15412,7 +15412,7 @@
 	<software name="sitopons">
 		<description>Sito Pons 500cc Grand Prix</description>
 		<year>1990</year>
-		<publisher>Zigurat</publisher>
+		<publisher>Zigurat Software</publisher>
 		<part name="flop1" interface="floppy_3">
 			<dataarea name="flop" size="58624">
 				<rom name="sito pons 500cc grand prix (1990)(zigurat)(es).dsk" size="58624" crc="a4d2515f" sha1="f9cd0be687108f3a7ef68aae4fbafa306722d41d" offset="0" />
@@ -15493,7 +15493,7 @@
 	<software name="smashtv">
 		<description>Smash TV</description>
 		<year>1991</year>
-		<publisher>Erbe</publisher>
+		<publisher>Erbe Software</publisher>
 		<part name="flop1" interface="floppy_3">
 			<dataarea name="flop" size="63232">
 				<rom name="smash tv (1991)(erbe)(es)(en)[re-release].dsk" size="63232" crc="537c4c8b" sha1="7b196f932ee796e8a1b2726dff93ccc99fe39f67" offset="0" />
@@ -15528,7 +15528,7 @@
 
 <!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
 	<software name="sokobansp" cloneof="sokoban">
-		<description>Sokoban (Spanish)</description>
+		<description>Sokoban (Spa)</description>
 		<year>2006</year>
 		<publisher>Compiler</publisher>
 		<part name="flop1" interface="floppy_3">
@@ -15616,7 +15616,7 @@
 	<software name="spacecrsa" cloneof="spacecrs">
 		<description>Space Crusade</description>
 		<year>1992</year>
-		<publisher>Gremlin Graphics</publisher>
+		<publisher>Gremlin Graphics Software</publisher>
 		<part name="flop1" interface="floppy_3">
 			<dataarea name="flop" size="199680">
 				<rom name="space crusade (1992)(gremlin graphics).dsk" size="199680" crc="ac78c209" sha1="8a2ea68d31c5ee026ca0a9b44c0a0c7657e7ed06" offset="0" />
@@ -15628,7 +15628,7 @@
 	<software name="sharrie2">
 		<description>Space Harrier II</description>
 		<year>1990</year>
-		<publisher>Grandslam</publisher>
+		<publisher>Grandslam Entertainments</publisher>
 		<part name="flop1" interface="floppy_3">
 			<feature name="part_id" value="Side A"/>
 			<dataarea name="flop" size="194816">
@@ -15676,9 +15676,9 @@
 
 <!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
 	<software name="spittimasp" cloneof="spittima">
-		<description>Spitting Image (Spain)</description>
+		<description>Spitting Image (Spa)</description>
 		<year>1989</year>
-		<publisher>Erbe</publisher>
+		<publisher>Erbe Software</publisher>
 		<part name="flop1" interface="floppy_3">
 			<dataarea name="flop" size="116992">
 				<rom name="spitting image (1989)(erbe)(es)(en).dsk" size="116992" crc="2592e3a9" sha1="9452d23da666547fa05ae4f5e1adc05a46da0999" offset="0" />
@@ -15926,9 +15926,9 @@
 
 <!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
 	<software name="stircrazsp" cloneof="stircraz">
-		<description>Stir Crazy Featuring Bobo (Spain)</description>
+		<description>Stir Crazy Featuring Bobo (Spa)</description>
 		<year>1990</year>
-		<publisher>Erbe</publisher>
+		<publisher>Erbe Software</publisher>
 		<part name="flop1" interface="floppy_3">
 			<dataarea name="flop" size="194816">
 				<rom name="stir crazy featuring bobo (1990)(erbe)(es)(en)[re-release].dsk" size="194816" crc="e8fb3ec4" sha1="50c5bda1b9d57e23eff42da53fb8cbe2523ac85e" offset="0" />
@@ -16021,7 +16021,7 @@
 	<!-- May be the same edition as the IPF -->
 		<description>Super Cars (alt)</description>
 		<year>1990</year>
-		<publisher>Gremlin Graphics</publisher>
+		<publisher>Gremlin Graphics Software</publisher>
 		<part name="flop1" interface="floppy_3">
 			<dataarea name="flop" size="174848">
 				<rom name="super cars (1990)(gremlin graphics).dsk" size="174848" crc="0ca22a11" sha1="10d892855a61470343d3e9fe68411e9d2f6b3f83" offset="0" />
@@ -16044,9 +16044,9 @@
 
 <!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
 	<software name="spscsimusp" cloneof="spscsimu">
-		<description>Super Scramble Simulator (Spain)</description>
+		<description>Super Scramble Simulator (Spa)</description>
 		<year>1989</year>
-		<publisher>Erbe</publisher>
+		<publisher>Erbe Software</publisher>
 		<part name="flop1" interface="floppy_3">
 			<dataarea name="flop" size="68608">
 				<rom name="super scramble simulator (1989)(erbe)(es)(en)[re-release].dsk" size="68608" crc="7e7e0a71" sha1="6fcb326fed039e3cf5dd2aa35bcd1a76b88e3f52" offset="0" />
@@ -16058,7 +16058,7 @@
 	<software name="spscsimu">
 		<description>Super Scramble Simulator</description>
 		<year>1989</year>
-		<publisher>Gremlin Graphics</publisher>
+		<publisher>Gremlin Graphics Software</publisher>
 		<part name="flop1" interface="floppy_3">
 			<dataarea name="flop" size="219136">
 				<rom name="super scramble simulator (1989)(gremlin graphics).dsk" size="219136" crc="28831769" sha1="efc4c460794941aad2c6acbc5aa48e98f1b3e949" offset="0" />
@@ -16118,7 +16118,7 @@
 	<software name="spchs335">
 		<description>Superchess 3 v3.5</description>
 		<year>1984</year>
-		<publisher>CP</publisher>
+		<publisher>CP Software</publisher>
 		<part name="flop1" interface="floppy_3">
 			<dataarea name="flop" size="194816">
 				<rom name="superchess 3 v3.5 (1984)(cp).dsk" size="194816" crc="a3329d71" sha1="181ff40d2f69b2409909ef8941dffc10c70d4cc6" offset="0" />
@@ -16149,7 +16149,7 @@
 	<software name="supsport">
 		<description>Supersports - The Alternative Olympics</description>
 		<year>1988</year>
-		<publisher>Gremlin Graphics</publisher>
+		<publisher>Gremlin Graphics Software</publisher>
 		<part name="flop1" interface="floppy_3">
 			<feature name="part_id" value="Side A"/>
 			<dataarea name="flop" size="176103">
@@ -16166,7 +16166,7 @@
 
 <!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
 	<software name="swoiannasp" cloneof="swoianna">
-		<description>The Sword of IANNA (Spanish)</description>
+		<description>The Sword of IANNA (Spa)</description>
 		<year>2017</year>
 		<publisher>RetroWorks</publisher>
 		<part name="flop1" interface="floppy_3">
@@ -16248,7 +16248,7 @@
 			<feature name="part_id" value="Side B"/>
 	<!-- Side B image shared with other master disks from Zeppelin Games. Verified at World of Spectrum. -->
 			<dataarea name="flop" size="256">
-				<rom name="championship run (1991)(zeppelin games)(side b)[master disk backup][re-release].dsk" size="256" crc="56947af2" sha1="40428c770d847a0fd1fd005b6cf1d03a34672d98" offset="0" />
+				<rom name="zeppelin games master disk side b.dsk" size="256" crc="56947af2" sha1="40428c770d847a0fd1fd005b6cf1d03a34672d98" offset="0" />
 			</dataarea>
 		</part>
 	</software>
@@ -16258,7 +16258,7 @@
 	<software name="taipana" cloneof="taipan">
 		<description>Tai-Pan (alt)</description>
 		<year>1987</year>
-		<publisher>Ocean</publisher>
+		<publisher>Ocean Software</publisher>
 		<part name="flop1" interface="floppy_3">
 			<dataarea name="flop" size="194560">
 				<rom name="tai-pan (1987)(ocean).dsk" size="194560" crc="458c4b7c" sha1="6fe0e05aa78573fda4b5c563cba5e5d287c25864" offset="0" />
@@ -16306,7 +16306,7 @@
 	<software name="targetpl">
 		<description>Target Plus</description>
 		<year>1988</year>
-		<publisher>Dinamic</publisher>
+		<publisher>Dinamic Software</publisher>
 		<info name="usage" value="Requires Gun Stick lightgun"/>
 		<part name="flop1" interface="floppy_3">
 			<dataarea name="flop" size="53504">
@@ -16355,7 +16355,7 @@
 	<software name="technoco">
 		<description>Techno-Cop</description>
 		<year>1988</year>
-		<publisher>Gremlin Graphics</publisher>
+		<publisher>Gremlin Graphics Software</publisher>
 		<part name="flop1" interface="floppy_3">
 			<dataarea name="flop" size="219136">
 				<rom name="techno-cop (1988)(gremlin graphics).dsk" size="219136" crc="d3de6ce2" sha1="ad966892ac92495095e565706ed4f672b39a7021" offset="0" />
@@ -16420,7 +16420,7 @@
 	<software name="term2a" cloneof="term2">
 		<description>Terminator 2 - Judgment Day (alt)</description>
 		<year>1991</year>
-		<publisher>Ocean</publisher>
+		<publisher>Ocean Software</publisher>
 		<part name="flop1" interface="floppy_3">
 			<dataarea name="flop" size="216320">
 				<rom name="terminator 2 - judgment day (1991)(ocean).dsk" size="216320" crc="d97a5f2a" sha1="512127b1523d9ba51889b3891592007dcbb89ed0" offset="0" />
@@ -16554,7 +16554,7 @@
 	<software name="thunderb">
 		<description>Thunderbirds</description>
 		<year>1989</year>
-		<publisher>Grandslam</publisher>
+		<publisher>Grandslam Entertainments</publisher>
 		<part name="flop1" interface="floppy_3">
 			<feature name="part_id" value="Side A"/>
 			<dataarea name="flop" size="194816">
@@ -16571,7 +16571,7 @@
 
 <!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
 	<software name="thunderbsp" cloneof="thunderb">
-		<description>Thunderbirds (Spain)</description>
+		<description>Thunderbirds (Spa)</description>
 		<year>1989</year>
 		<publisher>MCM</publisher>
 		<part name="flop1" interface="floppy_3">
@@ -16592,7 +16592,7 @@
 	<software name="thunderba" cloneof="thunderb">
 		<description>Thunderbirds (alt)</description>
 		<year>1989</year>
-		<publisher>Grandslam</publisher>
+		<publisher>Grandslam Entertainments</publisher>
 		<part name="flop1" interface="floppy_3">
 			<feature name="part_id" value="Side A"/>
 			<dataarea name="flop" size="194816">
@@ -16624,7 +16624,7 @@
 	<software name="tiburon" cloneof="jaws">
 		<description>Tiburon</description>
 		<year>1989</year>
-		<publisher>Erbe</publisher>
+		<publisher>Erbe Software</publisher>
 		<part name="flop1" interface="floppy_3">
 			<dataarea name="flop" size="78080">
 				<rom name="tiburon (1989)(erbe)(es)(en)[aka jaws][re-release].dsk" size="78080" crc="aaa7b9fe" sha1="f028fc6cc04d585c570193560849896925c3472f" offset="0" />
@@ -16659,7 +16659,7 @@
 
 <!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
 	<software name="timescansp" cloneof="timescan">
-		<description>Time Scanner (Spain)</description>
+		<description>Time Scanner (Spa)</description>
 		<year>1989</year>
 		<publisher>MCM</publisher>
 		<part name="flop1" interface="floppy_3">
@@ -16673,7 +16673,7 @@
 	<software name="tintmoonsp" cloneof="tintmoon">
 		<description>Tintin en la Luna</description>
 		<year>1989</year>
-		<publisher>Erbe</publisher>
+		<publisher>Erbe Software</publisher>
 		<part name="flop1" interface="floppy_3">
 			<dataarea name="flop" size="63488">
 				<rom name="tintin en la luna (1989)(erbe)(es)(en)[aka tintin on the moon][re-release].dsk" size="63488" crc="e4e8df96" sha1="e60fda54d391d7e1b073529f12e7aa74d6e5b7d2" offset="0" />
@@ -16762,9 +16762,9 @@
 
 <!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
 	<software name="toobinsp" cloneof="toobin">
-		<description>Toobin' (Spain)</description>
+		<description>Toobin' (Spa)</description>
 		<year>1989</year>
-		<publisher>Erbe</publisher>
+		<publisher>Erbe Software</publisher>
 		<part name="flop1" interface="floppy_3">
 			<dataarea name="flop" size="121856">
 				<rom name="toobin' (1989)(erbe)(es)(en)[re-release].dsk" size="121856" crc="0aa86bcb" sha1="6e22f2395bc263e0d2c33d058770f8a5e84d7369" offset="0" />
@@ -16815,7 +16815,7 @@
 	<software name="totrecala" cloneof="totrecal">
 		<description>Total Recall (alt)</description>
 		<year>1991</year>
-		<publisher>Ocean</publisher>
+		<publisher>Ocean Software</publisher>
 		<part name="flop1" interface="floppy_3">
 			<dataarea name="flop" size="178432">
 				<rom name="total recall (1991)(ocean).dsk" size="178432" crc="d58b27ec" sha1="618542c813bec4f3f55196af9033e51a37776965" offset="0" />
@@ -16827,7 +16827,7 @@
 	<software name="tourdefo">
 		<description>Tour de Force</description>
 		<year>1988</year>
-		<publisher>Gremlin Graphics</publisher>
+		<publisher>Gremlin Graphics Software</publisher>
 		<part name="flop1" interface="floppy_3">
 			<dataarea name="flop" size="174848">
 				<rom name="tour de force (1988)(gremlin graphics).dsk" size="174848" crc="c8999948" sha1="3ccb02f23add396d4e45eedf8a7511e7be206b77" offset="0" />
@@ -16932,7 +16932,7 @@
 	<software name="turbogir">
 		<description>Turbo Girl</description>
 		<year>1988</year>
-		<publisher>Dinamic</publisher>
+		<publisher>Dinamic Software</publisher>
 		<part name="flop1" interface="floppy_3">
 			<dataarea name="flop" size="58880">
 				<rom name="turbo girl (1988)(dinamic)(es).dsk" size="58880" crc="4fc6bb30" sha1="b98e25c0a5a75828bf930324dbe008a73a9e0ac9" offset="0" />
@@ -16961,9 +16961,9 @@
 
 <!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
 	<software name="turbooutsp" cloneof="turboout">
-		<description>Turbo Out Run (Spain)</description>
+		<description>Turbo Out Run (Spa)</description>
 		<year>1990</year>
-		<publisher>Erbe</publisher>
+		<publisher>Erbe Software</publisher>
 		<part name="flop1" interface="floppy_3">
 			<feature name="part_id" value="Side A"/>
 			<dataarea name="flop" size="255232">
@@ -17018,9 +17018,9 @@
 
 <!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
 	<software name="turrican" cloneof="turrican">
-		<description>Turrican (Spain)</description>
+		<description>Turrican (Spa)</description>
 		<year>1990</year>
-		<publisher>Erbe</publisher>
+		<publisher>Erbe Software</publisher>
 		<part name="flop1" interface="floppy_3">
 			<feature name="part_id" value="Side A"/>
 			<dataarea name="flop" size="194816">
@@ -17169,7 +17169,7 @@
 	<software name="untoucha">
 		<description>The Untouchables</description>
 		<year>1989</year>
-		<publisher>Ocean</publisher>
+		<publisher>Ocean Software</publisher>
 		<part name="flop1" interface="floppy_3">
 			<feature name="part_id" value="Side A"/>
 			<dataarea name="flop" size="128256">
@@ -17188,7 +17188,7 @@
 	<software name="untouchaa" cloneof="untoucha">
 		<description>The Untouchables (alt)</description>
 		<year>1989</year>
-		<publisher>Ocean</publisher>
+		<publisher>Ocean Software</publisher>
 		<part name="flop1" interface="floppy_3">
 			<feature name="part_id" value="Side A"/>
 			<dataarea name="flop" size="128256">
@@ -17207,7 +17207,7 @@
 	<software name="untouchab" cloneof="untoucha">
 		<description>The Untouchables (alt 2)</description>
 		<year>1989</year>
-		<publisher>Ocean</publisher>
+		<publisher>Ocean Software</publisher>
 		<part name="flop1" interface="floppy_3">
 			<dataarea name="flop" size="194816">
 				<rom name="untouchables, the (1989)(ocean).dsk" size="194816" crc="bcafafe3" sha1="f219d9eac35b054f49f2be5dbfc7c4940bb66415" offset="0" />
@@ -17219,7 +17219,7 @@
 	<software name="untouchac" cloneof="untoucha">
 		<description>The Untouchables (alt 3)</description>
 		<year>1989</year>
-		<publisher>Ocean</publisher>
+		<publisher>Ocean Software</publisher>
 		<part name="flop1" interface="floppy_3">
 			<dataarea name="flop" size="389376">
 				<rom name="untouchables, the (1989)(ocean)[a].dsk" size="389376" crc="6d4df741" sha1="a1f9b963c7181d062a45434f88a977a7314c5580" offset="0" />
@@ -17277,9 +17277,9 @@
 
 <!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
 	<software name="vigilantsp" cloneof="vigilant">
-		<description>Vigilante (Spain)</description>
+		<description>Vigilante (Spa)</description>
 		<year>1989</year>
-		<publisher>Erbe</publisher>
+		<publisher>Erbe Software</publisher>
 		<part name="flop1" interface="floppy_3">
 			<dataarea name="flop" size="127744">
 				<rom name="vigilante (1989)(erbe)(es)(en)[re-release].dsk" size="127744" crc="688b068b" sha1="e29674d3d8b797022334543bb9e48ce687a2738b" offset="0" />
@@ -17425,9 +17425,9 @@
 
 <!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
 	<software name="weclemansp" cloneof="wecleman">
-		<description>WEC Le Mans (Spain)</description>
+		<description>WEC Le Mans (Spa)</description>
 		<year>1989</year>
-		<publisher>Erbe</publisher>
+		<publisher>Erbe Software</publisher>
 		<part name="flop1" interface="floppy_3">
 			<dataarea name="flop" size="70400">
 				<rom name="wec le mans (1989)(erbe)(es)(en).dsk" size="70400" crc="51cff9a9" sha1="6c83a3f0d1865094925d932f907001f96cca6002" offset="0" />
@@ -17439,7 +17439,7 @@
 	<software name="wwfwrest">
 		<description>WWF WrestleMania</description>
 		<year>1991</year>
-		<publisher>Erbe</publisher>
+		<publisher>Erbe Software</publisher>
 		<part name="flop1" interface="floppy_3">
 			<feature name="part_id" value="Side A"/>
 			<dataarea name="flop" size="187904">
@@ -17526,7 +17526,7 @@
 	<software name="welltris">
 		<description>Welltris</description>
 		<year>1991</year>
-		<publisher>Erbe</publisher>
+		<publisher>Erbe Software</publisher>
 		<part name="flop1" interface="floppy_3">
 			<dataarea name="flop" size="78080">
 				<rom name="welltris (1991)(erbe)(es)(en)[re-release].dsk" size="78080" crc="e2c07cf0" sha1="fb270ca2c53498bd04d5e4ddc8a806c51f887318" offset="0" />
@@ -17551,7 +17551,7 @@
 	<software name="wtss">
 		<description>Where Time Stood Still</description>
 		<year>1988</year>
-		<publisher>Ocean</publisher>
+		<publisher>Ocean Software</publisher>
 		<part name="flop1" interface="floppy_3">
 			<dataarea name="flop" size="155648">
 				<rom name="where time stood still (1988)(ocean)[aka land that time forgot, the][aka tibet].dsk" size="155648" crc="b14f1c51" sha1="6bd26b6364493679e8c956cef34ebcdc6db13894" offset="0" />
@@ -17654,7 +17654,7 @@
 			<feature name="part_id" value="Side B"/>
 	<!-- Side B image shared with other master disks from Zeppelin Games. Verified at World of Spectrum. -->
 			<dataarea name="flop" size="256">
-				<rom name="championship run (1991)(zeppelin games)(side b)[master disk backup][re-release].dsk" size="256" crc="56947af2" sha1="40428c770d847a0fd1fd005b6cf1d03a34672d98" offset="0" />
+				<rom name="zeppelin games master disk side b.dsk" size="256" crc="56947af2" sha1="40428c770d847a0fd1fd005b6cf1d03a34672d98" offset="0" />
 			</dataarea>
 		</part>
 	</software>
@@ -17748,9 +17748,9 @@
 
 <!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
 	<software name="xoutsp" cloneof="xout">
-		<description>X-Out (Spain)</description>
+		<description>X-Out (Spa)</description>
 		<year>1990</year>
-		<publisher>Erbe</publisher>
+		<publisher>Erbe Software</publisher>
 		<part name="flop1" interface="floppy_3">
 			<feature name="part_id" value="Side A"/>
 			<dataarea name="flop" size="53760">
@@ -17827,9 +17827,9 @@
 
 <!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
 	<software name="xybotssp" cloneof="xybots">
-		<description>Xybots (Spain)</description>
+		<description>Xybots (Spa)</description>
 		<year>1989</year>
-		<publisher>Erbe</publisher>
+		<publisher>Erbe Software</publisher>
 		<part name="flop1" interface="floppy_3">
 			<dataarea name="flop" size="131328">
 				<rom name="xybots (1989)(erbe)(es)(en)[re-release].dsk" size="131328" crc="f06c87e4" sha1="7ee414b540d5cce2e13f90e1d5aa4c860ff5162e" offset="0" />
@@ -19456,7 +19456,7 @@
 	<software name="2x1fhpha">
 		<description>2 X 1: Phantis + Freddy Hardest</description>
 		<year>1987</year>
-		<publisher>Dinamic</publisher>
+		<publisher>Dinamic Software</publisher>
 		<part name="flop1" interface="floppy_3">
 			<feature name="part_id" value="Side A: Freddy Hardest"/>
 			<dataarea name="flop" size = "109568">
@@ -19474,7 +19474,7 @@
 	<software name="2x1huntg">
 		<description>2 X 1: Hundra + Turbo Girl</description>
 		<year>1988</year>
-		<publisher>Dinamic</publisher>
+		<publisher>Dinamic Software</publisher>
 		<part name="flop1" interface="floppy_3">
 			<feature name="part_id" value="Side A: Hundra"/>
 			<dataarea name="flop" size = "59097">
@@ -19508,9 +19508,9 @@
 	</software>
 
 	<software name="ausgamessp">
-		<description>Australian Games (Spain)</description>
+		<description>Australian Games (Spa)</description>
 		<year>1990</year>
-		<publisher>Erbe</publisher>
+		<publisher>Erbe Software</publisher>
 		<part name="flop1" interface="floppy_3">
 			<feature name="part_id" value="Side A"/>
 			<dataarea name="flop" size = "194816">
@@ -19526,9 +19526,9 @@
 	</software>
 
 	<software name="badlandssp" cloneof="badlands">
-		<description>Badlands (Spain)</description>
+		<description>Badlands (Spa)</description>
 		<year>1990</year>
-		<publisher>Erbe</publisher>
+		<publisher>Erbe Software</publisher>
 		<part name="flop1" interface="floppy_3">
 			<dataarea name="flop" size = "97995">
 				<rom name="Badlands.dsk" size="97995" crc="44ae6f1e" sha1="683489b807cced8c290f8274e428df56d3535cd1" offset="0"/>
@@ -19537,7 +19537,7 @@
 	</software>
 
 	<software name="buggyboysp" cloneof="buggyboy">
-		<description>Buggy Boy (Spain)</description>
+		<description>Buggy Boy (Spa)</description>
 		<year>1988</year>
 		<publisher>MCM</publisher>
 		<part name="flop1" interface="floppy_3">
@@ -19548,7 +19548,7 @@
 	</software>
 
 	<software name="clschss4sp" cloneof="clschss4">
-		<description>Colossus Chess 4 (Spain)</description>
+		<description>Colossus Chess 4 (Spa)</description>
 		<year>1986</year>
 		<publisher>Proein</publisher>
 		<part name="flop1" interface="floppy_3">
@@ -19591,7 +19591,7 @@
 	<software name="Drazen Petrovic Basket (Erbe)">
 		<description>Drazen Petrovic Basket</description>
 		<year>1989</year>
-		<publisher>Erbe</publisher>
+		<publisher>Erbe Software</publisher>
 		<part name="flop1" interface="floppy_3">
 			<dataarea name="flop" size = "73216">
 				<rom name="Drazen Petrovic Basket (Erbe).DSK" size="73216" crc="17eeb154" sha1="4e0b0edd771ad5dc622c449a73bae1b0a11e4789" offset="0"/>
@@ -19620,7 +19620,7 @@
 	<software name="esanchvib" cloneof="esanchvi">
 		<description>Emilio Sanchez Vicario Grand Slam (alt 2)</description>
 		<year>1990</year>
-		<publisher>Zigurat</publisher>
+		<publisher>Zigurat Software</publisher>
 		<part name="flop1" interface="floppy_3">
 			<dataarea name="flop" size = "58939">
 				<rom name="Emilio Sanchez Vicario Grand Slam.dsk" size="58939" crc="5640d214" sha1="6c033e39e84822a6fbf9c6ee61125693c8f86d3b" offset="0"/>
@@ -19629,9 +19629,9 @@
 	</software>
 
 	<software name="epromsp" cloneof="eprom">
-		<description>Escape from the Planet of the Robot Monsters (Spain)</description>
+		<description>Escape from the Planet of the Robot Monsters (Spa)</description>
 		<year>1990</year>
-		<publisher>Erbe</publisher>
+		<publisher>Erbe Software</publisher>
 		<part name="flop1" interface="floppy_3">
 			<dataarea name="flop" size = "194816">
 				<rom name="Escape from the planet of the robot monsters (Erbe).dsk" size="194816" crc="0bb41cee" sha1="689e11d47ba487499ba952f0ef401deed4a1be13" offset="0"/>
@@ -19662,7 +19662,7 @@
 	</software>
 
 	<software name="goldnaxespa" cloneof="goldnaxe">
-		<description>Golden Axe (Spain) (alt)</description>
+		<description>Golden Axe (Spa) (alt)</description>
 		<year>1990</year>
 		<publisher>MCM</publisher>
 		<part name="flop1" interface="floppy_3">
@@ -19680,9 +19680,9 @@
 	</software>
 
 	<software name="gunshipsp" cloneof="gunship">
-		<description>Gunship (Spain)</description>
+		<description>Gunship (Spa)</description>
 		<year>1987</year>
-		<publisher>Erbe</publisher>
+		<publisher>Erbe Software</publisher>
 		<part name="flop1" interface="floppy_3">
 			<feature name="part_id" value="Side A"/>
 			<dataarea name="flop" size = "151040">
@@ -19698,9 +19698,9 @@
 	</software>
 
 	<software name="highstelsp">
-		<description>High Steel (Spain)</description>
+		<description>High Steel (Spa)</description>
 		<year>1989</year>
-		<publisher>Erbe</publisher>
+		<publisher>Erbe Software</publisher>
 		<part name="flop1" interface="floppy_3">
 			<dataarea name="flop" size = "58624">
 				<rom name="High Steel (Erbe Software).dsk" size="58624" crc="39f355cc" sha1="79cc8da772100bf639af90efbd85d10735cbd7e0" offset="0"/>
@@ -19709,7 +19709,7 @@
 	</software>
 
 	<software name="italia90sp" cloneof="italia90">
-		<description>Italia '90 - World Cup Soccer (Spain)</description>
+		<description>Italia '90 - World Cup Soccer (Spa)</description>
 		<year>1989</year>
 		<publisher>Dro Soft</publisher>
 		<part name="flop1" interface="floppy_3">
@@ -19733,7 +19733,7 @@
 	<software name="los40v5">
 		<description>Los 40 Principales Vol. 4</description>
 		<year>1987</year>
-		<publisher>Erbe</publisher>
+		<publisher>Erbe Software</publisher>
 		<part name="flop1" interface="floppy_3">
 			<feature name="part_id" value="Side A: Rambo + Krakout"/>
 			<dataarea name="flop" size="194816">
@@ -19791,9 +19791,9 @@
 
 	<software name="narcsp" cloneof="narc">
 	<!-- This dump of Side A has been manually fixed, a new untampered one may be needed for verification. -->
-		<description>NARC (Spain)</description>
+		<description>NARC (Spa)</description>
 		<year>1990</year>
-		<publisher>Erbe</publisher>
+		<publisher>Erbe Software</publisher>
 		<part name="flop1" interface="floppy_3">
 			<feature name="part_id" value="Side A"/>
 			<dataarea name="flop" size = "226048">
@@ -19811,9 +19811,9 @@
 	<!-- This image came from a dual-system Spectrum/Amstrad release (Side A: Spectrum, Side B: Amstrad) -->
 	<!-- Dump made with SAMdisk -->
 	<software name="navymovespa" cloneof="navymove">
-		<description>Navy Moves (Spanish) (alt)</description>
+		<description>Navy Moves (Spa) (alt)</description>
 		<year>1988</year>
-		<publisher>Dinamic</publisher>
+		<publisher>Dinamic Software</publisher>
 		<part name="flop1" interface="floppy_3">
 			<dataarea name="flop" size="166817">
 				<rom name="Navy Moves (Doble Edición) (side A).dsk" size="166817" crc="718149f4" sha1="5018740f71bc2ae08343f4040590cfa2550333bf" offset="0" />
@@ -19828,7 +19828,7 @@
 	<software name="navymove">
 		<description>Navy Moves</description>
 		<year>1988</year>
-		<publisher>Dinamic</publisher>
+		<publisher>Dinamic Software</publisher>
 		<part name="flop1" interface="floppy_3">
 			<dataarea name="flop" size="214784">
 				<rom name="navy moves (1988)(dinamic)(es)(en)(side b).dsk" size="214784" crc="c32323a2" sha1="da30c11411368b22474b032f39e8f8b968f7903b" offset="0" />
@@ -19837,7 +19837,7 @@
 -->
 
 	<software name="ninjawarsp" cloneof="ninjawar">
-		<description>The Ninja Warriors (Spain)</description>
+		<description>The Ninja Warriors (Spa)</description>
 		<year>1990</year>
 		<publisher>Dro Soft</publisher>
 		<part name="flop1" interface="floppy_3">
@@ -19850,7 +19850,7 @@
 	<software name="powrmagc">
 		<description>Power Magic</description>
 		<year>1990</year>
-		<publisher>Zigurat</publisher>
+		<publisher>Zigurat Software</publisher>
 		<part name="flop1" interface="floppy_3">
 			<dataarea name="flop" size = "63488">
 				<rom name="Power Magic.dsk" size="63488" crc="2a0017e0" sha1="1a6bdbbef1a1e22176a492b228b508a982db29ee" offset="0"/>
@@ -19859,9 +19859,9 @@
 	</software>
 
 	<software name="rbislandsp" cloneof="rbisland">
-		<description>Rainbow Islands (Spain)</description>
+		<description>Rainbow Islands (Spa)</description>
 		<year>1990</year>
-		<publisher>Erbe</publisher>
+		<publisher>Erbe Software</publisher>
 		<part name="flop1" interface="floppy_3">
 			<dataarea name="flop" size = "176107">
 				<rom name="Rainbow Islands (Erbe Software).dsk" size="176107" crc="8011bfaa" sha1="28356ae9a4df3144248cae45c0a1b7fd812f8fb0" offset="0"/>
@@ -19891,7 +19891,7 @@
 	<!-- This dump of Side A has been manually fixed, a new untampered one may be needed for verification. -->
 		<description>Rescate Atlantida (alt 3)</description>
 		<year>1989</year>
-		<publisher>Dinamic</publisher>
+		<publisher>Dinamic Software</publisher>
 		<part name="flop1" interface="floppy_3">
 			<feature name="part_id" value="Side A"/>
 			<dataarea name="flop" size = "150659">
@@ -19907,7 +19907,7 @@
 	</software>
 
 	<software name="ringwarssp">
-		<description>Ring Wars (Spain)</description>
+		<description>Ring Wars (Spa)</description>
 		<year>1989</year>
 		<publisher>MCM</publisher>
 		<part name="flop1" interface="floppy_3">
@@ -19919,7 +19919,7 @@
 
 	<software name="simuhitssp">
 	<!-- No good dump known of Side B, but Side A seems to include everything. -->
-		<description>Simulation Hits (Spain)</description>
+		<description>Simulation Hits (Spa)</description>
 		<year>1989</year>
 		<publisher>Proein</publisher>
 		<part name="flop1" interface="floppy_3">
@@ -19963,7 +19963,7 @@
 	<!-- Game recovered from the original developer's archives -->
 		<description>The Prayer Of The Warrior</description>
 		<year>1992</year>
-		<publisher>Zigurat</publisher>
+		<publisher>Zigurat Software</publisher>
 		<part name="flop1" interface="floppy_3">
 			<feature name="part_id" value="Side A"/>
 			<dataarea name="flop" size = "194816">
@@ -20009,9 +20009,9 @@
 	</software>
 
 	<software name="toobinspa" cloneof="toobin">
-		<description>Toobin' (Spain) (alt)</description>
+		<description>Toobin' (Spa) (alt)</description>
 		<year>1989</year>
-		<publisher>Erbe</publisher>
+		<publisher>Erbe Software</publisher>
 		<part name="flop1" interface="floppy_3">
 			<dataarea name="flop" size = "122405">
 				<rom name="Toobin (Erbe).dsk" size="122405" crc="19c5e569" sha1="3eb3eecaf23e4ef5bd3ca5761eccf9aad1fa60b7" offset="0"/>
@@ -20020,7 +20020,7 @@
 	</software>
 
 	<software name="trainetnsp">
-		<description>The Train: Escape to Normandy (Spain)</description>
+		<description>The Train: Escape to Normandy (Spa)</description>
 		<year>1988</year>
 		<publisher>Dro Soft</publisher>
 		<part name="flop1" interface="floppy_3">

--- a/hash/specpls3_flop.xml
+++ b/hash/specpls3_flop.xml
@@ -7884,8 +7884,8 @@
 	</software>
 
 <!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
-	<software name="barbariasp">
-		<description>Barbarian (Spa)</description>
+	<software name="barbaria">
+		<description>Barbarian</description>
 		<year>1988</year>
 		<publisher>Dro Soft</publisher>
 		<part name="flop1" interface="floppy_3">
@@ -16417,8 +16417,8 @@
 	</software>
 
 <!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
-	<software name="terrorposp">
-		<description>Terrorpods (Spa)</description>
+	<software name="terrorpo">
+		<description>Terrorpods</description>
 		<year>1989</year>
 		<publisher>Dro Soft</publisher>
 		<part name="flop1" interface="floppy_3">

--- a/hash/specpls3_flop.xml
+++ b/hash/specpls3_flop.xml
@@ -7884,8 +7884,8 @@
 	</software>
 
 <!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
-	<software name="barbaria">
-		<description>Barbarian</description>
+	<software name="barbariasp">
+		<description>Barbarian (Spa)</description>
 		<year>1988</year>
 		<publisher>Dro Soft</publisher>
 		<part name="flop1" interface="floppy_3">

--- a/hash/specpls3_flop.xml
+++ b/hash/specpls3_flop.xml
@@ -2771,7 +2771,7 @@
 				<rom name="transfer +3 (1988)(topo soft)(es)(side a).dsk" size="180224" crc="ce9356db" sha1="3c20847d71a2ff8227ba0205b5fecad8bb3597d0" offset="0" />
 			</dataarea>
 		</part>
-		<part name="flop1" interface="floppy_3">
+		<part name="flop2" interface="floppy_3">
 			<feature name="part_id" value="Side B"/>
 			<dataarea name="flop" size="180224">
 				<rom name="transfer +3 (1988)(topo soft)(es)(side b)[a].dsk" size="180224" crc="475be7a1" sha1="f4f38459f6154d2cad84264409a6a353a0393882" offset="0" />
@@ -3031,7 +3031,7 @@
 				<rom name="2 por 1 - platoon (1989)(erbe).dsk" size="194816" crc="0341da38" sha1="ced84b0c722d3b7ca87727003c1d825f0bb723e9" offset="0" />
 			</dataarea>
 		</part>
-		<part name="flop1" interface="floppy_3">
+		<part name="flop2" interface="floppy_3">
 			<feature name="part_id" value="Side B: Arkanoid II: Revenge of Doh"/>
 			<dataarea name="flop" size="58624">
 				<rom name="2 por 1 - arkanoid ii - revenge of doh (1989)(erbe).dsk" size="58624" crc="671b73b3" sha1="56d72c852be3ab2547d348b92fe96dc6cfa4c095" offset="0" />
@@ -3088,7 +3088,7 @@
 				<rom name="2 por 1 - silent shadow (1988)(erbe)(es).dsk" size="194816" crc="e308222a" sha1="3512aba07e8087b3b3b22952f30133c057f92897" offset="0" />
 			</dataarea>
 		</part>
-		<part name="flop1" interface="floppy_3">
+		<part name="flop2" interface="floppy_3">
 			<feature name="part_id" value="Side B: Mad Mix Game"/>
 			<dataarea name="flop" size="194816">
 				<rom name="2 por 1 - mad mix game (1988)(erbe)(es).dsk" size="194816" crc="c530fc92" sha1="3ba4cae93aded2a468e8b424dd46f1b05f7b18bd" offset="0" />
@@ -3247,13 +3247,13 @@
 				<rom name="20 game pack (19xx)(comet)(disk 1 of 2 side b).dsk" size="194816" crc="0c4f057a" sha1="ab36f880f872d18a4315f5bad78bd5961f7787b2" offset="0" />
 			</dataarea>
 		</part>
-		<part name="flop1" interface="floppy_3">
+		<part name="flop3" interface="floppy_3">
 			<feature name="part_id" value="Disk 2, Side A"/>
 			<dataarea name="flop" size="194816">
 				<rom name="20 game pack (19xx)(comet)(disk 2 of 2 side a).dsk" size="194816" crc="f374a90f" sha1="c053291bea9fd33ea463e9aa5e5530056cf4a615" offset="0" />
 			</dataarea>
 		</part>
-		<part name="flop2" interface="floppy_3">
+		<part name="flop4" interface="floppy_3">
 			<feature name="part_id" value="Disk 2, Side B"/>
 			<dataarea name="flop" size="194816">
 				<rom name="20 game pack (19xx)(comet)(disk 2 of 2 side b).dsk" size="194816" crc="e794781e" sha1="6a6c9e4a8083bef5e405db20ed4897668965296a" offset="0" />
@@ -3367,7 +3367,7 @@
 				<rom name="40 principales vol. 10, los - super soccer + ramon rodriguez (1987)(erbe)(es)(en).dsk" size="194816" crc="e3cfb4fd" sha1="d91dffe5f813aa2bb55883568487c6073f158911" offset="0" />
 			</dataarea>
 		</part>
-		<part name="flop1" interface="floppy_3">
+		<part name="flop2" interface="floppy_3">
 			<feature name="part_id" value="Side B: Pole Position + Abu Simbel Profanation"/>
 			<dataarea name="flop" size="194816">
 				<rom name="40 principales vol. 10, los - pole position + abu simbel profanation (1987)(erbe)(es)(en).dsk" size="194816" crc="624a60d6" sha1="5a669643703075479ab57123bb82aa46d755272a" offset="0" />
@@ -3577,7 +3577,7 @@
 				<rom name="40 principales vol. 9, los (1987)(erbe)(es)(en-es)(side a).dsk" size="194816" crc="fad70a24" sha1="05b136fbcbc2ff78ee1b9df8a8c8eee84b5b27cd" offset="0" />
 			</dataarea>
 		</part>
-		<part name="flop1" interface="floppy_3">
+		<part name="flop2" interface="floppy_3">
 			<feature name="part_id" value="Side B: World Series Basketball + Nonamed"/>
 			<dataarea name="flop" size="194816">
 				<rom name="40 principales vol. 9, los (1987)(erbe)(es)(en)(side b).dsk" size="194816" crc="8c5e18a1" sha1="ede67667b46bb8d785398c58d22263158ed744af" offset="0" />
@@ -3821,7 +3821,7 @@
 				<rom name="best of elite vol 1 - frank bruno's boxing + bomb jack (1987)(hit-pak).dsk" size="214784" crc="d7dcaba9" sha1="4390a79bea5a12930b52d12e8bc3a0eb4bafb5eb" offset="0" />
 			</dataarea>
 		</part>
-		<part name="flop1" interface="floppy_3">
+		<part name="flop2" interface="floppy_3">
 			<feature name="part_id" value="Side B: Airwolf + Commando"/>
 			<dataarea name="flop" size="214784">
 				<rom name="best of elite vol 1 - airwolf + commando (1987)(hit-pak).dsk" size="214784" crc="36042980" sha1="41b40047372fac5c7001031de46ff4db79b27561" offset="0" />
@@ -3971,7 +3971,7 @@
 				<rom name="computer classics - aliens + cauldron ii - the pumpkin strikes back + dynamite dan (1987)(beau-jolly).dsk" size="204544" crc="f34e00f7" sha1="293aa4a82b1163cff606a9c8a8ff1e9c4a4d9364" offset="0" />
 			</dataarea>
 		</part>
-		<part name="flop1" interface="floppy_3">
+		<part name="flop2" interface="floppy_3">
 			<feature name="part_id" value="Side B: Into the Eagle's Nest + Exolon"/>
 			<dataarea name="flop" size="204544">
 				<rom name="computer classics - into the eagle's nest + exolon (1987)(beau-jolly).dsk" size="204544" crc="a1d84366" sha1="c8e1f9ae43d3e44614eb0bf6b51807e1c6ee79df" offset="0" />
@@ -4028,7 +4028,7 @@
 				<rom name="data east's arcade alley - express raider + last mission (1988)(u.s. gold)(side a).dsk" size="194816" crc="4621ccee" sha1="6357e892ac1e242d93f145bd1fc3a925133db1a4" offset="0" />
 			</dataarea>
 		</part>
-		<part name="flop1" interface="floppy_3">
+		<part name="flop2" interface="floppy_3">
 			<feature name="part_id" value="Side B: Kung-Fu Master + Breakthru"/>
 			<dataarea name="flop" size="194816">
 				<rom name="data east's arcade alley - kung-fu master + breakthru (1988)(u.s. gold).dsk" size="194816" crc="3ec5943f" sha1="1a653fa41d7fcd7aaffe928d2c0185301dd764d7" offset="0" />
@@ -4337,7 +4337,7 @@
 				<rom name="five star games 3 - aliens + the sacred armour of antiriad + the way of the exploding fist (1987)(beau-jolly).dsk" size="194816" crc="a4183f58" sha1="bda5e566d528700d8dc829636a59a55a8755f055" offset="0" />
 			</dataarea>
 		</part>
-		<part name="flop1" interface="floppy_3">
+		<part name="flop2" interface="floppy_3">
 			<feature name="part_id" value="Side B: Spindizzy + Starquake + Tau Ceti + Uridium+"/>
 			<dataarea name="flop" size="194816">
 				<rom name="five star games 3 - spindizzy + starquake + tau ceti + uridium+ (1987)(beau-jolly).dsk" size="194816" crc="52571952" sha1="23a2ce48d8ea3116578084c398702be0c3adb8d4" offset="0" />
@@ -4506,25 +4506,25 @@
 				<rom name="giants - out run (1988)(u.s. gold)(disk 1 of 3 side b).dsk" size="154624" crc="e55f2a26" sha1="296cc4091571beb20dbea551adaf7a53e13214a2" offset="0" />
 			</dataarea>
 		</part>
-		<part name="flop1" interface="floppy_3">
+		<part name="flop3" interface="floppy_3">
 			<feature name="part_id" value="Side A: 720 Degrees + Rolling Thunder"/>
 			<dataarea name="flop" size="194816">
 				<rom name="giants - 720 degrees + rolling thunder (1988)(u.s. gold)(disk 2 of 3 side a).dsk" size="194816" crc="f2ded21e" sha1="055f552e55fc5d2d698f9a17c6524cf8a21d2614" offset="0" />
 			</dataarea>
 		</part>
-		<part name="flop2" interface="floppy_3">
+		<part name="flop4" interface="floppy_3">
 			<feature name="part_id" value="Side B: Gauntlet II"/>
 			<dataarea name="flop" size="174336">
 				<rom name="giants - gauntlet ii (1988)(u.s. gold)(disk 2 of 3 side b).dsk" size="174336" crc="34f085e5" sha1="f15d5d0f21192a7d3e8881b20fcf26b63a93173e" offset="0" />
 			</dataarea>
 		</part>
-		<part name="flop1" interface="floppy_3">
+		<part name="flop5" interface="floppy_3">
 			<feature name="part_id" value="Side A: California Games"/>
 			<dataarea name="flop" size="182016">
 				<rom name="giants - california games (1988)(u.s. gold)(disk 3 of 3 side a).dsk" size="182016" crc="345824a9" sha1="d071db70eca434477322f6b105cc7830f2892f73" offset="0" />
 			</dataarea>
 		</part>
-		<part name="flop2" interface="floppy_3">
+		<part name="flop6" interface="floppy_3">
 			<feature name="part_id" value="Side B: California Games"/>
 			<dataarea name="flop" size="182528">
 				<rom name="giants - california games (1988)(u.s. gold)(disk 3 of 3 side b).dsk" size="182528" crc="3b596738" sha1="2333a2612b1dbd633dadaba41c5c058bcf52e8ba" offset="0" />
@@ -5884,7 +5884,7 @@
 				<rom name="plus 3 sports - strike (1987)(mastertronic)(side a).dsk" size="194816" crc="3ca3f142" sha1="dfaf7bb837087a04b993fa83a45471177e91be4f" offset="0" />
 			</dataarea>
 		</part>
-		<part name="flop1" interface="floppy_3">
+		<part name="flop2" interface="floppy_3">
 			<feature name="part_id" value="Side B: Speed King 2"/>
 			<dataarea name="flop" size="194816">
 				<rom name="plus 3 sports - speed king 2 (1987)(mastertronic)(side b).dsk" size="194816" crc="2519315e" sha1="ae1f1e21969fec88305fc9200eae5b288d711739" offset="0" />
@@ -6196,19 +6196,19 @@
 				<rom name="soccer mania (1990)(addictive games)(disk 1 of 2 side a).dsk" size="194816" crc="bfcc36bb" sha1="6d6a74fe478bdfc039f3dc67e851a6951413dbf8" offset="0" />
 			</dataarea>
 		</part>
-		<part name="flop1" interface="floppy_3">
+		<part name="flop2" interface="floppy_3">
 			<feature name="part_id" value="Disk 1, Side A: Football Manager: World Cup Edition"/>
 			<dataarea name="flop" size="194816">
 				<rom name="soccer mania - world cup edition (1990)(addictive games)(disk 1 of 2 side b).dsk" size="194816" crc="7f49f5cd" sha1="6d6a3ea81aeffbc9a300ae6252c81183a3df5aa4" offset="0" />
 			</dataarea>
 		</part>
-		<part name="flop2" interface="floppy_3">
+		<part name="flop3" interface="floppy_3">
 			<feature name="part_id" value="Disk 2, Side A: Gazza's Super Soccer"/>
 			<dataarea name="flop" size="194816">
 				<rom name="soccer mania (1990)(addictive games)(disk 2 of 2 side a).dsk" size="194816" crc="347bc85e" sha1="f89876979105843a68d1e06aa8dab94dc599597e" offset="0" />
 			</dataarea>
 		</part>
-		<part name="flop3" interface="floppy_3">
+		<part name="flop4" interface="floppy_3">
 			<feature name="part_id" value="Disk 2, Side B: MicroProse Soccer"/>
 			<dataarea name="flop" size="194816">
 				<rom name="soccer mania (1990)(addictive games)(disk 2 of 2 side b).dsk" size="194816" crc="53a7650a" sha1="5c44e0b45cbb2dccbd2725fa96be07caf9563cc3" offset="0" />
@@ -6447,7 +6447,7 @@
 				<rom name="take five - gangplank + just imagine (1988)(pirate)(side a).dsk" size="194816" crc="60ef133d" sha1="c1c85b3014eccf68baead4015688528c2eb325dd" offset="0" />
 			</dataarea>
 		</part>
-		<part name="flop1" interface="floppy_3">
+		<part name="flop2" interface="floppy_3">
 			<feature name="part_id" value="Side B: Dusty Droid and the Garbage Gobblers + O.K. Yah + Don't Say It, Spray It"/>
 			<dataarea name="flop" size="194816">
 				<rom name="take five - dusty droid and the garbage gobblers + o.k. yah + don't say it, spray it (1988)(pirate)(side b).dsk" size="194816" crc="c02bad77" sha1="a28709dbc02fd94161e51516aae7a6dd4f62df20" offset="0" />
@@ -6593,7 +6593,7 @@
 				<rom name="traveller's tales - phoenix + the violator of voodoo (1993)(zenobi)(side a).dsk" size="194816" crc="30e96557" sha1="72179269718719ea83e2c1994f938c99b015145d" offset="0" />
 			</dataarea>
 		</part>
-		<part name="flop1" interface="floppy_3">
+		<part name="flop2" interface="floppy_3">
 			<feature name="part_id" value="Side B: Aztec Assault + Celtic Carnage"/>
 			<dataarea name="flop" size="194816">
 				<rom name="traveller's tales - aztec assault + celtic carnage (1993)(zenobi)(side b).dsk" size="194816" crc="6af8f2c7" sha1="636611c8143f00b4b47ba2ac593481d07ae83642" offset="0" />
@@ -15011,7 +15011,7 @@
 			</dataarea>
 		</part>
 		<publisher>Level 9 Computing</publisher>
-		<part name="flop1" interface="floppy_3">
+		<part name="flop2" interface="floppy_3">
 			<dataarea name="flop" size="194816">
 				<rom name="scapeghost (1989)(level 9 computing)(side b)[a][aka spook].dsk" size="194816" crc="c464a1e9" sha1="baf17b2ebba89cbb29af430be2399c05f03d4ad3" offset="0" />
 			</dataarea>
@@ -19960,8 +19960,8 @@
 	<software name="prayoftwa" cloneof="prayoftw">
 	<!-- Modified version of the game which includes both loads in one side of the disc. -->
 		<description>The Prayer of the Warrior (alt)</description>
-		<year></year>
-		<publisher></publisher>
+		<year>1992</year>
+		<publisher>Zigurat Software</publisher>
 		<part name="flop1" interface="floppy_3">
 			<dataarea name="flop" size = "194816">
 				<rom name="The Prayer of the Warrior (Zup).dsk" size="194816" crc="f9b00ee9" sha1="f18303f4295f1127c8e499ce197d6a17397cd70a" offset="0"/>

--- a/hash/specpls3_flop.xml
+++ b/hash/specpls3_flop.xml
@@ -8695,7 +8695,7 @@
 	</software>
 
 <!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
-	<!-- This is an old version, dated 201711 -->
+	<!-- This is an old version, dated 20171114 -->
 	<software name="cvaniasia" cloneof="cvaniasi">
 		<description>Castlevania - Spectral Interlude (alt)</description>
 		<year>2015</year>
@@ -8708,7 +8708,7 @@
 	</software>
 
 <!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
-	<!-- This is an old version, dated 201711 -->
+	<!-- This is an old version, dated 20171114 -->
 	<software name="cvaniasispa" cloneof="cvaniasi">
 		<description>Castlevania - Spectral Interlude (Spa) (alt)</description>
 		<year>2015</year>
@@ -8721,7 +8721,7 @@
 	</software>
 
 <!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
-	<!-- This is an old version, dated 201711 -->
+	<!-- This is an old version, dated 20171117 -->
 	<software name="cvaniasiita" cloneof="cvaniasi">
 		<description>Castlevania - Spectral Interlude (Ita) (alt)</description>
 		<year>2015</year>
@@ -8734,7 +8734,7 @@
 	</software>
 
 <!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
-	<!-- This is an old version, dated 201711 -->
+	<!-- This is an old version, dated 20171114 -->
 	<software name="cvaniasirua" cloneof="cvaniasi">
 		<description>Castlevania - Spectral Interlude (Rus) (alt)</description>
 		<year>2015</year>
@@ -8747,7 +8747,7 @@
 	</software>
 
 <!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
-	<!-- This is an old version, dated 201711 -->
+	<!-- This is an old version, dated 20171116 -->
 	<software name="cvaniasipoa" cloneof="cvaniasi">
 		<description>Castlevania - Spectral Interlude (Pol) (alt)</description>
 		<year>2015</year>
@@ -20016,6 +20016,8 @@
 	</software>
 
 <!-- Other floppy images -->
+
+	<!-- This version is dated 20180316 -->
 	<software name="cvaniasi">
 		<description>Castlevania - Spectral Interlude</description>
 		<year>2015</year>
@@ -20027,6 +20029,7 @@
 		</part>
 	</software>
 
+	<!-- This version is dated 20180316 -->
 	<software name="cvaniasiit" cloneof="cvaniasi">
 		<description>Castlevania - Spectral Interlude (Ita)</description>
 		<year>2015</year>
@@ -20038,6 +20041,7 @@
 		</part>
 	</software>
 
+	<!-- This version is dated 20180316 -->
 	<software name="cvaniasipo" cloneof="cvaniasi">
 		<description>Castlevania - Spectral Interlude (Pol)</description>
 		<year>2015</year>
@@ -20049,6 +20053,7 @@
 		</part>
 	</software>
 
+	<!-- This version is dated 20180316 -->
 	<software name="cvaniasiru" cloneof="cvaniasi">
 		<description>Castlevania - Spectral Interlude (Rus)</description>
 		<year>2015</year>
@@ -20060,6 +20065,7 @@
 		</part>
 	</software>
 
+	<!-- This version is dated 20180316 -->
 	<software name="cvaniasisp" cloneof="cvaniasi">
 		<description>Castlevania - Spectral Interlude (Spa)</description>
 		<year>2015</year>

--- a/hash/specpls3_flop.xml
+++ b/hash/specpls3_flop.xml
@@ -19804,6 +19804,7 @@
 				<rom name="navy moves (1988)(dinamic)(es)(en)(side b).dsk" size="214784" crc="c32323a2" sha1="da30c11411368b22474b032f39e8f8b968f7903b" offset="0" />
 			</dataarea>
 		</part>
+	</software>
 
 	<software name="ninjawarsp" cloneof="ninjawar">
 		<description>The Ninja Warriors (Spa)</description>

--- a/hash/specpls3_flop.xml
+++ b/hash/specpls3_flop.xml
@@ -16153,8 +16153,9 @@
 	</software>
 
 <!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
-	<software name="swoiannasp" cloneof="swoianna">
-		<description>The Sword of IANNA (Spa)</description>
+	<!-- This is an older version of the game, dated 20170922 -->
+	<software name="swoiannaa" cloneof="swoianna">
+		<description>The Sword of IANNA (alt)</description>
 		<year>2017</year>
 		<publisher>RetroWorks</publisher>
 		<part name="flop1" interface="floppy_3">
@@ -16172,6 +16173,7 @@
 	</software>
 
 <!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<!-- This version is dated 20171126 -->
 	<software name="swoianna">
 		<description>The Sword of IANNA</description>
 		<year>2017</year>

--- a/hash/specpls3_flop.xml
+++ b/hash/specpls3_flop.xml
@@ -8697,7 +8697,7 @@
 <!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
 	<!-- This is an old version, dated 201711 -->
 	<software name="cvaniasia" cloneof="cvaniasi">
-		<description>Castlevania - Spectral Interlude</description>
+		<description>Castlevania - Spectral Interlude (alt)</description>
 		<year>2015</year>
 		<publisher>Rewind Team</publisher>
 		<part name="flop1" interface="floppy_3">
@@ -8710,7 +8710,7 @@
 <!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
 	<!-- This is an old version, dated 201711 -->
 	<software name="cvaniasispa" cloneof="cvaniasi">
-		<description>Castlevania - Spectral Interlude (Spa)</description>
+		<description>Castlevania - Spectral Interlude (Spa) (alt)</description>
 		<year>2015</year>
 		<publisher>Rewind Team</publisher>
 		<part name="flop1" interface="floppy_3">
@@ -8723,7 +8723,7 @@
 <!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
 	<!-- This is an old version, dated 201711 -->
 	<software name="cvaniasiita" cloneof="cvaniasi">
-		<description>Castlevania - Spectral Interlude (Ita)</description>
+		<description>Castlevania - Spectral Interlude (Ita) (alt)</description>
 		<year>2015</year>
 		<publisher>Rewind Team</publisher>
 		<part name="flop1" interface="floppy_3">
@@ -8736,7 +8736,7 @@
 <!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
 	<!-- This is an old version, dated 201711 -->
 	<software name="cvaniasirua" cloneof="cvaniasi">
-		<description>Castlevania - Spectral Interlude (Rus)</description>
+		<description>Castlevania - Spectral Interlude (Rus) (alt)</description>
 		<year>2015</year>
 		<publisher>Rewind Team</publisher>
 		<part name="flop1" interface="floppy_3">
@@ -8749,7 +8749,7 @@
 <!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
 	<!-- This is an old version, dated 201711 -->
 	<software name="cvaniasipoa" cloneof="cvaniasi">
-		<description>Castlevania - Spectral Interlude (Pol)</description>
+		<description>Castlevania - Spectral Interlude (Pol) (alt)</description>
 		<year>2015</year>
 		<publisher>Rewind Team</publisher>
 		<part name="flop1" interface="floppy_3">

--- a/hash/specpls3_flop.xml
+++ b/hash/specpls3_flop.xml
@@ -1757,8 +1757,8 @@
 	</software>
 
 <!-- From "Sinclair ZX Spectrum - Applications - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
-	<software name="3dgamemkdro" cloneof="3dgamemk">
-		<description>3D Game Maker (Spain, Dro Soft)</description>
+	<software name="3dgamemksp" cloneof="3dgamemk">
+		<description>3D Game Maker (Spa)</description>
 		<year>1987</year>
 		<publisher>Dro Soft</publisher>
 		<part name="flop1" interface="floppy_3">
@@ -1769,8 +1769,8 @@
 	</software>
 
 <!-- From "Sinclair ZX Spectrum - Applications - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
-	<software name="3dgamemkzaf" cloneof="3dgamemk">
-		<description>3D Game Maker (Spain, Zafiro)</description>
+	<software name="3dgamemkspa" cloneof="3dgamemk">
+		<description>3D Game Maker (Spa) (alt)</description>
 		<year>1987</year>
 		<publisher>Zafiro Software Division</publisher>
 		<part name="flop1" interface="floppy_3">

--- a/hash/specpls3_flop.xml
+++ b/hash/specpls3_flop.xml
@@ -5897,13 +5897,13 @@
 		<description>Plus 3 Sports (alt)</description>
 		<year>1987</year>
 		<publisher>Mastertronic</publisher>
-		<part name="flop2" interface="floppy_3">
+		<part name="flop1" interface="floppy_3">
 			<feature name="part_id" value="Side A: Strike + Bump, Set, Spike!"/>
 			<dataarea name="flop" size="194816">
 				<rom name="plus 3 sports - strike (1987)(mastertronic).dsk" size="194816" crc="00518e1e" sha1="0e4e653ac7408039aeb711ecb08518504c9d6bb9" offset="0" />
 			</dataarea>
 		</part>
-		<part name="flop1" interface="floppy_3">
+		<part name="flop2" interface="floppy_3">
 			<feature name="part_id" value="Side B: Speed King 2"/>
 			<dataarea name="flop" size="194816">
 				<rom name="plus 3 sports - speed king 2 (1987)(mastertronic).dsk" size="194816" crc="19eb4e02" sha1="8c9b17e2456f262e3b1e8a4a8ac26aaca5d5a6eb" offset="0" />
@@ -15010,7 +15010,6 @@
 				<rom name="scapeghost (1989)(level 9 computing)(side a)[a][aka spook].dsk" size="194816" crc="1d10fcd4" sha1="221bf55fe048ef70dfb6b0a9e3c9bda2b04ab078" offset="0" />
 			</dataarea>
 		</part>
-		<publisher>Level 9 Computing</publisher>
 		<part name="flop2" interface="floppy_3">
 			<dataarea name="flop" size="194816">
 				<rom name="scapeghost (1989)(level 9 computing)(side b)[a][aka spook].dsk" size="194816" crc="c464a1e9" sha1="baf17b2ebba89cbb29af430be2399c05f03d4ad3" offset="0" />

--- a/hash/specpls3_flop.xml
+++ b/hash/specpls3_flop.xml
@@ -19788,7 +19788,6 @@
 	</software>
 
 	<!-- This image came from a dual-system Spectrum/Amstrad release (Side A: Spectrum, Side B: Amstrad) -->
-	<!-- Dump made with SAMdisk -->
 	<software name="navymovespa" cloneof="navymove">
 		<description>Navy Moves (Spa) (alt)</description>
 		<year>1988</year>

--- a/hash/specpls3_flop.xml
+++ b/hash/specpls3_flop.xml
@@ -2461,7 +2461,7 @@
 	</software>
 
 <!-- From "Sinclair ZX Spectrum - Applications - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
-	<software name="pawes" cloneof="paw">
+	<software name="pawsp" cloneof="paw">
 		<description>Professional Adventure Writer (Spa)</description>
 		<year>1986</year>
 		<publisher>Aventuras AD</publisher>
@@ -8395,7 +8395,7 @@
 	</software>
 
 <!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
-	<software name="bbrg" cloneof="bbrg">
+	<software name="bbrgsp" cloneof="bbrg">
 		<description>Buffalo Bill's Wild West Show (Spa)</description>
 		<year>1989</year>
 		<publisher>System 4</publisher>
@@ -8724,7 +8724,7 @@
 
 <!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
 	<software name="cvaniasiit" cloneof="cvaniasi">
-		<description>Castlevania - Spectral Interlude (Italian)</description>
+		<description>Castlevania - Spectral Interlude (Ita)</description>
 		<year>2015</year>
 		<publisher>Rewind Team</publisher>
 		<part name="flop1" interface="floppy_3">
@@ -8736,7 +8736,7 @@
 
 <!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
 	<software name="cvaniasiru" cloneof="cvaniasi">
-		<description>Castlevania - Spectral Interlude (Russian)</description>
+		<description>Castlevania - Spectral Interlude (Rus)</description>
 		<year>2015</year>
 		<publisher>Rewind Team</publisher>
 		<part name="flop1" interface="floppy_3">
@@ -8748,7 +8748,7 @@
 
 <!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
 	<software name="cvaniasipo" cloneof="cvaniasi">
-		<description>Castlevania - Spectral Interlude (Polish)</description>
+		<description>Castlevania - Spectral Interlude (Pol)</description>
 		<year>2015</year>
 		<publisher>Rewind Team</publisher>
 		<part name="flop1" interface="floppy_3">
@@ -9384,7 +9384,7 @@
 
 <!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
 	<!-- May be the same edition as the IPF -->
-	<software name="cyberno2" cloneof="cyberno2">
+	<software name="cyberno2a" cloneof="cyberno2">
 		<description>Cybernoid II - The Revenge (alt)</description>
 		<year>1988</year>
 		<publisher>Hewson Consultants</publisher>
@@ -11446,7 +11446,7 @@
 
 <!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
 	<!-- May be the same edition as the IPF -->
-	<software name="herolanca" name="herolanc">
+	<software name="herolanca" cloneof="herolanc">
 		<description>Heroes of the Lance (alt)</description>
 		<year>1988</year>
 		<publisher>U.S. Gold</publisher>
@@ -11581,8 +11581,8 @@
 	</software>
 
 <!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
-	<software name="hkma" cloneof="hkm">
-		<description>Human Killing Machine (alt)</description>
+	<software name="hkmb" cloneof="hkm">
+		<description>Human Killing Machine (alt 2)</description>
 		<year>1988</year>
 		<publisher>U.S. Gold</publisher>
 		<part name="flop1" interface="floppy_3">
@@ -11885,7 +11885,7 @@
 <!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
 	<!-- May be the same edition as the IPF -->
 	<software name="italia90a" cloneof="italia90">
-		<description>Italia '90 - World Cup Soccer</description>
+		<description>Italia '90 - World Cup Soccer (alt)</description>
 		<year>1989</year>
 		<publisher>Virgin Games</publisher>
 		<part name="flop1" interface="floppy_3">
@@ -12893,7 +12893,7 @@
 
 <!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
 	<!-- May be the same edition as the IPF -->
-	<software name="mickey" cloneof="mickey">
+	<software name="mickeya" cloneof="mickey">
 		<description>Mickey Mouse - The Computer Game (alt)</description>
 		<year>1988</year>
 		<publisher>Gremlin Graphics Software</publisher>
@@ -14023,7 +14023,7 @@
 
 <!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
 	<!-- May be the same edition as the IPF -->
-	<software name="pawn" cloneof="pawn">
+	<software name="pawna" cloneof="pawn">
 		<description>The Pawn v2.4 (alt)</description>
 		<year>1987</year>
 		<publisher>Rainbird Software</publisher>
@@ -14036,7 +14036,7 @@
 
 <!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
 	<!-- May be the same edition as the IPF -->
-	<software name="pawn" cloneof="pawn">
+	<software name="pawnb" cloneof="pawn">
 		<description>The Pawn v2.4 (alt 2)</description>
 		<year>1987</year>
 		<publisher>Rainbird Software</publisher>
@@ -14686,7 +14686,7 @@
 	</software>
 
 <!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
-	<software name="roadblst" cloneof="roadblst">
+	<software name="roadblstsp" cloneof="roadblst">
 		<description>Road Blasters (Spa)</description>
 		<year>1988</year>
 		<publisher>Erbe Software</publisher>
@@ -14699,7 +14699,7 @@
 
 <!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
 	<!-- May be the same edition as the IPF -->
-	<software name="roadblst" cloneof="roadblst">
+	<software name="roadblsta" cloneof="roadblst">
 		<description>Road Blasters (alt)</description>
 		<year>1988</year>
 		<publisher>U.S. Gold</publisher>
@@ -14793,7 +14793,7 @@
 
 <!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
 	<!-- May be the same edition as the IPF -->
-	<software name="rthunder" cloneof="rthunder">
+	<software name="rthundera" cloneof="rthunder">
 		<description>Rolling Thunder (alt)</description>
 		<year>1988</year>
 		<publisher>U.S. Gold</publisher>
@@ -15005,7 +15005,7 @@
 	</software>
 
 <!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
-	<software name="scapegho" cloneof="scapegho">
+	<software name="scapeghoa" cloneof="scapegho">
 		<description>Scapeghost (alt)</description>
 		<year>1989</year>
 		<publisher>Level 9 Computing</publisher>
@@ -16609,7 +16609,7 @@
 	</software>
 
 <!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
-	<software name="tiburon" cloneof="jaws">
+	<software name="jawssp">
 		<description>Tiburon</description>
 		<year>1989</year>
 		<publisher>Erbe Software</publisher>
@@ -17005,7 +17005,7 @@
 	</software>
 
 <!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
-	<software name="turrican" cloneof="turrican">
+	<software name="turricansp" cloneof="turrican">
 		<description>Turrican (Spa)</description>
 		<year>1990</year>
 		<publisher>Erbe Software</publisher>
@@ -19576,8 +19576,8 @@
 		</part>
 	</software>
 
-	<software name="Drazen Petrovic Basket (Erbe)">
-		<description>Drazen Petrovic Basket</description>
+	<software name="drazenpba" cloneof="drazenpb">
+		<description>Drazen Petrovic Basket (alt)</description>
 		<year>1989</year>
 		<publisher>Erbe Software</publisher>
 		<part name="flop1" interface="floppy_3">

--- a/hash/specpls3_flop.xml
+++ b/hash/specpls3_flop.xml
@@ -2416,7 +2416,7 @@
 	<software name="ocpartst">
 		<description>The OCP Art Studio</description>
 		<year>1985</year>
-		<publisher>Rainbird</publisher>
+		<publisher>Rainbird Software</publisher>
 		<part name="flop1" interface="floppy_3">
 			<dataarea name="flop" size="194816">
 				<rom name="ocp art studio, the (1985)(rainbird)[m useless soft].dsk" size="194816" crc="696c593c" sha1="1b1a0307bd265a55d7f4a701acedbbc4cb34a724" offset="0" />
@@ -2428,7 +2428,7 @@
 	<software name="ocpartsta" cloneof="ocpartst">
 		<description>The OCP Art Studio (alt)</description>
 		<year>1985</year>
-		<publisher>Rainbird</publisher>
+		<publisher>Rainbird Software</publisher>
 		<part name="flop1" interface="floppy_3">
 			<dataarea name="flop" size="194816">
 				<rom name="ocp art studio, the (1985)(rainbird)[m useless soft][a].dsk" size="194816" crc="fcc3298f" sha1="1eed3410b0810b3854a07acd1eb0c371571c501d" offset="0" />
@@ -2440,7 +2440,7 @@
 	<software name="ocpartstb" cloneof="ocpartst">
 		<description>The OCP Art Studio (alt 2)</description>
 		<year>1985</year>
-		<publisher>Rainbird</publisher>
+		<publisher>Rainbird Software</publisher>
 		<part name="flop1" interface="floppy_3">
 			<dataarea name="flop" size="194816">
 				<rom name="ocp art studio, the (1985)(rainbird)[m useless soft][a2].dsk" size="194816" crc="a9652e70" sha1="4f329c43beaae11bca917fb6928916f4f805baa0" offset="0" />
@@ -3647,7 +3647,7 @@
 	<software name="anbigdsk">
 		<description>Another Big Disk</description>
 		<year>1991</year>
-		<publisher>Zenobi</publisher>
+		<publisher>Zenobi Software</publisher>
 		<part name="flop1" interface="floppy_3">
 			<feature name="part_id" value="Side A: The Menagerie + The Miser + Bog of Brit"/>
 			<dataarea name="flop" size="194816">
@@ -3721,7 +3721,7 @@
 	<software name="arnadv12">
 		<description>Arnold the Adventurer 1 + 2</description>
 		<year>19??</year>
-		<publisher>Zenobi</publisher>
+		<publisher>Zenobi Software</publisher>
 		<part name="flop1" interface="floppy_3">
 			<dataarea name="flop" size="194816">
 				<rom name="arnold the adventurer 1 + 2 (19xx)(zenobi).dsk" size="194816" crc="2de22fac" sha1="b721610fbf50a964560810e678c55fae31d2a0d4" offset="0" />
@@ -3733,7 +3733,7 @@
 	<software name="balrogbd">
 		<description>Balrog's Big Disk</description>
 		<year>1991</year>
-		<publisher>Zenobi</publisher>
+		<publisher>Zenobi Software</publisher>
 		<part name="flop1" interface="floppy_3">
 			<feature name="part_id" value="Side A: Pawns of War + Crack City + Stalker"/>
 			<dataarea name="flop" size="194816">
@@ -3752,7 +3752,7 @@
 	<software name="balrtril">
 		<description>The Balrogian Trilogy</description>
 		<year>1990</year>
-		<publisher>Zenobi</publisher>
+		<publisher>Zenobi Software</publisher>
 		<part name="flop1" interface="floppy_3">
 			<feature name="part_id" value="Side A: Fuddo &amp; Slam + An Everyday Tale of a Seeker of Gold"/>
 			<dataarea name="flop" size="194816">
@@ -3771,7 +3771,7 @@
 	<software name="barddraq">
 		<description>The Bardic Rites + Dragon-Quest</description>
 		<year>1994</year>
-		<publisher>Zenobi</publisher>
+		<publisher>Zenobi Software</publisher>
 		<part name="flop1" interface="floppy_3">
 			<feature name="part_id" value="Side A: The Bardic Rites"/>
 			<dataarea name="flop" size="194816">
@@ -3790,7 +3790,7 @@
 	<software name="bartbret">
 		<description>Bart Bear + The Return of Bart Bear</description>
 		<year>19??</year>
-		<publisher>Zenobi</publisher>
+		<publisher>Zenobi Software</publisher>
 		<part name="flop1" interface="floppy_3">
 			<dataarea name="flop" size="194816">
 				<rom name="bart bear - the return of bart bear (19xx)(zenobi).dsk" size="194816" crc="0396887f" sha1="c2f8db9fea7b7fc90fd043d7e509691a32856b2b" offset="0" />
@@ -3802,7 +3802,7 @@
 	<software name="bstclles">
 		<description>The Best of Clive and Les</description>
 		<year>1991</year>
-		<publisher>Zenobi</publisher>
+		<publisher>Zenobi Software</publisher>
 		<part name="flop1" interface="floppy_3">
 			<dataarea name="flop" size="194816">
 				<rom name="best of clive and les, the - the little wandering guru + nightwing + demi-god (1991)(zenobi).dsk" size="194816" crc="f577d853" sha1="4fd34aecf2a22be831ebfb498724c1b52b593e92" offset="0" />
@@ -3833,7 +3833,7 @@
 	<software name="bogbmena">
 		<description>Bog of Brit + The Menagerie</description>
 		<year>1990</year>
-		<publisher>Zenobi</publisher>
+		<publisher>Zenobi Software</publisher>
 		<part name="flop1" interface="floppy_3">
 			<dataarea name="flop" size="194816">
 				<rom name="bog of brit + menagerie, the (1990)(zenobi)[re-release].dsk" size="194816" crc="dc47c945" sha1="1d999f7809037b4207bb5feeba9f52172edb1cc3" offset="0" />
@@ -4052,7 +4052,7 @@
 	<software name="dicksgal">
 		<description>Dicks Galore</description>
 		<year>1992</year>
-		<publisher>Zenobi</publisher>
+		<publisher>Zenobi Software</publisher>
 		<part name="flop1" interface="floppy_3">
 			<feature name="part_id" value="Side A: Robin of Sherlock"/>
 			<dataarea name="flop" size="197376">
@@ -4153,7 +4153,7 @@
 	<software name="doublecl">
 		<description>Double Classic</description>
 		<year>1988</year>
-		<publisher>Zenobi</publisher>
+		<publisher>Zenobi Software</publisher>
 		<part name="flop1" interface="floppy_3">
 			<feature name="part_id" value="Side A: Diablo!"/>
 			<dataarea name="flop" size="194816">
@@ -4311,7 +4311,7 @@
 	<software name="evenyeta">
 		<description>Even Yet Another Big Disk</description>
 		<year>1991</year>
-		<publisher>Zenobi</publisher>
+		<publisher>Zenobi Software</publisher>
 		<part name="flop1" interface="floppy_3">
 			<feature name="part_id" value="Side A: The Dogboy + Kobyashi Ag'Kwo - A Return to Naru"/>
 			<dataarea name="flop" size="194816">
@@ -4349,7 +4349,7 @@
 	<software name="fyabdisk">
 		<description>Found Yet Another Big Disk</description>
 		<year>1991</year>
-		<publisher>Zenobi</publisher>
+		<publisher>Zenobi Software</publisher>
 		<part name="flop1" interface="floppy_3">
 			<feature name="part_id" value="Side A: The End is Nigh"/>
 			<dataarea name="flop" size="194816">
@@ -4412,7 +4412,7 @@
 	<software name="gaggeorg">
 		<description>Gaggles of George</description>
 		<year>1996</year>
-		<publisher>Zenobi</publisher>
+		<publisher>Zenobi Software</publisher>
 		<part name="flop1" interface="floppy_3">
 			<feature name="part_id" value="Side A: Brian - The Novice Barbarian + A Fistful of Necronomicons"/>
 			<dataarea name="flop" size="194816">
@@ -4431,7 +4431,7 @@
 	<software name="gameover">
 		<description>Game Over + Game Over 2</description>
 		<year>19??</year>
-		<publisher>Imagine</publisher>
+		<publisher>Imagine Software</publisher>
 		<part name="flop1" interface="floppy_3">
 			<feature name="part_id" value="Side A: Game Over"/>
 			<dataarea name="flop" size="101888">
@@ -4611,7 +4611,7 @@
 	<software name="hairytoe">
 		<description>Hairy Toes</description>
 		<year>1992</year>
-		<publisher>Zenobi</publisher>
+		<publisher>Zenobi Software</publisher>
 		<part name="flop1" interface="floppy_3">
 			<feature name="part_id" value="Side A: Bored of the Rings"/>
 			<dataarea name="flop" size="194816">
@@ -4630,7 +4630,7 @@
 	<software name="handfham">
 		<description>A Handful of Hamsters</description>
 		<year>1993</year>
-		<publisher>Zenobi</publisher>
+		<publisher>Zenobi Software</publisher>
 		<part name="flop1" interface="floppy_3">
 			<feature name="part_id" value="Side A: Brian + Aunt Velma + Desmond and Gertrude"/>
 			<dataarea name="flop" size="194816">
@@ -4840,7 +4840,7 @@
 	<software name="jennybd1">
 		<description>Jenny's Big Disk Vol 1</description>
 		<year>1991</year>
-		<publisher>Zenobi</publisher>
+		<publisher>Zenobi Software</publisher>
 		<part name="flop1" interface="floppy_3">
 			<feature name="part_id" value="Side A: Behold Atlantis"/>
 			<dataarea name="flop" size="194816">
@@ -4859,7 +4859,7 @@
 	<software name="jennybd2">
 		<description>Jenny's Big Disk Vol 2</description>
 		<year>1990</year>
-		<publisher>Zenobi</publisher>
+		<publisher>Zenobi Software</publisher>
 		<part name="flop1" interface="floppy_3">
 			<feature name="part_id" value="Side A: The Lost Temple"/>
 			<dataarea name="flop" size="194816">
@@ -4878,7 +4878,7 @@
 	<software name="jenynbd1">
 		<description>Jenny's Next Big Disk Vol 1</description>
 		<year>1991</year>
-		<publisher>Zenobi</publisher>
+		<publisher>Zenobi Software</publisher>
 		<part name="flop1" interface="floppy_3">
 			<feature name="part_id" value="Side A: The Curse of Calutha"/>
 			<dataarea name="flop" size="194816">
@@ -4897,7 +4897,7 @@
 	<software name="jenynbd2">
 		<description>Jenny's Next Big Disk Vol 2</description>
 		<year>1992</year>
-		<publisher>Zenobi</publisher>
+		<publisher>Zenobi Software</publisher>
 		<part name="flop1" interface="floppy_3">
 			<feature name="part_id" value="Side A: Laskar's Crystals"/>
 			<dataarea name="flop" size="209408">
@@ -5016,7 +5016,7 @@
 	<software name="jeweldar">
 		<description>Jewels of Darkness</description>
 		<year>1986</year>
-		<publisher>Rainbird</publisher>
+		<publisher>Rainbird Software</publisher>
 		<part name="flop1" interface="floppy_3">
 			<dataarea name="flop" size="194816">
 				<rom name="jewels of darkness (1986)(rainbird).dsk" size="194816" crc="1b1a7650" sha1="da619ff04356ce9ae0f22cf0eeabe2dc39aa918e" offset="0" />
@@ -5028,7 +5028,7 @@
 	<software name="kidnafps">
 		<description>Kidnapped + For Pete's Sake</description>
 		<year>1993</year>
-		<publisher>Zenobi</publisher>
+		<publisher>Zenobi Software</publisher>
 		<part name="flop1" interface="floppy_3">
 			<feature name="part_id" value="Side A: Kidnapped"/>
 			<dataarea name="flop" size="195121">
@@ -5047,7 +5047,7 @@
 	<software name="konaccol">
 		<description>Konami's Arcade Collection</description>
 		<year>1988</year>
-		<publisher>Imagine</publisher>
+		<publisher>Imagine Software</publisher>
 		<part name="flop1" interface="floppy_3">
 			<feature name="part_id" value="Disk 1, Side A: Shao-Lin's Road + Jail Break + Nemesis"/>
 			<dataarea name="flop" size="214784">
@@ -5097,7 +5097,7 @@
 	<software name="lotbdsks">
 		<description>Last of the Big Disks</description>
 		<year>1993</year>
-		<publisher>Zenobi</publisher>
+		<publisher>Zenobi Software</publisher>
 		<part name="flop1" interface="floppy_3">
 			<feature name="part_id" value="Side A: Kidnapped + Celtic Carnage + Personal Computer Whirled"/>
 			<dataarea name="flop" size="194816">
@@ -5198,7 +5198,7 @@
 	<software name="loflaur1">
 		<description>Loads of Laurence Vol. 1</description>
 		<year>1996</year>
-		<publisher>Zenobi</publisher>
+		<publisher>Zenobi Software</publisher>
 		<part name="flop1" interface="floppy_3">
 			<feature name="part_id" value="Side A: There's a Bomb Under Parliament + The Mummy's Crypt"/>
 			<dataarea name="flop" size="194816">
@@ -5217,7 +5217,7 @@
 	<software name="loflaur2">
 		<description>Loads of Laurence Vol. 2</description>
 		<year>1996</year>
-		<publisher>Zenobi</publisher>
+		<publisher>Zenobi Software</publisher>
 		<part name="flop1" interface="floppy_3">
 			<feature name="part_id" value="Side A: The Golden Pyramid + Lost in Time + Meltdown"/>
 			<dataarea name="flop" size="194816">
@@ -5401,7 +5401,7 @@
 	<software name="micfmadp">
 		<description>Microfair Madness Plus</description>
 		<year>1991</year>
-		<publisher>Zenobi</publisher>
+		<publisher>Zenobi Software</publisher>
 		<part name="flop1" interface="floppy_3">
 			<feature name="part_id" value="Side A"/>
 			<dataarea name="flop" size="194816">
@@ -5476,7 +5476,7 @@
 	<software name="nopehiao">
 		<description>Nope Here's Another One</description>
 		<year>1993</year>
-		<publisher>Zenobi</publisher>
+		<publisher>Zenobi Software</publisher>
 		<part name="flop1" interface="floppy_3">
 			<feature name="part_id" value="Side A: Diarmid I + For Pete's Sake"/>
 			<dataarea name="flop" size="194816">
@@ -5495,7 +5495,7 @@
 	<software name="notanobd">
 		<description>Not Another Big Disk</description>
 		<year>1992</year>
-		<publisher>Zenobi</publisher>
+		<publisher>Zenobi Software</publisher>
 		<part name="flop1" interface="floppy_3">
 			<feature name="part_id" value="Side A: The Fisher King + Darkest Road II - 'Twas a Time of Dread"/>
 			<dataarea name="flop" size="194816">
@@ -5514,7 +5514,7 @@
 	<software name="ohshiabd">
 		<description>Oh Sh1t Another Big Disk</description>
 		<year>1993</year>
-		<publisher>Zenobi</publisher>
+		<publisher>Zenobi Software</publisher>
 		<part name="flop1" interface="floppy_3">
 			<feature name="part_id" value="Side A: Project Nova + Arnold the Adventurer III"/>
 			<dataarea name="flop" size="194816">
@@ -5533,7 +5533,7 @@
 	<software name="onemorbd">
 		<description>One More Big Disk</description>
 		<year>1992</year>
-		<publisher>Zenobi</publisher>
+		<publisher>Zenobi Software</publisher>
 		<part name="flop1" interface="floppy_3">
 			<feature name="part_id" value="Side A: The Violator of Voodoo + The Amulet of Darath + The Taxman Cometh"/>
 			<dataarea name="flop" size="194816">
@@ -5932,7 +5932,7 @@
 	<software name="probtlbd">
 		<description>Probably the Last Big Disk</description>
 		<year>1995</year>
-		<publisher>Zenobi</publisher>
+		<publisher>Zenobi Software</publisher>
 		<part name="flop1" interface="floppy_3">
 			<feature name="part_id" value="Side A: Perseus + The Final Demand"/>
 			<dataarea name="flop" size="194816">
@@ -5951,7 +5951,7 @@
 	<software name="prjnbote">
 		<description>Project Nova + Beginning of the End</description>
 		<year>19??</year>
-		<publisher>Zenobi</publisher>
+		<publisher>Zenobi Software</publisher>
 		<part name="flop1" interface="floppy_3">
 			<feature name="part_id" value="Side A: Project Nova"/>
 			<dataarea name="flop" size="194816">
@@ -6037,7 +6037,7 @@
 	<software name="samuahos">
 		<description>Sam's Un-Excellent Adventure + The Hospital</description>
 		<year>1994</year>
-		<publisher>Zenobi</publisher>
+		<publisher>Zenobi Software</publisher>
 		<part name="flop1" interface="floppy_3">
 			<dataarea name="flop" size="194816">
 				<rom name="sam's un-excellent adventure + the hospital - sam's un-excellent adventure (1994)(zenobi).dsk" size="194816" crc="c4293106" sha1="de58f5aaa5be5a3af953068b179e9b8fb72377bd" offset="0" />
@@ -6061,7 +6061,7 @@
 	<software name="silicond">
 		<description>Silicon Dreams</description>
 		<year>1986</year>
-		<publisher>Rainbird</publisher>
+		<publisher>Rainbird Software</publisher>
 		<part name="flop1" interface="floppy_3">
 			<feature name="part_id" value="Side A"/>
 			<dataarea name="flop" size="194816">
@@ -6167,7 +6167,7 @@
 	<software name="smallcol">
 		<description>A Small Collection of Hamster Droppings</description>
 		<year>1993</year>
-		<publisher>Zenobi</publisher>
+		<publisher>Zenobi Software</publisher>
 		<part name="flop1" interface="floppy_3">
 			<feature name="part_id" value="Side A: The Life of a Lone Electron + The Quest for the Holy"/>
 			<dataarea name="flop" size="194816">
@@ -6260,7 +6260,7 @@
 	<software name="stillabd">
 		<description>Still Another Big Disk</description>
 		<year>1992</year>
-		<publisher>Zenobi</publisher>
+		<publisher>Zenobi Software</publisher>
 		<part name="flop1" interface="floppy_3">
 			<feature name="part_id" value="Side A: Darkest Road III - The Unborn One + Phoenix"/>
 			<dataarea name="flop" size="194816">
@@ -6279,7 +6279,7 @@
 	<software name="stilombd">
 		<description>Still One More Big Disk</description>
 		<year>19??</year>
-		<publisher>Zenobi</publisher>
+		<publisher>Zenobi Software</publisher>
 		<part name="flop1" interface="floppy_3">
 			<feature name="part_id" value="Side A: The Tears of the Moon + The Mines of Lithiad"/>
 			<dataarea name="flop" size="194816">
@@ -6298,7 +6298,7 @@
 	<software name="stufmabd">
 		<description>Stuff Me Another Big Disk</description>
 		<year>19??</year>
-		<publisher>Zenobi</publisher>
+		<publisher>Zenobi Software</publisher>
 		<part name="flop1" interface="floppy_3">
 			<feature name="part_id" value="Side A: Aztec Assault + The Lost Twilight"/>
 			<dataarea name="flop" size="194816">
@@ -6454,7 +6454,7 @@
 	<software name="taxbills">
 		<description>Tax Bills</description>
 		<year>19??</year>
-		<publisher>Zenobi</publisher>
+		<publisher>Zenobi Software</publisher>
 		<part name="flop1" interface="floppy_3">
 			<dataarea name="flop" size="194816">
 				<rom name="tax bills - the taxman cometh + tax returns + the final demand (19xx)(zenobi).dsk" size="194816" crc="cc30a3da" sha1="fa056d97fdf52341229aab72d09d9396fc286a17" offset="0" />
@@ -6581,7 +6581,7 @@
 	<software name="travtals">
 		<description>Traveller's Tales</description>
 		<year>1993</year>
-		<publisher>Zenobi</publisher>
+		<publisher>Zenobi Software</publisher>
 		<part name="flop1" interface="floppy_3">
 			<feature name="part_id" value="Side A: Phoenix + The Violator of Voodoo"/>
 			<dataarea name="flop" size="194816">
@@ -6669,7 +6669,7 @@
 	<software name="whoopabd">
 		<description>Whoops Another Big Disk</description>
 		<year>1994</year>
-		<publisher>Zenobi</publisher>
+		<publisher>Zenobi Software</publisher>
 		<part name="flop1" interface="floppy_3">
 			<feature name="part_id" value="Side A: Leopold the Minstrel"/>
 			<dataarea name="flop" size="194816">
@@ -6744,7 +6744,7 @@
 	<software name="yetanobd">
 		<description>Yet Another Big Disk</description>
 		<year>19??</year>
-		<publisher>Zenobi</publisher>
+		<publisher>Zenobi Software</publisher>
 		<part name="flop1" interface="floppy_3">
 			<feature name="part_id" value="Side A: Agatha's Folly + Arnold the Adventurer"/>
 			<dataarea name="flop" size="194816">
@@ -6763,7 +6763,7 @@
 	<software name="yippombd">
 		<description>Yippee One More Big Disk</description>
 		<year>1993</year>
-		<publisher>Zenobi</publisher>
+		<publisher>Zenobi Software</publisher>
 		<part name="flop1" interface="floppy_3">
 			<feature name="part_id" value="Side A: Stranded + Out of the Limelight"/>
 			<dataarea name="flop" size="194816">
@@ -7178,7 +7178,7 @@
 	<software name="abadcrima" cloneof="abadcrim">
 		<description>La Abadia del Crimen (alt)</description>
 		<year>1988</year>
-		<publisher>MCM</publisher>
+		<publisher>MCM Software</publisher>
 		<part name="flop1" interface="floppy_3">
 			<dataarea name="flop" size="191744">
 				<rom name="abadia del crimen, la (1988)(mcm)(es)[re-release].dsk" size="191744" crc="1052ece9" sha1="d94b16011f80428d49edb0af7dec4d73e13021f2" offset="0" />
@@ -7190,7 +7190,7 @@
 	<software name="afighter">
 		<description>Action Fighter</description>
 		<year>1989</year>
-		<publisher>Firebird</publisher>
+		<publisher>Firebird Software</publisher>
 		<part name="flop1" interface="floppy_3">
 			<dataarea name="flop" size="194816">
 				<rom name="action fighter (1989)(firebird).dsk" size="194816" crc="2db88300" sha1="f8511df3b99924755ca52ec3f1b0ec175e18b7c4" offset="0" />
@@ -7316,7 +7316,7 @@
 	<software name="agathafo">
 		<description>Agatha's Folly</description>
 		<year>1989</year>
-		<publisher>Zenobi</publisher>
+		<publisher>Zenobi Software</publisher>
 		<part name="flop1" interface="floppy_3">
 			<feature name="part_id" value="Side A"/>
 			<dataarea name="flop" size="194816">
@@ -7335,7 +7335,7 @@
 	<software name="agathafoa" cloneof="agathafo">
 		<description>Agatha's Folly (alt)</description>
 		<year>1989</year>
-		<publisher>Zenobi</publisher>
+		<publisher>Zenobi Software</publisher>
 		<part name="flop1" interface="floppy_3">
 			<dataarea name="flop" size="194816">
 				<rom name="agatha's folly (1989)(zenobi).dsk" size="194816" crc="6ac0d7e5" sha1="d8e2f4cc3c49087c14dd9b73996d17a2186f45fd" offset="0" />
@@ -7366,7 +7366,7 @@
 	<software name="alienres">
 		<description>Alien Research Centre</description>
 		<year>1990</year>
-		<publisher>Zenobi</publisher>
+		<publisher>Zenobi Software</publisher>
 		<part name="flop1" interface="floppy_3">
 			<dataarea name="flop" size="194816">
 				<rom name="alien research centre (1990)(zenobi).dsk" size="194816" crc="db2bc7a4" sha1="4c9aade94605af27eb7d50a82a00bc1053ce87b8" offset="0" />
@@ -7426,7 +7426,7 @@
 	<software name="allinada">
 		<description>All in a Day's Work</description>
 		<year>1996</year>
-		<publisher>Zenobi</publisher>
+		<publisher>Zenobi Software</publisher>
 		<part name="flop1" interface="floppy_3">
 			<feature name="part_id" value="Side A"/>
 			<dataarea name="flop" size="194816">
@@ -7531,7 +7531,7 @@
 	<software name="amuldara">
 		<description>The Amulet of Darath</description>
 		<year>1992</year>
-		<publisher>Zenobi</publisher>
+		<publisher>Zenobi Software</publisher>
 		<part name="flop1" interface="floppy_3">
 			<dataarea name="flop" size="194816">
 				<rom name="amulet of darath, the (1992)(zenobi).dsk" size="194816" crc="6c2d3b50" sha1="6fe5169df72e34a41e0ea557ae1c85540a4b8600" offset="0" />
@@ -7543,7 +7543,7 @@
 	<software name="apprenti">
 		<description>The Apprentice</description>
 		<year>1993</year>
-		<publisher>Zenobi</publisher>
+		<publisher>Zenobi Software</publisher>
 		<part name="flop1" interface="floppy_3">
 			<dataarea name="flop" size="194816">
 				<rom name="apprentice, the (1993)(zenobi).dsk" size="194816" crc="86e40adc" sha1="f8b6f9a8fb83c9e004aeb9e84dd7989323adb2cb" offset="0" />
@@ -7555,7 +7555,7 @@
 	<software name="april7th">
 		<description>April 7th</description>
 		<year>1992</year>
-		<publisher>Zenobi</publisher>
+		<publisher>Zenobi Software</publisher>
 		<part name="flop1" interface="floppy_3">
 			<dataarea name="flop" size="194816">
 				<rom name="april 7th (1992)(zenobi).dsk" size="194816" crc="f2ee2bd1" sha1="501de56a06afc02e13623eab143664754acd9248" offset="0" />
@@ -7603,7 +7603,7 @@
 	<software name="arkanoi2">
 		<description>Arkanoid - Revenge of Doh</description>
 		<year>1988</year>
-		<publisher>Imagine</publisher>
+		<publisher>Imagine Software</publisher>
 		<part name="flop1" interface="floppy_3">
 			<dataarea name="flop" size="214784">
 				<rom name="arkanoid - revenge of doh (1988)(imagine)[aka arkanoid 2].dsk" size="214784" crc="e5dafb18" sha1="9e3d9552dd438d3a224ea19fc5e19730e1738bef" offset="0" />
@@ -7615,7 +7615,7 @@
 	<software name="arntadv3">
 		<description>Arnold the Adventurer III - This Time It's Personal</description>
 		<year>1992</year>
-		<publisher>Zenobi</publisher>
+		<publisher>Zenobi Software</publisher>
 		<part name="flop1" interface="floppy_3">
 			<dataarea name="flop" size="194816">
 				<rom name="arnold the adventurer iii - this time it's personal (1992)(zenobi).dsk" size="194816" crc="c5159e2b" sha1="f1916459527b2f153849d05624cad97c3dd650f4" offset="0" />
@@ -7703,7 +7703,7 @@
 	<software name="aurascop">
 		<description>Aura-Scope</description>
 		<year>1991</year>
-		<publisher>Zenobi</publisher>
+		<publisher>Zenobi Software</publisher>
 		<part name="flop1" interface="floppy_3">
 			<dataarea name="flop" size="194816">
 				<rom name="aura-scope (1991)(zenobi)[aka horrorscope][re-release].dsk" size="194816" crc="06e2ce3b" sha1="4da4ad217593a8e6301bc2800a2a836bd7417ea1" offset="0" />
@@ -7783,7 +7783,7 @@
 	<software name="aztcaslt">
 		<description>Aztec Assault</description>
 		<year>1992</year>
-		<publisher>Zenobi</publisher>
+		<publisher>Zenobi Software</publisher>
 		<part name="flop1" interface="floppy_3">
 			<dataarea name="flop" size="194816">
 				<rom name="aztec assault (1992)(zenobi).dsk" size="194816" crc="9c23191d" sha1="d6ae6a418a37a5467e2c3ff969f5e1aeeb2e6a61" offset="0" />
@@ -7845,7 +7845,7 @@
 	<software name="baddudes">
 		<description>Bad Dudes vs. Dragon Ninja</description>
 		<year>1988</year>
-		<publisher>Imagine</publisher>
+		<publisher>Imagine Software</publisher>
 		<part name="flop1" interface="floppy_3">
 			<dataarea name="flop" size="144896">
 				<rom name="bad dudes vs. dragon ninja (1988)(imagine).dsk" size="144896" crc="62c50d95" sha1="bc00cd74d7ef98d43ca9bfafe4edbea825d30c0c" offset="0" />
@@ -7870,7 +7870,7 @@
 	<software name="balrgcat">
 		<description>The Balrog and the Cat</description>
 		<year>1988</year>
-		<publisher>Zenobi</publisher>
+		<publisher>Zenobi Software</publisher>
 		<part name="flop1" interface="floppy_3">
 			<dataarea name="flop" size="194816">
 				<rom name="balrog and the cat, the (1988)(zenobi).dsk" size="194816" crc="646814a2" sha1="3548ee10ccc4a77ebc96b5b79c037aac85d475ce" offset="0" />
@@ -7949,7 +7949,7 @@
 	<software name="bardrite">
 		<description>The Bardic Rites</description>
 		<year>1994</year>
-		<publisher>Zenobi</publisher>
+		<publisher>Zenobi Software</publisher>
 		<part name="flop1" interface="floppy_3">
 			<dataarea name="flop" size="194816">
 				<rom name="bardic rites, the (1994)(zenobi).dsk" size="194816" crc="99c8df43" sha1="627fd79979146655854164c8b20165ef9f2045aa" offset="0" />
@@ -8045,7 +8045,7 @@
 	<software name="thebeast">
 		<description>The Beast</description>
 		<year>1988</year>
-		<publisher>Zenobi</publisher>
+		<publisher>Zenobi Software</publisher>
 		<part name="flop1" interface="floppy_3">
 			<dataarea name="flop" size="194816">
 				<rom name="beast, the (1988)(zenobi)[re-release].dsk" size="194816" crc="33cc73f0" sha1="747f285b901f388aed5dd547cf5cc2740833d50b" offset="0" />
@@ -8081,7 +8081,7 @@
 	<software name="begotend">
 		<description>The Beginning of the End</description>
 		<year>1992</year>
-		<publisher>Zenobi</publisher>
+		<publisher>Zenobi Software</publisher>
 		<part name="flop1" interface="floppy_3">
 			<dataarea name="flop" size="194816">
 				<rom name="beginning of the end, the (1992)(zenobi).dsk" size="194816" crc="d7513346" sha1="61c9b420a52fa920374b9f2ac7b326ed6bc1c8ed" offset="0" />
@@ -8093,7 +8093,7 @@
 	<software name="behclod4">
 		<description>Behind Closed Doors 4 - Balrog's Day Out</description>
 		<year>1989</year>
-		<publisher>Zenobi</publisher>
+		<publisher>Zenobi Software</publisher>
 		<part name="flop1" interface="floppy_3">
 			<dataarea name="flop" size="194816">
 				<rom name="behind closed doors 4 - balrog's day out (1989)(zenobi).dsk" size="194816" crc="dc5066f6" sha1="500d838a4327e72ef829c31b31fedb755cba4a5c" offset="0" />
@@ -8105,7 +8105,7 @@
 	<software name="bermtria">
 		<description>The Bermuda Triangle</description>
 		<year>1991</year>
-		<publisher>Zenobi</publisher>
+		<publisher>Zenobi Software</publisher>
 		<part name="flop1" interface="floppy_3">
 			<dataarea name="flop" size="194816">
 				<rom name="bermuda triangle, the (1991)(zenobi).dsk" size="194816" crc="1f56095c" sha1="8515f73018bccab506daaae8274ca394eda9c8b5" offset="0" />
@@ -8184,7 +8184,7 @@
 	<software name="bticepalsp" cloneof="bticepal">
 		<description>Beyond the Ice Palace (Spa)</description>
 		<year>1988</year>
-		<publisher>MCM</publisher>
+		<publisher>MCM Software</publisher>
 		<part name="flop1" interface="floppy_3">
 			<dataarea name="flop" size="194816">
 				<rom name="beyond the ice palace (1988)(mcm)(es)(en)[re-release].dsk" size="194816" crc="a547670b" sha1="cde06121712e3beeeb1faca842a1731f2dab850b" offset="0" />
@@ -8208,7 +8208,7 @@
 	<software name="blacklam">
 		<description>Black Lamp</description>
 		<year>1988</year>
-		<publisher>Firebird</publisher>
+		<publisher>Firebird Software</publisher>
 		<part name="flop1" interface="floppy_3">
 			<dataarea name="flop" size="78080">
 				<rom name="black lamp (1988)(firebird).dsk" size="78080" crc="e90869b8" sha1="c98bc347c956d2b0ee2542fc07b171237a324ad5" offset="0" />
@@ -8220,7 +8220,7 @@
 	<software name="blacktwr">
 		<description>The Black Tower</description>
 		<year>1984</year>
-		<publisher>Zenobi</publisher>
+		<publisher>Zenobi Software</publisher>
 		<part name="flop1" interface="floppy_3">
 			<dataarea name="flop" size="194816">
 				<rom name="black tower, the (1984)(zenobi).dsk" size="194816" crc="d3b64e66" sha1="80f9a5b6eeafcc185019b818ac40e6786f57bef5" offset="0" />
@@ -8314,7 +8314,7 @@
 	<software name="boydfile">
 		<description>The Boyd File</description>
 		<year>1990</year>
-		<publisher>Zenobi</publisher>
+		<publisher>Zenobi Software</publisher>
 		<part name="flop1" interface="floppy_3">
 			<dataarea name="flop" size="194816">
 				<rom name="boyd file, the (1990)(zenobi).dsk" size="194816" crc="a10f7dcb" sha1="338836359459d8adfb54bd2c9e99bc683dad71db" offset="0" />
@@ -8338,7 +8338,7 @@
 	<software name="btnovbar">
 		<description>Brian - The Novice Barbarian</description>
 		<year>1994</year>
-		<publisher>Zenobi</publisher>
+		<publisher>Zenobi Software</publisher>
 		<part name="flop1" interface="floppy_3">
 			<dataarea name="flop" size="194816">
 				<rom name="brian - the novice barbarian (1994)(zenobi).dsk" size="194816" crc="5118b277" sha1="71138e6dd21e30728c1a388b1eaa25efbd93f8ff" offset="0" />
@@ -8374,7 +8374,7 @@
 	<software name="bublbobl">
 		<description>Bubble Bobble</description>
 		<year>1987</year>
-		<publisher>Firebird</publisher>
+		<publisher>Firebird Software</publisher>
 		<part name="flop1" interface="floppy_3">
 			<dataarea name="flop" size="78080">
 				<rom name="bubble bobble (1987)(firebird).dsk" size="78080" crc="ad820cf2" sha1="dc43630be33bdf4279d6cf51d2539b8a3e4ac768" offset="0" />
@@ -8459,7 +8459,7 @@
 	<software name="bugsy">
 		<description>Bugsy</description>
 		<year>1986</year>
-		<publisher>Zenobi</publisher>
+		<publisher>Zenobi Software</publisher>
 		<part name="flop1" interface="floppy_3">
 			<dataarea name="flop" size="194816">
 				<rom name="bugsy (1986)(zenobi)[re-release].dsk" size="194816" crc="60b11040" sha1="6d3744cec7aa20dda6d7edf7ad4420fed318b66e" offset="0" />
@@ -8642,7 +8642,7 @@
 	<software name="carrierca" cloneof="carrierc">
 		<description>Carrier Command (alt)</description>
 		<year>1989</year>
-		<publisher>Rainbird</publisher>
+		<publisher>Rainbird Software</publisher>
 		<part name="flop1" interface="floppy_3">
 			<dataarea name="flop" size="194816">
 				<rom name="carrier command (1989)(rainbird)[passworded].dsk" size="194816" crc="dc5836b6" sha1="834acdb689df5ce1fae378830fd40706176a1759" offset="0" />
@@ -8654,7 +8654,7 @@
 	<software name="cotbehsm">
 		<description>The Case of the Beheaded Smuggler</description>
 		<year>1988</year>
-		<publisher>Zenobi</publisher>
+		<publisher>Zenobi Software</publisher>
 		<part name="flop1" interface="floppy_3">
 			<dataarea name="flop" size="194816">
 				<rom name="case of the beheaded smuggler, the (1988)(zenobi)[re-release].dsk" size="194816" crc="b6283daf" sha1="ae1fdb8f733286d58242c872fa43a48d6dd2c2e3" offset="0" />
@@ -8762,7 +8762,7 @@
 	<software name="celtcarn">
 		<description>Celtic Carnage</description>
 		<year>1993</year>
-		<publisher>Zenobi</publisher>
+		<publisher>Zenobi Software</publisher>
 		<part name="flop1" interface="floppy_3">
 			<dataarea name="flop" size="194816">
 				<rom name="celtic carnage (1993)(zenobi).dsk" size="194816" crc="505f7fca" sha1="f902367330bcfe90564404a3ec640a79aaf1dda3" offset="0" />
@@ -8774,7 +8774,7 @@
 	<software name="chainrea">
 		<description>Chain Reaction</description>
 		<year>1987</year>
-		<publisher>Durell</publisher>
+		<publisher>Durell Software</publisher>
 		<part name="flop1" interface="floppy_3">
 			<dataarea name="flop" size="194816">
 				<rom name="chain reaction (1987)(durell).dsk" size="194816" crc="37f5a6d9" sha1="237922f83435be87ec93ca2eedcd1ae10c7304a5" offset="0" />
@@ -9024,7 +9024,7 @@
 	<software name="tcitadel">
 		<description>The Citadel</description>
 		<year>1995</year>
-		<publisher>Zenobi</publisher>
+		<publisher>Zenobi Software</publisher>
 		<part name="flop1" interface="floppy_3">
 			<dataarea name="flop" size="194816">
 				<rom name="citadel, the (1995)(zenobi).dsk" size="194816" crc="274ae290" sha1="8aed7e6ae7cb69e11e6cd2f44bc1c6bc6d02c5f7" offset="0" />
@@ -9036,7 +9036,7 @@
 	<software name="civlsrv2">
 		<description>Civil Service II</description>
 		<year>1994</year>
-		<publisher>Zenobi</publisher>
+		<publisher>Zenobi Software</publisher>
 		<part name="flop1" interface="floppy_3">
 			<dataarea name="flop" size="194816">
 				<rom name="civil service ii (1994)(zenobi).dsk" size="194816" crc="88ecdb07" sha1="0a9aa0bbd6122edde9c9bce9303583b6a98be283" offset="0" />
@@ -9072,7 +9072,7 @@
 	<software name="cloud99">
 		<description>Cloud 99</description>
 		<year>1988</year>
-		<publisher>Zenobi</publisher>
+		<publisher>Zenobi Software</publisher>
 		<part name="flop1" interface="floppy_3">
 			<dataarea name="flop" size="194816">
 				<rom name="cloud 99 (1988)(zenobi)[re-release].dsk" size="194816" crc="5842de80" sha1="b454e12a32543825a6c593dc68dd9a2b8654d567" offset="0" />
@@ -9202,7 +9202,7 @@
 	<software name="corpston">
 		<description>Corporal Stone</description>
 		<year>1992</year>
-		<publisher>Zenobi</publisher>
+		<publisher>Zenobi Software</publisher>
 		<part name="flop1" interface="floppy_3">
 			<dataarea name="flop" size="194816">
 				<rom name="corporal stone (1992)(zenobi).dsk" size="194816" crc="8b578a60" sha1="ef6d6a69d6d953b73ca780e370aec12cd99373f8" offset="0" />
@@ -9215,7 +9215,7 @@
 	<software name="corruptna" cloneof="corruptn">
 		<description>Corruption (alt)</description>
 		<year>1988</year>
-		<publisher>Rainbird</publisher>
+		<publisher>Rainbird Software</publisher>
 		<part name="flop1" interface="floppy_3">
 			<dataarea name="flop" size="194816">
 				<rom name="corruption (1988)(rainbird).dsk" size="194816" crc="1dc27c17" sha1="3fd52b22960c0285472a7e87ea6a9fdb5684ee82" offset="0" />
@@ -9228,7 +9228,7 @@
 	<software name="corruptnb" cloneof="corruptn">
 		<description>Corruption (alt 2)</description>
 		<year>1988</year>
-		<publisher>Rainbird</publisher>
+		<publisher>Rainbird Software</publisher>
 		<part name="flop1" interface="floppy_3">
 			<dataarea name="flop" size="194816">
 				<rom name="corruption (1988)(rainbird)[a].dsk" size="194816" crc="4e60b833" sha1="cdf95bb26eb4d5e0baec7838cfca832936cc7540" offset="0" />
@@ -9241,7 +9241,7 @@
 	<software name="corruptnc" cloneof="corruptn">
 		<description>Corruption (alt 3)</description>
 		<year>1988</year>
-		<publisher>Rainbird</publisher>
+		<publisher>Rainbird Software</publisher>
 		<part name="flop1" interface="floppy_3">
 			<dataarea name="flop" size="194816">
 				<rom name="corruption (1988)(rainbird)[a2].dsk" size="194816" crc="e7e5feaf" sha1="94b0b7203a9478ec7e232677a902cb90ec4abbdd" offset="0" />
@@ -9265,7 +9265,7 @@
 	<software name="crackcty">
 		<description>Crack City</description>
 		<year>1989</year>
-		<publisher>Zenobi</publisher>
+		<publisher>Zenobi Software</publisher>
 		<part name="flop1" interface="floppy_3">
 			<dataarea name="flop" size="194816">
 				<rom name="crack city (1989)(zenobi).dsk" size="194816" crc="e4ef29e9" sha1="1b8d94c8adb69ec1f963d6fddd49f43947a46afb" offset="0" />
@@ -9337,7 +9337,7 @@
 	<software name="crystkin">
 		<description>Crystals of Kings</description>
 		<year>1993</year>
-		<publisher>Zenobi</publisher>
+		<publisher>Zenobi Software</publisher>
 		<part name="flop1" interface="floppy_3">
 			<dataarea name="flop" size="194816">
 				<rom name="crystals of kings (1993)(zenobi).dsk" size="194816" crc="6fa4745e" sha1="4e0ce417dee743183886bce9ccc4f3c2d3fe72f9" offset="0" />
@@ -9361,7 +9361,7 @@
 	<software name="cursnimu">
 		<description>The Curse of Nimue</description>
 		<year>1995</year>
-		<publisher>Zenobi</publisher>
+		<publisher>Zenobi Software</publisher>
 		<part name="flop1" interface="floppy_3">
 			<dataarea name="flop" size="194816">
 				<rom name="curse of nimue, the (1995)(zenobi).dsk" size="194816" crc="77db9af2" sha1="ffc3cc67bf86dc4091bd600443e615dbeaee3aea" offset="0" />
@@ -9541,7 +9541,7 @@
 	<software name="darktowr">
 		<description>The Dark Tower</description>
 		<year>1992</year>
-		<publisher>Zenobi</publisher>
+		<publisher>Zenobi Software</publisher>
 		<part name="flop1" interface="floppy_3">
 			<dataarea name="flop" size="204544">
 				<rom name="dark tower, the (1992)(zenobi)[re-release].dsk" size="204544" crc="57131a03" sha1="58f8bd782f144bd7f15e07b6f9240f3c06a936c1" offset="0" />
@@ -9553,7 +9553,7 @@
 	<software name="darkstro">
 		<description>The Darkest Road</description>
 		<year>1991</year>
-		<publisher>Zenobi</publisher>
+		<publisher>Zenobi Software</publisher>
 		<part name="flop1" interface="floppy_3">
 			<dataarea name="flop" size="194816">
 				<rom name="darkest road, the (1991)(zenobi).dsk" size="194816" crc="9226b17e" sha1="dd2517993b61100372798225c63869462dfcb99c" offset="0" />
@@ -9613,7 +9613,7 @@
 	<software name="deeksdee">
 		<description>Deek's Deeds</description>
 		<year>1990</year>
-		<publisher>Zenobi</publisher>
+		<publisher>Zenobi Software</publisher>
 		<part name="flop1" interface="floppy_3">
 			<dataarea name="flop" size="194816">
 				<rom name="deek's deeds (1990)(zenobi)[re-release].dsk" size="194816" crc="b5ba9c79" sha1="c8bc7bcf561c44daab22a75662ddc69e25b08e80" offset="0" />
@@ -9675,7 +9675,7 @@
 	<software name="diarmid">
 		<description>Diarmid</description>
 		<year>1993</year>
-		<publisher>Zenobi</publisher>
+		<publisher>Zenobi Software</publisher>
 		<part name="flop1" interface="floppy_3">
 			<dataarea name="flop" size="194816">
 				<rom name="diarmid (1993)(zenobi).dsk" size="194816" crc="4b08234a" sha1="173e145e0bbe47764618022be5edcb632dc6cefe" offset="0" />
@@ -9699,7 +9699,7 @@
 	<software name="dogboy">
 		<description>The Dogboy</description>
 		<year>1985</year>
-		<publisher>Zenobi</publisher>
+		<publisher>Zenobi Software</publisher>
 		<part name="flop1" interface="floppy_3">
 			<dataarea name="flop" size="194816">
 				<rom name="dogboy, the (1985)(zenobi)[re-release].dsk" size="194816" crc="b7f4582c" sha1="40828308aa82e7208c4d154ace4b79a861c3a0c1" offset="0" />
@@ -9711,7 +9711,7 @@
 	<software name="dominatrsp" cloneof="dominatr">
 		<description>Dominator (Spa)</description>
 		<year>1989</year>
-		<publisher>MCM</publisher>
+		<publisher>MCM Software</publisher>
 		<part name="flop1" interface="floppy_3">
 			<dataarea name="flop" size="121856">
 				<rom name="dominator (1989)(mcm)(es)(en)[re-release].dsk" size="121856" crc="0ca1868a" sha1="dc6d54da26a5271340910aa52a76d49dc67216bd" offset="0" />
@@ -9724,7 +9724,7 @@
 	<software name="dominatra" cloneof="dominatr">
 		<description>Dominator (alt)</description>
 		<year>1989</year>
-		<publisher>System 3</publisher>
+		<publisher>System 3 Software</publisher>
 		<part name="flop1" interface="floppy_3">
 			<dataarea name="flop" size="234752">
 				<rom name="dominator (1989)(system 3).dsk" size="234752" crc="a8475699" sha1="fc39aa181b7db27aa0a92a0458f54e75fe610ede" offset="0" />
@@ -9793,7 +9793,7 @@
 	<software name="drjekyll">
 		<description>Dr. Jekyll and Mr. Hyde (master disk)</description>
 		<year>1988</year>
-		<publisher>Zenobi</publisher>
+		<publisher>Zenobi Software</publisher>
 		<part name="flop1" interface="floppy_3">
 			<feature name="part_id" value="Side A"/>
 			<dataarea name="flop" size="194816">
@@ -9824,7 +9824,7 @@
 	<software name="dragnque">
 		<description>Dragon-Quest</description>
 		<year>1994</year>
-		<publisher>Zenobi</publisher>
+		<publisher>Zenobi Software</publisher>
 		<part name="flop1" interface="floppy_3">
 			<dataarea name="flop" size="194816">
 				<rom name="dragon-quest (1994)(zenobi).dsk" size="194816" crc="74097eb9" sha1="7cb723772404ec52399aab549ca2324877a75cad" offset="0" />
@@ -9896,7 +9896,7 @@
 	<software name="dungromp">
 		<description>A Dungeon Romp</description>
 		<year>1995</year>
-		<publisher>Zenobi</publisher>
+		<publisher>Zenobi Software</publisher>
 		<part name="flop1" interface="floppy_3">
 			<dataarea name="flop" size="194816">
 				<rom name="dungeon romp, a (1995)(zenobi).dsk" size="194816" crc="3e99350f" sha1="4db3b696c9659c060ed51eb658e97b06a79f92ba" offset="0" />
@@ -9908,7 +9908,7 @@
 	<software name="dungmald">
 		<description>The Dungeons of Maldread</description>
 		<year>1995</year>
-		<publisher>Zenobi</publisher>
+		<publisher>Zenobi Software</publisher>
 		<part name="flop1" interface="floppy_3">
 			<dataarea name="flop" size="194816">
 				<rom name="dungeons of maldread, the (1995)(zenobi).dsk" size="194816" crc="f83f9881" sha1="50d3747b5e45bba24e92054525efc41a855f4b6d" offset="0" />
@@ -10005,7 +10005,7 @@
 	<software name="elfinwar">
 		<description>The Elfin Wars</description>
 		<year>1994</year>
-		<publisher>Zenobi</publisher>
+		<publisher>Zenobi Software</publisher>
 		<part name="flop1" interface="floppy_3">
 			<dataarea name="flop" size="194816">
 				<rom name="elfin wars, the (1994)(zenobi).dsk" size="194816" crc="026b892b" sha1="49b9412ac4e400ae53a1dbcef4f7c6c977880f6b" offset="0" />
@@ -10017,7 +10017,7 @@
 	<software name="elfindor">
 		<description>Elfindor</description>
 		<year>1989</year>
-		<publisher>Zenobi</publisher>
+		<publisher>Zenobi Software</publisher>
 		<part name="flop1" interface="floppy_3">
 			<dataarea name="flop" size="194816">
 				<rom name="elfindor (1989)(zenobi)[re-release].dsk" size="194816" crc="3d6b222f" sha1="75a57b2af4042253332808a1298f5e8174e95227" offset="0" />
@@ -10041,7 +10041,7 @@
 	<software name="ellisndi">
 		<description>The Ellisnore Diamond</description>
 		<year>1992</year>
-		<publisher>Zenobi</publisher>
+		<publisher>Zenobi Software</publisher>
 		<part name="flop1" interface="floppy_3">
 			<dataarea name="flop" size="194816">
 				<rom name="ellisnore diamond, the (1992)(zenobi)[re-release].dsk" size="194816" crc="ee8934c6" sha1="3947b2c10415643d432e905ffca736aaf1142511" offset="0" />
@@ -10053,7 +10053,7 @@
 	<software name="emeraelf">
 		<description>The Emerald Elf</description>
 		<year>1995</year>
-		<publisher>Zenobi</publisher>
+		<publisher>Zenobi Software</publisher>
 		<part name="flop1" interface="floppy_3">
 			<dataarea name="flop" size="194816">
 				<rom name="emerald elf, the (1995)(zenobi).dsk" size="194816" crc="95eaa5a9" sha1="38c565f37d17a6235f3db1d0e1bfcd06377baaca" offset="0" />
@@ -10113,7 +10113,7 @@
 	<software name="emlynhug">
 		<description>Emlyn Hughes International Soccer</description>
 		<year>1989</year>
-		<publisher>Audiogenic</publisher>
+		<publisher>Audiogenic Software</publisher>
 		<part name="flop1" interface="floppy_3">
 			<dataarea name="flop" size="194816">
 				<rom name="emlyn hughes international soccer (1989)(audiogenic).dsk" size="194816" crc="ebc0e76c" sha1="594526e9c2f40bdddd11c7f8a0d9ed4455d66377" offset="0" />
@@ -10137,7 +10137,7 @@
 	<software name="endisnig">
 		<description>The End Is Nigh</description>
 		<year>1994</year>
-		<publisher>Zenobi</publisher>
+		<publisher>Zenobi Software</publisher>
 		<part name="flop1" interface="floppy_3">
 			<dataarea name="flop" size="196096">
 				<rom name="end is nigh, the (1994)(zenobi).dsk" size="196096" crc="48e73904" sha1="23e85f5830bcc3cdfbfd385a80e2f4d7351c50fd" offset="0" />
@@ -10162,7 +10162,7 @@
 	<software name="efhodkma">
 		<description>The Escape from Hodgkins' Manor</description>
 		<year>1990</year>
-		<publisher>Zenobi</publisher>
+		<publisher>Zenobi Software</publisher>
 		<part name="flop1" interface="floppy_3">
 			<dataarea name="flop" size="194816">
 				<rom name="escape from hodgkins' manor, the (1990)(zenobi).dsk" size="194816" crc="4943ed9f" sha1="d2fa28b6de2422860bba3c76ec24119b2ab791fa" offset="0" />
@@ -10174,7 +10174,7 @@
 	<software name="eschabit">
 		<description>The Escaping Habit</description>
 		<year>1992</year>
-		<publisher>Zenobi</publisher>
+		<publisher>Zenobi Software</publisher>
 		<part name="flop1" interface="floppy_3">
 			<dataarea name="flop" size="194816">
 				<rom name="escaping habit, the (1992)(zenobi).dsk" size="194816" crc="8083eba9" sha1="9e74c50b00acc63c9a93a68f275924b21e9fbd50" offset="0" />
@@ -10354,7 +10354,7 @@
 	<software name="finalch4">
 		<description>The Final Chorus v4</description>
 		<year>1995</year>
-		<publisher>Zenobi</publisher>
+		<publisher>Zenobi Software</publisher>
 		<part name="flop1" interface="floppy_3">
 			<dataarea name="flop" size="194816">
 				<rom name="final chorus, the v4 (1995)(zenobi).dsk" size="194816" crc="d08b9197" sha1="1e468dc36387e0bd1e0dd940f1a789a92176fd30" offset="0" />
@@ -10366,7 +10366,7 @@
 	<software name="findeman">
 		<description>The Final Demand</description>
 		<year>1993</year>
-		<publisher>Zenobi</publisher>
+		<publisher>Zenobi Software</publisher>
 		<part name="flop1" interface="floppy_3">
 			<dataarea name="flop" size="194816">
 				<rom name="final demand, the (1993)(zenobi).dsk" size="194816" crc="a40709ef" sha1="4c5f3188c56403299a939e0f2f2d851ab45fb0e3" offset="0" />
@@ -10424,7 +10424,7 @@
 	<software name="fisha" cloneof="fish">
 		<description>Fish! (alt)</description>
 		<year>1989</year>
-		<publisher>Rainbird</publisher>
+		<publisher>Rainbird Software</publisher>
 		<part name="flop1" interface="floppy_3">
 			<dataarea name="flop" size="195072">
 				<rom name="fish (1989)(rainbird).dsk" size="195072" crc="9b110b8c" sha1="fb2313141dda5289a12b40cd91a12ac271f763bc" offset="0" />
@@ -10436,7 +10436,7 @@
 	<software name="fishv103">
 		<description>Fish v1.03</description>
 		<year>1989</year>
-		<publisher>Rainbird</publisher>
+		<publisher>Rainbird Software</publisher>
 		<part name="flop1" interface="floppy_3">
 			<dataarea name="flop" size="194816">
 				<rom name="fish v1.03 (1989)(rainbird).dsk" size="194816" crc="367d44c8" sha1="a51b0cdefaffeae1d905be7f43af9a9bd3f60db7" offset="0" />
@@ -10448,7 +10448,7 @@
 	<software name="fishrkin">
 		<description>The Fisher King</description>
 		<year>1991</year>
-		<publisher>Zenobi</publisher>
+		<publisher>Zenobi Software</publisher>
 		<part name="flop1" interface="floppy_3">
 			<dataarea name="flop" size="194816">
 				<rom name="fisher king, the (1991)(zenobi).dsk" size="194816" crc="59f46ec1" sha1="e845c6a90def997cf23b21ad2f8778d017a699f2" offset="0" />
@@ -10460,7 +10460,7 @@
 	<software name="ffonecro">
 		<description>A Fistful of Necronomicons</description>
 		<year>1995</year>
-		<publisher>Zenobi</publisher>
+		<publisher>Zenobi Software</publisher>
 		<part name="flop1" interface="floppy_3">
 			<dataarea name="flop" size="194816">
 				<rom name="fistful of necronomicons, a (1995)(zenobi).dsk" size="194816" crc="9708f9dc" sha1="017585b35183a3b34251598ba3bd487fa79209ee" offset="0" />
@@ -10472,7 +10472,7 @@
 	<software name="flameout">
 		<description>Flameout</description>
 		<year>1994</year>
-		<publisher>Zenobi</publisher>
+		<publisher>Zenobi Software</publisher>
 		<part name="flop1" interface="floppy_3">
 			<dataarea name="flop" size="194816">
 				<rom name="flameout (1994)(zenobi).dsk" size="194816" crc="7fe10b1b" sha1="7b9682942393ab38974f9fa92580685c639f34af" offset="0" />
@@ -10541,7 +10541,7 @@
 	<software name="forpetes">
 		<description>For Pete's Sake</description>
 		<year>1993</year>
-		<publisher>Zenobi</publisher>
+		<publisher>Zenobi Software</publisher>
 		<part name="flop1" interface="floppy_3">
 			<dataarea name="flop" size="194816">
 				<rom name="for pete's sake (1993)(zenobi).dsk" size="194816" crc="2013dbe6" sha1="d2cd15437ebda07e9e40708c4847b9e61636583a" offset="0" />
@@ -10705,7 +10705,7 @@
 	<software name="gwoaname">
 		<description>Game Without a Name</description>
 		<year>1987</year>
-		<publisher>Zenobi</publisher>
+		<publisher>Zenobi Software</publisher>
 		<part name="flop1" interface="floppy_3">
 			<dataarea name="flop" size="194816">
 				<rom name="game without a name (1987)(zenobi)[re-release].dsk" size="194816" crc="def2f93d" sha1="5638e013a70b850ba3d99cb96149f40b9db49b7d" offset="0" />
@@ -10977,7 +10977,7 @@
 	<software name="godsowar">
 		<description>The Gods of War</description>
 		<year>1987</year>
-		<publisher>Zenobi</publisher>
+		<publisher>Zenobi Software</publisher>
 		<part name="flop1" interface="floppy_3">
 			<dataarea name="flop" size="194816">
 				<rom name="gods of war, the (1987)(zenobi)[re-release].dsk" size="194816" crc="5f17551f" sha1="323f1944464f40f6f3d3c71f3325720f976cee81" offset="0" />
@@ -10989,7 +10989,7 @@
 	<software name="goldnaxesp" cloneof="goldnaxe">
 		<description>Golden Axe (Spa)</description>
 		<year>1990</year>
-		<publisher>MCM</publisher>
+		<publisher>MCM Software</publisher>
 		<part name="flop1" interface="floppy_3">
 			<feature name="part_id" value="Side A"/>
 			<dataarea name="flop" size="165888">
@@ -11039,7 +11039,7 @@
 	<software name="goldlock">
 		<description>The Golden Locket</description>
 		<year>1993</year>
-		<publisher>Zenobi</publisher>
+		<publisher>Zenobi Software</publisher>
 		<part name="flop1" interface="floppy_3">
 			<dataarea name="flop" size="194816">
 				<rom name="golden locket, the (1993)(zenobi)[re-release].dsk" size="194816" crc="53843bdd" sha1="607631dea927f5e00fba2818e0f5b795e954fe9e" offset="0" />
@@ -11051,7 +11051,7 @@
 	<software name="goldpyra">
 		<description>The Golden Pyramid</description>
 		<year>1991</year>
-		<publisher>Zenobi</publisher>
+		<publisher>Zenobi Software</publisher>
 		<part name="flop1" interface="floppy_3">
 			<dataarea name="flop" size="194816">
 				<rom name="golden pyramid, the (1991)(zenobi).dsk" size="194816" crc="bedb25dc" sha1="706f7604eac2baeb15ebdfef25c631c1dd82ecdd" offset="0" />
@@ -11063,7 +11063,7 @@
 	<software name="gswobhak">
 		<description>The Golden Sword of Bhakhor</description>
 		<year>1991</year>
-		<publisher>Zenobi</publisher>
+		<publisher>Zenobi Software</publisher>
 		<part name="flop1" interface="floppy_3">
 			<dataarea name="flop" size="194816">
 				<rom name="golden sword of bhakhor, the (1991)(zenobi).dsk" size="194816" crc="d02d944a" sha1="6b4eb8e54dcd781f04d7c37e6198bb60fb75ed79" offset="0" />
@@ -11124,7 +11124,7 @@
 	<software name="gwar">
 		<description>Guerrilla War - Hail the Heroes</description>
 		<year>1988</year>
-		<publisher>Imagine</publisher>
+		<publisher>Imagine Software</publisher>
 		<part name="flop1" interface="floppy_3">
 			<dataarea name="flop" size="134144">
 				<rom name="guerrilla war - hail the heroes (1988)(imagine).dsk" size="134144" crc="58d62d43" sha1="e17740a5fe4fd6468f9d107229bf252d94f3ef45" offset="0" />
@@ -11136,7 +11136,7 @@
 	<software name="guilthie">
 		<description>The Guild of Thieves</description>
 		<year>1988</year>
-		<publisher>Rainbird</publisher>
+		<publisher>Rainbird Software</publisher>
 		<part name="flop1" interface="floppy_3">
 			<feature name="part_id" value="Side A"/>
 			<dataarea name="flop" size="194816">
@@ -11155,7 +11155,7 @@
 	<software name="guilthiea" cloneof="guilthie">
 		<description>The Guild of Thieves (alt)</description>
 		<year>1988</year>
-		<publisher>Rainbird</publisher>
+		<publisher>Rainbird Software</publisher>
 		<part name="flop1" interface="floppy_3">
 			<dataarea name="flop" size="194816">
 				<rom name="guild of thieves, the (1988)(rainbird)(side a)[a].dsk" size="194816" crc="7832e385" sha1="a4c37a58156b5b957be5aefb9aaf0878c39f1123" offset="0" />
@@ -11461,7 +11461,7 @@
 	<software name="hidnseek">
 		<description>Hide and Seek</description>
 		<year>1995</year>
-		<publisher>Zenobi</publisher>
+		<publisher>Zenobi Software</publisher>
 		<part name="flop1" interface="floppy_3">
 			<dataarea name="flop" size="194816">
 				<rom name="hide and seek (1995)(zenobi)[re-release].dsk" size="194816" crc="a7b8a803" sha1="ee73f444d4637195c7272ea392dd174e534e0413" offset="0" />
@@ -11473,7 +11473,7 @@
 	<software name="hobshoar">
 		<description>Hob's Hoard</description>
 		<year>1991</year>
-		<publisher>Zenobi</publisher>
+		<publisher>Zenobi Software</publisher>
 		<part name="flop1" interface="floppy_3">
 			<dataarea name="flop" size="194816">
 				<rom name="hob's hoard (1991)(zenobi).dsk" size="194816" crc="beca6e53" sha1="9b7f1c131bbab3b588a79667f06930535d0e47e8" offset="0" />
@@ -11547,7 +11547,7 @@
 	<software name="houseott">
 		<description>The House on the Tor</description>
 		<year>1990</year>
-		<publisher>Zenobi</publisher>
+		<publisher>Zenobi Software</publisher>
 		<part name="flop1" interface="floppy_3">
 			<dataarea name="flop" size="194816">
 				<rom name="house on the tor, the (1990)(zenobi).dsk" size="194816" crc="a29246d9" sha1="49b35455d6747345933cefac220fe46fdd6cb76e" offset="0" />
@@ -11559,7 +11559,7 @@
 	<software name="thehouse">
 		<description>The House</description>
 		<year>1994</year>
-		<publisher>Zenobi</publisher>
+		<publisher>Zenobi Software</publisher>
 		<part name="flop1" interface="floppy_3">
 			<dataarea name="flop" size="194816">
 				<rom name="house, the (1994)(zenobi).dsk" size="194816" crc="ce8ac110" sha1="56edf0e0151b87a7bf0e559638373a92a9c99496" offset="0" />
@@ -11644,7 +11644,7 @@
 	<software name="impact">
 		<description>Impact</description>
 		<year>1992</year>
-		<publisher>Zenobi</publisher>
+		<publisher>Zenobi Software</publisher>
 		<part name="flop1" interface="floppy_3">
 			<dataarea name="flop" size="194816">
 				<rom name="impact (1992)(zenobi).dsk" size="194816" crc="596680d7" sha1="8b834a5283f06b3d14bd70e3ba7d5aa82b5378db" offset="0" />
@@ -11792,7 +11792,7 @@
 	<software name="inkarate">
 		<description>International Karate</description>
 		<year>1985</year>
-		<publisher>System 3</publisher>
+		<publisher>System 3 Software</publisher>
 		<part name="flop1" interface="floppy_3">
 			<dataarea name="flop" size="194816">
 				<rom name="international karate (1985)(system 3).dsk" size="194816" crc="7321dcb7" sha1="85b8c729932f58e096a6d7dcbcb0441ea1162c6e" offset="0" />
@@ -11937,7 +11937,7 @@
 	<software name="jadeston">
 		<description>The Jade Stone</description>
 		<year>1987</year>
-		<publisher>Zenobi</publisher>
+		<publisher>Zenobi Software</publisher>
 		<part name="flop1" interface="floppy_3">
 			<feature name="part_id" value="Side A"/>
 			<dataarea name="flop" size="194816">
@@ -11956,7 +11956,7 @@
 	<software name="jadestona" cloneof="jadeston">>
 		<description>The Jade Stone (alt)</description>
 		<year>1987</year>
-		<publisher>Zenobi</publisher>
+		<publisher>Zenobi Software</publisher>
 		<part name="flop1" interface="floppy_3">
 			<dataarea name="flop" size="194816">
 				<rom name="jade stone, the (1987)(zenobi)[re-release].dsk" size="194816" crc="49966c26" sha1="9b58a66a9733afc97b9313279e90084436b9ef1d" offset="0" />
@@ -12000,7 +12000,7 @@
 	<software name="jesterqu">
 		<description>Jester Quest</description>
 		<year>1988</year>
-		<publisher>Zenobi</publisher>
+		<publisher>Zenobi Software</publisher>
 		<part name="flop1" interface="floppy_3">
 			<dataarea name="flop" size="194816">
 				<rom name="jester quest (1988)(zenobi)[re-release].dsk" size="194816" crc="3503d839" sha1="c01d6ed8687c2ef51470e8ac0993f18be847bd4f" offset="0" />
@@ -12012,7 +12012,7 @@
 	<software name="jbikesim">
 		<description>Jet Bike Simulator</description>
 		<year>1989</year>
-		<publisher>MCM</publisher>
+		<publisher>MCM Software</publisher>
 		<part name="flop1" interface="floppy_3">
 			<feature name="part_id" value="Side A"/>
 			<dataarea name="flop" size="208384">
@@ -12043,7 +12043,7 @@
 	<software name="jinxter">
 		<description>Jinxter</description>
 		<year>1988</year>
-		<publisher>Rainbird</publisher>
+		<publisher>Rainbird Software</publisher>
 		<part name="flop1" interface="floppy_3">
 			<dataarea name="flop" size="194816">
 				<rom name="jinxter (1988)(rainbird).dsk" size="194816" crc="845679ed" sha1="81abfa5dc7aaba651416e4cd3e608a35efcb6003" offset="0" />
@@ -12055,7 +12055,7 @@
 	<software name="jinxtera" cloneof="jinxter">
 		<description>Jinxter (alt)</description>
 		<year>1988</year>
-		<publisher>Rainbird</publisher>
+		<publisher>Rainbird Software</publisher>
 		<part name="flop1" interface="floppy_3">
 			<dataarea name="flop" size="194816">
 				<rom name="jinxter (1988)(rainbird)[a].dsk" size="194816" crc="7e71fb55" sha1="46d026205cec35b7852096ae05a7b7921d14f947" offset="0" />
@@ -12111,7 +12111,7 @@
 	<software name="khangpla">
 		<description>The Khangrin Plans</description>
 		<year>1992</year>
-		<publisher>Zenobi</publisher>
+		<publisher>Zenobi Software</publisher>
 		<part name="flop1" interface="floppy_3">
 			<dataarea name="flop" size="194816">
 				<rom name="khangrin plans, the (1992)(zenobi).dsk" size="194816" crc="775b884f" sha1="669b305e0c2dfde4b27b5141c620dbc7dd3b9a67" offset="0" />
@@ -12167,7 +12167,7 @@
 	<software name="kidnappe">
 		<description>Kidnapped</description>
 		<year>1993</year>
-		<publisher>Zenobi</publisher>
+		<publisher>Zenobi Software</publisher>
 		<part name="flop1" interface="floppy_3">
 			<dataarea name="flop" size="194816">
 				<rom name="kidnapped (1993)(zenobi).dsk" size="194816" crc="81158672" sha1="cde1ce0687c59de52c7e7ea040d948f8e9fd5ebd" offset="0" />
@@ -12191,7 +12191,7 @@
 	<software name="kniglife">
 		<description>Knight Life</description>
 		<year>1995</year>
-		<publisher>Zenobi</publisher>
+		<publisher>Zenobi Software</publisher>
 		<part name="flop1" interface="floppy_3">
 			<dataarea name="flop" size="194816">
 				<rom name="knight life (1995)(zenobi)[re-release].dsk" size="194816" crc="475d8674" sha1="d70a7c9754461ed5f00c53d64c77aea49e8a26dd" offset="0" />
@@ -12203,7 +12203,7 @@
 	<software name="knigorc2">
 		<description>Knight Orc v2</description>
 		<year>1987</year>
-		<publisher>Rainbird</publisher>
+		<publisher>Rainbird Software</publisher>
 		<part name="flop1" interface="floppy_3">
 			<feature name="part_id" value="Side A"/>
 			<dataarea name="flop" size="194816">
@@ -12222,7 +12222,7 @@
 	<software name="kobyaak">
 		<description>Kobyashi Ag'Kwo - A Return to Naru</description>
 		<year>1991</year>
-		<publisher>Zenobi</publisher>
+		<publisher>Zenobi Software</publisher>
 		<part name="flop1" interface="floppy_3">
 			<dataarea name="flop" size="194816">
 				<rom name="kobyashi ag'kwo - a return to naru (1991)(zenobi).dsk" size="194816" crc="c2fe764f" sha1="b7bb825691f738fc86ec3c7fb5439135abb699f0" offset="0" />
@@ -12234,7 +12234,7 @@
 	<software name="kobyanar">
 		<description>Kobyashi Naru</description>
 		<year>1992</year>
-		<publisher>Zenobi</publisher>
+		<publisher>Zenobi Software</publisher>
 		<part name="flop1" interface="floppy_3">
 			<dataarea name="flop" size="194816">
 				<rom name="kobyashi naru (1992)(zenobi).dsk" size="194816" crc="36838f89" sha1="f565893ae4bf1f6624ab01684a662cd9e6561d43" offset="0" />
@@ -12246,7 +12246,7 @@
 	<software name="krazykar">
 		<description>The Krazy Kartoonist Kaper</description>
 		<year>1991</year>
-		<publisher>Zenobi</publisher>
+		<publisher>Zenobi Software</publisher>
 		<part name="flop1" interface="floppy_3">
 			<dataarea name="flop" size="194816">
 				<rom name="krazy kartoonist kaper, the (1991)(zenobi)[re-release].dsk" size="194816" crc="2b788d74" sha1="09959def47b5983c292933bf5c5cf3cb7e0ffc1a" offset="0" />
@@ -12294,7 +12294,7 @@
 	<software name="labopain">
 		<description>Labour Pains</description>
 		<year>1995</year>
-		<publisher>Zenobi</publisher>
+		<publisher>Zenobi Software</publisher>
 		<part name="flop1" interface="floppy_3">
 			<dataarea name="flop" size="194816">
 				<rom name="labour pains (1995)(zenobi).dsk" size="194816" crc="738366d9" sha1="898a86b4d51470078c0ef6972da6b4b8c6df1aff" offset="0" />
@@ -12306,7 +12306,7 @@
 	<software name="laboherc">
 		<description>The Labours of Hercules</description>
 		<year>1987</year>
-		<publisher>Zenobi</publisher>
+		<publisher>Zenobi Software</publisher>
 		<part name="flop1" interface="floppy_3">
 			<dataarea name="flop" size="194816">
 				<rom name="labours of hercules, the (1987)(zenobi)[re-release].dsk" size="194816" crc="227a46ce" sha1="6df89841500cb7804beb566fd8cd77f0c6370cb4" offset="0" />
@@ -12337,7 +12337,7 @@
 	<software name="laskretu">
 		<description>Laskar's Return</description>
 		<year>1996</year>
-		<publisher>Zenobi</publisher>
+		<publisher>Zenobi Software</publisher>
 		<part name="flop1" interface="floppy_3">
 			<dataarea name="flop" size="194816">
 				<rom name="laskar's return (1996)(zenobi).dsk" size="194816" crc="fcd56503" sha1="da7c6830dd2e0b8868eab0c6f48b8b70eccec6be" offset="0" />
@@ -12386,7 +12386,7 @@
 	<software name="legalami">
 		<description>A Legacy for Alaric - The Magic Isle</description>
 		<year>1989</year>
-		<publisher>Zenobi</publisher>
+		<publisher>Zenobi Software</publisher>
 		<part name="flop1" interface="floppy_3">
 			<dataarea name="flop" size="194816">
 				<rom name="legacy for alaric, a - the magic isle (1989)(zenobi).dsk" size="194816" crc="eee4511d" sha1="2c9509a694c1522b7654b7666ee340053d5ce275" offset="0" />
@@ -12485,7 +12485,7 @@
 	<software name="lightmar">
 		<description>Lightmare</description>
 		<year>1989</year>
-		<publisher>Zenobi</publisher>
+		<publisher>Zenobi Software</publisher>
 		<part name="flop1" interface="floppy_3">
 			<dataarea name="flop" size="194816">
 				<rom name="lightmare (1989)(zenobi)[re-release].dsk" size="194816" crc="7fab0f98" sha1="6f75150a0a570d0b9f3685682f141068837507b0" offset="0" />
@@ -12497,7 +12497,7 @@
 	<software name="litwangu">
 		<description>Little Wandering Guru</description>
 		<year>1990</year>
-		<publisher>Zenobi</publisher>
+		<publisher>Zenobi Software</publisher>
 		<part name="flop1" interface="floppy_3">
 			<dataarea name="flop" size="194816">
 				<rom name="little wandering guru (1990)(zenobi).dsk" size="194816" crc="d67fd30b" sha1="be5524083666238d46f6cfc63676e6257c0d3b38" offset="0" />
@@ -12534,7 +12534,7 @@
 	<software name="lonewolfa" cloneof="lonewolf">
 		<description>Lone Wolf - The Mirror of Death (alt)</description>
 		<year>1991</year>
-		<publisher>Audiogenic</publisher>
+		<publisher>Audiogenic Software</publisher>
 		<part name="flop1" interface="floppy_3">
 			<dataarea name="flop" size="194816">
 				<rom name="lone wolf - the mirror of death (1991)(audiogenic)[aka lone wolf 3].dsk" size="194816" crc="f3f5dfe2" sha1="6545eabf78d4dfda9381864c30680cd49d06fce0" offset="0" />
@@ -12546,7 +12546,7 @@
 	<software name="looseend">
 		<description>Loose Ends</description>
 		<year>1995</year>
-		<publisher>Zenobi</publisher>
+		<publisher>Zenobi Software</publisher>
 		<part name="flop1" interface="floppy_3">
 			<dataarea name="flop" size="194816">
 				<rom name="loose ends (1995)(zenobi).dsk" size="194816" crc="ff20dd56" sha1="e700e95fd910e4d3879cad07d85785433da7fe78" offset="0" />
@@ -12582,7 +12582,7 @@
 	<software name="losttwil">
 		<description>The Lost Twilight</description>
 		<year>1992</year>
-		<publisher>Zenobi</publisher>
+		<publisher>Zenobi Software</publisher>
 		<part name="flop1" interface="floppy_3">
 			<dataarea name="flop" size="194816">
 				<rom name="lost twilight, the (1992)(zenobi).dsk" size="194816" crc="30650533" sha1="8027860047eb4930e2fdf038d9afc0e292ab9f6b" offset="0" />
@@ -12594,7 +12594,7 @@
 	<software name="lostinti">
 		<description>Lost in Time</description>
 		<year>1993</year>
-		<publisher>Zenobi</publisher>
+		<publisher>Zenobi Software</publisher>
 		<part name="flop1" interface="floppy_3">
 			<dataarea name="flop" size="194816">
 				<rom name="lost in time (1993)(zenobi).dsk" size="194816" crc="880e6526" sha1="024adaa12a5ec729a38a889369115c00197257f4" offset="0" />
@@ -12711,7 +12711,7 @@
 	<software name="manabtho">
 		<description>Man About the House</description>
 		<year>1994</year>
-		<publisher>Zenobi</publisher>
+		<publisher>Zenobi Software</publisher>
 		<part name="flop1" interface="floppy_3">
 			<dataarea name="flop" size="195584">
 				<rom name="man about the house (1994)(zenobi).dsk" size="195584" crc="228ce391" sha1="13c4903dcb060c867f5ecf4e47148e100e361891" offset="0" />
@@ -12754,7 +12754,7 @@
 	<software name="themappe">
 		<description>The Mapper</description>
 		<year>1992</year>
-		<publisher>Zenobi</publisher>
+		<publisher>Zenobi Software</publisher>
 		<part name="flop1" interface="floppy_3">
 			<dataarea name="flop" size="194816">
 				<rom name="mapper, the (1992)(zenobi).dsk" size="194816" crc="5a054203" sha1="1242f4424b6dafa9818a7a95260600a349525161" offset="0" />
@@ -12859,7 +12859,7 @@
 	<software name="meltdown">
 		<description>Meltdown</description>
 		<year>1993</year>
-		<publisher>Zenobi</publisher>
+		<publisher>Zenobi Software</publisher>
 		<part name="flop1" interface="floppy_3">
 			<dataarea name="flop" size="194816">
 				<rom name="meltdown (1993)(zenobi).dsk" size="194816" crc="79e96439" sha1="67bfe6fe8124d9ab64c2c2eec27c663b1ba1a0fb" offset="0" />
@@ -13053,7 +13053,7 @@
 	<software name="mineslit">
 		<description>The Mines of Lithiad</description>
 		<year>1992</year>
-		<publisher>Zenobi</publisher>
+		<publisher>Zenobi Software</publisher>
 		<part name="flop1" interface="floppy_3">
 			<dataarea name="flop" size="194816">
 				<rom name="mines of lithiad, the (1992)(zenobi).dsk" size="194816" crc="ef26827d" sha1="1d8816a4efb4110804144d6bc8c01e30f40e4a6d" offset="0" />
@@ -13065,7 +13065,7 @@
 	<software name="themiser">
 		<description>The Miser</description>
 		<year>1990</year>
-		<publisher>Zenobi</publisher>
+		<publisher>Zenobi Software</publisher>
 		<part name="flop1" interface="floppy_3">
 			<dataarea name="flop" size="194816">
 				<rom name="miser, the (1990)(zenobi)[re-release].dsk" size="194816" crc="e6047e88" sha1="8a0ffb19d6d945069f1c81e2bed5d542d9f3242f" offset="0" />
@@ -13176,7 +13176,7 @@
 	<software name="mrheli">
 		<description>Mr. Heli</description>
 		<year>1989</year>
-		<publisher>Firebird</publisher>
+		<publisher>Firebird Software</publisher>
 		<part name="flop1" interface="floppy_3">
 			<dataarea name="flop" size="194816">
 				<rom name="mr. heli (1989)(firebird).dsk" size="194816" crc="90d80eb1" sha1="b8564ca8d32e8148b8383c2d2438d82557f67d2b" offset="0" />
@@ -13188,7 +13188,7 @@
 	<software name="mumcry21">
 		<description>The Mummy's Crypt v2.1</description>
 		<year>1992</year>
-		<publisher>Zenobi</publisher>
+		<publisher>Zenobi Software</publisher>
 		<part name="flop1" interface="floppy_3">
 			<dataarea name="flop" size="194816">
 				<rom name="mummy's crypt, the v2.1 (1992)(zenobi)[re-release].dsk" size="194816" crc="608ab573" sha1="9548ee0a3a2d4fb3f838bb8578fa817f1069da2b" offset="0" />
@@ -13248,7 +13248,7 @@
 	<software name="murdhesa">
 		<description>Murder - He Said</description>
 		<year>1993</year>
-		<publisher>Zenobi</publisher>
+		<publisher>Zenobi Software</publisher>
 		<part name="flop1" interface="floppy_3">
 			<dataarea name="flop" size="194816">
 				<rom name="murder - he said (1993)(zenobi).dsk" size="194816" crc="80b24b05" sha1="221d3290ca81d52fae54f265f33ba8d346265166" offset="0" />
@@ -13260,7 +13260,7 @@
 	<software name="murdhunt">
 		<description>Murder Hunt</description>
 		<year>1989</year>
-		<publisher>Zenobi</publisher>
+		<publisher>Zenobi Software</publisher>
 		<part name="flop1" interface="floppy_3">
 			<dataarea name="flop" size="194816">
 				<rom name="murder hunt (1989)(zenobi)[re-release].dsk" size="194816" crc="ac1eb412" sha1="9ee6625ae921fab337c1b6ab840791ba9be75a66" offset="0" />
@@ -13272,7 +13272,7 @@
 	<software name="murdhun2">
 		<description>Murder Hunt II</description>
 		<year>1992</year>
-		<publisher>Zenobi</publisher>
+		<publisher>Zenobi Software</publisher>
 		<part name="flop1" interface="floppy_3">
 			<dataarea name="flop" size="194816">
 				<rom name="murder hunt ii (1992)(zenobi).dsk" size="194816" crc="4e8c8f76" sha1="71d1d2a16d069072589ac7dc2017972495f0c4ff" offset="0" />
@@ -13284,7 +13284,7 @@
 	<software name="mutiny">
 		<description>Mutiny</description>
 		<year>1995</year>
-		<publisher>Zenobi</publisher>
+		<publisher>Zenobi Software</publisher>
 		<part name="flop1" interface="floppy_3">
 			<feature name="part_id" value="Side A"/>
 			<dataarea name="flop" size="194816">
@@ -13559,7 +13559,7 @@
 	<software name="normlame">
 		<description>Norman's Lament</description>
 		<year>1990</year>
-		<publisher>Zenobi</publisher>
+		<publisher>Zenobi Software</publisher>
 		<part name="flop1" interface="floppy_3">
 			<dataarea name="flop" size="194816">
 				<rom name="norman's lament (1990)(zenobi).dsk" size="194816" crc="5320aa7a" sha1="dd3a9d5b8fe0191ecc0374fc52dbec2cc1ee992a" offset="0" />
@@ -13684,7 +13684,7 @@
 	<software name="ooowomim">
 		<description>One of our Wombats is Missing</description>
 		<year>1990</year>
-		<publisher>Zenobi</publisher>
+		<publisher>Zenobi Software</publisher>
 		<part name="flop1" interface="floppy_3">
 			<feature name="part_id" value="Side A"/>
 			<dataarea name="flop" size="194816">
@@ -13789,7 +13789,7 @@
 	<software name="opprland">
 		<description>The Oppressed Land</description>
 		<year>1990</year>
-		<publisher>Zenobi</publisher>
+		<publisher>Zenobi Software</publisher>
 		<part name="flop1" interface="floppy_3">
 			<dataarea name="flop" size="194816">
 				<rom name="oppressed land, the (1990)(zenobi).dsk" size="194816" crc="784f03dc" sha1="fbbdf6f40860d13f6dbb0f3f88d1d04fda9c85dd" offset="0" />
@@ -13801,7 +13801,7 @@
 	<software name="origamessp" cloneof="origames">
 		<description>Oriental Games (Spa)</description>
 		<year>1990</year>
-		<publisher>MCM</publisher>
+		<publisher>MCM Software</publisher>
 		<part name="flop1" interface="floppy_3">
 			<feature name="part_id" value="Side A"/>
 			<dataarea name="flop" size="73216">
@@ -13858,7 +13858,7 @@
 	<software name="ootlimel">
 		<description>Out of the Limelight</description>
 		<year>1992</year>
-		<publisher>Zenobi</publisher>
+		<publisher>Zenobi Software</publisher>
 		<part name="flop1" interface="floppy_3">
 			<dataarea name="flop" size="194816">
 				<rom name="out of the limelight (1992)(zenobi).dsk" size="194816" crc="af5dd72d" sha1="665105700b8b92575304ac6a0a7affeee3bbe072" offset="0" />
@@ -13882,7 +13882,7 @@
 	<software name="overlandsp" cloneof="overland">
 		<description>Overlander (Spa)</description>
 		<year>1988</year>
-		<publisher>MCM</publisher>
+		<publisher>MCM Software</publisher>
 		<part name="flop1" interface="floppy_3">
 			<dataarea name="flop" size="194816">
 				<rom name="overlander (1988)(mcm)(es)(en)[re-release].dsk" size="194816" crc="fd817c95" sha1="8fe3b288a4451eeea76aa0ec95200e9478e49a4c" offset="0" />
@@ -13895,7 +13895,7 @@
 	<software name="p47thuna" cloneof="p47thun">>
 		<description>P-47 Thunderbolt (alt)</description>
 		<year>1990</year>
-		<publisher>Firebird</publisher>
+		<publisher>Firebird Software</publisher>
 		<part name="flop1" interface="floppy_3">
 			<dataarea name="flop" size="194816">
 				<rom name="p-47 thunderbolt (1990)(firebird)[aka p-47 - the freedom fighter].dsk" size="194816" crc="ff20e266" sha1="85b1597808079780bca508d5ecb4cc950c168fe3" offset="0" />
@@ -14013,7 +14013,7 @@
 	<software name="passshtsp" cloneof="passsht">
 		<description>Passing Shot (Spa)</description>
 		<year>1989</year>
-		<publisher>MCM</publisher>
+		<publisher>MCM Software</publisher>
 		<part name="flop1" interface="floppy_3">
 			<dataarea name="flop" size="194816">
 				<rom name="passing shot (1989)(mcm)(es)(en)[re-release].dsk" size="194816" crc="41e3ce91" sha1="ddcbdf011275f3d1dcb456f6208f7aec4a75e2b0" offset="0" />
@@ -14026,7 +14026,7 @@
 	<software name="pawn" cloneof="pawn">
 		<description>The Pawn v2.4 (alt)</description>
 		<year>1987</year>
-		<publisher>Rainbird</publisher>
+		<publisher>Rainbird Software</publisher>
 		<part name="flop1" interface="floppy_3">
 			<dataarea name="flop" size="194816">
 				<rom name="pawn, the v2.4 (1987)(rainbird).dsk" size="194816" crc="fdb74ece" sha1="3f96becbf552b207213bdabd950e6ea752b7d8ca" offset="0" />
@@ -14039,7 +14039,7 @@
 	<software name="pawn" cloneof="pawn">
 		<description>The Pawn v2.4 (alt 2)</description>
 		<year>1987</year>
-		<publisher>Rainbird</publisher>
+		<publisher>Rainbird Software</publisher>
 		<part name="flop1" interface="floppy_3">
 			<dataarea name="flop" size="194816">
 				<rom name="pawn, the v2.4 (1987)(rainbird)[a].dsk" size="194816" crc="0790cc76" sha1="17cecc0a0c3c0fa4f081267b45db375e4fb3a3d5" offset="0" />
@@ -14051,7 +14051,7 @@
 	<software name="powthein">
 		<description>Pawns of War - The Infiltrator</description>
 		<year>1989</year>
-		<publisher>Zenobi</publisher>
+		<publisher>Zenobi Software</publisher>
 		<part name="flop1" interface="floppy_3">
 			<dataarea name="flop" size="194816">
 				<rom name="pawns of war - the infiltrator (1989)(zenobi)[re-release].dsk" size="194816" crc="71814e63" sha1="7db46cb122021913544d9c483c2d78e3ba309298" offset="0" />
@@ -14063,7 +14063,7 @@
 	<software name="pendlogr">
 		<description>The Pendant of Logryn</description>
 		<year>1989</year>
-		<publisher>Zenobi</publisher>
+		<publisher>Zenobi Software</publisher>
 		<part name="flop1" interface="floppy_3">
 			<dataarea name="flop" size="194816">
 				<rom name="pendant of logryn, the (1989)(zenobi)[re-release].dsk" size="194816" crc="1ac9391d" sha1="3b4a421e912e37b3c8f3d8f225e29ea339434c4f" offset="0" />
@@ -14099,7 +14099,7 @@
 	<software name="perseus">
 		<description>Perseus</description>
 		<year>1993</year>
-		<publisher>Zenobi</publisher>
+		<publisher>Zenobi Software</publisher>
 		<part name="flop1" interface="floppy_3">
 			<dataarea name="flop" size="194816">
 				<rom name="perseus (1993)(zenobi).dsk" size="194816" crc="5f5a500c" sha1="1f58f7f143ff2cf659ed3a2921e153a2c7d8ee0a" offset="0" />
@@ -14111,7 +14111,7 @@
 	<software name="pecompwi">
 		<description>Personal Computer Whirled</description>
 		<year>1992</year>
-		<publisher>Zenobi</publisher>
+		<publisher>Zenobi Software</publisher>
 		<part name="flop1" interface="floppy_3">
 			<dataarea name="flop" size="194816">
 				<rom name="personal computer whirled (1992)(zenobi)[re-release].dsk" size="194816" crc="4b45d4c9" sha1="496c79dee580d91b07edf3f5bb5dee5f3735e57a" offset="0" />
@@ -14135,7 +14135,7 @@
 	<software name="phoenix">
 		<description>Phoenix</description>
 		<year>1991</year>
-		<publisher>Zenobi</publisher>
+		<publisher>Zenobi Software</publisher>
 		<part name="flop1" interface="floppy_3">
 			<dataarea name="flop" size="194816">
 				<rom name="phoenix (1991)(zenobi).dsk" size="194816" crc="3b1dcbab" sha1="262d3728db62851bbf7a95fc33f0f9993d1567f1" offset="0" />
@@ -14266,7 +14266,7 @@
 	<software name="protenntsp" cloneof="protennt">>
 		<description>Pro Tennis Tour</description>
 		<year>1990</year>
-		<publisher>MCM</publisher>
+		<publisher>MCM Software</publisher>
 		<part name="flop1" interface="floppy_3">
 			<dataarea name="flop" size="63488">
 				<rom name="pro tennis tour (1990)(mcm)(es)(en)[re-release].dsk" size="63488" crc="3cc76873" sha1="ac0fd453b2f00ef63477a25a43bd482a65b8cb84" offset="0" />
@@ -14303,7 +14303,7 @@
 	<software name="projnova">
 		<description>Project Nova</description>
 		<year>1987</year>
-		<publisher>Zenobi</publisher>
+		<publisher>Zenobi Software</publisher>
 		<part name="flop1" interface="floppy_3">
 			<dataarea name="flop" size="194816">
 				<rom name="project nova (1987)(zenobi)[re-release].dsk" size="194816" crc="430d1985" sha1="c065c33b861fd4882569407ae27b50c22784ab0e" offset="0" />
@@ -14365,7 +14365,7 @@
 	<software name="qholysmt">
 		<description>Quest for the Holy Something</description>
 		<year>1992</year>
-		<publisher>Zenobi</publisher>
+		<publisher>Zenobi Software</publisher>
 		<part name="flop1" interface="floppy_3">
 			<dataarea name="flop" size="194816">
 				<rom name="quest for the holy something (1992)(zenobi).dsk" size="194816" crc="966cab79" sha1="c9d0e3a2c98c89251ad0bde5a6a1a60d5401bbf0" offset="0" />
@@ -14428,7 +14428,7 @@
 	<software name="radioman">
 		<description>Radiomania</description>
 		<year>1991</year>
-		<publisher>Zenobi</publisher>
+		<publisher>Zenobi Software</publisher>
 		<part name="flop1" interface="floppy_3">
 			<dataarea name="flop" size="194816">
 				<rom name="radiomania (1991)(zenobi).dsk" size="194816" crc="74edb005" sha1="7226284e7a66c8ed8290046b0e44a0f3ffb89281" offset="0" />
@@ -14496,7 +14496,7 @@
 	<software name="bttf3sp" cloneof="bttf3">
 		<description>Regreso al Futuro - Parte III</description>
 		<year>1991</year>
-		<publisher>MCM</publisher>
+		<publisher>MCM Software</publisher>
 		<part name="flop1" interface="floppy_3">
 			<feature name="part_id" value="Side A"/>
 			<dataarea name="flop" size="194816">
@@ -14516,7 +14516,7 @@
 	<software name="renegadea" cloneof="renegade">
 		<description>Renegade (alt)</description>
 		<year>1987</year>
-		<publisher>Imagine</publisher>
+		<publisher>Imagine Software</publisher>
 		<part name="flop1" interface="floppy_3">
 			<dataarea name="flop" size="194816">
 				<rom name="renegade (1987)(imagine).dsk" size="194816" crc="9414eedd" sha1="ea6ba8c9f8db52cd827cfbe7cb576cf746865de9" offset="0" />
@@ -14529,7 +14529,7 @@
 	<software name="renegadeb" cloneof="renegade">
 		<description>Renegade (alt 2)</description>
 		<year>1987</year>
-		<publisher>Imagine</publisher>
+		<publisher>Imagine Software</publisher>
 		<part name="flop1" interface="floppy_3">
 			<dataarea name="flop" size="194816">
 				<rom name="renegade (1987)(imagine)[a].dsk" size="194816" crc="bddac6b2" sha1="c4311ea7f5ee36a6b112299aaae107e4855adad9" offset="0" />
@@ -14634,7 +14634,7 @@
 	<software name="rhymecry">
 		<description>Rhyme Cryme</description>
 		<year>1995</year>
-		<publisher>Zenobi</publisher>
+		<publisher>Zenobi Software</publisher>
 		<part name="flop1" interface="floppy_3">
 			<feature name="part_id" value="Side A"/>
 			<dataarea name="flop" size="194816">
@@ -14653,7 +14653,7 @@
 	<software name="rickdang">
 		<description>Rick Dangerous</description>
 		<year>1989</year>
-		<publisher>Firebird</publisher>
+		<publisher>Firebird Software</publisher>
 		<part name="flop1" interface="floppy_3">
 			<dataarea name="flop" size="194816">
 				<rom name="rick dangerous (1989)(firebird).dsk" size="194816" crc="23a903d9" sha1="4d216ea0e695d7cc931dd4cd6f5cc64350d20450" offset="0" />
@@ -14884,7 +14884,7 @@
 	<software name="runngman">
 		<description>The Running Man</description>
 		<year>1989</year>
-		<publisher>MCM</publisher>
+		<publisher>MCM Software</publisher>
 		<part name="flop1" interface="floppy_3">
 			<dataarea name="flop" size="160768">
 				<rom name="running man, the (1989)(mcm)(es)(en)[re-release].dsk" size="160768" crc="502e531a" sha1="ca50672595b1f8da4ba1b614d761039b42b90f3a" offset="0" />
@@ -14908,7 +14908,7 @@
 	<software name="saboteu2">
 		<description>Saboteur II - Avenging Angel</description>
 		<year>1987</year>
-		<publisher>Durell</publisher>
+		<publisher>Durell Software</publisher>
 		<part name="flop1" interface="floppy_3">
 			<dataarea name="flop" size="194816">
 				<rom name="saboteur ii - avenging angel (1987)(durell)[h alex rider, 2015][tr pl][speed-up version].dsk" size="194816" crc="4c9b8d3d" sha1="7ed014dadff63cedd9ea6744793b76af8782611b" offset="0" />
@@ -14933,7 +14933,7 @@
 	<software name="salamand">
 		<description>Salamander</description>
 		<year>1987</year>
-		<publisher>Imagine</publisher>
+		<publisher>Imagine Software</publisher>
 		<part name="flop1" interface="floppy_3">
 			<dataarea name="flop" size="70656">
 				<rom name="salamander (1987)(imagine)[re-release].dsk" size="70656" crc="62bfd974" sha1="fc4bc578c463f58a023c716f7df679afb8cb253e" offset="0" />
@@ -14945,7 +14945,7 @@
 	<software name="usagiyoj">
 		<description>Samurai Warrior - The Battles of... Usagi Yojimbo</description>
 		<year>1988</year>
-		<publisher>Firebird</publisher>
+		<publisher>Firebird Software</publisher>
 		<part name="flop1" interface="floppy_3">
 			<dataarea name="flop" size="73216">
 				<rom name="samurai warrior - the battles of... usagi yojimbo (1988)(firebird)[aka battle of... usagi yojimbo, the].dsk" size="73216" crc="fa8df0ac" sha1="ef854f176c30934d1309982322f983194ae60153" offset="0" />
@@ -15051,7 +15051,7 @@
 	<software name="seasorce">
 		<description>Seaside Sorcery</description>
 		<year>1997</year>
-		<publisher>Zenobi</publisher>
+		<publisher>Zenobi Software</publisher>
 		<part name="flop1" interface="floppy_3">
 			<dataarea name="flop" size="194816">
 				<rom name="seaside sorcery (1997)(zenobi).dsk" size="194816" crc="f58ff9dc" sha1="5ad5d43bfb5c7ec4e763a03317c85698e889b905" offset="0" />
@@ -15075,7 +15075,7 @@
 	<software name="sentinel">
 		<description>The Sentinel</description>
 		<year>1987</year>
-		<publisher>Firebird</publisher>
+		<publisher>Firebird Software</publisher>
 		<part name="flop1" interface="floppy_3">
 			<dataarea name="flop" size="78080">
 				<rom name="sentinel, the (1987)(firebird).dsk" size="78080" crc="5665c629" sha1="d03ca9d8dd2fca34aa174edccf17eda12d202409" offset="0" />
@@ -15087,7 +15087,7 @@
 	<software name="serptale">
 		<description>A Serpentine Tale</description>
 		<year>1993</year>
-		<publisher>Zenobi</publisher>
+		<publisher>Zenobi Software</publisher>
 		<part name="flop1" interface="floppy_3">
 			<dataarea name="flop" size="194816">
 				<rom name="serpentine tale, a (1993)(zenobi)[re-release].dsk" size="194816" crc="bd0e89f2" sha1="7af072b5755b119ec22141ed4ab10ac0c54cc52e" offset="0" />
@@ -15216,7 +15216,7 @@
 	<software name="shardino">
 		<description>Shard of Inovar</description>
 		<year>1987</year>
-		<publisher>Zenobi</publisher>
+		<publisher>Zenobi Software</publisher>
 		<part name="flop1" interface="floppy_3">
 			<dataarea name="flop" size="194816">
 				<rom name="shard of inovar (1987)(zenobi)[re-release].dsk" size="194816" crc="517d327c" sha1="284702077cee0618f6eae705557a290717b9bd5e" offset="0" />
@@ -15248,7 +15248,7 @@
 	<software name="sherlami">
 		<description>Sherlock Holmes - The Lamberley Mystery</description>
 		<year>1990</year>
-		<publisher>Zenobi</publisher>
+		<publisher>Zenobi Software</publisher>
 		<part name="flop1" interface="floppy_3">
 			<dataarea name="flop" size="194816">
 				<rom name="sherlock holmes - the lamberley mystery (1990)(zenobi).dsk" size="194816" crc="2a9c732a" sha1="36fae868e3a83cd4f553b070384048cf5959170a" offset="0" />
@@ -15344,7 +15344,7 @@
 	<software name="silvwolf">
 		<description>Silverwolf</description>
 		<year>1992</year>
-		<publisher>Zenobi</publisher>
+		<publisher>Zenobi Software</publisher>
 		<part name="flop1" interface="floppy_3">
 			<dataarea name="flop" size="194816">
 				<rom name="silverwolf (1992)(zenobi)[re-release].dsk" size="194816" crc="a1ced916" sha1="f99b5f686b4d2cafe58ee284562d009087319e87" offset="0" />
@@ -15438,7 +15438,7 @@
 	<software name="slaugcav">
 		<description>The Slaughter Caves</description>
 		<year>1989</year>
-		<publisher>Zenobi</publisher>
+		<publisher>Zenobi Software</publisher>
 		<part name="flop1" interface="floppy_3">
 			<dataarea name="flop" size="194816">
 				<rom name="slaughter caves, the (1989)(zenobi).dsk" size="194816" crc="4ec7b7e1" sha1="05cb1351e4226244ba3ac0756419b4ac2a0b2f7d" offset="0" />
@@ -15542,7 +15542,7 @@
 	<software name="soldoffo">
 		<description>Soldier of Fortune</description>
 		<year>1988</year>
-		<publisher>Firebird</publisher>
+		<publisher>Firebird Software</publisher>
 		<part name="flop1" interface="floppy_3">
 			<dataarea name="flop" size="73216">
 				<rom name="soldier of fortune (1988)(firebird).dsk" size="73216" crc="a88165f9" sha1="720363a3afad04d495279db7fd8f43902d67b1f3" offset="0" />
@@ -15579,7 +15579,7 @@
 	<software name="songofta">
 		<description>The Song of Taliesin</description>
 		<year>1994</year>
-		<publisher>Zenobi</publisher>
+		<publisher>Zenobi Software</publisher>
 		<part name="flop1" interface="floppy_3">
 			<dataarea name="flop" size="194816">
 				<rom name="song of taliesin, the (1994)(zenobi).dsk" size="194816" crc="b7e4fb2d" sha1="071eaa34379e895102c3007e2eca28f89c0eab93" offset="0" />
@@ -15773,7 +15773,7 @@
 	<software name="staffofp">
 		<description>The Staff of Power</description>
 		<year>1991</year>
-		<publisher>Zenobi</publisher>
+		<publisher>Zenobi Software</publisher>
 		<part name="flop1" interface="floppy_3">
 			<dataarea name="flop" size="194816">
 				<rom name="staff of power, the (1991)(zenobi).dsk" size="194816" crc="58cf287b" sha1="4d6ab194e4ce1b42992a64784dd7f676c6ffdb06" offset="0" />
@@ -15798,7 +15798,7 @@
 	<software name="stalker">
 		<description>Stalker</description>
 		<year>1990</year>
-		<publisher>Zenobi</publisher>
+		<publisher>Zenobi Software</publisher>
 		<part name="flop1" interface="floppy_3">
 			<dataarea name="flop" size="194816">
 				<rom name="stalker (1990)(zenobi).dsk" size="194816" crc="b0390b04" sha1="c34fcf6cc5d09d2a3a15632152bfb07ec8c428f2" offset="0" />
@@ -15860,7 +15860,7 @@
 	<software name="starglida" cloneof="starglid">
 		<description>Starglider (alt)</description>
 		<year>1986</year>
-		<publisher>Rainbird</publisher>
+		<publisher>Rainbird Software</publisher>
 		<part name="flop1" interface="floppy_3">
 			<dataarea name="flop" size="194816">
 				<rom name="starglider (1986)(rainbird).dsk" size="194816" crc="2a296abd" sha1="36420eae3caf6ae04c3b03d1ade59a13dad29ee9" offset="0" />
@@ -15872,7 +15872,7 @@
 	<software name="stargli2">
 		<description>Starglider 2 - The Egrons Strike Back</description>
 		<year>1989</year>
-		<publisher>Rainbird</publisher>
+		<publisher>Rainbird Software</publisher>
 		<part name="flop1" interface="floppy_3">
 			<dataarea name="flop" size="194816">
 				<rom name="starglider 2 - the egrons strike back (1989)(rainbird).dsk" size="194816" crc="f6bdeb90" sha1="69f0b5f5b1ebdf67dad43eb7852b95b33db3d5d3" offset="0" />
@@ -15952,7 +15952,7 @@
 	<software name="stranded">
 		<description>Stranded</description>
 		<year>1992</year>
-		<publisher>Zenobi</publisher>
+		<publisher>Zenobi Software</publisher>
 		<part name="flop1" interface="floppy_3">
 			<dataarea name="flop" size="194816">
 				<rom name="stranded (1992)(zenobi).dsk" size="194816" crc="9483615b" sha1="dfbe0660b1725999f76af69770491b71f7fb437f" offset="0" />
@@ -16213,7 +16213,7 @@
 	<software name="twasatim">
 		<description>T'Was a Time of Dread</description>
 		<year>1992</year>
-		<publisher>Zenobi</publisher>
+		<publisher>Zenobi Software</publisher>
 		<part name="flop1" interface="floppy_3">
 			<dataarea name="flop" size="194816">
 				<rom name="t'was a time of dread (1992)(zenobi).dsk" size="194816" crc="a6d11b34" sha1="b59d8b92bd71bdbe2bf383ab8c0468e54981018c" offset="0" />
@@ -16258,7 +16258,7 @@
 	<software name="tlsmathe">
 		<description>The Tales of Mathematica</description>
 		<year>1990</year>
-		<publisher>Zenobi</publisher>
+		<publisher>Zenobi Software</publisher>
 		<part name="flop1" interface="floppy_3">
 			<dataarea name="flop" size="194816">
 				<rom name="tales of mathematica, the (1990)(zenobi).dsk" size="194816" crc="254feaae" sha1="fe4e845b1e380bcbf9a1c352429476d21c9432a9" offset="0" />
@@ -16282,7 +16282,7 @@
 	<software name="targrene">
 		<description>Target: Renegade</description>
 		<year>1988</year>
-		<publisher>Imagine</publisher>
+		<publisher>Imagine Software</publisher>
 		<part name="flop1" interface="floppy_3">
 			<dataarea name="flop" size="134144">
 				<rom name="target - renegade (1988)(imagine).dsk" size="134144" crc="c93b5664" sha1="61f5623c5a614558b8431c4cddbc5ae11313c897" offset="0" />
@@ -16307,7 +16307,7 @@
 	<software name="taxretur">
 		<description>Tax Returns</description>
 		<year>1992</year>
-		<publisher>Zenobi</publisher>
+		<publisher>Zenobi Software</publisher>
 		<part name="flop1" interface="floppy_3">
 			<dataarea name="flop" size="194816">
 				<rom name="tax returns (1992)(zenobi).dsk" size="194816" crc="03d83545" sha1="3dce8cdb905a5ef79ff5af534af19a202433ecf4" offset="0" />
@@ -16319,7 +16319,7 @@
 	<software name="taxmanco">
 		<description>The Taxman Cometh</description>
 		<year>1991</year>
-		<publisher>Zenobi</publisher>
+		<publisher>Zenobi Software</publisher>
 		<part name="flop1" interface="floppy_3">
 			<dataarea name="flop" size="194816">
 				<rom name="taxman cometh, the (1991)(zenobi).dsk" size="194816" crc="05399461" sha1="e626dcb4c47a4bf4f5c4a7564d36672f85edeef8" offset="0" />
@@ -16331,7 +16331,7 @@
 	<software name="tearmoon">
 		<description>The Tears of the Moon</description>
 		<year>1992</year>
-		<publisher>Zenobi</publisher>
+		<publisher>Zenobi Software</publisher>
 		<part name="flop1" interface="floppy_3">
 			<dataarea name="flop" size="204544">
 				<rom name="tears of the moon, the (1992)(zenobi).dsk" size="204544" crc="e21084cf" sha1="bf084143f9b7f5825742f7259804e3babcef0bb8" offset="0" />
@@ -16355,7 +16355,7 @@
 	<software name="teenagee">
 		<description>Teenage Emergency</description>
 		<year>1995</year>
-		<publisher>Zenobi</publisher>
+		<publisher>Zenobi Software</publisher>
 		<part name="flop1" interface="floppy_3">
 			<dataarea name="flop" size="194816">
 				<rom name="teenage emergency (1995)(zenobi).dsk" size="194816" crc="a945f2f5" sha1="7e5cba7d570959609896663a6a0d6d735cc5d1a3" offset="0" />
@@ -16395,7 +16395,7 @@
 	<software name="tengrebt">
 		<description>Ten Green Bottles</description>
 		<year>1995</year>
-		<publisher>Zenobi</publisher>
+		<publisher>Zenobi Software</publisher>
 		<part name="flop1" interface="floppy_3">
 			<dataarea name="flop" size="194816">
 				<rom name="ten green bottles (1995)(zenobi).dsk" size="194816" crc="667dfed2" sha1="da5f6806ebc46dec7ae7c63d9f11e650f39ab845" offset="0" />
@@ -16468,7 +16468,7 @@
 	<software name="tparkuk">
 		<description>Theme Park U.K.</description>
 		<year>1993</year>
-		<publisher>Zenobi</publisher>
+		<publisher>Zenobi Software</publisher>
 		<part name="flop1" interface="floppy_3">
 			<dataarea name="flop" size="194816">
 				<rom name="theme park u.k. (1993)(zenobi)[re-release].dsk" size="194816" crc="82d68d37" sha1="b43330b5962f776ae595d88bd3711378c7d80a17" offset="0" />
@@ -16480,7 +16480,7 @@
 	<software name="tparkusa">
 		<description>Theme Park U.S.A.</description>
 		<year>1993</year>
-		<publisher>Zenobi</publisher>
+		<publisher>Zenobi Software</publisher>
 		<part name="flop1" interface="floppy_3">
 			<dataarea name="flop" size="194816">
 				<rom name="theme park u.s.a. (1993)(zenobi).dsk" size="194816" crc="fa6b510f" sha1="4141a805840d7c990ec5b9b671ca2ddde5853807" offset="0" />
@@ -16492,7 +16492,7 @@
 	<software name="tabombup">
 		<description>There's a Bomb Under Parliament</description>
 		<year>1991</year>
-		<publisher>Zenobi</publisher>
+		<publisher>Zenobi Software</publisher>
 		<part name="flop1" interface="floppy_3">
 			<dataarea name="flop" size="194816">
 				<rom name="there's a bomb under parliament (1991)(zenobi).dsk" size="194816" crc="61cfed6b" sha1="67b4598e5b2e961cbe4215f364bb5b71c37e5e5c" offset="0" />
@@ -16504,7 +16504,7 @@
 	<software name="thirnins">
 		<description>The Thirty-Nine Steps</description>
 		<year>1995</year>
-		<publisher>Zenobi</publisher>
+		<publisher>Zenobi Software</publisher>
 		<part name="flop1" interface="floppy_3">
 			<dataarea name="flop" size="194816">
 				<rom name="thirty-nine steps, the (1995)(zenobi)[aka 39 steps, the].dsk" size="194816" crc="97ce88e7" sha1="bbeb7c4764736f822e31a0518026f890ca0b81e4" offset="0" />
@@ -16561,7 +16561,7 @@
 	<software name="thunderbsp" cloneof="thunderb">
 		<description>Thunderbirds (Spa)</description>
 		<year>1989</year>
-		<publisher>MCM</publisher>
+		<publisher>MCM Software</publisher>
 		<part name="flop1" interface="floppy_3">
 			<feature name="part_id" value="Side A"/>
 			<dataarea name="flop" size="174848">
@@ -16649,7 +16649,7 @@
 	<software name="timescansp" cloneof="timescan">
 		<description>Time Scanner (Spa)</description>
 		<year>1989</year>
-		<publisher>MCM</publisher>
+		<publisher>MCM Software</publisher>
 		<part name="flop1" interface="floppy_3">
 			<dataarea name="flop" size="144384">
 				<rom name="time scanner (1989)(mcm)(es)(en)[re-release].dsk" size="144384" crc="f6be60cc" sha1="980ff8cbcf5727eca1cbe3d5158d2514d66f1504" offset="0" />
@@ -16704,7 +16704,7 @@
 	<software name="toddlert">
 		<description>Toddler Trouble</description>
 		<year>1996</year>
-		<publisher>Zenobi</publisher>
+		<publisher>Zenobi Software</publisher>
 		<part name="flop1" interface="floppy_3">
 			<dataarea name="flop" size="194816">
 				<rom name="toddler trouble (1996)(zenobi).dsk" size="194816" crc="bad46cb8" sha1="1393e49ebea152d62a47b43ac4d28b9e3e86932b" offset="0" />
@@ -16764,7 +16764,7 @@
 	<software name="tmhtsp" cloneof="tmht">
 		<description>Tortugas Ninja</description>
 		<year>1990</year>
-		<publisher>MCM</publisher>
+		<publisher>MCM Software</publisher>
 		<info name="usage" value="Requires manual for password protection"/>
 		<part name="flop1" interface="floppy_3">
 			<dataarea name="flop" size="73216">
@@ -16778,7 +16778,7 @@
 	<software name="tmhtsp2" cloneof="tmht">
 		<description>Tortugas Ninja (unprotected)</description>
 		<year>1990</year>
-		<publisher>MCM</publisher>
+		<publisher>MCM Software</publisher>
 		<part name="flop1" interface="floppy_3">
 			<dataarea name="flop" size="73216">
 				<rom name="tortugas ninja (1990)(mcm)(es)(en)[aka teenage mutant hero turtles][re-release].dsk" size="73216" crc="6766d492" sha1="7ae9c02004b4f67c7c70d0cc1e3e1157538d3418" offset="0" />
@@ -16827,7 +16827,7 @@
 	<software name="treasisl">
 		<description>Treasure Island</description>
 		<year>1991</year>
-		<publisher>Zenobi</publisher>
+		<publisher>Zenobi Software</publisher>
 		<part name="flop1" interface="floppy_3">
 			<dataarea name="flop" size="194816">
 				<rom name="treasure island (1991)(zenobi)[re-release].dsk" size="194816" crc="a9627167" sha1="2b72da4fa8c55c883b33bbfd7288b83e9acdb526" offset="0" />
@@ -16896,7 +16896,7 @@
 	<software name="troublew">
 		<description>Trouble with Trolls</description>
 		<year>1996</year>
-		<publisher>Zenobi</publisher>
+		<publisher>Zenobi Software</publisher>
 		<part name="flop1" interface="floppy_3">
 			<dataarea name="flop" size="194816">
 				<rom name="trouble with trolls (1996)(zenobi).dsk" size="194816" crc="b4b266d8" sha1="457b199bd8d62a11813e985caad268a4adbcf259" offset="0" />
@@ -17065,7 +17065,7 @@
 	<software name="twdaysch">
 		<description>The Twelve Days of Christmas</description>
 		<year>1994</year>
-		<publisher>Zenobi</publisher>
+		<publisher>Zenobi Software</publisher>
 		<part name="flop1" interface="floppy_3">
 			<dataarea name="flop" size="194816">
 				<rom name="twelve days of christmas, the (1994)(zenobi).dsk" size="194816" crc="954564f0" sha1="f24abcc5bda989a189f6d817332db7becb865e01" offset="0" />
@@ -17108,7 +17108,7 @@
 	<software name="typhoon">
 		<description>Typhoon</description>
 		<year>1988</year>
-		<publisher>Imagine</publisher>
+		<publisher>Imagine Software</publisher>
 		<part name="flop1" interface="floppy_3">
 			<dataarea name="flop" size="156672">
 				<rom name="typhoon (1988)(imagine).dsk" size="156672" crc="71be4480" sha1="8475b7e1957fccad01db0ad92f2a741be11f62c8" offset="0" />
@@ -17120,7 +17120,7 @@
 	<software name="typhoonb" cloneof="typhoon">
 		<description>Typhoon (alt)</description>
 		<year>1988</year>
-		<publisher>Imagine</publisher>
+		<publisher>Imagine Software</publisher>
 		<part name="flop1" interface="floppy_3">
 			<dataarea name="flop" size="194816">
 				<rom name="typhoon (1988)(imagine)[a].dsk" size="194816" crc="a3d5abe7" sha1="8e106d7fc0f2048712f5179e9b57f8d5ad93eb41" offset="0" />
@@ -17132,7 +17132,7 @@
 	<software name="typhoonc" cloneof="typhoon">
 		<description>Typhoon (alt 2)</description>
 		<year>1988</year>
-		<publisher>Imagine</publisher>
+		<publisher>Imagine Software</publisher>
 		<part name="flop1" interface="floppy_3">
 			<dataarea name="flop" size="155648">
 				<rom name="typhoon (1988)(imagine)[a2].dsk" size="155648" crc="192f7e58" sha1="f9285638c65e08bed3a11e0ae44293743b4fb917" offset="0" />
@@ -17144,7 +17144,7 @@
 	<software name="unbornon">
 		<description>The Unborn One</description>
 		<year>1991</year>
-		<publisher>Zenobi</publisher>
+		<publisher>Zenobi Software</publisher>
 		<part name="flop1" interface="floppy_3">
 			<dataarea name="flop" size="194816">
 				<rom name="unborn one, the (1991)(zenobi).dsk" size="194816" crc="70778ba8" sha1="05a8f137a7fba635a1a57226e6873ca081644b12" offset="0" />
@@ -17219,7 +17219,7 @@
 	<software name="urban">
 		<description>Urban</description>
 		<year>1991</year>
-		<publisher>Zenobi</publisher>
+		<publisher>Zenobi Software</publisher>
 		<part name="flop1" interface="floppy_3">
 			<dataarea name="flop" size="194816">
 				<rom name="urban (1991)(zenobi).dsk" size="194816" crc="d2c13bb6" sha1="961b3b7c51943998326074b9db3c9a12899d92ae" offset="0" />
@@ -17231,7 +17231,7 @@
 	<software name="venom">
 		<description>Venom</description>
 		<year>1988</year>
-		<publisher>Zenobi</publisher>
+		<publisher>Zenobi Software</publisher>
 		<part name="flop1" interface="floppy_3">
 			<dataarea name="flop" size="194816">
 				<rom name="venom (1988)(zenobi)[re-release].dsk" size="194816" crc="4ef0d1ee" sha1="6623a8b2d8934afc6a1197594a97ae8330164ced" offset="0" />
@@ -17243,7 +17243,7 @@
 	<software name="verybigc">
 		<description>The Very Big Cave Adventure</description>
 		<year>1986</year>
-		<publisher>Zenobi</publisher>
+		<publisher>Zenobi Software</publisher>
 		<part name="flop1" interface="floppy_3">
 			<dataarea name="flop" size="194816">
 				<rom name="very big cave adventure, the (1986)(zenobi)[re-release].dsk" size="194816" crc="57d0ccbb" sha1="5d35574bc5d8ccf621aa3b24691e739615840c6a" offset="0" />
@@ -17318,7 +17318,7 @@
 	<software name="vindicat">
 		<description>The Vindicator</description>
 		<year>1988</year>
-		<publisher>Imagine</publisher>
+		<publisher>Imagine Software</publisher>
 		<part name="flop1" interface="floppy_3">
 			<dataarea name="flop" size="221184">
 				<rom name="vindicator, the (1988)(imagine).dsk" size="221184" crc="c63202dc" sha1="b0bcc18baf2134ebbde4b1ac1c231ebaf8d5084b" offset="0" />
@@ -17330,7 +17330,7 @@
 	<software name="vindicata" cloneof="vindicat">
 		<description>The Vindicator (alt)</description>
 		<year>1988</year>
-		<publisher>Imagine</publisher>
+		<publisher>Imagine Software</publisher>
 		<part name="flop1" interface="floppy_3">
 			<dataarea name="flop" size="194816">
 				<rom name="vindicator, the (1988)(imagine)[a].dsk" size="194816" crc="7cddd8a0" sha1="194b8cf0dcca32553e3a880e20fea4d37454ef2e" offset="0" />
@@ -17342,7 +17342,7 @@
 	<software name="vindicatb" cloneof="vindicat">
 		<description>The Vindicator (alt 2)</description>
 		<year>1988</year>
-		<publisher>Imagine</publisher>
+		<publisher>Imagine Software</publisher>
 		<part name="flop1" interface="floppy_3">
 			<dataarea name="flop" size="194816">
 				<rom name="vindicator, the (1988)(imagine)[a2].dsk" size="194816" crc="f7318fed" sha1="b287dfd9651095aa4d7e93ce03061ea0fae80499" offset="0" />
@@ -17354,7 +17354,7 @@
 	<software name="violvood">
 		<description>The Violator of Voodoo</description>
 		<year>1991</year>
-		<publisher>Zenobi</publisher>
+		<publisher>Zenobi Software</publisher>
 		<part name="flop1" interface="floppy_3">
 			<dataarea name="flop" size="194816">
 				<rom name="violator of voodoo, the (1991)(zenobi).dsk" size="194816" crc="1360096e" sha1="7d3d1d1b7e79a9b4f3fd3f8ec418303828283295" offset="0" />
@@ -17366,7 +17366,7 @@
 	<software name="virus">
 		<description>Virus</description>
 		<year>1988</year>
-		<publisher>Firebird</publisher>
+		<publisher>Firebird Software</publisher>
 		<part name="flop1" interface="floppy_3">
 			<dataarea name="flop" size="73216">
 				<rom name="virus (1988)(firebird).dsk" size="73216" crc="7fb23c60" sha1="5b8ffbd10aab44a224064f794432c229846ab627" offset="0" />
@@ -17391,7 +17391,7 @@
 	<software name="wecleman">
 		<description>WEC Le Mans</description>
 		<year>1988</year>
-		<publisher>Imagine</publisher>
+		<publisher>Imagine Software</publisher>
 		<part name="flop1" interface="floppy_3">
 			<dataarea name="flop" size="194816">
 				<rom name="wec le mans (1988)(imagine).dsk" size="194816" crc="7e865452" sha1="d6e41f7a5c257858922b8b9d26131be93abb344d" offset="0" />
@@ -17403,7 +17403,7 @@
 	<software name="weclemana" cloneof="wecleman">
 		<description>WEC Le Mans (alt)</description>
 		<year>1988</year>
-		<publisher>Imagine</publisher>
+		<publisher>Imagine Software</publisher>
 		<part name="flop1" interface="floppy_3">
 			<dataarea name="flop" size="112640">
 				<rom name="wec le mans (1988)(imagine)[a].dsk" size="112640" crc="ee4cc288" sha1="2aaf533389d90dc4377396386c4abb6e07d4c7aa" offset="0" />
@@ -17446,7 +17446,7 @@
 	<software name="wanderer">
 		<description>Wanderer</description>
 		<year>1989</year>
-		<publisher>MCM</publisher>
+		<publisher>MCM Software</publisher>
 		<part name="flop1" interface="floppy_3">
 			<dataarea name="flop" size="85760">
 				<rom name="wanderer (1989)(mcm)(es)(en)[re-release].dsk" size="85760" crc="79b50978" sha1="3d3101f5d9ea075b837fe68caff99eb0947c811a" offset="0" />
@@ -17502,7 +17502,7 @@
 	<software name="wellofzo">
 		<description>The Well of Zol</description>
 		<year>1994</year>
-		<publisher>Zenobi</publisher>
+		<publisher>Zenobi Software</publisher>
 		<part name="flop1" interface="floppy_3">
 			<dataarea name="flop" size="194816">
 				<rom name="well of zol, the (1994)(zenobi).dsk" size="194816" crc="53239936" sha1="a7dd128057ee8dfba7718e7c691413dcc0f7fb3d" offset="0" />
@@ -17551,7 +17551,7 @@
 	<software name="whitefea">
 		<description>The White Feather Cloak</description>
 		<year>1992</year>
-		<publisher>Zenobi</publisher>
+		<publisher>Zenobi Software</publisher>
 		<part name="flop1" interface="floppy_3">
 			<dataarea name="flop" size="194816">
 				<rom name="white feather cloak, the (1992)(zenobi)[re-release].dsk" size="194816" crc="b9cba097" sha1="24a74a05414d5565d3ecdae3badb8d31fd980696" offset="0" />
@@ -17582,7 +17582,7 @@
 	<software name="wizardqu">
 		<description>Wizard Quest</description>
 		<year>1992</year>
-		<publisher>Zenobi</publisher>
+		<publisher>Zenobi Software</publisher>
 		<part name="flop1" interface="floppy_3">
 			<dataarea name="flop" size="194816">
 				<rom name="wizard quest (1992)(zenobi).dsk" size="194816" crc="68a39e6b" sha1="dfbd2ff0cad92e093535cb2bf7698e14fbc46803" offset="0" />
@@ -17594,7 +17594,7 @@
 	<software name="wizardoz">
 		<description>The Wizard of Oz</description>
 		<year>1995</year>
-		<publisher>Zenobi</publisher>
+		<publisher>Zenobi Software</publisher>
 		<part name="flop1" interface="floppy_3">
 			<dataarea name="flop" size="194816">
 				<rom name="wizard of oz, the (1995)(zenobi).dsk" size="194816" crc="49211c28" sha1="5e910a68ca1f4e36e75a2cb598f1ff37037a01e3" offset="0" />
@@ -17619,7 +17619,7 @@
 	<software name="wrldclru">
 		<description>World Class Rugby</description>
 		<year>1991</year>
-		<publisher>Audiogenic</publisher>
+		<publisher>Audiogenic Software</publisher>
 		<part name="flop1" interface="floppy_3">
 			<dataarea name="flop" size="194816">
 				<rom name="world class rugby (1991)(audiogenic)[aka sports action rugby].dsk" size="194816" crc="b872dd44" sha1="2955b8cc19dc423caa56c52f1d87201379bff23e" offset="0" />
@@ -17829,7 +17829,7 @@
 	<software name="zenquest">
 		<description>Zen Quest</description>
 		<year>1995</year>
-		<publisher>Zenobi</publisher>
+		<publisher>Zenobi Software</publisher>
 		<part name="flop1" interface="floppy_3">
 			<dataarea name="flop" size="194816">
 				<rom name="zen quest (1995)(zenobi).dsk" size="194816" crc="eafce910" sha1="cc5adca5233706f5480fe1bfc10f12cacd910a10" offset="0" />
@@ -17873,7 +17873,7 @@
 	<software name="zzzz">
 		<description>Zzzz</description>
 		<year>1986</year>
-		<publisher>Zenobi</publisher>
+		<publisher>Zenobi Software</publisher>
 		<part name="flop1" interface="floppy_3">
 			<dataarea name="flop" size="194816">
 				<rom name="zzzz (1986)(zenobi)[re-release].dsk" size="194816" crc="87122e5a" sha1="455c344a7b0ffce91dbf18c33d0e696fd569c7c1" offset="0" />
@@ -19527,7 +19527,7 @@
 	<software name="buggyboysp" cloneof="buggyboy">
 		<description>Buggy Boy (Spa)</description>
 		<year>1988</year>
-		<publisher>MCM</publisher>
+		<publisher>MCM Software</publisher>
 		<part name="flop1" interface="floppy_3">
 			<dataarea name="flop" size = "195635">
 				<rom name="Buggy Boy.dsk" size="195635" crc="c37afecb" sha1="19550826617711dd2d8c0d17421b6f5266a44cd1" offset="0"/>
@@ -19652,7 +19652,7 @@
 	<software name="goldnaxespa" cloneof="goldnaxe">
 		<description>Golden Axe (Spa) (alt)</description>
 		<year>1990</year>
-		<publisher>MCM</publisher>
+		<publisher>MCM Software</publisher>
 		<part name="flop1" interface="floppy_3">
 			<feature name="part_id" value="Side A"/>
 			<dataarea name="flop" size = "166599">
@@ -19860,7 +19860,7 @@
 	<software name="bttf3spa" cloneof="bttf3">
 		<description>Regreso al Futuro - Parte III (alt)</description>
 		<year>1991</year>
-		<publisher>MCM</publisher>
+		<publisher>MCM Software</publisher>
 		<part name="flop1" interface="floppy_3">
 			<feature name="part_id" value="Side A"/>
 			<dataarea name="flop" size = "195635">
@@ -19897,7 +19897,7 @@
 	<software name="ringwarssp">
 		<description>Ring Wars (Spa)</description>
 		<year>1989</year>
-		<publisher>MCM</publisher>
+		<publisher>MCM Software</publisher>
 		<part name="flop1" interface="floppy_3">
 			<dataarea name="flop" size = "189952">
 				<rom name="Ring Wars.dsk" size="189952" crc="2dd821c4" sha1="e662b7d4b6915078901caadc8028b0b2acdc8a06" offset="0"/>

--- a/hash/specpls3_flop.xml
+++ b/hash/specpls3_flop.xml
@@ -5751,7 +5751,7 @@
 	<software name="pirate33a" cloneof="pirate33">
 		<description>Pirate 3 +3 (alt)</description>
 		<year>1987</year>
-		<publisher>Pirate</publisher>
+		<publisher>Pirate Software</publisher>
 		<part name="flop1" interface="floppy_3">
 			<dataarea name="flop" size="194816">
 				<rom name="pirate 3 +3 - smash out + call me psycho + holiday in sumaria (1987)(pirate).dsk" size="194816" crc="c9c2142f" sha1="9ae3faaa820eceb282dde70c7a22117747a1c36b" offset="0" />
@@ -6440,7 +6440,7 @@
 	<software name="takefive">
 		<description>Take Five</description>
 		<year>1988</year>
-		<publisher>Pirate</publisher>
+		<publisher>Pirate Software</publisher>
 		<part name="flop1" interface="floppy_3">
 			<feature name="part_id" value="Side A: Gangplank + Just Imagine"/>
 			<dataarea name="flop" size="194816">

--- a/hash/specpls3_flop.xml
+++ b/hash/specpls3_flop.xml
@@ -19559,17 +19559,18 @@
 	</software>
 
 	<software name="comarcav">
+	<!-- No good dump exists of Disk 2. -->
 		<description>Comic, Arcade &amp; Aventura</description>
 		<year>1991</year>
 		<publisher>Dro Soft</publisher>
 		<part name="flop1" interface="floppy_3">
-			<feature name="part_id" value="Side A: Capitan Trueno, Freddy Hardest"/>
+			<feature name="part_id" value="Disk 1, Side A: Capitan Trueno, Freddy Hardest"/>
 			<dataarea name="flop" size = "166817">
 				<rom name="Comic, Arcade &amp; Aventura - Disk 1 Side 1.dsk" size="166817" crc="926eafa7" sha1="73401bac1b1c0b2c5e7b1f164378bf1bd83de99a" offset="0"/>
 			</dataarea>
 		</part>
 		<part name="flop2" interface="floppy_3">
-			<feature name="part_id" value="Side B: Cozumel, Cosmic Sheriff"/>
+			<feature name="part_id" value="Disk 1, Side B: Cozumel, Cosmic Sheriff"/>
 			<dataarea name="flop" size = "146815">
 				<rom name="Comic, Arcade &amp; Aventura - Disk 1 Side 2.dsk" size="146815" crc="f3aa29d1" sha1="e64bd9a87a81dd273751d6dca1a1e413d9018fa1" offset="0"/>
 			</dataarea>

--- a/hash/specpls3_flop.xml
+++ b/hash/specpls3_flop.xml
@@ -3905,7 +3905,7 @@
 		<part name="flop2" interface="floppy_3">
 			<feature name="part_id" value="Side B: Short Circuit + The Great Escape + Yie Ar Kung-Fu"/>
 			<dataarea name="flop" size="194560">
-			<rom name="chartbusters - short circuit + the great escape + yie ar kung-fu (19xx)(ocean)(side b).dsk" size="194560" crc="2c6606cf" sha1="e2224ab3990f61d451fa6741419b6a2653314658" offset="0" />
+				<rom name="chartbusters - short circuit + the great escape + yie ar kung-fu (19xx)(ocean)(side b).dsk" size="194560" crc="2c6606cf" sha1="e2224ab3990f61d451fa6741419b6a2653314658" offset="0" />
 			</dataarea>
 		</part>
 	</software>
@@ -8695,7 +8695,8 @@
 	</software>
 
 <!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
-	<software name="cvaniasi">
+	<!-- This is an old version, dated 201711 -->
+	<software name="cvaniasia" cloneof="cvaniasi">
 		<description>Castlevania - Spectral Interlude</description>
 		<year>2015</year>
 		<publisher>Rewind Team</publisher>
@@ -8707,7 +8708,8 @@
 	</software>
 
 <!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
-	<software name="cvaniasisp" cloneof="cvaniasi">
+	<!-- This is an old version, dated 201711 -->
+	<software name="cvaniasispa" cloneof="cvaniasi">
 		<description>Castlevania - Spectral Interlude (Spa)</description>
 		<year>2015</year>
 		<publisher>Rewind Team</publisher>
@@ -8719,7 +8721,8 @@
 	</software>
 
 <!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
-	<software name="cvaniasiit" cloneof="cvaniasi">
+	<!-- This is an old version, dated 201711 -->
+	<software name="cvaniasiita" cloneof="cvaniasi">
 		<description>Castlevania - Spectral Interlude (Ita)</description>
 		<year>2015</year>
 		<publisher>Rewind Team</publisher>
@@ -8731,7 +8734,8 @@
 	</software>
 
 <!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
-	<software name="cvaniasiru" cloneof="cvaniasi">
+	<!-- This is an old version, dated 201711 -->
+	<software name="cvaniasirua" cloneof="cvaniasi">
 		<description>Castlevania - Spectral Interlude (Rus)</description>
 		<year>2015</year>
 		<publisher>Rewind Team</publisher>
@@ -8743,7 +8747,8 @@
 	</software>
 
 <!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
-	<software name="cvaniasipo" cloneof="cvaniasi">
+	<!-- This is an old version, dated 201711 -->
+	<software name="cvaniasipoa" cloneof="cvaniasi">
 		<description>Castlevania - Spectral Interlude (Pol)</description>
 		<year>2015</year>
 		<publisher>Rewind Team</publisher>
@@ -20010,5 +20015,60 @@
 		</part>
 	</software>
 
+<!-- Other floppy images -->
+	<software name="cvaniasi">
+		<description>Castlevania - Spectral Interlude</description>
+		<year>2015</year>
+		<publisher>Rewind Team</publisher>
+		<part name="flop1" interface="floppy_3">
+			<dataarea name="flop" size="194816">
+				<rom name="castleenglish.dsk" size="194816" crc="d03dce64" sha1="fa128c8f3cd307018cbe826605fa55277ca9065b" offset="0"/>
+			</dataarea>
+		</part>
+	</software>
+
+	<software name="cvaniasiit" cloneof="cvaniasi">
+		<description>Castlevania - Spectral Interlude (Ita)</description>
+		<year>2015</year>
+		<publisher>Rewind Team</publisher>
+		<part name="flop1" interface="floppy_3">
+			<dataarea name="flop" size="194816">
+				<rom name="castleitalian.dsk" size="194816" crc="78bada74" sha1="87915ed0de02bf7ebc69735bc700ac04c42813b0" offset="0"/>
+			</dataarea>
+		</part>
+	</software>
+
+	<software name="cvaniasipo" cloneof="cvaniasi">
+		<description>Castlevania - Spectral Interlude (Pol)</description>
+		<year>2015</year>
+		<publisher>Rewind Team</publisher>
+		<part name="flop1" interface="floppy_3">
+			<dataarea name="flop" size="194816">
+				<rom name="castlepoland.dsk" size="194816" crc="e34eb33f" sha1="6885cac79a3061701c68cb414b8e151310735513" offset="0"/>
+			</dataarea>
+		</part>
+	</software>
+
+	<software name="cvaniasiru" cloneof="cvaniasi">
+		<description>Castlevania - Spectral Interlude (Rus)</description>
+		<year>2015</year>
+		<publisher>Rewind Team</publisher>
+		<part name="flop1" interface="floppy_3">
+			<dataarea name="flop" size="194816">
+				<rom name="castlerussian.dsk" size="194816" crc="a90d610c" sha1="40bb9aa34d4fad35dc2574f4721d07b83863bfe9" offset="0"/>
+			</dataarea>
+		</part>
+	</software>
+
+	<software name="cvaniasisp" cloneof="cvaniasi">
+		<description>Castlevania - Spectral Interlude (Spa)</description>
+		<year>2015</year>
+		<publisher>Rewind Team</publisher>
+		<part name="flop1" interface="floppy_3">
+			<dataarea name="flop" size="194816">
+				<rom name="castlespanish.dsk" size="194816" crc="0077de9c" sha1="f172cd6a5d39b1a46cfb9151851996e81f5bb4b8" offset="0"/>
+			</dataarea>
+		</part>
+	</software>
 
 </softwarelist>

--- a/hash/specpls3_flop.xml
+++ b/hash/specpls3_flop.xml
@@ -1683,7 +1683,7 @@
 	Notes about the known DSK dumps:
 		Some dumps may come with an empty Side B, which is technically correct for games which were released with an empty side on purpose. These were usually labeled as "Sin grabar para tu uso" ("Unrecorded for your use") in many Spanish releases.
 		Some of the "master disks" from Zeppelin Games share the same file (same SHA-1) for their Side B. This has been verified against the downloads available in World of Spectrum.
-		A few releases had a version for a different system on the other side. These have been commented out but not removed, for reference.
+		A few releases had a version for a different system on the other side. These haven't been removed, as it was possible for the user to insert those sides and do anything they wanted with them.
 		
 -->
 
@@ -8133,27 +8133,18 @@
 		<year>1989</year>
 		<publisher>Dinamic Software</publisher>
 		<part name="flop1" interface="floppy_3">
+			<feature name="part_id" value="Side A: Spectrum"/>
 			<dataarea name="flop" size="80384">
 				<rom name="bestial warrior (1989)(dinamic)(es)[a].dsk" size="80384" crc="208235f6" sha1="50d9a3bb79b82deb6c08253cfbffa460bb8abaa2" offset="0" />
 			</dataarea>
 		</part>
-	</software>
-
-<!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
-	<!-- This image came from a dual-system Spectrum/Amstrad release (Side A: Spectrum, Side B: Amstrad) -->
-<!--
-	<software name="bestialw">
-		<description>Bestial Warrior (rerelease)</description>
-		<year>1989</year>
-		<publisher>Dinamic Software</publisher>
-		<part name="flop1" interface="floppy_3">
+		<part name="flop2" interface="floppy_3">
+			<feature name="part_id" value="Side B: Amstrad"/>
 			<dataarea name="flop" size="91136">
 				<rom name="bestial warrior (1989)(dinamic)(es)(side b).dsk" size="91136" crc="3fd882c2" sha1="977204c72ef1b1643e33516ffe904b35ad87c826" offset="0" />
 			</dataarea>
 		</part>
 	</software>
--->
-
 	
 <!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
 	<!-- May be the same edition as the IPF -->
@@ -19803,21 +19794,13 @@
 		<year>1988</year>
 		<publisher>Dinamic Software</publisher>
 		<part name="flop1" interface="floppy_3">
+			<feature name="part_id" value="Side A: Spectrum"/>
 			<dataarea name="flop" size="166817">
 				<rom name="Navy Moves (Doble Edición) (side A).dsk" size="166817" crc="718149f4" sha1="5018740f71bc2ae08343f4040590cfa2550333bf" offset="0" />
 			</dataarea>
 		</part>
-	</software>
-
-<!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
-	<!-- This image came from a dual-system Spectrum/Amstrad release (Side A: Spectrum, Side B: Amstrad) -->
-	<!-- Dump made with CPDRead -->
-<!--
-	<software name="navymove">
-		<description>Navy Moves</description>
-		<year>1988</year>
-		<publisher>Dinamic Software</publisher>
-		<part name="flop1" interface="floppy_3">
+		<part name="flop2" interface="floppy_3">
+			<feature name="part_id" value="Side B: Amstrad"/>
 			<dataarea name="flop" size="214784">
 				<rom name="navy moves (1988)(dinamic)(es)(en)(side b).dsk" size="214784" crc="c32323a2" sha1="da30c11411368b22474b032f39e8f8b968f7903b" offset="0" />
 			</dataarea>

--- a/hash/specpls3_flop.xml
+++ b/hash/specpls3_flop.xml
@@ -16417,8 +16417,8 @@
 	</software>
 
 <!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
-	<software name="terrorpo">
-		<description>Terrorpods</description>
+	<software name="terrorposp">
+		<description>Terrorpods (Spa)</description>
 		<year>1989</year>
 		<publisher>Dro Soft</publisher>
 		<part name="flop1" interface="floppy_3">

--- a/hash/specpls3_flop.xml
+++ b/hash/specpls3_flop.xml
@@ -1667,18 +1667,17828 @@
 		</part>
 	</software>
 
+<!--
+	Below is a selection of (most of) the DSK files featured in the TOSEC DAT files which, according to Lady Eklipse, include all files that were in TOSEC and all files from www.worldofspectrum.org which were never in TOSEC before. Which file and update they come from is commented for each entry, so that they can be consulted.
 
-	<!-- Other images -->
+	Files removed:
+		- Files marked as "bad dumps" which have a "good" parent set.
+		- Trained games, except for a "cheat version" of Neighbours which may have come from the original developers.
+		- 80-track (3.5'') disk images.
+		- Files generated with the ZXZVM interpreter.
+		- Games from the Crap Games Competition.
 
-	<software name="pacmania" >
-		<description>Pac-Mania (Euro, Aus)</description>
-		<year>1988</year>
-		<publisher>Grandslam Entertainments</publisher>
+	All the DSK files which have a corresponding IPF have been labeled as "alt" clones until they're confirmed to come from the exact same release and can be safely removed (there's an added disclaimer about it in each of these entries, to make them easy to locate).
+	Other alt versions not in World of Spectrum have been kept for the same reason, since the exact source of each file doesn't seem to be properly documented anywhere, which means they'd need some research before a safe removal.
+
+	Notes about the known DSK dumps:
+		Some dumps may come with an empty Side B, which is technically correct for games which were released with an empty side on purpose. These were usually labeled as "Sin grabar para tu uso" ("Unrecorded for your use") in many Spanish releases.
+		Some of the "master disks" from Zeppelin Games share the same file (same SHA-1) for their Side B. This has been verified against the downloads available in World of Spectrum.
+		A few releases had a version for a different system on the other side. These have been commented out but not removed, for reference.
+		
+-->
+
+<!-- From "Sinclair ZX Spectrum - Applications - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="plus3uti">
+		<description>+3 Utilities</description>
+		<year>19??</year>
+		<publisher>&lt;unknown&gt;</publisher>
 		<part name="flop1" interface="floppy_3">
-			<dataarea name="flop" size="195328">
-				<rom name="pac-mania.dsk" size="195328" crc="88f5506b" sha1="827c95935dd3a1dd919989fc6d7a0efa4e5aebc1" offset="0" />
+			<feature name="part_id" value="Side A"/>
+			<dataarea name="flop" size="226048">
+				<rom name="+3 utilities (19xx)(-)(side a).dsk" size="226048" crc="cb9b1cf8" sha1="3f6887c23f6096e15c04c8705a9dc7e0a011136f" offset="0" />
+			</dataarea>
+		</part>
+		<part name="flop2" interface="floppy_3">
+			<feature name="part_id" value="Side B"/>
+			<dataarea name="flop" size="226048">
+				<rom name="+3 utilities (19xx)(-)(side b).dsk" size="226048" crc="dac28f08" sha1="bcf0365cc1a094e70bc8c4cfecdef66f64299ff6" offset="0" />
 			</dataarea>
 		</part>
 	</software>
 
+<!-- From "Sinclair ZX Spectrum - Applications - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="007trans">
+		<description>007 Trans-Master</description>
+		<year>1988</year>
+		<publisher>ZX-Guaranteed</publisher>
+		<part name="flop1" interface="floppy_3">
+			<feature name="part_id" value="Side A"/>
+			<dataarea name="flop" size="251711">
+				<rom name="007 trans-master (1988)(zx-guaranteed)(side a)[samdisk].dsk" size="251711" crc="4e2d8460" sha1="408eb22ee2f973920d2265f1adabf9342203a923" offset="0" />
+			</dataarea>
+		</part>
+		<part name="flop2" interface="floppy_3">
+			<feature name="part_id" value="Side B"/>
+			<dataarea name="flop" size="195635">
+				<rom name="007 trans-master (1988)(zx-guaranteed)(side b)[samdisk].dsk" size="195635" crc="1a105700" sha1="1d8242ba18cd0c2596d4172d073aeb8984efb807" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Applications - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="3dconkit">
+		<description>3D Construction Kit</description>
+		<year>1991</year>
+		<publisher>Domark</publisher>
+		<part name="flop1" interface="floppy_3">
+			<feature name="part_id" value="Side A"/>
+			<dataarea name="flop" size="194816">
+				<rom name="3d construction kit (1991)(domark)(side a).dsk" size="194816" crc="3487ed0f" sha1="f690e55eb863eda62e66f3d4e1bc2486d08b3db7" offset="0" />
+			</dataarea>
+		</part>
+		<part name="flop2" interface="floppy_3">
+			<feature name="part_id" value="Side B"/>
+			<dataarea name="flop" size="194816">
+				<rom name="3d construction kit (1991)(domark)(side b).dsk" size="194816" crc="76ace043" sha1="b5aecf13e6cdbf9b3b75ae75427f3d6baa56b9ef" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Applications - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="3dgamemk">
+		<description>3D Game Maker</description>
+		<year>1987</year>
+		<publisher>CRL Group</publisher>
+		<part name="flop1" interface="floppy_3">
+			<dataarea name="flop" size="194816">
+				<rom name="3d game maker (1987)(crl group).dsk" size="194816" crc="d398b5bd" sha1="2896af452d00e389315407ca66c628fcb8b15307" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Applications - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="3dgamemkdro" cloneof="3dgamemk">
+		<description>3D Game Maker (Spain, Dro Soft)</description>
+		<year>1987</year>
+		<publisher>Dro Soft</publisher>
+		<part name="flop1" interface="floppy_3">
+			<dataarea name="flop" size="194816">
+				<rom name="3d game maker (1987)(dro soft)(es)(en)[re-release].dsk" size="194816" crc="1b06a5bc" sha1="6324e5c0e5f41f37d076d631a3be43e1a70ba472" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Applications - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="3dgamemkzaf" cloneof="3dgamemk">
+		<description>3D Game Maker (Spain, Zafiro)</description>
+		<year>1987</year>
+		<publisher>Zafiro Software Division</publisher>
+		<part name="flop1" interface="floppy_3">
+			<dataarea name="flop" size="194816">
+				<rom name="3d game maker (1987)(zafiro software division)(es)(en)[re-release].dsk" size="194816" crc="df6b4a8e" sha1="a87af7093fe5a43c63e4af2e4486bfdae47fc4c2" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Applications - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="3dgamemka" cloneof="3dgamemk">
+		<description>3D Game Maker (alt)</description>
+		<year>1987</year>
+		<publisher>CRL Group</publisher>
+		<part name="flop1" interface="floppy_3">
+			<dataarea name="flop" size="194816">
+				<rom name="3d game maker (1987)(crl group)[a].dsk" size="194816" crc="f61327af" sha1="2e220165c97eb8b3511d9103b051dd2e5eba7792" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Applications - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="3dgamemkb" cloneof="3dgamemk">
+		<description>3D Game Maker (alt 2)</description>
+		<year>1987</year>
+		<publisher>CRL Group</publisher>
+		<part name="flop1" interface="floppy_3">
+			<dataarea name="flop" size="194816">
+				<rom name="3d game maker (1987)(crl group)[a2].dsk" size="194816" crc="0c34a517" sha1="268bdbf5004cd2d475147a3c4523cc264c8da844" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Applications - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="alkdevbe">
+		<description>Alkatraz Development Disks - Bedturn Project Backup</description>
+		<year>19??</year>
+		<publisher>&lt;unknown&gt;</publisher>
+		<part name="flop1" interface="floppy_3">
+			<feature name="part_id" value="Side A"/>
+			<dataarea name="flop" size="194816">
+				<rom name="alkatraz development disks - bedturn project backup (19xx)(-)(side a).dsk" size="194816" crc="20c60438" sha1="d3c5a0b7245a76c59813cc60bc1fa418a722fbfc" offset="0" />
+			</dataarea>
+		</part>
+		<part name="flop2" interface="floppy_3">
+			<feature name="part_id" value="Side B"/>
+			<dataarea name="flop" size="194816">
+				<rom name="alkatraz development disks - bedturn project backup (19xx)(-)(side b).dsk" size="194816" crc="ea9f0113" sha1="7642f9f5418515358821a1d3da74713a475d449c" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Applications - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="alkdevde">
+		<description>Alkatraz Development Disks - Designer + Assembler Backup</description>
+		<year>19??</year>
+		<publisher>&lt;unknown&gt;</publisher>
+		<part name="flop1" interface="floppy_3">
+			<feature name="part_id" value="Side A"/>
+			<dataarea name="flop" size="194816">
+				<rom name="alkatraz development disks - designer + assembler backup (19xx)(-)(side a).dsk" size="194816" crc="7ea28851" sha1="f28aeab46476c78a323b821a125a00988826eaf1" offset="0" />
+			</dataarea>
+		</part>
+		<part name="flop2" interface="floppy_3">
+			<feature name="part_id" value="Side B"/>
+			<dataarea name="flop" size="194816">
+				<rom name="alkatraz development disks - designer + assembler backup (19xx)(-)(side b).dsk" size="194816" crc="af054290" sha1="0fc31beb8073b3b3a2f51a8e4591024d736bf011" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Applications - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="alkdevdi">
+		<description>Alkatraz Development Disks - Disk Protection Source Code</description>
+		<year>19??</year>
+		<publisher>&lt;unknown&gt;</publisher>
+		<part name="flop1" interface="floppy_3">
+			<feature name="part_id" value="Side A"/>
+			<dataarea name="flop" size="194816">
+				<rom name="alkatraz development disks - disk protection source code (19xx)(-)(side a).dsk" size="194816" crc="ed298d37" sha1="f3a0de55390b92101af0696c3aae318d6c169e3b" offset="0" />
+			</dataarea>
+		</part>
+		<part name="flop2" interface="floppy_3">
+			<feature name="part_id" value="Side B"/>
+			<dataarea name="flop" size="194816">
+				<rom name="alkatraz development disks - disk protection source code (19xx)(-)(side b).dsk" size="194816" crc="7b999303" sha1="3c682b6b0e3093c8e52142a53620f6ebd126144c" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Applications - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="alkdevlo">
+		<description>Alkatraz Development Disks - Locoscript Start of Day 25-10-88</description>
+		<year>19??</year>
+		<publisher>&lt;unknown&gt;</publisher>
+		<part name="flop1" interface="floppy_3">
+			<feature name="part_id" value="Side A"/>
+			<dataarea name="flop" size="195328">
+				<rom name="alkatraz development disks - locoscript start of day 25-10-88 (19xx)(-)(side a).dsk" size="195328" crc="8467b466" sha1="28de851c4321d8bcfcd933681da80464c91495da" offset="0" />
+			</dataarea>
+		</part>
+		<part name="flop2" interface="floppy_3">
+			<feature name="part_id" value="Side B"/>
+			<dataarea name="flop" size="256">
+				<rom name="alkatraz development disks - locoscript start of day 25-10-88 (19xx)(-)(side b).dsk" size="256" crc="3241c590" sha1="e1c83cdc6ace15ad9986ed23118b4de3152edd48" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Applications - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="alkdevma">
+		<description>Alkatraz Development Disks - Main Enc + BASIC Run Sample Backup</description>
+		<year>19??</year>
+		<publisher>&lt;unknown&gt;</publisher>
+		<part name="flop1" interface="floppy_3">
+			<feature name="part_id" value="Side A"/>
+			<dataarea name="flop" size="194816">
+				<rom name="alkatraz development disks - main enc + basic run sample backup (19xx)(-)(side a).dsk" size="194816" crc="d799893c" sha1="41a073df4816cf8136800b800df7fdda798d063a" offset="0" />
+			</dataarea>
+		</part>
+		<part name="flop2" interface="floppy_3">
+			<feature name="part_id" value="Side B"/>
+			<dataarea name="flop" size="194816">
+				<rom name="alkatraz development disks - main enc + basic run sample backup (19xx)(-)(side b).dsk" size="194816" crc="a957d8af" sha1="fa30634dc41c54bfa38cc79ccefd1f78dc7307ce" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Applications - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="alkdevme">
+		<description>Alkatraz Development Disks - Main Encryptor + Screen Load Designer</description>
+		<year>19??</year>
+		<publisher>&lt;unknown&gt;</publisher>
+		<part name="flop1" interface="floppy_3">
+			<feature name="part_id" value="Side A"/>
+			<dataarea name="flop" size="194816">
+				<rom name="alkatraz development disks - main encryptor + screen load designer (19xx)(-)(side a).dsk" size="194816" crc="85b9c090" sha1="a06ce891b7ffde8d5aed9305efcbe78c6d830077" offset="0" />
+			</dataarea>
+		</part>
+		<part name="flop2" interface="floppy_3">
+			<feature name="part_id" value="Side B"/>
+			<dataarea name="flop" size="194816">
+				<rom name="alkatraz development disks - main encryptor + screen load designer (19xx)(-)(side b).dsk" size="194816" crc="f0942b49" sha1="aced8a4ee1bcb14af0ea2d00627c992c0aed8051" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Applications - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="alkdevmp">
+		<description>Alkatraz Development Disks - Mastering Program</description>
+		<year>19??</year>
+		<publisher>&lt;unknown&gt;</publisher>
+		<part name="flop1" interface="floppy_3">
+			<feature name="part_id" value="Side A"/>
+			<dataarea name="flop" size="194816">
+				<rom name="alkatraz development disks - mastering program (19xx)(-)(side a).dsk" size="194816" crc="2c4b33ac" sha1="669e43e1f108e3a5bb0765fd8c26317334b7a6c8" offset="0" />
+			</dataarea>
+		</part>
+		<part name="flop2" interface="floppy_3">
+			<feature name="part_id" value="Side B"/>
+			<dataarea name="flop" size="195328">
+				<rom name="alkatraz development disks - mastering program (19xx)(-)(side b).dsk" size="195328" crc="8267f81d" sha1="ba6c302eb793a0b606b573a8f9ea687050acacb5" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Applications - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="alkdevnw">
+		<description>Alkatraz Development Disks - New Word</description>
+		<year>19??</year>
+		<publisher>&lt;unknown&gt;</publisher>
+		<part name="flop1" interface="floppy_3">
+			<feature name="part_id" value="Side A"/>
+			<dataarea name="flop" size="194816">
+				<rom name="alkatraz development disks - new word (19xx)(-)(side a).dsk" size="194816" crc="4bfc1cc7" sha1="0f60502c5ac790a54f8fe7bc0a25f0d18359f44c" offset="0" />
+			</dataarea>
+		</part>
+		<part name="flop2" interface="floppy_3">
+			<feature name="part_id" value="Side B"/>
+			<dataarea name="flop" size="194816">
+				<rom name="alkatraz development disks - new word (19xx)(-)(side b).dsk" size="194816" crc="fb3a3bb3" sha1="f24a1d06c7ec8608edfe4b38b7b5e3529220c1fe" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Applications - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="alkdevrp">
+		<description>Alkatraz Development Disks - Run Program + BASIC Constructor</description>
+		<year>19??</year>
+		<publisher>&lt;unknown&gt;</publisher>
+		<part name="flop1" interface="floppy_3">
+			<feature name="part_id" value="Side A"/>
+			<dataarea name="flop" size="194816">
+				<rom name="alkatraz development disks - run program + basic constructor (19xx)(-)(side a).dsk" size="194816" crc="bfaad1c4" sha1="b9c1c83044708178ec27a31045bc1ad4498862d9" offset="0" />
+			</dataarea>
+		</part>
+		<part name="flop2" interface="floppy_3">
+			<feature name="part_id" value="Side B"/>
+			<dataarea name="flop" size="194816">
+				<rom name="alkatraz development disks - run program + basic constructor (19xx)(-)(side b).dsk" size="194816" crc="50bd1755" sha1="976406e782419329e7fe4165494a387022f12077" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Applications - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="alkdevsl">
+		<description>Alkatraz Development Disks - Sample Loader + Master Installer Backup</description>
+		<year>19??</year>
+		<publisher>&lt;unknown&gt;</publisher>
+		<part name="flop1" interface="floppy_3">
+			<feature name="part_id" value="Side A"/>
+			<dataarea name="flop" size="194816">
+				<rom name="alkatraz development disks - sample loader + master installer backup (19xx)(-)(side a).dsk" size="194816" crc="dde17998" sha1="d902feaf17b492f1d8078895989e46cb7db271f1" offset="0" />
+			</dataarea>
+		</part>
+		<part name="flop2" interface="floppy_3">
+			<feature name="part_id" value="Side B"/>
+			<dataarea name="flop" size="194816">
+				<rom name="alkatraz development disks - sample loader + master installer backup (19xx)(-)(side b).dsk" size="194816" crc="6d6226d1" sha1="b0dc9c87a3268f75fcc787348b158060720ecd70" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Applications - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="alkdevsi">
+		<description>Alkatraz Development Disks - Simple Loader + Encryptor Constructor</description>
+		<year>19??</year>
+		<publisher>&lt;unknown&gt;</publisher>
+		<part name="flop1" interface="floppy_3">
+			<feature name="part_id" value="Side A"/>
+			<dataarea name="flop" size="194816">
+				<rom name="alkatraz development disks - simple loader + encryptor constructor (19xx)(-)(side a).dsk" size="194816" crc="ea7c4658" sha1="c7a595b2b4f41242974af5e04dbebe6cf8101408" offset="0" />
+			</dataarea>
+		</part>
+		<part name="flop2" interface="floppy_3">
+			<feature name="part_id" value="Side B"/>
+			<dataarea name="flop" size="194816">
+				<rom name="alkatraz development disks - simple loader + encryptor constructor (19xx)(-)(side b).dsk" size="194816" crc="1c8977a5" sha1="11cdce40bd608ef138e68ebb0f3c0b3e04b82b67" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Applications - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="alkdevta">
+		<description>Alkatraz Development Disks - Tape System Text Backup</description>
+		<year>19??</year>
+		<publisher>&lt;unknown&gt;</publisher>
+		<part name="flop1" interface="floppy_3">
+			<feature name="part_id" value="Side A"/>
+			<dataarea name="flop" size="194816">
+				<rom name="alkatraz development disks - tape system text backup (19xx)(-)(side a).dsk" size="194816" crc="0bab95ac" sha1="a74dba9e624394543585d115622bdb878a9882b8" offset="0" />
+			</dataarea>
+		</part>
+		<part name="flop2" interface="floppy_3">
+			<feature name="part_id" value="Side B"/>
+			<dataarea name="flop" size="195840">
+				<rom name="alkatraz development disks - tape system text backup (19xx)(-)(side b).dsk" size="195840" crc="bd77584a" sha1="8e50a3c6187b84a1c96b8009e7e14eac821ac613" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Applications - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="artist2">
+		<description>The Artist II</description>
+		<year>1986</year>
+		<publisher>Softechnics</publisher>
+		<part name="flop1" interface="floppy_3">
+			<dataarea name="flop" size="194816">
+				<rom name="artist ii, the (1986)(softechnics).dsk" size="194816" crc="a752bb2a" sha1="e8ffd0e4e8ae696065bf5c3db2a9337cf2c387ea" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Applications - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="artist2a" cloneof="artist2">
+		<description>The Artist II (alt)</description>
+		<year>1986</year>
+		<publisher>Softechnics</publisher>
+		<part name="flop1" interface="floppy_3">
+			<dataarea name="flop" size="194816">
+				<rom name="artist ii, the (1986)(softechnics)[a].dsk" size="194816" crc="82e620b7" sha1="bf9adceb3fd8e524edca6ca24c6b87bf39574c54" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Applications - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="cadmaste">
+		<description>CAD-Master - Light Pen &amp; Graphics Software</description>
+		<year>1985</year>
+		<publisher>Trojan Products</publisher>
+		<part name="flop1" interface="floppy_3">
+			<dataarea name="flop" size="194816">
+				<rom name="cad-master - light pen &amp; graphics software (1985)(trojan products).dsk" size="194816" crc="69b132c2" sha1="d0d336a4e1371ec08847e136874b48c49a8fe4a2" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Applications - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="cpmplus1">
+		<description>CP-M Plus v1.0</description>
+		<year>1988</year>
+		<publisher>Locomotive</publisher>
+		<part name="flop1" interface="floppy_3">
+			<feature name="part_id" value="Side A"/>
+			<dataarea name="flop" size="194816">
+				<rom name="cp-m plus v1.0 (1988)(locomotive)(side a).dsk" size="194816" crc="c10ae485" sha1="48cf8d80d5a56786175e18acf2cca819ffb43cde" offset="0" />
+			</dataarea>
+		</part>
+		<part name="flop2" interface="floppy_3">
+			<feature name="part_id" value="Side B"/>
+			<dataarea name="flop" size="194816">
+				<rom name="cp-m plus v1.0 (1988)(locomotive)(side b).dsk" size="194816" crc="ddd0943f" sha1="9e34e27167d8f9544d73104390de59bc91cf029d" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Applications - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="complmcp">
+		<description>Complete Machine Code Package</description>
+		<year>1987</year>
+		<publisher>Roybot</publisher>
+		<part name="flop1" interface="floppy_3">
+			<dataarea name="flop" size="194816">
+				<rom name="complete machine code package (1987)(roybot).dsk" size="194816" crc="07ebb241" sha1="bce17b0972ea3196028f10820cfb7b224fb4ae16" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Applications - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="coursem3">
+		<description>Coursemaster v3.88</description>
+		<year>1988</year>
+		<publisher>Intraset</publisher>
+		<part name="flop1" interface="floppy_3">
+			<feature name="part_id" value="Side A"/>
+			<dataarea name="flop" size="194816">
+				<rom name="coursemaster v3.88 (1988)(intraset)(side a).dsk" size="194816" crc="9be595c6" sha1="d60b4f383514939ec24746de639250d3147ceffb" offset="0" />
+			</dataarea>
+		</part>
+		<part name="flop2" interface="floppy_3">
+			<feature name="part_id" value="Side B"/>
+			<dataarea name="flop" size="194816">
+				<rom name="coursemaster v3.88 (1988)(intraset)(side b).dsk" size="194816" crc="2a3229bb" sha1="31929b0b6c138da716918c0dc93849e855164101" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Applications - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="coursem3a" cloneof="coursem3">
+		<description>Coursemaster v3.88 (alt)</description>
+		<year>1988</year>
+		<publisher>Intraset</publisher>
+		<part name="flop1" interface="floppy_3">
+			<feature name="part_id" value="Side A"/>
+			<dataarea name="flop" size="194816">
+				<rom name="coursemaster v3.88 (1988)(intraset)(side a)[a].dsk" size="194816" crc="a57c526a" sha1="e53c4981d82add2be2c9516e05e7177904747484" offset="0" />
+			</dataarea>
+		</part>
+		<part name="flop2" interface="floppy_3">
+		<!-- Side missing from dump, using same as parent set -->
+			<feature name="part_id" value="Side B"/>
+			<dataarea name="flop" size="194816">
+				<rom name="coursemaster v3.88 (1988)(intraset)(side b).dsk" size="194816" crc="2a3229bb" sha1="31929b0b6c138da716918c0dc93849e855164101" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Applications - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="db1plus3">
+		<description>DB1 Plus 3 Disc Backup Utility</description>
+		<year>1988</year>
+		<publisher>Kobrahsoft</publisher>
+		<part name="flop1" interface="floppy_3">
+			<dataarea name="flop" size="194048">
+				<rom name="db1 plus 3 disc backup utility (1988)(kobrahsoft).dsk" size="194048" crc="b5034824" sha1="31330c2433400360cba392657a53ac109f5e1ae3" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Applications - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="dicev21">
+		<description>DICE v2.1</description>
+		<year>1988</year>
+		<publisher>Kobrahsoft</publisher>
+		<part name="flop1" interface="floppy_3">
+			<dataarea name="flop" size="19712">
+				<rom name="dice v2.1 (1988)(kobrahsoft)[aka disc information copier editor].dsk" size="19712" crc="4904a08a" sha1="4060b24dd339c92f0ee71fc33c6b0b0ccee7846c" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Applications - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="du54v504">
+		<description>DU54 v5.04</description>
+		<year>1998</year>
+		<publisher>John Elliott</publisher>
+		<part name="flop1" interface="floppy_3">
+			<dataarea name="flop" size="194816">
+				<rom name="du54 v5.04 (1998)(elliott, john)[aka disc util].dsk" size="194816" crc="c9148461" sha1="f12f007a80984a56d1e5704c21a443dd98c4d2f1" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Applications - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="du54v504a" cloneof="du54v504">
+		<description>DU54 v5.04 (alt)</description>
+		<year>1998</year>
+		<publisher>John Elliott</publisher>
+		<part name="flop1" interface="floppy_3">
+			<dataarea name="flop" size="194816">
+				<rom name="du54 v5.04 (1998)(elliott, john)[a][aka disc util].dsk" size="194816" crc="f54c98c5" sha1="92c704ccb2dd34f19910c174534860dd283e9d21" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Applications - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="discolog">
+		<description>Discology +3</description>
+		<year>1988</year>
+		<publisher>New Frontier</publisher>
+		<part name="flop1" interface="floppy_3">
+			<dataarea name="flop" size="183296">
+				<rom name="discology +3 (1988)(new frontier)(es).dsk" size="183296" crc="ff15f5b0" sha1="cd33b3b6c9495d3c01f837c58b41d707c3ff9337" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Applications - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="discopac">
+		<description>Discopack +3</description>
+		<year>1989</year>
+		<publisher>New Frontier</publisher>
+		<part name="flop1" interface="floppy_3">
+			<dataarea name="flop" size="204288">
+				<rom name="discopack +3 (1989)(new frontier)(es).dsk" size="204288" crc="f3b87c1a" sha1="6dfb92f4e5b45c5e33d0c7f64fa6814f121fc8f7" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Applications - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="diskdoct">
+		<description>Disk Doctor</description>
+		<year>1990</year>
+		<publisher>Supersoft</publisher>
+		<part name="flop1" interface="floppy_3">
+			<dataarea name="flop" size="194816">
+				<rom name="disk doctor (1990)(supersoft).dsk" size="194816" crc="b773bcbd" sha1="8eb18a2bc5a94632bea142a9fe42941e3605c976" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Applications - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="eddduced">
+		<description>Edd the Duck Editor (master disk)</description>
+		<year>1990</year>
+		<publisher>Zeppelin Games</publisher>
+		<part name="flop1" interface="floppy_3">
+			<feature name="part_id" value="Side A"/>
+			<dataarea name="flop" size="194816">
+				<rom name="edd the duck editor (1990)(zeppelin games)(side a)[master disk].dsk" size="194816" crc="80f3d962" sha1="f411b24c9798678eeff7adb99e8f1f23700dd34b" offset="0" />
+			</dataarea>
+		</part>
+		<part name="flop2" interface="floppy_3">
+			<feature name="part_id" value="Side B"/>
+			<dataarea name="flop" size="194816">
+				<rom name="edd the duck editor (1990)(zeppelin games)(side b)[master disk].dsk" size="194816" crc="d589b8cd" sha1="8fa913c63e1a4e94e92a00c4e86398258acbbedb" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Applications - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="flexipag">
+		<description>Flexipage Viewdata Author</description>
+		<year>1986</year>
+		<publisher>Flexibase</publisher>
+		<part name="flop1" interface="floppy_3">
+			<feature name="part_id" value="Side A"/>
+			<dataarea name="flop" size="194816">
+				<rom name="flexipage viewdata author (1986)(flexibase)(side a)[aka flexibase 8][aka flexipage 200][aka flexipage author].dsk" size="194816" crc="e89dc560" sha1="748d0dece2f53f00bd96423138e727b8124b8334" offset="0" />
+			</dataarea>
+		</part>
+		<part name="flop2" interface="floppy_3">
+			<feature name="part_id" value="Side B"/>
+			<dataarea name="flop" size="194816">
+				<rom name="flexipage viewdata author (1986)(flexibase)(side b)[aka flexibase 8][aka flexipage 200][aka flexipage author].dsk" size="194816" crc="6b6f2e9a" sha1="7f18802231a7f00dca38f12b6a9715ccb5186a7a" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Applications - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="footboxf">
+		<description>Football Boxform</description>
+		<year>1988</year>
+		<publisher>Boxoft</publisher>
+		<part name="flop1" interface="floppy_3">
+			<dataarea name="flop" size="194816">
+				<rom name="football boxform (1988)(boxoft).dsk" size="194816" crc="72d70f4d" sha1="1fd4833e1e779f43b722ee1bd82102f782a7e036" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Applications - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="g3ptog80">
+		<description>GENS3P to GENS80 Source Files Converter</description>
+		<year>1995</year>
+		<publisher>Useless Soft</publisher>
+		<part name="flop1" interface="floppy_3">
+			<dataarea name="flop" size="194816">
+				<rom name="gens3p to gens80 source files converter (1995)(useless soft).dsk" size="194816" crc="80291a4a" sha1="0803019d8631552f11f11b5819460eeb2ec28743" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Applications - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="hisobc12">
+		<description>HiSoft BASIC Compiler v1.2 +3</description>
+		<year>1986</year>
+		<publisher>HiSoft</publisher>
+		<part name="flop1" interface="floppy_3">
+			<dataarea name="flop" size="194816">
+				<rom name="hisoft basic compiler v1.2 +3 (1986)(hisoft).dsk" size="194816" crc="1043af7f" sha1="54c2de392c5a21e2a8f9e93e658c8d9ae0491f56" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Applications - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="hisoc13">
+		<description>HiSoft C v1.3 +3</description>
+		<year>1984</year>
+		<publisher>HiSoft</publisher>
+		<part name="flop1" interface="floppy_3">
+			<dataarea name="flop" size="194816">
+				<rom name="hisoft c v1.3 +3 (1984)(hisoft).dsk" size="194816" crc="a9809dc7" sha1="497986e05feebcfa73082d74f48b8c8fde4efac1" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Applications - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="hisoftdp">
+		<description>HiSoft Devpac</description>
+		<year>1983</year>
+		<publisher>HiSoft</publisher>
+		<part name="flop1" interface="floppy_3">
+			<dataarea name="flop" size="194816">
+				<rom name="hisoft devpac (1983)(hisoft).dsk" size="194816" crc="fa4173ea" sha1="f5e05ef551888e21de3de4c6d2de4538d05bfdd9" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Applications - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="hisoftdpa">
+		<description>HiSoft Devpac (alt)</description>
+		<year>1983</year>
+		<publisher>HiSoft</publisher>
+		<part name="flop1" interface="floppy_3">
+			<dataarea name="flop" size="194816">
+				<rom name="hisoft devpac (1983)(hisoft)[a].dsk" size="194816" crc="5a9afe8c" sha1="a00ad4d624bcfcd8b1dc35ff64413c6b52abf34c" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Applications - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="hispasc4">
+		<description>HiSoft Pascal 4</description>
+		<year>1983</year>
+		<publisher>HiSoft</publisher>
+		<part name="flop1" interface="floppy_3">
+			<dataarea name="flop" size="194816">
+				<rom name="hisoft pascal 4 (1983)(hisoft).dsk" size="194816" crc="77fb585e" sha1="5830aee8baff81c2744616a6ff3820ea3f515968" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Applications - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="instreca">
+		<description>Instant Recall</description>
+		<year>1988</year>
+		<publisher>Supersoft</publisher>
+		<part name="flop1" interface="floppy_3">
+			<dataarea name="flop" size="194816">
+				<rom name="instant recall (1988)(supersoft).dsk" size="194816" crc="32094d6a" sha1="a5d7e6bd6810dc2a6e2fd6c4eea0afab0989b62c" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Applications - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="lastword">
+		<description>The Last Word</description>
+		<year>1985</year>
+		<publisher>Myrmidon</publisher>
+		<part name="flop1" interface="floppy_3">
+			<dataarea name="flop" size="194816">
+				<rom name="last word, the (1985)(myrmidon).dsk" size="194816" crc="c4283b67" sha1="0a709233bde2f19790a4c7b9540714941df0b2b9" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Applications - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="lifeguar">
+		<description>Lifeguard</description>
+		<year>1987</year>
+		<publisher>Romantic Robot UK</publisher>
+		<info name="usage" value="Requires Multiface" />
+		<part name="flop1" interface="floppy_3">
+			<dataarea name="flop" size="193792">
+				<rom name="lifeguard (1987)(romantic robot uk)[aka unlimited lives finder][needs multiface].dsk" size="193792" crc="b749526e" sha1="2eeff796a6b545366daf3226325404ec0d2d3b7d" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Applications - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="masterfi">
+		<description>Masterfile +3</description>
+		<year>1987</year>
+		<publisher>Campbell Systems</publisher>
+		<part name="flop1" interface="floppy_3">
+			<dataarea name="flop" size="194816">
+				<rom name="masterfile +3 (1987)(campbell systems)[aka masterfile plus 3][aka masterfile plus three].dsk" size="194816" crc="0c19b526" sha1="012ffcaa92fb8edb2b7a6df816d6317dfa041165" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Applications - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="musicmae">
+		<description>Music Maestro</description>
+		<year>1989</year>
+		<publisher>Torchraven</publisher>
+		<part name="flop1" interface="floppy_3">
+			<feature name="part_id" value="Side A"/>
+			<dataarea name="flop" size="194816">
+				<rom name="music maestro (1989)(torchraven)(side a).dsk" size="194816" crc="d01bdbbc" sha1="b0bbddc2d83890cde7ce63b507e46b3465e52574" offset="0" />
+			</dataarea>
+		</part>
+		<part name="flop2" interface="floppy_3">
+			<feature name="part_id" value="Side B"/>
+			<dataarea name="flop" size="194816">
+				<rom name="music maestro (1989)(torchraven)(side b).dsk" size="194816" crc="f7dd2726" sha1="55ab5a3c12e6fd5afed49fb5365af3a8ec494b76" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Applications - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="ocpartst">
+		<description>The OCP Art Studio</description>
+		<year>1985</year>
+		<publisher>Rainbird</publisher>
+		<part name="flop1" interface="floppy_3">
+			<dataarea name="flop" size="194816">
+				<rom name="ocp art studio, the (1985)(rainbird)[m useless soft].dsk" size="194816" crc="696c593c" sha1="1b1a0307bd265a55d7f4a701acedbbc4cb34a724" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Applications - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="ocpartsta" cloneof="ocpartst">
+		<description>The OCP Art Studio (alt)</description>
+		<year>1985</year>
+		<publisher>Rainbird</publisher>
+		<part name="flop1" interface="floppy_3">
+			<dataarea name="flop" size="194816">
+				<rom name="ocp art studio, the (1985)(rainbird)[m useless soft][a].dsk" size="194816" crc="fcc3298f" sha1="1eed3410b0810b3854a07acd1eb0c371571c501d" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Applications - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="ocpartstb" cloneof="ocpartst">
+		<description>The OCP Art Studio (alt 2)</description>
+		<year>1985</year>
+		<publisher>Rainbird</publisher>
+		<part name="flop1" interface="floppy_3">
+			<dataarea name="flop" size="194816">
+				<rom name="ocp art studio, the (1985)(rainbird)[m useless soft][a2].dsk" size="194816" crc="a9652e70" sha1="4f329c43beaae11bca917fb6928916f4f805baa0" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Applications - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="plus3dia">
+		<description>Plus 3 Diary &amp; Filing System</description>
+		<year>1989</year>
+		<publisher>Kobrahsoft</publisher>
+		<part name="flop1" interface="floppy_3">
+			<dataarea name="flop" size="194816">
+				<rom name="plus 3 diary &amp; filing system (1989)(kobrahsoft)[aka plus 3 diary &amp; database].dsk" size="194816" crc="4ee5ffec" sha1="d8d687a5e7ededbda35804509373282de9e44f48" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Applications - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="pawes" cloneof="paw">
+		<description>Professional Adventure Writer (Spanish)</description>
+		<year>1986</year>
+		<publisher>Aventuras AD</publisher>
+		<part name="flop1" interface="floppy_3">
+			<dataarea name="flop" size="194816">
+				<rom name="professional adventure writer (1986)(aventuras ad)(es)[re-release].dsk" size="194816" crc="9faccc2f" sha1="30452eb8b15082f9eb3c37538276d2238dfdc8fd" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Applications - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="paw">
+		<description>Professional Adventure Writer</description>
+		<year>1986</year>
+		<publisher>Gilsoft International</publisher>
+		<part name="flop1" interface="floppy_3">
+			<feature name="part_id" value="Side A"/>
+			<dataarea name="flop" size="194816">
+				<rom name="professional adventure writer (1986)(gilsoft international)(side a)[aka paw][aka professional adventure writing system, the].dsk" size="194816" crc="fcf1e861" sha1="017a2ac8487ac8999141f6008b9e31b12c9c5197" offset="0" />
+			</dataarea>
+		</part>
+		<part name="flop2" interface="floppy_3">
+			<feature name="part_id" value="Side B"/>
+			<dataarea name="flop" size="194816">
+				<rom name="professional adventure writer (1986)(gilsoft international)(side b)[aka paw][aka professional adventure writing system, the].dsk" size="194816" crc="41b52f47" sha1="1502b0027a4a3937744af410d6d773ac7c826c36" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Applications - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="revelado">
+		<description>Revelados</description>
+		<year>2006</year>
+		<publisher>Compiler</publisher>
+		<part name="flop1" interface="floppy_3">
+			<dataarea name="flop" size="194816">
+				<rom name="revelados (2006)(compiler)(es).dsk" size="194816" crc="94e98ecc" sha1="b9d28a05266642e83470d257b36853a29588b44b" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Applications - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="seba080a">
+		<description>SE Basic v0.80a</description>
+		<year>2002</year>
+		<publisher>Amstrad</publisher>
+		<part name="flop1" interface="floppy_3">
+			<dataarea name="flop" size="194816">
+				<rom name="se basic v0.80a (2002)(amstrad).dsk" size="194816" crc="44ef415d" sha1="a3539d713e07126c01c68ea983493a13fd137beb" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Applications - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="sp4ttop3">
+		<description>SP4 Tape to +3 Disc Utility</description>
+		<year>1988</year>
+		<publisher>Kobrahsoft</publisher>
+		<part name="flop1" interface="floppy_3">
+			<dataarea name="flop" size="194048">
+				<rom name="sp4 tape to +3 disc utility (1988)(kobrahsoft).dsk" size="194048" crc="6fd72ba4" sha1="8ca4224826f019c2685472e84995b085e6d2f9f2" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Applications - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="sp5ttop3">
+		<description>SP5 Tape to +3 Disc Utility</description>
+		<year>1989</year>
+		<publisher>Kobrahsoft</publisher>
+		<part name="flop1" interface="floppy_3">
+			<dataarea name="flop" size="194048">
+				<rom name="sp5 tape to +3 disc utility (1989)(kobrahsoft).dsk" size="194048" crc="095c8d89" sha1="44af233b40abd8f6dfcddb92c3c9c8bf714ad2a5" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Applications - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="sp6ttop3">
+		<description>SP6 Tape to +3 Disc Utility</description>
+		<year>1990</year>
+		<publisher>Kobrahsoft</publisher>
+		<part name="flop1" interface="floppy_3">
+			<dataarea name="flop" size="194048">
+				<rom name="sp6 tape to +3 disc utility (1990)(kobrahsoft).dsk" size="194048" crc="48897832" sha1="dd4dda5bd1cbef8f84d7bc89b233aa1f798d41de" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Applications - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="sp7ttop3">
+		<description>SP7 Tape to +3 Disc Utility</description>
+		<year>1991</year>
+		<publisher>Kobrahsoft</publisher>
+		<part name="flop1" interface="floppy_3">
+			<dataarea name="flop" size="194048">
+				<rom name="sp7 tape to +3 disc utility (1991)(kobrahsoft).dsk" size="194048" crc="de79afe4" sha1="d84d10e9449944416c5f3ffdee72c47935a53fad" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Applications - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="sqtracke">
+		<description>SQ-Tracker +3</description>
+		<year>1998</year>
+		<publisher>T.D.M.</publisher>
+		<part name="flop1" interface="floppy_3">
+			<dataarea name="flop" size="194816">
+				<rom name="sq-tracker +3 (1998)(t.d.m.).dsk" size="194816" crc="2f06ec84" sha1="00ad89d4ad50119e3aa685579fbe12fe8d7d7191" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Applications - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="tapedisc">
+		<description>Tapedisc</description>
+		<year>1988</year>
+		<publisher>MicroHobby</publisher>
+		<part name="flop1" interface="floppy_3">
+			<dataarea name="flop" size="194816">
+				<rom name="tapedisc (1988)(microhobby)(es).dsk" size="194816" crc="01d1a285" sha1="084c862aa10ac956c52b1b5bd63f19cc85f285cd" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Applications - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="tarotmas">
+		<description>Tarot Master</description>
+		<year>1991</year>
+		<publisher>Lawrence O'Shaughnessy</publisher>
+		<part name="flop1" interface="floppy_3">
+			<dataarea name="flop" size="226048">
+				<rom name="tarot master (1991)(o'shaughnessy, lawrence).dsk" size="226048" crc="d3633ac6" sha1="aecacbb1acf01f296950559db90784e3fb20d2d3" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Applications - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="tassign">
+		<description>Tas-Sign</description>
+		<year>1988</year>
+		<publisher>Tasman</publisher>
+		<part name="flop1" interface="floppy_3">
+			<dataarea name="flop" size="194816">
+				<rom name="tas-sign (1988)(tasman).dsk" size="194816" crc="999b7f6f" sha1="75ab549b6de054a2819621551790d0e094f71445" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Applications - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="tasspell">
+		<description>Tas-Spell Plus Three</description>
+		<year>1988</year>
+		<publisher>Tasman</publisher>
+		<part name="flop1" interface="floppy_3">
+			<feature name="part_id" value="Side A"/>
+			<dataarea name="flop" size="194816">
+				<rom name="tas-spell plus three (1988)(tasman)(side a)[aka tas-spell +3].dsk" size="194816" crc="aa03a493" sha1="0baf43422e6571a2a77de4e18fec4db0dbeb418d" offset="0" />
+			</dataarea>
+		</part>
+		<part name="flop2" interface="floppy_3">
+			<feature name="part_id" value="Side B"/>
+			<dataarea name="flop" size="194816">
+				<rom name="tas-spell plus three (1988)(tasman)(side b)[aka tas-spell +3].dsk" size="194816" crc="497f22c7" sha1="1b0ba5ad7b6b55a5b7b6524b8758bf256feb2f3b" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Applications - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="tascalc">
+		<description>Tascalc</description>
+		<year>1988</year>
+		<publisher>Tasman</publisher>
+		<part name="flop1" interface="floppy_3">
+			<dataarea name="flop" size="194816">
+				<rom name="tascalc (1988)(tasman).dsk" size="194816" crc="537f5ef7" sha1="43d2c47e6ff706e5f5ea6f687913c98bc35622f4" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Applications - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="tasprip3">
+		<description>Tasprint Plus Three</description>
+		<year>1987</year>
+		<publisher>Tasman</publisher>
+		<part name="flop1" interface="floppy_3">
+			<dataarea name="flop" size="194816">
+				<rom name="tasprint plus three (1987)(tasman)[aka tasprint +3].dsk" size="194816" crc="26d05a14" sha1="d3ca6acc08e211d6b951b7f9fae487754e7771cd" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Applications - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="tasprip3a" cloneof="tasprip3">
+		<description>Tasprint Plus Three (alt)</description>
+		<year>1987</year>
+		<publisher>Tasman</publisher>
+		<part name="flop1" interface="floppy_3">
+			<dataarea name="flop" size="194816">
+				<rom name="tasprint plus three (1987)(tasman)[a][aka tasprint +3].dsk" size="194816" crc="eba33d38" sha1="ea9a8615f0ae5a9f33b3df6b1f32d4912fb42cb7" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Applications - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="taswide">
+		<description>Taswide</description>
+		<year>1984</year>
+		<publisher>Tasman</publisher>
+		<part name="flop1" interface="floppy_3">
+			<dataarea name="flop" size="194816">
+				<rom name="taswide (1984)(tasman).dsk" size="194816" crc="e020669f" sha1="2b69019b159972e5ca363899b2dfc66be769fd1f" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Applications - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="tw2totwp3">
+		<description>Tasword 2 to Tasword +3 Text File Converter</description>
+		<year>2000</year>
+		<publisher>Useless Soft</publisher>
+		<part name="flop1" interface="floppy_3">
+			<dataarea name="flop" size="194816">
+				<rom name="tasword 2 to tasword +3 text file converter (2000)(useless soft).dsk" size="194816" crc="94019809" sha1="ab9af0c49d8df6b592b6de4d36f8dc72e5ad2056" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Applications - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="tasworp3">
+		<description>Tasword Plus Three</description>
+		<year>1987</year>
+		<publisher>Tasman</publisher>
+		<part name="flop1" interface="floppy_3">
+			<feature name="part_id" value="Side A"/>
+			<dataarea name="flop" size="194816">
+				<rom name="tasword plus three (1987)(tasman)(side a)[aka tasword +3].dsk" size="194816" crc="b3a93e81" sha1="e4279f748ec1d23006bd3f8576a6e64972199e64" offset="0" />
+			</dataarea>
+		</part>
+		<part name="flop2" interface="floppy_3">
+			<feature name="part_id" value="Side B"/>
+			<dataarea name="flop" size="194816">
+				<rom name="tasword plus three (1987)(tasman)(side b)[aka tasword +3].dsk" size="194816" crc="3891b8ef" sha1="853be0255357a5f114cafb019bb783eabb310d2a" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Applications - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="tasworp3sp" cloneof="tasworp3">
+		<description>Tasword Plus Three (Spanish)</description>
+		<year>1987</year>
+		<publisher>Tasman</publisher>
+		<part name="flop1" interface="floppy_3">
+			<feature name="part_id" value="Side A"/>
+			<dataarea name="flop" size="194816">
+				<rom name="tasword plus three (1987)(tasman)(es)(side a)[re-release].dsk" size="194816" crc="cf015fc8" sha1="7996be09b72d6c1098674af6b5a13e77c4af0b1d" offset="0" />
+			</dataarea>
+		</part>
+		<part name="flop2" interface="floppy_3">
+			<feature name="part_id" value="Side B"/>
+			<dataarea name="flop" size="194816">
+				<rom name="tasword plus three (1987)(tasman)(es)(side b)[re-release].dsk" size="194816" crc="c1ba089e" sha1="319d61fef7b7450c5f5e5cc2410ddc1b5bedbf5f" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Applications - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="tasword2">
+		<description>Tasword Two - The Word Processor</description>
+		<year>1983</year>
+		<publisher>Tasman</publisher>
+		<part name="flop1" interface="floppy_3">
+			<dataarea name="flop" size="194816">
+				<rom name="tasword two - the word processor (1983)(tasman)[aka tasword 3].dsk" size="194816" crc="0ce8a996" sha1="af4443b2d95eed8d46a75a0822cd9e5affbe6cb7" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Applications - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="transfp3">
+		<description>Transfer +3</description>
+		<year>1988</year>
+		<publisher>Topo Soft</publisher>
+		<part name="flop1" interface="floppy_3">
+			<feature name="part_id" value="Side A"/>
+			<dataarea name="flop" size="180224">
+				<rom name="transfer +3 (1988)(topo soft)(es)(side a).dsk" size="180224" crc="ce9356db" sha1="3c20847d71a2ff8227ba0205b5fecad8bb3597d0" offset="0" />
+			</dataarea>
+		</part>
+		<part name="flop2" interface="floppy_3">
+			<feature name="part_id" value="Side B"/>
+			<dataarea name="flop" size="194816">
+				<rom name="transfer +3 (1988)(topo soft)(es)(side b).dsk" size="194816" crc="175013d2" sha1="0b2bb936b33d568d37c2881f6a18d48f03529c06" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Applications - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="transfp3ba" cloneof="transfp3">
+		<description>Transfer +3 (alt)</description>
+		<year>1988</year>
+		<publisher>Topo Soft</publisher>
+		<part name="flop1" interface="floppy_3">
+			<feature name="part_id" value="Side A"/>
+		<!-- Side missing from dump, using same as parent set -->
+			<dataarea name="flop" size="180224">
+				<rom name="transfer +3 (1988)(topo soft)(es)(side a).dsk" size="180224" crc="ce9356db" sha1="3c20847d71a2ff8227ba0205b5fecad8bb3597d0" offset="0" />
+			</dataarea>
+		</part>
+		<part name="flop1" interface="floppy_3">
+			<feature name="part_id" value="Side B"/>
+			<dataarea name="flop" size="180224">
+				<rom name="transfer +3 (1988)(topo soft)(es)(side b)[a].dsk" size="180224" crc="475be7a1" sha1="f4f38459f6154d2cad84264409a6a353a0393882" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Applications - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="udggener">
+		<description>UDG Generator</description>
+		<year>1985</year>
+		<publisher>Tom Collier</publisher>
+		<part name="flop1" interface="floppy_3">
+			<dataarea name="flop" size="194816">
+				<rom name="udg generator (1985)(collier, tom).dsk" size="194816" crc="8798715f" sha1="67b2fd4259be79b327ac65d5040976e165550290" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Applications - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="ukmlotto">
+		<description>UK Main Lotto Random Number Generator</description>
+		<year>2012</year>
+		<publisher>&lt;homebrew&gt;</publisher>
+		<info name="author" value="Tom Collier"/>
+		<part name="flop1" interface="floppy_3">
+			<dataarea name="flop" size="194816">
+				<rom name="uk main lotto random number generator (2012)(collier, tom).dsk" size="194816" crc="9a26bb13" sha1="7b28f6a06f564956aeb1ce99296b82035c0ec0c7" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Applications - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="videomas">
+		<description>Videomaster</description>
+		<year>1991</year>
+		<publisher>Chris Brown</publisher>
+		<part name="flop1" interface="floppy_3">
+			<feature name="part_id" value="Side A"/>
+			<dataarea name="flop" size="90279">
+				<rom name="videomaster (1991)(brown, chris)(side a).dsk" size="90279" crc="98b32241" sha1="0199c4f2ac1664c7fa284ee44bf44dbdac41d285" offset="0" />
+			</dataarea>
+		</part>
+		<part name="flop2" interface="floppy_3">
+			<feature name="part_id" value="Side B"/>
+			<dataarea name="flop" size="195635">
+				<rom name="videomaster (1991)(brown, chris)(side b).dsk" size="195635" crc="6027c9cd" sha1="0d8e456fe26fc9d30b3305504492539c425d7725" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Applications - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="videomasa" cloneof="videomas">
+		<description>Videomaster (alt)</description>
+		<year>1991</year>
+		<publisher>Chris Brown</publisher>
+		<part name="flop1" interface="floppy_3">
+			<feature name="part_id" value="Side A"/>
+			<dataarea name="flop" size="195635">
+				<rom name="videomaster (1991)(brown, chris)(side a)[a].dsk" size="195635" crc="f5307a26" sha1="a77be31228bc017f47cb1985a1f881b47d33fcf6" offset="0" />
+			</dataarea>
+		</part>
+		<part name="flop2" interface="floppy_3">
+			<feature name="part_id" value="Side B"/>
+			<dataarea name="flop" size="195635">
+				<rom name="videomaster (1991)(brown, chris)(side b)[a].dsk" size="195635" crc="7ad77abd" sha1="947dbed2e857c3d81bbac0c49199391575c59102" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Applications - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="videomasb" cloneof="videomas">
+		<description>Videomaster (alt 2)</description>
+		<year>1991</year>
+		<publisher>Chris Brown</publisher>
+		<part name="flop1" interface="floppy_3">
+			<feature name="part_id" value="Side A"/>
+			<dataarea name="flop" size="195635">
+				<rom name="videomaster (1991)(brown, chris)(side a)[a2].dsk" size="195635" crc="9be26c4c" sha1="4eacf40b1b349d3032f496b79f77fec61f2f01c1" offset="0" />
+			</dataarea>
+		</part>
+		<part name="flop2" interface="floppy_3">
+			<feature name="part_id" value="Side B"/>
+			<dataarea name="flop" size="195635">
+				<rom name="videomaster (1991)(brown, chris)(side b)[a2].dsk" size="195635" crc="d8108013" sha1="3895fae3c0674f9e25635d2d5a1ef6992116c621" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Applications - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="wordmast">
+		<description>Word-Master</description>
+		<year>1987</year>
+		<publisher>Cardex</publisher>
+		<part name="flop1" interface="floppy_3">
+			<feature name="part_id" value="Side A"/>
+			<dataarea name="flop" size="195635">
+				<rom name="word-master (1987)(cardex)(side a).dsk" size="195635" crc="70e1c500" sha1="31ff03dbd9716dfd887272ce351d63c24a630515" offset="0" />
+			</dataarea>
+		</part>
+		<part name="flop2" interface="floppy_3">
+			<feature name="part_id" value="Side B"/>
+			<dataarea name="flop" size="195635">
+				<rom name="word-master (1987)(cardex)(side b).dsk" size="195635" crc="388ca5a7" sha1="0ce7c6c799f74c43d4f206610e71d3ab8151ae3c" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Applications - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="zxcpm22">
+		<description>ZX CP-M 2.2</description>
+		<year>2009</year>
+		<publisher>M. Williams</publisher>
+		<part name="flop1" interface="floppy_3">
+			<dataarea name="flop" size="194816">
+				<rom name="zx cp-m 2.2 (2009)(williams, m.).dsk" size="194816" crc="26fc1fc5" sha1="ea79fec488af3a0189af0f724d27f1ec0afc010b" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Compilations - Applications - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="glatools">
+		<description>Gary Lancaster Tools Collection</description>
+		<year>19??</year>
+		<publisher>Gary Lancaster</publisher>
+		<part name="flop1" interface="floppy_3">
+			<dataarea name="flop" size="194816">
+				<rom name="gary lancaster tools collection (19xx)(lancaster, gary).dsk" size="194816" crc="be29a003" sha1="5b58aa747dccb2c9b5e0bcdb5d93aca895b77dad" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Compilations - Applications - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="jtetool1">
+		<description>Jesus Tejero Tools Collection 01</description>
+		<year>19??</year>
+		<publisher>&lt;homebrew&gt;</publisher>
+		<info name="author" value="Jesus Tejero"/>
+		<part name="flop1" interface="floppy_3">
+			<feature name="part_id" value="Side A"/>
+			<dataarea name="flop" size="194816">
+				<rom name="jesus tejero tools collection 01 (19xx)(tejero, jesus)(es)(side a).dsk" size="194816" crc="22714808" sha1="7ba4cf9653d771a5b3b8a0134e0a838bd3797b12" offset="0" />
+			</dataarea>
+		</part>
+		<part name="flop2" interface="floppy_3">
+			<feature name="part_id" value="Side B"/>
+			<dataarea name="flop" size="194816">
+				<rom name="jesus tejero tools collection 01 (19xx)(tejero, jesus)(es)(side b).dsk" size="194816" crc="071a42f1" sha1="89fb642e4b84f5bfc2f10d1d19453810d5d71edf" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Compilations - Applications - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="jtetool2">
+		<description>Jesus Tejero Tools Collection 02</description>
+		<year>19??</year>
+		<publisher>&lt;homebrew&gt;</publisher>
+		<info name="author" value="Jesus Tejero"/>
+		<part name="flop1" interface="floppy_3">
+			<feature name="part_id" value="Side A"/>
+			<dataarea name="flop" size="194816">
+				<rom name="jesus tejero tools collection 02 (19xx)(tejero, jesus)(es)(side a).dsk" size="194816" crc="cfc5778a" sha1="e83b1a3e44f20a6be456ba0ef37853d0f29bad87" offset="0" />
+			</dataarea>
+		</part>
+		<part name="flop2" interface="floppy_3">
+			<feature name="part_id" value="Side B"/>
+			<dataarea name="flop" size="194816">
+				<rom name="jesus tejero tools collection 02 (19xx)(tejero, jesus)(es)(side b).dsk" size="194816" crc="48a98df6" sha1="9dbf4ad35f9ed5f948f6b9962498a29e6a1b9ba9" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Compilations - Applications - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="spcpmpma">
+		<description>Spectrum CP-M Plus + Mallard BASIC</description>
+		<year>1988</year>
+		<publisher>Locomotive</publisher>
+		<part name="flop1" interface="floppy_3">
+			<feature name="part_id" value="Side A"/>
+			<dataarea name="flop" size="194816">
+				<rom name="spectrum cp-m plus + mallard basic (1988)(locomotive)(side a).dsk" size="194816" crc="46020cc4" sha1="4e29c17caf0118e73d028d03cdf689a26ddcf91b" offset="0" />
+			</dataarea>
+		</part>
+		<part name="flop2" interface="floppy_3">
+			<feature name="part_id" value="Side B"/>
+			<dataarea name="flop" size="194816">
+				<rom name="spectrum cp-m plus + mallard basic (1988)(locomotive)(side b).dsk" size="194816" crc="5fc4ea79" sha1="642084c6d930bd1eb4ae1906f4ee107c2b3ca6b6" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Compilations - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="2x1chqin">
+		<description>2 Por 1: Chase H.Q. + Indiana Jones y la Ultima Cruzada</description>
+		<year>1989</year>
+		<publisher>Erbe</publisher>
+		<part name="flop1" interface="floppy_3">
+			<feature name="part_id" value="Side A: Chase H.Q."/>
+			<dataarea name="flop" size="185088">
+				<rom name="2 por 1 - chase h.q. + indiana jones y la ultima cruzada (1989)(erbe)(es)(en)(side a).dsk" size="185088" crc="d77030f1" sha1="69277d56c97f34405328b7bd253e414fdf3b06a6" offset="0" />
+			</dataarea>
+		</part>
+		<part name="flop2" interface="floppy_3">
+			<feature name="part_id" value="Side B: Indiana Jones y la Ultima Cruzada"/>
+			<dataarea name="flop" size="194816">
+				<rom name="2 por 1 - chase h.q. + indiana jones y la ultima cruzada - indiana jones and the last crusade (1989)(erbe)(es)(en)(side b).dsk" size="194816" crc="6cef7d55" sha1="105f953307459319b3c09365815046ba00706803" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Compilations - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="2x1mot">
+		<description>2 Por 1: Motor Massacre + Final Assault</description>
+		<year>1989</year>
+		<publisher>Erbe</publisher>
+		<part name="flop1" interface="floppy_3">
+			<feature name="part_id" value="Side A: Motor Massacre"/>
+			<dataarea name="flop" size="108032">
+				<rom name="2 por 1 - motor massacre + final assault (1989)(erbe)(es)(en-es)(side a).dsk" size="108032" crc="dbbf98de" sha1="872d73f66c8d4ebea239d94bd82263726cfc8a2b" offset="0" />
+			</dataarea>
+		</part>
+		<part name="flop2" interface="floppy_3">
+			<feature name="part_id" value="Side B: Final Assault"/>
+			<dataarea name="flop" size="105216">
+				<rom name="2 por 1 - motor massacre + final assault (1989)(erbe)(es)(en)(side b).dsk" size="105216" crc="2378daa5" sha1="e4dc4d597a494d8fa6d2ac8db7a145c0552799da" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Compilations - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="2x1pla">
+		<description>2 Por 1: Platoon + Arkanoid - Revenge of Doh</description>
+		<year>19??</year>
+		<publisher>Erbe</publisher>
+		<part name="flop1" interface="floppy_3">
+			<feature name="part_id" value="Side A: Platoon"/>
+			<dataarea name="flop" size="194816">
+				<rom name="2 por 1 - platoon + arkanoid - revenge of doh (19xx)(erbe)(es)(en)(side a).dsk" size="194816" crc="f17652cb" sha1="5143e9a248d2a2b906b94b3ec6cd5b7e0443a3d4" offset="0" />
+			</dataarea>
+		</part>
+		<part name="flop2" interface="floppy_3">
+			<feature name="part_id" value="Side B: Arkanoid - Revenge of Doh"/>
+			<dataarea name="flop" size="58624">
+				<rom name="2 por 1 - platoon + arkanoid - revenge of doh (19xx)(erbe)(es)(en)(side b).dsk" size="58624" crc="dd6d244f" sha1="e714cb3e224264c86ef27d46f78897f5c147f8ee" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Compilations - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="2x1ren">
+		<description>2 Por 1: Renegade + Target Renegade</description>
+		<year>1988</year>
+		<publisher>Erbe</publisher>
+		<part name="flop1" interface="floppy_3">
+			<feature name="part_id" value="Side A: Renegade"/>
+			<dataarea name="flop" size="73472">
+				<rom name="2 por 1 - renegade + target renegade (1988)(erbe)(es)(en)(side a).dsk" size="73472" crc="e911ad63" sha1="9d161f6ca0ade6533de21cc276fc0937d826adde" offset="0" />
+			</dataarea>
+		</part>
+		<part name="flop2" interface="floppy_3">
+			<feature name="part_id" value="Side B: Target Renegade"/>
+			<dataarea name="flop" size="194816">
+				<rom name="2 por 1 - renegade + target renegade (1988)(erbe)(es)(en)(side b).dsk" size="194816" crc="f27b2afa" sha1="4735a96bb82d57dbcb9a9b82cda7e6c3bcc9f624" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Compilations - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="2x1sil">
+		<description>2 Por 1: Silent Shadow + Mad Mix Game</description>
+		<year>1988</year>
+		<publisher>Erbe</publisher>
+		<part name="flop1" interface="floppy_3">
+			<feature name="part_id" value="Side A: Silent Shadow"/>
+			<dataarea name="flop" size="194816">
+				<rom name="2 por 1 - silent shadow + mad mix game (1988)(erbe)(es)(side a).dsk" size="194816" crc="2defa16f" sha1="3a47e75174489d3d2214dddf04276bb2afbc62f4" offset="0" />
+			</dataarea>
+		</part>
+		<part name="flop2" interface="floppy_3">
+			<feature name="part_id" value="Side B: Mad Mix Game"/>
+			<dataarea name="flop" size="194816">
+				<rom name="2 por 1 - silent shadow + mad mix game (1988)(erbe)(es)(side b).dsk" size="194816" crc="e0d5655d" sha1="528446ad75a650b1971508a7d1b34195379c1f38" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Compilations - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="2x1tec">
+		<description>2 Por 1: Techno Cop + Mickey Mouse</description>
+		<year>1988</year>
+		<publisher>Erbe</publisher>
+		<part name="flop1" interface="floppy_3">
+			<feature name="part_id" value="Side A: Techno Cop"/>
+			<dataarea name="flop" size="224512">
+				<rom name="2 por 1 - techno cop + mickey mouse (1988)(erbe)(es)(en)(side a).dsk" size="224512" crc="1e2df00d" sha1="db16b55ef02dafa3c518a168dff46fb6a18ffaff" offset="0" />
+			</dataarea>
+		</part>
+		<part name="flop2" interface="floppy_3">
+			<feature name="part_id" value="Side B: Mickey Mouse"/>
+			<dataarea name="flop" size="194816">
+				<rom name="2 por 1 - techno cop + mickey mouse (1988)(erbe)(es)(en)(side b).dsk" size="194816" crc="b12215a5" sha1="2c26d0d99fbf6232fd58c8815357238d39ffd06a" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Compilations - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="2x1the">
+		<description>2 Por 1: The Deep + The Muncher</description>
+		<year>1989</year>
+		<publisher>Erbe</publisher>
+		<part name="flop1" interface="floppy_3">
+			<feature name="part_id" value="Side A: The Deep"/>
+			<dataarea name="flop" size="213760">
+				<rom name="2 por 1 - the deep + the muncher (1989)(erbe)(es)(en)(side a).dsk" size="213760" crc="7c1129d8" sha1="b60f3ede48e54cb09249513ef172b7da6fd30c72" offset="0" />
+			</dataarea>
+		</part>
+		<part name="flop2" interface="floppy_3">
+			<feature name="part_id" value="Side B: The Muncher"/>
+			<dataarea name="flop" size="135680">
+				<rom name="2 por 1 - the deep + the muncher (1989)(erbe)(es)(en)(side b).dsk" size="135680" crc="e92043cd" sha1="26e26db4f65ac3cd98e832da4e5074e49bdaba35" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Compilations - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="2x1thu">
+		<description>2 Por 1: Thunder Blade + Cybernoid II</description>
+		<year>1988</year>
+		<publisher>Erbe</publisher>
+		<part name="flop1" interface="floppy_3">
+			<feature name="part_id" value="Side A: Thunder Blade"/>
+			<dataarea name="flop" size="194816">
+				<rom name="2 por 1 - thunder blade + cybernoid ii (1988)(erbe)(es)(en)(side a).dsk" size="194816" crc="a21e7aea" sha1="5315b49c3224fbc1125b05167aa8ebae11be1bba" offset="0" />
+			</dataarea>
+		</part>
+		<part name="flop2" interface="floppy_3">
+			<feature name="part_id" value="Side B: Cybernoid II"/>
+			<dataarea name="flop" size="82944">
+				<rom name="2 por 1 - thunder blade + cybernoid ii - cybernoid ii - the revenge (1988)(erbe)(es)(en)(side b).dsk" size="82944" crc="aeab4d68" sha1="eddf11183b011353570d5b76a4c6d0330dee32ea" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Compilations - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="2x1ven">
+		<description>2 Por 1: MASK III: VENOM Strikes Back + North Star</description>
+		<year>1989</year>
+		<publisher>Erbe</publisher>
+		<part name="flop1" interface="floppy_3">
+			<feature name="part_id" value="Side A: MASK III: VENOM Strikes Back"/>
+			<dataarea name="flop" size="173824">
+				<rom name="2 por 1 - venom strikes back + north star - mask iii - venom strikes back (1989)(erbe)(es)(en)(side a).dsk" size="173824" crc="b98b5c24" sha1="3c467d6f40d8106169ff3e7ec6b43f41b729d8be" offset="0" />
+			</dataarea>
+		</part>
+		<part name="flop2" interface="floppy_3">
+			<feature name="part_id" value="Side B: North Star"/>
+			<dataarea name="flop" size="170752">
+				<rom name="2 por 1 - venom strikes back + north star (1989)(erbe)(es)(en)(side b).dsk" size="170752" crc="79bfe6c7" sha1="fe39524ea205bd302fbdbd36ba6305171ea16da2" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Compilations - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="2x1capit">
+		<description>2 X 1: Capitan Sevilla + Meganova</description>
+		<year>1988</year>
+		<publisher>Dinamic</publisher>
+		<part name="flop1" interface="floppy_3">
+			<feature name="part_id" value="Side A: Capitan Sevilla"/>
+			<dataarea name="flop" size="112640">
+				<rom name="2 x 1 - capitan sevilla + meganova (1988)(dinamic)(es)(side a).dsk" size="112640" crc="bcdb0833" sha1="0c5d19c9df94c5d8409223945092f2f7ee708906" offset="0" />
+			</dataarea>
+		</part>
+		<part name="flop2" interface="floppy_3">
+			<feature name="part_id" value="Side B: Meganova"/>
+			<dataarea name="flop" size="91136">
+				<rom name="2 x 1 - capitan sevilla + meganova (1988)(dinamic)(es)(en)(side b).dsk" size="91136" crc="1d467a85" sha1="45abfbb911589dc1241fbd04d501e876448dba69" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Compilations - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="2x1corsa">
+		<description>2 X 1: Corsarios + Mutan Zone</description>
+		<year>1989</year>
+		<publisher>Opera Soft</publisher>
+		<part name="flop1" interface="floppy_3">
+			<feature name="part_id" value="Side A: Corsarios"/>
+			<dataarea name="flop" size="218880">
+				<rom name="2 x 1 - corsarios + mutan zone (1989)(opera soft)(es)(side a).dsk" size="218880" crc="1273e70c" sha1="7a8ac3eff6df1ca72f111004cb029ecd9da8205a" offset="0" />
+			</dataarea>
+		</part>
+		<part name="flop2" interface="floppy_3">
+			<feature name="part_id" value="Side B: Mutan Zone"/>
+			<dataarea name="flop" size="218880">
+				<rom name="2 x 1 - corsarios + mutan zone (1989)(opera soft)(es)(side b).dsk" size="218880" crc="0ff83d7a" sha1="e87198b2707d9e21cc181022f3bc459ae92efa03" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Compilations - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="2x1donqu">
+		<description>2 X 1: Don Quijote + Mega-Corp</description>
+		<year>1987</year>
+		<publisher>Dinamic</publisher>
+		<part name="flop1" interface="floppy_3">
+			<feature name="part_id" value="Side A: Don Quijote"/>
+			<dataarea name="flop" size="109568">
+				<rom name="2 x 1 - don quijote + mega-corp (1987)(dinamic)(es)(en)(side a).dsk" size="109568" crc="b9094639" sha1="31f64289041a660952ad51707c81871c10ed7ad3" offset="0" />
+			</dataarea>
+		</part>
+		<part name="flop2" interface="floppy_3">
+			<feature name="part_id" value="Side B: Mega-Corp"/>
+			<dataarea name="flop" size="109568">
+				<rom name="2 x 1 - don quijote + mega-corp (1987)(dinamic)(es)(side b).dsk" size="109568" crc="8a73c4fa" sha1="942f9f802bac53ed0c25c4bfc41c08513de60762" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Compilations - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="2x1pla">
+		<description>2 por 1: Platoon + Arkanoid II: Revenge of Doh</description>
+		<year>1989</year>
+		<publisher>Erbe</publisher>
+		<part name="flop1" interface="floppy_3">
+			<feature name="part_id" value="Side A: Platoon"/>
+			<dataarea name="flop" size="194816">
+				<rom name="2 por 1 - platoon (1989)(erbe).dsk" size="194816" crc="0341da38" sha1="ced84b0c722d3b7ca87727003c1d825f0bb723e9" offset="0" />
+			</dataarea>
+		</part>
+		<part name="flop1" interface="floppy_3">
+			<feature name="part_id" value="Side B: Arkanoid II: Revenge of Doh"/>
+			<dataarea name="flop" size="58624">
+				<rom name="2 por 1 - arkanoid ii - revenge of doh (1989)(erbe).dsk" size="58624" crc="671b73b3" sha1="56d72c852be3ab2547d348b92fe96dc6cfa4c095" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Compilations - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="2x1sil">
+		<description>2 por 1: Silent Shadow + Mad Mix Game</description>
+		<year>1988</year>
+		<publisher>Erbe</publisher>
+		<part name="flop1" interface="floppy_3">
+			<feature name="part_id" value="Side A: Silent Shadow"/>
+			<dataarea name="flop" size="194816">
+				<rom name="2 por 1 - silent shadow (1988)(erbe)(es).dsk" size="194816" crc="e308222a" sha1="3512aba07e8087b3b3b22952f30133c057f92897" offset="0" />
+			</dataarea>
+		</part>
+		<part name="flop1" interface="floppy_3">
+			<feature name="part_id" value="Side B: Mad Mix Game"/>
+			<dataarea name="flop" size="194816">
+				<rom name="2 por 1 - mad mix game (1988)(erbe)(es).dsk" size="194816" crc="c530fc92" sha1="3ba4cae93aded2a468e8b424dd46f1b05f7b18bd" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+
+<!-- From "Sinclair ZX Spectrum - Compilations - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="20gamepa">
+		<description>20 Game Pack</description>
+		<year>19??</year>
+		<publisher>Comet</publisher>
+		<part name="flop1" interface="floppy_3">
+			<feature name="part_id" value="Disk 1, Side A"/>
+			<dataarea name="flop" size="194816">
+				<rom name="20 game pack (19xx)(comet)(disk 1 of 2 side a).dsk" size="194816" crc="17f824d4" sha1="eeafae9cbc821251c079ebeab05a7698e13a563b" offset="0" />
+			</dataarea>
+		</part>
+		<part name="flop2" interface="floppy_3">
+			<feature name="part_id" value="Disk 1, Side B"/>
+			<dataarea name="flop" size="194816">
+				<rom name="20 game pack (19xx)(comet)(disk 1 of 2 side b).dsk" size="194816" crc="0c4f057a" sha1="ab36f880f872d18a4315f5bad78bd5961f7787b2" offset="0" />
+			</dataarea>
+		</part>
+		<part name="flop1" interface="floppy_3">
+			<feature name="part_id" value="Disk 2, Side A"/>
+			<dataarea name="flop" size="194816">
+				<rom name="20 game pack (19xx)(comet)(disk 2 of 2 side a).dsk" size="194816" crc="f374a90f" sha1="c053291bea9fd33ea463e9aa5e5530056cf4a615" offset="0" />
+			</dataarea>
+		</part>
+		<part name="flop2" interface="floppy_3">
+			<feature name="part_id" value="Disk 2, Side B"/>
+			<dataarea name="flop" size="194816">
+				<rom name="20 game pack (19xx)(comet)(disk 2 of 2 side b).dsk" size="194816" crc="e794781e" sha1="6a6c9e4a8083bef5e405db20ed4897668965296a" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Compilations - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="4soccers">
+		<description>4 Soccer Simulators</description>
+		<year>1988</year>
+		<publisher>Code Masters Gold</publisher>
+		<part name="flop1" interface="floppy_3">
+			<feature name="part_id" value="Side A: 11-a-Side Soccer + Indoor Soccer"/>
+			<dataarea name="flop" size="213760">
+				<rom name="4 soccer simulators (1988)(code masters gold)(side a)[aka four soccer simulators][aka pro soccer simulator].dsk" size="213760" crc="db963a7f" sha1="fc3875238c36e5adb7072ae3775a396f282b942e" offset="0" />
+			</dataarea>
+		</part>
+		<part name="flop2" interface="floppy_3">
+			<feature name="part_id" value="Side B: Street Soccer + Soccer Skills"/>
+			<dataarea name="flop" size="213760">
+				<rom name="4 soccer simulators (1988)(code masters gold)(side b)[aka four soccer simulators][aka pro soccer simulator].dsk" size="213760" crc="6591918b" sha1="fc8ac07175243156415f49b22c5e3a7c5fc127c4" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Compilations - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="4topgame">
+		<description>4 Top Games - Pulsator + Slaine - The Celtic Barbarian</description>
+		<year>1987</year>
+		<publisher>Martech Games</publisher>
+		<part name="flop1" interface="floppy_3">
+			<feature name="part_id" value="Side A: Pulsator"/>
+			<dataarea name="flop" size="194560">
+				<rom name="4 top games - pulsator + slaine - the celtic barbarian (1987)(martech games)(side a).dsk" size="194560" crc="e0429b01" sha1="a6d7bbef5246cd2911f2fe78fccee6fa98972c61" offset="0" />
+			</dataarea>
+		</part>
+		<part name="flop2" interface="floppy_3">
+			<feature name="part_id" value="Side B: Slaine - The Celtic Barbarian"/>
+			<dataarea name="flop" size="194560">
+				<rom name="4 top games - catch 23 + nemesis the warlock (1987)(martech games)(side b).dsk" size="194560" crc="214d2d60" sha1="31301ca3a0b939d780af5cddaf35b6f69182edc1" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Compilations - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="los40v1">
+		<description>Los 40 Principales Vol. 1</description>
+		<year>1987</year>
+		<publisher>Erbe</publisher>
+		<part name="flop1" interface="floppy_3">
+			<feature name="part_id" value="Side A: Batman + Thanatos"/>
+			<dataarea name="flop" size="194816">
+				<rom name="40 principales vol. 1, los - batman + thanatos (1987)(erbe)(es)(en-es)(side a).dsk" size="194816" crc="d40e42cf" sha1="793164dada3c40ffbaced6cebc00ccfbf69a0d8b" offset="0" />
+			</dataarea>
+		</part>
+		<part name="flop2" interface="floppy_3">
+			<feature name="part_id" value="Side B: Spirits + Asterix and the Magic Cauldron"/>
+			<dataarea name="flop" size="194816">
+				<rom name="40 principales vol. 1, los - spirits + asterix and the magic cauldron (1987)(erbe)(es)(en)(side b).dsk" size="194816" crc="2f948ee8" sha1="7b10ed4d87627f0b2407a3e048ee2ac64c101367" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Compilations - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="los40v1a" cloneof="los40v1">
+		<description>Los 40 Principales Vol. 1 (alt)</description>
+		<year>1987</year>
+		<publisher>Erbe</publisher>
+		<part name="flop1" interface="floppy_3">
+			<feature name="part_id" value="Side A: Batman + Thanatos"/>
+			<dataarea name="flop" size="194816">
+				<rom name="40 principales vol. 1, los - batman + thanatos (1987)(erbe)(es)(en).dsk" size="194816" crc="cc1065eb" sha1="241933d1e5754176fb6f7764ef4fed618a9be77e" offset="0" />
+			</dataarea>
+		</part>
+		<part name="flop2" interface="floppy_3">
+			<feature name="part_id" value="Side B: Spirits + Asterix and the Magic Cauldron"/>
+			<dataarea name="flop" size="194816">
+				<rom name="40 principales vol. 1, los - spirits + asterix and the magic cauldron (1987)(erbe)(es)(en).dsk" size="194816" crc="43fd2cac" sha1="a24ea3e43bf1c14c5d0e67577ee36f8c8a5ae0be" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Compilations - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="los40v10">
+		<description>Los 40 Principales Vol. 10</description>
+		<year>1987</year>
+		<publisher>Erbe</publisher>
+		<part name="flop1" interface="floppy_3">
+			<feature name="part_id" value="Side A: Super Soccer + Ramon Rodriguez"/>
+			<dataarea name="flop" size="194816">
+				<rom name="40 principales vol. 10, los (1987)(erbe)(es)(en-es)(side a).dsk" size="194816" crc="79c0ae58" sha1="ee481fbfa0856a3017ca3b50dd9602f0f8469307" offset="0" />
+			</dataarea>
+		</part>
+		<part name="flop2" interface="floppy_3">
+			<feature name="part_id" value="Side B: Pole Position + Abu Simbel Profanation"/>
+			<dataarea name="flop" size="194816">
+				<rom name="40 principales vol. 10, los (1987)(erbe)(es)(en)(side b).dsk" size="194816" crc="4ef2a38d" sha1="6b1a1c3960b76b0008c271cda3bf9302dfebad77" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Compilations - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="los40v10a" cloneof="los40v10">
+		<description>Los 40 Principales Vol. 10 (alt)</description>
+		<year>1987</year>
+		<publisher>Erbe</publisher>
+		<part name="flop1" interface="floppy_3">
+			<feature name="part_id" value="Side A: Super Soccer + Ramon Rodriguez"/>
+			<dataarea name="flop" size="194816">
+				<rom name="40 principales vol. 10, los - super soccer + ramon rodriguez (1987)(erbe)(es)(en).dsk" size="194816" crc="e3cfb4fd" sha1="d91dffe5f813aa2bb55883568487c6073f158911" offset="0" />
+			</dataarea>
+		</part>
+		<part name="flop1" interface="floppy_3">
+			<feature name="part_id" value="Side B: Pole Position + Abu Simbel Profanation"/>
+			<dataarea name="flop" size="194816">
+				<rom name="40 principales vol. 10, los - pole position + abu simbel profanation (1987)(erbe)(es)(en).dsk" size="194816" crc="624a60d6" sha1="5a669643703075479ab57123bb82aa46d755272a" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Compilations - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="los40v2">
+		<description>Los 40 Principales Vol. 2</description>
+		<year>1987</year>
+		<publisher>Erbe</publisher>
+		<part name="flop1" interface="floppy_3">
+			<feature name="part_id" value="Side A: The Great Escape + Zorro"/>
+			<dataarea name="flop" size="194816">
+				<rom name="40 principales vol. 2, los (1987)(erbe)(es)(en-es)(side a).dsk" size="194816" crc="c2cf1d53" sha1="c8836f903da024338abe8ef8b33d7fdfd542e6ff" offset="0" />
+			</dataarea>
+		</part>
+		<part name="flop2" interface="floppy_3">
+			<feature name="part_id" value="Side B: Inspector Gadget + Antiriad"/>
+			<dataarea name="flop" size="194816">
+				<rom name="40 principales vol. 2, los (1987)(erbe)(es)(en)(side b).dsk" size="194816" crc="3461ebaa" sha1="9e70d1306add385e524659e6231f302e2d68b568" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Compilations - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="los40v3">
+		<description>Los 40 Principales Vol. 3</description>
+		<year>1987</year>
+		<publisher>Erbe</publisher>
+		<part name="flop1" interface="floppy_3">
+			<feature name="part_id" value="Side A: Arkanoid + Nightmare Rally"/>
+			<dataarea name="flop" size="194816">
+				<rom name="40 principales vol. 3, los (1987)(erbe)(es)(en-es)(side a).dsk" size="194816" crc="74131d2a" sha1="54035f94d4b8cd70e9c1fc9d76f1e3eeb45ef739" offset="0" />
+			</dataarea>
+		</part>
+		<part name="flop2" interface="floppy_3">
+			<feature name="part_id" value="Side B: Movie + Phantomas"/>
+			<dataarea name="flop" size="194816">
+				<rom name="40 principales vol. 3, los (1987)(erbe)(es)(en)(side b).dsk" size="194816" crc="5dda7a2b" sha1="04d3c2c148d70f202c3782ecb163b9a2d35cfee9" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Compilations - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="los40v3a" cloneof="los40v3">
+		<description>Los 40 Principales Vol. 3 (alt)</description>
+		<year>1987</year>
+		<publisher>Erbe</publisher>
+		<part name="flop1" interface="floppy_3">
+			<feature name="part_id" value="Side A: Arkanoid + Nightmare Rally"/>
+			<dataarea name="flop" size="194816">
+				<rom name="40 principales vol. 3, los - arkanoid + nightmare rally (1987)(erbe)(es)(en)[aka 40 principales, los - vol. 03 - arkanoid + nightmare rally].dsk" size="194816" crc="bf661330" sha1="e209b965d3779f63185e45944b065064da40a36c" offset="0" />
+			</dataarea>
+		</part>
+		<part name="flop2" interface="floppy_3">
+			<feature name="part_id" value="Side B: Movie + Phantomas"/>
+			<dataarea name="flop" size="194816">
+				<rom name="40 principales vol. 3, los - movie + phantomas (1987)(erbe)(es)(en).dsk" size="194816" crc="31a090a1" sha1="c218b9248af6a04c81c14979ed2c2b9f7da96cfd" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Compilations - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="los40v5">
+		<description>Los 40 Principales Vol. 5</description>
+		<year>1987</year>
+		<publisher>Erbe</publisher>
+		<part name="flop1" interface="floppy_3">
+			<feature name="part_id" value="Side A: Kung-Fu Master + Three Weeks in Paradise"/>
+			<dataarea name="flop" size="194816">
+				<rom name="40 principales vol. 5, los (1987)(erbe)(es)(en-es)(side a).dsk" size="194816" crc="dced94ad" sha1="9f3837ee55ad3f7cc3e27ef11998a821dc93bdda" offset="0" />
+			</dataarea>
+		</part>
+		<part name="flop2" interface="floppy_3">
+			<feature name="part_id" value="Side B: Breakthru + Phantomas II"/>
+			<dataarea name="flop" size="194816">
+				<rom name="40 principales vol. 5, los (1987)(erbe)(es)(en)(side b).dsk" size="194816" crc="e058bb55" sha1="f283715635bf83f399d6e3ce737d9cbb128f6360" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Compilations - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="los40v6">
+		<description>Los 40 Principales Vol. 6</description>
+		<year>1987</year>
+		<publisher>Erbe</publisher>
+		<part name="flop1" interface="floppy_3">
+			<feature name="part_id" value="Side A: Rocky + Survivor"/>
+			<dataarea name="flop" size="194816">
+				<rom name="40 principales vol. 6, los - rocky + survivor (1987)(erbe)(es)(en-es)(side a).dsk" size="194816" crc="826eb3ee" sha1="9e62f609db8d84c9f8db9b253c6a7c7867f28a64" offset="0" />
+			</dataarea>
+		</part>
+		<part name="flop2" interface="floppy_3">
+			<feature name="part_id" value="Side B: The Way of the Exploding Fist + Nemesis the Warlock"/>
+			<dataarea name="flop" size="194816">
+				<rom name="40 principales vol. 6, los - the way of the exploding fist + nemesis the warlock (1987)(erbe)(es)(en)(side b).dsk" size="194816" crc="366acc72" sha1="3116c8a66c6be6d185ed1b211d7ce7d3ade3a0e8" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+
+<!-- From "Sinclair ZX Spectrum - Compilations - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="los40v6a" cloneof="los40v6">
+		<description>Los 40 Principales Vol. 6 (alt)</description>
+		<year>1987</year>
+		<publisher>Erbe</publisher>
+		<part name="flop1" interface="floppy_3">
+			<feature name="part_id" value="Side A: Rocky + Survivor"/>
+			<dataarea name="flop" size="194816">
+				<rom name="40 principales vol. 6, los - rocky + survivor (1987)(erbe)(es).dsk" size="194816" crc="fe1eae07" sha1="705fa61c03a27194cf031f0542d375eacb5d41f0" offset="0" />
+			</dataarea>
+		</part>
+		<part name="flop2" interface="floppy_3">
+			<feature name="part_id" value="Side B: The Way of the Exploding Fist + Nemesis the Warlock"/>
+			<dataarea name="flop" size="194816">
+				<rom name="40 principales vol. 6, los - the way of the exploding fist + nemesis the warlock (1987)(erbe)(es)(en).dsk" size="194816" crc="1861a94b" sha1="f2bd0cb1ed02e1cba60435c19bd58e0acaf6bf16" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Compilations - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="los40v7">
+		<description>Los 40 Principales Vol. 7</description>
+		<year>1987</year>
+		<publisher>Erbe</publisher>
+		<part name="flop1" interface="floppy_3">
+			<feature name="part_id" value="Side A: Saboteur 2 + Las Tres Luces de Glaurung"/>
+			<dataarea name="flop" size="194816">
+				<rom name="40 principales vol. 7, los (1987)(erbe)(es)(en-es)(side a).dsk" size="194816" crc="4b8b5d59" sha1="6bd353df0e3eb5424e6aea89bcd27ba3349118db" offset="0" />
+			</dataarea>
+		</part>
+		<part name="flop2" interface="floppy_3">
+			<feature name="part_id" value="Side B: Camelot Warriors + Dustin"/>
+			<dataarea name="flop" size="194816">
+				<rom name="40 principales vol. 7, los (1987)(erbe)(es)(en)(side b).dsk" size="194816" crc="d3564e75" sha1="016d5f3a9545320f3f9a6ad265a3f7df0278de7d" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Compilations - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="los40v8">
+		<description>Los 40 Principales Vol. 8</description>
+		<year>1987</year>
+		<publisher>Erbe</publisher>
+		<part name="flop1" interface="floppy_3">
+			<feature name="part_id" value="Side A: Barbarian + Cauldron II"/>
+			<dataarea name="flop" size="194816">
+				<rom name="40 principales vol. 8, los (1987)(erbe)(es)(en-es)(side a).dsk" size="194816" crc="1077758c" sha1="bf24432fd0248340b314ddbcc04b3eb2c9350195" offset="0" />
+			</dataarea>
+		</part>
+		<part name="flop2" interface="floppy_3">
+			<feature name="part_id" value="Side B: Saboteur + West Bank"/>
+			<dataarea name="flop" size="194816">
+				<rom name="40 principales vol. 8, los (1987)(erbe)(es)(en)(side b).dsk" size="194816" crc="8ef48835" sha1="5f9c57c795ca5f9a9a1cae5cd5e7078be0a0b705" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Compilations - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="los40v8a" cloneof="los40v8">
+		<description>Los 40 Principales Vol. 8 (alt)</description>
+		<year>1987</year>
+		<publisher>Erbe</publisher>
+		<part name="flop1" interface="floppy_3">
+			<feature name="part_id" value="Side A: Barbarian + Cauldron II"/>
+			<dataarea name="flop" size="194816">
+				<rom name="40 principales vol. 8, los - barbarian + cauldron ii - the pumpkin strikes back (1987)(erbe)(es)(en).dsk" size="194816" crc="8a786f29" sha1="5fe9b2c722ba835a95ba9690b14497c8d3fca6ec" offset="0" />
+			</dataarea>
+		</part>
+		<part name="flop2" interface="floppy_3">
+			<feature name="part_id" value="Side B: Saboteur + West Bank"/>
+			<dataarea name="flop" size="194816">
+				<rom name="40 principales vol. 8, los - saboteur + west bank (1987)(erbe)(es)(en).dsk" size="194816" crc="19eb9f73" sha1="0616802b7251b5dc3a0766bdefe84e2d52a9ad1a" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Compilations - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="los40v8b" cloneof="los40v8">
+		<description>Los 40 Principales Vol. 8 (alt 2)</description>
+		<year>1987</year>
+		<publisher>Erbe</publisher>
+		<part name="flop1" interface="floppy_3">
+			<feature name="part_id" value="Side A: Barbarian + Cauldron II"/>
+			<dataarea name="flop" size="194816">
+				<rom name="40 principales vol. 8, los - barbarian + cauldron ii - the pumpkin strikes back (1987)(erbe)(es)(en)[a].dsk" size="194816" crc="54acc38e" sha1="eafadcf282e0d922be5b28caed86f2ad65f12a3a" offset="0" />
+			</dataarea>
+		</part>
+		<part name="flop2" interface="floppy_3">
+			<feature name="part_id" value="Side B: Saboteur + West Bank"/>
+			<dataarea name="flop" size="194816">
+				<rom name="40 principales vol. 8, los - saboteur + west bank (1987)(erbe)(es)(en)[a].dsk" size="194816" crc="4ee1ea8a" sha1="c7fe4aff2c7e522304057d454849b350d5d929c7" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Compilations - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="los40v9">
+		<description>Los 40 Principales Vol. 9</description>
+		<year>1987</year>
+		<publisher>Erbe</publisher>
+		<part name="flop1" interface="floppy_3">
+			<feature name="part_id" value="Side A: Uridium + Uchi Mata"/>
+			<dataarea name="flop" size="194816">
+				<rom name="40 principales vol. 9, los (1987)(erbe)(es)(en-es)(side a).dsk" size="194816" crc="fad70a24" sha1="05b136fbcbc2ff78ee1b9df8a8c8eee84b5b27cd" offset="0" />
+			</dataarea>
+		</part>
+		<part name="flop1" interface="floppy_3">
+			<feature name="part_id" value="Side B: World Series Basketball + Nonamed"/>
+			<dataarea name="flop" size="194816">
+				<rom name="40 principales vol. 9, los (1987)(erbe)(es)(en)(side b).dsk" size="194816" crc="8c5e18a1" sha1="ede67667b46bb8d785398c58d22263158ed744af" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Compilations - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="amscompd">
+		<description>Amstrad Compilation Disk Spectrum Plus 3</description>
+		<year>1987</year>
+		<publisher>Amstrad</publisher>
+		<part name="flop1" interface="floppy_3">
+			<feature name="part_id" value="Side A: Gift from the Gods + Mailstrom + N.O.M.A.D."/>
+			<dataarea name="flop" size="194816">
+				<rom name="amstrad compilation disk spectrum plus 3 - gift from the gods + mailstrom + n.o.m.a.d. (1987)(amstrad)(side a).dsk" size="194816" crc="a05a58f8" sha1="148e437f0d035f3460733205c546eb9d2022c909" offset="0" />
+			</dataarea>
+		</part>
+		<part name="flop2" interface="floppy_3">
+			<feature name="part_id" value="Side B: Daley Thompson's Supertest + Cosmic Wartoad"/>
+			<dataarea name="flop" size="194816">
+				<rom name="amstrad compilation disk spectrum plus 3 - daley thompson's supertest + cosmic wartoad (1987)(amstrad)(side b).dsk" size="194816" crc="c84b1e03" sha1="4242cda1493d0ded1766ad9de14727a7ec2b53eb" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Compilations - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="amscompda" cloneof="amscompd">
+		<description>Amstrad Compilation Disk Spectrum Plus 3 (alt)</description>
+		<year>1987</year>
+		<publisher>Amstrad</publisher>
+		<part name="flop1" interface="floppy_3">
+			<feature name="part_id" value="Side A: Gift from the Gods + Mailstrom + N.O.M.A.D."/>
+			<dataarea name="flop" size="194816">
+				<rom name="amstrad compilation disk spectrum plus 3 - gift from the gods + mailstrom + n.o.m.a.d. (1987)(amstrad).dsk" size="194816" crc="8fc5a575" sha1="37474b491853775d7b0f9983f50a655106bc7800" offset="0" />
+			</dataarea>
+		</part>
+		<part name="flop2" interface="floppy_3">
+			<feature name="part_id" value="Side B: Daley Thompson's Supertest + Cosmic Wartoad"/>
+			<dataarea name="flop" size="194816">
+				<rom name="amstrad compilation disk spectrum plus 3 - daley thompson's supertest + cosmic wartoad (1987)(amstrad).dsk" size="194816" crc="e7f1d954" sha1="9299a87cb3dd915660f16d5cc8b0082db84a2711" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Compilations - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="amscompdb" cloneof="amscompd">
+		<description>Amstrad Compilation Disk Spectrum Plus 3 (alt 2)</description>
+		<year>1987</year>
+		<publisher>Amstrad</publisher>
+		<part name="flop1" interface="floppy_3">
+		<!-- Side missing from dump, using same as parent set -->
+			<feature name="part_id" value="Side A: Gift from the Gods + Mailstrom + N.O.M.A.D."/>
+			<dataarea name="flop" size="194816">
+				<rom name="amstrad compilation disk spectrum plus 3 - gift from the gods + mailstrom + n.o.m.a.d. (1987)(amstrad)(side a).dsk" size="194816" crc="a05a58f8" sha1="148e437f0d035f3460733205c546eb9d2022c909" offset="0" />
+			</dataarea>
+		</part>
+		<part name="flop2" interface="floppy_3">
+			<feature name="part_id" value="Side B: Daley Thompson's Supertest + Cosmic Wartoad"/>
+			<dataarea name="flop" size="194816">
+				<rom name="amstrad compilation disk spectrum plus 3 - daley thompson's supertest + cosmic wartoad (1987)(amstrad)[a].dsk" size="194816" crc="f273df89" sha1="b19047727440ade850268f129ba2e4ceadb9163f" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Compilations - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="anbigdsk">
+		<description>Another Big Disk</description>
+		<year>1991</year>
+		<publisher>Zenobi</publisher>
+		<part name="flop1" interface="floppy_3">
+			<feature name="part_id" value="Side A: The Menagerie + The Miser + Bog of Brit"/>
+			<dataarea name="flop" size="194816">
+				<rom name="another big disk - the menagerie + the miser + bog of brit (1991)(zenobi)(side a).dsk" size="194816" crc="7a22c6b0" sha1="91279fbb792a02efa15e710b3f2783cb0d8d74bb" offset="0" />
+			</dataarea>
+		</part>
+		<part name="flop2" interface="floppy_3">
+			<feature name="part_id" value="Side B: The Pendant of Logryn"/>
+			<dataarea name="flop" size="194816">
+				<rom name="another big disk - the pendant of logryn (1991)(zenobi)(side b).dsk" size="194816" crc="9a1aadd3" sha1="4e442d0d7b1607351027d8e8a01622829de7c57f" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Compilations - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="arccolv1">
+		<description>Arcade Collection Volume 1</description>
+		<year>1990</year>
+		<publisher>Players</publisher>
+		<part name="flop1" interface="floppy_3">
+			<feature name="part_id" value="Side A"/>
+			<dataarea name="flop" size="195635">
+				<rom name="arcade collection volume 1 (1990)(players)(side a).dsk" size="195635" crc="a49ab925" sha1="2ec5adfd4a91f00e91888856b8dac19629f16408" offset="0" />
+			</dataarea>
+		</part>
+		<part name="flop2" interface="floppy_3">
+			<feature name="part_id" value="Side B"/>
+			<dataarea name="flop" size="195635">
+				<rom name="arcade collection volume 1 (1990)(players)(side b).dsk" size="195635" crc="7dbbfe6e" sha1="7b001d134285c7f370b8ec692d93b909319f8219" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Compilations - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="arccolv2">
+		<description>Arcade Collection Volume 2</description>
+		<year>1990</year>
+		<publisher>Players</publisher>
+		<part name="flop1" interface="floppy_3">
+			<dataarea name="flop" size="194816">
+				<rom name="arcade collection volume 2 (1990)(players)[aka hotshots arcade 2].dsk" size="194816" crc="6329fc50" sha1="009ef6c638821269f2d101500323117ce1839215" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Compilations - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="arccolv2a" cloneof="arccolv2">
+		<description>Arcade Collection Volume 2 (alt)</description>
+		<year>1990</year>
+		<publisher>Players</publisher>
+		<part name="flop1" interface="floppy_3">
+			<dataarea name="flop" size="194816">
+				<rom name="arcade collection volume 2 - moving target + cobra force + task force (1990)(players)[aka hotshots arcade 2].dsk" size="194816" crc="990e7ee8" sha1="925127f9ad26e4ba7946e62c332f5db75abf300c" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Compilations - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="acextra3">
+		<description>Arcade Extravaganza Disk 3</description>
+		<year>1988</year>
+		<publisher>Alternative</publisher>
+		<part name="flop1" interface="floppy_3">
+			<dataarea name="flop" size="194816">
+				<rom name="arcade extravaganza disk 3 (1988)(alternative).dsk" size="194816" crc="e421ac09" sha1="5d8fce028a7793d3ecf84086244a9fb77104cc94" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Compilations - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="arnadv12">
+		<description>Arnold the Adventurer 1 + 2</description>
+		<year>19??</year>
+		<publisher>Zenobi</publisher>
+		<part name="flop1" interface="floppy_3">
+			<dataarea name="flop" size="194816">
+				<rom name="arnold the adventurer 1 + 2 (19xx)(zenobi).dsk" size="194816" crc="2de22fac" sha1="b721610fbf50a964560810e678c55fae31d2a0d4" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Compilations - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="balrogbd">
+		<description>Balrog's Big Disk</description>
+		<year>1991</year>
+		<publisher>Zenobi</publisher>
+		<part name="flop1" interface="floppy_3">
+			<feature name="part_id" value="Side A: Pawns of War + Crack City + Stalker"/>
+			<dataarea name="flop" size="194816">
+				<rom name="balrog's big disk - pawns of war + crack city + stalker (1991)(zenobi)(side a).dsk" size="194816" crc="2420fde6" sha1="0ae1560b42f3751e53b949384a903b54b720ad5d" offset="0" />
+			</dataarea>
+		</part>
+		<part name="flop2" interface="floppy_3">
+			<feature name="part_id" value="Side B: Pawns of War II - The Infiltrator + Sherlock Holmes - The Case of the Beheaded"/>
+			<dataarea name="flop" size="194816">
+				<rom name="balrog's big disk - pawns of war ii - the infiltrator + sherlock holmes - the case of the beheaded (1991)(zenobi)(side b).dsk" size="194816" crc="4cd5597d" sha1="e95d285c863ef75a3215b778be879210af03eca5" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Compilations - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="balrtril">
+		<description>The Balrogian Trilogy</description>
+		<year>1990</year>
+		<publisher>Zenobi</publisher>
+		<part name="flop1" interface="floppy_3">
+			<feature name="part_id" value="Side A: Fuddo &amp; Slam + An Everyday Tale of a Seeker of Gold"/>
+			<dataarea name="flop" size="194816">
+				<rom name="balrogian trilogy, the - fuddo &amp; slam + an everyday tale of a seeker of gold (1990)(zenobi)(side a).dsk" size="194816" crc="b24c8eb3" sha1="d95392ef03df89350cf3a88198f3272322f942a4" offset="0" />
+			</dataarea>
+		</part>
+		<part name="flop2" interface="floppy_3">
+			<feature name="part_id" value="Side B: Bulbo and the Lizard-King + Heroes and Villiains, The Illustrated Guide"/>
+			<dataarea name="flop" size="194816">
+				<rom name="balrogian trilogy, the (1990)(zenobi)(side b).dsk" size="194816" crc="ca9781f5" sha1="9509fafb718bff4a79d4263fafd32bd652280a60" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Compilations - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="barddraq">
+		<description>The Bardic Rites + Dragon-Quest</description>
+		<year>1994</year>
+		<publisher>Zenobi</publisher>
+		<part name="flop1" interface="floppy_3">
+			<feature name="part_id" value="Side A: The Bardic Rites"/>
+			<dataarea name="flop" size="194816">
+				<rom name="bardic rite, the + dragon-quest (1994)(zenobi)(side a).dsk" size="194816" crc="e9f37369" sha1="762066e0834221fba3f750d4fb6903104da9e749" offset="0" />
+			</dataarea>
+		</part>
+		<part name="flop2" interface="floppy_3">
+			<feature name="part_id" value="Side B: Dragon-Quest"/>
+			<dataarea name="flop" size="194816">
+				<rom name="bardic rite, the + dragon-quest (1994)(zenobi)(side b).dsk" size="194816" crc="a6ba75ed" sha1="be15f27cce94d496664120282610f6e222864105" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Compilations - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="bartbret">
+		<description>Bart Bear + The Return of Bart Bear</description>
+		<year>19??</year>
+		<publisher>Zenobi</publisher>
+		<part name="flop1" interface="floppy_3">
+			<dataarea name="flop" size="194816">
+				<rom name="bart bear - the return of bart bear (19xx)(zenobi).dsk" size="194816" crc="0396887f" sha1="c2f8db9fea7b7fc90fd043d7e509691a32856b2b" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Compilations - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="bstclles">
+		<description>The Best of Clive and Les</description>
+		<year>1991</year>
+		<publisher>Zenobi</publisher>
+		<part name="flop1" interface="floppy_3">
+			<dataarea name="flop" size="194816">
+				<rom name="best of clive and les, the - the little wandering guru + nightwing + demi-god (1991)(zenobi).dsk" size="194816" crc="f577d853" sha1="4fd34aecf2a22be831ebfb498724c1b52b593e92" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Compilations - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="belitev1">
+		<description>Best of Elite Vol. 1</description>
+		<year>1987</year>
+		<publisher>Hit-Pak</publisher>
+		<part name="flop1" interface="floppy_3">
+			<feature name="part_id" value="Side A: Frank Bruno's Boxing + Bomb Jack"/>
+			<dataarea name="flop" size="214784">
+				<rom name="best of elite vol 1 - frank bruno's boxing + bomb jack (1987)(hit-pak).dsk" size="214784" crc="d7dcaba9" sha1="4390a79bea5a12930b52d12e8bc3a0eb4bafb5eb" offset="0" />
+			</dataarea>
+		</part>
+		<part name="flop1" interface="floppy_3">
+			<feature name="part_id" value="Side B: Airwolf + Commando"/>
+			<dataarea name="flop" size="214784">
+				<rom name="best of elite vol 1 - airwolf + commando (1987)(hit-pak).dsk" size="214784" crc="36042980" sha1="41b40047372fac5c7001031de46ff4db79b27561" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Compilations - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="bogbmena">
+		<description>Bog of Brit + The Menagerie</description>
+		<year>1990</year>
+		<publisher>Zenobi</publisher>
+		<part name="flop1" interface="floppy_3">
+			<dataarea name="flop" size="194816">
+				<rom name="bog of brit + menagerie, the (1990)(zenobi)[re-release].dsk" size="194816" crc="dc47c945" sha1="1d999f7809037b4207bb5feeba9f52172edb1cc3" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Compilations - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="bootsact">
+		<description>Boots Action Pack</description>
+		<year>1987</year>
+		<publisher>Boots</publisher>
+		<part name="flop1" interface="floppy_3">
+			<feature name="part_id" value="Side A"/>
+			<dataarea name="flop" size="194560">
+				<rom name="boots action pack (1987)(boots)(side a).dsk" size="194560" crc="64e69648" sha1="1ef510c5de07b93e3703f820ce170a831cead5f8" offset="0" />
+			</dataarea>
+		</part>
+		<part name="flop2" interface="floppy_3">
+			<feature name="part_id" value="Side B"/>
+			<dataarea name="flop" size="194816">
+				<rom name="boots action pack (1987)(boots)(side b).dsk" size="194816" crc="199e7278" sha1="146f78330dfddb38f24411abb49eefb7aba83783" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Compilations - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="cezcoll1">
+		<description>CEZ Collection Vol.1</description>
+		<year>2008</year>
+		<publisher>Computer Emuzone</publisher>
+		<part name="flop1" interface="floppy_3">
+			<feature name="part_id" value="Side A: Cannon Bubble + BeTiled! + Moggy"/>
+			<dataarea name="flop" size="194816">
+				<rom name="cez collection vol.1 (2008)(computer emuzone)(es)(side a).dsk" size="194816" crc="9a228323" sha1="ed7241701293769e29caa3b931578bd17ed3a3e8" offset="0" />
+			</dataarea>
+		</part>
+		<part name="flop2" interface="floppy_3">
+			<feature name="part_id" value="Side B: Phantomasa 2 + Columns + Phantomas Saga: Infinity"/>
+			<dataarea name="flop" size="194816">
+				<rom name="cez collection vol.1 (2008)(computer emuzone)(es)(side b).dsk" size="194816" crc="5a0ab5e1" sha1="d7cb0ec40d9f05f5531d7f3b687ea46ecd43aa7c" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Compilations - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="cartcap3">
+		<description>Cartoon Capers Disk 3</description>
+		<year>1988</year>
+		<publisher>Alternative</publisher>
+		<part name="flop1" interface="floppy_3">
+			<dataarea name="flop" size="194816">
+				<rom name="cartoon capers disk 3 (1988)(alternative).dsk" size="194816" crc="bd43f24b" sha1="a5a5f52b283f84d7dfa2d904712a1d25ba75dcb8" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Compilations - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="chartbus">
+		<description>Chartbusters</description>
+		<year>19??</year>
+		<publisher>Ocean</publisher>
+		<part name="flop1" interface="floppy_3">
+			<feature name="part_id" value="Side A: Cobra + Mutants + Green Beret"/>
+			<dataarea name="flop" size="194560">
+				<rom name="chartbusters - cobra + mutants + green beret (19xx)(ocean)(side a).dsk" size="194560" crc="43019e2e" sha1="82ba8864be71bb8d17c714b7fd0713ad147d79e3" offset="0" />
+			</dataarea>
+		</part>
+		<part name="flop2" interface="floppy_3">
+			<feature name="part_id" value="Side B: Short Circuit + The Great Escape + Yie Ar Kung-Fu"/>
+			<dataarea name="flop" size="194560">
+			<rom name="chartbusters - short circuit + the great escape + yie ar kung-fu (19xx)(ocean)(side b).dsk" size="194560" crc="2c6606cf" sha1="e2224ab3990f61d451fa6741419b6a2653314658" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Compilations - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="clasgam4">
+		<description>Classic Games 4</description>
+		<year>1989</year>
+		<publisher>CP</publisher>
+		<part name="flop1" interface="floppy_3">
+			<dataarea name="flop" size="194816">
+				<rom name="classic games 4 (1989)(cp).dsk" size="194816" crc="c2c629e1" sha1="20a45c48006b88ca85800a1f8a6d8c38381e35d7" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Compilations - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="colexdin">
+		<description>Coleccion de Exitos Dinamic</description>
+		<year>1988</year>
+		<publisher>Dinamic</publisher>
+		<part name="flop1" interface="floppy_3">
+			<feature name="part_id" value="Side A: Army Moves + Game Over + Camelot Warriors + Nonamed"/>
+			<dataarea name="flop" size="214784">
+				<rom name="coleccion de exitos dinamic (1988)(dinamic)(es)(side a).dsk" size="214784" crc="ca9527ca" sha1="71d635ed97ba4483d00c7aed0fbe6bd813268629" offset="0" />
+			</dataarea>
+		</part>
+		<part name="flop2" interface="floppy_3">
+			<feature name="part_id" value="Side B: Abu Simbel + Dustin + Phantomas 2 + Don Quijote"/>
+			<dataarea name="flop" size="214784">
+				<rom name="coleccion de exitos dinamic (1988)(dinamic)(es)(side b).dsk" size="214784" crc="4293fe06" sha1="a72a1bfd8a70206d6000a3883c54ee9417f19425" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Compilations - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="commperf">
+		<description>Command Performance</description>
+		<year>1989</year>
+		<publisher>U.S. Gold</publisher>
+		<part name="flop1" interface="floppy_3">
+			<feature name="part_id" value="Side A"/>
+			<dataarea name="flop" size="219648">
+				<rom name="command performance (1989)(u.s. gold)(side a).dsk" size="219648" crc="d9efa2c8" sha1="011bb04acbdf1d94b575472be757f2fd67457e1f" offset="0" />
+			</dataarea>
+		</part>
+		<part name="flop2" interface="floppy_3">
+			<feature name="part_id" value="Side B"/>
+			<dataarea name="flop" size="219648">
+				<rom name="command performance (1989)(u.s. gold)(side b).dsk" size="219648" crc="89841c5e" sha1="e4aaac3e4291239b5d2debc89b939b3ff09e4c66" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Compilations - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="comoltri">
+		<description>Complex Oldfield Trilogy</description>
+		<year>2011</year>
+		<publisher>&lt;homebrew&gt;</publisher>
+		<info name="author" value="Ignacio Prini Garcia"/>
+		<part name="flop1" interface="floppy_3">
+			<dataarea name="flop" size="194816">
+				<rom name="complex oldfield trilogy (2011)(garcia, ignacio prini)(es)(en).dsk" size="194816" crc="5de10460" sha1="e5121150239f6feae731c4b249bb31fc202a0056" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Compilations - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="compclas">
+		<description>Computer Classics</description>
+		<year>1987</year>
+		<publisher>Beau-Jolly</publisher>
+		<part name="flop1" interface="floppy_3">
+			<feature name="part_id" value="Side A: Aliens + Cauldron II - The Pumpkin Strikes Back + Dynamite Dan"/>
+			<dataarea name="flop" size="204544">
+				<rom name="computer classics - aliens + cauldron ii - the pumpkin strikes back + dynamite dan (1987)(beau-jolly).dsk" size="204544" crc="f34e00f7" sha1="293aa4a82b1163cff606a9c8a8ff1e9c4a4d9364" offset="0" />
+			</dataarea>
+		</part>
+		<part name="flop1" interface="floppy_3">
+			<feature name="part_id" value="Side B: Into the Eagle's Nest + Exolon"/>
+			<dataarea name="flop" size="204544">
+				<rom name="computer classics - into the eagle's nest + exolon (1987)(beau-jolly).dsk" size="204544" crc="a1d84366" sha1="c8e1f9ae43d3e44614eb0bf6b51807e1c6ee79df" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Compilations - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="dtppack">
+		<description>DTP Pack</description>
+		<year>1988</year>
+		<publisher>P.C.G. Computer</publisher>
+		<part name="flop1" interface="floppy_3">
+			<feature name="part_id" value="Side A: Word-Master"/>
+			<dataarea name="flop" size="194816">
+				<rom name="dtp pack (1988)(p.c.g. computer)(side a).dsk" size="194816" crc="5c1e0941" sha1="ce781bbfa6fa3f68f5705331887fb5adf3a3271b" offset="0" />
+			</dataarea>
+		</part>
+		<part name="flop2" interface="floppy_3">
+			<feature name="part_id" value="Side B: Headliner + Typeliner & Font Editor"/>
+			<dataarea name="flop" size="194816">
+				<rom name="dtp pack (1988)(p.c.g. computer)(side b).dsk" size="194816" crc="b3f9e13d" sha1="af4ebdf3ebcf3c7143fac4740bf4f9b90894e440" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Compilations - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="dearcgal">
+		<description>Data East's Arcade Alley</description>
+		<year>1988</year>
+		<publisher>U.S. Gold</publisher>
+		<part name="flop1" interface="floppy_3">
+			<feature name="part_id" value="Side A: Express Raider + Last Mission"/>
+			<dataarea name="flop" size="194816">
+				<rom name="data east's arcade alley - express raider + last mission (1988)(u.s. gold)(side a).dsk" size="194816" crc="4621ccee" sha1="6357e892ac1e242d93f145bd1fc3a925133db1a4" offset="0" />
+			</dataarea>
+		</part>
+		<part name="flop2" interface="floppy_3">
+			<feature name="part_id" value="Side B: Kung-Fu Master + Breakthru"/>
+			<dataarea name="flop" size="194816">
+				<rom name="data east's arcade alley - kung-fu master + breakthru (1988)(u.s. gold)(side b).dsk" size="194816" crc="117f5368" sha1="24c459c63cd1829131c6fc6dd730ffc9f192cf45" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Compilations - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="dearcgala" cloneof="dearcgal">
+		<description>Data East's Arcade Alley (alt)</description>
+		<year>1988</year>
+		<publisher>U.S. Gold</publisher>
+		<part name="flop1" interface="floppy_3">
+			<feature name="part_id" value="Side A: Express Raider + Last Mission"/>
+			<dataarea name="flop" size="194816">
+				<rom name="data east's arcade alley - express raider + last mission (1988)(u.s. gold)(side a).dsk" size="194816" crc="4621ccee" sha1="6357e892ac1e242d93f145bd1fc3a925133db1a4" offset="0" />
+			</dataarea>
+		</part>
+		<part name="flop1" interface="floppy_3">
+			<feature name="part_id" value="Side B: Kung-Fu Master + Breakthru"/>
+			<dataarea name="flop" size="194816">
+				<rom name="data east's arcade alley - kung-fu master + breakthru (1988)(u.s. gold).dsk" size="194816" crc="3ec5943f" sha1="1a653fa41d7fcd7aaffe928d2c0185301dd764d7" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Compilations - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="delberts">
+		<description>Delbert's Hamster-Wheel of Fortune</description>
+		<year>1992</year>
+		<publisher>Delbert the Hamster</publisher>
+		<part name="flop1" interface="floppy_3">
+			<dataarea name="flop" size="194816">
+				<rom name="delbert's hamster-wheel of fortune (1992)(delbert the hamster).dsk" size="194816" crc="4926b045" sha1="a1b2b39d92ea14d1daa207624b70c2fadae6ee7c" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Compilations - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="dicksgal">
+		<description>Dicks Galore</description>
+		<year>1992</year>
+		<publisher>Zenobi</publisher>
+		<part name="flop1" interface="floppy_3">
+			<feature name="part_id" value="Side A: Robin of Sherlock"/>
+			<dataarea name="flop" size="197376">
+				<rom name="dicks galore (1992)(zenobi)(side a).dsk" size="197376" crc="cf38d6de" sha1="7499d53d6419f645e2acf969d0aa1db883bdbe61" offset="0" />
+			</dataarea>
+		</part>
+		<part name="flop2" interface="floppy_3">
+			<feature name="part_id" value="Side B: The Big Sleaze"/>
+			<dataarea name="flop" size="194816">
+				<rom name="dicks galore (1992)(zenobi)(side b).dsk" size="194816" crc="621a14ab" sha1="f08c273685367a590261b850f5ec8ec716bd3aaf" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Compilations - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="dinamic5">
+		<description>Dinamic 5 Aniversario</description>
+		<year>1989</year>
+		<publisher>Dinamic</publisher>
+		<part name="flop1" interface="floppy_3">
+			<feature name="part_id" value="Disk 1, Side A: Los Pajaros de Bangkok + Mega-Corp"/>
+			<dataarea name="flop" size="214784">
+				<rom name="dinamic 5 aniversario - los pajaros de bangkok + mega-corp (1989)(dinamic)(es)(disk 1 of 4 side a)[aka pack 5 aniversario].dsk" size="214784" crc="8b6a817e" sha1="2afb682db6296cc2e469155424d82dd6e145ed58" offset="0" />
+			</dataarea>
+		</part>
+		<part name="flop2" interface="floppy_3">
+			<feature name="part_id" value="Disk 1, Side B: Freddy Hardest + Meganova"/>
+			<dataarea name="flop" size="214784">
+				<rom name="dinamic 5 aniversario - freddy hardest + meganova (1989)(dinamic)(es)(disk 1 of 4 side b)[aka pack 5 aniversario].dsk" size="214784" crc="c1f9665e" sha1="0567c26069742768753c927b0a6a1963211fa441" offset="0" />
+			</dataarea>
+		</part>
+		<part name="flop3" interface="floppy_3">
+			<feature name="part_id" value="Disk 2, Side A: Phantis + Abu Simbel Profanation + Dustin + West Bank"/>
+			<dataarea name="flop" size="214784">
+				<rom name="dinamic 5 aniversario - phantis + abu simbel profanation + dustin + west bank (1989)(dinamic)(es)(disk 2 of 4 side b)[aka pack 5 aniversario].dsk" size="214784" crc="862604dd" sha1="acfca1a0b55c23581d17cb9aafaa2064634c4715" offset="0" />
+			</dataarea>
+		</part>
+		<part name="flop4" interface="floppy_3">
+			<feature name="part_id" value="Disk 2, Side B: Capitan Sevilla + Rocky + Fernando Martin Basket Master + Hundra"/>
+			<dataarea name="flop" size="214784">
+				<rom name="dinamic 5 aniversario - capitan sevilla + rocky + fernando martin basket master + hundra (1989)(dinamic)(es)(disk 2 of 4 side a)[aka pack 5 aniversario].dsk" size="214784" crc="bd5513f3" sha1="179f00b1381108ec88fcdacb5119de4b9c7041ff" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Compilations - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="dinamic5a" cloneof="dinamic5">
+		<description>Dinamic 5 Aniversario (alt)</description>
+		<year>1989</year>
+		<publisher>Dinamic</publisher>
+		<part name="flop1" interface="floppy_3">
+			<feature name="part_id" value="Disk 1, Side A: Los Pajaros de Bangkok + Mega-Corp"/>
+			<dataarea name="flop" size="214784">
+				<rom name="dinamic 5 aniversario - los pajaros de bangkok + mega-corp (1989)(dinamic)(es)(disk 1 of 4 side a)[aka pack 5 aniversario].dsk" size="214784" crc="8b6a817e" sha1="2afb682db6296cc2e469155424d82dd6e145ed58" offset="0" />
+			</dataarea>
+		</part>
+		<part name="flop2" interface="floppy_3">
+			<feature name="part_id" value="Disk 1, Side B: Freddy Hardest + Meganova"/>
+			<dataarea name="flop" size="214784">
+				<rom name="dinamic 5 aniversario - freddy hardest + meganova (1989)(dinamic)(es)(disk 1 of 4 side b)[aka pack 5 aniversario].dsk" size="214784" crc="c1f9665e" sha1="0567c26069742768753c927b0a6a1963211fa441" offset="0" />
+			</dataarea>
+		</part>
+		<part name="flop3" interface="floppy_3">
+			<feature name="part_id" value="Disk 2, Side A: Phantis + Abu Simbel Profanation + Dustin + West Bank"/>
+			<dataarea name="flop" size="214784">
+				<rom name="dinamic 5 aniversario - phantis + abu simbel profanation + dustin + west bank (1989)(dinamic)(es)(disk 2 of 4 side b)[aka pack 5 aniversario].dsk" size="214784" crc="862604dd" sha1="acfca1a0b55c23581d17cb9aafaa2064634c4715" offset="0" />
+			</dataarea>
+		</part>
+		<part name="flop4" interface="floppy_3">
+			<feature name="part_id" value="Disk 2, Side B: Capitan Sevilla + Rocky + Fernando Martin Basket Master + Hundra"/>
+			<dataarea name="flop" size="214784">
+				<rom name="dinamic 5 aniversario - capitan sevilla + rocky + fernando martin basket master + hundra (1989)(dinamic)(es)(disk 2 of 4 side a)[aka pack 5 aniversario].dsk" size="214784" crc="bd5513f3" sha1="179f00b1381108ec88fcdacb5119de4b9c7041ff" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+
+<!-- From "Sinclair ZX Spectrum - Compilations - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="dixonspr">
+		<description>Dixons Premier Collection for Your +3</description>
+		<year>1988</year>
+		<publisher>Dixons</publisher>
+		<part name="flop1" interface="floppy_3">
+			<feature name="part_id" value="Side A: Athena + Slap Fight + Wizball"/>
+			<dataarea name="flop" size="214784">
+				<rom name="dixons premier collection for your +3 - athena + slap fight + wizball (1988)(dixons)(side a).dsk" size="214784" crc="e92b802c" sha1="b72177d547b749b52e46b3f443d85ededfa3a75f" offset="0" />
+			</dataarea>
+		</part>
+		<part name="flop2" interface="floppy_3">
+			<feature name="part_id" value="Side B: Game Over + Arkanoid + Tank"/>
+			<dataarea name="flop" size="214784">
+				<rom name="dixons premier collection for your +3 - game over + arkanoid + tank (1988)(dixons)(side b).dsk" size="214784" crc="a21496c5" sha1="b29de08493f37ad01bfb88e7a06762c5d5f1f906" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Compilations - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="doublecl">
+		<description>Double Classic</description>
+		<year>1988</year>
+		<publisher>Zenobi</publisher>
+		<part name="flop1" interface="floppy_3">
+			<feature name="part_id" value="Side A: Diablo!"/>
+			<dataarea name="flop" size="194816">
+				<rom name="double classic (1988)(zenobi)(side a).dsk" size="194816" crc="80ea8e9d" sha1="2bd5961f2b50479d9600cf9545c94237d70f5342" offset="0" />
+			</dataarea>
+		</part>
+		<part name="flop2" interface="floppy_3">
+			<feature name="part_id" value="Side B: Dr. Jekyll and Mr. Hyde	"/>
+			<dataarea name="flop" size="194816">
+				<rom name="double classic (1988)(zenobi)(side b).dsk" size="194816" crc="a92e7e19" sha1="4e7aeebbe48f81534ac6e8e6d3d64b8e08500c7a" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Compilations - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="epyx21">
+		<description>Epyx 21</description>
+		<year>1990</year>
+		<publisher>U.S. Gold</publisher>
+		<part name="flop1" interface="floppy_3">
+			<feature name="part_id" value="Disk 1, Side A"/>
+			<dataarea name="flop" size="254208">
+				<rom name="epyx 21 (1990)(u.s. gold)(disk 1 of 2 side a).dsk" size="254208" crc="31775c37" sha1="3e07255bf51a9d44d5adebc7b12b09d2a37735b2" offset="0" />
+			</dataarea>
+		</part>
+		<part name="flop2" interface="floppy_3">
+			<feature name="part_id" value="Disk 1, Side B"/>
+			<dataarea name="flop" size="255232">
+				<rom name="epyx 21 (1990)(u.s. gold)(disk 1 of 2 side b).dsk" size="255232" crc="84dc286e" sha1="4983fcc6eb2168ee94205bb19032bd68fa5913a3" offset="0" />
+			</dataarea>
+		</part>
+		<part name="flop3" interface="floppy_3">
+			<feature name="part_id" value="Disk 2"/>
+			<dataarea name="flop" size="256256">
+				<rom name="epyx 21 (1990)(u.s. gold)(disk 2 of 2).dsk" size="256256" crc="251117ed" sha1="89cd3b465cdc35df7399996a4a0ca33a70bbdb46" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Compilations - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="erbe88">
+		<description>Erbe 88</description>
+		<year>1988</year>
+		<publisher>Erbe</publisher>
+		<part name="flop1" interface="floppy_3">
+			<feature name="part_id" value="Disk 1, Side A: Chicago 30's + Coliseum"/>
+			<dataarea name="flop" size="194816">
+				<rom name="erbe 88 - chicago 30's + coliseum (1988)(erbe)(es).dsk" size="194816" crc="00933d7d" sha1="19d5fcbe03c3148ea7079be5d39b88de3ee9579d" offset="0" />
+			</dataarea>
+		</part>
+		<part name="flop2" interface="floppy_3">
+			<feature name="part_id" value="Disk 1, Side B: Titanic"/>
+			<dataarea name="flop" size="194816">
+				<rom name="erbe 88 - titanic (1988)(erbe)(es).dsk" size="194816" crc="a4545d81" sha1="c8d824b8af1a93971ea9297f5feef04cd902460d" offset="0" />
+			</dataarea>
+		</part>
+		<part name="flop3" interface="floppy_3">
+			<feature name="part_id" value="Disk 2, Side A: Operation Wolf"/>
+			<dataarea name="flop" size="194816">
+				<rom name="erbe 88 - operation wolf (1988)(erbe)(es).dsk" size="194816" crc="8684cb85" sha1="17ef91450cc7e81a02846ac92aa2e37c35cbd7c7" offset="0" />
+			</dataarea>
+		</part>
+		<part name="flop4" interface="floppy_3">
+			<feature name="part_id" value="Disk 2, Side B: Psycho Pig U.X.B."/>
+			<dataarea name="flop" size="63488">
+				<rom name="erbe 88 - psycho pig u.x.b. (1988)(erbe)(es).dsk" size="63488" crc="6494096f" sha1="9202225cadeea646288cddb514a098d6333c262d" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Compilations - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="erbe88a" cloneof="erbe88">
+		<description>Erbe 88 (alt)</description>
+		<year>1988</year>
+		<publisher>Erbe</publisher>
+		<part name="flop1" interface="floppy_3">
+			<feature name="part_id" value="Disk 1, Side A: Chicago 30's + Coliseum"/>
+			<dataarea name="flop" size="116992">
+				<rom name="erbe 88 - chicago 30's + coliseum (1988)(erbe)(es)(disk 1 of 3 side a).dsk" size="116992" crc="68c614a5" sha1="7aacdd3676b6d45023105c64eab30006cc893eac" offset="0" />
+			</dataarea>
+		</part>
+		<part name="flop2" interface="floppy_3">
+			<feature name="part_id" value="Disk 1, Side B: Titanic"/>
+			<dataarea name="flop" size="116992">
+				<rom name="erbe 88 - titanic (1988)(erbe)(es)(disk 1 of 3 side b).dsk" size="116992" crc="601a2bbc" sha1="2b102f7e62a13821e079797aefd6fc72106ecf9e" offset="0" />
+			</dataarea>
+		</part>
+		<part name="flop3" interface="floppy_3">
+			<feature name="part_id" value="Disk 2, Side A: Operation Wolf"/>
+			<dataarea name="flop" size="194816">
+				<rom name="erbe 88 (1988)(erbe)(es)(disk 2 of 3 side a).dsk" size="194816" crc="e60e1d0c" sha1="c8243daf73b2936d1142e362f77a5f874acccba4" offset="0" />
+			</dataarea>
+		</part>
+		<part name="flop4" interface="floppy_3">
+			<feature name="part_id" value="Disk 2, Side B: Psycho Pig U.X.B."/>
+			<dataarea name="flop" size="68352">
+				<rom name="erbe 88 (1988)(erbe)(es)(disk 2 of 3 side b).dsk" size="68352" crc="3d8e6ea8" sha1="e3b07c3193ae36005073da72702e0134310d18e2" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Compilations - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="erbe88b" cloneof="erbe88">
+		<description>Erbe 88 (alt 2)</description>
+		<year>1988</year>
+		<publisher>Erbe</publisher>
+		<part name="flop1" interface="floppy_3">
+		<!-- Side missing from dump, using same as parent set -->
+			<feature name="part_id" value="Disk 1, Side A: Chicago 30's + Coliseum"/>
+			<dataarea name="flop" size="194816">
+				<rom name="erbe 88 - chicago 30's + coliseum (1988)(erbe)(es).dsk" size="194816" crc="00933d7d" sha1="19d5fcbe03c3148ea7079be5d39b88de3ee9579d" offset="0" />
+			</dataarea>
+		</part>
+		<part name="flop2" interface="floppy_3">
+		<!-- Side missing from dump, using same as parent set -->
+			<feature name="part_id" value="Disk 1, Side B: Titanic"/>
+			<dataarea name="flop" size="194816">
+				<rom name="erbe 88 - titanic (1988)(erbe)(es).dsk" size="194816" crc="a4545d81" sha1="c8d824b8af1a93971ea9297f5feef04cd902460d" offset="0" />
+			</dataarea>
+		</part>
+		<part name="flop3" interface="floppy_3">
+			<feature name="part_id" value="Disk 2, Side A: Operation Wolf"/>
+			<dataarea name="flop" size="194816">
+				<rom name="erbe 88 - operation wolf (1988)(erbe)(es)[a].dsk" size="194816" crc="0975a93a" sha1="010edc4e3470e29eeaccf1fea8ff53910c8ee1dc" offset="0" />
+			</dataarea>
+		</part>
+		<part name="flop4" interface="floppy_3">
+			<feature name="part_id" value="Disk 2, Side B: Psycho Pig U.X.B."/>
+			<dataarea name="flop" size="68352">
+				<rom name="erbe 88 - psycho pig u.x.b. (1988)(erbe)(es)[a].dsk" size="68352" crc="103dba81" sha1="debe0011ae1c8a63fc3858d66ca778c8aaf38c3c" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Compilations - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="escapefr">
+		<description>Escape from Prison Planet + Hounds of Hell</description>
+		<year>19??</year>
+		<publisher>The Adventure Workshop</publisher>
+		<part name="flop1" interface="floppy_3">
+			<feature name="part_id" value="Side A: Escape from Prison Planet"/>
+			<dataarea name="flop" size="194816">
+				<rom name="escape from prison planet + hounds of hell (19xx)(adventure workshop, the)(side a).dsk" size="194816" crc="4295ad13" sha1="785bbe2d378fc71c07cb5fdfd74c704a7d693132" offset="0" />
+			</dataarea>
+		</part>
+		<part name="flop2" interface="floppy_3">
+			<feature name="part_id" value="Side B: Hounds of Hell"/>
+			<dataarea name="flop" size="194816">
+				<rom name="escape from prison planet + hounds of hell (19xx)(adventure workshop, the)(side b).dsk" size="194816" crc="fc35c9d4" sha1="7aa8693ebbe0acc1cc866c1b1064e914913094b7" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Compilations - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="evenyeta">
+		<description>Even Yet Another Big Disk</description>
+		<year>1991</year>
+		<publisher>Zenobi</publisher>
+		<part name="flop1" interface="floppy_3">
+			<feature name="part_id" value="Side A: The Dogboy + Kobyashi Ag'Kwo - A Return to Naru"/>
+			<dataarea name="flop" size="194816">
+				<rom name="even yet another big disk - the dogboy + kobyashi ag'kwo - a return to naru (1991)(zenobi)(side a).dsk" size="194816" crc="0e5c3a13" sha1="0f507f72b0b096f37ef307443bb50e7fa88edaae" offset="0" />
+			</dataarea>
+		</part>
+		<part name="flop2" interface="floppy_3">
+			<feature name="part_id" value="Side B: Silverwolf + Darkest Road"/>
+			<dataarea name="flop" size="194816">
+				<rom name="even yet another big disk - silverwolf + darkest road (1991)(zenobi)(side b).dsk" size="194816" crc="d4481c89" sha1="df54fd6d863731938d2067e94fb7ff9bf68cbc67" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Compilations - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="fivestg3">
+		<description>Five Star Games 3</description>
+		<year>1987</year>
+		<publisher>Beau-Jolly</publisher>
+		<part name="flop1" interface="floppy_3">
+			<feature name="part_id" value="Side A: Aliens + The Sacred Armour of Antiriad + The Way of the Exploding Fist"/>
+			<dataarea name="flop" size="194816">
+				<rom name="five star games 3 - aliens + the sacred armour of antiriad + the way of the exploding fist (1987)(beau-jolly).dsk" size="194816" crc="a4183f58" sha1="bda5e566d528700d8dc829636a59a55a8755f055" offset="0" />
+			</dataarea>
+		</part>
+		<part name="flop1" interface="floppy_3">
+			<feature name="part_id" value="Side B: Spindizzy + Starquake + Tau Ceti + Uridium+"/>
+			<dataarea name="flop" size="194816">
+				<rom name="five star games 3 - spindizzy + starquake + tau ceti + uridium+ (1987)(beau-jolly).dsk" size="194816" crc="52571952" sha1="23a2ce48d8ea3116578084c398702be0c3adb8d4" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Compilations - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="fyabdisk">
+		<description>Found Yet Another Big Disk</description>
+		<year>1991</year>
+		<publisher>Zenobi</publisher>
+		<part name="flop1" interface="floppy_3">
+			<feature name="part_id" value="Side A: The End is Nigh"/>
+			<dataarea name="flop" size="194816">
+				<rom name="found yet another big disk - the end is nigh (1991)(zenobi)(side a).dsk" size="194816" crc="0fd39d7a" sha1="2291ace6106dc57389039e58c82887f1807eac9d" offset="0" />
+			</dataarea>
+		</part>
+		<part name="flop2" interface="floppy_3">
+			<feature name="part_id" value="Side B: Brian - The Novice Barbarian + Civil Service + Man About the House"/>
+			<dataarea name="flop" size="194816">
+				<rom name="found yet another big disk - brian - the novice barbarian + civil service + man about the house (1991)(zenobi)(side b).dsk" size="194816" crc="f6a2ac35" sha1="71eb7edc2621a1973aa0e5e1b46075cfc0911695" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Compilations - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="fourggv3">
+		<description>Four Great Games Volume 3</description>
+		<year>1988</year>
+		<publisher>Micro Value</publisher>
+		<part name="flop1" interface="floppy_3">
+			<feature name="part_id" value="Side A"/>
+			<dataarea name="flop" size="194816">
+				<rom name="four great games volume 3 (1988)(micro value)[aka microvalue vol. 3].dsk" size="194816" crc="b439e35b" sha1="aafee1249e8ac3f6ec55631b5c59328b55515b36" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Compilations - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="frankbbb">
+		<description>Frank Bruno's Big Box</description>
+		<year>1989</year>
+		<publisher>Elite Systems</publisher>
+		<part name="flop1" interface="floppy_3">
+			<feature name="part_id" value="Disk 1, Side A: Frank Bruno's Boxing + Bomb Jack"/>
+			<dataarea name="flop" size="194816">
+				<rom name="frank bruno's big box (1989)(elite systems)(disk 1 of 4 side a).dsk" size="194816" crc="2c8a15df" sha1="0ba9000def471f11594b303304844f038c12e5a5" offset="0" />
+			</dataarea>
+		</part>
+		<part name="flop2" interface="floppy_3">
+			<feature name="part_id" value="Disk 1, Side B: Airwolf + Commando + Scooby Doo"/>
+			<dataarea name="flop" size="194816">
+				<rom name="frank bruno's big box (1989)(elite systems)(disk 1 of 4 side b).dsk" size="194816" crc="33f3b9f4" sha1="9a774e45a3c3b5f736c159345a0c8a2ef728dd86" offset="0" />
+			</dataarea>
+		</part>
+		<part name="flop3" interface="floppy_3">
+			<feature name="part_id" value="Disk 2, Side A: 1942 + Batty + Ghost 'n Goblins"/>
+			<dataarea name="flop" size="194816">
+				<rom name="frank bruno's big box (1989)(elite systems)(disk 2 of 4 side a).dsk" size="194816" crc="f93cef0c" sha1="3f371f869842621c1445519fdd7e537c3abe9c93" offset="0" />
+			</dataarea>
+		</part>
+		<part name="flop4" interface="floppy_3">
+			<feature name="part_id" value="Disk 2, Side B: Battle Ships + Saboteur"/>
+			<dataarea name="flop" size="194816">
+				<rom name="frank bruno's big box (1989)(elite systems)(disk 2 of 4 side b).dsk" size="194816" crc="1492c7ad" sha1="c5a5de4cfc383533d02bad47567e21a7a08815db" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Compilations - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="gaggeorg">
+		<description>Gaggles of George</description>
+		<year>1996</year>
+		<publisher>Zenobi</publisher>
+		<part name="flop1" interface="floppy_3">
+			<feature name="part_id" value="Side A: Brian - The Novice Barbarian + A Fistful of Necronomicons"/>
+			<dataarea name="flop" size="194816">
+				<rom name="gaggles of george - brian - the novice barbarian + a fistful of necronomicons (1996)(zenobi)(side a).dsk" size="194816" crc="1ee71ba8" sha1="c6e692b8a11fac0e125362888d1b49cac8ea4d2e" offset="0" />
+			</dataarea>
+		</part>
+		<part name="flop2" interface="floppy_3">
+			<feature name="part_id" value="Side B: Trouble with Trolls + The Emerald Elf"/>
+			<dataarea name="flop" size="194816">
+				<rom name="gaggles of george - trouble with trolls + the emerald elf (1996)(zenobi)(side b).dsk" size="194816" crc="7f144a30" sha1="4bd81a0bf2f22ca42d901377e8112ffddabcbf98" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Compilations - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="gameover">
+		<description>Game Over + Game Over 2</description>
+		<year>19??</year>
+		<publisher>Imagine</publisher>
+		<part name="flop1" interface="floppy_3">
+			<feature name="part_id" value="Side A: Game Over"/>
+			<dataarea name="flop" size="101888">
+				<rom name="game over + game over 2 (19xx)(imagine)(side a).dsk" size="101888" crc="6d00c99e" sha1="c4f455027c568c1d2b2538455d48cc74326e88f4" offset="0" />
+			</dataarea>
+		</part>
+		<part name="flop2" interface="floppy_3">
+			<feature name="part_id" value="Side B: Game Over II"/>
+			<dataarea name="flop" size="107264">
+				<rom name="game over + game over 2 (19xx)(imagine)(side b).dsk" size="107264" crc="26859d00" sha1="b806d734fdc966ad6ab0ce0a522fcfdf731efd5f" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Compilations - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="gsandmat">
+		<description>Game, Set and Match</description>
+		<year>1987</year>
+		<publisher>Ocean</publisher>
+		<part name="flop1" interface="floppy_3">
+			<feature name="part_id" value="Side A: GBA Championship Basketball + Super Soccer + World Series Baseball"/>
+			<dataarea name="flop" size="194560">
+				<rom name="game, set and match - gba championship basketball + super soccer + world series baseball (1987)(ocean).dsk" size="194560" crc="6f8325fc" sha1="0cbe9b1ad58ac17b1e0cdd59e390ed2095f68c43" offset="0" />
+			</dataarea>
+		</part>
+		<part name="flop2" interface="floppy_3">
+			<feature name="part_id" value="Side A: Hyper Sports + Konami's Tennis"/>
+			<dataarea name="flop" size="194560">
+				<rom name="game, set and match - hyper sports + konami's tennis (1987)(ocean).dsk" size="194560" crc="5873c4f6" sha1="4b1031a0ffcb952862aa500b3428fc8b5a7d9a08" offset="0" />
+			</dataarea>
+		</part>
+		<part name="flop3" interface="floppy_3">
+			<feature name="part_id" value="Side A: Konami's Ping Pong + Daley Thompson's Supertest"/>
+			<dataarea name="flop" size="194560">
+				<rom name="game, set and match - konami's ping pong + daley thompson's supertest (1987)(ocean).dsk" size="194560" crc="51ce1b94" sha1="7022c2172a46d6c705da4343eaa9d1b47547a09e" offset="0" />
+			</dataarea>
+		</part>
+		<part name="flop4" interface="floppy_3">
+			<feature name="part_id" value="Side A: Barry McGuigan World Championship Boxing + Jonah Barrington's Squash + Pool"/>
+			<dataarea name="flop" size="194560">
+				<rom name="game, set and match - barry mcguigan world championship boxing + jonah barrington's squash + pool (1987)(ocean).dsk" size="194560" crc="e2b334e1" sha1="d514e073868c131af165d89920aff1f4c849a36f" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Compilations - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="germmstr">
+		<description>The German Master</description>
+		<year>1993</year>
+		<publisher>Kosmos</publisher>
+		<part name="flop1" interface="floppy_3">
+			<dataarea name="flop" size="194816">
+				<rom name="german master, the (1993)(kosmos).dsk" size="194816" crc="f8eaac2a" sha1="6fe7928e0a35a1aec442eda354853d4b9ff1d593" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Compilations - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="giantsug">
+		<description>Giants (U.S. Gold)</description>
+		<year>1988</year>
+		<publisher>U.S. Gold</publisher>
+		<part name="flop1" interface="floppy_3">
+			<feature name="part_id" value="Disk 1, Side A: Out Run"/>
+			<dataarea name="flop" size="134144">
+				<rom name="giants - out run (1988)(u.s. gold)(disk 1 of 3 side a).dsk" size="134144" crc="2ebaa196" sha1="7a27e07d14b6d095e90a4e5fb1550c72651dad27" offset="0" />
+			</dataarea>
+		</part>
+		<part name="flop2" interface="floppy_3">
+			<feature name="part_id" value="Disk 1, Side B: Out Run"/>
+			<dataarea name="flop" size="154624">
+				<rom name="giants - out run (1988)(u.s. gold)(disk 1 of 3 side b).dsk" size="154624" crc="e55f2a26" sha1="296cc4091571beb20dbea551adaf7a53e13214a2" offset="0" />
+			</dataarea>
+		</part>
+		<part name="flop1" interface="floppy_3">
+			<feature name="part_id" value="Side A: 720 Degrees + Rolling Thunder"/>
+			<dataarea name="flop" size="194816">
+				<rom name="giants - 720 degrees + rolling thunder (1988)(u.s. gold)(disk 2 of 3 side a).dsk" size="194816" crc="f2ded21e" sha1="055f552e55fc5d2d698f9a17c6524cf8a21d2614" offset="0" />
+			</dataarea>
+		</part>
+		<part name="flop2" interface="floppy_3">
+			<feature name="part_id" value="Side B: Gauntlet II"/>
+			<dataarea name="flop" size="174336">
+				<rom name="giants - gauntlet ii (1988)(u.s. gold)(disk 2 of 3 side b).dsk" size="174336" crc="34f085e5" sha1="f15d5d0f21192a7d3e8881b20fcf26b63a93173e" offset="0" />
+			</dataarea>
+		</part>
+		<part name="flop1" interface="floppy_3">
+			<feature name="part_id" value="Side A: California Games"/>
+			<dataarea name="flop" size="182016">
+				<rom name="giants - california games (1988)(u.s. gold)(disk 3 of 3 side a).dsk" size="182016" crc="345824a9" sha1="d071db70eca434477322f6b105cc7830f2892f73" offset="0" />
+			</dataarea>
+		</part>
+		<part name="flop2" interface="floppy_3">
+			<feature name="part_id" value="Side B: California Games"/>
+			<dataarea name="flop" size="182528">
+				<rom name="giants - california games (1988)(u.s. gold)(disk 3 of 3 side b).dsk" size="182528" crc="3b596738" sha1="2333a2612b1dbd633dadaba41c5c058bcf52e8ba" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Compilations - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="goldsibr">
+		<description>Gold, Silver, Bronze</description>
+		<year>1988</year>
+		<publisher>U.S. Gold</publisher>
+		<part name="flop1" interface="floppy_3">
+			<feature name="part_id" value="Disk 1, Side A: Summer Games"/>
+			<dataarea name="flop" size="184576">
+				<rom name="gold, silver, bronze (1988)(u.s. gold)(side a).dsk" size="184576" crc="3034504a" sha1="f20baaf234c68f322d527d076aa837075127a935" offset="0" />
+			</dataarea>
+		</part>
+		<part name="flop2" interface="floppy_3">
+			<feature name="part_id" value="Disk 1, Side B: Summer Games"/>
+			<dataarea name="flop" size="180480">
+				<rom name="gold, silver, bronze (1988)(u.s. gold)(side b).dsk" size="180480" crc="cd24812e" sha1="97dc0397ac86f4b46906c8191ef58e14502c442d" offset="0" />
+			</dataarea>
+		</part>
+		<part name="flop3" interface="floppy_3">
+			<feature name="part_id" value="Disk 2, Side A: Summer Games II"/>
+			<dataarea name="flop" size="194816">
+				<rom name="gold, silver, bronze (1988)(u.s. gold)(side a)[a].dsk" size="194816" crc="0422099d" sha1="94fe94accdd84bb642a1563b3cac8226c7db39b9" offset="0" />
+			</dataarea>
+		</part>
+		<part name="flop4" interface="floppy_3">
+			<feature name="part_id" value="Disk 2, Side B: Summer Games II"/>
+			<dataarea name="flop" size="194816">
+				<rom name="gold, silver, bronze (1988)(u.s. gold)(side b)[a].dsk" size="194816" crc="f69fca95" sha1="635179013ca325526e23a32623487342ae950fbb" offset="0" />
+			</dataarea>
+		</part>
+		<part name="flop5" interface="floppy_3">
+			<feature name="part_id" value="Disk 3: Winter Games"/>
+			<dataarea name="flop" size="194816">
+				<rom name="gold, silver, bronze (1988)(u.s. gold).dsk" size="194816" crc="046fe4f5" sha1="c19641545d22432e01c29c31c52770cad2d30566" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Compilations - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="grabbedb">
+		<description>Grabbed by the Ghoulies + Helvera - Mistress of the Park</description>
+		<year>1993</year>
+		<publisher>FSF Adventures</publisher>
+		<part name="flop1" interface="floppy_3">
+			<feature name="part_id" value="Side A: Grabbed by the Ghoulies"/>
+			<dataarea name="flop" size="195635">
+				<rom name="grabbed by the ghoulies + helvera - mistress of the park (1993)(fsf adventures)(side a).dsk" size="195635" crc="e5e82113" sha1="5f5de7204497820d9bcd9c73b2f1deede108a884" offset="0" />
+			</dataarea>
+		</part>
+		<part name="flop2" interface="floppy_3">
+			<feature name="part_id" value="Side B: Helvera - Mistress of the Park"/>
+			<dataarea name="flop" size="195121">
+				<rom name="grabbed by the ghoulies + helvera - mistress of the park (1993)(fsf adventures)(side b).dsk" size="195121" crc="c90726df" sha1="c08fd3e559823420f2dcc5d3b66f9671e0059da6" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Compilations - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="granypeq">
+		<description>Grandes y Pequenos</description>
+		<year>19??</year>
+		<publisher>DIMensionNEW</publisher>
+		<part name="flop1" interface="floppy_3">
+			<feature name="part_id" value="Side A"/>
+			<dataarea name="flop" size="194816">
+				<rom name="grandes y pequenos (19xx)(dimensionnew)(es)(side a).dsk" size="194816" crc="8abe3df8" sha1="ed8b86e3d88b262f6aa31164479455322929fe65" offset="0" />
+			</dataarea>
+		</part>
+		<part name="flop2" interface="floppy_3">
+			<feature name="part_id" value="Side B"/>
+			<dataarea name="flop" size="194816">
+				<rom name="grandes y pequenos (19xx)(dimensionnew)(es)(side b).dsk" size="194816" crc="5a5169e4" sha1="43cfafaaef72f6a61b1478e1b01ee5994d824290" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Compilations - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="hairytoe">
+		<description>Hairy Toes</description>
+		<year>1992</year>
+		<publisher>Zenobi</publisher>
+		<part name="flop1" interface="floppy_3">
+			<feature name="part_id" value="Side A: Bored of the Rings"/>
+			<dataarea name="flop" size="194816">
+				<rom name="hairy toes (1992)(zenobi)(side a).dsk" size="194816" crc="6a0bacb5" sha1="c0321b609e53b5ef1f66fa20e66b2f7d345d09c8" offset="0" />
+			</dataarea>
+		</part>
+		<part name="flop2" interface="floppy_3">
+			<feature name="part_id" value="Side B: The Boggit"/>
+			<dataarea name="flop" size="194816">
+				<rom name="hairy toes (1992)(zenobi)(side b).dsk" size="194816" crc="c811fad1" sha1="35106e77a739ba31f8010e9184548f43949f24b0" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Compilations - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="handfham">
+		<description>A Handful of Hamsters</description>
+		<year>1993</year>
+		<publisher>Zenobi</publisher>
+		<part name="flop1" interface="floppy_3">
+			<feature name="part_id" value="Side A: Brian + Aunt Velma + Desmond and Gertrude"/>
+			<dataarea name="flop" size="194816">
+				<rom name="handful of hamsters, a (1993)(zenobi)(side a).dsk" size="194816" crc="62b16c8a" sha1="5e3c6f208d65a2e444cee8f06f08d58e7ba9168a" offset="0" />
+			</dataarea>
+		</part>
+		<part name="flop2" interface="floppy_3">
+			<feature name="part_id" value="Side B: Raymond Pringle + Larry the Lemming + Snow Joke + Star Flaws"/>
+			<dataarea name="flop" size="194816">
+				<rom name="handful of hamsters, a (1993)(zenobi)(side b).dsk" size="194816" crc="4aa88009" sha1="45261509ddcc4eb4e3ce362f5ef55fa3182fded4" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Compilations - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="heroes00">
+		<description>Heroes - </description>
+		<year>1990</year>
+		<publisher>Domark</publisher>
+		<part name="flop1" interface="floppy_3">
+			<feature name="part_id" value="Disk 1, Side A: 007 - Licence to Kill"/>
+			<dataarea name="flop" size="194816">
+				<rom name="heroes - 007 - licence to kill (1990)(domark)(disk 2 of 2 side a).dsk" size="194816" crc="bbed625c" sha1="dda1f24159aad33de62620f60ef38f818fa0ce2f" offset="0" />
+			</dataarea>
+		</part>
+		<part name="flop2" interface="floppy_3">
+			<feature name="part_id" value="Disk 1, Side B: Star Wars"/>
+			<dataarea name="flop" size="194816">
+				<rom name="heroes - star wars (1990)(domark)(disk 2 of 2 side b).dsk" size="194816" crc="1da0fe94" sha1="f8ae04e3682c642f49f77325441e33d22bb92e13" offset="0" />
+			</dataarea>
+		</part>
+		<part name="flop3" interface="floppy_3">
+			<feature name="part_id" value="Disk 2, Side A: Barbarian II - The Dungeon of Drax"/>
+			<dataarea name="flop" size="254720">
+				<rom name="heroes - barbarian ii - the dungeon of drax (1990)(domark)(disk 1 of 2 side a).dsk" size="254720" crc="c5f59915" sha1="be8bb66b0865d1c3933a7bc5286a47e762a06014" offset="0" />
+			</dataarea>
+		</part>
+		<part name="flop4" interface="floppy_3">
+			<feature name="part_id" value="Disk 2, Side B: The Running Man"/>
+			<dataarea name="flop" size="194816">
+				<rom name="heroes - the running man (1990)(domark)(disk 1 of 2 side b).dsk" size="194816" crc="10b9030f" sha1="7fa7a664ef93308584e421fc8604491a06b05a2e" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Compilations - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="javher1">
+		<description>Javier Herrera Games Collection 01</description>
+		<year>19??</year>
+		<publisher>&lt;homebrew&gt;</publisher>
+		<info name="author" value="Javier Herrera"/>
+		<part name="flop1" interface="floppy_3">
+			<feature name="part_id" value="Side A"/>
+			<dataarea name="flop" size="194816">
+				<rom name="javier herrera games collection 01 (19xx)(herrera, javier)(side a).dsk" size="194816" crc="8e88719c" sha1="c381aa7d50e6514908443e41a05bc3aa5f26c00b" offset="0" />
+			</dataarea>
+		</part>
+		<part name="flop2" interface="floppy_3">
+			<feature name="part_id" value="Side B"/>
+			<dataarea name="flop" size="194816">
+				<rom name="javier herrera games collection 01 (19xx)(herrera, javier)(side b).dsk" size="194816" crc="1b13630c" sha1="82b45efa805d60e83d20bbee193817e2163a6121" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Compilations - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="javher2">
+		<description>Javier Herrera Games Collection 02</description>
+		<year>19??</year>
+		<publisher>&lt;homebrew&gt;</publisher>
+		<info name="author" value="Javier Herrera"/>
+		<part name="flop1" interface="floppy_3">
+			<feature name="part_id" value="Side A"/>
+			<dataarea name="flop" size="194816">
+				<rom name="javier herrera games collection 02 (19xx)(herrera, javier)(side a).dsk" size="194816" crc="585d1e40" sha1="350a69050ffff673a2a3630c0cba133ac9407104" offset="0" />
+			</dataarea>
+		</part>
+		<part name="flop2" interface="floppy_3">
+			<feature name="part_id" value="Side B"/>
+			<dataarea name="flop" size="194816">
+				<rom name="javier herrera games collection 02 (19xx)(herrera, javier)(side b).dsk" size="194816" crc="d6618660" sha1="112e207edb35fbe8ed8b2bd5cefdddcd320c1265" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Compilations - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="javher3">
+		<description>Javier Herrera Games Collection 03</description>
+		<year>19??</year>
+		<publisher>&lt;homebrew&gt;</publisher>
+		<info name="author" value="Javier Herrera"/>
+		<part name="flop1" interface="floppy_3">
+			<feature name="part_id" value="Side A"/>
+			<dataarea name="flop" size="194816">
+				<rom name="javier herrera games collection 03 (19xx)(herrera, javier)(side a).dsk" size="194816" crc="aee0e8fb" sha1="461a59555e7a356bb0f259ea581db875ed8c9b4e" offset="0" />
+			</dataarea>
+		</part>
+		<part name="flop2" interface="floppy_3">
+			<feature name="part_id" value="Side B"/>
+			<dataarea name="flop" size="194816">
+				<rom name="javier herrera games collection 03 (19xx)(herrera, javier)(side b).dsk" size="194816" crc="860f1ad5" sha1="41ee5ce0d8fc524a0fefc170787a3cc2c23ebfa6" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Compilations - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="javher4">
+		<description>Javier Herrera Games Collection 04</description>
+		<year>19??</year>
+		<publisher>&lt;homebrew&gt;</publisher>
+		<info name="author" value="Javier Herrera"/>
+		<part name="flop1" interface="floppy_3">
+			<feature name="part_id" value="Side A"/>
+			<dataarea name="flop" size="194816">
+				<rom name="javier herrera games collection 04 (19xx)(herrera, javier)(side a).dsk" size="194816" crc="945a50e7" sha1="4f4d6a6b79b0663db941fcd00dc4b610227965f9" offset="0" />
+			</dataarea>
+		</part>
+		<part name="flop2" interface="floppy_3">
+			<feature name="part_id" value="Side B"/>
+			<dataarea name="flop" size="194816">
+				<rom name="javier herrera games collection 04 (19xx)(herrera, javier)(side b).dsk" size="194816" crc="f144360d" sha1="880e66995adaa86bf7af0e080813adf07dcc54dc" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Compilations - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="javher5">
+		<description>Javier Herrera Games Collection 05</description>
+		<year>19??</year>
+		<publisher>&lt;homebrew&gt;</publisher>
+		<info name="author" value="Javier Herrera"/>
+		<part name="flop1" interface="floppy_3">
+			<feature name="part_id" value="Side A"/>
+			<dataarea name="flop" size="194816">
+				<rom name="javier herrera games collection 05 (19xx)(herrera, javier)(side a).dsk" size="194816" crc="fd15463f" sha1="8751b52e632326bf6a7d85a6452e1bc2015105b4" offset="0" />
+			</dataarea>
+		</part>
+		<part name="flop2" interface="floppy_3">
+			<feature name="part_id" value="Side B"/>
+			<dataarea name="flop" size="194816">
+				<rom name="javier herrera games collection 05 (19xx)(herrera, javier)(side b).dsk" size="194816" crc="9ea0fb52" sha1="dee8356f68826b6ced8a22a6d840b815422071c3" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Compilations - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="javher6">
+		<description>Javier Herrera Games Collection 06</description>
+		<year>19??</year>
+		<publisher>&lt;homebrew&gt;</publisher>
+		<info name="author" value="Javier Herrera"/>
+		<part name="flop1" interface="floppy_3">
+			<feature name="part_id" value="Side A"/>
+			<dataarea name="flop" size="194816">
+				<rom name="javier herrera games collection 06 (19xx)(herrera, javier)(side a).dsk" size="194816" crc="ff05a19e" sha1="85e7e6c2f39dac4342565649cc1948a697188828" offset="0" />
+			</dataarea>
+		</part>
+		<part name="flop2" interface="floppy_3">
+			<feature name="part_id" value="Side B"/>
+			<dataarea name="flop" size="193792">
+				<rom name="javier herrera games collection 06 (19xx)(herrera, javier)(side b).dsk" size="193792" crc="d129c849" sha1="6485512d6e32cc83e6db22050df1e231dfbbb3af" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Compilations - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="javher9">
+		<description>Javier Herrera Games Collection 09</description>
+		<year>19??</year>
+		<publisher>&lt;homebrew&gt;</publisher>
+		<info name="author" value="Javier Herrera"/>
+		<part name="flop1" interface="floppy_3">
+			<feature name="part_id" value="Side A"/>
+			<dataarea name="flop" size="194816">
+				<rom name="javier herrera games collection 09 (19xx)(herrera, javier)(side a).dsk" size="194816" crc="ad137e62" sha1="0f375a8287bd2f05efc5825549df01bfbc2024f7" offset="0" />
+			</dataarea>
+		</part>
+		<part name="flop2" interface="floppy_3">
+			<feature name="part_id" value="Side B"/>
+			<dataarea name="flop" size="194816">
+				<rom name="javier herrera games collection 09 (19xx)(herrera, javier)(side b).dsk" size="194816" crc="b3fc35d5" sha1="8e24264fe8b7a5a53806798cde7e0d56dd232318" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Compilations - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="javher10">
+		<description>Javier Herrera Games Collection 10</description>
+		<year>19??</year>
+		<publisher>&lt;homebrew&gt;</publisher>
+		<info name="author" value="Javier Herrera"/>
+		<part name="flop1" interface="floppy_3">
+			<feature name="part_id" value="Side A"/>
+			<dataarea name="flop" size="194816">
+				<rom name="javier herrera games collection 10 (19xx)(herrera, javier)(side a).dsk" size="194816" crc="4a4d462b" sha1="d90d9c48e773e2b71dcc42a3755733e8ee00b876" offset="0" />
+			</dataarea>
+		</part>
+		<part name="flop2" interface="floppy_3">
+			<feature name="part_id" value="Side B"/>
+			<dataarea name="flop" size="194816">
+				<rom name="javier herrera games collection 10 (19xx)(herrera, javier)(side b).dsk" size="194816" crc="639ba3f6" sha1="f342fa23801f4fc5c888f02d36eed9cb167a8871" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Compilations - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="jennybd1">
+		<description>Jenny's Big Disk Vol 1</description>
+		<year>1991</year>
+		<publisher>Zenobi</publisher>
+		<part name="flop1" interface="floppy_3">
+			<feature name="part_id" value="Side A: Behold Atlantis"/>
+			<dataarea name="flop" size="194816">
+				<rom name="jenny's big disk vol 1 (1991)(zenobi)(side a).dsk" size="194816" crc="04408dce" sha1="83e0bc202f3beaf6361c03cf8f8757f721e8b7d6" offset="0" />
+			</dataarea>
+		</part>
+		<part name="flop2" interface="floppy_3">
+			<feature name="part_id" value="Side B: Eclipse"/>
+			<dataarea name="flop" size="194816">
+				<rom name="jenny's big disk vol 1 (1991)(zenobi)(side b).dsk" size="194816" crc="8aac5b2f" sha1="37e2f6f17b84bfeff83c8345918acec4a8a9e8cb" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Compilations - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="jennybd2">
+		<description>Jenny's Big Disk Vol 2</description>
+		<year>1990</year>
+		<publisher>Zenobi</publisher>
+		<part name="flop1" interface="floppy_3">
+			<feature name="part_id" value="Side A: The Lost Temple"/>
+			<dataarea name="flop" size="194816">
+				<rom name="jenny's big disk vol 2 (1990)(zenobi)(side a).dsk" size="194816" crc="0a4cb350" sha1="4a13aa3b24c9e385f95847f17d5d3321605d025a" offset="0" />
+			</dataarea>
+		</part>
+		<part name="flop2" interface="floppy_3">
+			<feature name="part_id" value="Side B: The Treasure of Santa Maria"/>
+			<dataarea name="flop" size="194816">
+				<rom name="jenny's big disk vol 2 (1990)(zenobi)(side b).dsk" size="194816" crc="4f3ae846" sha1="860b39e96eeae42c162a22f944466c0d9142ca0f" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Compilations - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="jenynbd1">
+		<description>Jenny's Next Big Disk Vol 1</description>
+		<year>1991</year>
+		<publisher>Zenobi</publisher>
+		<part name="flop1" interface="floppy_3">
+			<feature name="part_id" value="Side A: The Curse of Calutha"/>
+			<dataarea name="flop" size="194816">
+				<rom name="jenny's next big disk vol 1 (1991)(zenobi)(side a).dsk" size="194816" crc="79c7a85c" sha1="3978615fe5311f291d4c32ac43e45ff29fb7b615" offset="0" />
+			</dataarea>
+		</part>
+		<part name="flop2" interface="floppy_3">
+			<feature name="part_id" value="Side B: The Legacy"/>
+			<dataarea name="flop" size="194816">
+				<rom name="jenny's next big disk vol 1 (1991)(zenobi)(side b).dsk" size="194816" crc="7989e4ce" sha1="2367c4d459fa34a35bb5022c15ce434a95f03baa" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Compilations - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="jenynbd2">
+		<description>Jenny's Next Big Disk Vol 2</description>
+		<year>1992</year>
+		<publisher>Zenobi</publisher>
+		<part name="flop1" interface="floppy_3">
+			<feature name="part_id" value="Side A: Laskar's Crystals"/>
+			<dataarea name="flop" size="209408">
+				<rom name="jenny's next big disk vol 2 (1992)(zenobi)(side a).dsk" size="209408" crc="6b291a87" sha1="b9737c023e7e9075d8b1941c893ea2c72b39516b" offset="0" />
+			</dataarea>
+		</part>
+		<part name="flop2" interface="floppy_3">
+			<feature name="part_id" value="Side B: Marooned"/>
+			<dataarea name="flop" size="194816">
+				<rom name="jenny's next big disk vol 2 (1992)(zenobi)(side b).dsk" size="194816" crc="93d0566d" sha1="b9a62b6ab72bb7e82aab610d34eff98f0ab54447" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Compilations - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="jestej1">
+		<description>Jesus Tejero Software Collection 01</description>
+		<year>19??</year>
+		<publisher>&lt;homebrew&gt;</publisher>
+		<info name="author" value="Jesus Tejero"/>
+		<part name="flop1" interface="floppy_3">
+			<feature name="part_id" value="Side A"/>
+			<dataarea name="flop" size="194816">
+				<rom name="jesus tejero software collection 01 (19xx)(tejero, jesus)(es)(side a).dsk" size="194816" crc="6f866526" sha1="6f7ebd43e7fe846a327a52890ed109c758178f51" offset="0" />
+			</dataarea>
+		</part>
+		<part name="flop2" interface="floppy_3">
+			<feature name="part_id" value="Side B"/>
+			<dataarea name="flop" size="194816">
+				<rom name="jesus tejero software collection 01 (19xx)(tejero, jesus)(es)(side b).dsk" size="194816" crc="4a997a96" sha1="31e9604ba90626568bb2dd6f98ce65421adef904" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Compilations - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="jestej2">
+		<description>Jesus Tejero Software Collection 02</description>
+		<year>19??</year>
+		<publisher>&lt;homebrew&gt;</publisher>
+		<info name="author" value="Jesus Tejero"/>
+		<part name="flop1" interface="floppy_3">
+			<feature name="part_id" value="Side A"/>
+			<dataarea name="flop" size="194816">
+				<rom name="jesus tejero software collection 02 (19xx)(tejero, jesus)(es)(side a).dsk" size="194816" crc="1c6b3879" sha1="d91a08044ac652626916fb8168747353fb872727" offset="0" />
+			</dataarea>
+		</part>
+		<part name="flop2" interface="floppy_3">
+			<feature name="part_id" value="Side B"/>
+			<dataarea name="flop" size="194816">
+				<rom name="jesus tejero software collection 02 (19xx)(tejero, jesus)(es)(side b).dsk" size="194816" crc="29908ccc" sha1="6261f8744f9588149043dfa1f163198a8d0a592f" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Compilations - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="jestej3">
+		<description>Jesus Tejero Software Collection 03</description>
+		<year>19??</year>
+		<publisher>&lt;homebrew&gt;</publisher>
+		<info name="author" value="Jesus Tejero"/>
+		<part name="flop1" interface="floppy_3">
+			<feature name="part_id" value="Side A"/>
+			<dataarea name="flop" size="194816">
+				<rom name="jesus tejero software collection 03 (19xx)(tejero, jesus)(es)(side a).dsk" size="194816" crc="3cd316b8" sha1="312e2cbe04be6d255ffa835ab8aee31281cc3169" offset="0" />
+			</dataarea>
+		</part>
+		<part name="flop2" interface="floppy_3">
+			<feature name="part_id" value="Side B"/>
+			<dataarea name="flop" size="194816">
+				<rom name="jesus tejero software collection 03 (19xx)(tejero, jesus)(es)(side b).dsk" size="194816" crc="f4bfd57c" sha1="3ecf16672b0d0232f390263fbb669212c4d1896d" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Compilations - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="jestej4">
+		<description>Jesus Tejero Software Collection 04</description>
+		<year>19??</year>
+		<publisher>&lt;homebrew&gt;</publisher>
+		<info name="author" value="Jesus Tejero"/>
+		<part name="flop1" interface="floppy_3">
+			<feature name="part_id" value="Side A"/>
+			<dataarea name="flop" size="194816">
+				<rom name="jesus tejero software collection 04 (19xx)(tejero, jesus)(es)(side a).dsk" size="194816" crc="9969a712" sha1="db44821a2215befb5829710822f7fbb8f6bba94d" offset="0" />
+			</dataarea>
+		</part>
+		<part name="flop2" interface="floppy_3">
+			<feature name="part_id" value="Side B"/>
+			<dataarea name="flop" size="194816">
+				<rom name="jesus tejero software collection 04 (19xx)(tejero, jesus)(es)(side b).dsk" size="194816" crc="c67c7d7e" sha1="d6cdc08a7a3178c75d63ba9cbbae641189cf7d58" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Compilations - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="jestej5">
+		<description>Jesus Tejero Software Collection 05</description>
+		<year>19??</year>
+		<publisher>&lt;homebrew&gt;</publisher>
+		<info name="author" value="Jesus Tejero"/>
+		<part name="flop1" interface="floppy_3">
+			<feature name="part_id" value="Side A"/>
+			<dataarea name="flop" size="194816">
+				<rom name="jesus tejero software collection 05 (19xx)(tejero, jesus)(es)(side a).dsk" size="194816" crc="e0df9b47" sha1="1692adc48cc61d3d20c5c31fd5e428da18f36082" offset="0" />
+			</dataarea>
+		</part>
+		<part name="flop2" interface="floppy_3">
+			<feature name="part_id" value="Side B"/>
+			<dataarea name="flop" size="194816">
+				<rom name="jesus tejero software collection 05 (19xx)(tejero, jesus)(es)(side b).dsk" size="194816" crc="2f1b581b" sha1="dcee200454cd16508490922d7721bcb65040d6d4" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Compilations - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="jeweldar">
+		<description>Jewels of Darkness</description>
+		<year>1986</year>
+		<publisher>Rainbird</publisher>
+		<part name="flop1" interface="floppy_3">
+			<dataarea name="flop" size="194816">
+				<rom name="jewels of darkness (1986)(rainbird).dsk" size="194816" crc="1b1a7650" sha1="da619ff04356ce9ae0f22cf0eeabe2dc39aa918e" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Compilations - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="kidnafps">
+		<description>Kidnapped + For Pete's Sake</description>
+		<year>1993</year>
+		<publisher>Zenobi</publisher>
+		<part name="flop1" interface="floppy_3">
+			<feature name="part_id" value="Side A: Kidnapped"/>
+			<dataarea name="flop" size="195121">
+				<rom name="kidnapped + for pete's sake (1993)(zenobi)(side a).dsk" size="195121" crc="c88fcc08" sha1="5f9505b5ef2380314161b384e11eae243760b02f" offset="0" />
+			</dataarea>
+		</part>
+		<part name="flop2" interface="floppy_3">
+			<feature name="part_id" value="Side B: For Pete's Sake"/>
+			<dataarea name="flop" size="195635">
+				<rom name="kidnapped + for pete's sake (1993)(zenobi)(side b).dsk" size="195635" crc="9c1af001" sha1="8a587d3745699a2547e6ccdf6007a344b03d21f5" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Compilations - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="konaccol">
+		<description>Konami's Arcade Collection</description>
+		<year>1988</year>
+		<publisher>Imagine</publisher>
+		<part name="flop1" interface="floppy_3">
+			<feature name="part_id" value="Disk 1, Side A: Shao-Lin's Road + Jail Break + Nemesis"/>
+			<dataarea name="flop" size="214784">
+				<rom name="konami's arcade collection - shao-lin's road + jail break + nemesis (1988)(imagine)(disk 1 of 2 side a).dsk" size="214784" crc="e7c46afe" sha1="385c2bf89c20de4180ff3a6f8043838c13f7eebe" offset="0" />
+			</dataarea>
+		</part>
+		<part name="flop2" interface="floppy_3">
+			<feature name="part_id" value="Disk 1, Side B: Hyper Sports + Mikie + Green Beret"/>
+			<dataarea name="flop" size="214784">
+				<rom name="konami's arcade collection - hyper sports + mikie + green beret (1988)(imagine)(disk 1 of 2 side b).dsk" size="214784" crc="52ffd779" sha1="5d20442ae382b97f186c4c512e29104eb46b7a71" offset="0" />
+			</dataarea>
+		</part>
+		<part name="flop3" interface="floppy_3">
+			<feature name="part_id" value="Disk 2, Side A: Jackal + Yie Ar Kung-Fu"/>
+			<dataarea name="flop" size="214784">
+				<rom name="konami's arcade collection - jackal + yie ar kung-fu (1988)(imagine)(disk 2 of 2 side a).dsk" size="214784" crc="8a0d2595" sha1="ce4b6b67d4256e66acbdcf2f1a0209d04d8fa239" offset="0" />
+			</dataarea>
+		</part>
+		<part name="flop4" interface="floppy_3">
+			<feature name="part_id" value="Disk 2, Side B: Konami's Ping Pong + Yie Ar Kung-Fu II"/>
+			<dataarea name="flop" size="214784">
+				<rom name="konami's arcade collection - konami's ping pong + yie ar kung-fu ii (1988)(imagine)(disk 2 of 2 side b).dsk" size="214784" crc="e39e4c8c" sha1="2727cc2395a75f8b4c69a31e3dee44950a7d960a" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Compilations - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="krazktgk">
+		<description>Krazy Kartoonist Kaper + The Grue-Knapped</description>
+		<year>1991</year>
+		<publisher>FSF Adventures</publisher>
+		<part name="flop1" interface="floppy_3">
+			<feature name="part_id" value="Side A: Krazy Kartoonist Kaper"/>
+			<dataarea name="flop" size="194816">
+				<rom name="krazy kartoonist kaper + grue-knapped, the (1991)(fsf adventures)(side a).dsk" size="194816" crc="1712580c" sha1="7b563696bd077c2a1c8865c91a20d4f243fa5fb7" offset="0" />
+			</dataarea>
+		</part>
+		<part name="flop2" interface="floppy_3">
+			<feature name="part_id" value="Side B: The Grue-Knapped"/>
+			<dataarea name="flop" size="194816">
+				<rom name="krazy kartoonist kaper + grue-knapped, the (1991)(fsf adventures)(side b).dsk" size="194816" crc="7599ce82" sha1="6eb40c49ce89f42bf7aeb00328cdbacfe7b9ce75" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Compilations - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="lotbdsks">
+		<description>Last of the Big Disks</description>
+		<year>1993</year>
+		<publisher>Zenobi</publisher>
+		<part name="flop1" interface="floppy_3">
+			<feature name="part_id" value="Side A: Kidnapped + Celtic Carnage + Personal Computer Whirled"/>
+			<dataarea name="flop" size="194816">
+				<rom name="last of the big disks - kidnapped + celtic carnage + personal computer whirled (1993)(zenobi)(side a).dsk" size="194816" crc="9054eae2" sha1="a40ff8b4710c7d9854183a7bce222138336bcf72" offset="0" />
+			</dataarea>
+		</part>
+		<part name="flop2" interface="floppy_3">
+			<feature name="part_id" value="Side B: Microfair Madness + The Search for Smok"/>
+			<dataarea name="flop" size="194816">
+				<rom name="last of the big disks - microfair madness + the search for smok (1993)(zenobi)(side b).dsk" size="194816" crc="e1f5c23f" sha1="8d9ce5f5105e868a5615d8621f865a4433a2798a" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Compilations - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="leadboa3">
+		<description>Leader Board Par 3</description>
+		<year>1988</year>
+		<publisher>U.S. Gold</publisher>
+		<part name="flop1" interface="floppy_3">
+			<feature name="part_id" value="Side A: Leaderboard + Leaderboard Tournament"/>
+			<dataarea name="flop" size="194816">
+				<rom name="leader board par 3 - leaderboard + leaderboard tournament (1988)(u.s. gold)(disk 1 of 2).dsk" size="194816" crc="ce7bb0b9" sha1="146ad94cd850568ce94303f602b3cbb6ccbf16e6" offset="0" />
+			</dataarea>
+		</part>
+		<part name="flop2" interface="floppy_3">
+			<feature name="part_id" value="Disk 2, Side A: World Class Leaderboard"/>
+			<dataarea name="flop" size="194816">
+				<rom name="leader board par 3 - world class leaderboard (1988)(u.s. gold)(disk 2 of 2 side a).dsk" size="194816" crc="7796b0f6" sha1="428894e7cb23fb9702c0a3db0c7692ce3e7079e0" offset="0" />
+			</dataarea>
+		</part>
+		<part name="flop3" interface="floppy_3">
+			<feature name="part_id" value="Disk 2, Side B: World Class Leaderboard"/>
+			<dataarea name="flop" size="194816">
+				<rom name="leader board par 3 - world class leaderboard (1988)(u.s. gold)(disk 2 of 2 side b).dsk" size="194816" crc="b9ef96d2" sha1="903b9a18cecfdfe20413ee6c11edc18e14e920fa" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Compilations - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="liveammo">
+		<description>Live Ammo</description>
+		<year>1987</year>
+		<publisher>Ocean</publisher>
+		<part name="flop1" interface="floppy_3">
+			<feature name="part_id" value="Side A: Green Beret + Top Gun + Rambo"/>
+			<dataarea name="flop" size="194560">
+				<rom name="live ammo - green beret + top gun + rambo (1987)(ocean)(side a)[aka live action].dsk" size="194560" crc="f20462e2" sha1="246756c5264e80b907edb78333ecde2c3f2b0aca" offset="0" />
+			</dataarea>
+		</part>
+		<part name="flop2" interface="floppy_3">
+			<feature name="part_id" value="Side B: The Great Escape + Army Moves"/>
+			<dataarea name="flop" size="194560">
+				<rom name="live ammo - the great escape + army moves (1987)(ocean)(side b)[aka live action].dsk" size="194560" crc="09dac59c" sha1="aa79dd1cf0b013806403bd4be1e4879653a77d9f" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Compilations - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="liveammoa" cloneof="liveammo">
+		<description>Live Ammo - Green Beret + Top Gun + Rambo (alt)</description>
+		<year>1987</year>
+		<publisher>Ocean</publisher>
+		<part name="flop1" interface="floppy_3">
+			<feature name="part_id" value="Side A: Green Beret + Top Gun + Rambo"/>
+			<dataarea name="flop" size="194560">
+				<rom name="live ammo - green beret + top gun + rambo (1987)(ocean)(side a)[a][aka live action].dsk" size="194560" crc="3d3499d5" sha1="83fd130baf796cfdd318d46dfdf2f80c007166b8" offset="0" />
+			</dataarea>
+		</part>
+		<part name="flop2" interface="floppy_3">
+			<feature name="part_id" value="Side B: The Great Escape + Army Moves"/>
+			<dataarea name="flop" size="194560">
+				<rom name="live ammo - the great escape + army moves (1987)(ocean)(side b)[a][aka live action].dsk" size="194560" crc="438bc244" sha1="7b42af186c1a92af69d9622bfc136f9bf97ac09e" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Compilations - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="lomejdin">
+		<description>Lo Mejor de Dinamic</description>
+		<year>1988</year>
+		<publisher>Dinamic</publisher>
+		<part name="flop1" interface="floppy_3">
+			<feature name="part_id" value="Side A: Game Over + Freddy Hardest + Fernando Martin Basket Master"/>
+			<dataarea name="flop" size="209408">
+				<rom name="lo mejor de dinamic - game over + freddy hardest + fernando martin basket master (1988)(dinamic)(es)(side a).dsk" size="209408" crc="e09dc659" sha1="50a6deae79be0b167f631b3292cdccf335d9a60c" offset="0" />
+			</dataarea>
+		</part>
+		<part name="flop2" interface="floppy_3">
+			<feature name="part_id" value="Side B: Army Moves + Phantis + Turbo Girl"/>
+			<dataarea name="flop" size="204032">
+				<rom name="lo mejor de dinamic - army moves + phantis + turbo girl (1988)(dinamic)(es)(side b).dsk" size="204032" crc="0c247f68" sha1="7ba19c5aae87c90b5f256ac7b43d8bc30bbd19e6" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Compilations - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="loflaur1">
+		<description>Loads of Laurence Vol. 1</description>
+		<year>1996</year>
+		<publisher>Zenobi</publisher>
+		<part name="flop1" interface="floppy_3">
+			<feature name="part_id" value="Side A: There's a Bomb Under Parliament + The Mummy's Crypt"/>
+			<dataarea name="flop" size="194816">
+				<rom name="loads of laurence vol. 1 - there's a bomb under parliament + the mummy's crypt (1996)(zenobi)(side a).dsk" size="194816" crc="7c9ca040" sha1="9d95b6480e0f94519fff6f2d30a5a6ae6eaa7a7a" offset="0" />
+			</dataarea>
+		</part>
+		<part name="flop2" interface="floppy_3">
+			<feature name="part_id" value="Side B: Beyond El Dorado + The Bermuda Triangle + Impact"/>
+			<dataarea name="flop" size="194816">
+				<rom name="loads of laurence vol. 1 - beyond el dorado + the bermuda triangle + impact (1996)(zenobi)(side b).dsk" size="194816" crc="5c8c90d5" sha1="0ad23b937ec441268818f9b5529d1105de599a2d" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Compilations - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="loflaur2">
+		<description>Loads of Laurence Vol. 2</description>
+		<year>1996</year>
+		<publisher>Zenobi</publisher>
+		<part name="flop1" interface="floppy_3">
+			<feature name="part_id" value="Side A: The Golden Pyramid + Lost in Time + Meltdown"/>
+			<dataarea name="flop" size="194816">
+				<rom name="loads of laurence vol. 2 - the golden pyramid + lost in time + meltdown (1996)(zenobi)(side a).dsk" size="194816" crc="95bd5549" sha1="45849d538278b00c634b71c317fb54d6ce6496aa" offset="0" />
+			</dataarea>
+		</part>
+		<part name="flop2" interface="floppy_3">
+			<feature name="part_id" value="Side B: Flameout + The Well of Zol"/>
+			<dataarea name="flop" size="194816">
+				<rom name="loads of laurence vol. 2 - flameout + the well of zol (1996)(zenobi)(side b).dsk" size="194816" crc="5e88127c" sha1="56da25c5b55a4039c3cf48aceea2704cff76b7e7" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Compilations - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="magkntri">
+		<description>Magic Knight Trilogy</description>
+		<year>1988</year>
+		<publisher>Mastertronic</publisher>
+		<part name="flop1" interface="floppy_3">
+			<feature name="part_id" value="Side A: Finders Keepers + Spellbound"/>
+			<dataarea name="flop" size="194816">
+				<rom name="magic knight trilogy - finders keepers + spellbound (1988)(mastertronic)(side a).dsk" size="194816" crc="f1964316" sha1="b080d54460e7ca6c9fa7b9445245c3df95fd83cf" offset="0" />
+			</dataarea>
+		</part>
+		<part name="flop2" interface="floppy_3">
+			<feature name="part_id" value="Side B: Knight Tyme"/>
+			<dataarea name="flop" size="194816">
+				<rom name="magic knight trilogy - knight tyme (1988)(mastertronic)(side b).dsk" size="194816" crc="53b5b3ac" sha1="9c639201488a6736ad4c2a1b862acfab67ca0cd9" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Compilations - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="magnsevn">
+		<description>The Magnificent Seven</description>
+		<year>1987</year>
+		<publisher>Ocean</publisher>
+		<part name="flop1" interface="floppy_3">
+			<feature name="part_id" value="Side A: Wizball + Arkanoid + Yie Ar Kung-Fu + Short Circuit"/>
+			<dataarea name="flop" size="215291">
+				<rom name="magnificent seven, the (1987)(ocean)(side a)[aka magnificent 7, the].dsk" size="215291" crc="f5ca67aa" sha1="327cc32f56285c0ae863178af05637c081c782b3" offset="0" />
+			</dataarea>
+		</part>
+		<part name="flop2" interface="floppy_3">
+			<feature name="part_id" value="Side B: Frankie Goes to Hollywood + Head over Heels + The Great Escape + Cobra"/>
+			<dataarea name="flop" size="215291">
+				<rom name="magnificent seven, the (1987)(ocean)(side b)[aka magnificent 7, the].dsk" size="215291" crc="db67ff77" sha1="3d2a91462691614a02e09695ab0c4f283cbb31ce" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Compilations - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="mastrcd4">
+		<description>Mastertronic +3 Compilation Disk 4</description>
+		<year>19??</year>
+		<publisher>Mastertronic</publisher>
+		<part name="flop1" interface="floppy_3">
+			<feature name="part_id" value="Side A: Angleball + Kikstart 2 + Knight Tyme + Stormbringer"/>
+			<dataarea name="flop" size="194816">
+				<rom name="mastertronic +3 compilation disk 4 - angleball + kikstart 2 + knight tyme + stormbringer (19xx)(mastertronic)(side a).dsk" size="194816" crc="ded9efb7" sha1="7ee82cbfc69d7f86561eba6cc1c0d705340995eb" offset="0" />
+			</dataarea>
+		</part>
+		<part name="flop2" interface="floppy_3">
+			<feature name="part_id" value="Side B: Amaurote + The Curse of Sherwood + Milk Race + Speed King 2"/>
+			<dataarea name="flop" size="194816">
+				<rom name="mastertronic +3 compilation disk 4 - amaurote + the curse of sherwood + milk race + speed king 2 (19xx)(mastertronic)(side b).dsk" size="194816" crc="d5f7d3fb" sha1="862e454932feb9072a8f6dbb1f13761d3135b4d1" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Compilations - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="mega4">
+		<description>Mega 4</description>
+		<year>1991</year>
+		<publisher>Topo Soft</publisher>
+		<part name="flop1" interface="floppy_3">
+			<feature name="part_id" value="Disk 1, Side A: Gremlins 2"/>
+			<dataarea name="flop" size="194816">
+				<rom name="mega 4 (1991)(topo soft)(es)(disk 1 of 2 side a).dsk" size="194816" crc="13c2370e" sha1="8188fee3a09fba1cf6323dc8868990a71679b19a" offset="0" />
+			</dataarea>
+		</part>
+		<part name="flop2" interface="floppy_3">
+			<feature name="part_id" value="Disk 1, Side B: Lorna"/>
+			<dataarea name="flop" size="194816">
+				<rom name="mega 4 (1991)(topo soft)(es)(disk 1 of 2 side b).dsk" size="194816" crc="621f53be" sha1="857d0f6d468b5a719379d737899e061c4a9773bc" offset="0" />
+			</dataarea>
+		</part>
+		<part name="flop3" interface="floppy_3">
+			<feature name="part_id" value="Disk 2, Side A: Zona 0"/>
+			<dataarea name="flop" size="97536">
+				<rom name="mega 4 (1991)(topo soft)(es)(disk 2 of 2 side a).dsk" size="97536" crc="3e04c21b" sha1="9b6fab5fbc5c92ecd615061fbde7d29122a98d85" offset="0" />
+			</dataarea>
+		</part>
+		<part name="flop4" interface="floppy_3">
+			<feature name="part_id" value="Disk 2, Side B: La Espada Sagrada"/>
+			<dataarea name="flop" size="121856">
+				<rom name="mega 4 (1991)(topo soft)(es)(disk 2 of 2 side b).dsk" size="121856" crc="586fb225" sha1="063b2857c8330c0fb959871cc6452aaf7c9d13b4" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Compilations - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="megabox">
+		<description>Mega Box</description>
+		<year>1991</year>
+		<publisher>Dinamic</publisher>
+		<part name="flop1" interface="floppy_3">
+			<feature name="part_id" value="Disk 1, Side A: Narco Police"/>
+			<dataarea name="flop" size="131584">
+				<rom name="mega box - narco police (1991)(dinamic)(es)(en)(side a).dsk" size="131584" crc="4fc97365" sha1="cdb281bcfb2e7889bbf618c3c62c87eb297a034c" offset="0" />
+			</dataarea>
+		</part>
+		<part name="flop2" interface="floppy_3">
+			<feature name="part_id" value="Disk 1, Side B: After the War + Navy Moves"/>
+			<dataarea name="flop" size="214784">
+				<rom name="mega box - after the war + navy moves (1991)(dinamic)(es)(en)(side b).dsk" size="214784" crc="07764790" sha1="1bcb904cb152cb1d20f0aed7e5b7a231d2ba8f56" offset="0" />
+			</dataarea>
+		</part>
+		<part name="flop3" interface="floppy_3">
+			<feature name="part_id" value="Disk 2, Side A: Satan + Astro Marine Corps"/>
+			<dataarea name="flop" size="214784">
+				<rom name="mega box - satan + astro marine corps (1991)(dinamic)(es)(side a).dsk" size="214784" crc="ee89887d" sha1="6f496382613dbebfd3f039cbe065ce90a806d4ac" offset="0" />
+			</dataarea>
+		</part>
+<!-- Disk 2 Side B seems to contain an unreadable copy of Disk 2 Side A. Needs investigation. -->
+		<part name="flop4" interface="floppy_3">
+			<feature name="part_id" value="Disk 2, Side B: Satan + Astro Marine Corps"/>
+			<dataarea name="flop" size="212736">
+				<rom name="mega box - satan + astro marine corps (1991)(dinamic)(es)(en)(side b).dsk" size="212736" crc="28a2d57c" sha1="96585c649730dc6434bd3c766b9e68212da0c3c1" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Compilations - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="metalact">
+		<description>Metal Action</description>
+		<year>1990</year>
+		<publisher>Dinamic</publisher>
+		<part name="flop1" interface="floppy_3">
+			<feature name="part_id" value="Side A: After the War + La Aventura Original + Satan I"/>
+			<dataarea name="flop" size="214784">
+				<rom name="metal action - after the war + la aventura original + satan i (1990)(dinamic)(es)(side a).dsk" size="214784" crc="a4816646" sha1="0ba180abcc0f621fa68a722d0d188b7419ed8a9f" offset="0" />
+			</dataarea>
+		</part>
+		<part name="flop2" interface="floppy_3">
+			<feature name="part_id" value="Side B: Astro Marine Corps + Freddy Hardest in South Manhattan + Satan II"/>
+			<dataarea name="flop" size="198656">
+				<rom name="metal action - astro marine corps + freddy hardest in south manhattan + satan ii (1990)(dinamic)(es)(side b).dsk" size="198656" crc="746623a9" sha1="6ed5887945c1a642f0aef96d3902210026a8104e" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Compilations - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="micbyte1">
+		<description>MicroByte - Serie Clasicos Spectrum 01</description>
+		<year>19??</year>
+		<publisher>&lt;homebrew&gt;</publisher>
+		<info name="author" value="Miguel"/>
+		<part name="flop1" interface="floppy_3">
+			<dataarea name="flop" size="194816">
+				<rom name="microbyte - serie clasicos spectrum 01 (19xx)(miguel)(es).dsk" size="194816" crc="4ab75f4d" sha1="953eed11249c00d7696e2db3b180096b735dceb1" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Compilations - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="micbyte2">
+		<description>MicroByte - Serie Clasicos Spectrum 02</description>
+		<year>19??</year>
+		<publisher>&lt;homebrew&gt;</publisher>
+		<info name="author" value="Miguel"/>
+		<part name="flop1" interface="floppy_3">
+			<dataarea name="flop" size="194816">
+				<rom name="microbyte - serie clasicos spectrum 02 (19xx)(miguel)(es).dsk" size="194816" crc="c1553807" sha1="8843a77e66ff399ff5900f5bc64dd597af3dab72" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Compilations - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="micfmadp">
+		<description>Microfair Madness Plus</description>
+		<year>1991</year>
+		<publisher>Zenobi</publisher>
+		<part name="flop1" interface="floppy_3">
+			<feature name="part_id" value="Side A"/>
+			<dataarea name="flop" size="194816">
+				<rom name="microfair madness plus - desmond and gertrude + microfair madness + the search for smok (1991)(zenobi).dsk" size="194816" crc="4b9fd5ad" sha1="dd0ec9b23350e5b32f50d074f0e386bd68b5e765" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Compilations - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="mvalue6p">
+		<description>Microvalue 6 Pack</description>
+		<year>1987</year>
+		<publisher>Tynesoft</publisher>
+		<part name="flop1" interface="floppy_3">
+			<feature name="part_id" value="Side A: Colin the Cleaner + Mutations + Ian Botham's Test Match"/>
+			<dataarea name="flop" size="194816">
+				<rom name="microvalue 6 pack - colin the cleaner + mutations + ian botham's test match (1987)(tynesoft)(side a).dsk" size="194816" crc="1273d5d2" sha1="ad7fc5d1ea26131b5cb209b256c53ae9036fbdfb" offset="0" />
+			</dataarea>
+		</part>
+		<part name="flop2" interface="floppy_3">
+			<feature name="part_id" value="Side B: Pyjamarama + Big Bad John + Automania"/>
+			<dataarea name="flop" size="194816">
+				<rom name="microvalue 6 pack - pyjamarama + big bad john + automania (1987)(tynesoft)(side b).dsk" size="194816" crc="4e478bb2" sha1="55b49d95a739889bb20e7fd0f0733a5a0283e559" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Compilations - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="mindstre">
+		<description>Mind-Stretchers</description>
+		<year>1990</year>
+		<publisher>Virgin Mastertronic</publisher>
+		<part name="flop1" interface="floppy_3">
+			<dataarea name="flop" size="165376">
+				<rom name="mind-stretchers (1990)(virgin mastertronic).dsk" size="165376" crc="9d54d0a4" sha1="45d1239a649777556ca4833cb2c195a5104d4a6a" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Compilations - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="mond2014">
+		<description>Monty Designs 2014</description>
+		<year>2014</year>
+		<publisher>PixelSoftware</publisher>
+		<part name="flop1" interface="floppy_3">
+			<dataarea name="flop" size="194816">
+				<rom name="monty designs 2014 - androide + genehtik + bluber (2014)(pixelsoftware).dsk" size="194816" crc="0f487f70" sha1="ec84a660b9535a91ae5201e11c638c24ad31a53b" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Compilations - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="multispo">
+		<description>Multi Sports</description>
+		<year>1991</year>
+		<publisher>Dinamic</publisher>
+		<part name="flop1" interface="floppy_3">
+			<feature name="part_id" value="Side A: Basket Master + Aspar GP Master + Simulador Profesional de Tenis"/>
+			<dataarea name="flop" size="144896">
+				<rom name="multi sports (1991)(dinamic)(es)(en)(side a).dsk" size="144896" crc="882d9c98" sha1="91c6c6976cf7e583b9fb13207cd334bbd383fea5" offset="0" />
+			</dataarea>
+		</part>
+		<part name="flop2" interface="floppy_3">
+			<feature name="part_id" value="Side B: Michel Futbol Master + Michel Super Skills + Choy-Lee-Fut Kung-Fu Warrior"/>
+			<dataarea name="flop" size="144896">
+				<rom name="multi sports (1991)(dinamic)(es)(en)(side b).dsk" size="144896" crc="916b49ac" sha1="d6e71b8e68931c72d85568f36bc64200524996c0" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Compilations - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="nopehiao">
+		<description>Nope Here's Another One</description>
+		<year>1993</year>
+		<publisher>Zenobi</publisher>
+		<part name="flop1" interface="floppy_3">
+			<feature name="part_id" value="Side A: Diarmid I + For Pete's Sake"/>
+			<dataarea name="flop" size="194816">
+				<rom name="nope here's another one - diarmid i + for pete's sake (1993)(zenobi)(side a).dsk" size="194816" crc="342d58d2" sha1="b7c2a37498809be13e0d58a9463080d2436ade3b" offset="0" />
+			</dataarea>
+		</part>
+		<part name="flop2" interface="floppy_3">
+			<feature name="part_id" value="Side B: Diarmid II + The Krazy Kartoonist Kaper"/>
+			<dataarea name="flop" size="194816">
+				<rom name="nope here's another one - diarmid ii + the krazy kartoonist kaper (1993)(zenobi)(side b).dsk" size="194816" crc="5804ef65" sha1="b8be1f38c41493df3622d1ef5627f4c9fe7e0cb9" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Compilations - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="notanobd">
+		<description>Not Another Big Disk</description>
+		<year>1992</year>
+		<publisher>Zenobi</publisher>
+		<part name="flop1" interface="floppy_3">
+			<feature name="part_id" value="Side A: The Fisher King + Darkest Road II - 'Twas a Time of Dread"/>
+			<dataarea name="flop" size="194816">
+				<rom name="not another big disk - the fisher king + darkest road ii - 'twas a time of dread (1992)(zenobi)(side a).dsk" size="194816" crc="d51a0966" sha1="06480040fb39f7f48f58ade714017f63d458057a" offset="0" />
+			</dataarea>
+		</part>
+		<part name="flop2" interface="floppy_3">
+			<feature name="part_id" value="Side B: Treasure Island + Arnold the Adventurer II"/>
+			<dataarea name="flop" size="194816">
+				<rom name="not another big disk - treasure island + arnold the adventurer ii (1992)(zenobi)(side b).dsk" size="194816" crc="deb41208" sha1="9a4a2e6e977961bf9514616bf3005d177c8c893d" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Compilations - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="ohshiabd">
+		<description>Oh Sh1t Another Big Disk</description>
+		<year>1993</year>
+		<publisher>Zenobi</publisher>
+		<part name="flop1" interface="floppy_3">
+			<feature name="part_id" value="Side A: Project Nova + Arnold the Adventurer III"/>
+			<dataarea name="flop" size="194816">
+				<rom name="oh sh1t another big disk - project nova + arnold the adventurer iii (1993)(zenobi)(side a).dsk" size="194816" crc="5ec6066b" sha1="56f1bceab442a54b1e06dea2830f057de66c0e6e" offset="0" />
+			</dataarea>
+		</part>
+		<part name="flop2" interface="floppy_3">
+			<feature name="part_id" value="Side B: The Beginning of the End + The Escaping Habit"/>
+			<dataarea name="flop" size="194816">
+				<rom name="oh sh1t another big disk - the beginning of the end + the escaping habit (1993)(zenobi)(side b).dsk" size="194816" crc="df3103e8" sha1="a57f6399d1c0b1b5addf2f701f08158ad1c4679a" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Compilations - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="onemorbd">
+		<description>One More Big Disk</description>
+		<year>1992</year>
+		<publisher>Zenobi</publisher>
+		<part name="flop1" interface="floppy_3">
+			<feature name="part_id" value="Side A: The Violator of Voodoo + The Amulet of Darath + The Taxman Cometh"/>
+			<dataarea name="flop" size="194816">
+				<rom name="one more big disk - the violator of voodoo + the amulet of darath + the taxman cometh (1992)(zenobi)(side a).dsk" size="194816" crc="996dd6e0" sha1="e2e4fd9e90538c44471c96c1ca583d6b7af1333a" offset="0" />
+			</dataarea>
+		</part>
+		<part name="flop2" interface="floppy_3">
+			<feature name="part_id" value="Side B: Jester's Jaunt"/>
+			<dataarea name="flop" size="194816">
+				<rom name="one more big disk - jester's jaunt (1992)(zenobi)(side b).dsk" size="194816" crc="a496001a" sha1="15faf116f3ca52dc97b9328edd6009e7af479d9e" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Compilations - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+<!-- Both sides contain the same games, dumps are only slightly different by the end -->
+	<software name="operast1">
+		<description>Opera Storys 1</description>
+		<year>1989</year>
+		<publisher>Opera Soft</publisher>
+		<part name="flop1" interface="floppy_3">
+			<feature name="part_id" value="Side A"/>
+			<dataarea name="flop" size="216064">
+				<rom name="opera storys 1 (1989)(opera soft)(es)(side a).dsk" size="216064" crc="7a89187f" sha1="9e017d666630e69509aa7ab03815eab2e1502d32" offset="0" />
+			</dataarea>
+		</part>
+		<part name="flop2" interface="floppy_3">
+			<feature name="part_id" value="Side B"/>
+			<dataarea name="flop" size="216064">
+				<rom name="opera storys 1 (1989)(opera soft)(es)(side b).dsk" size="216064" crc="b11259cc" sha1="7281fa2272fc5700b895ee29686fd7149e1aba6f" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Compilations - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="operassp">
+		<description>Opera Super Sports</description>
+		<year>19??</year>
+		<publisher>Opera Soft</publisher>
+		<part name="flop1" interface="floppy_3">
+			<feature name="part_id" value="Side A: Mundial de Futbol + Golden Basket (loader) + Poli Diaz + Jai Alai"/>
+			<dataarea name="flop" size="214784">
+				<rom name="opera super sports (19xx)(opera soft)(es)(side a).dsk" size="214784" crc="eb287d3f" sha1="aebe8ec2ee88e4aa664d63284e5fa98a66e9d177" offset="0" />
+			</dataarea>
+		</part>
+		<part name="flop2" interface="floppy_3">
+			<feature name="part_id" value="Side B: Angel Nieto Pole 5002 + Golden Basket (data)"/>
+			<dataarea name="flop" size="214784">
+				<rom name="opera super sports (19xx)(opera soft)(es)(side b).dsk" size="214784" crc="eacde44f" sha1="c2e9d1799a793f2de39228175f14aa55fb3f61ac" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Compilations - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="pawsft1">
+		<description>PAWS for Thought Vol 1</description>
+		<year>1992</year>
+		<publisher>The Guild</publisher>
+		<part name="flop1" interface="floppy_3">
+			<feature name="part_id" value="Side A: Corya + Alstrad"/>
+			<dataarea name="flop" size="195635">
+				<rom name="paws for thought vol 1 (1992)(guild, the)(side a).dsk" size="195635" crc="361231f8" sha1="d3d61af659680843920ad342288c0408549a19b4" offset="0" />
+			</dataarea>
+		</part>
+		<part name="flop2" interface="floppy_3">
+			<feature name="part_id" value="Side B: The Last Believer + Dungeon of Torgar"/>
+			<dataarea name="flop" size="195635">
+				<rom name="paws for thought vol 1 (1992)(guild, the)(side b).dsk" size="195635" crc="6c2c4196" sha1="a8efbc00354b08fe8f1ebe44b1ba972f1ea6983d" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Compilations - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="pawsft2">
+		<description>PAWS for Thought Vol 2</description>
+		<year>1992</year>
+		<publisher>The Guild</publisher>
+		<part name="flop1" interface="floppy_3">
+			<feature name="part_id" value="Side A: Deathbringer + Arlene"/>
+			<dataarea name="flop" size="195635">
+				<rom name="paws for thought vol 2 (1992)(guild, the)(side a).dsk" size="195635" crc="9d90f497" sha1="16b1425b020746176ef6e08d8e40c60984bc36f2" offset="0" />
+			</dataarea>
+		</part>
+		<part name="flop2" interface="floppy_3">
+			<feature name="part_id" value="Side B: Teacher Trouble + The Calling"/>
+			<dataarea name="flop" size="195635">
+				<rom name="paws for thought vol 2 (1992)(guild, the)(side b).dsk" size="195635" crc="f90a2db5" sha1="fd2dcfc0ab5562f44de5c7345691f5c295760aa9" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Compilations - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="pawsft3">
+		<description>PAWS for Thought Vol 3</description>
+		<year>1992</year>
+		<publisher>The Guild</publisher>
+		<part name="flop1" interface="floppy_3">
+			<feature name="part_id" value="Side A: Homicide Hotel + Theseus"/>
+			<dataarea name="flop" size="195635">
+				<rom name="paws for thought vol 3 (1992)(guild, the)(side a).dsk" size="195635" crc="c7dfcdcc" sha1="a433d4e42cc6909e15ac5547e4cdbbae1458d934" offset="0" />
+			</dataarea>
+		</part>
+		<part name="flop2" interface="floppy_3">
+			<feature name="part_id" value="Side B: The Island + Holiday"/>
+			<dataarea name="flop" size="195635">
+				<rom name="paws for thought vol 3 (1992)(guild, the)(side b).dsk" size="195635" crc="71642671" sha1="43289904235edca1c2684a09a5bebe5ff5d86c39" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Compilations - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="pdtape02">
+		<description>PD Tape 02 - +3 Utilities</description>
+		<year>1990</year>
+		<publisher>B.G. Services</publisher>
+		<info name="usage" value="Side B requires Locomotive CP/M+" />
+		<part name="flop1" interface="floppy_3">
+			<feature name="part_id" value="Side A: PLUS 3 DOS files"/>
+			<dataarea name="flop" size="194816">
+				<rom name="pd tape 02 - +3 utilities (1990)(b.g. services)(disk 2 of 2 side a).dsk" size="194816" crc="86251c16" sha1="a0b48e8d1928fb1d0899324bf47f9be72fb7bf63" offset="0" />
+			</dataarea>
+		</part>
+		<part name="flop2" interface="floppy_3">
+			<feature name="part_id" value="Side B: CP/M+ Files"/>
+			<dataarea name="flop" size="194816">
+				<rom name="pd tape 02 - +3 utilities (1990)(b.g. services)(disk 2 of 2 side b).dsk" size="194816" crc="867839c6" sha1="3f037b776102b492bf9c265381c75bbfc70aca35" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Compilations - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="packferp">
+		<description>Pack Ferpecto</description>
+		<year>2005</year>
+		<publisher>Compiler</publisher>
+		<part name="flop1" interface="floppy_3">
+			<dataarea name="flop" size="194816">
+				<rom name="pack ferpecto (2005)(compiler)(es).dsk" size="194816" crc="749e3227" sha1="d884a32faa1d1675add8a130137a51fe34a81705" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Compilations - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="packrsp3">
+		<description>Pack Regalo Sinclair +3</description>
+		<year>1988</year>
+		<publisher>Dinamic</publisher>
+		<part name="flop1" interface="floppy_3">
+			<feature name="part_id" value="Side A: Game Over + Phantomas 1 + Phantomas 2"/>
+			<dataarea name="flop" size="187904">
+				<rom name="pack regalo sinclair +3 - game over + phantomas 1 + phantomas 2 (1988)(dinamic)(es)(side a).dsk" size="187904" crc="9c6d116f" sha1="a3d239bbfbb69c8dceb4e243a8a460e726337efc" offset="0" />
+			</dataarea>
+		</part>
+		<part name="flop2" interface="floppy_3">
+			<feature name="part_id" value="Side B: Army Moves + Camelot Warriors + Nonamed"/>
+			<dataarea name="flop" size="171776">
+				<rom name="pack regalo sinclair +3 - army moves + camelot warriors + nonamed (1988)(dinamic)(es)(side b).dsk" size="171776" crc="a675fb82" sha1="a5c2bf0df0f4148e53c134c0a2c85f60fb715f3f" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Compilations - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="packrsp3a" cloneof="packrsp3">
+		<description>Pack Regalo Sinclair +3 (alt)</description>
+		<year>1988</year>
+		<publisher>Dinamic</publisher>
+		<part name="flop1" interface="floppy_3">
+			<feature name="part_id" value="Side A: Game Over + Phantomas 1 + Phantomas 2"/>
+			<dataarea name="flop" size="187904">
+				<rom name="pack regalo sinclair +3 - game over + phantomas 1 + phantomas 2 (1988)(dinamic)(es).dsk" size="187904" crc="81631cfc" sha1="f92ba195c4a203d72238345f4e65af0b413a9415" offset="0" />
+			</dataarea>
+		</part>
+		<part name="flop2" interface="floppy_3">
+			<feature name="part_id" value="Side B: Army Moves + Camelot Warriors + Nonamed"/>
+			<dataarea name="flop" size="171776">
+				<rom name="pack regalo sinclair +3 - army moves + camelot warriors + nonamed (1988)(dinamic)(es).dsk" size="171776" crc="ae1ed918" sha1="88f81d0239badb23d3cd4349e7696cbae6005cea" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Compilations - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="pwmer1com">
+		<description>Paul Woakes' Mercenary 1 Compendium</description>
+		<year>1988</year>
+		<publisher>Novagen</publisher>
+		<part name="flop1" interface="floppy_3">
+			<dataarea name="flop" size="216315">
+				<rom name="paul woakes' mercenary 1 compendium (1988)(novagen).dsk" size="216315" crc="2daacafe" sha1="064076b6a8675b75104c7510f98601f49633feec" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Compilations - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="picknmix">
+		<description>Pick'n'Mix</description>
+		<year>1991</year>
+		<publisher>The Adventure Workshop</publisher>
+		<part name="flop1" interface="floppy_3">
+			<feature name="part_id" value="Side A: The Base + Dungeon of Torgar"/>
+			<dataarea name="flop" size="195635">
+				<rom name="pick'n'mix (1991)(adventure workshop, the)(side a).dsk" size="195635" crc="79b92a8d" sha1="7ac9fe89f40750d7709c474b42daeb5a923b4ca8" offset="0" />
+			</dataarea>
+		</part>
+		<part name="flop2" interface="floppy_3">
+			<feature name="part_id" value="Side B: The Calling + Holiday to Remember"/>
+			<dataarea name="flop" size="195635">
+				<rom name="pick'n'mix (1991)(adventure workshop, the)(side b).dsk" size="195635" crc="ba2e4d61" sha1="5ee01291528bdcc2e26a1c8defc96a3234533bba" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Compilations - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="pirat3p3">
+		<description>Pirate 3 +3</description>
+		<year>1987</year>
+		<publisher>Pirate</publisher>
+		<part name="flop1" interface="floppy_3">
+			<dataarea name="flop" size="194816">
+				<rom name="pirate 3 +3 - smash out + call me psycho + holiday in sumaria (1987)(pirate).dsk" size="194816" crc="c9c2142f" sha1="9ae3faaa820eceb282dde70c7a22117747a1c36b" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Compilations - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="plus3adv">
+		<description>Plus 3 Adventures</description>
+		<year>1988</year>
+		<publisher>Mastertronic</publisher>
+		<part name="flop1" interface="floppy_3">
+			<feature name="part_id" value="Side A: Kobyashi Naru + Shard of Inovar"/>
+			<dataarea name="flop" size="199936">
+				<rom name="plus 3 adventures - kobyashi naru + shard of inovar (1988)(mastertronic)(side a).dsk" size="199936" crc="6612191f" sha1="f56779d29f6fbb238f1bd69b685c8ea13a5730e8" offset="0" />
+			</dataarea>
+		</part>
+		<part name="flop2" interface="floppy_3">
+			<feature name="part_id" value="Side B: Venom"/>
+			<dataarea name="flop" size="199936">
+				<rom name="plus 3 adventures - venom (1988)(mastertronic)(side b).dsk" size="199936" crc="49f53b53" sha1="ea5bebbebaf165c58f0d378907a54526d3b6bf39" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Compilations - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="plus3arc">
+		<description>Plus 3 Arcade</description>
+		<year>1987</year>
+		<publisher>Mastertronic</publisher>
+		<part name="flop1" interface="floppy_3">
+			<feature name="part_id" value="Side A: Motos + Angleball"/>
+			<dataarea name="flop" size="194816">
+				<rom name="plus 3 arcade - motos + angleball (1987)(mastertronic)(side a).dsk" size="194816" crc="50f0bfdc" sha1="2be49f0b518cd990a13131d17700a875597b01ea" offset="0" />
+			</dataarea>
+		</part>
+		<part name="flop2" interface="floppy_3">
+			<feature name="part_id" value="Side B: Bosconian '87"/>
+			<dataarea name="flop" size="194816">
+				<rom name="plus 3 arcade - bosconian '87 (1987)(mastertronic)(side b).dsk" size="194816" crc="d1152f1f" sha1="9cb5b8dde020cf2a105be79ed24c4c50f143d9f1" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Compilations - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="plus3bik">
+		<description>Plus 3 Biker</description>
+		<year>1987</year>
+		<publisher>Mastertronic</publisher>
+		<part name="flop1" interface="floppy_3">
+			<feature name="part_id" value="Side A: Action Biker + Milk Race"/>
+			<dataarea name="flop" size="194816">
+				<rom name="plus 3 biker - action biker + milk race (1987)(mastertronic)(side a).dsk" size="194816" crc="d0a57894" sha1="38ca1b5653aa42dbb31cd38ae8a333fabb35b34f" offset="0" />
+			</dataarea>
+		</part>
+		<part name="flop2" interface="floppy_3">
+			<feature name="part_id" value="Side B: Kikstart 2"/>
+			<dataarea name="flop" size="194816">
+				<rom name="plus 3 biker - kikstart 2 (1987)(mastertronic)(side b).dsk" size="194816" crc="020d9c6a" sha1="6c9ed10a84c94bafc2cf543045deb0d9bba66d6d" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Compilations - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="plus3hit">
+		<description>Plus 3 Hits</description>
+		<year>1987</year>
+		<publisher>Mastertronic</publisher>
+		<part name="flop1" interface="floppy_3">
+			<feature name="part_id" value="Side A: Amaurote + Hyperbowl"/>
+			<dataarea name="flop" size="194816">
+				<rom name="plus 3 hits - amaurote + hyperbowl (1987)(mastertronic)(side a).dsk" size="194816" crc="3167db93" sha1="88c9e14e4e25530eae7072fbaa0bcfc550e4ab8d" offset="0" />
+			</dataarea>
+		</part>
+		<part name="flop2" interface="floppy_3">
+			<feature name="part_id" value="Side B: Feud"/>
+			<dataarea name="flop" size="194816">
+				<rom name="plus 3 hits - feud (1987)(mastertronic)(side b).dsk" size="194816" crc="985ff5d6" sha1="d19770ab6ce95e66cb81fcd6010ab009dd61cf69" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Compilations - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="plus3pac">
+		<description>Plus 3 Pack</description>
+		<year>1987</year>
+		<publisher>Gremlin Graphics</publisher>
+		<part name="flop1" interface="floppy_3">
+			<feature name="part_id" value="Side A: Krakout + Future Knight"/>
+			<dataarea name="flop" size="174848">
+				<rom name="plus 3 pack - krakout + future knight (1987)(gremlin graphics)(side a).dsk" size="174848" crc="7ef38f33" sha1="cf62819033a9950c6b6a11c3e8c912de09e8045f" offset="0" />
+			</dataarea>
+		</part>
+		<part name="flop2" interface="floppy_3">
+			<feature name="part_id" value="Side B: Bounder + Thing Bounces Back"/>
+			<dataarea name="flop" size="174848">
+				<rom name="plus 3 pack - bounder + thing bounces back (1987)(gremlin graphics)(side b).dsk" size="174848" crc="e94a2db9" sha1="3deeae0c924d2c39ce4b91a9b6d2ab0a85903fad" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Compilations - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="plus3pac">
+		<description>Plus 3 Pack (Dinamic)</description>
+		<year>1988</year>
+		<publisher>Dinamic</publisher>
+		<part name="flop1" interface="floppy_3">
+			<feature name="part_id" value="Side A: Game Over + Fernando Martin Basket Master"/>
+			<dataarea name="flop" size="144384">
+				<rom name="plus 3 pack (1988)(dinamic)(es)(side a).dsk" size="144384" crc="895d2e1c" sha1="ce2fcfe0f9cc72a22025fb7a979fec5695fea506" offset="0" />
+			</dataarea>
+		</part>
+		<part name="flop2" interface="floppy_3">
+			<feature name="part_id" value="Side B: Army Moves + Don Quijote"/>
+			<dataarea name="flop" size="174848">
+				<rom name="plus 3 pack (1988)(dinamic)(es)(en)(side b).dsk" size="174848" crc="827bed18" sha1="679fe04d41185da84b586f9a3b9a1a2526b84827" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Compilations - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="plus3spo">
+		<description>Plus 3 Sports</description>
+		<year>1987</year>
+		<publisher>Mastertronic</publisher>
+		<part name="flop1" interface="floppy_3">
+			<feature name="part_id" value="Side A: Strike + Bump, Set, Spike!"/>
+			<dataarea name="flop" size="194816">
+				<rom name="plus 3 sports - strike (1987)(mastertronic)(side a).dsk" size="194816" crc="3ca3f142" sha1="dfaf7bb837087a04b993fa83a45471177e91be4f" offset="0" />
+			</dataarea>
+		</part>
+		<part name="flop1" interface="floppy_3">
+			<feature name="part_id" value="Side B: Speed King 2"/>
+			<dataarea name="flop" size="194816">
+				<rom name="plus 3 sports - speed king 2 (1987)(mastertronic)(side b).dsk" size="194816" crc="2519315e" sha1="ae1f1e21969fec88305fc9200eae5b288d711739" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Compilations - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="plus3spoa" cloneof="plus3spo">
+		<description>Plus 3 Sports (alt)</description>
+		<year>1987</year>
+		<publisher>Mastertronic</publisher>
+		<part name="flop2" interface="floppy_3">
+			<feature name="part_id" value="Side A: Strike + Bump, Set, Spike!"/>
+			<dataarea name="flop" size="194816">
+				<rom name="plus 3 sports - strike (1987)(mastertronic).dsk" size="194816" crc="00518e1e" sha1="0e4e653ac7408039aeb711ecb08518504c9d6bb9" offset="0" />
+			</dataarea>
+		</part>
+		<part name="flop1" interface="floppy_3">
+			<feature name="part_id" value="Side B: Speed King 2"/>
+			<dataarea name="flop" size="194816">
+				<rom name="plus 3 sports - speed king 2 (1987)(mastertronic).dsk" size="194816" crc="19eb4e02" sha1="8c9b17e2456f262e3b1e8a4a8ac26aaca5d5a6eb" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Compilations - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="powerspo">
+		<description>Powersports</description>
+		<year>1991</year>
+		<publisher>Zigurat</publisher>
+		<part name="flop1" interface="floppy_3">
+			<feature name="part_id" value="Side A: Carlos Sainz + Paris-Dakar"/>
+			<dataarea name="flop" size="194816">
+				<rom name="powersports - carlos sainz + paris-dakar (1991)(zigurat)(es)(side a).dsk" size="194816" crc="b8fb3307" sha1="1ac6ff52fdd5d0901d0a7ec191e2c60f82a91bea" offset="0" />
+			</dataarea>
+		</part>
+		<part name="flop2" interface="floppy_3">
+			<feature name="part_id" value="Side B: Sito Pons 500cc Grand Prix + Emilio Sanchez Vicario Grand Slam"/>
+			<dataarea name="flop" size="121856">
+				<rom name="powersports - sito pons 500cc grand prix + emilio sanchez vicario grand slam (1991)(zigurat)(es)(side b).dsk" size="121856" crc="e0771590" sha1="27f0a8abab611c6878487c426a4368ae9afdf9ca" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Compilations - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="probtlbd">
+		<description>Probably the Last Big Disk</description>
+		<year>1995</year>
+		<publisher>Zenobi</publisher>
+		<part name="flop1" interface="floppy_3">
+			<feature name="part_id" value="Side A: Perseus + The Final Demand"/>
+			<dataarea name="flop" size="194816">
+				<rom name="probably the last big disk - perseus + the final demand (1995)(zenobi)(side b).dsk" size="194816" crc="262d29dc" sha1="e50a166d1e20c6467043617d04f5dfd02619b11d" offset="0" />
+			</dataarea>
+		</part>
+		<part name="flop2" interface="floppy_3">
+			<feature name="part_id" value="Side B: The Apprentice + Theme Park U.S.A."/>
+			<dataarea name="flop" size="194816">
+				<rom name="probably the last big disk - the apprentice + theme park u.s.a. (1995)(zenobi)(side a).dsk" size="194816" crc="e680e164" sha1="cd569d82b45a39aaabf19fe23334240f103d4005" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Compilations - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="prjnbote">
+		<description>Project Nova + Beginning of the End</description>
+		<year>19??</year>
+		<publisher>Zenobi</publisher>
+		<part name="flop1" interface="floppy_3">
+			<feature name="part_id" value="Side A: Project Nova"/>
+			<dataarea name="flop" size="194816">
+				<rom name="project nova + beginning of the end (19xx)(zenobi)(side a).dsk" size="194816" crc="e0c08b0c" sha1="97a6120b38d307cd7eb36ff1dbb117654aef300e" offset="0" />
+			</dataarea>
+		</part>
+		<part name="flop2" interface="floppy_3">
+			<feature name="part_id" value="Side B: Beginning of the End"/>
+			<dataarea name="flop" size="194816">
+				<rom name="project nova + beginning of the end (19xx)(zenobi)(side b).dsk" size="194816" crc="2b0923c7" sha1="e23ff51da1ad4901af6dcaa5050910dd0d56c4d5" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Compilations - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="readrap2">
+		<description>Read-Right-Away: Reading Pack 2</description>
+		<year>1987</year>
+		<publisher>H.S.</publisher>
+		<part name="flop1" interface="floppy_3">
+			<dataarea name="flop" size="194816">
+				<rom name="read-right-away - reading pack 2 (1987)(h.s.).dsk" size="194816" crc="94d5b7f0" sha1="238845d4cf14b7ffea27831993f05daf6842b42b" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Compilations - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="reptonmn">
+		<description>Repton Mania</description>
+		<year>1989</year>
+		<publisher>Superior</publisher>
+		<part name="flop1" interface="floppy_3">
+			<dataarea name="flop" size="254720">
+				<rom name="repton mania - repton 1 + 2 (1989)(superior).dsk" size="254720" crc="2ed24adb" sha1="c452b252272ba4ebb7c509c6a7358b867df94c64" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Compilations - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="runbrspc">
+		<description>Run, Bronwynn, Run + The Spectre of Castle Coris</description>
+		<year>1992</year>
+		<publisher>FSF Adventures</publisher>
+		<part name="flop1" interface="floppy_3">
+			<feature name="part_id" value="Side A: Run, Bronwynn, Run"/>
+			<dataarea name="flop" size="195635">
+				<rom name="run, bronwynn, run + spectre of castle coris, the (1992)(fsf adventures)(side a).dsk" size="195635" crc="690f1e91" sha1="c7a2ae6d0926f1ccc540ad44f765f7dddee8a62b" offset="0" />
+			</dataarea>
+		</part>
+		<part name="flop2" interface="floppy_3">
+			<feature name="part_id" value="Side B: The Spectre of Castle Coris"/>
+			<dataarea name="flop" size="195635">
+				<rom name="run, bronwynn, run + spectre of castle coris, the (1992)(fsf adventures)(side b).dsk" size="195635" crc="833809c9" sha1="cf69a93b96cea22bd13076e087a1e92702b2dc8f" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Compilations - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="sp5">
+		<description>SP5</description>
+		<year>1992</year>
+		<publisher>Kobrahsoft</publisher>
+		<part name="flop1" interface="floppy_3">
+			<dataarea name="flop" size="194048">
+				<rom name="sp5 (1992)(kobrahsoft).dsk" size="194048" crc="41dad7b5" sha1="04cedbe1d9b8fb966e20db0da87c478d6649f07e" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Compilations - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="srsgames">
+		<description>SRS Games Disc</description>
+		<year>1988</year>
+		<publisher>Steam Railway Simulations</publisher>
+		<part name="flop1" interface="floppy_3">
+			<dataarea name="flop" size="194816">
+				<rom name="srs games disc (1988)(steam railway simulations).dsk" size="194816" crc="0d6897ae" sha1="ed569e9a9685116e057533192b78b457dad8ece5" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Compilations - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="samuahos">
+		<description>Sam's Un-Excellent Adventure + The Hospital</description>
+		<year>1994</year>
+		<publisher>Zenobi</publisher>
+		<part name="flop1" interface="floppy_3">
+			<dataarea name="flop" size="194816">
+				<rom name="sam's un-excellent adventure + the hospital - sam's un-excellent adventure (1994)(zenobi).dsk" size="194816" crc="c4293106" sha1="de58f5aaa5be5a3af953068b179e9b8fb72377bd" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Compilations - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="shootac2">
+		<description>Shootacular Disk 2</description>
+		<year>1988</year>
+		<publisher>Alternative</publisher>
+		<part name="flop1" interface="floppy_3">
+			<dataarea name="flop" size="195328">
+				<rom name="shootacular disk 2 (1988)(alternative).dsk" size="195328" crc="ce79b362" sha1="2eef6ecdc55ebb3fb5bd2550470b8435cdab4c07" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Compilations - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="silicond">
+		<description>Silicon Dreams</description>
+		<year>1986</year>
+		<publisher>Rainbird</publisher>
+		<part name="flop1" interface="floppy_3">
+			<feature name="part_id" value="Side A"/>
+			<dataarea name="flop" size="194816">
+				<rom name="silicon dreams - snowball + return to eden + the worm in paradise (1986)(rainbird).dsk" size="194816" crc="eae38e7d" sha1="f2ffd2fd60696a38c2a2f9fbd4638cf154de8db9" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Compilations - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="sincactp">
+		<description>Sinclair Action Pack - Lightgun Games</description>
+		<year>1989</year>
+		<publisher>Sinclair Research</publisher>
+		<part name="flop1" interface="floppy_3">
+			<feature name="part_id" value="Side A: Missile Ground Zero + Solar Invasion"/>
+			<dataarea name="flop" size="194816">
+				<rom name="sinclair action pack - lightgun games - lightgun games - missile ground zero + solar invasion (1989)(virgin mastertronic)(side a)[lightgun].dsk" size="194816" crc="8c3be2fa" sha1="1580bfde74955b629b2c4e3cbe4ccc524fec9f80" offset="0" />
+			</dataarea>
+		</part>
+		<part name="flop2" interface="floppy_3">
+			<feature name="part_id" value="Side B: Rookie + Robot Attack + Bullseye"/>
+			<dataarea name="flop" size="194816">
+				<rom name="sinclair action pack - lightgun games - lightgun games - rookie + robot attack + bullseye (1989)(virgin mastertronic)(side b)[lightgun].dsk" size="194816" crc="e706c6db" sha1="366a7b2b04a44007a3254fc0618ceb0d9df70e72" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Compilations - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="sincactpa" cloneof="sincactp">
+		<description>Sinclair Action Pack - Lightgun Games (re-release)</description>
+		<year>1989</year>
+		<publisher>Virgin Mastertronic</publisher>
+		<part name="flop1" interface="floppy_3">
+			<feature name="part_id" value="Side A: Missile Ground Zero + Solar Invasion"/>
+			<dataarea name="flop" size="194816">
+				<rom name="sinclair action pack - lightgun games - lightgun games - missile ground zero + solar invasion (1989)(sinclair research)[lightgun][re-release].dsk" size="194816" crc="5af8ba21" sha1="f5d45c97f2cda96fe8ed5be37d81fbd916e38e17" offset="0" />
+			</dataarea>
+		</part>
+		<part name="flop2" interface="floppy_3">
+			<feature name="part_id" value="Side B: Rookie + Robot Attack + Bullseye"/>
+			<dataarea name="flop" size="194816">
+				<rom name="sinclair action pack - lightgun games - lightgun games - rookie + robot attack + bullseye (1989)(sinclair research)[lightgun][re-release].dsk" size="194816" crc="f050f2ff" sha1="e68a94ee005f2ac47238ab43a1653ab641b25c0f" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Compilations - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="sincgcom">
+		<description>Sinclair Game Compilation</description>
+		<year>1988</year>
+		<publisher>Sinclair Research</publisher>
+		<part name="flop1" interface="floppy_3">
+			<feature name="part_id" value="Disk 1, Side A: Finders Keepers + S.O.S. + Type-Rope + Ultimate Combat Mission"/>
+			<dataarea name="flop" size="194816">
+				<rom name="sinclair game compilation (1988)(sinclair research)(disk 1 of 7 side a).dsk" size="194816" crc="27523b36" sha1="abfb2f751169bbd0ab00092b167bfcfac47067e9" offset="0" />
+			</dataarea>
+		</part>
+		<part name="flop2" interface="floppy_3">
+			<feature name="part_id" value="Disk 1, Side B: Jackle &amp; Wide + Rasterscan + spore + Sport of Kings"/>
+			<dataarea name="flop" size="194816">
+				<rom name="sinclair game compilation (1988)(sinclair research)(disk 1 of 7 side b).dsk" size="194816" crc="b963f51d" sha1="a0510fe07cd3011d5e5614a2b82b23683539a59c" offset="0" />
+			</dataarea>
+		</part>
+		<part name="flop3" interface="floppy_3">
+			<feature name="part_id" value="Disk 2, Side A: Agent X + Con-Quest + Strike"/>
+			<dataarea name="flop" size="194816">
+				<rom name="sinclair game compilation (1988)(sinclair research)(disk 2 of 7 side a).dsk" size="194816" crc="34f11c94" sha1="f207b9dc8a52e6f4353e7a4f1117e122e5e99ae7" offset="0" />
+			</dataarea>
+		</part>
+		<part name="flop4" interface="floppy_3">
+			<feature name="part_id" value="Disk 2, Side B: Colony + One Man and His Droid + Plexar + Wulfan the Barbarian"/>
+			<dataarea name="flop" size="194816">
+				<rom name="sinclair game compilation (1988)(sinclair research)(disk 2 of 7 side b).dsk" size="194816" crc="61d265c5" sha1="38272bc5eb6080a538d39ca3c0c4364d7ce58a63" offset="0" />
+			</dataarea>
+		</part>
+		<part name="flop5" interface="floppy_3">
+			<feature name="part_id" value="Disk 3, Side A: Molecule Man + Molecule Man Maze Designer + Universal Hero + Xcel"/>
+			<dataarea name="flop" size="194816">
+				<rom name="sinclair game compilation (1988)(sinclair research)(disk 3 of 7 side a).dsk" size="194816" crc="b2b665ca" sha1="8f699fc81027396ae4ec9fb8c1566fa8ec418775" offset="0" />
+			</dataarea>
+		</part>
+		<part name="flop6" interface="floppy_3">
+			<feature name="part_id" value="Disk 3, Side B: Brian Jacks Superstar Challenge + Eddie Kidd Jump Challenge + Level 5"/>
+			<dataarea name="flop" size="194816">
+				<rom name="sinclair game compilation (1988)(sinclair research)(disk 3 of 7 side b).dsk" size="194816" crc="32dc231f" sha1="b77d9a76668c8e2b1d35e5f4872c76e2ec482dc4" offset="0" />
+			</dataarea>
+		</part>
+		<part name="flop7" interface="floppy_3">
+			<feature name="part_id" value="Disk 4, Side A: Angle Ball + Kikstart 2 + Knight Tyme + Stormbringer"/>
+			<dataarea name="flop" size="194816">
+				<rom name="sinclair game compilation (1988)(sinclair research)(disk 4 of 7 side a).dsk" size="194816" crc="3463efac" sha1="1ec505f714b41df061700520a749652abe76e43a" offset="0" />
+			</dataarea>
+		</part>
+		<part name="flop8" interface="floppy_3">
+			<feature name="part_id" value="Disk 4, Side B: Amaurote + Curse of Sherwood + Milk Race + Speed King 2"/>
+			<dataarea name="flop" size="194816">
+				<rom name="sinclair game compilation (1988)(sinclair research)(disk 4 of 7 side b).dsk" size="194816" crc="82d7bd38" sha1="9739c2e529386ea8a6f9f01605754e0b41db5583" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Compilations - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="smallcol">
+		<description>A Small Collection of Hamster Droppings</description>
+		<year>1993</year>
+		<publisher>Zenobi</publisher>
+		<part name="flop1" interface="floppy_3">
+			<feature name="part_id" value="Side A: The Life of a Lone Electron + The Quest for the Holy"/>
+			<dataarea name="flop" size="194816">
+				<rom name="small collection of hamster droppings, a - the life of a lone electron + the quest for the holy (1993)(zenobi)(side a).dsk" size="194816" crc="a05d75de" sha1="48da53854c071a63579cc9bb4070545bea23708a" offset="0" />
+			</dataarea>
+		</part>
+		<part name="flop2" interface="floppy_3">
+			<feature name="part_id" value="Side B: First Past the Post + Get Me to the Church on Ti"/>
+			<dataarea name="flop" size="194816">
+				<rom name="small collection of hamster droppings, a - first past the post + get me to the church on time (1993)(zenobi)(side b).dsk" size="194816" crc="8de6f9c6" sha1="e45b8df3e8f009bcfb055db9e392c7cefc050708" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Compilations - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="soccerma">
+		<description>Soccer Mania</description>
+		<year>1990</year>
+		<publisher>Addictive Games</publisher>
+		<part name="flop1" interface="floppy_3">
+			<feature name="part_id" value="Disk 1, Side A: Football Manager 2"/>
+			<dataarea name="flop" size="194816">
+				<rom name="soccer mania (1990)(addictive games)(disk 1 of 2 side a).dsk" size="194816" crc="bfcc36bb" sha1="6d6a74fe478bdfc039f3dc67e851a6951413dbf8" offset="0" />
+			</dataarea>
+		</part>
+		<part name="flop1" interface="floppy_3">
+			<feature name="part_id" value="Disk 1, Side A: Football Manager: World Cup Edition"/>
+			<dataarea name="flop" size="194816">
+				<rom name="soccer mania - world cup edition (1990)(addictive games)(disk 1 of 2 side b).dsk" size="194816" crc="7f49f5cd" sha1="6d6a3ea81aeffbc9a300ae6252c81183a3df5aa4" offset="0" />
+			</dataarea>
+		</part>
+		<part name="flop2" interface="floppy_3">
+			<feature name="part_id" value="Disk 2, Side A: Gazza's Super Soccer"/>
+			<dataarea name="flop" size="194816">
+				<rom name="soccer mania (1990)(addictive games)(disk 2 of 2 side a).dsk" size="194816" crc="347bc85e" sha1="f89876979105843a68d1e06aa8dab94dc599597e" offset="0" />
+			</dataarea>
+		</part>
+		<part name="flop3" interface="floppy_3">
+			<feature name="part_id" value="Disk 2, Side B: MicroProse Soccer"/>
+			<dataarea name="flop" size="194816">
+				<rom name="soccer mania (1990)(addictive games)(disk 2 of 2 side b).dsk" size="194816" crc="53a7650a" sha1="5c44e0b45cbb2dccbd2725fa96be07caf9563cc3" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Compilations - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="solidgol">
+		<description>Solid Gold</description>
+		<year>1988</year>
+		<publisher>U.S. Gold</publisher>
+		<part name="flop1" interface="floppy_3">
+			<feature name="part_id" value="Disk 1, Side A: Gauntlet"/>
+			<dataarea name="flop" size="194816">
+				<rom name="solid gold - gauntlet (1988)(u.s. gold)(disk 1 of 2 side a).dsk" size="194816" crc="c484db81" sha1="36d053aa0ca9ee259f71ce173d58dae0f8a26d5f" offset="0" />
+			</dataarea>
+		</part>
+		<part name="flop2" interface="floppy_3">
+			<feature name="part_id" value="Disk 1, Side B: Ace of Aces"/>
+			<dataarea name="flop" size="214784">
+				<rom name="solid gold - ace of aces (1988)(u.s. gold)(disk 1 of 2 side b).dsk" size="214784" crc="02bd6078" sha1="e0e9a50a28f2260b3b80fe6e987cd75dca815af1" offset="0" />
+			</dataarea>
+		</part>
+		<part name="flop3" interface="floppy_3">
+			<feature name="part_id" value="Disk 2, Side A: Winter Games + Leaderboard"/>
+			<dataarea name="flop" size="214784">
+				<rom name="solid gold - winter games + leaderboard (1988)(u.s. gold)(disk 2 of 2 side a).dsk" size="214784" crc="28c69d3e" sha1="4ca67601511c3b4a539403e921609dcced093858" offset="0" />
+			</dataarea>
+		</part>
+		<part name="flop4" interface="floppy_3">
+			<feature name="part_id" value="Disk 2, Side B: Infiltrator"/>
+			<dataarea name="flop" size="214784">
+				<rom name="solid gold - infiltrator (1988)(u.s. gold)(disk 2 of 2 side b).dsk" size="214784" crc="42a5d06c" sha1="1abf1fd0473b280b0eb2965e03d49bbfe96b7174" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Compilations - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="sportac1">
+		<description>Sportacular Disk 1</description>
+		<year>1988</year>
+		<publisher>Alternative</publisher>
+		<part name="flop1" interface="floppy_3">
+			<dataarea name="flop" size="194816">
+				<rom name="sportacular disk 1 - soccer boss + olympic spectacular + indoor soccer (1988)(alternative).dsk" size="194816" crc="d42b8502" sha1="7299f66abbe1f01b02b43274a8ca9e3dabe56a7f" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Compilations - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="stillabd">
+		<description>Still Another Big Disk</description>
+		<year>1992</year>
+		<publisher>Zenobi</publisher>
+		<part name="flop1" interface="floppy_3">
+			<feature name="part_id" value="Side A: Darkest Road III - The Unborn One + Phoenix"/>
+			<dataarea name="flop" size="194816">
+				<rom name="still another big disk - darkest road iii - the unborn one + phoenix (1992)(zenobi)(side a).dsk" size="194816" crc="ce9ef1af" sha1="60a6457305484d1915b1bb2c4336319e333782e8" offset="0" />
+			</dataarea>
+		</part>
+		<part name="flop2" interface="floppy_3">
+			<feature name="part_id" value="Side B: A Legacy for Alaric + A Legacy for Alaric II - The Magic Isle"/>
+			<dataarea name="flop" size="194816">
+				<rom name="still another big disk - a legacy for alaric + a legacy for alaric ii - the magic isle (1992)(zenobi)(side b).dsk" size="194816" crc="f197bb87" sha1="c93391dc04b69a54c3ae393cf954a0cd210741f0" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Compilations - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="stilombd">
+		<description>Still One More Big Disk</description>
+		<year>19??</year>
+		<publisher>Zenobi</publisher>
+		<part name="flop1" interface="floppy_3">
+			<feature name="part_id" value="Side A: The Tears of the Moon + The Mines of Lithiad"/>
+			<dataarea name="flop" size="194816">
+				<rom name="still one more big disk - the tears of the moon + the mines of lithiad (19xx)(zenobi)(side a).dsk" size="194816" crc="3b2b5a44" sha1="6c8b9c7fa1317aa733c926cdab60b1f0b5dc0d03" offset="0" />
+			</dataarea>
+		</part>
+		<part name="flop2" interface="floppy_3">
+			<feature name="part_id" value="Side B: Jack the Ripper"/>
+			<dataarea name="flop" size="194816">
+				<rom name="still one more big disk - jack the ripper (19xx)(zenobi)(side b).dsk" size="194816" crc="ddd95fb1" sha1="262d7ee2a21f7e768e0e8a91b14d673c5e790cfb" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Compilations - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="stufmabd">
+		<description>Stuff Me Another Big Disk</description>
+		<year>19??</year>
+		<publisher>Zenobi</publisher>
+		<part name="flop1" interface="floppy_3">
+			<feature name="part_id" value="Side A: Aztec Assault + The Lost Twilight"/>
+			<dataarea name="flop" size="194816">
+				<rom name="stuff me another big disk - aztec assault + the lost twilight (19xx)(zenobi)(side a).dsk" size="194816" crc="08be0ed3" sha1="9caa7f44a42cce7af12c22b296305baa9e82f0db" offset="0" />
+			</dataarea>
+		</part>
+		<part name="flop2" interface="floppy_3">
+			<feature name="part_id" value="Side B: The Dark Tower + The Khangrin Plans"/>
+			<dataarea name="flop" size="194816">
+				<rom name="stuff me another big disk - the dark tower + the khangrin plans (19xx)(zenobi)(side b).dsk" size="194816" crc="06df0298" sha1="177aaf98eef31956181e308c8325017d9d5fec00" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Compilations - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="suncompu">
+		<description>The Sun Computer Crosswords Volume 1</description>
+		<year>1988</year>
+		<publisher>Akom</publisher>
+		<part name="flop1" interface="floppy_3">
+			<dataarea name="flop" size="194816">
+				<rom name="sun computer crosswords volume 1, the (1988)(akom).dsk" size="194816" crc="99a83f33" sha1="c701b7e4c5760a16669ca140cc45615a24af7889" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Compilations - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="supremec">
+		<description>Supreme Challenge</description>
+		<year>1988</year>
+		<publisher>Beau-Jolly</publisher>
+		<part name="flop1" interface="floppy_3">
+			<feature name="part_id" value="Side A: ACE 2 + The Sentinel + Tetris"/>
+			<dataarea name="flop" size="194816">
+				<rom name="supreme challenge - ace 2 - the ultimate head to head conflict + the sentinel + tetris (1988)(beau-jolly)(side a).dsk" size="194816" crc="bed32d10" sha1="038b63e4822822f46eb29149237554dc6676cac6" offset="0" />
+			</dataarea>
+		</part>
+		<part name="flop2" interface="floppy_3">
+			<feature name="part_id" value="Side B: Elite + Starglider"/>
+			<dataarea name="flop" size="194816">
+				<rom name="supreme challenge - elite + starglider (1988)(beau-jolly)(side b).dsk" size="194816" crc="7999f89e" sha1="6bd19bd6ddcb7d20b2aa5134f931db56566acbd8" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Compilations - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="supremec">
+		<description>Supreme Challenge: Soccer Spectacular</description>
+		<year>1989</year>
+		<publisher>Beau-Jolly</publisher>
+		<part name="flop1" interface="floppy_3">
+			<feature name="part_id" value="Side A: Peter Shilton's Handball Maradona + Soccer Supremo + World Champions"/>
+			<dataarea name="flop" size="194816">
+				<rom name="supreme challenge - soccer spectacular (1989)(beau-jolly)(side a).dsk" size="194816" crc="156ebf8a" sha1="58076376d1762b166194b29aa3d9a80c2d3706d2" offset="0" />
+			</dataarea>
+		</part>
+		<part name="flop2" interface="floppy_3">
+			<feature name="part_id" value="Side B: Football Manager + Peter Beardsley's International Football"/>
+			<dataarea name="flop" size="194816">
+				<rom name="supreme challenge - soccer spectacular (1989)(beau-jolly)(side b).dsk" size="194816" crc="38f1cff2" sha1="eb577147cefd532c19f6acf20e1b30c8f131bd50" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Compilations - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="tntdomrk">
+		<description>TNT</description>
+		<year>1990</year>
+		<publisher>Domark</publisher>
+		<part name="flop1" interface="floppy_3">
+			<feature name="part_id" value="Disk 1, Side A: Hard Drivin'"/>
+			<dataarea name="flop" size="194816">
+				<rom name="tnt - hard drivin' (1990)(domark)(disk 1 of 3 side a).dsk" size="194816" crc="32a8c50c" sha1="94bfd5b159e23684e4f9ed708e4ccdee113db140" offset="0" />
+			</dataarea>
+		</part>
+		<part name="flop2" interface="floppy_3">
+			<feature name="part_id" value="Disk 1, Side B: Toobin' + Xybots + APB"/>
+			<dataarea name="flop" size="344832">
+				<rom name="tnt - toobin' + xybots + apb - all points bulletin (1990)(domark)(disk 1 of 3 side b).dsk" size="344832" crc="8a8ea8ab" sha1="627542f6422dea4022cbd86c3fc6a3c73d8d905e" offset="0" />
+			</dataarea>
+		</part>
+		<part name="flop3" interface="floppy_3">
+			<feature name="part_id" value="Disk 2: Dragon Spirit"/>
+			<dataarea name="flop" size="194816">
+				<rom name="tnt - dragon spirit (1990)(domark)(disk 2 of 3).dsk" size="194816" crc="7286ca1d" sha1="c0d8267bb534a60cd82ab61d8e154502dd284ef3" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Compilations - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="tntdomrksp" cloneof="tntdomrk">
+		<description>TNT (Spain)</description>
+		<year>1991</year>
+		<publisher>Dro Soft</publisher>
+		<part name="flop1" interface="floppy_3">
+			<feature name="part_id" value="Disk 1, Side A: Xybots + Toobin'"/>
+			<dataarea name="flop" size="182016">
+				<rom name="tnt (1991)(dro soft)(es)(en)(disk 1 of 3 side a).dsk" size="182016" crc="856e202a" sha1="9a426e12690b9b6bc92528ed76d3a90d14d68881" offset="0" />
+			</dataarea>
+		</part>
+		<part name="flop2" interface="floppy_3">
+			<feature name="part_id" value="Disk 1, Side B: APB"/>
+			<dataarea name="flop" size="131584">
+				<rom name="tnt (1991)(dro soft)(es)(en)(disk 1 of 3 side b).dsk" size="131584" crc="00e4a5f2" sha1="077c97ebb631b25679de74e8e693bb34b17b700c" offset="0" />
+			</dataarea>
+		</part>
+		<part name="flop3" interface="floppy_3">
+			<feature name="part_id" value="Disk 2, Side A: Hard Drivin'"/>
+			<dataarea name="flop" size="58624">
+				<rom name="tnt (1991)(dro soft)(es)(en)(disk 2 of 3 side a).dsk" size="58624" crc="17c26e04" sha1="25c2588c93ccfb585c598448ccc71c60982b072b" offset="0" />
+			</dataarea>
+		</part>
+		<part name="flop4" interface="floppy_3">
+			<feature name="part_id" value="Disk 2, Side B: Dragon Spirit"/>
+			<dataarea name="flop" size="194816">
+				<rom name="tnt (1991)(dro soft)(es)(en)(disk 2 of 3 side b).dsk" size="194816" crc="edde7dc8" sha1="b09e36bfdbae3d430554d9fe4e27956251b31641" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Compilations - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="take3spo">
+		<description>Take 3 Sports</description>
+		<year>1988</year>
+		<publisher>Blue Ribbon</publisher>
+		<part name="flop1" interface="floppy_3">
+			<dataarea name="flop" size="194816">
+				<rom name="take 3 sports (1988)(blue ribbon).dsk" size="194816" crc="ad087045" sha1="e29d7ace547d11d06d7e43674bd19426c929502b" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Compilations - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="takefive">
+		<description>Take Five</description>
+		<year>1988</year>
+		<publisher>Pirate</publisher>
+		<part name="flop1" interface="floppy_3">
+			<feature name="part_id" value="Side A: Gangplank + Just Imagine"/>
+			<dataarea name="flop" size="194816">
+				<rom name="take five - gangplank + just imagine (1988)(pirate)(side a).dsk" size="194816" crc="60ef133d" sha1="c1c85b3014eccf68baead4015688528c2eb325dd" offset="0" />
+			</dataarea>
+		</part>
+		<part name="flop1" interface="floppy_3">
+			<feature name="part_id" value="Side B: Dusty Droid and the Garbage Gobblers + O.K. Yah + Don't Say It, Spray It"/>
+			<dataarea name="flop" size="194816">
+				<rom name="take five - dusty droid and the garbage gobblers + o.k. yah + don't say it, spray it (1988)(pirate)(side b).dsk" size="194816" crc="c02bad77" sha1="a28709dbc02fd94161e51516aae7a6dd4f62df20" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Compilations - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="taxbills">
+		<description>Tax Bills</description>
+		<year>19??</year>
+		<publisher>Zenobi</publisher>
+		<part name="flop1" interface="floppy_3">
+			<dataarea name="flop" size="194816">
+				<rom name="tax bills - the taxman cometh + tax returns + the final demand (19xx)(zenobi).dsk" size="194816" crc="cc30a3da" sha1="fa056d97fdf52341229aab72d09d9396fc286a17" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Compilations - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="timenmgk">
+		<description>Time and Magik</description>
+		<year>1988</year>
+		<publisher>Mandarin</publisher>
+		<part name="flop1" interface="floppy_3">
+			<feature name="part_id" value="Side A"/>
+			<dataarea name="flop" size="194816">
+				<rom name="time and magik (1988)(mandarin)(side a).dsk" size="194816" crc="91a6e149" sha1="8c4a9a528ec1da23544f11e9147488271024c0a7" offset="0" />
+			</dataarea>
+		</part>
+		<part name="flop2" interface="floppy_3">
+			<feature name="part_id" value="Side B"/>
+			<dataarea name="flop" size="194816">
+				<rom name="time and magik (1988)(mandarin)(side b).dsk" size="194816" crc="81f95393" sha1="20b81b8fe1ecd332efbf0e4852b87f1f306e211d" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Compilations - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="timenmgka" cloneof="timenmgk">
+		<description>Time and Magik (alt)</description>
+		<year>1988</year>
+		<publisher>Mandarin</publisher>
+		<part name="flop1" interface="floppy_3">
+			<feature name="part_id" value="Side A"/>
+			<dataarea name="flop" size="194816">
+				<rom name="time and magik (1988)(mandarin)(side a)[a].dsk" size="194816" crc="8ba9c810" sha1="2298a68bdd7cb7b39d239519d463f8242bd611e1" offset="0" />
+			</dataarea>
+		</part>
+		<part name="flop2" interface="floppy_3">
+			<feature name="part_id" value="Side B"/>
+			<dataarea name="flop" size="194816">
+				<rom name="time and magik (1988)(mandarin)(side b)[a].dsk" size="194816" crc="52ffb435" sha1="afad039ffd0e8c6f36d1686dc1ad6912c73ebdac" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Compilations - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="atodamaq">
+		<description>A Toda Maquina</description>
+		<year>1989</year>
+		<publisher>Erbe</publisher>
+		<part name="flop1" interface="floppy_3">
+			<feature name="part_id" value="Side A: Dragon Ninja + Afterburner"/>
+			<dataarea name="flop" size="261120">
+				<rom name="toda maquina, a - dragon ninja + afterburner (1989)(erbe)(es)(en).dsk" size="261120" crc="ff7f0d26" sha1="c3a7d5b914105224d707e36a88b73ea74506c215" offset="0" />
+			</dataarea>
+		</part>
+		<part name="flop2" interface="floppy_3">
+			<feature name="part_id" value="Side B: Rambo III + Robocop + Batman"/>
+			<dataarea name="flop" size="261120">
+				<rom name="toda maquina, a - rambo iii + robocop + batman (1989)(erbe)(es)(en).dsk" size="261120" crc="9b5ce0b6" sha1="b229d4a53451ea0138e394334fae50d2d189e79c" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Compilations - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="top10col">
+		<description>Top 10 Collection</description>
+		<year>1988</year>
+		<publisher>Hit-Pak</publisher>
+		<part name="flop1" interface="floppy_3">
+			<feature name="part_id" value="Side A: Airwolf + Combat Lynx + Critical Mass + Deep Strike + Saboteur"/>
+			<dataarea name="flop" size="214784">
+				<rom name="top 10 collection (1988)(hit-pak)(side a)[aka top ten collection].dsk" size="214784" crc="ef1edec3" sha1="1dc75bb4a6bc2bf92d85cda33f84dd816cfa4f81" offset="0" />
+			</dataarea>
+		</part>
+		<part name="flop2" interface="floppy_3">
+			<feature name="part_id" value="Side B: Bomb Jack II + Saboteur 2 + Sigma 7 + Thanatos + Turbo Esprit"/>
+			<dataarea name="flop" size="214784">
+				<rom name="top 10 collection (1988)(hit-pak)(side b)[aka top ten collection].dsk" size="214784" crc="46a55552" sha1="3d343ccc80eda55a2824713ac7f88f713cef086d" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Compilations - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="topbytop">
+		<description>Top By Topo</description>
+		<year>1989</year>
+		<publisher>Topo Soft</publisher>
+		<part name="flop1" interface="floppy_3">
+			<feature name="part_id" value="Side A: Mad Mix Game + Score 3020 + Tuareg + Wells &amp; Fargo"/>
+			<dataarea name="flop" size="189952">
+				<rom name="top by topo - mad mix game + score 3020 + tuareg + wells &amp; fargo (1989)(topo soft)(es)(side a).dsk" size="189952" crc="37289d2e" sha1="0c2658923b025c77b31de622a2e37f47c9a1467c" offset="0" />
+			</dataarea>
+		</part>
+		<part name="flop2" interface="floppy_3">
+			<feature name="part_id" value="Side B: Metropolis + Rock 'n Roller + Blackbeard + Emilio Butragueno Futbol"/>
+			<dataarea name="flop" size="185088">
+				<rom name="top by topo - metropolis + rock 'n roller + blackbeard + emilio butragueno futbol (1989)(topo soft)(es)(side b).dsk" size="185088" crc="0f2e4848" sha1="3424c891f86e5ed35fc4bfd6c29f8bbdbd96108c" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Compilations - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+<!-- Labeled as "bad dump" in TOSEC for some reason, but it's the same dump at World of Spectrum. -->
+	<software name="totalerb">
+		<description>Total</description>
+		<year>1989</year>
+		<publisher>Erbe</publisher>
+		<part name="flop1" interface="floppy_3">
+			<feature name="part_id" value="Side A: Platoon + Arkanoid II: Revenge of Doh + Combat School"/>
+			<dataarea name="flop" size="215296">
+				<rom name="total - platoon + arkanoid ii - revenge of doh + combat school (1989)(erbe)(es)(en)(side a)[b].dsk" size="215296" crc="90fe6396" sha1="d721e1aac28c159b7463acc0e165316a19091699" offset="0" />
+			</dataarea>
+		</part>
+		<part name="flop2" interface="floppy_3">
+			<feature name="part_id" value="Side B: Target Renegade"/>
+			<dataarea name="flop" size="204544">
+				<rom name="total - renegade ii - target renegade (1989)(erbe)(es)(en)(side b).dsk" size="204544" crc="8ee50a77" sha1="6794e5e61a5a08a69141001e60b6ed5ec5e95a85" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Compilations - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="travtals">
+		<description>Traveller's Tales</description>
+		<year>1993</year>
+		<publisher>Zenobi</publisher>
+		<part name="flop1" interface="floppy_3">
+			<feature name="part_id" value="Side A: Phoenix + The Violator of Voodoo"/>
+			<dataarea name="flop" size="194816">
+				<rom name="traveller's tales - phoenix + the violator of voodoo (1993)(zenobi)(side a).dsk" size="194816" crc="30e96557" sha1="72179269718719ea83e2c1994f938c99b015145d" offset="0" />
+			</dataarea>
+		</part>
+		<part name="flop1" interface="floppy_3">
+			<feature name="part_id" value="Side B: Aztec Assault + Celtic Carnage"/>
+			<dataarea name="flop" size="194816">
+				<rom name="traveller's tales - aztec assault + celtic carnage (1993)(zenobi)(side b).dsk" size="194816" crc="6af8f2c7" sha1="636611c8143f00b4b47ba2ac593481d07ae83642" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Compilations - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="vitamina">
+		<description>Vitaminas</description>
+		<year>1989</year>
+		<publisher>Erbe</publisher>
+		<part name="flop1" interface="floppy_3">
+			<feature name="part_id" value="Side A: Street Fighter + Bionic Commando (loader) + Road Blasters + 1943"/>
+			<dataarea name="flop" size="198656">
+				<rom name="vitaminas (1989)(erbe)(es)(en)(side a).dsk" size="198656" crc="00bc7d39" sha1="263f4d343f08a90f813b528e7c575e239d3a9053" offset="0" />
+			</dataarea>
+		</part>
+		<part name="flop2" interface="floppy_3">
+			<feature name="part_id" value="Side B: Road Blasters + Bionic Commando (data)"/>
+			<dataarea name="flop" size="214784">
+				<rom name="vitaminas (1989)(erbe)(es)(en)(side b).dsk" size="214784" crc="aa430b4f" sha1="5f27e3e31eaaf36f4cdf8da175c3d6cabb994368" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Compilations - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="watchamp">
+		<description>We Are the Champions</description>
+		<year>1988</year>
+		<publisher>Ocean</publisher>
+		<part name="flop1" interface="floppy_3">
+			<feature name="part_id" value="Side A: International Karate+ + Renegade"/>
+			<dataarea name="flop" size="214784">
+				<rom name="we are the champions - international karate+ + renegade (1988)(ocean).dsk" size="214784" crc="e94b8d59" sha1="51291b522ca939b17ef22771880fbbe23696a23b" offset="0" />
+			</dataarea>
+		</part>
+		<part name="flop2" interface="floppy_3">
+			<feature name="part_id" value="Side B: Barbarian + Super Sprint + Rampage"/>
+			<dataarea name="flop" size="214784">
+				<rom name="we are the champions - barbarian + super sprint + rampage (1988)(ocean).dsk" size="214784" crc="b25e4d6a" sha1="aa549353dd8a793fb7e56e0873717d6ac85b86fa" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Compilations - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="whlsfire">
+		<description>Wheels of Fire</description>
+		<year>1990</year>
+		<publisher>Domark</publisher>
+		<part name="flop1" interface="floppy_3">
+			<feature name="part_id" value="Disk 1, Side A: Chase H.Q. + Power Drift"/>
+			<dataarea name="flop" size="229632">
+				<rom name="wheels of fire (1990)(domark)(disk 1 of 4 side a).dsk" size="229632" crc="36fca6e2" sha1="2085a0bfd58e75bdfebc82cd99baff8f2a2c09f0" offset="0" />
+			</dataarea>
+		</part>
+		<part name="flop2" interface="floppy_3">
+			<feature name="part_id" value="Disk 1, Side B: Hard Drivin'"/>
+			<dataarea name="flop" size="194816">
+				<rom name="wheels of fire (1990)(domark)(disk 1 of 4 side b).dsk" size="194816" crc="37233886" sha1="23c12b78303fd8f713ca174745c9df569c645450" offset="0" />
+			</dataarea>
+		</part>
+		<part name="flop3" interface="floppy_3">
+			<feature name="part_id" value="Disk 2, Side A: Turbo Out Run (loader)"/>
+			<dataarea name="flop" size="255232">
+				<rom name="wheels of fire (1990)(domark)(disk 2 of 4 side a).dsk" size="255232" crc="7d64968f" sha1="d2d1a5777a3baf84d4bdf829e79985cd6a7e9272" offset="0" />
+			</dataarea>
+		</part>
+		<part name="flop4" interface="floppy_3">
+			<feature name="part_id" value="Disk 2, Side B: Turbo Out Run (data)"/>
+			<dataarea name="flop" size="256256">
+				<rom name="wheels of fire (1990)(domark)(disk 2 of 4 side b).dsk" size="256256" crc="01a5deba" sha1="961f1fb2c23b701298d65432e3e44591312be7fa" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Compilations - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="whoopabd">
+		<description>Whoops Another Big Disk</description>
+		<year>1994</year>
+		<publisher>Zenobi</publisher>
+		<part name="flop1" interface="floppy_3">
+			<feature name="part_id" value="Side A: Leopold the Minstrel"/>
+			<dataarea name="flop" size="194816">
+				<rom name="whoops another big disk (1994)(zenobi)(side a).dsk" size="194816" crc="10657ec8" sha1="17ef9c2634677e22d4d78d703f64854642a92e3c" offset="0" />
+			</dataarea>
+		</part>
+		<part name="flop2" interface="floppy_3">
+			<feature name="part_id" value="Side B: Lycanthropy"/>
+			<dataarea name="flop" size="194816">
+				<rom name="whoops another big disk (1994)(zenobi)(side b).dsk" size="194816" crc="f1967db9" sha1="b3c0b4d2f88be6d3bac70e76821d5751d6189ee7" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Compilations - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="winnteam">
+		<description>The Winning Team</description>
+		<year>1991</year>
+		<publisher>Domark</publisher>
+		<part name="flop1" interface="floppy_3">
+			<feature name="part_id" value="Disk 1, Side A: APB"/>
+			<dataarea name="flop" size="204544">
+				<rom name="winning team, the - apb - all points bulletin (1991)(domark)(disk 1 of 3 side a).dsk" size="204544" crc="d904319c" sha1="79886092a741edd86bc7baabb5bb03d4bae06fdf" offset="0" />
+			</dataarea>
+		</part>
+		<part name="flop2" interface="floppy_3">
+			<feature name="part_id" value="Disk 1, Side B: Escape from the Planet of the Robot Monsters"/>
+			<dataarea name="flop" size="194816">
+				<rom name="winning team, the - escape from the planet of the robot monsters (1991)(domark)(disk 1 of 3 side b).dsk" size="194816" crc="0f4962ac" sha1="f378a46c7feef8549bcf79f4546b52985bc20dfe" offset="0" />
+			</dataarea>
+		</part>
+		<part name="flop3" interface="floppy_3">
+			<feature name="part_id" value="Disk 2, Side A: Cyberball"/>
+			<dataarea name="flop" size="194816">
+				<rom name="winning team, the - cyberball (1991)(domark)(disk 2 of 3 side a).dsk" size="194816" crc="767aa935" sha1="bbd0c198890c8ccfafe9dab988651d46e2ddc0cf" offset="0" />
+			</dataarea>
+		</part>
+		<part name="flop4" interface="floppy_3">
+			<feature name="part_id" value="Disk 2, Side B: Klax"/>
+			<dataarea name="flop" size="194816">
+				<rom name="winning team, the - klax (1991)(domark)(disk 2 of 3 side b).dsk" size="194816" crc="6e64d9a3" sha1="959baad53b114a5b93a5d778fd1e8c00916a2081" offset="0" />
+			</dataarea>
+		</part>
+		<part name="flop5" interface="floppy_3">
+			<feature name="part_id" value="Disk 3: Vindicators"/>
+			<dataarea name="flop" size="175872">
+				<rom name="winning team, the - vindicators (1991)(domark)(disk 3 of 3).dsk" size="175872" crc="287191e2" sha1="a3bea18ac143348a8dea03f86fd142d9576a4e1d" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Compilations - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="worldcup">
+		<description>World Cup Year 90 Compilation</description>
+		<year>1990</year>
+		<publisher>Empire</publisher>
+		<part name="flop1" interface="floppy_3">
+			<feature name="part_id" value="Side A: Gary Lineker's Hot-Shot"/>
+			<dataarea name="flop" size="219136">
+				<rom name="world cup year 90 compilation - gary lineker's hot-shot (1990)(empire)(side a).dsk" size="219136" crc="9e086fde" sha1="72a23897af495c77849ac733fac94de62cae90fb" offset="0" />
+			</dataarea>
+		</part>
+		<part name="flop2" interface="floppy_3">
+			<feature name="part_id" value="Side B: Track Suit Manager + Kick Off"/>
+			<dataarea name="flop" size="267520">
+				<rom name="world cup year 90 compilation - track suit manager + kick off (1990)(empire)(side b).dsk" size="267520" crc="fafc45f7" sha1="d94cfdc743895f3f89a60e9e007f3cae60219cf8" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Compilations - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="yetanobd">
+		<description>Yet Another Big Disk</description>
+		<year>19??</year>
+		<publisher>Zenobi</publisher>
+		<part name="flop1" interface="floppy_3">
+			<feature name="part_id" value="Side A: Agatha's Folly + Arnold the Adventurer"/>
+			<dataarea name="flop" size="194816">
+				<rom name="yet another big disk - agatha's folly + arnold the adventurer (19xx)(zenobi)(side a).dsk" size="194816" crc="c7b47449" sha1="80c18ca2f29cc3750d292fa7dd5e42eda861cf1b" offset="0" />
+			</dataarea>
+		</part>
+		<part name="flop2" interface="floppy_3">
+			<feature name="part_id" value="Side B: The Jade Stone + The Ellisnore Diamond"/>
+			<dataarea name="flop" size="194816">
+				<rom name="yet another big disk - the jade stone + the ellisnore diamond (19xx)(zenobi)(side b).dsk" size="194816" crc="3103713f" sha1="96c58c2887113bcf01738779651e9c7463a980ec" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Compilations - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="yippombd">
+		<description>Yippee One More Big Disk</description>
+		<year>1993</year>
+		<publisher>Zenobi</publisher>
+		<part name="flop1" interface="floppy_3">
+			<feature name="part_id" value="Side A: Stranded + Out of the Limelight"/>
+			<dataarea name="flop" size="194816">
+				<rom name="yippee one more big disk - stranded + out of the limelight (1993)(zenobi)(side a).dsk" size="194816" crc="40019a81" sha1="f6a85c2a79e9476e38ec5bec08d29d6862a670bb" offset="0" />
+			</dataarea>
+		</part>
+		<part name="flop2" interface="floppy_3">
+			<feature name="part_id" value="Side B: Tax Returns + Murder - He Said"/>
+			<dataarea name="flop" size="194816">
+				<rom name="yippee one more big disk - tax returns + murder - he said (1993)(zenobi)(side b).dsk" size="194816" crc="719624bf" sha1="29eba5c055f09ae49118735139dbbfa66185b92a" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Compilations - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="zappak">
+		<description>Zap-Pak</description>
+		<year>1988</year>
+		<publisher>Players Premier</publisher>
+		<part name="flop1" interface="floppy_3">
+			<feature name="part_id" value="Side A: Cybernation + Riding the Rapids"/>
+			<dataarea name="flop" size="160768">
+				<rom name="zap-pak - cybernation + riding the rapids (1988)(players premier).dsk" size="160768" crc="1d6888cb" sha1="69ff8f18e52b3c54e62c72bfcf92267f4360aacc" offset="0" />
+			</dataarea>
+		</part>
+		<part name="flop2" interface="floppy_3">
+			<feature name="part_id" value="Side B: Joe Blade + Xanthius"/>
+			<dataarea name="flop" size="165632">
+				<rom name="zap-pak - joe blade + xanthius (1988)(players premier).dsk" size="165632" crc="27730ac1" sha1="27b06711206766e209e59bee3a7bec2e9f05dc9e" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Demos - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="chipnsfx">
+		<description>CHIPNSFX Tracker+player</description>
+		<year>2017</year>
+		<publisher>&lt;unknown&gt;</publisher>
+		<part name="flop1" interface="floppy_3">
+			<dataarea name="flop" size="9984">
+				<rom name="chipnsfx tracker+player (2017-05)(-).dsk" size="9984" crc="8ecbecd5" sha1="0c3bf106f0d42ca13ded461c1b06449351e5ec43" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+	<software name="ansbacfa">
+		<description>Answer Back Factfile 500 - Arithmetic - Ages 6-11</description>
+		<year>1985</year>
+		<publisher>Kosmos</publisher>
+		<part name="flop1" interface="floppy_3">
+			<dataarea name="flop" size="194816">
+				<rom name="answer back factfile 500 - arithmetic - ages 6-11 (1985)(kosmos).dsk" size="194816" crc="02a79ba0" sha1="22a6681d3b1579da9795b39aad01bd396ab4a170" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Educational - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="ansbacjq">
+		<description>Answer Back Junior Quiz</description>
+		<year>1985</year>
+		<publisher>Kosmos</publisher>
+		<part name="flop1" interface="floppy_3">
+			<dataarea name="flop" size="194816">
+				<rom name="answer back junior quiz (1985)(kosmos).dsk" size="194816" crc="a00f2d25" sha1="a5ee4b4f142b0f0e46c6f71368dad1224a8db4c3" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Educational - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="castclow">
+		<description>Castles and Clowns</description>
+		<year>1985</year>
+		<publisher>Macmillan</publisher>
+		<part name="flop1" interface="floppy_3">
+			<dataarea name="flop" size="194816">
+				<rom name="castles and clowns (1985)(macmillan).dsk" size="194816" crc="b79676fd" sha1="8561af217f3b00ef56bfa452bca3b67e2dbe2c04" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Educational - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="castclowa" cloneof="castclow">
+		<description>Castles and Clowns (alt)</description>
+		<year>1985</year>
+		<publisher>Macmillan</publisher>
+		<part name="flop1" interface="floppy_3">
+			<dataarea name="flop" size="194816">
+				<rom name="castles and clowns (1985)(macmillan)[a].dsk" size="194816" crc="0764b8fa" sha1="37a2931cdfd5813ec859126c5e0f445a389660d2" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Educational - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="countadd">
+		<description>Count and Add</description>
+		<year>1992</year>
+		<publisher>Lander</publisher>
+		<part name="flop1" interface="floppy_3">
+			<dataarea name="flop" size="194816">
+				<rom name="count and add (1992)(lander).dsk" size="194816" crc="3aef3126" sha1="45444aba9099091eda6e10d582e797fb9f539038" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Educational - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="funsc268">
+		<description>Fun School 2 for 6-8 Year Olds</description>
+		<year>1989</year>
+		<publisher>Database Educational</publisher>
+		<part name="flop1" interface="floppy_3">
+			<dataarea name="flop" size="194816">
+				<rom name="fun school 2 for 6-8 year olds (1989)(database educational)[aka fun school 2 for 6 to 8 years].dsk" size="194816" crc="54456709" sha1="8ceeb4b62ed72e7f0efabf7f3c10b5347395ffbd" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Educational - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="funsc268a" cloneof="funsc268">
+		<description>Fun School 2 for 6-8 Year Olds (alt)</description>
+		<year>1989</year>
+		<publisher>Database Educational</publisher>
+		<part name="flop1" interface="floppy_3">
+			<dataarea name="flop" size="194816">
+				<rom name="fun school 2 for 6-8 year olds (1989)(database educational)[a][aka fun school 2 for 6 to 8 years].dsk" size="194816" crc="91e7199e" sha1="29531481a5c28030b56669cd21e8a78d7196cb82" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Educational - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="funsc268b" cloneof="funsc268">
+		<description>Fun School 2 for 6-8 Year Olds (alt 2)</description>
+		<year>1989</year>
+		<publisher>Database Educational</publisher>
+		<part name="flop1" interface="floppy_3">
+			<dataarea name="flop" size="194816">
+				<rom name="fun school 2 for 6-8 year olds (1989)(database educational)[a2][aka fun school 2 for 6 to 8 years].dsk" size="194816" crc="857a1482" sha1="85db0fc04d6a8da7e060262da05dd554930d0cba" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Educational - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="funsc268c" cloneof="funsc268">
+		<description>Fun School 2 for 6-8 Year Olds (alt 3)</description>
+		<year>1989</year>
+		<publisher>Database Educational</publisher>
+		<part name="flop1" interface="floppy_3">
+			<dataarea name="flop" size="194816">
+				<rom name="fun school 2 for 6-8 year olds (1989)(database educational)[a3][aka fun school 2 for 6 to 8 years].dsk" size="194816" crc="7bffa05e" sha1="5d844874bc517fe8f05823452c5ceda9125ef661" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Educational - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="funsc28">
+		<description>Fun School 2 for the Over-8s</description>
+		<year>1989</year>
+		<publisher>Database Educational</publisher>
+		<part name="flop1" interface="floppy_3">
+			<dataarea name="flop" size="195328">
+				<rom name="fun school 2 for the over-8s (1989)(database educational)[aka fun school 2 for ages 8 to 12].dsk" size="195328" crc="f724e19d" sha1="493e38ce4f4f83c2cfda6bc5dbc589167ce3e64f" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Educational - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="funsc357">
+		<description>Fun School 3 for 5-7 Year Olds</description>
+		<year>1991</year>
+		<publisher>Database Educational</publisher>
+		<part name="flop1" interface="floppy_3">
+			<feature name="part_id" value="Side A"/>
+			<dataarea name="flop" size="194816">
+				<rom name="fun school 3 for 5-7 year olds (1991)(database educational)(side a).dsk" size="194816" crc="e7665457" sha1="3129d1d29d5d9226bb8aa25d79b52a429811a219" offset="0" />
+			</dataarea>
+		</part>
+		<part name="flop2" interface="floppy_3">
+			<feature name="part_id" value="Side B"/>
+			<dataarea name="flop" size="194816">
+				<rom name="fun school 3 for 5-7 year olds (1991)(database educational)(side b).dsk" size="194816" crc="326672b9" sha1="0b97a077ced3b478d1a4d98454e14eaa2fc12b01" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Educational - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="funsc37">
+		<description>Fun School 3 for the Over-7s</description>
+		<year>1991</year>
+		<publisher>Database Educational</publisher>
+		<part name="flop1" interface="floppy_3">
+			<feature name="part_id" value="Side A"/>
+			<dataarea name="flop" size="194816">
+				<rom name="fun school 3 for the over-7s (1991)(database educational)(side a).dsk" size="194816" crc="f0d9aa91" sha1="57b9a9a23b097477de7b7a7254ca134b216cd754" offset="0" />
+			</dataarea>
+		</part>
+		<part name="flop2" interface="floppy_3">
+			<feature name="part_id" value="Side B"/>
+			<dataarea name="flop" size="194816">
+				<rom name="fun school 3 for the over-7s (1991)(database educational)(side b).dsk" size="194816" crc="b70a7e32" sha1="c83a137e588bb4710b137a8aa965626353b69e0c" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Educational - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="funsc35">
+		<description>Fun School 3 for the Under-5s</description>
+		<year>1991</year>
+		<publisher>Database Educational</publisher>
+		<part name="flop1" interface="floppy_3">
+			<feature name="part_id" value="Side A"/>
+			<dataarea name="flop" size="194816">
+				<rom name="fun school 3 for the under-5s (1991)(database educational)(side a).dsk" size="194816" crc="54b0410d" sha1="f4dd65ec44b7ce2059e807f15bfce8caefdca097" offset="0" />
+			</dataarea>
+		</part>
+		<part name="flop2" interface="floppy_3">
+			<feature name="part_id" value="Side B"/>
+			<dataarea name="flop" size="194816">
+				<rom name="fun school 3 for the under-5s (1991)(database educational)(side b).dsk" size="194816" crc="1fdaad89" sha1="04eb15bbf5f70e14722cb0e77cf58be30ed1e81b" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Educational - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="funsc457">
+		<description>Fun School 4 for 5-7 Year Olds</description>
+		<year>1992</year>
+		<publisher>Europress</publisher>
+		<part name="flop1" interface="floppy_3">
+			<feature name="part_id" value="Side A"/>
+			<dataarea name="flop" size="194816">
+				<rom name="fun school 4 for 5-7 year olds (1992)(europress)(side a).dsk" size="194816" crc="4decf77a" sha1="a5cd9e81812918104de18a6b70b48aa539d7efd9" offset="0" />
+			</dataarea>
+		</part>
+		<part name="flop2" interface="floppy_3">
+			<feature name="part_id" value="Side B"/>
+			<dataarea name="flop" size="194816">
+				<rom name="fun school 4 for 5-7 year olds (1992)(europress)(side b).dsk" size="194816" crc="76b510f1" sha1="0bb4de05d19bccc41486dd0c80468bd1989f9431" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Educational - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="funsc4711">
+		<description>Fun School 4 for 7-11 Year Olds</description>
+		<year>1992</year>
+		<publisher>Europress</publisher>
+		<part name="flop1" interface="floppy_3">
+			<feature name="part_id" value="Side A"/>
+			<dataarea name="flop" size="141312">
+				<rom name="fun school 4 for 7-11 year olds (1992)(europress)(side a).dsk" size="141312" crc="8abd62ed" sha1="447b61201ef1f7753a375ed1377f1ab6222a6fd5" offset="0" />
+			</dataarea>
+		</part>
+		<part name="flop2" interface="floppy_3">
+			<feature name="part_id" value="Side B"/>
+			<dataarea name="flop" size="116992">
+				<rom name="fun school 4 for 7-11 year olds (1992)(europress)(side b).dsk" size="116992" crc="9e3ba186" sha1="65245e006c650fa4a43dba7a9b51221fc6b31775" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Educational - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="henrbook">
+		<description>Henrietta's Book of Spells</description>
+		<year>1990</year>
+		<publisher>Scetlander</publisher>
+		<part name="flop1" interface="floppy_3">
+			<dataarea name="flop" size="194816">
+				<rom name="henrietta's book of spells (1990)(scetlander).dsk" size="194816" crc="201aecb4" sha1="d125585c16c09ea6b84fa687d16d4bda00689d16" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Educational - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="identeur">
+		<description>Identify Europe</description>
+		<year>1987</year>
+		<publisher>Kosmos</publisher>
+		<part name="flop1" interface="floppy_3">
+			<dataarea name="flop" size="194816">
+				<rom name="identify europe (1987)(kosmos).dsk" size="194816" crc="4f9dfb6f" sha1="bc632b6df0104e74af93bb2a2fd4ba338bf9d86a" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Educational - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="junglmth">
+		<description>Jungle Maths</description>
+		<year>1983</year>
+		<publisher>Scisoft</publisher>
+		<part name="flop1" interface="floppy_3">
+			<dataarea name="flop" size="194816">
+				<rom name="jungle maths (1983)(scisoft).dsk" size="194816" crc="2cf83377" sha1="50dfd0ac361229be0e96fd65d2a70796f421e289" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Educational - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="spangold">
+		<description>Spanish Gold</description>
+		<year>1983</year>
+		<publisher>Chalksoft</publisher>
+		<part name="flop1" interface="floppy_3">
+			<dataarea name="flop" size="194816">
+				<rom name="spanish gold (1983)(chalksoft).dsk" size="194816" crc="b1bcc0ef" sha1="c5436ac0a5d97e64e87361329217a07e55afe14c" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Educational - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="ttefunwo">
+		<description>Thomas the Tank Engine's Fun With Words</description>
+		<year>1990</year>
+		<publisher>Friendly Learning</publisher>
+		<part name="flop1" interface="floppy_3">
+			<feature name="part_id" value="Side A"/>
+			<dataarea name="flop" size="194816">
+				<rom name="thomas the tank engine's fun with words (1990)(friendly learning)(side a).dsk" size="194816" crc="683a32a9" sha1="76f98308babf1addc111db18a85b3c99dded8f53" offset="0" />
+			</dataarea>
+		</part>
+		<part name="flop2" interface="floppy_3">
+			<feature name="part_id" value="Side B"/>
+			<dataarea name="flop" size="194816">
+				<rom name="thomas the tank engine's fun with words (1990)(friendly learning)(side b).dsk" size="194816" crc="e7eec040" sha1="bb86b1107ebfdf69d0938a70547c05f31f57bf91" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Educational - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="wordpowe">
+		<description>Word Power</description>
+		<year>1983</year>
+		<publisher>Sulis</publisher>
+		<part name="flop1" interface="floppy_3">
+			<dataarea name="flop" size="194816">
+				<rom name="word power (1983)(sulis).dsk" size="194816" crc="29f22d7d" sha1="858527f3df5c6bfd3841b1c47f2cf1edfef90280" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Educational - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="wordspic">
+		<description>Words and Pictures</description>
+		<year>1984</year>
+		<publisher>Chalksoft</publisher>
+		<part name="flop1" interface="floppy_3">
+			<dataarea name="flop" size="194816">
+				<rom name="words and pictures (1984)(chalksoft).dsk" size="194816" crc="055d76fa" sha1="1f07c6324f8593a2fb22090c3d93def221331cea" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="3dgrandpmd">
+		<description>3D Grand Prix (master disk)</description>
+		<year>1991</year>
+		<publisher>Zeppelin Games</publisher>
+		<part name="flop1" interface="floppy_3">
+			<dataarea name="flop" size="194816">
+				<rom name="3d grand prix (1991)(zeppelin games)(side a)[aka grand prix championship][master disk].dsk" size="194816" crc="54a0ded1" sha1="10a2e3500752544bacbf654cf3744af5d2cbf6b2" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="ace2">
+		<description>ACE 2 - The Ultimate Head to Head Conflict</description>
+		<year>1987</year>
+		<publisher>Cascade Games</publisher>
+		<part name="flop1" interface="floppy_3">
+			<dataarea name="flop" size="194816">
+				<rom name="ace 2 - the ultimate head to head conflict (1987)(cascade games).dsk" size="194816" crc="40b617e6" sha1="e32a487c7367913fdd7ab89da08ce742a830e960" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="apb">
+		<description>APB - All Points Bulletin</description>
+		<year>1989</year>
+		<publisher>Domark</publisher>
+		<part name="flop1" interface="floppy_3">
+			<dataarea name="flop" size="190208">
+				<rom name="apb (1989)(domark)[aka all points bulletin].dsk" size="190208" crc="595363f9" sha1="58df342adf1e4a67304cfc5c0194b194c17dad5f" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="atf">
+		<description>ATF - Advanced Tactical Fighter</description>
+		<year>1988</year>
+		<publisher>Digital Integration</publisher>
+		<part name="flop1" interface="floppy_3">
+			<dataarea name="flop" size="102400">
+				<rom name="atf (1988)(digital integration)[aka advanced tactical fighter].dsk" size="102400" crc="ee8aad31" sha1="05f77ee7281f667ec1f92ecb7a1af6552c9431ae" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="atfsp" cloneof="atf">
+		<description>ATF - Advanced Tactical Fighter (Spain)</description>
+		<year>1988</year>
+		<publisher>Zafiro Software Division</publisher>
+		<part name="flop1" interface="floppy_3">
+			<dataarea name="flop" size="102400">
+				<rom name="atf (1988)(zafiro software division)(es)(en)[re-release].dsk" size="102400" crc="59320d5c" sha1="d6d94e6e54c28bf1393eba6e1a5ac4cd1d173fe9" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="abadcrim">
+		<description>La Abadia del Crimen</description>
+		<year>1988</year>
+		<publisher>MCM</publisher>
+		<part name="flop1" interface="floppy_3">
+			<dataarea name="flop" size="191744">
+				<rom name="abadia del crimen, la (1988)(mcm)(es)[re-release].dsk" size="191744" crc="1052ece9" sha1="d94b16011f80428d49edb0af7dec4d73e13021f2" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="afighter">
+		<description>Action Fighter</description>
+		<year>1989</year>
+		<publisher>Firebird</publisher>
+		<part name="flop1" interface="floppy_3">
+			<dataarea name="flop" size="194816">
+				<rom name="action fighter (1989)(firebird).dsk" size="194816" crc="2db88300" sha1="f8511df3b99924755ca52ec3f1b0ec175e18b7c4" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<!-- May be the same edition as the IPF -->
+	<software name="aforcea" cloneof="aforce">
+		<description>Action Force - International Heroes (alt)</description>
+		<year>1987</year>
+		<publisher>Virgin Games</publisher>
+		<part name="flop1" interface="floppy_3">
+			<dataarea name="flop" size="194560">
+				<rom name="action force - international heroes (1987)(virgin games).dsk" size="194560" crc="2c5f41d4" sha1="edb1ae391d64f330cabe4e50b0066c801bc54cc1" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<!-- May be the same edition as the IPF -->
+	<software name="aforce2a" cloneof="aforce2">
+		<description>Action Force II - International Heroes (alt)</description>
+		<year>1988</year>
+		<publisher>Virgin Games</publisher>
+		<part name="flop1" interface="floppy_3">
+			<dataarea name="flop" size="214272">
+				<rom name="action force ii - international heroes (1988)(virgin games).dsk" size="214272" crc="ea3f2c0d" sha1="63eb5e445a2029e238b08a63ba17b476a27d4d23" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="tiebreaksp" cloneof="tiebreak">
+		<description>Adidas Championship Tie-Break (Spain)</description>
+		<year>1990</year>
+		<publisher>Erbe</publisher>
+		<part name="flop1" interface="floppy_3">
+			<dataarea name="flop" size="73216">
+				<rom name="adidas championship tie-break (1990)(erbe)(es)(en)[re-release].dsk" size="73216" crc="dd6cd54d" sha1="bd915b96fe9fa36c17c3f92f2bbc954720567867" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<!-- May be the same edition as the IPF -->
+	<software name="tiebreaka" cloneof="tiebreak">
+		<description>Adidas Championship Tie-Break (alt)</description>
+		<year>1990</year>
+		<publisher>Ocean</publisher>
+		<part name="flop1" interface="floppy_3">
+			<dataarea name="flop" size="196352">
+				<rom name="adidas championship tie-break (1990)(ocean).dsk" size="196352" crc="c5a7238c" sha1="815ca74726a688d0878303bfd7558b5f82c17388" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="afterwar">
+		<description>After the War</description>
+		<year>1989</year>
+		<publisher>Dinamic</publisher>
+		<part name="flop1" interface="floppy_3">
+			<dataarea name="flop" size="118016">
+				<rom name="after the war (1989)(dinamic)(es)(en).dsk" size="118016" crc="cb90314d" sha1="970d0ef6ec0223be59b46298e91be212bdeceda1" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="afterwarsp" cloneof="afterwar">
+		<description>After the War (Spain)</description>
+		<year>1989</year>
+		<publisher>Dinamic</publisher>
+		<part name="flop1" interface="floppy_3">
+			<dataarea name="flop" size="166400">
+				<rom name="after the war (1989)(dinamic)(es).dsk" size="166400" crc="3dabca4d" sha1="202216a662531fa8c5fba654aac78d91c6db0f4c" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="aburner">
+		<description>Afterburner</description>
+		<year>1988</year>
+		<publisher>Activision</publisher>
+		<part name="flop1" interface="floppy_3">
+			<feature name="part_id" value="Side A"/>
+			<dataarea name="flop" size="214784">
+				<rom name="afterburner (1988)(activision)(side a).dsk" size="214784" crc="ceaebfa1" sha1="fc65a2a8a7c7e77ddcf28554e8f8ae08057bd1e5" offset="0" />
+			</dataarea>
+		</part>
+		<part name="flop2" interface="floppy_3">
+			<feature name="part_id" value="Side B"/>
+			<dataarea name="flop" size="214784">
+				<rom name="afterburner (1988)(activision)(side b).dsk" size="214784" crc="d3330013" sha1="8348adc6e09bc227ab85ae032d6f9d8f968e1310" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="aburnera" cloneof="aburner">
+		<description>Afterburner (alt)</description>
+		<year>1988</year>
+		<publisher>Activision</publisher>
+		<part name="flop1" interface="floppy_3">
+			<feature name="part_id" value="Side A"/>
+			<dataarea name="flop" size="214784">
+				<rom name="afterburner (1988)(activision)(side a)[a].dsk" size="214784" crc="e3388dc3" sha1="6a96ed52748275d3b8c8a6ec105b7f97733228a9" offset="0" />
+			</dataarea>
+		</part>
+		<part name="flop2" interface="floppy_3">
+			<feature name="part_id" value="Side B"/>
+		<!-- Side missing from dump, using same as parent set -->
+			<dataarea name="flop" size="214784">
+				<rom name="afterburner (1988)(activision)(side b).dsk" size="214784" crc="d3330013" sha1="8348adc6e09bc227ab85ae032d6f9d8f968e1310" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="agathafo">
+		<description>Agatha's Folly</description>
+		<year>1989</year>
+		<publisher>Zenobi</publisher>
+		<part name="flop1" interface="floppy_3">
+			<feature name="part_id" value="Side A"/>
+			<dataarea name="flop" size="194816">
+				<rom name="agatha's folly (1989)(zenobi)(side a).dsk" size="194816" crc="d569dc69" sha1="93518c5dc62b9e60d39c39b55c0d935c03eedb34" offset="0" />
+			</dataarea>
+		</part>
+		<part name="flop2" interface="floppy_3">
+			<feature name="part_id" value="Side B"/>
+			<dataarea name="flop" size="194816">
+				<rom name="agatha's folly (1989)(zenobi)(side b).dsk" size="194816" crc="513d78d3" sha1="0c7a88208c15ceb6b33abc8a2e8b193e593a1fb5" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="agathafoa" cloneof="agathafo">
+		<description>Agatha's Folly (alt)</description>
+		<year>1989</year>
+		<publisher>Zenobi</publisher>
+		<part name="flop1" interface="floppy_3">
+			<dataarea name="flop" size="194816">
+				<rom name="agatha's folly (1989)(zenobi).dsk" size="194816" crc="6ac0d7e5" sha1="d8e2f4cc3c49087c14dd9b73996d17a2186f45fd" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="airbrang">
+		<description>Airborne Ranger</description>
+		<year>1988</year>
+		<publisher>MicroProse</publisher>
+		<part name="flop1" interface="floppy_3">
+			<feature name="part_id" value="Side A"/>
+			<dataarea name="flop" size="209152">
+				<rom name="airborne ranger (1988)(microprose)(side a).dsk" size="209152" crc="caee7972" sha1="6cc64601dadb692b6c7ee1ae115345f1bca748a9" offset="0" />
+			</dataarea>
+		</part>
+		<part name="flop2" interface="floppy_3">
+			<feature name="part_id" value="Side B"/>
+			<dataarea name="flop" size="194816">
+				<rom name="airborne ranger (1988)(microprose)(side b).dsk" size="194816" crc="17331dce" sha1="ece46c1567a8e37bc46bd61f8c772effa00243bb" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="alienres">
+		<description>Alien Research Centre</description>
+		<year>1990</year>
+		<publisher>Zenobi</publisher>
+		<part name="flop1" interface="floppy_3">
+			<dataarea name="flop" size="194816">
+				<rom name="alien research centre (1990)(zenobi).dsk" size="194816" crc="db2bc7a4" sha1="4c9aade94605af27eb7d50a82a00bc1053ce87b8" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="astormsp" cloneof="astorm">
+		<description>Alien Storm (Spain)</description>
+		<year>1991</year>
+		<publisher>Erbe</publisher>
+		<part name="flop1" interface="floppy_3">
+			<dataarea name="flop" size="255232">
+				<rom name="alien storm (1991)(erbe)(es)(en)[re-release].dsk" size="255232" crc="deea5c29" sha1="fce55879436faff99fb58de3bdc3b52ee7e15e17" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="astorm">
+		<description>Alien Storm</description>
+		<year>1991</year>
+		<publisher>U.S. Gold</publisher>
+		<part name="flop1" interface="floppy_3">
+			<dataarea name="flop" size="389376">
+				<rom name="alien storm (1991)(u.s. gold).dsk" size="389376" crc="7bbc42ae" sha1="13c74820255ea1e7797d90208d1e4db8e610c303" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="aliensyn">
+		<description>Alien Syndrome</description>
+		<year>1988</year>
+		<publisher>ACE</publisher>
+		<part name="flop1" interface="floppy_3">
+			<dataarea name="flop" size="194816">
+				<rom name="alien syndrome (1988)(ace).dsk" size="194816" crc="f7cb4c52" sha1="6aa692ebce02b84c803debeb610f4eb0d313707d" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="aliensynsp" cloneof="aliensyn">
+		<description>Alien Syndrome (Spain)</description>
+		<year>1988</year>
+		<publisher>Dro Soft</publisher>
+		<part name="flop1" interface="floppy_3">
+			<dataarea name="flop" size="194816">
+				<rom name="alien syndrome (1988)(dro soft)(es)(en)[re-release].dsk" size="194816" crc="e2c722af" sha1="c76e486de716cabe52a968df6913001df479511a" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="allinada">
+		<description>All in a Day's Work</description>
+		<year>1996</year>
+		<publisher>Zenobi</publisher>
+		<part name="flop1" interface="floppy_3">
+			<feature name="part_id" value="Side A"/>
+			<dataarea name="flop" size="194816">
+				<rom name="all in a day's work (1996)(zenobi)(side a).dsk" size="194816" crc="fc9fdcc7" sha1="9b616bb325491c4466125b85c328bba856c30481" offset="0" />
+			</dataarea>
+		</part>
+		<part name="flop2" interface="floppy_3">
+			<feature name="part_id" value="Side B"/>
+			<dataarea name="flop" size="194816">
+				<rom name="all in a day's work (1996)(zenobi)(side b).dsk" size="194816" crc="de25e5f7" sha1="fd993d7f673d797b0a6fe1b7d0d08f18dc29f6c4" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="amerbsktmd">
+		<description>All-American Basketball (master disk)</description>
+		<year>1992</year>
+		<publisher>Zeppelin Games</publisher>
+		<part name="flop1" interface="floppy_3">
+			<feature name="part_id" value="Side A"/>
+			<dataarea name="flop" size="194816">
+				<rom name="all-american basketball (1992)(zeppelin games)(side a)[master disk].dsk" size="194816" crc="1b9bd910" sha1="7502f8042d64ca8a045c2bdbb7ddbed976839b9e" offset="0" />
+			</dataarea>
+		</part>
+		<part name="flop2" interface="floppy_3">
+			<feature name="part_id" value="Side B"/>
+			<dataarea name="flop" size="194816">
+				<rom name="all-american basketball (1992)(zeppelin games)(side b)[master disk].dsk" size="194816" crc="a5c993ed" sha1="5b2d23073972b992cecd65b0044d954b6e905426" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="spmandoom">
+		<description>The Amazing Spider-Man and Captain America in Dr. Doom's Revenge</description>
+		<year>1989</year>
+		<publisher>Empire</publisher>
+		<part name="flop1" interface="floppy_3">
+			<dataarea name="flop" size="194816">
+				<rom name="amazing spider-man and captain america in dr. doom's revenge, the (1989)(empire).dsk" size="194816" crc="ad142fd9" sha1="a7fa82a92bf1db333065c0a74115c5990033e6d8" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="am3dpoolmd">
+		<description>American 3D Pool (master disk)</description>
+		<year>1992</year>
+		<publisher>Zeppelin Games</publisher>
+		<part name="flop1" interface="floppy_3">
+			<feature name="part_id" value="Side A"/>
+			<dataarea name="flop" size="194816">
+				<rom name="american 3d pool (1992)(zeppelin games)(side a)[master disk].dsk" size="194816" crc="3133c3a7" sha1="88d7dc1629b19213ad5013cece5d7914da260399" offset="0" />
+			</dataarea>
+		</part>
+		<part name="flop2" interface="floppy_3">
+			<feature name="part_id" value="Side B"/>
+			<dataarea name="flop" size="194816">
+				<rom name="american 3d pool (1992)(zeppelin games)(side b)[master disk].dsk" size="194816" crc="9e62a21c" sha1="2d6d741dfcf6c914fa153f49a0febf824d7cabd0" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="amnes102sp" cloneof="amnes102">
+		<description>Amnesia v1.02 (Spanish)</description>
+		<year>2015</year>
+		<publisher>Huelvy</publisher>
+		<part name="flop1" interface="floppy_3">
+			<dataarea name="flop" size="194816">
+				<rom name="amnesia v1.02 (2015-12-05)(huelvy)(es).dsk" size="194816" crc="6c797654" sha1="77462f3706073c6a46db1d09c8bbb299e0cda3d8" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="amnes102">
+		<description>Amnesia v1.02</description>
+		<year>2015</year>
+		<publisher>Huelvy</publisher>
+		<part name="flop1" interface="floppy_3">
+			<dataarea name="flop" size="194816">
+				<rom name="amnesia v1.02 (2015-12-05)(huelvy).dsk" size="194816" crc="3207f613" sha1="ca4465100649b6210566ec07dbccc6d5bd45be90" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="amotospu">
+		<description>Amoto's Puf</description>
+		<year>1988</year>
+		<publisher>SPE</publisher>
+		<part name="flop1" interface="floppy_3">
+			<dataarea name="flop" size="194816">
+				<rom name="amoto's puf (1988)(spe)(es).dsk" size="194816" crc="ea11bf11" sha1="3399583f7a9bd712e9aa1a7c6ac83e79112289d4" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="amuldara">
+		<description>The Amulet of Darath</description>
+		<year>1992</year>
+		<publisher>Zenobi</publisher>
+		<part name="flop1" interface="floppy_3">
+			<dataarea name="flop" size="194816">
+				<rom name="amulet of darath, the (1992)(zenobi).dsk" size="194816" crc="6c2d3b50" sha1="6fe5169df72e34a41e0ea557ae1c85540a4b8600" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="apprenti">
+		<description>The Apprentice</description>
+		<year>1993</year>
+		<publisher>Zenobi</publisher>
+		<part name="flop1" interface="floppy_3">
+			<dataarea name="flop" size="194816">
+				<rom name="apprentice, the (1993)(zenobi).dsk" size="194816" crc="86e40adc" sha1="f8b6f9a8fb83c9e004aeb9e84dd7989323adb2cb" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="april7th">
+		<description>April 7th</description>
+		<year>1992</year>
+		<publisher>Zenobi</publisher>
+		<part name="flop1" interface="floppy_3">
+			<dataarea name="flop" size="194816">
+				<rom name="april 7th (1992)(zenobi).dsk" size="194816" crc="f2ee2bd1" sha1="501de56a06afc02e13623eab143664754acd9248" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="aplj1311" cloneof="aplj1312">
+		<description>Apulija 13 V1.1</description>
+		<year>2013</year>
+		<publisher>Alessandro Grussu</publisher>
+		<part name="flop1" interface="floppy_3">
+			<dataarea name="flop" size="194816">
+				<rom name="apulija 13 v1.1 (2013)(grussu, alessandro)(it)(m4).dsk" size="194816" crc="5db02461" sha1="1a7474e0bab3c271318edd6b8e4d0544a3962b35" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="aplj1312">
+		<description>Apulija 13 v1.2</description>
+		<year>2013</year>
+		<publisher>Alessandro Grussu</publisher>
+		<part name="flop1" interface="floppy_3">
+			<dataarea name="flop" size="194816">
+				<rom name="apulija 13 v1.2 (2013-09-24)(grussu, alessandro)(it)(m4).dsk" size="194816" crc="c0eee6bf" sha1="d12e8fe086625a3aab7757fc35ea21b8768c92c6" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="arctcfox">
+		<description>Arctic Fox</description>
+		<year>1988</year>
+		<publisher>Electronic Arts</publisher>
+		<part name="flop1" interface="floppy_3">
+			<dataarea name="flop" size="195840">
+				<rom name="arctic fox (1988)(electronic arts).dsk" size="195840" crc="b1d9a818" sha1="cdcdacb38e26b94782cba0efb5371062ee5b08d3" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="arkanoi2">
+		<description>Arkanoid - Revenge of Doh</description>
+		<year>1988</year>
+		<publisher>Imagine</publisher>
+		<part name="flop1" interface="floppy_3">
+			<dataarea name="flop" size="214784">
+				<rom name="arkanoid - revenge of doh (1988)(imagine)[aka arkanoid 2].dsk" size="214784" crc="e5dafb18" sha1="9e3d9552dd438d3a224ea19fc5e19730e1738bef" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="arntadv3">
+		<description>Arnold the Adventurer III - This Time It's Personal</description>
+		<year>1992</year>
+		<publisher>Zenobi</publisher>
+		<part name="flop1" interface="floppy_3">
+			<dataarea name="flop" size="194816">
+				<rom name="arnold the adventurer iii - this time it's personal (1992)(zenobi).dsk" size="194816" crc="c5159e2b" sha1="f1916459527b2f153849d05624cad97c3dd650f4" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<!-- May be the same edition as the IPF -->
+	<software name="arturaa" cloneof="artura">
+		<description>Artura (alt)</description>
+		<year>1989</year>
+		<publisher>Gremlin Graphics</publisher>
+		<part name="flop1" interface="floppy_3">
+			<feature name="part_id" value="Side A"/>
+			<dataarea name="flop" size="194816">
+				<rom name="artura (1989)(gremlin graphics)(side a).dsk" size="194816" crc="a60019cb" sha1="3303b24cc705b4b6051223d653288ef115d90b2d" offset="0" />
+			</dataarea>
+		</part>
+		<part name="flop2" interface="floppy_3">
+			<feature name="part_id" value="Side B"/>
+			<dataarea name="flop" size="194816">
+				<rom name="artura (1989)(gremlin graphics)(side b).dsk" size="194816" crc="9e8f9c27" sha1="4e2b395bbaf8e08341f515cdfc5744931d72872b" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="asalycas">
+		<description>Asalto y Castigo</description>
+		<year>2009</year>
+		<publisher>&lt;homebrew&gt;</publisher>
+		<info name="author" value="Jose Baltasar Garcia Perez-Schofield"/>
+		<part name="flop1" interface="floppy_3">
+			<dataarea name="flop" size="194816">
+				<rom name="asalto y castigo (2009)(perez-schofield, jose baltasar garcia)(es).dsk" size="194816" crc="2942f741" sha1="09332e67e9d646e39409985443055dd56aa42acc" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="aspargpm">
+		<description>Aspar GP Master</description>
+		<year>1988</year>
+		<publisher>Dinamic</publisher>
+		<part name="flop1" interface="floppy_3">
+			<feature name="part_id" value="Side A"/>
+			<dataarea name="flop" size="58880">
+				<rom name="aspar gp master (1988)(dinamic)(es)(side a).dsk" size="58880" crc="c583f871" sha1="1b94e7d003a6b243eaf0ddaa05fb7189025ddce3" offset="0" />
+			</dataarea>
+		</part>
+		<part name="flop2" interface="floppy_3">
+			<feature name="part_id" value="Side B"/>
+			<dataarea name="flop" size="80384">
+				<rom name="aspar gp master (1988)(dinamic)(es)(en)(side b).dsk" size="80384" crc="300e8562" sha1="3db8311950a6db82494c7ccfbc3605d5dc4c92a0" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="aspargpmsp" cloneof="aspargpm">
+		<description>Aspar GP Master (alt)</description>
+		<year>1988</year>
+		<publisher>Dinamic</publisher>
+		<part name="flop1" interface="floppy_3">
+			<dataarea name="flop" size="58880">
+				<rom name="aspar gp master (1988)(dinamic)(es).dsk" size="58880" crc="8c452eea" sha1="1618afa3986147ee842af394198ea662de76f6a9" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="amc">
+		<description>Astro Marine Corps</description>
+		<year>1989</year>
+		<publisher>Dinamic</publisher>
+		<part name="flop1" interface="floppy_3">
+			<dataarea name="flop" size="128768">
+				<rom name="astro marine corps (1989)(dinamic)(es)[aka amc].dsk" size="128768" crc="49da31a0" sha1="045a8026457cebe101fa76c856654812e4830c3f" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="aurascop">
+		<description>Aura-Scope</description>
+		<year>1991</year>
+		<publisher>Zenobi</publisher>
+		<part name="flop1" interface="floppy_3">
+			<dataarea name="flop" size="194816">
+				<rom name="aura-scope (1991)(zenobi)[aka horrorscope][re-release].dsk" size="194816" crc="06e2ce3b" sha1="4da4ad217593a8e6301bc2800a2a836bd7417ea1" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="autocras">
+		<description>Autocrash</description>
+		<year>1991</year>
+		<publisher>Zigurat</publisher>
+		<part name="flop1" interface="floppy_3">
+			<dataarea name="flop" size="63488">
+				<rom name="autocrash (1991)(zigurat)(es).dsk" size="63488" crc="9d26fed0" sha1="1aea386a6243646e3dfce6bce6d013e6e86a6ca3" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="aventesp">
+		<description>La Aventura Espacial</description>
+		<year>1990</year>
+		<publisher>Aventuras AD</publisher>
+		<part name="flop1" interface="floppy_3">
+			<dataarea name="flop" size="102400">
+				<rom name="aventura espacial, la (1990)(aventuras ad)(es).dsk" size="102400" crc="a0609dc1" sha1="e8f20ca45e3393233578cfd8abc2a038aab608cd" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="aventori">
+		<description>La Aventura Original</description>
+		<year>1989</year>
+		<publisher>Aventuras AD</publisher>
+		<part name="flop1" interface="floppy_3">
+			<dataarea name="flop" size="206080">
+				<rom name="aventura original, la (1989)(aventuras ad)(es).dsk" size="206080" crc="4c67d329" sha1="b76701e9a6d99195e866e3dd902be37f0aca45b0" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="pepetrue">
+		<description>Las Aventuras de Pepe Trueno</description>
+		<year>2003</year>
+		<publisher>&lt;homebrew&gt;</publisher>
+		<info name="author" value="Rockersuke Moroboshi"/>
+		<part name="flop1" interface="floppy_3">
+			<dataarea name="flop" size="194816">
+				<rom name="aventuras de pepe trueno, las (2003)(rockersuke moroboshi)(es).dsk" size="194816" crc="4d7ef85e" sha1="cd00274300da42b59e076edda185ad15f4cd1725" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="axeofkol">
+		<description>The Axe of Kolt</description>
+		<year>1990</year>
+		<publisher>FSF Adventures</publisher>
+		<part name="flop1" interface="floppy_3">
+			<feature name="part_id" value="Side A"/>
+			<dataarea name="flop" size="194816">
+				<rom name="axe of kolt, the (1990)(fsf adventures)(side a).dsk" size="194816" crc="cb7846ad" sha1="df43b9c0d8461f3e44c04a716b222e72db2a6d35" offset="0" />
+			</dataarea>
+		</part>
+		<part name="flop2" interface="floppy_3">
+			<feature name="part_id" value="Side B"/>
+			<dataarea name="flop" size="194816">
+				<rom name="axe of kolt, the (1990)(fsf adventures)(side b).dsk" size="194816" crc="52a2a8e1" sha1="72ee7458dd51806f3f8737f28f75c1163c6d8963" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="aztcaslt">
+		<description>Aztec Assault</description>
+		<year>1992</year>
+		<publisher>Zenobi</publisher>
+		<part name="flop1" interface="floppy_3">
+			<dataarea name="flop" size="194816">
+				<rom name="aztec assault (1992)(zenobi).dsk" size="194816" crc="9c23191d" sha1="d6ae6a418a37a5467e2c3ff969f5e1aeeb2e6a61" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="bttf2">
+		<description>Back to the Future Part II</description>
+		<year>1990</year>
+		<publisher>Image Works</publisher>
+		<part name="flop1" interface="floppy_3">
+			<feature name="part_id" value="Side A"/>
+			<dataarea name="flop" size="216320">
+				<rom name="back to the future part ii (1990)(image works)(side a).dsk" size="216320" crc="30c20cf0" sha1="ae22c8cd1fc94577bd45cf3a5d6075dce517ab03" offset="0" />
+			</dataarea>
+		</part>
+		<part name="flop2" interface="floppy_3">
+			<feature name="part_id" value="Side B"/>
+			<dataarea name="flop" size="194816">
+				<rom name="back to the future part ii (1990)(image works)(side b).dsk" size="194816" crc="ae0bffe4" sha1="05b70832fc272183a6ffac24a3bb9307b85a2b5d" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="bttf3">
+		<description>Back to the Future Part III</description>
+		<year>1991</year>
+		<publisher>Image Works</publisher>
+		<part name="flop1" interface="floppy_3">
+			<feature name="part_id" value="Side A"/>
+			<dataarea name="flop" size="196352">
+				<rom name="back to the future part iii (1991)(image works)(side a).dsk" size="196352" crc="3913c988" sha1="919d098cf7be3d0513baf53231b39b9d4867eaa2" offset="0" />
+			</dataarea>
+		</part>
+		<part name="flop2" interface="floppy_3">
+			<feature name="part_id" value="Side B"/>
+			<dataarea name="flop" size="194816">
+				<rom name="back to the future part iii (1991)(image works)(side b).dsk" size="194816" crc="1dd2ad6a" sha1="8e707432b2a6e7d0b10a7ef73f5bc5fd9da62857" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="bttf3a" cloneof="bttf3">
+		<description>Back to the Future Part III (alt)</description>
+		<year>1991</year>
+		<publisher>Image Works</publisher>
+		<part name="flop1" interface="floppy_3">
+			<dataarea name="flop" size="389376">
+				<rom name="back to the future part iii (1991)(image works)[aka back to the future iii].dsk" size="389376" crc="9fe3c153" sha1="fed66130a1b7d6a9abf808e2d50610f2006de42d" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="baddudes">
+		<description>Bad Dudes vs. Dragon Ninja</description>
+		<year>1988</year>
+		<publisher>Imagine</publisher>
+		<part name="flop1" interface="floppy_3">
+			<dataarea name="flop" size="144896">
+				<rom name="bad dudes vs. dragon ninja (1988)(imagine).dsk" size="144896" crc="62c50d95" sha1="bc00cd74d7ef98d43ca9bfafe4edbea825d30c0c" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<!-- May be the same edition as the IPF -->
+	<software name="badlands" cloneof="badlands">
+		<description>Badlands (alt)</description>
+		<year>1990</year>
+		<publisher>Domark</publisher>
+		<part name="flop1" interface="floppy_3">
+			<dataarea name="flop" size="194816">
+				<rom name="badlands (1990)(domark).dsk" size="194816" crc="51be78e0" sha1="64dcfb8260630b878ae0778a29d4008d107e806d" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="balrgcat">
+		<description>The Balrog and the Cat</description>
+		<year>1988</year>
+		<publisher>Zenobi</publisher>
+		<part name="flop1" interface="floppy_3">
+			<dataarea name="flop" size="194816">
+				<rom name="balrog and the cat, the (1988)(zenobi).dsk" size="194816" crc="646814a2" sha1="3548ee10ccc4a77ebc96b5b79c037aac85d475ce" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="barbaria">
+		<description>Barbarian</description>
+		<year>1988</year>
+		<publisher>Dro Soft</publisher>
+		<part name="flop1" interface="floppy_3">
+			<dataarea name="flop" size="63488">
+				<rom name="barbarian (1988)(dro soft)(es)(en)[re-release].dsk" size="63488" crc="d72642e4" sha1="56f2bc58e03a34b0d3098c06c7e52be64342e3c1" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="barbari2sp" cloneof="barbari2">
+		<description>Barbarian II - The Dungeon of Drax (Spain)</description>
+		<year>1988</year>
+		<publisher>Erbe</publisher>
+		<part name="flop1" interface="floppy_3">
+			<dataarea name="flop" size="144384">
+				<rom name="barbarian ii - the dungeon of drax (1988)(erbe)(es)(en)[re-release].dsk" size="144384" crc="8ba96bd6" sha1="aed9c7159d67af12e649f6a4b7f69c767ed38f94" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="barbari2">
+		<description>Barbarian II - The Dungeon of Drax</description>
+		<year>1988</year>
+		<publisher>Palace</publisher>
+		<part name="flop1" interface="floppy_3">
+			<dataarea name="flop" size="254720">
+				<rom name="barbarian ii - the dungeon of drax (1988)(palace).dsk" size="254720" crc="c34122e2" sha1="85aaa95586f4c72940dcbb4c172344a5cf65347c" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="barbari2a" cloneof="barbari2">
+		<description>Barbarian II - The Dungeon of Drax (alt)</description>
+		<year>1988</year>
+		<publisher>Palace</publisher>
+		<part name="flop1" interface="floppy_3">
+			<dataarea name="flop" size="144384">
+				<rom name="barbarian ii - the dungeon of drax (1988)(palace)[a].dsk" size="144384" crc="7f0aecdc" sha1="960844cba76d42f6ff1a37ecbb1a2cce8568368f" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="bardsta1">
+		<description>The Bard's Tale Vol 1 - Tales of the Unknown</description>
+		<year>1988</year>
+		<publisher>Electronic Arts</publisher>
+		<part name="flop1" interface="floppy_3">
+			<feature name="part_id" value="Side A"/>
+			<dataarea name="flop" size="194816">
+				<rom name="bard's tale vol 1, the - tales of the unknown (1988)(electronic arts)(side a).dsk" size="194816" crc="378a5215" sha1="8e3bd21491ca201fdcb71fcadd561ce3aa529a53" offset="0" />
+			</dataarea>
+		</part>
+		<part name="flop2" interface="floppy_3">
+			<feature name="part_id" value="Side B"/>
+			<dataarea name="flop" size="194816">
+				<rom name="bard's tale vol 1, the - tales of the unknown (1988)(electronic arts)(side b).dsk" size="194816" crc="c2ae64e9" sha1="b031822fd972de13a72cdea0fe77a327d388ed44" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="bardrite">
+		<description>The Bardic Rites</description>
+		<year>1994</year>
+		<publisher>Zenobi</publisher>
+		<part name="flop1" interface="floppy_3">
+			<dataarea name="flop" size="194816">
+				<rom name="bardic rites, the (1994)(zenobi).dsk" size="194816" crc="99c8df43" sha1="627fd79979146655854164c8b20165ef9f2045aa" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="batmancc">
+		<description>Batman - The Caped Crusader</description>
+		<year>1988</year>
+		<publisher>Ocean</publisher>
+		<part name="flop1" interface="floppy_3">
+			<dataarea name="flop" size="123392">
+				<rom name="batman - the caped crusader (1988)(ocean).dsk" size="123392" crc="91bfb255" sha1="004538f2c6b9258c301a5c232075d7d762f444a9" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="batmantm">
+		<description>Batman - The Movie</description>
+		<year>1989</year>
+		<publisher>Ocean</publisher>
+		<part name="flop1" interface="floppy_3">
+			<dataarea name="flop" size="194816">
+				<rom name="batman - the movie (1989)(ocean).dsk" size="194816" crc="31da53d6" sha1="50a94f8a0261fc4661af6fc791f684ed1737c9ba" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="batmantma" cloneof="batmantm">
+		<description>Batman - The Movie (alt)</description>
+		<year>1989</year>
+		<publisher>Ocean</publisher>
+		<part name="flop1" interface="floppy_3">
+			<dataarea name="flop" size="152576">
+				<rom name="batman - the movie (1989)(ocean)[a].dsk" size="152576" crc="a4db4011" sha1="e56a88a1837d8ad02c64ddd786ff8ece1d064087" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="batmantmb" cloneof="batmantm">
+		<description>Batman - The Movie (alt 2)</description>
+		<year>1989</year>
+		<publisher>Ocean</publisher>
+		<part name="flop1" interface="floppy_3">
+			<dataarea name="flop" size="194816">
+				<rom name="batman - the movie (1989)(ocean)[a2].dsk" size="194816" crc="111bd6db" sha1="2920d5ea39b487bd1c8713cf8117752ecc7a12a3" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="batmantmspa" cloneof="batmantm">
+		<description>Batman - The Movie (Spain) (alt)</description>
+		<year>1989</year>
+		<publisher>Erbe</publisher>
+		<part name="flop1" interface="floppy_3">
+			<dataarea name="flop" size="185088">
+				<rom name="batman - the movie (1989)(erbe)(es)(en)[a][re-release].dsk" size="185088" crc="d07587bc" sha1="94918c10f53710577cc86c3e3b89b37fec6577f9" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="batmantmsp" cloneof="batmantm">
+		<description>Batman - The Movie (Spain)</description>
+		<year>1989</year>
+		<publisher>Erbe</publisher>
+		<part name="flop1" interface="floppy_3">
+			<dataarea name="flop" size="185088">
+				<rom name="batman - the movie (1989)(erbe)(es)(en)[re-release].dsk" size="185088" crc="42936386" sha1="75b4ea3e5659f5d39b115abf795ff8175dc0ae06" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="beachvol">
+		<description>Beach Volley</description>
+		<year>1989</year>
+		<publisher>Erbe</publisher>
+		<part name="flop1" interface="floppy_3">
+			<dataarea name="flop" size="97536">
+				<rom name="beach volley (1989)(erbe)(es)(en)[re-release].dsk" size="97536" crc="f8c13542" sha1="93673eaec3f66e8e14461e94d55cbb69b944f171" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="thebeast">
+		<description>The Beast</description>
+		<year>1988</year>
+		<publisher>Zenobi</publisher>
+		<part name="flop1" interface="floppy_3">
+			<dataarea name="flop" size="194816">
+				<rom name="beast, the (1988)(zenobi)[re-release].dsk" size="194816" crc="33cc73f0" sha1="747f285b901f388aed5dd547cf5cc2740833d50b" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="bedlamsp" cloneof="bedlam">
+		<description>Bedlam (Spain)</description>
+		<year>1988</year>
+		<publisher>Erbe</publisher>
+		<part name="flop1" interface="floppy_3">
+			<dataarea name="flop" size="194816">
+				<rom name="bedlam (1988)(erbe)(es)(en)[re-release].dsk" size="194816" crc="4f8f724b" sha1="c93e9de8363fbd4b48c9aa23095af34b4e42a940" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="bedlam">
+		<description>Bedlam</description>
+		<year>1988</year>
+		<publisher>Go</publisher>
+		<part name="flop1" interface="floppy_3">
+			<dataarea name="flop" size="194816">
+				<rom name="bedlam (1988)(go).dsk" size="194816" crc="a69e1974" sha1="be74fdc1b70756e405bfc53cf54ee7c790e96e36" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="begotend">
+		<description>The Beginning of the End</description>
+		<year>1992</year>
+		<publisher>Zenobi</publisher>
+		<part name="flop1" interface="floppy_3">
+			<dataarea name="flop" size="194816">
+				<rom name="beginning of the end, the (1992)(zenobi).dsk" size="194816" crc="d7513346" sha1="61c9b420a52fa920374b9f2ac7b326ed6bc1c8ed" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="behclod4">
+		<description>Behind Closed Doors 4 - Balrog's Day Out</description>
+		<year>1989</year>
+		<publisher>Zenobi</publisher>
+		<part name="flop1" interface="floppy_3">
+			<dataarea name="flop" size="194816">
+				<rom name="behind closed doors 4 - balrog's day out (1989)(zenobi).dsk" size="194816" crc="dc5066f6" sha1="500d838a4327e72ef829c31b31fedb755cba4a5c" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="bermtria">
+		<description>The Bermuda Triangle</description>
+		<year>1991</year>
+		<publisher>Zenobi</publisher>
+		<part name="flop1" interface="floppy_3">
+			<dataarea name="flop" size="194816">
+				<rom name="bermuda triangle, the (1991)(zenobi).dsk" size="194816" crc="1f56095c" sha1="8515f73018bccab506daaae8274ca394eda9c8b5" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="bestialwgs" cloneof="bestialw">
+		<description>Bestial Warrior (Gun Stick)</description>
+		<year>1989</year>
+		<publisher>Dinamic</publisher>
+		<info name="usage" value="Requires Gun Stick light gun"/>
+		<part name="flop1" interface="floppy_3">
+			<dataarea name="flop" size="75008">
+				<rom name="bestial warrior (1989)(dinamic)(es).dsk" size="75008" crc="64a24dbd" sha1="10eada64f580e6c3e08971bd6cc0bd90aaf54ebe" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<!-- According to World of Spectrum, this image came from a dual-system Spectrum/Amstrad release (Side A: Spectrum, Side B: Amstrad) -->
+	<software name="bestialw">
+		<description>Bestial Warrior</description>
+		<year>1989</year>
+		<publisher>Dinamic</publisher>
+		<part name="flop1" interface="floppy_3">
+			<dataarea name="flop" size="80384">
+				<rom name="bestial warrior (1989)(dinamic)(es)[a].dsk" size="80384" crc="208235f6" sha1="50d9a3bb79b82deb6c08253cfbffa460bb8abaa2" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<!-- According to World of Spectrum, this image came from a dual-system Spectrum/Amstrad release (Side A: Spectrum, Side B: Amstrad) -->
+<!--
+	<software name="bestialw">
+		<description>Bestial Warrior (rerelease)</description>
+		<year>1989</year>
+		<publisher>Dinamic</publisher>
+		<part name="flop1" interface="floppy_3">
+			<dataarea name="flop" size="91136">
+				<rom name="bestial warrior (1989)(dinamic)(es)(side b).dsk" size="91136" crc="3fd882c2" sha1="977204c72ef1b1643e33516ffe904b35ad87c826" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+-->
+
+	
+<!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<!-- May be the same edition as the IPF -->
+	<software name="bhcopa" cloneof="bhcop">
+		<description>Beverly Hills Cop (alt)</description>
+		<year>1990</year>
+		<publisher>Tynesoft</publisher>
+		<part name="flop1" interface="floppy_3">
+			<dataarea name="flop" size="194816">
+				<rom name="beverly hills cop (1990)(tynesoft).dsk" size="194816" crc="ad7c72d1" sha1="186496c66a7a9e9cabdf7e5bc76b3183d4a06941" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="bticepal">
+		<description>Beyond the Ice Palace</description>
+		<year>1988</year>
+		<publisher>Elite Systems</publisher>
+		<part name="flop1" interface="floppy_3">
+			<dataarea name="flop" size="214784">
+				<rom name="beyond the ice palace (1988)(elite systems).dsk" size="214784" crc="364b9753" sha1="e8aff84d40510100028fb15de89ab3071036c6f2" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="bticepalsp" cloneof="bticepal">
+		<description>Beyond the Ice Palace (Spain)</description>
+		<year>1988</year>
+		<publisher>MCM</publisher>
+		<part name="flop1" interface="floppy_3">
+			<dataarea name="flop" size="194816">
+				<rom name="beyond the ice palace (1988)(mcm)(es)(en)[re-release].dsk" size="194816" crc="a547670b" sha1="cde06121712e3beeeb1faca842a1731f2dab850b" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="bioninjamd">
+		<description>Bionic Ninja (master disk)</description>
+		<year>1989</year>
+		<publisher>Zeppelin Games</publisher>
+		<part name="flop1" interface="floppy_3">
+			<dataarea name="flop" size="194816">
+				<rom name="bionic ninja (1989)(zeppelin games)(side a)[master disk].dsk" size="194816" crc="99c63497" sha1="b4517e6a2124eb1fc6e5f658c9591ef0b867840f" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="blacklam">
+		<description>Black Lamp</description>
+		<year>1988</year>
+		<publisher>Firebird</publisher>
+		<part name="flop1" interface="floppy_3">
+			<dataarea name="flop" size="78080">
+				<rom name="black lamp (1988)(firebird).dsk" size="78080" crc="e90869b8" sha1="c98bc347c956d2b0ee2542fc07b171237a324ad5" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="blacktwr">
+		<description>The Black Tower</description>
+		<year>1984</year>
+		<publisher>Zenobi</publisher>
+		<part name="flop1" interface="floppy_3">
+			<dataarea name="flop" size="194816">
+				<rom name="black tower, the (1984)(zenobi).dsk" size="194816" crc="d3b64e66" sha1="80f9a5b6eeafcc185019b818ac40e6786f57bef5" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="blstroid">
+		<description>Blasteroids</description>
+		<year>1989</year>
+		<publisher>Image Works</publisher>
+		<part name="flop1" interface="floppy_3">
+			<dataarea name="flop" size="174848">
+				<rom name="blasteroids (1989)(image works).dsk" size="174848" crc="47c49e33" sha1="71ed33708c9bd8481da358e5ee5c62d9f4e901d2" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="blinscarmd">
+		<description>Blinky's Scary School (master disk)</description>
+		<year>1990</year>
+		<publisher>Zeppelin Games</publisher>
+		<part name="flop1" interface="floppy_3">
+			<dataarea name="flop" size="199680">
+				<rom name="blinky's scary school (1990)(zeppelin games)(side a)[master disk].dsk" size="199680" crc="6c13f156" sha1="b58ea972c196119403801ea66b50da8fe2e9be3e" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<!-- May be the same edition as the IPF -->
+	<software name="bloodwyca" cloneof="bloodwyc">
+		<description>Bloodwych (alt)</description>
+		<year>1990</year>
+		<publisher>Image Works</publisher>
+		<part name="flop1" interface="floppy_3">
+			<dataarea name="flop" size="194816">
+				<rom name="bloodwych (1990)(image works).dsk" size="194816" crc="d650514e" sha1="0132b678fd1a1003b90aa613a1d70ac9f87134ce" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<!-- May be the same edition as the IPF -->
+	<software name="boggita" cloneof="boggit">
+		<description>The Boggit - Bored Too (alt)</description>
+		<year>1986</year>
+		<publisher>CRL Group</publisher>
+		<part name="flop1" interface="floppy_3">
+			<dataarea name="flop" size="194816">
+				<rom name="boggit, the - bored too (1986)(crl group).dsk" size="194816" crc="0ada70d5" sha1="fb558e0b129a091fbebf0ee76c96ed37eb061ca6" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="bnzabros">
+		<description>Bonanza Bros.</description>
+		<year>1992</year>
+		<publisher>U.S. Gold</publisher>
+		<part name="flop1" interface="floppy_3">
+			<feature name="part_id" value="Side A"/>
+			<dataarea name="flop" size="255232">
+				<rom name="bonanza bros. (1992)(u.s. gold)(side a).dsk" size="255232" crc="79c23b90" sha1="b3fc3de4e20bcfea9d341896624d2710da06cea5" offset="0" />
+			</dataarea>
+		</part>
+		<part name="flop2" interface="floppy_3">
+			<feature name="part_id" value="Side B"/>
+			<dataarea name="flop" size="255232">
+				<rom name="bonanza bros. (1992)(u.s. gold)(side b).dsk" size="255232" crc="bc619eef" sha1="8596ee563127f2ef5dd047feb482e5b1a5834e97" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<!-- May be the same edition as the IPF -->
+	<software name="bookdeada" cloneof="bookdead">
+		<description>Book of the Dead (alt)</description>
+		<year>1987</year>
+		<publisher>CRL Group</publisher>
+		<part name="flop1" interface="floppy_3">
+			<dataarea name="flop" size="194816">
+				<rom name="book of the dead (1987)(crl group)[re-release].dsk" size="194816" crc="bc6b999a" sha1="3a1b2cc0692a7767c0db3d4affaa29025e723898" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="boydfile">
+		<description>The Boyd File</description>
+		<year>1990</year>
+		<publisher>Zenobi</publisher>
+		<part name="flop1" interface="floppy_3">
+			<dataarea name="flop" size="194816">
+				<rom name="boyd file, the (1990)(zenobi).dsk" size="194816" crc="a10f7dcb" sha1="338836359459d8adfb54bd2c9e99bc683dad71db" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="bravesta">
+		<description>BraveStarr</description>
+		<year>1987</year>
+		<publisher>Go</publisher>
+		<part name="flop1" interface="floppy_3">
+			<dataarea name="flop" size="194816">
+				<rom name="bravestarr (1987)(go).dsk" size="194816" crc="ebd6d548" sha1="585a027a2029675df07ea0e7786e9fdfbda60c9b" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="btnovbar">
+		<description>Brian - The Novice Barbarian</description>
+		<year>1994</year>
+		<publisher>Zenobi</publisher>
+		<part name="flop1" interface="floppy_3">
+			<dataarea name="flop" size="194816">
+				<rom name="brian - the novice barbarian (1994)(zenobi).dsk" size="194816" crc="5118b277" sha1="71138e6dd21e30728c1a388b1eaa25efbd93f8ff" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="bcfofort">
+		<description>Brian Clough's Football Fortunes</description>
+		<year>1987</year>
+		<publisher>CDS Microsystems</publisher>
+		<part name="flop1" interface="floppy_3">
+			<dataarea name="flop" size="194816">
+				<rom name="brian clough's football fortunes (1987)(cds microsystems).dsk" size="194816" crc="6cbefb15" sha1="4ea4df092ad0059a9e7e5a0e0e136d675a12ad3e" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="brdgpgal">
+		<description>Bridge Player Galactica</description>
+		<year>1989</year>
+		<publisher>CP</publisher>
+		<part name="flop1" interface="floppy_3">
+			<dataarea name="flop" size="194816">
+				<rom name="bridge player galactica (1989)(cp).dsk" size="194816" crc="be950646" sha1="b921a28c699b1e785b613ac8a7e5fb2ee0fcf6ba" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="bublbobl">
+		<description>Bubble Bobble</description>
+		<year>1987</year>
+		<publisher>Firebird</publisher>
+		<part name="flop1" interface="floppy_3">
+			<dataarea name="flop" size="78080">
+				<rom name="bubble bobble (1987)(firebird).dsk" size="78080" crc="ad820cf2" sha1="dc43630be33bdf4279d6cf51d2539b8a3e4ac768" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="bublbust">
+		<description>Bubble Buster</description>
+		<year>1984</year>
+		<publisher>Sinclair Research</publisher>
+		<part name="flop1" interface="floppy_3">
+			<dataarea name="flop" size="194816">
+				<rom name="bubble buster (1984)(sinclair research).dsk" size="194816" crc="bd8be2d5" sha1="e0acc64b08cdca0fb17fb1567aee8328f039423a" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="bbrg" cloneof="bbrg">
+		<description>Buffalo Bill's Wild West Show (Spain)</description>
+		<year>1989</year>
+		<publisher>System 4</publisher>
+		<part name="flop1" interface="floppy_3">
+			<dataarea name="flop" size="194816">
+				<rom name="buffalo bill's wild west show (1989)(system 4)(es)(en)[re-release].dsk" size="194816" crc="98087bfb" sha1="6bb33ab8dfdc7b7c0081e6eb49abd68df760358a" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<!-- May be the same edition as the IPF -->
+	<software name="bbrga" cloneof="bbrg">
+		<description>Buffalo Bill's Wild West Show (alt)</description>
+		<year>1989</year>
+		<publisher>Tynesoft</publisher>
+		<part name="flop1" interface="floppy_3">
+			<dataarea name="flop" size="194816">
+				<rom name="buffalo bill's wild west show (1989)(tynesoft)[aka buffalo bill's rodeo games].dsk" size="194816" crc="35a8bbb9" sha1="d0c7112c0cb98ce3476383cf46fa9d3b1ef7d4c2" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="buggyboy">
+		<description>Buggy Boy</description>
+		<year>1988</year>
+		<publisher>Elite Systems</publisher>
+		<part name="flop1" interface="floppy_3">
+			<dataarea name="flop" size="214784">
+				<rom name="buggy boy (1988)(elite systems).dsk" size="214784" crc="c567c3ab" sha1="752f46a60fe96049315e2a9afd3cf0103e254cf1" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="buggyboya" cloneof="buggyboy">
+		<description>Buggy Boy (alt)</description>
+		<year>1988</year>
+		<publisher>Elite Systems</publisher>
+		<part name="flop1" interface="floppy_3">
+			<dataarea name="flop" size="214784">
+				<rom name="buggy boy (1988)(elite systems)[a].dsk" size="214784" crc="57649b27" sha1="d546ec0b36a4d469f0b1663f39105b088653a272" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="buggyran">
+		<description>Buggy Ranger</description>
+		<year>1990</year>
+		<publisher>Dinamic</publisher>
+		<part name="flop1" interface="floppy_3">
+			<dataarea name="flop" size="64256">
+				<rom name="buggy ranger (1990)(dinamic)(es).dsk" size="64256" crc="8b7ece82" sha1="fba219989f6d81a249a92deee818762d017c9b37" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="bugsy">
+		<description>Bugsy</description>
+		<year>1986</year>
+		<publisher>Zenobi</publisher>
+		<part name="flop1" interface="floppy_3">
+			<dataarea name="flop" size="194816">
+				<rom name="bugsy (1986)(zenobi)[re-release].dsk" size="194816" crc="60b11040" sha1="6d3744cec7aa20dda6d7edf7ad4420fed318b66e" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="bumpy">
+		<description>Bumpy</description>
+		<year>1989</year>
+		<publisher>Proein Soft Line</publisher>
+		<part name="flop1" interface="floppy_3">
+			<dataarea name="flop" size="194816">
+				<rom name="bumpy (1989)(proein soft line)(es)(en)[re-release].dsk" size="194816" crc="c31c1761" sha1="535ef007a517e9c64f8327e5f402c396d768f178" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<!-- May be the same edition as the IPF -->
+	<software name="butchilla" cloneof="butchill">
+		<description>Butcher Hill (alt)</description>
+		<year>1989</year>
+		<publisher>Gremlin Graphics</publisher>
+		<part name="flop1" interface="floppy_3">
+			<dataarea name="flop" size="194816">
+				<rom name="butcher hill (1989)(gremlin graphics).dsk" size="194816" crc="43d9764d" sha1="cdc2d744c058bb8f788ecf7c46a127db486dc915" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="byfairme">
+		<description>By Fair Means...or Foul</description>
+		<year>1989</year>
+		<publisher>Superior</publisher>
+		<part name="flop1" interface="floppy_3">
+			<dataarea name="flop" size="214784">
+				<rom name="by fair means...or foul (1989)(superior).dsk" size="214784" crc="6d191978" sha1="9bc03db30b5825be2b65c8e3b2be112f6b5c5ffb" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="cabalsp" cloneof="cabal">
+		<description>Cabal (Spain)</description>
+		<year>1989</year>
+		<publisher>Erbe</publisher>
+		<part name="flop1" interface="floppy_3">
+			<dataarea name="flop" size="185088">
+				<rom name="cabal (1989)(erbe)(es)(en)[re-release].dsk" size="185088" crc="64cd1c52" sha1="eaff4e540200b432387ad8159b9ebfd2fda37deb" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="cabal">
+		<description>Cabal</description>
+		<year>1989</year>
+		<publisher>Ocean</publisher>
+		<part name="flop1" interface="floppy_3">
+			<dataarea name="flop" size="164352">
+				<rom name="cabal (1989)(ocean).dsk" size="164352" crc="12a62acc" sha1="e021057ade1a87dc0f429f505af97f587295478a" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="caligams">
+		<description>California Games</description>
+		<year>1987</year>
+		<publisher>U.S. Gold</publisher>
+		<part name="flop1" interface="floppy_3">
+			<dataarea name="flop" size="182016">
+				<rom name="california games (1987)(u.s. gold)(side a).dsk" size="182016" crc="68089b7a" sha1="31f8220eef17c214c050a62370b95246023f0cb6" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="canbubbl">
+		<description>Cannon Bubble</description>
+		<year>2007</year>
+		<publisher>Computer Emuzone</publisher>
+		<part name="flop1" interface="floppy_3">
+			<dataarea name="flop" size="194816">
+				<rom name="cannon bubble (2007)(computer emuzone)(es)(en).dsk" size="194816" crc="79a65c7e" sha1="916aee8d92c4d2657873adf2a5df2d10bc3157ee" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="cpsevill">
+		<description>Capitan Sevilla</description>
+		<year>1988</year>
+		<publisher>Dinamic</publisher>
+		<part name="flop1" interface="floppy_3">
+			<dataarea name="flop" size="175360">
+				<rom name="capitan sevilla (1988)(dinamic)(es).dsk" size="175360" crc="e7a740da" sha1="5b00d1bea69edd2b9ea7069aae5bd6467528be0d" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="cptrueno">
+		<description>El Capitan Trueno</description>
+		<year>1990</year>
+		<publisher>Dinamic</publisher>
+		<part name="flop1" interface="floppy_3">
+			<dataarea name="flop" size="107264">
+				<rom name="capitan trueno, el (1990)(dinamic)(es).dsk" size="107264" crc="ae4033aa" sha1="ebfba4e9b058aec5d123d5c5d00d8ed6e325ce72" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="cptblood">
+		<description>Captain Blood</description>
+		<year>1988</year>
+		<publisher>Exxos</publisher>
+		<part name="flop1" interface="floppy_3">
+			<dataarea name="flop" size="194816">
+				<rom name="captain blood (1988)(exxos)(fr)(en).dsk" size="194816" crc="e17df717" sha1="1041bb79b8db774876d2b459e6c425ce1d22f3f8" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="cptblooda" cloneof="cptblood">
+		<description>Captain Blood (alt)</description>
+		<year>1988</year>
+		<publisher>Exxos</publisher>
+		<part name="flop1" interface="floppy_3">
+			<dataarea name="flop" size="209408">
+				<rom name="captain blood (1988)(exxos)(fr)(en)[a].dsk" size="209408" crc="5b95e764" sha1="542f17338147ec719df11d3e60c2c71588dfbb51" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<!-- This is the dump at World of Spectrum -->
+	<software name="cptplnet">
+		<description>Captain Planet and the Planeteers</description>
+		<year>1991</year>
+		<publisher>Mindscape International</publisher>
+		<part name="flop1" interface="floppy_3">
+			<dataarea name="flop" size="255232">
+				<rom name="captain planet and the planeteers (1991)(mindscape international)(side a).dsk" size="255232" crc="de0baf9a" sha1="0d171f094ef1c197728fb094738a9e3192e1cb47" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="cptplneta" cloneof="cptplnet">
+		<description>Captain Planet and the Planeteers (alt)</description>
+		<year>1991</year>
+		<publisher>Mindscape International</publisher>
+		<part name="flop1" interface="floppy_3">
+			<dataarea name="flop" size="255232">
+				<rom name="captain planet and the planeteers (1991)(mindscape international).dsk" size="255232" crc="cc688e2f" sha1="9647cad3b005bcb1326e964a44f0bdce15b6e4de" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="csainz">
+		<description>Carlos Sainz - Campeonato del Mundo de Rallies</description>
+		<year>1990</year>
+		<publisher>Zigurat</publisher>
+		<part name="flop1" interface="floppy_3">
+			<dataarea name="flop" size="58624">
+				<rom name="carlos sainz - campeonato del mundo de rallies (1990)(zigurat)(es).dsk" size="58624" crc="69b938d9" sha1="8c78ff2f741668a9d583598bd0d71ae3c94ec054" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<!-- May be the same edition as the IPF -->
+	<software name="carrierca" cloneof="carrierc">
+		<description>Carrier Command (alt)</description>
+		<year>1989</year>
+		<publisher>Rainbird</publisher>
+		<part name="flop1" interface="floppy_3">
+			<dataarea name="flop" size="194816">
+				<rom name="carrier command (1989)(rainbird)[passworded].dsk" size="194816" crc="dc5836b6" sha1="834acdb689df5ce1fae378830fd40706176a1759" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="cotbehsm">
+		<description>The Case of the Beheaded Smuggler</description>
+		<year>1988</year>
+		<publisher>Zenobi</publisher>
+		<part name="flop1" interface="floppy_3">
+			<dataarea name="flop" size="194816">
+				<rom name="case of the beheaded smuggler, the (1988)(zenobi)[re-release].dsk" size="194816" crc="b6283daf" sha1="ae1fdb8f733286d58242c872fa43a48d6dd2c2e3" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="castlmassp" cloneof="castlmas">
+		<description>Castle Master (Spanish)</description>
+		<year>1990</year>
+		<publisher>Erbe</publisher>
+		<part name="flop1" interface="floppy_3">
+			<dataarea name="flop" size="68352">
+				<rom name="castle master (1990)(erbe)(es)[re-release].dsk" size="68352" crc="a6e15f9f" sha1="adb6fa50b973e23868e2ecdbada09894e39835a2" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="castlmas">
+		<description>Castle Master</description>
+		<year>1990</year>
+		<publisher>Incentive</publisher>
+		<part name="flop1" interface="floppy_3">
+			<dataarea name="flop" size="194816">
+				<rom name="castle master (1990)(incentive).dsk" size="194816" crc="4a793e62" sha1="ac429bc3b62f539053e045d025f1332fff32e099" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="castlmasa" cloneof="castlmas">
+		<description>Castle Master (alt)</description>
+		<year>1990</year>
+		<publisher>Incentive</publisher>
+		<part name="flop1" interface="floppy_3">
+			<dataarea name="flop" size="98304">
+				<rom name="castle master (1990)(incentive)[a].dsk" size="98304" crc="b8ded2a7" sha1="402bf37121588be8ed99008deefad85df191ae42" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="cvaniasi">
+		<description>Castlevania - Spectral Interlude</description>
+		<year>2015</year>
+		<publisher>Rewind Team</publisher>
+		<part name="flop1" interface="floppy_3">
+			<dataarea name="flop" size="194816">
+				<rom name="castlevania - spectral interlude (2015)(rewind team)(pl)(en).dsk" size="194816" crc="adb5b561" sha1="8514973da6717ffb50a80c674cf11f1fa18317c3" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="cvaniasisp" cloneof="cvaniasi">
+		<description>Castlevania - Spectral Interlude (Spanish)</description>
+		<year>2015</year>
+		<publisher>Rewind Team</publisher>
+		<part name="flop1" interface="floppy_3">
+			<dataarea name="flop" size="194816">
+				<rom name="castlevania - spectral interlude (2015)(rewind team)(pl)(es).dsk" size="194816" crc="76c0c512" sha1="8f7176b315f48fe02bd7a3e041b3029f66ab1b57" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="cvaniasiit" cloneof="cvaniasi">
+		<description>Castlevania - Spectral Interlude (Italian)</description>
+		<year>2015</year>
+		<publisher>Rewind Team</publisher>
+		<part name="flop1" interface="floppy_3">
+			<dataarea name="flop" size="194816">
+				<rom name="castlevania - spectral interlude (2015)(rewind team)(pl)(it).dsk" size="194816" crc="c199872f" sha1="cfc1e9ea70770d8e7f74736e0cdffc9e6a22fbdd" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="cvaniasiru" cloneof="cvaniasi">
+		<description>Castlevania - Spectral Interlude (Russian)</description>
+		<year>2015</year>
+		<publisher>Rewind Team</publisher>
+		<part name="flop1" interface="floppy_3">
+			<dataarea name="flop" size="194816">
+				<rom name="castlevania - spectral interlude (2015)(rewind team)(pl)(ru).dsk" size="194816" crc="65e836f5" sha1="5efc5518be07f11402f79a0c3c4e56b4385712d8" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="cvaniasipo" cloneof="cvaniasi">
+		<description>Castlevania - Spectral Interlude (Polish)</description>
+		<year>2015</year>
+		<publisher>Rewind Team</publisher>
+		<part name="flop1" interface="floppy_3">
+			<dataarea name="flop" size="194816">
+				<rom name="castlevania - spectral interlude (2015)(rewind team)(pl).dsk" size="194816" crc="fab90486" sha1="f9910c639e7b70d4297cfd4d6c31153fc7460648" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="celtcarn">
+		<description>Celtic Carnage</description>
+		<year>1993</year>
+		<publisher>Zenobi</publisher>
+		<part name="flop1" interface="floppy_3">
+			<dataarea name="flop" size="194816">
+				<rom name="celtic carnage (1993)(zenobi).dsk" size="194816" crc="505f7fca" sha1="f902367330bcfe90564404a3ec640a79aaf1dda3" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="chainrea">
+		<description>Chain Reaction</description>
+		<year>1987</year>
+		<publisher>Durell</publisher>
+		<part name="flop1" interface="floppy_3">
+			<dataarea name="flop" size="194816">
+				<rom name="chain reaction (1987)(durell).dsk" size="194816" crc="37f5a6d9" sha1="237922f83435be87ec93ca2eedcd1ae10c7304a5" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="champrun">
+		<description>Championship Run</description>
+		<year>1991</year>
+		<publisher>Impulze</publisher>
+		<part name="flop1" interface="floppy_3">
+			<dataarea name="flop" size="78080">
+				<rom name="championship run (1991)(impulze).dsk" size="78080" crc="62dc5d14" sha1="dc80cf88bf6b805b9b98523aaeaf9d84edf4d601" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="champrunamd" cloneof="champrun">
+		<description>Championship Run (rerelease) (master disk)</description>
+		<year>1991</year>
+		<publisher>Zeppelin Games</publisher>
+		<part name="flop1" interface="floppy_3">
+			<feature name="part_id" value="Side A"/>
+			<dataarea name="flop" size="194816">
+				<rom name="championship run (1991)(zeppelin games)(side a)[master disk][re-release].dsk" size="194816" crc="b19b4051" sha1="923342c2035eb88b111b1b6d4cccf473eca89c1c" offset="0" />
+			</dataarea>
+		</part>
+		<part name="flop2" interface="floppy_3">
+			<feature name="part_id" value="Side B"/>
+			<dataarea name="flop" size="194816">
+				<rom name="championship run (1991)(zeppelin games)(side b)[master disk][re-release].dsk" size="194816" crc="e397f7e8" sha1="ebfcfc1073a8cea96f27c791c42e39450c81930c" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="champrunamdb" cloneof="champrun">
+		<description>Championship Run (rerelease) (master disk backup)</description>
+		<year>1991</year>
+		<publisher>Zeppelin Games</publisher>
+		<part name="flop1" interface="floppy_3">
+			<feature name="part_id" value="Side A"/>
+			<dataarea name="flop" size="78080">
+				<rom name="championship run (1991)(zeppelin games)(side a)[master disk backup][re-release].dsk" size="78080" crc="ba87b776" sha1="1bb234a9b2bf7305be38ea914db8614b27d3c7cb" offset="0" />
+			</dataarea>
+		</part>
+		<part name="flop2" interface="floppy_3">
+			<feature name="part_id" value="Side B"/>
+	<!-- Side B image shared with other master disks from Zeppelin Games. Verified at World of Spectrum. -->
+			<dataarea name="flop" size="256">
+				<rom name="championship run (1991)(zeppelin games)(side b)[master disk backup][re-release].dsk" size="256" crc="56947af2" sha1="40428c770d847a0fd1fd005b6cf1d03a34672d98" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="champrunatmd" cloneof="champrun">
+		<description>Championship Run (rerelease) (tape master disk)</description>
+		<year>1991</year>
+		<publisher>Zeppelin Games</publisher>
+		<part name="flop1" interface="floppy_3">
+			<feature name="part_id" value="Side A"/>
+			<dataarea name="flop" size="194816">
+				<rom name="championship run (1991)(zeppelin games)(side a)[re-release][tape master disk].dsk" size="194816" crc="92d61b0f" sha1="634f4caa0b6fcf8d13d1ebf8ac199b2d3efc1225" offset="0" />
+			</dataarea>
+		</part>
+		<part name="flop2" interface="floppy_3">
+			<feature name="part_id" value="Side B"/>
+	<!-- Side B image shared with other master disks from Zeppelin Games. Verified at World of Spectrum. -->
+			<dataarea name="flop" size="256">
+				<rom name="championship run (1991)(zeppelin games)(side b)[master disk backup][re-release].dsk" size="256" crc="56947af2" sha1="40428c770d847a0fd1fd005b6cf1d03a34672d98" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="achaninha" cloneof="achaninh">
+		<description>A Chance in Hell (Extreme)</description>
+		<year>2011</year>
+		<publisher>&lt;homebrew&gt;</publisher>
+		<info name="author" value="Steven Flanagan"/>
+		<part name="flop1" interface="floppy_3">
+			<dataarea name="flop" size="194816">
+				<rom name="chance in hell, a (2011)(flanagan, steven).dsk" size="194816" crc="a6eb4266" sha1="7dd15b428e8e8140c328c91d271d0e88a750a003" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="achaninh">
+		<description>A Chance in Hell</description>
+		<year>2011</year>
+		<publisher>&lt;homebrew&gt;</publisher>
+		<info name="author" value="Steven Flanagan"/>
+		<part name="flop1" interface="floppy_3">
+			<dataarea name="flop" size="194816">
+				<rom name="chance in hell, a (2011)(flanagan, steven)[a].dsk" size="194816" crc="b64196d4" sha1="8821c909c89db9e8d71b4b67e138838e94d11337" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="chasehqsp" cloneof="chasehq">
+		<description>Chase H.Q. (Spain)</description>
+		<year>1989</year>
+		<publisher>Erbe</publisher>
+		<part name="flop1" interface="floppy_3">
+			<dataarea name="flop" size="185088">
+				<rom name="chase h.q. (1989)(erbe)(es)(en)[re-release].dsk" size="185088" crc="317e46d5" sha1="66de397575284efb76a08ef63dbe5db41be03249" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="chasehq">
+		<description>Chase H.Q.</description>
+		<year>1989</year>
+		<publisher>Ocean</publisher>
+		<part name="flop1" interface="floppy_3">
+			<dataarea name="flop" size="168192">
+				<rom name="chase h.q. (1989)(ocean).dsk" size="168192" crc="9c56fc47" sha1="1347cb84b7b232da4a587c573ba893cf171c6df3" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="chasehq2sp" cloneof="chasehq2">
+		<description>Chase H.Q. II - Special Criminal Investigation (Spain)</description>
+		<year>1990</year>
+		<publisher>Erbe</publisher>
+		<part name="flop1" interface="floppy_3">
+			<dataarea name="flop" size="146176">
+				<rom name="chase h.q. ii - special criminal investigation (1990)(erbe)(es)(en)[re-release].dsk" size="146176" crc="5b451c6e" sha1="58101ac75972e690b13eb7665d0ae245c47cefab" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="chasehq2">
+		<description>Chase H.Q. II - Special Criminal Investigations</description>
+		<year>1990</year>
+		<publisher>Ocean</publisher>
+		<part name="flop1" interface="floppy_3">
+			<dataarea name="flop" size="127232">
+				<rom name="chase h.q. ii - special criminal investigations (1990)(ocean).dsk" size="127232" crc="3b77b2ad" sha1="82ca5734e13e42347f3c6ca182049d45d5cc6bad" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="chessm2k">
+		<description>The Chessmaster 2000</description>
+		<year>1990</year>
+		<publisher>Dro Soft</publisher>
+		<part name="flop1" interface="floppy_3">
+			<dataarea name="flop" size="58880">
+				<rom name="chessmaster 2000, the (1990)(dro soft)(es).dsk" size="58880" crc="7a4053fb" sha1="b7520505f5988297c46a05ae1abf27f186873dbd" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<!-- May be the same edition as the IPF -->
+	<software name="chicag30a" cloneof="chicag30">
+		<description>Chicago 30's (alt)</description>
+		<year>1988</year>
+		<publisher>U.S. Gold</publisher>
+		<part name="flop1" interface="floppy_3">
+			<dataarea name="flop" size="219136">
+				<rom name="chicago 30's (1988)(u.s. gold)[aka chicago's 30][re-release].dsk" size="219136" crc="1030eeba" sha1="dc5a492d935f464de7b0eef800cfcf87786bd0d8" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<!-- May be the same edition as the IPF -->
+	<software name="chicag30b" cloneof="chicag30">
+		<description>Chicago 30's (alt 2)</description>
+		<year>1988</year>
+		<publisher>U.S. Gold</publisher>
+		<part name="flop1" interface="floppy_3">
+			<dataarea name="flop" size="219136">
+				<rom name="chicago 30's (1988)(u.s. gold)[a][aka chicago's 30][re-release].dsk" size="219136" crc="aaaee4bf" sha1="bd36eecd8dcb771329553eb76dbbb769a016d61d" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="choyleef">
+		<description>Choy-Lee-Fut Kung-Fu Warrior</description>
+		<year>1990</year>
+		<publisher>Positive</publisher>
+		<part name="flop1" interface="floppy_3">
+			<dataarea name="flop" size="194816">
+				<rom name="choy-lee-fut kung-fu warrior (1990)(positive)(es).dsk" size="194816" crc="b30c89c7" sha1="7cf7a24137ace679ad7896a6af4f5c88af9c6f85" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="chuckyea">
+		<description>Chuck Yeager's Advanced Flight Trainer</description>
+		<year>1989</year>
+		<publisher>Electronic Arts</publisher>
+		<part name="flop1" interface="floppy_3">
+			<dataarea name="flop" size="254720">
+				<rom name="chuck yeager's advanced flight trainer (1989)(electronic arts).dsk" size="254720" crc="467cfc4c" sha1="856851011941721a3f3a2fc3bbcd4e5994cdd42d" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="chuckyeaa" cloneof="chuckyea">
+		<description>Chuck Yeager's Advanced Flight Trainer (alt)</description>
+		<year>1989</year>
+		<publisher>Electronic Arts</publisher>
+		<part name="flop1" interface="floppy_3">
+			<dataarea name="flop" size="254720">
+				<rom name="chuck yeager's advanced flight trainer (1989)(electronic arts)[a].dsk" size="254720" crc="9feb1e56" sha1="6f4215091e7625739a6274c11e6e6cdd89949750" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="circgams">
+		<description>Circus Games</description>
+		<year>1988</year>
+		<publisher>Tynesoft</publisher>
+		<part name="flop1" interface="floppy_3">
+			<feature name="part_id" value="Side A"/>
+			<dataarea name="flop" size="151040">
+				<rom name="circus games (1988)(tynesoft)(side a).dsk" size="151040" crc="fd8bf77b" sha1="50528b58dd252d2ad5b6fdd7dc468eda0f815b20" offset="0" />
+			</dataarea>
+		</part>
+		<part name="flop2" interface="floppy_3">
+			<feature name="part_id" value="Side B"/>
+			<dataarea name="flop" size="92672">
+				<rom name="circus games (1988)(tynesoft)(side b).dsk" size="92672" crc="3951ee76" sha1="aaeb8723a415252a8a59a99251094dcc867b8185" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="tcitadel">
+		<description>The Citadel</description>
+		<year>1995</year>
+		<publisher>Zenobi</publisher>
+		<part name="flop1" interface="floppy_3">
+			<dataarea name="flop" size="194816">
+				<rom name="citadel, the (1995)(zenobi).dsk" size="194816" crc="274ae290" sha1="8aed7e6ae7cb69e11e6cd2f44bc1c6bc6d02c5f7" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="civlsrv2">
+		<description>Civil Service II</description>
+		<year>1994</year>
+		<publisher>Zenobi</publisher>
+		<part name="flop1" interface="floppy_3">
+			<dataarea name="flop" size="194816">
+				<rom name="civil service ii (1994)(zenobi).dsk" size="194816" crc="88ecdb07" sha1="0a9aa0bbd6122edde9c9bce9303583b6a98be283" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="clckch89">
+		<description>Clock Chess '89</description>
+		<year>1989</year>
+		<publisher>CP</publisher>
+		<part name="flop1" interface="floppy_3">
+			<dataarea name="flop" size="194816">
+				<rom name="clock chess '89 (1989)(cp).dsk" size="194816" crc="32467893" sha1="a6b698715f6c413dd3f1910d6dff8720e3643aa8" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="clckch89sp" cloneof="clckch89">
+		<description>Clock Chess '89 (Spain)</description>
+		<year>1989</year>
+		<publisher>System 4</publisher>
+		<part name="flop1" interface="floppy_3">
+			<dataarea name="flop" size="194816">
+				<rom name="clock chess '89 (1989)(system 4)(es)(en)[re-release].dsk" size="194816" crc="0ab6eb85" sha1="7776e4c21215798a8c1a264029b5adc14882d6f7" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="cloud99">
+		<description>Cloud 99</description>
+		<year>1988</year>
+		<publisher>Zenobi</publisher>
+		<part name="flop1" interface="floppy_3">
+			<dataarea name="flop" size="194816">
+				<rom name="cloud 99 (1988)(zenobi)[re-release].dsk" size="194816" crc="5842de80" sha1="b454e12a32543825a6c593dc68dd9a2b8654d567" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="clsbrid4">
+		<description>Colossus Bridge 4</description>
+		<year>1986</year>
+		<publisher>CDS Microsystems</publisher>
+		<part name="flop1" interface="floppy_3">
+			<dataarea name="flop" size="194816">
+				<rom name="colossus bridge 4 (1986)(cds microsystems)[aka colossus 4 bridge].dsk" size="194816" crc="73271bc3" sha1="aa725cfffb117d42c81fd059404d5c3f0b14d56f" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="clschss4">
+		<description>Colossus Chess 4</description>
+		<year>1986</year>
+		<publisher>CDS Microsystems</publisher>
+		<part name="flop1" interface="floppy_3">
+			<feature name="part_id" value="Side A"/>
+			<dataarea name="flop" size="194816">
+				<rom name="colossus chess 4 (1986)(cds microsystems)(side a)[aka colossus 4 chess].dsk" size="194816" crc="75eabff4" sha1="b0c7e68c086c252e30dc98b53d0949f4323a1edc" offset="0" />
+			</dataarea>
+		</part>
+		<part name="flop2" interface="floppy_3">
+			<feature name="part_id" value="Side B"/>
+			<dataarea name="flop" size="194816">
+				<rom name="colossus chess 4 (1986)(cds microsystems)(side b)[aka colossus 4 chess].dsk" size="194816" crc="54843a73" sha1="a5de3c29a447dc6837e2da39085dc1c2eaedb237" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+<!-- This is the dump from World of Spectrum -->
+	<software name="clschss4a" cloneof="clschss4">
+		<description>Colossus Chess 4 (alt)</description>
+		<year>1986</year>
+		<publisher>CDS Microsystems</publisher>
+		<part name="flop1" interface="floppy_3">
+			<dataarea name="flop" size="194816">
+				<rom name="colossus chess 4 (1986)(cds microsystems)[aka colossus 4 chess].dsk" size="194816" crc="5a5078a3" sha1="0bab187cce31ef3948e91fa9d4f94b0804571a98" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<!-- TOSEC specifies that it's "Side A", may require a Side B at some point? -->
+	<software name="clschss4b" cloneof="clschss4">
+		<description>Colossus Chess 4 (alt 2)</description>
+		<year>1986</year>
+		<publisher>CDS Microsystems</publisher>
+		<part name="flop1" interface="floppy_3">
+			<dataarea name="flop" size="194816">
+				<rom name="colossus chess 4 (1986)(cds microsystems)(side a)[a][aka colossus 4 chess].dsk" size="194816" crc="7665818f" sha1="7e8d5ce4cdc15837bd8d36720d07a17d46545873" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="cmquatro">
+		<description>Comando Quatro</description>
+		<year>1989</year>
+		<publisher>Zigurat</publisher>
+		<part name="flop1" interface="floppy_3">
+			<dataarea name="flop" size="68352">
+				<rom name="comando quatro (1989)(zigurat)(es).dsk" size="68352" crc="1f253875" sha1="ba4c1ba3e604bb35bb1ef91a855b993833f090e7" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="comtracr">
+		<description>Comando Tracer</description>
+		<year>1989</year>
+		<publisher>Dinamic</publisher>
+		<part name="flop1" interface="floppy_3">
+			<dataarea name="flop" size="75008">
+				<rom name="comando tracer (1989)(dinamic)(es).dsk" size="75008" crc="985c2136" sha1="be76783bd8429b9f3ec2cd8702e7419b1c632ee6" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+<!-- May be a clone of combatsc -->
+	<software name="combatsg">
+		<description>Combat School + Gryzor Preview</description>
+		<year>1987</year>
+		<publisher>Ocean</publisher>
+		<part name="flop1" interface="floppy_3">
+			<dataarea name="flop" size="214784">
+				<rom name="combat school + gryzor preview (1987)(ocean).dsk" size="214784" crc="2996f5e8" sha1="0dc0e1340835d35071a5a2873346462faa07233d" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="contcircsp" cloneof="contcirc">
+		<description>Continental Circus (Spain)</description>
+		<year>1989</year>
+		<publisher>Dro Soft</publisher>
+		<part name="flop1" interface="floppy_3">
+			<dataarea name="flop" size="194816">
+				<rom name="continental circus (1989)(dro soft)(es)(en)[re-release].dsk" size="194816" crc="424df271" sha1="36a5c13f30b4b97d6e8944f4767dd9c1eab41c13" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="contcirc">
+		<description>Continental Circus</description>
+		<year>1989</year>
+		<publisher>Virgin Mastertronic</publisher>
+		<part name="flop1" interface="floppy_3">
+			<dataarea name="flop" size="224256">
+				<rom name="continental circus (1989)(virgin mastertronic).dsk" size="224256" crc="a9d27a04" sha1="ba5e1a91ea1ada4debbe41ae923fd9ab89c1c2e6" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="corpston">
+		<description>Corporal Stone</description>
+		<year>1992</year>
+		<publisher>Zenobi</publisher>
+		<part name="flop1" interface="floppy_3">
+			<dataarea name="flop" size="194816">
+				<rom name="corporal stone (1992)(zenobi).dsk" size="194816" crc="8b578a60" sha1="ef6d6a69d6d953b73ca780e370aec12cd99373f8" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<!-- May be the same edition as the IPF -->
+	<software name="corruptna" cloneof="corruptn">
+		<description>Corruption (alt)</description>
+		<year>1988</year>
+		<publisher>Rainbird</publisher>
+		<part name="flop1" interface="floppy_3">
+			<dataarea name="flop" size="194816">
+				<rom name="corruption (1988)(rainbird).dsk" size="194816" crc="1dc27c17" sha1="3fd52b22960c0285472a7e87ea6a9fdb5684ee82" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<!-- May be the same edition as the IPF -->
+	<software name="corruptnb" cloneof="corruptn">
+		<description>Corruption (alt 2)</description>
+		<year>1988</year>
+		<publisher>Rainbird</publisher>
+		<part name="flop1" interface="floppy_3">
+			<dataarea name="flop" size="194816">
+				<rom name="corruption (1988)(rainbird)[a].dsk" size="194816" crc="4e60b833" sha1="cdf95bb26eb4d5e0baec7838cfca832936cc7540" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<!-- May be the same edition as the IPF -->
+	<software name="corruptnc" cloneof="corruptn">
+		<description>Corruption (alt 3)</description>
+		<year>1988</year>
+		<publisher>Rainbird</publisher>
+		<part name="flop1" interface="floppy_3">
+			<dataarea name="flop" size="194816">
+				<rom name="corruption (1988)(rainbird)[a2].dsk" size="194816" crc="e7e5feaf" sha1="94b0b7203a9478ec7e232677a902cb90ec4abbdd" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="cosmicsh">
+		<description>Cosmic Sheriff</description>
+		<year>1990</year>
+		<publisher>Dinamic</publisher>
+		<part name="flop1" interface="floppy_3">
+			<dataarea name="flop" size="101888">
+				<rom name="cosmic sheriff (1990)(dinamic)(es).dsk" size="101888" crc="98a9e2ff" sha1="93de281cb9c787633c86448d1e0a0ba0cd3001c8" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="crackcty">
+		<description>Crack City</description>
+		<year>1989</year>
+		<publisher>Zenobi</publisher>
+		<part name="flop1" interface="floppy_3">
+			<dataarea name="flop" size="194816">
+				<rom name="crack city (1989)(zenobi).dsk" size="194816" crc="e4ef29e9" sha1="1b8d94c8adb69ec1f963d6fddd49f43947a46afb" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="cray5">
+		<description>Cray-5</description>
+		<year>2011</year>
+		<publisher>RetroWorks</publisher>
+		<part name="flop1" interface="floppy_3">
+			<dataarea name="flop" size="194816">
+				<rom name="cray-5 (2011)(retroworks)(es)(en).dsk" size="194816" crc="79e634e5" sha1="a65086e80b5d478d703269558f4c853ff53d5fc8" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="crzycars">
+		<description>Crazy Cars</description>
+		<year>1988</year>
+		<publisher>Titus</publisher>
+		<part name="flop1" interface="floppy_3">
+			<dataarea name="flop" size="194816">
+				<rom name="crazy cars (1988)(titus)(fr)(en).dsk" size="194816" crc="27c1e745" sha1="d7d3d2a19b9e0c6a0d1fad3dfc126380bd147f94" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="crzycarsa" cloneof="crzycars">
+		<description>Crazy Cars (alt)</description>
+		<year>1988</year>
+		<publisher>Titus</publisher>
+		<part name="flop1" interface="floppy_3">
+			<dataarea name="flop" size="194816">
+				<rom name="crazy cars (1988)(titus)(fr)(en)[a].dsk" size="194816" crc="4d694436" sha1="23d0afc62538d4a1784c5f938f74cc7e6a881b6b" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="crzcars2">
+		<description>Crazy Cars II</description>
+		<year>1988</year>
+		<publisher>Titus</publisher>
+		<part name="flop1" interface="floppy_3">
+			<dataarea name="flop" size="199680">
+				<rom name="crazy cars ii (1988)(titus)(fr)(en).dsk" size="199680" crc="0024faa8" sha1="cd6a4b7efa1a3dabc55baa844d2f0c3b98f93878" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="cricketm">
+		<description>Cricket Master</description>
+		<year>1989</year>
+		<publisher>Challenge</publisher>
+		<part name="flop1" interface="floppy_3">
+			<dataarea name="flop" size="194816">
+				<rom name="cricket master (1989)(challenge).dsk" size="194816" crc="636dadcc" sha1="e5a4685b8308834e06be0e329637567b8cf84154" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="crystkin">
+		<description>Crystals of Kings</description>
+		<year>1993</year>
+		<publisher>Zenobi</publisher>
+		<part name="flop1" interface="floppy_3">
+			<dataarea name="flop" size="194816">
+				<rom name="crystals of kings (1993)(zenobi).dsk" size="194816" crc="6fa4745e" sha1="4e0ce417dee743183886bce9ccc4f3c2d3fe72f9" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="currojim">
+		<description>Curro Jimenez</description>
+		<year>1989</year>
+		<publisher>Zigurat</publisher>
+		<part name="flop1" interface="floppy_3">
+			<dataarea name="flop" size="73216">
+				<rom name="curro jimenez (1989)(zigurat)(es).dsk" size="73216" crc="0e92a03c" sha1="c5de62cfdd369a8a13c685aa54595087c61f9a74" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="cursnimu">
+		<description>The Curse of Nimue</description>
+		<year>1995</year>
+		<publisher>Zenobi</publisher>
+		<part name="flop1" interface="floppy_3">
+			<dataarea name="flop" size="194816">
+				<rom name="curse of nimue, the (1995)(zenobi).dsk" size="194816" crc="77db9af2" sha1="ffc3cc67bf86dc4091bd600443e615dbeaee3aea" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<!-- May be the same edition as the IPF -->
+	<software name="cybernoda" cloneof="cybernod">
+		<description>Cybernoid - The Fighting Machine (alt)</description>
+		<year>1988</year>
+		<publisher>Hewson Consultants</publisher>
+		<part name="flop1" interface="floppy_3">
+			<dataarea name="flop" size="174848">
+				<rom name="cybernoid - the fighting machine (1988)(hewson consultants).dsk" size="174848" crc="c6dbf46f" sha1="347e6911d7a410ad89c16033b323d366d12c256b" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<!-- May be the same edition as the IPF -->
+	<software name="cyberno2" cloneof="cyberno2">
+		<description>Cybernoid II - The Revenge (alt)</description>
+		<year>1988</year>
+		<publisher>Hewson Consultants</publisher>
+		<part name="flop1" interface="floppy_3">
+			<dataarea name="flop" size="194816">
+				<rom name="cybernoid ii - the revenge (1988)(hewson consultants).dsk" size="194816" crc="0e7d5f2f" sha1="6c960f9d8e26136443985192909717f1fa81211d" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="cybo2900">
+		<description>Cyborg 2900</description>
+		<year>2011</year>
+		<publisher>&lt;homebrew&gt;</publisher>
+		<info name="author" value="Steven Flanagan"/>
+		<part name="flop1" interface="floppy_3">
+			<dataarea name="flop" size="194816">
+				<rom name="cyborg 2900 (2011)(flanagan, steven)(gb)(de).dsk" size="194816" crc="e14dbf81" sha1="85f71b1c71e113b6991477cf771a5b125c4cafb2" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="thecycle">
+		<description>The Cycles</description>
+		<year>1989</year>
+		<publisher>Accolade</publisher>
+		<part name="flop1" interface="floppy_3">
+			<dataarea name="flop" size="86784">
+				<rom name="cycles, the (1989)(accolade).dsk" size="86784" crc="ab7498ff" sha1="1ff1b55fbfc376b86fac0401d04b31294bef3fe2" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="thecyclesp" cloneof="thecycle">
+		<description>The Cycles (Spain)</description>
+		<year>1989</year>
+		<publisher>Dro Soft</publisher>
+		<part name="flop1" interface="floppy_3">
+			<dataarea name="flop" size="194816">
+				<rom name="cycles, the (1989)(dro soft)(es)(en)[re-release].dsk" size="194816" crc="93969d71" sha1="6466f9cc120ed536ac85f01cc619f7b2d7f40336" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="daleytoc">
+		<description>Daley Thompson's Olympic Challenge</description>
+		<year>1988</year>
+		<publisher>Ocean</publisher>
+		<part name="flop1" interface="floppy_3">
+			<dataarea name="flop" size="220160">
+				<rom name="daley thompson's olympic challenge (1988)(ocean)[aka daley thompson '88].dsk" size="220160" crc="5d0ed5ac" sha1="ff4726f3e2b4281fb251526f876c74a7a0ac132c" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="dandare2">
+		<description>Dan Dare II - Mekon's Revenge</description>
+		<year>1988</year>
+		<publisher>Virgin Games</publisher>
+		<part name="flop1" interface="floppy_3">
+			<dataarea name="flop" size="214784">
+				<rom name="dan dare ii - mekon's revenge (1988)(virgin games).dsk" size="214784" crc="ad23d8bd" sha1="f05d36abc09a04831c1fbfea9e512159101ee297" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<!-- May be the same edition as the IPF -->
+	<software name="dandare3a" cloneof="dandare3">
+		<description>Dan Dare III - The Escape (alt)</description>
+		<year>1990</year>
+		<publisher>Virgin Games</publisher>
+		<part name="flop1" interface="floppy_3">
+			<dataarea name="flop" size="62720">
+				<rom name="dan dare iii - the escape (1990)(virgin games)[aka crazy jet racer][aka dan dare 3 - la escapada].dsk" size="62720" crc="e0b5ca78" sha1="961945064f12a3cb6ba57be3be82f7be36918443" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="dariuspl">
+		<description>Darius+</description>
+		<year>1990</year>
+		<publisher>The Edge</publisher>
+		<part name="flop1" interface="floppy_3">
+			<feature name="part_id" value="Side A"/>
+			<dataarea name="flop" size="194816">
+				<rom name="darius+ (1990)(edge, the)(side a).dsk" size="194816" crc="01d1ceed" sha1="5314521cc4d414ae8cbed0e3de39f7b82d8aa306" offset="0" />
+			</dataarea>
+		</part>
+		<part name="flop2" interface="floppy_3">
+			<feature name="part_id" value="Side B"/>
+			<dataarea name="flop" size="194816">
+				<rom name="darius+ (1990)(edge, the)(side b).dsk" size="194816" crc="1d258f68" sha1="05e228e532e3ab14e5f4afd4e98a841b8d886251" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<!-- May be the same edition as the IPF -->
+	<software name="darkfusna" cloneof="darkfusn">
+		<description>Dark Fusion (alt)</description>
+		<year>1988</year>
+		<publisher>Gremlin Graphics</publisher>
+		<part name="flop1" interface="floppy_3">
+			<dataarea name="flop" size="219136">
+				<rom name="dark fusion (1988)(gremlin graphics).dsk" size="219136" crc="bcc16b2e" sha1="e4802f43c53db059cce6a398056fb0823c8c2a52" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="darkglad">
+		<description>The Dark Gladiator</description>
+		<year>1993</year>
+		<publisher>FSF Adventures</publisher>
+		<part name="flop1" interface="floppy_3">
+			<dataarea name="flop" size="194816">
+				<rom name="dark gladiator, the (1993)(fsf adventures).dsk" size="194816" crc="4d77a737" sha1="9d18b6ec0e2304165f7df34812c4b1a8a54479bc" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="darkside">
+		<description>Dark Side</description>
+		<year>1988</year>
+		<publisher>Incentive</publisher>
+		<part name="flop1" interface="floppy_3">
+			<dataarea name="flop" size="194816">
+				<rom name="dark side (1988)(incentive).dsk" size="194816" crc="0f4880e0" sha1="876868ce588801c8c0272a660d6420ce4bcde0d6" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="darksidesp" cloneof="darkside">
+		<description>Dark Side (Spain)</description>
+		<year>1988</year>
+		<publisher>System 4</publisher>
+		<part name="flop1" interface="floppy_3">
+			<dataarea name="flop" size="194816">
+				<rom name="dark side (1988)(system 4)(es)(en)[re-release].dsk" size="194816" crc="ad260ab9" sha1="8a19363f5f76cf096d630d300ae3183b3c8103ca" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="darktowr">
+		<description>The Dark Tower</description>
+		<year>1992</year>
+		<publisher>Zenobi</publisher>
+		<part name="flop1" interface="floppy_3">
+			<dataarea name="flop" size="204544">
+				<rom name="dark tower, the (1992)(zenobi)[re-release].dsk" size="204544" crc="57131a03" sha1="58f8bd782f144bd7f15e07b6f9240f3c06a936c1" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="darkstro">
+		<description>The Darkest Road</description>
+		<year>1991</year>
+		<publisher>Zenobi</publisher>
+		<part name="flop1" interface="floppy_3">
+			<dataarea name="flop" size="194816">
+				<rom name="darkest road, the (1991)(zenobi).dsk" size="194816" crc="9226b17e" sha1="dd2517993b61100372798225c63869462dfcb99c" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="deawish3">
+		<description>Death Wish 3</description>
+		<year>1987</year>
+		<publisher>Gremlin Graphics</publisher>
+		<part name="flop1" interface="floppy_3">
+			<dataarea name="flop" size="194816">
+				<rom name="death wish 3 (1987)(gremlin graphics).dsk" size="194816" crc="43f7fd6d" sha1="07fc65dd723143b183280074cdb2f786427b0f5e" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="deawish3a" cloneof="deawish3">
+		<description>Death Wish 3 (alt)</description>
+		<year>1987</year>
+		<publisher>Gremlin Graphics</publisher>
+		<part name="flop1" interface="floppy_3">
+			<dataarea name="flop" size="194816">
+				<rom name="death wish 3 (1987)(gremlin graphics)[a].dsk" size="194816" crc="668d8e22" sha1="500e9e2746f1e914052465b56597b2a77a1389d5" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="deawish3b" cloneof="deawish3">
+		<description>Death Wish 3 (alt 2)</description>
+		<year>1987</year>
+		<publisher>Gremlin Graphics</publisher>
+		<part name="flop1" interface="floppy_3">
+			<dataarea name="flop" size="194816">
+				<rom name="death wish 3 (1987)(gremlin graphics)[a2].dsk" size="194816" crc="c0b36014" sha1="cf4cdcd8cc6bcd090e639679818a66fa73944550" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="decmieye">
+		<description>Deception of the Mind's Eye</description>
+		<year>1993</year>
+		<publisher>Electric Storm Productions</publisher>
+		<part name="flop1" interface="floppy_3">
+			<dataarea name="flop" size="194816">
+				<rom name="deception of the mind's eye (1993)(electric storm productions).dsk" size="194816" crc="6d7b98ff" sha1="c769e5326b96c37a815d2a25ebfea02f9fc2a40e" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="deeksdee">
+		<description>Deek's Deeds</description>
+		<year>1990</year>
+		<publisher>Zenobi</publisher>
+		<part name="flop1" interface="floppy_3">
+			<dataarea name="flop" size="194816">
+				<rom name="deek's deeds (1990)(zenobi)[re-release].dsk" size="194816" crc="b5ba9c79" sha1="c8bc7bcf561c44daab22a75662ddc69e25b08e80" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<!-- May be the same edition as the IPF -->
+	<software name="deepa" cloneof="deep">
+		<description>The Deep (alt)</description>
+		<year>1988</year>
+		<publisher>U.S. Gold</publisher>
+		<part name="flop1" interface="floppy_3">
+			<dataarea name="flop" size="213760">
+				<rom name="deep, the (1988)(u.s. gold).dsk" size="213760" crc="642620c1" sha1="003fb8ce69ef6d29dcddcf369edf8a0b088e6769" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="dotearth">
+		<description>Defenders of the Earth</description>
+		<year>1990</year>
+		<publisher>Enigma Variations</publisher>
+		<part name="flop1" interface="floppy_3">
+			<dataarea name="flop" size="195840">
+				<rom name="defenders of the earth (1990)(enigma variations).dsk" size="195840" crc="ca58887c" sha1="bb58eeaa31252fd85bc985dc0f249aa42544a6c7" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<!-- May be the same edition as the IPF -->
+	<software name="deflektra" cloneof="deflektr">
+		<description>Deflektor (alt)</description>
+		<year>1987</year>
+		<publisher>Gremlin Graphics</publisher>
+		<part name="flop1" interface="floppy_3">
+			<dataarea name="flop" size="174848">
+				<rom name="deflektor (1987)(gremlin graphics).dsk" size="174848" crc="63929c07" sha1="adc7f9ba5f9bbded9a60f104b51973ff1808a94f" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="totrecalsp" cloneof="totrecal">
+		<description>Desafio Total</description>
+		<year>1991</year>
+		<publisher>Erbe</publisher>
+		<part name="flop1" interface="floppy_3">
+			<dataarea name="flop" size="151040">
+				<rom name="desafio total (1991)(erbe)(es)(en)[aka total recall][re-release].dsk" size="151040" crc="341d1500" sha1="793d902be2b432531b8e901750ca301a16e0675d" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="diarmid">
+		<description>Diarmid</description>
+		<year>1993</year>
+		<publisher>Zenobi</publisher>
+		<part name="flop1" interface="floppy_3">
+			<dataarea name="flop" size="194816">
+				<rom name="diarmid (1993)(zenobi).dsk" size="194816" crc="4b08234a" sha1="173e145e0bbe47764618022be5edcb632dc6cefe" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="diosacoz">
+		<description>La Diosa de Cozumel</description>
+		<year>1990</year>
+		<publisher>Aventuras AD</publisher>
+		<part name="flop1" interface="floppy_3">
+			<dataarea name="flop" size="126720">
+				<rom name="diosa de cozumel, la (1990)(aventuras ad)(es).dsk" size="126720" crc="47b10a66" sha1="be799ad89d4ad9047158e9e25ecd74e6e65ae3ab" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="dogboy">
+		<description>The Dogboy</description>
+		<year>1985</year>
+		<publisher>Zenobi</publisher>
+		<part name="flop1" interface="floppy_3">
+			<dataarea name="flop" size="194816">
+				<rom name="dogboy, the (1985)(zenobi)[re-release].dsk" size="194816" crc="b7f4582c" sha1="40828308aa82e7208c4d154ace4b79a861c3a0c1" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="dominatrsp" cloneof="dominatr">
+		<description>Dominator (Spain)</description>
+		<year>1989</year>
+		<publisher>MCM</publisher>
+		<part name="flop1" interface="floppy_3">
+			<dataarea name="flop" size="121856">
+				<rom name="dominator (1989)(mcm)(es)(en)[re-release].dsk" size="121856" crc="0ca1868a" sha1="dc6d54da26a5271340910aa52a76d49dc67216bd" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<!-- May be the same edition as the IPF -->
+	<software name="dominatra" cloneof="dominatr">
+		<description>Dominator (alt)</description>
+		<year>1989</year>
+		<publisher>System 3</publisher>
+		<part name="flop1" interface="floppy_3">
+			<dataarea name="flop" size="234752">
+				<rom name="dominator (1989)(system 3).dsk" size="234752" crc="a8475699" sha1="fc39aa181b7db27aa0a92a0458f54e75fe610ede" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="ddragonsp" cloneof="ddragon">
+		<description>Double Dragon (Spain)</description>
+		<year>1989</year>
+		<publisher>Dro Soft</publisher>
+		<part name="flop1" interface="floppy_3">
+			<feature name="part_id" value="Side A"/>
+			<dataarea name="flop" size="170496">
+				<rom name="double dragon (1989)(dro soft)(es)(en)(side a)[re-release].dsk" size="170496" crc="a9a2d5c4" sha1="cf88aaec4f3fef0537638bc225ee92894c2e8d05" offset="0" />
+			</dataarea>
+		</part>
+		<part name="flop2" interface="floppy_3">
+			<feature name="part_id" value="Side B"/>
+			<dataarea name="flop" size="63488">
+				<rom name="double dragon (1989)(dro soft)(es)(en)(side b)[re-release].dsk" size="63488" crc="016a0453" sha1="d5faeb6ce277eb30c394e6438775a01ebb7378d8" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="ddragon">
+		<description>Double Dragon</description>
+		<year>1989</year>
+		<publisher>Melbourne House</publisher>
+		<part name="flop1" interface="floppy_3">
+			<feature name="part_id" value="Side A"/>
+			<dataarea name="flop" size="170496">
+				<rom name="double dragon (1989)(melbourne house)(side a).dsk" size="170496" crc="5c97aaf4" sha1="c906ed3124fd6b7c2e247e2a2863755ab10eae00" offset="0" />
+			</dataarea>
+		</part>
+		<part name="flop2" interface="floppy_3">
+			<feature name="part_id" value="Side B"/>
+			<dataarea name="flop" size="63488">
+				<rom name="double dragon (1989)(melbourne house)(side b).dsk" size="63488" crc="1c50d9dd" sha1="ea88d3e0e16f4534862ae8476fdcbe965916bfa1" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="ddragon2">
+		<description>Double Dragon II - The Revenge</description>
+		<year>1989</year>
+		<publisher>Virgin Mastertronic</publisher>
+		<part name="flop1" interface="floppy_3">
+			<feature name="part_id" value="Side A"/>
+			<dataarea name="flop" size="197888">
+				<rom name="double dragon ii - the revenge (1989)(virgin mastertronic)(side a).dsk" size="197888" crc="8170bb9b" sha1="5480069cc2719e4a7d604d26efeef08390b5235a" offset="0" />
+			</dataarea>
+		</part>
+		<part name="flop2" interface="floppy_3">
+			<feature name="part_id" value="Side B"/>
+			<dataarea name="flop" size="194816">
+				<rom name="double dragon ii - the revenge (1989)(virgin mastertronic)(side b).dsk" size="194816" crc="0625d7e9" sha1="c9b8823d3564d0d2cd853f9586a36c6b49346735" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="drjekyll">
+		<description>Dr. Jekyll and Mr. Hyde (master disk)</description>
+		<year>1988</year>
+		<publisher>Zenobi</publisher>
+		<part name="flop1" interface="floppy_3">
+			<feature name="part_id" value="Side A"/>
+			<dataarea name="flop" size="194816">
+				<rom name="dr. jekyll and mr. hyde (1988)(zenobi)(side a)[master disk][re-release].dsk" size="194816" crc="3429d25d" sha1="b9725f433771122798ba28ed40441204b14fe95c" offset="0" />
+			</dataarea>
+		</part>
+		<part name="flop2" interface="floppy_3">
+			<feature name="part_id" value="Side B"/>
+			<dataarea name="flop" size="194816">
+				<rom name="dr. jekyll and mr. hyde (1988)(zenobi)(side b)[master disk][re-release].dsk" size="194816" crc="d3cbb30d" sha1="e49eca6a9332a89ebeb747df5997a1ab7716ee81" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="baddudessp" cloneof="baddudes">
+		<description>Dragon Ninja (Spain)</description>
+		<year>1988</year>
+		<publisher>Erbe</publisher>
+		<part name="flop1" interface="floppy_3">
+			<dataarea name="flop" size="135680">
+				<rom name="dragon ninja (1988)(erbe)(es)(en)[re-release].dsk" size="135680" crc="13338cd1" sha1="8b6703803bf4afe5fd7de30fdabab4ffcccbb0ac" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="dragnque">
+		<description>Dragon-Quest</description>
+		<year>1994</year>
+		<publisher>Zenobi</publisher>
+		<part name="flop1" interface="floppy_3">
+			<dataarea name="flop" size="194816">
+				<rom name="dragon-quest (1994)(zenobi).dsk" size="194816" crc="74097eb9" sha1="7cb723772404ec52399aab549ca2324877a75cad" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="drakkar">
+		<description>Drakkar</description>
+		<year>1989</year>
+		<publisher>Delta Software S.L.</publisher>
+		<part name="flop1" interface="floppy_3">
+			<dataarea name="flop" size="102400">
+				<rom name="drakkar (1989)(delta software s.l.)(es)[aka drakar].dsk" size="102400" crc="816c2a6d" sha1="4d7eaf60c528cfae76a79de655da4732f151f8b2" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="drazenpb">
+		<description>Drazen Petrovic Basket</description>
+		<year>1989</year>
+		<publisher>Topo Soft</publisher>
+		<part name="flop1" interface="floppy_3">
+			<dataarea name="flop" size="73216">
+				<rom name="drazen petrovic basket (1989)(topo soft)(es).dsk" size="73216" crc="0ef58280" sha1="744f2e6de5131cdfc6e151bd3701b95da57a2100" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="driller">
+		<description>Driller</description>
+		<year>1987</year>
+		<publisher>Incentive</publisher>
+		<part name="flop1" interface="floppy_3">
+			<dataarea name="flop" size="204544">
+				<rom name="driller (1987)(incentive)[passworded].dsk" size="204544" crc="e4c9034f" sha1="3bd8abab0fa649862218b6f4a42387c68733402a" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="duckout">
+		<description>Duck Out</description>
+		<year>1989</year>
+		<publisher>Dro Soft</publisher>
+		<part name="flop1" interface="floppy_3">
+			<dataarea name="flop" size="194816">
+				<rom name="duck out (1989)(dro soft)(es)(en).dsk" size="194816" crc="ca48cc1d" sha1="64ec19958898c2d97a79e42f126adbef055d3e94" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="td2tduel">
+		<description>The Duel - Test Drive II</description>
+		<year>1989</year>
+		<publisher>Accolade</publisher>
+		<part name="flop1" interface="floppy_3">
+			<dataarea name="flop" size="66048">
+				<rom name="duel, the - test drive ii (1989)(accolade).dsk" size="66048" crc="693d20c7" sha1="9b816281dbe1c98d652727078d60b1528def9b55" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="dungromp">
+		<description>A Dungeon Romp</description>
+		<year>1995</year>
+		<publisher>Zenobi</publisher>
+		<part name="flop1" interface="floppy_3">
+			<dataarea name="flop" size="194816">
+				<rom name="dungeon romp, a (1995)(zenobi).dsk" size="194816" crc="3e99350f" sha1="4db3b696c9659c060ed51eb658e97b06a79f92ba" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="dungmald">
+		<description>The Dungeons of Maldread</description>
+		<year>1995</year>
+		<publisher>Zenobi</publisher>
+		<part name="flop1" interface="floppy_3">
+			<dataarea name="flop" size="194816">
+				<rom name="dungeons of maldread, the (1995)(zenobi).dsk" size="194816" crc="f83f9881" sha1="50d3747b5e45bba24e92054525efc41a855f4b6d" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="ddux">
+		<description>Dynamite Dux</description>
+		<year>1989</year>
+		<publisher>Activision</publisher>
+		<part name="flop1" interface="floppy_3">
+			<dataarea name="flop" size="153088">
+				<rom name="dynamite dux (1989)(activision).dsk" size="153088" crc="6f8c2d14" sha1="f6878b252d887cd6dc24bf934c4a7f35936be50e" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="dynwar">
+		<description>Dynasty Wars</description>
+		<year>1990</year>
+		<publisher>U.S. Gold</publisher>
+		<part name="flop1" interface="floppy_3">
+			<dataarea name="flop" size="133632">
+				<rom name="dynasty wars (1990)(u.s. gold).dsk" size="133632" crc="efd8e230" sha1="2e834f96544eeb6fd39dad939c3685bc3d932b26" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="emotion">
+		<description>E-motion</description>
+		<year>1990</year>
+		<publisher>Erbe</publisher>
+		<part name="flop1" interface="floppy_3">
+			<dataarea name="flop" size="78080">
+				<rom name="e-motion (1990)(erbe)(es)(en)[re-release].dsk" size="78080" crc="216e6ce4" sha1="96f573de05900cd43a3351c031cf8eeb3b16f1f8" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<!-- May be the same edition as the IPF -->
+	<software name="echelona" cloneof="echelon">
+		<description>Echelon (alt)</description>
+		<year>1988</year>
+		<publisher>U.S. Gold</publisher>
+		<part name="flop1" interface="floppy_3">
+			<dataarea name="flop" size="194816">
+				<rom name="echelon (1988)(u.s. gold).dsk" size="194816" crc="7bce0509" sha1="37a23c2ae41a81645dd719b509333801d58643a6" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="eddthedumd" cloneof="eddthedu">
+		<description>Edd the Duck (master disk)</description>
+		<year>1990</year>
+		<publisher>Zeppelin Games</publisher>
+		<part name="flop1" interface="floppy_3">
+			<dataarea name="flop" size="64768">
+				<rom name="edd the duck (1990)(zeppelin games)(side a)[master disk][re-release].dsk" size="64768" crc="ef813afc" sha1="31462f540c2b1a8cc75aee1d542bd53f4891a3e9" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="eddthedutmd" cloneof="eddthedu">
+		<description>Edd the Duck (tape master disk)</description>
+		<year>1990</year>
+		<publisher>Zeppelin Games</publisher>
+		<part name="flop1" interface="floppy_3">
+			<dataarea name="flop" size="256000">
+				<rom name="edd the duck (1990)(zeppelin games)(side a)[re-release][tape master disk].dsk" size="256000" crc="1be41a6d" sha1="b208c586b5428fd31a043a2fc4380c89be4f74cc" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="eddthedu">
+		<description>Edd the Duck</description>
+		<year>1990</year>
+		<publisher>Zeppelin Games</publisher>
+		<part name="flop1" interface="floppy_3">
+			<dataarea name="flop" size="64768">
+				<rom name="edd the duck (1990)(zeppelin games)[re-release].dsk" size="64768" crc="b023516f" sha1="ba6fe9a835f9ac2c0c35c30d6eedff2b53069068" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="elfinwar">
+		<description>The Elfin Wars</description>
+		<year>1994</year>
+		<publisher>Zenobi</publisher>
+		<part name="flop1" interface="floppy_3">
+			<dataarea name="flop" size="194816">
+				<rom name="elfin wars, the (1994)(zenobi).dsk" size="194816" crc="026b892b" sha1="49b9412ac4e400ae53a1dbcef4f7c6c977880f6b" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="elfindor">
+		<description>Elfindor</description>
+		<year>1989</year>
+		<publisher>Zenobi</publisher>
+		<part name="flop1" interface="floppy_3">
+			<dataarea name="flop" size="194816">
+				<rom name="elfindor (1989)(zenobi)[re-release].dsk" size="194816" crc="3d6b222f" sha1="75a57b2af4042253332808a1298f5e8174e95227" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="eliminat">
+		<description>Eliminator</description>
+		<year>1988</year>
+		<publisher>Erbe</publisher>
+		<part name="flop1" interface="floppy_3">
+			<dataarea name="flop" size="52992">
+				<rom name="eliminator (1988)(erbe)(es)(en)[re-release].dsk" size="52992" crc="d14edabd" sha1="d375b03df6b0fcf137a57580f572c6fc2c56cb22" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="ellisndi">
+		<description>The Ellisnore Diamond</description>
+		<year>1992</year>
+		<publisher>Zenobi</publisher>
+		<part name="flop1" interface="floppy_3">
+			<dataarea name="flop" size="194816">
+				<rom name="ellisnore diamond, the (1992)(zenobi)[re-release].dsk" size="194816" crc="ee8934c6" sha1="3947b2c10415643d432e905ffca736aaf1142511" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="emeraelf">
+		<description>The Emerald Elf</description>
+		<year>1995</year>
+		<publisher>Zenobi</publisher>
+		<part name="flop1" interface="floppy_3">
+			<dataarea name="flop" size="194816">
+				<rom name="emerald elf, the (1995)(zenobi).dsk" size="194816" crc="95eaa5a9" sha1="38c565f37d17a6235f3db1d0e1bfcd06377baaca" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="emilbutr">
+		<description>Emilio Butragueno Futbol</description>
+		<year>1988</year>
+		<publisher>Ocean Software - Topo Soft</publisher>
+		<part name="flop1" interface="floppy_3">
+			<dataarea name="flop" size="58624">
+				<rom name="emilio butragueno futbol (1988)(ocean software - topo soft)(gb)(es).dsk" size="58624" crc="94d830d3" sha1="e1778ad33325399f2c9c3f9a5d788f374ac1098f" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="emilbutra" cloneof="emilbutr">
+		<description>Emilio Butragueno Futbol (alt)</description>
+		<year>1988</year>
+		<publisher>Ocean Software - Topo Soft</publisher>
+		<part name="flop1" interface="floppy_3">
+			<dataarea name="flop" size="116992">
+				<rom name="emilio butragueno futbol (1988)(ocean software - topo soft)(gb)(es)[a].dsk" size="116992" crc="a6184800" sha1="6bbfc0bc81082d1719b932b96128d362b3c7730f" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="esanchvi">
+		<description>Emilio Sanchez Vicario Grand Slam</description>
+		<year>1990</year>
+		<publisher>Zigurat</publisher>
+		<part name="flop1" interface="floppy_3">
+			<dataarea name="flop" size="58624">
+				<rom name="emilio sanchez vicario grand slam (1990)(zigurat)(es).dsk" size="58624" crc="c048d1f6" sha1="2bee364efe14224fba67057635970d7ebbf24a94" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="esanchvia" cloneof="esanchvi">
+		<description>Emilio Sanchez Vicario Grand Slam (alt)</description>
+		<year>1990</year>
+		<publisher>Zigurat</publisher>
+		<part name="flop1" interface="floppy_3">
+			<dataarea name="flop" size="58624">
+				<rom name="emilio sanchez vicario grand slam (1990)(zigurat)(es)[a].dsk" size="58624" crc="09b82d36" sha1="78c5f01c0d0af55813a4eb69495f430a338d39e9" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="emlynhug">
+		<description>Emlyn Hughes International Soccer</description>
+		<year>1989</year>
+		<publisher>Audiogenic</publisher>
+		<part name="flop1" interface="floppy_3">
+			<dataarea name="flop" size="194816">
+				<rom name="emlyn hughes international soccer (1989)(audiogenic).dsk" size="194816" crc="ebc0e76c" sha1="594526e9c2f40bdddd11c7f8a0d9ed4455d66377" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="esb">
+		<description>Star Wars - The Empire Strikes Back</description>
+		<year>1988</year>
+		<publisher>Domark</publisher>
+		<part name="flop1" interface="floppy_3">
+			<dataarea name="flop" size="195328">
+				<rom name="empire strikes back, the (1988)(domark).dsk" size="195328" crc="d95b5247" sha1="7c78b580409018da83683fe6e4e5ab687f9f6100" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="endisnig">
+		<description>The End Is Nigh</description>
+		<year>1994</year>
+		<publisher>Zenobi</publisher>
+		<part name="flop1" interface="floppy_3">
+			<dataarea name="flop" size="196096">
+				<rom name="end is nigh, the (1994)(zenobi).dsk" size="196096" crc="48e73904" sha1="23e85f5830bcc3cdfbfd385a80e2f4d7351c50fd" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<!-- May be the same edition as the IPF -->
+	<software name="erika" cloneof="erik">
+		<description>Erik - the Phantom of the Opera (alt)</description>
+		<year>1987</year>
+		<publisher>Crysys</publisher>
+		<part name="flop1" interface="floppy_3">
+			<dataarea name="flop" size="194816">
+				<rom name="erik - the phantom of the opera (1987)(crysys).dsk" size="194816" crc="08b83623" sha1="53834f2930e893f8961949b3d3a6fcf6d61513fc" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="efhodkma">
+		<description>The Escape from Hodgkins' Manor</description>
+		<year>1990</year>
+		<publisher>Zenobi</publisher>
+		<part name="flop1" interface="floppy_3">
+			<dataarea name="flop" size="194816">
+				<rom name="escape from hodgkins' manor, the (1990)(zenobi).dsk" size="194816" crc="4943ed9f" sha1="d2fa28b6de2422860bba3c76ec24119b2ab791fa" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="eschabit">
+		<description>The Escaping Habit</description>
+		<year>1992</year>
+		<publisher>Zenobi</publisher>
+		<part name="flop1" interface="floppy_3">
+			<dataarea name="flop" size="194816">
+				<rom name="escaping habit, the (1992)(zenobi).dsk" size="194816" crc="8083eba9" sha1="9e74c50b00acc63c9a93a68f275924b21e9fbd50" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<!-- May be the same edition as the IPF -->
+	<software name="espionaga" cloneof="espionag">
+		<description>Espionage (alt)</description>
+		<year>1988</year>
+		<publisher>Grandslam</publisher>
+		<info name="usage" value="Requires manual for password protection"/>
+		<part name="flop1" interface="floppy_3">
+			<dataarea name="flop" size="78080">
+				<rom name="espionage (1988)(grandslam)[passworded].dsk" size="78080" crc="69318518" sha1="36c295268a4c9ffb1311ed74bcea286a2e0be716" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="euspleag">
+		<description>European Superleague</description>
+		<year>1991</year>
+		<publisher>CDS Microsystems</publisher>
+		<part name="flop1" interface="floppy_3">
+			<dataarea name="flop" size="194816">
+				<rom name="european superleague (1991)(cds microsystems).dsk" size="194816" crc="78795ffd" sha1="03dc2bf5e3973765ae4b86352db8b22c6d8f83bf" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="extreme">
+		<description>Extreme</description>
+		<year>1991</year>
+		<publisher>Digital Integration</publisher>
+		<part name="flop1" interface="floppy_3">
+			<dataarea name="flop" size="63232">
+				<rom name="extreme (1991)(digital integration).dsk" size="63232" crc="67f4f1ba" sha1="ced54f8de664326392b48ed29072a4d5d5bea3eb" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="eye">
+		<description>Eye</description>
+		<year>1987</year>
+		<publisher>Endurance Games</publisher>
+		<part name="flop1" interface="floppy_3">
+			<dataarea name="flop" size="194816">
+				<rom name="eye (1987)(endurance games).dsk" size="194816" crc="a3f4c053" sha1="f4e24bf0714a533db047243aa2259efd849d874c" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="f1">
+		<description>F-1</description>
+		<year>1991</year>
+		<publisher>Zigurat</publisher>
+		<part name="flop1" interface="floppy_3">
+			<dataarea name="flop" size="58624">
+				<rom name="f-1 (1991)(zigurat)(es)[aka formula 1 g.p. simulator].dsk" size="58624" crc="0aa6b65d" sha1="671fd441c1efeae1e78f7ecbe78990d590e45179" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="f15strik">
+		<description>F-15 Strike Eagle</description>
+		<year>1990</year>
+		<publisher>Erbe</publisher>
+		<part name="flop1" interface="floppy_3">
+			<dataarea name="flop" size="48896">
+				<rom name="f-15 strike eagle (1990)(erbe)(es)(en).dsk" size="48896" crc="23150627" sha1="2f9f70218a77982f01a4dc12436a1cf90cc6da4c" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<!-- May be the same edition as the IPF -->
+	<software name="f16comba" cloneof="f16comb">
+		<description>F-16 Combat Pilot (alt)</description>
+		<year>1991</year>
+		<publisher>Digital Integration</publisher>
+		<part name="flop1" interface="floppy_3">
+			<dataarea name="flop" size="253952">
+				<rom name="f-16 combat pilot (1991)(digital integration).dsk" size="253952" crc="01b3104a" sha1="c3ebb2c4643f22e3b2526828d80b6927399f2f7c" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="f1tornadtmd">
+		<description>F1 Tornado Simulator (tape master disk)</description>
+		<year>1991</year>
+		<publisher>Zeppelin Games</publisher>
+		<part name="flop1" interface="floppy_3">
+			<dataarea name="flop" size="194816">
+				<rom name="f1 tornado simulator (1991)(zeppelin games)(side a)[tape master disk].dsk" size="194816" crc="e47114da" sha1="b1bf502cda2506caca76b29ec022acc9d9f28334" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<!-- May be the same edition as the IPF -->
+	<software name="federatna" cloneof="federatn">
+		<description>Federation (alt)</description>
+		<year>1988</year>
+		<publisher>CRL Group</publisher>
+		<part name="flop1" interface="floppy_3">
+			<dataarea name="flop" size="194816">
+				<rom name="federation (1988)(crl group)[aka quann tulla].dsk" size="194816" crc="0d18bc80" sha1="870ff7bd8239a44491a09d35d00adc60e2be0f4e" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="fernmdie">
+		<description>Fernandez Must Die</description>
+		<year>1988</year>
+		<publisher>Image Works</publisher>
+		<part name="flop1" interface="floppy_3">
+			<dataarea name="flop" size="204544">
+				<rom name="fernandez must die (1988)(image works).dsk" size="204544" crc="c3e2704a" sha1="8aecdf2e969486e5e5705c508c64a606196285c8" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="fmbasket">
+		<description>Fernando Martin Basket Master</description>
+		<year>1987</year>
+		<publisher>Dinamic</publisher>
+		<part name="flop1" interface="floppy_3">
+			<dataarea name="flop" size="61696">
+				<rom name="fernando martin basket master (1987)(dinamic)(es).dsk" size="61696" crc="72b4c4a7" sha1="d051b2fa332e4a043be9db87a5fabf865a7280fb" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="fiendish">
+		<description>Fiendish Freddy's Big Top o'Fun</description>
+		<year>1990</year>
+		<publisher>Mindscape International</publisher>
+		<info name="usage" value="Requires manual for password protection"/>
+		<part name="flop1" interface="floppy_3">
+			<feature name="part_id" value="Disk 1, Side A"/>
+			<dataarea name="flop" size="210688">
+				<rom name="fiendish freddy's big top o'fun (1990)(mindscape international)(disk 1 of 2 side a)[aka fiendish freddy's big top of fun].dsk" size="210688" crc="cb007678" sha1="c4fb51a1847efb8d2525280c8897e02d1c0246b1" offset="0" />
+			</dataarea>
+		</part>
+		<part name="flop2" interface="floppy_3">
+			<feature name="part_id" value="Disk 1, Side B"/>
+			<dataarea name="flop" size="210688">
+				<rom name="fiendish freddy's big top o'fun (1990)(mindscape international)(disk 1 of 2 side b)[aka fiendish freddy's big top of fun].dsk" size="210688" crc="7cc2258e" sha1="2de100a539a094138a275ac640be547205449315" offset="0" />
+			</dataarea>
+		</part>
+		<part name="flop3" interface="floppy_3">
+			<feature name="part_id" value="Disk 2, Side A"/>
+			<dataarea name="flop" size="210688">
+				<rom name="fiendish freddy's big top o'fun (1990)(mindscape international)(disk 2 of 2 side a)[aka fiendish freddy's big top of fun].dsk" size="210688" crc="b67fa7d0" sha1="097e034ac017abf99e95c57ac246fe41c525ce88" offset="0" />
+			</dataarea>
+		</part>
+		<part name="flop4" interface="floppy_3">
+			<feature name="part_id" value="Disk 2, Side B"/>
+			<dataarea name="flop" size="210688">
+				<rom name="fiendish freddy's big top o'fun (1990)(mindscape international)(disk 2 of 2 side b)[aka fiendish freddy's big top of fun].dsk" size="210688" crc="66b997c1" sha1="4c69f04de665f9ce180045955c79d1b52519df5d" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="finalch4">
+		<description>The Final Chorus v4</description>
+		<year>1995</year>
+		<publisher>Zenobi</publisher>
+		<part name="flop1" interface="floppy_3">
+			<dataarea name="flop" size="194816">
+				<rom name="final chorus, the v4 (1995)(zenobi).dsk" size="194816" crc="d08b9197" sha1="1e468dc36387e0bd1e0dd940f1a789a92176fd30" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="findeman">
+		<description>The Final Demand</description>
+		<year>1993</year>
+		<publisher>Zenobi</publisher>
+		<part name="flop1" interface="floppy_3">
+			<dataarea name="flop" size="194816">
+				<rom name="final demand, the (1993)(zenobi).dsk" size="194816" crc="a40709ef" sha1="4c5f3188c56403299a939e0f2f2d851ab45fb0e3" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="ffight">
+		<description>Final Fight</description>
+		<year>1991</year>
+		<publisher>U.S. Gold</publisher>
+		<part name="flop1" interface="floppy_3">
+			<feature name="part_id" value="Side A"/>
+			<dataarea name="flop" size="255232">
+				<rom name="final fight (1991)(u.s. gold)(side a).dsk" size="255232" crc="3dfc49e0" sha1="49bb04a9285a332f46370260d8883263f65f7c46" offset="0" />
+			</dataarea>
+		</part>
+		<part name="flop2" interface="floppy_3">
+			<feature name="part_id" value="Side B"/>
+			<dataarea name="flop" size="255232">
+				<rom name="final fight (1991)(u.s. gold)(side b).dsk" size="255232" crc="47ba3e39" sha1="dfc152177861daf9c6b2d8fb1a9b04cac78697ee" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<!-- May be the same edition as the IPF -->
+	<software name="fireflya" cloneof="firefly">
+		<description>Firefly (alt)</description>
+		<year>1988</year>
+		<publisher>Ocean</publisher>
+		<part name="flop1" interface="floppy_3">
+			<dataarea name="flop" size="214784">
+				<rom name="firefly (1988)(ocean).dsk" size="214784" crc="ea47b03f" sha1="e0f89ccf21303bee7fa8121b82e92b5827d288c6" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="fwproble">
+		<description>First World Problems</description>
+		<year>2014</year>
+		<publisher>&lt;homebrew&gt;</publisher>
+		<info name="author" value="ZX-Studio"/>
+		<part name="flop1" interface="floppy_3">
+			<dataarea name="flop" size="194816">
+				<rom name="first world problems (2014-09)(zx-studio).dsk" size="194816" crc="0e7c38d5" sha1="dc279a65d532ad052b47a1e197f494b017dc7e93" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<!-- May be the same edition as the IPF -->
+	<software name="fisha" cloneof="fish">
+		<description>Fish! (alt)</description>
+		<year>1989</year>
+		<publisher>Rainbird</publisher>
+		<part name="flop1" interface="floppy_3">
+			<dataarea name="flop" size="195072">
+				<rom name="fish (1989)(rainbird).dsk" size="195072" crc="9b110b8c" sha1="fb2313141dda5289a12b40cd91a12ac271f763bc" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="fishv103">
+		<description>Fish v1.03</description>
+		<year>1989</year>
+		<publisher>Rainbird</publisher>
+		<part name="flop1" interface="floppy_3">
+			<dataarea name="flop" size="194816">
+				<rom name="fish v1.03 (1989)(rainbird).dsk" size="194816" crc="367d44c8" sha1="a51b0cdefaffeae1d905be7f43af9a9bd3f60db7" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="fishrkin">
+		<description>The Fisher King</description>
+		<year>1991</year>
+		<publisher>Zenobi</publisher>
+		<part name="flop1" interface="floppy_3">
+			<dataarea name="flop" size="194816">
+				<rom name="fisher king, the (1991)(zenobi).dsk" size="194816" crc="59f46ec1" sha1="e845c6a90def997cf23b21ad2f8778d017a699f2" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="ffonecro">
+		<description>A Fistful of Necronomicons</description>
+		<year>1995</year>
+		<publisher>Zenobi</publisher>
+		<part name="flop1" interface="floppy_3">
+			<dataarea name="flop" size="194816">
+				<rom name="fistful of necronomicons, a (1995)(zenobi).dsk" size="194816" crc="9708f9dc" sha1="017585b35183a3b34251598ba3bd487fa79209ee" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="flameout">
+		<description>Flameout</description>
+		<year>1994</year>
+		<publisher>Zenobi</publisher>
+		<part name="flop1" interface="floppy_3">
+			<dataarea name="flop" size="194816">
+				<rom name="flameout (1994)(zenobi).dsk" size="194816" crc="7fe10b1b" sha1="7b9682942393ab38974f9fa92580685c639f34af" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<!-- May be the same edition as the IPF -->
+	<software name="footdir2a" cloneof="footdir2">
+		<description>Football Director II (alt)</description>
+		<year>1987</year>
+		<publisher>D&amp;H Games</publisher>
+		<part name="flop1" interface="floppy_3">
+			<dataarea name="flop" size="194816">
+				<rom name="football director ii (1987)(d&amp;h games).dsk" size="194816" crc="72886e79" sha1="7dfb23c32594aaa76891c502bfd27de6031aeaa0" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="fbmanagr">
+		<description>Football Manager</description>
+		<year>1982</year>
+		<publisher>Addictive Games</publisher>
+		<part name="flop1" interface="floppy_3">
+			<dataarea name="flop" size="194816">
+				<rom name="football manager (1982)(addictive games).dsk" size="194816" crc="b705269b" sha1="8b587fccf87e90f402262f1314996d1fca9fe37a" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="fbmanag3">
+		<description>Football Manager 3</description>
+		<year>1991</year>
+		<publisher>Addictive Games</publisher>
+		<part name="flop1" interface="floppy_3">
+			<feature name="part_id" value="Side A"/>
+			<dataarea name="flop" size="194816">
+				<rom name="football manager 3 (1991)(addictive games)(side a).dsk" size="194816" crc="a1514dc0" sha1="8cbf454e00edc0c92b333554566d9b305c5db587" offset="0" />
+			</dataarea>
+		</part>
+		<part name="flop2" interface="floppy_3">
+			<feature name="part_id" value="Side B"/>
+			<dataarea name="flop" size="194816">
+				<rom name="football manager 3 (1991)(addictive games)(side b).dsk" size="194816" crc="960d092a" sha1="5b2f005d623c1eb5406133d92a51d142ef5384aa" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<!-- May be the same edition as the IPF -->
+	<software name="foty2a" cloneof="foty2">
+		<description>Footballer of the Year 2 (alt)</description>
+		<year>1989</year>
+		<publisher>Gremlin Graphics</publisher>
+		<part name="flop1" interface="floppy_3">
+			<dataarea name="flop" size="255232">
+				<rom name="footballer of the year 2 (1989)(gremlin graphics).dsk" size="255232" crc="ed6b20ca" sha1="e9e349e01090b6323036cbe476e2197d3999e598" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="forpetes">
+		<description>For Pete's Sake</description>
+		<year>1993</year>
+		<publisher>Zenobi</publisher>
+		<part name="flop1" interface="floppy_3">
+			<dataarea name="flop" size="194816">
+				<rom name="for pete's sake (1993)(zenobi).dsk" size="194816" crc="2013dbe6" sha1="d2cd15437ebda07e9e40708c4847b9e61636583a" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="forgottn">
+		<description>Forgotten Worlds</description>
+		<year>1989</year>
+		<publisher>U.S. Gold</publisher>
+		<part name="flop1" interface="floppy_3">
+			<dataarea name="flop" size="213760">
+				<rom name="forgotten worlds (1989)(u.s. gold).dsk" size="213760" crc="2e8774e0" sha1="ac689946f98ace1e72edbfa4101f239b39a8d132" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="forgottna" cloneof="forgottn">
+		<description>Forgotten Worlds (alt)</description>
+		<year>1989</year>
+		<publisher>U.S. Gold</publisher>
+		<part name="flop1" interface="floppy_3">
+			<dataarea name="flop" size="133120">
+				<rom name="forgotten worlds (1989)(u.s. gold)[a].dsk" size="133120" crc="01bd6ff9" sha1="df381f59162d6c5979e598c75e2dec2a0d27494d" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="foursymb">
+		<description>The Four Symbols</description>
+		<year>1992</year>
+		<publisher>FSF Adventures</publisher>
+		<part name="flop1" interface="floppy_3">
+			<dataarea name="flop" size="194816">
+				<rom name="four symbols, the (1992)(fsf adventures).dsk" size="194816" crc="ba5f9395" sha1="c364ab3404004ae9caaeb3cde00a4ad0765345f9" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="foxxfigb">
+		<description>Foxx Fights Back</description>
+		<year>1988</year>
+		<publisher>Image Works</publisher>
+		<part name="flop1" interface="floppy_3">
+			<dataarea name="flop" size="73216">
+				<rom name="foxx fights back (1988)(image works)[f][aka fox fights back].dsk" size="73216" crc="c8362449" sha1="74abfc7c6f649b2724ca9efc1639ab586c8d5f09" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="fredhams">
+		<description>Freddy Hardest en Manhattan Sur</description>
+		<year>1989</year>
+		<publisher>Dinamic</publisher>
+		<part name="flop1" interface="floppy_3">
+			<dataarea name="flop" size="69632">
+				<rom name="freddy hardest en manhattan sur (1989)(dinamic)(es)[aka freddy hardest in south manhattan].dsk" size="69632" crc="421fbbe2" sha1="fd35f4b9f7c2525eed5dff0958d74732a1a46a1b" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="frightma">
+		<description>Frightmare</description>
+		<year>1988</year>
+		<publisher>Cascade Games</publisher>
+		<part name="flop1" interface="floppy_3">
+			<dataarea name="flop" size="194816">
+				<rom name="frightmare (1988)(cascade games).dsk" size="194816" crc="8b1fc84a" sha1="f9c574d1e34d937c688524ecea115775b8192759" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="fullthr2tmd">
+		<description>Full Throttle 2 (tape master disk)</description>
+		<year>1990</year>
+		<publisher>Zeppelin Games</publisher>
+		<part name="flop1" interface="floppy_3">
+			<dataarea name="flop" size="194816">
+				<rom name="full throttle 2 (1990)(zeppelin games)(side a)[tape master disk].dsk" size="194816" crc="8cd531b9" sha1="12b96391beb7b97a99eab2191b010b7900a82b17" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="funkyfuna" cloneof="funkyfun">
+		<description>Funky Fungus (alt)</description>
+		<year>2013</year>
+		<publisher>Alessandro Grussu</publisher>
+		<part name="flop1" interface="floppy_3">
+			<dataarea name="flop" size="194816">
+				<rom name="funky fungus (2013-09)(grussu, alessandro)(it)(m5).dsk" size="194816" crc="3300d623" sha1="94b79a2cb8744aa14bc6ebe0ca3d3d238b1751f4" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<!-- This version adds Italian to the language selection screen -->
+	<software name="funkyfun">
+		<description>Funky Fungus</description>
+		<year>2013</year>
+		<publisher>Alessandro Grussu</publisher>
+		<part name="flop1" interface="floppy_3">
+			<dataarea name="flop" size="194816">
+				<rom name="funky fungus (2013-09)(grussu, alessandro)(it)(m6).dsk" size="194816" crc="2438e3be" sha1="c8b718e2391504bdd116c7ea61bcd5de311d7f68" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="thefury">
+		<description>The Fury</description>
+		<year>1988</year>
+		<publisher>Martech Games</publisher>
+		<part name="flop1" interface="floppy_3">
+			<dataarea name="flop" size="214784">
+				<rom name="fury, the (1988)(martech games).dsk" size="214784" crc="63e21004" sha1="9591fe65eb2a0489b68aa623cb4e4711ba61422a" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="glocr360sp" cloneof="glocr360">
+		<description>G-LOC (Spain)</description>
+		<year>1992</year>
+		<publisher>Erbe</publisher>
+		<part name="flop1" interface="floppy_3">
+			<dataarea name="flop" size="127232">
+				<rom name="g-loc (1992)(erbe)(es)(en)[re-release].dsk" size="127232" crc="49e92c72" sha1="2b72df02d48e33984ed7e07ea064d6cf76cedbfe" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="glocr360">
+		<description>G-LOC - R360</description>
+		<year>1992</year>
+		<publisher>U.S. Gold</publisher>
+		<part name="flop1" interface="floppy_3">
+			<feature name="part_id" value="Side A"/>
+			<dataarea name="flop" size="255232">
+				<rom name="g-loc - r360 (1992)(u.s. gold)(side a).dsk" size="255232" crc="80751c5f" sha1="7fa45f3f94598f53398f8c32f6b5e89fbeb2605a" offset="0" />
+			</dataarea>
+		</part>
+		<part name="flop2" interface="floppy_3">
+			<feature name="part_id" value="Side B"/>
+			<dataarea name="flop" size="255232">
+				<rom name="g-loc - r360 (1992)(u.s. gold)(side b).dsk" size="255232" crc="af608104" sha1="a490a0e6121b1d16039ba5ef542c903b80faddcc" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="gwoaname">
+		<description>Game Without a Name</description>
+		<year>1987</year>
+		<publisher>Zenobi</publisher>
+		<part name="flop1" interface="floppy_3">
+			<dataarea name="flop" size="194816">
+				<rom name="game without a name (1987)(zenobi)[re-release].dsk" size="194816" crc="def2f93d" sha1="5638e013a70b850ba3d99cb96149f40b9db49b7d" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="gamessum">
+		<description>The Games - Summer Edition</description>
+		<year>1989</year>
+		<publisher>U.S. Gold</publisher>
+		<part name="flop1" interface="floppy_3">
+			<feature name="part_id" value="Side A"/>
+			<dataarea name="flop" size="194816">
+				<rom name="games - summer edition, the (1989)(u.s. gold)(side a).dsk" size="194816" crc="8d1100e4" sha1="eb8cc85279dbd1075dd783ba2807df92345021e5" offset="0" />
+			</dataarea>
+		</part>
+		<part name="flop2" interface="floppy_3">
+			<feature name="part_id" value="Side B"/>
+			<dataarea name="flop" size="194816">
+				<rom name="games - summer edition, the (1989)(u.s. gold)(side b).dsk" size="194816" crc="2f767573" sha1="dc8979f7558a486611f420f2cab285d82f00c7d8" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<!-- May be the same edition as the IPF -->
+	<software name="garfielda" cloneof="garfield">
+		<description>Garfield - Big, Fat, Hairy Deal (alt)</description>
+		<year>1988</year>
+		<publisher>The Edge</publisher>
+		<part name="flop1" interface="floppy_3">
+			<dataarea name="flop" size="194816">
+				<rom name="garfield - big, fat, hairy deal (1988)(edge, the).dsk" size="194816" crc="f49a2bfb" sha1="5b93c42be8793cee1e8a73d4ce4ad5308f829346" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<!-- May be the same edition as the IPF -->
+	<software name="linekskla" cloneof name="linekskl">
+		<description>Gary Lineker's Super Skills (alt)</description>
+		<year>1988</year>
+		<publisher>Gremlin Graphics</publisher>
+		<part name="flop1" interface="floppy_3">
+			<dataarea name="flop" size="194816">
+				<rom name="gary lineker's super skills (1988)(gremlin graphics).dsk" size="194816" crc="0383082c" sha1="3d62fbab0784ee24e2d624d84f4607ba39556879" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<!-- May be the same edition as the IPF -->
+	<software name="lineksssa" cloneof="lineksss">
+		<description>Gary Lineker's Super Star Soccer (alt)</description>
+		<year>1987</year>
+		<publisher>Gremlin Graphics</publisher>
+		<part name="flop1" interface="floppy_3">
+			<dataarea name="flop" size="174848">
+				<rom name="gary lineker's super star soccer (1987)(gremlin graphics).dsk" size="174848" crc="5ad471d4" sha1="9dfb8be61451f07184a1570dc0c42a290f884e75" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<!-- May be the same edition as the IPF -->
+	<software name="lineksssb" cloneof="lineksss">
+		<description>Gary Lineker's Super Star Soccer (alt 2)</description>
+		<year>1987</year>
+		<publisher>Gremlin Graphics</publisher>
+		<part name="flop1" interface="floppy_3">
+			<dataarea name="flop" size="174848">
+				<rom name="gary lineker's super star soccer (1987)(gremlin graphics)[a].dsk" size="174848" crc="33b7cea7" sha1="5147ecbc3eddb6bcada1f4516ca0139087b96851" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<!-- May be the same edition as the IPF -->
+	<software name="gauntletb" cloneof="gauntlet">
+		<description>Gauntlet (alt 2)</description>
+		<year>1987</year>
+		<publisher>U.S. Gold</publisher>
+		<part name="flop1" interface="floppy_3">
+			<dataarea name="flop" size="174848">
+				<rom name="gauntlet (1987)(u.s. gold).dsk" size="174848" crc="30f6477a" sha1="cace3b49f91e1e4b7c87c924e5df05294ab6a635" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<!-- May be the same edition as the IPF -->
+	<software name="gauntleta" cloneof="gauntlet">
+		<description>Gauntlet (alt)</description>
+		<year>1987</year>
+		<publisher>U.S. Gold</publisher>
+		<part name="flop1" interface="floppy_3">
+			<dataarea name="flop" size="194816">
+				<rom name="gauntlet (1987)(u.s. gold)[a].dsk" size="194816" crc="9073be5a" sha1="e360dab9875526fb0e3a94459d966dc0005efdcc" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<!-- May be the same edition as the IPF -->
+	<software name="gauntlt2a" cloneof="gauntlt2">
+		<description>Gauntlet II (alt)</description>
+		<year>1988</year>
+		<publisher>U.S. Gold</publisher>
+		<part name="flop1" interface="floppy_3">
+			<dataarea name="flop" size="174848">
+				<rom name="gauntlet ii (1988)(u.s. gold).dsk" size="174848" crc="9684ed6f" sha1="80a82fd9179e0cb5afd6eb3d0613508ef696da3e" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="gaunt3">
+		<description>Gauntlet III - The Final Quest</description>
+		<year>1991</year>
+		<publisher>Erbe</publisher>
+		<part name="flop1" interface="floppy_3">
+			<feature name="part_id" value="Side A"/>
+			<dataarea name="flop" size="255232">
+				<rom name="gauntlet iii - the final quest (1991)(erbe)(es)(en)(side a)[re-release].dsk" size="255232" crc="4fef2283" sha1="5b3f7b84d489900d62c594ee6430bfc40826ff69" offset="0" />
+			</dataarea>
+		</part>
+		<part name="flop2" interface="floppy_3">
+			<feature name="part_id" value="Side B"/>
+			<dataarea name="flop" size="256256">
+				<rom name="gauntlet iii - the final quest (1991)(erbe)(es)(en)(side b)[re-release].dsk" size="256256" crc="0c9043a0" sha1="7b923998a993f8d2bc48a54d67ce5deb693d14f5" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<!-- May be the same edition as the IPF -->
+	<software name="gazza2a" cloneof="gazza2">
+		<description>Gazza II (alt)</description>
+		<year>1990</year>
+		<publisher>Empire</publisher>
+		<part name="flop1" interface="floppy_3">
+			<dataarea name="flop" size="185088">
+				<rom name="gazza ii (1990)(empire).dsk" size="185088" crc="21159d93" sha1="5854e7aff0623135f9347a9a52512dd5e3c6c2c2" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="gazzasp" cloneof="gazza">
+		<description>Gazza's Super Soccer (Spain)</description>
+		<year>1990</year>
+		<publisher>Proein Soft Line</publisher>
+		<part name="flop1" interface="floppy_3">
+			<dataarea name="flop" size="194816">
+				<rom name="gazza's super soccer (1990)(proein soft line)(es)[re-release].dsk" size="194816" crc="d22b0f96" sha1="f25374b0533edda86d5fa9239e475f650df573c0" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="gemiwing">
+		<description>Gemini Wing</description>
+		<year>1989</year>
+		<publisher>Virgin Mastertronic</publisher>
+		<part name="flop1" interface="floppy_3">
+			<feature name="part_id" value="Side A"/>
+			<dataarea name="flop" size="49920">
+				<rom name="gemini wing (1989)(virgin mastertronic)(side a).dsk" size="49920" crc="ac37933e" sha1="e45156913ef978f1343313675ec9707506a1db83" offset="0" />
+			</dataarea>
+		</part>
+		<part name="flop2" interface="floppy_3">
+			<feature name="part_id" value="Side B"/>
+			<dataarea name="flop" size="189952">
+				<rom name="gemini wing (1989)(virgin mastertronic)(side b).dsk" size="189952" crc="b6fa2da2" sha1="5250b1bb4bb427f1caa40c95c85892299c86e200" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="genedown">
+		<description>Genesis - Dawn of a New Day</description>
+		<year>2010</year>
+		<publisher>RetroWorks</publisher>
+		<part name="flop1" interface="floppy_3">
+			<dataarea name="flop" size="194816">
+				<rom name="genesis - dawn of a new day (2010)(retroworks)(es)(en).dsk" size="194816" crc="b66be9f1" sha1="3cfbba9fe3fecd88970179782f44e4a8696492a1" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="ghoulssp" cloneof="ghouls">
+		<description>Ghouls 'n' Ghosts (Spain)</description>
+		<year>1989</year>
+		<publisher>Erbe</publisher>
+		<part name="flop1" interface="floppy_3">
+			<dataarea name="flop" size="255232">
+				<rom name="ghouls 'n' ghosts (1989)(erbe)(es)(en)[re-release].dsk" size="255232" crc="0e2116f3" sha1="7872f08c3ed59f1a0fe25c47483588ddaacff99e" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<!-- May be the same edition as the IPF -->
+	<software name="ghoulsa" cloneof="ghouls">
+		<description>Ghouls 'n' Ghosts (alt)</description>
+		<year>1989</year>
+		<publisher>U.S. Gold</publisher>
+		<part name="flop1" interface="floppy_3">
+			<dataarea name="flop" size="236032">
+				<rom name="ghouls 'n' ghosts (1989)(u.s. gold).dsk" size="236032" crc="684b0a6e" sha1="b222ee7bc8da5ef2ff368393b5b322ca7cceab65" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="giantkil">
+		<description>Giant Killer</description>
+		<year>1988</year>
+		<publisher>Topologika</publisher>
+		<part name="flop1" interface="floppy_3">
+			<dataarea name="flop" size="194816">
+				<rom name="giant killer (1988)(topologika).dsk" size="194816" crc="a14f9071" sha1="2b2817a0335d68b737198f6a63abefcd200eefd9" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="gnomeran">
+		<description>Gnome Ranger</description>
+		<year>1987</year>
+		<publisher>Level 9 Computing</publisher>
+		<part name="flop1" interface="floppy_3">
+			<feature name="part_id" value="Side A"/>
+			<dataarea name="flop" size="194816">
+				<rom name="gnome ranger (1987)(level 9 computing)(side a).dsk" size="194816" crc="c0a2c1d9" sha1="72dd23ade8f456d89227c117fc2a8deaa9cfed6a" offset="0" />
+			</dataarea>
+		</part>
+		<part name="flop2" interface="floppy_3">
+			<feature name="part_id" value="Side B"/>
+			<dataarea name="flop" size="194816">
+				<rom name="gnome ranger (1987)(level 9 computing)(side b).dsk" size="194816" crc="5cf4fde5" sha1="196e6eeba57acf9d3144c57786416510fd25735f" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="gnomerana" cloneof="gnomeran">
+		<description>Gnome Ranger (alt)</description>
+		<year>1987</year>
+		<publisher>Level 9 Computing</publisher>
+		<part name="flop1" interface="floppy_3">
+			<feature name="part_id" value="Side A"/>
+			<dataarea name="flop" size="194816">
+				<rom name="gnome ranger (1987)(level 9 computing)(side a)[a].dsk" size="194816" crc="ab6f9fc4" sha1="dee58071ffdcad55e876989ae3c6044c7b113c05" offset="0" />
+			</dataarea>
+		</part>
+		<part name="flop2" interface="floppy_3">
+			<feature name="part_id" value="Side B"/>
+			<dataarea name="flop" size="194816">
+				<rom name="gnome ranger (1987)(level 9 computing)(side b)[a].dsk" size="194816" crc="78d2948c" sha1="cb60320983e5293c988ad59ff8d855e947662345" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="godsowar">
+		<description>The Gods of War</description>
+		<year>1987</year>
+		<publisher>Zenobi</publisher>
+		<part name="flop1" interface="floppy_3">
+			<dataarea name="flop" size="194816">
+				<rom name="gods of war, the (1987)(zenobi)[re-release].dsk" size="194816" crc="5f17551f" sha1="323f1944464f40f6f3d3c71f3325720f976cee81" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="goldnaxesp" cloneof="goldnaxe">
+		<description>Golden Axe (Spain)</description>
+		<year>1990</year>
+		<publisher>MCM</publisher>
+		<part name="flop1" interface="floppy_3">
+			<feature name="part_id" value="Side A"/>
+			<dataarea name="flop" size="165888">
+				<rom name="golden axe (1990)(mcm)(es)(en)(side a)[re-release].dsk" size="165888" crc="6d1f7b39" sha1="ac6adace846dfb0317b10fe0b1c0563e024e2cc5" offset="0" />
+			</dataarea>
+		</part>
+		<part name="flop2" interface="floppy_3">
+			<feature name="part_id" value="Side B"/>
+			<dataarea name="flop" size="194816">
+				<rom name="golden axe (1990)(mcm)(es)(en)(side b)[re-release].dsk" size="194816" crc="66d2022a" sha1="ceb5c62acb2a9f9282aeee1f696dd336b9d853a7" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="goldnaxe">
+		<description>Golden Axe</description>
+		<year>1990</year>
+		<publisher>Virgin Games</publisher>
+		<part name="flop1" interface="floppy_3">
+			<feature name="part_id" value="Side A"/>
+			<dataarea name="flop" size="212736">
+				<rom name="golden axe (1990)(virgin games)(side a).dsk" size="212736" crc="2a528ede" sha1="091755e551ee628919411c50a0b0eeb387488658" offset="0" />
+			</dataarea>
+		</part>
+		<part name="flop2" interface="floppy_3">
+			<feature name="part_id" value="Side B"/>
+			<dataarea name="flop" size="194816">
+				<rom name="golden axe (1990)(virgin games)(side b).dsk" size="194816" crc="fcdd188f" sha1="bc390526d92c77193626f0419f89febd24ba3af9" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="gobasket">
+		<description>Golden Basket</description>
+		<year>1990</year>
+		<publisher>Opera Soft</publisher>
+		<part name="flop1" interface="floppy_3">
+			<dataarea name="flop" size="211968">
+				<rom name="golden basket (1990)(opera soft)(es).dsk" size="211968" crc="59dee941" sha1="4018f2064473474ff5e8b25f8f4323c0f7611b99" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="goldlock">
+		<description>The Golden Locket</description>
+		<year>1993</year>
+		<publisher>Zenobi</publisher>
+		<part name="flop1" interface="floppy_3">
+			<dataarea name="flop" size="194816">
+				<rom name="golden locket, the (1993)(zenobi)[re-release].dsk" size="194816" crc="53843bdd" sha1="607631dea927f5e00fba2818e0f5b795e954fe9e" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="goldpyra">
+		<description>The Golden Pyramid</description>
+		<year>1991</year>
+		<publisher>Zenobi</publisher>
+		<part name="flop1" interface="floppy_3">
+			<dataarea name="flop" size="194816">
+				<rom name="golden pyramid, the (1991)(zenobi).dsk" size="194816" crc="bedb25dc" sha1="706f7604eac2baeb15ebdfef25c631c1dd82ecdd" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="gswobhak">
+		<description>The Golden Sword of Bhakhor</description>
+		<year>1991</year>
+		<publisher>Zenobi</publisher>
+		<part name="flop1" interface="floppy_3">
+			<dataarea name="flop" size="194816">
+				<rom name="golden sword of bhakhor, the (1991)(zenobi).dsk" size="194816" crc="d02d944a" sha1="6b4eb8e54dcd781f04d7c37e6198bb60fb75ed79" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="grabghou">
+		<description>Grabbed by the Ghoulies</description>
+		<year>1992</year>
+		<publisher>FSF Adventures</publisher>
+		<part name="flop1" interface="floppy_3">
+			<dataarea name="flop" size="194816">
+				<rom name="grabbed by the ghoulies (1992)(fsf adventures)[re-release].dsk" size="194816" crc="dace798a" sha1="d449a4229125d4e858e7da44176d358be22b17cb" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="graesocctmd">
+		<description>Graeme Souness Soccer Manager (tape master disk)</description>
+		<year>1992</year>
+		<publisher>Zeppelin Games</publisher>
+		<part name="flop1" interface="floppy_3">
+			<dataarea name="flop" size="194816">
+				<rom name="graeme souness soccer manager (1992)(zeppelin games)[tape master disk].dsk" size="194816" crc="a28d55c1" sha1="3ea9842497c958a7c4f1c7ce3da5e3c4c24460b1" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<!-- would be clone of "Hudson Hawk" if a dump existed -->
+	<software name="hudsonhasp">
+		<description>El Gran Halcon</description>
+		<year>1991</year>
+		<publisher>Erbe</publisher>
+		<part name="flop1" interface="floppy_3">
+			<dataarea name="flop" size="146176">
+				<rom name="gran halcon, el (1991)(erbe)(es)(en)[aka hudson hawk][re-release].dsk" size="146176" crc="9bcc8c2b" sha1="df35fafcb381b0d02eb04baf6926b61ac83f0581" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="gryzor">
+		<description>Gryzor</description>
+		<year>1987</year>
+		<publisher>Ocean</publisher>
+		<part name="flop1" interface="floppy_3">
+			<dataarea name="flop" size="194816">
+				<rom name="gryzor (1987)(ocean).dsk" size="194816" crc="c237d67d" sha1="1ffb3dac932ab7b84cd9d06ed4a88312680026e9" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="gwar">
+		<description>Guerrilla War - Hail the Heroes</description>
+		<year>1988</year>
+		<publisher>Imagine</publisher>
+		<part name="flop1" interface="floppy_3">
+			<dataarea name="flop" size="134144">
+				<rom name="guerrilla war - hail the heroes (1988)(imagine).dsk" size="134144" crc="58d62d43" sha1="e17740a5fe4fd6468f9d107229bf252d94f3ef45" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="guilthie">
+		<description>The Guild of Thieves</description>
+		<year>1988</year>
+		<publisher>Rainbird</publisher>
+		<part name="flop1" interface="floppy_3">
+			<feature name="part_id" value="Side A"/>
+			<dataarea name="flop" size="194816">
+				<rom name="guild of thieves, the (1988)(rainbird)(side a).dsk" size="194816" crc="3048e6d4" sha1="56143b609159649b8ab836553cdaf84f7d2188e8" offset="0" />
+			</dataarea>
+		</part>
+		<part name="flop2" interface="floppy_3">
+			<feature name="part_id" value="Side B"/>
+			<dataarea name="flop" size="194816">
+				<rom name="guild of thieves, the (1988)(rainbird)(side b).dsk" size="194816" crc="869107d0" sha1="555451be82b911d0612445f4560a48303f195916" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="guilthiea" cloneof="guilthie">
+		<description>The Guild of Thieves (alt)</description>
+		<year>1988</year>
+		<publisher>Rainbird</publisher>
+		<part name="flop1" interface="floppy_3">
+			<dataarea name="flop" size="194816">
+				<rom name="guild of thieves, the (1988)(rainbird)(side a)[a].dsk" size="194816" crc="7832e385" sha1="a4c37a58156b5b957be5aefb9aaf0878c39f1123" offset="0" />
+			</dataarea>
+		</part>
+		<part name="flop2" interface="floppy_3">
+			<feature name="part_id" value="Side B"/>
+		<!-- Side missing from dump, using same as parent set -->
+			<dataarea name="flop" size="194816">
+				<rom name="guild of thieves, the (1988)(rainbird)(side b).dsk" size="194816" crc="869107d0" sha1="555451be82b911d0612445f4560a48303f195916" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="guiltell">
+		<description>Guillermo Tell</description>
+		<year>1989</year>
+		<publisher>Opera Soft</publisher>
+		<info name="usage" value="Requires Gun Stick lightgun"/>
+		<part name="flop1" interface="floppy_3">
+			<dataarea name="flop" size="216064">
+				<rom name="guillermo tell (1989)(opera soft)(es).dsk" size="216064" crc="6c1dae08" sha1="e4c18ad9bb2f04c1466c4cfd30362d57531ef9e5" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="gunship">
+		<description>Gunship</description>
+		<year>1987</year>
+		<publisher>MicroProse</publisher>
+		<part name="flop1" interface="floppy_3">
+			<feature name="part_id" value="Side A"/>
+			<dataarea name="flop" size="194816">
+				<rom name="gunship (1987)(microprose)(side a).dsk" size="194816" crc="b8c9e143" sha1="81e9922afff03d074d995c00614b490baaa1a10f" offset="0" />
+			</dataarea>
+		</part>
+		<part name="flop2" interface="floppy_3">
+			<feature name="part_id" value="Side B"/>
+			<dataarea name="flop" size="194816">
+				<rom name="gunship (1987)(microprose)(side b).dsk" size="194816" crc="abc054f8" sha1="60dfff8cbe8deb3cbadc770d1a320d3c4d5c247c" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="gunshipa" cloneof="gunship">
+		<description>Gunship (alt)</description>
+		<year>1987</year>
+		<publisher>MicroProse</publisher>
+		<part name="flop1" interface="floppy_3">
+			<feature name="part_id" value="Side A"/>
+			<dataarea name="flop" size="194816">
+				<rom name="gunship (1987)(microprose)(side a)[a].dsk" size="194816" crc="cb851c5f" sha1="c87ef92255d3b4739f13005995913a1b1ccd61ed" offset="0" />
+			</dataarea>
+		</part>
+		<part name="flop2" interface="floppy_3">
+			<feature name="part_id" value="Side B"/>
+			<dataarea name="flop" size="194816">
+				<rom name="gunship (1987)(microprose)(side b)[a].dsk" size="194816" crc="35775533" sha1="641ffdeb1d785040b2fab099d6442f617f2e11ca" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<!-- May be the same edition as the IPF -->
+	<software name="hatea" cloneof="hate">
+		<description>H.A.T.E. - Hostile All Terrain Encounter (alt)</description>
+		<year>1989</year>
+		<publisher>Gremlin Graphics</publisher>
+		<part name="flop1" interface="floppy_3">
+			<dataarea name="flop" size="219136">
+				<rom name="h.a.t.e. (1989)(gremlin graphics)[aka hostile all terrain encounter].dsk" size="219136" crc="c77d0383" sha1="60c22e50e0827fa2d8ee63fe496cd2e47046ba5a" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="harddriv">
+		<description>Hard Drivin'</description>
+		<year>1989</year>
+		<publisher>Domark</publisher>
+		<part name="flop1" interface="floppy_3">
+			<dataarea name="flop" size="194816">
+				<rom name="hard drivin' (1989)(domark).dsk" size="194816" crc="c26cc54a" sha1="77b919946cc3bc66a6a62c9a788351fd369fa75f" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="harddrivsp" cloneof="harddriv">
+		<description>Hard Drivin' (Spain)</description>
+		<year>1989</year>
+		<publisher>Erbe</publisher>
+		<part name="flop1" interface="floppy_3">
+			<dataarea name="flop" size="63488">
+				<rom name="hard drivin' (1989)(erbe)(es)(en)[re-release].dsk" size="63488" crc="e6f85a75" sha1="4e9a802f657b7fc04a02b0e0877830c582105ccf" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="harddriva" cloneof="harddriv">
+		<description>Hard Drivin' (alt)</description>
+		<year>1989</year>
+		<publisher>Domark</publisher>
+		<part name="flop1" interface="floppy_3">
+			<dataarea name="flop" size="194816">
+				<rom name="hard drivin' (1989)(domark)[a].dsk" size="194816" crc="384b47f2" sha1="08a23a450b6fbb383444b94e29bba02e871fb174" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="hellfiat">
+		<description>Hellfire Attack</description>
+		<year>1989</year>
+		<publisher>Martech Games</publisher>
+		<part name="flop1" interface="floppy_3">
+			<feature name="part_id" value="Side A"/>
+			<dataarea name="flop" size="214784">
+				<rom name="hellfire attack (1989)(martech games)(side a).dsk" size="214784" crc="793a0cac" sha1="5fe57928392926af38b69983d5f29dfd7f7632e9" offset="0" />
+			</dataarea>
+		</part>
+		<part name="flop2" interface="floppy_3">
+			<feature name="part_id" value="Side B"/>
+			<dataarea name="flop" size="194816">
+				<rom name="hellfire attack (1989)(martech games)(side b).dsk" size="194816" crc="12a71f04" sha1="c47c87075ec8cfe4ed9d4040e0accf1989079d86" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="helvera">
+		<description>Helvera - Mistress of the Park</description>
+		<year>1993</year>
+		<publisher>FSF Adventures</publisher>
+		<part name="flop1" interface="floppy_3">
+			<dataarea name="flop" size="194816">
+				<rom name="helvera - mistress of the park (1993)(fsf adventures).dsk" size="194816" crc="4da1fe77" sha1="069936422b4ff7ba66321efb70edb7eeba64c72a" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="hermitag">
+		<description>The Hermitage</description>
+		<year>1989</year>
+		<publisher>Pegasus</publisher>
+		<part name="flop1" interface="floppy_3">
+			<feature name="part_id" value="Side A"/>
+			<dataarea name="flop" size="194816">
+				<rom name="hermitage, the (1989)(pegasus)(side a).dsk" size="194816" crc="324ca25e" sha1="c8dfe93e92cd64160890698fac76329e140c6ebb" offset="0" />
+			</dataarea>
+		</part>
+		<part name="flop2" interface="floppy_3">
+			<feature name="part_id" value="Side B"/>
+			<dataarea name="flop" size="194816">
+				<rom name="hermitage, the (1989)(pegasus)(side b).dsk" size="194816" crc="c66477bb" sha1="0e1a7102c315843b58e057f45201a7803c356979" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<!-- May be the same edition as the IPF -->
+	<software name="heroqsta" cloneof="heroqst">
+		<description>Hero Quest (alt)</description>
+		<year>1991</year>
+		<publisher>Gremlin Graphics</publisher>
+		<part name="flop1" interface="floppy_3">
+			<dataarea name="flop" size="194816">
+				<rom name="hero quest (1991)(gremlin graphics).dsk" size="194816" crc="ab30a1d0" sha1="915dde45e84df561fea89b8b4c3cea6892ca85c1" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<!-- May be the same edition as the IPF -->
+	<software name="heroqstb" cloneof="heroqst">
+		<description>Hero Quest (alt 2)</description>
+		<year>1991</year>
+		<publisher>Gremlin Graphics</publisher>
+		<part name="flop1" interface="floppy_3">
+			<dataarea name="flop" size="194816">
+				<rom name="hero quest (1991)(gremlin graphics)[a].dsk" size="194816" crc="758aca42" sha1="1646d3fc7ad3719351cc9be38f3a7e714d9d866f" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<!-- May be the same edition as the IPF -->
+	<software name="heroqstc" cloneof="heroqst">
+		<description>Hero Quest (alt 3)</description>
+		<year>1991</year>
+		<publisher>Gremlin Graphics</publisher>
+		<part name="flop1" interface="floppy_3">
+			<dataarea name="flop" size="194816">
+				<rom name="hero quest (1991)(gremlin graphics)[a2].dsk" size="194816" crc="dec047e7" sha1="94dae34b89d72eed5e05f64a85f86aeac4ae8827" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<!-- May be the same edition as the IPF -->
+	<software name="heroqstd" cloneof="heroqst">
+		<description>Hero Quest (alt 4)</description>
+		<year>1991</year>
+		<publisher>Gremlin Graphics</publisher>
+		<part name="flop1" interface="floppy_3">
+			<dataarea name="flop" size="199680">
+				<rom name="hero quest (1991)(gremlin graphics)[a3].dsk" size="199680" crc="ceb5f071" sha1="1033f9307c145f34d8bc6d0fb8f8c7e581165588" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="heroque2">
+		<description>Hero Quest - Return of the Witch Lord</description>
+		<year>1991</year>
+		<publisher>Gremlin Graphics</publisher>
+		<part name="flop1" interface="floppy_3">
+			<dataarea name="flop" size="194816">
+				<rom name="hero quest - return of the witch lord (1991)(gremlin graphics).dsk" size="194816" crc="e11de839" sha1="6e72c9ffdfcefc98f26be651d6af9897f42c1826" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="heroque2a" cloneof="heroque2">
+		<description>Hero Quest - Return of the Witch Lord (alt)</description>
+		<year>1991</year>
+		<publisher>Gremlin Graphics</publisher>
+		<part name="flop1" interface="floppy_3">
+			<dataarea name="flop" size="194816">
+				<rom name="hero quest - return of the witch lord (1991)(gremlin graphics)[a].dsk" size="194816" crc="4ed5a340" sha1="71954827b51a39b4a682f94198026adf9f6f9205" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="heroque2b" cloneof="heroque2">
+		<description>Hero Quest - Return of the Witch Lord (alt 2)</description>
+		<year>1991</year>
+		<publisher>Gremlin Graphics</publisher>
+		<part name="flop1" interface="floppy_3">
+			<dataarea name="flop" size="194816">
+				<rom name="hero quest - return of the witch lord (1991)(gremlin graphics)[a2].dsk" size="194816" crc="86da0a2e" sha1="003e63884fb0a6dffcab7de701fad9df3206b4b5" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="heroque2c" cloneof="heroque2">
+		<description>Hero Quest - Return of the Witch Lord (alt 3)</description>
+		<year>1991</year>
+		<publisher>Gremlin Graphics</publisher>
+		<part name="flop1" interface="floppy_3">
+			<dataarea name="flop" size="199680">
+				<rom name="hero quest - return of the witch lord (1991)(gremlin graphics)[a3].dsk" size="199680" crc="cdac513e" sha1="c20215ef636d6c2f92a5af5a87a8c2e8ce8be774" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="heroesre">
+		<description>Heroes Rescue</description>
+		<year>2016</year>
+		<publisher>Defecto Digital Studios</publisher>
+		<part name="flop1" interface="floppy_3">
+			<dataarea name="flop" size="204544">
+				<rom name="heroes rescue (2016-12-23)(defecto digital studios).dsk" size="204544" crc="1802d377" sha1="909d426b26179f2521f43ab8074246a504007319" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="herolancsp" cloneof="herolanc">
+		<description>Heroes of the Lance (Spain)</description>
+		<year>1988</year>
+		<publisher>Erbe</publisher>
+		<part name="flop1" interface="floppy_3">
+			<dataarea name="flop" size="194816">
+				<rom name="heroes of the lance (1988)(erbe)(es)(en)[re-release].dsk" size="194816" crc="99cc6af8" sha1="afd6e3b1ae18888ed999d690a9373a0f7778c7a5" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<!-- May be the same edition as the IPF -->
+	<software name="herolanca" name="herolanc">
+		<description>Heroes of the Lance (alt)</description>
+		<year>1988</year>
+		<publisher>U.S. Gold</publisher>
+		<part name="flop1" interface="floppy_3">
+			<dataarea name="flop" size="194816">
+				<rom name="heroes of the lance (1988)(u.s. gold).dsk" size="194816" crc="48f81876" sha1="d801954e2eca715f3b0b0057ebccd7021c7cae9a" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="hidnseek">
+		<description>Hide and Seek</description>
+		<year>1995</year>
+		<publisher>Zenobi</publisher>
+		<part name="flop1" interface="floppy_3">
+			<dataarea name="flop" size="194816">
+				<rom name="hide and seek (1995)(zenobi)[re-release].dsk" size="194816" crc="a7b8a803" sha1="ee73f444d4637195c7272ea392dd174e534e0413" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="hobshoar">
+		<description>Hob's Hoard</description>
+		<year>1991</year>
+		<publisher>Zenobi</publisher>
+		<part name="flop1" interface="floppy_3">
+			<dataarea name="flop" size="194816">
+				<rom name="hob's hoard (1991)(zenobi).dsk" size="194816" crc="beca6e53" sha1="9b7f1c131bbab3b588a79667f06930535d0e47e8" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="hoppingm">
+		<description>Hopping Mad</description>
+		<year>1988</year>
+		<publisher>Elite Systems</publisher>
+		<part name="flop1" interface="floppy_3">
+			<dataarea name="flop" size="161024">
+				<rom name="hopping mad (1988)(elite systems)[aka hoppin' mad].dsk" size="161024" crc="a9a4d047" sha1="7e3fac325b154027565744795e70c2f387668a44" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="hostagessp" cloneof="hostages">
+		<description>Hostages (Spain)</description>
+		<year>1990</year>
+		<publisher>Erbe</publisher>
+		<part name="flop1" interface="floppy_3">
+			<feature name="part_id" value="Side A"/>
+			<dataarea name="flop" size="174848">
+				<rom name="hostages (1990)(erbe)(es)(en)(side a)[re-release].dsk" size="174848" crc="2d074804" sha1="0d75703c852d2941794701ccf668dc8edc68ad56" offset="0" />
+			</dataarea>
+		</part>
+		<part name="flop2" interface="floppy_3">
+			<feature name="part_id" value="Side B"/>
+			<dataarea name="flop" size="174848">
+				<rom name="hostages (1990)(erbe)(es)(en)(side b)[re-release].dsk" size="174848" crc="55da5edb" sha1="77a872dfe8a5b37880e27c101660e62fcb9102bb" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="hostages">
+		<description>Hostages</description>
+		<year>1990</year>
+		<publisher>Infogrames</publisher>
+		<part name="flop1" interface="floppy_3">
+			<feature name="part_id" value="Side A"/>
+			<dataarea name="flop" size="148736">
+				<rom name="hostages (1990)(infogrames)(fr)(en)(side a).dsk" size="148736" crc="181e0d1e" sha1="4db8c8ea16e12caa75cf6a5ebe046fe15f901726" offset="0" />
+			</dataarea>
+		</part>
+		<part name="flop2" interface="floppy_3">
+			<feature name="part_id" value="Side B"/>
+			<dataarea name="flop" size="135680">
+				<rom name="hostages (1990)(infogrames)(fr)(en)(side b).dsk" size="135680" crc="c5d910c7" sha1="0ad584237568a82c5c20a0e9b565303b8ac229d0" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="hotshot">
+		<description>Hotshot</description>
+		<year>1988</year>
+		<publisher>Prism Leisure Corporation</publisher>
+		<part name="flop1" interface="floppy_3">
+			<dataarea name="flop" size="204544">
+				<rom name="hotshot (1988)(prism leisure corporation)[re-release].dsk" size="204544" crc="c0382c46" sha1="34aa79e19795da44846fd0362cfbbf2318a1ea8a" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="houseott">
+		<description>The House on the Tor</description>
+		<year>1990</year>
+		<publisher>Zenobi</publisher>
+		<part name="flop1" interface="floppy_3">
+			<dataarea name="flop" size="194816">
+				<rom name="house on the tor, the (1990)(zenobi).dsk" size="194816" crc="a29246d9" sha1="49b35455d6747345933cefac220fe46fdd6cb76e" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="thehouse">
+		<description>The House</description>
+		<year>1994</year>
+		<publisher>Zenobi</publisher>
+		<part name="flop1" interface="floppy_3">
+			<dataarea name="flop" size="194816">
+				<rom name="house, the (1994)(zenobi).dsk" size="194816" crc="ce8ac110" sha1="56edf0e0151b87a7bf0e559638373a92a9c99496" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<!-- May be the same edition as the IPF -->
+	<software name="hkma" cloneof="hkm">
+		<description>H.K.M. - Human Killing Machine (alt)</description>
+		<year>1988</year>
+		<publisher>U.S. Gold</publisher>
+		<part name="flop1" interface="floppy_3">
+			<dataarea name="flop" size="219136">
+				<rom name="human killing machine (1988)(u.s. gold)[aka hkm].dsk" size="219136" crc="6070005d" sha1="aa6993a2e75dee924a8a673358c507922dbe939f" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="hkma" cloneof="hkm">
+		<description>Human Killing Machine (alt)</description>
+		<year>1988</year>
+		<publisher>U.S. Gold</publisher>
+		<part name="flop1" interface="floppy_3">
+			<dataarea name="flop" size="213760">
+				<rom name="human killing machine (1988)(u.s. gold)[a][aka hkm].dsk" size="213760" crc="23f6daf4" sha1="8a3d32f5da2c9087c1b50d4a205ad6086cd13862" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="ineedspe">
+		<description>I Need Speed</description>
+		<year>2009</year>
+		<publisher>Computer Emuzone</publisher>
+		<part name="flop1" interface="floppy_3">
+			<dataarea name="flop" size="194816">
+				<rom name="i need speed (2009)(computer emuzone)(es)(en).dsk" size="194816" crc="f1f45a4a" sha1="f63895b1d4353454c4ba29fce31bf9d2d4fa126a" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="icebreak">
+		<description>Ice-Breaker</description>
+		<year>1990</year>
+		<publisher>Topo Soft</publisher>
+		<part name="flop1" interface="floppy_3">
+			<dataarea name="flop" size="116992">
+				<rom name="ice-breaker (1990)(topo soft)(es).dsk" size="116992" crc="b92855fa" sha1="9bb3c9a9465251794cb4f52dba61b41fc31d6d0d" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="ikariwar">
+		<description>Ikari Warriors</description>
+		<year>1988</year>
+		<publisher>Elite Systems</publisher>
+		<part name="flop1" interface="floppy_3">
+			<dataarea name="flop" size="214784">
+				<rom name="ikari warriors (1988)(elite systems).dsk" size="214784" crc="6a5e6217" sha1="92702073e396e40ef274ed8bb90b0e2562ef6d64" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="ikariwara" alt="ikariwar">
+		<description>Ikari Warriors (alt)</description>
+		<year>1988</year>
+		<publisher>Elite Systems</publisher>
+		<part name="flop1" interface="floppy_3">
+			<dataarea name="flop" size="204032">
+				<rom name="ikari warriors (1988)(elite systems)[a].dsk" size="204032" crc="aa6e26a1" sha1="879c95e0827b5baace546ddf94a5f49a4555ab0c" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="impact">
+		<description>Impact</description>
+		<year>1992</year>
+		<publisher>Zenobi</publisher>
+		<part name="flop1" interface="floppy_3">
+			<dataarea name="flop" size="194816">
+				<rom name="impact (1992)(zenobi).dsk" size="194816" crc="596680d7" sha1="8b834a5283f06b3d14bd70e3ba7d5aa82b5378db" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="impossamsp" cloneof="impossam">
+		<description>Impossamole (Spain)</description>
+		<year>1990</year>
+		<publisher>Erbe</publisher>
+		<part name="flop1" interface="floppy_3">
+			<dataarea name="flop" size="214784">
+				<rom name="impossamole (1990)(erbe)(es)(en)[re-release].dsk" size="214784" crc="4e9a963d" sha1="1f0723d701dbaad0c57a47e0bde0ff79d5a58dd1" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="impossam">
+		<description>Impossamole</description>
+		<year>1990</year>
+		<publisher>Gremlin Graphics</publisher>
+		<part name="flop1" interface="floppy_3">
+			<dataarea name="flop" size="214784">
+				<rom name="impossamole (1990)(gremlin graphics).dsk" size="214784" crc="04ece926" sha1="dd49acee739bf6629420813275271305f8b48db2" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="indy3sp">
+		<description>Indiana Jones y la Ultima Cruzada</description>
+		<year>1989</year>
+		<publisher>Erbe</publisher>
+		<part name="flop1" interface="floppy_3">
+			<dataarea name="flop" size="194816">
+				<rom name="indiana jones y la ultima cruzada (1989)(erbe)(es)(en)[aka indiana jones and the last crusade][re-release].dsk" size="194816" crc="e2de5128" sha1="e0c5862105818b5d88fe5543f04ddc67f45be587" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="inf2rtre">
+		<description>Infiltrado 2 - Return To Reactor</description>
+		<year>2004</year>
+		<publisher>OCTOCOM</publisher>
+		<part name="flop1" interface="floppy_3">
+			<dataarea name="flop" size="194816">
+				<rom name="infiltrado 2 - return to reactor (2004)(octocom)(es).dsk" size="194816" crc="9196fcf8" sha1="392d82daf3c96bd84918935c9d3835a2127f1109" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="ingrback">
+		<description>Ingrid's Back</description>
+		<year>1988</year>
+		<publisher>Level 9 Computing</publisher>
+		<part name="flop1" interface="floppy_3">
+			<feature name="part_id" value="Side A"/>
+			<dataarea name="flop" size="194816">
+				<rom name="ingrid's back (1988)(level 9 computing)(side a).dsk" size="194816" crc="7b9efce5" sha1="c15eb32cc8c21ab3dc5919d3699ffbf707a52d6f" offset="0" />
+			</dataarea>
+		</part>
+		<part name="flop2" interface="floppy_3">
+			<feature name="part_id" value="Side B"/>
+			<dataarea name="flop" size="194816">
+				<rom name="ingrid's back (1988)(level 9 computing)(side b).dsk" size="194816" crc="02a85f6a" sha1="d401c963d2fd9a7cd80641e5c5ea34ffe54ae8a7" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="ingrbacka" cloneof="ingrback">
+		<description>Ingrid's Back (alt)</description>
+		<year>1988</year>
+		<publisher>Level 9 Computing</publisher>
+		<part name="flop1" interface="floppy_3">
+			<feature name="part_id" value="Side A"/>
+			<dataarea name="flop" size="194816">
+				<rom name="ingrid's back (1988)(level 9 computing)(side a)[a].dsk" size="194816" crc="7d33b69a" sha1="49230a2de96ad140c97c60cc31a03c6db1a77a06" offset="0" />
+			</dataarea>
+		</part>
+		<part name="flop2" interface="floppy_3">
+			<feature name="part_id" value="Side B"/>
+			<dataarea name="flop" size="194816">
+				<rom name="ingrid's back (1988)(level 9 computing)(side b)[a].dsk" size="194816" crc="a8c6adff" sha1="2e5f36a31a6eff7ff68d0105c28a03d7ba08133d" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="ingrbackb" cloneof="ingrback">
+		<description>Ingrid's Back (alt 2)</description>
+		<year>1988</year>
+		<publisher>Level 9 Computing</publisher>
+		<part name="flop1" interface="floppy_3">
+			<dataarea name="flop" size="389376">
+				<rom name="ingrid's back (1988)(level 9 computing)(side a)[a2].dsk" size="389376" crc="9f4244cf" sha1="67367fd3815e826f95b96a2cd56011cf7857e328" offset="0" />
+			</dataarea>
+		</part>
+		<part name="flop2" interface="floppy_3">
+			<feature name="part_id" value="Side B"/>
+		<!-- Side missing from dump, using same as parent set -->
+			<dataarea name="flop" size="194816">
+				<rom name="ingrid's back (1988)(level 9 computing)(side b).dsk" size="194816" crc="02a85f6a" sha1="d401c963d2fd9a7cd80641e5c5ea34ffe54ae8a7" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="intercit">
+		<description>The Inter City</description>
+		<year>1988</year>
+		<publisher>Steam Railway Simulations</publisher>
+		<part name="flop1" interface="floppy_3">
+			<dataarea name="flop" size="194816">
+				<rom name="inter city, the (1988)(steam railway simulations).dsk" size="194816" crc="63c6f473" sha1="d76be72e72634a97dc5ebd98fae82b7c4a0c2b8c" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="i5asfoottmd">
+		<description>International 5 A Side Football (tape master disk)</description>
+		<year>1992</year>
+		<publisher>Zeppelin Games</publisher>
+		<part name="flop1" interface="floppy_3">
+			<feature name="part_id" value="Side A"/>
+			<dataarea name="flop" size="194816">
+				<rom name="international 5 a side football (1992)(zeppelin games)(side a)[tape master disk].dsk" size="194816" crc="9e5b009d" sha1="cc2563d1268d9053070d0d6ffeb0d96170e7756c" offset="0" />
+			</dataarea>
+		</part>
+		<part name="flop2" interface="floppy_3">
+			<feature name="part_id" value="Side B"/>
+			<dataarea name="flop" size="194816">
+				<rom name="international 5 a side football (1992)(zeppelin games)(side b)[master disk].dsk" size="194816" crc="77a9b7e9" sha1="1b1ef57247eea772d00bb0bb9c9e264b443b8b93" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="inkarate">
+		<description>International Karate</description>
+		<year>1985</year>
+		<publisher>System 3</publisher>
+		<part name="flop1" interface="floppy_3">
+			<dataarea name="flop" size="194816">
+				<rom name="international karate (1985)(system 3).dsk" size="194816" crc="7321dcb7" sha1="85b8c729932f58e096a6d7dcbcb0441ea1162c6e" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="inttenn">
+		<description>International Tennis (master disk)</description>
+		<year>1992</year>
+		<publisher>Zeppelin Games</publisher>
+		<part name="flop1" interface="floppy_3">
+			<feature name="part_id" value="Side A"/>
+			<dataarea name="flop" size="194816">
+				<rom name="international tennis (1992)(zeppelin games)(side a)[master disk].dsk" size="194816" crc="a7fdd3c9" sha1="f696e4e7647a71bf8699fef24b5993ab09f2d398" offset="0" />
+			</dataarea>
+		</part>
+		<part name="flop2" interface="floppy_3">
+			<feature name="part_id" value="Side B"/>
+			<dataarea name="flop" size="194816">
+				<rom name="international tennis (1992)(zeppelin games)(side b).dsk" size="194816" crc="99808d9b" sha1="fe9e1a0ad26eedeca49fb5f33855e686b9cf1412" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="eaglnest">
+		<description>Into the Eagle's Nest</description>
+		<year>1987</year>
+		<publisher>Pandora</publisher>
+		<part name="flop1" interface="floppy_3">
+			<dataarea name="flop" size="73216">
+				<rom name="into the eagle's nest (1987)(pandora).dsk" size="73216" crc="32543165" sha1="6a3712a1938fef366d1ca4e5202f3b3a42711c57" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="untouchasp" cloneof="untoucha">
+		<description>Los Intocables</description>
+		<year>1989</year>
+		<publisher>Erbe</publisher>
+		<part name="flop1" interface="floppy_3">
+			<feature name="part_id" value="Side A"/>
+			<dataarea name="flop" size="39168">
+				<rom name="intocables, los (1989)(erbe)(es)(en)(side a)[aka untouchables, the][re-release].dsk" size="39168" crc="25d0a261" sha1="2fce2e88ee1f03affec4086011966ee90098ca7e" offset="0" />
+			</dataarea>
+		</part>
+		<part name="flop2" interface="floppy_3">
+			<feature name="part_id" value="Side B"/>
+			<dataarea name="flop" size="194816">
+				<rom name="intocables, los (1989)(erbe)(es)(en)(side b)[aka untouchables, the][re-release].dsk" size="194816" crc="cf0ff520" sha1="49a6c3aa3c0a45bf7cbb6633a1fe6738430b0a26" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<!-- May be the same edition as the IPF -->
+	<software name="ironlorda" cloneof="ironlord">
+		<description>Iron Lord (alt)</description>
+		<year>1989</year>
+		<publisher>Ubi Soft</publisher>
+		<part name="flop1" interface="floppy_3">
+			<dataarea name="flop" size="215296">
+				<rom name="iron lord (1989)(ubi soft)(fr)(en).dsk" size="215296" crc="6b0e52b2" sha1="8965b9086d66cbab42bc69f8a3abef2cbc9d23dd" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="isotcons">
+		<description>Isotopia Construction Set</description>
+		<year>2007</year>
+		<publisher>OCTOCOM</publisher>
+		<part name="flop1" interface="floppy_3">
+			<feature name="part_id" value="Side A"/>
+			<dataarea name="flop" size="194816">
+				<rom name="isotopia construction set (2007)(octocom)(es)(side a).dsk" size="194816" crc="14cb6ba0" sha1="d9f2a0783fda351a1a8b48551fbc7bb28e4e7c1e" offset="0" />
+			</dataarea>
+		</part>
+		<part name="flop2" interface="floppy_3">
+			<feature name="part_id" value="Side B"/>
+			<dataarea name="flop" size="194816">
+				<rom name="isotopia construction set (2007)(octocom)(es)(side b).dsk" size="194816" crc="405e6921" sha1="d6b8908dbc2810b1f55ae2e3aa5cafc68d541ea3" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<!-- May be the same edition as the IPF -->
+	<software name="italia90a" cloneof="italia90">
+		<description>Italia '90 - World Cup Soccer</description>
+		<year>1989</year>
+		<publisher>Virgin Games</publisher>
+		<part name="flop1" interface="floppy_3">
+			<dataarea name="flop" size="62720">
+				<rom name="italia '90 - world cup soccer (1989)(virgin games)[aka world cup soccer '90].dsk" size="62720" crc="f163182d" sha1="ed9cb8943e7275fe04b88174d8b9b5b7373ca9f1" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<!-- This would be a clone of "Italy 1990" if a dump existed. Not to confuse with "Italia '90 - World Cup Soccer" -->
+	<software name="italy90sp">
+		<description>Italia 1990</description>
+		<year>1990</year>
+		<publisher>Erbe</publisher>
+		<part name="flop1" interface="floppy_3">
+			<dataarea name="flop" size="80896">
+				<rom name="italia 1990 (1990)(erbe)(es)(en)[aka italy 1990][re-release].dsk" size="80896" crc="c682f692" sha1="682b9a4e2c93700635507aaeeaac92ce4a0bfb2f" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<!-- May be the same edition as the IPF -->
+	<software name="offroada" cloneof="offroad">
+		<description>Ivan 'Ironman' Stewart's Super Off Road (alt)</description>
+		<year>1990</year>
+		<publisher>Virgin Games</publisher>
+		<part name="flop1" interface="floppy_3">
+			<dataarea name="flop" size="56320">
+				<rom name="ivan 'ironman' stewart's super off road racer (1990)(virgin games).dsk" size="56320" crc="79166768" sha1="e35c4bff06d9ffaba8f84782cc5430d3e9107b48" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="jabato">
+		<description>Jabato</description>
+		<year>1989</year>
+		<publisher>Aventuras AD</publisher>
+		<part name="flop1" interface="floppy_3">
+			<dataarea name="flop" size="107264">
+				<rom name="jabato vs imperio - libertad (1989)(aventuras ad)(es).dsk" size="107264" crc="56519b9f" sha1="56ae5c77ff9e90aab9332af90cb126befb1585a8" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="jadeston">
+		<description>The Jade Stone</description>
+		<year>1987</year>
+		<publisher>Zenobi</publisher>
+		<part name="flop1" interface="floppy_3">
+			<feature name="part_id" value="Side A"/>
+			<dataarea name="flop" size="194816">
+				<rom name="jade stone, the (1987)(zenobi)(side a)[re-release].dsk" size="194816" crc="a62c7ffc" sha1="2a8d8b151521de78e8e746991215327ef408be10" offset="0" />
+			</dataarea>
+		</part>
+		<part name="flop2" interface="floppy_3">
+			<feature name="part_id" value="Side B"/>
+			<dataarea name="flop" size="194816">
+				<rom name="jade stone, the (1987)(zenobi)(side b)[re-release].dsk" size="194816" crc="b9dac541" sha1="392622dd2211fa9d8cd9502accd2169d276e613a" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="jadestona" cloneof="jadeston">>
+		<description>The Jade Stone (alt)</description>
+		<year>1987</year>
+		<publisher>Zenobi</publisher>
+		<part name="flop1" interface="floppy_3">
+			<dataarea name="flop" size="194816">
+				<rom name="jade stone, the (1987)(zenobi)[re-release].dsk" size="194816" crc="49966c26" sha1="9b58a66a9733afc97b9313279e90084436b9ef1d" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="jkhansqu">
+		<description>Jahangir Khan's World Championship Squash</description>
+		<year>1991</year>
+		<publisher>Krisalis</publisher>
+		<part name="flop1" interface="floppy_3">
+			<feature name="part_id" value="Side A"/>
+			<dataarea name="flop" size="194816">
+				<rom name="jahangir khan's world championship squash (1991)(krisalis)(side a).dsk" size="194816" crc="6cf8742c" sha1="7072549688ce96f3867bbbb647032803d5b72093" offset="0" />
+			</dataarea>
+		</part>
+		<part name="flop2" interface="floppy_3">
+			<feature name="part_id" value="Side B"/>
+			<dataarea name="flop" size="194816">
+				<rom name="jahangir khan's world championship squash (1991)(krisalis)(side b).dsk" size="194816" crc="654bbd30" sha1="78494f135b0182d9c1c3028c12dc4f79e5e95b02" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="janosik">
+		<description>Janosik</description>
+		<year>2013</year>
+		<publisher>&lt;homebrew&gt;</publisher>
+		<info name="author" value="Alex Heather, Rafal Miazga"/>
+		<part name="flop1" interface="floppy_3">
+			<dataarea name="flop" size="194816">
+				<rom name="janosik (2013)(heather, alex - miazga, rafal)(en-pl).dsk" size="194816" crc="27f80962" sha1="fafa9dd2ba30d6302b1ffe5ba32d0eac2a1e9832" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="jesterqu">
+		<description>Jester Quest</description>
+		<year>1988</year>
+		<publisher>Zenobi</publisher>
+		<part name="flop1" interface="floppy_3">
+			<dataarea name="flop" size="194816">
+				<rom name="jester quest (1988)(zenobi)[re-release].dsk" size="194816" crc="3503d839" sha1="c01d6ed8687c2ef51470e8ac0993f18be847bd4f" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="jbikesim">
+		<description>Jet Bike Simulator</description>
+		<year>1989</year>
+		<publisher>MCM</publisher>
+		<part name="flop1" interface="floppy_3">
+			<feature name="part_id" value="Side A"/>
+			<dataarea name="flop" size="208384">
+				<rom name="jet bike simulator (1989)(mcm)(es)(en)(side a).dsk" size="208384" crc="30433f34" sha1="48a9225faaf25e6b731df976d402a817d8ad8800" offset="0" />
+			</dataarea>
+		</part>
+		<part name="flop2" interface="floppy_3">
+			<feature name="part_id" value="Side B"/>
+			<dataarea name="flop" size="194816">
+				<rom name="jet bike simulator (1989)(mcm)(es)(en)(side b).dsk" size="194816" crc="79e4c0cb" sha1="d7b5cfbab542e5e77447d02d42568c7a27bd7a85" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="jsw128k">
+		<description>Jet Set Willy 128K</description>
+		<year>1996</year>
+		<publisher>John Elliott</publisher>
+		<part name="flop1" interface="floppy_3">
+			<dataarea name="flop" size="194816">
+				<rom name="jet set willy 128k (1996)(elliott, john).dsk" size="194816" crc="13ec1459" sha1="3e294edc5a2756230b0ea6f9d44b2b2034d67504" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="jinxter">
+		<description>Jinxter</description>
+		<year>1988</year>
+		<publisher>Rainbird</publisher>
+		<part name="flop1" interface="floppy_3">
+			<dataarea name="flop" size="194816">
+				<rom name="jinxter (1988)(rainbird).dsk" size="194816" crc="845679ed" sha1="81abfa5dc7aaba651416e4cd3e608a35efcb6003" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="jinxtera" cloneof="jinxter">
+		<description>Jinxter (alt)</description>
+		<year>1988</year>
+		<publisher>Rainbird</publisher>
+		<part name="flop1" interface="floppy_3">
+			<dataarea name="flop" size="194816">
+				<rom name="jinxter (1988)(rainbird)[a].dsk" size="194816" crc="7e71fb55" sha1="46d026205cec35b7852096ae05a7b7921d14f947" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="jockywil">
+		<description>Jocky Wilson's Compendium of Darts (tape master disk)</description>
+		<year>1991</year>
+		<publisher>Zeppelin Games</publisher>
+		<part name="flop1" interface="floppy_3">
+			<feature name="part_id" value="Side A"/>
+			<dataarea name="flop" size="194816">
+				<rom name="jocky wilson's compendium of darts (1991)(zeppelin games)(side a)[tape master disk].dsk" size="194816" crc="68116070" sha1="684f2f5521860e779c2d94d00108417286164671" offset="0" />
+			</dataarea>
+		</part>
+		<part name="flop2" interface="floppy_3">
+			<feature name="part_id" value="Side B"/>
+			<dataarea name="flop" size="194816">
+				<rom name="jocky wilson's compendium of darts (1991)(zeppelin games)(side b)[tape master disk].dsk" size="194816" crc="d56ab3bb" sha1="141a6d47460a5f5db1cc3eef7926ce80f6feaca4" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="junglewa">
+		<description>Jungle Warrior</description>
+		<year>1990</year>
+		<publisher>Zigurat</publisher>
+		<part name="flop1" interface="floppy_3">
+			<dataarea name="flop" size="63488">
+				<rom name="jungle warrior (1990)(zigurat)(es).dsk" size="63488" crc="3ca364a1" sha1="5cbaa05e1994dab8b18a9d9a126296d00a9bda66" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<!-- May be the same edition as the IPF -->
+	<software name="dalglisha" cloneof="dalglish">
+		<description>Kenny Dalglish Soccer Match (alt)</description>
+		<year>1990</year>
+		<publisher>Impressions</publisher>
+		<part name="flop1" interface="floppy_3">
+			<dataarea name="flop" size="194816">
+				<rom name="kenny dalglish soccer match (1990)(impressions).dsk" size="194816" crc="931767d6" sha1="17f63db7606e3b3b6dfe0803151b7c2cd3a475b8" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="khangpla">
+		<description>The Khangrin Plans</description>
+		<year>1992</year>
+		<publisher>Zenobi</publisher>
+		<part name="flop1" interface="floppy_3">
+			<dataarea name="flop" size="194816">
+				<rom name="khangrin plans, the (1992)(zenobi).dsk" size="194816" crc="775b884f" sha1="669b305e0c2dfde4b27b5141c620dbc7dd3b9a67" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<!-- May be the same edition as the IPF -->
+	<software name="kickoffa" cloneof="kickoff">
+		<description>Kick Off (alt)</description>
+		<year>1989</year>
+		<publisher>Anco</publisher>
+		<part name="flop1" interface="floppy_3">
+			<dataarea name="flop" size="194816">
+				<rom name="kick off (1989)(anco).dsk" size="194816" crc="6e2d2e18" sha1="d54e7dbc333ed5b99be8507169bffd6c0c2505da" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="kickoff2">
+		<description>Kick Off 2</description>
+		<year>1990</year>
+		<publisher>Anco</publisher>
+		<part name="flop1" interface="floppy_3">
+			<dataarea name="flop" size="160256">
+				<rom name="kick off 2 (1990)(anco).dsk" size="160256" crc="36135461" sha1="9f6ff7abb598322a77708e335d2bb4d981011d44" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="kickboxv">
+		<description>Kick-Box Vigilante (master disk)</description>
+		<year>1991</year>
+		<publisher>Zeppelin Games</publisher>
+		<part name="flop1" interface="floppy_3">
+			<feature name="part_id" value="Side A"/>
+			<dataarea name="flop" size="194816">
+				<rom name="kick-box vigilante (1991)(zeppelin games)(side a)[master disk].dsk" size="194816" crc="f2100695" sha1="0962c96fc583b64e18755157a392caf376237441" offset="0" />
+			</dataarea>
+		</part>
+		<part name="flop2" interface="floppy_3">
+			<feature name="part_id" value="Side B"/>
+			<dataarea name="flop" size="194816">
+				<rom name="kick-box vigilante (1991)(zeppelin games)(side b)[master disk].dsk" size="194816" crc="b03443f7" sha1="f76e6e9613bf1e13aad1ef07cb535d08fd9e4d14" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="kidnappe">
+		<description>Kidnapped</description>
+		<year>1993</year>
+		<publisher>Zenobi</publisher>
+		<part name="flop1" interface="floppy_3">
+			<dataarea name="flop" size="194816">
+				<rom name="kidnapped (1993)(zenobi).dsk" size="194816" crc="81158672" sha1="cde1ce0687c59de52c7e7ea040d948f8e9fd5ebd" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="klax">
+		<description>Klax</description>
+		<year>1990</year>
+		<publisher>Erbe</publisher>
+		<part name="flop1" interface="floppy_3">
+			<dataarea name="flop" size="146176">
+				<rom name="klax (1990)(erbe)(es)(en)[re-release].dsk" size="146176" crc="125e3c32" sha1="5148844e91af58b41f1b0867584d16dc4c52203c" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="kniglife">
+		<description>Knight Life</description>
+		<year>1995</year>
+		<publisher>Zenobi</publisher>
+		<part name="flop1" interface="floppy_3">
+			<dataarea name="flop" size="194816">
+				<rom name="knight life (1995)(zenobi)[re-release].dsk" size="194816" crc="475d8674" sha1="d70a7c9754461ed5f00c53d64c77aea49e8a26dd" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="knigorc2">
+		<description>Knight Orc v2</description>
+		<year>1987</year>
+		<publisher>Rainbird</publisher>
+		<part name="flop1" interface="floppy_3">
+			<feature name="part_id" value="Side A"/>
+			<dataarea name="flop" size="194816">
+				<rom name="knight orc v2 (1987)(rainbird)(side a).dsk" size="194816" crc="9a647bf9" sha1="7fa2d01743805510ef3f5f9ea0b580c944afe681" offset="0" />
+			</dataarea>
+		</part>
+		<part name="flop2" interface="floppy_3">
+			<feature name="part_id" value="Side B"/>
+			<dataarea name="flop" size="194816">
+				<rom name="knight orc v2 (1987)(rainbird)(side b).dsk" size="194816" crc="9f5f16b4" sha1="607aae53b43fa25b7a71622fc9be875b2f92eb2e" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="kobyaak">
+		<description>Kobyashi Ag'Kwo - A Return to Naru</description>
+		<year>1991</year>
+		<publisher>Zenobi</publisher>
+		<part name="flop1" interface="floppy_3">
+			<dataarea name="flop" size="194816">
+				<rom name="kobyashi ag'kwo - a return to naru (1991)(zenobi).dsk" size="194816" crc="c2fe764f" sha1="b7bb825691f738fc86ec3c7fb5439135abb699f0" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="kobyanar">
+		<description>Kobyashi Naru</description>
+		<year>1992</year>
+		<publisher>Zenobi</publisher>
+		<part name="flop1" interface="floppy_3">
+			<dataarea name="flop" size="194816">
+				<rom name="kobyashi naru (1992)(zenobi).dsk" size="194816" crc="36838f89" sha1="f565893ae4bf1f6624ab01684a662cd9e6561d43" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="krazykar">
+		<description>The Krazy Kartoonist Kaper</description>
+		<year>1991</year>
+		<publisher>Zenobi</publisher>
+		<part name="flop1" interface="floppy_3">
+			<dataarea name="flop" size="194816">
+				<rom name="krazy kartoonist kaper, the (1991)(zenobi)[re-release].dsk" size="194816" crc="2b788d74" sha1="09959def47b5983c292933bf5c5cf3cb7e0ffc1a" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="krunel">
+		<description>Krunel</description>
+		<year>2013</year>
+		<publisher>speccy.pl</publisher>
+		<part name="flop1" interface="floppy_3">
+			<dataarea name="flop" size="174336">
+				<rom name="krunel (2013-10)(speccy.pl)(pl)(en-pl)[retrokomp - load error].dsk" size="174336" crc="7bb2e53b" sha1="456a002a3ceee37a0383a6059c5ea63b629f9918" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="krunela" cloneof="krunel">
+		<description>Krunel (alt)</description>
+		<year>2013</year>
+		<publisher>speccy.pl</publisher>
+		<part name="flop1" interface="floppy_3">
+			<dataarea name="flop" size="194816">
+				<rom name="krunel (2013-10)(speccy.pl)(pl)(en-pl)[a][retrokomp - load error].dsk" size="194816" crc="146999a7" sha1="f5ee214443a1147539158512f5aca939c6ea0f5c" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="ledstorm">
+		<description>LED Storm Rally 2011</description>
+		<year>1988</year>
+		<publisher>Go</publisher>
+		<part name="flop1" interface="floppy_3">
+			<dataarea name="flop" size="194816">
+				<rom name="led storm rally 2011 (1988)(go).dsk" size="194816" crc="1a675e8d" sha1="295acfddcdff4a98ea290d9a9b2cf2da1b97de94" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="labopain">
+		<description>Labour Pains</description>
+		<year>1995</year>
+		<publisher>Zenobi</publisher>
+		<part name="flop1" interface="floppy_3">
+			<dataarea name="flop" size="194816">
+				<rom name="labour pains (1995)(zenobi).dsk" size="194816" crc="738366d9" sha1="898a86b4d51470078c0ef6972da6b4b8c6df1aff" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="laboherc">
+		<description>The Labours of Hercules</description>
+		<year>1987</year>
+		<publisher>Zenobi</publisher>
+		<part name="flop1" interface="floppy_3">
+			<dataarea name="flop" size="194816">
+				<rom name="labours of hercules, the (1987)(zenobi)[re-release].dsk" size="194816" crc="227a46ce" sha1="6df89841500cb7804beb566fd8cd77f0c6370cb4" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="lancelot">
+		<description>Lancelot</description>
+		<year>1988</year>
+		<publisher>Mandarin</publisher>
+		<part name="flop1" interface="floppy_3">
+			<feature name="part_id" value="Side A"/>
+			<dataarea name="flop" size="194816">
+				<rom name="lancelot (1988)(mandarin)(side a).dsk" size="194816" crc="9f77d0c7" sha1="00fcd843694d17a24b87746de910b7455c59795c" offset="0" />
+			</dataarea>
+		</part>
+		<part name="flop2" interface="floppy_3">
+			<feature name="part_id" value="Side B"/>
+			<dataarea name="flop" size="194816">
+				<rom name="lancelot (1988)(mandarin)(side b).dsk" size="194816" crc="73998eb5" sha1="a294d19bba726790c8b13b3f6ded3d5481cfc024" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="laskretu">
+		<description>Laskar's Return</description>
+		<year>1996</year>
+		<publisher>Zenobi</publisher>
+		<part name="flop1" interface="floppy_3">
+			<dataarea name="flop" size="194816">
+				<rom name="laskar's return (1996)(zenobi).dsk" size="194816" crc="fcd56503" sha1="da7c6830dd2e0b8868eab0c6f48b8b70eccec6be" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="lastduel">
+		<description>Last Duel</description>
+		<year>1989</year>
+		<publisher>U.S. Gold</publisher>
+		<part name="flop1" interface="floppy_3">
+			<dataarea name="flop" size="194816">
+				<rom name="last duel (1989)(u.s. gold).dsk" size="194816" crc="937a1143" sha1="92cc8ff23398d0fcd653375789d4772bff06d6e5" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<!-- May be the same edition as the IPF -->
+	<software name="lmohicana" cloneof="lmohican">
+		<description>The Last Mohican (alt)</description>
+		<year>1987</year>
+		<publisher>CRL Group</publisher>
+		<part name="flop1" interface="floppy_3">
+			<dataarea name="flop" size="194816">
+				<rom name="last mohican, the (1987)(crl group).dsk" size="194816" crc="40884d58" sha1="9e634b17b883ea6a3c4bd170a9290b472518643f" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="lazertag">
+		<description>Lazer Tag</description>
+		<year>1987</year>
+		<publisher>Go</publisher>
+		<part name="flop1" interface="floppy_3">
+			<dataarea name="flop" size="194816">
+				<rom name="lazer tag (1987)(go).dsk" size="194816" crc="a9fbd8fa" sha1="6e58f24e163b1ca99c0d11992bf7c1fdf743a3d2" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="legalami">
+		<description>A Legacy for Alaric - The Magic Isle</description>
+		<year>1989</year>
+		<publisher>Zenobi</publisher>
+		<part name="flop1" interface="floppy_3">
+			<dataarea name="flop" size="194816">
+				<rom name="legacy for alaric, a - the magic isle (1989)(zenobi).dsk" size="194816" crc="eee4511d" sha1="2c9509a694c1522b7654b7666ee340053d5ce275" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="lictokil">
+		<description>Licence to Kill</description>
+		<year>1989</year>
+		<publisher>Domark</publisher>
+		<part name="flop1" interface="floppy_3">
+			<dataarea name="flop" size="204544">
+				<rom name="licence to kill (1989)(domark).dsk" size="204544" crc="a7c8a74a" sha1="ad18bc2d679b787d22b9f606a0064afb2fdd5fdb" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="lictokila" cloneof="lictokil">
+		<description>Licence to Kill (alt)</description>
+		<year>1989</year>
+		<publisher>Domark</publisher>
+		<part name="flop1" interface="floppy_3">
+			<dataarea name="flop" size="62976">
+				<rom name="licence to kill (1989)(domark)[a].dsk" size="62976" crc="bffb147d" sha1="ac598ec517cdb0a87c0bffd9573b9bca794a6c24" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="lightcorsp" cloneof="lightcor">
+		<description>The Light Corridor (Spain)</description>
+		<year>1991</year>
+		<publisher>Erbe</publisher>
+		<part name="flop1" interface="floppy_3">
+			<dataarea name="flop" size="194816">
+				<rom name="light corridor, the (1991)(erbe)(es)(en)[re-release].dsk" size="194816" crc="9b575adf" sha1="5022b6e27edcc1072fda6bc516652b09e11c9277" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="lightcorspa" cloneof="lightcor">
+		<description>The Light Corridor (Spain) (alt)</description>
+		<year>1991</year>
+		<publisher>Erbe</publisher>
+		<part name="flop1" interface="floppy_3">
+			<dataarea name="flop" size="194816">
+				<rom name="light corridor, the (1991)(erbe)(es)(en)[a][re-release].dsk" size="194816" crc="fb7dbaf8" sha1="681888333e367e1673b6d1afad9d65880bb2125d" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<!-- May be the same edition as the IPF -->
+	<software name="lightcora" cloneof="lightcor">
+		<description>The Light Corridor (alt)</description>
+		<year>1991</year>
+		<publisher>Infogrames</publisher>
+		<part name="flop1" interface="floppy_3">
+			<dataarea name="flop" size="125696">
+				<rom name="light corridor, the (1991)(infogrames)(fr)(en)[aka light tunnel, the].dsk" size="125696" crc="92a595c8" sha1="e1b98eda358556ca198122da93588cfcf2529be0" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<!-- May be the same edition as the IPF -->
+	<software name="lightcorb" cloneof="lightcor">
+		<description>The Light Corridor (alt 2)</description>
+		<year>1991</year>
+		<publisher>Infogrames</publisher>
+		<part name="flop1" interface="floppy_3">
+			<dataarea name="flop" size="194816">
+				<rom name="light corridor, the (1991)(infogrames)(fr)(en)[a][aka light tunnel, the].dsk" size="194816" crc="34e92790" sha1="700e723d46527bf2b2e9ef777424bde9c61f8836" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<!-- May be the same edition as the IPF -->
+	<software name="lightcorc" cloneof="lightcor">
+		<description>The Light Corridor (alt 3)</description>
+		<year>1991</year>
+		<publisher>Infogrames</publisher>
+		<part name="flop1" interface="floppy_3">
+			<dataarea name="flop" size="194816">
+				<rom name="light corridor, the (1991)(infogrames)(fr)(en)[a2][aka light tunnel, the].dsk" size="194816" crc="68c833eb" sha1="4a44c1a6711a6312132aaab4653326bd3de4ee5c" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="lightmar">
+		<description>Lightmare</description>
+		<year>1989</year>
+		<publisher>Zenobi</publisher>
+		<part name="flop1" interface="floppy_3">
+			<dataarea name="flop" size="194816">
+				<rom name="lightmare (1989)(zenobi)[re-release].dsk" size="194816" crc="7fab0f98" sha1="6f75150a0a570d0b9f3685682f141068837507b0" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="litwangu">
+		<description>Little Wandering Guru</description>
+		<year>1990</year>
+		<publisher>Zenobi</publisher>
+		<part name="flop1" interface="floppy_3">
+			<dataarea name="flop" size="194816">
+				<rom name="little wandering guru (1990)(zenobi).dsk" size="194816" crc="d67fd30b" sha1="be5524083666238d46f6cfc63676e6257c0d3b38" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="liveandl">
+		<description>Live and Let Die - The Computer Game</description>
+		<year>1988</year>
+		<publisher>Domark</publisher>
+		<part name="flop1" interface="floppy_3">
+			<dataarea name="flop" size="194816">
+				<rom name="live and let die - the computer game (1988)(domark)[aka aquablast].dsk" size="194816" crc="9f28c23c" sha1="ca5037c6e004907de9e20e9fee9f6fe1adba8539" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="lmidnghta" cloneof="lmidnght">
+		<description>Loads of Midnight (alt)</description>
+		<year>1987</year>
+		<publisher>CRL Group</publisher>
+		<part name="flop1" interface="floppy_3">
+			<dataarea name="flop" size="194816">
+				<rom name="loads of midnight (1987)(crl group).dsk" size="194816" crc="6c184eee" sha1="16fc80fb50a860331e7688510a18859668d4e9e5" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<!-- May be the same edition as the IPF -->
+	<software name="lonewolfa" cloneof="lonewolf">
+		<description>Lone Wolf - The Mirror of Death (alt)</description>
+		<year>1991</year>
+		<publisher>Audiogenic</publisher>
+		<part name="flop1" interface="floppy_3">
+			<dataarea name="flop" size="194816">
+				<rom name="lone wolf - the mirror of death (1991)(audiogenic)[aka lone wolf 3].dsk" size="194816" crc="f3f5dfe2" sha1="6545eabf78d4dfda9381864c30680cd49d06fce0" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="looseend">
+		<description>Loose Ends</description>
+		<year>1995</year>
+		<publisher>Zenobi</publisher>
+		<part name="flop1" interface="floppy_3">
+			<dataarea name="flop" size="194816">
+				<rom name="loose ends (1995)(zenobi).dsk" size="194816" crc="ff20dd56" sha1="e700e95fd910e4d3879cad07d85785433da7fe78" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="lordsoch">
+		<description>Lords of Chaos</description>
+		<year>1990</year>
+		<publisher>Blade</publisher>
+		<part name="flop1" interface="floppy_3">
+			<dataarea name="flop" size="194816">
+				<rom name="lords of chaos (1990)(blade).dsk" size="194816" crc="a53890ef" sha1="f62c1ea98f84544533ad9d9e7a887f1b7e1f2f41" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="lordsocha" cloneof="lordsoch">
+		<description>Lords of Chaos (alt)</description>
+		<year>1990</year>
+		<publisher>Blade</publisher>
+		<part name="flop1" interface="floppy_3">
+			<dataarea name="flop" size="194816">
+				<rom name="lords of chaos (1990)(blade)[a].dsk" size="194816" crc="ffe27e16" sha1="522cb63098aad24516dd0e1d0acf8849f2db0a3c" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="losttwil">
+		<description>The Lost Twilight</description>
+		<year>1992</year>
+		<publisher>Zenobi</publisher>
+		<part name="flop1" interface="floppy_3">
+			<dataarea name="flop" size="194816">
+				<rom name="lost twilight, the (1992)(zenobi).dsk" size="194816" crc="30650533" sha1="8027860047eb4930e2fdf038d9afc0e292ab9f6b" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="lostinti">
+		<description>Lost in Time</description>
+		<year>1993</year>
+		<publisher>Zenobi</publisher>
+		<part name="flop1" interface="floppy_3">
+			<dataarea name="flop" size="194816">
+				<rom name="lost in time (1993)(zenobi).dsk" size="194816" crc="880e6526" sha1="024adaa12a5ec729a38a889369115c00197257f4" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="lotussp" cloneof="lotus">
+		<description>Lotus Esprit Turbo Challenge (Spain)</description>
+		<year>1990</year>
+		<publisher>Erbe</publisher>
+		<part name="flop1" interface="floppy_3">
+			<dataarea name="flop" size="199680">
+				<rom name="lotus esprit turbo challenge (1990)(erbe)(es)(en)[re-release].dsk" size="199680" crc="f187be6b" sha1="da097b93b3f0b1e86b7842272a45afea4899e878" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<!-- May be the same edition as the IPF -->
+	<software name="lotusa" cloneof="lotus">
+		<description>Lotus Esprit Turbo Challenge (alt)</description>
+		<year>1990</year>
+		<publisher>Gremlin Graphics</publisher>
+		<part name="flop1" interface="floppy_3">
+			<dataarea name="flop" size="199680">
+				<rom name="lotus esprit turbo challenge (1990)(gremlin graphics).dsk" size="199680" crc="e923e142" sha1="ee13b432dfc4ed546e18404f6a87390904b05de9" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<!-- May be the same edition as the IPF -->
+	<software name="mask3a" cloneof="mask3">
+		<description>Mask III - Venom Strikes Back (alt)</description>
+		<year>1988</year>
+		<publisher>Gremlin Graphics</publisher>
+		<part name="flop1" interface="floppy_3">
+			<dataarea name="flop" size="174848">
+				<rom name="mask iii - venom strikes back (1988)(gremlin graphics).dsk" size="174848" crc="8b33e09b" sha1="91884a8317c4a1db2d06e7683f6e5d7ee93e68c2" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="madmix2">
+		<description>Mad Mix 2 - en el Castillo de los Fantasmas</description>
+		<year>1990</year>
+		<publisher>Topo Soft</publisher>
+		<part name="flop1" interface="floppy_3">
+			<dataarea name="flop" size="121856">
+				<rom name="mad mix 2 - en el castillo de los fantasmas (1990)(topo soft)(es).dsk" size="121856" crc="034ba62a" sha1="a1ddd069ab31d173f981617e86dfcddcc28d3ae5" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="madmix">
+		<description>Mad Mix Game</description>
+		<year>1988</year>
+		<publisher>Topo Soft</publisher>
+		<part name="flop1" interface="floppy_3">
+			<dataarea name="flop" size="194816">
+				<rom name="mad mix game (1988)(topo soft)(es).dsk" size="194816" crc="b358a0a4" sha1="438a6951c8ab4c02616541d0c977639b96d91fbd" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="magicfie">
+		<description>Magic Fields</description>
+		<year>1996</year>
+		<publisher>Zack</publisher>
+		<part name="flop1" interface="floppy_3">
+			<dataarea name="flop" size="194816">
+				<rom name="magic fields (1996)(zack).dsk" size="194816" crc="d6bc3077" sha1="2446d53a8c23d50e9d904c4d990ec52cde33d805" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="magicjoh">
+		<description>Magic Johnson's Basketball</description>
+		<year>1990</year>
+		<publisher>Dro Soft</publisher>
+		<part name="flop1" interface="floppy_3">
+			<dataarea name="flop" size="179968">
+				<rom name="magic johnson's basketball (1990)(dro soft)(es).dsk" size="179968" crc="a2141eff" sha1="33acdfe75a0148d8fcc9322f1a922328b6851e7e" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="magnmoon">
+		<description>Magnetic Moon</description>
+		<year>1989</year>
+		<publisher>FSF Adventures</publisher>
+		<part name="flop1" interface="floppy_3">
+			<feature name="part_id" value="Side A"/>
+			<dataarea name="flop" size="194816">
+				<rom name="magnetic moon (1989)(fsf adventures)(side a).dsk" size="194816" crc="e5549cb9" sha1="97f2db8c8f20e2b55fd6fa23d9ec3e14f3fa5bae" offset="0" />
+			</dataarea>
+		</part>
+		<part name="flop2" interface="floppy_3">
+			<feature name="part_id" value="Side B"/>
+			<dataarea name="flop" size="194816">
+				<rom name="magnetic moon (1989)(fsf adventures)(side b).dsk" size="194816" crc="fcf49c0c" sha1="667d915e4bebb36a675b7ace30830d1d374c0c6a" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="manabtho">
+		<description>Man About the House</description>
+		<year>1994</year>
+		<publisher>Zenobi</publisher>
+		<part name="flop1" interface="floppy_3">
+			<dataarea name="flop" size="195584">
+				<rom name="man about the house (1994)(zenobi).dsk" size="195584" crc="228ce391" sha1="13c4903dcb060c867f5ecf4e47148e100e361891" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="manchunisp" cloneof="manchuni">
+		<description>Manchester United (Spain)</description>
+		<year>1990</year>
+		<publisher>System 4</publisher>
+		<part name="flop1" interface="floppy_3">
+			<dataarea name="flop" size="194816">
+				<rom name="manchester united (1990)(system 4)(es)[re-release].dsk" size="194816" crc="820d22dd" sha1="8d0a38f4faf8367674eeb75fb1067220478877ae" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="manchuni">
+		<description>Manchester United - The Official Computer Game</description>
+		<year>1990</year>
+		<publisher>Krisalis</publisher>
+		<part name="flop1" interface="floppy_3">
+			<feature name="part_id" value="Side A"/>
+			<dataarea name="flop" size="194816">
+				<rom name="manchester united - the official computer game (1990)(krisalis)(side a).dsk" size="194816" crc="136dfa7f" sha1="62dc94c188a7ffd69b8164eaacf341272c602dde" offset="0" />
+			</dataarea>
+		</part>
+		<part name="flop2" interface="floppy_3">
+			<feature name="part_id" value="Side B"/>
+			<dataarea name="flop" size="194816">
+				<rom name="manchester united - the official computer game (1990)(krisalis)(side b).dsk" size="194816" crc="90f83d48" sha1="d61bbbdca571666fe87b70380791e6fba181b1e9" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="themappe">
+		<description>The Mapper</description>
+		<year>1992</year>
+		<publisher>Zenobi</publisher>
+		<part name="flop1" interface="floppy_3">
+			<dataarea name="flop" size="194816">
+				<rom name="mapper, the (1992)(zenobi).dsk" size="194816" crc="5a054203" sha1="1242f4424b6dafa9818a7a95260600a349525161" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<!-- May be the same edition as the IPF -->
+	<software name="mastersa" cloneof="masters">
+		<description>Masters of the Universe - The Movie (alt)</description>
+		<year>1987</year>
+		<publisher>Gremlin Graphics</publisher>
+		<part name="flop1" interface="floppy_3">
+			<dataarea name="flop" size="174848">
+				<rom name="masters of the universe - the movie (1987)(gremlin graphics).dsk" size="174848" crc="2f9a0bdb" sha1="e7c580e989076026cded8688e70e264ab36ece19" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="matchda2a" cloneof="matchda2">
+		<description>Match Day II (alt)</description>
+		<year>1987</year>
+		<publisher>Ocean</publisher>
+		<part name="flop1" interface="floppy_3">
+			<dataarea name="flop" size="214784">
+				<rom name="match day ii (1987)(ocean).dsk" size="214784" crc="bf33c550" sha1="a07e166575814e59f3b4a95ea9617de6bec7525a" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="matchda2">
+		<description>Match Day II</description>
+		<year>1987</year>
+		<publisher>Ocean</publisher>
+		<part name="flop1" interface="floppy_3">
+			<dataarea name="flop" size="208384">
+				<rom name="match day ii (1987)(ocean)[a].dsk" size="208384" crc="584f511d" sha1="50bf8521cc8b86af9d2307f0af6d2441707cf82e" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="matchotdtmd">
+		<description>Match of the Day (tape master disk)</description>
+		<year>1992</year>
+		<publisher>Zeppelin Premier</publisher>
+		<part name="flop1" interface="floppy_3">
+			<feature name="part_id" value="Side A"/>
+			<dataarea name="flop" size="194816">
+				<rom name="match of the day (1992)(zeppelin premier)(side a)[tape master disk].dsk" size="194816" crc="3ae454c0" sha1="d760c1b13bcd87158243f24cdbccd323e8f541c5" offset="0" />
+			</dataarea>
+		</part>
+		<part name="flop2" interface="floppy_3">
+			<feature name="part_id" value="Side B"/>
+			<dataarea name="flop" size="194816">
+				<rom name="match of the day (1992)(zeppelin premier)(side b)[tape master disk].dsk" size="194816" crc="974d8a03" sha1="a937cdf001322220fd906503fe8a686665a432a7" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="megaphx">
+		<description>Mega Phoenix</description>
+		<year>1991</year>
+		<publisher>Dinamic</publisher>
+		<part name="flop1" interface="floppy_3">
+			<dataarea name="flop" size="61952">
+				<rom name="mega phoenix (1991)(dinamic)(es)(en).dsk" size="61952" crc="c0b40920" sha1="794b2904af91cb3cc9ab90b755d0585a5575db96" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="megatwin">
+		<description>Mega Twins</description>
+		<year>19??</year>
+		<publisher>U.S. Gold</publisher>
+		<part name="flop1" interface="floppy_3">
+			<dataarea name="flop" size="194816">
+				<rom name="mega twins (19xx)(u.s. gold).dsk" size="194816" crc="bb36aa81" sha1="36dac0d2d5ad150374a2b96da4a1f919014842fe" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<!-- May be the same edition as the IPF -->
+	<software name="megapocla" cloneof="megapocl">
+		<description>MegaApocalypse (alt)</description>
+		<year>1988</year>
+		<publisher>Martech Games</publisher>
+		<part name="flop1" interface="floppy_3">
+			<dataarea name="flop" size="194560">
+				<rom name="mega-apocalypse (1988)(martech games).dsk" size="194560" crc="09ab5dfb" sha1="55c1d99704a52620b8d3eef3dbb4fc6b64078b32" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="meltdown">
+		<description>Meltdown</description>
+		<year>1993</year>
+		<publisher>Zenobi</publisher>
+		<part name="flop1" interface="floppy_3">
+			<dataarea name="flop" size="194816">
+				<rom name="meltdown (1993)(zenobi).dsk" size="194816" crc="79e96439" sha1="67bfe6fe8124d9ab64c2c2eec27c663b1ba1a0fb" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="merctarg">
+		<description>Mercenary - Escape from Targ</description>
+		<year>1987</year>
+		<publisher>Novagen</publisher>
+		<part name="flop1" interface="floppy_3">
+			<dataarea name="flop" size="214784">
+				<rom name="mercenary - escape from targ (1987)(novagen)[aka mercenary i].dsk" size="214784" crc="0cb15868" sha1="f26f5c17f52814380093ce9ebc04ebba57c12118" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="metropol">
+		<description>Metropolis</description>
+		<year>1989</year>
+		<publisher>Topo Soft</publisher>
+		<part name="flop1" interface="floppy_3">
+			<dataarea name="flop" size="102400">
+				<rom name="metropolis (1989)(topo soft)(es).dsk" size="102400" crc="313c2f98" sha1="b181ea90b8721341ff3bf1a02087ba15e5fc5cc3" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<!-- May be the same edition as the IPF -->
+	<software name="mickey" cloneof="mickey">
+		<description>Mickey Mouse - The Computer Game (alt)</description>
+		<year>1988</year>
+		<publisher>Gremlin Graphics</publisher>
+		<part name="flop1" interface="floppy_3">
+			<dataarea name="flop" size="174848">
+				<rom name="mickey mouse - the computer game (1988)(gremlin graphics).dsk" size="174848" crc="7ffc722d" sha1="29a312a7d1c5a9bc90c6e747c05d6a28947a0b11" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+<!-- Unknown if it comes from the "large case" or "small case" releases, or a different one -->
+	<software name="micpsocc">
+		<description>MicroProse Soccer</description>
+		<year>1989</year>
+		<publisher>MicroProse</publisher>
+		<part name="flop1" interface="floppy_3">
+			<feature name="part_id" value="Side A"/>
+			<dataarea name="flop" size="204288">
+				<rom name="microprose soccer (1989)(microprose)(side a).dsk" size="204288" crc="b680f0db" sha1="0fb565f33db3414c2ea6ac54465f32d65a445b3e" offset="0" />
+			</dataarea>
+		</part>
+		<part name="flop2" interface="floppy_3">
+			<feature name="part_id" value="Side B"/>
+			<dataarea name="flop" size="198400">
+				<rom name="microprose soccer (1989)(microprose)(side b).dsk" size="198400" crc="282461f8" sha1="74c714f3959583861e54f0d4d173d3189d7b1f23" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="micpsoccl" cloneof="micpsocc">
+		<description>MicroProse Soccer (large case release)</description>
+		<year>1989</year>
+		<publisher>MicroProse</publisher>
+		<part name="flop1" interface="floppy_3">
+			<feature name="part_id" value="Side A"/>
+			<dataarea name="flop" size="198400">
+				<rom name="microprose soccer (1989)(microprose)(side a)[large case].dsk" size="198400" crc="cc39b989" sha1="4331bf5eb6f92c7f3df08d90f035397f4cf9f4e5" offset="0" />
+			</dataarea>
+		</part>
+		<part name="flop2" interface="floppy_3">
+			<feature name="part_id" value="Side B"/>
+			<dataarea name="flop" size="198400">
+				<rom name="microprose soccer (1989)(microprose)(side b)[large case].dsk" size="198400" crc="def0ef4c" sha1="8a20e82c15a92b2d4a961039473e750ec183565d" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="micpsoccs" cloneof="micpsocc">
+		<description>MicroProse Soccer (small case release)</description>
+		<year>1989</year>
+		<publisher>MicroProse</publisher>
+		<part name="flop1" interface="floppy_3">
+			<feature name="part_id" value="Side A"/>
+			<dataarea name="flop" size="199680">
+				<rom name="microprose soccer (1989)(microprose)(side a)[small case].dsk" size="199680" crc="e8863f3d" sha1="c389a8c63fa1a5dd4fd7eea514b1c4462361b79f" offset="0" />
+			</dataarea>
+		</part>
+		<part name="flop2" interface="floppy_3">
+			<feature name="part_id" value="Side B"/>
+			<dataarea name="flop" size="194816">
+				<rom name="microprose soccer (1989)(microprose)(side b)[small case].dsk" size="194816" crc="4270be41" sha1="98a2e1005deb05398fbd51697cf23ef568e3daa9" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="micpsoccsp" cloneof="micpsocc">
+		<description>MicroProse Soccer (Spain)</description>
+		<year>1990</year>
+		<publisher>Erbe</publisher>
+		<part name="flop1" interface="floppy_3">
+			<feature name="part_id" value="Side A"/>
+			<dataarea name="flop" size="126720">
+				<rom name="microprose soccer (1990)(erbe)(es)(en)(side a).dsk" size="126720" crc="1a3db2c7" sha1="ad2406b5a85e4a3486ee349c81bc008a5a5cd880" offset="0" />
+			</dataarea>
+		</part>
+		<part name="flop2" interface="floppy_3">
+			<feature name="part_id" value="Side B"/>
+			<dataarea name="flop" size="126720">
+				<rom name="microprose soccer (1990)(erbe)(es)(en)(side b).dsk" size="126720" crc="010d5914" sha1="52e77e6b35392cb055ba70513f335adaee061724" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="midressp" cloneof="midres">
+		<description>Midnight Resistance (Spain)</description>
+		<year>1990</year>
+		<publisher>Erbe</publisher>
+		<part name="flop1" interface="floppy_3">
+			<dataarea name="flop" size="155904">
+				<rom name="midnight resistance (1990)(erbe)(es)(en)[re-release].dsk" size="155904" crc="f76b30d2" sha1="55c8124f6fc372eaae8c83d42a0dbfec8331aa23" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="midresa" cloneof="midres">
+		<description>Midnight Resistance (alt)</description>
+		<year>1990</year>
+		<publisher>Ocean</publisher>
+		<part name="flop1" interface="floppy_3">
+			<dataarea name="flop" size="194816">
+				<rom name="midnight resistance (1990)(ocean).dsk" size="194816" crc="bebed342" sha1="ed5067b98d17085961e4079630f78a8cae1c2e6b" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="midresb" cloneof="midres">
+		<description>Midnight Resistance (alt 2)</description>
+		<year>1990</year>
+		<publisher>Ocean</publisher>
+		<part name="flop1" interface="floppy_3">
+			<dataarea name="flop" size="133120">
+				<rom name="midnight resistance (1990)(ocean)[a].dsk" size="133120" crc="cd5e36f6" sha1="4264fe3752d41250bb506a4e55d05ee609fbe89b" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="midsumdd">
+		<description>A Midsummer Days Dream</description>
+		<year>1994</year>
+		<publisher>The Adventure Workshop</publisher>
+		<part name="flop1" interface="floppy_3">
+			<feature name="part_id" value="Side A"/>
+			<dataarea name="flop" size="194816">
+				<rom name="midsummer days dream, a (1994)(adventure workshop, the)(side a).dsk" size="194816" crc="0186997c" sha1="cf81c30648dc1a4dfd9354543f4b4200d7655103" offset="0" />
+			</dataarea>
+		</part>
+		<part name="flop2" interface="floppy_3">
+			<feature name="part_id" value="Side B"/>
+			<dataarea name="flop" size="194816">
+				<rom name="midsummer days dream, a (1994)(adventure workshop, the)(side b).dsk" size="194816" crc="258653a4" sha1="14f76b880678600ab0640320637f435c65687be3" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="mikegunn">
+		<description>Mike Gunner</description>
+		<year>1988</year>
+		<publisher>Dinamic</publisher>
+		<info name="usage" value="Requires Gun Stick lightgun"/>
+		<part name="flop1" interface="floppy_3">
+			<dataarea name="flop" size="48128">
+				<rom name="mike gunner (1988)(dinamic)(es).dsk" size="48128" crc="cd42d72c" sha1="1c3deadb5b1c773eb672785a4a3a9ddf0628a3fc" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="mineslit">
+		<description>The Mines of Lithiad</description>
+		<year>1992</year>
+		<publisher>Zenobi</publisher>
+		<part name="flop1" interface="floppy_3">
+			<dataarea name="flop" size="194816">
+				<rom name="mines of lithiad, the (1992)(zenobi).dsk" size="194816" crc="ef26827d" sha1="1d8816a4efb4110804144d6bc8c01e30f40e4a6d" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="themiser">
+		<description>The Miser</description>
+		<year>1990</year>
+		<publisher>Zenobi</publisher>
+		<part name="flop1" interface="floppy_3">
+			<dataarea name="flop" size="194816">
+				<rom name="miser, the (1990)(zenobi)[re-release].dsk" size="194816" crc="e6047e88" sha1="8a0ffb19d6d945069f1c81e2bed5d542d9f3242f" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<!-- May be the same edition as the IPF -->
+	<software name="montypyta" cloneof="montypyt">
+		<description>Monty Python's Flying Circus (alt)</description>
+		<year>1990</year>
+		<publisher>Virgin Games</publisher>
+		<part name="flop1" interface="floppy_3">
+			<dataarea name="flop" size="444160">
+				<rom name="monty python's flying circus (1990)(virgin games).dsk" size="444160" crc="65ef4491" sha1="8ca022b6217973f74088ce73e342d985170526f5" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="moonwalk">
+		<description>Moonwalker</description>
+		<year>1989</year>
+		<publisher>Erbe</publisher>
+		<part name="flop1" interface="floppy_3">
+			<dataarea name="flop" size="175360">
+				<rom name="moonwalker (1989)(erbe)(es)(en)[re-release].dsk" size="175360" crc="39947fe4" sha1="101558c1c2d1eaa6cceb0e577ea5e592a9b5d77f" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="morta2sc">
+		<description>Mortadelo y Filemon II - Safari Callejero</description>
+		<year>1990</year>
+		<publisher>Dro Soft</publisher>
+		<part name="flop1" interface="floppy_3">
+			<dataarea name="flop" size="136448">
+				<rom name="mortadelo y filemon ii - safari callejero (1990)(dro soft)(es).dsk" size="136448" crc="d1ce653f" sha1="145f9f353caceb4b9d120825df518aad989c5358" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="mot">
+		<description>Mot</description>
+		<year>1989</year>
+		<publisher>Opera Soft</publisher>
+		<part name="flop1" interface="floppy_3">
+			<feature name="part_id" value="Side A"/>
+			<dataarea name="flop" size="216064">
+				<rom name="mot (1989)(opera soft)(es)(side a).dsk" size="216064" crc="38cb620e" sha1="ac1720562402058bec93bb1874f2ffb6a254a31d" offset="0" />
+			</dataarea>
+		</part>
+		<part name="flop2" interface="floppy_3">
+			<feature name="part_id" value="Side B"/>
+			<dataarea name="flop" size="216064">
+				<rom name="mot (1989)(opera soft)(es)(en)(side b).dsk" size="216064" crc="1ce38009" sha1="6be5093a31679a9c9015f85a9e63dd677d78f6a5" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="motorbik">
+		<description>Motorbike Madness</description>
+		<year>1988</year>
+		<publisher>Dro Soft</publisher>
+		<part name="flop1" interface="floppy_3">
+			<dataarea name="flop" size="87808">
+				<rom name="motorbike madness (1988)(dro soft)(es)(en)[re-release].dsk" size="87808" crc="4046284a" sha1="20f002bcb06f6512bad05e21a968c46a512bfe17" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="mbikeractmdb" cloneof="mbikeractmd">
+		<description>Mountain Bike Racer (tape master disk backup)</description>
+		<year>1990</year>
+		<publisher>Zeppelin Games</publisher>
+		<part name="flop1" interface="floppy_3">
+			<dataarea name="flop" size="221696">
+				<rom name="mountain bike racer (1990)(zeppelin games)(side a)[tape master disk backup].dsk" size="221696" crc="227c9919" sha1="5d1fcf6073631ccca5c56e971e419bd2d1a8fcd2" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="mbikeractmd">
+		<description>Mountain Bike Racer (tape master disk)</description>
+		<year>1990</year>
+		<publisher>Zeppelin Games</publisher>
+		<part name="flop1" interface="floppy_3">
+			<feature name="part_id" value="Side A"/>
+			<dataarea name="flop" size="221184">
+				<rom name="mountain bike racer (1990)(zeppelin games)(side a)[tape master disk].dsk" size="221184" crc="f7d64c70" sha1="0c039a8292e5ce3c60c7f83b15e252ffe6e719aa" offset="0" />
+			</dataarea>
+		</part>
+		<part name="flop2" interface="floppy_3">
+			<feature name="part_id" value="Side B"/>
+			<dataarea name="flop" size="221184">
+				<rom name="mountain bike racer (1990)(zeppelin games)(side b)[tape master disk].dsk" size="221184" crc="1617646c" sha1="d09be5ebcaa4f43650cf251a55ec334a1e319001" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="mrheli">
+		<description>Mr. Heli</description>
+		<year>1989</year>
+		<publisher>Firebird</publisher>
+		<part name="flop1" interface="floppy_3">
+			<dataarea name="flop" size="194816">
+				<rom name="mr. heli (1989)(firebird).dsk" size="194816" crc="90d80eb1" sha1="b8564ca8d32e8148b8383c2d2438d82557f67d2b" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="mumcry21">
+		<description>The Mummy's Crypt v2.1</description>
+		<year>1992</year>
+		<publisher>Zenobi</publisher>
+		<part name="flop1" interface="floppy_3">
+			<dataarea name="flop" size="194816">
+				<rom name="mummy's crypt, the v2.1 (1992)(zenobi)[re-release].dsk" size="194816" crc="608ab573" sha1="9548ee0a3a2d4fb3f838bb8578fa817f1069da2b" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="themunch">
+		<description>The Muncher Eats Chewits</description>
+		<year>1988</year>
+		<publisher>Gremlin Graphics</publisher>
+		<part name="flop1" interface="floppy_3">
+			<dataarea name="flop" size="219136">
+				<rom name="muncher eats chewits, the (1988)(gremlin graphics)[aka t-wrecks].dsk" size="219136" crc="270a56fa" sha1="783a340ffcc78cee07e51953272467302277e459" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="mufutbol">
+		<description>Mundial de Futbol</description>
+		<year>1990</year>
+		<publisher>Opera Soft</publisher>
+		<part name="flop1" interface="floppy_3">
+			<dataarea name="flop" size="213760">
+				<rom name="mundial de futbol (1990)(opera soft)(es).dsk" size="213760" crc="8e6822c8" sha1="5aad4dde6097f92818d54ff100a65032cbdba519" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="italia90sp" cloneof="italia90">
+		<description>Mundial de Futbol Italia '90</description>
+		<year>1989</year>
+		<publisher>Dro Soft</publisher>
+		<part name="flop1" interface="floppy_3">
+			<dataarea name="flop" size="53760">
+				<rom name="mundial de futbol italia '90 (1989)(dro soft)(es)(en)[aka italia '90 - world cup soccer][re-release].dsk" size="53760" crc="2f2383c2" sha1="ba167694d1a341e339d3943b477f5a48bca37a2c" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="italia90spa" cloneof="italia90">
+		<description>Mundial de Futbol Italia '90 (alt)</description>
+		<year>1989</year>
+		<publisher>Dro Soft</publisher>
+		<part name="flop1" interface="floppy_3">
+			<dataarea name="flop" size="194816">
+				<rom name="mundial de futbol italia '90 (1989)(dro soft)(es)(en)[a][aka italia '90 - world cup soccer][re-release].dsk" size="194816" crc="f1195dff" sha1="d5102712dede9536d154996e095d83afa0545c42" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="murdhesa">
+		<description>Murder - He Said</description>
+		<year>1993</year>
+		<publisher>Zenobi</publisher>
+		<part name="flop1" interface="floppy_3">
+			<dataarea name="flop" size="194816">
+				<rom name="murder - he said (1993)(zenobi).dsk" size="194816" crc="80b24b05" sha1="221d3290ca81d52fae54f265f33ba8d346265166" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="murdhunt">
+		<description>Murder Hunt</description>
+		<year>1989</year>
+		<publisher>Zenobi</publisher>
+		<part name="flop1" interface="floppy_3">
+			<dataarea name="flop" size="194816">
+				<rom name="murder hunt (1989)(zenobi)[re-release].dsk" size="194816" crc="ac1eb412" sha1="9ee6625ae921fab337c1b6ab840791ba9be75a66" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="murdhun2">
+		<description>Murder Hunt II</description>
+		<year>1992</year>
+		<publisher>Zenobi</publisher>
+		<part name="flop1" interface="floppy_3">
+			<dataarea name="flop" size="194816">
+				<rom name="murder hunt ii (1992)(zenobi).dsk" size="194816" crc="4e8c8f76" sha1="71d1d2a16d069072589ac7dc2017972495f0c4ff" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="mutiny">
+		<description>Mutiny</description>
+		<year>1995</year>
+		<publisher>Zenobi</publisher>
+		<part name="flop1" interface="floppy_3">
+			<feature name="part_id" value="Side A"/>
+			<dataarea name="flop" size="194816">
+				<rom name="mutiny (1995)(zenobi)(side a).dsk" size="194816" crc="c32b1aff" sha1="12c7d93106b97fbc49d36cc1bc2ef3b90dbe444f" offset="0" />
+			</dataarea>
+		</part>
+		<part name="flop2" interface="floppy_3">
+			<feature name="part_id" value="Side B"/>
+			<dataarea name="flop" size="194816">
+				<rom name="mutiny (1995)(zenobi)(side b).dsk" size="194816" crc="84e125d1" sha1="84d95956eeadd16b9159082e32a611436a0f8ca4" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="mystical">
+		<description>Mystical</description>
+		<year>1991</year>
+		<publisher>Infogrames</publisher>
+		<part name="flop1" interface="floppy_3">
+			<dataarea name="flop" size="199680">
+				<rom name="mystical (1991)(infogrames)(fr)(en).dsk" size="199680" crc="8484c2f3" sha1="52549d1ede9927f975725cdad0eba5a68585df19" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="narc">
+		<description>NARC</description>
+		<year>1990</year>
+		<publisher>Ocean</publisher>
+		<part name="flop1" interface="floppy_3">
+			<feature name="part_id" value="Side A"/>
+			<dataarea name="flop" size="472832">
+				<rom name="narc (1990)(ocean)(side a).dsk" size="472832" crc="ab564c53" sha1="d6246df64708b1a16ce54f8705ae32ea5a1bb4ad" offset="0" />
+			</dataarea>
+		</part>
+		<part name="flop2" interface="floppy_3">
+			<feature name="part_id" value="Side B"/>
+			<dataarea name="flop" size="472832">
+				<rom name="narc (1990)(ocean)(side b).dsk" size="472832" crc="407be166" sha1="7cb436ca6a45201b71a440316a6178589d910e64" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="narcopol">
+		<description>Narco Police</description>
+		<year>1990</year>
+		<publisher>Dinamic</publisher>
+		<part name="flop1" interface="floppy_3">
+			<dataarea name="flop" size="131584">
+				<rom name="narco police (1990)(dinamic)(es)(en).dsk" size="131584" crc="732da12d" sha1="856417a7c4902b5a88398dadf8528aab4527880d" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+<!-- Spanish version includes Army Moves as a bonus. -->
+	<software name="navymovesp" cloneof="navymove">
+		<description>Navy Moves (Spanish)</description>
+		<year>1988</year>
+		<publisher>Dinamic</publisher>
+		<part name="flop1" interface="floppy_3">
+			<dataarea name="flop" size="166400">
+				<rom name="navy moves + army moves (1988)(dinamic)(es).dsk" size="166400" crc="ac230638" sha1="6eb9dd96efe181d0d9f09698501f5fb3f4d77a10" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="navymove">
+		<description>Navy Moves</description>
+		<year>1988</year>
+		<publisher>The Hit Squad</publisher>
+		<part name="flop1" interface="floppy_3">
+			<dataarea name="flop" size="112640">
+				<rom name="navy moves (1988)(hit squad, the)[re-release].dsk" size="112640" crc="b7747a37" sha1="54d7af7ed62d747e3231325348d09a37b107806c" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<!-- According to World of Spectrum, this image came from a dual-system Spectrum/Amstrad release (Side A: Spectrum, Side B: Amstrad) -->
+	<software name="navymovespa" cloneof="navymove">
+		<description>Navy Moves (Spanish) (alt)</description>
+		<year>1988</year>
+		<publisher>Dinamic</publisher>
+		<part name="flop1" interface="floppy_3">
+			<dataarea name="flop" size="166400">
+				<rom name="navy moves + army moves (1988)(dinamic)(es)(side a).dsk" size="166400" crc="65a30aca" sha1="e7ba54851e45d717a9205b0219a0dde16a30028e" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<!-- According to World of Spectrum, this image came from a dual-system Spectrum/Amstrad release (Side A: Spectrum, Side B: Amstrad) -->
+<!--
+	<software name="navymove">
+		<description>Navy Moves</description>
+		<year>1988</year>
+		<publisher>Dinamic</publisher>
+		<part name="flop1" interface="floppy_3">
+			<dataarea name="flop" size="214784">
+				<rom name="navy moves (1988)(dinamic)(es)(en)(side b).dsk" size="214784" crc="c32323a2" sha1="da30c11411368b22474b032f39e8f8b968f7903b" offset="0" />
+			</dataarea>
+		</part>
+-->
+
+<!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="navyseal">
+		<description>Navy SEALs</description>
+		<year>1991</year>
+		<publisher>Erbe</publisher>
+		<part name="flop1" interface="floppy_3">
+			<feature name="part_id" value="Side A"/>
+			<dataarea name="flop" size="155904">
+				<rom name="navy seals (1991)(erbe)(es)(en)(side a)[re-release].dsk" size="155904" crc="af3ffaf7" sha1="dbfdadcaecddfff4f33e2cc6edda386dc6e8a2d9" offset="0" />
+			</dataarea>
+		</part>
+		<part name="flop2" interface="floppy_3">
+			<feature name="part_id" value="Side B"/>
+			<dataarea name="flop" size="155904">
+				<rom name="navy seals (1991)(erbe)(es)(en)(side b)[re-release].dsk" size="155904" crc="66e8d525" sha1="bb0330e4dddb1904623c6c38ad92f938167fad95" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="neighboumd" cloneof="neighbou">
+		<description>Neighbours (master disk)</description>
+		<year>1992</year>
+		<publisher>Impulze</publisher>
+		<part name="flop1" interface="floppy_3">
+			<feature name="part_id" value="Side A"/>
+			<dataarea name="flop" size="73216">
+				<rom name="neighbours (1992)(impulze)(side a)[master disk].dsk" size="73216" crc="136cc7ba" sha1="8282e676c2241cfa273ae660e68b4fabb4b887e6" offset="0" />
+			</dataarea>
+		</part>
+		<part name="flop2" interface="floppy_3">
+			<feature name="part_id" value="Side B"/>
+	<!-- Side B image shared with other master disks from Zeppelin Games. Verified at World of Spectrum. -->
+			<dataarea name="flop" size="256">
+				<rom name="championship run (1991)(zeppelin games)(side b)[master disk backup][re-release].dsk" size="256" crc="56947af2" sha1="40428c770d847a0fd1fd005b6cf1d03a34672d98" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="neighboutmd" cloneof="neighbou">
+		<description>Neighbours (tape master disk)</description>
+		<year>1992</year>
+		<publisher>Impulze</publisher>
+		<part name="flop1" interface="floppy_3">
+			<feature name="part_id" value="Side A"/>
+			<dataarea name="flop" size="194816">
+				<rom name="neighbours (1992)(impulze)(side a)[tape master disk].dsk" size="194816" crc="df4c42dc" sha1="d776a6ff0f573df2495bf9c2d1d6f75a46265f96" offset="0" />
+			</dataarea>
+		</part>
+		<part name="flop2" interface="floppy_3">
+			<feature name="part_id" value="Side B"/>
+			<dataarea name="flop" size="194816">
+				<rom name="neighbours (1992)(impulze)(side b)[tape master disk].dsk" size="194816" crc="8eeb6d63" sha1="2750a6253294cdfae673c9ca985d7f0afc7631be" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="neighbou">
+		<description>Neighbours</description>
+		<year>1992</year>
+		<publisher>Impulze</publisher>
+		<part name="flop1" interface="floppy_3">
+			<dataarea name="flop" size="73216">
+				<rom name="neighbours (1992)(impulze).dsk" size="73216" crc="9f7cb361" sha1="e45a12a6c0a2f743cc972a4960cf049bc2ce6372" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+<!-- Labeled in World of Spectrum as "(CheatVersion)(MasterDisk)", might come from the developers? -->
+	<software name="neighbouch" cloneof="neighbou">
+		<description>Neighbours (cheat version) (master disk)</description>
+		<year>1992</year>
+		<publisher>Impulze</publisher>
+		<part name="flop1" interface="floppy_3">
+			<dataarea name="flop" size="194816">
+				<rom name="neighbours (1992)(impulze)[t][master disk].dsk" size="194816" crc="02088631" sha1="8b786d01e28e05a2ce5650bcf66eca9c22c28f32" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="tnzssp" cloneof="tnzs">
+		<description>The New Zealand Story (Spain)</description>
+		<year>1989</year>
+		<publisher>Erbe</publisher>
+		<part name="flop1" interface="floppy_3">
+			<feature name="part_id" value="Side A"/>
+			<dataarea name="flop" size="68352">
+				<rom name="new zealand story, the (1989)(erbe)(es)(en)(side a)[re-release].dsk" size="68352" crc="13a78210" sha1="902bd77d3f62893e625a50161a451a5c912c0d74" offset="0" />
+			</dataarea>
+		</part>
+		<part name="flop2" interface="floppy_3">
+			<feature name="part_id" value="Side B"/>
+			<dataarea name="flop" size="194816">
+				<rom name="new zealand story, the (1989)(erbe)(es)(en)(side b)[re-release].dsk" size="194816" crc="979cf378" sha1="7b9930423248682b7153ccaa1d70112c6e0246bc" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="tnzs">
+		<description>The New Zealand Story</description>
+		<year>1989</year>
+		<publisher>Ocean</publisher>
+		<part name="flop1" interface="floppy_3">
+			<feature name="part_id" value="Side A"/>
+			<dataarea name="flop" size="62720">
+				<rom name="new zealand story, the (1989)(ocean)(side a).dsk" size="62720" crc="3548a836" sha1="b854381b0fcbd37fa195e0bd9380ffd75465290e" offset="0" />
+			</dataarea>
+		</part>
+		<part name="flop2" interface="floppy_3">
+			<feature name="part_id" value="Side B"/>
+			<dataarea name="flop" size="194816">
+				<rom name="new zealand story, the (1989)(ocean)(side b).dsk" size="194816" crc="a3fe1ef8" sha1="b75d300142fb523324ae3d2596ead775c715a52d" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="nigelman">
+		<description>Nigel Mansell's Grand Prix</description>
+		<year>1988</year>
+		<publisher>Martech Games</publisher>
+		<part name="flop1" interface="floppy_3">
+			<dataarea name="flop" size="194560">
+				<rom name="nigel mansell's grand prix (1988)(martech games).dsk" size="194560" crc="fb7f4a21" sha1="0100151048ec2379fbc108dec6cd43babeb3f659" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="nightbre">
+		<description>Night Breed - The Action Game</description>
+		<year>1990</year>
+		<publisher>Ocean</publisher>
+		<part name="flop1" interface="floppy_3">
+			<dataarea name="flop" size="389376">
+				<rom name="night breed - the action game (1990)(ocean).dsk" size="389376" crc="8e6cd752" sha1="c4a2ff13a02ae7b6bbf3b2ff6a79b391c0198853" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="nighthun">
+		<description>Night Hunter</description>
+		<year>1990</year>
+		<publisher>Ubi Soft</publisher>
+		<part name="flop1" interface="floppy_3">
+			<feature name="part_id" value="Side A"/>
+			<dataarea name="flop" size="194816">
+				<rom name="night hunter (1990)(ubi soft)(fr)(en)(side a).dsk" size="194816" crc="b90f206d" sha1="36ce59aee1dc31968603e6a5303be13a711130d7" offset="0" />
+			</dataarea>
+		</part>
+		<part name="flop2" interface="floppy_3">
+			<feature name="part_id" value="Side B"/>
+			<dataarea name="flop" size="194816">
+				<rom name="night hunter (1990)(ubi soft)(fr)(en)(side b).dsk" size="194816" crc="85b80971" sha1="84ef0e18d3ae67bf44a6886f5651f2ced0788b6d" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="nighraid">
+		<description>Night Raider</description>
+		<year>1988</year>
+		<publisher>Gremlin Graphics</publisher>
+		<part name="flop1" interface="floppy_3">
+			<dataarea name="flop" size="174848">
+				<rom name="night raider (1988)(gremlin graphics).dsk" size="174848" crc="0d889fc6" sha1="bb06295dae9be9ebf460e170d3672351aaa83438" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="ninjawarsp" cloneof="ninjawar">
+		<description>The Ninja Warriors (Spain)</description>
+		<year>1989</year>
+		<publisher>Dro Soft</publisher>
+		<part name="flop1" interface="floppy_3">
+			<dataarea name="flop" size="194816">
+				<rom name="ninja warriors, the (1989)(dro soft)(es)(en)[re-release].dsk" size="194816" crc="55b8fd20" sha1="3379b6da9807c8077273f332318a41680818ceb9" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="normlame">
+		<description>Norman's Lament</description>
+		<year>1990</year>
+		<publisher>Zenobi</publisher>
+		<part name="flop1" interface="floppy_3">
+			<dataarea name="flop" size="194816">
+				<rom name="norman's lament (1990)(zenobi).dsk" size="194816" crc="5320aa7a" sha1="dd3a9d5b8fe0191ecc0374fc52dbec2cc1ee992a" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="northsou">
+		<description>North &amp; South</description>
+		<year>1991</year>
+		<publisher>Infogrames</publisher>
+		<part name="flop1" interface="floppy_3">
+			<feature name="part_id" value="Side A"/>
+			<dataarea name="flop" size="174848">
+				<rom name="north &amp; south (1991)(infogrames)(fr)(m3)(side a)[aka norte y sur].dsk" size="174848" crc="a26c2515" sha1="3a5b97612eff5e949f274911e4a313221fe532f6" offset="0" />
+			</dataarea>
+		</part>
+		<part name="flop2" interface="floppy_3">
+			<feature name="part_id" value="Side B"/>
+			<dataarea name="flop" size="174336">
+				<rom name="north &amp; south (1991)(infogrames)(fr)(m3)(side b)[aka norte y sur].dsk" size="174336" crc="55745fc0" sha1="c21b0d87bdb7214cf4627f75ef717018d35cd5a8" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="northsoua" cloneof="northsou">
+		<description>North &amp; South (alt)</description>
+		<year>1991</year>
+		<publisher>Infogrames</publisher>
+		<part name="flop1" interface="floppy_3">
+			<feature name="part_id" value="Side A"/>
+			<dataarea name="flop" size="174848">
+				<rom name="north &amp; south (1991)(infogrames)(fr)(m3)(side a)[a][aka norte y sur].dsk" size="174848" crc="2fa550b1" sha1="bb6302a481d61b938041b2f3823f456ef51991d4" offset="0" />
+			</dataarea>
+		</part>
+		<part name="flop2" interface="floppy_3">
+			<feature name="part_id" value="Side B"/>
+			<dataarea name="flop" size="165632">
+				<rom name="north &amp; south (1991)(infogrames)(fr)(m3)(side b)[a][aka norte y sur].dsk" size="165632" crc="69845996" sha1="2f6cacd8b595b415ceeb4fd928bb50e3d1dc76ec" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="northsoub" cloneof="northsou">
+		<description>North &amp; South (alt 2)</description>
+		<year>1991</year>
+		<publisher>Infogrames</publisher>
+		<part name="flop1" interface="floppy_3">
+			<feature name="part_id" value="Side A"/>
+			<dataarea name="flop" size="174848">
+				<rom name="north &amp; south (1991)(infogrames)(fr)(m3)(side a)[a2][aka norte y sur].dsk" size="174848" crc="bdb9cfcd" sha1="04938fd4a3512a05ad7614c6da363ac6d7a8320a" offset="0" />
+			</dataarea>
+		</part>
+		<part name="flop2" interface="floppy_3">
+			<feature name="part_id" value="Side B"/>
+			<dataarea name="flop" size="174336">
+				<rom name="north &amp; south (1991)(infogrames)(fr)(m3)(side b)[a2][aka norte y sur].dsk" size="174336" crc="7c18181c" sha1="ae0acb4abea3fb1bbe64473f72c00ad8bd31755e" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="northsouc" cloneof="northsou">
+		<description>North &amp; South (alt 3)</description>
+		<year>1991</year>
+		<publisher>Infogrames</publisher>
+		<part name="flop1" interface="floppy_3">
+			<feature name="part_id" value="Side A"/>
+			<dataarea name="flop" size="174848">
+				<rom name="north &amp; south (1991)(infogrames)(fr)(m3)(side a)[a3][aka norte y sur].dsk" size="174848" crc="46c6efc2" sha1="aae910c6ae93cb000941b7906475a18507be7de4" offset="0" />
+			</dataarea>
+		</part>
+		<part name="flop2" interface="floppy_3">
+			<feature name="part_id" value="Side B"/>
+			<dataarea name="flop" size="165632">
+				<rom name="north &amp; south (1991)(infogrames)(fr)(m3)(side b)[a3][aka norte y sur].dsk" size="165632" crc="7797a1bc" sha1="5637f4eb48731894d33c61f5d8cf79e7eae1ddf3" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<!-- May be the same edition as the IPF -->
+	<software name="northstra" cloneof="northstr">
+		<description>North Star (alt)</description>
+		<year>1988</year>
+		<publisher>Gremlin Graphics</publisher>
+		<part name="flop1" interface="floppy_3">
+			<dataarea name="flop" size="174848">
+				<rom name="north star (1988)(gremlin graphics).dsk" size="174848" crc="2472f3ba" sha1="0704862da03f1e09f822412f18fea05e74112239" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="northstrb" cloneof="northstr">
+		<description>North Star (alt 2)</description>
+		<year>1988</year>
+		<publisher>Gremlin Graphics</publisher>
+		<part name="flop1" interface="floppy_3">
+			<dataarea name="flop" size="162048">
+				<rom name="north star (1988)(gremlin graphics)[a].dsk" size="162048" crc="17fe7830" sha1="0af689b80ddbc79a4c62c97b1dc7ee4918b54172" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="oblitersp" cloneof="obliter">
+		<description>Obliterator (Spain)</description>
+		<year>1989</year>
+		<publisher>Dro Soft</publisher>
+		<part name="flop1" interface="floppy_3">
+			<dataarea name="flop" size="194816">
+				<rom name="obliterator (1989)(dro soft)(es)(en)[re-release].dsk" size="194816" crc="4a40e00b" sha1="e4d2de260f26676a1cea16e1b4ac087b76966431" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="ooowomim">
+		<description>One of our Wombats is Missing</description>
+		<year>1990</year>
+		<publisher>Zenobi</publisher>
+		<part name="flop1" interface="floppy_3">
+			<feature name="part_id" value="Side A"/>
+			<dataarea name="flop" size="194816">
+				<rom name="one of our wombats is missing (1990)(zenobi)(side a).dsk" size="194816" crc="a8f1eef9" sha1="83aa1f75c73da8a95979d9fd06550e27fdccaff9" offset="0" />
+			</dataarea>
+		</part>
+		<part name="flop2" interface="floppy_3">
+			<feature name="part_id" value="Side B"/>
+			<dataarea name="flop" size="194816">
+				<rom name="one of our wombats is missing (1990)(zenobi)(side b).dsk" size="194816" crc="36f2fe65" sha1="2e198f54d3a5cdbfe7cc3b49c727e5c572d14e8b" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="othundersp" cloneof="othunder">
+		<description>Operation Thunderbolt (Spain)</description>
+		<year>1989</year>
+		<publisher>Erbe</publisher>
+		<part name="flop1" interface="floppy_3">
+			<feature name="part_id" value="Side A"/>
+			<dataarea name="flop" size="48896">
+				<rom name="operation thunderbolt (1989)(erbe)(es)(en)(side a)[re-release].dsk" size="48896" crc="92ab8927" sha1="f9761cb713bc47d226c2cfc138fea5e04eb49f19" offset="0" />
+			</dataarea>
+		</part>
+		<part name="flop2" interface="floppy_3">
+			<feature name="part_id" value="Side B"/>
+			<dataarea name="flop" size="194816">
+				<rom name="operation thunderbolt (1989)(erbe)(es)(en)(side b)[re-release].dsk" size="194816" crc="e2b3b82c" sha1="d724ed13afcca95f92ca879225262743dd713cd4" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="othunder">
+		<description>Operation Thunderbolt</description>
+		<year>1989</year>
+		<publisher>Ocean</publisher>
+		<part name="flop1" interface="floppy_3">
+			<feature name="part_id" value="Side A"/>
+			<dataarea name="flop" size="128256">
+				<rom name="operation thunderbolt (1989)(ocean)(side a).dsk" size="128256" crc="f2690887" sha1="e3773ce1320b978c7f643f2559257b09c44aa25a" offset="0" />
+			</dataarea>
+		</part>
+		<part name="flop2" interface="floppy_3">
+			<feature name="part_id" value="Side B"/>
+			<dataarea name="flop" size="194816">
+				<rom name="operation thunderbolt (1989)(ocean)(side b).dsk" size="194816" crc="78bca289" sha1="858b349c190d975bc881116cbefaa11ac7214521" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="opwolfsp" cloneof="opwolf">
+		<description>Operation Wolf (Spain)</description>
+		<year>1988</year>
+		<publisher>Erbe</publisher>
+		<part name="flop1" interface="floppy_3">
+			<dataarea name="flop" size="194816">
+				<rom name="operation wolf (1988)(erbe)(es)(en)[re-release].dsk" size="194816" crc="937ab39f" sha1="6d9bfdd66290b424300bdf57266a24d5e2b85750" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="opwolf">
+		<description>Operation Wolf</description>
+		<year>1988</year>
+		<publisher>Ocean</publisher>
+		<part name="flop1" interface="floppy_3">
+			<dataarea name="flop" size="194816">
+				<rom name="operation wolf (1988)(ocean).dsk" size="194816" crc="8fb0ea8d" sha1="3fb8835bba7eeb68ff5ce3ab3dd950f7a33f71a6" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="opwolfa" cloneof="opwolf">
+		<description>Operation Wolf (alt)</description>
+		<year>1988</year>
+		<publisher>Ocean</publisher>
+		<part name="flop1" interface="floppy_3">
+			<dataarea name="flop" size="150272">
+				<rom name="operation wolf (1988)(ocean)[a].dsk" size="150272" crc="79031b22" sha1="6c0cf20992922bf114f7a1a59c967a32c670fea1" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="opwolfb" cloneof="opwolf">
+		<description>Operation Wolf (alt 2)</description>
+		<year>1988</year>
+		<publisher>Ocean</publisher>
+		<part name="flop1" interface="floppy_3">
+			<dataarea name="flop" size="194816">
+				<rom name="operation wolf (1988)(ocean)[a2].dsk" size="194816" crc="7c713a26" sha1="b971311ee8938b3c5bf2937fc4cac8a6dbfd0572" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="opprland">
+		<description>The Oppressed Land</description>
+		<year>1990</year>
+		<publisher>Zenobi</publisher>
+		<part name="flop1" interface="floppy_3">
+			<dataarea name="flop" size="194816">
+				<rom name="oppressed land, the (1990)(zenobi).dsk" size="194816" crc="784f03dc" sha1="fbbdf6f40860d13f6dbb0f3f88d1d04fda9c85dd" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="origamessp" cloneof="origames">
+		<description>Oriental Games (Spain)</description>
+		<year>1990</year>
+		<publisher>MCM</publisher>
+		<part name="flop1" interface="floppy_3">
+			<feature name="part_id" value="Side A"/>
+			<dataarea name="flop" size="73216">
+				<rom name="oriental games (1990)(mcm)(es)(en)(side a)[re-release].dsk" size="73216" crc="34a1c47d" sha1="8f18f7df100b47cc238f9669cb841d2acbf8827b" offset="0" />
+			</dataarea>
+		</part>
+		<part name="flop2" interface="floppy_3">
+			<feature name="part_id" value="Side B"/>
+			<dataarea name="flop" size="121856">
+				<rom name="oriental games (1990)(mcm)(es)(en)(side b)[re-release].dsk" size="121856" crc="7d9ae3f4" sha1="4418bcf7959d7c18a6f579c709c9f2f0150bfbc0" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="origames">
+		<description>Oriental Games</description>
+		<year>1990</year>
+		<publisher>Micro Style</publisher>
+		<part name="flop1" interface="floppy_3">
+			<feature name="part_id" value="Side A"/>
+			<dataarea name="flop" size="194816">
+				<rom name="oriental games (1990)(micro style)(side a).dsk" size="194816" crc="5e5a0a57" sha1="2e138f9bb657ddf57db856502e495eb9ebe31f5e" offset="0" />
+			</dataarea>
+		</part>
+		<part name="flop2" interface="floppy_3">
+			<feature name="part_id" value="Side B"/>
+			<dataarea name="flop" size="194816">
+				<rom name="oriental games (1990)(micro style)(side b).dsk" size="194816" crc="b128d8ca" sha1="a5e0d5fec27a6bedf237c94107f1dae4df026fa4" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="outrun">
+		<description>Out Run</description>
+		<year>1987</year>
+		<publisher>U.S. Gold</publisher>
+		<part name="flop1" interface="floppy_3">
+			<feature name="part_id" value="Side A"/>
+			<dataarea name="flop" size="134144">
+				<rom name="out run (1987)(u.s. gold)(side a).dsk" size="134144" crc="62666641" sha1="1dcfebd59440d4af1c1033d1cc5c7581f23c7239" offset="0" />
+			</dataarea>
+		</part>
+		<part name="flop2" interface="floppy_3">
+			<feature name="part_id" value="Side B"/>
+			<dataarea name="flop" size="155648">
+				<rom name="out run (1987)(u.s. gold)(side b).dsk" size="155648" crc="28055b6c" sha1="68ec47293426f6f7afbc99c5eeddfe97e8870f82" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="ootlimel">
+		<description>Out of the Limelight</description>
+		<year>1992</year>
+		<publisher>Zenobi</publisher>
+		<part name="flop1" interface="floppy_3">
+			<dataarea name="flop" size="194816">
+				<rom name="out of the limelight (1992)(zenobi).dsk" size="194816" crc="af5dd72d" sha1="665105700b8b92575304ac6a0a7affeee3bbe072" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="overland">
+		<description>Overlander</description>
+		<year>1988</year>
+		<publisher>Elite Systems</publisher>
+		<part name="flop1" interface="floppy_3">
+			<dataarea name="flop" size="91136">
+				<rom name="overlander (1988)(elite systems).dsk" size="91136" crc="d5d287ee" sha1="4839bd9d81f5c269cebd56c54ef7b012f8956591" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="overlandsp" cloneof="overland">
+		<description>Overlander (Spain)</description>
+		<year>1988</year>
+		<publisher>MCM</publisher>
+		<part name="flop1" interface="floppy_3">
+			<dataarea name="flop" size="194816">
+				<rom name="overlander (1988)(mcm)(es)(en)[re-release].dsk" size="194816" crc="fd817c95" sha1="8fe3b288a4451eeea76aa0ec95200e9478e49a4c" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<!-- May be the same edition as the IPF -->
+	<software name="p47thuna" cloneof="p47thun">>
+		<description>P-47 Thunderbolt (alt)</description>
+		<year>1990</year>
+		<publisher>Firebird</publisher>
+		<part name="flop1" interface="floppy_3">
+			<dataarea name="flop" size="194816">
+				<rom name="p-47 thunderbolt (1990)(firebird)[aka p-47 - the freedom fighter].dsk" size="194816" crc="ff20e266" sha1="85b1597808079780bca508d5ecb4cc950c168fe3" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<!-- May be the same edition as the IPF -->
+	<software name="phmpegasa" cloneof="phmpegas">
+		<description>P.H.M. Pegasus (alt)</description>
+		<year>1988</year>
+		<publisher>Electronic Arts</publisher>
+		<part name="flop1" interface="floppy_3">
+			<dataarea name="flop" size="214784">
+				<rom name="p.h.m. pegasus (1988)(electronic arts).dsk" size="214784" crc="9d937816" sha1="f800efee965cd349879697d5c2f7fc2980ce25b6" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<!-- May be the same edition as the IPF -->
+	<software name="paclanda" cloneof="pacland">
+		<description>Pac-Land (alt)</description>
+		<year>1989</year>
+		<publisher>Grandslam Entertainments - Quicksilva</publisher>
+		<part name="flop1" interface="floppy_3">
+			<dataarea name="flop" size="92160">
+				<rom name="pac-land (1989)(grandslam entertainments - quicksilva).dsk" size="92160" crc="c81f942c" sha1="7a10093852e05f8d34b6e312132efaadb56aab25" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="pacmania">
+		<description>Pac-Mania</description>
+		<year>1988</year>
+		<publisher>Grandslam</publisher>
+		<part name="flop1" interface="floppy_3">
+			<dataarea name="flop" size="195328">
+				<rom name="pac-mania (1988)(grandslam).dsk" size="195328" crc="88f5506b" sha1="827c95935dd3a1dd919989fc6d7a0efa4e5aebc1" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="pangsp" cloneof="pang">
+		<description>Pang (Spain)</description>
+		<year>1990</year>
+		<publisher>Erbe</publisher>
+		<part name="flop1" interface="floppy_3">
+			<dataarea name="flop" size="194816">
+				<rom name="pang (1990)(erbe)(es)(en)[re-release].dsk" size="194816" crc="8407042b" sha1="8cf020876ba5d66995fa5752dd6c036913135f23" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="panga" cloneof="pang">
+		<description>Pang (alt)</description>
+		<year>1990</year>
+		<publisher>Ocean</publisher>
+		<part name="flop1" interface="floppy_3">
+			<dataarea name="flop" size="173312">
+				<rom name="pang (1990)(ocean).dsk" size="173312" crc="28b7f247" sha1="3ba6421683859545be99d43c06a1fb887a60f80f" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="paperbo2">
+		<description>Paperboy 2</description>
+		<year>1992</year>
+		<publisher>Mindscape International</publisher>
+		<part name="flop1" interface="floppy_3">
+			<feature name="part_id" value="Side A"/>
+			<dataarea name="flop" size="335301">
+				<rom name="paperboy 2 (1992)(mindscape international)(side a).dsk" size="335301" crc="20db73bf" sha1="a37839752b9d449557a0227b4b246461dcb326ae" offset="0" />
+			</dataarea>
+		</part>
+		<part name="flop2" interface="floppy_3">
+			<feature name="part_id" value="Side B"/>
+			<dataarea name="flop" size="335301">
+				<rom name="paperboy 2 (1992)(mindscape international)(side b).dsk" size="335301" crc="d66c3272" sha1="6ba906f203a7be38b9505a1fc45719e4a9124952" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="parisdak">
+		<description>Paris-Dakar</description>
+		<year>1988</year>
+		<publisher>Zigurat</publisher>
+		<part name="flop1" interface="floppy_3">
+			<dataarea name="flop" size="87808">
+				<rom name="paris-dakar (1988)(zigurat)(es).dsk" size="87808" crc="2a06e40a" sha1="8d210174ddd8f21404943b7509f101edaa37b90b" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<!-- May be the same edition as the IPF -->
+	<software name="passshta" cloneof="passsht">
+		<description>Passing Shot (alt)</description>
+		<year>1989</year>
+		<publisher>Image Works</publisher>
+		<part name="flop1" interface="floppy_3">
+			<dataarea name="flop" size="58624">
+				<rom name="passing shot (1989)(image works).dsk" size="58624" crc="576d7ee4" sha1="73361708502067fc803afbfae66138bfbccd2f6c" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="passshtsp" cloneof="passsht">
+		<description>Passing Shot (Spain)</description>
+		<year>1989</year>
+		<publisher>MCM</publisher>
+		<part name="flop1" interface="floppy_3">
+			<dataarea name="flop" size="194816">
+				<rom name="passing shot (1989)(mcm)(es)(en)[re-release].dsk" size="194816" crc="41e3ce91" sha1="ddcbdf011275f3d1dcb456f6208f7aec4a75e2b0" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<!-- May be the same edition as the IPF -->
+	<software name="pawn" cloneof="pawn">
+		<description>The Pawn v2.4 (alt)</description>
+		<year>1987</year>
+		<publisher>Rainbird</publisher>
+		<part name="flop1" interface="floppy_3">
+			<dataarea name="flop" size="194816">
+				<rom name="pawn, the v2.4 (1987)(rainbird).dsk" size="194816" crc="fdb74ece" sha1="3f96becbf552b207213bdabd950e6ea752b7d8ca" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<!-- May be the same edition as the IPF -->
+	<software name="pawn" cloneof="pawn">
+		<description>The Pawn v2.4 (alt 2)</description>
+		<year>1987</year>
+		<publisher>Rainbird</publisher>
+		<part name="flop1" interface="floppy_3">
+			<dataarea name="flop" size="194816">
+				<rom name="pawn, the v2.4 (1987)(rainbird)[a].dsk" size="194816" crc="0790cc76" sha1="17cecc0a0c3c0fa4f081267b45db375e4fb3a3d5" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="powthein">
+		<description>Pawns of War - The Infiltrator</description>
+		<year>1989</year>
+		<publisher>Zenobi</publisher>
+		<part name="flop1" interface="floppy_3">
+			<dataarea name="flop" size="194816">
+				<rom name="pawns of war - the infiltrator (1989)(zenobi)[re-release].dsk" size="194816" crc="71814e63" sha1="7db46cb122021913544d9c483c2d78e3ba309298" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="pendlogr">
+		<description>The Pendant of Logryn</description>
+		<year>1989</year>
+		<publisher>Zenobi</publisher>
+		<part name="flop1" interface="floppy_3">
+			<dataarea name="flop" size="194816">
+				<rom name="pendant of logryn, the (1989)(zenobi)[re-release].dsk" size="194816" crc="1ac9391d" sha1="3b4a421e912e37b3c8f3d8f225e29ea339434c4f" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="lospajbk">
+		<description>Pepe Carvalho en los Pajaros de Bangkok</description>
+		<year>1988</year>
+		<publisher>Dinamic</publisher>
+		<part name="flop1" interface="floppy_3">
+			<dataarea name="flop" size="112640">
+				<rom name="pepe carvalho en los pajaros de bangkok (1988)(dinamic)(es).dsk" size="112640" crc="eaf66708" sha1="5723b9cca75f13917254ba2efb720be6dc3843ad" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="pericode">
+		<description>Perico Delgado Maillot Amarillo</description>
+		<year>1989</year>
+		<publisher>Topo Soft</publisher>
+		<part name="flop1" interface="floppy_3">
+			<dataarea name="flop" size="180224">
+				<rom name="perico delgado maillot amarillo (1989)(topo soft)(es).dsk" size="180224" crc="5d389bba" sha1="0417ff3e50a06dbd6aae44067e5794ac96ad6908" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="perseus">
+		<description>Perseus</description>
+		<year>1993</year>
+		<publisher>Zenobi</publisher>
+		<part name="flop1" interface="floppy_3">
+			<dataarea name="flop" size="194816">
+				<rom name="perseus (1993)(zenobi).dsk" size="194816" crc="5f5a500c" sha1="1f58f7f143ff2cf659ed3a2921e153a2c7d8ee0a" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="pecompwi">
+		<description>Personal Computer Whirled</description>
+		<year>1992</year>
+		<publisher>Zenobi</publisher>
+		<part name="flop1" interface="floppy_3">
+			<dataarea name="flop" size="194816">
+				<rom name="personal computer whirled (1992)(zenobi)[re-release].dsk" size="194816" crc="4b45d4c9" sha1="496c79dee580d91b07edf3f5bb5dee5f3735e57a" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="phsagain">
+		<description>Phantomas Saga - Infinity</description>
+		<year>2006</year>
+		<publisher>Computer Emuzone</publisher>
+		<part name="flop1" interface="floppy_3">
+			<dataarea name="flop" size="194816">
+				<rom name="phantomas saga - infinity (2006)(computer emuzone)(es)(en).dsk" size="194816" crc="624fd560" sha1="86258b926dd667690c1874a6b981374507195f03" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="phoenix">
+		<description>Phoenix</description>
+		<year>1991</year>
+		<publisher>Zenobi</publisher>
+		<part name="flop1" interface="floppy_3">
+			<dataarea name="flop" size="194816">
+				<rom name="phoenix (1991)(zenobi).dsk" size="194816" crc="3b1dcbab" sha1="262d3728db62851bbf7a95fc33f0f9993d1567f1" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="picknpil">
+		<description>Pick 'n' Pile</description>
+		<year>1991</year>
+		<publisher>Ubi Soft</publisher>
+		<part name="flop1" interface="floppy_3">
+			<dataarea name="flop" size="194816">
+				<rom name="pick 'n' pile (1991)(ubi soft)(fr)(en).dsk" size="194816" crc="0cec1fb9" sha1="e2e358a3fe590305db1e0a56da8faf92bb2f433e" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="pictionasp" cloneof="pictiona">
+		<description>Pictionary - El juego en el que todos pintan</description>
+		<year>1989</year>
+		<publisher>Erbe</publisher>
+		<part name="flop1" interface="floppy_3">
+			<dataarea name="flop" size="180224">
+				<rom name="pictionary (1989)(erbe)(es)[re-release].dsk" size="180224" crc="6ad3cefb" sha1="299e4e31ae07102b2d84e1858d9346b1b38d2099" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="pictiona">
+		<description>Pictionary - The Game of Quick Draw</description>
+		<year>1989</year>
+		<publisher>Domark</publisher>
+		<part name="flop1" interface="floppy_3">
+			<dataarea name="flop" size="194816">
+				<rom name="pictionary - the game of quick draw (1989)(domark).dsk" size="194816" crc="b1361a19" sha1="3c7ee3be8c1a5fab578c45b843c7d2777fd07606" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<!-- May be the same edition as the IPF -->
+	<software name="pipmaniaa" cloneof="pipmania">
+		<description>Pipe Mania (alt)</description>
+		<year>1990</year>
+		<publisher>Empire</publisher>
+		<part name="flop1" interface="floppy_3">
+			<dataarea name="flop" size="194816">
+				<rom name="pipe mania (1990)(empire).dsk" size="194816" crc="456edf8c" sha1="1b93a1c85477b9e482832d0230743ac23dfe90ce" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="pitfight">
+		<description>Pit-Fighter</description>
+		<year>1991</year>
+		<publisher>Domark</publisher>
+		<part name="flop1" interface="floppy_3">
+			<feature name="part_id" value="Side A"/>
+			<dataarea name="flop" size="194816">
+				<rom name="pit-fighter (1991)(domark)(side a).dsk" size="194816" crc="0b27c5a6" sha1="41a26bff3de33bc4f8eb0b43d7d4bd831e02132f" offset="0" />
+			</dataarea>
+		</part>
+		<part name="flop2" interface="floppy_3">
+			<feature name="part_id" value="Side B"/>
+			<dataarea name="flop" size="194816">
+				<rom name="pit-fighter (1991)(domark)(side b).dsk" size="194816" crc="52116688" sha1="e8846ae680bf112f0f38f4e54f9a984a0f666686" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<!-- May be the same edition as the IPF -->
+	<software name="platoona" cloneof="platoon">
+		<description>Platoon (alt)</description>
+		<year>1988</year>
+		<publisher>Ocean</publisher>
+		<part name="flop1" interface="floppy_3">
+			<dataarea name="flop" size="131072">
+				<rom name="platoon (1988)(ocean).dsk" size="131072" crc="45dc4898" sha1="a19824ab2b59ab29d31d6cb56851e0bcc3c4138b" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<!-- May be the same edition as the IPF -->
+	<software name="predatr2a" cloneof="predatr2">
+		<description>Predator 2 (alt)</description>
+		<year>1991</year>
+		<publisher>Image Works</publisher>
+		<part name="flop1" interface="floppy_3">
+			<dataarea name="flop" size="194816">
+				<rom name="predator 2 (1991)(image works).dsk" size="194816" crc="19a74e60" sha1="94759fbcba4baf9004ebf5ca72d2781437fb68a0" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="prelmont">
+		<description>Preliminary Monty</description>
+		<year>2009</year>
+		<publisher>&lt;homebrew&gt;</publisher>
+		<info name="author" value="Andrew Zhiglov"/>
+		<part name="flop1" interface="floppy_3">
+			<dataarea name="flop" size="194816">
+				<rom name="preliminary monty (2009)(zhiglov, andrew)(ru)(en).dsk" size="194816" crc="faa053d9" sha1="33877c4547f4d661e3facd5c055af1a909374978" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="prisoner">
+		<description>The Prisoner</description>
+		<year>2014</year>
+		<publisher>Commodore Plus</publisher>
+		<part name="flop1" interface="floppy_3">
+			<dataarea name="flop" size="194816">
+				<rom name="prisoner, the (2014)(commodore plus)(es)(en)[aka prisionero, el].dsk" size="194816" crc="7aa50408" sha1="1c8fe7bd7f4baf63db2e68818460979b55602a30" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="protenntsp" cloneof="protennt">>
+		<description>Pro Tennis Tour</description>
+		<year>1990</year>
+		<publisher>MCM</publisher>
+		<part name="flop1" interface="floppy_3">
+			<dataarea name="flop" size="63488">
+				<rom name="pro tennis tour (1990)(mcm)(es)(en)[re-release].dsk" size="63488" crc="3cc76873" sha1="ac0fd453b2f00ef63477a25a43bd482a65b8cb84" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<!-- May be the same edition as the IPF -->
+	<software name="protennta" cloneof="protennt">>
+		<description>Pro Tennis Tour (alt)</description>
+		<year>1990</year>
+		<publisher>Ubi Soft</publisher>
+		<part name="flop1" interface="floppy_3">
+			<dataarea name="flop" size="194816">
+				<rom name="pro tennis tour (1990)(ubi soft)(fr)(en).dsk" size="194816" crc="2f11c3bd" sha1="631823abc8cfaa684f855d697998b06c46f1893a" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="prohibit">
+		<description>Prohibition</description>
+		<year>1987</year>
+		<publisher>Zafi Chip</publisher>
+		<part name="flop1" interface="floppy_3">
+			<dataarea name="flop" size="194816">
+				<rom name="prohibition (1987)(zafi chip)(es)(en)[re-release].dsk" size="194816" crc="53a85112" sha1="bb2ed61464d1ccf7eb239988cbe7992b3387e37f" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="projnova">
+		<description>Project Nova</description>
+		<year>1987</year>
+		<publisher>Zenobi</publisher>
+		<part name="flop1" interface="floppy_3">
+			<dataarea name="flop" size="194816">
+				<rom name="project nova (1987)(zenobi)[re-release].dsk" size="194816" crc="430d1985" sha1="c065c33b861fd4882569407ae27b50c22784ab0e" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="pstfight">
+		<description>Project Stealth Fighter</description>
+		<year>1990</year>
+		<publisher>MicroProse</publisher>
+		<part name="flop1" interface="floppy_3">
+			<feature name="part_id" value="Side A"/>
+			<dataarea name="flop" size="194816">
+				<rom name="project stealth fighter (1990)(microprose)(side a)[aka f-19 stealth fighter].dsk" size="194816" crc="48cda235" sha1="a5b23c6d9654dbf9f090b388788306d3e50b63df" offset="0" />
+			</dataarea>
+		</part>
+		<part name="flop2" interface="floppy_3">
+			<feature name="part_id" value="Side B"/>
+			<dataarea name="flop" size="194816">
+				<rom name="project stealth fighter (1990)(microprose)(side b)[aka f-19 stealth fighter].dsk" size="194816" crc="766d3231" sha1="2e98cc257873737dbd0d43d885bd5118725646b0" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="purpsatd">
+		<description>Purple Saturn Day</description>
+		<year>1989</year>
+		<publisher>Exxos</publisher>
+		<part name="flop1" interface="floppy_3">
+			<dataarea name="flop" size="194816">
+				<rom name="purple saturn day (1989)(exxos)(fr)(en).dsk" size="194816" crc="5f9d4dc6" sha1="063c53a541630bf27ab6c9a06bed7c6741490c18" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="q10tankb">
+		<description>Q10 Tank Buster (master disk)</description>
+		<year>1992</year>
+		<publisher>Zeppelin Games</publisher>
+		<part name="flop1" interface="floppy_3">
+			<feature name="part_id" value="Side A"/>
+			<dataarea name="flop" size="194816">
+				<rom name="q10 tank buster (1992)(zeppelin games)(side a)[master disk].dsk" size="194816" crc="5c99ad82" sha1="9c68045ea57f4576e1676b39db2d3a8e6ff7f841" offset="0" />
+			</dataarea>
+		</part>
+		<part name="flop2" interface="floppy_3">
+			<feature name="part_id" value="Side B"/>
+			<dataarea name="flop" size="194816">
+				<rom name="q10 tank buster (1992)(zeppelin games)(side b).dsk" size="194816" crc="0986135e" sha1="4f773cf7d97657c88535c5a445872064752c3bb3" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="qholysmt">
+		<description>Quest for the Holy Something</description>
+		<year>1992</year>
+		<publisher>Zenobi</publisher>
+		<part name="flop1" interface="floppy_3">
+			<dataarea name="flop" size="194816">
+				<rom name="quest for the holy something (1992)(zenobi).dsk" size="194816" crc="966cab79" sha1="c9d0e3a2c98c89251ad0bde5a6a1a60d5401bbf0" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<!-- May be the same edition as the IPF -->
+	<software name="qoscrupa" cloneof="qoscrup">
+		<description>A Question of Scruples - The Computer Edition (alt)</description>
+		<year>1987</year>
+		<publisher>Leisure Genius</publisher>
+		<part name="flop1" interface="floppy_3">
+			<dataarea name="flop" size="194560">
+				<rom name="question of scruples - the computer edition, a (1987)(leisure genius).dsk" size="194560" crc="32d4e533" sha1="8b36ccbf3a87bca7aee778d4e17a32e519888cea" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<!-- May be the same edition as the IPF -->
+	<software name="qosa" cloneof="qos">
+		<description>A Question of Sport (alt)</description>
+		<year>1989</year>
+		<publisher>Elite Systems</publisher>
+		<part name="flop1" interface="floppy_3">
+			<dataarea name="flop" size="194816">
+				<rom name="question of sport, a (1989)(elite systems).dsk" size="194816" crc="87726a94" sha1="d9998e11c5a578d9994447ca3251731e69b88966" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="ram">
+		<description>R.A.M.</description>
+		<year>1990</year>
+		<publisher>Topo Soft</publisher>
+		<part name="flop1" interface="floppy_3">
+			<dataarea name="flop" size="92672">
+				<rom name="r.a.m. (1990)(topo soft)(es).dsk" size="92672" crc="7f9d37fa" sha1="5a14290edb30eb365a3e500926a186cd948755c1" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<!-- May be the same edition as the IPF -->
+	<software name="rbibb2a" cloneof="rbibb2">
+		<description>R.B.I. 2 Baseball (alt)</description>
+		<year>1991</year>
+		<publisher>Domark</publisher>
+		<part name="flop1" interface="floppy_3">
+			<dataarea name="flop" size="194816">
+				<rom name="r.b.i. 2 baseball (1991)(domark).dsk" size="194816" crc="5c77dc45" sha1="088df7f83b465e851b5cf18fc6deaefaeebc1a14" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="radioman">
+		<description>Radiomania</description>
+		<year>1991</year>
+		<publisher>Zenobi</publisher>
+		<part name="flop1" interface="floppy_3">
+			<dataarea name="flop" size="194816">
+				<rom name="radiomania (1991)(zenobi).dsk" size="194816" crc="74edb005" sha1="7226284e7a66c8ed8290046b0e44a0f3ffb89281" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="railstom">
+		<description>Raiders of the Lost Tomb</description>
+		<year>1995</year>
+		<publisher>The Adventure Workshop</publisher>
+		<part name="flop1" interface="floppy_3">
+			<feature name="part_id" value="Side A"/>
+			<dataarea name="flop" size="194816">
+				<rom name="raiders of the lost tomb (1995)(adventure workshop, the)(side a).dsk" size="194816" crc="13a48640" sha1="32590e55e3f99add1edb23a4fc24880093ee529e" offset="0" />
+			</dataarea>
+		</part>
+		<part name="flop2" interface="floppy_3">
+			<feature name="part_id" value="Side B"/>
+			<dataarea name="flop" size="194816">
+				<rom name="raiders of the lost tomb (1995)(adventure workshop, the)(side b).dsk" size="194816" crc="7718f843" sha1="a89c1aebde5631e933982967d194cd1b08af30df" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<!-- May be the same edition as the IPF -->
+	<software name="rbislanda" cloneof="rbisland">
+		<description>Rainbow Islands (alt)</description>
+		<year>1990</year>
+		<publisher>Ocean</publisher>
+		<part name="flop1" interface="floppy_3">
+			<dataarea name="flop" size="175360">
+				<rom name="rainbow islands - the story of bubble bobble 2 (1990)(ocean).dsk" size="175360" crc="8409c9ed" sha1="db9bf5bd455ac679142d5727226e9685aeebb1f5" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="recvives">
+		<description>Recopilacion Vives</description>
+		<year>19??</year>
+		<publisher>&lt;unknown&gt;</publisher>
+		<part name="flop1" interface="floppy_3">
+			<dataarea name="flop" size="194816">
+				<rom name="recopilacion vives (19xx)(-)(es).dsk" size="194816" crc="7e3ae000" sha1="a0a4de3585943f143b559986e837ab34068e6e67" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="redheatsp" cloneof="redheat">
+		<description>Red Heat (Spain)</description>
+		<year>1989</year>
+		<publisher>Erbe</publisher>
+		<part name="flop1" interface="floppy_3">
+			<dataarea name="flop" size="175360">
+				<rom name="red heat (1989)(erbe)(es)(en)[re-release].dsk" size="175360" crc="59b14ef2" sha1="19fccf544fb00c9767c8472684d936effa76fca6" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="redheat">
+		<description>Red Heat</description>
+		<year>1989</year>
+		<publisher>Ocean</publisher>
+		<part name="flop1" interface="floppy_3">
+			<dataarea name="flop" size="157184">
+				<rom name="red heat (1989)(ocean).dsk" size="157184" crc="2be37cbe" sha1="75c53860247c0af7c81337519f25f84ed8700dd2" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="bttf3sp" cloneof="bttf3">
+		<description>Regreso al Futuro - Parte III</description>
+		<year>1991</year>
+		<publisher>MCM</publisher>
+		<part name="flop1" interface="floppy_3">
+			<feature name="part_id" value="Side A"/>
+			<dataarea name="flop" size="194816">
+				<rom name="regreso al futuro - parte iii (1991)(mcm)(es)(en)(side a)[aka back to the future part 3][re-release].dsk" size="194816" crc="bc1c6dc0" sha1="d34c63ea589953cb689c5ca47b0433e91e68ec0a" offset="0" />
+			</dataarea>
+		</part>
+		<part name="flop2" interface="floppy_3">
+			<feature name="part_id" value="Side B"/>
+			<dataarea name="flop" size="194816">
+				<rom name="regreso al futuro - parte iii (1991)(mcm)(es)(en)(side b)[aka back to the future part 3][re-release].dsk" size="194816" crc="87ddb7cf" sha1="3c6e9e3524baacb4c34666ae89dd9124b0ee055a" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<!-- May be the same edition as the IPF -->
+	<software name="renegadea" cloneof="renegade">
+		<description>Renegade (alt)</description>
+		<year>1987</year>
+		<publisher>Imagine</publisher>
+		<part name="flop1" interface="floppy_3">
+			<dataarea name="flop" size="194816">
+				<rom name="renegade (1987)(imagine).dsk" size="194816" crc="9414eedd" sha1="ea6ba8c9f8db52cd827cfbe7cb576cf746865de9" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<!-- May be the same edition as the IPF -->
+	<software name="renegadeb" cloneof="renegade">
+		<description>Renegade (alt 2)</description>
+		<year>1987</year>
+		<publisher>Imagine</publisher>
+		<part name="flop1" interface="floppy_3">
+			<dataarea name="flop" size="194816">
+				<rom name="renegade (1987)(imagine)[a].dsk" size="194816" crc="bddac6b2" sha1="c4311ea7f5ee36a6b112299aaae107e4855adad9" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+<!-- This is the dump from World of Spectrum -->
+	<software name="rescatla">
+		<description>Rescate Atlantida</description>
+		<year>1989</year>
+		<publisher>Dinamic</publisher>
+		<part name="flop1" interface="floppy_3">
+			<feature name="part_id" value="Side A"/>
+			<dataarea name="flop" size="150272">
+				<rom name="rescate atlantida (1989)(dinamic)(es)(en)(side a).dsk" size="150272" crc="2bbc9650" sha1="9b7d423d415a9535958da60ec26624f89bc3563c" offset="0" />
+			</dataarea>
+		</part>
+		<part name="flop2" interface="floppy_3">
+			<feature name="part_id" value="Side B"/>
+			<dataarea name="flop" size="166400">
+				<rom name="rescate atlantida (1989)(dinamic)(es)(en)(side b).dsk" size="166400" crc="a7d4f505" sha1="9d2ede9cb0ba5c96e6967a9df42425e55099fc06" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="rescatlaa" cloneof="rescatla">
+		<description>Rescate Atlantida (alt)</description>
+		<year>1989</year>
+		<publisher>Dinamic</publisher>
+		<part name="flop1" interface="floppy_3">
+			<dataarea name="flop" size="214784">
+				<rom name="rescate atlantida (1989)(dinamic)(es).dsk" size="214784" crc="176a12e4" sha1="4c71b572b282007732fb6a4ff617369c68f8c1ab" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="rescatlab" cloneof="rescatla">
+		<description>Rescate Atlantida (alt 2)</description>
+		<year>1989</year>
+		<publisher>Dinamic</publisher>
+		<part name="flop1" interface="floppy_3">
+			<dataarea name="flop" size="214784">
+				<rom name="rescate atlantida (1989)(dinamic)(es)[a].dsk" size="214784" crc="b259c19e" sha1="1dda1d59b8fafa91ca3fe15df6f5aada24d85cd5" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="jedia" cloneof="jedi">
+		<description>Star Wars - Return of the Jedi (alt)</description>
+		<year>1989</year>
+		<publisher>Domark</publisher>
+		<part name="flop1" interface="floppy_3">
+			<dataarea name="flop" size="194816">
+				<rom name="return of the jedi (1989)(domark).dsk" size="194816" crc="93e39844" sha1="95118a8cdc853521c39085950838aceaf48d35f2" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="jedisp" cloneof="jedi">
+		<description>Star Wars - Return of the Jedi (Spain)</description>
+		<year>1989</year>
+		<publisher>Erbe</publisher>
+		<part name="flop1" interface="floppy_3">
+			<dataarea name="flop" size="68352">
+				<rom name="return of the jedi (1989)(erbe)(es)(en)[re-release].dsk" size="68352" crc="c0f1f626" sha1="f4cb6a5bd15f7e6c3b35678f2da31b9a332d11b1" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="jedispa" cloneof="jedi">
+		<description>Star Wars - Return of the Jedi (Spain) (alt)</description>
+		<year>1989</year>
+		<publisher>Erbe</publisher>
+		<part name="flop1" interface="floppy_3">
+			<dataarea name="flop" size="136448">
+				<rom name="return of the jedi (1989)(erbe)(es)(en)[a][re-release].dsk" size="136448" crc="c5cdb566" sha1="6befbc050becec8e084b1dec01d1c59487192cd0" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<!-- May be the same edition as the IPF -->
+	<software name="rexa" cloneof="rex">
+		<description>Rex (alt)</description>
+		<year>1988</year>
+		<publisher>Martech Games</publisher>
+		<part name="flop1" interface="floppy_3">
+			<dataarea name="flop" size="194816">
+				<rom name="rex (1988)(martech games)[aka zenith].dsk" size="194816" crc="fada783b" sha1="75a4ec59bfe5ea598267d8f6ac38453129169f3b" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="rhymecry">
+		<description>Rhyme Cryme</description>
+		<year>1995</year>
+		<publisher>Zenobi</publisher>
+		<part name="flop1" interface="floppy_3">
+			<feature name="part_id" value="Side A"/>
+			<dataarea name="flop" size="194816">
+				<rom name="rhyme cryme (1995)(zenobi)(side a).dsk" size="194816" crc="fcf41521" sha1="b5ff68d6bf063514903af931027a783b762ed56e" offset="0" />
+			</dataarea>
+		</part>
+		<part name="flop2" interface="floppy_3">
+			<feature name="part_id" value="Side B"/>
+			<dataarea name="flop" size="194816">
+				<rom name="rhyme cryme (1995)(zenobi)(side b).dsk" size="194816" crc="b14e9e7b" sha1="418f1bb000e950bc6c265dbd7133a8f88af27e8d" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="rickdang">
+		<description>Rick Dangerous</description>
+		<year>1989</year>
+		<publisher>Firebird</publisher>
+		<part name="flop1" interface="floppy_3">
+			<dataarea name="flop" size="194816">
+				<rom name="rick dangerous (1989)(firebird).dsk" size="194816" crc="23a903d9" sha1="4d216ea0e695d7cc931dd4cd6f5cc64350d20450" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="rickdan2">
+		<description>Rick Dangerous 2</description>
+		<year>1990</year>
+		<publisher>Micro Style</publisher>
+		<part name="flop1" interface="floppy_3">
+			<dataarea name="flop" size="220160">
+				<rom name="rick dangerous 2 (1990)(micro style).dsk" size="220160" crc="2d5aa66b" sha1="25a971a7363961787a8a4d1611142fac5a0c1e3e" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="riptoff">
+		<description>Riptoff</description>
+		<year>1991</year>
+		<publisher>Your Sinclair</publisher>
+		<part name="flop1" interface="floppy_3">
+			<dataarea name="flop" size="194816">
+				<rom name="riptoff (1991)(your sinclair).dsk" size="194816" crc="7578aac8" sha1="40c401f368c9cce742139e40d33dfaf45bc50a94" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="roadblst" cloneof="roadblst">
+		<description>Road Blasters (Spain)</description>
+		<year>1988</year>
+		<publisher>Erbe</publisher>
+		<part name="flop1" interface="floppy_3">
+			<dataarea name="flop" size="214784">
+				<rom name="road blasters (1988)(erbe)(es)(en)[re-release].dsk" size="214784" crc="5966a1bc" sha1="59df737d0dd64fe5c8a6973b1c88efca1892f80a" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<!-- May be the same edition as the IPF -->
+	<software name="roadblst" cloneof="roadblst">
+		<description>Road Blasters (alt)</description>
+		<year>1988</year>
+		<publisher>U.S. Gold</publisher>
+		<part name="flop1" interface="floppy_3">
+			<dataarea name="flop" size="214784">
+				<rom name="road blasters (1988)(u.s. gold).dsk" size="214784" crc="012de59c" sha1="5fe7f856e85b63f4628f741b92f85ac81541ea82" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="robocop">
+		<description>Robocop</description>
+		<year>1988</year>
+		<publisher>Ocean</publisher>
+		<part name="flop1" interface="floppy_3">
+			<dataarea name="flop" size="134144">
+				<rom name="robocop (1988)(ocean).dsk" size="134144" crc="545558f7" sha1="ad1e7ed55d62d8eec7bae80904f73be7f5ffd59e" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="robocopa" cloneof="robocop">
+		<description>Robocop (alt)</description>
+		<year>1988</year>
+		<publisher>Ocean</publisher>
+		<part name="flop1" interface="floppy_3">
+			<dataarea name="flop" size="128768">
+				<rom name="robocop (1988)(ocean)[a].dsk" size="128768" crc="c3218b5c" sha1="f56181f60553f4ac00631f8720b713bd42490a85" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="robocop2sp" cloneof="robocop2">
+		<description>Robocop 2 (Spain)</description>
+		<year>1990</year>
+		<publisher>Erbe</publisher>
+		<part name="flop1" interface="floppy_3">
+			<dataarea name="flop" size="160768">
+				<rom name="robocop 2 (1990)(erbe)(es)(en)[re-release].dsk" size="160768" crc="93b27353" sha1="78047deee2d869dbe4554617e385aa2c0998ac48" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<!-- May be the same edition as the IPF -->
+	<software name="robocop2a" cloneof="robocop2">
+		<description>Robocop 2 (alt)</description>
+		<year>1990</year>
+		<publisher>Ocean</publisher>
+		<part name="flop1" interface="floppy_3">
+			<dataarea name="flop" size="225536">
+				<rom name="robocop 2 (1990)(ocean).dsk" size="225536" crc="afa8626e" sha1="eaf866424fa3d2b0ea006a970d3fd475147040ac" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<!-- May be the same edition as the IPF -->
+	<software name="robocop2b" cloneof="robocop2">
+		<description>Robocop 2 (alt 2)</description>
+		<year>1990</year>
+		<publisher>Ocean</publisher>
+		<part name="flop1" interface="floppy_3">
+			<dataarea name="flop" size="225536">
+				<rom name="robocop 2 (1990)(ocean)[a].dsk" size="225536" crc="d3298f36" sha1="e7815e2062f98883759629dd4a0cda36862f1961" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="rocknrol">
+		<description>Rock 'n Roll</description>
+		<year>1989</year>
+		<publisher>Rainbow Arts</publisher>
+		<part name="flop1" interface="floppy_3">
+			<feature name="part_id" value="Side A"/>
+			<dataarea name="flop" size="194816">
+				<rom name="rock 'n roll (1989)(rainbow arts)(side a).dsk" size="194816" crc="8e00a1a0" sha1="378a77e1e653679e97a16245342c6a0cfd76560e" offset="0" />
+			</dataarea>
+		</part>
+		<part name="flop2" interface="floppy_3">
+			<feature name="part_id" value="Side B"/>
+			<dataarea name="flop" size="194816">
+				<rom name="rock 'n roll (1989)(rainbow arts)(side b).dsk" size="194816" crc="9c629673" sha1="d6135a003ada344ad6572f4b4a2f3b7fa6c0fc3f" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<!-- May be the same edition as the IPF -->
+	<software name="rthunder" cloneof="rthunder">
+		<description>Rolling Thunder (alt)</description>
+		<year>1988</year>
+		<publisher>U.S. Gold</publisher>
+		<part name="flop1" interface="floppy_3">
+			<dataarea name="flop" size="194816">
+				<rom name="rolling thunder (1988)(u.s. gold).dsk" size="194816" crc="075e555b" sha1="712dc41dbcaa62314e8fdbd2718569f1fa96e379" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="roundbnd">
+		<description>Round the Bend</description>
+		<year>1991</year>
+		<publisher>Impulze</publisher>
+		<part name="flop1" interface="floppy_3">
+			<dataarea name="flop" size="68352">
+				<rom name="round the bend (1991)(impulze)[aka doc croc's outrageous adventures].dsk" size="68352" crc="f5494d4b" sha1="c670a0b723682b6de7ca7f89edcb85680ad5f2a4" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="roundbndmdb" cloneof="roundbnd">
+		<description>Round the Bend (master disk backup)</description>
+		<year>1991</year>
+		<publisher>Impulze</publisher>
+		<part name="flop1" interface="floppy_3">
+			<feature name="part_id" value="Side A"/>
+			<dataarea name="flop" size="194816">
+				<rom name="round the bend (1991)(impulze)(side a)[aka doc croc's outrageous adventures][master disk backup].dsk" size="194816" crc="d6abbdf3" sha1="f6197df7e325b3390be71980939715d04dbd056f" offset="0" />
+			</dataarea>
+		</part>
+		<part name="flop2" interface="floppy_3">
+			<feature name="part_id" value="Side B"/>
+		<!-- Side B file shared with master disk. Verified at World of Spectrum. -->
+			<dataarea name="flop" size="194816">
+				<rom name="round the bend (1991)(impulze)(side b)[aka doc croc's outrageous adventures][master disk backup].dsk" size="194816" crc="3f369cfe" sha1="3f2948425c21742c2d88ca658490488f642bad5e" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="roundbndmd" cloneof="roundbnd">
+		<description>Round the Bend (master disk)</description>
+		<year>1991</year>
+		<publisher>Impulze</publisher>
+		<part name="flop1" interface="floppy_3">
+			<feature name="part_id" value="Side A"/>
+			<dataarea name="flop" size="68352">
+				<rom name="round the bend (1991)(impulze)(side a)[aka doc croc's outrageous adventures][master disk].dsk" size="68352" crc="ed9c3df8" sha1="f02ea8a83b173233071d7401fab9b44a272cfd8c" offset="0" />
+			</dataarea>
+		</part>
+		<part name="flop2" interface="floppy_3">
+			<feature name="part_id" value="Side B"/>
+			<dataarea name="flop" size="194816">
+				<rom name="round the bend (1991)(impulze)(side b)[aka doc croc's outrageous adventures][master disk backup].dsk" size="194816" crc="3f369cfe" sha1="3f2948425c21742c2d88ca658490488f642bad5e" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<!-- May be the same edition as the IPF -->
+	<software name="rungaunta" cloneof="rungaunt">
+		<description>Run the Gauntlet</description>
+		<year>1989</year>
+		<publisher>Ocean</publisher>
+		<part name="flop1" interface="floppy_3">
+			<dataarea name="flop" size="174848">
+				<rom name="run the gauntlet (1989)(ocean).dsk" size="174848" crc="908cd12d" sha1="bc74b1f45b05e3e5a0f93e186aeb9e938d469d0f" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="runbronw">
+		<description>Run, Bronwynn, Run</description>
+		<year>1992</year>
+		<publisher>FSF Adventures</publisher>
+		<part name="flop1" interface="floppy_3">
+			<dataarea name="flop" size="194816">
+				<rom name="run, bronwynn, run (1992)(fsf adventures).dsk" size="194816" crc="d1315cea" sha1="22ad24cd7199bfcde0ec5ba7984c6fa2650b94c8" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="runngman">
+		<description>The Running Man</description>
+		<year>1989</year>
+		<publisher>MCM</publisher>
+		<part name="flop1" interface="floppy_3">
+			<dataarea name="flop" size="160768">
+				<rom name="running man, the (1989)(mcm)(es)(en)[re-release].dsk" size="160768" crc="502e531a" sha1="ca50672595b1f8da4ba1b614d761039b42b90f3a" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="stunrunn">
+		<description>S.T.U.N. Runner</description>
+		<year>1990</year>
+		<publisher>Domark</publisher>
+		<part name="flop1" interface="floppy_3">
+			<dataarea name="flop" size="215296">
+				<rom name="s.t.u.n. runner (1990)(domark).dsk" size="215296" crc="0feddfe9" sha1="8d3289f150cecc9d7c4e5c02c1e94be3c11376c6" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="saboteu2">
+		<description>Saboteur II - Avenging Angel</description>
+		<year>1987</year>
+		<publisher>Durell</publisher>
+		<part name="flop1" interface="floppy_3">
+			<dataarea name="flop" size="194816">
+				<rom name="saboteur ii - avenging angel (1987)(durell)[h alex rider, 2015][tr pl][speed-up version].dsk" size="194816" crc="4c9b8d3d" sha1="7ed014dadff63cedd9ea6744793b76af8782611b" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<!-- May be the same edition as the IPF -->
+	<software name="saintgrva" cloneof="saintgrv">
+		<description>Saint &amp; Greavsie</description>
+		<year>1989</year>
+		<publisher>Grandslam</publisher>
+		<part name="flop1" interface="floppy_3">
+			<dataarea name="flop" size="220160">
+				<rom name="saint and greavsie (1989)(grandslam).dsk" size="220160" crc="5152c80b" sha1="5175ce4e09020f840dddd7da345b9c0b4eb30af6" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="salamand">
+		<description>Salamander</description>
+		<year>1987</year>
+		<publisher>Imagine</publisher>
+		<part name="flop1" interface="floppy_3">
+			<dataarea name="flop" size="70656">
+				<rom name="salamander (1987)(imagine)[re-release].dsk" size="70656" crc="62bfd974" sha1="fc4bc578c463f58a023c716f7df679afb8cb253e" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="usagiyoj">
+		<description>Samurai Warrior - The Battles of... Usagi Yojimbo</description>
+		<year>1988</year>
+		<publisher>Firebird</publisher>
+		<part name="flop1" interface="floppy_3">
+			<dataarea name="flop" size="73216">
+				<rom name="samurai warrior - the battles of... usagi yojimbo (1988)(firebird)[aka battle of... usagi yojimbo, the].dsk" size="73216" crc="fa8df0ac" sha1="ef854f176c30934d1309982322f983194ae60153" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="santxmca">
+		<description>Santa's Xmas Caper (tape master disk)</description>
+		<year>1991</year>
+		<publisher>Zeppelin Games</publisher>
+		<part name="flop1" interface="floppy_3">
+			<feature name="part_id" value="Side A"/>
+			<dataarea name="flop" size="194816">
+				<rom name="santa's xmas caper (1991)(zeppelin games)(side a)[aka santa's christmas capers][aka you are santa claus][tape master disk].dsk" size="194816" crc="ac72f16b" sha1="1ee2388ecb420b4900006eb0583f9fb3805e5bf1" offset="0" />
+			</dataarea>
+		</part>
+		<part name="flop2" interface="floppy_3">
+			<feature name="part_id" value="Side B"/>
+	<!-- Side B image shared with other master disks from Zeppelin Games. Verified at World of Spectrum. -->
+			<dataarea name="flop" size="256">
+				<rom name="championship run (1991)(zeppelin games)(side b)[master disk backup][re-release].dsk" size="256" crc="56947af2" sha1="40428c770d847a0fd1fd005b6cf1d03a34672d98" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="satan">
+		<description>Satan</description>
+		<year>1989</year>
+		<publisher>Dinamic</publisher>
+		<part name="flop1" interface="floppy_3">
+			<dataarea name="flop" size="107264">
+				<rom name="satan (1989)(dinamic)(es).dsk" size="107264" crc="82642bef" sha1="344dd36d44076d079d8a62b678a8f4139a274526" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="scapegho">
+		<description>Scapeghost</description>
+		<year>1989</year>
+		<publisher>Level 9 Computing</publisher>
+		<part name="flop1" interface="floppy_3">
+			<feature name="part_id" value="Side A"/>
+			<dataarea name="flop" size="194816">
+				<rom name="scapeghost (1989)(level 9 computing)(side a)[aka spook].dsk" size="194816" crc="49303a17" sha1="9d8c1d37dee5df439a8945dc087fbc9082a4269c" offset="0" />
+			</dataarea>
+		</part>
+		<part name="flop2" interface="floppy_3">
+			<feature name="part_id" value="Side B"/>
+			<dataarea name="flop" size="194816">
+				<rom name="scapeghost (1989)(level 9 computing)(side b)[aka spook].dsk" size="194816" crc="497b537b" sha1="f75eb772cc5d27177ab4e8a50b0c66a71c8da497" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="scapegho" cloneof="scapegho">
+		<description>Scapeghost (alt)</description>
+		<year>1989</year>
+		<publisher>Level 9 Computing</publisher>
+		<part name="flop1" interface="floppy_3">
+			<dataarea name="flop" size="194816">
+				<rom name="scapeghost (1989)(level 9 computing)(side a)[a][aka spook].dsk" size="194816" crc="1d10fcd4" sha1="221bf55fe048ef70dfb6b0a9e3c9bda2b04ab078" offset="0" />
+			</dataarea>
+		</part>
+		<publisher>Level 9 Computing</publisher>
+		<part name="flop1" interface="floppy_3">
+			<dataarea name="flop" size="194816">
+				<rom name="scapeghost (1989)(level 9 computing)(side b)[a][aka spook].dsk" size="194816" crc="c464a1e9" sha1="baf17b2ebba89cbb29af430be2399c05f03d4ad3" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<!-- May be the same edition as the IPF -->
+	<software name="scrabdxa" cloneof="scrabdx">
+		<description>Scrabble Deluxe (alt)</description>
+		<year>1987</year>
+		<publisher>Leisure Genius</publisher>
+		<part name="flop1" interface="floppy_3">
+			<dataarea name="flop" size="194560">
+				<rom name="scrabble deluxe (1987)(leisure genius)[aka deluxe computer scrabble].dsk" size="194560" crc="3033f933" sha1="8ec1cf29e28980f7943feee4f64e3a0635d56eb4" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="sspirits">
+		<description>Scramble Spirits</description>
+		<year>1990</year>
+		<publisher>Grandslam</publisher>
+		<part name="flop1" interface="floppy_3">
+			<dataarea name="flop" size="194816">
+				<rom name="scramble spirits (1990)(grandslam).dsk" size="194816" crc="28617137" sha1="b1898340c7eadb2bf29417aaf8006792277c09f8" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="seasorce">
+		<description>Seaside Sorcery</description>
+		<year>1997</year>
+		<publisher>Zenobi</publisher>
+		<part name="flop1" interface="floppy_3">
+			<dataarea name="flop" size="194816">
+				<rom name="seaside sorcery (1997)(zenobi).dsk" size="194816" crc="f58ff9dc" sha1="5ad5d43bfb5c7ec4e763a03317c85698e889b905" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="sendasal">
+		<description>Senda Salvaje</description>
+		<year>1990</year>
+		<publisher>Zigurat</publisher>
+		<part name="flop1" interface="floppy_3">
+			<dataarea name="flop" size="102400">
+				<rom name="senda salvaje (1990)(zigurat)(es).dsk" size="102400" crc="54f0d03f" sha1="a334fc0d768554e29e678017d90cff53adba1ab6" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="sentinel">
+		<description>The Sentinel</description>
+		<year>1987</year>
+		<publisher>Firebird</publisher>
+		<part name="flop1" interface="floppy_3">
+			<dataarea name="flop" size="78080">
+				<rom name="sentinel, the (1987)(firebird).dsk" size="78080" crc="5665c629" sha1="d03ca9d8dd2fca34aa174edccf17eda12d202409" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="serptale">
+		<description>A Serpentine Tale</description>
+		<year>1993</year>
+		<publisher>Zenobi</publisher>
+		<part name="flop1" interface="floppy_3">
+			<dataarea name="flop" size="194816">
+				<rom name="serpentine tale, a (1993)(zenobi)[re-release].dsk" size="194816" crc="bd0e89f2" sha1="7af072b5755b119ec22141ed4ab10ac0c54cc52e" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="setotaisde" cloneof="setotais">>
+		<description>Seto Taisho vs Yokai (German, Spanish)</description>
+		<year>2016</year>
+		<publisher>Alessandro Grussu</publisher>
+		<part name="flop1" interface="floppy_3">
+			<dataarea name="flop" size="194816">
+				<rom name="seto taisho vs yokai (2016-02-29)(grussu, alessandro)(de-es).dsk" size="194816" crc="c1ebd473" sha1="4c32c7b87911b5ba209cc4c48083d2e157a582be" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="setotais">
+		<description>Seto Taisho vs Yokai (English, Italian)</description>
+		<year>2016</year>
+		<publisher>Alessandro Grussu</publisher>
+		<part name="flop1" interface="floppy_3">
+			<dataarea name="flop" size="194816">
+				<rom name="seto taisho vs yokai (2016-02-29)(grussu, alessandro)(en-it).dsk" size="194816" crc="12d6499a" sha1="1ed7e33084dfcdde9870c623de2f30795cedc5f7" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="setotaisfr" cloneof="setotais">>
+		<description>Seto Taisho vs Yokai (French, Portuguese)</description>
+		<year>2016</year>
+		<publisher>Alessandro Grussu</publisher>
+		<part name="flop1" interface="floppy_3">
+			<dataarea name="flop" size="194816">
+				<rom name="seto taisho vs yokai (2016-02-29)(grussu, alessandro)(fr-pt).dsk" size="194816" crc="6d28e331" sha1="d5650a8fdd2fee7e54cfce32ad8301561aebdf57" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="shackled">
+		<description>Shackled</description>
+		<year>1988</year>
+		<publisher>U.S. Gold</publisher>
+		<part name="flop1" interface="floppy_3">
+			<dataarea name="flop" size="194816">
+				<rom name="shackled (1988)(u.s. gold).dsk" size="194816" crc="27f51075" sha1="e14b0956f3d4f5981295266b0ed80a8d3fa739f4" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="shdancer">
+		<description>Shadow Dancer</description>
+		<year>1991</year>
+		<publisher>Erbe</publisher>
+		<part name="flop1" interface="floppy_3">
+			<feature name="part_id" value="Side A"/>
+			<dataarea name="flop" size="165632">
+				<rom name="shadow dancer (1991)(erbe)(es)(en)(side a)[re-release].dsk" size="165632" crc="39313626" sha1="3ae6a7e3f074a7d582cdc7df93268b7065fcaa1e" offset="0" />
+			</dataarea>
+		</part>
+		<part name="flop2" interface="floppy_3">
+			<feature name="part_id" value="Side B"/>
+			<dataarea name="flop" size="194816">
+				<rom name="shadow dancer (1991)(erbe)(es)(en)(side b)[re-release].dsk" size="194816" crc="ead87fd5" sha1="13c74b2352c19f646b64445b347cfc0b6e88805d" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="shadoww">
+		<description>Shadow Warriors</description>
+		<year>1990</year>
+		<publisher>Ocean</publisher>
+		<part name="flop1" interface="floppy_3">
+			<dataarea name="flop" size="208640">
+				<rom name="shadow warriors (1990)(ocean).dsk" size="208640" crc="4d0a3727" sha1="ae8c3160465f6b021355fa83997ae2a90c0ef649" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="sotbeastsp" cloneof="sotbeast">
+		<description>Shadow of the Beast (Spain)</description>
+		<year>1990</year>
+		<publisher>Erbe</publisher>
+		<part name="flop1" interface="floppy_3">
+			<feature name="part_id" value="Side A"/>
+			<dataarea name="flop" size="44288">
+				<rom name="shadow of the beast (1990)(erbe)(es)(en)(side a)[re-release].dsk" size="44288" crc="d6617fdb" sha1="fcfc943a3dabcc00e235ab34ca44a688940ddb43" offset="0" />
+			</dataarea>
+		</part>
+		<part name="flop2" interface="floppy_3">
+			<feature name="part_id" value="Side B"/>
+			<dataarea name="flop" size="153088">
+				<rom name="shadow of the beast (1990)(erbe)(es)(en)(side b)[re-release].dsk" size="153088" crc="80f74e58" sha1="96ebf96237d41f8d2efa3c06e4dc26d62281416f" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="sotbeast">
+		<description>Shadow of the Beast</description>
+		<year>1990</year>
+		<publisher>Gremlin Graphics</publisher>
+		<part name="flop1" interface="floppy_3">
+			<feature name="part_id" value="Side A"/>
+			<dataarea name="flop" size="174848">
+				<rom name="shadow of the beast (1990)(gremlin graphics)(side a).dsk" size="174848" crc="5078cdbf" sha1="0a9685669cab7d1d41646e945c8db250d5933b4b" offset="0" />
+			</dataarea>
+		</part>
+		<part name="flop2" interface="floppy_3">
+			<feature name="part_id" value="Side B"/>
+			<dataarea name="flop" size="174848">
+				<rom name="shadow of the beast (1990)(gremlin graphics)(side b).dsk" size="174848" crc="c36997da" sha1="a215b923a0150d21a889105a820f20ff356bbab3" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="shardino">
+		<description>Shard of Inovar</description>
+		<year>1987</year>
+		<publisher>Zenobi</publisher>
+		<part name="flop1" interface="floppy_3">
+			<dataarea name="flop" size="194816">
+				<rom name="shard of inovar (1987)(zenobi)[re-release].dsk" size="194816" crc="517d327c" sha1="284702077cee0618f6eae705557a290717b9bd5e" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="sharkmol">
+		<description>Sharkey's Moll (tape master disk)</description>
+		<year>1991</year>
+		<publisher>Zeppelin Games</publisher>
+		<part name="flop1" interface="floppy_3">
+			<feature name="part_id" value="Side A"/>
+			<dataarea name="flop" size="194816">
+				<rom name="sharkey's moll (1991)(zeppelin games)(side a)[aka operation shark][tape master disk].dsk" size="194816" crc="3d17527f" sha1="dc6973e0318a484b75c424c6221e34504f885cd8" offset="0" />
+			</dataarea>
+		</part>
+		<part name="flop2" interface="floppy_3">
+			<feature name="part_id" value="Side B"/>
+	<!-- Side B image shared with other master disks from Zeppelin Games. Verified at World of Spectrum. -->
+			<dataarea name="flop" size="256">
+				<rom name="championship run (1991)(zeppelin games)(side b)[master disk backup][re-release].dsk" size="256" crc="56947af2" sha1="40428c770d847a0fd1fd005b6cf1d03a34672d98" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="sherlami">
+		<description>Sherlock Holmes - The Lamberley Mystery</description>
+		<year>1990</year>
+		<publisher>Zenobi</publisher>
+		<part name="flop1" interface="floppy_3">
+			<dataarea name="flop" size="194816">
+				<rom name="sherlock holmes - the lamberley mystery (1990)(zenobi).dsk" size="194816" crc="2a9c732a" sha1="36fae868e3a83cd4f553b070384048cf5959170a" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="shinobisp" cloneof="shinobi">
+		<description>Shinobi (Spain)</description>
+		<year>1989</year>
+		<publisher>Dro Soft</publisher>
+		<part name="flop1" interface="floppy_3">
+			<dataarea name="flop" size="194816">
+				<rom name="shinobi (1989)(dro soft)(es)(en)[re-release].dsk" size="194816" crc="4663ae78" sha1="0ad60c222997942884c7c34e41840ee198722980" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="shinobi">
+		<description>Shinobi</description>
+		<year>1989</year>
+		<publisher>Virgin Games</publisher>
+		<part name="flop1" interface="floppy_3">
+			<dataarea name="flop" size="201216">
+				<rom name="shinobi (1989)(virgin games).dsk" size="201216" crc="64bbd9df" sha1="5300fe9292a3bc914dfeef10e3ad4d2cbd2a5d02" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="sidearms">
+		<description>Side Arms</description>
+		<year>1988</year>
+		<publisher>Go</publisher>
+		<part name="flop1" interface="floppy_3">
+			<dataarea name="flop" size="194816">
+				<rom name="side arms (1988)(go).dsk" size="194816" crc="9199aa09" sha1="e23fdec7d476cfcef5754262541580ff40e76318" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="silkworm">
+		<description>Silkworm</description>
+		<year>1989</year>
+		<publisher>Virgin Games</publisher>
+		<part name="flop1" interface="floppy_3">
+			<dataarea name="flop" size="81408">
+				<rom name="silkworm (1989)(virgin games).dsk" size="81408" crc="399e0d4e" sha1="209150254f605ce39c9f51e1aaeb9cb4571f0ace" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="silkwormsp" cloneofe="silkworm">>
+		<description>Silkworm (Spain)</description>
+		<year>1989</year>
+		<publisher>Erbe</publisher>
+		<part name="flop1" interface="floppy_3">
+			<dataarea name="flop" size="68352">
+				<rom name="silkworm (1989)(erbe)(es)(en)[re-release].dsk" size="68352" crc="1f3bb8ca" sha1="aeb2576b0f616e920145f3e4575e188d84f578db" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="silkwormspa" cloneofe="silkworm">>
+		<description>Silkworm (Spain) (alt)</description>
+		<year>1989</year>
+		<publisher>Erbe</publisher>
+		<part name="flop1" interface="floppy_3">
+			<dataarea name="flop" size="68352">
+				<rom name="silkworm (1989)(erbe)(es)(en)[a][re-release].dsk" size="68352" crc="1a5a1dac" sha1="cbe96a6d5448f6d0681599abfd48aaed372917ee" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="silkwormspb" cloneofe="silkworm">>
+		<description>Silkworm (Spain) (alt 2)</description>
+		<year>1989</year>
+		<publisher>Erbe</publisher>
+		<part name="flop1" interface="floppy_3">
+			<dataarea name="flop" size="67328">
+				<rom name="silkworm (1989)(erbe)(es)(en)[a2][re-release].dsk" size="67328" crc="e3321b40" sha1="f54c7d1851a1acaf867e747f801a595934eeb0af" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="silvwolf">
+		<description>Silverwolf</description>
+		<year>1992</year>
+		<publisher>Zenobi</publisher>
+		<part name="flop1" interface="floppy_3">
+			<dataarea name="flop" size="194816">
+				<rom name="silverwolf (1992)(zenobi)[re-release].dsk" size="194816" crc="a1ced916" sha1="f99b5f686b4d2cafe58ee284562d009087319e87" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<!-- May be the same edition as the IPF -->
+	<software name="simcitya" cloneof="simcity">
+		<description>Sim City (alt)</description>
+		<year>1990</year>
+		<publisher>Infogrames</publisher>
+		<part name="flop1" interface="floppy_3">
+			<dataarea name="flop" size="194816">
+				<rom name="sim city (1990)(infogrames)(fr)(en).dsk" size="194816" crc="472c0a72" sha1="3abc13d4fe3c42cf8245840890f8f8e1b7c4d598" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="bartvssm">
+		<description>The Simpsons - Bart vs. the Space Mutants</description>
+		<year>1991</year>
+		<publisher>Erbe</publisher>
+		<part name="flop1" interface="floppy_3">
+			<feature name="part_id" value="Side A"/>
+			<dataarea name="flop" size="216320">
+				<rom name="simpsons - bart vs. the space mutants, the (1991)(erbe)(es)(en)(side a)[re-release].dsk" size="216320" crc="a00c2816" sha1="f5b1e86051810971d073e015d8b444ef96466bbe" offset="0" />
+			</dataarea>
+		</part>
+		<part name="flop2" interface="floppy_3">
+			<feature name="part_id" value="Side B"/>
+			<dataarea name="flop" size="216320">
+				<rom name="simpsons - bart vs. the space mutants, the (1991)(erbe)(es)(en)(side b)[re-release].dsk" size="216320" crc="f1cdff77" sha1="ef71e50c841a00e6ecdfde047e2c3fcc2b889a78" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="sirfred">
+		<description>Sir Fred</description>
+		<year>1986</year>
+		<publisher>Made in Spain</publisher>
+		<part name="flop1" interface="floppy_3">
+			<dataarea name="flop" size="194816">
+				<rom name="sir fred (1986)(made in spain)(es).dsk" size="194816" crc="adf9a9f0" sha1="c16ccb453b56b3991f6e4a1a603ee74aae66077e" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="sitopons">
+		<description>Sito Pons 500cc Grand Prix</description>
+		<year>1990</year>
+		<publisher>Zigurat</publisher>
+		<part name="flop1" interface="floppy_3">
+			<dataarea name="flop" size="58624">
+				<rom name="sito pons 500cc grand prix (1990)(zigurat)(es).dsk" size="58624" crc="a4d2515f" sha1="f9cd0be687108f3a7ef68aae4fbafa306722d41d" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<!-- May be the same edition as the IPF -->
+	<software name="skatballa" cloneof="skatball">
+		<description>Skateball (alt)</description>
+		<year>1988</year>
+		<publisher>Ubi Soft</publisher>
+		<part name="flop1" interface="floppy_3">
+			<dataarea name="flop" size="194816">
+				<rom name="skateball (1988)(ubi soft)(fr)(en).dsk" size="194816" crc="07f0ab2b" sha1="2503637efd9b6d57f1c4c8d1b40dde6462d595ed" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<!-- May be the same edition as the IPF -->
+	<software name="skullxboa" cloneof="skullxbo">
+		<description>Skull &amp; Crossbones (alt)</description>
+		<year>1991</year>
+		<publisher>Domark</publisher>
+		<part name="flop1" interface="floppy_3">
+			<dataarea name="flop" size="227072">
+				<rom name="skull &amp; crossbones (1991)(domark).dsk" size="227072" crc="a8327f25" sha1="4373fadbb69cc3d0940ca7ce91f3f6e5672dac05" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="slaugcav">
+		<description>The Slaughter Caves</description>
+		<year>1989</year>
+		<publisher>Zenobi</publisher>
+		<part name="flop1" interface="floppy_3">
+			<dataarea name="flop" size="194816">
+				<rom name="slaughter caves, the (1989)(zenobi).dsk" size="194816" crc="4ec7b7e1" sha1="05cb1351e4226244ba3ac0756419b4ac2a0b2f7d" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="sleepwal">
+		<description>Sleepwalker (tape master disk)</description>
+		<year>1992</year>
+		<publisher>Zeppelin Games</publisher>
+		<part name="flop1" interface="floppy_3">
+			<feature name="part_id" value="Side A"/>
+			<dataarea name="flop" size="204544">
+				<rom name="sleepwalker (1992)(zeppelin games)(side a)[tape master disk].dsk" size="204544" crc="b2388672" sha1="52af33ca5ece70fe921871b8dedd158e7a0df7a0" offset="0" />
+			</dataarea>
+		</part>
+		<part name="flop2" interface="floppy_3">
+			<feature name="part_id" value="Side B"/>
+			<dataarea name="flop" size="204032">
+				<rom name="sleepwalker (1992)(zeppelin games)(side b)[tape master disk].dsk" size="204032" crc="841eccbd" sha1="d0ba5a8dc801bd03fd644f5ff6774f4ed5889e91" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="slowglas">
+		<description>Slowglass</description>
+		<year>1990</year>
+		<publisher>Slowglass</publisher>
+		<part name="flop1" interface="floppy_3">
+			<dataarea name="flop" size="194816">
+				<rom name="slowglass (1990)(slowglass)(es).dsk" size="194816" crc="9871570f" sha1="8368e425ce77d0cde6a13b9498b89423365bddb4" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="smashtv">
+		<description>Smash TV</description>
+		<year>1991</year>
+		<publisher>Erbe</publisher>
+		<part name="flop1" interface="floppy_3">
+			<dataarea name="flop" size="63232">
+				<rom name="smash tv (1991)(erbe)(es)(en)[re-release].dsk" size="63232" crc="537c4c8b" sha1="7b196f932ee796e8a1b2726dff93ccc99fe39f67" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<!-- May be the same edition as the IPF -->
+	<software name="snoopya" cloneof="snoopy">
+		<description>Snoopy (alt)</description>
+		<year>1990</year>
+		<publisher>The Edge</publisher>
+		<part name="flop1" interface="floppy_3">
+			<dataarea name="flop" size="195072">
+				<rom name="snoopy (1990)(edge, the).dsk" size="195072" crc="f0773376" sha1="75ffe0c2f2c3fd99c446bdf1f97a34b1b54e3f47" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="sokoban">
+		<description>Sokoban</description>
+		<year>2006</year>
+		<publisher>Compiler</publisher>
+		<part name="flop1" interface="floppy_3">
+			<dataarea name="flop" size="194816">
+				<rom name="sokoban (2006)(compiler)(es)(en).dsk" size="194816" crc="7c9661ad" sha1="2e76b26808d115e750c7aedd700eac1284f58b48" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="sokobansp" cloneof="sokoban">
+		<description>Sokoban (Spanish)</description>
+		<year>2006</year>
+		<publisher>Compiler</publisher>
+		<part name="flop1" interface="floppy_3">
+			<dataarea name="flop" size="194816">
+				<rom name="sokoban (2006)(compiler)(es).dsk" size="194816" crc="2fe0a1d0" sha1="8f53882a9481ab44dd484ae7c17cf448b1c18a85" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="solnegro">
+		<description>Sol Negro</description>
+		<year>1989</year>
+		<publisher>Opera Soft</publisher>
+		<part name="flop1" interface="floppy_3">
+			<dataarea name="flop" size="230400">
+				<rom name="sol negro (1989)(opera soft)(es).dsk" size="230400" crc="3e1dc4fd" sha1="d76f73af3f00fdec6e38fcc428efc8fda86fdf32" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="soldoffo">
+		<description>Soldier of Fortune</description>
+		<year>1988</year>
+		<publisher>Firebird</publisher>
+		<part name="flop1" interface="floppy_3">
+			<dataarea name="flop" size="73216">
+				<rom name="soldier of fortune (1988)(firebird).dsk" size="73216" crc="a88165f9" sha1="720363a3afad04d495279db7fd8f43902d67b1f3" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="soldiero">
+		<description>Soldier of Light</description>
+		<year>1988</year>
+		<publisher>ACE</publisher>
+		<part name="flop1" interface="floppy_3">
+			<dataarea name="flop" size="194816">
+				<rom name="soldier of light (1988)(ace).dsk" size="194816" crc="8de198b1" sha1="dde86e28951db167097e08ee6989f17380d3f62a" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<!-- May be the same edition as the IPF -->
+	<software name="soldlghta" cloneof="soldlght">
+		<description>Soldier of Light (alt)</description>
+		<year>1988</year>
+		<publisher>Dro Soft</publisher>
+		<part name="flop1" interface="floppy_3">
+			<dataarea name="flop" size="194816">
+				<rom name="soldier of light (1988)(dro soft)(es)(en)[re-release].dsk" size="194816" crc="fce2bb56" sha1="ed21b6fffdafa96800976f276c542837f60ac830" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="songofta">
+		<description>The Song of Taliesin</description>
+		<year>1994</year>
+		<publisher>Zenobi</publisher>
+		<part name="flop1" interface="floppy_3">
+			<dataarea name="flop" size="194816">
+				<rom name="song of taliesin, the (1994)(zenobi).dsk" size="194816" crc="b7e4fb2d" sha1="071eaa34379e895102c3007e2eca28f89c0eab93" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="soviet">
+		<description>Soviet</description>
+		<year>1990</year>
+		<publisher>Opera Soft</publisher>
+		<part name="flop1" interface="floppy_3">
+			<dataarea name="flop" size="214784">
+				<rom name="soviet (1990)(opera soft)(es)(en).dsk" size="214784" crc="416c7bb9" sha1="4a9e5f3e59b00296aeb465bf85dd55345d8fb925" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<!-- May be the same edition as the IPF -->
+	<software name="spacecrsa" cloneof="spacecrs">
+		<description>Space Crusade</description>
+		<year>1992</year>
+		<publisher>Gremlin Graphics</publisher>
+		<part name="flop1" interface="floppy_3">
+			<dataarea name="flop" size="199680">
+				<rom name="space crusade (1992)(gremlin graphics).dsk" size="199680" crc="ac78c209" sha1="8a2ea68d31c5ee026ca0a9b44c0a0c7657e7ed06" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="sharrie2">
+		<description>Space Harrier II</description>
+		<year>1990</year>
+		<publisher>Grandslam</publisher>
+		<part name="flop1" interface="floppy_3">
+			<feature name="part_id" value="Side A"/>
+			<dataarea name="flop" size="194816">
+				<rom name="space harrier ii (1990)(grandslam)(side a).dsk" size="194816" crc="965723a5" sha1="c2af9c86652996c2d573f7cc8e131ffd30bd8bb2" offset="0" />
+			</dataarea>
+		</part>
+		<part name="flop2" interface="floppy_3">
+			<feature name="part_id" value="Side B"/>
+			<dataarea name="flop" size="194816">
+				<rom name="space harrier ii (1990)(grandslam)(side b).dsk" size="194816" crc="025d0275" sha1="46100285448c978d8a79d2caa56ed402d5156278" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="spccasc2">
+		<description>The Spectre of Castle Coris v2</description>
+		<year>1990</year>
+		<publisher>FSF Adventures</publisher>
+		<part name="flop1" interface="floppy_3">
+			<dataarea name="flop" size="194816">
+				<rom name="spectre of castle coris, the v2 (1990)(fsf adventures).dsk" size="194816" crc="7c6025ef" sha1="933b3bc8096cd232de18db585dc6e13b3e3d4826" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="spherica">
+		<description>Spherical</description>
+		<year>1989</year>
+		<publisher>Rainbow Arts</publisher>
+		<part name="flop1" interface="floppy_3">
+			<feature name="part_id" value="Side A"/>
+			<dataarea name="flop" size="194816">
+				<rom name="spherical (1989)(rainbow arts)(side a).dsk" size="194816" crc="36fb8105" sha1="145dcb29fca1f4f3a19c3b2bb15538bd9ce44e9d" offset="0" />
+			</dataarea>
+		</part>
+		<part name="flop2" interface="floppy_3">
+			<feature name="part_id" value="Side B"/>
+			<dataarea name="flop" size="194816">
+				<rom name="spherical (1989)(rainbow arts)(side b).dsk" size="194816" crc="8c290b43" sha1="376f94df266481930a93b840aaabffce7ce8da6b" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="spittimasp" cloneof="spittima">
+		<description>Spitting Image (Spain)</description>
+		<year>1989</year>
+		<publisher>Erbe</publisher>
+		<part name="flop1" interface="floppy_3">
+			<dataarea name="flop" size="116992">
+				<rom name="spitting image (1989)(erbe)(es)(en).dsk" size="116992" crc="2592e3a9" sha1="9452d23da666547fa05ae4f5e1adc05a46da0999" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="spittima">
+		<description>Spitting Image - The Computer Game</description>
+		<year>1988</year>
+		<publisher>Domark</publisher>
+		<part name="flop1" interface="floppy_3">
+			<dataarea name="flop" size="194816">
+				<rom name="spitting image - the computer game (1988)(domark).dsk" size="194816" crc="4116a854" sha1="6df79a1d0deff4c3b177d1dc6a48d20c50196fcb" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="sportria">
+		<description>Sporting Triangles</description>
+		<year>1989</year>
+		<publisher>CDS Microsystems</publisher>
+		<part name="flop1" interface="floppy_3">
+			<feature name="part_id" value="Side A"/>
+			<dataarea name="flop" size="194816">
+				<rom name="sporting triangles (1989)(cds microsystems)(side a).dsk" size="194816" crc="8ef1179f" sha1="115533a2c46af100e10b0f2142c2deb3d66c8e9f" offset="0" />
+			</dataarea>
+		</part>
+		<part name="flop2" interface="floppy_3">
+			<feature name="part_id" value="Side B"/>
+			<dataarea name="flop" size="217600">
+				<rom name="sporting triangles (1989)(cds microsystems)(side b).dsk" size="217600" crc="871434ab" sha1="87c1c0d4a3f9b9858177449f08a8dcd6fb3d9144" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="sportriaa" cloneof="sportria">
+		<description>Sporting Triangles (alt)</description>
+		<year>1989</year>
+		<publisher>CDS Microsystems</publisher>
+		<part name="flop1" interface="floppy_3">
+			<feature name="part_id" value="Side A"/>
+			<dataarea name="flop" size="194816">
+				<rom name="sporting triangles (1989)(cds microsystems)(side a)[a].dsk" size="194816" crc="c8e03477" sha1="8f8d4b1e7d97b65c5f0f71697c2e5c44c11e5cec" offset="0" />
+			</dataarea>
+		</part>
+		<part name="flop2" interface="floppy_3">
+			<feature name="part_id" value="Side B"/>
+			<dataarea name="flop" size="219136">
+				<rom name="sporting triangles (1989)(cds microsystems)(side b)[a].dsk" size="219136" crc="75602549" sha1="405badca4b71dd1844caaa39a8bec7e1ecc3bf60" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<!-- May be the same edition as the IPF -->
+	<software name="spywholma" cloneof="spywholm">
+		<description>The Spy Who Loved Me (alt)</description>
+		<year>1990</year>
+		<publisher>Domark</publisher>
+		<part name="flop1" interface="floppy_3">
+			<dataarea name="flop" size="194816">
+				<rom name="spy who loved me, the (1990)(domark).dsk" size="194816" crc="2899eeb8" sha1="608d32c04d8a279e8f1fc8a4e6265a1aedfdf596" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+<!-- Only the Spanish version has been dumped, unknown if it had any other releases. -->
+	<software name="stdragon">
+		<description>St. Dragon</description>
+		<year>1990</year>
+		<publisher>Dro Soft</publisher>
+		<part name="flop1" interface="floppy_3">
+			<feature name="part_id" value="Side A"/>
+			<dataarea name="flop" size="194816">
+				<rom name="st. dragon (1990)(dro soft)(es)(en)(side a)[re-release].dsk" size="194816" crc="73cb914d" sha1="2e425aefc2a342b204b77fcf37fa038a78a8eb9b" offset="0" />
+			</dataarea>
+		</part>
+		<part name="flop2" interface="floppy_3">
+			<feature name="part_id" value="Side B"/>
+			<dataarea name="flop" size="194816">
+				<rom name="st. dragon (1990)(dro soft)(es)(en)(side b)[re-release].dsk" size="194816" crc="b0fc6e49" sha1="0b9130bf2c9e81d36d9517ecddb5dd36194c651a" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="stackup">
+		<description>Stack Up (tape master disk)</description>
+		<year>1991</year>
+		<publisher>Zeppelin Games</publisher>
+		<part name="flop1" interface="floppy_3">
+			<dataarea name="flop" size="194816">
+				<rom name="stack up (1991)(zeppelin games)(side a)[tape master disk].dsk" size="194816" crc="6fb5d8b1" sha1="4e7442d6fb9b3335ca37ae48abade64e1558e7a3" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="staffofp">
+		<description>The Staff of Power</description>
+		<year>1991</year>
+		<publisher>Zenobi</publisher>
+		<part name="flop1" interface="floppy_3">
+			<dataarea name="flop" size="194816">
+				<rom name="staff of power, the (1991)(zenobi).dsk" size="194816" crc="58cf287b" sha1="4d6ab194e4ce1b42992a64784dd7f676c6ffdb06" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<!-- May be the same edition as the IPF -->
+	<software name="stalingra" cloneof="stalingr">
+		<description>Stalingrad (alt)</description>
+		<year>1988</year>
+		<publisher>CCS</publisher>
+		<part name="flop1" interface="floppy_3">
+			<dataarea name="flop" size="194816">
+				<rom name="stalingrad (1988)(ccs).dsk" size="194816" crc="b8e30ec1" sha1="3e59fe248f3bbad97fd4b7b34fe528ade488e8f6" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="stalker">
+		<description>Stalker</description>
+		<year>1990</year>
+		<publisher>Zenobi</publisher>
+		<part name="flop1" interface="floppy_3">
+			<dataarea name="flop" size="194816">
+				<rom name="stalker (1990)(zenobi).dsk" size="194816" crc="b0390b04" sha1="c34fcf6cc5d09d2a3a15632152bfb07ec8c428f2" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="starcont">
+		<description>Star Control</description>
+		<year>1991</year>
+		<publisher>Dro Soft</publisher>
+		<part name="flop1" interface="floppy_3">
+			<dataarea name="flop" size="194816">
+				<rom name="star control (1991)(dro soft)(es)(en)[re-release].dsk" size="194816" crc="6ae46465" sha1="2a497f52a687388e63ffc8500ac3ec88d66d4f20" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="starrai2">
+		<description>Star Raiders II</description>
+		<year>1987</year>
+		<publisher>Electric Dreams</publisher>
+		<part name="flop1" interface="floppy_3">
+			<dataarea name="flop" size="204544">
+				<rom name="star raiders ii (1987)(electric dreams).dsk" size="204544" crc="83b53901" sha1="6bab4a36af709dab36a9587cdb36a9397e73f253" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<!-- May be the same edition as the IPF -->
+	<software name="starwarsa" cloneof="starwars">
+		<description>Star Wars (alt)</description>
+		<year>1987</year>
+		<publisher>Domark</publisher>
+		<part name="flop1" interface="floppy_3">
+			<dataarea name="flop" size="194816">
+				<rom name="star wars (1987)(domark).dsk" size="194816" crc="c830d827" sha1="8578572586f25c927bf50463718ce75188bd6f57" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="starbyte">
+		<description>Starbyte</description>
+		<year>1987</year>
+		<publisher>Mister Chip</publisher>
+		<part name="flop1" interface="floppy_3">
+			<dataarea name="flop" size="102400">
+				<rom name="starbyte (1987)(mister chip)(es).dsk" size="102400" crc="c3f2930d" sha1="645bd0c0caa36d6ccd00335b445da45fc5dd3dce" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<!-- May be the same edition as the IPF -->
+	<software name="starglida" cloneof="starglid">
+		<description>Starglider (alt)</description>
+		<year>1986</year>
+		<publisher>Rainbird</publisher>
+		<part name="flop1" interface="floppy_3">
+			<dataarea name="flop" size="194816">
+				<rom name="starglider (1986)(rainbird).dsk" size="194816" crc="2a296abd" sha1="36420eae3caf6ae04c3b03d1ade59a13dad29ee9" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="stargli2">
+		<description>Starglider 2 - The Egrons Strike Back</description>
+		<year>1989</year>
+		<publisher>Rainbird</publisher>
+		<part name="flop1" interface="floppy_3">
+			<dataarea name="flop" size="194816">
+				<rom name="starglider 2 - the egrons strike back (1989)(rainbird).dsk" size="194816" crc="f6bdeb90" sha1="69f0b5f5b1ebdf67dad43eb7852b95b33db3d5d3" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<!-- May be the same edition as the IPF -->
+	<software name="cchaplina" cloneof="cchaplin">
+		<description>Starring Charlie Chaplin (alt)</description>
+		<year>1987</year>
+		<publisher>U.S. Gold</publisher>
+		<part name="flop1" interface="floppy_3">
+			<dataarea name="flop" size="194816">
+				<rom name="starring charlie chaplin (1987)(u.s. gold).dsk" size="194816" crc="1df5d541" sha1="3a39892b5f1a310ec7530b687fab434f9aae5e8c" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="starship">
+		<description>Starship Quest</description>
+		<year>1989</year>
+		<publisher>FSF Adventures</publisher>
+		<part name="flop1" interface="floppy_3">
+			<feature name="part_id" value="Side A"/>
+			<dataarea name="flop" size="194816">
+				<rom name="starship quest (1989)(fsf adventures)(side a).dsk" size="194816" crc="92ebcedb" sha1="30a1f975780ea809fecf0415af6c18f64e21372c" offset="0" />
+			</dataarea>
+		</part>
+		<part name="flop2" interface="floppy_3">
+			<feature name="part_id" value="Side B"/>
+			<dataarea name="flop" size="194816">
+				<rom name="starship quest (1989)(fsf adventures)(side b).dsk" size="194816" crc="41b39b65" sha1="6ddf86a5598841f9a19bfa5ad778b2fccc011edd" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="stircrazsp" cloneof="stircraz">
+		<description>Stir Crazy Featuring Bobo (Spain)</description>
+		<year>1990</year>
+		<publisher>Erbe</publisher>
+		<part name="flop1" interface="floppy_3">
+			<dataarea name="flop" size="194816">
+				<rom name="stir crazy featuring bobo (1990)(erbe)(es)(en)[re-release].dsk" size="194816" crc="e8fb3ec4" sha1="50c5bda1b9d57e23eff42da53fb8cbe2523ac85e" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="stircraz">
+		<description>Stir Crazy Featuring Bobo</description>
+		<year>1990</year>
+		<publisher>Infogrames</publisher>
+		<part name="flop1" interface="floppy_3">
+			<dataarea name="flop" size="194816">
+				<rom name="stir crazy featuring bobo (1990)(infogrames)(fr)(en).dsk" size="194816" crc="98dbef8b" sha1="717259d1fa05209a899f1ddfef20c9c72efacfb1" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="stormlor">
+		<description>Stormlord</description>
+		<year>1989</year>
+		<publisher>Hewson Consultants</publisher>
+		<part name="flop1" interface="floppy_3">
+			<dataarea name="flop" size="194816">
+				<rom name="stormlord (1989)(hewson consultants).dsk" size="194816" crc="0979a296" sha1="0924f2b950c99dc9040d7a7eb64bd46a53227e46" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="stranded">
+		<description>Stranded</description>
+		<year>1992</year>
+		<publisher>Zenobi</publisher>
+		<part name="flop1" interface="floppy_3">
+			<dataarea name="flop" size="194816">
+				<rom name="stranded (1992)(zenobi).dsk" size="194816" crc="9483615b" sha1="dfbe0660b1725999f76af69770491b71f7fb437f" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="strfight">
+		<description>Street Fighter</description>
+		<year>1988</year>
+		<publisher>Go</publisher>
+		<part name="flop1" interface="floppy_3">
+			<dataarea name="flop" size="194816">
+				<rom name="street fighter (1988)(go).dsk" size="194816" crc="867ed9cc" sha1="2aa9fc365e4434db2e9e54074b491fb730431862" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<!-- May be the same edition as the IPF -->
+	<software name="subbuteoa" cloneof="subbuteo">
+		<description>Subbuteo - The Computer Game (alt)</description>
+		<year>1990</year>
+		<publisher>Electronic Zoo</publisher>
+		<part name="flop1" interface="floppy_3">
+			<dataarea name="flop" size="194816">
+				<rom name="subbuteo - the computer game (1990)(electronic zoo).dsk" size="194816" crc="2bdbb1d3" sha1="e85338f53b360019702b91ef969c06a5d7dae406" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="summgam2">
+		<description>Summer Games II</description>
+		<year>1988</year>
+		<publisher>U.S. Gold</publisher>
+		<part name="flop1" interface="floppy_3">
+			<feature name="part_id" value="Side A"/>
+			<dataarea name="flop" size="194816">
+				<rom name="summer games ii (1988)(u.s. gold)(side a).dsk" size="194816" crc="e9a395be" sha1="495f06647275a71c2da1f0c03878f1586bbf7ed9" offset="0" />
+			</dataarea>
+		</part>
+		<part name="flop2" interface="floppy_3">
+			<feature name="part_id" value="Side B"/>
+			<dataarea name="flop" size="194816">
+				<rom name="summer games ii (1988)(u.s. gold)(side b).dsk" size="194816" crc="98858aef" sha1="965171b35927ca86a3edc24ebfac6abd10792bfd" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="supercara" cloneof="supercar">
+	<!-- May be the same edition as the IPF -->
+		<description>Super Cars (alt)</description>
+		<year>1990</year>
+		<publisher>Gremlin Graphics</publisher>
+		<part name="flop1" interface="floppy_3">
+			<dataarea name="flop" size="174848">
+				<rom name="super cars (1990)(gremlin graphics).dsk" size="174848" crc="0ca22a11" sha1="10d892855a61470343d3e9fe68411e9d2f6b3f83" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<!-- May be the same edition as the IPF -->
+	<software name="suprcycla" cloneof="suprcycl">
+		<description>Super Cycle (alt)</description>
+		<year>1987</year>
+		<publisher>U.S. Gold</publisher>
+		<part name="flop1" interface="floppy_3">
+			<dataarea name="flop" size="194816">
+				<rom name="super cycle (1987)(u.s. gold).dsk" size="194816" crc="bd0f4919" sha1="f5dcb5c3dd83dc5bfa7e13dca2fc7060a8899a61" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="spscsimusp" cloneof="spscsimu">
+		<description>Super Scramble Simulator (Spain)</description>
+		<year>1989</year>
+		<publisher>Erbe</publisher>
+		<part name="flop1" interface="floppy_3">
+			<dataarea name="flop" size="68608">
+				<rom name="super scramble simulator (1989)(erbe)(es)(en)[re-release].dsk" size="68608" crc="7e7e0a71" sha1="6fcb326fed039e3cf5dd2aa35bcd1a76b88e3f52" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="spscsimu">
+		<description>Super Scramble Simulator</description>
+		<year>1989</year>
+		<publisher>Gremlin Graphics</publisher>
+		<part name="flop1" interface="floppy_3">
+			<dataarea name="flop" size="219136">
+				<rom name="super scramble simulator (1989)(gremlin graphics).dsk" size="219136" crc="28831769" sha1="efc4c460794941aad2c6acbc5aa48e98f1b3e949" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="ssinva" cloneof="ssinv">
+		<description>Super Space Invaders (alt)</description>
+		<year>1991</year>
+		<publisher>Domark</publisher>
+		<part name="flop1" interface="floppy_3">
+			<dataarea name="flop" size="194816">
+				<rom name="super space invaders (1991)(domark)[aka space invaders '91].dsk" size="194816" crc="49e654a3" sha1="4d17e0192046883b15f928b93df13d1638395713" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="ssinvb" cloneof="ssinv">
+		<description>Super Space Invaders (alt 2)</description>
+		<year>1991</year>
+		<publisher>Domark</publisher>
+		<part name="flop1" interface="floppy_3">
+			<dataarea name="flop" size="194816">
+				<rom name="super space invaders (1991)(domark)[a][aka space invaders '91].dsk" size="194816" crc="8f014e05" sha1="5c9c70e29d788b03151d992b9e119ee49a63a01e" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="ssinvc" cloneof="ssinv">
+		<description>Super Space Invaders (alt 3)</description>
+		<year>1991</year>
+		<publisher>Domark</publisher>
+		<part name="flop1" interface="floppy_3">
+			<dataarea name="flop" size="194816">
+				<rom name="super space invaders (1991)(domark)[a2][aka space invaders '91].dsk" size="194816" crc="17742dec" sha1="4ae71d91affa353353f125137d04f69b94dcf88e" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="superspa">
+		<description>Super Space Invaders</description>
+		<year>1991</year>
+		<publisher>Domark</publisher>
+		<part name="flop1" interface="floppy_3">
+			<dataarea name="flop" size="194816">
+				<rom name="super space invaders (1991)(domark)[a3][aka space invaders '91].dsk" size="194816" crc="568d63df" sha1="e9e3ebd679de2a559611452cc4fc5ea6d50db53d" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="spchs335">
+		<description>Superchess 3 v3.5</description>
+		<year>1984</year>
+		<publisher>CP</publisher>
+		<part name="flop1" interface="floppy_3">
+			<dataarea name="flop" size="194816">
+				<rom name="superchess 3 v3.5 (1984)(cp).dsk" size="194816" crc="a3329d71" sha1="181ff40d2f69b2409909ef8941dffc10c70d4cc6" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="superman">
+		<description>Superman - The Man of Steel</description>
+		<year>1989</year>
+		<publisher>Tynesoft</publisher>
+		<part name="flop1" interface="floppy_3">
+			<feature name="part_id" value="Side A"/>
+			<dataarea name="flop" size="194816">
+				<rom name="superman - the man of steel (1989)(tynesoft)(side a).dsk" size="194816" crc="08d9cc71" sha1="b3828014329ad06e16ade91324f517e22849a3bc" offset="0" />
+			</dataarea>
+		</part>
+		<part name="flop2" interface="floppy_3">
+			<feature name="part_id" value="Side B"/>
+			<dataarea name="flop" size="194816">
+				<rom name="superman - the man of steel (1989)(tynesoft)(side b).dsk" size="194816" crc="b3c0c0f3" sha1="7c343d678eb85659967cb06aa6350096159f397e" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="supsport">
+		<description>Supersports - The Alternative Olympics</description>
+		<year>1988</year>
+		<publisher>Gremlin Graphics</publisher>
+		<part name="flop1" interface="floppy_3">
+			<feature name="part_id" value="Side A"/>
+			<dataarea name="flop" size="176103">
+				<rom name="supersports - the alternative olympics (1988)(gremlin graphics)(side a)[aka super sports - the olympic challenge].dsk" size="176103" crc="21b31fff" sha1="f5685271d3dc1d49aa593d48299b9c3da98603a2" offset="0" />
+			</dataarea>
+		</part>
+		<part name="flop2" interface="floppy_3">
+			<feature name="part_id" value="Side B"/>
+			<dataarea name="flop" size="176103">
+				<rom name="supersports - the alternative olympics (1988)(gremlin graphics)(side b)[aka super sports - the olympic challenge].dsk" size="176103" crc="73da3eac" sha1="f03b0a34ad6d67576e62b51f0a75abf88a7aef86" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="swoiannasp" cloneof="swoianna">
+		<description>The Sword of IANNA (Spanish)</description>
+		<year>2017</year>
+		<publisher>RetroWorks</publisher>
+		<part name="flop1" interface="floppy_3">
+			<feature name="part_id" value="Side A"/>
+			<dataarea name="flop" size="194816">
+				<rom name="sword of ianna, the (2017-09-30)(retroworks)(es)(side a).dsk" size="194816" crc="fcddb65d" sha1="eed1758d470b08aa9ab14dffee3f8d665639f931" offset="0" />
+			</dataarea>
+		</part>
+		<part name="flop2" interface="floppy_3">
+			<feature name="part_id" value="Side B"/>
+			<dataarea name="flop" size="194816">
+				<rom name="sword of ianna, the (2017-09-30)(retroworks)(es)(side b).dsk" size="194816" crc="eede4f21" sha1="2d26ea4273848fa36ffb1eb45f418ce0f5169c64" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="swoianna">
+		<description>The Sword of IANNA</description>
+		<year>2017</year>
+		<publisher>RetroWorks</publisher>
+		<part name="flop1" interface="floppy_3">
+			<feature name="part_id" value="Side A"/>
+			<dataarea name="flop" size="194816">
+				<rom name="sword of ianna, the (2017-09-30)(retroworks)(es)(en-es)(side a).dsk" size="194816" crc="b6acb571" sha1="2c91875620ad05fd9a1347e7454907b30fac91be" offset="0" />
+			</dataarea>
+		</part>
+		<part name="flop2" interface="floppy_3">
+			<feature name="part_id" value="Side B"/>
+			<dataarea name="flop" size="194816">
+				<rom name="sword of ianna, the (2017-09-30)(retroworks)(es)(en-es)(side b).dsk" size="194816" crc="a007c1b5" sha1="57bde6daf306674a7f8cab9d6784f2175cc9dc25" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="swotsamu">
+		<description>Sword of the Samurai (master disk)</description>
+		<year>1992</year>
+		<publisher>Zeppelin Games</publisher>
+		<part name="flop1" interface="floppy_3">
+			<feature name="part_id" value="Side A"/>
+			<dataarea name="flop" size="194816">
+				<rom name="sword of the samurai (1992)(zeppelin games)(side a)[master disk].dsk" size="194816" crc="69842c84" sha1="7e39573278bb0c3c35ec3b7a18bcbce76cb17572" offset="0" />
+			</dataarea>
+		</part>
+		<part name="flop2" interface="floppy_3">
+			<feature name="part_id" value="Side B"/>
+			<dataarea name="flop" size="194816">
+				<rom name="sword of the samurai (1992)(zeppelin games)(side b).dsk" size="194816" crc="b2523378" sha1="3553502492ad245ba8156228c323b6cc10d99698" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="twasatim">
+		<description>T'Was a Time of Dread</description>
+		<year>1992</year>
+		<publisher>Zenobi</publisher>
+		<part name="flop1" interface="floppy_3">
+			<dataarea name="flop" size="194816">
+				<rom name="t'was a time of dread (1992)(zenobi).dsk" size="194816" crc="a6d11b34" sha1="b59d8b92bd71bdbe2bf383ab8c0468e54981018c" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="tchitort">
+		<description>Tai Chi Tortoise (tape master disk)</description>
+		<year>1991</year>
+		<publisher>Zeppelin Games</publisher>
+		<part name="flop1" interface="floppy_3">
+			<feature name="part_id" value="Side A"/>
+			<dataarea name="flop" size="194816">
+				<rom name="tai chi tortoise (1991)(zeppelin games)(side a)[tape master disk].dsk" size="194816" crc="6412ea4f" sha1="5ebc7ac6ae06ae2eb4b6224d5b1fa28fc5b4014c" offset="0" />
+			</dataarea>
+		</part>
+		<part name="flop2" interface="floppy_3">
+			<feature name="part_id" value="Side B"/>
+	<!-- Side B image shared with other master disks from Zeppelin Games. Verified at World of Spectrum. -->
+			<dataarea name="flop" size="256">
+				<rom name="championship run (1991)(zeppelin games)(side b)[master disk backup][re-release].dsk" size="256" crc="56947af2" sha1="40428c770d847a0fd1fd005b6cf1d03a34672d98" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<!-- May be the same edition as the IPF -->
+	<software name="taipana" cloneof="taipan">
+		<description>Tai-Pan (alt)</description>
+		<year>1987</year>
+		<publisher>Ocean</publisher>
+		<part name="flop1" interface="floppy_3">
+			<dataarea name="flop" size="194560">
+				<rom name="tai-pan (1987)(ocean).dsk" size="194560" crc="458c4b7c" sha1="6fe0e05aa78573fda4b5c563cba5e5d287c25864" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="tlsmathe">
+		<description>The Tales of Mathematica</description>
+		<year>1990</year>
+		<publisher>Zenobi</publisher>
+		<part name="flop1" interface="floppy_3">
+			<dataarea name="flop" size="194816">
+				<rom name="tales of mathematica, the (1990)(zenobi).dsk" size="194816" crc="254feaae" sha1="fe4e845b1e380bcbf9a1c352429476d21c9432a9" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="tankatta">
+		<description>Tank Attack</description>
+		<year>1988</year>
+		<publisher>CDS Microsystems</publisher>
+		<part name="flop1" interface="floppy_3">
+			<dataarea name="flop" size="194816">
+				<rom name="tank attack (1988)(cds microsystems).dsk" size="194816" crc="215fa4e2" sha1="9429a58f1d122ee7feec9db25d6c50f25b58871d" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="targrene">
+		<description>Target: Renegade</description>
+		<year>1988</year>
+		<publisher>Imagine</publisher>
+		<part name="flop1" interface="floppy_3">
+			<dataarea name="flop" size="134144">
+				<rom name="target - renegade (1988)(imagine).dsk" size="134144" crc="c93b5664" sha1="61f5623c5a614558b8431c4cddbc5ae11313c897" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="targetpl">
+		<description>Target Plus</description>
+		<year>1988</year>
+		<publisher>Dinamic</publisher>
+		<info name="usage" value="Requires Gun Stick lightgun"/>
+		<part name="flop1" interface="floppy_3">
+			<dataarea name="flop" size="53504">
+				<rom name="target plus (1988)(dinamic)(es)[gunstick].dsk" size="53504" crc="7de2c214" sha1="ff7ea991a28a559ad2df6f0ffbaf67dba5137996" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="taxretur">
+		<description>Tax Returns</description>
+		<year>1992</year>
+		<publisher>Zenobi</publisher>
+		<part name="flop1" interface="floppy_3">
+			<dataarea name="flop" size="194816">
+				<rom name="tax returns (1992)(zenobi).dsk" size="194816" crc="03d83545" sha1="3dce8cdb905a5ef79ff5af534af19a202433ecf4" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="taxmanco">
+		<description>The Taxman Cometh</description>
+		<year>1991</year>
+		<publisher>Zenobi</publisher>
+		<part name="flop1" interface="floppy_3">
+			<dataarea name="flop" size="194816">
+				<rom name="taxman cometh, the (1991)(zenobi).dsk" size="194816" crc="05399461" sha1="e626dcb4c47a4bf4f5c4a7564d36672f85edeef8" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="tearmoon">
+		<description>The Tears of the Moon</description>
+		<year>1992</year>
+		<publisher>Zenobi</publisher>
+		<part name="flop1" interface="floppy_3">
+			<dataarea name="flop" size="204544">
+				<rom name="tears of the moon, the (1992)(zenobi).dsk" size="204544" crc="e21084cf" sha1="bf084143f9b7f5825742f7259804e3babcef0bb8" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="technoco">
+		<description>Techno-Cop</description>
+		<year>1988</year>
+		<publisher>Gremlin Graphics</publisher>
+		<part name="flop1" interface="floppy_3">
+			<dataarea name="flop" size="219136">
+				<rom name="techno-cop (1988)(gremlin graphics).dsk" size="219136" crc="d3de6ce2" sha1="ad966892ac92495095e565706ed4f672b39a7021" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="teenagee">
+		<description>Teenage Emergency</description>
+		<year>1995</year>
+		<publisher>Zenobi</publisher>
+		<part name="flop1" interface="floppy_3">
+			<dataarea name="flop" size="194816">
+				<rom name="teenage emergency (1995)(zenobi).dsk" size="194816" crc="a945f2f5" sha1="7e5cba7d570959609896663a6a0d6d735cc5d1a3" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<!-- May be the same edition as the IPF -->
+	<software name="tmhta" cloneof="tmht">
+		<description>Teenage Mutant Hero Turtles (alt)</description>
+		<year>1990</year>
+		<publisher>Image Works</publisher>
+		<info name="usage" value="Requires manual for password protection"/>
+		<part name="flop1" interface="floppy_3">
+			<dataarea name="flop" size="194816">
+				<rom name="teenage mutant hero turtles (1990)(image works)[passworded].dsk" size="194816" crc="ffb00416" sha1="680ae4dccfe54c1117df40edff50b1fa51b7c00b" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<!-- May be the same edition as the IPF -->
+	<software name="tmhtb" cloneof="tmht">
+		<description>Teenage Mutant Hero Turtles (alt 2)</description>
+		<year>1990</year>
+		<publisher>Image Works</publisher>
+		<info name="usage" value="Requires manual for password protection"/>
+		<part name="flop1" interface="floppy_3">
+			<dataarea name="flop" size="194816">
+				<rom name="teenage mutant hero turtles (1990)(image works)[a][passworded].dsk" size="194816" crc="059786ae" sha1="2ca0e8a8c0a24a11fe2904cf586cdd32fa1bc6bb" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="tengrebt">
+		<description>Ten Green Bottles</description>
+		<year>1995</year>
+		<publisher>Zenobi</publisher>
+		<part name="flop1" interface="floppy_3">
+			<dataarea name="flop" size="194816">
+				<rom name="ten green bottles (1995)(zenobi).dsk" size="194816" crc="667dfed2" sha1="da5f6806ebc46dec7ae7c63d9f11e650f39ab845" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<!-- May be the same edition as the IPF -->
+	<software name="term2a" cloneof="term2">
+		<description>Terminator 2 - Judgment Day (alt)</description>
+		<year>1991</year>
+		<publisher>Ocean</publisher>
+		<part name="flop1" interface="floppy_3">
+			<dataarea name="flop" size="216320">
+				<rom name="terminator 2 - judgment day (1991)(ocean).dsk" size="216320" crc="d97a5f2a" sha1="512127b1523d9ba51889b3891592007dcbb89ed0" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="terrorpo">
+		<description>Terrorpods</description>
+		<year>1989</year>
+		<publisher>Dro Soft</publisher>
+		<part name="flop1" interface="floppy_3">
+			<dataarea name="flop" size="58624">
+				<rom name="terrorpods (1989)(dro soft)(es)(en)[re-release].dsk" size="58624" crc="4e335ea4" sha1="4fc4e61c48103a6b1bd3af4662ee1926338cffca" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="tetris">
+		<description>Tetris</description>
+		<year>1988</year>
+		<publisher>Mirrorsoft</publisher>
+		<part name="flop1" interface="floppy_3">
+			<dataarea name="flop" size="194816">
+				<rom name="tetris (1988)(mirrorsoft).dsk" size="194816" crc="6c230d3f" sha1="04119edaf20c012d953426be34c0d52990d88687" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="tetrisa" cloneof="tetris">
+		<description>Tetris (alt)</description>
+		<year>1988</year>
+		<publisher>Mirrorsoft</publisher>
+		<part name="flop1" interface="floppy_3">
+			<dataarea name="flop" size="204544">
+				<rom name="tetris (1988)(mirrorsoft)[a].dsk" size="204544" crc="e7febbfc" sha1="8d2652072d6334c1011e9539136b9558eeb61d76" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="tetrisb" cloneof="tetris">
+		<description>Tetris (alt 2)</description>
+		<year>1988</year>
+		<publisher>Mirrorsoft</publisher>
+		<part name="flop1" interface="floppy_3">
+			<dataarea name="flop" size="204544">
+				<rom name="tetris (1988)(mirrorsoft)[a2].dsk" size="204544" crc="a1cd0a44" sha1="6a10201bd233d96c7b47bf252df1f0462b7de3e7" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="tparkuk">
+		<description>Theme Park U.K.</description>
+		<year>1993</year>
+		<publisher>Zenobi</publisher>
+		<part name="flop1" interface="floppy_3">
+			<dataarea name="flop" size="194816">
+				<rom name="theme park u.k. (1993)(zenobi)[re-release].dsk" size="194816" crc="82d68d37" sha1="b43330b5962f776ae595d88bd3711378c7d80a17" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="tparkusa">
+		<description>Theme Park U.S.A.</description>
+		<year>1993</year>
+		<publisher>Zenobi</publisher>
+		<part name="flop1" interface="floppy_3">
+			<dataarea name="flop" size="194816">
+				<rom name="theme park u.s.a. (1993)(zenobi).dsk" size="194816" crc="fa6b510f" sha1="4141a805840d7c990ec5b9b671ca2ddde5853807" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="tabombup">
+		<description>There's a Bomb Under Parliament</description>
+		<year>1991</year>
+		<publisher>Zenobi</publisher>
+		<part name="flop1" interface="floppy_3">
+			<dataarea name="flop" size="194816">
+				<rom name="there's a bomb under parliament (1991)(zenobi).dsk" size="194816" crc="61cfed6b" sha1="67b4598e5b2e961cbe4215f364bb5b71c37e5e5c" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="thirnins">
+		<description>The Thirty-Nine Steps</description>
+		<year>1995</year>
+		<publisher>Zenobi</publisher>
+		<part name="flop1" interface="floppy_3">
+			<dataarea name="flop" size="194816">
+				<rom name="thirty-nine steps, the (1995)(zenobi)[aka 39 steps, the].dsk" size="194816" crc="97ce88e7" sha1="bbeb7c4764736f822e31a0518026f890ca0b81e4" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<!-- May be the same edition as the IPF -->
+	<software name="tbladea" cloneof="tblade">
+		<description>Thunder Blade (alt)</description>
+		<year>1988</year>
+		<publisher>U.S. Gold</publisher>
+		<part name="flop1" interface="floppy_3">
+			<dataarea name="flop" size="194816">
+				<rom name="thunder blade (1988)(u.s. gold).dsk" size="194816" crc="13a82ea8" sha1="395cabc0eb12af6856ca9c685bbde042bf54300e" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<!-- May be the same edition as the IPF -->
+	<software name="tbladeb" cloneof="tblade">
+		<description>Thunder Blade (alt 2)</description>
+		<year>1988</year>
+		<publisher>U.S. Gold</publisher>
+		<part name="flop1" interface="floppy_3">
+			<dataarea name="flop" size="194816">
+				<rom name="thunder blade (1988)(u.s. gold)[a].dsk" size="194816" crc="c6ff5741" sha1="c2a090224dc93f68f97b51fbbfe3555d0e6a7a07" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="thunderb">
+		<description>Thunderbirds</description>
+		<year>1989</year>
+		<publisher>Grandslam</publisher>
+		<part name="flop1" interface="floppy_3">
+			<feature name="part_id" value="Side A"/>
+			<dataarea name="flop" size="194816">
+				<rom name="thunderbirds (1989)(grandslam)(side a).dsk" size="194816" crc="66fd1e53" sha1="410e2afaa9c5273b048c1830838835dd37d217ed" offset="0" />
+			</dataarea>
+		</part>
+		<part name="flop2" interface="floppy_3">
+			<feature name="part_id" value="Side B"/>
+			<dataarea name="flop" size="194816">
+				<rom name="thunderbirds (1989)(grandslam)(side b).dsk" size="194816" crc="60f605fa" sha1="aa856c625ed23dc634ff9f9dc73dcb84f13123e0" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="thunderbsp" cloneof="thunderb">
+		<description>Thunderbirds (Spain)</description>
+		<year>1989</year>
+		<publisher>MCM</publisher>
+		<part name="flop1" interface="floppy_3">
+			<feature name="part_id" value="Side A"/>
+			<dataarea name="flop" size="174848">
+				<rom name="thunderbirds (1989)(mcm)(es)(en)(side a)[re-release].dsk" size="174848" crc="ce593266" sha1="2d68121c14b7a2b959eb949f6bccf85ffaa55ca5" offset="0" />
+			</dataarea>
+		</part>
+		<part name="flop2" interface="floppy_3">
+			<feature name="part_id" value="Side B"/>
+			<dataarea name="flop" size="174848">
+				<rom name="thunderbirds (1989)(mcm)(es)(en)(side b)[re-release].dsk" size="174848" crc="0e8dc579" sha1="7614e72ff525cc87867eef68cb885e746caff727" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="thunderba" cloneof="thunderb">
+		<description>Thunderbirds (alt)</description>
+		<year>1989</year>
+		<publisher>Grandslam</publisher>
+		<part name="flop1" interface="floppy_3">
+			<feature name="part_id" value="Side A"/>
+			<dataarea name="flop" size="194816">
+				<rom name="thunderbirds (1989)(grandslam)(side a)[a].dsk" size="194816" crc="cb8427bb" sha1="7eba9267736f5ca2b4e245ebe6e7e2f031a08f79" offset="0" />
+			</dataarea>
+		</part>
+		<part name="flop2" interface="floppy_3">
+			<feature name="part_id" value="Side B"/>
+			<dataarea name="flop" size="194816">
+				<rom name="thunderbirds (1989)(grandslam)(side b)[a].dsk" size="194816" crc="61099896" sha1="c20b818cf298e15765adfb1385f3c5c604873864" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<!-- May be the same edition as the IPF -->
+	<software name="thdrcatsa" cloneof="thdrcats">
+		<description>Thundercats (alt)</description>
+		<year>1987</year>
+		<publisher>Elite Systems</publisher>
+		<part name="flop1" interface="floppy_3">
+			<dataarea name="flop" size="194816">
+				<rom name="thundercats (1987)(elite systems).dsk" size="194816" crc="89029622" sha1="c4aa09753aa87f8e7193bff875f3531886cc1ce3" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="tiburon" cloneof="jaws">
+		<description>Tiburon</description>
+		<year>1989</year>
+		<publisher>Erbe</publisher>
+		<part name="flop1" interface="floppy_3">
+			<dataarea name="flop" size="78080">
+				<rom name="tiburon (1989)(erbe)(es)(en)[aka jaws][re-release].dsk" size="78080" crc="aaa7b9fe" sha1="f028fc6cc04d585c570193560849896925c3472f" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="timecrys">
+		<description>The Time Crystal</description>
+		<year>2011</year>
+		<publisher>&lt;homebrew&gt;</publisher>
+		<info name="author" value="Steven Flanagan"/>
+		<part name="flop1" interface="floppy_3">
+			<dataarea name="flop" size="194816">
+				<rom name="time crystal, the (2011)(flanagan, steven).dsk" size="194816" crc="777f0094" sha1="a7a16b0f6bfa89879d9672ec17df0df0bbb07cfb" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="timescan">
+		<description>Time Scanner</description>
+		<year>1989</year>
+		<publisher>Activision</publisher>
+		<part name="flop1" interface="floppy_3">
+			<dataarea name="flop" size="194816">
+				<rom name="time scanner (1989)(activision).dsk" size="194816" crc="941f35d2" sha1="bd23dd1b8911e2d3c125d983502c9ecf6fb0a965" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="timescansp" cloneof="timescan">
+		<description>Time Scanner (Spain)</description>
+		<year>1989</year>
+		<publisher>MCM</publisher>
+		<part name="flop1" interface="floppy_3">
+			<dataarea name="flop" size="144384">
+				<rom name="time scanner (1989)(mcm)(es)(en)[re-release].dsk" size="144384" crc="f6be60cc" sha1="980ff8cbcf5727eca1cbe3d5158d2514d66f1504" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="tintmoonsp" cloneof="tintmoon">
+		<description>Tintin en la Luna</description>
+		<year>1989</year>
+		<publisher>Erbe</publisher>
+		<part name="flop1" interface="floppy_3">
+			<dataarea name="flop" size="63488">
+				<rom name="tintin en la luna (1989)(erbe)(es)(en)[aka tintin on the moon][re-release].dsk" size="63488" crc="e4e8df96" sha1="e60fda54d391d7e1b073529f12e7aa74d6e5b7d2" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="tintmoon">
+		<description>Tintin on the Moon</description>
+		<year>1989</year>
+		<publisher>Infogrames</publisher>
+		<part name="flop1" interface="floppy_3">
+			<dataarea name="flop" size="204544">
+				<rom name="tintin on the moon (1989)(infogrames)(fr)(en).dsk" size="204544" crc="18094850" sha1="44c2069bb173bfb5ea070f4eaea9b7a9bae09c88" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="titanicb">
+		<description>Titanic Blinky (tape master disk)</description>
+		<year>1991</year>
+		<publisher>Zeppelin Games</publisher>
+		<part name="flop1" interface="floppy_3">
+			<feature name="part_id" value="Side A"/>
+			<dataarea name="flop" size="194816">
+				<rom name="titanic blinky (1991)(zeppelin games)(side a)[tape master disk].dsk" size="194816" crc="b472ed9c" sha1="8a0107792cd59d729f3c39dc7d1c7fcd943dd62c" offset="0" />
+			</dataarea>
+		</part>
+		<part name="flop2" interface="floppy_3">
+			<feature name="part_id" value="Side B"/>
+			<dataarea name="flop" size="194816">
+				<rom name="titanic blinky (1991)(zeppelin games)(side b)[tape master disk].dsk" size="194816" crc="84304cc7" sha1="9194585c484c1ace0fecb779af0f4fdd0a5ce4ce" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="toddlert">
+		<description>Toddler Trouble</description>
+		<year>1996</year>
+		<publisher>Zenobi</publisher>
+		<part name="flop1" interface="floppy_3">
+			<dataarea name="flop" size="194816">
+				<rom name="toddler trouble (1996)(zenobi).dsk" size="194816" crc="bad46cb8" sha1="1393e49ebea152d62a47b43ac4d28b9e3e86932b" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="tomahawk">
+		<description>Tomahawk</description>
+		<year>1985</year>
+		<publisher>Digital Integration</publisher>
+		<part name="flop1" interface="floppy_3">
+			<dataarea name="flop" size="102400">
+				<rom name="tomahawk (1985)(digital integration)[aka thunderbird].dsk" size="102400" crc="706d95cd" sha1="afb87bc59e3ce983f829fe6c63a29cbd38d5d202" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="toobin">
+		<description>Toobin'</description>
+		<year>1989</year>
+		<publisher>Domark</publisher>
+		<part name="flop1" interface="floppy_3">
+			<dataarea name="flop" size="204288">
+				<rom name="toobin' (1989)(domark).dsk" size="204288" crc="89cd9303" sha1="a3a38047aee158f77ab5f772561c70d05a222d8d" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="toobina" cloneof="toobin">
+		<description>Toobin' (alt)</description>
+		<year>1989</year>
+		<publisher>Domark</publisher>
+		<part name="flop1" interface="floppy_3">
+			<dataarea name="flop" size="190208">
+				<rom name="toobin' (1989)(domark)[a].dsk" size="190208" crc="7ec3488c" sha1="693cf9676485a0578db838963da90b5a895c26cc" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="toobinsp" cloneof="toobin">
+		<description>Toobin' (Spain)</description>
+		<year>1989</year>
+		<publisher>Erbe</publisher>
+		<part name="flop1" interface="floppy_3">
+			<dataarea name="flop" size="121856">
+				<rom name="toobin' (1989)(erbe)(es)(en)[re-release].dsk" size="121856" crc="0aa86bcb" sha1="6e22f2395bc263e0d2c33d058770f8a5e84d7369" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="tmhtsp" cloneof="tmht">
+		<description>Tortugas Ninja</description>
+		<year>1990</year>
+		<publisher>MCM</publisher>
+		<info name="usage" value="Requires manual for password protection"/>
+		<part name="flop1" interface="floppy_3">
+			<dataarea name="flop" size="73216">
+				<rom name="tortugas ninja (1990)(mcm)(es)(en)[aka teenage mutant hero turtles][passworded][re-release].dsk" size="73216" crc="37875ffb" sha1="9af1d34f7861c163407256fb49fa569aeece4e54" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+<!-- This is the dump in World of Spectrum, but original version was password protected (rerelease or hack?) -->
+	<software name="tmhtsp2" cloneof="tmht">
+		<description>Tortugas Ninja (unprotected)</description>
+		<year>1990</year>
+		<publisher>MCM</publisher>
+		<part name="flop1" interface="floppy_3">
+			<dataarea name="flop" size="73216">
+				<rom name="tortugas ninja (1990)(mcm)(es)(en)[aka teenage mutant hero turtles][re-release].dsk" size="73216" crc="6766d492" sha1="7ae9c02004b4f67c7c70d0cc1e3e1157538d3418" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="totalecl">
+		<description>Total Eclipse</description>
+		<year>1988</year>
+		<publisher>Incentive</publisher>
+		<part name="flop1" interface="floppy_3">
+			<dataarea name="flop" size="194816">
+				<rom name="total eclipse (1988)(incentive).dsk" size="194816" crc="37ca3e96" sha1="89c3cdcdeb53daa4f684a606ec79ba16c6362c9f" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<!-- May be the same edition as the IPF -->
+	<software name="totrecala" cloneof="totrecal">
+		<description>Total Recall (alt)</description>
+		<year>1991</year>
+		<publisher>Ocean</publisher>
+		<part name="flop1" interface="floppy_3">
+			<dataarea name="flop" size="178432">
+				<rom name="total recall (1991)(ocean).dsk" size="178432" crc="d58b27ec" sha1="618542c813bec4f3f55196af9033e51a37776965" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="tourdefo">
+		<description>Tour de Force</description>
+		<year>1988</year>
+		<publisher>Gremlin Graphics</publisher>
+		<part name="flop1" interface="floppy_3">
+			<dataarea name="flop" size="174848">
+				<rom name="tour de force (1988)(gremlin graphics).dsk" size="174848" crc="c8999948" sha1="3ccb02f23add396d4e45eedf8a7511e7be206b77" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="treasisl">
+		<description>Treasure Island</description>
+		<year>1991</year>
+		<publisher>Zenobi</publisher>
+		<part name="flop1" interface="floppy_3">
+			<dataarea name="flop" size="194816">
+				<rom name="treasure island (1991)(zenobi)[re-release].dsk" size="194816" crc="a9627167" sha1="2b72da4fa8c55c883b33bbfd7288b83e9acdb526" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<!-- May be the same edition as the IPF -->
+	<software name="brookinga" cloneof="brooking">
+		<description>Trevor Brooking's World Cup Glory (alt)</description>
+		<year>1990</year>
+		<publisher>Challenge</publisher>
+		<part name="flop1" interface="floppy_3">
+			<dataarea name="flop" size="194816">
+				<rom name="trevor brooking's world cup glory (1990)(challenge).dsk" size="194816" crc="d0aefb7f" sha1="c73e42dd17e06b581711b1b870a6e953e2c05ce2" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="trigger">
+		<description>Trigger</description>
+		<year>1989</year>
+		<publisher>Opera Soft</publisher>
+		<part name="flop1" interface="floppy_3">
+			<dataarea name="flop" size="217344">
+				<rom name="trigger (1989)(opera soft)(es).dsk" size="217344" crc="8940aa50" sha1="77ee6b6045a32e8ca0b42561e30c40fa9607318b" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="triggergs" cloneof="trigger">
+		<description>Trigger (Gun Stick)</description>
+		<year>1989</year>
+		<publisher>Opera Soft</publisher>
+		<info name="usage" value="Requires Gun Stick lightgun"/>
+		<part name="flop1" interface="floppy_3">
+			<dataarea name="flop" size="214784">
+				<rom name="trigger (1989)(opera soft)(es)[gunstick].dsk" size="214784" crc="f628b19b" sha1="fa93a4b8b4e92063165e4f4823272898d4225836" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="trivialp">
+		<description>Trivial Pursuit - A New Beginning</description>
+		<year>1988</year>
+		<publisher>Domark</publisher>
+		<part name="flop1" interface="floppy_3">
+			<feature name="part_id" value="Side A"/>
+			<dataarea name="flop" size="194816">
+				<rom name="trivial pursuit - a new beginning (1988)(domark)(side a).dsk" size="194816" crc="60b7be4a" sha1="097c69e7f820508770ab5a85ae3d270ee478a51e" offset="0" />
+			</dataarea>
+		</part>
+		<part name="flop2" interface="floppy_3">
+			<feature name="part_id" value="Side B"/>
+			<dataarea name="flop" size="194816">
+				<rom name="trivial pursuit - a new beginning (1988)(domark)(side b).dsk" size="194816" crc="3d052505" sha1="b4edfe5dde39a4d759f2961d26a208f443c69e43" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="troublew">
+		<description>Trouble with Trolls</description>
+		<year>1996</year>
+		<publisher>Zenobi</publisher>
+		<part name="flop1" interface="floppy_3">
+			<dataarea name="flop" size="194816">
+				<rom name="trouble with trolls (1996)(zenobi).dsk" size="194816" crc="b4b266d8" sha1="457b199bd8d62a11813e985caad268a4adbcf259" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="tuareg">
+		<description>Tuareg</description>
+		<year>1988</year>
+		<publisher>Topo Soft</publisher>
+		<part name="flop1" interface="floppy_3">
+			<dataarea name="flop" size="112128">
+				<rom name="tuareg (1988)(topo soft)(es).dsk" size="112128" crc="cd014088" sha1="297497602a178235fd89240dfaaab433b3de0fde" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="turbogir">
+		<description>Turbo Girl</description>
+		<year>1988</year>
+		<publisher>Dinamic</publisher>
+		<part name="flop1" interface="floppy_3">
+			<dataarea name="flop" size="58880">
+				<rom name="turbo girl (1988)(dinamic)(es).dsk" size="58880" crc="4fc6bb30" sha1="b98e25c0a5a75828bf930324dbe008a73a9e0ac9" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="turboout">
+		<description>Turbo Out Run</description>
+		<year>1989</year>
+		<publisher>U.S. Gold</publisher>
+		<part name="flop1" interface="floppy_3">
+			<feature name="part_id" value="Side A"/>
+			<dataarea name="flop" size="255232">
+				<rom name="turbo out run (1989)(u.s. gold)(side a).dsk" size="255232" crc="2d08c5e8" sha1="b0e41605685c2369b4928ad110e3d7901dcc694c" offset="0" />
+			</dataarea>
+		</part>
+		<part name="flop2" interface="floppy_3">
+			<feature name="part_id" value="Side B"/>
+			<dataarea name="flop" size="256256">
+				<rom name="turbo out run (1989)(u.s. gold)(side b).dsk" size="256256" crc="6cf33b9f" sha1="46ef8778a9902349e51b6b154166164598663c63" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="turbooutsp" cloneof="turboout">
+		<description>Turbo Out Run (Spain)</description>
+		<year>1990</year>
+		<publisher>Erbe</publisher>
+		<part name="flop1" interface="floppy_3">
+			<feature name="part_id" value="Side A"/>
+			<dataarea name="flop" size="255232">
+				<rom name="turbo out run (1990)(erbe)(es)(en)(side a).dsk" size="255232" crc="47a254d0" sha1="4444838b316d90cb3710a5700767f8865346ebf8" offset="0" />
+			</dataarea>
+		</part>
+		<part name="flop2" interface="floppy_3">
+			<feature name="part_id" value="Side B"/>
+			<dataarea name="flop" size="256256">
+				<rom name="turbo out run (1990)(erbe)(es)(en)(side b).dsk" size="256256" crc="da1780bf" sha1="de01ad584cf0ac548dd95a52d7f494be35c08594" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="turboska">
+		<description>Turbo Skate Fighter (tape master disk)</description>
+		<year>1989</year>
+		<publisher>Zeppelin Games</publisher>
+		<part name="flop1" interface="floppy_3">
+			<feature name="part_id" value="Side A"/>
+			<dataarea name="flop" size="194816">
+				<rom name="turbo skate fighter (1989)(zeppelin games)(side a)[tape master disk].dsk" size="194816" crc="8eb4cbbd" sha1="b9916d55091d468765fdc7afebf6928d64ee651d" offset="0" />
+			</dataarea>
+		</part>
+		<part name="flop2" interface="floppy_3">
+			<feature name="part_id" value="Side B"/>
+			<dataarea name="flop" size="194816">
+				<rom name="turbo skate fighter (1989)(zeppelin games)(side b)[tape master disk].dsk" size="194816" crc="5307f975" sha1="c49886b9808292c6ad6aff9cfba7f68d85542444" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="turrican">
+		<description>Turrican</description>
+		<year>1990</year>
+		<publisher>Rainbow Arts</publisher>
+		<part name="flop1" interface="floppy_3">
+			<feature name="part_id" value="Side A"/>
+			<dataarea name="flop" size="224512">
+				<rom name="turrican (1990)(rainbow arts)(side a).dsk" size="224512" crc="e3445b47" sha1="624fa5b7e7e9f3c8af65fbcc20883ef2de69f822" offset="0" />
+			</dataarea>
+		</part>
+		<part name="flop2" interface="floppy_3">
+			<feature name="part_id" value="Side B"/>
+			<dataarea name="flop" size="215296">
+				<rom name="turrican (1990)(rainbow arts)(side b).dsk" size="215296" crc="847ee5ee" sha1="cc8ebfc85c287cdeae6aca540dc44c434aa47add" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="turrican" cloneof="turrican">
+		<description>Turrican (Spain)</description>
+		<year>1990</year>
+		<publisher>Erbe</publisher>
+		<part name="flop1" interface="floppy_3">
+			<feature name="part_id" value="Side A"/>
+			<dataarea name="flop" size="194816">
+				<rom name="turrican (1990)(erbe)(es)(en)(side a)[re-release].dsk" size="194816" crc="3b661054" sha1="3e5db821ce825bec75c53394e29d4aaceb300a40" offset="0" />
+			</dataarea>
+		</part>
+		<part name="flop2" interface="floppy_3">
+			<feature name="part_id" value="Side B"/>
+			<dataarea name="flop" size="194816">
+				<rom name="turrican (1990)(erbe)(es)(en)(side b)[re-release].dsk" size="194816" crc="602069ea" sha1="ef791c7497f9622942913a8526b6db18acfa83b1" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="turrica2">
+		<description>Turrican II - The Final Fight</description>
+		<year>1991</year>
+		<publisher>Rainbow Arts</publisher>
+		<part name="flop1" interface="floppy_3">
+			<feature name="part_id" value="Side A"/>
+			<dataarea name="flop" size="227072">
+				<rom name="turrican ii - the final fight (1991)(rainbow arts)(side a).dsk" size="227072" crc="117fbcc7" sha1="bd1c00a297f6594e950db359a823bdf60b662f5a" offset="0" />
+			</dataarea>
+		</part>
+		<part name="flop2" interface="floppy_3">
+			<feature name="part_id" value="Side B"/>
+			<dataarea name="flop" size="231424">
+				<rom name="turrican ii - the final fight (1991)(rainbow arts)(side b).dsk" size="231424" crc="3731bfbc" sha1="c274000b93dd8d6620b2d4e85ab542b1fd0061ba" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="turrica2a" cloneof="turrica2">
+		<description>Turrican II - The Final Fight (alt)</description>
+		<year>1991</year>
+		<publisher>Rainbow Arts</publisher>
+		<part name="flop1" interface="floppy_3">
+			<feature name="part_id" value="Side A"/>
+			<dataarea name="flop" size="227072">
+				<rom name="turrican ii - the final fight (1991)(rainbow arts)(side a)[a].dsk" size="227072" crc="e733816f" sha1="e95ec76f20b21cba90978296c2dfdc7f2b550a8d" offset="0" />
+			</dataarea>
+		</part>
+		<part name="flop2" interface="floppy_3">
+			<feature name="part_id" value="Side B"/>
+			<dataarea name="flop" size="227072">
+				<rom name="turrican ii - the final fight (1991)(rainbow arts)(side b)[a].dsk" size="227072" crc="554124c8" sha1="64d396bbcc59a2fd9efdf066725e37f4548d9358" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="twdaysch">
+		<description>The Twelve Days of Christmas</description>
+		<year>1994</year>
+		<publisher>Zenobi</publisher>
+		<part name="flop1" interface="floppy_3">
+			<dataarea name="flop" size="194816">
+				<rom name="twelve days of christmas, the (1994)(zenobi).dsk" size="194816" crc="954564f0" sha1="f24abcc5bda989a189f6d817332db7becb865e01" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="twiligkr">
+		<description>Twilight: Krajina Tienov</description>
+		<year>1996</year>
+		<publisher>Dmytro Gryshcenko</publisher>
+		<part name="flop1" interface="floppy_3">
+			<dataarea name="flop" size="389376">
+				<rom name="twilight - krajina tienov (1996)(gryshcenko, dmytro)(ua)(en)[re-release].dsk" size="389376" crc="95c3c411" sha1="92318c23b9442754c6948c52af5dfde3529e511e" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="twinworl">
+		<description>Twin World</description>
+		<year>1990</year>
+		<publisher>Ubi Soft</publisher>
+		<part name="flop1" interface="floppy_3">
+			<feature name="part_id" value="Side A"/>
+			<dataarea name="flop" size="215296">
+				<rom name="twin world (1990)(ubi soft)(fr)(en)(side a).dsk" size="215296" crc="2f5ae73e" sha1="ab4c3231626550ef3dca2500169bb8029af1fe76" offset="0" />
+			</dataarea>
+		</part>
+		<part name="flop2" interface="floppy_3">
+			<feature name="part_id" value="Side B"/>
+			<dataarea name="flop" size="215296">
+				<rom name="twin world (1990)(ubi soft)(fr)(en)(side b).dsk" size="215296" crc="afc6c6dc" sha1="182da821939b391f6b6b7da1cbb6ebc72332cc35" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="typhoon">
+		<description>Typhoon</description>
+		<year>1988</year>
+		<publisher>Imagine</publisher>
+		<part name="flop1" interface="floppy_3">
+			<dataarea name="flop" size="156672">
+				<rom name="typhoon (1988)(imagine).dsk" size="156672" crc="71be4480" sha1="8475b7e1957fccad01db0ad92f2a741be11f62c8" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="typhoonb" cloneof="typhoon">
+		<description>Typhoon (alt)</description>
+		<year>1988</year>
+		<publisher>Imagine</publisher>
+		<part name="flop1" interface="floppy_3">
+			<dataarea name="flop" size="194816">
+				<rom name="typhoon (1988)(imagine)[a].dsk" size="194816" crc="a3d5abe7" sha1="8e106d7fc0f2048712f5179e9b57f8d5ad93eb41" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="typhoonc" cloneof="typhoon">
+		<description>Typhoon (alt 2)</description>
+		<year>1988</year>
+		<publisher>Imagine</publisher>
+		<part name="flop1" interface="floppy_3">
+			<dataarea name="flop" size="155648">
+				<rom name="typhoon (1988)(imagine)[a2].dsk" size="155648" crc="192f7e58" sha1="f9285638c65e08bed3a11e0ae44293743b4fb917" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="unbornon">
+		<description>The Unborn One</description>
+		<year>1991</year>
+		<publisher>Zenobi</publisher>
+		<part name="flop1" interface="floppy_3">
+			<dataarea name="flop" size="194816">
+				<rom name="unborn one, the (1991)(zenobi).dsk" size="194816" crc="70778ba8" sha1="05a8f137a7fba635a1a57226e6873ca081644b12" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+<!-- This is the dump in World of Spectrum -->
+	<software name="untoucha">
+		<description>The Untouchables</description>
+		<year>1989</year>
+		<publisher>Ocean</publisher>
+		<part name="flop1" interface="floppy_3">
+			<feature name="part_id" value="Side A"/>
+			<dataarea name="flop" size="128256">
+				<rom name="untouchables, the (1989)(ocean)(side a)[a].dsk" size="128256" crc="a87d3156" sha1="beab754fb66cee2ff5a398bbb601c9b745cd15ca" offset="0" />
+			</dataarea>
+		</part>
+		<part name="flop2" interface="floppy_3">
+			<feature name="part_id" value="Side B"/>
+			<dataarea name="flop" size="194816">
+				<rom name="untouchables, the (1989)(ocean)(side b)[a].dsk" size="194816" crc="ecdea7cd" sha1="13ae5b6aa2ac616ee1d678875d4190dbc10e4f46" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="untouchaa" cloneof="untoucha">
+		<description>The Untouchables (alt)</description>
+		<year>1989</year>
+		<publisher>Ocean</publisher>
+		<part name="flop1" interface="floppy_3">
+			<feature name="part_id" value="Side A"/>
+			<dataarea name="flop" size="128256">
+				<rom name="untouchables, the (1989)(ocean)(side a).dsk" size="128256" crc="6cbd1492" sha1="7ca0908dc9ae4102a020f2cadc589efe19ac56b5" offset="0" />
+			</dataarea>
+		</part>
+		<part name="flop2" interface="floppy_3">
+			<feature name="part_id" value="Side B"/>
+			<dataarea name="flop" size="194304">
+				<rom name="untouchables, the (1989)(ocean)(side b).dsk" size="194304" crc="58c33b4d" sha1="5a911a5743d39b1baba94838dc40510be67326c4" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="untouchab" cloneof="untoucha">
+		<description>The Untouchables (alt 2)</description>
+		<year>1989</year>
+		<publisher>Ocean</publisher>
+		<part name="flop1" interface="floppy_3">
+			<dataarea name="flop" size="194816">
+				<rom name="untouchables, the (1989)(ocean).dsk" size="194816" crc="bcafafe3" sha1="f219d9eac35b054f49f2be5dbfc7c4940bb66415" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="untouchac" cloneof="untoucha">
+		<description>The Untouchables (alt 3)</description>
+		<year>1989</year>
+		<publisher>Ocean</publisher>
+		<part name="flop1" interface="floppy_3">
+			<dataarea name="flop" size="389376">
+				<rom name="untouchables, the (1989)(ocean)[a].dsk" size="389376" crc="6d4df741" sha1="a1f9b963c7181d062a45434f88a977a7314c5580" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="urban">
+		<description>Urban</description>
+		<year>1991</year>
+		<publisher>Zenobi</publisher>
+		<part name="flop1" interface="floppy_3">
+			<dataarea name="flop" size="194816">
+				<rom name="urban (1991)(zenobi).dsk" size="194816" crc="d2c13bb6" sha1="961b3b7c51943998326074b9db3c9a12899d92ae" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="venom">
+		<description>Venom</description>
+		<year>1988</year>
+		<publisher>Zenobi</publisher>
+		<part name="flop1" interface="floppy_3">
+			<dataarea name="flop" size="194816">
+				<rom name="venom (1988)(zenobi)[re-release].dsk" size="194816" crc="4ef0d1ee" sha1="6623a8b2d8934afc6a1197594a97ae8330164ced" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="verybigc">
+		<description>The Very Big Cave Adventure</description>
+		<year>1986</year>
+		<publisher>Zenobi</publisher>
+		<part name="flop1" interface="floppy_3">
+			<dataarea name="flop" size="194816">
+				<rom name="very big cave adventure, the (1986)(zenobi)[re-release].dsk" size="194816" crc="57d0ccbb" sha1="5d35574bc5d8ccf621aa3b24691e739615840c6a" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="viajealc">
+		<description>Viaje al Centro de la Tierra</description>
+		<year>1989</year>
+		<publisher>Topo Soft</publisher>
+		<part name="flop1" interface="floppy_3">
+			<dataarea name="flop" size="136448">
+				<rom name="viaje al centro de la tierra (1989)(topo soft)(es).dsk" size="136448" crc="1654175f" sha1="a341c6182ac225fb471cfcec62f1a67e04ae7211" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="vigilantsp" cloneof="vigilant">
+		<description>Vigilante (Spain)</description>
+		<year>1989</year>
+		<publisher>Erbe</publisher>
+		<part name="flop1" interface="floppy_3">
+			<dataarea name="flop" size="127744">
+				<rom name="vigilante (1989)(erbe)(es)(en)[re-release].dsk" size="127744" crc="688b068b" sha1="e29674d3d8b797022334543bb9e48ce687a2738b" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<!-- May be the same edition as the IPF -->
+	<software name="vigilanta" cloneof="vigilant">
+		<description>Vigilante (alt)</description>
+		<year>1989</year>
+		<publisher>U.S. Gold</publisher>
+		<part name="flop1" interface="floppy_3">
+			<dataarea name="flop" size="39411">
+				<rom name="vigilante (1989)(u.s. gold).dsk" size="39411" crc="b7e1877a" sha1="6bc3c346155c7a26da005f71d04e0ac0c4c38688" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<!-- May be the same edition as the IPF -->
+	<software name="vigilantb" cloneof="vigilant">
+		<description>Vigilante (alt 2)</description>
+		<year>1989</year>
+		<publisher>U.S. Gold</publisher>
+		<part name="flop1" interface="floppy_3">
+			<dataarea name="flop" size="203520">
+				<rom name="vigilante (1989)(u.s. gold)[a].dsk" size="203520" crc="bf35d60a" sha1="dcd5b864eb359cd702fc30ee6f4c11aa4f401be0" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<!-- May be the same edition as the IPF -->
+	<software name="vigilantc" cloneof="vigilant">
+		<description>Vigilante (alt 3)</description>
+		<year>1989</year>
+		<publisher>U.S. Gold</publisher>
+		<part name="flop1" interface="floppy_3">
+			<dataarea name="flop" size="219136">
+				<rom name="vigilante (1989)(u.s. gold)[a2].dsk" size="219136" crc="90710ee7" sha1="ada31397d1f6dfb807857cf867fb44c19cec8c28" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="vindicat">
+		<description>The Vindicator</description>
+		<year>1988</year>
+		<publisher>Imagine</publisher>
+		<part name="flop1" interface="floppy_3">
+			<dataarea name="flop" size="221184">
+				<rom name="vindicator, the (1988)(imagine).dsk" size="221184" crc="c63202dc" sha1="b0bcc18baf2134ebbde4b1ac1c231ebaf8d5084b" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="vindicata" cloneof="vindicat">
+		<description>The Vindicator (alt)</description>
+		<year>1988</year>
+		<publisher>Imagine</publisher>
+		<part name="flop1" interface="floppy_3">
+			<dataarea name="flop" size="194816">
+				<rom name="vindicator, the (1988)(imagine)[a].dsk" size="194816" crc="7cddd8a0" sha1="194b8cf0dcca32553e3a880e20fea4d37454ef2e" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="vindicatb" cloneof="vindicat">
+		<description>The Vindicator (alt 2)</description>
+		<year>1988</year>
+		<publisher>Imagine</publisher>
+		<part name="flop1" interface="floppy_3">
+			<dataarea name="flop" size="194816">
+				<rom name="vindicator, the (1988)(imagine)[a2].dsk" size="194816" crc="f7318fed" sha1="b287dfd9651095aa4d7e93ce03061ea0fae80499" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="violvood">
+		<description>The Violator of Voodoo</description>
+		<year>1991</year>
+		<publisher>Zenobi</publisher>
+		<part name="flop1" interface="floppy_3">
+			<dataarea name="flop" size="194816">
+				<rom name="violator of voodoo, the (1991)(zenobi).dsk" size="194816" crc="1360096e" sha1="7d3d1d1b7e79a9b4f3fd3f8ec418303828283295" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="virus">
+		<description>Virus</description>
+		<year>1988</year>
+		<publisher>Firebird</publisher>
+		<part name="flop1" interface="floppy_3">
+			<dataarea name="flop" size="73216">
+				<rom name="virus (1988)(firebird).dsk" size="73216" crc="7fb23c60" sha1="5b8ffbd10aab44a224064f794432c229846ab627" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="vixena" cloneof="vixen">
+	<!-- May be the same edition as the IPF -->
+		<description>Vixen (alt)</description>
+		<year>1988</year>
+		<publisher>Martech Games</publisher>
+		<part name="flop1" interface="floppy_3">
+			<dataarea name="flop" size="194560">
+				<rom name="vixen (1988)(martech games).dsk" size="194560" crc="6f95265a" sha1="977c0e438119eb0bac2c23b78296ad21c1344e52" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="wecleman">
+		<description>WEC Le Mans</description>
+		<year>1988</year>
+		<publisher>Imagine</publisher>
+		<part name="flop1" interface="floppy_3">
+			<dataarea name="flop" size="194816">
+				<rom name="wec le mans (1988)(imagine).dsk" size="194816" crc="7e865452" sha1="d6e41f7a5c257858922b8b9d26131be93abb344d" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="weclemana" cloneof="wecleman">
+		<description>WEC Le Mans (alt)</description>
+		<year>1988</year>
+		<publisher>Imagine</publisher>
+		<part name="flop1" interface="floppy_3">
+			<dataarea name="flop" size="112640">
+				<rom name="wec le mans (1988)(imagine)[a].dsk" size="112640" crc="ee4cc288" sha1="2aaf533389d90dc4377396386c4abb6e07d4c7aa" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="weclemansp" cloneof="wecleman">
+		<description>WEC Le Mans (Spain)</description>
+		<year>1989</year>
+		<publisher>Erbe</publisher>
+		<part name="flop1" interface="floppy_3">
+			<dataarea name="flop" size="70400">
+				<rom name="wec le mans (1989)(erbe)(es)(en).dsk" size="70400" crc="51cff9a9" sha1="6c83a3f0d1865094925d932f907001f96cca6002" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="wwfwrest">
+		<description>WWF WrestleMania</description>
+		<year>1991</year>
+		<publisher>Erbe</publisher>
+		<part name="flop1" interface="floppy_3">
+			<feature name="part_id" value="Side A"/>
+			<dataarea name="flop" size="187904">
+				<rom name="wwf wrestlemania (1991)(erbe)(es)(en)(side a)[re-release].dsk" size="187904" crc="f36dd6e4" sha1="a18d7e2ca11bd9d1e7347097fd48fec3d0cf192e" offset="0" />
+			</dataarea>
+		</part>
+		<part name="flop2" interface="floppy_3">
+			<feature name="part_id" value="Side B"/>
+			<dataarea name="flop" size="217088">
+				<rom name="wwf wrestlemania (1991)(erbe)(es)(en)(side b)[re-release].dsk" size="217088" crc="c114cf9c" sha1="bac503cbf750029b14de04aff5af8699367b596b" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="wanderer">
+		<description>Wanderer</description>
+		<year>1989</year>
+		<publisher>MCM</publisher>
+		<part name="flop1" interface="floppy_3">
+			<dataarea name="flop" size="85760">
+				<rom name="wanderer (1989)(mcm)(es)(en)[re-release].dsk" size="85760" crc="79b50978" sha1="3d3101f5d9ea075b837fe68caff99eb0947c811a" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="wander3d">
+		<description>Wanderer 3D</description>
+		<year>1989</year>
+		<publisher>Elite Systems</publisher>
+		<part name="flop1" interface="floppy_3">
+			<dataarea name="flop" size="214784">
+				<rom name="wanderer 3d (1989)(elite systems).dsk" size="214784" crc="4c413eed" sha1="0b9044bc343f198521e09ec8b09c95799d4f9209" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="warinmid">
+		<description>War in Middle Earth</description>
+		<year>1989</year>
+		<publisher>Dro Soft</publisher>
+		<part name="flop1" interface="floppy_3">
+			<dataarea name="flop" size="194816">
+				<rom name="war in middle earth (1989)(dro soft)(es)[re-release].dsk" size="194816" crc="c79caf16" sha1="11fd036f842417aeb5f4c90fd335f46151a9bee4" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<!-- May be the same edition as the IPF -->
+	<software name="warmidlea" cloneof="warmidle">
+		<description>War in Middle Earth</description>
+		<year>1989</year>
+		<publisher>Melbourne House</publisher>
+		<part name="flop1" interface="floppy_3">
+			<feature name="part_id" value="Side A"/>
+			<dataarea name="flop" size="175872">
+				<rom name="war in middle earth (1989)(melbourne house)(side a).dsk" size="175872" crc="68822747" sha1="1e9af74431f6237596738f9a3bc52e58db122984" offset="0" />
+			</dataarea>
+		</part>
+		<part name="flop2" interface="floppy_3">
+			<feature name="part_id" value="Side B"/>
+			<dataarea name="flop" size="194816">
+				<rom name="war in middle earth (1989)(melbourne house)(side b).dsk" size="194816" crc="c369b306" sha1="f4b3d2238729333dde5e0e0c903e7cb4d2c3d351" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="wellofzo">
+		<description>The Well of Zol</description>
+		<year>1994</year>
+		<publisher>Zenobi</publisher>
+		<part name="flop1" interface="floppy_3">
+			<dataarea name="flop" size="194816">
+				<rom name="well of zol, the (1994)(zenobi).dsk" size="194816" crc="53239936" sha1="a7dd128057ee8dfba7718e7c691413dcc0f7fb3d" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="welltris">
+		<description>Welltris</description>
+		<year>1991</year>
+		<publisher>Erbe</publisher>
+		<part name="flop1" interface="floppy_3">
+			<dataarea name="flop" size="78080">
+				<rom name="welltris (1991)(erbe)(es)(en)[re-release].dsk" size="78080" crc="e2c07cf0" sha1="fb270ca2c53498bd04d5e4ddc8a806c51f887318" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<!-- May be the same edition as the IPF -->
+	<software name="welltrisa" cloneof="welltris">
+		<description>Welltris (alt)</description>
+		<year>1991</year>
+		<publisher>Infogrames</publisher>
+		<part name="flop1" interface="floppy_3">
+			<dataarea name="flop" size="194816">
+				<rom name="welltris (1991)(infogrames)(fr)(en).dsk" size="194816" crc="88c856c0" sha1="5d721ce272977bfe713b6f046f3bab49dd24e9a9" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="wtss">
+		<description>Where Time Stood Still</description>
+		<year>1988</year>
+		<publisher>Ocean</publisher>
+		<part name="flop1" interface="floppy_3">
+			<dataarea name="flop" size="155648">
+				<rom name="where time stood still (1988)(ocean)[aka land that time forgot, the][aka tibet].dsk" size="155648" crc="b14f1c51" sha1="6bd26b6364493679e8c956cef34ebcdc6db13894" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="whitefea">
+		<description>The White Feather Cloak</description>
+		<year>1992</year>
+		<publisher>Zenobi</publisher>
+		<part name="flop1" interface="floppy_3">
+			<dataarea name="flop" size="194816">
+				<rom name="white feather cloak, the (1992)(zenobi)[re-release].dsk" size="194816" crc="b9cba097" sha1="24a74a05414d5565d3ecdae3badb8d31fd980696" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="wintol88">
+		<description>Winter Olympiad '88</description>
+		<year>1988</year>
+		<publisher>Tynesoft</publisher>
+		<part name="flop1" interface="floppy_3">
+			<feature name="part_id" value="Side A"/>
+			<dataarea name="flop" size="194816">
+				<rom name="winter olympiad '88 (1988)(tynesoft)(side a).dsk" size="194816" crc="502652dc" sha1="8afe3a599d1b877cd2a6bfed1adfc7aaa3c69a76" offset="0" />
+			</dataarea>
+		</part>
+		<part name="flop2" interface="floppy_3">
+			<feature name="part_id" value="Side B"/>
+			<dataarea name="flop" size="194816">
+				<rom name="winter olympiad '88 (1988)(tynesoft)(side b).dsk" size="194816" crc="0b1cff37" sha1="a33690ad993c8fad983c49d866b2b3529f85582b" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="wizardqu">
+		<description>Wizard Quest</description>
+		<year>1992</year>
+		<publisher>Zenobi</publisher>
+		<part name="flop1" interface="floppy_3">
+			<dataarea name="flop" size="194816">
+				<rom name="wizard quest (1992)(zenobi).dsk" size="194816" crc="68a39e6b" sha1="dfbd2ff0cad92e093535cb2bf7698e14fbc46803" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="wizardoz">
+		<description>The Wizard of Oz</description>
+		<year>1995</year>
+		<publisher>Zenobi</publisher>
+		<part name="flop1" interface="floppy_3">
+			<dataarea name="flop" size="194816">
+				<rom name="wizard of oz, the (1995)(zenobi).dsk" size="194816" crc="49211c28" sha1="5e910a68ca1f4e36e75a2cb598f1ff37037a01e3" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<!-- May be the same edition as the IPF -->
+	<software name="wcboxmana" cloneof="wcboxman">
+		<description>World Championship Boxing Manager (alt)</description>
+		<year>1990</year>
+		<publisher>Goliath Games</publisher>
+		<part name="flop1" interface="floppy_3">
+			<dataarea name="flop" size="194816">
+				<rom name="world championship boxing manager (1990)(goliath games).dsk" size="194816" crc="d2a8e969" sha1="5f7446c07e17c9110a59ab65a45f3723311b3fb7" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="wrldclru">
+		<description>World Class Rugby</description>
+		<year>1991</year>
+		<publisher>Audiogenic</publisher>
+		<part name="flop1" interface="floppy_3">
+			<dataarea name="flop" size="194816">
+				<rom name="world class rugby (1991)(audiogenic)[aka sports action rugby].dsk" size="194816" crc="b872dd44" sha1="2955b8cc19dc423caa56c52f1d87201379bff23e" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="worldcri">
+		<description>World Cricket (tape master disk)</description>
+		<year>1991</year>
+		<publisher>Zeppelin Games</publisher>
+		<part name="flop1" interface="floppy_3">
+			<feature name="part_id" value="Side A"/>
+			<dataarea name="flop" size="194816">
+				<rom name="world cricket (1991)(zeppelin games)(side a)[tape master disk].dsk" size="194816" crc="9eeb2c31" sha1="7ab98010ac3374019abfd67ab6e21f46045e25e1" offset="0" />
+			</dataarea>
+		</part>
+		<part name="flop2" interface="floppy_3">
+			<feature name="part_id" value="Side B"/>
+	<!-- Side B image shared with other master disks from Zeppelin Games. Verified at World of Spectrum. -->
+			<dataarea name="flop" size="256">
+				<rom name="championship run (1991)(zeppelin games)(side b)[master disk backup][re-release].dsk" size="256" crc="56947af2" sha1="40428c770d847a0fd1fd005b6cf1d03a34672d98" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="worldrug">
+		<description>World Rugby (tape master disk)</description>
+		<year>1993</year>
+		<publisher>Zeppelin Games</publisher>
+		<part name="flop1" interface="floppy_3">
+			<feature name="part_id" value="Side A"/>
+			<dataarea name="flop" size="194816">
+				<rom name="world rugby (1993)(zeppelin games)(side a)[tape master disk].dsk" size="194816" crc="02431985" sha1="c8dc139cf45decf7a562a4ded04e50c32601c3ec" offset="0" />
+			</dataarea>
+		</part>
+		<part name="flop2" interface="floppy_3">
+			<feature name="part_id" value="Side B"/>
+			<dataarea name="flop" size="194816">
+				<rom name="world rugby (1993)(zeppelin games)(side b)[tape master disk].dsk" size="194816" crc="700985aa" sha1="05a3d5d98a06eb0c5f7f7b7208c6ac0a670f777f" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="worldsoc">
+		<description>World Soccer (tape master disk)</description>
+		<year>1990</year>
+		<publisher>Zeppelin Games</publisher>
+		<part name="flop1" interface="floppy_3">
+			<feature name="part_id" value="Side A"/>
+			<dataarea name="flop" size="194816">
+				<rom name="world soccer (1990)(zeppelin games)(side a)[tape master disk].dsk" size="194816" crc="acf9aa7e" sha1="2efff08d88d301db7b0b531124a7ce50095f3773" offset="0" />
+			</dataarea>
+		</part>
+		<part name="flop2" interface="floppy_3">
+			<feature name="part_id" value="Side B"/>
+			<dataarea name="flop" size="194816">
+				<rom name="world soccer (1990)(zeppelin games)(side b)[tape master disk].dsk" size="194816" crc="aea985b6" sha1="3a91c13b3b7885be96413dc42821eab8044bff8d" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="wresupst">
+		<description>Wrestling Superstars</description>
+		<year>1993</year>
+		<publisher>Code Masters</publisher>
+		<part name="flop1" interface="floppy_3">
+			<dataarea name="flop" size="194816">
+				<rom name="wrestling superstars (1993)(code masters).dsk" size="194816" crc="208f3bae" sha1="ebc7184c17bb78ec56f9abc0103e88cd83c4a536" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="wresupsta" cloneof="wresupst">
+		<description>Wrestling Superstars (alt)</description>
+		<year>1993</year>
+		<publisher>Code Masters</publisher>
+		<part name="flop1" interface="floppy_3">
+			<dataarea name="flop" size="194816">
+				<rom name="wrestling superstars (1993)(code masters)[a].dsk" size="194816" crc="2905ac90" sha1="1e52b85bff098c25284e1c4ea5c78ed3f8118c46" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="wresupstb" cloneof="wresupst">
+		<description>Wrestling Superstars (alt 2)</description>
+		<year>1993</year>
+		<publisher>Code Masters</publisher>
+		<part name="flop1" interface="floppy_3">
+			<dataarea name="flop" size="194816">
+				<rom name="wrestling superstars (1993)(code masters)[a2].dsk" size="194816" crc="a1a893b7" sha1="b804d2542edf2b10792fb7f4d42c69f02291a442" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<!-- May be the same edition as the IPF -->
+	<software name="xouta" cloneof="xout">
+		<description>X-Out (alt)</description>
+		<year>1990</year>
+		<publisher>Rainbow Arts</publisher>
+		<part name="flop1" interface="floppy_3">
+			<dataarea name="flop" size="255232">
+				<rom name="x-out (1990)(rainbow arts).dsk" size="255232" crc="41e419a2" sha1="61d73d0116e33fcad00fe44548a3af79892602ad" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="xoutsp" cloneof="xout">
+		<description>X-Out (Spain)</description>
+		<year>1990</year>
+		<publisher>Erbe</publisher>
+		<part name="flop1" interface="floppy_3">
+			<feature name="part_id" value="Side A"/>
+			<dataarea name="flop" size="53760">
+				<rom name="x-out (1990)(erbe)(es)(en)(side a)[re-release].dsk" size="53760" crc="0c5f3eb3" sha1="de382a5a0d2615e01d2736bddaa7c162fed1d6fb" offset="0" />
+			</dataarea>
+		</part>
+		<part name="flop2" interface="floppy_3">
+			<feature name="part_id" value="Side B"/>
+			<!-- Game data -->
+			<dataarea name="flop" size="194816">
+				<rom name="x-out (1990)(erbe)(es)(en)(side b)[re-release].dsk" size="194816" crc="37450ff0" sha1="1fe41fc4ce85f112c7820e2aa8ae19ea14af2f87" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<!-- May be the same edition as the IPF -->
+	<software name="xenona" cloneof="xenon">
+		<description>Xenon (alt)</description>
+		<year>1988</year>
+		<publisher>Melbourne House</publisher>
+		<part name="flop1" interface="floppy_3">
+			<dataarea name="flop" size="194816">
+				<rom name="xenon (1988)(melbourne house).dsk" size="194816" crc="3c91a046" sha1="d01bd31987d66a6886163a7e9caa4f2c9fd2e083" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="xenophob">
+		<description>Xenophobe</description>
+		<year>1989</year>
+		<publisher>Micro Style</publisher>
+		<part name="flop1" interface="floppy_3">
+			<feature name="part_id" value="Side A"/>
+			<dataarea name="flop" size="181248">
+				<rom name="xenophobe (1989)(micro style)(side a).dsk" size="181248" crc="cab64cfd" sha1="2a7c42e5f7d57eb98fc8a2c988a43637dc3f9c30" offset="0" />
+			</dataarea>
+		</part>
+		<part name="flop2" interface="floppy_3">
+			<feature name="part_id" value="Side B"/>
+			<!-- Side seems to be empty but it's a good dump of it. -->
+			<dataarea name="flop" size="194816">
+				<rom name="xenophobe (1989)(micro style)(side b).dsk" size="194816" crc="15368607" sha1="6c61f0dbab63b59f5328a010f10681a081fe660d" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<!-- This is the dump at World of Spectrum -->
+	<software name="xenophoba" cloneof="xenophob">
+		<description>Xenophobe (alt)</description>
+		<year>1989</year>
+		<publisher>Micro Style</publisher>
+		<part name="flop1" interface="floppy_3">
+			<dataarea name="flop" size="181248">
+				<rom name="xenophobe (1989)(micro style).dsk" size="181248" crc="4f34e9f2" sha1="4fb73fb61a62b8a82c32c6807ef716c6c6ae1f54" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<!-- May be the same edition as the IPF -->
+	<software name="xybotsa" cloneof="xybots">
+		<description>Xybots (alt)</description>
+		<year>1989</year>
+		<publisher>Domark</publisher>
+		<part name="flop1" interface="floppy_3">
+			<dataarea name="flop" size="174848">
+				<rom name="xybots (1989)(domark).dsk" size="174848" crc="a1f722cc" sha1="8ecd129b8ef8cc53f3ee20753f6471c6a29a19d9" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="xybotssp" cloneof="xybots">
+		<description>Xybots (Spain)</description>
+		<year>1989</year>
+		<publisher>Erbe</publisher>
+		<part name="flop1" interface="floppy_3">
+			<dataarea name="flop" size="131328">
+				<rom name="xybots (1989)(erbe)(es)(en)[re-release].dsk" size="131328" crc="f06c87e4" sha1="7ee414b540d5cce2e13f90e1d5aa4c860ff5162e" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="zenquest">
+		<description>Zen Quest</description>
+		<year>1995</year>
+		<publisher>Zenobi</publisher>
+		<part name="flop1" interface="floppy_3">
+			<dataarea name="flop" size="194816">
+				<rom name="zen quest (1995)(zenobi).dsk" size="194816" crc="eafce910" sha1="cc5adca5233706f5480fe1bfc10f12cacd910a10" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+<!-- Unclear why TOSEC labels Side B as "(master disk)", it's the regular dump available at World of Spectrum. -->
+	<software name="zipizape">
+		<description>Zipi y Zape</description>
+		<year>1989</year>
+		<publisher>Dro Soft</publisher>
+		<part name="flop1" interface="floppy_3">
+			<feature name="part_id" value="Side A"/>
+			<dataarea name="flop" size="194816">
+				<rom name="zipi y zape (1989)(dro soft)(es)(side a).dsk" size="194816" crc="c5de7d52" sha1="462c9dc62a14882c8d1e43c49c09d6aff55eaa25" offset="0" />
+			</dataarea>
+		</part>
+		<part name="flop2" interface="floppy_3">
+			<feature name="part_id" value="Side B"/>
+			<dataarea name="flop" size="194816">
+				<rom name="zipi y zape (1989)(dro soft)(es)(side b)[master disk].dsk" size="194816" crc="6a86c00e" sha1="0e19d7c080c4579b387eae7e279f1a82bd286bb8" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="zipizapea" cloneof="zipizape">
+		<description>Zipi y Zape (alt)</description>
+		<year>1989</year>
+		<publisher>Dro Soft</publisher>
+		<part name="flop1" interface="floppy_3">
+			<dataarea name="flop" size="194816">
+				<rom name="zipi y zape (1989)(dro soft)(es).dsk" size="194816" crc="b962d47d" sha1="1bf0c1c4a705be0c7fbd4027718eca7e11d1a3ff" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="zzzz">
+		<description>Zzzz</description>
+		<year>1986</year>
+		<publisher>Zenobi</publisher>
+		<part name="flop1" interface="floppy_3">
+			<dataarea name="flop" size="194816">
+				<rom name="zzzz (1986)(zenobi)[re-release].dsk" size="194816" crc="87122e5a" sha1="455c344a7b0ffce91dbf18c33d0e696fd569c7c1" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Compilations - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+<!-- Erroneously identified as a compilation in TOSEC -->
+	<software name="emilbut2">
+		<description>Emilio Butragueno 2</description>
+		<year>1989</year>
+		<publisher>Erbe Software - Ocean</publisher>
+		<part name="flop1" interface="floppy_3">
+			<dataarea name="flop" size="194816">
+				<rom name="emilio butragueno 2 (1989)(erbe software - ocean)(es)[aka emilio butragueno futbol 2].dsk" size="194816" crc="0ac224b8" sha1="7d3df2ca6721a3d5bd225ae64c66faf6da709bb0" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Magazines - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="outle023">
+		<description>Outlet issue 023</description>
+		<year>1989</year>
+		<publisher>Outlet</publisher>
+		<part name="flop1" interface="floppy_3">
+			<dataarea name="flop" size="216195">
+				<rom name="outlet issue 023 (1989)(outlet).dsk" size="216195" crc="8f4208a4" sha1="f54637374a61ff327f3d2b4df0c5f45da125081b" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Magazines - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="outle024">
+		<description>Outlet issue 024</description>
+		<year>1989</year>
+		<publisher>Outlet</publisher>
+		<part name="flop1" interface="floppy_3">
+			<dataarea name="flop" size="215296">
+				<rom name="outlet issue 024 (1989)(outlet).dsk" size="215296" crc="ac70f43f" sha1="b0a57deb37ae0d38c49da016d47380e0df2d93c9" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Magazines - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="outle025">
+		<description>Outlet issue 025</description>
+		<year>1989</year>
+		<publisher>Outlet</publisher>
+		<part name="flop1" interface="floppy_3">
+			<dataarea name="flop" size="215296">
+				<rom name="outlet issue 025 (1989)(outlet).dsk" size="215296" crc="759d28cd" sha1="9b3490cab42971ec88e4cbcea5a79806c830f998" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Magazines - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="outle026">
+		<description>Outlet issue 026</description>
+		<year>1989</year>
+		<publisher>Outlet</publisher>
+		<part name="flop1" interface="floppy_3">
+			<dataarea name="flop" size="215296">
+				<rom name="outlet issue 026 (1989)(outlet).dsk" size="215296" crc="4ea1efac" sha1="53d7402fa8c6fc52a5d615aa438658f6cf5d4826" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Magazines - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="outle027">
+		<description>Outlet issue 027</description>
+		<year>1989</year>
+		<publisher>Outlet</publisher>
+		<part name="flop1" interface="floppy_3">
+			<dataarea name="flop" size="215296">
+				<rom name="outlet issue 027 (1989)(outlet).dsk" size="215296" crc="1a59232f" sha1="565f0bc985f3c2fda6f05a5b3011e1925b2f11df" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Magazines - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="outle028">
+		<description>Outlet issue 028</description>
+		<year>1989</year>
+		<publisher>Outlet</publisher>
+		<part name="flop1" interface="floppy_3">
+			<feature name="part_id" value="Side A"/>
+			<dataarea name="flop" size="215296">
+				<rom name="outlet issue 028 (1989)(outlet).dsk" size="215296" crc="2be73d7b" sha1="499cc8bef5494ebf7afac9d1dfde37e49209bd84" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Magazines - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="outle029">
+		<description>Outlet issue 029</description>
+		<year>1990</year>
+		<publisher>Outlet</publisher>
+		<part name="flop1" interface="floppy_3">
+			<feature name="part_id" value="Side A"/>
+			<dataarea name="flop" size="226048">
+				<rom name="outlet issue 029 (1990)(outlet).dsk" size="226048" crc="96509834" sha1="53e5aaebd4299f1b54290f6c1367a8105a6db85e" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Magazines - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="outle030">
+		<description>Outlet issue 030</description>
+		<year>1990</year>
+		<publisher>Outlet</publisher>
+		<part name="flop1" interface="floppy_3">
+			<feature name="part_id" value="Side A"/>
+			<dataarea name="flop" size="226987">
+				<rom name="outlet issue 030 (1990)(outlet).dsk" size="226987" crc="78ac2b53" sha1="65b1e939f71af926528483ce1e961aa7e4a312cf" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Magazines - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="outle031">
+		<description>Outlet issue 031</description>
+		<year>1990</year>
+		<publisher>Outlet</publisher>
+		<part name="flop1" interface="floppy_3">
+			<feature name="part_id" value="Side A"/>
+			<dataarea name="flop" size="215296">
+				<rom name="outlet issue 031 (1990)(outlet).dsk" size="215296" crc="c8617655" sha1="9b33fa287b0ef19c0b93e34c89eaa46757a79510" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Magazines - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="outle032">
+		<description>Outlet issue 032</description>
+		<year>1990</year>
+		<publisher>Outlet</publisher>
+		<part name="flop1" interface="floppy_3">
+			<feature name="part_id" value="Side A"/>
+			<dataarea name="flop" size="215296">
+				<rom name="outlet issue 032 (1990)(outlet).dsk" size="215296" crc="73d6b349" sha1="a968e70e0f01f91293f28bfa5153c48b1f807ba8" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Magazines - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="outle033">
+		<description>Outlet issue 033</description>
+		<year>1990</year>
+		<publisher>Outlet</publisher>
+		<part name="flop1" interface="floppy_3">
+			<feature name="part_id" value="Side A"/>
+			<dataarea name="flop" size="226048">
+				<rom name="outlet issue 033 (1990)(outlet).dsk" size="226048" crc="d581a48c" sha1="146f34bb6ef486ef78fe0fa3d45fdba12b77b2de" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Magazines - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="outle034">
+		<description>Outlet issue 034</description>
+		<year>1990</year>
+		<publisher>Outlet</publisher>
+		<part name="flop1" interface="floppy_3">
+			<feature name="part_id" value="Side A"/>
+			<dataarea name="flop" size="215296">
+				<rom name="outlet issue 034 (1990)(outlet)(side a).dsk" size="215296" crc="7478a2ec" sha1="936bf5ffa16d6a5f1e725e84e7befe43c04bdc44" offset="0" />
+			</dataarea>
+		</part>
+		<part name="flop2" interface="floppy_3">
+			<feature name="part_id" value="Side B"/>
+			<dataarea name="flop" size="215296">
+				<rom name="outlet issue 034 (1990)(outlet)(side b).dsk" size="215296" crc="23b2d907" sha1="91113badec95b211eabd5373ae8480e6bb679875" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Magazines - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="outle035">
+		<description>Outlet issue 035</description>
+		<year>1990</year>
+		<publisher>Outlet</publisher>
+		<part name="flop1" interface="floppy_3">
+			<feature name="part_id" value="Side A"/>
+			<dataarea name="flop" size="226048">
+				<rom name="outlet issue 035 (1990)(outlet)(side a).dsk" size="226048" crc="d2773333" sha1="2c4afe1b5ca2b8a447ef6a36852766abe37fa9b8" offset="0" />
+			</dataarea>
+		</part>
+		<part name="flop2" interface="floppy_3">
+			<feature name="part_id" value="Side B"/>
+			<dataarea name="flop" size="226048">
+				<rom name="outlet issue 035 (1990)(outlet)(side b).dsk" size="226048" crc="cca00458" sha1="64274c235096f06f7892c5e00d92dd9a77f17298" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Magazines - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="outle036">
+		<description>Outlet issue 036</description>
+		<year>1990</year>
+		<publisher>Outlet</publisher>
+		<part name="flop1" interface="floppy_3">
+			<feature name="part_id" value="Side A"/>
+			<dataarea name="flop" size="226048">
+				<rom name="outlet issue 036 (1990)(outlet)(side a).dsk" size="226048" crc="2beb6f89" sha1="5ef8acdf3f5a1c7d407ec4e1786eef3b611586be" offset="0" />
+			</dataarea>
+		</part>
+		<part name="flop2" interface="floppy_3">
+			<feature name="part_id" value="Side B"/>
+			<dataarea name="flop" size="226048">
+				<rom name="outlet issue 036 (1990)(outlet)(side b).dsk" size="226048" crc="8d09857b" sha1="5b938838fc37ac6e9f39906f240d990795613b3b" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Magazines - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="outle037">
+		<description>Outlet issue 037</description>
+		<year>1990</year>
+		<publisher>Outlet</publisher>
+		<part name="flop1" interface="floppy_3">
+			<feature name="part_id" value="Side A"/>
+			<dataarea name="flop" size="226048">
+				<rom name="outlet issue 037 (1990)(outlet)(side a).dsk" size="226048" crc="a611d7f0" sha1="13c5f63ff5cd2aff096b8544668a2139b3cb9db3" offset="0" />
+			</dataarea>
+		</part>
+		<part name="flop2" interface="floppy_3">
+			<feature name="part_id" value="Side B"/>
+			<dataarea name="flop" size="226048">
+				<rom name="outlet issue 037 (1990)(outlet)(side b).dsk" size="226048" crc="b689fdd9" sha1="b0d60d4045e7ec950453d588b3098e843588721e" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Magazines - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="outle038">
+		<description>Outlet issue 038</description>
+		<year>1990</year>
+		<publisher>Outlet</publisher>
+		<part name="flop1" interface="floppy_3">
+			<feature name="part_id" value="Side A"/>
+			<dataarea name="flop" size="226048">
+				<rom name="outlet issue 038 (1990)(outlet)(side a).dsk" size="226048" crc="33ac27ee" sha1="ca4817821c0e988aefb347f559d0c15a55bbeecc" offset="0" />
+			</dataarea>
+		</part>
+		<part name="flop2" interface="floppy_3">
+			<feature name="part_id" value="Side B"/>
+			<dataarea name="flop" size="226048">
+				<rom name="outlet issue 038 (1990)(outlet)(side b).dsk" size="226048" crc="86ab9fa0" sha1="466228c2c0558b5c730bc2f1256344c92c486064" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Magazines - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="outle039">
+		<description>Outlet issue 039</description>
+		<year>1990</year>
+		<publisher>Outlet</publisher>
+		<part name="flop1" interface="floppy_3">
+			<feature name="part_id" value="Side A"/>
+			<dataarea name="flop" size="226048">
+				<rom name="outlet issue 039 (1990)(outlet)(side a).dsk" size="226048" crc="b33cfc27" sha1="3f70b89c4eeff58d020bc1543545d491d03f2faf" offset="0" />
+			</dataarea>
+		</part>
+		<part name="flop2" interface="floppy_3">
+			<feature name="part_id" value="Side B"/>
+			<dataarea name="flop" size="226048">
+				<rom name="outlet issue 039 (1990)(outlet)(side b).dsk" size="226048" crc="ac4a55bf" sha1="de66fdf471bf6b7a6db9ac5a45034bd609e5d4b4" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Magazines - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="outle040">
+		<description>Outlet issue 040</description>
+		<year>1990</year>
+		<publisher>Outlet</publisher>
+		<part name="flop1" interface="floppy_3">
+			<feature name="part_id" value="Side A"/>
+			<dataarea name="flop" size="226048">
+				<rom name="outlet issue 040 (1990)(outlet)(side a).dsk" size="226048" crc="064caff0" sha1="5e5a91ec40b62a1efdb09ea5b13a9eedea3c0e3a" offset="0" />
+			</dataarea>
+		</part>
+		<part name="flop2" interface="floppy_3">
+			<feature name="part_id" value="Side B"/>
+			<dataarea name="flop" size="226048">
+				<rom name="outlet issue 040 (1990)(outlet)(side b).dsk" size="226048" crc="70ad9d52" sha1="55ebd26a35257456ab2bc1060085219f19f3cd24" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Magazines - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="outle041">
+		<description>Outlet issue 041</description>
+		<year>1991</year>
+		<publisher>Outlet</publisher>
+		<part name="flop1" interface="floppy_3">
+			<feature name="part_id" value="Side A"/>
+			<dataarea name="flop" size="226048">
+				<rom name="outlet issue 041 (1991)(outlet)(side a).dsk" size="226048" crc="2f29d082" sha1="7af01f71d39be3d5d5d4218f341f45fffb8785b0" offset="0" />
+			</dataarea>
+		</part>
+		<part name="flop2" interface="floppy_3">
+			<feature name="part_id" value="Side B"/>
+			<dataarea name="flop" size="226048">
+				<rom name="outlet issue 041 (1991)(outlet)(side b).dsk" size="226048" crc="557aa714" sha1="130b1e56ab6514f2510438409589452789d1a388" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Magazines - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="outle042">
+		<description>Outlet issue 042</description>
+		<year>1991</year>
+		<publisher>Outlet</publisher>
+		<part name="flop1" interface="floppy_3">
+			<feature name="part_id" value="Side A"/>
+			<dataarea name="flop" size="226048">
+				<rom name="outlet issue 042 (1991)(outlet)(side a).dsk" size="226048" crc="9960321e" sha1="c7762c92f3e42e610184eddbbb38f0546dc14a79" offset="0" />
+			</dataarea>
+		</part>
+		<part name="flop2" interface="floppy_3">
+			<feature name="part_id" value="Side B"/>
+			<dataarea name="flop" size="226048">
+				<rom name="outlet issue 042 (1991)(outlet)(side b).dsk" size="226048" crc="348484ba" sha1="2fec990437274d452926b8a8f1225beccd572f9c" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Magazines - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="outle043">
+		<description>Outlet issue 043</description>
+		<year>1991</year>
+		<publisher>Outlet</publisher>
+		<part name="flop1" interface="floppy_3">
+			<feature name="part_id" value="Side A"/>
+			<dataarea name="flop" size="226048">
+				<rom name="outlet issue 043 (1991)(outlet)(side a).dsk" size="226048" crc="39a79367" sha1="41fa0297c379f4dd33fcfab5418dcd1aab995058" offset="0" />
+			</dataarea>
+		</part>
+		<part name="flop2" interface="floppy_3">
+			<feature name="part_id" value="Side B"/>
+			<dataarea name="flop" size="226048">
+				<rom name="outlet issue 043 (1991)(outlet)(side b).dsk" size="226048" crc="ad442f10" sha1="9cd6fd6ae5b2c490b3a7801ec2a889397f896ccc" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Magazines - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="outle044">
+		<description>Outlet issue 044</description>
+		<year>1991</year>
+		<publisher>Outlet</publisher>
+		<part name="flop1" interface="floppy_3">
+			<feature name="part_id" value="Side A"/>
+			<dataarea name="flop" size="226048">
+				<rom name="outlet issue 044 (1991)(outlet)(side a).dsk" size="226048" crc="47eb9929" sha1="fcd9f604ec274905a81a1258e58c32bb088566f3" offset="0" />
+			</dataarea>
+		</part>
+		<part name="flop2" interface="floppy_3">
+			<feature name="part_id" value="Side B"/>
+			<dataarea name="flop" size="226048">
+				<rom name="outlet issue 044 (1991)(outlet)(side b).dsk" size="226048" crc="bbedeac6" sha1="0b6c76ad7d5c833c9c9b7a769d55978111bf1063" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Magazines - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="outle045">
+		<description>Outlet issue 045</description>
+		<year>1991</year>
+		<publisher>Outlet</publisher>
+		<part name="flop1" interface="floppy_3">
+			<feature name="part_id" value="Side A"/>
+			<dataarea name="flop" size="226048">
+				<rom name="outlet issue 045 (1991)(outlet)(side a).dsk" size="226048" crc="389979ae" sha1="aacbff56da6ea5e9d85e453e03d43ac469eec03a" offset="0" />
+			</dataarea>
+		</part>
+		<part name="flop2" interface="floppy_3">
+			<feature name="part_id" value="Side B"/>
+			<dataarea name="flop" size="226048">
+				<rom name="outlet issue 045 (1991)(outlet)(side b).dsk" size="226048" crc="ef99b650" sha1="4ef0ee1d56d48ec72e8f2d8075a452aabb689cf5" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Magazines - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="outle046">
+		<description>Outlet issue 046</description>
+		<year>1991</year>
+		<publisher>Outlet</publisher>
+		<part name="flop1" interface="floppy_3">
+			<feature name="part_id" value="Side A"/>
+			<dataarea name="flop" size="226048">
+				<rom name="outlet issue 046 (1991)(outlet)(side a).dsk" size="226048" crc="2afb91ef" sha1="39b029151e7dbef71413c9fe058fb133f4ac90a1" offset="0" />
+			</dataarea>
+		</part>
+		<part name="flop2" interface="floppy_3">
+			<feature name="part_id" value="Side B"/>
+			<dataarea name="flop" size="226048">
+				<rom name="outlet issue 046 (1991)(outlet)(side b).dsk" size="226048" crc="f6eec609" sha1="2d7f2a7cd6ae374bfaf31ffa28b87220e607d07e" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Magazines - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="outle047">
+		<description>Outlet issue 047</description>
+		<year>1991</year>
+		<publisher>Outlet</publisher>
+		<part name="flop1" interface="floppy_3">
+			<feature name="part_id" value="Side A"/>
+			<dataarea name="flop" size="226048">
+				<rom name="outlet issue 047 (1991)(outlet)(side a).dsk" size="226048" crc="63efa2fc" sha1="3c506a9713e3e631e3fc823e02552e2bf53254bb" offset="0" />
+			</dataarea>
+		</part>
+		<part name="flop2" interface="floppy_3">
+			<feature name="part_id" value="Side B"/>
+			<dataarea name="flop" size="226048">
+				<rom name="outlet issue 047 (1991)(outlet)(side b).dsk" size="226048" crc="bd48c4f2" sha1="3f67f96f92d69c10ac360c45dcfbeb512e578cfb" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Magazines - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="outle048">
+		<description>Outlet issue 048</description>
+		<year>1991</year>
+		<publisher>Outlet</publisher>
+		<part name="flop1" interface="floppy_3">
+			<feature name="part_id" value="Side A"/>
+			<dataarea name="flop" size="226048">
+				<rom name="outlet issue 048 (1991)(outlet)(side a).dsk" size="226048" crc="8f316696" sha1="fd1342dc497c2c7ae23b59ad92cbdc21150d1721" offset="0" />
+			</dataarea>
+		</part>
+		<part name="flop2" interface="floppy_3">
+			<feature name="part_id" value="Side B"/>
+			<dataarea name="flop" size="226048">
+				<rom name="outlet issue 048 (1991)(outlet)(side b).dsk" size="226048" crc="cda45114" sha1="79e7e3aa3dfecfd1e37332d492257c185a50c36a" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Magazines - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="outle049">
+		<description>Outlet issue 049</description>
+		<year>1991</year>
+		<publisher>Outlet</publisher>
+		<part name="flop1" interface="floppy_3">
+			<feature name="part_id" value="Side A"/>
+			<dataarea name="flop" size="226048">
+				<rom name="outlet issue 049 (1991)(outlet)(side a).dsk" size="226048" crc="8114e28f" sha1="12ce75a67ee9ff9e1ef26a31456c09a6467ec527" offset="0" />
+			</dataarea>
+		</part>
+		<part name="flop2" interface="floppy_3">
+			<feature name="part_id" value="Side B"/>
+			<dataarea name="flop" size="226048">
+				<rom name="outlet issue 049 (1991)(outlet)(side b).dsk" size="226048" crc="da2e4308" sha1="32c1e1cf048d24ad0ce22a598f93a9031fd221fd" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Magazines - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="outle050">
+		<description>Outlet issue 050</description>
+		<year>1991</year>
+		<publisher>Outlet</publisher>
+		<part name="flop1" interface="floppy_3">
+			<feature name="part_id" value="Side A"/>
+			<dataarea name="flop" size="226048">
+				<rom name="outlet issue 050 (1991)(outlet)(side a).dsk" size="226048" crc="7e587a46" sha1="8baab165d2044d301a7d0a1336ff2e32e6d6b940" offset="0" />
+			</dataarea>
+		</part>
+		<part name="flop2" interface="floppy_3">
+			<feature name="part_id" value="Side B"/>
+			<dataarea name="flop" size="226048">
+				<rom name="outlet issue 050 (1991)(outlet)(side b).dsk" size="226048" crc="05f01d3f" sha1="27b6f933a723e41d785dc08c92d7152c2e70cb5e" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Magazines - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="outle051">
+		<description>Outlet issue 051</description>
+		<year>1991</year>
+		<publisher>Outlet</publisher>
+		<part name="flop1" interface="floppy_3">
+			<feature name="part_id" value="Side A"/>
+			<dataarea name="flop" size="226048">
+				<rom name="outlet issue 051 (1991)(outlet)(side a).dsk" size="226048" crc="8b60a5cb" sha1="4b0199da41b79c5829800a4a0cd66f3cdd898bec" offset="0" />
+			</dataarea>
+		</part>
+		<part name="flop2" interface="floppy_3">
+			<feature name="part_id" value="Side B"/>
+			<dataarea name="flop" size="226048">
+				<rom name="outlet issue 051 (1991)(outlet)(side b).dsk" size="226048" crc="2a06937e" sha1="7ef139e94b9d1bf5ada3f7ee87ca9950423bb947" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Magazines - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="outle052">
+		<description>Outlet issue 052</description>
+		<year>1991</year>
+		<publisher>Outlet</publisher>
+		<part name="flop1" interface="floppy_3">
+			<feature name="part_id" value="Side A"/>
+			<dataarea name="flop" size="226048">
+				<rom name="outlet issue 052 (1991)(outlet)(side a).dsk" size="226048" crc="3267f917" sha1="1773e81bec3178ceb9e22eb4894c5787d170fae2" offset="0" />
+			</dataarea>
+		</part>
+		<part name="flop2" interface="floppy_3">
+			<feature name="part_id" value="Side B"/>
+			<dataarea name="flop" size="226048">
+				<rom name="outlet issue 052 (1991)(outlet)(side b).dsk" size="226048" crc="e21c8753" sha1="e29a9c4616da0e1f857143ba16c587eaa6cc6565" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Magazines - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="outle053">
+		<description>Outlet issue 053</description>
+		<year>1992</year>
+		<publisher>Outlet</publisher>
+		<part name="flop1" interface="floppy_3">
+			<feature name="part_id" value="Side A"/>
+			<dataarea name="flop" size="226048">
+				<rom name="outlet issue 053 (1992)(outlet)(side a).dsk" size="226048" crc="c7764a94" sha1="5c60ff9b0dbf060b2ab2fa663783760d46ddaf50" offset="0" />
+			</dataarea>
+		</part>
+		<part name="flop2" interface="floppy_3">
+			<feature name="part_id" value="Side B"/>
+			<dataarea name="flop" size="226048">
+				<rom name="outlet issue 053 (1992)(outlet)(side b).dsk" size="226048" crc="ef4fb121" sha1="bf668422a05c255ae5ebb56f59f85907c9de3639" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Magazines - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="outle054">
+		<description>Outlet issue 054</description>
+		<year>1992</year>
+		<publisher>Outlet</publisher>
+		<part name="flop1" interface="floppy_3">
+			<feature name="part_id" value="Side A"/>
+			<dataarea name="flop" size="226048">
+				<rom name="outlet issue 054 (1992)(outlet)(side a).dsk" size="226048" crc="0c090ec6" sha1="77fb3ef8b6659c98484a83d62020c1557087f697" offset="0" />
+			</dataarea>
+		</part>
+		<part name="flop2" interface="floppy_3">
+			<feature name="part_id" value="Side B"/>
+			<dataarea name="flop" size="226048">
+				<rom name="outlet issue 054 (1992)(outlet)(side b).dsk" size="226048" crc="eb1f1a71" sha1="ab65f251a750ed3fc434b758025c06eba22c5573" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Magazines - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="outle055">
+		<description>Outlet issue 055</description>
+		<year>1992</year>
+		<publisher>Outlet</publisher>
+		<part name="flop1" interface="floppy_3">
+			<feature name="part_id" value="Side A"/>
+			<dataarea name="flop" size="226048">
+				<rom name="outlet issue 055 (1992)(outlet)(side a).dsk" size="226048" crc="2475c9f3" sha1="021adc780ec1a211f01b234fac82febf54ac9075" offset="0" />
+			</dataarea>
+		</part>
+		<part name="flop2" interface="floppy_3">
+			<feature name="part_id" value="Side B"/>
+			<dataarea name="flop" size="226048">
+				<rom name="outlet issue 055 (1992)(outlet)(side b).dsk" size="226048" crc="d1f64117" sha1="1e7265765d6ae4c237d05fc08aff7f96a8da4990" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Magazines - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="outle056">
+		<description>Outlet issue 056</description>
+		<year>1992</year>
+		<publisher>Outlet</publisher>
+		<part name="flop1" interface="floppy_3">
+			<feature name="part_id" value="Side A"/>
+			<dataarea name="flop" size="226048">
+				<rom name="outlet issue 056 (1992)(outlet)(side a).dsk" size="226048" crc="9ca279e4" sha1="0d981a2cc0a6232c89c7817928c02a7b8bbde2ed" offset="0" />
+			</dataarea>
+		</part>
+		<part name="flop2" interface="floppy_3">
+			<feature name="part_id" value="Side B"/>
+			<dataarea name="flop" size="226048">
+				<rom name="outlet issue 056 (1992)(outlet)(side b).dsk" size="226048" crc="f84a4413" sha1="da3823af23c7defb8267dc655c55ca80061fbe6d" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Magazines - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="outle057">
+		<description>Outlet issue 057</description>
+		<year>1992</year>
+		<publisher>Outlet</publisher>
+		<part name="flop1" interface="floppy_3">
+			<feature name="part_id" value="Side A"/>
+			<dataarea name="flop" size="226048">
+				<rom name="outlet issue 057 (1992)(outlet)(side a).dsk" size="226048" crc="59380255" sha1="5d75e99f253b768a08d6dcc637e372158fceacc4" offset="0" />
+			</dataarea>
+		</part>
+		<part name="flop2" interface="floppy_3">
+			<feature name="part_id" value="Side B"/>
+			<dataarea name="flop" size="226048">
+				<rom name="outlet issue 057 (1992)(outlet)(side b).dsk" size="226048" crc="d5774496" sha1="42da487dbeeffd8ac86dd037f34014c11cc316ce" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Magazines - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="outle059">
+		<description>Outlet issue 059</description>
+		<year>1992</year>
+		<publisher>Outlet</publisher>
+		<part name="flop1" interface="floppy_3">
+			<feature name="part_id" value="Side A"/>
+			<dataarea name="flop" size="226048">
+				<rom name="outlet issue 059 (1992)(outlet)(side a).dsk" size="226048" crc="b82451b3" sha1="1169d5a1d594725bc90fe0a95757306087150704" offset="0" />
+			</dataarea>
+		</part>
+		<part name="flop2" interface="floppy_3">
+			<feature name="part_id" value="Side B"/>
+			<dataarea name="flop" size="226048">
+				<rom name="outlet issue 059 (1992)(outlet)(side b).dsk" size="226048" crc="16547a16" sha1="1a37cca8cafc48e4d9e056b322ae005c61a926e7" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Magazines - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="outle060">
+		<description>Outlet issue 060</description>
+		<year>1992</year>
+		<publisher>Outlet</publisher>
+		<part name="flop1" interface="floppy_3">
+			<feature name="part_id" value="Side A"/>
+			<dataarea name="flop" size="226048">
+				<rom name="outlet issue 060 (1992)(outlet)(side a).dsk" size="226048" crc="cfdfd178" sha1="37f7dd1b98d3f3d0c6d594437237069d09564776" offset="0" />
+			</dataarea>
+		</part>
+		<part name="flop2" interface="floppy_3">
+			<feature name="part_id" value="Side B"/>
+			<dataarea name="flop" size="226048">
+				<rom name="outlet issue 060 (1992)(outlet)(side b).dsk" size="226048" crc="e6c80363" sha1="450ab2039a50bbd47df39e4ee3511b46a6e321b4" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Magazines - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="outle061">
+		<description>Outlet issue 061</description>
+		<year>1992</year>
+		<publisher>Outlet</publisher>
+		<part name="flop1" interface="floppy_3">
+			<feature name="part_id" value="Side A"/>
+			<dataarea name="flop" size="226048">
+				<rom name="outlet issue 061 (1992)(outlet)(side a).dsk" size="226048" crc="e3c0a52a" sha1="7d70167e02deb869a44b83865465748e590edf84" offset="0" />
+			</dataarea>
+		</part>
+		<part name="flop2" interface="floppy_3">
+			<feature name="part_id" value="Side B"/>
+			<dataarea name="flop" size="226048">
+				<rom name="outlet issue 061 (1992)(outlet)(side b).dsk" size="226048" crc="361490c4" sha1="6291164a6caaf75f2454b56a1fe507ed9613ba70" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Magazines - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="outle062">
+		<description>Outlet issue 062</description>
+		<year>1992</year>
+		<publisher>Outlet</publisher>
+		<part name="flop1" interface="floppy_3">
+			<feature name="part_id" value="Side A"/>
+			<dataarea name="flop" size="226048">
+				<rom name="outlet issue 062 (1992)(outlet)(side a).dsk" size="226048" crc="d0a860b6" sha1="3b900961607e58a02eebb229ace45b033893a422" offset="0" />
+			</dataarea>
+		</part>
+		<part name="flop2" interface="floppy_3">
+			<feature name="part_id" value="Side B"/>
+			<dataarea name="flop" size="226048">
+				<rom name="outlet issue 062 (1992)(outlet)(side b).dsk" size="226048" crc="092808e0" sha1="8c2e71eb7dc70959b5ca391885de29041ba6d32f" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Magazines - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="outle066">
+		<description>Outlet issue 066</description>
+		<year>1993</year>
+		<publisher>Outlet</publisher>
+		<part name="flop1" interface="floppy_3">
+			<feature name="part_id" value="Side A"/>
+			<dataarea name="flop" size="226048">
+				<rom name="outlet issue 066 (1993)(outlet)(side a).dsk" size="226048" crc="16701775" sha1="ea7c02c3e56ac2cac3773314e827deae017fb019" offset="0" />
+			</dataarea>
+		</part>
+		<part name="flop2" interface="floppy_3">
+			<feature name="part_id" value="Side B"/>
+			<dataarea name="flop" size="226048">
+				<rom name="outlet issue 066 (1993)(outlet)(side b).dsk" size="226048" crc="08bd360b" sha1="390f6326c9be0df92c1aeacd8dadcf7687e05d9e" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Magazines - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="outle067">
+		<description>Outlet issue 067</description>
+		<year>1993</year>
+		<publisher>Outlet</publisher>
+		<part name="flop1" interface="floppy_3">
+			<feature name="part_id" value="Side A"/>
+			<dataarea name="flop" size="226048">
+				<rom name="outlet issue 067 (1993)(outlet)(side a).dsk" size="226048" crc="58bd8c25" sha1="254ed6879714188c642d6c7707a45335eb375dcd" offset="0" />
+			</dataarea>
+		</part>
+		<part name="flop2" interface="floppy_3">
+			<feature name="part_id" value="Side B"/>
+			<dataarea name="flop" size="226048">
+				<rom name="outlet issue 067 (1993)(outlet)(side b).dsk" size="226048" crc="8421d669" sha1="a188c64412e91c9a06a865a1924f543edfc2fa47" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Magazines - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="outle068">
+		<description>Outlet issue 068</description>
+		<year>1993</year>
+		<publisher>Outlet</publisher>
+		<part name="flop1" interface="floppy_3">
+			<feature name="part_id" value="Side A"/>
+			<dataarea name="flop" size="226048">
+				<rom name="outlet issue 068 (1993)(outlet)(side a).dsk" size="226048" crc="99450290" sha1="541e7f2b4e646461e0ebbe76253a39e43a2eaef2" offset="0" />
+			</dataarea>
+		</part>
+		<part name="flop2" interface="floppy_3">
+			<feature name="part_id" value="Side B"/>
+			<dataarea name="flop" size="226048">
+				<rom name="outlet issue 068 (1993)(outlet)(side b).dsk" size="226048" crc="41f50495" sha1="32ab73779d2d0895c44234108dd7e73fcae34808" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Magazines - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="outle069">
+		<description>Outlet issue 069</description>
+		<year>1993</year>
+		<publisher>Outlet</publisher>
+		<part name="flop1" interface="floppy_3">
+			<feature name="part_id" value="Side A"/>
+			<dataarea name="flop" size="226048">
+				<rom name="outlet issue 069 (1993)(outlet)(side a).dsk" size="226048" crc="9300d94c" sha1="0b4a2a95d513fd238b7e72519682ff4a29757cc7" offset="0" />
+			</dataarea>
+		</part>
+		<part name="flop2" interface="floppy_3">
+			<feature name="part_id" value="Side B"/>
+			<dataarea name="flop" size="226048">
+				<rom name="outlet issue 069 (1993)(outlet)(side b).dsk" size="226048" crc="08cecce5" sha1="a3bd59f0dcd919a826b7a1e8c0e16d7ec2aa29fc" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Magazines - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="outle070">
+		<description>Outlet issue 070</description>
+		<year>1993</year>
+		<publisher>Outlet</publisher>
+		<part name="flop1" interface="floppy_3">
+			<feature name="part_id" value="Side A"/>
+			<dataarea name="flop" size="226048">
+				<rom name="outlet issue 070 (1993)(outlet)(side a).dsk" size="226048" crc="43c63528" sha1="807ddeeb9cd17fb849b59d489e17c770e70576c0" offset="0" />
+			</dataarea>
+		</part>
+		<part name="flop2" interface="floppy_3">
+			<feature name="part_id" value="Side B"/>
+			<dataarea name="flop" size="226048">
+				<rom name="outlet issue 070 (1993)(outlet)(side b).dsk" size="226048" crc="758a3b19" sha1="0c6d6069518d261310e3b23771542b783f26acad" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Magazines - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="outle071">
+		<description>Outlet issue 071</description>
+		<year>1993</year>
+		<publisher>Outlet</publisher>
+		<part name="flop1" interface="floppy_3">
+			<feature name="part_id" value="Side A"/>
+			<dataarea name="flop" size="226048">
+				<rom name="outlet issue 071 (1993)(outlet)(side a).dsk" size="226048" crc="71e04e05" sha1="5c2a526b9144eaaab87bc0b091b9259bbfe4b254" offset="0" />
+			</dataarea>
+		</part>
+		<part name="flop2" interface="floppy_3">
+			<feature name="part_id" value="Side B"/>
+			<dataarea name="flop" size="226048">
+				<rom name="outlet issue 071 (1993)(outlet)(side b).dsk" size="226048" crc="5739563e" sha1="e469c9767f1fdaf7389559abee648befa87bd780" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Magazines - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="outle072">
+		<description>Outlet issue 072</description>
+		<year>1993</year>
+		<publisher>Outlet</publisher>
+		<part name="flop1" interface="floppy_3">
+			<feature name="part_id" value="Side A"/>
+			<dataarea name="flop" size="226048">
+				<rom name="outlet issue 072 (1993)(outlet)(side a).dsk" size="226048" crc="96537901" sha1="306f8ef4849ad23e49676def5599351647cdd1fa" offset="0" />
+			</dataarea>
+		</part>
+		<part name="flop2" interface="floppy_3">
+			<feature name="part_id" value="Side B"/>
+			<dataarea name="flop" size="226048">
+				<rom name="outlet issue 072 (1993)(outlet)(side b).dsk" size="226048" crc="bf1e0618" sha1="c5fa329076a41dab631d2e2f6af8abe1f321ef45" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Magazines - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="outle074">
+		<description>Outlet issue 074</description>
+		<year>1993</year>
+		<publisher>Outlet</publisher>
+		<part name="flop1" interface="floppy_3">
+			<feature name="part_id" value="Side A"/>
+			<dataarea name="flop" size="226048">
+				<rom name="outlet issue 074 (1993)(outlet)(side a).dsk" size="226048" crc="1c8b63e1" sha1="cadfb5b6d0b2297bbb7ef8c8d87b921cb478e591" offset="0" />
+			</dataarea>
+		</part>
+		<part name="flop2" interface="floppy_3">
+			<feature name="part_id" value="Side B"/>
+			<dataarea name="flop" size="226048">
+				<rom name="outlet issue 074 (1993)(outlet)(side b).dsk" size="226048" crc="2cc94dd8" sha1="ec2fcc8ab7958f9bf0b4e877a45f610bc2796aaa" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Magazines - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="outle077">
+		<description>Outlet issue 077</description>
+		<year>1994</year>
+		<publisher>Outlet</publisher>
+		<part name="flop1" interface="floppy_3">
+			<feature name="part_id" value="Side A"/>
+			<dataarea name="flop" size="226048">
+				<rom name="outlet issue 077 (1994)(outlet)(side a).dsk" size="226048" crc="70b9b111" sha1="35c3fdaa8181811673adce188e2e87a5933558f4" offset="0" />
+			</dataarea>
+		</part>
+		<part name="flop2" interface="floppy_3">
+			<feature name="part_id" value="Side B"/>
+			<dataarea name="flop" size="226048">
+				<rom name="outlet issue 077 (1994)(outlet)(side b).dsk" size="226048" crc="ad5ca0a1" sha1="1d2e8b134d993fe1f822c822c689647430670c19" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Magazines - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="outle080">
+		<description>Outlet issue 080</description>
+		<year>1994</year>
+		<publisher>Outlet</publisher>
+		<part name="flop1" interface="floppy_3">
+			<feature name="part_id" value="Side A"/>
+			<dataarea name="flop" size="226048">
+				<rom name="outlet issue 080 (1994)(outlet)(side a).dsk" size="226048" crc="0ee19ca2" sha1="bf1347141360b01e1ed93c8003611323cda75503" offset="0" />
+			</dataarea>
+		</part>
+		<part name="flop2" interface="floppy_3">
+			<feature name="part_id" value="Side B"/>
+			<dataarea name="flop" size="226048">
+				<rom name="outlet issue 080 (1994)(outlet)(side b).dsk" size="226048" crc="9af5a81a" sha1="3a66c12239a42dfed940108d4449aad6c6ef074d" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Magazines - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="outle081">
+		<description>Outlet issue 081</description>
+		<year>1994</year>
+		<publisher>Outlet</publisher>
+		<part name="flop1" interface="floppy_3">
+			<feature name="part_id" value="Side A"/>
+			<dataarea name="flop" size="226048">
+				<rom name="outlet issue 081 (1994)(outlet)(side a).dsk" size="226048" crc="08360731" sha1="37c64c4a4baeb020d44ea8f54e9846107f106540" offset="0" />
+			</dataarea>
+		</part>
+		<part name="flop2" interface="floppy_3">
+			<feature name="part_id" value="Side B"/>
+			<dataarea name="flop" size="226048">
+				<rom name="outlet issue 081 (1994)(outlet)(side b).dsk" size="226048" crc="9f92e4e2" sha1="6cfe9c6564b29d23417cb56e1b3d4d05491de4e8" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Magazines - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="outle082">
+		<description>Outlet issue 082</description>
+		<year>1994</year>
+		<publisher>Outlet</publisher>
+		<part name="flop1" interface="floppy_3">
+			<feature name="part_id" value="Side A"/>
+			<dataarea name="flop" size="226048">
+				<rom name="outlet issue 082 (1994)(outlet)(side a).dsk" size="226048" crc="51be8024" sha1="6cde8546beb0883c741b9190062b29e32738f690" offset="0" />
+			</dataarea>
+		</part>
+		<part name="flop2" interface="floppy_3">
+			<feature name="part_id" value="Side B"/>
+			<dataarea name="flop" size="226048">
+				<rom name="outlet issue 082 (1994)(outlet)(side b).dsk" size="226048" crc="39786d03" sha1="a4ba3002e8c920f6f12e333cca675104ae131c06" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Magazines - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="outle083">
+		<description>Outlet issue 083</description>
+		<year>1994</year>
+		<publisher>Outlet</publisher>
+		<part name="flop1" interface="floppy_3">
+			<feature name="part_id" value="Side A"/>
+			<dataarea name="flop" size="226048">
+				<rom name="outlet issue 083 (1994)(outlet)(side a).dsk" size="226048" crc="83416c11" sha1="ba6890d829e0f7b4aebefe717a1b59218ac58831" offset="0" />
+			</dataarea>
+		</part>
+		<part name="flop2" interface="floppy_3">
+			<feature name="part_id" value="Side B"/>
+			<dataarea name="flop" size="226048">
+				<rom name="outlet issue 083 (1994)(outlet)(side b).dsk" size="226048" crc="979e150c" sha1="a82963d60e3b40b3c3270cd646772963d9a62285" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Magazines - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="outle084">
+		<description>Outlet issue 084</description>
+		<year>1994</year>
+		<publisher>Outlet</publisher>
+		<part name="flop1" interface="floppy_3">
+			<feature name="part_id" value="Side A"/>
+			<dataarea name="flop" size="226048">
+				<rom name="outlet issue 084 (1994)(outlet)(side a).dsk" size="226048" crc="b0370b7a" sha1="a7652daafc722169d7c1d54ed752a229245c19fe" offset="0" />
+			</dataarea>
+		</part>
+		<part name="flop2" interface="floppy_3">
+			<feature name="part_id" value="Side B"/>
+			<dataarea name="flop" size="226048">
+				<rom name="outlet issue 084 (1994)(outlet)(side b).dsk" size="226048" crc="4800f224" sha1="2996d027138252d5efa97e9732488bcce97e5a5c" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Magazines - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="outle086">
+		<description>Outlet issue 086</description>
+		<year>1994</year>
+		<publisher>Outlet</publisher>
+		<part name="flop1" interface="floppy_3">
+			<feature name="part_id" value="Side A"/>
+			<dataarea name="flop" size="226048">
+				<rom name="outlet issue 086 (1994)(outlet)(side a).dsk" size="226048" crc="9b79992e" sha1="6f7774063179b0a14f4e4e32f4d1339149f6c158" offset="0" />
+			</dataarea>
+		</part>
+		<part name="flop2" interface="floppy_3">
+			<feature name="part_id" value="Side B"/>
+			<dataarea name="flop" size="226048">
+				<rom name="outlet issue 086 (1994)(outlet)(side b).dsk" size="226048" crc="a6771318" sha1="b05a3182dabc83914eb0eee20eca438d73ce5977" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Magazines - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="outle087">
+		<description>Outlet issue 087</description>
+		<year>1994</year>
+		<publisher>Outlet</publisher>
+		<part name="flop1" interface="floppy_3">
+			<feature name="part_id" value="Side A"/>
+			<dataarea name="flop" size="226048">
+				<rom name="outlet issue 087 (1994)(outlet)(side a).dsk" size="226048" crc="735bb8ec" sha1="dace26efb5d40ceeb6208fb3cd9faedf34db8b3b" offset="0" />
+			</dataarea>
+		</part>
+		<part name="flop2" interface="floppy_3">
+			<feature name="part_id" value="Side B"/>
+			<dataarea name="flop" size="226048">
+				<rom name="outlet issue 087 (1994)(outlet)(side b).dsk" size="226048" crc="2edd1b09" sha1="534e7bca4fc6b7794f272277d6d535769437c471" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Magazines - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="outle088">
+		<description>Outlet issue 088</description>
+		<year>1994</year>
+		<publisher>Outlet</publisher>
+		<part name="flop1" interface="floppy_3">
+			<feature name="part_id" value="Side A"/>
+			<dataarea name="flop" size="226048">
+				<rom name="outlet issue 088 (1994)(outlet)(side a).dsk" size="226048" crc="411a360e" sha1="a7452f031a873dd40348af24b2cfd8d04a6c2cb5" offset="0" />
+			</dataarea>
+		</part>
+		<part name="flop2" interface="floppy_3">
+			<feature name="part_id" value="Side B"/>
+			<dataarea name="flop" size="226048">
+				<rom name="outlet issue 088 (1994)(outlet)(side b).dsk" size="226048" crc="fb4a75ca" sha1="c2179916c377384d3e6deed5ef486c1343ad4473" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Magazines - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="outle089">
+		<description>Outlet issue 089</description>
+		<year>1995</year>
+		<publisher>Outlet</publisher>
+		<part name="flop1" interface="floppy_3">
+			<feature name="part_id" value="Side A"/>
+			<dataarea name="flop" size="226048">
+				<rom name="outlet issue 089 (1995)(outlet)(side a).dsk" size="226048" crc="78ee8697" sha1="b3724ad26e580450ecb549e01232b0a0607ef24a" offset="0" />
+			</dataarea>
+		</part>
+		<part name="flop2" interface="floppy_3">
+			<feature name="part_id" value="Side B"/>
+			<dataarea name="flop" size="226048">
+				<rom name="outlet issue 089 (1995)(outlet)(side b).dsk" size="226048" crc="351d0b7f" sha1="3eaf9aac6939f6ae05a1799418d2341b98ec1d0a" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Magazines - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="outle090">
+		<description>Outlet issue 090</description>
+		<year>1995</year>
+		<publisher>Outlet</publisher>
+		<part name="flop1" interface="floppy_3">
+			<feature name="part_id" value="Side A"/>
+			<dataarea name="flop" size="226048">
+				<rom name="outlet issue 090 (1995)(outlet)(side a).dsk" size="226048" crc="a20d3d17" sha1="e4c63aee85e411354ed6842cf29d7ef2a746eeeb" offset="0" />
+			</dataarea>
+		</part>
+		<part name="flop2" interface="floppy_3">
+			<feature name="part_id" value="Side B"/>
+			<dataarea name="flop" size="226048">
+				<rom name="outlet issue 090 (1995)(outlet)(side b).dsk" size="226048" crc="99295cd8" sha1="ae1d6e49ddf68ce27b460c5d866e43596e9db9b4" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Magazines - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="outle091">
+		<description>Outlet issue 091</description>
+		<year>1995</year>
+		<publisher>Outlet</publisher>
+		<part name="flop1" interface="floppy_3">
+			<feature name="part_id" value="Side A"/>
+			<dataarea name="flop" size="226048">
+				<rom name="outlet issue 091 (1995)(outlet)(side a).dsk" size="226048" crc="641e4365" sha1="bb7e5064d02180096c0eb6615dd4ae2b370bede5" offset="0" />
+			</dataarea>
+		</part>
+		<part name="flop2" interface="floppy_3">
+			<feature name="part_id" value="Side B"/>
+			<dataarea name="flop" size="226048">
+				<rom name="outlet issue 091 (1995)(outlet)(side b).dsk" size="226048" crc="fe3b1dd5" sha1="a46f2cadb5e6627a359c9476d797be57c8e1757a" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Magazines - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="outle092">
+		<description>Outlet issue 092</description>
+		<year>1995</year>
+		<publisher>Outlet</publisher>
+		<part name="flop1" interface="floppy_3">
+			<feature name="part_id" value="Side A"/>
+			<dataarea name="flop" size="226048">
+				<rom name="outlet issue 092 (1995)(outlet)(side a).dsk" size="226048" crc="c8f1aa35" sha1="f3e62de14ac4039eb60d1e02b36a52e66f3e8249" offset="0" />
+			</dataarea>
+		</part>
+		<part name="flop2" interface="floppy_3">
+			<feature name="part_id" value="Side B"/>
+			<dataarea name="flop" size="226048">
+				<rom name="outlet issue 092 (1995)(outlet)(side b).dsk" size="226048" crc="76b5a3ce" sha1="8aebe0ad435314f7c8e2bbaa76cf78cfc85bcbef" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Magazines - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="outle093">
+		<description>Outlet issue 093</description>
+		<year>1995</year>
+		<publisher>Outlet</publisher>
+		<part name="flop1" interface="floppy_3">
+			<feature name="part_id" value="Side A"/>
+			<dataarea name="flop" size="226048">
+				<rom name="outlet issue 093 (1995)(outlet)(side a).dsk" size="226048" crc="6a37384a" sha1="7b82874ac10771804f2d9f8752ffbad868237c9f" offset="0" />
+			</dataarea>
+		</part>
+		<part name="flop2" interface="floppy_3">
+			<feature name="part_id" value="Side B"/>
+			<dataarea name="flop" size="226048">
+				<rom name="outlet issue 093 (1995)(outlet)(side b).dsk" size="226048" crc="b8b57c3e" sha1="d70cfae2627615f401691a8b08913e59b79a2ccf" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Magazines - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="outle094">
+		<description>Outlet issue 094</description>
+		<year>1995</year>
+		<publisher>Outlet</publisher>
+		<part name="flop1" interface="floppy_3">
+			<feature name="part_id" value="Side A"/>
+			<dataarea name="flop" size="226048">
+				<rom name="outlet issue 094 (1995)(outlet)(side a).dsk" size="226048" crc="0300670d" sha1="1531002883ae0709d2d9b92a045f3a0c4650d528" offset="0" />
+			</dataarea>
+		</part>
+		<part name="flop2" interface="floppy_3">
+			<feature name="part_id" value="Side B"/>
+			<dataarea name="flop" size="226048">
+				<rom name="outlet issue 094 (1995)(outlet)(side b).dsk" size="226048" crc="21a271d0" sha1="64a1084bd7fed43d19b909186c85e84cabefc721" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Magazines - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="outle095">
+		<description>Outlet issue 095</description>
+		<year>1995</year>
+		<publisher>Outlet</publisher>
+		<part name="flop1" interface="floppy_3">
+			<feature name="part_id" value="Side A"/>
+			<dataarea name="flop" size="226048">
+				<rom name="outlet issue 095 (1995)(outlet)(side a).dsk" size="226048" crc="0b94a0d9" sha1="f67d967f18608e905ec2df9b1291e9ede3b42ca6" offset="0" />
+			</dataarea>
+		</part>
+		<part name="flop2" interface="floppy_3">
+			<feature name="part_id" value="Side B"/>
+			<dataarea name="flop" size="226048">
+				<rom name="outlet issue 095 (1995)(outlet)(side b).dsk" size="226048" crc="091552d9" sha1="f6cfa8ae37ea8a1c3c7963a75cf5fa15c4d7c07e" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Magazines - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="outle096">
+		<description>Outlet issue 096</description>
+		<year>1995</year>
+		<publisher>Outlet</publisher>
+		<part name="flop1" interface="floppy_3">
+			<feature name="part_id" value="Side A"/>
+			<dataarea name="flop" size="226048">
+				<rom name="outlet issue 096 (1995)(outlet)(side a).dsk" size="226048" crc="1efd43eb" sha1="49459ee92d9d69e61c1ac8cfb62b41d2989131c5" offset="0" />
+			</dataarea>
+		</part>
+		<part name="flop2" interface="floppy_3">
+			<feature name="part_id" value="Side B"/>
+			<dataarea name="flop" size="226048">
+				<rom name="outlet issue 096 (1995)(outlet)(side b).dsk" size="226048" crc="fe1953c5" sha1="2daf42b85f768cd9642672e898b6bdaaf7fd42e0" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Magazines - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="outle097">
+		<description>Outlet issue 097</description>
+		<year>1995</year>
+		<publisher>Outlet</publisher>
+		<part name="flop1" interface="floppy_3">
+			<feature name="part_id" value="Side A"/>
+			<dataarea name="flop" size="226048">
+				<rom name="outlet issue 097 (1995)(outlet)(side a).dsk" size="226048" crc="e2e1c840" sha1="7bdbf5ee01ab10223bc4c4f8f8b5204f0367fde3" offset="0" />
+			</dataarea>
+		</part>
+		<part name="flop2" interface="floppy_3">
+			<feature name="part_id" value="Side B"/>
+			<dataarea name="flop" size="226048">
+				<rom name="outlet issue 097 (1995)(outlet)(side b).dsk" size="226048" crc="a0633e44" sha1="57a81ac480bf1a35f14f64bd4f9111ded543d506" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Magazines - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="outle098">
+		<description>Outlet issue 098</description>
+		<year>1995</year>
+		<publisher>Outlet</publisher>
+		<part name="flop1" interface="floppy_3">
+			<feature name="part_id" value="Side A"/>
+			<dataarea name="flop" size="226048">
+				<rom name="outlet issue 098 (1995)(outlet)(side a).dsk" size="226048" crc="2d36c7d1" sha1="b0f8df560f325fb3e6c8f2d3bc00f7dbd040d564" offset="0" />
+			</dataarea>
+		</part>
+		<part name="flop2" interface="floppy_3">
+			<feature name="part_id" value="Side B"/>
+			<dataarea name="flop" size="226048">
+				<rom name="outlet issue 098 (1995)(outlet)(side b).dsk" size="226048" crc="da72da56" sha1="880ba726c46e4c4b4cfd9757b1c4fc0cd4e24727" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Magazines - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="outle099">
+		<description>Outlet issue 099</description>
+		<year>1995</year>
+		<publisher>Outlet</publisher>
+		<part name="flop1" interface="floppy_3">
+			<feature name="part_id" value="Side A"/>
+			<dataarea name="flop" size="226048">
+				<rom name="outlet issue 099 (1995)(outlet)(side a).dsk" size="226048" crc="2486cb95" sha1="6a5faba62a342f7b5ab3ddf39e146fcb2b6daf8f" offset="0" />
+			</dataarea>
+		</part>
+		<part name="flop2" interface="floppy_3">
+			<feature name="part_id" value="Side B"/>
+			<dataarea name="flop" size="226048">
+				<rom name="outlet issue 099 (1995)(outlet)(side b).dsk" size="226048" crc="0571efe9" sha1="f1214c79248c9c999da9c5d5a4ebdd43e29a8ef5" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Magazines - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="outle100">
+		<description>Outlet issue 100</description>
+		<year>1995</year>
+		<publisher>Outlet</publisher>
+		<part name="flop1" interface="floppy_3">
+			<feature name="part_id" value="Side A"/>
+			<dataarea name="flop" size="226048">
+				<rom name="outlet issue 100 (1995)(outlet)(side a).dsk" size="226048" crc="92c2f2d1" sha1="a575a84d95f7db280dc9fd998c91a23db0f27267" offset="0" />
+			</dataarea>
+		</part>
+		<part name="flop2" interface="floppy_3">
+			<feature name="part_id" value="Side B"/>
+			<dataarea name="flop" size="226048">
+				<rom name="outlet issue 100 (1995)(outlet)(side b).dsk" size="226048" crc="a8127cff" sha1="e487759b43e1b2d82a67cc0d7ccfc8ff3ea7812c" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Magazines - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="outle102">
+		<description>Outlet issue 102</description>
+		<year>1996</year>
+		<publisher>Outlet</publisher>
+		<part name="flop1" interface="floppy_3">
+			<feature name="part_id" value="Side A"/>
+			<dataarea name="flop" size="226048">
+				<rom name="outlet issue 102 (1996)(outlet)(side a).dsk" size="226048" crc="1cfa72cc" sha1="085e184d9d79752bdd2298e21b6347c67fd64efa" offset="0" />
+			</dataarea>
+		</part>
+		<part name="flop2" interface="floppy_3">
+			<feature name="part_id" value="Side B"/>
+			<dataarea name="flop" size="226048">
+				<rom name="outlet issue 102 (1996)(outlet)(side b).dsk" size="226048" crc="5fb0e6a1" sha1="2b6f82877b371c7cbcb984f411e45ca7118affe0" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Magazines - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="outle104">
+		<description>Outlet issue 104</description>
+		<year>1996</year>
+		<publisher>Outlet</publisher>
+		<part name="flop1" interface="floppy_3">
+			<feature name="part_id" value="Side A"/>
+			<dataarea name="flop" size="226048">
+				<rom name="outlet issue 104 (1996)(outlet)(side a).dsk" size="226048" crc="3638c100" sha1="14e82b8fdbf15ebf6220b50ff09f7925c8000c21" offset="0" />
+			</dataarea>
+		</part>
+		<part name="flop2" interface="floppy_3">
+			<feature name="part_id" value="Side B"/>
+			<dataarea name="flop" size="226048">
+				<rom name="outlet issue 104 (1996)(outlet)(side b).dsk" size="226048" crc="0492eeae" sha1="27271fabb5a9d299d15088680d19d48914c460fe" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Magazines - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="outle106">
+		<description>Outlet issue 106</description>
+		<year>1996</year>
+		<publisher>Outlet</publisher>
+		<part name="flop1" interface="floppy_3">
+			<feature name="part_id" value="Side A"/>
+			<dataarea name="flop" size="226048">
+				<rom name="outlet issue 106 (1996)(outlet)(side a).dsk" size="226048" crc="73b6080a" sha1="d93c13cd0cda70e1b8df9b06e094e9801b1af56c" offset="0" />
+			</dataarea>
+		</part>
+		<part name="flop2" interface="floppy_3">
+			<feature name="part_id" value="Side B"/>
+			<dataarea name="flop" size="226048">
+				<rom name="outlet issue 106 (1996)(outlet)(side b).dsk" size="226048" crc="7d840a8c" sha1="757bd288deb55fc5bba8711d883c6d12fdeb8b44" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Magazines - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="outle107">
+		<description>Outlet issue 107</description>
+		<year>1996</year>
+		<publisher>Outlet</publisher>
+		<part name="flop1" interface="floppy_3">
+			<feature name="part_id" value="Side A"/>
+			<dataarea name="flop" size="226048">
+				<rom name="outlet issue 107 (1996)(outlet)(side a).dsk" size="226048" crc="04e6e5bc" sha1="01ed80e78299493b3f0d3d7db3db1144fa74322b" offset="0" />
+			</dataarea>
+		</part>
+		<part name="flop2" interface="floppy_3">
+			<feature name="part_id" value="Side B"/>
+			<dataarea name="flop" size="226048">
+				<rom name="outlet issue 107 (1996)(outlet)(side b).dsk" size="226048" crc="274f7a00" sha1="352181d82bc4980c40f57661928dc849782c69bf" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Magazines - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="outle108">
+		<description>Outlet issue 108</description>
+		<year>1996</year>
+		<publisher>Outlet</publisher>
+		<part name="flop1" interface="floppy_3">
+			<feature name="part_id" value="Side A"/>
+			<dataarea name="flop" size="226048">
+				<rom name="outlet issue 108 (1996)(outlet)(side a).dsk" size="226048" crc="45ff3b5a" sha1="3167e7af4738b045d7bdf508c23efda94e877ac2" offset="0" />
+			</dataarea>
+		</part>
+		<part name="flop2" interface="floppy_3">
+			<feature name="part_id" value="Side B"/>
+			<dataarea name="flop" size="226048">
+				<rom name="outlet issue 108 (1996)(outlet)(side b).dsk" size="226048" crc="cf70a1f1" sha1="618e5f1fcc3579cdaffc4dc5f916d2062f68c697" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Magazines - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="outle109">
+		<description>Outlet issue 109</description>
+		<year>1996</year>
+		<publisher>Outlet</publisher>
+		<part name="flop1" interface="floppy_3">
+			<feature name="part_id" value="Side A"/>
+			<dataarea name="flop" size="226048">
+				<rom name="outlet issue 109 (1996)(outlet)(side a).dsk" size="226048" crc="aff33564" sha1="88efe6492245ecaaa490d6c1d9c474502ce8d86b" offset="0" />
+			</dataarea>
+		</part>
+		<part name="flop2" interface="floppy_3">
+			<feature name="part_id" value="Side B"/>
+			<dataarea name="flop" size="226048">
+				<rom name="outlet issue 109 (1996)(outlet)(side b).dsk" size="226048" crc="120381b0" sha1="088f1dbefde9b01002ba09944fe10a7c6f3ebd99" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Magazines - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="outle110">
+		<description>Outlet issue 110</description>
+		<year>1996</year>
+		<publisher>Outlet</publisher>
+		<part name="flop1" interface="floppy_3">
+			<feature name="part_id" value="Side A"/>
+			<dataarea name="flop" size="226048">
+				<rom name="outlet issue 110 (1996)(outlet)(side a).dsk" size="226048" crc="ecf0bf64" sha1="ee4ba7bed464dd309e94b242b76084e0c6b49929" offset="0" />
+			</dataarea>
+		</part>
+		<part name="flop2" interface="floppy_3">
+			<feature name="part_id" value="Side B"/>
+			<dataarea name="flop" size="226048">
+				<rom name="outlet issue 110 (1996)(outlet)(side b).dsk" size="226048" crc="ad4dc57f" sha1="6b66f7126636f99a274e2ecb8e7a89261dad5200" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Magazines - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="outle111">
+		<description>Outlet issue 111</description>
+		<year>1996</year>
+		<publisher>Outlet</publisher>
+		<part name="flop1" interface="floppy_3">
+			<feature name="part_id" value="Side A"/>
+			<dataarea name="flop" size="226048">
+				<rom name="outlet issue 111 (1996)(outlet)(side a).dsk" size="226048" crc="068a68ae" sha1="0419e102cc9cee67651d607a86fe36460f1183a3" offset="0" />
+			</dataarea>
+		</part>
+		<part name="flop2" interface="floppy_3">
+			<feature name="part_id" value="Side B"/>
+			<dataarea name="flop" size="226048">
+				<rom name="outlet issue 111 (1996)(outlet)(side b).dsk" size="226048" crc="28988916" sha1="b256c843e19511122a33a160af5df559d21ae55f" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Magazines - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="outle112">
+		<description>Outlet issue 112</description>
+		<year>1996</year>
+		<publisher>Outlet</publisher>
+		<part name="flop1" interface="floppy_3">
+			<feature name="part_id" value="Side A"/>
+			<dataarea name="flop" size="226048">
+				<rom name="outlet issue 112 (1996)(outlet)(side a).dsk" size="226048" crc="b0669b73" sha1="aff6cc065f8b45fd11308c22ddcec41b359d4458" offset="0" />
+			</dataarea>
+		</part>
+		<part name="flop2" interface="floppy_3">
+			<feature name="part_id" value="Side B"/>
+			<dataarea name="flop" size="226048">
+				<rom name="outlet issue 112 (1996)(outlet)(side b).dsk" size="226048" crc="d91a283b" sha1="e3b7314e3369fe47fbfa55c0bd7169b564882203" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Magazines - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="outle113">
+		<description>Outlet issue 113</description>
+		<year>1997</year>
+		<publisher>Outlet</publisher>
+		<part name="flop1" interface="floppy_3">
+			<feature name="part_id" value="Side A"/>
+			<dataarea name="flop" size="226048">
+				<rom name="outlet issue 113 (1997)(outlet)(side a).dsk" size="226048" crc="a68f6362" sha1="b5ff3286c88224adf20dba3c191720ba172f1958" offset="0" />
+			</dataarea>
+		</part>
+		<part name="flop2" interface="floppy_3">
+			<feature name="part_id" value="Side B"/>
+			<dataarea name="flop" size="226048">
+				<rom name="outlet issue 113 (1997)(outlet)(side b).dsk" size="226048" crc="89e5e066" sha1="a7dad0d07a29819b8a80f60e47ae6de34a71e321" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Magazines - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="outle114">
+		<description>Outlet issue 114</description>
+		<year>1997</year>
+		<publisher>Outlet</publisher>
+		<part name="flop1" interface="floppy_3">
+			<feature name="part_id" value="Side A"/>
+			<dataarea name="flop" size="226048">
+				<rom name="outlet issue 114 (1997)(outlet)(side a).dsk" size="226048" crc="74345db7" sha1="c9fb8e62d585f3cb9edfa27442c9f417d80db186" offset="0" />
+			</dataarea>
+		</part>
+		<part name="flop2" interface="floppy_3">
+			<feature name="part_id" value="Side B"/>
+			<dataarea name="flop" size="226048">
+				<rom name="outlet issue 114 (1997)(outlet)(side b).dsk" size="226048" crc="fb9f0437" sha1="c2d4e1e7a5aac196e2d9279416293c10df2aeec8" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Magazines - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="outle115">
+		<description>Outlet issue 115</description>
+		<year>1997</year>
+		<publisher>Outlet</publisher>
+		<part name="flop1" interface="floppy_3">
+			<feature name="part_id" value="Side A"/>
+			<dataarea name="flop" size="226048">
+				<rom name="outlet issue 115 (1997)(outlet)(side a).dsk" size="226048" crc="9aee9e0f" sha1="be84db2b91f19229079a1560f54d92672f2b281d" offset="0" />
+			</dataarea>
+		</part>
+		<part name="flop2" interface="floppy_3">
+			<feature name="part_id" value="Side B"/>
+			<dataarea name="flop" size="226048">
+				<rom name="outlet issue 115 (1997)(outlet)(side b).dsk" size="226048" crc="726b1600" sha1="dcbc19c1867edf358d5e6608fb1e435c712c5eec" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Magazines - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="outle116">
+		<description>Outlet issue 116</description>
+		<year>1997</year>
+		<publisher>Outlet</publisher>
+		<part name="flop1" interface="floppy_3">
+			<feature name="part_id" value="Side A"/>
+			<dataarea name="flop" size="226048">
+				<rom name="outlet issue 116 (1997)(outlet)(side a).dsk" size="226048" crc="614ee69d" sha1="f849eeeff8f4c18c34b2525f5d13f0f832fd8794" offset="0" />
+			</dataarea>
+		</part>
+		<part name="flop2" interface="floppy_3">
+			<feature name="part_id" value="Side B"/>
+			<dataarea name="flop" size="226048">
+				<rom name="outlet issue 116 (1997)(outlet)(side b).dsk" size="226048" crc="ef33c336" sha1="79912ef40f92993e956064ec97f3e127008cd707" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Magazines - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="outle118">
+		<description>Outlet issue 118</description>
+		<year>1997</year>
+		<publisher>Outlet</publisher>
+		<part name="flop1" interface="floppy_3">
+			<feature name="part_id" value="Side A"/>
+			<dataarea name="flop" size="226048">
+				<rom name="outlet issue 118 (1997)(outlet)(side a).dsk" size="226048" crc="4c89511a" sha1="25d1f269327ed78d3b8be0ee0190f44d796c3c36" offset="0" />
+			</dataarea>
+		</part>
+		<part name="flop2" interface="floppy_3">
+			<feature name="part_id" value="Side B"/>
+			<dataarea name="flop" size="226048">
+				<rom name="outlet issue 118 (1997)(outlet)(side b).dsk" size="226048" crc="7fc890cf" sha1="91fa641b09e05292ea103dc00fb5883fb87cc994" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Magazines - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="outle119">
+		<description>Outlet issue 119</description>
+		<year>1997</year>
+		<publisher>Outlet</publisher>
+		<part name="flop1" interface="floppy_3">
+			<feature name="part_id" value="Side A"/>
+			<dataarea name="flop" size="226048">
+				<rom name="outlet issue 119 (1997)(outlet)(side a).dsk" size="226048" crc="87767ef5" sha1="2107cc5870278efe23b602dc39e069cd138f0a8d" offset="0" />
+			</dataarea>
+		</part>
+		<part name="flop2" interface="floppy_3">
+			<feature name="part_id" value="Side B"/>
+			<dataarea name="flop" size="226048">
+				<rom name="outlet issue 119 (1997)(outlet)(side b).dsk" size="226048" crc="7587f1d3" sha1="ebad6d34c48363045858de977bd96b3536fce8ea" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Magazines - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="outle120">
+		<description>Outlet issue 120</description>
+		<year>1997</year>
+		<publisher>Outlet</publisher>
+		<part name="flop1" interface="floppy_3">
+			<feature name="part_id" value="Side A"/>
+			<dataarea name="flop" size="226048">
+				<rom name="outlet issue 120 (1997)(outlet)(side a).dsk" size="226048" crc="3ff428b5" sha1="5bc0b755ccbdc8d841c4a1fa9d65aa127495153f" offset="0" />
+			</dataarea>
+		</part>
+		<part name="flop2" interface="floppy_3">
+			<feature name="part_id" value="Side B"/>
+			<dataarea name="flop" size="226048">
+				<rom name="outlet issue 120 (1997)(outlet)(side b).dsk" size="226048" crc="b8ff2c62" sha1="0a32a349648f2a47c6b8edfc70efe6892931d79a" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- From "Sinclair ZX Spectrum - Magazines - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
+	<software name="outle121">
+		<description>Outlet issue 121</description>
+		<year>1997</year>
+		<publisher>Outlet</publisher>
+		<part name="flop1" interface="floppy_3">
+			<feature name="part_id" value="Side A"/>
+			<dataarea name="flop" size="226048">
+				<rom name="outlet issue 121 (1997)(outlet)(side a).dsk" size="226048" crc="e6e29d03" sha1="b37a5e7e41fa88cfbe5fed141259dad54b821c06" offset="0" />
+			</dataarea>
+		</part>
+		<part name="flop2" interface="floppy_3">
+			<feature name="part_id" value="Side B"/>
+			<dataarea name="flop" size="226048">
+				<rom name="outlet issue 121 (1997)(outlet)(side b).dsk" size="226048" crc="fd653c43" sha1="f25d4b2d07339a54bd43954a0c68c2bfdc8232bd" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+	
 </softwarelist>

--- a/hash/specpls3_flop.xml
+++ b/hash/specpls3_flop.xml
@@ -19805,7 +19805,6 @@
 				<rom name="navy moves (1988)(dinamic)(es)(en)(side b).dsk" size="214784" crc="c32323a2" sha1="da30c11411368b22474b032f39e8f8b968f7903b" offset="0" />
 			</dataarea>
 		</part>
--->
 
 	<software name="ninjawarsp" cloneof="ninjawar">
 		<description>The Ninja Warriors (Spa)</description>


### PR DESCRIPTION
These changes add most of the DSKs featured in the latest TOSEC DAT files which, according to Lady Eklipse, include all files that were in TOSEC and all files from www.worldofspectrum.org which were never in TOSEC before. Which file and update they come from is commented for each entry, so that they can be consulted.

	Files removed:
		- Files marked as "bad dumps" which have a "good" parent set.
		- Trained games, except for a "cheat version" of Neighbours which may have come from the original developers.
		- 80-track (3.5'') disk images.
		- Files generated with the ZXZVM interpreter.
		- Games from the Crap Games Competition.

All the DSK files which have a corresponding IPF have been labeled as "alt" clones until they're confirmed to come from the exact same release and can be safely removed (there's an added disclaimer about it in each of these entries, to make them easy to locate).
Other alt versions not in World of Spectrum have been kept for the same reason, since the exact source of each file doesn't seem to be properly documented anywhere, which means they'd need some research before a safe removal.

Notes about the known DSK dumps:
-Some dumps may come with an empty Side B, which is technically correct for games which were released with an empty side on purpose. These were usually labeled as "Sin grabar para tu uso" ("Unrecorded for your use") in many Spanish releases.
-Some of the "master disks" from Zeppelin Games share the same file (same SHA-1) for their Side B. This has been verified against the downloads available in World of Spectrum.
-A few releases had a version for a different system on the other side. These have been commented out but not removed, for reference.


I'm listing here some unofficial/homebrew disk collections which may or may not qualify to be included, so that you can decide their fate:

"Javier Herrera Games Collection": A bunch of well-known commercial games put in many disks.
"Jesus Tejero Software Collection": 48K games ported to many disks.
"Jesus Tejero Tools Collection": This disks include a bunch of utilities for +3 disks such as an "autoload sector creator", some of which I haven't found outside the compilations. Might be useful when testing disk emulation?
"MicroByte - Serie Clasicos Spectrum": Disk copies of the "Clásicos Spectrum" collection of 48K/16K cassettes. Only a selection of these was officially made available in disk form.
"Gary Lancaster Tools Collection": I can't load this one, maybe it has some copy protection or something. Haven't found any info about it.