### PR TITLE
dsk_dsk.cpp: Avoid segfault if double sided DSK image is loaded on si…

### DIFF
--- a/src/lib/formats/dsk_dsk.cpp
+++ b/src/lib/formats/dsk_dsk.cpp
@@ -362,6 +362,12 @@ bool dsk_format::load(io_generic *io, uint32_t form_factor, floppy_image *image)
 		skip = 2;
 	}
 	int tracks  = header[0x30];
+
+	int img_tracks, img_heads;
+	image->get_maximal_geometry(img_tracks, img_heads);
+	if (tracks > img_tracks || heads > img_heads)
+		return false;
+
 	uint64_t track_offsets[84*2];
 	int cnt =0;
 	if (!extendformat) {


### PR DESCRIPTION
…mple sided disk device

MAME crashed if user was trying to load a dsk image with more heads or tracks than disk device supports.
Now the error 'Incompatible image format' is raised.