### PR TITLE
cave.cpp : Updates

### DIFF
--- a/src/mame/includes/cave.h
+++ b/src/mame/includes/cave.h
@@ -27,7 +27,9 @@ public:
 		, m_vram(*this, "vram.%u", 0)
 		, m_vctrl(*this, "vctrl.%u", 0)
 		, m_spriteram(*this, "spriteram.%u", 0)
-		, m_paletteram(*this, "paletteram.%u", 0)
+		, m_io_in0(*this, "IN0")
+		, m_touch_x(*this, "TOUCH%u_X", 1U)
+		, m_touch_y(*this, "TOUCH%u_Y", 1U)
 		, m_spriteregion(*this, "sprites%u", 0)
 		, m_tileregion(*this, "layer%u", 0)
 		, m_okiregion(*this, "oki%u", 1)
@@ -42,9 +44,9 @@ public:
 		, m_int_timer_left(*this, "int_timer_left")
 		, m_int_timer_right(*this, "int_timer_right")
 		, m_eeprom(*this, "eeprom")
-		, m_gfxdecode(*this, "gfxdecode")
-		, m_screen(*this, "screen")
-		, m_palette(*this, "palette")
+		, m_gfxdecode(*this, "gfxdecode.%u", 0U)
+		, m_screen(*this, "screen.%u", 0U)
+		, m_palette(*this, "palette.%u", 0U)
 		, m_soundlatch(*this, "soundlatch")
 		, m_startup(*this, "startup")
 		, m_led_outputs(*this, "led%u", 0U)
@@ -105,46 +107,47 @@ private:
 
 	u16 irq_cause_r(offs_t offset);
 	u8 soundflags_r();
-	DECLARE_READ16_MEMBER(soundflags_ack_r);
-	DECLARE_WRITE16_MEMBER(sound_cmd_w);
-	DECLARE_READ8_MEMBER(soundlatch_lo_r);
-	DECLARE_READ8_MEMBER(soundlatch_hi_r);
-	DECLARE_READ16_MEMBER(soundlatch_ack_r);
-	DECLARE_WRITE8_MEMBER(soundlatch_ack_w);
+	u16 soundflags_ack_r();
+	void sound_cmd_w(u16 data);
+	u8 soundlatch_lo_r();
+	u8 soundlatch_hi_r();
+	u16 soundlatch_ack_r();
+	void soundlatch_ack_w(u8 data);
 	void gaia_coin_w(u8 data);
-	DECLARE_READ16_MEMBER(donpachi_videoregs_r);
-	DECLARE_WRITE16_MEMBER(korokoro_leds_w);
-	template<int Chip> DECLARE_WRITE16_MEMBER(pwrinst2_vctrl_w);
-	DECLARE_READ16_MEMBER(sailormn_input0_r);
+	u16 donpachi_videoregs_r(offs_t offset);
+	void korokoro_leds_w(offs_t offset, u16 data, u16 mem_mask);
+	template<int Chip> void pwrinst2_vctrl_w(offs_t offset, u16 data, u16 mem_mask);
+	u16 sailormn_input0_r();
 	void tjumpman_leds_w(u8 data);
 	void pacslot_leds_w(u8 data);
 	template<int Mask> void z80_rombank_w(u8 data);
 	template<int Mask> void oki1_bank_w(u8 data);
 	template<int Mask> void oki2_bank_w(u8 data);
-	template<int Chip> DECLARE_WRITE16_MEMBER(vram_w);
-	template<int Chip> DECLARE_WRITE16_MEMBER(vram_8x8_w);
+	template<int Chip> void vram_w(offs_t offset, u16 data, u16 mem_mask);
+	template<int Chip> void vram_8x8_w(offs_t offset, u16 data, u16 mem_mask);
 	void eeprom_w(u8 data);
 	void sailormn_eeprom_w(u8 data);
 	void hotdogst_eeprom_w(u8 data);
 	void guwange_eeprom_w(u8 data);
 	void metmqstr_eeprom_w(u8 data);
-	void korokoro_eeprom_w(offs_t offset, uint16_t data, uint16_t mem_mask);
-	DECLARE_READ16_MEMBER(pwrinst2_eeprom_r);
+	void korokoro_eeprom_w(offs_t offset, u16 data, u16 mem_mask);
+	u16 pwrinst2_eeprom_r();
 	void tjumpman_eeprom_w(u8 data);
-	void ppsatan_eeprom_w(offs_t offset, uint16_t data, uint16_t mem_mask);
-	DECLARE_WRITE16_MEMBER(ppsatan_io_mux_w);
-	DECLARE_READ16_MEMBER(ppsatan_touch1_r);
-	DECLARE_READ16_MEMBER(ppsatan_touch2_r);
-	DECLARE_WRITE16_MEMBER(ppsatan_out_w);
-	uint16_t ppsatan_touch_r(int player);
+	void ppsatan_eeprom_w(offs_t offset, u16 data, u16 mem_mask);
+	void ppsatan_io_mux_w(offs_t offset, u16 data, u16 mem_mask);
+	template<int Player> u16 ppsatan_touch_r();
+	void ppsatan_out_w(offs_t offset, u16 data, u16 mem_mask);
 	TILE_GET_INFO_MEMBER(sailormn_get_tile_info_2);
-	template<int Chip> TILE_GET_INFO_MEMBER(get_tile_info);
+	template<int Chip, int Gfx> TILE_GET_INFO_MEMBER(get_tile_info);
 	DECLARE_MACHINE_RESET(sailormn);
-	DECLARE_VIDEO_START(cave_1_layer);
-	DECLARE_VIDEO_START(cave_2_layers);
-	DECLARE_VIDEO_START(cave_3_layers);
-	DECLARE_VIDEO_START(cave_4_layers);
-	DECLARE_VIDEO_START(sailormn_3_layers);
+	DECLARE_VIDEO_START(ddonpach);
+	DECLARE_VIDEO_START(dfeveron);
+	DECLARE_VIDEO_START(donpachi);
+	DECLARE_VIDEO_START(korokoro);
+	DECLARE_VIDEO_START(ppsatan);
+	DECLARE_VIDEO_START(pwrinst2);
+	DECLARE_VIDEO_START(sailormn);
+	DECLARE_VIDEO_START(uopoko);
 	void cave_palette(palette_device &palette);
 	void dfeveron_palette(palette_device &palette);
 	void korokoro_palette(palette_device &palette);
@@ -152,11 +155,11 @@ private:
 	void pwrinst2_palette(palette_device &palette);
 	void sailormn_palette(palette_device &palette);
 	void ppsatan_palette(palette_device &palette);
-	uint32_t screen_update(screen_device &screen, bitmap_rgb32 &bitmap, const rectangle &cliprect);
-	uint32_t screen_update_ppsatan_core (screen_device &screen, bitmap_rgb32 &bitmap, const rectangle &cliprect, int chip);
-	uint32_t screen_update_ppsatan_top  (screen_device &screen, bitmap_rgb32 &bitmap, const rectangle &cliprect);
-	uint32_t screen_update_ppsatan_left (screen_device &screen, bitmap_rgb32 &bitmap, const rectangle &cliprect);
-	uint32_t screen_update_ppsatan_right(screen_device &screen, bitmap_rgb32 &bitmap, const rectangle &cliprect);
+	u32 screen_update(screen_device &screen, bitmap_rgb32 &bitmap, const rectangle &cliprect);
+	u32 screen_update_ppsatan_core (screen_device &screen, bitmap_rgb32 &bitmap, const rectangle &cliprect, int chip);
+	u32 screen_update_ppsatan_top  (screen_device &screen, bitmap_rgb32 &bitmap, const rectangle &cliprect);
+	u32 screen_update_ppsatan_left (screen_device &screen, bitmap_rgb32 &bitmap, const rectangle &cliprect);
+	u32 screen_update_ppsatan_right(screen_device &screen, bitmap_rgb32 &bitmap, const rectangle &cliprect);
 	INTERRUPT_GEN_MEMBER(interrupt);
 	INTERRUPT_GEN_MEMBER(interrupt_ppsatan);
 	TIMER_CALLBACK_MEMBER(vblank_end);
@@ -178,11 +181,14 @@ private:
 	virtual void machine_reset() override;
 
 	/* memory pointers */
-	optional_shared_ptr_array<uint16_t, 4> m_videoregs;
-	optional_shared_ptr_array<uint16_t, 4> m_vram;
-	optional_shared_ptr_array<uint16_t, 4> m_vctrl;
-	optional_shared_ptr_array<uint16_t, 4> m_spriteram;
-	optional_shared_ptr_array<uint16_t, 4> m_paletteram;
+	optional_shared_ptr_array<u16, 4> m_videoregs;
+	optional_shared_ptr_array<u16, 4> m_vram;
+	optional_shared_ptr_array<u16, 4> m_vctrl;
+	optional_shared_ptr_array<u16, 4> m_spriteram;
+
+	optional_ioport m_io_in0;
+	optional_ioport_array<2> m_touch_x;
+	optional_ioport_array<2> m_touch_y;
 
 	/* memory regions */
 	optional_memory_region_array<4> m_spriteregion;
@@ -206,7 +212,7 @@ private:
 
 		int priority = 0, flags = 0;
 
-		const uint8_t *pen_data = nullptr;  /* points to top left corner of tile data */
+		const u8 *pen_data = nullptr;  /* points to top left corner of tile data */
 		int line_offset = 0;
 
 		pen_t base_pen = 0;
