### PR TITLE
pgm.cpp, pgmprot_*.cpp : Updates

### DIFF
--- a/src/mame/drivers/pgm.cpp
+++ b/src/mame/drivers/pgm.cpp
@@ -204,27 +204,27 @@ Notes:
 #define PGMLOGERROR 0
 
 
-READ16_MEMBER(pgm_state::pgm_videoram_r)
+u16 pgm_state::videoram_r(offs_t offset)
 {
 	if (offset < 0x4000 / 2)
-		return m_bg_videoram[offset&0x7ff];
+		return m_bg_videoram[offset & 0x7ff];
 	else if (offset < 0x7000 / 2)
-		return m_tx_videoram[offset&0xfff];
+		return m_tx_videoram[offset & 0xfff];
 	else
 		return m_videoram[offset];
 }
 
-WRITE16_MEMBER(pgm_state::pgm_videoram_w)
+void pgm_state::videoram_w(offs_t offset, u16 data, u16 mem_mask)
 {
 	if (offset < 0x4000 / 2)
-		pgm_bg_videoram_w(space, offset&0x7ff, data, mem_mask);
+		bg_videoram_w(offset & 0x7ff, data, mem_mask);
 	else if (offset < 0x7000 / 2)
-		pgm_tx_videoram_w(space, offset&0xfff, data, mem_mask);
+		tx_videoram_w(offset & 0xfff, data, mem_mask);
 	else
 		COMBINE_DATA(&m_videoram[offset]);
 }
 
-WRITE16_MEMBER(pgm_state::pgm_coin_counter_w)
+void pgm_state::coin_counter_w(u16 data)
 {
 	machine().bookkeeping().coin_counter_w(0, data & 0x0001);
 	machine().bookkeeping().coin_counter_w(1, data & 0x0002);
@@ -232,26 +232,23 @@ WRITE16_MEMBER(pgm_state::pgm_coin_counter_w)
 	machine().bookkeeping().coin_counter_w(3, data & 0x0008);
 }
 
-READ16_MEMBER(pgm_state::z80_ram_r)
+u8 pgm_state::z80_ram_r(offs_t offset)
 {
-	return (m_z80_mainram[offset * 2] << 8) | m_z80_mainram[offset * 2 + 1];
+	return m_z80_mainram[offset];
 }
 
-WRITE16_MEMBER(pgm_state::z80_ram_w)
+void pgm_state::z80_ram_w(offs_t offset, u8 data)
 {
-	int pc = m_maincpu->pc();
+	const int pc = m_maincpu->pc();
 
-	if (ACCESSING_BITS_8_15)
-		m_z80_mainram[offset * 2] = data >> 8;
-	if (ACCESSING_BITS_0_7)
-		m_z80_mainram[offset * 2 + 1] = data;
+	m_z80_mainram[offset] = data;
 
 	if (pc != 0xf12 && pc != 0xde2 && pc != 0x100c50 && pc != 0x100b20)
 		if (PGMLOGERROR)
-			logerror("Z80: write %04x, %04x @ %04x (%06x)\n", offset * 2, data, mem_mask, m_maincpu->pc());
+			logerror("Z80: write %04x, %02x (%06x)\n", offset, data, m_maincpu->pc());
 }
 
-WRITE16_MEMBER(pgm_state::z80_reset_w)
+void pgm_state::z80_reset_w(offs_t offset, u16 data, u16 mem_mask)
 {
 	if (PGMLOGERROR)
 		logerror("Z80: reset %04x @ %04x (%06x)\n", data, mem_mask, m_maincpu->pc());
@@ -270,24 +267,21 @@ WRITE16_MEMBER(pgm_state::z80_reset_w)
 	}
 }
 
-WRITE16_MEMBER(pgm_state::z80_ctrl_w)
+void pgm_state::z80_ctrl_w(offs_t offset, u16 data, u16 mem_mask)
 {
 	if (PGMLOGERROR)
 		logerror("Z80: ctrl %04x @ %04x (%06x)\n", data, mem_mask, m_maincpu->pc());
 }
 
-WRITE16_MEMBER(pgm_state::m68k_l1_w)
+void pgm_state::m68k_l1_w(u8 data)
 {
-	if(ACCESSING_BITS_0_7)
-	{
-		if (PGMLOGERROR)
-			logerror("SL 1 m68.w %02x (%06x) IRQ\n", data & 0xff, m_maincpu->pc());
-		m_soundlatch->write(data);
-		m_soundcpu->pulse_input_line(INPUT_LINE_NMI, attotime::zero);
-	}
+	if (PGMLOGERROR)
+		logerror("SL 1 m68.w %02x (%06x) IRQ\n", data, m_maincpu->pc());
+	m_soundlatch->write(data);
+	m_soundcpu->pulse_input_line(INPUT_LINE_NMI, attotime::zero);
 }
 
-WRITE8_MEMBER(pgm_state::z80_l3_w)
+void pgm_state::z80_l3_w(u8 data)
 {
 	if (PGMLOGERROR)
 		logerror("SL 3 z80.w %02x (%04x)\n", data, m_soundcpu->pc());
@@ -320,12 +314,11 @@ void pgm_state::pgm_base_mem(address_map &map)
 
 	map(0x800000, 0x81ffff).ram().mirror(0x0e0000).share("sram"); /* Main Ram */
 
-	map(0x900000, 0x907fff).mirror(0x0f8000).rw(FUNC(pgm_state::pgm_videoram_r), FUNC(pgm_state::pgm_videoram_w)).share("videoram"); /* IGS023 VIDEO CHIP */
+	map(0x900000, 0x907fff).mirror(0x0f8000).rw(FUNC(pgm_state::videoram_r), FUNC(pgm_state::videoram_w)).share("videoram"); /* IGS023 VIDEO CHIP */
 	map(0xa00000, 0xa011ff).ram().w(m_palette, FUNC(palette_device::write16)).share("palette");
 	map(0xb00000, 0xb0ffff).ram().share("videoregs"); /* Video Regs inc. Zoom Table */
 
-	map(0xc00003, 0xc00003).r(m_soundlatch, FUNC(generic_latch_8_device::read));
-	map(0xc00002, 0xc00003).w(FUNC(pgm_state::m68k_l1_w));
+	map(0xc00003, 0xc00003).r(m_soundlatch, FUNC(generic_latch_8_device::read)).w(FUNC(pgm_state::m68k_l1_w));
 	map(0xc00005, 0xc00005).rw("soundlatch2", FUNC(generic_latch_8_device::read), FUNC(generic_latch_8_device::write));
 	map(0xc00007, 0xc00007).rw("rtc", FUNC(v3021_device::read), FUNC(v3021_device::write));
 	map(0xc00008, 0xc00009).w(FUNC(pgm_state::z80_reset_w));
@@ -335,7 +328,7 @@ void pgm_state::pgm_base_mem(address_map &map)
 	map(0xc08000, 0xc08001).portr("P1P2");
 	map(0xc08002, 0xc08003).portr("P3P4");
 	map(0xc08004, 0xc08005).portr("Service");
-	map(0xc08006, 0xc08007).portr("DSW").w(FUNC(pgm_state::pgm_coin_counter_w));
+	map(0xc08006, 0xc08007).portr("DSW").w(FUNC(pgm_state::coin_counter_w));
 
 	map(0xc10000, 0xc1ffff).rw(FUNC(pgm_state::z80_ram_r), FUNC(pgm_state::z80_ram_w)); /* Z80 Program */
 }
@@ -452,9 +445,9 @@ static const gfx_layout pgm8_charlayout =
 	8,8,
 	RGN_FRAC(1,1),
 	4,
-	{ 3, 2, 1, 0 },
-	{ 0, 4, 8, 12, 16, 20, 24, 28 },
-	{ 0*32, 1*32, 2*32, 3*32, 4*32, 5*32, 6*32, 7*32 },
+	{ STEP4(3,-1) },
+	{ STEP8(0,4) },
+	{ STEP8(0,4*8) },
 	8*32
 };
 
@@ -464,15 +457,9 @@ static const gfx_layout pgm32_charlayout =
 	RGN_FRAC(1,1),
 	5,
 	{ 4, 3, 2, 1, 0 },
-	{ 0, 5, 10, 15, 20, 25, 30, 35,
-		40, 45, 50, 55, 60, 65, 70, 75,
-		80, 85, 90, 95, 100, 105, 110, 115,
-		120, 125, 130, 135, 140, 145, 150, 155 },
-	{ 0*160, 1*160, 2*160, 3*160, 4*160, 5*160, 6*160, 7*160,
-		8*160, 9*160,10*160,11*160,12*160,13*160,14*160,15*160,
-		16*160,17*160,18*160,19*160,20*160,21*160,22*160,23*160,
-		24*160,25*160,26*160,27*160,28*160,29*160,30*160,31*160 },
-		32*160
+	{ STEP32(0,5) },
+	{ STEP32(0,5*32) },
+	32*32*5
 };
 
 GFXDECODE_START( gfx_pgm )
@@ -484,24 +471,19 @@ GFXDECODE_END
 
 /* most games require IRQ4 for inputs to work, Puzzli 2 is explicit about not wanting it tho
    what is the source? */
-TIMER_DEVICE_CALLBACK_MEMBER(pgm_state::pgm_interrupt)
+TIMER_DEVICE_CALLBACK_MEMBER(pgm_state::interrupt)
 {
 	int scanline = param;
 
-// already being generated  by m_maincpu->set_vblank_int("screen", FUNC(pgm_state::irq6_line_hold));
-//  if(scanline == 224)
+// already being generated by m_maincpu->set_vblank_int("screen", FUNC(pgm_state::irq6_line_hold));
+//  if (scanline == 224)
 //      m_maincpu->set_input_line(6, HOLD_LINE);
 
-	if(scanline == 0)
+	if (scanline == 0)
 		if (!m_irq4_disabled) m_maincpu->set_input_line(4, HOLD_LINE);
 }
 
-MACHINE_START_MEMBER(pgm_state,pgm)
-{
-//  machine().base_datetime(m_systime);
-}
-
-MACHINE_RESET_MEMBER(pgm_state,pgm)
+void pgm_state::machine_reset()
 {
 	m_soundcpu->set_input_line(INPUT_LINE_HALT, ASSERT_LINE);
 }
@@ -512,14 +494,11 @@ void pgm_state::pgmbase(machine_config &config)
 	M68000(config, m_maincpu, 20000000); /* 20 mhz! verified on real board */
 	m_maincpu->set_addrmap(AS_PROGRAM, &pgm_state::pgm_basic_mem);
 	m_maincpu->set_vblank_int("screen", FUNC(pgm_state::irq6_line_hold));
-	TIMER(config, "scantimer").configure_scanline(FUNC(pgm_state::pgm_interrupt), "screen", 0, 1);
+	TIMER(config, "scantimer").configure_scanline(FUNC(pgm_state::interrupt), "screen", 0, 1);
 
 	Z80(config, m_soundcpu, 33868800/4);
 	m_soundcpu->set_addrmap(AS_PROGRAM, &pgm_state::pgm_z80_mem);
 	m_soundcpu->set_addrmap(AS_IO, &pgm_state::pgm_z80_io);
-
-	MCFG_MACHINE_START_OVERRIDE(pgm_state, pgm )
-	MCFG_MACHINE_RESET_OVERRIDE(pgm_state, pgm )
 
 	NVRAM(config, "sram", nvram_device::DEFAULT_ALL_0);
 
@@ -531,14 +510,12 @@ void pgm_state::pgmbase(machine_config &config)
 	screen.set_vblank_time(ATTOSECONDS_IN_USEC(0));
 	screen.set_size(64*8, 64*8);
 	screen.set_visarea(0*8, 56*8-1, 0*8, 28*8-1);
-	screen.set_screen_update(FUNC(pgm_state::screen_update_pgm));
-	screen.screen_vblank().set(FUNC(pgm_state::screen_vblank_pgm));
+	screen.set_screen_update(FUNC(pgm_state::screen_update));
+	screen.screen_vblank().set(FUNC(pgm_state::screen_vblank));
 	screen.set_palette(m_palette);
 
 	GFXDECODE(config, m_gfxdecode, m_palette, gfx_pgm);
-	PALETTE(config, m_palette).set_format(palette_device::xRGB_555, 0x1200/2);
-
-	MCFG_VIDEO_START_OVERRIDE(pgm_state,pgm)
+	PALETTE(config, m_palette, palette_device::BLACK).set_format(palette_device::xRGB_555, 0x1200/2);
 
 	/*sound hardware */
 	SPEAKER(config, "mono").front_center();
@@ -579,7 +556,7 @@ ROM_START( pgm )
 	ROM_REGION( 0x600000, "maincpu", 0 ) /* 68000 Code */
 	PGM_68K_BIOS
 
-	ROM_REGION( 0x200000, "tiles", 0 ) /* 8x8 Text Layer Tiles */
+	ROM_REGION( 0x280000, "tiles", 0 ) /* 8x8 Text Layer Tiles */
 	PGM_VIDEO_BIOS
 
 	ROM_REGION( 0x200000, "ics", 0 ) /* Samples - (8 bit mono 11025Hz) - */
@@ -594,7 +571,7 @@ ROM_START( orlegend )
 	PGM_68K_BIOS
 	ROM_LOAD16_WORD_SWAP( "p0103.rom",    0x100000, 0x200000, CRC(d5e93543) SHA1(f081edc26514ca8354c13c7f6f89aba8e4d3e7d2) )
 
-	ROM_REGION( 0x800000, "tiles",  0 ) /* 8x8 Text Tiles + 32x32 BG Tiles */
+	ROM_REGION( 0xa00000, "tiles",  0 ) /* 8x8 Text Tiles + 32x32 BG Tiles */
 	PGM_VIDEO_BIOS
 	ROM_LOAD( "t0100.u8",     0x180000, 0x400000, CRC(61425e1e) SHA1(20753b86fc12003cfd763d903f034dbba8010b32) )
 
@@ -621,7 +598,7 @@ ROM_START( orlegende )
 	PGM_68K_BIOS
 	ROM_LOAD16_WORD_SWAP( "p0102.rom",    0x100000, 0x200000, CRC(4d0f6cc5) SHA1(8d41f0a712fb11a1da865f5159e5e27447b4388a) )
 
-	ROM_REGION( 0x800000, "tiles",  0 ) /* 8x8 Text Tiles + 32x32 BG Tiles */
+	ROM_REGION( 0xa00000, "tiles",  0 ) /* 8x8 Text Tiles + 32x32 BG Tiles */
 	PGM_VIDEO_BIOS
 	ROM_LOAD( "t0100.u8",     0x180000, 0x400000, CRC(61425e1e) SHA1(20753b86fc12003cfd763d903f034dbba8010b32) )
 
@@ -648,7 +625,7 @@ ROM_START( orlegendc )
 	PGM_68K_BIOS
 	ROM_LOAD16_WORD_SWAP( "p0101.160",    0x100000, 0x200000, CRC(b24f0c1e) SHA1(a2cf75d739681f091c24ef78ed6fc13aa8cfe0c6) )
 
-	ROM_REGION( 0x800000, "tiles",  0 ) /* 8x8 Text Tiles + 32x32 BG Tiles */
+	ROM_REGION( 0xa00000, "tiles",  0 ) /* 8x8 Text Tiles + 32x32 BG Tiles */
 	PGM_VIDEO_BIOS
 	ROM_LOAD( "t0100.u8",     0x180000, 0x400000, CRC(61425e1e) SHA1(20753b86fc12003cfd763d903f034dbba8010b32) )
 
@@ -675,7 +652,7 @@ ROM_START( orlegendca )
 	PGM_68K_BIOS
 	ROM_LOAD16_WORD_SWAP( "p0101.102",    0x100000, 0x200000, CRC(7a22e1cb) SHA1(4fe0fde00521b0915146334ea7213f3eb7e2affc) )
 
-	ROM_REGION( 0x800000, "tiles",  0 ) /* 8x8 Text Tiles + 32x32 BG Tiles */
+	ROM_REGION( 0xa00000, "tiles",  0 ) /* 8x8 Text Tiles + 32x32 BG Tiles */
 	PGM_VIDEO_BIOS
 	ROM_LOAD( "t0100.u8",     0x180000, 0x400000, CRC(61425e1e) SHA1(20753b86fc12003cfd763d903f034dbba8010b32) )
 
@@ -737,7 +714,7 @@ ROM_START( orlegend111c )
 	ROM_LOAD16_BYTE( "olv111ch.u7",     0x200001, 0x080000, CRC(6ee79faf) SHA1(039b4b07b8577f0d3022ae01210c00375624cb3c) )
 	ROM_LOAD16_BYTE( "olv111ch.u11",    0x200000, 0x080000, CRC(b80ddd3c) SHA1(55c700ce71ffdee392e03fd9d4719542c3527132) )
 
-	ROM_REGION( 0x800000, "tiles",  0 ) /* 8x8 Text Tiles + 32x32 BG Tiles */
+	ROM_REGION( 0xa00000, "tiles",  0 ) /* 8x8 Text Tiles + 32x32 BG Tiles */
 	PGM_VIDEO_BIOS
 	ROM_LOAD( "t0100.u8",     0x180000, 0x400000, CRC(61425e1e) SHA1(20753b86fc12003cfd763d903f034dbba8010b32) )
 
@@ -768,7 +745,7 @@ ROM_START( orlegend111t )
 	ROM_LOAD16_BYTE( "olv111tw.u7",     0x200001, 0x080000, CRC(27628e87) SHA1(a0effd83dc57ac72ba4f110737a075705d78e798) )
 	ROM_LOAD16_BYTE( "olv111tw.u11",    0x200000, 0x080000, CRC(23f33bc9) SHA1(f24490370d40d905afe8b716a3953b4e9f0aada4) )
 
-	ROM_REGION( 0x800000, "tiles",  0 ) /* 8x8 Text Tiles + 32x32 BG Tiles */
+	ROM_REGION( 0xa00000, "tiles",  0 ) /* 8x8 Text Tiles + 32x32 BG Tiles */
 	PGM_VIDEO_BIOS
 	ROM_LOAD( "t0100.u8",     0x180000, 0x400000, CRC(61425e1e) SHA1(20753b86fc12003cfd763d903f034dbba8010b32) )
 
@@ -798,7 +775,7 @@ ROM_START( orlegend111k )
 	ROM_LOAD16_BYTE( "olv111ko.u7",     0x200001, 0x080000, CRC(27628e87) SHA1(a0effd83dc57ac72ba4f110737a075705d78e798) )
 	ROM_LOAD16_BYTE( "olv111ko.u11",    0x200000, 0x080000, CRC(23f33bc9) SHA1(f24490370d40d905afe8b716a3953b4e9f0aada4) )
 
-	ROM_REGION( 0x800000, "tiles",  0 ) /* 8x8 Text Tiles + 32x32 BG Tiles */
+	ROM_REGION( 0xa00000, "tiles",  0 ) /* 8x8 Text Tiles + 32x32 BG Tiles */
 	PGM_VIDEO_BIOS
 	ROM_LOAD( "t0100.u8",     0x180000, 0x400000, CRC(61425e1e) SHA1(20753b86fc12003cfd763d903f034dbba8010b32) )
 
@@ -859,7 +836,7 @@ ROM_START( orlegend105k )
 	ROM_LOAD16_BYTE( "olv105ko.u7",     0x200001, 0x080000, CRC(5712facc) SHA1(2d95ebd1703874e89ac3a206f8c1f0ece6e833e0) )
 	ROM_LOAD16_BYTE( "olv105ko.u11",    0x200000, 0x080000, CRC(40ae4d9e) SHA1(62d7a96438b7fe93f74753333f50e077d417971e) )
 
-	ROM_REGION( 0x800000, "tiles",  0 ) /* 8x8 Text Tiles + 32x32 BG Tiles */
+	ROM_REGION( 0xa00000, "tiles",  0 ) /* 8x8 Text Tiles + 32x32 BG Tiles */
 	PGM_VIDEO_BIOS
 	ROM_LOAD( "t0100.u8",     0x180000, 0x400000, CRC(61425e1e) SHA1(20753b86fc12003cfd763d903f034dbba8010b32) )
 
@@ -953,7 +930,7 @@ ROM_START( drgw2 )
 	PGM_68K_BIOS
 	ROM_LOAD16_WORD_SWAP( "v-110x.u2",    0x100000, 0x080000, CRC(1978106b) SHA1(af8a13d7783b755a58762c98bdc32cab845b2251) )
 
-	ROM_REGION( 0x800000, "tiles",  0 ) /* 8x8 Text Tiles + 32x32 BG Tiles */
+	ROM_REGION( 0xa00000, "tiles",  0 ) /* 8x8 Text Tiles + 32x32 BG Tiles */
 	PGM_VIDEO_BIOS
 	ROM_LOAD( "pgmt0200.u7",    0x180000, 0x400000, CRC(b0f6534d) SHA1(174cacd81169a0e0d14790ac06d03caed737e05d) )
 
@@ -972,7 +949,7 @@ ROM_START( dw2v100x )
 	PGM_68K_BIOS
 	ROM_LOAD16_WORD_SWAP( "dragonv100x.bin",    0x100000, 0x080000,  CRC(5e71851d) SHA1(62052469f69daec88efd26652c1b893d6f981912) )
 
-	ROM_REGION( 0x800000, "tiles",  0 ) /* 8x8 Text Tiles + 32x32 BG Tiles */
+	ROM_REGION( 0xa00000, "tiles",  0 ) /* 8x8 Text Tiles + 32x32 BG Tiles */
 	PGM_VIDEO_BIOS
 	ROM_LOAD( "pgmt0200.u7",    0x180000, 0x400000, CRC(b0f6534d) SHA1(174cacd81169a0e0d14790ac06d03caed737e05d) )
 
@@ -991,7 +968,7 @@ ROM_START( drgw2c )
 	PGM_68K_BIOS
 	ROM_LOAD16_WORD_SWAP( "v-100c.u2",    0x100000, 0x080000, CRC(67467981) SHA1(58af01a3871b6179fe42ff471cc39a2161940043) )
 
-	ROM_REGION( 0x800000, "tiles",  0 ) /* 8x8 Text Tiles + 32x32 BG Tiles */
+	ROM_REGION( 0xa00000, "tiles",  0 ) /* 8x8 Text Tiles + 32x32 BG Tiles */
 	PGM_VIDEO_BIOS
 	ROM_LOAD( "pgmt0200.u7",    0x180000, 0x400000, CRC(b0f6534d) SHA1(174cacd81169a0e0d14790ac06d03caed737e05d) )
 
@@ -1010,7 +987,7 @@ ROM_START( drgw2j )
 	PGM_68K_BIOS
 	ROM_LOAD16_WORD_SWAP( "v-100j.u2",    0x100000, 0x080000, CRC(f8f8393e) SHA1(ef0db668b4e4f661d4c1e95d57afe881bcdf13cc) )
 
-	ROM_REGION( 0x800000, "tiles",  0 ) /* 8x8 Text Tiles + 32x32 BG Tiles */
+	ROM_REGION( 0xa00000, "tiles",  0 ) /* 8x8 Text Tiles + 32x32 BG Tiles */
 	PGM_VIDEO_BIOS
 	ROM_LOAD( "pgmt0200.u7",    0x180000, 0x400000, CRC(b0f6534d) SHA1(174cacd81169a0e0d14790ac06d03caed737e05d) )
 
@@ -1029,7 +1006,7 @@ ROM_START( drgw2hk ) // the IGS025 has a "DRAGON-II 0004-1" sticker, the IGS012 
 	PGM_68K_BIOS
 	ROM_LOAD16_WORD_SWAP( "dragon_ii_v-100-h.u2",    0x100000, 0x080000, CRC(c6e2e6ec) SHA1(84145dfb26857ea20efb233363f175bc9bb25b0c) )
 
-	ROM_REGION( 0x800000, "tiles",  0 ) /* 8x8 Text Tiles + 32x32 BG Tiles */
+	ROM_REGION( 0xa00000, "tiles",  0 ) /* 8x8 Text Tiles + 32x32 BG Tiles */
 	PGM_VIDEO_BIOS
 	ROM_LOAD( "pgmt0200.u7",    0x180000, 0x400000, CRC(b0f6534d) SHA1(174cacd81169a0e0d14790ac06d03caed737e05d) )
 
@@ -1068,7 +1045,7 @@ ROM_START( drgw3 )
 	ROM_REGION( 0x010000, "igs022data", 0 ) /* Protection Data - is it correct for this set? */
 	ROM_LOAD( "dw3_v100.u15", 0x000000, 0x010000, CRC(03dc4fdf) SHA1(b329b04325d4f725231b1bb7862eedef2319b652) )
 
-	ROM_REGION( 0xc00000, "tiles", 0 ) /* 8x8 Text Tiles + 32x32 BG Tiles */
+	ROM_REGION( 0xa00000, "tiles", 0 ) /* 8x8 Text Tiles + 32x32 BG Tiles */
 	PGM_VIDEO_BIOS
 	ROM_LOAD( "dw3t0400.u18",   0x180000, 0x400000, CRC(b70f3357) SHA1(8733969d7d21f540f295a9f747a4bb8f0d325cf0) )
 
@@ -1094,7 +1071,7 @@ ROM_START( drgw3105 )
 	ROM_REGION( 0x010000, "igs022data", 0 ) /* Protection Data - is it correct for this set? */
 	ROM_LOAD( "dw3_v100.u15", 0x000000, 0x010000, CRC(03dc4fdf) SHA1(b329b04325d4f725231b1bb7862eedef2319b652) )
 
-	ROM_REGION( 0xc00000, "tiles", 0 ) /* 8x8 Text Tiles + 32x32 BG Tiles */
+	ROM_REGION( 0xa00000, "tiles", 0 ) /* 8x8 Text Tiles + 32x32 BG Tiles */
 	PGM_VIDEO_BIOS
 	ROM_LOAD( "dw3t0400.u18",   0x180000, 0x400000, CRC(b70f3357) SHA1(8733969d7d21f540f295a9f747a4bb8f0d325cf0) )
 
@@ -1119,7 +1096,7 @@ ROM_START( drgw3103 )
 	ROM_REGION( 0x010000, "igs022data", 0 ) /* Protection Data */
 	ROM_LOAD( "dw3_v100.u15", 0x000000, 0x010000, CRC(03dc4fdf) SHA1(b329b04325d4f725231b1bb7862eedef2319b652) )
 
-	ROM_REGION( 0xc00000, "tiles", 0 ) /* 8x8 Text Tiles + 32x32 BG Tiles */
+	ROM_REGION( 0xa00000, "tiles", 0 ) /* 8x8 Text Tiles + 32x32 BG Tiles */
 	PGM_VIDEO_BIOS
 	ROM_LOAD( "dw3t0400.u18",   0x180000, 0x400000, CRC(b70f3357) SHA1(8733969d7d21f540f295a9f747a4bb8f0d325cf0) )
 
@@ -1167,7 +1144,7 @@ ROM_START( drgw3100 )
 	ROM_REGION( 0x010000, "igs022data", 0 ) /* Protection Data */
 	ROM_LOAD( "dw3_v100.u15", 0x000000, 0x010000, CRC(03dc4fdf) SHA1(b329b04325d4f725231b1bb7862eedef2319b652) )
 
