### PR TITLE
Fix regressions in k573dio/k573fpga/mas3507d

### DIFF
--- a/src/devices/sound/mas3507d.cpp
+++ b/src/devices/sound/mas3507d.cpp
@@ -396,6 +396,10 @@ void mas3507d_device::sound_stream_update(sound_stream &stream, stream_sample_t 
 	int pos = 0;
 
 	if(!playback_enabled) {
+		for(int i=pos; i != samples; i++) {
+			outputs[0][i] = 0;
+			outputs[1][i] = 0;
+		}
 		return;
 	}
 

--- a/src/devices/sound/mas3507d.cpp
+++ b/src/devices/sound/mas3507d.cpp
@@ -41,10 +41,7 @@ void mas3507d_device::device_reset()
 	i2c_bus_address = UNKNOWN;
 	i2c_bus_curbit = -1;
 	i2c_bus_curval = 0;
-	total_sample_count = 0;
-	total_samples_decoded = 0;
-	last_samples = 0;
-	playback_enabled = false;
+	set_playback_enabled(false);
 }
 
 void mas3507d_device::i2c_scl_w(bool line)

--- a/src/devices/sound/mas3507d.cpp
+++ b/src/devices/sound/mas3507d.cpp
@@ -30,7 +30,6 @@ void mas3507d_device::device_start()
 {
 	current_rate = 44100;
 	stream = stream_alloc(0, 2, current_rate);
-	mp3dec_init(&mp3_dec);
 	cb_sample.resolve();
 }
 
