### PR TITLE
Original Apple II WOZ images to June 7th, 2019, AppleWorks in Misc (nw)

### DIFF
--- a/hash/apple2_flop_clcracked.xml
+++ b/hash/apple2_flop_clcracked.xml
@@ -487,9 +487,11 @@
 
 	<software name="mrdo">
 		<description>Mr. Do (cleanly cracked)</description>
-		<year>1983</year>
+		<year>1985</year>
 		<publisher>Datasoft</publisher>
+		<info name="release" value="2015-07-05"/>
 		<!-- No compatibility data known at this time. -->
+		<!-- Crack was updated on 2015-07-05 to fix corrupted blocks. -->
 
 		<part name="flop1" interface="floppy_5_25">
 			<dataarea name="flop" size="143360">
@@ -502,6 +504,7 @@
 		<description>Ms. Pac Man (cleanly cracked)</description>
 		<year>1983</year>
 		<publisher>Atari</publisher>
+		<info name="release" value="2015-03-18"/>
 		<!-- No compatibility data known at this time. -->
 
 		<part name="flop1" interface="floppy_5_25">
@@ -3087,7 +3090,6 @@
 		<description>Agenda Files (cleanly cracked)</description>
 		<year>1981</year>
 		<publisher>Apple Computer</publisher>
-		<!-- Dump release date not known at this time. -->
 		<info name="release" value="2018-06-09"/>
 
 		<part name="flop1" interface="floppy_5_25">

--- a/hash/apple2_flop_clcracked.xml
+++ b/hash/apple2_flop_clcracked.xml
@@ -534,6 +534,7 @@
 		<description>Pac-Man (Atari) (cleanly cracked)</description>
 		<year>1983</year>
 		<publisher>Atari</publisher>
+		<info name="release" value="2015-03-18"/>
 		<!-- No compatibility data known at this time. -->
 
 		<part name="flop1" interface="floppy_5_25">
@@ -546,7 +547,8 @@
 	<software name="pacmand">
 		<description>Pac-Man (Datasoft) (cleanly cracked)</description>
 		<year>1983</year>
-		<publisher>Datasoft / Namco America</publisher>
+		<publisher>Datasoft</publisher>
+		<info name="release" value="2015-03-10"/>
 		<!-- No compatibility data known at this time. -->
 
 		<part name="flop1" interface="floppy_5_25">
@@ -557,9 +559,10 @@
 	</software>
 
 	<software name="pacmant">
-		<description>Pac-Man (Thunder Mountain copyight) (cleanly cracked)</description>
+		<description>Pac-Man (Thunder Mountain) (cleanly cracked)</description>
 		<year>1983</year>
-		<publisher>Thunder Mountain / Namco</publisher>
+		<publisher>Thunder Mountain</publisher>
+		<info name="release" value="2015-05-12"/>
 		<!-- No compatibility data known at this time. -->
 
 		<part name="flop1" interface="floppy_5_25">
@@ -5849,11 +5852,13 @@
 		<!-- No compatibility data known at this time. -->
 
 		<part name="flop1" interface="floppy_5_25">
+			<feature name="part_id" value="Side A"/>
 			<dataarea name="flop" size="143360">
 				<rom name="championship baseball (4am crack) side a.dsk" size="143360" crc="dc772a9f" sha1="0dccab61467b5d08c3de4a05e9410ce56d2bbf4d" />
 			</dataarea>
 		</part>
 		<part name="flop2" interface="floppy_5_25">
+			<feature name="part_id" value="Side B"/>
 			<dataarea name="flop" size="143360">
 				<rom name="championship baseball (4am crack) side b.dsk" size="143360" crc="b4767c81" sha1="4ad26e03f0227ec4eada7ad0709222baf79427bb" />
 			</dataarea>
@@ -5910,11 +5915,13 @@
 		<!-- No compatibility data known at this time. -->
 
 		<part name="flop1" interface="floppy_5_25">
+			<feature name="part_id" value="Disk 1"/>
 			<dataarea name="flop" size="143360">
 				<rom name="chariots, cougars, and kings (4am crack) disk 1.dsk" size="143360" crc="8fc9df9f" sha1="d966d3a65ff4eb861d9faa58fb491a33c4b94fe8" />
 			</dataarea>
 		</part>
 		<part name="flop2" interface="floppy_5_25">
+			<feature name="part_id" value="Disk 2"/>
 			<dataarea name="flop" size="143360">
 				<rom name="chariots, cougars, and kings (4am crack) disk 2.dsk" size="143360" crc="57dcc568" sha1="fccb739ccc8dcddd00b60dcabad2745909f0f517" />
 			</dataarea>

--- a/hash/apple2_flop_misc.xml
+++ b/hash/apple2_flop_misc.xml
@@ -45,6 +45,75 @@
 		</part>
 	</software>
 
+	<software name="apwrks12">
+		<description>AppleWorks (Version 1.2, USA)</description>
+		<year>1983</year>
+		<publisher>Apple Computer, Inc.</publisher>
+
+		<part name="flop1" interface="floppy_5_25">
+			<feature name="part_id" value="Disk 1 - Startup"/>
+			<dataarea name="flop" size="143360">
+				<rom name="appleworks 1.2 startup.dsk" size="143360" crc="0cdc2045" sha1="a0505b4af4502d2de421f1d5aaa3968582f19dad" />
+			</dataarea>
+		</part>
+		<part name="flop2" interface="floppy_5_25">
+			<feature name="part_id" value="Disk 2 - Program"/>
+			<dataarea name="flop" size="143360">
+				<rom name="appleworks 1.2 program.dsk" size="143360" crc="ee501dac" sha1="f0b9b7dcec03d88c82b6a8de69f6d4fdee8ebc07" />
+			</dataarea>
+		</part>
+	</software>
+
+	<software name="apwrks13">
+		<description>AppleWorks (Version 1.3, USA)</description>
+		<year>1985</year>
+		<publisher>Apple Computer, Inc.</publisher>
+
+		<part name="flop1" interface="floppy_5_25">
+			<feature name="part_id" value="Disk 1 - Boot"/>
+			<dataarea name="flop" size="143360">
+				<rom name="appleworks_v13boot.dsk" size="143360" crc="535eef61" sha1="bdebfc3adfb1e5341fd77826040f2155e246ef5b" />
+			</dataarea>
+		</part>
+		<part name="flop2" interface="floppy_5_25">
+			<feature name="part_id" value="Disk 2 - Program"/>
+			<dataarea name="flop" size="143360">
+				<rom name="appleworks_v13programdisk.dsk" size="143360" crc="29748ff9" sha1="7f9e86ea50343082ad6d2bb608e5da4befd48a9c" />
+			</dataarea>
+		</part>
+	</software>
+
+	<software name="apwrks20">
+		<description>AppleWorks (Version 2.0, USA)</description>
+		<year>1986</year>
+		<publisher>Apple Computer, Inc.</publisher>
+
+		<part name="flop1" interface="floppy_5_25">
+			<feature name="part_id" value="Disk 1 - Boot"/>
+			<dataarea name="flop" size="143360">
+				<rom name="appleworks 2.0 boot disk.po" size="143360" crc="a1a7d2c4" sha1="f45a436399f83d5213604ab395978e7cc726aa91" />
+			</dataarea>
+		</part>
+		<part name="flop2" interface="floppy_5_25">
+			<feature name="part_id" value="Disk 2 - Program"/>
+			<dataarea name="flop" size="143360">
+				<rom name="appleworks 2.0 program disk.po" size="143360" crc="4142bffd" sha1="088e69ddb3e9821fc7d20c7cfcd241636467bc89" />
+			</dataarea>
+		</part>
+		<part name="flop3" interface="floppy_5_25">
+			<feature name="part_id" value="Disk 3 - Sample disk 1"/>
+			<dataarea name="flop" size="143360">
+				<rom name="appleworks 2.0 sample disk 1.po" size="143360" crc="f20d113e" sha1="d057ad439f0e33e035194b08df1ce62832f15bef" />
+			</dataarea>
+		</part>
+		<part name="flop4" interface="floppy_5_25">
+			<feature name="part_id" value="Disk 4 - Sample disk 2"/>
+			<dataarea name="flop" size="143360">
+				<rom name="appleworks 2.0 sample disk 2.po" size="143360" crc="ae3e43a7" sha1="1014aed563546747844702216bed53bb958d69da" />
+			</dataarea>
+		</part>
+	</software>
+
 	<software name="amdos35">
 		<description>AmDOS (v3.5)</description>
 		<year>1986</year>

--- a/hash/apple2_flop_orig.xml
+++ b/hash/apple2_flop_orig.xml
@@ -5353,4 +5353,75 @@
 		</part>
 	</software>
 
+	<software name="chmpbase">
+		<description>Championship Baseball</description>
+		<year>1986</year>
+		<publisher>Activision</publisher>
+		<info name="release" value="2019-06-06"/>
+		<sharedfeat name="compatibility" value="A2P,A2E,A2EE,A2C,A2GS" />
+		<!-- It requires a 64K Apple ][+ or later. -->
+
+		<part name="flop1" interface="floppy_5_25">
+			<feature name="part_id" value="Side A"/>
+			<dataarea name="flop" size="234841">
+				<rom name="Championship Baseball side A.woz" size="234841" crc="d2b4c74b" sha1="d36792910f466809fd7021cbf34ece4225c31f4c" />
+			</dataarea>
+		</part>
+		<part name="flop2" interface="floppy_5_25">
+			<feature name="part_id" value="Side B"/>
+			<dataarea name="flop" size="234841">
+				<rom name="Championship Baseball side B.woz" size="234841" crc="643f1049" sha1="4f29d8b36f113ae223d9b5e34198b894f7a55a16" />
+			</dataarea>
+		</part>
+	</software>
+
+	<software name="wizardoz">
+		<description>The Wizard of Oz</description>
+		<year>1985</year>
+		<publisher>Windham Classics</publisher>
+		<info name="release" value="2019-06-07"/>
+		<sharedfeat name="compatibility" value="A2P,A2E,A2EE,A2C,A2GS" />
+		<!-- It requires a 64K Apple ][+ or later.- -->
+
+		<part name="flop1" interface="floppy_5_25">
+			<feature name="part_id" value="Disk A"/>
+			<dataarea name="flop" size="234866">
+				<rom name="The Wizard of Oz disk A.woz" size="234866" crc="4522de5f" sha1="b2459cf8ea2791d82b5da58e7b0aa25caf140f94" />
+			</dataarea>
+		</part>
+		<part name="flop2" interface="floppy_5_25">
+			<feature name="part_id" value="Disk B"/>
+			<dataarea name="flop" size="234866">
+				<rom name="The Wizard of Oz disk B.woz" size="234866" crc="e9de932e" sha1="fa02f177b45bde15ffc06101031fd01ca8710033" />
+			</dataarea>
+		</part>
+		<part name="flop3" interface="floppy_5_25">
+			<feature name="part_id" value="Disk C"/>
+			<dataarea name="flop" size="234866">
+				<rom name="The Wizard of Oz disk C.woz" size="234866" crc="0ed1d4cb" sha1="78a9fb5edb2fd249e7804607cd7bd3ee248115af" />
+			</dataarea>
+		</part>
+		<part name="flop4" interface="floppy_5_25">
+			<feature name="part_id" value="Disk D"/>
+			<dataarea name="flop" size="234866">
+				<rom name="The Wizard of Oz disk D.woz" size="234866" crc="1c0e7e78" sha1="25d7e25b66c475d0881138ba302be722683df6e6" />
+			</dataarea>
+		</part>
+	</software>
+
+	<software name="queenphb">
+		<description>The Queen of Phobos</description>
+		<year>1982</year>
+		<publisher>Phoenix Software</publisher>
+		<info name="release" value="2019-06-07"/>
+		<sharedfeat name="compatibility" value="A2,A2P,A2E,A2EE,A2C,A2GS" />
+		<!-- It runs on any Apple II with 48K. -->
+
+		<part name="flop1" interface="floppy_5_25">
+			<dataarea name="flop" size="181581">
+				<rom name="The Queen of Phobos.woz" size="181581" crc="6c31a42a" sha1="7617ff8f126edaab1daf8954ea7d6cac07bb1e77" />
+			</dataarea>
+		</part>
+	</software>
+
 </softwarelist>


### PR DESCRIPTION
Adds several new WOZ originals, three versions of AppleWorks in the misc disks section, and some small metadata corrections.