### PR TITLE
Sega 315-5313 color related function updates

### DIFF
--- a/src/devices/video/315_5124.cpp
+++ b/src/devices/video/315_5124.cpp
@@ -174,6 +174,15 @@ void sega315_5313_mode4_device::sega315_5313_palette(palette_device &palette) co
 		palette.set_pen_color(i + (512 * 1), level[r], level[g], level[b]); // shadow
 		palette.set_pen_color(i + (512 * 2), level[7 + r], level[7 + g], level[7 + b]); // hilight
 	}
+	// seperated SMS compatible mode color (reference : http://www.sega-16.com/forum/showthread.php?30530-SMS-VDP-output-levels)
+	static const u8 sms_level[4] = {0,99,162,255};
+	for (int i = 0; i < 64; i++)
+	{
+		const u8 r = (i & 0x0003) >> 0;
+		const u8 g = (i & 0x000c) >> 2;
+		const u8 b = (i & 0x0030) >> 4;
+		palette.set_pen_color(i + (512 * 3), sms_level[r], sms_level[g], sms_level[b]); // normal
+	}
 }
 
 
@@ -1791,7 +1800,7 @@ void sega315_5313_mode4_device::update_palette()
 
 	for (int i = 0; i < 32; i++)
 	{
-		m_current_palette[i] = ((m_CRAM[i] & 0x30) << 3) | ((m_CRAM[i] & 0x0c ) << 2) | ((m_CRAM[i] & 0x03) << 1);
+		m_current_palette[i] = (512 * 3) + (m_CRAM[i] & 0x3f);
 	}
 }
 
@@ -2006,6 +2015,6 @@ void sega315_5313_mode4_device::device_add_mconfig(machine_config &config)
 {
 	sega315_5246_device::device_add_mconfig(config);
 
-	m_palette->set_entries(512 * 3);
+	m_palette->set_entries((512 * 3) + 64);
 	m_palette->set_init(FUNC(sega315_5313_mode4_device::sega315_5313_palette));
 }

--- a/src/devices/video/315_5124.cpp
+++ b/src/devices/video/315_5124.cpp
@@ -123,9 +123,9 @@ void sega315_5124_device::sega315_5124_palette(palette_device &palette) const
 {
 	for (int i = 0; i < 64; i++)
 	{
-		const int r = i & 0x03;
-		const int g = (i & 0x0c) >> 2;
-		const int b = (i & 0x30) >> 4;
+		const u8 r = i & 0x03;
+		const u8 g = (i & 0x0c) >> 2;
+		const u8 b = (i & 0x30) >> 4;
 		palette.set_pen_color(i, pal2bit(r), pal2bit(g), pal2bit(b));
 	}
 	// sms and sg1000-mark3 uses a different palette for modes 0 to 3 - see http://www.smspower.org/Development/Palette
@@ -153,10 +153,26 @@ void sega315_5377_device::sega315_5377_palette(palette_device &palette) const
 {
 	for (int i = 0; i < 4096; i++)
 	{
-		const int r = i & 0x000f;
-		const int g = (i & 0x00f0) >> 4;
-		const int b = (i & 0x0f00) >> 8;
+		const u8 r = i & 0x000f;
+		const u8 g = (i & 0x00f0) >> 4;
+		const u8 b = (i & 0x0f00) >> 8;
 		palette.set_pen_color(i, pal4bit(r), pal4bit(g), pal4bit(b));
+	}
+}
+
+
+void sega315_5313_mode4_device::sega315_5313_palette(palette_device &palette) const
+{
+	// non-linear (reference : http://gendev.spritesmind.net/forum/viewtopic.php?f=22&t=2188)
+	static const u8 level[15] = {0,29,52,70,87,101,116,130,144,158,172,187,206,228,255};
+	for (int i = 0; i < 512; i++)
+	{
+		const u8 r = (i & 0x0007) >> 0;
+		const u8 g = (i & 0x0038) >> 3;
+		const u8 b = (i & 0x01c0) >> 6;
+		palette.set_pen_color(i + (512 * 0), level[r << 1], level[g << 1], level[b << 1]); // normal
+		palette.set_pen_color(i + (512 * 1), level[r], level[g], level[b]); // shadow
+		palette.set_pen_color(i + (512 * 2), level[7 + r], level[7 + g], level[7 + b]); // hilight
 	}
 }
 
@@ -1759,6 +1775,27 @@ void sega315_5377_device::update_palette()
 }
 
 
