### PR TITLE
toaplan2.cpp : Updates

### DIFF
--- a/src/mame/drivers/toaplan2.cpp
+++ b/src/mame/drivers/toaplan2.cpp
@@ -445,21 +445,35 @@ MACHINE_RESET_MEMBER(toaplan2_state,ghox)
 }
 
 
+MACHINE_RESET_MEMBER(toaplan2_state,bgaregga)
+{
+	MACHINE_RESET_CALL_MEMBER(toaplan2);
+	for (int chip = 0; chip < 2; chip++)
+	{
+		for (int i = 0; i < 8; i++)
+		{
+			if (m_raizing_okibank[chip][i] != nullptr)
+				m_raizing_okibank[chip][i]->set_entry(0);
+		}
+	}
+}
+
+
 void toaplan2_state::init_dogyuun()
 {
-	m_v25_reset_line = 0x20;
+	m_sound_reset_bit = 0x20;
 }
 
 
 void toaplan2_state::init_fixeight()
 {
-	m_v25_reset_line = 0x08;
+	m_sound_reset_bit = 0x08;
 }
 
 
 void toaplan2_state::init_fixeightbl()
 {
-	uint8_t *ROM = memregion("oki1")->base();
+	u8 *ROM = memregion("oki1")->base();
 
 	m_okibank->configure_entries(0, 5, &ROM[0x30000], 0x10000);
 }
@@ -467,13 +481,13 @@ void toaplan2_state::init_fixeightbl()
 
 void toaplan2_state::init_vfive()
 {
-	m_v25_reset_line = 0x10;
+	m_sound_reset_bit = 0x10;
 }
 
 
 void toaplan2_state::init_pipibibsbl()
 {
-	uint16_t *ROM = (uint16_t *)(memregion("maincpu")->base());
+	u16 *ROM = (u16 *)(memregion("maincpu")->base());
 
 	for (int i = 0; i < (0x040000/2); i += 4)
 	{
@@ -484,21 +498,38 @@ void toaplan2_state::init_pipibibsbl()
 	}
 }
 
+void toaplan2_state::install_raizing_okibank(int chip)
+{
+	assert(m_oki_rom[chip] && m_raizing_okibank[chip][0]);
+
+	for (int i = 0; i < 4; i++)
+	{
+		m_raizing_okibank[chip][i]->configure_entries(0, 16, &m_oki_rom[chip][(i * 0x100)], 0x10000);
+	}
+	m_raizing_okibank[chip][4]->configure_entries(0, 16, &m_oki_rom[chip][0x400], 0x10000);
+	for (int i = 5; i < 8; i++)
+	{
+		m_raizing_okibank[chip][i]->configure_entries(0, 16, &m_oki_rom[chip][0], 0x10000);
+	}
+}
 
 void toaplan2_state::init_bgaregga()
 {
-	uint8_t *Z80 = memregion("audiocpu")->base();
+	u8 *Z80 = memregion("audiocpu")->base();
 
 	m_audiobank->configure_entries(0, 8, Z80, 0x4000); // Test mode only, Mirror of First 128KB Areas?
 	m_audiobank->configure_entries(8, 8, Z80, 0x4000);
+	install_raizing_okibank(0);
 }
 
 
 void toaplan2_state::init_batrider()
 {
-	uint8_t *Z80 = memregion("audiocpu")->base();
+	u8 *Z80 = memregion("audiocpu")->base();
 
 	m_audiobank->configure_entries(0, 16, Z80, 0x4000);
+	install_raizing_okibank(0);
+	install_raizing_okibank(1);
 	m_sndirq_line = 4;
 }
 
@@ -510,12 +541,11 @@ void toaplan2_state::init_bbakraid()
 
 void toaplan2_state::init_enmadaio()
 {
-	uint8_t *ROM = memregion("oki1")->base();
+	u8 *ROM = memregion("oki1")->base();
 
 	m_okibank->configure_entries(0, 0x60, ROM, 0x40000);
 	m_okibank->set_entry(0);
 }
-
 
 
 /***************************************************************************
@@ -535,7 +565,7 @@ void toaplan2_state::cpu_space_pipibibsbl_map(address_map &map)
 }
 
 
-READ16_MEMBER(toaplan2_state::video_count_r)
+u16 toaplan2_state::video_count_r()
 {
 	/* +---------+---------+--------+---------------------------+ */
 	/* | /H-Sync | /V-Sync | /Blank |       Scanline Count      | */
@@ -545,7 +575,7 @@ READ16_MEMBER(toaplan2_state::video_count_r)
 
 	int vpos = m_screen->vpos();
 
-	int video_status = 0xff00;    // Set signals inactive
+	u16 video_status = 0xff00;    // Set signals inactive
 
 	vpos = (vpos + 15) % 262;
 
@@ -566,7 +596,7 @@ READ16_MEMBER(toaplan2_state::video_count_r)
 }
 
 
-WRITE8_MEMBER(toaplan2_state::toaplan2_coin_w)
+void toaplan2_state::coin_w(u8 data)
 {
 	/* +----------------+------ Bits 7-5 not used ------+--------------+ */
 	/* | Coin Lockout 2 | Coin Lockout 1 | Coin Count 2 | Coin Count 1 | */
@@ -574,93 +604,62 @@ WRITE8_MEMBER(toaplan2_state::toaplan2_coin_w)
 
 	if (data & 0x0f)
 	{
-		machine().bookkeeping().coin_lockout_w(0, ((data & 4) ? 0 : 1) );
-		machine().bookkeeping().coin_lockout_w(1, ((data & 8) ? 0 : 1) );
-		machine().bookkeeping().coin_counter_w(0, (data & 1) );
-		machine().bookkeeping().coin_counter_w(1, (data & 2) );
+		machine().bookkeeping().coin_lockout_w(0, BIT(~data, 2));
+		machine().bookkeeping().coin_lockout_w(1, BIT(~data, 3));
+		machine().bookkeeping().coin_counter_w(0, BIT( data, 0));
+		machine().bookkeeping().coin_counter_w(1, BIT( data, 1));
 	}
 	else
 	{
 		machine().bookkeeping().coin_lockout_global_w(1);    // Lock all coin slots
 	}
-	if (data & 0xe0)
+	if (data & 0xf0)
 	{
 		logerror("Writing unknown upper bits (%02x) to coin control\n",data);
 	}
 }
 
-WRITE8_MEMBER(toaplan2_state::pwrkick_coin_w)
+void toaplan2_state::pwrkick_coin_w(u8 data)
 {
-	machine().bookkeeping().coin_counter_w(0, (data & 2) >> 1 ); // medal
-	machine().bookkeeping().coin_counter_w(1, (data & 8) >> 3 ); // 10 yen
-	machine().bookkeeping().coin_counter_w(2, (data & 1) ); // 100 yen
+	machine().bookkeeping().coin_counter_w(0, BIT(data, 1)); // medal
+	machine().bookkeeping().coin_counter_w(1, BIT(data, 3)); // 10 yen
+	machine().bookkeeping().coin_counter_w(2, BIT(data, 0)); // 100 yen
 	m_hopper->motor_w(BIT(data, 7));
 }
 
-WRITE8_MEMBER(toaplan2_state::pwrkick_coin_lockout_w)
+void toaplan2_state::pwrkick_coin_lockout_w(u8 data)
 {
-	machine().bookkeeping().coin_lockout_w(0, (data & 4) ? 0 : 1);
-	machine().bookkeeping().coin_lockout_w(1, (data & 4) ? 0 : 1);
-	machine().bookkeeping().coin_lockout_w(2, (data & 2) ? 0 : 1);
+	machine().bookkeeping().coin_lockout_w(0, BIT(~data, 2));
+	machine().bookkeeping().coin_lockout_w(1, BIT(~data, 2));
+	machine().bookkeeping().coin_lockout_w(2, BIT(~data, 1));
 }
 
 
-WRITE16_MEMBER(toaplan2_state::toaplan2_coin_word_w)
+void toaplan2_state::coin_sound_reset_w(u8 data)
 {
-	if (ACCESSING_BITS_0_7)
-	{
-		toaplan2_coin_w(space, offset, data & 0xff);
-	}
-	if (ACCESSING_BITS_8_15 && (data & 0xff00) )
-	{
-		logerror("Writing unknown upper MSB command (%04x) to coin control\n",data & 0xff00);
-	}
+	logerror("coin_sound_reset_w %02x\n",data);
+
+	coin_w(data & ~m_sound_reset_bit);
+	sound_reset_w(data & m_sound_reset_bit);
 }
 
 
-WRITE16_MEMBER(toaplan2_state::toaplan2_v25_coin_word_w)
+void toaplan2_state::shippumd_coin_w(u8 data)
 {
-	logerror("toaplan2_v25_coin_word_w %04x\n",data);
-
-	if (ACCESSING_BITS_0_7)
-	{
-		toaplan2_coin_w(space, offset, data & 0x0f);
-
-		m_audiocpu->set_input_line(INPUT_LINE_RESET,  (data & m_v25_reset_line) ? CLEAR_LINE : ASSERT_LINE);
-	}
-	if (ACCESSING_BITS_8_15 && (data & 0xff00) )
-	{
-		logerror("Writing unknown upper MSB command (%04x) to coin control\n",data & 0xff00);
-	}
+	coin_w(data & ~0x10);
+	m_oki[0]->set_rom_bank(BIT(data, 4));
 }
 
 
-WRITE16_MEMBER(toaplan2_state::shippumd_coin_word_w)
-{
-	if (ACCESSING_BITS_0_7)
-	{
-		toaplan2_coin_w(space, offset, data & 0xff);
-		m_oki[0]->set_rom_bank((data & 0x10) >> 4);
-	}
-	if (ACCESSING_BITS_8_15 && (data & 0xff00) )
-	{
-		logerror("Writing unknown upper MSB command (%04x) to coin control\n",data & 0xff00);
-	}
-}
-
-
-READ16_MEMBER(toaplan2_state::shared_ram_r)
+u8 toaplan2_state::shared_ram_r(offs_t offset)
 {
 	return m_shared_ram[offset];
 }
 
 
-WRITE16_MEMBER(toaplan2_state::shared_ram_w)
+void toaplan2_state::shared_ram_w(offs_t offset, u8 data)
 {
-	if (ACCESSING_BITS_0_7)
-	{
-		m_shared_ram[offset] = data;
-	}
+	m_shared_ram[offset] = data;
 }
 
 
@@ -674,41 +673,39 @@ CUSTOM_INPUT_MEMBER(toaplan2_state::c2map_r)
 }
 
 
-READ16_MEMBER(toaplan2_state::ghox_p1_h_analog_r)
+u16 toaplan2_state::ghox_p1_h_analog_r()
 {
-	int8_t value, new_value;
-
-	new_value = ioport("PAD1")->read();
+	const s8 new_value = m_io_pad[0]->read();
 	if (new_value == m_old_p1_paddle_h) return 0;
-	value = new_value - m_old_p1_paddle_h;
-	m_old_p1_paddle_h = new_value;
+	const s8 value = new_value - m_old_p1_paddle_h;
+	if (!machine().side_effects_disabled())
+		m_old_p1_paddle_h = new_value;
 	return value;
 }
 
 
-READ16_MEMBER(toaplan2_state::ghox_p2_h_analog_r)
+u16 toaplan2_state::ghox_p2_h_analog_r()
 {
-	int8_t value, new_value;
-
-	new_value = ioport("PAD2")->read();
+	const s8 new_value = m_io_pad[1]->read();
 	if (new_value == m_old_p2_paddle_h) return 0;
-	value = new_value - m_old_p2_paddle_h;
-	m_old_p2_paddle_h = new_value;
+	const s8 value = new_value - m_old_p2_paddle_h;
+	if (!machine().side_effects_disabled())
+		m_old_p2_paddle_h = new_value;
 	return value;
 }
 
-WRITE16_MEMBER(toaplan2_state::fixeight_subcpu_ctrl_w)
+void toaplan2_state::sound_reset_w(u8 data)
 {
-	m_audiocpu->set_input_line(INPUT_LINE_RESET, (data & m_v25_reset_line) ? CLEAR_LINE : ASSERT_LINE);
+	m_audiocpu->set_input_line(INPUT_LINE_RESET, (data & m_sound_reset_bit) ? CLEAR_LINE : ASSERT_LINE);
 }
 
 template<int Chip>
