### PR TITLE
gaelco2.cpp : Updates

### DIFF
--- a/src/mame/drivers/gaelco2.cpp
+++ b/src/mame/drivers/gaelco2.cpp
@@ -85,18 +85,18 @@ void gaelco2_state::mcu_hostmem_map(address_map &map)
 
 void gaelco2_state::maniacsq_map(address_map &map)
 {
-	map(0x000000, 0x03ffff).rom();                                                                     /* ROM */
-	map(0x200000, 0x20ffff).ram().w(FUNC(gaelco2_state::gaelco2_vram_w)).share("spriteram");                         /* Video RAM */
+	map(0x000000, 0x03ffff).rom();                                                                                         /* ROM */
+	map(0x200000, 0x20ffff).ram().w(FUNC(gaelco2_state::vram_w)).share("spriteram");                                       /* Video RAM */
 	map(0x202890, 0x2028ff).rw("gaelco", FUNC(gaelco_gae1_device::gaelcosnd_r), FUNC(gaelco_gae1_device::gaelcosnd_w));    /* Sound Registers */
-	map(0x210000, 0x211fff).ram().w(FUNC(gaelco2_state::gaelco2_palette_w)).share("paletteram");                     /* Palette */
-	map(0x218004, 0x218009).ram().share("vregs");                                                   /* Video Registers */
-	map(0x300000, 0x300001).portr("IN0");                                                        /* DSW #1 + Input 1P */
-	map(0x300002, 0x300003).portr("IN1");                                                        /* DSW #2 + Input 2P */
-	map(0x30004a, 0x30004b).nopw();                                                                /* Sound muting? */
-	map(0x320000, 0x320001).portr("COIN");                                                       /* COINSW + SERVICESW */
-	map(0x500000, 0x500001).w(FUNC(gaelco2_state::alighunt_coin_w));                                                  /* Coin lockout + counters */
-	map(0xfe0000, 0xfe7fff).ram();                                                                     /* Work RAM */
-	map(0xfe8000, 0xfeffff).ram().share("shareram");                                                /* Work RAM */
+	map(0x210000, 0x211fff).ram().w(FUNC(gaelco2_state::palette_w)).share("paletteram");                                   /* Palette */
+	map(0x218004, 0x218009).ram().w(FUNC(gaelco2_state::vregs_w)).share("vregs");                                          /* Video Registers */
+	map(0x300000, 0x300001).portr("IN0");                                                                                  /* DSW #1 + Input 1P */
+	map(0x300002, 0x300003).portr("IN1");                                                                                  /* DSW #2 + Input 2P */
+	map(0x30004a, 0x30004b).nopw();                                                                                        /* Sound muting? */
+	map(0x320000, 0x320001).portr("COIN");                                                                                 /* COINSW + SERVICESW */
+	map(0x500000, 0x500001).w(FUNC(gaelco2_state::alighunt_coin_w));                                                       /* Coin lockout + counters */
+	map(0xfe0000, 0xfe7fff).ram();                                                                                         /* Work RAM */
+	map(0xfe8000, 0xfeffff).ram().share("shareram");                                                                       /* Work RAM */
 }
 
 
@@ -193,7 +193,7 @@ void gaelco2_state::maniacsq(machine_config &config)
 	screen.set_vblank_time(ATTOSECONDS_IN_USEC(2500)); /* not accurate */
 	screen.set_size(64*16, 32*16);
 	screen.set_visarea(0, 320-1, 16, 256-1);
-	screen.set_screen_update(FUNC(gaelco2_state::screen_update_gaelco2));
+	screen.set_screen_update(FUNC(gaelco2_state::screen_update));
 	screen.screen_vblank().set("spriteram", FUNC(buffered_spriteram16_device::vblank_copy_rising));
 	screen.set_palette(m_palette);
 
