### PR TITLE
kaneko_tmap.cpp : Updates / Cleanups

### DIFF
--- a/src/mame/drivers/expro02.cpp
+++ b/src/mame/drivers/expro02.cpp
@@ -225,14 +225,15 @@ public:
 	expro02_state(const machine_config &mconfig, device_type type, const char *tag) :
 		driver_device(mconfig, type, tag),
 		m_maincpu(*this, "maincpu"),
+		m_view2(*this, "view2"),
+		m_kaneko_spr(*this, "kan_spr"),
 		m_palette(*this, "palette"),
 		m_screen(*this, "screen"),
 		m_paletteram(*this, "palette"),
 		m_fg_ind8_pixram(*this, "fg_ind8ram"),
 		m_bg_rgb555_pixram(*this, "bg_rgb555ram"),
-		m_view2_0(*this, "view2_0"),
-		m_kaneko_spr(*this, "kan_spr"),
-		m_spriteram(*this, "spriteram")
+		m_spriteram(*this, "spriteram"),
+		m_okibank(*this, "okibank")
 	{ }
 
 	void supmodel(machine_config &config);
@@ -249,17 +250,25 @@ public:
 
 private:
 	required_device<cpu_device> m_maincpu;
+	optional_device<kaneko_view2_tilemap_device> m_view2;
+	required_device<kaneko16_sprite_device> m_kaneko_spr;
 	required_device<palette_device> m_palette;
 	required_device<screen_device> m_screen;
 
 	required_shared_ptr<uint16_t> m_paletteram;
 	required_shared_ptr<uint16_t> m_fg_ind8_pixram;
 	required_shared_ptr<uint16_t> m_bg_rgb555_pixram;
-	optional_device<kaneko_view2_tilemap_device> m_view2_0;
-	required_device<kaneko16_sprite_device> m_kaneko_spr;
 	required_shared_ptr<uint16_t> m_spriteram;
 
-	DECLARE_WRITE8_MEMBER(expro02_6295_bankswitch_w);
+	optional_memory_bank m_okibank;
+
+	uint16_t m_vram_tile_addition[2]; // galsnew
+
+	template<unsigned Layer> void tilebank_w(u8 data);
+
+	void tile_callback(u8 layer, u32 *code);
+
+	void oki_bankswitch_w(u8 data);
 
 	virtual void machine_start() override;
 	void expro02_palette(palette_device &palette) const;
@@ -285,10 +294,30 @@ private:
 	void zipzap_map(address_map &map);
 };
 
+/* some weird logic needed for Gals Panic on the EXPRO02 board */
+template<unsigned Layer>
+void expro02_state::tilebank_w(u8 data)
+{
+	int val = data << 8;
+
+	if (m_vram_tile_addition[Layer] != val)
+	{
+		m_vram_tile_addition[Layer] = val;
+		m_view2->mark_layer_dirty(Layer);
+	}
+}
+
+void expro02_state::tile_callback(u8 layer, u32 *code)
+{
+	u32 res = *code;
+	res += m_vram_tile_addition[layer];
+	*code = res;
+}
 
 void expro02_state::machine_start()
 {
-	membank("okibank")->configure_entries(0, 16, memregion("oki")->base(), 0x10000);
+	m_okibank->configure_entries(0, 16, memregion("oki")->base(), 0x10000);
+	save_item(NAME(m_vram_tile_addition));
 }
 
 void expro02_state::expro02_palette(palette_device &palette) const
