### PR TITLE
pc98.xml: softlist updates, part 5 (D)

### DIFF
--- a/hash/pc98.xml
+++ b/hash/pc98.xml
@@ -13863,7 +13863,7 @@ only have some part of Windows file and a Video driver(CLGD?).
 		<!-- Origin: Neo Kobe Collection -->
 		<description>Desire - Haitoku no Rasen</description>
 		<year>1994</year>
-		<publisher>ジャパンホームビデオ  (Japan Home Video)</publisher>
+		<publisher>シーズウェア (C's Ware)</publisher>
 		<info name="alt_title" value="デザイア 背徳の螺旋" />
 		<info name="release" value="19940722" />
 		<part name="flop1" interface="floppy_5_25">

--- a/hash/pc98.xml
+++ b/hash/pc98.xml
@@ -11886,8 +11886,8 @@ only have some part of Windows file and a Video driver(CLGD?).
 		<info name="alt_title" value="３Ｄ（ディー・オーどきどき）ディスク Ｖｏｌ．２" />
 		<info name="release" value="199109xx" />
 		<part name="flop1" interface="floppy_5_25">
-			<dataarea name="flop" size="1265664">
-				<rom name="d.o. doki doki disk vol. 2.hdm" size="1265664" crc="a7c042e8" sha1="6fd31e52dd44a2d6dab959d9313baeb83afec1e2" offset="0" />
+			<dataarea name="flop" size="1261568">
+				<rom name="d.o. doki doki disk vol. 2.hdm" size="1261568" crc="a7c042e8" sha1="6fd31e52dd44a2d6dab959d9313baeb83afec1e2" offset="0" />
 			</dataarea>
 		</part>
 	</software>
@@ -31126,7 +31126,7 @@ Requires MS-DOS 5.00H plus an unknown procedure (HDD install?)
 		<part name="flop2" interface="floppy_5_25">
 			<feature name="part_id" value="System Disk 2"/>
 			<dataarea name="flop" size="1261568">
-				<rom name="new 3d golf simulation (ver. 2.0) (system disk 1).hdm" size="1261568" crc="61c74384" sha1="fdfdd616188e22bd041d6dbecc635a23cdab7694" offset="0" />
+				<rom name="new 3d golf simulation (ver. 2.0) (system disk 2).hdm" size="1261568" crc="61c74384" sha1="fdfdd616188e22bd041d6dbecc635a23cdab7694" offset="0" />
 			</dataarea>
 		</part>
 	</software>

--- a/hash/pc98.xml
+++ b/hash/pc98.xml
@@ -9202,6 +9202,7 @@ only have some part of Windows file and a Video driver(CLGD?).
 		<publisher>シエラオンラインジャパン (Sierra On-Line Japan)</publisher>
 		<info name="alt_title" value="ドクターブレイン パズルの城 ~ Dr. Brain - Puzzle no Shiro" />
 		<info name="release" value="19921009" />
+		<info name="usage" value="Run INSTALL.COM from DOS" />
 		<part name="flop1" interface="floppy_5_25">
 			<feature name="part_id" value="Disk 1"/>
 			<dataarea name="flop" size="1265664">
@@ -11705,7 +11706,7 @@ only have some part of Windows file and a Video driver(CLGD?).
 	</software>
 
 	<software name="dennoga2">
-		<description>Dennou Gakuen 2 - Cybernetic Hi-School Part 2 - Highway Buster</description>
+		<description>Cybernetic Hi-School / Dennou Gakuen Part 2 - Highway Buster</description>
 		<year>1989</year>
 		<publisher>ガイナックス (Gainax)</publisher>
 		<info name="alt_title" value="電脳学園２ ハイウェイバスター！！" />
@@ -11821,19 +11822,19 @@ only have some part of Windows file and a Video driver(CLGD?).
 		<info name="alt_title" value="ディー・アーク 外伝" />
 		<info name="release" value="19930709" />
 		<part name="flop1" interface="floppy_5_25">
-			<feature name="part_id" value="Disk 1"/>
+			<feature name="part_id" value="Disk A"/>
 			<dataarea name="flop" size="1265664">
 				<rom name="dark gaiden_1.fdi" size="1265664" crc="14a00525" sha1="928d4969fdd9caf950f5931e734407a2c8b09f7e" offset="0" />
 			</dataarea>
 		</part>
 		<part name="flop2" interface="floppy_5_25">
-			<feature name="part_id" value="Disk 2"/>
+			<feature name="part_id" value="Disk B"/>
 			<dataarea name="flop" size="1265664">
 				<rom name="dark gaiden_2.fdi" size="1265664" crc="a4a7ca7f" sha1="0b8c56f14b4cdfe5f2c4c983804faa64a8940e25" offset="0" />
 			</dataarea>
 		</part>
 		<part name="flop3" interface="floppy_5_25">
-			<feature name="part_id" value="Disk 3"/>
+			<feature name="part_id" value="Disk C"/>
 			<dataarea name="flop" size="1265664">
 				<rom name="dark gaiden_3.fdi" size="1265664" crc="9faf648c" sha1="a96f69f25c323cef74894809c0fa1235d32a5643" offset="0" />
 			</dataarea>
@@ -11878,6 +11879,7 @@ only have some part of Windows file and a Video driver(CLGD?).
 	</software>
 
 	<software name="dodokid2">
+		<!-- Origin: Neo Kobe Collection -->
 		<description>D.O. Doki Doki Disk Vol. 02</description>
 		<year>1991</year>
 		<publisher>ディー・オー (D.O.)</publisher>
@@ -11885,7 +11887,7 @@ only have some part of Windows file and a Video driver(CLGD?).
 		<info name="release" value="199109xx" />
 		<part name="flop1" interface="floppy_5_25">
 			<dataarea name="flop" size="1265664">
-				<rom name="3d_disk2.fdi" size="1265664" crc="9f98e520" sha1="0cc17640de59c4145b7e2e9d89a37bc3db56a6a9" offset="0" />
+				<rom name="d.o. doki doki disk vol. 2.hdm" size="1265664" crc="a7c042e8" sha1="6fd31e52dd44a2d6dab959d9313baeb83afec1e2" offset="0" />
 			</dataarea>
 		</part>
 	</software>
@@ -11953,9 +11955,29 @@ only have some part of Windows file and a Video driver(CLGD?).
 		</part>
 	</software>
 
+	<software name="dodokid8">
+		<!-- Origin: Neo Kobe Collection -->
+		<description>D.O. Doki Doki Disk Vol. 08</description>
+		<year>1995</year>
+		<publisher>ディー・オー (D.O.)</publisher>
+		<info name="alt_title" value="３Ｄ（ディー・オーどきどき）ディスク Ｖｏｌ．９" />
+		<part name="flop1" interface="floppy_5_25">
+			<feature name="part_id" value="Disk A"/>
+			<dataarea name="flop" size="1261568">
+				<rom name="d.o. doki doki disk vol. 8 (disk a).hdm" size="1261568" crc="672b16cc" sha1="e34b513b22bca44772f02dd69ce8f2c799492bc1" offset="0" />
+			</dataarea>
+		</part>
+		<part name="flop2" interface="floppy_5_25">
+			<feature name="part_id" value="Disk B"/>
+			<dataarea name="flop" size="1261568">
+				<rom name="d.o. doki doki disk vol. 8 (disk b).hdm" size="1261568" crc="52d31cf0" sha1="564b666018e9b1533840154c5174124b4b42607b" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
 	<software name="dodokid9">
 		<description>D.O. Doki Doki Disk Vol. 09</description>
-		<year>19??</year>
+		<year>1995</year>
 		<publisher>ディー・オー (D.O.)</publisher>
 		<info name="alt_title" value="３Ｄ（ディー・オーどきどき）ディスク Ｖｏｌ．９" />
 		<part name="flop1" interface="floppy_5_25">
@@ -11972,8 +11994,8 @@ only have some part of Windows file and a Video driver(CLGD?).
 		</part>
 	</software>
 
-<!-- disk A maybe damaged? -->
 	<software name="dokaizo">
+		<!-- Origin: Neo Kobe Collection -->
 		<description>D.O. Kaizokuban</description>
 		<year>1993</year>
 		<publisher>ディー・オー (D.O.)</publisher>
@@ -11981,24 +12003,25 @@ only have some part of Windows file and a Video driver(CLGD?).
 		<info name="release" value="19930501" />
 		<part name="flop1" interface="floppy_5_25">
 			<feature name="part_id" value="Disk A"/>
-			<dataarea name="flop" size="1265664">
-				<rom name="adisk.fdi" size="1265664" crc="2364e23a" sha1="03f77067fc02844f2d223deb409af4c218c785b9" offset="0" />
+			<dataarea name="flop" size="1261568">
+				<rom name="d.o. kaizokuban (disk a).hdm" size="1261568" crc="1bbea9a5" sha1="e626f0ae9d04302cd35ec8efd26b91da399ff734" offset="0" />
 			</dataarea>
 		</part>
 		<part name="flop2" interface="floppy_5_25">
 			<feature name="part_id" value="Disk B"/>
-			<dataarea name="flop" size="1265664">
-				<rom name="bdisk.fdi" size="1265664" crc="56992f79" sha1="ff1a0474a5ac51f6b068f891481de3a9519d852b" offset="0" />
+			<dataarea name="flop" size="1261568">
+				<rom name="d.o. kaizokuban (disk b).hdm" size="1261568" crc="535646fb" sha1="2c4ffc25383cf26e01472c5177c4cfc23406dfeb" offset="0" />
 			</dataarea>
 		</part>
 		<part name="flop3" interface="floppy_5_25">
 			<feature name="part_id" value="Disk C"/>
-			<dataarea name="flop" size="1265664">
-				<rom name="cdisk.fdi" size="1265664" crc="5fe21553" sha1="6476fabc3a5ad27f48e8b5d7abf6da9b1d403faf" offset="0" />
+			<dataarea name="flop" size="1261568">
+				<rom name="d.o. kaizokuban (disk c).hdm" size="1261568" crc="5a2d7cd1" sha1="b00303406321df2cee5745668a8df0945b3597b7" offset="0" />
 			</dataarea>
 		</part>
 	</software>
 
+	<!-- Seems to work only on 286-based machines (e.g. PC-9801UX) -->
 	<software name="dps">
 		<description>D.P.S. - Dream Program System</description>
 		<year>1989</year>
@@ -12019,7 +12042,8 @@ only have some part of Windows file and a Video driver(CLGD?).
 		</part>
 	</software>
 
-	<software name="dpsa" cloneof="dps" supported="no">
+	<!-- Seems to work only on 286-based machines (e.g. PC-9801UX) -->
+	<software name="dpsa" cloneof="dps">
 		<description>D.P.S. - Dream Program System (Alt)</description>
 		<year>1989</year>
 		<publisher>アリスソフト (Alicesoft)</publisher>
@@ -12135,7 +12159,8 @@ only have some part of Windows file and a Video driver(CLGD?).
 		</part>
 	</software>
 
-	<software name="dwars">
+	<!-- Seems to work only on 286-based machines (e.g. PC-9801UX) -->
+	<software name="dwars" supported="partial">
 		<description>D.Wars</description>
 		<year>1989</year>
 		<publisher>ソフトプラン (Soft Plan)</publisher>
@@ -12200,6 +12225,7 @@ only have some part of Windows file and a Video driver(CLGD?).
 		<publisher>Quota</publisher>
 		<info name="alt_title" value="大撃沈 日米 海底の対決" />
 		<info name="release" value="19911220" />
+		<info name="usage" value="Boot from a DOS floppy with Disk 1 on the second drive, and run T.BAT. After the system copy finishes, boot from Disk 1. The game has copy protection that requires the original manual." />
 		<part name="flop1" interface="floppy_5_25">
 			<feature name="part_id" value="Disk 1"/>
 			<dataarea name="flop" size="1281968">
@@ -12243,6 +12269,27 @@ only have some part of Windows file and a Video driver(CLGD?).
 			</dataarea>
 		</part>
 	</software>
+
+	<software name="daijutai">
+		<!-- Origin: Neo Kobe Collection -->
+		<description>Daijuutai</description>
+		<year>1993</year>
+		<publisher>日本道路協会 (Japan Road Association)</publisher>
+		<info name="alt_title" value="大渋滞" />
+		<part name="flop1" interface="floppy_5_25">
+			<feature name="part_id" value="Disk 1"/>
+			<dataarea name="flop" size="1261568">
+				<rom name="daijuutai (disk 1).hdm" size="1261568" crc="fcc1aa73" sha1="acc8b2688ed774c994a92a50a76469c8ddc954f1" offset="0" />
+			</dataarea>
+		</part>
+		<part name="flop2" interface="floppy_5_25">
+			<feature name="part_id" value="Disk 2"/>
+			<dataarea name="flop" size="1261568">
+				<rom name="daijuutai (disk 2).hdm" size="1261568" crc="a77f442a" sha1="b632203581c9b430cd876866bed3dd3603c112ee" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
 
 	<software name="nankaish">
 		<description>Daikairei - Nankai no Shitou</description>
@@ -12296,6 +12343,7 @@ only have some part of Windows file and a Video driver(CLGD?).
 		<publisher>システムソフト (SystemSoft)</publisher>
 		<info name="alt_title" value="大海戦 ソロモン１９４２－１９４３" />
 		<info name="release" value="19950728" />
+		<info name="usage" value="Run SSHDINST.BAT from DOS to install to HDD. Requires a serial number printed on the user registration card." />
 		<part name="flop1" interface="floppy_5_25">
 			<feature name="part_id" value="Game Disk 1"/>
 			<dataarea name="flop" size="1261568">
@@ -12347,7 +12395,7 @@ only have some part of Windows file and a Video driver(CLGD?).
 			</dataarea>
 		</part>
 		<part name="flop2" interface="floppy_5_25">
-			<feature name="part_id" value="Umi? Disk"/>
+			<feature name="part_id" value="Umi Disk"/>
 			<dataarea name="flop" size="1265664">
 				<rom name="daijidai_umi.fdi" size="1265664" crc="29121f73" sha1="2349a44a6d3cb9a5a04e6b5b9d6d1e49ae0123ba" offset="0" />
 			</dataarea>
@@ -12361,24 +12409,18 @@ only have some part of Windows file and a Video driver(CLGD?).
 		<info name="alt_title" value="大航海時代２" />
 		<info name="release" value="19930210" />
 		<part name="flop1" interface="floppy_5_25">
-			<feature name="part_id" value="Start Disk"/>
-			<dataarea name="flop" size="1265664">
-				<rom name="daijidai2_kidou.fdi" size="1265664" crc="2f0bd0f8" sha1="ea4ab0480d36c99e9529627fdfb434651828c61f" offset="0" />
-			</dataarea>
-		</part>
-		<part name="flop2" interface="floppy_5_25">
 			<feature name="part_id" value="Disk A"/>
 			<dataarea name="flop" size="1265664">
 				<rom name="daijidai2_a.fdi" size="1265664" crc="410d8a3b" sha1="0d6ccb59e472d1664375e92e0e95d27d1977c394" offset="0" />
 			</dataarea>
 		</part>
-		<part name="flop3" interface="floppy_5_25">
+		<part name="flop2" interface="floppy_5_25">
 			<feature name="part_id" value="Disk B"/>
 			<dataarea name="flop" size="1265664">
 				<rom name="daijidai2_b.fdi" size="1265664" crc="629a0348" sha1="fdba78b90c6294a2244565caa590a451bf0a2fad" offset="0" />
 			</dataarea>
 		</part>
-		<part name="flop4" interface="floppy_5_25">
+		<part name="flop3" interface="floppy_5_25">
 			<feature name="part_id" value="Disk C"/>
 			<dataarea name="flop" size="1265664">
 				<rom name="daijidai2_c.fdi" size="1265664" crc="2c0e6f94" sha1="4d8514707b4be68da86bd35230699dd5e56ed0d7" offset="0" />
@@ -12399,7 +12441,8 @@ only have some part of Windows file and a Video driver(CLGD?).
 		</part>
 	</software>
 
-	<software name="daisenr2ed" cloneof="daisenr2">
+	<!-- Fails to boot with a BASIC error: "BASIC LEBEL ERROR TYPE 64:n 390 RESET" -->
+	<software name="daisenr2ed" cloneof="daisenr2" supported="no">
 		<description>Daisenryaku II - Editor Set</description>
 		<year>1987</year>
 		<publisher>システムソフト (SystemSoft)</publisher>
@@ -12413,7 +12456,8 @@ only have some part of Windows file and a Video driver(CLGD?).
 		</part>
 	</software>
 
-	<software name="daisn2sp">
+	<!-- Black screen on boot -->
+	<software name="daisn2sp" supported="no">
 		<description>Daisenryaku II SP</description>
 		<year>1988</year>
 		<publisher>システムソフト (SystemSoft)</publisher>
@@ -12467,32 +12511,27 @@ only have some part of Windows file and a Video driver(CLGD?).
 		<info name="alt_title" value="大戦略３＇９０" />
 		<info name="release" value="19901026" />
 		<part name="flop1" interface="floppy_5_25">
-			<feature name="part_id" value="Disk A"/>
+			<feature name="part_id" value="Disk 1"/>
 			<dataarea name="flop" size="1281968">
 				<rom name="daisenryaku 3'90 (j) a.d88" size="1281968" crc="cd2b4ce8" sha1="ed24528b6856dbd078d534e1c224bb281bc2920a" offset="0" />
 			</dataarea>
 		</part>
 		<part name="flop2" interface="floppy_5_25">
-			<feature name="part_id" value="Disk B"/>
+			<feature name="part_id" value="Disk 2"/>
 			<dataarea name="flop" size="1281968">
 				<rom name="daisenryaku 3'90 (j) b.d88" size="1281968" crc="c909755c" sha1="c70c2e95a0384040db3ce81daaa5ee72cf35734d" offset="0" />
 			</dataarea>
 		</part>
 		<part name="flop3" interface="floppy_5_25">
-			<feature name="part_id" value="Disk C"/>
+			<feature name="part_id" value="Disk 3"/>
 			<dataarea name="flop" size="1281968">
 				<rom name="daisenryaku 3'90 (j) c.d88" size="1281968" crc="3637166f" sha1="fd5632902a34ff7afbf60cc406e49fd1bd96d459" offset="0" />
 			</dataarea>
 		</part>
-		<part name="flop4" interface="floppy_5_25">
-			<feature name="part_id" value="User Disk"/>
-			<dataarea name="flop" size="1265664">
-				<rom name="daisenryaku 3'90 (j) user.fdi" size="1265664" crc="28b9452f" sha1="c8930a973cb5b6875631a0cad99b846d067353ae" offset="0" status="baddump" />
-			</dataarea>
-		</part>
 	</software>
 
-	<software name="daisn390ed" cloneof="daisn390">
+	<!-- Black screen on boot -->
+	<software name="daisn390ed" cloneof="daisn390" supported="no">
 		<description>Daisenryaku III '90 - Kakuchou Editor Disk</description>
 		<year>1991</year>
 		<publisher>タケル (Takeru)</publisher>
@@ -12512,7 +12551,7 @@ only have some part of Windows file and a Video driver(CLGD?).
 		<publisher>システムソフト (SystemSoft)</publisher>
 		<info name="alt_title" value="大戦略３＇９０ マップコレクション" />
 		<info name="release" value="19901213" />
-		<info name="usage" value="Requires &quot;Daisenryaku III '90&quot; to work" />
+		<info name="usage" value="Requires &quot;Daisenryaku III '90&quot; to work. On the map screen, insert this disk on drive 1 and press F1 to load." />
 		<part name="flop1" interface="floppy_5_25">
 			<dataarea name="flop" size="1086448">
 				<rom name="daisenr3_90_map_set_1.d88" size="1086448" crc="b0a80ecb" sha1="42e47bef1abfd18b43d48de0279a21054a0ba0a7" offset="0" />
@@ -12526,7 +12565,7 @@ only have some part of Windows file and a Video driver(CLGD?).
 		<publisher>システムソフト (SystemSoft)</publisher>
 		<info name="alt_title" value="大戦略３＇９０ マップコレクション２" />
 		<info name="release" value="19910628" />
-		<info name="usage" value="Requires &quot;Daisenryaku III '90&quot; to work" />
+		<info name="usage" value="Requires &quot;Daisenryaku III '90&quot; to work. On the map screen, insert this disk on drive 1 and press F1 to load." />
 		<part name="flop1" interface="floppy_5_25">
 			<feature name="part_id" value="Disk 1"/>
 			<dataarea name="flop" size="1086448">
@@ -12541,7 +12580,8 @@ only have some part of Windows file and a Video driver(CLGD?).
 		</part>
 	</software>
 
-	<software name="daisenr4">
+	<!-- The process of creating a new user disk works, but the game hangs when you try to load a map -->
+	<software name="daisenr4" supported="no">
 		<description>Daisenryaku IV</description>
 		<year>1992</year>
 		<publisher>システムソフト (SystemSoft)</publisher>
@@ -12575,8 +12615,8 @@ only have some part of Windows file and a Video driver(CLGD?).
 		</part>
 	</software>
 
-<!-- Editor for multiple Daisenryaku games (Super Daisenryaku, Campaign Daisenryaku, or Daisenryaku 3 '90) -->
-	<software name="daisnmed">
+	<!-- Editor for multiple Daisenryaku games (Super Daisenryaku, Campaign Daisenryaku, or Daisenryaku 3 '90). Boots to a black screen with a mouse cursor. -->
+	<software name="daisnmed" supported="no">
 		<description>Daisenryaku Multi-Editor</description>
 		<year>1992</year>
 		<publisher>システムソフト (SystemSoft)</publisher>
@@ -12622,7 +12662,8 @@ only have some part of Windows file and a Video driver(CLGD?).
 		</part>
 	</software>
 
-	<software name="daiva">
+	<!-- Can't run the game, it asks for the system disk even when it's inserted -->
+	<software name="daiva" supported="no">
 		<description>Daiva - Kari-Yuga no Kouki</description>
 		<year>1987</year>
 		<publisher>ティーアンドイーソフト (T&amp;E Soft)</publisher>
@@ -12642,7 +12683,7 @@ only have some part of Windows file and a Video driver(CLGD?).
 		</part>
 	</software>
 
-	<software name="daivaa" cloneof="daiva">
+	<software name="daivaa" cloneof="daiva" supported="no">
 		<description>Daiva - Kari-Yuga no Kouki (Alt Format)</description>
 		<year>1987</year>
 		<publisher>ティーアンドイーソフト (T&amp;E Soft)</publisher>
@@ -12682,7 +12723,8 @@ only have some part of Windows file and a Video driver(CLGD?).
 		</part>
 	</software>
 
-	<software name="dalkhint">
+	<!-- Works only on 286-based machines (e.g. PC-9801UX) -->
+	<software name="dalkhint" supported="partial">
 		<description>Dalk Hint-Disk.</description>
 		<year>1992?</year>
 		<publisher>アリスソフト (AliceSoft)</publisher>
@@ -12709,6 +12751,21 @@ only have some part of Windows file and a Video driver(CLGD?).
 			<feature name="part_id" value="Disk D"/>
 			<dataarea name="flop" size="1265664">
 				<rom name="dalk_h_d.fdi" size="1265664" crc="62e74fd7" sha1="a88a0e5198f38c9137f501c5cd7f25afd4bef460" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+	<!-- MAME fails to mount the image with "Incorrect layout on track 1 head 0, expected_size=166666, current_size=174464" error -->
+	<software name="dambustr" supported="no">
+		<!-- Origin: Neo Kobe Collection -->
+		<description>Dam Busters</description>
+		<year>1986</year>
+		<publisher>アポロテクニカ (Apollo Technica)</publisher>
+		<info name="alt_title" value="ダムバスターズ" />
+		<info name="release" value="198601xx" />
+		<part name="flop1" interface="floppy_5_25">
+			<dataarea name="flop" size="1086448">
+				<rom name="dam busters [nfd r1].nfd" size="3765072" crc="2bd54d4e" sha1="3a1df219c32478405f7ae2797d46f1ec7262eb5f" offset="0" />
 			</dataarea>
 		</part>
 	</software>
@@ -12794,7 +12851,36 @@ only have some part of Windows file and a Video driver(CLGD?).
 		</part>
 	</software>
 
-	<software name="daremo">
+	<!-- The screen glitches out when scrolling and the game seems to hang -->
+	<software name="dangtoys" supported="no">
+		<!-- Origin: Neo Kobe Collection -->
+		<description>Dangerous Toys</description>
+		<year>1996</year>
+		<publisher>ラブ・ガン (Love Gun)</publisher>
+		<info name="alt_title" value="デンジャラス トイズ" />
+		<info name="release" value="19961213" />
+		<part name="flop1" interface="floppy_5_25">
+			<feature name="part_id" value="Disk A"/>
+			<dataarea name="flop" size="1261568">
+				<rom name="dangerous toys (disk a).hdm" size="1261568" crc="f84e55ef" sha1="91355fb8e22451f47c3b7dab0930d8491ff16760" offset="0" />
+			</dataarea>
+		</part>
+		<part name="flop2" interface="floppy_5_25">
+			<feature name="part_id" value="Disk B"/>
+			<dataarea name="flop" size="1261568">
+				<rom name="dangerous toys (disk b).hdm" size="1261568" crc="8b2baf54" sha1="ee7749b3c7ee556c0a8050cc15c16b799197769f" offset="0" />
+			</dataarea>
+		</part>
+		<part name="flop3" interface="floppy_5_25">
+			<feature name="part_id" value="Disk C"/>
+			<dataarea name="flop" size="1261568">
+				<rom name="dangerous toys (disk c).hdm" size="1261568" crc="2fb28172" sha1="ccc2bb8b2fc3b233fd0dae1d8da575682213fccf" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+	<!-- Black screen on boot -->
+	<software name="daremo" supported="no">
 		<description>Dare mo Shiranai... Ushinawareta Kioku no Tobira</description>
 		<year>1994</year>
 		<publisher>エクシィーズ (Xyz)</publisher>
@@ -12820,12 +12906,52 @@ only have some part of Windows file and a Video driver(CLGD?).
 		</part>
 	</software>
 
-	<software name="dkuniomk">
+	<software name="darkser">
+		<!-- Origin: Neo Kobe Collection -->
+		<description>Dark Seraphim</description>
+		<year>1995</year>
+		<publisher>呉ソフトウエア工房 (Kure Software Koubou)</publisher>
+		<info name="alt_title" value="ダークセラフィム" />
+		<info name="release" value="19950715" />
+		<part name="flop1" interface="floppy_5_25">
+			<feature name="part_id" value="System Disk"/>
+			<dataarea name="flop" size="1261568">
+				<rom name="dark seraphim (system disk).hdm" size="1261568" crc="0232795d" sha1="c9272ac9d93525245541157c03584768bfb04995" offset="0" />
+			</dataarea>
+		</part>
+		<part name="flop2" interface="floppy_5_25">
+			<feature name="part_id" value="Opening Disk"/>
+			<dataarea name="flop" size="1261568">
+				<rom name="dark seraphim (opening disk).hdm" size="1261568" crc="46a814f5" sha1="b8c20484d110f88423955a1f32974a71193232dd" offset="0" />
+			</dataarea>
+		</part>
+		<part name="flop3" interface="floppy_5_25">
+			<feature name="part_id" value="Data Disk 1"/>
+			<dataarea name="flop" size="1261568">
+				<rom name="dark seraphim (data disk 1).hdm" size="1261568" crc="87fd283f" sha1="5afcc8e1bfef66a0f4575569a773c219b13e6cab" offset="0" />
+			</dataarea>
+		</part>
+		<part name="flop4" interface="floppy_5_25">
+			<feature name="part_id" value="Data Disk 2"/>
+			<dataarea name="flop" size="1261568">
+				<rom name="dark seraphim (data disk 2).hdm" size="1261568" crc="0276248b" sha1="c8efd58a44d797002fcedb53431ed269bef069a8" offset="0" />
+			</dataarea>
+		</part>
+		<part name="flop5" interface="floppy_5_25">
+			<feature name="part_id" value="Data Disk 4"/>
+			<dataarea name="flop" size="1261568">
+				<rom name="dark seraphim (data disk 3).hdm" size="1261568" crc="1b6049a4" sha1="d6a1a92978addf6ce2f360cb223e6131e317eba3" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+	<software name="angieomk">
 		<description>Daraku no Kuni no Angie - Kyoukai no Mesu Dorei-tachi SP Disk - Ayashii Omake Disk</description>
 		<year>1996</year>
 		<publisher>PIL</publisher>
 		<info name="alt_title" value="堕落の国のアンジー ～狂界の牝奴隷達～ ＳＰディスク「妖しいおま毛ディスク」" />
 		<info name="release" value="19960419" />
+		<info name="usage" value="Requires an existing HDD installation of Daraku no Kuni no Angie. Run OMA_INST.BAT from DOS to install." />
 		<part name="flop1" interface="floppy_5_25">
 			<dataarea name="flop" size="1265664">
 				<rom name="daraku_omake.fdi" size="1265664" crc="9da69a33" sha1="989b8d0e1cec6a62add7e90063f7725fa4394cec" offset="0" />
@@ -12910,12 +13036,28 @@ only have some part of Windows file and a Video driver(CLGD?).
 		</part>
 	</software>
 
+	<!-- No music -->
+	<software name="dkyouko" supported="partial">
+		<!-- Origin: Neo Kobe Collection -->
+		<description>Datenshi Kyouko Part I</description>
+		<year>1988</year>
+		<publisher>ニューシステムハウスオー！ (New System House Oh!)</publisher>
+		<info name="alt_title" value="堕天使ＫＹＯＵＫＯ Ｐａｒｔ１" />
+		<info name="release" value="198812xx" />
+		<part name="flop1" interface="floppy_5_25">
+			<dataarea name="flop" size="1261568">
+				<rom name="datenshi kyouko.hdm" size="1261568" crc="b43a9936" sha1="48fee7bf4d67d6cdf6ece0af42cc4918d5fa445f" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
 	<software name="daysduel">
 		<description>Days in Duel</description>
 		<year>1994</year>
 		<publisher>スワット (Swat)</publisher>
 		<info name="alt_title" value="デイズ イン デュエル" />
 		<info name="release" value="19940428" />
+		<info name="usage" value="Run INST.BAT from DOS to copy the system files" />
 		<part name="flop1" interface="floppy_5_25">
 			<feature name="part_id" value="Disk A"/>
 			<dataarea name="flop" size="1265664">
@@ -12948,7 +13090,8 @@ only have some part of Windows file and a Video driver(CLGD?).
 		</part>
 	</software>
 
-	<software name="deadbrn">
+	<!-- The main menu text is invisible -->
+	<software name="deadbrn" supported="partial">
 		<description>Dead of the Brain - Shiryou no Sakebi</description>
 		<year>1992</year>
 		<publisher>フェアリーテール (Fairytale)</publisher>
@@ -12980,7 +13123,8 @@ only have some part of Windows file and a Video driver(CLGD?).
 		</part>
 	</software>
 
-	<software name="deadbrn2">
+	<!-- The main menu text is invisible -->
+	<software name="deadbrn2" supported="partial">
 		<description>Dead of the Brain 2</description>
 		<year>1993</year>
 		<publisher>フェアリーテール (Fairytale)</publisher>
@@ -13012,42 +13156,29 @@ only have some part of Windows file and a Video driver(CLGD?).
 		</part>
 	</software>
 
-	<software name="dkkrynn">
+	<!-- Can't change disks, so it's not possible to save or load characters -->
+	<software name="dkkrynn" supported="no">
 		<description>Death Knights of Krynn</description>
 		<year>1993</year>
 		<publisher>ポニーキャニオン (Pony Canyon)</publisher>
 		<info name="alt_title" value="ＡＤ＆Ｄ デスナイト オブ クリン" />
 		<info name="release" value="19930820" />
 		<part name="flop1" interface="floppy_5_25">
-			<feature name="part_id" value="Disk A"/>
+			<feature name="part_id" value="Disk 1"/>
 			<dataarea name="flop" size="1265664">
 				<rom name="disk_a.fdi" size="1265664" crc="24ab1f37" sha1="af0060a279aa815ee87d14bcb37db1e4a1d51834" offset="0" />
 			</dataarea>
 		</part>
 		<part name="flop2" interface="floppy_5_25">
-			<feature name="part_id" value="Disk B"/>
+			<feature name="part_id" value="Disk 2"/>
 			<dataarea name="flop" size="1265664">
 				<rom name="disk_b.fdi" size="1265664" crc="04930388" sha1="cbb664965f6775a05ee7ad6de7636038a7edc4f6" offset="0" />
 			</dataarea>
 		</part>
 	</software>
 
-<!-- Presumably copy protection floppy, to be used with CD-Rom -->
-	<software name="debut">
-		<description>Debut (PC-9821 CD ver.)</description>
-		<year>1994</year>
-		<publisher>データウエスト (Data West)</publisher>
-		<info name="alt_title" value="誕生 ～デビュー～" />
-		<info name="release" value="19940408" />
-		<part name="flop1" interface="floppy_5_25">
-			<dataarea name="flop" size="1265664">
-				<rom name="tanjou key.fdi" size="1265664" crc="24a63939" sha1="e2d3b9e62f11dd2abf7bfb21d35255448871bfea" offset="0" />
-			</dataarea>
-		</part>
-	</software>
-
 	<software name="defana">
-		<description>De.Fana - Full Animation A.V.G. Series: 2</description>
+		<description>De.FaNa - Full Animation Adventure Series #2</description>
 		<year>1995</year>
 		<publisher>姫屋ソフト (Himeya Soft)</publisher>
 		<info name="alt_title" value="デ・ファーナ" />
@@ -13084,7 +13215,8 @@ only have some part of Windows file and a Video driver(CLGD?).
 		</part>
 	</software>
 
-	<software name="deflektr">
+	<!-- No sound -->
+	<software name="deflektr" supported="partial">
 		<description>Deflektor</description>
 		<year>1991</year>
 		<publisher>B·P·S (Bullet-Proof Software)</publisher>
@@ -13122,6 +13254,45 @@ only have some part of Windows file and a Video driver(CLGD?).
 		</part>
 	</software>
 
+	<software name="deadforc">
+		<!-- Origin: Neo Kobe Collection -->
+		<description>Dead Force</description>
+		<year>1994</year>
+		<publisher>風雅システム (Fuga System)</publisher>
+		<info name="alt_title" value="デッドフォース" />
+		<info name="release" value="19940729" />
+		<part name="flop1" interface="floppy_5_25">
+			<feature name="part_id" value="System Disk"/>
+			<dataarea name="flop" size="1261568">
+				<rom name="dead force (system disk).hdm" size="1261568" crc="c0244968" sha1="41440bf6f2cd790ff25c4967772b6962aa178945" offset="0" />
+			</dataarea>
+		</part>
+		<part name="flop2" interface="floppy_5_25">
+			<feature name="part_id" value="Data Disk A"/>
+			<dataarea name="flop" size="1261568">
+				<rom name="dead force (disk a).hdm" size="1261568" crc="0fdf3cc4" sha1="23f300bff32701a34bd47137a9911911ebc6a0ca" offset="0" />
+			</dataarea>
+		</part>
+		<part name="flop3" interface="floppy_5_25">
+			<feature name="part_id" value="Data Disk B"/>
+			<dataarea name="flop" size="1261568">
+				<rom name="dead force (disk b).hdm" size="1261568" crc="1e876415" sha1="e481ccde1fb0d009f993ca7cb1238d04b6a753e9" offset="0" />
+			</dataarea>
+		</part>
+		<part name="flop4" interface="floppy_5_25">
+			<feature name="part_id" value="Data Disk C"/>
+			<dataarea name="flop" size="1261568">
+				<rom name="dead force (disk c).hdm" size="1261568" crc="7b01dc69" sha1="638029f5bef074434536e5a1a04f41522089c13f" offset="0" />
+			</dataarea>
+		</part>
+		<part name="flop5" interface="floppy_5_25">
+			<feature name="part_id" value="Data Disk D"/>
+			<dataarea name="flop" size="1261568">
+				<rom name="dead force (disk d).hdm" size="1261568" crc="90697bd9" sha1="d3c35ff76e3a6ef4cce51087516cff4a04c530e6" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
 	<software name="dbringer">
 		<description>Death Bringer</description>
 		<year>1988</year>
@@ -13155,6 +13326,67 @@ only have some part of Windows file and a Video driver(CLGD?).
 		</part>
 	</software>
 
+	<software name="dlunch">
+		<!-- Origin: Neo Kobe Collection -->
+		<description>Delicious Lunch Pack</description>
+		<year>1996</year>
+		<publisher>スクープ (Scoop)</publisher>
+		<info name="alt_title" value="デリシャス らんちぱっく" />
+		<info name="release" value="19960621" />
+		<part name="flop1" interface="floppy_5_25">
+			<feature name="part_id" value="Disk 1"/>
+			<dataarea name="flop" size="1261568">
+				<rom name="delicious lunchpack (disk 1).hdm" size="1261568" crc="8e494599" sha1="507de6b6fb2449db47d31b736478322a8a6294cd" offset="0" />
+			</dataarea>
+		</part>
+		<part name="flop2" interface="floppy_5_25">
+			<feature name="part_id" value="Disk 2"/>
+			<dataarea name="flop" size="1261568">
+				<rom name="delicious lunchpack (disk 2).hdm" size="1261568" crc="0c657966" sha1="69694584ace1f937209587d363f8a11c26132c62" offset="0" />
+			</dataarea>
+		</part>
+		<part name="flop3" interface="floppy_5_25">
+			<feature name="part_id" value="Disk 3"/>
+			<dataarea name="flop" size="1261568">
+				<rom name="delicious lunchpack (disk 3).hdm" size="1261568" crc="2aff44e3" sha1="18020ae1f93c93ec3b23f12fa4eea4c038229841" offset="0" />
+			</dataarea>
+		</part>
+		<part name="flop4" interface="floppy_5_25">
+			<feature name="part_id" value="Disk 4"/>
+			<dataarea name="flop" size="1261568">
+				<rom name="delicious lunchpack (disk 4).hdm" size="1261568" crc="4eab65bc" sha1="e8d3315b82e731422036e5539ebb44921502e18b" offset="0" />
+			</dataarea>
+		</part>
+		<part name="flop5" interface="floppy_5_25">
+			<feature name="part_id" value="Disk 5"/>
+			<dataarea name="flop" size="1261568">
+				<rom name="delicious lunchpack (disk 5).hdm" size="1261568" crc="576cc74b" sha1="2beca878dbeb205f490407316e17392d521a09ed" offset="0" />
+			</dataarea>
+		</part>
+		<part name="flop6" interface="floppy_5_25">
+			<feature name="part_id" value="Disk 6"/>
+			<dataarea name="flop" size="1261568">
+				<rom name="delicious lunchpack (disk 6).hdm" size="1261568" crc="7e9ff690" sha1="d6153592cdb7dfedf82d1aae479836a44b17c5a1" offset="0" />
+			</dataarea>
+		</part>
+		<part name="flop7" interface="floppy_5_25">
+			<feature name="part_id" value="Disk 7"/>
+			<dataarea name="flop" size="1261568">
+				<rom name="delicious lunchpack (disk 7).hdm" size="1261568" crc="f2974a5e" sha1="de05a86ffa610b2ae6e7a7af79a2469f280a5827" offset="0" />
+			</dataarea>
+		</part>
+		<part name="flop8" interface="floppy_5_25">
+			<feature name="part_id" value="Disk 8"/>
+			<dataarea name="flop" size="1261568">
+				<rom name="delicious lunchpack (disk 8).hdm" size="1261568" crc="de0118fd" sha1="f957f9ba807633f012ee023e6ec937f258acc56e" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+	<!-- 
+	This game saves its configuration to the system disk, and this particular image has sound disabled.
+	To enable sound, select the "音源の設定" option on the main menu, choose FM or MIDI, and reset.
+	-->
 	<software name="delphi">
 		<description>Delphi no Shintaku</description>
 		<year>1993</year>
@@ -13162,27 +13394,27 @@ only have some part of Windows file and a Video driver(CLGD?).
 		<info name="alt_title" value="デルフォイの神託" />
 		<info name="release" value="19930325" />
 		<part name="flop1" interface="floppy_5_25">
-			<feature name="part_id" value="System"/>
+			<feature name="part_id" value="System Disk"/>
+			<dataarea name="flop" size="1265664">
+				<rom name="delphi_system.fdi" size="1265664" crc="227a1e81" sha1="02c160059f559a660c794c9149010d727b6202eb" offset="0" />
+			</dataarea>
+		</part>
+		<part name="flop2" interface="floppy_5_25">
+			<feature name="part_id" value="Data Disk 1"/>
 			<dataarea name="flop" size="1265664">
 				<rom name="delphi_data_1.fdi" size="1265664" crc="999f3837" sha1="dd2ba8d3a613e81255ac8666a8e5523efefa7ded" offset="0" />
 			</dataarea>
 		</part>
-		<part name="flop2" interface="floppy_5_25">
-			<feature name="part_id" value="Data 1"/>
+		<part name="flop3" interface="floppy_5_25">
+			<feature name="part_id" value="Data Disk 2"/>
 			<dataarea name="flop" size="1265664">
 				<rom name="delphi_data_2.fdi" size="1265664" crc="d73ee316" sha1="64e421177282416e8b7f73c8d356ad861fe7b160" offset="0" />
 			</dataarea>
 		</part>
-		<part name="flop3" interface="floppy_5_25">
-			<feature name="part_id" value="Data 2"/>
+		<part name="flop4" interface="floppy_5_25">
+			<feature name="part_id" value="Data Disk 3"/>
 			<dataarea name="flop" size="1265664">
 				<rom name="delphi_data_3.fdi" size="1265664" crc="6bb3e510" sha1="d7b4ea32056aeb6d84cc265bcbf2b9b740cc138e" offset="0" />
-			</dataarea>
-		</part>
-		<part name="flop4" interface="floppy_5_25">
-			<feature name="part_id" value="Data 3"/>
-			<dataarea name="flop" size="1265664">
-				<rom name="delphi_system.fdi" size="1265664" crc="227a1e81" sha1="02c160059f559a660c794c9149010d727b6202eb" offset="0" />
 			</dataarea>
 		</part>
 	</software>
@@ -13257,7 +13489,8 @@ only have some part of Windows file and a Video driver(CLGD?).
 		</part>
 	</software>
 
-	<software name="denurse2">
+	<!-- Doesn't recognize disk changes -->
+	<software name="denurse2" supported="no">
 		<description>Dengeki Nurse 2 - More Sexy</description>
 		<year>1994</year>
 		<publisher>カクテル・ソフト (Cocktail Soft)</publisher>
@@ -13339,6 +13572,28 @@ only have some part of Windows file and a Video driver(CLGD?).
 		</part>
 	</software>
 
+	<!-- The mouse cursor doesn't work correctly -->
+	<software name="dengarou" supported="partial">
+		<!-- Origin: Neo Kobe Collection -->
+		<description>Dennou Garou</description>
+		<year>1993</year>
+		<publisher>アップルパイ／コーヒーぶれいく (Apple Pie / Coffee Break)</publisher>
+		<info name="alt_title" value="電脳画廊" />
+		<info name="release" value="19930910" />
+		<part name="flop1" interface="floppy_5_25">
+			<feature name="part_id" value="Disk 1"/>
+			<dataarea name="flop" size="1261568">
+				<rom name="dennou garou (disk 1).hdm" size="1261568" crc="9929beec" sha1="c1b969e5ef4cc8cd30fe7a4005ae6771dfe8efd3" offset="0" />
+			</dataarea>
+		</part>
+		<part name="flop2" interface="floppy_5_25">
+			<feature name="part_id" value="Disk 2"/>
+			<dataarea name="flop" size="1261568">
+				<rom name="dennou garou (disk 2).hdm" size="1261568" crc="df567663" sha1="47c89753763541dfb6b5cb7ebd7328e137f90a57" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+	
 	<software name="vieen3">
 		<description>Dennou Sentai La Vie en Three</description>
 		<year>1994</year>
@@ -13397,7 +13652,8 @@ only have some part of Windows file and a Video driver(CLGD?).
 		</part>
 	</software>
 
-	<software name="dennoten">
+	<!-- Hangs with a constant beep just after starting the game -->
+	<software name="dennoten" supported="no">
 		<description>Dennou Tenshi - Digital Ange</description>
 		<year>1993</year>
 		<publisher>ＧＡＭＥテクノポリス (Game Technopolis)</publisher>
@@ -13441,7 +13697,8 @@ only have some part of Windows file and a Video driver(CLGD?).
 		</part>
 	</software>
 
-	<software name="denwabel">
+	<!-- Doesn't recognize disk changes -->
+	<software name="denwabel" supported="no">
 		<description>Denwa no Bell ga... - Erotic Baka Novel</description>
 		<year>1993</year>
 		<publisher>カクテル・ソフト (Cocktail Soft)</publisher>
@@ -13467,33 +13724,35 @@ only have some part of Windows file and a Video driver(CLGD?).
 		</part>
 	</software>
 
-	<software name="dstall">
+	<!-- Doesn't recognize disk changes, so it's not possible to create a user disk -->
+	<software name="dstall" supported="no">
 		<description>Derby Stallion 98</description>
 		<year>1993</year>
 		<publisher>アスキー (ASCII)</publisher>
 		<info name="alt_title" value="ダービースタリオン９８" />
 		<info name="release" value="19930528" />
 		<part name="flop1" interface="floppy_5_25">
-			<feature name="part_id" value="Master? Disk"/>
+			<feature name="part_id" value="Demo Disk"/>
 			<dataarea name="flop" size="1265664">
 				<rom name="dstall_m.fdi" size="1265664" crc="ed367e02" sha1="c841fae4221a3c88bab073aa84ead2f8004d2821" offset="0" />
 			</dataarea>
 		</part>
 		<part name="flop2" interface="floppy_5_25">
-			<feature name="part_id" value="Data? Disk"/>
+			<feature name="part_id" value="Data Disk"/>
 			<dataarea name="flop" size="1265664">
 				<rom name="dstall_d.fdi" size="1265664" crc="888a12d9" sha1="e495b6a3434dab92bfceab5a6726a9711c488492" offset="0" />
 			</dataarea>
 		</part>
 		<part name="flop3" interface="floppy_5_25">
-			<feature name="part_id" value="Save? Disk"/>
+			<feature name="part_id" value="System Disk"/>
 			<dataarea name="flop" size="1265664">
 				<rom name="dstall_s.fdi" size="1265664" crc="9ae87798" sha1="0b19bf021f00fd2c4fedecef90455e75a3b6c9b2" offset="0" />
 			</dataarea>
 		</part>
 	</software>
 
-	<software name="dstalla" cloneof="dstall">
+	<!-- Doesn't recognize disk changes, so it's not possible to create a user disk -->
+	<software name="dstalla" cloneof="dstall" supported="no">
 		<description>Derby Stallion 98 (Alt)</description>
 		<year>1993</year>
 		<publisher>アスキー (ASCII)</publisher>
@@ -13525,6 +13784,7 @@ only have some part of Windows file and a Video driver(CLGD?).
 		<publisher>アスキー (ASCII)</publisher>
 		<info name="alt_title" value="ダービースタリオン エキスパート" />
 		<info name="release" value="19941001" />
+		<info name="usage" value="Requires HDD installation. Run INST.EXE from DOS." />
 		<part name="flop1" interface="floppy_5_25">
 			<feature name="part_id" value="Disk 1"/>
 			<dataarea name="flop" size="1281968">
@@ -13551,38 +13811,6 @@ only have some part of Windows file and a Video driver(CLGD?).
 		</part>
 	</software>
 
-	<software name="dstallexk" cloneof="dstallex">
-		<description>Derby Stallion Expert Kit</description>
-		<year>1994</year>
-		<publisher>アスキー (ASCII)</publisher>
-		<info name="alt_title" value="ダービースタリオン エキスパートキット" />
-		<info name="usage" value="Requires &quot;Derby Stallion Expert&quot; to work" />
-		<part name="flop1" interface="floppy_5_25">
-			<feature name="part_id" value="Disk 1"/>
-			<dataarea name="flop" size="1261568">
-				<rom name="derby_stallion_expert_kit_1.hdm" size="1261568" crc="c61ac324" sha1="72508eaf5d6f83c31e63e94fd462ce10095603a8" offset="0" />
-			</dataarea>
-		</part>
-		<part name="flop2" interface="floppy_5_25">
-			<feature name="part_id" value="Disk 2"/>
-			<dataarea name="flop" size="1261568">
-				<rom name="derby_stallion_expert_kit_2.hdm" size="1261568" crc="81a4fac9" sha1="1d6307864b89a1d0ebc2c6bcbded4e9588b2011c" offset="0" />
-			</dataarea>
-		</part>
-		<part name="flop3" interface="floppy_5_25">
-			<feature name="part_id" value="Disk 3"/>
-			<dataarea name="flop" size="1261568">
-				<rom name="derby_stallion_expert_kit_3.hdm" size="1261568" crc="c832ccfc" sha1="bbeac4564df5a355786e6045ee21dfaf6c7420e5" offset="0" />
-			</dataarea>
-		</part>
-		<part name="flop4" interface="floppy_5_25">
-			<feature name="part_id" value="Disk 4"/>
-			<dataarea name="flop" size="1261568">
-				<rom name="derby_stallion_expert_kit_4.hdm" size="1261568" crc="3436def2" sha1="f8497abcca777ebc9d635fa06da5d057f07943f8" offset="0" />
-			</dataarea>
-		</part>
-	</software>
-
 	<software name="derringr">
 		<description>Derringer</description>
 		<year>1988</year>
@@ -13599,6 +13827,73 @@ only have some part of Windows file and a Video driver(CLGD?).
 			<feature name="part_id" value="Disk B"/>
 			<dataarea name="flop" size="1089776">
 				<rom name="drrngerb.d88" size="1089776" crc="f6a0ab11" sha1="64cf7d04e2a2fa946d9b42c8866e88a734e0e082" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+	<!-- All the menus and the mouse cursor are invisible -->
+	<software name="desdragn" supported="no">
+		<!-- Origin: Neo Kobe Collection -->
+		<description>Desert Dragoon - Sabaku no Ryuukihei</description>
+		<year>1993</year>
+		<publisher>ジャパンホームビデオ  (Japan Home Video)</publisher>
+		<info name="alt_title" value="デザートドラグーン ～砂漠の竜騎兵～" />
+		<info name="release" value="19930709" />
+		<part name="flop1" interface="floppy_5_25">
+			<feature name="part_id" value="Disk 1"/>
+			<dataarea name="flop" size="1261568">
+				<rom name="desert dragoon (disk 1).hdm" size="1261568" crc="ed791c50" sha1="8ff2b2d50d480840b6826b452ec37f336921583e" offset="0" />
+			</dataarea>
+		</part>
+		<part name="flop2" interface="floppy_5_25">
+			<feature name="part_id" value="Disk 2"/>
+			<dataarea name="flop" size="1261568">
+				<rom name="desert dragoon (disk 2).hdm" size="1261568" crc="17d7029f" sha1="b3eff3de574c0dc27f7642387ba80712ef89e154" offset="0" />
+			</dataarea>
+		</part>
+		<part name="flop3" interface="floppy_5_25">
+			<feature name="part_id" value="Omake Disk"/>
+			<dataarea name="flop" size="1261568">
+				<rom name="desert dragoon (omake disk).hdm" size="1261568" crc="9a4f2368" sha1="cc6176b00859966cf1d8d4f096104fd8c7dc5985" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+	<software name="desire">
+		<!-- Origin: Neo Kobe Collection -->
+		<description>Desire - Haitoku no Rasen</description>
+		<year>1994</year>
+		<publisher>ジャパンホームビデオ  (Japan Home Video)</publisher>
+		<info name="alt_title" value="デザイア 背徳の螺旋" />
+		<info name="release" value="19940722" />
+		<part name="flop1" interface="floppy_5_25">
+			<feature name="part_id" value="Disk A"/>
+			<dataarea name="flop" size="1261568">
+				<rom name="desire - haitoku no rasen (disk a).hdm" size="1261568" crc="e35168e8" sha1="455cde02ff0158146b5bff9cd0d89ec40ef67a00" offset="0" />
+			</dataarea>
+		</part>
+		<part name="flop2" interface="floppy_5_25">
+			<feature name="part_id" value="Disk B"/>
+			<dataarea name="flop" size="1261568">
+				<rom name="desire - haitoku no rasen (disk b).hdm" size="1261568" crc="c36b1bb4" sha1="12edc9f4fb9d61f3f86b9664444c495c9af8243b" offset="0" />
+			</dataarea>
+		</part>
+		<part name="flop3" interface="floppy_5_25">
+			<feature name="part_id" value="Disk C"/>
+			<dataarea name="flop" size="1261568">
+				<rom name="desire - haitoku no rasen (disk c).hdm" size="1261568" crc="5b0ca21c" sha1="dbe2117860969c8fd6ddaf743f78ae439fcbdf81" offset="0" />
+			</dataarea>
+		</part>
+		<part name="flop4" interface="floppy_5_25">
+			<feature name="part_id" value="Disk D"/>
+			<dataarea name="flop" size="1261568">
+				<rom name="desire - haitoku no rasen (disk d).hdm" size="1261568" crc="333394b4" sha1="ebfc9f3e2a7cf1a5d7f41c0a6608ce4be640cd5a" offset="0" />
+			</dataarea>
+		</part>
+		<part name="flop5" interface="floppy_5_25">
+			<feature name="part_id" value="Disk E"/>
+			<dataarea name="flop" size="1261568">
+				<rom name="desire - haitoku no rasen (disk e).hdm" size="1261568" crc="e19bdba6" sha1="7b9a23bf718e34d9b8d26a3c780d931168c874df" offset="0" />
 			</dataarea>
 		</part>
 	</software>
@@ -13635,6 +13930,50 @@ only have some part of Windows file and a Video driver(CLGD?).
 		</part>
 	</software>
 
+	<!-- 
+		Doesn't recognize disk changes, but it's possible to install the game to HDD.
+		Also, This game is supposed to play voice samples, but in MAME it just outputs a constant beep.
+	-->
+	<software name="diadrum" supported="partial">
+		<!-- Origin: Neo Kobe Collection -->
+		<description>Diadrum</description>
+		<year>1993</year>
+		<publisher>日本クリエイト (Nihon Create)</publisher>
+		<info name="alt_title" value="ディアドラム" />
+		<info name="release" value="19931202" />
+		<info name="usage" value="Run INSTHD.EXE from DOS to install to HDD" />
+		<part name="flop1" interface="floppy_5_25">
+			<feature name="part_id" value="Disk A / System Disk"/>
+			<dataarea name="flop" size="1261568">
+				<rom name="diadrum (disk a - system).hdm" size="1261568" crc="3c0b628c" sha1="931bf98c6209c21a126bce484eacdb7a63646fd9" offset="0" />
+			</dataarea>
+		</part>
+		<part name="flop2" interface="floppy_5_25">
+			<feature name="part_id" value="Disk B / Game Disk"/>
+			<dataarea name="flop" size="1261568">
+				<rom name="diadrum (disk b - game).hdm" size="1261568" crc="49801198" sha1="1a675dcfde32774e6e24d9d1a29024e3803f42f2" offset="0" />
+			</dataarea>
+		</part>
+		<part name="flop3" interface="floppy_5_25">
+			<feature name="part_id" value="Disk C / Scenario Disk"/>
+			<dataarea name="flop" size="1261568">
+				<rom name="diadrum (disk c - scenario).hdm" size="1261568" crc="cff4e204" sha1="e452ea03608d6a834e2c409ee2dabb24bfd52f8d" offset="0" />
+			</dataarea>
+		</part>
+		<part name="flop4" interface="floppy_5_25">
+			<feature name="part_id" value="Disk D / Making Disk"/>
+			<dataarea name="flop" size="1261568">
+				<rom name="diadrum (disk d - making).hdm" size="1261568" crc="3e6c3023" sha1="ef87293040fbce8ed85dfe82698198218fcc2e2c" offset="0" />
+			</dataarea>
+		</part>
+		<part name="flop5" interface="floppy_5_25">
+			<feature name="part_id" value="Disk E / Voice Disk"/>
+			<dataarea name="flop" size="1261568">
+				<rom name="diadrum (disk e - voice).hdm" size="1261568" crc="85748d4c" sha1="6858d83b20e4cacf64739c4f23db9c2a366f0bbf" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
 	<software name="diesirae">
 		<description>Dies Irae</description>
 		<year>1996</year>
@@ -13642,36 +13981,43 @@ only have some part of Windows file and a Video driver(CLGD?).
 		<info name="alt_title" value="ディエス・イレ" />
 		<info name="release" value="19960426" />
 		<part name="flop1" interface="floppy_5_25">
+			<feature name="part_id" value="Disk 1"/>
 			<dataarea name="flop" size="1265664">
 				<rom name="disk 01.fdi" size="1265664" crc="64062e33" sha1="39a569c136dc07b066d3b10e554f880c5eabd012" offset="0" />
 			</dataarea>
 		</part>
 		<part name="flop2" interface="floppy_5_25">
+			<feature name="part_id" value="Disk 2"/>
 			<dataarea name="flop" size="1265664">
 				<rom name="disk 02.fdi" size="1265664" crc="3fe46dca" sha1="77246389f45c00b752353915d54a8810e72ab255" offset="0" />
 			</dataarea>
 		</part>
 		<part name="flop3" interface="floppy_5_25">
+			<feature name="part_id" value="Disk 3"/>
 			<dataarea name="flop" size="1265664">
 				<rom name="disk 03.fdi" size="1265664" crc="727128a8" sha1="19ba7599f081d59d9c7715f73393a81a281cb3a9" offset="0" />
 			</dataarea>
 		</part>
 		<part name="flop4" interface="floppy_5_25">
+			<feature name="part_id" value="Disk 4"/>
 			<dataarea name="flop" size="1265664">
 				<rom name="disk 04.fdi" size="1265664" crc="9fa604b7" sha1="9e64d04cbef0a41761916f7d6f439579a41af5b6" offset="0" />
 			</dataarea>
 		</part>
 		<part name="flop5" interface="floppy_5_25">
+			<feature name="part_id" value="Disk 5"/>
 			<dataarea name="flop" size="1265664">
 				<rom name="disk 05.fdi" size="1265664" crc="6d153354" sha1="0939936b7da243e4c7d7f227a74b9e58ceff9e4a" offset="0" />
 			</dataarea>
 		</part>
 		<part name="flop6" interface="floppy_5_25">
+			<feature name="part_id" value="Disk 6"/>
 			<dataarea name="flop" size="1265664">
 				<rom name="disk 06.fdi" size="1265664" crc="c138e98a" sha1="c09f94739b45aca4f68a3cfd6b5e529bc8c5698c" offset="0" />
 			</dataarea>
 		</part>
 		<part name="flop7" interface="floppy_5_25">
+			<feature name="part_id" value="Disk 7"/>
 			<dataarea name="flop" size="1265664">
 				<rom name="disk 07.fdi" size="1265664" crc="b6d36111" sha1="16f039bb49607d38e0acb5eee262b9d55941c6b7" offset="0" />
 			</dataarea>
@@ -13762,12 +14108,14 @@ only have some part of Windows file and a Video driver(CLGD?).
 		</part>
 	</software>
 
+	<!-- Runs too fast on anything other than an 8086 CPU -->
 	<software name="dios">
 		<description>Dios</description>
 		<year>1989</year>
 		<publisher>ザインソフト (Zain Soft)</publisher>
 		<info name="alt_title" value="ディオス" />
 		<info name="release" value="19891111" />
+		<info name="usage" value="Disk A contains the opening sequence. To start the actual game, boot from disk B, create a user disk from the main menu (recommended to use an image in MFI format), replace disk B with the user disk, and insert disk C on drive 2." />
 		<part name="flop1" interface="floppy_5_25">
 			<feature name="part_id" value="Disk A"/>
 			<dataarea name="flop" size="1086448">
@@ -13794,12 +14142,63 @@ only have some part of Windows file and a Video driver(CLGD?).
 		</part>
 	</software>
 
+	<!-- No sound, and the game hangs after creating your character -->
+	<software name="diremono" supported="no">
+		<!-- Origin: Neo Kobe Collection -->
+		<description>Director Monogatari</description>
+		<year>1988</year>
+		<publisher>ビクター音楽産業 (Victor Musical Industries)</publisher>
+		<info name="alt_title" value="ディレクター物語" />
+		<info name="release" value="19880921" />
+		<part name="flop1" interface="floppy_5_25">
+			<feature name="part_id" value="Disk 1"/>
+			<dataarea name="flop" size="1086448">
+				<rom name="director monogatari (disk 1).d88" size="1086448" crc="5b45487f" sha1="e23c77fb7c41bd86f865b14f2767406ea9e1a172" offset="0" />
+			</dataarea>
+		</part>
+		<part name="flop2" interface="floppy_5_25">
+			<feature name="part_id" value="Disk 2"/>
+			<dataarea name="flop" size="1086448">
+				<rom name="director monogatari (disk 2).d88" size="1086448" crc="41540039" sha1="6335efce6e24e40bfacb55d8f4ef02a1cc00d92b" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+	<!-- Some visual glitches -->
+	<software name="dires" supported="partial">
+		<!-- Origin: Neo Kobe Collection -->
+		<description>Dires - Giger Loop</description>
+		<year>1988</year>
+		<publisher>ボーステック (Bothtec)</publisher>
+		<info name="alt_title" value="ダイレス －Ｇｉｇｅｒ Ｌｏｏｐ－" />
+		<info name="release" value="198805xx" />
+		<part name="flop" interface="floppy_5_25">
+			<dataarea name="flop" size="1261568">
+				<rom name="dires - giger loop.hdm" size="1261568" crc="8ca69a2a" sha1="05cc59d2bc61552afd0440cef608be7c810e9ab8" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+	<!-- The software is inside a LZH archive. It's unclear if this is how it was actually distributed. -->
+	<software name="diskx2">
+		<!-- Origin: Neo Kobe Collection -->
+		<description>DiskX II</description>
+		<year>1994</year>
+		<publisher>A.I. Soft</publisher>
+		<part name="flop" interface="floppy_5_25">
+			<dataarea name="flop" size="1261568">
+				<rom name="diskx ii.hdm" size="1261568" crc="3b8f60fa" sha1="3e8714609156b9d16209bfaeafed1e80827fadb3" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
 	<software name="ds98_00">
 		<description>Disc Station 98 #00 - Soukan Junbi-gou</description>
 		<year>1990</year>
 		<publisher>コンパイル (Compile)</publisher>
 		<info name="alt_title" value="ディスクステーション９８＃００ 創刊準備号" />
 		<info name="release" value="19901020" />
+		<info name="usage" value="Boot from disk 3 for the main menu. The other disks are game demos." />
 		<part name="flop1" interface="floppy_5_25">
 			<feature name="part_id" value="Disk 1"/>
 			<dataarea name="flop" size="1281968">
@@ -13826,6 +14225,7 @@ only have some part of Windows file and a Video driver(CLGD?).
 		<publisher>コンパイル (Compile)</publisher>
 		<info name="alt_title" value="ディスクステーション９８＃０１ 創刊号" />
 		<info name="release" value="19901211" />
+		<info name="usage" value="Boot from disk 4 for the main menu. The other disks are game demos." />
 		<part name="flop1" interface="floppy_5_25">
 			<feature name="part_id" value="Disk 1"/>
 			<dataarea name="flop" size="1265664">
@@ -13858,6 +14258,7 @@ only have some part of Windows file and a Video driver(CLGD?).
 		<publisher>コンパイル (Compile)</publisher>
 		<info name="alt_title" value="ディスクステーション９８＃０２" />
 		<info name="release" value="19910219" />
+		<info name="usage" value="Boot from disk 4 for the main menu. The other disks are game demos." />
 		<part name="flop1" interface="floppy_5_25">
 			<feature name="part_id" value="Disk 1"/>
 			<dataarea name="flop" size="1265664">
@@ -13890,6 +14291,7 @@ only have some part of Windows file and a Video driver(CLGD?).
 		<publisher>コンパイル (Compile)</publisher>
 		<info name="alt_title" value="ディスクステーション９８＃０４" />
 		<info name="release" value="19910621" />
+		<info name="usage" value="Boot from disk 4 for the main menu. The other disks are game demos." />
 		<part name="flop1" interface="floppy_5_25">
 			<feature name="part_id" value="Disk 1"/>
 			<dataarea name="flop" size="1280928">
@@ -14316,11 +14718,12 @@ only have some part of Windows file and a Video driver(CLGD?).
 	</software>
 
 	<software name="ds98_mc">
-		<description>Disc Station 98 Bessatu - Map &amp; Construction</description>
+		<description>Disc Station 98 Bessatsu - Map &amp; Construction</description>
 		<year>1991</year>
 		<publisher>コンパイル (Compile)</publisher>
 		<info name="alt_title" value="ディスクステーション９８ 別冊 ＭＡＰ＆ＣＯＮＳＴＲＵＣＴＩＯＮ" />
 		<info name="release" value="19910920" />
+		<info name="usage" value="Boot from disk 4 for the main menu. The other disks are game demos." />
 		<part name="flop1" interface="floppy_5_25">
 			<feature name="part_id" value="Disk 1"/>
 			<dataarea name="flop" size="1265664">
@@ -14353,6 +14756,7 @@ only have some part of Windows file and a Video driver(CLGD?).
 		<publisher>コンパイル (Compile)</publisher>
 		<info name="alt_title" value="ディスクステーション９８ ＥＸ＃１" />
 		<info name="release" value="19910319" />
+		<info name="usage" value="Boot from disk 4 for the main menu. The other disks are game demos." />
 		<part name="flop1" interface="floppy_5_25">
 			<feature name="part_id" value="Disk 1"/>
 			<dataarea name="flop" size="1281968">
@@ -14385,6 +14789,7 @@ only have some part of Windows file and a Video driver(CLGD?).
 		<publisher>コンパイル (Compile)</publisher>
 		<info name="alt_title" value="ディスクステーション９８ ＥＸ＃２" />
 		<info name="release" value="19910521" />
+		<info name="usage" value="Boot from disk 4 for the main menu. The other disks are game demos." />
 		<part name="flop1" interface="floppy_5_25">
 			<feature name="part_id" value="Disk 1"/>
 			<dataarea name="flop" size="1265664">
@@ -14658,19 +15063,19 @@ only have some part of Windows file and a Video driver(CLGD?).
 		<info name="alt_title" value="ディスクステーション Ｖｏｌ．０７" />
 		<info name="release" value="19950707" />
 		<part name="flop1" interface="floppy_5_25">
-			<feature name="part_id" value="Disk A"/>
+			<feature name="part_id" value="Disk 1"/>
 			<dataarea name="flop" size="1265664">
 				<rom name="7a.fdi" size="1265664" crc="230dfaa9" sha1="5bf2b1f4cea8ff4567eabf1d2fb1e5017b5b5ebc" offset="0" />
 			</dataarea>
 		</part>
 		<part name="flop2" interface="floppy_5_25">
-			<feature name="part_id" value="Disk B"/>
+			<feature name="part_id" value="Disk 2"/>
 			<dataarea name="flop" size="1265664">
 				<rom name="7b.fdi" size="1265664" crc="c6fefee4" sha1="b69f1f191ffecc46dcdb0a3acc4bb221e5860b56" offset="0" />
 			</dataarea>
 		</part>
 		<part name="flop3" interface="floppy_5_25">
-			<feature name="part_id" value="Disk C"/>
+			<feature name="part_id" value="Disk 3"/>
 			<dataarea name="flop" size="1265664">
 				<rom name="7c.fdi" size="1265664" crc="ef223078" sha1="6af6d5ca571fae700509dd646b6fd1b8109cbcde" offset="0" />
 			</dataarea>
@@ -14720,14 +15125,15 @@ only have some part of Windows file and a Video driver(CLGD?).
 		<year>1992</year>
 		<publisher>総合ビジネスアシスト (ABA)</publisher>
 		<info name="alt_title" value="ディスクバトラー" />
+		<info name="usage" value="Boot from a DOS floppy with disk 1 in drive 2, then tun DBINST.EXE from disk 1." />
 		<part name="flop1" interface="floppy_5_25">
-			<feature name="part_id" value="Disk A"/>
+			<feature name="part_id" value="Disk 1"/>
 			<dataarea name="flop" size="1281968">
 				<rom name="dskbtlr1.d88" size="1281968" crc="c1846f23" sha1="f4a5eb2fe619eec6ad2b6395867960ef8f3cc198" offset="0" />
 			</dataarea>
 		</part>
 		<part name="flop2" interface="floppy_5_25">
-			<feature name="part_id" value="Disk B"/>
+			<feature name="part_id" value="Disk 2"/>
 			<dataarea name="flop" size="1281968">
 				<rom name="dskbtlr2.d88" size="1281968" crc="4cf40e2f" sha1="1371aad54c11ba0d2b2ccef736eeb4afffaf8da4" offset="0" />
 			</dataarea>
@@ -14750,6 +15156,84 @@ only have some part of Windows file and a Video driver(CLGD?).
 			<feature name="part_id" value="Disk B"/>
 			<dataarea name="flop" size="1265664">
 				<rom name="zukan_b.fdi" size="1265664" crc="01fdfbfb" sha1="df87123766eb0ee483d47ab6e1e7d82244158fd0" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+	<software name="bishodai">
+		<!-- Origin: Neo Kobe Collection -->
+		<description>Bishoujo Daizukan</description>
+		<year>1992</year>
+		<publisher>サンタ・フェ (Santa Fe)</publisher>
+		<info name="alt_title" value="美少女大図鑑" />
+		<info name="release" value="19920227" />
+		<part name="flop1" interface="floppy_5_25">
+			<feature name="part_id" value="Disk A"/>
+			<dataarea name="flop" size="1261568">
+				<rom name="disk bishoujo daizukan (disk a).hdm" size="1261568" crc="2306279d" sha1="277a5dab3f6c185067731fc17f648ada7457c4cd" offset="0" />
+			</dataarea>
+		</part>
+		<part name="flop2" interface="floppy_5_25">
+			<feature name="part_id" value="Disk B"/>
+			<dataarea name="flop" size="1261568">
+				<rom name="disk bishoujo daizukan (disk b).hdm" size="1261568" crc="c23ecece" sha1="03ddef0c46613fcc6bd8a22fd60b023a6b671320" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+	<software name="divers">
+		<!-- Origin: Neo Kobe Collection -->
+		<description>Diver's</description>
+		<year>1994</year>
+		<publisher>ミンク (Mink)</publisher>
+		<info name="alt_title" value="ダイバーズ" />
+		<info name="release" value="19940811" />
+		<part name="flop1" interface="floppy_5_25">
+			<feature name="part_id" value="Disk A"/>
+			<dataarea name="flop" size="1261568">
+				<rom name="diver's (disk a).hdm" size="1261568" crc="042e54d8" sha1="ffaf6684e1412f76b651279d32e3f06897098704" offset="0" />
+			</dataarea>
+		</part>
+		<part name="flop2" interface="floppy_5_25">
+			<feature name="part_id" value="Disk B"/>
+			<dataarea name="flop" size="1261568">
+				<rom name="diver's (disk b).hdm" size="1261568" crc="bad55779" sha1="0ae0c951cadfb8a992820575aead61b2e24ad56b" offset="0" />
+			</dataarea>
+		</part>
+		<part name="flop3" interface="floppy_5_25">
+			<feature name="part_id" value="Disk C"/>
+			<dataarea name="flop" size="1261568">
+				<rom name="diver's (disk c).hdm" size="1261568" crc="e8151351" sha1="bf7f735461cbda2f7efc0594d7a5f716da457f4b" offset="0" />
+			</dataarea>
+		</part>
+		<part name="flop4" interface="floppy_5_25">
+			<feature name="part_id" value="Disk D"/>
+			<dataarea name="flop" size="1261568">
+				<rom name="diver's (disk d).hdm" size="1261568" crc="7ba66c83" sha1="6aa006df219dc16d4337e81345423c2d58318bfd" offset="0" />
+			</dataarea>
+		</part>
+		<part name="flop5" interface="floppy_5_25">
+			<feature name="part_id" value="Disk E"/>
+			<dataarea name="flop" size="1261568">
+				<rom name="diver's (disk e).hdm" size="1261568" crc="55b19b2d" sha1="46750fa3a93ce583d59e4b6728137813829ed3e4" offset="0" />
+			</dataarea>
+		</part>
+		<part name="flop6" interface="floppy_5_25">
+			<feature name="part_id" value="Disk F"/>
+			<dataarea name="flop" size="1261568">
+				<rom name="diver's (disk f).hdm" size="1261568" crc="8454f520" sha1="a8d253190d6f55f716611e262b4955aaad4b9484" offset="0" />
+			</dataarea>
+		</part>
+		<part name="flop7" interface="floppy_5_25">
+			<feature name="part_id" value="Disk G"/>
+			<dataarea name="flop" size="1261568">
+				<rom name="diver's (disk g).hdm" size="1261568" crc="0666c706" sha1="6a2f9fa9cb56d9aaf3548e01071b191897bbc165" offset="0" />
+			</dataarea>
+		</part>
+		<part name="flop8" interface="floppy_5_25">
+			<feature name="part_id" value="Disk H"/>
+			<dataarea name="flop" size="1261568">
+				<rom name="diver's (disk h).hdm" size="1261568" crc="d6e75d77" sha1="6636a0ddd2e7d20da971e661fff6532e3ca63c16" offset="0" />
 			</dataarea>
 		</part>
 	</software>
@@ -14792,7 +15276,8 @@ only have some part of Windows file and a Video driver(CLGD?).
 		</part>
 	</software>
 
-	<software name="dokicard">
+	<!-- Seems to work only on 286-based machines (e.g. PC-9801UX) -->
+	<software name="dokicard" supported="partial">
 		<description>Doki Doki Card League</description>
 		<year>1990</year>
 		<publisher>グレイト (Great)</publisher>
@@ -14811,7 +15296,118 @@ only have some part of Windows file and a Video driver(CLGD?).
 		</part>
 	</software>
 
-	<software name="dokishut">
+	<!-- Seems to work only on 286-based machines (e.g. PC-9801UX) -->
+	<software name="dokipl1" supported="partial">
+		<!-- Origin: Neo Kobe Collection -->
+		<description>Doki Doki Pretty League Dai-1-wa - Pink Angels Kiki Ippatsu no Maki</description>
+		<year>1994</year>
+		<publisher>グレイト (Great)</publisher>
+		<info name="alt_title" value="ドキドキぷりてぃリーグ 第１話 ピンクエンジェルス危機一髪の巻" />
+		<info name="release" value="19941215" />
+		<part name="flop1" interface="floppy_5_25">
+			<feature name="part_id" value="Disk A"/>
+			<dataarea name="flop" size="1261568">
+				<rom name="doki doki pretty league dai-1-wa - pink angels kiki ippatsu no maki (disk a).hdm" size="1261568" crc="df5ab782" sha1="912cdd6b479b5f414849dabb8b337c3ea227bc65" offset="0" />
+			</dataarea>
+		</part>
+		<part name="flop2" interface="floppy_5_25">
+			<feature name="part_id" value="Disk B"/>
+			<dataarea name="flop" size="1261568">
+				<rom name="doki doki pretty league dai-1-wa - pink angels kiki ippatsu no maki (disk b).hdm" size="1261568" crc="ea0d48fc" sha1="ed34b15f972b7a16f469f3e4b537a0b3b602c386" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+	<!-- Seems to work only on 286-based machines (e.g. PC-9801UX) -->
+	<software name="dokipl2" supported="partial">
+		<!-- Origin: Neo Kobe Collection -->
+		<description>Doki Doki Pretty League Dai-2-wa - Mou Hitotsu no Rival</description>
+		<year>1995</year>
+		<publisher>グレイト (Great)</publisher>
+		<info name="alt_title" value="ドキドキぷりてぃリーグ 第２話 もうひとつのライバル" />
+		<info name="release" value="19950115" />
+		<part name="flop1" interface="floppy_5_25">
+			<feature name="part_id" value="Disk A"/>
+			<dataarea name="flop" size="1261568">
+				<rom name="doki doki pretty league dai-2-wa - mou hitotsu no rival (disk a).hdm" size="1261568" crc="1989b1dd" sha1="2a24f145568ffb39573f81e537c1342436d8c411" offset="0" />
+			</dataarea>
+		</part>
+		<part name="flop2" interface="floppy_5_25">
+			<feature name="part_id" value="Disk B"/>
+			<dataarea name="flop" size="1261568">
+				<rom name="doki doki pretty league dai-2-wa - mou hitotsu no rival (disk b).hdm" size="1261568" crc="18c47531" sha1="02dd2e2aac423875c2b1842792d2173e5012f160" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+	<!-- Seems to work only on 286-based machines (e.g. PC-9801UX) -->
+	<software name="dokipl3" supported="partial">
+		<!-- Origin: Neo Kobe Collection -->
+		<description>Doki Doki Pretty League Dai-3-wa - Minami no Umi no Kai no Maki</description>
+		<year>1995</year>
+		<publisher>グレイト (Great)</publisher>
+		<info name="alt_title" value="ドキドキぷりてぃリーグ 第３話 南の海の怪の巻" />
+		<info name="release" value="19950218" />
+		<part name="flop1" interface="floppy_5_25">
+			<feature name="part_id" value="Disk A"/>
+			<dataarea name="flop" size="1261568">
+				<rom name="doki doki pretty league dai-3-wa - minami no umi no kai no maki (disk a).hdm" size="1261568" crc="f44de33c" sha1="89dabf35ea0f5c91d46d0dcee4f6dd9af93269a3" offset="0" />
+			</dataarea>
+		</part>
+		<part name="flop2" interface="floppy_5_25">
+			<feature name="part_id" value="Disk B"/>
+			<dataarea name="flop" size="1261568">
+				<rom name="doki doki pretty league dai-3-wa - minami no umi no kai no maki (disk b).hdm" size="1261568" crc="29b8ecd1" sha1="1f39985cf4aac687d8695cf7737bd8ca99dafb7c" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+	<!-- Seems to work only on 286-based machines (e.g. PC-9801UX) -->
+	<software name="dokipl4" supported="partial">
+		<!-- Origin: Neo Kobe Collection -->
+		<description>Doki Doki Pretty League Dai-4-wa - Nanase no Himitsu no Maki</description>
+		<year>1995</year>
+		<publisher>グレイト (Great)</publisher>
+		<info name="alt_title" value="ドキドキぷりてぃリーグ 第４話 七瀬の秘密の巻" />
+		<info name="release" value="19950315" />
+		<part name="flop1" interface="floppy_5_25">
+			<feature name="part_id" value="Disk A"/>
+			<dataarea name="flop" size="1261568">
+				<rom name="doki doki pretty league dai-4-wa - nanase no himitsu no maki (disk a).hdm" size="1261568" crc="fa6fe515" sha1="ace467baf1e2a575a230bf17969b5899b9db14d4" offset="0" />
+			</dataarea>
+		</part>
+		<part name="flop2" interface="floppy_5_25">
+			<feature name="part_id" value="Disk B"/>
+			<dataarea name="flop" size="1261568">
+				<rom name="doki doki pretty league dai-4-wa - nanase no himitsu no maki (disk b).hdm" size="1261568" crc="d7b8ef94" sha1="9e2cc962fa86d221440b123d099ae00b16c84e51" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+	<!-- Seems to work only on 286-based machines (e.g. PC-9801UX) -->
+	<software name="dokipl5" supported="partial">
+		<!-- Origin: Neo Kobe Collection -->
+		<description>Doki Doki Pretty League Dai-5-wa - Saraba Pink Angels-tachi</description>
+		<year>1995</year>
+		<publisher>グレイト (Great)</publisher>
+		<info name="alt_title" value="ドキドキぷりてぃリーグ 第５話 さらばピンクエンジェルス達" />
+		<info name="release" value="19950415" />
+		<part name="flop1" interface="floppy_5_25">
+			<feature name="part_id" value="Disk A"/>
+			<dataarea name="flop" size="1261568">
+				<rom name="doki doki pretty league dai-5-wa - saraba pink angels-tachi (disk a).hdm" size="1261568" crc="a747aeb3" sha1="ed5c9ceb2313b69b48532840b1dfecdb31392c64" offset="0" />
+			</dataarea>
+		</part>
+		<part name="flop2" interface="floppy_5_25">
+			<feature name="part_id" value="Disk B"/>
+			<dataarea name="flop" size="1261568">
+				<rom name="doki doki pretty league dai-5-wa - saraba pink angels-tachi (disk b).hdm" size="1261568" crc="897a9773" sha1="c2bcced9dea4e6a7aa067f3990adc48180762c41" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+	<!-- Black screen on boot -->
+	<software name="dokishut" supported="no">
 		<description>Doki Doki Shutter Chance</description>
 		<year>1989</year>
 		<publisher>エルフ (Elf)</publisher>
@@ -14824,7 +15420,7 @@ only have some part of Windows file and a Video driver(CLGD?).
 		</part>
 	</software>
 
-	<software name="dokishutt1" cloneof="dokishut">
+	<software name="dokishutt1" cloneof="dokishut" supported="no">
 		<description>Doki Doki Shutter Chance Tsuika Data 1 - Joshikou Hen</description>
 		<year>1989</year>
 		<publisher>エルフ (Elf)</publisher>
@@ -14838,7 +15434,7 @@ only have some part of Windows file and a Video driver(CLGD?).
 		</part>
 	</software>
 
-	<software name="dokishutt2" cloneof="dokishut">
+	<software name="dokishutt2" cloneof="dokishut" supported="no">
 		<description>Doki Doki Shutter Chance Tsuika Data 2 - Nurse Hen</description>
 		<year>1989</year>
 		<publisher>エルフ (Elf)</publisher>
@@ -14852,7 +15448,7 @@ only have some part of Windows file and a Video driver(CLGD?).
 		</part>
 	</software>
 
-	<software name="dokishutt3" cloneof="dokishut">
+	<software name="dokishutt3" cloneof="dokishut" supported="no">
 		<description>Doki Doki Shutter Chance Tsuika Data 3 - Bus Guide Hen</description>
 		<year>1989</year>
 		<publisher>エルフ (Elf)</publisher>
@@ -14866,8 +15462,8 @@ only have some part of Windows file and a Video driver(CLGD?).
 		</part>
 	</software>
 
-<!-- 2dd image -->
-	<software name="dokkinm">
+	<!-- Black screen on boot. Could be related to the disk format, since it's a 2DD disk. -->
+	<software name="dokkinm" supported="no">
 		<description>Dokkin Minako-sensei</description>
 		<year>1988</year>
 		<publisher>テクトハウス (Tect House)</publisher>
@@ -14905,6 +15501,7 @@ only have some part of Windows file and a Video driver(CLGD?).
 		</part>
 	</software>
 
+	<!-- Seems to work only on 286-based machines (e.g. PC-9801UX) -->
 	<software name="doll">
 		<description>Doll - Paragon Sex A Doll</description>
 		<year>1989</year>
@@ -14931,6 +15528,7 @@ only have some part of Windows file and a Video driver(CLGD?).
 		</part>
 	</software>
 
+	<!-- Sound only works with a PC-9801-26K card. Might not be an emulation bug. -->
 	<software name="dome">
 		<description>Dome</description>
 		<year>1988</year>
@@ -14962,45 +15560,238 @@ only have some part of Windows file and a Video driver(CLGD?).
 		<year>1994</year>
 		<publisher>イマジニア (Imagineer)</publisher>
 		<info name="release" value="19941209" />
+		<info name="usage" value="Requires HDD installation and a PC-9821 computer. Run INSTALL.EXE from DOS." />
 		<part name="flop1" interface="floppy_5_25">
-			<feature name="part_id" value="Disk 1"/>
+			<feature name="part_id" value="Boot Disk / Disk 6"/>
 			<dataarea name="flop" size="1265664">
 				<rom name="doom (1993)(id software)(disk 1 of 6).fdi" size="1265664" crc="106808ed" sha1="01658e1b92440324b4b5929e7dc56f19b12ed60d" offset="0" />
 			</dataarea>
 		</part>
 		<part name="flop2" interface="floppy_5_25">
-			<feature name="part_id" value="Disk 2"/>
+			<feature name="part_id" value="Disk 1"/>
 			<dataarea name="flop" size="1265664">
 				<rom name="doom (1993)(id software)(disk 2 of 6).fdi" size="1265664" crc="afda5ec9" sha1="b9dea2a019a69ff662c4008b4662178d50dddce9" offset="0" />
 			</dataarea>
 		</part>
 		<part name="flop3" interface="floppy_5_25">
-			<feature name="part_id" value="Disk 3"/>
+			<feature name="part_id" value="Disk 2"/>
 			<dataarea name="flop" size="1265664">
 				<rom name="doom (1993)(id software)(disk 3 of 6).fdi" size="1265664" crc="c3dd2d90" sha1="ad742b32de853bb26d8278de045d80529672d7c3" offset="0" />
 			</dataarea>
 		</part>
 		<part name="flop4" interface="floppy_5_25">
-			<feature name="part_id" value="Disk 4"/>
+			<feature name="part_id" value="Disk 3"/>
 			<dataarea name="flop" size="1265664">
 				<rom name="doom (1993)(id software)(disk 4 of 6).fdi" size="1265664" crc="3b891425" sha1="d5fef6d6ef70ac83cc3dba0f368398ea42f2956f" offset="0" />
 			</dataarea>
 		</part>
 		<part name="flop5" interface="floppy_5_25">
-			<feature name="part_id" value="Disk 5"/>
+			<feature name="part_id" value="Disk 4"/>
 			<dataarea name="flop" size="1265664">
 				<rom name="doom (1993)(id software)(disk 5 of 6).fdi" size="1265664" crc="8a189541" sha1="551b32a8144efe190c2d55468ff0807f70609c9b" offset="0" />
 			</dataarea>
 		</part>
 		<part name="flop6" interface="floppy_5_25">
-			<feature name="part_id" value="Disk 6"/>
+			<feature name="part_id" value="Disk 5"/>
 			<dataarea name="flop" size="1265664">
 				<rom name="doom (1993)(id software)(disk 6 of 6).fdi" size="1265664" crc="73130118" sha1="63a35164bbb0b6bb7758302c6d1577c005695412" offset="0" />
 			</dataarea>
 		</part>
 	</software>
 
-	<software name="doordoor">
+	<!-- Disk P is included with the game, and contains a patch for a minor bug where the last line of the message after level 11 is drawn off-screen -->
+	<software name="doom2">
+		<!-- Origin: Neo Kobe Collection -->
+		<description>Doom II</description>
+		<year>1995</year>
+		<publisher>イマジニア (Imagineer)</publisher>
+		<info name="release" value="19950929" />
+		<info name="usage" value="Requires HDD installation and a PC-9821 computer. Run INSTALL.EXE from DOS." />
+		<part name="flop1" interface="floppy_5_25">
+			<feature name="part_id" value="Disk 1"/>
+			<dataarea name="flop" size="1261568">
+				<rom name="doom ii (disk 1).hdm" size="1261568" crc="443276de" sha1="0b7e439a90d87cb9c7f941c7ef1633945ddea740" offset="0" />
+			</dataarea>
+		</part>
+		<part name="flop2" interface="floppy_5_25">
+			<feature name="part_id" value="Disk 2"/>
+			<dataarea name="flop" size="1261568">
+				<rom name="doom ii (disk 2).hdm" size="1261568" crc="618f6f4e" sha1="dc87f92ffbb1a5c62ff4fa1f03968fb46953a831" offset="0" />
+			</dataarea>
+		</part>
+		<part name="flop3" interface="floppy_5_25">
+			<feature name="part_id" value="Disk 3"/>
+			<dataarea name="flop" size="1261568">
+				<rom name="doom ii (disk 3).hdm" size="1261568" crc="1b643a38" sha1="6b3f9400cb95a6822d317a3e84de642ff4648442" offset="0" />
+			</dataarea>
+		</part>
+		<part name="flop4" interface="floppy_5_25">
+			<feature name="part_id" value="Disk 4"/>
+			<dataarea name="flop" size="1261568">
+				<rom name="doom ii (disk 4).hdm" size="1261568" crc="290058fe" sha1="7ff2e831c5516fe3856bfab2210d292937ea91e4" offset="0" />
+			</dataarea>
+		</part>
+		<part name="flop5" interface="floppy_5_25">
+			<feature name="part_id" value="Disk 5"/>
+			<dataarea name="flop" size="1261568">
+				<rom name="doom ii (disk 5).hdm" size="1261568" crc="7863fd42" sha1="022f6be4b605606486f711653840377a03bdde91" offset="0" />
+			</dataarea>
+		</part>
+		<part name="flop6" interface="floppy_5_25">
+			<feature name="part_id" value="Disk 6"/>
+			<dataarea name="flop" size="1261568">
+				<rom name="doom ii (disk 6).hdm" size="1261568" crc="2905764d" sha1="a98d2a865b0d408f17a49479bd562218c154b8a9" offset="0" />
+			</dataarea>
+		</part>
+		<part name="flop7" interface="floppy_5_25">
+			<feature name="part_id" value="Disk 7"/>
+			<dataarea name="flop" size="1261568">
+				<rom name="doom ii (disk 7).hdm" size="1261568" crc="b1deba44" sha1="89f1e54fec6d959954a56a8ae7ce030dda8eac14" offset="0" />
+			</dataarea>
+		</part>
+		<part name="flop8" interface="floppy_5_25">
+			<feature name="part_id" value="Disk 8"/>
+			<dataarea name="flop" size="1261568">
+				<rom name="doom ii (disk 8).hdm" size="1261568" crc="e62503af" sha1="4078d2f26100d33f712ff7396f7ddff9bd4c0b76" offset="0" />
+			</dataarea>
+		</part>
+		<part name="flop9" interface="floppy_5_25">
+			<feature name="part_id" value="Disk P"/>
+			<dataarea name="flop" size="1261568">
+				<rom name="doom ii (disk p - patch file).hdm" size="1261568" crc="44d368e5" sha1="21c318a5f40402b1a0ae9acfa9d35009c25a2132" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+	<software name="doop">
+		<!-- Origin: Neo Kobe Collection -->
+		<description>Doop</description>
+		<year>1997</year>
+		<publisher>メイビーソフト トゥルース (May-Be Soft Truse)</publisher>
+		<info name="alt_title" value="ドォープ" />
+		<info name="release" value="19971009" />
+		<info name="usage" value="Requires HDD installation. Run INSTALL.EXE from DOS." />
+		<part name="flop1" interface="floppy_5_25">
+			<feature name="part_id" value="Disk A"/>
+			<dataarea name="flop" size="1261568">
+				<rom name="doop (disk a).hdm" size="1261568" crc="6739719a" sha1="b8e55366bf6c3e4f5805d3b7360f0d500dd5f369" offset="0" />
+			</dataarea>
+		</part>
+		<part name="flop2" interface="floppy_5_25">
+			<feature name="part_id" value="Disk B"/>
+			<dataarea name="flop" size="1261568">
+				<rom name="doop (disk b).hdm" size="1261568" crc="b6fd6e8b" sha1="136eafd589fc306316b9160caf992f8965720e61" offset="0" />
+			</dataarea>
+		</part>
+		<part name="flop3" interface="floppy_5_25">
+			<feature name="part_id" value="Disk C"/>
+			<dataarea name="flop" size="1261568">
+				<rom name="doop (disk c).hdm" size="1261568" crc="156da8da" sha1="8d6584bcd4c368c60ef4d6f314de3854de34ff35" offset="0" />
+			</dataarea>
+		</part>
+		<part name="flop4" interface="floppy_5_25">
+			<feature name="part_id" value="Disk D"/>
+			<dataarea name="flop" size="1261568">
+				<rom name="doop (disk d).hdm" size="1261568" crc="037436de" sha1="d077edc72e9b7a52d6707e94a67c8b5d37031732" offset="0" />
+			</dataarea>
+		</part>
+		<part name="flop5" interface="floppy_5_25">
+			<feature name="part_id" value="Disk E"/>
+			<dataarea name="flop" size="1261568">
+				<rom name="doop (disk e).hdm" size="1261568" crc="2e4b5535" sha1="ea4d6cca68154035e15e83f0a13db0960c8b724b" offset="0" />
+			</dataarea>
+		</part>
+		<part name="flop6" interface="floppy_5_25">
+			<feature name="part_id" value="Disk F"/>
+			<dataarea name="flop" size="1261568">
+				<rom name="doop (disk f).hdm" size="1261568" crc="206d69b8" sha1="fd7d7e61fa3e9466caebf9ada5e9994911acffbd" offset="0" />
+			</dataarea>
+		</part>
+		<part name="flop7" interface="floppy_5_25">
+			<feature name="part_id" value="Disk G"/>
+			<dataarea name="flop" size="1261568">
+				<rom name="doop (disk g).hdm" size="1261568" crc="ccfdc871" sha1="0496be6979a60c960549d98fecc8cba36b9f84ed" offset="0" />
+			</dataarea>
+		</part>
+		<part name="flop8" interface="floppy_5_25">
+			<feature name="part_id" value="Disk H"/>
+			<dataarea name="flop" size="1261568">
+				<rom name="doop (disk h).hdm" size="1261568" crc="2e9296e9" sha1="8bd6f15e47eed03ec7722e7240f86e3ef98b35ae" offset="0" />
+			</dataarea>
+		</part>
+		<part name="flop9" interface="floppy_5_25">
+			<feature name="part_id" value="Disk I"/>
+			<dataarea name="flop" size="1261568">
+				<rom name="doop (disk i).hdm" size="1261568" crc="50018128" sha1="58090b4ad32f9929ad021d96060980182ac1c6cf" offset="0" />
+			</dataarea>
+		</part>
+		<part name="flop10" interface="floppy_5_25">
+			<feature name="part_id" value="Disk J"/>
+			<dataarea name="flop" size="1261568">
+				<rom name="doop (disk j).hdm" size="1261568" crc="0484b65d" sha1="f86054a1ac846913db176391606f0475a3378187" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+	<software name="doraemot">
+		<!-- Origin: Neo Kobe Collection -->
+		<description>Dora Dora Emotion - Seihaiden</description>
+		<year>1995</year>
+		<publisher>カクテル・ソフト (Cocktail Soft)</publisher>
+		<info name="alt_title" value="ＤＯＲＡＤＯＲＡエモーション ～聖牌伝～" />
+		<info name="release" value="19950721" />
+		<part name="flop1" interface="floppy_5_25">
+			<feature name="part_id" value="Disk A"/>
+			<dataarea name="flop" size="1261568">
+				<rom name="dora dora emotion - seihaiden (disk a).hdm" size="1261568" crc="1cce8038" sha1="348320b05133e40692d791a3915707d3405d8862" offset="0" />
+			</dataarea>
+		</part>
+		<part name="flop2" interface="floppy_5_25">
+			<feature name="part_id" value="Disk B"/>
+			<dataarea name="flop" size="1261568">
+				<rom name="dora dora emotion - seihaiden (disk b).hdm" size="1261568" crc="bbc54dfb" sha1="6e115025d1a80163fb5b772006c06bb2969f3974" offset="0" />
+			</dataarea>
+		</part>
+		<part name="flop3" interface="floppy_5_25">
+			<feature name="part_id" value="Disk C"/>
+			<dataarea name="flop" size="1261568">
+				<rom name="dora dora emotion - seihaiden (disk c).hdm" size="1261568" crc="e00a24ba" sha1="a78b5d38fc100be21835c6ae732bc24f4fb17187" offset="0" />
+			</dataarea>
+		</part>
+		<part name="flop4" interface="floppy_5_25">
+			<feature name="part_id" value="Disk D"/>
+			<dataarea name="flop" size="1261568">
+				<rom name="dora dora emotion - seihaiden (disk d).hdm" size="1261568" crc="18dcd205" sha1="af10424262b44a82eb665774cdceb1c85fef3cb3" offset="0" />
+			</dataarea>
+		</part>
+		<part name="flop5" interface="floppy_5_25">
+			<feature name="part_id" value="Disk E"/>
+			<dataarea name="flop" size="1261568">
+				<rom name="dora dora emotion - seihaiden (disk e).hdm" size="1261568" crc="f9e818b7" sha1="3ce4e332db510234c293336d40a4e05d7567d3dc" offset="0" />
+			</dataarea>
+		</part>
+		<part name="flop6" interface="floppy_5_25">
+			<feature name="part_id" value="Disk F"/>
+			<dataarea name="flop" size="1261568">
+				<rom name="dora dora emotion - seihaiden (disk f).hdm" size="1261568" crc="ef149fb8" sha1="af69bf03a9279053f746d9b7825a4bf99372a294" offset="0" />
+			</dataarea>
+		</part>
+		<part name="flop7" interface="floppy_5_25">
+			<feature name="part_id" value="Disk G"/>
+			<dataarea name="flop" size="1261568">
+				<rom name="dora dora emotion - seihaiden (disk g).hdm" size="1261568" crc="3e6c028b" sha1="2019c06f1a4f69246db462eb5e645b635b9cf3d6" offset="0" />
+			</dataarea>
+		</part>
+		<part name="flop8" interface="floppy_5_25">
+			<feature name="part_id" value="Disk H"/>
+			<dataarea name="flop" size="1261568">
+				<rom name="dora dora emotion - seihaiden (disk h).hdm" size="1261568" crc="fcf723a4" sha1="c5ed1653ed6ad057b5f7316de54d5b48d8102654" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+	<!-- Fails to boot with a "Disk I/O Error" -->
+	<software name="doordoor" supported="no">
 		<description>Door Door</description>
 		<year>1984</year>
 		<publisher>エニックス (Enix)</publisher>
@@ -15026,55 +15817,55 @@ only have some part of Windows file and a Video driver(CLGD?).
 			</dataarea>
 		</part>
 		<part name="flop2" interface="floppy_5_25">
-			<feature name="part_id" value="Disk A"/>
+			<feature name="part_id" value="Game Disk 1"/>
 			<dataarea name="flop" size="1265664">
 				<rom name="dor_se93(diska).fdi" size="1265664" crc="20340015" sha1="bce9139fc4576c6d49fb79111f6472707379957c" offset="0" />
 			</dataarea>
 		</part>
 		<part name="flop3" interface="floppy_5_25">
-			<feature name="part_id" value="Disk B"/>
+			<feature name="part_id" value="Game Disk 2"/>
 			<dataarea name="flop" size="1265664">
 				<rom name="dor_se93(diskb).fdi" size="1265664" crc="e3e2ad93" sha1="98c546f3a9723c709fa7a4da5fe87625fae9a07e" offset="0" />
 			</dataarea>
 		</part>
 		<part name="flop4" interface="floppy_5_25">
-			<feature name="part_id" value="Disk C"/>
+			<feature name="part_id" value="Game Disk 3"/>
 			<dataarea name="flop" size="1265664">
 				<rom name="dor_se93(diskc).fdi" size="1265664" crc="fea72e17" sha1="2b884afdc17817ed371749be2d8e9c95e5e9fb23" offset="0" />
 			</dataarea>
 		</part>
 		<part name="flop5" interface="floppy_5_25">
-			<feature name="part_id" value="Disk D"/>
+			<feature name="part_id" value="Game Disk 4"/>
 			<dataarea name="flop" size="1265664">
 				<rom name="dor_se93(diskd).fdi" size="1265664" crc="3935e460" sha1="4c65cc130ad2252efa7645ae7e33d96fdf71b0c6" offset="0" />
 			</dataarea>
 		</part>
 		<part name="flop6" interface="floppy_5_25">
-			<feature name="part_id" value="Disk E"/>
+			<feature name="part_id" value="Game Disk 5"/>
 			<dataarea name="flop" size="1265664">
 				<rom name="dor_se93(diske).fdi" size="1265664" crc="178264c8" sha1="9b28252bdb563e7625a99d585a6c56f45703e90e" offset="0" />
 			</dataarea>
 		</part>
 		<part name="flop7" interface="floppy_5_25">
-			<feature name="part_id" value="Disk F"/>
+			<feature name="part_id" value="Game Disk 6"/>
 			<dataarea name="flop" size="1265664">
 				<rom name="dor_se93(diskf).fdi" size="1265664" crc="ece485c1" sha1="ce4486b726ad1b6e4fab96cd3695658366b350f8" offset="0" />
 			</dataarea>
 		</part>
 		<part name="flop8" interface="floppy_5_25">
-			<feature name="part_id" value="Disk G"/>
+			<feature name="part_id" value="Game Disk 7"/>
 			<dataarea name="flop" size="1265664">
 				<rom name="dor_se93(diskg).fdi" size="1265664" crc="3e242161" sha1="a78944ee3ff75d5ff1e85b6110e52011b929c336" offset="0" />
 			</dataarea>
 		</part>
 		<part name="flop9" interface="floppy_5_25">
-			<feature name="part_id" value="Disk H"/>
+			<feature name="part_id" value="Game Disk 8"/>
 			<dataarea name="flop" size="1265664">
 				<rom name="dor_se93(diskh).fdi" size="1265664" crc="d9a31e79" sha1="7e0a948a7c5f8747ab25429d132eac239ec4dfb7" offset="0" />
 			</dataarea>
 		</part>
 		<part name="flop10" interface="floppy_5_25">
-			<feature name="part_id" value="Disk I"/>
+			<feature name="part_id" value="Game Disk 9"/>
 			<dataarea name="flop" size="1265664">
 				<rom name="dor_se93(diski).fdi" size="1265664" crc="77e69cfa" sha1="98ad0cad460c468865fba546c204789918d73b92" offset="0" />
 			</dataarea>
@@ -15094,38 +15885,39 @@ only have some part of Windows file and a Video driver(CLGD?).
 			</dataarea>
 		</part>
 		<part name="flop2" interface="floppy_5_25">
-			<feature name="part_id" value="Disk 1"/>
+			<feature name="part_id" value="Game Disk 1"/>
 			<dataarea name="flop" size="1265664">
 				<rom name="dor special edition s 01.fdi" size="1265664" crc="a9687985" sha1="db7e6ec27719bd090ba9cb4075af54ac1827d456" offset="0" />
 			</dataarea>
 		</part>
 		<part name="flop3" interface="floppy_5_25">
-			<feature name="part_id" value="Disk 2"/>
+			<feature name="part_id" value="Game Disk 2"/>
 			<dataarea name="flop" size="1265664">
 				<rom name="dor special edition s 02.fdi" size="1265664" crc="2d5a69f9" sha1="19c2f78569efab53ada482835c00cb56ea7b3a1d" offset="0" />
 			</dataarea>
 		</part>
 		<part name="flop4" interface="floppy_5_25">
-			<feature name="part_id" value="Disk 3"/>
+			<feature name="part_id" value="Game Disk 3"/>
 			<dataarea name="flop" size="1265664">
 				<rom name="dor special edition s 03.fdi" size="1265664" crc="f2014553" sha1="14ac56077a15d13717b35fbb8683422c978fce80" offset="0" />
 			</dataarea>
 		</part>
 		<part name="flop5" interface="floppy_5_25">
-			<feature name="part_id" value="Disk 4"/>
+			<feature name="part_id" value="Game Disk 4"/>
 			<dataarea name="flop" size="1265664">
 				<rom name="dor special edition s 04.fdi" size="1265664" crc="a70f500e" sha1="e10bc81d7ae76d4cd66b35671f21ca147ecf81f3" offset="0" />
 			</dataarea>
 		</part>
 		<part name="flop6" interface="floppy_5_25">
-			<feature name="part_id" value="Disk 5"/>
+			<feature name="part_id" value="Game Disk 5"/>
 			<dataarea name="flop" size="1265664">
 				<rom name="dor special edition s 05.fdi" size="1265664" crc="cbb50dd4" sha1="6105d358e3e795357eddc2f86353e9e60c8ff165" offset="0" />
 			</dataarea>
 		</part>
 	</software>
 
-	<software name="dbleagle">
+	<!-- The controls don't work properly -->
+	<software name="dbleagle" supported="no">
 		<description>Double Eagle</description>
 		<year>1989</year>
 		<publisher>アートディンク (Artdink)</publisher>
@@ -15152,6 +15944,7 @@ only have some part of Windows file and a Video driver(CLGD?).
 		<publisher>エルフ (Elf)</publisher>
 		<info name="alt_title" value="同級生２ ＨＤ専用版" />
 		<info name="release" value="19950131" />
+		<info name="usage" value="Requires HDD installation. Run INSTALL.EXE from DOS." />
 		<part name="flop1" interface="floppy_5_25">
 			<feature name="part_id" value="Disk A"/>
 			<dataarea name="flop" size="1281968">
@@ -15220,7 +16013,8 @@ only have some part of Windows file and a Video driver(CLGD?).
 		</part>
 	</software>
 
-	<software name="dokyuse2sp" cloneof="dokyuse2">
+	<!-- MAME fails to mount the images with "Fatal error: Incorrect layout on track 0 head 0, expected_size=166666, current_size=167648" error -->
+	<software name="dokyuse2sp" cloneof="dokyuse2" supported="no">
 		<description>Doukyuusei 2 HD Senyou Ban - Special Disk</description>
 		<year>1995</year>
 		<publisher>エルフ (Elf)</publisher>
@@ -15270,6 +16064,7 @@ only have some part of Windows file and a Video driver(CLGD?).
 		<year>1992</year>
 		<publisher>アリスソフト (AliceSoft)</publisher>
 		<info name="release" value="19920415" />
+		<info name="usage" value="Boot from a DOS floppy and run INST.COM from Disk A" />
 		<part name="flop1" interface="floppy_5_25">
 			<feature name="part_id" value="Disk A"/>
 			<dataarea name="flop" size="1281968">
@@ -15284,6 +16079,35 @@ only have some part of Windows file and a Video driver(CLGD?).
 		</part>
 	</software>
 
+	<!-- PC-9801-86 sound mode doesn't work, even with the appropriate board installed -->
+	<software name="dr2janki" supported="partial">
+		<!-- Origin: Neo Kobe Collection -->
+		<description>DR² Night Janki</description>
+		<year>1995</year>
+		<publisher>リーフ (Leaf)</publisher>
+		<info name="release" value="19950224" />
+		<info name="alt_title" value="ＤＲ² ナイト雀鬼" />
+		<part name="flop1" interface="floppy_5_25">
+			<feature name="part_id" value="Disk A"/>
+			<dataarea name="flop" size="1261568">
+				<rom name="dr^2 night janki (disk a).hdm" size="1261568" crc="8061c05a" sha1="04365c36ee0ff0ae99d7025fd121da0d92d6b906" offset="0" />
+			</dataarea>
+		</part>
+		<part name="flop2" interface="floppy_5_25">
+			<feature name="part_id" value="Disk B"/>
+			<dataarea name="flop" size="1261568">
+				<rom name="dr^2 night janki (disk b).hdm" size="1261568" crc="a11390d0" sha1="465f8d3e4d7548cb73d233b5a2be92773e5853f4" offset="0" />
+			</dataarea>
+		</part>
+		<part name="flop3" interface="floppy_5_25">
+			<feature name="part_id" value="Disk C"/>
+			<dataarea name="flop" size="1261568">
+				<rom name="dr^2 night janki (disk c).hdm" size="1261568" crc="ea88622c" sha1="02ea979b961cf965cb6c593808212d8b2f27eb88" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+	<!-- Seems to work only on 286-based machines (e.g. PC-9801UX) -->
 	<software name="dracula">
 		<description>Dracula Hakushaku</description>
 		<year>1992</year>
@@ -15316,7 +16140,8 @@ only have some part of Windows file and a Video driver(CLGD?).
 		</part>
 	</software>
 
-	<software name="dbuster">
+	<!-- Sprites leave "trails" on screen -->
+	<software name="dbuster" supported="partial">
 		<description>Dragon Buster</description>
 		<year>1989</year>
 		<publisher>マイコンソフト (Micom Soft?)</publisher>
@@ -15381,7 +16206,8 @@ only have some part of Windows file and a Video driver(CLGD?).
 		</part>
 	</software>
 
-	<software name="draghalf">
+	<!-- Doesn't recognize disk changes, but it's possible to install the game to HDD -->
+	<software name="draghalf" supported="partial">
 		<description>Dragon Half</description>
 		<year>1993</year>
 		<publisher>マイクロキャビン (Microcabin)</publisher>
@@ -15477,12 +16303,14 @@ only have some part of Windows file and a Video driver(CLGD?).
 		</part>
 	</software>
 
-	<software name="dknight3">
+	<!-- Doesn't recognize disk changes, but it's possible to install the game to HDD -->
+	<software name="dknight3" supported="partial">
 		<description>Dragon Knight III</description>
 		<year>1991</year>
 		<publisher>エルフ (Elf)</publisher>
 		<info name="alt_title" value="ドラゴンナイト３" />
 		<info name="release" value="19911214" />
+		<info name="usage" value="To install the game to HDD, create a new directory, copy INSTALL.EXE from disk B to it, and run it. After installation, run DR3.BAT to start the game" />
 		<part name="flop1" interface="floppy_5_25">
 			<feature name="part_id" value="Disk A"/>
 			<dataarea name="flop" size="1265664">
@@ -15525,7 +16353,7 @@ only have some part of Windows file and a Video driver(CLGD?).
 		<description>Dragon Knight 4 - Special Disk</description>
 		<year>1994</year>
 		<publisher>エルフ (Elf)</publisher>
-		<info name="alt_title" value="ドラゴンナイト３" />
+		<info name="alt_title" value="ドラゴンナイト4 Special Disk" />
 		<info name="release" value="19911214" />
 		<info name="usage" value="Requires &quot;Dragon Knight 4&quot; to work" />
 		<part name="flop1" interface="floppy_5_25">
@@ -15538,6 +16366,98 @@ only have some part of Windows file and a Video driver(CLGD?).
 			<feature name="part_id" value="Disk B"/>
 			<dataarea name="flop" size="1261568">
 				<rom name="dknight4 specialdisk_b.fdi" size="1261568" crc="724258bb" sha1="2518bedc499bec1d23cbee5871283110505e8954" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+	<!-- There is no Episode 1, this is actually the first game in the series -->
+	<software name="silk">
+		<!-- Origin: Neo Kobe Collection -->
+		<description>Dragon Master Silk - Ryuu Shoukan Musume - Episode II</description>
+		<year>1992</year>
+		<publisher>ギミックハウス (Gimmick House)</publisher>
+		<info name="alt_title" value="ドラゴンマスターシルク ～龍召還娘～ Ｅｐｉｓｏｄｅ II" />
+		<info name="release" value="19921204" />
+		<part name="flop1" interface="floppy_5_25">
+			<feature name="part_id" value="Disk 1"/>
+			<dataarea name="flop" size="1261568">
+				<rom name="dragon master silk (disk 1).hdm" size="1261568" crc="c63be072" sha1="786aebfab84f074f159a79b62cc7641b33f2f409" offset="0" />
+			</dataarea>
+		</part>
+		<part name="flop2" interface="floppy_5_25">
+			<feature name="part_id" value="Disk 2"/>
+			<dataarea name="flop" size="1261568">
+				<rom name="dragon master silk (disk 2).hdm" size="1261568" crc="9e2917f4" sha1="af18092394b7aa822f2aef120a0d92958207aac9" offset="0" />
+			</dataarea>
+		</part>
+		<part name="flop3" interface="floppy_5_25">
+			<feature name="part_id" value="Disk 3"/>
+			<dataarea name="flop" size="1261568">
+				<rom name="dragon master silk (disk 3).hdm" size="1261568" crc="31d30df3" sha1="90a8cd660b0d67c27e025358b280321bd2731822" offset="0" />
+			</dataarea>
+		</part>
+		<part name="flop4" interface="floppy_5_25">
+			<feature name="part_id" value="Disk 4"/>
+			<dataarea name="flop" size="1261568">
+				<rom name="dragon master silk (disk 4).hdm" size="1261568" crc="0e679f5f" sha1="2be2caea30c6412b8076c645b8eed73d7460d01d" offset="0" />
+			</dataarea>
+		</part>
+		<part name="flop5" interface="floppy_5_25">
+			<feature name="part_id" value="Disk 5"/>
+			<dataarea name="flop" size="1261568">
+				<rom name="dragon master silk (disk 5).hdm" size="1261568" crc="20be46a7" sha1="3f98575cac0e209f32a41f293de6e97e49d1e43f" offset="0" />
+			</dataarea>
+		</part>
+		<part name="flop6" interface="floppy_5_25">
+			<feature name="part_id" value="Disk 6"/>
+			<dataarea name="flop" size="1261568">
+				<rom name="dragon master silk (disk 6).hdm" size="1261568" crc="50ec7a6c" sha1="aaaed89b8af66b68df0aabf9f7299ce7e702ce40" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+	<!-- This set has a different executable file -->
+	<software name="silka" cloneof="silk">
+		<!-- Origin: Neo Kobe Collection -->
+		<description>Dragon Master Silk - Ryuu Shoukan Musume - Episode II (Alt Disk 1)</description>
+		<year>1992</year>
+		<publisher>ギミックハウス (Gimmick House)</publisher>
+		<info name="alt_title" value="ドラゴンマスターシルク ～龍召還娘～ Ｅｐｉｓｏｄｅ II" />
+		<info name="release" value="19921204" />
+		<part name="flop1" interface="floppy_5_25">
+			<feature name="part_id" value="Disk 1"/>
+			<dataarea name="flop" size="1261568">
+				<rom name="dragon master silk (disk 1) [alt 2].hdm" size="1261568" crc="b5bae065" sha1="b0f5961cd9ae37e2fbb2c053f94ff761d5d73af6" offset="0" />
+			</dataarea>
+		</part>
+		<part name="flop2" interface="floppy_5_25">
+			<feature name="part_id" value="Disk 2"/>
+			<dataarea name="flop" size="1261568">
+				<rom name="dragon master silk (disk 2).hdm" size="1261568" crc="9e2917f4" sha1="af18092394b7aa822f2aef120a0d92958207aac9" offset="0" />
+			</dataarea>
+		</part>
+		<part name="flop3" interface="floppy_5_25">
+			<feature name="part_id" value="Disk 3"/>
+			<dataarea name="flop" size="1261568">
+				<rom name="dragon master silk (disk 3).hdm" size="1261568" crc="31d30df3" sha1="90a8cd660b0d67c27e025358b280321bd2731822" offset="0" />
+			</dataarea>
+		</part>
+		<part name="flop4" interface="floppy_5_25">
+			<feature name="part_id" value="Disk 4"/>
+			<dataarea name="flop" size="1261568">
+				<rom name="dragon master silk (disk 4).hdm" size="1261568" crc="0e679f5f" sha1="2be2caea30c6412b8076c645b8eed73d7460d01d" offset="0" />
+			</dataarea>
+		</part>
+		<part name="flop5" interface="floppy_5_25">
+			<feature name="part_id" value="Disk 5"/>
+			<dataarea name="flop" size="1261568">
+				<rom name="dragon master silk (disk 5).hdm" size="1261568" crc="20be46a7" sha1="3f98575cac0e209f32a41f293de6e97e49d1e43f" offset="0" />
+			</dataarea>
+		</part>
+		<part name="flop6" interface="floppy_5_25">
+			<feature name="part_id" value="Disk 6"/>
+			<dataarea name="flop" size="1261568">
+				<rom name="dragon master silk (disk 6).hdm" size="1261568" crc="50ec7a6c" sha1="aaaed89b8af66b68df0aabf9f7299ce7e702ce40" offset="0" />
 			</dataarea>
 		</part>
 	</software>
@@ -15660,16 +16580,17 @@ only have some part of Windows file and a Video driver(CLGD?).
 		<publisher>日本ファルコム (Nihon Falcom)</publisher>
 		<info name="alt_title" value="ドラゴンスレイヤー英雄伝説" />
 		<info name="release" value="19900420" />
+		<info name="usage" value="To start a new game, boot from the event disk. To load an existing save, boot from the program disk with scenario disk on drive 2. Make a copy of the scenario disk to be able to save permanently." />
 		<part name="flop1" interface="floppy_5_25">
-			<feature name="part_id" value="Program Disk"/>
-			<dataarea name="flop" size="1281968">
-				<rom name="ed1 program.d88" size="1281968" crc="ed4cff2c" sha1="938394f9248dcefe17cbbc15435604da02f5fa89" offset="0" />
-			</dataarea>
-		</part>
-		<part name="flop2" interface="floppy_5_25">
 			<feature name="part_id" value="Event Disk"/>
 			<dataarea name="flop" size="1281968">
 				<rom name="ed1 event.d88" size="1281968" crc="04e47e7b" sha1="9fd992b5c525ccedea6a802ac1b7a9e4e73ec09e" offset="0" />
+			</dataarea>
+		</part>
+		<part name="flop2" interface="floppy_5_25">
+			<feature name="part_id" value="Program Disk"/>
+			<dataarea name="flop" size="1281968">
+				<rom name="ed1 program.d88" size="1281968" crc="ed4cff2c" sha1="938394f9248dcefe17cbbc15435604da02f5fa89" offset="0" />
 			</dataarea>
 		</part>
 		<part name="flop3" interface="floppy_5_25">
@@ -15686,32 +16607,33 @@ only have some part of Windows file and a Video driver(CLGD?).
 		<publisher>日本ファルコム (Nihon Falcom)</publisher>
 		<info name="alt_title" value="ドラゴンスレイヤー英雄伝説２" />
 		<info name="release" value="19920319" />
+		<info name="usage" value="Create a copy of the program disk with the プログラムディスクのバックアップ option, then boot from it" />
 		<part name="flop1" interface="floppy_5_25">
-			<feature name="part_id" value="Main"/>
-			<dataarea name="flop" size="1265664">
-				<rom name="ed2_m.fdi" size="1265664" crc="0cfd2ddb" sha1="1d7aca616bbc4bc2da2967a9995bd40d519d5bfd" offset="0" />
-			</dataarea>
-		</part>
-		<part name="flop2" interface="floppy_5_25">
-			<feature name="part_id" value="Program"/>
+			<feature name="part_id" value="Program Disk"/>
 			<dataarea name="flop" size="1265664">
 				<rom name="ed2_p.fdi" size="1265664" crc="4b7c4b5e" sha1="41082ae4e386bf8f69c84e8b51dfdcc1f6749243" offset="0" />
 			</dataarea>
 		</part>
+		<part name="flop2" interface="floppy_5_25">
+			<feature name="part_id" value="Master Program Disk"/>
+			<dataarea name="flop" size="1265664">
+				<rom name="ed2_m.fdi" size="1265664" crc="0cfd2ddb" sha1="1d7aca616bbc4bc2da2967a9995bd40d519d5bfd" offset="0" />
+			</dataarea>
+		</part>
 		<part name="flop3" interface="floppy_5_25">
-			<feature name="part_id" value="Scenario 1"/>
+			<feature name="part_id" value="Scenario Disk 1"/>
 			<dataarea name="flop" size="1265664">
 				<rom name="ed2_s1.fdi" size="1265664" crc="a1386eca" sha1="149a1a2f49c4d5b8358ca088426d6850456f6fc5" offset="0" />
 			</dataarea>
 		</part>
 		<part name="flop4" interface="floppy_5_25">
-			<feature name="part_id" value="Scenario 2"/>
+			<feature name="part_id" value="Scenario Disk 2"/>
 			<dataarea name="flop" size="1265664">
 				<rom name="ed2_s2.fdi" size="1265664" crc="27427125" sha1="5c1a42786cdf47127e6e1357c27b3981dcf7e40c" offset="0" />
 			</dataarea>
 		</part>
 		<part name="flop5" interface="floppy_5_25">
-			<feature name="part_id" value="Scenario 3"/>
+			<feature name="part_id" value="Scenario Disk 3"/>
 			<dataarea name="flop" size="1265664">
 				<rom name="ed2_s3.fdi" size="1265664" crc="1ce6911a" sha1="ace726e6efe12dc224d9dae52c91955bc5835ef0" offset="0" />
 			</dataarea>
@@ -15782,6 +16704,7 @@ only have some part of Windows file and a Video driver(CLGD?).
 		<publisher>スタークラフト (Starcraft)</publisher>
 		<info name="alt_title" value="ドラゴンウォーズ" />
 		<info name="release" value="19901212" />
+		<info name="usage" value="Run DRAGON.EXE from DOS" />
 		<part name="flop1" interface="floppy_5_25">
 			<feature name="part_id" value="Disk 1"/>
 			<dataarea name="flop" size="1281968">
@@ -15836,7 +16759,8 @@ only have some part of Windows file and a Video driver(CLGD?).
 		</part>
 	</software>
 
-	<software name="drakkhen">
+	<!-- Some graphics glitches -->
+	<software name="drakkhen" supported="partial">
 		<description>Drakkhen</description>
 		<year>1991</year>
 		<publisher>EPICソニー (EPIC Sony)</publisher>
@@ -15849,7 +16773,117 @@ only have some part of Windows file and a Video driver(CLGD?).
 		</part>
 	</software>
 
-	<software name="dualtarg">
+	<software name="dtheater">
+		<!-- Origin: Neo Kobe Collection -->
+		<description>Dream Theater</description>
+		<year>1994</year>
+		<publisher>ワイルドライフ (Wild Life)</publisher>
+		<info name="alt_title" value="ドリームシアター" />
+		<info name="release" value="19941028" />
+		<info name="usage" value="Run DOSINST.EXE to copy system files, or HDDINST.EXE to install to HDD" />
+		<part name="flop1" interface="floppy_5_25">
+			<feature name="part_id" value="Disk A"/>
+			<dataarea name="flop" size="1261568">
+				<rom name="dream theater (disk a).hdm" size="1261568" crc="cd0dfeb4" sha1="744c105f300b5aa6565924db2362e5c7a1d4366c" offset="0" />
+			</dataarea>
+		</part>
+		<part name="flop2" interface="floppy_5_25">
+			<feature name="part_id" value="Disk B"/>
+			<dataarea name="flop" size="1261568">
+				<rom name="dream theater (disk b).hdm" size="1261568" crc="be6eea87" sha1="f4b438cccf37eb6feed32a7b50d4b01d76747233" offset="0" />
+			</dataarea>
+		</part>
+		<part name="flop3" interface="floppy_5_25">
+			<feature name="part_id" value="Disk C"/>
+			<dataarea name="flop" size="1261568">
+				<rom name="dream theater (disk c).hdm" size="1261568" crc="bff484a9" sha1="f5ff731f1004ab3ec26abbf3da67986d04ad6330" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+	<!-- This set contains fragments of source code and compiler logs for the installer program -->
+	<software name="dtheatera" cloneof="dtheater">
+		<!-- Origin: Neo Kobe Collection -->
+		<description>Dream Theater (Alt)</description>
+		<year>1994</year>
+		<publisher>ワイルドライフ (Wild Life)</publisher>
+		<info name="alt_title" value="ドリームシアター" />
+		<info name="release" value="19941028" />
+		<info name="usage" value="Run DOSINST.EXE to copy system files, or HDDINST.EXE to install to HDD" />
+		<part name="flop1" interface="floppy_5_25">
+			<feature name="part_id" value="Disk A"/>
+			<dataarea name="flop" size="1261568">
+				<rom name="dream theater [set 1] (disk a).hdm" size="1261568" crc="2e7a8a7a" sha1="2734b65b7f45933e79d104d6babc417f5c6ff847" offset="0" />
+			</dataarea>
+		</part>
+		<part name="flop2" interface="floppy_5_25">
+			<feature name="part_id" value="Disk B"/>
+			<dataarea name="flop" size="1261568">
+				<rom name="dream theater set 1] (disk b).hdm" size="1261568" crc="1aaaffa7" sha1="cbdef42e4f1bc968f77ac0eab4a45737740e2f9f" offset="0" />
+			</dataarea>
+		</part>
+		<part name="flop3" interface="floppy_5_25">
+			<feature name="part_id" value="Disk C"/>
+			<dataarea name="flop" size="1261568">
+				<rom name="dream theater set 1] (disk c).hdm" size="1261568" crc="cd54ae87" sha1="526067c86b590f3fc8383b43bd38ce77fc49a9f8" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+	<software name="dualsoul">
+		<!-- Origin: Neo Kobe Collection -->
+		<description>Dual Soul</description>
+		<year>1995</year>
+		<publisher>アイル (AIL)</publisher>
+		<info name="alt_title" value="デュアルソウル" />
+		<info name="release" value="19950415" />
+		<info name="usage" value="Boot DOS from floppy, then put Disk A on drive 1 and the DOS floppy on drive 2. Run INST.COM to copy the system files." />
+		<part name="flop1" interface="floppy_5_25">
+			<feature name="part_id" value="Disk A"/>
+			<dataarea name="flop" size="1261568">
+				<rom name="dual soul (disk a).hdm" size="1261568" crc="163e648b" sha1="4be5163d6f8c348060f49d5517d393438cd6481f" offset="0" />
+			</dataarea>
+		</part>
+		<part name="flop2" interface="floppy_5_25">
+			<feature name="part_id" value="Disk B"/>
+			<dataarea name="flop" size="1261568">
+				<rom name="dual soul (disk b).hdm" size="1261568" crc="5c714077" sha1="cf725d799b256f25022cfa1f1990c7e5f2fffb6f" offset="0" />
+			</dataarea>
+		</part>
+		<part name="flop3" interface="floppy_5_25">
+			<feature name="part_id" value="Disk C"/>
+			<dataarea name="flop" size="1261568">
+				<rom name="dual soul (disk c).hdm" size="1261568" crc="a74e2222" sha1="c3770e190c26e5d66f6c6434bbd0d1e99493e912" offset="0" />
+			</dataarea>
+		</part>
+		<part name="flop4" interface="floppy_5_25">
+			<feature name="part_id" value="Disk D"/>
+			<dataarea name="flop" size="1261568">
+				<rom name="dual soul (disk d).hdm" size="1261568" crc="fb0b61a6" sha1="f85e028e6b042bf0f6082aee7b8075803f5ac4db" offset="0" />
+			</dataarea>
+		</part>
+		<part name="flop5" interface="floppy_5_25">
+			<feature name="part_id" value="Disk E"/>
+			<dataarea name="flop" size="1261568">
+				<rom name="dual soul (disk e).hdm" size="1261568" crc="b739a305" sha1="79df307922357837718e3e04ccef81b6ec31813e" offset="0" />
+			</dataarea>
+		</part>
+		<part name="flop6" interface="floppy_5_25">
+			<feature name="part_id" value="Disk F"/>
+			<dataarea name="flop" size="1261568">
+				<rom name="dual soul (disk f).hdm" size="1261568" crc="5e9124df" sha1="0717d3d8a4554f401730969d3e5eb5fa6078ec04" offset="0" />
+			</dataarea>
+		</part>
+		<part name="flop7" interface="floppy_5_25">
+			<feature name="part_id" value="Disk G"/>
+			<dataarea name="flop" size="1261568">
+				<rom name="dual soul (disk g).hdm" size="1261568" crc="bc975819" sha1="3b6c2c512560121da8c1758c24e7fe1bee968363" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+	<!-- Missing text in the intro -->
+	<software name="dualtarg" supported="partial">
 		<description>Dual Targets - The 4th Unit Act. 3</description>
 		<year>1989</year>
 		<publisher>データウエスト (Data West)</publisher>
@@ -15869,33 +16903,91 @@ only have some part of Windows file and a Video driver(CLGD?).
 		</part>
 	</software>
 
-	<software name="duel">
+	<!-- No sound -->
+	<software name="duel" supported="partial">
 		<description>Duel</description>
 		<year>1990</year>
 		<publisher>呉ソフトウエア工房  (KSK)</publisher>
 		<info name="alt_title" value="デュエル" />
 		<info name="release" value="19900512" />
 		<part name="flop1" interface="floppy_5_25">
-			<feature name="part_id" value="Char"/>
-			<dataarea name="flop" size="1089776">
-				<rom name="duelchar.d88" size="1089776" crc="7839ccb8" sha1="10e8e2c6e8e4d7ac145df1ec57e60b0b52bda86d" offset="0" />
-			</dataarea>
-		</part>
-		<part name="flop2" interface="floppy_5_25">
-			<feature name="part_id" value="Map"/>
-			<dataarea name="flop" size="1089776">
-				<rom name="duelmap.d88" size="1089776" crc="8906b0fc" sha1="7e3a89d42e8e7e13173266e077c07586e7caeae6" offset="0" />
-			</dataarea>
-		</part>
-		<part name="flop3" interface="floppy_5_25">
-			<feature name="part_id" value="Opening"/>
+			<feature name="part_id" value="Opening Disk"/>
 			<dataarea name="flop" size="1086448">
 				<rom name="duelopen.d88" size="1086448" crc="8abaaf81" sha1="2e86098fe1ddf9af00f111cace170765405712b0" offset="0" />
 			</dataarea>
 		</part>
+		<part name="flop2" interface="floppy_5_25">
+			<feature name="part_id" value="Character Disk"/>
+			<dataarea name="flop" size="1089776">
+				<rom name="duelchar.d88" size="1089776" crc="7839ccb8" sha1="10e8e2c6e8e4d7ac145df1ec57e60b0b52bda86d" offset="0" />
+			</dataarea>
+		</part>
+		<part name="flop3" interface="floppy_5_25">
+			<feature name="part_id" value="Map Disk"/>
+			<dataarea name="flop" size="1089776">
+				<rom name="duelmap.d88" size="1089776" crc="8906b0fc" sha1="7e3a89d42e8e7e13173266e077c07586e7caeae6" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+	
+	<software name="duelkawa">
+		<!-- Origin: Neo Kobe Collection -->
+		<description>Duel - Kawanakajima Scenario</description>
+		<year>1991</year>
+		<publisher>呉ソフトウエア工房  (KSK)</publisher>
+		<info name="alt_title" value="デュエル 川中島シナリオ" />
+		<info name="release" value="19910720" />
+		<info name="usage" value="Expansion disk for Duel. Boot from the original Duel opening disk, then switch to the character/map disks from this set when prompted" />
+		<part name="flop1" interface="floppy_5_25">
+			<feature name="part_id" value="Character Disk"/>
+			<dataarea name="flop" size="1089776">
+				<rom name="duel kawanakajima (character disk).d88" size="1089776" crc="51b0bc48" sha1="5f9bed2551ad539758780dfe76e2a0fd9c683572" offset="0" />
+			</dataarea>
+		</part>
+		<part name="flop2" interface="floppy_5_25">
+			<feature name="part_id" value="Map Disk"/>
+			<dataarea name="flop" size="1089776">
+				<rom name="duel kawanakajima (map disk).d88" size="1089776" crc="a3bddafd" sha1="2e13e0d2e43d3b696d73a761b84ccfa4f16c575c" offset="0" />
+			</dataarea>
+		</part>
 	</software>
 
-	<software name="dbuster2">
+	<software name="duelsuc">
+		<!-- Origin: Neo Kobe Collection -->
+		<description>Duel Succession</description>
+		<year>1996</year>
+		<publisher>呉ソフトウエア工房  (KSK)</publisher>
+		<info name="alt_title" value="デュエル・サクセション" />
+		<info name="release" value="19960323" />
+		<info name="usage" value="Requires HDD installation. Run DSINST.EXE from DOS." />
+		<part name="flop1" interface="floppy_5_25">
+			<feature name="part_id" value="Disk 1"/>
+			<dataarea name="flop" size="1261568">
+				<rom name="duel succession (disk 1).hdm" size="1261568" crc="19450867" sha1="650364bef283adce48a2daf30e893bacf1b7c196" offset="0" />
+			</dataarea>
+		</part>
+		<part name="flop2" interface="floppy_5_25">
+			<feature name="part_id" value="Disk 2"/>
+			<dataarea name="flop" size="1261568">
+				<rom name="duel succession (disk 2).hdm" size="1261568" crc="def752af" sha1="792a603246327b9b8892ff603b4b27fc8fa3f258" offset="0" />
+			</dataarea>
+		</part>
+		<part name="flop3" interface="floppy_5_25">
+			<feature name="part_id" value="Disk 3"/>
+			<dataarea name="flop" size="1261568">
+				<rom name="duel succession (disk 3).hdm" size="1261568" crc="6a23e31b" sha1="4f6017fc341374d9ce033baac7e20f98c8d34b84" offset="0" />
+			</dataarea>
+		</part>
+		<part name="flop4" interface="floppy_5_25">
+			<feature name="part_id" value="Disk 4"/>
+			<dataarea name="flop" size="1261568">
+				<rom name="duel succession (disk 4).hdm" size="1261568" crc="4d4a5fc1" sha1="fd997f86364432ad6ddae6078facd218f0aff494" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+	<!-- Disk changes don't work. It's possible to start the game if you skip the opening sequence, but it might not work correctly later. --> 
+	<software name="dbuster2" supported="partial">
 		<description>Dungeon Buster 2 Revive</description>
 		<year>1991</year>
 		<publisher>グレイト (Great)</publisher>
@@ -15941,6 +17033,91 @@ only have some part of Windows file and a Video driver(CLGD?).
 		</part>
 	</software>
 
+	<!-- 
+		This is a revised edition that adds:
+		- An optional 16-color compatible graphics driver, for older PC-9801 computers
+		- An updated installer that can use SMARTDRV.EXE instead of SMARTDRV.SYS, hence allowing DOS versions newer than 5.0 
+	-->
+	<software name="dhack">
+		<!-- Origin: Neo Kobe Collection -->
+		<description>Dungeon Hack (newer, 16/256 colors)</description>
+		<year>1995</year>
+		<publisher>ライトスタッフ (Right Stuff)</publisher>
+		<info name="alt_title" value="ダンジョンハック" />
+		<info name="release" value="19950707" />
+		<info name="usage" value="Requires HDD installation and a PC-9821 machine. Run INSTALL.BAT from DOS to install." />
+		<part name="flop1" interface="floppy_5_25">
+			<feature name="part_id" value="Disk 1"/>
+			<dataarea name="flop" size="1261568">
+				<rom name="dungeon hack [set 1] (disk 1).hdm" size="1261568" crc="3654075a" sha1="71cafd5ef505f989cccc13084130ef8814fb8270" offset="0" />
+			</dataarea>
+		</part>
+		<part name="flop2" interface="floppy_5_25">
+			<feature name="part_id" value="Disk 2"/>
+			<dataarea name="flop" size="1261568">
+				<rom name="dungeon hack [set 1] (disk 2).hdm" size="1261568" crc="922b0967" sha1="bac8b44f952acd5ddf1f40795dd61e0c7ff7473f" offset="0" />
+			</dataarea>
+		</part>
+		<part name="flop3" interface="floppy_5_25">
+			<feature name="part_id" value="Disk 3"/>
+			<dataarea name="flop" size="1261568">
+				<rom name="dungeon hack [set 1] (disk 3).hdm" size="1261568" crc="e66d56da" sha1="bfb0e172555ceda15172355b139ac3e0aaf5abfe" offset="0" />
+			</dataarea>
+		</part>
+		<part name="flop4" interface="floppy_5_25">
+			<feature name="part_id" value="Disk 4"/>
+			<dataarea name="flop" size="1261568">
+				<rom name="dungeon hack [set 1] (disk 4).hdm" size="1261568" crc="793a691f" sha1="5d4727b53649769f3b88161b3602133aae920482" offset="0" />
+			</dataarea>
+		</part>
+		<part name="flop5" interface="floppy_5_25">
+			<feature name="part_id" value="Disk 5"/>
+			<dataarea name="flop" size="1261568">
+				<rom name="dungeon hack [set 1] (disk 5).hdm" size="1261568" crc="8c67e73b" sha1="63631343b5cc7ba4a4cdda553eb8725250388dbb" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+	<software name="dhacko" cloneof="dhack">
+		<!-- Origin: Neo Kobe Collection -->
+		<description>Dungeon Hack (older, 256 colors, requires DOS 5.0)</description>
+		<year>1995</year>
+		<publisher>ライトスタッフ (Right Stuff)</publisher>
+		<info name="alt_title" value="ダンジョンハック" />
+		<info name="release" value="19950331" />
+		<info name="usage" value="Requires HDD installation and a PC-9821 machine. Run INSTALL.BAT from DOS to install." />
+		<part name="flop1" interface="floppy_5_25">
+			<feature name="part_id" value="Disk 1"/>
+			<dataarea name="flop" size="1261568">
+				<rom name="dungeon hack (disk 1).hdm" size="1261568" crc="46416012" sha1="a523b12fd7b48f46fdab078a21e416e0758aef12" offset="0" />
+			</dataarea>
+		</part>
+		<part name="flop2" interface="floppy_5_25">
+			<feature name="part_id" value="Disk 2"/>
+			<dataarea name="flop" size="1261568">
+				<rom name="dungeon hack (disk 2).hdm" size="1261568" crc="72f24f6c" sha1="0901386358476c8a9ed8527cbaf76ce100db5c75" offset="0" />
+			</dataarea>
+		</part>
+		<part name="flop3" interface="floppy_5_25">
+			<feature name="part_id" value="Disk 3"/>
+			<dataarea name="flop" size="1261568">
+				<rom name="dungeon hack (disk 3).hdm" size="1261568" crc="9b29eae4" sha1="610b39a9ca953d1e5bda06d3522ff7236c894e16" offset="0" />
+			</dataarea>
+		</part>
+		<part name="flop4" interface="floppy_5_25">
+			<feature name="part_id" value="Disk 4"/>
+			<dataarea name="flop" size="1261568">
+				<rom name="dungeon hack (disk 4).hdm" size="1261568" crc="ed7634ba" sha1="d5457d8ea124a0c6d3b8a20c08a0d321713e1b4a" offset="0" />
+			</dataarea>
+		</part>
+		<part name="flop5" interface="floppy_5_25">
+			<feature name="part_id" value="Disk 5"/>
+			<dataarea name="flop" size="1261568">
+				<rom name="dungeon hack (disk 5).hdm" size="1261568" crc="f646d5a2" sha1="d32c891be5e9676332282e0cb3f40c135a715384" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
 	<software name="dungharl">
 		<description>Dungeon Harlem</description>
 		<year>1991</year>
@@ -15961,7 +17138,8 @@ only have some part of Windows file and a Video driver(CLGD?).
 		</part>
 	</software>
 
-	<software name="dmaster">
+	<!-- Sound doesn't work, it just produces a constant beep -->
+	<software name="dmaster" supported="partial">
 		<description>Dungeon Master</description>
 		<year>1990</year>
 		<publisher>ビクター音楽産業 (Victor Musical Industries)</publisher>
@@ -15970,19 +17148,6 @@ only have some part of Windows file and a Video driver(CLGD?).
 		<part name="flop1" interface="floppy_5_25">
 			<dataarea name="flop" size="1261568">
 				<rom name="main.fdi" size="1261568" crc="4d4c1e78" sha1="2e36bbe621cfa76dddc0e9b2916ff7c512f31db6" offset="0" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="dmastera" cloneof="dmaster">
-		<description>Dungeon Master (Alt Format)</description>
-		<year>1990</year>
-		<publisher>ビクター音楽産業 (Victor Musical Industries)</publisher>
-		<info name="alt_title" value="ダンジョンマスター" />
-		<info name="release" value="19900209" />
-		<part name="flop1" interface="floppy_5_25">
-			<dataarea name="flop" size="1281968">
-				<rom name="dungeon master (ftl).d88" size="1281968" crc="5ef9226b" sha1="cd0730df8f501d03dc337a15a6619ba4405de216" offset="0" />
 			</dataarea>
 		</part>
 	</software>
@@ -16009,44 +17174,6 @@ only have some part of Windows file and a Video driver(CLGD?).
 			<feature name="part_id" value="Disk C - Data Disk"/>
 			<dataarea name="flop" size="1265664">
 				<rom name="dungeonmasteriipc-9801diskcdatadisk.fdi" size="1265664" crc="2160bbf9" sha1="10d574c9cbe1c0f84224bbda63b3a967b469ffa2" offset="0" />
-			</dataarea>
-		</part>
-		<part name="flop4" interface="floppy_5_25">
-			<feature name="part_id" value="Disk D - Save Disk"/>
-			<dataarea name="flop" size="1265664">
-				<rom name="dungeonmasteriipc-9801diskdsavedisk.fdi" size="1265664" crc="4e96e580" sha1="32bdefc23eb6388ab063cbb6b647476d6001bab0" offset="0" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="dmaster2a" cloneof="dmaster2">
-		<description>Dungeon Master II - Skullkeep (Alt Save Disk)</description>
-		<year>1993</year>
-		<publisher>ビクターエンタテインメント (Victor Entertainment)</publisher>
-		<info name="alt_title" value="ダンジョンマスター２ スカルキープ" />
-		<info name="release" value="19931223" />
-		<part name="flop1" interface="floppy_5_25">
-			<feature name="part_id" value="Disk A - System Disk"/>
-			<dataarea name="flop" size="1265664">
-				<rom name="dngmstr2_sys.fdi" size="1265664" crc="da88321b" sha1="6bca2e9a4ee849de755ecd43b0054f47deeadba6" offset="0" />
-			</dataarea>
-		</part>
-		<part name="flop2" interface="floppy_5_25">
-			<feature name="part_id" value="Disk B - Key Disk"/>
-			<dataarea name="flop" size="1265664">
-				<rom name="dngmstr2_key.fdi" size="1265664" crc="2bfb6d27" sha1="6ea0c802bddb9dc6db0bb1ce085c3cd3851eb090" offset="0" />
-			</dataarea>
-		</part>
-		<part name="flop3" interface="floppy_5_25">
-			<feature name="part_id" value="Disk C - Data Disk"/>
-			<dataarea name="flop" size="1265664">
-				<rom name="dngmstr2_data.fdi" size="1265664" crc="2160bbf9" sha1="10d574c9cbe1c0f84224bbda63b3a967b469ffa2" offset="0" />
-			</dataarea>
-		</part>
-		<part name="flop4" interface="floppy_5_25">
-			<feature name="part_id" value="Disk D - Save Disk"/>
-			<dataarea name="flop" size="1265664">
-				<rom name="dngmstr2_save.fdi" size="1265664" crc="b00bf825" sha1="06980efdc02e540b36248aa25afb95b4099ee2a7" offset="0" />
 			</dataarea>
 		</part>
 	</software>
@@ -29970,18 +31097,36 @@ Requires MS-DOS 5.00H plus an unknown procedure (HDD install?)
 		</part>
 	</software>
 
-<!-- Expansion of Pebble Beach no Hatou ?? -->
-	<software name="devilc">
+	<software name="3dgolfdc">
 		<description>New 3D Golf Simulation - Devil's Course</description>
 		<year>1992</year>
 		<publisher>ティーアンドイーソフト (T&amp;E Soft)</publisher>
 		<info name="alt_title" value="デビルズコース" />
 		<info name="release" value="19921120" />
-		<info name="usage" value="Requires &quot;NEW 3D Golf Simulation&quot; to work" />
+		<info name="usage" value="Requires an existing installation of the New 3D Golf Simulation V2.0 (3dgolfv2) system. Run INSTALL.COM from System Disk 1 to install this course disk" />
 		<part name="flop1" interface="floppy_5_25">
 			<feature name="part_id" value="Course Disk (Devil's Course)"/>
 			<dataarea name="flop" size="1281968">
 				<rom name="devil's course.d88" size="1281968" crc="9cbc4634" sha1="02007eecc7cc0cf4e60cc8a7efba60d870a0126c" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+	
+	<software name="3dgolfv2">
+		<!-- Origin: Neo Kobe Collection -->
+		<description>New 3D Golf Simulation Ver. 2.0</description>
+		<year>1992</year>
+		<publisher>ティーアンドイーソフト (T&amp;E Soft)</publisher>
+		<part name="flop1" interface="floppy_5_25">
+			<feature name="part_id" value="System Disk 1"/>
+			<dataarea name="flop" size="1261568">
+				<rom name="new 3d golf simulation (ver. 2.0) (system disk 1).hdm" size="1261568" crc="0dd11b22" sha1="6e73fa6f8adb571eb9ab97d63e50868a32b6d8a1" offset="0" />
+			</dataarea>
+		</part>
+		<part name="flop2" interface="floppy_5_25">
+			<feature name="part_id" value="System Disk 2"/>
+			<dataarea name="flop" size="1261568">
+				<rom name="new 3d golf simulation (ver. 2.0) (system disk 1).hdm" size="1261568" crc="61c74384" sha1="fdfdd616188e22bd041d6dbecc635a23cdab7694" offset="0" />
 			</dataarea>
 		</part>
 	</software>
@@ -31369,6 +32514,57 @@ Requires MS-DOS 5.00H plus an unknown procedure (HDD install?)
 			<feature name="part_id" value="Disk 2"/>
 			<dataarea name="flop" size="1265664">
 				<rom name="paradice (aion)(disk 2 of 2).fdi" size="1265664" crc="a852be5b" sha1="66b10cc3140a431da2ae31c60beb1c7ca02bd33c" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+	<software name="paracels">
+		<!-- Origin: Neo Kobe Collection -->
+		<description>Paracelsus no Maken</description>
+		<year>1994</year>
+		<publisher>ハミングバード (HummingBird)</publisher>
+		<info name="alt_title" value="パラケルススの魔剣" />
+		<info name="release" value="19941202" />
+		<part name="flop1" interface="floppy_5_25">
+			<feature name="part_id" value="System Disk"/>
+			<dataarea name="flop" size="1261568">
+				<rom name="das schwert des paracelsus (paracelsus no maken) (system disk).hdm" size="1261568" crc="f2d894de" sha1="b75f20710cb87904ade92fea10fe81130dace7b0" offset="0" />
+			</dataarea>
+		</part>
+		<part name="flop2" interface="floppy_5_25">
+			<feature name="part_id" value="Disk 1"/>
+			<dataarea name="flop" size="1261568">
+				<rom name="das schwert des paracelsus (paracelsus no maken) (disk 1).hdm" size="1261568" crc="ceef8441" sha1="a68de74aa6845bc241c52b7e889b47d80d29f93e" offset="0" />
+			</dataarea>
+		</part>
+		<part name="flop3" interface="floppy_5_25">
+			<feature name="part_id" value="Disk 2"/>
+			<dataarea name="flop" size="1261568">
+				<rom name="das schwert des paracelsus (paracelsus no maken) (disk 2).hdm" size="1261568" crc="a82ce6ed" sha1="16d5e7d7a7d28eb31e72ccecdd50025c56c374a2" offset="0" />
+			</dataarea>
+		</part>
+		<part name="flop4" interface="floppy_5_25">
+			<feature name="part_id" value="Disk 3"/>
+			<dataarea name="flop" size="1261568">
+				<rom name="das schwert des paracelsus (paracelsus no maken) (disk 3).hdm" size="1261568" crc="3c7dcf4a" sha1="726958a13f02351df5df9d3e14f6086ee958dc92" offset="0" />
+			</dataarea>
+		</part>
+		<part name="flop5" interface="floppy_5_25">
+			<feature name="part_id" value="Disk 4"/>
+			<dataarea name="flop" size="1261568">
+				<rom name="das schwert des paracelsus (paracelsus no maken) (disk 4).hdm" size="1261568" crc="68311e0f" sha1="037023fd0dfd9a04479cd5ee0d48bc49b94fdfce" offset="0" />
+			</dataarea>
+		</part>
+		<part name="flop6" interface="floppy_5_25">
+			<feature name="part_id" value="Disk 5"/>
+			<dataarea name="flop" size="1261568">
+				<rom name="das schwert des paracelsus (paracelsus no maken) (disk 5).hdm" size="1261568" crc="55db2a0a" sha1="417733d3cd0c894e3809ad3497438556c7f9d788" offset="0" />
+			</dataarea>
+		</part>
+		<part name="flop7" interface="floppy_5_25">
+			<feature name="part_id" value="Disk 6"/>
+			<dataarea name="flop" size="1261568">
+				<rom name="das schwert des paracelsus (paracelsus no maken) (disk 6).hdm" size="1261568" crc="343e7a05" sha1="aa9adaf300286f4ff1797ce04bdaafa85a140d52" offset="0" />
 			</dataarea>
 		</part>
 	</software>
@@ -46466,6 +47662,25 @@ Requires MS-DOS 5.00H plus an unknown procedure (HDD install?)
 		</part>
 	</software>
 
+	<software name="ztdc">
+		<!-- Origin: Neo Kobe Collection -->
+		<description>Z's Triphony - Digital Craft</description>
+		<year>1990</year>
+		<publisher>Zeit</publisher>
+		<part name="flop1" interface="floppy_5_25">
+			<feature name="part_id" value="System Disk"/>
+			<dataarea name="flop" size="1261568">
+				<rom name="digital craft (system disk).hdm" size="1261568" crc="45f15a0d" sha1="189bebabdd5ba83e36282ae44c71e1535988c1ed" offset="0" />
+			</dataarea>
+		</part>
+		<part name="flop2" interface="floppy_5_25">
+			<feature name="part_id" value="Utility Disk"/>
+			<dataarea name="flop" size="1261568">
+				<rom name="digital craft (utility disk).hdm" size="1261568" crc="005d4662" sha1="17b8e53db508c01b8ce55cd895b106e9cf69c35c" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
 	<software name="zaibatsu">
 		<description>Zaibatsu Ginkou - Teito Yabou Hen</description>
 		<year>1992</year>
@@ -47663,7 +48878,6 @@ Requires MS-DOS 5.00H plus an unknown procedure (HDD install?)
 				<rom name="crw2_3.nfd" size="1329680" crc="c358b6f7" sha1="9be92868d254878c656c5db6d17b84c0849ed597" offset="0" />
 			</dataarea>
 		</part>
-
 	</software>
 
 	<!-- The installer hangs on disk change most of the time -->
@@ -47839,7 +49053,7 @@ Requires MS-DOS 5.00H plus an unknown procedure (HDD install?)
 		</part>
 	</software>
 
-	<software name="dpssg2" supported="no">
+	<software name="dpssg2">
 		<description>D.P.S. SG 2 - Dream Program System SG Set 2</description>
 		<year>1991</year>
 		<publisher>アリスソフト (Alicesoft)</publisher>
@@ -47871,34 +49085,35 @@ Requires MS-DOS 5.00H plus an unknown procedure (HDD install?)
 		</part>
 	</software>
 
-	<software name="daikaire" supported="no">
+	<!-- The "Honjou Bouei Sakusen" map disk doesn't seem to work in any emulators. Probably a bad dump. -->
+	<software name="daikaire" supported="partial">
 		<description>Daikairei - Dainippon Teikoku Kaigun no Kiseki</description>
 		<year>1988</year>
 		<publisher>アートディンク (Artdink)</publisher>
 		<info name="alt_title" value="大海令 大日本帝国海軍の軌跡" />
 		<info name="release" value="19881208" />
 		<part name="flop1" interface="floppy_5_25">
-			<feature name="part_id" value="System"/>
+			<feature name="part_id" value="System Disk"/>
 			<dataarea name="flop" size="1261568">
 				<rom name="daikairei - dainippon teikoku kaigun no kiseki_sys.hdm" size="1261568" crc="e829c4ba" sha1="3ca892d94307fcf22b3f80c1ba8560158c8378d9" offset="0" />
 			</dataarea>
 		</part>
 		<part name="flop2" interface="floppy_5_25">
-			<feature name="part_id" value="Hon?"/>
+			<feature name="part_id" value="Title Disk"/>
 			<dataarea name="flop" size="1261568">
-				<rom name="daikairei - dainippon teikoku kaigun no kiseki_hon.hdm" size="1261568" crc="dc36dda8" sha1="dea2b414fe7e1c0f9d3d2106d69dbc180e537b4a" offset="0" />
+				<rom name="daikairei - dainippon teikoku kaigun no kiseki_tit.hdm" size="1261568" crc="dacd6791" sha1="1e12656c672dbd198984e8ba70071aaaf61b592d" offset="0" />
 			</dataarea>
 		</part>
 		<part name="flop3" interface="floppy_5_25">
-			<feature name="part_id" value="Par?"/>
+			<feature name="part_id" value="Map Disk: Shinju-wan Kougeki Sakusen"/>
 			<dataarea name="flop" size="1261568">
 				<rom name="daikairei - dainippon teikoku kaigun no kiseki_par.hdm" size="1261568" crc="9bfaf70d" sha1="59ae9dde2b839c69d0657afad2c7b98b36c98df7" offset="0" />
 			</dataarea>
 		</part>
 		<part name="flop4" interface="floppy_5_25">
-			<feature name="part_id" value="Tit?"/>
+			<feature name="part_id" value="Map Disk: Honjou Bouei Sakusen"/>
 			<dataarea name="flop" size="1261568">
-				<rom name="daikairei - dainippon teikoku kaigun no kiseki_tit.hdm" size="1261568" crc="dacd6791" sha1="1e12656c672dbd198984e8ba70071aaaf61b592d" offset="0" />
+				<rom name="daikairei - dainippon teikoku kaigun no kiseki_hon.hdm" size="1261568" crc="dc36dda8" sha1="dea2b414fe7e1c0f9d3d2106d69dbc180e537b4a" offset="0" status="baddump" />
 			</dataarea>
 		</part>
 	</software>
@@ -47924,6 +49139,7 @@ Requires MS-DOS 5.00H plus an unknown procedure (HDD install?)
 		</part>
 	</software>
 
+	<!-- Black screen on boot -->
 	<software name="daisenr3a" cloneof="daisenr3" supported="no">
 		<description>Daisenryaku III - Great Commander (Alt Format)</description>
 		<year>1989</year>
@@ -48008,6 +49224,7 @@ Requires MS-DOS 5.00H plus an unknown procedure (HDD install?)
 		</part>
 	</software>
 
+	<!-- Hangs at the main menu -->
 	<software name="deep" supported="no">
 		<description>Deep</description>
 		<year>1994</year>
@@ -48064,38 +49281,39 @@ Requires MS-DOS 5.00H plus an unknown procedure (HDD install?)
 		</part>
 	</software>
 
-	<software name="diamondp" supported="no">
+	<software name="diamondp">
 		<description>Diamond Players</description>
 		<year>1992</year>
 		<publisher>日本テレネット (Nihon Telenet)</publisher>
 		<info name="alt_title" value="ダイヤモンドプレイヤーズ" />
 		<info name="release" value="19920725" />
 		<part name="flop1" interface="floppy_5_25">
-			<feature name="part_id" value="System"/>
+			<feature name="part_id" value="System Disk"/>
 			<dataarea name="flop" size="1329680">
 				<rom name="sy.nfd" size="1329680" crc="774371b7" sha1="35d32a5397ef2d7efb8e7598d3a313649cc43760" offset="0" />
 			</dataarea>
 		</part>
 		<part name="flop2" interface="floppy_5_25">
-			<feature name="part_id" value="Data"/>
+			<feature name="part_id" value="Data Disk"/>
 			<dataarea name="flop" size="1329680">
 				<rom name="da.nfd" size="1329680" crc="70f2ebee" sha1="883f522c9e9a4d4f45ae7b7ad95da9f825aa1cb2" offset="0" />
 			</dataarea>
 		</part>
 		<part name="flop3" interface="floppy_5_25">
-			<feature name="part_id" value="Shina?"/>
+			<feature name="part_id" value="Scenario Disk"/>
 			<dataarea name="flop" size="1329680">
 				<rom name="shina.nfd" size="1329680" crc="43863767" sha1="0f86cc55d457618fad95f56eee6fa995fc1df78e" offset="0" />
 			</dataarea>
 		</part>
 	</software>
 
-	<software name="ds98_03" supported="no">
+	<software name="ds98_03">
 		<description>Disc Station 98 #03</description>
 		<year>1991</year>
 		<publisher>コンパイル (Compile)</publisher>
 		<info name="alt_title" value="ディスクステーション９８＃０３" />
 		<info name="release" value="19910419" />
+		<info name="usage" value="Boot from disk 4 for the main menu. The other disks are game demos." />
 		<part name="flop1" interface="floppy_5_25">
 			<feature name="part_id" value="Disk 1"/>
 			<dataarea name="flop" size="1329680">
@@ -48128,6 +49346,7 @@ Requires MS-DOS 5.00H plus an unknown procedure (HDD install?)
 		<publisher>コンパイル (Compile)</publisher>
 		<info name="alt_title" value="ディスクステーション９８＃０５" />
 		<info name="release" value="19910820" />
+		<info name="usage" value="Boot from disk 4 for the main menu. The other disks are game demos." />
 		<part name="flop1" interface="floppy_5_25">
 			<feature name="part_id" value="Disk 1"/>
 			<dataarea name="flop" size="1329680">
@@ -48154,7 +49373,7 @@ Requires MS-DOS 5.00H plus an unknown procedure (HDD install?)
 		</part>
 	</software>
 
-	<software name="ds98_11a" cloneof="ds98_11" supported="no">
+	<software name="ds98_11a" cloneof="ds98_11">
 		<description>Disc Station 98 #11 (Alt Format)</description>
 		<year>1992</year>
 		<publisher>コンパイル (Compile)</publisher>
@@ -48180,7 +49399,8 @@ Requires MS-DOS 5.00H plus an unknown procedure (HDD install?)
 		</part>
 	</software>
 
-	<software name="dna" supported="no">
+	<!-- Seems to work only on 286-based machines (e.g. PC-9801UX) -->
+	<software name="dna" supported="partial">
 		<description>DNA</description>
 		<year>1987</year>
 		<publisher>グレイ (Gray)</publisher>
@@ -48193,7 +49413,7 @@ Requires MS-DOS 5.00H plus an unknown procedure (HDD install?)
 		</part>
 	</software>
 
-	<software name="dprinces" supported="no">
+	<software name="dprinces">
 		<description>Dragon Princess - Ryuu no Densetsu</description>
 		<year>1992</year>
 		<publisher>ハートソフト (Heart Soft)</publisher>
@@ -48201,63 +49421,37 @@ Requires MS-DOS 5.00H plus an unknown procedure (HDD install?)
 		<info name="release" value="19920424" />
 		<part name="flop1" interface="floppy_5_25">
 			<feature name="part_id" value="Disk 1"/>
-			<dataarea name="flop" size="1089808">
-				<rom name="drpr_1.nfd" size="1089808" crc="eaf4b899" sha1="85f9585eec0ea0482134fb0e35128ff3da6d6ae6" offset="0" />
+			<dataarea name="flop" size="1086448">
+				<rom name="drpr_1.d88" size="1086448" crc="af474408" sha1="e248bba0b3465c943f4e7b2e447dcdea654b959b" offset="0" />
 			</dataarea>
 		</part>
 		<part name="flop2" interface="floppy_5_25">
 			<feature name="part_id" value="Disk 2"/>
-			<dataarea name="flop" size="1089808">
-				<rom name="drpr_2.nfd" size="1089808" crc="2b1f69d6" sha1="e1f3df2b502a1560645b65465b32ee736b0f973b" offset="0" />
+			<dataarea name="flop" size="1086448">
+				<rom name="drpr_2.d88" size="1086448" crc="be83e7a2" sha1="f12a0c7fbaf0d5bad05756cb7ca06add5e3ac9a3" offset="0" />
 			</dataarea>
 		</part>
 		<part name="flop3" interface="floppy_5_25">
 			<feature name="part_id" value="Disk 3"/>
-			<dataarea name="flop" size="1089808">
-				<rom name="drpr_3.nfd" size="1089808" crc="ef8303e2" sha1="721c088e80546168e61556d2500380fb5dcbf57b" offset="0" />
+			<dataarea name="flop" size="1086448">
+				<rom name="drpr_3.d88" size="1086448" crc="415289b3" sha1="74b40fe728bd66f05e12fd6077647d6b59bc6a5c" offset="0" />
 			</dataarea>
 		</part>
 		<part name="flop4" interface="floppy_5_25">
 			<feature name="part_id" value="Disk 4"/>
-			<dataarea name="flop" size="1089808">
-				<rom name="drpr_4.nfd" size="1089808" crc="f94c1d94" sha1="026400de3a310b3d464a395e07cc770dec7aa8ac" offset="0" />
+			<dataarea name="flop" size="1086448">
+				<rom name="drpr_4.d88" size="1086448" crc="6501860d" sha1="020d3e6bacb0e1b40bf4789fb889de2139be158f" offset="0" />
 			</dataarea>
 		</part>
 	</software>
 
-	<software name="dslayeda" cloneof="dslayed" supported="no">
-		<description>Dragon Slayer - The Legend of Heroes - Eiyuu Densetsu (Alt Format)</description>
-		<year>1990</year>
-		<publisher>日本ファルコム (Nihon Falcom)</publisher>
-		<info name="alt_title" value="ドラゴンスレイヤー英雄伝説" />
-		<info name="release" value="19900420" />
-		<part name="flop1" interface="floppy_5_25">
-			<feature name="part_id" value="Program Disk"/>
-			<dataarea name="flop" size="1329680">
-				<rom name="program.nfd" size="1329680" crc="3bf6af67" sha1="e4eb8c10a7a9a455912135d3c09bf753498ddf83" offset="0" />
-			</dataarea>
-		</part>
-		<part name="flop2" interface="floppy_5_25">
-			<feature name="part_id" value="Event Disk"/>
-			<dataarea name="flop" size="1329680">
-				<rom name="event.nfd" size="1329680" crc="c9319157" sha1="2daeff81931661af78006dee5298830e7d7fee3a" offset="0" />
-			</dataarea>
-		</part>
-		<part name="flop3" interface="floppy_5_25">
-			<feature name="part_id" value="Scenario Disk"/>
-			<dataarea name="flop" size="1329680">
-				<rom name="scenario.nfd" size="1329680" crc="da0147bf" sha1="271814d6bbed5a04d8e7c571e2eacd84a8cbed74" offset="0" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="dungbust" supported="no">
+	<software name="dungbust">
 		<description>Dungeon Buster</description>
 		<year>1990</year>
 		<publisher>グレイト (Great)</publisher>
 		<info name="alt_title" value="ダンジョンバスター" />
 		<part name="flop1" interface="floppy_5_25">
-			<feature name="part_id" value="System?"/>
+			<feature name="part_id" value="System Disk"/>
 			<dataarea name="flop" size="1107984">
 				<rom name="dbusters.nfd" size="1107984" crc="e45daf56" sha1="e31f43a4aa2742b6909dfdda6921fca17235a9b4" offset="0" />
 			</dataarea>
@@ -54525,7 +55719,7 @@ SPACE EMPIRE
 	</software>
 
 	<software name="clonedol">
-		<description>Clone Doll - Kagai Juugyou</description>
+		<description>Clone Doll - Kagai Jugyou</description>
 		<year>1995</year>
 		<publisher>スペースプロジェクト (Space Project)</publisher>
 		<info name="alt_title" value="クローンドール 課外授業" />
@@ -54817,7 +56011,7 @@ SPACE EMPIRE
 		</part>
 	</software>
 
-	<software name="dalk" supported="no">
+	<software name="dalk">
 		<description>Dalk</description>
 		<year>1992</year>
 		<publisher>アリスソフト (AliceSoft)</publisher>
@@ -54860,12 +56054,13 @@ SPACE EMPIRE
 		</part>
 	</software>
 
-	<software name="darakuni" supported="no">
+	<software name="angie">
 		<description>Daraku no Kuni no Angie - Kyoukai no Mesu Dorei-tachi</description>
 		<year>1996</year>
 		<publisher>PIL</publisher>
 		<info name="alt_title" value="堕落の国のアンジー ～狂界の牝奴隷達～" />
 		<info name="release" value="19960419" />
+		<info name="usage" value="Run HDX.BAT from DOS to install to HDD" />
 		<part name="flop1" interface="floppy_5_25">
 			<feature name="part_id" value="Disk A"/>
 			<dataarea name="flop" size="1301500">
@@ -54916,6 +56111,7 @@ SPACE EMPIRE
 		</part>
 	</software>
 
+	<!-- Disk changes don't work -->
 	<software name="deja2" supported="no">
 		<description>De・Ja 2</description>
 		<year>1992</year>
@@ -54984,7 +56180,8 @@ SPACE EMPIRE
 		</part>
 	</software>
 
-	<software name="denurse" supported="no">
+	<!-- Seems to work only on 286-based machines (e.g. PC-9801UX) -->
+	<software name="denurse" supported="partial">
 		<description>Dengeki Nurse</description>
 		<year>1992</year>
 		<publisher>カクテル・ソフト (Cocktail Soft)</publisher>
@@ -55022,8 +56219,8 @@ SPACE EMPIRE
 		</part>
 	</software>
 
-	<software name="dennoga3" supported="no">
-		<description>Dennou Gakuen 3 - Cybernetic Hi-School III - Top wo Nerae!</description>
+	<software name="dennoga3">
+		<description>Cybernetic Hi-School / Dennou Gakuen III - Top wo Nerae!</description>
 		<year>1990</year>
 		<publisher>ガイナックス (Gainax)</publisher>
 		<info name="alt_title" value="電脳学園３ トップをねらえ！" />
@@ -55054,7 +56251,7 @@ SPACE EMPIRE
 		</part>
 	</software>
 
-	<software name="dokivact" supported="no">
+	<software name="dokivact">
 		<description>Doki Doki Vacation - Kirameku Kisetsu no Naka de</description>
 		<year>1995</year>
 		<publisher>カクテル・ソフト (Cocktail Soft)</publisher>
@@ -55110,33 +56307,35 @@ SPACE EMPIRE
 		</part>
 	</software>
 
+	<!-- Hangs at the Peach Soft logo -->
 	<software name="doppyun" supported="no">
 		<description>Doppyun Donpisha</description>
 		<year>1993</year>
 		<publisher>ピーチソフト (Peach Soft)</publisher>
 		<info name="alt_title" value="ドッぴゅんドンぴ写" />
 		<info name="release" value="19931217" />
+		<info name="usage" value="Run SYSCOPY.BAT to copy system files to Disk A, or INSTALL.BAT to install to HDD." />
 		<part name="flop1" interface="floppy_5_25">
-			<feature name="part_id" value="Disk 1"/>
+			<feature name="part_id" value="Disk A"/>
 			<dataarea name="flop" size="1108988">
 				<rom name="doppyundonpishya (1993)(peach)(disk 1 of 3)[req install].fdd" size="1108988" crc="e8a18940" sha1="3094bbe0078ff5217af099586512d303c6b3fd70" offset="0" />
 			</dataarea>
 		</part>
 		<part name="flop2" interface="floppy_5_25">
-			<feature name="part_id" value="Disk 2"/>
+			<feature name="part_id" value="Disk B"/>
 			<dataarea name="flop" size="1291260">
 				<rom name="doppyundonpishya (1993)(peach)(disk 2 of 3)[req install].fdd" size="1291260" crc="d490bfc1" sha1="a512ac1b39f661b73cbf67814f463233b31508a5" offset="0" />
 			</dataarea>
 		</part>
 		<part name="flop3" interface="floppy_5_25">
-			<feature name="part_id" value="Disk 3"/>
+			<feature name="part_id" value="Disk C"/>
 			<dataarea name="flop" size="1249276">
 				<rom name="doppyundonpishya (1993)(peach)(disk 3 of 3)[req install].fdd" size="1249276" crc="6c37e875" sha1="84f0ee08aa196abf6434459fb059b19afa0f2f76" offset="0" />
 			</dataarea>
 		</part>
 	</software>
 
-	<software name="dor1" supported="no">
+	<software name="dor1">
 		<description>DOR</description>
 		<year>1992</year>
 		<publisher>ディー・オー (D.O.)</publisher>
@@ -55168,7 +56367,7 @@ SPACE EMPIRE
 		</part>
 	</software>
 
-	<software name="dor2" supported="no">
+	<software name="dor2">
 		<description>DOR Part 2</description>
 		<year>1992</year>
 		<publisher>ディー・オー (D.O.)</publisher>
@@ -55200,7 +56399,7 @@ SPACE EMPIRE
 		</part>
 	</software>
 
-	<software name="dor3" supported="no">
+	<software name="dor3">
 		<description>DOR Part 3</description>
 		<year>1992</year>
 		<publisher>ディー・オー (D.O.)</publisher>
@@ -55232,6 +56431,7 @@ SPACE EMPIRE
 		</part>
 	</software>
 
+	<!-- Doesn't recognize disk changes -->
 	<software name="dokyusei" supported="no">
 		<description>Doukyuusei</description>
 		<year>1992</year>
@@ -55294,7 +56494,7 @@ SPACE EMPIRE
 		</part>
 	</software>
 
-	<software name="dknight4" supported="no">
+	<software name="dknight4">
 		<description>Dragon Knight 4</description>
 		<year>1994</year>
 		<publisher>エルフ (Elf)</publisher>
@@ -55374,58 +56574,53 @@ SPACE EMPIRE
 		</part>
 	</software>
 
-	<software name="dslayed4" supported="no">
-		<description>Dragon Slayer - The Legend of Heroes IV - Eiyuu Densetsu IV - Akai Shizuku</description>
+	<software name="loh4">
+		<description>The Legend of Heroes IV - Eiyuu Densetsu IV - Akai Shizuku</description>
 		<year>1996</year>
 		<publisher>日本ファルコム (Nihon Falcom)</publisher>
-		<info name="alt_title" value="ドラゴンスレイヤー英雄伝説４ 朱紅い雫" />
+		<info name="alt_title" value="英雄伝説４ 朱紅い雫" />
 		<info name="release" value="19960524" />
+		<info name="usage" value="Create a user disk with the ユーザーディスクを作成する option, then boot from it" />
 		<part name="flop1" interface="floppy_5_25">
-			<feature name="part_id" value="Program"/>
-			<dataarea name="flop" size="1264636">
+			<feature name="part_id" value="Program Disk"/>
+			<dataarea name="flop" size="1264636"> 
 				<rom name="dragonslayer eiyu densetsu 4 (1996)(falcom)(disk 1 of 8)(program disk).fdd" size="1264636" crc="46b6761c" sha1="d58d43647d6f9b4c6fa61d67ed6a25c3f9dfa5a4" offset="0" />
 			</dataarea>
 		</part>
 		<part name="flop2" interface="floppy_5_25">
-			<feature name="part_id" value="Data Disc 1"/>
+			<feature name="part_id" value="Data Disk 1"/>
 			<dataarea name="flop" size="1207292">
 				<rom name="dragonslayer eiyu densetsu 4 (1996)(falcom)(disk 2 of 8)(data disc 1).fdd" size="1207292" crc="a4357b08" sha1="f92a6078be61314461f6e9891d6483ea76e58b3b" offset="0" />
 			</dataarea>
 		</part>
 		<part name="flop3" interface="floppy_5_25">
-			<feature name="part_id" value="Data Disc 2"/>
+			<feature name="part_id" value="Data Disk 2"/>
 			<dataarea name="flop" size="1217532">
 				<rom name="dragonslayer eiyu densetsu 4 (1996)(falcom)(disk 3 of 8)(data disc 2).fdd" size="1217532" crc="eb4f6e8c" sha1="1d8ed7e0c97adeac4bcd923d3b667764ff9b3825" offset="0" />
 			</dataarea>
 		</part>
 		<part name="flop4" interface="floppy_5_25">
-			<feature name="part_id" value="Data Disc 3"/>
+			<feature name="part_id" value="Data Disk 3"/>
 			<dataarea name="flop" size="1259516">
 				<rom name="dragonslayer eiyu densetsu 4 (1996)(falcom)(disk 4 of 8)(data disc 3).fdd" size="1259516" crc="1d570e9c" sha1="a1b9c93731a65879a291a8f2a1ca3437c13199d7" offset="0" />
 			</dataarea>
 		</part>
 		<part name="flop5" interface="floppy_5_25">
-			<feature name="part_id" value="Data Disc 4"/>
+			<feature name="part_id" value="Data Disk 4"/>
 			<dataarea name="flop" size="1127420">
 				<rom name="dragonslayer eiyu densetsu 4 (1996)(falcom)(disk 5 of 8)(data disc 4).fdd" size="1127420" crc="32b75fe5" sha1="d127ebf2ca24639380111436b9250594351ca305" offset="0" />
 			</dataarea>
 		</part>
 		<part name="flop6" interface="floppy_5_25">
-			<feature name="part_id" value="Data Disc 5"/>
+			<feature name="part_id" value="Data Disk 5"/>
 			<dataarea name="flop" size="1164284">
 				<rom name="dragonslayer eiyu densetsu 4 (1996)(falcom)(disk 6 of 8)(data disc 5).fdd" size="1164284" crc="121097cc" sha1="cd1705203222b80f223e151ab0baae0b4538cc0e" offset="0" />
 			</dataarea>
 		</part>
 		<part name="flop7" interface="floppy_5_25">
-			<feature name="part_id" value="Data Disc 6"/>
+			<feature name="part_id" value="Data Disk 6"/>
 			<dataarea name="flop" size="1153020">
 				<rom name="dragonslayer eiyu densetsu 4 (1996)(falcom)(disk 7 of 8)(data disc 6).fdd" size="1153020" crc="94b3feb4" sha1="c7a432ffcc0d168cd89e09090dc090846aa83fda" offset="0" />
-			</dataarea>
-		</part>
-		<part name="flop8" interface="floppy_5_25">
-			<feature name="part_id" value="User"/>
-			<dataarea name="flop" size="1264636">
-				<rom name="dragonslayer eiyu densetsu 4 (1996)(falcom)(disk 8 of 8)(user disk).fdd" size="1264636" crc="19f02cac" sha1="23a10b99f2ba65c72b4440ebf03a6bbebfe9e81e" offset="0" status="baddump" />
 			</dataarea>
 		</part>
 	</software>
@@ -61009,12 +62204,13 @@ SPACE EMPIRE
 		</part>
 	</software>
 
-	<software name="dreamy" supported="no">
+	<software name="dreamy">
 		<description>Yume Utsutsu - Dreamy</description>
 		<year>1994</year>
 		<publisher>megami</publisher>
 		<info name="alt_title" value="夢現 Ｄｒｅａｍｙ －ゆめうつつ－" />
 		<info name="release" value="19940709" />
+		<info name="usage" value="Run SYSINST.COM to copy system files, or HDINST.BAT to install to HDD" />
 		<part name="flop1" interface="floppy_5_25">
 			<feature name="part_id" value="System Disk"/>
 			<dataarea name="flop" size="1179644">
@@ -62097,11 +63293,12 @@ SPACE EMPIRE
  -->
 
 
-	<software name="doujins1" supported="no">
+	<software name="doujins1">
 		<description>Doujin Soft Shuusaku Game Collection Vol. 1 (5.25&quot; Disks)</description>
 		<year>19??</year>
 		<publisher>Shuwa System Trading</publisher>
 		<info name="alt_title" value="同人ソフト秀作ゲームコレクションＶｏｌ１" />
+		<info name="usage" value="Run INST.EXE from DOS" />
 		<part name="flop1" interface="floppy_5_25">
 			<dataarea name="flop" size="1261568">
 				<rom name="excellent1.hdm" size="1261568" crc="14c373d5" sha1="3d14424849c87dea389f39e22a1409e61a426bf2" offset="0" />
@@ -62176,6 +63373,7 @@ SPACE EMPIRE
 		<year>19??</year>
 		<publisher>Shuwa System Trading</publisher>
 		<info name="alt_title" value="同人ソフト秀作ゲームコレクションＶｏｌ２" />
+		<info name="usage" value="Run INST.EXE from DOS" />
 		<part name="flop1" interface="floppy_5_25">
 			<dataarea name="flop" size="1265664">
 				<rom name="diksk_1.fdi" size="1265664" crc="ca511d15" sha1="5390cc7ac793c7460cc79396ecc2f7a760ed9018" offset="0" />
@@ -62203,6 +63401,7 @@ SPACE EMPIRE
 		<year>19??</year>
 		<publisher>Shuwa System Trading</publisher>
 		<info name="alt_title" value="同人ソフト秀作ゲームコレクション 特別編" />
+		<info name="usage" value="Run INST.BAT from DOS" />
 		<part name="flop1" interface="floppy_5_25">
 			<dataarea name="flop" size="1265664">
 				<rom name="diksk_1.fdi" size="1265664" crc="34c3424d" sha1="3af6451d4c728867077a070b912ab0afff4410b7" offset="0" />
@@ -62794,6 +63993,7 @@ SPACE EMPIRE
 		</part>
 	</software>
 
+	<!-- MAME fails to mount the image with "Fatal error: Incorrect layout on track 0 head 0, expected_size=166666, current_size=167648" error -->
 	<software name="dynamo" supported="no">
 		<description>Dynamo</description>
 		<year>1991</year>
@@ -63182,7 +64382,8 @@ SPACE EMPIRE
 		</part>
 	</software>
 
-	<software name="dynamite">
+	<!-- This game is supposed to play sound effects through the beeper, but in MAME it just outputs a constant beep -->
+	<software name="dynamite" supported="partial">
 		<description>Dynamite Girl</description>
 		<year>19??</year>
 		<publisher>&lt;unofficial&gt;</publisher>
@@ -64150,6 +65351,7 @@ doujin?!?
 		<year>19??</year>
 		<publisher>&lt;doujin&gt;</publisher>
 		<info name="author" value="Circle D-Tens" />
+		<info name="usage" value="Run 98.BAT from DOS" />
 		<part name="flop1" interface="floppy_5_25">
 			<dataarea name="flop" size="1265664">
 				<rom name="d-ten_cg_library_vol5.fdi" size="1265664" crc="74d9854d" sha1="6e210fbe6c1063f21ed46f1ea7932985e4960efc" offset="0" />
@@ -64170,6 +65372,7 @@ doujin?!?
 		</part>
 	</software>
 
+	<!-- This probably requires 3.5" floppy emulation -->
 	<software name="daihinm">
 		<description>Dai Hinmin - Taiketsu Seifuku Musume</description>
 		<year>19??</year>
@@ -64184,8 +65387,8 @@ doujin?!?
 	</software>
 
 	<software name="daifugog">
-		<description>Daifugo Gakuen</description>
-		<year>19??</year>
+		<description>Daifuugou Gakuen</description>
+		<year>1993</year>
 		<publisher>&lt;doujin&gt;</publisher>
 		<info name="author" value="Joshoku Soft" />
 		<info name="alt_title" value="大富豪学園" />
@@ -64196,11 +65399,12 @@ doujin?!?
 		</part>
 	</software>
 
-	<software name="dv2994" supported="no">
+	<software name="dv2994">
 		<description>Deja Vu~2994.</description>
 		<year>1994</year>
 		<publisher>&lt;doujin&gt;</publisher>
 		<info name="author" value="Circle UNYou." />
+		<info name="usage" value="Run 98.BAT from DOS" />
 		<part name="flop1" interface="floppy_5_25">
 			<dataarea name="flop" size="1261568">
 				<rom name="deja_vu_2994.hdm" size="1261568" crc="52b29c34" sha1="f33c7d989d1d29ea080471e3679fc253c74c8429" offset="0" />
@@ -64208,10 +65412,11 @@ doujin?!?
 		</part>
 	</software>
 
-	<software name="denza" supported="no">
+	<software name="denza">
 		<description>Denza</description>
 		<year>19??</year>
 		<publisher>&lt;doujin&gt;</publisher>
+		<info name="usage" value="Run VIEW.EXE from DOS" />
 		<part name="flop1" interface="floppy_5_25">
 			<dataarea name="flop" size="1261568">
 				<rom name="denza.hdm" size="1261568" crc="4a4cc654" sha1="92b9322a2a523cbbc8b38cafc29849351c1ca6d8" offset="0" />
@@ -64231,7 +65436,8 @@ doujin?!?
 		</part>
 	</software>
 
-	<software name="destructa" cloneof="destruct">
+	<!-- MAME fails to mount the disk: "Incorrect layout on track 0 head 0, expected_size=166666, current_size=167648" -->
+	<software name="destructa" cloneof="destruct" supported="no">
 		<description>Destructor (Alt)</description>
 		<year>19??</year>
 		<publisher>&lt;doujin&gt;</publisher>
@@ -64243,7 +65449,7 @@ doujin?!?
 		</part>
 	</software>
 
-	<software name="devilchn" supported="no">
+	<software name="devilchn">
 		<description>Devil Chain 98</description>
 		<year>19??</year>
 		<publisher>&lt;doujin&gt;</publisher>
@@ -64288,11 +65494,12 @@ doujin?!?
 		</part>
 	</software>
 
-	<software name="doridq7" supported="no">
+	<software name="doridq7">
 		<description>Dori Dor Qizu 7 (Bad Sectors)</description>
 		<year>19??</year>
 		<publisher>&lt;doujin&gt;</publisher>
 		<info name="author" value="Daikokuya Dennou" />
+		<info name="usage" value="Run GAME.BAT from DOS" />
 		<part name="flop1" interface="floppy_5_25">
 			<dataarea name="flop" size="1261568">
 				<rom name="dori_dor_qizu_(dori_dor_7)(bad_sectors).hdm" size="1261568" crc="482b6135" sha1="c68a3a2d7f3e72a68c0196bb85612b1e3624a45f" offset="0" status="baddump" />
@@ -64300,11 +65507,12 @@ doujin?!?
 		</part>
 	</software>
 
-	<software name="doridq8" supported="no">
+	<software name="doridq8">
 		<description>Dori Dor Qizu 8</description>
 		<year>19??</year>
 		<publisher>&lt;doujin&gt;</publisher>
 		<info name="author" value="Daikokuya Dennou" />
+		<info name="usage" value="Run GAME.BAT from DOS" />
 		<part name="flop1" interface="floppy_5_25">
 			<dataarea name="flop" size="1261568">
 				<rom name="dori_dor_qizu_(dori_dor_8).hdm" size="1261568" crc="1acfd8e8" sha1="fd0bb26786b829add89fd3fe709fd5acc25de613" offset="0" />
@@ -64312,6 +65520,7 @@ doujin?!?
 		</part>
 	</software>
 
+	<!-- This probably requires 3.5" floppy emulation -->
 	<software name="dragnegg">
 		<description>Dragon Egg</description>
 		<year>19??</year>
@@ -64329,6 +65538,7 @@ doujin?!?
 		<year>1995</year>
 		<publisher>&lt;doujin&gt;</publisher>
 		<info name="author" value="T&amp;H Projects" />
+		<info name="usage" value="Run DZ.BAT from DOS" />
 		<part name="flop1" interface="floppy_5_25">
 			<dataarea name="flop" size="1265664">
 				<rom name="dgogoz.fdi" size="1265664" crc="6b38b4fe" sha1="47c6bcee6a7cd8dee0344eefa3c49f387d07ac5f" offset="0" />
@@ -64551,6 +65761,7 @@ doujin?!?
 		<year>19??</year>
 		<publisher>&lt;doujin&gt;</publisher>
 		<info name="alt_title" value="行け行け電大バス" />
+		<info name="usage" value="Run DDB.BAT from DOS" />
 		<part name="flop1" interface="floppy_5_25">
 			<dataarea name="flop" size="1265664">
 				<rom name="bus.fdi" size="1265664" crc="8e6f20b0" sha1="50ab28fa3d05325c52ace23eaf22a2367bb639dd" offset="0" />
@@ -64563,6 +65774,7 @@ doujin?!?
 		<year>19??</year>
 		<publisher>&lt;doujin&gt;</publisher>
 		<info name="alt_title" value="行け行け電大バス" />
+		<info name="usage" value="Run DDB.BAT from DOS" />
 		<part name="flop1" interface="floppy_5_25">
 			<dataarea name="flop" size="1265664">
 				<rom name="go_go_electric_bus.fdi" size="1265664" crc="e81855ab" sha1="d85606941d5bcbf431689471b2250e09384c4dfd" offset="0" />
@@ -66726,8 +67938,9 @@ Same as Police Quest 2 - Quest for Glory stand-alone disks
 		</part>
 	</software>
 
-	<software name="datsumj">
-		<description>Datsui Mahjong Margarita (?)</description>
+	<!-- Black screen on boot -->
+	<software name="datsumj" supported="no">
+		<description>Datsui Mahjong Margarita</description>
 		<year>19??</year>
 		<publisher>&lt;doujin&gt;</publisher>
 		<info name="alt_title" value="脱衣麻雀マルガリータ" />

--- a/hash/pc98_cd.xml
+++ b/hash/pc98_cd.xml
@@ -1285,10 +1285,10 @@
 		<rom name="Delicious Lunch Pack (1996)(ScooP).bin" size="9056256" crc="b7edf982" sha1="c7a3e3ae987f2ef4eed96fb41d1b3fc916bfdff7"/>
 		<rom name="Delicious Lunch Pack (1996)(ScooP).cue" size="100" crc="9e5b4353" sha1="5cb7bec576e601dd974c9ad916c2fa4ff69c3dba"/>
 		-->
-		<description>Delicious - Lunch Pack</description>
+		<description>Delicious Lunch Pack</description>
 		<year>1996</year>
-		<publisher>ScooP</publisher>
-		<info name="alt_title" value="デリシャスらんちぱっく" />
+		<publisher>スクープ (Scoop)</publisher>
+		<info name="alt_title" value="デリシャス らんちぱっく" />
 		<part name="cdrom" interface="cdrom">
 			<diskarea name="cdrom">
 				<disk name="delicious lunch pack (1996)(scoop)" sha1="529d1b311de74d39c7be2e7fa27f2ba1bab24156" />
@@ -1566,6 +1566,7 @@
 		</part>
 	</software>
 
+	<!-- Disk P is included with the game, and contains a patch for a minor bug where the last line of the message after level 11 is drawn off-screen -->
 	<software name="doom2">
 		<!--
 		Origin: redump.org
@@ -1576,6 +1577,12 @@
 		<year>1995</year>
 		<publisher>イマジニア (Imagineer)</publisher>
 		<info name="release" value="19950929" />
+		<part name="flop1" interface="floppy_5_25">
+			<feature name="part_id" value="Disk P"/>
+			<dataarea name="flop" size="1261568">
+				<rom name="doom ii (disk p - patch file).hdm" size="1261568" crc="44d368e5" sha1="21c318a5f40402b1a0ae9acfa9d35009c25a2132" offset="0" />
+			</dataarea>
+		</part>
 		<part name="cdrom" interface="cdrom">
 			<diskarea name="cdrom">
 				<disk name="doom ii (japan)" sha1="d6e6ac62129f441e1e4ca0c551923e5f49cc2b68" />
@@ -1583,9 +1590,40 @@
 		</part>
 	</software>
 
+	<!-- PC-9821 / DOS/V hybrid -->
+	<software name="drgnlore">
+		<!--
+		Origin: Neo Kobe Collection
+		CCD converted to CUE with GNU ccd2cue
+		<rom name="Dragon Lore (Disc 1).ccd" size="771" crc="fbf1cb83" md5="5e9712fe93a7b3096d0afe8d4401981e" sha1="15e13b7dcbd5bf8cec68259e1294deeb706842ac"/>
+		<rom name="Dragon Lore (Disc 1).cue" size="82" crc="70b82b63" md5="9db6e499c9c09f38659dd0ef531d70aa" sha1="60fd857e8574a00196516f47efb560d871563ad8"/>
+		<rom name="Dragon Lore (Disc 1).img" size="741310416" crc="1c59fb4b" md5="be8010f46710c1fce21feea316f90fea" sha1="4fd81f2d05c3036ace452373cf0597848eeeca17"/>
+		<rom name="Dragon Lore (Disc 1).sub" size="30257568" crc="ce02414d" md5="6cb736851ddc7f45306dacef0d41c714" sha1="05e808b2983fa08e16c1dafbc3af2d597ecea8aa"/>
+		<rom name="Dragon Lore (Disc 2).ccd" size="772" crc="f64bfdc1" md5="70337d7149ba233265560af3968d8ddf" sha1="5daa2ebf7bc02999b359509876abbf43ae7afbbe"/>
+		<rom name="Dragon Lore (Disc 2).cue" size="82" crc="aff13bd6" md5="5420246f92127a659f7ac40ef4d60f67" sha1="882f81b4a818f71ca81ffb523552d0d6e2cc3b8f"/>
+		<rom name="Dragon Lore (Disc 2).img" size="662937072" crc="82da9d69" md5="083c944d7186afb5a168f92a5a94dc76" sha1="859aa76d949ce7b1a08e353efea90347051eac5b"/>
+		<rom name="Dragon Lore (Disc 2).sub" size="27058656" crc="d505c200" md5="29626fe78dcab6f4b1bd207e1ca92d31" sha1="3fa965f0b12b8d9abd2ed2dc291ffc1cef40c9ed"/>
+		-->
+		<description>Dragon Lore</description>
+		<year>1996</year>
+		<publisher>ケイエスエス (KSS)</publisher>
+		<info name="alt_title" value="ドラゴンロア" />
+		<info name="release" value="19960419" />
+		<part name="cdrom1" interface="cdrom">
+			<diskarea name="cdrom">
+				<disk name="dragon lore (disc 1)" sha1="50a8f19aa42fc307a6aebe3ae80cf139d49c2eed" />
+			</diskarea>
+		</part>
+		<part name="cdrom2" interface="cdrom">
+			<diskarea name="cdrom">
+				<disk name="dragon lore (disc 2)" sha1="0251559705b17242ccf0f833642b0595f4cc45fc" />
+			</diskarea>
+		</part>
+	</software>
+
 	<!-- PC-98x1 / DOS/V hybrid -->
-	<!-- Blank screen when running DS.BAT; also, there's apparently no way to install the game - maybe it's missing a floppy disk? -->
-	<software name="duelsucp" supported="no">
+	<!-- This is an expansion disk for Duel Succession. The installer only seems to run under Windows, but copying the files from the PC98 directory to the DS install directory works -->
+	<software name="duelsucp">
 		<!--
 		Origin: P2P
 		<rom name="DUEL succession Plus kit (1996)(Kure Software Koubou).ccd" size="3636" crc="8317e961" sha1="57b2aa6bf0a6cf0db7c8d4dfab48d9bc84822736"/>


### PR DESCRIPTION
- Added new software items from the Neo Kobe Collection:

D.O. Doki Doki Disk Vol. 08
Daijuutai
Dam Busters
Dangerous Toys
Dark Seraphim
Datenshi Kyouko Part I
Dead Force
Delicious Lunch Pack
Dennou Garou
Desert Dragoon - Sabaku no Ryuukihei
Desire - Haitoku no Rasen
Diadrum
Director Monogatari
Dires - Giger Loop
DiskX II
Bishoujo Daizukan
Diver's
Doki Doki Pretty League Dai-1-wa - Pink Angels Kiki Ippatsu no Maki
Doki Doki Pretty League Dai-2-wa - Mou Hitotsu no Rival
Doki Doki Pretty League Dai-3-wa - Minami no Umi no Kai no Maki
Doki Doki Pretty League Dai-4-wa - Nanase no Himitsu no Maki
Doki Doki Pretty League Dai-5-wa - Saraba Pink Angels-tachi
Doom II
Doop
Dora Dora Emotion - Seihaiden
DR² Night Janki
Dragon Master Silk - Ryuu Shoukan Musume - Episode II
Dragon Master Silk - Ryuu Shoukan Musume - Episode II (Alt Disk 1)
Dream Theater
Dream Theater (Alt)
Dual Soul
Duel - Kawanakajima Scenario
Duel Succession
Dungeon Hack (newer, 16/256 colors)
Dungeon Hack (older, 256 colors, requires DOS 5.0)
New 3D Golf Simulation Ver. 2.0
Paracelsus no Maken
Z's Triphony - Digital Craft

- Re-tested software entries with current MAME

- Relabeled disks with their actual names

- Added usage notes for software that needs DOS

- Removed user disks from games where they aren't included in the original box, and the user is expected to create them.

- Removed duplicate images where the only differences are in the saved
game data

- Removed the "Debut" CD version floppy, since it's already included in pc98_cd.xml

- Replaced "D.O. Doki Doki Disk Vol. 02", "D.O. Kaizokuban" and "Dragon Princess - Ryuu no Densetsu" with working dumps.

- Reordered some disks so they are auto-mounted in a more logical way

- Some minor title / spelling fixes

pc98_cd.xml:

- Added a new software item (Dragon Lore)

- Added Disk P to Doom II, since it's also included with the CD version

- Added notes for Duel Succession Plus Kit