+void sega315_5313_mode4_device::update_palette()
+{
+	/* Exit if palette has no changes */
+	if (!m_cram_dirty)
+	{
+		return;
+	}
+	m_cram_dirty = false;
+
+	if (m_vdp_mode != 4)
+	{
+		return;
+	}
+
+	for (int i = 0; i < 32; i++)
+	{
+		m_current_palette[i] = ((m_CRAM[i] & 0x30) << 3) | ((m_CRAM[i] & 0x0c ) << 2) | ((m_CRAM[i] & 0x03) << 1);
+	}
+}
+
+
 void sega315_5124_device::cram_write(u8 data)
 {
 	u16 address = m_addr & m_cram_mask;
@@ -1959,4 +1996,16 @@ void sega315_5377_device::device_add_mconfig(machine_config &config)
 	GAMEGEAR(config.replace(), m_snsnd, DERIVED_CLOCK(1, 3));
 	m_snsnd->add_route(0, *this, 1.0, AUTO_ALLOC_INPUT, 0);
 	m_snsnd->add_route(1, *this, 1.0, AUTO_ALLOC_INPUT, 1);
+}
+
+//-------------------------------------------------
+//  device_add_mconfig - add machine configuration
+//-------------------------------------------------
+
+void sega315_5313_mode4_device::device_add_mconfig(machine_config &config)
+{
+	sega315_5246_device::device_add_mconfig(config);
+
+	m_palette->set_entries(512 * 3);
+	m_palette->set_init(FUNC(sega315_5313_mode4_device::sega315_5313_palette));
 }

--- a/src/devices/video/315_5124.h
+++ b/src/devices/video/315_5124.h
@@ -245,6 +245,9 @@ public:
 protected:
 	sega315_5313_mode4_device(const machine_config &mconfig, device_type type, const char *tag, device_t *owner, u32 clock, u8 cram_size, u8 palette_offset, u8 reg_num_mask, int max_sprite_zoom_hcount, int max_sprite_zoom_vcount, const u8 *line_timing);
 
+	virtual void device_add_mconfig(machine_config &config) override;
+
+	virtual void update_palette() override;
 	virtual void write_memory(u8 data) override;
 	virtual void load_vram_addr(u8 data) override;
 	virtual void select_sprites(int line) override;
@@ -253,6 +256,9 @@ protected:
 	virtual void select_display_mode() override;
 	virtual void select_extended_res_mode4(bool M1, bool M2, bool M3) override;
 	virtual void draw_leftmost_pixels_mode4(int *line_buffer, int *priority_selected, int fine_x_scroll, int palette_selected, int tile_line) override;
+
+private:
+	void sega315_5313_palette(palette_device &palette) const;
 };
 
 #endif // MAME_VIDEO_315_5124_H