@@ -326,7 +325,7 @@ void mas3507d_device::run_program(uint32_t adr)
 
 void mas3507d_device::fill_buffer()
 {
-	while(mp3_count < mp3data.size()) {
+	while(mp3_count + 2 < mp3data.size()) {
 		u16 v = cb_sample();
 		mp3data[mp3_count++] = v >> 8;
 		mp3data[mp3_count++] = v;

--- a/src/devices/sound/mas3507d.cpp
+++ b/src/devices/sound/mas3507d.cpp
@@ -43,6 +43,7 @@ void mas3507d_device::device_reset()
 	i2c_bus_curbit = -1;
 	i2c_bus_curval = 0;
 	total_sample_count = 0;
+	playback_enabled = false;
 }
 
 void mas3507d_device::i2c_scl_w(bool line)
@@ -343,10 +344,7 @@ void mas3507d_device::fill_buffer()
 	std::copy(mp3data.begin() + mp3_info.frame_bytes, mp3data.end(), mp3data.begin());
 	mp3_count -= mp3_info.frame_bytes;
 
-	if(mp3_info.channels == 1)
-		sample_count = scount;
-	else
-		sample_count = scount;
+	sample_count = scount;
 
 	if(mp3_info.hz != current_rate) {
 		current_rate = mp3_info.hz;
@@ -394,6 +392,11 @@ void mas3507d_device::append_buffer(stream_sample_t **outputs, int &pos, int sco
 void mas3507d_device::sound_stream_update(sound_stream &stream, stream_sample_t **inputs, stream_sample_t **outputs, int samples)
 {
 	int pos = 0;
+
+	if(!playback_enabled) {
+		return;
+	}
+
 	total_sample_count += samples;
 	append_buffer(outputs, pos, samples);
 	for(;;) {

--- a/src/devices/sound/mas3507d.cpp
+++ b/src/devices/sound/mas3507d.cpp
@@ -285,6 +285,7 @@ void mas3507d_device::mem_write(int bank, uint32_t adr, uint32_t val)
 	case 0x0032f: logerror("MAS3507D: OutputConfig = %05x\n", val); break;
 	case 0x107f8:
 		logerror("MAS3507D: left->left   gain = %05x (%d dB, %f%%)\n", val, gain_to_db(val), gain_to_percentage(val));
+		stream->set_output_gain(0, gain_to_percentage(val));
 		break;
 	case 0x107f9:
 		logerror("MAS3507D: left->right  gain = %05x (%d dB, %f%%)\n", val, gain_to_db(val), gain_to_percentage(val));
@@ -294,6 +295,7 @@ void mas3507d_device::mem_write(int bank, uint32_t adr, uint32_t val)
 		break;
 	case 0x107fb:
 		logerror("MAS3507D: right->right gain = %05x (%d dB, %f%%)\n", val, gain_to_db(val), gain_to_percentage(val));
+		stream->set_output_gain(1, gain_to_percentage(val));
 		break;
 	default: logerror("MAS3507D: %d:%04x = %05x\n", bank, adr, val); break;
 	}

--- a/src/devices/sound/mas3507d.cpp
+++ b/src/devices/sound/mas3507d.cpp
@@ -43,6 +43,8 @@ void mas3507d_device::device_reset()
 	i2c_bus_curbit = -1;
 	i2c_bus_curval = 0;
 	total_sample_count = 0;
+	total_samples_decoded = 0;
+	last_samples = 0;
 	playback_enabled = false;
 }
 
@@ -352,6 +354,8 @@ void mas3507d_device::fill_buffer()
 		current_rate = mp3_info.hz;
 		stream->set_sample_rate(current_rate);
 	}
+
+	total_samples_decoded += sample_count;
 }
 
 void mas3507d_device::append_buffer(stream_sample_t **outputs, int &pos, int scount)
@@ -403,7 +407,8 @@ void mas3507d_device::sound_stream_update(sound_stream &stream, stream_sample_t 
 		return;
 	}
 
-	total_sample_count += samples;
+	total_sample_count += last_samples;
+	last_samples = samples;
 	append_buffer(outputs, pos, samples);
 	for(;;) {
 		if(pos == samples)

--- a/src/devices/sound/mas3507d.h
+++ b/src/devices/sound/mas3507d.h
@@ -22,24 +22,7 @@ public:
 	void i2c_scl_w(bool line);
 	void i2c_sda_w(bool line);
 
-	void reset_sample_count() { total_sample_count = 0; }
-	u32 get_sample_count() const { return total_sample_count; }
-	u32 get_samples_decoded() const { return total_samples_decoded; }
-	bool is_playing() { return playback_enabled && total_sample_count <= total_samples_decoded; }
-
-	void set_playback_enabled(bool enabled) {
-		playback_enabled = enabled;
-		reset_sample_count();
-
-		memset(mp3data.data(), 0, mp3data.size());
-		memset(samples.data(), 0, samples.size());
-		mp3_count = 0;
-		total_samples_decoded = 0;
-		last_samples = 0;
-		sample_count = 0;
-
-		mp3dec_init(&mp3_dec);
-	}
+	u32 get_frame_count() const { return total_frame_count; }
 
 protected:
 	virtual void device_start() override;
@@ -58,8 +41,8 @@ private:
 	int i2c_bus_curbit;
 	uint8_t i2c_bus_curval;
 	int mp3_count, sample_count, current_rate;
-	u32 total_sample_count, total_samples_decoded, last_samples;
-	bool playback_enabled;
+	u32 total_frame_count;
+	bool playback_enabled, playback_waiting;
 
 	mp3dec_t mp3_dec;
 	mp3dec_frame_info_t mp3_info;

--- a/src/devices/sound/mas3507d.h
+++ b/src/devices/sound/mas3507d.h
@@ -25,7 +25,13 @@ public:
 	void reset_sample_count() { total_sample_count = 0; }
 	u32 get_sample_count() const { return total_sample_count; }
 
-	void set_playback_enabled(bool enabled) { playback_enabled = enabled; }
+	void set_playback_enabled(bool enabled) {
+		playback_enabled = enabled;
+		reset_sample_count();
+
+		memset(mp3data.data(), 0, mp3data.size());
+		mp3_count = 0;
+	}
 
 protected:
 	virtual void device_start() override;
@@ -56,7 +62,6 @@ private:
 	bool i2c_device_got_address(uint8_t address);
 	void i2c_device_got_byte(uint8_t byte);
 	void i2c_device_got_stop();
-
 
 	enum { UNDEFINED, CONTROL, DATA_READ, DATA_WRITE, BAD } i2c_subdest;
 	enum { CMD_BAD, CMD_RUN, CMD_READ_CTRL, CMD_WRITE_REG, CMD_WRITE_MEM, CMD_READ_REG, CMD_READ_MEM } i2c_command;

--- a/src/devices/sound/mas3507d.h
+++ b/src/devices/sound/mas3507d.h
@@ -22,14 +22,17 @@ public:
 	void i2c_scl_w(bool line);
 	void i2c_sda_w(bool line);
 
-	void reset_sample_count() { total_sample_count = 0; }
+	void reset_sample_count() { total_sample_count = total_samples_decoded = last_samples = 0; }
 	u32 get_sample_count() const { return total_sample_count; }
+	u32 get_samples_decoded() const { return total_samples_decoded; }
+	bool is_playing() { return playback_enabled && total_sample_count <= total_samples_decoded; }
 
 	void set_playback_enabled(bool enabled) {
 		playback_enabled = enabled;
 		reset_sample_count();
 
 		memset(mp3data.data(), 0, mp3data.size());
+		memset(samples.data(), 0, samples.size());
 		mp3_count = 0;
 	}
 
@@ -50,7 +53,7 @@ private:
 	int i2c_bus_curbit;
 	uint8_t i2c_bus_curval;
 	int mp3_count, sample_count, current_rate;
-	u32 total_sample_count;
+	u32 total_sample_count, total_samples_decoded, last_samples;
 	bool playback_enabled;
 
 	mp3dec_t mp3_dec;

--- a/src/devices/sound/mas3507d.h
+++ b/src/devices/sound/mas3507d.h
@@ -22,7 +22,7 @@ public:
 	void i2c_scl_w(bool line);
 	void i2c_sda_w(bool line);
 
-	void reset_sample_count() { total_sample_count = total_samples_decoded = last_samples = 0; }
+	void reset_sample_count() { total_sample_count = total_samples_decoded = last_samples = sample_count = 0; }
 	u32 get_sample_count() const { return total_sample_count; }
 	u32 get_samples_decoded() const { return total_samples_decoded; }
 	bool is_playing() { return playback_enabled && total_sample_count <= total_samples_decoded; }

--- a/src/devices/sound/mas3507d.h
+++ b/src/devices/sound/mas3507d.h
@@ -25,6 +25,8 @@ public:
 	void reset_sample_count() { total_sample_count = 0; }
 	u32 get_sample_count() const { return total_sample_count; }
 
+	void set_playback_enabled(bool enabled) { playback_enabled = enabled; }
+
 protected:
 	virtual void device_start() override;
 	virtual void device_reset() override;
@@ -43,6 +45,7 @@ private:
 	uint8_t i2c_bus_curval;
 	int mp3_count, sample_count, current_rate;
 	u32 total_sample_count;
+	bool playback_enabled;
 
 	mp3dec_t mp3_dec;
 	mp3dec_frame_info_t mp3_info;

--- a/src/devices/sound/mas3507d.h
+++ b/src/devices/sound/mas3507d.h
@@ -22,7 +22,7 @@ public:
 	void i2c_scl_w(bool line);
 	void i2c_sda_w(bool line);
 
-	void reset_sample_count() { total_sample_count = total_samples_decoded = last_samples = sample_count = 0; }
+	void reset_sample_count() { total_sample_count = 0; }
 	u32 get_sample_count() const { return total_sample_count; }
 	u32 get_samples_decoded() const { return total_samples_decoded; }
 	bool is_playing() { return playback_enabled && total_sample_count <= total_samples_decoded; }
@@ -34,6 +34,9 @@ public:
 		memset(mp3data.data(), 0, mp3data.size());
 		memset(samples.data(), 0, samples.size());
 		mp3_count = 0;
+		total_samples_decoded = 0;
+		last_samples = 0;
+		sample_count = 0;
 
 		mp3dec_init(&mp3_dec);
 	}

--- a/src/devices/sound/mas3507d.h
+++ b/src/devices/sound/mas3507d.h
@@ -34,6 +34,8 @@ public:
 		memset(mp3data.data(), 0, mp3data.size());
 		memset(samples.data(), 0, samples.size());
 		mp3_count = 0;
+
+		mp3dec_init(&mp3_dec);
 	}
 
 protected:
@@ -47,7 +49,7 @@ private:
 	enum { IDLE, STARTED, NAK, ACK, ACK2 } i2c_bus_state;
 	enum { UNKNOWN, VALIDATED, WRONG } i2c_bus_address;
 
-	std::array<u8, 8000> mp3data;
+	std::array<u8, 0xe00> mp3data;
 	std::array<mp3d_sample_t, MINIMP3_MAX_SAMPLES_PER_FRAME> samples;
 	bool i2c_scli, i2c_sclo, i2c_sdai, i2c_sdao;
 	int i2c_bus_curbit;

--- a/src/mame/machine/k573dio.cpp
+++ b/src/mame/machine/k573dio.cpp
@@ -218,7 +218,6 @@ WRITE16_MEMBER(k573dio_device::mpeg_start_adr_low_w)
 	k573fpga->set_mp3_cur_adr((k573fpga->get_mp3_cur_adr() & 0xffff0000) | data); // low
 	if(is_ddrsbm_fpga)
 		k573fpga->set_crypto_key3(0);
-	mas3507d->reset_sample_count();
 }
 
 WRITE16_MEMBER(k573dio_device::mpeg_end_adr_high_w)
