### PR TITLE
 New WORKING machines 

### DIFF
--- a/src/mame/drivers/nes_vt.cpp
+++ b/src/mame/drivers/nes_vt.cpp
@@ -1824,16 +1824,16 @@ CONS( 200?, vdogdeme,  0,  0,  nes_vt,    nes_vt, nes_vt_state, empty_init, "VRT
 CONS( 200?, vdogdemo,  0,  0,  nes_vt,    nes_vt, nes_vt_state, empty_init, "VRT", "V-Dog (prototype)", MACHINE_NOT_WORKING )
 
 // Bundled as "VT03 Demo" on the V.R. Technology VT SDK
-CONS( 200?, pinkjelly, 0,  0,  nes_vt,    nes_vt, nes_vt_state, empty_init, "VRT / Simmer Technology Co., Ltd.", "Pink Jelly", MACHINE_IMPERFECT_GRAPHICS )
+CONS( 200?, pinkjelly, 0,  0,  nes_vt,    nes_vt, nes_vt_state, empty_init, "VRT / Simmer Technology Co., Ltd.", "VRT VT SDK 'Pink Jelly' (VT03 Demo)", MACHINE_IMPERFECT_GRAPHICS )
 
 // Bundled as "C-Compiler Demo Program 2" on the V.R. Technology VT SDK
-CONS( 200?, vtpinball, 0,  0,  nes_vt,    nes_vt, nes_vt_state, empty_init, "VRT / OJ-Jungle", "Pinball", MACHINE_NOT_WORKING )
+CONS( 200?, vtpinball, 0,  0,  nes_vt,    nes_vt, nes_vt_state, empty_init, "VRT / OJ-Jungle", "VRT VT SDK 'Pinball' (C-Compiler Demo Program 2)", MACHINE_NOT_WORKING )
 
 // Bundled as "Sound Generator FMDemo" on the V.R. Technology VT SDK
-CONS( 200?, vtsndtest, 0,  0,  nes_vt,    nes_vt, nes_vt_state, empty_init, "VRT", "VT03 Sound Test", MACHINE_IMPERFECT_CONTROLS )
+CONS( 200?, vtsndtest, 0,  0,  nes_vt,    nes_vt, nes_vt_state, empty_init, "VRT", "VRT VT SDK 'VT03 Sound Test' (Sound Generator FMDemo)", MACHINE_IMPERFECT_CONTROLS )
 
 // Bundled as "Demo for VT03 Pic32" on the V.R. Technology VT SDK
-CONS( 200?, vtboxing,     0,  0,  nes_vt, nes_vt, nes_vt_state, empty_init, "VRT", "Boxing", MACHINE_NOT_WORKING )
+CONS( 200?, vtboxing,     0,  0,  nes_vt, nes_vt, nes_vt_state, empty_init, "VRT", "VRT VT SDK 'Boxing' (Demo for VT03 Pic32)", MACHINE_NOT_WORKING )
 
 // should be VT03 based
 // for testing 'Shark', 'Octopus', 'Harbor', and 'Earth Fighter' use the extended colour modes, other games just seem to use standard NES modes

--- a/src/mame/drivers/nes_vt.cpp
+++ b/src/mame/drivers/nes_vt.cpp
@@ -1526,6 +1526,26 @@ ROM_START( vdogdemo )
 	ROM_LOAD( "rom.bin", 0x00000, 0x80000, CRC(054af705) SHA1(e730aeaa94b9cc28aa8b512a5bf411ec45226831) )
 ROM_END
 
+ROM_START( pinkjelly )
+	ROM_REGION( 0x200000, "mainrom", 0 )
+	ROM_LOAD( "seesaw.bin", 0x00000, 0x200000, CRC(67b5a079) SHA1(36ebfd64809af072b73acfa3a426b57017851bf4) )
+ROM_END
+
+ROM_START( vtpinball )
+	ROM_REGION( 0x80000, "mainrom", 0 )
+	ROM_LOAD( "rom.bin", 0x00000, 0x80000, CRC(62e52c23) SHA1(b83b82c928b9fe82abfaa915196322153787c8ce) )
+ROM_END
+
+ROM_START( vtsndtest )
+	ROM_REGION( 0x80000, "mainrom", 0 )
+	ROM_LOAD( "rom.bin", 0x00000, 0x80000, CRC(ddc2bc9c) SHA1(fb9209c62d1496ba7fe379e8a078cabd48cccd9b) )
+ROM_END
+
+ROM_START( vtboxing )
+	ROM_REGION( 0x80000, "mainrom", 0 )
+	ROM_LOAD( "rom.bin", 0x00000, 0x80000, CRC(c115b1af) SHA1(82106e1c11c3279c5d8731c112f713fa3f290125) )
+ROM_END
+
 ROM_START( mc_dgear )
 	ROM_REGION( 0x400000, "mainrom", 0 )
 	ROM_LOAD( "dreamgear 75-in-1.prg", 0x00000, 0x400000, CRC(9aabcb8f) SHA1(aa9446b7777fa64503871225fcaf2a17aafd9af1) )
@@ -1802,6 +1822,18 @@ CONS( 200?, vdogdeme,  0,  0,  nes_vt,    nes_vt, nes_vt_state, empty_init, "VRT
 
 // this is glitchy even in other emulators, might just be entirely unfinished, it selects banks but they don't contain the required gfx?
 CONS( 200?, vdogdemo,  0,  0,  nes_vt,    nes_vt, nes_vt_state, empty_init, "VRT", "V-Dog (prototype)", MACHINE_NOT_WORKING )
+
+// Bundled as "VT03 Demo" on the V.R. Technology VT SDK
+CONS( 200?, pinkjelly, 0,  0,  nes_vt,    nes_vt, nes_vt_state, empty_init, "VRT / Simmer Technology Co., Ltd.", "Pink Jelly", MACHINE_IMPERFECT_GRAPHICS )
+
+// Bundled as "C-Compiler Demo Program 2" on the V.R. Technology VT SDK
+CONS( 200?, vtpinball, 0,  0,  nes_vt,    nes_vt, nes_vt_state, empty_init, "VRT / OJ-Jungle", "Pinball", MACHINE_NOT_WORKING )
+
+// Bundled as "Sound Generator FMDemo" on the V.R. Technology VT SDK
+CONS( 200?, vtsndtest, 0,  0,  nes_vt,    nes_vt, nes_vt_state, empty_init, "VRT", "VT03 Sound Test", MACHINE_IMPERFECT_CONTROLS )
+
+// Bundled as "Demo for VT03 Pic32" on the V.R. Technology VT SDK
+CONS( 200?, vtboxing,     0,  0,  nes_vt, nes_vt, nes_vt_state, empty_init, "VRT", "Boxing", MACHINE_NOT_WORKING )
 
 // should be VT03 based
 // for testing 'Shark', 'Octopus', 'Harbor', and 'Earth Fighter' use the extended colour modes, other games just seem to use standard NES modes

--- a/src/mame/mame.lst
+++ b/src/mame/mame.lst
@@ -30542,6 +30542,10 @@ nespal                          // Nintendo Entertainment System PAL
 @source:nes_vt.cpp
 vdogdeme
 vdogdemo
+pinkjelly                       // From V.R. Technology VT SDK
+vtpinball                       // From V.R. Technology VT SDK
+vtsndtest                       // From V.R. Technology VT SDK
+vtboxing                        // From V.R. Technology VT SDK
 mc_dgear
 dgun2500
 dgun2561


### PR DESCRIPTION
---------------------------------------------------------
VRT VT SDK 'Pink Jelly' (VT03 Demo) [ClawGrip]
VRT VT SDK 'VT03 Sound Test' (Sound Generator FMDemo) [ClawGrip]

New NOT_WORKING machines
---------------------------------------------------------
VRT VT SDK 'Pinball' (C-Compiler Demo Program 2) [ClawGrip]
VRT VT SDK 'Boxing' (Demo for VT03 Pic32) [ClawGrip]

(nw) All those programs came from the official VT SDK from V.R. Technology. I'm not sure about the flags, as being demo programs I'm not sure what they should really do or look like. At least "Pink Jelly" looks better on the emulator bundled with the VRT VT SDK than on MAME.