### PR TITLE
exedexes.cpp : Updates

### DIFF
--- a/src/mame/includes/exedexes.h
+++ b/src/mame/includes/exedexes.h
@@ -25,6 +25,7 @@ public:
 		m_nbg_yscroll(*this, "nbg_yscroll"),
 		m_nbg_xscroll(*this, "nbg_xscroll"),
 		m_bg_scroll(*this, "bg_scroll"),
+		m_tilerom(*this, "tilerom"),
 		m_maincpu(*this, "maincpu"),
 		m_gfxdecode(*this, "gfxdecode"),
 		m_palette(*this, "palette")
@@ -35,37 +36,38 @@ public:
 private:
 	/* memory pointers */
 	required_device<buffered_spriteram8_device> m_spriteram;
-	required_shared_ptr<uint8_t> m_videoram;
-	required_shared_ptr<uint8_t> m_colorram;
-	required_shared_ptr<uint8_t> m_nbg_yscroll;
-	required_shared_ptr<uint8_t> m_nbg_xscroll;
-	required_shared_ptr<uint8_t> m_bg_scroll;
+	required_shared_ptr<u8> m_videoram;
+	required_shared_ptr<u8> m_colorram;
+	required_shared_ptr<u8> m_nbg_yscroll;
+	required_shared_ptr<u8> m_nbg_xscroll;
+	required_shared_ptr<u8> m_bg_scroll;
+	required_region_ptr<u8> m_tilerom;
 
 	/* video-related */
-	tilemap_t        *m_bg_tilemap;
-	tilemap_t        *m_fg_tilemap;
-	tilemap_t        *m_tx_tilemap;
+	tilemap_t      *m_bg_tilemap;
+	tilemap_t      *m_fg_tilemap;
+	tilemap_t      *m_tx_tilemap;
 	int            m_chon;
 	int            m_objon;
 	int            m_sc1on;
 	int            m_sc2on;
 
-	DECLARE_WRITE8_MEMBER(exedexes_videoram_w);
-	DECLARE_WRITE8_MEMBER(exedexes_colorram_w);
-	DECLARE_WRITE8_MEMBER(exedexes_c804_w);
-	DECLARE_WRITE8_MEMBER(exedexes_gfxctrl_w);
+	void videoram_w(offs_t offset, u8 data);
+	void colorram_w(offs_t offset, u8 data);
+	void c804_w(u8 data);
+	void gfxctrl_w(u8 data);
 	TILE_GET_INFO_MEMBER(get_bg_tile_info);
 	TILE_GET_INFO_MEMBER(get_fg_tile_info);
 	TILE_GET_INFO_MEMBER(get_tx_tile_info);
-	TILEMAP_MAPPER_MEMBER(exedexes_bg_tilemap_scan);
-	TILEMAP_MAPPER_MEMBER(exedexes_fg_tilemap_scan);
+	TILEMAP_MAPPER_MEMBER(bg_tilemap_scan);
+	TILEMAP_MAPPER_MEMBER(fg_tilemap_scan);
 	virtual void machine_start() override;
 	virtual void machine_reset() override;
 	virtual void video_start() override;
 	void exedexes_palette(palette_device &palette) const;
-	uint32_t screen_update_exedexes(screen_device &screen, bitmap_ind16 &bitmap, const rectangle &cliprect);
-	TIMER_DEVICE_CALLBACK_MEMBER(exedexes_scanline);
-	void draw_sprites( bitmap_ind16 &bitmap, const rectangle &cliprect, int priority );
+	u32 screen_update(screen_device &screen, bitmap_ind16 &bitmap, const rectangle &cliprect);
+	TIMER_DEVICE_CALLBACK_MEMBER(scanline);
+	void draw_sprites(screen_device &screen, bitmap_ind16 &bitmap, const rectangle &cliprect);
 	required_device<cpu_device> m_maincpu;
 	required_device<gfxdecode_device> m_gfxdecode;
 	required_device<palette_device> m_palette;

--- a/src/mame/video/exedexes.cpp
+++ b/src/mame/video/exedexes.cpp
@@ -10,11 +10,7 @@
 
 #include "emu.h"
 #include "includes/exedexes.h"
