### PR TITLE
upd765: Implement SRB status register, including RDDATA bit.  

### DIFF
--- a/scripts/src/formats.lua
+++ b/scripts/src/formats.lua
@@ -727,6 +727,18 @@ end
 
 --------------------------------------------------
 --
+--@src/lib/formats/dvk_mx_dsk.h,FORMATS["DVK_MX_DSK"] = true
+--------------------------------------------------
+
+if (FORMATS["DVK_MX_DSK"]~=null  or _OPTIONS["with-tools"]) then
+	files {
+		MAME_DIR.. "src/lib/formats/dvk_mx_dsk.cpp",
+		MAME_DIR.. "src/lib/formats/dvk_mx_dsk.h",
+	}
+end
+
+--------------------------------------------------
+--
 --@src/lib/formats/esq16_dsk.h,FORMATS["ESQ16_DSK"] = true
 --------------------------------------------------
 

--- a/src/devices/imagedev/floppy.cpp
+++ b/src/devices/imagedev/floppy.cpp
@@ -784,6 +784,25 @@ attotime floppy_image_device::get_next_index_time(std::vector<uint32_t> &buf, in
 	return base + attotime::from_nsec((uint64_t(next_position)*2000/floppy_ratio_1+1)/2);
 }
 
+int floppy_image_device::get_rddata(const attotime &when)
+{
+	if(!image || mon)
+		return -1;
+
+	std::vector<uint32_t> &buf = image->get_buffer(cyl, ss, subcyl);
+	uint32_t cells = buf.size();
+	if(cells <= 1)
+		return -1;
+
+	attotime base;
+	int index = find_index(find_position(base, when), buf);
+
+	if(index == -1)
+		return -1;
+
+	return (buf[index] & floppy_image::MG_MASK) >> floppy_image::MG_SHIFT;
+}
+
 attotime floppy_image_device::get_next_transition(const attotime &from_when)
 {
 	if(!image || mon)

--- a/src/devices/imagedev/floppy.h
+++ b/src/devices/imagedev/floppy.h
@@ -126,6 +126,7 @@ public:
 	void index_resync();
 	attotime time_next_index();
 	attotime get_next_transition(const attotime &from_when);
+	int get_rddata(const attotime &when);
 	void write_flux(const attotime &start, const attotime &end, int transition_count, const attotime *transitions);
 	void set_write_splice(const attotime &when);
 	int get_sides() { return sides; }

--- a/src/lib/formats/dvk_mx_dsk.cpp
+++ b/src/lib/formats/dvk_mx_dsk.cpp
@@ -1,0 +1,177 @@
+// license:BSD-3-Clause
+// copyright-holders:Sergey Svishchev
+/**********************************************************************
+
+	formats/dvk_mx_dsk.cpp
+
+	Floppies used by DVK MX: controller
+
+	http://torlus.com/floppy/forum/viewtopic.php?f=19&t=1384
+
+	Track format is almost entirely driver-dependent (only sync word
+	0x00f3 is mandatory), because hardware always reads or writes
+	entire track.  'old' format is used by stock driver, 'new' --
+	by 3rd party one. Formatting tools produce yet other variants...
+
+	Floppy drives were 40- and 80-track, double-sided.  'new' driver
+	also supports single-sided floppies.
+
+************************************************************************/
+
+#include <assert.h>
+
+#include "flopimg.h"
+#include "formats/dvk_mx_dsk.h"
+
+const floppy_image_format_t::desc_e dvk_mx_format::dvk_mx_new_desc[] = {
+	/* 01 */ { FM, 0x00, 8*2 },	// eight 0x0000 words
+	/* 03 */ { FM, 0x00, 1 },
+	/* 02 */ { FM, 0xf3, 1 },	// word 0x00f3
+	/* 05 */ { FM, 0x00, 1 },
+	/* 04 */ { TRACK_ID_FM },	// track number word
+	/* 05 */ { SECTOR_LOOP_START, 0, 10 },	// 11 sectors
+	/* 07 */ {   SECTOR_DATA_MX, -1 },
+	/* 10 */ { SECTOR_LOOP_END },
+	/* 13 */ { FM, 0x83, 1 },
+	/* 12 */ { OFFSET_ID_FM },
+	/* 15 */ { FM, 0x83, 1 },
+	/* 14 */ { OFFSET_ID_FM },
+	/* 17 */ { FM, 0x83, 1 },
+	/* 16 */ { OFFSET_ID_FM },
+	/* 18 */ { END }
+};
+
+const floppy_image_format_t::desc_e dvk_mx_format::dvk_mx_old_desc[] = {
+	/* 01 */ { FM, 0x00, 30*2 },
+	/* 03 */ { FM, 0x00, 1 },
+	/* 02 */ { FM, 0xf3, 1 },	// word 0x00f3
+	/* 05 */ { FM, 0x00, 1 },
+	/* 04 */ { TRACK_ID_FM },	// track number word
+	/* 06 */ { SECTOR_LOOP_START, 0, 10 },	// 11 sectors
+	/* 07 */ {   SECTOR_DATA_MX, -1 },
+	/* 10 */ { SECTOR_LOOP_END },
+	/* 13 */ { FM, 0x83, 1 },
+	/* 11 */ { FM, 0x01, 1 },
+	/* 15 */ { FM, 0x83, 1 },
+	/* 14 */ { FM, 0x01, 1 },
+	/* 16 */ { END }
+};
+
+dvk_mx_format::dvk_mx_format()
+{
+}
+
+const char *dvk_mx_format::name() const
+{
+	return "mx";
+}
+
+const char *dvk_mx_format::description() const
+{
+	return "DVK MX: floppy image";
+}
+
+const char *dvk_mx_format::extensions() const
+{
+	return "mx";
+}
+
+bool dvk_mx_format::supports_save() const
+{
+	return false;
+}
+
+void dvk_mx_format::find_size(io_generic *io, uint8_t &track_count, uint8_t &head_count, uint8_t &sector_count)
+{
+	uint64_t size = io_generic_size(io);
+
+	switch (size)
+	{
+	case 112640:
+		track_count = 40;
+		sector_count = 11;
+		head_count = 1;
+		break;
+	case 225280:
+		track_count = 40;
+		sector_count = 11;
+		head_count = 2;
+		break;
+	case 450560:
+		track_count = 80;
+		sector_count = 11;
+		head_count = 2;
+		break;
+	default:
+		track_count = head_count = sector_count = 0;
+		break;
+	}
+}
+
+int dvk_mx_format::identify(io_generic *io, uint32_t form_factor)
+{
+	uint8_t track_count, head_count, sector_count;
+
+	find_size(io, track_count, head_count, sector_count);
+
+	if (track_count)
+	{
+		uint8_t sectdata[512];
+		io_generic_read(io, sectdata, 512, 512);
+		// check value in RT-11 home block.  see src/tools/imgtool/modules/rt11.cpp
+		if (pick_integer_le(sectdata, 0724, 2) == 6)
+			return 100;
+		else
+			return 75;
+
+	}
+
+	return 0;
+}
+
+bool dvk_mx_format::load(io_generic *io, uint32_t form_factor, floppy_image *image)
+{
+	uint8_t track_count, head_count, sector_count;
+
+	find_size(io, track_count, head_count, sector_count);
+	if (track_count == 0) return false;
+
+	uint8_t sectdata[11 * 256];
+	desc_s sectors[11];
+	for (int i = 0; i < sector_count; i++)
+	{
+		sectors[i].data = sectdata + 256 * i;
+		sectors[i].size = 256;
+		sectors[i].sector_id = i;
+	}
+
+	int track_size = sector_count * 256;
+	for (int track = 0; track < track_count; track++)
+	{
+		for (int head = 0; head < head_count; head++)
+		{
+			io_generic_read(io, sectdata, (track * head_count + head) * track_size, track_size);
+			generate_track(dvk_mx_new_desc, track, head, sectors, sector_count, 45824, image);
+		}
+	}
+
+	if (head_count == 1)
+	{
+		image->set_variant(floppy_image::SSDD);
+	}
+	else
+	{
+		if (track_count > 40)
+		{
+			image->set_variant(floppy_image::DSQD);
+		}
+		else
+		{
+			image->set_variant(floppy_image::DSDD);
+		}
+	}
+
+	return true;
+}
+
+const floppy_format_type FLOPPY_DVK_MX_FORMAT = &floppy_image_format_creator<dvk_mx_format>;

--- a/src/lib/formats/dvk_mx_dsk.h
+++ b/src/lib/formats/dvk_mx_dsk.h
@@ -1,0 +1,39 @@
+// license:BSD-3-Clause
+// copyright-holders:Sergey Svishchev
+/*********************************************************************
+
+	formats/dvk_mx_dsk.h
+
+*********************************************************************/
+
+#ifndef DVK_MX_DSK_H_
+#define DVK_MX_DSK_H_
+
+#pragma once
+
+#include "flopimg.h"
+#include "imageutl.h"
+
+class dvk_mx_format : public floppy_image_format_t
+{
+public:
+	dvk_mx_format();
+
+	virtual int identify(io_generic *io, uint32_t form_factor) override;
+	virtual bool load(io_generic *io, uint32_t form_factor, floppy_image *image) override;
+
+	virtual const char *name() const override;
+	virtual const char *description() const override;
+	virtual const char *extensions() const override;
+	virtual bool supports_save() const override;
+
+	static const desc_e dvk_mx_old_desc[];
+	static const desc_e dvk_mx_new_desc[];
+
+private:
+	void find_size(io_generic *io, uint8_t &track_count, uint8_t &head_count, uint8_t &sector_count);
+};
+
+extern const floppy_format_type FLOPPY_DVK_MX_FORMAT;
+
+#endif /* DVK_MX_DSK_H_ */

--- a/src/lib/formats/flopimg.cpp
+++ b/src/lib/formats/flopimg.cpp
@@ -1038,6 +1038,7 @@ bool floppy_image_format_t::type_data_mfm(int type, int p1, const gen_crc_info *
 		type == SIZE_ID ||
 		type == OFFSET_ID_O ||
 		type == OFFSET_ID_E ||
+		type == OFFSET_ID_FM ||
 		type == SECTOR_ID_O ||
 		type == SECTOR_ID_E ||
 		type == REMAIN_O ||
@@ -1521,6 +1522,10 @@ void floppy_image_format_t::generate_track(const desc_e *desc, int track, int he
 			mfm_half_w(buffer, 6, track*2+head);
 			break;
 
+		case OFFSET_ID_FM:
+			fm_w(buffer, 8, track*2+head);
+			break;
+
 		case SECTOR_ID_O:
 			mfm_half_w(buffer, 7, sector_idx);
 			break;
@@ -1647,6 +1652,21 @@ void floppy_image_format_t::generate_track(const desc_e *desc, int track, int he
 			const desc_s *csect = sect + (desc[index].p1 >= 0 ? desc[index].p1 : sector_idx);
 			for(int i=0; i != csect->size; i++)
 				_8n1_w(buffer, 8, csect->data[i]);
+			break;
+		}
+
+		case SECTOR_DATA_MX: {
+			const desc_s *csect = sect + (desc[index].p1 >= 0 ? desc[index].p1 : sector_idx);
+			uint16_t cksum = 0, data;
+			for(int i=0; i < csect->size; i+=2)
+			{
+				data = csect->data[i+1];
+				fm_w(buffer, 8, data);
+				data = (data << 8) | csect->data[i];
+				fm_w(buffer, 8, csect->data[i]);
+				cksum += data;
+			}
+			fm_w(buffer, 16, cksum);
 			break;
 		}
 

--- a/src/lib/formats/flopimg.h
+++ b/src/lib/formats/flopimg.h
@@ -333,6 +333,7 @@ protected:
 		SECTOR_INFO_GCR6,       //!< Sector info byte, gcr6-encoded
 		OFFSET_ID_O,            //!< Offset (track*2+head) byte, odd bits, mfm-encoded
 		OFFSET_ID_E,            //!< Offset (track*2+head) byte, even bits, mfm-encoded
+		OFFSET_ID_FM,           //!< Offset (track*2+head) byte, fm-encoded
 		SECTOR_ID_O,            //!< Sector id byte, odd bits, mfm-encoded
 		SECTOR_ID_E,            //!< Sector id byte, even bits, mfm-encoded
 		REMAIN_O,               //!< Remaining sector count, odd bits, mfm-encoded, total sector count in p1
@@ -345,6 +346,7 @@ protected:
 		SECTOR_DATA_GCR5,       //!< Sector data to gcr5-encode, which in p1, -1 for the current one per the sector id
 		SECTOR_DATA_MAC,        //!< Transformed sector data + checksum, mac style, id in p1, -1 for the current one per the sector id
 		SECTOR_DATA_8N1,        //!< Sector data to 8N1-encode, which in p1, -1 for the current one per the sector id
+		SECTOR_DATA_MX,         //!< Sector data to MX-encode, which in p1, -1 for the current one per the sector id
 
 		CRC_CCITT_START,        //!< Start a CCITT CRC calculation, with the usual x^16 + x^12 + x^5 + 1 (11021) polynomial, p1 = crc id
 		CRC_CCITT_FM_START,     //!< Start a CCITT CRC calculation, with the usual x^16 + x^12 + x^5 + 1 (11021) polynomial, p1 = crc id

--- a/src/tools/floptool.cpp
+++ b/src/tools/floptool.cpp
@@ -51,6 +51,8 @@
 
 #include "formats/hpi_dsk.h"
 
+#include "formats/dvk_mx_dsk.h"
+
 static floppy_format_type floppy_formats[] = {
 	FLOPPY_MFI_FORMAT,
 	FLOPPY_DFI_FORMAT,
@@ -89,7 +91,9 @@ static floppy_format_type floppy_formats[] = {
 
 	FLOPPY_APPLIX_FORMAT,
 
-	FLOPPY_HPI_FORMAT
+	FLOPPY_HPI_FORMAT,
+
+	FLOPPY_DVK_MX_FORMAT
 };
 
 void CLIB_DECL ATTR_PRINTF(1,2) logerror(const char *format, ...)


### PR DESCRIPTION
Replace magic numbers. (nw)

Add dvk_mx floppy format.  Combined, this lets MXONPC run in at586 driver.