### PR TITLE
upd765.cpp: Correct result from Read ID when scan failed

### DIFF
--- a/src/devices/machine/upd765.cpp
+++ b/src/devices/machine/upd765.cpp
@@ -2292,6 +2292,9 @@ void upd765_family_device::read_id_start(floppy_info &fi)
 		return;
 	}
 
+	for(int i=0; i<4; i++)
+		cur_live.idbuf[i] = command[i+2];
+
 	read_id_continue(fi);
 }
 


### PR DESCRIPTION
Result from Read ID must be the sector ID information during execution phase. So result must be:

- Zeroes if not ready (execution phase is not reached).
- Command codes if ready but scan failed (execution phase is reached but ID is not found). This patch fixes this.
- If scan is correct then result is the ID information from sector found.

Fix MT 06611