### PR TITLE
Add plugin for autofire

### DIFF
--- a/plugins/autofire/autofire_menu.lua
+++ b/plugins/autofire/autofire_menu.lua
@@ -148,6 +148,7 @@ local function handle_configure_menu(index, event)
 		end
 	-- On frames
 	elseif index == 3 then
+		manager:machine():popmessage(_('Number of frames button will be pressed'))
 		if event == 'left' then
 			current_button.on_frames = current_button.on_frames - 1
 		elseif event == 'right' then
@@ -155,6 +156,7 @@ local function handle_configure_menu(index, event)
 		end
 	-- Off frames
 	elseif index == 4 then
+		manager:machine():popmessage(_('Number of frames button will be released'))
 		if event == 'left' then
 			current_button.off_frames = current_button.off_frames - 1
 		elseif event == 'right' then
@@ -277,6 +279,7 @@ function lib:populate_menu(buttons)
 end
 
 function lib:handle_menu_event(index, event, buttons)
+	manager:machine():popmessage()
 	local current_menu = menu_stack[#menu_stack]
 	if current_menu == MENU_TYPES.MAIN then
 		return handle_main_menu(index, event, buttons)

--- a/plugins/autofire/autofire_menu.lua
+++ b/plugins/autofire/autofire_menu.lua
@@ -1,0 +1,292 @@
+local lib = {}
+
+-- Set of all menus
+local MENU_TYPES = { MAIN = 0, EDIT = 1, ADD = 2, BUTTON = 3 }
+
+-- Set of sections within a menu
+local MENU_SECTIONS = { HEADER = 0, CONTENT = 1, FOOTER = 2 }
+
+-- Last index of header items (above main content) in menu
+local header_height = 0
+
+-- Last index of content items (below header, above footer) in menu
+local content_height = 0
+
+-- Stack of menus (see MENU_TYPES)
+local menu_stack = { MENU_TYPES.MAIN }
+
+-- Button being created/edited
+local current_button = {}
+
+-- Inputs that can be autofired (to list in BUTTON menu)
+local inputs = {}
+
+-- Returns the section (from MENU_SECTIONS) and the index within that section
+local function menu_section(index)
+	if index <= header_height then
+		return MENU_SECTIONS.HEADER, index
+	elseif index <= content_height then
+		return MENU_SECTIONS.CONTENT, index - header_height
+	else
+		return MENU_SECTIONS.FOOTER, index - content_height
+	end
+end
+
+local function create_new_button()
+	return {
+		on_frames = 1,
+		off_frames = 1,
+		counter = 0
+	}
+end
+
+local function is_button_complete(button)
+	return button.port and button.field and button.key and button.on_frames and button.off_frames and button.button and button.counter
+end
+
+local function is_supported_input(ioport_field)
+	-- IPT_BUTTON1 through IPT_BUTTON16 in ioport_type enum (ioport.h)
+	return ioport_field.type >= 64 and ioport_field.type <= 79
+end
+
+-- Main menu
+
+local function populate_main_menu(buttons)
+	local menu = {}
+	menu[#menu + 1] = {_('Autofire buttons'), '', 'off'}
+	menu[#menu + 1] = {'---', '', ''}
+	header_height = #menu
+
+	for index, button in ipairs(buttons) do
+		-- Assume refresh rate of 60 Hz; maybe better to use screen_device refresh()?
+		local rate = 60 / (button.on_frames + button.off_frames)
+		-- Round to two decimal places
+		rate = math.floor(rate * 100) / 100
+		local text = button.button.name .. ' [' .. rate .. ' Hz]'
+		local subtext = manager:machine():input():code_name(button.key)
+		menu[#menu + 1] = {text, subtext, ''}
+	end
+	content_height = #menu
+
+	menu[#menu + 1] = {'---', '', ''}
+	menu[#menu + 1] = {_('Add autofire button'), '', ''}
+	return menu
+end
+
+local function handle_main_menu(index, event, buttons)
+	local section, adjusted_index = menu_section(index)
+	if section == MENU_SECTIONS.CONTENT then
+		if event == 'select' then
+			current_button = buttons[adjusted_index]
+			table.insert(menu_stack, MENU_TYPES.EDIT)
+			return true
+		elseif event == 'clear' then
+			table.remove(buttons, adjusted_index)
+			return true
+		end
+	elseif section == MENU_SECTIONS.FOOTER then
+		if event == 'select' then
+			current_button = create_new_button()
+			table.insert(menu_stack, MENU_TYPES.ADD)
+			return true
+		end
+	end
+	return false
+end
+
+-- Add/edit menus (mostly identical)
+
+local function populate_configure_menu(menu)
+	local button_name = current_button.button and current_button.button.name or _('NOT SET')
+	local key_name = current_button.key and manager:machine():input():code_name(current_button.key) or _('NOT SET')
+	menu[#menu + 1] = {_('Input'), button_name, ''}
+	menu[#menu + 1] = {_('Hotkey'), key_name, ''}
+	menu[#menu + 1] = {_('On frames'), current_button.on_frames, current_button.on_frames > 1 and 'lr' or 'r'}
+	menu[#menu + 1] = {_('Off frames'), current_button.off_frames, current_button.off_frames > 1 and 'lr' or 'r'}
+end
+
+-- Borrowed from the cheat plugin
+local function poll_for_hotkey()
+	local input = manager:machine():input()
+	manager:machine():popmessage(_('Press button for hotkey or wait to leave unchanged'))
+	manager:machine():video():frame_update(true)
+	input:seq_poll_start('switch')
+	local time = os.clock()
+	while (not input:seq_poll()) and (os.clock() < time + 1) do end
+	local tokens = input:seq_to_tokens(input:seq_poll_final())
+	manager:machine():popmessage()
+	manager:machine():video():frame_update(true)
+
+	local final_token = nil
+	for token in tokens:gmatch('%S+') do
+		final_token = token
+	end
+	return final_token and input:code_from_token(final_token) or nil
+end
+
+local function handle_configure_menu(index, event)
+	-- Input
+	if index == 1 then
+		if event == 'select' then
+			table.insert(menu_stack, MENU_TYPES.BUTTON)
+			return true
+		else
+			return false
+		end
+	-- Hotkey
+	elseif index == 2 then
+		if event == 'select' then
+			local keycode = poll_for_hotkey()
+			if keycode then
+				current_button.key = keycode
+				return true
+			else
+				return false
+			end
+		else
+			return false
+		end
+	-- On frames
+	elseif index == 3 then
+		if event == 'left' then
+			current_button.on_frames = current_button.on_frames - 1
+		elseif event == 'right' then
+			current_button.on_frames = current_button.on_frames + 1
+		end
+	-- Off frames
+	elseif index == 4 then
+		if event == 'left' then
+			current_button.off_frames = current_button.off_frames - 1
+		elseif event == 'right' then
+			current_button.off_frames = current_button.off_frames + 1
+		end
+	end
+	return true
+end
+
+local function populate_edit_menu()
+	local menu = {}
+	menu[#menu + 1] = {_('Edit autofire button'), '', 'off'}
+	menu[#menu + 1] = {'---', '', ''}
+	header_height = #menu
+
+	populate_configure_menu(menu)
+	content_height = #menu
+
+	menu[#menu + 1] = {'---', '', ''}
+	menu[#menu + 1] = {_('Done'), '', ''}
+	return menu
+end
+
+local function handle_edit_menu(index, event, buttons)
+	local section, adjusted_index = menu_section(index)
+	if section == MENU_SECTIONS.CONTENT then
+		return handle_configure_menu(adjusted_index, event)
+	elseif section == MENU_SECTIONS.FOOTER then
+		if event == 'select' then
+			table.remove(menu_stack)
+			return true
+		end
+	end
+	return false
+end
+
+local function populate_add_menu()
+	local menu = {}
+	menu[#menu + 1] = {_('Add autofire button'), '', 'off'}
+	menu[#menu + 1] = {'---', '', ''}
+	header_height = #menu
+
+	populate_configure_menu(menu)
+	content_height = #menu
+
+	menu[#menu + 1] = {'---', '', ''}
+	if is_button_complete(current_button) then
+		menu[#menu + 1] = {_('Create'), '', ''}
+	else
+		menu[#menu + 1] = {_('Cancel'), '', ''}
+	end
+	return menu
+end
+
+local function handle_add_menu(index, event, buttons)
+	local section, adjusted_index = menu_section(index)
+	if section == MENU_SECTIONS.CONTENT then
+		return handle_configure_menu(adjusted_index, event)
+	elseif section == MENU_SECTIONS.FOOTER then
+		if event == 'select' then
+			table.remove(menu_stack)
+			if is_button_complete(current_button) then
+				buttons[#buttons + 1] = current_button
+			end
+			return true
+		end
+	end
+	return false
+end
+
+-- Button selection menu
+
+local function populate_button_menu()
+	menu = {}
+	inputs = {}
+	menu[#menu + 1] = {_('Select an input for autofire'), '', 'off'}
+	menu[#menu + 1] = {'---', '', ''}
+	header_height = #menu
+
+	for port_key, port in pairs(manager:machine():ioport().ports) do
+		for field_key, field in pairs(port.fields) do
+			if is_supported_input(field) then
+				menu[#menu + 1] = {field.name, '', ''}
+				inputs[#inputs + 1] = {
+					port_name = port_key,
+					field_name = field_key,
+					ioport_field = field
+				}
+			end
+		end
+	end
+	content_height = #menu
+	return menu
+end
+
+local function handle_button_menu(index, event)
+	local section, adjusted_index = menu_section(index)
+	if section == MENU_SECTIONS.CONTENT and event == 'select' then
+		local selected_input = inputs[adjusted_index]
+		current_button.port = selected_input.port_name
+		current_button.field = selected_input.field_name
+		current_button.button = selected_input.ioport_field
+		table.remove(menu_stack)
+		return true
+	end
+	return false
+end
+
+function lib:populate_menu(buttons)
+	local current_menu = menu_stack[#menu_stack]
+	if current_menu == MENU_TYPES.MAIN then
+		return populate_main_menu(buttons)
+	elseif current_menu == MENU_TYPES.EDIT then
+		return populate_edit_menu()
+	elseif current_menu == MENU_TYPES.ADD then
+		return populate_add_menu()
+	elseif current_menu == MENU_TYPES.BUTTON then
+		return populate_button_menu()
+	end
+end
+
+function lib:handle_menu_event(index, event, buttons)
+	local current_menu = menu_stack[#menu_stack]
+	if current_menu == MENU_TYPES.MAIN then
+		return handle_main_menu(index, event, buttons)
+	elseif current_menu == MENU_TYPES.EDIT then
+		return handle_edit_menu(index, event, buttons)
+	elseif current_menu == MENU_TYPES.ADD then
+		return handle_add_menu(index, event, buttons)
+	elseif current_menu == MENU_TYPES.BUTTON then
+		return handle_button_menu(index, event)
+	end
+end
+
+return lib

--- a/plugins/autofire/autofire_save.lua
+++ b/plugins/autofire/autofire_save.lua
@@ -10,13 +10,14 @@ end
 
 local function initialize_button(settings)
 	if settings.port and settings.field and settings.key and settings.on_frames and settings.off_frames then
-		local new_button = {}
-		new_button.port = settings.port
-		new_button.field = settings.field
-		new_button.key = manager:machine():input():code_from_token(settings.key)
-		new_button.on_frames = settings.on_frames
-		new_button.off_frames = settings.off_frames
-		new_button.counter = 0
+		local new_button = {
+			port = settings.port,
+			field = settings.field,
+			key = manager:machine():input():code_from_token(settings.key),
+			on_frames = settings.on_frames,
+			off_frames = settings.off_frames,
+			counter = 0
+		}
 		local port = manager:machine():ioport().ports[settings.port]
 		if port then
 			local field = port.fields[settings.field]
@@ -32,12 +33,13 @@ end
 local function serialize_settings(button_list)
 	local settings = {}
 	for index, button in ipairs(button_list) do
-		setting = {}
-		setting.port = button.port
-		setting.field = button.field
-		setting.key = manager:machine():input():code_to_token(button.key)
-		setting.on_frames = button.on_frames
-		setting.off_frames = button.off_frames
+		setting = {
+			port = button.port,
+			field = button.field,
+			key = manager:machine():input():code_to_token(button.key),
+			on_frames = button.on_frames,
+			off_frames = button.off_frames
+		}
 		settings[#settings + 1] = setting
 	end
 	return settings

--- a/plugins/autofire/autofire_save.lua
+++ b/plugins/autofire/autofire_save.lua
@@ -1,0 +1,84 @@
+local lib = {}
+
+local function get_settings_path()
+	return lfs.env_replace(manager:machine():options().entries.pluginspath:value():match('([^;]+)')) .. '/autofire/cfg/'
+end
+
+local function get_settings_filename()
+	return emu.romname() .. '.cfg'
+end
+
+local function initialize_button(settings)
+	if settings.port and settings.field and settings.key and settings.on_frames and settings.off_frames then
+		local new_button = {}
+		new_button.port = settings.port
+		new_button.field = settings.field
+		new_button.key = settings.key
+		new_button.on_frames = settings.on_frames
+		new_button.off_frames = settings.off_frames
+		new_button.counter = 0
+		local port = manager:machine():ioport().ports[settings.port]
+		if port then
+			local field = port.fields[settings.field]
+			if field then
+				new_button.button = field
+				return new_button
+			end
+		end
+	end
+	return nil
+end
+
+local function serialize_settings(button_list)
+	local settings = {}
+	for index, button in ipairs(button_list) do
+		setting = {}
+		setting.port = button.port
+		setting.field = button.field
+		setting.key = button.key
+		setting.on_frames = button.on_frames
+		setting.off_frames = button.off_frames
+		settings[#settings + 1] = setting
+	end
+	return settings
+end
+
+function lib:load_settings()
+	local buttons = {}
+	local json = require('json')
+	local file = io.open(get_settings_path() .. get_settings_filename(), 'r')
+	if not file then
+		return buttons
+	end
+	local loaded_settings = json.parse(file:read('a'))
+	file:close()
+	if not loaded_settings then
+		return buttons
+	end
+	for index, button_settings in ipairs(loaded_settings) do
+		local new_button = initialize_button(button_settings)
+		if new_button then
+			buttons[#buttons + 1] = new_button
+		end
+	end
+	return buttons
+end
+
+function lib:save_settings(buttons)
+	local path = get_settings_path()
+	local attr = lfs.attributes(path)
+	if not attr then
+		lfs.mkdir(path)
+	elseif attr.mode ~= 'directory' then
+		return
+	end
+	local json = require('json')
+	local settings = serialize_settings(buttons)
+	local file = io.open(path .. get_settings_filename(), 'w')
+	if file then
+		file:write(json.stringify(settings, {indent = true}))
+		file:close()
+	end
+end
+
+return lib

--- a/plugins/autofire/autofire_save.lua
+++ b/plugins/autofire/autofire_save.lua
@@ -13,7 +13,7 @@ local function initialize_button(settings)
 		local new_button = {}
 		new_button.port = settings.port
 		new_button.field = settings.field
-		new_button.key = settings.key
+		new_button.key = manager:machine():input():code_from_token(settings.key)
 		new_button.on_frames = settings.on_frames
 		new_button.off_frames = settings.off_frames
 		new_button.counter = 0
@@ -35,7 +35,7 @@ local function serialize_settings(button_list)
 		setting = {}
 		setting.port = button.port
 		setting.field = button.field
-		setting.key = button.key
+		setting.key = manager:machine():input():code_to_token(button.key)
 		setting.on_frames = button.on_frames
 		setting.off_frames = button.off_frames
 		settings[#settings + 1] = setting

--- a/plugins/autofire/init.lua
+++ b/plugins/autofire/init.lua
@@ -56,83 +56,17 @@ function autofire.startplugin()
 		end
 	end
 
-	local function initialize_button(settings)
-		if settings.port and settings.field and settings.key and settings.on_frames and settings.off_frames then
-			local new_button = {}
-			new_button.port = settings.port
-			new_button.field = settings.field
-			new_button.key = settings.key
-			new_button.on_frames = settings.on_frames
-			new_button.off_frames = settings.off_frames
-			new_button.counter = 0
-			local port = manager:machine():ioport().ports[settings.port]
-			if port then
-				local field = port.fields[settings.field]
-				if field then
-					new_button.button = field
-					return new_button
-				end
-			end
-		end
-		return nil
-	end
-
-	local function get_settings_path()
-		return lfs.env_replace(manager:machine():options().entries.pluginspath:value():match('([^;]+)')) .. '/autofire/cfg/'
-	end
-
-	local function get_settings_filename()
-		return emu.romname() .. '.cfg'
-	end
-
 	local function load_settings()
-		buttons = {}
-		local json = require('json')
-		local file = io.open(get_settings_path() .. get_settings_filename(), 'r')
-		if not file then
-			return
+		local loader = require('autofire/autofire_save')
+		if loader then
+			buttons = loader:load_settings()
 		end
-		local loaded_settings = json.parse(file:read('a'))
-		file:close()
-		if not loaded_settings then
-			return
-		end
-		for index, button_settings in ipairs(loaded_settings) do
-			local new_button = initialize_button(button_settings)
-			if new_button then
-				buttons[#buttons + 1] = new_button
-			end
-		end
-	end
-
-	local function serialize_settings(button_list)
-		local settings = {}
-		for index, button in ipairs(button_list) do
-			setting = {}
-			setting.port = button.port
-			setting.field = button.field
-			setting.key = button.key
-			setting.on_frames = button.on_frames
-			setting.off_frames = button.off_frames
-			settings[#settings + 1] = setting
-		end
-		return settings
 	end
 
 	local function save_settings()
-		local path = get_settings_path()
-		local attr = lfs.attributes(path)
-		if not attr then
-			lfs.mkdir(path)
-		elseif attr.mode ~= 'directory' then
-			return
-		end
-		local json = require('json')
-		local settings = serialize_settings(buttons)
-		local file = io.open(path .. get_settings_filename(), 'w')
-		if file then
-			file:write(json.stringify(settings, {indent = true}))
-			file:close()
+		local saver = require('autofire/autofire_save')
+		if saver then
+			saver:save_settings(buttons)
 		end
 	end
 

--- a/plugins/autofire/init.lua
+++ b/plugins/autofire/init.lua
@@ -1,0 +1,40 @@
+-- license:BSD-3-Clause
+-- copyright-holders:Jack Li
+local exports = {}
+exports.name = "autofire"
+exports.version = "0.0.1"
+exports.description = "Autofire plugin"
+exports.license = "The BSD 3-Clause License"
+exports.author = { name = "Jack Li" }
+
+local autofire = exports
+
+function autofire.startplugin()
+	local key = 'KEYCODE_Q'
+	local on_frames = 1
+	local off_frames = 60
+	local counter = 0
+
+	local function per_frame()
+		if emu.romname() == '___empty' then
+			return
+		end
+		if manager:machine().paused then
+			return
+		end
+		local keycode = manager:machine():input():code_from_token(key)
+		local pressed = manager:machine():input():code_pressed(keycode)
+		local p1b1 = manager:machine():ioport().ports[':P1'].fields['P1 Button 1']
+		if pressed then
+			p1b1:set_value(counter < on_frames and 1 or 0)
+			counter = (counter + 1) % (on_frames + off_frames)
+		else
+			counter = 0
+			p1b1:set_value(0)
+		end
+	end
+
+	emu.register_frame(per_frame)
+end
+
+return exports

--- a/plugins/autofire/init.lua
+++ b/plugins/autofire/init.lua
@@ -14,17 +14,15 @@ function autofire.startplugin()
 	-- List of autofire buttons, each being a table with keys:
 	--   'port' - port name of the button being autofired
 	--   'field' - field name of the button being autofired
-	--   'key' - token of the keybinding
+	--   'key' - input_code of the keybinding
 	--   'on_frames' - number of frames button is pressed
 	--   'off_frames' - number of frames button is released
-	--   'button' - reference to ioport_field (not persisted)
-	--   'counter' - position in autofire cycle (not persisted)
-	-- port, field, key, on_frames, and off_frames are loaded from/saved to a file on start/stop.
+	--   'button' - reference to ioport_field
+	--   'counter' - position in autofire cycle
 	local buttons = {}
 
 	local function process_button(button)
-		local keycode = manager:machine():input():code_from_token(button.key)
-		local pressed = manager:machine():input():code_pressed(keycode)
+		local pressed = manager:machine():input():code_pressed(button.key)
 		if pressed then
 			local state = button.counter < button.on_frames and 1 or 0
 			button.counter = (button.counter + 1) % (button.on_frames + button.off_frames)

--- a/plugins/autofire/init.lua
+++ b/plugins/autofire/init.lua
@@ -10,28 +10,83 @@ exports.author = { name = "Jack Li" }
 local autofire = exports
 
 function autofire.startplugin()
-	local key = 'KEYCODE_Q'
-	local on_frames = 1
-	local off_frames = 60
-	local counter = 0
 
-	local function per_frame()
-		if emu.romname() == '___empty' then
-			return
-		end
-		local keycode = manager:machine():input():code_from_token(key)
+	-- List of autofire buttons, each being a table with keys:
+	--   'port' - port name of the button being autofired
+	--   'field' - field name of the button being autofired
+	--   'key' - token of the keybinding
+	--   'on_frames' - number of frames button is pressed
+	--   'off_frames' - number of frames button is released
+	--   'button' - reference to ioport_field (not persisted)
+	--   'counter' - position in autofire cycle (not persisted)
+	-- port, field, key, on_frames, and off_frames are loaded from/saved to a file on start/stop.
+	local buttons = {}
+
+	local function process_button(button)
+		local keycode = manager:machine():input():code_from_token(button.key)
 		local pressed = manager:machine():input():code_pressed(keycode)
-		local p1b1 = manager:machine():ioport().ports[':P1'].fields['P1 Button 1']
 		if pressed then
-			p1b1:set_value(counter < on_frames and 1 or 0)
-			counter = (counter + 1) % (on_frames + off_frames)
+			button.button:set_value(button.counter < button.on_frames and 1 or 0)
+			button.counter = (button.counter + 1) % (button.on_frames + button.off_frames)
 		else
-			counter = 0
-			p1b1:set_value(0)
+			button.counter = 0
+			button.button:set_value(0)
 		end
 	end
 
-	emu.register_frame_done(per_frame)
+	local function process_frame()
+		for i, button in ipairs(buttons) do
+			process_button(button)
+		end
+	end
+
+	local function initialize_button(settings)
+		if settings.port and settings.field and settings.key and settings.on_frames and settings.off_frames then
+			local new_button = {}
+			new_button.port = settings.port
+			new_button.field = settings.field
+			new_button.key = settings.key
+			new_button.on_frames = settings.on_frames
+			new_button.off_frames = settings.off_frames
+			new_button.counter = 0
+			local port = manager:machine():ioport().ports[settings.port]
+			if port then
+				local field = port.fields[settings.field]
+				if field then
+					new_button.button = field
+					return new_button
+				end
+			end
+		end
+		return nil
+	end
+
+	local function load_settings()
+		buttons = {}
+		local json = require('json')
+		local file = io.open(lfs.env_replace(manager:machine():options().entries.pluginspath:value():match("([^;]+)")) .. "/autofire/cfg/" .. emu.romname() .. ".cfg", "r")
+		if not file then
+			return
+		end
+		local loaded_settings = json.parse(file:read('a'))
+		if not loaded_settings then
+			return
+		end
+		for index, button_settings in ipairs(loaded_settings) do
+			local new_button = initialize_button(button_settings)
+			if new_button then
+				buttons[#buttons + 1] = new_button
+			end
+		end
+	end
+
+	local function save_settings()
+		print('saving settings')
+	end
+
+	emu.register_frame_done(process_frame)
+	emu.register_start(load_settings)
+	emu.register_stop(save_settings)
 end
 
 return exports

--- a/plugins/autofire/init.lua
+++ b/plugins/autofire/init.lua
@@ -19,9 +19,6 @@ function autofire.startplugin()
 		if emu.romname() == '___empty' then
 			return
 		end
-		if manager:machine().paused then
-			return
-		end
 		local keycode = manager:machine():input():code_from_token(key)
 		local pressed = manager:machine():input():code_pressed(keycode)
 		local p1b1 = manager:machine():ioport().ports[':P1'].fields['P1 Button 1']
@@ -34,7 +31,7 @@ function autofire.startplugin()
 		end
 	end
 
-	emu.register_frame(per_frame)
+	emu.register_frame_done(per_frame)
 end
 
 return exports

--- a/plugins/autofire/init.lua
+++ b/plugins/autofire/init.lua
@@ -1,11 +1,11 @@
 -- license:BSD-3-Clause
 -- copyright-holders:Jack Li
 local exports = {}
-exports.name = "autofire"
-exports.version = "0.0.1"
-exports.description = "Autofire plugin"
-exports.license = "The BSD 3-Clause License"
-exports.author = { name = "Jack Li" }
+exports.name = 'autofire'
+exports.version = '0.0.1'
+exports.description = 'Autofire plugin'
+exports.license = 'The BSD 3-Clause License'
+exports.author = { name = 'Jack Li' }
 
 local autofire = exports
 
@@ -78,7 +78,7 @@ function autofire.startplugin()
 	end
 
 	local function get_settings_path()
-		return lfs.env_replace(manager:machine():options().entries.pluginspath:value():match("([^;]+)")) .. "/autofire/cfg/"
+		return lfs.env_replace(manager:machine():options().entries.pluginspath:value():match('([^;]+)')) .. '/autofire/cfg/'
 	end
 
 	local function get_settings_filename()

--- a/plugins/autofire/init.lua
+++ b/plugins/autofire/init.lua
@@ -68,9 +68,28 @@ function autofire.startplugin()
 		end
 	end
 
+	local function menu_callback(index, event)
+		local menu_handler = require('autofire/autofire_menu')
+		if menu_handler then
+			return menu_handler:handle_menu_event(index, event, buttons)
+		else
+			return false
+		end
+	end
+
+	local function menu_populate()
+		local menu_handler = require('autofire/autofire_menu')
+		if menu_handler then
+			return menu_handler:populate_menu(buttons)
+		else
+			return {{_('Failed to load autofire menu'), '', ''}}
+		end
+	end
+
 	emu.register_frame_done(process_frame)
 	emu.register_start(load_settings)
 	emu.register_stop(save_settings)
+	emu.register_menu(menu_callback, menu_populate, _('Autofire'))
 end
 
 return exports

--- a/plugins/autofire/plugin.json
+++ b/plugins/autofire/plugin.json
@@ -1,0 +1,10 @@
+{
+  "plugin": {
+	"name": "autofire",
+	"description": "Autofire plugin",
+	"version": "0.0.1",
+	"author": "Jack Li",
+	"type": "plugin",
+	"start": "false"
+  }
+}


### PR DESCRIPTION
This is a plugin I wrote to provide autofire/turbo functionality in MAME. MAME already has a built-in autofire feature accessed through the cheats menu, but this implementation contains extra features/flexibility, including:
- Saving and loading autofire settings (saves a config file per rom so autofire settings will be remembered the next time you load the rom)
- Separate buttons for autofire and non-autofire
- Individual autofire rates per button (e.g. one button for 30 Hz autofire and another for 15 Hz). The number of frames to hold the button and the number of frames to release the button are individually customizable.

Note: One potential point of confusion is that the autofire keybindings are managed in the menu provided by the plugin, separate from the regular input menu. It's possible to assign an autofire button to the same key as its non-autofire equivalent, in which case holding the key will cause the non-autofire button to win out and you won't get autofire.