@@ -449,10 +449,10 @@ INPUT_PORTS_END
 void gaelco2_state::saltcrdi_map(address_map &map)
 {
 	map(0x000000, 0x03ffff).rom();
-	map(0x200000, 0x20ffff).ram().w(FUNC(gaelco2_state::gaelco2_vram_w)).share("spriteram");
+	map(0x200000, 0x20ffff).ram().w(FUNC(gaelco2_state::vram_w)).share("spriteram");
 	map(0x202890, 0x2028ff).rw("gaelco", FUNC(gaelco_gae1_device::gaelcosnd_r), FUNC(gaelco_gae1_device::gaelcosnd_w));
-	map(0x210000, 0x211fff).ram().w(FUNC(gaelco2_state::gaelco2_palette_w)).share("paletteram");
-	map(0x218004, 0x218009).ram().share("vregs");
+	map(0x210000, 0x211fff).ram().w(FUNC(gaelco2_state::palette_w)).share("paletteram");
+	map(0x218004, 0x218009).ram().w(FUNC(gaelco2_state::vregs_w)).share("vregs");
 	map(0x300000, 0x300001).portr("IN0");
 	map(0x310000, 0x310001).portr("DSW");
 	map(0x320000, 0x320001).portr("COIN");
@@ -476,7 +476,7 @@ void gaelco2_state::saltcrdi(machine_config &config)
 	screen.set_vblank_time(ATTOSECONDS_IN_USEC(2500)); /* not accurate */
 	screen.set_size(64*16, 32*16);
 	screen.set_visarea(0, 384-1, 16, 256-1);
-	screen.set_screen_update(FUNC(gaelco2_state::screen_update_gaelco2));
+	screen.set_screen_update(FUNC(gaelco2_state::screen_update));
 	screen.screen_vblank().set("spriteram", FUNC(buffered_spriteram16_device::vblank_copy_rising));
 	screen.set_palette(m_palette);
 
@@ -558,19 +558,19 @@ Note    1x 28x2 edge connector
 
 void gaelco2_state::play2000_map(address_map &map)
 {
-	map(0x000000, 0x03ffff).rom();                                                                     /* ROM */
-	map(0x100000, 0x100001).portr("IN0");                                                        /* Coins + other buttons? */
+	map(0x000000, 0x03ffff).rom();                                                                                         /* ROM */
+	map(0x100000, 0x100001).portr("IN0");                                                                                  /* Coins + other buttons? */
 	map(0x110000, 0x110001).portr("IN1");
-	map(0x200000, 0x20ffff).ram().w(FUNC(gaelco2_state::gaelco2_vram_w)).share("spriteram");                         /* Video RAM */
+	map(0x200000, 0x20ffff).ram().w(FUNC(gaelco2_state::vram_w)).share("spriteram");                                       /* Video RAM */
 	map(0x202890, 0x2028ff).rw("gaelco", FUNC(gaelco_gae1_device::gaelcosnd_r), FUNC(gaelco_gae1_device::gaelcosnd_w));    /* Sound Registers */
-	map(0x214000, 0x214fff).ram().w(FUNC(gaelco2_state::gaelco2_palette_w)).share("paletteram");                     /* Palette */
-	map(0x215000, 0x217fff).ram();                                                                     /* Written to, but unused? */
-	map(0x218000, 0x218003).ram();                                                                     /* Written to, but unused? */
-	map(0x218004, 0x218009).ram().share("vregs");                                                   /* Video Registers */
-	map(0x21800a, 0x218fff).ram();                                                                     /* Written to, but unused? */
+	map(0x214000, 0x214fff).ram().w(FUNC(gaelco2_state::palette_w)).share("paletteram");                                   /* Palette */
+	map(0x215000, 0x217fff).ram();                                                                                         /* Written to, but unused? */
+	map(0x218000, 0x218003).ram();                                                                                         /* Written to, but unused? */
+	map(0x218004, 0x218009).ram().w(FUNC(gaelco2_state::vregs_w)).share("vregs");                                          /* Video Registers */
+	map(0x21800a, 0x218fff).ram();                                                                                         /* Written to, but unused? */
 	// AM_RANGE(0x843100, 0x84315e)  ?
-	map(0xfe0000, 0xfe7fff).ram();                                                                     /* Work RAM */
-	map(0xfe8000, 0xfeffff).ram().share("shareram");                                                /* Work RAM */
+	map(0xfe0000, 0xfe7fff).ram();                                                                                         /* Work RAM */
+	map(0xfe8000, 0xfeffff).ram().share("shareram");                                                                       /* Work RAM */
 }
 
 static INPUT_PORTS_START( play2000 )
@@ -732,7 +732,7 @@ void gaelco2_state::play2000(machine_config &config)
 	screen.set_vblank_time(ATTOSECONDS_IN_USEC(2500)); /* not accurate */
 	screen.set_size(64*16, 32*16);
 	screen.set_visarea(0, 384-1, 16, 256-1);
-	screen.set_screen_update(FUNC(gaelco2_state::screen_update_gaelco2));
+	screen.set_screen_update(FUNC(gaelco2_state::screen_update));
 	screen.screen_vblank().set("spriteram", FUNC(buffered_spriteram16_device::vblank_copy_rising));
 	screen.set_palette(m_palette);
 
@@ -757,30 +757,30 @@ void gaelco2_state::play2000(machine_config &config)
                                 BANG
   ============================================================================*/
 
-READ16_MEMBER(bang_state::p1_gun_x){return (m_light0_x->read() * 320 / 0x100) + 1;}
-READ16_MEMBER(bang_state::p1_gun_y){return (m_light0_y->read() * 240 / 0x100) - 4;}
-READ16_MEMBER(bang_state::p2_gun_x){return (m_light1_x->read() * 320 / 0x100) + 1;}
-READ16_MEMBER(bang_state::p2_gun_y){return (m_light1_y->read() * 240 / 0x100) - 4;}
+u16 bang_state::p1_gun_x(){return (m_light0_x->read() * 320 / 0x100) + 1;}
+u16 bang_state::p1_gun_y(){return (m_light0_y->read() * 240 / 0x100) - 4;}
+u16 bang_state::p2_gun_x(){return (m_light1_x->read() * 320 / 0x100) + 1;}
+u16 bang_state::p2_gun_y(){return (m_light1_y->read() * 240 / 0x100) - 4;}
 
 void bang_state::bang_map(address_map &map)
 {
-	map(0x000000, 0x0fffff).rom();                                                                     /* ROM */
-	map(0x200000, 0x20ffff).ram().w(FUNC(bang_state::gaelco2_vram_w)).share("spriteram");                         /* Video RAM */
+	map(0x000000, 0x0fffff).rom();                                                                                         /* ROM */
+	map(0x200000, 0x20ffff).ram().w(FUNC(bang_state::vram_w)).share("spriteram");                                          /* Video RAM */
 	map(0x202890, 0x2028ff).rw("gaelco", FUNC(gaelco_cg1v_device::gaelcosnd_r), FUNC(gaelco_cg1v_device::gaelcosnd_w));    /* Sound Registers */
-	map(0x210000, 0x211fff).ram().w(FUNC(bang_state::gaelco2_palette_w)).share("paletteram");                     /* Palette */
-	map(0x218004, 0x218009).readonly();                                                                /* Video Registers */
-	map(0x218004, 0x218007).writeonly().share("vregs");                                             /* Video Registers */
-	map(0x218008, 0x218009).nopw();                                                                /* CLR INT Video */
+	map(0x210000, 0x211fff).ram().w(FUNC(bang_state::palette_w)).share("paletteram");                                      /* Palette */
+	map(0x218004, 0x218009).readonly();                                                                                    /* Video Registers */
+	map(0x218004, 0x218007).w(FUNC(bang_state::vregs_w)).share("vregs");                                                   /* Video Registers */
+	map(0x218008, 0x218009).nopw();                                                                                        /* CLR INT Video */
 	map(0x300000, 0x300001).portr("P1");
-	map(0x300002, 0x300003).nopr();                                                                 /* Random number generator? */
-	map(0x300000, 0x30000f).w(m_mainlatch, FUNC(ls259_device::write_d0)).umask16(0x00ff);                  /* Coin Counters & serial EEPROM */
+	map(0x300002, 0x300003).nopr();                                                                                        /* Random number generator? */
+	map(0x300000, 0x30000f).w(m_mainlatch, FUNC(ls259_device::write_d0)).umask16(0x00ff);                                  /* Coin Counters & serial EEPROM */
 	map(0x300010, 0x300011).portr("P2");
 	map(0x300020, 0x300021).portr("COIN");
-	map(0x310000, 0x310001).r(FUNC(bang_state::p1_gun_x)).w(FUNC(bang_state::bang_clr_gun_int_w));                             /* Gun 1P X */ /* CLR INT Gun */
-	map(0x310002, 0x310003).r(FUNC(bang_state::p2_gun_x));                                                          /* Gun 2P X */
-	map(0x310004, 0x310005).r(FUNC(bang_state::p1_gun_y));                                                          /* Gun 1P Y */
-	map(0x310006, 0x310007).r(FUNC(bang_state::p2_gun_y));                                                          /* Gun 2P Y */
-	map(0xfe0000, 0xfeffff).ram();                                                                     /* Work RAM */
+	map(0x310000, 0x310001).r(FUNC(bang_state::p1_gun_x)).w(FUNC(bang_state::bang_clr_gun_int_w));                         /* Gun 1P X */ /* CLR INT Gun */
+	map(0x310002, 0x310003).r(FUNC(bang_state::p2_gun_x));                                                                 /* Gun 2P X */
+	map(0x310004, 0x310005).r(FUNC(bang_state::p1_gun_y));                                                                 /* Gun 1P Y */
+	map(0x310006, 0x310007).r(FUNC(bang_state::p2_gun_y));                                                                 /* Gun 2P Y */
+	map(0xfe0000, 0xfeffff).ram();                                                                                         /* Work RAM */
 }
 
 
@@ -838,7 +838,7 @@ void bang_state::bang(machine_config &config)
 	screen.set_vblank_time(ATTOSECONDS_IN_USEC(2500)); /* not accurate */
 	screen.set_size(64*16, 32*16);
 	screen.set_visarea(0, 320-1, 16, 256-1);
-	screen.set_screen_update(FUNC(gaelco2_state::screen_update_gaelco2));
+	screen.set_screen_update(FUNC(gaelco2_state::screen_update));
 	screen.screen_vblank().set("spriteram", FUNC(buffered_spriteram16_device::vblank_copy_rising));
 	screen.set_palette(m_palette);
 
@@ -970,18 +970,18 @@ ROM_END
 
 void gaelco2_state::alighunt_map(address_map &map)
 {
-	map(0x000000, 0x0fffff).rom();                                                                         /* ROM */
-	map(0x200000, 0x20ffff).ram().w(FUNC(gaelco2_state::gaelco2_vram_w)).share("spriteram");                             /* Video RAM */
-	map(0x202890, 0x2028ff).rw("gaelco", FUNC(gaelco_gae1_device::gaelcosnd_r), FUNC(gaelco_gae1_device::gaelcosnd_w));        /* Sound Registers */
-	map(0x210000, 0x211fff).ram().w(FUNC(gaelco2_state::gaelco2_palette_w)).share("paletteram");                         /* Palette */
-	map(0x218004, 0x218009).ram().share("vregs");                                                       /* Video Registers */
-	map(0x300000, 0x300001).portr("IN0");                                                            /* DSW #1 + Input 1P */
-	map(0x300002, 0x300003).portr("IN1");                                                            /* DSW #2 + Input 2P */
-	map(0x320000, 0x320001).portr("COIN");                                                           /* COINSW + SERVICESW */
-	map(0x500000, 0x500001).w(FUNC(gaelco2_state::alighunt_coin_w));                                                      /* Coin lockout + counters */
-	map(0x500006, 0x500007).nopw();                                                                    /* ??? */
-	map(0xfe0000, 0xfe7fff).ram();                                                                         /* Work RAM */
-	map(0xfe8000, 0xfeffff).ram().share("shareram");                                                    /* Work RAM (shared with D5002FP) */
+	map(0x000000, 0x0fffff).rom();                                                                                         /* ROM */
+	map(0x200000, 0x20ffff).ram().w(FUNC(gaelco2_state::vram_w)).share("spriteram");                                       /* Video RAM */
+	map(0x202890, 0x2028ff).rw("gaelco", FUNC(gaelco_gae1_device::gaelcosnd_r), FUNC(gaelco_gae1_device::gaelcosnd_w));    /* Sound Registers */
+	map(0x210000, 0x211fff).ram().w(FUNC(gaelco2_state::palette_w)).share("paletteram");                                   /* Palette */
+	map(0x218004, 0x218009).ram().w(FUNC(gaelco2_state::vregs_w)).share("vregs");                                          /* Video Registers */
+	map(0x300000, 0x300001).portr("IN0");                                                                                  /* DSW #1 + Input 1P */
+	map(0x300002, 0x300003).portr("IN1");                                                                                  /* DSW #2 + Input 2P */
+	map(0x320000, 0x320001).portr("COIN");                                                                                 /* COINSW + SERVICESW */
+	map(0x500000, 0x500001).w(FUNC(gaelco2_state::alighunt_coin_w));                                                       /* Coin lockout + counters */
+	map(0x500006, 0x500007).nopw();                                                                                        /* ??? */
+	map(0xfe0000, 0xfe7fff).ram();                                                                                         /* Work RAM */
+	map(0xfe8000, 0xfeffff).ram().share("shareram");                                                                       /* Work RAM (shared with D5002FP) */
 }
 
 
@@ -1077,7 +1077,7 @@ void gaelco2_state::alighunt(machine_config &config)
 	screen.set_vblank_time(ATTOSECONDS_IN_USEC(2500)); /* not accurate */
 	screen.set_size(64*16, 32*16);
 	screen.set_visarea(0, 320-1, 16, 256-1);
-	screen.set_screen_update(FUNC(gaelco2_state::screen_update_gaelco2));
+	screen.set_screen_update(FUNC(gaelco2_state::screen_update));
 	screen.screen_vblank().set("spriteram", FUNC(buffered_spriteram16_device::vblank_copy_rising));
 	screen.set_palette(m_palette);
 
@@ -1240,18 +1240,18 @@ ROM_END
 
 void gaelco2_state::touchgo_map(address_map &map)
 {
-	map(0x000000, 0x0fffff).rom();                                                                         /* ROM */
-	map(0x200000, 0x20ffff).ram().w(FUNC(gaelco2_state::gaelco2_vram_w)).share("spriteram");                             /* Video RAM */
-	map(0x202890, 0x2028ff).rw("gaelco", FUNC(gaelco_gae1_device::gaelcosnd_r), FUNC(gaelco_gae1_device::gaelcosnd_w));        /* Sound Registers */
-	map(0x210000, 0x211fff).ram().w(FUNC(gaelco2_state::gaelco2_palette_w)).share("paletteram");                         /* Palette */
-	map(0x218004, 0x218009).ram().share("vregs");                                                       /* Video Registers */
-	map(0x300000, 0x300001).portr("IN0");                                                            /* DSW #1 + Input 1P */
-	map(0x300002, 0x300003).portr("IN1");                                                            /* DSW #2 + Input 2P */
-	map(0x300004, 0x300005).portr("IN2");                                                            /* COINSW + Input 3P */
-	map(0x300006, 0x300007).portr("IN3");                                                            /* SERVICESW + Input 4P */
-	map(0x500000, 0x500001).select(0x0038).w(FUNC(gaelco2_state::wrally2_latch_w));                                    /* Coin counters */
-	map(0xfe0000, 0xfe7fff).ram();                                                                         /* Work RAM */
-	map(0xfe8000, 0xfeffff).ram().share("shareram");                                                    /* Work RAM (shared with D5002FP) */
+	map(0x000000, 0x0fffff).rom();                                                                                         /* ROM */
+	map(0x200000, 0x20ffff).ram().w(FUNC(gaelco2_state::vram_w)).share("spriteram");                                       /* Video RAM */
+	map(0x202890, 0x2028ff).rw("gaelco", FUNC(gaelco_gae1_device::gaelcosnd_r), FUNC(gaelco_gae1_device::gaelcosnd_w));    /* Sound Registers */
+	map(0x210000, 0x211fff).ram().w(FUNC(gaelco2_state::palette_w)).share("paletteram");                                   /* Palette */
+	map(0x218004, 0x218009).ram().w(FUNC(gaelco2_state::vregs_w)).share("vregs");                                          /* Video Registers */
+	map(0x300000, 0x300001).portr("IN0");                                                                                  /* DSW #1 + Input 1P */
+	map(0x300002, 0x300003).portr("IN1");                                                                                  /* DSW #2 + Input 2P */
+	map(0x300004, 0x300005).portr("IN2");                                                                                  /* COINSW + Input 3P */
+	map(0x300006, 0x300007).portr("IN3");                                                                                  /* SERVICESW + Input 4P */
+	map(0x500000, 0x500001).select(0x0038).w(FUNC(gaelco2_state::wrally2_latch_w));                                        /* Coin counters */
+	map(0xfe0000, 0xfe7fff).ram();                                                                                         /* Work RAM */
+	map(0xfe8000, 0xfeffff).ram().share("shareram");                                                                       /* Work RAM (shared with D5002FP) */
 }
 
 
@@ -1386,7 +1386,7 @@ void gaelco2_state::touchgo(machine_config &config)
 	lscreen.set_vblank_time(ATTOSECONDS_IN_USEC(2500)); /* not accurate */
 	lscreen.set_size(64*16, 32*16);
 	lscreen.set_visarea(0, 480-1, 16, 256-1);
-	lscreen.set_screen_update(FUNC(gaelco2_state::screen_update_gaelco2_left));
+	lscreen.set_screen_update(FUNC(gaelco2_state::screen_update_left));
 	lscreen.set_palette(m_palette);
 
 	screen_device &rscreen(SCREEN(config, "rscreen", SCREEN_TYPE_RASTER));
@@ -1394,7 +1394,7 @@ void gaelco2_state::touchgo(machine_config &config)
 	rscreen.set_vblank_time(ATTOSECONDS_IN_USEC(2500)); /* not accurate */
 	rscreen.set_size(64*16, 32*16);
 	rscreen.set_visarea(0, 480-1, 16, 256-1);
-	rscreen.set_screen_update(FUNC(gaelco2_state::screen_update_gaelco2_right));
+	rscreen.set_screen_update(FUNC(gaelco2_state::screen_update_right));
 	rscreen.screen_vblank().set("spriteram", FUNC(buffered_spriteram16_device::vblank_copy_rising));
 	rscreen.set_palette(m_palette);
 
@@ -1620,18 +1620,18 @@ ROM_END
 
 void gaelco2_state::snowboar_map(address_map &map)
 {
-	map(0x000000, 0x0fffff).rom();                                                                         /* ROM */
-	map(0x200000, 0x20ffff).ram().w(FUNC(gaelco2_state::gaelco2_vram_w)).share("spriteram");                             /* Video RAM */
-	map(0x202890, 0x2028ff).rw("gaelco", FUNC(gaelco_cg1v_device::gaelcosnd_r), FUNC(gaelco_cg1v_device::gaelcosnd_w));        /* Sound Registers */
-	map(0x210000, 0x211fff).ram().w(FUNC(gaelco2_state::gaelco2_palette_w)).share("paletteram");                         /* Palette */
-	map(0x212000, 0x213fff).ram();                                                                         /* Extra RAM */
-	map(0x218004, 0x218009).ram().share("vregs");                                                       /* Video Registers */
+	map(0x000000, 0x0fffff).rom();                                                                                                                /* ROM */
+	map(0x200000, 0x20ffff).ram().w(FUNC(gaelco2_state::vram_w)).share("spriteram");                                                              /* Video RAM */
+	map(0x202890, 0x2028ff).rw("gaelco", FUNC(gaelco_cg1v_device::gaelcosnd_r), FUNC(gaelco_cg1v_device::gaelcosnd_w));                           /* Sound Registers */
+	map(0x210000, 0x211fff).ram().w(FUNC(gaelco2_state::palette_w)).share("paletteram");                                                          /* Palette */
+	map(0x212000, 0x213fff).ram();                                                                                                                /* Extra RAM */
+	map(0x218004, 0x218009).ram().w(FUNC(gaelco2_state::vregs_w)).share("vregs");                                                                 /* Video Registers */
 	map(0x300000, 0x300001).portr("P1");
-	map(0x300000, 0x30000f).w(m_mainlatch, FUNC(ls259_device::write_d0)).umask16(0x00ff);                      /* Coin Counters & serial EEPROM */
+	map(0x300000, 0x30000f).w(m_mainlatch, FUNC(ls259_device::write_d0)).umask16(0x00ff);                                                         /* Coin Counters & serial EEPROM */
 	map(0x300010, 0x300011).portr("P2");
 	map(0x300020, 0x300021).portr("COIN");
 	map(0x310000, 0x31ffff).rw(FUNC(gaelco2_state::snowboar_protection_r), FUNC(gaelco2_state::snowboar_protection_w)).share("snowboar_prot");    /* Protection */
-	map(0xfe0000, 0xfeffff).ram();                                                                                 /* Work RAM */
+	map(0xfe0000, 0xfeffff).ram();                                                                                                                /* Work RAM */
 }
 
 
@@ -1691,7 +1691,7 @@ void gaelco2_state::snowboar(machine_config &config)
 	screen.set_vblank_time(ATTOSECONDS_IN_USEC(2500)); /* not accurate */
 	screen.set_size(64*16, 32*16);
 	screen.set_visarea(0, 384-1, 16, 256-1);
-	screen.set_screen_update(FUNC(gaelco2_state::screen_update_gaelco2));
+	screen.set_screen_update(FUNC(gaelco2_state::screen_update));
 	screen.screen_vblank().set(m_spriteram, FUNC(buffered_spriteram16_device::vblank_copy_rising));
 	screen.set_palette(m_palette);
 
@@ -1735,7 +1735,7 @@ void gaelco2_state::maniacsqs(machine_config &config)
 	screen.set_vblank_time(ATTOSECONDS_IN_USEC(2500)); /* not accurate */
 	screen.set_size(64*16, 32*16);
 	screen.set_visarea(0, 320-1, 16, 256-1);
-	screen.set_screen_update(FUNC(gaelco2_state::screen_update_gaelco2));
+	screen.set_screen_update(FUNC(gaelco2_state::screen_update));
 	screen.screen_vblank().set(m_spriteram, FUNC(buffered_spriteram16_device::vblank_copy_rising));
 	screen.set_palette(m_palette);
 
@@ -1853,19 +1853,19 @@ ROM_END
 
 void wrally2_state::wrally2_map(address_map &map)
 {
-	map(0x000000, 0x0fffff).rom();                                                                     /* ROM */
-	map(0x200000, 0x20ffff).ram().w(FUNC(wrally2_state::gaelco2_vram_w)).share("spriteram");                         /* Video RAM */
+	map(0x000000, 0x0fffff).rom();                                                                                         /* ROM */
+	map(0x200000, 0x20ffff).ram().w(FUNC(wrally2_state::vram_w)).share("spriteram");                                       /* Video RAM */
 	map(0x202890, 0x2028ff).rw("gaelco", FUNC(gaelco_gae1_device::gaelcosnd_r), FUNC(gaelco_gae1_device::gaelcosnd_w));    /* Sound Registers */
-	map(0x210000, 0x211fff).ram().w(FUNC(wrally2_state::gaelco2_palette_w)).share("paletteram");                     /* Palette */
-	map(0x212000, 0x213fff).ram();                                                                     /* Extra RAM */
-	map(0x218004, 0x218009).ram().share("vregs");                                                   /* Video Registers */
-	map(0x300000, 0x300001).portr("IN0");                                                        /* DIPSW #2 + Inputs 1P */
-	map(0x300002, 0x300003).portr("IN1");                                                        /* DIPSW #1 */
-	map(0x300004, 0x300005).portr("IN2");                                                        /* Inputs 2P + COINSW */
-	map(0x300006, 0x300007).portr("IN3");                                                        /* SERVICESW */
-	map(0x400000, 0x400001).select(0x0038).w(FUNC(wrally2_state::wrally2_latch_w));                                /* Coin counters, etc. */
-	map(0xfe0000, 0xfe7fff).ram();                                                                     /* Work RAM */
-	map(0xfe8000, 0xfeffff).ram().share("shareram");                                                /* Work RAM (shared with D5002FP) */
+	map(0x210000, 0x211fff).ram().w(FUNC(wrally2_state::palette_w)).share("paletteram");                                   /* Palette */
+	map(0x212000, 0x213fff).ram();                                                                                         /* Extra RAM */
+	map(0x218004, 0x218009).ram().w(FUNC(wrally2_state::vregs_w)).share("vregs");                                          /* Video Registers */
+	map(0x300000, 0x300001).portr("IN0");                                                                                  /* DIPSW #2 + Inputs 1P */
+	map(0x300002, 0x300003).portr("IN1");                                                                                  /* DIPSW #1 */
+	map(0x300004, 0x300005).portr("IN2");                                                                                  /* Inputs 2P + COINSW */
+	map(0x300006, 0x300007).portr("IN3");                                                                                  /* SERVICESW */
+	map(0x400000, 0x400001).select(0x0038).w(FUNC(wrally2_state::wrally2_latch_w));                                        /* Coin counters, etc. */
+	map(0xfe0000, 0xfe7fff).ram();                                                                                         /* Work RAM */
+	map(0xfe8000, 0xfeffff).ram().share("shareram");                                                                       /* Work RAM (shared with D5002FP) */
 }
 
 
@@ -1984,7 +1984,7 @@ void wrally2_state::wrally2(machine_config &config)
 	lscreen.set_vblank_time(ATTOSECONDS_IN_USEC(2500)); /* not accurate */
 	lscreen.set_size(384, 32*16);
 	lscreen.set_visarea(0, 384-1, 16, 256-1);
-	lscreen.set_screen_update(FUNC(gaelco2_state::screen_update_gaelco2_left));
+	lscreen.set_screen_update(FUNC(gaelco2_state::screen_update_left));
 	lscreen.set_palette(m_palette);
 
 	screen_device &rscreen(SCREEN(config, "rscreen", SCREEN_TYPE_RASTER));
@@ -1992,7 +1992,7 @@ void wrally2_state::wrally2(machine_config &config)
 	rscreen.set_vblank_time(ATTOSECONDS_IN_USEC(2500)); /* not accurate */
 	rscreen.set_size(384, 32*16);
 	rscreen.set_visarea(0, 384-1, 16, 256-1);
-	rscreen.set_screen_update(FUNC(gaelco2_state::screen_update_gaelco2_right));
+	rscreen.set_screen_update(FUNC(gaelco2_state::screen_update_right));
 	rscreen.screen_vblank().set(m_spriteram, FUNC(buffered_spriteram16_device::vblank_copy_rising));
 	rscreen.set_palette(m_palette);
 
@@ -2298,36 +2298,36 @@ ROM_END
 
 
 
-GAME( 1994, aligator,    0,         alighunt_d5002fp, alighunt, gaelco2_state, init_alighunt, ROT0, "Gaelco", "Alligator Hunt (World, protected)", 0 )
-GAME( 1994, aligators,   aligator,  alighunt_d5002fp, alighunt, gaelco2_state, init_alighunt, ROT0, "Gaelco", "Alligator Hunt (Spain, protected)", 0 )
-GAME( 1994, aligatorun,  aligator,  alighunt,         alighunt, gaelco2_state, init_alighunt, ROT0, "Gaelco", "Alligator Hunt (unprotected, set 1)", 0 )
-GAME( 1994, aligatoruna, aligator,  alighunt,         alighunt, gaelco2_state, init_alighunt, ROT0, "Gaelco", "Alligator Hunt (unprotected, set 2)", 0 ) // strange version, starts on space stages, but clearly a recompile not a trivial hack of the above, show version maybe?
+GAME( 1994, aligator,    0,         alighunt_d5002fp, alighunt, gaelco2_state, init_alighunt,  ROT0, "Gaelco", "Alligator Hunt (World, protected)", 0 )
+GAME( 1994, aligators,   aligator,  alighunt_d5002fp, alighunt, gaelco2_state, init_alighunt,  ROT0, "Gaelco", "Alligator Hunt (Spain, protected)", 0 )
+GAME( 1994, aligatorun,  aligator,  alighunt,         alighunt, gaelco2_state, init_alighunt,  ROT0, "Gaelco", "Alligator Hunt (unprotected, set 1)", 0 )
+GAME( 1994, aligatoruna, aligator,  alighunt,         alighunt, gaelco2_state, init_alighunt,  ROT0, "Gaelco", "Alligator Hunt (unprotected, set 2)", 0 ) // strange version, starts on space stages, but clearly a recompile not a trivial hack of the above, show version maybe?
 
-GAME( 1995, touchgo,     0,         touchgo_d5002fp,  touchgo,  gaelco2_state, init_touchgo,  ROT0, "Gaelco", "Touch & Go (World)", MACHINE_IMPERFECT_SOUND )
-GAME( 1995, touchgon,    touchgo,   touchgo_d5002fp,  touchgo,  gaelco2_state, init_touchgo,  ROT0, "Gaelco", "Touch & Go (Non North America)", MACHINE_IMPERFECT_SOUND )
-GAME( 1995, touchgoe,    touchgo,   touchgo_d5002fp,  touchgo,  gaelco2_state, init_touchgo,  ROT0, "Gaelco", "Touch & Go (earlier revision)",  MACHINE_IMPERFECT_SOUND )
-GAME( 1995, touchgok,    touchgo,   touchgo,          touchgo,  gaelco2_state, init_touchgo,  ROT0, "Gaelco", "Touch & Go (Korea, unprotected)", MACHINE_IMPERFECT_SOUND ) // doesn't say 'Korea' but was sourced there, shows 2 copyright lines like the 'earlier revision'
+GAME( 1995, touchgo,     0,         touchgo_d5002fp,  touchgo,  gaelco2_state, init_touchgo,   ROT0, "Gaelco", "Touch & Go (World)", MACHINE_IMPERFECT_SOUND )
+GAME( 1995, touchgon,    touchgo,   touchgo_d5002fp,  touchgo,  gaelco2_state, init_touchgo,   ROT0, "Gaelco", "Touch & Go (Non North America)", MACHINE_IMPERFECT_SOUND )
+GAME( 1995, touchgoe,    touchgo,   touchgo_d5002fp,  touchgo,  gaelco2_state, init_touchgo,   ROT0, "Gaelco", "Touch & Go (earlier revision)",  MACHINE_IMPERFECT_SOUND )
+GAME( 1995, touchgok,    touchgo,   touchgo,          touchgo,  gaelco2_state, init_touchgo,   ROT0, "Gaelco", "Touch & Go (Korea, unprotected)", MACHINE_IMPERFECT_SOUND ) // doesn't say 'Korea' but was sourced there, shows 2 copyright lines like the 'earlier revision'
 
-GAME( 1995, wrally2,     0,         wrally2,          wrally2,  wrally2_state, init_wrally2,  ROT0, "Gaelco", "World Rally 2: Twin Racing (mask ROM version)", 0 )
-GAME( 1995, wrally2a,    wrally2,   wrally2,          wrally2,  wrally2_state, empty_init,    ROT0, "Gaelco", "World Rally 2: Twin Racing (EPROM version)", 0 )
+GAME( 1995, wrally2,     0,         wrally2,          wrally2,  wrally2_state, init_wrally2,   ROT0, "Gaelco", "World Rally 2: Twin Racing (mask ROM version)", 0 )
+GAME( 1995, wrally2a,    wrally2,   wrally2,          wrally2,  wrally2_state, empty_init,     ROT0, "Gaelco", "World Rally 2: Twin Racing (EPROM version)", 0 )
 
 // All sets identify as Version 1.0, but are clearly different revisions
-GAME( 1996, maniacsq,    0,         maniacsq_d5002fp, maniacsq, gaelco2_state, empty_init,    ROT0, "Gaelco", "Maniac Square (protected, Version 1.0, Checksum DEEE)", 0 )
-GAME( 1996, maniacsqa,   maniacsq,  maniacsq_d5002fp, maniacsq, gaelco2_state, empty_init,    ROT0, "Gaelco", "Maniac Square (protected, Version 1.0, Checksum CF2D)", 0 )
-GAME( 1996, maniacsqu,   maniacsq,  maniacsq,         maniacsq, gaelco2_state, empty_init,    ROT0, "Gaelco", "Maniac Square (unprotected, Version 1.0, Checksum BB73)", 0 )
-GAME( 1996, maniacsqs,   maniacsq,  maniacsqs,        snowboar, gaelco2_state, empty_init,    ROT0, "Gaelco", "Maniac Square (unprotected, Version 1.0, Checksum 66B1, 960419/1 PCB)", 0 ) // Official version on Snow Board Championship PCB, doesn't use the protection
+GAME( 1996, maniacsq,    0,         maniacsq_d5002fp, maniacsq, gaelco2_state, empty_init,     ROT0, "Gaelco", "Maniac Square (protected, Version 1.0, Checksum DEEE)", 0 )
+GAME( 1996, maniacsqa,   maniacsq,  maniacsq_d5002fp, maniacsq, gaelco2_state, empty_init,     ROT0, "Gaelco", "Maniac Square (protected, Version 1.0, Checksum CF2D)", 0 )
+GAME( 1996, maniacsqu,   maniacsq,  maniacsq,         maniacsq, gaelco2_state, empty_init,     ROT0, "Gaelco", "Maniac Square (unprotected, Version 1.0, Checksum BB73)", 0 )
+GAME( 1996, maniacsqs,   maniacsq,  maniacsqs,        snowboar, gaelco2_state, empty_init,     ROT0, "Gaelco", "Maniac Square (unprotected, Version 1.0, Checksum 66B1, 960419/1 PCB)", 0 ) // Official version on Snow Board Championship PCB, doesn't use the protection
 
-GAME( 1996, snowboar,    0,         snowboar,         snowboar, gaelco2_state, empty_init,    ROT0, "Gaelco", "Snow Board Championship (Version 2.1)", 0 )
-GAME( 1996, snowboara,   snowboar,  snowboar,         snowboar, gaelco2_state, init_snowboar, ROT0, "Gaelco", "Snow Board Championship (Version 2.0)", 0 )
+GAME( 1996, snowboar,    0,         snowboar,         snowboar, gaelco2_state, init_snowboar,  ROT0, "Gaelco", "Snow Board Championship (Version 2.1)", 0 )
+GAME( 1996, snowboara,   snowboar,  snowboar,         snowboar, gaelco2_state, init_snowboara, ROT0, "Gaelco", "Snow Board Championship (Version 2.0)", 0 )
 
-GAME( 1998, bang,        0,         bang,             bang,     bang_state,    init_bang,     ROT0, "Gaelco", "Bang!", 0 )
-GAME( 1998, bangj,       bang,      bang,             bang,     bang_state,    init_bang,     ROT0, "Gaelco", "Gun Gabacho (Japan)", 0 )
+GAME( 1998, bang,        0,         bang,             bang,     bang_state,    init_bang,      ROT0, "Gaelco", "Bang!", 0 )
+GAME( 1998, bangj,       bang,      bang,             bang,     bang_state,    init_bang,      ROT0, "Gaelco", "Gun Gabacho (Japan)", 0 )
 
 // 2-in-1 gambling game, appears to be cloned Gaelco hardware complete with DS5002FP, or possibly manufactured by Gaelco for Nova Desitec but without any Gaelco branding.
 // these are Italian versions, English versions also exist
-GAME( 1999, play2000,    0,         play2000,         play2000, gaelco2_state, init_play2000, ROT0, "Nova Desitec", "Play 2000 (Super Slot & Gran Tesoro) (v7.0i) (Italy)",  0 )
-GAME( 1999, play2000_50i,play2000,  play2000,         play2000, gaelco2_state, empty_init,    ROT0, "Nova Desitec", "Play 2000 (Super Slot & Gran Tesoro) (v5.0i) (Italy)",  MACHINE_NOT_WORKING ) // bad dump
-GAME( 1999, play2000_40i,play2000,  play2000,         play2000, gaelco2_state, init_play2000, ROT0, "Nova Desitec", "Play 2000 (Super Slot & Gran Tesoro) (v4.0i) (Italy)",  0 )
+GAME( 1999, play2000,    0,         play2000,         play2000, gaelco2_state, init_play2000,  ROT0, "Nova Desitec", "Play 2000 (Super Slot & Gran Tesoro) (v7.0i) (Italy)",  0 )
+GAME( 1999, play2000_50i,play2000,  play2000,         play2000, gaelco2_state, empty_init,     ROT0, "Nova Desitec", "Play 2000 (Super Slot & Gran Tesoro) (v5.0i) (Italy)",  MACHINE_NOT_WORKING ) // bad dump
+GAME( 1999, play2000_40i,play2000,  play2000,         play2000, gaelco2_state, init_play2000,  ROT0, "Nova Desitec", "Play 2000 (Super Slot & Gran Tesoro) (v4.0i) (Italy)",  0 )
 
 // Gym exercise bike
-GAME( 1997, saltcrdi,   0,          saltcrdi,         saltcrdi, gaelco2_state, empty_init,    ROT0, "Salter Fitness / Gaelco", "Pro Tele Cardioline (Salter Fitness Bike V.1.0, Checksum 02AB)", MACHINE_NOT_WORKING ) // there are other machines in the Cardioline series, without TV displays
+GAME( 1997, saltcrdi,   0,          saltcrdi,         saltcrdi, gaelco2_state, empty_init,     ROT0, "Salter Fitness / Gaelco", "Pro Tele Cardioline (Salter Fitness Bike V.1.0, Checksum 02AB)", MACHINE_NOT_WORKING ) // there are other machines in the Cardioline series, without TV displays

--- a/src/mame/includes/gaelco2.h
+++ b/src/mame/includes/gaelco2.h
@@ -10,18 +10,18 @@
 class gaelco2_state : public driver_device
 {
 public:
-	gaelco2_state(const machine_config &mconfig, device_type type, const char *tag)
-		: driver_device(mconfig, type, tag),
-		m_maincpu(*this,"maincpu"),
+	gaelco2_state(const machine_config &mconfig, device_type type, const char *tag) :
+		driver_device(mconfig, type, tag),
+		m_maincpu(*this, "maincpu"),
 		m_mainlatch(*this, "mainlatch"),
-		m_spriteram(*this,"spriteram"),
+		m_spriteram(*this, "spriteram"),
 		m_eeprom(*this, "eeprom"),
 		m_gfxdecode(*this, "gfxdecode"),
 		m_palette(*this, "palette"),
 		m_global_spritexoff(0),
 		m_vregs(*this, "vregs"),
 		m_snowboar_protection(*this, "snowboar_prot"),
-		m_generic_paletteram_16(*this, "paletteram"),
+		m_paletteram(*this, "paletteram"),
 		m_shareram(*this, "shareram")
 	{ }
 
@@ -38,6 +38,7 @@ public:
 
 	void init_touchgo();
 	void init_snowboar();
+	void init_snowboara();
 	void init_alighunt();
 	void init_wrally2();
 	void init_play2000();
@@ -48,9 +49,9 @@ public:
 	DECLARE_VIDEO_START(gaelco2);
 	DECLARE_VIDEO_START(gaelco2_dual);
 
-	uint32_t screen_update_gaelco2(screen_device &screen, bitmap_ind16 &bitmap, const rectangle &cliprect);
-	uint32_t screen_update_gaelco2_left(screen_device &screen, bitmap_ind16 &bitmap, const rectangle &cliprect);
-	uint32_t screen_update_gaelco2_right(screen_device &screen, bitmap_ind16 &bitmap, const rectangle &cliprect);
+	u32 screen_update(screen_device &screen, bitmap_ind16 &bitmap, const rectangle &cliprect);
+	u32 screen_update_left(screen_device &screen, bitmap_ind16 &bitmap, const rectangle &cliprect);
+	u32 screen_update_right(screen_device &screen, bitmap_ind16 &bitmap, const rectangle &cliprect);
 
 protected:
 	required_device<m68000_device> m_maincpu;
@@ -60,28 +61,27 @@ protected:
 	required_device<gfxdecode_device> m_gfxdecode;
 	required_device<palette_device> m_palette;
 
-	DECLARE_WRITE16_MEMBER(gaelco2_vram_w);
-	DECLARE_WRITE16_MEMBER(gaelco2_palette_w);
+	void vram_w(offs_t offset, u16 data, u16 mem_mask = ~0);
+	void vregs_w(offs_t offset, u16 data, u16 mem_mask = ~0);
+	void palette_w(offs_t offset, u16 data, u16 mem_mask = ~0);
 
-	DECLARE_WRITE16_MEMBER(wrally2_latch_w);
+	void wrally2_latch_w(offs_t offset, u16 data);
 
 	void mcu_hostmem_map(address_map &map);
 
 private:
-	DECLARE_WRITE8_MEMBER(shareram_w);
-	DECLARE_READ8_MEMBER(shareram_r);
-	DECLARE_WRITE16_MEMBER(alighunt_coin_w);
+	void shareram_w(offs_t offset, u8 data);
+	u8 shareram_r(offs_t offset);
+	void alighunt_coin_w(u16 data);
 	DECLARE_WRITE_LINE_MEMBER(coin3_counter_w);
 	DECLARE_WRITE_LINE_MEMBER(coin4_counter_w);
-	DECLARE_READ16_MEMBER(snowboar_protection_r);
-	DECLARE_WRITE16_MEMBER(snowboar_protection_w);
-	TILE_GET_INFO_MEMBER(get_tile_info_gaelco2_screen0);
-	TILE_GET_INFO_MEMBER(get_tile_info_gaelco2_screen1);
-	TILE_GET_INFO_MEMBER(get_tile_info_gaelco2_screen0_dual);
-	TILE_GET_INFO_MEMBER(get_tile_info_gaelco2_screen1_dual);
+	u16 snowboar_protection_r();
+	void snowboar_protection_w(offs_t offset, u16 data, u16 mem_mask = ~0);
+	template<unsigned Layer> TILE_GET_INFO_MEMBER(get_tile_info);
+	template<unsigned Layer> TILE_GET_INFO_MEMBER(get_tile_info_dual);
 	void draw_sprites(screen_device &screen, bitmap_ind16 &bitmap, const rectangle &cliprect, int mask);
-	uint32_t dual_update(screen_device &screen, bitmap_ind16 &bitmap, const rectangle &cliprect, int index);
-	void gaelco2_ROM16_split_gfx(const char *src_reg, const char *dst_reg, int start, int length, int dest1, int dest2);
+	u32 dual_update(screen_device &screen, bitmap_ind16 &bitmap, const rectangle &cliprect, int index);
+	void ROM16_split_gfx(const char *src_reg, const char *dst_reg, int start, int length, int dest1, int dest2);
 
 	void alighunt_map(address_map &map);
 	void maniacsq_map(address_map &map);
@@ -90,17 +90,17 @@ private:
 	void touchgo_map(address_map &map);
 	void saltcrdi_map(address_map &map);
 
-	uint32_t snowboard_latch;
+	u32 m_snowboard_latch;
 
-	uint16_t *m_videoram;
+	u16 *m_videoram;
 	tilemap_t *m_pant[2];
 	int m_dual_monitor;
 	int m_global_spritexoff;
 
-	required_shared_ptr<uint16_t> m_vregs;
-	optional_shared_ptr<uint16_t> m_snowboar_protection;
-	required_shared_ptr<uint16_t> m_generic_paletteram_16;
-	optional_shared_ptr<uint16_t> m_shareram;
+	required_shared_ptr<u16> m_vregs;
+	optional_shared_ptr<u16> m_snowboar_protection;
+	required_shared_ptr<u16> m_paletteram;
+	optional_shared_ptr<u16> m_shareram;
 };
 
 
@@ -127,11 +127,11 @@ private:
 
 	int m_clr_gun_int;
 
-	DECLARE_READ16_MEMBER(p1_gun_x);
-	DECLARE_READ16_MEMBER(p1_gun_y);
-	DECLARE_READ16_MEMBER(p2_gun_x);
-	DECLARE_READ16_MEMBER(p2_gun_y);
-	DECLARE_WRITE16_MEMBER(bang_clr_gun_int_w);
+	u16 p1_gun_x();
+	u16 p1_gun_y();
+	u16 p2_gun_x();
+	u16 p2_gun_y();
+	void bang_clr_gun_int_w(u16 data);
 	TIMER_DEVICE_CALLBACK_MEMBER(bang_irq);
 	void bang_map(address_map &map);
 };

