### PR TITLE
A2 WOZ and clean cracked updates for May 14th 2019 (nw)

### DIFF
--- a/hash/apple2_flop_clcracked.xml
+++ b/hash/apple2_flop_clcracked.xml
@@ -2460,17 +2460,19 @@
 		<year>1986</year>
 		<publisher>Davidson &amp; Associates, Inc.</publisher>
 		<!-- No compatibility data known at this time. -->
+		<!-- On May 10th, 2019, updated disk image from new source to fix some
+		minor data corruption	on side A, track $1C -->
 
 		<part name="flop1" interface="floppy_5_25">
 			<feature name="part_id" value="Side A"/>
 			<dataarea name="flop" size="143360">
-				<rom name="grammar gremlins (4am crack) side a.dsk" size="143360" crc="6c8489fa" sha1="38428a2f090900660fa4ff581e770004b71ad801" />
+				<rom name="grammar gremlins (4am crack) side a.dsk" size="143360" crc="31adc94a" sha1="40527334a0d59281b6559f2464018fae8fc807ac" />
 			</dataarea>
 		</part>
 		<part name="flop2" interface="floppy_5_25">
 			<feature name="part_id" value="Side B"/>
 			<dataarea name="flop" size="143360">
-				<rom name="grammar gremlins (4am crack) side b.dsk" size="143360" crc="b07ee7b3" sha1="0c4171e8a85bd5627a8c3a25da4c29cc68c2038b" />
+				<rom name="grammar gremlins (4am crack) side b.dsk" size="143360" crc="21e242be" sha1="1f922b9c30bea0d4a9e2bdbdb66d67da8bd361f8" />
 			</dataarea>
 		</part>
 	</software>

--- a/hash/apple2_flop_clcracked.xml
+++ b/hash/apple2_flop_clcracked.xml
@@ -1365,6 +1365,7 @@
 		</part>
 	</software>
 
+<<<<<<< HEAD
 	<software name="casemisc">
 		<description>Case of the Missing Chick (cleanly cracked)</description>
 		<year>1986</year>
@@ -1378,6 +1379,8 @@
 		</part>
 	</software>
 
+=======
+>>>>>>> Correct duplicate entry, redumped images, set name adjustments (nw)
 	<software name="catmouse">
 		<description>Cat 'n Mouse (cleanly cracked)</description>
 		<year>1986</year>
@@ -2460,19 +2463,39 @@
 		<year>1986</year>
 		<publisher>Davidson &amp; Associates, Inc.</publisher>
 		<!-- No compatibility data known at this time. -->
+
+		<part name="flop1" interface="floppy_5_25">
+			<feature name="part_id" value="Side A"/>
+			<dataarea name="flop" size="143360">
+				<rom name="grammar gremlins (4am crack) side a.dsk" size="143360" crc="6c8489fa" sha1="38428a2f090900660fa4ff581e770004b71ad801" />
+			</dataarea>
+		</part>
+		<part name="flop2" interface="floppy_5_25">
+			<feature name="part_id" value="Side B"/>
+			<dataarea name="flop" size="143360">
+				<rom name="grammar gremlins (4am crack) side b.dsk" size="143360" crc="b07ee7b3" sha1="0c4171e8a85bd5627a8c3a25da4c29cc68c2038b" />
+			</dataarea>
+		</part>
+	</software>
+
+	<software name="gramgr87">
+		<description>Grammar Gremlins (1987) (cleanly cracked)</description>
+		<year>1987</year>
+		<publisher>Davidson &amp; Associates, Inc.</publisher>
+		<!-- No compatibility data known at this time. -->
 		<!-- On May 10th, 2019, updated disk image from new source to fix some
 		minor data corruption	on side A, track $1C -->
 
 		<part name="flop1" interface="floppy_5_25">
 			<feature name="part_id" value="Side A"/>
 			<dataarea name="flop" size="143360">
-				<rom name="grammar gremlins (4am crack) side a.dsk" size="143360" crc="31adc94a" sha1="40527334a0d59281b6559f2464018fae8fc807ac" />
+				<rom name="grammar gremlins 1987 (4am crack) side a.dsk" size="143360" crc="31adc94a" sha1="40527334a0d59281b6559f2464018fae8fc807ac" />
 			</dataarea>
 		</part>
 		<part name="flop2" interface="floppy_5_25">
 			<feature name="part_id" value="Side B"/>
 			<dataarea name="flop" size="143360">
-				<rom name="grammar gremlins (4am crack) side b.dsk" size="143360" crc="21e242be" sha1="1f922b9c30bea0d4a9e2bdbdb66d67da8bd361f8" />
+				<rom name="grammar gremlins 1987 (4am crack) side b.dsk" size="143360" crc="21e242be" sha1="1f922b9c30bea0d4a9e2bdbdb66d67da8bd361f8" />
 			</dataarea>
 		</part>
 	</software>
@@ -4986,7 +5009,7 @@
 		</part>
 	</software>
 
-	<software name="berserkerraids">
+	<software name="berraids">
 		<description>Berserker Raids (cleanly cracked)</description>
 		<year>1983</year>
 		<publisher>Berserker Works</publisher>
@@ -6068,7 +6091,7 @@
 		</part>
 	</software>
 
-	<software name="clozethink">
+	<software name="clozthnk">
 		<description>Cloze Thinking (cleanly cracked)</description>
 		<year>1985</year>
 		<publisher>A/V Concepts Corp.</publisher>
@@ -6092,7 +6115,7 @@
 		</part>
 	</software>
 
-	<software name="clozereadc">
+	<software name="clzreadc">
 		<description>Clozed Reading Comprehension (cleanly cracked)</description>
 		<year>1985</year>
 		<publisher>Queue</publisher>

--- a/hash/apple2_flop_clcracked.xml
+++ b/hash/apple2_flop_clcracked.xml
@@ -6745,50 +6745,91 @@
 		<!-- No compatibility data known at this time. -->
 
 		<part name="flop1" interface="floppy_5_25">
+			<feature name="part_id" value="Disk 1 - Associated nouns"/>
 			<dataarea name="flop" size="143360">
 				<rom name="computerized reading for aphasics (4am crack) disk 1 - associated nouns.dsk" size="143360" crc="f1a01aa0" sha1="3495ec57e11c6190c46a50f42f62c4a5e6a4bc4d" />
 			</dataarea>
 		</part>
 		<part name="flop2" interface="floppy_5_25">
+			<feature name="part_id" value="Disk 2 - Categories"/>
 			<dataarea name="flop" size="143360">
 				<rom name="computerized reading for aphasics (4am crack) disk 2 - categories.dsk" size="143360" crc="6f36bcdd" sha1="e4648d1bce5ffb5e69bf0ccceaa6f97efa368820" />
 			</dataarea>
 		</part>
 		<part name="flop3" interface="floppy_5_25">
+			<feature name="part_id" value="Disk 3 - Modifiers"/>
 			<dataarea name="flop" size="143360">
 				<rom name="computerized reading for aphasics (4am crack) disk 3 - modifiers.dsk" size="143360" crc="81f40b72" sha1="5c2f1c5d3ed4258e1027a8000b9968faf3f46e51" />
 			</dataarea>
 		</part>
 		<part name="flop4" interface="floppy_5_25">
+			<feature name="part_id" value="Disk 4 - Synonyms"/>
 			<dataarea name="flop" size="143360">
 				<rom name="computerized reading for aphasics (4am crack) disk 4 - synonyms.dsk" size="143360" crc="ec2269ef" sha1="12316fcbb24bf237eb58166980e2c12dc3d9fa5d" />
 			</dataarea>
 		</part>
 		<part name="flop5" interface="floppy_5_25">
+			<feature name="part_id" value="Disk 5 - Antonyms"/>
 			<dataarea name="flop" size="143360">
 				<rom name="computerized reading for aphasics (4am crack) disk 5 - antonyms.dsk" size="143360" crc="9bfb9dee" sha1="a0da31699c0b05d188eaf9bcc145ba70e9d216a8" />
 			</dataarea>
 		</part>
 		<part name="flop6" interface="floppy_5_25">