-
-
-#define TileMap(offs) (machine.root_device().memregion("gfx5")->base()[offs])
-#define BackTileMap(offs) (machine.root_device().memregion("gfx5")->base()[offs+0x4000])
-
+#include "screen.h"
 
 /***************************************************************************
 
@@ -35,14 +31,14 @@
 
 void exedexes_state::exedexes_palette(palette_device &palette) const
 {
-	const uint8_t *color_prom = memregion("proms")->base();
+	const u8 *color_prom = memregion("proms")->base();
 
 	// create a lookup table for the palette
 	for (int i = 0; i < 0x100; i++)
 	{
-		int const r = pal4bit(color_prom[i + 0x000]);
-		int const g = pal4bit(color_prom[i + 0x100]);
-		int const b = pal4bit(color_prom[i + 0x200]);
+		const int r = pal4bit(color_prom[i + 0x000]);
+		const int g = pal4bit(color_prom[i + 0x100]);
+		const int b = pal4bit(color_prom[i + 0x200]);
 
 		palette.set_indirect_color(i, rgb_t(r, g, b));
 	}
@@ -53,45 +49,45 @@ void exedexes_state::exedexes_palette(palette_device &palette) const
 	// characters use colors 0xc0-0xcf
 	for (int i = 0; i < 0x100; i++)
 	{
-		uint8_t const ctabentry = color_prom[i] | 0xc0;
+		const u8 ctabentry = color_prom[i] | 0xc0;
 		palette.set_pen_indirect(i, ctabentry);
 	}
 
 	// 32x32 tiles use colors 0-0x0f
 	for (int i = 0x100; i < 0x200; i++)
 	{
-		uint8_t const ctabentry = color_prom[i];
+		const u8 ctabentry = color_prom[i];
 		palette.set_pen_indirect(i, ctabentry);
 	}
 
 	// 16x16 tiles use colors 0x40-0x4f
 	for (int i = 0x200; i < 0x300; i++)
 	{
-		uint8_t const ctabentry = color_prom[i] | 0x40;
+		const u8 ctabentry = color_prom[i] | 0x40;
 		palette.set_pen_indirect(i, ctabentry);
 	}
 
 	// sprites use colors 0x80-0xbf in four banks
 	for (int i = 0x300; i < 0x400; i++)
 	{
-		uint8_t const ctabentry = color_prom[i] | (color_prom[i + 0x100] << 4) | 0x80;
+		const u8 ctabentry = color_prom[i] | (color_prom[i + 0x100] << 4) | 0x80;
 		palette.set_pen_indirect(i, ctabentry);
 	}
 }
 
-WRITE8_MEMBER(exedexes_state::exedexes_videoram_w)
+void exedexes_state::videoram_w(offs_t offset, u8 data)
 {
 	m_videoram[offset] = data;
 	m_tx_tilemap->mark_tile_dirty(offset);
 }
 
-WRITE8_MEMBER(exedexes_state::exedexes_colorram_w)
+void exedexes_state::colorram_w(offs_t offset, u8 data)
 {
 	m_colorram[offset] = data;
 	m_tx_tilemap->mark_tile_dirty(offset);
 }
 
-WRITE8_MEMBER(exedexes_state::exedexes_c804_w)
+void exedexes_state::c804_w(u8 data)
 {
 	/* bits 0 and 1 are coin counters */
 	machine().bookkeeping().coin_counter_w(0, data & 0x01);
@@ -106,7 +102,7 @@ WRITE8_MEMBER(exedexes_state::exedexes_c804_w)
 	/* other bits seem to be unused */
 }
 