--- a/src/mame/machine/gaelco2.cpp
+++ b/src/mame/machine/gaelco2.cpp
@@ -22,7 +22,7 @@
 
 ***************************************************************************/
 
-void gaelco2_state::gaelco2_ROM16_split_gfx(const char *src_reg, const char *dst_reg, int start, int length, int dest1, int dest2)
+void gaelco2_state::ROM16_split_gfx(const char *src_reg, const char *dst_reg, int start, int length, int dest1, int dest2)
 {
 	int i;
 
@@ -67,16 +67,16 @@ void gaelco2_state::init_alighunt()
 	*/
 
 	/* split ROM u48 */
-	gaelco2_ROM16_split_gfx("gfx2", "gfx1", 0x0000000, 0x0400000, 0x0000000, 0x0400000);
+	ROM16_split_gfx("gfx2", "gfx1", 0x0000000, 0x0400000, 0x0000000, 0x0400000);
 
 	/* split ROM u47 */
-	gaelco2_ROM16_split_gfx("gfx2", "gfx1", 0x0400000, 0x0400000, 0x0200000, 0x0600000);
+	ROM16_split_gfx("gfx2", "gfx1", 0x0400000, 0x0400000, 0x0200000, 0x0600000);
 
 	/* split ROM u50 */
-	gaelco2_ROM16_split_gfx("gfx2", "gfx1", 0x0800000, 0x0400000, 0x0800000, 0x0c00000);
+	ROM16_split_gfx("gfx2", "gfx1", 0x0800000, 0x0400000, 0x0800000, 0x0c00000);
 
 	/* split ROM u49 */
-	gaelco2_ROM16_split_gfx("gfx2", "gfx1", 0x0c00000, 0x0400000, 0x0a00000, 0x0e00000);
+	ROM16_split_gfx("gfx2", "gfx1", 0x0c00000, 0x0400000, 0x0a00000, 0x0e00000);
 }
 
 