@@ -266,6 +265,16 @@ READ16_MEMBER(k573dio_device::mpeg_ctrl_r)
 WRITE16_MEMBER(k573dio_device::mpeg_ctrl_w)
 {
 	k573fpga->set_mpeg_ctrl(data);
+
+	if (data == 0xe000) {
+		// Start playback flag
+		mas3507d->set_playback_enabled(true);
+		mas3507d->reset_sample_count();
+	} else if (data == 0xa000) {
+		// End playback flag
+		mas3507d->set_playback_enabled(false);
+		mas3507d->reset_sample_count();
+	}
 }
 
 WRITE16_MEMBER(k573dio_device::ram_write_adr_high_w)

--- a/src/mame/machine/k573dio.cpp
+++ b/src/mame/machine/k573dio.cpp
@@ -235,12 +235,14 @@ WRITE16_MEMBER(k573dio_device::mpeg_end_adr_low_w)
 
 READ16_MEMBER(k573dio_device::mpeg_key_1_r)
 {
-	return k573fpga->get_crypto_key1();
+	// Dance Dance Revolution Solo Bass Mix reads this key before starting songs
+	return crypto_key1;
 }
 
 WRITE16_MEMBER(k573dio_device::mpeg_key_1_w)
 {
 	logerror("FPGA MPEG key 1/3 %04x\n", data);
+	crypto_key1 = data;
 	k573fpga->set_crypto_key1(data);
 }
 