@@ -218,64 +224,64 @@ private:
 
 	struct
 	{
-		int    clip_left, clip_right, clip_top, clip_bottom;
-		uint8_t  *baseaddr;
-		int    line_offset;
-		uint8_t  *baseaddr_zbuf;
-		int    line_offset_zbuf;
+		int clip_left, clip_right, clip_top, clip_bottom;
+		u8  *baseaddr;
+		int line_offset;
+		u8  *baseaddr_zbuf;
+		int line_offset_zbuf;
 	} m_blit;
 
 	std::unique_ptr<sprite_cave []> m_sprite[4];
 	sprite_cave *m_sprite_table[4][MAX_PRIORITY][MAX_SPRITE_NUM + 1];
 
-	tilemap_t    *m_tilemap[4];
-	int          m_tiledim[4];
-	int          m_old_tiledim[4];
+	tilemap_t *m_tilemap[4];
+	bool      m_tiledim[4];
+	bool      m_old_tiledim[4];
 
-	bitmap_ind16 m_sprite_zbuf;
-	uint16_t     m_sprite_zbuf_baseval;
+	bitmap_ind16 m_sprite_zbuf[4];
+	u16       m_sprite_zbuf_baseval;
 
-	int          m_num_sprites[4];
+	int       m_num_sprites[4];
 
-	int          m_spriteram_bank[4];
-	int          m_spriteram_bank_delay[4];
+	int       m_spriteram_bank[4];
+	int       m_spriteram_bank_delay[4];
 
-	std::unique_ptr<uint16_t[]>      m_palette_map[4];
+	int       m_layers_offs_x;
+	int       m_layers_offs_y;
+	int       m_row_effect_offs_n;
+	int       m_row_effect_offs_f;
+	u16       m_background_pen[4];
 
-	int          m_layers_offs_x;
-	int          m_layers_offs_y;
-	int          m_row_effect_offs_n;
-	int          m_row_effect_offs_f;
-	int          m_background_pen;
-
-	int          m_spritetype[2];
-	int          m_kludge;
+	int       m_spritetype[2];
+	int       m_kludge;
 	emu_timer *m_vblank_end_timer;
 
+	u16       m_sprite_base_pal;
+	u16       m_sprite_granularity;
 
 	/* misc */
-	int          m_time_vblank_irq;
-	uint8_t      m_irq_level;
-	uint8_t      m_vblank_irq;
-	uint8_t      m_sound_irq;
-	uint8_t      m_unknown_irq;
-	uint8_t      m_agallet_vblank_irq;
+	int       m_time_vblank_irq;
+	u8        m_irq_level;
+	u8        m_vblank_irq;
+	u8        m_sound_irq;
+	u8        m_unknown_irq;
+	u8        m_agallet_vblank_irq;
 
 	/* sound related */
-	int          m_soundbuf_wptr;
-	int          m_soundbuf_rptr;
-	uint8_t      m_soundbuf_data[32];
-	bool         m_soundbuf_empty;
-	//uint8_t    m_sound_flag[2];
+	int       m_soundbuf_wptr;
+	int       m_soundbuf_rptr;
+	u8        m_soundbuf_data[32];
+	bool      m_soundbuf_empty;
+	//u8      m_sound_flag[2];
 
 	/* game specific */
 	// sailormn
-	int          m_sailormn_tilebank;
+	int       m_sailormn_tilebank;
 	// korokoro
-	uint16_t     m_leds[2];
-	int          m_hopper;
+	u16       m_leds[2];
+	int       m_hopper;
 	// ppsatan
-	uint16_t     m_ppsatan_io_mux;
+	u16       m_ppsatan_io_mux;
 
 	/* devices */
 	required_device<cpu_device> m_maincpu;
@@ -285,9 +291,9 @@ private:
 	optional_device<timer_device> m_int_timer_left;
 	optional_device<timer_device> m_int_timer_right;
 	optional_device<eeprom_serial_93cxx_device> m_eeprom;
-	required_device<gfxdecode_device> m_gfxdecode;
-	required_device<screen_device> m_screen;
-	required_device<palette_device> m_palette;
+	optional_device_array<gfxdecode_device, 4> m_gfxdecode;
+	optional_device_array<screen_device, 4> m_screen;
+	optional_device_array<palette_device, 4> m_palette;
 	optional_device<generic_latch_16_device> m_soundlatch;
 	optional_device<timer_device> m_startup;
 	output_finder<9> m_led_outputs;
@@ -295,21 +301,21 @@ private:
 	int m_rasflag;
 	int m_old_rasflag;
 
-	inline void tilemap_draw( int chip, screen_device &screen, bitmap_rgb32 &bitmap, const rectangle &cliprect, uint32_t flags, uint32_t priority, uint32_t priority2, int GFX );
+	inline void tilemap_draw(int chip, screen_device &screen, bitmap_rgb32 &bitmap, const rectangle &cliprect, u32 flags, u32 priority, u32 priority2, int GFX);
 	void set_pens(int chip);
-	void vh_start( int num );
+	void vh_start(int num, u16 sprcol_base, u16 sprcol_granularity);
 	void get_sprite_info_cave(int chip);
 	void get_sprite_info_donpachi(int chip);
-	void sprite_init();
+	void sprite_init(int chip);
 	void sprite_check(int chip, screen_device &screen, const rectangle &clip);
-	void do_blit_zoom32( int chip, const sprite_cave *sprite );
-	void do_blit_zoom32_zb( int chip, const sprite_cave *sprite );
-	void do_blit_32( int chip, const sprite_cave *sprite );
-	void do_blit_32_zb( int chip, const sprite_cave *sprite );
-	void sprite_draw_cave( int chip, int priority );
-	void sprite_draw_cave_zbuf( int chip, int priority );
-	void sprite_draw_donpachi( int chip, int priority );
-	void sprite_draw_donpachi_zbuf( int chip, int priority );
+	void do_blit_zoom32(int chip, const sprite_cave *sprite);
+	void do_blit_zoom32_zb(int chip, const sprite_cave *sprite);
+	void do_blit_32(int chip, const sprite_cave *sprite);
+	void do_blit_32_zb(int chip, const sprite_cave *sprite);
+	void sprite_draw_cave(int chip, int priority);
+	void sprite_draw_cave_zbuf(int chip, int priority);
+	void sprite_draw_donpachi(int chip, int priority);
+	void sprite_draw_donpachi_zbuf(int chip, int priority);
 	void init_cave();
 	void init_z80_bank();
 	void init_oki_bank(int chip);

--- a/src/mame/video/cave.cpp
+++ b/src/mame/video/cave.cpp
@@ -61,110 +61,6 @@ Note:   if MAME_DEBUG is defined, pressing:
 
 /***************************************************************************
 
-                            Palette Init Routines
-
-    Function needed for games with 4 bit sprites, rather than 8 bit,
-    or games with an odd colors mapping for the layers.
-
-***************************************************************************/
-
-void cave_state::cave_palette(palette_device &palette)
-{
-	for (int chip = 0; chip < 4; chip++)
-	{
-		// create a 1:1 palette map covering everything
-		m_palette_map[chip] = std::make_unique<uint16_t[]>(palette.entries());
-
-		int const maxpens = m_paletteram[chip].bytes() / 2;
-		if (maxpens)
-		{
-			for (int pen = 0; pen < palette.entries(); pen++)
-				m_palette_map[chip][pen] = pen % maxpens;
-		}
-	}
-}
-
-void cave_state::dfeveron_palette(palette_device &palette)
-{
-	/* Fill the 0-3fff range, used by sprites ($40 color codes * $100 pens)
-	   Here sprites have 16 pens, but the sprite drawing routine always
-	   multiplies the color code by $100 (for consistency).
-	   That's why we need this function.    */
-
-	cave_palette(palette);
-
-	for (int color = 0; color < 0x40; color++)
-		for (int pen = 0; pen < 0x10; pen++)
-			m_palette_map[0][(color << 8) | pen] = (color << 4) | pen;
-}
-
-void cave_state::mazinger_palette(palette_device &palette)
-{
-	cave_palette(palette);
-
-	// sprites (encrypted) are 4 bit deep
-	for (int color = 0; color < 0x40; color++)
-		for (int pen = 0; pen < 0x100; pen++)
-			m_palette_map[0][(color << 8) | pen] = (color << 4) + pen; // yes, PLUS, not OR
-
-	// layer 0 is 6 bit deep, there are 64 color codes but only $400 colors are actually addressable
-	for (int color = 0; color < 0x40; color++)
-		for (int pen = 0; pen < 0x40; pen++)
-			m_palette_map[0][0x4400 + ((color << 6) | pen)] = 0x400 | ((color & 0x0f) << 6) | pen;
-}
-
-void cave_state::sailormn_palette(palette_device &palette)
-{
-	cave_palette(palette);
-
-	// sprites (encrypted) are 4 bit deep
-	for (int color = 0; color < 0x40; color++)
-		for (int pen = 0; pen < 0x100; pen++)
-			m_palette_map[0][(color << 8) | pen] = (color << 4) + pen; // yes, PLUS, not OR
-
-	// layer 2 is 6 bit deep, there are 64 color codes but only $400 colors are actually addressable
-	for (int color = 0; color < 0x40; color++)
-		for (int pen = 0; pen < 0x40; pen++)
-			m_palette_map[0][0x4c00 + ((color << 6) | pen)] = 0xc00 | ((color & 0x0f) << 6) | pen;
-}
-
-void cave_state::pwrinst2_palette(palette_device &palette)
-{
-	cave_palette(palette);
-
-	for (int color = 0; color < 0x80; color++)
-		for (int pen = 0; pen < 0x10; pen++)
-			m_palette_map[0][(color << 8) | pen] = (color << 4) | pen;
-
-	for (int pen = 0x8000; pen < 0xa800; pen++)
-		m_palette_map[0][pen] = pen - 0x8000;
-}
-
-void cave_state::korokoro_palette(palette_device &palette)
-{
-	cave_palette(palette);
-
-	for (int color = 0; color < 0x40; color++)
-		for (int pen = 0; pen < 0x10; pen++)
-			m_palette_map[0][(color << 8) | pen] = 0x3c00 | (color << 4) | pen;
-}
-
-
-void cave_state::set_pens(int chip)
-{
-	for (int pen = 0; pen < m_palette->entries(); pen++)
-	{
-		uint16_t const data = m_paletteram[chip][m_palette_map[chip][pen]];
-
-		rgb_t const color(pal5bit(data >> 5), pal5bit(data >> 10), pal5bit(data >> 0));
-
-		m_palette->set_pen_color(pen, color);
-	}
-}
-
-
-/***************************************************************************
-
                                   Tiles Format
 
     Offset:     Bits:                   Value:
@@ -186,12 +82,12 @@ void cave_state::set_pens(int chip)
 
 ***************************************************************************/
 
