### PR TITLE
smartfp clearly uses unsp isa20 push/pop instructions in the interrupt

### DIFF
--- a/src/devices/cpu/unsp/unsp.cpp
+++ b/src/devices/cpu/unsp/unsp.cpp
@@ -146,7 +146,7 @@ std::unique_ptr<util::disasm_interface> unsp_12_device::create_disassembler()
 
 std::unique_ptr<util::disasm_interface> unsp_20_device::create_disassembler()
 {
-	return std::make_unique<unsp_12_disassembler>();
+	return std::make_unique<unsp_20_disassembler>();
 }
 
 void unsp_device::unimplemented_opcode(uint16_t op)

--- a/src/devices/cpu/unsp/unsp_extended.cpp
+++ b/src/devices/cpu/unsp/unsp_extended.cpp
@@ -27,10 +27,10 @@ void unsp_20_device::execute_extended_group(uint16_t op)
 	case 0x00: case 0x10:
 	{
 		// Ext Register Ra = Ra op Rb
-		uint8_t aluop = (op & 0xf000) >> 12;
-		uint8_t rb = (op & 0x000f) >> 0;
-		uint8_t ra = (op & 0x0e00) >> 9;
-		ra |= (op & 0x0100) >> 5;
+		uint8_t aluop = (ximm & 0xf000) >> 12;
+		uint8_t rb = (ximm & 0x000f) >> 0;
+		uint8_t ra = (ximm & 0x0e00) >> 9;
+		ra |= (ximm & 0x0100) >> 5;
 
 		logerror("(Ext) %s = %s %s %s\n", (ra & 0x8) ? extregs[ra & 0x7] : regs[ra & 0x7]
 														 , (ra & 0x8) ? extregs[ra & 0x7] : regs[ra & 0x7]
@@ -43,15 +43,18 @@ void unsp_20_device::execute_extended_group(uint16_t op)
 	case 0x02:
 	{
 		// Ext Push/Pop
-		if (op & 0x8000)
+		if (ximm & 0x8000)
 		{
-			uint8_t rb =   (op & 0x000f) >> 0;
-			uint8_t size = (op & 0x7000) >> 12;
-			uint8_t rx   = (op & 0x0e00) >> 9;
+			uint8_t rb =   (ximm & 0x000f) >> 0;
+			uint8_t size = (ximm & 0x7000) >> 12;
+			uint8_t rx   = (ximm & 0x0e00) >> 9;
 
-			if (rx+1 >= size && rx < size+7)
+			if (size == 0) size = 8;
+			size -= 1;
+
+			if ((rx-size) >= 0)
 				logerror("(Ext) push %s, %s to [%s]\n",
-					   extregs[rx+1-size], extregs[rx], (rb & 0x8) ? extregs[rb & 0x7] : regs[rb & 0x7]);
+					   extregs[rx-size], extregs[rx], (rb & 0x8) ? extregs[rb & 0x7] : regs[rb & 0x7]);
 			else
 				logerror("(Ext) push <BAD>\n");
 
@@ -59,15 +62,19 @@ void unsp_20_device::execute_extended_group(uint16_t op)
 		}
 		else
 		{
-			uint8_t rb =   (op & 0x000f) >> 0;
-			uint8_t size = (op & 0x7000) >> 12;
-			uint8_t rx   = (op & 0x0e00) >> 9;
+			uint8_t rb =   (ximm & 0x000f) >> 0;
+			uint8_t size = (ximm & 0x7000) >> 12;
+			uint8_t rx   = (ximm & 0x0e00) >> 9;
 
-			if (rx+1 < 8 && rx+size < 8)
+			if (size == 0) size = 8;
+			size -= 1;
+
+			if ((rx-size) >= 0)
 				logerror("(Ext) pop %s, %s from [%s]\n",
-					   extregs[rx+1], extregs[rx+size], (rb & 0x8) ? extregs[rb & 0x7] : regs[rb & 0x7]);
+					   extregs[rx-size], extregs[rx], (rb & 0x8) ? extregs[rb & 0x7] : regs[rb & 0x7]);
 			else
 				logerror("(Ext) pop <BAD>\n");
+
 
 			unimplemented_opcode(op, ximm);
 		}
@@ -79,10 +86,10 @@ void unsp_20_device::execute_extended_group(uint16_t op)
 		add_lpc(1);
 
 		// Ra=Rb op IMM16
-		uint8_t aluop = (op & 0xf000) >> 12;
-		uint8_t rb = (op & 0x000f) >> 0;
-		uint8_t ra = (op & 0x0e00) >> 9;
-		ra |= (op & 0x0100) >> 5;
+		uint8_t aluop = (ximm & 0xf000) >> 12;
+		uint8_t rb = (ximm & 0x000f) >> 0;
+		uint8_t ra = (ximm & 0x0e00) >> 9;
+		ra |= (ximm & 0x0100) >> 5;
 
 		logerror("(Ext) %s = %s %s %04x\n", (ra & 0x8) ? extregs[ra & 0x7] : regs[ra & 0x7]
 														   , (rb & 0x8) ? extregs[rb & 0x7] : regs[rb & 0x7]
@@ -100,10 +107,10 @@ void unsp_20_device::execute_extended_group(uint16_t op)
 		add_lpc(1);
 
 		// Ra=Rb op [A16]
-		uint8_t aluop = (op & 0xf000) >> 12;
-		uint8_t rb = (op & 0x000f) >> 0;
-		uint8_t ra = (op & 0x0e00) >> 9;
-		ra |= (op & 0x0100) >> 5;
+		uint8_t aluop = (ximm & 0xf000) >> 12;
+		uint8_t rb = (ximm & 0x000f) >> 0;
+		uint8_t ra = (ximm & 0x0e00) >> 9;
+		ra |= (ximm & 0x0100) >> 5;
 
 		logerror("(Ext) %s = %s %s [%04x]\n", (ra & 0x8) ? extregs[ra & 0x7] : regs[ra & 0x7]
 															 , (rb & 0x8) ? extregs[rb & 0x7] : regs[rb & 0x7]
@@ -121,10 +128,10 @@ void unsp_20_device::execute_extended_group(uint16_t op)
 		add_lpc(1);
 
 		//[A16] = Ra op Rb
-		uint8_t aluop = (op & 0xf000) >> 12;
-		uint8_t rb = (op & 0x000f) >> 0;
-		uint8_t ra = (op & 0x0e00) >> 9;
-		ra |= (op & 0x0100) >> 5;
+		uint8_t aluop = (ximm & 0xf000) >> 12;
+		uint8_t rb = (ximm & 0x000f) >> 0;
+		uint8_t ra = (ximm & 0x0e00) >> 9;
+		ra |= (ximm & 0x0100) >> 5;
 
 		logerror("(Ext) [0x4x] = %s %s %s\n", ximm_2
 															 , (ra & 0x8) ? extregs[ra & 0x7] : regs[ra & 0x7]
@@ -138,10 +145,10 @@ void unsp_20_device::execute_extended_group(uint16_t op)
 	case 0x08: case 0x09:
 	{
 		// Ext Indirect Rx=Rx op [Ry@]
-		uint8_t aluop = (op & 0xf000) >> 12;
-		uint8_t ry = (op & 0x0007) >> 0;
-		uint8_t form = (op & 0x0018) >> 3;
-		uint8_t rx = (op & 0x0e00) >> 9;
+		uint8_t aluop = (ximm & 0xf000) >> 12;
+		uint8_t ry = (ximm & 0x0007) >> 0;
+		uint8_t form = (ximm & 0x0018) >> 3;
+		uint8_t rx = (ximm & 0x0e00) >> 9;
 
 		logerror("(Ext) %s=%s %s", extregs[rx], extregs[rx], aluops[aluop]);
 		logerror(forms[form], extregs[ry]);
@@ -152,10 +159,10 @@ void unsp_20_device::execute_extended_group(uint16_t op)
 	case 0x0a: case 0x0b:
 	{
 		// Ext DS_Indirect Rx=Rx op ds:[Ry@]
-		uint8_t aluop = (op & 0xf000) >> 12;
-		uint8_t ry = (op & 0x0007) >> 0;
-		uint8_t form = (op & 0x0018) >> 3;
-		uint8_t rx = (op & 0x0e00) >> 9;
+		uint8_t aluop = (ximm & 0xf000) >> 12;
+		uint8_t ry = (ximm & 0x0007) >> 0;
+		uint8_t form = (ximm & 0x0018) >> 3;
+		uint8_t rx = (ximm & 0x0e00) >> 9;
 
 		logerror("(Ext) %s=%s %s ds:", extregs[rx], extregs[rx], aluops[aluop]);
 		logerror(forms[form], extregs[ry]);
@@ -166,9 +173,9 @@ void unsp_20_device::execute_extended_group(uint16_t op)
 	case 0x18: case 0x19: case 0x1a: case 0x1b:
 	{
 		// Ext IM6 Rx=Rx op IM6
-		uint8_t aluop = (op & 0xf000) >> 12;
-		uint8_t rx = (op & 0x0e00) >> 9;
-		uint8_t imm6 = (op & 0x003f) >> 0;
+		uint8_t aluop = (ximm & 0xf000) >> 12;
+		uint8_t rx = (ximm & 0x0e00) >> 9;
+		uint8_t imm6 = (ximm & 0x003f) >> 0;
 
 		logerror("(Ext) %s=%s %s %02x\n", extregs[rx], extregs[rx], aluops[aluop], imm6 );
 		unimplemented_opcode(op, ximm);
@@ -178,9 +185,9 @@ void unsp_20_device::execute_extended_group(uint16_t op)
 	case 0x0c: case 0x0d: case 0x0e: case 0x0f:
 	{
 		// Ext Base+Disp6 Rx=Rx op [BP+IM6]
-		uint8_t aluop = (op & 0xf000) >> 12;
-		uint8_t rx = (op & 0x0e00) >> 9;
-		uint8_t imm6 = (op & 0x003f) >> 0;
+		uint8_t aluop = (ximm & 0xf000) >> 12;
+		uint8_t rx = (ximm & 0x0e00) >> 9;
+		uint8_t imm6 = (ximm & 0x003f) >> 0;
 
 		logerror("(Ext) %s=%s %s [BP+%02x]\n", extregs[rx], extregs[rx], aluops[aluop], imm6 );
 		unimplemented_opcode(op, ximm);
@@ -190,9 +197,9 @@ void unsp_20_device::execute_extended_group(uint16_t op)
 	case 0x1c: case 0x1d: case 0x1e: case 0x1f:
 	{
 		// Ext A6 Rx=Rx op [A6]
-		uint8_t aluop = (op & 0xf000) >> 12;
-		uint8_t rx = (op & 0x0e00) >> 9;
-		uint8_t a6 = (op & 0x003f) >> 0;
+		uint8_t aluop = (ximm & 0xf000) >> 12;
+		uint8_t rx = (ximm & 0x0e00) >> 9;
+		uint8_t a6 = (ximm & 0x003f) >> 0;
 
 		logerror("(Ext) %s=%s %s [%02x]\n", extregs[rx], extregs[rx], aluops[aluop], a6 );
 		unimplemented_opcode(op, ximm);

--- a/src/devices/cpu/unsp/unsp_extended.cpp
+++ b/src/devices/cpu/unsp/unsp_extended.cpp
@@ -42,6 +42,8 @@ void unsp_20_device::execute_extended_group(uint16_t op)
 	}
 	case 0x02:
 	{
+		// register decoding could be incorrect here
+
 		// Ext Push/Pop
 		if (ximm & 0x8000)
 		{

--- a/src/devices/cpu/unsp/unsp_fxxx.cpp
+++ b/src/devices/cpu/unsp/unsp_fxxx.cpp
@@ -370,6 +370,14 @@ void unsp_device::execute_fxxx_101_group(uint16_t op)
 inline void unsp_device::execute_fxxx_110_group(uint16_t op)
 {
 	//uint32_t len = 1;
+	
+	// some sources say this is FFc0, but smartfp clearly uses ff80
+	// EXTOP   1 1 1 1   1 1 1 1   1 0 0 0   0 0 0 0    (+16 bit imm)
+	if ((op == 0xff80) && m_iso >= 20)
+	{
+		return execute_extended_group(op);
+	}	
+	
 	//                         |   | |
 	// signed * signed  (size 16,1,2,3,4,5,6,7)
 	// MULS    1 1 1 1*  r r r 1*  1 0*s s   s r r r    (1* = sign bit, 1* = sign bit 0* = upper size bit)
@@ -383,11 +391,7 @@ inline void unsp_device::execute_fxxx_111_group(uint16_t op)
 {
 	//uint32_t len = 1;
 	//                         |   | |
-	// EXTOP   1 1 1 1   1 1 1 1   1 1 0 0   0 0 0 0    (+16 bit imm)
-	if ((op == 0xffc0) && m_iso >= 20)
-	{
-		return execute_extended_group(op);
-	}
+
 
 	// signed * signed  (size 8,9,10,11,12,13,14,15)
 	// MULS    1 1 1 1*  r r r 1*  1 1*s s   s r r r    (1* = sign bit, 1* = sign bit 1* = upper size bit)

--- a/src/devices/cpu/unsp/unspdasm.h
+++ b/src/devices/cpu/unsp/unspdasm.h
@@ -43,7 +43,7 @@ protected:
 	offs_t disassemble_fxxx_011_group(std::ostream& stream, offs_t pc, uint16_t op, uint16_t ximm);
 	offs_t disassemble_fxxx_100_group(std::ostream& stream, offs_t pc, uint16_t op, uint16_t ximm);
 	virtual offs_t disassemble_fxxx_101_group(std::ostream& stream, offs_t pc, uint16_t op, uint16_t ximm);
-	offs_t disassemble_fxxx_110_group(std::ostream& stream, offs_t pc, uint16_t op, uint16_t ximm);
+	offs_t disassemble_fxxx_110_group(std::ostream& stream, offs_t pc, uint16_t op, uint16_t ximm, const data_buffer& opcodes);
 	offs_t disassemble_fxxx_111_group(std::ostream& stream, offs_t pc, uint16_t op, uint16_t ximm, const data_buffer& opcodes);
 
 	virtual offs_t disassemble_exxx_group(std::ostream& stream, offs_t pc, uint16_t op, uint16_t ximm);

--- a/src/devices/cpu/unsp/unspdasm_extended.cpp
+++ b/src/devices/cpu/unsp/unspdasm_extended.cpp
@@ -30,10 +30,10 @@ offs_t unsp_20_disassembler::disassemble_extended_group(std::ostream& stream, of
 	case 0x00: case 0x10:
 	{
 		// Ext Register Ra = Ra op Rb
-		uint8_t aluop = (op & 0xf000) >> 12;
-		uint8_t rb = (op & 0x000f) >> 0;
-		uint8_t ra = (op & 0x0e00) >> 9;
-		ra |= (op & 0x0100) >> 5;
+		uint8_t aluop = (ximm & 0xf000) >> 12;
+		uint8_t rb = (ximm & 0x000f) >> 0;
+		uint8_t ra = (ximm & 0x0e00) >> 9;
+		ra |= (ximm & 0x0100) >> 5;
 
 		util::stream_format(stream, "(Ext) %s = %s %s %s", (ra & 0x8) ? extregs[ra & 0x7] : regs[ra & 0x7]
 														 , (ra & 0x8) ? extregs[ra & 0x7] : regs[ra & 0x7]
@@ -43,28 +43,36 @@ offs_t unsp_20_disassembler::disassemble_extended_group(std::ostream& stream, of
 	}
 	case 0x02:
 	{
-		// Ext Push/Pop
-		if (op & 0x8000)
-		{
-			uint8_t rb =   (op & 0x000f) >> 0;
-			uint8_t size = (op & 0x7000) >> 12;
-			uint8_t rx   = (op & 0x0e00) >> 9;
+		// register decoding could be incorrect here
 
-			if (rx+1 >= size && rx < size+7)
+		// Ext Push/Pop
+		if (ximm & 0x8000)
+		{
+			uint8_t rb =   (ximm & 0x000f) >> 0;
+			uint8_t size = (ximm & 0x7000) >> 12;
+			uint8_t rx   = (ximm & 0x0e00) >> 9;
+
+			if (size == 0) size = 8;
+			size -= 1;
+
+			if ((rx-size) >= 0)
 				util::stream_format(stream, "(Ext) push %s, %s to [%s]",
-					   extregs[rx+1-size], extregs[rx], (rb & 0x8) ? extregs[rb & 0x7] : regs[rb & 0x7]);
+					   extregs[rx-size], extregs[rx], (rb & 0x8) ? extregs[rb & 0x7] : regs[rb & 0x7]);
 			else
 				util::stream_format(stream, "(Ext) push <BAD>");
 		}
 		else
 		{
-			uint8_t rb =   (op & 0x000f) >> 0;
-			uint8_t size = (op & 0x7000) >> 12;
-			uint8_t rx   = (op & 0x0e00) >> 9;
+			uint8_t rb =   (ximm & 0x000f) >> 0;
+			uint8_t size = (ximm & 0x7000) >> 12;
+			uint8_t rx   = (ximm & 0x0e00) >> 9;
 
-			if (rx+1 < 8 && rx+size < 8)
+			if (size == 0) size = 8;
+			size -= 1;
+
+			if ((rx-size) >= 0)
 				util::stream_format(stream, "(Ext) pop %s, %s from [%s]",
-					   extregs[rx+1], extregs[rx+size], (rb & 0x8) ? extregs[rb & 0x7] : regs[rb & 0x7]);
+					   extregs[rx-size], extregs[rx], (rb & 0x8) ? extregs[rb & 0x7] : regs[rb & 0x7]);
 			else
 				util::stream_format(stream, "(Ext) pop <BAD>");
 		}
@@ -75,10 +83,10 @@ offs_t unsp_20_disassembler::disassemble_extended_group(std::ostream& stream, of
 		// Ra=Rb op IMM16
 		len = 3;
 		uint16_t imm16_2 = opcodes.r16(pc + 2);
-		uint8_t aluop = (op & 0xf000) >> 12;
-		uint8_t rb = (op & 0x000f) >> 0;
-		uint8_t ra = (op & 0x0e00) >> 9;
-		ra |= (op & 0x0100) >> 5;
+		uint8_t aluop = (ximm & 0xf000) >> 12;
+		uint8_t rb = (ximm & 0x000f) >> 0;
+		uint8_t ra = (ximm & 0x0e00) >> 9;
+		ra |= (ximm & 0x0100) >> 5;
 
 		util::stream_format(stream, "(Ext) %s = %s %s %04x", (ra & 0x8) ? extregs[ra & 0x7] : regs[ra & 0x7]
 														   , (rb & 0x8) ? extregs[rb & 0x7] : regs[rb & 0x7]
@@ -93,10 +101,10 @@ offs_t unsp_20_disassembler::disassemble_extended_group(std::ostream& stream, of
 		// Ra=Rb op [A16]
 		len = 3;
 		uint16_t imm16_2 = opcodes.r16(pc + 2);
-		uint8_t aluop = (op & 0xf000) >> 12;
-		uint8_t rb = (op & 0x000f) >> 0;
-		uint8_t ra = (op & 0x0e00) >> 9;
-		ra |= (op & 0x0100) >> 5;
+		uint8_t aluop = (ximm & 0xf000) >> 12;
+		uint8_t rb = (ximm & 0x000f) >> 0;
+		uint8_t ra = (ximm & 0x0e00) >> 9;
+		ra |= (ximm & 0x0100) >> 5;
 
 		util::stream_format(stream, "(Ext) %s = %s %s [%04x]", (ra & 0x8) ? extregs[ra & 0x7] : regs[ra & 0x7]
 															 , (rb & 0x8) ? extregs[rb & 0x7] : regs[rb & 0x7]
@@ -111,10 +119,10 @@ offs_t unsp_20_disassembler::disassemble_extended_group(std::ostream& stream, of
 		//[A16] = Ra op Rb
 		len = 3;
 		uint16_t imm16_2 = opcodes.r16(pc + 2);
-		uint8_t aluop = (op & 0xf000) >> 12;
-		uint8_t rb = (op & 0x000f) >> 0;
-		uint8_t ra = (op & 0x0e00) >> 9;
-		ra |= (op & 0x0100) >> 5;
+		uint8_t aluop = (ximm & 0xf000) >> 12;
+		uint8_t rb = (ximm & 0x000f) >> 0;
+		uint8_t ra = (ximm & 0x0e00) >> 9;
+		ra |= (ximm & 0x0100) >> 5;
 
 		util::stream_format(stream, "(Ext) [0x4x] = %s %s %s", imm16_2
 															 , (ra & 0x8) ? extregs[ra & 0x7] : regs[ra & 0x7]
@@ -127,10 +135,10 @@ offs_t unsp_20_disassembler::disassemble_extended_group(std::ostream& stream, of
 	{
 		// Ext Indirect Rx=Rx op [Ry@]
 
-		uint8_t aluop = (op & 0xf000) >> 12;
-		uint8_t ry = (op & 0x0007) >> 0;
-		uint8_t form = (op & 0x0018) >> 3;
-		uint8_t rx = (op & 0x0e00) >> 9;
+		uint8_t aluop = (ximm & 0xf000) >> 12;
+		uint8_t ry = (ximm & 0x0007) >> 0;
+		uint8_t form = (ximm & 0x0018) >> 3;
+		uint8_t rx = (ximm & 0x0e00) >> 9;
 
 		util::stream_format(stream, "(Ext) %s=%s %s", extregs[rx], extregs[rx], aluops[aluop]);
 		util::stream_format(stream, forms[form], extregs[ry]);
@@ -141,10 +149,10 @@ offs_t unsp_20_disassembler::disassemble_extended_group(std::ostream& stream, of
 	{
 		// Ext DS_Indirect Rx=Rx op ds:[Ry@]
 
-		uint8_t aluop = (op & 0xf000) >> 12;
-		uint8_t ry = (op & 0x0007) >> 0;
-		uint8_t form = (op & 0x0018) >> 3;
-		uint8_t rx = (op & 0x0e00) >> 9;
+		uint8_t aluop = (ximm & 0xf000) >> 12;
+		uint8_t ry = (ximm & 0x0007) >> 0;
+		uint8_t form = (ximm & 0x0018) >> 3;
+		uint8_t rx = (ximm & 0x0e00) >> 9;
 
 		util::stream_format(stream, "(Ext) %s=%s %s ds:", extregs[rx], extregs[rx], aluops[aluop]);
 		util::stream_format(stream, forms[form], extregs[ry]);
@@ -155,9 +163,9 @@ offs_t unsp_20_disassembler::disassemble_extended_group(std::ostream& stream, of
 	{
 		// Ext IM6 Rx=Rx op IM6
 
-		uint8_t aluop = (op & 0xf000) >> 12;
-		uint8_t rx = (op & 0x0e00) >> 9;
-		uint8_t imm6 = (op & 0x003f) >> 0;
+		uint8_t aluop = (ximm & 0xf000) >> 12;
+		uint8_t rx = (ximm & 0x0e00) >> 9;
+		uint8_t imm6 = (ximm & 0x003f) >> 0;
 
 		util::stream_format(stream, "(Ext) %s=%s %s %02x", extregs[rx], extregs[rx], aluops[aluop], imm6 );
 		return UNSP_DASM_OK;
@@ -167,9 +175,9 @@ offs_t unsp_20_disassembler::disassemble_extended_group(std::ostream& stream, of
 	{
 		// Ext Base+Disp6 Rx=Rx op [BP+IM6]
 
-		uint8_t aluop = (op & 0xf000) >> 12;
-		uint8_t rx = (op & 0x0e00) >> 9;
-		uint8_t imm6 = (op & 0x003f) >> 0;
+		uint8_t aluop = (ximm & 0xf000) >> 12;
+		uint8_t rx = (ximm & 0x0e00) >> 9;
+		uint8_t imm6 = (ximm & 0x003f) >> 0;
 
 		util::stream_format(stream, "(Ext) %s=%s %s [BP+%02x]", extregs[rx], extregs[rx], aluops[aluop], imm6 );
 		return UNSP_DASM_OK;
@@ -179,9 +187,9 @@ offs_t unsp_20_disassembler::disassemble_extended_group(std::ostream& stream, of
 	{
 		// Ext A6 Rx=Rx op [A6]
 
-		uint8_t aluop = (op & 0xf000) >> 12;
-		uint8_t rx = (op & 0x0e00) >> 9;
-		uint8_t a6 = (op & 0x003f) >> 0;
+		uint8_t aluop = (ximm & 0xf000) >> 12;
+		uint8_t rx = (ximm & 0x0e00) >> 9;
+		uint8_t a6 = (ximm & 0x003f) >> 0;
 
 		util::stream_format(stream, "(Ext) %s=%s %s [%02x]", extregs[rx], extregs[rx], aluops[aluop], a6 );
 		return UNSP_DASM_OK;

--- a/src/devices/cpu/unsp/unspdasm_fxxx.cpp
+++ b/src/devices/cpu/unsp/unspdasm_fxxx.cpp
@@ -304,8 +304,17 @@ offs_t unsp_disassembler::disassemble_fxxx_101_group(std::ostream& stream, offs_
 	return UNSP_DASM_OK;
 }
 
-offs_t unsp_disassembler::disassemble_fxxx_110_group(std::ostream& stream, offs_t pc, uint16_t op, uint16_t ximm)
+offs_t unsp_disassembler::disassemble_fxxx_110_group(std::ostream& stream, offs_t pc, uint16_t op, uint16_t ximm, const data_buffer &opcodes)
 {
+	//                         |   | |
+
+	// some sources say this is FFc0, but smartfp clearly uses ff80
+	// EXTOP   1 1 1 1   1 1 1 1   1 0 0 0   0 0 0 0    (+16 bit imm)
+	if ((op == 0xff80) && m_iso >= 20)
+	{
+		return disassemble_extended_group(stream, pc, op, ximm, opcodes);
+	}
+
 	uint32_t len = 1;
 	//                         |   | |
 	// signed * signed  (size 16,1,2,3,4,5,6,7)
@@ -319,12 +328,6 @@ offs_t unsp_disassembler::disassemble_fxxx_110_group(std::ostream& stream, offs_
 offs_t unsp_disassembler::disassemble_fxxx_111_group(std::ostream& stream, offs_t pc, uint16_t op, uint16_t ximm,const data_buffer &opcodes)
 {
 	uint32_t len = 1;
-	//                         |   | |
-	// EXTOP   1 1 1 1   1 1 1 1   1 1 0 0   0 0 0 0    (+16 bit imm)
-	if ((op == 0xffc0) && m_iso >= 20)
-	{
-		return disassemble_extended_group(stream, pc, op, ximm, opcodes);
-	}
 
 	// signed * signed  (size 8,9,10,11,12,13,14,15)
 	// MULS    1 1 1 1*  r r r 1*  1 1*s s   s r r r    (1* = sign bit, 1* = sign bit 1* = upper size bit)
@@ -360,7 +363,7 @@ offs_t unsp_disassembler::disassemble_fxxx_group(std::ostream &stream, offs_t pc
 		return disassemble_fxxx_101_group(stream, pc, op, ximm);
 
 	case 0x6:
-		return disassemble_fxxx_110_group(stream, pc, op, ximm);
+		return disassemble_fxxx_110_group(stream, pc, op, ximm, opcodes);
 
 	case 0x7:
 		return disassemble_fxxx_111_group(stream, pc, op, ximm, opcodes);

--- a/src/mame/drivers/sunplus_gcm394.cpp
+++ b/src/mame/drivers/sunplus_gcm394.cpp
@@ -57,7 +57,7 @@ void gcm394_game_state::base(machine_config &config)
 {
 	GCM394(config, m_spg, XTAL(27'000'000), m_maincpu, m_screen);
 
-	UNSP_12(config, m_maincpu, XTAL(27'000'000));
+	UNSP_20(config, m_maincpu, XTAL(27'000'000)); // code at 8019 uses extended opcode, so must be 2.0+?
 	m_maincpu->set_addrmap(AS_PROGRAM, &gcm394_game_state::mem_map_4m);
 
 	SCREEN(config, m_screen, SCREEN_TYPE_RASTER);


### PR DESCRIPTION
smartfp clearly uses unsp isa20 push/pop instructions in the interrupt even if nowhere else in the code (nw)