### PR TITLE
drawgfx.cpp : Updates

### DIFF
--- a/src/devices/video/stvvdp2.cpp
+++ b/src/devices/video/stvvdp2.cpp
@@ -2369,16 +2369,6 @@ uint8_t saturn_state::stv_vdp2_check_vram_cycle_pattern_registers( uint8_t acces
 	return access_command_ok == 3 ? 1 : 0;
 }
 
-static inline uint32_t stv_add_blend(uint32_t a, uint32_t b)
-{
-	rgb_t rb = (a & 0xff00ff) + (b & 0xff00ff);
-	rgb_t g = (a & 0x00ff00) + (b & 0x00ff00);
-	return rgb_t((rb & 0x1000000) ? 0xff : rb.r(),
-		(g & 0x0010000) ? 0xff : g.g(),
-		(rb & 0x0000100) ? 0xff : rb.b()
-	);
-}
-
 
 void saturn_state::stv_vdp2_compute_color_offset( int *r, int *g, int *b, int cor )
 {
@@ -2572,7 +2562,7 @@ void saturn_state::stv_vdp2_drawgfxzoom(
 							{
 								int c = source[x_index>>16];
 								if ((transparency & STV_TRANSPARENCY_NONE) || (c != 0))
-									dest[x] = stv_add_blend(dest[x],pal[c]);
+									dest[x] = add_blend_r32(dest[x],pal[c]);
 							}
 							x_index += dx;
 						}
@@ -2768,7 +2758,7 @@ void saturn_state::stv_vdp2_drawgfxzoom_rgb555(
 								stv_vdp2_compute_color_offset(&r,&g,&b,stv2_current_tilemap.fade_control & 2);
 
 							if ((transparency & STV_TRANSPARENCY_NONE) || (data & 0x8000))
-								dest[x] = stv_add_blend(dest[x], rgb_t(r, g, b));
+								dest[x] = add_blend_r32(dest[x], rgb_t(r, g, b));
 
 							x_index += dx;
 						}
@@ -4366,7 +4356,7 @@ void saturn_state::stv_vdp2_draw_line(bitmap_rgb32 &bitmap, const rectangle &cli
 				pen = (gfxdata[base_offs+0]<<8)|gfxdata[base_offs+1];
 				pix = bitmap.pix32(y, x);
 
-				bitmap.pix32(y, x) = stv_add_blend(m_palette->pen(pen & 0x7ff),pix);
+				bitmap.pix32(y, x) = add_blend_r32(m_palette->pen(pen & 0x7ff),pix);
 			}
 		}
 	}
@@ -4842,7 +4832,7 @@ void saturn_state::stv_vdp2_copy_roz_bitmap(bitmap_rgb32 &bitmap,
 						if(stv2_current_tilemap.fade_control & 1)
 							stv_vdp2_compute_color_offset_UINT32(&pix,stv2_current_tilemap.fade_control & 2);
 
-						line[hcnt] = stv_add_blend( line[hcnt], pix );
+						line[hcnt] = add_blend_r32( line[hcnt], pix );
 					}
 				}
 				else
@@ -4946,7 +4936,7 @@ void saturn_state::stv_vdp2_copy_roz_bitmap(bitmap_rgb32 &bitmap,
 						if(stv2_current_tilemap.fade_control & 1)
 							stv_vdp2_compute_color_offset_UINT32(&pix,stv2_current_tilemap.fade_control & 2);
 
-						line[hcnt] = stv_add_blend( line[hcnt], pix );
+						line[hcnt] = add_blend_r32( line[hcnt], pix );
 					}
 				}
 				else
