### PR TITLE
jaguar.cpp : Updates

### DIFF
--- a/src/mame/drivers/jaguar.cpp
+++ b/src/mame/drivers/jaguar.cpp
@@ -1382,7 +1382,7 @@ void jaguar_state::m68020_map(address_map &map)
 	map(0xa30000, 0xa30003).w("watchdog", FUNC(watchdog_timer_device::reset32_w));
 	map(0xa40000, 0xa40003).w(FUNC(jaguar_state::eeprom_enable_w));
 	map(0xb70000, 0xb70003).rw(FUNC(jaguar_state::misc_control_r), FUNC(jaguar_state::misc_control_w));
-	map(0xc00000, 0xdfffff).bankr("mainsndbank");
+//	map(0xc00000, 0xdfffff).bankr("mainsndbank");
 	map(0xe00030, 0xe0003f).rw(m_ide, FUNC(vt83c461_device::config_r), FUNC(vt83c461_device::config_w));
 	map(0xe001f0, 0xe001f7).rw(m_ide, FUNC(vt83c461_device::cs0_r), FUNC(vt83c461_device::cs0_w));
 	map(0xe003f0, 0xe003f7).rw(m_ide, FUNC(vt83c461_device::cs1_r), FUNC(vt83c461_device::cs1_w));
@@ -1394,7 +1394,7 @@ void jaguar_state::m68020_map(address_map &map)
 	map(0xf10000, 0xf103ff).rw(FUNC(jaguar_state::jerry_regs_r), FUNC(jaguar_state::jerry_regs_w));
 	map(0xf16000, 0xf1600b).r(FUNC(jaguar_state::cojag_gun_input_r)); // GPI02
 	map(0xf17000, 0xf17003).lr16("f17000", [this]() { return uint16_t(m_system->read()); }); // GPI03
-//  AM_RANGE(0xf17800, 0xf17803) AM_WRITE(latch_w)          // GPI04
+//  map(0xf17800, 0xf17803).w(FUNC(jaguar_state::(latch_w));          // GPI04
 	map(0xf17c00, 0xf17c03).portr("P1_P2");      // GPI05
 	map(0xf1a100, 0xf1a13f).rw(FUNC(jaguar_state::dspctrl_r), FUNC(jaguar_state::dspctrl_w));
 	map(0xf1a140, 0xf1a17f).rw(FUNC(jaguar_state::serial_r), FUNC(jaguar_state::serial_w));

--- a/src/mame/video/jaguar.cpp
+++ b/src/mame/video/jaguar.cpp
@@ -547,7 +547,7 @@ WRITE32_MEMBER( jaguar_state::blitter_w )
 		m_blitter_status = 0;
 		int inner_count = m_blitter_regs[B_COUNT] & 0xffff;
 		int outer_count = m_blitter_regs[B_COUNT] >> 16;
-		timer_set(attotime::from_ticks(inner_count * outer_count, JAGUAR_CLOCK), TID_BLITTER_DONE);
+		timer_set(attotime::from_ticks(inner_count * outer_count, m_gpu->clock()), TID_BLITTER_DONE);
 		blitter_run();
 	}
 
@@ -611,7 +611,7 @@ WRITE16_MEMBER( jaguar_state::tom_regs_w )
 			case PIT1:
 				if (m_gpu_regs[PIT0] && m_gpu_regs[PIT0] != 0xffff) //FIXME: avoid too much small timers for now
 				{
-					sample_period = attotime::from_ticks((1+m_gpu_regs[PIT0]) * (1+m_gpu_regs[PIT1]), JAGUAR_CLOCK/2);
+					sample_period = attotime::from_ticks((1+m_gpu_regs[PIT0]) * (1+m_gpu_regs[PIT1]), m_gpu->clock()/2);
 					timer_set(sample_period, TID_PIT);
 				}
 				break;
@@ -724,7 +724,7 @@ void jaguar_state::device_timer(emu_timer &timer, device_timer_id id, int param,
 			}
 			if (m_gpu_regs[PIT0] != 0)
 			{
-				attotime sample_period = attotime::from_ticks((1+m_gpu_regs[PIT0]) * (1+m_gpu_regs[PIT1]), JAGUAR_CLOCK/2);
+				attotime sample_period = attotime::from_ticks((1+m_gpu_regs[PIT0]) * (1+m_gpu_regs[PIT1]), m_gpu->clock()/2);
 				timer_set(sample_period, TID_PIT);
 			}
 			break;


### PR DESCRIPTION
Correct gpu timer rate related to gpu clock, Fix notes, Fix crash cause in 68ec020 cpu games (all 68ec020 based games are HDD based, no bankswitched ROMs)