@@ -346,12 +375,12 @@ uint32_t expro02_state::screen_update_backgrounds(screen_device &screen, bitmap_
 
 	screen.priority().fill(0, cliprect);
 
-	if (m_view2_0)
+	if (m_view2)
 	{
-		m_view2_0->kaneko16_prepare(bitmap, cliprect);
+		m_view2->prepare(bitmap, cliprect);
 
 		for (int i = 0; i < 8; i++)
-			m_view2_0->render_tilemap_chip(screen, bitmap, cliprect, i);
+			m_view2->render_tilemap(screen, bitmap, cliprect, i);
 	}
 
 	return 0;
@@ -640,9 +669,9 @@ INPUT_PORTS_END
  *
  *************************************/
 
-WRITE8_MEMBER( expro02_state::expro02_6295_bankswitch_w )
+void expro02_state::oki_bankswitch_w(u8 data)
 {
-	membank("okibank")->set_entry(data & 0x0f);
+	m_okibank->set_entry(data & 0x0f);
 }
 
 
@@ -657,13 +686,13 @@ void expro02_state::expro02_video_base_map(address_map &map)
 {
 	map(0x500000, 0x51ffff).ram().share("fg_ind8ram");
 	map(0x520000, 0x53ffff).ram().share("bg_rgb555ram");
-	map(0x580000, 0x583fff).rw(m_view2_0, FUNC(kaneko_view2_tilemap_device::kaneko_tmap_vram_r), FUNC(kaneko_view2_tilemap_device::kaneko_tmap_vram_w));
+	map(0x580000, 0x583fff).m(m_view2, FUNC(kaneko_view2_tilemap_device::vram_map));
 	map(0x600000, 0x600fff).ram().w(m_palette, FUNC(palette_device::write16)).share("palette"); // palette?
-	map(0x680000, 0x68001f).rw(m_view2_0, FUNC(kaneko_view2_tilemap_device::kaneko_tmap_regs_r), FUNC(kaneko_view2_tilemap_device::kaneko_tmap_regs_w));
+	map(0x680000, 0x68001f).rw(m_view2, FUNC(kaneko_view2_tilemap_device::regs_r), FUNC(kaneko_view2_tilemap_device::regs_w));
 	map(0x700000, 0x700fff).ram().share("spriteram");    // sprites? 0x72f words tested
 	map(0x780000, 0x78001f).rw(m_kaneko_spr, FUNC(kaneko16_sprite_device::kaneko16_sprites_regs_r), FUNC(kaneko16_sprite_device::kaneko16_sprites_regs_w));
-	map(0xd80000, 0xd80001).w(m_view2_0, FUNC(kaneko_view2_tilemap_device::galsnew_vram_1_tilebank_w));   /* ??? */
-	map(0xe80000, 0xe80001).w(m_view2_0, FUNC(kaneko_view2_tilemap_device::galsnew_vram_0_tilebank_w));   /* ??? */
+	map(0xd80001, 0xd80001).w(FUNC(expro02_state::tilebank_w<1>));   /* ??? */
+	map(0xe80001, 0xe80001).w(FUNC(expro02_state::tilebank_w<0>));   /* ??? */
 }
 
 void expro02_state::expro02_video_base_map_noview2(address_map &map)
@@ -689,7 +718,7 @@ void expro02_state::expro02_map(address_map &map)
 	map(0x800000, 0x800001).portr("DSW1");
 	map(0x800002, 0x800003).portr("DSW2");
 	map(0x800004, 0x800005).portr("SYSTEM");
-	map(0x900000, 0x900000).w(FUNC(expro02_state::expro02_6295_bankswitch_w));
+	map(0x900000, 0x900000).w(FUNC(expro02_state::oki_bankswitch_w));
 	map(0xa00000, 0xa00001).nopw();    /* ??? */
 	map(0xc80000, 0xc8ffff).ram();
 	map(0xe00000, 0xe00015).rw("calc1_mcu", FUNC(kaneko_hit_device::kaneko_hit_r), FUNC(kaneko_hit_device::kaneko_hit_w));
@@ -705,7 +734,7 @@ void expro02_state::fantasia_map(address_map &map)
 	map(0x800002, 0x800003).portr("DSW2");
 	map(0x800004, 0x800005).portr("SYSTEM");
 	map(0x800006, 0x800007).noprw(); // ? used ?
-	map(0x900000, 0x900000).w(FUNC(expro02_state::expro02_6295_bankswitch_w));
+	map(0x900000, 0x900000).w(FUNC(expro02_state::oki_bankswitch_w));
 	map(0xa00000, 0xa00001).nopw();    /* ??? */
 	map(0xc80000, 0xc8ffff).ram();
 	map(0xf00000, 0xf00000).rw("oki", FUNC(okim6295_device::read), FUNC(okim6295_device::write));
@@ -723,7 +752,7 @@ void expro02_state::comad_map(address_map &map)
 //  map(0x800006, 0x800007);    ??
 	map(0x80000a, 0x80000b).r(FUNC(expro02_state::comad_timer_r)); /* bits 8-a = timer? palette update code waits for them to be 111 */
 	map(0x80000c, 0x80000d).r(FUNC(expro02_state::comad_timer_r)); /* missw96 bits 8-a = timer? palette update code waits for them to be 111 */
-	map(0x900000, 0x900000).w(FUNC(expro02_state::expro02_6295_bankswitch_w));  /* not sure */
+	map(0x900000, 0x900000).w(FUNC(expro02_state::oki_bankswitch_w));  /* not sure */
 	map(0xc00000, 0xc0ffff).ram();
 	map(0xc80000, 0xc8ffff).ram();
 	map(0xf00000, 0xf00000).r(FUNC(expro02_state::comad_okim6295_r)).w("oki", FUNC(okim6295_device::write)); /* fantasia, missw96 */
@@ -739,7 +768,7 @@ void expro02_state::fantsia2_map(address_map &map)
 	map(0x800004, 0x800005).portr("SYSTEM");
 //  map(0x800006, 0x800007);    ??
 	map(0x800008, 0x800009).r(FUNC(expro02_state::comad_timer_r)); /* bits 8-a = timer? palette update code waits for them to be 111 */
-	map(0x900000, 0x900000).w(FUNC(expro02_state::expro02_6295_bankswitch_w));  /* not sure */
+	map(0x900000, 0x900000).w(FUNC(expro02_state::oki_bankswitch_w));  /* not sure */
 	map(0xa00000, 0xa00001).nopw();    /* coin counters, + ? */
 	map(0xc80000, 0xc80000).r(FUNC(expro02_state::comad_okim6295_r)).w("oki", FUNC(okim6295_device::write));
 	map(0xf80000, 0xf8ffff).ram();
@@ -758,7 +787,7 @@ void expro02_state::galhustl_map(address_map &map)
 	map(0x800000, 0x800001).portr("DSW1");
 	map(0x800002, 0x800003).portr("DSW2");
 	map(0x800004, 0x800005).portr("SYSTEM");
-	map(0x900000, 0x900000).w(FUNC(expro02_state::expro02_6295_bankswitch_w));
+	map(0x900000, 0x900000).w(FUNC(expro02_state::oki_bankswitch_w));
 	map(0xa00000, 0xa00001).nopw(); // ?
 	map(0xd00000, 0xd00000).rw("oki", FUNC(okim6295_device::read), FUNC(okim6295_device::write));
 	map(0xe80000, 0xe8ffff).ram();
@@ -775,7 +804,7 @@ void expro02_state::zipzap_map(address_map &map)
 	map(0x800000, 0x800001).portr("DSW1");
 	map(0x800002, 0x800003).portr("DSW2");
 	map(0x800004, 0x800005).portr("SYSTEM");
-	map(0x900000, 0x900000).w(FUNC(expro02_state::expro02_6295_bankswitch_w));
+	map(0x900000, 0x900000).w(FUNC(expro02_state::oki_bankswitch_w));
 	map(0xc00000, 0xc00000).r(FUNC(expro02_state::comad_okim6295_r)).w("oki", FUNC(okim6295_device::write)); /* fantasia, missw96 */
 	map(0xc80000, 0xc8ffff).ram();     // main ram
 
@@ -792,7 +821,7 @@ void expro02_state::supmodel_map(address_map &map)
 	map(0x800004, 0x800005).portr("SYSTEM");
 	map(0x800006, 0x800007).r(FUNC(expro02_state::comad_timer_r));
 	map(0x800008, 0x800009).r(FUNC(expro02_state::comad_timer_r));
-	map(0x900000, 0x900000).w(FUNC(expro02_state::expro02_6295_bankswitch_w));  /* not sure */
+	map(0x900000, 0x900000).w(FUNC(expro02_state::oki_bankswitch_w));  /* not sure */
 	map(0xa00000, 0xa00001).nopw();
 	map(0xc80000, 0xc8ffff).ram();
 	map(0xd80000, 0xd80001).nopw();
@@ -811,7 +840,7 @@ void expro02_state::smissw_map(address_map &map)
 	map(0x800004, 0x800005).portr("SYSTEM");
 	map(0x800006, 0x800007).r(FUNC(expro02_state::comad_timer_r));
 	map(0x80000e, 0x80000f).r(FUNC(expro02_state::comad_timer_r));
-	map(0x900000, 0x900000).w(FUNC(expro02_state::expro02_6295_bankswitch_w));  /* not sure */
+	map(0x900000, 0x900000).w(FUNC(expro02_state::oki_bankswitch_w));  /* not sure */
 	map(0xa00000, 0xa00001).nopw();
 	map(0xc00000, 0xc0ffff).ram();
 	map(0xd80000, 0xd80001).nopw();
@@ -902,7 +931,7 @@ GFXDECODE_END
 void expro02_state::expro02(machine_config &config)
 {
 	/* basic machine hardware */
-	M68000(config, m_maincpu, 12000000);
+	M68000(config, m_maincpu, 12_MHz_XTAL);
 	m_maincpu->set_addrmap(AS_PROGRAM, &expro02_state::expro02_map);
 	TIMER(config, "scantimer").configure_scanline(FUNC(expro02_state::scanline), "screen", 0, 1);
 
@@ -920,10 +949,11 @@ void expro02_state::expro02(machine_config &config)
 	GFXDECODE(config, "gfxdecode", m_palette, gfx_expro02);
 	PALETTE(config, m_palette, FUNC(expro02_state::expro02_palette)).set_format(palette_device::GRBx_555, 2048 + 32768);
 
-	KANEKO_TMAP(config, m_view2_0);
-	m_view2_0->set_gfx_region(1);
-	m_view2_0->set_offset(0x5b, 0x8, 256, 224);
-	m_view2_0->set_gfxdecode_tag("gfxdecode");
+	KANEKO_TMAP(config, m_view2);
+	m_view2->set_gfx_region(1);
+	m_view2->set_offset(0x5b, 0x8, 256, 224);
+	m_view2->set_gfxdecode_tag("gfxdecode");
+	m_view2->set_tile_callback(kaneko_view2_tilemap_device::view2_cb_delegate(FUNC(expro02_state::tile_callback), this));
 
 	KANEKO_VU002_SPRITE(config, m_kaneko_spr);
 	m_kaneko_spr->set_priorities(8,8,8,8); // above all (not verified)
@@ -954,8 +984,8 @@ void expro02_state::comad(machine_config &config)
 	config.device_remove("calc1_mcu");
 
 	// these values might not be correct, behavior differs from original boards
-	m_view2_0->set_invert_flip(1);
-	m_view2_0->set_offset(-256, -216, 256, 224);
+	m_view2->set_invert_flip(1);
+	m_view2->set_offset(-256, -216, 256, 224);
 
 	subdevice<watchdog_timer_device>("watchdog")->set_time(attotime::from_seconds(0));  /* a guess, and certainly wrong */
 }
@@ -964,7 +994,7 @@ void expro02_state::comad_noview2(machine_config &config)
 {
 	comad(config);
 
-	config.device_remove("view2_0");
+	config.device_remove("view2");
 
 	subdevice<gfxdecode_device>("gfxdecode")->set_info(gfx_expro02_noview2);
 }

--- a/src/mame/drivers/jchan.cpp
+++ b/src/mame/drivers/jchan.cpp
@@ -299,11 +299,11 @@ uint32_t jchan_state::screen_update(screen_device &screen, bitmap_ind16 &bitmap,
 
 	screen.priority().fill(0, cliprect);
 
-	m_view2->kaneko16_prepare(bitmap, cliprect);
+	m_view2->prepare(bitmap, cliprect);
 
 	for (int i = 0; i < 8; i++)
 	{
-		m_view2->render_tilemap_chip(screen,bitmap,cliprect,i);
+		m_view2->render_tilemap(screen,bitmap,cliprect,i);
 	}
 
 	for (int chip = 0; chip < 2; chip++)
@@ -486,8 +486,8 @@ void jchan_state::jchan_sub(address_map &map)
 	map(0x400000, 0x403fff).ram().share("mainsub_shared");
 
 	/* VIEW2 Tilemap - [D] grid tested, cleared ($1d84), also cleared at startup ($810-$826) */
-	map(0x500000, 0x503fff).rw(m_view2, FUNC(kaneko_view2_tilemap_device::kaneko_tmap_vram_r), FUNC(kaneko_view2_tilemap_device::kaneko_tmap_vram_w));
-	map(0x600000, 0x60001f).rw(m_view2, FUNC(kaneko_view2_tilemap_device::kaneko_tmap_regs_r), FUNC(kaneko_view2_tilemap_device::kaneko_tmap_regs_w));
+	map(0x500000, 0x503fff).m(m_view2, FUNC(kaneko_view2_tilemap_device::vram_map));
+	map(0x600000, 0x60001f).rw(m_view2, FUNC(kaneko_view2_tilemap_device::regs_r), FUNC(kaneko_view2_tilemap_device::regs_w));
 
 	/* background sprites */
 	map(0x700000, 0x703fff).ram().w(FUNC(jchan_state::sknsspr_sprite32_w<1>)).share("spriteram_2");
@@ -510,7 +510,7 @@ static const gfx_layout tilelayout =
 	32*32
 };
 
-// we don't decode the sprites, they are non-tile based and RLE encoded!, see suprnova.cpp */
+// we don't decode the sprites, they are non-tile based and RLE encoded!, see sknsspr.cpp */
 
 static GFXDECODE_START( gfx_jchan )
 	GFXDECODE_ENTRY( "gfx3", 0, tilelayout,   0, 0x4000/16  )

--- a/src/mame/drivers/kaneko16.cpp
+++ b/src/mame/drivers/kaneko16.cpp
@@ -310,8 +310,8 @@ void kaneko16_berlwall_state::berlwall_map(address_map &map)
 	map(0x800200, 0x80021f).rw(FUNC(kaneko16_berlwall_state::kaneko16_ay_YM2149_r<1>), FUNC(kaneko16_berlwall_state::kaneko16_ay_YM2149_w<1>));
 	map(0x8003fe, 0x8003ff).noprw(); // for OKI when accessed as .l
 	map(0x800400, 0x800401).rw(FUNC(kaneko16_berlwall_state::berlwall_oki_r), FUNC(kaneko16_berlwall_state::berlwall_oki_w));
-	map(0xc00000, 0xc03fff).rw("view2_0", FUNC(kaneko_view2_tilemap_device::kaneko_tmap_vram_r), FUNC(kaneko_view2_tilemap_device::kaneko_tmap_vram_w));
-	map(0xd00000, 0xd0001f).rw("view2_0", FUNC(kaneko_view2_tilemap_device::kaneko_tmap_regs_r), FUNC(kaneko_view2_tilemap_device::kaneko_tmap_regs_w));
+	map(0xc00000, 0xc03fff).m(m_view2[0], FUNC(kaneko_view2_tilemap_device::vram_map));
+	map(0xd00000, 0xd0001f).rw(m_view2[0], FUNC(kaneko_view2_tilemap_device::regs_r), FUNC(kaneko_view2_tilemap_device::regs_w));
 }
 
 
