### PR TITLE
Implement Namcot 163 expansion sound volume difference related to NES 2.0 submapper format

### DIFF
--- a/hash/nes.xml
+++ b/hash/nes.xml
@@ -3478,6 +3478,7 @@
 			<feature name="slot" value="namcot_163" />
 			<feature name="pcb" value="NAMCOT-163" />
 			<feature name="batt" value="yes" />
+			<feature name="n163-vol" value="SUBMAPPER 2" />
 			<dataarea name="prg" size="131072">
 				<rom name="0.prg" size="131072" crc="3296ff7a" sha1="ebb64e13f8c244eaa8187624771c84b9f67f8ea7" offset="00000" />
 			</dataarea>
@@ -8648,6 +8649,7 @@
 			<feature name="slot" value="namcot_163" />
 			<feature name="pcb" value="NAMCOT-163" />
 			<feature name="batt" value="yes" />
+			<feature name="n163-vol" value="SUBMAPPER 2" />
 			<dataarea name="prg" size="131072">
 				<rom name="0.prg" size="131072" crc="96533999" sha1="1fa339a59832562a3acd1b524f6e41ed125486bf" offset="00000" />
 			</dataarea>
@@ -9820,6 +9822,7 @@
 		<part name="cart" interface="nes_cart">
 			<feature name="slot" value="namcot_163" />
 			<feature name="pcb" value="NAMCOT-163" />
+			<feature name="n163-vol" value="SUBMAPPER 2" />
 			<dataarea name="prg" size="131072">
 				<rom name="namcotdnpr" size="131072" crc="fba98643" sha1="6f79e0aae58654fe50ab5daf47a1c5f6f33c74ef" offset="00000" />
 			</dataarea>
@@ -10913,6 +10916,7 @@
 		<part name="cart" interface="nes_cart">
 			<feature name="slot" value="namcot_163" />
 			<feature name="pcb" value="NAMCOT-163" />
+			<feature name="n163-vol" value="SUBMAPPER 5" />
 			<dataarea name="prg" size="131072">
 				<rom name="0.prg" size="131072" crc="5f162195" sha1="f41389f92ad771633b1132558a31344a895f8c74" offset="00000" />
 			</dataarea>
@@ -12110,6 +12114,7 @@
 			<feature name="slot" value="namcot_163" />
 			<feature name="pcb" value="NAMCOT-163" />
 			<feature name="batt" value="yes" />
+			<feature name="n163-vol" value="SUBMAPPER 2" />
 			<dataarea name="prg" size="131072">
 				<rom name="namcot f90 prg" size="131072" crc="429fd177" sha1="08f506bad1ffae78783ac35ffead1621df89c0ff" offset="00000" />
 			</dataarea>
@@ -12771,6 +12776,7 @@
 		<part name="cart" interface="nes_cart">
 			<feature name="slot" value="namcot_163" />
 			<feature name="pcb" value="NAMCOT-163" />
+			<feature name="n163-vol" value="SUBMAPPER 3" />
 			<dataarea name="prg" size="131072">
 				<rom name="0.prg" size="131072" crc="968dcf09" sha1="0dabc907e0608ac4d9dd38345a22a69c61484ac4" offset="00000" />
 			</dataarea>
@@ -17113,6 +17119,7 @@
 		<part name="cart" interface="nes_cart">
 			<feature name="slot" value="namcot_163" />
 			<feature name="pcb" value="NAMCOT-163" />
+			<feature name="n163-vol" value="SUBMAPPER 2" />
 			<feature name="batt" value="yes" />
 			<dataarea name="prg" size="262144">
 				<rom name="0.prg" size="262144" crc="dd454208" sha1="21cdda0eaa26c688b63010abb490b810e87cfc28" offset="00000" />
@@ -19108,6 +19115,7 @@
 		<part name="cart" interface="nes_cart">
 			<feature name="slot" value="namcot_163" />
 			<feature name="pcb" value="NAMCOT-163" />
