### PR TITLE
daryde.cpp: Add NVRAM dump to "cricket" [@LosTrastosDeXaX, ClawGrip]

### DIFF
--- a/src/mame/drivers/daryde.cpp
+++ b/src/mame/drivers/daryde.cpp
@@ -137,6 +137,9 @@ ROM_START(cricket)
 	ROM_REGION(0x22e, "pal", 0)
 	ROM_LOAD("a_palce16v8h.ic4", 0x000, 0x117, NO_DUMP)
 	ROM_LOAD("b_palce16v8h.ic5", 0x117, 0x117, NO_DUMP)
+	
+        ROM_REGION(0x2000, "nvram", 0)
+	ROM_LOAD("ds1225y.ic7", 0x0000, 0x2000, BAD_DUMP CRC(3a7f0f6f) SHA1(b672859399db854bc049c75beea482b5afb3d2bb)) // NVRAM dumped from a working machine, but may not be the default
 ROM_END
 
 GAME(1995, cricket, 0, pandart, pandart, daryde_state, empty_init, ROT0, "Daryde S. L.", "Cricket",       MACHINE_IS_SKELETON_MECHANICAL)


### PR DESCRIPTION
(nw) It may be useful to have a working NVRAM dump when working on the driver