### PR TITLE
fuukifg.cpp : Updates

### DIFF
--- a/src/mame/drivers/fuukifg2.cpp
+++ b/src/mame/drivers/fuukifg2.cpp
@@ -63,19 +63,27 @@ To Do:
 
 ***************************************************************************/
 
-WRITE16_MEMBER(fuuki16_state::vregs_w)
+void fuuki16_state::vregs_w(offs_t offset, u16 data, u16 mem_mask)
 {
-	uint16_t old_data = m_vregs[offset];
-	uint16_t new_data = COMBINE_DATA(&m_vregs[offset]);
-	if ((offset == 0x1c/2) && old_data != new_data)
+	const u16 old = m_vregs[offset];
+	data = COMBINE_DATA(&m_vregs[offset]);
+	if (old != data)
 	{
-		const rectangle &visarea = m_screen->visible_area();
-		attotime period = m_screen->frame_period();
-		m_raster_interrupt_timer->adjust(m_screen->time_until_pos(new_data, visarea.max_x + 1), 0, period);
+		if (offset == 0x1c / 2)
+		{
+			const rectangle &visarea = m_screen->visible_area();
+			attotime period = m_screen->frame_period();
+			m_raster_interrupt_timer->adjust(m_screen->time_until_pos(data, visarea.max_x + 1), 0, period);
+		}
+		if (offset == 0x1e / 2)
+		{
+			if ((old ^ data) & 0x40)
+				m_tilemap[2]->mark_all_dirty();
+		}
 	}
 }
 
-WRITE8_MEMBER( fuuki16_state::sound_command_w )
+void fuuki16_state::sound_command_w(u8 data)
 {
 	m_soundlatch->write(data & 0xff);
 	m_audiocpu->pulse_input_line(INPUT_LINE_NMI, attotime::zero);
@@ -84,10 +92,19 @@ WRITE8_MEMBER( fuuki16_state::sound_command_w )
 }
 
 template<int Layer>
-WRITE16_MEMBER(fuuki16_state::vram_w)
+void fuuki16_state::vram_w(offs_t offset, u16 data, u16 mem_mask)
 {
 	COMBINE_DATA(&m_vram[Layer][offset]);
 	m_tilemap[Layer]->mark_tile_dirty(offset / 2);
+}
+
+template<int Layer>
+void fuuki16_state::vram_buffered_w(offs_t offset, u16 data, u16 mem_mask)
+{
+	const int buffer = (m_vregs[0x1e / 2] & 0x40) >> 6;
+	COMBINE_DATA(&m_vram[Layer][offset]);
+	if ((Layer & 1) == buffer)
+		m_tilemap[2]->mark_tile_dirty(offset / 2);
 }
 
 void fuuki16_state::fuuki16_map(address_map &map)
@@ -96,9 +113,9 @@ void fuuki16_state::fuuki16_map(address_map &map)
 	map(0x400000, 0x40ffff).ram();                                                                     // RAM
 	map(0x500000, 0x501fff).ram().w(FUNC(fuuki16_state::vram_w<0>)).share("vram.0");                  // Layers
 	map(0x502000, 0x503fff).ram().w(FUNC(fuuki16_state::vram_w<1>)).share("vram.1");                  //
-	map(0x504000, 0x505fff).ram().w(FUNC(fuuki16_state::vram_w<2>)).share("vram.2");                  //
-	map(0x506000, 0x507fff).ram().w(FUNC(fuuki16_state::vram_w<3>)).share("vram.3");                  //
-	map(0x600000, 0x601fff).mirror(0x008000).rw(m_fuukivid, FUNC(fuukivid_device::fuuki_sprram_r), FUNC(fuukivid_device::fuuki_sprram_w)).share("spriteram");   // Sprites, mirrored?
+	map(0x504000, 0x505fff).ram().w(FUNC(fuuki16_state::vram_buffered_w<2>)).share("vram.2");                  //
+	map(0x506000, 0x507fff).ram().w(FUNC(fuuki16_state::vram_buffered_w<3>)).share("vram.3");                  //
+	map(0x600000, 0x601fff).mirror(0x008000).ram().share("spriteram");   // Sprites, mirrored?
 	map(0x700000, 0x703fff).ram().w(m_palette, FUNC(palette_device::write16)).share("palette");    // Palette
 	map(0x800000, 0x800001).portr("SYSTEM");
 	map(0x810000, 0x810001).portr("P1_P2");
@@ -118,7 +135,7 @@ void fuuki16_state::fuuki16_map(address_map &map)
 
 ***************************************************************************/
 
-WRITE8_MEMBER(fuuki16_state::sound_rombank_w)
+void fuuki16_state::sound_rombank_w(u8 data)
 {
 	if (data <= 2)
 		m_soundbank->set_entry(data);
@@ -126,7 +143,7 @@ WRITE8_MEMBER(fuuki16_state::sound_rombank_w)
 		logerror("CPU #1 - PC %04X: unknown bank bits: %02X\n", m_audiocpu->pc(), data);
 }
 
