### PR TITLE
bsmt2000: fix 4-bit ADPCM sample playback

### DIFF
--- a/src/devices/sound/bsmt2000.cpp
+++ b/src/devices/sound/bsmt2000.cpp
@@ -180,8 +180,8 @@ void bsmt2000_device::sound_stream_update(sound_stream &stream, stream_sample_t 
 	// just fill with current left/right values
 	for (int samp = 0; samp < samples; samp++)
 	{
-		outputs[0][samp] = m_left_data * 16;
-		outputs[1][samp] = m_right_data * 16;
+		outputs[0][samp] = m_left_data;
+		outputs[1][samp] = m_right_data;
 	}
 }
 
@@ -264,8 +264,8 @@ READ16_MEMBER( bsmt2000_device::tms_data_r )
 
 READ16_MEMBER( bsmt2000_device::tms_rom_r )
 {
-	// underlying logic assumes this is a sign-extended value
-	return (int8_t)read_byte((m_rom_bank << 16) + m_rom_address);
+	// DSP code expects a 16-bit value with the data in the high byte
+	return (int16_t)(read_byte((m_rom_bank << 16) + m_rom_address) << 8);
 }
 
 

--- a/src/mame/drivers/deco32.cpp
+++ b/src/mame/drivers/deco32.cpp
@@ -3664,7 +3664,7 @@ ROM_START( tattass )
 	ROM_LOAD16_BYTE( "ob2_c2.b3",  0x700000, 0x80000,  CRC(90fe5f4f) SHA1(2149e9eae152556c632ebd4d0b2de49e40916a77) )
 	ROM_LOAD16_BYTE( "ob2_c3.b3",  0x700001, 0x80000,  CRC(e3517e6e) SHA1(68ac60570423d8f0d7cff3db1901c9c050d0be91) )
 
-	ROM_REGION(0x1000000, "bsmt", 0 ) // are the sample roms 100% confirmed as good? some sounds cause everything to cut out followed by a loud static pop? (did the same before the bsmt decap)
+	ROM_REGION(0x1000000, "bsmt", 0 )
 	ROM_LOAD( "u17.snd",  0x000000, 0x80000,  CRC(b945c18d) SHA1(6556bbb4a7057df3680132f24687fa944006c784) )
 	ROM_LOAD( "u21.snd",  0x080000, 0x80000,  CRC(10b2110c) SHA1(83e5938ed22da2874022e1dc8df76c72d95c448d) )
 	ROM_LOAD( "u36.snd",  0x100000, 0x80000,  CRC(3b73abe2) SHA1(195096e2302e84123b23b4ccd982fb3ab9afe42c) )


### PR DESCRIPTION
The BSMT2000 audio board has support for 12 sound channels; 11 of them are for playing back signed 8-bit PCM, and the remaining one is for a custom 4-bit ADPCM format. Previously, ADPCM samples would not play back at all, or clip out the entire audio stream. 

Originally, tms_rom_w loaded a single byte from the sample ROM and sign-extended it to 16 bits. From looking at the DSP code, the problem for ADPCM is that the sample is required to be in the high byte; the DSP uses the midpoint of the 32-bit accumulator register to slice the sample into two nibbles. Regular PCM playback still worked (at 1/256th the expected amplitude!), but was extra quiet and a bit distorted at low volumes.

This patch changes tms_rom_w to shift-extend each sample, and removes the gain boost on the audio output. Fixes a number of missing samples/severe audio glitches in Tattoo Assassins (e.g. the bird call in the jungle level).