### PR TITLE
seibucats.cpp, seibuspi.cpp : Updates

### DIFF
--- a/src/mame/drivers/seibucats.cpp
+++ b/src/mame/drivers/seibucats.cpp
@@ -111,56 +111,81 @@ public:
 
 private:
 	// screen updates
-//  uint32_t screen_update(screen_device &screen, bitmap_ind16 &bitmap, const rectangle &cliprect);
+//  u32 screen_update(screen_device &screen, bitmap_ind16 &bitmap, const rectangle &cliprect);
 //  IRQ_CALLBACK_MEMBER(spi_irq_callback);
 //  INTERRUPT_GEN_MEMBER(spi_interrupt);
 
-	DECLARE_READ16_MEMBER(input_mux_r);
-	DECLARE_WRITE16_MEMBER(input_select_w);
-	DECLARE_WRITE16_MEMBER(output_latch_w);
-	DECLARE_WRITE16_MEMBER(aux_rtc_w);
+	u16 input_mux_r();
+	void input_select_w(u16 data);
+	void output_latch_w(u16 data);
+	void aux_rtc_w(u16 data);
 
 	void seibucats_map(address_map &map);
 
 	// driver_device overrides
 	virtual void machine_start() override;
 	virtual void machine_reset() override;
+	virtual void video_start() override;
 
-//  virtual void video_start() override;
-
-	uint16_t m_input_select;
+	u16 m_input_select;
 
 //  optional_ioport_array<5> m_key;
 //  optional_ioport m_special;
 };
 
-// identical to EJ Sakura
-READ16_MEMBER(seibucats_state::input_mux_r)
+void seibucats_state::video_start()
 {
-	uint16_t ret = m_special->read();
+	m_video_dma_length = 0;
+	m_video_dma_address = 0;
+	m_layer_enable = 0;
+	m_layer_bank = 0;
+	m_rf2_layer_bank = 0;
+	m_rowscroll_enable = false;
+	set_layer_offsets();
+
+	m_tilemap_ram_size = 0;
+	m_palette_ram_size = 0x4000; // TODO : correct?
+	m_sprite_ram_size = 0x2000; // TODO : correct?
+	m_sprite_bpp = 6; // see above
+
+	m_tilemap_ram = nullptr;
+	m_palette_ram = make_unique_clear<u32[]>(m_palette_ram_size/4);
+	m_sprite_ram = make_unique_clear<u32[]>(m_sprite_ram_size/4);
+
+	m_palette->basemem().set(&m_palette_ram[0], m_palette_ram_size, 32, ENDIANNESS_LITTLE, 2);
+
+	memset(m_alpha_table, 0, 0x2000); // TODO : no alpha blending?
+
+	register_video_state();
+}
+
+// identical to EJ Sakura
+u16 seibucats_state::input_mux_r()
+{
+	u16 ret = m_special->read();
 
 	// multiplexed inputs
 	for (int i = 0; i < 5; i++)
-		if (m_input_select >> i & 1)
+		if (BIT(m_input_select, i))
 			ret &= m_key[i]->read();
 
 	return ret;
 }
 
-WRITE16_MEMBER(seibucats_state::input_select_w)
+void seibucats_state::input_select_w(u16 data)
 {
 	// Note that this is active high in ejsakura but active low here
 	m_input_select = data ^ 0xffff;
 }
 
-WRITE16_MEMBER(seibucats_state::output_latch_w)
+void seibucats_state::output_latch_w(u16 data)
 {
 	m_eeprom->di_write((data & 0x8000) ? 1 : 0);
 	m_eeprom->clk_write((data & 0x4000) ? ASSERT_LINE : CLEAR_LINE);
 	m_eeprom->cs_write((data & 0x2000) ? ASSERT_LINE : CLEAR_LINE);
 }
 
-WRITE16_MEMBER(seibucats_state::aux_rtc_w)
+void seibucats_state::aux_rtc_w(u16 data)
 {
 }
 
@@ -254,20 +279,14 @@ static const gfx_layout sys386f_spritelayout =
 	RGN_FRAC(1,4),
 	8,
 	{ 0, 8, RGN_FRAC(1,4)+0, RGN_FRAC(1,4)+8, RGN_FRAC(2,4)+0, RGN_FRAC(2,4)+8, RGN_FRAC(3,4)+0, RGN_FRAC(3,4)+8 },
-	{
-		7,6,5,4,3,2,1,0,23,22,21,20,19,18,17,16
-	},
-	{
-		0*32,1*32,2*32,3*32,4*32,5*32,6*32,7*32,8*32,9*32,10*32,11*32,12*32,13*32,14*32,15*32
-	},
+	{ STEP8(7,-1), STEP8(8*2+7,-1) },
+	{ STEP16(0,8*4) },
 	16*32
 };
 
 
 static GFXDECODE_START( gfx_seibucats )
-	GFXDECODE_ENTRY( "gfx1", 0, sys386f_spritelayout,   5632, 16 ) // Not used, legacy charlayout
-	GFXDECODE_ENTRY( "gfx2", 0, sys386f_spritelayout,   4096, 24 ) // Not used, legacy tilelayout
-	GFXDECODE_ENTRY( "gfx3", 0, sys386f_spritelayout,   0, 96 )
+	GFXDECODE_ENTRY( "sprites", 0, sys386f_spritelayout, 0, 64 )
 GFXDECODE_END
 
 
@@ -324,7 +343,7 @@ void seibucats_state::seibucats(machine_config &config)
 
 	ymz280b_device &ymz(YMZ280B(config, "ymz", XTAL(16'384'000)));
 	ymz.add_route(0, "lspeaker", 1.0);
-	ymz.add_route(0, "rspeaker", 1.0);
+	ymz.add_route(1, "rspeaker", 1.0);
 }
 
 
@@ -335,7 +354,7 @@ void seibucats_state::seibucats(machine_config &config)
 ***************************************************************************/
 
 #define SEIBUCATS_OBJ_LOAD \
-	ROM_REGION( 0x400000, "gfx3", ROMREGION_ERASE00) \
+	ROM_REGION( 0x400000, "sprites", ROMREGION_ERASE00) \
 /*  obj4.u0234 empty slot */ \
 	ROM_LOAD16_WORD_SWAP("obj03.u0232", 0x100000, 0x100000, BAD_DUMP CRC(15c230cf) SHA1(7e12871d6e34e28cd4b5b23af6b0cbdff9432500)  ) \
 	ROM_LOAD16_WORD_SWAP("obj02.u0233", 0x200000, 0x100000, BAD_DUMP CRC(dffd0114) SHA1(b74254061b6da5a2ce310ea89684db430b43583e)  ) \
@@ -348,10 +367,6 @@ ROM_START( emjjoshi )
 	ROM_LOAD32_BYTE( "prg1.u011",    0x000001, 0x080000, CRC(1082ede1) SHA1(0d1a682f37ede5c9070c14d1c3491a3082ad0759) )
 	ROM_LOAD32_BYTE( "prg2.u017",    0x000002, 0x080000, CRC(df85a8f7) SHA1(83226767b0c33e8cc3baee6f6bb17e4f1a6c9c27) )
 	ROM_LOAD32_BYTE( "prg3.u015",    0x000003, 0x080000, CRC(6fe7fd41) SHA1(e7ea9cb83bdeed4872f9e423b8294b9ca4b29b6b) )
-
-	ROM_REGION( 0x30000, "gfx1", ROMREGION_ERASEFF ) /* text layer roms - none! */
-
-	ROM_REGION( 0x900000, "gfx2", ROMREGION_ERASEFF ) /* background layer roms - none! */
 
 	SEIBUCATS_OBJ_LOAD
 
@@ -368,10 +383,6 @@ ROM_START( emjscanb )
 	ROM_LOAD32_BYTE( "prg2.u017",    0x000002, 0x080000, CRC(b89d7693) SHA1(174b2ecfd8a3c593a81905c1c9d62728f710f5d1) )
 	ROM_LOAD32_BYTE( "prg3.u015",    0x000003, 0x080000, CRC(6b38a07b) SHA1(2131ae726fc38c8054801c1de4d17eec5b55dd2d) )
 
-	ROM_REGION( 0x30000, "gfx1", ROMREGION_ERASEFF ) /* text layer roms - none! */
-
-	ROM_REGION( 0x900000, "gfx2", ROMREGION_ERASEFF ) /* background layer roms - none! */
-
 	SEIBUCATS_OBJ_LOAD
 
 	DISK_REGION("dvd")
@@ -385,10 +396,6 @@ ROM_START( emjtrapz )
 	ROM_LOAD32_BYTE( "prg2.u017",    0x000002, 0x080000, CRC(69995273) SHA1(a7e10d21a524a286acd0a8c19c41a101eee30626) )
 	ROM_LOAD32_BYTE( "prg3.u015",    0x000003, 0x080000, CRC(99f86a19) SHA1(41deb5eb78c0a675da7e1b1bbd5c440e157c7a25) )
 
-	ROM_REGION( 0x30000, "gfx1", ROMREGION_ERASEFF ) /* text layer roms - none! */
-
-	ROM_REGION( 0x900000, "gfx2", ROMREGION_ERASEFF ) /* background layer roms - none! */
-
 	SEIBUCATS_OBJ_LOAD
 
 	DISK_REGION("dvd")
@@ -397,11 +404,11 @@ ROM_END
 
 void seibucats_state::init_seibucats()
 {
-	uint16_t *src = (uint16_t *)memregion("gfx3")->base();
-	uint16_t tmp[0x40 / 2], offset;
+	u16 *src = (u16 *)memregion("sprites")->base();
+	u16 tmp[0x40 / 2], offset;
 
 	// sprite_reorder() only
-	for (int i = 0; i < memregion("gfx3")->bytes() / 0x40; i++)
+	for (int i = 0; i < memregion("sprites")->bytes() / 0x40; i++)
 	{
 		memcpy(tmp, src, 0x40);
 
@@ -411,7 +418,7 @@ void seibucats_state::init_seibucats()
 			*src++ = tmp[offset];
 		}
 	}
-//  seibuspi_rise11_sprite_decrypt_rfjet(memregion("gfx3")->base(), 0x300000);
+//  seibuspi_rise11_sprite_decrypt_rfjet(memregion("sprites")->base(), 0x300000);
 }
 
 // Gravure Collection

--- a/src/mame/drivers/seibuspi.cpp
+++ b/src/mame/drivers/seibuspi.cpp
@@ -906,50 +906,50 @@ Notes:
 
 /*****************************************************************************/
 
-READ8_MEMBER(seibuspi_state::sound_fifo_status_r)
+u8 seibuspi_state::sound_fifo_status_r()
 {
 	// d0: fifo full flag (z80)
 	// d1: fifo empty flag (main)
 	// other bits: unused?
-	int d1 = (m_soundfifo[1] != nullptr) ? m_soundfifo[1]->ef_r() << 1 : 0;
+	const u8 d1 = (m_soundfifo[1] != nullptr) ? m_soundfifo[1]->ef_r() << 1 : 0;
 	return d1 | m_soundfifo[0]->ff_r();
 }
 
-READ8_MEMBER(seibuspi_state::spi_status_r)
+u8 seibuspi_state::spi_status_r()
 {
 	// d0: unknown status, waits for it to be set, video/dma related?
 	// other bits: unused?
 	return 0x01;
 }
 
-READ8_MEMBER(seibuspi_state::spi_ds2404_unknown_r)
+u8 seibuspi_state::spi_ds2404_unknown_r()
 {
 	// d0, d1, d2: unknown, waits for it to be cleared
 	return 0x00;
 }
 
-WRITE8_MEMBER(seibuspi_state::eeprom_w)
+void seibuspi_state::eeprom_w(u8 data)
 {
 	m_eeprom->di_write((data & 0x80) ? 1 : 0);
 	m_eeprom->clk_write((data & 0x40) ? ASSERT_LINE : CLEAR_LINE);
 	m_eeprom->cs_write((data & 0x20) ? ASSERT_LINE : CLEAR_LINE);
 }
 
-WRITE8_MEMBER(seibuspi_state::spi_layerbanks_eeprom_w)
+void seibuspi_state::spi_layerbanks_eeprom_w(u8 data)
 {
 	// low bits: tile banks
-	rf2_layer_bank_w(space, 0, data);
+	rf2_layer_bank_w(data);
 
 	// high bits: eeprom
-	eeprom_w(space, 0, data);
+	eeprom_w(data);
 }
 
-WRITE8_MEMBER(seibuspi_state::oki_bank_w)
+void seibuspi_state::oki_bank_w(u8 data)
 {
 	m_oki[1]->set_rom_bank((data >> 2) & 1);
 }
 
-WRITE8_MEMBER(seibuspi_state::z80_prg_transfer_w)
+void seibuspi_state::z80_prg_transfer_w(u8 data)
 {
 	if (m_z80_prg_transfer_pos < m_z80_rom->bytes())
 	{
@@ -958,7 +958,7 @@ WRITE8_MEMBER(seibuspi_state::z80_prg_transfer_w)
 	}
 }
 
-WRITE8_MEMBER(seibuspi_state::z80_enable_w)
+void seibuspi_state::z80_enable_w(u8 data)
 {
 	// d0: reset z80
 	// other bits: unused
@@ -966,18 +966,18 @@ WRITE8_MEMBER(seibuspi_state::z80_enable_w)
 	m_audiocpu->set_input_line(INPUT_LINE_RESET, (data & 0x01) ? CLEAR_LINE : ASSERT_LINE);
 }
 
-READ8_MEMBER(seibuspi_state::sb_coin_r)
+u8 seibuspi_state::sb_coin_r()
 {
-	uint8_t ret = m_sb_coin_latch;
-
-	m_sb_coin_latch = 0;
+	const u8 ret = m_sb_coin_latch;
+	if (!machine().side_effects_disabled())
+		m_sb_coin_latch = 0;
 	return ret;
 }
 
-READ32_MEMBER(seibuspi_state::ejsakura_keyboard_r)
+u32 seibuspi_state::ejsakura_keyboard_r()
 {
 	// coins/eeprom data
-	uint32_t ret = m_special->read();
+	u32 ret = m_special->read();
 
 	// multiplexed inputs
 	for (int i = 0; i < 5; i++)
@@ -987,7 +987,7 @@ READ32_MEMBER(seibuspi_state::ejsakura_keyboard_r)
 	return ret;
 }
 
-WRITE32_MEMBER(seibuspi_state::ejsakura_input_select_w)
+void seibuspi_state::ejsakura_input_select_w(u32 data)
 {
 	m_ejsakura_input_port = data;
 }
@@ -1124,19 +1124,19 @@ void seibuspi_state::sys386f_map(address_map &map)
 
 /*****************************************************************************/
 
-READ8_MEMBER(seibuspi_state::z80_soundfifo_status_r)
+u8 seibuspi_state::z80_soundfifo_status_r()
 {
 	// d0: fifo full flag (main)
 	// d1: fifo empty flag (z80)
 	// other bits: unused?
-	int d0 = (m_soundfifo[1] != nullptr) ? m_soundfifo[1]->ff_r() : 0;
+	const u8 d0 = (m_soundfifo[1] != nullptr) ? m_soundfifo[1]->ff_r() : 0;
 	return d0 | m_soundfifo[0]->ef_r() << 1;
 }
 
-WRITE8_MEMBER(seibuspi_state::z80_bank_w)
+void seibuspi_state::z80_bank_w(u8 data)
 {
 	// d0-d2: bank @ 8000
-	int bank = data & 7;
+	const u8 bank = data & 7;
 
 	if (bank != m_z80_lastbank)
 	{
@@ -1147,7 +1147,7 @@ WRITE8_MEMBER(seibuspi_state::z80_bank_w)
 	// d3: watchdog?
 }
 
-WRITE8_MEMBER(seibuspi_state::spi_coin_w)
+void seibuspi_state::spi_coin_w(u8 data)
 {
 	machine().bookkeeping().coin_counter_w(0, data & 1);
 	machine().bookkeeping().coin_counter_w(1, data & 2);
@@ -1227,7 +1227,7 @@ CUSTOM_INPUT_MEMBER(seibuspi_state::ejanhs_encode)
 	RON   - 110 port C
 	Start - 111 port A
 	*/
-	static const uint8_t encoding[] = { 6, 5, 4, 3, 2, 7 };
+	static const u8 encoding[] = { 6, 5, 4, 3, 2, 7 };
 	ioport_value state = ~m_key[(uintptr_t)param]->read();
 
 	for (int bit = 0; bit < ARRAY_LENGTH(encoding); bit++)
@@ -1445,11 +1445,11 @@ INPUT_PORTS_END
 static const gfx_layout spi_charlayout =
 {
 	8,8,        /* 8*8 characters */
-	4096,       /* 4096 characters */
+	RGN_FRAC(1,1),       /* 4096 characters */
 	5,          /* 6 bits per pixel */
 	{ 4, 8, 12, 16, 20 },
-	{ 3, 2, 1, 0, 27, 26, 25, 24 },
-	{ 0*48, 1*48, 2*48, 3*48, 4*48, 5*48, 6*48, 7*48 },
+	{ STEP4(3,-1), STEP4(4*6+3,-1) },
+	{ STEP8(0,4*6*2) },
 	6*8*8
 };
 
@@ -1457,66 +1457,66 @@ static const gfx_layout spi_charlayout =
 static const gfx_layout spi_charlayout0 =
 {
 	8,8,        /* 8*8 characters */
-	4096,       /* 4096 characters */
+	RGN_FRAC(1,1),       /* 4096 characters */
 	1,          /* 6 bits per pixel */
 	{ 0 },
-	{ 3, 2, 1, 0, 27, 26, 25, 24 },
-	{ 0*48, 1*48, 2*48, 3*48, 4*48, 5*48, 6*48, 7*48 },
+	{ STEP4(3,-1), STEP4(4*6+3,-1) },
+	{ STEP8(0,4*6*2) },
 	6*8*8
 };
 
 static const gfx_layout spi_charlayout1 =
 {
 	8,8,        /* 8*8 characters */
-	4096,       /* 4096 characters */
+	RGN_FRAC(1,1),       /* 4096 characters */
 	1,          /* 6 bits per pixel */
 	{ 4 },
-	{ 3, 2, 1, 0, 27, 26, 25, 24 },
-	{ 0*48, 1*48, 2*48, 3*48, 4*48, 5*48, 6*48, 7*48 },
+	{ STEP4(3,-1), STEP4(4*6+3,-1) },
+	{ STEP8(0,4*6*2) },
 	6*8*8
 };
 
 static const gfx_layout spi_charlayout2 =
 {
 	8,8,        /* 8*8 characters */
-	4096,       /* 4096 characters */
+	RGN_FRAC(1,1),       /* 4096 characters */
 	1,          /* 6 bits per pixel */
 	{ 8 },
-	{ 3, 2, 1, 0, 27, 26, 25, 24 },
-	{ 0*48, 1*48, 2*48, 3*48, 4*48, 5*48, 6*48, 7*48 },
+	{ STEP4(3,-1), STEP4(4*6+3,-1) },
+	{ STEP8(0,4*6*2) },
 	6*8*8
 };
 
 static const gfx_layout spi_charlayout3 =
 {
 	8,8,        /* 8*8 characters */
-	4096,       /* 4096 characters */
+	RGN_FRAC(1,1),       /* 4096 characters */
 	1,          /* 6 bits per pixel */
 	{ 12 },
-	{ 3, 2, 1, 0, 27, 26, 25, 24 },
-	{ 0*48, 1*48, 2*48, 3*48, 4*48, 5*48, 6*48, 7*48 },
+	{ STEP4(3,-1), STEP4(4*6+3,-1) },
+	{ STEP8(0,4*6*2) },
 	6*8*8
 };
 
 static const gfx_layout spi_charlayout4 =
 {
 	8,8,        /* 8*8 characters */
-	4096,       /* 4096 characters */
+	RGN_FRAC(1,1),       /* 4096 characters */
 	1,          /* 6 bits per pixel */
 	{ 16 },
-	{ 3, 2, 1, 0, 27, 26, 25, 24 },
-	{ 0*48, 1*48, 2*48, 3*48, 4*48, 5*48, 6*48, 7*48 },
+	{ STEP4(3,-1), STEP4(4*6+3,-1) },
+	{ STEP8(0,4*6*2) },
 	6*8*8
 };
 
 static const gfx_layout spi_charlayout5 =
 {
 	8,8,        /* 8*8 characters */
-	4096,       /* 4096 characters */
+	RGN_FRAC(1,1),       /* 4096 characters */
 	1,          /* 6 bits per pixel */
 	{ 20 },
-	{ 3, 2, 1, 0, 27, 26, 25, 24 },
-	{ 0*48, 1*48, 2*48, 3*48, 4*48, 5*48, 6*48, 7*48 },
+	{ STEP4(3,-1), STEP4(4*6+3,-1) },
+	{ STEP8(0,4*6*2) },
 	6*8*8
 };
 #endif
@@ -1527,15 +1527,8 @@ static const gfx_layout spi_tilelayout =
 	RGN_FRAC(1,1),
 	6,
 	{ 0, 4, 8, 12, 16, 20 },
-	{
-		3, 2, 1, 0,
-		27,26,25,24,
-		51,50,49,48,
-		75,74,73,72
-	},
-	{ 0*96, 1*96, 2*96, 3*96, 4*96, 5*96, 6*96, 7*96,
-		8*96, 9*96, 10*96, 11*96, 12*96, 13*96, 14*96, 15*96
-	},
+	{ STEP4(3,-1), STEP4(4*6+3,-1), STEP4(4*6*2+3,-1), STEP4(4*6*3+3,-1) },
+	{ STEP16(0,4*6*4) },
 	6*16*16
 };
 
@@ -1546,15 +1539,8 @@ static const gfx_layout spi_tilelayout0 =
 	RGN_FRAC(1,1),
 	1,
 	{ 0 },
-	{
-		3, 2, 1, 0,
-		27,26,25,24,
-		51,50,49,48,
-		75,74,73,72
-	},
-	{ 0*96, 1*96, 2*96, 3*96, 4*96, 5*96, 6*96, 7*96,
-		8*96, 9*96, 10*96, 11*96, 12*96, 13*96, 14*96, 15*96
-	},
+	{ STEP4(3,-1), STEP4(4*6+3,-1), STEP4(4*6*2+3,-1), STEP4(4*6*3+3,-1) },
+	{ STEP16(0,4*6*4) },
 	6*16*16
 };
 
@@ -1564,15 +1550,8 @@ static const gfx_layout spi_tilelayout1 =
 	RGN_FRAC(1,1),
 	1,
 	{ 4 },
-	{
-		3, 2, 1, 0,
-		27,26,25,24,
-		51,50,49,48,
-		75,74,73,72
-	},
-	{ 0*96, 1*96, 2*96, 3*96, 4*96, 5*96, 6*96, 7*96,
-		8*96, 9*96, 10*96, 11*96, 12*96, 13*96, 14*96, 15*96
-	},
+	{ STEP4(3,-1), STEP4(4*6+3,-1), STEP4(4*6*2+3,-1), STEP4(4*6*3+3,-1) },
+	{ STEP16(0,4*6*4) },
 	6*16*16
 };
 
@@ -1582,15 +1561,8 @@ static const gfx_layout spi_tilelayout2 =
 	RGN_FRAC(1,1),
 	1,
 	{ 8 },
-	{
-		3, 2, 1, 0,
-		27,26,25,24,
-		51,50,49,48,
-		75,74,73,72
-	},
-	{ 0*96, 1*96, 2*96, 3*96, 4*96, 5*96, 6*96, 7*96,
-		8*96, 9*96, 10*96, 11*96, 12*96, 13*96, 14*96, 15*96
-	},
+	{ STEP4(3,-1), STEP4(4*6+3,-1), STEP4(4*6*2+3,-1), STEP4(4*6*3+3,-1) },
+	{ STEP16(0,4*6*4) },
 	6*16*16
 };
 
@@ -1600,15 +1572,8 @@ static const gfx_layout spi_tilelayout3 =
 	RGN_FRAC(1,1),
 	1,
 	{ 12 },
-	{
-		3, 2, 1, 0,
-		27,26,25,24,
-		51,50,49,48,
-		75,74,73,72
-	},
-	{ 0*96, 1*96, 2*96, 3*96, 4*96, 5*96, 6*96, 7*96,
-		8*96, 9*96, 10*96, 11*96, 12*96, 13*96, 14*96, 15*96
-	},
+	{ STEP4(3,-1), STEP4(4*6+3,-1), STEP4(4*6*2+3,-1), STEP4(4*6*3+3,-1) },
+	{ STEP16(0,4*6*4) },
 	6*16*16
 };
 
@@ -1618,15 +1583,8 @@ static const gfx_layout spi_tilelayout4 =
 	RGN_FRAC(1,1),
 	1,
 	{ 16 },
-	{
-		3, 2, 1, 0,
-		27,26,25,24,
-		51,50,49,48,
-		75,74,73,72
-	},
-	{ 0*96, 1*96, 2*96, 3*96, 4*96, 5*96, 6*96, 7*96,
-		8*96, 9*96, 10*96, 11*96, 12*96, 13*96, 14*96, 15*96
-	},
+	{ STEP4(3,-1), STEP4(4*6+3,-1), STEP4(4*6*2+3,-1), STEP4(4*6*3+3,-1) },
+	{ STEP16(0,4*6*4) },
 	6*16*16
 };
 
@@ -1636,15 +1594,8 @@ static const gfx_layout spi_tilelayout5 =
 	RGN_FRAC(1,1),
 	1,
 	{ 20 },
-	{
-		3, 2, 1, 0,
-		27,26,25,24,
-		51,50,49,48,
-		75,74,73,72
-	},
-	{ 0*96, 1*96, 2*96, 3*96, 4*96, 5*96, 6*96, 7*96,
-		8*96, 9*96, 10*96, 11*96, 12*96, 13*96, 14*96, 15*96
-	},
+	{ STEP4(3,-1), STEP4(4*6+3,-1), STEP4(4*6*2+3,-1), STEP4(4*6*3+3,-1) },
+	{ STEP16(0,4*6*4) },
 	6*16*16
 };
 #endif
@@ -1655,12 +1606,8 @@ static const gfx_layout spi_spritelayout =
 	RGN_FRAC(1,3),
 	6,
 	{ 0,8, RGN_FRAC(1,3)+0,RGN_FRAC(1,3)+8,RGN_FRAC(2,3)+0,RGN_FRAC(2,3)+8  },
-	{
-		7,6,5,4,3,2,1,0,23,22,21,20,19,18,17,16
-	},
-	{
-		0*32,1*32,2*32,3*32,4*32,5*32,6*32,7*32,8*32,9*32,10*32,11*32,12*32,13*32,14*32,15*32
-	},
+	{ STEP8(7,-1), STEP8(8*2+7,-1) },
+	{ STEP16(0,8*4) },
 	16*32
 };
 
@@ -1671,12 +1618,8 @@ static const gfx_layout spi_spritelayout0 =
 	RGN_FRAC(1,3),
 	1,
 	{ 0 },
-	{
-		7,6,5,4,3,2,1,0,23,22,21,20,19,18,17,16
-	},
-	{
-		0*32,1*32,2*32,3*32,4*32,5*32,6*32,7*32,8*32,9*32,10*32,11*32,12*32,13*32,14*32,15*32
-	},
+	{ STEP8(7,-1), STEP8(8*2+7,-1) },
+	{ STEP16(0,8*4) },
 	16*32
 };
 
@@ -1686,12 +1629,8 @@ static const gfx_layout spi_spritelayout1 =
 	RGN_FRAC(1,3),
 	1,
 	{ 8 },
-	{
-		7,6,5,4,3,2,1,0,23,22,21,20,19,18,17,16
-	},
-	{
-		0*32,1*32,2*32,3*32,4*32,5*32,6*32,7*32,8*32,9*32,10*32,11*32,12*32,13*32,14*32,15*32
-	},
+	{ STEP8(7,-1), STEP8(8*2+7,-1) },
+	{ STEP16(0,8*4) },
 	16*32
 };
 
@@ -1701,12 +1640,8 @@ static const gfx_layout spi_spritelayout2 =
 	RGN_FRAC(1,3),
 	1,
 	{ RGN_FRAC(1,3)+0 },
-	{
-		7,6,5,4,3,2,1,0,23,22,21,20,19,18,17,16
-	},
-	{
-		0*32,1*32,2*32,3*32,4*32,5*32,6*32,7*32,8*32,9*32,10*32,11*32,12*32,13*32,14*32,15*32
-	},
+	{ STEP8(7,-1), STEP8(8*2+7,-1) },
+	{ STEP16(0,8*4) },
 	16*32
 };
 
@@ -1716,12 +1651,8 @@ static const gfx_layout spi_spritelayout3 =
 	RGN_FRAC(1,3),
 	1,
 	{ RGN_FRAC(1,3)+8 },
-	{
-		7,6,5,4,3,2,1,0,23,22,21,20,19,18,17,16
-	},
-	{
-		0*32,1*32,2*32,3*32,4*32,5*32,6*32,7*32,8*32,9*32,10*32,11*32,12*32,13*32,14*32,15*32
-	},
+	{ STEP8(7,-1), STEP8(8*2+7,-1) },
+	{ STEP16(0,8*4) },
 	16*32
 };
 
@@ -1731,12 +1662,8 @@ static const gfx_layout spi_spritelayout4 =
 	RGN_FRAC(1,3),
 	1,
 	{ RGN_FRAC(2,3)+0 },
-	{
-		7,6,5,4,3,2,1,0,23,22,21,20,19,18,17,16
-	},
-	{
-		0*32,1*32,2*32,3*32,4*32,5*32,6*32,7*32,8*32,9*32,10*32,11*32,12*32,13*32,14*32,15*32
-	},
+	{ STEP8(7,-1), STEP8(8*2+7,-1) },
+	{ STEP16(0,8*4) },
 	16*32
 };
 
@@ -1746,43 +1673,39 @@ static const gfx_layout spi_spritelayout5 =
 	RGN_FRAC(1,3),
 	1,
 	{ RGN_FRAC(2,3)+8 },
-	{
-		7,6,5,4,3,2,1,0,23,22,21,20,19,18,17,16
-	},
-	{
-		0*32,1*32,2*32,3*32,4*32,5*32,6*32,7*32,8*32,9*32,10*32,11*32,12*32,13*32,14*32,15*32
-	},
+	{ STEP8(7,-1), STEP8(8*2+7,-1) },
+	{ STEP16(0,8*4) },
 	16*32
 };
 #endif
 
 static GFXDECODE_START( gfx_spi )
-	GFXDECODE_ENTRY( "gfx1", 0, spi_charlayout,   5632, 16 )
-	GFXDECODE_ENTRY( "gfx2", 0, spi_tilelayout,   4096, 24 )
-	GFXDECODE_ENTRY( "gfx3", 0, spi_spritelayout,    0, 96 )
-#if PLANE_CHAR
-	GFXDECODE_ENTRY( "gfx1", 0, spi_charlayout0,   0x3ff, 1 )
-	GFXDECODE_ENTRY( "gfx1", 0, spi_charlayout1,   0x3ff, 1 )
-	GFXDECODE_ENTRY( "gfx1", 0, spi_charlayout2,   0x3ff, 1 )
-	GFXDECODE_ENTRY( "gfx1", 0, spi_charlayout3,   0x3ff, 1 )
-	GFXDECODE_ENTRY( "gfx1", 0, spi_charlayout4,   0x3ff, 1 )
-	GFXDECODE_ENTRY( "gfx1", 0, spi_charlayout5,   0x3ff, 1 )
+	GFXDECODE_ENTRY( "sprites", 0, spi_spritelayout,  0, 64 )
+	GFXDECODE_ENTRY( "tiles",   0, spi_tilelayout, 4096, 24 )
+	GFXDECODE_ENTRY( "chars",   0, spi_charlayout, 5632, 16 )
+#if PLANE_SPRITE
+	GFXDECODE_ENTRY( "sprites", 0, spi_spritelayout0, 0, 6144/2 )
+	GFXDECODE_ENTRY( "sprites", 0, spi_spritelayout1, 0, 6144/2 )
+	GFXDECODE_ENTRY( "sprites", 0, spi_spritelayout2, 0, 6144/2 )
+	GFXDECODE_ENTRY( "sprites", 0, spi_spritelayout3, 0, 6144/2 )
+	GFXDECODE_ENTRY( "sprites", 0, spi_spritelayout4, 0, 6144/2 )
+	GFXDECODE_ENTRY( "sprites", 0, spi_spritelayout5, 0, 6144/2 )
 #endif
 #if PLANE_TILE
