### PR TITLE
Z80SIO: fixed a few regressions after PR #5115

### DIFF
--- a/src/devices/machine/z80sio.cpp
+++ b/src/devices/machine/z80sio.cpp
@@ -1043,6 +1043,9 @@ void z80sio_channel::device_reset()
 	m_all_sent_delay = 0;
 	m_tx_in_pkt = false;
 	m_tx_forced_sync = true;
+	m_txd = 1;
+	out_txd_cb(1);
+	m_tx_sr = ~0;
 
 	// TODO: what happens to WAIT/READY?
 


### PR DESCRIPTION
Hi,

this commit fixes a few regressions caused by my last changes to Z80SIO driver.
In detail:

+ **altos5**, **isbc28612**, **isbc2861**, **c8002** now have the same exact image on screen as before at the end of 10 seconds of emulation,
+ **c5000** has one more word ("tape") displayed, probably because some initial self-test is now a bit faster,
+ **att4425** doesn't change after this fix, but I'm convinced that the current image is more correct (the one showing "keyboard test failed", as the generic rs232 keyboard that is connected has no loopback function).

This list of systems was provided by Tafoid as a comment to my last PR (#5115), it's probably not complete. I'll look into new regressions as they are reported.
Thanks.

--F.Ulivi