@@ -98,17 +98,17 @@ void gaelco2_state::init_touchgo()
 	*/
 
 	/* split ROM ic65 */
-	gaelco2_ROM16_split_gfx("gfx2", "gfx1", 0x0000000, 0x0400000, 0x0000000, 0x0400000);
+	ROM16_split_gfx("gfx2", "gfx1", 0x0000000, 0x0400000, 0x0000000, 0x0400000);
 
 	/* split ROM ic66 */
-	gaelco2_ROM16_split_gfx("gfx2", "gfx1", 0x0400000, 0x0200000, 0x0200000, 0x0600000);
+	ROM16_split_gfx("gfx2", "gfx1", 0x0400000, 0x0200000, 0x0200000, 0x0600000);
 
 	/* split ROM ic67 */
-	gaelco2_ROM16_split_gfx("gfx2", "gfx1", 0x0800000, 0x0400000, 0x0800000, 0x0c00000);
+	ROM16_split_gfx("gfx2", "gfx1", 0x0800000, 0x0400000, 0x0800000, 0x0c00000);
 }
 
 
-void gaelco2_state::init_snowboar()
+void gaelco2_state::init_snowboara()
 {
 	/*
 	For "gfx2" we have this memory map:
@@ -126,13 +126,14 @@ void gaelco2_state::init_snowboar()
 	*/
 
 	/* split ROM sb44 */
-	gaelco2_ROM16_split_gfx("gfx2", "gfx1", 0x0000000, 0x0400000, 0x0000000, 0x0400000);
+	ROM16_split_gfx("gfx2", "gfx1", 0x0000000, 0x0400000, 0x0000000, 0x0400000);
 
 	/* split ROM sb45 */
-	gaelco2_ROM16_split_gfx("gfx2", "gfx1", 0x0400000, 0x0400000, 0x0200000, 0x0600000);
+	ROM16_split_gfx("gfx2", "gfx1", 0x0400000, 0x0400000, 0x0200000, 0x0600000);
 
 	/* split ROM sb46 */
-	gaelco2_ROM16_split_gfx("gfx2", "gfx1", 0x0800000, 0x0400000, 0x0800000, 0x0c00000);
+	ROM16_split_gfx("gfx2", "gfx1", 0x0800000, 0x0400000, 0x0800000, 0x0c00000);
+	init_snowboar();
 }
 
 
