### PR TITLE
toypop.cpp: liblrabl: The sprite of the flower withered by an enemy like scissors was not correct.

### DIFF
--- a/src/mame/drivers/toypop.cpp
+++ b/src/mame/drivers/toypop.cpp
@@ -279,6 +279,9 @@ void namcos16_state::legacy_obj_draw(bitmap_ind16 &bitmap,const rectangle &clipr
 		uint8_t width = ((base_spriteram[count+bank2] & 4) >> 2) + 1;
 		uint8_t height = ((base_spriteram[count+bank2] & 8) >> 3) + 1;
 
+		tile &= ~(width - 1);
+		tile &= ~((height - 1) << 1);
+
 		if (flip)
 		{
 			fx ^= 1;


### PR DESCRIPTION
![Libble Rabble](https://user-images.githubusercontent.com/42865216/59566206-ba34e180-9097-11e9-9626-61bb6e6b2065.png)