-WRITE8_MEMBER(toaplan2_state::oki_bankswitch_w)
+void toaplan2_state::oki_bankswitch_w(u8 data)
 {
 	m_oki[Chip]->set_rom_bank(data & 1);
 }
 
-WRITE8_MEMBER(toaplan2_state::fixeightbl_oki_bankswitch_w)
+void toaplan2_state::fixeightbl_oki_bankswitch_w(u8 data)
 {
 	data &= 7;
 	if (data <= 4) m_okibank->set_entry(data);
@@ -720,7 +717,7 @@ WRITE8_MEMBER(toaplan2_state::fixeightbl_oki_bankswitch_w)
 ***************************************************************************/
 
 
-WRITE8_MEMBER(toaplan2_state::raizing_z80_bankswitch_w)
+void toaplan2_state::raizing_z80_bankswitch_w(u8 data)
 {
 	m_audiobank->set_entry(data & 0x0f);
 }
@@ -731,14 +728,18 @@ WRITE8_MEMBER(toaplan2_state::raizing_z80_bankswitch_w)
 // it may not be a coincidence that the composer and sound designer for
 // these two games, Manabu "Santaruru" Namiki, came to Raizing from NMK...
 
-WRITE8_MEMBER(toaplan2_state::raizing_oki_bankswitch_w)
+void toaplan2_state::raizing_oki_bankswitch_w(offs_t offset, u8 data)
 {
-	m_nmk112->okibank_w(offset, data & 0x0f);
-	m_nmk112->okibank_w(offset + 1, (data >> 4) & 0x0f);
+	m_raizing_okibank[(offset & 4) >> 2][offset & 3]->set_entry(data & 0xf);
+	m_raizing_okibank[(offset & 4) >> 2][4 + (offset & 3)]->set_entry(data & 0xf);
+	offset++;
+	data >>= 4;
+	m_raizing_okibank[(offset & 4) >> 2][offset & 3]->set_entry(data & 0xf);
+	m_raizing_okibank[(offset & 4) >> 2][4 + (offset & 3)]->set_entry(data & 0xf);
 }
 
 
-READ8_MEMBER(toaplan2_state::bgaregga_E01D_r)
+u8 toaplan2_state::bgaregga_E01D_r()
 {
 	// the Z80 reads this address during its IRQ routine,
 	// and reads the soundlatch only if the lowest bit is clear.
@@ -746,50 +747,49 @@ READ8_MEMBER(toaplan2_state::bgaregga_E01D_r)
 }
 
 
-READ16_MEMBER(toaplan2_state::batrider_z80_busack_r)
+u16 toaplan2_state::batrider_z80_busack_r()
 {
 	// Bit 0x01 returns the status of BUSAK from the Z80.
 	// These accesses are made when the 68K wants to read the Z80
 	// ROM code. Failure to return the correct status incurrs a Sound Error.
 
-
 	return m_z80_busreq;    // Loop BUSRQ to BUSAK
 }
 
 
-WRITE8_MEMBER(toaplan2_state::batrider_z80_busreq_w)
+void toaplan2_state::batrider_z80_busreq_w(u8 data)
 {
 	m_z80_busreq = (data & 0x01);   // see batrider_z80_busack_r above
 }
 
 
-READ16_MEMBER(toaplan2_state::batrider_z80rom_r)
+u16 toaplan2_state::batrider_z80rom_r(offs_t offset)
 {
 	return m_z80_rom[offset];
 }
 
 // these two latches are always written together, via a single move.l instruction
-WRITE8_MEMBER(toaplan2_state::batrider_soundlatch_w)
+void toaplan2_state::batrider_soundlatch_w(u8 data)
 {
 	m_soundlatch->write(data & 0xff);
 	m_audiocpu->set_input_line(INPUT_LINE_NMI, ASSERT_LINE);
 }
 
 
-WRITE8_MEMBER(toaplan2_state::batrider_soundlatch2_w)
+void toaplan2_state::batrider_soundlatch2_w(u8 data)
 {
 	m_soundlatch2->write(data & 0xff);
 	m_audiocpu->set_input_line(INPUT_LINE_NMI, ASSERT_LINE);
 }
 
-WRITE16_MEMBER(toaplan2_state::batrider_unknown_sound_w)
+void toaplan2_state::batrider_unknown_sound_w(u16 data)
 {
 	// the 68K writes here when it wants a sound acknowledge IRQ from the Z80
 	// for bbakraid this is on every sound command; for batrider, only on certain commands
 }
 
 
-WRITE16_MEMBER(toaplan2_state::batrider_clear_sndirq_w)
+void toaplan2_state::batrider_clear_sndirq_w(u16 data)
 {
 	// not sure whether this is correct
 	// the 68K writes here during the sound IRQ handler, and nowhere else...
@@ -797,27 +797,27 @@ WRITE16_MEMBER(toaplan2_state::batrider_clear_sndirq_w)
 }
 
 
-WRITE8_MEMBER(toaplan2_state::batrider_sndirq_w)
+void toaplan2_state::batrider_sndirq_w(u8 data)
 {
 	// if batrider_clear_sndirq_w() is correct, should this be ASSERT_LINE?
 	m_maincpu->set_input_line(m_sndirq_line, HOLD_LINE);
 }
 
 
-WRITE8_MEMBER(toaplan2_state::batrider_clear_nmi_w)
+void toaplan2_state::batrider_clear_nmi_w(u8 data)
 {
 	m_audiocpu->set_input_line(INPUT_LINE_NMI, CLEAR_LINE);
 }
 
 
-READ16_MEMBER(toaplan2_state::bbakraid_eeprom_r)
+u16 toaplan2_state::bbakraid_eeprom_r()
 {
 	// Bit 0x01 returns the status of BUSAK from the Z80.
 	// BUSRQ is activated via bit 0x10 on the EEPROM write port.
 	// These accesses are made when the 68K wants to read the Z80
 	// ROM code. Failure to return the correct status incurrs a Sound Error.
 
-	int data;
+	u8 data;
 	data  = ((m_eeprom->do_read() & 0x01) << 4);
 	data |= ((m_z80_busreq >> 4) & 0x01);   // Loop BUSRQ to BUSAK
 
@@ -825,13 +825,12 @@ READ16_MEMBER(toaplan2_state::bbakraid_eeprom_r)
 }
 
 
-WRITE16_MEMBER(toaplan2_state::bbakraid_eeprom_w)
+void toaplan2_state::bbakraid_eeprom_w(u8 data)
 {
-	if (data & ~0x001f)
-		logerror("CPU #0 PC:%06X - Unknown EEPROM data being written %04X\n",m_maincpu->pc(),data);
+	if (data & ~0x1f)
+		logerror("CPU #0 PC:%06X - Unknown EEPROM data being written %02X\n",m_maincpu->pc(),data);
 
-	if ( ACCESSING_BITS_0_7 )
-		ioport("EEPROMOUT")->write(data, 0xff);
+	m_eepromout->write(data, 0xff);
 
 	m_z80_busreq = data & 0x10; // see bbakraid_eeprom_r above
 }
@@ -841,7 +840,6 @@ INTERRUPT_GEN_MEMBER(toaplan2_state::bbakraid_snd_interrupt)
 {
 	device.execute().set_input_line(0, HOLD_LINE);
 }
-
 
 
 void toaplan2_state::tekipaki_68k_mem(address_map &map)
@@ -855,12 +853,11 @@ void toaplan2_state::tekipaki_68k_mem(address_map &map)
 	map(0x180010, 0x180011).portr("DSWB");
 	map(0x180020, 0x180021).portr("SYS");
 	map(0x180030, 0x180031).portr("JMPR");           // CPU 2 busy and Region Jumper block
-	map(0x180040, 0x180041).w(FUNC(toaplan2_state::toaplan2_coin_word_w));
+	map(0x180041, 0x180041).w(FUNC(toaplan2_state::coin_w));
 	map(0x180050, 0x180051).portr("IN1");
 	map(0x180060, 0x180061).portr("IN2");
 	map(0x180071, 0x180071).w(m_soundlatch, FUNC(generic_latch_8_device::write));
 }
-
 
 
 void toaplan2_state::ghox_68k_mem(address_map &map)
@@ -871,8 +868,8 @@ void toaplan2_state::ghox_68k_mem(address_map &map)
 	map(0x0c0000, 0x0c0fff).ram().w(m_palette, FUNC(palette_device::write16)).share("palette");
 	map(0x100000, 0x100001).r(FUNC(toaplan2_state::ghox_p1_h_analog_r));
 	map(0x140000, 0x14000d).rw(m_vdp[0], FUNC(gp9001vdp_device::read), FUNC(gp9001vdp_device::write));
-	map(0x180000, 0x180fff).rw(FUNC(toaplan2_state::shared_ram_r), FUNC(toaplan2_state::shared_ram_w));
-	map(0x181000, 0x181001).w(FUNC(toaplan2_state::toaplan2_coin_word_w));
+	map(0x180000, 0x180fff).rw(FUNC(toaplan2_state::shared_ram_r), FUNC(toaplan2_state::shared_ram_w)).umask16(0x00ff);
+	map(0x181001, 0x181001).w(FUNC(toaplan2_state::coin_w));
 	map(0x18100c, 0x18100d).portr("JMPR");
 }
 
@@ -884,8 +881,8 @@ void toaplan2_state::dogyuun_68k_mem(address_map &map)
 	map(0x200010, 0x200011).portr("IN1");
 	map(0x200014, 0x200015).portr("IN2");
 	map(0x200018, 0x200019).portr("SYS");
-	map(0x20001c, 0x20001d).w(FUNC(toaplan2_state::toaplan2_v25_coin_word_w)); // Coin count/lock + v25 reset line
-	map(0x210000, 0x21ffff).rw(FUNC(toaplan2_state::shared_ram_r), FUNC(toaplan2_state::shared_ram_w));
+	map(0x20001d, 0x20001d).w(FUNC(toaplan2_state::coin_sound_reset_w)); // Coin count/lock + v25 reset line
+	map(0x210000, 0x21ffff).rw(FUNC(toaplan2_state::shared_ram_r), FUNC(toaplan2_state::shared_ram_w)).umask16(0x00ff);
 	map(0x300000, 0x30000d).rw(m_vdp[0], FUNC(gp9001vdp_device::read), FUNC(gp9001vdp_device::write));
 	map(0x400000, 0x400fff).ram().w(m_palette, FUNC(palette_device::write16)).share("palette");
 	map(0x500000, 0x50000d).rw(m_vdp[1], FUNC(gp9001vdp_device::read), FUNC(gp9001vdp_device::write));
@@ -897,11 +894,11 @@ void toaplan2_state::kbash_68k_mem(address_map &map)
 {
 	map(0x000000, 0x07ffff).rom();
 	map(0x100000, 0x103fff).ram();
-	map(0x200000, 0x200fff).rw(FUNC(toaplan2_state::shared_ram_r), FUNC(toaplan2_state::shared_ram_w));
+	map(0x200000, 0x200fff).rw(FUNC(toaplan2_state::shared_ram_r), FUNC(toaplan2_state::shared_ram_w)).umask16(0x00ff);
 	map(0x208010, 0x208011).portr("IN1");
 	map(0x208014, 0x208015).portr("IN2");
 	map(0x208018, 0x208019).portr("SYS");
-	map(0x20801c, 0x20801d).w(FUNC(toaplan2_state::toaplan2_coin_word_w));
+	map(0x20801d, 0x20801d).w(FUNC(toaplan2_state::coin_w));
 	map(0x300000, 0x30000d).rw(m_vdp[0], FUNC(gp9001vdp_device::read), FUNC(gp9001vdp_device::write));
 	map(0x400000, 0x400fff).ram().w(m_palette, FUNC(palette_device::write16)).share("palette");
 	map(0x700000, 0x700001).r(FUNC(toaplan2_state::video_count_r));         // test bit 8
@@ -921,7 +918,7 @@ void toaplan2_state::kbash2_68k_mem(address_map &map)
 	map(0x200010, 0x200011).portr("IN1");
 	map(0x200014, 0x200015).portr("IN2");
 	map(0x200018, 0x200019).portr("SYS");
-	map(0x200021, 0x200021).rw("oki2", FUNC(okim6295_device::read), FUNC(okim6295_device::write));
+	map(0x200021, 0x200021).rw(m_oki[1], FUNC(okim6295_device::read), FUNC(okim6295_device::write));
 	map(0x200025, 0x200025).rw(m_oki[0], FUNC(okim6295_device::read), FUNC(okim6295_device::write));
 	map(0x200029, 0x200029).w(FUNC(toaplan2_state::oki_bankswitch_w<0>));
 	map(0x20002c, 0x20002d).r(FUNC(toaplan2_state::video_count_r));
@@ -950,7 +947,7 @@ void toaplan2_state::truxton2_68k_mem(address_map &map)
 	map(0x70000a, 0x70000b).portr("SYS");
 	map(0x700011, 0x700011).rw(m_oki[0], FUNC(okim6295_device::read), FUNC(okim6295_device::write));
 	map(0x700014, 0x700017).rw("ymsnd", FUNC(ym2151_device::read), FUNC(ym2151_device::write)).umask16(0x00ff);
-	map(0x70001e, 0x70001f).w(FUNC(toaplan2_state::toaplan2_coin_word_w));
+	map(0x70001f, 0x70001f).w(FUNC(toaplan2_state::coin_w));
 }
 
 
