### PR TITLE
fix vsllvm configuration

### DIFF
--- a/scripts/genie.lua
+++ b/scripts/genie.lua
@@ -1303,6 +1303,9 @@ configuration { "vsllvm" }
 		"_CRT_SECURE_NO_DEPRECATE",
 		"_CRT_STDIO_LEGACY_WIDE_SPECIFIERS",
 	}
+	includedirs {
+		MAME_DIR .. "3rdparty/dxsdk/Include"
+	}
 
 configuration { "vs20*" }
 		defines {
@@ -1481,6 +1484,7 @@ configuration { "vsllvm" }
 			"-Wno-tautological-undefined-compare",
 			"-Wno-deprecated-declarations",
 			"-Wno-macro-redefined",
+			"-Wno-narrowing",
 		}
 
 

--- a/scripts/src/osd/modules.lua
+++ b/scripts/src/osd/modules.lua
@@ -448,6 +448,7 @@ function osdmodulestargetconf()
 			"dsound",
 			"dxguid",
 			"oleaut32",
+			"winmm",
 		}
 	elseif _OPTIONS["targetos"]=="macosx" then
 		links {


### PR DESCRIPTION
- `dxsdk` was missing from includes
- `winmm` was missing from libs
- narrowing warning was silenced for VS, but not from vsllvm, where it leads to an error in `menu_video_options::handle()`