-	ROM_REGION( 0xc00000, "tiles", 0 ) /* 8x8 Text Tiles + 32x32 BG Tiles */
+	ROM_REGION( 0xa00000, "tiles", 0 ) /* 8x8 Text Tiles + 32x32 BG Tiles */
 	PGM_VIDEO_BIOS
 	ROM_LOAD( "dw3t0400.u18",   0x180000, 0x400000, CRC(b70f3357) SHA1(8733969d7d21f540f295a9f747a4bb8f0d325cf0) )
 
@@ -1219,7 +1196,7 @@ ROM_START( dwex )
 	ROM_REGION( 0x010000, "igs022data", 0 ) /* Protection Data */
 	ROM_LOAD( "ex_data.u15", 0x000000, 0x010000, CRC(03dc4fdf) SHA1(b329b04325d4f725231b1bb7862eedef2319b652) )
 
-	ROM_REGION( 0xc00000, "tiles", 0 ) /* 8x8 Text Tiles + 32x32 BG Tiles */
+	ROM_REGION( 0x500000, "tiles", 0 ) /* 8x8 Text Tiles + 32x32 BG Tiles */
 	PGM_VIDEO_BIOS
 	ROM_LOAD( "ex_t0400.u18", 0x180000, 0x200000, CRC(9ecc950d) SHA1(fd97f43818a3eb18254636166871fa09bd0d6c07) )
 
@@ -1244,7 +1221,7 @@ ROM_START( kov )
 	ROM_REGION( 0x4000, "prot", 0 ) /* ARM protection ASIC - internal rom */
 	ROM_LOAD( "kov_igs027a.bin", 0x000000, 0x04000, NO_DUMP )
 
-	ROM_REGION( 0xc00000, "tiles", 0 ) /* 8x8 Text Tiles + 32x32 BG Tiles */
+	ROM_REGION( 0xa00000, "tiles", 0 ) /* 8x8 Text Tiles + 32x32 BG Tiles */
 	PGM_VIDEO_BIOS
 	ROM_LOAD( "t0600.rom",    0x180000, 0x800000, CRC(4acc1ad6) SHA1(0668dbd5e856c2406910c6b7382548b37c631780) )
 
@@ -1271,7 +1248,7 @@ ROM_START( kov115 )
 	ROM_REGION( 0x4000, "prot", 0 ) /* ARM protection ASIC - internal rom */
 	ROM_LOAD( "kov_igs027a.bin", 0x000000, 0x04000, NO_DUMP )
 
-	ROM_REGION( 0xc00000, "tiles", 0 ) /* 8x8 Text Tiles + 32x32 BG Tiles */
+	ROM_REGION( 0xa00000, "tiles", 0 ) /* 8x8 Text Tiles + 32x32 BG Tiles */
 	PGM_VIDEO_BIOS
 	ROM_LOAD( "t0600.rom",    0x180000, 0x800000, CRC(4acc1ad6) SHA1(0668dbd5e856c2406910c6b7382548b37c631780) )
 
@@ -1333,7 +1310,7 @@ ROM_START( kov100 )
 	ROM_REGION( 0x4000, "prot", 0 ) /* ARM protection ASIC - internal rom */
 	ROM_LOAD( "kov_igs027a.bin", 0x000000, 0x04000, NO_DUMP )
 
-	ROM_REGION( 0xc00000, "tiles", 0 ) /* 8x8 Text Tiles + 32x32 BG Tiles */
+	ROM_REGION( 0xa00000, "tiles", 0 ) /* 8x8 Text Tiles + 32x32 BG Tiles */
 	PGM_VIDEO_BIOS
 	ROM_LOAD( "t0600.rom",    0x180000, 0x800000, CRC(4acc1ad6) SHA1(0668dbd5e856c2406910c6b7382548b37c631780) )
 
@@ -1364,7 +1341,7 @@ ROM_START( kov100hk )
 	ROM_REGION( 0x4000, "prot", 0 ) /* ARM protection ASIC - internal rom */
 	ROM_LOAD( "kov_igs027.bin", 0x000000, 0x04000, NO_DUMP ) // IGS 027 55857E 100 9901 HONG KONG
 
-	ROM_REGION( 0xc00000, "tiles", 0 ) /* 8x8 Text Tiles + 32x32 BG Tiles */
+	ROM_REGION( 0xa00000, "tiles", 0 ) /* 8x8 Text Tiles + 32x32 BG Tiles */
 	PGM_VIDEO_BIOS
 	ROM_LOAD( "t0600.rom",    0x180000, 0x800000, CRC(4acc1ad6) SHA1(0668dbd5e856c2406910c6b7382548b37c631780) )
 
@@ -1391,7 +1368,7 @@ ROM_START( kovplus )
 	ROM_REGION( 0x4000, "prot", 0 ) /* ARM protection ASIC - internal rom */
 	ROM_LOAD( "kov_igs027a.bin", 0x000000, 0x04000, NO_DUMP )
 
-	ROM_REGION( 0xc00000, "tiles", 0 ) /* 8x8 Text Tiles + 32x32 BG Tiles */
+	ROM_REGION( 0xa00000, "tiles", 0 ) /* 8x8 Text Tiles + 32x32 BG Tiles */
 	PGM_VIDEO_BIOS
 	ROM_LOAD( "t0600.rom",    0x180000, 0x800000, CRC(4acc1ad6) SHA1(0668dbd5e856c2406910c6b7382548b37c631780) )
 
@@ -1454,7 +1431,7 @@ ROM_START( kovplusa )
 	ROM_REGION( 0x4000, "prot", 0 ) /* ARM protection ASIC - internal rom */
 	ROM_LOAD( "kov_igs027a.bin", 0x000000, 0x04000, NO_DUMP )
 
-	ROM_REGION( 0xc00000, "tiles", 0 ) /* 8x8 Text Tiles + 32x32 BG Tiles */
+	ROM_REGION( 0xa00000, "tiles", 0 ) /* 8x8 Text Tiles + 32x32 BG Tiles */
 	PGM_VIDEO_BIOS
 	ROM_LOAD( "t0600.rom",    0x180000, 0x800000, CRC(4acc1ad6) SHA1(0668dbd5e856c2406910c6b7382548b37c631780) )
 
@@ -1481,7 +1458,7 @@ ROM_START( kovsgqyz )
 	ROM_REGION( 0x4000, "prot", 0 ) /* ARM protection ASIC - internal rom */
 	ROM_LOAD( "kovsgqyz_igs027a.bin", 0x000000, 0x04000, NO_DUMP ) // bootleg is probably a different device
 
-	ROM_REGION( 0xc00000, "tiles", 0 ) /* 8x8 Text Tiles + 32x32 BG Tiles */
+	ROM_REGION( 0xa00000, "tiles", 0 ) /* 8x8 Text Tiles + 32x32 BG Tiles */
 	PGM_VIDEO_BIOS
 	ROM_LOAD( "t0600.rom",    0x180000, 0x800000, CRC(4acc1ad6) SHA1(0668dbd5e856c2406910c6b7382548b37c631780) )
 
@@ -1508,7 +1485,7 @@ ROM_START( kovsgqyza )
 	ROM_REGION( 0x4000, "prot", 0 ) /* ARM protection ASIC - internal rom */
 	ROM_LOAD( "kovsgqyza_igs027a.bin", 0x000000, 0x04000, NO_DUMP ) // bootleg is probably a different device
 
-	ROM_REGION( 0xc00000, "tiles", 0 ) /* 8x8 Text Tiles + 32x32 BG Tiles */
+	ROM_REGION( 0xa00000, "tiles", 0 ) /* 8x8 Text Tiles + 32x32 BG Tiles */
 	PGM_VIDEO_BIOS
 	ROM_LOAD( "t0600.rom",    0x180000, 0x800000, CRC(4acc1ad6) SHA1(0668dbd5e856c2406910c6b7382548b37c631780) )
 
@@ -1535,7 +1512,7 @@ ROM_START( kovsgqyzb )
 	ROM_REGION( 0x4000, "prot", 0 ) /* ARM protection ASIC - internal rom */
 	ROM_LOAD( "kovsgqyzb_igs027a.bin", 0x000000, 0x04000, NO_DUMP ) // bootleg is probably a different device
 
-	ROM_REGION( 0xc00000, "tiles", 0 ) /* 8x8 Text Tiles + 32x32 BG Tiles */
+	ROM_REGION( 0xa00000, "tiles", 0 ) /* 8x8 Text Tiles + 32x32 BG Tiles */
 	PGM_VIDEO_BIOS
 	ROM_LOAD( "t0600.rom",    0x180000, 0x800000, CRC(4acc1ad6) SHA1(0668dbd5e856c2406910c6b7382548b37c631780) )
 
@@ -1566,7 +1543,7 @@ ROM_START( kovsh )
 	ROM_REGION( 0x4000, "prot", 0 ) /* ARM protection ASIC - internal rom */
 	ROM_LOAD( "kovsh_v100_china.asic", 0x000000, 0x04000,  CRC(0f09a5c1) SHA1(621b38c05f33277608d58b49822aebc930ae4870) )
 
-	ROM_REGION( 0xc00000, "tiles", 0 ) /* 8x8 Text Tiles + 32x32 BG Tiles */
+	ROM_REGION( 0xa00000, "tiles", 0 ) /* 8x8 Text Tiles + 32x32 BG Tiles */
 	PGM_VIDEO_BIOS
 	ROM_LOAD( "t0600.rom",    0x180000, 0x800000, CRC(4acc1ad6) SHA1(0668dbd5e856c2406910c6b7382548b37c631780) )
 
@@ -1596,7 +1573,7 @@ ROM_START( kovsh103 )
 	ROM_REGION( 0x4000, "prot", 0 ) /* ARM protection ASIC - internal rom */
 	ROM_LOAD( "kovsh_v100_china.asic", 0x000000, 0x04000,  CRC(0f09a5c1) SHA1(621b38c05f33277608d58b49822aebc930ae4870) )
 
-	ROM_REGION( 0xc00000, "tiles", 0 ) /* 8x8 Text Tiles + 32x32 BG Tiles */
+	ROM_REGION( 0xa00000, "tiles", 0 ) /* 8x8 Text Tiles + 32x32 BG Tiles */
 	PGM_VIDEO_BIOS
 	ROM_LOAD( "t0600.rom",    0x180000, 0x800000, CRC(4acc1ad6) SHA1(0668dbd5e856c2406910c6b7382548b37c631780) )
 
@@ -1626,7 +1603,7 @@ ROM_START( kovsh102 )
 	ROM_REGION( 0x4000, "prot", 0 ) /* ARM protection ASIC - internal rom */
 	ROM_LOAD( "kovsh_v100_china.asic", 0x000000, 0x04000,  CRC(0f09a5c1) SHA1(621b38c05f33277608d58b49822aebc930ae4870) )
 
-	ROM_REGION( 0xc00000, "tiles", 0 ) /* 8x8 Text Tiles + 32x32 BG Tiles */
+	ROM_REGION( 0xa00000, "tiles", 0 ) /* 8x8 Text Tiles + 32x32 BG Tiles */
 	PGM_VIDEO_BIOS
 	ROM_LOAD( "t0600.rom",    0x180000, 0x800000, CRC(4acc1ad6) SHA1(0668dbd5e856c2406910c6b7382548b37c631780) )
 
@@ -1656,7 +1633,7 @@ ROM_START( kovsh101 )
 	ROM_REGION( 0x4000, "prot", 0 ) /* ARM protection ASIC - internal rom */
 	ROM_LOAD( "kovsh_v100_china.asic", 0x000000, 0x04000,  CRC(0f09a5c1) SHA1(621b38c05f33277608d58b49822aebc930ae4870) )
 
-	ROM_REGION( 0xc00000, "tiles", 0 ) /* 8x8 Text Tiles + 32x32 BG Tiles */
+	ROM_REGION( 0xa00000, "tiles", 0 ) /* 8x8 Text Tiles + 32x32 BG Tiles */
 	PGM_VIDEO_BIOS
 	ROM_LOAD( "t0600.rom",    0x180000, 0x800000, CRC(4acc1ad6) SHA1(0668dbd5e856c2406910c6b7382548b37c631780) )
 
@@ -1686,7 +1663,7 @@ ROM_START( kovsh100 )
 	ROM_REGION( 0x4000, "prot", 0 ) /* ARM protection ASIC - internal rom */
 	ROM_LOAD( "kovsh_v100_china.asic", 0x000000, 0x04000,  CRC(0f09a5c1) SHA1(621b38c05f33277608d58b49822aebc930ae4870) )
 
-	ROM_REGION( 0xc00000, "tiles", 0 ) /* 8x8 Text Tiles + 32x32 BG Tiles */
+	ROM_REGION( 0xa00000, "tiles", 0 ) /* 8x8 Text Tiles + 32x32 BG Tiles */
 	PGM_VIDEO_BIOS
 	ROM_LOAD( "t0600.rom",    0x180000, 0x800000, CRC(4acc1ad6) SHA1(0668dbd5e856c2406910c6b7382548b37c631780) )
 
@@ -1716,7 +1693,7 @@ ROM_START( kovqhsgs )
 	ROM_REGION( 0x4000, "prot", 0 ) /* ARM protection ASIC - internal rom */
 	ROM_LOAD( "qhsg_prot.c51", 0x000000, 0x04000, BAD_DUMP CRC(0f09a5c1) SHA1(621b38c05f33277608d58b49822aebc930ae4870) )
 
-	ROM_REGION( 0xc00000, "tiles",  0 ) /* 8x8 Text Tiles + 32x32 BG Tiles */
+	ROM_REGION( 0xa00000, "tiles",  0 ) /* 8x8 Text Tiles + 32x32 BG Tiles */
 	PGM_VIDEO_BIOS
 	ROM_LOAD( "lsqh2_t01.rom",0x180000, 0x800000, CRC(d498d97f) SHA1(97a7b6d2ed1170449e7c2899448af7cbbca4c94f) )
 	ROM_IGNORE( 0x800000 )  // second half identical
@@ -1757,7 +1734,7 @@ ROM_START( photoy2k )
 	ROM_REGION( 0x4000, "prot", 0 ) /* ARM protection ASIC - internal rom */
 	ROM_LOAD( "igs027a_photoy2k_v100_china.asic", 0x000000, 0x04000, CRC(1a0b68f6) SHA1(290441ed652f54b26ace8f59a26220881fb62084) ) // 3 bytes differ from the read in the other sets.  I think this one is GOOD and the other is bad.  This always gives the same read, so unless the actual chips is bad... TBC
 
-	ROM_REGION( 0x480000, "tiles", 0 ) /* 8x8 Text Tiles + 32x32 BG Tiles */
+	ROM_REGION( 0x280000, "tiles", 0 ) /* 8x8 Text Tiles + 32x32 BG Tiles */
 	PGM_VIDEO_BIOS
 	ROM_LOAD( "t0700.rom",    0x180000, 0x080000, CRC(93943b4d) SHA1(3b439903853727d45d62c781af6073024eb3c5a3) )
 
@@ -1787,7 +1764,7 @@ ROM_START( photoy2k104 )
 	ROM_REGION( 0x4000, "prot", 0 ) /* ARM protection ASIC - internal rom */
 	ROM_LOAD( "igs027a_photoy2k_v100_china_alt.asic", 0x000000, 0x04000,  CRC(6dd7f257) SHA1(1984f98a282d8b3264674f231c3b7def1757cf72) )
 
-	ROM_REGION( 0x480000, "tiles", 0 ) /* 8x8 Text Tiles + 32x32 BG Tiles */
+	ROM_REGION( 0x280000, "tiles", 0 ) /* 8x8 Text Tiles + 32x32 BG Tiles */
 	PGM_VIDEO_BIOS
 	ROM_LOAD( "t0700.rom",    0x180000, 0x080000, CRC(93943b4d) SHA1(3b439903853727d45d62c781af6073024eb3c5a3) )
 
@@ -1849,7 +1826,7 @@ ROM_START( photoy2k102 )
 	ROM_REGION( 0x4000, "prot", 0 ) /* ARM protection ASIC - internal rom */
 	ROM_LOAD( "igs027a_photoy2k_v100_china_alt.asic", 0x000000, 0x04000,  CRC(6dd7f257) SHA1(1984f98a282d8b3264674f231c3b7def1757cf72) )
 
-	ROM_REGION( 0x480000, "tiles", 0 ) /* 8x8 Text Tiles + 32x32 BG Tiles */
+	ROM_REGION( 0x280000, "tiles", 0 ) /* 8x8 Text Tiles + 32x32 BG Tiles */
 	PGM_VIDEO_BIOS
 	ROM_LOAD( "t0700.rom",    0x180000, 0x080000, CRC(93943b4d) SHA1(3b439903853727d45d62c781af6073024eb3c5a3) )
 
@@ -1898,7 +1875,7 @@ ROM_START( py2k2 )
 	ROM_REGION( 0x4000, "prot", 0 ) /* ARM protection ASIC - internal rom */
 	ROM_LOAD( "igs027a_photoy2k2.asic", 0x000000, 0x04000, NO_DUMP )
 
-	ROM_REGION( 0x480000, "tiles", 0 ) /* 8x8 Text Tiles + 32x32 BG Tiles */
+	ROM_REGION( 0x280000, "tiles", 0 ) /* 8x8 Text Tiles + 32x32 BG Tiles */
 	PGM_VIDEO_BIOS
 	/* no extra tilemap rom */
 
@@ -1928,7 +1905,7 @@ ROM_START( pgm3in1 )
 
 	/* No external ARM rom */
 
-	ROM_REGION( 0x380000, "tiles", 0 ) /* 8x8 Text Tiles + 32x32 BG Tiles */
+	ROM_REGION( 0x500000, "tiles", 0 ) /* 8x8 Text Tiles + 32x32 BG Tiles */
 	PGM_VIDEO_BIOS
 	ROM_LOAD( "u5.u5",    0x180000, 0x200000, CRC(da375a50) SHA1(62cd2fd3dfc1897528eaa38d243d7a9526eac71b) )
 
@@ -2041,7 +2018,7 @@ ROM_START( killbld )
 	ROM_REGION( 0x010000, "igs022data", 0 ) /* Protection Data */
 	ROM_LOAD( "kb_u2.rom", 0x000000, 0x010000,  CRC(de3eae63) SHA1(03af767ef764055bda528b5cc6a24b9e1218cca8) )
 
-	ROM_REGION( 0x800000, "tiles", 0 ) /* 8x8 Text Tiles + 32x32 BG Tiles */
+	ROM_REGION( 0xa00000, "tiles", 0 ) /* 8x8 Text Tiles + 32x32 BG Tiles */
 	PGM_VIDEO_BIOS
 	ROM_LOAD( "t0300.u14",    0x180000, 0x400000, CRC(0922f7d9) SHA1(4302b4b7369e13f315fad14f7d6cad1321101d24) )
 
@@ -2077,7 +2054,7 @@ ROM_START( killbld104 )
 	ROM_REGION( 0x010000, "igs022data", 0 ) /* Protection Data */
 	ROM_LOAD( "kb_u2_v104.u2", 0x000000, 0x010000,  CRC(c970f6d5) SHA1(399fc6f80262784c566363c847dc3fdc4fb37494) )
 
-	ROM_REGION( 0x800000, "tiles", 0 ) /* 8x8 Text Tiles + 32x32 BG Tiles */
+	ROM_REGION( 0xa00000, "tiles", 0 ) /* 8x8 Text Tiles + 32x32 BG Tiles */
 	PGM_VIDEO_BIOS
 	ROM_LOAD( "t0300.u14",    0x180000, 0x400000, CRC(0922f7d9) SHA1(4302b4b7369e13f315fad14f7d6cad1321101d24) )
 
@@ -2113,7 +2090,7 @@ ROM_START( killbld106 )
 	ROM_REGION( 0x010000, "igs022data", 0 ) /* Protection Data */
 	ROM_LOAD( "kb_u2_v106.u2", 0x000000, 0x010000,  CRC(5df8cf51) SHA1(d82e281a43015da653fc37e97f52943e03a07112) )
 
-	ROM_REGION( 0x800000, "tiles", 0 ) /* 8x8 Text Tiles + 32x32 BG Tiles */
+	ROM_REGION( 0xa00000, "tiles", 0 ) /* 8x8 Text Tiles + 32x32 BG Tiles */
 	PGM_VIDEO_BIOS
 	ROM_LOAD( "t0300.u14",    0x180000, 0x400000, CRC(0922f7d9) SHA1(4302b4b7369e13f315fad14f7d6cad1321101d24) )
 
@@ -2201,7 +2178,7 @@ ROM_START( puzlstar )
 	ROM_REGION( 0x4000, "prot", 0 ) /* ARM protection ASIC - internal rom */
 	ROM_LOAD( "puzlstar_igs027a.bin", 0x000000, 0x04000, NO_DUMP )
 
-	ROM_REGION( 0xc00000, "tiles", 0 ) /* 8x8 Text Tiles + 32x32 BG Tiles */
+	ROM_REGION( 0x500000, "tiles", 0 ) /* 8x8 Text Tiles + 32x32 BG Tiles */
 	PGM_VIDEO_BIOS
 	ROM_LOAD( "t0800.u5",    0x180000, 0x200000, CRC(f9d84e59) SHA1(80ec77025ac5bf355b1a60f2a678dd4c56071f6b) )
 
@@ -2281,7 +2258,7 @@ ROM_START( olds103t )
 	PGM_68K_BIOS
 	ROM_LOAD16_WORD_SWAP( "p0500.v103",0x100000, 0x400000, CRC(17e32e14) SHA1(b8f731087af2c59fe5b1da31f1cb055d35c8b440) )
 
-	ROM_REGION( 0xc00000, "tiles",  0 ) /* 8x8 Text Tiles + 32x32 BG Tiles */
+	ROM_REGION( 0xa00000, "tiles",  0 ) /* 8x8 Text Tiles + 32x32 BG Tiles */
 	PGM_VIDEO_BIOS
 	ROM_LOAD( "t0500.rom",    0x180000, 0x400000, CRC(d881726c) SHA1(a82517e665996f7b7017c940f1fcf016fccb65c2) )
 	ROM_LOAD( "t0501.rom",    0x580000, 0x200000, CRC(d2106864) SHA1(65d827135b87d82196433aea3279608ee263feca) )
@@ -2322,7 +2299,7 @@ ROM_START( olds )
 	// clearly not for this revision
 	ROM_LOAD( "ram_dump", 0x000000, 0x04000, CRC(280cfb4e) SHA1(cd2bdcaa21347952c2bf38b105a204d327fde39e) )
 
-	ROM_REGION( 0xc00000, "tiles",  0 ) /* 8x8 Text Tiles + 32x32 BG Tiles */
+	ROM_REGION( 0xa00000, "tiles",  0 ) /* 8x8 Text Tiles + 32x32 BG Tiles */
 	PGM_VIDEO_BIOS
 	ROM_LOAD( "t0500.rom",    0x180000, 0x400000, CRC(d881726c) SHA1(a82517e665996f7b7017c940f1fcf016fccb65c2) )
 	ROM_LOAD( "t0501.rom",    0x580000, 0x200000, CRC(d2106864) SHA1(65d827135b87d82196433aea3279608ee263feca) )
@@ -2364,7 +2341,7 @@ ROM_START( olds100 )
 	ROM_REGION( 0x010000, "user1", 0 ) /* IGS028 Protection Data */
 	ROM_LOAD( "kd-u6.512", 0x000000, 0x010000,  CRC(e7613dda) SHA1(0d7c043b90e2f9a36a45066f22e3e305dc716676) )
 
-	ROM_REGION( 0xc00000, "tiles",  0 ) /* 8x8 Text Tiles + 32x32 BG Tiles */
+	ROM_REGION( 0xa00000, "tiles",  0 ) /* 8x8 Text Tiles + 32x32 BG Tiles */
 	PGM_VIDEO_BIOS
 	ROM_LOAD( "t0500.rom",    0x180000, 0x400000, CRC(d881726c) SHA1(a82517e665996f7b7017c940f1fcf016fccb65c2) )
 	ROM_LOAD( "t0501.rom",    0x580000, 0x200000, CRC(d2106864) SHA1(65d827135b87d82196433aea3279608ee263feca) )
@@ -2403,7 +2380,7 @@ ROM_START( olds100a )
 	// used to simulate encrypted DMA protection device for now ..
 	ROM_LOAD( "ram_dump", 0x000000, 0x04000, CRC(280cfb4e) SHA1(cd2bdcaa21347952c2bf38b105a204d327fde39e) )
 
-	ROM_REGION( 0xc00000, "tiles",  0 ) /* 8x8 Text Tiles + 32x32 BG Tiles */
+	ROM_REGION( 0xa00000, "tiles",  0 ) /* 8x8 Text Tiles + 32x32 BG Tiles */
 	PGM_VIDEO_BIOS
 	ROM_LOAD( "t0500.rom",    0x180000, 0x400000, CRC(d881726c) SHA1(a82517e665996f7b7017c940f1fcf016fccb65c2) )
 	ROM_LOAD( "t0501.rom",    0x580000, 0x200000, CRC(d2106864) SHA1(65d827135b87d82196433aea3279608ee263feca) )
@@ -2440,7 +2417,7 @@ ROM_START( kov2 )
 	ROM_REGION32_LE( 0x400000, "user1", 0 ) /* Protection Data (encrypted external ARM data) */
 	ROM_LOAD( "u19.102", 0x000000, 0x200000,   CRC(462e2980) SHA1(3da7c3d2c65b59f50c78be1c25922b71d40f6080) )
 
-	ROM_REGION( 0xc00000, "tiles", 0 ) /* 8x8 Text Tiles + 32x32 BG Tiles */
+	ROM_REGION( 0xa00000, "tiles", 0 ) /* 8x8 Text Tiles + 32x32 BG Tiles */
 	PGM_VIDEO_BIOS
 	ROM_LOAD( "t1200.rom",    0x180000, 0x800000, CRC(d7e26609) SHA1(bdad810f82fcf1d50a8791bdc495374ec5a309c6) )
 
@@ -2470,7 +2447,7 @@ ROM_START( kov2106 )
 	ROM_REGION32_LE( 0x400000, "user1", 0 ) /* Protection Data (encrypted external ARM data) */
 	ROM_LOAD( "u19.102", 0x000000, 0x200000,   CRC(462e2980) SHA1(3da7c3d2c65b59f50c78be1c25922b71d40f6080) )
 
-	ROM_REGION( 0xc00000, "tiles", 0 ) /* 8x8 Text Tiles + 32x32 BG Tiles */
+	ROM_REGION( 0xa00000, "tiles", 0 ) /* 8x8 Text Tiles + 32x32 BG Tiles */
 	PGM_VIDEO_BIOS
 	ROM_LOAD( "t1200.rom",    0x180000, 0x800000, CRC(d7e26609) SHA1(bdad810f82fcf1d50a8791bdc495374ec5a309c6) )
 
