### PR TITLE
fix for (imgtool) filtbas when strings left unterminated in basic lines

### DIFF
--- a/src/tools/imgtool/filtbas.cpp
+++ b/src/tools/imgtool/filtbas.cpp
@@ -116,6 +116,8 @@ static imgtoolerr_t basic_readfile(const basictokens *tokens,
 		destf.printf("%u ", (unsigned) line_number);
 		shift = 0x00;
 
+		in_string = false; // in case the last line didn't terminate a string
+
 		while((mem_stream->read(&b, 1) > 0) && (b != 0x00))
 		{
 			if (b == 0x22)


### PR DESCRIPTION
if a basic line didn't terminate a string with a closing double-quote (which is apparently ok - it is just automatically terminated by the basic interpreter), then basic_readfile() would fail to parse the first token on the following line (behaving as if it were still parsing a string from the previous line).

this change just forces each line to begin "outside" of a string (ie. the first encountered double quote on a line will always start a new string).
