### PR TITLE
pull SunPlus GCM394 titles out of vii.cpp

### DIFF
--- a/scripts/src/machine.lua
+++ b/scripts/src/machine.lua
@@ -2616,6 +2616,8 @@ end
 ---------------------------------------------------
 --
 --@src/devices/machine/spg2xx.h,MACHINES["SPG2XX"] = true
+--@src/devices/machine/spg110.h,MACHINES["SPG2XX"] = true
+--@src/devices/machine/sunplus_gcm394.h,MACHINES["SPG2XX"] = true
 ---------------------------------------------------
 
 if (MACHINES["SPG2XX"]~=null) then
@@ -2634,6 +2636,8 @@ if (MACHINES["SPG2XX"]~=null) then
 		MAME_DIR .. "src/devices/machine/spg110.h",
 		MAME_DIR .. "src/devices/machine/spg110_video.cpp",
 		MAME_DIR .. "src/devices/machine/spg110_video.h",
+		MAME_DIR .. "src/devices/machine/sunplus_gcm394.cpp",
+		MAME_DIR .. "src/devices/machine/sunplus_gcm394.h",
 	}
 end
 

--- a/scripts/target/mame/mess.lua
+++ b/scripts/target/mame/mess.lua
@@ -3538,6 +3538,7 @@ files {
 	MAME_DIR .. "src/mame/drivers/tvgame.cpp",
 	MAME_DIR .. "src/mame/drivers/spg110.cpp",
 	MAME_DIR .. "src/mame/drivers/vii.cpp",
+	MAME_DIR .. "src/mame/drivers/sunplus_gcm394.cpp",
 	MAME_DIR .. "src/mame/drivers/xavix.cpp",
 	MAME_DIR .. "src/mame/video/xavix.cpp",
 	MAME_DIR .. "src/mame/machine/xavix.cpp",

--- a/src/devices/cpu/unsp/unspdasm.cpp
+++ b/src/devices/cpu/unsp/unspdasm.cpp
@@ -72,6 +72,46 @@ void unsp_disassembler::print_indirect_op(std::ostream &stream, uint8_t opN, uin
 	util::stream_format(stream, forms[opN & 3], regs[opB]);
 }
 
+offs_t unsp_disassembler::disassemble_f_group(std::ostream& stream, offs_t pc, uint16_t op, uint16_t ximm, uint8_t opN, uint8_t opA, uint8_t opB, uint32_t len)
+{
+	switch (opN)
+	{
+	case 1:
+		if (opA == 7)
+		{
+			util::stream_format(stream, "<DUNNO f group>");
+			return UNSP_DASM_OK;
+		}
+		util::stream_format(stream, "mr = %s*%s, us", regs[opA], regs[opB]);
+		return UNSP_DASM_OK;
+	default:
+		util::stream_format(stream, "<DUNNO f group>");
+		return UNSP_DASM_OK;
+	}
+}
+
+offs_t unsp_newer_disassembler::disassemble_f_group(std::ostream& stream, offs_t pc, uint16_t op, uint16_t ximm, uint8_t opN, uint8_t opA, uint8_t opB, uint32_t len)
+{
+	// these are new opcodes on the later core
+
+	switch (opN)
+	{
+	case 1:
+		if (opA == 7)
+		{
+			util::stream_format(stream, "<EXTENDED f group>");
+			return UNSP_DASM_OK;
+		}
+		util::stream_format(stream, "mr = %s*%s, us", regs[opA], regs[opB]);
+		return UNSP_DASM_OK;
+	default:
+		util::stream_format(stream, "<EXTENDED f group>");
+		return UNSP_DASM_OK;
+	}
+}
+
+
+
 offs_t unsp_disassembler::disassemble(std::ostream &stream, offs_t pc, uint16_t op, uint16_t ximm)
 {
 	// the top four bits are the alu op or the branch condition, or E or F
@@ -344,20 +384,7 @@ offs_t unsp_disassembler::disassemble(std::ostream &stream, offs_t pc, uint16_t 
 
 
 	case 0x0f:
-		switch (opN)
-		{
-		case 1:
-			if (opA == 7)
-			{
-				util::stream_format(stream, "<DUNNO>");
-				return UNSP_DASM_OK;
-			}
-			util::stream_format(stream, "mr = %s*%s, us", regs[opA], regs[opB]);
-			return UNSP_DASM_OK;
-		default:
-			util::stream_format(stream, "<DUNNO>");
-			return UNSP_DASM_OK;
-		}
+		return disassemble_f_group(stream, pc, op, ximm, opN, opA, opB, len);
 
 	case 0x4f:
 		switch (opN)

--- a/src/devices/cpu/unsp/unspdasm.h
+++ b/src/devices/cpu/unsp/unspdasm.h
@@ -23,7 +23,14 @@ public:
 
 	virtual u32 opcode_alignment() const override;
 	virtual offs_t disassemble(std::ostream &stream, offs_t pc, const data_buffer &opcodes, const data_buffer &params) override;
+
 	offs_t disassemble(std::ostream &stream, offs_t pc, uint16_t op, uint16_t imm16);
+
+protected:
+	virtual offs_t disassemble_f_group(std::ostream& stream, offs_t pc, uint16_t op, uint16_t ximm, uint8_t opN, uint8_t opA, uint8_t opB, uint32_t len);
+
+	static char const *const regs[];
+	static char const *const jumps[];
 
 private:
 	void print_alu_op_start(std::ostream &stream, uint8_t op0, uint8_t opA);
@@ -31,8 +38,18 @@ private:
 	void print_alu_op_end(std::ostream &stream, uint8_t op0);
 	void print_indirect_op(std::ostream &stream, uint8_t opN, uint8_t opB);
 
-	static char const *const regs[];
-	static char const *const jumps[];
 };
+
+class unsp_newer_disassembler : public unsp_disassembler
+{
+public:
+	unsp_newer_disassembler() = default;
+	virtual ~unsp_newer_disassembler() = default;
+
+private:
+	virtual offs_t disassemble_f_group(std::ostream& stream, offs_t pc, uint16_t op, uint16_t ximm, uint8_t opN, uint8_t opA, uint8_t opB, uint32_t len) override;
+
+};
+
 
 #endif

--- a/src/devices/cpu/unsp/unspdrc.cpp
+++ b/src/devices/cpu/unsp/unspdrc.cpp
@@ -677,6 +677,18 @@ void unsp_device::generate_update_nz(drcuml_block &block)
     single opcode
 ------------------------------------------------------------------*/
 
+bool unsp_device::generate_f_group_opcode(drcuml_block& block, compiler_state& compiler, const opcode_desc* desc)
+{
+	return false;
+}
+
+bool unsp_newer_device::generate_f_group_opcode(drcuml_block& block, compiler_state& compiler, const opcode_desc* desc)
+{
+	// TODO: handle the extended opcodes
+	return true;
+}
+
+
 bool unsp_device::generate_opcode(drcuml_block &block, compiler_state &compiler, const opcode_desc *desc)
 {
 	uint32_t op = (uint32_t)desc->opptr.w[0];
@@ -1297,6 +1309,9 @@ bool unsp_device::generate_opcode(drcuml_block &block, compiler_state &compiler,
 			UML_MOV(block, I1, I2);
 			UML_CALLH(block, *m_mem_write);
 			return true;
+
+		case 0x0f: // Extended
+			return generate_f_group_opcode(block, compiler, desc);
 
 		default:
 			return false;

--- a/src/devices/machine/sunplus_gcm394.cpp
+++ b/src/devices/machine/sunplus_gcm394.cpp
@@ -1,0 +1,49 @@
+// license:BSD-3-Clause
+// copyright-holders:David Haywood
+/*****************************************************************************
+
+  SunPlus "GCM394" (based on die pictures)
+
+**********************************************************************/
+
+#include "emu.h"
+#include "sunplus_gcm394.h"
+
+DEFINE_DEVICE_TYPE(GCM394, sunplus_gcm394_device, "gcm394", "SunPlus GCM394 System-on-a-Chip")
+
+sunplus_gcm394_device::sunplus_gcm394_device(const machine_config &mconfig, const char *tag, device_t *owner, uint32_t clock)
+	: sunplus_gcm394_base_device(mconfig, GCM394, tag, owner, clock)
+{
+}
+
+READ16_MEMBER(sunplus_gcm394_base_device::unk_r)
+{
+	logerror("%s:sunplus_gcm394_base_device::unk_r @ 0x%04x\n", machine().describe_context(), offset + 0x7000);
+	return 0x00;
+}
+
+WRITE16_MEMBER(sunplus_gcm394_base_device::unk_w)
+{
+	logerror("%s:sunplus_gcm394_base_device::unk_w @ 0x%04x (data 0x%04x)\n", machine().describe_context(), offset + 0x7000, data);
+}
+
+void sunplus_gcm394_base_device::map(address_map &map)
+{
+	map(0x000000, 0x006fff).ram();
+	map(0x007000, 0x007fff).rw(FUNC(sunplus_gcm394_base_device::unk_r), FUNC(sunplus_gcm394_base_device::unk_w));
+}
+
+void sunplus_gcm394_base_device::device_start()
+{
+}
+
+void sunplus_gcm394_base_device::device_reset()
+{
+}
+
+void sunplus_gcm394_device::device_add_mconfig(machine_config &config)
+{
+	//SUNPLUS_GCM394_AUDIO(config, m_spg_audio, DERIVED_CLOCK(1, 1));
+	//m_spg_audio->add_route(0, *this, 1.0, AUTO_ALLOC_INPUT, 0);
+	//m_spg_audio->add_route(1, *this, 1.0, AUTO_ALLOC_INPUT, 1);
+}

--- a/src/devices/machine/sunplus_gcm394.h
+++ b/src/devices/machine/sunplus_gcm394.h
@@ -1,0 +1,66 @@
+// license:BSD-3-Clause
+// copyright-holders:David Haywood
+/*****************************************************************************
+
+  SunPlus "GCM394" (based on die pictures)
+
+**********************************************************************/
+
+#ifndef MAME_MACHINE_SUNPLUS_GCM394_H
+#define MAME_MACHINE_SUNPLUS_GCM394_H
+
+#pragma once
+
+#include "cpu/unsp/unsp.h"
+#include "screen.h"
+
+class sunplus_gcm394_base_device : public device_t, public device_mixer_interface
+{
+public:
+	sunplus_gcm394_base_device(const machine_config &mconfig, device_type type, const char *tag, device_t *owner, uint32_t clock)
+	: device_t(mconfig, type, tag, owner, clock)
+	, device_mixer_interface(mconfig, *this, 2)
+	, m_cpu(*this, finder_base::DUMMY_TAG)
+	, m_screen(*this, finder_base::DUMMY_TAG)
+	{
+	}
+
+	void map(address_map &map);
+
+	DECLARE_WRITE_LINE_MEMBER(vblank) { /*m_spg_video->vblank(state);*/ }
+	uint32_t screen_update(screen_device& screen, bitmap_rgb32& bitmap, const rectangle& cliprect) { return 0; /* m_spg_video->screen_update(screen, bitmap, cliprect);*/ }
+
+protected:
+
+	virtual void device_start() override;
+	virtual void device_reset() override;
+
+	required_device<unsp_device> m_cpu;
+	required_device<screen_device> m_screen;
+
+private:
+	DECLARE_READ16_MEMBER(unk_r);
+	DECLARE_WRITE16_MEMBER(unk_w);
+
+};
+
+class sunplus_gcm394_device : public sunplus_gcm394_base_device
+{
+public:
+	template <typename T, typename U>
+	sunplus_gcm394_device(const machine_config& mconfig, const char* tag, device_t* owner, uint32_t clock, T&& cpu_tag, U&& screen_tag)
+		: sunplus_gcm394_device(mconfig, tag, owner, clock)
+	{
+		m_cpu.set_tag(std::forward<T>(cpu_tag));
+		m_screen.set_tag(std::forward<U>(screen_tag));
+	}
+
+	sunplus_gcm394_device(const machine_config& mconfig, const char* tag, device_t* owner, uint32_t clock);
+
+	virtual void device_add_mconfig(machine_config& config) override;
+};
+
+
+DECLARE_DEVICE_TYPE(GCM394, sunplus_gcm394_device)
+
+#endif // MAME_MACHINE_SUNPLUS_GCM394_H

--- a/src/mame/drivers/gaelco2.cpp
+++ b/src/mame/drivers/gaelco2.cpp
@@ -2330,5 +2330,8 @@ GAME( 1999, play2000,    0,         play2000,         play2000, gaelco2_state, i
 GAME( 1999, play2000_50i,play2000,  play2000,         play2000, gaelco2_state, empty_init,     ROT0, "Nova Desitec", "Play 2000 (Super Slot & Gran Tesoro) (v5.0i) (Italy)",  MACHINE_NOT_WORKING ) // bad dump
 GAME( 1999, play2000_40i,play2000,  play2000,         play2000, gaelco2_state, init_play2000,  ROT0, "Nova Desitec", "Play 2000 (Super Slot & Gran Tesoro) (v4.0i) (Italy)",  0 )
 
-// Gym exercise bike
-GAME( 1997, saltcrdi,   0,          saltcrdi,         saltcrdi, gaelco2_state, empty_init,     ROT0, "Salter Fitness / Gaelco", "Pro Tele Cardioline (Salter Fitness Bike V.1.0, Checksum 02AB)", MACHINE_NOT_WORKING ) // there are other machines in the Cardioline series, without TV displays
+// Gym equipment
+GAME( 1997, saltcrdi,   0,          saltcrdi,         saltcrdi, gaelco2_state, empty_init,     ROT0, "Salter Fitness / Gaelco", "Pro Cycle Tele Cardioline (Salter Fitness Bike V.1.0, Checksum 02AB)", MACHINE_NOT_WORKING )
+// Pro Reclimber Tele
+// Pro Stepper Tele
+// there are other devices in Cardioline series that don't use displays

--- a/src/mame/drivers/sunplus_gcm394.cpp
+++ b/src/mame/drivers/sunplus_gcm394.cpp
@@ -1,0 +1,200 @@
+// license:BSD-3-Clause
+// copyright-holders:David Haywood
+/*
+	SunPlus unSP based hardware, SPG-??? (6xx?) (die is GCM394)
+
+	Compared to vii.cpp this is clearly newer, has extra opcodes, different internal map etc. also scaling and higher resolutions based on Spongebob
+
+		Smart Fit Park
+		SpongeBob SquarePants Bikini Bottom 500
+		Spiderman - The Masked Menace 'Spider Sense' (pad type with Spiderman model)
+		(Wireless Hunting? - maybe, register map looks the same even if it sets stack to 2fff not 6fff)
+
+	as these use newer opcodes in the FExx range they probably need a derived unSP type too
+*/
+
+#include "emu.h"
+
+#include "machine/sunplus_gcm394.h"
+#include "machine/spg2xx.h"
+
+#include "screen.h"
+#include "speaker.h"
+
+
+class gcm394_game_state : public driver_device
+{
+public:
+	gcm394_game_state(const machine_config &mconfig, device_type type, const char *tag)
+		: driver_device(mconfig, type, tag)
+		, m_maincpu(*this, "maincpu")
+		, m_screen(*this, "screen")
+		, m_spg(*this, "spg")
+		, m_bank(*this, "cartbank")
+	{ }
+
+	void base(machine_config &config);
+
+protected:
+	virtual void machine_start() override;
+	virtual void machine_reset() override;
+
+	void switch_bank(uint32_t bank);
+
+	required_device<unsp_device> m_maincpu;
+	required_device<screen_device> m_screen;
+	required_device<sunplus_gcm394_device> m_spg;
+
+	optional_memory_bank m_bank;
+
+	virtual void mem_map_4m(address_map &map);
+
+private:
+	uint32_t m_current_bank;
+};
+
+void gcm394_game_state::base(machine_config &config)
+{
+	GCM394(config, m_spg, XTAL(27'000'000), m_maincpu, m_screen);
+
+	UNSP_NEWER(config, m_maincpu, XTAL(27'000'000));
+	m_maincpu->set_addrmap(AS_PROGRAM, &gcm394_game_state::mem_map_4m);
+
+	SCREEN(config, m_screen, SCREEN_TYPE_RASTER);
+	m_screen->set_refresh_hz(60);
+	m_screen->set_size(320, 262);
+	m_screen->set_visarea(0, 320-1, 0, 240-1);
+	m_screen->set_screen_update("spg", FUNC(sunplus_gcm394_device::screen_update));
+	m_screen->screen_vblank().set(m_spg, FUNC(sunplus_gcm394_device::vblank));
+
+	SPEAKER(config, "lspeaker").front_left();
+	SPEAKER(config, "rspeaker").front_right();
+	m_spg->add_route(ALL_OUTPUTS, "lspeaker", 0.5);
+	m_spg->add_route(ALL_OUTPUTS, "rspeaker", 0.5);
+
+}
+
+void gcm394_game_state::switch_bank(uint32_t bank)
+{
+	if (bank != m_current_bank)
+	{
+		m_current_bank = bank;
+		m_bank->set_entry(bank);
+		m_maincpu->invalidate_cache();
+	}
+}
+
+void gcm394_game_state::machine_start()
+{
+	m_bank->configure_entries(0, (memregion("maincpu")->bytes() + 0x7fffff) / 0x800000, memregion("maincpu")->base(), 0x800000);
+	m_bank->set_entry(0);
+
+	save_item(NAME(m_current_bank));
+}
+
+void gcm394_game_state::machine_reset()
+{
+	m_current_bank = 0;
+}
+
+void gcm394_game_state::mem_map_4m(address_map &map)
+{
+	map(0x000000, 0x3fffff).bankr("cartbank");
+	map(0x000000, 0x007fff).m(m_spg, FUNC(sunplus_gcm394_device::map));
+}
+
+static INPUT_PORTS_START( gcm394 )
+INPUT_PORTS_END
+
+
+/*
+Wireless Hunting Video Game System
+(info provided with dump)
+
+System: Wireless Hunting Video Game System
+Publisher: Hamy / Kids Station Toys Inc
+Year: 2011
+ROM: FDI MSP55LV100G
+RAM: Micron Technology 48LC8M16A2
+
+Games:
+
+Secret Mission
+Predator
+Delta Force
+Toy Land
+Dream Forest
+Trophy Season
+Freedom Force
+Be Careful
+Net Power
+Open Training
+Super Archer
+Ultimate Frisbee
+UFO Shooting
+Happy Darts
+Balloon Shoot
+Avatair
+Angry Pirate
+Penguin War
+Ghost Shooter
+Duck Hunt
+
+
+ROM Board:
+
+Package: SO44
+Spacing: 1.27 mm
+Width: 16.14 mm
+Length: 27.78 mm
+Voltage: 3V
+Pinout:
+
+		  A25  A24
+			|  |
+	  +--------------------------+
+A21 --|==   #  # `.__.'        ==|-- A20
+A18 --|==                      ==|-- A19
+A17 --|==                      ==|-- A8
+ A7 --|==                      ==|-- A9
+ A6 --|==                  o   ==|-- A10
+ A5 --|==  +----------------+  ==|-- A11
+ A4 --|==  |                |  ==|-- A12
+ A3 --|==  |  MSP55LV100G   |  ==|-- A13
+ A2 --|==  |  0834 M02H     |  ==|-- A14
+ A1 --|==  |  JAPAN         |  ==|-- A15
+ A0 --|==  |                |  ==|-- A16
+#CE --|==  |                |  ==|-- A23
+GND --|==  |                |  ==|-- A22
+#OE --|==  |                |  ==|-- Q15
+ Q0 --|==  |                |  ==|-- Q7
+ Q8 --|==  |                |  ==|-- Q14
+ Q1 --|==  +----------------+  ==|-- Q6
+ Q9 --|==                      ==|-- Q13
+ Q2 --|==       M55L100G       ==|-- Q5
+Q10 --|==                      ==|-- Q12
+ Q3 --|==                      ==|-- Q4
+Q11 --|==                      ==|-- VCC
+	  +--------------------------+
+
+
+The only interesting string in this ROM is SPF2ALP,
+which is also found in the Wireless Air 60 ROM.
+
+*/
+
+ROM_START(wrlshunt)
+	ROM_REGION(0x8000000, "maincpu", ROMREGION_ERASE00)
+	ROM_LOAD16_WORD_SWAP("wireless.bin", 0x0000, 0x8000000, CRC(a6ecc20e) SHA1(3645f23ba2bb218e92d4560a8ae29dddbaabf796))
+ROM_END
+
+ROM_START(smartfp) // this has data in the area that would usually be covered by the SPG, is it accessible somehow this time?
+	ROM_REGION(0x800000, "maincpu", ROMREGION_ERASE00)
+	ROM_LOAD16_WORD_SWAP("smartfitpark.bin", 0x000000, 0x800000, CRC(ada84507) SHA1(a3a80bf71fae62ebcbf939166a51d29c24504428))
+ROM_END
+
+
+CONS(2011, wrlshunt, 0, 0, base, gcm394, gcm394_game_state, empty_init, "Hamy / Kids Station Toys Inc", "Wireless Hunting Video Game System", MACHINE_NO_SOUND | MACHINE_NOT_WORKING)
+
+CONS(2009, smartfp, 0, 0, base, gcm394, gcm394_game_state, empty_init, "Fisher-Price", "Fun 2 Learn Smart Fit Park", MACHINE_NOT_WORKING | MACHINE_IMPERFECT_SOUND)
+// Fun 2 Learn 3-in-1 SMART SPORTS  ?

--- a/src/mame/drivers/vii.cpp
+++ b/src/mame/drivers/vii.cpp
@@ -76,20 +76,13 @@
 
         ---
 
-        These are definitely different
+        These are definitely different but still unSP based
 
-        "SunPlus PA7801" ( known as Sunplus SPG110? ) see spg110.cpp instead
+        "SunPlus PA7801" ( known as Sunplus SPG110? )
+		- see spg110.cpp instead
 
-            Classic Arcade Pinball
-            EA Sports (NHL95 + Madden 95)
-            Spiderman 5-in-1 (original release)
-
-        "GCM394" (this is clearly newer, has extra opcodes, different internal map etc. also scaling and higher resolutions based on Spongebob)
-
-            Smart Fit Park
-			SpongeBob SquarePants Bikini Bottom 500
-			Spiderman - The Masked Menace 'Spider Sense' (pad type with Spiderman model)
-			(Wireless Hunting? - maybe)
+        "GCM394" (this is clearly newer, has extra opcodes, different internal map etc. also scaling and higher resolutions based on Spongebob) 
+		- see sunplus_gcm394.cpp instead
 
     Status:
 
@@ -1439,14 +1432,14 @@ INPUT_PORTS_END
 
 READ16_MEMBER(dreamlif_state::portb_r)
 {
-	// some kind of EEPROM device?
+	// some kind of EEPROM device?  has a HT93LC66A
 	logerror("%s: portb_r\n", machine().describe_context());
 	return 0x0000;
 }
 
 WRITE16_MEMBER(dreamlif_state::portb_w)
 {
-	// some kind of EEPROM device?
+	// some kind of EEPROM device? see above
 	logerror("%s: portb_w (%04x)\n", machine().describe_context(), data);
 }
 
@@ -2190,10 +2183,6 @@ ROM_START( dreamlif )
 	ROM_LOAD16_WORD_SWAP( "dreamlife.bin", 0x000000, 0x800000, CRC(632e0237) SHA1(a8586e8a626d75cf7782f13cfd9f1b938af23d56) )
 ROM_END
 
-ROM_START( smartfp )
-	ROM_REGION( 0x800000, "maincpu", ROMREGION_ERASE00 )
-	ROM_LOAD16_WORD_SWAP( "smartfitpark.bin", 0x000000, 0x800000, CRC(ada84507) SHA1(a3a80bf71fae62ebcbf939166a51d29c24504428) )
-ROM_END
 
 
 
@@ -2234,88 +2223,6 @@ ROM_START( wlsair60 )
 	ROM_REGION( 0x8400000, "maincpu", ROMREGION_ERASE00 )
 	ROM_LOAD16_WORD_SWAP( "wlsair60.nand", 0x0000, 0x8400000, CRC(eec23b97) SHA1(1bb88290cf54579a5bb51c08a02d793cd4d79f7a) )
 ROM_END
-
-/*
-Wireless Hunting Video Game System
-(info provided with dump)
-
-System: Wireless Hunting Video Game System
-Publisher: Hamy / Kids Station Toys Inc
-Year: 2011
-ROM: FDI MSP55LV100G
-RAM: Micron Technology 48LC8M16A2
-
-Games:
-
-Secret Mission
-Predator
-Delta Force
-Toy Land
-Dream Forest
-Trophy Season
-Freedom Force
-Be Careful
-Net Power
-Open Training
-Super Archer
-Ultimate Frisbee
-UFO Shooting
-Happy Darts
-Balloon Shoot
-Avatair
-Angry Pirate
-Penguin War
-Ghost Shooter
-Duck Hunt
-
-
-ROM Board:
-
-Package: SO44
-Spacing: 1.27 mm
-Width: 16.14 mm
-Length: 27.78 mm
-Voltage: 3V
-Pinout:
-
-          A25  A24
-            |  |
-      +--------------------------+
-A21 --|==   #  # `.__.'        ==|-- A20
-A18 --|==                      ==|-- A19
-A17 --|==                      ==|-- A8
- A7 --|==                      ==|-- A9
- A6 --|==                  o   ==|-- A10
- A5 --|==  +----------------+  ==|-- A11
- A4 --|==  |                |  ==|-- A12
- A3 --|==  |  MSP55LV100G   |  ==|-- A13
- A2 --|==  |  0834 M02H     |  ==|-- A14
- A1 --|==  |  JAPAN         |  ==|-- A15
- A0 --|==  |                |  ==|-- A16
-#CE --|==  |                |  ==|-- A23
-GND --|==  |                |  ==|-- A22
-#OE --|==  |                |  ==|-- Q15
- Q0 --|==  |                |  ==|-- Q7
- Q8 --|==  |                |  ==|-- Q14
- Q1 --|==  +----------------+  ==|-- Q6
- Q9 --|==                      ==|-- Q13
- Q2 --|==       M55L100G       ==|-- Q5
-Q10 --|==                      ==|-- Q12
- Q3 --|==                      ==|-- Q4
-Q11 --|==                      ==|-- VCC
-      +--------------------------+
-
-
-The only interesting string in this ROM is SPF2ALP,
-which is also found in the Wireless Air 60 ROM.
-
-*/
-
-ROM_START( wrlshunt )
-	ROM_REGION( 0x8000000, "maincpu", ROMREGION_ERASE00 )
-	ROM_LOAD16_WORD_SWAP( "wireless.bin", 0x0000, 0x8000000, CRC(a6ecc20e) SHA1(3645f23ba2bb218e92d4560a8ae29dddbaabf796) )
-ROM_END
-
 
 void spg2xx_game_state::init_crc()
 {
@@ -2437,13 +2344,6 @@ CONS( 2009, zone40,    0,       0,        non_spg_base, wirels60, spg2xx_game_st
 
 // Similar, SPG260?, scrambled
 CONS( 200?, lexizeus,    0,       0,        lexizeus, lexizeus, spg2xx_game_state, init_zeus, "Lexibook",          "Zeus IG900 20-in-1 (US?)",           MACHINE_NO_SOUND | MACHINE_NOT_WORKING )
-
-
-// valid looking code, but extended periperhal area (twice the size?) makes use of unemulated opcode 0xfe00 ?
-CONS( 2011, wrlshunt,  0,       0,        non_spg_base, wirels60, spg2xx_game_state, empty_init, "Hamy / Kids Station Toys Inc",                      "Wireless Hunting Video Game System", MACHINE_NO_SOUND | MACHINE_NOT_WORKING )
-// extended opcodes different internal map?
-CONS( 2009, smartfp,   0,       0,        non_spg_base, wirels60, spg2xx_game_state, empty_init, "Fisher-Price", "Fun 2 Learn Smart Fit Park",     MACHINE_NOT_WORKING | MACHINE_IMPERFECT_SOUND )
-// Fun 2 Learn 3-in-1 SMART SPORTS  ?
 
 // NAND dumps w/ internal bootstrap. Almost certainly do not fit in this driver, as the SPG2xx can only address up to 4Mwords. These are 'GeneralPlus' instead?
 CONS( 2010, wlsair60,  0,       0,        non_spg_base, wirels60, spg2xx_game_state, empty_init, "Jungle Soft / Kids Station Toys Inc",               "Wireless Air 60",   MACHINE_NO_SOUND | MACHINE_NOT_WORKING )

--- a/src/mame/mame.lst
+++ b/src/mame/mame.lst
@@ -36515,6 +36515,10 @@ srangero                        // (c) 1988
 srangerw                        // (c) 1988 SunA (WDK License)
 starfigh                        // (c) 1990 SunA
 
+@source:sunplus_gcm394.cpp
+smartfp                         // Smart Fit Park
+wrlshunt                        // Wireless: Hunting Video Game System
+
 @source:supbtime.cpp
 chinatwn                        // MAK (c) 1991 Data East Corporation (Japan)
 supbtime                        // MAE (c) 1990 Data East Corporation (World)
@@ -38810,7 +38814,6 @@ jak_nick                        //
 jak_sbfc                        //
 lexizeus                        // Lexibook
 vii                             // KenSingTon / Jungle Soft / Siatronics Vii
-wrlshunt                        // Wireless: Hunting Video Game System
 wirels60                        // Wireless 60
 wlsair60                        // Wireless Air 60
 zone40                          // Zone 40
@@ -38822,7 +38825,6 @@ rad_crik                        //
 rad_fb2                         //
 mattelcs                        //
 dreamlif                        //
-smartfp                         //
 icanguit                        //
 icanpian                        //
 

--- a/src/mame/mess.flt
+++ b/src/mame/mess.flt
@@ -739,6 +739,7 @@ sun2.cpp
 sun3.cpp
 sun3x.cpp
 sun4.cpp
+sunplus_gcm394.cpp
 super6.cpp
 super80.cpp
 superslave.cpp


### PR DESCRIPTION
pull SunPlus GCM394 titles out of vii.cpp
- it's a newer SoC (with a lot more capabilities, eg rotate, zoom, twice the sound channels)
- it uses an updated unSP core (with some extra opcodes)

also made the modifications needed to allow for extension of the unSP + disassembler once we've worked out what the extra opcodes are.