+			<feature name="n163-vol" value="SUBMAPPER 2" />
 			<dataarea name="prg" size="262144">
 				<rom name="0.prg" size="262144" crc="29c61b41" sha1="278003c283a43826f75fade6a41d9058cd99a3e0" offset="00000" />
 			</dataarea>
@@ -19260,6 +19268,7 @@
 		<part name="cart" interface="nes_cart">
 			<feature name="slot" value="namcot_163" />
 			<feature name="pcb" value="NAMCOT-163" />
+			<feature name="n163-vol" value="SUBMAPPER 2" />
 			<feature name="batt" value="yes" />
 			<dataarea name="prg" size="131072">
 				<rom name="namcot km prg" size="131072" crc="b1b9e187" sha1="cc1db05ce226c70752545fd82033a294f63aaa69" offset="00000" />
@@ -19941,6 +19950,7 @@
 		<part name="cart" interface="nes_cart">
 			<feature name="slot" value="namcot_163" />
 			<feature name="pcb" value="NAMCOT-163" />
+			<feature name="n163-vol" value="SUBMAPPER 5" />
 			<dataarea name="prg" size="131072">
 				<rom name="0.prg" size="131072" crc="1dd6619b" sha1="eca545c2a383584283cea2e73d7bd1f58698a25e" offset="00000" />
 			</dataarea>
@@ -23019,6 +23029,7 @@
 		<part name="cart" interface="nes_cart">
 			<feature name="slot" value="namcot_163" />
 			<feature name="pcb" value="NAMCOT-163" />
+			<feature name="n163-vol" value="SUBMAPPER 5" />
 			<dataarea name="prg" size="131072">
 				<rom name="0.prg" size="131072" crc="598fb9f5" sha1="5fa67a84067febcc63006553c5d6d86df614f9b2" offset="00000" />
 			</dataarea>
@@ -23733,6 +23744,7 @@
 		<part name="cart" interface="nes_cart">
 			<feature name="slot" value="namcot_163" />
 			<feature name="pcb" value="NAMCOT-163" />
+			<feature name="n163-vol" value="SUBMAPPER 3" />
 			<dataarea name="prg" size="262144">
 				<rom name="0.prg" size="262144" crc="1294ab5a" sha1="ade6b8872a24fc2e91fc717f2eeb05c773c18fdf" offset="00000" />
 			</dataarea>
@@ -24618,6 +24630,7 @@
 		<part name="cart" interface="nes_cart">
 			<feature name="slot" value="namcot_163" />
 			<feature name="pcb" value="NAMCOT-163" />
+			<feature name="n163-vol" value="SUBMAPPER 2" />
 			<feature name="batt" value="yes" />
 			<dataarea name="prg" size="131072">
 				<rom name="0.prg" size="131072" crc="af15338f" sha1="0c792cff77e2bbfca9248cddaa073b69b191c821" offset="00000" />
@@ -25867,6 +25880,7 @@
 		<part name="cart" interface="nes_cart">
 			<feature name="slot" value="namcot_163" />
 			<feature name="pcb" value="NAMCOT-163" />
+			<feature name="n163-vol" value="SUBMAPPER 2" />
 			<dataarea name="prg" size="262144">
 				<rom name="0.prg" size="262144" crc="2b825ce1" sha1="fa61d78845a7826768f07ba453eda15705223955" offset="00000" />
 			</dataarea>
@@ -25889,6 +25903,7 @@
 		<part name="cart" interface="nes_cart">
 			<feature name="slot" value="namcot_163" />
 			<feature name="pcb" value="NAMCOT-163" />
+			<feature name="n163-vol" value="SUBMAPPER 3" />
 			<dataarea name="prg" size="262144">
 				<rom name="0.prg" size="262144" crc="9a2b0641" sha1="781ee304241fdc19bbec4a66face364c64d904b8" offset="00000" />
 			</dataarea>