-template<int Chip>
+template<int Chip, int Gfx>
 TILE_GET_INFO_MEMBER(cave_state::get_tile_info)
 {
-	uint16_t *VRAM = m_vram[Chip];
-	int TDIM = m_tiledim[Chip];
-	uint32_t code, color, pri, tile;
+	u16 *VRAM = m_vram[Chip];
+	const bool TDIM = m_tiledim[Chip];
+	u32 code, color, pri, tile;
 
 	if (TDIM)
 	{
@@ -214,7 +110,7 @@ TILE_GET_INFO_MEMBER(cave_state::get_tile_info)
 		code  = (code & 0x00ffffff);
 	}
 
-	SET_TILE_INFO_MEMBER(Chip, code, color, 0 );
+	SET_TILE_INFO_MEMBER(Gfx, code, color, 0);
 	tileinfo.category = pri;
 }
 
@@ -232,11 +128,11 @@ void cave_state::sailormn_tilebank_w(int bank)
 
 TILE_GET_INFO_MEMBER(cave_state::sailormn_get_tile_info_2)
 {
-	uint32_t code, color, pri;
+	u32 code, color, pri;
 
 	if (m_tiledim[2])
 	{
-		uint32_t tile;
+		u32 tile;
 		tile  = (tile_index % (512 / 8)) / 2 + ((tile_index / (512 / 8)) / 2) * (512 / 16);
 		code  = (m_vram[2][tile * 2 + 0x0000 / 2] << 16) + m_vram[2][tile * 2 + 0x0002 / 2];
 
@@ -258,7 +154,7 @@ TILE_GET_INFO_MEMBER(cave_state::sailormn_get_tile_info_2)
 			code += 0x40000;
 	}
 
-	SET_TILE_INFO_MEMBER(2, code, color, 0 );
+	SET_TILE_INFO_MEMBER(2, code, color, 0);
 	tileinfo.category = pri;
 }
 
@@ -272,31 +168,32 @@ TILE_GET_INFO_MEMBER(cave_state::sailormn_get_tile_info_2)
 
 ***************************************************************************/
 
-void cave_state::vh_start( int num )
+void cave_state::vh_start(int num, u16 sprcol_base, u16 sprcol_granularity)
 {
-	assert(m_palette_map != nullptr);
+	m_sprite_base_pal = sprcol_base;
+	m_sprite_granularity = sprcol_granularity;
 
 	m_tilemap[0] = nullptr;
 	m_tilemap[1] = nullptr;
 	m_tilemap[2] = nullptr;
 	m_tilemap[3] = nullptr;
 
-	m_tiledim[0] = 0;
-	m_tiledim[1] = 0;
-	m_tiledim[2] = 0;
-	m_tiledim[3] = 0;
+	m_tiledim[0] = false;
+	m_tiledim[1] = false;
+	m_tiledim[2] = false;
+	m_tiledim[3] = false;
 
-	m_old_tiledim[0] = 0;
-	m_old_tiledim[1] = 0;
-	m_old_tiledim[2] = 0;
-	m_old_tiledim[3] = 0;
+	m_old_tiledim[0] = false;
+	m_old_tiledim[1] = false;
+	m_old_tiledim[2] = false;
+	m_old_tiledim[3] = false;
 
 	assert((num >= 1) && (num <= 4));
 
 	switch (num)
 	{
 		case 4:
-			m_tilemap[3] = &machine().tilemap().create(*m_gfxdecode, tilemap_get_info_delegate(FUNC(cave_state::get_tile_info<3>),this), TILEMAP_SCAN_ROWS, 8, 8, 512 / 8, 512 / 8);
+			m_tilemap[3] = &machine().tilemap().create(*m_gfxdecode[0], tilemap_get_info_delegate(&cave_state::get_tile_info<3, 3>, "screen0_layer3",this), TILEMAP_SCAN_ROWS, 8, 8, 512 / 8, 512 / 8);
 			m_tilemap[3]->set_transparent_pen(0);
 			m_tilemap[3]->set_scroll_rows(1);
 			m_tilemap[3]->set_scroll_cols(1);
@@ -304,7 +201,7 @@ void cave_state::vh_start( int num )
 			save_item(NAME(m_old_tiledim[3]));
 
 		case 3:
-			m_tilemap[2] = &machine().tilemap().create(*m_gfxdecode, tilemap_get_info_delegate(FUNC(cave_state::get_tile_info<2>),this), TILEMAP_SCAN_ROWS, 8, 8, 512 / 8, 512 / 8);
+			m_tilemap[2] = &machine().tilemap().create(*m_gfxdecode[0], tilemap_get_info_delegate(&cave_state::get_tile_info<2, 2>, "screen0_layer2",this), TILEMAP_SCAN_ROWS, 8, 8, 512 / 8, 512 / 8);
 			m_tilemap[2]->set_transparent_pen(0);
 			m_tilemap[2]->set_scroll_rows(1);
 			m_tilemap[2]->set_scroll_cols(1);
@@ -312,7 +209,7 @@ void cave_state::vh_start( int num )
 			save_item(NAME(m_old_tiledim[2]));
 
 		case 2:
-			m_tilemap[1] = &machine().tilemap().create(*m_gfxdecode, tilemap_get_info_delegate(FUNC(cave_state::get_tile_info<1>),this), TILEMAP_SCAN_ROWS, 8, 8, 512 / 8, 512 / 8);
+			m_tilemap[1] = &machine().tilemap().create(*m_gfxdecode[0], tilemap_get_info_delegate(&cave_state::get_tile_info<1, 1>, "screen0_layer1",this), TILEMAP_SCAN_ROWS, 8, 8, 512 / 8, 512 / 8);
 			m_tilemap[1]->set_transparent_pen(0);
 			m_tilemap[1]->set_scroll_rows(1);
 			m_tilemap[1]->set_scroll_cols(1);
@@ -320,7 +217,7 @@ void cave_state::vh_start( int num )
 			save_item(NAME(m_old_tiledim[1]));
 
 		case 1:
-			m_tilemap[0] = &machine().tilemap().create(*m_gfxdecode, tilemap_get_info_delegate(FUNC(cave_state::get_tile_info<0>),this), TILEMAP_SCAN_ROWS, 8, 8, 512 / 8, 512 / 8);
+			m_tilemap[0] = &machine().tilemap().create(*m_gfxdecode[0], tilemap_get_info_delegate(&cave_state::get_tile_info<0, 0>, "screen0_layer0",this), TILEMAP_SCAN_ROWS, 8, 8, 512 / 8, 512 / 8);
 			m_tilemap[0]->set_transparent_pen(0);
 			m_tilemap[0]->set_scroll_rows(1);
 			m_tilemap[0]->set_scroll_cols(1);
@@ -330,7 +227,7 @@ void cave_state::vh_start( int num )
 			break;
 	}
 
-	sprite_init();
+	sprite_init(0);
 
 	m_layers_offs_x = 0x13;
 	m_layers_offs_y = -0x12;
@@ -338,9 +235,9 @@ void cave_state::vh_start( int num )
 	m_row_effect_offs_n = -1;
 	m_row_effect_offs_f = 1;
 
-	m_background_pen    =  m_gfxdecode->gfx(0)->colorbase() +
-							(m_gfxdecode->gfx(0)->colors() - 1) *
-							m_gfxdecode->gfx(0)->granularity();
+	m_background_pen[0] = m_gfxdecode[0]->gfx(0)->colorbase() +
+							(m_gfxdecode[0]->gfx(0)->colors() - 1) *
+							m_gfxdecode[0]->gfx(0)->granularity();
 
 	switch (m_kludge)
 	{
@@ -349,31 +246,98 @@ void cave_state::vh_start( int num )
 			m_row_effect_offs_f = -1;
 			break;
 		case 2: /* uopoko dfeveron */
-			m_background_pen = 0x3f00;
+			m_background_pen[0] = m_gfxdecode[0]->gfx(0)->colorbase() - m_gfxdecode[0]->gfx(0)->granularity();
 			break;
 		case 4: /* pwrinst2 */
-			m_background_pen = 0x7f00;
+			m_background_pen[0] = m_gfxdecode[0]->gfx(0)->colorbase() - m_gfxdecode[0]->gfx(0)->granularity();
 			m_layers_offs_y++;
 			break;
 	}
 }
 