-	GFXDECODE_ENTRY( "gfx2", 0, spi_tilelayout0,   0x3ff, 1 )
-	GFXDECODE_ENTRY( "gfx2", 0, spi_tilelayout1,   0x3ff, 1 )
-	GFXDECODE_ENTRY( "gfx2", 0, spi_tilelayout2,   0x3ff, 1 )
-	GFXDECODE_ENTRY( "gfx2", 0, spi_tilelayout3,   0x3ff, 1 )
-	GFXDECODE_ENTRY( "gfx2", 0, spi_tilelayout4,   0x3ff, 1 )
-	GFXDECODE_ENTRY( "gfx2", 0, spi_tilelayout5,   0x3ff, 1 )
+	GFXDECODE_ENTRY( "tiles",   0, spi_tilelayout0,   0, 6144/2 )
+	GFXDECODE_ENTRY( "tiles",   0, spi_tilelayout1,   0, 6144/2 )
+	GFXDECODE_ENTRY( "tiles",   0, spi_tilelayout2,   0, 6144/2 )
+	GFXDECODE_ENTRY( "tiles",   0, spi_tilelayout3,   0, 6144/2 )
+	GFXDECODE_ENTRY( "tiles",   0, spi_tilelayout4,   0, 6144/2 )
+	GFXDECODE_ENTRY( "tiles",   0, spi_tilelayout5,   0, 6144/2 )
 #endif
-#if PLANE_SPRITE
-	GFXDECODE_ENTRY( "gfx3", 0, spi_spritelayout0, 0x3ff, 1 )
-	GFXDECODE_ENTRY( "gfx3", 0, spi_spritelayout1, 0x3ff, 1 )
-	GFXDECODE_ENTRY( "gfx3", 0, spi_spritelayout2, 0x3ff, 1 )
-	GFXDECODE_ENTRY( "gfx3", 0, spi_spritelayout3, 0x3ff, 1 )
-	GFXDECODE_ENTRY( "gfx3", 0, spi_spritelayout4, 0x3ff, 1 )
-	GFXDECODE_ENTRY( "gfx3", 0, spi_spritelayout5, 0x3ff, 1 )
+#if PLANE_CHAR
+	GFXDECODE_ENTRY( "chars",   0, spi_charlayout0,   0, 6144/2 )
+	GFXDECODE_ENTRY( "chars",   0, spi_charlayout1,   0, 6144/2 )
+	GFXDECODE_ENTRY( "chars",   0, spi_charlayout2,   0, 6144/2 )
+	GFXDECODE_ENTRY( "chars",   0, spi_charlayout3,   0, 6144/2 )
+	GFXDECODE_ENTRY( "chars",   0, spi_charlayout4,   0, 6144/2 )
+	GFXDECODE_ENTRY( "chars",   0, spi_charlayout5,   0, 6144/2 )
 #endif
 GFXDECODE_END
 
@@ -1792,19 +1715,13 @@ static const gfx_layout sys386f_spritelayout =
 	RGN_FRAC(1,4),
 	8,
 	{ 0, 8, RGN_FRAC(1,4)+0, RGN_FRAC(1,4)+8, RGN_FRAC(2,4)+0, RGN_FRAC(2,4)+8, RGN_FRAC(3,4)+0, RGN_FRAC(3,4)+8 },
-	{
-		7,6,5,4,3,2,1,0,23,22,21,20,19,18,17,16
-	},
-	{
-		0*32,1*32,2*32,3*32,4*32,5*32,6*32,7*32,8*32,9*32,10*32,11*32,12*32,13*32,14*32,15*32
-	},
+	{ STEP8(7,-1), STEP8(8*2+7,-1) },
+	{ STEP16(0,8*4) },
 	16*32
 };
 
 static GFXDECODE_START( gfx_sys386f )
-	GFXDECODE_ENTRY( "gfx1", 0, spi_charlayout,          5632, 16 ) // Not used
-	GFXDECODE_ENTRY( "gfx2", 0, spi_tilelayout,          4096, 24 ) // Not used
-	GFXDECODE_ENTRY( "gfx3", 0, sys386f_spritelayout,       0, 96 )
+	GFXDECODE_ENTRY( "sprites", 0, sys386f_spritelayout, 0, 32 )
 GFXDECODE_END
 
 
@@ -1831,9 +1748,9 @@ void seibuspi_state::init_spi_common()
 
 void seibuspi_state::init_sei252()
 {
-	text_decrypt(memregion("gfx1")->base());
-	bg_decrypt(memregion("gfx2")->base(), memregion("gfx2")->bytes());
-	seibuspi_sprite_decrypt(memregion("gfx3")->base(), 0x400000);
+	text_decrypt(memregion("chars")->base());
+	bg_decrypt(memregion("tiles")->base(), memregion("tiles")->bytes());
+	seibuspi_sprite_decrypt(memregion("sprites")->base(), 0x400000);
 	init_spi_common();
 }
 