@@ -960,8 +957,8 @@ void toaplan2_state::pipibibs_68k_mem(address_map &map)
 	map(0x080000, 0x082fff).ram();
 	map(0x0c0000, 0x0c0fff).ram().w(m_palette, FUNC(palette_device::write16)).share("palette");
 	map(0x140000, 0x14000d).rw(m_vdp[0], FUNC(gp9001vdp_device::read), FUNC(gp9001vdp_device::write));
-	map(0x190000, 0x190fff).rw(FUNC(toaplan2_state::shared_ram_r), FUNC(toaplan2_state::shared_ram_w));
-	map(0x19c01c, 0x19c01d).w(FUNC(toaplan2_state::toaplan2_coin_word_w));
+	map(0x190000, 0x190fff).rw(FUNC(toaplan2_state::shared_ram_r), FUNC(toaplan2_state::shared_ram_w)).umask16(0x00ff);
+	map(0x19c01d, 0x19c01d).w(FUNC(toaplan2_state::coin_w));
 	map(0x19c020, 0x19c021).portr("DSWA");
 	map(0x19c024, 0x19c025).portr("DSWB");
 	map(0x19c028, 0x19c029).portr("JMPR");
@@ -979,12 +976,12 @@ void toaplan2_state::pipibibi_bootleg_68k_mem(address_map &map)
 	map(0x083800, 0x087fff).ram();             // SpriteRAM (unused)
 	map(0x0c0000, 0x0c0fff).ram().w(m_palette, FUNC(palette_device::write16)).share("palette");
 	map(0x120000, 0x120fff).ram();             // Copy of SpriteRAM ?
-//  AM_RANGE(0x13f000, 0x13f001) AM_WRITENOP        // ???
+//  map(0x13f000, 0x13f001).nopw();        // ???
 	map(0x180000, 0x182fff).rw(m_vdp[0], FUNC(gp9001vdp_device::pipibibi_bootleg_videoram16_r), FUNC(gp9001vdp_device::pipibibi_bootleg_videoram16_w)); // TileRAM
 	map(0x188000, 0x18800f).w(m_vdp[0], FUNC(gp9001vdp_device::pipibibi_bootleg_scroll_w));
-	map(0x190002, 0x190003).r(FUNC(toaplan2_state::shared_ram_r));  // Z80 ready ?
-	map(0x190010, 0x190011).w(FUNC(toaplan2_state::shared_ram_w)); // Z80 task to perform
-	map(0x19c01c, 0x19c01d).w(FUNC(toaplan2_state::toaplan2_coin_word_w));
+	map(0x190003, 0x190003).r(FUNC(toaplan2_state::shared_ram_r));  // Z80 ready ?
+	map(0x190011, 0x190011).w(FUNC(toaplan2_state::shared_ram_w)); // Z80 task to perform
+	map(0x19c01d, 0x19c01d).w(FUNC(toaplan2_state::coin_w));
 	map(0x19c020, 0x19c021).portr("DSWA");
 	map(0x19c024, 0x19c025).portr("DSWB");
 	map(0x19c028, 0x19c029).portr("JMPR");
@@ -1002,15 +999,15 @@ void toaplan2_state::fixeight_68k_mem(address_map &map)
 	map(0x200004, 0x200005).portr("IN2");
 	map(0x200008, 0x200009).portr("IN3");
 	map(0x200010, 0x200011).portr("SYS");
-	map(0x20001c, 0x20001d).w(FUNC(toaplan2_state::toaplan2_coin_word_w));
-	map(0x280000, 0x28ffff).rw(FUNC(toaplan2_state::shared_ram_r), FUNC(toaplan2_state::shared_ram_w));
+	map(0x20001d, 0x20001d).w(FUNC(toaplan2_state::coin_w));
+	map(0x280000, 0x28ffff).rw(FUNC(toaplan2_state::shared_ram_r), FUNC(toaplan2_state::shared_ram_w)).umask16(0x00ff);
 	map(0x300000, 0x30000d).rw(m_vdp[0], FUNC(gp9001vdp_device::read), FUNC(gp9001vdp_device::write));
 	map(0x400000, 0x400fff).ram().w(m_palette, FUNC(palette_device::write16)).share("palette");
 	map(0x500000, 0x501fff).ram().w(FUNC(toaplan2_state::tx_videoram_w)).share("tx_videoram");
 	map(0x502000, 0x5021ff).ram().share("tx_lineselect");
 	map(0x503000, 0x5031ff).ram().w(FUNC(toaplan2_state::tx_linescroll_w)).share("tx_linescroll");
 	map(0x600000, 0x60ffff).ram().w(FUNC(toaplan2_state::tx_gfxram_w)).share("tx_gfxram");
-	map(0x700000, 0x700001).w(FUNC(toaplan2_state::fixeight_subcpu_ctrl_w));
+	map(0x700000, 0x700001).w(FUNC(toaplan2_state::sound_reset_w)).umask16(0x00ff).cswidth(16);
 	map(0x800000, 0x800001).r(FUNC(toaplan2_state::video_count_r));
 }
 
@@ -1039,12 +1036,12 @@ void toaplan2_state::vfive_68k_mem(address_map &map)
 {
 	map(0x000000, 0x07ffff).rom();
 	map(0x100000, 0x103fff).ram();
-//  AM_RANGE(0x200000, 0x20ffff) AM_NOP // Read at startup by broken ROM checksum code - see notes
+//  map(0x200000, 0x20ffff).noprw(); // Read at startup by broken ROM checksum code - see notes
 	map(0x200010, 0x200011).portr("IN1");
 	map(0x200014, 0x200015).portr("IN2");
 	map(0x200018, 0x200019).portr("SYS");
-	map(0x20001c, 0x20001d).w(FUNC(toaplan2_state::toaplan2_v25_coin_word_w)); // Coin count/lock + v25 reset line
-	map(0x210000, 0x21ffff).rw(FUNC(toaplan2_state::shared_ram_r), FUNC(toaplan2_state::shared_ram_w));
+	map(0x20001d, 0x20001d).w(FUNC(toaplan2_state::coin_sound_reset_w)); // Coin count/lock + v25 reset line
+	map(0x210000, 0x21ffff).rw(FUNC(toaplan2_state::shared_ram_r), FUNC(toaplan2_state::shared_ram_w)).umask16(0x00ff);
 	map(0x300000, 0x30000d).rw(m_vdp[0], FUNC(gp9001vdp_device::read), FUNC(gp9001vdp_device::write));
 	map(0x400000, 0x400fff).ram().w(m_palette, FUNC(palette_device::write16)).share("palette");
 	map(0x700000, 0x700001).r(FUNC(toaplan2_state::video_count_r));
@@ -1058,8 +1055,8 @@ void toaplan2_state::batsugun_68k_mem(address_map &map)
 	map(0x200010, 0x200011).portr("IN1");
 	map(0x200014, 0x200015).portr("IN2");
 	map(0x200018, 0x200019).portr("SYS");
-	map(0x20001c, 0x20001d).w(FUNC(toaplan2_state::toaplan2_v25_coin_word_w)); // Coin count/lock + v25 reset line
-	map(0x210000, 0x21ffff).rw(FUNC(toaplan2_state::shared_ram_r), FUNC(toaplan2_state::shared_ram_w));
+	map(0x20001d, 0x20001d).w(FUNC(toaplan2_state::coin_sound_reset_w)); // Coin count/lock + v25 reset line
+	map(0x210000, 0x21ffff).rw(FUNC(toaplan2_state::shared_ram_r), FUNC(toaplan2_state::shared_ram_w)).umask16(0x00ff);
 	map(0x300000, 0x30000d).rw(m_vdp[0], FUNC(gp9001vdp_device::read), FUNC(gp9001vdp_device::write));
 	map(0x400000, 0x400fff).ram().w(m_palette, FUNC(palette_device::write16)).share("palette");
 	map(0x500000, 0x50000d).rw(m_vdp[1], FUNC(gp9001vdp_device::read), FUNC(gp9001vdp_device::write));
@@ -1107,11 +1104,11 @@ void toaplan2_state::othldrby_68k_mem(address_map &map)
 	map(0x700010, 0x700011).portr("IN2");
 	map(0x70001c, 0x70001d).portr("SYS");
 	map(0x700031, 0x700031).w(FUNC(toaplan2_state::oki_bankswitch_w<0>));
-	map(0x700034, 0x700035).w(FUNC(toaplan2_state::toaplan2_coin_word_w));
+	map(0x700035, 0x700035).w(FUNC(toaplan2_state::coin_w));
 }
 
 
