### PR TITLE
pokey_device::step_pot: remove operations with no effect

### DIFF
--- a/src/devices/sound/pokey.cpp
+++ b/src/devices/sound/pokey.cpp
@@ -538,11 +538,8 @@ void pokey_device::step_keyboard()
 
 void pokey_device::step_pot()
 {
-	if ((m_SKCTL & SK_RESET) == 0)
-		return;
-
-	uint8_t upd = 0;
 	m_pot_counter++;
+	uint8_t upd = 0;
 	for (int pot = 0; pot < 8; pot++)
 	{
 		if ((m_POTx[pot]<m_pot_counter) || (m_pot_counter == 228))
@@ -551,7 +548,9 @@ void pokey_device::step_pot()
 			/* latching is emulated in read */
 		}
 	}
-	synchronize(SYNC_POT, upd);
+	// some pots latched?
+	if (upd != 0)
+		synchronize(SYNC_POT, upd);
 }
 
 /*


### PR DESCRIPTION
* step_pot is called from step_one_clock only and just in case pokey is not in
  reset state -> No need to check reset state again
* in case there were no bits in 'upd' latched to one, there is no need to call
  synchronize(SYNC_POT, 0) because m_ALLPOT won't change.

Performance results with missile / starwars (no pots):
Before:
./mame64 -bench 50 missile -> Average speed: 1171.67% (49 seconds)
./mame64 -bench 50 starwars -> Average speed: 551.66% (49 seconds)
After:
./mame64 -bench 50 missile -> Average speed: 1321.16% (49 seconds)
./mame64 -bench 50 starwars -> Average speed: 551.10% (49 seconds)

Signed-off-by: Andreas Müller <schnitzeltony@gmail.com>