@@ -151,10 +152,10 @@ void gaelco2_state::init_wrally2()
 	*/
 
 	/* split ROM wr2_ic69.ic69 */
-	gaelco2_ROM16_split_gfx("gfx2", "gfx1", 0x0000000, 0x0400000, 0x0000000, 0x0200000);
+	ROM16_split_gfx("gfx2", "gfx1", 0x0000000, 0x0400000, 0x0000000, 0x0200000);
 
 	/* split ROM wr2_ic70.ic70 */
-	gaelco2_ROM16_split_gfx("gfx2", "gfx1", 0x0400000, 0x0200000, 0x0400000, 0x0600000);
+	ROM16_split_gfx("gfx2", "gfx1", 0x0400000, 0x0200000, 0x0400000, 0x0600000);
 }
 
 
@@ -164,13 +165,13 @@ void gaelco2_state::init_wrally2()
 
 ***************************************************************************/
 
-WRITE8_MEMBER(gaelco2_state::shareram_w)
+void gaelco2_state::shareram_w(offs_t offset, u8 data)
 {
 	// why isn't there an AM_SOMETHING macro for this?
 	reinterpret_cast<u8 *>(m_shareram.target())[BYTE_XOR_BE(offset)] = data;
 }
 
-READ8_MEMBER(gaelco2_state::shareram_r)
+u8 gaelco2_state::shareram_r(offs_t offset)
 {
 	// why isn't there an AM_SOMETHING macro for this?
 	return reinterpret_cast<u8 const *>(m_shareram.target())[BYTE_XOR_BE(offset)];
@@ -183,7 +184,7 @@ READ8_MEMBER(gaelco2_state::shareram_r)
 
 ***************************************************************************/
 
-WRITE16_MEMBER(gaelco2_state::wrally2_latch_w)
+void gaelco2_state::wrally2_latch_w(offs_t offset, u16 data)
 {
 	m_mainlatch->write_bit(offset >> 2, BIT(data, 0));
 }
@@ -208,7 +209,7 @@ WRITE_LINE_MEMBER(gaelco2_state::coin4_counter_w)
 	machine().bookkeeping().coin_counter_w(3, state);
 }
 