@@ -332,14 +332,14 @@ void kaneko16_state::bakubrkr_map(address_map &map)
 	map(0x40001f, 0x40001f).w(FUNC(kaneko16_state::oki_bank0_w<7>)); // OKI bank Switch
 	map(0x400200, 0x40021f).rw(FUNC(kaneko16_state::kaneko16_ay_YM2149_r<1>), FUNC(kaneko16_state::kaneko16_ay_YM2149_w<1>));          // Sound
 	map(0x400401, 0x400401).rw("oki1", FUNC(okim6295_device::read), FUNC(okim6295_device::write));  //
-	map(0x500000, 0x503fff).rw("view2_0", FUNC(kaneko_view2_tilemap_device::kaneko_tmap_vram_r), FUNC(kaneko_view2_tilemap_device::kaneko_tmap_vram_w));
-	map(0x580000, 0x583fff).rw("view2_1", FUNC(kaneko_view2_tilemap_device::kaneko_tmap_vram_r), FUNC(kaneko_view2_tilemap_device::kaneko_tmap_vram_w));
+	map(0x500000, 0x503fff).m(m_view2[0], FUNC(kaneko_view2_tilemap_device::vram_map));
+	map(0x580000, 0x583fff).m(m_view2[1], FUNC(kaneko_view2_tilemap_device::vram_map));
 	map(0x600000, 0x601fff).ram().share("spriteram");                   // Sprites
 	map(0x700000, 0x700fff).ram().w(m_palette, FUNC(palette_device::write16)).share("palette");    // Palette