@@ -6867,7 +6857,7 @@ void saturn_state::draw_sprites(bitmap_rgb32 &bitmap, const rectangle &cliprect,
 						ccr = sprite_ccr[0];
 						if ( STV_VDP2_CCMD )
 						{
-							bitmap_line[x] = stv_add_blend( bitmap_line[x], rgb_t(r, g, b));
+							bitmap_line[x] = add_blend_r32( bitmap_line[x], rgb_t(r, g, b));
 						}
 						else
 						{
@@ -6914,7 +6904,7 @@ void saturn_state::draw_sprites(bitmap_rgb32 &bitmap, const rectangle &cliprect,
 								{
 									if ( STV_VDP2_CCMD )
 									{
-										bitmap_line[x] = stv_add_blend( bitmap_line[x], m_palette->pen(pix) );
+										bitmap_line[x] = add_blend_r32( bitmap_line[x], m_palette->pen(pix) );
 									}
 									else
 									{
@@ -7004,15 +6994,15 @@ void saturn_state::draw_sprites(bitmap_rgb32 &bitmap, const rectangle &cliprect,
 						{
 							if(double_x)
 							{
-								bitmap_line[x*2] = stv_add_blend( bitmap_line[x*2], rgb_t(r, g, b) );
-								if ( interlace_framebuffer == 1 ) bitmap_line2[x*2] = stv_add_blend( bitmap_line2[x*2], rgb_t(r, g, b) );
-								bitmap_line[x*2+1] = stv_add_blend( bitmap_line[x*2+1], rgb_t(r, g, b) );
-								if ( interlace_framebuffer == 1 ) bitmap_line2[x*2+1] = stv_add_blend( bitmap_line2[x*2+1], rgb_t(r, g, b) );
+								bitmap_line[x*2] = add_blend_r32( bitmap_line[x*2], rgb_t(r, g, b) );
+								if ( interlace_framebuffer == 1 ) bitmap_line2[x*2] = add_blend_r32( bitmap_line2[x*2], rgb_t(r, g, b) );
+								bitmap_line[x*2+1] = add_blend_r32( bitmap_line[x*2+1], rgb_t(r, g, b) );
+								if ( interlace_framebuffer == 1 ) bitmap_line2[x*2+1] = add_blend_r32( bitmap_line2[x*2+1], rgb_t(r, g, b) );
 							}
 							else
 							{
-								bitmap_line[x] = stv_add_blend( bitmap_line[x], rgb_t(r, g, b) );
-								if ( interlace_framebuffer == 1 ) bitmap_line2[x] = stv_add_blend( bitmap_line2[x], rgb_t(r, g, b) );
+								bitmap_line[x] = add_blend_r32( bitmap_line[x], rgb_t(r, g, b) );
+								if ( interlace_framebuffer == 1 ) bitmap_line2[x] = add_blend_r32( bitmap_line2[x], rgb_t(r, g, b) );
 							}
 						}
 						else
@@ -7098,15 +7088,15 @@ void saturn_state::draw_sprites(bitmap_rgb32 &bitmap, const rectangle &cliprect,
 								{
 									if(double_x)
 									{
-										bitmap_line[x*2] = stv_add_blend( bitmap_line[x*2], m_palette->pen(pix) );
-										if ( interlace_framebuffer == 1 ) bitmap_line2[x*2] = stv_add_blend( bitmap_line2[x], m_palette->pen(pix) );
-										bitmap_line[x*2+1] = stv_add_blend( bitmap_line[x*2+1], m_palette->pen(pix) );
-										if ( interlace_framebuffer == 1 ) bitmap_line2[x*2+1] = stv_add_blend( bitmap_line2[x], m_palette->pen(pix) );
+										bitmap_line[x*2] = add_blend_r32( bitmap_line[x*2], m_palette->pen(pix) );
+										if ( interlace_framebuffer == 1 ) bitmap_line2[x*2] = add_blend_r32( bitmap_line2[x], m_palette->pen(pix) );
+										bitmap_line[x*2+1] = add_blend_r32( bitmap_line[x*2+1], m_palette->pen(pix) );
+										if ( interlace_framebuffer == 1 ) bitmap_line2[x*2+1] = add_blend_r32( bitmap_line2[x], m_palette->pen(pix) );
 									}
 									else
 									{
-										bitmap_line[x] = stv_add_blend( bitmap_line[x], m_palette->pen(pix) );
-										if ( interlace_framebuffer == 1 ) bitmap_line2[x] = stv_add_blend( bitmap_line2[x], m_palette->pen(pix) );
+										bitmap_line[x] = add_blend_r32( bitmap_line[x], m_palette->pen(pix) );
+										if ( interlace_framebuffer == 1 ) bitmap_line2[x] = add_blend_r32( bitmap_line2[x], m_palette->pen(pix) );
 									}
 								}
 								else

--- a/src/emu/drawgfx.h
+++ b/src/emu/drawgfx.h
@@ -262,9 +262,9 @@ public:
 
 	// implementations moved here from specific drivers
 	void prio_transpen_additive(bitmap_rgb32 &dest, const rectangle &cliprect, u32 code, u32 color, int flipx, int flipy, s32 destx, s32 desty, bitmap_ind8 &priority, u32 pmask, u32 trans_pen);
-	void prio_zoom_transpen_additive(bitmap_rgb32 &dest, const rectangle &cliprect,u32 code, u32 color, int flipx, int flipy, s32 destx, s32 desty,u32 scalex, u32 scaley, bitmap_ind8 &priority, u32 pmask,u32 trans_pen);
-	void alphastore(bitmap_rgb32 &dest, const rectangle &cliprect,u32 code, u32 color, int flipx, int flipy, s32 destx, s32 desty,int fixedalpha, u8 *alphatable);
-	void alphatable(bitmap_rgb32 &dest, const rectangle &cliprect, u32 code, u32 color, int flipx, int flipy, s32 destx, s32 desty, int fixedalpha ,u8 *alphatable);
+	void prio_zoom_transpen_additive(bitmap_rgb32 &dest, const rectangle &cliprect, u32 code, u32 color, int flipx, int flipy, s32 destx, s32 desty, u32 scalex, u32 scaley, bitmap_ind8 &priority, u32 pmask, u32 trans_pen);
+	void alphastore(bitmap_rgb32 &dest, const rectangle &cliprect, u32 code, u32 color, int flipx, int flipy, s32 destx, s32 desty, int fixedalpha, u8 *alphatable);
+	void alphatable(bitmap_rgb32 &dest, const rectangle &cliprect, u32 code, u32 color, int flipx, int flipy, s32 destx, s32 desty, int fixedalpha, u8 *alphatable);
 private:
 	// internal helpers
 	void decode(u32 code);
@@ -316,13 +316,31 @@ private:
 void draw_scanline8(bitmap_ind16 &bitmap, s32 destx, s32 desty, s32 length, const u8 *srcptr, const pen_t *paldata);
 void draw_scanline8(bitmap_rgb32 &bitmap, s32 destx, s32 desty, s32 length, const u8 *srcptr, const pen_t *paldata);
 
+void prio_draw_scanline8(bitmap_ind16 &bitmap, s32 destx, s32 desty, s32 length, const u8 *srcptr, const pen_t *paldata, bitmap_ind8 &priority, u32 pmask);
+void prio_draw_scanline8(bitmap_rgb32 &bitmap, s32 destx, s32 desty, s32 length, const u8 *srcptr, const pen_t *paldata, bitmap_ind8 &priority, u32 pmask);
+
+void primask_draw_scanline8(bitmap_ind16 &bitmap, s32 destx, s32 desty, s32 length, const u8 *srcptr, const pen_t *paldata, bitmap_ind8 &priority, u8 pcode = 0, u8 pmask = 0xff);
+void primask_draw_scanline8(bitmap_rgb32 &bitmap, s32 destx, s32 desty, s32 length, const u8 *srcptr, const pen_t *paldata, bitmap_ind8 &priority, u8 pcode = 0, u8 pmask = 0xff);
+
 // copy pixels from a 16bpp buffer to a single scanline of a bitmap
 void draw_scanline16(bitmap_ind16 &bitmap, s32 destx, s32 desty, s32 length, const u16 *srcptr, const pen_t *paldata);
 void draw_scanline16(bitmap_rgb32 &bitmap, s32 destx, s32 desty, s32 length, const u16 *srcptr, const pen_t *paldata);
 
+void prio_draw_scanline16(bitmap_ind16 &bitmap, s32 destx, s32 desty, s32 length, const u16 *srcptr, const pen_t *paldata, bitmap_ind8 &priority, u32 pmask);
+void prio_draw_scanline16(bitmap_rgb32 &bitmap, s32 destx, s32 desty, s32 length, const u16 *srcptr, const pen_t *paldata, bitmap_ind8 &priority, u32 pmask);
+
+void primask_draw_scanline16(bitmap_ind16 &bitmap, s32 destx, s32 desty, s32 length, const u16 *srcptr, const pen_t *paldata, bitmap_ind8 &priority, u8 pcode = 0, u8 pmask = 0xff);
+void primask_draw_scanline16(bitmap_rgb32 &bitmap, s32 destx, s32 desty, s32 length, const u16 *srcptr, const pen_t *paldata, bitmap_ind8 &priority, u8 pcode = 0, u8 pmask = 0xff);
+
 // copy pixels from a 32bpp buffer to a single scanline of a bitmap
 void draw_scanline32(bitmap_ind16 &bitmap, s32 destx, s32 desty, s32 length, const u32 *srcptr, const pen_t *paldata);
 void draw_scanline32(bitmap_rgb32 &bitmap, s32 destx, s32 desty, s32 length, const u32 *srcptr, const pen_t *paldata);
+
+void prio_draw_scanline32(bitmap_ind16 &bitmap, s32 destx, s32 desty, s32 length, const u32 *srcptr, const pen_t *paldata, bitmap_ind8 &priority, u32 pmask);
+void prio_draw_scanline32(bitmap_rgb32 &bitmap, s32 destx, s32 desty, s32 length, const u32 *srcptr, const pen_t *paldata, bitmap_ind8 &priority, u32 pmask);
+
+void primask_draw_scanline32(bitmap_ind16 &bitmap, s32 destx, s32 desty, s32 length, const u32 *srcptr, const pen_t *paldata, bitmap_ind8 &priority, u8 pcode = 0, u8 pmask = 0xff);
+void primask_draw_scanline32(bitmap_rgb32 &bitmap, s32 destx, s32 desty, s32 length, const u32 *srcptr, const pen_t *paldata, bitmap_ind8 &priority, u8 pcode = 0, u8 pmask = 0xff);
 
 
 
@@ -348,11 +366,27 @@ void extract_scanline32(const bitmap_rgb32 &bitmap, s32 srcx, s32 srcy, s32 leng
 void copybitmap(bitmap_ind16 &dest, const bitmap_ind16 &src, int flipx, int flipy, s32 destx, s32 desty, const rectangle &cliprect);
 void copybitmap(bitmap_rgb32 &dest, const bitmap_rgb32 &src, int flipx, int flipy, s32 destx, s32 desty, const rectangle &cliprect);
 
+void prio_copybitmap(bitmap_ind16 &dest, const bitmap_ind16 &src, int flipx, int flipy, s32 destx, s32 desty, const rectangle &cliprect, bitmap_ind8 &priority, u32 pmask);
+void prio_copybitmap(bitmap_rgb32 &dest, const bitmap_rgb32 &src, int flipx, int flipy, s32 destx, s32 desty, const rectangle &cliprect, bitmap_ind8 &priority, u32 pmask);
+
+void primask_copybitmap(bitmap_ind16 &dest, const bitmap_ind16 &src, int flipx, int flipy, s32 destx, s32 desty, const rectangle &cliprect, bitmap_ind8 &priority, u8 pcode = 0, u8 pmask = 0xff);
+void primask_copybitmap(bitmap_rgb32 &dest, const bitmap_rgb32 &src, int flipx, int flipy, s32 destx, s32 desty, const rectangle &cliprect, bitmap_ind8 &priority, u8 pcode = 0, u8 pmask = 0xff);
+
 // copy from one bitmap to another, copying all unclipped pixels except those that match transpen
 void copybitmap_trans(bitmap_ind16 &dest, const bitmap_ind16 &src, int flipx, int flipy, s32 destx, s32 desty, const rectangle &cliprect, u32 transpen);
 void copybitmap_trans(bitmap_rgb32 &dest, const bitmap_rgb32 &src, int flipx, int flipy, s32 destx, s32 desty, const rectangle &cliprect, u32 transpen);
 
+void prio_copybitmap_trans(bitmap_ind16 &dest, const bitmap_ind16 &src, int flipx, int flipy, s32 destx, s32 desty, const rectangle &cliprect, bitmap_ind8 &priority, u32 pmask, u32 transpen);
+void prio_copybitmap_trans(bitmap_rgb32 &dest, const bitmap_rgb32 &src, int flipx, int flipy, s32 destx, s32 desty, const rectangle &cliprect, bitmap_ind8 &priority, u32 pmask, u32 transpen);
+
+void primask_copybitmap_trans(bitmap_ind16 &dest, const bitmap_ind16 &src, int flipx, int flipy, s32 destx, s32 desty, const rectangle &cliprect, u32 transpen, bitmap_ind8 &priority, u8 pcode = 0, u8 pmask = 0xff);
+void primask_copybitmap_trans(bitmap_rgb32 &dest, const bitmap_rgb32 &src, int flipx, int flipy, s32 destx, s32 desty, const rectangle &cliprect, u32 transpen, bitmap_ind8 &priority, u8 pcode = 0, u8 pmask = 0xff);
+
 void copybitmap_transalpha(bitmap_rgb32 &dest, const bitmap_rgb32 &src, int flipx, int flipy, s32 destx, s32 desty, const rectangle &cliprect);
+
+void prio_copybitmap_transalpha(bitmap_rgb32 &dest, const bitmap_rgb32 &src, int flipx, int flipy, s32 destx, s32 desty, const rectangle &cliprect, bitmap_ind8 &priority, u32 pmask);
+
+void primask_copybitmap_transalpha(bitmap_rgb32 &dest, const bitmap_rgb32 &src, int flipx, int flipy, s32 destx, s32 desty, const rectangle &cliprect, bitmap_ind8 &priority, u8 pcode = 0, u8 pmask = 0xff);
 
 /*
   Copy a bitmap onto another with scroll and wraparound.
@@ -370,9 +404,21 @@ void copybitmap_transalpha(bitmap_rgb32 &dest, const bitmap_rgb32 &src, int flip
 void copyscrollbitmap(bitmap_ind16 &dest, const bitmap_ind16 &src, u32 numrows, const s32 *rowscroll, u32 numcols, const s32 *colscroll, const rectangle &cliprect);
 void copyscrollbitmap(bitmap_rgb32 &dest, const bitmap_rgb32 &src, u32 numrows, const s32 *rowscroll, u32 numcols, const s32 *colscroll, const rectangle &cliprect);
 
+void prio_copyscrollbitmap(bitmap_ind16 &dest, const bitmap_ind16 &src, u32 numrows, const s32 *rowscroll, u32 numcols, const s32 *colscroll, const rectangle &cliprect, bitmap_ind8 &priority, u32 pmask);
+void prio_copyscrollbitmap(bitmap_rgb32 &dest, const bitmap_rgb32 &src, u32 numrows, const s32 *rowscroll, u32 numcols, const s32 *colscroll, const rectangle &cliprect, bitmap_ind8 &priority, u32 pmask);
+
+void primask_copyscrollbitmap(bitmap_ind16 &dest, const bitmap_ind16 &src, u32 numrows, const s32 *rowscroll, u32 numcols, const s32 *colscroll, const rectangle &cliprect, bitmap_ind8 &priority, u8 pcode = 0, u8 pmask = 0xff);
+void primask_copyscrollbitmap(bitmap_rgb32 &dest, const bitmap_rgb32 &src, u32 numrows, const s32 *rowscroll, u32 numcols, const s32 *colscroll, const rectangle &cliprect, bitmap_ind8 &priority, u8 pcode = 0, u8 pmask = 0xff);
+
 // copy from one bitmap to another, copying all unclipped pixels except those that match transpen, and applying scrolling to one or more rows/columns
 void copyscrollbitmap_trans(bitmap_ind16 &dest, const bitmap_ind16 &src, u32 numrows, const s32 *rowscroll, u32 numcols, const s32 *colscroll, const rectangle &cliprect, u32 transpen);
 void copyscrollbitmap_trans(bitmap_rgb32 &dest, const bitmap_rgb32 &src, u32 numrows, const s32 *rowscroll, u32 numcols, const s32 *colscroll, const rectangle &cliprect, u32 transpen);
+
+void prio_copyscrollbitmap_trans(bitmap_ind16 &dest, const bitmap_ind16 &src, u32 numrows, const s32 *rowscroll, u32 numcols, const s32 *colscroll, const rectangle &cliprect, bitmap_ind8 &priority, u32 pmask, u32 transpen);
+void prio_copyscrollbitmap_trans(bitmap_rgb32 &dest, const bitmap_rgb32 &src, u32 numrows, const s32 *rowscroll, u32 numcols, const s32 *colscroll, const rectangle &cliprect, bitmap_ind8 &priority, u32 pmask, u32 transpen);
+
+void primask_copyscrollbitmap_trans(bitmap_ind16 &dest, const bitmap_ind16 &src, u32 numrows, const s32 *rowscroll, u32 numcols, const s32 *colscroll, const rectangle &cliprect, u32 transpen, bitmap_ind8 &priority, u8 pcode = 0, u8 pmask = 0xff);
+void primask_copyscrollbitmap_trans(bitmap_rgb32 &dest, const bitmap_rgb32 &src, u32 numrows, const s32 *rowscroll, u32 numcols, const s32 *colscroll, const rectangle &cliprect, u32 transpen, bitmap_ind8 &priority, u8 pcode = 0, u8 pmask = 0xff);
 
 /*
     Copy a bitmap applying rotation, zooming, and arbitrary distortion.
@@ -407,9 +453,21 @@ void copyscrollbitmap_trans(bitmap_rgb32 &dest, const bitmap_rgb32 &src, u32 num
 void copyrozbitmap(bitmap_ind16 &dest, const rectangle &cliprect, const bitmap_ind16 &src, s32 startx, s32 starty, s32 incxx, s32 incxy, s32 incyx, s32 incyy, int wraparound);
 void copyrozbitmap(bitmap_rgb32 &dest, const rectangle &cliprect, const bitmap_rgb32 &src, s32 startx, s32 starty, s32 incxx, s32 incxy, s32 incyx, s32 incyy, int wraparound);
 
+void prio_copyrozbitmap(bitmap_ind16 &dest, const rectangle &cliprect, const bitmap_ind16 &src, s32 startx, s32 starty, s32 incxx, s32 incxy, s32 incyx, s32 incyy, int wraparound, bitmap_ind8 &priority, u32 pmask);
+void prio_copyrozbitmap(bitmap_rgb32 &dest, const rectangle &cliprect, const bitmap_rgb32 &src, s32 startx, s32 starty, s32 incxx, s32 incxy, s32 incyx, s32 incyy, int wraparound, bitmap_ind8 &priority, u32 pmask);
+
+void primask_copyrozbitmap(bitmap_ind16 &dest, const rectangle &cliprect, const bitmap_ind16 &src, s32 startx, s32 starty, s32 incxx, s32 incxy, s32 incyx, s32 incyy, int wraparound, bitmap_ind8 &priority, u8 pcode = 0, u8 pmask = 0xff);
+void primask_copyrozbitmap(bitmap_rgb32 &dest, const rectangle &cliprect, const bitmap_rgb32 &src, s32 startx, s32 starty, s32 incxx, s32 incxy, s32 incyx, s32 incyy, int wraparound, bitmap_ind8 &priority, u8 pcode = 0, u8 pmask = 0xff);
+
 // copy from one bitmap to another, with zoom and rotation, copying all unclipped pixels whose values do not match transpen
 void copyrozbitmap_trans(bitmap_ind16 &dest, const rectangle &cliprect, const bitmap_ind16 &src, s32 startx, s32 starty, s32 incxx, s32 incxy, s32 incyx, s32 incyy, int wraparound, u32 transparent_color);
 void copyrozbitmap_trans(bitmap_rgb32 &dest, const rectangle &cliprect, const bitmap_rgb32 &src, s32 startx, s32 starty, s32 incxx, s32 incxy, s32 incyx, s32 incyy, int wraparound, u32 transparent_color);
+
+void prio_copyrozbitmap_trans(bitmap_ind16 &dest, const rectangle &cliprect, const bitmap_ind16 &src, s32 startx, s32 starty, s32 incxx, s32 incxy, s32 incyx, s32 incyy, int wraparound, bitmap_ind8 &priority, u32 pmask, u32 transparent_color);
+void prio_copyrozbitmap_trans(bitmap_rgb32 &dest, const rectangle &cliprect, const bitmap_rgb32 &src, s32 startx, s32 starty, s32 incxx, s32 incxy, s32 incyx, s32 incyy, int wraparound, bitmap_ind8 &priority, u32 pmask, u32 transparent_color);
+
+void primask_copyrozbitmap_trans(bitmap_ind16 &dest, const rectangle &cliprect, const bitmap_ind16 &src, s32 startx, s32 starty, s32 incxx, s32 incxy, s32 incyx, s32 incyy, int wraparound, u32 transparent_color, bitmap_ind8 &priority, u8 pcode = 0, u8 pmask = 0xff);
+void primask_copyrozbitmap_trans(bitmap_rgb32 &dest, const rectangle &cliprect, const bitmap_rgb32 &src, s32 startx, s32 starty, s32 incxx, s32 incxy, s32 incyx, s32 incyy, int wraparound, u32 transparent_color, bitmap_ind8 &priority, u8 pcode = 0, u8 pmask = 0xff);
 
 
 
@@ -440,6 +498,32 @@ constexpr u32 alpha_blend_r32(u32 d, u32 s, u8 level)
 	return ((((s & 0x0000ff) * level + (d & 0x0000ff) * int(256 - level)) >> 8)) |
 			((((s & 0x00ff00) * level + (d & 0x00ff00) * int(256 - level)) >> 8) & 0x00ff00) |
 			((((s & 0xff0000) * level + (d & 0xff0000) * int(256 - level)) >> 8) & 0xff0000);
+}
+
+
+//-------------------------------------------------
+//  add_blend_r16 - additive blend two 16-bit
+//  5-5-5 RGB pixels
+//-------------------------------------------------
+
+constexpr u32 add_blend_r16(u32 d, u32 s)
+{
+	return std::min(u32((s & 0x001f) + (d & 0x001f)), u32(0x001f)) |
+			std::min(u32((s & 0x03e0) + (d & 0x03e0)), u32(0x03e0)) |
+			std::min(u32((s & 0x7c00) + (d & 0x7c00)), u32(0x7c00));
+}
+
+
+//-------------------------------------------------
+//  add_blend_r32 - additive blend two 32-bit
+//  8-8-8 RGB pixels
+//-------------------------------------------------
+
+constexpr u32 add_blend_r32(u32 d, u32 s)
+{
+	return std::min(u32((s & 0x0000ff) + (d & 0x0000ff)), u32(0x0000ff)) |
+			std::min(u32((s & 0x00ff00) + (d & 0x00ff00)), u32(0x00ff00)) |
+			std::min(u32((s & 0xff0000) + (d & 0xff0000)), u32(0xff0000));
 }
 
 //**************************************************************************

--- a/src/emu/drawgfxm.h
+++ b/src/emu/drawgfxm.h
@@ -78,6 +78,21 @@ do                                                                              
 	(DEST) = SOURCE;                                                                \
 }                                                                                   \
 while (0)
+#define PIXEL_OP_COPY_OPAQUE_PRIORITY(DEST, PRIORITY, SOURCE)                       \
+do                                                                                  \
+{                                                                                   \
+	if (((1 << ((PRIORITY) & 0x1f)) & pmask) == 0)                                  \
+		(DEST) = SOURCE;                                                            \
+	(PRIORITY) = 31;                                                                \
+}                                                                                   \
+while (0)
+#define PIXEL_OP_COPY_OPAQUE_PRIMASK(DEST, PRIORITY, SOURCE)                        \
+do                                                                                  \
+{                                                                                   \
+	(DEST) = SOURCE;                                                                \
+	(PRIORITY) = ((PRIORITY) & pmask) | pcode;                                      \
+}                                                                                   \
+while (0)
 
 /*-------------------------------------------------
     PIXEL_OP_COPY_TRANSPEN - render all pixels
@@ -93,6 +108,29 @@ do                                                                              
 		(DEST) = SOURCE;                                                            \
 }                                                                                   \
 while (0)
+#define PIXEL_OP_COPY_TRANSPEN_PRIORITY(DEST, PRIORITY, SOURCE)                     \
+do                                                                                  \
+{                                                                                   \
+	u32 srcdata = (SOURCE);                                                         \
+	if (srcdata != trans_pen)                                                       \
+	{                                                                               \
+		if (((1 << ((PRIORITY) & 0x1f)) & pmask) == 0)                              \
+			(DEST) = SOURCE;                                                        \
+		(PRIORITY) = 31;                                                            \
+	}                                                                               \
+}                                                                                   \
+while (0)
+#define PIXEL_OP_COPY_TRANSPEN_PRIMASK(DEST, PRIORITY, SOURCE)                      \
+do                                                                                  \
+{                                                                                   \
+	u32 srcdata = (SOURCE);                                                         \
+	if (srcdata != trans_pen)                                                       \
+	{                                                                               \
+		(DEST) = SOURCE;                                                            \
+		(PRIORITY) = ((PRIORITY) & pmask) | pcode;                                  \
+	}                                                                               \
+}                                                                                   \
+while (0)
 
 /*-------------------------------------------------
     PIXEL_OP_COPY_TRANSALPHA - render all pixels
@@ -100,12 +138,35 @@ while (0)
     directly
 -------------------------------------------------*/
 
-#define PIXEL_OP_COPY_TRANSALPHA(DEST, PRIORITY, SOURCE)                              \
+#define PIXEL_OP_COPY_TRANSALPHA(DEST, PRIORITY, SOURCE)                            \
 do                                                                                  \
 {                                                                                   \
 	u32 srcdata = (SOURCE);                                                         \
-	if ((srcdata & 0xff000000) != 0)                                            \
+	if ((srcdata & 0xff000000) != 0)                                                \
 		(DEST) = SOURCE;                                                            \
+}                                                                                   \
+while (0)
+#define PIXEL_OP_COPY_TRANSALPHA_PRIORITY(DEST, PRIORITY, SOURCE)                   \
+do                                                                                  \
+{                                                                                   \
+	u32 srcdata = (SOURCE);                                                         \
+	if ((srcdata & 0xff000000) != 0)                                                \
+	{                                                                               \
+		if (((1 << ((PRIORITY) & 0x1f)) & pmask) == 0)                              \
+			(DEST) = SOURCE;                                                        \
+		(PRIORITY) = 31;                                                            \
+	}                                                                               \
+}                                                                                   \
+while (0)
+#define PIXEL_OP_COPY_TRANSALPHA_PRIMASK(DEST, PRIORITY, SOURCE)                    \
+do                                                                                  \
+{                                                                                   \
+	u32 srcdata = (SOURCE);                                                         \
+	if ((srcdata & 0xff000000) != 0)                                                \
+	{                                                                               \
+		(DEST) = SOURCE;                                                            \
+		(PRIORITY) = ((PRIORITY) & pmask) | pcode;                                  \
+	}                                                                               \
 }                                                                                   \
 while (0)
 
@@ -127,6 +188,13 @@ do                                                                              
 	if (((1 << ((PRIORITY) & 0x1f)) & pmask) == 0)                                  \
 		(DEST) = paldata[SOURCE];                                                   \
 	(PRIORITY) = 31;                                                                \
+}                                                                                   \
+while (0)
+#define PIXEL_OP_REMAP_OPAQUE_PRIMASK(DEST, PRIORITY, SOURCE)                       \
+do                                                                                  \
+{                                                                                   \
+	(DEST) = paldata[SOURCE];                                                       \
+	(PRIORITY) = ((PRIORITY) & pmask) | pcode;                                      \
 }                                                                                   \
 while (0)
 

--- a/src/mame/drivers/realbrk.cpp
+++ b/src/mame/drivers/realbrk.cpp
@@ -53,9 +53,9 @@ To Do:
 
 
 /* Read 4 ten bit dip switches */
-READ16_MEMBER(realbrk_state::realbrk_dsw_r)
+u16 realbrk_state::realbrk_dsw_r()
 {
-	uint16_t sel = ~m_dsw_select[0];
+	const u16 sel = ~m_dsw_select[0];
 	if (sel & 0x01) return  (m_dsw_io[0]->read() & 0x00ff) << 8;      // DSW1 low bits
 	if (sel & 0x02) return  (m_dsw_io[1]->read() & 0x00ff) << 8;      // DSW2 low bits
 	if (sel & 0x04) return  (m_dsw_io[2]->read() & 0x00ff) << 8;      // DSW3 low bits
@@ -70,7 +70,7 @@ READ16_MEMBER(realbrk_state::realbrk_dsw_r)
 	return 0xffff;
 }
 
-READ16_MEMBER(realbrk_state::pkgnsh_input_r)
+u16 realbrk_state::pkgnsh_input_r(offs_t offset)
 {
 	switch(offset)
 	{
@@ -88,9 +88,9 @@ READ16_MEMBER(realbrk_state::pkgnsh_input_r)
 	return 0xffff;
 }
 
-READ16_MEMBER(realbrk_state::pkgnshdx_input_r)
+u16 realbrk_state::pkgnshdx_input_r(offs_t offset)
 {
-	uint16_t sel = ~m_dsw_select[0];
+	const u16 sel = ~m_dsw_select[0];
 
 	switch(offset)
 	{
@@ -122,7 +122,7 @@ READ16_MEMBER(realbrk_state::pkgnshdx_input_r)
 }
 
 
-READ16_MEMBER(realbrk_state::backup_ram_r)
+u16 realbrk_state::backup_ram_r(offs_t offset)
 {
 	/*TODO: understand the format & cmds of the backup-ram,maybe it's an
 	        unemulated tmp68301 feature?*/
@@ -133,7 +133,7 @@ READ16_MEMBER(realbrk_state::backup_ram_r)
 }
 
 
-READ16_MEMBER(realbrk_state::backup_ram_dx_r)
+u16 realbrk_state::backup_ram_dx_r(offs_t offset)
 {
 	/*TODO: understand the format & cmds of the backup-ram,maybe it's an
 	        unemulated tmp68301 feature?*/
@@ -143,13 +143,13 @@ READ16_MEMBER(realbrk_state::backup_ram_dx_r)
 		return m_backup_ram[offset];
 }
 
-WRITE16_MEMBER(realbrk_state::backup_ram_w)
+void realbrk_state::backup_ram_w(offs_t offset, u16 data, u16 mem_mask)
 {
 	COMBINE_DATA(&m_backup_ram[offset]);
 }
 
 template<int Layer>
-WRITE16_MEMBER(realbrk_state::vram_w)
+void realbrk_state::vram_w(offs_t offset, u16 data, u16 mem_mask)
 {
 	COMBINE_DATA(&m_vram[Layer][offset]);
 	m_tilemap[Layer]->mark_tile_dirty(offset/2);

--- a/src/mame/includes/realbrk.h
+++ b/src/mame/includes/realbrk.h
@@ -35,18 +35,21 @@ public:
 	void realbrk(machine_config &config);
 	void pkgnshdx(machine_config &config);
 
+protected:
+	virtual void video_start() override;
+
 private:
 	required_device<tmp68301_device> m_maincpu;
 	required_device<gfxdecode_device> m_gfxdecode;
 	required_device<screen_device> m_screen;
 	required_device<palette_device> m_palette;
 
-	required_shared_ptr<uint16_t> m_spriteram;
-	required_shared_ptr_array<uint16_t, 3> m_vram;
-	required_shared_ptr<uint16_t> m_vregs;
-	optional_shared_ptr<uint16_t> m_dsw_select;
-	optional_shared_ptr<uint16_t> m_backup_ram;
-	optional_shared_ptr_array<uint16_t, 2> m_vram_ras;
+	required_shared_ptr<u16> m_spriteram;
+	required_shared_ptr_array<u16, 3> m_vram;
+	required_shared_ptr<u16> m_vregs;
+	optional_shared_ptr<u16> m_dsw_select;
+	optional_shared_ptr<u16> m_backup_ram;
+	optional_shared_ptr_array<u16, 2> m_vram_ras;
 
 	optional_ioport_array<2> m_in_io;
 	optional_ioport_array<4> m_dsw_io;
@@ -59,30 +62,28 @@ private:
 	tilemap_t *m_tilemap[3];
 
 	// common
-	template<int Layer> DECLARE_WRITE16_MEMBER(vram_w);
-	DECLARE_WRITE16_MEMBER(vram_2_w);
-	DECLARE_WRITE16_MEMBER(vregs_w);
+	template<int Layer> void vram_w(offs_t offset, u16 data, u16 mem_mask);
+	void vram_2_w(offs_t offset, u16 data, u16 mem_mask);
+	void vregs_w(offs_t offset, u16 data, u16 mem_mask);
 
 	// realbrk and/or dai2kaku
-	DECLARE_READ16_MEMBER(realbrk_dsw_r);
-	DECLARE_WRITE16_MEMBER(realbrk_flipscreen_w);
-	DECLARE_WRITE16_MEMBER(dai2kaku_flipscreen_w);
+	u16 realbrk_dsw_r();
+	void realbrk_flipscreen_w(offs_t offset, u16 data, u16 mem_mask);
+	void dai2kaku_flipscreen_w(u16 data);
 
 	// pkgnsh and/or pkgnshdx
-	DECLARE_READ16_MEMBER(pkgnsh_input_r);
-	DECLARE_READ16_MEMBER(pkgnshdx_input_r);
-	DECLARE_READ16_MEMBER(backup_ram_r);
-	DECLARE_READ16_MEMBER(backup_ram_dx_r);
-	DECLARE_WRITE16_MEMBER(backup_ram_w);
+	u16 pkgnsh_input_r(offs_t offset);
+	u16 pkgnshdx_input_r(offs_t offset);
+	u16 backup_ram_r(offs_t offset);
+	u16 backup_ram_dx_r(offs_t offset);
+	void backup_ram_w(offs_t offset, u16 data, u16 mem_mask);
 
 	template<int Layer> TILE_GET_INFO_MEMBER(get_tile_info);
 	TILE_GET_INFO_MEMBER(get_tile_info_2);
 
-	virtual void video_start() override;
-
-	uint32_t screen_update(screen_device &screen, bitmap_ind16 &bitmap, const rectangle &cliprect);
-	uint32_t screen_update_dai2kaku(screen_device &screen, bitmap_ind16 &bitmap, const rectangle &cliprect);
-	template <bool Rotatable> void draw_sprites(bitmap_ind16 &bitmap,const rectangle &cliprect, int layer);
+	u32 screen_update(screen_device &screen, bitmap_ind16 &bitmap, const rectangle &cliprect);
+	u32 screen_update_dai2kaku(screen_device &screen, bitmap_ind16 &bitmap, const rectangle &cliprect);
+	template <bool Rotatable> void draw_sprites(bitmap_ind16 &bitmap,const rectangle &cliprect, bitmap_ind8 &priority);
 
 	DECLARE_WRITE_LINE_MEMBER(vblank_irq);
 	void base_mem(address_map &map);

--- a/src/mame/video/hng64.cpp
+++ b/src/mame/video/hng64.cpp
@@ -24,10 +24,10 @@ void hng64_state::hng64_mark_tile_dirty( int tilemap, int tile_index )
 
 
 // make this a function!
-// pppppppp ff--atttt tttttttt tttttttt
+// pppppppp ffattttt tttttttt tttttttt
 #define HNG64_GET_TILE_INFO                                                     \
 {                                                                               \
-	uint16_t tilemapinfo = (m_videoregs[reg]>>shift)&0xffff;                      \
+	uint16_t tilemapinfo = (m_videoregs[reg]>>shift)&0xffff;                    \
 	int tileno,pal, flip;                                                       \
 																				\
 	tileno = m_videoram[tile_index+(offset/4)];                                 \
@@ -220,21 +220,6 @@ static void hng64_configure_blit_parameters(blit_parameters *blit, tilemap_t *tm
 	}
 }
 
-static inline uint32_t alpha_additive_r32(uint32_t d, uint32_t s, uint8_t level)
-{
-	uint32_t add;
-	add = (s & 0x00ff0000) + (d & 0x00ff0000);
-	if (add & 0x01000000) d = (d & 0xff00ffff) | (0x00ff0000);
-	else d = (d & 0xff00ffff) | (add & 0x00ff0000);
-	add = (s & 0x000000ff) + (d & 0x000000ff);
-	if (add & 0x00000100) d = (d & 0xffffff00) | (0x000000ff);
-	else d = (d & 0xffffff00) | (add & 0x000000ff);
-	add = (s & 0x0000ff00) + (d & 0x0000ff00);
-	if (add & 0x00010000) d = (d & 0xffff00ff) | (0x0000ff00);
-	else d = (d & 0xffff00ff) | (add & 0x0000ff00);
-	return d;
-}
-
 
 /*-------------------------------------------------
     tilemap_draw_roz_core - render the tilemap's
@@ -247,7 +232,7 @@ do {                                                                            
 	if (blit->drawformat == HNG64_TILEMAP_NORMAL)                                       \
 		*(uint32_t *)dest = clut[INPUT_VAL];                                              \
 	else if (blit->drawformat == HNG64_TILEMAP_ADDITIVE)                                \
-		*(uint32_t *)dest = alpha_additive_r32(*(uint32_t *)dest, clut[INPUT_VAL], alpha);  \
+		*(uint32_t *)dest = add_blend_r32(*(uint32_t *)dest, clut[INPUT_VAL]);  \
 	else if (blit->drawformat == HNG64_TILEMAP_ALPHA)                                   \
 		*(uint32_t *)dest = alpha_blend_r32(*(uint32_t *)dest, clut[INPUT_VAL], alpha);     \
 } while (0)


### PR DESCRIPTION
Move additive blending function into drawgfx.h, Add priority related copybitmap and draw_scanline functions, Fix spacings
Priority related copybitmap and draw_scanline  functions are sprite like priority handling(prio_) and tilemap like priority handling (primask_), These are helpful for priority related bitmap / scanline drawing routines.
drawgfxm.cpp: Add variations of priority related pixel draw functions, Fix spacings
realbrk.cpp: Updates, Example usage for prio_copybitmap
Simplify handlers, Use priority bitmap for sprite priority, Fix spacings, Use shorter / correct type values