-WRITE16_MEMBER(gaelco2_state::alighunt_coin_w)
+void gaelco2_state::alighunt_coin_w(u16 data)
 {
 	/* Coin Lockouts */
 	machine().bookkeeping().coin_lockout_w(0, ~data & 0x01);
@@ -231,7 +232,7 @@ void bang_state::init_bang()
 	m_clr_gun_int = 0;
 }
 
-WRITE16_MEMBER(bang_state::bang_clr_gun_int_w)
+void bang_state::bang_clr_gun_int_w(u16 data)
 {
 	m_clr_gun_int = 1;
 }
@@ -300,12 +301,17 @@ WRITE_LINE_MEMBER(wrally2_state::wrally2_adc_cs)
 
 ***************************************************************************/
 
-static uint32_t rol(uint32_t x, unsigned int c)
+void gaelco2_state::init_snowboar()
+{
+	save_item(NAME(m_snowboard_latch));
+}
+
+static u32 rol(u32 x, u8 c)
 {
 	return (x << c) | (x >> (32 - c));
 }
 
-static uint16_t get_lo(uint32_t x)
+static u16 get_lo(u32 x)
 {
 	return ((x & 0x00000010) <<  1) |
 			((x & 0x00000800) <<  3) |
@@ -322,7 +328,7 @@ static uint16_t get_lo(uint32_t x)
 			((x & 0x00000020) >>  1);
 }
 