--- a/src/mame/machine/k573dio.cpp
+++ b/src/mame/machine/k573dio.cpp
@@ -286,38 +286,38 @@ WRITE16_MEMBER(k573dio_device::mpeg_ctrl_w)
 WRITE16_MEMBER(k573dio_device::ram_write_adr_high_w)
 {
 	// read and write address are shared
-	ram_adr = (ram_adr & 0x0000ffff) | (data << 16);
+	ram_adr = ((ram_adr & 0x0000ffff) | (data << 16)) & 0x1ffffff;
 }
 
 WRITE16_MEMBER(k573dio_device::ram_write_adr_low_w)
 {
 	// read and write address are shared
-	ram_adr = (ram_adr & 0xffff0000) | data;
+	ram_adr = ((ram_adr & 0xffff0000) | data) & 0x1ffffff;
 }
 
 READ16_MEMBER(k573dio_device::ram_r)
 {
-	uint16_t res = ram[ram_read_adr >> 1];
+	uint16_t res = ram[(ram_read_adr & 0x1ffffff) >> 1];
 	ram_read_adr += 2;
 	return res;
 }
 
 WRITE16_MEMBER(k573dio_device::ram_w)
 {
-	ram[ram_adr >> 1] = data;
+	ram[(ram_adr & 0x1ffffff) >> 1] = data;
 	ram_adr += 2;
 }
 
 WRITE16_MEMBER(k573dio_device::ram_read_adr_high_w)
 {
 	// read and write address are shared
-	ram_read_adr = (ram_read_adr & 0x0000ffff) | (data << 16);
+	ram_read_adr = ((ram_read_adr & 0x0000ffff) | (data << 16)) & 0x1ffffff;
 }
 
 WRITE16_MEMBER(k573dio_device::ram_read_adr_low_w)
 {
 	// read and write address are shared
-	ram_read_adr = (ram_read_adr & 0xffff0000) | data;
+	ram_read_adr = ((ram_read_adr & 0xffff0000) | data) & 0x1ffffff;
 }
 
 READ16_MEMBER(k573dio_device::mp3_playback_high_r)