-	map(0x800000, 0x80001f).rw("view2_0", FUNC(kaneko_view2_tilemap_device::kaneko_tmap_regs_r), FUNC(kaneko_view2_tilemap_device::kaneko_tmap_regs_w));
+	map(0x800000, 0x80001f).rw(m_view2[0], FUNC(kaneko_view2_tilemap_device::regs_r), FUNC(kaneko_view2_tilemap_device::regs_w));
 	map(0x900000, 0x90001f).rw(m_kaneko_spr, FUNC(kaneko16_sprite_device::kaneko16_sprites_regs_r), FUNC(kaneko16_sprite_device::kaneko16_sprites_regs_w));
 	map(0xa80000, 0xa80001).r("watchdog", FUNC(watchdog_timer_device::reset16_r));
-	map(0xb00000, 0xb0001f).rw("view2_1", FUNC(kaneko_view2_tilemap_device::kaneko_tmap_regs_r), FUNC(kaneko_view2_tilemap_device::kaneko_tmap_regs_w));
+	map(0xb00000, 0xb0001f).rw(m_view2[1], FUNC(kaneko_view2_tilemap_device::regs_r), FUNC(kaneko_view2_tilemap_device::regs_w));
 	map(0xd00000, 0xd00001).w(FUNC(kaneko16_state::kaneko16_eeprom_w));    // EEPROM
 	map(0xe00000, 0xe00001).portr("P1");
 	map(0xe00002, 0xe00003).portr("P2");
@@ -357,9 +357,9 @@ void kaneko16_state::blazeon_map(address_map &map)
 	map(0x000000, 0x0fffff).rom();     // ROM
 	map(0x300000, 0x30ffff).ram();     // Work RAM
 	map(0x500000, 0x500fff).ram().w(m_palette, FUNC(palette_device::write16)).share("palette");    // Palette
-	map(0x600000, 0x603fff).rw("view2_0", FUNC(kaneko_view2_tilemap_device::kaneko_tmap_vram_r), FUNC(kaneko_view2_tilemap_device::kaneko_tmap_vram_w));
+	map(0x600000, 0x603fff).m(m_view2[0], FUNC(kaneko_view2_tilemap_device::vram_map));
 	map(0x700000, 0x700fff).ram().share("spriteram");                   // Sprites
-	map(0x800000, 0x80001f).rw("view2_0", FUNC(kaneko_view2_tilemap_device::kaneko_tmap_regs_r), FUNC(kaneko_view2_tilemap_device::kaneko_tmap_regs_w));
+	map(0x800000, 0x80001f).rw(m_view2[0], FUNC(kaneko_view2_tilemap_device::regs_r), FUNC(kaneko_view2_tilemap_device::regs_w));
 	map(0x900000, 0x90001f).rw(m_kaneko_spr, FUNC(kaneko16_sprite_device::kaneko16_sprites_regs_r), FUNC(kaneko16_sprite_device::kaneko16_sprites_regs_w));
 	map(0x980000, 0x98001f).ram();                                                                             // Sprites Regs #2
 	map(0xc00000, 0xc00001).portr("DSW2_P1");
@@ -401,10 +401,10 @@ void kaneko16_gtmr_state::bloodwar_map(address_map &map)
 	map(0x2d0000, 0x2d0001).w("toybox", FUNC(kaneko_toybox_device::mcu_com3_w));
 	map(0x300000, 0x30ffff).ram().w(m_palette, FUNC(palette_device::write16)).share("palette");    // Palette
 	map(0x400000, 0x401fff).ram().share("spriteram");                   // Sprites
