### PR TITLE
Fix for 6809 disassembly

### DIFF
--- a/src/devices/cpu/m6809/6x09dasm.cpp
+++ b/src/devices/cpu/m6809/6x09dasm.cpp
@@ -214,6 +214,10 @@ offs_t m6x09_base_disassembler::disassemble(std::ostream &stream, offs_t pc, con
 		else if (numoperands == 2)
 		{
 			ea = params.r16(ppc);
+			if( !(ea & 0xff00) )
+			{
+				stream << '>'; // need the '>' to force an assembler to use EXT addressing
+			}
 			util::stream_format(stream, "$%04X", ea);
 		}
 		break;

--- a/src/devices/cpu/m6809/6x09dasm.cpp
+++ b/src/devices/cpu/m6809/6x09dasm.cpp
@@ -908,7 +908,7 @@ void m6x09_disassembler::indirect(std::ostream &stream, uint8_t pb, const data_b
 		break;
 
 	case 0x8c:  // (+/- 7 bit offset),PC
-		offset = (int8_t)params.r8(p);
+		offset = (int8_t)params.r8(p++);
 		util::stream_format(stream, "%s", (offset < 0) ? "-" : "");
 		util::stream_format(stream, "$%02X,PC", (offset < 0) ? -offset : offset);
 		break;

--- a/src/devices/cpu/m6809/6x09dasm.cpp
+++ b/src/devices/cpu/m6809/6x09dasm.cpp
@@ -230,7 +230,7 @@ offs_t m6x09_base_disassembler::disassemble(std::ostream &stream, offs_t pc, con
 			pb = params.r8(ppc);
 		}
 
-		indirect(stream, pb, params, p);
+		indexed(stream, pb, params, p);
 		break;
 
 	case IMM:
@@ -810,10 +810,10 @@ m6x09_disassembler::m6x09_disassembler(m6x09_instruction_level level, const char
 }
 
 //-------------------------------------------------
-//  indirect addressing mode for M6809/HD6309
+//  indexed addressing mode for M6809/HD6309
 //-------------------------------------------------
 
-void m6x09_disassembler::indirect(std::ostream &stream, uint8_t pb, const data_buffer &params, offs_t &p)
+void m6x09_disassembler::indexed(std::ostream &stream, uint8_t pb, const data_buffer &params, offs_t &p)
 {
 	uint8_t reg = (pb >> 5) & 3;
 	uint8_t pbm = pb & 0x8f;
@@ -1240,10 +1240,10 @@ konami_disassembler::konami_disassembler() : m6x09_base_disassembler(konami_opco
 }
 
 //-------------------------------------------------
-//  indirect addressing mode for Konami
+//  indexed addressing mode for Konami
 //-------------------------------------------------
 
-void konami_disassembler::indirect(std::ostream &stream, uint8_t mode, const data_buffer &params, offs_t &p)
+void konami_disassembler::indexed(std::ostream &stream, uint8_t mode, const data_buffer &params, offs_t &p)
 {
 	static const char index_reg[8][3] =
 	{

--- a/src/devices/cpu/m6809/6x09dasm.cpp
+++ b/src/devices/cpu/m6809/6x09dasm.cpp
@@ -909,15 +909,13 @@ void m6x09_disassembler::indexed(std::ostream &stream, uint8_t pb, const data_bu
 
 	case 0x8c:  // (+/- 7 bit offset),PC
 		offset = (int8_t)params.r8(p++);
-		util::stream_format(stream, "%s", (offset < 0) ? "-" : "");
-		util::stream_format(stream, "$%02X,PC", (offset < 0) ? -offset : offset);
+		util::stream_format(stream, "$%04X,PCR", (p+offset)); // PC Relative addressing (assembler computes offset from specified absolute address)
 		break;
 
 	case 0x8d:  // (+/- 15 bit offset),PC
 		offset = (int16_t)params.r16(p);
 		p += 2;
-		util::stream_format(stream, "%s", (offset < 0) ? "-" : "");
-		util::stream_format(stream, "$%04X,PC", (offset < 0) ? -offset : offset);
+		util::stream_format(stream, "$%04X,PCR", (p+offset)); // PC Relative addressing (assembler computes offset from specified absolute address)
 		break;
 
 	case 0x8e:  // (+/- W),R

--- a/src/devices/cpu/m6809/6x09dasm.h
+++ b/src/devices/cpu/m6809/6x09dasm.h
@@ -101,7 +101,7 @@ protected:
 	static const char *const hd6309_tfmregs[16];
 	static const char *const tfm_s[];
 
-	virtual void indirect(std::ostream &stream, uint8_t pb, const data_buffer &params, offs_t &p) = 0;
+	virtual void indexed(std::ostream &stream, uint8_t pb, const data_buffer &params, offs_t &p) = 0;
 	virtual void register_register(std::ostream &stream, uint8_t pb) = 0;
 
 private:
@@ -123,7 +123,7 @@ public:
 	m6x09_disassembler(m6x09_instruction_level level, const char teregs[16][4]);
 
 protected:
-	virtual void indirect(std::ostream &stream, uint8_t pb, const data_buffer &params, offs_t &p) override;
+	virtual void indexed(std::ostream &stream, uint8_t pb, const data_buffer &params, offs_t &p) override;
 	virtual void register_register(std::ostream &stream, uint8_t pb) override;
 
 private:
@@ -138,7 +138,7 @@ public:
 	konami_disassembler();
 
 protected:
-	virtual void indirect(std::ostream &stream, uint8_t pb, const data_buffer &params, offs_t &p) override;
+	virtual void indexed(std::ostream &stream, uint8_t pb, const data_buffer &params, offs_t &p) override;
 	virtual void register_register(std::ostream &stream, uint8_t pb) override;
 
 private:


### PR DESCRIPTION
fixed bug in 6809 disassembler where the pc was not being incremented correctly for one particular indexed addressing case (it so happens the first instruction executed when running "mame cocoe -d" exhibited this bug).  looks like just an oversight since it is correctly implemented elsewhere nearby for similar cases.

also, the indexed addressing member function was misnamed "indirect" (guessing it's just a typo since the flag is IND for this mode).  i went ahead and changed the name of indirect() to indexed() in the 6809 disassembly header/source (this done in a separate commit from the above fix).

added a change to use the absolute address in the operand for pc relative indexed addressing (where the assembler computes the offset).  i found that several 6809 assemblers *required* this even if using ",PC" instead of ",PCR" which meant the disassembled code simply would not assemble correctly at all before this change.

added a change to force extended addressing (via the ">" operand syntax) in cases where the given address were only one byte in length (in this case, many assemblers would simply choose to use direct addressing instead).  again, the goal was to make the disassembly able to re-assemble exactly as before the disassembly.