--- a/src/mame/machine/k573dio.cpp
+++ b/src/mame/machine/k573dio.cpp
@@ -260,6 +260,11 @@ WRITE16_MEMBER(k573dio_device::mas_i2c_w)
 
 READ16_MEMBER(k573dio_device::mpeg_ctrl_r)
 {
+	if (k573fpga->get_mpeg_ctrl() == 0x1000 && !mas3507d->is_playing()) {
+		k573fpga->set_mpeg_ctrl(0xa000);
+		mas3507d->set_playback_enabled(false);
+	}
+
 	return k573fpga->get_mpeg_ctrl();
 }
 

--- a/src/mame/machine/k573dio.cpp
+++ b/src/mame/machine/k573dio.cpp
@@ -267,11 +267,9 @@ WRITE16_MEMBER(k573dio_device::mpeg_ctrl_w)
 	if (data == 0xe000) {
 		// Start playback flag
 		mas3507d->set_playback_enabled(true);
-		mas3507d->reset_sample_count();
 	} else if (data == 0xa000) {
 		// End playback flag
 		mas3507d->set_playback_enabled(false);
-		mas3507d->reset_sample_count();
 	}
 }
 

--- a/src/mame/machine/k573dio.cpp
+++ b/src/mame/machine/k573dio.cpp
@@ -216,6 +216,9 @@ WRITE16_MEMBER(k573dio_device::mpeg_start_adr_low_w)
 {
 	logerror("FPGA MPEG start address low %04x\n", data);
 	k573fpga->set_mp3_cur_adr((k573fpga->get_mp3_cur_adr() & 0xffff0000) | data); // low
+
+	if(is_ddrsbm_fpga)
+		k573fpga->set_crypto_key3(0);
 }
 
 WRITE16_MEMBER(k573dio_device::mpeg_end_adr_high_w)

--- a/src/mame/machine/k573dio.cpp
+++ b/src/mame/machine/k573dio.cpp
@@ -282,21 +282,21 @@ WRITE16_MEMBER(k573dio_device::ram_write_adr_low_w)
 
 READ16_MEMBER(k573dio_device::ram_r)
 {
-	uint16_t res = ram[(ram_read_adr & 0x7fffff) >> 1];
+	uint16_t res = ram[ram_read_adr >> 1];
 	ram_read_adr += 2;
 	return res;
 }
 
 WRITE16_MEMBER(k573dio_device::ram_w)
 {
-	ram[(ram_adr & 0x1ffffff) >> 1] = data;
+	ram[ram_adr >> 1] = data;
 	ram_adr += 2;
 }
 
 WRITE16_MEMBER(k573dio_device::ram_read_adr_high_w)
 {
 	// read and write address are shared
-	ram_read_adr = (ram_read_adr & 0x001fffff) | (data << 16);
+	ram_read_adr = (ram_read_adr & 0x0000ffff) | (data << 16);
 }
 
 WRITE16_MEMBER(k573dio_device::ram_read_adr_low_w)

