### PR TITLE
pokey: yet another performance enhancement

### DIFF
--- a/src/devices/sound/pokey.cpp
+++ b/src/devices/sound/pokey.cpp
@@ -99,11 +99,6 @@
 #define TIMER2  1
 #define TIMER4  2
 
-/* values to add to the divisors for the different modes */
-#define DIVADD_LOCLK        1
-#define DIVADD_HICLK        4
-#define DIVADD_HICLK_JOINED 7
-
 /* AUDCx */
 #define NOTPOLY5    0x80    /* selects POLY5 or direct CLOCK */
 #define POLY4       0x40    /* selects POLY4 or POLY17 */
@@ -151,11 +146,6 @@
 
 #define DIV_64      28       /* divisor for 1.78979 MHz clock to 63.9211 kHz */
 #define DIV_15      114      /* divisor for 1.78979 MHz clock to 15.6999 kHz */
-
-#define P4(chip)  chip->poly4[chip->p4]
-#define P5(chip)  chip->poly5[chip->p5]
-#define P9(chip)  chip->poly9[chip->p9]
-#define P17(chip) chip->poly17[chip->p17]
 
 #define CLK_1 0
 #define CLK_28 1

--- a/src/devices/sound/pokey.h
+++ b/src/devices/sound/pokey.h
@@ -242,7 +242,8 @@ private:
 			m_counter = (m_counter + 1) & 0xff;
 			if (m_counter == 0 && m_borrow_cnt == 0)
 			{
-				m_borrow_cnt = 3;
+				m_borrow_cnt = m_parent->m_borrow_all_max = 3;
+
 				if (m_parent->m_IRQEN & m_INTMask)
 				{
 					/* Exposed state has changed: This should only be updated after a resync ... */
@@ -286,6 +287,7 @@ private:
 
 	uint32_t m_out_raw;         /* raw output */
 	bool m_old_raw_inval;       /* true: recalc m_out_raw required */
+	uint32_t m_borrow_all_max;  /* max borrow count for all channels */
 	double m_out_filter;        /* filtered output */
 
 	int32_t m_clock_cnt[3];     /* clock counters */


### PR DESCRIPTION
In case

* no counters are running at high speed without prescalers - and
* no prescalers have triggered - and
* there is no borrow counter expected to finish

there is no need to continue on step_one_clock.

Performance measuements:
Before:
./mame64 -bench 50 missile -> Average speed: 1322.75% (49 seconds)
./mame64 -bench 50 starwars -> Average speed: 548.97% (49 seconds)
./mame64 -bench 50 jedi -> Average speed: 375.08% (49 seconds)
After:
./mame64 -bench 50 missile -> Average speed: 1503.10% (49 seconds)
./mame64 -bench 50 starwars -> Average speed: 648.10% (49 seconds)
./mame64 -bench 50 jedi -> Average speed: 444.25% (49 seconds)

Signed-off-by: Andreas Müller <schnitzeltony@gmail.com>