### PR TITLE
Autofire plugin: Save/load fixes

### DIFF
--- a/plugins/autofire/autofire_menu.lua
+++ b/plugins/autofire/autofire_menu.lua
@@ -265,6 +265,14 @@ local function handle_button_menu(index, event)
 	return false
 end
 
+function lib:init_menu(buttons)
+	header_height = 0
+	content_height = 0
+	menu_stack = { MENU_TYPES.MAIN }
+	current_button = {}
+	inputs = {}
+end
+
 function lib:populate_menu(buttons)
 	local current_menu = menu_stack[#menu_stack]
 	if current_menu == MENU_TYPES.MAIN then

--- a/plugins/autofire/autofire_save.lua
+++ b/plugins/autofire/autofire_save.lua
@@ -1,7 +1,9 @@
 local lib = {}
 
+local plugin_path = ''
+
 local function get_settings_path()
-	return lfs.env_replace(manager:machine():options().entries.pluginspath:value():match('([^;]+)')) .. '/autofire/cfg/'
+	return plugin_path .. '/cfg/'
 end
 
 local function get_settings_filename()
@@ -43,6 +45,10 @@ local function serialize_settings(button_list)
 		settings[#settings + 1] = setting
 	end
 	return settings
+end
+
+function lib:set_plugin_path(path)
+	plugin_path = path
 end
 
 function lib:load_settings()

--- a/plugins/autofire/init.lua
+++ b/plugins/autofire/init.lua
@@ -21,6 +21,8 @@ function autofire.startplugin()
 	--   'counter' - position in autofire cycle
 	local buttons = {}
 
+	local current_rom = nil
+
 	local function process_button(button)
 		local pressed = manager:machine():input():code_pressed(button.key)
 		if pressed then
@@ -54,10 +56,26 @@ function autofire.startplugin()
 		end
 	end
 
+	local function reinit_buttons()
+		for i, button in ipairs(buttons) do
+			button.counter = 0
+			button.button = manager:machine():ioport().ports[button.port].fields[button.field]
+		end
+	end
+
 	local function load_settings()
-		local loader = require('autofire/autofire_save')
-		if loader then
-			buttons = loader:load_settings()
+		if current_rom == emu.romname() then
+			reinit_buttons()
+		else
+			local loader = require('autofire/autofire_save')
+			if loader then
+				buttons = loader:load_settings()
+			end
+		end
+		current_rom = emu.romname()
+		local menu_handler = require('autofire/autofire_menu')
+		if menu_handler then
+			menu_handler:init_menu(buttons)
 		end
 	end
 

--- a/plugins/autofire/init.lua
+++ b/plugins/autofire/init.lua
@@ -9,6 +9,13 @@ exports.author = { name = 'Jack Li' }
 
 local autofire = exports
 
+function autofire.set_folder(path)
+	local loader = require('autofire/autofire_save')
+	if loader then
+		loader:set_plugin_path(path)
+	end
+end
+
 function autofire.startplugin()
 
 	-- List of autofire buttons, each being a table with keys:

--- a/plugins/autofire/init.lua
+++ b/plugins/autofire/init.lua
@@ -2,7 +2,7 @@
 -- copyright-holders:Jack Li
 local exports = {}
 exports.name = 'autofire'
-exports.version = '0.0.1'
+exports.version = '0.0.2'
 exports.description = 'Autofire plugin'
 exports.license = 'The BSD 3-Clause License'
 exports.author = { name = 'Jack Li' }

--- a/plugins/autofire/plugin.json
+++ b/plugins/autofire/plugin.json
@@ -2,7 +2,7 @@
   "plugin": {
 	"name": "autofire",
 	"description": "Autofire plugin",
-	"version": "0.0.1",
+	"version": "0.0.2",
 	"author": "Jack Li",
 	"type": "plugin",
 	"start": "false"


### PR DESCRIPTION
This fixes a bug with saving/loading autofire settings, where soft-resetting the game would cause the settings to be lost due to their being reloaded from the settings file.

This also fixes a crash that could happen by hard-resetting a game in the middle of editing/adding an autofire button. The menu state would not be cleaned up, and accessing the old ioport_field references would cause MAME to crash.

I also replaced the get_settings_path implementation that reads the plugins path option and concatenates "/autofire/cfg/" with one that implements "set_folder" to get the plugin's directory, because I just learned that that exists.