@@ -31223,6 +31238,7 @@
 		<part name="cart" interface="nes_cart">
 			<feature name="slot" value="namcot_163" />
 			<feature name="pcb" value="NAMCOT-163" />
+			<feature name="n163-vol" value="SUBMAPPER 4" />
 			<dataarea name="prg" size="131072">
 				<rom name="0.prg" size="131072" crc="3deac303" sha1="95ef5172c9634402d6fa9c638ce46fe70ed505b9" offset="00000" />
 			</dataarea>
@@ -32110,6 +32126,7 @@
 		<part name="cart" interface="nes_cart">
 			<feature name="slot" value="namcot_163" />
 			<feature name="pcb" value="NAMCOT-163" />
+			<feature name="n163-vol" value="SUBMAPPER 3" />
 			<dataarea name="prg" size="262144">
 				<rom name="0.prg" size="262144" crc="6901346e" sha1="4e17d6626bf5da9f40b93d9ad3aca16f869053c7" offset="00000" />
 			</dataarea>
@@ -32136,6 +32153,7 @@
 		<part name="cart" interface="nes_cart">
 			<feature name="slot" value="namcot_163" />
 			<feature name="pcb" value="NAMCOT-163" />
+			<feature name="n163-vol" value="SUBMAPPER 5" />
 			<dataarea name="prg" size="131072">
 				<rom name="0.prg" size="131072" crc="b78970d2" sha1="eb818027f68a436286b532cbdc14584921a8e685" offset="00000" />
 			</dataarea>
@@ -35237,6 +35255,7 @@
 		<part name="cart" interface="nes_cart">
 			<feature name="slot" value="namcot_163" />
 			<feature name="pcb" value="NAMCOT-163" />
+			<feature name="n163-vol" value="SUBMAPPER 2" />
 			<dataarea name="prg" size="131072">
 				<rom name="0.prg" size="131072" crc="8a2824bb" sha1="ce25e790bf205b37746cff327ca5c1a533919f86" offset="00000" />
 			</dataarea>
@@ -42824,6 +42843,7 @@
 		<part name="cart" interface="nes_cart">
 			<feature name="slot" value="namcot_163" />
 			<feature name="pcb" value="NAMCOT-163" />
+			<feature name="n163-vol" value="SUBMAPPER 5" />
 			<dataarea name="prg" size="131072">
 				<rom name="namcot yd prg" size="131072" crc="17421900" sha1="5fda17f7d44a1529924156c5a2983f9f7d6c765e" offset="00000" />
 			</dataarea>

--- a/src/devices/bus/nes/namcot.cpp
+++ b/src/devices/bus/nes/namcot.cpp
@@ -209,6 +209,24 @@ void nes_namcot163_device::device_start()
 
 	m_mapper_sram_size = 0x2000;
 	m_mapper_sram = m_n163_ram;
+
+	// TODO : Measure actual volume
+	if (m_n163_vol == 2) // Submapper 2 - No expansion sound
+	{
+		m_namco163snd->set_output_gain(ALL_OUTPUTS, 0.0);
+	}
+	else if (m_n163_vol == 3) // Submapper 3 - N163 expansion sound: 11.0-13.0 dB louder than NES APU
+	{
+		m_namco163snd->set_output_gain(ALL_OUTPUTS, 1.125);
+	}
+	else if (m_n163_vol == 4) // Submapper 4 - N163 expansion sound: 16.0-17.0 dB louder than NES APU
+	{
+		m_namco163snd->set_output_gain(ALL_OUTPUTS, 1.17);
+	}
+	else if (m_n163_vol == 5) // Submapper 5 - N163 expansion sound: 18.0-19.5 dB louder than NES APU
+	{
+		m_namco163snd->set_output_gain(ALL_OUTPUTS, 1.19);
+	}
 }
 
 void nes_namcot163_device::pcb_reset()