-WRITE16_MEMBER(toaplan2_state::enmadaio_oki_bank_w)
+void toaplan2_state::enmadaio_oki_bank_w(offs_t offset, u16 data, u16 mem_mask)
 {
 	data &= mem_mask;
 
@@ -1128,7 +1125,7 @@ WRITE16_MEMBER(toaplan2_state::enmadaio_oki_bank_w)
 void toaplan2_state::enmadaio_68k_mem(address_map &map)
 {
 	map(0x000000, 0x07ffff).rom();
-	map(0x100000, 0x103fff).ram(); // AM_SHARE("nvram")
+	map(0x100000, 0x103fff).ram(); //.share("nvram");
 	map(0x104000, 0x10ffff).ram();
 
 	map(0x200000, 0x20000d).rw(m_vdp[0], FUNC(gp9001vdp_device::read), FUNC(gp9001vdp_device::write));
@@ -1143,7 +1140,7 @@ void toaplan2_state::enmadaio_68k_mem(address_map &map)
 	map(0x700010, 0x700011).portr("MISC3");
 	map(0x700014, 0x700015).portr("MISC4");
 	map(0x700018, 0x700019).portr("SYS");
-	map(0x70001c, 0x70001d).portr("UNK"); //AM_READ_PORT("SYS")
+	map(0x70001c, 0x70001d).portr("UNK"); //.portr("SYS");
 
 	map(0x700020, 0x700021).w(FUNC(toaplan2_state::enmadaio_oki_bank_w)); // oki bank
 
@@ -1169,7 +1166,7 @@ void toaplan2_state::snowbro2_68k_mem(address_map &map)
 	map(0x700018, 0x700019).portr("IN4");
 	map(0x70001c, 0x70001d).portr("SYS");
 	map(0x700031, 0x700031).w(FUNC(toaplan2_state::oki_bankswitch_w<0>));
-	map(0x700034, 0x700035).w(FUNC(toaplan2_state::toaplan2_coin_word_w));
+	map(0x700035, 0x700035).w(FUNC(toaplan2_state::coin_w));
 }
 
 
@@ -1177,8 +1174,8 @@ void toaplan2_state::mahoudai_68k_mem(address_map &map)
 {
 	map(0x000000, 0x07ffff).rom();
 	map(0x100000, 0x10ffff).ram();
-	map(0x218000, 0x21bfff).rw(FUNC(toaplan2_state::shared_ram_r), FUNC(toaplan2_state::shared_ram_w));
-	map(0x21c01c, 0x21c01d).w(FUNC(toaplan2_state::toaplan2_coin_word_w));
+	map(0x218000, 0x21bfff).rw(FUNC(toaplan2_state::shared_ram_r), FUNC(toaplan2_state::shared_ram_w)).umask16(0x00ff);
+	map(0x21c01d, 0x21c01d).w(FUNC(toaplan2_state::coin_w));
 	map(0x21c020, 0x21c021).portr("IN1");
 	map(0x21c024, 0x21c025).portr("IN2");
 	map(0x21c028, 0x21c029).portr("SYS");
@@ -1200,9 +1197,9 @@ void toaplan2_state::shippumd_68k_mem(address_map &map)
 {
 	map(0x000000, 0x0fffff).rom();
 	map(0x100000, 0x10ffff).ram();
-	map(0x218000, 0x21bfff).rw(FUNC(toaplan2_state::shared_ram_r), FUNC(toaplan2_state::shared_ram_w));
-//  AM_RANGE(0x21c008, 0x21c009) AM_WRITENOP                    // ???
-	map(0x21c01c, 0x21c01d).w(FUNC(toaplan2_state::shippumd_coin_word_w)); // Coin count/lock + oki bankswitch
+	map(0x218000, 0x21bfff).rw(FUNC(toaplan2_state::shared_ram_r), FUNC(toaplan2_state::shared_ram_w)).umask16(0x00ff);
+//  map(0x21c008, 0x21c009).nopw();                    // ???
+	map(0x21c01d, 0x21c01d).w(FUNC(toaplan2_state::shippumd_coin_w)); // Coin count/lock + oki bankswitch
 	map(0x21c020, 0x21c021).portr("IN1");
 	map(0x21c024, 0x21c025).portr("IN2");
 	map(0x21c028, 0x21c029).portr("SYS");
@@ -1224,8 +1221,8 @@ void toaplan2_state::bgaregga_68k_mem(address_map &map)
 {
 	map(0x000000, 0x0fffff).rom();
 	map(0x100000, 0x10ffff).ram();
-	map(0x218000, 0x21bfff).rw(FUNC(toaplan2_state::shared_ram_r), FUNC(toaplan2_state::shared_ram_w));
-	map(0x21c01c, 0x21c01d).w(FUNC(toaplan2_state::toaplan2_coin_word_w));
+	map(0x218000, 0x21bfff).rw(FUNC(toaplan2_state::shared_ram_r), FUNC(toaplan2_state::shared_ram_w)).umask16(0x00ff);
+	map(0x21c01d, 0x21c01d).w(FUNC(toaplan2_state::coin_w));
 	map(0x21c020, 0x21c021).portr("IN1");
 	map(0x21c024, 0x21c025).portr("IN2");
 	map(0x21c028, 0x21c029).portr("SYS");
@@ -1271,7 +1268,7 @@ void toaplan2_state::batrider_68k_mem(address_map &map)
 	map(0x500009, 0x500009).r("soundlatch3", FUNC(generic_latch_8_device::read));
 	map(0x50000b, 0x50000b).r("soundlatch4", FUNC(generic_latch_8_device::read));
 	map(0x50000c, 0x50000d).r(FUNC(toaplan2_state::batrider_z80_busack_r));
-	map(0x500010, 0x500011).w(FUNC(toaplan2_state::toaplan2_coin_word_w));
+	map(0x500011, 0x500011).w(FUNC(toaplan2_state::coin_w));
 	map(0x500021, 0x500021).w(FUNC(toaplan2_state::batrider_soundlatch_w));
 	map(0x500023, 0x500023).w(FUNC(toaplan2_state::batrider_soundlatch2_w));
 	map(0x500024, 0x500025).w(FUNC(toaplan2_state::batrider_unknown_sound_w));
@@ -1297,7 +1294,7 @@ void toaplan2_state::bbakraid_68k_mem(address_map &map)
 	map(0x500002, 0x500003).portr("SYS-DSW");
 	map(0x500004, 0x500005).portr("DSW");
 	map(0x500006, 0x500007).r(FUNC(toaplan2_state::video_count_r));
-	map(0x500008, 0x500009).w(FUNC(toaplan2_state::toaplan2_coin_word_w));
+	map(0x500009, 0x500009).w(FUNC(toaplan2_state::coin_w));
 	map(0x500011, 0x500011).r("soundlatch3", FUNC(generic_latch_8_device::read));
 	map(0x500013, 0x500013).r("soundlatch4", FUNC(generic_latch_8_device::read));
 	map(0x500015, 0x500015).w(FUNC(toaplan2_state::batrider_soundlatch_w));
@@ -1305,13 +1302,11 @@ void toaplan2_state::bbakraid_68k_mem(address_map &map)
 	map(0x500018, 0x500019).r(FUNC(toaplan2_state::bbakraid_eeprom_r));
 	map(0x50001a, 0x50001b).w(FUNC(toaplan2_state::batrider_unknown_sound_w));
 	map(0x50001c, 0x50001d).w(FUNC(toaplan2_state::batrider_clear_sndirq_w));
-	map(0x50001e, 0x50001f).w(FUNC(toaplan2_state::bbakraid_eeprom_w));
+	map(0x50001f, 0x50001f).w(FUNC(toaplan2_state::bbakraid_eeprom_w));
 	map(0x500080, 0x500081).w(FUNC(toaplan2_state::batrider_textdata_dma_w));
 	map(0x500082, 0x500083).w(FUNC(toaplan2_state::batrider_pal_text_dma_w));
 	map(0x5000c0, 0x5000cf).w(FUNC(toaplan2_state::batrider_objectbank_w)).umask16(0x00ff);
 }
-
-
 
 void toaplan2_state::pipibibs_sound_z80_mem(address_map &map)
 {
@@ -1327,7 +1322,7 @@ void toaplan2_state::raizing_sound_z80_mem(address_map &map)
 	map(0xc000, 0xdfff).ram().share("shared_ram");
 	map(0xe000, 0xe001).rw("ymsnd", FUNC(ym2151_device::read), FUNC(ym2151_device::write));
 	map(0xe004, 0xe004).rw(m_oki[0], FUNC(okim6295_device::read), FUNC(okim6295_device::write));
-	map(0xe00e, 0xe00e).w(FUNC(toaplan2_state::toaplan2_coin_w));
+	map(0xe00e, 0xe00e).w(FUNC(toaplan2_state::coin_w));
 }
 
 
@@ -1365,7 +1360,7 @@ void toaplan2_state::batrider_sound_z80_port(address_map &map)
 	map(0x4a, 0x4a).r(m_soundlatch2, FUNC(generic_latch_8_device::read));
 	map(0x80, 0x81).rw("ymsnd", FUNC(ym2151_device::read), FUNC(ym2151_device::write));
 	map(0x82, 0x82).rw(m_oki[0], FUNC(okim6295_device::read), FUNC(okim6295_device::write));
-	map(0x84, 0x84).rw("oki2", FUNC(okim6295_device::read), FUNC(okim6295_device::write));
+	map(0x84, 0x84).rw(m_oki[1], FUNC(okim6295_device::read), FUNC(okim6295_device::write));
 	map(0x88, 0x88).w(FUNC(toaplan2_state::raizing_z80_bankswitch_w));
 	map(0xc0, 0xc6).w(FUNC(toaplan2_state::raizing_oki_bankswitch_w));
 }
@@ -1437,9 +1432,22 @@ void toaplan2_state::enmadaio_oki(address_map &map)
 	map(0x00000, 0x3ffff).bankr("okibank");
 }
 
+// similar as NMK112, but GAL-driven; NOT actual NMK112 is present
+template<unsigned Chip>
+void toaplan2_state::raizing_oki(address_map &map)
+{
+	map(0x00000, 0x000ff).bankr(m_raizing_okibank[Chip][0]);
+	map(0x00100, 0x001ff).bankr(m_raizing_okibank[Chip][1]);
+	map(0x00200, 0x002ff).bankr(m_raizing_okibank[Chip][2]);
+	map(0x00300, 0x003ff).bankr(m_raizing_okibank[Chip][3]);
+	map(0x00400, 0x0ffff).bankr(m_raizing_okibank[Chip][4]);
+	map(0x10000, 0x1ffff).bankr(m_raizing_okibank[Chip][5]);
+	map(0x20000, 0x2ffff).bankr(m_raizing_okibank[Chip][6]);
+	map(0x30000, 0x3ffff).bankr(m_raizing_okibank[Chip][7]);
+}
 
 
-READ8_MEMBER(toaplan2_state::tekipaki_cmdavailable_r)
+u8 toaplan2_state::tekipaki_cmdavailable_r()
 {
 	if (m_soundlatch->pending_r()) return 0xff;
 	else return 0x00;
@@ -1536,7 +1544,6 @@ void toaplan2_state::ghox_hd647180_mem_map(address_map &map)
 *****************************************************************************/
 
 
-
 static INPUT_PORTS_START( toaplan2_2b )
 	PORT_START("IN1")
 	TOAPLAN_JOY_UDLR_2_BUTTONS( 1 )
@@ -1575,7 +1582,6 @@ static INPUT_PORTS_START( toaplan2_3b )
 	PORT_MODIFY("IN2")
 	TOAPLAN_JOY_UDLR_3_BUTTONS( 2 )
 INPUT_PORTS_END
-
 
 
 static INPUT_PORTS_START( tekipaki )
@@ -2274,7 +2280,6 @@ static INPUT_PORTS_START( vfive )
 	PORT_CONFSETTING(       0x0000, DEF_STR( Off ) )
 	PORT_CONFSETTING(       0x0080, DEF_STR( On ) )
 INPUT_PORTS_END
-
 
 
 static INPUT_PORTS_START( batsugun )
@@ -3290,7 +3295,7 @@ void toaplan2_state::ghox(machine_config &config)
 those 3 games have been seen with the NITRO905 chip, other alias are
 ts002mach for dogyuun, ts004dash for kbash and ts007spy for vfive */
 
-static const uint8_t nitro_decryption_table[256] = {
+static const u8 nitro_decryption_table[256] = {
 	0x1b,0x56,0x75,0x88,0x8c,0x06,0x58,0x72, 0x83,0x86,0x36,0x1a,0x5f,0xd3,0x8c,0xe9, /* 00 */
 	/* *//* *//* *//* *//* *//* *//* *//* */ /* *//* *//* *//* *//* *//* *//* *//* */
 	0x22,0x0f,0x03,0x2a,0xeb,0x2a,0xf9,0x0f, 0xa4,0xbd,0x75,0xf3,0x4f,0x53,0x8e,0xfe, /* 10 */
@@ -3585,7 +3590,7 @@ void toaplan2_state::pipibibsbl(machine_config &config)
 /* x = modified to match batsugun 'unencrypted' code - '?' likewise, but not so sure about them */
 /* e = opcodes used in the EEPROM service routine */
 /* this one seems more different to the other tables */
-static const uint8_t ts001turbo_decryption_table[256] = {
+static const u8 ts001turbo_decryption_table[256] = {
 	0x90,0x05,0x57,0x5f,0xfe,0x4f,0xbd,0x36, 0x80,0x8b,0x8a,0x0a,0x89,0x90,0x47,0x80, /* 00 */
 			/*r*//*r*//*r*//*r*//*r*//*r*//*r*/ /*r*//*r*//*r*//*r*//*r*/     /*r*//*r*/
 	0x22,0x90,0x90,0x5d,0x81,0x3c,0xb5,0x83, 0x68,0xff,0x75,0x75,0x8d,0x5b,0x8a,0x38, /* 10 */
@@ -3951,7 +3956,7 @@ void toaplan2_state::mahoudai(machine_config &config)
 	/* sound hardware */
 	SPEAKER(config, "mono").front_center();
 
-	YM2151(config, "ymsnd", 27_MHz_XTAL/8).add_route(ALL_OUTPUTS, "mono", 1.0);
+	YM2151(config, "ymsnd", 27_MHz_XTAL/8).add_route(ALL_OUTPUTS, "mono", 0.68);
 
 	OKIM6295(config, m_oki[0], 32_MHz_XTAL/32, okim6295_device::PIN7_HIGH);
 	m_oki[0]->add_route(ALL_OUTPUTS, "mono", 1.0);
@@ -3960,44 +3965,9 @@ void toaplan2_state::mahoudai(machine_config &config)
 
 void toaplan2_state::shippumd(machine_config &config)
 {
+	mahoudai(config);
 	/* basic machine hardware */
-	M68000(config, m_maincpu, 32_MHz_XTAL/2);   // 16MHz, 32MHz Oscillator
 	m_maincpu->set_addrmap(AS_PROGRAM, &toaplan2_state::shippumd_68k_mem);
-
-	Z80(config, m_audiocpu, 32_MHz_XTAL/8);     // 4MHz, 32MHz Oscillator
-	m_audiocpu->set_addrmap(AS_PROGRAM, &toaplan2_state::raizing_sound_z80_mem);
-
-	config.m_minimum_quantum = attotime::from_hz(600);
-
-	MCFG_MACHINE_RESET_OVERRIDE(toaplan2_state,toaplan2)
-
-	/* video hardware */
-	SCREEN(config, m_screen, SCREEN_TYPE_RASTER);
-	m_screen->set_video_attributes(VIDEO_UPDATE_BEFORE_VBLANK);
-	m_screen->set_raw(27_MHz_XTAL/4, 432, 0, 320, 262, 0, 240);
-	//m_screen->set_refresh_hz(60);
-	//m_screen->set_size(432, 262);
-	//m_screen->set_visarea(0, 319, 0, 239);
-	m_screen->set_screen_update(FUNC(toaplan2_state::screen_update_truxton2));
-	m_screen->screen_vblank().set(FUNC(toaplan2_state::screen_vblank));
-	m_screen->set_palette(m_palette);
-
-	GFXDECODE(config, m_gfxdecode, m_palette, gfx_textrom);
-	PALETTE(config, m_palette).set_format(palette_device::xBGR_555, T2PALETTE_LENGTH);
-
-	GP9001_VDP(config, m_vdp[0], 27_MHz_XTAL);
-	m_vdp[0]->set_palette(m_palette);
-	m_vdp[0]->vint_out_cb().set_inputline(m_maincpu, M68K_IRQ_4);
-
-	MCFG_VIDEO_START_OVERRIDE(toaplan2_state,bgaregga)
-
-	/* sound hardware */
-	SPEAKER(config, "mono").front_center();
-
-	YM2151(config, "ymsnd", 27_MHz_XTAL/8).add_route(ALL_OUTPUTS, "mono", 1.0);
-
-	OKIM6295(config, m_oki[0], 32_MHz_XTAL/32, okim6295_device::PIN7_HIGH);
-	m_oki[0]->add_route(ALL_OUTPUTS, "mono", 1.0);
 }
 
 void toaplan2_state::bgaregga(machine_config &config)
@@ -4011,7 +3981,7 @@ void toaplan2_state::bgaregga(machine_config &config)
 
 	config.m_minimum_quantum = attotime::from_hz(6000);
 
-	MCFG_MACHINE_RESET_OVERRIDE(toaplan2_state,toaplan2)
+	MCFG_MACHINE_RESET_OVERRIDE(toaplan2_state,bgaregga)
 
 	/* video hardware */
 	SCREEN(config, m_screen, SCREEN_TYPE_RASTER);
@@ -4040,13 +4010,11 @@ void toaplan2_state::bgaregga(machine_config &config)
 	m_soundlatch->data_pending_callback().set_inputline(m_audiocpu, 0);
 	m_soundlatch->set_separate_acknowledge(true);
 
-	YM2151(config, "ymsnd", 32_MHz_XTAL/8).add_route(ALL_OUTPUTS, "mono", 1.0);
+	YM2151(config, "ymsnd", 32_MHz_XTAL/8).add_route(ALL_OUTPUTS, "mono", 0.68);
 
 	OKIM6295(config, m_oki[0], 32_MHz_XTAL/16, okim6295_device::PIN7_HIGH);
+	m_oki[0]->set_addrmap(0, &toaplan2_state::raizing_oki<0>);
 	m_oki[0]->add_route(ALL_OUTPUTS, "mono", 1.0);
-
-	NMK112(config, m_nmk112, 0);
-	m_nmk112->set_rom0_tag("oki1");
 }
 
 
@@ -4070,7 +4038,7 @@ void toaplan2_state::batrider(machine_config &config)
 
 	config.m_minimum_quantum = attotime::from_hz(600);
 
-	MCFG_MACHINE_RESET_OVERRIDE(toaplan2_state,toaplan2)
+	MCFG_MACHINE_RESET_OVERRIDE(toaplan2_state,bgaregga)
 
 	ADDRESS_MAP_BANK(config, m_dma_space, 0);
 	m_dma_space->set_addrmap(0, &toaplan2_state::batrider_dma_mem);
@@ -4109,17 +4077,15 @@ void toaplan2_state::batrider(machine_config &config)
 	GENERIC_LATCH_8(config, "soundlatch3");
 	GENERIC_LATCH_8(config, "soundlatch4");
 
-	YM2151(config, "ymsnd", 32_MHz_XTAL/8).add_route(ALL_OUTPUTS, "mono", 1.0); // 4MHz, 32MHz Oscillator (verified)
+	YM2151(config, "ymsnd", 32_MHz_XTAL/8).add_route(ALL_OUTPUTS, "mono", 0.68); // 4MHz, 32MHz Oscillator (verified)
 
 	OKIM6295(config, m_oki[0], 32_MHz_XTAL/10, okim6295_device::PIN7_HIGH);
+	m_oki[0]->set_addrmap(0, &toaplan2_state::raizing_oki<0>);
 	m_oki[0]->add_route(ALL_OUTPUTS, "mono", 1.0);
 
 	OKIM6295(config, m_oki[1], 32_MHz_XTAL/10, okim6295_device::PIN7_LOW);
+	m_oki[1]->set_addrmap(0, &toaplan2_state::raizing_oki<1>);
 	m_oki[1]->add_route(ALL_OUTPUTS, "mono", 1.0);
-
-	NMK112(config, m_nmk112, 0);
-	m_nmk112->set_rom0_tag("oki1");
-	m_nmk112->set_rom1_tag("oki2");
 }
 
 
@@ -5043,8 +5009,8 @@ ROM_START( bgaregga )
 	ROM_REGION( 0x008000, "text", 0 )
 	ROM_LOAD( "text.u81", 0x00000, 0x08000, CRC(e67fd534) SHA1(987d0edffc2c243a13d4567319ea3d185eaadbf8) )
 
-	ROM_REGION( 0x140000, "oki1", 0 )        /* ADPCM Samples */
-	ROM_LOAD( "rom5.bin", 0x040000, 0x100000, CRC(f6d49863) SHA1(3a3c354852adad06e8a051511abfab7606bce382) )
+	ROM_REGION( 0x100000, "oki1", 0 )        /* ADPCM Samples */
+	ROM_LOAD( "rom5.bin", 0x000000, 0x100000, CRC(f6d49863) SHA1(3a3c354852adad06e8a051511abfab7606bce382) )
 ROM_END
 
 
@@ -5065,8 +5031,8 @@ ROM_START( bgareggahk )
 	ROM_REGION( 0x008000, "text", 0 )
 	ROM_LOAD( "text.u81", 0x00000, 0x08000, CRC(e67fd534) SHA1(987d0edffc2c243a13d4567319ea3d185eaadbf8) )
 
-	ROM_REGION( 0x140000, "oki1", 0 )        /* ADPCM Samples */
-	ROM_LOAD( "rom5.bin", 0x040000, 0x100000, CRC(f6d49863) SHA1(3a3c354852adad06e8a051511abfab7606bce382) )
+	ROM_REGION( 0x100000, "oki1", 0 )        /* ADPCM Samples */
+	ROM_LOAD( "rom5.bin", 0x000000, 0x100000, CRC(f6d49863) SHA1(3a3c354852adad06e8a051511abfab7606bce382) )
 ROM_END
 
 
@@ -5087,8 +5053,8 @@ ROM_START( bgareggatw )
 	ROM_REGION( 0x008000, "text", 0 )
 	ROM_LOAD( "text.u81", 0x00000, 0x08000, CRC(e67fd534) SHA1(987d0edffc2c243a13d4567319ea3d185eaadbf8) )
 
-	ROM_REGION( 0x140000, "oki1", 0 )        /* ADPCM Samples */
-	ROM_LOAD( "rom5.bin", 0x040000, 0x100000, CRC(f6d49863) SHA1(3a3c354852adad06e8a051511abfab7606bce382) )
+	ROM_REGION( 0x100000, "oki1", 0 )        /* ADPCM Samples */
+	ROM_LOAD( "rom5.bin", 0x000000, 0x100000, CRC(f6d49863) SHA1(3a3c354852adad06e8a051511abfab7606bce382) )
 ROM_END
 
 
@@ -5109,8 +5075,8 @@ ROM_START( bgaregganv )
 	ROM_REGION( 0x008000, "text", 0 )
 	ROM_LOAD( "text.u81", 0x00000, 0x08000, CRC(e67fd534) SHA1(987d0edffc2c243a13d4567319ea3d185eaadbf8) )
 
-	ROM_REGION( 0x140000, "oki1", 0 )        /* ADPCM Samples */
-	ROM_LOAD( "rom5.bin", 0x040000, 0x100000, CRC(f6d49863) SHA1(3a3c354852adad06e8a051511abfab7606bce382) )
+	ROM_REGION( 0x100000, "oki1", 0 )        /* ADPCM Samples */
+	ROM_LOAD( "rom5.bin", 0x000000, 0x100000, CRC(f6d49863) SHA1(3a3c354852adad06e8a051511abfab7606bce382) )
 ROM_END
 
 
@@ -5131,8 +5097,8 @@ ROM_START( bgareggat2 )
 	ROM_REGION( 0x008000, "text", 0 )
 	ROM_LOAD( "text.u81", 0x00000, 0x08000, CRC(e67fd534) SHA1(987d0edffc2c243a13d4567319ea3d185eaadbf8) )
 
-	ROM_REGION( 0x140000, "oki1", 0 )        /* ADPCM Samples */
-	ROM_LOAD( "rom5.bin", 0x040000, 0x100000, CRC(f6d49863) SHA1(3a3c354852adad06e8a051511abfab7606bce382) )
+	ROM_REGION( 0x100000, "oki1", 0 )        /* ADPCM Samples */
+	ROM_LOAD( "rom5.bin", 0x000000, 0x100000, CRC(f6d49863) SHA1(3a3c354852adad06e8a051511abfab7606bce382) )
 ROM_END
 
 
@@ -5153,8 +5119,8 @@ ROM_START( bgareggacn )
 	ROM_REGION( 0x008000, "text", 0 )
 	ROM_LOAD( "text.u81", 0x00000, 0x08000, CRC(e67fd534) SHA1(987d0edffc2c243a13d4567319ea3d185eaadbf8) )
 
-	ROM_REGION( 0x140000, "oki1", 0 )        /* ADPCM Samples */
-	ROM_LOAD( "rom5.bin", 0x040000, 0x100000, CRC(f6d49863) SHA1(3a3c354852adad06e8a051511abfab7606bce382) )
+	ROM_REGION( 0x100000, "oki1", 0 )        /* ADPCM Samples */
+	ROM_LOAD( "rom5.bin", 0x000000, 0x100000, CRC(f6d49863) SHA1(3a3c354852adad06e8a051511abfab7606bce382) )
 ROM_END
 
 
@@ -5175,8 +5141,8 @@ ROM_START( bgareggabl )
 	ROM_REGION( 0x010000, "user1", 0 ) // not graphics
 	ROM_LOAD( "2@-256", 0x00000, 0x08000, CRC(456dd16e) SHA1(84779ee64d3ea33ba1ba4dee39b504a81c6811a1) )
 
-	ROM_REGION( 0x140000, "oki1", 0 )        /* ADPCM Samples */
-	ROM_LOAD( "rom5.bin", 0x040000, 0x100000, CRC(f6d49863) SHA1(3a3c354852adad06e8a051511abfab7606bce382) )
+	ROM_REGION( 0x100000, "oki1", 0 )        /* ADPCM Samples */
+	ROM_LOAD( "rom5.bin", 0x000000, 0x100000, CRC(f6d49863) SHA1(3a3c354852adad06e8a051511abfab7606bce382) )
 ROM_END
 
 ROM_START( bgareggabla )
@@ -5198,8 +5164,8 @@ ROM_START( bgareggabla )
 	ROM_REGION( 0x010000, "user1", 0 ) // not graphics
 	ROM_LOAD( "base.bin", 0x00000, 0x08000, CRC(456dd16e) SHA1(84779ee64d3ea33ba1ba4dee39b504a81c6811a1) )
 
-	ROM_REGION( 0x140000, "oki1", 0 )        /* ADPCM Samples */
-	ROM_LOAD( "rom5.bin", 0x040000, 0x100000, CRC(f6d49863) SHA1(3a3c354852adad06e8a051511abfab7606bce382) )
+	ROM_REGION( 0x100000, "oki1", 0 )        /* ADPCM Samples */
+	ROM_LOAD( "rom5.bin", 0x000000, 0x100000, CRC(f6d49863) SHA1(3a3c354852adad06e8a051511abfab7606bce382) )
 ROM_END
 
 /*
@@ -5286,11 +5252,11 @@ ROM_START( batrider )
 	ROM_LOAD( "rom-2.bin", 0x800000, 0x400000, CRC(1bfea593) SHA1(ce06dc3097ae56b0df56d104bbf7efc9b5d968d4) )
 	ROM_LOAD( "rom-4.bin", 0xc00000, 0x400000, CRC(bee03c94) SHA1(5bc1e6769c42857c03456426b502fcb86a114f19) )
 
-	ROM_REGION( 0x140000, "oki1", 0 )       /* ADPCM Samples 1 */
-	ROM_LOAD( "rom-5.bin", 0x040000, 0x100000, CRC(4274daf6) SHA1(85557b4707d529e5914f03c7a856864f5c24950e) )
+	ROM_REGION( 0x100000, "oki1", 0 )       /* ADPCM Samples 1 */
+	ROM_LOAD( "rom-5.bin", 0x000000, 0x100000, CRC(4274daf6) SHA1(85557b4707d529e5914f03c7a856864f5c24950e) )
 
-	ROM_REGION( 0x140000, "oki2", 0 )       /* ADPCM Samples 2 */
-	ROM_LOAD( "rom-6.bin", 0x040000, 0x100000, CRC(2a1c2426) SHA1(8abc3688ffc5ebb94b8d5118d4fa0908f07fe791) )
+	ROM_REGION( 0x100000, "oki2", 0 )       /* ADPCM Samples 2 */
+	ROM_LOAD( "rom-6.bin", 0x000000, 0x100000, CRC(2a1c2426) SHA1(8abc3688ffc5ebb94b8d5118d4fa0908f07fe791) )
 ROM_END
 
 
@@ -5310,11 +5276,11 @@ ROM_START( batrideru )
 	ROM_LOAD( "rom-2.bin", 0x800000, 0x400000, CRC(1bfea593) SHA1(ce06dc3097ae56b0df56d104bbf7efc9b5d968d4) )
 	ROM_LOAD( "rom-4.bin", 0xc00000, 0x400000, CRC(bee03c94) SHA1(5bc1e6769c42857c03456426b502fcb86a114f19) )
 
-	ROM_REGION( 0x140000, "oki1", 0 )       /* ADPCM Samples 1 */
-	ROM_LOAD( "rom-5.bin", 0x040000, 0x100000, CRC(4274daf6) SHA1(85557b4707d529e5914f03c7a856864f5c24950e) )
+	ROM_REGION( 0x100000, "oki1", 0 )       /* ADPCM Samples 1 */
+	ROM_LOAD( "rom-5.bin", 0x000000, 0x100000, CRC(4274daf6) SHA1(85557b4707d529e5914f03c7a856864f5c24950e) )
 
-	ROM_REGION( 0x140000, "oki2", 0 )       /* ADPCM Samples 2 */
-	ROM_LOAD( "rom-6.bin", 0x040000, 0x100000, CRC(2a1c2426) SHA1(8abc3688ffc5ebb94b8d5118d4fa0908f07fe791) )
+	ROM_REGION( 0x100000, "oki2", 0 )       /* ADPCM Samples 2 */
+	ROM_LOAD( "rom-6.bin", 0x000000, 0x100000, CRC(2a1c2426) SHA1(8abc3688ffc5ebb94b8d5118d4fa0908f07fe791) )
 ROM_END
 
 
@@ -5334,11 +5300,11 @@ ROM_START( batriderc )
 	ROM_LOAD( "rom-2.bin", 0x800000, 0x400000, CRC(1bfea593) SHA1(ce06dc3097ae56b0df56d104bbf7efc9b5d968d4) )
 	ROM_LOAD( "rom-4.bin", 0xc00000, 0x400000, CRC(bee03c94) SHA1(5bc1e6769c42857c03456426b502fcb86a114f19) )
 
-	ROM_REGION( 0x140000, "oki1", 0 )       /* ADPCM Samples 1 */
-	ROM_LOAD( "rom-5.bin", 0x040000, 0x100000, CRC(4274daf6) SHA1(85557b4707d529e5914f03c7a856864f5c24950e) )
+	ROM_REGION( 0x100000, "oki1", 0 )       /* ADPCM Samples 1 */
+	ROM_LOAD( "rom-5.bin", 0x000000, 0x100000, CRC(4274daf6) SHA1(85557b4707d529e5914f03c7a856864f5c24950e) )
 
-	ROM_REGION( 0x140000, "oki2", 0 )       /* ADPCM Samples 2 */
-	ROM_LOAD( "rom-6.bin", 0x040000, 0x100000, CRC(2a1c2426) SHA1(8abc3688ffc5ebb94b8d5118d4fa0908f07fe791) )
+	ROM_REGION( 0x100000, "oki2", 0 )       /* ADPCM Samples 2 */
+	ROM_LOAD( "rom-6.bin", 0x000000, 0x100000, CRC(2a1c2426) SHA1(8abc3688ffc5ebb94b8d5118d4fa0908f07fe791) )
 ROM_END
 
 
@@ -5358,11 +5324,11 @@ ROM_START( batriderj )
 	ROM_LOAD( "rom-2.bin", 0x800000, 0x400000, CRC(1bfea593) SHA1(ce06dc3097ae56b0df56d104bbf7efc9b5d968d4) )
 	ROM_LOAD( "rom-4.bin", 0xc00000, 0x400000, CRC(bee03c94) SHA1(5bc1e6769c42857c03456426b502fcb86a114f19) )
 
-	ROM_REGION( 0x140000, "oki1", 0 )       /* ADPCM Samples 1 */
-	ROM_LOAD( "rom-5.bin", 0x040000, 0x100000, CRC(4274daf6) SHA1(85557b4707d529e5914f03c7a856864f5c24950e) )
+	ROM_REGION( 0x100000, "oki1", 0 )       /* ADPCM Samples 1 */
+	ROM_LOAD( "rom-5.bin", 0x000000, 0x100000, CRC(4274daf6) SHA1(85557b4707d529e5914f03c7a856864f5c24950e) )
 
-	ROM_REGION( 0x140000, "oki2", 0 )       /* ADPCM Samples 2 */
-	ROM_LOAD( "rom-6.bin", 0x040000, 0x100000, CRC(2a1c2426) SHA1(8abc3688ffc5ebb94b8d5118d4fa0908f07fe791) )
+	ROM_REGION( 0x100000, "oki2", 0 )       /* ADPCM Samples 2 */
+	ROM_LOAD( "rom-6.bin", 0x000000, 0x100000, CRC(2a1c2426) SHA1(8abc3688ffc5ebb94b8d5118d4fa0908f07fe791) )
 ROM_END
 
 
@@ -5382,11 +5348,11 @@ ROM_START( batriderk )
 	ROM_LOAD( "rom-2.bin", 0x800000, 0x400000, CRC(1bfea593) SHA1(ce06dc3097ae56b0df56d104bbf7efc9b5d968d4) )
 	ROM_LOAD( "rom-4.bin", 0xc00000, 0x400000, CRC(bee03c94) SHA1(5bc1e6769c42857c03456426b502fcb86a114f19) )
 
-	ROM_REGION( 0x140000, "oki1", 0 )       /* ADPCM Samples 1 */
-	ROM_LOAD( "rom-5.bin", 0x040000, 0x100000, CRC(4274daf6) SHA1(85557b4707d529e5914f03c7a856864f5c24950e) )
+	ROM_REGION( 0x100000, "oki1", 0 )       /* ADPCM Samples 1 */
+	ROM_LOAD( "rom-5.bin", 0x000000, 0x100000, CRC(4274daf6) SHA1(85557b4707d529e5914f03c7a856864f5c24950e) )
 
-	ROM_REGION( 0x140000, "oki2", 0 )       /* ADPCM Samples 2 */
-	ROM_LOAD( "rom-6.bin", 0x040000, 0x100000, CRC(2a1c2426) SHA1(8abc3688ffc5ebb94b8d5118d4fa0908f07fe791) )
+	ROM_REGION( 0x100000, "oki2", 0 )       /* ADPCM Samples 2 */
+	ROM_LOAD( "rom-6.bin", 0x000000, 0x100000, CRC(2a1c2426) SHA1(8abc3688ffc5ebb94b8d5118d4fa0908f07fe791) )
 ROM_END
 
 /* older version, might have only been released in Japan, Hong Kong and Taiwan? */
@@ -5406,11 +5372,11 @@ ROM_START( batriderja )
 	ROM_LOAD( "rom-2.bin", 0x800000, 0x400000, CRC(1bfea593) SHA1(ce06dc3097ae56b0df56d104bbf7efc9b5d968d4) )
 	ROM_LOAD( "rom-4.bin", 0xc00000, 0x400000, CRC(bee03c94) SHA1(5bc1e6769c42857c03456426b502fcb86a114f19) )
 
-	ROM_REGION( 0x140000, "oki1", 0 )       /* ADPCM Samples 1 */
-	ROM_LOAD( "rom-5.bin", 0x040000, 0x100000, CRC(4274daf6) SHA1(85557b4707d529e5914f03c7a856864f5c24950e) )
+	ROM_REGION( 0x100000, "oki1", 0 )       /* ADPCM Samples 1 */
+	ROM_LOAD( "rom-5.bin", 0x000000, 0x100000, CRC(4274daf6) SHA1(85557b4707d529e5914f03c7a856864f5c24950e) )
 
-	ROM_REGION( 0x140000, "oki2", 0 )       /* ADPCM Samples 2 */
-	ROM_LOAD( "rom-6.bin", 0x040000, 0x100000, CRC(2a1c2426) SHA1(8abc3688ffc5ebb94b8d5118d4fa0908f07fe791) )
+	ROM_REGION( 0x100000, "oki2", 0 )       /* ADPCM Samples 2 */
+	ROM_LOAD( "rom-6.bin", 0x000000, 0x100000, CRC(2a1c2426) SHA1(8abc3688ffc5ebb94b8d5118d4fa0908f07fe791) )
 ROM_END
 
 
@@ -5430,11 +5396,11 @@ ROM_START( batriderhk )
 	ROM_LOAD( "rom-2.bin", 0x800000, 0x400000, CRC(1bfea593) SHA1(ce06dc3097ae56b0df56d104bbf7efc9b5d968d4) )
 	ROM_LOAD( "rom-4.bin", 0xc00000, 0x400000, CRC(bee03c94) SHA1(5bc1e6769c42857c03456426b502fcb86a114f19) )
 
-	ROM_REGION( 0x140000, "oki1", 0 )       /* ADPCM Samples 1 */
-	ROM_LOAD( "rom-5.bin", 0x040000, 0x100000, CRC(4274daf6) SHA1(85557b4707d529e5914f03c7a856864f5c24950e) )
+	ROM_REGION( 0x100000, "oki1", 0 )       /* ADPCM Samples 1 */
+	ROM_LOAD( "rom-5.bin", 0x000000, 0x100000, CRC(4274daf6) SHA1(85557b4707d529e5914f03c7a856864f5c24950e) )
 
-	ROM_REGION( 0x140000, "oki2", 0 )       /* ADPCM Samples 2 */
-	ROM_LOAD( "rom-6.bin", 0x040000, 0x100000, CRC(2a1c2426) SHA1(8abc3688ffc5ebb94b8d5118d4fa0908f07fe791) )
+	ROM_REGION( 0x100000, "oki2", 0 )       /* ADPCM Samples 2 */
+	ROM_LOAD( "rom-6.bin", 0x000000, 0x100000, CRC(2a1c2426) SHA1(8abc3688ffc5ebb94b8d5118d4fa0908f07fe791) )
 ROM_END
 
 
@@ -5454,11 +5420,11 @@ ROM_START( batridert )
 	ROM_LOAD( "rom-2.bin", 0x800000, 0x400000, CRC(1bfea593) SHA1(ce06dc3097ae56b0df56d104bbf7efc9b5d968d4) )
 	ROM_LOAD( "rom-4.bin", 0xc00000, 0x400000, CRC(bee03c94) SHA1(5bc1e6769c42857c03456426b502fcb86a114f19) )
 
-	ROM_REGION( 0x140000, "oki1", 0 )       /* ADPCM Samples 1 */
-	ROM_LOAD( "rom-5.bin", 0x040000, 0x100000, CRC(4274daf6) SHA1(85557b4707d529e5914f03c7a856864f5c24950e) )
+	ROM_REGION( 0x100000, "oki1", 0 )       /* ADPCM Samples 1 */
+	ROM_LOAD( "rom-5.bin", 0x000000, 0x100000, CRC(4274daf6) SHA1(85557b4707d529e5914f03c7a856864f5c24950e) )
 
-	ROM_REGION( 0x140000, "oki2", 0 )       /* ADPCM Samples 2 */
-	ROM_LOAD( "rom-6.bin", 0x040000, 0x100000, CRC(2a1c2426) SHA1(8abc3688ffc5ebb94b8d5118d4fa0908f07fe791) )
+	ROM_REGION( 0x100000, "oki2", 0 )       /* ADPCM Samples 2 */
+	ROM_LOAD( "rom-6.bin", 0x000000, 0x100000, CRC(2a1c2426) SHA1(8abc3688ffc5ebb94b8d5118d4fa0908f07fe791) )
 ROM_END
 
 

--- a/src/mame/includes/toaplan2.h
+++ b/src/mame/includes/toaplan2.h
@@ -9,7 +9,6 @@
 #include "machine/bankdev.h"
 #include "machine/eepromser.h"
 #include "machine/gen_latch.h"
-#include "machine/nmk112.h"
 #include "machine/ticket.h"
 #include "machine/upd4992.h"
 #include "video/gp9001.h"
@@ -33,7 +32,6 @@ public:
 		, m_maincpu(*this, "maincpu")
 		, m_audiocpu(*this, "audiocpu")
 		, m_vdp(*this, "gp9001_%u", 0U)
-		, m_nmk112(*this, "nmk112")
 		, m_oki(*this, "oki%u", 1U)
 		, m_eeprom(*this, "eeprom")
 		, m_rtc(*this, "rtc")
@@ -45,8 +43,13 @@ public:
 		, m_hopper(*this, "hopper")
 		, m_dma_space(*this, "dma_space")
 		, m_z80_rom(*this, "audiocpu")
+		, m_oki_rom(*this, "oki%u", 1U)
 		, m_audiobank(*this, "audiobank")
 		, m_okibank(*this, "okibank")
+		, m_raizing_okibank{{*this, "raizing_okibank0_%u", 0U},
+							{*this, "raizing_okibank1_%u", 0U}}
+		, m_io_pad(*this, "PAD%u", 1U)
+		, m_eepromout(*this, "EEPROMOUT")
 	{ }
 
 	void dogyuun(machine_config &config);
@@ -91,17 +94,16 @@ private:
 	// We encode priority with colour in the tilemaps, so need a larger palette
 	static constexpr unsigned T2PALETTE_LENGTH = 0x10000;
 
-	optional_shared_ptr<uint8_t> m_shared_ram; // 8 bit RAM shared between 68K and sound CPU
-	optional_shared_ptr<uint16_t> m_tx_videoram;
-	optional_shared_ptr<uint16_t> m_tx_lineselect;
-	optional_shared_ptr<uint16_t> m_tx_linescroll;
-	optional_shared_ptr<uint16_t> m_tx_gfxram;
-	optional_shared_ptr<uint16_t> m_mainram;
+	optional_shared_ptr<u8> m_shared_ram; // 8 bit RAM shared between 68K and sound CPU
+	optional_shared_ptr<u16> m_tx_videoram;
+	optional_shared_ptr<u16> m_tx_lineselect;
+	optional_shared_ptr<u16> m_tx_linescroll;
+	optional_shared_ptr<u16> m_tx_gfxram;
+	optional_shared_ptr<u16> m_mainram;
 
 	required_device<m68000_base_device> m_maincpu;
 	optional_device<cpu_device> m_audiocpu;
 	optional_device_array<gp9001vdp_device, 2> m_vdp;
-	optional_device<nmk112_device> m_nmk112;
 	optional_device_array<okim6295_device, 2> m_oki;
 	optional_device<eeprom_serial_93cxx_device> m_eeprom;
 	optional_device<upd4992_device> m_rtc;
@@ -114,61 +116,67 @@ private:
 
 	optional_device<address_map_bank_device> m_dma_space;
 
-	optional_region_ptr<uint8_t> m_z80_rom;
+	optional_region_ptr<u8> m_z80_rom;
+	optional_region_ptr_array<u8, 2> m_oki_rom;
 	optional_memory_bank m_audiobank;
 	optional_memory_bank m_okibank;
+	optional_memory_bank_array<8> m_raizing_okibank[2];
 
-	int8_t m_old_p1_paddle_h; /* For Ghox */
-	int8_t m_old_p2_paddle_h;
-	uint8_t m_v25_reset_line; /* 0x20 for dogyuun/batsugun, 0x10 for vfive, 0x08 for fixeight */
-	uint8_t m_sndirq_line;        /* IRQ4 for batrider, IRQ2 for bbakraid */
-	uint8_t m_z80_busreq;
-	uint16_t m_gfxrom_bank[8];       /* Batrider object bank */
+	optional_ioport_array<2> m_io_pad;
+	optional_ioport m_eepromout;
+
+	s8 m_old_p1_paddle_h; /* For Ghox */
+	s8 m_old_p2_paddle_h;
+	u8 m_sound_reset_bit; /* 0x20 for dogyuun/batsugun, 0x10 for vfive, 0x08 for fixeight */
+	u8 m_sndirq_line;        /* IRQ4 for batrider, IRQ2 for bbakraid */
+	u8 m_z80_busreq;
+	u16 m_gfxrom_bank[8];       /* Batrider object bank */
 
 	bitmap_ind8 m_custom_priority_bitmap;
 	bitmap_ind16 m_secondary_render_bitmap;
 
 	tilemap_t *m_tx_tilemap;    /* Tilemap for extra-text-layer */
-	DECLARE_READ16_MEMBER(video_count_r);
-	DECLARE_WRITE8_MEMBER(toaplan2_coin_w);
-	DECLARE_WRITE16_MEMBER(toaplan2_coin_word_w);
-	DECLARE_WRITE16_MEMBER(toaplan2_v25_coin_word_w);
-	DECLARE_WRITE16_MEMBER(shippumd_coin_word_w);
-	DECLARE_READ16_MEMBER(shared_ram_r);
-	DECLARE_WRITE16_MEMBER(shared_ram_w);
-	DECLARE_READ16_MEMBER(ghox_p1_h_analog_r);
-	DECLARE_READ16_MEMBER(ghox_p2_h_analog_r);
-	DECLARE_WRITE16_MEMBER(fixeight_subcpu_ctrl_w);
-	DECLARE_WRITE8_MEMBER(fixeightbl_oki_bankswitch_w);
-	DECLARE_WRITE8_MEMBER(raizing_z80_bankswitch_w);
-	DECLARE_WRITE8_MEMBER(raizing_oki_bankswitch_w);
-	DECLARE_READ8_MEMBER(bgaregga_E01D_r);
-	DECLARE_READ16_MEMBER(batrider_z80_busack_r);
-	DECLARE_WRITE8_MEMBER(batrider_z80_busreq_w);
-	DECLARE_READ16_MEMBER(batrider_z80rom_r);
-	DECLARE_WRITE8_MEMBER(batrider_soundlatch_w);
-	DECLARE_WRITE8_MEMBER(batrider_soundlatch2_w);
-	DECLARE_WRITE16_MEMBER(batrider_unknown_sound_w);
-	DECLARE_WRITE16_MEMBER(batrider_clear_sndirq_w);
-	DECLARE_WRITE8_MEMBER(batrider_sndirq_w);
-	DECLARE_WRITE8_MEMBER(batrider_clear_nmi_w);
-	DECLARE_READ16_MEMBER(bbakraid_eeprom_r);
-	DECLARE_WRITE16_MEMBER(bbakraid_eeprom_w);
-	DECLARE_WRITE16_MEMBER(tx_videoram_w);
-	DECLARE_WRITE16_MEMBER(tx_linescroll_w);
-	DECLARE_WRITE16_MEMBER(tx_gfxram_w);
-	DECLARE_WRITE16_MEMBER(batrider_tx_gfxram_w);
-	DECLARE_WRITE16_MEMBER(batrider_textdata_dma_w);
-	DECLARE_WRITE16_MEMBER(batrider_pal_text_dma_w);
-	DECLARE_WRITE8_MEMBER(batrider_objectbank_w);
+	u16 video_count_r();
+	void coin_w(u8 data);
+	void coin_sound_reset_w(u8 data);
+	void shippumd_coin_w(u8 data);
+	u8 shared_ram_r(offs_t offset);
+	void shared_ram_w(offs_t offset, u8 data);
+	u16 ghox_p1_h_analog_r();
+	u16 ghox_p2_h_analog_r();
+	void sound_reset_w(u8 data);
+	void fixeightbl_oki_bankswitch_w(u8 data);
+	void raizing_z80_bankswitch_w(u8 data);
+	void raizing_oki_bankswitch_w(offs_t offset, u8 data);
+	u8 bgaregga_E01D_r();
+	u16 batrider_z80_busack_r();
+	void batrider_z80_busreq_w(u8 data);
+	u16 batrider_z80rom_r(offs_t offset);
+	void batrider_soundlatch_w(u8 data);
+	void batrider_soundlatch2_w(u8 data);
+	void batrider_unknown_sound_w(u16 data);
+	void batrider_clear_sndirq_w(u16 data);
+	void batrider_sndirq_w(u8 data);
+	void batrider_clear_nmi_w(u8 data);
+	u16 bbakraid_eeprom_r();
+	void bbakraid_eeprom_w(u8 data);
+	void tx_videoram_w(offs_t offset, u16 data, u16 mem_mask = ~0);
+	void tx_linescroll_w(offs_t offset, u16 data, u16 mem_mask = ~0);
+	void tx_gfxram_w(offs_t offset, u16 data, u16 mem_mask = ~0);
+	void batrider_tx_gfxram_w(offs_t offset, u16 data, u16 mem_mask = ~0);
+	void batrider_textdata_dma_w(u16 data);
+	void batrider_pal_text_dma_w(u16 data);
+	void batrider_objectbank_w(offs_t offset, u8 data);
 	void batrider_bank_cb(u8 layer, u32 &code);
 
-	template<int Chip> DECLARE_WRITE8_MEMBER(oki_bankswitch_w);
-	DECLARE_WRITE16_MEMBER(enmadaio_oki_bank_w);
+	template<int Chip> void oki_bankswitch_w(u8 data);
+	void enmadaio_oki_bank_w(offs_t offset, u16 data, u16 mem_mask = ~0);
+	void install_raizing_okibank(int chip);
 
 	TILE_GET_INFO_MEMBER(get_text_tile_info);
 	virtual void machine_start() override;
 	DECLARE_MACHINE_RESET(toaplan2);
+	DECLARE_MACHINE_RESET(bgaregga);
 	DECLARE_VIDEO_START(toaplan2);
 	DECLARE_MACHINE_RESET(ghox);
 	DECLARE_VIDEO_START(truxton2);
@@ -178,21 +186,21 @@ private:
 	DECLARE_VIDEO_START(batrider);
 
 	// Teki Paki sound
-	DECLARE_READ8_MEMBER(tekipaki_cmdavailable_r);
+	u8 tekipaki_cmdavailable_r();
 
-	uint32_t screen_update_toaplan2(screen_device &screen, bitmap_ind16 &bitmap, const rectangle &cliprect);
-	uint32_t screen_update_dogyuun(screen_device &screen, bitmap_ind16 &bitmap, const rectangle &cliprect);
-	uint32_t screen_update_batsugun(screen_device &screen, bitmap_ind16 &bitmap, const rectangle &cliprect);
-	uint32_t screen_update_truxton2(screen_device &screen, bitmap_ind16 &bitmap, const rectangle &cliprect);
-	uint32_t screen_update_bootleg(screen_device &screen, bitmap_ind16 &bitmap, const rectangle &cliprect);
+	u32 screen_update_toaplan2(screen_device &screen, bitmap_ind16 &bitmap, const rectangle &cliprect);
+	u32 screen_update_dogyuun(screen_device &screen, bitmap_ind16 &bitmap, const rectangle &cliprect);
+	u32 screen_update_batsugun(screen_device &screen, bitmap_ind16 &bitmap, const rectangle &cliprect);
+	u32 screen_update_truxton2(screen_device &screen, bitmap_ind16 &bitmap, const rectangle &cliprect);
+	u32 screen_update_bootleg(screen_device &screen, bitmap_ind16 &bitmap, const rectangle &cliprect);
 	DECLARE_WRITE_LINE_MEMBER(screen_vblank);
 	void cpu_space_fixeightbl_map(address_map &map);
 	void cpu_space_pipibibsbl_map(address_map &map);
 	INTERRUPT_GEN_MEMBER(bbakraid_snd_interrupt);
 	void create_tx_tilemap(int dx = 0, int dx_flipped = 0);
 
-	DECLARE_WRITE8_MEMBER(pwrkick_coin_w);
-	DECLARE_WRITE8_MEMBER(pwrkick_coin_lockout_w);
+	void pwrkick_coin_w(u8 data);
+	void pwrkick_coin_lockout_w(u8 data);
 
 	DECLARE_WRITE_LINE_MEMBER(toaplan2_reset);
 
@@ -226,6 +234,7 @@ private:
 	void pipibibs_68k_mem(address_map &map);
 	void pipibibs_sound_z80_mem(address_map &map);
 	void pwrkick_68k_mem(address_map &map);
+	template<unsigned Chip> void raizing_oki(address_map &map);
 	void raizing_sound_z80_mem(address_map &map);
 	void shippumd_68k_mem(address_map &map);
 	void snowbro2_68k_mem(address_map &map);

--- a/src/mame/video/toaplan2.cpp
+++ b/src/mame/video/toaplan2.cpp
@@ -35,11 +35,9 @@
 
 TILE_GET_INFO_MEMBER(toaplan2_state::get_text_tile_info)
 {
-	int color, tile_number, attrib;
-
-	attrib = m_tx_videoram[tile_index];
-	tile_number = attrib & 0x3ff;
-	color = attrib >> 10;
+	const u16 attrib = m_tx_videoram[tile_index];
+	const u32 tile_number = attrib & 0x3ff;
+	const u32 color = attrib >> 10;
 	SET_TILE_INFO_MEMBER(0,
 			tile_number,
 			color,
@@ -92,7 +90,7 @@ VIDEO_START_MEMBER(toaplan2_state,truxton2)
 	VIDEO_START_CALL_MEMBER(toaplan2);
 
 	/* Create the Text tilemap for this game */
-	m_gfxdecode->gfx(0)->set_source(reinterpret_cast<uint8_t *>(m_tx_gfxram.target()));
+	m_gfxdecode->gfx(0)->set_source(reinterpret_cast<u8 *>(m_tx_gfxram.target()));
 
 	create_tx_tilemap(0x1d5, 0x16a);
 }
@@ -136,7 +134,7 @@ VIDEO_START_MEMBER(toaplan2_state,batrider)
 	m_vdp[0]->disable_sprite_buffer(); // disable buffering on this game
 
 	/* Create the Text tilemap for this game */
-	m_gfxdecode->gfx(0)->set_source(reinterpret_cast<uint8_t *>(m_tx_gfxram.target()));
+	m_gfxdecode->gfx(0)->set_source(reinterpret_cast<u8 *>(m_tx_gfxram.target()));
 
 	create_tx_tilemap(0x1d4, 0x16b);
 
@@ -144,14 +142,14 @@ VIDEO_START_MEMBER(toaplan2_state,batrider)
 	save_item(NAME(m_gfxrom_bank));
 }
 
-WRITE16_MEMBER(toaplan2_state::tx_videoram_w)
+void toaplan2_state::tx_videoram_w(offs_t offset, u16 data, u16 mem_mask)
 {
 	COMBINE_DATA(&m_tx_videoram[offset]);
 	if (offset < 64*32)
 		m_tx_tilemap->mark_tile_dirty(offset);
 }
 
-WRITE16_MEMBER(toaplan2_state::tx_linescroll_w)
+void toaplan2_state::tx_linescroll_w(offs_t offset, u16 data, u16 mem_mask)
 {
 	/*** Line-Scroll RAM for Text Layer ***/
 	COMBINE_DATA(&m_tx_linescroll[offset]);
@@ -159,11 +157,11 @@ WRITE16_MEMBER(toaplan2_state::tx_linescroll_w)
 	m_tx_tilemap->set_scrollx(offset, m_tx_linescroll[offset]);
 }
 
-WRITE16_MEMBER(toaplan2_state::tx_gfxram_w)
+void toaplan2_state::tx_gfxram_w(offs_t offset, u16 data, u16 mem_mask)
 {
 	/*** Dynamic GFX decoding for Truxton 2 / FixEight ***/
 
-	uint16_t oldword = m_tx_gfxram[offset];
+	const u16 oldword = m_tx_gfxram[offset];
 
 	if (oldword != data)
 	{
@@ -172,11 +170,11 @@ WRITE16_MEMBER(toaplan2_state::tx_gfxram_w)
 	}
 }
 
-WRITE16_MEMBER(toaplan2_state::batrider_tx_gfxram_w)
+void toaplan2_state::batrider_tx_gfxram_w(offs_t offset, u16 data, u16 mem_mask)
 {
 	/*** Dynamic GFX decoding for Batrider / Battle Bakraid ***/
 
-	uint16_t oldword = m_tx_gfxram[offset];
+	const u16 oldword = m_tx_gfxram[offset];
 
 	if (oldword != data)
 	{
@@ -185,7 +183,7 @@ WRITE16_MEMBER(toaplan2_state::batrider_tx_gfxram_w)
 	}
 }
 
-WRITE16_MEMBER(toaplan2_state::batrider_textdata_dma_w)
+void toaplan2_state::batrider_textdata_dma_w(u16 data)
 {
 	/*** Dynamic Text GFX decoding for Batrider ***/
 	/*** Only done once during start-up ***/
@@ -196,7 +194,7 @@ WRITE16_MEMBER(toaplan2_state::batrider_textdata_dma_w)
 	}
 }
 
-WRITE16_MEMBER(toaplan2_state::batrider_pal_text_dma_w)
+void toaplan2_state::batrider_pal_text_dma_w(u16 data)
 {
 	// FIXME: In batrider and bbakraid, the text layer and palette RAM
 	// are probably DMA'd from main RAM by writing here at every vblank,
@@ -208,7 +206,7 @@ WRITE16_MEMBER(toaplan2_state::batrider_pal_text_dma_w)
 	}
 }
 
-WRITE8_MEMBER(toaplan2_state::batrider_objectbank_w)
+void toaplan2_state::batrider_objectbank_w(offs_t offset, u8 data)
 {
 	data &= 0xf;
 	if (m_gfxrom_bank[offset] != data)
@@ -224,7 +222,7 @@ void toaplan2_state::batrider_bank_cb(u8 layer, u32 &code)
 }
 
 // Dogyuun doesn't appear to require fancy mixing?
-uint32_t toaplan2_state::screen_update_dogyuun(screen_device &screen, bitmap_ind16 &bitmap, const rectangle &cliprect)
+u32 toaplan2_state::screen_update_dogyuun(screen_device &screen, bitmap_ind16 &bitmap, const rectangle &cliprect)
 {
 	bitmap.fill(0, cliprect);
 	if (m_vdp[1])
@@ -238,13 +236,12 @@ uint32_t toaplan2_state::screen_update_dogyuun(screen_device &screen, bitmap_ind
 		m_vdp[0]->render_vdp(bitmap, cliprect);
 	}
 
-
 	return 0;
 }
 
 
 // renders to 2 bitmaps, and mixes output
-uint32_t toaplan2_state::screen_update_batsugun(screen_device &screen, bitmap_ind16 &bitmap, const rectangle &cliprect)
+u32 toaplan2_state::screen_update_batsugun(screen_device &screen, bitmap_ind16 &bitmap, const rectangle &cliprect)
 {
 //  bitmap.fill(0, cliprect);
 //  gp9001_custom_priority_bitmap->fill(0, cliprect);
@@ -262,7 +259,6 @@ uint32_t toaplan2_state::screen_update_batsugun(screen_device &screen, bitmap_in
 		m_vdp[1]->render_vdp(m_secondary_render_bitmap, cliprect);
 	}
 
-
 	// key test places in batsugun
 	// level 2 - the two layers of clouds (will appear under background, or over ships if wrong)
 	// level 3 - the special effect 'layer' which should be under everything (will appear over background if wrong)
@@ -276,22 +272,19 @@ uint32_t toaplan2_state::screen_update_batsugun(screen_device &screen, bitmap_in
 
 	if (m_vdp[0] && m_vdp[1])
 	{
-		uint16_t* src_vdp0; // output buffer of vdp0
-		uint16_t* src_vdp1; // output buffer of vdp1
-
-		for (int y=cliprect.min_y;y<=cliprect.max_y;y++)
+		for (int y = cliprect.min_y; y <= cliprect.max_y; y++)
 		{
-			src_vdp0 = &bitmap.pix16(y);
-			src_vdp1 = &m_secondary_render_bitmap.pix16(y);
+			u16* src_vdp0 = &bitmap.pix16(y);
+			const u16* src_vdp1 = &m_secondary_render_bitmap.pix16(y);
 
-			for (int x=cliprect.min_x;x<=cliprect.max_x;x++)
+			for (int x = cliprect.min_x; x <= cliprect.max_x; x++)
 			{
-				uint16_t GPU0_LUTaddr = src_vdp0[x];
-				uint16_t GPU1_LUTaddr = src_vdp1[x];
+				const u16 GPU0_LUTaddr = src_vdp0[x];
+				const u16 GPU1_LUTaddr = src_vdp1[x];
 
 				// these equations is derived from the PAL, but doesn't seem to work?
 
-				int COMPARISON = ((GPU0_LUTaddr & 0x0780) > (GPU1_LUTaddr & 0x0780));
+				const bool COMPARISON = ((GPU0_LUTaddr & 0x0780) > (GPU1_LUTaddr & 0x0780));
 
 				// note: GPU1_LUTaddr & 0x000f - transparency check for vdp1? (gfx are 4bpp, the low 4 bits of the lookup would be the pixel data value)
 #if 0
@@ -340,7 +333,7 @@ uint32_t toaplan2_state::screen_update_batsugun(screen_device &screen, bitmap_in
 }
 
 
-uint32_t toaplan2_state::screen_update_toaplan2(screen_device &screen, bitmap_ind16 &bitmap, const rectangle &cliprect)
+u32 toaplan2_state::screen_update_toaplan2(screen_device &screen, bitmap_ind16 &bitmap, const rectangle &cliprect)
 {
 	bitmap.fill(0, cliprect);
 	m_custom_priority_bitmap.fill(0, cliprect);
@@ -351,7 +344,7 @@ uint32_t toaplan2_state::screen_update_toaplan2(screen_device &screen, bitmap_in
 
 
 /* fixeightbl and bgareggabl do not use the lineselect or linescroll tables */
-uint32_t toaplan2_state::screen_update_bootleg(screen_device &screen, bitmap_ind16 &bitmap, const rectangle &cliprect)
+u32 toaplan2_state::screen_update_bootleg(screen_device &screen, bitmap_ind16 &bitmap, const rectangle &cliprect)
 {
 	screen_update_toaplan2(screen, bitmap, cliprect);
 	m_tx_tilemap->draw(screen, bitmap, cliprect, 0);
@@ -359,7 +352,7 @@ uint32_t toaplan2_state::screen_update_bootleg(screen_device &screen, bitmap_ind
 }
 
 
-uint32_t toaplan2_state::screen_update_truxton2(screen_device &screen, bitmap_ind16 &bitmap, const rectangle &cliprect)
+u32 toaplan2_state::screen_update_truxton2(screen_device &screen, bitmap_ind16 &bitmap, const rectangle &cliprect)
 {
 	screen_update_toaplan2(screen, bitmap, cliprect);
 


### PR DESCRIPTION
Simplify handlers, Fix namings, Spacings, Reduce duplicates, Unnecessary lines, Runtime tag lookups, Correct output rate, Use optional_memory_bank for bgaregga/batrider OKI bankswitching because these aren't present NMK112, Use shorter / correct type values