--- a/src/mame/machine/k573dio.cpp
+++ b/src/mame/machine/k573dio.cpp
@@ -216,8 +216,6 @@ WRITE16_MEMBER(k573dio_device::mpeg_start_adr_low_w)
 {
 	logerror("FPGA MPEG start address low %04x\n", data);
 	k573fpga->set_mp3_cur_adr((k573fpga->get_mp3_cur_adr() & 0xffff0000) | data); // low
-	if(is_ddrsbm_fpga)
-		k573fpga->set_crypto_key3(0);
 }
 
 WRITE16_MEMBER(k573dio_device::mpeg_end_adr_high_w)

--- a/src/mame/machine/k573dio.h
+++ b/src/mame/machine/k573dio.h
@@ -43,10 +43,8 @@ public:
 	DECLARE_WRITE16_MEMBER(ram_w);
 	DECLARE_WRITE16_MEMBER(ram_read_adr_high_w);
 	DECLARE_WRITE16_MEMBER(ram_read_adr_low_w);
-	DECLARE_READ16_MEMBER(mp3_playback_high_r);
-	DECLARE_WRITE16_MEMBER(mp3_playback_high_w);
-	DECLARE_READ16_MEMBER(mp3_playback_low_r);
-	DECLARE_WRITE16_MEMBER(mp3_playback_low_w);
+	DECLARE_READ16_MEMBER(mp3_frame_count_high_r);
+	DECLARE_READ16_MEMBER(mp3_frame_count_low_r);
 	DECLARE_WRITE16_MEMBER(output_0_w);
 	DECLARE_WRITE16_MEMBER(output_1_w);
 	DECLARE_WRITE16_MEMBER(output_7_w);

--- a/src/mame/machine/k573dio.h
+++ b/src/mame/machine/k573dio.h
@@ -82,6 +82,7 @@ private:
 	void output(int offset, uint16_t data);
 
 	bool is_ddrsbm_fpga;
+	u16 crypto_key1;
 };
 
 DECLARE_DEVICE_TYPE(KONAMI_573_DIGITAL_IO_BOARD, k573dio_device)