@@ -2038,11 +1955,11 @@ void seibuspi_state::sys386i(machine_config &config)
 
 void seibuspi_state::init_sys386f()
 {
-	uint16_t *src = (uint16_t *)memregion("gfx3")->base();
-	uint16_t tmp[0x40 / 2], offset;
+	u16 *src = (u16 *)memregion("sprites")->base();
+	u16 tmp[0x40 / 2], offset;
 
 	// sprite_reorder() only
-	for (int i = 0; i < memregion("gfx3")->bytes() / 0x40; i++)
+	for (int i = 0; i < memregion("sprites")->bytes() / 0x40; i++)
 	{
 		memcpy(tmp, src, 0x40);
 
@@ -2135,9 +2052,9 @@ void seibuspi_state::init_rdft2()
 {
 	if (ENABLE_SPEEDUP_HACKS) m_maincpu->space(AS_PROGRAM).install_read_handler(0x00282ac, 0x00282af, read32_delegate(FUNC(seibuspi_state::rf2_speedup_r),this));
 
-	rdft2_text_decrypt(memregion("gfx1")->base());
-	rdft2_bg_decrypt(memregion("gfx2")->base(), memregion("gfx2")->bytes());
-	seibuspi_rise10_sprite_decrypt(memregion("gfx3")->base(), 0x600000);
+	rdft2_text_decrypt(memregion("chars")->base());
+	rdft2_bg_decrypt(memregion("tiles")->base(), memregion("tiles")->bytes());
+	seibuspi_rise10_sprite_decrypt(memregion("sprites")->base(), 0x600000);
 	init_spi_common();
 }
 
@@ -2145,9 +2062,9 @@ void seibuspi_state::init_rfjet()
 {
 	if (ENABLE_SPEEDUP_HACKS) m_maincpu->space(AS_PROGRAM).install_read_handler(0x002894c, 0x002894f, read32_delegate(FUNC(seibuspi_state::rfjet_speedup_r),this));
 
-	rfjet_text_decrypt(memregion("gfx1")->base());
-	rfjet_bg_decrypt(memregion("gfx2")->base(), memregion("gfx2")->bytes());
-	seibuspi_rise11_sprite_decrypt_rfjet(memregion("gfx3")->base(), 0x800000);
+	rfjet_text_decrypt(memregion("chars")->base());
+	rfjet_bg_decrypt(memregion("tiles")->base(), memregion("tiles")->bytes());
+	seibuspi_rise11_sprite_decrypt_rfjet(memregion("sprites")->base(), 0x800000);
 	init_spi_common();
 }
 
@@ -2268,7 +2185,7 @@ READ32_MEMBER(seibuspi_state::rfjet_speedup_r)
 	/* rfjetus */
 	if (m_maincpu->pc()==0x0205b39)
 	{
-		uint32_t r;
+		u32 r;
 		m_maincpu->spin_until_interrupt(); // idle
 		// Hack to enter test mode
 		r = m_mainram[0x002894c/4] & (~0x400);
@@ -2301,15 +2218,15 @@ ROM_START( senkyu )
 
 	ROM_REGION( 0x40000, "audiocpu", ROMREGION_ERASE00 ) /* 256K RAM, ROM from Z80 point-of-view */
 
-	ROM_REGION( 0x30000, "gfx1", ROMREGION_ERASEFF ) /* text layer roms */
+	ROM_REGION( 0x30000, "chars", ROMREGION_ERASEFF ) /* text layer roms */
 	ROM_LOAD24_WORD("fb_6.413", 0x000000, 0x20000, CRC(b57115c9) SHA1(eb95f416f522032ca949bfb6348f1ff824101f2d) )
 	ROM_LOAD24_BYTE("fb_5.48",  0x000002, 0x10000, CRC(440a9ae3) SHA1(3f57e6da91f0dac2d816c873759f1e1d3259caf1) )
 
-	ROM_REGION( 0x300000, "gfx2", ROMREGION_ERASEFF ) /* background layer roms */
+	ROM_REGION( 0x300000, "tiles", ROMREGION_ERASEFF ) /* background layer roms */
 	ROM_LOAD24_WORD("fb_bg-1d.415", 0x000000, 0x200000, CRC(eae7a1fc) SHA1(26d8a9f4e554848977ec1f6a8aad8751b558a8d4) )
 	ROM_LOAD24_BYTE("fb_bg-1p.410", 0x000002, 0x100000, CRC(b46e774e) SHA1(00b6c1d0b0ea37f4354acab543b270c0bf45896d) )
 
-	ROM_REGION( 0xc00000, "gfx3", 0 ) /* sprites */
+	ROM_REGION( 0xc00000, "sprites", 0 ) /* sprites */
 	ROM_LOAD("fb_obj-1.322", 0x000000, 0x400000, CRC(29f86f68) SHA1(1afe809ce00a25f8b27543e4188edc3e3e604951) )
 	ROM_LOAD("fb_obj-2.324", 0x400000, 0x400000, CRC(c9e3130b) SHA1(12b5d5363142e8efb3b7fc44289c0afffa5011c6) )
 	ROM_LOAD("fb_obj-3.323", 0x800000, 0x400000, CRC(f6c3bc49) SHA1(d0eb9c6aa3954d94e3a442a48e0fe6cc279f5513) )
@@ -2332,15 +2249,15 @@ ROM_START( senkyua )
 
 	ROM_REGION( 0x40000, "audiocpu", ROMREGION_ERASE00 ) /* 256K RAM, ROM from Z80 point-of-view */
 
-	ROM_REGION( 0x30000, "gfx1", ROMREGION_ERASEFF ) /* text layer roms */
+	ROM_REGION( 0x30000, "chars", ROMREGION_ERASEFF ) /* text layer roms */
 	ROM_LOAD24_WORD("fb_6.413", 0x000000, 0x20000, CRC(b57115c9) SHA1(eb95f416f522032ca949bfb6348f1ff824101f2d) )
 	ROM_LOAD24_BYTE("fb_5.48",  0x000002, 0x10000, CRC(440a9ae3) SHA1(3f57e6da91f0dac2d816c873759f1e1d3259caf1) )
 
-	ROM_REGION( 0x300000, "gfx2", ROMREGION_ERASEFF ) /* background layer roms */
+	ROM_REGION( 0x300000, "tiles", ROMREGION_ERASEFF ) /* background layer roms */
 	ROM_LOAD24_WORD("fb_bg-1d.415", 0x000000, 0x200000, CRC(eae7a1fc) SHA1(26d8a9f4e554848977ec1f6a8aad8751b558a8d4) )
 	ROM_LOAD24_BYTE("fb_bg-1p.410", 0x000002, 0x100000, CRC(b46e774e) SHA1(00b6c1d0b0ea37f4354acab543b270c0bf45896d) )
 
-	ROM_REGION( 0xc00000, "gfx3", 0 ) /* sprites */
+	ROM_REGION( 0xc00000, "sprites", 0 ) /* sprites */
 	ROM_LOAD("fb_obj-1.322", 0x000000, 0x400000, CRC(29f86f68) SHA1(1afe809ce00a25f8b27543e4188edc3e3e604951) )
 	ROM_LOAD("fb_obj-2.324", 0x400000, 0x400000, CRC(c9e3130b) SHA1(12b5d5363142e8efb3b7fc44289c0afffa5011c6) )
 	ROM_LOAD("fb_obj-3.323", 0x800000, 0x400000, CRC(f6c3bc49) SHA1(d0eb9c6aa3954d94e3a442a48e0fe6cc279f5513) )
@@ -2363,15 +2280,15 @@ ROM_START( batlball )
 
 	ROM_REGION( 0x40000, "audiocpu", ROMREGION_ERASE00 ) /* 256K RAM, ROM from Z80 point-of-view */
 
-	ROM_REGION( 0x30000, "gfx1", ROMREGION_ERASEFF ) /* text layer roms */
+	ROM_REGION( 0x30000, "chars", ROMREGION_ERASEFF ) /* text layer roms */
 	ROM_LOAD24_WORD("fb_6.413", 0x000000, 0x20000, CRC(b57115c9) SHA1(eb95f416f522032ca949bfb6348f1ff824101f2d) )
 	ROM_LOAD24_BYTE("fb_5.48",  0x000002, 0x10000, CRC(440a9ae3) SHA1(3f57e6da91f0dac2d816c873759f1e1d3259caf1) )
 
-	ROM_REGION( 0x300000, "gfx2", ROMREGION_ERASEFF ) /* background layer roms */
+	ROM_REGION( 0x300000, "tiles", ROMREGION_ERASEFF ) /* background layer roms */
 	ROM_LOAD24_WORD("fb_bg-1d.415", 0x000000, 0x200000, CRC(eae7a1fc) SHA1(26d8a9f4e554848977ec1f6a8aad8751b558a8d4) )
 	ROM_LOAD24_BYTE("fb_bg-1p.410", 0x000002, 0x100000, CRC(b46e774e) SHA1(00b6c1d0b0ea37f4354acab543b270c0bf45896d) )
 
-	ROM_REGION( 0xc00000, "gfx3", 0 ) /* sprites */
+	ROM_REGION( 0xc00000, "sprites", 0 ) /* sprites */
 	ROM_LOAD("fb_obj-1.322", 0x000000, 0x400000, CRC(29f86f68) SHA1(1afe809ce00a25f8b27543e4188edc3e3e604951) )
 	ROM_LOAD("fb_obj-2.324", 0x400000, 0x400000, CRC(c9e3130b) SHA1(12b5d5363142e8efb3b7fc44289c0afffa5011c6) )
 	ROM_LOAD("fb_obj-3.323", 0x800000, 0x400000, CRC(f6c3bc49) SHA1(d0eb9c6aa3954d94e3a442a48e0fe6cc279f5513) )
@@ -2394,15 +2311,15 @@ ROM_START( batlballo ) // Board has a low serial number 000014 and PCB date is 9
 
 	ROM_REGION( 0x40000, "audiocpu", ROMREGION_ERASE00 ) /* 256K RAM, ROM from Z80 point-of-view */
 
-	ROM_REGION( 0x30000, "gfx1", ROMREGION_ERASEFF ) /* text layer roms */
+	ROM_REGION( 0x30000, "chars", ROMREGION_ERASEFF ) /* text layer roms */
 	ROM_LOAD24_WORD("seibu_6.413", 0x000000, 0x20000, CRC(338556f9) SHA1(dfab6e1562dd9c373aa094a3791ecd4cd3c9b6f5) )
 	ROM_LOAD24_BYTE("seibu_5.48",  0x000002, 0x10000, CRC(6ccfb72e) SHA1(825b917ecd8495de23d55d2d2902d9d7c54ce4ed) )
 
-	ROM_REGION( 0x300000, "gfx2", ROMREGION_ERASEFF ) /* background layer roms */
+	ROM_REGION( 0x300000, "tiles", ROMREGION_ERASEFF ) /* background layer roms */
 	ROM_LOAD24_WORD("fb_bg-1d.415", 0x000000, 0x200000, CRC(eae7a1fc) SHA1(26d8a9f4e554848977ec1f6a8aad8751b558a8d4) )
 	ROM_LOAD24_BYTE("fb_bg-1p.410", 0x000002, 0x100000, CRC(b46e774e) SHA1(00b6c1d0b0ea37f4354acab543b270c0bf45896d) )
 
-	ROM_REGION( 0xc00000, "gfx3", 0 ) /* sprites */
+	ROM_REGION( 0xc00000, "sprites", 0 ) /* sprites */
 	ROM_LOAD("fb_obj-1.322", 0x000000, 0x400000, CRC(29f86f68) SHA1(1afe809ce00a25f8b27543e4188edc3e3e604951) )
 	ROM_LOAD("fb_obj-2.324", 0x400000, 0x400000, CRC(c9e3130b) SHA1(12b5d5363142e8efb3b7fc44289c0afffa5011c6) )
 	ROM_LOAD("fb_obj-3.323", 0x800000, 0x400000, CRC(f6c3bc49) SHA1(d0eb9c6aa3954d94e3a442a48e0fe6cc279f5513) )
@@ -2425,15 +2342,15 @@ ROM_START( batlballa )
 
 	ROM_REGION( 0x40000, "audiocpu", ROMREGION_ERASE00 ) /* 256K RAM, ROM from Z80 point-of-view */
 
-	ROM_REGION( 0x30000, "gfx1", ROMREGION_ERASEFF ) /* text layer roms */
+	ROM_REGION( 0x30000, "chars", ROMREGION_ERASEFF ) /* text layer roms */
 	ROM_LOAD24_WORD("fb_6.413", 0x000000, 0x20000, CRC(b57115c9) SHA1(eb95f416f522032ca949bfb6348f1ff824101f2d) )
 	ROM_LOAD24_BYTE("fb_5.48",  0x000002, 0x10000, CRC(440a9ae3) SHA1(3f57e6da91f0dac2d816c873759f1e1d3259caf1) )
 
-	ROM_REGION( 0x300000, "gfx2", ROMREGION_ERASEFF ) /* background layer roms */
+	ROM_REGION( 0x300000, "tiles", ROMREGION_ERASEFF ) /* background layer roms */
 	ROM_LOAD24_WORD("fb_bg-1d.415", 0x000000, 0x200000, CRC(eae7a1fc) SHA1(26d8a9f4e554848977ec1f6a8aad8751b558a8d4) )
 	ROM_LOAD24_BYTE("fb_bg-1p.410", 0x000002, 0x100000, CRC(b46e774e) SHA1(00b6c1d0b0ea37f4354acab543b270c0bf45896d) )
 
-	ROM_REGION( 0xc00000, "gfx3", 0 ) /* sprites */
+	ROM_REGION( 0xc00000, "sprites", 0 ) /* sprites */
 	ROM_LOAD("fb_obj-1.322", 0x000000, 0x400000, CRC(29f86f68) SHA1(1afe809ce00a25f8b27543e4188edc3e3e604951) )
 	ROM_LOAD("fb_obj-2.324", 0x400000, 0x400000, CRC(c9e3130b) SHA1(12b5d5363142e8efb3b7fc44289c0afffa5011c6) )
 	ROM_LOAD("fb_obj-3.323", 0x800000, 0x400000, CRC(f6c3bc49) SHA1(d0eb9c6aa3954d94e3a442a48e0fe6cc279f5513) )
@@ -2456,15 +2373,15 @@ ROM_START( batlballe ) /* Early version, PCB serial number of 19, hand written l
 
 	ROM_REGION( 0x40000, "audiocpu", ROMREGION_ERASE00 ) /* 256K RAM, ROM from Z80 point-of-view */
 
-	ROM_REGION( 0x30000, "gfx1", ROMREGION_ERASEFF ) /* text layer roms */
+	ROM_REGION( 0x30000, "chars", ROMREGION_ERASEFF ) /* text layer roms */
 	ROM_LOAD24_WORD("fb_6.413", 0x000000, 0x20000, CRC(b57115c9) SHA1(eb95f416f522032ca949bfb6348f1ff824101f2d) )
 	ROM_LOAD24_BYTE("fb_5.48",  0x000002, 0x10000, CRC(440a9ae3) SHA1(3f57e6da91f0dac2d816c873759f1e1d3259caf1) )
 
-	ROM_REGION( 0x300000, "gfx2", ROMREGION_ERASEFF ) /* background layer roms */
+	ROM_REGION( 0x300000, "tiles", ROMREGION_ERASEFF ) /* background layer roms */
 	ROM_LOAD24_WORD("fb_bg-1d.415", 0x000000, 0x200000, CRC(eae7a1fc) SHA1(26d8a9f4e554848977ec1f6a8aad8751b558a8d4) )
 	ROM_LOAD24_BYTE("fb_bg-1p.410", 0x000002, 0x100000, CRC(b46e774e) SHA1(00b6c1d0b0ea37f4354acab543b270c0bf45896d) )
 
-	ROM_REGION( 0xc00000, "gfx3", 0 ) /* sprites */
+	ROM_REGION( 0xc00000, "sprites", 0 ) /* sprites */
 	ROM_LOAD("fb_obj-1.322", 0x000000, 0x400000, CRC(29f86f68) SHA1(1afe809ce00a25f8b27543e4188edc3e3e604951) )
 	ROM_LOAD("fb_obj-2.324", 0x400000, 0x400000, CRC(c9e3130b) SHA1(12b5d5363142e8efb3b7fc44289c0afffa5011c6) )
 	ROM_LOAD("fb_obj-3.323", 0x800000, 0x400000, CRC(f6c3bc49) SHA1(d0eb9c6aa3954d94e3a442a48e0fe6cc279f5513) )
@@ -2487,15 +2404,15 @@ ROM_START( batlballu )
 
 	ROM_REGION( 0x40000, "audiocpu", ROMREGION_ERASE00 ) /* 256K RAM, ROM from Z80 point-of-view */
 
-	ROM_REGION( 0x30000, "gfx1", ROMREGION_ERASEFF ) /* text layer roms */
+	ROM_REGION( 0x30000, "chars", ROMREGION_ERASEFF ) /* text layer roms */
 	ROM_LOAD24_WORD("fb_6.413", 0x000000, 0x20000, CRC(b57115c9) SHA1(eb95f416f522032ca949bfb6348f1ff824101f2d) )
 	ROM_LOAD24_BYTE("fb_5.48",  0x000002, 0x10000, CRC(440a9ae3) SHA1(3f57e6da91f0dac2d816c873759f1e1d3259caf1) )
 
-	ROM_REGION( 0x300000, "gfx2", ROMREGION_ERASEFF ) /* background layer roms */
+	ROM_REGION( 0x300000, "tiles", ROMREGION_ERASEFF ) /* background layer roms */
 	ROM_LOAD24_WORD("fb_bg-1d.415", 0x000000, 0x200000, CRC(eae7a1fc) SHA1(26d8a9f4e554848977ec1f6a8aad8751b558a8d4) )
 	ROM_LOAD24_BYTE("fb_bg-1p.410", 0x000002, 0x100000, CRC(b46e774e) SHA1(00b6c1d0b0ea37f4354acab543b270c0bf45896d) )
 
-	ROM_REGION( 0xc00000, "gfx3", 0 ) /* sprites */
+	ROM_REGION( 0xc00000, "sprites", 0 ) /* sprites */
 	ROM_LOAD("fb_obj-1.322", 0x000000, 0x400000, CRC(29f86f68) SHA1(1afe809ce00a25f8b27543e4188edc3e3e604951) )
 	ROM_LOAD("fb_obj-2.324", 0x400000, 0x400000, CRC(c9e3130b) SHA1(12b5d5363142e8efb3b7fc44289c0afffa5011c6) )
 	ROM_LOAD("fb_obj-3.323", 0x800000, 0x400000, CRC(f6c3bc49) SHA1(d0eb9c6aa3954d94e3a442a48e0fe6cc279f5513) )
@@ -2519,17 +2436,17 @@ ROM_START( ejanhs )
 
 	ROM_REGION( 0x40000, "audiocpu", ROMREGION_ERASE00 ) /* 256K RAM, ROM from Z80 point-of-view */
 
-	ROM_REGION( 0x30000, "gfx1", ROMREGION_ERASEFF ) /* text layer roms */
+	ROM_REGION( 0x30000, "chars", ROMREGION_ERASEFF ) /* text layer roms */
 	ROM_LOAD24_WORD("ejan3_6.413", 0x000000, 0x20000, CRC(837e012c) SHA1(815452083b65885d6e66dfc058ceec81bb3e6678) )
 	ROM_LOAD24_BYTE("ejan3_5.48",  0x000002, 0x10000, CRC(d62db7bf) SHA1(c88f1bb6106c59179b914962ed8cdd4095fd9ce8) )
 
-	ROM_REGION( 0x600000, "gfx2", ROMREGION_ERASEFF ) /* background layer roms */
+	ROM_REGION( 0x600000, "tiles", ROMREGION_ERASEFF ) /* background layer roms */
 	ROM_LOAD24_WORD("ej3_bg1d.415", 0x000000, 0x200000, CRC(bcacabe0) SHA1(b73581cf923196326b5b0b99e6aedb915bab0880) )
 	ROM_LOAD24_BYTE("ej3_bg1p.410", 0x000002, 0x100000, CRC(1fd0eb5e) SHA1(ca64c8020b246128232f4f6c0a0a2dd9cd3efeae) )
 	ROM_LOAD24_WORD("ej3_bg2d.416", 0x300000, 0x100000, CRC(ea2acd69) SHA1(b796e9e4b7342bf452f5ffdbce32cfefc603ba0f) )
 	ROM_LOAD24_BYTE("ej3_bg2p.49",  0x300002, 0x080000, CRC(a4a9cb0f) SHA1(da177d13bb95bf6b987d3ca13bcdc86570807b2c) )
 
-	ROM_REGION( 0xc00000, "gfx3", 0 ) /* sprites */
+	ROM_REGION( 0xc00000, "sprites", 0 ) /* sprites */
 	ROM_LOAD("ej3_obj1.322", 0x000000, 0x400000, CRC(852f180e) SHA1(d4845dace45c05a68f3b38ccb301c5bf5dce4174) )
 	ROM_LOAD("ej3_obj2.324", 0x400000, 0x400000, CRC(1116ad08) SHA1(d5c81383b3f9ede7dd03e6be35487b40740b1f8f) )
 	ROM_LOAD("ej3_obj3.323", 0x800000, 0x400000, CRC(ccfe02b6) SHA1(368bc8efe9d6677ba3d0cfc0f450a4bda32988be) )
@@ -2553,17 +2470,17 @@ ROM_START( viprp1 )
 
 	ROM_REGION( 0x40000, "audiocpu", ROMREGION_ERASE00 ) /* 256K RAM, ROM from Z80 point-of-view */
 
-	ROM_REGION( 0x30000, "gfx1", ROMREGION_ERASEFF ) /* text layer roms */
+	ROM_REGION( 0x30000, "chars", ROMREGION_ERASEFF ) /* text layer roms */
 	ROM_LOAD24_WORD("seibu5.u0413", 0x000000, 0x20000, CRC(5ece677c) SHA1(b782cf3296f866f79fafa69ff719211c9d4026df) )
 	ROM_LOAD24_BYTE("seibu6.u048",  0x000002, 0x10000, CRC(44844ef8) SHA1(bcbe24d2ffb64f9165ba4ab7de27f44b99b5ff5a) )
 
-	ROM_REGION( 0x600000, "gfx2", ROMREGION_ERASEFF ) /* background layer roms */
+	ROM_REGION( 0x600000, "tiles", ROMREGION_ERASEFF ) /* background layer roms */
 	ROM_LOAD24_WORD("v_bg-11.415",  0x000000, 0x200000, CRC(6fc96736) SHA1(12df47d8af2c1febc1bce5bcf3218766447885bd) )
 	ROM_LOAD24_BYTE("v_bg-12.415",  0x000002, 0x100000, CRC(d3c7281c) SHA1(340bca1f31486609b3c34dd7830362a216ff648e) )
 	ROM_LOAD24_WORD("v_bg-21.410",  0x300000, 0x100000, CRC(d65b4318) SHA1(6522970d95ffa7fa2f32e0b5b4f0eb69e0286b36) )
 	ROM_LOAD24_BYTE("v_bg-22.416",  0x300002, 0x080000, CRC(24a0a23a) SHA1(0b0330717620e3f3274a25845d9edaf8023b9db2) )
 
-	ROM_REGION( 0xc00000, "gfx3", 0 ) /* sprites */
+	ROM_REGION( 0xc00000, "sprites", 0 ) /* sprites */
 	ROM_LOAD("v_obj-1.322",  0x000000, 0x400000, CRC(3be5b631) SHA1(fd1064428d28ca166a9267b968c0ba846cfed656) )
 	ROM_LOAD("v_obj-2.324",  0x400000, 0x400000, CRC(924153b4) SHA1(db5dadcfb4cd5e6efe9d995085936ce4f4eb4254) )
 	ROM_LOAD("v_obj-3.323",  0x800000, 0x400000, CRC(e9fb9062) SHA1(18e97b4c5cced2b529e6e72d8041c6f78fcec76e) )
@@ -2585,17 +2502,17 @@ ROM_START( viprp1k )
 
 	ROM_REGION( 0x40000, "audiocpu", ROMREGION_ERASE00 ) /* 256K RAM, ROM from Z80 point-of-view */
 
-	ROM_REGION( 0x30000, "gfx1", ROMREGION_ERASEFF ) /* text layer roms */
+	ROM_REGION( 0x30000, "chars", ROMREGION_ERASEFF ) /* text layer roms */
 	ROM_LOAD24_WORD("seibu5.u0413", 0x000000, 0x20000, CRC(1a35f2d8) SHA1(cd9b140f144a8c72756e18913eaef121963be341) ) // sldh
 	ROM_LOAD24_BYTE("seibu6.u048",  0x000002, 0x10000, CRC(e88bf049) SHA1(62f35840dc90b505118ed81ac0d75397a689783b) ) // sldh
 
-	ROM_REGION( 0x600000, "gfx2", ROMREGION_ERASEFF ) /* background layer roms */
+	ROM_REGION( 0x600000, "tiles", ROMREGION_ERASEFF ) /* background layer roms */
 	ROM_LOAD24_WORD("v_bg-11.415",  0x000000, 0x200000, CRC(6fc96736) SHA1(12df47d8af2c1febc1bce5bcf3218766447885bd) )
 	ROM_LOAD24_BYTE("v_bg-12.415",  0x000002, 0x100000, CRC(d3c7281c) SHA1(340bca1f31486609b3c34dd7830362a216ff648e) )
 	ROM_LOAD24_WORD("v_bg-21.410",  0x300000, 0x100000, CRC(d65b4318) SHA1(6522970d95ffa7fa2f32e0b5b4f0eb69e0286b36) )
 	ROM_LOAD24_BYTE("v_bg-22.416",  0x300002, 0x080000, CRC(24a0a23a) SHA1(0b0330717620e3f3274a25845d9edaf8023b9db2) )
 
-	ROM_REGION( 0xc00000, "gfx3", 0 ) /* sprites */
+	ROM_REGION( 0xc00000, "sprites", 0 ) /* sprites */
 	ROM_LOAD("v_obj-1.322",  0x000000, 0x400000, CRC(3be5b631) SHA1(fd1064428d28ca166a9267b968c0ba846cfed656) )
 	ROM_LOAD("v_obj-2.324",  0x400000, 0x400000, CRC(924153b4) SHA1(db5dadcfb4cd5e6efe9d995085936ce4f4eb4254) )
 	ROM_LOAD("v_obj-3.323",  0x800000, 0x400000, CRC(e9fb9062) SHA1(18e97b4c5cced2b529e6e72d8041c6f78fcec76e) )
@@ -2617,17 +2534,17 @@ ROM_START( viprp1u )
 
 	ROM_REGION( 0x40000, "audiocpu", ROMREGION_ERASE00 ) /* 256K RAM, ROM from Z80 point-of-view */
 
-	ROM_REGION( 0x30000, "gfx1", ROMREGION_ERASEFF ) /* text layer roms */
+	ROM_REGION( 0x30000, "chars", ROMREGION_ERASEFF ) /* text layer roms */
 	ROM_LOAD24_WORD("seibu5.u0413", 0x000000, 0x20000, CRC(5ece677c) SHA1(b782cf3296f866f79fafa69ff719211c9d4026df) )
 	ROM_LOAD24_BYTE("seibu6.u048",  0x000002, 0x10000, CRC(44844ef8) SHA1(bcbe24d2ffb64f9165ba4ab7de27f44b99b5ff5a) )
 
-	ROM_REGION( 0x600000, "gfx2", ROMREGION_ERASEFF ) /* background layer roms */
+	ROM_REGION( 0x600000, "tiles", ROMREGION_ERASEFF ) /* background layer roms */
 	ROM_LOAD24_WORD("v_bg-11.415",  0x000000, 0x200000, CRC(6fc96736) SHA1(12df47d8af2c1febc1bce5bcf3218766447885bd) )
 	ROM_LOAD24_BYTE("v_bg-12.415",  0x000002, 0x100000, CRC(d3c7281c) SHA1(340bca1f31486609b3c34dd7830362a216ff648e) )
 	ROM_LOAD24_WORD("v_bg-21.410",  0x300000, 0x100000, CRC(d65b4318) SHA1(6522970d95ffa7fa2f32e0b5b4f0eb69e0286b36) )
 	ROM_LOAD24_BYTE("v_bg-22.416",  0x300002, 0x080000, CRC(24a0a23a) SHA1(0b0330717620e3f3274a25845d9edaf8023b9db2) )
 
-	ROM_REGION( 0xc00000, "gfx3", 0 ) /* sprites */
+	ROM_REGION( 0xc00000, "sprites", 0 ) /* sprites */
 	ROM_LOAD("v_obj-1.322",  0x000000, 0x400000, CRC(3be5b631) SHA1(fd1064428d28ca166a9267b968c0ba846cfed656) )
 	ROM_LOAD("v_obj-2.324",  0x400000, 0x400000, CRC(924153b4) SHA1(db5dadcfb4cd5e6efe9d995085936ce4f4eb4254) )
 	ROM_LOAD("v_obj-3.323",  0x800000, 0x400000, CRC(e9fb9062) SHA1(18e97b4c5cced2b529e6e72d8041c6f78fcec76e) )
@@ -2649,17 +2566,17 @@ ROM_START( viprp1ua )
 
 	ROM_REGION( 0x40000, "audiocpu", ROMREGION_ERASE00 ) /* 256K RAM, ROM from Z80 point-of-view */
 
-	ROM_REGION( 0x30000, "gfx1", ROMREGION_ERASEFF ) /* text layer roms */
+	ROM_REGION( 0x30000, "chars", ROMREGION_ERASEFF ) /* text layer roms */
 	ROM_LOAD24_WORD("seibu5.u0413", 0x000000, 0x20000, CRC(5ece677c) SHA1(b782cf3296f866f79fafa69ff719211c9d4026df) )
 	ROM_LOAD24_BYTE("seibu6.u048",  0x000002, 0x10000, CRC(44844ef8) SHA1(bcbe24d2ffb64f9165ba4ab7de27f44b99b5ff5a) )
 
-	ROM_REGION( 0x600000, "gfx2", ROMREGION_ERASEFF ) /* background layer roms */
+	ROM_REGION( 0x600000, "tiles", ROMREGION_ERASEFF ) /* background layer roms */
 	ROM_LOAD24_WORD("v_bg-11.415",  0x000000, 0x200000, CRC(6fc96736) SHA1(12df47d8af2c1febc1bce5bcf3218766447885bd) )
 	ROM_LOAD24_BYTE("v_bg-12.415",  0x000002, 0x100000, CRC(d3c7281c) SHA1(340bca1f31486609b3c34dd7830362a216ff648e) )
 	ROM_LOAD24_WORD("v_bg-21.410",  0x300000, 0x100000, CRC(d65b4318) SHA1(6522970d95ffa7fa2f32e0b5b4f0eb69e0286b36) )
 	ROM_LOAD24_BYTE("v_bg-22.416",  0x300002, 0x080000, CRC(24a0a23a) SHA1(0b0330717620e3f3274a25845d9edaf8023b9db2) )
 
-	ROM_REGION( 0xc00000, "gfx3", 0 ) /* sprites */
+	ROM_REGION( 0xc00000, "sprites", 0 ) /* sprites */
 	ROM_LOAD("v_obj-1.322",  0x000000, 0x400000, CRC(3be5b631) SHA1(fd1064428d28ca166a9267b968c0ba846cfed656) )
 	ROM_LOAD("v_obj-2.324",  0x400000, 0x400000, CRC(924153b4) SHA1(db5dadcfb4cd5e6efe9d995085936ce4f4eb4254) )
 	ROM_LOAD("v_obj-3.323",  0x800000, 0x400000, CRC(e9fb9062) SHA1(18e97b4c5cced2b529e6e72d8041c6f78fcec76e) )
@@ -2681,17 +2598,17 @@ ROM_START( viprp1j )
 
 	ROM_REGION( 0x40000, "audiocpu", ROMREGION_ERASE00 ) /* 256K RAM, ROM from Z80 point-of-view */
 
-	ROM_REGION( 0x30000, "gfx1", ROMREGION_ERASEFF ) /* text layer roms */
+	ROM_REGION( 0x30000, "chars", ROMREGION_ERASEFF ) /* text layer roms */
 	ROM_LOAD24_WORD("seibu5.u0413", 0x000000, 0x20000, CRC(5ece677c) SHA1(b782cf3296f866f79fafa69ff719211c9d4026df) )
 	ROM_LOAD24_BYTE("seibu6.u048",  0x000002, 0x10000, CRC(44844ef8) SHA1(bcbe24d2ffb64f9165ba4ab7de27f44b99b5ff5a) )
 
-	ROM_REGION( 0x600000, "gfx2", ROMREGION_ERASEFF ) /* background layer roms */
+	ROM_REGION( 0x600000, "tiles", ROMREGION_ERASEFF ) /* background layer roms */
 	ROM_LOAD24_WORD("v_bg-11.415",  0x000000, 0x200000, CRC(6fc96736) SHA1(12df47d8af2c1febc1bce5bcf3218766447885bd) )
 	ROM_LOAD24_BYTE("v_bg-12.415",  0x000002, 0x100000, CRC(d3c7281c) SHA1(340bca1f31486609b3c34dd7830362a216ff648e) )
 	ROM_LOAD24_WORD("v_bg-21.410",  0x300000, 0x100000, CRC(d65b4318) SHA1(6522970d95ffa7fa2f32e0b5b4f0eb69e0286b36) )
 	ROM_LOAD24_BYTE("v_bg-22.416",  0x300002, 0x080000, CRC(24a0a23a) SHA1(0b0330717620e3f3274a25845d9edaf8023b9db2) )
 
-	ROM_REGION( 0xc00000, "gfx3", 0 ) /* sprites */
+	ROM_REGION( 0xc00000, "sprites", 0 ) /* sprites */
 	ROM_LOAD("v_obj-1.322",  0x000000, 0x400000, CRC(3be5b631) SHA1(fd1064428d28ca166a9267b968c0ba846cfed656) )
 	ROM_LOAD("v_obj-2.324",  0x400000, 0x400000, CRC(924153b4) SHA1(db5dadcfb4cd5e6efe9d995085936ce4f4eb4254) )
 	ROM_LOAD("v_obj-3.323",  0x800000, 0x400000, CRC(e9fb9062) SHA1(18e97b4c5cced2b529e6e72d8041c6f78fcec76e) )
@@ -2713,17 +2630,17 @@ ROM_START( viprp1s )
 
 	ROM_REGION( 0x40000, "audiocpu", ROMREGION_ERASE00 ) /* 256K RAM, ROM from Z80 point-of-view */
 
-	ROM_REGION( 0x30000, "gfx1", ROMREGION_ERASEFF ) /* text layer roms */
+	ROM_REGION( 0x30000, "chars", ROMREGION_ERASEFF ) /* text layer roms */
 	ROM_LOAD24_WORD("seibu5.u0413", 0x000000, 0x20000, CRC(5ece677c) SHA1(b782cf3296f866f79fafa69ff719211c9d4026df) )
 	ROM_LOAD24_BYTE("seibu6.u048",  0x000002, 0x10000, CRC(44844ef8) SHA1(bcbe24d2ffb64f9165ba4ab7de27f44b99b5ff5a) )
 
-	ROM_REGION( 0x600000, "gfx2", ROMREGION_ERASEFF ) /* background layer roms */
+	ROM_REGION( 0x600000, "tiles", ROMREGION_ERASEFF ) /* background layer roms */
 	ROM_LOAD24_WORD("v_bg-11.415",  0x000000, 0x200000, CRC(6fc96736) SHA1(12df47d8af2c1febc1bce5bcf3218766447885bd) )
 	ROM_LOAD24_BYTE("v_bg-12.415",  0x000002, 0x100000, CRC(d3c7281c) SHA1(340bca1f31486609b3c34dd7830362a216ff648e) )
 	ROM_LOAD24_WORD("v_bg-21.410",  0x300000, 0x100000, CRC(d65b4318) SHA1(6522970d95ffa7fa2f32e0b5b4f0eb69e0286b36) )
 	ROM_LOAD24_BYTE("v_bg-22.416",  0x300002, 0x080000, CRC(24a0a23a) SHA1(0b0330717620e3f3274a25845d9edaf8023b9db2) )
 
-	ROM_REGION( 0xc00000, "gfx3", 0 ) /* sprites */
+	ROM_REGION( 0xc00000, "sprites", 0 ) /* sprites */
 	ROM_LOAD("v_obj-1.322",  0x000000, 0x400000, CRC(3be5b631) SHA1(fd1064428d28ca166a9267b968c0ba846cfed656) )
 	ROM_LOAD("v_obj-2.324",  0x400000, 0x400000, CRC(924153b4) SHA1(db5dadcfb4cd5e6efe9d995085936ce4f4eb4254) )
 	ROM_LOAD("v_obj-3.323",  0x800000, 0x400000, CRC(e9fb9062) SHA1(18e97b4c5cced2b529e6e72d8041c6f78fcec76e) )
@@ -2745,17 +2662,17 @@ ROM_START( viprp1h )
 
 	ROM_REGION( 0x40000, "audiocpu", ROMREGION_ERASE00 ) /* 256K RAM, ROM from Z80 point-of-view */
 
-	ROM_REGION( 0x30000, "gfx1", ROMREGION_ERASEFF ) /* text layer roms */
+	ROM_REGION( 0x30000, "chars", ROMREGION_ERASEFF ) /* text layer roms */
 	ROM_LOAD24_WORD("viper_fix_010995.u0413", 0x000000, 0x20000, CRC(5ece677c) SHA1(b782cf3296f866f79fafa69ff719211c9d4026df) )
 	ROM_LOAD24_BYTE("viper_fixp_010995.u048", 0x000002, 0x10000, CRC(44844ef8) SHA1(bcbe24d2ffb64f9165ba4ab7de27f44b99b5ff5a) )
 
-	ROM_REGION( 0x600000, "gfx2", ROMREGION_ERASEFF ) /* background layer roms */
+	ROM_REGION( 0x600000, "tiles", ROMREGION_ERASEFF ) /* background layer roms */
 	ROM_LOAD24_WORD("v_bg-11.415",  0x000000, 0x200000, CRC(6fc96736) SHA1(12df47d8af2c1febc1bce5bcf3218766447885bd) )
 	ROM_LOAD24_BYTE("v_bg-12.415",  0x000002, 0x100000, CRC(d3c7281c) SHA1(340bca1f31486609b3c34dd7830362a216ff648e) )
 	ROM_LOAD24_WORD("v_bg-21.410",  0x300000, 0x100000, CRC(d65b4318) SHA1(6522970d95ffa7fa2f32e0b5b4f0eb69e0286b36) )
 	ROM_LOAD24_BYTE("v_bg-22.416",  0x300002, 0x080000, CRC(24a0a23a) SHA1(0b0330717620e3f3274a25845d9edaf8023b9db2) )
 
-	ROM_REGION( 0xc00000, "gfx3", 0 ) /* sprites */
+	ROM_REGION( 0xc00000, "sprites", 0 ) /* sprites */
 	ROM_LOAD("v_obj-1.322",  0x000000, 0x400000, CRC(3be5b631) SHA1(fd1064428d28ca166a9267b968c0ba846cfed656) )
 	ROM_LOAD("v_obj-2.324",  0x400000, 0x400000, CRC(924153b4) SHA1(db5dadcfb4cd5e6efe9d995085936ce4f4eb4254) )
 	ROM_LOAD("v_obj-3.323",  0x800000, 0x400000, CRC(e9fb9062) SHA1(18e97b4c5cced2b529e6e72d8041c6f78fcec76e) )
@@ -2777,17 +2694,17 @@ ROM_START( viprp1t )
 
 	ROM_REGION( 0x40000, "audiocpu", ROMREGION_ERASE00 ) /* 256K RAM, ROM from Z80 point-of-view */
 
-	ROM_REGION( 0x30000, "gfx1", ROMREGION_ERASEFF ) /* text layer roms */
+	ROM_REGION( 0x30000, "chars", ROMREGION_ERASEFF ) /* text layer roms */
 	ROM_LOAD24_WORD("viper_fix_010995.u0413", 0x000000, 0x20000, CRC(5ece677c) SHA1(b782cf3296f866f79fafa69ff719211c9d4026df) )
 	ROM_LOAD24_BYTE("viper_fixp_010995.u048", 0x000002, 0x10000, CRC(44844ef8) SHA1(bcbe24d2ffb64f9165ba4ab7de27f44b99b5ff5a) )
 
-	ROM_REGION( 0x600000, "gfx2", ROMREGION_ERASEFF ) /* background layer roms */
+	ROM_REGION( 0x600000, "tiles", ROMREGION_ERASEFF ) /* background layer roms */
 	ROM_LOAD24_WORD("v_bg-11.415",  0x000000, 0x200000, CRC(6fc96736) SHA1(12df47d8af2c1febc1bce5bcf3218766447885bd) )
 	ROM_LOAD24_BYTE("v_bg-12.415",  0x000002, 0x100000, CRC(d3c7281c) SHA1(340bca1f31486609b3c34dd7830362a216ff648e) )
 	ROM_LOAD24_WORD("v_bg-21.410",  0x300000, 0x100000, CRC(d65b4318) SHA1(6522970d95ffa7fa2f32e0b5b4f0eb69e0286b36) )
 	ROM_LOAD24_BYTE("v_bg-22.416",  0x300002, 0x080000, CRC(24a0a23a) SHA1(0b0330717620e3f3274a25845d9edaf8023b9db2) )
 
-	ROM_REGION( 0xc00000, "gfx3", 0 ) /* sprites */
+	ROM_REGION( 0xc00000, "sprites", 0 ) /* sprites */
 	ROM_LOAD("v_obj-1.322",  0x000000, 0x400000, CRC(3be5b631) SHA1(fd1064428d28ca166a9267b968c0ba846cfed656) )
 	ROM_LOAD("v_obj-2.324",  0x400000, 0x400000, CRC(924153b4) SHA1(db5dadcfb4cd5e6efe9d995085936ce4f4eb4254) )
 	ROM_LOAD("v_obj-3.323",  0x800000, 0x400000, CRC(e9fb9062) SHA1(18e97b4c5cced2b529e6e72d8041c6f78fcec76e) )
@@ -2809,17 +2726,17 @@ ROM_START( viprp1hk )
 
 	ROM_REGION( 0x40000, "audiocpu", ROMREGION_ERASE00 ) /* 256K RAM, ROM from Z80 point-of-view */
 
-	ROM_REGION( 0x30000, "gfx1", ROMREGION_ERASEFF ) /* text layer roms */
+	ROM_REGION( 0x30000, "chars", ROMREGION_ERASEFF ) /* text layer roms */
 	ROM_LOAD24_WORD("seibu_5", 0x000000, 0x20000, CRC(80920fed) SHA1(b35ed080925f6d0a0b6d2d1ab4fa919f625b1e6a) ) /* Different from both "new" & "old" versions */
 	ROM_LOAD24_BYTE("seibu_6", 0x000002, 0x10000, CRC(e71a8722) SHA1(3e0133fe1f85058ca6d9ac59d731f342c6b50e92) )
 
-	ROM_REGION( 0x600000, "gfx2", ROMREGION_ERASEFF ) /* background layer roms */
+	ROM_REGION( 0x600000, "tiles", ROMREGION_ERASEFF ) /* background layer roms */
 	ROM_LOAD24_WORD("v_bg-11.415",  0x000000, 0x200000, CRC(6fc96736) SHA1(12df47d8af2c1febc1bce5bcf3218766447885bd) )
 	ROM_LOAD24_BYTE("v_bg-12.415",  0x000002, 0x100000, CRC(d3c7281c) SHA1(340bca1f31486609b3c34dd7830362a216ff648e) )
 	ROM_LOAD24_WORD("v_bg-21.410",  0x300000, 0x100000, CRC(d65b4318) SHA1(6522970d95ffa7fa2f32e0b5b4f0eb69e0286b36) )
 	ROM_LOAD24_BYTE("v_bg-22.416",  0x300002, 0x080000, CRC(24a0a23a) SHA1(0b0330717620e3f3274a25845d9edaf8023b9db2) )
 
-	ROM_REGION( 0xc00000, "gfx3", 0 ) /* sprites */
+	ROM_REGION( 0xc00000, "sprites", 0 ) /* sprites */
 	ROM_LOAD("v_obj-1.322",  0x000000, 0x400000, CRC(3be5b631) SHA1(fd1064428d28ca166a9267b968c0ba846cfed656) )
 	ROM_LOAD("v_obj-2.324",  0x400000, 0x400000, CRC(924153b4) SHA1(db5dadcfb4cd5e6efe9d995085936ce4f4eb4254) )
 	ROM_LOAD("v_obj-3.323",  0x800000, 0x400000, CRC(e9fb9062) SHA1(18e97b4c5cced2b529e6e72d8041c6f78fcec76e) )
@@ -2841,17 +2758,17 @@ ROM_START( viprp1oj )
 
 	ROM_REGION( 0x40000, "audiocpu", ROMREGION_ERASE00 ) /* 256K RAM, ROM from Z80 point-of-view */
 
-	ROM_REGION( 0x30000, "gfx1", ROMREGION_ERASEFF ) /* text layer roms */
+	ROM_REGION( 0x30000, "chars", ROMREGION_ERASEFF ) /* text layer roms */
 	ROM_LOAD24_WORD("v_5-o.413", 0x000000, 0x20000, CRC(6d863acc) SHA1(3e3e14f51b9394b24d7cbf562f1cfffc9ec2216d) )
 	ROM_LOAD24_BYTE("v_6-o.48",  0x000002, 0x10000, CRC(fe7cb8f7) SHA1(55c7ab977c3666c8770deb62718d535673ffd4f8) )
 
-	ROM_REGION( 0x600000, "gfx2", ROMREGION_ERASEFF ) /* background layer roms */
+	ROM_REGION( 0x600000, "tiles", ROMREGION_ERASEFF ) /* background layer roms */
 	ROM_LOAD24_WORD("v_bg-11.415",  0x000000, 0x200000, CRC(6fc96736) SHA1(12df47d8af2c1febc1bce5bcf3218766447885bd) )
 	ROM_LOAD24_BYTE("v_bg-12.415",  0x000002, 0x100000, CRC(d3c7281c) SHA1(340bca1f31486609b3c34dd7830362a216ff648e) )
 	ROM_LOAD24_WORD("v_bg-21.410",  0x300000, 0x100000, CRC(d65b4318) SHA1(6522970d95ffa7fa2f32e0b5b4f0eb69e0286b36) )
 	ROM_LOAD24_BYTE("v_bg-22.416",  0x300002, 0x080000, CRC(24a0a23a) SHA1(0b0330717620e3f3274a25845d9edaf8023b9db2) )
 
-	ROM_REGION( 0xc00000, "gfx3", 0 ) /* sprites */
+	ROM_REGION( 0xc00000, "sprites", 0 ) /* sprites */
 	ROM_LOAD("v_obj-1.322",  0x000000, 0x400000, CRC(3be5b631) SHA1(fd1064428d28ca166a9267b968c0ba846cfed656) )
 	ROM_LOAD("v_obj-2.324",  0x400000, 0x400000, CRC(924153b4) SHA1(db5dadcfb4cd5e6efe9d995085936ce4f4eb4254) )
 	ROM_LOAD("v_obj-3.323",  0x800000, 0x400000, CRC(e9fb9062) SHA1(18e97b4c5cced2b529e6e72d8041c6f78fcec76e) )
@@ -2873,17 +2790,17 @@ ROM_START( viprp1ot )
 
 	ROM_REGION( 0x40000, "audiocpu", ROMREGION_ERASE00 ) /* 256K RAM, ROM from Z80 point-of-view */
 
-	ROM_REGION( 0x30000, "gfx1", ROMREGION_ERASEFF ) /* text layer roms */
+	ROM_REGION( 0x30000, "chars", ROMREGION_ERASEFF ) /* text layer roms */
 	ROM_LOAD24_WORD("v_5-o.413", 0x000000, 0x20000, CRC(6d863acc) SHA1(3e3e14f51b9394b24d7cbf562f1cfffc9ec2216d) )
 	ROM_LOAD24_BYTE("v_6-o.48",  0x000002, 0x10000, CRC(fe7cb8f7) SHA1(55c7ab977c3666c8770deb62718d535673ffd4f8) )
 
-	ROM_REGION( 0x600000, "gfx2", ROMREGION_ERASEFF ) /* background layer roms */
+	ROM_REGION( 0x600000, "tiles", ROMREGION_ERASEFF ) /* background layer roms */
 	ROM_LOAD24_WORD("v_bg-11.415",  0x000000, 0x200000, CRC(6fc96736) SHA1(12df47d8af2c1febc1bce5bcf3218766447885bd) )
 	ROM_LOAD24_BYTE("v_bg-12.415",  0x000002, 0x100000, CRC(d3c7281c) SHA1(340bca1f31486609b3c34dd7830362a216ff648e) )
 	ROM_LOAD24_WORD("v_bg-21.410",  0x300000, 0x100000, CRC(d65b4318) SHA1(6522970d95ffa7fa2f32e0b5b4f0eb69e0286b36) )
 	ROM_LOAD24_BYTE("v_bg-22.416",  0x300002, 0x080000, CRC(24a0a23a) SHA1(0b0330717620e3f3274a25845d9edaf8023b9db2) )
 
-	ROM_REGION( 0xc00000, "gfx3", 0 ) /* sprites */
+	ROM_REGION( 0xc00000, "sprites", 0 ) /* sprites */
 	ROM_LOAD("v_obj-1.322",  0x000000, 0x400000, CRC(3be5b631) SHA1(fd1064428d28ca166a9267b968c0ba846cfed656) )
 	ROM_LOAD("v_obj-2.324",  0x400000, 0x400000, CRC(924153b4) SHA1(db5dadcfb4cd5e6efe9d995085936ce4f4eb4254) )
 	ROM_LOAD("v_obj-3.323",  0x800000, 0x400000, CRC(e9fb9062) SHA1(18e97b4c5cced2b529e6e72d8041c6f78fcec76e) )
@@ -2906,18 +2823,18 @@ ROM_START( rdft ) /* SXX2C ROM SUB2 cart */
 
 	ROM_REGION( 0x40000, "audiocpu", ROMREGION_ERASE00 ) /* 256K RAM, ROM from Z80 point-of-view */
 
-	ROM_REGION( 0x30000, "gfx1", ROMREGION_ERASEFF ) /* text layer roms */
+	ROM_REGION( 0x30000, "chars", ROMREGION_ERASEFF ) /* text layer roms */
 	ROM_LOAD24_BYTE("gd_5.423", 0x000000, 0x10000, CRC(8f8d4e14) SHA1(06c803975767ae98f40ba7ac5764a5bc8baa3a30) )
 	ROM_LOAD24_BYTE("gd_6.424", 0x000001, 0x10000, CRC(6ac64968) SHA1(ec395205c24c4f864a1f805bb0d4641562d4faa9) )
 	ROM_LOAD24_BYTE("gd_7.48",  0x000002, 0x10000, CRC(4d87e1ea) SHA1(3230e9b643fad773e61ab8ce09c0cd7d4d0558e3) )
 
-	ROM_REGION( 0x600000, "gfx2", ROMREGION_ERASEFF ) /* background layer roms */
+	ROM_REGION( 0x600000, "tiles", ROMREGION_ERASEFF ) /* background layer roms */
 	ROM_LOAD24_WORD("gd_bg1-d.415", 0x000000, 0x200000, CRC(6a68054c) SHA1(5cbfc4ac90045f1401c2dda7a51936558c9de07e) )
 	ROM_LOAD24_BYTE("gd_bg1-p.410", 0x000002, 0x100000, CRC(3400794a) SHA1(719808f7442bac612cefd7b7fffcd665e6337ad0) )
 	ROM_LOAD24_WORD("gd_bg2-d.416", 0x300000, 0x200000, CRC(61cd2991) SHA1(bb608e3948bf9ea35b5e1615d2ba6858d029dcbe) )
 	ROM_LOAD24_BYTE("gd_bg2-p.49",  0x300002, 0x100000, CRC(502d5799) SHA1(c3a0e1a4f5a7b35572ae1ff31315da4ed08aa2fe) )
 
-	ROM_REGION( 0xc00000, "gfx3", 0 ) /* sprites */
+	ROM_REGION( 0xc00000, "sprites", 0 ) /* sprites */
 	ROM_LOAD("gd_obj-1.322", 0x000000, 0x400000, CRC(59d86c99) SHA1(d3c9241e7b51fe21f8351051b063f91dc69bf905) )
 	ROM_LOAD("gd_obj-2.324", 0x400000, 0x400000, CRC(1ceb0b6f) SHA1(97225a9b3e7be18080aa52f6570af2cce8f25c06) )
 	ROM_LOAD("gd_obj-3.323", 0x800000, 0x400000, CRC(36e93234) SHA1(51917a80b7da5c32a9434a1076fc2916d62e6a3e) )
@@ -2940,18 +2857,18 @@ ROM_START( rdftu )
 
 	ROM_REGION( 0x40000, "audiocpu", ROMREGION_ERASE00 ) /* 256K RAM, ROM from Z80 point-of-view */
 
-	ROM_REGION( 0x30000, "gfx1", ROMREGION_ERASEFF ) /* text layer roms */
+	ROM_REGION( 0x30000, "chars", ROMREGION_ERASEFF ) /* text layer roms */
 	ROM_LOAD24_BYTE("gd_5.423", 0x000000, 0x10000, CRC(8f8d4e14) SHA1(06c803975767ae98f40ba7ac5764a5bc8baa3a30) )
 	ROM_LOAD24_BYTE("gd_6.424", 0x000001, 0x10000, CRC(6ac64968) SHA1(ec395205c24c4f864a1f805bb0d4641562d4faa9) )
 	ROM_LOAD24_BYTE("gd_7.48",  0x000002, 0x10000, CRC(4d87e1ea) SHA1(3230e9b643fad773e61ab8ce09c0cd7d4d0558e3) )
 
-	ROM_REGION( 0x600000, "gfx2", ROMREGION_ERASEFF ) /* background layer roms */
+	ROM_REGION( 0x600000, "tiles", ROMREGION_ERASEFF ) /* background layer roms */
 	ROM_LOAD24_WORD("gd_bg1-d.415", 0x000000, 0x200000, CRC(6a68054c) SHA1(5cbfc4ac90045f1401c2dda7a51936558c9de07e) )
 	ROM_LOAD24_BYTE("gd_bg1-p.410", 0x000002, 0x100000, CRC(3400794a) SHA1(719808f7442bac612cefd7b7fffcd665e6337ad0) )
 	ROM_LOAD24_WORD("gd_bg2-d.416", 0x300000, 0x200000, CRC(61cd2991) SHA1(bb608e3948bf9ea35b5e1615d2ba6858d029dcbe) )
 	ROM_LOAD24_BYTE("gd_bg2-p.49",  0x300002, 0x100000, CRC(502d5799) SHA1(c3a0e1a4f5a7b35572ae1ff31315da4ed08aa2fe) )
 
-	ROM_REGION( 0xc00000, "gfx3", 0 ) /* sprites */
+	ROM_REGION( 0xc00000, "sprites", 0 ) /* sprites */
 	ROM_LOAD("gd_obj-1.322", 0x000000, 0x400000, CRC(59d86c99) SHA1(d3c9241e7b51fe21f8351051b063f91dc69bf905) )
 	ROM_LOAD("gd_obj-2.324", 0x400000, 0x400000, CRC(1ceb0b6f) SHA1(97225a9b3e7be18080aa52f6570af2cce8f25c06) )
 	ROM_LOAD("gd_obj-3.323", 0x800000, 0x400000, CRC(36e93234) SHA1(51917a80b7da5c32a9434a1076fc2916d62e6a3e) )
@@ -2973,17 +2890,17 @@ ROM_START( rdftua ) // This set uses SXX2C ROM SUB4 cart. Identical with rdftadi
 
 	ROM_REGION( 0x40000, "audiocpu", ROMREGION_ERASE00 ) /* 256K RAM, ROM from Z80 point-of-view */
 
-	ROM_REGION( 0x30000, "gfx1", ROMREGION_ERASEFF ) /* text layer roms */
+	ROM_REGION( 0x30000, "chars", ROMREGION_ERASEFF ) /* text layer roms */
 	ROM_LOAD24_WORD("raiden-f_fix.u0425", 0x000000, 0x20000, CRC(2be2936b) SHA1(9e719f7328a52af220b6f084c1e0990ca6e2d533) ) // socket is silkscreened on pcb FIX01
 	ROM_LOAD24_BYTE("seibu_7.u048",       0x000002, 0x10000, CRC(4d87e1ea) SHA1(3230e9b643fad773e61ab8ce09c0cd7d4d0558e3) ) // socket is silkscreened on pcb FIXP
 
-	ROM_REGION( 0x600000, "gfx2", ROMREGION_ERASEFF ) /* background layer roms */
+	ROM_REGION( 0x600000, "tiles", ROMREGION_ERASEFF ) /* background layer roms */
 	ROM_LOAD24_WORD("gun_dogs_bg1-d.u0415", 0x000000, 0x200000, CRC(6a68054c) SHA1(5cbfc4ac90045f1401c2dda7a51936558c9de07e) ) // pads are silkscreened on pcb BG12
 	ROM_LOAD24_BYTE("gun_dogs_bg1-p.u0410", 0x000002, 0x100000, CRC(3400794a) SHA1(719808f7442bac612cefd7b7fffcd665e6337ad0) ) // pads are silkscreened on pcb BG12P
 	ROM_LOAD24_WORD("gun_dogs_bg2-d.u0424", 0x300000, 0x200000, CRC(61cd2991) SHA1(bb608e3948bf9ea35b5e1615d2ba6858d029dcbe) ) // pads are silkscreened on pcb BG3
 	ROM_LOAD24_BYTE("gun_dogs_bg2-p.u049",  0x300002, 0x100000, CRC(502d5799) SHA1(c3a0e1a4f5a7b35572ae1ff31315da4ed08aa2fe) ) // pads are silkscreened on pcb BG3P
 
-	ROM_REGION( 0xc00000, "gfx3", 0 ) /* sprites */
+	ROM_REGION( 0xc00000, "sprites", 0 ) /* sprites */
 	ROM_LOAD("gun_dogs_obj-1.u0322", 0x000000, 0x400000, CRC(59d86c99) SHA1(d3c9241e7b51fe21f8351051b063f91dc69bf905) ) // pads are silkscreened on pcb OBJ1
 	ROM_LOAD("gun_dogs_obj-2.u0324", 0x400000, 0x400000, CRC(1ceb0b6f) SHA1(97225a9b3e7be18080aa52f6570af2cce8f25c06) ) // pads are silkscreened on pcb OBJ2
 	ROM_LOAD("gun_dogs_obj-3.u0323", 0x800000, 0x400000, CRC(36e93234) SHA1(51917a80b7da5c32a9434a1076fc2916d62e6a3e) ) // pads are silkscreened on pcb OBJ3
@@ -3006,18 +2923,18 @@ ROM_START( rdftj )
 
 	ROM_REGION( 0x40000, "audiocpu", ROMREGION_ERASE00 ) /* 256K RAM, ROM from Z80 point-of-view */
 
-	ROM_REGION( 0x30000, "gfx1", ROMREGION_ERASEFF ) /* text layer roms */
+	ROM_REGION( 0x30000, "chars", ROMREGION_ERASEFF ) /* text layer roms */
 	ROM_LOAD24_BYTE("gd_5.423", 0x000000, 0x10000, CRC(8f8d4e14) SHA1(06c803975767ae98f40ba7ac5764a5bc8baa3a30) )
 	ROM_LOAD24_BYTE("gd_6.424", 0x000001, 0x10000, CRC(6ac64968) SHA1(ec395205c24c4f864a1f805bb0d4641562d4faa9) )
 	ROM_LOAD24_BYTE("gd_7.48",  0x000002, 0x10000, CRC(4d87e1ea) SHA1(3230e9b643fad773e61ab8ce09c0cd7d4d0558e3) )
 
-	ROM_REGION( 0x600000, "gfx2", ROMREGION_ERASEFF ) /* background layer roms */
+	ROM_REGION( 0x600000, "tiles", ROMREGION_ERASEFF ) /* background layer roms */
 	ROM_LOAD24_WORD("gd_bg1-d.415", 0x000000, 0x200000, CRC(6a68054c) SHA1(5cbfc4ac90045f1401c2dda7a51936558c9de07e) )
 	ROM_LOAD24_BYTE("gd_bg1-p.410", 0x000002, 0x100000, CRC(3400794a) SHA1(719808f7442bac612cefd7b7fffcd665e6337ad0) )
 	ROM_LOAD24_WORD("gd_bg2-d.416", 0x300000, 0x200000, CRC(61cd2991) SHA1(bb608e3948bf9ea35b5e1615d2ba6858d029dcbe) )
 	ROM_LOAD24_BYTE("gd_bg2-p.49",  0x300002, 0x100000, CRC(502d5799) SHA1(c3a0e1a4f5a7b35572ae1ff31315da4ed08aa2fe) )
 
-	ROM_REGION( 0xc00000, "gfx3", 0 ) /* sprites */
+	ROM_REGION( 0xc00000, "sprites", 0 ) /* sprites */
 	ROM_LOAD("gd_obj-1.322", 0x000000, 0x400000, CRC(59d86c99) SHA1(d3c9241e7b51fe21f8351051b063f91dc69bf905) )
 	ROM_LOAD("gd_obj-2.324", 0x400000, 0x400000, CRC(1ceb0b6f) SHA1(97225a9b3e7be18080aa52f6570af2cce8f25c06) )
 	ROM_LOAD("gd_obj-3.323", 0x800000, 0x400000, CRC(36e93234) SHA1(51917a80b7da5c32a9434a1076fc2916d62e6a3e) )
@@ -3040,18 +2957,18 @@ ROM_START( rdftja )
 
 	ROM_REGION( 0x40000, "audiocpu", ROMREGION_ERASE00 ) /* 256K RAM, ROM from Z80 point-of-view */
 
-	ROM_REGION( 0x30000, "gfx1", ROMREGION_ERASEFF ) /* text layer roms */
+	ROM_REGION( 0x30000, "chars", ROMREGION_ERASEFF ) /* text layer roms */
 	ROM_LOAD24_BYTE("gd_5.423", 0x000000, 0x10000, CRC(8f8d4e14) SHA1(06c803975767ae98f40ba7ac5764a5bc8baa3a30) )
 	ROM_LOAD24_BYTE("gd_6.424", 0x000001, 0x10000, CRC(6ac64968) SHA1(ec395205c24c4f864a1f805bb0d4641562d4faa9) )
 	ROM_LOAD24_BYTE("gd_7.48",  0x000002, 0x10000, CRC(4d87e1ea) SHA1(3230e9b643fad773e61ab8ce09c0cd7d4d0558e3) )
 
-	ROM_REGION( 0x600000, "gfx2", ROMREGION_ERASEFF ) /* background layer roms */
+	ROM_REGION( 0x600000, "tiles", ROMREGION_ERASEFF ) /* background layer roms */
 	ROM_LOAD24_WORD("gd_bg1-d.415", 0x000000, 0x200000, CRC(6a68054c) SHA1(5cbfc4ac90045f1401c2dda7a51936558c9de07e) )
 	ROM_LOAD24_BYTE("gd_bg1-p.410", 0x000002, 0x100000, CRC(3400794a) SHA1(719808f7442bac612cefd7b7fffcd665e6337ad0) )
 	ROM_LOAD24_WORD("gd_bg2-d.416", 0x300000, 0x200000, CRC(61cd2991) SHA1(bb608e3948bf9ea35b5e1615d2ba6858d029dcbe) )
 	ROM_LOAD24_BYTE("gd_bg2-p.49",  0x300002, 0x100000, CRC(502d5799) SHA1(c3a0e1a4f5a7b35572ae1ff31315da4ed08aa2fe) )
 
-	ROM_REGION( 0xc00000, "gfx3", 0 ) /* sprites */
+	ROM_REGION( 0xc00000, "sprites", 0 ) /* sprites */
 	ROM_LOAD("gd_obj-1.322", 0x000000, 0x400000, CRC(59d86c99) SHA1(d3c9241e7b51fe21f8351051b063f91dc69bf905) )
 	ROM_LOAD("gd_obj-2.324", 0x400000, 0x400000, CRC(1ceb0b6f) SHA1(97225a9b3e7be18080aa52f6570af2cce8f25c06) )
 	ROM_LOAD("gd_obj-3.323", 0x800000, 0x400000, CRC(36e93234) SHA1(51917a80b7da5c32a9434a1076fc2916d62e6a3e) )
@@ -3073,17 +2990,17 @@ ROM_START( rdftjb ) /* SXX2C ROM SUB4 cart */
 
 	ROM_REGION( 0x40000, "audiocpu", ROMREGION_ERASE00 ) /* 256K RAM, ROM from Z80 point-of-view */
 
-	ROM_REGION( 0x30000, "gfx1", ROMREGION_ERASEFF ) /* text layer roms */
+	ROM_REGION( 0x30000, "chars", ROMREGION_ERASEFF ) /* text layer roms */
 	ROM_LOAD24_WORD("raiden-f_fix.u0425", 0x000000, 0x20000, CRC(2be2936b) SHA1(9e719f7328a52af220b6f084c1e0990ca6e2d533) ) // socket is silkscreened on pcb FIX01
 	ROM_LOAD24_BYTE("seibu_7.u048",       0x000002, 0x10000, CRC(4d87e1ea) SHA1(3230e9b643fad773e61ab8ce09c0cd7d4d0558e3) ) // socket is silkscreened on pcb FIXP
 
-	ROM_REGION( 0x600000, "gfx2", ROMREGION_ERASEFF ) /* background layer roms */
+	ROM_REGION( 0x600000, "tiles", ROMREGION_ERASEFF ) /* background layer roms */
 	ROM_LOAD24_WORD("gun_dogs_bg1-d.u0415", 0x000000, 0x200000, CRC(6a68054c) SHA1(5cbfc4ac90045f1401c2dda7a51936558c9de07e) ) // pads are silkscreened on pcb BG12
 	ROM_LOAD24_BYTE("gun_dogs_bg1-p.u0410", 0x000002, 0x100000, CRC(3400794a) SHA1(719808f7442bac612cefd7b7fffcd665e6337ad0) ) // pads are silkscreened on pcb BG12P
 	ROM_LOAD24_WORD("gun_dogs_bg2-d.u0424", 0x300000, 0x200000, CRC(61cd2991) SHA1(bb608e3948bf9ea35b5e1615d2ba6858d029dcbe) ) // pads are silkscreened on pcb BG3
 	ROM_LOAD24_BYTE("gun_dogs_bg2-p.u049",  0x300002, 0x100000, CRC(502d5799) SHA1(c3a0e1a4f5a7b35572ae1ff31315da4ed08aa2fe) ) // pads are silkscreened on pcb BG3P
 
-	ROM_REGION( 0xc00000, "gfx3", 0 ) /* sprites */
+	ROM_REGION( 0xc00000, "sprites", 0 ) /* sprites */
 	ROM_LOAD("gun_dogs_obj-1.u0322", 0x000000, 0x400000, CRC(59d86c99) SHA1(d3c9241e7b51fe21f8351051b063f91dc69bf905) ) // pads are silkscreened on pcb OBJ1
 	ROM_LOAD("gun_dogs_obj-2.u0324", 0x400000, 0x400000, CRC(1ceb0b6f) SHA1(97225a9b3e7be18080aa52f6570af2cce8f25c06) ) // pads are silkscreened on pcb OBJ2
 	ROM_LOAD("gun_dogs_obj-3.u0323", 0x800000, 0x400000, CRC(36e93234) SHA1(51917a80b7da5c32a9434a1076fc2916d62e6a3e) ) // pads are silkscreened on pcb OBJ3
@@ -3106,18 +3023,18 @@ ROM_START( rdftau )
 
 	ROM_REGION( 0x40000, "audiocpu", ROMREGION_ERASE00 ) /* 256K RAM, ROM from Z80 point-of-view */
 
-	ROM_REGION( 0x30000, "gfx1", ROMREGION_ERASEFF ) /* text layer roms */
+	ROM_REGION( 0x30000, "chars", ROMREGION_ERASEFF ) /* text layer roms */
 	ROM_LOAD24_BYTE("gd_5.423", 0x000000, 0x10000, CRC(8f8d4e14) SHA1(06c803975767ae98f40ba7ac5764a5bc8baa3a30) )
 	ROM_LOAD24_BYTE("gd_6.424", 0x000001, 0x10000, CRC(6ac64968) SHA1(ec395205c24c4f864a1f805bb0d4641562d4faa9) )
 	ROM_LOAD24_BYTE("gd_7.48",  0x000002, 0x10000, CRC(4d87e1ea) SHA1(3230e9b643fad773e61ab8ce09c0cd7d4d0558e3) )
 
-	ROM_REGION( 0x600000, "gfx2", ROMREGION_ERASEFF ) /* background layer roms */
+	ROM_REGION( 0x600000, "tiles", ROMREGION_ERASEFF ) /* background layer roms */
 	ROM_LOAD24_WORD("gd_bg1-d.415", 0x000000, 0x200000, CRC(6a68054c) SHA1(5cbfc4ac90045f1401c2dda7a51936558c9de07e) )
 	ROM_LOAD24_BYTE("gd_bg1-p.410", 0x000002, 0x100000, CRC(3400794a) SHA1(719808f7442bac612cefd7b7fffcd665e6337ad0) )
 	ROM_LOAD24_WORD("gd_bg2-d.416", 0x300000, 0x200000, CRC(61cd2991) SHA1(bb608e3948bf9ea35b5e1615d2ba6858d029dcbe) )
 	ROM_LOAD24_BYTE("gd_bg2-p.49",  0x300002, 0x100000, CRC(502d5799) SHA1(c3a0e1a4f5a7b35572ae1ff31315da4ed08aa2fe) )
 
-	ROM_REGION( 0xc00000, "gfx3", 0 ) /* sprites */
+	ROM_REGION( 0xc00000, "sprites", 0 ) /* sprites */
 	ROM_LOAD("gd_obj-1.322", 0x000000, 0x400000, CRC(59d86c99) SHA1(d3c9241e7b51fe21f8351051b063f91dc69bf905) )
 	ROM_LOAD("gd_obj-2.324", 0x400000, 0x400000, CRC(1ceb0b6f) SHA1(97225a9b3e7be18080aa52f6570af2cce8f25c06) )
 	ROM_LOAD("gd_obj-3.323", 0x800000, 0x400000, CRC(36e93234) SHA1(51917a80b7da5c32a9434a1076fc2916d62e6a3e) )
@@ -3140,18 +3057,18 @@ ROM_START( rdftauge )  /* SPI Cart "SXX2C ROM SUB2", Australia region (Tuning li
 
 	ROM_REGION( 0x40000, "audiocpu", ROMREGION_ERASE00 ) /* 256K RAM, ROM from Z80 point-of-view */
 
-	ROM_REGION( 0x30000, "gfx1", ROMREGION_ERASEFF ) /* text layer roms */
+	ROM_REGION( 0x30000, "chars", ROMREGION_ERASEFF ) /* text layer roms */
 	ROM_LOAD24_BYTE("seibu.5.u0423", 0x000000, 0x10000, CRC(8f8d4e14) SHA1(06c803975767ae98f40ba7ac5764a5bc8baa3a30) )
 	ROM_LOAD24_BYTE("seibu.6.u0424", 0x000001, 0x10000, CRC(6ac64968) SHA1(ec395205c24c4f864a1f805bb0d4641562d4faa9) )
 	ROM_LOAD24_BYTE("seibu.7.u048",  0x000002, 0x10000, CRC(4d87e1ea) SHA1(3230e9b643fad773e61ab8ce09c0cd7d4d0558e3) )
 
-	ROM_REGION( 0x600000, "gfx2", ROMREGION_ERASEFF ) /* background layer roms */
+	ROM_REGION( 0x600000, "tiles", ROMREGION_ERASEFF ) /* background layer roms */
 	ROM_LOAD24_WORD("gun_dogs_bg1-d.u0415", 0x000000, 0x200000, CRC(6a68054c) SHA1(5cbfc4ac90045f1401c2dda7a51936558c9de07e) )
 	ROM_LOAD24_BYTE("gun_dogs_bg1-p.u0410", 0x000002, 0x100000, CRC(3400794a) SHA1(719808f7442bac612cefd7b7fffcd665e6337ad0) )
 	ROM_LOAD24_WORD("gun_dogs_bg2-d.u0416", 0x300000, 0x200000, CRC(61cd2991) SHA1(bb608e3948bf9ea35b5e1615d2ba6858d029dcbe) )
 	ROM_LOAD24_BYTE("gun_dogs_bg2-p.u049",  0x300002, 0x100000, CRC(502d5799) SHA1(c3a0e1a4f5a7b35572ae1ff31315da4ed08aa2fe) )
 
-	ROM_REGION( 0xc00000, "gfx3", 0 ) /* sprites */
+	ROM_REGION( 0xc00000, "sprites", 0 ) /* sprites */
 	ROM_LOAD("gun_dogs_obj-1.u0322", 0x000000, 0x400000, CRC(59d86c99) SHA1(d3c9241e7b51fe21f8351051b063f91dc69bf905) )
 	ROM_LOAD("gun_dogs_obj-2.u0324", 0x400000, 0x400000, CRC(1ceb0b6f) SHA1(97225a9b3e7be18080aa52f6570af2cce8f25c06) )
 	ROM_LOAD("gun_dogs_obj-3.u0323", 0x800000, 0x400000, CRC(36e93234) SHA1(51917a80b7da5c32a9434a1076fc2916d62e6a3e) )
@@ -3174,18 +3091,18 @@ ROM_START( rdftit )
 
 	ROM_REGION( 0x40000, "audiocpu", ROMREGION_ERASE00 ) /* 256K RAM, ROM from Z80 point-of-view */
 
-	ROM_REGION( 0x30000, "gfx1", ROMREGION_ERASEFF ) /* text layer roms */
+	ROM_REGION( 0x30000, "chars", ROMREGION_ERASEFF ) /* text layer roms */
 	ROM_LOAD24_BYTE("gd_5.423", 0x000000, 0x10000, CRC(8f8d4e14) SHA1(06c803975767ae98f40ba7ac5764a5bc8baa3a30) )
 	ROM_LOAD24_BYTE("gd_6.424", 0x000001, 0x10000, CRC(6ac64968) SHA1(ec395205c24c4f864a1f805bb0d4641562d4faa9) )
 	ROM_LOAD24_BYTE("gd_7.48",  0x000002, 0x10000, CRC(4d87e1ea) SHA1(3230e9b643fad773e61ab8ce09c0cd7d4d0558e3) )
 
-	ROM_REGION( 0x600000, "gfx2", ROMREGION_ERASEFF ) /* background layer roms */
+	ROM_REGION( 0x600000, "tiles", ROMREGION_ERASEFF ) /* background layer roms */
 	ROM_LOAD24_WORD("gd_bg1-d.415", 0x000000, 0x200000, CRC(6a68054c) SHA1(5cbfc4ac90045f1401c2dda7a51936558c9de07e) )
 	ROM_LOAD24_BYTE("gd_bg1-p.410", 0x000002, 0x100000, CRC(3400794a) SHA1(719808f7442bac612cefd7b7fffcd665e6337ad0) )
 	ROM_LOAD24_WORD("gd_bg2-d.416", 0x300000, 0x200000, CRC(61cd2991) SHA1(bb608e3948bf9ea35b5e1615d2ba6858d029dcbe) )
 	ROM_LOAD24_BYTE("gd_bg2-p.49",  0x300002, 0x100000, CRC(502d5799) SHA1(c3a0e1a4f5a7b35572ae1ff31315da4ed08aa2fe) )
 
-	ROM_REGION( 0xc00000, "gfx3", 0 ) /* sprites */
+	ROM_REGION( 0xc00000, "sprites", 0 ) /* sprites */
 	ROM_LOAD("gd_obj-1.322", 0x000000, 0x400000, CRC(59d86c99) SHA1(d3c9241e7b51fe21f8351051b063f91dc69bf905) )
 	ROM_LOAD("gd_obj-2.324", 0x400000, 0x400000, CRC(1ceb0b6f) SHA1(97225a9b3e7be18080aa52f6570af2cce8f25c06) )
 	ROM_LOAD("gd_obj-3.323", 0x800000, 0x400000, CRC(36e93234) SHA1(51917a80b7da5c32a9434a1076fc2916d62e6a3e) )
@@ -3208,18 +3125,18 @@ ROM_START( rdfta )
 
 	ROM_REGION( 0x40000, "audiocpu", ROMREGION_ERASE00 ) /* 256K RAM, ROM from Z80 point-of-view */
 
-	ROM_REGION( 0x30000, "gfx1", ROMREGION_ERASEFF ) /* text layer roms */
+	ROM_REGION( 0x30000, "chars", ROMREGION_ERASEFF ) /* text layer roms */
 	ROM_LOAD24_BYTE("gd_5.423", 0x000000, 0x10000, CRC(8f8d4e14) SHA1(06c803975767ae98f40ba7ac5764a5bc8baa3a30) )
 	ROM_LOAD24_BYTE("gd_6.424", 0x000001, 0x10000, CRC(6ac64968) SHA1(ec395205c24c4f864a1f805bb0d4641562d4faa9) )
 	ROM_LOAD24_BYTE("gd_7.48",  0x000002, 0x10000, CRC(4d87e1ea) SHA1(3230e9b643fad773e61ab8ce09c0cd7d4d0558e3) )
 
-	ROM_REGION( 0x600000, "gfx2", ROMREGION_ERASEFF ) /* background layer roms */
+	ROM_REGION( 0x600000, "tiles", ROMREGION_ERASEFF ) /* background layer roms */
 	ROM_LOAD24_WORD("gd_bg1-d.415", 0x000000, 0x200000, CRC(6a68054c) SHA1(5cbfc4ac90045f1401c2dda7a51936558c9de07e) )
 	ROM_LOAD24_BYTE("gd_bg1-p.410", 0x000002, 0x100000, CRC(3400794a) SHA1(719808f7442bac612cefd7b7fffcd665e6337ad0) )
 	ROM_LOAD24_WORD("gd_bg2-d.416", 0x300000, 0x200000, CRC(61cd2991) SHA1(bb608e3948bf9ea35b5e1615d2ba6858d029dcbe) )
 	ROM_LOAD24_BYTE("gd_bg2-p.49",  0x300002, 0x100000, CRC(502d5799) SHA1(c3a0e1a4f5a7b35572ae1ff31315da4ed08aa2fe) )
 
-	ROM_REGION( 0xc00000, "gfx3", 0 ) /* sprites */
+	ROM_REGION( 0xc00000, "sprites", 0 ) /* sprites */
 	ROM_LOAD("gd_obj-1.322", 0x000000, 0x400000, CRC(59d86c99) SHA1(d3c9241e7b51fe21f8351051b063f91dc69bf905) )
 	ROM_LOAD("gd_obj-2.324", 0x400000, 0x400000, CRC(1ceb0b6f) SHA1(97225a9b3e7be18080aa52f6570af2cce8f25c06) )
 	ROM_LOAD("gd_obj-3.323", 0x800000, 0x400000, CRC(36e93234) SHA1(51917a80b7da5c32a9434a1076fc2916d62e6a3e) )
@@ -3242,18 +3159,18 @@ ROM_START( rdftgb )
 
 	ROM_REGION( 0x40000, "audiocpu", ROMREGION_ERASE00 ) /* 256K RAM, ROM from Z80 point-of-view */
 
-	ROM_REGION( 0x30000, "gfx1", ROMREGION_ERASEFF ) /* text layer roms */
+	ROM_REGION( 0x30000, "chars", ROMREGION_ERASEFF ) /* text layer roms */
 	ROM_LOAD24_BYTE("rf_5.u0423", 0x000000, 0x10000, CRC(8f8d4e14) SHA1(06c803975767ae98f40ba7ac5764a5bc8baa3a30) )
 	ROM_LOAD24_BYTE("rf_6.u0424", 0x000001, 0x10000, CRC(6ac64968) SHA1(ec395205c24c4f864a1f805bb0d4641562d4faa9) )
 	ROM_LOAD24_BYTE("rf_7.u048",  0x000002, 0x10000, CRC(4d87e1ea) SHA1(3230e9b643fad773e61ab8ce09c0cd7d4d0558e3) )
 
-	ROM_REGION( 0x600000, "gfx2", ROMREGION_ERASEFF ) /* background layer roms */
+	ROM_REGION( 0x600000, "tiles", ROMREGION_ERASEFF ) /* background layer roms */
 	ROM_LOAD24_WORD("gd_bg1-d.415", 0x000000, 0x200000, CRC(6a68054c) SHA1(5cbfc4ac90045f1401c2dda7a51936558c9de07e) )
 	ROM_LOAD24_BYTE("gd_bg1-p.410", 0x000002, 0x100000, CRC(3400794a) SHA1(719808f7442bac612cefd7b7fffcd665e6337ad0) )
 	ROM_LOAD24_WORD("gd_bg2-d.416", 0x300000, 0x200000, CRC(61cd2991) SHA1(bb608e3948bf9ea35b5e1615d2ba6858d029dcbe) )
 	ROM_LOAD24_BYTE("gd_bg2-p.49",  0x300002, 0x100000, CRC(502d5799) SHA1(c3a0e1a4f5a7b35572ae1ff31315da4ed08aa2fe) )
 
-	ROM_REGION( 0xc00000, "gfx3", 0 ) /* sprites */
+	ROM_REGION( 0xc00000, "sprites", 0 ) /* sprites */
 	ROM_LOAD("gd_obj-1.322", 0x000000, 0x400000, CRC(59d86c99) SHA1(d3c9241e7b51fe21f8351051b063f91dc69bf905) )
 	ROM_LOAD("gd_obj-2.324", 0x400000, 0x400000, CRC(1ceb0b6f) SHA1(97225a9b3e7be18080aa52f6570af2cce8f25c06) )
 	ROM_LOAD("gd_obj-3.323", 0x800000, 0x400000, CRC(36e93234) SHA1(51917a80b7da5c32a9434a1076fc2916d62e6a3e) )
@@ -3275,17 +3192,17 @@ ROM_START( rdftadi ) // Dream Island license - SXX2C ROM SUB4 cart
 
 	ROM_REGION( 0x40000, "audiocpu", ROMREGION_ERASE00 ) /* 256K RAM, ROM from Z80 point-of-view */
 
-	ROM_REGION( 0x30000, "gfx1", ROMREGION_ERASEFF ) /* text layer roms */
+	ROM_REGION( 0x30000, "chars", ROMREGION_ERASEFF ) /* text layer roms */
 	ROM_LOAD24_WORD("raiden-f_fix.u0425", 0x000000, 0x20000, CRC(2be2936b) SHA1(9e719f7328a52af220b6f084c1e0990ca6e2d533) ) // socket is silkscreened on pcb FIX01
 	ROM_LOAD24_BYTE("seibu_7.u048",       0x000002, 0x10000, CRC(4d87e1ea) SHA1(3230e9b643fad773e61ab8ce09c0cd7d4d0558e3) ) // socket is silkscreened on pcb FIXP
 
-	ROM_REGION( 0x600000, "gfx2", ROMREGION_ERASEFF ) /* background layer roms */
+	ROM_REGION( 0x600000, "tiles", ROMREGION_ERASEFF ) /* background layer roms */
 	ROM_LOAD24_WORD("gun_dogs_bg1-d.u0415", 0x000000, 0x200000, CRC(6a68054c) SHA1(5cbfc4ac90045f1401c2dda7a51936558c9de07e) ) // pads are silkscreened on pcb BG12
 	ROM_LOAD24_BYTE("gun_dogs_bg1-p.u0410", 0x000002, 0x100000, CRC(3400794a) SHA1(719808f7442bac612cefd7b7fffcd665e6337ad0) ) // pads are silkscreened on pcb BG12P
 	ROM_LOAD24_WORD("gun_dogs_bg2-d.u0424", 0x300000, 0x200000, CRC(61cd2991) SHA1(bb608e3948bf9ea35b5e1615d2ba6858d029dcbe) ) // pads are silkscreened on pcb BG3
 	ROM_LOAD24_BYTE("gun_dogs_bg2-p.u049",  0x300002, 0x100000, CRC(502d5799) SHA1(c3a0e1a4f5a7b35572ae1ff31315da4ed08aa2fe) ) // pads are silkscreened on pcb BG3P
 
-	ROM_REGION( 0xc00000, "gfx3", 0 ) /* sprites */
+	ROM_REGION( 0xc00000, "sprites", 0 ) /* sprites */
 	ROM_LOAD("gun_dogs_obj-1.u0322", 0x000000, 0x400000, CRC(59d86c99) SHA1(d3c9241e7b51fe21f8351051b063f91dc69bf905) ) // pads are silkscreened on pcb OBJ1
 	ROM_LOAD("gun_dogs_obj-2.u0324", 0x400000, 0x400000, CRC(1ceb0b6f) SHA1(97225a9b3e7be18080aa52f6570af2cce8f25c06) ) // pads are silkscreened on pcb OBJ2
 	ROM_LOAD("gun_dogs_obj-3.u0323", 0x800000, 0x400000, CRC(36e93234) SHA1(51917a80b7da5c32a9434a1076fc2916d62e6a3e) ) // pads are silkscreened on pcb OBJ3
@@ -3307,17 +3224,17 @@ ROM_START( rdftam ) // Metrotainment license - SXX2C ROM SUB4 cart
 
 	ROM_REGION( 0x40000, "audiocpu", ROMREGION_ERASE00 ) /* 256K RAM, ROM from Z80 point-of-view */
 
-	ROM_REGION( 0x30000, "gfx1", ROMREGION_ERASEFF ) /* text layer roms */
+	ROM_REGION( 0x30000, "chars", ROMREGION_ERASEFF ) /* text layer roms */
 	ROM_LOAD24_WORD("raiden-f_fix.u0425", 0x000000, 0x20000, CRC(2be2936b) SHA1(9e719f7328a52af220b6f084c1e0990ca6e2d533) ) // socket is silkscreened on pcb FIX01
 	ROM_LOAD24_BYTE("seibu_7.u048",       0x000002, 0x10000, CRC(4d87e1ea) SHA1(3230e9b643fad773e61ab8ce09c0cd7d4d0558e3) ) // socket is silkscreened on pcb FIXP
 
-	ROM_REGION( 0x600000, "gfx2", ROMREGION_ERASEFF ) /* background layer roms */
+	ROM_REGION( 0x600000, "tiles", ROMREGION_ERASEFF ) /* background layer roms */
 	ROM_LOAD24_WORD("gun_dogs_bg1-d.u0415", 0x000000, 0x200000, CRC(6a68054c) SHA1(5cbfc4ac90045f1401c2dda7a51936558c9de07e) ) // pads are silkscreened on pcb BG12
 	ROM_LOAD24_BYTE("gun_dogs_bg1-p.u0410", 0x000002, 0x100000, CRC(3400794a) SHA1(719808f7442bac612cefd7b7fffcd665e6337ad0) ) // pads are silkscreened on pcb BG12P
 	ROM_LOAD24_WORD("gun_dogs_bg2-d.u0424", 0x300000, 0x200000, CRC(61cd2991) SHA1(bb608e3948bf9ea35b5e1615d2ba6858d029dcbe) ) // pads are silkscreened on pcb BG3
 	ROM_LOAD24_BYTE("gun_dogs_bg2-p.u049",  0x300002, 0x100000, CRC(502d5799) SHA1(c3a0e1a4f5a7b35572ae1ff31315da4ed08aa2fe) ) // pads are silkscreened on pcb BG3P
 
-	ROM_REGION( 0xc00000, "gfx3", 0 ) /* sprites */
+	ROM_REGION( 0xc00000, "sprites", 0 ) /* sprites */
 	ROM_LOAD("gun_dogs_obj-1.u0322", 0x000000, 0x400000, CRC(59d86c99) SHA1(d3c9241e7b51fe21f8351051b063f91dc69bf905) ) // pads are silkscreened on pcb OBJ1
 	ROM_LOAD("gun_dogs_obj-2.u0324", 0x400000, 0x400000, CRC(1ceb0b6f) SHA1(97225a9b3e7be18080aa52f6570af2cce8f25c06) ) // pads are silkscreened on pcb OBJ2
 	ROM_LOAD("gun_dogs_obj-3.u0323", 0x800000, 0x400000, CRC(36e93234) SHA1(51917a80b7da5c32a9434a1076fc2916d62e6a3e) ) // pads are silkscreened on pcb OBJ3
@@ -3341,18 +3258,18 @@ ROM_START( rdft2 ) /* SPI Cart, Europe */
 
 	ROM_REGION( 0x40000, "audiocpu", ROMREGION_ERASE00 ) /* 256K RAM, ROM from Z80 point-of-view */
 
-	ROM_REGION( 0x30000, "gfx1", ROMREGION_ERASEFF ) /* text layer roms */
+	ROM_REGION( 0x30000, "chars", ROMREGION_ERASEFF ) /* text layer roms */
 	ROM_LOAD24_BYTE("fix0.u0524", 0x000001, 0x10000, CRC(6fdf4cf6) SHA1(7e9d4a49e829dfdc373c0f5acfbe8c7a91ac115b) )
 	ROM_LOAD24_BYTE("fix1.u0518", 0x000000, 0x10000, CRC(69b7899b) SHA1(d3cacd4ef4d2c95d803403101beb9d4be75fae61) )
 	ROM_LOAD24_BYTE("fixp.u0514", 0x000002, 0x10000, CRC(99a5fece) SHA1(44ae95d650ed6e00202d3438f5f91a5e52e319cb) )
 
-	ROM_REGION( 0xc00000, "gfx2", ROMREGION_ERASEFF ) /* background layer roms */
+	ROM_REGION( 0xc00000, "tiles", ROMREGION_ERASEFF ) /* background layer roms */
 	ROM_LOAD24_WORD("bg-1d.u0535", 0x000000, 0x400000, CRC(6143f576) SHA1(c034923d0663d9ef24357a03098b8cb81dbab9f8) )
 	ROM_LOAD24_BYTE("bg-1p.u0537", 0x000002, 0x200000, CRC(55e64ef7) SHA1(aae991268948d07342ee8ba1b3761bd180aab8ec) )
 	ROM_LOAD24_WORD("bg-2d.u0536", 0x600000, 0x400000, CRC(c607a444) SHA1(dc1aa96a42e9394ca6036359670a4ec6f830c96d) )
 	ROM_LOAD24_BYTE("bg-2p.u0538", 0x600002, 0x200000, CRC(f0830248) SHA1(6075df96b49e70d2243fef691e096119e7a4d044) )
 
-	ROM_REGION( 0x1200000, "gfx3", 0 ) /* sprites */
+	ROM_REGION( 0x1200000, "sprites", 0 ) /* sprites */
 	ROM_LOAD("obj3.u0434",  0x0000000, 0x400000, CRC(e08f42dc) SHA1(5188d71d4355eaf43ea8893b4cfc4fe80cc24f41) )
 	ROM_LOAD("obj3b.u0433", 0x0400000, 0x200000, CRC(1b6a523c) SHA1(99a420dbc8e22e7832ccda7cec9fa661a2a2687a) )
 	ROM_LOAD("obj2.u0431",  0x0600000, 0x400000, CRC(7aeadd8e) SHA1(47103c0579240c5b1add4d0b164eaf76f5fa97f0) )
@@ -3378,18 +3295,18 @@ ROM_START( rdft2u ) /* SPI Cart, USA */
 
 	ROM_REGION( 0x40000, "audiocpu", ROMREGION_ERASE00 ) /* 256K RAM, ROM from Z80 point-of-view */
 
-	ROM_REGION( 0x30000, "gfx1", ROMREGION_ERASEFF ) /* text layer roms */
+	ROM_REGION( 0x30000, "chars", ROMREGION_ERASEFF ) /* text layer roms */
 	ROM_LOAD24_BYTE("fix0.u0524", 0x000001, 0x10000, CRC(6fdf4cf6) SHA1(7e9d4a49e829dfdc373c0f5acfbe8c7a91ac115b) )
 	ROM_LOAD24_BYTE("fix1.u0518", 0x000000, 0x10000, CRC(69b7899b) SHA1(d3cacd4ef4d2c95d803403101beb9d4be75fae61) )
 	ROM_LOAD24_BYTE("fixp.u0514", 0x000002, 0x10000, CRC(99a5fece) SHA1(44ae95d650ed6e00202d3438f5f91a5e52e319cb) )
 
-	ROM_REGION( 0xc00000, "gfx2", ROMREGION_ERASEFF ) /* background layer roms */
+	ROM_REGION( 0xc00000, "tiles", ROMREGION_ERASEFF ) /* background layer roms */
 	ROM_LOAD24_WORD("bg-1d.u0535", 0x000000, 0x400000, CRC(6143f576) SHA1(c034923d0663d9ef24357a03098b8cb81dbab9f8) )
 	ROM_LOAD24_BYTE("bg-1p.u0537", 0x000002, 0x200000, CRC(55e64ef7) SHA1(aae991268948d07342ee8ba1b3761bd180aab8ec) )
 	ROM_LOAD24_WORD("bg-2d.u0536", 0x600000, 0x400000, CRC(c607a444) SHA1(dc1aa96a42e9394ca6036359670a4ec6f830c96d) )
 	ROM_LOAD24_BYTE("bg-2p.u0538", 0x600002, 0x200000, CRC(f0830248) SHA1(6075df96b49e70d2243fef691e096119e7a4d044) )
 
-	ROM_REGION( 0x1200000, "gfx3", 0 ) /* sprites */
+	ROM_REGION( 0x1200000, "sprites", 0 ) /* sprites */
 	ROM_LOAD("obj3.u0434",  0x0000000, 0x400000, CRC(e08f42dc) SHA1(5188d71d4355eaf43ea8893b4cfc4fe80cc24f41) )
 	ROM_LOAD("obj3b.u0433", 0x0400000, 0x200000, CRC(1b6a523c) SHA1(99a420dbc8e22e7832ccda7cec9fa661a2a2687a) )
 	ROM_LOAD("obj2.u0431",  0x0600000, 0x400000, CRC(7aeadd8e) SHA1(47103c0579240c5b1add4d0b164eaf76f5fa97f0) )
@@ -3415,18 +3332,18 @@ ROM_START( rdft2j ) /* SPI Cart, Japan */
 
 	ROM_REGION( 0x40000, "audiocpu", ROMREGION_ERASE00 ) /* 256K RAM, ROM from Z80 point-of-view */
 
-	ROM_REGION( 0x30000, "gfx1", ROMREGION_ERASEFF ) /* text layer roms */
+	ROM_REGION( 0x30000, "chars", ROMREGION_ERASEFF ) /* text layer roms */
 	ROM_LOAD24_BYTE("fix0.u0524", 0x000001, 0x10000, CRC(6fdf4cf6) SHA1(7e9d4a49e829dfdc373c0f5acfbe8c7a91ac115b) )
 	ROM_LOAD24_BYTE("fix1.u0518", 0x000000, 0x10000, CRC(69b7899b) SHA1(d3cacd4ef4d2c95d803403101beb9d4be75fae61) )
 	ROM_LOAD24_BYTE("fixp.u0514", 0x000002, 0x10000, CRC(99a5fece) SHA1(44ae95d650ed6e00202d3438f5f91a5e52e319cb) )
 
-	ROM_REGION( 0xc00000, "gfx2", ROMREGION_ERASEFF ) /* background layer roms */
+	ROM_REGION( 0xc00000, "tiles", ROMREGION_ERASEFF ) /* background layer roms */
 	ROM_LOAD24_WORD("bg-1d.u0535", 0x000000, 0x400000, CRC(6143f576) SHA1(c034923d0663d9ef24357a03098b8cb81dbab9f8) )
 	ROM_LOAD24_BYTE("bg-1p.u0537", 0x000002, 0x200000, CRC(55e64ef7) SHA1(aae991268948d07342ee8ba1b3761bd180aab8ec) )
 	ROM_LOAD24_WORD("bg-2d.u0536", 0x600000, 0x400000, CRC(c607a444) SHA1(dc1aa96a42e9394ca6036359670a4ec6f830c96d) )
 	ROM_LOAD24_BYTE("bg-2p.u0538", 0x600002, 0x200000, CRC(f0830248) SHA1(6075df96b49e70d2243fef691e096119e7a4d044) )
 
-	ROM_REGION( 0x1200000, "gfx3", 0 ) /* sprites */
+	ROM_REGION( 0x1200000, "sprites", 0 ) /* sprites */
 	ROM_LOAD("obj3.u0434",  0x0000000, 0x400000, CRC(e08f42dc) SHA1(5188d71d4355eaf43ea8893b4cfc4fe80cc24f41) )
 	ROM_LOAD("obj3b.u0433", 0x0400000, 0x200000, CRC(1b6a523c) SHA1(99a420dbc8e22e7832ccda7cec9fa661a2a2687a) )
 	ROM_LOAD("obj2.u0431",  0x0600000, 0x400000, CRC(7aeadd8e) SHA1(47103c0579240c5b1add4d0b164eaf76f5fa97f0) )
@@ -3452,18 +3369,18 @@ ROM_START( rdft2ja ) /* SPI Cart, Japan */
 
 	ROM_REGION( 0x40000, "audiocpu", ROMREGION_ERASE00 ) /* 256K RAM, ROM from Z80 point-of-view */
 
-	ROM_REGION( 0x30000, "gfx1", ROMREGION_ERASEFF ) /* text layer roms */
+	ROM_REGION( 0x30000, "chars", ROMREGION_ERASEFF ) /* text layer roms */
 	ROM_LOAD24_BYTE("rf2_5.bin", 0x000001, 0x10000, CRC(377cac2f) SHA1(f7c9323d79b77f6c8c02ba2c6cdca127d6e5cb5c) )
 	ROM_LOAD24_BYTE("rf2_6.bin", 0x000000, 0x10000, CRC(42bd5372) SHA1(c38df85b25070db9640eac541f71c0511bab0c98) )
 	ROM_LOAD24_BYTE("rf2_7.bin", 0x000002, 0x10000, CRC(1efaac7e) SHA1(8252af56dcb7a6306dc3422070176778e3c511c2) )
 
-	ROM_REGION( 0xc00000, "gfx2", ROMREGION_ERASEFF ) /* background layer roms */
+	ROM_REGION( 0xc00000, "tiles", ROMREGION_ERASEFF ) /* background layer roms */
 	ROM_LOAD24_WORD("bg-1d.u0535", 0x000000, 0x400000, CRC(6143f576) SHA1(c034923d0663d9ef24357a03098b8cb81dbab9f8) )
 	ROM_LOAD24_BYTE("bg-1p.u0537", 0x000002, 0x200000, CRC(55e64ef7) SHA1(aae991268948d07342ee8ba1b3761bd180aab8ec) )
 	ROM_LOAD24_WORD("bg-2d.u0536", 0x600000, 0x400000, CRC(c607a444) SHA1(dc1aa96a42e9394ca6036359670a4ec6f830c96d) )
 	ROM_LOAD24_BYTE("bg-2p.u0538", 0x600002, 0x200000, CRC(f0830248) SHA1(6075df96b49e70d2243fef691e096119e7a4d044) )
 
-	ROM_REGION( 0x1200000, "gfx3", 0 ) /* sprites */
+	ROM_REGION( 0x1200000, "sprites", 0 ) /* sprites */
 	ROM_LOAD("obj3.u0434",  0x0000000, 0x400000, CRC(e08f42dc) SHA1(5188d71d4355eaf43ea8893b4cfc4fe80cc24f41) )
 	ROM_LOAD("obj3b.u0433", 0x0400000, 0x200000, CRC(1b6a523c) SHA1(99a420dbc8e22e7832ccda7cec9fa661a2a2687a) )
 	ROM_LOAD("obj2.u0431",  0x0600000, 0x400000, CRC(7aeadd8e) SHA1(47103c0579240c5b1add4d0b164eaf76f5fa97f0) )
@@ -3489,18 +3406,18 @@ ROM_START( rdft2jb ) /* SPI Cart, Japan */
 
 	ROM_REGION( 0x40000, "audiocpu", ROMREGION_ERASE00 ) /* 256K RAM, ROM from Z80 point-of-view */
 
-	ROM_REGION( 0x30000, "gfx1", ROMREGION_ERASEFF ) /* text layer roms */
+	ROM_REGION( 0x30000, "chars", ROMREGION_ERASEFF ) /* text layer roms */
 	ROM_LOAD24_BYTE("rf2_5.bin", 0x000001, 0x10000, CRC(377cac2f) SHA1(f7c9323d79b77f6c8c02ba2c6cdca127d6e5cb5c) )
 	ROM_LOAD24_BYTE("rf2_6.bin", 0x000000, 0x10000, CRC(42bd5372) SHA1(c38df85b25070db9640eac541f71c0511bab0c98) )
 	ROM_LOAD24_BYTE("rf2_7.bin", 0x000002, 0x10000, CRC(1efaac7e) SHA1(8252af56dcb7a6306dc3422070176778e3c511c2) )
 
-	ROM_REGION( 0xc00000, "gfx2", ROMREGION_ERASEFF ) /* background layer roms */
+	ROM_REGION( 0xc00000, "tiles", ROMREGION_ERASEFF ) /* background layer roms */
 	ROM_LOAD24_WORD("bg-1d.u0535", 0x000000, 0x400000, CRC(6143f576) SHA1(c034923d0663d9ef24357a03098b8cb81dbab9f8) )
 	ROM_LOAD24_BYTE("bg-1p.u0537", 0x000002, 0x200000, CRC(55e64ef7) SHA1(aae991268948d07342ee8ba1b3761bd180aab8ec) )
 	ROM_LOAD24_WORD("bg-2d.u0536", 0x600000, 0x400000, CRC(c607a444) SHA1(dc1aa96a42e9394ca6036359670a4ec6f830c96d) )
 	ROM_LOAD24_BYTE("bg-2p.u0538", 0x600002, 0x200000, CRC(f0830248) SHA1(6075df96b49e70d2243fef691e096119e7a4d044) )
 
-	ROM_REGION( 0x1200000, "gfx3", 0 ) /* sprites */
+	ROM_REGION( 0x1200000, "sprites", 0 ) /* sprites */
 	ROM_LOAD("obj3.u0434",  0x0000000, 0x400000, CRC(e08f42dc) SHA1(5188d71d4355eaf43ea8893b4cfc4fe80cc24f41) )
 	ROM_LOAD("obj3b.u0433", 0x0400000, 0x200000, CRC(1b6a523c) SHA1(99a420dbc8e22e7832ccda7cec9fa661a2a2687a) )
 	ROM_LOAD("obj2.u0431",  0x0600000, 0x400000, CRC(7aeadd8e) SHA1(47103c0579240c5b1add4d0b164eaf76f5fa97f0) )
@@ -3526,18 +3443,18 @@ ROM_START( rdft2jc ) /* SPI SXX2C ROM SUB8 Cart, Japan */
 
 	ROM_REGION( 0x40000, "audiocpu", ROMREGION_ERASE00 ) /* 256K RAM, ROM from Z80 point-of-view */
 
-	ROM_REGION( 0x30000, "gfx1", ROMREGION_ERASEFF ) /* text layer roms */
+	ROM_REGION( 0x30000, "chars", ROMREGION_ERASEFF ) /* text layer roms */
 	ROM_LOAD24_BYTE("fix0.u0524", 0x000001, 0x10000, CRC(6fdf4cf6) SHA1(7e9d4a49e829dfdc373c0f5acfbe8c7a91ac115b) )
 	ROM_LOAD24_BYTE("fix1.u0518", 0x000000, 0x10000, CRC(69b7899b) SHA1(d3cacd4ef4d2c95d803403101beb9d4be75fae61) )
 	ROM_LOAD24_BYTE("fixp.u0514", 0x000002, 0x10000, CRC(99a5fece) SHA1(44ae95d650ed6e00202d3438f5f91a5e52e319cb) )
 
-	ROM_REGION( 0xc00000, "gfx2", ROMREGION_ERASEFF ) /* background layer roms */
+	ROM_REGION( 0xc00000, "tiles", ROMREGION_ERASEFF ) /* background layer roms */
 	ROM_LOAD24_WORD("bg-1d.u0535", 0x000000, 0x400000, CRC(6143f576) SHA1(c034923d0663d9ef24357a03098b8cb81dbab9f8) )
 	ROM_LOAD24_BYTE("bg-1p.u0537", 0x000002, 0x200000, CRC(55e64ef7) SHA1(aae991268948d07342ee8ba1b3761bd180aab8ec) )
 	ROM_LOAD24_WORD("bg-2d.u0536", 0x600000, 0x400000, CRC(c607a444) SHA1(dc1aa96a42e9394ca6036359670a4ec6f830c96d) )
 	ROM_LOAD24_BYTE("bg-2p.u0538", 0x600002, 0x200000, CRC(f0830248) SHA1(6075df96b49e70d2243fef691e096119e7a4d044) )
 
-	ROM_REGION( 0x1200000, "gfx3", 0 ) /* sprites */
+	ROM_REGION( 0x1200000, "sprites", 0 ) /* sprites */
 	ROM_LOAD("obj3.u0434",  0x0000000, 0x400000, CRC(e08f42dc) SHA1(5188d71d4355eaf43ea8893b4cfc4fe80cc24f41) )
 	ROM_LOAD("obj3b.u0433", 0x0400000, 0x200000, CRC(1b6a523c) SHA1(99a420dbc8e22e7832ccda7cec9fa661a2a2687a) )
 	ROM_LOAD("obj2.u0431",  0x0600000, 0x400000, CRC(7aeadd8e) SHA1(47103c0579240c5b1add4d0b164eaf76f5fa97f0) )
@@ -3563,18 +3480,18 @@ ROM_START( rdft2it ) /* SPI Cart, Italy */
 
 	ROM_REGION( 0x40000, "audiocpu", ROMREGION_ERASE00 ) /* 256K RAM, ROM from Z80 point-of-view */
 
-	ROM_REGION( 0x30000, "gfx1", ROMREGION_ERASEFF ) /* text layer roms */
+	ROM_REGION( 0x30000, "chars", ROMREGION_ERASEFF ) /* text layer roms */
 	ROM_LOAD24_BYTE("seibu5.bin", 0x000001, 0x10000, CRC(377cac2f) SHA1(f7c9323d79b77f6c8c02ba2c6cdca127d6e5cb5c) )
 	ROM_LOAD24_BYTE("seibu6.bin", 0x000000, 0x10000, CRC(42bd5372) SHA1(c38df85b25070db9640eac541f71c0511bab0c98) )
 	ROM_LOAD24_BYTE("seibu7.bin", 0x000002, 0x10000, CRC(1efaac7e) SHA1(8252af56dcb7a6306dc3422070176778e3c511c2) )
 
-	ROM_REGION( 0xc00000, "gfx2", ROMREGION_ERASEFF ) /* background layer roms */
+	ROM_REGION( 0xc00000, "tiles", ROMREGION_ERASEFF ) /* background layer roms */
 	ROM_LOAD24_WORD("bg-1d.u0535", 0x000000, 0x400000, CRC(6143f576) SHA1(c034923d0663d9ef24357a03098b8cb81dbab9f8) )
 	ROM_LOAD24_BYTE("bg-1p.u0537", 0x000002, 0x200000, CRC(55e64ef7) SHA1(aae991268948d07342ee8ba1b3761bd180aab8ec) )
 	ROM_LOAD24_WORD("bg-2d.u0536", 0x600000, 0x400000, CRC(c607a444) SHA1(dc1aa96a42e9394ca6036359670a4ec6f830c96d) )
 	ROM_LOAD24_BYTE("bg-2p.u0538", 0x600002, 0x200000, CRC(f0830248) SHA1(6075df96b49e70d2243fef691e096119e7a4d044) )
 
-	ROM_REGION( 0x1200000, "gfx3", 0 ) /* sprites */
+	ROM_REGION( 0x1200000, "sprites", 0 ) /* sprites */
 	ROM_LOAD("obj3.u0434",  0x0000000, 0x400000, CRC(e08f42dc) SHA1(5188d71d4355eaf43ea8893b4cfc4fe80cc24f41) )
 	ROM_LOAD("obj3b.u0433", 0x0400000, 0x200000, CRC(1b6a523c) SHA1(99a420dbc8e22e7832ccda7cec9fa661a2a2687a) )
 	ROM_LOAD("obj2.u0431",  0x0600000, 0x400000, CRC(7aeadd8e) SHA1(47103c0579240c5b1add4d0b164eaf76f5fa97f0) )
@@ -3601,18 +3518,18 @@ ROM_START( rdft2a ) /* SPI Cart, Asia (Metrotainment license); SPI PCB is marked
 
 	ROM_REGION( 0x40000, "audiocpu", ROMREGION_ERASE00 ) /* 256K RAM, ROM from Z80 point-of-view */
 
-	ROM_REGION( 0x30000, "gfx1", ROMREGION_ERASEFF ) /* text layer roms - all are 27C512 */
+	ROM_REGION( 0x30000, "chars", ROMREGION_ERASEFF ) /* text layer roms - all are 27C512 */
 	ROM_LOAD24_BYTE("seibu__5.u0524", 0x000001, 0x10000, CRC(6fdf4cf6) SHA1(7e9d4a49e829dfdc373c0f5acfbe8c7a91ac115b) ) // socket is silkscreened on pcb FIX0
 	ROM_LOAD24_BYTE("seibu__6.u0518", 0x000000, 0x10000, CRC(69b7899b) SHA1(d3cacd4ef4d2c95d803403101beb9d4be75fae61) ) // socket is silkscreened on pcb FIX1
 	ROM_LOAD24_BYTE("seibu__7.u0514", 0x000002, 0x10000, CRC(99a5fece) SHA1(44ae95d650ed6e00202d3438f5f91a5e52e319cb) ) // socket is silkscreened on pcb FIXP
 
-	ROM_REGION( 0xc00000, "gfx2", ROMREGION_ERASEFF ) /* background layer roms - half are MX semiconductor MX23C3210MC, half are some sort of 23C1610 equivalent with no visible manufacturer name */
+	ROM_REGION( 0xc00000, "tiles", ROMREGION_ERASEFF ) /* background layer roms - half are MX semiconductor MX23C3210MC, half are some sort of 23C1610 equivalent with no visible manufacturer name */
 	ROM_LOAD24_WORD("raiden-f2bg-1d.u0535",   0x000000, 0x400000, CRC(6143f576) SHA1(c034923d0663d9ef24357a03098b8cb81dbab9f8) ) // pads are silkscreened on pcb BG12
 	ROM_LOAD24_BYTE("raiden-f2__bg-1p.u0537", 0x000002, 0x200000, CRC(55e64ef7) SHA1(aae991268948d07342ee8ba1b3761bd180aab8ec) ) // pads are silkscreened on pcb BG12P
 	ROM_LOAD24_WORD("raiden-f2bg-2d.u0536",   0x600000, 0x400000, CRC(c607a444) SHA1(dc1aa96a42e9394ca6036359670a4ec6f830c96d) ) // pads are silkscreened on pcb BG3
 	ROM_LOAD24_BYTE("raiden-f2__bg-2p.u0538", 0x600002, 0x200000, CRC(f0830248) SHA1(6075df96b49e70d2243fef691e096119e7a4d044) ) // pads are silkscreened on pcb BG3P
 
-	ROM_REGION( 0x1200000, "gfx3", 0 ) /* sprites - all are paired MX semconductor MX23C3210TC and MX23C1610TC mask roms */
+	ROM_REGION( 0x1200000, "sprites", 0 ) /* sprites - all are paired MX semconductor MX23C3210TC and MX23C1610TC mask roms */
 	ROM_LOAD("raiden-f2obj-3.u0434", 0x0000000, 0x400000, CRC(e08f42dc) SHA1(5188d71d4355eaf43ea8893b4cfc4fe80cc24f41) ) // pads are silkscreened on pcb OBJ3
 	ROM_LOAD("raiden-f2obj-6.u0433", 0x0400000, 0x200000, CRC(1b6a523c) SHA1(99a420dbc8e22e7832ccda7cec9fa661a2a2687a) ) // pads are silkscreened on pcb OBJ3B
 	ROM_LOAD("raiden-f2obj-2.u0431", 0x0600000, 0x400000, CRC(7aeadd8e) SHA1(47103c0579240c5b1add4d0b164eaf76f5fa97f0) ) // pads are silkscreened on pcb OBJ2
@@ -3638,18 +3555,18 @@ ROM_START( rdft2aa ) /* SPI Cart, Asia (Dream Island license) */
 
 	ROM_REGION( 0x40000, "audiocpu", ROMREGION_ERASE00 ) /* 256K RAM, ROM from Z80 point-of-view */
 
-	ROM_REGION( 0x30000, "gfx1", ROMREGION_ERASEFF ) /* text layer roms */
+	ROM_REGION( 0x30000, "chars", ROMREGION_ERASEFF ) /* text layer roms */
 	ROM_LOAD24_BYTE("rf2_5.bin", 0x000001, 0x10000, CRC(377cac2f) SHA1(f7c9323d79b77f6c8c02ba2c6cdca127d6e5cb5c) )
 	ROM_LOAD24_BYTE("rf2_6.bin", 0x000000, 0x10000, CRC(42bd5372) SHA1(c38df85b25070db9640eac541f71c0511bab0c98) )
 	ROM_LOAD24_BYTE("rf2_7.bin", 0x000002, 0x10000, CRC(1efaac7e) SHA1(8252af56dcb7a6306dc3422070176778e3c511c2) )
 
-	ROM_REGION( 0xc00000, "gfx2", ROMREGION_ERASEFF ) /* background layer roms */
+	ROM_REGION( 0xc00000, "tiles", ROMREGION_ERASEFF ) /* background layer roms */
 	ROM_LOAD24_WORD("bg-1d.u0535", 0x000000, 0x400000, CRC(6143f576) SHA1(c034923d0663d9ef24357a03098b8cb81dbab9f8) )
 	ROM_LOAD24_BYTE("bg-1p.u0537", 0x000002, 0x200000, CRC(55e64ef7) SHA1(aae991268948d07342ee8ba1b3761bd180aab8ec) )
 	ROM_LOAD24_WORD("bg-2d.u0536", 0x600000, 0x400000, CRC(c607a444) SHA1(dc1aa96a42e9394ca6036359670a4ec6f830c96d) )
 	ROM_LOAD24_BYTE("bg-2p.u0538", 0x600002, 0x200000, CRC(f0830248) SHA1(6075df96b49e70d2243fef691e096119e7a4d044) )
 
-	ROM_REGION( 0x1200000, "gfx3", 0 ) /* sprites */
+	ROM_REGION( 0x1200000, "sprites", 0 ) /* sprites */
 	ROM_LOAD("obj3.u0434",  0x0000000, 0x400000, CRC(e08f42dc) SHA1(5188d71d4355eaf43ea8893b4cfc4fe80cc24f41) )
 	ROM_LOAD("obj3b.u0433", 0x0400000, 0x200000, CRC(1b6a523c) SHA1(99a420dbc8e22e7832ccda7cec9fa661a2a2687a) )
 	ROM_LOAD("obj2.u0431",  0x0600000, 0x400000, CRC(7aeadd8e) SHA1(47103c0579240c5b1add4d0b164eaf76f5fa97f0) )
@@ -3675,18 +3592,18 @@ ROM_START( rdft2t ) /* SPI Cart, Taiwan */
 
 	ROM_REGION( 0x40000, "audiocpu", ROMREGION_ERASE00 ) /* 256K RAM, ROM from Z80 point-of-view */
 
-	ROM_REGION( 0x30000, "gfx1", ROMREGION_ERASEFF ) /* text layer roms */
+	ROM_REGION( 0x30000, "chars", ROMREGION_ERASEFF ) /* text layer roms */
 	ROM_LOAD24_BYTE("rf2_5.bin", 0x000001, 0x10000, CRC(377cac2f) SHA1(f7c9323d79b77f6c8c02ba2c6cdca127d6e5cb5c) )
 	ROM_LOAD24_BYTE("rf2_6.bin", 0x000000, 0x10000, CRC(42bd5372) SHA1(c38df85b25070db9640eac541f71c0511bab0c98) )
 	ROM_LOAD24_BYTE("rf2_7.bin", 0x000002, 0x10000, CRC(1efaac7e) SHA1(8252af56dcb7a6306dc3422070176778e3c511c2) )
 
-	ROM_REGION( 0xc00000, "gfx2", ROMREGION_ERASEFF ) /* background layer roms */
+	ROM_REGION( 0xc00000, "tiles", ROMREGION_ERASEFF ) /* background layer roms */
 	ROM_LOAD24_WORD("bg-1d.u0535", 0x000000, 0x400000, CRC(6143f576) SHA1(c034923d0663d9ef24357a03098b8cb81dbab9f8) )
 	ROM_LOAD24_BYTE("bg-1p.u0537", 0x000002, 0x200000, CRC(55e64ef7) SHA1(aae991268948d07342ee8ba1b3761bd180aab8ec) )
 	ROM_LOAD24_WORD("bg-2d.u0536", 0x600000, 0x400000, CRC(c607a444) SHA1(dc1aa96a42e9394ca6036359670a4ec6f830c96d) )
 	ROM_LOAD24_BYTE("bg-2p.u0538", 0x600002, 0x200000, CRC(f0830248) SHA1(6075df96b49e70d2243fef691e096119e7a4d044) )
 
-	ROM_REGION( 0x1200000, "gfx3", 0 ) /* sprites */
+	ROM_REGION( 0x1200000, "sprites", 0 ) /* sprites */
 	ROM_LOAD("obj3.u0434",  0x0000000, 0x400000, CRC(e08f42dc) SHA1(5188d71d4355eaf43ea8893b4cfc4fe80cc24f41) )
 	ROM_LOAD("obj3b.u0433", 0x0400000, 0x200000, CRC(1b6a523c) SHA1(99a420dbc8e22e7832ccda7cec9fa661a2a2687a) )
 	ROM_LOAD("obj2.u0431",  0x0600000, 0x400000, CRC(7aeadd8e) SHA1(47103c0579240c5b1add4d0b164eaf76f5fa97f0) )
@@ -3713,18 +3630,18 @@ ROM_START( rfjet ) /* SPI Cart, Europe */
 
 	ROM_REGION( 0x40000, "audiocpu", ROMREGION_ERASE00 ) /* 256K RAM, ROM from Z80 point-of-view */
 
-	ROM_REGION( 0x30000, "gfx1", ROMREGION_ERASEFF ) /* text layer roms */
+	ROM_REGION( 0x30000, "chars", ROMREGION_ERASEFF ) /* text layer roms */
 	ROM_LOAD24_BYTE("fix0.u0524", 0x000001, 0x10000, CRC(8bc080be) SHA1(ad296fb98242c963072346a8de289e704b445ad4) )
 	ROM_LOAD24_BYTE("fix1.u0518", 0x000000, 0x10000, CRC(bded85e7) SHA1(ccb8c438ce6b9a742e3ab15be970b1e636783626) )
 	ROM_LOAD24_BYTE("fixp.u0514", 0x000002, 0x10000, CRC(015d0748) SHA1(b1e8eaeba63a7914f1dc27d7e3ca5d0b6db202ed) )
 
-	ROM_REGION( 0x900000, "gfx2", ROMREGION_ERASEFF ) /* background layer roms */
+	ROM_REGION( 0x900000, "tiles", ROMREGION_ERASEFF ) /* background layer roms */
 	ROM_LOAD24_WORD("bg-1d.u0543", 0x000000, 0x400000, CRC(edfd96da) SHA1(4813267f104619f569e5777e75b75304321abb49) )
 	ROM_LOAD24_BYTE("bg-1p.u0544", 0x000002, 0x200000, CRC(a4cc4631) SHA1(cc1c4f4de8a078ca774f5a328a9a58291949b1fb) )
 	ROM_LOAD24_WORD("bg-2d.u0545", 0x600000, 0x200000, CRC(731fbb59) SHA1(13cd29ec4d4c73582c5fb363218e737886826e5f) )
 	ROM_LOAD24_BYTE("bg-2p.u0546", 0x600002, 0x100000, CRC(03652c25) SHA1(c0d77285111bc84e008362981ac02a246678ed0a) )
 
-	ROM_REGION( 0x1800000, "gfx3", 0 ) /* sprites */
+	ROM_REGION( 0x1800000, "sprites", 0 ) /* sprites */
 	ROM_LOAD("obj-1.u0442", 0x0000000, 0x800000, CRC(58a59896) SHA1(edeaaa69987bd5d08c47ed9bf47a3901e2dcc892) )
 	ROM_LOAD("obj-2.u0443", 0x0800000, 0x800000, CRC(a121d1e3) SHA1(1851ae81f2ae9d3404aadd9fbc0ed7f9230290b9) )
 	ROM_LOAD("obj-3.u0444", 0x1000000, 0x800000, CRC(bc2c0c63) SHA1(c8d395722f7012c3be366a0fc9b224c537afabae) )
@@ -3747,18 +3664,18 @@ ROM_START( rfjetj ) /* SPI Cart, Japan */
 
 	ROM_REGION( 0x40000, "audiocpu", ROMREGION_ERASE00 ) /* 256K RAM, ROM from Z80 point-of-view */
 
-	ROM_REGION( 0x30000, "gfx1", ROMREGION_ERASEFF ) /* text layer roms */
+	ROM_REGION( 0x30000, "chars", ROMREGION_ERASEFF ) /* text layer roms */
 	ROM_LOAD24_BYTE("fix0.u0524", 0x000001, 0x10000, CRC(8bc080be) SHA1(ad296fb98242c963072346a8de289e704b445ad4) )
 	ROM_LOAD24_BYTE("fix1.u0518", 0x000000, 0x10000, CRC(bded85e7) SHA1(ccb8c438ce6b9a742e3ab15be970b1e636783626) )
 	ROM_LOAD24_BYTE("fixp.u0514", 0x000002, 0x10000, CRC(015d0748) SHA1(b1e8eaeba63a7914f1dc27d7e3ca5d0b6db202ed) )
 
-	ROM_REGION( 0x900000, "gfx2", ROMREGION_ERASEFF ) /* background layer roms */
+	ROM_REGION( 0x900000, "tiles", ROMREGION_ERASEFF ) /* background layer roms */
 	ROM_LOAD24_WORD("bg-1d.u0543", 0x000000, 0x400000, CRC(edfd96da) SHA1(4813267f104619f569e5777e75b75304321abb49) )
 	ROM_LOAD24_BYTE("bg-1p.u0544", 0x000002, 0x200000, CRC(a4cc4631) SHA1(cc1c4f4de8a078ca774f5a328a9a58291949b1fb) )
 	ROM_LOAD24_WORD("bg-2d.u0545", 0x600000, 0x200000, CRC(731fbb59) SHA1(13cd29ec4d4c73582c5fb363218e737886826e5f) )
 	ROM_LOAD24_BYTE("bg-2p.u0546", 0x600002, 0x100000, CRC(03652c25) SHA1(c0d77285111bc84e008362981ac02a246678ed0a) )
 
-	ROM_REGION( 0x1800000, "gfx3", 0 ) /* sprites */
+	ROM_REGION( 0x1800000, "sprites", 0 ) /* sprites */
 	ROM_LOAD("obj-1.u0442", 0x0000000, 0x800000, CRC(58a59896) SHA1(edeaaa69987bd5d08c47ed9bf47a3901e2dcc892) )
 	ROM_LOAD("obj-2.u0443", 0x0800000, 0x800000, CRC(a121d1e3) SHA1(1851ae81f2ae9d3404aadd9fbc0ed7f9230290b9) )
 	ROM_LOAD("obj-3.u0444", 0x1000000, 0x800000, CRC(bc2c0c63) SHA1(c8d395722f7012c3be366a0fc9b224c537afabae) )
@@ -3781,18 +3698,18 @@ ROM_START( rfjetu ) /* SPI Cart, US */
 
 	ROM_REGION( 0x40000, "audiocpu", ROMREGION_ERASE00 ) /* 256K RAM, ROM from Z80 point-of-view */
 
-	ROM_REGION( 0x30000, "gfx1", ROMREGION_ERASEFF ) /* text layer roms */
+	ROM_REGION( 0x30000, "chars", ROMREGION_ERASEFF ) /* text layer roms */
 	ROM_LOAD24_BYTE("fix0.u0524", 0x000001, 0x10000, CRC(8bc080be) SHA1(ad296fb98242c963072346a8de289e704b445ad4) )
 	ROM_LOAD24_BYTE("fix1.u0518", 0x000000, 0x10000, CRC(bded85e7) SHA1(ccb8c438ce6b9a742e3ab15be970b1e636783626) )
 	ROM_LOAD24_BYTE("fixp.u0514", 0x000002, 0x10000, CRC(015d0748) SHA1(b1e8eaeba63a7914f1dc27d7e3ca5d0b6db202ed) )
 
-	ROM_REGION( 0x900000, "gfx2", ROMREGION_ERASEFF ) /* background layer roms */
+	ROM_REGION( 0x900000, "tiles", ROMREGION_ERASEFF ) /* background layer roms */
 	ROM_LOAD24_WORD("bg-1d.u0543", 0x000000, 0x400000, CRC(edfd96da) SHA1(4813267f104619f569e5777e75b75304321abb49) )
 	ROM_LOAD24_BYTE("bg-1p.u0544", 0x000002, 0x200000, CRC(a4cc4631) SHA1(cc1c4f4de8a078ca774f5a328a9a58291949b1fb) )
 	ROM_LOAD24_WORD("bg-2d.u0545", 0x600000, 0x200000, CRC(731fbb59) SHA1(13cd29ec4d4c73582c5fb363218e737886826e5f) )
 	ROM_LOAD24_BYTE("bg-2p.u0546", 0x600002, 0x100000, CRC(03652c25) SHA1(c0d77285111bc84e008362981ac02a246678ed0a) )
 
-	ROM_REGION( 0x1800000, "gfx3", 0 ) /* sprites */
+	ROM_REGION( 0x1800000, "sprites", 0 ) /* sprites */
 	ROM_LOAD("obj-1.u0442", 0x0000000, 0x800000, CRC(58a59896) SHA1(edeaaa69987bd5d08c47ed9bf47a3901e2dcc892) )
 	ROM_LOAD("obj-2.u0443", 0x0800000, 0x800000, CRC(a121d1e3) SHA1(1851ae81f2ae9d3404aadd9fbc0ed7f9230290b9) )
 	ROM_LOAD("obj-3.u0444", 0x1000000, 0x800000, CRC(bc2c0c63) SHA1(c8d395722f7012c3be366a0fc9b224c537afabae) )
@@ -3815,18 +3732,18 @@ ROM_START( rfjeta ) /* SPI Cart, Asia */
 
 	ROM_REGION( 0x40000, "audiocpu", ROMREGION_ERASE00 ) /* 256K RAM, ROM from Z80 point-of-view */
 
-	ROM_REGION( 0x30000, "gfx1", ROMREGION_ERASEFF ) /* text layer roms */
+	ROM_REGION( 0x30000, "chars", ROMREGION_ERASEFF ) /* text layer roms */
 	ROM_LOAD24_BYTE("fix0.u0524", 0x000001, 0x10000, CRC(8bc080be) SHA1(ad296fb98242c963072346a8de289e704b445ad4) )
 	ROM_LOAD24_BYTE("fix1.u0518", 0x000000, 0x10000, CRC(bded85e7) SHA1(ccb8c438ce6b9a742e3ab15be970b1e636783626) )
 	ROM_LOAD24_BYTE("fixp.u0514", 0x000002, 0x10000, CRC(015d0748) SHA1(b1e8eaeba63a7914f1dc27d7e3ca5d0b6db202ed) )
 
-	ROM_REGION( 0x900000, "gfx2", ROMREGION_ERASEFF ) /* background layer roms */
+	ROM_REGION( 0x900000, "tiles", ROMREGION_ERASEFF ) /* background layer roms */
 	ROM_LOAD24_WORD("bg-1d.u0543", 0x000000, 0x400000, CRC(edfd96da) SHA1(4813267f104619f569e5777e75b75304321abb49) )
 	ROM_LOAD24_BYTE("bg-1p.u0544", 0x000002, 0x200000, CRC(a4cc4631) SHA1(cc1c4f4de8a078ca774f5a328a9a58291949b1fb) )
 	ROM_LOAD24_WORD("bg-2d.u0545", 0x600000, 0x200000, CRC(731fbb59) SHA1(13cd29ec4d4c73582c5fb363218e737886826e5f) )
 	ROM_LOAD24_BYTE("bg-2p.u0546", 0x600002, 0x100000, CRC(03652c25) SHA1(c0d77285111bc84e008362981ac02a246678ed0a) )
 
-	ROM_REGION( 0x1800000, "gfx3", 0 ) /* sprites */
+	ROM_REGION( 0x1800000, "sprites", 0 ) /* sprites */
 	ROM_LOAD("obj-1.u0442", 0x0000000, 0x800000, CRC(58a59896) SHA1(edeaaa69987bd5d08c47ed9bf47a3901e2dcc892) )
 	ROM_LOAD("obj-2.u0443", 0x0800000, 0x800000, CRC(a121d1e3) SHA1(1851ae81f2ae9d3404aadd9fbc0ed7f9230290b9) )
 	ROM_LOAD("obj-3.u0444", 0x1000000, 0x800000, CRC(bc2c0c63) SHA1(c8d395722f7012c3be366a0fc9b224c537afabae) )
@@ -3849,18 +3766,18 @@ ROM_START( rfjett ) /* SPI Cart, Taiwan */
 
 	ROM_REGION( 0x40000, "audiocpu", ROMREGION_ERASE00 ) /* 256K RAM, ROM from Z80 point-of-view */
 
-	ROM_REGION( 0x30000, "gfx1", ROMREGION_ERASEFF ) /* text layer roms */
+	ROM_REGION( 0x30000, "chars", ROMREGION_ERASEFF ) /* text layer roms */
 	ROM_LOAD24_BYTE("fix0.u0524", 0x000001, 0x10000, CRC(8bc080be) SHA1(ad296fb98242c963072346a8de289e704b445ad4) )
 	ROM_LOAD24_BYTE("fix1.u0518", 0x000000, 0x10000, CRC(bded85e7) SHA1(ccb8c438ce6b9a742e3ab15be970b1e636783626) )
 	ROM_LOAD24_BYTE("fixp.u0514", 0x000002, 0x10000, CRC(015d0748) SHA1(b1e8eaeba63a7914f1dc27d7e3ca5d0b6db202ed) )
 
-	ROM_REGION( 0x900000, "gfx2", ROMREGION_ERASEFF ) /* background layer roms */
+	ROM_REGION( 0x900000, "tiles", ROMREGION_ERASEFF ) /* background layer roms */
 	ROM_LOAD24_WORD("bg-1d.u0543", 0x000000, 0x400000, CRC(edfd96da) SHA1(4813267f104619f569e5777e75b75304321abb49) )
 	ROM_LOAD24_BYTE("bg-1p.u0544", 0x000002, 0x200000, CRC(a4cc4631) SHA1(cc1c4f4de8a078ca774f5a328a9a58291949b1fb) )
 	ROM_LOAD24_WORD("bg-2d.u0545", 0x600000, 0x200000, CRC(731fbb59) SHA1(13cd29ec4d4c73582c5fb363218e737886826e5f) )
 	ROM_LOAD24_BYTE("bg-2p.u0546", 0x600002, 0x100000, CRC(03652c25) SHA1(c0d77285111bc84e008362981ac02a246678ed0a) )
 
-	ROM_REGION( 0x1800000, "gfx3", 0 ) /* sprites */
+	ROM_REGION( 0x1800000, "sprites", 0 ) /* sprites */
 	ROM_LOAD("obj-1.u0442", 0x0000000, 0x800000, CRC(58a59896) SHA1(edeaaa69987bd5d08c47ed9bf47a3901e2dcc892) )
 	ROM_LOAD("obj-2.u0443", 0x0800000, 0x800000, CRC(a121d1e3) SHA1(1851ae81f2ae9d3404aadd9fbc0ed7f9230290b9) )
 	ROM_LOAD("obj-3.u0444", 0x1000000, 0x800000, CRC(bc2c0c63) SHA1(c8d395722f7012c3be366a0fc9b224c537afabae) )
@@ -3887,17 +3804,17 @@ ROM_START( rdfts ) /* Single board version SXX2E Ver3.0 */
 	ROM_REGION( 0x40000, "audiocpu", 0 ) /* 256K ROM for the Z80 */
 	ROM_LOAD("seibu_zprg.u1139", 0x000000, 0x20000, CRC(c1fda3e8) SHA1(c1d3a7ba0601a80534ec32249de71d33a828a162) ) // pads are silkscreened ZPRG
 
-	ROM_REGION( 0x30000, "gfx1", ROMREGION_ERASEFF ) /* text layer roms */
+	ROM_REGION( 0x30000, "chars", ROMREGION_ERASEFF ) /* text layer roms */
 	ROM_LOAD24_WORD("raiden-f_fix.u0535", 0x000000, 0x20000, CRC(2be2936b) SHA1(9e719f7328a52af220b6f084c1e0990ca6e2d533) ) // socket is silkscreened on pcb FIX01
 	ROM_LOAD24_BYTE("seibu_fix2.u0528",   0x000002, 0x10000, CRC(4d87e1ea) SHA1(3230e9b643fad773e61ab8ce09c0cd7d4d0558e3) ) // socket is silkscreened on pcb FIX2
 
-	ROM_REGION( 0x600000, "gfx2", ROMREGION_ERASEFF ) /* background layer roms */
+	ROM_REGION( 0x600000, "tiles", ROMREGION_ERASEFF ) /* background layer roms */
 	ROM_LOAD24_WORD("gun_dogs_bg1-d.u0526", 0x000000, 0x200000, CRC(6a68054c) SHA1(5cbfc4ac90045f1401c2dda7a51936558c9de07e) ) // pads are silkscreened on pcb BG12
 	ROM_LOAD24_BYTE("gun_dogs_bg1-p.u0531", 0x000002, 0x100000, CRC(3400794a) SHA1(719808f7442bac612cefd7b7fffcd665e6337ad0) ) // pads are silkscreened on pcb BG12P
 	ROM_LOAD24_WORD("gun_dogs_bg2-d.u0534", 0x300000, 0x200000, CRC(61cd2991) SHA1(bb608e3948bf9ea35b5e1615d2ba6858d029dcbe) ) // pads are silkscreened on pcb BG3
 	ROM_LOAD24_BYTE("gun_dogs_bg2-p.u0530", 0x300002, 0x100000, CRC(502d5799) SHA1(c3a0e1a4f5a7b35572ae1ff31315da4ed08aa2fe) ) // pads are silkscreened on pcb BG3P
 
-	ROM_REGION( 0xc00000, "gfx3", 0 ) /* sprites */
+	ROM_REGION( 0xc00000, "sprites", 0 ) /* sprites */
 	ROM_LOAD("gun_dogs_obj-1.u0322", 0x000000, 0x400000, CRC(59d86c99) SHA1(d3c9241e7b51fe21f8351051b063f91dc69bf905) ) // pads are silkscreened on pcb OBJ1
 	ROM_LOAD("gun_dogs_obj-2.u0324", 0x400000, 0x400000, CRC(1ceb0b6f) SHA1(97225a9b3e7be18080aa52f6570af2cce8f25c06) ) // pads are silkscreened on pcb OBJ2
 	ROM_LOAD("gun_dogs_obj-3.u0323", 0x800000, 0x400000, CRC(36e93234) SHA1(51917a80b7da5c32a9434a1076fc2916d62e6a3e) ) // pads are silkscreened on pcb OBJ3
@@ -3918,18 +3835,18 @@ ROM_START( rdft2us ) /* Single board version SXX2F */
 	ROM_REGION( 0x40000, "audiocpu", 0 ) /* 256K ROM for the Z80 */
 	ROM_LOAD("zprg.u091", 0x000000, 0x20000, CRC(cc543c4f) SHA1(6e5c93fd3d21c594571b071d4a830211e1f162b2) )
 
-	ROM_REGION( 0x30000, "gfx1", ROMREGION_ERASEFF ) /* text layer roms */
+	ROM_REGION( 0x30000, "chars", ROMREGION_ERASEFF ) /* text layer roms */
 	ROM_LOAD24_BYTE("fix0.u0524", 0x000001, 0x10000, CRC(6fdf4cf6) SHA1(7e9d4a49e829dfdc373c0f5acfbe8c7a91ac115b) )
 	ROM_LOAD24_BYTE("fix1.u0518", 0x000000, 0x10000, CRC(69b7899b) SHA1(d3cacd4ef4d2c95d803403101beb9d4be75fae61) )
 	ROM_LOAD24_BYTE("fixp.u0514", 0x000002, 0x10000, CRC(99a5fece) SHA1(44ae95d650ed6e00202d3438f5f91a5e52e319cb) )
 
-	ROM_REGION( 0xc00000, "gfx2", ROMREGION_ERASEFF ) /* background layer roms */
+	ROM_REGION( 0xc00000, "tiles", ROMREGION_ERASEFF ) /* background layer roms */
 	ROM_LOAD24_WORD("bg-1d.u0535", 0x000000, 0x400000, CRC(6143f576) SHA1(c034923d0663d9ef24357a03098b8cb81dbab9f8) )
 	ROM_LOAD24_BYTE("bg-1p.u0537", 0x000002, 0x200000, CRC(55e64ef7) SHA1(aae991268948d07342ee8ba1b3761bd180aab8ec) )
 	ROM_LOAD24_WORD("bg-2d.u0536", 0x600000, 0x400000, CRC(c607a444) SHA1(dc1aa96a42e9394ca6036359670a4ec6f830c96d) )
 	ROM_LOAD24_BYTE("bg-2p.u0538", 0x600002, 0x200000, CRC(f0830248) SHA1(6075df96b49e70d2243fef691e096119e7a4d044) )
 
-	ROM_REGION( 0x1200000, "gfx3", 0 ) /* sprites */
+	ROM_REGION( 0x1200000, "sprites", 0 ) /* sprites */
 	ROM_LOAD("obj3.u075",  0x0000000, 0x400000, CRC(e08f42dc) SHA1(5188d71d4355eaf43ea8893b4cfc4fe80cc24f41) )
 	ROM_LOAD("obj3b.u078", 0x0400000, 0x200000, CRC(1b6a523c) SHA1(99a420dbc8e22e7832ccda7cec9fa661a2a2687a) )
 	ROM_LOAD("obj2.u074",  0x0600000, 0x400000, CRC(7aeadd8e) SHA1(47103c0579240c5b1add4d0b164eaf76f5fa97f0) )
@@ -3953,18 +3870,18 @@ ROM_START( rfjets ) /* Single board version SXX2G */
 	ROM_REGION( 0x40000, "audiocpu", 0 ) /* 256K ROM for the Z80 */
 	ROM_LOAD("rfj-05.u091", 0x000000, 0x40000, CRC(a55e8799) SHA1(5d4ca9ae920ab54e23ee3b1b33db72711e744516) ) /* ZPRG */
 
-	ROM_REGION( 0x30000, "gfx1", ROMREGION_ERASEFF ) /* text layer roms */
+	ROM_REGION( 0x30000, "chars", ROMREGION_ERASEFF ) /* text layer roms */
 	ROM_LOAD24_BYTE("rfj-01.u0524", 0x000001, 0x10000, CRC(8bc080be) SHA1(ad296fb98242c963072346a8de289e704b445ad4) ) /* FIX0 */
 	ROM_LOAD24_BYTE("rfj-02.u0518", 0x000000, 0x10000, CRC(bded85e7) SHA1(ccb8c438ce6b9a742e3ab15be970b1e636783626) ) /* FIX1 */
 	ROM_LOAD24_BYTE("rfj-03.u0514", 0x000002, 0x10000, CRC(015d0748) SHA1(b1e8eaeba63a7914f1dc27d7e3ca5d0b6db202ed) ) /* FIXP */
 
-	ROM_REGION( 0x900000, "gfx2", ROMREGION_ERASEFF ) /* background layer roms */
+	ROM_REGION( 0x900000, "tiles", ROMREGION_ERASEFF ) /* background layer roms */
 	ROM_LOAD24_WORD("bg-1d.u0535", 0x000000, 0x400000, CRC(edfd96da) SHA1(4813267f104619f569e5777e75b75304321abb49) )
 	ROM_LOAD24_BYTE("bg-1p.u0537", 0x000002, 0x200000, CRC(a4cc4631) SHA1(cc1c4f4de8a078ca774f5a328a9a58291949b1fb) )
 	ROM_LOAD24_WORD("bg-2d.u0536", 0x600000, 0x200000, CRC(731fbb59) SHA1(13cd29ec4d4c73582c5fb363218e737886826e5f) )
 	ROM_LOAD24_BYTE("bg-2p.u0545", 0x600002, 0x100000, CRC(03652c25) SHA1(c0d77285111bc84e008362981ac02a246678ed0a) )
 
-	ROM_REGION( 0x1800000, "gfx3", 0 ) /* sprites */
+	ROM_REGION( 0x1800000, "sprites", 0 ) /* sprites */
 	ROM_LOAD("obj-1.u073", 0x0000000, 0x800000, CRC(58a59896) SHA1(edeaaa69987bd5d08c47ed9bf47a3901e2dcc892) )
 	ROM_LOAD("obj-2.u074", 0x0800000, 0x800000, CRC(a121d1e3) SHA1(1851ae81f2ae9d3404aadd9fbc0ed7f9230290b9) )
 	ROM_LOAD("obj-3.u075", 0x1000000, 0x800000, CRC(bc2c0c63) SHA1(c8d395722f7012c3be366a0fc9b224c537afabae) )
@@ -3995,18 +3912,18 @@ ROM_START( rfjetsa ) /* Single board version SXX2G */
 	ROM_REGION( 0x40000, "audiocpu", 0 ) /* 256K ROM for the Z80 */
 	ROM_LOAD("rfj-05.u091", 0x000000, 0x40000, CRC(a55e8799) SHA1(5d4ca9ae920ab54e23ee3b1b33db72711e744516) ) /* ZPRG */
 
-	ROM_REGION( 0x30000, "gfx1", ROMREGION_ERASEFF ) /* text layer roms */
+	ROM_REGION( 0x30000, "chars", ROMREGION_ERASEFF ) /* text layer roms */
 	ROM_LOAD24_BYTE("rfj-01.u0524", 0x000001, 0x10000, CRC(8bc080be) SHA1(ad296fb98242c963072346a8de289e704b445ad4) ) /* FIX0 */
 	ROM_LOAD24_BYTE("rfj-02.u0518", 0x000000, 0x10000, CRC(bded85e7) SHA1(ccb8c438ce6b9a742e3ab15be970b1e636783626) ) /* FIX1 */
 	ROM_LOAD24_BYTE("rfj-03.u0514", 0x000002, 0x10000, CRC(015d0748) SHA1(b1e8eaeba63a7914f1dc27d7e3ca5d0b6db202ed) ) /* FIXP */
 
-	ROM_REGION( 0x900000, "gfx2", ROMREGION_ERASEFF ) /* background layer roms */
+	ROM_REGION( 0x900000, "tiles", ROMREGION_ERASEFF ) /* background layer roms */
 	ROM_LOAD24_WORD("bg-1d.u0535", 0x000000, 0x400000, CRC(edfd96da) SHA1(4813267f104619f569e5777e75b75304321abb49) )
 	ROM_LOAD24_BYTE("bg-1p.u0537", 0x000002, 0x200000, CRC(a4cc4631) SHA1(cc1c4f4de8a078ca774f5a328a9a58291949b1fb) )
 	ROM_LOAD24_WORD("bg-2d.u0536", 0x600000, 0x200000, CRC(731fbb59) SHA1(13cd29ec4d4c73582c5fb363218e737886826e5f) )
 	ROM_LOAD24_BYTE("bg-2p.u0545", 0x600002, 0x100000, CRC(03652c25) SHA1(c0d77285111bc84e008362981ac02a246678ed0a) )
 
-	ROM_REGION( 0x1800000, "gfx3", 0 ) /* sprites */
+	ROM_REGION( 0x1800000, "sprites", 0 ) /* sprites */
 	ROM_LOAD("obj-1.u073", 0x0000000, 0x800000, CRC(58a59896) SHA1(edeaaa69987bd5d08c47ed9bf47a3901e2dcc892) )
 	ROM_LOAD("obj-2.u074", 0x0800000, 0x800000, CRC(a121d1e3) SHA1(1851ae81f2ae9d3404aadd9fbc0ed7f9230290b9) )
 	ROM_LOAD("obj-3.u075", 0x1000000, 0x800000, CRC(bc2c0c63) SHA1(c8d395722f7012c3be366a0fc9b224c537afabae) )
@@ -4025,18 +3942,18 @@ ROM_START( rdft22kc ) /* SYS386I */
 	ROM_LOAD32_WORD("prg0-1.267", 0x000000, 0x100000, CRC(0d7d6eb8) SHA1(3a71e1e0ba5bb500dc026debbb6189723c0c2890) )
 	ROM_LOAD32_WORD("prg2-3.266", 0x000002, 0x100000, CRC(ead53e69) SHA1(b0e2e06f403317054ecb48d2747034424245f129) )
 
-	ROM_REGION( 0x30000, "gfx1", ROMREGION_ERASEFF ) /* text layer roms */
+	ROM_REGION( 0x30000, "chars", ROMREGION_ERASEFF ) /* text layer roms */
 	ROM_LOAD24_BYTE("fix0.524", 0x000001, 0x10000, CRC(ed11d043) SHA1(fd3a5a33aa4d795941d64c0d23f9d6f8222843e3) )
 	ROM_LOAD24_BYTE("fix1.518", 0x000000, 0x10000, CRC(7036d70a) SHA1(3535b52c0fa1a1158cacc041f8aba2b9a1b43af5) )
 	ROM_LOAD24_BYTE("fix2.514", 0x000002, 0x10000, CRC(29b465da) SHA1(644454ab5e0dc1028e9512f85adfe5d8adb757de) )
 
-	ROM_REGION( 0xc00000, "gfx2", ROMREGION_ERASEFF ) /* background layer roms */
+	ROM_REGION( 0xc00000, "tiles", ROMREGION_ERASEFF ) /* background layer roms */
 	ROM_LOAD24_WORD("bg-1d.535", 0x000000, 0x400000, CRC(6143f576) SHA1(c034923d0663d9ef24357a03098b8cb81dbab9f8) )
 	ROM_LOAD24_BYTE("bg-1p.544", 0x000002, 0x200000, CRC(55e64ef7) SHA1(aae991268948d07342ee8ba1b3761bd180aab8ec) )
 	ROM_LOAD24_WORD("bg-2d.536", 0x600000, 0x400000, CRC(c607a444) SHA1(dc1aa96a42e9394ca6036359670a4ec6f830c96d) )
 	ROM_LOAD24_BYTE("bg-2p.545", 0x600002, 0x200000, CRC(f0830248) SHA1(6075df96b49e70d2243fef691e096119e7a4d044) )
 
-	ROM_REGION( 0x1200000, "gfx3", 0 ) /* sprites */
+	ROM_REGION( 0x1200000, "sprites", 0 ) /* sprites */
 	ROM_LOAD("obj3.075",  0x0000000, 0x400000, CRC(e08f42dc) SHA1(5188d71d4355eaf43ea8893b4cfc4fe80cc24f41) )
 	ROM_LOAD("obj6.078",  0x0400000, 0x200000, CRC(1b6a523c) SHA1(99a420dbc8e22e7832ccda7cec9fa661a2a2687a) )
 	ROM_LOAD("obj2.074",  0x0600000, 0x400000, CRC(7aeadd8e) SHA1(47103c0579240c5b1add4d0b164eaf76f5fa97f0) )
@@ -4057,18 +3974,18 @@ ROM_START( rfjet2kc ) /* SYS386I */
 	ROM_LOAD32_WORD("prg01.u267", 0x000000, 0x100000, CRC(36019fa8) SHA1(28baf0ed4a53b818c1e6986d5d3491373524eca1) )
 	ROM_LOAD32_WORD("prg23.u266", 0x000002, 0x100000, CRC(65695dde) SHA1(1b25dde03bc9319414144fc13b34c455112f4076) )
 
-	ROM_REGION( 0x30000, "gfx1", ROMREGION_ERASEFF ) /* text layer roms */
+	ROM_REGION( 0x30000, "chars", ROMREGION_ERASEFF ) /* text layer roms */
 	ROM_LOAD24_BYTE("rfj-01.524", 0x000001, 0x10000, CRC(e9d53007) SHA1(29aa7b70d5d5eb5e31426ac84143be44bc0597aa) )
 	ROM_LOAD24_BYTE("rfj-02.518", 0x000000, 0x10000, CRC(dd3eabd3) SHA1(31c8f7a0cd262096a77673b040326605db542ab8) )
 	ROM_LOAD24_BYTE("rfj-03.514", 0x000002, 0x10000, CRC(0daa8aac) SHA1(08a98fb3079ea9f78aa5b950bfeb30b0a805bab7) )
 
-	ROM_REGION( 0xc00000, "gfx2", ROMREGION_ERASEFF ) /* background layer roms */
+	ROM_REGION( 0xc00000, "tiles", ROMREGION_ERASEFF ) /* background layer roms */
 	ROM_LOAD24_WORD("bg-1d.u0535", 0x000000, 0x400000, CRC(edfd96da) SHA1(4813267f104619f569e5777e75b75304321abb49) )
 	ROM_LOAD24_BYTE("bg-1p.u0537", 0x000002, 0x200000, CRC(a4cc4631) SHA1(cc1c4f4de8a078ca774f5a328a9a58291949b1fb) )
 	ROM_LOAD24_WORD("bg-2d.u0536", 0x600000, 0x200000, CRC(731fbb59) SHA1(13cd29ec4d4c73582c5fb363218e737886826e5f) )
 	ROM_LOAD24_BYTE("bg-2p.u0547", 0x600002, 0x100000, CRC(03652c25) SHA1(c0d77285111bc84e008362981ac02a246678ed0a) )
 
-	ROM_REGION( 0x1800000, "gfx3", 0 ) /* sprites */
+	ROM_REGION( 0x1800000, "sprites", 0 ) /* sprites */
 	ROM_LOAD("obj-1.u073",  0x0000000, 0x800000, CRC(58a59896) SHA1(edeaaa69987bd5d08c47ed9bf47a3901e2dcc892) )
 	ROM_LOAD("obj-2.u074",  0x0800000, 0x800000, CRC(a121d1e3) SHA1(1851ae81f2ae9d3404aadd9fbc0ed7f9230290b9) )
 	ROM_LOAD("obj-3.u0749", 0x1000000, 0x800000, CRC(bc2c0c63) SHA1(c8d395722f7012c3be366a0fc9b224c537afabae) )
@@ -4088,11 +4005,7 @@ ROM_START( ejsakura ) /* SYS386F V2.0 */
 	ROM_LOAD32_BYTE("prg2.221",  0x100002, 0x40000, CRC(98a7b615) SHA1(ea34d8f3e9200a6d84efe9168e2f573ec5c2afd2) )
 	ROM_LOAD32_BYTE("prg3.220",  0x100003, 0x40000, CRC(9c3c037a) SHA1(a802e13a0b827896342d9d34dbb00d1c36cabaff) )
 
-	ROM_REGION( 0x30000, "gfx1", ROMREGION_ERASEFF ) /* text layer roms - none! */
-
-	ROM_REGION( 0x900000, "gfx2", ROMREGION_ERASEFF ) /* background layer roms - none! */
-
-	ROM_REGION( 0x1000000, "gfx3", 0 ) /* sprites */
+	ROM_REGION( 0x1000000, "sprites", 0 ) /* sprites */
 	ROM_LOAD16_WORD_SWAP("chr4.445", 0x000000, 0x400000, CRC(40c6c238) SHA1(0d07b59e25632feb070ce0e572ae75f9bb939893) )
 	ROM_LOAD16_WORD_SWAP("chr3.444", 0x400000, 0x400000, CRC(8e5d1de5) SHA1(c1ccb6b4341ee1e939958ec9e68280c6faa2ef1f) )
 	ROM_LOAD16_WORD_SWAP("chr2.443", 0x800000, 0x400000, CRC(638dc9ae) SHA1(0c11b1e688733fbaeabf83b33410714c22ae53cd) )
@@ -4110,11 +4023,7 @@ ROM_START( ejsakura12 ) /* SYS386F V1.2 */
 	ROM_LOAD32_BYTE("prg2v1.2.u0221",  0x100002, 0x40000, CRC(e13098ad) SHA1(abf471afd25a08ba1848964c988112c86d1dcfaa) )
 	ROM_LOAD32_BYTE("prg3v1.2.u0220",  0x100003, 0x40000, CRC(29b5460f) SHA1(c9cb0eb421a79b722bf5a0dc428d0f5f8499e170) )
 
-	ROM_REGION( 0x30000, "gfx1", ROMREGION_ERASEFF ) /* text layer roms - none! */
-
-	ROM_REGION( 0x900000, "gfx2", ROMREGION_ERASEFF ) /* background layer roms - none! */
-
-	ROM_REGION( 0x1000000, "gfx3", 0 ) /* sprites */
+	ROM_REGION( 0x1000000, "sprites", 0 ) /* sprites */
 	ROM_LOAD16_WORD_SWAP("chr4.445", 0x000000, 0x400000, CRC(40c6c238) SHA1(0d07b59e25632feb070ce0e572ae75f9bb939893) )
 	ROM_LOAD16_WORD_SWAP("chr3.444", 0x400000, 0x400000, CRC(8e5d1de5) SHA1(c1ccb6b4341ee1e939958ec9e68280c6faa2ef1f) )
 	ROM_LOAD16_WORD_SWAP("chr2.443", 0x800000, 0x400000, CRC(638dc9ae) SHA1(0c11b1e688733fbaeabf83b33410714c22ae53cd) )

--- a/src/mame/includes/seibuspi.h
+++ b/src/mame/includes/seibuspi.h
@@ -56,12 +56,12 @@ public:
 	IRQ_CALLBACK_MEMBER(spi_irq_callback);
 	INTERRUPT_GEN_MEMBER(spi_interrupt);
 
-	uint32_t screen_update_sys386f(screen_device &screen, bitmap_rgb32 &bitmap, const rectangle &cliprect);
+	u32 screen_update_sys386f(screen_device &screen, bitmap_rgb32 &bitmap, const rectangle &cliprect);
 
 protected:
 	required_device<cpu_device> m_maincpu;
 	optional_device<cpu_device> m_audiocpu;
-	required_shared_ptr<uint32_t> m_mainram;
+	required_shared_ptr<u32> m_mainram;
 	optional_memory_region m_z80_rom;
 	optional_device<eeprom_serial_93cxx_device> m_eeprom;
 	optional_device_array<fifo7200_device, 2> m_soundfifo;
@@ -76,19 +76,19 @@ protected:
 
 	int m_z80_prg_transfer_pos;
 	int m_z80_lastbank;
-	uint8_t m_sb_coin_latch;
-	uint8_t m_ejsakura_input_port;
+	u8 m_sb_coin_latch;
+	u8 m_ejsakura_input_port;
 	tilemap_t *m_text_layer;
 	tilemap_t *m_back_layer;
 	tilemap_t *m_midl_layer;
 	tilemap_t *m_fore_layer;
-	uint32_t m_video_dma_length;
-	uint32_t m_video_dma_address;
-	uint16_t m_layer_enable;
-	uint16_t m_layer_bank;
-	uint8_t m_rf2_layer_bank;
-	uint16_t m_scrollram[6];
-	int m_rowscroll_enable;
+	u32 m_video_dma_length;
+	u32 m_video_dma_address;
+	u16 m_layer_enable;
+	u16 m_layer_bank;
+	u8 m_rf2_layer_bank;
+	u16 m_scrollram[6];
+	bool m_rowscroll_enable;
 	int m_midl_layer_offset;
 	int m_fore_layer_offset;
 	int m_text_layer_offset;
@@ -96,40 +96,40 @@ protected:
 	int m_back_layer_d14;
 	int m_midl_layer_d14;
 	int m_fore_layer_d14;
-	std::unique_ptr<uint32_t[]> m_tilemap_ram;
-	std::unique_ptr<uint32_t[]> m_palette_ram;
-	std::unique_ptr<uint32_t[]> m_sprite_ram;
-	uint32_t m_tilemap_ram_size;
-	uint32_t m_palette_ram_size;
-	uint32_t m_sprite_ram_size;
-	uint32_t m_bg_fore_layer_position;
-	uint8_t m_alpha_table[0x2000];
+	std::unique_ptr<u32[]> m_tilemap_ram;
+	std::unique_ptr<u32[]> m_palette_ram;
+	std::unique_ptr<u32[]> m_sprite_ram;
+	u32 m_tilemap_ram_size;
+	u32 m_palette_ram_size;
+	u32 m_sprite_ram_size;
+	u32 m_bg_fore_layer_position;
+	u8 m_alpha_table[0x2000];
 	int m_sprite_bpp;
 
-	DECLARE_WRITE16_MEMBER(tile_decrypt_key_w);
-	DECLARE_WRITE16_MEMBER(spi_layer_bank_w);
-	DECLARE_WRITE16_MEMBER(spi_layer_enable_w);
-	DECLARE_WRITE8_MEMBER(rf2_layer_bank_w);
-	DECLARE_WRITE16_MEMBER(scroll_w);
-	DECLARE_WRITE32_MEMBER(tilemap_dma_start_w);
-	DECLARE_WRITE32_MEMBER(palette_dma_start_w);
-	DECLARE_WRITE16_MEMBER(sprite_dma_start_w);
-	DECLARE_WRITE32_MEMBER(video_dma_length_w);
-	DECLARE_WRITE32_MEMBER(video_dma_address_w);
-	DECLARE_READ8_MEMBER(spi_status_r);
-	DECLARE_READ8_MEMBER(spi_ds2404_unknown_r);
-	DECLARE_READ8_MEMBER(sb_coin_r);
-	DECLARE_WRITE8_MEMBER(spi_coin_w);
-	DECLARE_READ8_MEMBER(sound_fifo_status_r);
-	DECLARE_WRITE8_MEMBER(z80_prg_transfer_w);
-	DECLARE_WRITE8_MEMBER(z80_enable_w);
-	DECLARE_READ8_MEMBER(z80_soundfifo_status_r);
-	DECLARE_WRITE8_MEMBER(z80_bank_w);
-	DECLARE_READ32_MEMBER(ejsakura_keyboard_r);
-	DECLARE_WRITE32_MEMBER(ejsakura_input_select_w);
-	DECLARE_WRITE8_MEMBER(eeprom_w);
-	DECLARE_WRITE8_MEMBER(spi_layerbanks_eeprom_w);
-	DECLARE_WRITE8_MEMBER(oki_bank_w);
+	void tile_decrypt_key_w(u16 data);
+	void spi_layer_bank_w(offs_t offset, u16 data, u16 mem_mask = ~0);
+	void spi_layer_enable_w(offs_t offset, u16 data, u16 mem_mask = ~0);
+	void rf2_layer_bank_w(u8 data);
+	void scroll_w(offs_t offset, u16 data, u16 mem_mask = ~0);
+	void tilemap_dma_start_w(u32 data);
+	void palette_dma_start_w(u32 data);
+	void sprite_dma_start_w(u16 data);
+	void video_dma_length_w(offs_t offset, u32 data, u32 mem_mask = ~0);
+	void video_dma_address_w(offs_t offset, u32 data, u32 mem_mask = ~0);
+	u8 spi_status_r();
+	u8 spi_ds2404_unknown_r();
+	u8 sb_coin_r();
+	void spi_coin_w(u8 data);
+	u8 sound_fifo_status_r();
+	void z80_prg_transfer_w(u8 data);
+	void z80_enable_w(u8 data);
+	u8 z80_soundfifo_status_r();
+	void z80_bank_w(u8 data);
+	u32 ejsakura_keyboard_r();
+	void ejsakura_input_select_w(u32 data);
+	void eeprom_w(u8 data);
+	void spi_layerbanks_eeprom_w(u8 data);
+	void oki_bank_w(u8 data);
 
 	DECLARE_READ32_MEMBER(senkyu_speedup_r);
 	DECLARE_READ32_MEMBER(senkyua_speedup_r);
@@ -143,9 +143,9 @@ protected:
 	DECLARE_WRITE_LINE_MEMBER(ymf_irqhandler);
 
 	void set_layer_offsets();
-	void drawgfx_blend(bitmap_rgb32 &bitmap, const rectangle &cliprect, gfx_element *gfx, uint32_t code, uint32_t color, int flipx, int flipy, int sx, int sy, bitmap_ind8 &primap, int primask);
+	void drawgfx_blend(bitmap_rgb32 &bitmap, const rectangle &cliprect, gfx_element *gfx, u32 code, u32 color, bool flipx, bool flipy, int sx, int sy, bitmap_ind8 &primap, u8 primask);
 	void draw_sprites(bitmap_rgb32 &bitmap, const rectangle &cliprect, bitmap_ind8 &primap, int priority);
-	void combine_tilemap(bitmap_rgb32 &bitmap, const rectangle &cliprect, tilemap_t *tile, int sx, int sy, int opaque, int16_t *rowscroll);
+	void combine_tilemap(bitmap_rgb32 &bitmap, const rectangle &cliprect, tilemap_t *tile, int sx, int sy, int opaque, s16 *rowscroll);
 
 	virtual void machine_start() override;
 	virtual void video_start() override;
@@ -157,19 +157,19 @@ protected:
 	TILE_GET_INFO_MEMBER(get_back_tile_info);
 	TILE_GET_INFO_MEMBER(get_midl_tile_info);
 	TILE_GET_INFO_MEMBER(get_fore_tile_info);
-	uint32_t screen_update_spi(screen_device &screen, bitmap_rgb32 &bitmap, const rectangle &cliprect);
+	u32 screen_update_spi(screen_device &screen, bitmap_rgb32 &bitmap, const rectangle &cliprect);
 
 	void register_video_state();
 	void init_spi_common();
 
-	void text_decrypt(uint8_t *rom);
-	void bg_decrypt(uint8_t *rom, int size);
+	void text_decrypt(u8 *rom);
+	void bg_decrypt(u8 *rom, int size);
 
-	void rdft2_text_decrypt(uint8_t *rom);
-	void rdft2_bg_decrypt(uint8_t *rom, int size);
+	void rdft2_text_decrypt(u8 *rom);
+	void rdft2_bg_decrypt(u8 *rom, int size);
 
-	void rfjet_text_decrypt(uint8_t *rom);
-	void rfjet_bg_decrypt(uint8_t *rom, int size);
+	void rfjet_text_decrypt(u8 *rom);
+	void rfjet_bg_decrypt(u8 *rom, int size);
 
 	void base_map(address_map &map);
 	void rdft2_map(address_map &map);

--- a/src/mame/machine/seibuspi.cpp
+++ b/src/mame/machine/seibuspi.cpp
@@ -6,13 +6,11 @@
 
 // add two numbers generating carry from one bit to the next only if
 // the corresponding bit in carry_mask is 1
-static uint32_t partial_carry_sum(uint32_t add1,uint32_t add2,uint32_t carry_mask,int bits)
+static u32 partial_carry_sum(u32 add1,u32 add2,u32 carry_mask,int bits)
 {
-	int i,res,carry;
-
-	res = 0;
-	carry = 0;
-	for (i = 0;i < bits;i++)
+	int res = 0;
+	int carry = 0;
+	for (int i = 0; i < bits; i++)
 	{
 		int bit = BIT(add1,i) + BIT(add2,i) + carry;
 
@@ -32,17 +30,17 @@ static uint32_t partial_carry_sum(uint32_t add1,uint32_t add2,uint32_t carry_mas
 	return res;
 }
 
-uint32_t partial_carry_sum32(uint32_t add1,uint32_t add2,uint32_t carry_mask)
+u32 partial_carry_sum32(u32 add1,u32 add2,u32 carry_mask)
 {
 	return partial_carry_sum(add1,add2,carry_mask,32);
 }
 
-uint32_t partial_carry_sum24(uint32_t add1,uint32_t add2,uint32_t carry_mask)
+u32 partial_carry_sum24(u32 add1,u32 add2,u32 carry_mask)
 {
 	return partial_carry_sum(add1,add2,carry_mask,24);
 }
 
-static uint32_t partial_carry_sum16(uint32_t add1,uint32_t add2,uint32_t carry_mask)
+static u32 partial_carry_sum16(u32 add1,u32 add2,u32 carry_mask)
 {
 	return partial_carry_sum(add1,add2,carry_mask,16);
 }
@@ -70,7 +68,7 @@ Bits 0-3 select the permutation on 16 bits of the source data.
 Bits 4-14 are added to the source data, with partial carry.
 Bit 15 is still unknown.
 */
-static const uint16_t key_table[256]=
+static const u16 key_table[256]=
 {
 	0x3ad7,0x54b1,0x2d41,0x8ca0,0xa69b,0x9018,0x9db9,0x6559,
 	0xe9a7,0xb087,0x8a5e,0x821c,0xaafc,0x2ae7,0x557b,0xcd80,
@@ -121,7 +119,7 @@ static const uint16_t key_table[256]=
 #endif
 
 
-static const uint8_t spi_bitswap[16][16] =
+static const u8 spi_bitswap[16][16] =
 {
 	{ 15,14,13,12,11,10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0, },
 	{  7, 6, 5,14, 0,15, 4, 3, 2, 8, 9,10,11,12,13, 1, },
@@ -144,161 +142,152 @@ static const uint8_t spi_bitswap[16][16] =
 
 static int key(int table,int addr)
 {
-	int xorbit = 8 + ((table & 0xc) >> 2);
+	const int xorbit = 8 + ((table & 0xc) >> 2);
 	return BIT(key_table[addr & 0xff] >> 4,table) ^ BIT(addr,xorbit);
 }
 
 
-void seibuspi_sprite_decrypt(uint8_t *src, int rom_size)
+void seibuspi_sprite_decrypt(u8 *src, int rom_size)
 {
-	int i;
-
-
-	for(i = 0; i < rom_size/2; i++)
+	for (int i = 0; i < rom_size/2; i++)
 	{
-		int j;
-		int addr = i>>8;
-		int y1,y2,y3;
-		int s1,s2;
-		int add1,add2;
-		int plane0,plane1,plane2,plane3,plane4,plane5;
-		const uint8_t *bs;
+		const int addr = i >> 8;
 
-		y1 = src[2*i+0*rom_size+0] + (src[2*i+0*rom_size+1] << 8);
-		y2 = src[2*i+1*rom_size+0] + (src[2*i+1*rom_size+1] << 8);
-		y3 = src[2*i+2*rom_size+0] + (src[2*i+2*rom_size+1] << 8);
+		const u16 y1 = src[2 * i + 0 * rom_size + 0] + (src[2 * i + 0 * rom_size + 1] << 8);
+		const u16 y2 = src[2 * i + 1 * rom_size + 0] + (src[2 * i + 1 * rom_size + 1] << 8);
+		u16 y3       = src[2 * i + 2 * rom_size + 0] + (src[2 * i + 2 * rom_size + 1] << 8);
 
 
 		/* first of all, permutate 16 of the 48 bits */
-		bs = spi_bitswap[key_table[addr & 0xff]&0xf];
+		const u8 *bs = spi_bitswap[key_table[addr & 0xff] & 0xf];
 		y3 = bitswap<16>(y3, bs[0],bs[1],bs[2],bs[3],bs[4],bs[5],bs[6],bs[7],
 							bs[8],bs[9],bs[10],bs[11],bs[12],bs[13],bs[14],bs[15]);
 
 
 		// planes 4 & 5, interleaved
-		s1 =    (BIT(y1, 4) <<  0) |
-				(BIT(y3, 7) <<  1) |
-				(BIT(y3, 6) <<  2) |
-				(BIT(y2,12) <<  3) |
-				(BIT(y2, 3) <<  4) |
-				(BIT(y1,10) <<  5) |
-				(BIT(y1, 1) <<  6) |
-				(BIT(y3,14) <<  7) |
-				(BIT(y3, 2) <<  8) |
-				(BIT(y2, 9) <<  9) |
-				(BIT(y2, 0) << 10) |
-				(BIT(y1, 7) << 11) |
-				(BIT(y3,12) << 12) |
-				(BIT(y2,15) << 13) |
-				(BIT(y2, 6) << 14) |
-				(BIT(y1,13) << 15);
+		u32 s1 = (BIT(y1, 4) <<  0) |
+				 (BIT(y3, 7) <<  1) |
+				 (BIT(y3, 6) <<  2) |
+				 (BIT(y2,12) <<  3) |
+				 (BIT(y2, 3) <<  4) |
+				 (BIT(y1,10) <<  5) |
+				 (BIT(y1, 1) <<  6) |
+				 (BIT(y3,14) <<  7) |
+				 (BIT(y3, 2) <<  8) |
+				 (BIT(y2, 9) <<  9) |
+				 (BIT(y2, 0) << 10) |
+				 (BIT(y1, 7) << 11) |
+				 (BIT(y3,12) << 12) |
+				 (BIT(y2,15) << 13) |
+				 (BIT(y2, 6) << 14) |
+				 (BIT(y1,13) << 15);
 
-		add1 =  (BIT(addr,11) <<  0) |
-				(BIT(addr,10) <<  1) |
-				(key(10,addr) <<  2) |
-				(key( 5,addr) <<  3) |
-				(key( 4,addr) <<  4) |
-				(BIT(addr,11) <<  5) |
-				(BIT(addr,11) <<  6) |
-				(key( 7,addr) <<  7) |
-				(key( 6,addr) <<  8) |
-				(key( 1,addr) <<  9) |
-				(key( 0,addr) << 10) |
-				(BIT(addr,11) << 11) |
-				(key( 9,addr) << 12) |
-				(key( 8,addr) << 13) |
-				(key( 3,addr) << 14) |
-				(key( 2,addr) << 15);
+		u32 add1 = (BIT(addr,11) <<  0) |
+				   (BIT(addr,10) <<  1) |
+				   (key(10,addr) <<  2) |
+				   (key( 5,addr) <<  3) |
+				   (key( 4,addr) <<  4) |
+				   (BIT(addr,11) <<  5) |
+				   (BIT(addr,11) <<  6) |
+				   (key( 7,addr) <<  7) |
+				   (key( 6,addr) <<  8) |
+				   (key( 1,addr) <<  9) |
+				   (key( 0,addr) << 10) |
+				   (BIT(addr,11) << 11) |
+				   (key( 9,addr) << 12) |
+				   (key( 8,addr) << 13) |
+				   (key( 3,addr) << 14) |
+				   (key( 2,addr) << 15);
 
 		// planes 0-3, interleaved
-		s2 =    (BIT(y1, 5) <<  0) |
-				(BIT(y3, 0) <<  1) |
-				(BIT(y3, 5) <<  2) |
-				(BIT(y2,13) <<  3) |
-				(BIT(y2, 4) <<  4) |
-				(BIT(y1,11) <<  5) |
-				(BIT(y1, 2) <<  6) |
-				(BIT(y3, 9) <<  7) |
-				(BIT(y3, 3) <<  8) |
-				(BIT(y2, 8) <<  9) |
-				(BIT(y1,15) << 10) |
-				(BIT(y1, 6) << 11) |
-				(BIT(y3,11) << 12) |
-				(BIT(y2,14) << 13) |
-				(BIT(y2, 5) << 14) |
-				(BIT(y1,12) << 15) |
-				(BIT(y1, 3) << 16) |
-				(BIT(y3, 8) << 17) |
-				(BIT(y3,15) << 18) |
-				(BIT(y2,11) << 19) |
-				(BIT(y2, 2) << 20) |
-				(BIT(y1, 9) << 21) |
-				(BIT(y1, 0) << 22) |
-				(BIT(y3,10) << 23) |
-				(BIT(y3, 1) << 24) |
-				(BIT(y2,10) << 25) |
-				(BIT(y2, 1) << 26) |
-				(BIT(y1, 8) << 27) |
-				(BIT(y3,13) << 28) |
-				(BIT(y3, 4) << 29) |
-				(BIT(y2, 7) << 30) |
-				(BIT(y1,14) << 31);
+		u32 s2 = (BIT(y1, 5) <<  0) |
+				 (BIT(y3, 0) <<  1) |
+				 (BIT(y3, 5) <<  2) |
+				 (BIT(y2,13) <<  3) |
+				 (BIT(y2, 4) <<  4) |
+				 (BIT(y1,11) <<  5) |
+				 (BIT(y1, 2) <<  6) |
+				 (BIT(y3, 9) <<  7) |
+				 (BIT(y3, 3) <<  8) |
+				 (BIT(y2, 8) <<  9) |
+				 (BIT(y1,15) << 10) |
+				 (BIT(y1, 6) << 11) |
+				 (BIT(y3,11) << 12) |
+				 (BIT(y2,14) << 13) |
+				 (BIT(y2, 5) << 14) |
+				 (BIT(y1,12) << 15) |
+				 (BIT(y1, 3) << 16) |
+				 (BIT(y3, 8) << 17) |
+				 (BIT(y3,15) << 18) |
+				 (BIT(y2,11) << 19) |
+				 (BIT(y2, 2) << 20) |
+				 (BIT(y1, 9) << 21) |
+				 (BIT(y1, 0) << 22) |
+				 (BIT(y3,10) << 23) |
+				 (BIT(y3, 1) << 24) |
+				 (BIT(y2,10) << 25) |
+				 (BIT(y2, 1) << 26) |
+				 (BIT(y1, 8) << 27) |
+				 (BIT(y3,13) << 28) |
+				 (BIT(y3, 4) << 29) |
+				 (BIT(y2, 7) << 30) |
+				 (BIT(y1,14) << 31);
 
-		add2 =  (key( 0,addr) <<  0) |
-				(key( 1,addr) <<  1) |
-				(key( 2,addr) <<  2) |
-				(key( 3,addr) <<  3) |
-				(key( 4,addr) <<  4) |
-				(key( 5,addr) <<  5) |
-				(key( 6,addr) <<  6) |
-				(key( 7,addr) <<  7) |
-				(key( 8,addr) <<  8) |
-				(key( 9,addr) <<  9) |
-				(key(10,addr) << 10) |
-				(BIT(addr,10) << 11) |
-				(BIT(addr,11) << 12) |
-				(BIT(addr,11) << 13) |
-				(BIT(addr,11) << 14) |
-				(BIT(addr,11) << 15) |
-				(BIT(addr,11) << 16) |
-				(key( 7,addr) << 17) |
-				(BIT(addr,11) << 18) |
-				(key( 6,addr) << 19) |
-				(BIT(addr,11) << 20) |
-				(key( 5,addr) << 21) |
-				(BIT(addr,11) << 22) |
-				(key( 4,addr) << 23) |
-				(BIT(addr,10) << 24) |
-				(key( 3,addr) << 25) |
-				(key(10,addr) << 26) |
-				(key( 2,addr) << 27) |
-				(key( 9,addr) << 28) |
-				(key( 1,addr) << 29) |
-				(key( 8,addr) << 30) |
-				(key( 0,addr) << 31);
+		u32 add2 = (key( 0,addr) <<  0) |
+				   (key( 1,addr) <<  1) |
+				   (key( 2,addr) <<  2) |
+				   (key( 3,addr) <<  3) |
+				   (key( 4,addr) <<  4) |
+				   (key( 5,addr) <<  5) |
+				   (key( 6,addr) <<  6) |
+				   (key( 7,addr) <<  7) |
+				   (key( 8,addr) <<  8) |
+				   (key( 9,addr) <<  9) |
+				   (key(10,addr) << 10) |
+				   (BIT(addr,10) << 11) |
+				   (BIT(addr,11) << 12) |
+				   (BIT(addr,11) << 13) |
+				   (BIT(addr,11) << 14) |
+				   (BIT(addr,11) << 15) |
+				   (BIT(addr,11) << 16) |
+				   (key( 7,addr) << 17) |
+				   (BIT(addr,11) << 18) |
+				   (key( 6,addr) << 19) |
+				   (BIT(addr,11) << 20) |
+				   (key( 5,addr) << 21) |
+				   (BIT(addr,11) << 22) |
+				   (key( 4,addr) << 23) |
+				   (BIT(addr,10) << 24) |
+				   (key( 3,addr) << 25) |
+				   (key(10,addr) << 26) |
+				   (key( 2,addr) << 27) |
+				   (key( 9,addr) << 28) |
+				   (key( 1,addr) << 29) |
+				   (key( 8,addr) << 30) |
+				   (key( 0,addr) << 31);
 
 		s1 = partial_carry_sum( s1, add1, 0x3a59, 16 ) ^ 0x843a;
 		s2 = partial_carry_sum( s2, add2, 0x28d49cac, 32 ) ^ 0xc8e29f84;
 
 
 		// reorder the bits in the order MAME expects to decode the graphics
-		plane0 = plane1 = plane2 = plane3 = plane4 = plane5 = 0;
-		for (j = 0;j < 8;j++)
+		u8 plane0 = 0, plane1 = 0, plane2 = 0, plane3 = 0, plane4 = 0, plane5 = 0;
+		for (int j = 0; j < 8; j++)
 		{
-			plane5 |= (BIT(s1, 2*j+1) << j);
-			plane4 |= (BIT(s1, 2*j+0) << j);
-			plane3 |= (BIT(s2, 4*j+3) << j);
-			plane2 |= (BIT(s2, 4*j+2) << j);
-			plane1 |= (BIT(s2, 4*j+1) << j);
-			plane0 |= (BIT(s2, 4*j+0) << j);
+			plane5 |= (BIT(s1, 2 * j + 1) << j);
+			plane4 |= (BIT(s1, 2 * j + 0) << j);
+			plane3 |= (BIT(s2, 4 * j + 3) << j);
+			plane2 |= (BIT(s2, 4 * j + 2) << j);
+			plane1 |= (BIT(s2, 4 * j + 1) << j);
+			plane0 |= (BIT(s2, 4 * j + 0) << j);
 		}
 
-		src[2*i+0*rom_size+0] = plane5;
-		src[2*i+0*rom_size+1] = plane4;
-		src[2*i+1*rom_size+0] = plane3;
-		src[2*i+1*rom_size+1] = plane2;
-		src[2*i+2*rom_size+0] = plane1;
-		src[2*i+2*rom_size+1] = plane0;
+		src[2 * i + 0 * rom_size + 0] = plane5;
+		src[2 * i + 0 * rom_size + 1] = plane4;
+		src[2 * i + 1 * rom_size + 0] = plane3;
+		src[2 * i + 1 * rom_size + 1] = plane2;
+		src[2 * i + 2 * rom_size + 0] = plane1;
+		src[2 * i + 2 * rom_size + 1] = plane0;
 	}
 }
 
@@ -328,30 +317,26 @@ CPU 'main' (PC=002A0709): unmapped program memory dword write to 0000054C = 0000
 
 ******************************************************************************************/
 
-static void sprite_reorder(uint8_t *buffer)
+static void sprite_reorder(u8 *buffer)
 {
-	int j;
-	uint8_t temp[64];
-	for( j=0; j < 16; j++ ) {
-		temp[2*(j*2)+0] = buffer[2*j+0];
-		temp[2*(j*2)+1] = buffer[2*j+1];
-		temp[2*(j*2)+2] = buffer[2*j+32];
-		temp[2*(j*2)+3] = buffer[2*j+33];
+	u8 temp[64];
+	for (int j = 0; j < 16; j++)
+	{
+		temp[2 * (j * 2) + 0] = buffer[2 * j + 0];
+		temp[2 * (j * 2) + 1] = buffer[2 * j + 1];
+		temp[2 * (j * 2) + 2] = buffer[2 * j + 32];
+		temp[2 * (j * 2) + 3] = buffer[2 * j + 33];
 	}
 	memcpy(buffer, temp, 64);
 }
 
-void seibuspi_rise10_sprite_decrypt(uint8_t *rom, int size)
+void seibuspi_rise10_sprite_decrypt(u8 *rom, int size)
 {
-	int i;
-
-	for (i = 0; i < size/2; i++)
+	for (int i = 0; i < size / 2; i++)
 	{
-		uint32_t plane54,plane3210;
-
-		plane54 = rom[0*size+2*i] + (rom[0*size+2*i+1] << 8);
-		plane3210 = bitswap<32>(
-				rom[2*size+2*i] + (rom[2*size+2*i+1] << 8) + (rom[1*size+2*i] << 16) + (rom[1*size+2*i+1] << 24),
+		u32 plane54 = rom[0 * size + 2 * i] + (rom[0 * size + 2 * i + 1] << 8);
+		u32 plane3210 = bitswap<32>(
+				rom[2 * size + 2 * i] + (rom[2 * size + 2 * i + 1] << 8) + (rom[1 * size + 2 * i] << 16) + (rom[1 * size + 2 * i + 1] << 24),
 				23,13,24,4,16,12,25,30,
 				3,5,29,17,14,22,2,11,
 				27,6,15,21,1,28,10,20,
@@ -360,19 +345,19 @@ void seibuspi_rise10_sprite_decrypt(uint8_t *rom, int size)
 		plane54   = partial_carry_sum16( plane54, 0xabcb, 0x55aa ) ^ 0x6699;
 		plane3210 = partial_carry_sum32( plane3210, 0x654321d9 ^ 0x42, 0x1d463748 ) ^ 0x0ca352a9;
 
-		rom[0*size+2*i]   = plane54   >>  8;
-		rom[0*size+2*i+1] = plane54   >>  0;
-		rom[1*size+2*i]   = plane3210 >> 24;
-		rom[1*size+2*i+1] = plane3210 >> 16;
-		rom[2*size+2*i]   = plane3210 >>  8;
-		rom[2*size+2*i+1] = plane3210 >>  0;
+		rom[0 * size + 2 * i]     = plane54   >>  8;
+		rom[0 * size + 2 * i + 1] = plane54   >>  0;
+		rom[1 * size + 2 * i]     = plane3210 >> 24;
+		rom[1 * size + 2 * i + 1] = plane3210 >> 16;
+		rom[2 * size + 2 * i]     = plane3210 >>  8;
+		rom[2 * size + 2 * i + 1] = plane3210 >>  0;
 	}
 
-	for (i = 0; i < size/2; i += 32)
+	for (int i = 0; i < size / 2; i += 32)
 	{
-		sprite_reorder(&rom[0*size+2*i]);
-		sprite_reorder(&rom[1*size+2*i]);
-		sprite_reorder(&rom[2*size+2*i]);
+		sprite_reorder(&rom[0 * size + 2 * i]);
+		sprite_reorder(&rom[1 * size + 2 * i]);
+		sprite_reorder(&rom[2 * size + 2 * i]);
 	}
 }
 
@@ -424,99 +409,94 @@ CPU 'main' (PC=00021C74): unmapped program memory dword write to 0601004C = 0300
 ******************************************************************************************/
 
 
-static void seibuspi_rise11_sprite_decrypt(uint8_t *rom, int size,
-	uint32_t k1, uint32_t k2, uint32_t k3, uint32_t k4, uint32_t k5, int feversoc_kludge)
+static void seibuspi_rise11_sprite_decrypt(u8 *rom, int size,
+	u32 k1, u32 k2, u32 k3, u32 k4, u32 k5, int feversoc_kludge)
 {
-	int i;
-
-	for (i = 0; i < size/2; i++)
+	for (int i = 0; i < size/2; i++)
 	{
-		uint16_t b1,b2,b3;
-		uint32_t plane543,plane210;
+		const u16 b1 = rom[0 * size + 2 * i] + (rom[0 * size + 2 * i + 1] << 8);
+		const u16 b2 = rom[1 * size + 2 * i] + (rom[1 * size + 2 * i + 1] << 8);
+		const u16 b3 = rom[2 * size + 2 * i] + (rom[2 * size + 2 * i + 1] << 8);
 
-		b1 = rom[0*size+2*i] + (rom[0*size+2*i+1] << 8);
-		b2 = rom[1*size+2*i] + (rom[1*size+2*i+1] << 8);
-		b3 = rom[2*size+2*i] + (rom[2*size+2*i+1] << 8);
+		u32 plane543 = (BIT(b2,11)<< 0) |
+					   (BIT(b1, 6)<< 1) |
+					   (BIT(b3,12)<< 2) |
+					   (BIT(b3, 3)<< 3) |
+					   (BIT(b2,12)<< 4) |
+					   (BIT(b3,14)<< 5) |
+					   (BIT(b3, 4)<< 6) |
+					   (BIT(b1,11)<< 7) |
+					   (BIT(b1,12)<< 8) |
+					   (BIT(b1, 2)<< 9) |
+					   (BIT(b2, 5)<<10) |
+					   (BIT(b1, 9)<<11) |
+					   (BIT(b3, 1)<<12) |
+					   (BIT(b2, 2)<<13) |
+					   (BIT(b2,10)<<14) |
+					   (BIT(b3, 5)<<15) |
+					   (BIT(b1, 3)<<16) |
+					   (BIT(b2, 7)<<17) |
+					   (BIT(b1,15)<<18) |
+					   (BIT(b3, 9)<<19) |
+					   (BIT(b2,13)<<20) |
+					   (BIT(b1, 4)<<21) |
+					   (BIT(b3, 2)<<22) |
+					   (BIT(b2, 0)<<23);
 
-		plane543 =  (BIT(b2,11)<< 0) |
-					(BIT(b1, 6)<< 1) |
-					(BIT(b3,12)<< 2) |
-					(BIT(b3, 3)<< 3) |
-					(BIT(b2,12)<< 4) |
-					(BIT(b3,14)<< 5) |
-					(BIT(b3, 4)<< 6) |
-					(BIT(b1,11)<< 7) |
-					(BIT(b1,12)<< 8) |
-					(BIT(b1, 2)<< 9) |
-					(BIT(b2, 5)<<10) |
-					(BIT(b1, 9)<<11) |
-					(BIT(b3, 1)<<12) |
-					(BIT(b2, 2)<<13) |
-					(BIT(b2,10)<<14) |
-					(BIT(b3, 5)<<15) |
-					(BIT(b1, 3)<<16) |
-					(BIT(b2, 7)<<17) |
-					(BIT(b1,15)<<18) |
-					(BIT(b3, 9)<<19) |
-					(BIT(b2,13)<<20) |
-					(BIT(b1, 4)<<21) |
-					(BIT(b3, 2)<<22) |
-					(BIT(b2, 0)<<23);
-
-		plane210 =  (BIT(b1,14)<< 0) |
-					(BIT(b1, 1)<< 1) |
-					(BIT(b1,13)<< 2) |
-					(BIT(b3, 0)<< 3) |
-					(BIT(b1, 7)<< 4) |
-					(BIT(b2,14)<< 5) |
-					(BIT(b2, 4)<< 6) |
-					(BIT(b2, 9)<< 7) |
-					(BIT(b3, 8)<< 8) |
-					(BIT(b2, 1)<< 9) |
-					(BIT(b3, 7)<<10) |
-					(BIT(b2, 6)<<11) |
-					(BIT(b1, 0)<<12) |
-					(BIT(b3,11)<<13) |
-					(BIT(b2, 8)<<14) |
-					(BIT(b3,13)<<15) |
-					(BIT(b1, 8)<<16) |
-					(BIT(b3,10)<<17) |
-					(BIT(b3, 6)<<18) |
-					(BIT(b1,10)<<19) |
-					(BIT(b2,15)<<20) |
-					(BIT(b2, 3)<<21) |
-					(BIT(b1, 5)<<22) |
-					(BIT(b3,15)<<23);
+		u32 plane210 = (BIT(b1,14)<< 0) |
+					   (BIT(b1, 1)<< 1) |
+					   (BIT(b1,13)<< 2) |
+					   (BIT(b3, 0)<< 3) |
+					   (BIT(b1, 7)<< 4) |
+					   (BIT(b2,14)<< 5) |
+					   (BIT(b2, 4)<< 6) |
+					   (BIT(b2, 9)<< 7) |
+					   (BIT(b3, 8)<< 8) |
+					   (BIT(b2, 1)<< 9) |
+					   (BIT(b3, 7)<<10) |
+					   (BIT(b2, 6)<<11) |
+					   (BIT(b1, 0)<<12) |
+					   (BIT(b3,11)<<13) |
+					   (BIT(b2, 8)<<14) |
+					   (BIT(b3,13)<<15) |
+					   (BIT(b1, 8)<<16) |
+					   (BIT(b3,10)<<17) |
+					   (BIT(b3, 6)<<18) |
+					   (BIT(b1,10)<<19) |
+					   (BIT(b2,15)<<20) |
+					   (BIT(b2, 3)<<21) |
+					   (BIT(b1, 5)<<22) |
+					   (BIT(b3,15)<<23);
 
 		plane543 = partial_carry_sum32( plane543, k1, k2 ) ^ k3;
 		plane210 = partial_carry_sum24( plane210,  i, k4 ) ^ k5;
 		if (feversoc_kludge)
 			plane210 = partial_carry_sum24( plane210,  1, 0x000001 );
 
-		rom[0*size+2*i]   = plane543 >> 16;
-		rom[0*size+2*i+1] = plane543 >>  8;
-		rom[1*size+2*i]   = plane543 >>  0;
-		rom[1*size+2*i+1] = plane210 >> 16;
-		rom[2*size+2*i]   = plane210 >>  8;
-		rom[2*size+2*i+1] = plane210 >>  0;
+		rom[0 * size + 2 * i]     = plane543 >> 16;
+		rom[0 * size + 2 * i + 1] = plane543 >>  8;
+		rom[1 * size + 2 * i]     = plane543 >>  0;
+		rom[1 * size + 2 * i + 1] = plane210 >> 16;
+		rom[2 * size + 2 * i]     = plane210 >>  8;
+		rom[2 * size + 2 * i + 1] = plane210 >>  0;
 	}
 
-	for (i = 0; i < size/2; i += 32)
+	for (int i = 0; i < size / 2; i += 32)
 	{
-		sprite_reorder(&rom[0*size+2*i]);
-		sprite_reorder(&rom[1*size+2*i]);
-		sprite_reorder(&rom[2*size+2*i]);
+		sprite_reorder(&rom[0 * size + 2 * i]);
+		sprite_reorder(&rom[1 * size + 2 * i]);
+		sprite_reorder(&rom[2 * size + 2 * i]);
 	}
 }
 
 
-void seibuspi_rise11_sprite_decrypt_rfjet(uint8_t *rom, int size)
+void seibuspi_rise11_sprite_decrypt_rfjet(u8 *rom, int size)
 {
 	seibuspi_rise11_sprite_decrypt(rom, size, 0xabcb64, 0x55aadd, 0xab6a4c, 0xd6375b, 0x8bf23b, 0);
 }
 
 
-void seibuspi_rise11_sprite_decrypt_feversoc(uint8_t *rom, int size)
+void seibuspi_rise11_sprite_decrypt_feversoc(u8 *rom, int size)
 {
 	seibuspi_rise11_sprite_decrypt(rom, size, 0x9df5b2, 0x9ae999, 0x4a32e9, 0x968bd5, 0x1d97ac, 1);
 }

--- a/src/mame/machine/seibuspi.h
+++ b/src/mame/machine/seibuspi.h
@@ -3,10 +3,10 @@
 
 // TODO: modernize code
 
-uint32_t partial_carry_sum32(uint32_t add1,uint32_t add2,uint32_t carry_mask);
-uint32_t partial_carry_sum24(uint32_t add1,uint32_t add2,uint32_t carry_mask);
+u32 partial_carry_sum32(u32 add1,u32 add2,u32 carry_mask);
+u32 partial_carry_sum24(u32 add1,u32 add2,u32 carry_mask);
 
-void seibuspi_sprite_decrypt(uint8_t *src, int romsize);
-void seibuspi_rise10_sprite_decrypt(uint8_t *rom, int romsize);
-void seibuspi_rise11_sprite_decrypt_rfjet(uint8_t *rom, int romsize);
-void seibuspi_rise11_sprite_decrypt_feversoc(uint8_t *rom, int romsize);
+void seibuspi_sprite_decrypt(u8 *src, int romsize);
+void seibuspi_rise10_sprite_decrypt(u8 *rom, int romsize);
+void seibuspi_rise11_sprite_decrypt_rfjet(u8 *rom, int romsize);
+void seibuspi_rise11_sprite_decrypt_feversoc(u8 *rom, int romsize);

--- a/src/mame/video/seibuspi.cpp
+++ b/src/mame/video/seibuspi.cpp
@@ -13,6 +13,7 @@
 #include "machine/seibuspi.h"
 #include "screen.h"
 
+#include <algorithm>
 
 /**************************************************************************
 
@@ -38,46 +39,40 @@ custom CRTC on startup!! (writes to 000414)
 **************************************************************************/
 
 
-static uint32_t decrypt_tile(uint32_t val, int tileno, uint32_t key1, uint32_t key2, uint32_t key3)
+static u32 decrypt_tile(u32 val, int tileno, u32 key1, u32 key2, u32 key3)
 {
 	val = bitswap<24>(val, 18,19,9,5, 10,17,16,20, 21,22,6,11, 15,14,4,23, 0,1,7,8, 13,12,3,2);
 
 	return partial_carry_sum24( val, tileno + key1, key2 ) ^ key3;
 }
 
-static void decrypt_text(uint8_t *rom, uint32_t key1, uint32_t key2, uint32_t key3)
+static void decrypt_text(u8 *rom, u32 key1, u32 key2, u32 key3)
 {
-	int i;
-	for(i=0; i<0x10000; i++)
+	for (int i = 0; i < 0x10000; i++)
 	{
-		uint32_t w;
-
-		w = (rom[(i*3) + 0] << 16) | (rom[(i*3) + 1] << 8) | (rom[(i*3) +2]);
+		u32 w = (rom[(i * 3) + 0] << 16) | (rom[(i * 3) + 1] << 8) | (rom[(i * 3) + 2]);
 
 		w = decrypt_tile(w, i >> 4, key1, key2, key3);
 
-		rom[(i*3) + 0] = (w >> 16) & 0xff;
-		rom[(i*3) + 1] = (w >> 8) & 0xff;
-		rom[(i*3) + 2] = w & 0xff;
+		rom[(i * 3) + 0] = (w >> 16) & 0xff;
+		rom[(i * 3) + 1] = (w >> 8) & 0xff;
+		rom[(i * 3) + 2] = w & 0xff;
 	}
 }
 
-static void decrypt_bg(uint8_t *rom, int size, uint32_t key1, uint32_t key2, uint32_t key3)
+static void decrypt_bg(u8 *rom, int size, u32 key1, u32 key2, u32 key3)
 {
-	int i,j;
-	for(j=0; j<size; j+=0xc0000)
+	for (int j = 0; j < size; j += 0xc0000)
 	{
-		for(i=0; i<0x40000; i++)
+		for (int i = 0; i < 0x40000; i++)
 		{
-			uint32_t w;
-
-			w = (rom[j + (i*3) + 0] << 16) | (rom[j + (i*3) + 1] << 8) | (rom[j + (i*3) + 2]);
+			u32 w = (rom[j + (i * 3) + 0] << 16) | (rom[j + (i * 3) + 1] << 8) | (rom[j + (i * 3) + 2]);
 
 			w = decrypt_tile(w, i >> 6, key1, key2, key3);
 
-			rom[j + (i*3) + 0] = (w >> 16) & 0xff;
-			rom[j + (i*3) + 1] = (w >> 8) & 0xff;
-			rom[j + (i*3) + 2] = w & 0xff;
+			rom[j + (i * 3) + 0] = (w >> 16) & 0xff;
+			rom[j + (i * 3) + 1] = (w >> 8) & 0xff;
+			rom[j + (i * 3) + 2] = w & 0xff;
 		}
 	}
 }
@@ -92,12 +87,12 @@ cpu #0 (PC=0033B2EB): unmapped program memory dword write to 00000414 = 00004535
 cpu #0 (PC=0033B2EB): unmapped program memory dword write to 00000414 = 06DC0000 & FFFF0000
 ******************************************************************************************/
 
-void seibuspi_state::text_decrypt(uint8_t *rom)
+void seibuspi_state::text_decrypt(u8 *rom)
 {
 	decrypt_text( rom, 0x5a3845, 0x77cf5b, 0x1378df);
 }
 
-void seibuspi_state::bg_decrypt(uint8_t *rom, int size)
+void seibuspi_state::bg_decrypt(u8 *rom, int size)
 {
 	decrypt_bg( rom, size, 0x5a3845, 0x77cf5b, 0x1378df);
 }
@@ -112,12 +107,12 @@ cpu #0 (PC=002A097D): unmapped program memory dword write to 00000414 = 0000466B
 cpu #0 (PC=002A097D): unmapped program memory dword write to 00000414 = 3EDC0000 & FFFF0000
 ******************************************************************************************/
 
-void seibuspi_state::rdft2_text_decrypt(uint8_t *rom)
+void seibuspi_state::rdft2_text_decrypt(u8 *rom)
 {
 	decrypt_text( rom, 0x823146, 0x4de2f8, 0x157adc);
 }
 
-void seibuspi_state::rdft2_bg_decrypt(uint8_t *rom, int size)
+void seibuspi_state::rdft2_bg_decrypt(u8 *rom, int size)
 {
 	decrypt_bg( rom, size, 0x823146, 0x4de2f8, 0x157adc);
 }
@@ -132,17 +127,17 @@ cpu #0 (PC=002C40F9): unmapped program memory dword write to 00000414 = 0000547C
 cpu #0 (PC=002C40F9): unmapped program memory dword write to 00000414 = 3EDC0000 & FFFF0000
 ******************************************************************************************/
 
-void seibuspi_state::rfjet_text_decrypt(uint8_t *rom)
+void seibuspi_state::rfjet_text_decrypt(u8 *rom)
 {
 	decrypt_text( rom, 0xaea754, 0xfe8530, 0xccb666);
 }
 
-void seibuspi_state::rfjet_bg_decrypt(uint8_t *rom, int size)
+void seibuspi_state::rfjet_bg_decrypt(u8 *rom, int size)
 {
 	decrypt_bg( rom, size, 0xaea754, 0xfe8530, 0xccb666);
 }
 
-WRITE16_MEMBER(seibuspi_state::tile_decrypt_key_w)
+void seibuspi_state::tile_decrypt_key_w(u16 data)
 {
 	if (data != 0 && data != 1)
 		logerror("Decryption key: %04X\n", data);
@@ -172,7 +167,7 @@ void seibuspi_state::set_layer_offsets()
 	m_fore_layer_d14 = m_rf2_layer_bank << 12 & 0x4000;
 }
 
-WRITE16_MEMBER(seibuspi_state::spi_layer_bank_w)
+void seibuspi_state::spi_layer_bank_w(offs_t offset, u16 data, u16 mem_mask)
 {
 	//logerror("Writing %04X to layer register\n", data);
 
@@ -180,7 +175,7 @@ WRITE16_MEMBER(seibuspi_state::spi_layer_bank_w)
 	// r: rowscroll enable
 	// f: fore layer d13
 	// a: ? (0 in ejanhs and rdft22kc, 1 in all other games)
-	uint16_t prev = m_layer_bank;
+	const u16 prev = m_layer_bank;
 	COMBINE_DATA(&m_layer_bank);
 
 	m_rowscroll_enable = m_layer_bank >> 15 & 1;
@@ -191,13 +186,13 @@ WRITE16_MEMBER(seibuspi_state::spi_layer_bank_w)
 }
 
 
-WRITE8_MEMBER(seibuspi_state::rf2_layer_bank_w)
+void seibuspi_state::rf2_layer_bank_w(u8 data)
 {
 	// 00000fmb
 	// f: fore layer d14
 	// m: middle layer d14
 	// b: back layer d14
-	uint8_t prev = m_rf2_layer_bank;
+	const u8 prev = m_rf2_layer_bank;
 	m_rf2_layer_bank = data;
 	set_layer_offsets();
 
@@ -211,7 +206,7 @@ WRITE8_MEMBER(seibuspi_state::rf2_layer_bank_w)
 		m_fore_layer->mark_all_dirty();
 }
 
-WRITE16_MEMBER(seibuspi_state::spi_layer_enable_w)
+void seibuspi_state::spi_layer_enable_w(offs_t offset, u16 data, u16 mem_mask)
 {
 	// 00000000 000stfmb (0=on, 1=off)
 	// s: sprite layer
@@ -222,17 +217,17 @@ WRITE16_MEMBER(seibuspi_state::spi_layer_enable_w)
 	COMBINE_DATA(&m_layer_enable);
 }
 
-WRITE16_MEMBER(seibuspi_state::scroll_w)
+void seibuspi_state::scroll_w(offs_t offset, u16 data, u16 mem_mask)
 {
 	COMBINE_DATA(&m_scrollram[offset]);
 }
 
-WRITE32_MEMBER(seibuspi_state::video_dma_length_w)
+void seibuspi_state::video_dma_length_w(offs_t offset, u32 data, u32 mem_mask)
 {
 	COMBINE_DATA(&m_video_dma_length);
 }
 
-WRITE32_MEMBER(seibuspi_state::video_dma_address_w)
+void seibuspi_state::video_dma_address_w(offs_t offset, u32 data, u32 mem_mask)
 {
 	COMBINE_DATA(&m_video_dma_address);
 }
@@ -240,7 +235,7 @@ WRITE32_MEMBER(seibuspi_state::video_dma_address_w)
 
 /*****************************************************************************/
 
-WRITE32_MEMBER(seibuspi_state::tilemap_dma_start_w)
+void seibuspi_state::tilemap_dma_start_w(u32 data)
 {
 	if (!m_tilemap_ram)
 		return;
@@ -260,7 +255,7 @@ WRITE32_MEMBER(seibuspi_state::tilemap_dma_start_w)
 	/* back layer */
 	for (int i = 0; i < 0x800/4; i++)
 	{
-		uint32_t tile = m_mainram[index];
+		const u32 tile = m_mainram[index];
 		if (m_tilemap_ram[i] != tile)
 		{
 			m_tilemap_ram[i] = tile;
@@ -273,14 +268,14 @@ WRITE32_MEMBER(seibuspi_state::tilemap_dma_start_w)
 	/* back layer row scroll */
 	if (m_rowscroll_enable)
 	{
-		memcpy(&m_tilemap_ram[0x800/4], &m_mainram[index], 0x800/4);
+		std::copy_n(&m_mainram[index], 0x800/4, &m_tilemap_ram[0x800/4]);
 		index += 0x800/4;
 	}
 
 	/* fore layer */
 	for (int i = 0; i < 0x800/4; i++)
 	{
-		uint32_t tile = m_mainram[index];
+		const u32 tile = m_mainram[index];
 		if (m_tilemap_ram[i+m_fore_layer_offset] != tile)
 		{
 			m_tilemap_ram[i+m_fore_layer_offset] = tile;
@@ -293,14 +288,14 @@ WRITE32_MEMBER(seibuspi_state::tilemap_dma_start_w)
 	/* fore layer row scroll */
 	if (m_rowscroll_enable)
 	{
-		memcpy(&m_tilemap_ram[0x1800/4], &m_mainram[index], 0x800/4); // 0x2800/4?
+		std::copy_n(&m_mainram[index], 0x800/4, &m_tilemap_ram[0x1800/4]); // 0x2800/4?
 		index += 0x800/4;
 	}
 
 	/* middle layer */
 	for (int i = 0; i < 0x800/4; i++)
 	{
-		uint32_t tile = m_mainram[index];
+		const u32 tile = m_mainram[index];
 		if (m_tilemap_ram[i+m_midl_layer_offset] != tile)
 		{
 			m_tilemap_ram[i+m_midl_layer_offset] = tile;
@@ -313,14 +308,14 @@ WRITE32_MEMBER(seibuspi_state::tilemap_dma_start_w)
 	/* middle layer row scroll */
 	if (m_rowscroll_enable)
 	{
-		memcpy(&m_tilemap_ram[0x2800/4], &m_mainram[index], 0x800/4); // 0x1800/4?
+		std::copy_n(&m_mainram[index], 0x800/4, &m_tilemap_ram[0x2800/4]); // 0x1800/4?
 		index += 0x800/4;
 	}
 
 	/* text layer */
 	for (int i = 0; i < 0x1000/4; i++)
 	{
-		uint32_t tile = m_mainram[index];
+		const u32 tile = m_mainram[index];
 		if (m_tilemap_ram[i+m_text_layer_offset] != tile)
 		{
 			m_tilemap_ram[i+m_text_layer_offset] = tile;
@@ -332,9 +327,9 @@ WRITE32_MEMBER(seibuspi_state::tilemap_dma_start_w)
 }
 
 
-WRITE32_MEMBER(seibuspi_state::palette_dma_start_w)
+void seibuspi_state::palette_dma_start_w(u32 data)
 {
-	int dma_length = (m_video_dma_length + 1) * 2;
+	const int dma_length = (m_video_dma_length + 1) * 2;
 
 	// safety check
 	if (!DWORD_ALIGNED(m_video_dma_address) || (m_video_dma_length & 3) != 3 || dma_length > m_palette_ram_size || (m_video_dma_address + dma_length) > 0x40000)
@@ -344,7 +339,7 @@ WRITE32_MEMBER(seibuspi_state::palette_dma_start_w)
 
 	for (int i = 0; i < dma_length / 4; i++)
 	{
-		uint32_t color = m_mainram[m_video_dma_address / 4 + i];
+		const u32 color = m_mainram[m_video_dma_address / 4 + i];
 		if (m_palette_ram[i] != color)
 		{
 			m_palette_ram[i] = color;
@@ -355,7 +350,7 @@ WRITE32_MEMBER(seibuspi_state::palette_dma_start_w)
 }
 
 
-WRITE16_MEMBER(seibuspi_state::sprite_dma_start_w)
+void seibuspi_state::sprite_dma_start_w(u16 data)
 {
 	// safety check
 	if (!DWORD_ALIGNED(m_video_dma_address) || (m_video_dma_address + m_sprite_ram_size) > 0x40000)
@@ -363,16 +358,16 @@ WRITE16_MEMBER(seibuspi_state::sprite_dma_start_w)
 	if (m_video_dma_address < 0x800)
 		logerror("sprite_dma_start_w in I/O area: %X\n", m_video_dma_address);
 
-	memcpy(m_sprite_ram.get(), &m_mainram[m_video_dma_address / 4], m_sprite_ram_size);
+	std::copy_n(&m_mainram[m_video_dma_address / 4], m_sprite_ram_size / 4, &m_sprite_ram[0]);
 }
 
 
 /*****************************************************************************/
 
-void seibuspi_state::drawgfx_blend(bitmap_rgb32 &bitmap, const rectangle &cliprect, gfx_element *gfx, uint32_t code, uint32_t color, int flipx, int flipy, int sx, int sy, bitmap_ind8 &primap, int primask)
+void seibuspi_state::drawgfx_blend(bitmap_rgb32 &bitmap, const rectangle &cliprect, gfx_element *gfx, u32 code, u32 color, bool flipx, bool flipy, int sx, int sy, bitmap_ind8 &primap, u8 primask)
 {
-	int width = gfx->width();
-	int height = gfx->height();
+	const int width = gfx->width();
+	const int height = gfx->height();
 
 	int x1 = sx;
 	int x2 = sx + width - 1;
@@ -440,25 +435,26 @@ void seibuspi_state::drawgfx_blend(bitmap_rgb32 &bitmap, const rectangle &clipre
 		y2 = cliprect.max_y;
 	}
 
-	const pen_t *pens = &m_palette->pen(gfx->colorbase());
-	const uint8_t *src = gfx->get_data(code);
+	color = gfx->colorbase() + (color % gfx->colors()) * gfx->granularity();
+	const pen_t *pens = m_palette->pens();
+	const u8 *src = gfx->get_data(code % gfx->elements());
+	const u8 trans_pen = (1 << m_sprite_bpp) - 1;
 
 	// draw
 	for (int y = y1; y <= y2; y++)
 	{
-		uint32_t *dest = &bitmap.pix32(y);
-		uint8_t *pri = &primap.pix8(y);
-		uint8_t trans_pen = (1 << m_sprite_bpp) - 1;
+		u32 *dest = &bitmap.pix32(y);
+		u8 *pri = &primap.pix8(y);
 		int src_i = (py * width) + px;
 		py += yd;
 
 		for (int x = x1; x <= x2; x++)
 		{
-			uint8_t pen = src[src_i];
+			const u8 pen = src[src_i];
 			if (!(pri[x] & primask) && pen != trans_pen)
 			{
 				pri[x] |= primask;
-				int global_pen = pen + (color << m_sprite_bpp);
+				const u16 global_pen = pen + color;
 				if (m_alpha_table[global_pen])
 					dest[x] = alpha_blend_r32(dest[x], pens[global_pen], 0x7f);
 				else
@@ -471,9 +467,8 @@ void seibuspi_state::drawgfx_blend(bitmap_rgb32 &bitmap, const rectangle &clipre
 
 void seibuspi_state::draw_sprites(bitmap_rgb32 &bitmap, const rectangle &cliprect, bitmap_ind8 &primap, int priority)
 {
-	gfx_element *gfx = m_gfxdecode->gfx(2);
-	const int has_tile_high = (gfx->elements() > 0x10000) ? 1 : 0;
-	const int colormask = (m_sprite_bpp == 6) ? 0x3f : 0x1f;
+	gfx_element *gfx = m_gfxdecode->gfx(0);
+	const bool has_tile_high = (gfx->elements() > 0x10000);
 
 	static const int sprite_xtable[2][8] =
 	{
@@ -515,20 +510,20 @@ void seibuspi_state::draw_sprites(bitmap_rgb32 &bitmap, const rectangle &cliprec
 
 		if (priority != (m_sprite_ram[a + 0] >> 6 & 0x3))
 			continue;
-		int primask = 1 << priority;
+		const u8 primask = 1 << priority;
 
-		int16_t xpos = m_sprite_ram[a + 1] & 0x3ff;
+		s16 xpos = m_sprite_ram[a + 1] & 0x3ff;
 		if (xpos & 0x200)
 			xpos |= 0xfc00;
-		int16_t ypos = m_sprite_ram[a + 1] >> 16 & 0x1ff;
+		s16 ypos = m_sprite_ram[a + 1] >> 16 & 0x1ff;
 		if (ypos & 0x100)
 			ypos |= 0xfe00;
-		int color = m_sprite_ram[a + 0] & colormask;
+		const int color = m_sprite_ram[a + 0] & 0x3f;
 
 		int width = (m_sprite_ram[a + 0] >> 8 & 0x7) + 1;
 		int height = (m_sprite_ram[a + 0] >> 12 & 0x7) + 1;
-		int flip_x = m_sprite_ram[a + 0] >> 11 & 0x1;
-		int flip_y = m_sprite_ram[a + 0] >> 15 & 0x1;
+		const int flip_x = m_sprite_ram[a + 0] >> 11 & 0x1;
+		const int flip_y = m_sprite_ram[a + 0] >> 15 & 0x1;
 		int x1 = 0;
 		int y1 = 0;
 
@@ -559,17 +554,12 @@ void seibuspi_state::draw_sprites(bitmap_rgb32 &bitmap, const rectangle &cliprec
 	}
 }
 
-void seibuspi_state::combine_tilemap(bitmap_rgb32 &bitmap, const rectangle &cliprect, tilemap_t *tile, int sx, int sy, int opaque, int16_t *rowscroll)
+void seibuspi_state::combine_tilemap(bitmap_rgb32 &bitmap, const rectangle &cliprect, tilemap_t *tile, int sx, int sy, int opaque, s16 *rowscroll)
 {
-	uint16_t *src;
-	uint32_t *dest;
-	uint8_t *flags;
-	uint32_t xscroll_mask, yscroll_mask;
-
 	bitmap_ind16 &pen_bitmap = tile->pixmap();
 	bitmap_ind8 &flags_bitmap = tile->flagsmap();
-	xscroll_mask = pen_bitmap.width() - 1;
-	yscroll_mask = pen_bitmap.height() - 1;
+	const u32 xscroll_mask = pen_bitmap.width() - 1;
+	const u32 yscroll_mask = pen_bitmap.height() - 1;
 
 	for (int y = cliprect.min_y; y <= cliprect.max_y; y++)
 	{
@@ -579,14 +569,14 @@ void seibuspi_state::combine_tilemap(bitmap_rgb32 &bitmap, const rectangle &clip
 			rx += rowscroll[(y + sy) & yscroll_mask];
 		}
 
-		dest = &bitmap.pix32(y);
-		src = &pen_bitmap.pix16((y + sy) & yscroll_mask);
-		flags = &flags_bitmap.pix8((y + sy) & yscroll_mask);
+		u32 *dest = &bitmap.pix32(y);
+		const u16 *src = &pen_bitmap.pix16((y + sy) & yscroll_mask);
+		const u8 *flags = &flags_bitmap.pix8((y + sy) & yscroll_mask);
 		for (int x = cliprect.min_x + rx; x <= cliprect.max_x + rx; x++)
 		{
 			if (opaque || (flags[x & xscroll_mask] & (TILEMAP_PIXEL_LAYER0 | TILEMAP_PIXEL_LAYER1)))
 			{
-				uint16_t pen = src[x & xscroll_mask];
+				const u16 pen = src[x & xscroll_mask];
 				if (m_alpha_table[pen])
 					*dest = alpha_blend_r32(*dest, m_palette->pen(pen), 0x7f);
 				else
@@ -598,14 +588,14 @@ void seibuspi_state::combine_tilemap(bitmap_rgb32 &bitmap, const rectangle &clip
 }
 
 
-uint32_t seibuspi_state::screen_update_spi(screen_device &screen, bitmap_rgb32 &bitmap, const rectangle &cliprect)
+u32 seibuspi_state::screen_update_spi(screen_device &screen, bitmap_rgb32 &bitmap, const rectangle &cliprect)
 {
-	int16_t *back_rowscroll, *midl_rowscroll, *fore_rowscroll;
+	s16 *back_rowscroll, *midl_rowscroll, *fore_rowscroll;
 	if (m_rowscroll_enable)
 	{
-		back_rowscroll = (int16_t*)&m_tilemap_ram[0x200];
-		midl_rowscroll = (int16_t*)&m_tilemap_ram[0x600];
-		fore_rowscroll = (int16_t*)&m_tilemap_ram[0xa00];
+		back_rowscroll = (s16*)&m_tilemap_ram[0x200];
+		midl_rowscroll = (s16*)&m_tilemap_ram[0x600];
+		fore_rowscroll = (s16*)&m_tilemap_ram[0xa00];
 	}
 	else
 	{
@@ -651,7 +641,7 @@ uint32_t seibuspi_state::screen_update_spi(screen_device &screen, bitmap_rgb32 &
 	return 0;
 }
 
-uint32_t seibuspi_state::screen_update_sys386f(screen_device &screen, bitmap_rgb32 &bitmap, const rectangle &cliprect)
+u32 seibuspi_state::screen_update_sys386f(screen_device &screen, bitmap_rgb32 &bitmap, const rectangle &cliprect)
 {
 	screen.priority().fill(0, cliprect);
 	bitmap.fill(0, cliprect);
@@ -670,19 +660,19 @@ uint32_t seibuspi_state::screen_update_sys386f(screen_device &screen, bitmap_rgb
 TILE_GET_INFO_MEMBER(seibuspi_state::get_text_tile_info)
 {
 	int offs = tile_index / 2;
-	int tile = (m_tilemap_ram[offs + m_text_layer_offset] >> ((tile_index & 0x1) ? 16 : 0)) & 0xffff;
-	int color = (tile >> 12) & 0xf;
+	u32 tile = (m_tilemap_ram[offs + m_text_layer_offset] >> ((tile_index & 0x1) ? 16 : 0)) & 0xffff;
+	const u32 color = (tile >> 12) & 0xf;
 
 	tile &= 0xfff;
 
-	SET_TILE_INFO_MEMBER(0, tile, color, 0);
+	SET_TILE_INFO_MEMBER(2, tile, color, 0);
 }
 
 TILE_GET_INFO_MEMBER(seibuspi_state::get_back_tile_info)
 {
 	int offs = tile_index / 2;
-	int tile = (m_tilemap_ram[offs] >> ((tile_index & 0x1) ? 16 : 0)) & 0xffff;
-	int color = (tile >> 13) & 0x7;
+	u32 tile = (m_tilemap_ram[offs] >> ((tile_index & 0x1) ? 16 : 0)) & 0xffff;
+	const u32 color = (tile >> 13) & 0x7;
 
 	tile &= 0x1fff;
 	tile |= m_back_layer_d14;
@@ -693,8 +683,8 @@ TILE_GET_INFO_MEMBER(seibuspi_state::get_back_tile_info)
 TILE_GET_INFO_MEMBER(seibuspi_state::get_midl_tile_info)
 {
 	int offs = tile_index / 2;
-	int tile = (m_tilemap_ram[offs + m_midl_layer_offset] >> ((tile_index & 0x1) ? 16 : 0)) & 0xffff;
-	int color = (tile >> 13) & 0x7;
+	u32 tile = (m_tilemap_ram[offs + m_midl_layer_offset] >> ((tile_index & 0x1) ? 16 : 0)) & 0xffff;
+	const u32 color = (tile >> 13) & 0x7;
 
 	tile &= 0x1fff;
 	tile |= 0x2000;
@@ -706,8 +696,8 @@ TILE_GET_INFO_MEMBER(seibuspi_state::get_midl_tile_info)
 TILE_GET_INFO_MEMBER(seibuspi_state::get_fore_tile_info)
 {
 	int offs = tile_index / 2;
-	int tile = (m_tilemap_ram[offs + m_fore_layer_offset] >> ((tile_index & 0x1) ? 16 : 0)) & 0xffff;
-	int color = (tile >> 13) & 0x7;
+	u32 tile = (m_tilemap_ram[offs + m_fore_layer_offset] >> ((tile_index & 0x1) ? 16 : 0)) & 0xffff;
+	const u32 color = (tile >> 13) & 0x7;
 
 	tile &= 0x1fff;
 	tile |= m_bg_fore_layer_position;
@@ -725,7 +715,7 @@ void seibuspi_state::video_start()
 	m_layer_enable = 0;
 	m_layer_bank = 0;
 	m_rf2_layer_bank = 0;
-	m_rowscroll_enable = 0;
+	m_rowscroll_enable = false;
 	m_scrollram[0] = 0;
 	m_scrollram[1] = 0;
 	m_scrollram[2] = 0;
@@ -734,7 +724,7 @@ void seibuspi_state::video_start()
 	m_scrollram[5] = 0;
 	set_layer_offsets();
 
-	uint32_t region_length = memregion("gfx2")->bytes();
+	u32 region_length = memregion("tiles")->bytes();
 
 	if (region_length <= 0x300000)
 		m_bg_fore_layer_position = 0x2000;
@@ -748,13 +738,13 @@ void seibuspi_state::video_start()
 	m_sprite_ram_size = 0x1000;
 	m_sprite_bpp = 6;
 
-	m_tilemap_ram = make_unique_clear<uint32_t[]>(m_tilemap_ram_size/4);
-	m_palette_ram = make_unique_clear<uint32_t[]>(m_palette_ram_size/4);
-	m_sprite_ram = make_unique_clear<uint32_t[]>(m_sprite_ram_size/4);
+	m_tilemap_ram = make_unique_clear<u32[]>(m_tilemap_ram_size/4);
+	m_palette_ram = make_unique_clear<u32[]>(m_palette_ram_size/4);
+	m_sprite_ram = make_unique_clear<u32[]>(m_sprite_ram_size/4);
 
 	m_palette->basemem().set(&m_palette_ram[0], m_palette_ram_size, 32, ENDIANNESS_LITTLE, 2);
 
-	m_text_layer = &machine().tilemap().create(*m_gfxdecode, tilemap_get_info_delegate(FUNC(seibuspi_state::get_text_tile_info),this), TILEMAP_SCAN_ROWS, 8, 8, 64,32);
+	m_text_layer = &machine().tilemap().create(*m_gfxdecode, tilemap_get_info_delegate(FUNC(seibuspi_state::get_text_tile_info),this), TILEMAP_SCAN_ROWS,  8, 8,64,32);
 	m_back_layer = &machine().tilemap().create(*m_gfxdecode, tilemap_get_info_delegate(FUNC(seibuspi_state::get_back_tile_info),this), TILEMAP_SCAN_COLS, 16,16,32,32);
 	m_midl_layer = &machine().tilemap().create(*m_gfxdecode, tilemap_get_info_delegate(FUNC(seibuspi_state::get_midl_tile_info),this), TILEMAP_SCAN_COLS, 16,16,32,32);
 	m_fore_layer = &machine().tilemap().create(*m_gfxdecode, tilemap_get_info_delegate(FUNC(seibuspi_state::get_fore_tile_info),this), TILEMAP_SCAN_COLS, 16,16,32,32);
@@ -805,7 +795,7 @@ VIDEO_START_MEMBER(seibuspi_state,sys386f)
 	m_layer_enable = 0;
 	m_layer_bank = 0;
 	m_rf2_layer_bank = 0;
-	m_rowscroll_enable = 0;
+	m_rowscroll_enable = false;
 	set_layer_offsets();
 
 	m_tilemap_ram_size = 0;
@@ -814,8 +804,8 @@ VIDEO_START_MEMBER(seibuspi_state,sys386f)
 	m_sprite_bpp = 8;
 
 	m_tilemap_ram = nullptr;
-	m_palette_ram = make_unique_clear<uint32_t[]>(m_palette_ram_size/4);
-	m_sprite_ram = make_unique_clear<uint32_t[]>(m_sprite_ram_size/4);
+	m_palette_ram = make_unique_clear<u32[]>(m_palette_ram_size/4);
+	m_sprite_ram = make_unique_clear<u32[]>(m_sprite_ram_size/4);
 
 	m_palette->basemem().set(&m_palette_ram[0], m_palette_ram_size, 32, ENDIANNESS_LITTLE, 2);
 
@@ -826,6 +816,7 @@ VIDEO_START_MEMBER(seibuspi_state,sys386f)
 
 void seibuspi_state::register_video_state()
 {
+	m_gfxdecode->gfx(0)->set_granularity(1 << m_sprite_bpp);
 	save_item(NAME(m_video_dma_length));
 	save_item(NAME(m_video_dma_address));
 	save_item(NAME(m_layer_enable));


### PR DESCRIPTION
Simplify handlers, Simplify gfxdecodes, Fix / cleanup some DMA / drawing routines, Reduce unnecessary lines, Fix spacings, Namings, Use shorter / correct type values
seibucats.cpp : Add seperate video config related to no tilemap present, sprite bpp differs, Add notes, Fix sound output