### PR TITLE
revert tzx_cas changes from 0.202, they break things

### DIFF
--- a/src/lib/formats/tzx_cas.cpp
+++ b/src/lib/formats/tzx_cas.cpp
@@ -282,17 +282,13 @@ static int tzx_cas_handle_block( int16_t **buffer, const uint8_t *bytes, int pau
 		}
 	}
 	/* pause */
-	if (data_size > 0)
+	if (pause > 0)
 	{
 		int start_pause_samples = millisec_to_samplecount(1);
+		int rest_pause_samples = millisec_to_samplecount(pause - 1);
 
 		tzx_output_wave(buffer, start_pause_samples);
 		size += start_pause_samples;
-	}
-	if (pause > 0)
-	{
-		int rest_pause_samples = millisec_to_samplecount(pause - 1);
-
 		wave_data = WAVE_LOW;
 		tzx_output_wave(buffer, rest_pause_samples);
 		size += rest_pause_samples;


### PR DESCRIPTION
@AmatCoder it appears the changes you made cause the various Speedlock loaders to fail (this is the vast majority of the full-price commercial library for the system after a certain point, so this is a major regression.

as an example / test case, the following sets from the software list NO LONGER function in 0.202 due to the changes made.   (used with 'spectrum' machine)

batmana - fast loader - yellow/blue
batmanb - fast loader with timer, black/blue
batmanf - fast loader - yellow/blue

The following didn't change (mostly budget rereleases or alt tzx encodings that use different block types to represent the same things)

unknown loader/encoding (never worked due to flawed 0x19 - Generalized Data Block?)
batmanc
batmang

flashy border loaders (works before and after)
batman
batmand
batmanh

misc fast loader (works before and after)
batmane - fast loader - yellow/blue (works)