-	map(0x500000, 0x503fff).rw("view2_0", FUNC(kaneko_view2_tilemap_device::kaneko_tmap_vram_r), FUNC(kaneko_view2_tilemap_device::kaneko_tmap_vram_w));
-	map(0x580000, 0x583fff).rw("view2_1", FUNC(kaneko_view2_tilemap_device::kaneko_tmap_vram_r), FUNC(kaneko_view2_tilemap_device::kaneko_tmap_vram_w));
-	map(0x600000, 0x60001f).rw("view2_0", FUNC(kaneko_view2_tilemap_device::kaneko_tmap_regs_r), FUNC(kaneko_view2_tilemap_device::kaneko_tmap_regs_w));
-	map(0x680000, 0x68001f).rw("view2_1", FUNC(kaneko_view2_tilemap_device::kaneko_tmap_regs_r), FUNC(kaneko_view2_tilemap_device::kaneko_tmap_regs_w));
+	map(0x500000, 0x503fff).m(m_view2[0], FUNC(kaneko_view2_tilemap_device::vram_map));
+	map(0x580000, 0x583fff).m(m_view2[1], FUNC(kaneko_view2_tilemap_device::vram_map));
+	map(0x600000, 0x60001f).rw(m_view2[0], FUNC(kaneko_view2_tilemap_device::regs_r), FUNC(kaneko_view2_tilemap_device::regs_w));
+	map(0x680000, 0x68001f).rw(m_view2[1], FUNC(kaneko_view2_tilemap_device::regs_r), FUNC(kaneko_view2_tilemap_device::regs_w));
 	map(0x700000, 0x70001f).rw(m_kaneko_spr, FUNC(kaneko16_sprite_device::kaneko16_sprites_regs_r), FUNC(kaneko16_sprite_device::kaneko16_sprites_regs_w));
 	map(0x800001, 0x800001).rw("oki1", FUNC(okim6295_device::read), FUNC(okim6295_device::write));
 	map(0x880001, 0x880001).rw("oki2", FUNC(okim6295_device::read), FUNC(okim6295_device::write));
@@ -437,10 +437,10 @@ void kaneko16_gtmr_state::bonkadv_map(address_map &map)
 	map(0x2d0000, 0x2d0001).w("toybox", FUNC(kaneko_toybox_device::mcu_com3_w));
 	map(0x300000, 0x30ffff).ram().w(m_palette, FUNC(palette_device::write16)).share("palette");    // Palette
 	map(0x400000, 0x401fff).ram().share("spriteram");                   // Sprites
-	map(0x500000, 0x503fff).rw("view2_0", FUNC(kaneko_view2_tilemap_device::kaneko_tmap_vram_r), FUNC(kaneko_view2_tilemap_device::kaneko_tmap_vram_w));
-	map(0x580000, 0x583fff).rw("view2_1", FUNC(kaneko_view2_tilemap_device::kaneko_tmap_vram_r), FUNC(kaneko_view2_tilemap_device::kaneko_tmap_vram_w));
-	map(0x600000, 0x60001f).rw("view2_0", FUNC(kaneko_view2_tilemap_device::kaneko_tmap_regs_r), FUNC(kaneko_view2_tilemap_device::kaneko_tmap_regs_w));
-	map(0x680000, 0x68001f).rw("view2_1", FUNC(kaneko_view2_tilemap_device::kaneko_tmap_regs_r), FUNC(kaneko_view2_tilemap_device::kaneko_tmap_regs_w));
+	map(0x500000, 0x503fff).m(m_view2[0], FUNC(kaneko_view2_tilemap_device::vram_map));
+	map(0x580000, 0x583fff).m(m_view2[1], FUNC(kaneko_view2_tilemap_device::vram_map));
+	map(0x600000, 0x60001f).rw(m_view2[0], FUNC(kaneko_view2_tilemap_device::regs_r), FUNC(kaneko_view2_tilemap_device::regs_w));
+	map(0x680000, 0x68001f).rw(m_view2[1], FUNC(kaneko_view2_tilemap_device::regs_r), FUNC(kaneko_view2_tilemap_device::regs_w));
 	map(0x700000, 0x70001f).rw(m_kaneko_spr, FUNC(kaneko16_sprite_device::kaneko16_sprites_regs_r), FUNC(kaneko16_sprite_device::kaneko16_sprites_regs_w));
 	map(0x800001, 0x800001).rw("oki1", FUNC(okim6295_device::read), FUNC(okim6295_device::write));
 	map(0x880001, 0x880001).rw("oki2", FUNC(okim6295_device::read), FUNC(okim6295_device::write));
@@ -494,11 +494,11 @@ void kaneko16_gtmr_state::gtmr_map(address_map &map)
 	map(0x310000, 0x327fff).ram();                                                                     //
 	map(0x400000, 0x401fff).ram().share(m_spriteram);                       // Sprites
 
-	map(0x500000, 0x503fff).rw(m_view2[0], FUNC(kaneko_view2_tilemap_device::kaneko_tmap_vram_r), FUNC(kaneko_view2_tilemap_device::kaneko_tmap_vram_w));
-	map(0x580000, 0x583fff).rw(m_view2[1], FUNC(kaneko_view2_tilemap_device::kaneko_tmap_vram_r), FUNC(kaneko_view2_tilemap_device::kaneko_tmap_vram_w));
+	map(0x500000, 0x503fff).m(m_view2[0], FUNC(kaneko_view2_tilemap_device::vram_map));
+	map(0x580000, 0x583fff).m(m_view2[1], FUNC(kaneko_view2_tilemap_device::vram_map));
 
-	map(0x600000, 0x60000f).rw(m_view2[0], FUNC(kaneko_view2_tilemap_device::kaneko_tmap_regs_r), FUNC(kaneko_view2_tilemap_device::kaneko_tmap_regs_w));
-	map(0x680000, 0x68001f).rw(m_view2[1], FUNC(kaneko_view2_tilemap_device::kaneko_tmap_regs_r), FUNC(kaneko_view2_tilemap_device::kaneko_tmap_regs_w));
+	map(0x600000, 0x60000f).rw(m_view2[0], FUNC(kaneko_view2_tilemap_device::regs_r), FUNC(kaneko_view2_tilemap_device::regs_w));
+	map(0x680000, 0x68001f).rw(m_view2[1], FUNC(kaneko_view2_tilemap_device::regs_r), FUNC(kaneko_view2_tilemap_device::regs_w));
 
 	map(0x700000, 0x70001f).rw(m_kaneko_spr, FUNC(kaneko16_sprite_device::kaneko16_sprites_regs_r), FUNC(kaneko16_sprite_device::kaneko16_sprites_regs_w));
 
@@ -564,10 +564,10 @@ void kaneko16_gtmr_state::gtmr2_map(address_map &map)
 	map(0x310000, 0x327fff).ram(); //
 	map(0x400000, 0x401fff).ram().share(m_spriteram); // Sprites
 