-WRITE8_MEMBER(fuuki16_state::oki_banking_w)
+void fuuki16_state::oki_banking_w(u8 data)
 {
 	/*
 	    data & 0x06 is always equals to data & 0x60
@@ -373,10 +390,9 @@ static const gfx_layout layout_16x16x8 =
 };
 
 static GFXDECODE_START( gfx_fuuki16 )
-	GFXDECODE_ENTRY( "gfx1", 0, layout_16x16x4, 0x400*2, 0x40 ) // [0] Sprites
-	GFXDECODE_ENTRY( "gfx2", 0, layout_16x16x4, 0x400*0, 0x40 ) // [1] Layer 0
-	GFXDECODE_ENTRY( "gfx3", 0, layout_16x16x8, 0x400*1, 0x40 ) // [2] Layer 1
-	GFXDECODE_ENTRY( "gfx4", 0, layout_8x8x4,   0x400*3, 0x40 ) // [3] Layer 2/3
+	GFXDECODE_ENTRY( "gfx2", 0, layout_16x16x4, 0x400*0, 0x40 ) // [0] Layer 0
+	GFXDECODE_ENTRY( "gfx3", 0, layout_16x16x8, 0x400*1, 0x40 ) // [1] Layer 1
+	GFXDECODE_ENTRY( "gfx4", 0, layout_8x8x4,   0x400*3, 0x40 ) // [2] Layer 2
 GFXDECODE_END
 
 
@@ -425,7 +441,7 @@ void fuuki16_state::device_timer(emu_timer &timer, device_timer_id id, int param
 
 void fuuki16_state::machine_start()
 {
-	uint8_t *ROM = memregion("audiocpu")->base();
+	u8 *ROM = memregion("audiocpu")->base();
 
 	m_soundbank->configure_entries(0, 3, &ROM[0x8000], 0x8000);
 
@@ -466,7 +482,11 @@ void fuuki16_state::fuuki16(machine_config &config)
 	GFXDECODE(config, m_gfxdecode, m_palette, gfx_fuuki16);
 	PALETTE(config, m_palette).set_format(palette_device::xRGB_555, 0x4000 / 2);
 
-	FUUKI_VIDEO(config, m_fuukivid, 0, m_gfxdecode);
+	FUUKI_VIDEO(config, m_fuukivid, 0);
+	m_fuukivid->set_palette(m_palette);
+	m_fuukivid->set_color_base(0x400*2);
+	m_fuukivid->set_color_num(0x40);
+	m_fuukivid->set_colpri_callback(FUNC(fuuki16_state::fuuki16_colpri_cb), this);
 
 	/* sound hardware */
 	SPEAKER(config, "mono").front_center();
@@ -545,7 +565,7 @@ ROM_START( gogomile )
 	ROM_REGION( 0x20000, "audiocpu", 0 )        /* Z80 Code */
 	ROM_LOAD( "fs1.rom24", 0x00000, 0x20000, CRC(4e4bd371) SHA1(429e776135ce8960e147762763d952d16ed3f9d4) )
 
-	ROM_REGION( 0x200000, "gfx1", 0 )   /* 16x16x4 Sprites */
+	ROM_REGION( 0x200000, "fuukivid", 0 )   /* 16x16x4 Sprites */
 	ROM_LOAD16_WORD_SWAP( "lh537k2r.rom20", 0x000000, 0x200000, CRC(525dbf51) SHA1(f21876676cc60ed65bc86884da894b24830826bb) )
 
 	ROM_REGION( 0x200000, "gfx2", 0 )   /* 16x16x4 Tiles */
@@ -573,7 +593,7 @@ ROM_START( gogomileo )
 	ROM_REGION( 0x20000, "audiocpu", 0 )        /* Z80 Code */
 	ROM_LOAD( "fs1.rom24", 0x00000, 0x20000, CRC(4e4bd371) SHA1(429e776135ce8960e147762763d952d16ed3f9d4) )
 
-	ROM_REGION( 0x200000, "gfx1", 0 )   /* 16x16x4 Sprites */
+	ROM_REGION( 0x200000, "fuukivid", 0 )   /* 16x16x4 Sprites */
 	ROM_LOAD16_WORD_SWAP( "lh537k2r.rom20", 0x000000, 0x200000, CRC(525dbf51) SHA1(f21876676cc60ed65bc86884da894b24830826bb) )
 
 	ROM_REGION( 0x200000, "gfx2", 0 )   /* 16x16x4 Tiles */
@@ -635,7 +655,7 @@ ROM_START( pbancho )
 	ROM_REGION( 0x20000, "audiocpu", 0 )        /* Z80 Code */
 	ROM_LOAD( "no4.rom23", 0x00000, 0x20000, CRC(dfbfdb81) SHA1(84b0cbe843a9bbae43975afdbd029a9b76fd488b) )
 
-	ROM_REGION( 0x200000, "gfx1", 0 )   /* 16x16x4 Sprites */
+	ROM_REGION( 0x200000, "fuukivid", 0 )   /* 16x16x4 Sprites */
 	ROM_LOAD16_WORD_SWAP( "58.rom20", 0x000000, 0x200000, CRC(4dad0a2e) SHA1(a4f70557503110a5457b9096a79a5f249095fa55) )
 
 	ROM_REGION( 0x200000, "gfx2", 0 )   /* 16x16x4 Tiles */

--- a/src/mame/drivers/fuukifg3.cpp
+++ b/src/mame/drivers/fuukifg3.cpp
@@ -9,7 +9,7 @@
 
 Hardware is similar to FG-2 used for :
 "Go Go! Mile Smile", "Susume! Mile Smile (Japan)" & "Gyakuten!! Puzzle Bancho (Japan)"
-See fuukifg2.c
+See fuukifg2.cpp
 
 Main  CPU   :   M68020
 
@@ -174,37 +174,57 @@ FG-3J ROM-J 507KA0301P04       Rev:1.3
 ***************************************************************************/
 
 /* Sound comms */
-READ8_MEMBER(fuuki32_state::snd_020_r)
+u8 fuuki32_state::snd_020_r(offs_t offset)
 {
 	machine().scheduler().synchronize();
 	return m_shared_ram[offset];
 }
 
-WRITE8_MEMBER(fuuki32_state::snd_020_w)
+void fuuki32_state::snd_020_w(offs_t offset, u8 data, u8 mem_mask)
 {
 	machine().scheduler().synchronize();
 	COMBINE_DATA(&m_shared_ram[offset]);
 }
 
-WRITE32_MEMBER(fuuki32_state::vregs_w)
+u16 fuuki32_state::vregs_r(offs_t offset)
 {
-	if (m_vregs[offset] != data)
+	return m_vregs[offset];
+}
+
+void fuuki32_state::vregs_w(offs_t offset, u16 data, u16 mem_mask)
+{
+	const u16 old = m_vregs[offset];
+	data = COMBINE_DATA(&m_vregs[offset]);
+	if (old != data)
 	{
-		COMBINE_DATA(&m_vregs[offset]);
-		if (offset == 0x1c / 4)
+		if (offset == 0x1c / 2)
 		{
 			const rectangle &visarea = m_screen->visible_area();
 			attotime period = m_screen->frame_period();
-			m_raster_interrupt_timer->adjust(m_screen->time_until_pos(m_vregs[0x1c / 4] >> 16, visarea.max_x + 1), 0, period);
+			m_raster_interrupt_timer->adjust(m_screen->time_until_pos(data, visarea.max_x + 1), 0, period);
+		}
+		if (offset == 0x1e / 2)
+		{
+			if ((old ^ data) & 0x40)
+				m_tilemap[2]->mark_all_dirty();
 		}
 	}
 }
 
 template<int Layer>
-WRITE32_MEMBER(fuuki32_state::vram_w)
+void fuuki32_state::vram_w(offs_t offset, u32 data, u32 mem_mask)
 {
 	COMBINE_DATA(&m_vram[Layer][offset]);
 	m_tilemap[Layer]->mark_tile_dirty(offset);
+}
+
+template<int Layer>
+void fuuki32_state::vram_buffered_w(offs_t offset, u32 data, u32 mem_mask)
+{
+	const int buffer = (m_vregs[0x1e / 2] & 0x40) >> 6;
+	COMBINE_DATA(&m_vram[Layer][offset]);
+	if ((Layer & 1) == buffer)
+		m_tilemap[2]->mark_tile_dirty(offset);
 }
 
 void fuuki32_state::fuuki32_map(address_map &map)
@@ -215,18 +235,18 @@ void fuuki32_state::fuuki32_map(address_map &map)
 
 	map(0x500000, 0x501fff).ram().w(FUNC(fuuki32_state::vram_w<0>)).share("vram.0");  // Tilemap 1
 	map(0x502000, 0x503fff).ram().w(FUNC(fuuki32_state::vram_w<1>)).share("vram.1");  // Tilemap 2
-	map(0x504000, 0x505fff).ram().w(FUNC(fuuki32_state::vram_w<2>)).share("vram.2");  // Tilemap bg
-	map(0x506000, 0x507fff).ram().w(FUNC(fuuki32_state::vram_w<3>)).share("vram.3");  // Tilemap bg2
+	map(0x504000, 0x505fff).ram().w(FUNC(fuuki32_state::vram_buffered_w<2>)).share("vram.2");  // Tilemap bg
+	map(0x506000, 0x507fff).ram().w(FUNC(fuuki32_state::vram_buffered_w<3>)).share("vram.3");  // Tilemap bg2
 	map(0x508000, 0x517fff).ram();                                                                     // More tilemap, or linescroll? Seems to be empty all of the time
-	map(0x600000, 0x601fff).ram().rw(m_fuukivid, FUNC(fuukivid_device::fuuki_sprram_r), FUNC(fuukivid_device::fuuki_sprram_w)); // Sprites
+	map(0x600000, 0x601fff).rw(FUNC(fuuki32_state::sprram_r), FUNC(fuuki32_state::sprram_w)).share("spriteram"); // Sprites
 	map(0x700000, 0x703fff).ram().w(m_palette, FUNC(palette_device::write32)).share("palette"); // Palette
 
-	map(0x800000, 0x800003).lr16("800000", [this]() { return uint16_t(m_system->read()); }).nopw();  // Coin
-	map(0x810000, 0x810003).lr16("810000", [this]() { return uint16_t(m_inputs->read()); }).nopw();  // Player Inputs
-	map(0x880000, 0x880003).lr16("880000", [this]() { return uint16_t(m_dsw1->read()); });           // Service + DIPS
-	map(0x890000, 0x890003).lr16("890000", [this]() { return uint16_t(m_dsw2->read()); });           // More DIPS
+	map(0x800000, 0x800003).lr16("800000", [this]() { return u16(m_system->read()); }).nopw();  // Coin
+	map(0x810000, 0x810003).lr16("810000", [this]() { return u16(m_inputs->read()); }).nopw();  // Player Inputs
+	map(0x880000, 0x880003).lr16("880000", [this]() { return u16(m_dsw1->read()); });           // Service + DIPS
+	map(0x890000, 0x890003).lr16("890000", [this]() { return u16(m_dsw2->read()); });           // More DIPS
 
-	map(0x8c0000, 0x8c001f).ram().w(FUNC(fuuki32_state::vregs_w)).share("vregs");        // Video Registers
+	map(0x8c0000, 0x8c001f).rw(FUNC(fuuki32_state::vregs_r), FUNC(fuuki32_state::vregs_w)).share("vregs");        // Video Registers
 	map(0x8d0000, 0x8d0003).ram();                                                                     // Flipscreen Related
 	map(0x8e0000, 0x8e0003).ram().share("priority");                            // Controls layer order
 	map(0x903fe0, 0x903fff).rw(FUNC(fuuki32_state::snd_020_r), FUNC(fuuki32_state::snd_020_w)).umask32(0x00ff00ff);                                         // Shared with Z80
@@ -240,7 +260,7 @@ void fuuki32_state::fuuki32_map(address_map &map)
 
 ***************************************************************************/
 
-WRITE8_MEMBER(fuuki32_state::sound_bw_w)
+void fuuki32_state::sound_bw_w(u8 data)
 {
 	m_soundbank->set_entry(data);
 }
@@ -427,18 +447,6 @@ static const gfx_layout layout_8x8x4 =
 	8*8*4
 };
 
