### PR TITLE
xavix - store the extra codebank byte in a private stack when making long calls etc.

### DIFF
--- a/src/devices/cpu/m6502/oxavix.lst
+++ b/src/devices/cpu/m6502/oxavix.lst
@@ -4,8 +4,8 @@
 
 callf_xa3
 	read(SP);
-	write(SP, get_codebank());
-	dec_SP();
+	write_special_stack(get_codebank());
+	dec_special_stack();
 	TMP2 = read_pc();
 	TMP = read_pc();
 	//read(SP);
@@ -33,8 +33,8 @@ retf_imp
 	PC = read(SP);
 	inc_SP();
 	PC = set_h(PC, read(SP));
-	inc_SP();
-	TMP2 = read(SP);
+	inc_special_stack();
+	TMP2 = read_special_stack();
 	set_codebank(TMP2);
 	read_pc();
 	prefetch();
@@ -47,9 +47,9 @@ brk_xav_imp
 	} else {
 		read_pc();
 	}
-	write(SP, get_codebank());
+	write_special_stack(get_codebank());
 	set_codebank(0x00); // epo_efdx, rad_ping and rad_mtrk strongly suggest that interrupts must force bank 0 as code jumps to a ROM pointer stored earlier / a fixed pointer to a rom address in bank 0
-	dec_SP();
+	dec_special_stack();
 	write(SP, PC >> 8);
 	dec_SP();
 	write(SP, PC);
@@ -115,8 +115,8 @@ rti_xav_imp
 	PC = read(SP);
 	inc_SP();
 	PC = set_h(PC, read(SP));
-	inc_SP();
-	TMP2 = read(SP);
+	inc_special_stack();
+	TMP2 = read_special_stack();
 	set_codebank(TMP2);
 	prefetch();
 

--- a/src/devices/cpu/m6502/xavix.h
+++ b/src/devices/cpu/m6502/xavix.h
@@ -131,6 +131,18 @@ protected:
 	void set_databank(uint8_t bank);
 	uint8_t get_databank();
 
+	void write_special_stack(uint8_t data);
+	void dec_special_stack();
+	void inc_special_stack();
+	uint8_t read_special_stack();
+
+	/* we store the additional 'codebank' used for far calls in a different, private stack
+	   this seems to be neccessary for 'rad_hnt2' not to crash when bringing up the calibration / score table screens
+	   and also for ekara 'a1' cart not to crash shortly after going ingame
+	   it's possible however the stack format is just incorrect, so the exact reason for this being needed does
+	   need further research */
+	uint8_t m_special_stack[0x100];
+	uint8_t m_special_stackpos;
 };
 
 enum {


### PR DESCRIPTION
xavix - store the extra codebank byte in a private stack when making long calls etc. (fixes crash on calibration screen in rad_hnt2)

this seems feasible as it's an extension to the CPU, so keeping it in a private stack would maintain better compatibility with 6502 code