--- a/src/devices/video/315_5313.cpp
+++ b/src/devices/video/315_5313.cpp
@@ -204,11 +204,9 @@ sega315_5313_device::sega315_5313_device(const machine_config &mconfig, const ch
 	, m_highpri_renderline(nullptr)
 	, m_video_renderline(nullptr)
 	, m_palette_lookup(nullptr)
-	, m_palette_lookup_sprite(nullptr)
-	, m_palette_lookup_shadow(nullptr)
-	, m_palette_lookup_highlight(nullptr)
 	, m_space68k(nullptr)
 	, m_cpu68k(*this, finder_base::DUMMY_TAG)
+	, m_ext_palette(*this, finder_base::DUMMY_TAG)
 {
 	m_use_alt_timing = 0;
 	m_palwrite_base = -1;
@@ -222,8 +220,6 @@ sega315_5313_device::sega315_5313_device(const machine_config &mconfig, const ch
 void sega315_5313_device::device_add_mconfig(machine_config &config)
 {
 	sega315_5313_mode4_device::device_add_mconfig(config);
-
-	m_palette->set_entries(0x200); // more entries for 32X - not really the cleanest way to do this
 
 	SEGAPSG(config.replace(), m_snsnd, DERIVED_CLOCK(1, 15)).add_route(ALL_OUTPUTS, *this, 0.5, AUTO_ALLOC_INPUT, 0);
 }
@@ -294,22 +290,13 @@ void sega315_5313_device::device_start()
 	m_video_renderline = std::make_unique<uint32_t[]>(320);
 
 	m_palette_lookup = std::make_unique<uint16_t[]>(0x40);
-	m_palette_lookup_sprite = std::make_unique<uint16_t[]>(0x40);
-
-	m_palette_lookup_shadow = std::make_unique<uint16_t[]>(0x40);
-	m_palette_lookup_highlight = std::make_unique<uint16_t[]>(0x40);
 
 	memset(m_palette_lookup.get(),0x00,0x40*2);
-	memset(m_palette_lookup_sprite.get(),0x00,0x40*2);
-
-	memset(m_palette_lookup_shadow.get(),0x00,0x40*2);
-	memset(m_palette_lookup_highlight.get(),0x00,0x40*2);
-
 
 	if (!m_use_alt_timing)
-		m_render_bitmap = std::make_unique<bitmap_ind16>(320, 512); // allocate maximum sizes we're going to use, it's safer.
+		m_render_bitmap = std::make_unique<bitmap_rgb32>(320, 512); // allocate maximum sizes we're going to use, it's safer.
 	else
-		m_render_line = std::make_unique<uint16_t[]>(320);
+		m_render_line = std::make_unique<uint32_t[]>(320);
 
 	m_render_line_raw = std::make_unique<uint16_t[]>(320);
 
@@ -317,14 +304,11 @@ void sega315_5313_device::device_start()
 	// but better safe than sorry...
 	save_pointer(NAME(m_sprite_renderline), 1024);
 	save_pointer(NAME(m_highpri_renderline), 320);
-	save_pointer(NAME(m_video_renderline), 320/4);
+	save_pointer(NAME(m_video_renderline), 320);
 	save_pointer(NAME(m_palette_lookup), 0x40);
-	save_pointer(NAME(m_palette_lookup_sprite), 0x40);
-	save_pointer(NAME(m_palette_lookup_shadow), 0x40);
-	save_pointer(NAME(m_palette_lookup_highlight), 0x40);
-	save_pointer(NAME(m_render_line_raw), 320/2);
+	save_pointer(NAME(m_render_line_raw), 320);
 	if (m_use_alt_timing)
-		save_pointer(NAME(m_render_line), 320/2);
+		save_pointer(NAME(m_render_line), 320);
 
 	m_irq6_on_timer = machine().scheduler().timer_alloc(timer_expired_delegate(FUNC(sega315_5313_device::irq6_on_timer_callback), this));
 	m_irq4_on_timer = machine().scheduler().timer_alloc(timer_expired_delegate(FUNC(sega315_5313_device::irq4_on_timer_callback), this));
@@ -414,20 +398,17 @@ void sega315_5313_device::write_cram_value(int offset, int data)
 	//logerror("Wrote to CRAM addr %04x data %04x\n",m_vdp_address&0xfffe,m_cram[m_vdp_address>>1]);
 	if (m_use_cram)
 	{
-		int r,g,b;
-		r = ((data >> 1)&0x07);
-		g = ((data >> 5)&0x07);
-		b = ((data >> 9)&0x07);
-		if (m_palwrite_base != -1)
+		data = ((m_cram[offset] & 0xe) >> 1) | ((m_cram[offset] & 0xe0) >> 2) | ((m_cram[offset] & 0xe00) >> 3);
+		m_palette_lookup[offset] = data;
+		if (m_ext_palette != nullptr)
 		{
-			m_palette->set_pen_color(offset + m_palwrite_base ,pal3bit(r),pal3bit(g),pal3bit(b));
-			m_palette->set_pen_color(offset + m_palwrite_base + 0x40 ,pal3bit(r>>1),pal3bit(g>>1),pal3bit(b>>1));
-			m_palette->set_pen_color(offset + m_palwrite_base + 0x80 ,pal3bit((r>>1)|0x4),pal3bit((g>>1)|0x4),pal3bit((b>>1)|0x4));
+			if (m_palwrite_base != -1)
+			{
+				m_ext_palette->set_pen_color(offset + m_palwrite_base, m_palette->pen(data));
+				m_ext_palette->set_pen_color(offset + m_palwrite_base + 0x40, m_palette->pen(0x200 | data));
+				m_ext_palette->set_pen_color(offset + m_palwrite_base + 0x80, m_palette->pen(0x400 | data));
+			}
 		}
-		m_palette_lookup[offset] = (b<<2) | (g<<7) | (r<<12);
-		m_palette_lookup_sprite[offset] = (b<<2) | (g<<7) | (r<<12);
-		m_palette_lookup_shadow[offset] = (b<<1) | (g<<6) | (r<<11);
-		m_palette_lookup_highlight[offset] = ((b|0x08)<<1) | ((g|0x08)<<6) | ((r|0x08)<<11);
 	}
 }
 
@@ -2641,16 +2622,14 @@ void sega315_5313_device::render_videoline_to_videobuffer(int scanline)
 /* This converts our render buffer to real screen colours */
 void sega315_5313_device::render_videobuffer_to_screenbuffer(int scanline)
 {
-	uint16_t *lineptr;
-
-
+	uint32_t *lineptr;
 
 	if (!m_use_alt_timing)
 	{
 		if (scanline >= m_render_bitmap->height()) // safety, shouldn't happen now we allocate a fixed amount tho
 			return;
 
-		lineptr = &m_render_bitmap->pix16(scanline);
+		lineptr = &m_render_bitmap->pix32(scanline);
 
 	}
 	else
@@ -2659,6 +2638,9 @@ void sega315_5313_device::render_videobuffer_to_screenbuffer(int scanline)
 	for (int x = 0; x < 320; x++)
 	{
 		uint32_t dat = m_video_renderline[x];
+		uint16_t clut = m_palette_lookup[(dat & 0x3f)];
+		if (!MEGADRIVE_REG0_SPECIAL_PAL) // 3 bit color mode, correct?
+			clut &= 0x111;
 
 		if (!(dat & 0x20000))
 			m_render_line_raw[x] = 0x100;
@@ -2670,12 +2652,12 @@ void sega315_5313_device::render_videobuffer_to_screenbuffer(int scanline)
 		{
 			if (dat & 0x10000)
 			{
-				lineptr[x] = m_palette_lookup_sprite[(dat & 0x3f)];
+				lineptr[x] = m_palette->pen(clut);
 				m_render_line_raw[x] |= (dat & 0x3f) | 0x080;
 			}
 			else
 			{
-				lineptr[x] = m_palette_lookup[(dat & 0x3f)];
+				lineptr[x] = m_palette->pen(clut);
 				m_render_line_raw[x] |= (dat & 0x3f) | 0x040;
 			}
 
@@ -2691,26 +2673,25 @@ void sega315_5313_device::render_videobuffer_to_screenbuffer(int scanline)
 				case 0x10000: // (sprite) low priority, no shadow sprite, no highlight = shadow
 				case 0x12000: // (sprite) low priority, shadow sprite, no highlight = shadow
 				case 0x16000: // (sprite) normal pri,   shadow sprite, no highlight = shadow?
-					lineptr[x] = m_palette_lookup_shadow[(dat & 0x3f)];
+					lineptr[x] = m_palette->pen(0x200 | clut);
 					m_render_line_raw[x] |= (dat & 0x3f) | 0x000;
 					break;
 
 				case 0x4000: // normal pri, no shadow sprite, no highlight = normal;
 				case 0x8000: // low pri, highlight sprite = normal;
-					lineptr[x] = m_palette_lookup[(dat & 0x3f)];
+					lineptr[x] = m_palette->pen(clut);
 					m_render_line_raw[x] |= (dat & 0x3f) | 0x040;
 					break;
 
 				case 0x14000: // (sprite) normal pri, no shadow sprite, no highlight = normal;
 				case 0x18000: // (sprite) low pri, highlight sprite = normal;
-					lineptr[x] = m_palette_lookup_sprite[(dat & 0x3f)];
+					lineptr[x] = m_palette->pen(clut);
 					m_render_line_raw[x] |= (dat & 0x3f) | 0x080;
 					break;
 
-
 				case 0x0c000: // normal pri, highlight set = highlight?
 				case 0x1c000: // (sprite) normal pri, highlight set = highlight?
-					lineptr[x] = m_palette_lookup_highlight[(dat & 0x3f)];
+					lineptr[x] = m_palette->pen(0x400 | clut);
 					m_render_line_raw[x] |= (dat & 0x3f) | 0x0c0;
 					break;
 

--- a/src/devices/video/315_5313.h
+++ b/src/devices/video/315_5313.h
@@ -23,7 +23,7 @@ public:
 
 	sega315_5313_device(const machine_config &mconfig, const char *tag, device_t *owner, uint32_t clock);
 
-	typedef device_delegate<void (int x, uint32_t priority, uint16_t &lineptr)> md_32x_scanline_delegate;
+	typedef device_delegate<void (int x, uint32_t priority, uint32_t &lineptr)> md_32x_scanline_delegate;
 	typedef device_delegate<void (int scanline, int irq6)> md_32x_interrupt_delegate;
 	typedef device_delegate<void (int scanline)> md_32x_scanline_helper_delegate;
 
@@ -33,7 +33,7 @@ public:
 
 	void set_alt_timing(int use_alt_timing) { m_use_alt_timing = use_alt_timing; }
 	void set_pal_write_base(int palwrite_base) { m_palwrite_base = palwrite_base; }
-	template <typename T> void set_palette(T &&tag) { m_palette.set_tag(std::forward<T>(tag)); }
+	template <typename T> void set_palette(T &&tag) { m_ext_palette.set_tag(std::forward<T>(tag)); }
 
 	// Temporary solution while 32x VDP mixing and scanline interrupting is moved outside MD VDP
 	template <typename... T> void set_md_32x_scanline(T &&... args) { m_32x_scanline_func = md_32x_scanline_delegate(std::forward<T>(args)...); }
@@ -75,8 +75,8 @@ public:
 			m_render_bitmap->fill(0);
 	}
 
-	std::unique_ptr<bitmap_ind16> m_render_bitmap;
-	std::unique_ptr<uint16_t[]> m_render_line;
+	std::unique_ptr<bitmap_rgb32> m_render_bitmap;
+	std::unique_ptr<uint32_t[]> m_render_line;
 	std::unique_ptr<uint16_t[]> m_render_line_raw;
 
 	TIMER_DEVICE_CALLBACK_MEMBER( megadriv_scanline_timer_callback_alt_timing );
@@ -180,12 +180,10 @@ private:
 	std::unique_ptr<uint8_t[]> m_highpri_renderline;
 	std::unique_ptr<uint32_t[]> m_video_renderline;
 	std::unique_ptr<uint16_t[]> m_palette_lookup;
-	std::unique_ptr<uint16_t[]> m_palette_lookup_sprite; // for C2
-	std::unique_ptr<uint16_t[]> m_palette_lookup_shadow;
-	std::unique_ptr<uint16_t[]> m_palette_lookup_highlight;
 
 	address_space *m_space68k;
 	required_device<m68000_base_device> m_cpu68k;
+	optional_device<palette_device> m_ext_palette;
 };
 
 

--- a/src/mame/drivers/megadriv.cpp
+++ b/src/mame/drivers/megadriv.cpp
@@ -580,7 +580,7 @@ DEVICE_IMAGE_LOAD_MEMBER( md_cons_state, _32x_cart )
 }
 
 
-void md_cons_state::_32x_scanline_callback(int x, uint32_t priority, uint16_t &lineptr)
+void md_cons_state::_32x_scanline_callback(int x, uint32_t priority, uint32_t &lineptr)
 {
 	if (m_32x)
 		m_32x->_32x_render_videobuffer_to_screenbuffer(x, priority, lineptr);
@@ -612,7 +612,6 @@ MACHINE_CONFIG_START(md_cons_state::genesis_32x)
 	m_vdp->add_route(ALL_OUTPUTS, "rspeaker", (0.25)/2);
 
 	SEGA_32X_NTSC(config, m_32x, (MASTER_CLOCK_NTSC * 3) / 7, m_maincpu, m_scan_timer);
-	m_32x->set_palette_tag("gen_vdp:palette");
 
 	subdevice<screen_device>("megadriv")->screen_vblank().set(FUNC(md_cons_state::screen_vblank_console));
 
@@ -647,7 +646,6 @@ MACHINE_CONFIG_START(md_cons_state::mdj_32x)
 	m_vdp->add_route(ALL_OUTPUTS, "rspeaker", (0.25)/2);
 
 	SEGA_32X_NTSC(config, m_32x, (MASTER_CLOCK_NTSC * 3) / 7, m_maincpu, m_scan_timer);
-	m_32x->set_palette_tag("gen_vdp:palette");
 
 	subdevice<screen_device>("megadriv")->screen_vblank().set(FUNC(md_cons_state::screen_vblank_console));
 
@@ -682,7 +680,6 @@ MACHINE_CONFIG_START(md_cons_state::md_32x)
 	m_vdp->add_route(ALL_OUTPUTS, "rspeaker", (0.25)/2);
 
 	SEGA_32X_PAL(config, m_32x, (MASTER_CLOCK_PAL * 3) / 7, m_maincpu, m_scan_timer);
-	m_32x->set_palette_tag("gen_vdp:palette");
 
 	subdevice<screen_device>("megadriv")->screen_vblank().set(FUNC(md_cons_state::screen_vblank_console));
 

--- a/src/mame/drivers/vgmplay.cpp
+++ b/src/mame/drivers/vgmplay.cpp
@@ -3642,14 +3642,11 @@ MACHINE_CONFIG_START(vgmplay_state::vgmplay)
 
 	/// TODO: rewrite to generate audio without using DAC devices
 	SEGA_32X_NTSC(config, m_sega32x, 0, "sega32x_maincpu", "sega32x_scanline_timer");
-	m_sega32x->set_palette_tag("sega32x_palette");
 
 	auto& sega32x_maincpu(M68000(config, "sega32x_maincpu", 0));
 	sega32x_maincpu.set_disable();
 
 	TIMER(config, "sega32x_scanline_timer", 0);
-
-	PALETTE(config, "sega32x_palette").set_entries(0xc0 * 2);
 
 	m_sega32x->subdevice<cpu_device>("32x_master_sh2")->set_disable();
 	m_sega32x->subdevice<cpu_device>("32x_slave_sh2")->set_disable();

--- a/src/mame/includes/megadriv.h
+++ b/src/mame/includes/megadriv.h
@@ -183,7 +183,7 @@ public:
 
 	DECLARE_DEVICE_IMAGE_LOAD_MEMBER( _32x_cart );
 
-	void _32x_scanline_callback(int x, uint32_t priority, uint16_t &lineptr);
+	void _32x_scanline_callback(int x, uint32_t priority, uint32_t &lineptr);
 	void _32x_interrupt_callback(int scanline, int irq6);
 	void _32x_scanline_helper_callback(int scanline);
 

--- a/src/mame/machine/mega32x.h
+++ b/src/mame/machine/mega32x.h
@@ -13,7 +13,7 @@
 #include "sound/dac.h"
 #include "emupal.h"
 
-class sega_32x_device : public device_t
+class sega_32x_device : public device_t, public device_palette_interface
 {
 public:
 	void pause_cpu();
@@ -29,9 +29,6 @@ public:
 		m_32x_hcount_compare_val = -1;
 		update_total_scanlines(mode3);
 	}
-
-	// configuration
-	template <typename T> void set_palette_tag(T &&tag) { m_palette.set_tag(std::forward<T>(tag)); }
 
 	DECLARE_READ32_MEMBER( _32x_sh2_master_4000_common_4002_r );
 	DECLARE_READ32_MEMBER( _32x_sh2_slave_4000_common_4002_r );
@@ -101,7 +98,7 @@ public:
 	SH2_DMA_FIFO_DATA_AVAILABLE_CB(_32x_fifo_available_callback);
 
 	void _32x_render_videobuffer_to_screenbuffer_helper(int scanline);
-	void _32x_render_videobuffer_to_screenbuffer(int x, uint32_t priority, uint16_t &lineptr);
+	void _32x_render_videobuffer_to_screenbuffer(int x, uint32_t priority, uint32_t &lineptr);
 	int sh2_master_pwmint_enable, sh2_slave_pwmint_enable;
 
 	void _32x_check_framebuffer_swap(bool enabled);
@@ -119,6 +116,9 @@ protected:
 	virtual void device_start() override;
 	virtual void device_reset() override;
 	virtual void device_add_mconfig(machine_config &config) override;
+
+	// device_palette_interface overrides
+	virtual uint32_t palette_entries() const override { return 32*32*32/**2*/; }
 
 	void update_total_scanlines(bool mode3) { m_total_scanlines = mode3 ? (m_base_total_scanlines * 2) : m_base_total_scanlines; }  // this gets set at each EOF
 
@@ -194,7 +194,6 @@ private:
 	std::unique_ptr<uint16_t[]> m_32x_dram1;
 	uint16_t *m_32x_display_dram, *m_32x_access_dram;
 	std::unique_ptr<uint16_t[]> m_32x_palette;
-	std::unique_ptr<uint16_t[]> m_32x_palette_lookup;
 
 	uint16_t m_fifo_block_a[4];
 	uint16_t m_fifo_block_b[4];
@@ -204,8 +203,6 @@ private:
 	int m_current_fifo_read_pos;
 	int m_fifo_block_a_full;
 	int m_fifo_block_b_full;
-
-	required_device<palette_device> m_palette;
 };
 
 

--- a/src/mame/machine/megadriv.cpp
+++ b/src/mame/machine/megadriv.cpp
@@ -752,17 +752,16 @@ uint32_t md_base_state::screen_update_megadriv(screen_device &screen, bitmap_rgb
 	for (int y = cliprect.min_y; y <= cliprect.max_y; y++)
 	{
 		uint32_t* desty = &bitmap.pix32(y, 0);
-		uint16_t* srcy;
+		uint32_t* srcy;
 
 		if (!m_vdp->m_use_alt_timing)
-			srcy = &m_vdp->m_render_bitmap->pix(y, 0);
+			srcy = &m_vdp->m_render_bitmap->pix32(y, 0);
 		else
 			srcy = m_vdp->m_render_line.get();
 
 		for (int x = cliprect.min_x; x <= cliprect.max_x; x++)
 		{
-			uint16_t src = srcy[x];
-			desty[x] = rgb_t(pal5bit(src >> 10), pal5bit(src >> 5), pal5bit(src >> 0));
+			desty[x] = srcy[x];
 		}
 	}
 


### PR DESCRIPTION
315_5124.cpp : Use color lookup and correct color levels for 315_5313, Add notes
315_5313.cpp : Use color lookup, Convert bitmap drawing function into bitmap_rgb32, Reduce unused, Fix save pointers, Fix external palette handlers, Implement 3 bit color mode
mega32x.cpp : Use color lookup, Reduce unuseds, Add device_palette_interface