@@ -2501,7 +2478,7 @@ ROM_START( kov2104 )
 	ROM_REGION32_LE( 0x400000, "user1", 0 ) /* Protection Data (encrypted external ARM data) */
 	ROM_LOAD( "u19.102", 0x000000, 0x200000,   CRC(462e2980) SHA1(3da7c3d2c65b59f50c78be1c25922b71d40f6080) )
 
-	ROM_REGION( 0xc00000, "tiles", 0 ) /* 8x8 Text Tiles + 32x32 BG Tiles */
+	ROM_REGION( 0xa00000, "tiles", 0 ) /* 8x8 Text Tiles + 32x32 BG Tiles */
 	PGM_VIDEO_BIOS
 	ROM_LOAD( "t1200.rom",    0x180000, 0x800000, CRC(d7e26609) SHA1(bdad810f82fcf1d50a8791bdc495374ec5a309c6) )
 
@@ -2532,7 +2509,7 @@ ROM_START( kov2103 )
 	ROM_REGION32_LE( 0x400000, "user1", 0 ) /* Protection Data (encrypted external ARM data) */
 	ROM_LOAD( "u19.101", 0x000000, 0x200000, CRC(8c35f2fe) SHA1(d4858f97fcfad0f342fccbc9cf1590276cc3c69c) )
 
-	ROM_REGION( 0xc00000, "tiles", 0 ) /* 8x8 Text Tiles + 32x32 BG Tiles */
+	ROM_REGION( 0xa00000, "tiles", 0 ) /* 8x8 Text Tiles + 32x32 BG Tiles */
 	PGM_VIDEO_BIOS
 	ROM_LOAD( "t1200.rom",    0x180000, 0x800000, CRC(d7e26609) SHA1(bdad810f82fcf1d50a8791bdc495374ec5a309c6) )
 
@@ -2563,7 +2540,7 @@ ROM_START( kov2102 )
 	ROM_REGION32_LE( 0x400000, "user1", 0 ) /* Protection Data (encrypted external ARM data) */
 	ROM_LOAD( "u19.101", 0x000000, 0x200000, CRC(8c35f2fe) SHA1(d4858f97fcfad0f342fccbc9cf1590276cc3c69c) )
 
-	ROM_REGION( 0xc00000, "tiles", 0 ) /* 8x8 Text Tiles + 32x32 BG Tiles */
+	ROM_REGION( 0xa00000, "tiles", 0 ) /* 8x8 Text Tiles + 32x32 BG Tiles */
 	PGM_VIDEO_BIOS
 	ROM_LOAD( "t1200.rom",    0x180000, 0x800000, CRC(d7e26609) SHA1(bdad810f82fcf1d50a8791bdc495374ec5a309c6) )
 
@@ -2594,7 +2571,7 @@ ROM_START( kov2101 )
 	ROM_REGION32_LE( 0x400000, "user1", 0 ) /* Protection Data (encrypted external ARM data) */
 	ROM_LOAD( "u19.101", 0x000000, 0x200000, CRC(8c35f2fe) SHA1(d4858f97fcfad0f342fccbc9cf1590276cc3c69c) )
 
-	ROM_REGION( 0xc00000, "tiles", 0 ) /* 8x8 Text Tiles + 32x32 BG Tiles */
+	ROM_REGION( 0xa00000, "tiles", 0 ) /* 8x8 Text Tiles + 32x32 BG Tiles */
 	PGM_VIDEO_BIOS
 	ROM_LOAD( "t1200.rom",    0x180000, 0x800000, CRC(d7e26609) SHA1(bdad810f82fcf1d50a8791bdc495374ec5a309c6) )
 
@@ -2625,7 +2602,7 @@ ROM_START( kov2100 )
 	ROM_REGION32_LE( 0x400000, "user1", 0 ) /* Protection Data (encrypted external ARM data) */
 	ROM_LOAD( "u19.100", 0x000000, 0x200000,   CRC(edd59922) SHA1(09b14f20f685944a93292c83e5830849aade42c9) )
 
-	ROM_REGION( 0xc00000, "tiles", 0 ) /* 8x8 Text Tiles + 32x32 BG Tiles */
+	ROM_REGION( 0xa00000, "tiles", 0 ) /* 8x8 Text Tiles + 32x32 BG Tiles */
 	PGM_VIDEO_BIOS
 	ROM_LOAD( "t1200.rom",    0x180000, 0x800000, CRC(d7e26609) SHA1(bdad810f82fcf1d50a8791bdc495374ec5a309c6) )
 
@@ -2657,7 +2634,7 @@ ROM_START( kov2p )
 	ROM_REGION32_LE( 0x400000, "user1", 0 ) /* Protection Data (encrypted external ARM data) */
 	ROM_LOAD( "v200-16.rom", 0x000000, 0x200000,  CRC(16a0c11f) SHA1(ce449cef76ebd5657d49b57951e2eb0f132e203e) )
 
-	ROM_REGION( 0xc00000, "tiles", 0 ) /* 8x8 Text Tiles + 32x32 BG Tiles */
+	ROM_REGION( 0xa00000, "tiles", 0 ) /* 8x8 Text Tiles + 32x32 BG Tiles */
 	PGM_VIDEO_BIOS
 	ROM_LOAD( "t1200.rom",    0x180000, 0x800000, CRC(d7e26609) SHA1(bdad810f82fcf1d50a8791bdc495374ec5a309c6) )
 
@@ -2688,7 +2665,7 @@ ROM_START( kov2p204 )
 	ROM_REGION32_LE( 0x400000, "user1", 0 ) /* Protection Data (encrypted external ARM data) */
 	ROM_LOAD( "v200-16.rom", 0x000000, 0x200000,  CRC(16a0c11f) SHA1(ce449cef76ebd5657d49b57951e2eb0f132e203e) )
 
-	ROM_REGION( 0xc00000, "tiles", 0 ) /* 8x8 Text Tiles + 32x32 BG Tiles */
+	ROM_REGION( 0xa00000, "tiles", 0 ) /* 8x8 Text Tiles + 32x32 BG Tiles */
 	PGM_VIDEO_BIOS
 	ROM_LOAD( "t1200.rom",    0x180000, 0x800000, CRC(d7e26609) SHA1(bdad810f82fcf1d50a8791bdc495374ec5a309c6) )
 
@@ -2719,7 +2696,7 @@ ROM_START( kov2p202 )
 	ROM_REGION32_LE( 0x400000, "user1", 0 ) /* Protection Data (encrypted external ARM data) */
 	ROM_LOAD( "v200-16.rom", 0x000000, 0x200000,  CRC(16a0c11f) SHA1(ce449cef76ebd5657d49b57951e2eb0f132e203e) )
 
-	ROM_REGION( 0xc00000, "tiles", 0 ) /* 8x8 Text Tiles + 32x32 BG Tiles */
+	ROM_REGION( 0xa00000, "tiles", 0 ) /* 8x8 Text Tiles + 32x32 BG Tiles */
 	PGM_VIDEO_BIOS
 	ROM_LOAD( "t1200.rom",    0x180000, 0x800000, CRC(d7e26609) SHA1(bdad810f82fcf1d50a8791bdc495374ec5a309c6) )
 
@@ -2750,7 +2727,7 @@ ROM_START( kov2p200 )
 	ROM_REGION32_LE( 0x400000, "user1", 0 ) /* Protection Data (encrypted external ARM data) */
 	ROM_LOAD( "v200-16.rom", 0x000000, 0x200000,  CRC(16a0c11f) SHA1(ce449cef76ebd5657d49b57951e2eb0f132e203e) )
 
-	ROM_REGION( 0xc00000, "tiles", 0 ) /* 8x8 Text Tiles + 32x32 BG Tiles */
+	ROM_REGION( 0xa00000, "tiles", 0 ) /* 8x8 Text Tiles + 32x32 BG Tiles */
 	PGM_VIDEO_BIOS
 	ROM_LOAD( "t1200.rom",    0x180000, 0x800000, CRC(d7e26609) SHA1(bdad810f82fcf1d50a8791bdc495374ec5a309c6) )
 
@@ -2817,7 +2794,7 @@ Some logic IC's, resistors, caps etc.
 #define DDP2_COMMON_ROMS \
 	ROM_REGION32_LE( 0x400000, "user1", 0 ) /* Protection Data (encrypted external ARM data) */ \
 	ROM_LOAD( "v100.u23", 0x000000, 0x20000, CRC(06c3dd29) SHA1(20c9479f158467fc2037dcf162b6c6be18c91d46) ) \
-	ROM_REGION( 0xc00000, "tiles", 0 ) /* 8x8 Text Tiles + 32x32 BG Tiles */ \
+	ROM_REGION( 0xa00000, "tiles", 0 ) /* 8x8 Text Tiles + 32x32 BG Tiles */ \
 	PGM_VIDEO_BIOS \
 	ROM_LOAD( "t1300.u21",    0x180000, 0x800000, CRC(e748f0cb) SHA1(5843bee3a17c33648ce904af2b98c6a90aff7393) ) \
 	ROM_REGION( 0x1000000, "sprcol", 0 ) /* Sprite Colour Data */ \
@@ -2988,7 +2965,7 @@ ROM_START( dw2001 )
 	ROM_REGION32_LE( 0x4000000, "user1", ROMREGION_ERASEFF )
 	ROM_LOAD( "2001.u12", 0x000000, 0x80000, CRC(973db1ab) SHA1(cc35e1a8534fa5d59d888f530769bae4e08c62ca) ) // external ARM data rom (encrypted)
 
-	ROM_REGION( 0x600000, "tiles", 0 ) /* 8x8 Text Tiles + 32x32 BG Tiles */
+	ROM_REGION( 0x500000, "tiles", 0 ) /* 8x8 Text Tiles + 32x32 BG Tiles */
 	PGM_VIDEO_BIOS
 	ROM_LOAD( "2001.u11",    0x180000, 0x200000, CRC(b27cf093) SHA1(7c5736a3d72b89742da1c92b2604d66e48b95e56) )
 
@@ -3016,7 +2993,7 @@ ROM_START( dwpc )
 	ROM_REGION32_LE( 0x4000000, "user1", ROMREGION_ERASEFF )
 	ROM_LOAD( "dwpc_v100jp.u12", 0x000000, 0x80000, CRC(0d112126) SHA1(2b569b8ef974d1d9906cc052eee63b869c8d4fa4) ) // external ARM data rom (encrypted)
 
-	ROM_REGION( 0x600000, "tiles", 0 ) /* 8x8 Text Tiles + 32x32 BG Tiles */
+	ROM_REGION( 0xa00000, "tiles", 0 ) /* 8x8 Text Tiles + 32x32 BG Tiles */
 	PGM_VIDEO_BIOS
 	ROM_LOAD( "dwpc_v100jp.u11",    0x180000, 0x400000, CRC(3aa5a787) SHA1(ef7bb83f7141b24621c86237244fd9f280923ed1) )
 
@@ -3094,7 +3071,7 @@ ROM_START( puzzli2 )
 	ROM_REGION( 0x4000, "prot", ROMREGION_ERASEFF ) /* ARM protection ASIC - internal rom */
 	ROM_LOAD( "puzzli2_igs027a.bin", 0x000000, 0x04000, NO_DUMP )
 
-	ROM_REGION( 0x600000, "tiles", 0 ) /* 8x8 Text Tiles + 32x32 BG Tiles */
+	ROM_REGION( 0x500000, "tiles", 0 ) /* 8x8 Text Tiles + 32x32 BG Tiles */
 	PGM_VIDEO_BIOS
 	ROM_LOAD( "t0900.u9",    0x180000, 0x200000, CRC(70615611) SHA1(a46d4aa71396947b427f9ba4ba0e636876c09d6b) )
 
@@ -3119,7 +3096,7 @@ ROM_START( puzzli2s )
 	ROM_REGION( 0x4000, "prot", ROMREGION_ERASEFF ) /* ARM protection ASIC - internal rom */
 	ROM_LOAD( "puzzli2_igs027a.bin", 0x000000, 0x04000, NO_DUMP )
 
-	ROM_REGION( 0x600000, "tiles", 0 ) /* 8x8 Text Tiles + 32x32 BG Tiles */
+	ROM_REGION( 0x500000, "tiles", 0 ) /* 8x8 Text Tiles + 32x32 BG Tiles */
 	PGM_VIDEO_BIOS
 	ROM_LOAD( "t0900.u9",    0x180000, 0x200000, CRC(70615611) SHA1(a46d4aa71396947b427f9ba4ba0e636876c09d6b) )
 
@@ -3205,7 +3182,7 @@ ROM_START( martmast )
 	ROM_REGION32_LE( 0x400000, "user1", 0 ) /* Protection Data (encrypted external ARM data) */
 	ROM_LOAD( "v102_16m.u10", 0x000000, 0x200000,  CRC(18b745e6) SHA1(7bcb58dd3a2d6072f492cf0dd7181cb061c1f49d) )
 
-	ROM_REGION( 0xc00000, "tiles", 0 ) /* 8x8 Text Tiles + 32x32 BG Tiles */
+	ROM_REGION( 0xa00000, "tiles", 0 ) /* 8x8 Text Tiles + 32x32 BG Tiles */
 	PGM_VIDEO_BIOS
 	ROM_LOAD( "t1000.u3",    0x180000, 0x800000, CRC(bbf879b5) SHA1(bd9a6aea34ad4001e89e62ff4b7a2292eb833c00) )
 
@@ -3237,7 +3214,7 @@ ROM_START( martmastc )
 	ROM_REGION32_LE( 0x400000, "user1", 0 ) /* Protection Data (encrypted external ARM data) */
 	ROM_LOAD( "v102_16m.u10", 0x000000, 0x200000,  CRC(18b745e6) SHA1(7bcb58dd3a2d6072f492cf0dd7181cb061c1f49d) )
 
-	ROM_REGION( 0xc00000, "tiles", 0 ) /* 8x8 Text Tiles + 32x32 BG Tiles */
+	ROM_REGION( 0xa00000, "tiles", 0 ) /* 8x8 Text Tiles + 32x32 BG Tiles */
 	PGM_VIDEO_BIOS
 	ROM_LOAD( "t1000.u3",    0x180000, 0x800000, CRC(bbf879b5) SHA1(bd9a6aea34ad4001e89e62ff4b7a2292eb833c00) )
 
@@ -3269,7 +3246,7 @@ ROM_START( martmastc103 )
 	ROM_REGION32_LE( 0x400000, "user1", 0 ) /* Protection Data (encrypted external ARM data) */
 	ROM_LOAD( "v102_16m.u10", 0x000000, 0x200000,  CRC(18b745e6) SHA1(7bcb58dd3a2d6072f492cf0dd7181cb061c1f49d) )
 
-	ROM_REGION( 0xc00000, "tiles", 0 ) /* 8x8 Text Tiles + 32x32 BG Tiles */
+	ROM_REGION( 0xa00000, "tiles", 0 ) /* 8x8 Text Tiles + 32x32 BG Tiles */
 	PGM_VIDEO_BIOS
 	ROM_LOAD( "t1000.u3",    0x180000, 0x800000, CRC(bbf879b5) SHA1(bd9a6aea34ad4001e89e62ff4b7a2292eb833c00) )
 
@@ -3301,7 +3278,7 @@ ROM_START( martmastc102 )
 	ROM_REGION32_LE( 0x400000, "user1", 0 ) /* Protection Data (encrypted external ARM data) */
 	ROM_LOAD( "martmast_u10-v101.160", 0x000000, 0x200000,   CRC(d5d93294) SHA1(58d0a99749f7dc05814892b508ce21b160410947) )
 
-	ROM_REGION( 0xc00000, "tiles", 0 ) /* 8x8 Text Tiles + 32x32 BG Tiles */
+	ROM_REGION( 0xa00000, "tiles", 0 ) /* 8x8 Text Tiles + 32x32 BG Tiles */
 	PGM_VIDEO_BIOS
 	ROM_LOAD( "t1000.u3",    0x180000, 0x800000, CRC(bbf879b5) SHA1(bd9a6aea34ad4001e89e62ff4b7a2292eb833c00) )
 
@@ -3339,7 +3316,7 @@ ROM_START( martmasttw )
 	ROM_REGION32_LE( 0x400000, "user1", 0 ) /* Protection Data (encrypted external ARM data) */
 	ROM_LOAD( "mm_v101_u10.bin", 0x000000, 0x400000,   CRC(917beb91) SHA1(0d867d8382518197ac98522bfc69063042db9890) ) // double size wrt to other sets
 
-	ROM_REGION( 0xc00000, "tiles", 0 ) /* 8x8 Text Tiles + 32x32 BG Tiles */
+	ROM_REGION( 0xa00000, "tiles", 0 ) /* 8x8 Text Tiles + 32x32 BG Tiles */
 	PGM_VIDEO_BIOS
 	ROM_LOAD( "t1000.u3",    0x180000, 0x800000, CRC(bbf879b5) SHA1(bd9a6aea34ad4001e89e62ff4b7a2292eb833c00) )
 
@@ -3422,7 +3399,7 @@ ROM_START( dmnfrnt )
 	ROM_REGION( 0x800000, "user1", 0 ) /* Protection Data (encrypted external ARM data, internal missing) */
 	ROM_LOAD( "v105_32m.u26", 0x000000, 0x400000,  CRC(c798c2ef) SHA1(91e364c33b935293fa765ca521cdb67ac45ec70f) )
 
-	ROM_REGION( 0xc00000, "tiles", 0 ) /* 8x8 Text Tiles + 32x32 BG Tiles */
+	ROM_REGION( 0xa00000, "tiles", 0 ) /* 8x8 Text Tiles + 32x32 BG Tiles */
 	PGM_VIDEO_BIOS
 	ROM_LOAD( "t04501.u29",    0x180000, 0x800000, CRC(900eaaac) SHA1(4033cb7b28fcadb92d5af3ea7fdd1c22747618fd) )
 
@@ -3451,7 +3428,7 @@ ROM_START( dmnfrnta )
 	ROM_REGION( 0x800000, "user1", 0 ) /* Protection Data (encrypted external ARM data, internal missing) */
 	ROM_LOAD( "v101_32m.u26", 0x000000, 0x400000,  CRC(93965281) SHA1(89da198aaa7ca759cb96b5f18859a477e55fd590) )
 
-	ROM_REGION( 0xc00000, "tiles", 0 ) /* 8x8 Text Tiles + 32x32 BG Tiles */
+	ROM_REGION( 0xa00000, "tiles", 0 ) /* 8x8 Text Tiles + 32x32 BG Tiles */
 	PGM_VIDEO_BIOS
 	ROM_LOAD( "t04501.u29",    0x180000, 0x800000, CRC(900eaaac) SHA1(4033cb7b28fcadb92d5af3ea7fdd1c22747618fd) )
 
@@ -3481,7 +3458,7 @@ ROM_START( dmnfrntb )
 	ROM_REGION( 0x800000, "user1", 0 ) /* Protection Data (encrypted external ARM data, internal missing) */
 	ROM_LOAD( "v103_32m.u26", 0x000000, 0x400000, CRC(e78383a3) SHA1(7ae99e93489e79fb1e4240124d22b6002fb7fe18) )
 
-	ROM_REGION( 0xc00000, "tiles", 0 ) /* 8x8 Text Tiles + 32x32 BG Tiles */
+	ROM_REGION( 0xa00000, "tiles", 0 ) /* 8x8 Text Tiles + 32x32 BG Tiles */
 	PGM_VIDEO_BIOS
 	ROM_LOAD( "t04501.u29",    0x180000, 0x800000, CRC(900eaaac) SHA1(4033cb7b28fcadb92d5af3ea7fdd1c22747618fd) )
 
@@ -3510,7 +3487,7 @@ ROM_START( dmnfrntpcb )
 	ROM_REGION( 0x800000, "user1", 0 ) /* Protection Data (encrypted external ARM data, internal missing) */
 	ROM_LOAD( "demonfront_v107-u62.bin",     0x000000, 0x400000, CRC(cb94772e) SHA1(4213600be41fd9ea295dd308920b1d89b635724f) )
 
-	ROM_REGION( 0xc00000, "tiles", 0 ) /* 8x8 Text Tiles + 32x32 BG Tiles */
+	ROM_REGION( 0xa00000, "tiles", 0 ) /* 8x8 Text Tiles + 32x32 BG Tiles */
 	PGM_VIDEO_BIOS
 	ROM_LOAD( "t04501.u29",    0x180000, 0x800000, CRC(900eaaac) SHA1(4033cb7b28fcadb92d5af3ea7fdd1c22747618fd) )
 
@@ -3545,7 +3522,7 @@ ROM_START( theglad )
 	ROM_REGION( 0x800000, "user1", 0 ) /* Protection Data (encrypted external ARM data, internal missing) */
 	ROM_LOAD( "v107.u26", 0x000000, 0x200000,  CRC(f7c61357) SHA1(52d31c464dfc83c5371b078cb6b73c0d0e0d57e3) ) // 06/06/03 16:17:27 V107
 
-	ROM_REGION( 0xc00000, "tiles", 0 ) /* 8x8 Text Tiles + 32x32 BG Tiles */
+	ROM_REGION( 0xa00000, "tiles", 0 ) /* 8x8 Text Tiles + 32x32 BG Tiles */
 	PGM_VIDEO_BIOS
 	ROM_LOAD( "t04601.u33",   0x180000, 0x800000, CRC(e5dab371) SHA1(2e3c93958eb0326b6b84b95c2168626f26bbac76) )
 
@@ -3575,7 +3552,7 @@ ROM_START( theglad100 ) // is this actually a pre-v100 proto?
 	ROM_REGION( 0x800000, "user1", 0 ) /* Protection Data (encrypted external ARM data, internal missing) */
 	ROM_LOAD( "u2.rom", 0x000000, 0x200000,  CRC(c7bcf2ae) SHA1(10bc012c83987f594d5375a51bc4be2e17568a81) ) // 01/16/03 10:39:25 V100
 
-	ROM_REGION( 0xc00000, "tiles", 0 ) /* 8x8 Text Tiles + 32x32 BG Tiles */
+	ROM_REGION( 0xa00000, "tiles", 0 ) /* 8x8 Text Tiles + 32x32 BG Tiles */
 	PGM_VIDEO_BIOS
 	ROM_LOAD( "t04601.u33",   0x180000, 0x800000, CRC(e5dab371) SHA1(2e3c93958eb0326b6b84b95c2168626f26bbac76) )
 
@@ -3606,7 +3583,7 @@ ROM_START( theglad101 )
 	ROM_REGION( 0x800000, "user1", 0 ) /* Protection Data (encrypted external ARM data, internal missing) */
 	ROM_LOAD( "v101.u26", 0x000000, 0x200000, CRC(23faec02) SHA1(9065d55c2a14e6889e735a452bbc32530056645a) ) // 03/13/03 14:06:44 V101
 
-	ROM_REGION( 0xc00000, "tiles", 0 ) /* 8x8 Text Tiles + 32x32 BG Tiles */
+	ROM_REGION( 0xa00000, "tiles", 0 ) /* 8x8 Text Tiles + 32x32 BG Tiles */
 	PGM_VIDEO_BIOS
 	ROM_LOAD( "t04601.u33",   0x180000, 0x800000, CRC(e5dab371) SHA1(2e3c93958eb0326b6b84b95c2168626f26bbac76) )
 
@@ -3637,7 +3614,7 @@ ROM_START( thegladpcb )
 	ROM_REGION( 0x800000, "user1", 0 ) /* Protection Data (encrypted external ARM data, internal missing) */
 	ROM_LOAD( "igs_v100.62", 0x000000, 0x200000, CRC(0f3f511e) SHA1(28dd8d27495cec86e968a3ea549c5b30513dbb6e) ) // 02/25/03 16:32:21 V100
 
-	ROM_REGION( 0xc00000, "tiles", 0 ) /* 8x8 Text Tiles + 32x32 BG Tiles */
+	ROM_REGION( 0xa00000, "tiles", 0 ) /* 8x8 Text Tiles + 32x32 BG Tiles */
 	ROM_LOAD( "pgm_t01s.u72", 0x000000, 0x200000, CRC(1a7123a0) SHA1(cc567f577bfbf45427b54d6695b11b74f2578af3) ) // standard PGM tx bios
 	ROM_LOAD( "t04601.u71",   0x180000, 0x800000, CRC(e5dab371) SHA1(2e3c93958eb0326b6b84b95c2168626f26bbac76) )
 
@@ -3666,7 +3643,7 @@ ROM_START( oldsplus )
 
 	ROM_REGION( 0x800000, "user1", ROMREGION_ERASE00 )
 
-	ROM_REGION( 0xc00000, "tiles", 0 ) /* 8x8 Text Tiles + 32x32 BG Tiles */
+	ROM_REGION( 0xa00000, "tiles", 0 ) /* 8x8 Text Tiles + 32x32 BG Tiles */
 	PGM_VIDEO_BIOS
 	ROM_LOAD( "t05301.rom",   0x180000, 0x800000, CRC(8257bbb0) SHA1(b48067b7e7081a15fddf21739b641d677c2df3d9) )
 
@@ -3693,7 +3670,7 @@ ROM_START( kovshp )
 	ROM_REGION( 0x4000, "prot", 0 ) /* ARM protection ASIC - internal rom */
 	ROM_LOAD( "kovsh_v100_china.asic", 0x000000, 0x04000, BAD_DUMP CRC(0f09a5c1) SHA1(621b38c05f33277608d58b49822aebc930ae4870) ) // this is the kovsh ARM rom, we intercept and modify protection calls
 
-	ROM_REGION( 0xc00000, "tiles", 0 ) /* 8x8 Text Tiles + 32x32 BG Tiles */
+	ROM_REGION( 0xa00000, "tiles", 0 ) /* 8x8 Text Tiles + 32x32 BG Tiles */
 	PGM_VIDEO_BIOS
 	ROM_LOAD( "t0600.rom",    0x180000, 0x800000, CRC(4acc1ad6) SHA1(0668dbd5e856c2406910c6b7382548b37c631780) )
 
@@ -3720,7 +3697,7 @@ ROM_START( kovshpa )
 	ROM_REGION( 0x4000, "prot", 0 ) /* ARM protection ASIC - internal rom */
 	ROM_LOAD( "kovsh_v100_china.asic", 0x000000, 0x04000, BAD_DUMP CRC(0f09a5c1) SHA1(621b38c05f33277608d58b49822aebc930ae4870) ) // this is the kovsh ARM rom, we intercept and modify protection calls
 
-	ROM_REGION( 0xc00000, "tiles", 0 ) /* 8x8 Text Tiles + 32x32 BG Tiles */
+	ROM_REGION( 0xa00000, "tiles", 0 ) /* 8x8 Text Tiles + 32x32 BG Tiles */
 	PGM_VIDEO_BIOS
 	ROM_LOAD( "t0600.rom",    0x180000, 0x800000, CRC(4acc1ad6) SHA1(0668dbd5e856c2406910c6b7382548b37c631780) )
 
@@ -3749,7 +3726,7 @@ ROM_START( kovytzy )
 	ROM_REGION( 0x4000, "prot", 0 ) /* ARM protection ASIC - internal rom */
 	ROM_LOAD( "kovsh_v100_china.asic", 0x000000, 0x04000, BAD_DUMP CRC(0f09a5c1) SHA1(621b38c05f33277608d58b49822aebc930ae4870) ) // this is the kovsh ARM rom, we intercept and modify protection calls
 