-WRITE8_MEMBER(exedexes_state::exedexes_gfxctrl_w)
+void exedexes_state::gfxctrl_w(u8 data)
 {
 	/* bit 4 is bg enable */
 	m_sc2on = data & 0x10;
@@ -123,40 +119,38 @@ WRITE8_MEMBER(exedexes_state::exedexes_gfxctrl_w)
 
 TILE_GET_INFO_MEMBER(exedexes_state::get_bg_tile_info)
 {
-	uint8_t *tilerom = memregion("gfx5")->base();
-
-	int attr = tilerom[tile_index];
-	int code = attr & 0x3f;
-	int color = tilerom[tile_index + (8 * 8)];
-	int flags = ((attr & 0x40) ? TILE_FLIPX : 0) | ((attr & 0x80) ? TILE_FLIPY : 0);
+	const u8 attr = m_tilerom[tile_index];
+	const u8 code = attr & 0x3f;
+	const u8 color = m_tilerom[tile_index + (8 * 8)];
+	const int flags = ((attr & 0x40) ? TILE_FLIPX : 0) | ((attr & 0x80) ? TILE_FLIPY : 0);
 
 	SET_TILE_INFO_MEMBER(1, code, color, flags);
 }
 
 TILE_GET_INFO_MEMBER(exedexes_state::get_fg_tile_info)
 {
-	int code = memregion("gfx5")->base()[tile_index];
+	const u8 code = m_tilerom[tile_index];
 
 	SET_TILE_INFO_MEMBER(2, code, 0, 0);
 }
 
 TILE_GET_INFO_MEMBER(exedexes_state::get_tx_tile_info)
 {
-	int code = m_videoram[tile_index] + 2 * (m_colorram[tile_index] & 0x80);
-	int color = m_colorram[tile_index] & 0x3f;
+	const u32 code = m_videoram[tile_index] + 2 * (m_colorram[tile_index] & 0x80);
+	const u8 color = m_colorram[tile_index] & 0x3f;
 
 	tileinfo.group = color;
 
 	SET_TILE_INFO_MEMBER(0, code, color, 0);
 }
 
-TILEMAP_MAPPER_MEMBER(exedexes_state::exedexes_bg_tilemap_scan)
+TILEMAP_MAPPER_MEMBER(exedexes_state::bg_tilemap_scan)
 {
 	/* logical (col,row) -> memory offset */
 	return ((col * 32 & 0xe0) >> 5) + ((row * 32 & 0xe0) >> 2) + ((col * 32 & 0x3f00) >> 1) + 0x4000;
 }
 
-TILEMAP_MAPPER_MEMBER(exedexes_state::exedexes_fg_tilemap_scan)
+TILEMAP_MAPPER_MEMBER(exedexes_state::fg_tilemap_scan)
 {
 	/* logical (col,row) -> memory offset */
 	return ((col * 16 & 0xf0) >> 4) + (row * 16 & 0xf0) + (col * 16 & 0x700) + ((row * 16 & 0x700) << 3);
@@ -164,66 +158,61 @@ TILEMAP_MAPPER_MEMBER(exedexes_state::exedexes_fg_tilemap_scan)
 
 void exedexes_state::video_start()
 {
-	m_bg_tilemap = &machine().tilemap().create(*m_gfxdecode, tilemap_get_info_delegate(FUNC(exedexes_state::get_bg_tile_info),this), tilemap_mapper_delegate(FUNC(exedexes_state::exedexes_bg_tilemap_scan),this), 32, 32, 64, 64);
-	m_fg_tilemap = &machine().tilemap().create(*m_gfxdecode, tilemap_get_info_delegate(FUNC(exedexes_state::get_fg_tile_info),this), tilemap_mapper_delegate(FUNC(exedexes_state::exedexes_fg_tilemap_scan),this), 16, 16, 128, 128);
+	m_bg_tilemap = &machine().tilemap().create(*m_gfxdecode, tilemap_get_info_delegate(FUNC(exedexes_state::get_bg_tile_info),this), tilemap_mapper_delegate(FUNC(exedexes_state::bg_tilemap_scan),this), 32, 32, 64, 64);
+	m_fg_tilemap = &machine().tilemap().create(*m_gfxdecode, tilemap_get_info_delegate(FUNC(exedexes_state::get_fg_tile_info),this), tilemap_mapper_delegate(FUNC(exedexes_state::fg_tilemap_scan),this), 16, 16, 128, 128);
 	m_tx_tilemap = &machine().tilemap().create(*m_gfxdecode, tilemap_get_info_delegate(FUNC(exedexes_state::get_tx_tile_info),this), TILEMAP_SCAN_ROWS, 8, 8, 32, 32);
 
 	m_fg_tilemap->set_transparent_pen(0);
 	m_tx_tilemap->configure_groups(*m_gfxdecode->gfx(0), 0xcf);
 }
 
-void exedexes_state::draw_sprites( bitmap_ind16 &bitmap, const rectangle &cliprect, int priority )
+void exedexes_state::draw_sprites(screen_device &screen, bitmap_ind16 &bitmap, const rectangle &cliprect)
 {
-	uint8_t *buffered_spriteram = m_spriteram->buffer();
-	int offs;
+	const u8 *buffered_spriteram = m_spriteram->buffer();
 
 	if (!m_objon)
 		return;
 
-	priority = priority ? 0x40 : 0x00;
-
-	for (offs = m_spriteram->bytes() - 32;offs >= 0;offs -= 32)
+	for (int offs = 0; offs < m_spriteram->bytes(); offs += 32)
 	{
-		if ((buffered_spriteram[offs + 1] & 0x40) == priority)
-		{
-			int code, color, flipx, flipy, sx, sy;
+		u32 primask = 0;
+		if (buffered_spriteram[offs + 1] & 0x40)
+			primask |= GFX_PMASK_2;
 
-			code = buffered_spriteram[offs];
-			color = buffered_spriteram[offs + 1] & 0x0f;
-			flipx = buffered_spriteram[offs + 1] & 0x10;
-			flipy = buffered_spriteram[offs + 1] & 0x20;
-			sx = buffered_spriteram[offs + 3] - ((buffered_spriteram[offs + 1] & 0x80) << 1);
-			sy = buffered_spriteram[offs + 2];
+		const u32 code = buffered_spriteram[offs];
+		const u32 color = buffered_spriteram[offs + 1] & 0x0f;
+		const bool flipx = buffered_spriteram[offs + 1] & 0x10;
+		const bool flipy = buffered_spriteram[offs + 1] & 0x20;
+		const int sx = buffered_spriteram[offs + 3] - ((buffered_spriteram[offs + 1] & 0x80) << 1);
+		const int sy = buffered_spriteram[offs + 2];
 
-			m_gfxdecode->gfx(3)->transpen(bitmap,cliprect,
-					code,
-					color,
-					flipx,flipy,
-					sx,sy,0);
-		}
+		m_gfxdecode->gfx(3)->prio_transpen(bitmap,cliprect,
+				code,
+				color,
+				flipx,flipy,
+				sx,sy,screen.priority(),primask,0);
 	}
 }
 
-uint32_t exedexes_state::screen_update_exedexes(screen_device &screen, bitmap_ind16 &bitmap, const rectangle &cliprect)
+u32 exedexes_state::screen_update(screen_device &screen, bitmap_ind16 &bitmap, const rectangle &cliprect)
 {
+	screen.priority().fill(0, cliprect);
 	if (m_sc2on)
 	{
 		m_bg_tilemap->set_scrollx(0, ((m_bg_scroll[1]) << 8) + m_bg_scroll[0]);
-		m_bg_tilemap->draw(screen, bitmap, cliprect, 0, 0);
+		m_bg_tilemap->draw(screen, bitmap, cliprect, 0, 1);
 	}
 	else
 		bitmap.fill(0, cliprect);
-
-	draw_sprites(bitmap, cliprect, 1);
 
 	if (m_sc1on)
 	{
 		m_fg_tilemap->set_scrollx(0, ((m_nbg_yscroll[1]) << 8) + m_nbg_yscroll[0]);
 		m_fg_tilemap->set_scrolly(0, ((m_nbg_xscroll[1]) << 8) + m_nbg_xscroll[0]);
-		m_fg_tilemap->draw(screen, bitmap, cliprect, 0, 0);
+		m_fg_tilemap->draw(screen, bitmap, cliprect, 0, 2);
 	}
 
-	draw_sprites(bitmap, cliprect, 0);
+	draw_sprites(screen, bitmap, cliprect);
 
 	if (m_chon)
 		m_tx_tilemap->draw(screen, bitmap, cliprect, 0, 0);


### PR DESCRIPTION
Use prio_* for sprite draw routine, Simplify handlers, gfxdecodes, Reduce runtime tag lookups, Unnecessary lines, Fix namings, Spacings