### PR TITLE
Flash latches the color as on real QL

### DIFF
--- a/src/mame/video/zx8301.cpp
+++ b/src/mame/video/zx8301.cpp
@@ -278,6 +278,9 @@ void zx8301_device::draw_line_mode8(bitmap_rgb32 &bitmap, int y, uint16_t da)
 {
 	int x = 0;
 
+	bool flash_active = false;
+	int flash_color = 0;
+
 	for (int word = 0; word < 64; word++)
 	{
 		uint8_t byte_high = readbyte(da++);
@@ -292,9 +295,14 @@ void zx8301_device::draw_line_mode8(bitmap_rgb32 &bitmap, int y, uint16_t da)
 
 			int color = (green << 2) | (red << 1) | blue;
 
+			if (flash_active) {
+				color = flash_color;
+			}
+
 			if (flash && m_flash)
 			{
-				color = 0;
+				flash_active = !flash_active;
+				flash_color = color;
 			}
 
 			bitmap.pix32(y, x++) = PALETTE_ZX8301[color];

--- a/src/mame/video/zx8301.cpp
+++ b/src/mame/video/zx8301.cpp
@@ -295,7 +295,8 @@ void zx8301_device::draw_line_mode8(bitmap_rgb32 &bitmap, int y, uint16_t da)
 
 			int color = (green << 2) | (red << 1) | blue;
 
-			if (flash_active) {
+			if (flash_active)
+			{
 				color = flash_color;
 			}
 


### PR DESCRIPTION
The previous behavior looks like it was a temporary implementation, where it was just flashing black. This patch makes the flash bit latch the current color until another set flash bit appears. I've compared it with the real hardware, and it looks the same (except for the speed of the flash).