### PR TITLE
Change autofire config directory to homepath

### DIFF
--- a/plugins/autofire/autofire_save.lua
+++ b/plugins/autofire/autofire_save.lua
@@ -1,7 +1,7 @@
 local lib = {}
 
 local function get_settings_path()
-	return lfs.env_replace(manager:machine():options().entries.pluginspath:value():match('([^;]+)')) .. '/autofire/cfg/'
+	return lfs.env_replace(manager:machine():options().entries.homepath:value():match('([^;]+)')) .. '/autofire/'
 end
 
 local function get_settings_filename()

--- a/plugins/autofire/autofire_save.lua
+++ b/plugins/autofire/autofire_save.lua
@@ -1,9 +1,7 @@
 local lib = {}
 
-local plugin_path = ''
-
 local function get_settings_path()
-	return plugin_path .. '/cfg/'
+	return lfs.env_replace(manager:machine():options().entries.pluginspath:value():match('([^;]+)')) .. '/autofire/cfg/'
 end
 
 local function get_settings_filename()
@@ -45,10 +43,6 @@ local function serialize_settings(button_list)
 		settings[#settings + 1] = setting
 	end
 	return settings
-end
-
-function lib:set_plugin_path(path)
-	plugin_path = path
 end
 
 function lib:load_settings()

--- a/plugins/autofire/init.lua
+++ b/plugins/autofire/init.lua
@@ -9,13 +9,6 @@ exports.author = { name = 'Jack Li' }
 
 local autofire = exports
 
-function autofire.set_folder(path)
-	local loader = require('autofire/autofire_save')
-	if loader then
-		loader:set_plugin_path(path)
-	end
-end
-
 function autofire.startplugin()
 
 	-- List of autofire buttons, each being a table with keys:

--- a/plugins/autofire/init.lua
+++ b/plugins/autofire/init.lua
@@ -2,7 +2,7 @@
 -- copyright-holders:Jack Li
 local exports = {}
 exports.name = 'autofire'
-exports.version = '0.0.2'
+exports.version = '0.0.3'
 exports.description = 'Autofire plugin'
 exports.license = 'The BSD 3-Clause License'
 exports.author = { name = 'Jack Li' }

--- a/plugins/autofire/plugin.json
+++ b/plugins/autofire/plugin.json
@@ -2,7 +2,7 @@
   "plugin": {
 	"name": "autofire",
 	"description": "Autofire plugin",
-	"version": "0.0.2",
+	"version": "0.0.3",
 	"author": "Jack Li",
 	"type": "plugin",
 	"start": "false"


### PR DESCRIPTION
According to feedback on #5093 and [documentation that I missed](https://docs.mamedev.org/commandline/commandline-all.html#core-search-path-options), plugins are expected to save data to homepath rather than pluginspath.