-static uint16_t get_hi(uint32_t x)
+static u16 get_hi(u32 x)
 {
 	return ((x & 0x00001400) >>  0) |
 			((x & 0x10000000) >> 26) |
@@ -341,7 +347,7 @@ static uint16_t get_hi(uint32_t x)
 			((x & 0x00000100) >>  1);
 }
 
-static uint16_t get_out(uint16_t x)
+static u16 get_out(u16 x)
 {
 	return ((x & 0xc840) <<  0) |
 			((x & 0x0080) <<  2) |
@@ -357,27 +363,25 @@ static uint16_t get_out(uint16_t x)
 			((x & 0x0020) >>  2);
 }
 
-uint16_t mangle(uint32_t x)
+u16 mangle(u32 x)
 {
-	uint16_t a = get_lo(x);
-	uint16_t b = get_hi(x);
+	u16 a = get_lo(x);
+	u16 b = get_hi(x);
 	return get_out(((a ^ 0x0010) - (b ^ 0x0024)) ^ 0x5496);
 }
 
-READ16_MEMBER(gaelco2_state::snowboar_protection_r)
+u16 gaelco2_state::snowboar_protection_r()
 {
-	uint16_t ret  = mangle(snowboard_latch);
+	u16 ret = mangle(m_snowboard_latch);
 	ret = ((ret & 0xff00) >> 8) | ((ret & 0x00ff) << 8);
 	return ret;
-
 }
 
-WRITE16_MEMBER(gaelco2_state::snowboar_protection_w)
+void gaelco2_state::snowboar_protection_w(offs_t offset, u16 data, u16 mem_mask)
 {
 	COMBINE_DATA(&m_snowboar_protection[offset]);
 
-	snowboard_latch = (snowboard_latch << 16) | data;
+	m_snowboard_latch = (m_snowboard_latch << 16) | data;
 
 	logerror("%06x: protection write %04x to %04x\n", m_maincpu->pc(), data, offset*2);
-
 }


### PR DESCRIPTION
Reduce duplicates, unnecessary lines, defines, Fix namings, spacings, code styles, Simplify handlers, Use shorter/correct type values
Mark tilemap dirty when RAM base is changed]
Allow save for snowboar exclusive protection related value