+			<feature name="part_id" value="Disk 6 - Non-associated nouns"/>
 			<dataarea name="flop" size="143360">
 				<rom name="computerized reading for aphasics (4am crack) disk 6 - non-associated nouns.dsk" size="143360" crc="d236a387" sha1="66c5ac4d58787c22a9985359d494a602b1fdd477" />
 			</dataarea>
 		</part>
 		<part name="flop7" interface="floppy_5_25">
+			<feature name="part_id" value="Disk 7 - Closure"/>
 			<dataarea name="flop" size="143360">
 				<rom name="computerized reading for aphasics (4am crack) disk 7 - closure.dsk" size="143360" crc="eaddca8e" sha1="ed876474a2ab6cb78f9aba3f8b96f127f0705567" />
 			</dataarea>
 		</part>
 		<part name="flop8" interface="floppy_5_25">
+			<feature name="part_id" value="Disk 8 - Yes/No Questions"/>
 			<dataarea name="flop" size="143360">
 				<rom name="computerized reading for aphasics (4am crack) disk 8 - yes-no questions.dsk" size="143360" crc="615850be" sha1="b0eba97c4f6494400bc447a9751b18e76ea615fd" />
 			</dataarea>
 		</part>
 		<part name="flop9" interface="floppy_5_25">
+			<feature name="part_id" value="Disk 9 - Definitions"/>
 			<dataarea name="flop" size="143360">
 				<rom name="computerized reading for aphasics (4am crack) disk 9 - definitions.dsk" size="143360" crc="c13b6285" sha1="d4579e3fa09fb2d3989354238b9b4ae0cb69eb7f" />
 			</dataarea>
 		</part>
 	</software>
 
+	<software name="7ctygold">
+		<description>Seven Cities of Gold (cleanly cracked)</description>
+		<year>1984</year>
+		<publisher>Electronic Arts</publisher>
+		<info name="release" value="2017-03-02"/>
+
+		<part name="flop1" interface="floppy_5_25">
+			<feature name="part_id" value="Side A"/>
+			<dataarea name="flop" size="143360">
+				<rom name="seven cities of gold (4am and san inc crack) side a.dsk" size="143360" crc="f9566cfe" sha1="ed194e27de65d7ec89e59834ceab579f92735900" offset="0x0000" />
+			</dataarea>
+		</part>
+		<part name="flop2" interface="floppy_5_25">
+			<feature name="part_id" value="Side B"/>
+			<dataarea name="flop" size="143360">
+				<rom name="seven cities of gold (4am and san inc crack) side b.dsk" size="143360" crc="5456b895" sha1="4fc6b15de84729ee06594b485e28b8da647f506b" offset="0x0000" />
+			</dataarea>
+		</part>
+	</software>
+
+	<software name="stkybpr2">
+		<description>Stickybear Printer (Revision 2) (cleanly cracked)</description>
+		<year>1985</year>
+		<publisher>Optimum Resource</publisher>
+		<info name="release" value="2017-11-06"/>
+
+		<part name="flop1" interface="floppy_5_25">
+			<dataarea name="flop" size="143360">
+				<rom name="stickybear printer rev. 2 (4am crack).dsk" size="143360" crc="692399fc" sha1="ceb1b6572b82e064a3ead8a3f61b41239d3bf4bd" offset="0x0000" />
+			</dataarea>
+		</part>
+	</software>
 </softwarelist>

--- a/hash/apple2_flop_orig.xml
+++ b/hash/apple2_flop_orig.xml
@@ -4463,4 +4463,244 @@
 		</part>
 	</software>
 