-/* 16x16x4 */
-static const gfx_layout layout_16x16x4 =
-{
-	16,16,
-	RGN_FRAC(1,1),
-	4,
-	{ STEP4(0,1) },
-	{ STEP16(0,4) },
-	{ STEP16(0,16*4) },
-	16*16*4
-};
-
 /* 16x16x8 */
 static const gfx_layout layout_16x16x8 =
 {
@@ -452,10 +460,9 @@ static const gfx_layout layout_16x16x8 =
 };
 
 static GFXDECODE_START( gfx_fuuki32 )
-	GFXDECODE_ENTRY( "gfx1", 0, layout_16x16x4, 0x400*2, 0x40 ) // [0] Sprites
-	GFXDECODE_ENTRY( "gfx2", 0, layout_16x16x8, 0x400*0, 0x40 ) // [1] Layer 1
-	GFXDECODE_ENTRY( "gfx3", 0, layout_16x16x8, 0x400*1, 0x40 ) // [2] Layer 2
-	GFXDECODE_ENTRY( "gfx4", 0, layout_8x8x4,   0x400*3, 0x40 ) // [3] BG Layer
+	GFXDECODE_ENTRY( "gfx2", 0, layout_16x16x8, 0x400*0, 0x40 ) // [0] Layer 1
+	GFXDECODE_ENTRY( "gfx3", 0, layout_16x16x8, 0x400*1, 0x40 ) // [1] Layer 2
+	GFXDECODE_ENTRY( "gfx4", 0, layout_8x8x4,   0x400*3, 0x40 ) // [2] BG Layer
 GFXDECODE_END
 
 
