### PR TITLE
mc6845.cpp: Do not reset line counter when screen parameters changed

### DIFF
--- a/src/devices/video/mc6845.cpp
+++ b/src/devices/video/mc6845.cpp
@@ -582,8 +582,6 @@ void mc6845_device::recompute_parameters(bool postload)
 		m_hsync_off_pos = hsync_off_pos;
 		m_vsync_on_pos = vsync_on_pos;
 		m_vsync_off_pos = vsync_off_pos;
-		if (!postload) // set m_line_counter to 0 on normal operation, but not on postload
-			m_line_counter = 0;
 	}
 }
 


### PR DESCRIPTION
Fix MT 06997, 06854 and 06423.
Also others games like "Profanation 2" works now.