+	<software name="msadvent">
+		<description>Microsoft Adventure</description>
+		<year>1980</year>
+		<publisher>Microsoft</publisher>
+		<info name="release" value="2019-04-12"/>
+		<sharedfeat name="compatibility" value="A2,A2P,A2E,A2EE,A2C,A2GS" />
+		<!-- It requires a 13-sector drive but otherwise runs on any
+		Apple II with 32K.-->
+
+		<part name="flop1" interface="floppy_5_25">
+			<dataarea name="flop" size="234771">
+				<rom name="Microsoft Adventure.woz" size="234771" crc="6e623593" sha1="d52f0a3b95a386875cb3691f5471e8c14440ccb8" offset="0x0000" />
+			</dataarea>
+		</part>
+	</software>
+
+	<software name="mcinvadr">
+		<description>Micro Invaders</description>
+		<year>1979</year>
+		<publisher>Programma Software</publisher>
+		<info name="release" value="2019-04-13"/>
+		<sharedfeat name="compatibility" value="A2,A2P,A2E,A2EE,A2C,A2GS" />
+		<!-- It requires a 13-sector drive but otherwise runs on any
+		Apple II with 32K.-->
+
+		<part name="flop1" interface="floppy_5_25">
+			<dataarea name="flop" size="234781">
+				<rom name="Micro Invaders.woz" size="234781" crc="28ae8795" sha1="f18c23182c56da29e657f0f53f16f65a3a64e33d" offset="0x0000" />
+			</dataarea>
+		</part>
+	</software>
+
+	<software name="blballmb">
+		<description>Blister Ball and Mad Bomber</description>
+		<year>1981</year>
+		<publisher>Creative Computing Software</publisher>
+		<info name="release" value="2019-04-16"/>
+		<sharedfeat name="compatibility" value="A2,A2P,A2E,A2EE,A2C,A2GS" />
+		<!-- It requires a 13-sector drive but otherwise runs on any
+		Apple II with 48K.-->
+
+		<part name="flop1" interface="floppy_5_25">
+			<dataarea name="flop" size="234789">
+				<rom name="Blisterball and Mad Bomber.woz" size="234789" crc="464e6b8d" sha1="f4ac813e979ea5c0e9b476a57063b37c25713d46" offset="0x0000" />
+			</dataarea>
+		</part>
+	</software>
+
+	<software name="mstypetr">
+		<description>Typing Tutor</description>
+		<year>1979</year>
+		<publisher>Microsoft</publisher>
+		<info name="release" value="2019-04-16"/>
+		<sharedfeat name="compatibility" value="A2,A2P,A2E,A2EE,A2C,A2GS" />
+		<!-- It requires a 13-sector drive but otherwise runs on any
+		Apple II with 48K. -->
+
+		<part name="flop1" interface="floppy_5_25">
+			<dataarea name="flop" size="234810">
+				<rom name="Typing Tutor.woz" size="234810" crc="58306c14" sha1="b056c2772643d89336a6ee9894b5dfbd411f53f1" offset="0x0000" />
+			</dataarea>
+		</part>
+	</software>
+
+	<software name="spwarior">
+		<description>Space Warrior</description>
+		<year>1981</year>
+		<publisher>Broderbund Software</publisher>
+		<info name="release" value="2019-04-20"/>
+		<sharedfeat name="compatibility" value="A2,A2P,A2E,A2EE,A2C,A2GS" />
+		<!-- It runs on any Apple II with 32K. -->
+
+		<part name="flop1" interface="floppy_5_25">
+			<dataarea name="flop" size="61721">
+				<rom name="Space Warrior.woz" size="61721" crc="e0b4e0ed" sha1="96cd4e7ba3e49c48d29987fec219f452eb33b413" offset="0x0000" />
+			</dataarea>
+		</part>
+	</software>
+
+	<software name="crmcrown">
+		<description>The Crimson Crown</description>
+		<year>1985</year>
+		<publisher>Polarware</publisher>
+		<info name="release" value="2019-04-20"/>
+		<sharedfeat name="compatibility" value="A2P,A2E,A2EE,A2C,A2GS" />
+		<!-- It requires a 64K Apple ][+ or later. -->
+
+		<part name="flop1" interface="floppy_5_25">
+			<feature name="part_id" value="Side A"/>
+			<dataarea name="flop" size="234766">
+				<rom name="The Crimson Crown side A.woz" size="234766" crc="3ba098cb" sha1="039acb376d74b1079469af9b49ec0220d03f5318" offset="0x0000" />
+			</dataarea>
+		</part>
+		<part name="flop2" interface="floppy_5_25">
+			<feature name="part_id" value="Side B"/>
+			<dataarea name="flop" size="234766">
+				<rom name="The Crimson Crown side B.woz" size="234766" crc="d158deed" sha1="e02ca1c7af89f56efe1d6767c40963161dfbe926" offset="0x0000" />
+			</dataarea>
+		</part>
+	</software>
+
+	<software name="zyhearts">
+		<description>Zykron Hearts</description>
+		<year>1986</year>
+		<publisher> Zykron Company</publisher>
+		<info name="release" value="2019-04-20"/>
+		<sharedfeat name="compatibility" value="A2P,A2E,A2EE,A2C,A2GS" />
+		<!-- It requires a 48K Apple ][+ or later. -->
+
+		<part name="flop1" interface="floppy_5_25">
+			<dataarea name="flop" size="246767">
+				<rom name="Zykron Hearts.woz" size="246767" crc="5e55409f" sha1="342f513e287128acb67e0b839d815b143b43990c" offset="0x0000" />
+			</dataarea>
+		</part>
+	</software>
+
+	<software name="grush82">
+		<description>Gold Rush (1982) (Sentient Software)</description>
+		<year>1982</year>
+		<publisher>Sentient Software</publisher>
+		<info name="release" value="2019-04-20"/>
+		<sharedfeat name="compatibility" value="A2,A2P,A2E,A2EE,A2C,A2GS" />
+		<!-- It runs on any Apple II with 48K. -->
+
+		<part name="flop1" interface="floppy_5_25">
+			<dataarea name="flop" size="208162">
+				<rom name="Gold Rush.woz" size="208162" crc="e8ee2a66" sha1="68b196839e56d49a451adf216591754fb45618a4" offset="0x0000" />
+			</dataarea>
+		</part>
+	</software>
+
+	<software name="prshcomp">
+		<description>The Print Shop Companion (Version 1.2)</description>
+		<year>1985</year>
+		<publisher>Broderbund Software</publisher>
+		<info name="release" value="2019-04-20"/>
+		<sharedfeat name="compatibility" value="A2P,A2E,A2EE,A2C,A2GS" />
+		<!-- It requires a 64K Apple ][+ or later. -->
+		<!-- This is the final version produced for the Apple II. -->
+
+		<part name="flop1" interface="floppy_5_25">
+			<dataarea name="flop" size="234794">
+				<rom name="The Print Shop Companion v1.2 side A.woz" size="234794" crc="e8af250e" sha1="875f61ac89ec48ed450fb646e5eafd9a24233c4d" offset="0x0000" />
+			</dataarea>
+		</part>
+		<part name="flop2" interface="floppy_5_25">
+			<dataarea name="flop" size="234794">
+				<rom name="The Print Shop Companion v1.2 side B.woz" size="234794" crc="a06b52a9" sha1="1c6f461fbd4c78dd48480c334f0d5f1df2cf591e" offset="0x0000" />
+			</dataarea>
+		</part>
+	</software>
+
+	<software name="saadland">
+		<description>Adventureland (Version 2.0/416)</description>
+		<year>1982</year>
+		<publisher>Adventure International</publisher>
+		<info name="release" value="2019-04-23"/>
+		<sharedfeat name="compatibility" value="A2P,A2E,A2EE,A2C,A2GS" />
+		<!-- It requires a 48K Apple ][+ or later.-->
+
+		<part name="flop1" interface="floppy_5_25">
+			<feature name="part_id" value="Side A"/>
+			<dataarea name="flop" size="234839">
+				<rom name="S.A.G.A. 1 - Adventureland side A.woz" size="234839" crc="cb8da55c" sha1="3e2f79d3c52d6e97510aac3ced977c60eb6b5360" offset="0x0000" />
+			</dataarea>
+		</part>
+		<part name="flop2" interface="floppy_5_25">
+			<feature name="part_id" value="Side B - Boot Disk"/>
+			<dataarea name="flop" size="234839">
+				<rom name="S.A.G.A. 1 - Adventureland side B (boot).woz" size="234839" crc="83cb42a3" sha1="a50127f7650549b4e73bb5a2e718ceefc456a232" offset="0x0000" />
+			</dataarea>
+		</part>
+	</software>
+
+	<software name="sapiradv">
+		<description>Pirate Adventure (Version 2.1/408)</description>
+		<year>1982</year>
+		<publisher>Adventure International</publisher>
+		<info name="release" value="2019-04-23"/>
+		<sharedfeat name="compatibility" value="A2P,A2E,A2EE,A2C,A2GS" />
+		<!-- It requires a 48K Apple ][+ or later.-->
+
+		<part name="flop1" interface="floppy_5_25">
+			<feature name="part_id" value="Side A"/>
+			<dataarea name="flop" size="234855">
+				<rom name="S.A.G.A. 2 - Pirate Adventure side A.woz" size="234855" crc="e1d89cb0" sha1="a1d672605f4b3bb4585f13824fc521b0681b3d89" offset="0x0000" />
+			</dataarea>
+		</part>
+		<part name="flop2" interface="floppy_5_25">
+			<feature name="part_id" value="Side B - Boot Disk"/>
+			<dataarea name="flop" size="234855">
+				<rom name="S.A.G.A. 2 - Pirate Adventure side B (boot).woz" size="234855" crc="36443115" sha1="bbe23e9d3f21b389f41be4795d34b2c9c1c87208" offset="0x0000" />
+			</dataarea>
+		</part>
+	</software>
+
+	<software name="samisimp">
+		<description>Mission Impossible (Version 2.1/306)</description>
+		<year>1982</year>
+		<publisher>Adventure International</publisher>
+		<info name="release" value="2019-04-23"/>
+		<sharedfeat name="compatibility" value="A2P,A2E,A2EE,A2C,A2GS" />
+		<!-- It requires a 48K Apple ][+ or later.-->
+
+		<part name="flop1" interface="floppy_5_25">
+			<feature name="part_id" value="Side A"/>
+			<dataarea name="flop" size="234836">
+				<rom name="S.A.G.A. 3 - Mission Impossible side A.woz" size="234836" crc="6e0da536" sha1="dda47d2b1916803174a7b8d1dad23e0b428ff0d7" offset="0x0000" />
+			</dataarea>
+		</part>
+		<part name="flop2" interface="floppy_5_25">
+			<feature name="part_id" value="Side B - Boot Disk"/>
+			<dataarea name="flop" size="234836">
+				<rom name="S.A.G.A. 3 - Mission Impossible side B (boot).woz" size="234836" crc="b4c1cd26" sha1="4f68d858f02ebff83c115e06485ce78a7f47d8b9" offset="0x0000" />
+			</dataarea>
+		</part>
+	</software>
+
+	<software name="savoodoo">
+		<description>Voodoo Castle (Version 2.1/119)</description>
+		<year>1982</year>
+		<publisher>Adventure International</publisher>
+		<info name="release" value="2019-04-24"/>
+		<sharedfeat name="compatibility" value="A2P,A2E,A2EE,A2C,A2GS" />
+		<!-- It requires a 48K Apple ][+ or later.-->
+
+		<part name="flop1" interface="floppy_5_25">
+			<feature name="part_id" value="Side A"/>
+			<dataarea name="flop" size="234840">
+				<rom name="S.A.G.A. 4 - Voodoo Castle side A.woz" size="234840" crc="9922794b" sha1="a0ba732d20ae0f01f8a7237256c5e14fce74c9c6" offset="0x0000" />
+			</dataarea>
+		</part>
+		<part name="flop2" interface="floppy_5_25">
+			<feature name="part_id" value="Side B - Boot Disk"/>
+			<dataarea name="flop" size="234840">
+				<rom name="S.A.G.A. 4 - Voodoo Castle side B (boot).woz" size="234840" crc="00149d2f" sha1="ec747fef709fa8a01cf6bb0f0d8bff042015b528" offset="0x0000" />
+			</dataarea>
+		</part>
+	</software>
+
 </softwarelist>

--- a/hash/apple2_flop_orig.xml
+++ b/hash/apple2_flop_orig.xml
@@ -4793,11 +4793,10 @@
 		<info name="release" value="2019-04-30"/>
 		<sharedfeat name="compatibility" value="A2,A2P,A2E,A2EE,A2C,A2GS" />
 		<!-- It runs on any Apple II with 48K. -->
-		<!-- Appears to be at least one missing disk. We'll need to revisit this later.. -->
 
 		<part name="flop1" interface="floppy_5_25">
 			<dataarea name="flop" size="233545">
-				<rom name="Wishbringer - Disk 1, Side A.woz" size="233545" crc="02a3fb1d" sha1="d21077ff029223bbdcb1dafae0433ca6cdff670a" offset="0x0000" />
+				<rom name="Wishbringer r68.woz" size="233545" crc="02a3fb1d" sha1="d21077ff029223bbdcb1dafae0433ca6cdff670a" offset="0x0000" />
 			</dataarea>
 		</part>
 	</software>

--- a/hash/apple2_flop_orig.xml
+++ b/hash/apple2_flop_orig.xml
@@ -4474,7 +4474,7 @@
 
 		<part name="flop1" interface="floppy_5_25">
 			<dataarea name="flop" size="234771">
-				<rom name="Microsoft Adventure.woz" size="234771" crc="6e623593" sha1="d52f0a3b95a386875cb3691f5471e8c14440ccb8" offset="0x0000" />
+				<rom name="Microsoft Adventure.woz" size="234771" crc="6e623593" sha1="d52f0a3b95a386875cb3691f5471e8c14440ccb8" />
 			</dataarea>
 		</part>
 	</software>
@@ -4490,7 +4490,7 @@
 
 		<part name="flop1" interface="floppy_5_25">
 			<dataarea name="flop" size="234781">
-				<rom name="Micro Invaders.woz" size="234781" crc="28ae8795" sha1="f18c23182c56da29e657f0f53f16f65a3a64e33d" offset="0x0000" />
+				<rom name="Micro Invaders.woz" size="234781" crc="28ae8795" sha1="f18c23182c56da29e657f0f53f16f65a3a64e33d" />
 			</dataarea>
 		</part>
 	</software>
@@ -4506,7 +4506,7 @@
 
 		<part name="flop1" interface="floppy_5_25">
 			<dataarea name="flop" size="234789">
-				<rom name="Blisterball and Mad Bomber.woz" size="234789" crc="464e6b8d" sha1="f4ac813e979ea5c0e9b476a57063b37c25713d46" offset="0x0000" />
+				<rom name="Blisterball and Mad Bomber.woz" size="234789" crc="464e6b8d" sha1="f4ac813e979ea5c0e9b476a57063b37c25713d46" />
 			</dataarea>
 		</part>
 	</software>
@@ -4522,7 +4522,7 @@
 
 		<part name="flop1" interface="floppy_5_25">
 			<dataarea name="flop" size="234810">
-				<rom name="Typing Tutor.woz" size="234810" crc="58306c14" sha1="b056c2772643d89336a6ee9894b5dfbd411f53f1" offset="0x0000" />
+				<rom name="Typing Tutor.woz" size="234810" crc="58306c14" sha1="b056c2772643d89336a6ee9894b5dfbd411f53f1" />
 			</dataarea>
 		</part>
 	</software>
@@ -4537,7 +4537,7 @@
 
 		<part name="flop1" interface="floppy_5_25">
 			<dataarea name="flop" size="61721">
-				<rom name="Space Warrior.woz" size="61721" crc="e0b4e0ed" sha1="96cd4e7ba3e49c48d29987fec219f452eb33b413" offset="0x0000" />
+				<rom name="Space Warrior.woz" size="61721" crc="e0b4e0ed" sha1="96cd4e7ba3e49c48d29987fec219f452eb33b413" />
 			</dataarea>
 		</part>
 	</software>
@@ -4553,13 +4553,13 @@
 		<part name="flop1" interface="floppy_5_25">
 			<feature name="part_id" value="Side A"/>
 			<dataarea name="flop" size="234766">
-				<rom name="The Crimson Crown side A.woz" size="234766" crc="3ba098cb" sha1="039acb376d74b1079469af9b49ec0220d03f5318" offset="0x0000" />
+				<rom name="The Crimson Crown side A.woz" size="234766" crc="3ba098cb" sha1="039acb376d74b1079469af9b49ec0220d03f5318" />
 			</dataarea>
 		</part>
 		<part name="flop2" interface="floppy_5_25">
 			<feature name="part_id" value="Side B"/>
 			<dataarea name="flop" size="234766">
-				<rom name="The Crimson Crown side B.woz" size="234766" crc="d158deed" sha1="e02ca1c7af89f56efe1d6767c40963161dfbe926" offset="0x0000" />
+				<rom name="The Crimson Crown side B.woz" size="234766" crc="d158deed" sha1="e02ca1c7af89f56efe1d6767c40963161dfbe926" />
 			</dataarea>
 		</part>
 	</software>
@@ -4574,7 +4574,7 @@
 
 		<part name="flop1" interface="floppy_5_25">
 			<dataarea name="flop" size="246767">
-				<rom name="Zykron Hearts.woz" size="246767" crc="5e55409f" sha1="342f513e287128acb67e0b839d815b143b43990c" offset="0x0000" />
+				<rom name="Zykron Hearts.woz" size="246767" crc="5e55409f" sha1="342f513e287128acb67e0b839d815b143b43990c" />
 			</dataarea>
 		</part>
 	</software>
@@ -4589,7 +4589,7 @@
 
 		<part name="flop1" interface="floppy_5_25">
 			<dataarea name="flop" size="208162">
-				<rom name="Gold Rush.woz" size="208162" crc="e8ee2a66" sha1="68b196839e56d49a451adf216591754fb45618a4" offset="0x0000" />
+				<rom name="Gold Rush.woz" size="208162" crc="e8ee2a66" sha1="68b196839e56d49a451adf216591754fb45618a4" />
 			</dataarea>
 		</part>
 	</software>
@@ -4605,12 +4605,12 @@
 
 		<part name="flop1" interface="floppy_5_25">
 			<dataarea name="flop" size="234794">
-				<rom name="The Print Shop Companion v1.2 side A.woz" size="234794" crc="e8af250e" sha1="875f61ac89ec48ed450fb646e5eafd9a24233c4d" offset="0x0000" />
+				<rom name="The Print Shop Companion v1.2 side A.woz" size="234794" crc="e8af250e" sha1="875f61ac89ec48ed450fb646e5eafd9a24233c4d" />
 			</dataarea>
 		</part>
 		<part name="flop2" interface="floppy_5_25">
 			<dataarea name="flop" size="234794">
-				<rom name="The Print Shop Companion v1.2 side B.woz" size="234794" crc="a06b52a9" sha1="1c6f461fbd4c78dd48480c334f0d5f1df2cf591e" offset="0x0000" />
+				<rom name="The Print Shop Companion v1.2 side B.woz" size="234794" crc="a06b52a9" sha1="1c6f461fbd4c78dd48480c334f0d5f1df2cf591e" />
 			</dataarea>
 		</part>
 	</software>
@@ -4626,13 +4626,13 @@
 		<part name="flop1" interface="floppy_5_25">
 			<feature name="part_id" value="Side A"/>
 			<dataarea name="flop" size="234839">
-				<rom name="S.A.G.A. 1 - Adventureland side A.woz" size="234839" crc="cb8da55c" sha1="3e2f79d3c52d6e97510aac3ced977c60eb6b5360" offset="0x0000" />
+				<rom name="S.A.G.A. 1 - Adventureland side A.woz" size="234839" crc="cb8da55c" sha1="3e2f79d3c52d6e97510aac3ced977c60eb6b5360" />
 			</dataarea>
 		</part>
 		<part name="flop2" interface="floppy_5_25">
 			<feature name="part_id" value="Side B - Boot Disk"/>
 			<dataarea name="flop" size="234839">
-				<rom name="S.A.G.A. 1 - Adventureland side B (boot).woz" size="234839" crc="83cb42a3" sha1="a50127f7650549b4e73bb5a2e718ceefc456a232" offset="0x0000" />
+				<rom name="S.A.G.A. 1 - Adventureland side B (boot).woz" size="234839" crc="83cb42a3" sha1="a50127f7650549b4e73bb5a2e718ceefc456a232" />
 			</dataarea>
 		</part>
 	</software>
@@ -4648,13 +4648,13 @@
 		<part name="flop1" interface="floppy_5_25">
 			<feature name="part_id" value="Side A"/>
 			<dataarea name="flop" size="234855">
-				<rom name="S.A.G.A. 2 - Pirate Adventure side A.woz" size="234855" crc="e1d89cb0" sha1="a1d672605f4b3bb4585f13824fc521b0681b3d89" offset="0x0000" />
+				<rom name="S.A.G.A. 2 - Pirate Adventure side A.woz" size="234855" crc="e1d89cb0" sha1="a1d672605f4b3bb4585f13824fc521b0681b3d89" />
 			</dataarea>
 		</part>
 		<part name="flop2" interface="floppy_5_25">
 			<feature name="part_id" value="Side B - Boot Disk"/>
 			<dataarea name="flop" size="234855">
-				<rom name="S.A.G.A. 2 - Pirate Adventure side B (boot).woz" size="234855" crc="36443115" sha1="bbe23e9d3f21b389f41be4795d34b2c9c1c87208" offset="0x0000" />
+				<rom name="S.A.G.A. 2 - Pirate Adventure side B (boot).woz" size="234855" crc="36443115" sha1="bbe23e9d3f21b389f41be4795d34b2c9c1c87208" />
 			</dataarea>
 		</part>
 	</software>
@@ -4670,13 +4670,13 @@
 		<part name="flop1" interface="floppy_5_25">
 			<feature name="part_id" value="Side A"/>
 			<dataarea name="flop" size="234836">
-				<rom name="S.A.G.A. 3 - Mission Impossible side A.woz" size="234836" crc="6e0da536" sha1="dda47d2b1916803174a7b8d1dad23e0b428ff0d7" offset="0x0000" />
+				<rom name="S.A.G.A. 3 - Mission Impossible side A.woz" size="234836" crc="6e0da536" sha1="dda47d2b1916803174a7b8d1dad23e0b428ff0d7" />
 			</dataarea>
 		</part>
 		<part name="flop2" interface="floppy_5_25">
 			<feature name="part_id" value="Side B - Boot Disk"/>
 			<dataarea name="flop" size="234836">
-				<rom name="S.A.G.A. 3 - Mission Impossible side B (boot).woz" size="234836" crc="b4c1cd26" sha1="4f68d858f02ebff83c115e06485ce78a7f47d8b9" offset="0x0000" />
+				<rom name="S.A.G.A. 3 - Mission Impossible side B (boot).woz" size="234836" crc="b4c1cd26" sha1="4f68d858f02ebff83c115e06485ce78a7f47d8b9" />
 			</dataarea>
 		</part>
 	</software>
@@ -4692,13 +4692,13 @@
 		<part name="flop1" interface="floppy_5_25">
 			<feature name="part_id" value="Side A"/>
 			<dataarea name="flop" size="234840">
-				<rom name="S.A.G.A. 4 - Voodoo Castle side A.woz" size="234840" crc="9922794b" sha1="a0ba732d20ae0f01f8a7237256c5e14fce74c9c6" offset="0x0000" />
+				<rom name="S.A.G.A. 4 - Voodoo Castle side A.woz" size="234840" crc="9922794b" sha1="a0ba732d20ae0f01f8a7237256c5e14fce74c9c6" />
 			</dataarea>
 		</part>
 		<part name="flop2" interface="floppy_5_25">
 			<feature name="part_id" value="Side B - Boot Disk"/>
 			<dataarea name="flop" size="234840">
-				<rom name="S.A.G.A. 4 - Voodoo Castle side B (boot).woz" size="234840" crc="00149d2f" sha1="ec747fef709fa8a01cf6bb0f0d8bff042015b528" offset="0x0000" />
+				<rom name="S.A.G.A. 4 - Voodoo Castle side B (boot).woz" size="234840" crc="00149d2f" sha1="ec747fef709fa8a01cf6bb0f0d8bff042015b528" />
 			</dataarea>
 		</part>
 	</software>
@@ -4714,13 +4714,13 @@
 		<part name="flop1" interface="floppy_5_25">
 			<feature name="part_id" value="Side A"/>
 			<dataarea name="flop" size="234889">
-				<rom name="s.a.g.a. 5 - the count side a.woz" size="234889" crc="db0ac44a" sha1="6a49a12ed5f813fe1b1e543df5948fee37a539e3" offset="0x0000" />
+				<rom name="s.a.g.a. 5 - the count side a.woz" size="234889" crc="db0ac44a" sha1="6a49a12ed5f813fe1b1e543df5948fee37a539e3" />
 			</dataarea>
 		</part>
 		<part name="flop2" interface="floppy_5_25">
 			<feature name="part_id" value="Side B - Boot Disk"/>
 			<dataarea name="flop" size="234889">
-				<rom name="s.a.g.a. 5 - the count side b (boot).woz" size="234889" crc="20bfc490" sha1="d12e09db9bf8be8b901b57ca993c13d75defc557" offset="0x0000" />
+				<rom name="s.a.g.a. 5 - the count side b (boot).woz" size="234889" crc="20bfc490" sha1="d12e09db9bf8be8b901b57ca993c13d75defc557" />
 			</dataarea>
 		</part>
 	</software>
@@ -4736,13 +4736,13 @@
 		<part name="flop1" interface="floppy_5_25">
 			<feature name="part_id" value="Side A"/>
 			<dataarea name="flop" size="234841">
-				<rom name="s.a.g.a. 6 - strange odyssey side a.woz" size="234841" crc="1c916bcb" sha1="9fbaed1c571186abff4705db9716828103971d6a" offset="0x0000" />
+				<rom name="s.a.g.a. 6 - strange odyssey side a.woz" size="234841" crc="1c916bcb" sha1="9fbaed1c571186abff4705db9716828103971d6a" />
 			</dataarea>
 		</part>
 		<part name="flop2" interface="floppy_5_25">
 			<feature name="part_id" value="Side B - Boot Disk"/>
 			<dataarea name="flop" size="234841">
-				<rom name="s.a.g.a. 6 - strange odyssey side b (boot).woz" size="234841" crc="78f7127a" sha1="aaca5ec74f1578b9e3b01df9074745cf43a33e2e" offset="0x0000" />
+				<rom name="s.a.g.a. 6 - strange odyssey side b (boot).woz" size="234841" crc="78f7127a" sha1="aaca5ec74f1578b9e3b01df9074745cf43a33e2e" />
 			</dataarea>
 		</part>
 	</software>
@@ -4759,7 +4759,7 @@
 
 		<part name="flop1" interface="floppy_5_25">
 			<dataarea name="flop" size="354552">
-				<rom name="neptune.woz" size="354552" crc="f7469fc6" sha1="2ae817ab9c5291908d902df22facdecd9c2b364f" offset="0x0000" />
+				<rom name="neptune.woz" size="354552" crc="f7469fc6" sha1="2ae817ab9c5291908d902df22facdecd9c2b364f" />
 			</dataarea>
 		</part>
 	</software>
@@ -4775,13 +4775,13 @@
 		<part name="flop1" interface="floppy_5_25">
 			<feature name="part_id" value="Side A"/>
 			<dataarea name="flop" size="233533">
-				<rom name="where in europe is carmen sandiego side a.woz" size="233533" crc="aa41e758" sha1="cccfae850e791d3eeae13097d4fbefd85f3543a6" offset="0x0000" />
+				<rom name="where in europe is carmen sandiego side a.woz" size="233533" crc="aa41e758" sha1="cccfae850e791d3eeae13097d4fbefd85f3543a6" />
 			</dataarea>
 		</part>
 		<part name="flop2" interface="floppy_5_25">
 			<feature name="part_id" value="Side B"/>
 			<dataarea name="flop" size="233533">
-				<rom name="where in europe is carmen sandiego side b.woz" size="233533" crc="32e8e026" sha1="701d0a865e3a567c663d214b03edc57472ca585a" offset="0x0000" />
+				<rom name="where in europe is carmen sandiego side b.woz" size="233533" crc="32e8e026" sha1="701d0a865e3a567c663d214b03edc57472ca585a" />
 			</dataarea>
 		</part>
 	</software>
@@ -4796,7 +4796,7 @@
 
 		<part name="flop1" interface="floppy_5_25">
 			<dataarea name="flop" size="233545">
-				<rom name="Wishbringer r68.woz" size="233545" crc="02a3fb1d" sha1="d21077ff029223bbdcb1dafae0433ca6cdff670a" offset="0x0000" />
+				<rom name="Wishbringer r68.woz" size="233545" crc="02a3fb1d" sha1="d21077ff029223bbdcb1dafae0433ca6cdff670a" />
 			</dataarea>
 		</part>
 	</software>
@@ -4813,7 +4813,7 @@
 
 		<part name="flop1" interface="floppy_5_25">
 			<dataarea name="flop" size="352021">
-				<rom name="dueling digits.woz" size="352021" crc="f1a7b5dc" sha1="cebd874ea25606d8ddbd566813beecfaa4973b67" offset="0x0000" />
+				<rom name="dueling digits.woz" size="352021" crc="f1a7b5dc" sha1="cebd874ea25606d8ddbd566813beecfaa4973b67" />
 			</dataarea>
 		</part>
 	</software>
@@ -4828,7 +4828,7 @@
 
 		<part name="flop1" interface="floppy_5_25">
 			<dataarea name="flop" size="234776">
-				<rom name="elite.woz" size="234776" crc="9f499559" sha1="03d5420b1b43561a06caae2482799686aca3f916" offset="0x0000" />
+				<rom name="elite.woz" size="234776" crc="9f499559" sha1="03d5420b1b43561a06caae2482799686aca3f916" />
 			</dataarea>
 		</part>
 	</software>
@@ -4843,7 +4843,7 @@
 
 		<part name="flop1" interface="floppy_5_25">
 			<dataarea name="flop" size="234728">
-				<rom name="fore.woz" size="234728" crc="ef113e2e" sha1="f4ca8eb9aed7619034d3fce066d305b902ba840a" offset="0x0000" />
+				<rom name="fore.woz" size="234728" crc="ef113e2e" sha1="f4ca8eb9aed7619034d3fce066d305b902ba840a" />
 			</dataarea>
 		</part>
 	</software>
@@ -4858,7 +4858,7 @@
 
 		<part name="flop1" interface="floppy_5_25">
 			<dataarea name="flop" size="101647">
-				<rom name="gorgon.woz" size="101647" crc="2e984e99" sha1="bab4cd57a2ea7dd053e01e4892eba2ed0da29107" offset="0x0000" />
+				<rom name="gorgon.woz" size="101647" crc="2e984e99" sha1="bab4cd57a2ea7dd053e01e4892eba2ed0da29107" />
 			</dataarea>
 		</part>
 	</software>
@@ -4873,7 +4873,7 @@
 
 		<part name="flop1" interface="floppy_5_25">
 			<dataarea name="flop" size="234755">
-				<rom name="hacker.woz" size="234755" crc="4291a82b" sha1="184e9e72db1467dda0b1af328a6a9dcdbfb59248" offset="0x0000" />
+				<rom name="hacker.woz" size="234755" crc="4291a82b" sha1="184e9e72db1467dda0b1af328a6a9dcdbfb59248" />
 			</dataarea>
 		</part>
 	</software>
@@ -4888,7 +4888,7 @@
 
 		<part name="flop1" interface="floppy_5_25">
 			<dataarea name="flop" size="173820">
-				<rom name="impossible mission.woz" size="173820" crc="09f41927" sha1="2863391b12c0878050203c8b3ef39e23c0c84e1d" offset="0x0000" />
+				<rom name="impossible mission.woz" size="173820" crc="09f41927" sha1="2863391b12c0878050203c8b3ef39e23c0c84e1d" />
 			</dataarea>
 		</part>
 	</software>
@@ -4905,7 +4905,7 @@
 
 		<part name="flop1" interface="floppy_5_25">
 			<dataarea name="flop" size="222943">
-				<rom name="juggler.woz" size="222943" crc="926b28c6" sha1="f12f580bea163ffe578043e040feba5717722ff9" offset="0x0000" />
+				<rom name="juggler.woz" size="222943" crc="926b28c6" sha1="f12f580bea163ffe578043e040feba5717722ff9" />
 			</dataarea>
 		</part>
 	</software>
@@ -4920,7 +4920,7 @@
 
 		<part name="flop1" interface="floppy_5_25">
 			<dataarea name="flop" size="234763">
-				<rom name="sorcerer of siva.woz" size="234763" crc="e14e1c8b" sha1="34119f636f0044300abd50f963b45fa929a17277" offset="0x0000" />
+				<rom name="sorcerer of siva.woz" size="234763" crc="e14e1c8b" sha1="34119f636f0044300abd50f963b45fa929a17277" />
 			</dataarea>
 		</part>
 	</software>
@@ -4935,7 +4935,7 @@
 
 		<part name="flop1" interface="floppy_5_25">
 			<dataarea name="flop" size="233482">
-				<rom name="top fuel eliminator.woz" size="233482" crc="43754194" sha1="9bcb067eef38d2f0c780d34e4217c37aa87201a2" offset="0x0000" />
+				<rom name="top fuel eliminator.woz" size="233482" crc="43754194" sha1="9bcb067eef38d2f0c780d34e4217c37aa87201a2" />
 			</dataarea>
 		</part>
 	</software>
@@ -4950,7 +4950,7 @@
 
 		<part name="flop1" interface="floppy_5_25">
 			<dataarea name="flop" size="234822">
-				<rom name="zork ii r7.woz" size="234822" crc="5af3cc87" sha1="1481c2ac3148420516fc773b6f4aacd1f8588a8c" offset="0x0000" />
+				<rom name="zork ii r7.woz" size="234822" crc="5af3cc87" sha1="1481c2ac3148420516fc773b6f4aacd1f8588a8c" />
 			</dataarea>
 		</part>
 	</software>
@@ -4966,13 +4966,13 @@
 		<part name="flop1" interface="floppy_5_25">
 			<feature name="part_id" value="Side A"/>
 			<dataarea name="flop" size="234755">
-				<rom name="tass times in tonetown side a.woz" size="234755" crc="d59794e3" sha1="7c8d67dc20e88aa407679887b9487634b74114f4" offset="0x0000" />
+				<rom name="tass times in tonetown side a.woz" size="234755" crc="d59794e3" sha1="7c8d67dc20e88aa407679887b9487634b74114f4" />
 			</dataarea>
 		</part>
 		<part name="flop2" interface="floppy_5_25">
 			<feature name="part_id" value="Side B"/>
 			<dataarea name="flop" size="234755">
-				<rom name="tass times in tonetown side b.woz" size="234755" crc="66a80d72" sha1="04ccf2549727cdff3a75cda80b84eb35e2c1f35f" offset="0x0000" />
+				<rom name="tass times in tonetown side b.woz" size="234755" crc="66a80d72" sha1="04ccf2549727cdff3a75cda80b84eb35e2c1f35f" />
 			</dataarea>
 		</part>
 	</software>
@@ -4987,7 +4987,7 @@
 
 		<part name="flop1" interface="floppy_5_25">
 			<dataarea name="flop" size="234718">
-				<rom name="robotwar.woz" size="234718" crc="8e355339" sha1="4de8885d81eeb04998cfd8af62f943a7bbd7220c" offset="0x0000" />
+				<rom name="robotwar.woz" size="234718" crc="8e355339" sha1="4de8885d81eeb04998cfd8af62f943a7bbd7220c" />
 			</dataarea>
 		</part>
 	</software>

--- a/hash/apple2_flop_orig.xml
+++ b/hash/apple2_flop_orig.xml
@@ -3425,7 +3425,7 @@
 	</software>
 
 	<software name="wishbr23">
-		<description>Wishbringer (r23)</description>
+		<description>Wishbringer (r23 / 880706)</description>
 		<year>1988</year>
 		<publisher>Infocom</publisher>
 		<info name="release" value="2019-01-18"/>
@@ -4447,7 +4447,7 @@
 	</software>
 
 	<software name="zork1r5">
-		<description>Zork I: The Great Underground Empire (revision 5)</description>
+		<description>Zork I: The Great Underground Empire (Revision 5)</description>
 		<year>1980</year>
 		<publisher>Personal Software</publisher>
 		<info name="release" value="2019-04-11"/>
@@ -4703,4 +4703,293 @@
 		</part>
 	</software>
 
+	<software name="satcount">
+		<description>The Count (Version 2.1/115)</description>
+		<year>1982</year>
+		<publisher>Adventure International</publisher>
+		<info name="release" value="2019-04-25"/>
+		<sharedfeat name="compatibility" value="A2P,A2E,A2EE,A2C,A2GS" />
+		<!-- It requires a 48K Apple ][+ or later. -->
+
+		<part name="flop1" interface="floppy_5_25">
+			<feature name="part_id" value="Side A"/>
+			<dataarea name="flop" size="234889">
+				<rom name="s.a.g.a. 5 - the count side a.woz" size="234889" crc="db0ac44a" sha1="6a49a12ed5f813fe1b1e543df5948fee37a539e3" offset="0x0000" />
+			</dataarea>
+		</part>
+		<part name="flop2" interface="floppy_5_25">
+			<feature name="part_id" value="Side B - Boot Disk"/>
+			<dataarea name="flop" size="234889">
+				<rom name="s.a.g.a. 5 - the count side b (boot).woz" size="234889" crc="20bfc490" sha1="d12e09db9bf8be8b901b57ca993c13d75defc557" offset="0x0000" />
+			</dataarea>
+		</part>
+	</software>
+
+	<software name="sastodys">
+		<description>Strange Odyssey (Version 2.1/119)</description>
+		<year>1982</year>
+		<publisher>Adventure International</publisher>
+		<info name="release" value="2019-04-26"/>
+		<sharedfeat name="compatibility" value="A2P,A2E,A2EE,A2C,A2GS" />
+		<!-- It requires a 48K Apple ][+ or later. -->
+
+		<part name="flop1" interface="floppy_5_25">
+			<feature name="part_id" value="Side A"/>
+			<dataarea name="flop" size="234841">
+				<rom name="s.a.g.a. 6 - strange odyssey side a.woz" size="234841" crc="1c916bcb" sha1="9fbaed1c571186abff4705db9716828103971d6a" offset="0x0000" />
+			</dataarea>
+		</part>
+		<part name="flop2" interface="floppy_5_25">
+			<feature name="part_id" value="Side B - Boot Disk"/>
+			<dataarea name="flop" size="234841">
+				<rom name="s.a.g.a. 6 - strange odyssey side b (boot).woz" size="234841" crc="78f7127a" sha1="aaca5ec74f1578b9e3b01df9074745cf43a33e2e" offset="0x0000" />
+			</dataarea>
+		</part>
+	</software>
+
+	<software name="naptune">
+		<description>Neptune</description>
+		<year>1982</year>
+		<publisher>Gebelli Software</publisher>
+		<info name="release" value="2019-04-27"/>
+		<sharedfeat name="compatibility" value="A2,A2P" />
+		<!-- It requires a 48K Apple ][ or ][+.
+		Due to compatibility issues created by the copy protection,
+		it will not run on later models. -->
+
+		<part name="flop1" interface="floppy_5_25">
+			<dataarea name="flop" size="354552">
+				<rom name="neptune.woz" size="354552" crc="f7469fc6" sha1="2ae817ab9c5291908d902df22facdecd9c2b364f" offset="0x0000" />
+			</dataarea>
+		</part>
+	</software>
+
+	<software name="carmneur">
+		<description>Where in Europe is Carmen Sandiego</description>
+		<year>1988</year>
+		<publisher>Broderbund Software</publisher>
+		<info name="release" value="2019-04-28"/>
+		<sharedfeat name="compatibility" value="A2E,A2EE,A2C,A2GS" />
+		<!-- It requires a 128K Apple //e or later.-->
+
+		<part name="flop1" interface="floppy_5_25">
+			<feature name="part_id" value="Side A"/>
+			<dataarea name="flop" size="233533">
+				<rom name="where in europe is carmen sandiego side a.woz" size="233533" crc="aa41e758" sha1="cccfae850e791d3eeae13097d4fbefd85f3543a6" offset="0x0000" />
+			</dataarea>
+		</part>
+		<part name="flop2" interface="floppy_5_25">
+			<feature name="part_id" value="Side B"/>
+			<dataarea name="flop" size="233533">
+				<rom name="where in europe is carmen sandiego side b.woz" size="233533" crc="32e8e026" sha1="701d0a865e3a567c663d214b03edc57472ca585a" offset="0x0000" />
+			</dataarea>
+		</part>
+	</software>
+
+	<software name="wishbr68">
+		<description>Wishbringer (Rev 68 / 850501)</description>
+		<year>1985</year>
+		<publisher>Infocom</publisher>
+		<info name="release" value="2019-04-30"/>
+		<sharedfeat name="compatibility" value="A2,A2P,A2E,A2EE,A2C,A2GS" />
+		<!-- It runs on any Apple II with 48K. -->
+		<!-- Appears to be at least one missing disk. We'll need to revisit this later.. -->
+
+		<part name="flop1" interface="floppy_5_25">
+			<dataarea name="flop" size="233545">
+				<rom name="Wishbringer - Disk 1, Side A.woz" size="233545" crc="02a3fb1d" sha1="d21077ff029223bbdcb1dafae0433ca6cdff670a" offset="0x0000" />
+			</dataarea>
+		</part>
+	</software>
+
+	<software name="dueldigt">
+		<description>Dueling Digits</description>
+		<year>1982</year>
+		<publisher>Broderbund Software</publisher>
+		<info name="release" value="2019-05-01"/>
+		<sharedfeat name="compatibility" value="A2,A2P" />
+		<!-- It requires a 48K Apple ][ or ][+.
+		Due to compatibility problems created by the copy protection,
+		it will not run on later models. -->
+
+		<part name="flop1" interface="floppy_5_25">
+			<dataarea name="flop" size="352021">
+				<rom name="dueling digits.woz" size="352021" crc="f1a7b5dc" sha1="cebd874ea25606d8ddbd566813beecfaa4973b67" offset="0x0000" />
+			</dataarea>
+		</part>
+	</software>
+
+	<software name="elite">
+		<description>Elite</description>
+		<year>1985</year>
+		<publisher>Firebird</publisher>
+		<info name="release" value="2019-05-06"/>
+		<sharedfeat name="compatibility" value="A2P,A2E,A2EE,A2C,A2GS" />
+		<!-- It requires a 48K Apple ][+ or later. -->
+
+		<part name="flop1" interface="floppy_5_25">
+			<dataarea name="flop" size="234776">
+				<rom name="elite.woz" size="234776" crc="9f499559" sha1="03d5420b1b43561a06caae2482799686aca3f916" offset="0x0000" />
+			</dataarea>
+		</part>
+	</software>
+
+	<software name="epyxfore">
+		<description>Fore</description>
+		<year>1982</year>
+		<publisher>Epyx</publisher>
+		<info name="release" value="2019-05-06"/>
+		<sharedfeat name="compatibility" value="A2P,A2E,A2EE,A2C,A2GS" />
+		<!-- It requires a 48K Apple ][+ or later. -->
+
+		<part name="flop1" interface="floppy_5_25">
+			<dataarea name="flop" size="234728">
+				<rom name="fore.woz" size="234728" crc="ef113e2e" sha1="f4ca8eb9aed7619034d3fce066d305b902ba840a" offset="0x0000" />
+			</dataarea>
+		</part>
+	</software>
+
+	<software name="gorgon">
+		<description>Gorgon</description>
+		<year>1981</year>
+		<publisher>Sirius Software</publisher>
+		<info name="release" value="2019-05-06"/>
+		<sharedfeat name="compatibility" value="A2,A2P,A2E,A2EE,A2C,A2GS" />
+		<!-- It runs on any Apple II with 48K. -->
+
+		<part name="flop1" interface="floppy_5_25">
+			<dataarea name="flop" size="101647">
+				<rom name="gorgon.woz" size="101647" crc="2e984e99" sha1="bab4cd57a2ea7dd053e01e4892eba2ed0da29107" offset="0x0000" />
+			</dataarea>
+		</part>
+	</software>
+
+	<software name="hacker">
+		<description>Hacker</description>
+		<year>1985</year>
+		<publisher>Activision</publisher>
+		<info name="release" value="2019-05-06"/>
+		<sharedfeat name="compatibility" value="A2,A2P,A2E,A2EE,A2C,A2GS" />
+		<!-- It requires a 64K Apple ][+ or later. -->
+
+		<part name="flop1" interface="floppy_5_25">
+			<dataarea name="flop" size="234755">
+				<rom name="hacker.woz" size="234755" crc="4291a82b" sha1="184e9e72db1467dda0b1af328a6a9dcdbfb59248" offset="0x0000" />
+			</dataarea>
+		</part>
+	</software>
+
+	<software name="impmisn">
+		<description>Impossible Mission</description>
+		<year>1984</year>
+		<publisher>Epyx</publisher>
+		<info name="release" value="2019-05-06"/>
+		<sharedfeat name="compatibility" value="A2,A2P,A2E,A2EE,A2C,A2GS" />
+		<!-- It requires a 64K Apple ][+ or later. -->
+
+		<part name="flop1" interface="floppy_5_25">
+			<dataarea name="flop" size="173820">
+				<rom name="impossible mission.woz" size="173820" crc="09f41927" sha1="2863391b12c0878050203c8b3ef39e23c0c84e1d" offset="0x0000" />
+			</dataarea>
+		</part>
+	</software>
+
+	<software name="juggler">
+		<description>Juggler</description>
+		<year>1982</year>
+		<publisher>IDSI</publisher>
+		<info name="release" value="2019-05-06"/>
+		<sharedfeat name="compatibility" value="A2,A2P,A2E,A2EE,A2C,A2GS" />
+		<!-- It requires a 48K Apple ][ or Apple ][+.
+		Due to compatibility problems created by the copy protection,
+		it will not run on later models. -->
+
+		<part name="flop1" interface="floppy_5_25">
+			<dataarea name="flop" size="222943">
+				<rom name="juggler.woz" size="222943" crc="926b28c6" sha1="f12f580bea163ffe578043e040feba5717722ff9" offset="0x0000" />
+			</dataarea>
+		</part>
+	</software>
+
+	<software name="sorcsiva">
+		<description>Sorcerer of Siva</description>
+		<year>1981</year>
+		<publisher>epyx</publisher>
+		<info name="release" value="2019-05-08"/>
+		<sharedfeat name="compatibility" value="A2P,A2E,A2EE,A2C,A2GS" />
+		<!-- It requires a 48K Apple ][+ or later. -->
+
+		<part name="flop1" interface="floppy_5_25">
+			<dataarea name="flop" size="234763">
+				<rom name="sorcerer of siva.woz" size="234763" crc="e14e1c8b" sha1="34119f636f0044300abd50f963b45fa929a17277" offset="0x0000" />
+			</dataarea>
+		</part>
+	</software>
+
+	<software name="tfelimin">
+		<description>Top Fuel Eliminator</description>
+		<year>1987</year>
+		<publisher>Activision</publisher>
+		<info name="release" value="2019-05-09"/>
+		<sharedfeat name="compatibility" value="A2,A2P,A2E,A2EE,A2C,A2GS" />
+		<!-- It runs on any Apple II with 48K. -->
+
+		<part name="flop1" interface="floppy_5_25">
+			<dataarea name="flop" size="233482">
+				<rom name="top fuel eliminator.woz" size="233482" crc="43754194" sha1="9bcb067eef38d2f0c780d34e4217c37aa87201a2" offset="0x0000" />
+			</dataarea>
+		</part>
+	</software>
+
+	<software name="zork2r7">
+		<description>Zork II (Revision 7)</description>
+		<year>1981</year>
+		<publisher>Infocom</publisher>
+		<info name="release" value="2019-05-10"/>
+		<sharedfeat name="compatibility" value="A2,A2P,A2E,A2EE,A2C,A2GS" />
+		<!-- It runs on any Apple ][] with 32K. -->
+
+		<part name="flop1" interface="floppy_5_25">
+			<dataarea name="flop" size="234822">
+				<rom name="zork ii r7.woz" size="234822" crc="5af3cc87" sha1="1481c2ac3148420516fc773b6f4aacd1f8588a8c" offset="0x0000" />
+			</dataarea>
+		</part>
+	</software>
+
+	<software name="tonetown">
+		<description>Tass Times in Tonetown</description>
+		<year>1986</year>
+		<publisher>Activision</publisher>
+		<info name="release" value="2019-05-10"/>
+		<sharedfeat name="compatibility" value="A2P,A2E,A2EE,A2C,A2GS" />
+		<!-- It requires a 64K Apple ][+ or later. -->
+
+		<part name="flop1" interface="floppy_5_25">
+			<feature name="part_id" value="Side A"/>
+			<dataarea name="flop" size="234755">
+				<rom name="tass times in tonetown side a.woz" size="234755" crc="d59794e3" sha1="7c8d67dc20e88aa407679887b9487634b74114f4" offset="0x0000" />
+			</dataarea>
+		</part>
+		<part name="flop2" interface="floppy_5_25">
+			<feature name="part_id" value="Side B"/>
+			<dataarea name="flop" size="234755">
+				<rom name="tass times in tonetown side b.woz" size="234755" crc="66a80d72" sha1="04ccf2549727cdff3a75cda80b84eb35e2c1f35f" offset="0x0000" />
+			</dataarea>
+		</part>
+	</software>
+
+	<software name="robotwar">
+		<description>Robotwar</description>
+		<year>1981</year>
+		<publisher>MUSE Software</publisher>
+		<info name="release" value="2019-05-11"/>
+		<sharedfeat name="compatibility" value="A2P,A2E,A2EE,A2C,A2GS" />
+		<!-- It requires a 48K Apple ][+ or later. -->
+
+		<part name="flop1" interface="floppy_5_25">
+			<dataarea name="flop" size="234718">
+				<rom name="robotwar.woz" size="234718" crc="8e355339" sha1="4de8885d81eeb04998cfd8af62f943a7bbd7220c" offset="0x0000" />
+			</dataarea>
+		</part>
+	</software>
 </softwarelist>


### PR DESCRIPTION
This is an interim update to get my own work caught up with the official branch. There will be at least one more PR this month.

Add originals:

Microsoft Adventure, Micro Invaders, Blister Ball and Mad Bomber, Typing Tutor, Space Warrior, The Crimson Crown, Zykron Hearts, Gold Rush, The Print Shop Companion (Version 1.2), Adventureland (Version 2.0/416), Pirate Adventure (Version 2.1/408), Mission Impossible (Version 2.1/306), Voodoo Castle (Version 2.1/119), The Count, Strange Odyssey, Neptune, Where in Europe is Carmen Sandiego, Wishbringer (R68), Dueling Digits, Elite, Fore, Gorgon, Hacker, Impossible Mission, Juggler, Sorcerer of Siva, Top Fuel Eliminator, Zork II (R7), Tass Times in Tonetown, Robotwar

Cleanly cracked:
Seven Cities of Gold, Stickybear Printer (Revision 2)

Fixes: 

Disk titles for computerized reading for aphasics
Grammar Gremlins (redumped)
Remove duplicate entry for "Case of the Missing Chick"
Removal of unnecessary offset