@@ -492,7 +499,7 @@ void fuuki32_state::device_timer(emu_timer &timer, device_timer_id id, int param
 
 void fuuki32_state::machine_start()
 {
-	uint8_t *ROM = memregion("soundcpu")->base();
+	u8 *ROM = memregion("soundcpu")->base();
 
 	m_soundbank->configure_entries(0, 0x10, &ROM[0], 0x8000);
 
@@ -535,7 +542,12 @@ void fuuki32_state::fuuki32(machine_config &config)
 	GFXDECODE(config, m_gfxdecode, m_palette, gfx_fuuki32);
 	PALETTE(config, m_palette).set_format(palette_device::xRGB_555, 0x4000 / 2);
 
-	FUUKI_VIDEO(config, m_fuukivid, 0, m_gfxdecode);
+	FUUKI_VIDEO(config, m_fuukivid, 0);
+	m_fuukivid->set_palette(m_palette);
+	m_fuukivid->set_color_base(0x400*2);
+	m_fuukivid->set_color_num(0x40);
+	m_fuukivid->set_tile_callback(FUNC(fuuki32_state::fuuki32_tile_cb), this);
+	m_fuukivid->set_colpri_callback(FUNC(fuuki32_state::fuuki32_colpri_cb), this);
 
 	/* sound hardware */
 	SPEAKER(config, "lspeaker").front_left();
@@ -579,7 +591,7 @@ ROM_START( asurabld )
 	ROM_REGION( 0x80000, "soundcpu", 0 ) /* Z80 */
 	ROM_LOAD( "srom.u7", 0x00000, 0x80000, CRC(bb1deb89) SHA1(b1c70abddc0b9a88beb69a592376ff69a7e091eb) )
 
-	ROM_REGION( 0x2000000, "gfx1", 0 )
+	ROM_REGION( 0x2000000, "fuukivid", 0 )
 	/* 0x0000000 - 0x03fffff empty */ /* spXX.uYY - XX is the bank number! */
 	ROM_LOAD16_WORD_SWAP( "sp23.u14", 0x0400000, 0x400000, CRC(7df492eb) SHA1(30b88a3cd025ffc8c28fef06e0784755be37ef8e) )
 	ROM_LOAD16_WORD_SWAP( "sp45.u15", 0x0800000, 0x400000, CRC(1890f42a) SHA1(22254fe38fd83f4602a25e1ccba32df16edaf3f9) )
@@ -621,7 +633,7 @@ ROM_START( asurabus )
 	ROM_REGION( 0x80000, "soundcpu", 0 ) /* Z80 */
 	ROM_LOAD( "srom.u7", 0x00000, 0x80000, CRC(368da389) SHA1(1423b709da40bf3033c9032c4bd07658f1a969de) )
 
-	ROM_REGION( 0x2000000, "gfx1", 0 )
+	ROM_REGION( 0x2000000, "fuukivid", 0 )
 	ROM_LOAD16_WORD_SWAP( "sp01.u13", 0x0000000, 0x400000, CRC(5edea463) SHA1(22a780912f060bae0c9a403a7bfd4d27f25b76e3) )
 	ROM_LOAD16_WORD_SWAP( "sp23.u14", 0x0400000, 0x400000, CRC(91b1b0de) SHA1(341367966559ef2027415b673eb0db704680c81f) )
 	ROM_LOAD16_WORD_SWAP( "sp45.u15", 0x0800000, 0x400000, CRC(96c69aac) SHA1(cf053523026651427f884b9dd7c095af362dd24e) )
@@ -656,7 +668,7 @@ ROM_START( asurabusa )
 	ROM_REGION( 0x80000, "soundcpu", 0 ) /* Z80 */
 	ROM_LOAD( "srom.u7", 0x00000, 0x80000, CRC(368da389) SHA1(1423b709da40bf3033c9032c4bd07658f1a969de) )
 
-	ROM_REGION( 0x2000000, "gfx1", 0 )
+	ROM_REGION( 0x2000000, "fuukivid", 0 )
 	ROM_LOAD16_WORD_SWAP( "sp01.u13", 0x0000000, 0x400000, CRC(5edea463) SHA1(22a780912f060bae0c9a403a7bfd4d27f25b76e3) )
 	ROM_LOAD16_WORD_SWAP( "sp23.u14", 0x0400000, 0x400000, CRC(91b1b0de) SHA1(341367966559ef2027415b673eb0db704680c81f) )
 	ROM_LOAD16_WORD_SWAP( "sp45.u15", 0x0800000, 0x400000, CRC(96c69aac) SHA1(cf053523026651427f884b9dd7c095af362dd24e) )

--- a/src/mame/includes/fuukifg2.h
+++ b/src/mame/includes/fuukifg2.h
@@ -54,7 +54,7 @@ private:
 
 	/* memory pointers */
 	required_shared_ptr<u16> m_spriteram;
-	required_shared_ptr_array<u16,4> m_vram;
+	required_shared_ptr_array<u16, 4> m_vram;
 	required_shared_ptr<u16> m_vregs;
 	required_shared_ptr<u16> m_unknown;
 	required_shared_ptr<u16> m_priority;

--- a/src/mame/includes/fuukifg2.h
+++ b/src/mame/includes/fuukifg2.h
@@ -24,6 +24,7 @@ public:
 		, m_palette(*this, "palette")
 		, m_fuukivid(*this, "fuukivid")
 		, m_soundlatch(*this, "soundlatch")
+		, m_spriteram(*this, "spriteram")
 		, m_vram(*this, "vram.%u", 0)
 		, m_vregs(*this, "vregs")
 		, m_unknown(*this, "unknown")
@@ -52,26 +53,28 @@ private:
 	required_device<generic_latch_8_device> m_soundlatch;
 
 	/* memory pointers */
-	required_shared_ptr_array<uint16_t,4> m_vram;
-	required_shared_ptr<uint16_t> m_vregs;
-	required_shared_ptr<uint16_t> m_unknown;
-	required_shared_ptr<uint16_t> m_priority;
+	required_shared_ptr<u16> m_spriteram;
+	required_shared_ptr_array<u16,4> m_vram;
+	required_shared_ptr<u16> m_vregs;
+	required_shared_ptr<u16> m_unknown;
+	required_shared_ptr<u16> m_priority;
 
 	required_memory_bank m_soundbank;
 
 	/* video-related */
-	tilemap_t     *m_tilemap[4];
+	tilemap_t     *m_tilemap[3];
 
 	/* misc */
 	emu_timer   *m_level_1_interrupt_timer;
 	emu_timer   *m_vblank_interrupt_timer;
 	emu_timer   *m_raster_interrupt_timer;
 
-	DECLARE_WRITE16_MEMBER(vregs_w);
-	DECLARE_WRITE8_MEMBER(sound_command_w);
-	DECLARE_WRITE8_MEMBER(sound_rombank_w);
-	template<int Layer> DECLARE_WRITE16_MEMBER(vram_w);
-	DECLARE_WRITE8_MEMBER(oki_banking_w);
+	void vregs_w(offs_t offset, u16 data, u16 mem_mask = ~0);
+	void sound_command_w(u8 data);
+	void sound_rombank_w(u8 data);
+	template<int Layer> void vram_w(offs_t offset, u16 data, u16 mem_mask = ~0);
+	template<int Layer> void vram_buffered_w(offs_t offset, u16 data, u16 mem_mask = ~0);
+	void oki_banking_w(u8 data);
 
 	template<int Layer> TILE_GET_INFO_MEMBER(get_tile_info);
 
@@ -79,8 +82,9 @@ private:
 	virtual void machine_reset() override;
 	virtual void video_start() override;
 
-	uint32_t screen_update(screen_device &screen, bitmap_ind16 &bitmap, const rectangle &cliprect);
-	void draw_layer( screen_device &screen, bitmap_ind16 &bitmap, const rectangle &cliprect, int i, int flag, int pri );
+	void fuuki16_colpri_cb(u32 &colour, u32 &pri_mask);
+	u32 screen_update(screen_device &screen, bitmap_ind16 &bitmap, const rectangle &cliprect);
+	void draw_layer(screen_device &screen, bitmap_ind16 &bitmap, const rectangle &cliprect, u8 i, int flag, u8 pri, u8 primask = 0xff);
 
 	void fuuki16_map(address_map &map);
 	void fuuki16_sound_io_map(address_map &map);

--- a/src/mame/includes/fuukifg3.h
+++ b/src/mame/includes/fuukifg3.h
@@ -27,8 +27,9 @@ public:
 		, m_screen(*this, "screen")
 		, m_palette(*this, "palette")
 		, m_fuukivid(*this, "fuukivid")
+		, m_spriteram(*this, "spriteram", 32U)
 		, m_vram(*this, "vram.%u", 0)
-		, m_vregs(*this, "vregs")
+		, m_vregs(*this, "vregs", 32U)
 		, m_priority(*this, "priority")
 		, m_tilebank(*this, "tilebank")
 		, m_shared_ram(*this, "shared_ram")
@@ -57,13 +58,13 @@ private:
 	required_device<fuukivid_device> m_fuukivid;
 
 	/* memory pointers */
-	required_shared_ptr_array<uint32_t,4> m_vram;
-	required_shared_ptr<uint32_t> m_vregs;
-	required_shared_ptr<uint32_t> m_priority;
-	required_shared_ptr<uint32_t> m_tilebank;
-	required_shared_ptr<uint8_t> m_shared_ram;
-	//uint32_t *    m_buf_spriteram;
-	//uint32_t *    m_buf_spriteram2;
+	required_shared_ptr<u16> m_spriteram;
+	required_shared_ptr_array<u32,4> m_vram;
+	required_shared_ptr<u16> m_vregs;
+	required_shared_ptr<u32> m_priority;
+	required_shared_ptr<u32> m_tilebank;
+	required_shared_ptr<u8> m_shared_ram;
+	std::unique_ptr<u16[]> m_buf_spriteram[2];
 
 	required_memory_bank m_soundbank;
 
@@ -73,20 +74,23 @@ private:
 	required_ioport m_dsw2;
 
 	/* video-related */
-	tilemap_t     *m_tilemap[4];
-	uint32_t      m_spr_buffered_tilebank[2];
+	tilemap_t     *m_tilemap[3];
+	u32      m_spr_buffered_tilebank[2];
 
 	/* misc */
 	emu_timer   *m_level_1_interrupt_timer;
 	emu_timer   *m_vblank_interrupt_timer;
 	emu_timer   *m_raster_interrupt_timer;
 
-	DECLARE_READ8_MEMBER(snd_020_r);
-	DECLARE_WRITE8_MEMBER(snd_020_w);
-	DECLARE_WRITE32_MEMBER(vregs_w);
-	DECLARE_WRITE8_MEMBER(sound_bw_w);
-	DECLARE_WRITE8_MEMBER(snd_ymf278b_w);
-	template<int Layer> DECLARE_WRITE32_MEMBER(vram_w);
+	u8 snd_020_r(offs_t offset);
+	void snd_020_w(offs_t offset, u8 data, u8 mem_mask = ~0);
+	void sprram_w(offs_t offset, u16 data, u16 mem_mask = ~0);
+	u16 sprram_r(offs_t offset);
+	u16 vregs_r(offs_t offset);
+	void vregs_w(offs_t offset, u16 data, u16 mem_mask = ~0);
+	void sound_bw_w(u8 data);
+	template<int Layer> void vram_w(offs_t offset, u32 data, u32 mem_mask = ~0);
+	template<int Layer> void vram_buffered_w(offs_t offset, u32 data, u32 mem_mask = ~0);
 
 	template<int Layer, int ColShift> TILE_GET_INFO_MEMBER(get_tile_info);
 
@@ -94,9 +98,11 @@ private:
 	virtual void machine_reset() override;
 	virtual void video_start() override;
 
-	uint32_t screen_update(screen_device &screen, bitmap_ind16 &bitmap, const rectangle &cliprect);
+	void fuuki32_tile_cb(u32 &code);
+	void fuuki32_colpri_cb(u32 &colour, u32 &pri_mask);
+	u32 screen_update(screen_device &screen, bitmap_ind16 &bitmap, const rectangle &cliprect);
 	DECLARE_WRITE_LINE_MEMBER(screen_vblank);
-	void draw_layer( screen_device &screen, bitmap_ind16 &bitmap, const rectangle &cliprect, int i, int flag, int pri );
+	void draw_layer(screen_device &screen, bitmap_ind16 &bitmap, const rectangle &cliprect, u8 i, int flag, u8 pri, u8 primask = 0xff);
 
 	void fuuki32_map(address_map &map);
 	void fuuki32_sound_io_map(address_map &map);

--- a/src/mame/includes/fuukifg3.h
+++ b/src/mame/includes/fuukifg3.h
@@ -59,7 +59,7 @@ private:
 
 	/* memory pointers */
 	required_shared_ptr<u16> m_spriteram;
-	required_shared_ptr_array<u32,4> m_vram;
+	required_shared_ptr_array<u32, 4> m_vram;
 	required_shared_ptr<u16> m_vregs;
 	required_shared_ptr<u32> m_priority;
 	required_shared_ptr<u32> m_tilebank;

--- a/src/mame/video/fuukifg.cpp
+++ b/src/mame/video/fuukifg.cpp
@@ -9,28 +9,35 @@
 
 DEFINE_DEVICE_TYPE(FUUKI_VIDEO, fuukivid_device, "fuukivid", "Fuuki Video")
 
-fuukivid_device::fuukivid_device(const machine_config &mconfig, const char *tag, device_t *owner, uint32_t clock)
+fuukivid_device::fuukivid_device(const machine_config &mconfig, const char *tag, device_t *owner, u32 clock)
 	: device_t(mconfig, FUUKI_VIDEO, tag, owner, clock)
+	, device_gfx_interface(mconfig, *this, nullptr)
 	, device_video_interface(mconfig, *this)
-	, m_gfxdecode(*this, finder_base::DUMMY_TAG)
+	, m_gfx_region(*this, DEVICE_SELF)
+	, m_colbase(0)
+	, m_colnum(0x100)
 {
 }
 
 void fuukivid_device::device_start()
 {
-	m_sprram = make_unique_clear<uint16_t[]>(0x2000 / 2);
+	/* 16x16x4 */
+	gfx_layout layout_16x16x4 =
+	{
+		16,16,
+		RGN_FRAC(1,1),
+		4,
+		{ STEP4(0,1) },
+		{ STEP16(0,4) },
+		{ STEP16(0,16*4) },
+		16*16*4
+	};
+	layout_16x16x4.total = m_gfx_region->bytes() / ((16*16*4) / 8);
 
-	// fuukifg3 clearly has buffered ram, it is unclear if fuukifg2 has
-	// it is likely these render to a framebuffer as the tile bank (which is probably external hw) also needs to be banked
-	// suggesting that the sprites are rendered earlier, then displayed from a buffer
+	m_tile_cb.bind_relative_to(*owner());
+	m_colpri_cb.bind_relative_to(*owner());
 
-	m_sprram_old = make_unique_clear<uint16_t[]>(0x2000 / 2);
-	m_sprram_old2 = make_unique_clear<uint16_t[]>(0x2000 / 2);
-
-	save_pointer(NAME(m_sprram), 0x2000 / 2);
-	save_pointer(NAME(m_sprram_old), 0x2000 / 2);
-	save_pointer(NAME(m_sprram_old2), 0x2000 / 2);
-
+	set_gfx(0, std::make_unique<gfx_element>(&palette(), layout_16x16x4, m_gfx_region->base(), 0, m_colnum, m_colbase));
 }
 
 void fuukivid_device::device_reset()
@@ -69,71 +76,53 @@ void fuukivid_device::device_reset()
 
 ***************************************************************************/
 
-void fuukivid_device::draw_sprites( screen_device &screen, bitmap_ind16 &bitmap, const rectangle &cliprect, int flip_screen , uint32_t* tilebank)
+void fuukivid_device::draw_sprites(screen_device &screen, bitmap_ind16 &bitmap, const rectangle &cliprect, bool flip_screen, u16 *spriteram, u32 size)
 {
 	// as we're likely framebuffered (sprites are delayed by 2-3 frames, at least on FG3, and doing rasters on sprites causes glitches) we
 	// only draw the sprites when MAME wants to draw the final screen line.  Ideally we should framebuffer them instead.
 	if (cliprect.max_y != screen.visible_area().max_y)
 		return;
 
-	rectangle spriteclip = screen.visible_area();
+	const bool tilebank = !m_tile_cb.isnull();
+	const bool priority = !m_colpri_cb.isnull();
+	const rectangle spriteclip = screen.visible_area();
 
-	int offs;
-	gfx_element *gfx = m_gfxdecode->gfx(0);
-	bitmap_ind8 &priority_bitmap = screen.priority();
+	const int max_x = spriteclip.max_x + 1;
+	const int max_y = spriteclip.max_y + 1;
 
-	uint16_t *spriteram16 = m_sprram.get();
-
-	if (tilebank) spriteram16 = m_sprram_old2.get(); // so that FG3 uses the buffered RAM
-
-	int max_x = spriteclip.max_x + 1;
-	int max_y = spriteclip.max_y + 1;
+	int start, end, inc;
+	if (priority)             { start = size - 4; end =   -4; inc = -4; }
+	else                      { start =        0; end = size; inc = +4; }
 
 	/* Draw them backwards, for pdrawgfx */
-	for ( offs = (0x2000 - 8) / 2; offs >=0; offs -= 8 / 2 )
+	for (int offs = start; offs != end; offs += inc)
 	{
-		int x, y, xstart, ystart, xend, yend, xinc, yinc;
-		int xnum, ynum, xzoom, yzoom, flipx, flipy;
-		int pri_mask;
-
-		int sx = spriteram16[offs + 0];
-		int sy = spriteram16[offs + 1];
-		int attr = spriteram16[offs + 2];
-		int code = spriteram16[offs + 3];
-
+		const u16 data0 = spriteram[offs + 0];
+		const u16 data1 = spriteram[offs + 1];
+		const u16 attr = spriteram[offs + 2];
+		u32 code = spriteram[offs + 3];
 		if (tilebank)
-		{
-			int bank = (code & 0xc000) >> 14;
-			int bank_lookedup;
+			m_tile_cb(code);
 
-			bank_lookedup = ((tilebank[1] & 0xffff0000) >> (16 + bank * 4)) & 0xf;
-			code &= 0x3fff;
-			code += bank_lookedup * 0x4000;
-		}
-
-		if (sx & 0x400)
+		if (data0 & 0x400)
 			continue;
 
-		flipx = sx & 0x0800;
-		flipy = sy & 0x0800;
+		int flipx = data0 & 0x0800;
+		int flipy = data1 & 0x0800;
 
-		xnum = ((sx >> 12) & 0xf) + 1;
-		ynum = ((sy >> 12) & 0xf) + 1;
+		const int xnum = ((data0 >> 12) & 0xf) + 1;
+		const int ynum = ((data1 >> 12) & 0xf) + 1;
 
-		xzoom = 16 * 8 - (8 * ((attr >> 12) & 0xf)) / 2;
-		yzoom = 16 * 8 - (8 * ((attr >>  8) & 0xf)) / 2;
+		const int xzoom = 16 * 8 - (8 * ((attr >> 12) & 0xf)) / 2;
+		const int yzoom = 16 * 8 - (8 * ((attr >>  8) & 0xf)) / 2;
 
-		switch ((attr >> 6) & 3)
-		{
-			case 3: pri_mask = 0xf0 | 0xcc | 0xaa;  break;  // behind all layers
-			case 2: pri_mask = 0xf0 | 0xcc;         break;  // behind fg + middle layer
-			case 1: pri_mask = 0xf0;                break;  // behind fg layer
-			case 0:
-			default:    pri_mask = 0;                       // above all
-		}
+		u32 pri_mask = 0;
+		u32 colour = attr & 0xff;
+		if (priority)
+			m_colpri_cb(colour, pri_mask);
 
-		sx = (sx & 0x1ff) - (sx & 0x200);
-		sy = (sy & 0x1ff) - (sy & 0x200);
+		int sx = (data0 & 0x1ff) - (data0 & 0x200);
+		int sy = (data1 & 0x1ff) - (data1 & 0x200);
 
 		if (flip_screen)
 		{
@@ -141,39 +130,54 @@ void fuukivid_device::draw_sprites( screen_device &screen, bitmap_ind16 &bitmap,
 			flipy = !flipy;     sy = max_y - sy - ynum * 16;
 		}
 
+		int xstart, ystart, xend, yend, xinc, yinc;
 		if (flipx)  { xstart = xnum-1;  xend = -1;    xinc = -1; }
 		else        { xstart = 0;       xend = xnum;  xinc = +1; }
 
 		if (flipy)  { ystart = ynum-1;  yend = -1;    yinc = -1; }
 		else        { ystart = 0;       yend = ynum;  yinc = +1; }
 
-		for (y = ystart; y != yend; y += yinc)
+		for (int y = ystart; y != yend; y += yinc)
 		{
-			for (x = xstart; x != xend; x += xinc)
+			for (int x = xstart; x != xend; x += xinc)
 			{
-				if (xzoom == (16*8) && yzoom == (16*8))
-					gfx->prio_transpen(bitmap,spriteclip,
-									code++,
-									attr & 0x3f,
-									flipx, flipy,
-									sx + x * 16, sy + y * 16,
-									priority_bitmap,
-									pri_mask,15 );
+				if (priority)
+				{
+					if (xzoom == (16*8) && yzoom == (16*8))
+						gfx(0)->prio_transpen(bitmap,spriteclip,
+										code++,
+										colour,
+										flipx, flipy,
+										sx + x * 16, sy + y * 16,
+										screen.priority(), pri_mask, 15);
+					else
+						gfx(0)->prio_zoom_transpen(bitmap,spriteclip,
+										code++,
+										colour,
+										flipx, flipy,
+										sx + (x * xzoom) / 8, sy + (y * yzoom) / 8,
+										(0x10000/0x10/8) * (xzoom + 8), (0x10000/0x10/8) * (yzoom + 8),// nearest greater integer value to avoid holes
+										screen.priority(), pri_mask, 15);
+				}
 				else
-					gfx->prio_zoom_transpen(bitmap,spriteclip,
-									code++,
-									attr & 0x3f,
-									flipx, flipy,
-									sx + (x * xzoom) / 8, sy + (y * yzoom) / 8,
-									(0x10000/0x10/8) * (xzoom + 8),(0x10000/0x10/8) * (yzoom + 8),  priority_bitmap,// nearest greater integer value to avoid holes
-									pri_mask,15 );
+				{
+					if (xzoom == (16*8) && yzoom == (16*8))
+						gfx(0)->transpen(bitmap,spriteclip,
+										code++,
+										colour,
+										flipx, flipy,
+										sx + x * 16, sy + y * 16,
+										15);
+					else
+						gfx(0)->zoom_transpen(bitmap,spriteclip,
+										code++,
+										colour,
+										flipx, flipy,
+										sx + (x * xzoom) / 8, sy + (y * yzoom) / 8,
+										(0x10000/0x10/8) * (xzoom + 8), (0x10000/0x10/8) * (yzoom + 8),// nearest greater integer value to avoid holes
+										15);
+				}
 			}
 		}
 	}
-}
-
-void fuukivid_device::buffer_sprites(void)
-{
-	memcpy(m_sprram_old2.get(), m_sprram_old.get(), 0x2000);
-	memcpy(m_sprram_old.get(), m_sprram.get(), 0x2000);
 }

--- a/src/mame/video/fuukifg2.cpp
+++ b/src/mame/video/fuukifg2.cpp
@@ -10,7 +10,7 @@
 
     [ 4 Scrolling Layers ]
 
-                            [ Layer 0 ]     [ Layer 1 ]     [ Layers 2&3 (double-buffered) ]
+                            [ Layer 0 ]     [ Layer 1 ]     [ Layer 2 (double-buffered) ]
 
     Tile Size:              16 x 16 x 4     16 x 16 x 8     8 x 8 x 4
     Layer Size (tiles):     64 x 32         64 x 32         64 x 32
@@ -49,9 +49,10 @@
 template<int Layer>
 TILE_GET_INFO_MEMBER(fuuki16_state::get_tile_info)
 {
-	uint16_t code = m_vram[Layer][2 * tile_index + 0];
-	uint16_t attr = m_vram[Layer][2 * tile_index + 1];
-	SET_TILE_INFO_MEMBER((Layer < 2) ? (1 + Layer) : 3, code, attr & 0x3f, TILE_FLIPYX((attr >> 6) & 3));
+	const int buffer = (Layer < 2) ? 0 : (m_vregs[0x1e / 2] & 0x40) >> 6;
+	const u16 code = m_vram[Layer|buffer][2 * tile_index + 0];
+	const u16 attr = m_vram[Layer|buffer][2 * tile_index + 1];
+	SET_TILE_INFO_MEMBER(Layer, code, attr & 0x3f, TILE_FLIPYX((attr >> 6) & 3));
 }
 
 /***************************************************************************
@@ -77,16 +78,28 @@ void fuuki16_state::video_start()
 	m_tilemap[0] = &machine().tilemap().create(*m_gfxdecode, tilemap_get_info_delegate(FUNC(fuuki16_state::get_tile_info<0>),this), TILEMAP_SCAN_ROWS, 16, 16, 64, 32);
 	m_tilemap[1] = &machine().tilemap().create(*m_gfxdecode, tilemap_get_info_delegate(FUNC(fuuki16_state::get_tile_info<1>),this), TILEMAP_SCAN_ROWS, 16, 16, 64, 32);
 	m_tilemap[2] = &machine().tilemap().create(*m_gfxdecode, tilemap_get_info_delegate(FUNC(fuuki16_state::get_tile_info<2>),this), TILEMAP_SCAN_ROWS,  8,  8, 64, 32);
-	m_tilemap[3] = &machine().tilemap().create(*m_gfxdecode, tilemap_get_info_delegate(FUNC(fuuki16_state::get_tile_info<3>),this), TILEMAP_SCAN_ROWS,  8,  8, 64, 32);
 
 	m_tilemap[0]->set_transparent_pen(0x0f);    // 4 bits
 	m_tilemap[1]->set_transparent_pen(0xff);    // 8 bits
 	m_tilemap[2]->set_transparent_pen(0x0f);    // 4 bits
-	m_tilemap[3]->set_transparent_pen(0x0f);    // 4 bits
 
-	m_gfxdecode->gfx(2)->set_granularity(16); /* 256 colour tiles with palette selectable on 16 colour boundaries */
+	m_gfxdecode->gfx(1)->set_granularity(16); /* 256 colour tiles with palette selectable on 16 colour boundaries */
 }
 
+
+void fuuki16_state::fuuki16_colpri_cb(u32 &colour, u32 &pri_mask)
+{
+	const u8 priority = (colour >> 6) & 3;
+	switch (priority)
+	{
+		case 3:  pri_mask = 0xf0 | 0xcc | 0xaa;  break;  // behind all layers
+		case 2:  pri_mask = 0xf0 | 0xcc;         break;  // behind fg + middle layer
+		case 1:  pri_mask = 0xf0;                break;  // behind fg layer
+		case 0:
+		default: pri_mask = 0;                       // above all
+	}
+	colour &= 0x3f;
+}
 
 
 /***************************************************************************
@@ -107,7 +120,7 @@ void fuuki16_state::video_start()
 
         10-1a.w     ? 0
         1c.w        Trigger a level 5 irq on this raster line
-        1e.w        ? $3390/$3393 (Flip Screen Off/On), $0040 is buffer for tilemap 2 or 3
+        1e.w        ? $3390/$3393 (Flip Screen Off/On), $0040 is buffer for tilemap 2
 
     Priority Register (priority):
 
@@ -123,33 +136,18 @@ void fuuki16_state::video_start()
 ***************************************************************************/
 
 /* Wrapper to handle bg and bg2 ttogether */
-void fuuki16_state::draw_layer( screen_device &screen, bitmap_ind16 &bitmap, const rectangle &cliprect, int i, int flag, int pri )
+void fuuki16_state::draw_layer(screen_device &screen, bitmap_ind16 &bitmap, const rectangle &cliprect, u8 i, int flag, u8 pri, u8 primask)
 {
-	int buffer = (m_vregs[0x1e / 2] & 0x40) >> 6;
-
-	switch( i )
-	{
-		case 2: m_tilemap[2|buffer]->draw(screen, bitmap, cliprect, flag, pri);
-				return;
-		case 1: m_tilemap[1]->draw(screen, bitmap, cliprect, flag, pri);
-				return;
-		case 0: m_tilemap[0]->draw(screen, bitmap, cliprect, flag, pri);
-				return;
-	}
+	m_tilemap[i]->draw(screen, bitmap, cliprect, flag, pri, primask);
 }
 
-uint32_t fuuki16_state::screen_update(screen_device &screen, bitmap_ind16 &bitmap, const rectangle &cliprect)
+u32 fuuki16_state::screen_update(screen_device &screen, bitmap_ind16 &bitmap, const rectangle &cliprect)
 {
-	uint16_t layer0_scrollx, layer0_scrolly;
-	uint16_t layer1_scrollx, layer1_scrolly;
-	uint16_t layer2_scrollx, layer2_scrolly;
-	uint16_t scrollx_offs, scrolly_offs;
-
 	/*
 	It's not independent bits causing layers to switch, that wouldn't make sense with 3 bits.
 	See fuukifg3 for more justification
 	*/
-	static const int pri_table[6][3] = {
+	static const u8 pri_table[6][3] = {
 		{ 0, 1, 2 },
 		{ 0, 2, 1 },
 		{ 1, 0, 2 },
@@ -157,24 +155,24 @@ uint32_t fuuki16_state::screen_update(screen_device &screen, bitmap_ind16 &bitma
 		{ 2, 0, 1 },
 		{ 2, 1, 0 }};
 
-	int tm_front  = pri_table[m_priority[0] & 0x0f][0];
-	int tm_middle = pri_table[m_priority[0] & 0x0f][1];
-	int tm_back   = pri_table[m_priority[0] & 0x0f][2];
+	const u8 tm_front  = pri_table[m_priority[0] & 0x0f][0];
+	const u8 tm_middle = pri_table[m_priority[0] & 0x0f][1];
+	const u8 tm_back   = pri_table[m_priority[0] & 0x0f][2];
 
 	flip_screen_set(m_vregs[0x1e / 2] & 1);
 
 	/* Layers scrolling */
 
-	scrolly_offs = m_vregs[0xc / 2] - (flip_screen() ? 0x103 : 0x1f3);
-	scrollx_offs = m_vregs[0xe / 2] - (flip_screen() ? 0x2a7 : 0x3f6);
+	const u16 scrolly_offs = m_vregs[0xc / 2] - (flip_screen() ? 0x103 : 0x1f3);
+	const u16 scrollx_offs = m_vregs[0xe / 2] - (flip_screen() ? 0x2a7 : 0x3f6);
 
-	layer0_scrolly = m_vregs[0x0 / 2] + scrolly_offs;
-	layer0_scrollx = m_vregs[0x2 / 2] + scrollx_offs;
-	layer1_scrolly = m_vregs[0x4 / 2] + scrolly_offs;
-	layer1_scrollx = m_vregs[0x6 / 2] + scrollx_offs;
+	const u16 layer0_scrolly = m_vregs[0x0 / 2] + scrolly_offs;
+	const u16 layer0_scrollx = m_vregs[0x2 / 2] + scrollx_offs;
+	const u16 layer1_scrolly = m_vregs[0x4 / 2] + scrolly_offs;
+	const u16 layer1_scrollx = m_vregs[0x6 / 2] + scrollx_offs;
 
-	layer2_scrolly = m_vregs[0x8 / 2];
-	layer2_scrollx = m_vregs[0xa / 2];
+	const u16 layer2_scrolly = m_vregs[0x8 / 2];
+	const u16 layer2_scrollx = m_vregs[0xa / 2];
 
 	m_tilemap[0]->set_scrollx(0, layer0_scrollx);
 	m_tilemap[0]->set_scrolly(0, layer0_scrolly);
@@ -183,8 +181,6 @@ uint32_t fuuki16_state::screen_update(screen_device &screen, bitmap_ind16 &bitma
 
 	m_tilemap[2]->set_scrollx(0, layer2_scrollx + 0x10);
 	m_tilemap[2]->set_scrolly(0, layer2_scrolly /*+ 0x02*/);
-	m_tilemap[3]->set_scrollx(0, layer2_scrollx + 0x10);
-	m_tilemap[3]->set_scrolly(0, layer2_scrolly /*+ 0x02*/);
 
 	/* The backmost tilemap decides the background color(s) but sprites can
 	   go below the opaque pixels of that tilemap. We thus need to mark the
@@ -199,7 +195,7 @@ uint32_t fuuki16_state::screen_update(screen_device &screen, bitmap_ind16 &bitma
 	draw_layer(screen, bitmap, cliprect, tm_middle, 0, 2);
 	draw_layer(screen, bitmap, cliprect, tm_front,  0, 4);
 
-	m_fuukivid->draw_sprites(screen, bitmap, cliprect, flip_screen(), nullptr);
+	m_fuukivid->draw_sprites(screen, bitmap, cliprect, flip_screen(), m_spriteram, m_spriteram.bytes() / 2);
 
 	return 0;
 }

--- a/src/mame/video/fuukifg3.cpp
+++ b/src/mame/video/fuukifg3.cpp
@@ -10,7 +10,7 @@
 
     [ 4 Scrolling Layers ]
 
-                            [ Layer 0 ]     [ Layer 1 ]     [ Layers 2&3 (double-buffered) ]
+                            [ Layer 0 ]     [ Layer 1 ]     [ Layer 2 (double-buffered) ]
 
     Tile Size:              16 x 16 x 8     16 x 16 x 8     8 x 8 x 4
     Layer Size (tiles):     64 x 32         64 x 32         64 x 32
@@ -53,9 +53,10 @@
 template<int Layer, int ColShift>
 TILE_GET_INFO_MEMBER(fuuki32_state::get_tile_info)
 {
-	uint16_t code = (m_vram[Layer][tile_index] & 0xffff0000) >> 16;
-	uint16_t attr = (m_vram[Layer][tile_index] & 0x0000ffff);
-	SET_TILE_INFO_MEMBER((Layer < 2) ? (1 + Layer) : 3, code, (attr & 0x3f) >> ColShift, TILE_FLIPYX(attr >> 6));
+	const int buffer = (Layer < 2) ? 0 : (m_vregs[0x1e / 2] & 0x40) >> 6;
+	const u16 code = (m_vram[Layer|buffer][tile_index] & 0xffff0000) >> 16;
+	const u16 attr = (m_vram[Layer|buffer][tile_index] & 0x0000ffff);
+	SET_TILE_INFO_MEMBER(Layer, code, (attr & 0x3f) >> ColShift, TILE_FLIPYX(attr >> 6));
 }
 
 /***************************************************************************
@@ -68,24 +69,58 @@ TILE_GET_INFO_MEMBER(fuuki32_state::get_tile_info)
 
 void fuuki32_state::video_start()
 {
-//  m_buf_spriteram = std::make_unique<uint32_t[]>(m_spriteram.bytes() / 4);
-//  m_buf_spriteram2 = std::make_unique<uint32_t[]>(m_spriteram.bytes() / 4);
+	const u32 spriteram_size = m_spriteram.bytes();
+	m_buf_spriteram[0] = make_unique_clear<u16[]>(spriteram_size / 2);
+	m_buf_spriteram[1] = make_unique_clear<u16[]>(spriteram_size / 2);
 
 	m_tilemap[0] = &machine().tilemap().create(*m_gfxdecode, tilemap_get_info_delegate(&fuuki32_state::get_tile_info<0, 4>, "layer0", this), TILEMAP_SCAN_ROWS, 16, 16, 64, 32);
 	m_tilemap[1] = &machine().tilemap().create(*m_gfxdecode, tilemap_get_info_delegate(&fuuki32_state::get_tile_info<1, 4>, "layer1", this), TILEMAP_SCAN_ROWS, 16, 16, 64, 32);
 	m_tilemap[2] = &machine().tilemap().create(*m_gfxdecode, tilemap_get_info_delegate(&fuuki32_state::get_tile_info<2, 0>, "layer2", this), TILEMAP_SCAN_ROWS,  8,  8, 64, 32);
-	m_tilemap[3] = &machine().tilemap().create(*m_gfxdecode, tilemap_get_info_delegate(&fuuki32_state::get_tile_info<3, 0>, "layer3", this), TILEMAP_SCAN_ROWS,  8,  8, 64, 32);
 
 	m_tilemap[0]->set_transparent_pen(0xff);    // 8 bits
 	m_tilemap[1]->set_transparent_pen(0xff);    // 8 bits
 	m_tilemap[2]->set_transparent_pen(0x0f);    // 4 bits
-	m_tilemap[3]->set_transparent_pen(0x0f);    // 4 bits
 
-	//m_gfxdecode->gfx(1)->set_granularity(16); /* 256 colour tiles with palette selectable on 16 colour boundaries */
-	//m_gfxdecode->gfx(2)->set_granularity(16);
+	//m_gfxdecode->gfx(0)->set_granularity(16); /* 256 colour tiles with palette selectable on 16 colour boundaries */
+	//m_gfxdecode->gfx(1)->set_granularity(16);
+
+	save_pointer(NAME(m_buf_spriteram[0]), spriteram_size / 2);
+	save_pointer(NAME(m_buf_spriteram[1]), spriteram_size / 2);
 }
 
 
+void fuuki32_state::sprram_w(offs_t offset, u16 data, u16 mem_mask)
+{
+	COMBINE_DATA(&m_spriteram[offset]);
+};
+
+u16 fuuki32_state::sprram_r(offs_t offset)
+{
+	return m_spriteram[offset];
+}
+
+void fuuki32_state::fuuki32_tile_cb(u32 &code)
+{
+	const u32 bank = (code & 0xc000) >> 14;
+
+	const u32 bank_lookedup = ((m_spr_buffered_tilebank[1] & 0xffff0000) >> (16 + bank * 4)) & 0xf;
+	code &= 0x3fff;
+	code += bank_lookedup * 0x4000;
+}
+
+void fuuki32_state::fuuki32_colpri_cb(u32 &colour, u32 &pri_mask)
+{
+	const u8 priority = (colour >> 6) & 3;
+	switch (priority)
+	{
+		case 3:  pri_mask = 0xf0 | 0xcc | 0xaa;  break;  // behind all layers
+		case 2:  pri_mask = 0xf0 | 0xcc;         break;  // behind fg + middle layer
+		case 1:  pri_mask = 0xf0;                break;  // behind fg layer
+		case 0:
+		default: pri_mask = 0;                       // above all
+	}
+	colour &= 0x3f;
+}
 
 /***************************************************************************
 
@@ -105,7 +140,7 @@ void fuuki32_state::video_start()
 
         10-1a.w     ? 0
         1c.w        Trigger a level 5 irq on this raster line
-        1e.w        ? $3390/$3393 (Flip Screen Off/On), $0040 is buffer for tilemap 2 or 3
+        1e.w        ? $3390/$3393 (Flip Screen Off/On), $0040 is buffer for tilemap 2
 
     Priority Register (priority):
 
@@ -121,33 +156,18 @@ void fuuki32_state::video_start()
 ***************************************************************************/
 
 /* Wrapper to handle bg and bg2 ttogether */
-void fuuki32_state::draw_layer( screen_device &screen, bitmap_ind16 &bitmap, const rectangle &cliprect, int i, int flag, int pri )
+void fuuki32_state::draw_layer(screen_device &screen, bitmap_ind16 &bitmap, const rectangle &cliprect, u8 i, int flag, u8 pri, u8 primask)
 {
-	int buffer = ((m_vregs[0x1e / 4] & 0x0000ffff) & 0x40) >> 6;
-
-	switch( i )
-	{
-		case 2: m_tilemap[2|buffer]->draw(screen, bitmap, cliprect, flag, pri);
-				return;
-		case 1: m_tilemap[1]->draw(screen, bitmap, cliprect, flag, pri);
-				return;
-		case 0: m_tilemap[0]->draw(screen, bitmap, cliprect, flag, pri);
-				return;
-	}
+	m_tilemap[i]->draw(screen, bitmap, cliprect, flag, pri, primask);
 }
 
-uint32_t fuuki32_state::screen_update(screen_device &screen, bitmap_ind16 &bitmap, const rectangle &cliprect)
+u32 fuuki32_state::screen_update(screen_device &screen, bitmap_ind16 &bitmap, const rectangle &cliprect)
 {
-	uint16_t layer0_scrollx, layer0_scrolly;
-	uint16_t layer1_scrollx, layer1_scrolly;
-	uint16_t layer2_scrollx, layer2_scrolly;
-	uint16_t scrollx_offs,   scrolly_offs;
-
 	/*
 	It's not independent bits causing layers to switch, that wouldn't make sense with 3 bits.
 	*/
 
-	static const int pri_table[6][3] = {
+	static const u8 pri_table[6][3] = {
 		{ 0, 1, 2 }, // Special moves 0>1, 0>2 (0,1,2 or 0,2,1)
 		{ 0, 2, 1 }, // Two Levels - 0>1 (0,1,2 or 0,2,1 or 2,0,1)
 		{ 1, 0, 2 }, // Most Levels - 2>1 1>0 2>0 (1,0,2)
@@ -155,24 +175,24 @@ uint32_t fuuki32_state::screen_update(screen_device &screen, bitmap_ind16 &bitma
 		{ 2, 0, 1 }, // Title etc. - 0>1 (0,1,2 or 0,2,1 or 2,0,1)
 		{ 2, 1, 0 }}; // Char Select, prison stage 1>0 (leaves 1,2,0 or 2,1,0)
 
-	int tm_front  = pri_table[(m_priority[0] >> 16) & 0x0f][0];
-	int tm_middle = pri_table[(m_priority[0] >> 16) & 0x0f][1];
-	int tm_back   = pri_table[(m_priority[0] >> 16) & 0x0f][2];
+	const u8 tm_front  = pri_table[(m_priority[0] >> 16) & 0x0f][0];
+	const u8 tm_middle = pri_table[(m_priority[0] >> 16) & 0x0f][1];
+	const u8 tm_back   = pri_table[(m_priority[0] >> 16) & 0x0f][2];
 
-	flip_screen_set((m_vregs[0x1e / 4] & 0x0000ffff) & 1);
+	flip_screen_set(m_vregs[0x1e / 2] & 1);
 
 	/* Layers scrolling */
 
-	scrolly_offs = ((m_vregs[0xc / 4] & 0xffff0000) >> 16) - (flip_screen() ? 0x103 : 0x1f3);
-	scrollx_offs =  (m_vregs[0xc / 4] & 0x0000ffff) - (flip_screen() ? 0x2c7 : 0x3f6);
+	const u16 scrolly_offs = m_vregs[0xc / 2] - (flip_screen() ? 0x103 : 0x1f3);
+	const u16 scrollx_offs = m_vregs[0xe / 2] - (flip_screen() ? 0x2c7 : 0x3f6);
 
-	layer0_scrolly = ((m_vregs[0x0 / 4] & 0xffff0000) >> 16) + scrolly_offs;
-	layer0_scrollx = ((m_vregs[0x0 / 4] & 0x0000ffff)) + scrollx_offs;
-	layer1_scrolly = ((m_vregs[0x4 / 4] & 0xffff0000) >> 16) + scrolly_offs;
-	layer1_scrollx = ((m_vregs[0x4 / 4] & 0x0000ffff)) + scrollx_offs;
+	const u16 layer0_scrolly = m_vregs[0x0 / 2] + scrolly_offs;
+	const u16 layer0_scrollx = m_vregs[0x2 / 2] + scrollx_offs;
+	const u16 layer1_scrolly = m_vregs[0x4 / 2] + scrolly_offs;
+	const u16 layer1_scrollx = m_vregs[0x6 / 2] + scrollx_offs;
 
-	layer2_scrolly = ((m_vregs[0x8 / 4] & 0xffff0000) >> 16);
-	layer2_scrollx = ((m_vregs[0x8 / 4] & 0x0000ffff));
+	const u16 layer2_scrolly = m_vregs[0x8 / 2];
+	const u16 layer2_scrollx = m_vregs[0xa / 2];
 
 	m_tilemap[0]->set_scrollx(0, layer0_scrollx);
 	m_tilemap[0]->set_scrolly(0, layer0_scrolly);
@@ -181,8 +201,6 @@ uint32_t fuuki32_state::screen_update(screen_device &screen, bitmap_ind16 &bitma
 
 	m_tilemap[2]->set_scrollx(0, layer2_scrollx);
 	m_tilemap[2]->set_scrolly(0, layer2_scrolly);
-	m_tilemap[3]->set_scrollx(0, layer2_scrollx);
-	m_tilemap[3]->set_scrolly(0, layer2_scrolly);
 
 	/* The bg colour is the last pen i.e. 0x1fff */
 	bitmap.fill((0x800 * 4) - 1, cliprect);
@@ -192,7 +210,7 @@ uint32_t fuuki32_state::screen_update(screen_device &screen, bitmap_ind16 &bitma
 	draw_layer(screen, bitmap, cliprect, tm_middle, 0, 2);
 	draw_layer(screen, bitmap, cliprect, tm_front,  0, 4);
 
-	m_fuukivid->draw_sprites(screen, bitmap, cliprect, flip_screen(), m_spr_buffered_tilebank);
+	m_fuukivid->draw_sprites(screen, bitmap, cliprect, flip_screen(), m_buf_spriteram[1].get(), m_spriteram.bytes() / 2);
 	return 0;
 }
 
@@ -204,6 +222,7 @@ WRITE_LINE_MEMBER(fuuki32_state::screen_vblank)
 		/* Buffer sprites and tilebank by 2 frames */
 		m_spr_buffered_tilebank[1] = m_spr_buffered_tilebank[0];
 		m_spr_buffered_tilebank[0] = m_tilebank[0];
-		m_fuukivid->buffer_sprites();
+		memcpy(m_buf_spriteram[1].get(), m_buf_spriteram[0].get(), m_spriteram.bytes());
+		memcpy(m_buf_spriteram[0].get(), m_spriteram, m_spriteram.bytes());
 	}
 }


### PR DESCRIPTION
Use callback for colour, priority, tilebank behaviors, Internalize gfxdecodes, Use external spriteram, Reduce unnecessary lines, Fix spacings, Use shorter / correct type values
fuukifg2.cpp, fuukifg3.cpp : Updates
Correct spriteram, vreg types, Use tilemap buffer behavior into RAM bank (number of actually visible tilemap layer is 3), SImplify handlers, Reduce unnecessary lines, Fix notes, Spacings, Use shorter / correct type values