--- a/src/mame/machine/k573fpga.cpp
+++ b/src/mame/machine/k573fpga.cpp
@@ -140,8 +140,9 @@ u16 k573fpga_device::decrypt_ddrsbm(u16 data)
 
 u16 k573fpga_device::get_decrypted()
 {
-	if(mp3_cur_adr >= mp3_end_adr || (mpeg_ctrl_flag & 0xe000) != 0xe000)
+	if(mp3_cur_adr >= mp3_end_adr || (mpeg_ctrl_flag & 0xe000) != 0xe000) {
 		return 0;
+	}
 
 	u16 src = ram[mp3_cur_adr >> 1];
 	u16 result = use_ddrsbm_fpga ? decrypt_ddrsbm(src) : decrypt_default(src);

--- a/src/mame/machine/k573fpga.cpp
+++ b/src/mame/machine/k573fpga.cpp
@@ -143,7 +143,7 @@ u16 k573fpga_device::get_decrypted()
 	if(mp3_cur_adr >= mp3_end_adr || (mpeg_ctrl_flag & 0xe000) != 0xe000)
 		return 0;
 
-	u16 src = ram[(mp3_cur_adr & 0x1ffffff) >> 1];
+	u16 src = ram[mp3_cur_adr >> 1];
 	u16 result = use_ddrsbm_fpga ? decrypt_ddrsbm(src) : decrypt_default(src);
 	mp3_cur_adr += 2;
 

--- a/src/mame/machine/k573fpga.h
+++ b/src/mame/machine/k573fpga.h
@@ -20,12 +20,10 @@ public:
 	void set_ram(u16 *v) { ram = v; }
 	u16 get_decrypted();
 
-	void set_crypto_key1(u16 v) { crypto_key1 = v; }
+	void set_crypto_key1(u16 v) { orig_crypto_key1 = crypto_key1 = v; }
 	void set_crypto_key2(u16 v) { crypto_key2 = v; }
 	void set_crypto_key3(u8 v) { crypto_key3 = v; }
-	u16 get_crypto_key1() const { return crypto_key1; }
-	u16 get_crypto_key2() const { return crypto_key2; }
-	u8 get_crypto_key3() const { return crypto_key3; }
+	u16 get_crypto_key1() const { return orig_crypto_key1; }
 
 	uint32_t get_mp3_cur_adr() { return mp3_cur_adr; }
 	void set_mp3_cur_adr(u32 v) { mp3_cur_adr = v; }
@@ -46,7 +44,7 @@ protected:
 private:
 	u16 *ram;
 
-	u16 crypto_key1, crypto_key2;
+	u16 orig_crypto_key1, crypto_key1, crypto_key2;
 	u8 crypto_key3;
 
 	u32 mp3_cur_adr, mp3_end_adr, mpeg_ctrl_flag;

--- a/src/mame/machine/k573fpga.h
+++ b/src/mame/machine/k573fpga.h
@@ -20,10 +20,9 @@ public:
 	void set_ram(u16 *v) { ram = v; }
 	u16 get_decrypted();
 
-	void set_crypto_key1(u16 v) { orig_crypto_key1 = crypto_key1 = v; }
+	void set_crypto_key1(u16 v) { crypto_key1 = v; }
 	void set_crypto_key2(u16 v) { crypto_key2 = v; }
 	void set_crypto_key3(u8 v) { crypto_key3 = v; }
-	u16 get_crypto_key1() const { return orig_crypto_key1; }
 
 	uint32_t get_mp3_cur_adr() { return mp3_cur_adr; }
 	void set_mp3_cur_adr(u32 v) { mp3_cur_adr = v; }
@@ -44,7 +43,7 @@ protected:
 private:
 	u16 *ram;
 
-	u16 orig_crypto_key1, crypto_key1, crypto_key2;
+	u16 crypto_key1, crypto_key2;
 	u8 crypto_key3;
 
 	u32 mp3_cur_adr, mp3_end_adr, mpeg_ctrl_flag;

--- a/src/mame/machine/k573fpga.h
+++ b/src/mame/machine/k573fpga.h
@@ -36,6 +36,8 @@ public:
 	u16 get_mpeg_ctrl();
 	void set_mpeg_ctrl(u16 data);
 
+	bool is_playing() { return (mpeg_ctrl_flag & 0xe000) == 0xe000 && mp3_cur_adr < mp3_end_adr; }
+
 protected:
 	virtual void device_start() override;
 	virtual void device_reset() override;


### PR DESCRIPTION
**Please don't merge until there has been a sufficient review done.**

This fixes most of the regressions from https://github.com/mamedev/mame/commit/c910c1cf0ab357df250aff10002547e52e896f76.

I will be leaving comments to explain why I made certain changes just to make sure we're on the same page and make it easier to give advice for a better way to write something. It might be easier to review on a per-commit basis since the commits are pretty self-contained.

~~The MP3 decoder still has heavy glitching problems but that's probably going to take the longest time to fix out of the regressions.~~

Update: All bugs that I had previously found, except one where you can briefly hear the previously played audio for less than a second between MP3 transitions, have been fixed now with the latest commits. (2019/06/02)