--- a/src/devices/bus/nes/nes_ines.hxx
+++ b/src/devices/bus/nes/nes_ines.hxx
@@ -428,6 +428,16 @@ void nes_cart_slot_device::call_load_ines()
 			bus_conflict = true;
 		else if (mapper == 7 && submapper == 2)
 			bus_conflict = true;
+		// 019: Namcot N163
+		else if (mapper == 19)
+		{
+			int vol = submapper & 0x07;
+			if (vol >= 0 && vol <= 5)
+			{
+				pcb_id = NAMCOT_163;
+				m_cart->set_n163_vol(vol);
+			}
+		}
 		// 021, 023, 025: VRC4 / VRC2
 		else if (mapper == 21 || mapper == 23 || mapper == 25)
 		{

--- a/src/devices/bus/nes/nes_pcb.hxx
+++ b/src/devices/bus/nes/nes_pcb.hxx
@@ -435,6 +435,41 @@ static int nes_cart_get_line( const char *feature )
 	return nes_line->line;
 }
 
+struct n163_vol_lines
+{
+	const char *tag;
+	int line;
+};
+
+static const struct n163_vol_lines n163_vol_table[] =
+{
+	{ "SUBMAPPER 0",    0 },
+	{ "SUBMAPPER 1",    1 },
+	{ "SUBMAPPER 2",    2 },
+	{ "SUBMAPPER 3",    3 },
+	{ "SUBMAPPER 4",    4 },
+	{ "SUBMAPPER 5",    5 },
+	{ nullptr }
+};
+
+static int n163_get_submapper_num( const char *feature )
+{
+	const struct n163_vol_lines *n163_line = &n163_vol_table[0];
+
+	if (feature == nullptr)
+		return 128;
+
+	while (n163_line->tag)
+	{
+		if (strcmp(n163_line->tag, feature) == 0)
+			break;
+
+		n163_line++;
+	}
+
+	return n163_line->line;
+}
+
 void nes_cart_slot_device::call_load_pcb()
 {
 	uint32_t vram_size = 0, prgram_size = 0, battery_size = 0, mapper_sram_size = 0;
@@ -549,6 +584,12 @@ void nes_cart_slot_device::call_load_pcb()
 	{
 		if (get_feature("batt"))
 			mapper_sram_size = m_cart->get_mapper_sram_size();
+	}
+
+	if (m_pcb_id == NAMCOT_163)
+	{
+		if (get_feature("n163-vol"))
+			m_cart->set_n163_vol(n163_get_submapper_num(get_feature("n163-vol")));
 	}
 
 

--- a/src/devices/bus/nes/nes_slot.h
+++ b/src/devices/bus/nes/nes_slot.h
@@ -200,6 +200,7 @@ public:
 
 	void set_ce(int mask, int state) {  m_ce_mask = mask; m_ce_state = state; }
 	void set_vrc_lines(int PRG_A, int PRG_B, int CHR) { m_vrc_ls_prg_a = PRG_A; m_vrc_ls_prg_b = PRG_B; m_vrc_ls_chr = CHR; }
+	void set_n163_vol(int vol) { m_n163_vol = vol; }
 	void set_x1_005_alt(bool val) { m_x1_005_alt_mirroring = val; }
 	void set_bus_conflict(bool val) { m_bus_conflict = val; }
 	uint8_t get_open_bus() { return m_open_bus; }
@@ -267,6 +268,7 @@ protected:
 	int m_vrc_ls_prg_a;
 	int m_vrc_ls_prg_b;
 	int m_vrc_ls_chr;
+	int m_n163_vol;
 
 	int m_mirroring;
 	bool m_pcb_ctrl_mirror, m_four_screen_vram, m_has_trainer;


### PR DESCRIPTION
devices/bus/nes/namcot.cpp : Add note

reference : https://wiki.nesdev.com/w/index.php/INES_Mapper_019