-VIDEO_START_MEMBER(cave_state,cave_1_layer){    vh_start(1);    }
-VIDEO_START_MEMBER(cave_state,cave_2_layers){   vh_start(2);    }
-VIDEO_START_MEMBER(cave_state,cave_3_layers){   vh_start(3);    }
-VIDEO_START_MEMBER(cave_state,cave_4_layers){   vh_start(4);    }
-
-
-VIDEO_START_MEMBER(cave_state,sailormn_3_layers)
+// ddonpach esprade gaia guwange (8bpp tilemap)
+VIDEO_START_MEMBER(cave_state,ddonpach)
 {
-	vh_start(2);
+	vh_start(3, 0, 256);
+}
+
+// dfeveron mazinger
+VIDEO_START_MEMBER(cave_state,dfeveron)
+{
+	vh_start(2, 0, 16);
+}
+
+// donpachi hotdogst metmqstr
+VIDEO_START_MEMBER(cave_state,donpachi)
+{
+	vh_start(3, 0, 16);
+}
+
+// korokoro (different sprite base palette)
+VIDEO_START_MEMBER(cave_state,korokoro)
+{
+	vh_start(1, 0x3c00, 16);
+}
+
+// ppsatan (3 screen)
+VIDEO_START_MEMBER(cave_state,ppsatan)
+{
+	vh_start(1, 0x3c00, 16);
+	m_tilemap[2] = &machine().tilemap().create(*m_gfxdecode[2], tilemap_get_info_delegate(&cave_state::get_tile_info<2, 0>, "screen2_layer0",this), TILEMAP_SCAN_ROWS, 8, 8, 512 / 8, 512 / 8);
+	m_tilemap[2]->set_transparent_pen(0);
+	m_tilemap[2]->set_scroll_rows(1);
+	m_tilemap[2]->set_scroll_cols(1);
+	save_item(NAME(m_tiledim[2]));
+	save_item(NAME(m_old_tiledim[2]));
+
+	m_tilemap[1] = &machine().tilemap().create(*m_gfxdecode[1], tilemap_get_info_delegate(&cave_state::get_tile_info<1, 0>, "screen1_layer0",this), TILEMAP_SCAN_ROWS, 8, 8, 512 / 8, 512 / 8);
+	m_tilemap[1]->set_transparent_pen(0);
+	m_tilemap[1]->set_scroll_rows(1);
+	m_tilemap[1]->set_scroll_cols(1);
+	save_item(NAME(m_tiledim[1]));
+	save_item(NAME(m_old_tiledim[1]));
+
+	for (int chip = 1; chip < 3; chip++)
+	{
+		m_background_pen[chip] = m_gfxdecode[chip]->gfx(0)->colorbase() +
+							(m_gfxdecode[chip]->gfx(0)->colors() - 1) *
+							m_gfxdecode[chip]->gfx(0)->granularity();
+
+		switch (m_kludge)
+		{
+			case 2: /* uopoko dfeveron */
+			case 4: /* pwrinst2 */
+				m_background_pen[chip] = m_gfxdecode[chip]->gfx(0)->colorbase() - m_gfxdecode[chip]->gfx(0)->granularity();
+				break;
+		}
+	}
+}
+
+// pwrinst2
+VIDEO_START_MEMBER(cave_state,pwrinst2)
+{
+	vh_start(4, 0, 16);
+}
+
+// sailormn agallet
+VIDEO_START_MEMBER(cave_state,sailormn)
+{
+	vh_start(2, 0, 16);
 
 	/* Layer 2 (8x8) needs to be handled differently */
-	m_tilemap[2] = &machine().tilemap().create(*m_gfxdecode, tilemap_get_info_delegate(FUNC(cave_state::sailormn_get_tile_info_2),this), TILEMAP_SCAN_ROWS, 8, 8, 512 / 8, 512 / 8 );
+	m_tilemap[2] = &machine().tilemap().create(*m_gfxdecode[0], tilemap_get_info_delegate(FUNC(cave_state::sailormn_get_tile_info_2),this), TILEMAP_SCAN_ROWS, 8, 8, 512 / 8, 512 / 8);
 
 	m_tilemap[2]->set_transparent_pen(0);
 	m_tilemap[2]->set_scroll_rows(1);
 	m_tilemap[2]->set_scroll_cols(1);
+	save_item(NAME(m_tiledim[2]));
+	save_item(NAME(m_old_tiledim[2]));
+}
+
+// uopoko tjumpman (8bpp tilemap, but single tilemap layer)
+VIDEO_START_MEMBER(cave_state,uopoko)
+{
+	vh_start(1, 0, 256);
 }
 
 /***************************************************************************
@@ -411,28 +375,23 @@ VIDEO_START_MEMBER(cave_state,sailormn_3_layers)
 void cave_state::get_sprite_info_cave(int chip)
 {
 	chip %= 4;
-	pen_t base_pal = 0;
-	const uint8_t *base_gfx = m_spriteregion[chip]->base();
-	int code_max = m_spriteregion[chip]->bytes() / (16*16);
+	const u8 *base_gfx = m_spriteregion[chip]->base();
+	const int code_max = m_spriteregion[chip]->bytes() / (16*16);
 
-	uint16_t *source;
-	uint16_t *finish;
 	sprite_cave *sprite = m_sprite[chip].get();
 
-	int glob_flipx = m_videoregs[chip][0] & 0x8000;
-	int glob_flipy = m_videoregs[chip][1] & 0x8000;
+	const int glob_flipx = m_videoregs[chip][0] & 0x8000;
+	const int glob_flipy = m_videoregs[chip][1] & 0x8000;
 
-	int max_x = m_screen->width();
-	int max_y = m_screen->height();
+	const int max_x = m_screen[chip]->width();
+	const int max_y = m_screen[chip]->height();
 
-	source = m_spriteram[chip] + (0x4000 / 2) * m_spriteram_bank[chip];
-
-	finish = source + (0x4000 / 2);
-
+	const u16 *source = m_spriteram[chip] + (0x4000 / 2) * m_spriteram_bank[chip];
+	const u16 *finish = source + (0x4000 / 2);
 
 	for (; source < finish; source += 8)
 	{
-		int x, y, attr, code, zoomx, zoomy, size, flipx, flipy;
+		int x, y;
 		int total_width_f, total_height_f;
 
 		if (m_spritetype[0] == 2)    /* Hot Dog Storm */
@@ -445,11 +404,11 @@ void cave_state::get_sprite_info_cave(int chip)
 			x = source[0] << 2;
 			y = source[1] << 2;
 		}
-		attr  = source[2];
-		code  = source[3] + ((attr & 3) << 16);
-		zoomx = source[4];
-		zoomy = source[5];
-		size  = source[6];
+		const u16 attr  = source[2];
+		u32 code        = source[3] + ((attr & 3) << 16);
+		int zoomx       = source[4];
+		int zoomy       = source[5];
+		const u16 size  = source[6];
 
 		sprite->tile_width  = ((size >> 8) & 0x1f) * 16;
 		sprite->tile_height = ((size >> 0) & 0x1f) * 16;
@@ -461,8 +420,8 @@ void cave_state::get_sprite_info_cave(int chip)
 		code %= code_max;
 		sprite->pen_data = base_gfx + (16 * 16) * code;
 
-		flipx = attr & 0x0008;
-		flipy = attr & 0x0004;
+		int flipx = attr & 0x0008;
+		int flipy = attr & 0x0004;
 
 		sprite->total_width  = (total_width_f  = sprite->tile_width  * zoomx) / 0x100;
 		sprite->total_height = (total_height_f = sprite->tile_height * zoomy) / 0x100;
@@ -511,13 +470,13 @@ void cave_state::get_sprite_info_cave(int chip)
 		if (x > 0x1ff)  x -= 0x400;
 		if (y > 0x1ff)  y -= 0x400;
 
-		if (x + sprite->total_width <= 0 || x >= max_x || y + sprite->total_height <= 0 || y >= max_y )
+		if (x + sprite->total_width <= 0 || x >= max_x || y + sprite->total_height <= 0 || y >= max_y)
 		{continue;}
 
 		sprite->priority    = (attr & 0x0030) >> 4;
 		sprite->flags       = SPRITE_VISIBLE_CAVE;
 		sprite->line_offset = sprite->tile_width;
-		sprite->base_pen    = base_pal + (attr & 0x3f00);   // first 0x4000 colors
+		sprite->base_pen    = m_sprite_base_pal + (((attr & 0x3f00) >> 8) * m_sprite_granularity);   // first 0x4000 colors
 
 		if (glob_flipx) { x = max_x - x - sprite->total_width;  flipx = !flipx; }
 		if (glob_flipy) { y = max_y - y - sprite->total_height; flipy = !flipy; }