-	ROM_REGION( 0xc00000, "tiles", 0 ) /* 8x8 Text Tiles + 32x32 BG Tiles */
+	ROM_REGION( 0xa00000, "tiles", 0 ) /* 8x8 Text Tiles + 32x32 BG Tiles */
 	PGM_VIDEO_BIOS
 	ROM_LOAD( "t0600.rom",    0x180000, 0x800000, CRC(4acc1ad6) SHA1(0668dbd5e856c2406910c6b7382548b37c631780) )
 
@@ -3776,7 +3753,7 @@ ROM_START( kovshxas )
 	ROM_REGION( 0x4000, "prot", 0 ) /* ARM protection ASIC - internal rom */
 	ROM_LOAD( "kovsh_v100_china.asic", 0x000000, 0x04000, BAD_DUMP CRC(0f09a5c1) SHA1(621b38c05f33277608d58b49822aebc930ae4870) ) // this is the kovsh ARM rom, we intercept and modify protection calls
 
-	ROM_REGION( 0xc00000, "tiles", 0 ) /* 8x8 Text Tiles + 32x32 BG Tiles */
+	ROM_REGION( 0xa00000, "tiles", 0 ) /* 8x8 Text Tiles + 32x32 BG Tiles */
 	PGM_VIDEO_BIOS
 	ROM_LOAD( "t0600.rom",    0x180000, 0x800000, CRC(4acc1ad6) SHA1(0668dbd5e856c2406910c6b7382548b37c631780) )
 
@@ -3804,7 +3781,7 @@ ROM_START( kovlsqh )
 	ROM_REGION( 0x4000, "prot", 0 ) /* ARM protection ASIC - internal rom */
 	ROM_LOAD( "kovsh_v100_china.asic", 0x000000, 0x04000, BAD_DUMP CRC(0f09a5c1) SHA1(621b38c05f33277608d58b49822aebc930ae4870) ) // this is the kovsh ARM rom, we intercept and modify protection calls
 
-	ROM_REGION( 0xc00000, "tiles",  0 ) /* 8x8 Text Tiles + 32x32 BG Tiles */
+	ROM_REGION( 0xa00000, "tiles",  0 ) /* 8x8 Text Tiles + 32x32 BG Tiles */
 	PGM_VIDEO_BIOS
 	ROM_LOAD( "lsqh2_t01.rom",0x180000, 0x800000, CRC(d498d97f) SHA1(97a7b6d2ed1170449e7c2899448af7cbbca4c94f) )
 	ROM_IGNORE( 0x800000 )  // second half identical
@@ -3833,7 +3810,7 @@ ROM_START( kovlsqh2 )
 	ROM_REGION( 0x4000, "prot", 0 ) /* ARM protection ASIC - internal rom */
 	ROM_LOAD( "kovsh_v100_china.asic", 0x000000, 0x04000, BAD_DUMP CRC(0f09a5c1) SHA1(621b38c05f33277608d58b49822aebc930ae4870) ) // this is the kovsh ARM rom, we intercept and modify protection calls
 
-	ROM_REGION( 0xc00000, "tiles",  0 ) /* 8x8 Text Tiles + 32x32 BG Tiles */
+	ROM_REGION( 0xa00000, "tiles",  0 ) /* 8x8 Text Tiles + 32x32 BG Tiles */
 	PGM_VIDEO_BIOS
 	ROM_LOAD( "lsqh2_t01.rom",0x180000, 0x800000, CRC(d498d97f) SHA1(97a7b6d2ed1170449e7c2899448af7cbbca4c94f) )
 	ROM_IGNORE( 0x800000 )  // second half identical
@@ -3863,7 +3840,7 @@ ROM_START( kovlsjb )
 	ROM_REGION( 0x4000, "prot", 0 ) /* ARM protection ASIC - internal rom */
 	ROM_LOAD( "kovsh_v100_china.asic", 0x000000, 0x04000, BAD_DUMP CRC(0f09a5c1) SHA1(621b38c05f33277608d58b49822aebc930ae4870) ) // this is the kovsh ARM rom, we intercept and modify protection calls
 
-	ROM_REGION( 0xc00000, "tiles",  0 ) /* 8x8 Text Tiles + 32x32 BG Tiles */
+	ROM_REGION( 0xa00000, "tiles",  0 ) /* 8x8 Text Tiles + 32x32 BG Tiles */
 	PGM_VIDEO_BIOS
 	ROM_LOAD( "lsqh2_t01.rom",0x180000, 0x800000, CRC(d498d97f) SHA1(97a7b6d2ed1170449e7c2899448af7cbbca4c94f) )
 	ROM_IGNORE( 0x800000 )  // second half identical
@@ -3892,7 +3869,7 @@ ROM_START( kovlsjba )
 	ROM_REGION( 0x4000, "prot", 0 ) /* ARM protection ASIC - internal rom */
 	ROM_LOAD( "kovsh_v100_china.asic", 0x000000, 0x04000, BAD_DUMP CRC(0f09a5c1) SHA1(621b38c05f33277608d58b49822aebc930ae4870) ) // this is the kovsh ARM rom, we intercept and modify protection calls
 
-	ROM_REGION( 0xc00000, "tiles",  0 ) /* 8x8 Text Tiles + 32x32 BG Tiles */
+	ROM_REGION( 0xa00000, "tiles",  0 ) /* 8x8 Text Tiles + 32x32 BG Tiles */
 	PGM_VIDEO_BIOS
 	ROM_LOAD( "lsqh2_t01.rom",0x180000, 0x800000, CRC(d498d97f) SHA1(97a7b6d2ed1170449e7c2899448af7cbbca4c94f) )
 	ROM_IGNORE( 0x800000 )  // second half identical
@@ -3930,7 +3907,7 @@ ROM_START( killbldp )
 	ROM_REGION( 0x800000, "user1", 0 ) /* Protection Data (encrypted external ARM data) */
 	ROM_LOAD( "v300x.u26", 0x000000, 0x200000,  CRC(144388c8) SHA1(d7469df077c1a674129f18210584ba4d05a61888) ) // 05-09-16 23:52:32 V300
 
-	ROM_REGION( 0x800000, "tiles", 0 ) /* 8x8 Text Tiles + 32x32 BG Tiles */
+	ROM_REGION( 0xa00000, "tiles", 0 ) /* 8x8 Text Tiles + 32x32 BG Tiles */
 	PGM_VIDEO_BIOS
 	ROM_LOAD( "t05701w032.bin",0x180000, 0x400000, CRC(567c714f) SHA1(b25b20e1ec9f077d6f7b9d41723a68d0d461bef2) )
 
@@ -3961,7 +3938,7 @@ ROM_START( svg )
 	ROM_LOAD( "u26.bin", 0x000000, 0x400000, CRC(46826ec8) SHA1(ad1daf6f615fb8d748ce7f98f19dd3bf22f79fba) ) // 10/11/05 10:07:20 V201
 	ROM_LOAD( "u29.bin", 0x400000, 0x400000, CRC(fa5f3901) SHA1(8ab7c6763df4f752b50ed2197063f58046b32ddb) )
 
-	ROM_REGION( 0xc00000, "tiles", 0 ) /* 8x8 Text Tiles + 32x32 BG Tiles */
+	ROM_REGION( 0x500000, "tiles", 0 ) /* 8x8 Text Tiles + 32x32 BG Tiles */
 	PGM_VIDEO_BIOS
 	ROM_LOAD( "t05601w016.bin",0x180000, 0x200000, CRC(03e110dc) SHA1(41c8f286e9303b24ba6235b341371c298226fb6a) )
 
@@ -3994,7 +3971,7 @@ ROM_START( svgtw )
 	ROM_LOAD( "v101tw.u26", 0x000000, 0x400000, CRC(cc24f542) SHA1(623ed398d2eeea229833d92eb4fb6492133202b3) ) // 06/20/05 11:36:15 V100
 	ROM_LOAD( "v101tw.u36", 0x400000, 0x400000, CRC(f18283e2) SHA1(15323c5f816a0bf6f510311eb49d485ccf713cf7) )
 
-	ROM_REGION( 0xc00000, "tiles", 0 ) /* 8x8 Text Tiles + 32x32 BG Tiles */
+	ROM_REGION( 0x500000, "tiles", 0 ) /* 8x8 Text Tiles + 32x32 BG Tiles */
 	PGM_VIDEO_BIOS
 	ROM_LOAD( "t05601w016.bin",0x180000, 0x200000, CRC(03e110dc) SHA1(41c8f286e9303b24ba6235b341371c298226fb6a) )
 
@@ -4029,7 +4006,7 @@ ROM_START( svgpcb )
 	ROM_LOAD( "svg_v100jp.u64", 0x000000, 0x400000, CRC(399d4a8b) SHA1(b120e8386a259e6fd7941acf3c33cf288eda616c) ) // 05/12/05 15:31:35 V100
 	ROM_LOAD( "svg_v100jp.u65", 0x400000, 0x400000, CRC(6e1c33b1) SHA1(66f26b2f4c0b3dcf6d1bb1df48e2ddbcc9d9432d) )
 
-	ROM_REGION( 0xc00000, "tiles", 0 ) /* 8x8 Text Tiles + 32x32 BG Tiles */
+	ROM_REGION( 0x500000, "tiles", 0 ) /* 8x8 Text Tiles + 32x32 BG Tiles */
 	PGM_VIDEO_BIOS // IGS PGM T01S 1B8558A1 M002146
 	ROM_LOAD( "t05601w016.bin",0x180000, 0x200000, CRC(03e110dc) SHA1(41c8f286e9303b24ba6235b341371c298226fb6a) ) // IGS T05601W016 2C35 B270 2L464103 B050924
 
@@ -4065,7 +4042,7 @@ ROM_START( happy6 )
 	ROM_REGION( 0x800000, "user1", 0 ) /* Protection Data (encrypted external ARM data) */
 	ROM_LOAD( "v102cn.u26", 0x000000, 0x400000, CRC(310510fb) SHA1(e0e80a04e9f7bf27e6581a8935c960bad33bb6de) ) // 03/16/04 14:29:17 V102
 
-	ROM_REGION( 0xc00000, "tiles", 0 ) /* 8x8 Text Tiles + 32x32 BG Tiles */
+	ROM_REGION( 0xa00000, "tiles", 0 ) /* 8x8 Text Tiles + 32x32 BG Tiles */
 	PGM_VIDEO_BIOS
 	ROM_LOAD( "t01w64m.u29",0x180000, 0x800000, CRC(2d3feb8b) SHA1(9832b1c46b1ee73febf5c5c8913859f4e0581665) )
 
@@ -4096,7 +4073,7 @@ ROM_START( happy6101 )
 	ROM_REGION( 0x800000, "user1", 0 ) /* Protection Data (encrypted external ARM data) */
 	ROM_LOAD( "happy6in1_v101cn.u26", 0x000000, 0x400000, CRC(4a48ca1c) SHA1(3bebc091787903d45cb84c7302046602a903f59c) )
 
-	ROM_REGION( 0xc00000, "tiles", 0 ) /* 8x8 Text Tiles + 32x32 BG Tiles */
+	ROM_REGION( 0xa00000, "tiles", 0 ) /* 8x8 Text Tiles + 32x32 BG Tiles */
 	PGM_VIDEO_BIOS
 	ROM_LOAD( "t01w64m.u29",0x180000, 0x800000, CRC(2d3feb8b) SHA1(9832b1c46b1ee73febf5c5c8913859f4e0581665) )
 
@@ -4122,7 +4099,7 @@ ROM_START( ket )
 	ROM_REGION( 0x4000, "prot", 0 ) /* ARM protection ASIC - internal rom */
 	ROM_LOAD( "ket_igs027a.bin", 0x000000, 0x04000, NO_DUMP )
 
-	ROM_REGION( 0xc00000, "tiles", 0 ) /* 8x8 Text Tiles + 32x32 BG Tiles */
+	ROM_REGION( 0xa00000, "tiles", 0 ) /* 8x8 Text Tiles + 32x32 BG Tiles */
 	ROM_LOAD( "pgm_t01s.rom", 0x000000, 0x200000, CRC(1a7123a0) SHA1(cc567f577bfbf45427b54d6695b11b74f2578af3) ) // same as standard PGM text bios - surface scratched to remove details
 	ROM_LOAD( "t04701w064.u19",   0x180000, 0x800000, CRC(2665b041) SHA1(fb1107778b66f2af0de77ac82e1ee2902f53a959) ) //text-1
 
@@ -4149,7 +4126,7 @@ ROM_START( ket1 ) // only difference between this and ket1 is the rom fill on th
 	ROM_REGION( 0x4000, "prot", 0 ) /* ARM protection ASIC - internal rom */
 	ROM_LOAD( "ket_igs027a.bin", 0x000000, 0x04000, NO_DUMP )
 
-	ROM_REGION( 0xc00000, "tiles", 0 ) /* 8x8 Text Tiles + 32x32 BG Tiles */
+	ROM_REGION( 0xa00000, "tiles", 0 ) /* 8x8 Text Tiles + 32x32 BG Tiles */
 	ROM_LOAD( "pgm_t01s.rom", 0x000000, 0x200000, CRC(1a7123a0) SHA1(cc567f577bfbf45427b54d6695b11b74f2578af3) ) // same as standard PGM text bios - surface scratched to remove details
 	ROM_LOAD( "t04701w064.u19",   0x180000, 0x800000, CRC(2665b041) SHA1(fb1107778b66f2af0de77ac82e1ee2902f53a959) ) //text-1
 
@@ -4176,7 +4153,7 @@ ROM_START( keta )
 	ROM_REGION( 0x4000, "prot", 0 ) /* ARM protection ASIC - internal rom */
 	ROM_LOAD( "ket_igs027a.bin", 0x000000, 0x04000, NO_DUMP )
 
-	ROM_REGION( 0xc00000, "tiles", 0 ) /* 8x8 Text Tiles + 32x32 BG Tiles */
+	ROM_REGION( 0xa00000, "tiles", 0 ) /* 8x8 Text Tiles + 32x32 BG Tiles */
 	ROM_LOAD( "pgm_t01s.rom", 0x000000, 0x200000, CRC(1a7123a0) SHA1(cc567f577bfbf45427b54d6695b11b74f2578af3) ) // same as standard PGM text bios - surface scratched to remove details
 	ROM_LOAD( "t04701w064.u19",   0x180000, 0x800000, CRC(2665b041) SHA1(fb1107778b66f2af0de77ac82e1ee2902f53a959) ) //text-1
 
@@ -4203,7 +4180,7 @@ ROM_START( ketb )
 	ROM_REGION( 0x4000, "prot", 0 ) /* ARM protection ASIC - internal rom */
 	ROM_LOAD( "ket_igs027a.bin", 0x000000, 0x04000, NO_DUMP )
 
-	ROM_REGION( 0xc00000, "tiles", 0 ) /* 8x8 Text Tiles + 32x32 BG Tiles */
+	ROM_REGION( 0xa00000, "tiles", 0 ) /* 8x8 Text Tiles + 32x32 BG Tiles */
 	ROM_LOAD( "pgm_t01s.rom", 0x000000, 0x200000, CRC(1a7123a0) SHA1(cc567f577bfbf45427b54d6695b11b74f2578af3) ) // same as standard PGM text bios - surface scratched to remove details
 	ROM_LOAD( "t04701w064.u19",   0x180000, 0x800000, CRC(2665b041) SHA1(fb1107778b66f2af0de77ac82e1ee2902f53a959) ) //text-1
 
@@ -4231,7 +4208,7 @@ ROM_START( ketarr10 )
 	ROM_REGION( 0x4000, "prot", 0 ) /* ARM protection ASIC - internal rom */
 	ROM_LOAD( "ket_igs027a.bin", 0x000000, 0x04000, NO_DUMP )
 
-	ROM_REGION( 0xc00000, "tiles", 0 ) /* 8x8 Text Tiles + 32x32 BG Tiles */
+	ROM_REGION( 0xa00000, "tiles", 0 ) /* 8x8 Text Tiles + 32x32 BG Tiles */
 	ROM_LOAD( "pgm_t01s.rom", 0x000000, 0x200000, CRC(1a7123a0) SHA1(cc567f577bfbf45427b54d6695b11b74f2578af3) ) // same as standard PGM text bios - surface scratched to remove details
 	ROM_LOAD( "t04701w064.u19", 0x180000, 0x800000, CRC(2665b041) SHA1(fb1107778b66f2af0de77ac82e1ee2902f53a959) ) //text-1
 
@@ -4259,7 +4236,7 @@ ROM_START( ketarrf )
 	ROM_REGION( 0x4000, "prot", 0 ) /* ARM protection ASIC - internal rom */
 	ROM_LOAD( "ket_igs027a.bin", 0x000000, 0x04000, NO_DUMP )
 
-	ROM_REGION( 0xc00000, "tiles", 0 ) /* 8x8 Text Tiles + 32x32 BG Tiles */
+	ROM_REGION( 0xa00000, "tiles", 0 ) /* 8x8 Text Tiles + 32x32 BG Tiles */
 	ROM_LOAD( "pgm_t01s.rom", 0x000000, 0x200000, CRC(1a7123a0) SHA1(cc567f577bfbf45427b54d6695b11b74f2578af3) ) // same as standard PGM text bios - surface scratched to remove details
 	ROM_LOAD( "t04701w064.u19", 0x180000, 0x800000, CRC(2665b041) SHA1(fb1107778b66f2af0de77ac82e1ee2902f53a959) ) //text-1
 
@@ -4286,7 +4263,7 @@ ROM_START( ketarr15 )
 	ROM_REGION( 0x4000, "prot", 0 ) /* ARM protection ASIC - internal rom */
 	ROM_LOAD( "ket_igs027a.bin", 0x000000, 0x04000, NO_DUMP )
 
-	ROM_REGION( 0xc00000, "tiles", 0 ) /* 8x8 Text Tiles + 32x32 BG Tiles */
+	ROM_REGION( 0xa00000, "tiles", 0 ) /* 8x8 Text Tiles + 32x32 BG Tiles */
 	ROM_LOAD( "pgm_t01s.rom", 0x000000, 0x200000, CRC(1a7123a0) SHA1(cc567f577bfbf45427b54d6695b11b74f2578af3) ) // same as standard PGM text bios - surface scratched to remove details
 	ROM_LOAD( "t04701w064.u19", 0x180000, 0x800000, CRC(2665b041) SHA1(fb1107778b66f2af0de77ac82e1ee2902f53a959) ) //text-1
 
@@ -4313,7 +4290,7 @@ ROM_START( ketarrs15 )
 	ROM_REGION( 0x4000, "prot", 0 ) /* ARM protection ASIC - internal rom */
 	ROM_LOAD( "ket_igs027a.bin", 0x000000, 0x04000, NO_DUMP )
 
-	ROM_REGION( 0xc00000, "tiles", 0 ) /* 8x8 Text Tiles + 32x32 BG Tiles */
+	ROM_REGION( 0xa00000, "tiles", 0 ) /* 8x8 Text Tiles + 32x32 BG Tiles */
 	ROM_LOAD( "pgm_t01s.rom", 0x000000, 0x200000, CRC(1a7123a0) SHA1(cc567f577bfbf45427b54d6695b11b74f2578af3) ) // same as standard PGM text bios - surface scratched to remove details
 	ROM_LOAD( "t04701w064.u19", 0x180000, 0x800000, CRC(2665b041) SHA1(fb1107778b66f2af0de77ac82e1ee2902f53a959) ) //text-1
 
@@ -4340,7 +4317,7 @@ ROM_START( ketarr151 )
 	ROM_REGION( 0x4000, "prot", 0 ) /* ARM protection ASIC - internal rom */
 	ROM_LOAD( "ket_igs027a.bin", 0x000000, 0x04000, NO_DUMP )
 
-	ROM_REGION( 0xc00000, "tiles", 0 ) /* 8x8 Text Tiles + 32x32 BG Tiles */
+	ROM_REGION( 0xa00000, "tiles", 0 ) /* 8x8 Text Tiles + 32x32 BG Tiles */
 	ROM_LOAD( "pgm_t01s.rom", 0x000000, 0x200000, CRC(1a7123a0) SHA1(cc567f577bfbf45427b54d6695b11b74f2578af3) ) // same as standard PGM text bios - surface scratched to remove details
 	ROM_LOAD( "t04701w064.u19", 0x180000, 0x800000, CRC(2665b041) SHA1(fb1107778b66f2af0de77ac82e1ee2902f53a959) ) //text-1
 
@@ -4367,7 +4344,7 @@ ROM_START( ketarrs151 )
 	ROM_REGION( 0x4000, "prot", 0 ) /* ARM protection ASIC - internal rom */
 	ROM_LOAD( "ket_igs027a.bin", 0x000000, 0x04000, NO_DUMP )
 
-	ROM_REGION( 0xc00000, "tiles", 0 ) /* 8x8 Text Tiles + 32x32 BG Tiles */
+	ROM_REGION( 0xa00000, "tiles", 0 ) /* 8x8 Text Tiles + 32x32 BG Tiles */
 	ROM_LOAD( "pgm_t01s.rom", 0x000000, 0x200000, CRC(1a7123a0) SHA1(cc567f577bfbf45427b54d6695b11b74f2578af3) ) // same as standard PGM text bios - surface scratched to remove details
 	ROM_LOAD( "t04701w064.u19", 0x180000, 0x800000, CRC(2665b041) SHA1(fb1107778b66f2af0de77ac82e1ee2902f53a959) ) //text-1
 
@@ -4393,7 +4370,7 @@ ROM_START( ketarr )
 	ROM_REGION( 0x4000, "prot", 0 )
 	ROM_LOAD( "ket_igs027a.bin", 0x000000, 0x04000, NO_DUMP )
 
-	ROM_REGION( 0xc00000, "tiles", 0 )
+	ROM_REGION( 0xa00000, "tiles", 0 )
 	ROM_LOAD( "pgm_t01s.rom", 0x000000, 0x200000, CRC(1a7123a0) SHA1(cc567f577bfbf45427b54d6695b11b74f2578af3) )
 	ROM_LOAD( "t04701w064.u19", 0x180000, 0x800000, CRC(2665b041) SHA1(fb1107778b66f2af0de77ac82e1ee2902f53a959) ) //text-1
 
@@ -4437,7 +4414,7 @@ ROM_START( ketbl ) // this assumes a Dodonpachi 2 Bee Storm cart was used
 	ROM_REGION32_LE( 0x400000, "user1", 0 ) /* Protection Data (encrypted external ARM data) */ // leftover from original game
 	ROM_LOAD( "v100.u23", 0x000000, 0x20000, CRC(06c3dd29) SHA1(20c9479f158467fc2037dcf162b6c6be18c91d46) )
 
-	ROM_REGION( 0xc00000, "tiles", 0 ) /* 8x8 Text Tiles + 32x32 BG Tiles */
+	ROM_REGION( 0xa00000, "tiles", 0 ) /* 8x8 Text Tiles + 32x32 BG Tiles */
 	PGM_VIDEO_BIOS
 	ROM_LOAD( "t04701w064.u19",   0x180000, 0x800000, CRC(2665b041) SHA1(fb1107778b66f2af0de77ac82e1ee2902f53a959) ) //text-1
 
@@ -4461,7 +4438,7 @@ ROM_START( espgal )
 	ROM_REGION( 0x4000, "prot", 0 ) /* ARM protection ASIC - internal rom */
 	ROM_LOAD( "espgal_igs027a.bin", 0x000000, 0x04000, NO_DUMP )
 
-	ROM_REGION( 0xc00000, "tiles", 0 ) /* 8x8 Text Tiles + 32x32 BG Tiles */
+	ROM_REGION( 0xa00000, "tiles", 0 ) /* 8x8 Text Tiles + 32x32 BG Tiles */
 	ROM_LOAD( "t01s.u18", 0x000000, 0x200000, CRC(1a7123a0) SHA1(cc567f577bfbf45427b54d6695b11b74f2578af3) ) // same as standard PGM text bios - surface scratched to remove details
 	ROM_LOAD( "t04801w064.u19",   0x180000, 0x800000, CRC(6021c79e) SHA1(fbc340dafb18aa3094de29b881318a5a9794e4bc) ) //text-1
 
@@ -4489,7 +4466,7 @@ ROM_START( espgalbl ) // this assumes a Dodonpachi 2 Bee Storm cart was used
 	ROM_REGION32_LE( 0x400000, "user1", 0 ) /* Protection Data (encrypted external ARM data) */ // leftover from original game
 	ROM_LOAD( "v100.u23", 0x000000, 0x20000, CRC(06c3dd29) SHA1(20c9479f158467fc2037dcf162b6c6be18c91d46) )
 
-	ROM_REGION( 0xc00000, "tiles", 0 ) /* 8x8 Text Tiles + 32x32 BG Tiles */
+	ROM_REGION( 0xa00000, "tiles", 0 ) /* 8x8 Text Tiles + 32x32 BG Tiles */
 	PGM_VIDEO_BIOS
 	ROM_LOAD( "t04801w064.u19",   0x180000, 0x800000, CRC(6021c79e) SHA1(fbc340dafb18aa3094de29b881318a5a9794e4bc) ) //text-1
 
@@ -4514,7 +4491,7 @@ ROM_START( ddp3 )
 	ROM_REGION( 0x4000, "prot", 0 ) /* ARM protection ASIC - internal rom */
 	ROM_LOAD( "ddp3_igs027a.bin", 0x000000, 0x04000, NO_DUMP )
 
-	ROM_REGION( 0xc00000, "tiles", 0 ) /* 8x8 Text Tiles + 32x32 BG Tiles */
+	ROM_REGION( 0xa00000, "tiles", 0 ) /* 8x8 Text Tiles + 32x32 BG Tiles */
 	ROM_LOAD( "pgm_t01s.rom", 0x000000, 0x200000, CRC(1a7123a0) SHA1(cc567f577bfbf45427b54d6695b11b74f2578af3) ) // same as standard PGM bios
 	ROM_LOAD( "t04401w064.u19",0x180000, 0x800000, CRC(3a95f19c) SHA1(fd3c47cf0b8b1e20c6bec4be68a089fc8bbf4dbe) ) //text-1
 
@@ -4541,7 +4518,7 @@ ROM_START( ddpdoj )
 	ROM_REGION( 0x4000, "prot", 0 ) /* ARM protection ASIC - internal rom */
 	ROM_LOAD( "ddp3_igs027a.bin", 0x000000, 0x04000, NO_DUMP )
 
-	ROM_REGION( 0xc00000, "tiles", 0 ) /* 8x8 Text Tiles + 32x32 BG Tiles */
+	ROM_REGION( 0xa00000, "tiles", 0 ) /* 8x8 Text Tiles + 32x32 BG Tiles */
 	ROM_LOAD( "pgm_t01s.rom", 0x000000, 0x200000, CRC(1a7123a0) SHA1(cc567f577bfbf45427b54d6695b11b74f2578af3) ) // same as standard PGM bios
 	ROM_LOAD( "t04401w064.u19",0x180000, 0x800000, CRC(3a95f19c) SHA1(fd3c47cf0b8b1e20c6bec4be68a089fc8bbf4dbe) ) //text-1
 