-	map(0x500000, 0x503fff).rw(m_view2[0], FUNC(kaneko_view2_tilemap_device::kaneko_tmap_vram_r), FUNC(kaneko_view2_tilemap_device::kaneko_tmap_vram_w));
-	map(0x580000, 0x583fff).rw(m_view2[1], FUNC(kaneko_view2_tilemap_device::kaneko_tmap_vram_r), FUNC(kaneko_view2_tilemap_device::kaneko_tmap_vram_w));
-	map(0x600000, 0x60000f).rw(m_view2[0], FUNC(kaneko_view2_tilemap_device::kaneko_tmap_regs_r), FUNC(kaneko_view2_tilemap_device::kaneko_tmap_regs_w));
-	map(0x680000, 0x68001f).rw(m_view2[1], FUNC(kaneko_view2_tilemap_device::kaneko_tmap_regs_r), FUNC(kaneko_view2_tilemap_device::kaneko_tmap_regs_w));
+	map(0x500000, 0x503fff).m(m_view2[0], FUNC(kaneko_view2_tilemap_device::vram_map));
+	map(0x580000, 0x583fff).m(m_view2[1], FUNC(kaneko_view2_tilemap_device::vram_map));
+	map(0x600000, 0x60000f).rw(m_view2[0], FUNC(kaneko_view2_tilemap_device::regs_r), FUNC(kaneko_view2_tilemap_device::regs_w));
+	map(0x680000, 0x68001f).rw(m_view2[1], FUNC(kaneko_view2_tilemap_device::regs_r), FUNC(kaneko_view2_tilemap_device::regs_w));
 
 	map(0x700000, 0x70001f).rw(m_kaneko_spr, FUNC(kaneko16_sprite_device::kaneko16_sprites_regs_r), FUNC(kaneko16_sprite_device::kaneko16_sprites_regs_w));
 	map(0x800001, 0x800001).rw(m_oki[0], FUNC(okim6295_device::read), FUNC(okim6295_device::write)); // Samples
@@ -602,12 +602,12 @@ void kaneko16_state::mgcrystl_map(address_map &map)
 	map(0x400200, 0x40021f).rw(FUNC(kaneko16_state::kaneko16_ay_YM2149_r<1>), FUNC(kaneko16_state::kaneko16_ay_YM2149_w<1>));
 	map(0x400401, 0x400401).rw(m_oki[0], FUNC(okim6295_device::read), FUNC(okim6295_device::write));
 	map(0x500000, 0x500fff).ram().w(m_palette, FUNC(palette_device::write16)).share("palette");    // Palette
-	map(0x600000, 0x603fff).rw(m_view2[0], FUNC(kaneko_view2_tilemap_device::kaneko_tmap_vram_r), FUNC(kaneko_view2_tilemap_device::kaneko_tmap_vram_w));
-	map(0x680000, 0x683fff).rw(m_view2[1], FUNC(kaneko_view2_tilemap_device::kaneko_tmap_vram_r), FUNC(kaneko_view2_tilemap_device::kaneko_tmap_vram_w));
+	map(0x600000, 0x603fff).m(m_view2[0], FUNC(kaneko_view2_tilemap_device::vram_map));
+	map(0x680000, 0x683fff).m(m_view2[1], FUNC(kaneko_view2_tilemap_device::vram_map));
 	map(0x700000, 0x701fff).ram().share("spriteram");                   // Sprites
-	map(0x800000, 0x80001f).rw(m_view2[0], FUNC(kaneko_view2_tilemap_device::kaneko_tmap_regs_r), FUNC(kaneko_view2_tilemap_device::kaneko_tmap_regs_w));
+	map(0x800000, 0x80001f).rw(m_view2[0], FUNC(kaneko_view2_tilemap_device::regs_r), FUNC(kaneko_view2_tilemap_device::regs_w));
 	map(0x900000, 0x90001f).rw(m_kaneko_spr, FUNC(kaneko16_sprite_device::kaneko16_sprites_regs_r), FUNC(kaneko16_sprite_device::kaneko16_sprites_regs_w));
-	map(0xb00000, 0xb0001f).rw(m_view2[1], FUNC(kaneko_view2_tilemap_device::kaneko_tmap_regs_r), FUNC(kaneko_view2_tilemap_device::kaneko_tmap_regs_w));
+	map(0xb00000, 0xb0001f).rw(m_view2[1], FUNC(kaneko_view2_tilemap_device::regs_r), FUNC(kaneko_view2_tilemap_device::regs_w));
 	map(0xa00000, 0xa00001).r(m_watchdog, FUNC(watchdog_timer_device::reset16_r));    // Watchdog
 	map(0xc00000, 0xc00001).portr("DSW_P1");
 	map(0xc00002, 0xc00003).portr("P2");
@@ -644,8 +644,8 @@ void kaneko16_shogwarr_state::shogwarr_map(address_map &map)
 	map(0x400001, 0x400001).rw(m_oki[0], FUNC(okim6295_device::read), FUNC(okim6295_device::write)); // Samples
 	map(0x480001, 0x480001).rw(m_oki[1], FUNC(okim6295_device::read), FUNC(okim6295_device::write));
 	map(0x580000, 0x581fff).ram().share("spriteram");                   // Sprites
-	map(0x600000, 0x603fff).rw(m_view2[0], FUNC(kaneko_view2_tilemap_device::kaneko_tmap_vram_r), FUNC(kaneko_view2_tilemap_device::kaneko_tmap_vram_w));
-	map(0x800000, 0x80001f).rw(m_view2[0], FUNC(kaneko_view2_tilemap_device::kaneko_tmap_regs_r), FUNC(kaneko_view2_tilemap_device::kaneko_tmap_regs_w));
+	map(0x600000, 0x603fff).m(m_view2[0], FUNC(kaneko_view2_tilemap_device::vram_map));
+	map(0x800000, 0x80001f).rw(m_view2[0], FUNC(kaneko_view2_tilemap_device::regs_r), FUNC(kaneko_view2_tilemap_device::regs_w));
 	map(0x900000, 0x90001f).rw(m_kaneko_spr, FUNC(kaneko16_sprite_device::kaneko16_sprites_regs_r), FUNC(kaneko16_sprite_device::kaneko16_sprites_regs_w));
 	map(0xa00000, 0xa0007f).rw(m_kaneko_hit, FUNC(kaneko_hit_device::kaneko_hit_r), FUNC(kaneko_hit_device::kaneko_hit_w));
 	map(0xa80000, 0xa80001).rw(m_watchdog, FUNC(watchdog_timer_device::reset16_r), FUNC(watchdog_timer_device::reset16_w));