@@ -536,39 +495,34 @@ void cave_state::get_sprite_info_cave(int chip)
 void cave_state::get_sprite_info_donpachi(int chip)
 {
 	chip %= 4;
-	pen_t base_pal = 0;
-	const uint8_t *base_gfx = m_spriteregion[chip]->base();
-	int code_max = m_spriteregion[chip]->bytes() / (16*16);
-
-	uint16_t *source;
-	uint16_t *finish;
+	const u8 *base_gfx = m_spriteregion[chip]->base();
+	const int code_max = m_spriteregion[chip]->bytes() / (16*16);
 
 	sprite_cave *sprite = m_sprite[chip].get();
 
-	int glob_flipx = m_videoregs[chip][0] & 0x8000;
-	int glob_flipy = m_videoregs[chip][1] & 0x8000;
+	const int glob_flipx = m_videoregs[chip][0] & 0x8000;
+	const int glob_flipy = m_videoregs[chip][1] & 0x8000;
 
-	int max_x = m_screen->width();
-	int max_y = m_screen->height();
+	const int max_x = m_screen[chip]->width();
+	const int max_y = m_screen[chip]->height();
 
-	source = m_spriteram[chip] + (0x4000 / 2) * m_spriteram_bank[chip];
-
-	finish = source + (0x4000 / 2);
+	const u16 *source = m_spriteram[chip] + (0x4000 / 2) * m_spriteram_bank[chip];
+	const u16 *finish = source + (0x4000 / 2);
 
 	for (; source < finish; source += 8)
 	{
-		int x, y, attr, code, size, flipx, flipy;
+		int y;
 
-		attr = source[0];
-		code = source[1] + ((attr & 3) << 16);
-		x    = source[2] & 0x3ff;
+		const u16 attr = source[0];
+		u32 code       = source[1] + ((attr & 3) << 16);
+		int x          = source[2] & 0x3ff;
 
 		if (m_spritetype[0] == 3)    /* pwrinst2 */
 			y = (source[3] + 1) & 0x3ff;
 		else
 			y = source[3] & 0x3ff;
 
-		size = source[4];
+		const u16 size = source[4];
 
 		sprite->tile_width  = sprite->total_width  = ((size >> 8) & 0x1f) * 16;
 		sprite->tile_height = sprite->total_height = ((size >> 0) & 0x1f) * 16;
@@ -581,21 +535,21 @@ void cave_state::get_sprite_info_donpachi(int chip)
 		if (y > 0x1ff)  y -= 0x400;
 
 		if (!sprite->tile_width || !sprite->tile_height ||
-			x + sprite->total_width <= 0 || x >= max_x || y + sprite->total_height <= 0 || y >= max_y )
+			x + sprite->total_width <= 0 || x >= max_x || y + sprite->total_height <= 0 || y >= max_y)
 		{continue;}
 
-		flipx    = attr & 0x0008;
-		flipy    = attr & 0x0004;
+		int flipx    = attr & 0x0008;
+		int flipy    = attr & 0x0004;
 
 		if (m_spritetype[0] == 3)    /* pwrinst2 */
 		{
 			sprite->priority = ((attr & 0x0010) >> 4) + 2;
-			sprite->base_pen = base_pal + (attr & 0x3f00) + 0x4000 * ((attr & 0x0020) >> 5);
+			sprite->base_pen = m_sprite_base_pal + ((((attr & 0x3f00) >> 8) + ((attr & 0x0020) << 1)) * m_sprite_granularity);
 		}
 		else
 		{
 			sprite->priority = (attr & 0x0030) >> 4;
-			sprite->base_pen = base_pal + (attr & 0x3f00);  // first 0x4000 colors
+			sprite->base_pen = m_sprite_base_pal + (((attr & 0x3f00) >> 8) * m_sprite_granularity);  // first 0x4000 colors
 		}
 
 		sprite->flags = SPRITE_VISIBLE_CAVE;
@@ -616,8 +570,15 @@ void cave_state::get_sprite_info_donpachi(int chip)
 }
 
 