@@ -4569,7 +4546,7 @@ ROM_START( ddpdoja )
 	ROM_REGION( 0x4000, "prot", 0 ) /* ARM protection ASIC - internal rom */
 	ROM_LOAD( "ddp3_igs027a.bin", 0x000000, 0x04000, NO_DUMP )
 
-	ROM_REGION( 0xc00000, "tiles", 0 ) /* 8x8 Text Tiles + 32x32 BG Tiles */
+	ROM_REGION( 0xa00000, "tiles", 0 ) /* 8x8 Text Tiles + 32x32 BG Tiles */
 	ROM_LOAD( "pgm_t01s.rom", 0x000000, 0x200000, CRC(1a7123a0) SHA1(cc567f577bfbf45427b54d6695b11b74f2578af3) ) // same as standard PGM bios
 	ROM_LOAD( "t04401w064.u19",0x180000, 0x800000, CRC(3a95f19c) SHA1(fd3c47cf0b8b1e20c6bec4be68a089fc8bbf4dbe) ) //text-1
 
@@ -4596,7 +4573,7 @@ ROM_START( ddpdojb )
 	ROM_REGION( 0x4000, "prot", 0 ) /* ARM protection ASIC - internal rom */
 	ROM_LOAD( "ddp3_igs027a.bin", 0x000000, 0x04000, NO_DUMP )
 
-	ROM_REGION( 0xc00000, "tiles", 0 ) /* 8x8 Text Tiles + 32x32 BG Tiles */
+	ROM_REGION( 0xa00000, "tiles", 0 ) /* 8x8 Text Tiles + 32x32 BG Tiles */
 	ROM_LOAD( "pgm_t01s.rom", 0x000000, 0x200000, CRC(1a7123a0) SHA1(cc567f577bfbf45427b54d6695b11b74f2578af3) ) // same as standard PGM bios
 	ROM_LOAD( "t04401w064.u19",0x180000, 0x800000, CRC(3a95f19c) SHA1(fd3c47cf0b8b1e20c6bec4be68a089fc8bbf4dbe) ) //text-1
 
@@ -4624,7 +4601,7 @@ ROM_START( ddpdojblk )
 	ROM_REGION( 0x4000, "prot", 0 ) /* ARM protection ASIC - internal rom */
 	ROM_LOAD( "ddp3_igs027a.bin", 0x000000, 0x04000, NO_DUMP )
 
-	ROM_REGION( 0xc00000, "tiles", 0 ) /* 8x8 Text Tiles + 32x32 BG Tiles */
+	ROM_REGION( 0xa00000, "tiles", 0 ) /* 8x8 Text Tiles + 32x32 BG Tiles */
 	ROM_LOAD( "pgm_t01s.rom", 0x000000, 0x200000, CRC(1a7123a0) SHA1(cc567f577bfbf45427b54d6695b11b74f2578af3) ) // same as standard PGM bios
 	ROM_LOAD( "t04401w064.u19",0x180000, 0x800000, CRC(3a95f19c) SHA1(fd3c47cf0b8b1e20c6bec4be68a089fc8bbf4dbe) ) //text-1
 
@@ -4651,7 +4628,7 @@ ROM_START( ddpdojblka )
 	ROM_REGION( 0x4000, "prot", 0 ) /* ARM protection ASIC - internal rom */
 	ROM_LOAD( "ddp3_igs027a.bin", 0x000000, 0x04000, NO_DUMP )
 
-	ROM_REGION( 0xc00000, "tiles", 0 ) /* 8x8 Text Tiles + 32x32 BG Tiles */
+	ROM_REGION( 0xa00000, "tiles", 0 ) /* 8x8 Text Tiles + 32x32 BG Tiles */
 	ROM_LOAD( "pgm_t01s.rom", 0x000000, 0x200000, CRC(1a7123a0) SHA1(cc567f577bfbf45427b54d6695b11b74f2578af3) ) // same as standard PGM bios
 	ROM_LOAD( "t04401w064.u19",0x180000, 0x800000, CRC(3a95f19c) SHA1(fd3c47cf0b8b1e20c6bec4be68a089fc8bbf4dbe) ) //text-1
 
@@ -4679,7 +4656,7 @@ ROM_START( ddpdojblkbl )
 	ROM_REGION( 0x4000, "prot", 0 ) /* ARM protection ASIC - internal rom */
 	ROM_LOAD( "kovsh_v100_china.asic", 0x000000, 0x04000,  CRC(0f09a5c1) SHA1(621b38c05f33277608d58b49822aebc930ae4870) )
 
-	ROM_REGION( 0xc00000, "tiles", 0 ) /* 8x8 Text Tiles + 32x32 BG Tiles */
+	ROM_REGION( 0xa00000, "tiles", 0 ) /* 8x8 Text Tiles + 32x32 BG Tiles */
 	PGM_VIDEO_BIOS
 	ROM_LOAD( "t04401w064.u19",0x180000, 0x800000, CRC(3a95f19c) SHA1(fd3c47cf0b8b1e20c6bec4be68a089fc8bbf4dbe) ) //text-1
 
