### PR TITLE
Fix up some commented out testing code (nw)

### DIFF
--- a/src/devices/cpu/i386/cache.h
+++ b/src/devices/cpu/i386/cache.h
@@ -8,9 +8,10 @@
 
 /* To test it outside of Mame
 #include <cstdlib>
+#include <cstdint>
 
-typedef unsigned char u8;
-typedef unsigned int u32;
+typedef uint8_t u8;
+typedef uint32_t u32;
 */
 
 enum {


### PR DESCRIPTION
Basically, there was some testing code here that assumed unsigned char was always 8 bits, and that unsigned int was always 32 bits, which fails on some systems.