-void cave_state::sprite_init()
+void cave_state::sprite_init(int chip)
 {
+	m_screen[chip]->register_screen_bitmap(m_sprite_zbuf[chip]);
+
+	save_item(NAME(m_sprite_zbuf[chip]), chip);
+
+	if (chip != 0)
+		return;
+
 	if (m_spritetype[0] == 0 || m_spritetype[0] == 2) // most of the games
 	{
 		m_get_sprite_info = &cave_state::get_sprite_info_cave;
@@ -630,7 +591,6 @@ void cave_state::sprite_init()
 	}
 
 	m_sprite_zbuf_baseval = 0x10000 - MAX_SPRITE_NUM;
-	m_screen->register_screen_bitmap(m_sprite_zbuf);
 
 	for (int chip = 0; chip < 4; chip++)
 	{
@@ -644,7 +604,6 @@ void cave_state::sprite_init()
 
 	m_sprite_draw = &cave_state::sprite_draw_donpachi;
 
-	save_item(NAME(m_sprite_zbuf));
 	save_item(NAME(m_sprite_zbuf_baseval));
 	save_item(NAME(m_num_sprites));
 	save_item(NAME(m_spriteram_bank));
@@ -659,10 +618,10 @@ void cave_state::sprite_init()
 void cave_state::sprite_check(int chip, screen_device &screen, const rectangle &clip)
 {
 	{   /* set clip */
-		int left = clip.min_x;
-		int top = clip.min_y;
-		int right = clip.max_x + 1;
-		int bottom = clip.max_y + 1;
+		const int left = clip.min_x;
+		const int top = clip.min_y;
+		const int right = clip.max_x + 1;
+		const int bottom = clip.max_y + 1;
 
 		m_blit.clip_left = left;
 		m_blit.clip_top = top;
@@ -681,11 +640,11 @@ void cave_state::sprite_check(int chip, screen_device &screen, const rectangle &
 		while (sprite < finish)
 		{
 			if (sprite->x + sprite->total_width  > m_blit.clip_left && sprite->x < m_blit.clip_right  &&
-				sprite->y + sprite->total_height > m_blit.clip_top  && sprite->y < m_blit.clip_bottom    )
+				sprite->y + sprite->total_height > m_blit.clip_top  && sprite->y < m_blit.clip_bottom   )
 			{
 				m_sprite_table[chip][sprite->priority][i[sprite->priority]++] = sprite;
 
-				if(!(spritetype & CAVE_SPRITETYPE_ZBUF))
+				if (!(spritetype & CAVE_SPRITETYPE_ZBUF))
 				{
 					if (priority_check > sprite->priority)
 						spritetype |= CAVE_SPRITETYPE_ZBUF;
@@ -711,8 +670,8 @@ void cave_state::sprite_check(int chip, screen_device &screen, const rectangle &
 				m_sprite_draw = &cave_state::sprite_draw_cave_zbuf;
 				if (clip.min_y == visarea.min_y)
 				{
-					if(!(m_sprite_zbuf_baseval += MAX_SPRITE_NUM))
-						m_sprite_zbuf.fill(0, visarea);
+					if (!(m_sprite_zbuf_baseval += MAX_SPRITE_NUM))
+						m_sprite_zbuf[chip].fill(0, visarea);
 				}
 				break;
 
@@ -720,8 +679,8 @@ void cave_state::sprite_check(int chip, screen_device &screen, const rectangle &
 				m_sprite_draw = &cave_state::sprite_draw_donpachi_zbuf;
 				if (clip.min_y == visarea.min_y)
 				{
-					if(!(m_sprite_zbuf_baseval += MAX_SPRITE_NUM))
-						m_sprite_zbuf.fill(0, visarea);
+					if (!(m_sprite_zbuf_baseval += MAX_SPRITE_NUM))
+						m_sprite_zbuf[chip].fill(0, visarea);
 				}
 				break;
 
@@ -732,7 +691,7 @@ void cave_state::sprite_check(int chip, screen_device &screen, const rectangle &
 	}
 }
 
-void cave_state::do_blit_zoom32( int chip, const sprite_cave *sprite )
+void cave_state::do_blit_zoom32(int chip, const sprite_cave *sprite)
 {
 	/*  assumes SPRITE_LIST_RAW_DATA flag is set */
 	int x1, x2, y1, y2, dx, dy;
@@ -782,7 +741,7 @@ void cave_state::do_blit_zoom32( int chip, const sprite_cave *sprite )
 			return;
 	}
 
-	if (sprite->flags & SPRITE_FLIPY_CAVE )
+	if (sprite->flags & SPRITE_FLIPY_CAVE)
 	{
 		y2 = sprite->y;
 		y1 = y2 + sprite->total_height;
@@ -818,41 +777,36 @@ void cave_state::do_blit_zoom32( int chip, const sprite_cave *sprite )
 				y1++;
 			}
 		}
-		if (y2 > m_blit.clip_bottom )
+		if (y2 > m_blit.clip_bottom)
 			y2 = m_blit.clip_bottom;
 		if (y1 >= y2)
 			return;
 	}
 
 	{
-		const uint8_t *pen_data = sprite->pen_data -1 -sprite->line_offset;
-		pen_t base_pen = sprite->base_pen;
-		int x, y;
-		uint8_t pen;
-		int pitch = m_blit.line_offset * dy / 4;
-		uint32_t *dest = (uint32_t *)(m_blit.baseaddr + m_blit.line_offset * y1);
+		const u8 *pen_data = sprite->pen_data -1 -sprite->line_offset;
+		const pen_t base_pen = sprite->base_pen;
+		const int pitch = m_blit.line_offset * dy / 4;
+		u32 *dest = (u32 *)(m_blit.baseaddr + m_blit.line_offset * y1);
 		int ycount = ycount0;
 
-		for (y = y1; y != y2; y += dy)
+		for (int y = y1; y != y2; y += dy)
 		{
-			int xcount;
-			const uint8_t *source;
-
 			if (ycount & 0xffff0000)
 			{
-				xcount = xcount0;
+				int xcount = xcount0;
 				pen_data += sprite->line_offset * (ycount >> 16);
 				ycount &= 0xffff;
-				source = pen_data;
-				for (x = x1; x != x2; x += dx)
+				const u8 *source = pen_data;
+				for (int x = x1; x != x2; x += dx)
 				{
 					if (xcount & 0xffff0000)
 					{
 						source += xcount >> 16;
 						xcount &= 0xffff;
-						pen = *source;
+						const u8 pen = *source;
 						if (pen)
-							dest[x] = m_palette->pen_color(base_pen + pen);
+							dest[x] = m_palette[chip]->pen_color(base_pen + pen);
 					}
 					xcount += sprite->zoomx_re;
 				}
@@ -864,7 +818,7 @@ void cave_state::do_blit_zoom32( int chip, const sprite_cave *sprite )
 }
 
 
-void cave_state::do_blit_zoom32_zb( int chip, const sprite_cave *sprite )
+void cave_state::do_blit_zoom32_zb(int chip, const sprite_cave *sprite)
 {
 	/*  assumes SPRITE_LIST_RAW_DATA flag is set */
 	int x1, x2, y1, y2, dx, dy;
@@ -954,38 +908,33 @@ void cave_state::do_blit_zoom32_zb( int chip, const sprite_cave *sprite )
 	}
 
 	{
-		const uint8_t *pen_data = sprite->pen_data - 1 - sprite->line_offset;
-		pen_t base_pen = sprite->base_pen;
-		int x, y;
-		uint8_t pen;
-		int pitch = m_blit.line_offset * dy / 4;
-		uint32_t *dest = (uint32_t *)(m_blit.baseaddr + m_blit.line_offset * y1);
-		int pitchz = m_blit.line_offset_zbuf * dy / 2;
-		uint16_t *zbf = (uint16_t *)(m_blit.baseaddr_zbuf + m_blit.line_offset_zbuf * y1);
-		uint16_t pri_sp = (uint16_t)(sprite - m_sprite[chip].get()) + m_sprite_zbuf_baseval;
+		const u8 *pen_data = sprite->pen_data - 1 - sprite->line_offset;
+		const pen_t base_pen = sprite->base_pen;
+		const int pitch = m_blit.line_offset * dy / 4;
+		u32 *dest = (u32 *)(m_blit.baseaddr + m_blit.line_offset * y1);
+		const int pitchz = m_blit.line_offset_zbuf * dy / 2;
+		u16 *zbf = (u16 *)(m_blit.baseaddr_zbuf + m_blit.line_offset_zbuf * y1);
+		const u16 pri_sp = (u16)(sprite - m_sprite[chip].get()) + m_sprite_zbuf_baseval;
 		int ycount = ycount0;
 
-		for (y = y1; y != y2; y += dy)
+		for (int y = y1; y != y2; y += dy)
 		{
-			int xcount;
-			const uint8_t *source;
-
 			if (ycount & 0xffff0000)
 			{
-				xcount = xcount0;
+				int xcount = xcount0;
 				pen_data += sprite->line_offset * (ycount >> 16);
 				ycount &= 0xffff;
-				source = pen_data;
-				for (x = x1; x != x2; x += dx)
+				const u8 *source = pen_data;
+				for (int x = x1; x != x2; x += dx)
 				{
 					if (xcount & 0xffff0000)
 					{
 						source += xcount >> 16;
 						xcount &= 0xffff;
-						pen = *source;
+						const u8 pen = *source;
 						if (pen && (zbf[x] <= pri_sp))
 						{
-							dest[x] = m_palette->pen_color(base_pen + pen);
+							dest[x] = m_palette[chip]->pen_color(base_pen + pen);
 							zbf[x] = pri_sp;
 						}
 					}
@@ -999,7 +948,7 @@ void cave_state::do_blit_zoom32_zb( int chip, const sprite_cave *sprite )
 	}
 }
 
-void cave_state::do_blit_32( int chip, const sprite_cave *sprite )
+void cave_state::do_blit_32(int chip, const sprite_cave *sprite)
 {
 	/*  assumes SPRITE_LIST_RAW_DATA flag is set */
 	int x1, x2, y1, y2, dx, dy;
@@ -1056,7 +1005,7 @@ void cave_state::do_blit_32( int chip, const sprite_cave *sprite )
 		y1 = sprite->y;
 		y2 = y1 + sprite->total_height;
 		dy = 1;
-		if (y1 < m_blit.clip_top )
+		if (y1 < m_blit.clip_top)
 		{
 			ycount0 = m_blit.clip_top - y1;
 			y1 = m_blit.clip_top;
@@ -1068,23 +1017,20 @@ void cave_state::do_blit_32( int chip, const sprite_cave *sprite )
 	}
 
 	{
-		const uint8_t *pen_data = sprite->pen_data;
-		pen_t base_pen = sprite->base_pen;
-		int x, y;
-		uint8_t pen;
-		int pitch = m_blit.line_offset * dy / 4;
-		uint32_t *dest = (uint32_t *)(m_blit.baseaddr + m_blit.line_offset * y1);
+		const u8 *pen_data = sprite->pen_data;
+		const pen_t base_pen = sprite->base_pen;
+		const int pitch = m_blit.line_offset * dy / 4;
+		u32 *dest = (u32 *)(m_blit.baseaddr + m_blit.line_offset * y1);
 
 		pen_data += sprite->line_offset * ycount0 + xcount0;
-		for (y = y1; y != y2; y += dy)
+		for (int y = y1; y != y2; y += dy)
 		{
-			const uint8_t *source;
-			source = pen_data;
-			for (x = x1; x != x2; x += dx)
+			const u8 *source = pen_data;
+			for (int x = x1; x != x2; x += dx)
 			{
-				pen = *source;
+				const u8 pen = *source;
 				if (pen)
-					dest[x] = m_palette->pen_color(base_pen + pen);
+					dest[x] = m_palette[chip]->pen_color(base_pen + pen);
 				source++;
 			}
 			pen_data += sprite->line_offset;
@@ -1094,7 +1040,7 @@ void cave_state::do_blit_32( int chip, const sprite_cave *sprite )
 }
 
 
-void cave_state::do_blit_32_zb( int chip, const sprite_cave *sprite )
+void cave_state::do_blit_32_zb(int chip, const sprite_cave *sprite)
 {
 	/*  assumes SPRITE_LIST_RAW_DATA flag is set */
 	int x1, x2, y1, y2, dx, dy;
@@ -1164,27 +1110,25 @@ void cave_state::do_blit_32_zb( int chip, const sprite_cave *sprite )
 	}
 
 	{
-		const uint8_t *pen_data = sprite->pen_data;
-		pen_t base_pen = sprite->base_pen;
-		int x, y;
-		uint8_t pen;
-		int pitch = m_blit.line_offset * dy / 4;
-		uint32_t *dest = (uint32_t *)(m_blit.baseaddr + m_blit.line_offset * y1);
-		int pitchz = m_blit.line_offset_zbuf * dy / 2;
-		uint16_t *zbf = (uint16_t *)(m_blit.baseaddr_zbuf + m_blit.line_offset_zbuf * y1);
-		uint16_t pri_sp = (uint16_t)(sprite - m_sprite[chip].get()) + m_sprite_zbuf_baseval;
+		const u8 *pen_data = sprite->pen_data;
+		const pen_t base_pen = sprite->base_pen;
+		const int pitch = m_blit.line_offset * dy / 4;
+		u32 *dest = (u32 *)(m_blit.baseaddr + m_blit.line_offset * y1);
+		const int pitchz = m_blit.line_offset_zbuf * dy / 2;
+		u16 *zbf = (u16 *)(m_blit.baseaddr_zbuf + m_blit.line_offset_zbuf * y1);
+		const u16 pri_sp = (u16)(sprite - m_sprite[chip].get()) + m_sprite_zbuf_baseval;
 
 		pen_data += sprite->line_offset * ycount0 + xcount0;
-		for (y = y1; y != y2; y += dy)
+		for (int y = y1; y != y2; y += dy)
 		{
-			const uint8_t *source;
+			const u8 *source;
 			source = pen_data;
-			for (x = x1; x != x2; x += dx)
+			for (int x = x1; x != x2; x += dx)
 			{
-				pen = *source;
+				const u8 pen = *source;
 				if (pen && (zbf[x] <= pri_sp))
 				{
-					dest[x] = m_palette->pen_color(base_pen + pen);
+					dest[x] = m_palette[chip]->pen_color(base_pen + pen);
 					zbf[x] = pri_sp;
 				}
 				source++;
@@ -1197,7 +1141,7 @@ void cave_state::do_blit_32_zb( int chip, const sprite_cave *sprite )
 }
 
 
-void cave_state::sprite_draw_cave( int chip, int priority )
+void cave_state::sprite_draw_cave(int chip, int priority)
 {
 	int i = 0;
 	while (m_sprite_table[chip][priority][i])
@@ -1210,7 +1154,7 @@ void cave_state::sprite_draw_cave( int chip, int priority )
 	}
 }
 
-void cave_state::sprite_draw_cave_zbuf( int chip, int priority )
+void cave_state::sprite_draw_cave_zbuf(int chip, int priority)
 {
 	int i = 0;
 	while (m_sprite_table[chip][priority][i])
@@ -1223,14 +1167,14 @@ void cave_state::sprite_draw_cave_zbuf( int chip, int priority )
 	}
 }
 
-void cave_state::sprite_draw_donpachi( int chip, int priority )
+void cave_state::sprite_draw_donpachi(int chip, int priority)
 {
 	int i = 0;
 	while (m_sprite_table[chip][priority][i])
 		do_blit_32(chip, m_sprite_table[chip][priority][i++]);
 }
 
-void cave_state::sprite_draw_donpachi_zbuf( int chip, int priority )
+void cave_state::sprite_draw_donpachi_zbuf(int chip, int priority)
 {
 	int i = 0;
 	while (m_sprite_table[chip][priority][i])
@@ -1294,30 +1238,29 @@ void cave_state::sprite_draw_donpachi_zbuf( int chip, int priority )
 
 ***************************************************************************/
 
-inline void cave_state::tilemap_draw( int chip,
+inline void cave_state::tilemap_draw(int chip,
 	screen_device &screen, bitmap_rgb32 &bitmap, const rectangle &cliprect,
-	uint32_t flags, uint32_t priority, uint32_t priority2, int GFX )
+	u32 flags, u32 priority, u32 priority2, int GFX)
 {
 	tilemap_t *TILEMAP = m_tilemap[GFX];
-	uint16_t *VRAM = m_vram[GFX];
-	uint16_t *VCTRL = m_vctrl[GFX];
-	int sx, sy, flipx, flipy, offs_x, offs_y, offs_row;
+	const u16 *VRAM = m_vram[GFX];
+	const u16 *VCTRL = m_vctrl[GFX];
 
 	/* Bail out if ... */
 
-	if  ( (!TILEMAP) ||                         /* no tilemap; */
+	if ((!TILEMAP) ||                               /* no tilemap; */
 			((VCTRL[2] & 0x0003) != priority2) ||   /* tilemap's global priority not the requested one; */
-			((VCTRL[2] & 0x0010))   )               /* tilemap's disabled. */
+			((VCTRL[2] & 0x0010)))                  /* tilemap's disabled. */
 		return;
 
-	flipx = ~VCTRL[0] & 0x8000;
-	flipy = ~VCTRL[1] & 0x8000;
-	TILEMAP->set_flip((flipx ? TILEMAP_FLIPX : 0) | (flipy ? TILEMAP_FLIPY : 0) );
+	const bool flipx = ~VCTRL[0] & 0x8000;
+	const bool flipy = ~VCTRL[1] & 0x8000;
+	TILEMAP->set_flip((flipx ? TILEMAP_FLIPX : 0) | (flipy ? TILEMAP_FLIPY : 0));
 
-	offs_x  =   m_layers_offs_x;
-	offs_y  =   m_layers_offs_y;
+	int offs_x         = m_layers_offs_x;
+	const int offs_y   = m_layers_offs_y;
 
-	offs_row =  flipy ? m_row_effect_offs_f : m_row_effect_offs_n;
+	const int offs_row = flipy ? m_row_effect_offs_f : m_row_effect_offs_n;
 
 	/* An additional 8 pixel offset for layers with 8x8 tiles. Plus
 	   Layer 0 is displaced by 1 pixel wrt Layer 1, so is Layer 2 wrt
@@ -1327,13 +1270,13 @@ inline void cave_state::tilemap_draw( int chip,
 	else if (TILEMAP == m_tilemap[2])    offs_x -= (m_tiledim[2] ? 3 : (3 + 8));
 	else if (TILEMAP == m_tilemap[3])    offs_x -= (m_tiledim[3] ? 4 : (4 + 8));
 
-	sx = VCTRL[0] - m_videoregs[chip][0] + (flipx ? (offs_x + 2) : -offs_x);
-	sy = VCTRL[1] - m_videoregs[chip][1] + (flipy ? (offs_y + 2) : -offs_y);
+	const int sx = VCTRL[0] - m_videoregs[chip][0] + (flipx ? (offs_x + 2) : -offs_x);
+	const int sy = VCTRL[1] - m_videoregs[chip][1] + (flipy ? (offs_y + 2) : -offs_y);
 
 	if (VCTRL[1] & 0x4000)  // row-select
 	{
 		rectangle clip;
-		int startline, endline, vramdata0, vramdata1;
+		int endline, vramdata0, vramdata1;
 
 		/*
 		    Row-select:
@@ -1346,19 +1289,17 @@ inline void cave_state::tilemap_draw( int chip,
 		clip.min_x = cliprect.min_x;
 		clip.max_x = cliprect.max_x;
 
-		for (startline = cliprect.min_y; startline <= cliprect.max_y;)
+		for (int startline = cliprect.min_y; startline <= cliprect.max_y;)
 		{
 			/* Find the largest slice */
 			vramdata0 = (vramdata1 = VRAM[(0x1002 + (((sy + offs_row + startline) * 4) & 0x7ff)) / 2]);
-			for(endline = startline + 1; endline <= cliprect.max_y; endline++)
-				if((++vramdata1) != VRAM[(0x1002 + (((sy + offs_row + endline) * 4) & 0x7ff)) / 2]) break;
+			for (endline = startline + 1; endline <= cliprect.max_y; endline++)
+				if ((++vramdata1) != VRAM[(0x1002 + (((sy + offs_row + endline) * 4) & 0x7ff)) / 2]) break;
 
 			TILEMAP->set_scrolly(0, vramdata0 - startline);
 
 			if (VCTRL[0] & 0x4000)  // row-scroll, row-select
 			{
-				int line;
-
 				/*
 				    Row-scroll:
 
@@ -1368,7 +1309,7 @@ inline void cave_state::tilemap_draw( int chip,
 				*/
 
 				TILEMAP->set_scroll_rows(512);
-				for(line = startline; line < endline; line++)
+				for (int line = startline; line < endline; line++)
 					TILEMAP->set_scrollx((vramdata0 - startline + line) & 511,
 										sx + VRAM[(0x1000 + (((sy + offs_row + line) * 4) & 0x7ff)) / 2]);
 			}
@@ -1396,17 +1337,16 @@ inline void cave_state::tilemap_draw( int chip,
 	}
 	else if (VCTRL[0] & 0x4000) // row-scroll, no row-select
 	{
-		int line;
 		TILEMAP->set_scroll_rows(512);
-		for(line = cliprect.min_y; line <= cliprect.max_y; line++)
+		for (int line = cliprect.min_y; line <= cliprect.max_y; line++)
 			TILEMAP->set_scrollx((line + sy) & 511,
-							sx + VRAM[(0x1000+(((sy + offs_row + line) * 4) & 0x7ff)) / 2] );
+							sx + VRAM[(0x1000+(((sy + offs_row + line) * 4) & 0x7ff)) / 2]);
 		TILEMAP->set_scrolly(0, sy);
 		TILEMAP->draw(screen, bitmap, cliprect, flags, priority);
 	}
 	else
 	{
-		/* DEF_STR( Normal ) scrolling */
+		/* DEF_STR(Normal) scrolling */
 		TILEMAP->set_scroll_rows(1);
 		TILEMAP->set_scroll_cols(1);
 		TILEMAP->set_scrollx(0, sx);
@@ -1416,20 +1356,17 @@ inline void cave_state::tilemap_draw( int chip,
 }
 
 
-uint32_t cave_state::screen_update(screen_device &screen, bitmap_rgb32 &bitmap, const rectangle &cliprect)
+u32 cave_state::screen_update(screen_device &screen, bitmap_rgb32 &bitmap, const rectangle &cliprect)
 {
-	int pri, pri2, GFX;
 	int layers_ctrl = -1;
 
-	set_pens(0);
-
-	m_blit.baseaddr = reinterpret_cast<uint8_t *>(bitmap.raw_pixptr(0));
+	m_blit.baseaddr = reinterpret_cast<u8 *>(bitmap.raw_pixptr(0));
 	m_blit.line_offset = bitmap.rowbytes();
-	m_blit.baseaddr_zbuf = reinterpret_cast<uint8_t *>(m_sprite_zbuf.raw_pixptr(0));
-	m_blit.line_offset_zbuf = m_sprite_zbuf.rowbytes();
+	m_blit.baseaddr_zbuf = reinterpret_cast<u8 *>(m_sprite_zbuf[0].raw_pixptr(0));
+	m_blit.line_offset_zbuf = m_sprite_zbuf[0].rowbytes();
 
 	/* Choose the tilemap to display (8x8 tiles or 16x16 tiles) */
-	for (GFX = 0; GFX < 4; GFX++)
+	for (int GFX = 0; GFX < 4; GFX++)
 	{
 		if (m_tilemap[GFX])
 		{
@@ -1442,8 +1379,8 @@ uint32_t cave_state::screen_update(screen_device &screen, bitmap_rgb32 &bitmap, 
 
 #ifdef MAME_DEBUG
 {
-	if ( machine().input().code_pressed(KEYCODE_Z) || machine().input().code_pressed(KEYCODE_X) || machine().input().code_pressed(KEYCODE_C) ||
-			machine().input().code_pressed(KEYCODE_V) || machine().input().code_pressed(KEYCODE_B) )
+	if (machine().input().code_pressed(KEYCODE_Z) || machine().input().code_pressed(KEYCODE_X) || machine().input().code_pressed(KEYCODE_C) ||
+			machine().input().code_pressed(KEYCODE_V) || machine().input().code_pressed(KEYCODE_B))
 	{
 		int msk = 0, val = 0;
 
@@ -1464,7 +1401,7 @@ uint32_t cave_state::screen_update(screen_device &screen, bitmap_rgb32 &bitmap, 
 		/* Show the video registers (cave_videoregs) */
 		popmessage("%04X %04X %04X %04X %04X %04X %04X %04X",
 			m_videoregs[0][0], m_videoregs[0][1], m_videoregs[0][2], m_videoregs[0][3],
-			m_videoregs[0][4], m_videoregs[0][5], m_videoregs[0][6], m_videoregs[0][7] );
+			m_videoregs[0][4], m_videoregs[0][5], m_videoregs[0][6], m_videoregs[0][7]);
 #endif
 		/* Show the scroll / flags registers of the selected layer */
 		if ((m_tilemap[0]) && (msk & 0x000f))   popmessage("x:%04X y:%04X f:%04X", m_vctrl[0][0],m_vctrl[0][1],m_vctrl[0][2]);
@@ -1475,7 +1412,7 @@ uint32_t cave_state::screen_update(screen_device &screen, bitmap_rgb32 &bitmap, 
 
 	/* Show the row / "column" scroll enable flags, when they change state */
 	m_rasflag = 0;
-	for (GFX = 0; GFX < 4; GFX++)
+	for (int GFX = 0; GFX < 4; GFX++)
 	{
 		if (m_tilemap[GFX])
 		{
@@ -1490,7 +1427,7 @@ uint32_t cave_state::screen_update(screen_device &screen, bitmap_rgb32 &bitmap, 
 			(m_rasflag & 0x0001) ? 'x' : ' ', (m_rasflag & 0x0002) ? 'y' : ' ',
 			(m_rasflag & 0x0010) ? 'x' : ' ', (m_rasflag & 0x0020) ? 'y' : ' ',
 			(m_rasflag & 0x0100) ? 'x' : ' ', (m_rasflag & 0x0200) ? 'y' : ' ',
-			(m_rasflag & 0x1000) ? 'x' : ' ', (m_rasflag & 0x2000) ? 'y' : ' ' );
+			(m_rasflag & 0x1000) ? 'x' : ' ', (m_rasflag & 0x2000) ? 'y' : ' ');
 		m_old_rasflag = m_rasflag;
 	}
 }
@@ -1498,7 +1435,7 @@ uint32_t cave_state::screen_update(screen_device &screen, bitmap_rgb32 &bitmap, 
 
 	sprite_check(0, screen, cliprect);
 
-	bitmap.fill(m_palette->pen_color(m_background_pen), cliprect);
+	bitmap.fill(m_palette[0]->pen_color(m_background_pen[0]), cliprect);
 
 	/*
 	    Tiles and sprites are ordered by priority (0 back, 3 front) with
@@ -1512,11 +1449,11 @@ uint32_t cave_state::screen_update(screen_device &screen, bitmap_rgb32 &bitmap, 
 	    Tiles with the same priority *and* the same priority of their layer
 	    are ordered by layer (0 back, 2 front)
 	*/
-	for (pri = 0; pri <= 3; pri++)  // tile / sprite priority
+	for (int pri = 0; pri <= 3; pri++)  // tile / sprite priority
 	{
 		if (layers_ctrl & (1 << (pri + 16)))    (this->*m_sprite_draw)(0, pri);
 
-		for (pri2 = 0; pri2 <= 3; pri2++)   // priority of the whole layer
+		for (int pri2 = 0; pri2 <= 3; pri2++)   // priority of the whole layer
 		{
 			if (layers_ctrl & (1 << (pri +  0)))    tilemap_draw(0, screen, bitmap, cliprect, pri, 0, pri2, 0);
 			if (layers_ctrl & (1 << (pri +  4)))    tilemap_draw(0, screen, bitmap, cliprect, pri, 0, pri2, 1);
@@ -1536,7 +1473,7 @@ void cave_state::get_sprite_info(int chip)
 	if (m_videoregs[chip] == nullptr)
 		return;
 
-	int spriteram_bankmax = m_spriteram[chip].bytes() / 0x4000;
+	const int spriteram_bankmax = m_spriteram[chip].bytes() / 0x4000;
 
 	if (m_kludge == 3)   /* mazinger metmqstr */
 	{
@@ -1565,32 +1502,12 @@ void cave_state::device_post_load()
 
 // Poka Poka Satan: 3 screens * (1 Sprite chip + 1 Tilemap chip)
 
-void cave_state::ppsatan_palette(palette_device &palette)
+u32 cave_state::screen_update_ppsatan_core(screen_device &screen, bitmap_rgb32 &bitmap, const rectangle &cliprect, int chip)
 {
-	cave_palette(palette);
-
-	for (int chip = 0; chip < 3; chip++)
-	{
-		//  Sprites: 0x987800 - 0x988fff
-		for (int color = 0; color < 0x40; color++)
-			for (int pen = 0; pen < 0x10; pen++)
-				m_palette_map[chip][(color << 8) | pen] = 0x7800/2 + ((color << 4) | pen);
-
-		//  Tiles:   0x980000 - 0x9803ff
-		for (int color = 0; color < 0x40; color++)
-			for (int pen = 0; pen < 0x10; pen++)
-				m_palette_map[chip][0x4000 + ((color << 4) | pen)] = ((color << 4) | pen);
-	}
-}
-
-uint32_t cave_state::screen_update_ppsatan_core(screen_device &screen, bitmap_rgb32 &bitmap, const rectangle &cliprect, int chip)
-{
-	set_pens(chip);
-
-	m_blit.baseaddr = reinterpret_cast<uint8_t *>(bitmap.raw_pixptr(0));
+	m_blit.baseaddr = reinterpret_cast<u8 *>(bitmap.raw_pixptr(0));
 	m_blit.line_offset = bitmap.rowbytes();
-	m_blit.baseaddr_zbuf = reinterpret_cast<uint8_t *>(m_sprite_zbuf.raw_pixptr(0));
-	m_blit.line_offset_zbuf = m_sprite_zbuf.rowbytes();
+	m_blit.baseaddr_zbuf = reinterpret_cast<u8 *>(m_sprite_zbuf[chip].raw_pixptr(0));
+	m_blit.line_offset_zbuf = m_sprite_zbuf[chip].rowbytes();
 
 	m_tiledim[chip] = m_vctrl[chip][1] & 0x2000;
 	if (m_tiledim[chip] != m_old_tiledim[chip])
@@ -1599,7 +1516,7 @@ uint32_t cave_state::screen_update_ppsatan_core(screen_device &screen, bitmap_rg
 
 	sprite_check(chip, screen, cliprect);
 
-	bitmap.fill(m_palette->pen_color(m_background_pen), cliprect);
+	bitmap.fill(m_palette[chip]->pen_color(m_background_pen[chip]), cliprect);
 
 	for (int pri = 0; pri <= 3; pri++)  // tile / sprite priority
 	{
@@ -1612,16 +1529,16 @@ uint32_t cave_state::screen_update_ppsatan_core(screen_device &screen, bitmap_rg
 	return 0;
 }
 
-uint32_t cave_state::screen_update_ppsatan_top(screen_device &screen, bitmap_rgb32 &bitmap, const rectangle &cliprect)
+u32 cave_state::screen_update_ppsatan_top(screen_device &screen, bitmap_rgb32 &bitmap, const rectangle &cliprect)
 {
 	return screen_update_ppsatan_core(screen, bitmap, cliprect, 0);
 }
-uint32_t cave_state::screen_update_ppsatan_left(screen_device &screen, bitmap_rgb32 &bitmap, const rectangle &cliprect)
+u32 cave_state::screen_update_ppsatan_left(screen_device &screen, bitmap_rgb32 &bitmap, const rectangle &cliprect)
 {
 	machine().crosshair().get_crosshair(1).set_screen(&screen);
 	return screen_update_ppsatan_core(screen, bitmap, cliprect, 1);
 }
-uint32_t cave_state::screen_update_ppsatan_right(screen_device &screen, bitmap_rgb32 &bitmap, const rectangle &cliprect)
+u32 cave_state::screen_update_ppsatan_right(screen_device &screen, bitmap_rgb32 &bitmap, const rectangle &cliprect)
 {
 	machine().crosshair().get_crosshair(0).set_screen(&screen);
 	return screen_update_ppsatan_core(screen, bitmap, cliprect, 2);


### PR DESCRIPTION
Simplify handlers, Use common interface for palette, Use seperated gfxdecode, palette, screen finder, bitmap for ppsatan each screen, Move sprite granularity into video_start, Allow save state for sailormn 3th tilemap, Reduce runtime tag lookups, Unnecessary lines, Fix debugger issue, Fix spacings, Use shorter / correct type values, Add notes