### PR TITLE
fmtowns_cd.xml: fix some mistakes

### DIFF
--- a/hash/fmtowns_cd.xml
+++ b/hash/fmtowns_cd.xml
@@ -6062,7 +6062,7 @@ User/save disks that can be created from the game itself are not included.
 		<part name="flop1" interface="floppy_3_5">
 			<feature name="part_id" value="User Disk" />
 			<dataarea name="flop" size="1261568">
-				<rom name="the lord of the rings - the two towers user disk" size="1281968" crc="51c5461f" sha1="31548881ebfd4eb50281b3086709e5ff02a72ddd" offset="000000" />
+				<rom name="the lord of the rings - the two towers user disk.bin" size="1261568" crc="51c5461f" sha1="31548881ebfd4eb50281b3086709e5ff02a72ddd" offset="000000" />
 			</dataarea>
 		</part>
 		<part name="cdrom" interface="fmt_cdrom">


### PR DESCRIPTION
This is a quick fix for a couple of mistakes that I made with PR #4808. It corrects the name and size of the lotr2 user disk.