--- a/src/mame/drivers/sandscrp.cpp
+++ b/src/mame/drivers/sandscrp.cpp
@@ -146,11 +146,11 @@ uint32_t sandscrp_state::screen_update(screen_device &screen, bitmap_ind16 &bitm
 
 	screen.priority().fill(0, cliprect);
 
-	m_view2->kaneko16_prepare(bitmap, cliprect);
+	m_view2->prepare(bitmap, cliprect);
 
 	for ( int l = 0; l < 4; l++ )
 	{
-		m_view2->render_tilemap_chip(screen,bitmap,cliprect,l);
+		m_view2->render_tilemap(screen,bitmap,cliprect,l);
 	}
 
 	// copy sprite bitmap to screen
@@ -158,7 +158,7 @@ uint32_t sandscrp_state::screen_update(screen_device &screen, bitmap_ind16 &bitm
 
 	for ( int h = 4; h < 8; h++ ) // high bit of tile priority : above sprites
 	{
-		m_view2->render_tilemap_chip(screen,bitmap,cliprect,h);
+		m_view2->render_tilemap(screen,bitmap,cliprect,h);
 	}
 
 	return 0;
@@ -285,8 +285,8 @@ void sandscrp_state::sandscrp_mem(address_map &map)
 
 	map(0x700000, 0x70ffff).ram();     // RAM
 	map(0x200000, 0x20001f).rw("calc1_mcu", FUNC(kaneko_hit_device::kaneko_hit_r), FUNC(kaneko_hit_device::kaneko_hit_w));
-	map(0x300000, 0x30001f).rw(m_view2, FUNC(kaneko_view2_tilemap_device::kaneko_tmap_regs_r), FUNC(kaneko_view2_tilemap_device::kaneko_tmap_regs_w));
-	map(0x400000, 0x403fff).rw(m_view2, FUNC(kaneko_view2_tilemap_device::kaneko_tmap_vram_r), FUNC(kaneko_view2_tilemap_device::kaneko_tmap_vram_w));
+	map(0x300000, 0x30001f).rw(m_view2, FUNC(kaneko_view2_tilemap_device::regs_r), FUNC(kaneko_view2_tilemap_device::regs_w));
+	map(0x400000, 0x403fff).m(m_view2, FUNC(kaneko_view2_tilemap_device::vram_map));
 	map(0x500000, 0x501fff).rw(m_pandora, FUNC(kaneko_pandora_device::spriteram_LSB_r), FUNC(kaneko_pandora_device::spriteram_LSB_w)); // sprites
 	map(0x600000, 0x600fff).ram().w("palette", FUNC(palette_device::write16)).share("palette");    // Palette
 	map(0xa00000, 0xa00001).w(FUNC(sandscrp_state::coincounter_w));  // Coin Counters (Lockout unused)

--- a/src/mame/video/kaneko16.cpp
+++ b/src/mame/video/kaneko16.cpp
@@ -61,19 +61,17 @@ void kaneko16_state::kaneko16_fill_bitmap(_BitmapClass &bitmap, const rectangle 
 template<class _BitmapClass>
 uint32_t kaneko16_state::screen_update_common(screen_device &screen, _BitmapClass &bitmap, const rectangle &cliprect)
 {
-	int i;
-
 	screen.priority().fill(0, cliprect);
 
-	if (m_view2[0].found()) m_view2[0]->kaneko16_prepare(bitmap, cliprect);
-	if (m_view2[1].found()) m_view2[1]->kaneko16_prepare(bitmap, cliprect);
+	if (m_view2[0].found()) m_view2[0]->prepare(bitmap, cliprect);
+	if (m_view2[1].found()) m_view2[1]->prepare(bitmap, cliprect);
 
-	for ( i = 0; i < 8; i++ )
+	for (int i = 0; i < 8; i++)
 	{
 		if (m_view2[0].found())
-			m_view2[0]->render_tilemap_chip(screen,bitmap,cliprect,i);
+			m_view2[0]->render_tilemap(screen,bitmap,cliprect,i);
 		if (m_view2[1].found())
-			m_view2[1]->render_tilemap_chip_alt(screen,bitmap,cliprect,i, m_VIEW2_2_pri);
+			m_view2[1]->render_tilemap_alt(screen,bitmap,cliprect,i, m_VIEW2_2_pri);
 	}
 
 	return 0;
@@ -100,7 +98,7 @@ uint32_t kaneko16_state::screen_update_kaneko16(screen_device &screen, bitmap_in
 
 
 
-/* Berlwall and Gals Panic have an additional hi-color layers */
+/* berlwall have an additional hi-color layers */
 
 VIDEO_START_MEMBER(kaneko16_berlwall_state,berlwall)
 {
@@ -124,11 +122,10 @@ VIDEO_START_MEMBER(kaneko16_berlwall_state,berlwall)
 			{
 				int addr  = screen * (256 * 256) + x + y * 256;
 				int data = RAM[addr * 2 + 0] * 256 + RAM[addr * 2 + 1];
-				int r,g,b;
 
-				r = (data & 0x07c0) >>  6;
-				g = (data & 0xf800) >> 11;
-				b = (data & 0x003e) >>  1;
+				int r = (data & 0x07c0) >>  6;
+				int g = (data & 0xf800) >> 11;
+				int b = (data & 0x003e) >>  1;
 
 				/* apply a simple decryption */
 				r ^= 0x09;

--- a/src/mame/video/kaneko_tmap.h
+++ b/src/mame/video/kaneko_tmap.h
@@ -5,17 +5,15 @@
 
 #pragma once
 
-
-
 class kaneko_view2_tilemap_device : public device_t
 {
 public:
 	kaneko_view2_tilemap_device(const machine_config &mconfig, const char *tag, device_t *owner)
-		: kaneko_view2_tilemap_device(mconfig, tag, owner, (uint32_t)0)
+		: kaneko_view2_tilemap_device(mconfig, tag, owner, (u32)0)
 	{
 	}
 
-	kaneko_view2_tilemap_device(const machine_config &mconfig, const char *tag, device_t *owner, uint32_t clock);
+	kaneko_view2_tilemap_device(const machine_config &mconfig, const char *tag, device_t *owner, u32 clock);
 
 	// configuration
 	template <typename T> void set_gfxdecode_tag(T &&tag) { m_gfxdecode.set_tag(std::forward<T>(tag)); }
@@ -29,56 +27,55 @@ public:
 	}
 	void set_invert_flip(int invert_flip) { m_invert_flip = invert_flip; } // for fantasia (bootleg)
 
-	void get_tile_info(tile_data &tileinfo, tilemap_memory_index tile_index, int _N_);
-	void kaneko16_vram_w(offs_t offset, uint16_t data, uint16_t mem_mask, int _N_);
+	typedef device_delegate<void (u8, u32*)> view2_cb_delegate;
+	void set_tile_callback(view2_cb_delegate cb) { m_view2_cb = cb; }
+
+	void vram_w(int _N_, offs_t offset, u16 data, u16 mem_mask = u16(~0));
 
 	// call to do the rendering etc.
 	template<class _BitmapClass>
-	void kaneko16_prepare_common(_BitmapClass &bitmap, const rectangle &cliprect);
+	void prepare_common(_BitmapClass &bitmap, const rectangle &cliprect);
 	template<class _BitmapClass>
-	void render_tilemap_chip_common(screen_device &screen, _BitmapClass &bitmap, const rectangle &cliprect, int pri);
+	void render_tilemap_common(screen_device &screen, _BitmapClass &bitmap, const rectangle &cliprect, int pri);
 	template<class _BitmapClass>
-	void render_tilemap_chip_alt_common(screen_device &screen, _BitmapClass &bitmap, const rectangle &cliprect, int pri, int v2pri);
+	void render_tilemap_alt_common(screen_device &screen, _BitmapClass &bitmap, const rectangle &cliprect, int pri, int v2pri);
 
-	void kaneko16_prepare(bitmap_ind16 &bitmap, const rectangle &cliprect);
-	void kaneko16_prepare(bitmap_rgb32 &bitmap, const rectangle &cliprect);
-	void render_tilemap_chip(screen_device &screen, bitmap_ind16 &bitmap, const rectangle &cliprect, int pri);
-	void render_tilemap_chip(screen_device &screen, bitmap_rgb32 &bitmap, const rectangle &cliprect, int pri);
-	void render_tilemap_chip_alt(screen_device &screen, bitmap_ind16 &bitmap, const rectangle &cliprect, int pri, int v2pri);
-	void render_tilemap_chip_alt(screen_device &screen, bitmap_rgb32 &bitmap, const rectangle &cliprect, int pri, int v2pri);
+	void prepare(bitmap_ind16 &bitmap, const rectangle &cliprect);
+	void prepare(bitmap_rgb32 &bitmap, const rectangle &cliprect);
+	void render_tilemap(screen_device &screen, bitmap_ind16 &bitmap, const rectangle &cliprect, int pri);
+	void render_tilemap(screen_device &screen, bitmap_rgb32 &bitmap, const rectangle &cliprect, int pri);
+	void render_tilemap_alt(screen_device &screen, bitmap_ind16 &bitmap, const rectangle &cliprect, int pri, int v2pri);
+	void render_tilemap_alt(screen_device &screen, bitmap_rgb32 &bitmap, const rectangle &cliprect, int pri, int v2pri);
 
 
 	// access
-	DECLARE_READ16_MEMBER( kaneko_tmap_vram_r );
-	DECLARE_WRITE16_MEMBER( kaneko_tmap_vram_w );
+	void vram_map(address_map &map);
 
-	DECLARE_READ16_MEMBER( kaneko_tmap_regs_r );
-	DECLARE_WRITE16_MEMBER( kaneko_tmap_regs_w );
+	u16 regs_r(offs_t offset);
+	void regs_w(offs_t offset, u16 data, u16 mem_mask = u16(~0));
 
-	DECLARE_WRITE16_MEMBER(kaneko16_vram_0_w);
-	DECLARE_WRITE16_MEMBER(kaneko16_vram_1_w);
+	void vram_0_w(offs_t offset, u16 data, u16 mem_mask = u16(~0));
+	void vram_1_w(offs_t offset, u16 data, u16 mem_mask = u16(~0));
 
-	DECLARE_READ16_MEMBER(kaneko16_vram_0_r);
-	DECLARE_READ16_MEMBER(kaneko16_vram_1_r);
+	u16 vram_0_r(offs_t offset);
+	u16 vram_1_r(offs_t offset);
 
-	DECLARE_READ16_MEMBER(kaneko16_scroll_0_r);
-	DECLARE_READ16_MEMBER(kaneko16_scroll_1_r);
+	void scroll_0_w(offs_t offset, u16 data, u16 mem_mask = u16(~0));
+	void scroll_1_w(offs_t offset, u16 data, u16 mem_mask = u16(~0));
 
-	DECLARE_WRITE16_MEMBER( kaneko16_scroll_0_w );
-	DECLARE_WRITE16_MEMBER( kaneko16_scroll_1_w );
+	u16 scroll_0_r(offs_t offset);
+	u16 scroll_1_r(offs_t offset);
 
-	DECLARE_WRITE16_MEMBER(galsnew_vram_0_tilebank_w);
-	DECLARE_WRITE16_MEMBER(galsnew_vram_1_tilebank_w);
-
-
+	void mark_layer_dirty(u8 Layer);
 
 protected:
 	virtual void device_start() override;
 	virtual void device_reset() override;
 
 private:
-	TILE_GET_INFO_MEMBER(get_tile_info_0);
-	TILE_GET_INFO_MEMBER(get_tile_info_1);
+	template<unsigned Layer> TILE_GET_INFO_MEMBER(get_tile_info);
+	required_shared_ptr_array<u16, 2> m_vram;
+	required_shared_ptr_array<u16, 2> m_vscroll;
 	required_device<gfxdecode_device> m_gfxdecode;
 
 	// set when creating device
@@ -86,11 +83,9 @@ private:
 	int m_dx, m_dy, m_xdim, m_ydim;
 	int m_invert_flip;
 
-	std::unique_ptr<uint16_t[]> m_vram[2];
-	std::unique_ptr<uint16_t[]> m_vscroll[2];
-	std::unique_ptr<uint16_t[]> m_regs;
+	view2_cb_delegate   m_view2_cb;
+	std::unique_ptr<u16[]> m_regs;
 	tilemap_t* m_tmap[2];
-	uint16_t m_vram_tile_addition[2]; // galsnew
 };
 
 


### PR DESCRIPTION
Add address_map for VRAM handling, Move expro02.cpp exclusive tilemap bankswitching function into expro02.cpp (now callback'd), Fix namings, Reduce duplicates, Simplify handlers
expro02.cpp : Minor simplify handlers, Reduce runtime tag lookup, Minor fix naming
jchan.cpp : Fix notes
kaneko16.cpp : Reduce unnecessary lines, Fix notes