### PR TITLE
taito_f3.cpp, 2mindril.cpp : Updates

### DIFF
--- a/src/mame/drivers/2mindril.cpp
+++ b/src/mame/drivers/2mindril.cpp
@@ -55,26 +55,27 @@ public:
 
 	void init_drill();
 
+protected:
+	virtual void machine_start() override;
+	virtual void machine_reset() override;
+
 private:
 	/* input-related */
 	required_ioport m_in0;
-	uint8_t         m_defender_sensor;
-	uint8_t         m_shutter_sensor;
-	uint16_t        m_irq_reg;
+	u8         m_defender_sensor;
+	u8         m_shutter_sensor;
+	u16        m_irq_reg;
 
 	/* devices */
-	DECLARE_READ8_MEMBER(arm_pwr_r);
-	DECLARE_READ8_MEMBER(sensors_r);
-	DECLARE_WRITE8_MEMBER(coins_w);
-	DECLARE_WRITE16_MEMBER(sensors_w);
-	DECLARE_READ16_MEMBER(drill_irq_r);
-	DECLARE_WRITE16_MEMBER(drill_irq_w);
+	u8 arm_pwr_r();
+	u8 sensors_r();
+	void coins_w(u8 data);
+	void sensors_w(u16 data);
+	u16 irq_r();
+	void irq_w(offs_t offset, u16 data, u16 mem_mask);
 
-	DECLARE_MACHINE_START(drill);
-	DECLARE_MACHINE_RESET(drill);
-	INTERRUPT_GEN_MEMBER(drill_vblank_irq);
+	INTERRUPT_GEN_MEMBER(vblank_irq);
 	//INTERRUPT_GEN_MEMBER(drill_device_irq);
-	void tile_decode();
 	DECLARE_WRITE_LINE_MEMBER(irqhandler);
 
 	void drill_map(address_map &map);
@@ -92,23 +93,23 @@ protected:
 };
 
 
-READ8_MEMBER(_2mindril_state::arm_pwr_r)
+u8 _2mindril_state::arm_pwr_r()
 {
 	int arm_pwr = m_in0->read();//throw
 
-	if(arm_pwr > 0xe0) return ~0x18;
-	if(arm_pwr > 0xc0) return ~0x14;
-	if(arm_pwr > 0x80) return ~0x12;
-	if(arm_pwr > 0x40) return ~0x10;
+	if (arm_pwr > 0xe0) return ~0x18;
+	if (arm_pwr > 0xc0) return ~0x14;
+	if (arm_pwr > 0x80) return ~0x12;
+	if (arm_pwr > 0x40) return ~0x10;
 	else return ~0x00;
 }
 
-READ8_MEMBER(_2mindril_state::sensors_r)
+u8 _2mindril_state::sensors_r()
 {
 	return (m_defender_sensor) | (m_shutter_sensor);
 }
 
-WRITE8_MEMBER(_2mindril_state::coins_w)
+void _2mindril_state::coins_w(u8 data)
 {
 	machine().bookkeeping().coin_counter_w(0, data & 0x04);
 	machine().bookkeeping().coin_counter_w(1, data & 0x08);
@@ -147,7 +148,7 @@ void _2mindril_state::device_timer(emu_timer &timer, device_timer_id id, int par
 }
 #endif
 
-WRITE16_MEMBER(_2mindril_state::sensors_w)
+void _2mindril_state::sensors_w(u16 data)
 {
 	/*---- xxxx ---- ---- select "lamps" (guess)*/
 	/*---- ---- ---- -x-- lamp*/
@@ -174,12 +175,12 @@ WRITE16_MEMBER(_2mindril_state::sensors_w)
 	}
 }
 
-READ16_MEMBER(_2mindril_state::drill_irq_r)
+u16 _2mindril_state::irq_r()
 {
 	return m_irq_reg;
 }
 
-WRITE16_MEMBER(_2mindril_state::drill_irq_w)
+void _2mindril_state::irq_w(offs_t offset, u16 data, u16 mem_mask)
 {
 	/*
 	(note: could rather be irq mask)
@@ -187,13 +188,13 @@ WRITE16_MEMBER(_2mindril_state::drill_irq_w)
 	---- ---- ---- x--- irq lv 4 ack, 0->1 latch
 	---- ---- -??- -??? connected to the other levels?
 	*/
-	if(((m_irq_reg & 8) == 0) && data & 8)
+	if (((m_irq_reg & 8) == 0) && data & 8)
 		m_maincpu->set_input_line(4, CLEAR_LINE);
 
-	if(((m_irq_reg & 0x10) == 0) && data & 0x10)
+	if (((m_irq_reg & 0x10) == 0) && data & 0x10)
 		m_maincpu->set_input_line(5, CLEAR_LINE);
 
-	if(data & 0xffe7)
+	if (data & 0xffe7)
 		printf("%04x\n",data);
 
 	COMBINE_DATA(&m_irq_reg);
@@ -204,18 +205,18 @@ void _2mindril_state::drill_map(address_map &map)
 	map(0x000000, 0x07ffff).rom();
 	map(0x200000, 0x20ffff).ram();
 	map(0x300000, 0x3000ff).ram();
-	map(0x400000, 0x40ffff).rw(FUNC(_2mindril_state::f3_spriteram_r), FUNC(_2mindril_state::f3_spriteram_w));
-	map(0x410000, 0x41bfff).rw(FUNC(_2mindril_state::f3_pf_data_r), FUNC(_2mindril_state::f3_pf_data_w));
-	map(0x41c000, 0x41dfff).rw(FUNC(_2mindril_state::f3_videoram_r), FUNC(_2mindril_state::f3_videoram_w));
-	map(0x41e000, 0x41ffff).rw(FUNC(_2mindril_state::f3_vram_r), FUNC(_2mindril_state::f3_vram_w));
-	map(0x420000, 0x42ffff).rw(FUNC(_2mindril_state::f3_lineram_r), FUNC(_2mindril_state::f3_lineram_w));
-	map(0x430000, 0x43ffff).rw(FUNC(_2mindril_state::f3_pivot_r), FUNC(_2mindril_state::f3_pivot_w));
-	map(0x460000, 0x46000f).w(FUNC(_2mindril_state::f3_control_0_w));
-	map(0x460010, 0x46001f).w(FUNC(_2mindril_state::f3_control_1_w));
+	map(0x400000, 0x40ffff).ram().share("spriteram");
+	map(0x410000, 0x41bfff).ram().w(FUNC(_2mindril_state::pf_ram_w)).share("pf_ram");
+	map(0x41c000, 0x41dfff).ram().w(FUNC(_2mindril_state::textram_w)).share("textram");
+	map(0x41e000, 0x41ffff).ram().w(FUNC(_2mindril_state::charram_w)).share("charram");
+	map(0x420000, 0x42ffff).ram().share("line_ram");
+	map(0x430000, 0x43ffff).ram().w(FUNC(_2mindril_state::pivot_w)).share("pivot_ram");
+	map(0x460000, 0x46000f).w(FUNC(_2mindril_state::control_0_w));
+	map(0x460010, 0x46001f).w(FUNC(_2mindril_state::control_1_w));
 	map(0x500000, 0x501fff).ram().w(m_palette, FUNC(palette_device::write16)).share("palette");
 	map(0x502022, 0x502023).nopw(); //countinously switches between 0 and 2
 	map(0x600000, 0x600007).rw("ymsnd", FUNC(ym2610_device::read), FUNC(ym2610_device::write)).umask16(0x00ff);
-	map(0x60000c, 0x60000d).rw(FUNC(_2mindril_state::drill_irq_r), FUNC(_2mindril_state::drill_irq_w));
+	map(0x60000c, 0x60000d).rw(FUNC(_2mindril_state::irq_r), FUNC(_2mindril_state::irq_w));
 	map(0x60000e, 0x60000f).ram(); // unknown purpose, zeroed at start-up and nothing else
 	map(0x700000, 0x70000f).rw("tc0510nio", FUNC(tc0510nio_device::read), FUNC(tc0510nio_device::write)).umask16(0xff00);
 	map(0x800000, 0x800001).w(FUNC(_2mindril_state::sensors_w));
@@ -269,7 +270,7 @@ static const gfx_layout charlayout =
 	4,
 	{ 0,1,2,3 },
 	{ 20, 16, 28, 24, 4, 0, 12, 8 },
-	{ 0*32, 1*32, 2*32, 3*32, 4*32, 5*32, 6*32, 7*32 },
+	{ STEP8(0,4*8) },
 	32*8
 };
 
@@ -280,52 +281,19 @@ static const gfx_layout pivotlayout =
 	4,
 	{ 0,1,2,3 },
 	{ 20, 16, 28, 24, 4, 0, 12, 8 },
-	{ 0*32, 1*32, 2*32, 3*32, 4*32, 5*32, 6*32, 7*32 },
+	{ STEP8(0,4*8) },
 	32*8
 };
 
-static const gfx_layout spriteram_layout =
-{
-	16,16,
-	RGN_FRAC(1,2),
-	6,  /* Palettes have 4 bpp indexes despite up to 6 bpp data */
-	{ RGN_FRAC(1,2)+0, RGN_FRAC(1,2)+1, 0, 1, 2, 3 },
-	{
-	4, 0, 12, 8,
-	16+4, 16+0, 16+12, 16+8,
-	32+4, 32+0, 32+12, 32+8,
-	48+4, 48+0, 48+12, 48+8 },
-	{ 0*64, 1*64, 2*64, 3*64, 4*64, 5*64, 6*64, 7*64,
-			8*64, 9*64, 10*64, 11*64, 12*64, 13*64, 14*64, 15*64 },
-	128*8   /* every sprite takes 128 consecutive bytes */
-};
-
-static const gfx_layout tile_layout =
-{
-	16,16,
-	RGN_FRAC(1,2),
-	6,  /* Palettes have 4 bpp indexes despite up to 6 bpp data */
-	{ RGN_FRAC(1,2)+2, RGN_FRAC(1,2)+3, 0, 1, 2, 3 },
-	{
-	4, 0, 16+4, 16+0,
-	8+4, 8+0, 24+4, 24+0,
-	32+4, 32+0, 48+4, 48+0,
-	40+4, 40+0, 56+4, 56+0,
-	},
-	{ 0*64, 1*64, 2*64, 3*64, 4*64, 5*64, 6*64, 7*64,
-			8*64, 9*64, 10*64, 11*64, 12*64, 13*64, 14*64, 15*64 },
-	128*8   /* every sprite takes 128 consecutive bytes */
-};
-
 static GFXDECODE_START( gfx_2mindril )
-	GFXDECODE_ENTRY( nullptr,   0x000000, charlayout,       0x0000, 0x0400>>4 ) /* Dynamically modified */
-	GFXDECODE_ENTRY( "gfx2", 0x000000, tile_layout,      0x0000, 0x2000>>4 ) /* Tiles area */
-	GFXDECODE_ENTRY( "gfx1", 0x000000, spriteram_layout, 0x1000, 0x1000>>4 ) /* Sprites area */
-	GFXDECODE_ENTRY( nullptr,   0x000000, pivotlayout,      0x0000,  0x400>>4 ) /* Dynamically modified */
+	GFXDECODE_ENTRY( nullptr,   0x000000, charlayout,             0x0000, 0x0400>>4 ) /* Dynamically modified */
+	GFXDECODE_ENTRY( "tilemap", 0x000000, gfx_16x16x4_packed_lsb, 0x0000, 0x2000>>4 ) /* Tiles area */
+	GFXDECODE_ENTRY( "sprites", 0x000000, gfx_16x16x4_packed_lsb, 0x1000, 0x1000>>4 ) /* Sprites area */
+	GFXDECODE_ENTRY( nullptr,   0x000000, pivotlayout,            0x0000,  0x400>>4 ) /* Dynamically modified */
 GFXDECODE_END
 
 
-INTERRUPT_GEN_MEMBER(_2mindril_state::drill_vblank_irq)
+INTERRUPT_GEN_MEMBER(_2mindril_state::vblank_irq)
 {
 	device.execute().set_input_line(4, ASSERT_LINE);
 }
@@ -344,14 +312,14 @@ WRITE_LINE_MEMBER(_2mindril_state::irqhandler)
 }
 
 
-MACHINE_START_MEMBER(_2mindril_state,drill)
+void _2mindril_state::machine_start()
 {
 	save_item(NAME(m_defender_sensor));
 	save_item(NAME(m_shutter_sensor));
 	save_item(NAME(m_irq_reg));
 }
 
-MACHINE_RESET_MEMBER(_2mindril_state,drill)
+void _2mindril_state::machine_reset()
 {
 	m_defender_sensor = 0;
 	m_shutter_sensor = 0;
@@ -362,7 +330,7 @@ void _2mindril_state::drill(machine_config &config)
 {
 	M68000(config, m_maincpu, 16000000);
 	m_maincpu->set_addrmap(AS_PROGRAM, &_2mindril_state::drill_map);
-	m_maincpu->set_vblank_int("screen", FUNC(_2mindril_state::drill_vblank_irq));
+	m_maincpu->set_vblank_int("screen", FUNC(_2mindril_state::vblank_irq));
 	//MCFG_DEVICE_PERIODIC_INT_DRIVER(_2mindril_state, drill_device_irq, 60)
 	GFXDECODE(config, m_gfxdecode, m_palette, gfx_2mindril);
 
@@ -373,16 +341,13 @@ void _2mindril_state::drill(machine_config &config)
 	tc0510nio.write_4_callback().set(FUNC(_2mindril_state::coins_w));
 	tc0510nio.read_7_callback().set_ioport("COINS");
 
-	MCFG_MACHINE_START_OVERRIDE(_2mindril_state,drill)
-	MCFG_MACHINE_RESET_OVERRIDE(_2mindril_state,drill)
-
 	SCREEN(config, m_screen, SCREEN_TYPE_RASTER);
 	m_screen->set_refresh_hz(60);
 	m_screen->set_vblank_time(ATTOSECONDS_IN_USEC(2500)); /* inaccurate, same as Taito F3? (needs screen raw params anyway) */
 	m_screen->set_size(40*8+48*2, 32*8);
 	m_screen->set_visarea(46, 40*8-1 + 46, 24, 24+224-1);
-	m_screen->set_screen_update(FUNC(_2mindril_state::screen_update_f3));
-	m_screen->screen_vblank().set(FUNC(_2mindril_state::screen_vblank_f3));
+	m_screen->set_screen_update(FUNC(_2mindril_state::screen_update));
+	m_screen->screen_vblank().set(FUNC(_2mindril_state::screen_vblank));
 
 	PALETTE(config, m_palette).set_format(palette_device::RRRRGGGGBBBBRGBx, 0x2000);
 
@@ -406,78 +371,20 @@ ROM_START( 2mindril )
 	ROM_REGION( 0x200000, "ymsnd", 0 ) /* Samples */
 	ROM_LOAD( "d58-11.ic31", 0x000000, 0x200000,  CRC(dc26d58d) SHA1(cffb18667da18f5367b02af85a2f7674dd61ae97) )
 
-	ROM_REGION( 0x800000, "gfx1", ROMREGION_ERASE00 )
+	ROM_REGION( 0x400000, "sprites", ROMREGION_ERASE00 )
+	ROM_REGION( 0x200000, "sprites_hi", ROMREGION_ERASE00 )
 
-	ROM_REGION( 0x800000, "gfx2", 0 )
-	ROM_LOAD16_BYTE( "d58-09.ic28", 0x000001, 0x200000, CRC(d8f6a86a) SHA1(d6b2ec309e21064574ee63e025ae4716b1982a98) )
-	ROM_LOAD16_BYTE( "d58-08.ic27", 0x000000, 0x200000, CRC(9f5a3f52) SHA1(7b696bd823819965b974c853cebc1660750db61e) )
-	ROM_LOAD( "d58-10.ic29", 0x400000, 0x200000, CRC(74c87e08) SHA1(f39b3a64f8338ccf5ca6eb76cee92a10fe0aad8f) )
-	ROM_RELOAD(              0x600000, 0x200000 )
+	ROM_REGION( 0x400000, "tilemap", 0 )
+	ROM_LOAD32_WORD( "d58-08.ic27", 0x000000, 0x200000, CRC(9f5a3f52) SHA1(7b696bd823819965b974c853cebc1660750db61e) )
+	ROM_LOAD32_WORD( "d58-09.ic28", 0x000002, 0x200000, CRC(d8f6a86a) SHA1(d6b2ec309e21064574ee63e025ae4716b1982a98) )
+
+	ROM_REGION( 0x200000, "tilemap_hi", 0 )
+	ROM_LOAD       ( "d58-10.ic29", 0x000000, 0x200000, CRC(74c87e08) SHA1(f39b3a64f8338ccf5ca6eb76cee92a10fe0aad8f) )
 ROM_END
-
-void _2mindril_state::tile_decode()
-{
-	uint8_t lsb,msb;
-	uint32_t offset,i;
-	uint8_t *gfx = memregion("gfx2")->base();
-	int size=memregion("gfx2")->bytes();
-	int data;
-
-	/* Setup ROM formats:
-
-	    Some games will only use 4 or 5 bpp sprites, and some only use 4 bpp tiles,
-	    I don't believe this is software or prom controlled but simply the unused data lines
-	    are tied low on the game board if unused.  This is backed up by the fact the palette
-	    indices are always related to 4 bpp data, even in 6 bpp games.
-
-	    Most (all?) games with 5bpp tiles have the sixth bit set. Also, in Arabian Magic
-	    sprites 1200-120f contain 6bpp data which is probably bogus.
-	    video_start clears the fifth and sixth bit of the decoded graphics according
-	    to the bit depth specified in f3_config_table.
-
-	*/
-
-	offset = size/2;
-	for (i = size/2+size/4; i<size; i+=2)
-	{
-		/* Expand 2bits into 4bits format */
-		lsb = gfx[i+1];
-		msb = gfx[i];
-
-		gfx[offset+0]=((msb&0x02)<<3) | ((msb&0x01)>>0) | ((lsb&0x02)<<4) | ((lsb&0x01)<<1);
-		gfx[offset+2]=((msb&0x08)<<1) | ((msb&0x04)>>2) | ((lsb&0x08)<<2) | ((lsb&0x04)>>1);
-		gfx[offset+1]=((msb&0x20)>>1) | ((msb&0x10)>>4) | ((lsb&0x20)<<0) | ((lsb&0x10)>>3);
-		gfx[offset+3]=((msb&0x80)>>3) | ((msb&0x40)>>6) | ((lsb&0x80)>>2) | ((lsb&0x40)>>5);
-
-		offset+=4;
-	}
-
-	gfx = memregion("gfx1")->base();
-	size=memregion("gfx1")->bytes();
-
-	offset = size/2;
-	for (i = size/2+size/4; i<size; i++)
-	{
-		int d1,d2,d3,d4;
-
-		/* Expand 2bits into 4bits format */
-		data = gfx[i];
-		d1 = (data>>0) & 3;
-		d2 = (data>>2) & 3;
-		d3 = (data>>4) & 3;
-		d4 = (data>>6) & 3;
-
-		gfx[offset] = (d1<<2) | (d2<<6);
-		offset++;
-
-		gfx[offset] = (d3<<2) | (d4<<6);
-		offset++;
-	}
-}
 
 void _2mindril_state::init_drill()
 {
-	m_f3_game = TMDRILL;
+	m_game = TMDRILL;
 	tile_decode();
 }
 

--- a/src/mame/drivers/taito_f3.cpp
+++ b/src/mame/drivers/taito_f3.cpp
@@ -44,28 +44,28 @@
 
 CUSTOM_INPUT_MEMBER(taito_f3_state::f3_analog_r)
 {
-	int num = (uintptr_t)param;
-	int data = m_dial[num]->read();
-	return ((data & 0xf)<<12) | ((data & 0xff0)>>4);
+	const int num = (uintptr_t)param;
+	const int data = m_dial[num]->read();
+	return ((data & 0xf) << 12) | ((data & 0xff0) >> 4);
 }
 
 
 CUSTOM_INPUT_MEMBER(taito_f3_state::f3_coin_r)
 {
-	int num = (uintptr_t)param;
+	const int num = (uintptr_t)param;
 	return m_coin_word[num];
 }
 
-READ32_MEMBER(taito_f3_state::f3_control_r)
+u32 taito_f3_state::f3_control_r(offs_t offset)
 {
-	if (offset<6)
+	if (offset < 6)
 		return m_input[offset]->read();
 	else logerror("CPU #0 PC %06x: warning - read unmapped control address %06x\n", m_maincpu->pc(), offset);
 
 	return 0xffffffff;
 }
 
-WRITE32_MEMBER(taito_f3_state::f3_control_w)
+void taito_f3_state::f3_control_w(offs_t offset, u32 data, u32 mem_mask)
 {
 	switch (offset)
 	{
@@ -87,7 +87,7 @@ WRITE32_MEMBER(taito_f3_state::f3_control_w)
 		case 0x04: /* Eeprom */
 			if (ACCESSING_BITS_0_7)
 			{
-				ioport("EEPROMOUT")->write(data, 0xff);
+				m_eepromout->write(data, 0xff);
 			}
 			return;
 
@@ -105,22 +105,21 @@ WRITE32_MEMBER(taito_f3_state::f3_control_w)
 	logerror("CPU #0 PC %06x: warning - write unmapped control address %06x %08x\n",m_maincpu->pc(),offset,data);
 }
 
-WRITE32_MEMBER(taito_f3_state::f3_sound_reset_0_w)
+void taito_f3_state::sound_reset_0_w(u32 data)
 {
 	m_audiocpu->set_input_line(INPUT_LINE_RESET, CLEAR_LINE);
 }
 
-WRITE32_MEMBER(taito_f3_state::f3_sound_reset_1_w)
+void taito_f3_state::sound_reset_1_w(u32 data)
 {
 	m_audiocpu->set_input_line(INPUT_LINE_RESET, ASSERT_LINE);
 }
 
-WRITE32_MEMBER(taito_f3_state::f3_sound_bankswitch_w)
+void taito_f3_state::sound_bankswitch_w(offs_t offset, u32 data, u32 mem_mask)
 {
-	if (m_f3_game==KIRAMEKI) {
-		int idx;
-
-		idx = (offset << 1) & 0x1e;
+	if (m_game == KIRAMEKI)
+	{
+		int idx = (offset << 1) & 0x1e;
 		if (ACCESSING_BITS_0_15)
 			idx += 1;
 
@@ -129,14 +128,16 @@ WRITE32_MEMBER(taito_f3_state::f3_sound_bankswitch_w)
 
 		/* Banks are 0x20000 bytes each, divide by two to get data16
 		pointer rather than byte pointer */
-		m_taito_en->set_bank(1,idx);
+		m_taito_en->set_bank(1, idx);
 
-	} else {
+	}
+	else
+	{
 		logerror("Sound bankswitch in unsupported game\n");
 	}
 }
 
-WRITE16_MEMBER(taito_f3_state::f3_unk_w)
+void taito_f3_state::f3_unk_w(offs_t offset, u16 data)
 {
 	/*
 	Several games writes a value here at POST, dunno what kind of config this is ...
@@ -174,7 +175,7 @@ WRITE16_MEMBER(taito_f3_state::f3_unk_w)
 	popnpop:   0x0000
 	landmakr:  0x278b
 	*/
-	if(offset == 0)
+	if (offset == 0)
 		logerror("0x4c0000 write %04x\n",data);
 	else
 		popmessage("0x4c0002 write %04x, contact MAMEdev",data); //shouldn't happen
@@ -185,45 +186,65 @@ WRITE16_MEMBER(taito_f3_state::f3_unk_w)
 void taito_f3_state::f3_map(address_map &map)
 {
 	map(0x000000, 0x1fffff).rom();
-	map(0x300000, 0x30007f).w(FUNC(taito_f3_state::f3_sound_bankswitch_w));
-	map(0x400000, 0x41ffff).mirror(0x20000).ram().share("f3_ram");
-	map(0x440000, 0x447fff).ram().w(FUNC(taito_f3_state::f3_palette_24bit_w)).share("paletteram");
+	map(0x300000, 0x30007f).w(FUNC(taito_f3_state::sound_bankswitch_w));
+	map(0x400000, 0x41ffff).mirror(0x20000).ram();
+	map(0x440000, 0x447fff).ram().w(FUNC(taito_f3_state::palette_24bit_w)).share("paletteram");
 	map(0x4a0000, 0x4a001f).rw(FUNC(taito_f3_state::f3_control_r), FUNC(taito_f3_state::f3_control_w));
 	map(0x4c0000, 0x4c0003).w(FUNC(taito_f3_state::f3_unk_w));
-	map(0x600000, 0x60ffff).rw(FUNC(taito_f3_state::f3_spriteram_r), FUNC(taito_f3_state::f3_spriteram_w)); //AM_SHARE("spriteram")
-	map(0x610000, 0x61bfff).rw(FUNC(taito_f3_state::f3_pf_data_r), FUNC(taito_f3_state::f3_pf_data_w));       //AM_SHARE("f3_pf_data")
-	map(0x61c000, 0x61dfff).rw(FUNC(taito_f3_state::f3_videoram_r), FUNC(taito_f3_state::f3_videoram_w));     //AM_SHARE("videoram")
-	map(0x61e000, 0x61ffff).rw(FUNC(taito_f3_state::f3_vram_r), FUNC(taito_f3_state::f3_vram_w));             //AM_SHARE("f3_vram")
-	map(0x620000, 0x62ffff).rw(FUNC(taito_f3_state::f3_lineram_r), FUNC(taito_f3_state::f3_lineram_w));       //AM_SHARE("f3_line_ram")
-	map(0x630000, 0x63ffff).rw(FUNC(taito_f3_state::f3_pivot_r), FUNC(taito_f3_state::f3_pivot_w));           //AM_SHARE("f3_pivot_ram")
-	map(0x660000, 0x66000f).w(FUNC(taito_f3_state::f3_control_0_w));
-	map(0x660010, 0x66001f).w(FUNC(taito_f3_state::f3_control_1_w));
+	map(0x600000, 0x60ffff).rw(FUNC(taito_f3_state::spriteram_r), FUNC(taito_f3_state::spriteram_w)).share("spriteram");
+	map(0x610000, 0x61bfff).rw(FUNC(taito_f3_state::pf_ram_r), FUNC(taito_f3_state::pf_ram_w)).share("pf_ram");
+	map(0x61c000, 0x61dfff).rw(FUNC(taito_f3_state::textram_r), FUNC(taito_f3_state::textram_w)).share("textram");
+	map(0x61e000, 0x61ffff).rw(FUNC(taito_f3_state::charram_r), FUNC(taito_f3_state::charram_w)).share("charram");
+	map(0x620000, 0x62ffff).rw(FUNC(taito_f3_state::lineram_r), FUNC(taito_f3_state::lineram_w)).share("line_ram");
+	map(0x630000, 0x63ffff).rw(FUNC(taito_f3_state::pivot_r), FUNC(taito_f3_state::pivot_w)).share("pivot_ram");
+	map(0x660000, 0x66000f).w(FUNC(taito_f3_state::control_0_w));
+	map(0x660010, 0x66001f).w(FUNC(taito_f3_state::control_1_w));
 	map(0xc00000, 0xc007ff).rw("taito_en:dpram", FUNC(mb8421_device::left_r), FUNC(mb8421_device::left_w));
-	map(0xc80000, 0xc80003).w(FUNC(taito_f3_state::f3_sound_reset_0_w));
-	map(0xc80100, 0xc80103).w(FUNC(taito_f3_state::f3_sound_reset_1_w));
+	map(0xc80000, 0xc80003).w(FUNC(taito_f3_state::sound_reset_0_w));
+	map(0xc80100, 0xc80103).w(FUNC(taito_f3_state::sound_reset_1_w));
+}
+
+void taito_f3_state::bubsympb_oki_w(u8 data)
+{
+	//printf("write %08x %08x\n",data,mem_mask);
+	const u8 bank = data & 0xf;
+	if (data < 5)
+	{
+		m_okibank->set_entry(bank);
+	}
+	else
+	{
+		logerror("unknown oki bank write %02x at %08x", bank, m_maincpu->pc());
+	}
+	//printf("oki bank w %08x\n",data);
 }
 
 void taito_f3_state::bubsympb_map(address_map &map)
 {
 	map(0x000000, 0x1fffff).rom();
-	map(0x300000, 0x30007f).w(FUNC(taito_f3_state::f3_sound_bankswitch_w));
-	map(0x400000, 0x41ffff).mirror(0x20000).ram().share("f3_ram");
-	map(0x440000, 0x447fff).ram().w(FUNC(taito_f3_state::f3_palette_24bit_w)).share("paletteram");
+	map(0x300000, 0x30007f).w(FUNC(taito_f3_state::sound_bankswitch_w));
+	map(0x400000, 0x41ffff).mirror(0x20000).ram();
+	map(0x440000, 0x447fff).ram().w(FUNC(taito_f3_state::palette_24bit_w)).share("paletteram");
 	map(0x4a0000, 0x4a001b).rw(FUNC(taito_f3_state::f3_control_r), FUNC(taito_f3_state::f3_control_w));
-	map(0x4a001c, 0x4a001f).rw(FUNC(taito_f3_state::bubsympb_oki_r), FUNC(taito_f3_state::bubsympb_oki_w));
+	map(0x4a001d, 0x4a001d).w(FUNC(taito_f3_state::bubsympb_oki_w));
+	map(0x4a001f, 0x4a001f).rw(m_oki, FUNC(okim6295_device::read), FUNC(okim6295_device::write));
 	map(0x4c0000, 0x4c0003).w(FUNC(taito_f3_state::f3_unk_w));
-	map(0x600000, 0x60ffff).rw(FUNC(taito_f3_state::f3_spriteram_r), FUNC(taito_f3_state::f3_spriteram_w)); //AM_SHARE("spriteram")
-	map(0x610000, 0x61bfff).rw(FUNC(taito_f3_state::f3_pf_data_r), FUNC(taito_f3_state::f3_pf_data_w));       //AM_SHARE("f3_pf_data")
-	map(0x61c000, 0x61dfff).rw(FUNC(taito_f3_state::f3_videoram_r), FUNC(taito_f3_state::f3_videoram_w));     //AM_SHARE("videoram")
-	map(0x61e000, 0x61ffff).rw(FUNC(taito_f3_state::f3_vram_r), FUNC(taito_f3_state::f3_vram_w));             //AM_SHARE("f3_vram")
-	map(0x620000, 0x62ffff).rw(FUNC(taito_f3_state::f3_lineram_r), FUNC(taito_f3_state::f3_lineram_w));       //AM_SHARE("f3_line_ram")
-	map(0x630000, 0x63ffff).rw(FUNC(taito_f3_state::f3_pivot_r), FUNC(taito_f3_state::f3_pivot_w));           //AM_SHARE("f3_pivot_ram")
-	map(0x660000, 0x66000f).w(FUNC(taito_f3_state::f3_control_0_w));
-	map(0x660010, 0x66001f).w(FUNC(taito_f3_state::f3_control_1_w));
+	map(0x600000, 0x60ffff).rw(FUNC(taito_f3_state::spriteram_r), FUNC(taito_f3_state::spriteram_w)).share("spriteram");
+	map(0x610000, 0x61bfff).rw(FUNC(taito_f3_state::pf_ram_r), FUNC(taito_f3_state::pf_ram_w)).share("pf_ram");
+	map(0x61c000, 0x61dfff).rw(FUNC(taito_f3_state::textram_r), FUNC(taito_f3_state::textram_w)).share("textram");
+	map(0x61e000, 0x61ffff).rw(FUNC(taito_f3_state::charram_r), FUNC(taito_f3_state::charram_w)).share("charram");
+	map(0x620000, 0x62ffff).rw(FUNC(taito_f3_state::lineram_r), FUNC(taito_f3_state::lineram_w)).share("line_ram");
+	map(0x630000, 0x63ffff).rw(FUNC(taito_f3_state::pivot_r), FUNC(taito_f3_state::pivot_w)).share("pivot_ram");
+	map(0x660000, 0x66000f).w(FUNC(taito_f3_state::control_0_w));
+	map(0x660010, 0x66001f).w(FUNC(taito_f3_state::control_1_w));
 	map(0xc00000, 0xc007ff).ram();
 }
 
-
+void taito_f3_state::bubsympb_oki_map(address_map &map)
+{
+	map(0x00000, 0x2ffff).rom().region("oki", 0);
+	map(0x30000, 0x3ffff).bankr("okibank");
+}
 
 /******************************************************************************/
 
@@ -356,7 +377,7 @@ static const gfx_layout charlayout =
 	4,
 	{ 0,1,2,3 },
 	{ 20, 16, 28, 24, 4, 0, 12, 8 },
-	{ 0*32, 1*32, 2*32, 3*32, 4*32, 5*32, 6*32, 7*32 },
+	{ STEP8(0,4*8) },
 	32*8
 };
 
@@ -367,48 +388,15 @@ static const gfx_layout pivotlayout =
 	4,
 	{ 0,1,2,3 },
 	{ 20, 16, 28, 24, 4, 0, 12, 8 },
-	{ 0*32, 1*32, 2*32, 3*32, 4*32, 5*32, 6*32, 7*32 },
+	{ STEP8(0,4*8) },
 	32*8
 };
 
-static const gfx_layout spriteram_layout =
-{
-	16,16,
-	RGN_FRAC(1,2),
-	6,  /* Palettes have 4 bpp indexes despite up to 6 bpp data */
-	{ RGN_FRAC(1,2)+0, RGN_FRAC(1,2)+1, 0, 1, 2, 3 },
-	{
-	4, 0, 12, 8,
-	16+4, 16+0, 16+12, 16+8,
-	32+4, 32+0, 32+12, 32+8,
-	48+4, 48+0, 48+12, 48+8 },
-	{ 0*64, 1*64, 2*64, 3*64, 4*64, 5*64, 6*64, 7*64,
-			8*64, 9*64, 10*64, 11*64, 12*64, 13*64, 14*64, 15*64 },
-	128*8   /* every sprite takes 128 consecutive bytes */
-};
-
-static const gfx_layout tile_layout =
-{
-	16,16,
-	RGN_FRAC(1,2),
-	6,  /* Palettes have 4 bpp indexes despite up to 6 bpp data */
-	{ RGN_FRAC(1,2)+2, RGN_FRAC(1,2)+3, 0, 1, 2, 3 },
-	{
-	4, 0, 16+4, 16+0,
-	8+4, 8+0, 24+4, 24+0,
-	32+4, 32+0, 48+4, 48+0,
-	40+4, 40+0, 56+4, 56+0,
-	},
-	{ 0*64, 1*64, 2*64, 3*64, 4*64, 5*64, 6*64, 7*64,
-			8*64, 9*64, 10*64, 11*64, 12*64, 13*64, 14*64, 15*64 },
-	128*8   /* every sprite takes 128 consecutive bytes */
-};
-
 static GFXDECODE_START( gfx_taito_f3 )
-	GFXDECODE_ENTRY( nullptr,   0x000000, charlayout,       0x0000, 0x0400>>4 ) /* Dynamically modified */
-	GFXDECODE_ENTRY( "gfx2", 0x000000, tile_layout,      0x0000, 0x2000>>4 ) /* Tiles area */
-	GFXDECODE_ENTRY( "gfx1", 0x000000, spriteram_layout, 0x1000, 0x1000>>4 ) /* Sprites area */
-	GFXDECODE_ENTRY( nullptr,   0x000000, pivotlayout,      0x0000,  0x400>>4 ) /* Dynamically modified */
+	GFXDECODE_ENTRY( nullptr,   0x000000, charlayout,             0x0000, 0x0400>>4 ) /* Dynamically modified */
+	GFXDECODE_ENTRY( "tilemap", 0x000000, gfx_16x16x4_packed_lsb, 0x0000, 0x2000>>4 ) /* Tiles area */
+	GFXDECODE_ENTRY( "sprites", 0x000000, gfx_16x16x4_packed_lsb, 0x1000, 0x1000>>4 ) /* Sprites area */
+	GFXDECODE_ENTRY( nullptr,   0x000000, pivotlayout,            0x0000,  0x400>>4 ) /* Dynamically modified */
 GFXDECODE_END
 
 /******************************************************************************/
@@ -425,13 +413,13 @@ void taito_f3_state::device_timer(emu_timer &timer, device_timer_id id, int para
 	}
 }
 
-INTERRUPT_GEN_MEMBER(taito_f3_state::f3_interrupt2)
+INTERRUPT_GEN_MEMBER(taito_f3_state::interrupt2)
 {
 	device.execute().set_input_line(2, HOLD_LINE);  // vblank
 	m_interrupt3_timer->adjust(m_maincpu->cycles_to_attotime(10000));
 }
 
-static const uint16_t recalh_eeprom[64] = {
+static const u16 recalh_eeprom[64] = {
 	0x8554,0x0000,0x3000,0x0000,0x0000,0x0000,0x0000,0xf335,
 	0x0001,0x86a0,0x0013,0x0413,0x0000,0xc350,0x0019,0x000a,
 	0x0000,0x4e20,0x0003,0x180d,0x0000,0x2710,0x0005,0x1418,
@@ -452,7 +440,7 @@ void taito_f3_state::machine_start()
 void taito_f3_state::machine_reset()
 {
 	/* start with sound m68k off, qtheater relies on it (otherwise main CPU tries to reset it while 68k is working with irq table vectors). */
-	if(m_audiocpu)
+	if (m_audiocpu)
 		m_audiocpu->set_input_line(INPUT_LINE_RESET, ASSERT_LINE);
 }
 
@@ -461,7 +449,7 @@ void taito_f3_state::f3(machine_config &config)
 	/* basic machine hardware */
 	M68EC020(config, m_maincpu, XTAL(16'000'000));
 	m_maincpu->set_addrmap(AS_PROGRAM, &taito_f3_state::f3_map);
-	m_maincpu->set_vblank_int("screen", FUNC(taito_f3_state::f3_interrupt2));
+	m_maincpu->set_vblank_int("screen", FUNC(taito_f3_state::interrupt2));
 
 	EEPROM_93C46_16BIT(config, m_eeprom);
 
@@ -473,8 +461,8 @@ void taito_f3_state::f3(machine_config &config)
 	m_screen->set_vblank_time(ATTOSECONDS_IN_USEC(624)); /* 58.97 Hz, 624us vblank time */
 	m_screen->set_size(40*8+48*2, 32*8);
 	m_screen->set_visarea(46, 40*8-1 + 46, 24, 24+232-1);
-	m_screen->set_screen_update(FUNC(taito_f3_state::screen_update_f3));
-	m_screen->screen_vblank().set(FUNC(taito_f3_state::screen_vblank_f3));
+	m_screen->set_screen_update(FUNC(taito_f3_state::screen_update));
+	m_screen->screen_vblank().set(FUNC(taito_f3_state::screen_vblank));
 
 	GFXDECODE(config, m_gfxdecode, m_palette, gfx_taito_f3);
 	PALETTE(config, m_palette).set_entries(0x2000);
@@ -525,28 +513,17 @@ static const gfx_layout bubsympb_sprite_layout =
 	RGN_FRAC(1,6),
 	6,
 	{ RGN_FRAC(0,6), RGN_FRAC(1,6), RGN_FRAC(2,6), RGN_FRAC(3,6), RGN_FRAC(4,6), RGN_FRAC(5,6) },
-	{ 7,6,5,4,3,2,1,0,15,14,13,12,11,10,9,8 },
-	{ 0*16, 1*16, 2*16, 3*16, 4*16, 5*16, 6*16, 7*16, 8*16, 9*16, 10*16, 11*16, 12*16, 13*16, 14*16, 15*16 },
+	{ STEP16(15,-1) },
+	{ STEP16(0,16) },
 	16*16
-};
-
-static const gfx_layout bubsympb_tile_layout =
-{
-	16,16,
-	RGN_FRAC(1,2),
-	5,
-	{ RGN_FRAC(1,2)+0, 0,1,2,3 },
-	{ 20,16,12,8,4,0,28,24,52,48,44,40,36,32,60,56 },
-	{ 0*64, 1*64, 2*64, 3*64, 4*64, 5*64, 6*64, 7*64, 8*64, 9*64, 10*64, 11*64, 12*64, 13*64, 14*64, 15*64 },
-	16*64
 };
 
 
 static GFXDECODE_START( gfx_bubsympb )
-	GFXDECODE_ENTRY( nullptr,           0x000000, charlayout,          0,  64 ) /* Dynamically modified */
-	GFXDECODE_ENTRY( "gfx2", 0x000000, bubsympb_tile_layout, 0, 512 ) /* Tiles area */
-	GFXDECODE_ENTRY( "gfx1", 0x000000, bubsympb_sprite_layout, 4096, 256 ) /* Sprites area */
-	GFXDECODE_ENTRY( nullptr,           0x000000, pivotlayout,         0,  64 ) /* Dynamically modified */
+	GFXDECODE_ENTRY( nullptr,   0x000000, charlayout,                0,  64 ) /* Dynamically modified */
+	GFXDECODE_ENTRY( "tilemap", 0x000000, gfx_16x16x4_packed_lsb,    0, 512 ) /* Tiles area */
+	GFXDECODE_ENTRY( "sprites", 0x000000, bubsympb_sprite_layout, 4096, 256 ) /* Sprites area */
+	GFXDECODE_ENTRY( nullptr,   0x000000, pivotlayout,               0,  64 ) /* Dynamically modified */
 GFXDECODE_END
 
 void taito_f3_state::bubsympb(machine_config &config)
@@ -554,7 +531,7 @@ void taito_f3_state::bubsympb(machine_config &config)
 	/* basic machine hardware */
 	M68EC020(config, m_maincpu, XTAL(16'000'000));
 	m_maincpu->set_addrmap(AS_PROGRAM, &taito_f3_state::bubsympb_map);
-	m_maincpu->set_vblank_int("screen", FUNC(taito_f3_state::f3_interrupt2));
+	m_maincpu->set_vblank_int("screen", FUNC(taito_f3_state::interrupt2));
 
 	EEPROM_93C46_16BIT(config, m_eeprom);
 
@@ -566,8 +543,8 @@ void taito_f3_state::bubsympb(machine_config &config)
 	m_screen->set_vblank_time(ATTOSECONDS_IN_USEC(624)); /* 58.97 Hz, 624us vblank time */
 	m_screen->set_size(40*8+48*2, 32*8);
 	m_screen->set_visarea(46, 40*8-1 + 46, 31, 31+224-1);
-	m_screen->set_screen_update(FUNC(taito_f3_state::screen_update_f3));
-	m_screen->screen_vblank().set(FUNC(taito_f3_state::screen_vblank_f3));
+	m_screen->set_screen_update(FUNC(taito_f3_state::screen_update));
+	m_screen->screen_vblank().set(FUNC(taito_f3_state::screen_vblank));
 
 	GFXDECODE(config, m_gfxdecode, m_palette, gfx_bubsympb);
 	PALETTE(config, m_palette).set_entries(0x2000);
@@ -576,122 +553,134 @@ void taito_f3_state::bubsympb(machine_config &config)
 	SPEAKER(config, "mono").front_center();
 
 	OKIM6295(config, m_oki, 1000000, okim6295_device::PIN7_HIGH); // not verified
+	m_oki->set_addrmap(0, &taito_f3_state::bubsympb_oki_map);
 	m_oki->add_route(ALL_OUTPUTS, "mono", 1.0);
 }
 
 /******************************************************************************/
 
+#define EMPTY_SPRITE_HIDATA(len) ROM_REGION(len, "sprites_hi", ROMREGION_ERASE00 )
+#define EMPTY_TILEMAP_HIDATA(len) ROM_REGION(len, "tilemap_hi", ROMREGION_ERASE00 )
+
 ROM_START( ringrage )
-	ROM_REGION(0x200000, "maincpu", 0) /* 68020 code */
+	ROM_REGION( 0x200000, "maincpu", 0 ) /* 68020 code */
 	ROM_LOAD32_BYTE("d21-23.40", 0x000000, 0x40000, CRC(14e9ed65) SHA1(956db484375a43bcdf5a6a104e3c7d7ef5baaa1b) )
 	ROM_LOAD32_BYTE("d21-22.38", 0x000001, 0x40000, CRC(6f8b65b0) SHA1(a4f786b72068c6c9c1b23df67029eb0e2a982789) )
 	ROM_LOAD32_BYTE("d21-21.36", 0x000002, 0x40000, CRC(bf7234bc) SHA1(781b8f850275537e1ae2dae18a4554a1283cb432) )
 	ROM_LOAD32_BYTE("d21-25.34", 0x000003, 0x40000, CRC(aeff6e19) SHA1(7fd8f64f0a52dfe369a3709af8c043286b5b6fdf) )
 
-	ROM_REGION(0x800000, "gfx1" , 0 ) /* Sprites */
+	ROM_REGION( 0x400000, "sprites" , 0 ) /* Sprites */
 	ROM_LOAD16_BYTE("d21-02.66", 0x000000, 0x200000, CRC(facd3a02) SHA1(360c6e65d01dd2c33495ba928ef9986f754b3694) )
 	ROM_LOAD16_BYTE("d21-03.67", 0x000001, 0x200000, CRC(6f653e68) SHA1(840905f012c37d58160cc554c036ad25218ce3e6) )
-	ROM_LOAD       ("d21-04.68", 0x600000, 0x200000, CRC(9dcdceca) SHA1(e12bab5307ebe4c3b5f9284c91f3bf7ba4c8e9bc) )
-	ROM_FILL       (             0x400000, 0x200000, 0x00 )
 
-	ROM_REGION(0x200000, "gfx2" , 0 ) /* Tiles */
-	ROM_LOAD16_BYTE("d21-06.49", 0x000000, 0x080000, CRC(92d4a720) SHA1(81dc58c58d5f4f20ceeb5d6b90491f1efcbc67d3) )
-	ROM_LOAD16_BYTE("d21-07.50", 0x000001, 0x080000, CRC(6da696e9) SHA1(74332090b0de4193a669cd5242fd655e7b90f772) )
-	ROM_LOAD       ("d21-08.51", 0x180000, 0x080000, CRC(a0d95be9) SHA1(1746097e827ac10906f012c5c4f93c388a30f4b3) )
-	ROM_FILL       (             0x100000, 0x080000, 0x00 )
+	ROM_REGION( 0x200000, "sprites_hi", 0 )
+	ROM_LOAD       ("d21-04.68", 0x000000, 0x200000, CRC(9dcdceca) SHA1(e12bab5307ebe4c3b5f9284c91f3bf7ba4c8e9bc) )
 
-	ROM_REGION(0x140000, "taito_en:audiocpu", 0) /* sound CPU */
+	ROM_REGION( 0x100000, "tilemap" , 0 ) /* Tiles */
+	ROM_LOAD32_WORD("d21-06.49", 0x000000, 0x080000, CRC(92d4a720) SHA1(81dc58c58d5f4f20ceeb5d6b90491f1efcbc67d3) )
+	ROM_LOAD32_WORD("d21-07.50", 0x000002, 0x080000, CRC(6da696e9) SHA1(74332090b0de4193a669cd5242fd655e7b90f772) )
+
+	ROM_REGION( 0x080000, "tilemap_hi", 0 )
+	ROM_LOAD       ("d21-08.51", 0x000000, 0x080000, CRC(a0d95be9) SHA1(1746097e827ac10906f012c5c4f93c388a30f4b3) )
+
+	ROM_REGION( 0x140000, "taito_en:audiocpu", 0 ) /* sound CPU */
 	ROM_LOAD16_BYTE("d21-18.5", 0x100000, 0x20000, CRC(133b55d0) SHA1(feb5c9d0b1adcae3b16eb206c8ac4e73fd88bef4) )
 	ROM_LOAD16_BYTE("d21-19.6", 0x100001, 0x20000, CRC(1f98908f) SHA1(972c8f7e4e417831466714efd0b4cadca1f3e8e5) )
 
-	ROM_REGION16_BE(0x800000, "ensoniq.0" , ROMREGION_ERASE00 ) // V1: 2 banks
+	ROM_REGION16_BE( 0x800000, "ensoniq.0" , ROMREGION_ERASE00 ) // V1: 2 banks
 	ROM_LOAD16_BYTE("d21-01.17", 0x000000, 0x200000, CRC(1fb6f07d) SHA1(a7d21d4b0b0b141c4dbe66554e5362e2c8876067) ) // C8 C9 CA CB
 	// half empty
 	ROM_LOAD16_BYTE("d21-05.18", 0x600000, 0x100000, CRC(ed894fe1) SHA1(5bf2fb6abdcf25bc525a2c3b29dbf7aca0b18fea) ) // -std-
 ROM_END
 
 ROM_START( ringrageu )
-	ROM_REGION(0x200000, "maincpu", 0) /* 68020 code */
+	ROM_REGION( 0x200000, "maincpu", 0 ) /* 68020 code */
 	ROM_LOAD32_BYTE("d21-23.40", 0x000000, 0x40000, CRC(14e9ed65) SHA1(956db484375a43bcdf5a6a104e3c7d7ef5baaa1b) )
 	ROM_LOAD32_BYTE("d21-22.38", 0x000001, 0x40000, CRC(6f8b65b0) SHA1(a4f786b72068c6c9c1b23df67029eb0e2a982789) )
 	ROM_LOAD32_BYTE("d21-21.36", 0x000002, 0x40000, CRC(bf7234bc) SHA1(781b8f850275537e1ae2dae18a4554a1283cb432) )
 	ROM_LOAD32_BYTE("d21-24.34", 0x000003, 0x40000, CRC(404dee67) SHA1(1e46d52d72b6cbe5e8af9f0f8e8b1acf9c6feb26) )
 
-	ROM_REGION(0x800000, "gfx1" , 0 ) /* Sprites */
+	ROM_REGION( 0x400000, "sprites" , 0 ) /* Sprites */
 	ROM_LOAD16_BYTE("d21-02.66", 0x000000, 0x200000, CRC(facd3a02) SHA1(360c6e65d01dd2c33495ba928ef9986f754b3694) )
 	ROM_LOAD16_BYTE("d21-03.67", 0x000001, 0x200000, CRC(6f653e68) SHA1(840905f012c37d58160cc554c036ad25218ce3e6) )
-	ROM_LOAD       ("d21-04.68", 0x600000, 0x200000, CRC(9dcdceca) SHA1(e12bab5307ebe4c3b5f9284c91f3bf7ba4c8e9bc) )
-	ROM_FILL       (             0x400000, 0x200000, 0x00 )
 
-	ROM_REGION(0x200000, "gfx2" , 0 ) /* Tiles */
-	ROM_LOAD16_BYTE("d21-06.49", 0x000000, 0x080000, CRC(92d4a720) SHA1(81dc58c58d5f4f20ceeb5d6b90491f1efcbc67d3) )
-	ROM_LOAD16_BYTE("d21-07.50", 0x000001, 0x080000, CRC(6da696e9) SHA1(74332090b0de4193a669cd5242fd655e7b90f772) )
-	ROM_LOAD       ("d21-08.51", 0x180000, 0x080000, CRC(a0d95be9) SHA1(1746097e827ac10906f012c5c4f93c388a30f4b3) )
-	ROM_FILL       (             0x100000, 0x080000, 0x00 )
+	ROM_REGION( 0x200000, "sprites_hi", 0 )
+	ROM_LOAD       ("d21-04.68", 0x000000, 0x200000, CRC(9dcdceca) SHA1(e12bab5307ebe4c3b5f9284c91f3bf7ba4c8e9bc) )
 
-	ROM_REGION(0x140000, "taito_en:audiocpu", 0) /* sound CPU */
+	ROM_REGION( 0x100000, "tilemap" , 0 ) /* Tiles */
+	ROM_LOAD32_WORD("d21-06.49", 0x000000, 0x080000, CRC(92d4a720) SHA1(81dc58c58d5f4f20ceeb5d6b90491f1efcbc67d3) )
+	ROM_LOAD32_WORD("d21-07.50", 0x000002, 0x080000, CRC(6da696e9) SHA1(74332090b0de4193a669cd5242fd655e7b90f772) )
+
+	ROM_REGION( 0x080000, "tilemap_hi", 0 )
+	ROM_LOAD       ("d21-08.51", 0x000000, 0x080000, CRC(a0d95be9) SHA1(1746097e827ac10906f012c5c4f93c388a30f4b3) )
+
+	ROM_REGION( 0x140000, "taito_en:audiocpu", 0 ) /* sound CPU */
 	ROM_LOAD16_BYTE("d21-18.5", 0x100000, 0x20000, CRC(133b55d0) SHA1(feb5c9d0b1adcae3b16eb206c8ac4e73fd88bef4) )
 	ROM_LOAD16_BYTE("d21-19.6", 0x100001, 0x20000, CRC(1f98908f) SHA1(972c8f7e4e417831466714efd0b4cadca1f3e8e5) )
 
-	ROM_REGION16_BE(0x800000, "ensoniq.0" , ROMREGION_ERASE00 ) // V1: 2 banks
+	ROM_REGION16_BE( 0x800000, "ensoniq.0" , ROMREGION_ERASE00 ) // V1: 2 banks
 	ROM_LOAD16_BYTE("d21-01.17", 0x000000, 0x200000, CRC(1fb6f07d) SHA1(a7d21d4b0b0b141c4dbe66554e5362e2c8876067) ) // C8 C9 CA CB
 	// half empty
 	ROM_LOAD16_BYTE("d21-05.18", 0x600000, 0x100000, CRC(ed894fe1) SHA1(5bf2fb6abdcf25bc525a2c3b29dbf7aca0b18fea) ) // -std-
 ROM_END
 
 ROM_START( ringragej )
-	ROM_REGION(0x200000, "maincpu", 0) /* 68020 code */
+	ROM_REGION( 0x200000, "maincpu", 0 ) /* 68020 code */
 	ROM_LOAD32_BYTE("d21-23.40", 0x000000, 0x40000, CRC(14e9ed65) SHA1(956db484375a43bcdf5a6a104e3c7d7ef5baaa1b) )
 	ROM_LOAD32_BYTE("d21-22.38", 0x000001, 0x40000, CRC(6f8b65b0) SHA1(a4f786b72068c6c9c1b23df67029eb0e2a982789) )
 	ROM_LOAD32_BYTE("d21-21.36", 0x000002, 0x40000, CRC(bf7234bc) SHA1(781b8f850275537e1ae2dae18a4554a1283cb432) )
 	ROM_LOAD32_BYTE("d21-20.34", 0x000003, 0x40000, CRC(a8eb68a4) SHA1(040238fad0d17cac21b144b0fcab1774d2924da9) )
 
-	ROM_REGION(0x800000, "gfx1" , 0 ) /* Sprites */
+	ROM_REGION( 0x400000, "sprites" , 0 ) /* Sprites */
 	ROM_LOAD16_BYTE("d21-02.66", 0x000000, 0x200000, CRC(facd3a02) SHA1(360c6e65d01dd2c33495ba928ef9986f754b3694) )
 	ROM_LOAD16_BYTE("d21-03.67", 0x000001, 0x200000, CRC(6f653e68) SHA1(840905f012c37d58160cc554c036ad25218ce3e6) )
-	ROM_LOAD       ("d21-04.68", 0x600000, 0x200000, CRC(9dcdceca) SHA1(e12bab5307ebe4c3b5f9284c91f3bf7ba4c8e9bc) )
-	ROM_FILL       (             0x400000, 0x200000, 0x00 )
 
-	ROM_REGION(0x200000, "gfx2" , 0 ) /* Tiles */
-	ROM_LOAD16_BYTE("d21-06.49", 0x000000, 0x080000, CRC(92d4a720) SHA1(81dc58c58d5f4f20ceeb5d6b90491f1efcbc67d3) )
-	ROM_LOAD16_BYTE("d21-07.50", 0x000001, 0x080000, CRC(6da696e9) SHA1(74332090b0de4193a669cd5242fd655e7b90f772) )
-	ROM_LOAD       ("d21-08.51", 0x180000, 0x080000, CRC(a0d95be9) SHA1(1746097e827ac10906f012c5c4f93c388a30f4b3) )
-	ROM_FILL       (             0x100000, 0x080000, 0x00 )
+	ROM_REGION( 0x200000, "sprites_hi", 0 )
+	ROM_LOAD       ("d21-04.68", 0x000000, 0x200000, CRC(9dcdceca) SHA1(e12bab5307ebe4c3b5f9284c91f3bf7ba4c8e9bc) )
 
-	ROM_REGION(0x140000, "taito_en:audiocpu", 0) /* sound CPU */
+	ROM_REGION( 0x100000, "tilemap" , 0 ) /* Tiles */
+	ROM_LOAD32_WORD("d21-06.49", 0x000000, 0x080000, CRC(92d4a720) SHA1(81dc58c58d5f4f20ceeb5d6b90491f1efcbc67d3) )
+	ROM_LOAD32_WORD("d21-07.50", 0x000002, 0x080000, CRC(6da696e9) SHA1(74332090b0de4193a669cd5242fd655e7b90f772) )
+
+	ROM_REGION( 0x080000, "tilemap_hi", 0 )
+	ROM_LOAD       ("d21-08.51", 0x000000, 0x080000, CRC(a0d95be9) SHA1(1746097e827ac10906f012c5c4f93c388a30f4b3) )
+
+	ROM_REGION( 0x140000, "taito_en:audiocpu", 0 ) /* sound CPU */
 	ROM_LOAD16_BYTE("d21-18.5", 0x100000, 0x20000, CRC(133b55d0) SHA1(feb5c9d0b1adcae3b16eb206c8ac4e73fd88bef4) )
 	ROM_LOAD16_BYTE("d21-19.6", 0x100001, 0x20000, CRC(1f98908f) SHA1(972c8f7e4e417831466714efd0b4cadca1f3e8e5) )
 
-	ROM_REGION16_BE(0x800000, "ensoniq.0" , ROMREGION_ERASE00 ) // V1: 2 banks
+	ROM_REGION16_BE( 0x800000, "ensoniq.0" , ROMREGION_ERASE00 ) // V1: 2 banks
 	ROM_LOAD16_BYTE("d21-01.17", 0x000000, 0x200000, CRC(1fb6f07d) SHA1(a7d21d4b0b0b141c4dbe66554e5362e2c8876067) ) // C8 C9 CA CB
 	// half empty
 	ROM_LOAD16_BYTE("d21-05.18", 0x600000, 0x100000, CRC(ed894fe1) SHA1(5bf2fb6abdcf25bc525a2c3b29dbf7aca0b18fea) ) // -std-
 ROM_END
 
 ROM_START( arabianm )
-	ROM_REGION(0x200000, "maincpu", 0) /* 68020 code */
+	ROM_REGION( 0x200000, "maincpu", 0 ) /* 68020 code */
 	ROM_LOAD32_BYTE("d29-23.ic40", 0x000000, 0x40000, CRC(89a0c706) SHA1(d0df02be2b63566ec776bb13947f975062766a01) )
 	ROM_LOAD32_BYTE("d29-22.ic38", 0x000001, 0x40000, CRC(4afc22a4) SHA1(9579d134a1e4b0c86af9b41d136acfe6cc7f6624) )
 	ROM_LOAD32_BYTE("d29-21.ic36", 0x000002, 0x40000, CRC(ac32eb38) SHA1(19d8d965497e41a7a2f490a197322da7fd1fa40a) )
 	ROM_LOAD32_BYTE("d29-25.ic34", 0x000003, 0x40000, CRC(b9b652ed) SHA1(19cceef87884adeb03e5e330159541a1e503a7f2) )
 
-	ROM_REGION(0x400000, "gfx1" , 0) /* Sprites */
+	ROM_REGION( 0x200000, "sprites" , 0) /* Sprites */
 	ROM_LOAD16_BYTE("d29-03.ic66", 0x000000, 0x100000, CRC(aeaff456) SHA1(e70d0089e69d33d213be8195c31891f38fbcb53a) )
 	ROM_LOAD16_BYTE("d29-04.ic67", 0x000001, 0x100000, CRC(01711cfe) SHA1(26da4cc9dcb8d38bdf8c93015f77e58ffc9d1ba9) )
-	ROM_LOAD       ("d29-05.ic68", 0x300000, 0x100000, CRC(9b5f7a17) SHA1(89d9faedc7b55df6237f2c2ebb43de7de685cb66) )
-	ROM_FILL       (               0x200000, 0x100000, 0x00 )
 
-	ROM_REGION(0x200000, "gfx2" , 0) /* Tiles */
-	ROM_LOAD16_BYTE("d29-06.ic49", 0x000000, 0x080000, CRC(eea07bf3) SHA1(7860a2c0c592af000b56e59bd39d67b086fe3606) )
-	ROM_LOAD16_BYTE("d29-07.ic50", 0x000001, 0x080000, CRC(db3c094d) SHA1(5b60f0fa1054bf93ce51d310376b1abdb3022541) )
-	ROM_LOAD       ("d29-08.ic51", 0x180000, 0x080000, CRC(d7562851) SHA1(91d86e75ba7a590ca298b932b4cf8fa9228f115e) )
-	ROM_FILL       (               0x100000, 0x080000, 0x00 )
+	ROM_REGION( 0x100000, "sprites_hi", 0 )
+	ROM_LOAD       ("d29-05.ic68", 0x000000, 0x100000, CRC(9b5f7a17) SHA1(89d9faedc7b55df6237f2c2ebb43de7de685cb66) )
 
-	ROM_REGION(0x140000, "taito_en:audiocpu", 0) /* sound CPU */
+	ROM_REGION( 0x100000, "tilemap" , 0) /* Tiles */
+	ROM_LOAD32_WORD("d29-06.ic49", 0x000000, 0x080000, CRC(eea07bf3) SHA1(7860a2c0c592af000b56e59bd39d67b086fe3606) )
+	ROM_LOAD32_WORD("d29-07.ic50", 0x000002, 0x080000, CRC(db3c094d) SHA1(5b60f0fa1054bf93ce51d310376b1abdb3022541) )
+
+	ROM_REGION( 0x080000, "tilemap_hi", 0 )
+	ROM_LOAD       ("d29-08.ic51", 0x000000, 0x080000, CRC(d7562851) SHA1(91d86e75ba7a590ca298b932b4cf8fa9228f115e) )
+
+	ROM_REGION( 0x140000, "taito_en:audiocpu", 0 ) /* sound CPU */
 	ROM_LOAD16_BYTE("d29-18.ic5", 0x100000, 0x20000, CRC(d97780df) SHA1(d0f9d2fd7ce13f620bb44083bf012f67dda4b10b) )
 	ROM_LOAD16_BYTE("d29-19.ic6", 0x100001, 0x20000, CRC(b1ad365c) SHA1(1cd26d8feaaa06b50dfee32e9b7950b8ee92ac55) )
 
-	ROM_REGION16_BE(0x800000, "ensoniq.0" , ROMREGION_ERASE00 ) // V1: 2 banks
+	ROM_REGION16_BE( 0x800000, "ensoniq.0" , ROMREGION_ERASE00 ) // V1: 2 banks
 	ROM_LOAD16_BYTE("d29-01.ic17", 0x000000, 0x200000, CRC(545ac4b3) SHA1(f89513fca8a03cab11160aa1f0a9c3adbc8bda08) )   // C8 C9 CA CB
 	// half empty
 	ROM_LOAD16_BYTE("d29-02.ic18", 0x600000, 0x100000, CRC(ed894fe1) SHA1(5bf2fb6abdcf25bc525a2c3b29dbf7aca0b18fea) )   // -std-
@@ -709,29 +698,31 @@ ROM_START( arabianm )
 ROM_END
 
 ROM_START( arabianmj )
-	ROM_REGION(0x200000, "maincpu", 0) /* 68020 code */
+	ROM_REGION( 0x200000, "maincpu", 0 ) /* 68020 code */
 	ROM_LOAD32_BYTE("d29-23.ic40", 0x000000, 0x40000, CRC(89a0c706) SHA1(d0df02be2b63566ec776bb13947f975062766a01) )
 	ROM_LOAD32_BYTE("d29-22.ic38", 0x000001, 0x40000, CRC(4afc22a4) SHA1(9579d134a1e4b0c86af9b41d136acfe6cc7f6624) )
 	ROM_LOAD32_BYTE("d29-21.ic36", 0x000002, 0x40000, CRC(ac32eb38) SHA1(19d8d965497e41a7a2f490a197322da7fd1fa40a) )
 	ROM_LOAD32_BYTE("d29-20.ic34", 0x000003, 0x40000, CRC(57b833c1) SHA1(69beff431e400db17ca1983a7a4d6684a1ea701c) )
 
-	ROM_REGION(0x400000, "gfx1" , 0) /* Sprites */
+	ROM_REGION( 0x200000, "sprites" , 0) /* Sprites */
 	ROM_LOAD16_BYTE("d29-03.ic66", 0x000000, 0x100000, CRC(aeaff456) SHA1(e70d0089e69d33d213be8195c31891f38fbcb53a) )
 	ROM_LOAD16_BYTE("d29-04.ic67", 0x000001, 0x100000, CRC(01711cfe) SHA1(26da4cc9dcb8d38bdf8c93015f77e58ffc9d1ba9) )
-	ROM_LOAD       ("d29-05.ic68", 0x300000, 0x100000, CRC(9b5f7a17) SHA1(89d9faedc7b55df6237f2c2ebb43de7de685cb66) )
-	ROM_FILL       (               0x200000, 0x100000, 0x00 )
 
-	ROM_REGION(0x200000, "gfx2" , 0) /* Tiles */
-	ROM_LOAD16_BYTE("d29-06.ic49", 0x000000, 0x080000, CRC(eea07bf3) SHA1(7860a2c0c592af000b56e59bd39d67b086fe3606) )
-	ROM_LOAD16_BYTE("d29-07.ic50", 0x000001, 0x080000, CRC(db3c094d) SHA1(5b60f0fa1054bf93ce51d310376b1abdb3022541) )
-	ROM_LOAD       ("d29-08.ic51", 0x180000, 0x080000, CRC(d7562851) SHA1(91d86e75ba7a590ca298b932b4cf8fa9228f115e) )
-	ROM_FILL       (               0x100000, 0x080000, 0x00 )
+	ROM_REGION( 0x100000, "sprites_hi", 0 )
+	ROM_LOAD       ("d29-05.ic68", 0x000000, 0x100000, CRC(9b5f7a17) SHA1(89d9faedc7b55df6237f2c2ebb43de7de685cb66) )
 
-	ROM_REGION(0x140000, "taito_en:audiocpu", 0) /* sound CPU */
+	ROM_REGION( 0x100000, "tilemap" , 0) /* Tiles */
+	ROM_LOAD32_WORD("d29-06.ic49", 0x000000, 0x080000, CRC(eea07bf3) SHA1(7860a2c0c592af000b56e59bd39d67b086fe3606) )
+	ROM_LOAD32_WORD("d29-07.ic50", 0x000002, 0x080000, CRC(db3c094d) SHA1(5b60f0fa1054bf93ce51d310376b1abdb3022541) )
+
+	ROM_REGION( 0x080000, "tilemap_hi", 0 )
+	ROM_LOAD       ("d29-08.ic51", 0x000000, 0x080000, CRC(d7562851) SHA1(91d86e75ba7a590ca298b932b4cf8fa9228f115e) )
+
+	ROM_REGION( 0x140000, "taito_en:audiocpu", 0 ) /* sound CPU */
 	ROM_LOAD16_BYTE("d29-18.ic5", 0x100000, 0x20000, CRC(d97780df) SHA1(d0f9d2fd7ce13f620bb44083bf012f67dda4b10b) )
 	ROM_LOAD16_BYTE("d29-19.ic6", 0x100001, 0x20000, CRC(b1ad365c) SHA1(1cd26d8feaaa06b50dfee32e9b7950b8ee92ac55) )
 
-	ROM_REGION16_BE(0x800000, "ensoniq.0" , ROMREGION_ERASE00 ) // V1: 2 banks
+	ROM_REGION16_BE( 0x800000, "ensoniq.0" , ROMREGION_ERASE00 ) // V1: 2 banks
 	ROM_LOAD16_BYTE("d29-01.ic17", 0x000000, 0x200000, CRC(545ac4b3) SHA1(f89513fca8a03cab11160aa1f0a9c3adbc8bda08) )   // C8 C9 CA CB
 	// half empty
 	ROM_LOAD16_BYTE("d29-02.ic18", 0x600000, 0x100000, CRC(ed894fe1) SHA1(5bf2fb6abdcf25bc525a2c3b29dbf7aca0b18fea) )   // -std-
@@ -749,29 +740,31 @@ ROM_START( arabianmj )
 ROM_END
 
 ROM_START( arabianmu )
-	ROM_REGION(0x200000, "maincpu", 0) /* 68020 code */
+	ROM_REGION( 0x200000, "maincpu", 0 ) /* 68020 code */
 	ROM_LOAD32_BYTE("d29-23.ic40", 0x000000, 0x40000, CRC(89a0c706) SHA1(d0df02be2b63566ec776bb13947f975062766a01) )
 	ROM_LOAD32_BYTE("d29-22.ic38", 0x000001, 0x40000, CRC(4afc22a4) SHA1(9579d134a1e4b0c86af9b41d136acfe6cc7f6624) )
 	ROM_LOAD32_BYTE("d29-21.ic36", 0x000002, 0x40000, CRC(ac32eb38) SHA1(19d8d965497e41a7a2f490a197322da7fd1fa40a) )
 	ROM_LOAD32_BYTE("d29-24.ic34", 0x000003, 0x40000, CRC(ceb1627b) SHA1(c705ed956fa80ad77c53e8e2b9d27020255578bd) )
 
-	ROM_REGION(0x400000, "gfx1" , 0) /* Sprites */
+	ROM_REGION( 0x200000, "sprites" , 0) /* Sprites */
 	ROM_LOAD16_BYTE("d29-03.ic66", 0x000000, 0x100000, CRC(aeaff456) SHA1(e70d0089e69d33d213be8195c31891f38fbcb53a) )
 	ROM_LOAD16_BYTE("d29-04.ic67", 0x000001, 0x100000, CRC(01711cfe) SHA1(26da4cc9dcb8d38bdf8c93015f77e58ffc9d1ba9) )
-	ROM_LOAD       ("d29-05.ic68", 0x300000, 0x100000, CRC(9b5f7a17) SHA1(89d9faedc7b55df6237f2c2ebb43de7de685cb66) )
-	ROM_FILL       (               0x200000, 0x100000, 0x00 )
 
-	ROM_REGION(0x200000, "gfx2" , 0) /* Tiles */
-	ROM_LOAD16_BYTE("d29-06.ic49", 0x000000, 0x080000, CRC(eea07bf3) SHA1(7860a2c0c592af000b56e59bd39d67b086fe3606) )
-	ROM_LOAD16_BYTE("d29-07.ic50", 0x000001, 0x080000, CRC(db3c094d) SHA1(5b60f0fa1054bf93ce51d310376b1abdb3022541) )
-	ROM_LOAD       ("d29-08.ic51", 0x180000, 0x080000, CRC(d7562851) SHA1(91d86e75ba7a590ca298b932b4cf8fa9228f115e) )
-	ROM_FILL       (               0x100000, 0x080000, 0x00 )
+	ROM_REGION( 0x100000, "sprites_hi", 0 )
+	ROM_LOAD       ("d29-05.ic68", 0x000000, 0x100000, CRC(9b5f7a17) SHA1(89d9faedc7b55df6237f2c2ebb43de7de685cb66) )
 
-	ROM_REGION(0x140000, "taito_en:audiocpu", 0) /* sound CPU */
+	ROM_REGION( 0x100000, "tilemap" , 0) /* Tiles */
+	ROM_LOAD32_WORD("d29-06.ic49", 0x000000, 0x080000, CRC(eea07bf3) SHA1(7860a2c0c592af000b56e59bd39d67b086fe3606) )
+	ROM_LOAD32_WORD("d29-07.ic50", 0x000002, 0x080000, CRC(db3c094d) SHA1(5b60f0fa1054bf93ce51d310376b1abdb3022541) )
+
+	ROM_REGION( 0x080000, "tilemap_hi", 0 )
+	ROM_LOAD       ("d29-08.ic51", 0x000000, 0x080000, CRC(d7562851) SHA1(91d86e75ba7a590ca298b932b4cf8fa9228f115e) )
+
+	ROM_REGION( 0x140000, "taito_en:audiocpu", 0 ) /* sound CPU */
 	ROM_LOAD16_BYTE("d29-18.ic5", 0x100000, 0x20000, CRC(d97780df) SHA1(d0f9d2fd7ce13f620bb44083bf012f67dda4b10b) )
 	ROM_LOAD16_BYTE("d29-19.ic6", 0x100001, 0x20000, CRC(b1ad365c) SHA1(1cd26d8feaaa06b50dfee32e9b7950b8ee92ac55) )
 
-	ROM_REGION16_BE(0x800000, "ensoniq.0" , ROMREGION_ERASE00 ) // V1: 2 banks
+	ROM_REGION16_BE( 0x800000, "ensoniq.0" , ROMREGION_ERASE00 ) // V1: 2 banks
 	ROM_LOAD16_BYTE("d29-01.ic17", 0x000000, 0x200000, CRC(545ac4b3) SHA1(f89513fca8a03cab11160aa1f0a9c3adbc8bda08) )   // C8 C9 CA CB
 	// half empty
 	ROM_LOAD16_BYTE("d29-02.ic18", 0x600000, 0x100000, CRC(ed894fe1) SHA1(5bf2fb6abdcf25bc525a2c3b29dbf7aca0b18fea) )   // -std-
@@ -789,310 +782,330 @@ ROM_START( arabianmu )
 ROM_END
 
 ROM_START( ridingf )
-	ROM_REGION(0x200000, "maincpu", 0) /* 68020 code */
+	ROM_REGION( 0x200000, "maincpu", 0 ) /* 68020 code */
 	ROM_LOAD32_BYTE("d34-12.40", 0x000000, 0x40000, CRC(e67e69d4) SHA1(9960629a7576f6a1d8a0e17c1bfc202ceee9e824) )
 	ROM_LOAD32_BYTE("d34-11.38", 0x000001, 0x40000, CRC(7d240a88) SHA1(3410d3f66e868f2696dbd95adbbd393596d34351) )
 	ROM_LOAD32_BYTE("d34-10.36", 0x000002, 0x40000, CRC(8aa3f4ac) SHA1(ba3c1274dcaccf4ba97ff224cb453eb1ead510ed) )
 	ROM_LOAD32_BYTE("d34_14.34", 0x000003, 0x40000, CRC(e000198e) SHA1(3c9fdd40ade7b02021d23b7ce63a28d80bb6e8e0) )
 
-	ROM_REGION(0x800000, "gfx1" , 0) /* Sprites */
+	ROM_REGION( 0x400000, "sprites" , 0) /* Sprites */
 	ROM_LOAD16_BYTE("d34-01.66", 0x000000, 0x200000, CRC(7974e6aa) SHA1(f3f697d0e2f52011046aa2db2df25a4b55a631d5) )
 	ROM_LOAD16_BYTE("d34-02.67", 0x000001, 0x200000, CRC(f4422370) SHA1(27ba051e0dc27b39652ff1d940a2dd29965c6528) )
-	ROM_FILL       (             0x400000, 0x400000, 0x00 )
 
-	ROM_REGION(0x200000, "gfx2" , 0) /* Tiles */
-	ROM_LOAD16_BYTE("d34-05.49", 0x000000, 0x080000, CRC(72e3ee4b) SHA1(2b69487338c18ced7a2ac4f280e8e22aa7209eb3) )
-	ROM_LOAD16_BYTE("d34-06.50", 0x000001, 0x080000, CRC(edc9b9f3) SHA1(c57bec1c8882d95388c3fae7cb5a321bdb202737) )
-	ROM_FILL       (             0x100000, 0x100000, 0x00 )
+	EMPTY_SPRITE_HIDATA(0x200000)
 
-	ROM_REGION(0x140000, "taito_en:audiocpu", 0) /* sound CPU */
+	ROM_REGION( 0x100000, "tilemap" , 0) /* Tiles */
+	ROM_LOAD32_WORD("d34-05.49", 0x000000, 0x080000, CRC(72e3ee4b) SHA1(2b69487338c18ced7a2ac4f280e8e22aa7209eb3) )
+	ROM_LOAD32_WORD("d34-06.50", 0x000002, 0x080000, CRC(edc9b9f3) SHA1(c57bec1c8882d95388c3fae7cb5a321bdb202737) )
+
+	EMPTY_TILEMAP_HIDATA(0x080000)
+
+	ROM_REGION( 0x140000, "taito_en:audiocpu", 0 ) /* sound CPU */
 	ROM_LOAD16_BYTE("d34-07.5", 0x100000, 0x20000, CRC(67239e2b) SHA1(8e0268fab53d26cde5c1928326c4787533dc6ffe) )
 	ROM_LOAD16_BYTE("d34-08.6", 0x100001, 0x20000, CRC(2cf20323) SHA1(b2bbac3714ecfd75506ae000c7eec603dfe3e13d) )
 
-	ROM_REGION16_BE(0x800000, "ensoniq.0" , ROMREGION_ERASE00 ) // V1: 2 banks
+	ROM_REGION16_BE( 0x800000, "ensoniq.0" , ROMREGION_ERASE00 ) // V1: 2 banks
 	ROM_LOAD16_BYTE("d34-03.17", 0x000000, 0x200000, CRC(e534ef74) SHA1(532d00e927d3704e7557abd59e35de8b7661c8fa) ) // C8 C9 CA CB
 	// half empty
 	ROM_LOAD16_BYTE("d34-04.18", 0x600000, 0x100000, CRC(ed894fe1) SHA1(5bf2fb6abdcf25bc525a2c3b29dbf7aca0b18fea) ) // -std-
 ROM_END
 
 ROM_START( ridingfj )
-	ROM_REGION(0x200000, "maincpu", 0) /* 68020 code */
+	ROM_REGION( 0x200000, "maincpu", 0 ) /* 68020 code */
 	ROM_LOAD32_BYTE("d34-12.40", 0x000000, 0x40000, CRC(e67e69d4) SHA1(9960629a7576f6a1d8a0e17c1bfc202ceee9e824) )
 	ROM_LOAD32_BYTE("d34-11.38", 0x000001, 0x40000, CRC(7d240a88) SHA1(3410d3f66e868f2696dbd95adbbd393596d34351) )
 	ROM_LOAD32_BYTE("d34-10.36", 0x000002, 0x40000, CRC(8aa3f4ac) SHA1(ba3c1274dcaccf4ba97ff224cb453eb1ead510ed) )
 	ROM_LOAD32_BYTE("d34-09.34", 0x000003, 0x40000, CRC(0e0e78a2) SHA1(4c8d0a5d6b8c77be34fd7b9c4a2df4022e74443a) )
 
-	ROM_REGION(0x800000, "gfx1" , 0) /* Sprites */
+	ROM_REGION( 0x400000, "sprites" , 0) /* Sprites */
 	ROM_LOAD16_BYTE("d34-01.66", 0x000000, 0x200000, CRC(7974e6aa) SHA1(f3f697d0e2f52011046aa2db2df25a4b55a631d5) )
 	ROM_LOAD16_BYTE("d34-02.67", 0x000001, 0x200000, CRC(f4422370) SHA1(27ba051e0dc27b39652ff1d940a2dd29965c6528) )
-	ROM_FILL       (             0x400000, 0x400000, 0x00 )
 
-	ROM_REGION(0x200000, "gfx2" , 0) /* Tiles */
-	ROM_LOAD16_BYTE("d34-05.49", 0x000000, 0x080000, CRC(72e3ee4b) SHA1(2b69487338c18ced7a2ac4f280e8e22aa7209eb3) )
-	ROM_LOAD16_BYTE("d34-06.50", 0x000001, 0x080000, CRC(edc9b9f3) SHA1(c57bec1c8882d95388c3fae7cb5a321bdb202737) )
-	ROM_FILL       (             0x100000, 0x100000, 0x00 )
+	EMPTY_SPRITE_HIDATA(0x200000)
 
-	ROM_REGION(0x140000, "taito_en:audiocpu", 0) /* sound CPU */
+	ROM_REGION( 0x100000, "tilemap" , 0) /* Tiles */
+	ROM_LOAD32_WORD("d34-05.49", 0x000000, 0x080000, CRC(72e3ee4b) SHA1(2b69487338c18ced7a2ac4f280e8e22aa7209eb3) )
+	ROM_LOAD32_WORD("d34-06.50", 0x000002, 0x080000, CRC(edc9b9f3) SHA1(c57bec1c8882d95388c3fae7cb5a321bdb202737) )
+
+	EMPTY_TILEMAP_HIDATA(0x080000)
+
+	ROM_REGION( 0x140000, "taito_en:audiocpu", 0 ) /* sound CPU */
 	ROM_LOAD16_BYTE("d34-07.5", 0x100000, 0x20000, CRC(67239e2b) SHA1(8e0268fab53d26cde5c1928326c4787533dc6ffe) )
 	ROM_LOAD16_BYTE("d34-08.6", 0x100001, 0x20000, CRC(2cf20323) SHA1(b2bbac3714ecfd75506ae000c7eec603dfe3e13d) )
 
-	ROM_REGION16_BE(0x800000, "ensoniq.0" , ROMREGION_ERASE00 ) // V1: 2 banks
+	ROM_REGION16_BE( 0x800000, "ensoniq.0" , ROMREGION_ERASE00 ) // V1: 2 banks
 	ROM_LOAD16_BYTE("d34-03.17", 0x000000, 0x200000, CRC(e534ef74) SHA1(532d00e927d3704e7557abd59e35de8b7661c8fa) ) // C8 C9 CA CB
 	// half empty
 	ROM_LOAD16_BYTE("d34-04.18", 0x600000, 0x100000, CRC(ed894fe1) SHA1(5bf2fb6abdcf25bc525a2c3b29dbf7aca0b18fea) ) // -std-
 ROM_END
 
 ROM_START( ridingfu )
-	ROM_REGION(0x200000, "maincpu", 0) /* 68020 code */
+	ROM_REGION( 0x200000, "maincpu", 0 ) /* 68020 code */
 	ROM_LOAD32_BYTE("d34-12.40", 0x000000, 0x40000, CRC(e67e69d4) SHA1(9960629a7576f6a1d8a0e17c1bfc202ceee9e824) )
 	ROM_LOAD32_BYTE("d34-11.38", 0x000001, 0x40000, CRC(7d240a88) SHA1(3410d3f66e868f2696dbd95adbbd393596d34351) )
 	ROM_LOAD32_BYTE("d34-10.36", 0x000002, 0x40000, CRC(8aa3f4ac) SHA1(ba3c1274dcaccf4ba97ff224cb453eb1ead510ed) )
 	ROM_LOAD32_BYTE("d34_13.34", 0x000003, 0x40000, CRC(97072918) SHA1(7ae96fb7a07b7192c39ec496e1193c1cbfbbc770) )
 
-	ROM_REGION(0x800000, "gfx1" , 0) /* Sprites */
+	ROM_REGION( 0x400000, "sprites" , 0) /* Sprites */
 	ROM_LOAD16_BYTE("d34-01.66", 0x000000, 0x200000, CRC(7974e6aa) SHA1(f3f697d0e2f52011046aa2db2df25a4b55a631d5) )
 	ROM_LOAD16_BYTE("d34-02.67", 0x000001, 0x200000, CRC(f4422370) SHA1(27ba051e0dc27b39652ff1d940a2dd29965c6528) )
-	ROM_FILL       (             0x400000, 0x400000, 0x00 )
 
-	ROM_REGION(0x200000, "gfx2" , 0) /* Tiles */
-	ROM_LOAD16_BYTE("d34-05.49", 0x000000, 0x080000, CRC(72e3ee4b) SHA1(2b69487338c18ced7a2ac4f280e8e22aa7209eb3) )
-	ROM_LOAD16_BYTE("d34-06.50", 0x000001, 0x080000, CRC(edc9b9f3) SHA1(c57bec1c8882d95388c3fae7cb5a321bdb202737) )
-	ROM_FILL       (             0x100000, 0x100000, 0x00 )
+	EMPTY_SPRITE_HIDATA(0x200000)
 
-	ROM_REGION(0x140000, "taito_en:audiocpu", 0) /* sound CPU */
+	ROM_REGION( 0x100000, "tilemap" , 0) /* Tiles */
+	ROM_LOAD32_WORD("d34-05.49", 0x000000, 0x080000, CRC(72e3ee4b) SHA1(2b69487338c18ced7a2ac4f280e8e22aa7209eb3) )
+	ROM_LOAD32_WORD("d34-06.50", 0x000002, 0x080000, CRC(edc9b9f3) SHA1(c57bec1c8882d95388c3fae7cb5a321bdb202737) )
+
+	EMPTY_TILEMAP_HIDATA(0x080000)
+
+	ROM_REGION( 0x140000, "taito_en:audiocpu", 0 ) /* sound CPU */
 	ROM_LOAD16_BYTE("d34-07.5", 0x100000, 0x20000, CRC(67239e2b) SHA1(8e0268fab53d26cde5c1928326c4787533dc6ffe) )
 	ROM_LOAD16_BYTE("d34-08.6", 0x100001, 0x20000, CRC(2cf20323) SHA1(b2bbac3714ecfd75506ae000c7eec603dfe3e13d) )
 
-	ROM_REGION16_BE(0x800000, "ensoniq.0" , ROMREGION_ERASE00 ) // V1: 2 banks
+	ROM_REGION16_BE( 0x800000, "ensoniq.0" , ROMREGION_ERASE00 ) // V1: 2 banks
 	ROM_LOAD16_BYTE("d34-03.17", 0x000000, 0x200000, CRC(e534ef74) SHA1(532d00e927d3704e7557abd59e35de8b7661c8fa) ) // C8 C9 CA CB
 	// half empty
 	ROM_LOAD16_BYTE("d34-04.18", 0x600000, 0x100000, CRC(ed894fe1) SHA1(5bf2fb6abdcf25bc525a2c3b29dbf7aca0b18fea) ) // -std-
 ROM_END
 
 ROM_START( gseeker )
-	ROM_REGION(0x200000, "maincpu", 0) /* 68020 code */
+	ROM_REGION( 0x200000, "maincpu", 0 ) /* 68020 code */
 	ROM_LOAD32_BYTE("d40_12.rom", 0x000000, 0x40000, CRC(884055fb) SHA1(a91c3dcd635a3e22fbec94c9fc46d3c29fde5e71) )
 	ROM_LOAD32_BYTE("d40_11.rom", 0x000001, 0x40000, CRC(85e701d2) SHA1(da0bc34a2c64d2db2fe143ad5a77bf667de5b015) )
 	ROM_LOAD32_BYTE("d40_10.rom", 0x000002, 0x40000, CRC(1e659ac5) SHA1(cd435d361c4353b361ef975f208d81369d5d079f) )
 	ROM_LOAD32_BYTE("d40_14.rom", 0x000003, 0x40000, CRC(d9a76bd9) SHA1(8edaf114c1342b33fd518320a181743d1dd324c1) )
 
-	ROM_REGION(0x400000, "gfx1" , 0) /* Sprites */
+	ROM_REGION( 0x200000, "sprites" , 0) /* Sprites */
 	ROM_LOAD16_BYTE("d40_03.rom", 0x000000, 0x100000, CRC(bcd70efc) SHA1(c65f934022d84e29cfd396cf70b6c1afdf90500b) )
 	ROM_LOAD16_BYTE("d40_04.rom", 0x100001, 0x080000, CRC(cd2ac666) SHA1(abf09979f1fe8575323b95b95688628ce4fc2350) )
 	ROM_CONTINUE(0,0x80000)
 	ROM_LOAD16_BYTE("d40_15.rom", 0x000000, 0x080000, CRC(50555125) SHA1(587cdfb2e027c1d96ecc46d2612956deca5fd36f) )
 	ROM_LOAD16_BYTE("d40_16.rom", 0x000001, 0x080000, CRC(3f9bbe1e) SHA1(6d9b2d2d893257ad096c276eff4077f60a81921f) )
 	/* Taito manufactured mask roms 3 + 4 wrong, and later added 15 + 16 as a patch */
-	ROM_FILL       (              0x200000, 0x200000, 0x00 )
 
-	ROM_REGION(0x400000, "gfx2" , 0) /* Tiles */
-	ROM_LOAD16_BYTE("d40_05.rom", 0x000000, 0x100000, CRC(be6eec8f) SHA1(725e5e09f6ee60bd4c38fa223c4dea202c56f75f) )
-	ROM_LOAD16_BYTE("d40_06.rom", 0x000001, 0x100000, CRC(a822abe4) SHA1(1a0dd9dcb8e24daab6eb1661307ef0e10f7e4d4e) )
-	ROM_FILL       (              0x200000, 0x200000, 0x00 )
+	EMPTY_SPRITE_HIDATA(0x100000)
 
-	ROM_REGION(0x140000, "taito_en:audiocpu", 0) /* sound CPU */
+	ROM_REGION( 0x200000, "tilemap" , 0) /* Tiles */
+	ROM_LOAD32_WORD("d40_05.rom", 0x000000, 0x100000, CRC(be6eec8f) SHA1(725e5e09f6ee60bd4c38fa223c4dea202c56f75f) )
+	ROM_LOAD32_WORD("d40_06.rom", 0x000002, 0x100000, CRC(a822abe4) SHA1(1a0dd9dcb8e24daab6eb1661307ef0e10f7e4d4e) )
+
+	EMPTY_TILEMAP_HIDATA(0x100000)
+
+	ROM_REGION( 0x140000, "taito_en:audiocpu", 0 ) /* sound CPU */
 	ROM_LOAD16_BYTE("d40_07.rom", 0x100000, 0x20000, CRC(7e9b26c2) SHA1(d88ad39a9d70b4a5bd3f83e0d4d0725f659f1d2a) )
 	ROM_LOAD16_BYTE("d40_08.rom", 0x100001, 0x20000, CRC(9c926a28) SHA1(9d9ee75eb895edc381c3ab4df5af941f84cd2073) )
 
-	ROM_REGION16_BE(0x800000, "ensoniq.0" , ROMREGION_ERASE00 ) // V1: 2 banks
+	ROM_REGION16_BE( 0x800000, "ensoniq.0" , ROMREGION_ERASE00 ) // V1: 2 banks
 	ROM_LOAD16_BYTE("d40_01.rom", 0x000000, 0x200000, CRC(ee312e95) SHA1(885553950c2b2195d664639bf7e0d1ffa3e8346a) )    // C8 C9 CA CB
 	// half empty
 	ROM_LOAD16_BYTE("d40_02.rom", 0x600000, 0x100000, CRC(ed894fe1) SHA1(5bf2fb6abdcf25bc525a2c3b29dbf7aca0b18fea) )    // -std-
 ROM_END
 
 ROM_START( gseekerj )
-	ROM_REGION(0x200000, "maincpu", 0) /* 68020 code */
+	ROM_REGION( 0x200000, "maincpu", 0 ) /* 68020 code */
 	ROM_LOAD32_BYTE("d40_12.rom", 0x000000, 0x40000, CRC(884055fb) SHA1(a91c3dcd635a3e22fbec94c9fc46d3c29fde5e71) )
 	ROM_LOAD32_BYTE("d40_11.rom", 0x000001, 0x40000, CRC(85e701d2) SHA1(da0bc34a2c64d2db2fe143ad5a77bf667de5b015) )
 	ROM_LOAD32_BYTE("d40_10.rom", 0x000002, 0x40000, CRC(1e659ac5) SHA1(cd435d361c4353b361ef975f208d81369d5d079f) )
 	ROM_LOAD32_BYTE("d40-09.34",  0x000003, 0x40000, CRC(37a90af5) SHA1(1f3401148375c9ca638ca6db6098ea4acf7d63a6) )
 
-	ROM_REGION(0x400000, "gfx1" , 0) /* Sprites */
+	ROM_REGION( 0x200000, "sprites" , 0) /* Sprites */
 	ROM_LOAD16_BYTE("d40_03.rom", 0x000000, 0x100000, CRC(bcd70efc) SHA1(c65f934022d84e29cfd396cf70b6c1afdf90500b) )
 	ROM_LOAD16_BYTE("d40_04.rom", 0x100001, 0x080000, CRC(cd2ac666) SHA1(abf09979f1fe8575323b95b95688628ce4fc2350) )
 	ROM_CONTINUE(0,0x80000)
 	ROM_LOAD16_BYTE("d40_15.rom", 0x000000, 0x080000, CRC(50555125) SHA1(587cdfb2e027c1d96ecc46d2612956deca5fd36f) )
 	ROM_LOAD16_BYTE("d40_16.rom", 0x000001, 0x080000, CRC(3f9bbe1e) SHA1(6d9b2d2d893257ad096c276eff4077f60a81921f) )
 	/* Taito manufactured mask roms 3 + 4 wrong, and later added 15 + 16 as a patch */
-	ROM_FILL       (              0x200000, 0x200000, 0x00 )
 
-	ROM_REGION(0x400000, "gfx2" , 0) /* Tiles */
-	ROM_LOAD16_BYTE("d40_05.rom", 0x000000, 0x100000, CRC(be6eec8f) SHA1(725e5e09f6ee60bd4c38fa223c4dea202c56f75f) )
-	ROM_LOAD16_BYTE("d40_06.rom", 0x000001, 0x100000, CRC(a822abe4) SHA1(1a0dd9dcb8e24daab6eb1661307ef0e10f7e4d4e) )
-	ROM_FILL       (              0x200000, 0x200000, 0x00 )
+	EMPTY_SPRITE_HIDATA(0x100000)
 
-	ROM_REGION(0x140000, "taito_en:audiocpu", 0) /* sound CPU */
+	ROM_REGION( 0x200000, "tilemap" , 0) /* Tiles */
+	ROM_LOAD32_WORD("d40_05.rom", 0x000000, 0x100000, CRC(be6eec8f) SHA1(725e5e09f6ee60bd4c38fa223c4dea202c56f75f) )
+	ROM_LOAD32_WORD("d40_06.rom", 0x000002, 0x100000, CRC(a822abe4) SHA1(1a0dd9dcb8e24daab6eb1661307ef0e10f7e4d4e) )
+
+	EMPTY_TILEMAP_HIDATA(0x100000)
+
+	ROM_REGION( 0x140000, "taito_en:audiocpu", 0 ) /* sound CPU */
 	ROM_LOAD16_BYTE("d40_07.rom", 0x100000, 0x20000, CRC(7e9b26c2) SHA1(d88ad39a9d70b4a5bd3f83e0d4d0725f659f1d2a) )
 	ROM_LOAD16_BYTE("d40_08.rom", 0x100001, 0x20000, CRC(9c926a28) SHA1(9d9ee75eb895edc381c3ab4df5af941f84cd2073) )
 
-	ROM_REGION16_BE(0x800000, "ensoniq.0" , ROMREGION_ERASE00 ) // V1: 2 banks
+	ROM_REGION16_BE( 0x800000, "ensoniq.0" , ROMREGION_ERASE00 ) // V1: 2 banks
 	ROM_LOAD16_BYTE("d40_01.rom", 0x000000, 0x200000, CRC(ee312e95) SHA1(885553950c2b2195d664639bf7e0d1ffa3e8346a) )    // C8 C9 CA CB
 	// half empty
 	ROM_LOAD16_BYTE("d40_02.rom", 0x600000, 0x100000, CRC(ed894fe1) SHA1(5bf2fb6abdcf25bc525a2c3b29dbf7aca0b18fea) )    // -std-
 ROM_END
 
 ROM_START( gseekeru )
-	ROM_REGION(0x200000, "maincpu", 0) /* 68020 code */
+	ROM_REGION( 0x200000, "maincpu", 0 ) /* 68020 code */
 	ROM_LOAD32_BYTE("d40_12.rom", 0x000000, 0x40000, CRC(884055fb) SHA1(a91c3dcd635a3e22fbec94c9fc46d3c29fde5e71) )
 	ROM_LOAD32_BYTE("d40_11.rom", 0x000001, 0x40000, CRC(85e701d2) SHA1(da0bc34a2c64d2db2fe143ad5a77bf667de5b015) )
 	ROM_LOAD32_BYTE("d40_10.rom", 0x000002, 0x40000, CRC(1e659ac5) SHA1(cd435d361c4353b361ef975f208d81369d5d079f) )
 	ROM_LOAD32_BYTE("d40-13.bin", 0x000003, 0x40000, CRC(aea05b4f) SHA1(4be054ebec49d694a7a3ee9bc66c22c46126ea4f) )
 
-	ROM_REGION(0x400000, "gfx1" , 0) /* Sprites */
+	ROM_REGION( 0x200000, "sprites" , 0) /* Sprites */
 	ROM_LOAD16_BYTE("d40_03.rom", 0x000000, 0x100000, CRC(bcd70efc) SHA1(c65f934022d84e29cfd396cf70b6c1afdf90500b) )
 	ROM_LOAD16_BYTE("d40_04.rom", 0x100001, 0x080000, CRC(cd2ac666) SHA1(abf09979f1fe8575323b95b95688628ce4fc2350) )
 	ROM_CONTINUE(0,0x80000)
 	ROM_LOAD16_BYTE("d40_15.rom", 0x000000, 0x080000, CRC(50555125) SHA1(587cdfb2e027c1d96ecc46d2612956deca5fd36f) )
 	ROM_LOAD16_BYTE("d40_16.rom", 0x000001, 0x080000, CRC(3f9bbe1e) SHA1(6d9b2d2d893257ad096c276eff4077f60a81921f) )
 	/* Taito manufactured mask roms 3 + 4 wrong, and later added 15 + 16 as a patch */
-	ROM_FILL       (              0x200000, 0x200000, 0x00 )
 
-	ROM_REGION(0x400000, "gfx2" , 0) /* Tiles */
-	ROM_LOAD16_BYTE("d40_05.rom", 0x000000, 0x100000, CRC(be6eec8f) SHA1(725e5e09f6ee60bd4c38fa223c4dea202c56f75f) )
-	ROM_LOAD16_BYTE("d40_06.rom", 0x000001, 0x100000, CRC(a822abe4) SHA1(1a0dd9dcb8e24daab6eb1661307ef0e10f7e4d4e) )
-	ROM_FILL       (              0x200000, 0x200000, 0x00 )
+	EMPTY_SPRITE_HIDATA(0x100000)
 
-	ROM_REGION(0x140000, "taito_en:audiocpu", 0) /* sound CPU */
+	ROM_REGION( 0x200000, "tilemap" , 0) /* Tiles */
+	ROM_LOAD32_WORD("d40_05.rom", 0x000000, 0x100000, CRC(be6eec8f) SHA1(725e5e09f6ee60bd4c38fa223c4dea202c56f75f) )
+	ROM_LOAD32_WORD("d40_06.rom", 0x000002, 0x100000, CRC(a822abe4) SHA1(1a0dd9dcb8e24daab6eb1661307ef0e10f7e4d4e) )
+
+	EMPTY_TILEMAP_HIDATA(0x100000)
+
+	ROM_REGION( 0x140000, "taito_en:audiocpu", 0 ) /* sound CPU */
 	ROM_LOAD16_BYTE("d40_07.rom", 0x100000, 0x20000, CRC(7e9b26c2) SHA1(d88ad39a9d70b4a5bd3f83e0d4d0725f659f1d2a) )
 	ROM_LOAD16_BYTE("d40_08.rom", 0x100001, 0x20000, CRC(9c926a28) SHA1(9d9ee75eb895edc381c3ab4df5af941f84cd2073) )
 
-	ROM_REGION16_BE(0x800000, "ensoniq.0" , ROMREGION_ERASE00 ) // V1: 2 banks
+	ROM_REGION16_BE( 0x800000, "ensoniq.0" , ROMREGION_ERASE00 ) // V1: 2 banks
 	ROM_LOAD16_BYTE("d40_01.rom", 0x000000, 0x200000, CRC(ee312e95) SHA1(885553950c2b2195d664639bf7e0d1ffa3e8346a) )    // C8 C9 CA CB
 	// half empty
 	ROM_LOAD16_BYTE("d40_02.rom", 0x600000, 0x100000, CRC(ed894fe1) SHA1(5bf2fb6abdcf25bc525a2c3b29dbf7aca0b18fea) )    // -std-
 ROM_END
 
 ROM_START( commandw )
-	ROM_REGION(0x200000, "maincpu", 0) /* 68020 code */
+	ROM_REGION( 0x200000, "maincpu", 0 ) /* 68020 code */
 	ROM_LOAD32_BYTE("cw_mpr3.bin", 0x000000, 0x40000, CRC(636944fc) SHA1(47deffed68ac179f27bfdb21ed62d6555a4b8988) )
 	ROM_LOAD32_BYTE("cw_mpr2.bin", 0x000001, 0x40000, CRC(1151a42b) SHA1(e938913ecd3211a8fb4041ec5a5694cd9df9be69) )
 	ROM_LOAD32_BYTE("cw_mpr1.bin", 0x000002, 0x40000, CRC(93669389) SHA1(11336a15900c4f419f3af5c423fbc502f4db616b) )
 	ROM_LOAD32_BYTE("cw_mpr0.bin", 0x000003, 0x40000, CRC(0468df52) SHA1(0da923aa779b541e700c5249272e9c59ab59e863) )
 
-	ROM_REGION(0x1000000, "gfx1" , 0) /* Sprites */
+	ROM_REGION( 0x800000, "sprites" , 0) /* Sprites */
 	ROM_LOAD16_BYTE("cw_objl0.bin",  0x000000, 0x200000, CRC(9822102e) SHA1(c4e80ab4d54c39676ee6e557a03828250077765b) )
 	ROM_LOAD16_BYTE("cw_objm0.bin",  0x000001, 0x200000, CRC(f7687684) SHA1(0bed6362dee96083e2e8b6448c9f7bfa5166bfb7) )
-	ROM_LOAD16_BYTE("cw_objl1.bin",  0x400000, 0x200000,  CRC(ca3ad7f6) SHA1(849fbb89f0b132c83db5b7d699078da3cc10baf6) )
+	ROM_LOAD16_BYTE("cw_objl1.bin",  0x400000, 0x200000, CRC(ca3ad7f6) SHA1(849fbb89f0b132c83db5b7d699078da3cc10baf6) )
 	ROM_LOAD16_BYTE("cw_objm1.bin",  0x400001, 0x200000, CRC(504b1bf5) SHA1(7b8ff7834907a9cdab5416bf713487bf71b9070e) )
-	ROM_LOAD       ("cw_objh0.bin",  0xc00000, 0x200000, CRC(83d7e0ae) SHA1(774a07d0cadc2c8f5ec155270bf927e4462654e2) )
-	ROM_LOAD       ("cw_objh1.bin",  0xe00000, 0x200000, CRC(324f5832) SHA1(ff91243c5d09c4c46904640fe278a7485db70577) )
-	ROM_FILL       (                 0x800000, 0x400000, 0x00 )
 
-	ROM_REGION(0x400000, "gfx2" , 0) /* Tiles */
-	ROM_LOAD16_BYTE("cw_scr_l.bin", 0x000000, 0x100000, CRC(4d202323) SHA1(0150bcba6d2bf2c3cde88bb519f57f3b58314244) )
-	ROM_LOAD16_BYTE("cw_scr_m.bin", 0x000001, 0x100000, CRC(537b1c7d) SHA1(bc61aa61891366cbea4b8ecb820d93e28d01f8d2) )
-	ROM_LOAD       ("cw_scr_h.bin", 0x300000, 0x100000, CRC(001f85dd) SHA1(2532377c0b54bc964ea4e74911ff62fea2d53975) )
-	ROM_FILL       (                0x200000, 0x100000, 0x00 )
+	ROM_REGION( 0x400000, "sprites_hi", 0 )
+	ROM_LOAD       ("cw_objh0.bin",  0x000000, 0x200000, CRC(83d7e0ae) SHA1(774a07d0cadc2c8f5ec155270bf927e4462654e2) )
+	ROM_LOAD       ("cw_objh1.bin",  0x200000, 0x200000, CRC(324f5832) SHA1(ff91243c5d09c4c46904640fe278a7485db70577) )
 
-	ROM_REGION(0x140000, "taito_en:audiocpu", 0) /* sound CPU */
+	ROM_REGION( 0x200000, "tilemap" , 0) /* Tiles */
+	ROM_LOAD32_WORD("cw_scr_l.bin", 0x000000, 0x100000, CRC(4d202323) SHA1(0150bcba6d2bf2c3cde88bb519f57f3b58314244) )
+	ROM_LOAD32_WORD("cw_scr_m.bin", 0x000002, 0x100000, CRC(537b1c7d) SHA1(bc61aa61891366cbea4b8ecb820d93e28d01f8d2) )
+
+	ROM_REGION( 0x100000, "tilemap_hi", 0 )
+	ROM_LOAD       ("cw_scr_h.bin", 0x000000, 0x100000, CRC(001f85dd) SHA1(2532377c0b54bc964ea4e74911ff62fea2d53975) )
+
+	ROM_REGION( 0x140000, "taito_en:audiocpu", 0 ) /* sound CPU */
 	ROM_LOAD16_BYTE("cw_spr1.bin", 0x100000, 0x20000, CRC(c8f81c25) SHA1(1c914053826587cc2d5d2c0220a3e29a641fe6f9) )
 	ROM_LOAD16_BYTE("cw_spr0.bin", 0x100001, 0x20000, CRC(2aaa9dfb) SHA1(6d4c36ff54a84035c0ddf40e4f3eafd2adc15a5e) )
 
-	ROM_REGION16_BE(0x800000, "ensoniq.0" , ROMREGION_ERASE00 ) // V2: 4 banks, only 2 populated
+	ROM_REGION16_BE( 0x800000, "ensoniq.0" , ROMREGION_ERASE00 ) // V2: 4 banks, only 2 populated
 	ROM_LOAD16_BYTE("cw_pcm_0.bin", 0x000000, 0x200000, CRC(a1e26629) SHA1(0c5899a767f66f67a5d59b8d287d74b54f8c3727) )  // C8 C9 CA CB
 	ROM_LOAD16_BYTE("cw_pcm_1.bin", 0x400000, 0x200000, CRC(39fc6cf4) SHA1(d43ef294af62765bfec089fac1d67ad81e1b06da) )  // CC -- -std-
 ROM_END
 
 ROM_START( cupfinal )
-	ROM_REGION(0x200000, "maincpu", 0) /* 68020 code */
+	ROM_REGION( 0x200000, "maincpu", 0 ) /* 68020 code */
 	ROM_LOAD32_BYTE("d49-13.20", 0x000000, 0x20000, CRC(ccee5e73) SHA1(5273e3b9bc6fc4fa0c63d9c62aa6b638e9780c24) )
 	ROM_LOAD32_BYTE("d49-14.19", 0x000001, 0x20000, CRC(2323bf2e) SHA1(e43f9eac6887e39d5c0f39264aa914a5d5f84cca) )
 	ROM_LOAD32_BYTE("d49-16.18", 0x000002, 0x20000, CRC(8e73f739) SHA1(620a4d52abc00908cd1393babdc600b929019a51) )
 	ROM_LOAD32_BYTE("d49-20.17", 0x000003, 0x20000, CRC(1e9c392c) SHA1(4ed9390b84c23809215a42c930ab0451531cfef1) )
 
-	ROM_REGION(0xc00000, "gfx1" , 0) /* Sprites */
+	ROM_REGION( 0x600000, "sprites" , 0) /* Sprites */
 	ROM_LOAD16_BYTE("d49-01.12", 0x000000, 0x200000, CRC(1dc89f1c) SHA1(9597b1d8c9b447080ca9401aee83bb4a64bb8332) )
 	ROM_LOAD16_BYTE("d49-02.8",  0x000001, 0x200000, CRC(1e4c374f) SHA1(512edc6a934578d0e7371410a041150d3b13aaad) )
 	ROM_LOAD16_BYTE("d49-06.11", 0x400000, 0x100000, CRC(71ef4ee1) SHA1(1d7729dbc77f7201ff574e8aef65a55bd81c25a7) )
 	ROM_LOAD16_BYTE("d49-07.7",  0x400001, 0x100000, CRC(e5655b8f) SHA1(2c21745370bfe9dbf0e95f7ce42ed34a162bff64) )
-	ROM_LOAD       ("d49-03.4",  0x900000, 0x200000, CRC(cf9a8727) SHA1(f21787fdcdd8be2009c2d481a9b2d7fc03ce782e) )
-	ROM_LOAD       ("d49-08.3",  0xb00000, 0x100000, CRC(7d3c6536) SHA1(289b4bf79ebd9cbdf64ab956784d226e6d546654) )
-	ROM_FILL       (             0x600000, 0x300000, 0x00 )
 
-	ROM_REGION(0x200000, "gfx2" , 0) /* Tiles */
-	ROM_LOAD16_BYTE("d49-09.47", 0x000000, 0x080000, CRC(257ede01) SHA1(c36397d95706c5e68a7738c84829a51c5e8f5ef7) )
-	ROM_LOAD16_BYTE("d49-10.45", 0x000001, 0x080000, CRC(f587b787) SHA1(22db4904c134756ddd0f753f197419d27e60a827) )
-	ROM_LOAD       ("d49-11.43", 0x180000, 0x080000, CRC(11318b26) SHA1(a7153f9f406d52189f59cbe58d65f88f4e2e6fcc) )
-	ROM_FILL       (             0x100000, 0x080000, 0x00 )
+	ROM_REGION( 0x300000, "sprites_hi", 0 )
+	ROM_LOAD       ("d49-03.4",  0x000000, 0x200000, CRC(cf9a8727) SHA1(f21787fdcdd8be2009c2d481a9b2d7fc03ce782e) )
+	ROM_LOAD       ("d49-08.3",  0x200000, 0x100000, CRC(7d3c6536) SHA1(289b4bf79ebd9cbdf64ab956784d226e6d546654) )
 
-	ROM_REGION(0x140000, "taito_en:audiocpu", 0) /* 68000 sound CPU */
+	ROM_REGION( 0x100000, "tilemap" , 0) /* Tiles */
+	ROM_LOAD32_WORD("d49-09.47", 0x000000, 0x080000, CRC(257ede01) SHA1(c36397d95706c5e68a7738c84829a51c5e8f5ef7) )
+	ROM_LOAD32_WORD("d49-10.45", 0x000002, 0x080000, CRC(f587b787) SHA1(22db4904c134756ddd0f753f197419d27e60a827) )
+
+	ROM_REGION( 0x080000, "tilemap_hi", 0 )
+	ROM_LOAD       ("d49-11.43", 0x000000, 0x080000, CRC(11318b26) SHA1(a7153f9f406d52189f59cbe58d65f88f4e2e6fcc) )
+
+	ROM_REGION( 0x140000, "taito_en:audiocpu", 0 ) /* 68000 sound CPU */
 	ROM_LOAD16_BYTE("d49-17.32", 0x100000, 0x20000, CRC(f2058eba) SHA1(7faaa94fadf02b6304287b61fb9613f9f4169fef) )
 	ROM_LOAD16_BYTE("d49-18.33", 0x100001, 0x20000, CRC(a0fdd270) SHA1(9b5a2c8d35ea3bc6842e3c328447c3bf641b9237) )
 
-	ROM_REGION16_BE(0x800000, "ensoniq.0" , ROMREGION_ERASE00 ) // V1: 2 banks
+	ROM_REGION16_BE( 0x800000, "ensoniq.0" , ROMREGION_ERASE00 ) // V1: 2 banks
 	ROM_LOAD16_BYTE("d49-04.38", 0x000000, 0x200000, CRC(44b365a9) SHA1(14c4a6b193a0069360406c74c500ba24f2a55b62) ) // C8 C9 CA CB
 	// half empty
 	ROM_LOAD16_BYTE("d49-05.41", 0x600000, 0x100000, CRC(ed894fe1) SHA1(5bf2fb6abdcf25bc525a2c3b29dbf7aca0b18fea) ) // -std-
 ROM_END
 
 ROM_START( hthero93 )
-	ROM_REGION(0x200000, "maincpu", 0) /* 68020 code */
+	ROM_REGION( 0x200000, "maincpu", 0 ) /* 68020 code */
 	ROM_LOAD32_BYTE("d49-13.20", 0x000000, 0x20000, CRC(ccee5e73) SHA1(5273e3b9bc6fc4fa0c63d9c62aa6b638e9780c24) )
 	ROM_LOAD32_BYTE("d49-14.19", 0x000001, 0x20000, CRC(2323bf2e) SHA1(e43f9eac6887e39d5c0f39264aa914a5d5f84cca) )
 	ROM_LOAD32_BYTE("d49-16.18", 0x000002, 0x20000, CRC(8e73f739) SHA1(620a4d52abc00908cd1393babdc600b929019a51) )
 	ROM_LOAD32_BYTE("d49-19.17", 0x000003, 0x20000, CRC(f0925800) SHA1(e8d91b216a0409080b77cc1e832b7d15c66a5eef) ) /* Need to verify chip ID#: D49-19 is US and follows correct numbering scheme, should be D49-15 */
 
-	ROM_REGION(0xc00000, "gfx1" , 0) /* Sprites */
+	ROM_REGION( 0x600000, "sprites" , 0) /* Sprites */
 	ROM_LOAD16_BYTE("d49-01.12", 0x000000, 0x200000, CRC(1dc89f1c) SHA1(9597b1d8c9b447080ca9401aee83bb4a64bb8332) )
 	ROM_LOAD16_BYTE("d49-02.8",  0x000001, 0x200000, CRC(1e4c374f) SHA1(512edc6a934578d0e7371410a041150d3b13aaad) )
 	ROM_LOAD16_BYTE("d49-06.11", 0x400000, 0x100000, CRC(71ef4ee1) SHA1(1d7729dbc77f7201ff574e8aef65a55bd81c25a7) )
 	ROM_LOAD16_BYTE("d49-07.7",  0x400001, 0x100000, CRC(e5655b8f) SHA1(2c21745370bfe9dbf0e95f7ce42ed34a162bff64) )
-	ROM_LOAD       ("d49-03.4",  0x900000, 0x200000, CRC(cf9a8727) SHA1(f21787fdcdd8be2009c2d481a9b2d7fc03ce782e) )
-	ROM_LOAD       ("d49-08.3",  0xb00000, 0x100000, CRC(7d3c6536) SHA1(289b4bf79ebd9cbdf64ab956784d226e6d546654) )
-	ROM_FILL       (             0x600000, 0x300000, 0x00 )
 
-	ROM_REGION(0x200000, "gfx2" , 0) /* Tiles */
-	ROM_LOAD16_BYTE("d49-09.47", 0x000000, 0x080000, CRC(257ede01) SHA1(c36397d95706c5e68a7738c84829a51c5e8f5ef7) )
-	ROM_LOAD16_BYTE("d49-10.45", 0x000001, 0x080000, CRC(f587b787) SHA1(22db4904c134756ddd0f753f197419d27e60a827) )
-	ROM_LOAD       ("d49-11.43", 0x180000, 0x080000, CRC(11318b26) SHA1(a7153f9f406d52189f59cbe58d65f88f4e2e6fcc) )
-	ROM_FILL       (             0x100000, 0x080000, 0x00 )
+	ROM_REGION( 0x300000, "sprites_hi", 0 )
+	ROM_LOAD       ("d49-03.4",  0x000000, 0x200000, CRC(cf9a8727) SHA1(f21787fdcdd8be2009c2d481a9b2d7fc03ce782e) )
+	ROM_LOAD       ("d49-08.3",  0x200000, 0x100000, CRC(7d3c6536) SHA1(289b4bf79ebd9cbdf64ab956784d226e6d546654) )
 
-	ROM_REGION(0x140000, "taito_en:audiocpu", 0) /* 68000 sound CPU */
+	ROM_REGION( 0x100000, "tilemap" , 0) /* Tiles */
+	ROM_LOAD32_WORD("d49-09.47", 0x000000, 0x080000, CRC(257ede01) SHA1(c36397d95706c5e68a7738c84829a51c5e8f5ef7) )
+	ROM_LOAD32_WORD("d49-10.45", 0x000002, 0x080000, CRC(f587b787) SHA1(22db4904c134756ddd0f753f197419d27e60a827) )
+
+	ROM_REGION( 0x080000, "tilemap_hi", 0 )
+	ROM_LOAD       ("d49-11.43", 0x000000, 0x080000, CRC(11318b26) SHA1(a7153f9f406d52189f59cbe58d65f88f4e2e6fcc) )
+
+	ROM_REGION( 0x140000, "taito_en:audiocpu", 0 ) /* 68000 sound CPU */
 	ROM_LOAD16_BYTE("d49-17.32", 0x100000, 0x20000, CRC(f2058eba) SHA1(7faaa94fadf02b6304287b61fb9613f9f4169fef) )
 	ROM_LOAD16_BYTE("d49-18.33", 0x100001, 0x20000, CRC(a0fdd270) SHA1(9b5a2c8d35ea3bc6842e3c328447c3bf641b9237) )
 
-	ROM_REGION16_BE(0x800000, "ensoniq.0" , ROMREGION_ERASE00 ) // V1: 2 banks
+	ROM_REGION16_BE( 0x800000, "ensoniq.0" , ROMREGION_ERASE00 ) // V1: 2 banks
 	ROM_LOAD16_BYTE("d49-04.38", 0x000000, 0x200000, CRC(44b365a9) SHA1(14c4a6b193a0069360406c74c500ba24f2a55b62) ) // C8 C9 CA CB
 	// half empty
 	ROM_LOAD16_BYTE("d49-05.41", 0x600000, 0x100000, CRC(ed894fe1) SHA1(5bf2fb6abdcf25bc525a2c3b29dbf7aca0b18fea) ) // -std-
 ROM_END
 
 ROM_START( hthero93u )
-	ROM_REGION(0x200000, "maincpu", 0) /* 68020 code */
+	ROM_REGION( 0x200000, "maincpu", 0 ) /* 68020 code */
 	ROM_LOAD32_BYTE("d49-13.24", 0x000000, 0x20000, CRC(ccee5e73) SHA1(5273e3b9bc6fc4fa0c63d9c62aa6b638e9780c24) ) /* Dumped from the single board PCB, not a stardard F3 cart */
 	ROM_LOAD32_BYTE("d49-14.26", 0x000001, 0x20000, CRC(2323bf2e) SHA1(e43f9eac6887e39d5c0f39264aa914a5d5f84cca) )
 	ROM_LOAD32_BYTE("d49-16.37", 0x000002, 0x20000, CRC(8e73f739) SHA1(620a4d52abc00908cd1393babdc600b929019a51) )
 	ROM_LOAD32_BYTE("d49-19.35", 0x000003, 0x20000, CRC(699b09ba) SHA1(b8bf24571cdc0c4b295e0f3d2fdaa1e28ff111e3) )
 
-	ROM_REGION(0xc00000, "gfx1" , 0) /* Sprites */
+	ROM_REGION( 0x600000, "sprites" , 0) /* Sprites */
 	ROM_LOAD16_BYTE("d49-01.12", 0x000000, 0x200000, CRC(1dc89f1c) SHA1(9597b1d8c9b447080ca9401aee83bb4a64bb8332) )
 	ROM_LOAD16_BYTE("d49-02.8",  0x000001, 0x200000, CRC(1e4c374f) SHA1(512edc6a934578d0e7371410a041150d3b13aaad) )
 	ROM_LOAD16_BYTE("d49-06.11", 0x400000, 0x100000, CRC(71ef4ee1) SHA1(1d7729dbc77f7201ff574e8aef65a55bd81c25a7) )
 	ROM_LOAD16_BYTE("d49-07.7",  0x400001, 0x100000, CRC(e5655b8f) SHA1(2c21745370bfe9dbf0e95f7ce42ed34a162bff64) )
-	ROM_LOAD       ("d49-03.4",  0x900000, 0x200000, CRC(cf9a8727) SHA1(f21787fdcdd8be2009c2d481a9b2d7fc03ce782e) )
-	ROM_LOAD       ("d49-08.3",  0xb00000, 0x100000, CRC(7d3c6536) SHA1(289b4bf79ebd9cbdf64ab956784d226e6d546654) )
-	ROM_FILL       (             0x600000, 0x300000, 0x00 )
 
-	ROM_REGION(0x200000, "gfx2" , 0) /* Tiles */
-	ROM_LOAD16_BYTE("d49-09.47", 0x000000, 0x080000, CRC(257ede01) SHA1(c36397d95706c5e68a7738c84829a51c5e8f5ef7) )
-	ROM_LOAD16_BYTE("d49-10.45", 0x000001, 0x080000, CRC(f587b787) SHA1(22db4904c134756ddd0f753f197419d27e60a827) )
-	ROM_LOAD       ("d49-11.43", 0x180000, 0x080000, CRC(11318b26) SHA1(a7153f9f406d52189f59cbe58d65f88f4e2e6fcc) )
-	ROM_FILL       (             0x100000, 0x080000, 0x00 )
+	ROM_REGION( 0x300000, "sprites_hi", 0 )
+	ROM_LOAD       ("d49-03.4",  0x000000, 0x200000, CRC(cf9a8727) SHA1(f21787fdcdd8be2009c2d481a9b2d7fc03ce782e) )
+	ROM_LOAD       ("d49-08.3",  0x200000, 0x100000, CRC(7d3c6536) SHA1(289b4bf79ebd9cbdf64ab956784d226e6d546654) )
 
-	ROM_REGION(0x140000, "taito_en:audiocpu", 0) /* 68000 sound CPU */
+	ROM_REGION( 0x100000, "tilemap" , 0) /* Tiles */
+	ROM_LOAD32_WORD("d49-09.47", 0x000000, 0x080000, CRC(257ede01) SHA1(c36397d95706c5e68a7738c84829a51c5e8f5ef7) )
+	ROM_LOAD32_WORD("d49-10.45", 0x000002, 0x080000, CRC(f587b787) SHA1(22db4904c134756ddd0f753f197419d27e60a827) )
+
+	ROM_REGION( 0x080000, "tilemap_hi", 0 )
+	ROM_LOAD       ("d49-11.43", 0x000000, 0x080000, CRC(11318b26) SHA1(a7153f9f406d52189f59cbe58d65f88f4e2e6fcc) )
+
+	ROM_REGION( 0x140000, "taito_en:audiocpu", 0 ) /* 68000 sound CPU */
 	ROM_LOAD16_BYTE("d49-17.32", 0x100000, 0x20000, CRC(f2058eba) SHA1(7faaa94fadf02b6304287b61fb9613f9f4169fef) )
 	ROM_LOAD16_BYTE("d49-18.33", 0x100001, 0x20000, CRC(a0fdd270) SHA1(9b5a2c8d35ea3bc6842e3c328447c3bf641b9237) )
 
-	ROM_REGION16_BE(0x800000, "ensoniq.0" , ROMREGION_ERASE00 ) // V1: 2 banks
+	ROM_REGION16_BE( 0x800000, "ensoniq.0" , ROMREGION_ERASE00 ) // V1: 2 banks
 	ROM_LOAD16_BYTE("d49-04.38", 0x000000, 0x200000, CRC(44b365a9) SHA1(14c4a6b193a0069360406c74c500ba24f2a55b62) ) // C8 C9 CA CB
 	// half empty
 	ROM_LOAD16_BYTE("d49-05.41", 0x600000, 0x100000, CRC(ed894fe1) SHA1(5bf2fb6abdcf25bc525a2c3b29dbf7aca0b18fea) ) // -std-
 
-	ROM_REGION(0x800000, "palsgame" , ROMREGION_ERASE00 ) // all unprotected / unlocked (dumped from single PCB version of game)
+	ROM_REGION( 0x800000, "palsgame" , ROMREGION_ERASE00 ) // all unprotected / unlocked (dumped from single PCB version of game)
 	ROM_LOAD ("d49-12.ic60.bin", 0x000, 0x104, CRC(aa4cff37) SHA1(58e67e3807a32c403b1ef145d4bc5f91e1537554) )
 	ROM_LOAD ("d49-21.ic17.bin", 0x000, 0x104, CRC(821775d4) SHA1(f066cf6ee2118dd57c904fcff3bb287d57e16367) )
 
-	ROM_REGION(0x800000, "palsbase" , ROMREGION_ERASE00 ) // all unprotected / unlocked (dumped from single PCB version of game)
+	ROM_REGION( 0x800000, "palsbase" , ROMREGION_ERASE00 ) // all unprotected / unlocked (dumped from single PCB version of game)
 	// these should be the same on this and Arabian Magic, but the dumps don't match in all cases, maybe the AM ones were protected?
 	ROM_LOAD ("d29-11.ic15.bin", 0x000000, 0x157, CRC(5dd5c8f9) SHA1(5e6153d9e08985b2326dfd6d73f7b90136a7a4b1) )
 	ROM_LOAD ("d29-12.ic12.bin", 0x000000, 0x144, CRC(c872f1fd) SHA1(6bcf766f76d83c18fa1c095716a1298581aa06c2) )
@@ -1106,248 +1119,264 @@ ROM_END
 
 
 ROM_START( trstar )
-	ROM_REGION(0x200000, "maincpu", 0) /* 68020 code */
+	ROM_REGION( 0x200000, "maincpu", 0 ) /* 68020 code */
 	ROM_LOAD32_BYTE("d53-15-1.24", 0x000000, 0x40000, CRC(098bba94) SHA1(b77990213ac790d15bdc0dc1e8f7adf04fe5e952) )
 	ROM_LOAD32_BYTE("d53-16-1.26", 0x000001, 0x40000, CRC(4fa8b15c) SHA1(821c21e1b958614ba6636330583b3661f9e0cebb) )
 	ROM_LOAD32_BYTE("d53-18-1.37", 0x000002, 0x40000, CRC(aa71cfcc) SHA1(ba62c01255cdfe0821d1b72b7f11d6e1f88b09d7) )
 	ROM_LOAD32_BYTE("d53-20-1.35", 0x000003, 0x40000, CRC(4de1e287) SHA1(2b592ecbf8d81aca49844ed81c351818409f596f) )
 
-	ROM_REGION(0xc00000, "gfx1" , 0) /* Sprites */
+	ROM_REGION( 0x600000, "sprites" , 0) /* Sprites */
 	ROM_LOAD16_BYTE("d53-03.45", 0x000000, 0x200000, CRC(91b66145) SHA1(df5bc2e544ce80a98db1fe28b4a8af8c3905c7eb) )
 	ROM_LOAD16_BYTE("d53-04.46", 0x000001, 0x200000, CRC(ac3a5e80) SHA1(8a6ea8096099b465d63d56abc79ed77304fd4fa4) )
 	ROM_LOAD16_BYTE("d53-06.64", 0x400000, 0x100000, CRC(f4bac410) SHA1(569bcd81d596b24add5db4a145ae04750a1bb086) )
 	ROM_LOAD16_BYTE("d53-07.65", 0x400001, 0x100000, CRC(2f4773c3) SHA1(17cef13de0836923743b336cc5a64f7452629486) )
-	ROM_LOAD       ("d53-05.47", 0x900000, 0x200000, CRC(b9b68b15) SHA1(c3783b09b22954a959188b80e537fa84d827ac47) )
-	ROM_LOAD       ("d53-08.66", 0xb00000, 0x100000, CRC(ad13a1ee) SHA1(341112055b6bee33072c262f4ea7c4d0970888a6) )
-	ROM_FILL       (             0x600000, 0x300000, 0x00 )
 
-	ROM_REGION(0x400000, "gfx2" , 0) /* Tiles */
-	ROM_LOAD16_BYTE("d53-09.48", 0x000000, 0x100000, CRC(690554d3) SHA1(113afd8fe7b77a30c2e3c5baca3f19d74902625b) )
-	ROM_LOAD16_BYTE("d53-10.49", 0x000001, 0x100000, CRC(0ec05dc5) SHA1(781a6362ef963417fb6383a62dcc70d6f5b3131b) )
-	ROM_LOAD       ("d53-11.50", 0x300000, 0x100000, CRC(39c0a546) SHA1(53f03586f6586032fc3b4f90e987c1128edbb0a7) )
-	ROM_FILL       (             0x200000, 0x100000, 0x00 )
+	ROM_REGION( 0x300000, "sprites_hi", 0 )
+	ROM_LOAD       ("d53-05.47", 0x000000, 0x200000, CRC(b9b68b15) SHA1(c3783b09b22954a959188b80e537fa84d827ac47) )
+	ROM_LOAD       ("d53-08.66", 0x200000, 0x100000, CRC(ad13a1ee) SHA1(341112055b6bee33072c262f4ea7c4d0970888a6) )
 
-	ROM_REGION(0x140000, "taito_en:audiocpu", 0) /* 68000 sound CPU */
+	ROM_REGION( 0x200000, "tilemap" , 0) /* Tiles */
+	ROM_LOAD32_WORD("d53-09.48", 0x000000, 0x100000, CRC(690554d3) SHA1(113afd8fe7b77a30c2e3c5baca3f19d74902625b) )
+	ROM_LOAD32_WORD("d53-10.49", 0x000002, 0x100000, CRC(0ec05dc5) SHA1(781a6362ef963417fb6383a62dcc70d6f5b3131b) )
+
+	ROM_REGION( 0x100000, "tilemap_hi", 0 )
+	ROM_LOAD       ("d53-11.50", 0x000000, 0x100000, CRC(39c0a546) SHA1(53f03586f6586032fc3b4f90e987c1128edbb0a7) )
+
+	ROM_REGION( 0x140000, "taito_en:audiocpu", 0 ) /* 68000 sound CPU */
 	ROM_LOAD16_BYTE("d53-13.10", 0x100000, 0x20000, CRC(877f0361) SHA1(eda58d71fb06f739bee1451d7aa7e7e6dee10e03) )
 	ROM_LOAD16_BYTE("d53-14.23", 0x100001, 0x20000, CRC(a8664867) SHA1(dffddca469019abac33a1abe41c3fe83fbf553ce) )
 
-	ROM_REGION16_BE(0x800000, "ensoniq.0" , ROMREGION_ERASE00 ) // V2: 4 banks, only 2 populated
+	ROM_REGION16_BE( 0x800000, "ensoniq.0" , ROMREGION_ERASE00 ) // V2: 4 banks, only 2 populated
 	ROM_LOAD16_BYTE("d53-01.2", 0x000000, 0x200000, CRC(28fd2d9b) SHA1(e08037795952a28e7a5e90437f1b9675aadfa136) )  // C8 C9 CA CB
 	ROM_LOAD16_BYTE("d53-02.3", 0x400000, 0x200000, CRC(8bd4367a) SHA1(9b274fe321c4faedb7d44f7998ae2e37c6899688) )  // CC CD -std-
 ROM_END
 
 ROM_START( trstarj )
-	ROM_REGION(0x200000, "maincpu", 0) /* 68020 code */
+	ROM_REGION( 0x200000, "maincpu", 0 ) /* 68020 code */
 	ROM_LOAD32_BYTE("d53-15-1.24", 0x000000, 0x40000, CRC(098bba94) SHA1(b77990213ac790d15bdc0dc1e8f7adf04fe5e952) )
 	ROM_LOAD32_BYTE("d53-16-1.26", 0x000001, 0x40000, CRC(4fa8b15c) SHA1(821c21e1b958614ba6636330583b3661f9e0cebb) )
 	ROM_LOAD32_BYTE("d53-18-1.37", 0x000002, 0x40000, CRC(aa71cfcc) SHA1(ba62c01255cdfe0821d1b72b7f11d6e1f88b09d7) )
 	ROM_LOAD32_BYTE("d53-17-1.35", 0x000003, 0x40000, CRC(a3ef83ab) SHA1(c99170047e678a7acde1bf64f903f240e9384b94) )
 
-	ROM_REGION(0xc00000, "gfx1" , 0) /* Sprites */
+	ROM_REGION( 0x600000, "sprites" , 0) /* Sprites */
 	ROM_LOAD16_BYTE("d53-03.45", 0x000000, 0x200000, CRC(91b66145) SHA1(df5bc2e544ce80a98db1fe28b4a8af8c3905c7eb) )
 	ROM_LOAD16_BYTE("d53-04.46", 0x000001, 0x200000, CRC(ac3a5e80) SHA1(8a6ea8096099b465d63d56abc79ed77304fd4fa4) )
 	ROM_LOAD16_BYTE("d53-06.64", 0x400000, 0x100000, CRC(f4bac410) SHA1(569bcd81d596b24add5db4a145ae04750a1bb086) )
 	ROM_LOAD16_BYTE("d53-07.65", 0x400001, 0x100000, CRC(2f4773c3) SHA1(17cef13de0836923743b336cc5a64f7452629486) )
-	ROM_LOAD       ("d53-05.47", 0x900000, 0x200000, CRC(b9b68b15) SHA1(c3783b09b22954a959188b80e537fa84d827ac47) )
-	ROM_LOAD       ("d53-08.66", 0xb00000, 0x100000, CRC(ad13a1ee) SHA1(341112055b6bee33072c262f4ea7c4d0970888a6) )
-	ROM_FILL       (             0x600000, 0x300000, 0x00 )
 
-	ROM_REGION(0x400000, "gfx2" , 0) /* Tiles */
-	ROM_LOAD16_BYTE("d53-09.48", 0x000000, 0x100000, CRC(690554d3) SHA1(113afd8fe7b77a30c2e3c5baca3f19d74902625b) )
-	ROM_LOAD16_BYTE("d53-10.49", 0x000001, 0x100000, CRC(0ec05dc5) SHA1(781a6362ef963417fb6383a62dcc70d6f5b3131b) )
-	ROM_LOAD       ("d53-11.50", 0x300000, 0x100000, CRC(39c0a546) SHA1(53f03586f6586032fc3b4f90e987c1128edbb0a7) )
-	ROM_FILL       (             0x200000, 0x100000, 0x00 )
+	ROM_REGION( 0x300000, "sprites_hi", 0 )
+	ROM_LOAD       ("d53-05.47", 0x000000, 0x200000, CRC(b9b68b15) SHA1(c3783b09b22954a959188b80e537fa84d827ac47) )
+	ROM_LOAD       ("d53-08.66", 0x200000, 0x100000, CRC(ad13a1ee) SHA1(341112055b6bee33072c262f4ea7c4d0970888a6) )
 
-	ROM_REGION(0x140000, "taito_en:audiocpu", 0) /* 68000 sound CPU */
+	ROM_REGION( 0x200000, "tilemap" , 0) /* Tiles */
+	ROM_LOAD32_WORD("d53-09.48", 0x000000, 0x100000, CRC(690554d3) SHA1(113afd8fe7b77a30c2e3c5baca3f19d74902625b) )
+	ROM_LOAD32_WORD("d53-10.49", 0x000002, 0x100000, CRC(0ec05dc5) SHA1(781a6362ef963417fb6383a62dcc70d6f5b3131b) )
+
+	ROM_REGION( 0x100000, "tilemap_hi", 0 )
+	ROM_LOAD       ("d53-11.50", 0x000000, 0x100000, CRC(39c0a546) SHA1(53f03586f6586032fc3b4f90e987c1128edbb0a7) )
+
+	ROM_REGION( 0x140000, "taito_en:audiocpu", 0 ) /* 68000 sound CPU */
 	ROM_LOAD16_BYTE("d53-13.10", 0x100000, 0x20000, CRC(877f0361) SHA1(eda58d71fb06f739bee1451d7aa7e7e6dee10e03) )
 	ROM_LOAD16_BYTE("d53-14.23", 0x100001, 0x20000, CRC(a8664867) SHA1(dffddca469019abac33a1abe41c3fe83fbf553ce) )
 
-	ROM_REGION16_BE(0x800000, "ensoniq.0" , ROMREGION_ERASE00 ) // V2: 4 banks, only 2 populated
+	ROM_REGION16_BE( 0x800000, "ensoniq.0" , ROMREGION_ERASE00 ) // V2: 4 banks, only 2 populated
 	ROM_LOAD16_BYTE("d53-01.2", 0x000000, 0x200000, CRC(28fd2d9b) SHA1(e08037795952a28e7a5e90437f1b9675aadfa136) )  // C8 C9 CA CB
 	ROM_LOAD16_BYTE("d53-02.3", 0x400000, 0x200000, CRC(8bd4367a) SHA1(9b274fe321c4faedb7d44f7998ae2e37c6899688) )  // CC CD -std-
 ROM_END
 
 ROM_START( prmtmfgt )
-	ROM_REGION(0x200000, "maincpu", 0) /* 68020 code */
+	ROM_REGION( 0x200000, "maincpu", 0 ) /* 68020 code */
 	ROM_LOAD32_BYTE("d53-15-1.24", 0x000000, 0x40000, CRC(098bba94) SHA1(b77990213ac790d15bdc0dc1e8f7adf04fe5e952) )
 	ROM_LOAD32_BYTE("d53-16-1.26", 0x000001, 0x40000, CRC(4fa8b15c) SHA1(821c21e1b958614ba6636330583b3661f9e0cebb) )
 	ROM_LOAD32_BYTE("d53-18-1.37", 0x000002, 0x40000, CRC(aa71cfcc) SHA1(ba62c01255cdfe0821d1b72b7f11d6e1f88b09d7) )
 	ROM_LOAD32_BYTE("d53-19-1.35", 0x000003, 0x40000, CRC(3ae6d211) SHA1(f3e27e0169686633d8d8f2cbac05375aa94cfde9) )
 
-	ROM_REGION(0xc00000, "gfx1" , 0) /* Sprites */
+	ROM_REGION( 0x600000, "sprites" , 0) /* Sprites */
 	ROM_LOAD16_BYTE("d53-03.45", 0x000000, 0x200000, CRC(91b66145) SHA1(df5bc2e544ce80a98db1fe28b4a8af8c3905c7eb) )
 	ROM_LOAD16_BYTE("d53-04.46", 0x000001, 0x200000, CRC(ac3a5e80) SHA1(8a6ea8096099b465d63d56abc79ed77304fd4fa4) )
 	ROM_LOAD16_BYTE("d53-06.64", 0x400000, 0x100000, CRC(f4bac410) SHA1(569bcd81d596b24add5db4a145ae04750a1bb086) )
 	ROM_LOAD16_BYTE("d53-07.65", 0x400001, 0x100000, CRC(2f4773c3) SHA1(17cef13de0836923743b336cc5a64f7452629486) )
-	ROM_LOAD       ("d53-05.47", 0x900000, 0x200000, CRC(b9b68b15) SHA1(c3783b09b22954a959188b80e537fa84d827ac47) )
-	ROM_LOAD       ("d53-08.66", 0xb00000, 0x100000, CRC(ad13a1ee) SHA1(341112055b6bee33072c262f4ea7c4d0970888a6) )
-	ROM_FILL       (             0x600000, 0x300000, 0x00 )
 
-	ROM_REGION(0x400000, "gfx2" , 0) /* Tiles */
-	ROM_LOAD16_BYTE("d53-09.48", 0x000000, 0x100000, CRC(690554d3) SHA1(113afd8fe7b77a30c2e3c5baca3f19d74902625b) )
-	ROM_LOAD16_BYTE("d53-10.49", 0x000001, 0x100000, CRC(0ec05dc5) SHA1(781a6362ef963417fb6383a62dcc70d6f5b3131b) )
-	ROM_LOAD       ("d53-11.50", 0x300000, 0x100000, CRC(39c0a546) SHA1(53f03586f6586032fc3b4f90e987c1128edbb0a7) )
-	ROM_FILL       (             0x200000, 0x100000, 0x00 )
+	ROM_REGION( 0x300000, "sprites_hi", 0 )
+	ROM_LOAD       ("d53-05.47", 0x000000, 0x200000, CRC(b9b68b15) SHA1(c3783b09b22954a959188b80e537fa84d827ac47) )
+	ROM_LOAD       ("d53-08.66", 0x200000, 0x100000, CRC(ad13a1ee) SHA1(341112055b6bee33072c262f4ea7c4d0970888a6) )
 
-	ROM_REGION(0x140000, "taito_en:audiocpu", 0) /* 68000 sound CPU */
+	ROM_REGION( 0x200000, "tilemap" , 0) /* Tiles */
+	ROM_LOAD32_WORD("d53-09.48", 0x000000, 0x100000, CRC(690554d3) SHA1(113afd8fe7b77a30c2e3c5baca3f19d74902625b) )
+	ROM_LOAD32_WORD("d53-10.49", 0x000002, 0x100000, CRC(0ec05dc5) SHA1(781a6362ef963417fb6383a62dcc70d6f5b3131b) )
+
+	ROM_REGION( 0x100000, "tilemap_hi", 0 )
+	ROM_LOAD       ("d53-11.50", 0x000000, 0x100000, CRC(39c0a546) SHA1(53f03586f6586032fc3b4f90e987c1128edbb0a7) )
+
+	ROM_REGION( 0x140000, "taito_en:audiocpu", 0 ) /* 68000 sound CPU */
 	ROM_LOAD16_BYTE("d53-13.10", 0x100000, 0x20000, CRC(877f0361) SHA1(eda58d71fb06f739bee1451d7aa7e7e6dee10e03) )
 	ROM_LOAD16_BYTE("d53-14.23", 0x100001, 0x20000, CRC(a8664867) SHA1(dffddca469019abac33a1abe41c3fe83fbf553ce) )
 
-	ROM_REGION16_BE(0x800000, "ensoniq.0" , ROMREGION_ERASE00 ) // V2: 4 banks, only 2 populated
+	ROM_REGION16_BE( 0x800000, "ensoniq.0" , ROMREGION_ERASE00 ) // V2: 4 banks, only 2 populated
 	ROM_LOAD16_BYTE("d53-01.2", 0x000000, 0x200000, CRC(28fd2d9b) SHA1(e08037795952a28e7a5e90437f1b9675aadfa136) )  // C8 C9 CA CB
 	ROM_LOAD16_BYTE("d53-02.3", 0x400000, 0x200000, CRC(8bd4367a) SHA1(9b274fe321c4faedb7d44f7998ae2e37c6899688) )  // CC CD -std-
 ROM_END
 
 ROM_START( trstaro )
-	ROM_REGION(0x200000, "maincpu", 0) /* 68020 code */
+	ROM_REGION( 0x200000, "maincpu", 0 ) /* 68020 code */
 	ROM_LOAD32_BYTE("d53-15.24", 0x000000, 0x40000, CRC(f24de51b) SHA1(d45d1b60901995edf0721eae7eb8c6e829f47d8d) )
 	ROM_LOAD32_BYTE("d53-16.26", 0x000001, 0x40000, CRC(ffc84429) SHA1(23354c1a65853c06e5c959957a92b700b1418fd4) )
 	ROM_LOAD32_BYTE("d53-18.37", 0x000002, 0x40000, CRC(ea2d6e13) SHA1(96461b73de745c4b0ac99267931106e1d5dcb664) )
 	ROM_LOAD32_BYTE("d53-20.35", 0x000003, 0x40000, CRC(77e1f267) SHA1(763ccab234c45ea00908198b0aef3ba63ddfb8f8) )
 
-	ROM_REGION(0xc00000, "gfx1" , 0) /* Sprites */
+	ROM_REGION( 0x600000, "sprites" , 0) /* Sprites */
 	ROM_LOAD16_BYTE("d53-03.45", 0x000000, 0x200000, CRC(91b66145) SHA1(df5bc2e544ce80a98db1fe28b4a8af8c3905c7eb) )
 	ROM_LOAD16_BYTE("d53-04.46", 0x000001, 0x200000, CRC(ac3a5e80) SHA1(8a6ea8096099b465d63d56abc79ed77304fd4fa4) )
 	ROM_LOAD16_BYTE("d53-06.64", 0x400000, 0x100000, CRC(f4bac410) SHA1(569bcd81d596b24add5db4a145ae04750a1bb086) )
 	ROM_LOAD16_BYTE("d53-07.65", 0x400001, 0x100000, CRC(2f4773c3) SHA1(17cef13de0836923743b336cc5a64f7452629486) )
-	ROM_LOAD       ("d53-05.47", 0x900000, 0x200000, CRC(b9b68b15) SHA1(c3783b09b22954a959188b80e537fa84d827ac47) )
-	ROM_LOAD       ("d53-08.66", 0xb00000, 0x100000, CRC(ad13a1ee) SHA1(341112055b6bee33072c262f4ea7c4d0970888a6) )
-	ROM_FILL       (             0x600000, 0x300000, 0x00 )
 
-	ROM_REGION(0x400000, "gfx2" , 0) /* Tiles */
-	ROM_LOAD16_BYTE("d53-09.48", 0x000000, 0x100000, CRC(690554d3) SHA1(113afd8fe7b77a30c2e3c5baca3f19d74902625b) )
-	ROM_LOAD16_BYTE("d53-10.49", 0x000001, 0x100000, CRC(0ec05dc5) SHA1(781a6362ef963417fb6383a62dcc70d6f5b3131b) )
-	ROM_LOAD       ("d53-11.50", 0x300000, 0x100000, CRC(39c0a546) SHA1(53f03586f6586032fc3b4f90e987c1128edbb0a7) )
-	ROM_FILL       (             0x200000, 0x100000, 0x00 )
+	ROM_REGION( 0x300000, "sprites_hi", 0 )
+	ROM_LOAD       ("d53-05.47", 0x000000, 0x200000, CRC(b9b68b15) SHA1(c3783b09b22954a959188b80e537fa84d827ac47) )
+	ROM_LOAD       ("d53-08.66", 0x200000, 0x100000, CRC(ad13a1ee) SHA1(341112055b6bee33072c262f4ea7c4d0970888a6) )
 
-	ROM_REGION(0x140000, "taito_en:audiocpu", 0) /* 68000 sound CPU */
+	ROM_REGION( 0x200000, "tilemap" , 0) /* Tiles */
+	ROM_LOAD32_WORD("d53-09.48", 0x000000, 0x100000, CRC(690554d3) SHA1(113afd8fe7b77a30c2e3c5baca3f19d74902625b) )
+	ROM_LOAD32_WORD("d53-10.49", 0x000002, 0x100000, CRC(0ec05dc5) SHA1(781a6362ef963417fb6383a62dcc70d6f5b3131b) )
+
+	ROM_REGION( 0x100000, "tilemap_hi", 0 )
+	ROM_LOAD       ("d53-11.50", 0x000000, 0x100000, CRC(39c0a546) SHA1(53f03586f6586032fc3b4f90e987c1128edbb0a7) )
+
+	ROM_REGION( 0x140000, "taito_en:audiocpu", 0 ) /* 68000 sound CPU */
 	ROM_LOAD16_BYTE("d53-13.10", 0x100000, 0x20000, CRC(877f0361) SHA1(eda58d71fb06f739bee1451d7aa7e7e6dee10e03) )
 	ROM_LOAD16_BYTE("d53-14.23", 0x100001, 0x20000, CRC(a8664867) SHA1(dffddca469019abac33a1abe41c3fe83fbf553ce) )
 
-	ROM_REGION16_BE(0x800000, "ensoniq.0" , ROMREGION_ERASE00 ) // V2: 4 banks, only 2 populated
+	ROM_REGION16_BE( 0x800000, "ensoniq.0" , ROMREGION_ERASE00 ) // V2: 4 banks, only 2 populated
 	ROM_LOAD16_BYTE("d53-01.2", 0x000000, 0x200000, CRC(28fd2d9b) SHA1(e08037795952a28e7a5e90437f1b9675aadfa136) )  // C8 C9 CA CB
 	ROM_LOAD16_BYTE("d53-02.3", 0x400000, 0x200000, CRC(8bd4367a) SHA1(9b274fe321c4faedb7d44f7998ae2e37c6899688) )  // CC CD -std-
 ROM_END
 
 ROM_START( trstaroj )
-	ROM_REGION(0x200000, "maincpu", 0) /* 68020 code */
+	ROM_REGION( 0x200000, "maincpu", 0 ) /* 68020 code */
 	ROM_LOAD32_BYTE("d53-15.24", 0x000000, 0x40000, CRC(f24de51b) SHA1(d45d1b60901995edf0721eae7eb8c6e829f47d8d) )
 	ROM_LOAD32_BYTE("d53-16.26", 0x000001, 0x40000, CRC(ffc84429) SHA1(23354c1a65853c06e5c959957a92b700b1418fd4) )
 	ROM_LOAD32_BYTE("d53-18.37", 0x000002, 0x40000, CRC(ea2d6e13) SHA1(96461b73de745c4b0ac99267931106e1d5dcb664) )
 	ROM_LOAD32_BYTE("d53-17.35", 0x000003, 0x40000, CRC(99ef934b) SHA1(a04a27f67b2db87549f4dc09cf9d00f3480351a6) )
 
-	ROM_REGION(0xc00000, "gfx1" , 0) /* Sprites */
+	ROM_REGION( 0x600000, "sprites" , 0) /* Sprites */
 	ROM_LOAD16_BYTE("d53-03.45", 0x000000, 0x200000, CRC(91b66145) SHA1(df5bc2e544ce80a98db1fe28b4a8af8c3905c7eb) )
 	ROM_LOAD16_BYTE("d53-04.46", 0x000001, 0x200000, CRC(ac3a5e80) SHA1(8a6ea8096099b465d63d56abc79ed77304fd4fa4) )
 	ROM_LOAD16_BYTE("d53-06.64", 0x400000, 0x100000, CRC(f4bac410) SHA1(569bcd81d596b24add5db4a145ae04750a1bb086) )
 	ROM_LOAD16_BYTE("d53-07.65", 0x400001, 0x100000, CRC(2f4773c3) SHA1(17cef13de0836923743b336cc5a64f7452629486) )
-	ROM_LOAD       ("d53-05.47", 0x900000, 0x200000, CRC(b9b68b15) SHA1(c3783b09b22954a959188b80e537fa84d827ac47) )
-	ROM_LOAD       ("d53-08.66", 0xb00000, 0x100000, CRC(ad13a1ee) SHA1(341112055b6bee33072c262f4ea7c4d0970888a6) )
-	ROM_FILL       (             0x600000, 0x300000, 0x00 )
 
-	ROM_REGION(0x400000, "gfx2" , 0) /* Tiles */
-	ROM_LOAD16_BYTE("d53-09.48", 0x000000, 0x100000, CRC(690554d3) SHA1(113afd8fe7b77a30c2e3c5baca3f19d74902625b) )
-	ROM_LOAD16_BYTE("d53-10.49", 0x000001, 0x100000, CRC(0ec05dc5) SHA1(781a6362ef963417fb6383a62dcc70d6f5b3131b) )
-	ROM_LOAD       ("d53-11.50", 0x300000, 0x100000, CRC(39c0a546) SHA1(53f03586f6586032fc3b4f90e987c1128edbb0a7) )
-	ROM_FILL       (             0x200000, 0x100000, 0x00 )
+	ROM_REGION( 0x300000, "sprites_hi", 0 )
+	ROM_LOAD       ("d53-05.47", 0x000000, 0x200000, CRC(b9b68b15) SHA1(c3783b09b22954a959188b80e537fa84d827ac47) )
+	ROM_LOAD       ("d53-08.66", 0x200000, 0x100000, CRC(ad13a1ee) SHA1(341112055b6bee33072c262f4ea7c4d0970888a6) )
 
-	ROM_REGION(0x140000, "taito_en:audiocpu", 0) /* 68000 sound CPU */
+	ROM_REGION( 0x200000, "tilemap" , 0) /* Tiles */
+	ROM_LOAD32_WORD("d53-09.48", 0x000000, 0x100000, CRC(690554d3) SHA1(113afd8fe7b77a30c2e3c5baca3f19d74902625b) )
+	ROM_LOAD32_WORD("d53-10.49", 0x000002, 0x100000, CRC(0ec05dc5) SHA1(781a6362ef963417fb6383a62dcc70d6f5b3131b) )
+
+	ROM_REGION( 0x100000, "tilemap_hi", 0 )
+	ROM_LOAD       ("d53-11.50", 0x000000, 0x100000, CRC(39c0a546) SHA1(53f03586f6586032fc3b4f90e987c1128edbb0a7) )
+
+	ROM_REGION( 0x140000, "taito_en:audiocpu", 0 ) /* 68000 sound CPU */
 	ROM_LOAD16_BYTE("d53-13.10", 0x100000, 0x20000, CRC(877f0361) SHA1(eda58d71fb06f739bee1451d7aa7e7e6dee10e03) )
 	ROM_LOAD16_BYTE("d53-14.23", 0x100001, 0x20000, CRC(a8664867) SHA1(dffddca469019abac33a1abe41c3fe83fbf553ce) )
 
-	ROM_REGION16_BE(0x800000, "ensoniq.0" , ROMREGION_ERASE00 ) // V2: 4 banks, only 2 populated
+	ROM_REGION16_BE( 0x800000, "ensoniq.0" , ROMREGION_ERASE00 ) // V2: 4 banks, only 2 populated
 	ROM_LOAD16_BYTE("d53-01.2", 0x000000, 0x200000, CRC(28fd2d9b) SHA1(e08037795952a28e7a5e90437f1b9675aadfa136) )  // C8 C9 CA CB
 	ROM_LOAD16_BYTE("d53-02.3", 0x400000, 0x200000, CRC(8bd4367a) SHA1(9b274fe321c4faedb7d44f7998ae2e37c6899688) )  // CC CD -std-
 ROM_END
 
 ROM_START( prmtmfgto )
-	ROM_REGION(0x200000, "maincpu", 0) /* 68020 code */
+	ROM_REGION( 0x200000, "maincpu", 0 ) /* 68020 code */
 	ROM_LOAD32_BYTE("d53-15.24", 0x000000, 0x40000, CRC(f24de51b) SHA1(d45d1b60901995edf0721eae7eb8c6e829f47d8d) )
 	ROM_LOAD32_BYTE("d53-16.26", 0x000001, 0x40000, CRC(ffc84429) SHA1(23354c1a65853c06e5c959957a92b700b1418fd4) )
 	ROM_LOAD32_BYTE("d53-18.37", 0x000002, 0x40000, CRC(ea2d6e13) SHA1(96461b73de745c4b0ac99267931106e1d5dcb664) )
 	ROM_LOAD32_BYTE("d53-19.35", 0x000003, 0x40000, CRC(00e6c2f1) SHA1(cf4b9ee35be8138abfaa354d01184efbfe83cea2) )
 
-	ROM_REGION(0xc00000, "gfx1" , 0) /* Sprites */
+	ROM_REGION( 0x600000, "sprites" , 0) /* Sprites */
 	ROM_LOAD16_BYTE("d53-03.45", 0x000000, 0x200000, CRC(91b66145) SHA1(df5bc2e544ce80a98db1fe28b4a8af8c3905c7eb) )
 	ROM_LOAD16_BYTE("d53-04.46", 0x000001, 0x200000, CRC(ac3a5e80) SHA1(8a6ea8096099b465d63d56abc79ed77304fd4fa4) )
 	ROM_LOAD16_BYTE("d53-06.64", 0x400000, 0x100000, CRC(f4bac410) SHA1(569bcd81d596b24add5db4a145ae04750a1bb086) )
 	ROM_LOAD16_BYTE("d53-07.65", 0x400001, 0x100000, CRC(2f4773c3) SHA1(17cef13de0836923743b336cc5a64f7452629486) )
-	ROM_LOAD       ("d53-05.47", 0x900000, 0x200000, CRC(b9b68b15) SHA1(c3783b09b22954a959188b80e537fa84d827ac47) )
-	ROM_LOAD       ("d53-08.66", 0xb00000, 0x100000, CRC(ad13a1ee) SHA1(341112055b6bee33072c262f4ea7c4d0970888a6) )
-	ROM_FILL       (             0x600000, 0x300000, 0x00 )
 
-	ROM_REGION(0x400000, "gfx2" , 0) /* Tiles */
-	ROM_LOAD16_BYTE("d53-09.48", 0x000000, 0x100000, CRC(690554d3) SHA1(113afd8fe7b77a30c2e3c5baca3f19d74902625b) )
-	ROM_LOAD16_BYTE("d53-10.49", 0x000001, 0x100000, CRC(0ec05dc5) SHA1(781a6362ef963417fb6383a62dcc70d6f5b3131b) )
-	ROM_LOAD       ("d53-11.50", 0x300000, 0x100000, CRC(39c0a546) SHA1(53f03586f6586032fc3b4f90e987c1128edbb0a7) )
-	ROM_FILL       (             0x200000, 0x100000, 0x00 )
+	ROM_REGION( 0x300000, "sprites_hi", 0 )
+	ROM_LOAD       ("d53-05.47", 0x000000, 0x200000, CRC(b9b68b15) SHA1(c3783b09b22954a959188b80e537fa84d827ac47) )
+	ROM_LOAD       ("d53-08.66", 0x200000, 0x100000, CRC(ad13a1ee) SHA1(341112055b6bee33072c262f4ea7c4d0970888a6) )
 
-	ROM_REGION(0x140000, "taito_en:audiocpu", 0) /* 68000 sound CPU */
+	ROM_REGION( 0x200000, "tilemap" , 0) /* Tiles */
+	ROM_LOAD32_WORD("d53-09.48", 0x000000, 0x100000, CRC(690554d3) SHA1(113afd8fe7b77a30c2e3c5baca3f19d74902625b) )
+	ROM_LOAD32_WORD("d53-10.49", 0x000002, 0x100000, CRC(0ec05dc5) SHA1(781a6362ef963417fb6383a62dcc70d6f5b3131b) )
+
+	ROM_REGION( 0x100000, "tilemap_hi", 0 )
+	ROM_LOAD       ("d53-11.50", 0x000000, 0x100000, CRC(39c0a546) SHA1(53f03586f6586032fc3b4f90e987c1128edbb0a7) )
+
+	ROM_REGION( 0x140000, "taito_en:audiocpu", 0 ) /* 68000 sound CPU */
 	ROM_LOAD16_BYTE("d53-13.10", 0x100000, 0x20000, CRC(877f0361) SHA1(eda58d71fb06f739bee1451d7aa7e7e6dee10e03) )
 	ROM_LOAD16_BYTE("d53-14.23", 0x100001, 0x20000, CRC(a8664867) SHA1(dffddca469019abac33a1abe41c3fe83fbf553ce) )
 
-	ROM_REGION16_BE(0x800000, "ensoniq.0" , ROMREGION_ERASE00 ) // V2: 4 banks, only 2 populated
+	ROM_REGION16_BE( 0x800000, "ensoniq.0" , ROMREGION_ERASE00 ) // V2: 4 banks, only 2 populated
 	ROM_LOAD16_BYTE("d53-01.2", 0x000000, 0x200000, CRC(28fd2d9b) SHA1(e08037795952a28e7a5e90437f1b9675aadfa136) )  // C8 C9 CA CB
 	ROM_LOAD16_BYTE("d53-02.3", 0x400000, 0x200000, CRC(8bd4367a) SHA1(9b274fe321c4faedb7d44f7998ae2e37c6899688) )  // CC CD -std-
 ROM_END
 
 ROM_START( gunlock )
-	ROM_REGION(0x200000, "maincpu", 0) /* 68020 code */
+	ROM_REGION( 0x200000, "maincpu", 0 ) /* 68020 code */
 	ROM_LOAD32_BYTE("d66-18.ic24", 0x000000, 0x40000, CRC(8418513e) SHA1(a071647268fad08802b88fb6d795612218b7ddef) )
 	ROM_LOAD32_BYTE("d66-19.ic26", 0x000001, 0x40000, CRC(95731473) SHA1(ab79821cd6098a4db84ebc9a499c29b1525510a5) )
 	ROM_LOAD32_BYTE("d66-21.ic37", 0x000002, 0x40000, CRC(bd0d60f2) SHA1(609ed2b04cb9efc4b370dcbdf22fd168318989be) )
 	ROM_LOAD32_BYTE("d66-24.ic35", 0x000003, 0x40000, CRC(97816378) SHA1(b22cb442b663c7a10fbc292583cd788f66f10a25) )
 
-	ROM_REGION(0x400000, "gfx1" , 0) /* Sprites */
+	ROM_REGION( 0x200000, "sprites" , 0) /* Sprites */
 	ROM_LOAD16_BYTE("d66-03.ic45", 0x000000, 0x100000, CRC(e7a4a491) SHA1(87837e8dd1c9a1db5e540b678233634bd52328f0) )
 	ROM_LOAD16_BYTE("d66-04.ic46", 0x000001, 0x100000, CRC(c1c7aaa7) SHA1(f929516cf50d82b2d1d1b4c49a0eb1dea819aae1) )
-	ROM_LOAD       ("d66-05.ic47", 0x300000, 0x100000, CRC(a3cefe04) SHA1(dd4f47a814853f4512ce25c5f25121c53ee4ada1) )
-	ROM_FILL       (               0x200000, 0x100000, 0x00 )
 
-	ROM_REGION(0x400000, "gfx2" , 0) /* Tiles */
-	ROM_LOAD16_BYTE("d66-06.ic48", 0x000000, 0x100000, CRC(b3d8126d) SHA1(3cbb44f396973c36abdf3fdf391becb22bb6d661) )
-	ROM_LOAD16_BYTE("d66-07.ic49", 0x000001, 0x100000, CRC(a6da9be7) SHA1(b528505ab925db75acf31bfbed2035cbe36e7a74) )
-	ROM_LOAD       ("d66-08.ic50", 0x300000, 0x100000, CRC(9959f30b) SHA1(64bf2bf995c283c00d968e3c078b824de4084d3d) )
-	ROM_FILL       (               0x200000, 0x100000, 0x00 )
+	ROM_REGION( 0x100000, "sprites_hi", 0 )
+	ROM_LOAD       ("d66-05.ic47", 0x000000, 0x100000, CRC(a3cefe04) SHA1(dd4f47a814853f4512ce25c5f25121c53ee4ada1) )
 
-	ROM_REGION(0x180000, "taito_en:audiocpu", 0) /* 68000 code */
+	ROM_REGION( 0x200000, "tilemap" , 0) /* Tiles */
+	ROM_LOAD32_WORD("d66-06.ic48", 0x000000, 0x100000, CRC(b3d8126d) SHA1(3cbb44f396973c36abdf3fdf391becb22bb6d661) )
+	ROM_LOAD32_WORD("d66-07.ic49", 0x000002, 0x100000, CRC(a6da9be7) SHA1(b528505ab925db75acf31bfbed2035cbe36e7a74) )
+
+	ROM_REGION( 0x100000, "tilemap_hi", 0 )
+	ROM_LOAD       ("d66-08.ic50", 0x000000, 0x100000, CRC(9959f30b) SHA1(64bf2bf995c283c00d968e3c078b824de4084d3d) )
+
+	ROM_REGION( 0x180000, "taito_en:audiocpu", 0 ) /* 68000 code */
 	ROM_LOAD16_BYTE("d66-23.ic10", 0x100000, 0x40000, CRC(57fb7c49) SHA1(f8709fd1e9ea7cee10ee2288d13339f675a7d3ae) )
 	ROM_LOAD16_BYTE("d66-22.ic23", 0x100001, 0x40000, CRC(83dd7f9b) SHA1(dae21f64232d3e268f22b5e9899e0b726fdc9a9f) )
 
-	ROM_REGION16_BE(0x800000, "ensoniq.0" , ROMREGION_ERASE00 ) // V2: 4 banks, only 2 populated
+	ROM_REGION16_BE( 0x800000, "ensoniq.0" , ROMREGION_ERASE00 ) // V2: 4 banks, only 2 populated
 	ROM_LOAD16_BYTE("d66-01.ic2", 0x000000, 0x200000, CRC(58c92efa) SHA1(bb207b35b8f9538362bb99a9ec8df206694f00ce) )    // C8 C9 CA CB
 	ROM_LOAD16_BYTE("d66-02.ic3", 0x400000, 0x200000, CRC(dcdafaab) SHA1(c981c7e54a2a9aaa85bb758691858495d623b029) )    // CC CD -std-
 ROM_END
 
 ROM_START( gunlocko )
-	ROM_REGION(0x200000, "maincpu", 0) /* 68020 code */
+	ROM_REGION( 0x200000, "maincpu", 0 ) /* 68020 code */
 	ROM_LOAD32_BYTE("ic24.ic24", 0x000000, 0x40000, CRC(c6a89434) SHA1(8c9da876f4c8e1ee234431949357e8208b2178dd) )  // Gunlock  Ver 2.0O  1993/12/15  17:38:00
 	ROM_LOAD32_BYTE("ic26.ic26", 0x000001, 0x40000, CRC(0d1dd41d) SHA1(6bfa52305fc72e41dfe2d91a87e697dfe60e775a) )
 	ROM_LOAD32_BYTE("ic37.ic37", 0x000002, 0x40000, CRC(94bc17fe) SHA1(0786d6f028bcd53e8af4c3fe05a0df141d898da1) )
 	ROM_LOAD32_BYTE("ic35.ic35", 0x000003, 0x40000, CRC(ca47e1cd) SHA1(36163b7f7ff73c16d829d6917a2a4e6c1bf463f7) )
 
-	ROM_REGION(0x400000, "gfx1" , 0) /* Sprites */
+	ROM_REGION( 0x200000, "sprites" , 0) /* Sprites */
 	ROM_LOAD16_BYTE("lobj0-l.ic33", 0x000000, 0x080000, CRC(5fde6dbb) SHA1(390fb596566674b494e533f49b83655a8b27c312) )
 	ROM_LOAD16_BYTE("lobj0-m.ic25", 0x000001, 0x080000, CRC(d308db27) SHA1(b7a309c30a92abd9ed2f31d3827f19427949075f) )
 	ROM_LOAD16_BYTE("lobj1-l.ic32", 0x100000, 0x080000, CRC(83d76f4b) SHA1(8b0894f636e2f7d0c53d0789e7a8fb8e421f28cb) )  // LOBJ0-L + LOBJ1-L == D66-03.IC45
 	ROM_LOAD16_BYTE("lobj1-m.ic24", 0x100001, 0x080000, CRC(5034a854) SHA1(2e021e48e57ad4fc76d5f3a707c6634d1bc98b9c) )  // LOBJ0-M + LOBJ1-M == D66-04.IC46
-	ROM_LOAD       ("lobj0-h.ic16", 0x300000, 0x080000, CRC(8899db2e) SHA1(6767e398f5c7df79b0dc2f97b3e7af407793dd37) )
-	ROM_LOAD       ("lobj1-h.ic15", 0x380000, 0x080000, CRC(0607fd85) SHA1(f9c7116a4185a45e041c8e8726a781e6de859fc7) )  // LOBJ0-H + LOBJ1-H == D66-05.IC47
-	ROM_FILL       (                0x200000, 0x100000, 0x00 )
 
-	ROM_REGION(0x400000, "gfx2" , 0) /* Tiles */
+	ROM_REGION( 0x100000, "sprites_hi", 0 )
+	ROM_LOAD       ("lobj0-h.ic16", 0x000000, 0x080000, CRC(8899db2e) SHA1(6767e398f5c7df79b0dc2f97b3e7af407793dd37) )
+	ROM_LOAD       ("lobj1-h.ic15", 0x080000, 0x080000, CRC(0607fd85) SHA1(f9c7116a4185a45e041c8e8726a781e6de859fc7) )  // LOBJ0-H + LOBJ1-H == D66-05.IC47
+
+	ROM_REGION( 0x200000, "tilemap" , 0) /* Tiles */
 	ROM_LOAD32_BYTE("scr0-0.ic40", 0x000000, 0x080000, CRC(1c429d92) SHA1(71d2e2628e4ba5fdda34ed42c9d1c7c3df33b9aa) ) //  Odd bytes of D66-06.IC48
-	ROM_LOAD32_BYTE("scr0-2.ic38", 0x000001, 0x080000, CRC(e023c0f0) SHA1(e73c3ea44a3e8fef110ea20b6a1e8102efd0b2a9) ) //  Odd bytes of D66-07.IC49
-	ROM_LOAD32_BYTE("scr0-1.ic46", 0x000002, 0x080000, CRC(5f0cb8bf) SHA1(6e50ebce5c2346de4101c1dace75e9d65d9e6add) ) // Even bytes of D66-06.IC48
+	ROM_LOAD32_BYTE("scr0-1.ic46", 0x000001, 0x080000, CRC(5f0cb8bf) SHA1(6e50ebce5c2346de4101c1dace75e9d65d9e6add) ) // Even bytes of D66-06.IC48
+	ROM_LOAD32_BYTE("scr0-2.ic38", 0x000002, 0x080000, CRC(e023c0f0) SHA1(e73c3ea44a3e8fef110ea20b6a1e8102efd0b2a9) ) //  Odd bytes of D66-07.IC49
 	ROM_LOAD32_BYTE("scr0-3.ic44", 0x000003, 0x080000, CRC(37bbdbb9) SHA1(6ea2a36005494c45d38c44ddfc6236b2efb40962) ) // Even bytes of D66-07.IC49
-	ROM_LOAD16_BYTE("scr0-4.ic36", 0x300000, 0x080000, CRC(4f073d71) SHA1(9ac80922310fd9e7a0e59b5e1979c3cfa8cbf78b) ) // Even bytes of D66-08.IC50 (Odd bytes of D66-08.IC50 == 0xFF)
-	ROM_FILL       (               0x200000, 0x100000, 0x00 )
 
-	ROM_REGION(0x180000, "taito_en:audiocpu", 0) /* 68000 code */
+	ROM_REGION( 0x100000, "tilemap_hi", ROMREGION_ERASE00 )
+	ROM_LOAD16_BYTE("scr0-4.ic36", 0x000000, 0x080000, CRC(4f073d71) SHA1(9ac80922310fd9e7a0e59b5e1979c3cfa8cbf78b) ) // Even bytes of D66-08.IC50 (Odd bytes of D66-08.IC50 == 0xFF)
+
+	ROM_REGION( 0x180000, "taito_en:audiocpu", 0 ) /* 68000 code */
 	ROM_LOAD16_BYTE("d66-23.ic10", 0x100000, 0x40000, CRC(57fb7c49) SHA1(f8709fd1e9ea7cee10ee2288d13339f675a7d3ae) )
 	ROM_LOAD16_BYTE("d66-22.ic23", 0x100001, 0x40000, CRC(83dd7f9b) SHA1(dae21f64232d3e268f22b5e9899e0b726fdc9a9f) )
 
-	ROM_REGION16_BE(0x800000, "ensoniq.0" , ROMREGION_ERASE00 ) // V2: 4 banks, only 2 populated
+	ROM_REGION16_BE( 0x800000, "ensoniq.0" , ROMREGION_ERASE00 ) // V2: 4 banks, only 2 populated
 	ROM_LOAD16_BYTE("snd0.ic8", 0x000000, 0x080000, CRC(6a468f69) SHA1(77424ee26417e232a81a340cd192531cc59f1f50) )
 	ROM_LOAD16_BYTE("snd1.ic7", 0x100000, 0x080000, CRC(332827b5) SHA1(e1a75799e553ca3969e4aa52ec199c0bbdfcc02b) )
 	ROM_LOAD16_BYTE("snd2.ic6", 0x200000, 0x080000, CRC(b5e737dd) SHA1(a056ab589c35657580ea1d58e40ed2089e831112) )
@@ -1359,88 +1388,94 @@ ROM_START( gunlocko )
 ROM_END
 
 ROM_START( rayforce )
-	ROM_REGION(0x200000, "maincpu", 0) /* 68020 code */
+	ROM_REGION( 0x200000, "maincpu", 0 ) /* 68020 code */
 	ROM_LOAD32_BYTE("d66-18.ic24", 0x000000, 0x40000, CRC(8418513e) SHA1(a071647268fad08802b88fb6d795612218b7ddef) )
 	ROM_LOAD32_BYTE("d66-19.ic26", 0x000001, 0x40000, CRC(95731473) SHA1(ab79821cd6098a4db84ebc9a499c29b1525510a5) )
 	ROM_LOAD32_BYTE("d66-21.ic37", 0x000002, 0x40000, CRC(bd0d60f2) SHA1(609ed2b04cb9efc4b370dcbdf22fd168318989be) )
 	ROM_LOAD32_BYTE("d66-25.ic35", 0x000003, 0x40000, CRC(e08653ee) SHA1(03ae4e457369a4b29cd7d52408e28725e41ee244) )
 
-	ROM_REGION(0x400000, "gfx1" , 0) /* Sprites */
+	ROM_REGION( 0x200000, "sprites" , 0) /* Sprites */
 	ROM_LOAD16_BYTE("d66-03.ic45", 0x000000, 0x100000, CRC(e7a4a491) SHA1(87837e8dd1c9a1db5e540b678233634bd52328f0) )
 	ROM_LOAD16_BYTE("d66-04.ic46", 0x000001, 0x100000, CRC(c1c7aaa7) SHA1(f929516cf50d82b2d1d1b4c49a0eb1dea819aae1) )
-	ROM_LOAD       ("d66-05.ic47", 0x300000, 0x100000, CRC(a3cefe04) SHA1(dd4f47a814853f4512ce25c5f25121c53ee4ada1) )
-	ROM_FILL       (               0x200000, 0x100000, 0x00 )
 
-	ROM_REGION(0x400000, "gfx2" , 0) /* Tiles */
-	ROM_LOAD16_BYTE("d66-06.ic48", 0x000000, 0x100000, CRC(b3d8126d) SHA1(3cbb44f396973c36abdf3fdf391becb22bb6d661) )
-	ROM_LOAD16_BYTE("d66-07.ic49", 0x000001, 0x100000, CRC(a6da9be7) SHA1(b528505ab925db75acf31bfbed2035cbe36e7a74) )
-	ROM_LOAD       ("d66-08.ic49", 0x300000, 0x100000, CRC(9959f30b) SHA1(64bf2bf995c283c00d968e3c078b824de4084d3d) )
-	ROM_FILL       (               0x200000, 0x100000, 0x00 )
+	ROM_REGION( 0x100000, "sprites_hi", 0 )
+	ROM_LOAD       ("d66-05.ic47", 0x000000, 0x100000, CRC(a3cefe04) SHA1(dd4f47a814853f4512ce25c5f25121c53ee4ada1) )
 
-	ROM_REGION(0x180000, "taito_en:audiocpu", 0) /* 68000 code */
+	ROM_REGION( 0x200000, "tilemap" , 0) /* Tiles */
+	ROM_LOAD32_WORD("d66-06.ic48", 0x000000, 0x100000, CRC(b3d8126d) SHA1(3cbb44f396973c36abdf3fdf391becb22bb6d661) )
+	ROM_LOAD32_WORD("d66-07.ic49", 0x000002, 0x100000, CRC(a6da9be7) SHA1(b528505ab925db75acf31bfbed2035cbe36e7a74) )
+
+	ROM_REGION( 0x100000, "tilemap_hi", 0 )
+	ROM_LOAD       ("d66-08.ic49", 0x000000, 0x100000, CRC(9959f30b) SHA1(64bf2bf995c283c00d968e3c078b824de4084d3d) )
+
+	ROM_REGION( 0x180000, "taito_en:audiocpu", 0 ) /* 68000 code */
 	ROM_LOAD16_BYTE("d66-23.ic10", 0x100000, 0x40000, CRC(57fb7c49) SHA1(f8709fd1e9ea7cee10ee2288d13339f675a7d3ae) )
 	ROM_LOAD16_BYTE("d66-22.ic23", 0x100001, 0x40000, CRC(83dd7f9b) SHA1(dae21f64232d3e268f22b5e9899e0b726fdc9a9f) )
 
-	ROM_REGION16_BE(0x800000, "ensoniq.0" , ROMREGION_ERASE00 ) // V2: 4 banks, only 2 populated
+	ROM_REGION16_BE( 0x800000, "ensoniq.0" , ROMREGION_ERASE00 ) // V2: 4 banks, only 2 populated
 	ROM_LOAD16_BYTE("d66-01.ic2", 0x000000, 0x200000, CRC(58c92efa) SHA1(bb207b35b8f9538362bb99a9ec8df206694f00ce) )    // C8 C9 CA CB
 	ROM_LOAD16_BYTE("d66-02.ic3", 0x400000, 0x200000, CRC(dcdafaab) SHA1(c981c7e54a2a9aaa85bb758691858495d623b029) )    // CC CD -std-
 ROM_END
 
 ROM_START( rayforcej )
-	ROM_REGION(0x200000, "maincpu", 0) /* 68020 code */
+	ROM_REGION( 0x200000, "maincpu", 0 ) /* 68020 code */
 	ROM_LOAD32_BYTE("d66-18.ic24", 0x000000, 0x40000, CRC(8418513e) SHA1(a071647268fad08802b88fb6d795612218b7ddef) )
 	ROM_LOAD32_BYTE("d66-19.ic26", 0x000001, 0x40000, CRC(95731473) SHA1(ab79821cd6098a4db84ebc9a499c29b1525510a5) )
 	ROM_LOAD32_BYTE("d66-21.ic37", 0x000002, 0x40000, CRC(bd0d60f2) SHA1(609ed2b04cb9efc4b370dcbdf22fd168318989be) )
 	ROM_LOAD32_BYTE("d66-20.ic35", 0x000003, 0x40000, CRC(798f0254) SHA1(b070588053bddc3d0b0c2660192b0cb16bf8247f) )
 
-	ROM_REGION(0x400000, "gfx1" , 0) /* Sprites */
+	ROM_REGION( 0x200000, "sprites" , 0) /* Sprites */
 	ROM_LOAD16_BYTE("d66-03.ic45", 0x000000, 0x100000, CRC(e7a4a491) SHA1(87837e8dd1c9a1db5e540b678233634bd52328f0) )
 	ROM_LOAD16_BYTE("d66-04.ic46", 0x000001, 0x100000, CRC(c1c7aaa7) SHA1(f929516cf50d82b2d1d1b4c49a0eb1dea819aae1) )
-	ROM_LOAD       ("d66-05.ic47", 0x300000, 0x100000, CRC(a3cefe04) SHA1(dd4f47a814853f4512ce25c5f25121c53ee4ada1) )
-	ROM_FILL       (               0x200000, 0x100000, 0x00 )
 
-	ROM_REGION(0x400000, "gfx2" , 0) /* Tiles */
-	ROM_LOAD16_BYTE("d66-06.ic48", 0x000000, 0x100000, CRC(b3d8126d) SHA1(3cbb44f396973c36abdf3fdf391becb22bb6d661) )
-	ROM_LOAD16_BYTE("d66-07.ic49", 0x000001, 0x100000, CRC(a6da9be7) SHA1(b528505ab925db75acf31bfbed2035cbe36e7a74) )
-	ROM_LOAD       ("d66-08.ic49", 0x300000, 0x100000, CRC(9959f30b) SHA1(64bf2bf995c283c00d968e3c078b824de4084d3d) )
-	ROM_FILL       (               0x200000, 0x100000, 0x00 )
+	ROM_REGION( 0x100000, "sprites_hi", 0 )
+	ROM_LOAD       ("d66-05.ic47", 0x000000, 0x100000, CRC(a3cefe04) SHA1(dd4f47a814853f4512ce25c5f25121c53ee4ada1) )
 
-	ROM_REGION(0x180000, "taito_en:audiocpu", 0) /* 68000 code */
+	ROM_REGION( 0x200000, "tilemap" , 0) /* Tiles */
+	ROM_LOAD32_WORD("d66-06.ic48", 0x000000, 0x100000, CRC(b3d8126d) SHA1(3cbb44f396973c36abdf3fdf391becb22bb6d661) )
+	ROM_LOAD32_WORD("d66-07.ic49", 0x000002, 0x100000, CRC(a6da9be7) SHA1(b528505ab925db75acf31bfbed2035cbe36e7a74) )
+
+	ROM_REGION( 0x100000, "tilemap_hi", 0 )
+	ROM_LOAD       ("d66-08.ic49", 0x000000, 0x100000, CRC(9959f30b) SHA1(64bf2bf995c283c00d968e3c078b824de4084d3d) )
+
+	ROM_REGION( 0x180000, "taito_en:audiocpu", 0 ) /* 68000 code */
 	ROM_LOAD16_BYTE("d66-23.ic10", 0x100000, 0x40000, CRC(57fb7c49) SHA1(f8709fd1e9ea7cee10ee2288d13339f675a7d3ae) )
 	ROM_LOAD16_BYTE("d66-22.ic23", 0x100001, 0x40000, CRC(83dd7f9b) SHA1(dae21f64232d3e268f22b5e9899e0b726fdc9a9f) )
 
-	ROM_REGION16_BE(0x800000, "ensoniq.0" , ROMREGION_ERASE00 ) // V2: 4 banks, only 2 populated
+	ROM_REGION16_BE( 0x800000, "ensoniq.0" , ROMREGION_ERASE00 ) // V2: 4 banks, only 2 populated
 	ROM_LOAD16_BYTE("d66-01.ic2", 0x000000, 0x200000, CRC(58c92efa) SHA1(bb207b35b8f9538362bb99a9ec8df206694f00ce) )    // C8 C9 CA CB
 	ROM_LOAD16_BYTE("d66-02.ic3", 0x400000, 0x200000, CRC(dcdafaab) SHA1(c981c7e54a2a9aaa85bb758691858495d623b029) )    // CC CD -std-
 ROM_END
 
 ROM_START( scfinals ) /* This is the single PCB version */
-	ROM_REGION(0x200000, "maincpu", 0) /* 68020 code */
+	ROM_REGION( 0x200000, "maincpu", 0 ) /* 68020 code */
 	ROM_LOAD32_BYTE("d68-09.ic40", 0x000000, 0x40000, CRC(28193b3f) SHA1(cdbc185bbfbd34a1b892bacec4695b97c50a0bb7) )
 	ROM_LOAD32_BYTE("d68-10.ic38", 0x000001, 0x40000, CRC(67481bad) SHA1(97c7db7e705a2194b29c8a985702d9ccc936fd97) )
 	ROM_LOAD32_BYTE("d68-11.ic36", 0x000002, 0x40000, CRC(d456c124) SHA1(8466273ee6d81808d10b2d6be92f87a062da2131) )
 	ROM_LOAD32_BYTE("d68-12.ic34", 0x000003, 0x40000, CRC(dec41397) SHA1(17f41a42461c822f4b6d65e96e1ff7c20b0168c7) )
 
-	ROM_REGION(0xc00000, "gfx1" , 0) /* Sprites */
+	ROM_REGION( 0x600000, "sprites" , 0) /* Sprites */
 	ROM_LOAD16_BYTE("d49-01.12", 0x000000, 0x200000, CRC(1dc89f1c) SHA1(9597b1d8c9b447080ca9401aee83bb4a64bb8332) ) /* Single PCB version locations may differ */
 	ROM_LOAD16_BYTE("d49-02.8",  0x000001, 0x200000, CRC(1e4c374f) SHA1(512edc6a934578d0e7371410a041150d3b13aaad) )
 	ROM_LOAD16_BYTE("d49-06.11", 0x400000, 0x100000, CRC(71ef4ee1) SHA1(1d7729dbc77f7201ff574e8aef65a55bd81c25a7) )
 	ROM_LOAD16_BYTE("d49-07.7",  0x400001, 0x100000, CRC(e5655b8f) SHA1(2c21745370bfe9dbf0e95f7ce42ed34a162bff64) )
-	ROM_LOAD       ("d49-03.4",  0x900000, 0x200000, CRC(cf9a8727) SHA1(f21787fdcdd8be2009c2d481a9b2d7fc03ce782e) )
-	ROM_LOAD       ("d49-08.3",  0xb00000, 0x100000, CRC(7d3c6536) SHA1(289b4bf79ebd9cbdf64ab956784d226e6d546654) )
-	ROM_FILL       (             0x600000, 0x300000, 0x00 )
 
-	ROM_REGION(0x200000, "gfx2" , 0) /* Tiles */
-	ROM_LOAD16_BYTE("d49-09.47", 0x000000, 0x080000, CRC(257ede01) SHA1(c36397d95706c5e68a7738c84829a51c5e8f5ef7) ) /* Single PCB version locations may differ */
-	ROM_LOAD16_BYTE("d49-10.45", 0x000001, 0x080000, CRC(f587b787) SHA1(22db4904c134756ddd0f753f197419d27e60a827) )
-	ROM_LOAD       ("d49-11.43", 0x180000, 0x080000, CRC(11318b26) SHA1(a7153f9f406d52189f59cbe58d65f88f4e2e6fcc) )
-	ROM_FILL       (             0x100000, 0x080000, 0x00 )
+	ROM_REGION( 0x300000, "sprites_hi", 0 )
+	ROM_LOAD       ("d49-03.4",  0x000000, 0x200000, CRC(cf9a8727) SHA1(f21787fdcdd8be2009c2d481a9b2d7fc03ce782e) )
+	ROM_LOAD       ("d49-08.3",  0x200000, 0x100000, CRC(7d3c6536) SHA1(289b4bf79ebd9cbdf64ab956784d226e6d546654) )
 
-	ROM_REGION(0x140000, "taito_en:audiocpu", 0) /* 68000 sound CPU */
+	ROM_REGION( 0x100000, "tilemap" , 0) /* Tiles */
+	ROM_LOAD32_WORD("d49-09.47", 0x000000, 0x080000, CRC(257ede01) SHA1(c36397d95706c5e68a7738c84829a51c5e8f5ef7) ) /* Single PCB version locations may differ */
+	ROM_LOAD32_WORD("d49-10.45", 0x000002, 0x080000, CRC(f587b787) SHA1(22db4904c134756ddd0f753f197419d27e60a827) )
+
+	ROM_REGION( 0x080000, "tilemap_hi", 0 )
+	ROM_LOAD       ("d49-11.43", 0x000000, 0x080000, CRC(11318b26) SHA1(a7153f9f406d52189f59cbe58d65f88f4e2e6fcc) )
+
+	ROM_REGION( 0x140000, "taito_en:audiocpu", 0 ) /* 68000 sound CPU */
 	ROM_LOAD16_BYTE("d49-17.ic5", 0x100000, 0x20000, CRC(f2058eba) SHA1(7faaa94fadf02b6304287b61fb9613f9f4169fef) )
 	ROM_LOAD16_BYTE("d49-18.ic6", 0x100001, 0x20000, CRC(a0fdd270) SHA1(9b5a2c8d35ea3bc6842e3c328447c3bf641b9237) )
 
-	ROM_REGION16_BE(0x800000, "ensoniq.0" , ROMREGION_ERASE00 ) // V1: 2 banks
+	ROM_REGION16_BE( 0x800000, "ensoniq.0" , ROMREGION_ERASE00 ) // V1: 2 banks
 	ROM_LOAD16_BYTE("d49-04.38", 0x000000, 0x200000, CRC(44b365a9) SHA1(14c4a6b193a0069360406c74c500ba24f2a55b62) ) // C8 C9 CA CB
 	// half empty
 	ROM_LOAD16_BYTE("d49-05.41", 0x600000, 0x100000, CRC(ed894fe1) SHA1(5bf2fb6abdcf25bc525a2c3b29dbf7aca0b18fea) ) // -std-
@@ -1450,32 +1485,34 @@ ROM_START( scfinals ) /* This is the single PCB version */
 ROM_END
 
 ROM_START( scfinalso ) /* Cart version */
-	ROM_REGION(0x200000, "maincpu", 0) /* 68020 code */
+	ROM_REGION( 0x200000, "maincpu", 0 ) /* 68020 code */
 	ROM_LOAD32_BYTE("d68-01.20", 0x000000, 0x40000, CRC(cb951856) SHA1(c7b0418b957ed0feecc9dffe5a963bd22df0ac4e) )
 	ROM_LOAD32_BYTE("d68-02.19", 0x000001, 0x40000, CRC(4f94413a) SHA1(b46a35ab0150d5d5e53149c53f11978fbfa28159) )
 	ROM_LOAD32_BYTE("d68-04.18", 0x000002, 0x40000, CRC(4a4e4972) SHA1(5300380a57f70fe91c69f2b1e9d25253081e61da) )
 	ROM_LOAD32_BYTE("d68-03.17", 0x000003, 0x40000, CRC(a40be699) SHA1(03101d2aef8e7c0c332a3c8c0a025024f6cfe580) )
 
-	ROM_REGION(0xc00000, "gfx1" , 0) /* Sprites */
+	ROM_REGION( 0x600000, "sprites" , 0) /* Sprites */
 	ROM_LOAD16_BYTE("d49-01.12", 0x000000, 0x200000, CRC(1dc89f1c) SHA1(9597b1d8c9b447080ca9401aee83bb4a64bb8332) )
 	ROM_LOAD16_BYTE("d49-02.8",  0x000001, 0x200000, CRC(1e4c374f) SHA1(512edc6a934578d0e7371410a041150d3b13aaad) )
 	ROM_LOAD16_BYTE("d49-06.11", 0x400000, 0x100000, CRC(71ef4ee1) SHA1(1d7729dbc77f7201ff574e8aef65a55bd81c25a7) )
 	ROM_LOAD16_BYTE("d49-07.7",  0x400001, 0x100000, CRC(e5655b8f) SHA1(2c21745370bfe9dbf0e95f7ce42ed34a162bff64) )
-	ROM_LOAD       ("d49-03.4",  0x900000, 0x200000, CRC(cf9a8727) SHA1(f21787fdcdd8be2009c2d481a9b2d7fc03ce782e) )
-	ROM_LOAD       ("d49-08.3",  0xb00000, 0x100000, CRC(7d3c6536) SHA1(289b4bf79ebd9cbdf64ab956784d226e6d546654) )
-	ROM_FILL       (             0x600000, 0x300000, 0x00 )
 
-	ROM_REGION(0x200000, "gfx2" , 0) /* Tiles */
-	ROM_LOAD16_BYTE("d49-09.47", 0x000000, 0x080000, CRC(257ede01) SHA1(c36397d95706c5e68a7738c84829a51c5e8f5ef7) )
-	ROM_LOAD16_BYTE("d49-10.45", 0x000001, 0x080000, CRC(f587b787) SHA1(22db4904c134756ddd0f753f197419d27e60a827) )
-	ROM_LOAD       ("d49-11.43", 0x180000, 0x080000, CRC(11318b26) SHA1(a7153f9f406d52189f59cbe58d65f88f4e2e6fcc) )
-	ROM_FILL       (             0x100000, 0x080000, 0x00 )
+	ROM_REGION( 0x300000, "sprites_hi", 0 )
+	ROM_LOAD       ("d49-03.4",  0x000000, 0x200000, CRC(cf9a8727) SHA1(f21787fdcdd8be2009c2d481a9b2d7fc03ce782e) )
+	ROM_LOAD       ("d49-08.3",  0x200000, 0x100000, CRC(7d3c6536) SHA1(289b4bf79ebd9cbdf64ab956784d226e6d546654) )
 
-	ROM_REGION(0x140000, "taito_en:audiocpu", 0) /* 68000 sound CPU */
+	ROM_REGION( 0x100000, "tilemap" , 0) /* Tiles */
+	ROM_LOAD32_WORD("d49-09.47", 0x000000, 0x080000, CRC(257ede01) SHA1(c36397d95706c5e68a7738c84829a51c5e8f5ef7) )
+	ROM_LOAD32_WORD("d49-10.45", 0x000002, 0x080000, CRC(f587b787) SHA1(22db4904c134756ddd0f753f197419d27e60a827) )
+
+	ROM_REGION( 0x080000, "tilemap_hi", 0 )
+	ROM_LOAD       ("d49-11.43", 0x000000, 0x080000, CRC(11318b26) SHA1(a7153f9f406d52189f59cbe58d65f88f4e2e6fcc) )
+
+	ROM_REGION( 0x140000, "taito_en:audiocpu", 0 ) /* 68000 sound CPU */
 	ROM_LOAD16_BYTE("d49-17.32", 0x100000, 0x20000, CRC(f2058eba) SHA1(7faaa94fadf02b6304287b61fb9613f9f4169fef) )
 	ROM_LOAD16_BYTE("d49-18.33", 0x100001, 0x20000, CRC(a0fdd270) SHA1(9b5a2c8d35ea3bc6842e3c328447c3bf641b9237) )
 
-	ROM_REGION16_BE(0x800000, "ensoniq.0" , ROMREGION_ERASE00 ) // V1: 2 banks
+	ROM_REGION16_BE( 0x800000, "ensoniq.0" , ROMREGION_ERASE00 ) // V1: 2 banks
 	ROM_LOAD16_BYTE("d49-04.38", 0x000000, 0x200000, CRC(44b365a9) SHA1(14c4a6b193a0069360406c74c500ba24f2a55b62) ) // C8 C9 CA CB
 	// half empty
 	ROM_LOAD16_BYTE("d49-05.41", 0x600000, 0x100000, CRC(ed894fe1) SHA1(5bf2fb6abdcf25bc525a2c3b29dbf7aca0b18fea) ) // -std-
@@ -1485,94 +1522,100 @@ ROM_START( scfinalso ) /* Cart version */
 ROM_END
 
 ROM_START( lightbr )
-	ROM_REGION(0x200000, "maincpu", 0) /* 68020 code */
+	ROM_REGION( 0x200000, "maincpu", 0 ) /* 68020 code */
 	ROM_LOAD32_BYTE("d69-25.ic40", 0x000000, 0x80000, CRC(27f1b8be) SHA1(e5fc47644a000c96056e2013c42272ae5beeb98e) )
 	ROM_LOAD32_BYTE("d69-26.ic38", 0x000001, 0x80000, CRC(2ff7dba6) SHA1(8757d949f44bb69fbf918852046ed0cd46ab7864) )
 	ROM_LOAD32_BYTE("d69-28.ic36", 0x000002, 0x80000, CRC(a5546162) SHA1(35d9cd41f379e7fc4092c6c519b158208b977d89) )
 	ROM_LOAD32_BYTE("d69-27.ic34", 0x000003, 0x80000, CRC(e232a949) SHA1(aa6969e0aa195dbae1aecc4e812c590ab4389174) )
 
-	ROM_REGION(0xc00000, "gfx1" , 0) /* Sprites */
+	ROM_REGION( 0x600000, "sprites" , 0) /* Sprites */
 	ROM_LOAD16_BYTE("d69-06.bin", 0x000000, 0x200000, CRC(cb4aac81) SHA1(15d315c6b9695cc2fe07defc67c7a4fb26de1950) )
 	ROM_LOAD16_BYTE("d69-07.bin", 0x000001, 0x200000, CRC(b749f984) SHA1(39fd662bdc42e812519181a640a83e29e300826a) )
 	ROM_LOAD16_BYTE("d69-09.bin", 0x400000, 0x100000, CRC(a96c19b8) SHA1(7872b4dd9d51877bed709fec393413e41d6b954f) )
 	ROM_LOAD16_BYTE("d69-10.bin", 0x400001, 0x100000, CRC(36aa80c6) SHA1(aeb5f7632810564426761b5798539bf4c4a0c64c) )
-	ROM_LOAD       ("d69-08.bin", 0x900000, 0x200000, CRC(5b68d7d8) SHA1(f2ee3dd7100a3c9d8f402fe36dae2bc66cb17be3) )
-	ROM_LOAD       ("d69-11.bin", 0xb00000, 0x100000, CRC(c11adf92) SHA1(ee9ce49a43b419c4f44ac1aea8d0a12d7b289244) )
-	ROM_FILL       (              0x600000, 0x300000, 0x00 )
 
-	ROM_REGION(0x800000, "gfx2" , 0) /* Tiles */
-	ROM_LOAD16_BYTE("d69-03.bin", 0x000000, 0x200000, CRC(6999c86f) SHA1(8a91930edfc0b5d23e59f8c3b43131db6edb4d37) )
-	ROM_LOAD16_BYTE("d69-04.bin", 0x000001, 0x200000, CRC(cc91dcb7) SHA1(97f510b1e1a3adf49efe82babdd7abce3756ce4b) )
-	ROM_LOAD       ("d69-05.bin", 0x600000, 0x200000, CRC(f9f5433c) SHA1(d3de66385d883c72967c44bc29983d7a79f665d1) )
-	ROM_FILL       (              0x400000, 0x200000, 0x00 )
+	ROM_REGION( 0x300000, "sprites_hi", 0 )
+	ROM_LOAD       ("d69-08.bin", 0x000000, 0x200000, CRC(5b68d7d8) SHA1(f2ee3dd7100a3c9d8f402fe36dae2bc66cb17be3) )
+	ROM_LOAD       ("d69-11.bin", 0x200000, 0x100000, CRC(c11adf92) SHA1(ee9ce49a43b419c4f44ac1aea8d0a12d7b289244) )
 
-	ROM_REGION(0x140000, "taito_en:audiocpu", 0) /* 68000 sound CPU */
+	ROM_REGION( 0x400000, "tilemap" , 0) /* Tiles */
+	ROM_LOAD32_WORD("d69-03.bin", 0x000000, 0x200000, CRC(6999c86f) SHA1(8a91930edfc0b5d23e59f8c3b43131db6edb4d37) )
+	ROM_LOAD32_WORD("d69-04.bin", 0x000002, 0x200000, CRC(cc91dcb7) SHA1(97f510b1e1a3adf49efe82babdd7abce3756ce4b) )
+
+	ROM_REGION( 0x200000, "tilemap_hi", 0 )
+	ROM_LOAD       ("d69-05.bin", 0x000000, 0x200000, CRC(f9f5433c) SHA1(d3de66385d883c72967c44bc29983d7a79f665d1) )
+
+	ROM_REGION( 0x140000, "taito_en:audiocpu", 0 ) /* 68000 sound CPU */
 	ROM_LOAD16_BYTE("d69-18.bin", 0x100000, 0x20000, CRC(04600d7b) SHA1(666cfab09b61fd6e0bc4ff277018ebf1cda01b0e) )
 	ROM_LOAD16_BYTE("d69-19.bin", 0x100001, 0x20000, CRC(1484e853) SHA1(4459c18ba005786483c652857e527c6093efb036) )
 
-	ROM_REGION16_BE(0x800000, "ensoniq.0" , ROMREGION_ERASE00 ) // V2: 4 banks, only 2 populated
+	ROM_REGION16_BE( 0x800000, "ensoniq.0" , ROMREGION_ERASE00 ) // V2: 4 banks, only 2 populated
 	ROM_LOAD16_BYTE("d69-01.bin", 0x000000, 0x200000, CRC(9ac93ac2) SHA1(1c44f6ba95505f85b0c8a90395f09d2a49da3553) )    // C8 C9 CA CB
 	ROM_LOAD16_BYTE("d69-02.bin", 0x400000, 0x200000, CRC(dce28dd7) SHA1(eacfc98349b0608fc1a944c11f0483fb6caa4445) )    // CC CD -std-
 ROM_END
 
 ROM_START( dungeonm )
-	ROM_REGION(0x200000, "maincpu", 0) /* 68020 code */
+	ROM_REGION( 0x200000, "maincpu", 0 ) /* 68020 code */
 	ROM_LOAD32_BYTE("d69-20.bin", 0x000000, 0x80000, CRC(33650fe4) SHA1(df8b775749b1f0f02d0df6141597cc49fb3ae227) )
 	ROM_LOAD32_BYTE("d69-13.bin", 0x000001, 0x80000, CRC(dec2ec17) SHA1(8472a5aaea9e4e4fb5f7f4b5eda356b590d1541d) )
 	ROM_LOAD32_BYTE("d69-15.bin", 0x000002, 0x80000, CRC(323e1955) SHA1(d76582d1ff5a9aa87a498fea3280bc3c25ee9ec0) )
 	ROM_LOAD32_BYTE("d69-22.bin", 0x000003, 0x80000, CRC(f99e175d) SHA1(8f5f4710d72faed978e68e6e36703f47e8bab06f) )
 
-	ROM_REGION(0xc00000, "gfx1" , 0) /* Sprites */
+	ROM_REGION( 0x600000, "sprites" , 0) /* Sprites */
 	ROM_LOAD16_BYTE("d69-06.bin", 0x000000, 0x200000, CRC(cb4aac81) SHA1(15d315c6b9695cc2fe07defc67c7a4fb26de1950) )
 	ROM_LOAD16_BYTE("d69-07.bin", 0x000001, 0x200000, CRC(b749f984) SHA1(39fd662bdc42e812519181a640a83e29e300826a) )
 	ROM_LOAD16_BYTE("d69-09.bin", 0x400000, 0x100000, CRC(a96c19b8) SHA1(7872b4dd9d51877bed709fec393413e41d6b954f) )
 	ROM_LOAD16_BYTE("d69-10.bin", 0x400001, 0x100000, CRC(36aa80c6) SHA1(aeb5f7632810564426761b5798539bf4c4a0c64c) )
-	ROM_LOAD       ("d69-08.bin", 0x900000, 0x200000, CRC(5b68d7d8) SHA1(f2ee3dd7100a3c9d8f402fe36dae2bc66cb17be3) )
-	ROM_LOAD       ("d69-11.bin", 0xb00000, 0x100000, CRC(c11adf92) SHA1(ee9ce49a43b419c4f44ac1aea8d0a12d7b289244) )
-	ROM_FILL       (              0x600000, 0x300000, 0x00 )
 
-	ROM_REGION(0x800000, "gfx2" , 0) /* Tiles */
-	ROM_LOAD16_BYTE("d69-03.bin", 0x000000, 0x200000, CRC(6999c86f) SHA1(8a91930edfc0b5d23e59f8c3b43131db6edb4d37) )
-	ROM_LOAD16_BYTE("d69-04.bin", 0x000001, 0x200000, CRC(cc91dcb7) SHA1(97f510b1e1a3adf49efe82babdd7abce3756ce4b) )
-	ROM_LOAD       ("d69-05.bin", 0x600000, 0x200000, CRC(f9f5433c) SHA1(d3de66385d883c72967c44bc29983d7a79f665d1) )
-	ROM_FILL       (              0x400000, 0x200000, 0x00 )
+	ROM_REGION( 0x300000, "sprites_hi", 0 )
+	ROM_LOAD       ("d69-08.bin", 0x000000, 0x200000, CRC(5b68d7d8) SHA1(f2ee3dd7100a3c9d8f402fe36dae2bc66cb17be3) )
+	ROM_LOAD       ("d69-11.bin", 0x200000, 0x100000, CRC(c11adf92) SHA1(ee9ce49a43b419c4f44ac1aea8d0a12d7b289244) )
 
-	ROM_REGION(0x140000, "taito_en:audiocpu", 0) /* 68000 sound CPU */
+	ROM_REGION( 0x400000, "tilemap" , 0) /* Tiles */
+	ROM_LOAD32_WORD("d69-03.bin", 0x000000, 0x200000, CRC(6999c86f) SHA1(8a91930edfc0b5d23e59f8c3b43131db6edb4d37) )
+	ROM_LOAD32_WORD("d69-04.bin", 0x000002, 0x200000, CRC(cc91dcb7) SHA1(97f510b1e1a3adf49efe82babdd7abce3756ce4b) )
+
+	ROM_REGION( 0x200000, "tilemap_hi", 0 )
+	ROM_LOAD       ("d69-05.bin", 0x000000, 0x200000, CRC(f9f5433c) SHA1(d3de66385d883c72967c44bc29983d7a79f665d1) )
+
+	ROM_REGION( 0x140000, "taito_en:audiocpu", 0 ) /* 68000 sound CPU */
 	ROM_LOAD16_BYTE("d69-18.bin", 0x100000, 0x20000, CRC(04600d7b) SHA1(666cfab09b61fd6e0bc4ff277018ebf1cda01b0e) )
 	ROM_LOAD16_BYTE("d69-19.bin", 0x100001, 0x20000, CRC(1484e853) SHA1(4459c18ba005786483c652857e527c6093efb036) )
 
-	ROM_REGION16_BE(0x800000, "ensoniq.0" , ROMREGION_ERASE00 ) // V2: 4 banks, only 2 populated
+	ROM_REGION16_BE( 0x800000, "ensoniq.0" , ROMREGION_ERASE00 ) // V2: 4 banks, only 2 populated
 	ROM_LOAD16_BYTE("d69-01.bin", 0x000000, 0x200000, CRC(9ac93ac2) SHA1(1c44f6ba95505f85b0c8a90395f09d2a49da3553) )    // C8 C9 CA CB
 	ROM_LOAD16_BYTE("d69-02.bin", 0x400000, 0x200000, CRC(dce28dd7) SHA1(eacfc98349b0608fc1a944c11f0483fb6caa4445) )    // CC CD -std-
 ROM_END
 
 ROM_START( dungeonmu )
-	ROM_REGION(0x200000, "maincpu", 0) /* 68020 code */
+	ROM_REGION( 0x200000, "maincpu", 0 ) /* 68020 code */
 	ROM_LOAD32_BYTE("d69-20.bin", 0x000000, 0x80000, CRC(33650fe4) SHA1(df8b775749b1f0f02d0df6141597cc49fb3ae227) )
 	ROM_LOAD32_BYTE("d69-13.bin", 0x000001, 0x80000, CRC(dec2ec17) SHA1(8472a5aaea9e4e4fb5f7f4b5eda356b590d1541d) )
 	ROM_LOAD32_BYTE("d69-15.bin", 0x000002, 0x80000, CRC(323e1955) SHA1(d76582d1ff5a9aa87a498fea3280bc3c25ee9ec0) )
 	ROM_LOAD32_BYTE("d69-21.bin", 0x000003, 0x80000, CRC(c9d4e051) SHA1(7c7e76f0d0bca305ff6761aa509d344c2dac8e2e) )
 
-	ROM_REGION(0xc00000, "gfx1" , 0) /* Sprites */
+	ROM_REGION( 0x600000, "sprites" , 0) /* Sprites */
 	ROM_LOAD16_BYTE("d69-06.bin", 0x000000, 0x200000, CRC(cb4aac81) SHA1(15d315c6b9695cc2fe07defc67c7a4fb26de1950) )
 	ROM_LOAD16_BYTE("d69-07.bin", 0x000001, 0x200000, CRC(b749f984) SHA1(39fd662bdc42e812519181a640a83e29e300826a) )
 	ROM_LOAD16_BYTE("d69-09.bin", 0x400000, 0x100000, CRC(a96c19b8) SHA1(7872b4dd9d51877bed709fec393413e41d6b954f) )
 	ROM_LOAD16_BYTE("d69-10.bin", 0x400001, 0x100000, CRC(36aa80c6) SHA1(aeb5f7632810564426761b5798539bf4c4a0c64c) )
-	ROM_LOAD       ("d69-08.bin", 0x900000, 0x200000, CRC(5b68d7d8) SHA1(f2ee3dd7100a3c9d8f402fe36dae2bc66cb17be3) )
-	ROM_LOAD       ("d69-11.bin", 0xb00000, 0x100000, CRC(c11adf92) SHA1(ee9ce49a43b419c4f44ac1aea8d0a12d7b289244) )
-	ROM_FILL       (              0x600000, 0x300000, 0x00 )
 
-	ROM_REGION(0x800000, "gfx2" , 0) /* Tiles */
-	ROM_LOAD16_BYTE("d69-03.bin", 0x000000, 0x200000, CRC(6999c86f) SHA1(8a91930edfc0b5d23e59f8c3b43131db6edb4d37) )
-	ROM_LOAD16_BYTE("d69-04.bin", 0x000001, 0x200000, CRC(cc91dcb7) SHA1(97f510b1e1a3adf49efe82babdd7abce3756ce4b) )
-	ROM_LOAD       ("d69-05.bin", 0x600000, 0x200000, CRC(f9f5433c) SHA1(d3de66385d883c72967c44bc29983d7a79f665d1) )
-	ROM_FILL       (              0x400000, 0x200000, 0x00 )
+	ROM_REGION( 0x300000, "sprites_hi", 0 )
+	ROM_LOAD       ("d69-08.bin", 0x000000, 0x200000, CRC(5b68d7d8) SHA1(f2ee3dd7100a3c9d8f402fe36dae2bc66cb17be3) )
+	ROM_LOAD       ("d69-11.bin", 0x200000, 0x100000, CRC(c11adf92) SHA1(ee9ce49a43b419c4f44ac1aea8d0a12d7b289244) )
 
-	ROM_REGION(0x140000, "taito_en:audiocpu", 0) /* 68000 sound CPU */
+	ROM_REGION( 0x400000, "tilemap" , 0) /* Tiles */
+	ROM_LOAD32_WORD("d69-03.bin", 0x000000, 0x200000, CRC(6999c86f) SHA1(8a91930edfc0b5d23e59f8c3b43131db6edb4d37) )
+	ROM_LOAD32_WORD("d69-04.bin", 0x000002, 0x200000, CRC(cc91dcb7) SHA1(97f510b1e1a3adf49efe82babdd7abce3756ce4b) )
+
+	ROM_REGION( 0x200000, "tilemap_hi", 0 )
+	ROM_LOAD       ("d69-05.bin", 0x000000, 0x200000, CRC(f9f5433c) SHA1(d3de66385d883c72967c44bc29983d7a79f665d1) )
+
+	ROM_REGION( 0x140000, "taito_en:audiocpu", 0 ) /* 68000 sound CPU */
 	ROM_LOAD16_BYTE("d69-18.bin", 0x100000, 0x20000, CRC(04600d7b) SHA1(666cfab09b61fd6e0bc4ff277018ebf1cda01b0e) )
 	ROM_LOAD16_BYTE("d69-19.bin", 0x100001, 0x20000, CRC(1484e853) SHA1(4459c18ba005786483c652857e527c6093efb036) )
 
-	ROM_REGION16_BE(0x800000, "ensoniq.0" , ROMREGION_ERASE00 ) // V2: 4 banks, only 2 populated
+	ROM_REGION16_BE( 0x800000, "ensoniq.0" , ROMREGION_ERASE00 ) // V2: 4 banks, only 2 populated
 	ROM_LOAD16_BYTE("d69-01.bin", 0x000000, 0x200000, CRC(9ac93ac2) SHA1(1c44f6ba95505f85b0c8a90395f09d2a49da3553) )    // C8 C9 CA CB
 	ROM_LOAD16_BYTE("d69-02.bin", 0x400000, 0x200000, CRC(dce28dd7) SHA1(eacfc98349b0608fc1a944c11f0483fb6caa4445) )    // CC CD -std-
 ROM_END
@@ -1638,135 +1681,143 @@ Notes:
 */
 
 ROM_START( lightbrj )
-	ROM_REGION(0x200000, "maincpu", 0) /* 68020 code */
+	ROM_REGION( 0x200000, "maincpu", 0 ) /* 68020 code */
 	ROM_LOAD32_BYTE("d69-20.bin", 0x000000, 0x80000, CRC(33650fe4) SHA1(df8b775749b1f0f02d0df6141597cc49fb3ae227) )
 	ROM_LOAD32_BYTE("d69-13.bin", 0x000001, 0x80000, CRC(dec2ec17) SHA1(8472a5aaea9e4e4fb5f7f4b5eda356b590d1541d) )
 	ROM_LOAD32_BYTE("d69-15.bin", 0x000002, 0x80000, CRC(323e1955) SHA1(d76582d1ff5a9aa87a498fea3280bc3c25ee9ec0) )
 	ROM_LOAD32_BYTE("d69-14.bin", 0x000003, 0x80000, CRC(990bf945) SHA1(797794d7afc1e6e98ce1bfb3de3c241a96a8fa01) )
 
-	ROM_REGION(0xc00000, "gfx1" , 0) /* Sprites */
+	ROM_REGION( 0x600000, "sprites" , 0) /* Sprites */
 	ROM_LOAD16_BYTE("d69-06.bin", 0x000000, 0x200000, CRC(cb4aac81) SHA1(15d315c6b9695cc2fe07defc67c7a4fb26de1950) )
 	ROM_LOAD16_BYTE("d69-07.bin", 0x000001, 0x200000, CRC(b749f984) SHA1(39fd662bdc42e812519181a640a83e29e300826a) )
 	ROM_LOAD16_BYTE("d69-09.bin", 0x400000, 0x100000, CRC(a96c19b8) SHA1(7872b4dd9d51877bed709fec393413e41d6b954f) )
 	ROM_LOAD16_BYTE("d69-10.bin", 0x400001, 0x100000, CRC(36aa80c6) SHA1(aeb5f7632810564426761b5798539bf4c4a0c64c) )
-	ROM_LOAD       ("d69-08.bin", 0x900000, 0x200000, CRC(5b68d7d8) SHA1(f2ee3dd7100a3c9d8f402fe36dae2bc66cb17be3) )
-	ROM_LOAD       ("d69-11.bin", 0xb00000, 0x100000, CRC(c11adf92) SHA1(ee9ce49a43b419c4f44ac1aea8d0a12d7b289244) )
-	ROM_FILL       (              0x600000, 0x300000, 0x00 )
 
-	ROM_REGION(0x800000, "gfx2" , 0) /* Tiles */
-	ROM_LOAD16_BYTE("d69-03.bin", 0x000000, 0x200000, CRC(6999c86f) SHA1(8a91930edfc0b5d23e59f8c3b43131db6edb4d37) )
-	ROM_LOAD16_BYTE("d69-04.bin", 0x000001, 0x200000, CRC(cc91dcb7) SHA1(97f510b1e1a3adf49efe82babdd7abce3756ce4b) )
-	ROM_LOAD       ("d69-05.bin", 0x600000, 0x200000, CRC(f9f5433c) SHA1(d3de66385d883c72967c44bc29983d7a79f665d1) )
-	ROM_FILL       (              0x400000, 0x200000, 0x00 )
+	ROM_REGION( 0x300000, "sprites_hi", 0 )
+	ROM_LOAD       ("d69-08.bin", 0x000000, 0x200000, CRC(5b68d7d8) SHA1(f2ee3dd7100a3c9d8f402fe36dae2bc66cb17be3) )
+	ROM_LOAD       ("d69-11.bin", 0x200000, 0x100000, CRC(c11adf92) SHA1(ee9ce49a43b419c4f44ac1aea8d0a12d7b289244) )
 
-	ROM_REGION(0x140000, "taito_en:audiocpu", 0) /* 68000 sound CPU */
+	ROM_REGION( 0x400000, "tilemap" , 0) /* Tiles */
+	ROM_LOAD32_WORD("d69-03.bin", 0x000000, 0x200000, CRC(6999c86f) SHA1(8a91930edfc0b5d23e59f8c3b43131db6edb4d37) )
+	ROM_LOAD32_WORD("d69-04.bin", 0x000002, 0x200000, CRC(cc91dcb7) SHA1(97f510b1e1a3adf49efe82babdd7abce3756ce4b) )
+
+	ROM_REGION( 0x200000, "tilemap_hi", 0 )
+	ROM_LOAD       ("d69-05.bin", 0x000000, 0x200000, CRC(f9f5433c) SHA1(d3de66385d883c72967c44bc29983d7a79f665d1) )
+
+	ROM_REGION( 0x140000, "taito_en:audiocpu", 0 ) /* 68000 sound CPU */
 	ROM_LOAD16_BYTE("d69-18.bin", 0x100000, 0x20000, CRC(04600d7b) SHA1(666cfab09b61fd6e0bc4ff277018ebf1cda01b0e) )
 	ROM_LOAD16_BYTE("d69-19.bin", 0x100001, 0x20000, CRC(1484e853) SHA1(4459c18ba005786483c652857e527c6093efb036) )
 
-	ROM_REGION16_BE(0x800000, "ensoniq.0" , ROMREGION_ERASE00 ) // V2: 4 banks, only 2 populated
+	ROM_REGION16_BE( 0x800000, "ensoniq.0" , ROMREGION_ERASE00 ) // V2: 4 banks, only 2 populated
 	ROM_LOAD16_BYTE("d69-01.bin", 0x000000, 0x200000, CRC(9ac93ac2) SHA1(1c44f6ba95505f85b0c8a90395f09d2a49da3553) )    // C8 C9 CA CB
 	ROM_LOAD16_BYTE("d69-02.bin", 0x400000, 0x200000, CRC(dce28dd7) SHA1(eacfc98349b0608fc1a944c11f0483fb6caa4445) )    // CC CD -std-
 ROM_END
 
 ROM_START( intcup94 )
-	ROM_REGION(0x200000, "maincpu", 0) /* 68020 code */
+	ROM_REGION( 0x200000, "maincpu", 0 ) /* 68020 code */
 	ROM_LOAD32_BYTE("d78-07.20", 0x000000, 0x20000, CRC(8525d990) SHA1(b28aeb8727d615cae9eafd7710bf833a612ef7d4) )
 	ROM_LOAD32_BYTE("d78-06.19", 0x000001, 0x20000, CRC(42db1d41) SHA1(daf617764b04cd24e76dfa95423213c2a3692068) )
 	ROM_LOAD32_BYTE("d78-05.18", 0x000002, 0x20000, CRC(5f7fbbbc) SHA1(8936bcc4026b2819b8708911c9defe4436d070ad) )
 	ROM_LOAD32_BYTE("d78-11.17", 0x000003, 0x20000, CRC(bb9d2987) SHA1(98bea0346702eefd9f6f1839b95932b9b8bca902) )
 
-	ROM_REGION(0xc00000, "gfx1" , 0) /* Sprites */
+	ROM_REGION( 0x600000, "sprites" , 0) /* Sprites */
 	ROM_LOAD16_BYTE("d49-01.12", 0x000000, 0x200000, CRC(1dc89f1c) SHA1(9597b1d8c9b447080ca9401aee83bb4a64bb8332) )
 	ROM_LOAD16_BYTE("d49-02.8",  0x000001, 0x200000, CRC(1e4c374f) SHA1(512edc6a934578d0e7371410a041150d3b13aaad) )
 	ROM_LOAD16_BYTE("d49-06.11", 0x400000, 0x100000, CRC(71ef4ee1) SHA1(1d7729dbc77f7201ff574e8aef65a55bd81c25a7) )
 	ROM_LOAD16_BYTE("d49-07.7",  0x400001, 0x100000, CRC(e5655b8f) SHA1(2c21745370bfe9dbf0e95f7ce42ed34a162bff64) )
-	ROM_LOAD       ("d49-03.4",  0x900000, 0x200000, CRC(cf9a8727) SHA1(f21787fdcdd8be2009c2d481a9b2d7fc03ce782e) )
-	ROM_LOAD       ("d49-08.3",  0xb00000, 0x100000, CRC(7d3c6536) SHA1(289b4bf79ebd9cbdf64ab956784d226e6d546654) )
-	ROM_FILL       (             0x600000, 0x300000, 0x00 )
 
-	ROM_REGION(0x200000, "gfx2" , 0) /* Tiles */
-	ROM_LOAD16_BYTE("d78-01.47", 0x000000, 0x080000, CRC(543f8967) SHA1(2efa935e7d0fd317bbbad2758a618d408a56317c) )
-	ROM_LOAD16_BYTE("d78-02.45", 0x000001, 0x080000, CRC(e8289394) SHA1(b9957675f868f772943678b6a19fcc21dfd97a8d) )
-	ROM_LOAD       ("d78-03.43", 0x180000, 0x080000, CRC(a8bc36e5) SHA1(5777b9457292e8a9cbb4e8226ba939530ffab07c) )
-	ROM_FILL       (             0x100000, 0x080000, 0x00 )
+	ROM_REGION( 0x300000, "sprites_hi", 0 )
+	ROM_LOAD       ("d49-03.4",  0x000000, 0x200000, CRC(cf9a8727) SHA1(f21787fdcdd8be2009c2d481a9b2d7fc03ce782e) )
+	ROM_LOAD       ("d49-08.3",  0x200000, 0x100000, CRC(7d3c6536) SHA1(289b4bf79ebd9cbdf64ab956784d226e6d546654) )
 
-	ROM_REGION(0x180000, "taito_en:audiocpu", 0) /* 68000 sound CPU */
+	ROM_REGION( 0x100000, "tilemap" , 0) /* Tiles */
+	ROM_LOAD32_WORD("d78-01.47", 0x000000, 0x080000, CRC(543f8967) SHA1(2efa935e7d0fd317bbbad2758a618d408a56317c) )
+	ROM_LOAD32_WORD("d78-02.45", 0x000002, 0x080000, CRC(e8289394) SHA1(b9957675f868f772943678b6a19fcc21dfd97a8d) )
+
+	ROM_REGION( 0x080000, "tilemap_hi", 0 )
+	ROM_LOAD       ("d78-03.43", 0x000000, 0x080000, CRC(a8bc36e5) SHA1(5777b9457292e8a9cbb4e8226ba939530ffab07c) )
+
+	ROM_REGION( 0x180000, "taito_en:audiocpu", 0 ) /* 68000 sound CPU */
 	ROM_LOAD16_BYTE("d78-08.32", 0x100000, 0x20000, CRC(a629d07c) SHA1(b2904e106633a3960ceb2bc58b600ea60034ff0b) )
 	ROM_LOAD16_BYTE("d78-09.33", 0x100001, 0x20000, CRC(1f0efe01) SHA1(7bff748b9fcee170e430d90ee07eb9975d8fba59) )
 
-	ROM_REGION16_BE(0x800000, "ensoniq.0" , ROMREGION_ERASE00 ) // V2: 4 banks, only 2 populated
+	ROM_REGION16_BE( 0x800000, "ensoniq.0" , ROMREGION_ERASE00 ) // V2: 4 banks, only 2 populated
 	ROM_LOAD16_BYTE("d49-04.38", 0x000000, 0x200000, CRC(44b365a9) SHA1(14c4a6b193a0069360406c74c500ba24f2a55b62) ) // C8 C9 CA CB
 	// half empty
 	ROM_LOAD16_BYTE("d49-05.41", 0x600000, 0x100000, CRC(ed894fe1) SHA1(5bf2fb6abdcf25bc525a2c3b29dbf7aca0b18fea) ) // -std-
 ROM_END
 
 ROM_START( hthero94 )
-	ROM_REGION(0x200000, "maincpu", 0) /* 68020 code */
+	ROM_REGION( 0x200000, "maincpu", 0 ) /* 68020 code */
 	ROM_LOAD32_BYTE("d78-07.20", 0x000000, 0x20000, CRC(8525d990) SHA1(b28aeb8727d615cae9eafd7710bf833a612ef7d4) )
 	ROM_LOAD32_BYTE("d78-06.19", 0x000001, 0x20000, CRC(42db1d41) SHA1(daf617764b04cd24e76dfa95423213c2a3692068) )
 	ROM_LOAD32_BYTE("d78-05.18", 0x000002, 0x20000, CRC(5f7fbbbc) SHA1(8936bcc4026b2819b8708911c9defe4436d070ad) )
 	ROM_LOAD32_BYTE("d78-10.17", 0x000003, 0x20000, CRC(cc9a1911) SHA1(341b6c33b182e3a64a22f1dc43e9cf72c6aeea7b) )
 
-	ROM_REGION(0xc00000, "gfx1" , 0) /* Sprites */
+	ROM_REGION( 0x600000, "sprites" , 0) /* Sprites */
 	ROM_LOAD16_BYTE("d49-01.12", 0x000000, 0x200000, CRC(1dc89f1c) SHA1(9597b1d8c9b447080ca9401aee83bb4a64bb8332) )
 	ROM_LOAD16_BYTE("d49-02.8",  0x000001, 0x200000, CRC(1e4c374f) SHA1(512edc6a934578d0e7371410a041150d3b13aaad) )
 	ROM_LOAD16_BYTE("d49-06.11", 0x400000, 0x100000, CRC(71ef4ee1) SHA1(1d7729dbc77f7201ff574e8aef65a55bd81c25a7) )
 	ROM_LOAD16_BYTE("d49-07.7",  0x400001, 0x100000, CRC(e5655b8f) SHA1(2c21745370bfe9dbf0e95f7ce42ed34a162bff64) )
-	ROM_LOAD       ("d49-03.4",  0x900000, 0x200000, CRC(cf9a8727) SHA1(f21787fdcdd8be2009c2d481a9b2d7fc03ce782e) )
-	ROM_LOAD       ("d49-08.3",  0xb00000, 0x100000, CRC(7d3c6536) SHA1(289b4bf79ebd9cbdf64ab956784d226e6d546654) )
-	ROM_FILL       (             0x600000, 0x300000, 0x00 )
 
-	ROM_REGION(0x200000, "gfx2" , 0) /* Tiles */
-	ROM_LOAD16_BYTE("d78-01.47", 0x000000, 0x080000, CRC(543f8967) SHA1(2efa935e7d0fd317bbbad2758a618d408a56317c) )
-	ROM_LOAD16_BYTE("d78-02.45", 0x000001, 0x080000, CRC(e8289394) SHA1(b9957675f868f772943678b6a19fcc21dfd97a8d) )
-	ROM_LOAD       ("d78-03.43", 0x180000, 0x080000, CRC(a8bc36e5) SHA1(5777b9457292e8a9cbb4e8226ba939530ffab07c) )
-	ROM_FILL       (             0x100000, 0x080000, 0x00 )
+	ROM_REGION( 0x300000, "sprites_hi", 0 )
+	ROM_LOAD       ("d49-03.4",  0x000000, 0x200000, CRC(cf9a8727) SHA1(f21787fdcdd8be2009c2d481a9b2d7fc03ce782e) )
+	ROM_LOAD       ("d49-08.3",  0x200000, 0x100000, CRC(7d3c6536) SHA1(289b4bf79ebd9cbdf64ab956784d226e6d546654) )
 
-	ROM_REGION(0x180000, "taito_en:audiocpu", 0) /* 68000 sound CPU */
+	ROM_REGION( 0x100000, "tilemap" , 0) /* Tiles */
+	ROM_LOAD32_WORD("d78-01.47", 0x000000, 0x080000, CRC(543f8967) SHA1(2efa935e7d0fd317bbbad2758a618d408a56317c) )
+	ROM_LOAD32_WORD("d78-02.45", 0x000002, 0x080000, CRC(e8289394) SHA1(b9957675f868f772943678b6a19fcc21dfd97a8d) )
+
+	ROM_REGION( 0x080000, "tilemap_hi", 0 )
+	ROM_LOAD       ("d78-03.43", 0x000000, 0x080000, CRC(a8bc36e5) SHA1(5777b9457292e8a9cbb4e8226ba939530ffab07c) )
+
+	ROM_REGION( 0x180000, "taito_en:audiocpu", 0 ) /* 68000 sound CPU */
 	ROM_LOAD16_BYTE("d78-08.32", 0x100000, 0x20000, CRC(a629d07c) SHA1(b2904e106633a3960ceb2bc58b600ea60034ff0b) )
 	ROM_LOAD16_BYTE("d78-09.33", 0x100001, 0x20000, CRC(1f0efe01) SHA1(7bff748b9fcee170e430d90ee07eb9975d8fba59) )
 
-	ROM_REGION16_BE(0x800000, "ensoniq.0" , ROMREGION_ERASE00 ) // V2: 4 banks, only 2 populated
+	ROM_REGION16_BE( 0x800000, "ensoniq.0" , ROMREGION_ERASE00 ) // V2: 4 banks, only 2 populated
 	ROM_LOAD16_BYTE("d49-04.38", 0x000000, 0x200000, CRC(44b365a9) SHA1(14c4a6b193a0069360406c74c500ba24f2a55b62) ) // C8 C9 CA CB
 	// half empty
 	ROM_LOAD16_BYTE("d49-05.41", 0x600000, 0x100000, CRC(ed894fe1) SHA1(5bf2fb6abdcf25bc525a2c3b29dbf7aca0b18fea) ) // -std-
 ROM_END
 
 ROM_START( recalh )
-	ROM_REGION(0x200000, "maincpu", 0) /* 68020 code */
+	ROM_REGION( 0x200000, "maincpu", 0 ) /* 68020 code */
 	ROM_LOAD32_BYTE("rh_mpr3.bin", 0x000000, 0x80000, CRC(65202dd4) SHA1(8d5748d03868b127a7d727e00c1bce51a5bae129) )
 	ROM_LOAD32_BYTE("rh_mpr2.bin", 0x000001, 0x80000, CRC(3eda66db) SHA1(6d726762404d85008d6bebe5a77cebe505b650fc) )
 	ROM_LOAD32_BYTE("rh_mpr1.bin", 0x000002, 0x80000, CRC(536e74ca) SHA1(2a50bb2e93563273c4b0c0c59143893fe25d007e) )
 	ROM_LOAD32_BYTE("rh_mpr0.bin", 0x000003, 0x80000, CRC(38025817) SHA1(fa4cf98cfca95c462b19b873a7660f7cec71cf56) )
 
-	ROM_REGION(0x400000, "gfx1" , 0) /* Sprites */
+	ROM_REGION( 0x200000, "sprites" , 0) /* Sprites */
 	ROM_LOAD16_BYTE("rh_objl.bin", 0x000000, 0x100000, CRC(c1772b55) SHA1(f9a04b968c63e61fa8ca60d6f331f6df0d7dd10a) )
 	ROM_LOAD16_BYTE("rh_objm.bin", 0x000001, 0x100000, CRC(ef87c0fd) SHA1(63e99f331d05a1ff4faf0ea94019393fe2117f54) )
-	ROM_FILL       (               0x200000, 0x200000, 0x00 )
 
-	ROM_REGION(0x400000, "gfx2" , 0) /* Tiles */
-	ROM_LOAD16_BYTE("rh_scrl.bin", 0x000000, 0x100000, CRC(1e3f6b79) SHA1(fef029def6393a13f4a638686a7ec7c13851a5c0) )
-	ROM_LOAD16_BYTE("rh_scrm.bin", 0x000001, 0x100000, CRC(37200968) SHA1(4a8d5a17af7eb732f481bf174099845e8d8d6b87) )
-	ROM_FILL       (               0x200000, 0x200000, 0x00 )
+	EMPTY_SPRITE_HIDATA(0x100000)
 
-	ROM_REGION(0x140000, "taito_en:audiocpu", 0) /* sound CPU */
+	ROM_REGION( 0x200000, "tilemap" , 0) /* Tiles */
+	ROM_LOAD32_WORD("rh_scrl.bin", 0x000000, 0x100000, CRC(1e3f6b79) SHA1(fef029def6393a13f4a638686a7ec7c13851a5c0) )
+	ROM_LOAD32_WORD("rh_scrm.bin", 0x000002, 0x100000, CRC(37200968) SHA1(4a8d5a17af7eb732f481bf174099845e8d8d6b87) )
+
+	EMPTY_TILEMAP_HIDATA(0x100000)
+
+	ROM_REGION( 0x140000, "taito_en:audiocpu", 0 ) /* sound CPU */
 	ROM_LOAD16_BYTE("rh_spr1.bin", 0x100000, 0x20000, CRC(504cbc1d) SHA1(35a775c1ebc8107c553e43b9d84eb735446c26fd) )
 	ROM_LOAD16_BYTE("rh_spr0.bin", 0x100001, 0x20000, CRC(78fba467) SHA1(4586b061724be7ec413784b820c33cc0d6bbcd0c) )
 
-	ROM_REGION16_BE(0x800000, "ensoniq.0" , ROMREGION_ERASE00 ) // V2: 4 banks, only 2 populated
+	ROM_REGION16_BE( 0x800000, "ensoniq.0" , ROMREGION_ERASE00 ) // V2: 4 banks, only 2 populated
 	ROM_LOAD16_BYTE("rh_snd0.bin", 0x000000, 0x200000, CRC(386f5e1b) SHA1(d67d5f057c6db3092643f10ea10f977b1caa662f) )   // C8 CB CA C9
 	// half empty
 	ROM_LOAD16_BYTE("rh_snd1.bin", 0x600000, 0x100000, CRC(ed894fe1) SHA1(5bf2fb6abdcf25bc525a2c3b29dbf7aca0b18fea) )   // -std-
 ROM_END
 
 ROM_START( kaiserkn )
-	ROM_REGION(0x200000, "maincpu", 0) /* 68020 code */
+	ROM_REGION( 0x200000, "maincpu", 0 ) /* 68020 code */
 	ROM_LOAD32_BYTE("d84-25.20", 0x000000, 0x80000, CRC(2840893f) SHA1(079dece4667b029189622476cc618b88e57243a6) )
 	ROM_LOAD32_BYTE("d84-24.19", 0x000001, 0x80000, CRC(bf20c755) SHA1(9f6edfe9bb40051e8a93d06a391c993ed7288db6) )
 	ROM_LOAD32_BYTE("d84-23.18", 0x000002, 0x80000, CRC(39f12a9b) SHA1(4b3fe9b8b0abb46feacd11ffb6b505568f892483) )
 	ROM_LOAD32_BYTE("d84-29.17", 0x000003, 0x80000, CRC(9821f17a) SHA1(4a2c1ebeb1a1d3d756957956c883f8374aaf4f8d) )
 
-	ROM_REGION(0x1a00000, "gfx1" , 0) /* Sprites */
+	ROM_REGION( 0xd00000, "sprites" , 0) /* Sprites */
 	ROM_LOAD16_BYTE("d84-03.rom", 0x0000000, 0x200000, CRC(d786f552) SHA1(f73146892f714b5706d568fc8a135fddaa656570) )
 	ROM_LOAD16_BYTE("d84-04.rom", 0x0000001, 0x200000, CRC(d1f32b5d) SHA1(35289cce64fdbb8d966dd1d5307b5393be5e7799) )
 	ROM_LOAD16_BYTE("d84-06.rom", 0x0400000, 0x200000, CRC(fa924dab) SHA1(28a8c3cd701f8df0c53069bb576bb2a820f3a331) )
@@ -1775,26 +1826,28 @@ ROM_START( kaiserkn )
 	ROM_LOAD16_BYTE("d84-10.rom", 0x0800001, 0x200000, CRC(b84b7320) SHA1(f5de0d6da50d8ed753607b51e46bc9a4572ef431) )
 	ROM_LOAD16_BYTE("d84-19.rom", 0x0c00000, 0x080000, CRC(6ddf77e5) SHA1(a1323acaed37fce62a19e63a0800d9d1dc2cfff7) )
 	ROM_LOAD16_BYTE("d84-20.rom", 0x0c00001, 0x080000, CRC(f85041e5) SHA1(6b2814514338f550d6aa14dbe39e848e8e64edee) )
-	ROM_LOAD       ("d84-05.rom", 0x1380000, 0x200000, CRC(31a3c75d) SHA1(1a16ccb6a0a03ab715e5b016ab3b1b2cd0f1ae41) )
-	ROM_LOAD       ("d84-08.rom", 0x1580000, 0x200000, CRC(07347bf1) SHA1(34bd359933acdec7fd1ce047092a30d1177afc2c) )
-	ROM_LOAD       ("d84-11.rom", 0x1780000, 0x200000, CRC(a062c1d4) SHA1(158912aa3dd75c3961bf738f9ac9034f0b005b60) )
-	ROM_LOAD       ("d84-21.rom", 0x1980000, 0x080000, CRC(89f68b66) SHA1(95916f02f71357324effe59da4f847f2f30ea34a) )
-	ROM_FILL       (              0x0d00000, 0x680000, 0x00 )
 
-	ROM_REGION(0xc00000, "gfx2" , 0) /* Tiles */
-	ROM_LOAD16_BYTE("d84-12.rom", 0x000000, 0x200000, CRC(66a7a9aa) SHA1(a7d21f8b6370d16de3c1569019f2ad71d36e7a61) )
-	ROM_LOAD16_BYTE("d84-13.rom", 0x000001, 0x200000, CRC(ae125516) SHA1(d54e76e398ab0b0fb82f3154ba54fc823ff49a1a) )
-	ROM_LOAD16_BYTE("d84-16.rom", 0x400000, 0x100000, CRC(bcff9b2d) SHA1(0ca50ec809564eddf0ba7448a8fae9087d3b600b) )
-	ROM_LOAD16_BYTE("d84-17.rom", 0x400001, 0x100000, CRC(0be37cc3) SHA1(b10c10b93858cad0c962ef614cfd6daea712ef6b) )
-	ROM_LOAD       ("d84-14.rom", 0x900000, 0x200000, CRC(2b2e693e) SHA1(03eb37fa7dc68d54bf0f1800b8c0b581c344a40f) )
-	ROM_LOAD       ("d84-18.rom", 0xb00000, 0x100000, CRC(e812bcc5) SHA1(3574e4a99232d9fc7989ec5d1e8fe76b4b30784a) )
-	ROM_FILL       (              0x600000, 0x300000, 0x00 )
+	ROM_REGION( 0x680000, "sprites_hi", 0 )
+	ROM_LOAD       ("d84-05.rom", 0x0000000, 0x200000, CRC(31a3c75d) SHA1(1a16ccb6a0a03ab715e5b016ab3b1b2cd0f1ae41) )
+	ROM_LOAD       ("d84-08.rom", 0x0200000, 0x200000, CRC(07347bf1) SHA1(34bd359933acdec7fd1ce047092a30d1177afc2c) )
+	ROM_LOAD       ("d84-11.rom", 0x0400000, 0x200000, CRC(a062c1d4) SHA1(158912aa3dd75c3961bf738f9ac9034f0b005b60) )
+	ROM_LOAD       ("d84-21.rom", 0x0600000, 0x080000, CRC(89f68b66) SHA1(95916f02f71357324effe59da4f847f2f30ea34a) )
 
-	ROM_REGION(0x180000, "taito_en:audiocpu", 0) /* 68000 sound CPU */
+	ROM_REGION( 0x600000, "tilemap" , 0) /* Tiles */
+	ROM_LOAD32_WORD("d84-12.rom", 0x000000, 0x200000, CRC(66a7a9aa) SHA1(a7d21f8b6370d16de3c1569019f2ad71d36e7a61) )
+	ROM_LOAD32_WORD("d84-13.rom", 0x000002, 0x200000, CRC(ae125516) SHA1(d54e76e398ab0b0fb82f3154ba54fc823ff49a1a) )
+	ROM_LOAD32_WORD("d84-16.rom", 0x400000, 0x100000, CRC(bcff9b2d) SHA1(0ca50ec809564eddf0ba7448a8fae9087d3b600b) )
+	ROM_LOAD32_WORD("d84-17.rom", 0x400002, 0x100000, CRC(0be37cc3) SHA1(b10c10b93858cad0c962ef614cfd6daea712ef6b) )
+
+	ROM_REGION( 0x300000, "tilemap_hi", 0 )
+	ROM_LOAD       ("d84-14.rom", 0x000000, 0x200000, CRC(2b2e693e) SHA1(03eb37fa7dc68d54bf0f1800b8c0b581c344a40f) )
+	ROM_LOAD       ("d84-18.rom", 0x200000, 0x100000, CRC(e812bcc5) SHA1(3574e4a99232d9fc7989ec5d1e8fe76b4b30784a) )
+
+	ROM_REGION( 0x180000, "taito_en:audiocpu", 0 ) /* 68000 sound CPU */
 	ROM_LOAD16_BYTE("d84-26.32", 0x100000, 0x40000, CRC(4f5b8563) SHA1(1d4e06cbea7bc73a99d6e30be714fff420151bbc) )
 	ROM_LOAD16_BYTE("d84-27.33", 0x100001, 0x40000, CRC(fb0cb1ba) SHA1(16a79b53651a6131f7636db19738b456b7c28bff) )
 
-	ROM_REGION16_BE(0x1000000, "ensoniq.0" , ROMREGION_ERASE00 )    // V2: 4 banks
+	ROM_REGION16_BE( 0x1000000, "ensoniq.0" , ROMREGION_ERASE00 )    // V2: 4 banks
 	// empty
 	ROM_LOAD16_BYTE("d84-01.rom", 0x400000, 0x200000, CRC(9ad22149) SHA1(48055822e0cea228cdecf3d05ac24e50979b6f4d) )    // C8 C9 CA CB
 	ROM_LOAD16_BYTE("d84-02.rom", 0x800000, 0x200000, CRC(9e1827e4) SHA1(1840881b0f8f7b6225e6ffa12a8d4b463554988e) )    // CC CD CE CF
@@ -1803,13 +1856,13 @@ ROM_START( kaiserkn )
 ROM_END
 
 ROM_START( kaiserknj )
-	ROM_REGION(0x200000, "maincpu", 0) /* 68020 code */
+	ROM_REGION( 0x200000, "maincpu", 0 ) /* 68020 code */
 	ROM_LOAD32_BYTE("d84-25.20", 0x000000, 0x80000, CRC(2840893f) SHA1(079dece4667b029189622476cc618b88e57243a6) )
 	ROM_LOAD32_BYTE("d84-24.19", 0x000001, 0x80000, CRC(bf20c755) SHA1(9f6edfe9bb40051e8a93d06a391c993ed7288db6) )
 	ROM_LOAD32_BYTE("d84-23.18", 0x000002, 0x80000, CRC(39f12a9b) SHA1(4b3fe9b8b0abb46feacd11ffb6b505568f892483) )
 	ROM_LOAD32_BYTE("d84-22.17", 0x000003, 0x80000, CRC(762f9056) SHA1(c39854d865210d05fe745493098ef5990327c56e) )
 
-	ROM_REGION(0x1a00000, "gfx1" , 0) /* Sprites */
+	ROM_REGION( 0xd00000, "sprites" , 0) /* Sprites */
 	ROM_LOAD16_BYTE("d84-03.rom", 0x0000000, 0x200000, CRC(d786f552) SHA1(f73146892f714b5706d568fc8a135fddaa656570) )
 	ROM_LOAD16_BYTE("d84-04.rom", 0x0000001, 0x200000, CRC(d1f32b5d) SHA1(35289cce64fdbb8d966dd1d5307b5393be5e7799) )
 	ROM_LOAD16_BYTE("d84-06.rom", 0x0400000, 0x200000, CRC(fa924dab) SHA1(28a8c3cd701f8df0c53069bb576bb2a820f3a331) )
@@ -1818,26 +1871,28 @@ ROM_START( kaiserknj )
 	ROM_LOAD16_BYTE("d84-10.rom", 0x0800001, 0x200000, CRC(b84b7320) SHA1(f5de0d6da50d8ed753607b51e46bc9a4572ef431) )
 	ROM_LOAD16_BYTE("d84-19.rom", 0x0c00000, 0x080000, CRC(6ddf77e5) SHA1(a1323acaed37fce62a19e63a0800d9d1dc2cfff7) )
 	ROM_LOAD16_BYTE("d84-20.rom", 0x0c00001, 0x080000, CRC(f85041e5) SHA1(6b2814514338f550d6aa14dbe39e848e8e64edee) )
-	ROM_LOAD       ("d84-05.rom", 0x1380000, 0x200000, CRC(31a3c75d) SHA1(1a16ccb6a0a03ab715e5b016ab3b1b2cd0f1ae41) )
-	ROM_LOAD       ("d84-08.rom", 0x1580000, 0x200000, CRC(07347bf1) SHA1(34bd359933acdec7fd1ce047092a30d1177afc2c) )
-	ROM_LOAD       ("d84-11.rom", 0x1780000, 0x200000, CRC(a062c1d4) SHA1(158912aa3dd75c3961bf738f9ac9034f0b005b60) )
-	ROM_LOAD       ("d84-21.rom", 0x1980000, 0x080000, CRC(89f68b66) SHA1(95916f02f71357324effe59da4f847f2f30ea34a) )
-	ROM_FILL       (              0x0d00000, 0x680000, 0x00 )
 
-	ROM_REGION(0xc00000, "gfx2" , 0) /* Tiles */
-	ROM_LOAD16_BYTE("d84-12.rom", 0x000000, 0x200000, CRC(66a7a9aa) SHA1(a7d21f8b6370d16de3c1569019f2ad71d36e7a61) )
-	ROM_LOAD16_BYTE("d84-13.rom", 0x000001, 0x200000, CRC(ae125516) SHA1(d54e76e398ab0b0fb82f3154ba54fc823ff49a1a) )
-	ROM_LOAD16_BYTE("d84-16.rom", 0x400000, 0x100000, CRC(bcff9b2d) SHA1(0ca50ec809564eddf0ba7448a8fae9087d3b600b) )
-	ROM_LOAD16_BYTE("d84-17.rom", 0x400001, 0x100000, CRC(0be37cc3) SHA1(b10c10b93858cad0c962ef614cfd6daea712ef6b) )
-	ROM_LOAD       ("d84-14.rom", 0x900000, 0x200000, CRC(2b2e693e) SHA1(03eb37fa7dc68d54bf0f1800b8c0b581c344a40f) )
-	ROM_LOAD       ("d84-18.rom", 0xb00000, 0x100000, CRC(e812bcc5) SHA1(3574e4a99232d9fc7989ec5d1e8fe76b4b30784a) )
-	ROM_FILL       (              0x600000, 0x300000, 0x00 )
+	ROM_REGION( 0x680000, "sprites_hi", 0 )
+	ROM_LOAD       ("d84-05.rom", 0x0000000, 0x200000, CRC(31a3c75d) SHA1(1a16ccb6a0a03ab715e5b016ab3b1b2cd0f1ae41) )
+	ROM_LOAD       ("d84-08.rom", 0x0200000, 0x200000, CRC(07347bf1) SHA1(34bd359933acdec7fd1ce047092a30d1177afc2c) )
+	ROM_LOAD       ("d84-11.rom", 0x0400000, 0x200000, CRC(a062c1d4) SHA1(158912aa3dd75c3961bf738f9ac9034f0b005b60) )
+	ROM_LOAD       ("d84-21.rom", 0x0600000, 0x080000, CRC(89f68b66) SHA1(95916f02f71357324effe59da4f847f2f30ea34a) )
 
-	ROM_REGION(0x180000, "taito_en:audiocpu", 0) /* 68000 sound CPU */
+	ROM_REGION( 0x600000, "tilemap" , 0) /* Tiles */
+	ROM_LOAD32_WORD("d84-12.rom", 0x000000, 0x200000, CRC(66a7a9aa) SHA1(a7d21f8b6370d16de3c1569019f2ad71d36e7a61) )
+	ROM_LOAD32_WORD("d84-13.rom", 0x000002, 0x200000, CRC(ae125516) SHA1(d54e76e398ab0b0fb82f3154ba54fc823ff49a1a) )
+	ROM_LOAD32_WORD("d84-16.rom", 0x400000, 0x100000, CRC(bcff9b2d) SHA1(0ca50ec809564eddf0ba7448a8fae9087d3b600b) )
+	ROM_LOAD32_WORD("d84-17.rom", 0x400002, 0x100000, CRC(0be37cc3) SHA1(b10c10b93858cad0c962ef614cfd6daea712ef6b) )
+
+	ROM_REGION( 0x300000, "tilemap_hi", 0 )
+	ROM_LOAD       ("d84-14.rom", 0x000000, 0x200000, CRC(2b2e693e) SHA1(03eb37fa7dc68d54bf0f1800b8c0b581c344a40f) )
+	ROM_LOAD       ("d84-18.rom", 0x200000, 0x100000, CRC(e812bcc5) SHA1(3574e4a99232d9fc7989ec5d1e8fe76b4b30784a) )
+
+	ROM_REGION( 0x180000, "taito_en:audiocpu", 0 ) /* 68000 sound CPU */
 	ROM_LOAD16_BYTE("d84-26.32", 0x100000, 0x40000, CRC(4f5b8563) SHA1(1d4e06cbea7bc73a99d6e30be714fff420151bbc) )
 	ROM_LOAD16_BYTE("d84-27.33", 0x100001, 0x40000, CRC(fb0cb1ba) SHA1(16a79b53651a6131f7636db19738b456b7c28bff) )
 
-	ROM_REGION16_BE(0x1000000, "ensoniq.0" , ROMREGION_ERASE00 )    // V2: 4 banks
+	ROM_REGION16_BE( 0x1000000, "ensoniq.0" , ROMREGION_ERASE00 )    // V2: 4 banks
 	// empty
 	ROM_LOAD16_BYTE("d84-01.rom", 0x400000, 0x200000, CRC(9ad22149) SHA1(48055822e0cea228cdecf3d05ac24e50979b6f4d) )    // C8 C9 CA CB
 	ROM_LOAD16_BYTE("d84-02.rom", 0x800000, 0x200000, CRC(9e1827e4) SHA1(1840881b0f8f7b6225e6ffa12a8d4b463554988e) )    // CC CD CE CF
@@ -1846,13 +1901,13 @@ ROM_START( kaiserknj )
 ROM_END
 
 ROM_START( gblchmp )
-	ROM_REGION(0x200000, "maincpu", 0) /* 68020 code */
+	ROM_REGION( 0x200000, "maincpu", 0 ) /* 68020 code */
 	ROM_LOAD32_BYTE("d84-25.20", 0x000000, 0x80000, CRC(2840893f) SHA1(079dece4667b029189622476cc618b88e57243a6) )
 	ROM_LOAD32_BYTE("d84-24.19", 0x000001, 0x80000, CRC(bf20c755) SHA1(9f6edfe9bb40051e8a93d06a391c993ed7288db6) )
 	ROM_LOAD32_BYTE("d84-23.18", 0x000002, 0x80000, CRC(39f12a9b) SHA1(4b3fe9b8b0abb46feacd11ffb6b505568f892483) )
 	ROM_LOAD32_BYTE("d84-28.17", 0x000003, 0x80000, CRC(ef26c1ec) SHA1(99440573704252b59148b3c30a006ce152b30ada) )
 
-	ROM_REGION(0x1a00000, "gfx1" , 0) /* Sprites */
+	ROM_REGION( 0xd00000, "sprites" , 0) /* Sprites */
 	ROM_LOAD16_BYTE("d84-03.rom", 0x0000000, 0x200000, CRC(d786f552) SHA1(f73146892f714b5706d568fc8a135fddaa656570) )
 	ROM_LOAD16_BYTE("d84-04.rom", 0x0000001, 0x200000, CRC(d1f32b5d) SHA1(35289cce64fdbb8d966dd1d5307b5393be5e7799) )
 	ROM_LOAD16_BYTE("d84-06.rom", 0x0400000, 0x200000, CRC(fa924dab) SHA1(28a8c3cd701f8df0c53069bb576bb2a820f3a331) )
@@ -1861,26 +1916,28 @@ ROM_START( gblchmp )
 	ROM_LOAD16_BYTE("d84-10.rom", 0x0800001, 0x200000, CRC(b84b7320) SHA1(f5de0d6da50d8ed753607b51e46bc9a4572ef431) )
 	ROM_LOAD16_BYTE("d84-19.rom", 0x0c00000, 0x080000, CRC(6ddf77e5) SHA1(a1323acaed37fce62a19e63a0800d9d1dc2cfff7) )
 	ROM_LOAD16_BYTE("d84-20.rom", 0x0c00001, 0x080000, CRC(f85041e5) SHA1(6b2814514338f550d6aa14dbe39e848e8e64edee) )
-	ROM_LOAD       ("d84-05.rom", 0x1380000, 0x200000, CRC(31a3c75d) SHA1(1a16ccb6a0a03ab715e5b016ab3b1b2cd0f1ae41) )
-	ROM_LOAD       ("d84-08.rom", 0x1580000, 0x200000, CRC(07347bf1) SHA1(34bd359933acdec7fd1ce047092a30d1177afc2c) )
-	ROM_LOAD       ("d84-11.rom", 0x1780000, 0x200000, CRC(a062c1d4) SHA1(158912aa3dd75c3961bf738f9ac9034f0b005b60) )
-	ROM_LOAD       ("d84-21.rom", 0x1980000, 0x080000, CRC(89f68b66) SHA1(95916f02f71357324effe59da4f847f2f30ea34a) )
-	ROM_FILL       (              0x0d00000, 0x680000, 0x00 )
 
-	ROM_REGION(0xc00000, "gfx2" , 0) /* Tiles */
-	ROM_LOAD16_BYTE("d84-12.rom", 0x000000, 0x200000, CRC(66a7a9aa) SHA1(a7d21f8b6370d16de3c1569019f2ad71d36e7a61) )
-	ROM_LOAD16_BYTE("d84-13.rom", 0x000001, 0x200000, CRC(ae125516) SHA1(d54e76e398ab0b0fb82f3154ba54fc823ff49a1a) )
-	ROM_LOAD16_BYTE("d84-16.rom", 0x400000, 0x100000, CRC(bcff9b2d) SHA1(0ca50ec809564eddf0ba7448a8fae9087d3b600b) )
-	ROM_LOAD16_BYTE("d84-17.rom", 0x400001, 0x100000, CRC(0be37cc3) SHA1(b10c10b93858cad0c962ef614cfd6daea712ef6b) )
-	ROM_LOAD       ("d84-14.rom", 0x900000, 0x200000, CRC(2b2e693e) SHA1(03eb37fa7dc68d54bf0f1800b8c0b581c344a40f) )
-	ROM_LOAD       ("d84-18.rom", 0xb00000, 0x100000, CRC(e812bcc5) SHA1(3574e4a99232d9fc7989ec5d1e8fe76b4b30784a) )
-	ROM_FILL       (              0x600000, 0x300000, 0x00 )
+	ROM_REGION( 0x680000, "sprites_hi", 0 )
+	ROM_LOAD       ("d84-05.rom", 0x0000000, 0x200000, CRC(31a3c75d) SHA1(1a16ccb6a0a03ab715e5b016ab3b1b2cd0f1ae41) )
+	ROM_LOAD       ("d84-08.rom", 0x0200000, 0x200000, CRC(07347bf1) SHA1(34bd359933acdec7fd1ce047092a30d1177afc2c) )
+	ROM_LOAD       ("d84-11.rom", 0x0400000, 0x200000, CRC(a062c1d4) SHA1(158912aa3dd75c3961bf738f9ac9034f0b005b60) )
+	ROM_LOAD       ("d84-21.rom", 0x0600000, 0x080000, CRC(89f68b66) SHA1(95916f02f71357324effe59da4f847f2f30ea34a) )
 
-	ROM_REGION(0x180000, "taito_en:audiocpu", 0) /* 68000 sound CPU */
+	ROM_REGION( 0x600000, "tilemap" , 0) /* Tiles */
+	ROM_LOAD32_WORD("d84-12.rom", 0x000000, 0x200000, CRC(66a7a9aa) SHA1(a7d21f8b6370d16de3c1569019f2ad71d36e7a61) )
+	ROM_LOAD32_WORD("d84-13.rom", 0x000002, 0x200000, CRC(ae125516) SHA1(d54e76e398ab0b0fb82f3154ba54fc823ff49a1a) )
+	ROM_LOAD32_WORD("d84-16.rom", 0x400000, 0x100000, CRC(bcff9b2d) SHA1(0ca50ec809564eddf0ba7448a8fae9087d3b600b) )
+	ROM_LOAD32_WORD("d84-17.rom", 0x400002, 0x100000, CRC(0be37cc3) SHA1(b10c10b93858cad0c962ef614cfd6daea712ef6b) )
+
+	ROM_REGION( 0x300000, "tilemap_hi", 0 )
+	ROM_LOAD       ("d84-14.rom", 0x000000, 0x200000, CRC(2b2e693e) SHA1(03eb37fa7dc68d54bf0f1800b8c0b581c344a40f) )
+	ROM_LOAD       ("d84-18.rom", 0x200000, 0x100000, CRC(e812bcc5) SHA1(3574e4a99232d9fc7989ec5d1e8fe76b4b30784a) )
+
+	ROM_REGION( 0x180000, "taito_en:audiocpu", 0 ) /* 68000 sound CPU */
 	ROM_LOAD16_BYTE("d84-26.32", 0x100000, 0x40000, CRC(4f5b8563) SHA1(1d4e06cbea7bc73a99d6e30be714fff420151bbc) )
 	ROM_LOAD16_BYTE("d84-27.33", 0x100001, 0x40000, CRC(fb0cb1ba) SHA1(16a79b53651a6131f7636db19738b456b7c28bff) )
 
-	ROM_REGION16_BE(0x1000000, "ensoniq.0" , ROMREGION_ERASE00 )    // V2: 4 banks
+	ROM_REGION16_BE( 0x1000000, "ensoniq.0" , ROMREGION_ERASE00 )    // V2: 4 banks
 	// empty
 	ROM_LOAD16_BYTE("d84-01.rom", 0x400000, 0x200000, CRC(9ad22149) SHA1(48055822e0cea228cdecf3d05ac24e50979b6f4d) )    // C8 C9 CA CB
 	ROM_LOAD16_BYTE("d84-02.rom", 0x800000, 0x200000, CRC(9e1827e4) SHA1(1840881b0f8f7b6225e6ffa12a8d4b463554988e) )    // CC CD CE CF
@@ -1889,13 +1946,13 @@ ROM_START( gblchmp )
 ROM_END
 
 ROM_START( dankuga )
-	ROM_REGION(0x200000, "maincpu", 0) /* 68020 code */
+	ROM_REGION( 0x200000, "maincpu", 0 ) /* 68020 code */
 	ROM_LOAD32_BYTE("dkg_mpr3.20", 0x000000, 0x80000, CRC(ee1531ca) SHA1(5a78f44906c77a3195cbb41d256292255275643f) )
 	ROM_LOAD32_BYTE("dkg_mpr2.19", 0x000001, 0x80000, CRC(18a4748b) SHA1(31b912b532329d2cbd43df44f21e0923af7157d5) )
 	ROM_LOAD32_BYTE("dkg_mpr1.18", 0x000002, 0x80000, CRC(97566f69) SHA1(2f1ae6b9a463f20beea1558278741ddfe3901a6d) )
 	ROM_LOAD32_BYTE("dkg_mpr0.17", 0x000003, 0x80000, CRC(ad6ada07) SHA1(124db0cf8a5fbd99525633a2f783a0e1b281badf) )
 
-	ROM_REGION(0x1a00000, "gfx1" , 0) /* Sprites */
+	ROM_REGION( 0xd00000, "sprites" , 0) /* Sprites */
 	ROM_LOAD16_BYTE("d84-03.rom", 0x0000000, 0x200000, CRC(d786f552) SHA1(f73146892f714b5706d568fc8a135fddaa656570) )
 	ROM_LOAD16_BYTE("d84-04.rom", 0x0000001, 0x200000, CRC(d1f32b5d) SHA1(35289cce64fdbb8d966dd1d5307b5393be5e7799) )
 	ROM_LOAD16_BYTE("d84-06.rom", 0x0400000, 0x200000, CRC(fa924dab) SHA1(28a8c3cd701f8df0c53069bb576bb2a820f3a331) )
@@ -1904,26 +1961,28 @@ ROM_START( dankuga )
 	ROM_LOAD16_BYTE("d84-10.rom", 0x0800001, 0x200000, CRC(b84b7320) SHA1(f5de0d6da50d8ed753607b51e46bc9a4572ef431) )
 	ROM_LOAD16_BYTE("d84-19.rom", 0x0c00000, 0x080000, CRC(6ddf77e5) SHA1(a1323acaed37fce62a19e63a0800d9d1dc2cfff7) )
 	ROM_LOAD16_BYTE("d84-20.rom", 0x0c00001, 0x080000, CRC(f85041e5) SHA1(6b2814514338f550d6aa14dbe39e848e8e64edee) )
-	ROM_LOAD       ("d84-05.rom", 0x1380000, 0x200000, CRC(31a3c75d) SHA1(1a16ccb6a0a03ab715e5b016ab3b1b2cd0f1ae41) )
-	ROM_LOAD       ("d84-08.rom", 0x1580000, 0x200000, CRC(07347bf1) SHA1(34bd359933acdec7fd1ce047092a30d1177afc2c) )
-	ROM_LOAD       ("d84-11.rom", 0x1780000, 0x200000, CRC(a062c1d4) SHA1(158912aa3dd75c3961bf738f9ac9034f0b005b60) )
-	ROM_LOAD       ("d84-21.rom", 0x1980000, 0x080000, CRC(89f68b66) SHA1(95916f02f71357324effe59da4f847f2f30ea34a) )
-	ROM_FILL       (              0x0d00000, 0x680000, 0x00 )
 
-	ROM_REGION(0xc00000, "gfx2" , 0) /* Tiles */
-	ROM_LOAD16_BYTE("d84-12.rom", 0x000000, 0x200000, CRC(66a7a9aa) SHA1(a7d21f8b6370d16de3c1569019f2ad71d36e7a61) )
-	ROM_LOAD16_BYTE("d84-13.rom", 0x000001, 0x200000, CRC(ae125516) SHA1(d54e76e398ab0b0fb82f3154ba54fc823ff49a1a) )
-	ROM_LOAD16_BYTE("d84-16.rom", 0x400000, 0x100000, CRC(bcff9b2d) SHA1(0ca50ec809564eddf0ba7448a8fae9087d3b600b) )
-	ROM_LOAD16_BYTE("d84-17.rom", 0x400001, 0x100000, CRC(0be37cc3) SHA1(b10c10b93858cad0c962ef614cfd6daea712ef6b) )
-	ROM_LOAD       ("d84-14.rom", 0x900000, 0x200000, CRC(2b2e693e) SHA1(03eb37fa7dc68d54bf0f1800b8c0b581c344a40f) )
-	ROM_LOAD       ("d84-18.rom", 0xb00000, 0x100000, CRC(e812bcc5) SHA1(3574e4a99232d9fc7989ec5d1e8fe76b4b30784a) )
-	ROM_FILL       (              0x600000, 0x300000, 0x00 )
+	ROM_REGION( 0x680000, "sprites_hi", 0 )
+	ROM_LOAD       ("d84-05.rom", 0x0000000, 0x200000, CRC(31a3c75d) SHA1(1a16ccb6a0a03ab715e5b016ab3b1b2cd0f1ae41) )
+	ROM_LOAD       ("d84-08.rom", 0x0200000, 0x200000, CRC(07347bf1) SHA1(34bd359933acdec7fd1ce047092a30d1177afc2c) )
+	ROM_LOAD       ("d84-11.rom", 0x0400000, 0x200000, CRC(a062c1d4) SHA1(158912aa3dd75c3961bf738f9ac9034f0b005b60) )
+	ROM_LOAD       ("d84-21.rom", 0x0600000, 0x080000, CRC(89f68b66) SHA1(95916f02f71357324effe59da4f847f2f30ea34a) )
 
-	ROM_REGION(0x180000, "taito_en:audiocpu", 0) /* 68000 sound CPU */
+	ROM_REGION( 0x600000, "tilemap" , 0) /* Tiles */
+	ROM_LOAD32_WORD("d84-12.rom", 0x000000, 0x200000, CRC(66a7a9aa) SHA1(a7d21f8b6370d16de3c1569019f2ad71d36e7a61) )
+	ROM_LOAD32_WORD("d84-13.rom", 0x000002, 0x200000, CRC(ae125516) SHA1(d54e76e398ab0b0fb82f3154ba54fc823ff49a1a) )
+	ROM_LOAD32_WORD("d84-16.rom", 0x400000, 0x100000, CRC(bcff9b2d) SHA1(0ca50ec809564eddf0ba7448a8fae9087d3b600b) )
+	ROM_LOAD32_WORD("d84-17.rom", 0x400002, 0x100000, CRC(0be37cc3) SHA1(b10c10b93858cad0c962ef614cfd6daea712ef6b) )
+
+	ROM_REGION( 0x300000, "tilemap_hi", 0 )
+	ROM_LOAD       ("d84-14.rom", 0x000000, 0x200000, CRC(2b2e693e) SHA1(03eb37fa7dc68d54bf0f1800b8c0b581c344a40f) )
+	ROM_LOAD       ("d84-18.rom", 0x200000, 0x100000, CRC(e812bcc5) SHA1(3574e4a99232d9fc7989ec5d1e8fe76b4b30784a) )
+
+	ROM_REGION( 0x180000, "taito_en:audiocpu", 0 ) /* 68000 sound CPU */
 	ROM_LOAD16_BYTE("d84-26.32", 0x100000, 0x40000, CRC(4f5b8563) SHA1(1d4e06cbea7bc73a99d6e30be714fff420151bbc) )
 	ROM_LOAD16_BYTE("d84-27.33", 0x100001, 0x40000, CRC(fb0cb1ba) SHA1(16a79b53651a6131f7636db19738b456b7c28bff) )
 
-	ROM_REGION16_BE(0x1000000, "ensoniq.0" , ROMREGION_ERASE00 )    // V2: 4 banks
+	ROM_REGION16_BE( 0x1000000, "ensoniq.0" , ROMREGION_ERASE00 )    // V2: 4 banks
 	// empty
 	ROM_LOAD16_BYTE("d84-01.rom", 0x400000, 0x200000, CRC(9ad22149) SHA1(48055822e0cea228cdecf3d05ac24e50979b6f4d) )    // C8 C9 CA CB
 	ROM_LOAD16_BYTE("d84-02.rom", 0x800000, 0x200000, CRC(9e1827e4) SHA1(1840881b0f8f7b6225e6ffa12a8d4b463554988e) )    // CC CD CE CF
@@ -1932,142 +1991,152 @@ ROM_START( dankuga )
 ROM_END
 
 ROM_START( dariusg )
-	ROM_REGION(0x200000, "maincpu", 0) /* 68020 code */
+	ROM_REGION( 0x200000, "maincpu", 0 ) /* 68020 code */
 	ROM_LOAD32_BYTE("d87-12.bin", 0x000000, 0x80000, CRC(de78f328) SHA1(126464a826685f5bfab6cc099448ce4df207a407) )
 	ROM_LOAD32_BYTE("d87-11.bin", 0x000001, 0x80000, CRC(f7bed18e) SHA1(db7d92680f9f406a5295ee85ce110c1a56ed386f) )
 	ROM_LOAD32_BYTE("d87-10.bin", 0x000002, 0x80000, CRC(4149f66f) SHA1(57d36a62d490d9e53b6b80a92ea0e8c41d61799f) )
 	ROM_LOAD32_BYTE("d87-16.bin", 0x000003, 0x80000, CRC(8f7e5901) SHA1(b920f43374af30e2f7d7d01049af6746206c8ece) )
 
-	ROM_REGION(0x800000, "gfx1" , 0) /* Sprites */
+	ROM_REGION( 0x400000, "sprites" , 0) /* Sprites */
 	ROM_LOAD16_BYTE("d87-03.bin", 0x000000, 0x200000, CRC(4be1666e) SHA1(35ba7bcf29ec7a8f8b6944ee3544693d4df1bfc2) )
 	ROM_LOAD16_BYTE("d87-04.bin", 0x000001, 0x200000, CRC(2616002c) SHA1(003f98b740a697274385b8da03c78f3c6f7b5e89) )
-	ROM_LOAD       ("d87-05.bin", 0x600000, 0x200000, CRC(4e5891a9) SHA1(fd08d848079841c9237fa359a850980fd00114d8) )
-	ROM_FILL       (              0x400000, 0x200000, 0x00 )
 
-	ROM_REGION(0x800000, "gfx2" , 0) /* Tiles */
-	ROM_LOAD16_BYTE("d87-06.bin", 0x000000, 0x200000, CRC(3b97a07c) SHA1(72cdeffedeab0c1bd0e47f03172085390a2be393) )
-	ROM_LOAD16_BYTE("d87-17.bin", 0x000001, 0x200000, CRC(e601d63e) SHA1(256a6aeb5633fe1db407fad567169a9d0c911219) )
-	ROM_LOAD       ("d87-08.bin", 0x600000, 0x200000, CRC(76d23602) SHA1(ca53ea6641182c44a4038bbeaa5effb1687f1980) )
-	ROM_FILL       (              0x400000, 0x200000, 0x00 )
+	ROM_REGION( 0x200000, "sprites_hi", 0 )
+	ROM_LOAD       ("d87-05.bin", 0x000000, 0x200000, CRC(4e5891a9) SHA1(fd08d848079841c9237fa359a850980fd00114d8) )
 
-	ROM_REGION(0x180000, "taito_en:audiocpu", 0) /* 68000 sound CPU */
+	ROM_REGION( 0x400000, "tilemap" , 0) /* Tiles */
+	ROM_LOAD32_WORD("d87-06.bin", 0x000000, 0x200000, CRC(3b97a07c) SHA1(72cdeffedeab0c1bd0e47f03172085390a2be393) )
+	ROM_LOAD32_WORD("d87-17.bin", 0x000002, 0x200000, CRC(e601d63e) SHA1(256a6aeb5633fe1db407fad567169a9d0c911219) )
+
+	ROM_REGION( 0x200000, "tilemap_hi", 0 )
+	ROM_LOAD       ("d87-08.bin", 0x000000, 0x200000, CRC(76d23602) SHA1(ca53ea6641182c44a4038bbeaa5effb1687f1980) )
+
+	ROM_REGION( 0x180000, "taito_en:audiocpu", 0 ) /* 68000 sound CPU */
 	ROM_LOAD16_BYTE("d87-13.bin", 0x100000, 0x40000, CRC(15b1fff4) SHA1(28692b731ae98a47c2c5e11a8a71b61a813d9a64) )
 	ROM_LOAD16_BYTE("d87-14.bin", 0x100001, 0x40000, CRC(eecda29a) SHA1(6eb238e47bc7bf635ffbdbb25fb06a37db980ef8) )
 
-	ROM_REGION16_BE(0x800000, "ensoniq.0" , ROMREGION_ERASE00 ) // V2: 4 banks, only 2 populated
+	ROM_REGION16_BE( 0x800000, "ensoniq.0" , ROMREGION_ERASE00 ) // V2: 4 banks, only 2 populated
 	ROM_LOAD16_BYTE("d87-01.bin", 0x000000, 0x200000, CRC(3848a110) SHA1(802e91695a526f665c7fd261f0a7639a0b883c9e) )    // C9 CA CB CC
 	ROM_LOAD16_BYTE("d87-02.bin", 0x400000, 0x200000, CRC(9250abae) SHA1(07cae8edbc3cca0a95022d9b40a5c18a55350b67) )    // CD CE CF D0
 ROM_END
 
 ROM_START( dariusgj )
-	ROM_REGION(0x200000, "maincpu", 0) /* 68020 code */
+	ROM_REGION( 0x200000, "maincpu", 0 ) /* 68020 code */
 	ROM_LOAD32_BYTE("d87-12.bin", 0x000000, 0x80000, CRC(de78f328) SHA1(126464a826685f5bfab6cc099448ce4df207a407) )
 	ROM_LOAD32_BYTE("d87-11.bin", 0x000001, 0x80000, CRC(f7bed18e) SHA1(db7d92680f9f406a5295ee85ce110c1a56ed386f) )
 	ROM_LOAD32_BYTE("d87-10.bin", 0x000002, 0x80000, CRC(4149f66f) SHA1(57d36a62d490d9e53b6b80a92ea0e8c41d61799f) )
 	ROM_LOAD32_BYTE("d87-09.bin", 0x000003, 0x80000, CRC(6170382d) SHA1(85b0f9a3400884e1c073d5bdcdf7318377650eed) )
 
-	ROM_REGION(0x800000, "gfx1" , 0) /* Sprites */
+	ROM_REGION( 0x400000, "sprites" , 0) /* Sprites */
 	ROM_LOAD16_BYTE("d87-03.bin", 0x000000, 0x200000, CRC(4be1666e) SHA1(35ba7bcf29ec7a8f8b6944ee3544693d4df1bfc2) )
 	ROM_LOAD16_BYTE("d87-04.bin", 0x000001, 0x200000, CRC(2616002c) SHA1(003f98b740a697274385b8da03c78f3c6f7b5e89) )
-	ROM_LOAD       ("d87-05.bin", 0x600000, 0x200000, CRC(4e5891a9) SHA1(fd08d848079841c9237fa359a850980fd00114d8) )
-	ROM_FILL       (              0x400000, 0x200000, 0x00 )
 
-	ROM_REGION(0x800000, "gfx2" , 0) /* Tiles */
-	ROM_LOAD16_BYTE("d87-06.bin", 0x000000, 0x200000, CRC(3b97a07c) SHA1(72cdeffedeab0c1bd0e47f03172085390a2be393) )
-	ROM_LOAD16_BYTE("d87-17.bin", 0x000001, 0x200000, CRC(e601d63e) SHA1(256a6aeb5633fe1db407fad567169a9d0c911219) )
-	ROM_LOAD       ("d87-08.bin", 0x600000, 0x200000, CRC(76d23602) SHA1(ca53ea6641182c44a4038bbeaa5effb1687f1980) )
-	ROM_FILL       (              0x400000, 0x200000, 0x00 )
+	ROM_REGION( 0x200000, "sprites_hi", 0 )
+	ROM_LOAD       ("d87-05.bin", 0x000000, 0x200000, CRC(4e5891a9) SHA1(fd08d848079841c9237fa359a850980fd00114d8) )
 
-	ROM_REGION(0x180000, "taito_en:audiocpu", 0) /* 68000 sound CPU */
+	ROM_REGION( 0x400000, "tilemap" , 0) /* Tiles */
+	ROM_LOAD32_WORD("d87-06.bin", 0x000000, 0x200000, CRC(3b97a07c) SHA1(72cdeffedeab0c1bd0e47f03172085390a2be393) )
+	ROM_LOAD32_WORD("d87-17.bin", 0x000002, 0x200000, CRC(e601d63e) SHA1(256a6aeb5633fe1db407fad567169a9d0c911219) )
+
+	ROM_REGION( 0x200000, "tilemap_hi", 0 )
+	ROM_LOAD       ("d87-08.bin", 0x000000, 0x200000, CRC(76d23602) SHA1(ca53ea6641182c44a4038bbeaa5effb1687f1980) )
+
+	ROM_REGION( 0x180000, "taito_en:audiocpu", 0 ) /* 68000 sound CPU */
 	ROM_LOAD16_BYTE("d87-13.bin", 0x100000, 0x40000, CRC(15b1fff4) SHA1(28692b731ae98a47c2c5e11a8a71b61a813d9a64) )
 	ROM_LOAD16_BYTE("d87-14.bin", 0x100001, 0x40000, CRC(eecda29a) SHA1(6eb238e47bc7bf635ffbdbb25fb06a37db980ef8) )
 
-	ROM_REGION16_BE(0x800000, "ensoniq.0" , ROMREGION_ERASE00 ) // V2: 4 banks, only 2 populated
+	ROM_REGION16_BE( 0x800000, "ensoniq.0" , ROMREGION_ERASE00 ) // V2: 4 banks, only 2 populated
 	ROM_LOAD16_BYTE("d87-01.bin", 0x000000, 0x200000, CRC(3848a110) SHA1(802e91695a526f665c7fd261f0a7639a0b883c9e) )    // C9 CA CB CC
 	ROM_LOAD16_BYTE("d87-02.bin", 0x400000, 0x200000, CRC(9250abae) SHA1(07cae8edbc3cca0a95022d9b40a5c18a55350b67) )    // CD CE CF D0
 ROM_END
 
 ROM_START( dariusgu )
-	ROM_REGION(0x200000, "maincpu", 0) /* 68020 code */
+	ROM_REGION( 0x200000, "maincpu", 0 ) /* 68020 code */
 	ROM_LOAD32_BYTE("d87-12.bin", 0x000000, 0x80000, CRC(de78f328) SHA1(126464a826685f5bfab6cc099448ce4df207a407) )
 	ROM_LOAD32_BYTE("d87-11.bin", 0x000001, 0x80000, CRC(f7bed18e) SHA1(db7d92680f9f406a5295ee85ce110c1a56ed386f) )
 	ROM_LOAD32_BYTE("d87-10.bin", 0x000002, 0x80000, CRC(4149f66f) SHA1(57d36a62d490d9e53b6b80a92ea0e8c41d61799f) )
 	ROM_LOAD32_BYTE("d87-15.bin", 0x000003, 0x80000, CRC(f8796997) SHA1(fa286561bac9894cb260944ffa14d0059b882ab9) )
 
-	ROM_REGION(0x800000, "gfx1" , 0) /* Sprites */
+	ROM_REGION( 0x400000, "sprites" , 0) /* Sprites */
 	ROM_LOAD16_BYTE("d87-03.bin", 0x000000, 0x200000, CRC(4be1666e) SHA1(35ba7bcf29ec7a8f8b6944ee3544693d4df1bfc2) )
 	ROM_LOAD16_BYTE("d87-04.bin", 0x000001, 0x200000, CRC(2616002c) SHA1(003f98b740a697274385b8da03c78f3c6f7b5e89) )
-	ROM_LOAD       ("d87-05.bin", 0x600000, 0x200000, CRC(4e5891a9) SHA1(fd08d848079841c9237fa359a850980fd00114d8) )
-	ROM_FILL       (              0x400000, 0x200000, 0x00 )
 
-	ROM_REGION(0x800000, "gfx2" , 0) /* Tiles */
-	ROM_LOAD16_BYTE("d87-06.bin", 0x000000, 0x200000, CRC(3b97a07c) SHA1(72cdeffedeab0c1bd0e47f03172085390a2be393) )
-	ROM_LOAD16_BYTE("d87-17.bin", 0x000001, 0x200000, CRC(e601d63e) SHA1(256a6aeb5633fe1db407fad567169a9d0c911219) )
-	ROM_LOAD       ("d87-08.bin", 0x600000, 0x200000, CRC(76d23602) SHA1(ca53ea6641182c44a4038bbeaa5effb1687f1980) )
-	ROM_FILL       (              0x400000, 0x200000, 0x00 )
+	ROM_REGION( 0x200000, "sprites_hi", 0 )
+	ROM_LOAD       ("d87-05.bin", 0x000000, 0x200000, CRC(4e5891a9) SHA1(fd08d848079841c9237fa359a850980fd00114d8) )
 
-	ROM_REGION(0x180000, "taito_en:audiocpu", 0) /* 68000 sound CPU */
+	ROM_REGION( 0x400000, "tilemap" , 0) /* Tiles */
+	ROM_LOAD32_WORD("d87-06.bin", 0x000000, 0x200000, CRC(3b97a07c) SHA1(72cdeffedeab0c1bd0e47f03172085390a2be393) )
+	ROM_LOAD32_WORD("d87-17.bin", 0x000002, 0x200000, CRC(e601d63e) SHA1(256a6aeb5633fe1db407fad567169a9d0c911219) )
+
+	ROM_REGION( 0x200000, "tilemap_hi", 0 )
+	ROM_LOAD       ("d87-08.bin", 0x000000, 0x200000, CRC(76d23602) SHA1(ca53ea6641182c44a4038bbeaa5effb1687f1980) )
+
+	ROM_REGION( 0x180000, "taito_en:audiocpu", 0 ) /* 68000 sound CPU */
 	ROM_LOAD16_BYTE("d87-13.bin", 0x100000, 0x40000, CRC(15b1fff4) SHA1(28692b731ae98a47c2c5e11a8a71b61a813d9a64) )
 	ROM_LOAD16_BYTE("d87-14.bin", 0x100001, 0x40000, CRC(eecda29a) SHA1(6eb238e47bc7bf635ffbdbb25fb06a37db980ef8) )
 
-	ROM_REGION16_BE(0x800000, "ensoniq.0" , ROMREGION_ERASE00 ) // V2: 4 banks, only 2 populated
+	ROM_REGION16_BE( 0x800000, "ensoniq.0" , ROMREGION_ERASE00 ) // V2: 4 banks, only 2 populated
 	ROM_LOAD16_BYTE("d87-01.bin", 0x000000, 0x200000, CRC(3848a110) SHA1(802e91695a526f665c7fd261f0a7639a0b883c9e) )    // C9 CA CB CC
 	ROM_LOAD16_BYTE("d87-02.bin", 0x400000, 0x200000, CRC(9250abae) SHA1(07cae8edbc3cca0a95022d9b40a5c18a55350b67) )    // CD CE CF D0
 ROM_END
 
 ROM_START( dariusgx )
-	ROM_REGION(0x200000, "maincpu", 0) /* 68020 code */
+	ROM_REGION( 0x200000, "maincpu", 0 ) /* 68020 code */
 	ROM_LOAD32_BYTE("dge_mpr3.bin", 0x000000, 0x80000, CRC(1c1e24a7) SHA1(eafde331c3be5be55d0d838a84017f357ff92634) )
 	ROM_LOAD32_BYTE("dge_mpr2.bin", 0x000001, 0x80000, CRC(7be23e23) SHA1(4764355f51e207f4538dd753aea59bf2689835de) )
 	ROM_LOAD32_BYTE("dge_mpr1.bin", 0x000002, 0x80000, CRC(bc030f6f) SHA1(841396911d26ddfae0c9863431e02e0b5e762ac6) )
 	ROM_LOAD32_BYTE("dge_mpr0.bin", 0x000003, 0x80000, CRC(c5bd135c) SHA1(402e26a05f1c3162fa3a8d3fcb81ef334b733699) )
 
-	ROM_REGION(0x800000, "gfx1" , 0) /* Sprites */
+	ROM_REGION( 0x400000, "sprites" , 0) /* Sprites */
 	ROM_LOAD16_BYTE("d87-03.bin", 0x000000, 0x200000, CRC(4be1666e) SHA1(35ba7bcf29ec7a8f8b6944ee3544693d4df1bfc2) )
 	ROM_LOAD16_BYTE("d87-04.bin", 0x000001, 0x200000, CRC(2616002c) SHA1(003f98b740a697274385b8da03c78f3c6f7b5e89) )
-	ROM_LOAD       ("d87-05.bin", 0x600000, 0x200000, CRC(4e5891a9) SHA1(fd08d848079841c9237fa359a850980fd00114d8) )
-	ROM_FILL       (              0x400000, 0x200000, 0x00 )
 
-	ROM_REGION(0x800000, "gfx2" , 0) /* Tiles */
-	ROM_LOAD16_BYTE("d87-06.bin", 0x000000, 0x200000, CRC(3b97a07c) SHA1(72cdeffedeab0c1bd0e47f03172085390a2be393) )
-	ROM_LOAD16_BYTE("d87-17.bin", 0x000001, 0x200000, CRC(e601d63e) SHA1(256a6aeb5633fe1db407fad567169a9d0c911219) )
-	ROM_LOAD       ("d87-08.bin", 0x600000, 0x200000, CRC(76d23602) SHA1(ca53ea6641182c44a4038bbeaa5effb1687f1980) )
-	ROM_FILL       (              0x400000, 0x200000, 0x00 )
+	ROM_REGION( 0x200000, "sprites_hi", 0 )
+	ROM_LOAD       ("d87-05.bin", 0x000000, 0x200000, CRC(4e5891a9) SHA1(fd08d848079841c9237fa359a850980fd00114d8) )
 
-	ROM_REGION(0x180000, "taito_en:audiocpu", 0) /* 68000 sound CPU */
+	ROM_REGION( 0x400000, "tilemap" , 0) /* Tiles */
+	ROM_LOAD32_WORD("d87-06.bin", 0x000000, 0x200000, CRC(3b97a07c) SHA1(72cdeffedeab0c1bd0e47f03172085390a2be393) )
+	ROM_LOAD32_WORD("d87-17.bin", 0x000002, 0x200000, CRC(e601d63e) SHA1(256a6aeb5633fe1db407fad567169a9d0c911219) )
+
+	ROM_REGION( 0x200000, "tilemap_hi", 0 )
+	ROM_LOAD       ("d87-08.bin", 0x000000, 0x200000, CRC(76d23602) SHA1(ca53ea6641182c44a4038bbeaa5effb1687f1980) )
+
+	ROM_REGION( 0x180000, "taito_en:audiocpu", 0 ) /* 68000 sound CPU */
 	ROM_LOAD16_BYTE("d87-13.bin", 0x100000, 0x40000, CRC(15b1fff4) SHA1(28692b731ae98a47c2c5e11a8a71b61a813d9a64) )
 	ROM_LOAD16_BYTE("d87-14.bin", 0x100001, 0x40000, CRC(eecda29a) SHA1(6eb238e47bc7bf635ffbdbb25fb06a37db980ef8) )
 
-	ROM_REGION16_BE(0x800000, "ensoniq.0" , ROMREGION_ERASE00 ) // V2: 4 banks, only 2 populated
+	ROM_REGION16_BE( 0x800000, "ensoniq.0" , ROMREGION_ERASE00 ) // V2: 4 banks, only 2 populated
 	ROM_LOAD16_BYTE("d87-01.bin", 0x000000, 0x200000, CRC(3848a110) SHA1(802e91695a526f665c7fd261f0a7639a0b883c9e) )    // C9 CA CB CC
 	ROM_LOAD16_BYTE("d87-02.bin", 0x400000, 0x200000, CRC(9250abae) SHA1(07cae8edbc3cca0a95022d9b40a5c18a55350b67) )    // CD CE CF D0
 ROM_END
 
 
 ROM_START( bublbob2 )
-	ROM_REGION(0x200000, "maincpu", 0) /* 68020 code */
+	ROM_REGION( 0x200000, "maincpu", 0 ) /* 68020 code */
 	ROM_LOAD32_BYTE("d90-21.ic20", 0x000000, 0x40000, CRC(2a2b771a) SHA1(7f9bd768cf34069ca139261ebd8304325598fec6) )
 	ROM_LOAD32_BYTE("d90-20.ic19", 0x000001, 0x40000, CRC(f01f63b6) SHA1(cbdc8c6248a2c0c1bc77fdc28738f67ce9a6aec3) )
 	ROM_LOAD32_BYTE("d90-19.ic18", 0x000002, 0x40000, CRC(86eef19a) SHA1(9a389fefa280662843cafb68b5ae411e9348d34d) )
 	ROM_LOAD32_BYTE("d90-18.ic17", 0x000003, 0x40000, CRC(f5b8cdce) SHA1(cf6ce6638eebd7d2e1defdd48110cc3002109c5c) )
 
-	ROM_REGION(0x400000, "gfx1" , 0) /* Sprites */
+	ROM_REGION( 0x200000, "sprites" , 0) /* Sprites */
 	ROM_LOAD16_BYTE("d90-03", 0x000000, 0x100000, CRC(6fa894a1) SHA1(7c33e6d41e8928029b92d66557a3712b51c49c67) )
 	ROM_LOAD16_BYTE("d90-02", 0x000001, 0x100000, CRC(5ab04ca2) SHA1(6d87e7ca3167ff81a041cfedbbed84d51da997de) )
-	ROM_LOAD       ("d90-01", 0x300000, 0x100000, CRC(8aedb9e5) SHA1(fb49330f7985a829c9544ecfd0bc672494f29cf6) )
-	ROM_FILL       (          0x200000, 0x100000, 0x00 )
 
-	ROM_REGION(0x400000, "gfx2" , 0) /* Tiles */
-	ROM_LOAD16_BYTE("d90-08", 0x000000, 0x100000, CRC(25a4fb2c) SHA1(c8bf6fe2291c05386b32cd26bfcb379da756d7b5) )
-	ROM_LOAD16_BYTE("d90-07", 0x000001, 0x100000, CRC(b436b42d) SHA1(559827120273733147b260e0723054d926dbea5e) )
-	ROM_LOAD       ("d90-06", 0x300000, 0x100000, CRC(166a72b8) SHA1(7f70b8c960794322e1dc88e6600a2d13d948d873) )
-	ROM_FILL       (          0x200000, 0x100000, 0x00 )
+	ROM_REGION( 0x100000, "sprites_hi", 0 )
+	ROM_LOAD       ("d90-01", 0x000000, 0x100000, CRC(8aedb9e5) SHA1(fb49330f7985a829c9544ecfd0bc672494f29cf6) )
 
-	ROM_REGION(0x180000, "taito_en:audiocpu", 0) /* sound CPU */
+	ROM_REGION( 0x200000, "tilemap" , 0) /* Tiles */
+	ROM_LOAD32_WORD("d90-08", 0x000000, 0x100000, CRC(25a4fb2c) SHA1(c8bf6fe2291c05386b32cd26bfcb379da756d7b5) )
+	ROM_LOAD32_WORD("d90-07", 0x000002, 0x100000, CRC(b436b42d) SHA1(559827120273733147b260e0723054d926dbea5e) )
+
+	ROM_REGION( 0x100000, "tilemap_hi", 0 )
+	ROM_LOAD       ("d90-06", 0x000000, 0x100000, CRC(166a72b8) SHA1(7f70b8c960794322e1dc88e6600a2d13d948d873) )
+
+	ROM_REGION( 0x180000, "taito_en:audiocpu", 0 ) /* sound CPU */
 	ROM_LOAD16_BYTE("d90-13.ic32", 0x100000, 0x40000, CRC(6762bd90) SHA1(771db0382bc8dab2caf13d0fc20648366c685829) )
 	ROM_LOAD16_BYTE("d90-14.ic33", 0x100001, 0x40000, CRC(8e33357e) SHA1(68b81693c22e6357e37244f2a416818a81338138) )
 
-	ROM_REGION16_BE(0x800000, "ensoniq.0" , ROMREGION_ERASE00 ) // V2: 4 banks, only 2 populated
+	ROM_REGION16_BE( 0x800000, "ensoniq.0" , ROMREGION_ERASE00 ) // V2: 4 banks, only 2 populated
 	ROM_LOAD16_BYTE("d90-04", 0x000000, 0x200000, CRC(feee5fda) SHA1(b89354013ec4d34bcd51ecded412effa66dd2f2f) )    // C8 C9 CA CB
 	ROM_LOAD16_BYTE("d90-05", 0x400000, 0x200000, CRC(c192331f) SHA1(ebab05b3681c70b373bc06c1826be1cc397d3af7) )    // CC CD -std-
 
@@ -2079,29 +2148,31 @@ ROM_END
 
 
 ROM_START( bublbob2o )
-	ROM_REGION(0x200000, "maincpu", 0) /* 68020 code */
+	ROM_REGION( 0x200000, "maincpu", 0 ) /* 68020 code */
 	ROM_LOAD32_BYTE("d90-12", 0x000000, 0x40000, CRC(9e523996) SHA1(c49a426f9865f96e8021c8ed9a6ac094c5e586b1) )
 	ROM_LOAD32_BYTE("d90-11", 0x000001, 0x40000, CRC(edfdbb7f) SHA1(698ad631d5b13661645f2c5ccd3e4fbf0248053c) )
 	ROM_LOAD32_BYTE("d90-10", 0x000002, 0x40000, CRC(8e957d3d) SHA1(5db31e5788483b802592e1092bf98df51ff4b70e) )
 	ROM_LOAD32_BYTE("d90-17", 0x000003, 0x40000, CRC(711f1894) SHA1(8e574d9a63593fbe0c87840e79a2e2dbfc227671) )
 
-	ROM_REGION(0x400000, "gfx1" , 0) /* Sprites */
+	ROM_REGION( 0x200000, "sprites" , 0) /* Sprites */
 	ROM_LOAD16_BYTE("d90-03", 0x000000, 0x100000, CRC(6fa894a1) SHA1(7c33e6d41e8928029b92d66557a3712b51c49c67) )
 	ROM_LOAD16_BYTE("d90-02", 0x000001, 0x100000, CRC(5ab04ca2) SHA1(6d87e7ca3167ff81a041cfedbbed84d51da997de) )
-	ROM_LOAD       ("d90-01", 0x300000, 0x100000, CRC(8aedb9e5) SHA1(fb49330f7985a829c9544ecfd0bc672494f29cf6) )
-	ROM_FILL       (          0x200000, 0x100000, 0x00 )
 
-	ROM_REGION(0x400000, "gfx2" , 0) /* Tiles */
-	ROM_LOAD16_BYTE("d90-08", 0x000000, 0x100000, CRC(25a4fb2c) SHA1(c8bf6fe2291c05386b32cd26bfcb379da756d7b5) )
-	ROM_LOAD16_BYTE("d90-07", 0x000001, 0x100000, CRC(b436b42d) SHA1(559827120273733147b260e0723054d926dbea5e) )
-	ROM_LOAD       ("d90-06", 0x300000, 0x100000, CRC(166a72b8) SHA1(7f70b8c960794322e1dc88e6600a2d13d948d873) )
-	ROM_FILL       (          0x200000, 0x100000, 0x00 )
+	ROM_REGION( 0x100000, "sprites_hi", 0 )
+	ROM_LOAD       ("d90-01", 0x000000, 0x100000, CRC(8aedb9e5) SHA1(fb49330f7985a829c9544ecfd0bc672494f29cf6) )
 
-	ROM_REGION(0x180000, "taito_en:audiocpu", 0) /* sound CPU */
+	ROM_REGION( 0x200000, "tilemap" , 0) /* Tiles */
+	ROM_LOAD32_WORD("d90-08", 0x000000, 0x100000, CRC(25a4fb2c) SHA1(c8bf6fe2291c05386b32cd26bfcb379da756d7b5) )
+	ROM_LOAD32_WORD("d90-07", 0x000002, 0x100000, CRC(b436b42d) SHA1(559827120273733147b260e0723054d926dbea5e) )
+
+	ROM_REGION( 0x100000, "tilemap_hi", 0 )
+	ROM_LOAD       ("d90-06", 0x000000, 0x100000, CRC(166a72b8) SHA1(7f70b8c960794322e1dc88e6600a2d13d948d873) )
+
+	ROM_REGION( 0x180000, "taito_en:audiocpu", 0 ) /* sound CPU */
 	ROM_LOAD16_BYTE("d90-13.ic32", 0x100000, 0x40000, CRC(6762bd90) SHA1(771db0382bc8dab2caf13d0fc20648366c685829) )
 	ROM_LOAD16_BYTE("d90-14.ic33", 0x100001, 0x40000, CRC(8e33357e) SHA1(68b81693c22e6357e37244f2a416818a81338138) )
 
-	ROM_REGION16_BE(0x800000, "ensoniq.0" , ROMREGION_ERASE00 ) // V2: 4 banks, only 2 populated
+	ROM_REGION16_BE( 0x800000, "ensoniq.0" , ROMREGION_ERASE00 ) // V2: 4 banks, only 2 populated
 	ROM_LOAD16_BYTE("d90-04", 0x000000, 0x200000, CRC(feee5fda) SHA1(b89354013ec4d34bcd51ecded412effa66dd2f2f) )    // C8 C9 CA CB
 	ROM_LOAD16_BYTE("d90-05", 0x400000, 0x200000, CRC(c192331f) SHA1(ebab05b3681c70b373bc06c1826be1cc397d3af7) )    // CC CD -std-
 ROM_END
@@ -2109,36 +2180,40 @@ ROM_END
 /* Very early revision protoype boardset & roms */
 // todo, transfer information on PCB differences from http://forum.arcadeotaku.com/viewtopic.php?f=2&t=24965
 ROM_START( bublbob2p )
-	ROM_REGION(0x200000, "maincpu", 0) /* 68020 code */
+	ROM_REGION( 0x200000, "maincpu", 0 ) /* 68020 code */
 	ROM_LOAD32_BYTE("soft-3-8c9b.ic60", 0x000000, 0x40000, CRC(15d0594e) SHA1(7556377355860c3f7f600c2c352e5291da6a62f1) )
 	ROM_LOAD32_BYTE("soft-2-0587.ic61", 0x000001, 0x40000, CRC(d1a5231f) SHA1(1e9ccac78f690ef79f933743ce7c4d6fa42f5acd) )
 	ROM_LOAD32_BYTE("soft-1-9a9c.ic62", 0x000002, 0x40000, CRC(c11a4d26) SHA1(b327413f5420608f1ccbbac2e8941a82862377c5) )
 	ROM_LOAD32_BYTE("soft-0-a523.ic63", 0x000003, 0x40000, CRC(58131f9e) SHA1(d07d34bf079277a48151ef9e5e7c1240a36d1bdb) )
 
-	ROM_REGION(0x200000, "gfx1" , ROMREGION_ERASE00 ) /* Sprites */
-	ROM_LOAD16_BYTE       ("cq80-obj-0l-c166.ic8",  0x000000, 0x80000, CRC(9bff223b) SHA1(acf22731d91d61aefc3373f78006fd310bb89edf) )
-	ROM_LOAD16_BYTE       ("cq80-obj-0m-24f4.ic30", 0x000001, 0x80000, CRC(ee71f643) SHA1(7a2042c6fad8f1b7e0a3ad077d054dc163a22230) )
-	ROM_LOAD              ("cq80-obj-0h-990d.ic32", 0x180000, 0x80000, CRC(4d3a78e0) SHA1(b19fb66e6082a68dc8600b8882ba50a3afce27c3) )
+	ROM_REGION( 0x100000, "sprites" , 0) /* Sprites */
+	ROM_LOAD16_BYTE("cq80-obj-0l-c166.ic8",  0x000000, 0x80000, CRC(9bff223b) SHA1(acf22731d91d61aefc3373f78006fd310bb89edf) )
+	ROM_LOAD16_BYTE("cq80-obj-0m-24f4.ic30", 0x000001, 0x80000, CRC(ee71f643) SHA1(7a2042c6fad8f1b7e0a3ad077d054dc163a22230) )
 
-	ROM_REGION(0x400000, "gfx2" , ROMREGION_ERASE00 ) /* Tiles */
+	ROM_REGION( 0x080000, "sprites_hi", 0 )
+	ROM_LOAD       ("cq80-obj-0h-990d.ic32", 0x000000, 0x80000, CRC(4d3a78e0) SHA1(b19fb66e6082a68dc8600b8882ba50a3afce27c3) )
+
+	ROM_REGION( 0x200000, "tilemap" , 0) /* Tiles */
 	ROM_LOAD32_BYTE("cq80-scr0-5ba4.ic7", 0x000000, 0x080000, CRC(044dc38b) SHA1(0bb715c9ae8298c6852c6309d69f769e87ab2fdc) )
-	ROM_LOAD32_BYTE("cq80-scr1-a5f3.ic6", 0x000002, 0x080000, CRC(3cf3a3ba) SHA1(da7282104fbd9108bae12fa6722e077d80107d6d) )
-	ROM_LOAD32_BYTE("cq80-scr2-cc11.ic5", 0x000001, 0x080000, CRC(b81aa2c7) SHA1(4650c431dc2ed73f1e71337f3e7d4c1837b65bcf) )
+	ROM_LOAD32_BYTE("cq80-scr1-a5f3.ic6", 0x000001, 0x080000, CRC(3cf3a3ba) SHA1(da7282104fbd9108bae12fa6722e077d80107d6d) )
+	ROM_LOAD32_BYTE("cq80-scr2-cc11.ic5", 0x000002, 0x080000, CRC(b81aa2c7) SHA1(4650c431dc2ed73f1e71337f3e7d4c1837b65bcf) )
 	ROM_LOAD32_BYTE("cq80-scr3-4266.ic4", 0x000003, 0x080000, CRC(c114583f) SHA1(ec85e8f4135e48607bb84b810d57d570ef56b228) )
-	ROM_LOAD16_BYTE("cq80-scr4-7fe1.ic3", 0x300000, 0x080000, CRC(2bba1728) SHA1(cdd2e651c233a185fcbb3fd8f5eabee2af30f781) )
 
-	ROM_REGION(0x180000, "taito_en:audiocpu", 0) /* sound CPU */
-	ROM_LOAD16_BYTE("snd-h-348f.ic66", 0x100000, 0x20000, CRC(f66e60f2) SHA1(b94c97ccde179a69811137c77730c91924236bfe))
+	ROM_REGION( 0x100000, "tilemap_hi", ROMREGION_ERASE00 )
+	ROM_LOAD16_BYTE("cq80-scr4-7fe1.ic3", 0x000000, 0x080000, CRC(2bba1728) SHA1(cdd2e651c233a185fcbb3fd8f5eabee2af30f781) )
+
+	ROM_REGION( 0x180000, "taito_en:audiocpu", 0 ) /* sound CPU */
+	ROM_LOAD16_BYTE("snd-h-348f.ic66", 0x100000, 0x20000, CRC(f66e60f2) SHA1(b94c97ccde179a69811137c77730c91924236bfe) )
 	ROM_LOAD16_BYTE("snd-l-4ec1.ic65", 0x100001, 0x20000, CRC(d302d8bc) SHA1(02a2e69d0f4406578b12b05ab25d2abdf5bbba3c) )
 
-	ROM_REGION16_BE(0x800000, "ensoniq.0" , ROMREGION_ERASE00 )
+	ROM_REGION16_BE( 0x800000, "ensoniq.0" , ROMREGION_ERASE00 )
 	ROM_LOAD16_BYTE("cq80-snd-data0-7b5f.ic43", 0x000000, 0x080000, CRC(bf8f26d3) SHA1(b165fc62ed30ae56d27caffbb0b16321d3c5ef8b) )    // C8
 	ROM_LOAD16_BYTE("cq80-snd-data1-933b.ic44", 0x100000, 0x080000, CRC(62b00475) SHA1(d2b44940cefca76897b291d83b5ca8ec18dbe1fa) )    // C9
 
 	ROM_LOAD16_BYTE("cq80-snd3-std5-3a9c.ic10", 0x600000, 0x080000, CRC(26312451) SHA1(9f947a11592fd8420fc581914bf16e7ade75390c) )    // -std-
 	ROM_LOAD16_BYTE("cq80-snd2-std6-a148.ic11", 0x700000, 0x080000, CRC(2edaa9dc) SHA1(72fead505c4f44e5736ff7d545d72dfa37d613e2) )    // -std-
 
-	ROM_REGION(0x180000, "pals", 0)
+	ROM_REGION( 0x180000, "pals", 0 )
 	// dumped regular way, appear to be protected
 	//ROM_LOAD("pal20l10a.ic12.bin", 0x000, 0xcc, BAD_DUMP CRC(5d695690) SHA1(713cdbb894861eb5a6361026af8618df7e7db467) )
 	//ROM_LOAD("pal20l10a.ic24.bin", 0x000, 0xcc, BAD_DUMP CRC(5d695690) SHA1(713cdbb894861eb5a6361026af8618df7e7db467) )
@@ -2154,57 +2229,61 @@ ROM_END
 
 
 ROM_START( bubsymphe )
-	ROM_REGION(0x200000, "maincpu", 0) /* 68020 code */
+	ROM_REGION( 0x200000, "maincpu", 0 ) /* 68020 code */
 	ROM_LOAD32_BYTE("d90-12", 0x000000, 0x40000, CRC(9e523996) SHA1(c49a426f9865f96e8021c8ed9a6ac094c5e586b1) )
 	ROM_LOAD32_BYTE("d90-11", 0x000001, 0x40000, CRC(edfdbb7f) SHA1(698ad631d5b13661645f2c5ccd3e4fbf0248053c) )
 	ROM_LOAD32_BYTE("d90-10", 0x000002, 0x40000, CRC(8e957d3d) SHA1(5db31e5788483b802592e1092bf98df51ff4b70e) )
 	ROM_LOAD32_BYTE("d90-16", 0x000003, 0x40000, CRC(d12ef19b) SHA1(8715102b54c730c809b3964a80cd1aed863ba334) )
 
-	ROM_REGION(0x400000, "gfx1" , 0) /* Sprites */
+	ROM_REGION( 0x200000, "sprites" , 0) /* Sprites */
 	ROM_LOAD16_BYTE("d90-03", 0x000000, 0x100000, CRC(6fa894a1) SHA1(7c33e6d41e8928029b92d66557a3712b51c49c67) )
 	ROM_LOAD16_BYTE("d90-02", 0x000001, 0x100000, CRC(5ab04ca2) SHA1(6d87e7ca3167ff81a041cfedbbed84d51da997de) )
-	ROM_LOAD       ("d90-01", 0x300000, 0x100000, CRC(8aedb9e5) SHA1(fb49330f7985a829c9544ecfd0bc672494f29cf6) )
-	ROM_FILL       (          0x200000, 0x100000, 0x00 )
 
-	ROM_REGION(0x400000, "gfx2" , 0) /* Tiles */
-	ROM_LOAD16_BYTE("d90-08", 0x000000, 0x100000, CRC(25a4fb2c) SHA1(c8bf6fe2291c05386b32cd26bfcb379da756d7b5) )
-	ROM_LOAD16_BYTE("d90-07", 0x000001, 0x100000, CRC(b436b42d) SHA1(559827120273733147b260e0723054d926dbea5e) )
-	ROM_LOAD       ("d90-06", 0x300000, 0x100000, CRC(166a72b8) SHA1(7f70b8c960794322e1dc88e6600a2d13d948d873) )
-	ROM_FILL       (          0x200000, 0x100000, 0x00 )
+	ROM_REGION( 0x100000, "sprites_hi", 0 )
+	ROM_LOAD       ("d90-01", 0x000000, 0x100000, CRC(8aedb9e5) SHA1(fb49330f7985a829c9544ecfd0bc672494f29cf6) )
 
-	ROM_REGION(0x180000, "taito_en:audiocpu", 0) /* sound CPU */
+	ROM_REGION( 0x200000, "tilemap" , 0) /* Tiles */
+	ROM_LOAD32_WORD("d90-08", 0x000000, 0x100000, CRC(25a4fb2c) SHA1(c8bf6fe2291c05386b32cd26bfcb379da756d7b5) )
+	ROM_LOAD32_WORD("d90-07", 0x000002, 0x100000, CRC(b436b42d) SHA1(559827120273733147b260e0723054d926dbea5e) )
+
+	ROM_REGION( 0x100000, "tilemap_hi", 0 )
+	ROM_LOAD       ("d90-06", 0x000000, 0x100000, CRC(166a72b8) SHA1(7f70b8c960794322e1dc88e6600a2d13d948d873) )
+
+	ROM_REGION( 0x180000, "taito_en:audiocpu", 0 ) /* sound CPU */
 	ROM_LOAD16_BYTE("d90-13.ic32", 0x100000, 0x40000, CRC(6762bd90) SHA1(771db0382bc8dab2caf13d0fc20648366c685829) )
 	ROM_LOAD16_BYTE("d90-14.ic33", 0x100001, 0x40000, CRC(8e33357e) SHA1(68b81693c22e6357e37244f2a416818a81338138) )
 
-	ROM_REGION16_BE(0x800000, "ensoniq.0" , ROMREGION_ERASE00 ) // V2: 4 banks, only 2 populated
+	ROM_REGION16_BE( 0x800000, "ensoniq.0" , ROMREGION_ERASE00 ) // V2: 4 banks, only 2 populated
 	ROM_LOAD16_BYTE("d90-04", 0x000000, 0x200000, CRC(feee5fda) SHA1(b89354013ec4d34bcd51ecded412effa66dd2f2f) )    // C8 C9 CA CB
 	ROM_LOAD16_BYTE("d90-05", 0x400000, 0x200000, CRC(c192331f) SHA1(ebab05b3681c70b373bc06c1826be1cc397d3af7) )    // CC CD -std-
 ROM_END
 
 ROM_START( bubsymphj )
-	ROM_REGION(0x200000, "maincpu", 0) /* 68020 code */
+	ROM_REGION( 0x200000, "maincpu", 0 ) /* 68020 code */
 	ROM_LOAD32_BYTE("d90-12", 0x000000, 0x40000, CRC(9e523996) SHA1(c49a426f9865f96e8021c8ed9a6ac094c5e586b1) )
 	ROM_LOAD32_BYTE("d90-11", 0x000001, 0x40000, CRC(edfdbb7f) SHA1(698ad631d5b13661645f2c5ccd3e4fbf0248053c) )
 	ROM_LOAD32_BYTE("d90-10", 0x000002, 0x40000, CRC(8e957d3d) SHA1(5db31e5788483b802592e1092bf98df51ff4b70e) )
 	ROM_LOAD32_BYTE("d90-09", 0x000003, 0x40000, CRC(3f2090b7) SHA1(2a95c8c8dc23b618c0ce65497391d464494f4d6a) )
 
-	ROM_REGION(0x400000, "gfx1" , 0) /* Sprites */
+	ROM_REGION( 0x200000, "sprites" , 0) /* Sprites */
 	ROM_LOAD16_BYTE("d90-03", 0x000000, 0x100000, CRC(6fa894a1) SHA1(7c33e6d41e8928029b92d66557a3712b51c49c67) )
 	ROM_LOAD16_BYTE("d90-02", 0x000001, 0x100000, CRC(5ab04ca2) SHA1(6d87e7ca3167ff81a041cfedbbed84d51da997de) )
-	ROM_LOAD       ("d90-01", 0x300000, 0x100000, CRC(8aedb9e5) SHA1(fb49330f7985a829c9544ecfd0bc672494f29cf6) )
-	ROM_FILL       (          0x200000, 0x100000, 0x00 )
 
-	ROM_REGION(0x400000, "gfx2" , 0) /* Tiles */
-	ROM_LOAD16_BYTE("d90-08", 0x000000, 0x100000, CRC(25a4fb2c) SHA1(c8bf6fe2291c05386b32cd26bfcb379da756d7b5) )
-	ROM_LOAD16_BYTE("d90-07", 0x000001, 0x100000, CRC(b436b42d) SHA1(559827120273733147b260e0723054d926dbea5e) )
-	ROM_LOAD       ("d90-06", 0x300000, 0x100000, CRC(166a72b8) SHA1(7f70b8c960794322e1dc88e6600a2d13d948d873) )
-	ROM_FILL       (          0x200000, 0x100000, 0x00 )
+	ROM_REGION( 0x100000, "sprites_hi", 0 )
+	ROM_LOAD       ("d90-01", 0x000000, 0x100000, CRC(8aedb9e5) SHA1(fb49330f7985a829c9544ecfd0bc672494f29cf6) )
 
-	ROM_REGION(0x180000, "taito_en:audiocpu", 0) /* sound CPU */
+	ROM_REGION( 0x200000, "tilemap" , 0) /* Tiles */
+	ROM_LOAD32_WORD("d90-08", 0x000000, 0x100000, CRC(25a4fb2c) SHA1(c8bf6fe2291c05386b32cd26bfcb379da756d7b5) )
+	ROM_LOAD32_WORD("d90-07", 0x000002, 0x100000, CRC(b436b42d) SHA1(559827120273733147b260e0723054d926dbea5e) )
+
+	ROM_REGION( 0x100000, "tilemap_hi", 0 )
+	ROM_LOAD       ("d90-06", 0x000000, 0x100000, CRC(166a72b8) SHA1(7f70b8c960794322e1dc88e6600a2d13d948d873) )
+
+	ROM_REGION( 0x180000, "taito_en:audiocpu", 0 ) /* sound CPU */
 	ROM_LOAD16_BYTE("d90-13.ic32", 0x100000, 0x40000, CRC(6762bd90) SHA1(771db0382bc8dab2caf13d0fc20648366c685829) )
 	ROM_LOAD16_BYTE("d90-14.ic33", 0x100001, 0x40000, CRC(8e33357e) SHA1(68b81693c22e6357e37244f2a416818a81338138) )
 
-	ROM_REGION16_BE(0x800000, "ensoniq.0" , ROMREGION_ERASE00 ) // V2: 4 banks, only 2 populated
+	ROM_REGION16_BE( 0x800000, "ensoniq.0" , ROMREGION_ERASE00 ) // V2: 4 banks, only 2 populated
 	ROM_LOAD16_BYTE("d90-04", 0x000000, 0x200000, CRC(feee5fda) SHA1(b89354013ec4d34bcd51ecded412effa66dd2f2f) )    // C8 C9 CA CB
 	ROM_LOAD16_BYTE("d90-05", 0x400000, 0x200000, CRC(c192331f) SHA1(ebab05b3681c70b373bc06c1826be1cc397d3af7) )    // CC CD -std-
 
@@ -2244,82 +2323,88 @@ Dumped by tirino73
 
 
 ROM_START( bubsymphb )
-	ROM_REGION(0x200000, "maincpu", 0) /* 68020 code */
+	ROM_REGION( 0x200000, "maincpu", 0 ) /* 68020 code */
 	ROM_LOAD32_BYTE("bsb_d12.bin", 0x000000, 0x40000, CRC(d05160fc) SHA1(62eb47827d4089711af1187455faeb62a8d9e369) )
 	ROM_LOAD32_BYTE("bsb_d13.bin", 0x000001, 0x40000, CRC(83fc0d2c) SHA1(275a923e6e6b6763cb7036d94943609eb9ce866b) )
 	ROM_LOAD32_BYTE("bsb_d14.bin", 0x000002, 0x40000, CRC(e6d49bb7) SHA1(9ca509ffd3f46160f3bbb0ceee9abcd09f9f9ad1) )
 	ROM_LOAD32_BYTE("bsb_d15.bin", 0x000003, 0x40000, CRC(014cf8e0) SHA1(5e91fc6665c1d472d0651c06108ea6a8eb5ae8b4) )
 
-	ROM_REGION(0x300000, "gfx1" , 0) /* Sprites (5bpp) */
-	ROM_FILL       (        0x000000, 0x080000, 0x00 )
-	ROM_LOAD("bsb_d18.bin", 0x080000, 0x080000, CRC(22d7eeb5) SHA1(30aa4493c5bc98d9256817b9e3341b20d2b76f1f) )
-	ROM_LOAD("bsb_d19.bin", 0x100000, 0x080000, CRC(d36801fd) SHA1(5dc00942dbd9bb29214c206ea192f158b71b09dc) )
-	ROM_LOAD("bsb_d20.bin", 0x180000, 0x080000, CRC(20222e15) SHA1(41f2f94afd65d0c106752f254f20b593906cba28) )
-	ROM_LOAD("bsb_d17.bin", 0x200000, 0x080000, CRC(ea2eadfc) SHA1(2c4176e89f816166f410888cd2e837891a4289a3) )
-	ROM_LOAD("bsb_d16.bin", 0x280000, 0x080000, CRC(edccd4e0) SHA1(e00d3c1a91f9a96e1ae7d45842315d839c9cd440) )
+	ROM_REGION( 0x300000, "sprites" , 0) /* Sprites (5bpp) */
+	ROM_FILL            (               0x000000, 0x080000, 0x00 )
+	ROM_LOAD16_WORD_SWAP("bsb_d18.bin", 0x080000, 0x080000, CRC(22d7eeb5) SHA1(30aa4493c5bc98d9256817b9e3341b20d2b76f1f) )
+	ROM_LOAD16_WORD_SWAP("bsb_d19.bin", 0x100000, 0x080000, CRC(d36801fd) SHA1(5dc00942dbd9bb29214c206ea192f158b71b09dc) )
+	ROM_LOAD16_WORD_SWAP("bsb_d20.bin", 0x180000, 0x080000, CRC(20222e15) SHA1(41f2f94afd65d0c106752f254f20b593906cba28) )
+	ROM_LOAD16_WORD_SWAP("bsb_d17.bin", 0x200000, 0x080000, CRC(ea2eadfc) SHA1(2c4176e89f816166f410888cd2e837891a4289a3) )
+	ROM_LOAD16_WORD_SWAP("bsb_d16.bin", 0x280000, 0x080000, CRC(edccd4e0) SHA1(e00d3c1a91f9a96e1ae7d45842315d839c9cd440) )
 
-	ROM_REGION(0x400000, "gfx2" , 0) /* Tiles */
-	ROM_LOAD32_BYTE("bsb_d13b.bin", 0x000000, 0x080000, CRC(430af2aa) SHA1(e935f9f4e0558a25bd4010b44dbb4f38a9d359e0) )
+	ROM_REGION( 0x200000, "tilemap" , 0) /* Tiles */
+	ROM_LOAD32_BYTE("bsb_d15b.bin", 0x000000, 0x080000, CRC(74644ad4) SHA1(c7610e413c965eb4e40b548d13efdcbc3dde23be) )
 	ROM_LOAD32_BYTE("bsb_d14b.bin", 0x000001, 0x080000, CRC(c006e832) SHA1(4aebbac188af1ef9176581ac68ac12ce397f2f08) )
-	ROM_LOAD32_BYTE("bsb_d15b.bin", 0x000002, 0x080000, CRC(74644ad4) SHA1(c7610e413c965eb4e40b548d13efdcbc3dde23be) )
+	ROM_LOAD32_BYTE("bsb_d13b.bin", 0x000002, 0x080000, CRC(430af2aa) SHA1(e935f9f4e0558a25bd4010b44dbb4f38a9d359e0) )
 	ROM_LOAD32_BYTE("bsb_d12b.bin", 0x000003, 0x080000, CRC(cb2e2abb) SHA1(7e3a90cb8af298bac2aef80778341833e473b671) )
-	ROM_LOAD32_BYTE("bsb_d11b.bin", 0x200000, 0x080000, CRC(d0607829) SHA1(546c629ec22bb98202c7127ccb77df0b8f3a1966) )
 
-	ROM_REGION(0x100000, "oki" , ROMREGION_ERASE00 ) // OKI6295 samples
+	ROM_REGION( 0x100000, "tilemap_hi", 0 )
+	ROM_LOAD16_BYTE("bsb_d11b.bin", 0x000000, 0x080000, CRC(d0607829) SHA1(546c629ec22bb98202c7127ccb77df0b8f3a1966) )
+
+	ROM_REGION( 0x100000, "oki" , ROMREGION_ERASE00 ) // OKI6295 samples
 	ROM_LOAD("bsb_d11.bin", 0x000000, 0x080000, CRC(26bdc617) SHA1(993e7a52128fdd58f22d95521a629beb71ca7b91) ) // I haven't verified this dump.. but given how bad the rest is I'm not confident
 	ROM_RELOAD(0x80000,0x80000)
 ROM_END
 
 ROM_START( bubsymphu )
-	ROM_REGION(0x200000, "maincpu", 0) /* 68020 code */
+	ROM_REGION( 0x200000, "maincpu", 0 ) /* 68020 code */
 	ROM_LOAD32_BYTE("d90-12", 0x000000, 0x40000, CRC(9e523996) SHA1(c49a426f9865f96e8021c8ed9a6ac094c5e586b1) )
 	ROM_LOAD32_BYTE("d90-11", 0x000001, 0x40000, CRC(edfdbb7f) SHA1(698ad631d5b13661645f2c5ccd3e4fbf0248053c) )
 	ROM_LOAD32_BYTE("d90-10", 0x000002, 0x40000, CRC(8e957d3d) SHA1(5db31e5788483b802592e1092bf98df51ff4b70e) )
 	ROM_LOAD32_BYTE("d90-15", 0x000003, 0x40000, CRC(06182802) SHA1(c068ea8e8852033d0cf7bd4bca4b0411b7aebded) )
 
-	ROM_REGION(0x400000, "gfx1" , 0) /* Sprites */
+	ROM_REGION( 0x200000, "sprites" , 0) /* Sprites */
 	ROM_LOAD16_BYTE("d90-03", 0x000000, 0x100000, CRC(6fa894a1) SHA1(7c33e6d41e8928029b92d66557a3712b51c49c67) )
 	ROM_LOAD16_BYTE("d90-02", 0x000001, 0x100000, CRC(5ab04ca2) SHA1(6d87e7ca3167ff81a041cfedbbed84d51da997de) )
-	ROM_LOAD       ("d90-01", 0x300000, 0x100000, CRC(8aedb9e5) SHA1(fb49330f7985a829c9544ecfd0bc672494f29cf6) )
-	ROM_FILL       (          0x200000, 0x100000, 0x00 )
 
-	ROM_REGION(0x400000, "gfx2" , 0) /* Tiles */
-	ROM_LOAD16_BYTE("d90-08", 0x000000, 0x100000, CRC(25a4fb2c) SHA1(c8bf6fe2291c05386b32cd26bfcb379da756d7b5) )
-	ROM_LOAD16_BYTE("d90-07", 0x000001, 0x100000, CRC(b436b42d) SHA1(559827120273733147b260e0723054d926dbea5e) )
-	ROM_LOAD       ("d90-06", 0x300000, 0x100000, CRC(166a72b8) SHA1(7f70b8c960794322e1dc88e6600a2d13d948d873) )
-	ROM_FILL       (          0x200000, 0x100000, 0x00 )
+	ROM_REGION( 0x100000, "sprites_hi", 0 )
+	ROM_LOAD       ("d90-01", 0x000000, 0x100000, CRC(8aedb9e5) SHA1(fb49330f7985a829c9544ecfd0bc672494f29cf6) )
 
-	ROM_REGION(0x180000, "taito_en:audiocpu", 0) /* sound CPU */
+	ROM_REGION( 0x200000, "tilemap" , 0) /* Tiles */
+	ROM_LOAD32_WORD("d90-08", 0x000000, 0x100000, CRC(25a4fb2c) SHA1(c8bf6fe2291c05386b32cd26bfcb379da756d7b5) )
+	ROM_LOAD32_WORD("d90-07", 0x000002, 0x100000, CRC(b436b42d) SHA1(559827120273733147b260e0723054d926dbea5e) )
+
+	ROM_REGION( 0x100000, "tilemap_hi", 0 )
+	ROM_LOAD       ("d90-06", 0x000000, 0x100000, CRC(166a72b8) SHA1(7f70b8c960794322e1dc88e6600a2d13d948d873) )
+
+	ROM_REGION( 0x180000, "taito_en:audiocpu", 0 ) /* sound CPU */
 	ROM_LOAD16_BYTE("d90-13.ic32", 0x100000, 0x40000, CRC(6762bd90) SHA1(771db0382bc8dab2caf13d0fc20648366c685829) )
 	ROM_LOAD16_BYTE("d90-14.ic33", 0x100001, 0x40000, CRC(8e33357e) SHA1(68b81693c22e6357e37244f2a416818a81338138) )
 
-	ROM_REGION16_BE(0x800000, "ensoniq.0" , ROMREGION_ERASE00 ) // V2: 4 banks, only 2 populated
+	ROM_REGION16_BE( 0x800000, "ensoniq.0" , ROMREGION_ERASE00 ) // V2: 4 banks, only 2 populated
 	ROM_LOAD16_BYTE("d90-04", 0x000000, 0x200000, CRC(feee5fda) SHA1(b89354013ec4d34bcd51ecded412effa66dd2f2f) )    // C8 C9 CA CB
 	ROM_LOAD16_BYTE("d90-05", 0x400000, 0x200000, CRC(c192331f) SHA1(ebab05b3681c70b373bc06c1826be1cc397d3af7) )    // CC CD -std-
 ROM_END
 
 ROM_START( spcinvdj )
-	ROM_REGION(0x200000, "maincpu", 0) /* 68020 code */
+	ROM_REGION( 0x200000, "maincpu", 0 ) /* 68020 code */
 	ROM_LOAD32_BYTE("d93-04.bin", 0x000000, 0x20000, CRC(cd9a4e5c) SHA1(b163b8274570610af8697b1b38116dcf4c3593db) )
 	ROM_LOAD32_BYTE("d93-03.bin", 0x000001, 0x20000, CRC(0174bfc1) SHA1(133452f6a5bdf01b1b436077288a597734a8731a) )
 	ROM_LOAD32_BYTE("d93-02.bin", 0x000002, 0x20000, CRC(01922b31) SHA1(660c9c20e76a5f4094f1bfee9d75146f0829daeb) )
 	ROM_LOAD32_BYTE("d93-01.bin", 0x000003, 0x20000, CRC(4a74ab1c) SHA1(5f7ae70d8fa3f141239ed3de3a45c50e2d824864) )
 
-	ROM_REGION(0x200000, "gfx1" , 0) /* Sprites */
+	ROM_REGION( 0x100000, "sprites" , 0) /* Sprites */
 	ROM_LOAD16_BYTE("d93-07.12", 0x000000, 0x80000, CRC(8cf5b972) SHA1(75e383aed8548f4ac7d38f1f08bf33fae2a93064) )
 	ROM_LOAD16_BYTE("d93-08.08", 0x000001, 0x80000, CRC(4c11af2b) SHA1(e332372ab0d1322faa8d6d98f8a6e3bbf51d2008) )
-	ROM_FILL       (             0x100000, 0x100000,0x00 )
 
-	ROM_REGION(0x80000, "gfx2" , 0) /* Tiles */
-	ROM_LOAD16_BYTE("d93-09.47", 0x000000, 0x20000, CRC(9076f663) SHA1(c94e93e40926df33b6bb528e0ef30381631913d7) )
-	ROM_LOAD16_BYTE("d93-10.45", 0x000001, 0x20000, CRC(8a3f531b) SHA1(69f9971c45971018108a5d312d5bbcfd3caf9bd0) )
-	ROM_FILL       (             0x040000, 0x40000, 0x00 )
+	EMPTY_SPRITE_HIDATA(0x080000)
 
-	ROM_REGION(0x140000, "taito_en:audiocpu", 0) /* 68000 sound CPU */
+	ROM_REGION( 0x040000, "tilemap" , 0) /* Tiles */
+	ROM_LOAD32_WORD("d93-09.47", 0x000000, 0x20000, CRC(9076f663) SHA1(c94e93e40926df33b6bb528e0ef30381631913d7) )
+	ROM_LOAD32_WORD("d93-10.45", 0x000002, 0x20000, CRC(8a3f531b) SHA1(69f9971c45971018108a5d312d5bbcfd3caf9bd0) )
+
+	EMPTY_TILEMAP_HIDATA(0x020000)
+
+	ROM_REGION( 0x140000, "taito_en:audiocpu", 0 ) /* 68000 sound CPU */
 	ROM_LOAD16_BYTE("d93-05.bin", 0x100000, 0x20000, CRC(ff365596) SHA1(4cf2e0d6f42cf3fb69796be6092eff8a47f7f8b9) )
 	ROM_LOAD16_BYTE("d93-06.bin", 0x100001, 0x20000, CRC(ef7ad400) SHA1(01be403d575a543f089b910a5a8c381a6603e67e) )
 
-	ROM_REGION16_BE(0x400000, "ensoniq.0" , ROMREGION_ERASE00 ) // V2: 4 banks, only 1 populated
+	ROM_REGION16_BE( 0x400000, "ensoniq.0" , ROMREGION_ERASE00 ) // V2: 4 banks, only 1 populated
 	ROM_LOAD16_BYTE("d93-11.38", 0x000000, 0x80000, CRC(df5853de) SHA1(bb1ea604d44819dc7c82848c5bde9612f70f7528) )  // C8
 	ROM_LOAD16_BYTE("d93-12.39", 0x100000, 0x80000, CRC(b0f71d60) SHA1(35fc32764d9b82b1b40c5e9cc8e367cf842531a2) )  // C9
 	ROM_LOAD16_BYTE("d93-13.40", 0x200000, 0x80000, CRC(26312451) SHA1(9f947a11592fd8420fc581914bf16e7ade75390c) )  // -std-
@@ -2327,191 +2412,203 @@ ROM_START( spcinvdj )
 ROM_END
 
 ROM_START( pwrgoal )
-	ROM_REGION(0x200000, "maincpu", 0) /* 68020 code */
+	ROM_REGION( 0x200000, "maincpu", 0 ) /* 68020 code */
 	ROM_LOAD32_BYTE("d94-18.20", 0x000000, 0x40000, CRC(b92681c3) SHA1(0ca05a69d046668c878df3d2b7ae3172d748e290) )
 	ROM_LOAD32_BYTE("d94-17.19", 0x000001, 0x40000, CRC(6009333e) SHA1(4ab28f2d9e2b75adc668f5d9390e06086bbd97dc) )
 	ROM_LOAD32_BYTE("d94-16.18", 0x000002, 0x40000, CRC(c6dbc9c8) SHA1(4f096b59734db51eeddcf0649f2a6f11bdde9590) )
 	ROM_LOAD32_BYTE("d94-22.17", 0x000003, 0x40000, CRC(f672e487) SHA1(da62afc82aeae4aeeebbee0965cda3d84464ad09) )
 
-	ROM_REGION(0x1800000, "gfx1" , 0) /* Sprites */
+	ROM_REGION( 0xc00000, "sprites" , 0) /* Sprites */
 	ROM_LOAD16_BYTE("d94-09.bin", 0x0000000, 0x200000, CRC(425e6bec) SHA1(512508e7137fcdebdf2240dbbd37ea0cf1c4dcdc) )
 	ROM_LOAD16_BYTE("d94-08.bin", 0x0400000, 0x200000, CRC(bd909caf) SHA1(33952883afb8fe9b55dd258435af99881925e8d5) )
 	ROM_LOAD16_BYTE("d94-07.bin", 0x0800000, 0x200000, CRC(c8c95e49) SHA1(9bfdf63d6059b01a4cd5813239ba1bd98453a56b) )
 	ROM_LOAD16_BYTE("d94-06.bin", 0x0000001, 0x200000, CRC(0ed1df55) SHA1(10b22407ad0e03c37363783ee80f2cbf98a802a0) )
 	ROM_LOAD16_BYTE("d94-05.bin", 0x0400001, 0x200000, CRC(121c8542) SHA1(ec9b7e56c97a8b6ed0423f05b789ca89b1bb0d36) )
 	ROM_LOAD16_BYTE("d94-04.bin", 0x0800001, 0x200000, CRC(24958b50) SHA1(ea15ffa3a615e3e67c1bade6f6ef45424479115e) )
-	ROM_LOAD       ("d94-03.bin", 0x1200000, 0x200000, CRC(95e32072) SHA1(9797f65ecadc6b0f209bf262396315b61855c433) )
-	ROM_LOAD       ("d94-02.bin", 0x1400000, 0x200000, CRC(f460b9ac) SHA1(e36a812791bd0360380f397b1bc6c357391f585a) )
-	ROM_LOAD       ("d94-01.bin", 0x1600000, 0x200000, CRC(410ffccd) SHA1(0cab00c8e9de92ad81ac61f25bbe8bfd60f45ae0) )
-	ROM_FILL       (              0xc00000, 0x600000,0x00 )
 
-	ROM_REGION(0x400000, "gfx2" , 0) /* Tiles */
-	ROM_LOAD16_BYTE("d94-14.bin", 0x000000, 0x100000, CRC(b8ba5761) SHA1(7966ef3166d7d6b9913478eaef5dd4a2bf7d5a06) )
-	ROM_LOAD16_BYTE("d94-13.bin", 0x000001, 0x100000, CRC(cafc68ce) SHA1(5c1f49951e83d812f0c7697751f4876ab1d08141) )
-	ROM_LOAD       ("d94-12.bin", 0x300000, 0x100000, CRC(47064189) SHA1(99ceeb326dcc2e1c3acba8ac14d94dcb17c6e032) )
-	ROM_FILL       (              0x200000, 0x100000,0x00 )
+	ROM_REGION( 0x600000, "sprites_hi", 0 )
+	ROM_LOAD       ("d94-03.bin", 0x0000000, 0x200000, CRC(95e32072) SHA1(9797f65ecadc6b0f209bf262396315b61855c433) )
+	ROM_LOAD       ("d94-02.bin", 0x0200000, 0x200000, CRC(f460b9ac) SHA1(e36a812791bd0360380f397b1bc6c357391f585a) )
+	ROM_LOAD       ("d94-01.bin", 0x0400000, 0x200000, CRC(410ffccd) SHA1(0cab00c8e9de92ad81ac61f25bbe8bfd60f45ae0) )
 
-	ROM_REGION(0x180000, "taito_en:audiocpu", 0) /* 68000 sound CPU */
+	ROM_REGION( 0x200000, "tilemap" , 0) /* Tiles */
+	ROM_LOAD32_WORD("d94-14.bin", 0x000000, 0x100000, CRC(b8ba5761) SHA1(7966ef3166d7d6b9913478eaef5dd4a2bf7d5a06) )
+	ROM_LOAD32_WORD("d94-13.bin", 0x000002, 0x100000, CRC(cafc68ce) SHA1(5c1f49951e83d812f0c7697751f4876ab1d08141) )
+
+	ROM_REGION( 0x100000, "tilemap_hi", 0 )
+	ROM_LOAD       ("d94-12.bin", 0x000000, 0x100000, CRC(47064189) SHA1(99ceeb326dcc2e1c3acba8ac14d94dcb17c6e032) )
+
+	ROM_REGION( 0x180000, "taito_en:audiocpu", 0 ) /* 68000 sound CPU */
 	ROM_LOAD16_BYTE("d94-19.bin", 0x100000, 0x40000, CRC(c93dbcf4) SHA1(413520e652d809651aff9b1b74e6353112d34c12) ) /* Over dump?? 0x20000-0x3ffff == 0xFF */
 	ROM_LOAD16_BYTE("d94-20.bin", 0x100001, 0x40000, CRC(f232bf64) SHA1(bbfeae0785fc49c12aa6d9b1bd6ff7c8515f8fe7) ) /* Over dump?? 0x20000-0x3ffff == 0xFF */
 
-	ROM_REGION16_BE(0x800000, "ensoniq.0" , ROMREGION_ERASE00 ) // V2: 4 banks, only 2 populated
+	ROM_REGION16_BE( 0x800000, "ensoniq.0" , ROMREGION_ERASE00 ) // V2: 4 banks, only 2 populated
 	ROM_LOAD16_BYTE("d94-10.bin", 0x000000, 0x200000, CRC(a22563ae) SHA1(85f2a4ca5e085ac1d4c15feb737229764697ae85) )    // C8 C9 CA CB
 	ROM_LOAD16_BYTE("d94-11.bin", 0x400000, 0x200000, CRC(61ed83fa) SHA1(f6ca60b7af61fd3ac01a987f949d7a7bc96e43ff) )    // CD CE -std-
 ROM_END
 
 ROM_START( hthero95 )
-	ROM_REGION(0x200000, "maincpu", 0) /* 68020 code */
+	ROM_REGION( 0x200000, "maincpu", 0 ) /* 68020 code */
 	ROM_LOAD32_BYTE("d94-18.20", 0x000000, 0x40000, CRC(b92681c3) SHA1(0ca05a69d046668c878df3d2b7ae3172d748e290) )
 	ROM_LOAD32_BYTE("d94-17.19", 0x000001, 0x40000, CRC(6009333e) SHA1(4ab28f2d9e2b75adc668f5d9390e06086bbd97dc) )
 	ROM_LOAD32_BYTE("d94-16.18", 0x000002, 0x40000, CRC(c6dbc9c8) SHA1(4f096b59734db51eeddcf0649f2a6f11bdde9590) )
 	ROM_LOAD32_BYTE("d94-15.17", 0x000003, 0x40000, CRC(187c85ab) SHA1(8270930b95fafe5ad92ea978c1558c491d9668b0) )
 
-	ROM_REGION(0x1800000, "gfx1" , 0) /* Sprites */
+	ROM_REGION( 0xc00000, "sprites" , 0) /* Sprites */
 	ROM_LOAD16_BYTE("d94-09.bin", 0x0000000, 0x200000, CRC(425e6bec) SHA1(512508e7137fcdebdf2240dbbd37ea0cf1c4dcdc) )
 	ROM_LOAD16_BYTE("d94-08.bin", 0x0400000, 0x200000, CRC(bd909caf) SHA1(33952883afb8fe9b55dd258435af99881925e8d5) )
 	ROM_LOAD16_BYTE("d94-07.bin", 0x0800000, 0x200000, CRC(c8c95e49) SHA1(9bfdf63d6059b01a4cd5813239ba1bd98453a56b) )
 	ROM_LOAD16_BYTE("d94-06.bin", 0x0000001, 0x200000, CRC(0ed1df55) SHA1(10b22407ad0e03c37363783ee80f2cbf98a802a0) )
 	ROM_LOAD16_BYTE("d94-05.bin", 0x0400001, 0x200000, CRC(121c8542) SHA1(ec9b7e56c97a8b6ed0423f05b789ca89b1bb0d36) )
 	ROM_LOAD16_BYTE("d94-04.bin", 0x0800001, 0x200000, CRC(24958b50) SHA1(ea15ffa3a615e3e67c1bade6f6ef45424479115e) )
-	ROM_LOAD       ("d94-03.bin", 0x1200000, 0x200000, CRC(95e32072) SHA1(9797f65ecadc6b0f209bf262396315b61855c433) )
-	ROM_LOAD       ("d94-02.bin", 0x1400000, 0x200000, CRC(f460b9ac) SHA1(e36a812791bd0360380f397b1bc6c357391f585a) )
-	ROM_LOAD       ("d94-01.bin", 0x1600000, 0x200000, CRC(410ffccd) SHA1(0cab00c8e9de92ad81ac61f25bbe8bfd60f45ae0) )
-	ROM_FILL       (              0xc00000, 0x600000,0x00 )
 
-	ROM_REGION(0x400000, "gfx2" , 0) /* Tiles */
-	ROM_LOAD16_BYTE("d94-14.bin", 0x000000, 0x100000, CRC(b8ba5761) SHA1(7966ef3166d7d6b9913478eaef5dd4a2bf7d5a06) )
-	ROM_LOAD16_BYTE("d94-13.bin", 0x000001, 0x100000, CRC(cafc68ce) SHA1(5c1f49951e83d812f0c7697751f4876ab1d08141) )
-	ROM_LOAD       ("d94-12.bin", 0x300000, 0x100000, CRC(47064189) SHA1(99ceeb326dcc2e1c3acba8ac14d94dcb17c6e032) )
-	ROM_FILL       (              0x200000, 0x100000,0x00 )
+	ROM_REGION( 0x600000, "sprites_hi", 0 )
+	ROM_LOAD       ("d94-03.bin", 0x0000000, 0x200000, CRC(95e32072) SHA1(9797f65ecadc6b0f209bf262396315b61855c433) )
+	ROM_LOAD       ("d94-02.bin", 0x0200000, 0x200000, CRC(f460b9ac) SHA1(e36a812791bd0360380f397b1bc6c357391f585a) )
+	ROM_LOAD       ("d94-01.bin", 0x0400000, 0x200000, CRC(410ffccd) SHA1(0cab00c8e9de92ad81ac61f25bbe8bfd60f45ae0) )
 
-	ROM_REGION(0x180000, "taito_en:audiocpu", 0) /* 68000 sound CPU */
+	ROM_REGION( 0x200000, "tilemap" , 0) /* Tiles */
+	ROM_LOAD32_WORD("d94-14.bin", 0x000000, 0x100000, CRC(b8ba5761) SHA1(7966ef3166d7d6b9913478eaef5dd4a2bf7d5a06) )
+	ROM_LOAD32_WORD("d94-13.bin", 0x000002, 0x100000, CRC(cafc68ce) SHA1(5c1f49951e83d812f0c7697751f4876ab1d08141) )
+
+	ROM_REGION( 0x100000, "tilemap_hi", 0 )
+	ROM_LOAD       ("d94-12.bin", 0x000000, 0x100000, CRC(47064189) SHA1(99ceeb326dcc2e1c3acba8ac14d94dcb17c6e032) )
+
+	ROM_REGION( 0x180000, "taito_en:audiocpu", 0 ) /* 68000 sound CPU */
 	ROM_LOAD16_BYTE("d94-19.bin", 0x100000, 0x40000, CRC(c93dbcf4) SHA1(413520e652d809651aff9b1b74e6353112d34c12) ) /* Over dump?? 0x20000-0x3ffff == 0xFF */
 	ROM_LOAD16_BYTE("d94-20.bin", 0x100001, 0x40000, CRC(f232bf64) SHA1(bbfeae0785fc49c12aa6d9b1bd6ff7c8515f8fe7) ) /* Over dump?? 0x20000-0x3ffff == 0xFF */
 
-	ROM_REGION16_BE(0x800000, "ensoniq.0" , ROMREGION_ERASE00 ) // V2: 4 banks, only 2 populated
+	ROM_REGION16_BE( 0x800000, "ensoniq.0" , ROMREGION_ERASE00 ) // V2: 4 banks, only 2 populated
 	ROM_LOAD16_BYTE("d94-10.bin", 0x000000, 0x200000, CRC(a22563ae) SHA1(85f2a4ca5e085ac1d4c15feb737229764697ae85) )    // C8 C9 CA CB
 	ROM_LOAD16_BYTE("d94-11.bin", 0x400000, 0x200000, CRC(61ed83fa) SHA1(f6ca60b7af61fd3ac01a987f949d7a7bc96e43ff) )    // CD CE -std-
 ROM_END
 
 ROM_START( hthero95u )
-	ROM_REGION(0x200000, "maincpu", 0) /* 68020 code */
+	ROM_REGION( 0x200000, "maincpu", 0 ) /* 68020 code */
 	ROM_LOAD32_BYTE("d94-18.20", 0x000000, 0x40000, CRC(b92681c3) SHA1(0ca05a69d046668c878df3d2b7ae3172d748e290) )
 	ROM_LOAD32_BYTE("d94-17.19", 0x000001, 0x40000, CRC(6009333e) SHA1(4ab28f2d9e2b75adc668f5d9390e06086bbd97dc) )
 	ROM_LOAD32_BYTE("d94-16.18", 0x000002, 0x40000, CRC(c6dbc9c8) SHA1(4f096b59734db51eeddcf0649f2a6f11bdde9590) )
 	ROM_LOAD32_BYTE("d94-21.17", 0x000003, 0x40000, CRC(8175d411) SHA1(b93ffef510ecfaced6cae07ea6cd549af7473049) )
 
-	ROM_REGION(0x1800000, "gfx1" , 0) /* Sprites */
+	ROM_REGION( 0xc00000, "sprites" , 0) /* Sprites */
 	ROM_LOAD16_BYTE("d94-09.bin", 0x0000000, 0x200000, CRC(425e6bec) SHA1(512508e7137fcdebdf2240dbbd37ea0cf1c4dcdc) )
 	ROM_LOAD16_BYTE("d94-08.bin", 0x0400000, 0x200000, CRC(bd909caf) SHA1(33952883afb8fe9b55dd258435af99881925e8d5) )
 	ROM_LOAD16_BYTE("d94-07.bin", 0x0800000, 0x200000, CRC(c8c95e49) SHA1(9bfdf63d6059b01a4cd5813239ba1bd98453a56b) )
 	ROM_LOAD16_BYTE("d94-06.bin", 0x0000001, 0x200000, CRC(0ed1df55) SHA1(10b22407ad0e03c37363783ee80f2cbf98a802a0) )
 	ROM_LOAD16_BYTE("d94-05.bin", 0x0400001, 0x200000, CRC(121c8542) SHA1(ec9b7e56c97a8b6ed0423f05b789ca89b1bb0d36) )
 	ROM_LOAD16_BYTE("d94-04.bin", 0x0800001, 0x200000, CRC(24958b50) SHA1(ea15ffa3a615e3e67c1bade6f6ef45424479115e) )
-	ROM_LOAD       ("d94-03.bin", 0x1200000, 0x200000, CRC(95e32072) SHA1(9797f65ecadc6b0f209bf262396315b61855c433) )
-	ROM_LOAD       ("d94-02.bin", 0x1400000, 0x200000, CRC(f460b9ac) SHA1(e36a812791bd0360380f397b1bc6c357391f585a) )
-	ROM_LOAD       ("d94-01.bin", 0x1600000, 0x200000, CRC(410ffccd) SHA1(0cab00c8e9de92ad81ac61f25bbe8bfd60f45ae0) )
-	ROM_FILL       (              0xc00000, 0x600000,0x00 )
 
-	ROM_REGION(0x400000, "gfx2" , 0) /* Tiles */
-	ROM_LOAD16_BYTE("d94-14.bin", 0x000000, 0x100000, CRC(b8ba5761) SHA1(7966ef3166d7d6b9913478eaef5dd4a2bf7d5a06) )
-	ROM_LOAD16_BYTE("d94-13.bin", 0x000001, 0x100000, CRC(cafc68ce) SHA1(5c1f49951e83d812f0c7697751f4876ab1d08141) )
-	ROM_LOAD       ("d94-12.bin", 0x300000, 0x100000, CRC(47064189) SHA1(99ceeb326dcc2e1c3acba8ac14d94dcb17c6e032) )
-	ROM_FILL       (              0x200000, 0x100000,0x00 )
+	ROM_REGION( 0x600000, "sprites_hi", 0 )
+	ROM_LOAD       ("d94-03.bin", 0x0000000, 0x200000, CRC(95e32072) SHA1(9797f65ecadc6b0f209bf262396315b61855c433) )
+	ROM_LOAD       ("d94-02.bin", 0x0200000, 0x200000, CRC(f460b9ac) SHA1(e36a812791bd0360380f397b1bc6c357391f585a) )
+	ROM_LOAD       ("d94-01.bin", 0x0400000, 0x200000, CRC(410ffccd) SHA1(0cab00c8e9de92ad81ac61f25bbe8bfd60f45ae0) )
 
-	ROM_REGION(0x180000, "taito_en:audiocpu", 0) /* 68000 sound CPU */
+	ROM_REGION( 0x200000, "tilemap" , 0) /* Tiles */
+	ROM_LOAD32_WORD("d94-14.bin", 0x000000, 0x100000, CRC(b8ba5761) SHA1(7966ef3166d7d6b9913478eaef5dd4a2bf7d5a06) )
+	ROM_LOAD32_WORD("d94-13.bin", 0x000002, 0x100000, CRC(cafc68ce) SHA1(5c1f49951e83d812f0c7697751f4876ab1d08141) )
+
+	ROM_REGION( 0x100000, "tilemap_hi", 0 )
+	ROM_LOAD       ("d94-12.bin", 0x000000, 0x100000, CRC(47064189) SHA1(99ceeb326dcc2e1c3acba8ac14d94dcb17c6e032) )
+
+	ROM_REGION( 0x180000, "taito_en:audiocpu", 0 ) /* 68000 sound CPU */
 	ROM_LOAD16_BYTE("d94-19.bin", 0x100000, 0x40000, CRC(c93dbcf4) SHA1(413520e652d809651aff9b1b74e6353112d34c12) ) /* Over dump?? 0x20000-0x3ffff == 0xFF */
 	ROM_LOAD16_BYTE("d94-20.bin", 0x100001, 0x40000, CRC(f232bf64) SHA1(bbfeae0785fc49c12aa6d9b1bd6ff7c8515f8fe7) ) /* Over dump?? 0x20000-0x3ffff == 0xFF */
 
-	ROM_REGION16_BE(0x800000, "ensoniq.0" , ROMREGION_ERASE00 ) // V2: 4 banks, only 2 populated
+	ROM_REGION16_BE( 0x800000, "ensoniq.0" , ROMREGION_ERASE00 ) // V2: 4 banks, only 2 populated
 	ROM_LOAD16_BYTE("d94-10.bin", 0x000000, 0x200000, CRC(a22563ae) SHA1(85f2a4ca5e085ac1d4c15feb737229764697ae85) )    // C8 C9 CA CB
 	ROM_LOAD16_BYTE("d94-11.bin", 0x400000, 0x200000, CRC(61ed83fa) SHA1(f6ca60b7af61fd3ac01a987f949d7a7bc96e43ff) )    // CD CE -std-
 ROM_END
 
 ROM_START( hthero95a )
-	ROM_REGION(0x200000, "maincpu", 0) /* 68020 code */
+	ROM_REGION( 0x200000, "maincpu", 0 ) /* 68020 code */
 	ROM_LOAD32_BYTE("d94-26.20", 0x000000, 0x40000, CRC(3170fa0b) SHA1(75ce8eacbf64e370c5967541102e34d8aa3f815a) )
 	ROM_LOAD32_BYTE("d94-25.19", 0x000001, 0x40000, CRC(dfd5cbf9) SHA1(56b15eaf1032fa32c1c08ca0f9ab9701af12cbe4) )
 	ROM_LOAD32_BYTE("d94-24.18", 0x000002, 0x40000, CRC(d97269cc) SHA1(bbbd40368c713ce5baaaca3735ca41e0e72e8dc0) )
 	ROM_LOAD32_BYTE("d94-23.17", 0x000003, 0x40000, CRC(71092708) SHA1(ceb4bc42406c4627d3046b56958344496688b060) )
 
-	ROM_REGION(0x1800000, "gfx1" , 0) /* Sprites */
+	ROM_REGION( 0xc00000, "sprites" , 0) /* Sprites */
 	ROM_LOAD16_BYTE("d94-09.bin", 0x0000000, 0x200000, CRC(425e6bec) SHA1(512508e7137fcdebdf2240dbbd37ea0cf1c4dcdc) )
 	ROM_LOAD16_BYTE("d94-08.bin", 0x0400000, 0x200000, CRC(bd909caf) SHA1(33952883afb8fe9b55dd258435af99881925e8d5) )
 	ROM_LOAD16_BYTE("d94-07.bin", 0x0800000, 0x200000, CRC(c8c95e49) SHA1(9bfdf63d6059b01a4cd5813239ba1bd98453a56b) )
 	ROM_LOAD16_BYTE("d94-06.bin", 0x0000001, 0x200000, CRC(0ed1df55) SHA1(10b22407ad0e03c37363783ee80f2cbf98a802a0) )
 	ROM_LOAD16_BYTE("d94-05.bin", 0x0400001, 0x200000, CRC(121c8542) SHA1(ec9b7e56c97a8b6ed0423f05b789ca89b1bb0d36) )
 	ROM_LOAD16_BYTE("d94-04.bin", 0x0800001, 0x200000, CRC(24958b50) SHA1(ea15ffa3a615e3e67c1bade6f6ef45424479115e) )
-	ROM_LOAD       ("d94-03.bin", 0x1200000, 0x200000, CRC(95e32072) SHA1(9797f65ecadc6b0f209bf262396315b61855c433) )
-	ROM_LOAD       ("d94-02.bin", 0x1400000, 0x200000, CRC(f460b9ac) SHA1(e36a812791bd0360380f397b1bc6c357391f585a) )
-	ROM_LOAD       ("d94-01.bin", 0x1600000, 0x200000, CRC(410ffccd) SHA1(0cab00c8e9de92ad81ac61f25bbe8bfd60f45ae0) )
-	ROM_FILL       (              0xc00000, 0x600000,0x00 )
 
-	ROM_REGION(0x400000, "gfx2" , 0) /* Tiles */
-	ROM_LOAD16_BYTE("d94-14.bin", 0x000000, 0x100000, CRC(b8ba5761) SHA1(7966ef3166d7d6b9913478eaef5dd4a2bf7d5a06) )
-	ROM_LOAD16_BYTE("d94-13.bin", 0x000001, 0x100000, CRC(cafc68ce) SHA1(5c1f49951e83d812f0c7697751f4876ab1d08141) )
-	ROM_LOAD       ("d94-12.bin", 0x300000, 0x100000, CRC(47064189) SHA1(99ceeb326dcc2e1c3acba8ac14d94dcb17c6e032) )
-	ROM_FILL       (              0x200000, 0x100000,0x00 )
+	ROM_REGION( 0x600000, "sprites_hi", 0 )
+	ROM_LOAD       ("d94-03.bin", 0x0000000, 0x200000, CRC(95e32072) SHA1(9797f65ecadc6b0f209bf262396315b61855c433) )
+	ROM_LOAD       ("d94-02.bin", 0x0200000, 0x200000, CRC(f460b9ac) SHA1(e36a812791bd0360380f397b1bc6c357391f585a) )
+	ROM_LOAD       ("d94-01.bin", 0x0400000, 0x200000, CRC(410ffccd) SHA1(0cab00c8e9de92ad81ac61f25bbe8bfd60f45ae0) )
 
-	ROM_REGION(0x180000, "taito_en:audiocpu", 0) /* 68000 sound CPU */
+	ROM_REGION( 0x200000, "tilemap" , 0) /* Tiles */
+	ROM_LOAD32_WORD("d94-14.bin", 0x000000, 0x100000, CRC(b8ba5761) SHA1(7966ef3166d7d6b9913478eaef5dd4a2bf7d5a06) )
+	ROM_LOAD32_WORD("d94-13.bin", 0x000002, 0x100000, CRC(cafc68ce) SHA1(5c1f49951e83d812f0c7697751f4876ab1d08141) )
+
+	ROM_REGION( 0x100000, "tilemap_hi", 0 )
+	ROM_LOAD       ("d94-12.bin", 0x000000, 0x100000, CRC(47064189) SHA1(99ceeb326dcc2e1c3acba8ac14d94dcb17c6e032) )
+
+	ROM_REGION( 0x180000, "taito_en:audiocpu", 0 ) /* 68000 sound CPU */
 	ROM_LOAD16_BYTE("d94-19.bin", 0x100000, 0x40000, CRC(c93dbcf4) SHA1(413520e652d809651aff9b1b74e6353112d34c12) ) /* Over dump?? 0x20000-0x3ffff == 0xFF */
 	ROM_LOAD16_BYTE("d94-20.bin", 0x100001, 0x40000, CRC(f232bf64) SHA1(bbfeae0785fc49c12aa6d9b1bd6ff7c8515f8fe7) ) /* Over dump?? 0x20000-0x3ffff == 0xFF */
 
-	ROM_REGION16_BE(0x800000, "ensoniq.0" , ROMREGION_ERASE00 ) // V2: 4 banks, only 2 populated
+	ROM_REGION16_BE( 0x800000, "ensoniq.0" , ROMREGION_ERASE00 ) // V2: 4 banks, only 2 populated
 	ROM_LOAD16_BYTE("d94-10.bin", 0x000000, 0x200000, CRC(a22563ae) SHA1(85f2a4ca5e085ac1d4c15feb737229764697ae85) )    // C8 C9 CA CB
 	ROM_LOAD16_BYTE("d94-11.bin", 0x400000, 0x200000, CRC(61ed83fa) SHA1(f6ca60b7af61fd3ac01a987f949d7a7bc96e43ff) )    // CD CE -std-
 ROM_END
 
 ROM_START( qtheater )
-	ROM_REGION(0x200000, "maincpu", 0) /* 68020 code */
+	ROM_REGION( 0x200000, "maincpu", 0 ) /* 68020 code */
 	ROM_LOAD32_BYTE("d95-12.20", 0x000000, 0x80000, CRC(fcee76ee) SHA1(9ffeeda656368d1c065ba1cdb51a8665f7f7262a) )
 	ROM_LOAD32_BYTE("d95-11.19", 0x000001, 0x80000, CRC(b3c2b8d5) SHA1(536c13d71e858309f41e7c387cd988e8fe356bee) )
 	ROM_LOAD32_BYTE("d95-10.18", 0x000002, 0x80000, CRC(85236e40) SHA1(727c8f7361d7e0af3239bb0c0e7778ab30b12739) )
 	ROM_LOAD32_BYTE("d95-09.17", 0x000003, 0x80000, CRC(f456519c) SHA1(9226d33d8d16a7d1054c1183ac013fc5caf229e2) )
 
-	ROM_REGION(0x800000, "gfx1" , 0) /* Sprites */
+	ROM_REGION( 0x400000, "sprites" , 0) /* Sprites */
 	ROM_LOAD16_BYTE("d95-02.12", 0x000000, 0x200000, CRC(74ce6f3e) SHA1(eb03f44889bd2d5705e9d8cda6516b39758d9554) )
 	ROM_LOAD16_BYTE("d95-01.8",  0x000001, 0x200000, CRC(141beb7d) SHA1(bba91f47f68367e2bb3d89298cb62fac2d4edf7b) )
-	ROM_FILL       (             0x400000, 0x400000, 0x00 )
 
-	ROM_REGION(0x800000, "gfx2" , 0) /* Tiles */
-	ROM_LOAD16_BYTE("d95-06.47", 0x000000, 0x200000, CRC(70a0dcbb) SHA1(b1abe6a9a4afe55201229a62bae11ad1d96ca244) )
-	ROM_LOAD16_BYTE("d95-05.45", 0x000001, 0x200000, CRC(1a1a852b) SHA1(89827485a31af4e2457775a5d16f747a764b6d67) )
-	ROM_FILL       (             0x400000, 0x400000, 0x00 )
+	EMPTY_SPRITE_HIDATA(0x200000)
 
-	ROM_REGION(0x180000, "taito_en:audiocpu", 0) /* 68000 sound CPU */
+	ROM_REGION( 0x400000, "tilemap" , 0) /* Tiles */
+	ROM_LOAD32_WORD("d95-06.47", 0x000000, 0x200000, CRC(70a0dcbb) SHA1(b1abe6a9a4afe55201229a62bae11ad1d96ca244) )
+	ROM_LOAD32_WORD("d95-05.45", 0x000002, 0x200000, CRC(1a1a852b) SHA1(89827485a31af4e2457775a5d16f747a764b6d67) )
+
+	EMPTY_TILEMAP_HIDATA(0x200000)
+
+	ROM_REGION( 0x180000, "taito_en:audiocpu", 0 ) /* 68000 sound CPU */
 	ROM_LOAD16_BYTE("d95-07.32", 0x100000, 0x40000, CRC(3c201d70) SHA1(89fe4d363f4e1a847ba7d2894a2092708b287a33) )
 	ROM_LOAD16_BYTE("d95-08.33", 0x100001, 0x40000, CRC(01c23354) SHA1(7b332edc844b1b1c1513e879215089987645fa3f) )
 
-	ROM_REGION16_BE(0x800000, "ensoniq.0" , ROMREGION_ERASE00 ) // V2: 4 banks, only 2 populated
+	ROM_REGION16_BE( 0x800000, "ensoniq.0" , ROMREGION_ERASE00 ) // V2: 4 banks, only 2 populated
 	ROM_LOAD16_BYTE("d95-03.38", 0x000000, 0x200000, CRC(4149ea67) SHA1(35fc9e60cd368c6eab20e23deb581aa4f46e164e) ) // C8 C9 CA CB
 	ROM_LOAD16_BYTE("d95-04.41", 0x400000, 0x200000, CRC(e9049d16) SHA1(ffa7dfc5d1cb82a601bad26b634c993aedda7803) ) // CC CD -std-
 ROM_END
 
 ROM_START( spcinv95u )
-	ROM_REGION(0x200000, "maincpu", 0) /* 68020 code */
+	ROM_REGION( 0x200000, "maincpu", 0 ) /* 68020 code */
 	ROM_LOAD32_BYTE("e06-14.20", 0x000000, 0x20000, CRC(71ba7f00) SHA1(6b1d994c8319778aad3bec7bf7b24dc4944a36f0) )
 	ROM_LOAD32_BYTE("e06-13.19", 0x000001, 0x20000, CRC(f506ba4b) SHA1(551f9e87d2bfd513998648b175b63677cd6bdd74) )
 	ROM_LOAD32_BYTE("e06-12.18", 0x000002, 0x20000, CRC(06cbd72b) SHA1(0c8e11bd5f3fcf7451908c53e74ae545a0d97640) )
 	ROM_LOAD32_BYTE("e06-15.17", 0x000003, 0x20000, CRC(a6ec0103) SHA1(4f524a6b52bbdb370b8f98d26e7446da943e3edd) )
 
-	ROM_REGION(0x400000, "gfx1" , 0) /* Sprites */
+	ROM_REGION( 0x200000, "sprites" , 0) /* Sprites */
 	ROM_LOAD16_BYTE("e06-03", 0x000000, 0x100000, CRC(a24070ef) SHA1(9b6ac7852114c606e871a08cfb3b9e1081ac7030) )
 	ROM_LOAD16_BYTE("e06-02", 0x000001, 0x100000, CRC(8f646dea) SHA1(07cd79671f36df1a5bbf2434e92a601351a36259) )
-	ROM_LOAD       ("e06-01", 0x300000, 0x100000, CRC(51721b15) SHA1(448a9a7f3631072d8987351f5c0b8dd2c908d266) )
-	ROM_FILL       (          0x200000, 0x100000, 0x00 )
 
-	ROM_REGION(0x400000, "gfx2" , 0) /* Tiles */
-	ROM_LOAD16_BYTE("e06-08", 0x000000, 0x100000, CRC(72ae2fbf) SHA1(7fa7ec94a8031342a2446fb8eca0d89ecfd2fa4f) )
-	ROM_LOAD16_BYTE("e06-07", 0x000001, 0x100000, CRC(4b02e8f5) SHA1(02d8a97da52f9ba4033b8f0c3f455a908a9dce89) )
-	ROM_LOAD       ("e06-06", 0x300000, 0x100000, CRC(9380db3c) SHA1(83f5a46a01b9c15499e0dc2222df496d26baa0d4) )
-	ROM_FILL       (          0x200000, 0x100000, 0x00 )
+	ROM_REGION( 0x100000, "sprites_hi", 0 )
+	ROM_LOAD       ("e06-01", 0x000000, 0x100000, CRC(51721b15) SHA1(448a9a7f3631072d8987351f5c0b8dd2c908d266) )
 
-	ROM_REGION(0x180000, "taito_en:audiocpu", 0) /* 68000 sound CPU */
+	ROM_REGION( 0x200000, "tilemap" , 0) /* Tiles */
+	ROM_LOAD32_WORD("e06-08", 0x000000, 0x100000, CRC(72ae2fbf) SHA1(7fa7ec94a8031342a2446fb8eca0d89ecfd2fa4f) )
+	ROM_LOAD32_WORD("e06-07", 0x000002, 0x100000, CRC(4b02e8f5) SHA1(02d8a97da52f9ba4033b8f0c3f455a908a9dce89) )
+
+	ROM_REGION( 0x100000, "tilemap_hi", 0 )
+	ROM_LOAD       ("e06-06", 0x000000, 0x100000, CRC(9380db3c) SHA1(83f5a46a01b9c15499e0dc2222df496d26baa0d4) )
+
+	ROM_REGION( 0x180000, "taito_en:audiocpu", 0 ) /* 68000 sound CPU */
 	ROM_LOAD16_BYTE("e06-09.32", 0x100000, 0x40000, CRC(9bcafc87) SHA1(10b3f6da00a41550fe6a705232f0e33fda3c7e7c) )
 	ROM_LOAD16_BYTE("e06-10.33", 0x100001, 0x40000, CRC(b752b61f) SHA1(e948a8af19c70ba8b8e908c869bc88ed0cac8420) )
 
-	ROM_REGION16_BE(0x800000, "ensoniq.0" , ROMREGION_ERASE00 ) // V2: 4 banks, only 2 populated
+	ROM_REGION16_BE( 0x800000, "ensoniq.0" , ROMREGION_ERASE00 ) // V2: 4 banks, only 2 populated
 	ROM_LOAD16_BYTE("e06-04", 0x000000, 0x200000, CRC(1dac29df) SHA1(ed68a41def148dcf4057cfac87a2a563c6882e1d) )    // C8 C9 CA CB
 	ROM_LOAD16_BYTE("e06-05", 0x400000, 0x200000, CRC(f370ff15) SHA1(4bc464d1c3a28326c8b1ae2036387954cb1dd813) )    // CC CD CE CF
 
@@ -2524,29 +2621,31 @@ ROM_START( spcinv95u )
 ROM_END
 
 ROM_START( spcinv95 )
-	ROM_REGION(0x200000, "maincpu", 0) /* 68020 code */
+	ROM_REGION( 0x200000, "maincpu", 0 ) /* 68020 code */
 	ROM_LOAD32_BYTE("e06-14.20", 0x000000, 0x20000, CRC(71ba7f00) SHA1(6b1d994c8319778aad3bec7bf7b24dc4944a36f0) )
 	ROM_LOAD32_BYTE("e06-13.19", 0x000001, 0x20000, CRC(f506ba4b) SHA1(551f9e87d2bfd513998648b175b63677cd6bdd74) )
 	ROM_LOAD32_BYTE("e06-12.18", 0x000002, 0x20000, CRC(06cbd72b) SHA1(0c8e11bd5f3fcf7451908c53e74ae545a0d97640) )
 	ROM_LOAD32_BYTE("e06-16.17", 0x000003, 0x20000, CRC(d1eb3195) SHA1(40c5e326e8dd9a892abdab952f853799f26601b7) )
 
-	ROM_REGION(0x400000, "gfx1" , 0) /* Sprites */
+	ROM_REGION( 0x200000, "sprites" , 0) /* Sprites */
 	ROM_LOAD16_BYTE("e06-03", 0x000000, 0x100000, CRC(a24070ef) SHA1(9b6ac7852114c606e871a08cfb3b9e1081ac7030) )
 	ROM_LOAD16_BYTE("e06-02", 0x000001, 0x100000, CRC(8f646dea) SHA1(07cd79671f36df1a5bbf2434e92a601351a36259) )
-	ROM_LOAD       ("e06-01", 0x300000, 0x100000, CRC(51721b15) SHA1(448a9a7f3631072d8987351f5c0b8dd2c908d266) )
-	ROM_FILL       (          0x200000, 0x100000, 0x00 )
 
-	ROM_REGION(0x400000, "gfx2" , 0) /* Tiles */
-	ROM_LOAD16_BYTE("e06-08", 0x000000, 0x100000, CRC(72ae2fbf) SHA1(7fa7ec94a8031342a2446fb8eca0d89ecfd2fa4f) )
-	ROM_LOAD16_BYTE("e06-07", 0x000001, 0x100000, CRC(4b02e8f5) SHA1(02d8a97da52f9ba4033b8f0c3f455a908a9dce89) )
-	ROM_LOAD       ("e06-06", 0x300000, 0x100000, CRC(9380db3c) SHA1(83f5a46a01b9c15499e0dc2222df496d26baa0d4) )
-	ROM_FILL       (          0x200000, 0x100000, 0x00 )
+	ROM_REGION( 0x100000, "sprites_hi", 0 )
+	ROM_LOAD       ("e06-01", 0x000000, 0x100000, CRC(51721b15) SHA1(448a9a7f3631072d8987351f5c0b8dd2c908d266) )
 
-	ROM_REGION(0x180000, "taito_en:audiocpu", 0) /* 68000 sound CPU */
+	ROM_REGION( 0x200000, "tilemap" , 0) /* Tiles */
+	ROM_LOAD32_WORD("e06-08", 0x000000, 0x100000, CRC(72ae2fbf) SHA1(7fa7ec94a8031342a2446fb8eca0d89ecfd2fa4f) )
+	ROM_LOAD32_WORD("e06-07", 0x000002, 0x100000, CRC(4b02e8f5) SHA1(02d8a97da52f9ba4033b8f0c3f455a908a9dce89) )
+
+	ROM_REGION( 0x100000, "tilemap_hi", 0 )
+	ROM_LOAD       ("e06-06", 0x000000, 0x100000, CRC(9380db3c) SHA1(83f5a46a01b9c15499e0dc2222df496d26baa0d4) )
+
+	ROM_REGION( 0x180000, "taito_en:audiocpu", 0 ) /* 68000 sound CPU */
 	ROM_LOAD16_BYTE("e06-09.32", 0x100000, 0x40000, CRC(9bcafc87) SHA1(10b3f6da00a41550fe6a705232f0e33fda3c7e7c) )
 	ROM_LOAD16_BYTE("e06-10.33", 0x100001, 0x40000, CRC(b752b61f) SHA1(e948a8af19c70ba8b8e908c869bc88ed0cac8420) )
 
-	ROM_REGION16_BE(0x800000, "ensoniq.0" , ROMREGION_ERASE00 ) // V2: 4 banks, only 2 populated
+	ROM_REGION16_BE( 0x800000, "ensoniq.0" , ROMREGION_ERASE00 ) // V2: 4 banks, only 2 populated
 	ROM_LOAD16_BYTE("e06-04", 0x000000, 0x200000, CRC(1dac29df) SHA1(ed68a41def148dcf4057cfac87a2a563c6882e1d) )    // C8 C9 CA CB
 	ROM_LOAD16_BYTE("e06-05", 0x400000, 0x200000, CRC(f370ff15) SHA1(4bc464d1c3a28326c8b1ae2036387954cb1dd813) )    // CC CD CE CF
 
@@ -2559,29 +2658,31 @@ ROM_START( spcinv95 )
 ROM_END
 
 ROM_START( akkanvdr )
-	ROM_REGION(0x200000, "maincpu", 0) /* 68020 code */
+	ROM_REGION( 0x200000, "maincpu", 0 ) /* 68020 code */
 	ROM_LOAD32_BYTE("e06-14.20", 0x000000, 0x20000, CRC(71ba7f00) SHA1(6b1d994c8319778aad3bec7bf7b24dc4944a36f0) )
 	ROM_LOAD32_BYTE("e06-13.19", 0x000001, 0x20000, CRC(f506ba4b) SHA1(551f9e87d2bfd513998648b175b63677cd6bdd74) )
 	ROM_LOAD32_BYTE("e06-12.18", 0x000002, 0x20000, CRC(06cbd72b) SHA1(0c8e11bd5f3fcf7451908c53e74ae545a0d97640) )
 	ROM_LOAD32_BYTE("e06-11.17", 0x000003, 0x20000, CRC(3fe550b9) SHA1(6258d72204834abfba58bc2d5882f3616a6fd784) )
 
-	ROM_REGION(0x400000, "gfx1" , 0) /* Sprites */
+	ROM_REGION( 0x200000, "sprites" , 0) /* Sprites */
 	ROM_LOAD16_BYTE("e06-03", 0x000000, 0x100000, CRC(a24070ef) SHA1(9b6ac7852114c606e871a08cfb3b9e1081ac7030) )
 	ROM_LOAD16_BYTE("e06-02", 0x000001, 0x100000, CRC(8f646dea) SHA1(07cd79671f36df1a5bbf2434e92a601351a36259) )
-	ROM_LOAD       ("e06-01", 0x300000, 0x100000, CRC(51721b15) SHA1(448a9a7f3631072d8987351f5c0b8dd2c908d266) )
-	ROM_FILL       (          0x200000, 0x100000, 0x00 )
 
-	ROM_REGION(0x400000, "gfx2" , 0) /* Tiles */
-	ROM_LOAD16_BYTE("e06-08", 0x000000, 0x100000, CRC(72ae2fbf) SHA1(7fa7ec94a8031342a2446fb8eca0d89ecfd2fa4f) )
-	ROM_LOAD16_BYTE("e06-07", 0x000001, 0x100000, CRC(4b02e8f5) SHA1(02d8a97da52f9ba4033b8f0c3f455a908a9dce89) )
-	ROM_LOAD       ("e06-06", 0x300000, 0x100000, CRC(9380db3c) SHA1(83f5a46a01b9c15499e0dc2222df496d26baa0d4) )
-	ROM_FILL       (          0x200000, 0x100000, 0x00 )
+	ROM_REGION( 0x100000, "sprites_hi", 0 )
+	ROM_LOAD       ("e06-01", 0x000000, 0x100000, CRC(51721b15) SHA1(448a9a7f3631072d8987351f5c0b8dd2c908d266) )
 
-	ROM_REGION(0x180000, "taito_en:audiocpu", 0) /* 68000 sound CPU */
+	ROM_REGION( 0x200000, "tilemap" , 0) /* Tiles */
+	ROM_LOAD32_WORD("e06-08", 0x000000, 0x100000, CRC(72ae2fbf) SHA1(7fa7ec94a8031342a2446fb8eca0d89ecfd2fa4f) )
+	ROM_LOAD32_WORD("e06-07", 0x000002, 0x100000, CRC(4b02e8f5) SHA1(02d8a97da52f9ba4033b8f0c3f455a908a9dce89) )
+
+	ROM_REGION( 0x100000, "tilemap_hi", 0 )
+	ROM_LOAD       ("e06-06", 0x000000, 0x100000, CRC(9380db3c) SHA1(83f5a46a01b9c15499e0dc2222df496d26baa0d4) )
+
+	ROM_REGION( 0x180000, "taito_en:audiocpu", 0 ) /* 68000 sound CPU */
 	ROM_LOAD16_BYTE("e06-09.32", 0x100000, 0x40000, CRC(9bcafc87) SHA1(10b3f6da00a41550fe6a705232f0e33fda3c7e7c) )
 	ROM_LOAD16_BYTE("e06-10.33", 0x100001, 0x40000, CRC(b752b61f) SHA1(e948a8af19c70ba8b8e908c869bc88ed0cac8420) )
 
-	ROM_REGION16_BE(0x800000, "ensoniq.0" , ROMREGION_ERASE00 ) // V2: 4 banks, only 2 populated
+	ROM_REGION16_BE( 0x800000, "ensoniq.0" , ROMREGION_ERASE00 ) // V2: 4 banks, only 2 populated
 	ROM_LOAD16_BYTE("e06-04", 0x000000, 0x200000, CRC(1dac29df) SHA1(ed68a41def148dcf4057cfac87a2a563c6882e1d) )    // C8 C9 CA CB
 	ROM_LOAD16_BYTE("e06-05", 0x400000, 0x200000, CRC(f370ff15) SHA1(4bc464d1c3a28326c8b1ae2036387954cb1dd813) )    // CC CD CE CF
 ROM_END
@@ -2672,29 +2773,31 @@ Notes:
 */
 
 ROM_START( elvactr )
-	ROM_REGION(0x200000, "maincpu", 0) /* 68020 code */
+	ROM_REGION( 0x200000, "maincpu", 0 ) /* 68020 code */
 	ROM_LOAD32_BYTE("e02-12.20", 0x000000, 0x80000, CRC(ea5f5a32) SHA1(4f30c56fbf068fee6d3afb2479043c7e89f6c055) )
 	ROM_LOAD32_BYTE("e02-11.19", 0x000001, 0x80000, CRC(bcced8ff) SHA1(09c38c78300ba9d710b4e46ca71014bbc5ac46b4) )
 	ROM_LOAD32_BYTE("e02-10.18", 0x000002, 0x80000, CRC(72f1b952) SHA1(9fc41ecfbee3581d9e92ff3a2ab6e4b93567e31d) )
 	ROM_LOAD32_BYTE("e02-16.17",  0x000003, 0x80000, CRC(cd97182b) SHA1(b3387980acfeec81eb0178d5b2955ac39595e22d) )
 
-	ROM_REGION(0x800000, "gfx1", 0 ) /* Sprites */
+	ROM_REGION( 0x400000, "sprites", 0 ) /* Sprites */
 	ROM_LOAD16_BYTE("e02-03.12", 0x000000, 0x200000, CRC(c884ebb5) SHA1(49009056bfdc564eac0ae6b7b49f070f05dc4ee3) )
 	ROM_LOAD16_BYTE("e02-02.8",  0x000001, 0x200000, CRC(c8e06cfb) SHA1(071d095a4930ce18a782c577811b553a9705fbd7) )
-	ROM_LOAD       ("e02-01.4",  0x600000, 0x200000, CRC(2ba94726) SHA1(3e9cdd076338e0e5358571ce4f97576f1a6a12a7) )
-	ROM_FILL       (             0x400000, 0x200000, 0x00 )
 
-	ROM_REGION(0x800000, "gfx2", 0 ) /* Tiles */
-	ROM_LOAD16_BYTE("e02-08.47", 0x000000, 0x200000, CRC(29c9bd02) SHA1(a5b552ae7ac15f514ee6105410ec3e6e34ea0adb) )
-	ROM_LOAD16_BYTE("e02-07.45", 0x000001, 0x200000, CRC(5eeee925) SHA1(d302da28df8ac6d406ef45f1d282ee22ce243857) )
-	ROM_LOAD       ("e02-06.43", 0x600000, 0x200000, CRC(4c8726e9) SHA1(8ce2320a087f43c49428a39dafffec8c40d61b03) )
-	ROM_FILL       (             0x400000, 0x200000, 0x00 )
+	ROM_REGION( 0x200000, "sprites_hi", 0 )
+	ROM_LOAD       ("e02-01.4",  0x000000, 0x200000, CRC(2ba94726) SHA1(3e9cdd076338e0e5358571ce4f97576f1a6a12a7) )
 
-	ROM_REGION(0x180000, "taito_en:audiocpu", 0) /* 68000 sound CPU */
+	ROM_REGION( 0x400000, "tilemap", 0 ) /* Tiles */
+	ROM_LOAD32_WORD("e02-08.47", 0x000000, 0x200000, CRC(29c9bd02) SHA1(a5b552ae7ac15f514ee6105410ec3e6e34ea0adb) )
+	ROM_LOAD32_WORD("e02-07.45", 0x000002, 0x200000, CRC(5eeee925) SHA1(d302da28df8ac6d406ef45f1d282ee22ce243857) )
+
+	ROM_REGION( 0x200000, "tilemap_hi", 0 )
+	ROM_LOAD       ("e02-06.43", 0x000000, 0x200000, CRC(4c8726e9) SHA1(8ce2320a087f43c49428a39dafffec8c40d61b03) )
+
+	ROM_REGION( 0x180000, "taito_en:audiocpu", 0 ) /* 68000 sound CPU */
 	ROM_LOAD16_BYTE("e02-13.32", 0x100000, 0x40000, CRC(80932702) SHA1(c468234d03aa31b2aa0c3bd6bec32034216c2ae4) )
 	ROM_LOAD16_BYTE("e02-14.33", 0x100001, 0x40000, CRC(706671a5) SHA1(1ac90647d617e73f12a67274a025ae43a6b3a316) )
 
-	ROM_REGION16_BE(0x800000, "ensoniq.0" , ROMREGION_ERASE00 ) // V2: 4 banks, only 2 populated
+	ROM_REGION16_BE( 0x800000, "ensoniq.0" , ROMREGION_ERASE00 ) // V2: 4 banks, only 2 populated
 	ROM_LOAD16_BYTE("e02-04.38", 0x000000, 0x200000, CRC(b74307af) SHA1(deb42415049efa2df70e7b25ba8b1b716aa227f1) ) // C8 C9 CA CB
 	ROM_LOAD16_BYTE("e02-05.39", 0x400000, 0x200000, CRC(eb729855) SHA1(85253efe794e8b5ffaf16bcb1123bca831e776a5) ) // CC CD CE CF
 
@@ -2709,86 +2812,93 @@ ROM_START( elvactr )
 ROM_END
 
 ROM_START( elvactrj )
-	ROM_REGION(0x200000, "maincpu", 0) /* 68020 code */
+	ROM_REGION( 0x200000, "maincpu", 0 ) /* 68020 code */
 	ROM_LOAD32_BYTE("e02-12.20", 0x000000, 0x80000, CRC(ea5f5a32) SHA1(4f30c56fbf068fee6d3afb2479043c7e89f6c055) )
 	ROM_LOAD32_BYTE("e02-11.19", 0x000001, 0x80000, CRC(bcced8ff) SHA1(09c38c78300ba9d710b4e46ca71014bbc5ac46b4) )
 	ROM_LOAD32_BYTE("e02-10.18", 0x000002, 0x80000, CRC(72f1b952) SHA1(9fc41ecfbee3581d9e92ff3a2ab6e4b93567e31d) )
 	ROM_LOAD32_BYTE("e02-09.17", 0x000003, 0x80000, CRC(23997907) SHA1(e5b0b9069b29cf08e1a782c73f42137aec198f7f) )
 
-	ROM_REGION(0x800000, "gfx1", 0 ) /* Sprites */
+	ROM_REGION( 0x400000, "sprites", 0 ) /* Sprites */
 	ROM_LOAD16_BYTE("e02-03.12", 0x000000, 0x200000, CRC(c884ebb5) SHA1(49009056bfdc564eac0ae6b7b49f070f05dc4ee3) )
 	ROM_LOAD16_BYTE("e02-02.8",  0x000001, 0x200000, CRC(c8e06cfb) SHA1(071d095a4930ce18a782c577811b553a9705fbd7) )
-	ROM_LOAD       ("e02-01.4",  0x600000, 0x200000, CRC(2ba94726) SHA1(3e9cdd076338e0e5358571ce4f97576f1a6a12a7) )
-	ROM_FILL       (             0x400000, 0x200000, 0x00 )
 
-	ROM_REGION(0x800000, "gfx2", 0 ) /* Tiles */
-	ROM_LOAD16_BYTE("e02-08.47", 0x000000, 0x200000, CRC(29c9bd02) SHA1(a5b552ae7ac15f514ee6105410ec3e6e34ea0adb) )
-	ROM_LOAD16_BYTE("e02-07.45", 0x000001, 0x200000, CRC(5eeee925) SHA1(d302da28df8ac6d406ef45f1d282ee22ce243857) )
-	ROM_LOAD       ("e02-06.43", 0x600000, 0x200000, CRC(4c8726e9) SHA1(8ce2320a087f43c49428a39dafffec8c40d61b03) )
-	ROM_FILL       (             0x400000, 0x200000, 0x00 )
+	ROM_REGION( 0x200000, "sprites_hi", 0 )
+	ROM_LOAD       ("e02-01.4",  0x000000, 0x200000, CRC(2ba94726) SHA1(3e9cdd076338e0e5358571ce4f97576f1a6a12a7) )
 
-	ROM_REGION(0x180000, "taito_en:audiocpu", 0) /* 68000 sound CPU */
+	ROM_REGION( 0x400000, "tilemap", 0 ) /* Tiles */
+	ROM_LOAD32_WORD("e02-08.47", 0x000000, 0x200000, CRC(29c9bd02) SHA1(a5b552ae7ac15f514ee6105410ec3e6e34ea0adb) )
+	ROM_LOAD32_WORD("e02-07.45", 0x000002, 0x200000, CRC(5eeee925) SHA1(d302da28df8ac6d406ef45f1d282ee22ce243857) )
+
+	ROM_REGION( 0x200000, "tilemap_hi", 0 )
+	ROM_LOAD       ("e02-06.43", 0x000000, 0x200000, CRC(4c8726e9) SHA1(8ce2320a087f43c49428a39dafffec8c40d61b03) )
+
+	ROM_REGION( 0x180000, "taito_en:audiocpu", 0 ) /* 68000 sound CPU */
 	ROM_LOAD16_BYTE("e02-13.32", 0x100000, 0x40000, CRC(80932702) SHA1(c468234d03aa31b2aa0c3bd6bec32034216c2ae4) )
 	ROM_LOAD16_BYTE("e02-14.33", 0x100001, 0x40000, CRC(706671a5) SHA1(1ac90647d617e73f12a67274a025ae43a6b3a316) )
 
-	ROM_REGION16_BE(0x800000, "ensoniq.0" , ROMREGION_ERASE00 ) // V2: 4 banks, only 2 populated
+	ROM_REGION16_BE( 0x800000, "ensoniq.0" , ROMREGION_ERASE00 ) // V2: 4 banks, only 2 populated
 	ROM_LOAD16_BYTE("e02-04.38", 0x000000, 0x200000, CRC(b74307af) SHA1(deb42415049efa2df70e7b25ba8b1b716aa227f1) ) // C8 C9 CA CB
 	ROM_LOAD16_BYTE("e02-05.39", 0x400000, 0x200000, CRC(eb729855) SHA1(85253efe794e8b5ffaf16bcb1123bca831e776a5) ) // CC CD CE CF
 ROM_END
 
 ROM_START( elvact2u )
-	ROM_REGION(0x200000, "maincpu", 0) /* 68020 code */
+	ROM_REGION( 0x200000, "maincpu", 0 ) /* 68020 code */
 	ROM_LOAD32_BYTE("e02-12.20", 0x000000, 0x80000, CRC(ea5f5a32) SHA1(4f30c56fbf068fee6d3afb2479043c7e89f6c055) )
 	ROM_LOAD32_BYTE("e02-11.19", 0x000001, 0x80000, CRC(bcced8ff) SHA1(09c38c78300ba9d710b4e46ca71014bbc5ac46b4) )
 	ROM_LOAD32_BYTE("e02-10.18", 0x000002, 0x80000, CRC(72f1b952) SHA1(9fc41ecfbee3581d9e92ff3a2ab6e4b93567e31d) )
 	ROM_LOAD32_BYTE("e02-15.17", 0x000003, 0x80000, CRC(ba9028bd) SHA1(1d04ce5333143ed78ec297d89c0cdb99bf6e4bde) )
 
-	ROM_REGION(0x800000, "gfx1", 0 ) /* Sprites */
+	ROM_REGION( 0x400000, "sprites", 0 ) /* Sprites */
 	ROM_LOAD16_BYTE("e02-03.12", 0x000000, 0x200000, CRC(c884ebb5) SHA1(49009056bfdc564eac0ae6b7b49f070f05dc4ee3) )
 	ROM_LOAD16_BYTE("e02-02.8",  0x000001, 0x200000, CRC(c8e06cfb) SHA1(071d095a4930ce18a782c577811b553a9705fbd7) )
-	ROM_LOAD       ("e02-01.4",  0x600000, 0x200000, CRC(2ba94726) SHA1(3e9cdd076338e0e5358571ce4f97576f1a6a12a7) )
-	ROM_FILL       (             0x400000, 0x200000, 0x00 )
 
-	ROM_REGION(0x800000, "gfx2", 0 ) /* Tiles */
-	ROM_LOAD16_BYTE("e02-08.47", 0x000000, 0x200000, CRC(29c9bd02) SHA1(a5b552ae7ac15f514ee6105410ec3e6e34ea0adb) )
-	ROM_LOAD16_BYTE("e02-07.45", 0x000001, 0x200000, CRC(5eeee925) SHA1(d302da28df8ac6d406ef45f1d282ee22ce243857) )
-	ROM_LOAD       ("e02-06.43", 0x600000, 0x200000, CRC(4c8726e9) SHA1(8ce2320a087f43c49428a39dafffec8c40d61b03) )
-	ROM_FILL       (             0x400000, 0x200000, 0x00 )
+	ROM_REGION( 0x200000, "sprites_hi", 0 )
+	ROM_LOAD       ("e02-01.4",  0x000000, 0x200000, CRC(2ba94726) SHA1(3e9cdd076338e0e5358571ce4f97576f1a6a12a7) )
 
-	ROM_REGION(0x180000, "taito_en:audiocpu", 0) /* 68000 sound CPU */
+	ROM_REGION( 0x400000, "tilemap", 0 ) /* Tiles */
+	ROM_LOAD32_WORD("e02-08.47", 0x000000, 0x200000, CRC(29c9bd02) SHA1(a5b552ae7ac15f514ee6105410ec3e6e34ea0adb) )
+	ROM_LOAD32_WORD("e02-07.45", 0x000002, 0x200000, CRC(5eeee925) SHA1(d302da28df8ac6d406ef45f1d282ee22ce243857) )
+
+	ROM_REGION( 0x200000, "tilemap_hi", 0 )
+	ROM_LOAD       ("e02-06.43", 0x000000, 0x200000, CRC(4c8726e9) SHA1(8ce2320a087f43c49428a39dafffec8c40d61b03) )
+
+	ROM_REGION( 0x180000, "taito_en:audiocpu", 0 ) /* 68000 sound CPU */
 	ROM_LOAD16_BYTE("e02-13.32", 0x100000, 0x40000, CRC(80932702) SHA1(c468234d03aa31b2aa0c3bd6bec32034216c2ae4) )
 	ROM_LOAD16_BYTE("e02-14.33", 0x100001, 0x40000, CRC(706671a5) SHA1(1ac90647d617e73f12a67274a025ae43a6b3a316) )
 
-	ROM_REGION16_BE(0x800000, "ensoniq.0" , ROMREGION_ERASE00 ) // V2: 4 banks, only 2 populated
+	ROM_REGION16_BE( 0x800000, "ensoniq.0" , ROMREGION_ERASE00 ) // V2: 4 banks, only 2 populated
 	ROM_LOAD16_BYTE("e02-04.38", 0x000000, 0x200000, CRC(b74307af) SHA1(deb42415049efa2df70e7b25ba8b1b716aa227f1) ) // C8 C9 CA CB
 	ROM_LOAD16_BYTE("e02-05.39", 0x400000, 0x200000, CRC(eb729855) SHA1(85253efe794e8b5ffaf16bcb1123bca831e776a5) ) // CC CD CE CF
 ROM_END
 
 ROM_START( twinqix )
-	ROM_REGION(0x200000, "maincpu", 0) /* 68020 code */
+	ROM_REGION( 0x200000, "maincpu", 0 ) /* 68020 code */
 	ROM_LOAD32_BYTE("mpr0-3.b60", 0x000000, 0x40000, CRC(1a63d0de) SHA1(7d8d8a6c9c7f9dfc0a8a528a905e33388b8fe13d) )
 	ROM_LOAD32_BYTE("mpr0-2.b61", 0x000001, 0x40000, CRC(45a70987) SHA1(8cca6845064d943fd28416143e60399188b023cd) )
 	ROM_LOAD32_BYTE("mpr0-1.b62", 0x000002, 0x40000, CRC(531f9447) SHA1(4d18efaad9c3dd2b14d3125c0f9e18cfcde3a1f2) )
 	ROM_LOAD32_BYTE("mpr0-0.b63", 0x000003, 0x40000, CRC(a4c44c11) SHA1(b928134028bb8cddd6e34a501a4aad56173e2ae2) )
 
-	ROM_REGION(0x200000, "gfx1" , 0 ) /* Sprites */
+	ROM_REGION( 0x100000, "sprites" , 0 ) /* Sprites */
 	ROM_LOAD16_BYTE("obj0-0.a08", 0x000000, 0x080000, CRC(c6ea845c) SHA1(9df710637e8f64f7fec232b5ebbede588e07c2db) )
 	ROM_LOAD16_BYTE("obj0-1.a20", 0x000001, 0x080000, CRC(8c12b7fb) SHA1(8a52870fb9f508148619763fb6f37dd74b5386ca) )
-	ROM_FILL       (              0x100000, 0x100000, 0x00 )
 
-	ROM_REGION(0x400000, "gfx2" , 0 ) /* Tiles */
+	EMPTY_SPRITE_HIDATA(0x080000)
+
+	ROM_REGION( 0x200000, "tilemap" , 0 ) /* Tiles */
 	ROM_LOAD32_BYTE("scr0-0.b07",  0x000000, 0x080000, CRC(9a1b9b34) SHA1(ddf9c6ba0f9c340b580573e1d96ac76b1cd35beb) )
-	ROM_LOAD32_BYTE("scr0-1.b06",  0x000002, 0x080000, CRC(e9bef879) SHA1(7e720f5054a1ef3a28353f1c221f4cf15d3b7428) )
-	ROM_LOAD32_BYTE("scr0-2.b05",  0x000001, 0x080000, CRC(cac6854b) SHA1(c97fb7de48e1644695bbe431587d6c1be01ea62d) )
+	ROM_LOAD32_BYTE("scr0-1.b06",  0x000001, 0x080000, CRC(e9bef879) SHA1(7e720f5054a1ef3a28353f1c221f4cf15d3b7428) )
+	ROM_LOAD32_BYTE("scr0-2.b05",  0x000002, 0x080000, CRC(cac6854b) SHA1(c97fb7de48e1644695bbe431587d6c1be01ea62d) )
 	ROM_LOAD32_BYTE("scr0-3.b04",  0x000003, 0x080000, CRC(ce063034) SHA1(2ecff74427d7d2fa8d1db4ac87481d123d7ce003) )
-	ROM_LOAD16_BYTE("scr0-4.b03",  0x300000, 0x080000, CRC(d32280fe) SHA1(56b120128c5e4b8c6598a1de51269e6702a63175) )
-	ROM_LOAD16_BYTE("scr0-5.b02",  0x300001, 0x080000, CRC(fdd1a85b) SHA1(1d94a4858baef3e78c456049dc58249a574205fe) )
 
-	ROM_REGION(0x180000, "taito_en:audiocpu", 0) /* sound CPU */
+	ROM_REGION( 0x100000, "tilemap_hi", 0 )
+	ROM_LOAD16_BYTE("scr0-4.b03",  0x000000, 0x080000, CRC(d32280fe) SHA1(56b120128c5e4b8c6598a1de51269e6702a63175) )
+	ROM_LOAD16_BYTE("scr0-5.b02",  0x000001, 0x080000, CRC(fdd1a85b) SHA1(1d94a4858baef3e78c456049dc58249a574205fe) )
+
+	ROM_REGION( 0x180000, "taito_en:audiocpu", 0 ) /* sound CPU */
 	ROM_LOAD16_BYTE("spr0-1.b66", 0x100000, 0x40000, CRC(4b20e99d) SHA1(faf184daea0f1131bafa50edb48bd470d4c0b141) )
 	ROM_LOAD16_BYTE("spr0-0.b65", 0x100001, 0x40000, CRC(2569eb30) SHA1(ec804131025e600198cd8342925823340e7ef458) )
 
-	ROM_REGION16_BE(0x400000, "ensoniq.0" , ROMREGION_ERASE00 ) // V2: 4 banks, only 1 populated
+	ROM_REGION16_BE( 0x400000, "ensoniq.0" , ROMREGION_ERASE00 ) // V2: 4 banks, only 1 populated
 	ROM_LOAD16_BYTE("snd-0.b43",  0x000000, 0x80000, CRC(ad5405a9) SHA1(67ee42498d2c3c00015237b3b5cd020f9a7c4a18) ) // C8
 	ROM_LOAD16_BYTE("snd-1.b44",  0x100000, 0x80000, CRC(274864af) SHA1(47fefee23038bb751bdf6b6f48312ba0b6e38b90) ) // C9
 	ROM_LOAD16_BYTE("snd-14.b10", 0x200000, 0x80000, CRC(26312451) SHA1(9f947a11592fd8420fc581914bf16e7ade75390c) ) // -std-
@@ -2805,32 +2915,34 @@ ROM_START( twinqix )
 ROM_END
 
 ROM_START( quizhuhu )
-	ROM_REGION(0x200000, "maincpu", 0) /* 68020 code */
+	ROM_REGION( 0x200000, "maincpu", 0 ) /* 68020 code */
 	ROM_LOAD32_BYTE("e08-16.20", 0x000000, 0x80000, CRC(faa8f373) SHA1(e263b058288fcacf9b15188ab78e8fb05a8971a7) )
 	ROM_LOAD32_BYTE("e08-15.19", 0x000001, 0x80000, CRC(23acf231) SHA1(a87933439b3d1d92f8b9d545b13f20cc47a7fd4e) )
 	ROM_LOAD32_BYTE("e08-14.18", 0x000002, 0x80000, CRC(33a4951d) SHA1(69e8fe994f620ce056cdedca77bff1d0c6e74483) )
 	ROM_LOAD32_BYTE("e08-13.17", 0x000003, 0x80000, CRC(0936fd2a) SHA1(f0f7017c755b28644b67b4fd6d5e19c272e9c3a2) )
 
-	ROM_REGION(0xc00000, "gfx1" , 0) /* Sprites */
+	ROM_REGION( 0x600000, "sprites" , 0) /* Sprites */
 	ROM_LOAD16_BYTE("e08-06.12", 0x000000, 0x200000, CRC(8dadc9ac) SHA1(469e3c5063f5cb0832fb5bb5000ecd3c342cd095) )
 	ROM_LOAD16_BYTE("e08-04.8",  0x000001, 0x200000, CRC(5423721d) SHA1(7e9f4492845b7b4df0336203b1da6ca5ffeb36de) )
 	ROM_LOAD16_BYTE("e08-05.11", 0x400000, 0x100000, CRC(79d2e516) SHA1(7dc0c23f3995d14b443a3f67d488e5ab780e8a94) )
 	ROM_LOAD16_BYTE("e08-03.7",  0x400001, 0x100000, CRC(07b9ab6a) SHA1(db205822233c385e1dbe4a9d40b311df9bca7053) )
-	ROM_LOAD       ("e08-02.4",  0x900000, 0x200000, CRC(d89eb067) SHA1(bd8e1cf4c2046894c629d927fa05806b9b73505d) )
-	ROM_LOAD       ("e08-01.3",  0xb00000, 0x100000, CRC(90223c06) SHA1(f07dae563946908d471ae89db74a2e55c5ab5890) )
-	ROM_FILL       (             0x600000, 0x300000, 0x00 )
 
-	ROM_REGION(0x400000, "gfx2" , 0) /* Tiles */
-	ROM_LOAD16_BYTE("e08-12.47", 0x000000, 0x100000, CRC(6c711d36) SHA1(3fbff7783323d968ade72ac53531a7bcf7b9d234) )
-	ROM_LOAD16_BYTE("e08-11.45", 0x000001, 0x100000, CRC(56775a60) SHA1(8bb8190101f2e8487ebb707022ff89d97bb7b39a) )
-	ROM_LOAD       ("e08-10.43", 0x300000, 0x100000, CRC(60abc71b) SHA1(f4aa906920c6134c33a4dfb51724f3adbd3d7de4) )
-	ROM_FILL       (             0x200000, 0x100000, 0x00 )
+	ROM_REGION( 0x300000, "sprites_hi", 0 )
+	ROM_LOAD       ("e08-02.4",  0x000000, 0x200000, CRC(d89eb067) SHA1(bd8e1cf4c2046894c629d927fa05806b9b73505d) )
+	ROM_LOAD       ("e08-01.3",  0x200000, 0x100000, CRC(90223c06) SHA1(f07dae563946908d471ae89db74a2e55c5ab5890) )
 
-	ROM_REGION(0x140000, "taito_en:audiocpu", 0) /* 68000 sound CPU */
+	ROM_REGION( 0x200000, "tilemap" , 0) /* Tiles */
+	ROM_LOAD32_WORD("e08-12.47", 0x000000, 0x100000, CRC(6c711d36) SHA1(3fbff7783323d968ade72ac53531a7bcf7b9d234) )
+	ROM_LOAD32_WORD("e08-11.45", 0x000002, 0x100000, CRC(56775a60) SHA1(8bb8190101f2e8487ebb707022ff89d97bb7b39a) )
+
+	ROM_REGION( 0x100000, "tilemap_hi", 0 )
+	ROM_LOAD       ("e08-10.43", 0x000000, 0x100000, CRC(60abc71b) SHA1(f4aa906920c6134c33a4dfb51724f3adbd3d7de4) )
+
+	ROM_REGION( 0x140000, "taito_en:audiocpu", 0 ) /* 68000 sound CPU */
 	ROM_LOAD16_BYTE("e08-18.32", 0x100000, 0x20000, CRC(e695497e) SHA1(9d845b4c0bd9b40471fb4b5ab2f9240058bc324f) )
 	ROM_LOAD16_BYTE("e08-17.33", 0x100001, 0x20000, CRC(fafc7e4e) SHA1(26f46d5900fbf26d25651e7e818e486fc7a878ec) )
 
-	ROM_REGION16_BE(0x1000000, "ensoniq.0" , ROMREGION_ERASE00 )    // V2: 4 banks
+	ROM_REGION16_BE( 0x1000000, "ensoniq.0" , ROMREGION_ERASE00 )    // V2: 4 banks
 	// empty
 	ROM_LOAD16_BYTE("e08-07.38", 0x400000, 0x200000, CRC(c05dc85b) SHA1(d46ae3f066bbe041edde40358dd54f93e8e195de) ) // C8 C9 CA CB
 	ROM_LOAD16_BYTE("e08-08.39", 0x800000, 0x200000, CRC(3eb94a99) SHA1(e6e8832e87397811dfc40525f2a15fc0415cec68) ) // CC CD CE CF
@@ -2839,141 +2951,151 @@ ROM_END
 
 
 ROM_START( pbobble2 )
-	ROM_REGION(0x200000, "maincpu", ROMREGION_ERASE00) /* 68020 code */
+	ROM_REGION( 0x200000, "maincpu", ROMREGION_ERASE00 ) /* 68020 code */
 	ROM_LOAD32_BYTE("e10-22.bin", 0x000002, 0x40000, CRC(7b12105d) SHA1(b69379c5a79c365ed6e62e7ae478e4bbb4edfcb1) )
 	ROM_LOAD32_BYTE("e10-23.bin", 0x000001, 0x40000, CRC(56a66435) SHA1(ba9d405416090f3482c6ed610e7eb77b43459ff1) )
 	ROM_LOAD32_BYTE("e10-24.bin", 0x000000, 0x40000, CRC(f9d0794b) SHA1(320eee7790bf9a5141ad7b0ebfdec47e8f85a1c2) )
 	ROM_LOAD32_BYTE("e10-25.bin", 0x000003, 0x40000, CRC(ff0407d3) SHA1(4616bb9132f78c4f0212afbcc8d528934f822f44) )
 
-	ROM_REGION(0x400000, "gfx1" , 0) /* Sprites */
+	ROM_REGION( 0x200000, "sprites" , 0) /* Sprites */
 	ROM_LOAD16_BYTE("e10-02.rom", 0x000000, 0x100000, CRC(c0564490) SHA1(cbe9f880192c08f4d1db21d5ba14073b97e5f1d3) )
 	ROM_LOAD16_BYTE("e10-01.rom", 0x000001, 0x100000, CRC(8c26ff49) SHA1(cbb514c061106003d2ae2b6c43958b24feaad656) )
-	ROM_FILL       (              0x200000, 0x200000, 0x00 )
 
-	ROM_REGION(0x400000, "gfx2" , 0) /* Tiles */
-	ROM_LOAD16_BYTE("e10-07.rom", 0x000000, 0x100000, CRC(dcb3c29b) SHA1(b80c3a8ce53d696c57675e654c9927ef8687759e) )
-	ROM_LOAD16_BYTE("e10-06.rom", 0x000001, 0x100000, CRC(1b0f20e2) SHA1(66b44d059c2896abac2f0e7fc932489dee440ba0) )
-	ROM_LOAD       ("e10-05.rom", 0x300000, 0x100000, CRC(81266151) SHA1(aa3b144f32995425db97efce440e234a3c7a6715) )
-	ROM_FILL       (              0x200000, 0x100000, 0x00 )
+	EMPTY_SPRITE_HIDATA(0x100000)
 
-	ROM_REGION(0x180000, "taito_en:audiocpu", 0) /* 68000 sound CPU */
+	ROM_REGION( 0x200000, "tilemap" , 0) /* Tiles */
+	ROM_LOAD32_WORD("e10-07.rom", 0x000000, 0x100000, CRC(dcb3c29b) SHA1(b80c3a8ce53d696c57675e654c9927ef8687759e) )
+	ROM_LOAD32_WORD("e10-06.rom", 0x000002, 0x100000, CRC(1b0f20e2) SHA1(66b44d059c2896abac2f0e7fc932489dee440ba0) )
+
+	ROM_REGION( 0x100000, "tilemap_hi", 0 )
+	ROM_LOAD       ("e10-05.rom", 0x000000, 0x100000, CRC(81266151) SHA1(aa3b144f32995425db97efce440e234a3c7a6715) )
+
+	ROM_REGION( 0x180000, "taito_en:audiocpu", 0 ) /* 68000 sound CPU */
 	ROM_LOAD16_BYTE("e10-12.32", 0x100000, 0x40000, CRC(b92dc8ad) SHA1(0c1428d313507b1ae5a2af3b2fbaaa5650135e1e) )
 	ROM_LOAD16_BYTE("e10-13.33", 0x100001, 0x40000, CRC(87842c13) SHA1(d15b47c7430e677ae172f86fd5be595e4fe72e42) )
 
-	ROM_REGION16_BE(0x800000, "ensoniq.0" , ROMREGION_ERASE00 ) // V2: 4 banks, only 2 populated
+	ROM_REGION16_BE( 0x800000, "ensoniq.0" , ROMREGION_ERASE00 ) // V2: 4 banks, only 2 populated
 	ROM_LOAD16_BYTE("e10-04.rom", 0x000000, 0x200000, CRC(5c0862a6) SHA1(f916f63b8629239e3221e1e231e1b39962ef38ba) )    // C8 C9 CA CB
 	ROM_LOAD16_BYTE("e10-03.rom", 0x400000, 0x200000, CRC(46d68ac8) SHA1(ad014e9f0d458308014959ca6823077f581ab088) )    // CC CD CE CF
 
-	ROM_REGION(0x2000, "extra", 0)
+	ROM_REGION( 0x2000, "extra", 0 )
 	ROM_LOAD("e10-21.bin", 0x000000, 0x117, CRC(458499b7) SHA1(0c49aaf75539587d1f5367b3dc72799003824544) )
 //  ROM_LOAD("e10-21.jed", 0x000000, 0xc2b, CRC(8e9fa5d6) SHA1(5fb120d80f7ceee96a2fad863cf61a1f0b02877f) )
 ROM_END
 
 
 ROM_START( pbobble2o )
-	ROM_REGION(0x200000, "maincpu", 0) /* 68020 code */
+	ROM_REGION( 0x200000, "maincpu", 0 ) /* 68020 code */
 	ROM_LOAD32_BYTE("e10-11.20", 0x000000, 0x40000, CRC(b82f81da) SHA1(2cd0fb321c853497058545525f430b52c0788fb1) )
 	ROM_LOAD32_BYTE("e10-10.19", 0x000001, 0x40000, CRC(f432267a) SHA1(f9778fc627773e4e254faa0ce10e68407251ce95) )
 	ROM_LOAD32_BYTE("e10-09.18", 0x000002, 0x40000, CRC(e0b1b599) SHA1(99ef34b014db7c52f2ced05b2b90099a9c873259) )
 	ROM_LOAD32_BYTE("e10-15.17", 0x000003, 0x40000, CRC(a2c0a268) SHA1(c96bb8a2959266c5c832fb77d119ad129b9ef9ee) )
 
-	ROM_REGION(0x400000, "gfx1" , 0) /* Sprites */
+	ROM_REGION( 0x200000, "sprites" , 0) /* Sprites */
 	ROM_LOAD16_BYTE("e10-02.rom", 0x000000, 0x100000, CRC(c0564490) SHA1(cbe9f880192c08f4d1db21d5ba14073b97e5f1d3) )
 	ROM_LOAD16_BYTE("e10-01.rom", 0x000001, 0x100000, CRC(8c26ff49) SHA1(cbb514c061106003d2ae2b6c43958b24feaad656) )
-	ROM_FILL       (              0x200000, 0x200000, 0x00 )
 
-	ROM_REGION(0x400000, "gfx2" , 0) /* Tiles */
-	ROM_LOAD16_BYTE("e10-07.rom", 0x000000, 0x100000, CRC(dcb3c29b) SHA1(b80c3a8ce53d696c57675e654c9927ef8687759e) )
-	ROM_LOAD16_BYTE("e10-06.rom", 0x000001, 0x100000, CRC(1b0f20e2) SHA1(66b44d059c2896abac2f0e7fc932489dee440ba0) )
-	ROM_LOAD       ("e10-05.rom", 0x300000, 0x100000, CRC(81266151) SHA1(aa3b144f32995425db97efce440e234a3c7a6715) )
-	ROM_FILL       (              0x200000, 0x100000, 0x00 )
+	EMPTY_SPRITE_HIDATA(0x100000)
 
-	ROM_REGION(0x180000, "taito_en:audiocpu", 0) /* 68000 sound CPU */
+	ROM_REGION( 0x200000, "tilemap" , 0) /* Tiles */
+	ROM_LOAD32_WORD("e10-07.rom", 0x000000, 0x100000, CRC(dcb3c29b) SHA1(b80c3a8ce53d696c57675e654c9927ef8687759e) )
+	ROM_LOAD32_WORD("e10-06.rom", 0x000002, 0x100000, CRC(1b0f20e2) SHA1(66b44d059c2896abac2f0e7fc932489dee440ba0) )
+
+	ROM_REGION( 0x100000, "tilemap_hi", 0 )
+	ROM_LOAD       ("e10-05.rom", 0x000000, 0x100000, CRC(81266151) SHA1(aa3b144f32995425db97efce440e234a3c7a6715) )
+
+	ROM_REGION( 0x180000, "taito_en:audiocpu", 0 ) /* 68000 sound CPU */
 	ROM_LOAD16_BYTE("e10-12.32", 0x100000, 0x40000, CRC(b92dc8ad) SHA1(0c1428d313507b1ae5a2af3b2fbaaa5650135e1e) )
 	ROM_LOAD16_BYTE("e10-13.33", 0x100001, 0x40000, CRC(87842c13) SHA1(d15b47c7430e677ae172f86fd5be595e4fe72e42) )
 
-	ROM_REGION16_BE(0x800000, "ensoniq.0" , ROMREGION_ERASE00 ) // V2: 4 banks, only 2 populated
+	ROM_REGION16_BE( 0x800000, "ensoniq.0" , ROMREGION_ERASE00 ) // V2: 4 banks, only 2 populated
 	ROM_LOAD16_BYTE("e10-04.rom", 0x000000, 0x200000, CRC(5c0862a6) SHA1(f916f63b8629239e3221e1e231e1b39962ef38ba) )    // C8 C9 CA CB
 	ROM_LOAD16_BYTE("e10-03.rom", 0x400000, 0x200000, CRC(46d68ac8) SHA1(ad014e9f0d458308014959ca6823077f581ab088) )    // CC CD CE CF
 ROM_END
 
 ROM_START( pbobble2j )
-	ROM_REGION(0x200000, "maincpu", 0) /* 68020 code */
+	ROM_REGION( 0x200000, "maincpu", 0 ) /* 68020 code */
 	ROM_LOAD32_BYTE("e10-11.20", 0x000000, 0x40000, CRC(b82f81da) SHA1(2cd0fb321c853497058545525f430b52c0788fb1) )
 	ROM_LOAD32_BYTE("e10-10.19", 0x000001, 0x40000, CRC(f432267a) SHA1(f9778fc627773e4e254faa0ce10e68407251ce95) )
 	ROM_LOAD32_BYTE("e10-09.18", 0x000002, 0x40000, CRC(e0b1b599) SHA1(99ef34b014db7c52f2ced05b2b90099a9c873259) )
 	ROM_LOAD32_BYTE("e10-08.17", 0x000003, 0x40000, CRC(4ccec344) SHA1(dfb30d149dde6d8e1a117bf0bafb85178540aa58) )
 
-	ROM_REGION(0x400000, "gfx1" , 0) /* Sprites */
+	ROM_REGION( 0x200000, "sprites" , 0) /* Sprites */
 	ROM_LOAD16_BYTE("e10-02.rom", 0x000000, 0x100000, CRC(c0564490) SHA1(cbe9f880192c08f4d1db21d5ba14073b97e5f1d3) )
 	ROM_LOAD16_BYTE("e10-01.rom", 0x000001, 0x100000, CRC(8c26ff49) SHA1(cbb514c061106003d2ae2b6c43958b24feaad656) )
-	ROM_FILL       (              0x200000, 0x200000, 0x00 )
 
-	ROM_REGION(0x400000, "gfx2" , 0) /* Tiles */
-	ROM_LOAD16_BYTE("e10-07.rom", 0x000000, 0x100000, CRC(dcb3c29b) SHA1(b80c3a8ce53d696c57675e654c9927ef8687759e) )
-	ROM_LOAD16_BYTE("e10-06.rom", 0x000001, 0x100000, CRC(1b0f20e2) SHA1(66b44d059c2896abac2f0e7fc932489dee440ba0) )
-	ROM_LOAD       ("e10-05.rom", 0x300000, 0x100000, CRC(81266151) SHA1(aa3b144f32995425db97efce440e234a3c7a6715) )
-	ROM_FILL       (              0x200000, 0x100000, 0x00 )
+	EMPTY_SPRITE_HIDATA(0x100000)
 
-	ROM_REGION(0x180000, "taito_en:audiocpu", 0) /* 68000 sound CPU */
+	ROM_REGION( 0x200000, "tilemap" , 0) /* Tiles */
+	ROM_LOAD32_WORD("e10-07.rom", 0x000000, 0x100000, CRC(dcb3c29b) SHA1(b80c3a8ce53d696c57675e654c9927ef8687759e) )
+	ROM_LOAD32_WORD("e10-06.rom", 0x000002, 0x100000, CRC(1b0f20e2) SHA1(66b44d059c2896abac2f0e7fc932489dee440ba0) )
+
+	ROM_REGION( 0x100000, "tilemap_hi", 0 )
+	ROM_LOAD       ("e10-05.rom", 0x000000, 0x100000, CRC(81266151) SHA1(aa3b144f32995425db97efce440e234a3c7a6715) )
+
+	ROM_REGION( 0x180000, "taito_en:audiocpu", 0 ) /* 68000 sound CPU */
 	ROM_LOAD16_BYTE("e10-12.32", 0x100000, 0x40000, CRC(b92dc8ad) SHA1(0c1428d313507b1ae5a2af3b2fbaaa5650135e1e) )
 	ROM_LOAD16_BYTE("e10-13.33", 0x100001, 0x40000, CRC(87842c13) SHA1(d15b47c7430e677ae172f86fd5be595e4fe72e42) )
 
-	ROM_REGION16_BE(0x800000, "ensoniq.0" , ROMREGION_ERASE00 ) // V2: 4 banks, only 2 populated
+	ROM_REGION16_BE( 0x800000, "ensoniq.0" , ROMREGION_ERASE00 ) // V2: 4 banks, only 2 populated
 	ROM_LOAD16_BYTE("e10-04.rom", 0x000000, 0x200000, CRC(5c0862a6) SHA1(f916f63b8629239e3221e1e231e1b39962ef38ba) )    // C8 C9 CA CB
 	ROM_LOAD16_BYTE("e10-03.rom", 0x400000, 0x200000, CRC(46d68ac8) SHA1(ad014e9f0d458308014959ca6823077f581ab088) )    // CC CD CE CF
 ROM_END
 
 ROM_START( pbobble2u )
-	ROM_REGION(0x200000, "maincpu", 0) /* 68020 code */
+	ROM_REGION( 0x200000, "maincpu", 0 ) /* 68020 code */
 	ROM_LOAD32_BYTE("e10-20.20", 0x000000, 0x40000, CRC(97eb15c6) SHA1(712ed06ee3582e30acb03c06f4981b0f3d7c64f4) )
 	ROM_LOAD32_BYTE("e10-19.19", 0x000001, 0x40000, CRC(7082d796) SHA1(9dd8216123ae94f4e9bacea9a088ae73c71cfd19) )
 	ROM_LOAD32_BYTE("e10-18.18", 0x000002, 0x40000, CRC(2ffa3ef2) SHA1(dcf2cce623daaaacb53f17657019a4e334be0a16) )
 	ROM_LOAD32_BYTE("e10-14.17", 0x000003, 0x40000, CRC(4a19ed67) SHA1(21de5f6c3ab5e13b085010a49f33b88cb6388fa9) )
 
-	ROM_REGION(0x400000, "gfx1" , 0) /* Sprites */
+	ROM_REGION( 0x200000, "sprites" , 0) /* Sprites */
 	ROM_LOAD16_BYTE("e10-02.rom", 0x000000, 0x100000, CRC(c0564490) SHA1(cbe9f880192c08f4d1db21d5ba14073b97e5f1d3) )
 	ROM_LOAD16_BYTE("e10-01.rom", 0x000001, 0x100000, CRC(8c26ff49) SHA1(cbb514c061106003d2ae2b6c43958b24feaad656) )
-	ROM_FILL       (              0x200000, 0x200000, 0x00 )
 
-	ROM_REGION(0x400000, "gfx2" , 0) /* Tiles */
-	ROM_LOAD16_BYTE("e10-07.rom", 0x000000, 0x100000, CRC(dcb3c29b) SHA1(b80c3a8ce53d696c57675e654c9927ef8687759e) )
-	ROM_LOAD16_BYTE("e10-06.rom", 0x000001, 0x100000, CRC(1b0f20e2) SHA1(66b44d059c2896abac2f0e7fc932489dee440ba0) )
-	ROM_LOAD       ("e10-05.rom", 0x300000, 0x100000, CRC(81266151) SHA1(aa3b144f32995425db97efce440e234a3c7a6715) )
-	ROM_FILL       (              0x200000, 0x100000, 0x00 )
+	EMPTY_SPRITE_HIDATA(0x100000)
 
-	ROM_REGION(0x180000, "taito_en:audiocpu", 0) /* 68000 sound CPU */
+	ROM_REGION( 0x200000, "tilemap" , 0) /* Tiles */
+	ROM_LOAD32_WORD("e10-07.rom", 0x000000, 0x100000, CRC(dcb3c29b) SHA1(b80c3a8ce53d696c57675e654c9927ef8687759e) )
+	ROM_LOAD32_WORD("e10-06.rom", 0x000002, 0x100000, CRC(1b0f20e2) SHA1(66b44d059c2896abac2f0e7fc932489dee440ba0) )
+
+	ROM_REGION( 0x100000, "tilemap_hi", 0 )
+	ROM_LOAD       ("e10-05.rom", 0x000000, 0x100000, CRC(81266151) SHA1(aa3b144f32995425db97efce440e234a3c7a6715) )
+
+	ROM_REGION( 0x180000, "taito_en:audiocpu", 0 ) /* 68000 sound CPU */
 	ROM_LOAD16_BYTE("e10-16.32", 0x100000, 0x40000, CRC(765ce77a) SHA1(e2723bd6238da91d28307081909a7172a1825c83) )
 	ROM_LOAD16_BYTE("e10-17.33", 0x100001, 0x40000, CRC(0aec3b1e) SHA1(a76a020cefcfbf86b0d893a6eb8ff93cb571abeb) )
 
-	ROM_REGION16_BE(0x800000, "ensoniq.0" , ROMREGION_ERASE00 ) // V2: 4 banks, only 2 populated
+	ROM_REGION16_BE( 0x800000, "ensoniq.0" , ROMREGION_ERASE00 ) // V2: 4 banks, only 2 populated
 	ROM_LOAD16_BYTE("e10-04.rom", 0x000000, 0x200000, CRC(5c0862a6) SHA1(f916f63b8629239e3221e1e231e1b39962ef38ba) )    // C8 C9 CA CB
 	ROM_LOAD16_BYTE("e10-03.rom", 0x400000, 0x200000, CRC(46d68ac8) SHA1(ad014e9f0d458308014959ca6823077f581ab088) )    // CC CD CE CF
 ROM_END
 
 ROM_START( pbobble2x )
-	ROM_REGION(0x200000, "maincpu", 0) /* 68020 code */
+	ROM_REGION( 0x200000, "maincpu", 0 ) /* 68020 code */
 	ROM_LOAD32_BYTE("e10-29.20", 0x000000, 0x40000, CRC(f1e9ad3f) SHA1(8689d85f30e075d21e4be01a2a097a850a921c47) )
 	ROM_LOAD32_BYTE("e10-28.19", 0x000001, 0x40000, CRC(412a3602) SHA1(d754e6ac886676d2c1eb52de3a727894f316e6b5) )
 	ROM_LOAD32_BYTE("e10-27.18", 0x000002, 0x40000, CRC(88cc0b5c) SHA1(bb08a7b8b37356376052ed03f8515677811823c0) )
 	ROM_LOAD32_BYTE("e10-26.17", 0x000003, 0x40000, CRC(a5c24047) SHA1(62861577ce0aedb8d05360f0302fceecbde15420) )
 
-	ROM_REGION(0x400000, "gfx1" , 0) /* Sprites */
+	ROM_REGION( 0x200000, "sprites" , 0) /* Sprites */
 	ROM_LOAD16_BYTE("e10-02.rom", 0x000000, 0x100000, CRC(c0564490) SHA1(cbe9f880192c08f4d1db21d5ba14073b97e5f1d3) )
 	ROM_LOAD16_BYTE("e10-01.rom", 0x000001, 0x100000, CRC(8c26ff49) SHA1(cbb514c061106003d2ae2b6c43958b24feaad656) )
-	ROM_FILL       (              0x200000, 0x200000, 0x00 )
 
-	ROM_REGION(0x400000, "gfx2" , 0) /* Tiles */
-	ROM_LOAD16_BYTE("e10-07.rom", 0x000000, 0x100000, CRC(dcb3c29b) SHA1(b80c3a8ce53d696c57675e654c9927ef8687759e) )
-	ROM_LOAD16_BYTE("e10-06.rom", 0x000001, 0x100000, CRC(1b0f20e2) SHA1(66b44d059c2896abac2f0e7fc932489dee440ba0) )
-	ROM_LOAD       ("e10-05.rom", 0x300000, 0x100000, CRC(81266151) SHA1(aa3b144f32995425db97efce440e234a3c7a6715) )
-	ROM_FILL       (              0x200000, 0x100000, 0x00 )
+	EMPTY_SPRITE_HIDATA(0x100000)
 
-	ROM_REGION(0x180000, "taito_en:audiocpu", 0) /* 68000 sound CPU */
+	ROM_REGION( 0x200000, "tilemap" , 0) /* Tiles */
+	ROM_LOAD32_WORD("e10-07.rom", 0x000000, 0x100000, CRC(dcb3c29b) SHA1(b80c3a8ce53d696c57675e654c9927ef8687759e) )
+	ROM_LOAD32_WORD("e10-06.rom", 0x000002, 0x100000, CRC(1b0f20e2) SHA1(66b44d059c2896abac2f0e7fc932489dee440ba0) )
+
+	ROM_REGION( 0x100000, "tilemap_hi", 0 )
+	ROM_LOAD       ("e10-05.rom", 0x000000, 0x100000, CRC(81266151) SHA1(aa3b144f32995425db97efce440e234a3c7a6715) )
+
+	ROM_REGION( 0x180000, "taito_en:audiocpu", 0 ) /* 68000 sound CPU */
 	ROM_LOAD16_BYTE("e10-30.32", 0x100000, 0x40000, CRC(bb090c1e) SHA1(af2ff23d6f9bd56c25530cb9bf9f452b6f5210f5) )
 	ROM_LOAD16_BYTE("e10-31.33", 0x100001, 0x40000, CRC(f4b88d65) SHA1(c74dcb4bed979039fad1d5c7528c14ce4db1d5ec) )
 
-	ROM_REGION16_BE(0x800000, "ensoniq.0" , ROMREGION_ERASE00 ) // V2: 4 banks, only 2 populated
+	ROM_REGION16_BE( 0x800000, "ensoniq.0" , ROMREGION_ERASE00 ) // V2: 4 banks, only 2 populated
 	ROM_LOAD16_BYTE("e10-04.rom", 0x000000, 0x200000, CRC(5c0862a6) SHA1(f916f63b8629239e3221e1e231e1b39962ef38ba) )    // C8 C9 CA CB
 	ROM_LOAD16_BYTE("e10-03.rom", 0x400000, 0x200000, CRC(46d68ac8) SHA1(ad014e9f0d458308014959ca6823077f581ab088) )    // CC CD CE CF
 
@@ -2986,57 +3108,61 @@ ROM_START( pbobble2x )
 ROM_END
 
 ROM_START( gekiridn )
-	ROM_REGION(0x200000, "maincpu", 0) /* 68020 code */
+	ROM_REGION( 0x200000, "maincpu", 0 ) /* 68020 code */
 	ROM_LOAD32_BYTE("e11-12.ic20", 0x000000, 0x40000, CRC(6a7aaacf) SHA1(a8114c84e76c75c908a61d985d96aa4eb9a0ac5a) )
 	ROM_LOAD32_BYTE("e11-11.ic19", 0x000001, 0x40000, CRC(2284a08e) SHA1(3dcb91be0d3491ad5e77efd30bacd506dad0f848) )
 	ROM_LOAD32_BYTE("e11-10.ic18", 0x000002, 0x40000, CRC(8795e6ba) SHA1(9128c29fdce3276f55aad47451e4a507470c8b9f) )
 	ROM_LOAD32_BYTE("e11-15.ic17", 0x000003, 0x40000, CRC(5aef1fd8) SHA1(a94884e39172e664759bff53a6dd2f93422d3299) )
 
-	ROM_REGION(0x800000, "gfx1" , 0) /* Sprites */
+	ROM_REGION( 0x400000, "sprites" , 0) /* Sprites */
 	ROM_LOAD16_BYTE("e11-03.ic12", 0x000000, 0x200000, CRC(f73877c5) SHA1(1f6b7c0b8a0aaab3e5427d21de7fad3d3cbf737a) )
 	ROM_LOAD16_BYTE("e11-02.ic8",  0x000001, 0x200000, CRC(5722a83b) SHA1(823c20a33016a5506ca5415ec615c3d2546ca9ab) )
-	ROM_LOAD       ("e11-01.ic4",  0x600000, 0x200000, CRC(c2cd1069) SHA1(9744dd3d8a6d9200cea4429dafce5620b60e2960) )
-	ROM_FILL       (               0x400000, 0x200000, 0x00 )
 
-	ROM_REGION(0x800000, "gfx2" , 0) /* Tiles */
-	ROM_LOAD16_BYTE("e11-08.ic47", 0x000000, 0x200000, CRC(907f69d3) SHA1(0899ed58edcae22144625c349c9d2fe4d46d11e3) )
-	ROM_LOAD16_BYTE("e11-07.ic45", 0x000001, 0x200000, CRC(ef018607) SHA1(61b602b13754c3be21caf76acbfc10c87518ba47) )
-	ROM_LOAD       ("e11-06.ic43", 0x600000, 0x200000, CRC(200ce305) SHA1(c80a0b96510913a6411e6763fb72bf413fb792da) )
-	ROM_FILL       (               0x400000, 0x200000, 0x00 )
+	ROM_REGION( 0x200000, "sprites_hi", 0 )
+	ROM_LOAD       ("e11-01.ic4",  0x000000, 0x200000, CRC(c2cd1069) SHA1(9744dd3d8a6d9200cea4429dafce5620b60e2960) )
 
-	ROM_REGION(0x180000, "taito_en:audiocpu", 0) /* 68000 sound CPU */
+	ROM_REGION( 0x400000, "tilemap" , 0) /* Tiles */
+	ROM_LOAD32_WORD("e11-08.ic47", 0x000000, 0x200000, CRC(907f69d3) SHA1(0899ed58edcae22144625c349c9d2fe4d46d11e3) )
+	ROM_LOAD32_WORD("e11-07.ic45", 0x000002, 0x200000, CRC(ef018607) SHA1(61b602b13754c3be21caf76acbfc10c87518ba47) )
+
+	ROM_REGION( 0x200000, "tilemap_hi", 0 )
+	ROM_LOAD       ("e11-06.ic43", 0x000000, 0x200000, CRC(200ce305) SHA1(c80a0b96510913a6411e6763fb72bf413fb792da) )
+
+	ROM_REGION( 0x180000, "taito_en:audiocpu", 0 ) /* 68000 sound CPU */
 	ROM_LOAD16_BYTE("e11-13.ic32", 0x100000, 0x40000, CRC(f5c5486a) SHA1(4091f3ddb1e6cbc9dc89485e1e784a4b6fa191b7) )
 	ROM_LOAD16_BYTE("e11-14.ic33", 0x100001, 0x40000, CRC(7fa10f96) SHA1(50efefd890535e952022a494c5b4e9b33bb90fad) )
 
-	ROM_REGION16_BE(0x800000, "ensoniq.0" , ROMREGION_ERASE00 ) // V2: 4 banks, only 2 populated
+	ROM_REGION16_BE( 0x800000, "ensoniq.0" , ROMREGION_ERASE00 ) // V2: 4 banks, only 2 populated
 	ROM_LOAD16_BYTE("e11-04.ic38", 0x000000, 0x200000, CRC(e0ff4fb1) SHA1(81e186e3a692af1da316b8085a729c4f103d9a52) )   // C8 C9 CA CB
 	ROM_LOAD16_BYTE("e11-05.ic41", 0x400000, 0x200000, CRC(a4d08cf1) SHA1(ae2cabef7b7bcb8a788988c73d7af6fa4bb2c444) )   // CC CD -std-
 ROM_END
 
 ROM_START( gekiridnj )
-	ROM_REGION(0x200000, "maincpu", 0) /* 68020 code */
+	ROM_REGION( 0x200000, "maincpu", 0 ) /* 68020 code */
 	ROM_LOAD32_BYTE("e11-12.ic20", 0x000000, 0x40000, CRC(6a7aaacf) SHA1(a8114c84e76c75c908a61d985d96aa4eb9a0ac5a) )
 	ROM_LOAD32_BYTE("e11-11.ic19", 0x000001, 0x40000, CRC(2284a08e) SHA1(3dcb91be0d3491ad5e77efd30bacd506dad0f848) )
 	ROM_LOAD32_BYTE("e11-10.ic18", 0x000002, 0x40000, CRC(8795e6ba) SHA1(9128c29fdce3276f55aad47451e4a507470c8b9f) )
 	ROM_LOAD32_BYTE("e11-09.ic17", 0x000003, 0x40000, CRC(b4e17ef4) SHA1(ab06ab68aaa487cc3046a15fef3dde8581197391) )
 
-	ROM_REGION(0x800000, "gfx1" , 0) /* Sprites */
+	ROM_REGION( 0x400000, "sprites" , 0) /* Sprites */
 	ROM_LOAD16_BYTE("e11-03.ic12", 0x000000, 0x200000, CRC(f73877c5) SHA1(1f6b7c0b8a0aaab3e5427d21de7fad3d3cbf737a) )
 	ROM_LOAD16_BYTE("e11-02.ic8",  0x000001, 0x200000, CRC(5722a83b) SHA1(823c20a33016a5506ca5415ec615c3d2546ca9ab) )
-	ROM_LOAD       ("e11-01.ic4",  0x600000, 0x200000, CRC(c2cd1069) SHA1(9744dd3d8a6d9200cea4429dafce5620b60e2960) )
-	ROM_FILL       (               0x400000, 0x200000, 0x00 )
 
-	ROM_REGION(0x800000, "gfx2" , 0) /* Tiles */
-	ROM_LOAD16_BYTE("e11-08.ic47", 0x000000, 0x200000, CRC(907f69d3) SHA1(0899ed58edcae22144625c349c9d2fe4d46d11e3) )
-	ROM_LOAD16_BYTE("e11-07.ic45", 0x000001, 0x200000, CRC(ef018607) SHA1(61b602b13754c3be21caf76acbfc10c87518ba47) )
-	ROM_LOAD       ("e11-06.ic43", 0x600000, 0x200000, CRC(200ce305) SHA1(c80a0b96510913a6411e6763fb72bf413fb792da) )
-	ROM_FILL       (               0x400000, 0x200000, 0x00 )
+	ROM_REGION( 0x200000, "sprites_hi", 0 )
+	ROM_LOAD       ("e11-01.ic4",  0x000000, 0x200000, CRC(c2cd1069) SHA1(9744dd3d8a6d9200cea4429dafce5620b60e2960) )
 
-	ROM_REGION(0x180000, "taito_en:audiocpu", 0) /* 68000 sound CPU */
+	ROM_REGION( 0x400000, "tilemap" , 0) /* Tiles */
+	ROM_LOAD32_WORD("e11-08.ic47", 0x000000, 0x200000, CRC(907f69d3) SHA1(0899ed58edcae22144625c349c9d2fe4d46d11e3) )
+	ROM_LOAD32_WORD("e11-07.ic45", 0x000002, 0x200000, CRC(ef018607) SHA1(61b602b13754c3be21caf76acbfc10c87518ba47) )
+
+	ROM_REGION( 0x200000, "tilemap_hi", 0 )
+	ROM_LOAD       ("e11-06.ic43", 0x000000, 0x200000, CRC(200ce305) SHA1(c80a0b96510913a6411e6763fb72bf413fb792da) )
+
+	ROM_REGION( 0x180000, "taito_en:audiocpu", 0 ) /* 68000 sound CPU */
 	ROM_LOAD16_BYTE("e11-13.ic32", 0x100000, 0x40000, CRC(f5c5486a) SHA1(4091f3ddb1e6cbc9dc89485e1e784a4b6fa191b7) )
 	ROM_LOAD16_BYTE("e11-14.ic33", 0x100001, 0x40000, CRC(7fa10f96) SHA1(50efefd890535e952022a494c5b4e9b33bb90fad) )
 
-	ROM_REGION16_BE(0x800000, "ensoniq.0" , ROMREGION_ERASE00 ) // V2: 4 banks, only 2 populated
+	ROM_REGION16_BE( 0x800000, "ensoniq.0" , ROMREGION_ERASE00 ) // V2: 4 banks, only 2 populated
 	ROM_LOAD16_BYTE("e11-04.ic38", 0x000000, 0x200000, CRC(e0ff4fb1) SHA1(81e186e3a692af1da316b8085a729c4f103d9a52) )   // C8 C9 CA CB
 	ROM_LOAD16_BYTE("e11-05.ic41", 0x400000, 0x200000, CRC(a4d08cf1) SHA1(ae2cabef7b7bcb8a788988c73d7af6fa4bb2c444) )   // CC CD -std-
 ROM_END
@@ -3046,31 +3172,33 @@ ROM_END
 */
 
 ROM_START( tcobra2 )
-	ROM_REGION(0x200000, "maincpu", 0) /* 68020 code */
+	ROM_REGION( 0x200000, "maincpu", 0 ) /* 68020 code */
 	ROM_LOAD32_BYTE("e15-14.ic20", 0x000000, 0x40000, CRC(b527b733) SHA1(19efd647ea9c277b306714fe79ebf40d5f9d2187) )
 	ROM_LOAD32_BYTE("e15-13.ic19", 0x000001, 0x40000, CRC(0f03daf7) SHA1(de5aee5a339224dfe5e03a02d3ef5ffd5a39211e) )
 	ROM_LOAD32_BYTE("e15-12.ic18", 0x000002, 0x40000, CRC(59d832f2) SHA1(27019b4121b1f8b0b9e141234192b3da1a4af718) )
 	ROM_LOAD32_BYTE("e15-18.ic17", 0x000003, 0x40000, CRC(4908c3aa) SHA1(9b0230e6bafd0533ecbe89bc18fae6f3425ea1a3) )
 
-	ROM_REGION(0xc00000, "gfx1" , 0) /* Sprites */
+	ROM_REGION( 0x600000, "sprites" , 0) /* Sprites */
 	ROM_LOAD16_BYTE("e15-04.ic12", 0x000000, 0x200000, CRC(6ea8d9bd) SHA1(c31644e89752325ba2f174b60e31bd9659479391) )
 	ROM_LOAD16_BYTE("e15-02.ic8",  0x000001, 0x200000, CRC(bf1232aa) SHA1(1381bae2a18ed62f4ca28bcdaf07debfc9bf21af) )
 	ROM_LOAD16_BYTE("e15-03.ic11", 0x400000, 0x100000, CRC(be45a52f) SHA1(5d9735a774233b43003057cbab6ae7d6e0195dd2) )
 	ROM_LOAD16_BYTE("e15-01.ic7",  0x400001, 0x100000, CRC(85421aac) SHA1(327e72f0107e024ec9fc9dc20d381e2e20f36248) )
-	ROM_FILL       (               0x600000, 0x600000, 0x00 )
 
-	ROM_REGION(0xc00000, "gfx2" , 0) /* Tiles */
-	ROM_LOAD16_BYTE("e15-10.ic47", 0x000000, 0x200000, CRC(d8c96b00) SHA1(9cd275abb66b3475433ea2649dc872d7d35eb5b8) )
-	ROM_LOAD16_BYTE("e15-08.ic45", 0x000001, 0x200000, CRC(4bdb2bf3) SHA1(1146b7a5d9f26d3173a7c64768e55d53a0ab7b8e) )
-	ROM_LOAD16_BYTE("e15-09.ic46", 0x400000, 0x100000, CRC(07c29f60) SHA1(3ca0f632e7047cc50ee3ce24cd6c0c8c7252a278) )
-	ROM_LOAD16_BYTE("e15-07.ic44", 0x400001, 0x100000, CRC(8164f7ee) SHA1(4550521f820e93ec08b86d148135966d016cbf22) )
-	ROM_FILL       (               0x600000, 0x600000, 0x00 )
+	EMPTY_SPRITE_HIDATA(0x300000)
 
-	ROM_REGION(0x140000, "taito_en:audiocpu", 0) /* 68000 sound CPU */
+	ROM_REGION( 0x600000, "tilemap" , 0) /* Tiles */
+	ROM_LOAD32_WORD("e15-10.ic47", 0x000000, 0x200000, CRC(d8c96b00) SHA1(9cd275abb66b3475433ea2649dc872d7d35eb5b8) )
+	ROM_LOAD32_WORD("e15-08.ic45", 0x000002, 0x200000, CRC(4bdb2bf3) SHA1(1146b7a5d9f26d3173a7c64768e55d53a0ab7b8e) )
+	ROM_LOAD32_WORD("e15-09.ic46", 0x400000, 0x100000, CRC(07c29f60) SHA1(3ca0f632e7047cc50ee3ce24cd6c0c8c7252a278) )
+	ROM_LOAD32_WORD("e15-07.ic44", 0x400002, 0x100000, CRC(8164f7ee) SHA1(4550521f820e93ec08b86d148135966d016cbf22) )
+
+	EMPTY_TILEMAP_HIDATA(0x300000)
+
+	ROM_REGION( 0x140000, "taito_en:audiocpu", 0 ) /* 68000 sound CPU */
 	ROM_LOAD16_BYTE("e15-15.ic32", 0x100000, 0x20000, CRC(22126dfb) SHA1(a1af17e5c3440f1bab50d79f92c251f1a4536ca0) )
 	ROM_LOAD16_BYTE("e15-16.ic33", 0x100001, 0x20000, CRC(f8b58ea0) SHA1(c9e196620765efc4c7b535793a5d1f586698ce55) )
 
-	ROM_REGION16_BE(0x800000, "ensoniq.0" , ROMREGION_ERASE00 ) // V2: 4 banks, only 2 populated
+	ROM_REGION16_BE( 0x800000, "ensoniq.0" , ROMREGION_ERASE00 ) // V2: 4 banks, only 2 populated
 	ROM_LOAD16_BYTE("e15-05.ic38", 0x000000, 0x200000, CRC(3e5da5f6) SHA1(da6fc8b26cd02c45cfc0f1aa5292614e4d28cae4) )    // C8 C9 CA CB
 	ROM_LOAD16_BYTE("e15-06.ic41", 0x400000, 0x200000, CRC(b182a3e1) SHA1(db8569b069911bb84900b2aa5168c45ba3e985c7) )    // CC CD -std-
 
@@ -3083,31 +3211,33 @@ ROM_START( tcobra2 )
 ROM_END
 
 ROM_START( tcobra2u )
-	ROM_REGION(0x200000, "maincpu", 0) /* 68020 code */
+	ROM_REGION( 0x200000, "maincpu", 0 ) /* 68020 code */
 	ROM_LOAD32_BYTE("e15-14.ic20", 0x000000, 0x40000, CRC(b527b733) SHA1(19efd647ea9c277b306714fe79ebf40d5f9d2187) )
 	ROM_LOAD32_BYTE("e15-13.ic19", 0x000001, 0x40000, CRC(0f03daf7) SHA1(de5aee5a339224dfe5e03a02d3ef5ffd5a39211e) )
 	ROM_LOAD32_BYTE("e15-12.ic18", 0x000002, 0x40000, CRC(59d832f2) SHA1(27019b4121b1f8b0b9e141234192b3da1a4af718) )
 	ROM_LOAD32_BYTE("e15-17.ic17", 0x000003, 0x40000, CRC(3e0ff33c) SHA1(6da0a69272172e03921417f3949817756c7894b4) )
 
-	ROM_REGION(0xc00000, "gfx1" , 0) /* Sprites */
+	ROM_REGION( 0x600000, "sprites" , 0) /* Sprites */
 	ROM_LOAD16_BYTE("e15-04.ic12", 0x000000, 0x200000, CRC(6ea8d9bd) SHA1(c31644e89752325ba2f174b60e31bd9659479391) )
 	ROM_LOAD16_BYTE("e15-02.ic8",  0x000001, 0x200000, CRC(bf1232aa) SHA1(1381bae2a18ed62f4ca28bcdaf07debfc9bf21af) )
 	ROM_LOAD16_BYTE("e15-03.ic11", 0x400000, 0x100000, CRC(be45a52f) SHA1(5d9735a774233b43003057cbab6ae7d6e0195dd2) )
 	ROM_LOAD16_BYTE("e15-01.ic7",  0x400001, 0x100000, CRC(85421aac) SHA1(327e72f0107e024ec9fc9dc20d381e2e20f36248) )
-	ROM_FILL       (               0x600000, 0x600000, 0x00 )
 
-	ROM_REGION(0xc00000, "gfx2" , 0) /* Tiles */
-	ROM_LOAD16_BYTE("e15-10.ic47", 0x000000, 0x200000, CRC(d8c96b00) SHA1(9cd275abb66b3475433ea2649dc872d7d35eb5b8) )
-	ROM_LOAD16_BYTE("e15-08.ic45", 0x000001, 0x200000, CRC(4bdb2bf3) SHA1(1146b7a5d9f26d3173a7c64768e55d53a0ab7b8e) )
-	ROM_LOAD16_BYTE("e15-09.ic46", 0x400000, 0x100000, CRC(07c29f60) SHA1(3ca0f632e7047cc50ee3ce24cd6c0c8c7252a278) )
-	ROM_LOAD16_BYTE("e15-07.ic44", 0x400001, 0x100000, CRC(8164f7ee) SHA1(4550521f820e93ec08b86d148135966d016cbf22) )
-	ROM_FILL       (               0x600000, 0x600000, 0x00 )
+	EMPTY_SPRITE_HIDATA(0x300000)
 
-	ROM_REGION(0x140000, "taito_en:audiocpu", 0) /* 68000 sound CPU */
+	ROM_REGION( 0x600000, "tilemap" , 0) /* Tiles */
+	ROM_LOAD32_WORD("e15-10.ic47", 0x000000, 0x200000, CRC(d8c96b00) SHA1(9cd275abb66b3475433ea2649dc872d7d35eb5b8) )
+	ROM_LOAD32_WORD("e15-08.ic45", 0x000002, 0x200000, CRC(4bdb2bf3) SHA1(1146b7a5d9f26d3173a7c64768e55d53a0ab7b8e) )
+	ROM_LOAD32_WORD("e15-09.ic46", 0x400000, 0x100000, CRC(07c29f60) SHA1(3ca0f632e7047cc50ee3ce24cd6c0c8c7252a278) )
+	ROM_LOAD32_WORD("e15-07.ic44", 0x400002, 0x100000, CRC(8164f7ee) SHA1(4550521f820e93ec08b86d148135966d016cbf22) )
+
+	EMPTY_TILEMAP_HIDATA(0x300000)
+
+	ROM_REGION( 0x140000, "taito_en:audiocpu", 0 ) /* 68000 sound CPU */
 	ROM_LOAD16_BYTE("e15-15.ic32", 0x100000, 0x20000, CRC(22126dfb) SHA1(a1af17e5c3440f1bab50d79f92c251f1a4536ca0) )
 	ROM_LOAD16_BYTE("e15-16.ic33", 0x100001, 0x20000, CRC(f8b58ea0) SHA1(c9e196620765efc4c7b535793a5d1f586698ce55) )
 
-	ROM_REGION16_BE(0x800000, "ensoniq.0" , ROMREGION_ERASE00 ) // V2: 4 banks, only 2 populated
+	ROM_REGION16_BE( 0x800000, "ensoniq.0" , ROMREGION_ERASE00 ) // V2: 4 banks, only 2 populated
 	ROM_LOAD16_BYTE("e15-05.ic38", 0x000000, 0x200000, CRC(3e5da5f6) SHA1(da6fc8b26cd02c45cfc0f1aa5292614e4d28cae4) )    // C8 C9 CA CB
 	ROM_LOAD16_BYTE("e15-06.ic41", 0x400000, 0x200000, CRC(b182a3e1) SHA1(db8569b069911bb84900b2aa5168c45ba3e985c7) )    // CC CD -std-
 
@@ -3120,31 +3250,33 @@ ROM_START( tcobra2u )
 ROM_END
 
 ROM_START( ktiger2 )
-	ROM_REGION(0x200000, "maincpu", 0) /* 68020 code */
+	ROM_REGION( 0x200000, "maincpu", 0 ) /* 68020 code */
 	ROM_LOAD32_BYTE("e15-14.ic20", 0x000000, 0x40000, CRC(b527b733) SHA1(19efd647ea9c277b306714fe79ebf40d5f9d2187) )
 	ROM_LOAD32_BYTE("e15-13.ic19", 0x000001, 0x40000, CRC(0f03daf7) SHA1(de5aee5a339224dfe5e03a02d3ef5ffd5a39211e) )
 	ROM_LOAD32_BYTE("e15-12.ic18", 0x000002, 0x40000, CRC(59d832f2) SHA1(27019b4121b1f8b0b9e141234192b3da1a4af718) )
 	ROM_LOAD32_BYTE("e15-11.ic17", 0x000003, 0x40000, CRC(a706a286) SHA1(c3d1cdb0c5b1004acadc926ffd9083c9afea8608) )
 
-	ROM_REGION(0xc00000, "gfx1" , 0) /* Sprites */
+	ROM_REGION( 0x600000, "sprites" , 0) /* Sprites */
 	ROM_LOAD16_BYTE("e15-04.ic12", 0x000000, 0x200000, CRC(6ea8d9bd) SHA1(c31644e89752325ba2f174b60e31bd9659479391) )
 	ROM_LOAD16_BYTE("e15-02.ic8",  0x000001, 0x200000, CRC(bf1232aa) SHA1(1381bae2a18ed62f4ca28bcdaf07debfc9bf21af) )
 	ROM_LOAD16_BYTE("e15-03.ic11", 0x400000, 0x100000, CRC(be45a52f) SHA1(5d9735a774233b43003057cbab6ae7d6e0195dd2) )
 	ROM_LOAD16_BYTE("e15-01.ic7",  0x400001, 0x100000, CRC(85421aac) SHA1(327e72f0107e024ec9fc9dc20d381e2e20f36248) )
-	ROM_FILL       (               0x600000, 0x600000, 0x00 )
 
-	ROM_REGION(0xc00000, "gfx2" , 0) /* Tiles */
-	ROM_LOAD16_BYTE("e15-10.ic47", 0x000000, 0x200000, CRC(d8c96b00) SHA1(9cd275abb66b3475433ea2649dc872d7d35eb5b8) )
-	ROM_LOAD16_BYTE("e15-08.ic45", 0x000001, 0x200000, CRC(4bdb2bf3) SHA1(1146b7a5d9f26d3173a7c64768e55d53a0ab7b8e) )
-	ROM_LOAD16_BYTE("e15-09.ic46", 0x400000, 0x100000, CRC(07c29f60) SHA1(3ca0f632e7047cc50ee3ce24cd6c0c8c7252a278) )
-	ROM_LOAD16_BYTE("e15-07.ic44", 0x400001, 0x100000, CRC(8164f7ee) SHA1(4550521f820e93ec08b86d148135966d016cbf22) )
-	ROM_FILL       (               0x600000, 0x600000, 0x00 )
+	EMPTY_SPRITE_HIDATA(0x300000)
 
-	ROM_REGION(0x140000, "taito_en:audiocpu", 0) /* 68000 sound CPU */
+	ROM_REGION( 0x600000, "tilemap" , 0) /* Tiles */
+	ROM_LOAD32_WORD("e15-10.ic47", 0x000000, 0x200000, CRC(d8c96b00) SHA1(9cd275abb66b3475433ea2649dc872d7d35eb5b8) )
+	ROM_LOAD32_WORD("e15-08.ic45", 0x000002, 0x200000, CRC(4bdb2bf3) SHA1(1146b7a5d9f26d3173a7c64768e55d53a0ab7b8e) )
+	ROM_LOAD32_WORD("e15-09.ic46", 0x400000, 0x100000, CRC(07c29f60) SHA1(3ca0f632e7047cc50ee3ce24cd6c0c8c7252a278) )
+	ROM_LOAD32_WORD("e15-07.ic44", 0x400002, 0x100000, CRC(8164f7ee) SHA1(4550521f820e93ec08b86d148135966d016cbf22) )
+
+	EMPTY_TILEMAP_HIDATA(0x300000)
+
+	ROM_REGION( 0x140000, "taito_en:audiocpu", 0 ) /* 68000 sound CPU */
 	ROM_LOAD16_BYTE("e15-15.ic32", 0x100000, 0x20000, CRC(22126dfb) SHA1(a1af17e5c3440f1bab50d79f92c251f1a4536ca0) )
 	ROM_LOAD16_BYTE("e15-16.ic33", 0x100001, 0x20000, CRC(f8b58ea0) SHA1(c9e196620765efc4c7b535793a5d1f586698ce55) )
 
-	ROM_REGION16_BE(0x800000, "ensoniq.0" , ROMREGION_ERASE00 ) // V2: 4 banks, only 2 populated
+	ROM_REGION16_BE( 0x800000, "ensoniq.0" , ROMREGION_ERASE00 ) // V2: 4 banks, only 2 populated
 	ROM_LOAD16_BYTE("e15-05.ic38", 0x000000, 0x200000, CRC(3e5da5f6) SHA1(da6fc8b26cd02c45cfc0f1aa5292614e4d28cae4) )    // C8 C9 CA CB
 	ROM_LOAD16_BYTE("e15-06.ic41", 0x400000, 0x200000, CRC(b182a3e1) SHA1(db8569b069911bb84900b2aa5168c45ba3e985c7) )    // CC CD -std-
 
@@ -3157,28 +3289,30 @@ ROM_START( ktiger2 )
 ROM_END
 
 ROM_START( bubblem )
-	ROM_REGION(0x200000, "maincpu", 0) /* 68020 code */
+	ROM_REGION( 0x200000, "maincpu", 0 ) /* 68020 code */
 	ROM_LOAD32_BYTE("e21-21.20", 0x000000, 0x080000, CRC(cac4169c) SHA1(e1e5b9bbaecfd29ee764c8b29df8ffd08ef01866) )
 	ROM_LOAD32_BYTE("e21-20.19", 0x000001, 0x080000, CRC(7727c673) SHA1(cda3dbcf8da06e81b899008462bcd6b2ea43db81) )
 	ROM_LOAD32_BYTE("e21-19.18", 0x000002, 0x080000, CRC(be0b907d) SHA1(8bb6a149a4b0ccdb32396f7e750218a0bdc31965) )
 	ROM_LOAD32_BYTE("e21-18.17", 0x000003, 0x080000, CRC(d14e313a) SHA1(3913d396a6a72f539163c216809e54a06ecd3b96) )
 
-	ROM_REGION(0x800000, "gfx1" , 0) /* Sprites */
+	ROM_REGION( 0x400000, "sprites" , 0) /* Sprites */
 	ROM_LOAD16_BYTE("e21-02.rom", 0x000000, 0x200000, CRC(b7cb9232) SHA1(ba71cb98d49eadebb26d9f53bbaec1dc211077f5) )
 	ROM_LOAD16_BYTE("e21-01.rom", 0x000001, 0x200000, CRC(a11f2f99) SHA1(293c5996600cad05bf98f936f5f820d93d546099) )
-	ROM_FILL       (              0x400000, 0x400000, 0x00 )
 
-	ROM_REGION(0x400000, "gfx2" , 0) /* Tiles */
-	ROM_LOAD16_BYTE("e21-07.rom", 0x000000, 0x100000, CRC(7789bf7c) SHA1(bc8ef1696adac99a1fabae9b79afcd3461cf323b) )
-	ROM_LOAD16_BYTE("e21-06.rom", 0x000001, 0x100000, CRC(997fc0d7) SHA1(58a546f739072fedebfe7c972fe85f72107726b2) )
-	ROM_LOAD       ("e21-05.rom", 0x300000, 0x100000, CRC(07eab58f) SHA1(ae2d7b839b39d88d11652df74804a39230674467) )
-	ROM_FILL       (              0x200000, 0x100000, 0x00 )
+	EMPTY_SPRITE_HIDATA(0x200000)
 
-	ROM_REGION(0x180000, "taito_en:audiocpu", 0) /* Sound CPU */
+	ROM_REGION( 0x200000, "tilemap" , 0) /* Tiles */
+	ROM_LOAD32_WORD("e21-07.rom", 0x000000, 0x100000, CRC(7789bf7c) SHA1(bc8ef1696adac99a1fabae9b79afcd3461cf323b) )
+	ROM_LOAD32_WORD("e21-06.rom", 0x000002, 0x100000, CRC(997fc0d7) SHA1(58a546f739072fedebfe7c972fe85f72107726b2) )
+
+	ROM_REGION( 0x100000, "tilemap_hi", 0 )
+	ROM_LOAD       ("e21-05.rom", 0x000000, 0x100000, CRC(07eab58f) SHA1(ae2d7b839b39d88d11652df74804a39230674467) )
+
+	ROM_REGION( 0x180000, "taito_en:audiocpu", 0 ) /* Sound CPU */
 	ROM_LOAD16_BYTE("e21-12.32", 0x100000, 0x40000, CRC(34093de1) SHA1(d69d6b5f10b8fe86f727d739ed5aecceb15e01f7) )
 	ROM_LOAD16_BYTE("e21-13.33", 0x100001, 0x40000, CRC(9e9ec437) SHA1(b0265b688846c642d240b2f3677d2330d31eaa87) )
 
-	ROM_REGION16_BE(0x800000, "ensoniq.0" , ROMREGION_ERASE00 ) // V2: 4 banks, only 2 populated
+	ROM_REGION16_BE( 0x800000, "ensoniq.0" , ROMREGION_ERASE00 ) // V2: 4 banks, only 2 populated
 	ROM_LOAD16_BYTE("e21-03.rom", 0x000000, 0x200000, CRC(54c5f83d) SHA1(10a993199c8d5a1361bd29a4b92c404451c6da01) )    // C8 C9 CA CB
 	ROM_LOAD16_BYTE("e21-04.rom", 0x400000, 0x200000, CRC(e5af2a2d) SHA1(62a49504decc7160b710260218920d2d6d2af8f0) )    // CC CD -std-
 
@@ -3187,28 +3321,30 @@ ROM_START( bubblem )
 ROM_END
 
 ROM_START( bubblemu )
-	ROM_REGION(0x200000, "maincpu", 0) /* 68020 code */
+	ROM_REGION( 0x200000, "maincpu", 0 ) /* 68020 code */
 	ROM_LOAD32_BYTE("e21-17.20", 0x000000, 0x080000, CRC(0b72e8f1) SHA1(1b0289cafb1d4d3387c6ec42c0e8599229c79bba) )
 	ROM_LOAD32_BYTE("e21-16.19", 0x000001, 0x080000, CRC(b47354cc) SHA1(08e66573cae3ce21a6dbdbd79e32a2ab050f9bbd) )
 	ROM_LOAD32_BYTE("e21-15.18", 0x000002, 0x080000, CRC(64bf2c24) SHA1(be2d81fdc307841340a86a4ca0409a2bdbd35532) )
 	ROM_LOAD32_BYTE("e21-14.17", 0x000003, 0x080000, CRC(48aecd47) SHA1(3d2b7d3474968b0450731644e593338c9cf6f5b0) )
 
-	ROM_REGION(0x800000, "gfx1" , 0) /* Sprites */
+	ROM_REGION( 0x400000, "sprites" , 0) /* Sprites */
 	ROM_LOAD16_BYTE("e21-02.rom", 0x000000, 0x200000, CRC(b7cb9232) SHA1(ba71cb98d49eadebb26d9f53bbaec1dc211077f5) )
 	ROM_LOAD16_BYTE("e21-01.rom", 0x000001, 0x200000, CRC(a11f2f99) SHA1(293c5996600cad05bf98f936f5f820d93d546099) )
-	ROM_FILL       (              0x400000, 0x400000, 0x00 )
 
-	ROM_REGION(0x400000, "gfx2" , 0) /* Tiles */
-	ROM_LOAD16_BYTE("e21-07.rom", 0x000000, 0x100000, CRC(7789bf7c) SHA1(bc8ef1696adac99a1fabae9b79afcd3461cf323b) )
-	ROM_LOAD16_BYTE("e21-06.rom", 0x000001, 0x100000, CRC(997fc0d7) SHA1(58a546f739072fedebfe7c972fe85f72107726b2) )
-	ROM_LOAD       ("e21-05.rom", 0x300000, 0x100000, CRC(07eab58f) SHA1(ae2d7b839b39d88d11652df74804a39230674467) )
-	ROM_FILL       (              0x200000, 0x100000, 0x00 )
+	EMPTY_SPRITE_HIDATA(0x200000)
 
-	ROM_REGION(0x180000, "taito_en:audiocpu", 0) /* Sound CPU */
+	ROM_REGION( 0x200000, "tilemap" , 0) /* Tiles */
+	ROM_LOAD32_WORD("e21-07.rom", 0x000000, 0x100000, CRC(7789bf7c) SHA1(bc8ef1696adac99a1fabae9b79afcd3461cf323b) )
+	ROM_LOAD32_WORD("e21-06.rom", 0x000002, 0x100000, CRC(997fc0d7) SHA1(58a546f739072fedebfe7c972fe85f72107726b2) )
+
+	ROM_REGION( 0x100000, "tilemap_hi", 0 )
+	ROM_LOAD       ("e21-05.rom", 0x000000, 0x100000, CRC(07eab58f) SHA1(ae2d7b839b39d88d11652df74804a39230674467) )
+
+	ROM_REGION( 0x180000, "taito_en:audiocpu", 0 ) /* Sound CPU */
 	ROM_LOAD16_BYTE("e21-12.32", 0x100000, 0x40000, CRC(34093de1) SHA1(d69d6b5f10b8fe86f727d739ed5aecceb15e01f7) )
 	ROM_LOAD16_BYTE("e21-13.33", 0x100001, 0x40000, CRC(9e9ec437) SHA1(b0265b688846c642d240b2f3677d2330d31eaa87) )
 
-	ROM_REGION16_BE(0x800000, "ensoniq.0" , ROMREGION_ERASE00 ) // V2: 4 banks, only 2 populated
+	ROM_REGION16_BE( 0x800000, "ensoniq.0" , ROMREGION_ERASE00 ) // V2: 4 banks, only 2 populated
 	ROM_LOAD16_BYTE("e21-03.rom", 0x000000, 0x200000, CRC(54c5f83d) SHA1(10a993199c8d5a1361bd29a4b92c404451c6da01) )    // C8 C9 CA CB
 	ROM_LOAD16_BYTE("e21-04.rom", 0x400000, 0x200000, CRC(e5af2a2d) SHA1(62a49504decc7160b710260218920d2d6d2af8f0) )    // CC CD -std-
 
@@ -3217,28 +3353,30 @@ ROM_START( bubblemu )
 ROM_END
 
 ROM_START( bubblemj )
-	ROM_REGION(0x200000, "maincpu", 0) /* 68020 code */
+	ROM_REGION( 0x200000, "maincpu", 0 ) /* 68020 code */
 	ROM_LOAD32_BYTE("e21-11.20", 0x000000, 0x080000, CRC(df0eeae4) SHA1(4cc8d350da881947c1b9c4e0b8fbe220494f6c38) )
 	ROM_LOAD32_BYTE("e21-10.19", 0x000001, 0x080000, CRC(cdfb58f6) SHA1(70d2b8228ab4ddd572fe2ee53c1b7205b66ef6a3) )
 	ROM_LOAD32_BYTE("e21-09.18", 0x000002, 0x080000, CRC(6c305f17) SHA1(c4118722d697ccf54b43626a47673892a6c2caaf) )
 	ROM_LOAD32_BYTE("e21-08.17", 0x000003, 0x080000, CRC(27381ae2) SHA1(29b5d4bafa4ac02d35cb3ed7b7461e749ef2d6d6) )
 
-	ROM_REGION(0x800000, "gfx1" , 0) /* Sprites */
+	ROM_REGION( 0x400000, "sprites" , 0) /* Sprites */
 	ROM_LOAD16_BYTE("e21-02.rom", 0x000000, 0x200000, CRC(b7cb9232) SHA1(ba71cb98d49eadebb26d9f53bbaec1dc211077f5) )
 	ROM_LOAD16_BYTE("e21-01.rom", 0x000001, 0x200000, CRC(a11f2f99) SHA1(293c5996600cad05bf98f936f5f820d93d546099) )
-	ROM_FILL       (              0x400000, 0x400000, 0x00 )
 
-	ROM_REGION(0x400000, "gfx2" , 0) /* Tiles */
-	ROM_LOAD16_BYTE("e21-07.rom", 0x000000, 0x100000, CRC(7789bf7c) SHA1(bc8ef1696adac99a1fabae9b79afcd3461cf323b) )
-	ROM_LOAD16_BYTE("e21-06.rom", 0x000001, 0x100000, CRC(997fc0d7) SHA1(58a546f739072fedebfe7c972fe85f72107726b2) )
-	ROM_LOAD       ("e21-05.rom", 0x300000, 0x100000, CRC(07eab58f) SHA1(ae2d7b839b39d88d11652df74804a39230674467) )
-	ROM_FILL       (              0x200000, 0x100000, 0x00 )
+	EMPTY_SPRITE_HIDATA(0x200000)
 
-	ROM_REGION(0x180000, "taito_en:audiocpu", 0) /* Sound CPU */
+	ROM_REGION( 0x200000, "tilemap" , 0) /* Tiles */
+	ROM_LOAD32_WORD("e21-07.rom", 0x000000, 0x100000, CRC(7789bf7c) SHA1(bc8ef1696adac99a1fabae9b79afcd3461cf323b) )
+	ROM_LOAD32_WORD("e21-06.rom", 0x000002, 0x100000, CRC(997fc0d7) SHA1(58a546f739072fedebfe7c972fe85f72107726b2) )
+
+	ROM_REGION( 0x100000, "tilemap_hi", 0 )
+	ROM_LOAD       ("e21-05.rom", 0x000000, 0x100000, CRC(07eab58f) SHA1(ae2d7b839b39d88d11652df74804a39230674467) )
+
+	ROM_REGION( 0x180000, "taito_en:audiocpu", 0 ) /* Sound CPU */
 	ROM_LOAD16_BYTE("e21-12.32", 0x100000, 0x40000, CRC(34093de1) SHA1(d69d6b5f10b8fe86f727d739ed5aecceb15e01f7) )
 	ROM_LOAD16_BYTE("e21-13.33", 0x100001, 0x40000, CRC(9e9ec437) SHA1(b0265b688846c642d240b2f3677d2330d31eaa87) )
 
-	ROM_REGION16_BE(0x800000, "ensoniq.0" , ROMREGION_ERASE00 ) // V2: 4 banks, only 2 populated
+	ROM_REGION16_BE( 0x800000, "ensoniq.0" , ROMREGION_ERASE00 ) // V2: 4 banks, only 2 populated
 	ROM_LOAD16_BYTE("e21-03.rom", 0x000000, 0x200000, CRC(54c5f83d) SHA1(10a993199c8d5a1361bd29a4b92c404451c6da01) )    // C8 C9 CA CB
 	ROM_LOAD16_BYTE("e21-04.rom", 0x400000, 0x200000, CRC(e5af2a2d) SHA1(62a49504decc7160b710260218920d2d6d2af8f0) )    // CC CD -std-
 
@@ -3247,54 +3385,58 @@ ROM_START( bubblemj )
 ROM_END
 
 ROM_START( cleopatr )
-	ROM_REGION(0x200000, "maincpu", 0) /* 68020 code */
+	ROM_REGION( 0x200000, "maincpu", 0 ) /* 68020 code */
 	ROM_LOAD32_BYTE("e28-10.bin", 0x000000, 0x80000, CRC(013fbc39) SHA1(d36ac44609b88e1da35c98dda381042e0112ea00) )
 	ROM_LOAD32_BYTE("e28-09.bin", 0x000001, 0x80000, CRC(1c48a1f9) SHA1(791d321c03073cdd0269b970f926897446d2a6fb) )
 	ROM_LOAD32_BYTE("e28-08.bin", 0x000002, 0x80000, CRC(7564f199) SHA1(ec4b19edb0660ad478f6c0ec27d701368696a2e4) )
 	ROM_LOAD32_BYTE("e28-07.bin", 0x000003, 0x80000, CRC(a507797b) SHA1(6fa04091df1fa8c08f03b1ee378b4ec4a6ef7f51) )
 
-	ROM_REGION(0x200000, "gfx1" , 0) /* Sprites */
+	ROM_REGION( 0x100000, "sprites" , 0) /* Sprites */
 	ROM_LOAD16_BYTE("e28-02.bin", 0x000000, 0x080000, CRC(b20d47cb) SHA1(6888e5564688840fed1c123ab38467066cd59c7f) )
 	ROM_LOAD16_BYTE("e28-01.bin", 0x000001, 0x080000, CRC(4440e659) SHA1(71dece81bac8d638473c6531fed5c32798096af9) )
-	ROM_FILL       (              0x100000, 0x100000, 0x00 )
 
-	ROM_REGION(0x400000, "gfx2" , 0) /* Tiles */
-	ROM_LOAD16_BYTE("e28-06.bin", 0x000000, 0x100000, CRC(21d0c454) SHA1(f4c815984b19321cfab303fa6f21d9cad35b09f2) )
-	ROM_LOAD16_BYTE("e28-05.bin", 0x000001, 0x100000, CRC(2870dbbc) SHA1(4e412b90cbd9a05956cde3d8cff615ebadca9db6) )
-	ROM_LOAD       ("e28-04.bin", 0x300000, 0x100000, CRC(57aef029) SHA1(5c07209015d4749d1ffb3e9c1a890e6cfeec8cb0) )
-	ROM_FILL       (              0x200000, 0x100000, 0x00 )
+	EMPTY_SPRITE_HIDATA(0x080000)
 
-	ROM_REGION(0x140000, "taito_en:audiocpu", 0) /* Sound CPU */
+	ROM_REGION( 0x200000, "tilemap" , 0) /* Tiles */
+	ROM_LOAD32_WORD("e28-06.bin", 0x000000, 0x100000, CRC(21d0c454) SHA1(f4c815984b19321cfab303fa6f21d9cad35b09f2) )
+	ROM_LOAD32_WORD("e28-05.bin", 0x000002, 0x100000, CRC(2870dbbc) SHA1(4e412b90cbd9a05956cde3d8cff615ebadca9db6) )
+
+	ROM_REGION( 0x100000, "tilemap_hi", 0 )
+	ROM_LOAD       ("e28-04.bin", 0x000000, 0x100000, CRC(57aef029) SHA1(5c07209015d4749d1ffb3e9c1a890e6cfeec8cb0) )
+
+	ROM_REGION( 0x140000, "taito_en:audiocpu", 0 ) /* Sound CPU */
 	ROM_LOAD16_BYTE("e28-11.bin", 0x100000, 0x20000, CRC(01a06950) SHA1(94d22cd839f9027e9d45264c366e0cb5d698e0b6) )
 	ROM_LOAD16_BYTE("e28-12.bin", 0x100001, 0x20000, CRC(dc19260f) SHA1(fa0ca03a236326652e4f9898d07cd837c1507a9d) )
 
-	ROM_REGION16_BE(0x400000, "ensoniq.0" , ROMREGION_ERASE00 ) // V2: 4 banks, only 1 populated
+	ROM_REGION16_BE( 0x400000, "ensoniq.0" , ROMREGION_ERASE00 ) // V2: 4 banks, only 1 populated
 	ROM_LOAD16_BYTE("e28-03.bin", 0x000000, 0x200000, CRC(15c7989d) SHA1(7cc63d93e5c1f9f52f889e973bbefd5e6f7ce807) )    // C8 C9 CA CB
 ROM_END
 
 ROM_START( pbobble3 )
-	ROM_REGION(0x200000, "maincpu", 0) /* 68020 code */
+	ROM_REGION( 0x200000, "maincpu", 0 ) /* 68020 code */
 	ROM_LOAD32_BYTE("e29-12.rom", 0x000000, 0x80000, CRC(9eb19a00) SHA1(5a6417e4377070f9f01110dc6d513d0de01cff1e) )
 	ROM_LOAD32_BYTE("e29-11.rom", 0x000001, 0x80000, CRC(e54ada97) SHA1(325e2bc7156656cc262989910dde07a1746cf790) )
 	ROM_LOAD32_BYTE("e29-10.rom", 0x000002, 0x80000, CRC(1502a122) SHA1(cb981a4578aa30276c491a0ef47f5e05c05d8b28) )
 	ROM_LOAD32_BYTE("e29-16.rom", 0x000003, 0x80000, CRC(aac293da) SHA1(2188d1abe6aeefa872cf16db40999574497d982e) )
 
-	ROM_REGION(0x400000, "gfx1" , 0 ) /* Sprites */
+	ROM_REGION( 0x200000, "sprites" , 0 ) /* Sprites */
 	ROM_LOAD16_BYTE("e29-02.rom", 0x000000, 0x100000, CRC(437391d3) SHA1(b3cc64c68553d37e0bd09e0dece14901d8df5866) )
 	ROM_LOAD16_BYTE("e29-01.rom", 0x000001, 0x100000, CRC(52547c77) SHA1(d0cc8b8915cec1506c9733a1ce1638038ea93d25) )
-	ROM_FILL       (              0x200000, 0x200000, 0x00 )
 
-	ROM_REGION(0x400000, "gfx2" , 0 ) /* Tiles */
-	ROM_LOAD16_BYTE("e29-08.rom", 0x000000, 0x100000, CRC(7040a3d5) SHA1(ea284ec530aac20348f84122e38a508bbc283f44) )
-	ROM_LOAD16_BYTE("e29-07.rom", 0x000001, 0x100000, CRC(fca2ea9b) SHA1(a87ebedd0d16657288df434a70b8933fafe0ca25) )
-	ROM_LOAD       ("e29-06.rom", 0x300000, 0x100000, CRC(c16184f8) SHA1(ded417d9d116b5a2f7518fa404bc2dda1c6a6366) )
-	ROM_FILL       (              0x200000, 0x100000, 0x00 )
+	EMPTY_SPRITE_HIDATA(0x100000)
 
-	ROM_REGION(0x180000, "taito_en:audiocpu", 0) /* 68000 code */
+	ROM_REGION( 0x200000, "tilemap" , 0 ) /* Tiles */
+	ROM_LOAD32_WORD("e29-08.rom", 0x000000, 0x100000, CRC(7040a3d5) SHA1(ea284ec530aac20348f84122e38a508bbc283f44) )
+	ROM_LOAD32_WORD("e29-07.rom", 0x000002, 0x100000, CRC(fca2ea9b) SHA1(a87ebedd0d16657288df434a70b8933fafe0ca25) )
+
+	ROM_REGION( 0x100000, "tilemap_hi", 0 )
+	ROM_LOAD       ("e29-06.rom", 0x000000, 0x100000, CRC(c16184f8) SHA1(ded417d9d116b5a2f7518fa404bc2dda1c6a6366) )
+
+	ROM_REGION( 0x180000, "taito_en:audiocpu", 0 ) /* 68000 code */
 	ROM_LOAD16_BYTE("e29-13.rom", 0x100000, 0x40000, CRC(1ef551ef) SHA1(527defe8f35314304adb4b483285b08cd6ebe865) )
 	ROM_LOAD16_BYTE("e29-14.rom", 0x100001, 0x40000, CRC(7ee7e688) SHA1(d65aa9c449e1d64f10d1be9727a9d93ab1571e65) )
 
-	ROM_REGION16_BE(0x1000000, "ensoniq.0" , ROMREGION_ERASE00 )    // V2: 4 banks
+	ROM_REGION16_BE( 0x1000000, "ensoniq.0" , ROMREGION_ERASE00 )    // V2: 4 banks
 	// empty
 	ROM_LOAD16_BYTE("e29-03.rom", 0x400000, 0x200000, CRC(a4371658) SHA1(26510a3f6de97f49b10dfc5cb9b7da947a44bfcb) )    // CE CF D0 D1
 	ROM_LOAD16_BYTE("e29-04.rom", 0x800000, 0x200000, CRC(d1f42457) SHA1(2c77be6365deb5ef215da0c66da23b415623bdb1) )    // D2 C8 C9 CA
@@ -3302,28 +3444,30 @@ ROM_START( pbobble3 )
 ROM_END
 
 ROM_START( pbobble3u )
-	ROM_REGION(0x200000, "maincpu", 0) /* 68020 code */
+	ROM_REGION( 0x200000, "maincpu", 0 ) /* 68020 code */
 	ROM_LOAD32_BYTE("e29-12.rom", 0x000000, 0x80000, CRC(9eb19a00) SHA1(5a6417e4377070f9f01110dc6d513d0de01cff1e) )
 	ROM_LOAD32_BYTE("e29-11.rom", 0x000001, 0x80000, CRC(e54ada97) SHA1(325e2bc7156656cc262989910dde07a1746cf790) )
 	ROM_LOAD32_BYTE("e29-10.rom", 0x000002, 0x80000, CRC(1502a122) SHA1(cb981a4578aa30276c491a0ef47f5e05c05d8b28) )
 	ROM_LOAD32_BYTE("e29-15.bin", 0x000003, 0x80000, CRC(ddc5a34c) SHA1(f38c99ac33b199b3ed99a84c67984f23a864e5d4) )
 
-	ROM_REGION(0x400000, "gfx1" , 0 ) /* Sprites */
+	ROM_REGION( 0x200000, "sprites" , 0 ) /* Sprites */
 	ROM_LOAD16_BYTE("e29-02.rom", 0x000000, 0x100000, CRC(437391d3) SHA1(b3cc64c68553d37e0bd09e0dece14901d8df5866) )
 	ROM_LOAD16_BYTE("e29-01.rom", 0x000001, 0x100000, CRC(52547c77) SHA1(d0cc8b8915cec1506c9733a1ce1638038ea93d25) )
-	ROM_FILL       (              0x200000, 0x200000, 0x00 )
 
-	ROM_REGION(0x400000, "gfx2" , 0 ) /* Tiles */
-	ROM_LOAD16_BYTE("e29-08.rom", 0x000000, 0x100000, CRC(7040a3d5) SHA1(ea284ec530aac20348f84122e38a508bbc283f44) )
-	ROM_LOAD16_BYTE("e29-07.rom", 0x000001, 0x100000, CRC(fca2ea9b) SHA1(a87ebedd0d16657288df434a70b8933fafe0ca25) )
-	ROM_LOAD       ("e29-06.rom", 0x300000, 0x100000, CRC(c16184f8) SHA1(ded417d9d116b5a2f7518fa404bc2dda1c6a6366) )
-	ROM_FILL       (              0x200000, 0x100000, 0x00 )
+	EMPTY_SPRITE_HIDATA(0x100000)
 
-	ROM_REGION(0x180000, "taito_en:audiocpu", 0) /* 68000 code */
+	ROM_REGION( 0x200000, "tilemap" , 0 ) /* Tiles */
+	ROM_LOAD32_WORD("e29-08.rom", 0x000000, 0x100000, CRC(7040a3d5) SHA1(ea284ec530aac20348f84122e38a508bbc283f44) )
+	ROM_LOAD32_WORD("e29-07.rom", 0x000002, 0x100000, CRC(fca2ea9b) SHA1(a87ebedd0d16657288df434a70b8933fafe0ca25) )
+
+	ROM_REGION( 0x100000, "tilemap_hi", 0 )
+	ROM_LOAD       ("e29-06.rom", 0x000000, 0x100000, CRC(c16184f8) SHA1(ded417d9d116b5a2f7518fa404bc2dda1c6a6366) )
+
+	ROM_REGION( 0x180000, "taito_en:audiocpu", 0 ) /* 68000 code */
 	ROM_LOAD16_BYTE("e29-13.rom", 0x100000, 0x40000, CRC(1ef551ef) SHA1(527defe8f35314304adb4b483285b08cd6ebe865) )
 	ROM_LOAD16_BYTE("e29-14.rom", 0x100001, 0x40000, CRC(7ee7e688) SHA1(d65aa9c449e1d64f10d1be9727a9d93ab1571e65) )
 
-	ROM_REGION16_BE(0x1000000, "ensoniq.0" , ROMREGION_ERASE00 )    // V2: 4 banks
+	ROM_REGION16_BE( 0x1000000, "ensoniq.0" , ROMREGION_ERASE00 )    // V2: 4 banks
 	// empty
 	ROM_LOAD16_BYTE("e29-03.rom", 0x400000, 0x200000, CRC(a4371658) SHA1(26510a3f6de97f49b10dfc5cb9b7da947a44bfcb) )    // CE CF D0 D1
 	ROM_LOAD16_BYTE("e29-04.rom", 0x800000, 0x200000, CRC(d1f42457) SHA1(2c77be6365deb5ef215da0c66da23b415623bdb1) )    // D2 C8 C9 CA
@@ -3331,34 +3475,36 @@ ROM_START( pbobble3u )
 ROM_END
 
 ROM_START( pbobble3j )
-	ROM_REGION(0x200000, "maincpu", 0) /* 68020 code */
+	ROM_REGION( 0x200000, "maincpu", 0 ) /* 68020 code */
 	ROM_LOAD32_BYTE("e29-12.ic20", 0x000000, 0x80000, CRC(9eb19a00) SHA1(5a6417e4377070f9f01110dc6d513d0de01cff1e) )
 	ROM_LOAD32_BYTE("e29-11.ic19", 0x000001, 0x80000, CRC(e54ada97) SHA1(325e2bc7156656cc262989910dde07a1746cf790) )
 	ROM_LOAD32_BYTE("e29-10.ic18", 0x000002, 0x80000, CRC(1502a122) SHA1(cb981a4578aa30276c491a0ef47f5e05c05d8b28) )
 	ROM_LOAD32_BYTE("e29-09.ic17", 0x000003, 0x80000, CRC(44ccf2f6) SHA1(60877525feaa992b1b374acfb5c16439e5f32161) )
 
-	ROM_REGION(0x400000, "gfx1" , 0 ) /* Sprites */
+	ROM_REGION( 0x200000, "sprites" , 0 ) /* Sprites */
 	ROM_LOAD16_BYTE("e29-02.ic8",  0x000000, 0x100000, CRC(437391d3) SHA1(b3cc64c68553d37e0bd09e0dece14901d8df5866) )
 	ROM_LOAD16_BYTE("e29-01.ic12", 0x000001, 0x100000, CRC(52547c77) SHA1(d0cc8b8915cec1506c9733a1ce1638038ea93d25) )
-	ROM_FILL       (               0x200000, 0x200000, 0x00 )
 
-	ROM_REGION(0x400000, "gfx2" , 0 ) /* Tiles */
-	ROM_LOAD16_BYTE("e29-08.ic47", 0x000000, 0x100000, CRC(7040a3d5) SHA1(ea284ec530aac20348f84122e38a508bbc283f44) )
-	ROM_LOAD16_BYTE("e29-07.ic45", 0x000001, 0x100000, CRC(fca2ea9b) SHA1(a87ebedd0d16657288df434a70b8933fafe0ca25) )
-	ROM_LOAD       ("e29-06.ic43", 0x300000, 0x100000, CRC(c16184f8) SHA1(ded417d9d116b5a2f7518fa404bc2dda1c6a6366) )
-	ROM_FILL       (               0x200000, 0x100000, 0x00 )
+	EMPTY_SPRITE_HIDATA(0x100000)
 
-	ROM_REGION(0x180000, "taito_en:audiocpu", 0) /* 68000 code */
+	ROM_REGION( 0x200000, "tilemap" , 0 ) /* Tiles */
+	ROM_LOAD32_WORD("e29-08.ic47", 0x000000, 0x100000, CRC(7040a3d5) SHA1(ea284ec530aac20348f84122e38a508bbc283f44) )
+	ROM_LOAD32_WORD("e29-07.ic45", 0x000002, 0x100000, CRC(fca2ea9b) SHA1(a87ebedd0d16657288df434a70b8933fafe0ca25) )
+
+	ROM_REGION( 0x100000, "tilemap_hi", 0 )
+	ROM_LOAD       ("e29-06.ic43", 0x000000, 0x100000, CRC(c16184f8) SHA1(ded417d9d116b5a2f7518fa404bc2dda1c6a6366) )
+
+	ROM_REGION( 0x180000, "taito_en:audiocpu", 0 ) /* 68000 code */
 	ROM_LOAD16_BYTE("e29-13.ic32", 0x100000, 0x40000, CRC(1ef551ef) SHA1(527defe8f35314304adb4b483285b08cd6ebe865) )
 	ROM_LOAD16_BYTE("e29-14.ic33", 0x100001, 0x40000, CRC(7ee7e688) SHA1(d65aa9c449e1d64f10d1be9727a9d93ab1571e65) )
 
-	ROM_REGION16_BE(0x1000000, "ensoniq.0" , ROMREGION_ERASE00 )    // V2: 4 banks
+	ROM_REGION16_BE( 0x1000000, "ensoniq.0" , ROMREGION_ERASE00 )    // V2: 4 banks
 	// empty
 	ROM_LOAD16_BYTE("e29-03.ic38", 0x400000, 0x200000, CRC(a4371658) SHA1(26510a3f6de97f49b10dfc5cb9b7da947a44bfcb) )    // CE CF D0 D1
 	ROM_LOAD16_BYTE("e29-04.ic39", 0x800000, 0x200000, CRC(d1f42457) SHA1(2c77be6365deb5ef215da0c66da23b415623bdb1) )    // D2 C8 C9 CA
 	ROM_LOAD16_BYTE("e29-05.ic41", 0xc00000, 0x200000, CRC(e33c1234) SHA1(84c336ed6fd8723e824889fe7b52c284be659e62) )    // CB CC -std-
 
-	ROM_REGION(0x034a, "pals", 0)
+	ROM_REGION( 0x034a, "pals", 0 )
 	ROM_LOAD("d77-12.ic48.bin", 0x0000, 0x0001, NO_DUMP) /* PALCE16V8Q-15PC/4 */
 	ROM_LOAD("d77-14.ic21.bin", 0x0001, 0x0001, NO_DUMP) /* PALCE16V8Q-15PC/4 */
 	ROM_LOAD("d77-11.ic37.bin", 0x0002, 0x0001, NO_DUMP) /* PALCE16V8Q-15PC/4 */
@@ -3367,29 +3513,31 @@ ROM_START( pbobble3j )
 ROM_END
 
 ROM_START( arkretrn )
-	ROM_REGION(0x200000, "maincpu", 0) /* 68020 code */
+	ROM_REGION( 0x200000, "maincpu", 0 ) /* 68020 code */
 	ROM_LOAD32_BYTE("e36-11.20", 0x000000, 0x040000, CRC(b50cfb92) SHA1(dac69fc9ef03315b11bb94d19e3dfdc8867b08ed) )
 	ROM_LOAD32_BYTE("e36-10.19", 0x000001, 0x040000, CRC(c940dba1) SHA1(ec87c9e4250f8b2f15094681a4783bca8c68f576) )
 	ROM_LOAD32_BYTE("e36-09.18", 0x000002, 0x040000, CRC(f16985e0) SHA1(a74cfee8f958e7a32354d4353eeb199a7fb1ce64) )
 	ROM_LOAD32_BYTE("e36-15.17", 0x000003, 0x040000, CRC(4467ff37) SHA1(509a0d516def02d86d81b9868de0d9593539e65c) )
 
-	ROM_REGION(0x180000, "taito_en:audiocpu", 0) /* Sound CPU */
+	ROM_REGION( 0x180000, "taito_en:audiocpu", 0 ) /* Sound CPU */
 	ROM_LOAD16_BYTE("e36-12.32", 0x100000, 0x40000, CRC(3bae39be) SHA1(777142ecc24799b934ed51ac4cd8700bb6da7e3c) )
 	ROM_LOAD16_BYTE("e36-13.33", 0x100001, 0x40000, CRC(94448e82) SHA1(d7766490318623be770545918391c5e6144dd619) )
 
-	ROM_REGION(0x100000, "gfx1" , 0) /* Sprites */
+	ROM_REGION( 0x080000, "sprites" , 0) /* Sprites */
 	ROM_LOAD16_BYTE("e36-03.12", 0x000000, 0x040000, CRC(1ea8558b) SHA1(b8ea4d6e1fb551b3c47f336a5e60ec33f7be525f) )
 	ROM_LOAD16_BYTE("e36-02.8",  0x000001, 0x040000, CRC(694eda31) SHA1(1a6f85057395052571491f85c633d5632ab64865) )
-	ROM_LOAD       ("e36-01.4",  0x0c0000, 0x040000, CRC(54b9b2cd) SHA1(55ae964ea1d2cc40a6578c5339754a270096f01f) )
-	ROM_FILL       (             0x080000, 0x040000, 0x00 )
 
-	ROM_REGION(0x200000, "gfx2" , 0) /* Tiles */
-	ROM_LOAD16_BYTE("e36-07.47", 0x000000, 0x080000, CRC(266bf1c1) SHA1(489549478d7016400af2e643d4b98bf605237d34) )
-	ROM_LOAD16_BYTE("e36-06.45", 0x000001, 0x080000, CRC(110ab729) SHA1(0ccc0a5abbcfd79a069daf5162cd344a5fb225d5) )
-	ROM_LOAD       ("e36-05.43", 0x180000, 0x080000, CRC(db18bce2) SHA1(b6653facc7f5c624f5710a51f2b2abfe640177e2) )
-	ROM_FILL       (          0x100000, 0x080000, 0x00 )
+	ROM_REGION( 0x040000, "sprites_hi", 0 )
+	ROM_LOAD       ("e36-01.4",  0x000000, 0x040000, CRC(54b9b2cd) SHA1(55ae964ea1d2cc40a6578c5339754a270096f01f) )
 
-	ROM_REGION16_BE(0x400000, "ensoniq.0" , ROMREGION_ERASE00 ) // V2: 4 banks, only 1 populated
+	ROM_REGION( 0x100000, "tilemap" , 0) /* Tiles */
+	ROM_LOAD32_WORD("e36-07.47", 0x000000, 0x080000, CRC(266bf1c1) SHA1(489549478d7016400af2e643d4b98bf605237d34) )
+	ROM_LOAD32_WORD("e36-06.45", 0x000002, 0x080000, CRC(110ab729) SHA1(0ccc0a5abbcfd79a069daf5162cd344a5fb225d5) )
+
+	ROM_REGION( 0x080000, "tilemap_hi", 0 )
+	ROM_LOAD       ("e36-05.43", 0x000000, 0x080000, CRC(db18bce2) SHA1(b6653facc7f5c624f5710a51f2b2abfe640177e2) )
+
+	ROM_REGION16_BE( 0x400000, "ensoniq.0" , ROMREGION_ERASE00 ) // V2: 4 banks, only 1 populated
 	ROM_LOAD16_BYTE("e36-04.38", 0x000000, 0x200000, CRC(2250959b) SHA1(06943f1b72bdf325485356a01278d88aeae93d87) )    // C8 C9 CA CB
 
 	ROM_REGION( 0x0a00, "plds", 0 )
@@ -3401,29 +3549,31 @@ ROM_START( arkretrn )
 ROM_END
 
 ROM_START( arkretrnu )
-	ROM_REGION(0x200000, "maincpu", 0) /* 68020 code */
+	ROM_REGION( 0x200000, "maincpu", 0 ) /* 68020 code */
 	ROM_LOAD32_BYTE("e36-11.20", 0x000000, 0x040000, CRC(b50cfb92) SHA1(dac69fc9ef03315b11bb94d19e3dfdc8867b08ed) )
 	ROM_LOAD32_BYTE("e36-10.19", 0x000001, 0x040000, CRC(c940dba1) SHA1(ec87c9e4250f8b2f15094681a4783bca8c68f576) )
 	ROM_LOAD32_BYTE("e36-09.18", 0x000002, 0x040000, CRC(f16985e0) SHA1(a74cfee8f958e7a32354d4353eeb199a7fb1ce64) )
 	ROM_LOAD32_BYTE("e36-14.17", 0x000003, 0x040000, CRC(3360cfa1) SHA1(b06afc392b3864a895aed3a406d5d9886b1d0894) )
 
-	ROM_REGION(0x180000, "taito_en:audiocpu", 0) /* Sound CPU */
+	ROM_REGION( 0x180000, "taito_en:audiocpu", 0 ) /* Sound CPU */
 	ROM_LOAD16_BYTE("e36-12.32", 0x100000, 0x40000, CRC(3bae39be) SHA1(777142ecc24799b934ed51ac4cd8700bb6da7e3c) )
 	ROM_LOAD16_BYTE("e36-13.33", 0x100001, 0x40000, CRC(94448e82) SHA1(d7766490318623be770545918391c5e6144dd619) )
 
-	ROM_REGION(0x100000, "gfx1" , 0) /* Sprites */
+	ROM_REGION( 0x080000, "sprites" , 0) /* Sprites */
 	ROM_LOAD16_BYTE("e36-03.12", 0x000000, 0x040000, CRC(1ea8558b) SHA1(b8ea4d6e1fb551b3c47f336a5e60ec33f7be525f) )
 	ROM_LOAD16_BYTE("e36-02.8",  0x000001, 0x040000, CRC(694eda31) SHA1(1a6f85057395052571491f85c633d5632ab64865) )
-	ROM_LOAD       ("e36-01.4",  0x0c0000, 0x040000, CRC(54b9b2cd) SHA1(55ae964ea1d2cc40a6578c5339754a270096f01f) )
-	ROM_FILL       (             0x080000, 0x040000, 0x00 )
 
-	ROM_REGION(0x200000, "gfx2" , 0) /* Tiles */
-	ROM_LOAD16_BYTE("e36-07.47", 0x000000, 0x080000, CRC(266bf1c1) SHA1(489549478d7016400af2e643d4b98bf605237d34) )
-	ROM_LOAD16_BYTE("e36-06.45", 0x000001, 0x080000, CRC(110ab729) SHA1(0ccc0a5abbcfd79a069daf5162cd344a5fb225d5) )
-	ROM_LOAD       ("e36-05.43", 0x180000, 0x080000, CRC(db18bce2) SHA1(b6653facc7f5c624f5710a51f2b2abfe640177e2) )
-	ROM_FILL       (          0x100000, 0x080000, 0x00 )
+	ROM_REGION( 0x040000, "sprites_hi", 0 )
+	ROM_LOAD       ("e36-01.4",  0x000000, 0x040000, CRC(54b9b2cd) SHA1(55ae964ea1d2cc40a6578c5339754a270096f01f) )
 
-	ROM_REGION16_BE(0x400000, "ensoniq.0" , ROMREGION_ERASE00 ) // V2: 4 banks, only 1 populated
+	ROM_REGION( 0x100000, "tilemap" , 0) /* Tiles */
+	ROM_LOAD32_WORD("e36-07.47", 0x000000, 0x080000, CRC(266bf1c1) SHA1(489549478d7016400af2e643d4b98bf605237d34) )
+	ROM_LOAD32_WORD("e36-06.45", 0x000002, 0x080000, CRC(110ab729) SHA1(0ccc0a5abbcfd79a069daf5162cd344a5fb225d5) )
+
+	ROM_REGION( 0x080000, "tilemap_hi", 0 )
+	ROM_LOAD       ("e36-05.43", 0x000000, 0x080000, CRC(db18bce2) SHA1(b6653facc7f5c624f5710a51f2b2abfe640177e2) )
+
+	ROM_REGION16_BE( 0x400000, "ensoniq.0" , ROMREGION_ERASE00 ) // V2: 4 banks, only 1 populated
 	ROM_LOAD16_BYTE("e36-04.38", 0x000000, 0x200000, CRC(2250959b) SHA1(06943f1b72bdf325485356a01278d88aeae93d87) )    // C8 C9 CA CB
 
 	ROM_REGION( 0x0a00, "plds", 0 )
@@ -3435,29 +3585,31 @@ ROM_START( arkretrnu )
 ROM_END
 
 ROM_START( arkretrnj )
-	ROM_REGION(0x200000, "maincpu", 0) /* 68020 code */
+	ROM_REGION( 0x200000, "maincpu", 0 ) /* 68020 code */
 	ROM_LOAD32_BYTE("e36-11.20", 0x000000, 0x040000, CRC(b50cfb92) SHA1(dac69fc9ef03315b11bb94d19e3dfdc8867b08ed) )
 	ROM_LOAD32_BYTE("e36-10.19", 0x000001, 0x040000, CRC(c940dba1) SHA1(ec87c9e4250f8b2f15094681a4783bca8c68f576) )
 	ROM_LOAD32_BYTE("e36-09.18", 0x000002, 0x040000, CRC(f16985e0) SHA1(a74cfee8f958e7a32354d4353eeb199a7fb1ce64) )
 	ROM_LOAD32_BYTE("e36-08.17", 0x000003, 0x040000, CRC(aa699e1b) SHA1(6bde0759940e0f238e4fa5bd228115574ff927d8) )
 
-	ROM_REGION(0x180000, "taito_en:audiocpu", 0) /* Sound CPU */
+	ROM_REGION( 0x180000, "taito_en:audiocpu", 0 ) /* Sound CPU */
 	ROM_LOAD16_BYTE("e36-12.32", 0x100000, 0x40000, CRC(3bae39be) SHA1(777142ecc24799b934ed51ac4cd8700bb6da7e3c) )
 	ROM_LOAD16_BYTE("e36-13.33", 0x100001, 0x40000, CRC(94448e82) SHA1(d7766490318623be770545918391c5e6144dd619) )
 
-	ROM_REGION(0x100000, "gfx1" , 0) /* Sprites */
+	ROM_REGION( 0x080000, "sprites" , 0) /* Sprites */
 	ROM_LOAD16_BYTE("e36-03.12", 0x000000, 0x040000, CRC(1ea8558b) SHA1(b8ea4d6e1fb551b3c47f336a5e60ec33f7be525f) )
 	ROM_LOAD16_BYTE("e36-02.8",  0x000001, 0x040000, CRC(694eda31) SHA1(1a6f85057395052571491f85c633d5632ab64865) )
-	ROM_LOAD       ("e36-01.4",  0x0c0000, 0x040000, CRC(54b9b2cd) SHA1(55ae964ea1d2cc40a6578c5339754a270096f01f) )
-	ROM_FILL       (             0x080000, 0x040000, 0x00 )
 
-	ROM_REGION(0x200000, "gfx2" , 0) /* Tiles */
-	ROM_LOAD16_BYTE("e36-07.47", 0x000000, 0x080000, CRC(266bf1c1) SHA1(489549478d7016400af2e643d4b98bf605237d34) )
-	ROM_LOAD16_BYTE("e36-06.45", 0x000001, 0x080000, CRC(110ab729) SHA1(0ccc0a5abbcfd79a069daf5162cd344a5fb225d5) )
-	ROM_LOAD       ("e36-05.43", 0x180000, 0x080000, CRC(db18bce2) SHA1(b6653facc7f5c624f5710a51f2b2abfe640177e2) )
-	ROM_FILL       (          0x100000, 0x080000, 0x00 )
+	ROM_REGION( 0x040000, "sprites_hi", 0 )
+	ROM_LOAD       ("e36-01.4",  0x000000, 0x040000, CRC(54b9b2cd) SHA1(55ae964ea1d2cc40a6578c5339754a270096f01f) )
 
-	ROM_REGION16_BE(0x400000, "ensoniq.0" , ROMREGION_ERASE00 ) // V2: 4 banks, only 1 populated
+	ROM_REGION( 0x100000, "tilemap" , 0) /* Tiles */
+	ROM_LOAD32_WORD("e36-07.47", 0x000000, 0x080000, CRC(266bf1c1) SHA1(489549478d7016400af2e643d4b98bf605237d34) )
+	ROM_LOAD32_WORD("e36-06.45", 0x000002, 0x080000, CRC(110ab729) SHA1(0ccc0a5abbcfd79a069daf5162cd344a5fb225d5) )
+
+	ROM_REGION( 0x080000, "tilemap_hi", 0 )
+	ROM_LOAD       ("e36-05.43", 0x000000, 0x080000, CRC(db18bce2) SHA1(b6653facc7f5c624f5710a51f2b2abfe640177e2) )
+
+	ROM_REGION16_BE( 0x400000, "ensoniq.0" , ROMREGION_ERASE00 ) // V2: 4 banks, only 1 populated
 	ROM_LOAD16_BYTE("e36-04.38", 0x000000, 0x200000, CRC(2250959b) SHA1(06943f1b72bdf325485356a01278d88aeae93d87) )    // C8 C9 CA CB
 
 	ROM_REGION( 0x0a00, "plds", 0 )
@@ -3469,36 +3621,38 @@ ROM_START( arkretrnj )
 ROM_END
 
 ROM_START( kirameki )
-	ROM_REGION(0x200000, "maincpu", 0) /* 68020 code */
+	ROM_REGION( 0x200000, "maincpu", 0 ) /* 68020 code */
 	ROM_LOAD32_BYTE("e44-19.20", 0x000000, 0x80000, CRC(2f3b239a) SHA1(fb79955eba377d429ece04553251146b406143b1) )
 	ROM_LOAD32_BYTE("e44-18.19", 0x000001, 0x80000, CRC(3137c8bc) SHA1(5f5cb47e214fe116cf985e847fa8340cf2ea5a64) )
 	ROM_LOAD32_BYTE("e44-17.18", 0x000002, 0x80000, CRC(5905cd20) SHA1(52545622d3c7a31a9e95ab48e7251f1eae2c25b4) )
 	ROM_LOAD32_BYTE("e44-16.17", 0x000003, 0x80000, CRC(5e9ac3fd) SHA1(3c45707d0d260961df99249978c7e8f51dd1720e) )
 
-	ROM_REGION(0x1800000, "gfx1" , 0) /* Sprites */
+	ROM_REGION( 0xc00000, "sprites" , 0) /* Sprites */
 	ROM_LOAD16_BYTE("e44-06.12", 0x0000000, 0x400000, CRC(80526d58) SHA1(d32bf1e6494848b6e258b747245742310398be22) )
 	ROM_LOAD16_BYTE("e44-04.8",  0x0000001, 0x400000, CRC(28c7c295) SHA1(90189ae26833499218b2236d48ce500a2eea3235) )
 	ROM_LOAD16_BYTE("e44-05.11", 0x0800000, 0x200000, CRC(0fbc2b26) SHA1(0edd67213a9eba15fff0931a07608f9523ae1d95) )
 	ROM_LOAD16_BYTE("e44-03.7",  0x0800001, 0x200000, CRC(d9e63fb0) SHA1(f2d8c30a4aaa2090673d5d2b1071e586a05c0236) )
-	ROM_LOAD       ("e44-02.4",  0x1200000, 0x400000, CRC(5481efde) SHA1(560a1b8acf672781e912dca51599b5aa4d69520a) )
-	ROM_LOAD       ("e44-01.3",  0x1600000, 0x200000, CRC(c4bdf727) SHA1(793a22a30ef44db818cfac96ff8e9d2f99cb672f) )
-	ROM_FILL       (             0x0c00000, 0x600000, 0x00 )
 
-	ROM_REGION(0xc00000, "gfx2" , 0) /* Tiles */
-	ROM_LOAD16_BYTE("e44-14.47", 0x000000, 0x200000, CRC(4597c034) SHA1(3c16c20969df9e439d42a89e649146319df1b996) )
-	ROM_LOAD16_BYTE("e44-12.45", 0x000001, 0x200000, CRC(7160a181) SHA1(d4a351f38219694d6545b4c502c0ba0a7f0bdfd0) )
-	ROM_LOAD16_BYTE("e44-13.46", 0x400000, 0x100000, CRC(0b016c4e) SHA1(670d1741376cf929adad3c5e45f921ed4b317d31) )
-	ROM_LOAD16_BYTE("e44-11.44", 0x400001, 0x100000, CRC(34d84143) SHA1(d553ab2da9188b1881f70802637d46574a42787e) )
-	ROM_LOAD       ("e44-10.43", 0x900000, 0x200000, CRC(326f738e) SHA1(29c0c870341345eba10993446fecee08b6f13027) )
-	ROM_LOAD       ("e44-09.42", 0xb00000, 0x100000, CRC(a8e68eb7) SHA1(843bbb8a61bd4b9cbb14c7242281ce0c83c432ff) )
-	ROM_FILL       (             0x600000, 0x300000, 0x00 )
+	ROM_REGION( 0x600000, "sprites_hi", 0 )
+	ROM_LOAD       ("e44-02.4",  0x0000000, 0x400000, CRC(5481efde) SHA1(560a1b8acf672781e912dca51599b5aa4d69520a) )
+	ROM_LOAD       ("e44-01.3",  0x0400000, 0x200000, CRC(c4bdf727) SHA1(793a22a30ef44db818cfac96ff8e9d2f99cb672f) )
 
-	ROM_REGION(0x400000, "taito_en:audiocpu", 0) /* 68000 sound CPU */
+	ROM_REGION( 0x600000, "tilemap" , 0) /* Tiles */
+	ROM_LOAD32_WORD("e44-14.47", 0x000000, 0x200000, CRC(4597c034) SHA1(3c16c20969df9e439d42a89e649146319df1b996) )
+	ROM_LOAD32_WORD("e44-12.45", 0x000002, 0x200000, CRC(7160a181) SHA1(d4a351f38219694d6545b4c502c0ba0a7f0bdfd0) )
+	ROM_LOAD32_WORD("e44-13.46", 0x400000, 0x100000, CRC(0b016c4e) SHA1(670d1741376cf929adad3c5e45f921ed4b317d31) )
+	ROM_LOAD32_WORD("e44-11.44", 0x400002, 0x100000, CRC(34d84143) SHA1(d553ab2da9188b1881f70802637d46574a42787e) )
+
+	ROM_REGION( 0x300000, "tilemap_hi", 0 )
+	ROM_LOAD       ("e44-10.43", 0x000000, 0x200000, CRC(326f738e) SHA1(29c0c870341345eba10993446fecee08b6f13027) )
+	ROM_LOAD       ("e44-09.42", 0x200000, 0x100000, CRC(a8e68eb7) SHA1(843bbb8a61bd4b9cbb14c7242281ce0c83c432ff) )
+
+	ROM_REGION( 0x400000, "taito_en:audiocpu", 0 ) /* 68000 sound CPU */
 	ROM_LOAD16_BYTE("e44-20.51",      0x100000, 0x080000, CRC(4df7e051) SHA1(db0f5758458764a1c04116d5d5bbb20d4d36c875) )
 	ROM_LOAD16_BYTE("e44-21.52",      0x100001, 0x080000, CRC(d31b94b8) SHA1(41ee381d10254dc6e7163c5f353568539a96fc20) )
 	ROM_LOAD16_WORD_SWAP("e44-15.53", 0x200000, 0x200000, CRC(5043b608) SHA1(a328b8cc27ba1620a75a17cdf8571e217c42b9fd) ) /* Banked data */
 
-	ROM_REGION16_BE(0x1000000, "ensoniq.0" , ROMREGION_ERASE00 )    // V2: 4 banks
+	ROM_REGION16_BE( 0x1000000, "ensoniq.0" , ROMREGION_ERASE00 )    // V2: 4 banks
 	ROM_LOAD16_BYTE("e44-07.38", 0x000000, 0x400000, CRC(a9e28544) SHA1(0dc3e1755a93fda310d26ed5f95dd211c05e579e) ) // D2 C8 C8 C9 CA CB CC CD
 	ROM_LOAD16_BYTE("e44-08.39", 0x800000, 0x400000, CRC(33ba3037) SHA1(b4bbc4198929938607c444edf159ff40f53235d7) ) // CE CF D0 -- -- -- -std-
 
@@ -3507,32 +3661,34 @@ ROM_START( kirameki )
 ROM_END
 
 ROM_START( puchicar ) // an Asia cart was dumped and all ROMs match
-	ROM_REGION(0x200000, "maincpu", 0) /* 68020 code */
+	ROM_REGION( 0x200000, "maincpu", 0 ) /* 68020 code */
 	ROM_LOAD32_BYTE("e46-16", 0x000000, 0x80000, CRC(cf2accdf) SHA1(b1e9808299a3c68c939009275108ee76cd7f5749) )
 	ROM_LOAD32_BYTE("e46-15", 0x000001, 0x80000, CRC(c32c6ed8) SHA1(b0c4cca836e6957ecabdaddff23439f9d038a161) )
 	ROM_LOAD32_BYTE("e46-14", 0x000002, 0x80000, CRC(a154c300) SHA1(177d9f3514f1e59a1036b979d2ab969249f519ca) )
 	ROM_LOAD32_BYTE("e46-18", 0x000003, 0x80000, CRC(396e3122) SHA1(1000bfe22f783f7121a261d37551bde5687fff8b) )
 
-	ROM_REGION(0x1000000, "gfx1" , 0) /* Sprites */
+	ROM_REGION( 0x800000, "sprites" , 0) /* Sprites */
 	ROM_LOAD16_BYTE("e46-06", 0x000000, 0x200000, CRC(b74336f2) SHA1(f5039a4d2117c78e905e2ef6dec43e143a91915e) )
 	ROM_LOAD16_BYTE("e46-04", 0x000001, 0x200000, CRC(463ecc4c) SHA1(e1649e68acc1637a5dc596b1b29c735e286056af) )
 	ROM_LOAD16_BYTE("e46-05", 0x400000, 0x200000, CRC(83a32eee) SHA1(1a1059b0a5ba1542c866072ffe1874daba982387) )
 	ROM_LOAD16_BYTE("e46-03", 0x400001, 0x200000, CRC(eb768193) SHA1(1d48334c0dfb9f72484717c267ac9b9b8d887fc8) )
-	ROM_LOAD       ("e46-02", 0xc00000, 0x200000, CRC(fb046018) SHA1(48d9c582ec9ef59dcc7538598fbd7ea2117896af) )
-	ROM_LOAD       ("e46-01", 0xe00000, 0x200000, CRC(34fc2103) SHA1(dca199bbd0ad28a11960101cda8d110943b10822) )
-	ROM_FILL       (          0x800000, 0x400000, 0x00 )
 
-	ROM_REGION(0x400000, "gfx2" , 0) /* Tiles */
-	ROM_LOAD16_BYTE("e46-12", 0x000000, 0x100000, CRC(1f3a9851) SHA1(c8711e2ef0096b41cc9b4c41e521d44b824f7181) )
-	ROM_LOAD16_BYTE("e46-11", 0x000001, 0x100000, CRC(e9f10bf1) SHA1(4ee9be3846b262dc0992c904c40580353b164d46) )
-	ROM_LOAD       ("e46-10", 0x300000, 0x100000, CRC(1999b76a) SHA1(83d6d2efe250bf3b119982bbf701f9b9d856af2d) )
-	ROM_FILL       (          0x200000, 0x100000, 0x00 )
+	ROM_REGION( 0x400000, "sprites_hi", 0 )
+	ROM_LOAD       ("e46-02", 0x000000, 0x200000, CRC(fb046018) SHA1(48d9c582ec9ef59dcc7538598fbd7ea2117896af) )
+	ROM_LOAD       ("e46-01", 0x200000, 0x200000, CRC(34fc2103) SHA1(dca199bbd0ad28a11960101cda8d110943b10822) )
 
-	ROM_REGION(0x180000, "taito_en:audiocpu", 0) /* 68000 sound CPU */
+	ROM_REGION( 0x200000, "tilemap" , 0) /* Tiles */
+	ROM_LOAD32_WORD("e46-12", 0x000000, 0x100000, CRC(1f3a9851) SHA1(c8711e2ef0096b41cc9b4c41e521d44b824f7181) )
+	ROM_LOAD32_WORD("e46-11", 0x000002, 0x100000, CRC(e9f10bf1) SHA1(4ee9be3846b262dc0992c904c40580353b164d46) )
+
+	ROM_REGION( 0x100000, "tilemap_hi", 0 )
+	ROM_LOAD       ("e46-10", 0x000000, 0x100000, CRC(1999b76a) SHA1(83d6d2efe250bf3b119982bbf701f9b9d856af2d) )
+
+	ROM_REGION( 0x180000, "taito_en:audiocpu", 0 ) /* 68000 sound CPU */
 	ROM_LOAD16_BYTE("e46-21", 0x100000, 0x40000, CRC(b466cff6) SHA1(0757984f15a6ac9939c1e8625d5b9bfcbc788acc) )
 	ROM_LOAD16_BYTE("e46-22", 0x100001, 0x40000, CRC(c67b767e) SHA1(19f3db6615d7a6ed4d2636b6beabe2f3ed6d0c38) )
 
-	ROM_REGION16_BE(0x1000000, "ensoniq.0" , ROMREGION_ERASE00 )    // V2: 4 banks
+	ROM_REGION16_BE( 0x1000000, "ensoniq.0" , ROMREGION_ERASE00 )    // V2: 4 banks
 	// empty
 	ROM_LOAD16_BYTE("e46-07", 0x400000, 0x200000, CRC(f20af91e) SHA1(86040ff7ce591418b32c06c3a02fabcbe76281f5) )    // C8 C9 CA CB
 	ROM_LOAD16_BYTE("e46-08", 0x800000, 0x200000, CRC(f7f96e1d) SHA1(8a83ea9036e8647b8dec6b5e144288ed9c025779) )    // CC CD CE CF
@@ -3547,32 +3703,34 @@ ROM_START( puchicar ) // an Asia cart was dumped and all ROMs match
 ROM_END
 
 ROM_START( puchicarj )
-	ROM_REGION(0x200000, "maincpu", 0) /* 68020 code */
+	ROM_REGION( 0x200000, "maincpu", 0 ) /* 68020 code */
 	ROM_LOAD32_BYTE("e46-16", 0x000000, 0x80000, CRC(cf2accdf) SHA1(b1e9808299a3c68c939009275108ee76cd7f5749) )
 	ROM_LOAD32_BYTE("e46-15", 0x000001, 0x80000, CRC(c32c6ed8) SHA1(b0c4cca836e6957ecabdaddff23439f9d038a161) )
 	ROM_LOAD32_BYTE("e46-14", 0x000002, 0x80000, CRC(a154c300) SHA1(177d9f3514f1e59a1036b979d2ab969249f519ca) )
 	ROM_LOAD32_BYTE("e46.13", 0x000003, 0x80000, CRC(59fbdf3a) SHA1(4499a7579907e8e1d8ca2c29e8e8d12185e8fe4d) )
 
-	ROM_REGION(0x1000000, "gfx1" , 0) /* Sprites */
+	ROM_REGION( 0x800000, "sprites" , 0) /* Sprites */
 	ROM_LOAD16_BYTE("e46-06", 0x000000, 0x200000, CRC(b74336f2) SHA1(f5039a4d2117c78e905e2ef6dec43e143a91915e) )
 	ROM_LOAD16_BYTE("e46-04", 0x000001, 0x200000, CRC(463ecc4c) SHA1(e1649e68acc1637a5dc596b1b29c735e286056af) )
 	ROM_LOAD16_BYTE("e46-05", 0x400000, 0x200000, CRC(83a32eee) SHA1(1a1059b0a5ba1542c866072ffe1874daba982387) )
 	ROM_LOAD16_BYTE("e46-03", 0x400001, 0x200000, CRC(eb768193) SHA1(1d48334c0dfb9f72484717c267ac9b9b8d887fc8) )
-	ROM_LOAD       ("e46-02", 0xc00000, 0x200000, CRC(fb046018) SHA1(48d9c582ec9ef59dcc7538598fbd7ea2117896af) )
-	ROM_LOAD       ("e46-01", 0xe00000, 0x200000, CRC(34fc2103) SHA1(dca199bbd0ad28a11960101cda8d110943b10822) )
-	ROM_FILL       (          0x800000, 0x400000, 0x00 )
 
-	ROM_REGION(0x400000, "gfx2" , 0) /* Tiles */
-	ROM_LOAD16_BYTE("e46-12", 0x000000, 0x100000, CRC(1f3a9851) SHA1(c8711e2ef0096b41cc9b4c41e521d44b824f7181) )
-	ROM_LOAD16_BYTE("e46-11", 0x000001, 0x100000, CRC(e9f10bf1) SHA1(4ee9be3846b262dc0992c904c40580353b164d46) )
-	ROM_LOAD       ("e46-10", 0x300000, 0x100000, CRC(1999b76a) SHA1(83d6d2efe250bf3b119982bbf701f9b9d856af2d) )
-	ROM_FILL       (          0x200000, 0x100000, 0x00 )
+	ROM_REGION( 0x400000, "sprites_hi", 0 )
+	ROM_LOAD       ("e46-02", 0x000000, 0x200000, CRC(fb046018) SHA1(48d9c582ec9ef59dcc7538598fbd7ea2117896af) )
+	ROM_LOAD       ("e46-01", 0x200000, 0x200000, CRC(34fc2103) SHA1(dca199bbd0ad28a11960101cda8d110943b10822) )
 
-	ROM_REGION(0x180000, "taito_en:audiocpu", 0) /* 68000 sound CPU */
+	ROM_REGION( 0x200000, "tilemap" , 0) /* Tiles */
+	ROM_LOAD32_WORD("e46-12", 0x000000, 0x100000, CRC(1f3a9851) SHA1(c8711e2ef0096b41cc9b4c41e521d44b824f7181) )
+	ROM_LOAD32_WORD("e46-11", 0x000002, 0x100000, CRC(e9f10bf1) SHA1(4ee9be3846b262dc0992c904c40580353b164d46) )
+
+	ROM_REGION( 0x100000, "tilemap_hi", 0 )
+	ROM_LOAD       ("e46-10", 0x000000, 0x100000, CRC(1999b76a) SHA1(83d6d2efe250bf3b119982bbf701f9b9d856af2d) )
+
+	ROM_REGION( 0x180000, "taito_en:audiocpu", 0 ) /* 68000 sound CPU */
 	ROM_LOAD16_BYTE("e46-19", 0x100000, 0x40000, CRC(2624eba0) SHA1(ba0b13bda241c648c7f8520106acd8c0c888fe29) )
 	ROM_LOAD16_BYTE("e46-20", 0x100001, 0x40000, CRC(065e934f) SHA1(0ec1b5ae33b1c43776b9327c9d380787d64ed5f9) )
 
-	ROM_REGION16_BE(0x1000000, "ensoniq.0" , ROMREGION_ERASE00 )    // V2: 4 banks
+	ROM_REGION16_BE( 0x1000000, "ensoniq.0" , ROMREGION_ERASE00 )    // V2: 4 banks
 	// empty
 	ROM_LOAD16_BYTE("e46-07", 0x400000, 0x200000, CRC(f20af91e) SHA1(86040ff7ce591418b32c06c3a02fabcbe76281f5) )    // C8 C9 CA CB
 	ROM_LOAD16_BYTE("e46-08", 0x800000, 0x200000, CRC(f7f96e1d) SHA1(8a83ea9036e8647b8dec6b5e144288ed9c025779) )    // CC CD CE CF
@@ -3587,28 +3745,30 @@ ROM_START( puchicarj )
 ROM_END
 
 ROM_START( pbobble4 )
-	ROM_REGION(0x200000, "maincpu", 0) /* 68020 code */
+	ROM_REGION( 0x200000, "maincpu", 0 ) /* 68020 code */
 	ROM_LOAD32_BYTE("e49-12.20", 0x000000, 0x80000, CRC(fffea203) SHA1(6351209c78099f270c8d8c8aa4a2dd9ce126c4ed) )
 	ROM_LOAD32_BYTE("e49-11.19", 0x000001, 0x80000, CRC(bf69a087) SHA1(2acbdb7faf5bdb1d9b5b9506c0b6f02fedcbd6a5) )
 	ROM_LOAD32_BYTE("e49-10.18", 0x000002, 0x80000, CRC(0307460b) SHA1(7ad9c6e5d319d6727444ffd14a87c6885445cee0) )
 	ROM_LOAD32_BYTE("e49-16.17", 0x000003, 0x80000, CRC(0a021624) SHA1(21a948f9f4adce0aaf76292f419a7c289f265d30) )
 
-	ROM_REGION(0x400000, "gfx1" , 0) /* Sprites */
+	ROM_REGION( 0x200000, "sprites" , 0) /* Sprites */
 	ROM_LOAD16_BYTE("e49-02", 0x000000, 0x100000, CRC(c7d2f40b) SHA1(cc6813189d6b31d7db099e49443af395f137462c) )
 	ROM_LOAD16_BYTE("e49-01", 0x000001, 0x100000, CRC(a3dd5f85) SHA1(2b305fdc18806bb5d7c3de0ac6a6eb07f98b4d3d) )
-	ROM_FILL       (          0x200000, 0x200000, 0x00 )
 
-	ROM_REGION(0x400000, "gfx2" , 0) /* Tiles */
-	ROM_LOAD16_BYTE("e49-08", 0x000000, 0x100000, CRC(87408106) SHA1(6577568ab4b92d6a81f43cf9ea2f0e30e17e2742) )
-	ROM_LOAD16_BYTE("e49-07", 0x000001, 0x100000, CRC(1e1e8e1c) SHA1(9c3b994064c6af62b6a24cab85089a74fd92cf7f) )
-	ROM_LOAD       ("e49-06", 0x300000, 0x100000, CRC(ec85f7ce) SHA1(9fead68c38fc9ca84d34d70343b13665978c362b) )
-	ROM_FILL       (          0x200000, 0x100000, 0x00 )
+	EMPTY_SPRITE_HIDATA(0x100000)
 
-	ROM_REGION(0x180000, "taito_en:audiocpu", 0) /* 68000 code */
+	ROM_REGION( 0x200000, "tilemap" , 0) /* Tiles */
+	ROM_LOAD32_WORD("e49-08", 0x000000, 0x100000, CRC(87408106) SHA1(6577568ab4b92d6a81f43cf9ea2f0e30e17e2742) )
+	ROM_LOAD32_WORD("e49-07", 0x000002, 0x100000, CRC(1e1e8e1c) SHA1(9c3b994064c6af62b6a24cab85089a74fd92cf7f) )
+
+	ROM_REGION( 0x100000, "tilemap_hi", 0 )
+	ROM_LOAD       ("e49-06", 0x000000, 0x100000, CRC(ec85f7ce) SHA1(9fead68c38fc9ca84d34d70343b13665978c362b) )
+
+	ROM_REGION( 0x180000, "taito_en:audiocpu", 0 ) /* 68000 code */
 	ROM_LOAD16_BYTE("e49-13.32", 0x100000, 0x40000, CRC(83536f7f) SHA1(2252cee00ae260954cc76d92af8eb2a87d23cbfb) )
 	ROM_LOAD16_BYTE("e49-14.33", 0x100001, 0x40000, CRC(19815bdb) SHA1(38ad682236c7df0710055dd8dbdec30d5da0839d) )
 
-	ROM_REGION16_BE(0x1000000, "ensoniq.0" , ROMREGION_ERASE00 )    // V2: 4 banks
+	ROM_REGION16_BE( 0x1000000, "ensoniq.0" , ROMREGION_ERASE00 )    // V2: 4 banks
 	// empty
 	ROM_LOAD16_BYTE("e49-03", 0x400000, 0x200000, CRC(f64303e0) SHA1(4d5df77047522419d21ff36402076e9b7c5acff8) )    // C8 C9 CA CB
 	ROM_LOAD16_BYTE("e49-04", 0x800000, 0x200000, CRC(09be229c) SHA1(a3a88969b34628d2bf3163bdf85d520feac9a7ac) )    // E7 CD E8 E6
@@ -3623,28 +3783,30 @@ ROM_START( pbobble4 )
 ROM_END
 
 ROM_START( pbobble4j )
-	ROM_REGION(0x200000, "maincpu", 0) /* 68020 code */
+	ROM_REGION( 0x200000, "maincpu", 0 ) /* 68020 code */
 	ROM_LOAD32_BYTE("e49-12.20", 0x000000, 0x80000, CRC(fffea203) SHA1(6351209c78099f270c8d8c8aa4a2dd9ce126c4ed) )
 	ROM_LOAD32_BYTE("e49-11.19", 0x000001, 0x80000, CRC(bf69a087) SHA1(2acbdb7faf5bdb1d9b5b9506c0b6f02fedcbd6a5) )
 	ROM_LOAD32_BYTE("e49-10.18", 0x000002, 0x80000, CRC(0307460b) SHA1(7ad9c6e5d319d6727444ffd14a87c6885445cee0) )
 	ROM_LOAD32_BYTE("e49-09.17", 0x000003, 0x80000, CRC(e40c7708) SHA1(0a8e973bb1d8c6dea9124d2742d354c6f20c08ee) )
 
-	ROM_REGION(0x400000, "gfx1" , 0) /* Sprites */
+	ROM_REGION( 0x200000, "sprites" , 0) /* Sprites */
 	ROM_LOAD16_BYTE("e49-02", 0x000000, 0x100000, CRC(c7d2f40b) SHA1(cc6813189d6b31d7db099e49443af395f137462c) )
 	ROM_LOAD16_BYTE("e49-01", 0x000001, 0x100000, CRC(a3dd5f85) SHA1(2b305fdc18806bb5d7c3de0ac6a6eb07f98b4d3d) )
-	ROM_FILL       (          0x200000, 0x200000, 0x00 )
 
-	ROM_REGION(0x400000, "gfx2" , 0) /* Tiles */
-	ROM_LOAD16_BYTE("e49-08", 0x000000, 0x100000, CRC(87408106) SHA1(6577568ab4b92d6a81f43cf9ea2f0e30e17e2742) )
-	ROM_LOAD16_BYTE("e49-07", 0x000001, 0x100000, CRC(1e1e8e1c) SHA1(9c3b994064c6af62b6a24cab85089a74fd92cf7f) )
-	ROM_LOAD       ("e49-06", 0x300000, 0x100000, CRC(ec85f7ce) SHA1(9fead68c38fc9ca84d34d70343b13665978c362b) )
-	ROM_FILL       (          0x200000, 0x100000, 0x00 )
+	EMPTY_SPRITE_HIDATA(0x100000)
 
-	ROM_REGION(0x180000, "taito_en:audiocpu", 0) /* 68000 code */
+	ROM_REGION( 0x200000, "tilemap" , 0) /* Tiles */
+	ROM_LOAD32_WORD("e49-08", 0x000000, 0x100000, CRC(87408106) SHA1(6577568ab4b92d6a81f43cf9ea2f0e30e17e2742) )
+	ROM_LOAD32_WORD("e49-07", 0x000002, 0x100000, CRC(1e1e8e1c) SHA1(9c3b994064c6af62b6a24cab85089a74fd92cf7f) )
+
+	ROM_REGION( 0x100000, "tilemap_hi", 0 )
+	ROM_LOAD       ("e49-06", 0x000000, 0x100000, CRC(ec85f7ce) SHA1(9fead68c38fc9ca84d34d70343b13665978c362b) )
+
+	ROM_REGION( 0x180000, "taito_en:audiocpu", 0 ) /* 68000 code */
 	ROM_LOAD16_BYTE("e49-13.32", 0x100000, 0x40000, CRC(83536f7f) SHA1(2252cee00ae260954cc76d92af8eb2a87d23cbfb) )
 	ROM_LOAD16_BYTE("e49-14.33", 0x100001, 0x40000, CRC(19815bdb) SHA1(38ad682236c7df0710055dd8dbdec30d5da0839d) )
 
-	ROM_REGION16_BE(0x1000000, "ensoniq.0" , ROMREGION_ERASE00 )    // V2: 4 banks
+	ROM_REGION16_BE( 0x1000000, "ensoniq.0" , ROMREGION_ERASE00 )    // V2: 4 banks
 	// empty
 	ROM_LOAD16_BYTE("e49-03", 0x400000, 0x200000, CRC(f64303e0) SHA1(4d5df77047522419d21ff36402076e9b7c5acff8) )    // C8 C9 CA CB
 	ROM_LOAD16_BYTE("e49-04", 0x800000, 0x200000, CRC(09be229c) SHA1(a3a88969b34628d2bf3163bdf85d520feac9a7ac) )    // E7 CD E8 E6
@@ -3659,28 +3821,30 @@ ROM_START( pbobble4j )
 ROM_END
 
 ROM_START( pbobble4u )
-	ROM_REGION(0x200000, "maincpu", 0) /* 68020 code */
+	ROM_REGION( 0x200000, "maincpu", 0 ) /* 68020 code */
 	ROM_LOAD32_BYTE("e49-12.20", 0x000000, 0x80000, CRC(fffea203) SHA1(6351209c78099f270c8d8c8aa4a2dd9ce126c4ed) )
 	ROM_LOAD32_BYTE("e49-11.19", 0x000001, 0x80000, CRC(bf69a087) SHA1(2acbdb7faf5bdb1d9b5b9506c0b6f02fedcbd6a5) )
 	ROM_LOAD32_BYTE("e49-10.18", 0x000002, 0x80000, CRC(0307460b) SHA1(7ad9c6e5d319d6727444ffd14a87c6885445cee0) )
 	ROM_LOAD32_BYTE("e49-15.17", 0x000003, 0x80000, CRC(7d0526b2) SHA1(1b769f735735e9135418ff26c020d8ac7f62d857) )
 
-	ROM_REGION(0x400000, "gfx1" , 0) /* Sprites */
+	ROM_REGION( 0x200000, "sprites" , 0) /* Sprites */
 	ROM_LOAD16_BYTE("e49-02", 0x000000, 0x100000, CRC(c7d2f40b) SHA1(cc6813189d6b31d7db099e49443af395f137462c) )
 	ROM_LOAD16_BYTE("e49-01", 0x000001, 0x100000, CRC(a3dd5f85) SHA1(2b305fdc18806bb5d7c3de0ac6a6eb07f98b4d3d) )
-	ROM_FILL       (          0x200000, 0x200000, 0x00 )
 
-	ROM_REGION(0x400000, "gfx2" , 0) /* Tiles */
-	ROM_LOAD16_BYTE("e49-08", 0x000000, 0x100000, CRC(87408106) SHA1(6577568ab4b92d6a81f43cf9ea2f0e30e17e2742) )
-	ROM_LOAD16_BYTE("e49-07", 0x000001, 0x100000, CRC(1e1e8e1c) SHA1(9c3b994064c6af62b6a24cab85089a74fd92cf7f) )
-	ROM_LOAD       ("e49-06", 0x300000, 0x100000, CRC(ec85f7ce) SHA1(9fead68c38fc9ca84d34d70343b13665978c362b) )
-	ROM_FILL       (          0x200000, 0x100000, 0x00 )
+	EMPTY_SPRITE_HIDATA(0x100000)
 
-	ROM_REGION(0x180000, "taito_en:audiocpu", 0) /* 68000 code */
+	ROM_REGION( 0x200000, "tilemap" , 0) /* Tiles */
+	ROM_LOAD32_WORD("e49-08", 0x000000, 0x100000, CRC(87408106) SHA1(6577568ab4b92d6a81f43cf9ea2f0e30e17e2742) )
+	ROM_LOAD32_WORD("e49-07", 0x000002, 0x100000, CRC(1e1e8e1c) SHA1(9c3b994064c6af62b6a24cab85089a74fd92cf7f) )
+
+	ROM_REGION( 0x100000, "tilemap_hi", 0 )
+	ROM_LOAD       ("e49-06", 0x000000, 0x100000, CRC(ec85f7ce) SHA1(9fead68c38fc9ca84d34d70343b13665978c362b) )
+
+	ROM_REGION( 0x180000, "taito_en:audiocpu", 0 ) /* 68000 code */
 	ROM_LOAD16_BYTE("e49-13.32", 0x100000, 0x40000, CRC(83536f7f) SHA1(2252cee00ae260954cc76d92af8eb2a87d23cbfb) )
 	ROM_LOAD16_BYTE("e49-14.33", 0x100001, 0x40000, CRC(19815bdb) SHA1(38ad682236c7df0710055dd8dbdec30d5da0839d) )
 
-	ROM_REGION16_BE(0x1000000, "ensoniq.0" , ROMREGION_ERASE00 )    // V2: 4 banks
+	ROM_REGION16_BE( 0x1000000, "ensoniq.0" , ROMREGION_ERASE00 )    // V2: 4 banks
 	// empty
 	ROM_LOAD16_BYTE("e49-03", 0x400000, 0x200000, CRC(f64303e0) SHA1(4d5df77047522419d21ff36402076e9b7c5acff8) )    // C8 C9 CA CB
 	ROM_LOAD16_BYTE("e49-04", 0x800000, 0x200000, CRC(09be229c) SHA1(a3a88969b34628d2bf3163bdf85d520feac9a7ac) )    // E7 CD E8 E6
@@ -3695,29 +3859,31 @@ ROM_START( pbobble4u )
 ROM_END
 
 ROM_START( popnpopj )
-	ROM_REGION(0x200000, "maincpu", 0) /* 68020 code */
+	ROM_REGION( 0x200000, "maincpu", 0 ) /* 68020 code */
 	ROM_LOAD32_BYTE("e51-12.20", 0x000000, 0x80000, CRC(86a237d5) SHA1(4b87a51705a4d831b21ee770af17310c6c091c2e) )
 	ROM_LOAD32_BYTE("e51-11.19", 0x000001, 0x80000, CRC(8a49f34f) SHA1(8691fbc1e96f0c9eb550dbb8ae8d7ef371397166) )
 	ROM_LOAD32_BYTE("e51-10.18", 0x000002, 0x80000, CRC(4bce68f8) SHA1(1a9220926f4d8db509f4ccbf318d123f34c42153) )
 	ROM_LOAD32_BYTE("e51-09.17", 0x000003, 0x80000, CRC(4a086017) SHA1(edec4120b3d96a179f12949bd261b97d41351cab) )
 
-	ROM_REGION(0x400000, "gfx1" , 0) /* Sprites */
+	ROM_REGION( 0x200000, "sprites" , 0) /* Sprites */
 	ROM_LOAD16_BYTE("e51-03.12",0x000000, 0x100000, CRC(a24c4607) SHA1(2396fa927446568ad8d98ad6756813e2f30523dd) )
 	ROM_LOAD16_BYTE("e51-02.8", 0x000001, 0x100000, CRC(6aa8b96c) SHA1(aaf7917dce5fed43c68cd3065538b58666ef3dbc) )
-	ROM_LOAD       ("e51-01.4", 0x300000, 0x100000, CRC(70347e24) SHA1(6b4ab90f0209e50eac7bee3abcf40afb71ab950a) )
-	ROM_FILL       (            0x200000, 0x100000, 0x00 )
 
-	ROM_REGION(0x800000, "gfx2" , 0) /* Tiles */
-	ROM_LOAD16_BYTE("e51-08.47", 0x000000, 0x200000, CRC(3ad41f02) SHA1(a4959113c01062003df41cdf6146e8a034917ee2) )
-	ROM_LOAD16_BYTE("e51-07.45", 0x000001, 0x200000, CRC(95873e46) SHA1(02504cbd920c8dbcb5abec6388305eff38f7efe0) )
-	ROM_LOAD       ("e51-06.43", 0x600000, 0x200000, CRC(c240d6c8) SHA1(6f3b5224b7eb8783893375d432bbbfc37f81c230) )
-	ROM_FILL       (             0x400000, 0x200000, 0x00 )
+	ROM_REGION( 0x100000, "sprites_hi", 0 )
+	ROM_LOAD       ("e51-01.4", 0x000000, 0x100000, CRC(70347e24) SHA1(6b4ab90f0209e50eac7bee3abcf40afb71ab950a) )
 
-	ROM_REGION(0x180000, "taito_en:audiocpu", 0) /* 68000 sound CPU */
+	ROM_REGION( 0x400000, "tilemap" , 0) /* Tiles */
+	ROM_LOAD32_WORD("e51-08.47", 0x000000, 0x200000, CRC(3ad41f02) SHA1(a4959113c01062003df41cdf6146e8a034917ee2) )
+	ROM_LOAD32_WORD("e51-07.45", 0x000002, 0x200000, CRC(95873e46) SHA1(02504cbd920c8dbcb5abec6388305eff38f7efe0) )
+
+	ROM_REGION( 0x200000, "tilemap_hi", 0 )
+	ROM_LOAD       ("e51-06.43", 0x000000, 0x200000, CRC(c240d6c8) SHA1(6f3b5224b7eb8783893375d432bbbfc37f81c230) )
+
+	ROM_REGION( 0x180000, "taito_en:audiocpu", 0 ) /* 68000 sound CPU */
 	ROM_LOAD16_BYTE("e51-13.32", 0x100000, 0x40000, CRC(3b9e3986) SHA1(26340bda0ad2ea580e2395135617966676a71ad5) )
 	ROM_LOAD16_BYTE("e51-14.33", 0x100001, 0x40000, CRC(1f9a5015) SHA1(5da38c5fe2a50bcde6bd46ab1cb9a56dbab1a882) )
 
-	ROM_REGION16_BE(0x800000, "ensoniq.0" , ROMREGION_ERASE00 ) // V2: 4 banks, only 2 populated
+	ROM_REGION16_BE( 0x800000, "ensoniq.0" , ROMREGION_ERASE00 ) // V2: 4 banks, only 2 populated
 	ROM_LOAD16_BYTE("e51-04.38", 0x000000, 0x200000, CRC(66790f55) SHA1(ac539b2655dbcda1bdffb9f3cf4c96fb05721e9d) ) // C9 CA CB CC
 	ROM_LOAD16_BYTE("e51-05.41", 0x400000, 0x200000, CRC(4d08b26d) SHA1(071a11a1b1ee8b8129d02b15ec0e533912c91b04) ) // CD CE -std-
 
@@ -3730,29 +3896,31 @@ ROM_START( popnpopj )
 ROM_END
 
 ROM_START( popnpop )
-	ROM_REGION(0x200000, "maincpu", 0) /* 68020 code */
+	ROM_REGION( 0x200000, "maincpu", 0 ) /* 68020 code */
 	ROM_LOAD32_BYTE("e51-12.20", 0x000000, 0x80000, CRC(86a237d5) SHA1(4b87a51705a4d831b21ee770af17310c6c091c2e) )
 	ROM_LOAD32_BYTE("e51-11.19", 0x000001, 0x80000, CRC(8a49f34f) SHA1(8691fbc1e96f0c9eb550dbb8ae8d7ef371397166) )
 	ROM_LOAD32_BYTE("e51-10.18", 0x000002, 0x80000, CRC(4bce68f8) SHA1(1a9220926f4d8db509f4ccbf318d123f34c42153) )
 	ROM_LOAD32_BYTE("e51-16.17", 0x000003, 0x80000, CRC(2a9d8e0f) SHA1(a5363a98f03cbc7b5f7c393b21062730bd6ee2a8) )
 
-	ROM_REGION(0x400000, "gfx1" , 0) /* Sprites */
+	ROM_REGION( 0x200000, "sprites" , 0) /* Sprites */
 	ROM_LOAD16_BYTE("e51-03.12",0x000000, 0x100000, CRC(a24c4607) SHA1(2396fa927446568ad8d98ad6756813e2f30523dd) )
 	ROM_LOAD16_BYTE("e51-02.8", 0x000001, 0x100000, CRC(6aa8b96c) SHA1(aaf7917dce5fed43c68cd3065538b58666ef3dbc) )
-	ROM_LOAD       ("e51-01.4", 0x300000, 0x100000, CRC(70347e24) SHA1(6b4ab90f0209e50eac7bee3abcf40afb71ab950a) )
-	ROM_FILL       (            0x200000, 0x100000, 0x00 )
 
-	ROM_REGION(0x800000, "gfx2" , 0) /* Tiles */
-	ROM_LOAD16_BYTE("e51-08.47", 0x000000, 0x200000, CRC(3ad41f02) SHA1(a4959113c01062003df41cdf6146e8a034917ee2) )
-	ROM_LOAD16_BYTE("e51-07.45", 0x000001, 0x200000, CRC(95873e46) SHA1(02504cbd920c8dbcb5abec6388305eff38f7efe0) )
-	ROM_LOAD       ("e51-06.43", 0x600000, 0x200000, CRC(c240d6c8) SHA1(6f3b5224b7eb8783893375d432bbbfc37f81c230) )
-	ROM_FILL       (             0x400000, 0x200000, 0x00 )
+	ROM_REGION( 0x100000, "sprites_hi", 0 )
+	ROM_LOAD       ("e51-01.4", 0x000000, 0x100000, CRC(70347e24) SHA1(6b4ab90f0209e50eac7bee3abcf40afb71ab950a) )
 
-	ROM_REGION(0x180000, "taito_en:audiocpu", 0) /* 68000 sound CPU */
+	ROM_REGION( 0x400000, "tilemap" , 0) /* Tiles */
+	ROM_LOAD32_WORD("e51-08.47", 0x000000, 0x200000, CRC(3ad41f02) SHA1(a4959113c01062003df41cdf6146e8a034917ee2) )
+	ROM_LOAD32_WORD("e51-07.45", 0x000002, 0x200000, CRC(95873e46) SHA1(02504cbd920c8dbcb5abec6388305eff38f7efe0) )
+
+	ROM_REGION( 0x200000, "tilemap_hi", 0 )
+	ROM_LOAD       ("e51-06.43", 0x000000, 0x200000, CRC(c240d6c8) SHA1(6f3b5224b7eb8783893375d432bbbfc37f81c230) )
+
+	ROM_REGION( 0x180000, "taito_en:audiocpu", 0 ) /* 68000 sound CPU */
 	ROM_LOAD16_BYTE("e51-13.32", 0x100000, 0x40000, CRC(3b9e3986) SHA1(26340bda0ad2ea580e2395135617966676a71ad5) )
 	ROM_LOAD16_BYTE("e51-14.33", 0x100001, 0x40000, CRC(1f9a5015) SHA1(5da38c5fe2a50bcde6bd46ab1cb9a56dbab1a882) )
 
-	ROM_REGION16_BE(0x800000, "ensoniq.0" , ROMREGION_ERASE00 ) // V2: 4 banks, only 2 populated
+	ROM_REGION16_BE( 0x800000, "ensoniq.0" , ROMREGION_ERASE00 ) // V2: 4 banks, only 2 populated
 	ROM_LOAD16_BYTE("e51-04.38", 0x000000, 0x200000, CRC(66790f55) SHA1(ac539b2655dbcda1bdffb9f3cf4c96fb05721e9d) ) // C9 CA CB CC
 	ROM_LOAD16_BYTE("e51-05.41", 0x400000, 0x200000, CRC(4d08b26d) SHA1(071a11a1b1ee8b8129d02b15ec0e533912c91b04) ) // CD CE -std-
 
@@ -3765,29 +3933,31 @@ ROM_START( popnpop )
 ROM_END
 
 ROM_START( popnpopu )
-	ROM_REGION(0x200000, "maincpu", 0) /* 68020 code */
+	ROM_REGION( 0x200000, "maincpu", 0 ) /* 68020 code */
 	ROM_LOAD32_BYTE("e51-12.20", 0x000000, 0x80000, CRC(86a237d5) SHA1(4b87a51705a4d831b21ee770af17310c6c091c2e) )
 	ROM_LOAD32_BYTE("e51-11.19", 0x000001, 0x80000, CRC(8a49f34f) SHA1(8691fbc1e96f0c9eb550dbb8ae8d7ef371397166) )
 	ROM_LOAD32_BYTE("e51-10.18", 0x000002, 0x80000, CRC(4bce68f8) SHA1(1a9220926f4d8db509f4ccbf318d123f34c42153) )
 	ROM_LOAD32_BYTE("e51-15.17", 0x000003, 0x80000, CRC(1ad77903) SHA1(d5e631d70108d1f15bcfcacde914ac2fb95cb102) )
 
-	ROM_REGION(0x400000, "gfx1" , 0) /* Sprites */
+	ROM_REGION( 0x200000, "sprites" , 0) /* Sprites */
 	ROM_LOAD16_BYTE("e51-03.12",0x000000, 0x100000, CRC(a24c4607) SHA1(2396fa927446568ad8d98ad6756813e2f30523dd) )
 	ROM_LOAD16_BYTE("e51-02.8", 0x000001, 0x100000, CRC(6aa8b96c) SHA1(aaf7917dce5fed43c68cd3065538b58666ef3dbc) )
-	ROM_LOAD       ("e51-01.4", 0x300000, 0x100000, CRC(70347e24) SHA1(6b4ab90f0209e50eac7bee3abcf40afb71ab950a) )
-	ROM_FILL       (            0x200000, 0x100000, 0x00 )
 
-	ROM_REGION(0x800000, "gfx2" , 0) /* Tiles */
-	ROM_LOAD16_BYTE("e51-08.47", 0x000000, 0x200000, CRC(3ad41f02) SHA1(a4959113c01062003df41cdf6146e8a034917ee2) )
-	ROM_LOAD16_BYTE("e51-07.45", 0x000001, 0x200000, CRC(95873e46) SHA1(02504cbd920c8dbcb5abec6388305eff38f7efe0) )
-	ROM_LOAD       ("e51-06.43", 0x600000, 0x200000, CRC(c240d6c8) SHA1(6f3b5224b7eb8783893375d432bbbfc37f81c230) )
-	ROM_FILL       (             0x400000, 0x200000, 0x00 )
+	ROM_REGION( 0x100000, "sprites_hi", 0 )
+	ROM_LOAD       ("e51-01.4", 0x000000, 0x100000, CRC(70347e24) SHA1(6b4ab90f0209e50eac7bee3abcf40afb71ab950a) )
 
-	ROM_REGION(0x180000, "taito_en:audiocpu", 0) /* 68000 sound CPU */
+	ROM_REGION( 0x400000, "tilemap" , 0) /* Tiles */
+	ROM_LOAD32_WORD("e51-08.47", 0x000000, 0x200000, CRC(3ad41f02) SHA1(a4959113c01062003df41cdf6146e8a034917ee2) )
+	ROM_LOAD32_WORD("e51-07.45", 0x000002, 0x200000, CRC(95873e46) SHA1(02504cbd920c8dbcb5abec6388305eff38f7efe0) )
+
+	ROM_REGION( 0x200000, "tilemap_hi", 0 )
+	ROM_LOAD       ("e51-06.43", 0x000000, 0x200000, CRC(c240d6c8) SHA1(6f3b5224b7eb8783893375d432bbbfc37f81c230) )
+
+	ROM_REGION( 0x180000, "taito_en:audiocpu", 0 ) /* 68000 sound CPU */
 	ROM_LOAD16_BYTE("e51-13.32", 0x100000, 0x40000, CRC(3b9e3986) SHA1(26340bda0ad2ea580e2395135617966676a71ad5) )
 	ROM_LOAD16_BYTE("e51-14.33", 0x100001, 0x40000, CRC(1f9a5015) SHA1(5da38c5fe2a50bcde6bd46ab1cb9a56dbab1a882) )
 
-	ROM_REGION16_BE(0x800000, "ensoniq.0" , ROMREGION_ERASE00 ) // V2: 4 banks, only 2 populated
+	ROM_REGION16_BE( 0x800000, "ensoniq.0" , ROMREGION_ERASE00 ) // V2: 4 banks, only 2 populated
 	ROM_LOAD16_BYTE("e51-04.38", 0x000000, 0x200000, CRC(66790f55) SHA1(ac539b2655dbcda1bdffb9f3cf4c96fb05721e9d) ) // C9 CA CB CC
 	ROM_LOAD16_BYTE("e51-05.41", 0x400000, 0x200000, CRC(4d08b26d) SHA1(071a11a1b1ee8b8129d02b15ec0e533912c91b04) ) // CD CE -std-
 
@@ -3842,29 +4012,31 @@ Notes:
 */
 
 ROM_START( landmakr )
-	ROM_REGION(0x200000, "maincpu", 0) /* 68020 code */
+	ROM_REGION( 0x200000, "maincpu", 0 ) /* 68020 code */
 	ROM_LOAD32_BYTE("e61-19.20", 0x000000, 0x80000, CRC(f92eccd0) SHA1(88e836390be1ca08c578080662d17007a9e0bcc3) )
 	ROM_LOAD32_BYTE("e61-18.19", 0x000001, 0x80000, CRC(5a26c9e0) SHA1(e7f09722f6b7a459248c2c8ad0a2695365cc78dc) )
 	ROM_LOAD32_BYTE("e61-17.18", 0x000002, 0x80000, CRC(710776a8) SHA1(669aa086e7a5faedd90407e558c01bf5f0869790) )
 	ROM_LOAD32_BYTE("e61-16.17", 0x000003, 0x80000, CRC(b073cda9) SHA1(a8b713c3e17e431b5789a70d6f9b0e0a6b02624a) )
 
-	ROM_REGION(0x800000, "gfx1" , 0) /* Sprites */
+	ROM_REGION( 0x400000, "sprites" , 0) /* Sprites */
 	ROM_LOAD16_BYTE("e61-03.12",0x000000, 0x200000, CRC(e8abfc46) SHA1(fbde006f9822af3ed8debec525270d329981ea21) )
 	ROM_LOAD16_BYTE("e61-02.08",0x000001, 0x200000, CRC(1dc4a164) SHA1(33b412d9653099aaff8ed5e62d1ba4fc30aa9058) )
-	ROM_LOAD       ("e61-01.04",0x600000, 0x200000, CRC(6cdd8311) SHA1(7810a5a81f3b5a730d2088c79b12fffd77659b5b) )
-	ROM_FILL       (            0x400000, 0x200000, 0x00 )
 
-	ROM_REGION(0x800000, "gfx2" , 0) /* Tiles */
-	ROM_LOAD16_BYTE("e61-09.47", 0x000000, 0x200000, CRC(6ba29987) SHA1(b63c12523e19da66b3ca07c3548ac81bf57b59a1) )
-	ROM_LOAD16_BYTE("e61-08.45", 0x000001, 0x200000, CRC(76c98e14) SHA1(c021c325ab4ae410fa54e2eab61d34318867432b) )
-	ROM_LOAD       ("e61-07.43", 0x600000, 0x200000, CRC(4a57965d) SHA1(8e80788e0f47fb242da9af3aa19077dc0ec829b8) )
-	ROM_FILL       (             0x400000, 0x200000, 0x00 )
+	ROM_REGION( 0x200000, "sprites_hi", 0 )
+	ROM_LOAD       ("e61-01.04",0x000000, 0x200000, CRC(6cdd8311) SHA1(7810a5a81f3b5a730d2088c79b12fffd77659b5b) )
 
-	ROM_REGION(0x180000, "taito_en:audiocpu", 0) /* 68000 sound CPU */
+	ROM_REGION( 0x400000, "tilemap" , 0) /* Tiles */
+	ROM_LOAD32_WORD("e61-09.47", 0x000000, 0x200000, CRC(6ba29987) SHA1(b63c12523e19da66b3ca07c3548ac81bf57b59a1) )
+	ROM_LOAD32_WORD("e61-08.45", 0x000002, 0x200000, CRC(76c98e14) SHA1(c021c325ab4ae410fa54e2eab61d34318867432b) )
+
+	ROM_REGION( 0x200000, "tilemap_hi", 0 )
+	ROM_LOAD       ("e61-07.43", 0x000000, 0x200000, CRC(4a57965d) SHA1(8e80788e0f47fb242da9af3aa19077dc0ec829b8) )
+
+	ROM_REGION( 0x180000, "taito_en:audiocpu", 0 ) /* 68000 sound CPU */
 	ROM_LOAD16_BYTE("e61-14.32", 0x100000, 0x40000, CRC(18961bbb) SHA1(df054def35a49c0754356c15ec15336cbf28b063) )
 	ROM_LOAD16_BYTE("e61-15.33", 0x100001, 0x40000, CRC(2c64557a) SHA1(768007162d5d2cbe650c735bc1af2c10ed13b046) )
 
-	ROM_REGION16_BE(0x1000000, "ensoniq.0" , ROMREGION_ERASE00 )    // V2: 4 banks
+	ROM_REGION16_BE( 0x1000000, "ensoniq.0" , ROMREGION_ERASE00 )    // V2: 4 banks
 	// empty
 	ROM_LOAD16_BYTE("e61-04.38", 0x400000, 0x200000, CRC(c27aec0c) SHA1(e95da2db07a20a53662ebd45c033966e8a22a15a) ) // C8 C9 CA CB
 	ROM_LOAD16_BYTE("e61-05.39", 0x800000, 0x200000, CRC(83920d9d) SHA1(019e39ae85d1129f6d3b8460c4b1bd925f868ee2) ) // CC CD CE CF
@@ -3879,29 +4051,31 @@ ROM_START( landmakr )
 ROM_END
 
 ROM_START( landmakrj )
-	ROM_REGION(0x200000, "maincpu", 0) /* 68020 code */
+	ROM_REGION( 0x200000, "maincpu", 0 ) /* 68020 code */
 	ROM_LOAD32_BYTE("e61-13.20", 0x000000, 0x80000, CRC(0af756a2) SHA1(2dadac6873f2491ee77703f07f00dde2aa909355) )
 	ROM_LOAD32_BYTE("e61-12.19", 0x000001, 0x80000, CRC(636b3df9) SHA1(78a5bf4977bb90d710942188ce5016f3df499feb) )
 	ROM_LOAD32_BYTE("e61-11.18", 0x000002, 0x80000, CRC(279a0ee4) SHA1(08380286737b33db76a79b27d0df5faba17dfb96) )
 	ROM_LOAD32_BYTE("e61-10.17", 0x000003, 0x80000, CRC(daabf2b2) SHA1(dbfbe38841fc2f937052353eff1202790d364b9f) )
 
-	ROM_REGION(0x800000, "gfx1" , 0) /* Sprites */
+	ROM_REGION( 0x400000, "sprites" , 0) /* Sprites */
 	ROM_LOAD16_BYTE("e61-03.12",0x000000, 0x200000, CRC(e8abfc46) SHA1(fbde006f9822af3ed8debec525270d329981ea21) )
 	ROM_LOAD16_BYTE("e61-02.08",0x000001, 0x200000, CRC(1dc4a164) SHA1(33b412d9653099aaff8ed5e62d1ba4fc30aa9058) )
-	ROM_LOAD       ("e61-01.04",0x600000, 0x200000, CRC(6cdd8311) SHA1(7810a5a81f3b5a730d2088c79b12fffd77659b5b) )
-	ROM_FILL       (            0x400000, 0x200000, 0x00 )
 
-	ROM_REGION(0x800000, "gfx2" , 0) /* Tiles */
-	ROM_LOAD16_BYTE("e61-09.47", 0x000000, 0x200000, CRC(6ba29987) SHA1(b63c12523e19da66b3ca07c3548ac81bf57b59a1) )
-	ROM_LOAD16_BYTE("e61-08.45", 0x000001, 0x200000, CRC(76c98e14) SHA1(c021c325ab4ae410fa54e2eab61d34318867432b) )
-	ROM_LOAD       ("e61-07.43", 0x600000, 0x200000, CRC(4a57965d) SHA1(8e80788e0f47fb242da9af3aa19077dc0ec829b8) )
-	ROM_FILL       (             0x400000, 0x200000, 0x00 )
+	ROM_REGION( 0x200000, "sprites_hi", 0 )
+	ROM_LOAD       ("e61-01.04",0x000000, 0x200000, CRC(6cdd8311) SHA1(7810a5a81f3b5a730d2088c79b12fffd77659b5b) )
 
-	ROM_REGION(0x180000, "taito_en:audiocpu", 0) /* 68000 sound CPU */
+	ROM_REGION( 0x400000, "tilemap" , 0) /* Tiles */
+	ROM_LOAD32_WORD("e61-09.47", 0x000000, 0x200000, CRC(6ba29987) SHA1(b63c12523e19da66b3ca07c3548ac81bf57b59a1) )
+	ROM_LOAD32_WORD("e61-08.45", 0x000002, 0x200000, CRC(76c98e14) SHA1(c021c325ab4ae410fa54e2eab61d34318867432b) )
+
+	ROM_REGION( 0x200000, "tilemap_hi", 0 )
+	ROM_LOAD       ("e61-07.43", 0x000000, 0x200000, CRC(4a57965d) SHA1(8e80788e0f47fb242da9af3aa19077dc0ec829b8) )
+
+	ROM_REGION( 0x180000, "taito_en:audiocpu", 0 ) /* 68000 sound CPU */
 	ROM_LOAD16_BYTE("e61-14.32", 0x100000, 0x40000, CRC(18961bbb) SHA1(df054def35a49c0754356c15ec15336cbf28b063) )
 	ROM_LOAD16_BYTE("e61-15.33", 0x100001, 0x40000, CRC(2c64557a) SHA1(768007162d5d2cbe650c735bc1af2c10ed13b046) )
 
-	ROM_REGION16_BE(0x1000000, "ensoniq.0" , ROMREGION_ERASE00 )    // V2: 4 banks
+	ROM_REGION16_BE( 0x1000000, "ensoniq.0" , ROMREGION_ERASE00 )    // V2: 4 banks
 	// empty
 	ROM_LOAD16_BYTE("e61-04.38", 0x400000, 0x200000, CRC(c27aec0c) SHA1(e95da2db07a20a53662ebd45c033966e8a22a15a) ) // C8 C9 CA CB
 	ROM_LOAD16_BYTE("e61-05.39", 0x800000, 0x200000, CRC(83920d9d) SHA1(019e39ae85d1129f6d3b8460c4b1bd925f868ee2) ) // CC CD CE CF
@@ -3916,13 +4090,13 @@ ROM_START( landmakrj )
 ROM_END
 
 ROM_START( landmakrp ) // First 3 roms match parent, mpro-0.63 has bytes 7FFFE & 7FFFF reversed compared to parent.
-	ROM_REGION(0x200000, "maincpu", 0) /* 68020 code */
+	ROM_REGION( 0x200000, "maincpu", 0 ) /* 68020 code */
 	ROM_LOAD32_BYTE("mpro-3.60", 0x000000, 0x80000, CRC(f92eccd0) SHA1(88e836390be1ca08c578080662d17007a9e0bcc3) )
 	ROM_LOAD32_BYTE("mpro-2.61", 0x000001, 0x80000, CRC(5a26c9e0) SHA1(e7f09722f6b7a459248c2c8ad0a2695365cc78dc) )
 	ROM_LOAD32_BYTE("mpro-1.62", 0x000002, 0x80000, CRC(710776a8) SHA1(669aa086e7a5faedd90407e558c01bf5f0869790) )
 	ROM_LOAD32_BYTE("mpro-0.63", 0x000003, 0x80000, CRC(bc71dd2f) SHA1(ec0d07f9729a53737975547066bd1221f78563c5) ) // 7FFFE: 03 FF vs 7FFFE: FF 03 in parent
 
-	ROM_REGION(0x800000, "gfx1" , 0) /* Sprites */
+	ROM_REGION( 0x400000, "sprites" , 0) /* Sprites */
 	ROM_LOAD16_BYTE("obj0-0.8", 0x000000, 0x080000, CRC(4b862c1b) SHA1(ef46af27d0657b95f5f3bad13629f9119958fe78) )
 	ROM_LOAD16_BYTE("obj1-0.7", 0x100000, 0x080000, CRC(90502355) SHA1(e1edc0cec8ca53fda4d42f9b9fdd385379d7a958) )
 	ROM_LOAD16_BYTE("obj2-0.6", 0x200000, 0x080000, CRC(3bffe4b2) SHA1(6e9bb8716f312cb8c81ecebfc61f9dfc8c9013dc) )
@@ -3931,32 +4105,34 @@ ROM_START( landmakrp ) // First 3 roms match parent, mpro-0.63 has bytes 7FFFE &
 	ROM_LOAD16_BYTE("obj1-1.19",0x100001, 0x080000, CRC(a24edb24) SHA1(81fe77eccdd2a7ea02454e57e52b21ad57eb817e) )
 	ROM_LOAD16_BYTE("obj2-1.18",0x200001, 0x080000, CRC(1b2a87f3) SHA1(b7dc871196b92bb4f6ea31bff0717cb3a508bc05) )
 	ROM_LOAD16_BYTE("obj3-1.17",0x300001, 0x080000, CRC(c7e91180) SHA1(c8bfa43ab3b9a6c4ba08e1a7389880e964bb1d80) )
-	ROM_LOAD       ("obj0-2.32",0x600000, 0x080000, CRC(94cc01d0) SHA1(f4cf4cb237a3f2bd9df35424f85a84b70b47d402) )
-	ROM_LOAD       ("obj1-2.31",0x680000, 0x080000, CRC(c2757722) SHA1(83a921647eb0375e10c7f76c08ebe66f2a6fdcd9) )
-	ROM_LOAD       ("obj2-2.30",0x700000, 0x080000, CRC(934556ff) SHA1(aca8585680e66635b8872259cfd38edc96e92066) )
-	ROM_LOAD       ("obj3-2.29",0x780000, 0x080000, CRC(97f0f777) SHA1(787a33b91cb262cc3983a46ba259dd9b153d532a) )
-	ROM_FILL       (            0x400000, 0x200000, 0x00 )
 
-	ROM_REGION(0x800000, "gfx2" , 0) /* Tiles */
+	ROM_REGION( 0x200000, "sprites_hi", 0 )
+	ROM_LOAD       ("obj0-2.32",0x000000, 0x080000, CRC(94cc01d0) SHA1(f4cf4cb237a3f2bd9df35424f85a84b70b47d402) )
+	ROM_LOAD       ("obj1-2.31",0x080000, 0x080000, CRC(c2757722) SHA1(83a921647eb0375e10c7f76c08ebe66f2a6fdcd9) )
+	ROM_LOAD       ("obj2-2.30",0x100000, 0x080000, CRC(934556ff) SHA1(aca8585680e66635b8872259cfd38edc96e92066) )
+	ROM_LOAD       ("obj3-2.29",0x180000, 0x080000, CRC(97f0f777) SHA1(787a33b91cb262cc3983a46ba259dd9b153d532a) )
+
+	ROM_REGION( 0x400000, "tilemap" , 0) /* Tiles */
 	ROM_LOAD32_BYTE("scr0-0.7", 0x000000, 0x080000, CRC(da6ba562) SHA1(6aefd249d3491380837e04583a0069ed9c495d05) )
-	ROM_LOAD32_BYTE("scr0-1.6", 0x000002, 0x080000, CRC(8c201d27) SHA1(83147c35d03c7b5c84220a6442e99b87ba99cfbc) )
-	ROM_LOAD32_BYTE("scr0-2.5", 0x000001, 0x080000, CRC(36756b9c) SHA1(3d293b11d03fb4cdc5c041fcdade9941bf6a72d0) )
+	ROM_LOAD32_BYTE("scr0-1.6", 0x000001, 0x080000, CRC(8c201d27) SHA1(83147c35d03c7b5c84220a6442e99b87ba99cfbc) )
+	ROM_LOAD32_BYTE("scr0-2.5", 0x000002, 0x080000, CRC(36756b9c) SHA1(3d293b11d03fb4cdc5c041fcdade9941bf6a72d0) )
 	ROM_LOAD32_BYTE("scr0-3.4", 0x000003, 0x080000, CRC(4e0274f3) SHA1(d65378db78a310c664ef49a216f18e16c932f58d) )
 	ROM_LOAD32_BYTE("scr1-0.19",0x200000, 0x080000, CRC(2689f716) SHA1(6849e7d36aca5a678b74e1cce9e6a2381928c127) )
-	ROM_LOAD32_BYTE("scr1-1.18",0x200002, 0x080000, CRC(f3086949) SHA1(c21f5384294a9fcfb422dbb85565305520a334b5) )
-	ROM_LOAD32_BYTE("scr1-2.17",0x200001, 0x080000, CRC(7841468a) SHA1(58b60cbb4ec7e2d0d64fc42161b53b9ff5e2ca8c) )
+	ROM_LOAD32_BYTE("scr1-1.18",0x200001, 0x080000, CRC(f3086949) SHA1(c21f5384294a9fcfb422dbb85565305520a334b5) )
+	ROM_LOAD32_BYTE("scr1-2.17",0x200002, 0x080000, CRC(7841468a) SHA1(58b60cbb4ec7e2d0d64fc42161b53b9ff5e2ca8c) )
 	ROM_LOAD32_BYTE("scr1-3.16",0x200003, 0x080000, CRC(926ad229) SHA1(4840227c184bde8d125122a90a70102bf2757ccc) )
-	ROM_LOAD16_BYTE("scr0-4.3", 0x600000, 0x080000, CRC(5b3cf564) SHA1(003f1e4c653897016c95dee67161fa3964d4f5a8) )
-	ROM_LOAD16_BYTE("scr0-5.2", 0x600001, 0x080000, CRC(8e1ea0fe) SHA1(aa815d1d67bf72be6a0c4076490dfd36f28a82ab) )
-	ROM_LOAD16_BYTE("scr1-4.15",0x700000, 0x080000, CRC(783b6d10) SHA1(eab2c7b19890c1f6c13f0062978db5b81988499b) )
-	ROM_LOAD16_BYTE("scr1-5.14",0x700001, 0x080000, CRC(24aba128) SHA1(b03804c738d86bfafc1f8fb91f8e77e878d2dc83) )
-	ROM_FILL       (            0x400000, 0x200000, 0x00 )
 
-	ROM_REGION(0x180000, "taito_en:audiocpu", 0) /* 68000 sound CPU */
+	ROM_REGION( 0x200000, "tilemap_hi", 0 )
+	ROM_LOAD16_BYTE("scr0-4.3", 0x000000, 0x080000, CRC(5b3cf564) SHA1(003f1e4c653897016c95dee67161fa3964d4f5a8) )
+	ROM_LOAD16_BYTE("scr0-5.2", 0x000001, 0x080000, CRC(8e1ea0fe) SHA1(aa815d1d67bf72be6a0c4076490dfd36f28a82ab) )
+	ROM_LOAD16_BYTE("scr1-4.15",0x100000, 0x080000, CRC(783b6d10) SHA1(eab2c7b19890c1f6c13f0062978db5b81988499b) )
+	ROM_LOAD16_BYTE("scr1-5.14",0x100001, 0x080000, CRC(24aba128) SHA1(b03804c738d86bfafc1f8fb91f8e77e878d2dc83) )
+
+	ROM_REGION( 0x180000, "taito_en:audiocpu", 0 ) /* 68000 sound CPU */
 	ROM_LOAD16_BYTE("spro-1.66", 0x100000, 0x40000, CRC(18961bbb) SHA1(df054def35a49c0754356c15ec15336cbf28b063) )
 	ROM_LOAD16_BYTE("spro-0.65", 0x100001, 0x40000, CRC(2c64557a) SHA1(768007162d5d2cbe650c735bc1af2c10ed13b046) )
 
-	ROM_REGION16_BE(0x1000000, "ensoniq.0" , ROMREGION_ERASE00 )    // V2: 4 banks
+	ROM_REGION16_BE( 0x1000000, "ensoniq.0" , ROMREGION_ERASE00 )    // V2: 4 banks
 	// empty
 	ROM_LOAD16_BYTE("snd-0.43", 0x400000, 0x80000, CRC(0e5ef5c8) SHA1(e2840c9cedb9361b7eb307e87ea96f3bb6225487) )   // C8
 	ROM_LOAD16_BYTE("snd-1.44", 0x500000, 0x80000, CRC(2998fd65) SHA1(192e32f9934465bb0da5c1ad116c5ea9b286f36a) )   // C9
@@ -3974,14 +4150,8 @@ ROM_END
 
 /******************************************************************************/
 
-static void tile_decode(running_machine &machine)
+void taito_f3_state::tile_decode()
 {
-	uint8_t lsb,msb;
-	uint32_t offset,i;
-	uint8_t *gfx = machine.root_device().memregion("gfx2")->base();
-	int size=machine.root_device().memregion("gfx2")->bytes();
-	int data;
-
 	/* Setup ROM formats:
 
 	    Some games will only use 4 or 5 bpp sprites, and some only use 4 bpp tiles,
@@ -3996,230 +4166,228 @@ static void tile_decode(running_machine &machine)
 
 	*/
 
-	offset = size/2;
-	for (i = size/2+size/4; i<size; i+=2)
+	u8 *srcdata, *dest;
+	if (m_tilemaprom_hi)
 	{
-		/* Expand 2bits into 4bits format */
-		lsb = gfx[i+1];
-		msb = gfx[i];
+		u8 *tmap_hi = m_tilemaprom_hi;
+		gfx_element *pf_gfx = m_gfxdecode->gfx(1);
 
-		gfx[offset+0]=((msb&0x02)<<3) | ((msb&0x01)>>0) | ((lsb&0x02)<<4) | ((lsb&0x01)<<1);
-		gfx[offset+2]=((msb&0x08)<<1) | ((msb&0x04)>>2) | ((lsb&0x08)<<2) | ((lsb&0x04)>>1);
-		gfx[offset+1]=((msb&0x20)>>1) | ((msb&0x10)>>4) | ((lsb&0x20)<<0) | ((lsb&0x10)>>3);
-		gfx[offset+3]=((msb&0x80)>>3) | ((msb&0x40)>>6) | ((lsb&0x80)>>2) | ((lsb&0x40)>>5);
+		// allocate memory for the assembled data
+		srcdata = auto_alloc_array(machine(), u8, pf_gfx->elements() * pf_gfx->width() * pf_gfx->height());
 
-		offset+=4;
+		// loop over elements
+		dest = srcdata;
+		for (int c = 0; c < pf_gfx->elements(); c++)
+		{
+			const u8 *c0base = pf_gfx->get_data(c);
+
+			// loop over height
+			for (int y = 0; y < pf_gfx->height(); y++)
+			{
+				const u8 *c0 = c0base;
+
+				for (int x = 0; x < pf_gfx->width();)
+				{
+					u8 msb = *tmap_hi++;
+					u8 lsb = *tmap_hi++;
+					for (int i = 0; i < 8; i++)
+					{
+						*dest++ = (*c0++ & 0xf) | ((msb << 4) & 0x10) | ((lsb << 5) & 0x20);
+						x++;
+						msb >>= 1;
+						lsb >>= 1;
+					}
+				}
+				c0base += pf_gfx->rowbytes();
+			}
+		}
+
+		pf_gfx->set_raw_layout(srcdata, pf_gfx->width(), pf_gfx->height(), pf_gfx->elements(), 8 * pf_gfx->width(), 8 * pf_gfx->width() * pf_gfx->height());
 	}
 
-	gfx = machine.root_device().memregion("gfx1")->base();
-	size=machine.root_device().memregion("gfx1")->bytes();
-
-	offset = size/2;
-	for (i = size/2+size/4; i<size; i++)
+	// all but bubsymphb (bootleg board with different sprite gfx layout), 2mindril (no sprite gfx roms)
+	if (m_spriterom_hi)
 	{
-		int d1,d2,d3,d4;
+		u8 *spr_hi = m_spriterom_hi;
+		gfx_element *spr_gfx = m_gfxdecode->gfx(2);
 
-		/* Expand 2bits into 4bits format */
-		data = gfx[i];
-		d1 = (data>>0) & 3;
-		d2 = (data>>2) & 3;
-		d3 = (data>>4) & 3;
-		d4 = (data>>6) & 3;
+		// allocate memory for the assembled data
+		srcdata = auto_alloc_array(machine(), u8, spr_gfx->elements() * spr_gfx->width() * spr_gfx->height());
 
-		gfx[offset] = (d1<<2) | (d2<<6);
-		offset++;
+		// loop over elements
+		dest = srcdata;
+		for (int c = 0; c < spr_gfx->elements(); c++)
+		{
+			const u8 *c1base = spr_gfx->get_data(c);
 
-		gfx[offset] = (d3<<2) | (d4<<6);
-		offset++;
+			// loop over height
+			for (int y = 0; y < spr_gfx->height(); y++)
+			{
+				const u8 *c1 = c1base;
+
+				for (int x = 0; x < spr_gfx->width();)
+				{
+					/* Expand 2bits into 4bits format */
+					u8 hipix = *spr_hi++;
+					for (int i = 0; i < 4; i++)
+					{
+						*dest++ = (*c1++ & 0xf) | ((hipix << 4) & 0x30);
+						x++;
+						hipix >>= 2;
+					}
+				}
+				c1base += spr_gfx->rowbytes();
+			}
+		}
+
+		spr_gfx->set_raw_layout(srcdata, spr_gfx->width(), spr_gfx->height(), spr_gfx->elements(), 8 * spr_gfx->width(), 8 * spr_gfx->width() * spr_gfx->height());
 	}
 }
 
 void taito_f3_state::init_ringrage()
 {
-	m_f3_game=RINGRAGE;
-	tile_decode(machine());
+	m_game=RINGRAGE;
+	tile_decode();
 }
 
 void taito_f3_state::init_arabianm()
 {
-	m_f3_game=ARABIANM;
-	tile_decode(machine());
+	m_game=ARABIANM;
+	tile_decode();
 }
 
 void taito_f3_state::init_ridingf()
 {
-	m_f3_game=RIDINGF;
-	tile_decode(machine());
+	m_game=RIDINGF;
+	tile_decode();
 }
 
 void taito_f3_state::init_gseeker()
 {
-	m_f3_game=GSEEKER;
-	tile_decode(machine());
+	m_game=GSEEKER;
+	tile_decode();
 }
 
 void taito_f3_state::init_gunlock()
 {
-	m_f3_game=GUNLOCK;
-	tile_decode(machine());
+	m_game=GUNLOCK;
+	tile_decode();
 }
 
 void taito_f3_state::init_elvactr()
 {
-	m_f3_game=EACTION2;
-	tile_decode(machine());
+	m_game=EACTION2;
+	tile_decode();
 }
 
 void taito_f3_state::init_cupfinal()
 {
-	m_f3_game=SCFINALS;
-	tile_decode(machine());
+	m_game=SCFINALS;
+	tile_decode();
 }
 
 void taito_f3_state::init_trstaroj()
 {
-	m_f3_game=TRSTAR;
-	tile_decode(machine());
+	m_game=TRSTAR;
+	tile_decode();
 }
 
 void taito_f3_state::init_scfinals()
 {
-	m_f3_game=SCFINALS;
-	tile_decode(machine());
+	m_game=SCFINALS;
+	tile_decode();
 }
 
 void taito_f3_state::init_lightbr()
 {
-	m_f3_game=LIGHTBR;
-	tile_decode(machine());
+	m_game=LIGHTBR;
+	tile_decode();
 }
 
 void taito_f3_state::init_kaiserkn()
 {
-	m_f3_game=KAISERKN;
-	tile_decode(machine());
+	m_game=KAISERKN;
+	tile_decode();
 }
 
 void taito_f3_state::init_dariusg()
 {
-	m_f3_game=DARIUSG;
-	tile_decode(machine());
+	m_game=DARIUSG;
+	tile_decode();
 }
 
 void taito_f3_state::init_spcinvdj()
 {
-	m_f3_game=SPCINVDX;
-	tile_decode(machine());
+	m_game=SPCINVDX;
+	tile_decode();
 }
 
 void taito_f3_state::init_qtheater()
 {
-	m_f3_game=QTHEATER;
-	tile_decode(machine());
+	m_game=QTHEATER;
+	tile_decode();
 }
 
 void taito_f3_state::init_spcinv95()
 {
-	m_f3_game=SPCINV95;
-	tile_decode(machine());
+	m_game=SPCINV95;
+	tile_decode();
 }
 
 void taito_f3_state::init_gekirido()
 {
-	m_f3_game=GEKIRIDO;
-	tile_decode(machine());
+	m_game=GEKIRIDO;
+	tile_decode();
 }
 
 void taito_f3_state::init_ktiger2()
 {
-	m_f3_game=KTIGER2;
-	tile_decode(machine());
+	m_game=KTIGER2;
+	tile_decode();
 }
 
 void taito_f3_state::init_bubsymph()
 {
-	m_f3_game=BUBSYMPH;
-	tile_decode(machine());
+	m_game=BUBSYMPH;
+	tile_decode();
 }
-
-
-READ32_MEMBER(taito_f3_state::bubsympb_oki_r)
-{
-	return m_oki->read();
-}
-
-WRITE32_MEMBER(taito_f3_state::bubsympb_oki_w)
-{
-	//printf("write %08x %08x\n",data,mem_mask);
-	if (ACCESSING_BITS_0_7) m_oki->write(data&0xff);
-	//if (mem_mask==0x000000ff) downcast<okim6295_device *>(device)->write(0,data&0xff);
-	if (ACCESSING_BITS_16_23)
-	{
-		uint8_t *snd = memregion("oki")->base();
-		int bank = (data & 0x000f0000) >> 16;
-		// almost certainly wrong
-		memcpy(snd+0x30000, snd+0x80000+0x30000+bank*0x10000, 0x10000);
-
-		//printf("oki bank w %08x\n",data);
-	}
-
-
-}
-
 
 void taito_f3_state::init_bubsympb()
 {
-	m_f3_game=BUBSYMPH;
-	//tile_decode(machine());
+	m_game=BUBSYMPH;
+	tile_decode();
 
-	/* expand gfx rom */
-	{
-		int i;
-		uint8_t *gfx = memregion("gfx2")->base();
-
-		for (i=0x200000;i<0x400000; i+=4)
-		{
-			uint8_t byte = gfx[i];
-			gfx[i+0] = (byte & 0x80)? 1<<4 : 0<<4;
-			gfx[i+0]|= (byte & 0x40)? 1<<0 : 0<<0;
-			gfx[i+1] = (byte & 0x20)? 1<<4 : 0<<4;
-			gfx[i+1]|= (byte & 0x10)? 1<<0 : 0<<0;
-			gfx[i+2] = (byte & 0x08)? 1<<4 : 0<<4;
-			gfx[i+2]|= (byte & 0x04)? 1<<0 : 0<<0;
-			gfx[i+3] = (byte & 0x02)? 1<<4 : 0<<4;
-			gfx[i+3]|= (byte & 0x01)? 1<<0 : 0<<0;
-		}
-	}
+	// almost certainly wrong
+	m_okibank->configure_entries(0, 5, memregion("oki")->base() + 0x30000, 0x10000);
 }
-
 
 void taito_f3_state::init_bubblem()
 {
-	m_f3_game=BUBBLEM;
-	tile_decode(machine());
+	m_game=BUBBLEM;
+	tile_decode();
 }
 
 void taito_f3_state::init_cleopatr()
 {
-	m_f3_game=CLEOPATR;
-	tile_decode(machine());
+	m_game=CLEOPATR;
+	tile_decode();
 }
 
 void taito_f3_state::init_popnpop()
 {
-	m_f3_game=POPNPOP;
-	tile_decode(machine());
+	m_game=POPNPOP;
+	tile_decode();
 }
 
 void taito_f3_state::init_landmakr()
 {
-	m_f3_game=LANDMAKR;
-	tile_decode(machine());
+	m_game=LANDMAKR;
+	tile_decode();
 }
 
 void taito_f3_state::init_landmkrp()
 {
-	uint32_t *RAM = (uint32_t *)memregion("maincpu")->base();
+	u32 *RAM = (u32 *)memregion("maincpu")->base();
 
 	/* For some reason the least significant byte in the last 2 long words of
 	ROM is swapped.  As the roms have been verified ok, I assume this is some
@@ -4228,32 +4396,32 @@ void taito_f3_state::init_landmkrp()
 	RAM[0x1ffff8/4]=0xffffffff; /* From 0xffffff03 */
 	RAM[0x1ffffc/4]=0xffff0003; /* From 0xffff00ff */
 
-	m_f3_game=LANDMAKR;
-	tile_decode(machine());
+	m_game=LANDMAKR;
+	tile_decode();
 }
 
 void taito_f3_state::init_pbobble3()
 {
-	m_f3_game=PBOBBLE3;
-	tile_decode(machine());
+	m_game=PBOBBLE3;
+	tile_decode();
 }
 
 void taito_f3_state::init_pbobble4()
 {
-	m_f3_game=PBOBBLE4;
-	tile_decode(machine());
+	m_game=PBOBBLE4;
+	tile_decode();
 }
 
 void taito_f3_state::init_quizhuhu()
 {
-	m_f3_game=QUIZHUHU;
-	tile_decode(machine());
+	m_game=QUIZHUHU;
+	tile_decode();
 }
 
 void taito_f3_state::init_pbobble2()
 {
-	m_f3_game=PBOBBLE2;
-	tile_decode(machine());
+	m_game=PBOBBLE2;
+	tile_decode();
 }
 
 void taito_f3_state::init_pbobbl2p()
@@ -4262,70 +4430,68 @@ void taito_f3_state::init_pbobbl2p()
 	// which eventually causes the game to crash
 	//  -- protection check?? or some kind of checksum fail?
 
-	uint32_t *ROM = (uint32_t *)memregion("maincpu")->base();
+	u32 *ROM = (u32 *)memregion("maincpu")->base();
 
 	/* protection? */
 	ROM[0x40090/4]=0x00004e71|(ROM[0x40090/4]&0xffff0000);
 	ROM[0x40094/4]=0x4e714e71;
 
-	m_f3_game=PBOBBLE2;
-	tile_decode(machine());
+	m_game=PBOBBLE2;
+	tile_decode();
 }
-
-
 
 void taito_f3_state::init_pbobbl2x()
 {
-	m_f3_game=PBOBBLE2;
-	tile_decode(machine());
+	m_game=PBOBBLE2;
+	tile_decode();
 }
 
 void taito_f3_state::init_hthero95()
 {
-	m_f3_game=HTHERO95;
-	tile_decode(machine());
+	m_game=HTHERO95;
+	tile_decode();
 }
 
 void taito_f3_state::init_kirameki()
 {
-	m_f3_game=KIRAMEKI;
-	tile_decode(machine());
+	m_game=KIRAMEKI;
+	tile_decode();
 }
 
 void taito_f3_state::init_puchicar()
 {
-	m_f3_game=PUCHICAR;
-	tile_decode(machine());
+	m_game=PUCHICAR;
+	tile_decode();
 }
 
 void taito_f3_state::init_twinqix()
 {
-	m_f3_game=TWINQIX;
-	tile_decode(machine());
+	m_game=TWINQIX;
+	tile_decode();
 }
 
 void taito_f3_state::init_arkretrn()
 {
-	m_f3_game=ARKRETRN;
-	tile_decode(machine());
+	m_game=ARKRETRN;
+	tile_decode();
 }
 
 void taito_f3_state::init_intcup94()
 {
-	m_f3_game=SCFINALS;
-	tile_decode(machine());
+	m_game=SCFINALS;
+	tile_decode();
 }
 
 void taito_f3_state::init_recalh()
 {
-	m_f3_game=RECALH;
-	tile_decode(machine());
+	m_game=RECALH;
+	tile_decode();
 }
 
 void taito_f3_state::init_commandw()
 {
-	m_f3_game=COMMANDW;
-	tile_decode(machine());
+	m_game=COMMANDW;
+	tile_decode();
 }
 
 /******************************************************************************/

--- a/src/mame/includes/taito_f3.h
+++ b/src/mame/includes/taito_f3.h
@@ -60,19 +60,28 @@ public:
 	taito_f3_state(const machine_config &mconfig, device_type type, const char *tag)
 		: driver_device(mconfig, type, tag),
 		m_maincpu(*this, "maincpu"),
-		m_audiocpu(*this, "taito_en:audiocpu"),
-		m_taito_en(*this, "taito_en"),
 		m_watchdog(*this, "watchdog"),
-		m_oki(*this, "oki"),
 		m_gfxdecode(*this, "gfxdecode"),
 		m_screen(*this, "screen"),
 		m_palette(*this, "palette"),
 		m_eeprom(*this, "eeprom"),
-		m_f3_ram(*this,"f3_ram"),
-		m_paletteram32(*this, "paletteram"),
+		m_spriterom_hi(*this, "sprites_hi"),
+		m_tilemaprom_hi(*this, "tilemap_hi"),
+		m_textram(*this, "textram", 0),
+		m_spriteram(*this, "spriteram", 0),
+		m_charram(*this, "charram", 0),
+		m_line_ram(*this, "line_ram", 0),
+		m_pf_ram(*this, "pf_ram", 0),
+		m_pivot_ram(*this, "pivot_ram", 0),
 		m_input(*this, "IN.%u", 0),
 		m_dial(*this, "DIAL.%u", 0),
-		m_eepromin(*this, "EEPROMIN")
+		m_eepromin(*this, "EEPROMIN"),
+		m_eepromout(*this, "EEPROMOUT"),
+		m_audiocpu(*this, "taito_en:audiocpu"),
+		m_taito_en(*this, "taito_en"),
+		m_oki(*this, "oki"),
+		m_paletteram32(*this, "paletteram"),
+		m_okibank(*this, "okibank")
 	{ }
 
 	void f3_eeprom(machine_config &config);
@@ -132,75 +141,103 @@ protected:
 		TIMER_F3_INTERRUPT3
 	};
 
+	virtual void device_timer(emu_timer &timer, device_timer_id id, int param, void *ptr) override;
+	virtual void device_post_load(void) override;
+
+	virtual void machine_start() override;
+	virtual void machine_reset() override;
+	virtual void video_start() override;
+
 	required_device<cpu_device> m_maincpu;
-	optional_device<cpu_device> m_audiocpu;
-	optional_device<taito_en_device> m_taito_en;
 	optional_device<watchdog_timer_device> m_watchdog;
-	optional_device<okim6295_device> m_oki;
 	required_device<gfxdecode_device> m_gfxdecode;
 	required_device<screen_device> m_screen;
 	required_device<palette_device> m_palette;
 	optional_device<eeprom_serial_base_device> m_eeprom;
 
-	optional_shared_ptr<uint32_t> m_f3_ram;
-	optional_shared_ptr<uint32_t> m_paletteram32;
+	optional_region_ptr<u8> m_spriterom_hi; // all but 2mindril, bubsymphb
+	optional_region_ptr<u8> m_tilemaprom_hi;
+
+	required_shared_ptr<u16> m_textram;
+	required_shared_ptr<u16> m_spriteram;
+	required_shared_ptr<u16> m_charram;
+	required_shared_ptr<u16> m_line_ram;
+	required_shared_ptr<u16> m_pf_ram;
+	required_shared_ptr<u16> m_pivot_ram;
+
 	optional_ioport_array<6> m_input;
 	optional_ioport_array<2> m_dial;
 	optional_ioport m_eepromin;
-
-
-	std::unique_ptr<uint16_t[]> m_videoram;
-	std::unique_ptr<uint16_t[]> m_spriteram;
-	std::unique_ptr<uint16_t[]> m_f3_vram;
-	std::unique_ptr<uint16_t[]> m_f3_line_ram;
-	std::unique_ptr<uint16_t[]> m_f3_pf_data;
-	std::unique_ptr<uint16_t[]> m_f3_pivot_ram;
+	optional_ioport m_eepromout;
 
 	emu_timer *m_interrupt3_timer;
-	uint32_t m_coin_word[2];
-	int m_f3_game;
-	tilemap_t *m_pf1_tilemap;
-	tilemap_t *m_pf2_tilemap;
-	tilemap_t *m_pf3_tilemap;
-	tilemap_t *m_pf4_tilemap;
-	tilemap_t *m_pf5_tilemap;
-	tilemap_t *m_pf6_tilemap;
-	tilemap_t *m_pf7_tilemap;
-	tilemap_t *m_pf8_tilemap;
+	u32 m_coin_word[2];
+
+	struct tempsprite
+	{
+		int code, color;
+		int flipx, flipy;
+		int x, y;
+		int zoomx, zoomy;
+		int pri;
+	};
+
+	struct f3_playfield_line_inf
+	{
+		int alpha_mode[256];
+		int pri[256];
+
+		/* use for draw_scanlines */
+		u16 *src[256], *src_s[256], *src_e[256];
+		u8 *tsrc[256], *tsrc_s[256];
+		int x_count[256];
+		u32 x_zoom[256];
+		u32 clip0[256];
+		u32 clip1[256];
+	};
+
+	struct f3_spritealpha_line_inf
+	{
+		u16 alpha_level[256];
+		u16 spri[256];
+		u16 sprite_alpha[256];
+		u32 sprite_clip0[256];
+		u32 sprite_clip1[256];
+		s16 clip0_l[256];
+		s16 clip0_r[256];
+		s16 clip1_l[256];
+		s16 clip1_r[256];
+	};
+
+	int m_game;
+	tilemap_t *m_tilemap[8];
 	tilemap_t *m_pixel_layer;
 	tilemap_t *m_vram_layer;
-	std::unique_ptr<uint16_t[]> m_spriteram16_buffered;
-	uint16_t m_f3_control_0[8];
-	uint16_t m_f3_control_1[8];
+	std::unique_ptr<u16[]> m_spriteram16_buffered;
+	u16 m_control_0[8];
+	u16 m_control_1[8];
 	int m_flipscreen;
-	uint8_t m_sprite_extra_planes;
-	uint8_t m_sprite_pen_mask;
-	uint16_t *m_f3_pf_data_1;
-	uint16_t *m_f3_pf_data_2;
-	uint16_t *m_f3_pf_data_3;
-	uint16_t *m_f3_pf_data_4;
-	uint16_t *m_f3_pf_data_5;
-	uint16_t *m_f3_pf_data_6;
-	uint16_t *m_f3_pf_data_7;
-	uint16_t *m_f3_pf_data_8;
+	u8 m_sprite_extra_planes;
+	u8 m_sprite_pen_mask;
+	u16 *m_pf_data[8];
 	int m_sprite_lag;
-	uint8_t m_sprite_pri_usage;
+	u8 m_sprite_pri_usage;
 	bitmap_ind8 m_pri_alp_bitmap;
-	int m_f3_alpha_level_2as;
-	int m_f3_alpha_level_2ad;
-	int m_f3_alpha_level_3as;
-	int m_f3_alpha_level_3ad;
-	int m_f3_alpha_level_2bs;
-	int m_f3_alpha_level_2bd;
-	int m_f3_alpha_level_3bs;
-	int m_f3_alpha_level_3bd;
+	int m_alpha_level_2as;
+	int m_alpha_level_2ad;
+	int m_alpha_level_3as;
+	int m_alpha_level_3ad;
+	int m_alpha_level_2bs;
+	int m_alpha_level_2bd;
+	int m_alpha_level_3bs;
+	int m_alpha_level_3bd;
 	int m_alpha_level_last;
 	int m_width_mask;
 	int m_twidth_mask;
 	int m_twidth_mask_bit;
-	std::unique_ptr<uint8_t[]> m_tile_opaque_sp;
-	std::unique_ptr<uint8_t[]> m_tile_opaque_pf[8];
-	uint8_t m_add_sat[256][256];
+	std::unique_ptr<u8[]> m_tile_opaque_sp;
+	std::unique_ptr<u8[]> m_tile_opaque_pf[8];
+	u8 m_add_sat[256][256];
 	int m_alpha_s_1_1;
 	int m_alpha_s_1_2;
 	int m_alpha_s_1_4;
@@ -221,197 +258,151 @@ protected:
 	int m_alpha_s_3b_0;
 	int m_alpha_s_3b_1;
 	int m_alpha_s_3b_2;
-	uint32_t m_dval;
-	uint8_t m_pval;
-	uint8_t m_tval;
-	uint8_t m_pdest_2a;
-	uint8_t m_pdest_2b;
+	u32 m_dval;
+	u8 m_pval;
+	u8 m_tval;
+	u8 m_pdest_2a;
+	u8 m_pdest_2b;
 	int m_tr_2a;
 	int m_tr_2b;
-	uint8_t m_pdest_3a;
-	uint8_t m_pdest_3b;
+	u8 m_pdest_3a;
+	u8 m_pdest_3b;
 	int m_tr_3a;
 	int m_tr_3b;
-	uint16_t *m_src0;
-	uint16_t *m_src_s0;
-	uint16_t *m_src_e0;
-	uint16_t m_clip_al0;
-	uint16_t m_clip_ar0;
-	uint16_t m_clip_bl0;
-	uint16_t m_clip_br0;
-	uint8_t *m_tsrc0;
-	uint8_t *m_tsrc_s0;
-	uint32_t m_x_count0;
-	uint32_t m_x_zoom0;
-	uint16_t *m_src1;
-	uint16_t *m_src_s1;
-	uint16_t *m_src_e1;
-	uint16_t m_clip_al1;
-	uint16_t m_clip_ar1;
-	uint16_t m_clip_bl1;
-	uint16_t m_clip_br1;
-	uint8_t *m_tsrc1;
-	uint8_t *m_tsrc_s1;
-	uint32_t m_x_count1;
-	uint32_t m_x_zoom1;
-	uint16_t *m_src2;
-	uint16_t *m_src_s2;
-	uint16_t *m_src_e2;
-	uint16_t m_clip_al2;
-	uint16_t m_clip_ar2;
-	uint16_t m_clip_bl2;
-	uint16_t m_clip_br2;
-	uint8_t *m_tsrc2;
-	uint8_t *m_tsrc_s2;
-	uint32_t m_x_count2;
-	uint32_t m_x_zoom2;
-	uint16_t *m_src3;
-	uint16_t *m_src_s3;
-	uint16_t *m_src_e3;
-	uint16_t m_clip_al3;
-	uint16_t m_clip_ar3;
-	uint16_t m_clip_bl3;
-	uint16_t m_clip_br3;
-	uint8_t *m_tsrc3;
-	uint8_t *m_tsrc_s3;
-	uint32_t m_x_count3;
-	uint32_t m_x_zoom3;
-	uint16_t *m_src4;
-	uint16_t *m_src_s4;
-	uint16_t *m_src_e4;
-	uint16_t m_clip_al4;
-	uint16_t m_clip_ar4;
-	uint16_t m_clip_bl4;
-	uint16_t m_clip_br4;
-	uint8_t *m_tsrc4;
-	uint8_t *m_tsrc_s4;
-	uint32_t m_x_count4;
-	uint32_t m_x_zoom4;
+	u16 *m_src[5];
+	u16 *m_src_s[5];
+	u16 *m_src_e[5];
+	u16 m_clip_al[5];
+	u16 m_clip_ar[5];
+	u16 m_clip_bl[5];
+	u16 m_clip_br[5];
+	u8 *m_tsrc[5];
+	u8 *m_tsrc_s[5];
+	u32 m_x_count[5];
+	u32 m_x_zoom[5];
 	struct tempsprite *m_spritelist;
 	const struct tempsprite *m_sprite_end;
 	struct f3_playfield_line_inf *m_pf_line_inf;
 	struct f3_spritealpha_line_inf *m_sa_line_inf;
-	const struct F3config *m_f3_game_config;
-	int (taito_f3_state::*m_dpix_n[8][16])(uint32_t s_pix);
-	int (taito_f3_state::**m_dpix_lp[5])(uint32_t s_pix);
-	int (taito_f3_state::**m_dpix_sp[9])(uint32_t s_pix);
+	const struct F3config *m_game_config;
+	int (taito_f3_state::*m_dpix_n[8][16])(u32 s_pix);
+	int (taito_f3_state::**m_dpix_lp[5])(u32 s_pix);
+	int (taito_f3_state::**m_dpix_sp[9])(u32 s_pix);
 
-	DECLARE_READ32_MEMBER(f3_control_r);
-	DECLARE_WRITE32_MEMBER(f3_control_w);
-	DECLARE_WRITE32_MEMBER(f3_sound_reset_0_w);
-	DECLARE_WRITE32_MEMBER(f3_sound_reset_1_w);
-	DECLARE_WRITE32_MEMBER(f3_sound_bankswitch_w);
-	DECLARE_WRITE16_MEMBER(f3_unk_w);
-	DECLARE_READ32_MEMBER(bubsympb_oki_r);
-	DECLARE_WRITE32_MEMBER(bubsympb_oki_w);
-	DECLARE_READ16_MEMBER(f3_pf_data_r);
-	DECLARE_WRITE16_MEMBER(f3_pf_data_w);
-	DECLARE_WRITE16_MEMBER(f3_control_0_w);
-	DECLARE_WRITE16_MEMBER(f3_control_1_w);
-	DECLARE_READ16_MEMBER(f3_spriteram_r);
-	DECLARE_WRITE16_MEMBER(f3_spriteram_w);
-	DECLARE_READ16_MEMBER(f3_videoram_r);
-	DECLARE_WRITE16_MEMBER(f3_videoram_w);
-	DECLARE_READ16_MEMBER(f3_vram_r);
-	DECLARE_WRITE16_MEMBER(f3_vram_w);
-	DECLARE_READ16_MEMBER(f3_pivot_r);
-	DECLARE_WRITE16_MEMBER(f3_pivot_w);
-	DECLARE_READ16_MEMBER(f3_lineram_r);
-	DECLARE_WRITE16_MEMBER(f3_lineram_w);
-	DECLARE_WRITE32_MEMBER(f3_palette_24bit_w);
+	u16 pf_ram_r(offs_t offset);
+	void pf_ram_w(offs_t offset, u16 data, u16 mem_mask = ~0);
+	void control_0_w(offs_t offset, u16 data, u16 mem_mask = ~0);
+	void control_1_w(offs_t offset, u16 data, u16 mem_mask = ~0);
+	u16 spriteram_r(offs_t offset);
+	void spriteram_w(offs_t offset, u16 data, u16 mem_mask = ~0);
+	u16 textram_r(offs_t offset);
+	void textram_w(offs_t offset, u16 data, u16 mem_mask = ~0);
+	u16 charram_r(offs_t offset);
+	void charram_w(offs_t offset, u16 data, u16 mem_mask = ~0);
+	u16 pivot_r(offs_t offset);
+	void pivot_w(offs_t offset, u16 data, u16 mem_mask = ~0);
+	u16 lineram_r(offs_t offset);
+	void lineram_w(offs_t offset, u16 data, u16 mem_mask = ~0);
 
-	TILE_GET_INFO_MEMBER(get_tile_info1);
-	TILE_GET_INFO_MEMBER(get_tile_info2);
-	TILE_GET_INFO_MEMBER(get_tile_info3);
-	TILE_GET_INFO_MEMBER(get_tile_info4);
-	TILE_GET_INFO_MEMBER(get_tile_info5);
-	TILE_GET_INFO_MEMBER(get_tile_info6);
-	TILE_GET_INFO_MEMBER(get_tile_info7);
-	TILE_GET_INFO_MEMBER(get_tile_info8);
-	TILE_GET_INFO_MEMBER(get_tile_info_vram);
+	template<unsigned Layer> TILE_GET_INFO_MEMBER(get_tile_info);
+	TILE_GET_INFO_MEMBER(get_tile_info_text);
 	TILE_GET_INFO_MEMBER(get_tile_info_pixel);
-	uint32_t screen_update_f3(screen_device &screen, bitmap_rgb32 &bitmap, const rectangle &cliprect);
-	DECLARE_WRITE_LINE_MEMBER(screen_vblank_f3);
-	INTERRUPT_GEN_MEMBER(f3_interrupt2);
+	u32 screen_update(screen_device &screen, bitmap_rgb32 &bitmap, const rectangle &cliprect);
+	DECLARE_WRITE_LINE_MEMBER(screen_vblank);
 
 	void bubsympb_map(address_map &map);
 	void f3_map(address_map &map);
 
-	virtual void machine_start() override;
-	virtual void machine_reset() override;
-	virtual void video_start() override;
+	void tile_decode();
 
-	virtual void device_timer(emu_timer &timer, device_timer_id id, int param, void *ptr) override;
-	virtual void device_post_load(void) override;
-
-	inline void get_tile_info(tile_data &tileinfo, int tile_index, uint16_t *gfx_base);
-	inline void f3_drawgfx(bitmap_rgb32 &dest_bmp,const rectangle &clip,gfx_element *gfx,int code,int color,int flipx,int flipy,int sx,int sy,uint8_t pri_dst);
-	inline void f3_drawgfxzoom(bitmap_rgb32 &dest_bmp,const rectangle &clip,gfx_element *gfx,int code,int color,int flipx,int flipy,int sx,int sy,int scalex,int scaley,uint8_t pri_dst);
+	inline void f3_drawgfx(bitmap_rgb32 &dest_bmp, const rectangle &clip, gfx_element *gfx, int code, int color, int flipx, int flipy, int sx, int sy, u8 pri_dst);
+	inline void f3_drawgfxzoom(bitmap_rgb32 &dest_bmp, const rectangle &clip, gfx_element *gfx, int code, int color, int flipx, int flipy, int sx, int sy, int scalex, int scaley, u8 pri_dst);
 	void draw_sprites(bitmap_rgb32 &bitmap, const rectangle &cliprect);
-	void get_sprite_info(const uint16_t *spriteram16_ptr);
+	void get_sprite_info(const u16 *spriteram16_ptr);
 	void print_debug_info(bitmap_rgb32 &bitmap);
-	inline void f3_alpha_set_level();
-	inline void f3_alpha_blend32_s(int alphas, uint32_t s);
-	inline void f3_alpha_blend32_d(int alphas, uint32_t s);
-	inline void f3_alpha_blend_1_1(uint32_t s);
-	inline void f3_alpha_blend_1_2(uint32_t s);
-	inline void f3_alpha_blend_1_4(uint32_t s);
-	inline void f3_alpha_blend_1_5(uint32_t s);
-	inline void f3_alpha_blend_1_6(uint32_t s);
-	inline void f3_alpha_blend_1_8(uint32_t s);
-	inline void f3_alpha_blend_1_9(uint32_t s);
-	inline void f3_alpha_blend_1_a(uint32_t s);
-	inline void f3_alpha_blend_2a_0(uint32_t s);
-	inline void f3_alpha_blend_2a_4(uint32_t s);
-	inline void f3_alpha_blend_2a_8(uint32_t s);
-	inline void f3_alpha_blend_2b_0(uint32_t s);
-	inline void f3_alpha_blend_2b_4(uint32_t s);
-	inline void f3_alpha_blend_2b_8(uint32_t s);
-	inline void f3_alpha_blend_3a_0(uint32_t s);
-	inline void f3_alpha_blend_3a_1(uint32_t s);
-	inline void f3_alpha_blend_3a_2(uint32_t s);
-	inline void f3_alpha_blend_3b_0(uint32_t s);
-	inline void f3_alpha_blend_3b_1(uint32_t s);
-	inline void f3_alpha_blend_3b_2(uint32_t s);
-	int dpix_1_noalpha(uint32_t s_pix);
-	int dpix_ret1(uint32_t s_pix);
-	int dpix_ret0(uint32_t s_pix);
-	int dpix_1_1(uint32_t s_pix);
-	int dpix_1_2(uint32_t s_pix);
-	int dpix_1_4(uint32_t s_pix);
-	int dpix_1_5(uint32_t s_pix);
-	int dpix_1_6(uint32_t s_pix);
-	int dpix_1_8(uint32_t s_pix);
-	int dpix_1_9(uint32_t s_pix);
-	int dpix_1_a(uint32_t s_pix);
-	int dpix_2a_0(uint32_t s_pix);
-	int dpix_2a_4(uint32_t s_pix);
-	int dpix_2a_8(uint32_t s_pix);
-	int dpix_3a_0(uint32_t s_pix);
-	int dpix_3a_1(uint32_t s_pix);
-	int dpix_3a_2(uint32_t s_pix);
-	int dpix_2b_0(uint32_t s_pix);
-	int dpix_2b_4(uint32_t s_pix);
-	int dpix_2b_8(uint32_t s_pix);
-	int dpix_3b_0(uint32_t s_pix);
-	int dpix_3b_1(uint32_t s_pix);
-	int dpix_3b_2(uint32_t s_pix);
-	int dpix_2_0(uint32_t s_pix);
-	int dpix_2_4(uint32_t s_pix);
-	int dpix_2_8(uint32_t s_pix);
-	int dpix_3_0(uint32_t s_pix);
-	int dpix_3_1(uint32_t s_pix);
-	int dpix_3_2(uint32_t s_pix);
-	inline void dpix_1_sprite(uint32_t s_pix);
-	inline void dpix_bg(uint32_t bgcolor);
+	inline void alpha_set_level();
+	inline void alpha_blend32_s(int alphas, u32 s);
+	inline void alpha_blend32_d(int alphas, u32 s);
+	inline void alpha_blend_1_1(u32 s);
+	inline void alpha_blend_1_2(u32 s);
+	inline void alpha_blend_1_4(u32 s);
+	inline void alpha_blend_1_5(u32 s);
+	inline void alpha_blend_1_6(u32 s);
+	inline void alpha_blend_1_8(u32 s);
+	inline void alpha_blend_1_9(u32 s);
+	inline void alpha_blend_1_a(u32 s);
+	inline void alpha_blend_2a_0(u32 s);
+	inline void alpha_blend_2a_4(u32 s);
+	inline void alpha_blend_2a_8(u32 s);
+	inline void alpha_blend_2b_0(u32 s);
+	inline void alpha_blend_2b_4(u32 s);
+	inline void alpha_blend_2b_8(u32 s);
+	inline void alpha_blend_3a_0(u32 s);
+	inline void alpha_blend_3a_1(u32 s);
+	inline void alpha_blend_3a_2(u32 s);
+	inline void alpha_blend_3b_0(u32 s);
+	inline void alpha_blend_3b_1(u32 s);
+	inline void alpha_blend_3b_2(u32 s);
+	int dpix_1_noalpha(u32 s_pix);
+	int dpix_ret1(u32 s_pix);
+	int dpix_ret0(u32 s_pix);
+	int dpix_1_1(u32 s_pix);
+	int dpix_1_2(u32 s_pix);
+	int dpix_1_4(u32 s_pix);
+	int dpix_1_5(u32 s_pix);
+	int dpix_1_6(u32 s_pix);
+	int dpix_1_8(u32 s_pix);
+	int dpix_1_9(u32 s_pix);
+	int dpix_1_a(u32 s_pix);
+	int dpix_2a_0(u32 s_pix);
+	int dpix_2a_4(u32 s_pix);
+	int dpix_2a_8(u32 s_pix);
+	int dpix_3a_0(u32 s_pix);
+	int dpix_3a_1(u32 s_pix);
+	int dpix_3a_2(u32 s_pix);
+	int dpix_2b_0(u32 s_pix);
+	int dpix_2b_4(u32 s_pix);
+	int dpix_2b_8(u32 s_pix);
+	int dpix_3b_0(u32 s_pix);
+	int dpix_3b_1(u32 s_pix);
+	int dpix_3b_2(u32 s_pix);
+	int dpix_2_0(u32 s_pix);
+	int dpix_2_4(u32 s_pix);
+	int dpix_2_8(u32 s_pix);
+	int dpix_3_0(u32 s_pix);
+	int dpix_3_1(u32 s_pix);
+	int dpix_3_2(u32 s_pix);
+	inline void dpix_1_sprite(u32 s_pix);
+	inline void dpix_bg(u32 bgcolor);
 	void init_alpha_blend_func();
-	inline void draw_scanlines(bitmap_rgb32 &bitmap, int xsize, int16_t *draw_line_num, const struct f3_playfield_line_inf **line_t, const int *sprite, uint32_t orient, int skip_layer_num);
-	void visible_tile_check(struct f3_playfield_line_inf *line_t, int line, uint32_t x_index_fx,uint32_t y_index, uint16_t *f3_pf_data_n);
-	void calculate_clip(int y, uint16_t pri, uint32_t* clip0, uint32_t* clip1, int* line_enable);
+	inline void draw_scanlines(bitmap_rgb32 &bitmap, int xsize, s16 *draw_line_num, const struct f3_playfield_line_inf **line_t, const int *sprite, u32 orient, int skip_layer_num);
+	void visible_tile_check(struct f3_playfield_line_inf *line_t, int line, u32 x_index_fx, u32 y_index, u16 *pf_data_n);
+	void calculate_clip(int y, u16 pri, u32* clip0, u32* clip1, int *line_enable);
 	void get_spritealphaclip_info();
-	void get_line_ram_info(tilemap_t *tmap, int sx, int sy, int pos, uint16_t *f3_pf_data_n);
+	void get_line_ram_info(tilemap_t *tmap, int sx, int sy, int pos, u16 *pf_data_n);
 	void get_vram_info(tilemap_t *vram_tilemap, tilemap_t *pixel_tilemap, int sx, int sy);
 	void scanline_draw(bitmap_rgb32 &bitmap, const rectangle &cliprect);
+
+private:
+	optional_device<cpu_device> m_audiocpu;
+	optional_device<taito_en_device> m_taito_en;
+	optional_device<okim6295_device> m_oki;
+
+	optional_shared_ptr<u32> m_paletteram32;
+	optional_memory_bank m_okibank;
+
+	void bubsympb_oki_w(u8 data);
+	u32 f3_control_r(offs_t offset);
+	void f3_control_w(offs_t offset, u32 data, u32 mem_mask = ~0);
+	void f3_unk_w(offs_t offset, u16 data);
+	void sound_reset_0_w(u32 data);
+	void sound_reset_1_w(u32 data);
+	void sound_bankswitch_w(offs_t offset, u32 data, u32 mem_mask = ~0);
+	void palette_24bit_w(offs_t offset, u32 data, u32 mem_mask = ~0);
+
+	INTERRUPT_GEN_MEMBER(interrupt2);
+
+	void bubsympb_oki_map(address_map &map);
 };
 
 #endif // MAME_INCLUDES_TAITO_F3_H

--- a/src/mame/video/taito_f3.cpp
+++ b/src/mame/video/taito_f3.cpp
@@ -211,6 +211,8 @@ Playfield tile info:
 #include "includes/taito_f3.h"
 #include "render.h"
 
+#include <algorithm>
+
 #define VERBOSE 0
 #define DARIUSG_KLUDGE
 //#define DEBUG_F3 1
@@ -265,42 +267,6 @@ static const struct F3config f3_config_table[] =
 };
 
 
-struct tempsprite
-{
-	int code,color;
-	int flipx,flipy;
-	int x,y;
-	int zoomx,zoomy;
-	int pri;
-};
-
-struct f3_playfield_line_inf
-{
-	int alpha_mode[256];
-	int pri[256];
-
-	/* use for draw_scanlines */
-	uint16_t *src[256],*src_s[256],*src_e[256];
-	uint8_t *tsrc[256],*tsrc_s[256];
-	int x_count[256];
-	uint32_t x_zoom[256];
-	uint32_t clip0[256];
-	uint32_t clip1[256];
-};
-
-struct f3_spritealpha_line_inf
-{
-	uint16_t alpha_level[256];
-	uint16_t spri[256];
-	uint16_t sprite_alpha[256];
-	uint32_t sprite_clip0[256];
-	uint32_t sprite_clip1[256];
-	int16_t clip0_l[256];
-	int16_t clip0_r[256];
-	int16_t clip1_l[256];
-	int16_t clip1_r[256];
-};
-
 /*
 alpha_mode
 ---- --xx    0:disable 1:nomal 2:alpha 7000 3:alpha b000
@@ -327,6 +293,7 @@ pri_alp_bitmap
 void taito_f3_state::device_post_load()
 {
 	/* force a reread of the dynamic tiles in the pixel layer */
+	m_gfxdecode->gfx(0)->mark_all_dirty();
 	m_gfxdecode->gfx(3)->mark_all_dirty();
 }
 
@@ -334,180 +301,140 @@ void taito_f3_state::device_post_load()
 
 void taito_f3_state::print_debug_info(bitmap_rgb32 &bitmap)
 {
-/*  uint16_t *f3_line_ram = m_f3_line_ram.get();
+/*  u16 *line_ram = m_line_ram;
     int l[16];
     char buf[64*16];
     char *bufptr = buf;
 
-    bufptr += sprintf(bufptr,"%04X %04X %04X %04X\n",m_f3_control_0[0]>>6,m_f3_control_0[1]>>6,m_f3_control_0[2]>>6,m_f3_control_0[3]>>6);
-    bufptr += sprintf(bufptr,"%04X %04X %04X %04X\n",m_f3_control_0[4]>>7,m_f3_control_0[5]>>7,m_f3_control_0[6]>>7,m_f3_control_0[7]>>7);
-    bufptr += sprintf(bufptr,"%04X %04X %04X %04X\n",m_f3_control_1[0],m_f3_control_1[1],m_f3_control_1[2],m_f3_control_1[3]);
-    bufptr += sprintf(bufptr,"%04X %04X %04X %04X\n",m_f3_control_1[4],m_f3_control_1[5],m_f3_control_1[6],m_f3_control_1[7]);
+    bufptr += sprintf(bufptr,"%04X %04X %04X %04X\n", m_control_0[0] >> 6, m_control_0[1] >> 6, m_control_0[2] >> 6, m_control_0[3] >> 6);
+    bufptr += sprintf(bufptr,"%04X %04X %04X %04X\n", m_control_0[4] >> 7, m_control_0[5] >> 7, m_control_0[6] >> 7, m_control_0[7] >> 7);
+    bufptr += sprintf(bufptr,"%04X %04X %04X %04X\n", m_control_1[0], m_control_1[1], m_control_1[2], m_control_1[3]);
+    bufptr += sprintf(bufptr,"%04X %04X %04X %04X\n", m_control_1[4], m_control_1[5], m_control_1[6], m_control_1[7]);
 
-    bufptr += sprintf(bufptr,"%04X %04X %04X %04X %04X %04X %04X %04X\n",m_spriteram16_buffered[0],m_spriteram16_buffered[1],m_spriteram16_buffered[2],m_spriteram16_buffered[3],m_spriteram16_buffered[4],m_spriteram16_buffered[5],m_spriteram16_buffered[6],m_spriteram16_buffered[7]);
-    bufptr += sprintf(bufptr,"%04X %04X %04X %04X %04X %04X %04X %04X\n",m_spriteram16_buffered[8],m_spriteram16_buffered[9],m_spriteram16_buffered[10],m_spriteram16_buffered[11],m_spriteram16_buffered[12],m_spriteram16_buffered[13],m_spriteram16_buffered[14],m_spriteram16_buffered[15]);
-    bufptr += sprintf(bufptr,"%04X %04X %04X %04X %04X %04X %04X %04X\n",m_spriteram16_buffered[16],m_spriteram16_buffered[17],m_spriteram16_buffered[18],m_spriteram16_buffered[19],m_spriteram16_buffered[20],m_spriteram16_buffered[21],m_spriteram16_buffered[22],m_spriteram16_buffered[23]);
+    bufptr += sprintf(bufptr,"%04X %04X %04X %04X %04X %04X %04X %04X\n", m_spriteram16_buffered[0], m_spriteram16_buffered[1], m_spriteram16_buffered[2], m_spriteram16_buffered[3], m_spriteram16_buffered[4], m_spriteram16_buffered[5], m_spriteram16_buffered[6], m_spriteram16_buffered[7]);
+    bufptr += sprintf(bufptr,"%04X %04X %04X %04X %04X %04X %04X %04X\n", m_spriteram16_buffered[8], m_spriteram16_buffered[9], m_spriteram16_buffered[10], m_spriteram16_buffered[11], m_spriteram16_buffered[12], m_spriteram16_buffered[13], m_spriteram16_buffered[14], m_spriteram16_buffered[15]);
+    bufptr += sprintf(bufptr,"%04X %04X %04X %04X %04X %04X %04X %04X\n", m_spriteram16_buffered[16], m_spriteram16_buffered[17], m_spriteram16_buffered[18], m_spriteram16_buffered[19], m_spriteram16_buffered[20], m_spriteram16_buffered[21], m_spriteram16_buffered[22], m_spriteram16_buffered[23]);
 
-    l[0]=f3_line_ram[0x0040*2]&0xffff;
-    l[1]=f3_line_ram[0x00c0*2]&0xffff;
-    l[2]=f3_line_ram[0x0140*2]&0xffff;
-    l[3]=f3_line_ram[0x01c0*2]&0xffff;
-    bufptr += sprintf(bufptr,"Ctr1: %04x %04x %04x %04x\n",l[0],l[1],l[2],l[3]);
+    l[0] = line_ram[0x0040*2] & 0xffff;
+    l[1] = line_ram[0x00c0*2] & 0xffff;
+    l[2] = line_ram[0x0140*2] & 0xffff;
+    l[3] = line_ram[0x01c0*2] & 0xffff;
+    bufptr += sprintf(bufptr,"Ctr1: %04x %04x %04x %04x\n", l[0], l[1], l[2], l[3]);
 
-    l[0]=f3_line_ram[0x0240*2]&0xffff;
-    l[1]=f3_line_ram[0x02c0*2]&0xffff;
-    l[2]=f3_line_ram[0x0340*2]&0xffff;
-    l[3]=f3_line_ram[0x03c0*2]&0xffff;
-    bufptr += sprintf(bufptr,"Ctr2: %04x %04x %04x %04x\n",l[0],l[1],l[2],l[3]);
+    l[0] = line_ram[0x0240*2] & 0xffff;
+    l[1] = line_ram[0x02c0*2] & 0xffff;
+    l[2] = line_ram[0x0340*2] & 0xffff;
+    l[3] = line_ram[0x03c0*2] & 0xffff;
+    bufptr += sprintf(bufptr,"Ctr2: %04x %04x %04x %04x\n", l[0], l[1], l[2], l[3]);
 
-    l[0]=f3_line_ram[0x2c60*2]&0xffff;
-    l[1]=f3_line_ram[0x2ce0*2]&0xffff;
-    l[2]=f3_line_ram[0x2d60*2]&0xffff;
-    l[3]=f3_line_ram[0x2de0*2]&0xffff;
-    bufptr += sprintf(bufptr,"Pri : %04x %04x %04x %04x\n",l[0],l[1],l[2],l[3]);
+    l[0] = line_ram[0x2c60*2] & 0xffff;
+    l[1] = line_ram[0x2ce0*2] & 0xffff;
+    l[2] = line_ram[0x2d60*2] & 0xffff;
+    l[3] = line_ram[0x2de0*2] & 0xffff;
+    bufptr += sprintf(bufptr,"Pri : %04x %04x %04x %04x\n", l[0], l[1], l[2], l[3]);
 
-    l[0]=f3_line_ram[0x2060*2]&0xffff;
-    l[1]=f3_line_ram[0x20e0*2]&0xffff;
-    l[2]=f3_line_ram[0x2160*2]&0xffff;
-    l[3]=f3_line_ram[0x21e0*2]&0xffff;
-    bufptr += sprintf(bufptr,"Zoom: %04x %04x %04x %04x\n",l[0],l[1],l[2],l[3]);
+    l[0] = line_ram[0x2060*2] & 0xffff;
+    l[1] = line_ram[0x20e0*2] & 0xffff;
+    l[2] = line_ram[0x2160*2] & 0xffff;
+    l[3] = line_ram[0x21e0*2] & 0xffff;
+    bufptr += sprintf(bufptr,"Zoom: %04x %04x %04x %04x\n", l[0], l[1], l[2], l[3]);
 
-    l[0]=f3_line_ram[0x2860*2]&0xffff;
-    l[1]=f3_line_ram[0x28e0*2]&0xffff;
-    l[2]=f3_line_ram[0x2960*2]&0xffff;
-    l[3]=f3_line_ram[0x29e0*2]&0xffff;
-    bufptr += sprintf(bufptr,"Line: %04x %04x %04x %04x\n",l[0],l[1],l[2],l[3]);
+    l[0] = line_ram[0x2860*2] & 0xffff;
+    l[1] = line_ram[0x28e0*2] & 0xffff;
+    l[2] = line_ram[0x2960*2] & 0xffff;
+    l[3] = line_ram[0x29e0*2] & 0xffff;
+    bufptr += sprintf(bufptr,"Line: %04x %04x %04x %04x\n", l[0], l[1], l[2], l[3]);
 
-    l[0]=f3_line_ram[0x1c60*2]&0xffff;
-    l[1]=f3_line_ram[0x1ce0*2]&0xffff;
-    l[2]=f3_line_ram[0x1d60*2]&0xffff;
-    l[3]=f3_line_ram[0x1de0*2]&0xffff;
-    bufptr += sprintf(bufptr,"Sprt: %04x %04x %04x %04x\n",l[0],l[1],l[2],l[3]);
+    l[0] = line_ram[0x1c60*2] & 0xffff;
+    l[1] = line_ram[0x1ce0*2] & 0xffff;
+    l[2] = line_ram[0x1d60*2] & 0xffff;
+    l[3] = line_ram[0x1de0*2] & 0xffff;
+    bufptr += sprintf(bufptr,"Sprt: %04x %04x %04x %04x\n", l[0], l[1], l[2], l[3]);
 
-    l[0]=f3_line_ram[0x1860*2]&0xffff;
-    l[1]=f3_line_ram[0x18e0*2]&0xffff;
-    l[2]=f3_line_ram[0x1960*2]&0xffff;
-    l[3]=f3_line_ram[0x19e0*2]&0xffff;
-    bufptr += sprintf(bufptr,"Pivt: %04x %04x %04x %04x\n",l[0],l[1],l[2],l[3]);
+    l[0] = line_ram[0x1860*2] & 0xffff;
+    l[1] = line_ram[0x18e0*2] & 0xffff;
+    l[2] = line_ram[0x1960*2] & 0xffff;
+    l[3] = line_ram[0x19e0*2] & 0xffff;
+    bufptr += sprintf(bufptr,"Pivt: %04x %04x %04x %04x\n", l[0], l[1], l[2], l[3]);
 
-    l[0]=f3_line_ram[0x1060*2]&0xffff;
-    l[1]=f3_line_ram[0x10e0*2]&0xffff;
-    l[2]=f3_line_ram[0x1160*2]&0xffff;
-    l[3]=f3_line_ram[0x11e0*2]&0xffff;
-    bufptr += sprintf(bufptr,"Colm: %04x %04x %04x %04x\n",l[0],l[1],l[2],l[3]);
+    l[0] = line_ram[0x1060*2] & 0xffff;
+    l[1] = line_ram[0x10e0*2] & 0xffff;
+    l[2] = line_ram[0x1160*2] & 0xffff;
+    l[3] = line_ram[0x11e0*2] & 0xffff;
+    bufptr += sprintf(bufptr,"Colm: %04x %04x %04x %04x\n", l[0], l[1], l[2], l[3]);
 
-    l[0]=f3_line_ram[0x1460*2]&0xffff;
-    l[1]=f3_line_ram[0x14e0*2]&0xffff;
-    l[2]=f3_line_ram[0x1560*2]&0xffff;
-    l[3]=f3_line_ram[0x15e0*2]&0xffff;
-    bufptr += sprintf(bufptr,"5000: %04x %04x %04x %04x\n",l[0],l[1],l[2],l[3]);
+    l[0] = line_ram[0x1460*2] & 0xffff;
+    l[1] = line_ram[0x14e0*2] & 0xffff;
+    l[2] = line_ram[0x1560*2] & 0xffff;
+    l[3] = line_ram[0x15e0*2] & 0xffff;
+    bufptr += sprintf(bufptr,"5000: %04x %04x %04x %04x\n", l[0], l[1], l[2], l[3]);
 
-    machine().ui().draw_text(&machine().render().ui_container(), buf, 60, 40);*/
+    machine().ui().draw_text(&machine().render().ui_container(), buf, 60, 40); */
 }
 
 /******************************************************************************/
 
-inline void taito_f3_state::get_tile_info(tile_data &tileinfo, int tile_index, uint16_t *gfx_base)
+template<unsigned Layer>
+TILE_GET_INFO_MEMBER(taito_f3_state::get_tile_info)
 {
-	uint32_t tile=(gfx_base[tile_index*2+0]<<16)|(gfx_base[tile_index*2+1]&0xffff);
-	uint8_t abtype=(tile>>(16+9)) & 1;
+	const u32 tile = (m_pf_data[Layer][tile_index * 2 + 0] << 16) | (m_pf_data[Layer][tile_index * 2 + 1] & 0xffff);
+	const u8 abtype = (tile >> (16 + 9)) & 1;
 	// tiles can be configured to use 4, 5, or 6 bpp data.
 	// if tiles use more than 4bpp, the bottom bits of the color code must be masked out.
 	// This fixes (at least) the rain in round 6 of Arabian Magic.
-	uint8_t extra_planes = ((tile>>(16+10)) & 3); // 0 = 4bpp, 1 = 5bpp, 2 = unused?, 3 = 6bpp
+	const u8 extra_planes = ((tile >> (16 + 10)) & 3); // 0 = 4bpp, 1 = 5bpp, 2 = unused?, 3 = 6bpp
 
 	SET_TILE_INFO_MEMBER(1,
-			tile&0xffff,
-			(tile>>16) & 0x1ff & (~extra_planes),
-			TILE_FLIPYX( tile >> 30 ));
-	tileinfo.category =  abtype&1;      /* alpha blending type */
+			tile & 0xffff,
+			(tile >> 16) & 0x1ff & (~extra_planes),
+			TILE_FLIPYX(tile >> 30));
+	tileinfo.category =  abtype & 1;      /* alpha blending type */
 	tileinfo.pen_mask = (extra_planes << 4) | 0x0f;
 }
 
-TILE_GET_INFO_MEMBER(taito_f3_state::get_tile_info1)
+
+TILE_GET_INFO_MEMBER(taito_f3_state::get_tile_info_text)
 {
-	get_tile_info(tileinfo,tile_index,m_f3_pf_data_1);
-}
+	int flags = 0;
 
-TILE_GET_INFO_MEMBER(taito_f3_state::get_tile_info2)
-{
-	get_tile_info(tileinfo,tile_index,m_f3_pf_data_2);
-}
+	const u16 vram_tile = (m_textram[tile_index] & 0xffff);
 
-TILE_GET_INFO_MEMBER(taito_f3_state::get_tile_info3)
-{
-	get_tile_info(tileinfo,tile_index,m_f3_pf_data_3);
-}
-
-TILE_GET_INFO_MEMBER(taito_f3_state::get_tile_info4)
-{
-	get_tile_info(tileinfo,tile_index,m_f3_pf_data_4);
-}
-
-TILE_GET_INFO_MEMBER(taito_f3_state::get_tile_info5)
-{
-	get_tile_info(tileinfo,tile_index,m_f3_pf_data_5);
-}
-
-TILE_GET_INFO_MEMBER(taito_f3_state::get_tile_info6)
-{
-	get_tile_info(tileinfo,tile_index,m_f3_pf_data_6);
-}
-
-TILE_GET_INFO_MEMBER(taito_f3_state::get_tile_info7)
-{
-	get_tile_info(tileinfo,tile_index,m_f3_pf_data_7);
-}
-
-TILE_GET_INFO_MEMBER(taito_f3_state::get_tile_info8)
-{
-	get_tile_info(tileinfo,tile_index,m_f3_pf_data_8);
-}
-
-
-TILE_GET_INFO_MEMBER(taito_f3_state::get_tile_info_vram)
-{
-	int vram_tile;
-	int flags=0;
-
-	vram_tile = (m_videoram[tile_index]&0xffff);
-
-	if (vram_tile&0x0100) flags|=TILE_FLIPX;
-	if (vram_tile&0x8000) flags|=TILE_FLIPY;
+	if (vram_tile & 0x0100) flags |= TILE_FLIPX;
+	if (vram_tile & 0x8000) flags |= TILE_FLIPY;
 
 	SET_TILE_INFO_MEMBER(0,
-			vram_tile&0xff,
-			(vram_tile>>9)&0x3f,
+			vram_tile & 0xff,
+			(vram_tile >> 9) & 0x3f,
 			flags);
 }
 
 TILE_GET_INFO_MEMBER(taito_f3_state::get_tile_info_pixel)
 {
-	int vram_tile,col_off;
-	int flags=0;
-	int y_offs=(m_f3_control_1[5]&0x1ff);
-	if (m_flipscreen) y_offs+=0x100;
+	int col_off;
+	int flags = 0;
+	int y_offs = (m_control_1[5] & 0x1ff);
+	if (m_flipscreen) y_offs += 0x100;
 
 	/* Colour is shared with VRAM layer */
-	if ((((tile_index%32)*8 + y_offs)&0x1ff)>0xff)
-		col_off=0x800+((tile_index%32)*0x40)+((tile_index&0xfe0)>>5);
+	if ((((tile_index & 0x1f) * 8 + y_offs) & 0x1ff) > 0xff)
+		col_off = 0x800 + ((tile_index & 0x1f) << 6) + ((tile_index & 0xfe0) >> 5);
 	else
-		col_off=((tile_index%32)*0x40)+((tile_index&0xfe0)>>5);
+		col_off = ((tile_index & 0x1f) << 6) + ((tile_index & 0xfe0) >> 5);
 
-	vram_tile = (m_videoram[col_off]&0xffff);
+	const u16 vram_tile = (m_textram[col_off] & 0xffff);
 
-	if (vram_tile&0x0100) flags|=TILE_FLIPX;
-	if (vram_tile&0x8000) flags|=TILE_FLIPY;
+	if (vram_tile & 0x0100) flags |= TILE_FLIPX;
+	if (vram_tile & 0x8000) flags |= TILE_FLIPY;
 
 	SET_TILE_INFO_MEMBER(3,
 			tile_index,
-			(vram_tile>>9)&0x3f,
+			(vram_tile >> 9) & 0x3f,
 			flags);
 }
 
 /******************************************************************************/
 
-WRITE_LINE_MEMBER(taito_f3_state::screen_vblank_f3)
+WRITE_LINE_MEMBER(taito_f3_state::screen_vblank)
 {
 	// rising edge
 	if (state)
@@ -518,13 +445,13 @@ WRITE_LINE_MEMBER(taito_f3_state::screen_vblank_f3)
 			{
 				get_sprite_info(m_spriteram16_buffered.get());
 			}
-			memcpy(m_spriteram16_buffered.get(),m_spriteram.get(),0x10000);
+			memcpy(m_spriteram16_buffered.get(), m_spriteram.target(), 0x10000);
 		}
-		else if (m_sprite_lag==1)
+		else if (m_sprite_lag == 1)
 		{
 			if (machine().video().skip_this_frame() == 0)
 			{
-				get_sprite_info(m_spriteram.get());
+				get_sprite_info(m_spriteram.target());
 			}
 		}
 	}
@@ -532,17 +459,16 @@ WRITE_LINE_MEMBER(taito_f3_state::screen_vblank_f3)
 
 void taito_f3_state::video_start()
 {
-	const struct F3config *pCFG=&f3_config_table[0];
-	int i;
+	const struct F3config *pCFG = &f3_config_table[0];
 
-	m_f3_alpha_level_2as=127;
-	m_f3_alpha_level_2ad=127;
-	m_f3_alpha_level_3as=127;
-	m_f3_alpha_level_3ad=127;
-	m_f3_alpha_level_2bs=127;
-	m_f3_alpha_level_2bd=127;
-	m_f3_alpha_level_3bs=127;
-	m_f3_alpha_level_3bd=127;
+	m_alpha_level_2as = 127;
+	m_alpha_level_2ad = 127;
+	m_alpha_level_3as = 127;
+	m_alpha_level_3ad = 127;
+	m_alpha_level_2bs = 127;
+	m_alpha_level_2bd = 127;
+	m_alpha_level_3bs = 127;
+	m_alpha_level_3bd = 127;
 	m_alpha_level_last = -1;
 
 	m_pdest_2a = 0x10;
@@ -554,95 +480,88 @@ void taito_f3_state::video_start()
 	m_tr_3a = 0;
 	m_tr_3b = 1;
 
-	m_spritelist=nullptr;
-	m_spriteram16_buffered=nullptr;
-	m_pf_line_inf=nullptr;
-	m_tile_opaque_sp=nullptr;
+	m_spritelist = nullptr;
+	m_spriteram16_buffered = nullptr;
+	m_pf_line_inf = nullptr;
+	m_tile_opaque_sp = nullptr;
 
 	/* Setup individual game */
 	do {
-		if (pCFG->name==m_f3_game)
+		if (pCFG->name == m_game)
 		{
 			break;
 		}
 		pCFG++;
-	} while(pCFG->name);
+	} while (pCFG->name);
 
-	m_f3_game_config=pCFG;
+	m_game_config=pCFG;
 
-	m_f3_vram =      make_unique_clear<uint16_t[]>(0x2000/2);
-	m_f3_pf_data =   make_unique_clear<uint16_t[]>(0xc000/2);
-	m_videoram =     make_unique_clear<uint16_t[]>(0x2000/2);
-	m_f3_line_ram =  make_unique_clear<uint16_t[]>(0x10000/2);
-	m_f3_pivot_ram = make_unique_clear<uint16_t[]>(0x10000/2);
-	m_spriteram =    make_unique_clear<uint16_t[]>(0x10000/2);
+	if (m_game_config->extend)
+	{
+		m_tilemap[0] = &machine().tilemap().create(*m_gfxdecode, tilemap_get_info_delegate(FUNC(taito_f3_state::get_tile_info<0>), this), TILEMAP_SCAN_ROWS, 16, 16, 64, 32);
+		m_tilemap[1] = &machine().tilemap().create(*m_gfxdecode, tilemap_get_info_delegate(FUNC(taito_f3_state::get_tile_info<1>), this), TILEMAP_SCAN_ROWS, 16, 16, 64, 32);
+		m_tilemap[2] = &machine().tilemap().create(*m_gfxdecode, tilemap_get_info_delegate(FUNC(taito_f3_state::get_tile_info<2>), this), TILEMAP_SCAN_ROWS, 16, 16, 64, 32);
+		m_tilemap[3] = &machine().tilemap().create(*m_gfxdecode, tilemap_get_info_delegate(FUNC(taito_f3_state::get_tile_info<3>), this), TILEMAP_SCAN_ROWS, 16, 16, 64, 32);
 
-	if (m_f3_game_config->extend) {
-		m_pf1_tilemap = &machine().tilemap().create(*m_gfxdecode, tilemap_get_info_delegate(FUNC(taito_f3_state::get_tile_info1),this),TILEMAP_SCAN_ROWS,16,16,64,32);
-		m_pf2_tilemap = &machine().tilemap().create(*m_gfxdecode, tilemap_get_info_delegate(FUNC(taito_f3_state::get_tile_info2),this),TILEMAP_SCAN_ROWS,16,16,64,32);
-		m_pf3_tilemap = &machine().tilemap().create(*m_gfxdecode, tilemap_get_info_delegate(FUNC(taito_f3_state::get_tile_info3),this),TILEMAP_SCAN_ROWS,16,16,64,32);
-		m_pf4_tilemap = &machine().tilemap().create(*m_gfxdecode, tilemap_get_info_delegate(FUNC(taito_f3_state::get_tile_info4),this),TILEMAP_SCAN_ROWS,16,16,64,32);
+		m_pf_data[0] = m_pf_ram + (0x0000 / 2);
+		m_pf_data[1] = m_pf_ram + (0x2000 / 2);
+		m_pf_data[2] = m_pf_ram + (0x4000 / 2);
+		m_pf_data[3] = m_pf_ram + (0x6000 / 2);
 
-		m_f3_pf_data_1=m_f3_pf_data.get()+(0x0000/2);
-		m_f3_pf_data_2=m_f3_pf_data.get()+(0x2000/2);
-		m_f3_pf_data_3=m_f3_pf_data.get()+(0x4000/2);
-		m_f3_pf_data_4=m_f3_pf_data.get()+(0x6000/2);
+		m_width_mask = 0x3ff;
+		m_twidth_mask = 0x7f;
+		m_twidth_mask_bit = 7;
 
-		m_width_mask=0x3ff;
-		m_twidth_mask=0x7f;
-		m_twidth_mask_bit=7;
+		m_tilemap[0]->set_transparent_pen(0);
+		m_tilemap[1]->set_transparent_pen(0);
+		m_tilemap[2]->set_transparent_pen(0);
+		m_tilemap[3]->set_transparent_pen(0);
+	}
+	else
+	{
+		m_tilemap[0] = &machine().tilemap().create(*m_gfxdecode, tilemap_get_info_delegate(FUNC(taito_f3_state::get_tile_info<0>), this), TILEMAP_SCAN_ROWS, 16, 16, 32, 32);
+		m_tilemap[1] = &machine().tilemap().create(*m_gfxdecode, tilemap_get_info_delegate(FUNC(taito_f3_state::get_tile_info<1>), this), TILEMAP_SCAN_ROWS, 16, 16, 32, 32);
+		m_tilemap[2] = &machine().tilemap().create(*m_gfxdecode, tilemap_get_info_delegate(FUNC(taito_f3_state::get_tile_info<2>), this), TILEMAP_SCAN_ROWS, 16, 16, 32, 32);
+		m_tilemap[3] = &machine().tilemap().create(*m_gfxdecode, tilemap_get_info_delegate(FUNC(taito_f3_state::get_tile_info<3>), this), TILEMAP_SCAN_ROWS, 16, 16, 32, 32);
+		m_tilemap[4] = &machine().tilemap().create(*m_gfxdecode, tilemap_get_info_delegate(FUNC(taito_f3_state::get_tile_info<4>), this), TILEMAP_SCAN_ROWS, 16, 16, 32, 32);
+		m_tilemap[5] = &machine().tilemap().create(*m_gfxdecode, tilemap_get_info_delegate(FUNC(taito_f3_state::get_tile_info<5>), this), TILEMAP_SCAN_ROWS, 16, 16, 32, 32);
+		m_tilemap[6] = &machine().tilemap().create(*m_gfxdecode, tilemap_get_info_delegate(FUNC(taito_f3_state::get_tile_info<6>), this), TILEMAP_SCAN_ROWS, 16, 16, 32, 32);
+		m_tilemap[7] = &machine().tilemap().create(*m_gfxdecode, tilemap_get_info_delegate(FUNC(taito_f3_state::get_tile_info<7>), this), TILEMAP_SCAN_ROWS, 16, 16, 32, 32);
 
-		m_pf1_tilemap->set_transparent_pen(0);
-		m_pf2_tilemap->set_transparent_pen(0);
-		m_pf3_tilemap->set_transparent_pen(0);
-		m_pf4_tilemap->set_transparent_pen(0);
+		m_pf_data[0] = m_pf_ram + (0x0000 / 2);
+		m_pf_data[1] = m_pf_ram + (0x1000 / 2);
+		m_pf_data[2] = m_pf_ram + (0x2000 / 2);
+		m_pf_data[3] = m_pf_ram + (0x3000 / 2);
+		m_pf_data[4] = m_pf_ram + (0x4000 / 2);
+		m_pf_data[5] = m_pf_ram + (0x5000 / 2);
+		m_pf_data[6] = m_pf_ram + (0x6000 / 2);
+		m_pf_data[7] = m_pf_ram + (0x7000 / 2);
 
+		m_width_mask = 0x1ff;
+		m_twidth_mask = 0x3f;
+		m_twidth_mask_bit = 6;
 
-	} else {
-		m_pf1_tilemap = &machine().tilemap().create(*m_gfxdecode, tilemap_get_info_delegate(FUNC(taito_f3_state::get_tile_info1),this),TILEMAP_SCAN_ROWS,16,16,32,32);
-		m_pf2_tilemap = &machine().tilemap().create(*m_gfxdecode, tilemap_get_info_delegate(FUNC(taito_f3_state::get_tile_info2),this),TILEMAP_SCAN_ROWS,16,16,32,32);
-		m_pf3_tilemap = &machine().tilemap().create(*m_gfxdecode, tilemap_get_info_delegate(FUNC(taito_f3_state::get_tile_info3),this),TILEMAP_SCAN_ROWS,16,16,32,32);
-		m_pf4_tilemap = &machine().tilemap().create(*m_gfxdecode, tilemap_get_info_delegate(FUNC(taito_f3_state::get_tile_info4),this),TILEMAP_SCAN_ROWS,16,16,32,32);
-		m_pf5_tilemap = &machine().tilemap().create(*m_gfxdecode, tilemap_get_info_delegate(FUNC(taito_f3_state::get_tile_info5),this),TILEMAP_SCAN_ROWS,16,16,32,32);
-		m_pf6_tilemap = &machine().tilemap().create(*m_gfxdecode, tilemap_get_info_delegate(FUNC(taito_f3_state::get_tile_info6),this),TILEMAP_SCAN_ROWS,16,16,32,32);
-		m_pf7_tilemap = &machine().tilemap().create(*m_gfxdecode, tilemap_get_info_delegate(FUNC(taito_f3_state::get_tile_info7),this),TILEMAP_SCAN_ROWS,16,16,32,32);
-		m_pf8_tilemap = &machine().tilemap().create(*m_gfxdecode, tilemap_get_info_delegate(FUNC(taito_f3_state::get_tile_info8),this),TILEMAP_SCAN_ROWS,16,16,32,32);
-
-		m_f3_pf_data_1=m_f3_pf_data.get()+(0x0000/2);
-		m_f3_pf_data_2=m_f3_pf_data.get()+(0x1000/2);
-		m_f3_pf_data_3=m_f3_pf_data.get()+(0x2000/2);
-		m_f3_pf_data_4=m_f3_pf_data.get()+(0x3000/2);
-		m_f3_pf_data_5=m_f3_pf_data.get()+(0x4000/2);
-		m_f3_pf_data_6=m_f3_pf_data.get()+(0x5000/2);
-		m_f3_pf_data_7=m_f3_pf_data.get()+(0x6000/2);
-		m_f3_pf_data_8=m_f3_pf_data.get()+(0x7000/2);
-
-		m_width_mask=0x1ff;
-		m_twidth_mask=0x3f;
-		m_twidth_mask_bit=6;
-
-		m_pf1_tilemap->set_transparent_pen(0);
-		m_pf2_tilemap->set_transparent_pen(0);
-		m_pf3_tilemap->set_transparent_pen(0);
-		m_pf4_tilemap->set_transparent_pen(0);
-		m_pf5_tilemap->set_transparent_pen(0);
-		m_pf6_tilemap->set_transparent_pen(0);
-		m_pf7_tilemap->set_transparent_pen(0);
-		m_pf8_tilemap->set_transparent_pen(0);
+		m_tilemap[0]->set_transparent_pen(0);
+		m_tilemap[1]->set_transparent_pen(0);
+		m_tilemap[2]->set_transparent_pen(0);
+		m_tilemap[3]->set_transparent_pen(0);
+		m_tilemap[4]->set_transparent_pen(0);
+		m_tilemap[5]->set_transparent_pen(0);
+		m_tilemap[6]->set_transparent_pen(0);
+		m_tilemap[7]->set_transparent_pen(0);
 	}
 
-	m_spriteram16_buffered = std::make_unique<uint16_t[]>(0x10000/2);
+	m_spriteram16_buffered = std::make_unique<u16[]>(0x10000 / 2);
 	m_spritelist = auto_alloc_array(machine(), struct tempsprite, 0x400);
 	m_sprite_end = m_spritelist;
-	m_vram_layer = &machine().tilemap().create(*m_gfxdecode, tilemap_get_info_delegate(FUNC(taito_f3_state::get_tile_info_vram),this),TILEMAP_SCAN_ROWS,8,8,64,64);
-	m_pixel_layer = &machine().tilemap().create(*m_gfxdecode, tilemap_get_info_delegate(FUNC(taito_f3_state::get_tile_info_pixel),this),TILEMAP_SCAN_COLS,8,8,64,32);
+	m_vram_layer = &machine().tilemap().create(*m_gfxdecode, tilemap_get_info_delegate(FUNC(taito_f3_state::get_tile_info_text), this), TILEMAP_SCAN_ROWS, 8, 8, 64, 64);
+	m_pixel_layer = &machine().tilemap().create(*m_gfxdecode, tilemap_get_info_delegate(FUNC(taito_f3_state::get_tile_info_pixel), this), TILEMAP_SCAN_COLS, 8, 8, 64, 32);
 	m_pf_line_inf = auto_alloc_array(machine(), struct f3_playfield_line_inf, 5);
 	m_sa_line_inf = auto_alloc_array(machine(), struct f3_spritealpha_line_inf, 1);
 	m_screen->register_screen_bitmap(m_pri_alp_bitmap);
-	m_tile_opaque_sp = std::make_unique<uint8_t[]>(m_gfxdecode->gfx(2)->elements());
-	for (i=0; i<8; i++)
-		m_tile_opaque_pf[i] = std::make_unique<uint8_t[]>(m_gfxdecode->gfx(1)->elements());
-
+	m_tile_opaque_sp = std::make_unique<u8[]>(m_gfxdecode->gfx(2)->elements());
+	for (int i = 0; i < 8; i++)
+		m_tile_opaque_pf[i] = std::make_unique<u8[]>(m_gfxdecode->gfx(1)->elements());
 
 	m_vram_layer->set_transparent_pen(0);
 	m_pixel_layer->set_transparent_pen(0);
@@ -653,77 +572,64 @@ void taito_f3_state::video_start()
 	m_gfxdecode->gfx(2)->set_granularity(16);
 
 	m_flipscreen = 0;
-	memset(m_spriteram16_buffered.get(),0,0x10000);
-	memset(m_spriteram.get(),0,0x10000);
+	memset(m_spriteram16_buffered.get(), 0, 0x10000);
+	memset(&m_spriteram[0], 0, 0x10000);
 
-	save_pointer(NAME(m_videoram), 0x2000/2);
-	save_pointer(NAME(m_spriteram), 0x10000/2);
-	save_pointer(NAME(m_f3_vram), 0x2000/2);
-	save_pointer(NAME(m_f3_pf_data), 0xc000/2);
-	save_pointer(NAME(m_f3_line_ram), 0x10000/2);
-	save_pointer(NAME(m_f3_pivot_ram), 0x10000/2);
+	save_item(NAME(m_control_0));
+	save_item(NAME(m_control_1));
 
-	save_item(NAME(m_f3_control_0));
-	save_item(NAME(m_f3_control_1));
+	m_gfxdecode->gfx(0)->set_source((u8 *)m_charram.target());
+	m_gfxdecode->gfx(3)->set_source((u8 *)m_pivot_ram.target());
 
-	m_gfxdecode->gfx(0)->set_source((uint8_t *)m_f3_vram.get());
-	m_gfxdecode->gfx(3)->set_source((uint8_t *)m_f3_pivot_ram.get());
-
-	m_sprite_lag=m_f3_game_config->sprite_lag;
+	m_sprite_lag = m_game_config->sprite_lag;
 
 	init_alpha_blend_func();
 
 	{
 		gfx_element *sprite_gfx = m_gfxdecode->gfx(2);
-		int c;
 
-		for (c = 0;c < sprite_gfx->elements();c++)
+		for (int c = 0; c < sprite_gfx->elements(); c++)
 		{
-			int x,y;
-			int chk_trans_or_opa=0;
-			const uint8_t *dp = sprite_gfx->get_data(c);
-			for (y = 0;y < sprite_gfx->height();y++)
+			int chk_trans_or_opa = 0;
+			const u8 *dp = sprite_gfx->get_data(c);
+			for (int y = 0; y < sprite_gfx->height(); y++)
 			{
-				for (x = 0;x < sprite_gfx->width();x++)
+				for (int x = 0; x < sprite_gfx->width(); x++)
 				{
-					if(!dp[x]) chk_trans_or_opa|=2;
-					else       chk_trans_or_opa|=1;
+					if (!dp[x]) chk_trans_or_opa |= 2;
+					else        chk_trans_or_opa |= 1;
 				}
 				dp += sprite_gfx->rowbytes();
 			}
-			if(chk_trans_or_opa==1) m_tile_opaque_sp[c]=1;
-			else                    m_tile_opaque_sp[c]=0;
+			if (chk_trans_or_opa == 1) m_tile_opaque_sp[c] = 1;
+			else                       m_tile_opaque_sp[c] = 0;
 		}
 	}
 
-
 	{
 		gfx_element *pf_gfx = m_gfxdecode->gfx(1);
-		int c;
 
-		for (c = 0;c < pf_gfx->elements();c++)
+		for (int c = 0; c < pf_gfx->elements(); c++)
 		{
-			int x,y;
-			int extra_planes; /* 0 = 4bpp, 1=5bpp, 2=?, 3=6bpp */
-
-			for (extra_planes=0; extra_planes<4; extra_planes++)
+			for (int extra_planes = 0; extra_planes < 4; extra_planes++)
 			{
-				int chk_trans_or_opa=0;
-				uint8_t extra_mask = ((extra_planes << 4) | 0x0f);
-				const uint8_t *dp = pf_gfx->get_data(c);
+				int chk_trans_or_opa = 0;
+				/* 0 = 4bpp, 1=5bpp, 2=?, 3=6bpp */
+				const u8 extra_mask = ((extra_planes << 4) | 0x0f);
+				const u8 *dp = pf_gfx->get_data(c);
 
-				for (y = 0;y < pf_gfx->height();y++)
+				for (int y = 0; y < pf_gfx->height(); y++)
 				{
-					for (x = 0;x < pf_gfx->width();x++)
+					for (int x = 0; x < pf_gfx->width(); x++)
 					{
-						if(!(dp[x] & extra_mask))
-							chk_trans_or_opa|=2;
+						if (!(dp[x] & extra_mask))
+							chk_trans_or_opa |= 2;
 						else
-							chk_trans_or_opa|=1;
+							chk_trans_or_opa |= 1;
 					}
 					dp += pf_gfx->rowbytes();
 				}
-				m_tile_opaque_pf[extra_planes][c]=chk_trans_or_opa;
+				m_tile_opaque_pf[extra_planes][c] = chk_trans_or_opa;
 			}
 		}
 	}
@@ -731,103 +637,97 @@ void taito_f3_state::video_start()
 
 /******************************************************************************/
 
-READ16_MEMBER(taito_f3_state::f3_pf_data_r)
+u16 taito_f3_state::pf_ram_r(offs_t offset)
 {
-	return m_f3_pf_data[offset];
+	return m_pf_ram[offset];
 }
 
-WRITE16_MEMBER(taito_f3_state::f3_pf_data_w)
+void taito_f3_state::pf_ram_w(offs_t offset, u16 data, u16 mem_mask)
 {
-	COMBINE_DATA(&m_f3_pf_data[offset]);
+	COMBINE_DATA(&m_pf_ram[offset]);
 
-	if (m_f3_game_config->extend) {
-		if      (offset<0x1000) m_pf1_tilemap->mark_tile_dirty((offset & 0xfff) >> 1);
-		else if (offset<0x2000) m_pf2_tilemap->mark_tile_dirty((offset & 0xfff) >> 1);
-		else if (offset<0x3000) m_pf3_tilemap->mark_tile_dirty((offset & 0xfff) >> 1);
-		else if (offset<0x4000) m_pf4_tilemap->mark_tile_dirty((offset & 0xfff) >> 1);
-	} else {
-		if      (offset<0x0800) m_pf1_tilemap->mark_tile_dirty((offset & 0x7ff) >> 1);
-		else if (offset<0x1000) m_pf2_tilemap->mark_tile_dirty((offset & 0x7ff) >> 1);
-		else if (offset<0x1800) m_pf3_tilemap->mark_tile_dirty((offset & 0x7ff) >> 1);
-		else if (offset<0x2000) m_pf4_tilemap->mark_tile_dirty((offset & 0x7ff) >> 1);
-		else if (offset<0x2800) m_pf5_tilemap->mark_tile_dirty((offset & 0x7ff) >> 1);
-		else if (offset<0x3000) m_pf6_tilemap->mark_tile_dirty((offset & 0x7ff) >> 1);
-		else if (offset<0x3800) m_pf7_tilemap->mark_tile_dirty((offset & 0x7ff) >> 1);
-		else if (offset<0x4000) m_pf8_tilemap->mark_tile_dirty((offset & 0x7ff) >> 1);
+	if (m_game_config->extend)
+	{
+		if (offset < 0x4000)
+			m_tilemap[offset >> 12]->mark_tile_dirty((offset & 0xfff) >> 1);
+	}
+	else
+	{
+		if (offset < 0x4000)
+			m_tilemap[offset >> 11]->mark_tile_dirty((offset & 0x7ff) >> 1);
 	}
 }
 
-WRITE16_MEMBER(taito_f3_state::f3_control_0_w)
+void taito_f3_state::control_0_w(offs_t offset, u16 data, u16 mem_mask)
 {
-	COMBINE_DATA(&m_f3_control_0[offset]);
+	COMBINE_DATA(&m_control_0[offset]);
 }
 
-WRITE16_MEMBER(taito_f3_state::f3_control_1_w)
+void taito_f3_state::control_1_w(offs_t offset, u16 data, u16 mem_mask)
 {
-	COMBINE_DATA(&m_f3_control_1[offset]);
+	COMBINE_DATA(&m_control_1[offset]);
 }
 
-READ16_MEMBER(taito_f3_state::f3_spriteram_r)
+u16 taito_f3_state::spriteram_r(offs_t offset)
 {
 	return m_spriteram[offset];
 }
 
-WRITE16_MEMBER(taito_f3_state::f3_spriteram_w)
+void taito_f3_state::spriteram_w(offs_t offset, u16 data, u16 mem_mask)
 {
 	COMBINE_DATA(&m_spriteram[offset]);
 }
 
-READ16_MEMBER(taito_f3_state::f3_videoram_r)
+u16 taito_f3_state::textram_r(offs_t offset)
 {
-	return m_videoram[offset];
+	return m_textram[offset];
 }
 
-WRITE16_MEMBER(taito_f3_state::f3_videoram_w)
+void taito_f3_state::textram_w(offs_t offset, u16 data, u16 mem_mask)
 {
-	int tile,col_off;
-	COMBINE_DATA(&m_videoram[offset]);
+	COMBINE_DATA(&m_textram[offset]);
 
 	m_vram_layer->mark_tile_dirty(offset);
-	//m_vram_layer->mark_tile_dirty(offset+1);
+	//m_vram_layer->mark_tile_dirty(offset + 1);
 
-	if (offset>0x7ff) offset-=0x800;
+	if (offset > 0x7ff) offset -= 0x800;
 
-	tile=offset;
-	col_off=((tile&0x3f)*32)+((tile&0xfc0)>>6);
+	const int tile = offset;
+	const int col_off = ((tile & 0x3f) << 5) + ((tile & 0xfc0) >> 6);
 
 	m_pixel_layer->mark_tile_dirty(col_off);
 	//m_pixel_layer->mark_tile_dirty(col_off+32);
 }
 
 
-READ16_MEMBER(taito_f3_state::f3_vram_r)
+u16 taito_f3_state::charram_r(offs_t offset)
 {
-	return m_f3_vram[offset];
+	return m_charram[offset];
 }
 
-WRITE16_MEMBER(taito_f3_state::f3_vram_w)
+void taito_f3_state::charram_w(offs_t offset, u16 data, u16 mem_mask)
 {
-	COMBINE_DATA(&m_f3_vram[offset]);
-	m_gfxdecode->gfx(0)->mark_dirty(offset/16);
+	COMBINE_DATA(&m_charram[offset]);
+	m_gfxdecode->gfx(0)->mark_dirty(offset >> 4);
 }
 
-READ16_MEMBER(taito_f3_state::f3_pivot_r)
+u16 taito_f3_state::pivot_r(offs_t offset)
 {
-	return m_f3_pivot_ram[offset];
+	return m_pivot_ram[offset];
 }
 
-WRITE16_MEMBER(taito_f3_state::f3_pivot_w)
+void taito_f3_state::pivot_w(offs_t offset, u16 data, u16 mem_mask)
 {
-	COMBINE_DATA(&m_f3_pivot_ram[offset]);
-	m_gfxdecode->gfx(3)->mark_dirty(offset/16);
+	COMBINE_DATA(&m_pivot_ram[offset]);
+	m_gfxdecode->gfx(3)->mark_dirty(offset >> 4);
 }
 
-READ16_MEMBER(taito_f3_state::f3_lineram_r)
+u16 taito_f3_state::lineram_r(offs_t offset)
 {
-	return m_f3_line_ram[offset];
+	return m_line_ram[offset];
 }
 
-WRITE16_MEMBER(taito_f3_state::f3_lineram_w)
+void taito_f3_state::lineram_w(offs_t offset, u16 data, u16 mem_mask)
 {
 	#ifdef UNUSED_FUNCTION
 	/* DariusGX has an interesting bug at the start of Round D - the clearing of lineram
@@ -840,111 +740,123 @@ WRITE16_MEMBER(taito_f3_state::f3_lineram_w)
 	 *         fwiw PC=0x1768a0/0x1768a4 is where the game clears lineram in round D, which is a
 	 *         move.w Dn, (An,D7.w*2) , a kind of opcode that could've been bugged back then.
 	 */
-	if (m_f3_game==DARIUSG) {
+	if (m_game == DARIUSG)
+	{
 		if (m_f3_skip_this_frame)
 			return;
-		if (offset==0xb000/2 && data==0x003f) {
-			m_f3_skip_this_frame=1;
+		if (offset == 0xb000 / 2 && data == 0x003f)
+		{
+			m_f3_skip_this_frame = 1;
 			return;
 		}
 	}
 	#endif
 
-	COMBINE_DATA(&m_f3_line_ram[offset]);
+	COMBINE_DATA(&m_line_ram[offset]);
 }
 
-WRITE32_MEMBER(taito_f3_state::f3_palette_24bit_w)
+void taito_f3_state::palette_24bit_w(offs_t offset, u32 data, u32 mem_mask)
 {
-	int r,g,b;
+	int r, g, b;
 
 	COMBINE_DATA(&m_paletteram32[offset]);
 
 	/* 12 bit palette games - there has to be a palette select bit somewhere */
-	if (m_f3_game==SPCINVDX || m_f3_game==RIDINGF || m_f3_game==ARABIANM || m_f3_game==RINGRAGE) {
+	if (m_game == SPCINVDX || m_game == RIDINGF || m_game == ARABIANM || m_game == RINGRAGE)
+	{
 		b = 15 * ((m_paletteram32[offset] >> 4) & 0xf);
 		g = 15 * ((m_paletteram32[offset] >> 8) & 0xf);
 		r = 15 * ((m_paletteram32[offset] >> 12) & 0xf);
 	}
 
 	/* This is weird - why are only the sprites and VRAM palettes 21 bit? */
-	else if (m_f3_game==CLEOPATR) {
-		if (offset<0x100 || offset>0x1000) {
-			r = ((m_paletteram32[offset] >>16) & 0x7f)<<1;
-			g = ((m_paletteram32[offset] >> 8) & 0x7f)<<1;
-			b = ((m_paletteram32[offset] >> 0) & 0x7f)<<1;
-		} else {
-			r = (m_paletteram32[offset] >>16) & 0xff;
+	else if (m_game == CLEOPATR)
+	{
+		if (offset < 0x100 || offset > 0x1000)
+		{
+			r = ((m_paletteram32[offset] >> 16) & 0x7f) << 1;
+			g = ((m_paletteram32[offset] >> 8) & 0x7f) << 1;
+			b = ((m_paletteram32[offset] >> 0) & 0x7f) << 1;
+		}
+		else
+		{
+			r = (m_paletteram32[offset] >> 16) & 0xff;
 			g = (m_paletteram32[offset] >> 8) & 0xff;
 			b = (m_paletteram32[offset] >> 0) & 0xff;
 		}
 	}
 
 	/* Another weird couple - perhaps this is alpha blending related? */
-	else if (m_f3_game==TWINQIX || m_f3_game==RECALH) {
-		if (offset>0x1c00) {
-			r = ((m_paletteram32[offset] >>16) & 0x7f)<<1;
-			g = ((m_paletteram32[offset] >> 8) & 0x7f)<<1;
-			b = ((m_paletteram32[offset] >> 0) & 0x7f)<<1;
-		} else {
-			r = (m_paletteram32[offset] >>16) & 0xff;
+	else if (m_game == TWINQIX || m_game == RECALH)
+	{
+		if (offset > 0x1c00)
+		{
+			r = ((m_paletteram32[offset] >> 16) & 0x7f) << 1;
+			g = ((m_paletteram32[offset] >> 8) & 0x7f) << 1;
+			b = ((m_paletteram32[offset] >> 0) & 0x7f) << 1;
+		}
+		else
+		{
+			r = (m_paletteram32[offset] >> 16) & 0xff;
 			g = (m_paletteram32[offset] >> 8) & 0xff;
 			b = (m_paletteram32[offset] >> 0) & 0xff;
 		}
 	}
 
 	/* All other games - standard 24 bit palette */
-	else {
-		r = (m_paletteram32[offset] >>16) & 0xff;
+	else
+	{
+		r = (m_paletteram32[offset] >> 16) & 0xff;
 		g = (m_paletteram32[offset] >> 8) & 0xff;
 		b = (m_paletteram32[offset] >> 0) & 0xff;
 	}
 
-	m_palette->set_pen_color(offset,rgb_t(r,g,b));
+	m_palette->set_pen_color(offset, rgb_t(r, g, b));
 }
 
 /******************************************************************************/
 
 /*============================================================================*/
 
-#define SET_ALPHA_LEVEL(d,s)            \
+#define SET_ALPHA_LEVEL(d, s)           \
 {                                       \
 	int level = s;                      \
-	if(level == 0) level = -1;          \
-	d = level+1;                        \
+	if (level == 0) level = -1;         \
+	d = level + 1;                      \
 }
 
-inline void taito_f3_state::f3_alpha_set_level()
+inline void taito_f3_state::alpha_set_level()
 {
-//  SET_ALPHA_LEVEL(m_alpha_s_1_1, m_f3_alpha_level_2ad)
-	SET_ALPHA_LEVEL(m_alpha_s_1_1, 255-m_f3_alpha_level_2as)
-//  SET_ALPHA_LEVEL(m_alpha_s_1_2, m_f3_alpha_level_2bd)
-	SET_ALPHA_LEVEL(m_alpha_s_1_2, 255-m_f3_alpha_level_2bs)
-	SET_ALPHA_LEVEL(m_alpha_s_1_4, m_f3_alpha_level_3ad)
-//  SET_ALPHA_LEVEL(m_alpha_s_1_5, m_f3_alpha_level_3ad*m_f3_alpha_level_2ad/255)
-	SET_ALPHA_LEVEL(m_alpha_s_1_5, m_f3_alpha_level_3ad*(255-m_f3_alpha_level_2as)/255)
-//  SET_ALPHA_LEVEL(m_alpha_s_1_6, m_f3_alpha_level_3ad*m_f3_alpha_level_2bd/255)
-	SET_ALPHA_LEVEL(m_alpha_s_1_6, m_f3_alpha_level_3ad*(255-m_f3_alpha_level_2bs)/255)
-	SET_ALPHA_LEVEL(m_alpha_s_1_8, m_f3_alpha_level_3bd)
-//  SET_ALPHA_LEVEL(m_alpha_s_1_9, m_f3_alpha_level_3bd*m_f3_alpha_level_2ad/255)
-	SET_ALPHA_LEVEL(m_alpha_s_1_9, m_f3_alpha_level_3bd*(255-m_f3_alpha_level_2as)/255)
-//  SET_ALPHA_LEVEL(m_alpha_s_1_a, m_f3_alpha_level_3bd*m_f3_alpha_level_2bd/255)
-	SET_ALPHA_LEVEL(m_alpha_s_1_a, m_f3_alpha_level_3bd*(255-m_f3_alpha_level_2bs)/255)
+//  SET_ALPHA_LEVEL(m_alpha_s_1_1, m_alpha_level_2ad)
+	SET_ALPHA_LEVEL(m_alpha_s_1_1, 255 - m_alpha_level_2as)
+//  SET_ALPHA_LEVEL(m_alpha_s_1_2, m_alpha_level_2bd)
+	SET_ALPHA_LEVEL(m_alpha_s_1_2, 255 - m_alpha_level_2bs)
+	SET_ALPHA_LEVEL(m_alpha_s_1_4, m_alpha_level_3ad)
+//  SET_ALPHA_LEVEL(m_alpha_s_1_5, m_alpha_level_3ad*m_alpha_level_2ad / 255)
+	SET_ALPHA_LEVEL(m_alpha_s_1_5, m_alpha_level_3ad * (255 - m_alpha_level_2as) / 255)
+//  SET_ALPHA_LEVEL(m_alpha_s_1_6, m_alpha_level_3ad*m_alpha_level_2bd / 255)
+	SET_ALPHA_LEVEL(m_alpha_s_1_6, m_alpha_level_3ad * (255 - m_alpha_level_2bs) / 255)
+	SET_ALPHA_LEVEL(m_alpha_s_1_8, m_alpha_level_3bd)
+//  SET_ALPHA_LEVEL(m_alpha_s_1_9, m_alpha_level_3bd*m_alpha_level_2ad / 255)
+	SET_ALPHA_LEVEL(m_alpha_s_1_9, m_alpha_level_3bd * (255 - m_alpha_level_2as) / 255)
+//  SET_ALPHA_LEVEL(m_alpha_s_1_a, m_alpha_level_3bd*m_alpha_level_2bd / 255)
+	SET_ALPHA_LEVEL(m_alpha_s_1_a, m_alpha_level_3bd * (255 - m_alpha_level_2bs) / 255)
 
-	SET_ALPHA_LEVEL(m_alpha_s_2a_0, m_f3_alpha_level_2as)
-	SET_ALPHA_LEVEL(m_alpha_s_2a_4, m_f3_alpha_level_2as*m_f3_alpha_level_3ad/255)
-	SET_ALPHA_LEVEL(m_alpha_s_2a_8, m_f3_alpha_level_2as*m_f3_alpha_level_3bd/255)
+	SET_ALPHA_LEVEL(m_alpha_s_2a_0, m_alpha_level_2as)
+	SET_ALPHA_LEVEL(m_alpha_s_2a_4, m_alpha_level_2as * m_alpha_level_3ad / 255)
+	SET_ALPHA_LEVEL(m_alpha_s_2a_8, m_alpha_level_2as * m_alpha_level_3bd / 255)
 
-	SET_ALPHA_LEVEL(m_alpha_s_2b_0, m_f3_alpha_level_2bs)
-	SET_ALPHA_LEVEL(m_alpha_s_2b_4, m_f3_alpha_level_2bs*m_f3_alpha_level_3ad/255)
-	SET_ALPHA_LEVEL(m_alpha_s_2b_8, m_f3_alpha_level_2bs*m_f3_alpha_level_3bd/255)
+	SET_ALPHA_LEVEL(m_alpha_s_2b_0, m_alpha_level_2bs)
+	SET_ALPHA_LEVEL(m_alpha_s_2b_4, m_alpha_level_2bs * m_alpha_level_3ad / 255)
+	SET_ALPHA_LEVEL(m_alpha_s_2b_8, m_alpha_level_2bs * m_alpha_level_3bd / 255)
 
-	SET_ALPHA_LEVEL(m_alpha_s_3a_0, m_f3_alpha_level_3as)
-	SET_ALPHA_LEVEL(m_alpha_s_3a_1, m_f3_alpha_level_3as*m_f3_alpha_level_2ad/255)
-	SET_ALPHA_LEVEL(m_alpha_s_3a_2, m_f3_alpha_level_3as*m_f3_alpha_level_2bd/255)
+	SET_ALPHA_LEVEL(m_alpha_s_3a_0, m_alpha_level_3as)
+	SET_ALPHA_LEVEL(m_alpha_s_3a_1, m_alpha_level_3as * m_alpha_level_2ad / 255)
+	SET_ALPHA_LEVEL(m_alpha_s_3a_2, m_alpha_level_3as * m_alpha_level_2bd / 255)
 
-	SET_ALPHA_LEVEL(m_alpha_s_3b_0, m_f3_alpha_level_3bs)
-	SET_ALPHA_LEVEL(m_alpha_s_3b_1, m_f3_alpha_level_3bs*m_f3_alpha_level_2ad/255)
-	SET_ALPHA_LEVEL(m_alpha_s_3b_2, m_f3_alpha_level_3bs*m_f3_alpha_level_2bd/255)
+	SET_ALPHA_LEVEL(m_alpha_s_3b_0, m_alpha_level_3bs)
+	SET_ALPHA_LEVEL(m_alpha_s_3b_1, m_alpha_level_3bs * m_alpha_level_2ad / 255)
+	SET_ALPHA_LEVEL(m_alpha_s_3b_2, m_alpha_level_3bs * m_alpha_level_2bd / 255)
 }
 #undef SET_ALPHA_LEVEL
 
@@ -954,21 +866,19 @@ inline void taito_f3_state::f3_alpha_set_level()
 #define COLOR2 BYTE4_XOR_LE(1)
 #define COLOR3 BYTE4_XOR_LE(2)
 
-
-
-inline void taito_f3_state::f3_alpha_blend32_s(int alphas, uint32_t s)
+inline void taito_f3_state::alpha_blend32_s(int alphas, u32 s)
 {
-	uint8_t *sc = (uint8_t *)&s;
-	uint8_t *dc = (uint8_t *)&m_dval;
+	u8 *sc = (u8 *)&s;
+	u8 *dc = (u8 *)&m_dval;
 	dc[COLOR1] = (alphas * sc[COLOR1]) >> 8;
 	dc[COLOR2] = (alphas * sc[COLOR2]) >> 8;
 	dc[COLOR3] = (alphas * sc[COLOR3]) >> 8;
 }
 
-inline void taito_f3_state::f3_alpha_blend32_d(int alphas, uint32_t s)
+inline void taito_f3_state::alpha_blend32_d(int alphas, u32 s)
 {
-	uint8_t *sc = (uint8_t *)&s;
-	uint8_t *dc = (uint8_t *)&m_dval;
+	u8 *sc = (u8 *)&s;
+	u8 *dc = (u8 *)&m_dval;
 	dc[COLOR1] = m_add_sat[dc[COLOR1]][(alphas * sc[COLOR1]) >> 8];
 	dc[COLOR2] = m_add_sat[dc[COLOR2]][(alphas * sc[COLOR2]) >> 8];
 	dc[COLOR3] = m_add_sat[dc[COLOR3]][(alphas * sc[COLOR3]) >> 8];
@@ -976,474 +886,466 @@ inline void taito_f3_state::f3_alpha_blend32_d(int alphas, uint32_t s)
 
 /*============================================================================*/
 
-inline void taito_f3_state::f3_alpha_blend_1_1(uint32_t s){f3_alpha_blend32_d(m_alpha_s_1_1,s);}
-inline void taito_f3_state::f3_alpha_blend_1_2(uint32_t s){f3_alpha_blend32_d(m_alpha_s_1_2,s);}
-inline void taito_f3_state::f3_alpha_blend_1_4(uint32_t s){f3_alpha_blend32_d(m_alpha_s_1_4,s);}
-inline void taito_f3_state::f3_alpha_blend_1_5(uint32_t s){f3_alpha_blend32_d(m_alpha_s_1_5,s);}
-inline void taito_f3_state::f3_alpha_blend_1_6(uint32_t s){f3_alpha_blend32_d(m_alpha_s_1_6,s);}
-inline void taito_f3_state::f3_alpha_blend_1_8(uint32_t s){f3_alpha_blend32_d(m_alpha_s_1_8,s);}
-inline void taito_f3_state::f3_alpha_blend_1_9(uint32_t s){f3_alpha_blend32_d(m_alpha_s_1_9,s);}
-inline void taito_f3_state::f3_alpha_blend_1_a(uint32_t s){f3_alpha_blend32_d(m_alpha_s_1_a,s);}
+inline void taito_f3_state::alpha_blend_1_1(u32 s) { alpha_blend32_d(m_alpha_s_1_1, s); }
+inline void taito_f3_state::alpha_blend_1_2(u32 s) { alpha_blend32_d(m_alpha_s_1_2, s); }
+inline void taito_f3_state::alpha_blend_1_4(u32 s) { alpha_blend32_d(m_alpha_s_1_4, s); }
+inline void taito_f3_state::alpha_blend_1_5(u32 s) { alpha_blend32_d(m_alpha_s_1_5, s); }
+inline void taito_f3_state::alpha_blend_1_6(u32 s) { alpha_blend32_d(m_alpha_s_1_6, s); }
+inline void taito_f3_state::alpha_blend_1_8(u32 s) { alpha_blend32_d(m_alpha_s_1_8, s); }
+inline void taito_f3_state::alpha_blend_1_9(u32 s) { alpha_blend32_d(m_alpha_s_1_9, s); }
+inline void taito_f3_state::alpha_blend_1_a(u32 s) { alpha_blend32_d(m_alpha_s_1_a, s); }
 
-inline void taito_f3_state::f3_alpha_blend_2a_0(uint32_t s){f3_alpha_blend32_s(m_alpha_s_2a_0,s);}
-inline void taito_f3_state::f3_alpha_blend_2a_4(uint32_t s){f3_alpha_blend32_d(m_alpha_s_2a_4,s);}
-inline void taito_f3_state::f3_alpha_blend_2a_8(uint32_t s){f3_alpha_blend32_d(m_alpha_s_2a_8,s);}
+inline void taito_f3_state::alpha_blend_2a_0(u32 s) { alpha_blend32_s(m_alpha_s_2a_0, s); }
+inline void taito_f3_state::alpha_blend_2a_4(u32 s) { alpha_blend32_d(m_alpha_s_2a_4, s); }
+inline void taito_f3_state::alpha_blend_2a_8(u32 s) { alpha_blend32_d(m_alpha_s_2a_8, s); }
 
-inline void taito_f3_state::f3_alpha_blend_2b_0(uint32_t s){f3_alpha_blend32_s(m_alpha_s_2b_0,s);}
-inline void taito_f3_state::f3_alpha_blend_2b_4(uint32_t s){f3_alpha_blend32_d(m_alpha_s_2b_4,s);}
-inline void taito_f3_state::f3_alpha_blend_2b_8(uint32_t s){f3_alpha_blend32_d(m_alpha_s_2b_8,s);}
+inline void taito_f3_state::alpha_blend_2b_0(u32 s) { alpha_blend32_s(m_alpha_s_2b_0, s); }
+inline void taito_f3_state::alpha_blend_2b_4(u32 s) { alpha_blend32_d(m_alpha_s_2b_4, s); }
+inline void taito_f3_state::alpha_blend_2b_8(u32 s) { alpha_blend32_d(m_alpha_s_2b_8, s); }
 
-inline void taito_f3_state::f3_alpha_blend_3a_0(uint32_t s){f3_alpha_blend32_s(m_alpha_s_3a_0,s);}
-inline void taito_f3_state::f3_alpha_blend_3a_1(uint32_t s){f3_alpha_blend32_d(m_alpha_s_3a_1,s);}
-inline void taito_f3_state::f3_alpha_blend_3a_2(uint32_t s){f3_alpha_blend32_d(m_alpha_s_3a_2,s);}
+inline void taito_f3_state::alpha_blend_3a_0(u32 s) { alpha_blend32_s(m_alpha_s_3a_0, s); }
+inline void taito_f3_state::alpha_blend_3a_1(u32 s) { alpha_blend32_d(m_alpha_s_3a_1, s); }
+inline void taito_f3_state::alpha_blend_3a_2(u32 s) { alpha_blend32_d(m_alpha_s_3a_2, s); }
 
-inline void taito_f3_state::f3_alpha_blend_3b_0(uint32_t s){f3_alpha_blend32_s(m_alpha_s_3b_0,s);}
-inline void taito_f3_state::f3_alpha_blend_3b_1(uint32_t s){f3_alpha_blend32_d(m_alpha_s_3b_1,s);}
-inline void taito_f3_state::f3_alpha_blend_3b_2(uint32_t s){f3_alpha_blend32_d(m_alpha_s_3b_2,s);}
+inline void taito_f3_state::alpha_blend_3b_0(u32 s) { alpha_blend32_s(m_alpha_s_3b_0, s); }
+inline void taito_f3_state::alpha_blend_3b_1(u32 s) { alpha_blend32_d(m_alpha_s_3b_1, s); }
+inline void taito_f3_state::alpha_blend_3b_2(u32 s) { alpha_blend32_d(m_alpha_s_3b_2, s); }
 
 /*============================================================================*/
 
-int taito_f3_state::dpix_1_noalpha(uint32_t s_pix) {m_dval = s_pix; return 1;}
-int taito_f3_state::dpix_ret1(uint32_t s_pix) {return 1;}
-int taito_f3_state::dpix_ret0(uint32_t s_pix) {return 0;}
-int taito_f3_state::dpix_1_1(uint32_t s_pix) {if(s_pix) f3_alpha_blend_1_1(s_pix); return 1;}
-int taito_f3_state::dpix_1_2(uint32_t s_pix) {if(s_pix) f3_alpha_blend_1_2(s_pix); return 1;}
-int taito_f3_state::dpix_1_4(uint32_t s_pix) {if(s_pix) f3_alpha_blend_1_4(s_pix); return 1;}
-int taito_f3_state::dpix_1_5(uint32_t s_pix) {if(s_pix) f3_alpha_blend_1_5(s_pix); return 1;}
-int taito_f3_state::dpix_1_6(uint32_t s_pix) {if(s_pix) f3_alpha_blend_1_6(s_pix); return 1;}
-int taito_f3_state::dpix_1_8(uint32_t s_pix) {if(s_pix) f3_alpha_blend_1_8(s_pix); return 1;}
-int taito_f3_state::dpix_1_9(uint32_t s_pix) {if(s_pix) f3_alpha_blend_1_9(s_pix); return 1;}
-int taito_f3_state::dpix_1_a(uint32_t s_pix) {if(s_pix) f3_alpha_blend_1_a(s_pix); return 1;}
+int taito_f3_state::dpix_1_noalpha(u32 s_pix) { m_dval = s_pix; return 1; }
+int taito_f3_state::dpix_ret1(u32 s_pix) { return 1; }
+int taito_f3_state::dpix_ret0(u32 s_pix) { return 0; }
+int taito_f3_state::dpix_1_1(u32 s_pix) { if (s_pix) alpha_blend_1_1(s_pix); return 1; }
+int taito_f3_state::dpix_1_2(u32 s_pix) { if (s_pix) alpha_blend_1_2(s_pix); return 1; }
+int taito_f3_state::dpix_1_4(u32 s_pix) { if (s_pix) alpha_blend_1_4(s_pix); return 1; }
+int taito_f3_state::dpix_1_5(u32 s_pix) { if (s_pix) alpha_blend_1_5(s_pix); return 1; }
+int taito_f3_state::dpix_1_6(u32 s_pix) { if (s_pix) alpha_blend_1_6(s_pix); return 1; }
+int taito_f3_state::dpix_1_8(u32 s_pix) { if (s_pix) alpha_blend_1_8(s_pix); return 1; }
+int taito_f3_state::dpix_1_9(u32 s_pix) { if (s_pix) alpha_blend_1_9(s_pix); return 1; }
+int taito_f3_state::dpix_1_a(u32 s_pix) { if (s_pix) alpha_blend_1_a(s_pix); return 1; }
 
-int taito_f3_state::dpix_2a_0(uint32_t s_pix)
+int taito_f3_state::dpix_2a_0(u32 s_pix)
 {
-	if(s_pix) f3_alpha_blend_2a_0(s_pix);
+	if (s_pix) alpha_blend_2a_0(s_pix);
 	else      m_dval = 0;
-	if(m_pdest_2a) {m_pval |= m_pdest_2a;return 0;}
+	if (m_pdest_2a) { m_pval |= m_pdest_2a; return 0; }
 	return 1;
 }
-int taito_f3_state::dpix_2a_4(uint32_t s_pix)
+int taito_f3_state::dpix_2a_4(u32 s_pix)
 {
-	if(s_pix) f3_alpha_blend_2a_4(s_pix);
-	if(m_pdest_2a) {m_pval |= m_pdest_2a;return 0;}
+	if (s_pix) alpha_blend_2a_4(s_pix);
+	if (m_pdest_2a) { m_pval |= m_pdest_2a; return 0; }
 	return 1;
 }
-int taito_f3_state::dpix_2a_8(uint32_t s_pix)
+int taito_f3_state::dpix_2a_8(u32 s_pix)
 {
-	if(s_pix) f3_alpha_blend_2a_8(s_pix);
-	if(m_pdest_2a) {m_pval |= m_pdest_2a;return 0;}
+	if (s_pix) alpha_blend_2a_8(s_pix);
+	if (m_pdest_2a) { m_pval |= m_pdest_2a; return 0; }
 	return 1;
 }
 
-int taito_f3_state::dpix_3a_0(uint32_t s_pix)
+int taito_f3_state::dpix_3a_0(u32 s_pix)
 {
-	if(s_pix) f3_alpha_blend_3a_0(s_pix);
+	if (s_pix) alpha_blend_3a_0(s_pix);
 	else      m_dval = 0;
-	if(m_pdest_3a) {m_pval |= m_pdest_3a;return 0;}
+	if (m_pdest_3a) { m_pval |= m_pdest_3a; return 0; }
 	return 1;
 }
-int taito_f3_state::dpix_3a_1(uint32_t s_pix)
+int taito_f3_state::dpix_3a_1(u32 s_pix)
 {
-	if(s_pix) f3_alpha_blend_3a_1(s_pix);
-	if(m_pdest_3a) {m_pval |= m_pdest_3a;return 0;}
+	if (s_pix) alpha_blend_3a_1(s_pix);
+	if (m_pdest_3a) { m_pval |= m_pdest_3a; return 0; }
 	return 1;
 }
-int taito_f3_state::dpix_3a_2(uint32_t s_pix)
+int taito_f3_state::dpix_3a_2(u32 s_pix)
 {
-	if(s_pix) f3_alpha_blend_3a_2(s_pix);
-	if(m_pdest_3a) {m_pval |= m_pdest_3a;return 0;}
+	if (s_pix) alpha_blend_3a_2(s_pix);
+	if (m_pdest_3a) { m_pval |= m_pdest_3a; return 0; }
 	return 1;
 }
 
-int taito_f3_state::dpix_2b_0(uint32_t s_pix)
+int taito_f3_state::dpix_2b_0(u32 s_pix)
 {
-	if(s_pix) f3_alpha_blend_2b_0(s_pix);
+	if (s_pix) alpha_blend_2b_0(s_pix);
 	else      m_dval = 0;
-	if(m_pdest_2b) {m_pval |= m_pdest_2b;return 0;}
+	if (m_pdest_2b) { m_pval |= m_pdest_2b; return 0; }
 	return 1;
 }
-int taito_f3_state::dpix_2b_4(uint32_t s_pix)
+int taito_f3_state::dpix_2b_4(u32 s_pix)
 {
-	if(s_pix) f3_alpha_blend_2b_4(s_pix);
-	if(m_pdest_2b) {m_pval |= m_pdest_2b;return 0;}
+	if (s_pix) alpha_blend_2b_4(s_pix);
+	if (m_pdest_2b) { m_pval |= m_pdest_2b; return 0; }
 	return 1;
 }
-int taito_f3_state::dpix_2b_8(uint32_t s_pix)
+int taito_f3_state::dpix_2b_8(u32 s_pix)
 {
-	if(s_pix) f3_alpha_blend_2b_8(s_pix);
-	if(m_pdest_2b) {m_pval |= m_pdest_2b;return 0;}
+	if (s_pix) alpha_blend_2b_8(s_pix);
+	if (m_pdest_2b) { m_pval |= m_pdest_2b; return 0; }
 	return 1;
 }
 
-int taito_f3_state::dpix_3b_0(uint32_t s_pix)
+int taito_f3_state::dpix_3b_0(u32 s_pix)
 {
-	if(s_pix) f3_alpha_blend_3b_0(s_pix);
+	if (s_pix) alpha_blend_3b_0(s_pix);
 	else      m_dval = 0;
-	if(m_pdest_3b) {m_pval |= m_pdest_3b;return 0;}
+	if (m_pdest_3b) { m_pval |= m_pdest_3b; return 0; }
 	return 1;
 }
-int taito_f3_state::dpix_3b_1(uint32_t s_pix)
+int taito_f3_state::dpix_3b_1(u32 s_pix)
 {
-	if(s_pix) f3_alpha_blend_3b_1(s_pix);
-	if(m_pdest_3b) {m_pval |= m_pdest_3b;return 0;}
+	if (s_pix) alpha_blend_3b_1(s_pix);
+	if (m_pdest_3b) { m_pval |= m_pdest_3b; return 0; }
 	return 1;
 }
-int taito_f3_state::dpix_3b_2(uint32_t s_pix)
+int taito_f3_state::dpix_3b_2(u32 s_pix)
 {
-	if(s_pix) f3_alpha_blend_3b_2(s_pix);
-	if(m_pdest_3b) {m_pval |= m_pdest_3b;return 0;}
+	if (s_pix) alpha_blend_3b_2(s_pix);
+	if (m_pdest_3b) { m_pval |= m_pdest_3b; return 0; }
 	return 1;
 }
 
-int taito_f3_state::dpix_2_0(uint32_t s_pix)
+int taito_f3_state::dpix_2_0(u32 s_pix)
 {
-	uint8_t tr2=m_tval&1;
-	if(s_pix)
+	const u8 tr2 = m_tval & 1;
+	if (s_pix)
 	{
-		if(tr2==m_tr_2b)     {f3_alpha_blend_2b_0(s_pix);if(m_pdest_2b) m_pval |= m_pdest_2b;else return 1;}
-		else if(tr2==m_tr_2a)    {f3_alpha_blend_2a_0(s_pix);if(m_pdest_2a) m_pval |= m_pdest_2a;else return 1;}
+		if (tr2 == m_tr_2b)      { alpha_blend_2b_0(s_pix); if (m_pdest_2b) m_pval |= m_pdest_2b; else return 1; }
+		else if (tr2 == m_tr_2a) { alpha_blend_2a_0(s_pix); if (m_pdest_2a) m_pval |= m_pdest_2a; else return 1; }
 	}
 	else
 	{
-		if(tr2==m_tr_2b)     {m_dval = 0;if(m_pdest_2b) m_pval |= m_pdest_2b;else return 1;}
-		else if(tr2==m_tr_2a)    {m_dval = 0;if(m_pdest_2a) m_pval |= m_pdest_2a;else return 1;}
+		if (tr2 == m_tr_2b)      { m_dval = 0; if (m_pdest_2b) m_pval |= m_pdest_2b; else return 1; }
+		else if (tr2 == m_tr_2a) { m_dval = 0; if (m_pdest_2a) m_pval |= m_pdest_2a; else return 1; }
 	}
 	return 0;
 }
-int taito_f3_state::dpix_2_4(uint32_t s_pix)
+int taito_f3_state::dpix_2_4(u32 s_pix)
 {
-	uint8_t tr2=m_tval&1;
-	if(s_pix)
+	const u8 tr2 = m_tval & 1;
+	if (s_pix)
 	{
-		if(tr2==m_tr_2b)     {f3_alpha_blend_2b_4(s_pix);if(m_pdest_2b) m_pval |= m_pdest_2b;else return 1;}
-		else if(tr2==m_tr_2a)    {f3_alpha_blend_2a_4(s_pix);if(m_pdest_2a) m_pval |= m_pdest_2a;else return 1;}
+		if (tr2 == m_tr_2b)      { alpha_blend_2b_4(s_pix); if (m_pdest_2b) m_pval |= m_pdest_2b; else return 1; }
+		else if (tr2 == m_tr_2a) { alpha_blend_2a_4(s_pix); if (m_pdest_2a) m_pval |= m_pdest_2a; else return 1; }
 	}
 	else
 	{
-		if(tr2==m_tr_2b)     {if(m_pdest_2b) m_pval |= m_pdest_2b;else return 1;}
-		else if(tr2==m_tr_2a)    {if(m_pdest_2a) m_pval |= m_pdest_2a;else return 1;}
+		if (tr2 == m_tr_2b)      { if (m_pdest_2b) m_pval |= m_pdest_2b; else return 1; }
+		else if (tr2 == m_tr_2a) { if (m_pdest_2a) m_pval |= m_pdest_2a; else return 1; }
 	}
 	return 0;
 }
-int taito_f3_state::dpix_2_8(uint32_t s_pix)
+int taito_f3_state::dpix_2_8(u32 s_pix)
 {
-	uint8_t tr2=m_tval&1;
-	if(s_pix)
+	const u8 tr2 = m_tval & 1;
+	if (s_pix)
 	{
-		if(tr2==m_tr_2b)     {f3_alpha_blend_2b_8(s_pix);if(m_pdest_2b) m_pval |= m_pdest_2b;else return 1;}
-		else if(tr2==m_tr_2a)    {f3_alpha_blend_2a_8(s_pix);if(m_pdest_2a) m_pval |= m_pdest_2a;else return 1;}
+		if (tr2 == m_tr_2b)      { alpha_blend_2b_8(s_pix); if (m_pdest_2b) m_pval |= m_pdest_2b; else return 1; }
+		else if (tr2 == m_tr_2a) { alpha_blend_2a_8(s_pix); if (m_pdest_2a) m_pval |= m_pdest_2a; else return 1; }
 	}
 	else
 	{
-		if(tr2==m_tr_2b)     {if(m_pdest_2b) m_pval |= m_pdest_2b;else return 1;}
-		else if(tr2==m_tr_2a)    {if(m_pdest_2a) m_pval |= m_pdest_2a;else return 1;}
-	}
-	return 0;
-}
-
-int taito_f3_state::dpix_3_0(uint32_t s_pix)
-{
-	uint8_t tr2=m_tval&1;
-	if(s_pix)
-	{
-		if(tr2==m_tr_3b)     {f3_alpha_blend_3b_0(s_pix);if(m_pdest_3b) m_pval |= m_pdest_3b;else return 1;}
-		else if(tr2==m_tr_3a)    {f3_alpha_blend_3a_0(s_pix);if(m_pdest_3a) m_pval |= m_pdest_3a;else return 1;}
-	}
-	else
-	{
-		if(tr2==m_tr_3b)     {m_dval = 0;if(m_pdest_3b) m_pval |= m_pdest_3b;else return 1;}
-		else if(tr2==m_tr_3a)    {m_dval = 0;if(m_pdest_3a) m_pval |= m_pdest_3a;else return 1;}
-	}
-	return 0;
-}
-int taito_f3_state::dpix_3_1(uint32_t s_pix)
-{
-	uint8_t tr2=m_tval&1;
-	if(s_pix)
-	{
-		if(tr2==m_tr_3b)     {f3_alpha_blend_3b_1(s_pix);if(m_pdest_3b) m_pval |= m_pdest_3b;else return 1;}
-		else if(tr2==m_tr_3a)    {f3_alpha_blend_3a_1(s_pix);if(m_pdest_3a) m_pval |= m_pdest_3a;else return 1;}
-	}
-	else
-	{
-		if(tr2==m_tr_3b)     {if(m_pdest_3b) m_pval |= m_pdest_3b;else return 1;}
-		else if(tr2==m_tr_3a)    {if(m_pdest_3a) m_pval |= m_pdest_3a;else return 1;}
-	}
-	return 0;
-}
-int taito_f3_state::dpix_3_2(uint32_t s_pix)
-{
-	uint8_t tr2=m_tval&1;
-	if(s_pix)
-	{
-		if(tr2==m_tr_3b)     {f3_alpha_blend_3b_2(s_pix);if(m_pdest_3b) m_pval |= m_pdest_3b;else return 1;}
-		else if(tr2==m_tr_3a)    {f3_alpha_blend_3a_2(s_pix);if(m_pdest_3a) m_pval |= m_pdest_3a;else return 1;}
-	}
-	else
-	{
-		if(tr2==m_tr_3b)     {if(m_pdest_3b) m_pval |= m_pdest_3b;else return 1;}
-		else if(tr2==m_tr_3a)    {if(m_pdest_3a) m_pval |= m_pdest_3a;else return 1;}
+		if (tr2 == m_tr_2b)      { if (m_pdest_2b) m_pval |= m_pdest_2b; else return 1; }
+		else if (tr2 == m_tr_2a) { if (m_pdest_2a) m_pval |= m_pdest_2a; else return 1; }
 	}
 	return 0;
 }
 
-inline void taito_f3_state::dpix_1_sprite(uint32_t s_pix)
+int taito_f3_state::dpix_3_0(u32 s_pix)
 {
-	if(s_pix)
+	const u8 tr2 = m_tval & 1;
+	if (s_pix)
 	{
-		uint8_t p1 = m_pval&0xf0;
-		if     (p1==0x10)   f3_alpha_blend_1_1(s_pix);
-		else if(p1==0x20)   f3_alpha_blend_1_2(s_pix);
-		else if(p1==0x40)   f3_alpha_blend_1_4(s_pix);
-		else if(p1==0x50)   f3_alpha_blend_1_5(s_pix);
-		else if(p1==0x60)   f3_alpha_blend_1_6(s_pix);
-		else if(p1==0x80)   f3_alpha_blend_1_8(s_pix);
-		else if(p1==0x90)   f3_alpha_blend_1_9(s_pix);
-		else if(p1==0xa0)   f3_alpha_blend_1_a(s_pix);
+		if (tr2 == m_tr_3b)      { alpha_blend_3b_0(s_pix); if (m_pdest_3b) m_pval |= m_pdest_3b; else return 1; }
+		else if (tr2 == m_tr_3a) { alpha_blend_3a_0(s_pix); if (m_pdest_3a) m_pval |= m_pdest_3a; else return 1; }
+	}
+	else
+	{
+		if (tr2 == m_tr_3b)      { m_dval = 0; if (m_pdest_3b) m_pval |= m_pdest_3b; else return 1; }
+		else if (tr2 == m_tr_3a) { m_dval = 0; if (m_pdest_3a) m_pval |= m_pdest_3a; else return 1; }
+	}
+	return 0;
+}
+int taito_f3_state::dpix_3_1(u32 s_pix)
+{
+	const u8 tr2 = m_tval & 1;
+	if (s_pix)
+	{
+		if (tr2 == m_tr_3b)      { alpha_blend_3b_1(s_pix); if (m_pdest_3b) m_pval |= m_pdest_3b; else return 1; }
+		else if (tr2 == m_tr_3a) { alpha_blend_3a_1(s_pix); if (m_pdest_3a) m_pval |= m_pdest_3a; else return 1; }
+	}
+	else
+	{
+		if (tr2 == m_tr_3b)      { if (m_pdest_3b) m_pval |= m_pdest_3b; else return 1; }
+		else if (tr2 == m_tr_3a) { if (m_pdest_3a) m_pval |= m_pdest_3a; else return 1; }
+	}
+	return 0;
+}
+int taito_f3_state::dpix_3_2(u32 s_pix)
+{
+	const u8 tr2 = m_tval & 1;
+	if (s_pix)
+	{
+		if (tr2 == m_tr_3b)      { alpha_blend_3b_2(s_pix); if (m_pdest_3b) m_pval |= m_pdest_3b; else return 1; }
+		else if (tr2 == m_tr_3a) { alpha_blend_3a_2(s_pix); if (m_pdest_3a) m_pval |= m_pdest_3a; else return 1; }
+	}
+	else
+	{
+		if (tr2 == m_tr_3b)      { if (m_pdest_3b) m_pval |= m_pdest_3b; else return 1; }
+		else if (tr2 == m_tr_3a) { if (m_pdest_3a) m_pval |= m_pdest_3a; else return 1; }
+	}
+	return 0;
+}
+
+inline void taito_f3_state::dpix_1_sprite(u32 s_pix)
+{
+	if (s_pix)
+	{
+		const u8 p1 = m_pval & 0xf0;
+		if      (p1 == 0x10) alpha_blend_1_1(s_pix);
+		else if (p1 == 0x20) alpha_blend_1_2(s_pix);
+		else if (p1 == 0x40) alpha_blend_1_4(s_pix);
+		else if (p1 == 0x50) alpha_blend_1_5(s_pix);
+		else if (p1 == 0x60) alpha_blend_1_6(s_pix);
+		else if (p1 == 0x80) alpha_blend_1_8(s_pix);
+		else if (p1 == 0x90) alpha_blend_1_9(s_pix);
+		else if (p1 == 0xa0) alpha_blend_1_a(s_pix);
 	}
 }
 
-inline void taito_f3_state::dpix_bg(uint32_t bgcolor)
+inline void taito_f3_state::dpix_bg(u32 bgcolor)
 {
-	uint8_t p1 = m_pval&0xf0;
-	if(!p1)         m_dval = bgcolor;
-	else if(p1==0x10)   f3_alpha_blend_1_1(bgcolor);
-	else if(p1==0x20)   f3_alpha_blend_1_2(bgcolor);
-	else if(p1==0x40)   f3_alpha_blend_1_4(bgcolor);
-	else if(p1==0x50)   f3_alpha_blend_1_5(bgcolor);
-	else if(p1==0x60)   f3_alpha_blend_1_6(bgcolor);
-	else if(p1==0x80)   f3_alpha_blend_1_8(bgcolor);
-	else if(p1==0x90)   f3_alpha_blend_1_9(bgcolor);
-	else if(p1==0xa0)   f3_alpha_blend_1_a(bgcolor);
+	const u8 p1 = m_pval & 0xf0;
+	if (!p1)         m_dval = bgcolor;
+	else if (p1 == 0x10) alpha_blend_1_1(bgcolor);
+	else if (p1 == 0x20) alpha_blend_1_2(bgcolor);
+	else if (p1 == 0x40) alpha_blend_1_4(bgcolor);
+	else if (p1 == 0x50) alpha_blend_1_5(bgcolor);
+	else if (p1 == 0x60) alpha_blend_1_6(bgcolor);
+	else if (p1 == 0x80) alpha_blend_1_8(bgcolor);
+	else if (p1 == 0x90) alpha_blend_1_9(bgcolor);
+	else if (p1 == 0xa0) alpha_blend_1_a(bgcolor);
 }
 
 /******************************************************************************/
 
 void taito_f3_state::init_alpha_blend_func()
 {
-	m_dpix_n[0][0x0]=&taito_f3_state::dpix_1_noalpha;
-	m_dpix_n[0][0x1]=&taito_f3_state::dpix_1_noalpha;
-	m_dpix_n[0][0x2]=&taito_f3_state::dpix_1_noalpha;
-	m_dpix_n[0][0x3]=&taito_f3_state::dpix_1_noalpha;
-	m_dpix_n[0][0x4]=&taito_f3_state::dpix_1_noalpha;
-	m_dpix_n[0][0x5]=&taito_f3_state::dpix_1_noalpha;
-	m_dpix_n[0][0x6]=&taito_f3_state::dpix_1_noalpha;
-	m_dpix_n[0][0x7]=&taito_f3_state::dpix_1_noalpha;
-	m_dpix_n[0][0x8]=&taito_f3_state::dpix_1_noalpha;
-	m_dpix_n[0][0x9]=&taito_f3_state::dpix_1_noalpha;
-	m_dpix_n[0][0xa]=&taito_f3_state::dpix_1_noalpha;
-	m_dpix_n[0][0xb]=&taito_f3_state::dpix_1_noalpha;
-	m_dpix_n[0][0xc]=&taito_f3_state::dpix_1_noalpha;
-	m_dpix_n[0][0xd]=&taito_f3_state::dpix_1_noalpha;
-	m_dpix_n[0][0xe]=&taito_f3_state::dpix_1_noalpha;
-	m_dpix_n[0][0xf]=&taito_f3_state::dpix_1_noalpha;
+	m_dpix_n[0][0x0] = &taito_f3_state::dpix_1_noalpha;
+	m_dpix_n[0][0x1] = &taito_f3_state::dpix_1_noalpha;
+	m_dpix_n[0][0x2] = &taito_f3_state::dpix_1_noalpha;
+	m_dpix_n[0][0x3] = &taito_f3_state::dpix_1_noalpha;
+	m_dpix_n[0][0x4] = &taito_f3_state::dpix_1_noalpha;
+	m_dpix_n[0][0x5] = &taito_f3_state::dpix_1_noalpha;
+	m_dpix_n[0][0x6] = &taito_f3_state::dpix_1_noalpha;
+	m_dpix_n[0][0x7] = &taito_f3_state::dpix_1_noalpha;
+	m_dpix_n[0][0x8] = &taito_f3_state::dpix_1_noalpha;
+	m_dpix_n[0][0x9] = &taito_f3_state::dpix_1_noalpha;
+	m_dpix_n[0][0xa] = &taito_f3_state::dpix_1_noalpha;
+	m_dpix_n[0][0xb] = &taito_f3_state::dpix_1_noalpha;
+	m_dpix_n[0][0xc] = &taito_f3_state::dpix_1_noalpha;
+	m_dpix_n[0][0xd] = &taito_f3_state::dpix_1_noalpha;
+	m_dpix_n[0][0xe] = &taito_f3_state::dpix_1_noalpha;
+	m_dpix_n[0][0xf] = &taito_f3_state::dpix_1_noalpha;
 
-	m_dpix_n[1][0x0]=&taito_f3_state::dpix_1_noalpha;
-	m_dpix_n[1][0x1]=&taito_f3_state::dpix_1_1;
-	m_dpix_n[1][0x2]=&taito_f3_state::dpix_1_2;
-	m_dpix_n[1][0x3]=&taito_f3_state::dpix_ret1;
-	m_dpix_n[1][0x4]=&taito_f3_state::dpix_1_4;
-	m_dpix_n[1][0x5]=&taito_f3_state::dpix_1_5;
-	m_dpix_n[1][0x6]=&taito_f3_state::dpix_1_6;
-	m_dpix_n[1][0x7]=&taito_f3_state::dpix_ret1;
-	m_dpix_n[1][0x8]=&taito_f3_state::dpix_1_8;
-	m_dpix_n[1][0x9]=&taito_f3_state::dpix_1_9;
-	m_dpix_n[1][0xa]=&taito_f3_state::dpix_1_a;
-	m_dpix_n[1][0xb]=&taito_f3_state::dpix_ret1;
-	m_dpix_n[1][0xc]=&taito_f3_state::dpix_ret1;
-	m_dpix_n[1][0xd]=&taito_f3_state::dpix_ret1;
-	m_dpix_n[1][0xe]=&taito_f3_state::dpix_ret1;
-	m_dpix_n[1][0xf]=&taito_f3_state::dpix_ret1;
+	m_dpix_n[1][0x0] = &taito_f3_state::dpix_1_noalpha;
+	m_dpix_n[1][0x1] = &taito_f3_state::dpix_1_1;
+	m_dpix_n[1][0x2] = &taito_f3_state::dpix_1_2;
+	m_dpix_n[1][0x3] = &taito_f3_state::dpix_ret1;
+	m_dpix_n[1][0x4] = &taito_f3_state::dpix_1_4;
+	m_dpix_n[1][0x5] = &taito_f3_state::dpix_1_5;
+	m_dpix_n[1][0x6] = &taito_f3_state::dpix_1_6;
+	m_dpix_n[1][0x7] = &taito_f3_state::dpix_ret1;
+	m_dpix_n[1][0x8] = &taito_f3_state::dpix_1_8;
+	m_dpix_n[1][0x9] = &taito_f3_state::dpix_1_9;
+	m_dpix_n[1][0xa] = &taito_f3_state::dpix_1_a;
+	m_dpix_n[1][0xb] = &taito_f3_state::dpix_ret1;
+	m_dpix_n[1][0xc] = &taito_f3_state::dpix_ret1;
+	m_dpix_n[1][0xd] = &taito_f3_state::dpix_ret1;
+	m_dpix_n[1][0xe] = &taito_f3_state::dpix_ret1;
+	m_dpix_n[1][0xf] = &taito_f3_state::dpix_ret1;
 
-	m_dpix_n[2][0x0]=&taito_f3_state::dpix_2a_0;
-	m_dpix_n[2][0x1]=&taito_f3_state::dpix_ret0;
-	m_dpix_n[2][0x2]=&taito_f3_state::dpix_ret0;
-	m_dpix_n[2][0x3]=&taito_f3_state::dpix_ret0;
-	m_dpix_n[2][0x4]=&taito_f3_state::dpix_2a_4;
-	m_dpix_n[2][0x5]=&taito_f3_state::dpix_ret0;
-	m_dpix_n[2][0x6]=&taito_f3_state::dpix_ret0;
-	m_dpix_n[2][0x7]=&taito_f3_state::dpix_ret0;
-	m_dpix_n[2][0x8]=&taito_f3_state::dpix_2a_8;
-	m_dpix_n[2][0x9]=&taito_f3_state::dpix_ret0;
-	m_dpix_n[2][0xa]=&taito_f3_state::dpix_ret0;
-	m_dpix_n[2][0xb]=&taito_f3_state::dpix_ret0;
-	m_dpix_n[2][0xc]=&taito_f3_state::dpix_ret0;
-	m_dpix_n[2][0xd]=&taito_f3_state::dpix_ret0;
-	m_dpix_n[2][0xe]=&taito_f3_state::dpix_ret0;
-	m_dpix_n[2][0xf]=&taito_f3_state::dpix_ret0;
+	m_dpix_n[2][0x0] = &taito_f3_state::dpix_2a_0;
+	m_dpix_n[2][0x1] = &taito_f3_state::dpix_ret0;
+	m_dpix_n[2][0x2] = &taito_f3_state::dpix_ret0;
+	m_dpix_n[2][0x3] = &taito_f3_state::dpix_ret0;
+	m_dpix_n[2][0x4] = &taito_f3_state::dpix_2a_4;
+	m_dpix_n[2][0x5] = &taito_f3_state::dpix_ret0;
+	m_dpix_n[2][0x6] = &taito_f3_state::dpix_ret0;
+	m_dpix_n[2][0x7] = &taito_f3_state::dpix_ret0;
+	m_dpix_n[2][0x8] = &taito_f3_state::dpix_2a_8;
+	m_dpix_n[2][0x9] = &taito_f3_state::dpix_ret0;
+	m_dpix_n[2][0xa] = &taito_f3_state::dpix_ret0;
+	m_dpix_n[2][0xb] = &taito_f3_state::dpix_ret0;
+	m_dpix_n[2][0xc] = &taito_f3_state::dpix_ret0;
+	m_dpix_n[2][0xd] = &taito_f3_state::dpix_ret0;
+	m_dpix_n[2][0xe] = &taito_f3_state::dpix_ret0;
+	m_dpix_n[2][0xf] = &taito_f3_state::dpix_ret0;
 
-	m_dpix_n[3][0x0]=&taito_f3_state::dpix_3a_0;
-	m_dpix_n[3][0x1]=&taito_f3_state::dpix_3a_1;
-	m_dpix_n[3][0x2]=&taito_f3_state::dpix_3a_2;
-	m_dpix_n[3][0x3]=&taito_f3_state::dpix_ret0;
-	m_dpix_n[3][0x4]=&taito_f3_state::dpix_ret0;
-	m_dpix_n[3][0x5]=&taito_f3_state::dpix_ret0;
-	m_dpix_n[3][0x6]=&taito_f3_state::dpix_ret0;
-	m_dpix_n[3][0x7]=&taito_f3_state::dpix_ret0;
-	m_dpix_n[3][0x8]=&taito_f3_state::dpix_ret0;
-	m_dpix_n[3][0x9]=&taito_f3_state::dpix_ret0;
-	m_dpix_n[3][0xa]=&taito_f3_state::dpix_ret0;
-	m_dpix_n[3][0xb]=&taito_f3_state::dpix_ret0;
-	m_dpix_n[3][0xc]=&taito_f3_state::dpix_ret0;
-	m_dpix_n[3][0xd]=&taito_f3_state::dpix_ret0;
-	m_dpix_n[3][0xe]=&taito_f3_state::dpix_ret0;
-	m_dpix_n[3][0xf]=&taito_f3_state::dpix_ret0;
+	m_dpix_n[3][0x0] = &taito_f3_state::dpix_3a_0;
+	m_dpix_n[3][0x1] = &taito_f3_state::dpix_3a_1;
+	m_dpix_n[3][0x2] = &taito_f3_state::dpix_3a_2;
+	m_dpix_n[3][0x3] = &taito_f3_state::dpix_ret0;
+	m_dpix_n[3][0x4] = &taito_f3_state::dpix_ret0;
+	m_dpix_n[3][0x5] = &taito_f3_state::dpix_ret0;
+	m_dpix_n[3][0x6] = &taito_f3_state::dpix_ret0;
+	m_dpix_n[3][0x7] = &taito_f3_state::dpix_ret0;
+	m_dpix_n[3][0x8] = &taito_f3_state::dpix_ret0;
+	m_dpix_n[3][0x9] = &taito_f3_state::dpix_ret0;
+	m_dpix_n[3][0xa] = &taito_f3_state::dpix_ret0;
+	m_dpix_n[3][0xb] = &taito_f3_state::dpix_ret0;
+	m_dpix_n[3][0xc] = &taito_f3_state::dpix_ret0;
+	m_dpix_n[3][0xd] = &taito_f3_state::dpix_ret0;
+	m_dpix_n[3][0xe] = &taito_f3_state::dpix_ret0;
+	m_dpix_n[3][0xf] = &taito_f3_state::dpix_ret0;
 
-	m_dpix_n[4][0x0]=&taito_f3_state::dpix_2b_0;
-	m_dpix_n[4][0x1]=&taito_f3_state::dpix_ret0;
-	m_dpix_n[4][0x2]=&taito_f3_state::dpix_ret0;
-	m_dpix_n[4][0x3]=&taito_f3_state::dpix_ret0;
-	m_dpix_n[4][0x4]=&taito_f3_state::dpix_2b_4;
-	m_dpix_n[4][0x5]=&taito_f3_state::dpix_ret0;
-	m_dpix_n[4][0x6]=&taito_f3_state::dpix_ret0;
-	m_dpix_n[4][0x7]=&taito_f3_state::dpix_ret0;
-	m_dpix_n[4][0x8]=&taito_f3_state::dpix_2b_8;
-	m_dpix_n[4][0x9]=&taito_f3_state::dpix_ret0;
-	m_dpix_n[4][0xa]=&taito_f3_state::dpix_ret0;
-	m_dpix_n[4][0xb]=&taito_f3_state::dpix_ret0;
-	m_dpix_n[4][0xc]=&taito_f3_state::dpix_ret0;
-	m_dpix_n[4][0xd]=&taito_f3_state::dpix_ret0;
-	m_dpix_n[4][0xe]=&taito_f3_state::dpix_ret0;
-	m_dpix_n[4][0xf]=&taito_f3_state::dpix_ret0;
+	m_dpix_n[4][0x0] = &taito_f3_state::dpix_2b_0;
+	m_dpix_n[4][0x1] = &taito_f3_state::dpix_ret0;
+	m_dpix_n[4][0x2] = &taito_f3_state::dpix_ret0;
+	m_dpix_n[4][0x3] = &taito_f3_state::dpix_ret0;
+	m_dpix_n[4][0x4] = &taito_f3_state::dpix_2b_4;
+	m_dpix_n[4][0x5] = &taito_f3_state::dpix_ret0;
+	m_dpix_n[4][0x6] = &taito_f3_state::dpix_ret0;
+	m_dpix_n[4][0x7] = &taito_f3_state::dpix_ret0;
+	m_dpix_n[4][0x8] = &taito_f3_state::dpix_2b_8;
+	m_dpix_n[4][0x9] = &taito_f3_state::dpix_ret0;
+	m_dpix_n[4][0xa] = &taito_f3_state::dpix_ret0;
+	m_dpix_n[4][0xb] = &taito_f3_state::dpix_ret0;
+	m_dpix_n[4][0xc] = &taito_f3_state::dpix_ret0;
+	m_dpix_n[4][0xd] = &taito_f3_state::dpix_ret0;
+	m_dpix_n[4][0xe] = &taito_f3_state::dpix_ret0;
+	m_dpix_n[4][0xf] = &taito_f3_state::dpix_ret0;
 
-	m_dpix_n[5][0x0]=&taito_f3_state::dpix_3b_0;
-	m_dpix_n[5][0x1]=&taito_f3_state::dpix_3b_1;
-	m_dpix_n[5][0x2]=&taito_f3_state::dpix_3b_2;
-	m_dpix_n[5][0x3]=&taito_f3_state::dpix_ret0;
-	m_dpix_n[5][0x4]=&taito_f3_state::dpix_ret0;
-	m_dpix_n[5][0x5]=&taito_f3_state::dpix_ret0;
-	m_dpix_n[5][0x6]=&taito_f3_state::dpix_ret0;
-	m_dpix_n[5][0x7]=&taito_f3_state::dpix_ret0;
-	m_dpix_n[5][0x8]=&taito_f3_state::dpix_ret0;
-	m_dpix_n[5][0x9]=&taito_f3_state::dpix_ret0;
-	m_dpix_n[5][0xa]=&taito_f3_state::dpix_ret0;
-	m_dpix_n[5][0xb]=&taito_f3_state::dpix_ret0;
-	m_dpix_n[5][0xc]=&taito_f3_state::dpix_ret0;
-	m_dpix_n[5][0xd]=&taito_f3_state::dpix_ret0;
-	m_dpix_n[5][0xe]=&taito_f3_state::dpix_ret0;
-	m_dpix_n[5][0xf]=&taito_f3_state::dpix_ret0;
+	m_dpix_n[5][0x0] = &taito_f3_state::dpix_3b_0;
+	m_dpix_n[5][0x1] = &taito_f3_state::dpix_3b_1;
+	m_dpix_n[5][0x2] = &taito_f3_state::dpix_3b_2;
+	m_dpix_n[5][0x3] = &taito_f3_state::dpix_ret0;
+	m_dpix_n[5][0x4] = &taito_f3_state::dpix_ret0;
+	m_dpix_n[5][0x5] = &taito_f3_state::dpix_ret0;
+	m_dpix_n[5][0x6] = &taito_f3_state::dpix_ret0;
+	m_dpix_n[5][0x7] = &taito_f3_state::dpix_ret0;
+	m_dpix_n[5][0x8] = &taito_f3_state::dpix_ret0;
+	m_dpix_n[5][0x9] = &taito_f3_state::dpix_ret0;
+	m_dpix_n[5][0xa] = &taito_f3_state::dpix_ret0;
+	m_dpix_n[5][0xb] = &taito_f3_state::dpix_ret0;
+	m_dpix_n[5][0xc] = &taito_f3_state::dpix_ret0;
+	m_dpix_n[5][0xd] = &taito_f3_state::dpix_ret0;
+	m_dpix_n[5][0xe] = &taito_f3_state::dpix_ret0;
+	m_dpix_n[5][0xf] = &taito_f3_state::dpix_ret0;
 
-	m_dpix_n[6][0x0]=&taito_f3_state::dpix_2_0;
-	m_dpix_n[6][0x1]=&taito_f3_state::dpix_ret0;
-	m_dpix_n[6][0x2]=&taito_f3_state::dpix_ret0;
-	m_dpix_n[6][0x3]=&taito_f3_state::dpix_ret0;
-	m_dpix_n[6][0x4]=&taito_f3_state::dpix_2_4;
-	m_dpix_n[6][0x5]=&taito_f3_state::dpix_ret0;
-	m_dpix_n[6][0x6]=&taito_f3_state::dpix_ret0;
-	m_dpix_n[6][0x7]=&taito_f3_state::dpix_ret0;
-	m_dpix_n[6][0x8]=&taito_f3_state::dpix_2_8;
-	m_dpix_n[6][0x9]=&taito_f3_state::dpix_ret0;
-	m_dpix_n[6][0xa]=&taito_f3_state::dpix_ret0;
-	m_dpix_n[6][0xb]=&taito_f3_state::dpix_ret0;
-	m_dpix_n[6][0xc]=&taito_f3_state::dpix_ret0;
-	m_dpix_n[6][0xd]=&taito_f3_state::dpix_ret0;
-	m_dpix_n[6][0xe]=&taito_f3_state::dpix_ret0;
-	m_dpix_n[6][0xf]=&taito_f3_state::dpix_ret0;
+	m_dpix_n[6][0x0] = &taito_f3_state::dpix_2_0;
+	m_dpix_n[6][0x1] = &taito_f3_state::dpix_ret0;
+	m_dpix_n[6][0x2] = &taito_f3_state::dpix_ret0;
+	m_dpix_n[6][0x3] = &taito_f3_state::dpix_ret0;
+	m_dpix_n[6][0x4] = &taito_f3_state::dpix_2_4;
+	m_dpix_n[6][0x5] = &taito_f3_state::dpix_ret0;
+	m_dpix_n[6][0x6] = &taito_f3_state::dpix_ret0;
+	m_dpix_n[6][0x7] = &taito_f3_state::dpix_ret0;
+	m_dpix_n[6][0x8] = &taito_f3_state::dpix_2_8;
+	m_dpix_n[6][0x9] = &taito_f3_state::dpix_ret0;
+	m_dpix_n[6][0xa] = &taito_f3_state::dpix_ret0;
+	m_dpix_n[6][0xb] = &taito_f3_state::dpix_ret0;
+	m_dpix_n[6][0xc] = &taito_f3_state::dpix_ret0;
+	m_dpix_n[6][0xd] = &taito_f3_state::dpix_ret0;
+	m_dpix_n[6][0xe] = &taito_f3_state::dpix_ret0;
+	m_dpix_n[6][0xf] = &taito_f3_state::dpix_ret0;
 
-	m_dpix_n[7][0x0]=&taito_f3_state::dpix_3_0;
-	m_dpix_n[7][0x1]=&taito_f3_state::dpix_3_1;
-	m_dpix_n[7][0x2]=&taito_f3_state::dpix_3_2;
-	m_dpix_n[7][0x3]=&taito_f3_state::dpix_ret0;
-	m_dpix_n[7][0x4]=&taito_f3_state::dpix_ret0;
-	m_dpix_n[7][0x5]=&taito_f3_state::dpix_ret0;
-	m_dpix_n[7][0x6]=&taito_f3_state::dpix_ret0;
-	m_dpix_n[7][0x7]=&taito_f3_state::dpix_ret0;
-	m_dpix_n[7][0x8]=&taito_f3_state::dpix_ret0;
-	m_dpix_n[7][0x9]=&taito_f3_state::dpix_ret0;
-	m_dpix_n[7][0xa]=&taito_f3_state::dpix_ret0;
-	m_dpix_n[7][0xb]=&taito_f3_state::dpix_ret0;
-	m_dpix_n[7][0xc]=&taito_f3_state::dpix_ret0;
-	m_dpix_n[7][0xd]=&taito_f3_state::dpix_ret0;
-	m_dpix_n[7][0xe]=&taito_f3_state::dpix_ret0;
-	m_dpix_n[7][0xf]=&taito_f3_state::dpix_ret0;
+	m_dpix_n[7][0x0] = &taito_f3_state::dpix_3_0;
+	m_dpix_n[7][0x1] = &taito_f3_state::dpix_3_1;
+	m_dpix_n[7][0x2] = &taito_f3_state::dpix_3_2;
+	m_dpix_n[7][0x3] = &taito_f3_state::dpix_ret0;
+	m_dpix_n[7][0x4] = &taito_f3_state::dpix_ret0;
+	m_dpix_n[7][0x5] = &taito_f3_state::dpix_ret0;
+	m_dpix_n[7][0x6] = &taito_f3_state::dpix_ret0;
+	m_dpix_n[7][0x7] = &taito_f3_state::dpix_ret0;
+	m_dpix_n[7][0x8] = &taito_f3_state::dpix_ret0;
+	m_dpix_n[7][0x9] = &taito_f3_state::dpix_ret0;
+	m_dpix_n[7][0xa] = &taito_f3_state::dpix_ret0;
+	m_dpix_n[7][0xb] = &taito_f3_state::dpix_ret0;
+	m_dpix_n[7][0xc] = &taito_f3_state::dpix_ret0;
+	m_dpix_n[7][0xd] = &taito_f3_state::dpix_ret0;
+	m_dpix_n[7][0xe] = &taito_f3_state::dpix_ret0;
+	m_dpix_n[7][0xf] = &taito_f3_state::dpix_ret0;
 
-	for(int i = 0; i < 256; i++)
-		for(int j = 0; j < 256; j++)
-			m_add_sat[i][j] = (i + j < 256) ? i + j : 255;
+	for (int i = 0; i < 256; i++)
+		for (int j = 0; j < 256; j++)
+			m_add_sat[i][j] = std::min(i + j, 255);
 }
 
 /******************************************************************************/
 
 #define GET_PIXMAP_POINTER(pf_num) \
 { \
-	const struct f3_playfield_line_inf *line_tmp=line_t[pf_num]; \
-	m_src##pf_num=line_tmp->src[y]; \
-	m_src_s##pf_num=line_tmp->src_s[y]; \
-	m_src_e##pf_num=line_tmp->src_e[y]; \
-	m_tsrc##pf_num=line_tmp->tsrc[y]; \
-	m_tsrc_s##pf_num=line_tmp->tsrc_s[y]; \
-	m_x_count##pf_num=line_tmp->x_count[y]; \
-	m_x_zoom##pf_num=line_tmp->x_zoom[y]; \
-	m_clip_al##pf_num=line_tmp->clip0[y]&0xffff; \
-	m_clip_ar##pf_num=line_tmp->clip0[y]>>16; \
-	m_clip_bl##pf_num=line_tmp->clip1[y]&0xffff; \
-	m_clip_br##pf_num=line_tmp->clip1[y]>>16; \
+	const struct f3_playfield_line_inf *line_tmp = line_t[pf_num]; \
+	m_src[pf_num] = line_tmp->src[y]; \
+	m_src_s[pf_num] = line_tmp->src_s[y]; \
+	m_src_e[pf_num] = line_tmp->src_e[y]; \
+	m_tsrc[pf_num] = line_tmp->tsrc[y]; \
+	m_tsrc_s[pf_num] = line_tmp->tsrc_s[y]; \
+	m_x_count[pf_num] = line_tmp->x_count[y]; \
+	m_x_zoom[pf_num] = line_tmp->x_zoom[y]; \
+	m_clip_al[pf_num] = line_tmp->clip0[y] & 0xffff; \
+	m_clip_ar[pf_num] = line_tmp->clip0[y] >> 16; \
+	m_clip_bl[pf_num] = line_tmp->clip1[y] & 0xffff; \
+	m_clip_br[pf_num] = line_tmp->clip1[y] >> 16; \
 }
 
 #define CULC_PIXMAP_POINTER(pf_num) \
 { \
-	m_x_count##pf_num += m_x_zoom##pf_num; \
-	if(m_x_count##pf_num>>16) \
+	m_x_count[pf_num] += m_x_zoom[pf_num]; \
+	if (m_x_count[pf_num] >> 16) \
 	{ \
-		m_x_count##pf_num &= 0xffff; \
-		m_src##pf_num++; \
-		m_tsrc##pf_num++; \
-		if(m_src##pf_num==m_src_e##pf_num) {m_src##pf_num=m_src_s##pf_num; m_tsrc##pf_num=m_tsrc_s##pf_num;} \
+		m_x_count[pf_num] &= 0xffff; \
+		m_src[pf_num]++; \
+		m_tsrc[pf_num]++; \
+		if (m_src[pf_num] == m_src_e[pf_num]) { m_src[pf_num] = m_src_s[pf_num]; m_tsrc[pf_num] = m_tsrc_s[pf_num]; } \
 	} \
 }
 
 #define UPDATE_PIXMAP_SP(pf_num) \
-	if(cx>=clip_als && cx<clip_ars && !(cx>=clip_bls && cx<clip_brs)) \
+	if (cx >= clip_als && cx < clip_ars && !(cx >= clip_bls && cx < clip_brs)) \
 	{ \
-		sprite_pri=sprite[pf_num]&m_pval; \
-		if(sprite_pri) \
+		sprite_pri = sprite[pf_num] & m_pval; \
+		if (sprite_pri) \
 		{ \
-			if(sprite[pf_num]&0x100) break; \
-			if(!m_dpix_sp[sprite_pri]) \
+			if (sprite[pf_num] & 0x100) break; \
+			if (!m_dpix_sp[sprite_pri]) \
 			{ \
-				if(!(m_pval&0xf0)) break; \
-				else {dpix_1_sprite(*dsti);*dsti=m_dval;break;} \
+				if (!(m_pval & 0xf0)) break; \
+				else { dpix_1_sprite(*dsti); *dsti = m_dval; break; } \
 			} \
-			if((this->*m_dpix_sp[sprite_pri][m_pval>>4])(*dsti)) {*dsti=m_dval;break;} \
+			if ((this->*m_dpix_sp[sprite_pri][m_pval >> 4])(*dsti)) { *dsti = m_dval; break; } \
 		} \
 	}
 
 #define UPDATE_PIXMAP_LP(pf_num) \
-	if (cx>=m_clip_al##pf_num && cx<m_clip_ar##pf_num && !(cx>=m_clip_bl##pf_num && cx<m_clip_br##pf_num)) \
+	if (cx >= m_clip_al[pf_num] && cx < m_clip_ar[pf_num] && !(cx >= m_clip_bl[pf_num] && cx < m_clip_br[pf_num])) \
 	{ \
-		m_tval=*m_tsrc##pf_num; \
-		if(m_tval&0xf0) \
-			if((this->*m_dpix_lp[pf_num][m_pval>>4])(clut[*m_src##pf_num])) {*dsti=m_dval;break;} \
+		m_tval = *m_tsrc[pf_num]; \
+		if (m_tval & 0xf0) \
+			if ((this->*m_dpix_lp[pf_num][m_pval >> 4])(clut[*m_src[pf_num]])) { *dsti = m_dval; break; } \
 	}
 
 
 /*============================================================================*/
 
 inline void taito_f3_state::draw_scanlines(
-							bitmap_rgb32 &bitmap,int xsize,int16_t *draw_line_num,
+							bitmap_rgb32 &bitmap, int xsize, s16 *draw_line_num,
 							const struct f3_playfield_line_inf **line_t,
 							const int *sprite,
-							uint32_t orient,
+							u32 orient,
 							int skip_layer_num)
 {
 	const pen_t *clut = &m_palette->pen(0);
-	uint32_t bgcolor=clut[0];
-	int length;
+	const u32 bgcolor = clut[0];
 
-	const int x=46;
+	const int x = 46;
 
-
-
-
-
-
-	uint16_t clip_als=0, clip_ars=0, clip_bls=0, clip_brs=0;
-
-	uint8_t *dstp0,*dstp;
+	u16 clip_als = 0, clip_ars = 0, clip_bls = 0, clip_brs = 0;
 
 	int yadv = bitmap.rowpixels();
 	int yadvp = m_pri_alp_bitmap.rowpixels();
-	int i=0,y=draw_line_num[0];
+	int i = 0, y = draw_line_num[0];
 	int ty = y;
 
 	if (orient & ORIENTATION_FLIP_Y)
@@ -1453,34 +1355,33 @@ inline void taito_f3_state::draw_scanlines(
 		yadvp = -yadvp;
 	}
 
-	dstp0 = &m_pri_alp_bitmap.pix8(ty, x);
+	u8 *dstp0 = &m_pri_alp_bitmap.pix8(ty, x);
 
-	m_pdest_2a = m_f3_alpha_level_2ad ? 0x10 : 0;
-	m_pdest_2b = m_f3_alpha_level_2bd ? 0x20 : 0;
-	m_tr_2a =(m_f3_alpha_level_2as==0 && m_f3_alpha_level_2ad==255) ? -1 : 0;
-	m_tr_2b =(m_f3_alpha_level_2bs==0 && m_f3_alpha_level_2bd==255) ? -1 : 1;
-	m_pdest_3a = m_f3_alpha_level_3ad ? 0x40 : 0;
-	m_pdest_3b = m_f3_alpha_level_3bd ? 0x80 : 0;
-	m_tr_3a =(m_f3_alpha_level_3as==0 && m_f3_alpha_level_3ad==255) ? -1 : 0;
-	m_tr_3b =(m_f3_alpha_level_3bs==0 && m_f3_alpha_level_3bd==255) ? -1 : 1;
+	m_pdest_2a = m_alpha_level_2ad ? 0x10 : 0;
+	m_pdest_2b = m_alpha_level_2bd ? 0x20 : 0;
+	m_tr_2a =(m_alpha_level_2as == 0 && m_alpha_level_2ad == 255) ? -1 : 0;
+	m_tr_2b =(m_alpha_level_2bs == 0 && m_alpha_level_2bd == 255) ? -1 : 1;
+	m_pdest_3a = m_alpha_level_3ad ? 0x40 : 0;
+	m_pdest_3b = m_alpha_level_3bd ? 0x80 : 0;
+	m_tr_3a =(m_alpha_level_3as == 0 && m_alpha_level_3ad == 255) ? -1 : 0;
+	m_tr_3b =(m_alpha_level_3bs == 0 && m_alpha_level_3bd == 255) ? -1 : 1;
 
 	{
-		uint32_t *dsti0,*dsti;
-		dsti0 = &bitmap.pix32(ty, x);
-		while(1)
+		u32 *dsti0 = &bitmap.pix32(ty, x);
+		while (1)
 		{
-			int cx=0;
+			int cx = 0;
 
-			clip_als=m_sa_line_inf[0].sprite_clip0[y]&0xffff;
-			clip_ars=m_sa_line_inf[0].sprite_clip0[y]>>16;
-			clip_bls=m_sa_line_inf[0].sprite_clip1[y]&0xffff;
-			clip_brs=m_sa_line_inf[0].sprite_clip1[y]>>16;
+			clip_als = m_sa_line_inf[0].sprite_clip0[y] & 0xffff;
+			clip_ars = m_sa_line_inf[0].sprite_clip0[y] >> 16;
+			clip_bls = m_sa_line_inf[0].sprite_clip1[y] & 0xffff;
+			clip_brs = m_sa_line_inf[0].sprite_clip1[y] >> 16;
 
-			length=xsize;
-			dsti = dsti0;
-			dstp = dstp0;
+			int length = xsize;
+			u32 *dsti = dsti0;
+			u8 *dstp = dstp0;
 
-			switch(skip_layer_num)
+			switch (skip_layer_num)
 			{
 				case 0: GET_PIXMAP_POINTER(0)
 				case 1: GET_PIXMAP_POINTER(1)
@@ -1491,11 +1392,11 @@ inline void taito_f3_state::draw_scanlines(
 
 			while (1)
 			{
-				m_pval=*dstp;
-				if (m_pval!=0xff)
+				m_pval = *dstp;
+				if (m_pval != 0xff)
 				{
-					uint8_t sprite_pri;
-					switch(skip_layer_num)
+					u8 sprite_pri;
+					switch (skip_layer_num)
 					{
 						case 0: UPDATE_PIXMAP_SP(0) UPDATE_PIXMAP_LP(0)
 						case 1: UPDATE_PIXMAP_SP(1) UPDATE_PIXMAP_LP(1)
@@ -1503,18 +1404,18 @@ inline void taito_f3_state::draw_scanlines(
 						case 3: UPDATE_PIXMAP_SP(3) UPDATE_PIXMAP_LP(3)
 						case 4: UPDATE_PIXMAP_SP(4) UPDATE_PIXMAP_LP(4)
 						case 5: UPDATE_PIXMAP_SP(5)
-								if(!bgcolor) {if(!(m_pval&0xf0)) {*dsti=0;break;}}
+								if (!bgcolor) { if (!(m_pval & 0xf0)) { *dsti = 0; break; } }
 								else dpix_bg(bgcolor);
-								*dsti=m_dval;
+								*dsti = m_dval;
 					}
 				}
 
-				if(!(--length)) break;
+				if (!(--length)) break;
 				dsti++;
 				dstp++;
 				cx++;
 
-				switch(skip_layer_num)
+				switch (skip_layer_num)
 				{
 					case 0: CULC_PIXMAP_POINTER(0)
 					case 1: CULC_PIXMAP_POINTER(1)
@@ -1525,8 +1426,8 @@ inline void taito_f3_state::draw_scanlines(
 			}
 
 			i++;
-			if(draw_line_num[i]<0) break;
-			if(draw_line_num[i]==y+1)
+			if (draw_line_num[i] < 0) break;
+			if (draw_line_num[i] == y + 1)
 			{
 				dsti0 += yadv;
 				dstp0 += yadvp;
@@ -1535,9 +1436,9 @@ inline void taito_f3_state::draw_scanlines(
 			}
 			else
 			{
-				dsti0 += (draw_line_num[i]-y)*yadv;
-				dstp0 += (draw_line_num[i]-y)*yadvp;
-				y=draw_line_num[i];
+				dsti0 += (draw_line_num[i] - y) * yadv;
+				dstp0 += (draw_line_num[i] - y) * yadvp;
+				y = draw_line_num[i];
 			}
 		}
 	}
@@ -1550,175 +1451,170 @@ inline void taito_f3_state::draw_scanlines(
 void taito_f3_state::visible_tile_check(
 						struct f3_playfield_line_inf *line_t,
 						int line,
-						uint32_t x_index_fx,uint32_t y_index,
-						uint16_t *f3_pf_data_n)
+						u32 x_index_fx,u32 y_index,
+						u16 *pf_data_n)
 {
-	uint16_t *pf_base;
-	int i,trans_all,tile_index,tile_num;
-	int alpha_type,alpha_mode;
-	int opaque_all;
-	int total_elements;
+	u16 *pf_base;
 
-	alpha_mode=line_t->alpha_mode[line];
-	if(!alpha_mode) return;
+	int alpha_mode = line_t->alpha_mode[line];
+	if (!alpha_mode) return;
 
-	total_elements=m_gfxdecode->gfx(1)->elements();
+	const u32 total_elements = m_gfxdecode->gfx(1)->elements();
 
-	tile_index=x_index_fx>>16;
-	tile_num=(((line_t->x_zoom[line]*320+(x_index_fx & 0xffff)+0xffff)>>16)+(tile_index%16)+15)/16;
-	tile_index/=16;
+	int tile_index = x_index_fx >> 16;
+	const int tile_num = (((line_t->x_zoom[line] * 320 + (x_index_fx & 0xffff) + 0xffff) >> 16) + (tile_index & 0xf) + 15) >> 4;
+	tile_index >>= 4;
 
 	if (m_flipscreen)
 	{
-		pf_base=f3_pf_data_n+((31-(y_index/16))<<m_twidth_mask_bit);
-		tile_index=(m_twidth_mask-tile_index)-tile_num+1;
+		pf_base = pf_data_n + ((31 - (y_index >> 4)) << m_twidth_mask_bit);
+		tile_index = (m_twidth_mask - tile_index) - tile_num + 1;
 	}
-	else pf_base=f3_pf_data_n+((y_index/16)<<m_twidth_mask_bit);
+	else pf_base = pf_data_n + ((y_index >> 4) << m_twidth_mask_bit);
 
-
-	trans_all=1;
-	opaque_all=1;
-	alpha_type=0;
-	for(i=0;i<tile_num;i++)
+	bool trans_all = true;
+	bool opaque_all = true;
+	int alpha_type = 0;
+	for (int i = 0; i < tile_num; i++)
 	{
-		uint32_t tile=(pf_base[(tile_index*2+0)&m_twidth_mask]<<16)|(pf_base[(tile_index*2+1)&m_twidth_mask]);
-		uint8_t  extra_planes = (tile>>(16+10)) & 3;
-		if(tile&0xffff)
+		const u32 tile = (pf_base[(tile_index * 2 + 0) & m_twidth_mask] << 16) | (pf_base[(tile_index * 2 + 1) & m_twidth_mask]);
+		const u8  extra_planes = (tile >> (16 + 10)) & 3;
+		if (tile & 0xffff)
 		{
-			trans_all=0;
-			if(opaque_all)
+			trans_all = false;
+			if (opaque_all)
 			{
-				if(m_tile_opaque_pf[extra_planes][(tile&0xffff)%total_elements]!=1) opaque_all=0;
+				if (m_tile_opaque_pf[extra_planes][(tile & 0xffff) % total_elements] != 1) opaque_all = false;
 			}
 
-			if(alpha_mode==1)
+			if (alpha_mode == 1)
 			{
-				if(!opaque_all) return;
+				if (!opaque_all) return;
 			}
 			else
 			{
-				if(alpha_type!=3)
+				if (alpha_type != 3)
 				{
-					if((tile>>(16+9))&1) alpha_type|=2;
-					else                 alpha_type|=1;
+					if ((tile >> (16 + 9)) & 1) alpha_type |= 2;
+					else                        alpha_type |= 1;
 				}
-				else if(!opaque_all) break;
+				else if (!opaque_all) break;
 			}
 		}
-		else if(opaque_all) opaque_all=0;
+		else if (opaque_all) opaque_all = false;
 
 		tile_index++;
 	}
 
-	if(trans_all)   {line_t->alpha_mode[line]=0;return;}
+	if (trans_all) { line_t->alpha_mode[line] = 0; return; }
 
-	if(alpha_mode>1)
+	if (alpha_mode > 1)
 	{
-		line_t->alpha_mode[line]|=alpha_type<<4;
+		line_t->alpha_mode[line] |= alpha_type << 4;
 	}
 
-	if(opaque_all)
-		line_t->alpha_mode[line]|=0x80;
+	if (opaque_all)
+		line_t->alpha_mode[line] |= 0x80;
 }
 
 /******************************************************************************/
 
-void taito_f3_state::calculate_clip(int y, uint16_t pri, uint32_t* clip0, uint32_t* clip1, int* line_enable)
+void taito_f3_state::calculate_clip(int y, u16 pri, u32 *clip0, u32 *clip1, int *line_enable)
 {
-	const struct f3_spritealpha_line_inf *sa_line_t=&m_sa_line_inf[0];
+	const struct f3_spritealpha_line_inf *sa_line_t = &m_sa_line_inf[0];
 
 	switch (pri)
 	{
 	case 0x0100: /* Clip plane 1 enable */
 		{
 			if (sa_line_t->clip0_l[y] > sa_line_t->clip0_r[y])
-				*line_enable=0;
+				*line_enable = 0;
 			else
-				*clip0=(sa_line_t->clip0_l[y]) | (sa_line_t->clip0_r[y]<<16);
-			*clip1=0;
+				*clip0 = (sa_line_t->clip0_l[y]) | (sa_line_t->clip0_r[y] << 16);
+			*clip1 = 0;
 		}
 		break;
 	case 0x0110: /* Clip plane 1 enable, inverted */
 		{
-			*clip1=(sa_line_t->clip0_l[y]) | (sa_line_t->clip0_r[y]<<16);
-			*clip0=0x7fff0000;
+			*clip1 = (sa_line_t->clip0_l[y]) | (sa_line_t->clip0_r[y] << 16);
+			*clip0 = 0x7fff0000;
 		}
 		break;
 	case 0x0200: /* Clip plane 2 enable */
 		{
 			if (sa_line_t->clip1_l[y] > sa_line_t->clip1_r[y])
-				*line_enable=0;
+				*line_enable = 0;
 			else
-				*clip0=(sa_line_t->clip1_l[y]) | (sa_line_t->clip1_r[y]<<16);
-			*clip1=0;
+				*clip0 = (sa_line_t->clip1_l[y]) | (sa_line_t->clip1_r[y] << 16);
+			*clip1 = 0;
 		}
 		break;
 	case 0x0220: /* Clip plane 2 enable, inverted */
 		{
-			*clip1=(sa_line_t->clip1_l[y]) | (sa_line_t->clip1_r[y]<<16);
-			*clip0=0x7fff0000;
+			*clip1 = (sa_line_t->clip1_l[y]) | (sa_line_t->clip1_r[y] << 16);
+			*clip0 = 0x7fff0000;
 		}
 		break;
 	case 0x0300: /* Clip plane 1 & 2 enable */
 		{
-			int clipl=0,clipr=0;
+			int clipl = 0, clipr = 0;
 
 			if (sa_line_t->clip1_l[y] > sa_line_t->clip0_l[y])
-				clipl=sa_line_t->clip1_l[y];
+				clipl = sa_line_t->clip1_l[y];
 			else
-				clipl=sa_line_t->clip0_l[y];
+				clipl = sa_line_t->clip0_l[y];
 
 			if (sa_line_t->clip1_r[y] < sa_line_t->clip0_r[y])
-				clipr=sa_line_t->clip1_r[y];
+				clipr = sa_line_t->clip1_r[y];
 			else
-				clipr=sa_line_t->clip0_r[y];
+				clipr = sa_line_t->clip0_r[y];
 
 			if (clipl > clipr)
-				*line_enable=0;
+				*line_enable = 0;
 			else
-				*clip0=(clipl) | (clipr<<16);
-			*clip1=0;
+				*clip0 = (clipl) | (clipr << 16);
+			*clip1 = 0;
 		}
 		break;
 	case 0x0310: /* Clip plane 1 & 2 enable, plane 1 inverted */
 		{
 			if (sa_line_t->clip1_l[y] > sa_line_t->clip1_r[y])
-				line_enable=nullptr;
+				line_enable = nullptr;
 			else
-				*clip0=(sa_line_t->clip1_l[y]) | (sa_line_t->clip1_r[y]<<16);
+				*clip0 = (sa_line_t->clip1_l[y]) | (sa_line_t->clip1_r[y] << 16);
 
-			*clip1=(sa_line_t->clip0_l[y]) | (sa_line_t->clip0_r[y]<<16);
+			*clip1 = (sa_line_t->clip0_l[y]) | (sa_line_t->clip0_r[y] << 16);
 		}
 		break;
 	case 0x0320: /* Clip plane 1 & 2 enable, plane 2 inverted */
 		{
 			if (sa_line_t->clip0_l[y] > sa_line_t->clip0_r[y])
-				line_enable=nullptr;
+				line_enable = nullptr;
 			else
-				*clip0=(sa_line_t->clip0_l[y]) | (sa_line_t->clip0_r[y]<<16);
+				*clip0 = (sa_line_t->clip0_l[y]) | (sa_line_t->clip0_r[y] << 16);
 
-			*clip1=(sa_line_t->clip1_l[y]) | (sa_line_t->clip1_r[y]<<16);
+			*clip1 = (sa_line_t->clip1_l[y]) | (sa_line_t->clip1_r[y] << 16);
 		}
 		break;
 	case 0x0330: /* Clip plane 1 & 2 enable, both inverted */
 		{
-			int clipl=0,clipr=0;
+			int clipl = 0, clipr = 0;
 
 			if (sa_line_t->clip1_l[y] < sa_line_t->clip0_l[y])
-				clipl=sa_line_t->clip1_l[y];
+				clipl = sa_line_t->clip1_l[y];
 			else
-				clipl=sa_line_t->clip0_l[y];
+				clipl = sa_line_t->clip0_l[y];
 
 			if (sa_line_t->clip1_r[y] > sa_line_t->clip0_r[y])
-				clipr=sa_line_t->clip1_r[y];
+				clipr = sa_line_t->clip1_r[y];
 			else
-				clipr=sa_line_t->clip0_r[y];
+				clipr = sa_line_t->clip0_r[y];
 
 			if (clipl > clipr)
-				*line_enable=0;
+				*line_enable = 0;
 			else
-				*clip1=(clipl) | (clipr<<16);
-			*clip0=0x7fff0000;
+				*clip1 = (clipl) | (clipr << 16);
+			*clip0 = 0x7fff0000;
 		}
 		break;
 	default:
@@ -1729,241 +1625,245 @@ void taito_f3_state::calculate_clip(int y, uint16_t pri, uint32_t* clip0, uint32
 
 void taito_f3_state::get_spritealphaclip_info()
 {
-	struct f3_spritealpha_line_inf *line_t=&m_sa_line_inf[0];
+	struct f3_spritealpha_line_inf *line_t = &m_sa_line_inf[0];
 
-	int y,y_end,y_inc;
+	int y, y_end, y_inc;
 
-	int spri_base,clip_base_low,clip_base_high,inc;
+	int spri_base, clip_base_low, clip_base_high, inc;
 
-	uint16_t spri=0;
-	uint16_t sprite_clip=0;
-	uint16_t clip0_low=0, clip0_high=0, clip1_low=0;
-	int alpha_level=0;
-	uint16_t sprite_alpha=0;
+	u16 spri = 0;
+	u16 sprite_clip = 0;
+	u16 clip0_low = 0, clip0_high = 0, clip1_low = 0;
+	int alpha_level = 0;
+	u16 sprite_alpha = 0;
 
 	if (m_flipscreen)
 	{
-		spri_base=0x77fe;
-		clip_base_low=0x51fe;
-		clip_base_high=0x45fe;
-		inc=-2;
-		y=255;
-		y_end=-1;
-		y_inc=-1;
+		spri_base = 0x77fe;
+		clip_base_low = 0x51fe;
+		clip_base_high = 0x45fe;
+		inc = -2;
+		y = 255;
+		y_end = -1;
+		y_inc = -1;
 
 	}
 	else
 	{
-		spri_base=0x7600;
-		clip_base_low=0x5000;
-		clip_base_high=0x4400;
-		inc=2;
-		y=0;
-		y_end=256;
-		y_inc=1;
+		spri_base = 0x7600;
+		clip_base_low = 0x5000;
+		clip_base_high = 0x4400;
+		inc = 2;
+		y = 0;
+		y_end = 256;
+		y_inc = 1;
 	}
 
-	while(y!=y_end)
+	while (y != y_end)
 	{
 		/* The zoom, column and row values can latch according to control ram */
 		{
-			if (m_f3_line_ram[0x100+(y)]&1)
-				clip0_low=(m_f3_line_ram[clip_base_low/2]>> 0)&0xffff;
-			if (m_f3_line_ram[0x000+(y)]&4)
-				clip0_high=(m_f3_line_ram[clip_base_high/2]>> 0)&0xffff;
-			if (m_f3_line_ram[0x100+(y)]&2)
-				clip1_low=(m_f3_line_ram[(clip_base_low+0x200)/2]>> 0)&0xffff;
+			if (m_line_ram[0x100 + y] & 1)
+				clip0_low = (m_line_ram[clip_base_low / 2] >> 0) & 0xffff;
+			if (m_line_ram[0x000 + y] & 4)
+				clip0_high = (m_line_ram[clip_base_high / 2] >> 0) & 0xffff;
+			if (m_line_ram[0x100 + y] & 2)
+				clip1_low = (m_line_ram[(clip_base_low + 0x200) / 2] >> 0) & 0xffff;
 
-			if (m_f3_line_ram[(0x0600/2)+(y)]&0x8)
-				spri=m_f3_line_ram[spri_base/2]&0xffff;
-			if (m_f3_line_ram[(0x0600/2)+(y)]&0x4)
-				sprite_clip=m_f3_line_ram[(spri_base-0x200)/2]&0xffff;
-			if (m_f3_line_ram[(0x0400/2)+(y)]&0x1)
-				sprite_alpha=m_f3_line_ram[(spri_base-0x1600)/2]&0xffff;
-			if (m_f3_line_ram[(0x0400/2)+(y)]&0x2)
-				alpha_level=m_f3_line_ram[(spri_base-0x1400)/2]&0xffff;
+			if (m_line_ram[(0x0600 / 2) + y] & 0x8)
+				spri = m_line_ram[spri_base / 2] & 0xffff;
+			if (m_line_ram[(0x0600 / 2) + y] & 0x4)
+				sprite_clip = m_line_ram[(spri_base-0x200) / 2] & 0xffff;
+			if (m_line_ram[(0x0400 / 2) + y] & 0x1)
+				sprite_alpha = m_line_ram[(spri_base-0x1600) / 2] & 0xffff;
+			if (m_line_ram[(0x0400 / 2) + y] & 0x2)
+				alpha_level = m_line_ram[(spri_base-0x1400) / 2] & 0xffff;
 		}
 
 
-		line_t->alpha_level[y]=alpha_level;
-		line_t->spri[y]=spri;
-		line_t->sprite_alpha[y]=sprite_alpha;
-		line_t->clip0_l[y]=((clip0_low&0xff)|((clip0_high&0x1000)>>4)) - 47;
-		line_t->clip0_r[y]=(((clip0_low&0xff00)>>8)|((clip0_high&0x2000)>>5)) - 47;
-		line_t->clip1_l[y]=((clip1_low&0xff)|((clip0_high&0x4000)>>6)) - 47;
-		line_t->clip1_r[y]=(((clip1_low&0xff00)>>8)|((clip0_high&0x8000)>>7)) - 47;
-		if (line_t->clip0_l[y]<0) line_t->clip0_l[y]=0;
-		if (line_t->clip0_r[y]<0) line_t->clip0_r[y]=0;
-		if (line_t->clip1_l[y]<0) line_t->clip1_l[y]=0;
-		if (line_t->clip1_r[y]<0) line_t->clip1_r[y]=0;
+		line_t->alpha_level[y] = alpha_level;
+		line_t->spri[y] = spri;
+		line_t->sprite_alpha[y] = sprite_alpha;
+		line_t->clip0_l[y] = ((clip0_low & 0xff) | ((clip0_high & 0x1000) >> 4)) - 47;
+		line_t->clip0_r[y] = (((clip0_low & 0xff00) >> 8) | ((clip0_high & 0x2000) >> 5)) - 47;
+		line_t->clip1_l[y] = ((clip1_low & 0xff) | ((clip0_high & 0x4000) >> 6)) - 47;
+		line_t->clip1_r[y] = (((clip1_low & 0xff00) >> 8) | ((clip0_high & 0x8000) >> 7)) - 47;
+		if (line_t->clip0_l[y] < 0) line_t->clip0_l[y] = 0;
+		if (line_t->clip0_r[y] < 0) line_t->clip0_r[y] = 0;
+		if (line_t->clip1_l[y] < 0) line_t->clip1_l[y] = 0;
+		if (line_t->clip1_r[y] < 0) line_t->clip1_r[y] = 0;
 
 		/* Evaluate sprite clipping */
-		if (sprite_clip&0x080)
+		if (sprite_clip & 0x080)
 		{
-			line_t->sprite_clip0[y]=0x7fff7fff;
-			line_t->sprite_clip1[y]=0;
+			line_t->sprite_clip0[y] = 0x7fff7fff;
+			line_t->sprite_clip1[y] = 0;
 		}
-		else if (sprite_clip&0x33)
+		else if (sprite_clip & 0x33)
 		{
-			int line_enable=1;
-			calculate_clip(y, ((sprite_clip&0x33)<<4), &line_t->sprite_clip0[y], &line_t->sprite_clip1[y], &line_enable);
-			if (line_enable==0)
-				line_t->sprite_clip0[y]=0x7fff7fff;
+			int line_enable = 1;
+			calculate_clip(y, ((sprite_clip & 0x33) << 4), &line_t->sprite_clip0[y], &line_t->sprite_clip1[y], &line_enable);
+			if (line_enable == 0)
+				line_t->sprite_clip0[y] = 0x7fff7fff;
 		}
 		else
 		{
-			line_t->sprite_clip0[y]=0x7fff0000;
-			line_t->sprite_clip1[y]=0;
+			line_t->sprite_clip0[y] = 0x7fff0000;
+			line_t->sprite_clip1[y] = 0;
 		}
 
-		spri_base+=inc;
-		clip_base_low+=inc;
-		clip_base_high+=inc;
-		y +=y_inc;
+		spri_base += inc;
+		clip_base_low += inc;
+		clip_base_high += inc;
+		y += y_inc;
 	}
 }
 
 /* sx and sy are 16.16 fixed point numbers */
-void taito_f3_state::get_line_ram_info(tilemap_t *tmap, int sx, int sy, int pos, uint16_t *f3_pf_data_n)
+void taito_f3_state::get_line_ram_info(tilemap_t *tmap, int sx, int sy, int pos, u16 *pf_data_n)
 {
-	struct f3_playfield_line_inf *line_t=&m_pf_line_inf[pos];
+	struct f3_playfield_line_inf *line_t = &m_pf_line_inf[pos];
 
-	int y,y_start,y_end,y_inc;
-	int line_base,zoom_base,col_base,pri_base,inc;
+	int y_start, y_end, y_inc;
+	int line_base, zoom_base, col_base, pri_base, inc;
 
 	int line_enable;
-	int colscroll=0,x_offset=0,line_zoom=0;
-	uint32_t _y_zoom[256];
-	uint16_t pri=0;
-	int bit_select=1<<pos;
+	int colscroll = 0, x_offset = 0, line_zoom = 0;
+	u32 _y_zoom[256];
+	u16 pri = 0;
+	int bit_select = 1 << pos;
 
 	int _colscroll[256];
-	uint32_t _x_offset[256];
+	u32 _x_offset[256];
 	int y_index_fx;
 
-	sx+=((46<<16));
+	sx += ((46 << 16));
 
 	if (m_flipscreen)
 	{
-		line_base=0xa1fe + (pos*0x200);
-		zoom_base=0x81fe;// + (pos*0x200);
-		col_base =0x41fe + (pos*0x200);
-		pri_base =0xb1fe + (pos*0x200);
-		inc=-2;
-		y_start=255;
-		y_end=-1;
-		y_inc=-1;
+		line_base = 0xa1fe + (pos << 9);
+		zoom_base = 0x81fe;// + (pos << 9);
+		col_base = 0x41fe + (pos << 9);
+		pri_base = 0xb1fe + (pos << 9);
+		inc = -2;
+		y_start = 255;
+		y_end = -1;
+		y_inc = -1;
 
-		if (m_f3_game_config->extend)    sx=-sx+(((188-512)&0xffff)<<16); else sx=-sx+(188<<16); /* Adjust for flipped scroll position */
-		y_index_fx=-sy-(256<<16); /* Adjust for flipped scroll position */
+		 /* Adjust for flipped scroll position */
+		if (m_game_config->extend)
+			sx = -sx + (((188 - 512) & 0xffff) << 16);
+		else
+			sx = -sx + (188 << 16);
+
+		y_index_fx = -sy - (256 << 16); /* Adjust for flipped scroll position */
 	}
 	else
 	{
-		line_base=0xa000 + (pos*0x200);
-		zoom_base=0x8000;// + (pos*0x200);
-		col_base =0x4000 + (pos*0x200);
-		pri_base =0xb000 + (pos*0x200);
-		inc=2;
-		y_start=0;
-		y_end=256;
-		y_inc=1;
+		line_base = 0xa000 + (pos << 9);
+		zoom_base = 0x8000;// + (pos << 9);
+		col_base = 0x4000 + (pos << 9);
+		pri_base = 0xb000 + (pos << 9);
+		inc = 2;
+		y_start = 0;
+		y_end = 256;
+		y_inc = 1;
 
-		y_index_fx=sy;
+		y_index_fx = sy;
 	}
 
-	y=y_start;
+	int y = y_start;
 
-	while(y!=y_end)
+	while (y != y_end)
 	{
 		/* The zoom, column and row values can latch according to control ram */
 		{
-			if (m_f3_line_ram[0x600+(y)]&bit_select)
-				x_offset=(m_f3_line_ram[line_base/2]&0xffff)<<10;
-			if (m_f3_line_ram[0x700+(y)]&bit_select)
-				pri=m_f3_line_ram[pri_base/2]&0xffff;
+			if (m_line_ram[0x600 + y] & bit_select)
+				x_offset = (m_line_ram[line_base / 2] & 0xffff) << 10;
+			if (m_line_ram[0x700 + y] & bit_select)
+				pri = m_line_ram[pri_base / 2] & 0xffff;
 
 			// Zoom for playfields 1 & 3 is interleaved, as is the latch select
 			switch (pos)
 			{
 			case 0:
-				if (m_f3_line_ram[0x400+(y)]&bit_select)
-					line_zoom=m_f3_line_ram[(zoom_base+0x000)/2]&0xffff;
+				if (m_line_ram[0x400 + y] & bit_select)
+					line_zoom = m_line_ram[(zoom_base + 0x000) / 2] & 0xffff;
 				break;
 			case 1:
-				if (m_f3_line_ram[0x400+(y)]&0x2)
-					line_zoom=((m_f3_line_ram[(zoom_base+0x200)/2]&0xffff)&0xff00) | (line_zoom&0x00ff);
-				if (m_f3_line_ram[0x400+(y)]&0x8)
-					line_zoom=((m_f3_line_ram[(zoom_base+0x600)/2]&0xffff)&0x00ff) | (line_zoom&0xff00);
+				if (m_line_ram[0x400 + y] & 0x2)
+					line_zoom = ((m_line_ram[(zoom_base + 0x200) / 2] & 0xffff) & 0xff00) | (line_zoom & 0x00ff);
+				if (m_line_ram[0x400 + y] & 0x8)
+					line_zoom = ((m_line_ram[(zoom_base + 0x600) / 2] & 0xffff) & 0x00ff) | (line_zoom & 0xff00);
 				break;
 			case 2:
-				if (m_f3_line_ram[0x400+(y)]&bit_select)
-					line_zoom=m_f3_line_ram[(zoom_base+0x400)/2]&0xffff;
+				if (m_line_ram[0x400 + y] & bit_select)
+					line_zoom = m_line_ram[(zoom_base + 0x400) / 2] & 0xffff;
 				break;
 			case 3:
-				if (m_f3_line_ram[0x400+(y)]&0x8)
-					line_zoom=((m_f3_line_ram[(zoom_base+0x600)/2]&0xffff)&0xff00) | (line_zoom&0x00ff);
-				if (m_f3_line_ram[0x400+(y)]&0x2)
-					line_zoom=((m_f3_line_ram[(zoom_base+0x200)/2]&0xffff)&0x00ff) | (line_zoom&0xff00);
+				if (m_line_ram[0x400 + y] & 0x8)
+					line_zoom = ((m_line_ram[(zoom_base + 0x600) / 2] & 0xffff) & 0xff00) | (line_zoom & 0x00ff);
+				if (m_line_ram[0x400 + y] & 0x2)
+					line_zoom = ((m_line_ram[(zoom_base + 0x200) / 2] & 0xffff) & 0x00ff) | (line_zoom & 0xff00);
 				break;
 			default:
 				break;
 			}
 
 			// Column scroll only affects playfields 2 & 3
-			if (pos>=2 && m_f3_line_ram[0x000+(y)]&bit_select)
-				colscroll=(m_f3_line_ram[col_base/2]>> 0)&0x3ff;
+			if (pos >= 2 && m_line_ram[0x000 + y] & bit_select)
+				colscroll = (m_line_ram[col_base / 2] >> 0) & 0x3ff;
 		}
 
-		if (!pri || (!m_flipscreen && y<24) || (m_flipscreen && y>231) ||
-			(pri&0xc000)==0xc000 || !(pri&0x2000)/**/)
-			line_enable=0;
-		else if(pri&0x4000) //alpha1
-			line_enable=2;
-		else if(pri&0x8000) //alpha2
-			line_enable=3;
+		if (!pri || (!m_flipscreen && y < 24) || (m_flipscreen && y > 231) ||
+			(pri & 0xc000) == 0xc000 || !(pri & 0x2000)/**/)
+			line_enable = 0;
+		else if (pri & 0x4000) //alpha1
+			line_enable = 2;
+		else if (pri & 0x8000) //alpha2
+			line_enable = 3;
 		else
-			line_enable=1;
+			line_enable = 1;
 
-		_colscroll[y]=colscroll;
-		_x_offset[y]=(x_offset&0xffff0000) - (x_offset&0x0000ffff);
-		_y_zoom[y] = (line_zoom&0xff) << 9;
+		_colscroll[y] = colscroll;
+		_x_offset[y] = (x_offset & 0xffff0000) - (x_offset & 0x0000ffff);
+		_y_zoom[y] = (line_zoom & 0xff) << 9;
 
 		/* Evaluate clipping */
-		if (pri&0x0800)
-			line_enable=0;
-		else if (pri&0x0330)
+		if (pri & 0x0800)
+			line_enable = 0;
+		else if (pri & 0x0330)
 		{
 			//fast path todo - remove line enable
-			calculate_clip(y, pri&0x0330, &line_t->clip0[y], &line_t->clip1[y], &line_enable);
+			calculate_clip(y, pri & 0x0330, &line_t->clip0[y], &line_t->clip1[y], &line_enable);
 		}
 		else
 		{
 			/* No clipping */
-			line_t->clip0[y]=0x7fff0000;
-			line_t->clip1[y]=0;
+			line_t->clip0[y] = 0x7fff0000;
+			line_t->clip1[y] = 0;
 		}
 
-		line_t->x_zoom[y]=0x10000 - (line_zoom&0xff00);
-		line_t->alpha_mode[y]=line_enable;
-		line_t->pri[y]=pri;
+		line_t->x_zoom[y] = 0x10000 - (line_zoom & 0xff00);
+		line_t->alpha_mode[y] = line_enable;
+		line_t->pri[y] = pri;
 
-		zoom_base+=inc;
-		line_base+=inc;
-		col_base +=inc;
-		pri_base +=inc;
-		y +=y_inc;
+		zoom_base += inc;
+		line_base += inc;
+		col_base += inc;
+		pri_base += inc;
+		y += y_inc;
 	}
-
 
 	tilemap_t* tm = tmap;
 
-	y=y_start;
-	while(y!=y_end)
+	y = y_start;
+	while (y != y_end)
 	{
-		uint32_t x_index_fx;
-		uint32_t y_index;
+		u32 x_index_fx;
+		u32 y_index;
 
-		/* The football games use values in the range 0x200-0x3ff where the crowd should be drawn - !?
+		/* The football games use values in the range 0x200 - 0x3ff where the crowd should be drawn - !?
 
 		   This appears to cause it to reference outside of the normal tilemap RAM area into the unused
 		   area on the 32x32 tilemap configuration.. but exactly how isn't understood
@@ -1974,14 +1874,14 @@ void taito_f3_state::get_line_ram_info(tilemap_t *tmap, int sx, int sy, int pos,
 		    the crowd area still seems to 'lag' behind the pitch area however.. but these are the values
 		    in ram??
 		*/
-		int cs = _colscroll[y];
+		const int cs = _colscroll[y];
 
-		if (cs&0x200)
+		if (cs & 0x200)
 		{
-			if (m_pf5_tilemap && m_pf6_tilemap)
+			if (m_tilemap[4] && m_tilemap[5])
 			{
-				if (tmap == m_pf3_tilemap) tmap = m_pf5_tilemap; // pitch -> crowd
-				if (tmap == m_pf4_tilemap) tmap = m_pf6_tilemap; // corruption on goals -> blank (hthero94)
+				if (tmap == m_tilemap[2]) tmap = m_tilemap[4]; // pitch -> crowd
+				if (tmap == m_tilemap[3]) tmap = m_tilemap[5]; // corruption on goals -> blank (hthero94)
 			}
 		}
 		else
@@ -1993,115 +1893,114 @@ void taito_f3_state::get_line_ram_info(tilemap_t *tmap, int sx, int sy, int pos,
 		bitmap_ind16 &srcbitmap = tmap->pixmap();
 		bitmap_ind8 &flagsbitmap = tmap->flagsmap();
 
-		if(line_t->alpha_mode[y]!=0)
+		if (line_t->alpha_mode[y] != 0)
 		{
-			uint16_t *src_s;
-			uint8_t *tsrc_s;
+			u16 *src_s;
+			u8 *tsrc_s;
 
-			x_index_fx = (sx+_x_offset[y]-(10*0x10000)+(10*line_t->x_zoom[y]))&((m_width_mask<<16)|0xffff);
-			y_index = ((y_index_fx>>16)+_colscroll[y])&0x1ff;
+			x_index_fx = (sx+_x_offset[y]-(10*0x10000) + (10*line_t->x_zoom[y]))&((m_width_mask << 16)|0xffff);
+			y_index = ((y_index_fx >> 16)+_colscroll[y]) & 0x1ff;
 
 			/* check tile status */
-			visible_tile_check(line_t,y,x_index_fx,y_index,f3_pf_data_n);
+			visible_tile_check(line_t, y, x_index_fx, y_index, pf_data_n);
 
 			/* If clipping enabled for this line have to disable 'all opaque' optimisation */
-			if (line_t->clip0[y]!=0x7fff0000 || line_t->clip1[y]!=0)
-				line_t->alpha_mode[y]&=~0x80;
+			if (line_t->clip0[y] != 0x7fff0000 || line_t->clip1[y] != 0)
+				line_t->alpha_mode[y] &= ~0x80;
 
 			/* set pixmap index */
 			line_t->x_count[y]=x_index_fx & 0xffff; // Fractional part
-			line_t->src_s[y]=src_s=&srcbitmap.pix16(y_index);
-			line_t->src_e[y]=&src_s[m_width_mask+1];
-			line_t->src[y]=&src_s[x_index_fx>>16];
+			line_t->src_s[y] = src_s = &srcbitmap.pix16(y_index);
+			line_t->src_e[y] = &src_s[m_width_mask + 1];
+			line_t->src[y] = &src_s[x_index_fx >> 16];
 
-			line_t->tsrc_s[y]=tsrc_s=&flagsbitmap.pix8(y_index);
-			line_t->tsrc[y]=&tsrc_s[x_index_fx>>16];
+			line_t->tsrc_s[y]=tsrc_s = &flagsbitmap.pix8(y_index);
+			line_t->tsrc[y] = &tsrc_s[x_index_fx >> 16];
 		}
 
 		y_index_fx += _y_zoom[y];
-		y +=y_inc;
+		y += y_inc;
 	}
 }
 
 void taito_f3_state::get_vram_info(tilemap_t *vram_tilemap, tilemap_t *pixel_tilemap, int sx, int sy)
 {
-	const struct f3_spritealpha_line_inf *sprite_alpha_line_t=&m_sa_line_inf[0];
-	struct f3_playfield_line_inf *line_t=&m_pf_line_inf[4];
+	const struct f3_spritealpha_line_inf *sprite_alpha_line_t = &m_sa_line_inf[0];
+	struct f3_playfield_line_inf *line_t = &m_pf_line_inf[4];
 
-	int y,y_start,y_end,y_inc;
-	int pri_base,inc;
+	int y_start, y_end, y_inc;
+	int pri_base, inc;
 
 	int line_enable;
 
-	uint16_t pri=0;
+	u16 pri = 0;
 
-	const int vram_width_mask=0x3ff;
+	const int vram_width_mask = 0x3ff;
 
 	if (m_flipscreen)
 	{
-		pri_base =0x73fe;
-		inc=-2;
-		y_start=255;
-		y_end=-1;
-		y_inc=-1;
+		pri_base = 0x73fe;
+		inc = -2;
+		y_start = 255;
+		y_end = -1;
+		y_inc = -1;
 	}
 	else
 	{
-		pri_base =0x7200;
-		inc=2;
-		y_start=0;
-		y_end=256;
-		y_inc=1;
+		pri_base = 0x7200;
+		inc = 2;
+		y_start = 0;
+		y_end = 256;
+		y_inc = 1;
 
 	}
 
-	y=y_start;
-	while(y!=y_end)
+	int y = y_start;
+	while (y != y_end)
 	{
 		/* The zoom, column and row values can latch according to control ram */
 		{
-			if (m_f3_line_ram[(0x0600/2)+(y)]&0x2)
-				pri=(m_f3_line_ram[pri_base/2]&0xffff);
+			if (m_line_ram[(0x0600 / 2) + y] & 0x2)
+				pri = (m_line_ram[pri_base / 2] & 0xffff);
 		}
 
-
-		if (!pri || (!m_flipscreen && y<24) || (m_flipscreen && y>231) ||
-			(pri&0xc000)==0xc000 || !(pri&0x2000)/**/)
-			line_enable=0;
-		else if(pri&0x4000) //alpha1
-			line_enable=2;
-		else if(pri&0x8000) //alpha2
-			line_enable=3;
+		if (!pri || (!m_flipscreen && y < 24) || (m_flipscreen && y > 231) ||
+			(pri & 0xc000) == 0xc000 || !(pri & 0x2000)/**/)
+			line_enable = 0;
+		else if (pri & 0x4000) //alpha1
+			line_enable = 2;
+		else if (pri & 0x8000) //alpha2
+			line_enable = 3;
 		else
-			line_enable=1;
+			line_enable = 1;
 
-		line_t->pri[y]=pri;
+		line_t->pri[y] = pri;
 
 		/* Evaluate clipping */
-		if (pri&0x0800)
-			line_enable=0;
-		else if (pri&0x0330)
+		if (pri & 0x0800)
+			line_enable = 0;
+		else if (pri & 0x0330)
 		{
 			//fast path todo - remove line enable
-			calculate_clip(y, pri&0x0330, &line_t->clip0[y], &line_t->clip1[y], &line_enable);
+			calculate_clip(y, pri & 0x0330, &line_t->clip0[y], &line_t->clip1[y], &line_enable);
 		}
 		else
 		{
 			/* No clipping */
-			line_t->clip0[y]=0x7fff0000;
-			line_t->clip1[y]=0;
+			line_t->clip0[y] = 0x7fff0000;
+			line_t->clip1[y] = 0;
 		}
 
-		line_t->x_zoom[y]=0x10000;
-		line_t->alpha_mode[y]=line_enable;
-		if (line_t->alpha_mode[y]>1)
-			line_t->alpha_mode[y]|=0x10;
+		line_t->x_zoom[y] = 0x10000;
+		line_t->alpha_mode[y] = line_enable;
+		if (line_t->alpha_mode[y] > 1)
+			line_t->alpha_mode[y] |= 0x10;
 
-		pri_base +=inc;
-		y +=y_inc;
+		pri_base += inc;
+		y += y_inc;
 	}
 
-	sx&=0x1ff;
+	sx &= 0x1ff;
 
 	/* set pixmap pointer */
 	bitmap_ind16 &srcbitmap_pixel = pixel_tilemap->pixmap();
@@ -2109,32 +2008,32 @@ void taito_f3_state::get_vram_info(tilemap_t *vram_tilemap, tilemap_t *pixel_til
 	bitmap_ind16 &srcbitmap_vram = vram_tilemap->pixmap();
 	bitmap_ind8 &flagsbitmap_vram = vram_tilemap->flagsmap();
 
-	y=y_start;
-	while(y!=y_end)
+	y = y_start;
+	while (y != y_end)
 	{
-		if(line_t->alpha_mode[y]!=0)
+		if (line_t->alpha_mode[y] != 0)
 		{
-			uint16_t *src_s;
-			uint8_t *tsrc_s;
+			u16 *src_s;
+			u8 *tsrc_s;
 
 			// These bits in control ram indicate whether the line is taken from
 			// the VRAM tilemap layer or pixel layer.
-			const int usePixelLayer=((sprite_alpha_line_t->sprite_alpha[y]&0xa000)==0xa000);
+			const bool usePixelLayer = ((sprite_alpha_line_t->sprite_alpha[y] & 0xa000) == 0xa000);
 
 			/* set pixmap index */
-			line_t->x_count[y]=0xffff;
+			line_t->x_count[y] = 0xffff;
 			if (usePixelLayer)
-				line_t->src_s[y]=src_s=&srcbitmap_pixel.pix16(sy&0xff);
+				line_t->src_s[y] = src_s = &srcbitmap_pixel.pix16(sy & 0xff);
 			else
-				line_t->src_s[y]=src_s=&srcbitmap_vram.pix16(sy&0x1ff);
-			line_t->src_e[y]=&src_s[vram_width_mask+1];
-			line_t->src[y]=&src_s[sx];
+				line_t->src_s[y] = src_s = &srcbitmap_vram.pix16(sy & 0x1ff);
+			line_t->src_e[y] = &src_s[vram_width_mask + 1];
+			line_t->src[y] = &src_s[sx];
 
 			if (usePixelLayer)
-				line_t->tsrc_s[y]=tsrc_s=&flagsbitmap_pixel.pix8(sy&0xff);
+				line_t->tsrc_s[y]=tsrc_s = &flagsbitmap_pixel.pix8(sy & 0xff);
 			else
-				line_t->tsrc_s[y]=tsrc_s=&flagsbitmap_vram.pix8(sy&0x1ff);
-			line_t->tsrc[y]=&tsrc_s[sx];
+				line_t->tsrc_s[y]=tsrc_s = &flagsbitmap_vram.pix8(sy & 0x1ff);
+			line_t->tsrc[y] = &tsrc_s[sx];
 		}
 
 		sy++;
@@ -2146,353 +2045,338 @@ void taito_f3_state::get_vram_info(tilemap_t *vram_tilemap, tilemap_t *pixel_til
 
 void taito_f3_state::scanline_draw(bitmap_rgb32 &bitmap, const rectangle &cliprect)
 {
-	int i,j,y,ys,ye;
-	int y_start,y_end,y_start_next,y_end_next;
-	uint8_t draw_line[256];
-	int16_t draw_line_num[256];
+	int i, ys, ye;
+	int y_start, y_end, y_start_next, y_end_next;
+	u8 draw_line[256];
+	s16 draw_line_num[256];
 
-	uint32_t rot=0;
+	u32 rot = 0;
 
 	if (m_flipscreen)
 	{
-		rot=ORIENTATION_FLIP_Y;
-		ys=0;
-		ye=232;
+		rot = ORIENTATION_FLIP_Y;
+		ys = 0;
+		ye = 232;
 	}
 	else
 	{
-		ys=24;
-		ye=256;
+		ys = 24;
+		ye = 256;
 	}
 
-	y_start=ys;
-	y_end=ye;
-	memset(draw_line,0,256);
+	y_start = ys;
+	y_end = ye;
+	std::fill(std::begin(draw_line), std::end(draw_line), 0);
 
-	while(1)
+	while (1)
 	{
 		int pos;
-		int pri[5],alpha_mode[5],alpha_mode_flag[5],alpha_level;
-		uint16_t sprite_alpha;
-		uint8_t sprite_alpha_check;
-		uint8_t sprite_alpha_all_2a;
-		int spri;
-		int alpha;
+		int pri[5],alpha_mode[5],alpha_mode_flag[5];
+		u8 sprite_alpha_check;
+		u8 sprite_alpha_all_2a;
 		int layer_tmp[5];
 		struct f3_playfield_line_inf *pf_line_inf = m_pf_line_inf;
 		struct f3_spritealpha_line_inf *sa_line_inf = m_sa_line_inf;
-		int count_skip_layer=0;
-		int sprite[6]={0,0,0,0,0,0};
+		int count_skip_layer = 0;
+		int sprite[6] = {0, 0, 0, 0, 0, 0};
 		const struct f3_playfield_line_inf *line_t[5];
 
-
 		/* find same status of scanlines */
-		pri[0]=pf_line_inf[0].pri[y_start];
-		pri[1]=pf_line_inf[1].pri[y_start];
-		pri[2]=pf_line_inf[2].pri[y_start];
-		pri[3]=pf_line_inf[3].pri[y_start];
-		pri[4]=pf_line_inf[4].pri[y_start];
-		alpha_mode[0]=pf_line_inf[0].alpha_mode[y_start];
-		alpha_mode[1]=pf_line_inf[1].alpha_mode[y_start];
-		alpha_mode[2]=pf_line_inf[2].alpha_mode[y_start];
-		alpha_mode[3]=pf_line_inf[3].alpha_mode[y_start];
-		alpha_mode[4]=pf_line_inf[4].alpha_mode[y_start];
-		alpha_level=sa_line_inf[0].alpha_level[y_start];
-		spri=sa_line_inf[0].spri[y_start];
-		sprite_alpha=sa_line_inf[0].sprite_alpha[y_start];
+		pri[0] = pf_line_inf[0].pri[y_start];
+		pri[1] = pf_line_inf[1].pri[y_start];
+		pri[2] = pf_line_inf[2].pri[y_start];
+		pri[3] = pf_line_inf[3].pri[y_start];
+		pri[4] = pf_line_inf[4].pri[y_start];
+		alpha_mode[0] = pf_line_inf[0].alpha_mode[y_start];
+		alpha_mode[1] = pf_line_inf[1].alpha_mode[y_start];
+		alpha_mode[2] = pf_line_inf[2].alpha_mode[y_start];
+		alpha_mode[3] = pf_line_inf[3].alpha_mode[y_start];
+		alpha_mode[4] = pf_line_inf[4].alpha_mode[y_start];
+		const int alpha_level = sa_line_inf[0].alpha_level[y_start];
+		const int spri = sa_line_inf[0].spri[y_start];
+		const u16 sprite_alpha = sa_line_inf[0].sprite_alpha[y_start];
 
-		draw_line[y_start]=1;
-		draw_line_num[i=0]=y_start;
-		y_start_next=-1;
-		y_end_next=-1;
-		for(y=y_start+1;y<y_end;y++)
+		draw_line[y_start] = 1;
+		draw_line_num[i = 0] = y_start;
+		y_start_next = -1;
+		y_end_next = -1;
+		for (int y = y_start + 1; y < y_end; y++)
 		{
-			if(!draw_line[y])
+			if (!draw_line[y])
 			{
-				if(pri[0]!=pf_line_inf[0].pri[y]) y_end_next=y+1;
-				else if(pri[1]!=pf_line_inf[1].pri[y]) y_end_next=y+1;
-				else if(pri[2]!=pf_line_inf[2].pri[y]) y_end_next=y+1;
-				else if(pri[3]!=pf_line_inf[3].pri[y]) y_end_next=y+1;
-				else if(pri[4]!=pf_line_inf[4].pri[y]) y_end_next=y+1;
-				else if(alpha_mode[0]!=pf_line_inf[0].alpha_mode[y]) y_end_next=y+1;
-				else if(alpha_mode[1]!=pf_line_inf[1].alpha_mode[y]) y_end_next=y+1;
-				else if(alpha_mode[2]!=pf_line_inf[2].alpha_mode[y]) y_end_next=y+1;
-				else if(alpha_mode[3]!=pf_line_inf[3].alpha_mode[y]) y_end_next=y+1;
-				else if(alpha_mode[4]!=pf_line_inf[4].alpha_mode[y]) y_end_next=y+1;
-				else if(alpha_level!=sa_line_inf[0].alpha_level[y]) y_end_next=y+1;
-				else if(spri!=sa_line_inf[0].spri[y]) y_end_next=y+1;
-				else if(sprite_alpha!=sa_line_inf[0].sprite_alpha[y]) y_end_next=y+1;
+				if (pri[0] != pf_line_inf[0].pri[y]) y_end_next = y + 1;
+				else if (pri[1] != pf_line_inf[1].pri[y]) y_end_next = y + 1;
+				else if (pri[2] != pf_line_inf[2].pri[y]) y_end_next = y + 1;
+				else if (pri[3] != pf_line_inf[3].pri[y]) y_end_next = y + 1;
+				else if (pri[4] != pf_line_inf[4].pri[y]) y_end_next = y + 1;
+				else if (alpha_mode[0] != pf_line_inf[0].alpha_mode[y]) y_end_next = y + 1;
+				else if (alpha_mode[1] != pf_line_inf[1].alpha_mode[y]) y_end_next = y + 1;
+				else if (alpha_mode[2] != pf_line_inf[2].alpha_mode[y]) y_end_next = y + 1;
+				else if (alpha_mode[3] != pf_line_inf[3].alpha_mode[y]) y_end_next = y + 1;
+				else if (alpha_mode[4] != pf_line_inf[4].alpha_mode[y]) y_end_next = y + 1;
+				else if (alpha_level!=sa_line_inf[0].alpha_level[y]) y_end_next = y + 1;
+				else if (spri!=sa_line_inf[0].spri[y]) y_end_next = y + 1;
+				else if (sprite_alpha!=sa_line_inf[0].sprite_alpha[y]) y_end_next = y + 1;
 				else
 				{
-					draw_line[y]=1;
-					draw_line_num[++i]=y;
+					draw_line[y] = 1;
+					draw_line_num[++i] = y;
 					continue;
 				}
 
-				if(y_start_next<0) y_start_next=y;
+				if (y_start_next < 0) y_start_next = y;
 			}
 		}
-		y_end=y_end_next;
-		y_start=y_start_next;
-		draw_line_num[++i]=-1;
+		y_end = y_end_next;
+		y_start = y_start_next;
+		draw_line_num[++i] = -1;
 
 		/* alpha blend */
-		alpha_mode_flag[0]=alpha_mode[0]&~3;
-		alpha_mode_flag[1]=alpha_mode[1]&~3;
-		alpha_mode_flag[2]=alpha_mode[2]&~3;
-		alpha_mode_flag[3]=alpha_mode[3]&~3;
-		alpha_mode_flag[4]=alpha_mode[4]&~3;
-		alpha_mode[0]&=3;
-		alpha_mode[1]&=3;
-		alpha_mode[2]&=3;
-		alpha_mode[3]&=3;
-		alpha_mode[4]&=3;
-		if( alpha_mode[0]>1 ||
-			alpha_mode[1]>1 ||
-			alpha_mode[2]>1 ||
-			alpha_mode[3]>1 ||
-			alpha_mode[4]>1 ||
-			(sprite_alpha&0xff) != 0xff  )
+		alpha_mode_flag[0] = alpha_mode[0] & ~3;
+		alpha_mode_flag[1] = alpha_mode[1] & ~3;
+		alpha_mode_flag[2] = alpha_mode[2] & ~3;
+		alpha_mode_flag[3] = alpha_mode[3] & ~3;
+		alpha_mode_flag[4] = alpha_mode[4] & ~3;
+		alpha_mode[0] &= 3;
+		alpha_mode[1] &= 3;
+		alpha_mode[2] &= 3;
+		alpha_mode[3] &= 3;
+		alpha_mode[4] &= 3;
+		if (alpha_mode[0] > 1 ||
+			alpha_mode[1] > 1 ||
+			alpha_mode[2] > 1 ||
+			alpha_mode[3] > 1 ||
+			alpha_mode[4] > 1 ||
+			(sprite_alpha & 0xff) != 0xff)
 		{
 			/* set alpha level */
-			if(alpha_level!=m_alpha_level_last)
+			if (alpha_level != m_alpha_level_last)
 			{
-				int al_s,al_d;
-				int a=alpha_level;
-				int b=(a>>8)&0xf;
-				int c=(a>>4)&0xf;
-				int d=(a>>0)&0xf;
-				a>>=12;
+				int a = alpha_level;
+				const int b = (a >> 8) & 0xf;
+				const int c = (a >> 4) & 0xf;
+				const int d = (a >> 0) & 0xf;
+				a >>= 12;
 
 				/* b000 7000 */
-				al_s = ( (15-d)*256) / 8;
-				al_d = ( (15-b)*256) / 8;
-				if(al_s>255) al_s = 255;
-				if(al_d>255) al_d = 255;
-				m_f3_alpha_level_3as = al_s;
-				m_f3_alpha_level_3ad = al_d;
-				m_f3_alpha_level_2as = al_d;
-				m_f3_alpha_level_2ad = al_s;
+				int al_s = std::min(255, ((15 - d) * 256) / 8);
+				int al_d = std::min(255, ((15 - b) * 256) / 8);
+				m_alpha_level_3as = al_s;
+				m_alpha_level_3ad = al_d;
+				m_alpha_level_2as = al_d;
+				m_alpha_level_2ad = al_s;
 
-				al_s = ( (15-c)*256) / 8;
-				al_d = ( (15-a)*256) / 8;
-				if(al_s>255) al_s = 255;
-				if(al_d>255) al_d = 255;
-				m_f3_alpha_level_3bs = al_s;
-				m_f3_alpha_level_3bd = al_d;
-				m_f3_alpha_level_2bs = al_d;
-				m_f3_alpha_level_2bd = al_s;
+				al_s = std::min(255, ((15 - c) * 256) / 8);
+				al_d = std::min(255, ((15 - a) * 256) / 8);
+				m_alpha_level_3bs = al_s;
+				m_alpha_level_3bd = al_d;
+				m_alpha_level_2bs = al_d;
+				m_alpha_level_2bd = al_s;
 
-				f3_alpha_set_level();
-				m_alpha_level_last=alpha_level;
+				alpha_set_level();
+				m_alpha_level_last = alpha_level;
 			}
 
 			/* set sprite alpha mode */
-			sprite_alpha_check=0;
+			sprite_alpha_check = 0;
 			sprite_alpha_all_2a=1;
-			m_dpix_sp[1]=nullptr;
-			m_dpix_sp[2]=nullptr;
-			m_dpix_sp[4]=nullptr;
-			m_dpix_sp[8]=nullptr;
-			for(i=0;i<4;i++)    /* i = sprite priority offset */
+			m_dpix_sp[1] = nullptr;
+			m_dpix_sp[2] = nullptr;
+			m_dpix_sp[4] = nullptr;
+			m_dpix_sp[8] = nullptr;
+			for (i = 0; i < 4; i++)    /* i = sprite priority offset */
 			{
-				uint8_t sprite_alpha_mode=(sprite_alpha>>(i*2))&3;
-				uint8_t sftbit=1<<i;
-				if(m_sprite_pri_usage&sftbit)
+				const u8 sprite_alpha_mode = (sprite_alpha >> (i * 2)) & 3;
+				const u8 sftbit = 1 << i;
+				if (m_sprite_pri_usage & sftbit)
 				{
-					if(sprite_alpha_mode==1)
+					if (sprite_alpha_mode == 1)
 					{
-						if(m_f3_alpha_level_2as==0 && m_f3_alpha_level_2ad==255)
-							m_sprite_pri_usage&=~sftbit;  // Disable sprite priority block
+						if (m_alpha_level_2as == 0 && m_alpha_level_2ad == 255)
+							m_sprite_pri_usage &= ~sftbit;  // Disable sprite priority block
 						else
 						{
-							m_dpix_sp[sftbit]=m_dpix_n[2];
-							sprite_alpha_check|=sftbit;
+							m_dpix_sp[sftbit] = m_dpix_n[2];
+							sprite_alpha_check |= sftbit;
 						}
 					}
-					else if(sprite_alpha_mode==2)
+					else if (sprite_alpha_mode == 2)
 					{
-						if(sprite_alpha&0xff00)
+						if (sprite_alpha & 0xff00)
 						{
-							if(m_f3_alpha_level_3as==0 && m_f3_alpha_level_3ad==255) m_sprite_pri_usage&=~sftbit;
+							if (m_alpha_level_3as == 0 && m_alpha_level_3ad == 255) m_sprite_pri_usage &= ~sftbit;
 							else
 							{
-								m_dpix_sp[sftbit]=m_dpix_n[3];
-								sprite_alpha_check|=sftbit;
-								sprite_alpha_all_2a=0;
+								m_dpix_sp[sftbit] = m_dpix_n[3];
+								sprite_alpha_check |= sftbit;
+								sprite_alpha_all_2a = 0;
 							}
 						}
 						else
 						{
-							if(m_f3_alpha_level_3bs==0 && m_f3_alpha_level_3bd==255) m_sprite_pri_usage&=~sftbit;
+							if (m_alpha_level_3bs == 0 && m_alpha_level_3bd == 255) m_sprite_pri_usage &= ~sftbit;
 							else
 							{
-								m_dpix_sp[sftbit]=m_dpix_n[5];
-								sprite_alpha_check|=sftbit;
-								sprite_alpha_all_2a=0;
+								m_dpix_sp[sftbit] = m_dpix_n[5];
+								sprite_alpha_check |= sftbit;
+								sprite_alpha_all_2a = 0;
 							}
 						}
 					}
 				}
 			}
-
 
 			/* check alpha level */
-			for(i=0;i<5;i++)    /* i = playfield num (pos) */
+			for (i = 0; i < 5; i++)    /* i = playfield num (pos) */
 			{
-				int alpha_type = (alpha_mode_flag[i]>>4)&3;
+				const int alpha_type = (alpha_mode_flag[i] >> 4) & 3;
 
-				if(alpha_mode[i]==2)
+				if (alpha_mode[i] == 2)
 				{
-					if(alpha_type==1)
+					if (alpha_type == 1)
 					{
-						/* if (m_f3_alpha_level_2as==0   && m_f3_alpha_level_2ad==255)
-						 *     alpha_mode[i]=3; alpha_mode_flag[i] |= 0x80;}
+						/* if (m_alpha_level_2as == 0   && m_alpha_level_2ad == 255)
+						 *     alpha_mode[i]=3; alpha_mode_flag[i] |= 0x80; }
 						 * will display continue screen in gseeker (mt 00026) */
-						if     (m_f3_alpha_level_2as==0   && m_f3_alpha_level_2ad==255) alpha_mode[i]=0;
-						else if(m_f3_alpha_level_2as==255 && m_f3_alpha_level_2ad==0  ) alpha_mode[i]=1;
+						if      (m_alpha_level_2as == 0   && m_alpha_level_2ad == 255) alpha_mode[i] = 0;
+						else if (m_alpha_level_2as == 255 && m_alpha_level_2ad ==   0) alpha_mode[i] = 1;
 					}
-					else if(alpha_type==2)
+					else if (alpha_type == 2)
 					{
-						if     (m_f3_alpha_level_2bs==0   && m_f3_alpha_level_2bd==255) alpha_mode[i]=0;
-						else if(m_f3_alpha_level_2as==255 && m_f3_alpha_level_2ad==0 &&
-								m_f3_alpha_level_2bs==255 && m_f3_alpha_level_2bd==0  ) alpha_mode[i]=1;
+						if      (m_alpha_level_2bs == 0   && m_alpha_level_2bd == 255) alpha_mode[i] = 0;
+						else if (m_alpha_level_2as == 255 && m_alpha_level_2ad ==   0 &&
+								 m_alpha_level_2bs == 255 && m_alpha_level_2bd ==   0) alpha_mode[i] = 1;
 					}
-					else if(alpha_type==3)
+					else if (alpha_type == 3)
 					{
-						if     (m_f3_alpha_level_2as==0   && m_f3_alpha_level_2ad==255 &&
-								m_f3_alpha_level_2bs==0   && m_f3_alpha_level_2bd==255) alpha_mode[i]=0;
-						else if(m_f3_alpha_level_2as==255 && m_f3_alpha_level_2ad==0   &&
-								m_f3_alpha_level_2bs==255 && m_f3_alpha_level_2bd==0  ) alpha_mode[i]=1;
+						if      (m_alpha_level_2as == 0   && m_alpha_level_2ad == 255 &&
+								 m_alpha_level_2bs == 0   && m_alpha_level_2bd == 255) alpha_mode[i] = 0;
+						else if (m_alpha_level_2as == 255 && m_alpha_level_2ad ==   0 &&
+								 m_alpha_level_2bs == 255 && m_alpha_level_2bd ==   0) alpha_mode[i] = 1;
 					}
 				}
-				else if(alpha_mode[i]==3)
+				else if (alpha_mode[i] == 3)
 				{
-					if(alpha_type==1)
+					if (alpha_type == 1)
 					{
-						if     (m_f3_alpha_level_3as==0   && m_f3_alpha_level_3ad==255) alpha_mode[i]=0;
-						else if(m_f3_alpha_level_3as==255 && m_f3_alpha_level_3ad==0  ) alpha_mode[i]=1;
+						if      (m_alpha_level_3as == 0   && m_alpha_level_3ad == 255) alpha_mode[i] = 0;
+						else if (m_alpha_level_3as == 255 && m_alpha_level_3ad ==   0) alpha_mode[i] = 1;
 					}
-					else if(alpha_type==2)
+					else if (alpha_type == 2)
 					{
-						if     (m_f3_alpha_level_3bs==0   && m_f3_alpha_level_3bd==255) alpha_mode[i]=0;
-						else if(m_f3_alpha_level_3as==255 && m_f3_alpha_level_3ad==0 &&
-								m_f3_alpha_level_3bs==255 && m_f3_alpha_level_3bd==0  ) alpha_mode[i]=1;
+						if      (m_alpha_level_3bs == 0   && m_alpha_level_3bd == 255) alpha_mode[i] = 0;
+						else if (m_alpha_level_3as == 255 && m_alpha_level_3ad ==   0 &&
+								 m_alpha_level_3bs == 255 && m_alpha_level_3bd ==   0) alpha_mode[i] = 1;
 					}
-					else if(alpha_type==3)
+					else if (alpha_type == 3)
 					{
-						if     (m_f3_alpha_level_3as==0   && m_f3_alpha_level_3ad==255 &&
-								m_f3_alpha_level_3bs==0   && m_f3_alpha_level_3bd==255) alpha_mode[i]=0;
-						else if(m_f3_alpha_level_3as==255 && m_f3_alpha_level_3ad==0   &&
-								m_f3_alpha_level_3bs==255 && m_f3_alpha_level_3bd==0  ) alpha_mode[i]=1;
+						if      (m_alpha_level_3as == 0   && m_alpha_level_3ad == 255 &&
+								 m_alpha_level_3bs == 0   && m_alpha_level_3bd == 255) alpha_mode[i] = 0;
+						else if (m_alpha_level_3as == 255 && m_alpha_level_3ad ==   0 &&
+								 m_alpha_level_3bs == 255 && m_alpha_level_3bd ==   0) alpha_mode[i] = 1;
 					}
 				}
 			}
 
-			if (    (alpha_mode[0]==1 || alpha_mode[0]==2 || !alpha_mode[0]) &&
-					(alpha_mode[1]==1 || alpha_mode[1]==2 || !alpha_mode[1]) &&
-					(alpha_mode[2]==1 || alpha_mode[2]==2 || !alpha_mode[2]) &&
-					(alpha_mode[3]==1 || alpha_mode[3]==2 || !alpha_mode[3]) &&
-					(alpha_mode[4]==1 || alpha_mode[4]==2 || !alpha_mode[4]) &&
-					sprite_alpha_all_2a                     )
+			if ((alpha_mode[0] == 1 || alpha_mode[0] == 2 || !alpha_mode[0]) &&
+				(alpha_mode[1] == 1 || alpha_mode[1] == 2 || !alpha_mode[1]) &&
+				(alpha_mode[2] == 1 || alpha_mode[2] == 2 || !alpha_mode[2]) &&
+				(alpha_mode[3] == 1 || alpha_mode[3] == 2 || !alpha_mode[3]) &&
+				(alpha_mode[4] == 1 || alpha_mode[4] == 2 || !alpha_mode[4]) &&
+				sprite_alpha_all_2a)
 			{
-				int alpha_type = (alpha_mode_flag[0] | alpha_mode_flag[1] | alpha_mode_flag[2] | alpha_mode_flag[3])&0x30;
-				if(     (alpha_type==0x10 && m_f3_alpha_level_2as==255) ||
-						(alpha_type==0x20 && m_f3_alpha_level_2as==255 && m_f3_alpha_level_2bs==255) ||
-						(alpha_type==0x30 && m_f3_alpha_level_2as==255 && m_f3_alpha_level_2bs==255)  )
+				int alpha_type = (alpha_mode_flag[0] | alpha_mode_flag[1] | alpha_mode_flag[2] | alpha_mode_flag[3]) & 0x30;
+				if ((alpha_type == 0x10 && m_alpha_level_2as == 255) ||
+					(alpha_type == 0x20 && m_alpha_level_2as == 255 && m_alpha_level_2bs == 255) ||
+					(alpha_type == 0x30 && m_alpha_level_2as == 255 && m_alpha_level_2bs == 255))
 				{
-					if(alpha_mode[0]>1) alpha_mode[0]=1;
-					if(alpha_mode[1]>1) alpha_mode[1]=1;
-					if(alpha_mode[2]>1) alpha_mode[2]=1;
-					if(alpha_mode[3]>1) alpha_mode[3]=1;
-					if(alpha_mode[4]>1) alpha_mode[4]=1;
-					sprite_alpha_check=0;
-					m_dpix_sp[1]=nullptr;
-					m_dpix_sp[2]=nullptr;
-					m_dpix_sp[4]=nullptr;
-					m_dpix_sp[8]=nullptr;
+					if (alpha_mode[0] > 1) alpha_mode[0] = 1;
+					if (alpha_mode[1] > 1) alpha_mode[1] = 1;
+					if (alpha_mode[2] > 1) alpha_mode[2] = 1;
+					if (alpha_mode[3] > 1) alpha_mode[3] = 1;
+					if (alpha_mode[4] > 1) alpha_mode[4] = 1;
+					sprite_alpha_check = 0;
+					m_dpix_sp[1] = nullptr;
+					m_dpix_sp[2] = nullptr;
+					m_dpix_sp[4] = nullptr;
+					m_dpix_sp[8] = nullptr;
 				}
 			}
 		}
 		else
 		{
-			sprite_alpha_check=0;
-			m_dpix_sp[1]=nullptr;
-			m_dpix_sp[2]=nullptr;
-			m_dpix_sp[4]=nullptr;
-			m_dpix_sp[8]=nullptr;
+			sprite_alpha_check = 0;
+			m_dpix_sp[1] = nullptr;
+			m_dpix_sp[2] = nullptr;
+			m_dpix_sp[4] = nullptr;
+			m_dpix_sp[8] = nullptr;
 		}
-
-
 
 		/* set scanline priority */
 		{
-			int pri_max_opa=-1;
-			for(i=0;i<5;i++)    /* i = playfield num (pos) */
+			int pri_max_opa = -1;
+			for (i = 0; i < 5; i++)    /* i = playfield num (pos) */
 			{
-				int p0=pri[i];
-				int pri_sl1=p0&0x0f;
+				const int p0 = pri[i];
+				const int pri_sl1 = p0 & 0x0f;
 
-				layer_tmp[i]=i + (pri_sl1<<3);
+				layer_tmp[i] = i + (pri_sl1 << 3);
 
-				if(!alpha_mode[i])
+				if (!alpha_mode[i])
 				{
-					layer_tmp[i]|=0x80;
+					layer_tmp[i] |= 0x80;
 					count_skip_layer++;
 				}
-				else if(alpha_mode[i]==1 && (alpha_mode_flag[i]&0x80))
+				else if (alpha_mode[i] == 1 && (alpha_mode_flag[i] & 0x80))
 				{
-					if(layer_tmp[i]>pri_max_opa) pri_max_opa=layer_tmp[i];
+					if (layer_tmp[i] > pri_max_opa) pri_max_opa = layer_tmp[i];
 				}
 			}
 
-			if(pri_max_opa!=-1)
+			if (pri_max_opa != -1)
 			{
-				if(pri_max_opa>layer_tmp[0]) {layer_tmp[0]|=0x80;count_skip_layer++;}
-				if(pri_max_opa>layer_tmp[1]) {layer_tmp[1]|=0x80;count_skip_layer++;}
-				if(pri_max_opa>layer_tmp[2]) {layer_tmp[2]|=0x80;count_skip_layer++;}
-				if(pri_max_opa>layer_tmp[3]) {layer_tmp[3]|=0x80;count_skip_layer++;}
-				if(pri_max_opa>layer_tmp[4]) {layer_tmp[4]|=0x80;count_skip_layer++;}
+				if (pri_max_opa > layer_tmp[0]) { layer_tmp[0] |= 0x80; count_skip_layer++; }
+				if (pri_max_opa > layer_tmp[1]) { layer_tmp[1] |= 0x80; count_skip_layer++; }
+				if (pri_max_opa > layer_tmp[2]) { layer_tmp[2] |= 0x80; count_skip_layer++; }
+				if (pri_max_opa > layer_tmp[3]) { layer_tmp[3] |= 0x80; count_skip_layer++; }
+				if (pri_max_opa > layer_tmp[4]) { layer_tmp[4] |= 0x80; count_skip_layer++; }
 			}
 		}
 
-
 		/* sort layer_tmp */
-		for(i=0;i<4;i++)
+		for (i = 0; i < 4; i++)
 		{
-			for(j=i+1;j<5;j++)
+			for (int j = i + 1; j < 5; j++)
 			{
-				if(layer_tmp[i]<layer_tmp[j])
+				if (layer_tmp[i] < layer_tmp[j])
 				{
-					int temp = layer_tmp[i];
+					const int temp = layer_tmp[i];
 					layer_tmp[i] = layer_tmp[j];
 					layer_tmp[j] = temp;
 				}
 			}
 		}
 
-
 		/* check sprite & layer priority */
 		{
-			int l0,l1,l2,l3,l4;
 			int pri_sp[5];
 
-			l0=layer_tmp[0]>>3;
-			l1=layer_tmp[1]>>3;
-			l2=layer_tmp[2]>>3;
-			l3=layer_tmp[3]>>3;
-			l4=layer_tmp[4]>>3;
+			const int l0 = layer_tmp[0] >> 3;
+			const int l1 = layer_tmp[1] >> 3;
+			const int l2 = layer_tmp[2] >> 3;
+			const int l3 = layer_tmp[3] >> 3;
+			const int l4 = layer_tmp[4] >> 3;
 
-			pri_sp[0]=spri&0xf;
-			pri_sp[1]=(spri>>4)&0xf;
-			pri_sp[2]=(spri>>8)&0xf;
-			pri_sp[3]=spri>>12;
+			pri_sp[0] =  spri & 0xf;
+			pri_sp[1] = (spri >> 4) & 0xf;
+			pri_sp[2] = (spri >> 8) & 0xf;
+			pri_sp[3] =  spri >> 12;
 
-			for(i=0;i<4;i++)    /* i = sprite priority offset */
+			for (i = 0; i < 4; i++)    /* i = sprite priority offset */
 			{
-				int sp,sflg=1<<i;
-				if(!(m_sprite_pri_usage & sflg)) continue;
-				sp=pri_sp[i];
+				const int sflg = 1 << i;
+				if (!(m_sprite_pri_usage & sflg)) continue;
+				int sp = pri_sp[i];
 
 				/*
 				    sprite priority==playfield priority
@@ -2501,46 +2385,46 @@ void taito_f3_state::scanline_draw(bitmap_rgb32 &bitmap, const rectangle &clipre
 				        DARIUSG (ZONE V' BOSS) ---> playfield
 				*/
 
-				if (m_f3_game == BUBSYMPH ) sp++;        //BUBSYMPH (title)
-				if (m_f3_game == GSEEKER ) sp++;     //GSEEKER (plane leaving hangar)
+				if (m_game == BUBSYMPH) sp++;        //BUBSYMPH (title)
+				if (m_game == GSEEKER) sp++;     //GSEEKER (plane leaving hangar)
 
-						if(       sp>l0) sprite[0]|=sflg;
-				else if(sp<=l0 && sp>l1) sprite[1]|=sflg;
-				else if(sp<=l1 && sp>l2) sprite[2]|=sflg;
-				else if(sp<=l2 && sp>l3) sprite[3]|=sflg;
-				else if(sp<=l3 && sp>l4) sprite[4]|=sflg;
-				else if(sp<=l4         ) sprite[5]|=sflg;
+				if      (            sp > l0) sprite[0] |= sflg;
+				else if (sp <= l0 && sp > l1) sprite[1] |= sflg;
+				else if (sp <= l1 && sp > l2) sprite[2] |= sflg;
+				else if (sp <= l2 && sp > l3) sprite[3] |= sflg;
+				else if (sp <= l3 && sp > l4) sprite[4] |= sflg;
+				else if (sp <= l4           ) sprite[5] |= sflg;
 			}
 		}
 
 
 		/* draw scanlines */
-		alpha=0;
-		for(i=count_skip_layer;i<5;i++)
+		bool alpha = false;
+		for (i = count_skip_layer; i < 5; i++)
 		{
-			pos=layer_tmp[i]&7;
-			line_t[i]=&pf_line_inf[pos];
+			pos = layer_tmp[i] & 7;
+			line_t[i] = &pf_line_inf[pos];
 
-			if(sprite[i]&sprite_alpha_check) alpha=1;
-			else if(!alpha) sprite[i]|=0x100;
+			if (sprite[i] & sprite_alpha_check) alpha = true;
+			else if (!alpha) sprite[i] |= 0x100;
 
-			if(alpha_mode[pos]>1)
+			if (alpha_mode[pos] > 1)
 			{
-				int alpha_type=(((alpha_mode_flag[pos]>>4)&3)-1)*2;
-				m_dpix_lp[i]=m_dpix_n[alpha_mode[pos]+alpha_type];
-				alpha=1;
+				int alpha_type = (((alpha_mode_flag[pos] >> 4) & 3) - 1) * 2;
+				m_dpix_lp[i] = m_dpix_n[alpha_mode[pos]+alpha_type];
+				alpha = true;
 			}
 			else
 			{
-				if(alpha) m_dpix_lp[i]=m_dpix_n[1];
-				else      m_dpix_lp[i]=m_dpix_n[0];
+				if (alpha) m_dpix_lp[i] = m_dpix_n[1];
+				else       m_dpix_lp[i] = m_dpix_n[0];
 			}
 		}
-		if(sprite[5]&sprite_alpha_check) alpha=1;
-		else if(!alpha) sprite[5]|=0x100;
+		if (sprite[5] & sprite_alpha_check) alpha = true;
+		else if (!alpha) sprite[5] |= 0x100;
 
-		draw_scanlines(bitmap,320,draw_line_num,line_t,sprite,rot,count_skip_layer);
-		if(y_start<0) break;
+		draw_scanlines(bitmap, 320, draw_line_num, line_t, sprite, rot, count_skip_layer);
+		if (y_start < 0) break;
 	}
 }
 
@@ -2548,10 +2432,10 @@ void taito_f3_state::scanline_draw(bitmap_rgb32 &bitmap, const rectangle &clipre
 
 #define PSET_T                  \
 	c = *source & m_sprite_pen_mask; \
-	if(c)                       \
+	if (c)                       \
 	{                           \
-		p=*pri;                 \
-		if(!p || p==0xff)       \
+		p = *pri;                 \
+		if (!p || p == 0xff)       \
 		{                       \
 			*dest = pal[c];     \
 			*pri = pri_dst;     \
@@ -2559,8 +2443,8 @@ void taito_f3_state::scanline_draw(bitmap_rgb32 &bitmap, const rectangle &clipre
 	}
 
 #define PSET_O                  \
-	p=*pri;                     \
-	if(!p || p==0xff)           \
+	p = *pri;                     \
+	if (!p || p == 0xff)           \
 	{                           \
 		*dest = pal[*source & m_sprite_pen_mask];    \
 		*pri = pri_dst;         \
@@ -2571,40 +2455,39 @@ void taito_f3_state::scanline_draw(bitmap_rgb32 &bitmap, const rectangle &clipre
 	dest++;                     \
 	pri++;
 
-inline void taito_f3_state::f3_drawgfx(bitmap_rgb32 &dest_bmp,const rectangle &clip,
+inline void taito_f3_state::f3_drawgfx(bitmap_rgb32 &dest_bmp, const rectangle &clip,
 		gfx_element *gfx,
 		int code,
 		int color,
-		int flipx,int flipy,
-		int sx,int sy,
-		uint8_t pri_dst)
+		int flipx, int flipy,
+		int sx, int sy,
+		u8 pri_dst)
 {
 	rectangle myclip;
 
-	pri_dst=1<<pri_dst;
+	pri_dst = 1 << pri_dst;
 
 	/* KW 991012 -- Added code to force clip to bitmap boundary */
 	myclip = clip;
 	myclip &= dest_bmp.cliprect();
 
-
-	if( gfx )
+	if (gfx)
 	{
 		const pen_t *pal = &m_palette->pen(gfx->colorbase() + gfx->granularity() * (color % gfx->colors()));
-		const uint8_t *code_base = gfx->get_data(code % gfx->elements());
+		const u8 *code_base = gfx->get_data(code % gfx->elements());
 
 		{
 			/* compute sprite increment per screen pixel */
 			int dx = 1;
 			int dy = 1;
 
-			int ex = sx+16;
-			int ey = sy+16;
+			int ex = sx + 16;
+			int ey = sy + 16;
 
 			int x_index_base;
 			int y_index;
 
-			if( flipx )
+			if (flipx)
 			{
 				x_index_base = 15;
 				dx = -1;
@@ -2614,7 +2497,7 @@ inline void taito_f3_state::f3_drawgfx(bitmap_rgb32 &dest_bmp,const rectangle &c
 				x_index_base = 0;
 			}
 
-			if( flipy )
+			if (flipy)
 			{
 				y_index = 15;
 				dy = -1;
@@ -2624,52 +2507,52 @@ inline void taito_f3_state::f3_drawgfx(bitmap_rgb32 &dest_bmp,const rectangle &c
 				y_index = 0;
 			}
 
-			if( sx < myclip.min_x)
+			if (sx < myclip.min_x)
 			{ /* clip left */
-				int pixels = myclip.min_x-sx;
+				int pixels = myclip.min_x - sx;
 				sx += pixels;
-				x_index_base += pixels*dx;
+				x_index_base += pixels * dx;
 			}
-			if( sy < myclip.min_y )
+			if (sy < myclip.min_y)
 			{ /* clip top */
-				int pixels = myclip.min_y-sy;
+				int pixels = myclip.min_y - sy;
 				sy += pixels;
-				y_index += pixels*dy;
+				y_index += pixels * dy;
 			}
 			/* NS 980211 - fixed incorrect clipping */
-			if( ex > myclip.max_x+1 )
+			if (ex > myclip.max_x + 1)
 			{ /* clip right */
-				int pixels = ex-myclip.max_x-1;
+				int pixels = ex - myclip.max_x - 1;
 				ex -= pixels;
 			}
-			if( ey > myclip.max_y+1 )
+			if (ey > myclip.max_y + 1)
 			{ /* clip bottom */
-				int pixels = ey-myclip.max_y-1;
+				int pixels = ey - myclip.max_y - 1;
 				ey -= pixels;
 			}
 
-			if( ex>sx && ey>sy)
+			if (ex > sx && ey > sy)
 			{ /* skip if inner loop doesn't draw anything */
 //              if (dest_bmp.bpp == 32)
 				{
-					int y=ey-sy;
-					int x=(ex-sx-1)|(m_tile_opaque_sp[code % gfx->elements()]<<4);
-					const uint8_t *source0 = code_base + y_index * 16 + x_index_base;
-					uint32_t *dest0 = &dest_bmp.pix32(sy, sx);
-					uint8_t *pri0 = &m_pri_alp_bitmap.pix8(sy, sx);
-					int yadv = dest_bmp.rowpixels();
-					int yadvp = m_pri_alp_bitmap.rowpixels();
-					dy=dy*16;
-					while(1)
+					int y = ey - sy;
+					const int x = (ex - sx - 1) | (m_tile_opaque_sp[code % gfx->elements()] << 4);
+					const u8 *source0 = code_base + y_index * 16 + x_index_base;
+					u32 *dest0 = &dest_bmp.pix32(sy, sx);
+					u8 *pri0 = &m_pri_alp_bitmap.pix8(sy, sx);
+					const int yadv = dest_bmp.rowpixels();
+					const int yadvp = m_pri_alp_bitmap.rowpixels();
+					dy = dy * 16;
+					while (1)
 					{
-						const uint8_t *source = source0;
-						uint32_t *dest = dest0;
-						uint8_t *pri = pri0;
+						const u8 *source = source0;
+						u32 *dest = dest0;
+						u8 *pri = pri0;
 
-						switch(x)
+						switch (x)
 						{
 							int c;
-							uint8_t p;
+							u8 p;
 							case 31: PSET_O NEXT_P
 							case 30: PSET_O NEXT_P
 							case 29: PSET_O NEXT_P
@@ -2705,10 +2588,10 @@ inline void taito_f3_state::f3_drawgfx(bitmap_rgb32 &dest_bmp,const rectangle &c
 							case  0: PSET_T
 						}
 
-						if(!(--y)) break;
+						if (!(--y)) break;
 						source0 += dy;
-						dest0+=yadv;
-						pri0+=yadvp;
+						dest0 += yadv;
+						pri0 += yadvp;
 					}
 				}
 			}
@@ -2720,43 +2603,42 @@ inline void taito_f3_state::f3_drawgfx(bitmap_rgb32 &dest_bmp,const rectangle &c
 #undef NEXT_P
 
 
-inline void taito_f3_state::f3_drawgfxzoom(bitmap_rgb32 &dest_bmp,const rectangle &clip,
+inline void taito_f3_state::f3_drawgfxzoom(bitmap_rgb32 &dest_bmp, const rectangle &clip,
 		gfx_element *gfx,
 		int code,
 		int color,
-		int flipx,int flipy,
-		int sx,int sy,
+		int flipx, int flipy,
+		int sx, int sy,
 		int scalex, int scaley,
-		uint8_t pri_dst)
+		u8 pri_dst)
 {
 	rectangle myclip;
 
-	pri_dst=1<<pri_dst;
+	pri_dst = 1 << pri_dst;
 
 	/* KW 991012 -- Added code to force clip to bitmap boundary */
 	myclip = clip;
 	myclip &= dest_bmp.cliprect();
 
-
-	if( gfx )
+	if (gfx)
 	{
 		const pen_t *pal = &m_palette->pen(gfx->colorbase() + gfx->granularity() * (color % gfx->colors()));
-		const uint8_t *code_base = gfx->get_data(code % gfx->elements());
+		const u8 *code_base = gfx->get_data(code % gfx->elements());
 
 		{
 			/* compute sprite increment per screen pixel */
-			int dx = (16<<16)/scalex;
-			int dy = (16<<16)/scaley;
+			int dx = (16 << 16) / scalex;
+			int dy = (16 << 16) / scaley;
 
-			int ex = sx+scalex;
-			int ey = sy+scaley;
+			int ex = sx + scalex;
+			int ey = sy + scaley;
 
 			int x_index_base;
 			int y_index;
 
-			if( flipx )
+			if (flipx)
 			{
-				x_index_base = (scalex-1)*dx;
+				x_index_base = (scalex - 1) * dx;
 				dx = -dx;
 			}
 			else
@@ -2764,9 +2646,9 @@ inline void taito_f3_state::f3_drawgfxzoom(bitmap_rgb32 &dest_bmp,const rectangl
 				x_index_base = 0;
 			}
 
-			if( flipy )
+			if (flipy)
 			{
-				y_index = (scaley-1)*dy;
+				y_index = (scaley - 1) * dy;
 				dy = -dy;
 			}
 			else
@@ -2774,48 +2656,47 @@ inline void taito_f3_state::f3_drawgfxzoom(bitmap_rgb32 &dest_bmp,const rectangl
 				y_index = 0;
 			}
 
-			if( sx < myclip.min_x)
+			if (sx < myclip.min_x)
 			{ /* clip left */
-				int pixels = myclip.min_x-sx;
+				int pixels = myclip.min_x - sx;
 				sx += pixels;
-				x_index_base += pixels*dx;
+				x_index_base += pixels * dx;
 			}
-			if( sy < myclip.min_y )
+			if (sy < myclip.min_y)
 			{ /* clip top */
-				int pixels = myclip.min_y-sy;
+				int pixels = myclip.min_y - sy;
 				sy += pixels;
-				y_index += pixels*dy;
+				y_index += pixels * dy;
 			}
 			/* NS 980211 - fixed incorrect clipping */
-			if( ex > myclip.max_x+1 )
+			if (ex > myclip.max_x + 1)
 			{ /* clip right */
-				int pixels = ex-myclip.max_x-1;
+				int pixels = ex - myclip.max_x - 1;
 				ex -= pixels;
 			}
-			if( ey > myclip.max_y+1 )
+			if (ey > myclip.max_y + 1)
 			{ /* clip bottom */
-				int pixels = ey-myclip.max_y-1;
+				int pixels = ey - myclip.max_y - 1;
 				ey -= pixels;
 			}
 
-			if( ex>sx )
+			if (ex > sx)
 			{ /* skip if inner loop doesn't draw anything */
 //              if (dest_bmp.bpp == 32)
 				{
-					int y;
-					for( y=sy; y<ey; y++ )
+					for (int y = sy; y < ey; y++)
 					{
-						const uint8_t *source = code_base + (y_index>>16) * 16;
-						uint32_t *dest = &dest_bmp.pix32(y);
-						uint8_t *pri = &m_pri_alp_bitmap.pix8(y);
+						const u8 *source = code_base + (y_index >> 16) * 16;
+						u32 *dest = &dest_bmp.pix32(y);
+						u8 *pri = &m_pri_alp_bitmap.pix8(y);
 
-						int x, x_index = x_index_base;
-						for( x=sx; x<ex; x++ )
+						int x_index = x_index_base;
+						for (int x = sx; x < ex; x++)
 						{
-							int c = source[x_index>>16] & m_sprite_pen_mask;
-							if(c)
+							int c = source[x_index >> 16] & m_sprite_pen_mask;
+							if (c)
 							{
-								uint8_t p=pri[x];
+								const u8 p = pri[x];
 								if (p == 0 || p == 0xff)
 								{
 									dest[x] = pal[c];
@@ -2837,222 +2718,240 @@ inline void taito_f3_state::f3_drawgfxzoom(bitmap_rgb32 &dest_bmp,const rectangl
 	p##_addition = 0x100 - block_zoom_##p + p##_addition_left;  \
 	p##_addition_left = p##_addition & 0xf;                     \
 	p##_addition = p##_addition >> 4;                           \
-	/*zoom##p = p##_addition << 12;*/                           \
+	/*zoom##p = p##_addition << 12; */                           \
 }
 
-void taito_f3_state::get_sprite_info(const uint16_t *spriteram16_ptr)
+void taito_f3_state::get_sprite_info(const u16 *spriteram16_ptr)
 {
 	const rectangle &visarea = m_screen->visible_area();
-	const int min_x=visarea.min_x,max_x=visarea.max_x;
-	const int min_y=visarea.min_y,max_y=visarea.max_y;
-	int offs,spritecont,flipx,flipy,/*old_x,*/color,x,y;
-	int sprite,global_x=0,global_y=0,subglobal_x=0,subglobal_y=0;
-	int block_x=0, block_y=0;
-	int last_color=0,last_x=0,last_y=0,block_zoom_x=0,block_zoom_y=0;
-	int this_x,this_y;
-	int y_addition=16, x_addition=16;
-	int multi=0;
-	int sprite_top;
+	const int min_x = visarea.min_x, max_x = visarea.max_x;
+	const int min_y = visarea.min_y, max_y = visarea.max_y;
+	int global_x = 0,global_y = 0, subglobal_x = 0, subglobal_y = 0;
+	int block_x = 0, block_y = 0;
+	int last_color = 0, last_x = 0, last_y = 0,block_zoom_x = 0,block_zoom_y = 0;
+	int this_x, this_y;
+	int y_addition = 16, x_addition = 16;
+	int multi = 0;
 
 	int x_addition_left = 8, y_addition_left = 8;
 
 	struct tempsprite *sprite_ptr = m_spritelist;
 
-	int total_sprites=0;
+	int total_sprites = 0;
 
-	color=0;
-	flipx=flipy=0;
-	//old_x=0;
-	y=x=0;
+	int color = 0;
+	int flipx = 0, flipy = 0;
+	//int old_x = 0;
+	int y = 0, x = 0;
 
-	sprite_top=0x2000;
-	for (offs = 0; offs < sprite_top && (total_sprites < 0x400); offs += 8)
+	int sprite_top = 0x2000;
+	for (int offs = 0; offs < sprite_top && (total_sprites < 0x400); offs += 8)
 	{
-		const int current_offs=offs; /* Offs can change during loop, current_offs cannot */
+		const int current_offs = offs; /* Offs can change during loop, current_offs cannot */
 
 		/* Check if the sprite list jump command bit is set */
-		if ((spriteram16_ptr[current_offs+6+0]) & 0x8000) {
-			uint32_t jump = (spriteram16_ptr[current_offs+6+0])&0x3ff;
+		if ((spriteram16_ptr[current_offs + 6 + 0]) & 0x8000)
+		{
+			const u32 jump = (spriteram16_ptr[current_offs + 6 + 0]) & 0x3ff;
 
-			uint32_t new_offs=((offs&0x4000)|((jump<<4)/2));
-			if (new_offs==offs)
+			const u32 new_offs = ((offs & 0x4000) | ((jump << 4) / 2));
+			if (new_offs == offs)
 				break;
-			offs=new_offs - 8;
+			offs = new_offs - 8;
 		}
 
 		/* Check if special command bit is set */
-		if (spriteram16_ptr[current_offs+2+1] & 0x8000) {
-			uint32_t cntrl=(spriteram16_ptr[current_offs+4+1])&0xffff;
-			m_flipscreen=cntrl&0x2000;
+		if (spriteram16_ptr[current_offs + 2 + 1] & 0x8000)
+		{
+			const u32 cntrl = (spriteram16_ptr[current_offs + 4 + 1]) & 0xffff;
+			m_flipscreen = cntrl & 0x2000;
 
-			/*  cntrl&0x1000 = disabled?  (From F2 driver, doesn't seem used anywhere)
-			    cntrl&0x0010 = ???
-			    cntrl&0x0020 = ???
+			/*  cntrl & 0x1000 = disabled?  (From F2 driver, doesn't seem used anywhere)
+			    cntrl & 0x0010 = ???
+			    cntrl & 0x0020 = ???
 			*/
 
 			m_sprite_extra_planes = (cntrl & 0x0300) >> 8;   // 0 = 4bpp, 1 = 5bpp, 2 = unused?, 3 = 6bpp
 			m_sprite_pen_mask = (m_sprite_extra_planes << 4) | 0x0f;
 
 			/* Sprite bank select */
-			if (cntrl&1) {
-				offs=offs|0x4000;
-				sprite_top=sprite_top|0x4000;
+			if (cntrl & 1)
+			{
+				offs = offs | 0x4000;
+				sprite_top = sprite_top | 0x4000;
 			}
 		}
 
 		/* Set global sprite scroll */
-		if (((spriteram16_ptr[current_offs+2+0]) & 0xf000) == 0xa000) {
-			global_x = (spriteram16_ptr[current_offs+2+0]) & 0xfff;
+		if (((spriteram16_ptr[current_offs + 2 + 0]) & 0xf000) == 0xa000)
+		{
+			global_x = (spriteram16_ptr[current_offs + 2 + 0]) & 0xfff;
 			if (global_x >= 0x800) global_x -= 0x1000;
-			global_y = spriteram16_ptr[current_offs+2+1] & 0xfff;
+			global_y = spriteram16_ptr[current_offs + 2 + 1] & 0xfff;
 			if (global_y >= 0x800) global_y -= 0x1000;
 		}
 
 		/* And sub-global sprite scroll */
-		if (((spriteram16_ptr[current_offs+2+0]) & 0xf000) == 0x5000) {
-			subglobal_x = (spriteram16_ptr[current_offs+2+0]) & 0xfff;
+		if (((spriteram16_ptr[current_offs + 2 + 0]) & 0xf000) == 0x5000)
+		{
+			subglobal_x = (spriteram16_ptr[current_offs + 2 + 0]) & 0xfff;
 			if (subglobal_x >= 0x800) subglobal_x -= 0x1000;
-			subglobal_y = spriteram16_ptr[current_offs+2+1] & 0xfff;
+			subglobal_y = spriteram16_ptr[current_offs + 2 + 1] & 0xfff;
 			if (subglobal_y >= 0x800) subglobal_y -= 0x1000;
 		}
 
-		if (((spriteram16_ptr[current_offs+2+0]) & 0xf000) == 0xb000) {
-			subglobal_x = (spriteram16_ptr[current_offs+2+0]) & 0xfff;
+		if (((spriteram16_ptr[current_offs + 2 + 0]) & 0xf000) == 0xb000)
+		{
+			subglobal_x = (spriteram16_ptr[current_offs + 2 + 0]) & 0xfff;
 			if (subglobal_x >= 0x800) subglobal_x -= 0x1000;
-			subglobal_y = spriteram16_ptr[current_offs+2+1] & 0xfff;
+			subglobal_y = spriteram16_ptr[current_offs + 2 + 1] & 0xfff;
 			if (subglobal_y >= 0x800) subglobal_y -= 0x1000;
-			global_y=subglobal_y;
-			global_x=subglobal_x;
+			global_y = subglobal_y;
+			global_x = subglobal_x;
 		}
 
 		/* A real sprite to process! */
-		sprite = (spriteram16_ptr[current_offs+0+0]) | ((spriteram16_ptr[current_offs+4+1]&1)<<16);
-		spritecont = spriteram16_ptr[current_offs+4+0]>>8;
+		const int sprite = (spriteram16_ptr[current_offs + 0 + 0]) | ((spriteram16_ptr[current_offs + 4 + 1] & 1) << 16);
+		const int spritecont = spriteram16_ptr[current_offs + 4 + 0] >> 8;
 
 /* These games either don't set the XY control bits properly (68020 bug?), or
     have some different mode from the others */
 #ifdef DARIUSG_KLUDGE
-		if (m_f3_game==DARIUSG || m_f3_game==GEKIRIDO || m_f3_game==CLEOPATR || m_f3_game==RECALH)
-			multi=spritecont&0xf0;
+		if (m_game == DARIUSG || m_game == GEKIRIDO || m_game == CLEOPATR || m_game == RECALH)
+			multi = spritecont & 0xf0;
 #endif
 
 		/* Check if this sprite is part of a continued block */
-		if (multi) {
+		if (multi)
+		{
 			/* Bit 0x4 is 'use previous colour' for this block part */
-			if (spritecont&0x4) color=last_color;
-			else color=(spriteram16_ptr[current_offs+4+0])&0xff;
+			if (spritecont & 0x4) color=last_color;
+			else color = (spriteram16_ptr[current_offs + 4 + 0]) & 0xff;
 
 #ifdef DARIUSG_KLUDGE
-			if (m_f3_game==DARIUSG || m_f3_game==GEKIRIDO || m_f3_game==CLEOPATR || m_f3_game==RECALH) {
+			if (m_game == DARIUSG || m_game == GEKIRIDO || m_game == CLEOPATR || m_game == RECALH)
+			{
 				/* Adjust X Position */
-				if ((spritecont & 0x40) == 0) {
-					if (spritecont & 0x4) {
+				if ((spritecont & 0x40) == 0)
+				{
+					if (spritecont & 0x4)
 						x = block_x;
-					} else {
-						this_x = spriteram16_ptr[current_offs+2+0];
-						if (this_x&0x800) this_x= 0 - (0x800 - (this_x&0x7ff)); else this_x&=0x7ff;
+					else
+					{
+						this_x = spriteram16_ptr[current_offs + 2 + 0];
+						if (this_x & 0x800) this_x = 0 - (0x800 - (this_x & 0x7ff)); else this_x &= 0x7ff;
 
-						if ((spriteram16_ptr[current_offs+2+0])&0x8000) {
-							this_x+=0;
-						} else if ((spriteram16_ptr[current_offs+2+0])&0x4000) {
-							/* Ignore subglobal (but apply global) */
-							this_x+=global_x;
-						} else { /* Apply both scroll offsets */
-							this_x+=global_x+subglobal_x;
-						}
+						if ((spriteram16_ptr[current_offs + 2 + 0]) & 0x8000)
+							this_x += 0;
+						else if ((spriteram16_ptr[current_offs + 2 + 0]) & 0x4000) /* Ignore subglobal (but apply global) */
+							this_x += global_x;
+						else /* Apply both scroll offsets */
+							this_x += global_x + subglobal_x;
 
 						x = block_x = this_x;
 					}
 					x_addition_left = 8;
 					CALC_ZOOM(x)
 				}
-				else if ((spritecont & 0x80) != 0) {
-					x = last_x+x_addition;
+				else if ((spritecont & 0x80) != 0)
+				{
+					x = last_x + x_addition;
 					CALC_ZOOM(x)
 				}
 
 				/* Adjust Y Position */
-				if ((spritecont & 0x10) == 0) {
-					if (spritecont & 0x4) {
+				if ((spritecont & 0x10) == 0)
+				{
+					if (spritecont & 0x4)
 						y = block_y;
-					} else {
-						this_y = spriteram16_ptr[current_offs+2+1]&0xffff;
-						if (this_y&0x800) this_y= 0 - (0x800 - (this_y&0x7ff)); else this_y&=0x7ff;
+					else
+					{
+						this_y = spriteram16_ptr[current_offs + 2 + 1] & 0xffff;
+						if (this_y & 0x800) this_y = 0 - (0x800 - (this_y & 0x7ff)); else this_y &= 0x7ff;
 
-						if ((spriteram16_ptr[current_offs+2+0])&0x8000) {
-							this_y+=0;
-						} else if ((spriteram16_ptr[current_offs+2+0])&0x4000) {
-							/* Ignore subglobal (but apply global) */
-							this_y+=global_y;
-						} else { /* Apply both scroll offsets */
-							this_y+=global_y+subglobal_y;
-						}
+						if ((spriteram16_ptr[current_offs + 2 + 0]) & 0x8000)
+							this_y += 0;
+						else if ((spriteram16_ptr[current_offs + 2 + 0]) & 0x4000) /* Ignore subglobal (but apply global) */
+							this_y += global_y;
+						else /* Apply both scroll offsets */
+							this_y += global_y + subglobal_y;
 
 						y = block_y = this_y;
 					}
 					y_addition_left = 8;
 					CALC_ZOOM(y)
 				}
-				else if ((spritecont & 0x20) != 0) {
-					y = last_y+y_addition;
+				else if ((spritecont & 0x20) != 0)
+				{
+					y = last_y + y_addition;
 					CALC_ZOOM(y)
 				}
-			} else
+			}
+			else
 #endif
 			{
 				/* Adjust X Position */
-				if ((spritecont & 0x40) == 0) {
+				if ((spritecont & 0x40) == 0)
+				{
 					x = block_x;
 					x_addition_left = 8;
 					CALC_ZOOM(x)
 				}
-				else if ((spritecont & 0x80) != 0) {
-					x = last_x+x_addition;
+				else if ((spritecont & 0x80) != 0)
+				{
+					x = last_x + x_addition;
 					CALC_ZOOM(x)
 				}
 				/* Adjust Y Position */
-				if ((spritecont & 0x10) == 0) {
+				if ((spritecont & 0x10) == 0)
+				{
 					y = block_y;
 					y_addition_left = 8;
 					CALC_ZOOM(y)
 				}
-				else if ((spritecont & 0x20) != 0) {
-					y = last_y+y_addition;
+				else if ((spritecont & 0x20) != 0)
+				{
+					y = last_y + y_addition;
 					CALC_ZOOM(y)
 				}
 				/* Both zero = reread block latch? */
 			}
 		}
 		/* Else this sprite is the possible start of a block */
-		else {
-			color = (spriteram16_ptr[current_offs+4+0])&0xff;
-			last_color=color;
+		else
+		{
+			color = (spriteram16_ptr[current_offs + 4 + 0]) & 0xff;
+			last_color = color;
 
 			/* Sprite positioning */
-			this_y = spriteram16_ptr[current_offs+2+1]&0xffff;
-			this_x = spriteram16_ptr[current_offs+2+0]&0xffff;
-			if (this_y&0x800) this_y= 0 - (0x800 - (this_y&0x7ff)); else this_y&=0x7ff;
-			if (this_x&0x800) this_x= 0 - (0x800 - (this_x&0x7ff)); else this_x&=0x7ff;
+			this_y = spriteram16_ptr[current_offs + 2 + 1] & 0xffff;
+			this_x = spriteram16_ptr[current_offs + 2 + 0] & 0xffff;
+			if (this_y & 0x800) this_y = 0 - (0x800 - (this_y & 0x7ff)); else this_y &= 0x7ff;
+			if (this_x & 0x800) this_x = 0 - (0x800 - (this_x & 0x7ff)); else this_x &= 0x7ff;
 
 			/* Ignore both scroll offsets for this block */
-			if ((spriteram16_ptr[current_offs+2+0])&0x8000) {
-				this_x+=0;
-				this_y+=0;
-			} else if ((spriteram16_ptr[current_offs+2+0])&0x4000) {
-				/* Ignore subglobal (but apply global) */
-				this_x+=global_x;
-				this_y+=global_y;
-			} else { /* Apply both scroll offsets */
-				this_x+=global_x+subglobal_x;
-				this_y+=global_y+subglobal_y;
+			if ((spriteram16_ptr[current_offs + 2 + 0]) & 0x8000)
+			{
+				this_x += 0;
+				this_y += 0;
+			}
+			else if ((spriteram16_ptr[current_offs + 2 + 0]) & 0x4000) /* Ignore subglobal (but apply global) */
+			{
+				this_x += global_x;
+				this_y += global_y;
+			}
+			else /* Apply both scroll offsets */
+			{
+				this_x += global_x + subglobal_x;
+				this_y += global_y + subglobal_y;
 			}
 
 			block_y = y = this_y;
 			block_x = x = this_x;
 
-			block_zoom_x=spriteram16_ptr[current_offs+0+1];
-			block_zoom_y=(block_zoom_x>>8)&0xff;
-			block_zoom_x&=0xff;
+			block_zoom_x = spriteram16_ptr[current_offs + 0 + 1];
+			block_zoom_y = (block_zoom_x >> 8) & 0xff;
+			block_zoom_x &= 0xff;
 
 			x_addition_left = 8;
 			CALC_ZOOM(x)
@@ -3062,23 +2961,21 @@ void taito_f3_state::get_sprite_info(const uint16_t *spriteram16_ptr)
 		}
 
 		/* These features are common to sprite and block parts */
-		flipx = spritecont&0x1;
-		flipy = spritecont&0x2;
-		multi = spritecont&0x8;
+		flipx = spritecont & 0x1;
+		flipy = spritecont & 0x2;
+		multi = spritecont & 0x8;
 		last_x=x;
-		last_y=y;
+		last_y = y;
 
 		if (!sprite) continue;
 		if (!x_addition || !y_addition) continue;
 
 		if (m_flipscreen)
 		{
-			int tx,ty;
+			const int tx = 512 - x_addition - x;
+			const int ty = 256 - y_addition - y;
 
-			tx = 512-x_addition-x;
-			ty = 256-y_addition-y;
-
-			if (tx+x_addition<=min_x || tx>max_x || ty+y_addition<=min_y || ty>max_y) continue;
+			if (tx + x_addition <= min_x || tx > max_x || ty + y_addition <= min_y || ty > max_y) continue;
 			sprite_ptr->x = tx;
 			sprite_ptr->y = ty;
 			sprite_ptr->flipx = !flipx;
@@ -3086,13 +2983,12 @@ void taito_f3_state::get_sprite_info(const uint16_t *spriteram16_ptr)
 		}
 		else
 		{
-			if (x+x_addition<=min_x || x>max_x || y+y_addition<=min_y || y>max_y) continue;
+			if (x + x_addition <= min_x || x > max_x || y + y_addition <= min_y || y > max_y) continue;
 			sprite_ptr->x = x;
 			sprite_ptr->y = y;
 			sprite_ptr->flipx = flipx;
 			sprite_ptr->flipy = flipy;
 		}
-
 
 		sprite_ptr->code = sprite;
 		sprite_ptr->color = color;
@@ -3113,99 +3009,98 @@ void taito_f3_state::draw_sprites(bitmap_rgb32 &bitmap, const rectangle &cliprec
 	gfx_element *sprite_gfx = m_gfxdecode->gfx(2);
 
 	sprite_ptr = m_sprite_end;
-	m_sprite_pri_usage=0;
+	m_sprite_pri_usage = 0;
 
 	// if sprites use more than 4bpp, the bottom bits of the color code must be masked out.
 	// This fixes (at least) stage 1 battle ships and attract mode explosions in Ray Force.
 
 	while (sprite_ptr != m_spritelist)
 	{
-		int pri;
 		sprite_ptr--;
 
-		pri=sprite_ptr->pri;
-		m_sprite_pri_usage|=1<<pri;
+		const int pri = sprite_ptr->pri;
+		m_sprite_pri_usage |= 1 << pri;
 
-		if(sprite_ptr->zoomx==16 && sprite_ptr->zoomy==16)
+		if (sprite_ptr->zoomx == 16 && sprite_ptr->zoomy == 16)
 			f3_drawgfx(
-					bitmap,cliprect,sprite_gfx,
+					bitmap, cliprect, sprite_gfx,
 					sprite_ptr->code,
 					sprite_ptr->color & (~m_sprite_extra_planes),
-					sprite_ptr->flipx,sprite_ptr->flipy,
-					sprite_ptr->x,sprite_ptr->y,
+					sprite_ptr->flipx, sprite_ptr->flipy,
+					sprite_ptr->x, sprite_ptr->y,
 					pri);
 		else
 			f3_drawgfxzoom(
-					bitmap,cliprect,sprite_gfx,
+					bitmap, cliprect, sprite_gfx,
 					sprite_ptr->code,
 					sprite_ptr->color & (~m_sprite_extra_planes),
-					sprite_ptr->flipx,sprite_ptr->flipy,
-					sprite_ptr->x,sprite_ptr->y,
-					sprite_ptr->zoomx,sprite_ptr->zoomy,
+					sprite_ptr->flipx, sprite_ptr->flipy,
+					sprite_ptr->x, sprite_ptr->y,
+					sprite_ptr->zoomx, sprite_ptr->zoomy,
 					pri);
 	}
 }
 
 /******************************************************************************/
 
-uint32_t taito_f3_state::screen_update_f3(screen_device &screen, bitmap_rgb32 &bitmap, const rectangle &cliprect)
+u32 taito_f3_state::screen_update(screen_device &screen, bitmap_rgb32 &bitmap, const rectangle &cliprect)
 {
-	uint32_t sy_fix[5],sx_fix[5];
+	u32 sy_fix[5], sx_fix[5];
 
 	machine().tilemap().set_flip_all(m_flipscreen ? (TILEMAP_FLIPY | TILEMAP_FLIPX) : 0);
 
 	/* Setup scroll */
-	sy_fix[0]=((m_f3_control_0[4]&0xffff)<< 9) + (1<<16);
-	sy_fix[1]=((m_f3_control_0[5]&0xffff)<< 9) + (1<<16);
-	sy_fix[2]=((m_f3_control_0[6]&0xffff)<< 9) + (1<<16);
-	sy_fix[3]=((m_f3_control_0[7]&0xffff)<< 9) + (1<<16);
-	sx_fix[0]=((m_f3_control_0[0]&0xffc0)<<10) - (6<<16);
-	sx_fix[1]=((m_f3_control_0[1]&0xffc0)<<10) - (10<<16);
-	sx_fix[2]=((m_f3_control_0[2]&0xffc0)<<10) - (14<<16);
-	sx_fix[3]=((m_f3_control_0[3]&0xffc0)<<10) - (18<<16);
-	sx_fix[4]=-(m_f3_control_1[4])+41;
-	sy_fix[4]=-(m_f3_control_1[5]&0x1ff);
+	sy_fix[0] = ((m_control_0[4] & 0xffff) <<  9) + (1 << 16);
+	sy_fix[1] = ((m_control_0[5] & 0xffff) <<  9) + (1 << 16);
+	sy_fix[2] = ((m_control_0[6] & 0xffff) <<  9) + (1 << 16);
+	sy_fix[3] = ((m_control_0[7] & 0xffff) <<  9) + (1 << 16);
+	sx_fix[0] = ((m_control_0[0] & 0xffc0) << 10) - (6 << 16);
+	sx_fix[1] = ((m_control_0[1] & 0xffc0) << 10) - (10 << 16);
+	sx_fix[2] = ((m_control_0[2] & 0xffc0) << 10) - (14 << 16);
+	sx_fix[3] = ((m_control_0[3] & 0xffc0) << 10) - (18 << 16);
+	sx_fix[4] = -(m_control_1[4]) + 41;
+	sy_fix[4] = -(m_control_1[5] & 0x1ff);
 
-	sx_fix[0]-=((m_f3_control_0[0]&0x003f)<<10)+0x0400-0x10000;
-	sx_fix[1]-=((m_f3_control_0[1]&0x003f)<<10)+0x0400-0x10000;
-	sx_fix[2]-=((m_f3_control_0[2]&0x003f)<<10)+0x0400-0x10000;
-	sx_fix[3]-=((m_f3_control_0[3]&0x003f)<<10)+0x0400-0x10000;
+	sx_fix[0]-=((m_control_0[0] & 0x003f) << 10) + 0x0400 - 0x10000;
+	sx_fix[1]-=((m_control_0[1] & 0x003f) << 10) + 0x0400 - 0x10000;
+	sx_fix[2]-=((m_control_0[2] & 0x003f) << 10) + 0x0400 - 0x10000;
+	sx_fix[3]-=((m_control_0[3] & 0x003f) << 10) + 0x0400 - 0x10000;
 
 	if (m_flipscreen)
 	{
-		sy_fix[0]= 0x3000000-sy_fix[0];
-		sy_fix[1]= 0x3000000-sy_fix[1];
-		sy_fix[2]= 0x3000000-sy_fix[2];
-		sy_fix[3]= 0x3000000-sy_fix[3];
-		sx_fix[0]=-0x1a00000-sx_fix[0];
-		sx_fix[1]=-0x1a00000-sx_fix[1];
-		sx_fix[2]=-0x1a00000-sx_fix[2];
-		sx_fix[3]=-0x1a00000-sx_fix[3];
-		sx_fix[4]=-sx_fix[4] + 75;
-		sy_fix[4]=-sy_fix[4];
+		sy_fix[0] =  0x3000000 - sy_fix[0];
+		sy_fix[1] =  0x3000000 - sy_fix[1];
+		sy_fix[2] =  0x3000000 - sy_fix[2];
+		sy_fix[3] =  0x3000000 - sy_fix[3];
+		sx_fix[0] = -0x1a00000 - sx_fix[0];
+		sx_fix[1] = -0x1a00000 - sx_fix[1];
+		sx_fix[2] = -0x1a00000 - sx_fix[2];
+		sx_fix[3] = -0x1a00000 - sx_fix[3];
+		sx_fix[4] = -sx_fix[4] + 75;
+		sy_fix[4] = -sy_fix[4];
 	}
 
 	m_pri_alp_bitmap.fill(0, cliprect);
 
 	/* sprites */
-	if (m_sprite_lag==0)
-		get_sprite_info(m_spriteram.get());
+	if (m_sprite_lag == 0)
+		get_sprite_info(m_spriteram.target());
 
 	/* Update sprite buffer */
-	draw_sprites(bitmap,cliprect);
+	draw_sprites(bitmap, cliprect);
 
 	/* Parse sprite, alpha & clipping parts of lineram */
 	get_spritealphaclip_info();
 
 	/* Parse playfield effects */
-	get_line_ram_info(m_pf1_tilemap,sx_fix[0],sy_fix[0],0,m_f3_pf_data_1);
-	get_line_ram_info(m_pf2_tilemap,sx_fix[1],sy_fix[1],1,m_f3_pf_data_2);
-	get_line_ram_info(m_pf3_tilemap,sx_fix[2],sy_fix[2],2,m_f3_pf_data_3);
-	get_line_ram_info(m_pf4_tilemap,sx_fix[3],sy_fix[3],3,m_f3_pf_data_4);
-	get_vram_info(m_vram_layer,m_pixel_layer,sx_fix[4],sy_fix[4]);
+	get_line_ram_info(m_tilemap[0], sx_fix[0], sy_fix[0], 0, m_pf_data[0]);
+	get_line_ram_info(m_tilemap[1], sx_fix[1], sy_fix[1], 1, m_pf_data[1]);
+	get_line_ram_info(m_tilemap[2], sx_fix[2], sy_fix[2], 2, m_pf_data[2]);
+	get_line_ram_info(m_tilemap[3], sx_fix[3], sy_fix[3], 3, m_pf_data[3]);
+	get_vram_info(m_vram_layer, m_pixel_layer, sx_fix[4], sy_fix[4]);
 
 	/* Draw final framebuffer */
-	scanline_draw(bitmap,cliprect);
+	scanline_draw(bitmap, cliprect);
 
 	if (VERBOSE)
 		print_debug_info(bitmap);


### PR DESCRIPTION
Convert VRAMs into shared_ptr, Fix namings, Spacings, Simplify gfxdecodes, Handlers, Split hi 2bpp of gfx data to each rom, Correct 6bpp gfx decode behavior into mix ROM data, Reduce duplicates, Runtime tag lookups, Unnecessary lines, Move structs into taito_f3.h, Fix postload
taito_f3.h : Move taito_f3.cpp exclusive things under private: