### PR TITLE
gp9001.cpp : Updates

### DIFF
--- a/src/mame/drivers/toaplan2.cpp
+++ b/src/mame/drivers/toaplan2.cpp
@@ -4095,6 +4095,7 @@ void toaplan2_state::batrider(machine_config &config)
 
 	GP9001_VDP(config, m_vdp[0], 27_MHz_XTAL);
 	m_vdp[0]->set_palette(m_palette);
+	m_vdp[0]->set_tile_callback(gp9001vdp_device::gp9001_cb_delegate(FUNC(toaplan2_state::batrider_bank_cb), this));
 	m_vdp[0]->vint_out_cb().set_inputline(m_maincpu, M68K_IRQ_2);
 
 	MCFG_VIDEO_START_OVERRIDE(toaplan2_state,batrider)
@@ -4162,6 +4163,7 @@ void toaplan2_state::bbakraid(machine_config &config)
 
 	GP9001_VDP(config, m_vdp[0], 27_MHz_XTAL);
 	m_vdp[0]->set_palette(m_palette);
+	m_vdp[0]->set_tile_callback(gp9001vdp_device::gp9001_cb_delegate(FUNC(toaplan2_state::batrider_bank_cb), this));
 	m_vdp[0]->vint_out_cb().set_inputline(m_maincpu, M68K_IRQ_1);
 
 	MCFG_VIDEO_START_OVERRIDE(toaplan2_state,batrider)

--- a/src/mame/includes/toaplan2.h
+++ b/src/mame/includes/toaplan2.h
@@ -123,6 +123,7 @@ private:
 	uint8_t m_v25_reset_line; /* 0x20 for dogyuun/batsugun, 0x10 for vfive, 0x08 for fixeight */
 	uint8_t m_sndirq_line;        /* IRQ4 for batrider, IRQ2 for bbakraid */
 	uint8_t m_z80_busreq;
+	uint16_t m_gfxrom_bank[8];       /* Batrider object bank */
 
 	bitmap_ind8 m_custom_priority_bitmap;
 	bitmap_ind16 m_secondary_render_bitmap;
@@ -160,6 +161,7 @@ private:
 	DECLARE_WRITE16_MEMBER(batrider_textdata_dma_w);
 	DECLARE_WRITE16_MEMBER(batrider_pal_text_dma_w);
 	DECLARE_WRITE8_MEMBER(batrider_objectbank_w);
+	void batrider_bank_cb(u8 layer, u32 &code);
 
 	template<int Chip> DECLARE_WRITE8_MEMBER(oki_bankswitch_w);
 	DECLARE_WRITE16_MEMBER(enmadaio_oki_bank_w);

--- a/src/mame/video/gp9001.cpp
+++ b/src/mame/video/gp9001.cpp
@@ -174,17 +174,6 @@ void gp9001vdp_device::map(address_map &map)
 //  map(0x3800, 0x3fff).ram(); // sprite mirror?
 }
 
-static const gfx_layout layout =
-{
-	8,8,            /* 8x8 */
-	RGN_FRAC(1,2),  /* Number of 8x8 sprites */
-	4,              /* 4 bits per pixel */
-	{ RGN_FRAC(1,2)+8, RGN_FRAC(1,2), 8, 0 },
-	{ STEP8(0,1) },
-	{ STEP8(0,8*2) },
-	8*8*2
-};
-
 // each 16x16 tile is actually 4 8x8 tile groups.
 static const gfx_layout layout_16x16 =
 {
@@ -197,9 +186,20 @@ static const gfx_layout layout_16x16 =
 	16*16*2
 };
 
+static const gfx_layout layout =
+{
+	8,8,            /* 8x8 */
+	RGN_FRAC(1,2),  /* Number of 8x8 sprites */
+	4,              /* 4 bits per pixel */
+	{ RGN_FRAC(1,2)+8, RGN_FRAC(1,2), 8, 0 },
+	{ STEP8(0,1) },
+	{ STEP8(0,8*2) },
+	8*8*2
+};
+
 GFXDECODE_MEMBER( gp9001vdp_device::gfxinfo )
-	GFXDECODE_DEVICE( DEVICE_SELF, 0, layout,       0, 0x1000 )
 	GFXDECODE_DEVICE( DEVICE_SELF, 0, layout_16x16, 0, 0x1000 )
+	GFXDECODE_DEVICE( DEVICE_SELF, 0, layout,       0, 0x1000 )
 GFXDECODE_END
 
 
@@ -239,7 +239,7 @@ TILE_GET_INFO_MEMBER(gp9001vdp_device::get_tile_info)
 	}
 
 	const u32 color = attrib & 0x0fff; // 0x0f00 priority, 0x007f colour
-	SET_TILE_INFO_MEMBER(1,
+	SET_TILE_INFO_MEMBER(0,
 			tile_number,
 			color,
 			0);
@@ -629,8 +629,8 @@ void gp9001vdp_device::draw_sprites( bitmap_ind16 &bitmap, const rectangle &clip
 {
 	const u16 *source = (m_sp.use_sprite_buffer) ? m_spriteram->buffer() : m_spriteram->live();
 
-	const u32 total_elements = gfx(0)->elements();
-	const u32 total_colors = gfx(0)->colors();
+	const u32 total_elements = gfx(1)->elements();
+	const u32 total_colors = gfx(1)->colors();
 
 	int old_x = (-(m_sp.scrollx)) & 0x1ff;
 	int old_y = (-(m_sp.scrolly)) & 0x1ff;
@@ -727,7 +727,7 @@ void gp9001vdp_device::draw_sprites( bitmap_ind16 &bitmap, const rectangle &clip
 					color %= total_colors;
 					const pen_t *paldata = &palette().pen(color * 16);
 					{
-						const u8* srcdata = gfx(0)->get_data(sprite);
+						const u8* srcdata = gfx(1)->get_data(sprite);
 						int count = 0;
 						int ystart, yend, yinc;
 						int xstart, xend, xinc;

--- a/src/mame/video/gp9001.h
+++ b/src/mame/video/gp9001.h
@@ -70,7 +70,6 @@ protected:
 
 	address_space_config        m_space_config;
 
-	TILEMAP_MAPPER_MEMBER(gp9001_scan_rows);
 	template<int Layer> TILE_GET_INFO_MEMBER(get_tile_info);
 
 private:
@@ -124,7 +123,6 @@ private:
 		bool use_sprite_buffer;
 	};
 
-	static const gfx_layout layout;
 	DECLARE_GFXDECODE_MEMBER(gfxinfo);
 
 	void voffs_w(u16 data, u16 mem_mask = ~0);

--- a/src/mame/video/gp9001.h
+++ b/src/mame/video/gp9001.h
@@ -19,12 +19,15 @@ class gp9001vdp_device : public device_t,
 	};
 
 public:
-	gp9001vdp_device(const machine_config &mconfig, const char *tag, device_t *owner, uint32_t clock);
+	gp9001vdp_device(const machine_config &mconfig, const char *tag, device_t *owner, u32 clock);
+
+	typedef device_delegate<void (u8 layer, u32 &code)> gp9001_cb_delegate;
+	void set_tile_callback(gp9001_cb_delegate cb) { m_gp9001_cb = cb; }
 
 	auto vint_out_cb() { return m_vint_out_cb.bind(); }
 
-	void draw_sprites(bitmap_ind16 &bitmap, const rectangle &cliprect, const uint8_t* primap);
-	void draw_custom_tilemap(bitmap_ind16 &bitmap, const rectangle &cliprect, int layer, const uint8_t* priremap, const uint8_t* pri_enable);
+	void draw_sprites(bitmap_ind16 &bitmap, const rectangle &cliprect, const u8* primap);
+	void draw_custom_tilemap(bitmap_ind16 &bitmap, const rectangle &cliprect, int layer, const u8* priremap, const u8* pri_enable);
 	void render_vdp(bitmap_ind16 &bitmap, const rectangle &cliprect);
 	void screen_eof();
 	void create_tilemaps();
@@ -40,30 +43,22 @@ public:
 	void set_sp_extra_offsets(int xn, int yn, int xf, int yf) { m_sp.set_extra_offsets(xn, yn, xf, yf); }
 
 	// ROM banking control
-	void set_gfxrom_banked() { m_gfxrom_is_banked = true; }
-	void set_gfxrom_bank(unsigned index, uint16_t value)
-	{
-		if (m_gfxrom_bank[index] !=  value)
-		{
-			m_gfxrom_bank[index] = value;
-			m_gfxrom_bank_dirty = true;
-		}
-	}
+	void set_dirty() { m_gfxrom_bank_dirty = true; }
 
 	// access to VDP
-	uint16_t read(offs_t offset, u16 mem_mask);
-	void write(offs_t offset, u16 data, u16 mem_mask);
+	u16 read(offs_t offset, u16 mem_mask = ~0);
+	void write(offs_t offset, u16 data, u16 mem_mask = ~0);
 
 	DECLARE_READ_LINE_MEMBER(hsync_r);
 	DECLARE_READ_LINE_MEMBER(vsync_r);
 	DECLARE_READ_LINE_MEMBER(fblank_r);
 
 	// this bootleg has strange access
-	DECLARE_READ16_MEMBER(pipibibi_bootleg_videoram16_r);
-	DECLARE_WRITE16_MEMBER(pipibibi_bootleg_videoram16_w);
-	DECLARE_READ16_MEMBER(pipibibi_bootleg_spriteram16_r);
-	DECLARE_WRITE16_MEMBER(pipibibi_bootleg_spriteram16_w);
-	DECLARE_WRITE16_MEMBER(pipibibi_bootleg_scroll_w);
+	u16 pipibibi_bootleg_videoram16_r(offs_t offset);
+	void pipibibi_bootleg_videoram16_w(offs_t offset, u16 data, u16 mem_mask = ~0);
+	u16 pipibibi_bootleg_spriteram16_r(offs_t offset);
+	void pipibibi_bootleg_spriteram16_w(offs_t offset, u16 data, u16 mem_mask = ~0);
+	void pipibibi_bootleg_scroll_w(offs_t offset, u16 data, u16 mem_mask = ~0);
 
 protected:
 	virtual void device_add_mconfig(machine_config &config) override;
@@ -75,11 +70,12 @@ protected:
 
 	address_space_config        m_space_config;
 
+	TILEMAP_MAPPER_MEMBER(gp9001_scan_rows);
 	template<int Layer> TILE_GET_INFO_MEMBER(get_tile_info);
 
 private:
 	// internal handlers
-	template<int Layer> DECLARE_WRITE16_MEMBER(tmap_w);
+	template<int Layer> void tmap_w(offs_t offset, u16 data, u16 mem_mask = ~0);
 
 	static constexpr unsigned BG_VRAM_SIZE   = 0x1000;   /* Background RAM size */
 	static constexpr unsigned FG_VRAM_SIZE   = 0x1000;   /* Foreground RAM size */
@@ -104,9 +100,9 @@ private:
 			extra_yoffset.flipped = yf;
 		}
 
-		uint16_t flip;
-		uint16_t scrollx;
-		uint16_t scrolly;
+		u16 flip;
+		u16 scrollx;
+		u16 scrolly;
 
 		gp9001layeroffsets extra_xoffset;
 		gp9001layeroffsets extra_yoffset;
@@ -114,41 +110,32 @@ private:
 
 	struct tilemaplayer : gp9001layer
 	{
-		void set_scrollx_and_flip_reg(uint16_t data, uint16_t mem_mask, bool f);
-		void set_scrolly_and_flip_reg(uint16_t data, uint16_t mem_mask, bool f);
+		void set_scrollx_and_flip_reg(u16 data, u16 mem_mask, bool f);
+		void set_scrolly_and_flip_reg(u16 data, u16 mem_mask, bool f);
 
 		tilemap_t *tmap;
 	};
 
 	struct spritelayer : gp9001layer
 	{
-		void set_scrollx_and_flip_reg(uint16_t data, uint16_t mem_mask, bool f);
-		void set_scrolly_and_flip_reg(uint16_t data, uint16_t mem_mask, bool f);
+		void set_scrollx_and_flip_reg(u16 data, u16 mem_mask, bool f);
+		void set_scrolly_and_flip_reg(u16 data, u16 mem_mask, bool f);
 
 		bool use_sprite_buffer;
 	};
 
-	int get_tile_number(int layer, int index)
-	{
-		uint16_t const value = m_vram[layer][(index << 1) | 1];
-		if (m_gfxrom_is_banked)
-			return (m_gfxrom_bank[(value >> 13) & 7] << 13) | (value & 0x1fff);
-		else
-			return value;
-	}
-
-	static const gfx_layout tilelayout, spritelayout;
+	static const gfx_layout layout;
 	DECLARE_GFXDECODE_MEMBER(gfxinfo);
 
-	void voffs_w(uint16_t data, uint16_t mem_mask);
+	void voffs_w(u16 data, u16 mem_mask = ~0);
 	int videoram16_r(void);
-	void videoram16_w(uint16_t data, uint16_t mem_mask);
-	uint16_t vdpstatus_r(void);
-	void scroll_reg_select_w(uint16_t data, uint16_t mem_mask);
-	void scroll_reg_data_w(uint16_t data, uint16_t mem_mask);
+	void videoram16_w(u16 data, u16 mem_mask = ~0);
+	u16 vdpstatus_r(void);
+	void scroll_reg_select_w(u16 data, u16 mem_mask = ~0);
+	void scroll_reg_data_w(u16 data, u16 mem_mask = ~0);
 
-	uint16_t m_voffs;
-	uint16_t m_scroll_reg;
+	u16 m_voffs;
+	u16 m_scroll_reg;
 
 	tilemaplayer m_tm[3];
 	spritelayer m_sp;
@@ -156,13 +143,12 @@ private:
 	// technically this is just rom banking, allowing the chip to see more graphic ROM, however it's easier to handle it
 	// in the chip implementation than externally for now (which would require dynamic decoding of the entire charsets every
 	// time the bank was changed)
-	bool m_gfxrom_is_banked;
 	bool m_gfxrom_bank_dirty;       /* dirty flag of object bank (for Batrider) */
-	uint16_t m_gfxrom_bank[8];       /* Batrider object bank */
 
-	required_shared_ptr_array<uint16_t, 3> m_vram;
+	required_shared_ptr_array<u16, 3> m_vram;
 	required_device<buffered_spriteram16_device> m_spriteram;
 
+	gp9001_cb_delegate m_gp9001_cb;
 	devcb_write_line m_vint_out_cb;
 	emu_timer *m_raise_irq_timer;
 };

--- a/src/mame/video/toaplan2.cpp
+++ b/src/mame/video/toaplan2.cpp
@@ -89,7 +89,7 @@ VIDEO_START_MEMBER(toaplan2_state,toaplan2)
 
 VIDEO_START_MEMBER(toaplan2_state,truxton2)
 {
-	VIDEO_START_CALL_MEMBER( toaplan2 );
+	VIDEO_START_CALL_MEMBER(toaplan2);
 
 	/* Create the Text tilemap for this game */
 	m_gfxdecode->gfx(0)->set_source(reinterpret_cast<uint8_t *>(m_tx_gfxram.target()));
@@ -99,15 +99,15 @@ VIDEO_START_MEMBER(toaplan2_state,truxton2)
 
 VIDEO_START_MEMBER(toaplan2_state,fixeightbl)
 {
-	VIDEO_START_CALL_MEMBER( toaplan2 );
+	VIDEO_START_CALL_MEMBER(toaplan2);
 
 	/* Create the Text tilemap for this game */
 	create_tx_tilemap();
 
 	/* This bootleg has additional layer offsets on the VDP */
-	m_vdp[0]->set_tm_extra_offsets(0, -0x1d6 - 26, -0x1ef - 15, 0, 0 );
-	m_vdp[0]->set_tm_extra_offsets(1, -0x1d8 - 22, -0x1ef - 15, 0, 0 );
-	m_vdp[0]->set_tm_extra_offsets(2, -0x1da - 18, -0x1ef - 15, 0, 0 );
+	m_vdp[0]->set_tm_extra_offsets(0, -0x1d6 - 26, -0x1ef - 15, 0, 0);
+	m_vdp[0]->set_tm_extra_offsets(1, -0x1d8 - 22, -0x1ef - 15, 0, 0);
+	m_vdp[0]->set_tm_extra_offsets(2, -0x1da - 18, -0x1ef - 15, 0, 0);
 	m_vdp[0]->set_sp_extra_offsets(8/*-0x1cc - 64*/, 8/*-0x1ef - 128*/, 0, 0);
 
 	m_vdp[0]->init_scroll_regs();
@@ -115,7 +115,7 @@ VIDEO_START_MEMBER(toaplan2_state,fixeightbl)
 
 VIDEO_START_MEMBER(toaplan2_state,bgaregga)
 {
-	VIDEO_START_CALL_MEMBER( toaplan2 );
+	VIDEO_START_CALL_MEMBER(toaplan2);
 
 	/* Create the Text tilemap for this game */
 	create_tx_tilemap(0x1d4, 0x16b);
@@ -123,7 +123,7 @@ VIDEO_START_MEMBER(toaplan2_state,bgaregga)
 
 VIDEO_START_MEMBER(toaplan2_state,bgareggabl)
 {
-	VIDEO_START_CALL_MEMBER( toaplan2 );
+	VIDEO_START_CALL_MEMBER(toaplan2);
 
 	/* Create the Text tilemap for this game */
 	create_tx_tilemap(4, 4);
@@ -131,7 +131,7 @@ VIDEO_START_MEMBER(toaplan2_state,bgareggabl)
 
 VIDEO_START_MEMBER(toaplan2_state,batrider)
 {
-	VIDEO_START_CALL_MEMBER( toaplan2 );
+	VIDEO_START_CALL_MEMBER(toaplan2);
 
 	m_vdp[0]->disable_sprite_buffer(); // disable buffering on this game
 
@@ -141,7 +141,7 @@ VIDEO_START_MEMBER(toaplan2_state,batrider)
 	create_tx_tilemap(0x1d4, 0x16b);
 
 	/* Has special banking */
-	m_vdp[0]->set_gfxrom_banked();
+	save_item(NAME(m_gfxrom_bank));
 }
 
 WRITE16_MEMBER(toaplan2_state::tx_videoram_w)
@@ -210,9 +210,18 @@ WRITE16_MEMBER(toaplan2_state::batrider_pal_text_dma_w)
 
 WRITE8_MEMBER(toaplan2_state::batrider_objectbank_w)
 {
-	m_vdp[0]->set_gfxrom_bank(offset, data & 0x0f);
+	data &= 0xf;
+	if (m_gfxrom_bank[offset] != data)
+	{
+		m_gfxrom_bank[offset] = data;
+		m_vdp[0]->set_dirty();
+	}
 }
 
+void toaplan2_state::batrider_bank_cb(u8 layer, u32 &code)
+{
+	code = (m_gfxrom_bank[code >> 15] << 15) | (code & 0x7fff);
+}
 
 // Dogyuun doesn't appear to require fancy mixing?
 uint32_t toaplan2_state::screen_update_dogyuun(screen_device &screen, bitmap_ind16 &bitmap, const rectangle &cliprect)
@@ -370,7 +379,6 @@ uint32_t toaplan2_state::screen_update_truxton2(screen_device &screen, bitmap_in
 	}
 	return 0;
 }
-
 
 
 WRITE_LINE_MEMBER(toaplan2_state::screen_vblank)


### PR DESCRIPTION
Simplify handlers, gfxdecodes, Correct tilemap behavior (each tiles are grouped 4 8x8 tile), Use callback for gfx bankswitching behavior, Use shorter / correct type values
toaplan2.cpp : Fix spacing, Reduce unnecessary lines