@@ -4703,9 +4680,8 @@ ROM_END
 
 void pgm_state::expand_colourdata()
 {
-	uint8_t *src = memregion( "sprcol" )->base();
-	size_t srcsize = memregion( "sprcol" )->bytes();
-	int cnt;
+	u8 *src = memregion("sprcol")->base();
+	size_t srcsize = memregion("sprcol")->bytes();
 	size_t needed = srcsize / 2 * 3;
 
 	/* work out how much ram we need to allocate to expand the sprites into
@@ -4714,22 +4690,20 @@ void pgm_state::expand_colourdata()
 	while (m_sprite_a_region_size < needed)
 		m_sprite_a_region_size <<= 1;
 
-	m_sprite_a_region = std::make_unique<uint8_t[]>(m_sprite_a_region_size);
+	m_sprite_a_region = std::make_unique<u8[]>(m_sprite_a_region_size);
 
-	for (cnt = 0 ; cnt < srcsize / 2 ; cnt++)
+	for (int cnt = 0 ; cnt < srcsize / 2 ; cnt++)
 	{
-		uint16_t colpack;
-
-		colpack = ((src[cnt * 2]) | (src[cnt * 2 + 1] << 8));
+		const u16 colpack = ((src[cnt * 2]) | (src[cnt * 2 + 1] << 8));
 		m_sprite_a_region[cnt * 3 + 0] = (colpack >> 0 ) & 0x1f;
 		m_sprite_a_region[cnt * 3 + 1] = (colpack >> 5 ) & 0x1f;
 		m_sprite_a_region[cnt * 3 + 2] = (colpack >> 10) & 0x1f;
 	}
 }
 
-void pgm_state::pgm_basic_init( bool set_bank)
+void pgm_state::pgm_basic_init(bool set_bank)
 {
-	uint8_t *ROM = memregion("maincpu")->base();
+	u8 *ROM = memregion("maincpu")->base();
 	if (set_bank) membank("bank1")->set_base(&ROM[0x100000]);
 
 	expand_colourdata();

--- a/src/mame/machine/pgmprot_igs025_igs012.cpp
+++ b/src/mame/machine/pgmprot_igs025_igs012.cpp
@@ -25,14 +25,13 @@
 
 void pgm_012_025_state::pgm_drgw2_decrypt()
 {
-	int i;
-	uint16_t *src = (uint16_t *) (memregion("maincpu")->base()+0x100000);
+	u16 *src = (u16 *) (memregion("maincpu")->base() + 0x100000);
 
 	int rom_size = 0x80000;
 
-	for (i = 0; i < rom_size / 2; i++)
+	for (int i = 0; i < rom_size / 2; i++)
 	{
-		uint16_t x = src[i];
+		u16 x = src[i];
 
 		if (((i & 0x20890) == 0) || ((i & 0x20000) == 0x20000 && (i & 0x01500) != 0x01400))
 			x ^= 0x0002;
@@ -46,7 +45,7 @@ void pgm_012_025_state::pgm_drgw2_decrypt()
 
 // All tables all xored by 'warning' information at $1354ee (drgw2)
 // tables are the same as drgw3 and olds
-static const uint8_t drgw2_source_data[0x08][0xec] =
+static const u8 drgw2_source_data[0x08][0xec] =
 {
 	{ 0, }, // Region 0, not used
 	{   // Region 1, $13A886
@@ -106,24 +105,14 @@ static const uint8_t drgw2_source_data[0x08][0xec] =
 	{ 0, }  // Region 7, not used
 };
 
-MACHINE_RESET_MEMBER(pgm_012_025_state,drgw2)
-{
-	MACHINE_RESET_CALL_MEMBER(pgm);
-
-
-}
-
 void pgm_012_025_state::drgw2_common_init()
 {
 	m_maincpu->space(AS_PROGRAM).install_readwrite_handler(0xd80000, 0xd80003, read16_delegate(FUNC(igs025_device::killbld_igs025_prot_r), (igs025_device*)m_igs025), write16_delegate(FUNC(igs025_device::drgw2_d80000_protection_w), (igs025_device*)m_igs025));
-
 
 	m_igs025->m_kb_source_data = drgw2_source_data;
 
 	pgm_basic_init();
 	pgm_drgw2_decrypt();
-
-
 }
 
 void pgm_012_025_state::drgw2_mem(address_map &map)
@@ -141,19 +130,17 @@ void pgm_012_025_state::pgm_012_025_drgw2(machine_config &config)
 
 	IGS025(config, m_igs025, 0);
 	//m_igs025->set_external_cb(FUNC(pgm_022_025_state::igs025_to_igs012_callback), this);
-
-	MCFG_MACHINE_RESET_OVERRIDE(pgm_012_025_state,drgw2)
 }
 
 
 void pgm_012_025_state::init_drgw2()
 {
 	/* incomplete? */
-	uint16_t *mem16 = (uint16_t *)memregion("maincpu")->base();
+	u16 *mem16 = (u16 *)memregion("maincpu")->base();
 
 	drgw2_common_init();
 
-	int region = 0x06;
+	const int region = 0x06;
 	m_igs025->m_kb_region = region;
 	m_igs025->m_kb_game_id = region | (region << 8) | (region << 16) | (region << 24);
 
@@ -164,11 +151,11 @@ void pgm_012_025_state::init_drgw2()
 
 void pgm_012_025_state::init_dw2v100x()
 {
-	uint16_t *mem16 = (uint16_t *)memregion("maincpu")->base();
+	u16 *mem16 = (u16 *)memregion("maincpu")->base();
 
 	drgw2_common_init();
 
-	int region = 0x06;
+	const int region = 0x06;
 	m_igs025->m_kb_region = region;
 	m_igs025->m_kb_game_id = region | (region << 8) | (region << 16) | (region << 24);
 
@@ -179,11 +166,11 @@ void pgm_012_025_state::init_dw2v100x()
 
 void pgm_012_025_state::init_drgw2c()
 {
-	uint16_t *mem16 = (uint16_t *)memregion("maincpu")->base();
+	u16 *mem16 = (u16 *)memregion("maincpu")->base();
 
 	drgw2_common_init();
 
-	int region = 0x05;
+	const int region = 0x05;
 	m_igs025->m_kb_region = region;
 	m_igs025->m_kb_game_id = region | (region << 8) | (region << 16) | (region << 24);
 
@@ -194,11 +181,11 @@ void pgm_012_025_state::init_drgw2c()
 
 void pgm_012_025_state::init_drgw2j()
 {
-	uint16_t *mem16 = (uint16_t *)memregion("maincpu")->base();
+	u16 *mem16 = (u16 *)memregion("maincpu")->base();
 
 	drgw2_common_init();
 
-	int region = 0x01;
+	const int region = 0x01;
 	m_igs025->m_kb_region = region;
 	m_igs025->m_kb_game_id = region | (region << 8) | (region << 16) | (region << 24);
 
@@ -212,11 +199,11 @@ void pgm_012_025_state::init_drgw2hk()
 	drgw2_common_init();
 
 	// todo, correct protection sequence for this region?
-	int region = 0x01;
+	const int region = 0x01;
 	m_igs025->m_kb_region = region;
 	m_igs025->m_kb_game_id = region | (region << 8) | (region << 16) | (region << 24);
 
-	uint16_t *mem16 = (uint16_t *)memregion("maincpu")->base();
+	u16 *mem16 = (u16 *)memregion("maincpu")->base();
 	mem16[0x12f520 / 2] = 0x4e93;
 	mem16[0x12f5c6 / 2] = 0x4e93;
 	mem16[0x12f656 / 2] = 0x4e93;

--- a/src/mame/machine/pgmprot_igs025_igs012.h
+++ b/src/mame/machine/pgmprot_igs025_igs012.h
@@ -10,10 +10,6 @@ public:
 	{
 	}
 
-
-	required_device<igs025_device> m_igs025;
-
-	void pgm_drgw2_decrypt();
 	void drgw2_common_init();
 
 	void init_drgw2();
@@ -22,7 +18,10 @@ public:
 	void init_drgw2j();
 	void init_drgw2hk();
 
-	DECLARE_MACHINE_RESET(drgw2);
 	void pgm_012_025_drgw2(machine_config &config);
+private:
+	required_device<igs025_device> m_igs025;
+
+	void pgm_drgw2_decrypt();
 	void drgw2_mem(address_map &map);
 };

--- a/src/mame/machine/pgmprot_igs025_igs022.cpp
+++ b/src/mame/machine/pgmprot_igs025_igs022.cpp
@@ -36,18 +36,18 @@
 
 void pgm_022_025_state::pgm_dw3_decrypt()
 {
-	int i;
-	uint16_t *src = (uint16_t *) (memregion("maincpu")->base()+0x100000);
+	u16 *src = (u16 *) (memregion("maincpu")->base() + 0x100000);
 
 	int rom_size = 0x100000;
 
-	for(i=0; i<rom_size/2; i++) {
-		uint16_t x = src[i];
+	for (int i = 0; i < rom_size / 2; i++)
+	{
+		u16 x = src[i];
 
-		if((i & 0x005460) == 0x001400 || (i & 0x005450) == 0x001040)
+		if ((i & 0x005460) == 0x001400 || (i & 0x005450) == 0x001040)
 			x ^= 0x0100;
 
-		if((i & 0x005e00) == 0x001c00 || (i & 0x005580) == 0x001100)
+		if ((i & 0x005e00) == 0x001c00 || (i & 0x005580) == 0x001100)
 			x ^= 0x0040;
 
 		src[i] = x;
@@ -56,18 +56,18 @@ void pgm_022_025_state::pgm_dw3_decrypt()
 
 void pgm_022_025_state::pgm_killbld_decrypt()
 {
-	int i;
-	uint16_t *src = (uint16_t *) (memregion("maincpu")->base()+0x100000);
+	u16 *src = (u16 *) (memregion("maincpu")->base() + 0x100000);
 
 	int rom_size = 0x200000;
 
-	for(i=0; i<rom_size/2; i++) {
-		uint16_t x = src[i];
+	for (int i = 0; i < rom_size / 2; i++)
+	{
+		u16 x = src[i];
 
-		if((i & 0x006d00) == 0x000400 || (i & 0x006c80) == 0x000880)
+		if ((i & 0x006d00) == 0x000400 || (i & 0x006c80) == 0x000880)
 			x ^= 0x0008;
 
-		if((i & 0x007500) == 0x002400 || (i & 0x007600) == 0x003200)
+		if ((i & 0x007500) == 0x002400 || (i & 0x007600) == 0x003200)
 			x ^= 0x1000;
 
 		src[i] = x;
@@ -75,7 +75,7 @@ void pgm_022_025_state::pgm_killbld_decrypt()
 }
 
 // these were all xored by a table at $178B2A
-static const uint8_t killbld_source_data[0x0c][0xec] =  // offsets to these tables stored at $155ed0
+static const u8 killbld_source_data[0x0c][0xec] =  // offsets to these tables stored at $155ed0
 {
 	{ // region 16, $178772
 		0x5e, 0x09, 0xb3, 0x39, 0x60, 0x71, 0x71, 0x53, 0x11, 0xe5, 0x26, 0x34, 0x4c, 0x8c, 0x90, 0xee,
@@ -189,7 +189,7 @@ static const uint8_t killbld_source_data[0x0c][0xec] =  // offsets to these tabl
 
 // all tables xored with data from $149c4c
 // tables are the same as olds and drgw2
-static const uint8_t dw3_source_data[0x08][0xec] =
+static const u8 dw3_source_data[0x08][0xec] =
 {
 	{ 0, },
 	{ // region 1, $14c21a
@@ -315,25 +315,23 @@ static const uint8_t dw3_source_data[0x08][0xec] =
 
 MACHINE_RESET_MEMBER(pgm_022_025_state,killbld)
 {
-	int region = (ioport(":Region")->read()) & 0xff;
+	const int region = (ioport(":Region")->read()) & 0xff;
 
 	m_igs025->m_kb_region = region - 0x16;
 	m_igs025->m_kb_game_id = 0x89911400 | region;
 
-	MACHINE_RESET_CALL_MEMBER(pgm);
+	pgm_state::machine_reset();
 }
 
 MACHINE_RESET_MEMBER(pgm_022_025_state, dw3)
 {
-	int region = (ioport(":Region")->read()) & 0xff;
+	const int region = (ioport(":Region")->read()) & 0xff;
 
 	m_igs025->m_kb_region = region;
 	m_igs025->m_kb_game_id = 0x00060000 | region;
 
-	MACHINE_RESET_CALL_MEMBER(pgm);
+	pgm_state::machine_reset();
 }
-
-
 
 
 void pgm_022_025_state::igs025_to_igs022_callback( void )
@@ -341,7 +339,6 @@ void pgm_022_025_state::igs025_to_igs022_callback( void )
 //  printf("igs025_to_igs022_callback\n");
 	m_igs022->IGS022_handle_command();
 }
-
 
 
 void pgm_022_025_state::init_killbld()

--- a/src/mame/machine/pgmprot_igs025_igs022.h
+++ b/src/mame/machine/pgmprot_igs025_igs022.h
@@ -15,7 +15,7 @@ public:
 	void pgm_dw3_decrypt();
 	void pgm_killbld_decrypt();
 
-	required_shared_ptr<uint16_t> m_sharedprotram;
+	required_shared_ptr<u16> m_sharedprotram;
 
 	void init_killbld();
 	void init_drgw3();

--- a/src/mame/machine/pgmprot_igs025_igs028.cpp
+++ b/src/mame/machine/pgmprot_igs025_igs028.cpp
@@ -26,7 +26,7 @@
 
 // tables are xored by table at $1998dc
 // tables are the same as drgw3 and drgw2
-static const uint8_t m_olds_source_data[8][0xec] = // table addresses $2951CA
+static const u8 m_olds_source_data[8][0xec] = // table addresses $2951CA
 {
 	{ // region 0, unused...
 		0,
@@ -152,14 +152,14 @@ static const uint8_t m_olds_source_data[8][0xec] = // table addresses $2951CA
 	}
 };
 
-MACHINE_RESET_MEMBER(pgm_028_025_state,olds)
+void pgm_028_025_state::machine_reset()
 {
-	int region = (ioport(":Region")->read()) & 0xff;
+	const int region = (ioport(":Region")->read()) & 0xff;
 
 	m_igs025->m_kb_region = region;
 	m_igs025->m_kb_game_id = 0x00900000 | region;
 
-	MACHINE_RESET_CALL_MEMBER(pgm);
+	pgm_state::machine_reset();
 }
 
 void pgm_028_025_state::init_olds()
@@ -169,7 +169,6 @@ void pgm_028_025_state::init_olds()
 	m_maincpu->space(AS_PROGRAM).install_readwrite_handler(0xdcb400, 0xdcb403, read16_delegate(FUNC(igs025_device::killbld_igs025_prot_r), (igs025_device*)m_igs025), write16_delegate(FUNC(igs025_device::olds_w), (igs025_device*)m_igs025));
 	m_igs028->m_sharedprotram = m_sharedprotram;
 	m_igs025->m_kb_source_data = m_olds_source_data;
-
 }
 
 void pgm_028_025_state::olds_mem(address_map &map)
@@ -196,8 +195,6 @@ void pgm_028_025_state::pgm_028_025_ol(machine_config &config)
 	m_igs025->set_external_cb(FUNC(pgm_028_025_state::igs025_to_igs028_callback), this);
 
 	IGS028(config, m_igs028, 0);
-
-	MCFG_MACHINE_RESET_OVERRIDE(pgm_028_025_state,olds)
 }
 
 

--- a/src/mame/machine/pgmprot_igs025_igs028.h
+++ b/src/mame/machine/pgmprot_igs025_igs028.h
@@ -13,15 +13,20 @@ public:
 	{
 	}
 
-	required_shared_ptr<uint16_t> m_sharedprotram;
+	void init_olds();
+
+	void pgm_028_025_ol(machine_config &config);
+
+protected:
+	virtual void machine_reset() override;
+
+private:
+	required_shared_ptr<u16> m_sharedprotram;
 	required_device<igs025_device> m_igs025;
 	required_device<igs028_device> m_igs028;
 
 	void igs025_to_igs028_callback( void );
 
-	void init_olds();
-	DECLARE_MACHINE_RESET(olds);
-	void pgm_028_025_ol(machine_config &config);
 	void olds_mem(address_map &map);
 };
 

--- a/src/mame/machine/pgmprot_igs027a_type1.h
+++ b/src/mame/machine/pgmprot_igs027a_type1.h
@@ -14,40 +14,6 @@ public:
 		m_puzzli_54_trigger = 0;
 	}
 
-	/////////////// simulations
-	uint16_t m_value0;
-	uint16_t m_value1;
-	uint16_t m_valuekey;
-	uint16_t m_ddp3lastcommand;
-	uint32_t m_valueresponse;
-	int m_curslots;
-	uint32_t m_slots[0x100];
-
-	// pstars / oldsplus / kov
-	uint16_t m_pstar_e7_value;
-	uint16_t m_pstar_b1_value;
-	uint16_t m_pstar_ce_value;
-	uint16_t m_kov_c0_value;
-	uint16_t m_kov_cb_value;
-	uint16_t m_kov_fe_value;
-	uint16_t m_extra_ram[0x100];
-	// puzzli2
-	int32_t m_puzzli_54_trigger;
-
-	typedef void (pgm_arm_type1_state::*pgm_arm_sim_command_handler)(int pc);
-
-	pgm_arm_sim_command_handler arm_sim_handler;
-
-	/////////////// emulation
-	uint16_t        m_pgm_arm_type1_highlatch_arm_w;
-	uint16_t        m_pgm_arm_type1_lowlatch_arm_w;
-	uint16_t        m_pgm_arm_type1_highlatch_68k_w;
-	uint16_t        m_pgm_arm_type1_lowlatch_68k_w;
-	uint32_t        m_pgm_arm_type1_counter;
-	optional_shared_ptr<uint32_t> m_arm7_shareram;
-
-	optional_device<cpu_device> m_prot;
-
 	void init_photoy2k();
 	void init_kovsh();
 	void init_kovshp();
@@ -64,36 +30,78 @@ public:
 	void init_kov();
 	void init_kovboot();
 	void init_oldsplus();
+
+	void pgm_arm_type1_sim(machine_config &config);
+	void pgm_arm_type1_cave(machine_config &config);
+	void pgm_arm_type1(machine_config &config);
+
+protected:
+	virtual void machine_start() override;
+
+private:
+	/////////////// simulations
+	u16 m_value0;
+	u16 m_value1;
+	u16 m_valuekey;
+	u16 m_ddp3lastcommand;
+	u32 m_valueresponse;
+	int m_curslots;
+	u32 m_slots[0x100];
+
+	// pstars / oldsplus / kov
+	u16 m_pstar_e7_value;
+	u16 m_pstar_b1_value;
+	u16 m_pstar_ce_value;
+	u16 m_kov_c0_value;
+	u16 m_kov_cb_value;
+	u16 m_kov_fe_value;
+	u16 m_extra_ram[0x100];
+	// puzzli2
+	s32 m_puzzli_54_trigger;
+
+	typedef void (pgm_arm_type1_state::*pgm_arm_sim_command_handler)(int pc);
+
+	pgm_arm_sim_command_handler arm_sim_handler;
+
+	/////////////// emulation
+	u16 m_arm_type1_highlatch_arm_w;
+	u16 m_arm_type1_lowlatch_arm_w;
+	u16 m_arm_type1_highlatch_68k_w;
+	u16 m_arm_type1_lowlatch_68k_w;
+	u32 m_arm_type1_counter;
+	optional_shared_ptr<u32> m_arm7_shareram;
+
+	optional_device<cpu_device> m_prot;
 	DECLARE_MACHINE_START(pgm_arm_type1);
 
-	DECLARE_READ32_MEMBER( pgm_arm7_type1_protlatch_r );
-	DECLARE_WRITE32_MEMBER( pgm_arm7_type1_protlatch_w );
-	DECLARE_READ16_MEMBER( pgm_arm7_type1_68k_protlatch_r );
-	DECLARE_WRITE16_MEMBER( pgm_arm7_type1_68k_protlatch_w );
-	DECLARE_READ16_MEMBER( pgm_arm7_type1_ram_r );
-	DECLARE_WRITE16_MEMBER( pgm_arm7_type1_ram_w );
-	DECLARE_READ32_MEMBER( pgm_arm7_type1_unk_r );
-	DECLARE_READ32_MEMBER( pgm_arm7_type1_exrom_r );
-	DECLARE_READ32_MEMBER( pgm_arm7_type1_shareram_r );
-	DECLARE_WRITE32_MEMBER( pgm_arm7_type1_shareram_w );
-	void pgm_arm7_type1_latch_init();
-	DECLARE_READ16_MEMBER( kovsh_fake_region_r );
-	DECLARE_WRITE16_MEMBER( kovshp_asic27a_write_word );
+	u16 arm7_type1_protlatch_r(offs_t offset);
+	void arm7_type1_protlatch_w(offs_t offset, u16 data);
+	u16 arm7_type1_68k_protlatch_r(offs_t offset);
+	void arm7_type1_68k_protlatch_w(offs_t offset, u16 data);
+	u16 arm7_type1_ram_r(offs_t offset, u16 mem_mask = ~0);
+	void arm7_type1_ram_w(offs_t offset, u16 data, u16 mem_mask = ~0);
+	u32 arm7_type1_unk_r();
+	u32 arm7_type1_exrom_r();
+	u32 arm7_type1_shareram_r(offs_t offset, u32 mem_mask = ~0);
+	void arm7_type1_shareram_w(offs_t offset, u32 data, u32 mem_mask = ~0);
+	void arm7_type1_latch_init();
+	u16 kovsh_fake_region_r();
+	void kovshp_asic27a_write_word(offs_t offset, u16 data);
 	void pgm_decode_kovlsqh2_tiles();
-	void pgm_decode_kovlsqh2_sprites(uint8_t *src );
+	void pgm_decode_kovlsqh2_sprites(u8 *src );
 	void pgm_decode_kovlsqh2_samples();
 	void pgm_decode_kovqhsgs_program();
 	void pgm_decode_kovqhsgs2_program();
-	DECLARE_READ16_MEMBER( pgm_arm7_type1_sim_r );
+	DECLARE_READ16_MEMBER( arm7_type1_sim_r );
 	void command_handler_ddp3(int pc);
 	void command_handler_puzzli2(int pc);
 	void command_handler_py2k2(int pc);
 	void command_handler_pstars(int pc);
 	void command_handler_kov(int pc);
 	void command_handler_oldsplus(int pc);
-	DECLARE_WRITE16_MEMBER( pgm_arm7_type1_sim_w );
-	DECLARE_READ16_MEMBER( pgm_arm7_type1_sim_protram_r );
-	DECLARE_READ16_MEMBER( pstars_arm7_type1_sim_protram_r );
+	DECLARE_WRITE16_MEMBER( arm7_type1_sim_w );
+	u16 arm7_type1_sim_protram_r(offs_t offset);
+	u16 pstars_arm7_type1_sim_protram_r(offs_t offset);
 	int m_simregion;
 
 	/* puzzli2 protection internal state stuff */
@@ -108,7 +116,7 @@ public:
 	int prev_tablloc;
 	int numbercolumns;
 	int depth;
-	uint16_t m_row_bitmask;
+	u16 m_row_bitmask;
 	int hackcount;
 	int hackcount2;
 	int hack_47_value;
@@ -116,19 +124,16 @@ public:
 	int hack_31_table_offset2;
 	int p2_31_retcounter;
 
-	uint8_t coverage[256]; // coverage is how much of the table we've managed to verify using known facts about the table structure
+	u8 coverage[256]; // coverage is how much of the table we've managed to verify using known facts about the table structure
 
 	int command_31_write_type;
 
 
 	// the maximum level size returned or read by the device appears to be this size
-	uint16_t level_structure[8][10];
+	u16 level_structure[8][10];
 
 
-	int puzzli2_take_leveldata_value(uint8_t datvalue);
-	void pgm_arm_type1_sim(machine_config &config);
-	void pgm_arm_type1_cave(machine_config &config);
-	void pgm_arm_type1(machine_config &config);
+	int puzzli2_take_leveldata_value(u8 datvalue);
 	void _55857E_arm7_map(address_map &map);
 	void cavepgm_mem(address_map &map);
 	void kov_map(address_map &map);

--- a/src/mame/machine/pgmprot_igs027a_type2.cpp
+++ b/src/mame/machine/pgmprot_igs027a_type2.cpp
@@ -36,16 +36,17 @@
 #include "includes/pgm.h"
 #include "machine/pgmprot_igs027a_type2.h"
 
-READ32_MEMBER(pgm_arm_type2_state::arm7_latch_arm_r )
+u32 pgm_arm_type2_state::arm7_latch_arm_r(offs_t offset, u32 mem_mask)
 {
-	m_prot->set_input_line(ARM7_FIRQ_LINE, CLEAR_LINE ); // guess
+	if (!machine().side_effects_disabled())
+		m_prot->set_input_line(ARM7_FIRQ_LINE, CLEAR_LINE ); // guess
 
 	if (PGMARM7LOGERROR)
 		logerror("%s ARM7: Latch read: %08x (%08x)\n", machine().describe_context(), m_kov2_latchdata_68k_w, mem_mask);
 	return m_kov2_latchdata_68k_w;
 }
 
-WRITE32_MEMBER(pgm_arm_type2_state::arm7_latch_arm_w )
+void pgm_arm_type2_state::arm7_latch_arm_w(offs_t offset, u32 data, u32 mem_mask)
 {
 	if (PGMARM7LOGERROR)
 		logerror("%s ARM7: Latch write: %08x (%08x)\n", machine().describe_context(), data, mem_mask);
@@ -53,28 +54,28 @@ WRITE32_MEMBER(pgm_arm_type2_state::arm7_latch_arm_w )
 	COMBINE_DATA(&m_kov2_latchdata_arm_w);
 }
 
-READ32_MEMBER(pgm_arm_type2_state::arm7_shareram_r )
+u32 pgm_arm_type2_state::arm7_shareram_r(offs_t offset, u32 mem_mask)
 {
 	if (PGMARM7LOGERROR)
 		logerror("%s ARM7: ARM7 Shared RAM Read: %04x = %08x (%08x)\n", machine().describe_context(), offset << 2, m_arm7_shareram[offset], mem_mask);
 	return m_arm7_shareram[offset];
 }
 
-WRITE32_MEMBER(pgm_arm_type2_state::arm7_shareram_w )
+void pgm_arm_type2_state::arm7_shareram_w(offs_t offset, u32 data, u32 mem_mask)
 {
 	if (PGMARM7LOGERROR)
 		logerror("%s ARM7: ARM7 Shared RAM Write: %04x = %08x (%08x)\n", machine().describe_context(), offset << 2, data, mem_mask);
 	COMBINE_DATA(&m_arm7_shareram[offset]);
 }
 
-READ16_MEMBER(pgm_arm_type2_state::arm7_latch_68k_r )
+u16 pgm_arm_type2_state::arm7_latch_68k_r(offs_t offset, u16 mem_mask)
 {
 	if (PGMARM7LOGERROR)
 		logerror("%s M68K: Latch read: %04x (%04x)\n", machine().describe_context(), m_kov2_latchdata_arm_w & 0x0000ffff, mem_mask);
 	return m_kov2_latchdata_arm_w;
 }
 
-WRITE16_MEMBER(pgm_arm_type2_state::arm7_latch_68k_w )
+void pgm_arm_type2_state::arm7_latch_68k_w(offs_t offset, u16 data, u16 mem_mask)
 {
 	if (PGMARM7LOGERROR)
 		logerror("%s M68K: Latch write: %04x (%04x)\n", machine().describe_context(), data & 0x0000ffff, mem_mask);
@@ -83,18 +84,18 @@ WRITE16_MEMBER(pgm_arm_type2_state::arm7_latch_68k_w )
 	m_prot->set_input_line(ARM7_FIRQ_LINE, ASSERT_LINE ); // guess
 }
 
-READ16_MEMBER(pgm_arm_type2_state::arm7_ram_r )
+u16 pgm_arm_type2_state::arm7_ram_r(offs_t offset, u16 mem_mask)
 {
-	uint16_t *share16 = reinterpret_cast<uint16_t *>(m_arm7_shareram.target());
+	const u16 *share16 = reinterpret_cast<u16 *>(m_arm7_shareram.target());
 
 	if (PGMARM7LOGERROR)
 		logerror("%s M68K: ARM7 Shared RAM Read: %04x = %04x (%08x)\n", machine().describe_context(), BYTE_XOR_LE(offset), share16[BYTE_XOR_LE(offset)], mem_mask);
 	return share16[BYTE_XOR_LE(offset)];
 }
 
-WRITE16_MEMBER(pgm_arm_type2_state::arm7_ram_w )
+void pgm_arm_type2_state::arm7_ram_w(offs_t offset, u16 data, u16 mem_mask)
 {
-	uint16_t *share16 = reinterpret_cast<uint16_t *>(m_arm7_shareram.target());
+	u16 *share16 = reinterpret_cast<u16 *>(m_arm7_shareram.target());
 
 	if (PGMARM7LOGERROR)
 		logerror("%s M68K: ARM7 Shared RAM Write: %04x = %04x (%04x)\n", machine().describe_context(), BYTE_XOR_LE(offset), data, mem_mask);
@@ -124,19 +125,11 @@ void pgm_arm_type2_state::_55857F_arm7_map(address_map &map)
 	map(0x50000000, 0x500003ff).ram();
 }
 
-MACHINE_START_MEMBER(pgm_arm_type2_state,pgm_arm_type2)
-{
-	MACHINE_START_CALL_MEMBER(pgm);
-	/* register type specific Save State stuff here */
-}
-
 /******* ARM 55857F *******/
 
 void pgm_arm_type2_state::pgm_arm_type2(machine_config &config)
 {
 	pgmbase(config);
-
-	MCFG_MACHINE_START_OVERRIDE(pgm_arm_type2_state, pgm_arm_type2 )
 
 	m_maincpu->set_addrmap(AS_PROGRAM, &pgm_arm_type2_state::kov2_mem);
 
@@ -144,8 +137,6 @@ void pgm_arm_type2_state::pgm_arm_type2(machine_config &config)
 	ARM7(config, m_prot, 20000000);    // 55857F
 	m_prot->set_addrmap(AS_PROGRAM, &pgm_arm_type2_state::_55857F_arm7_map);
 }
-
-
 
 
 void pgm_arm_type2_state::kov2_latch_init()
@@ -157,20 +148,20 @@ void pgm_arm_type2_state::kov2_latch_init()
 	save_item(NAME(m_kov2_latchdata_arm_w));
 }
 
-WRITE32_MEMBER(pgm_arm_type2_state::kov2_arm_region_w )
+void pgm_arm_type2_state::kov2_arm_region_w(offs_t offset, u32 data, u32 mem_mask)
 {
-	int pc = m_prot->pc();
-	int regionhack = ioport("RegionHack")->read();
-	if (pc==0x190 && regionhack != 0xff) data = (data & 0xffff0000) | (regionhack << 0);
+	const int pc = m_prot->pc();
+	const int regionhack = m_regionhack->read();
+	if (pc == 0x190 && regionhack != 0xff) data = (data & 0xffff0000) | (regionhack << 0);
 	COMBINE_DATA(&m_arm7_shareram[0x138/4]);
 }
 
-WRITE32_MEMBER(pgm_arm_type2_state::kov2p_arm_region_w )
+void pgm_arm_type2_state::kov2p_arm_region_w(offs_t offset, u32 data, u32 mem_mask)
 {
-	int pc = m_prot->pc();
-	int regionhack = ioport("RegionHack")->read();
+	const int pc = m_prot->pc();
+	const int regionhack = m_regionhack->read();
 //  printf("%08x\n", pc);
-	if (pc==0x1b0 && regionhack != 0xff) data = (data & 0xffff0000) | (regionhack << 0);
+	if (pc == 0x1b0 && regionhack != 0xff) data = (data & 0xffff0000) | (regionhack << 0);
 	COMBINE_DATA(&m_arm7_shareram[0x138/4]);
 }
 
@@ -182,7 +173,7 @@ void pgm_arm_type2_state::init_kov2()
 	kov2_latch_init();
 
 	// we only have a HK internal ROM dumped for now, allow us to override that for debugging purposes.
-	m_prot->space(AS_PROGRAM).install_write_handler(0x48000138, 0x4800013b, write32_delegate(FUNC(pgm_arm_type2_state::kov2_arm_region_w),this));
+	m_prot->space(AS_PROGRAM).install_write_handler(0x48000138, 0x4800013b, write32s_delegate(FUNC(pgm_arm_type2_state::kov2_arm_region_w),this));
 }
 
 
@@ -196,14 +187,14 @@ void pgm_arm_type2_state::init_kov2p()
 	kov2_latch_init();
 
 	// we only have a China internal ROM dumped for now, allow us to override that for debugging purposes.
-	m_prot->space(AS_PROGRAM).install_write_handler(0x48000138, 0x4800013b, write32_delegate(FUNC(pgm_arm_type2_state::kov2p_arm_region_w),this));
+	m_prot->space(AS_PROGRAM).install_write_handler(0x48000138, 0x4800013b, write32s_delegate(FUNC(pgm_arm_type2_state::kov2p_arm_region_w),this));
 }
 
-WRITE32_MEMBER(pgm_arm_type2_state::martmast_arm_region_w )
+void pgm_arm_type2_state::martmast_arm_region_w(offs_t offset, u32 data, u32 mem_mask)
 {
-	int pc = m_prot->pc();
-	int regionhack = ioport("RegionHack")->read();
-	if (pc==0x170 && regionhack != 0xff) data = (data & 0xffff0000) | (regionhack << 0);
+	const int pc = m_prot->pc();
+	const int regionhack = m_regionhack->read();
+	if (pc == 0x170 && regionhack != 0xff) data = (data & 0xffff0000) | (regionhack << 0);
 	COMBINE_DATA(&m_arm7_shareram[0x138/4]);
 }
 
@@ -215,27 +206,25 @@ void pgm_arm_type2_state::init_martmast()
 	kov2_latch_init();
 
 	// we only have a USA / CHINA internal ROMs dumped for now, allow us to override that for debugging purposes.
-	m_prot->space(AS_PROGRAM).install_write_handler(0x48000138, 0x4800013b, write32_delegate(FUNC(pgm_arm_type2_state::martmast_arm_region_w),this));
+	m_prot->space(AS_PROGRAM).install_write_handler(0x48000138, 0x4800013b, write32s_delegate(FUNC(pgm_arm_type2_state::martmast_arm_region_w),this));
 }
-
-
 
 
 READ32_MEMBER(pgm_arm_type2_state::ddp2_speedup_r )
 {
-	int pc = m_prot->pc();
-	uint32_t data = m_arm_ram[0x300c/4];
+	const int pc = m_prot->pc();
+	const u32 data = m_arm_ram[0x300c/4];
 
-	if (pc==0x080109b4)
+	if (pc == 0x080109b4)
 	{
 		/* if we've hit the loop where this is read and both values are 0 then the only way out is an interrupt */
 		int r4 = (m_prot->state_int(ARM7_R4));
 		r4 += 0xe;
 
-		if (r4==0x18002f9e)
+		if (r4 == 0x18002f9e)
 		{
-			uint32_t data2 =  m_arm_ram[0x2F9C/4]&0xffff0000;
-			if ((data==0x00000000) && (data2==0x00000000)) space.device().execute().spin_until_interrupt();
+			const u32 data2 =  m_arm_ram[0x2F9C/4] & 0xffff0000;
+			if ((data == 0x00000000) && (data2 == 0x00000000)) space.device().execute().spin_until_interrupt();
 		}
 	}
 
@@ -244,8 +233,8 @@ READ32_MEMBER(pgm_arm_type2_state::ddp2_speedup_r )
 
 READ16_MEMBER(pgm_arm_type2_state::ddp2_main_speedup_r )
 {
-	uint16_t data = m_mainram[0x0ee54/2];
-	int pc = m_maincpu->pc();
+	const u16 data = m_mainram[0x0ee54/2];
+	const int pc = m_maincpu->pc();
 
 	if (pc == 0x149dce) m_maincpu->spin_until_interrupt();
 	if (pc == 0x149cfe) m_maincpu->spin_until_interrupt();
@@ -278,7 +267,6 @@ void pgm_arm_type2_state::init_dwpc()
 	kov2_latch_init();
 	pgm_mm_decrypt(machine()); // encryption is the same as martial masters
 }
-
 
 
 INPUT_PORTS_START( kov2 )

--- a/src/mame/machine/pgmprot_igs027a_type2.h
+++ b/src/mame/machine/pgmprot_igs027a_type2.h
@@ -10,37 +10,39 @@ public:
 			m_arm7_shareram(*this, "arm7_shareram"),
 			m_prot(*this, "prot") {
 	}
-	// kov2
-	uint32_t        m_kov2_latchdata_68k_w;
-	uint32_t        m_kov2_latchdata_arm_w;
-
-	required_shared_ptr<uint32_t> m_arm_ram;
-	required_shared_ptr<uint32_t> m_arm7_shareram;
-
-	optional_device<cpu_device> m_prot;
-
 	void init_kov2();
 	void init_kov2p();
 	void init_martmast();
 	void init_ddp2();
 	void init_dw2001();
 	void init_dwpc();
-	DECLARE_MACHINE_START(pgm_arm_type2);
-	DECLARE_READ32_MEMBER( arm7_latch_arm_r );
-	DECLARE_WRITE32_MEMBER( arm7_latch_arm_w );
-	DECLARE_READ32_MEMBER( arm7_shareram_r );
-	DECLARE_WRITE32_MEMBER( arm7_shareram_w );
-	DECLARE_READ16_MEMBER( arm7_latch_68k_r );
-	DECLARE_WRITE16_MEMBER( arm7_latch_68k_w );
-	DECLARE_READ16_MEMBER( arm7_ram_r );
-	DECLARE_WRITE16_MEMBER( arm7_ram_w );
+
+	void pgm_arm_type2(machine_config &config);
+
+private:
+	// kov2
+	u32        m_kov2_latchdata_68k_w;
+	u32        m_kov2_latchdata_arm_w;
+
+	required_shared_ptr<u32> m_arm_ram;
+	required_shared_ptr<u32> m_arm7_shareram;
+
+	optional_device<cpu_device> m_prot;
+
+	u32 arm7_latch_arm_r(offs_t offset, u32 mem_mask = ~0);
+	void arm7_latch_arm_w(offs_t offset, u32 data, u32 mem_mask = ~0);
+	u32 arm7_shareram_r(offs_t offset, u32 mem_mask = ~0);
+	void arm7_shareram_w(offs_t offset, u32 data, u32 mem_mask = ~0);
+	u16 arm7_latch_68k_r(offs_t offset, u16 mem_mask = ~0);
+	void arm7_latch_68k_w(offs_t offset, u16 data, u16 mem_mask = ~0);
+	u16 arm7_ram_r(offs_t offset, u16 mem_mask = ~0);
+	void arm7_ram_w(offs_t offset, u16 data, u16 mem_mask = ~0);
 	void kov2_latch_init();
-	DECLARE_WRITE32_MEMBER( martmast_arm_region_w );
-	DECLARE_WRITE32_MEMBER( kov2_arm_region_w );
-	DECLARE_WRITE32_MEMBER( kov2p_arm_region_w );
+	void martmast_arm_region_w(offs_t offset, u32 data, u32 mem_mask = ~0);
+	void kov2_arm_region_w(offs_t offset, u32 data, u32 mem_mask = ~0);
+	void kov2p_arm_region_w(offs_t offset, u32 data, u32 mem_mask = ~0);
 	DECLARE_READ32_MEMBER( ddp2_speedup_r );
 	DECLARE_READ16_MEMBER( ddp2_main_speedup_r );
-	void pgm_arm_type2(machine_config &config);
 	void _55857F_arm7_map(address_map &map);
 	void kov2_mem(address_map &map);
 };

--- a/src/mame/machine/pgmprot_igs027a_type3.cpp
+++ b/src/mame/machine/pgmprot_igs027a_type3.cpp
@@ -47,53 +47,53 @@
 #include "includes/pgm.h"
 #include "machine/pgmprot_igs027a_type3.h"
 
-WRITE32_MEMBER(pgm_arm_type3_state::svg_arm7_ram_sel_w )
+void pgm_arm_type3_state::svg_arm7_ram_sel_w(u32 data)
 {
 //  printf("svg_arm7_ram_sel_w %08x\n", data);
 	machine().scheduler().synchronize(); // force resync
 	m_svg_ram_sel = data & 1;
 }
 
-READ32_MEMBER(pgm_arm_type3_state::svg_arm7_shareram_r )
+u32 pgm_arm_type3_state::svg_arm7_shareram_r(offs_t offset)
 {
-	uint32_t retdata = m_svg_shareram[m_svg_ram_sel & 1][offset];
+	const u32 retdata = m_svg_shareram[m_svg_ram_sel & 1][offset];
 //  logerror("%s ARM7: shared read (bank %02x) offset - %08x retdata - %08x mask - %08x\n", machine().describe_context(), m_svg_ram_sel, offset*4, retdata, mem_mask );
 	return retdata;
 }
 
-WRITE32_MEMBER(pgm_arm_type3_state::svg_arm7_shareram_w )
+void pgm_arm_type3_state::svg_arm7_shareram_w(offs_t offset, u32 data, u32 mem_mask)
 {
 //  logerror("%s ARM7: shared write (bank %02x) offset - %08x retdata - %08x mask - %08x\n", machine().describe_context(), m_svg_ram_sel, offset*4, data, mem_mask );
 	COMBINE_DATA(&m_svg_shareram[m_svg_ram_sel & 1][offset]);
 }
 
-READ16_MEMBER(pgm_arm_type3_state::svg_m68k_ram_r )
+u16 pgm_arm_type3_state::svg_m68k_ram_r(offs_t offset)
 {
-	int ram_sel = (m_svg_ram_sel & 1) ^ 1;
-	uint16_t *share16 = (uint16_t *)(m_svg_shareram[ram_sel & 1].get());
+	const int ram_sel = (m_svg_ram_sel & 1) ^ 1;
+	const u16 *share16 = (u16 *)(m_svg_shareram[ram_sel & 1].get());
 
 	return share16[BYTE_XOR_LE(offset)];
 }
 
-WRITE16_MEMBER(pgm_arm_type3_state::svg_m68k_ram_w )
+void pgm_arm_type3_state::svg_m68k_ram_w(offs_t offset, u16 data, u16 mem_mask)
 {
-	int ram_sel = (m_svg_ram_sel & 1) ^ 1;
-	uint16_t *share16 = (uint16_t *)(m_svg_shareram[ram_sel & 1].get());
+	const int ram_sel = (m_svg_ram_sel & 1) ^ 1;
+	u16 *share16 = (u16 *)(m_svg_shareram[ram_sel & 1].get());
 
 	COMBINE_DATA(&share16[BYTE_XOR_LE(offset)]);
 }
 
-READ16_MEMBER(pgm_arm_type3_state::svg_68k_nmi_r )
+u16 pgm_arm_type3_state::svg_68k_nmi_r()
 {
 	return 0;
 }
 
-WRITE16_MEMBER(pgm_arm_type3_state::svg_68k_nmi_w )
+void pgm_arm_type3_state::svg_68k_nmi_w(u16 data)
 {
 	m_prot->pulse_input_line(ARM7_FIRQ_LINE, m_prot->minimum_quantum_time());
 }
 
-WRITE16_MEMBER(pgm_arm_type3_state::svg_latch_68k_w )
+void pgm_arm_type3_state::svg_latch_68k_w(offs_t offset, u16 data, u16 mem_mask)
 {
 	if (PGMARM7LOGERROR)
 		logerror("M68K: Latch write: %04x (%04x) %s\n", data & 0x0000ffff, mem_mask, machine().describe_context());
@@ -101,7 +101,7 @@ WRITE16_MEMBER(pgm_arm_type3_state::svg_latch_68k_w )
 }
 
 
-READ16_MEMBER(pgm_arm_type3_state::svg_latch_68k_r )
+u16 pgm_arm_type3_state::svg_latch_68k_r(offs_t offset, u16 mem_mask)
 {
 	if (PGMARM7LOGERROR)
 		logerror("M68K: Latch read: %04x (%04x) %s\n", m_svg_latchdata_arm_w & 0x0000ffff, mem_mask, machine().describe_context());
@@ -109,15 +109,14 @@ READ16_MEMBER(pgm_arm_type3_state::svg_latch_68k_r )
 }
 
 
-
-READ32_MEMBER(pgm_arm_type3_state::svg_latch_arm_r )
+u32 pgm_arm_type3_state::svg_latch_arm_r(offs_t offset, u32 mem_mask)
 {
 	if (PGMARM7LOGERROR)
 		logerror("ARM7: Latch read: %08x (%08x) %s\n", m_svg_latchdata_68k_w, mem_mask, machine().describe_context());
 	return m_svg_latchdata_68k_w;
 }
 
-WRITE32_MEMBER(pgm_arm_type3_state::svg_latch_arm_w )
+void pgm_arm_type3_state::svg_latch_arm_w(offs_t offset, u32 data, u32 mem_mask)
 {
 	if (PGMARM7LOGERROR)
 		logerror("ARM7: Latch write: %08x (%08x) %s\n", data, mem_mask, machine().describe_context());
@@ -152,12 +151,10 @@ void pgm_arm_type3_state::_55857G_arm7_map(address_map &map)
 }
 
 
-
-
-MACHINE_RESET_MEMBER(pgm_arm_type3_state, pgm_arm_type3_reset)
+void pgm_arm_type3_state::machine_reset()
 {
 	// internal roms aren't fully dumped
-	uint16_t *temp16 = (uint16_t *)memregion("prot")->base();
+	u16 *temp16 = (u16 *)memregion("prot")->base();
 	int base = -1;
 
 	if (!strcmp(machine().system().name, "theglad")) base = 0x3316;
@@ -171,20 +168,14 @@ MACHINE_RESET_MEMBER(pgm_arm_type3_state, pgm_arm_type3_reset)
 
 	if (base != -1)
 	{
-		int regionhack = ioport("RegionHack")->read();
+		const int regionhack = m_regionhack->read();
 		if (regionhack != 0xff)
 		{
 //          printf("%04x\n", temp16[(base) / 2]);
 			temp16[(base) / 2] = regionhack; base += 2;
 		}
 	}
-	MACHINE_RESET_CALL_MEMBER(pgm);
-}
-
-MACHINE_START_MEMBER(pgm_arm_type3_state,pgm_arm_type3)
-{
-	MACHINE_START_CALL_MEMBER(pgm);
-	/* register type specific Save State stuff here */
+	pgm_state::machine_reset();
 }
 
 
@@ -194,24 +185,19 @@ void pgm_arm_type3_state::pgm_arm_type3(machine_config &config)
 {
 	pgmbase(config);
 
-	MCFG_MACHINE_START_OVERRIDE(pgm_arm_type3_state, pgm_arm_type3 )
-
 	m_maincpu->set_addrmap(AS_PROGRAM, &pgm_arm_type3_state::svg_68k_mem);
 
 	/* protection CPU */
 	ARM7(config, m_prot, XTAL(33'000'000));    // 55857G - 33Mhz Xtal, at least on SVG
 	m_prot->set_addrmap(AS_PROGRAM, &pgm_arm_type3_state::_55857G_arm7_map);
-
-	MCFG_MACHINE_RESET_OVERRIDE(pgm_arm_type3_state, pgm_arm_type3_reset)
 }
-
 
 
 void pgm_arm_type3_state::svg_basic_init()
 {
 	pgm_basic_init();
-	m_svg_shareram[0] = std::make_unique<uint32_t[]>(0x20000 / 4);
-	m_svg_shareram[1] = std::make_unique<uint32_t[]>(0x20000 / 4);
+	m_svg_shareram[0] = std::make_unique<u32[]>(0x20000 / 4);
+	m_svg_shareram[1] = std::make_unique<u32[]>(0x20000 / 4);
 	m_svg_ram_sel = 0;
 
 	save_pointer(NAME(m_svg_shareram[0]), 0x20000 / 4);
@@ -221,11 +207,10 @@ void pgm_arm_type3_state::svg_basic_init()
 
 void pgm_arm_type3_state::pgm_create_dummy_internal_arm_region(int size)
 {
-	uint16_t *temp16 = (uint16_t *)memregion("prot")->base();
+	u16 *temp16 = (u16 *)memregion("prot")->base();
 
 	// fill with RX 14
-	int i;
-	for (i=0;i<size/2;i+=2)
+	for (int i = 0; i < size / 2; i += 2)
 	{
 		temp16[i] = 0xff1e;
 		temp16[i+1] = 0xe12f;
@@ -254,7 +239,7 @@ void pgm_arm_type3_state::svg_latch_init()
 
 READ32_MEMBER(pgm_arm_type3_state::theglad_speedup_r )
 {
-	int pc = m_prot->pc();
+	const int pc = m_prot->pc();
 	if (pc == 0x7c4) m_prot->eat_cycles(500);
 	//else printf("theglad_speedup_r %08x\n", pc);
 	return m_arm_ram2[0x00c/4];
@@ -263,7 +248,7 @@ READ32_MEMBER(pgm_arm_type3_state::theglad_speedup_r )
 
 READ32_MEMBER(pgm_arm_type3_state::happy6_speedup_r )
 {
-	int pc = m_prot->pc();
+	const int pc = m_prot->pc();
 	if (pc == 0x0a08) m_prot->eat_cycles(500);
 	//else printf("theglad_speedup_r %08x\n", pc);
 	return m_arm_ram2[0x00c/4];
@@ -272,14 +257,14 @@ READ32_MEMBER(pgm_arm_type3_state::happy6_speedup_r )
 // installed over rom
 READ32_MEMBER(pgm_arm_type3_state::svg_speedup_r )
 {
-	int pc = m_prot->pc();
+	const int pc = m_prot->pc();
 	if (pc == 0xb90) m_prot->eat_cycles(500);
 	return m_armrom[0xb90/4];
 }
 
 READ32_MEMBER(pgm_arm_type3_state::svgpcb_speedup_r )
 {
-	int pc = m_prot->pc();
+	const int pc = m_prot->pc();
 	if (pc == 0x9e0) m_prot->eat_cycles(500);
 	return m_armrom[0x9e0/4];
 }
@@ -287,13 +272,11 @@ READ32_MEMBER(pgm_arm_type3_state::svgpcb_speedup_r )
 
 void pgm_arm_type3_state::pgm_create_dummy_internal_arm_region_theglad(int is_svg)
 {
-	uint16_t *temp16 = (uint16_t *)memregion("prot")->base();
-	int i;
-	for (i=0;i<0x188/2;i+=2)
+	u16 *temp16 = (u16 *)memregion("prot")->base();
+	for (int i = 0; i < 0x188 / 2; i += 2)
 	{
 		temp16[i] = 0xFFFE;
 		temp16[i+1] = 0xEAFF;
-
 	}
 
 	// the interrupt code appears to be at 0x08000010
@@ -497,8 +480,6 @@ void pgm_arm_type3_state::pgm_create_dummy_internal_arm_region_theglad(int is_sv
 		temp16[(base) / 2] = 0xe59f; base += 2;
 	}
 
-
-
 	base = 0x150;
 	temp16[(base) /2] = 0xff1e; base += 2;
 	temp16[(base) /2] = 0xe12f; base += 2;
@@ -527,7 +508,7 @@ void pgm_arm_type3_state::init_theglad()
 void pgm_arm_type3_state::pgm_patch_external_arm_rom_jumptable_theglada(int base)
 {
 	// we don't have the correct internal ROM for this version, so insead we use the one we have and patch the jump table in the external ROM
-	uint32_t subroutine_addresses[] =
+	u32 subroutine_addresses[] =
 	{
 		0x00FC, 0x00E8, 0x0110, 0x0150, 0x0194, 0x06C8, 0x071C, 0x0728,
 		0x0734, 0x0740, 0x0784, 0x0794, 0x07FC, 0x0840, 0x086C, 0x0988,
@@ -547,7 +528,7 @@ void pgm_arm_type3_state::pgm_patch_external_arm_rom_jumptable_theglada(int base
 		0x3050, 0x30A4, 0x30F8, 0x3120, 0x249C, 0x24C0, 0x27BC, 0x2B40,
 		0x2BF4, 0x2CD8, 0x2E2C
 	};
-	uint16_t *extprot = (uint16_t *)memregion("user1")->base();
+	u16 *extprot = (u16 *)memregion("user1")->base();
 	/*
 	0x00C8,0x00B4,0x00DC,0x011C,0x0160,0x02DC,0x0330,0x033C,
 	0x0348,0x0354,0x0398,0x03A8,0x0410,0x0454,0x0480,0x059C,
@@ -571,7 +552,7 @@ void pgm_arm_type3_state::pgm_patch_external_arm_rom_jumptable_theglada(int base
 
 	for (auto & subroutine_addresse : subroutine_addresses)
 	{
-//      uint32_t addr = extprot[(base/2)] | (extprot[(base/2) + 1] << 16);
+//      u32 addr = extprot[(base/2)] | (extprot[(base/2) + 1] << 16);
 		extprot[(base / 2)] = subroutine_addresse;
 
 		base += 4;
@@ -653,7 +634,7 @@ void pgm_arm_type3_state::init_svg()
 	pgm_svg_decrypt(machine());
 	svg_latch_init();
 	pgm_create_dummy_internal_arm_region_theglad(1);
-	m_armrom = (uint32_t *)memregion("prot")->base();
+	m_armrom = (u32 *)memregion("prot")->base();
 	m_prot->space(AS_PROGRAM).install_read_handler(0xB90, 0xB93, read32_delegate(FUNC(pgm_arm_type3_state::svg_speedup_r),this));
 
 
@@ -665,7 +646,7 @@ void pgm_arm_type3_state::init_svgpcb()
 	pgm_svgpcb_decrypt(machine());
 	svg_latch_init();
 	pgm_create_dummy_internal_arm_region_theglad(0);
-	m_armrom = (uint32_t *)memregion("prot")->base();
+	m_armrom = (u32 *)memregion("prot")->base();
 	m_prot->space(AS_PROGRAM).install_read_handler(0x9e0, 0x9e3, read32_delegate(FUNC(pgm_arm_type3_state::svgpcb_speedup_r),this));
 
 }
@@ -673,7 +654,7 @@ void pgm_arm_type3_state::init_svgpcb()
 
 READ32_MEMBER(pgm_arm_type3_state::killbldp_speedup_r )
 {
-	int pc = m_prot->pc();
+	const int pc = m_prot->pc();
 	if (pc == 0x7d8) m_prot->eat_cycles(500);
 	//else printf("killbldp_speedup_r %08x\n", pc);
 	return m_arm_ram2[0x00c/4];
@@ -687,7 +668,7 @@ void pgm_arm_type3_state::init_killbldp()
 
 	m_prot->space(AS_PROGRAM).install_read_handler(0x1000000c, 0x1000000f, read32_delegate(FUNC(pgm_arm_type3_state::killbldp_speedup_r),this));
 
-//  uint16_t *temp16 = (uint16_t *)memregion("prot")->base();
+//  u16 *temp16 = (u16 *)memregion("prot")->base();
 //  int base = 0xfc; // startup table uploads
 //  temp16[(base) /2] = 0x0000; base += 2;
 //  temp16[(base) /2] = 0xE1A0; base += 2;
@@ -704,7 +685,7 @@ void pgm_arm_type3_state::init_killbldp()
 
 READ32_MEMBER(pgm_arm_type3_state::dmnfrnt_speedup_r )
 {
-	int pc = m_prot->pc();
+	const int pc = m_prot->pc();
 	if (pc == 0x8000fea) m_prot->eat_cycles(500);
 //  else printf("dmn_speedup_r %08x\n", pc);
 	return m_arm_ram[0x000444/4];
@@ -712,8 +693,8 @@ READ32_MEMBER(pgm_arm_type3_state::dmnfrnt_speedup_r )
 
 READ16_MEMBER(pgm_arm_type3_state::dmnfrnt_main_speedup_r )
 {
-	uint16_t data = m_mainram[0xa03c/2];
-	int pc = m_maincpu->pc();
+	u16 data = m_mainram[0xa03c/2];
+	const int pc = m_maincpu->pc();
 	if (pc == 0x10193a) m_maincpu->spin_until_interrupt();
 	else if (pc == 0x1019a4) m_maincpu->spin_until_interrupt();
 	return data;
@@ -736,10 +717,10 @@ void pgm_arm_type3_state::init_dmnfrnt()
 	// the internal rom probably also supplies the region here
 	// we have to copy it to both shared ram regions because it reads from a different one before the attract story?
 	// could be a timing error? or shared ram behavior isn't how we think it is?
-	uint16_t *share16;
-	share16 = (uint16_t *)(m_svg_shareram[1].get());
+	u16 *share16;
+	share16 = (u16 *)(m_svg_shareram[1].get());
 	share16[0x158/2] = 0x0005;
-	share16 = (uint16_t *)(m_svg_shareram[0].get());
+	share16 = (u16 *)(m_svg_shareram[0].get());
 	share16[0x158/2] = 0x0005;
 }
 
@@ -748,9 +729,9 @@ void pgm_arm_type3_state::init_dmnfrnt()
 // buffer[i] = src[j]
 
 // todo, collapse these to an address swap
-void pgm_arm_type3_state::pgm_descramble_happy6(uint8_t* src)
+void pgm_arm_type3_state::pgm_descramble_happy6(u8* src)
 {
-	std::vector<uint8_t> buffer(0x800000);
+	std::vector<u8> buffer(0x800000);
 	int writeaddress = 0;
 
 	for (int j = 0; j < 0x800; j += 0x200)
@@ -766,9 +747,9 @@ void pgm_arm_type3_state::pgm_descramble_happy6(uint8_t* src)
 
 
 
-void pgm_arm_type3_state::pgm_descramble_happy6_2(uint8_t* src)
+void pgm_arm_type3_state::pgm_descramble_happy6_2(u8* src)
 {
-	std::vector<uint8_t> buffer(0x800000);
+	std::vector<u8> buffer(0x800000);
 	int writeaddress = 0;
 	for (int k = 0; k < 0x800000; k += 0x100000)
 	{
@@ -799,23 +780,23 @@ INPUT_PORTS_END
 
 void pgm_arm_type3_state::init_happy6()
 {
-	uint8_t *src = (uint8_t *)(machine().root_device().memregion("tiles")->base()) + 0x180000;
+	u8 *src = (u8 *)(machine().root_device().memregion("tiles")->base()) + 0x180000;
 	pgm_descramble_happy6(src);
 	pgm_descramble_happy6_2(src);
 
-	src = (uint8_t *)(machine().root_device().memregion("sprcol")->base()) + 0x000000;
+	src = (u8 *)(machine().root_device().memregion("sprcol")->base()) + 0x000000;
 	pgm_descramble_happy6(src);
 	pgm_descramble_happy6_2(src);
 
-	src = (uint8_t *)(machine().root_device().memregion("sprcol")->base()) + 0x0800000;
+	src = (u8 *)(machine().root_device().memregion("sprcol")->base()) + 0x0800000;
 	pgm_descramble_happy6(src);
 	pgm_descramble_happy6_2(src);
 
-	src = (uint8_t *)(machine().root_device().memregion("sprmask")->base());
+	src = (u8 *)(machine().root_device().memregion("sprmask")->base());
 	pgm_descramble_happy6(src);
 	pgm_descramble_happy6_2(src);
 
-	src = (uint8_t *)(machine().root_device().memregion("ics")->base()) + 0x400000;
+	src = (u8 *)(machine().root_device().memregion("ics")->base()) + 0x400000;
 	pgm_descramble_happy6(src);
 	pgm_descramble_happy6_2(src);
 

--- a/src/mame/machine/pgmprot_igs027a_type3.h
+++ b/src/mame/machine/pgmprot_igs027a_type3.h
@@ -10,19 +10,6 @@ public:
 			m_arm_ram2(*this, "arm_ram2"),
 			m_prot(*this, "prot") {
 	}
-	// svg
-	int           m_svg_ram_sel;
-	std::unique_ptr<uint32_t[]>      m_svg_shareram[2];    //for 5585G MACHINE
-
-	uint32_t        m_svg_latchdata_68k_w;
-	uint32_t        m_svg_latchdata_arm_w;
-	required_shared_ptr<uint32_t> m_arm_ram;
-	required_shared_ptr<uint32_t> m_arm_ram2;
-
-	uint32_t* m_armrom;
-
-	optional_device<cpu_device> m_prot;
-
 	void init_theglad();
 	void init_theglada();
 	void init_svg();
@@ -30,24 +17,43 @@ public:
 	void init_killbldp();
 	void init_dmnfrnt();
 	void init_happy6();
-	DECLARE_MACHINE_START(pgm_arm_type3);
-	DECLARE_WRITE32_MEMBER( svg_arm7_ram_sel_w );
-	DECLARE_READ32_MEMBER( svg_arm7_shareram_r );
-	DECLARE_WRITE32_MEMBER( svg_arm7_shareram_w );
-	DECLARE_READ16_MEMBER( svg_m68k_ram_r );
-	DECLARE_WRITE16_MEMBER( svg_m68k_ram_w );
-	DECLARE_READ16_MEMBER( svg_68k_nmi_r );
-	DECLARE_WRITE16_MEMBER( svg_68k_nmi_w );
-	DECLARE_WRITE16_MEMBER( svg_latch_68k_w );
-	DECLARE_READ16_MEMBER( svg_latch_68k_r );
-	DECLARE_READ32_MEMBER( svg_latch_arm_r );
-	DECLARE_WRITE32_MEMBER( svg_latch_arm_w );
+
+	void pgm_arm_type3(machine_config &config);
+
+protected:
+	virtual void machine_reset() override;
+
+private:
+	// svg
+	int m_svg_ram_sel;
+	std::unique_ptr<u32[]> m_svg_shareram[2];    //for 5585G MACHINE
+
+	u32 m_svg_latchdata_68k_w;
+	u32 m_svg_latchdata_arm_w;
+	required_shared_ptr<u32> m_arm_ram;
+	required_shared_ptr<u32> m_arm_ram2;
+
+	u32* m_armrom;
+
+	optional_device<cpu_device> m_prot;
+
+	void svg_arm7_ram_sel_w(u32 data);
+	u32 svg_arm7_shareram_r(offs_t offset);
+	void svg_arm7_shareram_w(offs_t offset, u32 data, u32 mem_mask = ~0);
+	u16 svg_m68k_ram_r(offs_t offset);
+	void svg_m68k_ram_w(offs_t offset, u16 data, u16 mem_mask = ~0);
+	u16 svg_68k_nmi_r();
+	void svg_68k_nmi_w(u16 data);
+	void svg_latch_68k_w(offs_t offset, u16 data, u16 mem_mask = ~0);
+	u16 svg_latch_68k_r(offs_t offset, u16 mem_mask = ~0);
+	u32 svg_latch_arm_r(offs_t offset, u32 mem_mask = ~0);
+	void svg_latch_arm_w(offs_t offset, u32 data, u32 mem_mask = ~0);
 	void svg_basic_init();
 	void pgm_create_dummy_internal_arm_region(int size);
 	void pgm_patch_external_arm_rom_jumptable_theglada(int base);
 	void pgm_create_dummy_internal_arm_region_theglad(int is_svg);
-	void pgm_descramble_happy6(uint8_t* src);
-	void pgm_descramble_happy6_2(uint8_t* src);
+	void pgm_descramble_happy6(u8* src);
+	void pgm_descramble_happy6_2(u8* src);
 	void svg_latch_init();
 	DECLARE_READ32_MEMBER( dmnfrnt_speedup_r );
 	DECLARE_READ16_MEMBER( dmnfrnt_main_speedup_r );
@@ -56,8 +62,6 @@ public:
 	DECLARE_READ32_MEMBER( happy6_speedup_r );
 	DECLARE_READ32_MEMBER( svg_speedup_r );
 	DECLARE_READ32_MEMBER( svgpcb_speedup_r );
-	DECLARE_MACHINE_RESET(pgm_arm_type3_reset);
-	void pgm_arm_type3(machine_config &config);
 	void _55857G_arm7_map(address_map &map);
 	void svg_68k_mem(address_map &map);
 };

--- a/src/mame/machine/pgmprot_orlegend.cpp
+++ b/src/mame/machine/pgmprot_orlegend.cpp
@@ -18,7 +18,7 @@
 
 void pgm_asic3_state::asic3_compute_hold(int y, int z)
 {
-	unsigned short old = m_asic3_hold;
+	const u16 old = m_asic3_hold;
 
 	m_asic3_hold = ((old << 1) | (old >> 15));
 
@@ -27,7 +27,7 @@ void pgm_asic3_state::asic3_compute_hold(int y, int z)
 	m_asic3_hold ^= BIT(m_asic3_x, 2) << 10;
 	m_asic3_hold ^= BIT(old, 5);
 
-	switch (ioport("Region")->read()) // The mode is dependent on the region
+	switch (m_region->read()) // The mode is dependent on the region
 	{
 		case 0:
 		case 1:
@@ -52,13 +52,13 @@ READ16_MEMBER(pgm_asic3_state::pgm_asic3_r)
 	switch (m_asic3_reg)
 	{
 		case 0x00: // region is supplied by the protection device
-			return (m_asic3_latch[0] & 0xf7) | ((ioport("Region")->read() << 3) & 0x08);
+			return (m_asic3_latch[0] & 0xf7) | ((m_region->read() << 3) & 0x08);
 
 		case 0x01:
 			return m_asic3_latch[1];
 
 		case 0x02: // region is supplied by the protection device
-			return (m_asic3_latch[2] & 0x7f) | ((ioport("Region")->read() << 6) & 0x80);
+			return (m_asic3_latch[2] & 0x7f) | ((m_region->read() << 6) & 0x80);
 
 		case 0x03:
 			return bitswap<8>(m_asic3_hold, 5,2,9,7,10,13,12,15);
@@ -95,7 +95,8 @@ READ16_MEMBER(pgm_asic3_state::pgm_asic3_r)
 
 WRITE16_MEMBER(pgm_asic3_state::pgm_asic3_w)
 {
-	if (offset == 0) {
+	if (offset == 0)
+	{
 		m_asic3_reg = data;
 		return;
 	}

--- a/src/mame/machine/pgmprot_orlegend.h
+++ b/src/mame/machine/pgmprot_orlegend.h
@@ -9,18 +9,20 @@ public:
 		: pgm_state(mconfig, type, tag) {
 	}
 
-	// ASIC 3 (oriental legends protection)
-	uint8_t         m_asic3_reg;
-	uint8_t         m_asic3_latch[3];
-	uint8_t         m_asic3_x;
-	uint16_t        m_asic3_hilo;
-	uint16_t        m_asic3_hold;
-
 	void init_orlegend();
+	void pgm_asic3(machine_config &config);
+
+private:
+	// ASIC 3 (oriental legends protection)
+	u8         m_asic3_reg;
+	u8         m_asic3_latch[3];
+	u8         m_asic3_x;
+	u16        m_asic3_hilo;
+	u16        m_asic3_hold;
+
 	void asic3_compute_hold(int,int);
 	DECLARE_READ16_MEMBER( pgm_asic3_r );
 	DECLARE_WRITE16_MEMBER( pgm_asic3_w );
-	void pgm_asic3(machine_config &config);
 };
 
 INPUT_PORTS_EXTERN( orlegend );

--- a/src/mame/video/pgm.cpp
+++ b/src/mame/video/pgm.cpp
@@ -19,11 +19,11 @@
 // bg pri is 2
 // sprite already here is 1 / 3
 
-inline void pgm_state::pgm_draw_pix( int xdrawpos, int pri, uint16_t* dest, uint8_t* destpri, uint16_t srcdat)
+inline void pgm_state::pgm_draw_pix(int xdrawpos, int pri, u16* dest, u8* destpri, const rectangle &cliprect, u16 srcdat)
 {
-	if ((xdrawpos >= 0) && (xdrawpos < 448))
+	if ((xdrawpos >= cliprect.min_x) && (xdrawpos <= cliprect.max_x))
 	{
-		if (!(destpri[xdrawpos]&1))
+		if (!(destpri[xdrawpos] & 1))
 		{
 			if (!pri)
 			{
@@ -31,41 +31,41 @@ inline void pgm_state::pgm_draw_pix( int xdrawpos, int pri, uint16_t* dest, uint
 			}
 			else
 			{
-				if (!(destpri[xdrawpos]&2))
+				if (!(destpri[xdrawpos] & 2))
 				{
 					dest[xdrawpos] = srcdat;
 				}
 			}
 		}
 
-		destpri[xdrawpos]|=1;
+		destpri[xdrawpos] |= 1;
 	}
 }
 
-inline void pgm_state::pgm_draw_pix_nopri( int xdrawpos, uint16_t* dest, uint8_t* destpri, uint16_t srcdat)
+inline void pgm_state::pgm_draw_pix_nopri(int xdrawpos, u16* dest, u8* destpri, const rectangle &cliprect, u16 srcdat)
 {
-	if ((xdrawpos >= 0) && (xdrawpos < 448))
+	if ((xdrawpos >= cliprect.min_x) && (xdrawpos <= cliprect.max_x))
 	{
-		if (!(destpri[xdrawpos]&1))
+		if (!(destpri[xdrawpos] & 1))
 		{
 			dest[xdrawpos] = srcdat;
 		}
-		destpri[xdrawpos]|=1;
+		destpri[xdrawpos] |= 1;
 	}
 }
 
-inline void pgm_state::pgm_draw_pix_pri( int xdrawpos, uint16_t* dest, uint8_t* destpri, uint16_t srcdat)
+inline void pgm_state::pgm_draw_pix_pri(int xdrawpos, u16* dest, u8* destpri, const rectangle &cliprect, u16 srcdat)
 {
-	if ((xdrawpos >= 0) && (xdrawpos < 448))
+	if ((xdrawpos >= cliprect.min_x) && (xdrawpos <= cliprect.max_x))
 	{
-		if (!(destpri[xdrawpos]&1))
+		if (!(destpri[xdrawpos] & 1))
 		{
-			if (!(destpri[xdrawpos]&2))
+			if (!(destpri[xdrawpos] & 2))
 			{
 				dest[xdrawpos] = srcdat;
 			}
 		}
-		destpri[xdrawpos]|=1;
+		destpri[xdrawpos] |= 1;
 	}
 }
 
@@ -74,41 +74,33 @@ inline void pgm_state::pgm_draw_pix_pri( int xdrawpos, uint16_t* dest, uint8_t* 
   for complex zoomed cases
 *************************************************************************/
 
-void pgm_state::draw_sprite_line( int wide, uint16_t* dest, uint8_t* destpri, int xzoom, int xgrow, int flip, int xpos, int pri, int realxsize, int palt, int draw )
+void pgm_state::draw_sprite_line(int wide, u16* dest, u8* destpri, const rectangle &cliprect, int xzoom, bool xgrow, int flip, int xpos, int pri, int realxsize, int palt, bool draw)
 {
-	int xcnt,xcntdraw;
-	int xzoombit;
 	int xoffset = 0;
 	int xdrawpos = 0;
 
-	uint8_t *adata = m_sprite_a_region.get();
-	size_t  adatasize = m_sprite_a_region_size - 1;
+	u8 *adata = m_sprite_a_region.get();
+	size_t adatasize = m_sprite_a_region_size - 1;
 
-	uint16_t msk;
-	uint16_t srcdat;
+	int xcntdraw = 0;
 
-	xcnt = 0;
-	xcntdraw = 0;
-
-	for (xcnt = 0 ; xcnt < wide ; xcnt++)
+	for (int xcnt = 0; xcnt < wide; xcnt++)
 	{
-		int x;
+		u16 msk = ((m_bdata[(m_boffset + 1) & m_bdata.mask()] << 8) |(m_bdata[(m_boffset + 0) & m_bdata.mask()] << 0));
 
-		msk = ((m_bdata[(m_boffset + 1) & m_bdata.mask()] << 8) |( m_bdata[(m_boffset + 0) & m_bdata.mask()] << 0));
-
-		for (x = 0; x < 16; x++)
+		for (int x = 0; x < 16; x++)
 		{
-			if (!(msk & 0x0001))
+			if (!(BIT(msk, 0)))
 			{
-				srcdat = adata[m_aoffset & adatasize] + palt * 32;
+				const u16 srcdat = adata[m_aoffset & adatasize] + palt * 32;
 				m_aoffset++;
 
 				if (draw)
 				{
-					xzoombit = (xzoom >> (xoffset & 0x1f)) & 1;
+					const bool xzoombit = BIT(xzoom, xoffset & 0x1f);
 					xoffset++;
 
-					if (xzoombit == 1 && xgrow == 1)
+					if (xzoombit && xgrow)
 					{ // double this column
 
 						if (!(flip & 0x01))
@@ -116,7 +108,7 @@ void pgm_state::draw_sprite_line( int wide, uint16_t* dest, uint8_t* destpri, in
 						else
 							xdrawpos = xpos + realxsize - xcntdraw;
 
-						pgm_draw_pix(xdrawpos, pri, dest, destpri, srcdat);
+						pgm_draw_pix(xdrawpos, pri, dest, destpri, cliprect, srcdat);
 
 						xcntdraw++;
 
@@ -125,11 +117,11 @@ void pgm_state::draw_sprite_line( int wide, uint16_t* dest, uint8_t* destpri, in
 						else
 							xdrawpos = xpos + realxsize - xcntdraw;
 
-						pgm_draw_pix(xdrawpos, pri, dest, destpri, srcdat);
+						pgm_draw_pix(xdrawpos, pri, dest, destpri, cliprect, srcdat);
 
 						xcntdraw++;
 					}
-					else if (xzoombit == 1 && xgrow == 0)
+					else if (xzoombit && (!xgrow))
 					{
 						/* skip this column */
 					}
@@ -140,7 +132,7 @@ void pgm_state::draw_sprite_line( int wide, uint16_t* dest, uint8_t* destpri, in
 						else
 							xdrawpos = xpos + realxsize - xcntdraw;
 
-						pgm_draw_pix(xdrawpos, pri, dest, destpri, srcdat);
+						pgm_draw_pix(xdrawpos, pri, dest, destpri, cliprect, srcdat);
 
 						xcntdraw++;
 					}
@@ -149,53 +141,44 @@ void pgm_state::draw_sprite_line( int wide, uint16_t* dest, uint8_t* destpri, in
 			}
 			else
 			{
-				xzoombit = (xzoom >> (xoffset & 0x1f)) & 1;
+				const bool xzoombit = BIT(xzoom, xoffset & 0x1f);
 				xoffset++;
-				if (xzoombit == 1 && xgrow == 1) { xcntdraw+=2; }
-				else if (xzoombit == 1 && xgrow == 0) { }
+				if (xzoombit && xgrow) { xcntdraw += 2; }
+				else if (xzoombit && (!xgrow)) { }
 				else { xcntdraw++; }
 			}
 
 			msk >>= 1;
-
-
 		}
 
 		m_boffset += 2;
 	}
 }
 
-void pgm_state::draw_sprite_new_zoomed( int wide, int high, int xpos, int ypos, int palt, int flip, bitmap_ind16 &bitmap, bitmap_ind8 &priority_bitmap, uint32_t xzoom, int xgrow, uint32_t yzoom, int ygrow, int pri )
+void pgm_state::draw_sprite_new_zoomed(int wide, int high, int xpos, int ypos, int palt, int flip, bitmap_ind16 &bitmap, const rectangle &cliprect, bitmap_ind8 &priority_bitmap, u32 xzoom, bool xgrow, u32 yzoom, bool ygrow, int pri)
 {
-	int ycnt;
 	int ydrawpos;
-	uint16_t *dest;
-	uint8_t* destpri;
-	int ycntdraw;
-	int yzoombit;
-	int xzoombit;
 	int xcnt = 0;
-
 
 	m_aoffset = (m_bdata[(m_boffset + 3) & m_bdata.mask()] << 24) | (m_bdata[(m_boffset + 2) & m_bdata.mask()] << 16) |
 				(m_bdata[(m_boffset + 1) & m_bdata.mask()] << 8) | (m_bdata[(m_boffset + 0) & m_bdata.mask()] << 0);
 	m_aoffset = m_aoffset >> 2; m_aoffset *= 3;
 
-	m_boffset+=4;
+	m_boffset += 4;
 
 	/* precalculate where drawing will end, for flipped zoomed cases. */
 	/* if we're to avoid pre-decoding the data for each sprite each time we draw then we have to draw the sprite data
 	   in the order it is in ROM due to the nature of the compresson scheme.  This means drawing upwards from the end point
 	   in the case of flipped sprites */
-	ycnt = 0;
-	ycntdraw = 0;
+	int ycnt = 0;
+	int ycntdraw = 0;
 	int realysize = 0;
 
 	while (ycnt < high)
 	{
-		yzoombit = (yzoom >> (ycnt & 0x1f)) & 1;
-		if (yzoombit == 1 && ygrow == 1) { realysize+=2; }
-		else if (yzoombit == 1 && ygrow == 0) { }
+		const bool yzoombit = BIT(yzoom, ycnt & 0x1f);
+		if (yzoombit && ygrow) { realysize += 2; }
+		else if (yzoombit && (!ygrow)) { }
 		else { realysize++; };
 
 		ycnt++;
@@ -206,15 +189,14 @@ void pgm_state::draw_sprite_new_zoomed( int wide, int high, int xpos, int ypos, 
 
 	while (xcnt < wide * 16)
 	{
-		xzoombit = (xzoom >> (xcnt & 0x1f)) & 1;
-		if (xzoombit == 1 && xgrow == 1) { realxsize+=2; }
-		else if (xzoombit == 1 && xgrow == 0) { }
+		const bool xzoombit = BIT(xzoom, xcnt & 0x1f);
+		if (xzoombit && xgrow) { realxsize += 2; }
+		else if (xzoombit && (!xgrow)) { }
 		else { realxsize++; };
 
 		xcnt++;
 	}
 	realxsize--;
-
 
 	/* now draw it */
 	ycnt = 0;
@@ -222,27 +204,27 @@ void pgm_state::draw_sprite_new_zoomed( int wide, int high, int xpos, int ypos, 
 
 	while (ycnt < high)
 	{
-		yzoombit = (yzoom >> (ycnt & 0x1f)) & 1;
+		const bool yzoombit = BIT(yzoom, ycnt & 0x1f);
 
-		if (yzoombit == 1 && ygrow == 1) // double this line
+		if (yzoombit && ygrow) // double this line
 		{
-			int temp_aoffset = m_aoffset;
-			int temp_boffset = m_boffset;
+			const int temp_aoffset = m_aoffset;
+			const int temp_boffset = m_boffset;
 
 			if (!(flip & 0x02))
 				ydrawpos = ypos + ycntdraw;
 			else
 				ydrawpos = ypos + realysize - ycntdraw;
 
-			if ((ydrawpos >= 0) && (ydrawpos < 224))
+			if ((ydrawpos >= cliprect.min_y) && (ydrawpos <= cliprect.max_y))
 			{
-				dest = &bitmap.pix16(ydrawpos);
-				destpri = &priority_bitmap.pix8(ydrawpos);
-				draw_sprite_line(wide, dest, destpri, xzoom, xgrow, flip, xpos, pri, realxsize, palt, 1);
+				u16 *dest = &bitmap.pix16(ydrawpos);
+				u8 *destpri = &priority_bitmap.pix8(ydrawpos);
+				draw_sprite_line(wide, dest, destpri, cliprect, xzoom, xgrow, flip, xpos, pri, realxsize, palt, true);
 			}
 			else
 			{
-				draw_sprite_line(wide, nullptr, nullptr, xzoom, xgrow, flip, xpos, pri, realxsize, palt, 0);
+				draw_sprite_line(wide, nullptr, nullptr, cliprect, xzoom, xgrow, flip, xpos, pri, realxsize, palt, false);
 			}
 
 			ycntdraw++;
@@ -256,24 +238,24 @@ void pgm_state::draw_sprite_new_zoomed( int wide, int high, int xpos, int ypos, 
 			else
 				ydrawpos = ypos + realysize - ycntdraw;
 
-			if ((ydrawpos >= 0) && (ydrawpos < 224))
+			if ((ydrawpos >= cliprect.min_y) && (ydrawpos <= cliprect.max_y))
 			{
-				dest = &bitmap.pix16(ydrawpos);
-				destpri = &priority_bitmap.pix8(ydrawpos);
-				draw_sprite_line(wide, dest, destpri, xzoom, xgrow, flip, xpos, pri, realxsize, palt, 1);
+				u16 *dest = &bitmap.pix16(ydrawpos);
+				u8 *destpri = &priority_bitmap.pix8(ydrawpos);
+				draw_sprite_line(wide, dest, destpri, cliprect, xzoom, xgrow, flip, xpos, pri, realxsize, palt, true);
 			}
 			else
 			{
-				draw_sprite_line(wide, nullptr, nullptr, xzoom, xgrow, flip, xpos, pri, realxsize, palt, 0);
+				draw_sprite_line(wide, nullptr, nullptr, cliprect, xzoom, xgrow, flip, xpos, pri, realxsize, palt, false);
 
 				if (!(flip & 0x02))
 				{
-					if (ydrawpos>224)
+					if (ydrawpos >= cliprect.max_y)
 						return;
 				}
 				else
 				{
-					if (ydrawpos<0)
+					if (ydrawpos < cliprect.min_y)
 						return;
 				}
 			}
@@ -281,10 +263,10 @@ void pgm_state::draw_sprite_new_zoomed( int wide, int high, int xpos, int ypos, 
 			ycntdraw++;
 
 		}
-		else if (yzoombit == 1 && ygrow == 0)
+		else if (yzoombit && (!ygrow))
 		{
 			/* skip this line */
-			draw_sprite_line(wide, nullptr, nullptr, xzoom, xgrow, flip, xpos, pri, realxsize, palt, 0);
+			draw_sprite_line(wide, nullptr, nullptr, cliprect, xzoom, xgrow, flip, xpos, pri, realxsize, palt, false);
 		}
 		else /* normal line */
 		{
@@ -293,24 +275,24 @@ void pgm_state::draw_sprite_new_zoomed( int wide, int high, int xpos, int ypos, 
 			else
 				ydrawpos = ypos + realysize - ycntdraw;
 
-			if ((ydrawpos >= 0) && (ydrawpos < 224))
+			if ((ydrawpos >= cliprect.min_y) && (ydrawpos <= cliprect.max_y))
 			{
-				dest = &bitmap.pix16(ydrawpos);
-				destpri = &priority_bitmap.pix8(ydrawpos);
-				draw_sprite_line(wide, dest, destpri, xzoom, xgrow, flip, xpos, pri, realxsize, palt, 1);
+				u16 *dest = &bitmap.pix16(ydrawpos);
+				u8 *destpri = &priority_bitmap.pix8(ydrawpos);
+				draw_sprite_line(wide, dest, destpri, cliprect, xzoom, xgrow, flip, xpos, pri, realxsize, palt, true);
 			}
 			else
 			{
-				draw_sprite_line(wide, nullptr, nullptr, xzoom, xgrow, flip, xpos, pri, realxsize, palt, 0);
+				draw_sprite_line(wide, nullptr, nullptr, cliprect, xzoom, xgrow, flip, xpos, pri, realxsize, palt, false);
 
 				if (!(flip & 0x02))
 				{
-					if (ydrawpos>224)
+					if (ydrawpos >= cliprect.max_y)
 						return;
 				}
 				else
 				{
-					if (ydrawpos<0)
+					if (ydrawpos < cliprect.min_y)
 						return;
 				}
 
@@ -324,33 +306,26 @@ void pgm_state::draw_sprite_new_zoomed( int wide, int high, int xpos, int ypos, 
 }
 
 
-void pgm_state::draw_sprite_line_basic( int wide, uint16_t* dest, uint8_t* destpri, int flip, int xpos, int pri, int realxsize, int palt, int draw )
+void pgm_state::draw_sprite_line_basic(int wide, u16* dest, u8* destpri, const rectangle &cliprect, int flip, int xpos, int pri, int realxsize, int palt, bool draw)
 {
-	int xcnt,xcntdraw;
 	int xoffset = 0;
 	int xdrawpos = 0;
-	uint8_t *adata = m_sprite_a_region.get();
-	size_t  adatasize = m_sprite_a_region_size - 1;
+	u8 *adata = m_sprite_a_region.get();
+	size_t adatasize = m_sprite_a_region_size - 1;
 
-	uint16_t msk;
-	uint16_t srcdat;
-
-	xcnt = 0;
-	xcntdraw = 0;
+	int xcntdraw = 0;
 
 	if (!pri)
 	{
-		for (xcnt = 0 ; xcnt < wide ; xcnt++)
+		for (int xcnt = 0; xcnt < wide; xcnt++)
 		{
-			int x;
+			u16 msk = ((m_bdata[(m_boffset + 1) & m_bdata.mask()] << 8) |(m_bdata[(m_boffset + 0) & m_bdata.mask()] << 0));
 
-			msk = ((m_bdata[(m_boffset + 1) & m_bdata.mask()] << 8) |( m_bdata[(m_boffset + 0) & m_bdata.mask()] << 0));
-
-			for (x = 0; x < 16; x++)
+			for (int x = 0; x < 16; x++)
 			{
-				if (!(msk & 0x0001))
+				if (!(BIT(msk, 0)))
 				{
-					srcdat = adata[m_aoffset & adatasize] + palt * 32;
+					const u16 srcdat = adata[m_aoffset & adatasize] + palt * 32;
 					m_aoffset++;
 
 					if (draw)
@@ -362,7 +337,7 @@ void pgm_state::draw_sprite_line_basic( int wide, uint16_t* dest, uint8_t* destp
 						else
 							xdrawpos = xpos + realxsize - xcntdraw;
 
-						pgm_draw_pix_nopri(xdrawpos, dest, destpri, srcdat);
+						pgm_draw_pix_nopri(xdrawpos, dest, destpri, cliprect, srcdat);
 
 						xcntdraw++;
 					}
@@ -382,17 +357,15 @@ void pgm_state::draw_sprite_line_basic( int wide, uint16_t* dest, uint8_t* destp
 	}
 	else
 	{
-		for (xcnt = 0 ; xcnt < wide ; xcnt++)
+		for (int xcnt = 0; xcnt < wide; xcnt++)
 		{
-			int x;
+			u16 msk = ((m_bdata[(m_boffset + 1) & m_bdata.mask()] << 8) |(m_bdata[(m_boffset + 0) & m_bdata.mask()] << 0));
 
-			msk = ((m_bdata[(m_boffset + 1) & m_bdata.mask()] << 8) |( m_bdata[(m_boffset + 0) & m_bdata.mask()] << 0));
-
-			for (x = 0; x < 16; x++)
+			for (int x = 0; x < 16; x++)
 			{
-				if (!(msk & 0x0001))
+				if (!(BIT(msk, 0)))
 				{
-					srcdat = adata[m_aoffset & adatasize] + palt * 32;
+					const u16 srcdat = adata[m_aoffset & adatasize] + palt * 32;
 					m_aoffset++;
 
 					if (draw)
@@ -404,7 +377,7 @@ void pgm_state::draw_sprite_line_basic( int wide, uint16_t* dest, uint8_t* destp
 						else
 							xdrawpos = xpos + realxsize - xcntdraw;
 
-						pgm_draw_pix_pri(xdrawpos, dest, destpri, srcdat);
+						pgm_draw_pix_pri(xdrawpos, dest, destpri, cliprect, srcdat);
 
 						xcntdraw++;
 					}
@@ -429,26 +402,22 @@ void pgm_state::draw_sprite_line_basic( int wide, uint16_t* dest, uint8_t* destp
   simplified version for non-zoomed cases, a bit faster
 *************************************************************************/
 
-void pgm_state::draw_sprite_new_basic( int wide, int high, int xpos, int ypos, int palt, int flip, bitmap_ind16 &bitmap, bitmap_ind8 &priority_bitmap, int pri )
+void pgm_state::draw_sprite_new_basic(int wide, int high, int xpos, int ypos, int palt, int flip, bitmap_ind16 &bitmap, const rectangle &cliprect, bitmap_ind8 &priority_bitmap, int pri)
 {
-	int ycnt;
 	int ydrawpos;
-	uint16_t *dest;
-	uint8_t* destpri;
-	int ycntdraw;
 
 	m_aoffset = (m_bdata[(m_boffset + 3) & m_bdata.mask()] << 24) | (m_bdata[(m_boffset + 2) & m_bdata.mask()] << 16) |
 				(m_bdata[(m_boffset + 1) & m_bdata.mask()] << 8) | (m_bdata[(m_boffset + 0) & m_bdata.mask()] << 0);
 	m_aoffset = m_aoffset >> 2; m_aoffset *= 3;
 
-	m_boffset+=4;
+	m_boffset += 4;
 
-	int realysize = high-1;
-	int realxsize = (wide * 16)-1;
+	const int realysize = high - 1;
+	const int realxsize = (wide * 16) - 1;
 
 	/* now draw it */
-	ycnt = 0;
-	ycntdraw = 0;
+	int ycnt = 0;
+	int ycntdraw = 0;
 
 	while (ycnt < high)
 	{
@@ -457,24 +426,24 @@ void pgm_state::draw_sprite_new_basic( int wide, int high, int xpos, int ypos, i
 		else
 			ydrawpos = ypos + realysize - ycntdraw;
 
-		if ((ydrawpos >= 0) && (ydrawpos < 224))
+		if ((ydrawpos >= cliprect.min_y) && (ydrawpos <= cliprect.max_y))
 		{
-			dest = &bitmap.pix16(ydrawpos);
-			destpri = &priority_bitmap.pix8(ydrawpos);
-			draw_sprite_line_basic(wide, dest, destpri, flip, xpos, pri, realxsize, palt, 1);
+			u16 *dest = &bitmap.pix16(ydrawpos);
+			u8 *destpri = &priority_bitmap.pix8(ydrawpos);
+			draw_sprite_line_basic(wide, dest, destpri, cliprect, flip, xpos, pri, realxsize, palt, true);
 		}
 		else
 		{
-			draw_sprite_line_basic(wide, nullptr, nullptr, flip, xpos, pri, realxsize, palt, 0);
+			draw_sprite_line_basic(wide, nullptr, nullptr, cliprect, flip, xpos, pri, realxsize, palt, false);
 
 			if (!(flip & 0x02))
 			{
-				if (ydrawpos>224)
+				if (ydrawpos >= cliprect.max_y)
 					return;
 			}
 			else
 			{
-				if (ydrawpos<0)
+				if (ydrawpos < cliprect.min_y)
 					return;
 			}
 		}
@@ -485,7 +454,7 @@ void pgm_state::draw_sprite_new_basic( int wide, int high, int xpos, int ypos, i
 }
 
 
-void pgm_state::draw_sprites( bitmap_ind16& spritebitmap, uint16_t *sprite_source, bitmap_ind8& priority_bitmap )
+void pgm_state::draw_sprites(bitmap_ind16& spritebitmap, const rectangle &cliprect, u16 *sprite_source, bitmap_ind8& priority_bitmap)
 {
 	/* ZZZZ Zxxx xxxx xxxx
 	   zzzz z-yy yyyy yyyy
@@ -494,35 +463,33 @@ void pgm_state::draw_sprites( bitmap_ind16& spritebitmap, uint16_t *sprite_sourc
 	   wwww wwwh hhhh hhhh
 	*/
 
-	const uint16_t *finish = m_spritebufferram.get() + (0xa00 / 2);
+	const u16 *finish = m_spritebufferram.get() + (0xa00 / 2);
 
-	uint16_t* start = sprite_source;
+	u16* start = sprite_source;
 
 	while (sprite_source < finish)
 	{
 		if (!sprite_source[4]) break; /* is this right? */
 		sprite_source += 5;
 	}
-	sprite_source-=5;
+	sprite_source -= 5;
 
 	while (sprite_source >= start)
 	{
-		int xpos = sprite_source[0] & 0x07ff;
-		int ypos = sprite_source[1] & 0x03ff;
-		int xzom = (sprite_source[0] & 0x7800) >> 11;
-		int xgrow = (sprite_source[0] & 0x8000) >> 15;
-		int yzom = (sprite_source[1] & 0x7800) >> 11;
-		int ygrow = (sprite_source[1] & 0x8000) >> 15;
-		int palt = (sprite_source[2] & 0x1f00) >> 8;
-		int flip = (sprite_source[2] & 0x6000) >> 13;
-		int boff = ((sprite_source[2] & 0x007f) << 16) | (sprite_source[3] & 0xffff);
-		int wide = (sprite_source[4] & 0x7e00) >> 9;
-		int high = sprite_source[4] & 0x01ff;
-		int pri = (sprite_source[2] & 0x0080) >>  7;
+		int xpos =          sprite_source[0] & 0x07ff;
+		int ypos =          sprite_source[1] & 0x03ff;
+		int xzom =         (sprite_source[0] & 0x7800) >> 11;
+		const bool xgrow = (sprite_source[0] & 0x8000) >> 15;
+		int yzom =         (sprite_source[1] & 0x7800) >> 11;
+		const bool ygrow = (sprite_source[1] & 0x8000) >> 15;
+		const int palt =   (sprite_source[2] & 0x1f00) >> 8;
+		const int flip =   (sprite_source[2] & 0x6000) >> 13;
+		int boff =        ((sprite_source[2] & 0x007f) << 16) | (sprite_source[3] & 0xffff);
+		const int wide =   (sprite_source[4] & 0x7e00) >> 9;
+		const int high =    sprite_source[4] & 0x01ff;
+		const int pri =    (sprite_source[2] & 0x0080) >>  7;
 
-		uint32_t xzoom, yzoom;
-
-		uint16_t* sprite_zoomtable = &m_videoregs[0x1000 / 2];
+		const u16* sprite_zoomtable = &m_videoregs[0x1000 / 2];
 
 		if (xgrow)
 		{
@@ -536,31 +503,31 @@ void pgm_state::draw_sprites( bitmap_ind16& spritebitmap, uint16_t *sprite_sourc
 			yzom = 0x10 - yzom;
 		}
 
-		xzoom = (sprite_zoomtable[xzom * 2] << 16) | sprite_zoomtable[xzom * 2 + 1];
-		yzoom = (sprite_zoomtable[yzom * 2] << 16) | sprite_zoomtable[yzom * 2 + 1];
+		u32 xzoom = (sprite_zoomtable[xzom * 2] << 16) | sprite_zoomtable[xzom * 2 + 1];
+		u32 yzoom = (sprite_zoomtable[yzom * 2] << 16) | sprite_zoomtable[yzom * 2 + 1];
 
 		boff *= 2;
-		if (xpos > 0x3ff) xpos -=0x800;
-		if (ypos > 0x1ff) ypos -=0x400;
+		if (xpos > 0x3ff) xpos -= 0x800;
+		if (ypos > 0x1ff) ypos -= 0x400;
 
 		//if ((priority == 1) && (pri == 0)) break;
 
 		m_boffset = boff;
-		if ((!xzoom) && (!yzoom)) draw_sprite_new_basic(wide, high, xpos, ypos, palt, flip, spritebitmap, priority_bitmap, pri );
-		else draw_sprite_new_zoomed(wide, high, xpos, ypos, palt, flip, spritebitmap, priority_bitmap, xzoom, xgrow, yzoom, ygrow, pri );
+		if ((!xzoom) && (!yzoom)) draw_sprite_new_basic(wide, high, xpos, ypos, palt, flip, spritebitmap, cliprect, priority_bitmap, pri);
+		else draw_sprite_new_zoomed(wide, high, xpos, ypos, palt, flip, spritebitmap, cliprect, priority_bitmap, xzoom, xgrow, yzoom, ygrow, pri);
 
 		sprite_source -= 5;
 	}
 }
 
 /* TX Layer */
-WRITE16_MEMBER(pgm_state::pgm_tx_videoram_w)
+void pgm_state::tx_videoram_w(offs_t offset, u16 data, u16 mem_mask)
 {
 	m_tx_videoram[offset] = data;
 	m_tx_tilemap->mark_tile_dirty(offset / 2);
 }
 
-TILE_GET_INFO_MEMBER(pgm_state::get_pgm_tx_tilemap_tile_info)
+TILE_GET_INFO_MEMBER(pgm_state::get_tx_tile_info)
 {
 /* 0x904000 - 0x90ffff is the Text Overlay Ram (pgm_tx_videoram)
     each tile uses 4 bytes, the tilemap is 64x128?
@@ -576,33 +543,28 @@ TILE_GET_INFO_MEMBER(pgm_state::get_pgm_tx_tilemap_tile_info)
     p = palette
     f = flip
 */
-	int tileno, colour, flipyx; //,game;
-
-	tileno = m_tx_videoram[tile_index * 2] & 0xffff;
-	colour = (m_tx_videoram[tile_index * 2 + 1] & 0x3e) >> 1;
-	flipyx = (m_tx_videoram[tile_index * 2 + 1] & 0xc0) >> 6;
+	const u32 tileno = m_tx_videoram[tile_index * 2] & 0xffff;
+	const u32 colour = (m_tx_videoram[tile_index * 2 + 1] & 0x3e) >> 1;
+	const u8  flipyx = (m_tx_videoram[tile_index * 2 + 1] & 0xc0) >> 6;
 
 	SET_TILE_INFO_MEMBER(0,tileno,colour,TILE_FLIPYX(flipyx));
 }
 
 /* BG Layer */
 
-WRITE16_MEMBER(pgm_state::pgm_bg_videoram_w)
+void pgm_state::bg_videoram_w(offs_t offset, u16 data, u16 mem_mask)
 {
 	m_bg_videoram[offset] = data;
 	m_bg_tilemap->mark_tile_dirty(offset / 2);
 }
 
-TILE_GET_INFO_MEMBER(pgm_state::get_pgm_bg_tilemap_tile_info)
+TILE_GET_INFO_MEMBER(pgm_state::get_bg_tile_info)
 {
 	/* pretty much the same as tx layer */
 
-	int tileno, colour, flipyx;
-
-	tileno = m_bg_videoram[tile_index *2] & 0xffff;
-
-	colour = (m_bg_videoram[tile_index * 2 + 1] & 0x3e) >> 1;
-	flipyx = (m_bg_videoram[tile_index * 2 + 1] & 0xc0) >> 6;
+	const u32 tileno = m_bg_videoram[tile_index *2] & 0xffff;
+	const u32 colour = (m_bg_videoram[tile_index * 2 + 1] & 0x3e) >> 1;
+	const u8  flipyx = (m_bg_videoram[tile_index * 2 + 1] & 0xc0) >> 6;
 
 	SET_TILE_INFO_MEMBER(1,tileno,colour,TILE_FLIPYX(flipyx));
 }
@@ -611,58 +573,47 @@ TILE_GET_INFO_MEMBER(pgm_state::get_pgm_bg_tilemap_tile_info)
 
 /*** Video - Start / Update ****************************************************/
 
-VIDEO_START_MEMBER(pgm_state,pgm)
+void pgm_state::video_start()
 {
-	int i;
-
 	m_aoffset = 0;
 	m_boffset = 0;
 
-	m_tx_tilemap = &machine().tilemap().create(*m_gfxdecode, tilemap_get_info_delegate(FUNC(pgm_state::get_pgm_tx_tilemap_tile_info),this), TILEMAP_SCAN_ROWS, 8, 8, 64, 32);
+	m_tx_tilemap = &machine().tilemap().create(*m_gfxdecode, tilemap_get_info_delegate(FUNC(pgm_state::get_tx_tile_info),this), TILEMAP_SCAN_ROWS, 8, 8, 64, 32);
 	m_tx_tilemap->set_transparent_pen(15);
 
-	m_bg_tilemap = &machine().tilemap().create(*m_gfxdecode, tilemap_get_info_delegate(FUNC(pgm_state::get_pgm_bg_tilemap_tile_info),this), TILEMAP_SCAN_ROWS, 32, 32, 64, 16);
+	m_bg_tilemap = &machine().tilemap().create(*m_gfxdecode, tilemap_get_info_delegate(FUNC(pgm_state::get_bg_tile_info),this), TILEMAP_SCAN_ROWS, 32, 32, 64, 16);
 	m_bg_tilemap->set_transparent_pen(31);
 	m_bg_tilemap->set_scroll_rows(16 * 32);
 
-	for (i = 0; i < 0x1200 / 2; i++)
-		m_palette->set_pen_color(i, rgb_t(0, 0, 0));
-
-	m_spritebufferram = make_unique_clear<uint16_t[]>(0xa00/2);
+	m_spritebufferram = make_unique_clear<u16[]>(0xa00/2);
 
 	save_pointer(NAME(m_spritebufferram), 0xa00/2);
 }
 
-uint32_t pgm_state::screen_update_pgm(screen_device &screen, bitmap_ind16 &bitmap, const rectangle &cliprect)
+u32 pgm_state::screen_update(screen_device &screen, bitmap_ind16 &bitmap, const rectangle &cliprect)
 {
-	int y;
-
 	bitmap.fill(0x3ff, cliprect); // ddp2 igs logo needs 0x3ff
 
 	screen.priority().fill(0, cliprect);
 
 	m_bg_tilemap->set_scrolly(0, m_videoregs[0x2000/2]);
 
-	for (y = 0; y < 224; y++)
+	for (int y = cliprect.min_y; y <= cliprect.max_y; y++)
 		m_bg_tilemap->set_scrollx((y + m_videoregs[0x2000 / 2]) & 0x1ff, m_videoregs[0x3000 / 2] + m_rowscrollram[y]);
-
 
 	m_bg_tilemap->draw(screen, bitmap, cliprect, 0, 2);
 
-	draw_sprites(bitmap, m_spritebufferram.get(), screen.priority());
+	draw_sprites(bitmap, cliprect, m_spritebufferram.get(), screen.priority());
 
 	m_tx_tilemap->set_scrolly(0, m_videoregs[0x5000/2]);
 	m_tx_tilemap->set_scrollx(0, m_videoregs[0x6000/2]); // Check
 
-
 	m_tx_tilemap->draw(screen, bitmap, cliprect, 0, 0);
 
-
 	return 0;
-
 }
 
-WRITE_LINE_MEMBER(pgm_state::screen_vblank_pgm)
+WRITE_LINE_MEMBER(pgm_state::screen_vblank)
 {
 	// rising edge
 	if (state)


### PR DESCRIPTION
Simplify handlers, Simplify gfxdecodes, Move non-public things into protected: and/or private:, Make sprite drawing routine related to cliprect, Fix tilemap region size for fit 5bpp tile correctly, Reduce unuseds, Unnecessary lines, MCFG_MACHINE_START, MCFG_MACHINE_RESET, MCFG_VIDEO_START overrides, Runtime tag lookups, Fix debugger issues, Fix namings, Spacings, Use shorter / correct type values, Fix notes
Move palette init function into machine_config