### PR TITLE
o2.cpp: Add notes about the O2 Keyboard MCU (Zilog "RT101+228A") [Sea…

### DIFF
--- a/src/mame/drivers/o2.cpp
+++ b/src/mame/drivers/o2.cpp
@@ -12,6 +12,11 @@
     1f000000 - 1f3fffff      MACE
     1fc00000 - 1fc7ffff      Boot ROM
     40000000 - 7fffffff      RAM
+    
+NOTE: The default Sgi O2 Keyboard (Model No. RT6856T, Part No. 121472-101-B, 
+      Sgi No. 062-0002-001) has a Zilog "RT101+228A" MCU, which is really a
+      Zilog Z8615 (a Z8-based PC keyboard controller) with 4K ROM (undumped).
+      It might have a custom ROM, since it had special marking.
 
 **********************************************************************/
 


### PR DESCRIPTION
…n Riddle]

Some info discovered after decapping the Zilog MCU from the default Sgi Keyboard for the O2