### PR TITLE
pokey: force recalculation of raw sound output after reset

### DIFF
--- a/src/devices/sound/pokey.cpp
+++ b/src/devices/sound/pokey.cpp
@@ -1031,6 +1031,7 @@ void pokey_device::write_internal(offs_t offset, uint8_t data)
 			m_clock_cnt[0] = 0;
 			m_clock_cnt[1] = 0;
 			m_clock_cnt[2] = 0;
+			m_old_raw_inval = true;
 			/* FIXME: Serial port reset ! */
 		}
 		break;


### PR DESCRIPTION
* This fixes a regression introduced by [1]
* Could not detect and performance change introduced by this

[1] https://github.com/mamedev/mame/pull/4702/commits/308c3c2d04ce8f3af09f620f524579145cbbcaf0

Signed-off-by: Andreas Müller <schnitzeltony@gmail.com>