### PR TITLE
Fixed Great Guns palette init typo

### DIFF
--- a/src/mame/arcade.flt
+++ b/src/mame/arcade.flt
@@ -1167,6 +1167,7 @@ stadhero.cpp
 starcrus.cpp
 starfire.cpp
 stargame.cpp
+starrider.cpp
 starshp1.cpp
 starwars.cpp
 statriv2.cpp

--- a/src/mame/drivers/mazerbla.cpp
+++ b/src/mame/drivers/mazerbla.cpp
@@ -1053,7 +1053,7 @@ void mazerbla_state::greatgun(machine_config &config)
 	m_screen->set_screen_update(FUNC(mazerbla_state::screen_update_mazerbla));
 	m_screen->screen_vblank().set(FUNC(mazerbla_state::screen_vblank));
 
-	PALETTE(config, "palette", FUNC(mazerbla_state::mazerbla_palette), 246+1);
+	PALETTE(config, "palette", FUNC(mazerbla_state::mazerbla_palette), 256+1);
 
 	/* sound hardware */
 	SPEAKER(config, "mono").front_center();


### PR DESCRIPTION
In MAME 0.206 the MCFG macros were removed and Great Guns crashed in the attract mode.

Typo in palette init:

PALETTE(config, "palette", FUNC(mazerbla_state::mazerbla_palette), 246+1);

246+1
instead of
256+1
