### PR TITLE
myb3k: Add support for FDC4712

### DIFF
--- a/src/devices/bus/isa/myb3k_fdc.cpp
+++ b/src/devices/bus/isa/myb3k_fdc.cpp
@@ -12,14 +12,12 @@
      - 1-4 x DSDD 80 tracks, 8 sectors/track, 512 bytes/sector 720KB
 
     FDC4712 - 8" FDD4733
-     - 1-2 x DSDD 154 tracks, 8 sector/track, 1024 bytes/sector 1232KB
+     - 1-4 x DSDD 154 tracks, 8 sector/track, 1024 bytes/sector 1232KB
 
     Step/One service manuals: http://nivelleringslikaren.eu/stepone/
 
    TODO:
    - Verify FDC4710 as soon as we find a 160Kb floppy image
-   - Add FDC4712 8" as soon as we get a visual or schematics on it
-   - Reduce code duplication by introducing a base class, once all are emulated
    - Put these into global ISA8 collection
 
 ********************************************************************************/
@@ -49,21 +47,13 @@
 
 DEFINE_DEVICE_TYPE(ISA8_MYB3K_FDC4710, isa8_myb3k_fdc4710_device, "isa8_myb3k_fdc4710", "FDC4710 SSDD Floppy Disk Controller")
 DEFINE_DEVICE_TYPE(ISA8_MYB3K_FDC4711, isa8_myb3k_fdc4711_device, "isa8_myb3k_fdc4711", "FDC4711 DSDD Floppy Disk Controller")
+DEFINE_DEVICE_TYPE(ISA8_MYB3K_FDC4712, isa8_myb3k_fdc4712_device, "isa8_myb3k_fdc4712", "FDC4712 DSDD Floppy Disk Controller")
 
-void isa8_myb3k_fdc4710_device::map(address_map &map)
+void isa8_myb3k_fdc471x_device_base::map(address_map &map)
 {
-//  AM_RANGE(0x00, 0x03) AM_DEVREADWRITE("fdc", mb8876_device, read, write) AM_MIRROR(0x500)
-	map(0x00, 0x03).r(FUNC(isa8_myb3k_fdc4710_device::myb3k_inv_fdc_data_r)).w(FUNC(isa8_myb3k_fdc4710_device::myb3k_inv_fdc_data_w)).mirror(0x500);
-	map(0x04, 0x04).w(FUNC(isa8_myb3k_fdc4710_device::myb3k_fdc_command)).mirror(0x500);
-	map(0x05, 0x05).r(FUNC(isa8_myb3k_fdc4710_device::myb3k_fdc_status)).mirror(0x500);
-}
-
-void isa8_myb3k_fdc4711_device::map(address_map &map)
-{
-//  AM_RANGE(0x00, 0x03) AM_DEVREADWRITE("fdc", fd1791_device, read, write) AM_MIRROR(0x500)
-	map(0x00, 0x03).r(FUNC(isa8_myb3k_fdc4711_device::myb3k_inv_fdc_data_r)).w(FUNC(isa8_myb3k_fdc4711_device::myb3k_inv_fdc_data_w)).mirror(0x500);
-	map(0x04, 0x04).w(FUNC(isa8_myb3k_fdc4711_device::myb3k_fdc_command)).mirror(0x500);
-	map(0x05, 0x05).r(FUNC(isa8_myb3k_fdc4711_device::myb3k_fdc_status)).mirror(0x500);
+	map(0x00, 0x03).r(FUNC(isa8_myb3k_fdc471x_device_base::myb3k_inv_fdc_data_r)).w(FUNC(isa8_myb3k_fdc471x_device_base::myb3k_inv_fdc_data_w));
+	map(0x04, 0x04).w(FUNC(isa8_myb3k_fdc471x_device_base::myb3k_fdc_command));
+	map(0x05, 0x05).r(FUNC(isa8_myb3k_fdc471x_device_base::myb3k_fdc_status));
 }
 
 FLOPPY_FORMATS_MEMBER( isa8_myb3k_fdc4710_device::myb3k_floppy_formats )
@@ -72,6 +62,10 @@ FLOPPY_FORMATS_END
 
 FLOPPY_FORMATS_MEMBER( isa8_myb3k_fdc4711_device::myb3k_floppy_formats )
 	FLOPPY_PC_FORMAT,
+	FLOPPY_IMD_FORMAT
+FLOPPY_FORMATS_END
+
+FLOPPY_FORMATS_MEMBER( isa8_myb3k_fdc4712_device::myb3k_floppy_formats )
 	FLOPPY_IMD_FORMAT
 FLOPPY_FORMATS_END
 
@@ -85,124 +79,105 @@ static void myb3k_qd_floppies(device_slot_interface &device)
 	device.option_add("525qd", FLOPPY_525_QD);
 }
 
-#if 0
 static void myb3k_8inch_floppies(device_slot_interface &device)
 {
 	device.option_add("8dsdd", FLOPPY_8_DSDD);
 }
-#endif
 
 //-------------------------------------------------
 //  device_add_mconfig - add device configuration
 //-------------------------------------------------
-/*  */
+
+void isa8_myb3k_fdc471x_device_base::device_add_mconfig(machine_config &config)
+{
+	m_fdc->intrq_wr_callback().set(FUNC(isa8_myb3k_fdc471x_device_base::irq_w));
+	m_fdc->drq_wr_callback().set(FUNC(isa8_myb3k_fdc471x_device_base::drq_w));
+}
+
 void isa8_myb3k_fdc4710_device::device_add_mconfig(machine_config &config)
 {
 	MB8876(config, m_fdc, XTAL(15'974'400) / 8); /* From StepOne schematics */
-	m_fdc->intrq_wr_callback().set(FUNC(isa8_myb3k_fdc4710_device::irq_w));
-	m_fdc->drq_wr_callback().set(FUNC(isa8_myb3k_fdc4710_device::drq_w));
-	FLOPPY_CONNECTOR(config, m_fdd0, myb3k_sd_floppies, "525sd", isa8_myb3k_fdc4710_device::myb3k_floppy_formats);
-	FLOPPY_CONNECTOR(config, m_fdd1, myb3k_sd_floppies, "525sd", isa8_myb3k_fdc4710_device::myb3k_floppy_formats);
+	FLOPPY_CONNECTOR(config, m_floppy_connectors[0], myb3k_sd_floppies, "525sd", isa8_myb3k_fdc4710_device::myb3k_floppy_formats);
+	FLOPPY_CONNECTOR(config, m_floppy_connectors[1], myb3k_sd_floppies, "525sd", isa8_myb3k_fdc4710_device::myb3k_floppy_formats);
+
+	isa8_myb3k_fdc471x_device_base::device_add_mconfig(config);
 }
 
 /* Main difference from fdc4710 is that a Hitachi HA16632AP has replaced the discrete VFO enabling 720Kb disks */
 void isa8_myb3k_fdc4711_device::device_add_mconfig(machine_config &config)
 {
-	FD1791(config, m_fdc, XTAL(15'974'400) / 16);
-	m_fdc->intrq_wr_callback().set(FUNC(isa8_myb3k_fdc4711_device::irq_w));
-	m_fdc->drq_wr_callback().set(FUNC(isa8_myb3k_fdc4711_device::drq_w));
-	FLOPPY_CONNECTOR(config, m_fdd0, myb3k_qd_floppies, "525qd", isa8_myb3k_fdc4711_device::myb3k_floppy_formats);
-	FLOPPY_CONNECTOR(config, m_fdd1, myb3k_qd_floppies, "525qd", isa8_myb3k_fdc4711_device::myb3k_floppy_formats);
-	FLOPPY_CONNECTOR(config, m_fdd2, myb3k_qd_floppies, "525qd", isa8_myb3k_fdc4711_device::myb3k_floppy_formats);
-	FLOPPY_CONNECTOR(config, m_fdd3, myb3k_qd_floppies, "525qd", isa8_myb3k_fdc4711_device::myb3k_floppy_formats);
+	MB8876(config, m_fdc, XTAL(15'974'400) / 16);
+	FLOPPY_CONNECTOR(config, m_floppy_connectors[0], myb3k_qd_floppies, "525qd", isa8_myb3k_fdc4711_device::myb3k_floppy_formats);
+	FLOPPY_CONNECTOR(config, m_floppy_connectors[1], myb3k_qd_floppies, "525qd", isa8_myb3k_fdc4711_device::myb3k_floppy_formats);
+	FLOPPY_CONNECTOR(config, m_floppy_connectors[2], myb3k_qd_floppies, "525qd", isa8_myb3k_fdc4711_device::myb3k_floppy_formats);
+	FLOPPY_CONNECTOR(config, m_floppy_connectors[3], myb3k_qd_floppies, "525qd", isa8_myb3k_fdc4711_device::myb3k_floppy_formats);
+
+	isa8_myb3k_fdc471x_device_base::device_add_mconfig(config);
 }
 
-#if 0
 void isa8_myb3k_fdc4712_device::device_add_mconfig(machine_config &config)
 {
-	FD1791(config, m_fdc, XTAL(15'974'400) / 8);
-	m_fdc->intrq_wr_callback().set(FUNC(isa8_myb3k_fdc4712_device::irq_w));
-	m_fdc->drq_wr_callback().set(FUNC(isa8_myb3k_fdc4712_device::drq_w));
-	FLOPPY_CONNECTOR(config, m_fdd0, myb3k_8inch_floppies, "8dsdd", isa8_myb3k_fdc4712_device::myb3k_floppy_formats);
-	FLOPPY_CONNECTOR(config, m_fdd1, myb3k_8inch_floppies, "8dsdd", isa8_myb3k_fdc4712_device::myb3k_floppy_formats);
+	MB8876(config, m_fdc, XTAL(15'974'400) / 8);
+	FLOPPY_CONNECTOR(config, m_floppy_connectors[0], myb3k_8inch_floppies, "8dsdd", isa8_myb3k_fdc4712_device::myb3k_floppy_formats);
+	FLOPPY_CONNECTOR(config, m_floppy_connectors[1], myb3k_8inch_floppies, "8dsdd", isa8_myb3k_fdc4712_device::myb3k_floppy_formats);
+	FLOPPY_CONNECTOR(config, m_floppy_connectors[2], myb3k_8inch_floppies, "8dsdd", isa8_myb3k_fdc4712_device::myb3k_floppy_formats);
+	FLOPPY_CONNECTOR(config, m_floppy_connectors[3], myb3k_8inch_floppies, "8dsdd", isa8_myb3k_fdc4712_device::myb3k_floppy_formats);
+
+	isa8_myb3k_fdc471x_device_base::device_add_mconfig(config);
 }
-#endif
 
 //**************************************************************************
 //  LIVE DEVICES
 //**************************************************************************
-isa8_myb3k_fdc4710_device::isa8_myb3k_fdc4710_device(const machine_config &mconfig, device_type type, const char *tag, device_t *owner, uint32_t clock) :
-	device_t(mconfig, type, tag, owner, clock)
-	, device_isa8_card_interface(mconfig, *this)
-	, m_fdc(*this, "fdc")
-	, m_fdd0(*this, "fdc:0")
-	, m_fdd1(*this, "fdc:1")
+isa8_myb3k_fdc471x_device_base::isa8_myb3k_fdc471x_device_base(const machine_config &mconfig, device_type type, const char *tag, device_t *owner, uint32_t clock) :
+	device_t(mconfig, type, tag, owner, clock),
+	device_isa8_card_interface(mconfig, *this),
+	m_fdc(*this, "fdc"),
+	m_floppy_connectors(*this, "fdc:%u", 0)
 {
 }
 
-isa8_myb3k_fdc4710_device::isa8_myb3k_fdc4710_device(const machine_config &mconfig, const char *tag, device_t *owner, uint32_t clock) : isa8_myb3k_fdc4710_device(mconfig, ISA8_MYB3K_FDC4710, tag, owner, clock)
+isa8_myb3k_fdc4710_device::isa8_myb3k_fdc4710_device(const machine_config &mconfig, const char *tag, device_t *owner, uint32_t clock) :
+	isa8_myb3k_fdc471x_device_base(mconfig, ISA8_MYB3K_FDC4710, tag, owner, clock)
 {
+	has_motor_control = true;
+	io_base = 0x20;
+	dma_channel = 2;
 }
 
-isa8_myb3k_fdc4711_device::isa8_myb3k_fdc4711_device(const machine_config &mconfig, device_type type, const char *tag, device_t *owner, uint32_t clock) :
-	device_t(mconfig, type, tag, owner, clock)
-	, device_isa8_card_interface(mconfig, *this)
-	, m_fdc(*this, "fdc")
-	, m_fdd0(*this, "fdc:0")
-	, m_fdd1(*this, "fdc:1")
-	, m_fdd2(*this, "fdc:2")
-	, m_fdd3(*this, "fdc:3")
+isa8_myb3k_fdc4711_device::isa8_myb3k_fdc4711_device(const machine_config &mconfig, const char *tag, device_t *owner, uint32_t clock) :
+	isa8_myb3k_fdc471x_device_base(mconfig, ISA8_MYB3K_FDC4711, tag, owner, clock)
 {
+	has_motor_control = true;
+	io_base = 0x20;
+	dma_channel = 2;
 }
 
-isa8_myb3k_fdc4711_device::isa8_myb3k_fdc4711_device(const machine_config &mconfig, const char *tag, device_t *owner, uint32_t clock) : isa8_myb3k_fdc4711_device(mconfig, ISA8_MYB3K_FDC4711, tag, owner, clock)
+isa8_myb3k_fdc4712_device::isa8_myb3k_fdc4712_device(const machine_config &mconfig, const char *tag, device_t *owner, uint32_t clock) :
+	isa8_myb3k_fdc471x_device_base(mconfig, ISA8_MYB3K_FDC4712, tag, owner, clock),
+	selected_drive(0)
 {
+	has_motor_control = false;
+	io_base = 0x520;
+	dma_channel = 1;
 }
 
 //-------------------------------------------------
 //  device_start - device-specific startup
 //-------------------------------------------------
-void isa8_myb3k_fdc4710_device::device_start()
+void isa8_myb3k_fdc471x_device_base::device_start()
 {
 	LOG("%s\n", FUNCNAME);
 
 	set_isa_device();
-	m_isa->set_dma_channel(2, this, true);
-	m_isa->install_device(0x020, 0x027, *this, &isa8_myb3k_fdc4710_device::map);
-}
-
-void isa8_myb3k_fdc4711_device::device_start()
-{
-	LOG("%s\n", FUNCNAME);
-
-	set_isa_device();
-	m_isa->install_device(0x020, 0x027, *this, &isa8_myb3k_fdc4711_device::map);
-	m_isa->set_dma_channel(2, this, true);
-}
-
-//-------------------------------------------------
-//  device_reset - device-specific reset
-//-------------------------------------------------
-void isa8_myb3k_fdc4710_device::device_reset()
-{
-	LOG("%s\n", FUNCNAME);
-}
-
-void isa8_myb3k_fdc4711_device::device_reset()
-{
-	LOG("%s\n", FUNCNAME);
+	m_isa->install_device(io_base, io_base + 7, *this, &isa8_myb3k_fdc471x_device_base::map);
+	m_isa->set_dma_channel(dma_channel, this, true);
 }
 
 //-------------------------------------------------
 //  irq_w - signal interrupt request to ISA bus
 //-------------------------------------------------
-WRITE_LINE_MEMBER( isa8_myb3k_fdc4710_device::irq_w )
-{
-	LOG("%s: %d\n", FUNCNAME, state);
-	m_isa->irq6_w(state ? ASSERT_LINE : CLEAR_LINE);
-}
-
-WRITE_LINE_MEMBER( isa8_myb3k_fdc4711_device::irq_w )
+WRITE_LINE_MEMBER( isa8_myb3k_fdc471x_device_base::irq_w )
 {
 	LOG("%s: %d\n", FUNCNAME, state);
 	m_isa->irq6_w(state ? ASSERT_LINE : CLEAR_LINE);
@@ -211,27 +186,25 @@ WRITE_LINE_MEMBER( isa8_myb3k_fdc4711_device::irq_w )
 //-------------------------------------------------
 //  drq_w - signal dma request to ISA bus
 //-------------------------------------------------
-WRITE_LINE_MEMBER( isa8_myb3k_fdc4710_device::drq_w )
+WRITE_LINE_MEMBER( isa8_myb3k_fdc471x_device_base::drq_w )
 {
 	LOG("%s: %d\n", FUNCNAME, state);
-	m_isa->drq2_w(state ? ASSERT_LINE : CLEAR_LINE);
-}
 
-WRITE_LINE_MEMBER( isa8_myb3k_fdc4711_device::drq_w )
-{
-	LOG("%s: %d\n", FUNCNAME, state);
-	m_isa->drq2_w(state ? ASSERT_LINE : CLEAR_LINE);
+	switch (dma_channel)
+	{
+	case 1:
+		m_isa->drq1_w(state);
+	case 2:
+		m_isa->drq2_w(state);
+	default:
+		break;
+	}
 }
 
 //-------------------------------------------------
-//  dack_r - return FDC data trough DMA
+//  dack_r - return FDC data through DMA
 //-------------------------------------------------
-uint8_t isa8_myb3k_fdc4710_device::dack_r(int line)
-{
-	return ~(m_fdc->data_r());
-}
-
-uint8_t isa8_myb3k_fdc4711_device::dack_r(int line)
+uint8_t isa8_myb3k_fdc471x_device_base::dack_r(int line)
 {
 	return ~(m_fdc->data_r());
 }
@@ -239,23 +212,13 @@ uint8_t isa8_myb3k_fdc4711_device::dack_r(int line)
 //-------------------------------------------------
 //  dack_w - write DMA data to FDC
 //-------------------------------------------------
-void isa8_myb3k_fdc4710_device::dack_w(int line, uint8_t data)
-{
-	return m_fdc->data_w(data);
-}
-
-void isa8_myb3k_fdc4711_device::dack_w(int line, uint8_t data)
+void isa8_myb3k_fdc471x_device_base::dack_w(int line, uint8_t data)
 {
 	return m_fdc->data_w(data);
 }
 
 #if 0 // eop/tc is used to for logic around multi sector transfers
-void isa8_myb3k_fdc4710_device::eop_w(int state)
-{
-	m_fdc->tc_w(state == ASSERT_LINE);
-}
-
-void isa8_myb3k_fdc4711_device::eop_w(int state)
+void isa8_myb3k_fdc471x_device_base::eop_w(int state)
 {
 	m_fdc->tc_w(state == ASSERT_LINE);
 }
@@ -264,14 +227,7 @@ void isa8_myb3k_fdc4711_device::eop_w(int state)
 //--------------------------------------------------------
 //  myb3k_inv_fdc_data_r - a LS240 inverts databus for FDC
 //--------------------------------------------------------
-READ8_MEMBER( isa8_myb3k_fdc4710_device::myb3k_inv_fdc_data_r )
-{
-	uint8_t tmp = m_fdc->read(offset);
-	LOGR("%s: %02x -> %02x\n", FUNCNAME, tmp, (~tmp) & 0xff);
-	return ~tmp;
-}
-
-READ8_MEMBER( isa8_myb3k_fdc4711_device::myb3k_inv_fdc_data_r )
+READ8_MEMBER( isa8_myb3k_fdc471x_device_base::myb3k_inv_fdc_data_r )
 {
 	uint8_t tmp = m_fdc->read(offset);
 	LOGR("%s: %02x -> %02x\n", FUNCNAME, tmp, (~tmp) & 0xff);
@@ -281,13 +237,7 @@ READ8_MEMBER( isa8_myb3k_fdc4711_device::myb3k_inv_fdc_data_r )
 //--------------------------------------------------------
 //  myb3k_inv_fdc_data_w - a LS240 inverts databus for FDC
 //--------------------------------------------------------
-WRITE8_MEMBER( isa8_myb3k_fdc4710_device::myb3k_inv_fdc_data_w )
-{
-	LOG("%s: %02x -> %02x\n", FUNCNAME, data, (~data) & 0xff);
-	m_fdc->write(offset, (~data) & 0xff);
-}
-
-WRITE8_MEMBER( isa8_myb3k_fdc4711_device::myb3k_inv_fdc_data_w )
+WRITE8_MEMBER( isa8_myb3k_fdc471x_device_base::myb3k_inv_fdc_data_w )
 {
 	LOG("%s: %02x -> %02x\n", FUNCNAME, data, (~data) & 0xff);
 	m_fdc->write(offset, (~data) & 0xff);
@@ -296,84 +246,73 @@ WRITE8_MEMBER( isa8_myb3k_fdc4711_device::myb3k_inv_fdc_data_w )
 //-------------------------------------------------
 //  myb3k_fdc_command - descrete fdc card features
 //-------------------------------------------------
-WRITE8_MEMBER( isa8_myb3k_fdc4710_device::myb3k_fdc_command )
-{
-	data = ~data;
-	LOG("%s: %02x\n", FUNCNAME, data);
-	LOGCMD(" - Drive %d\n", ~data & FDC_DRIVE_SEL);
-	LOGCMD(" - Side  %d\n", (data & FDC_SIDE_SEL) ? 0 : 1);
-	LOGCMD(" - Motor %s\n", (data & FDC_MOTOR_ON) ? "OFF" : "ON");
-	LOGCMD(" - Density %s\n", (data & FDC_DDEN) ? "FM" : "MFM");
 
+WRITE8_MEMBER( isa8_myb3k_fdc471x_device_base::myb3k_fdc_command )
+{
+	LOG("%s: %02x\n", FUNCNAME, data);
+
+	auto selected_drive = data & FDC_DRIVE_SEL;
+	auto selected_side = (data & FDC_SIDE_SEL) ? 1 : 0;
+	bool motor_on = (data & FDC_MOTOR_ON) != 0;
+	bool dden = (data & FDC_DDEN) != 0;
+
+	LOGCMD(" - Drive %d\n", selected_drive);
+	LOGCMD(" - Side  %d\n", selected_side);
+	LOGCMD(" - Density %s\n", dden ? "MFM" : "FM");
+	
+	if (has_motor_control)
+		LOGCMD(" - Motor %s\n", motor_on ? "ON" : "OFF");
+
+	auto floppy_connector = m_floppy_connectors[selected_drive];
 	floppy_image_device *floppy = nullptr;
 
-	switch(~data & FDC_DRIVE_SEL) // Y0-Y3 on a '139 maps to drive 4 to 1 respectively
-	{
-	case 0:floppy = m_fdd0->get_device(); break;
-	case 1:floppy = m_fdd1->get_device(); break;
-	}
+	if (floppy_connector.found())
+		floppy = floppy_connector->get_device();
+	
+	m_fdc->set_floppy(floppy);
 
-	if (floppy)
+	if (floppy != nullptr)
 	{
-		LOGCMD(" - Floppy found\n");
-		m_fdc->set_floppy(floppy);
-		floppy->ss_w((data & FDC_SIDE_SEL) ? 0 : 1);
-		floppy->mon_w((data & FDC_MOTOR_ON) ? 1 : 0); // Active low and inverter on incomming data line
-	}
-	else
-	{
-		LOGCMD(" - Floppy not found\n");
-	}
-	m_fdc->dden_w((data & FDC_DDEN) ? 1 : 0); // active low == MFM
+		floppy->ss_w(selected_side);
+
+		if (has_motor_control)
+			floppy->mon_w(motor_on ? 0 : 1); // Active low and inverter on incoming data line
+	} 
+
+	m_fdc->dden_w(dden ? 0 : 1); // active low == MFM
 }
 
-WRITE8_MEMBER( isa8_myb3k_fdc4711_device::myb3k_fdc_command )
+WRITE8_MEMBER( isa8_myb3k_fdc4712_device::myb3k_fdc_command )
 {
-	data = ~data;
-	LOG("%s: %02x\n", FUNCNAME, data);
-	LOGCMD(" - Drive %d\n", ~data & FDC_DRIVE_SEL);
-	LOGCMD(" - Side  %d\n", (data & FDC_SIDE_SEL) ? 0 : 1);
-	LOGCMD(" - Motor %s\n", (data & FDC_MOTOR_ON) ? "OFF" : "ON");
-	LOGCMD(" - Density %s\n", (data & FDC_DDEN) ? "FM" : "MFM");
-
-	floppy_image_device *floppy = nullptr;
-
-	switch(~data & FDC_DRIVE_SEL) // Y0-Y3 on a '139 maps to drive 4 to 1 respectively
-	{
-	case 0:floppy = m_fdd0->get_device(); break;
-	case 1:floppy = m_fdd1->get_device(); break;
-	case 2:floppy = m_fdd2->get_device(); break;
-	case 3:floppy = m_fdd3->get_device(); break;
-	}
-
-	if (floppy)
-	{
-		LOGCMD(" - Floppy found\n");
-		m_fdc->set_floppy(floppy);
-		floppy->ss_w((data & FDC_SIDE_SEL) ? 0 : 1);
-		floppy->mon_w((data & FDC_MOTOR_ON) ? 1 : 0); // Active low and inverter on incomming data line
-	}
-	else
-	{
-		LOGCMD(" - Floppy not found\n");
-	}
-	m_fdc->dden_w((data & FDC_DDEN) ? 1 : 0); // active low == MFM
+	selected_drive = data & FDC_DRIVE_SEL;
+	isa8_myb3k_fdc471x_device_base::myb3k_fdc_command(space, offset, data, mem_mask);
 }
 
 //-------------------------------------------------
-//  myb3k_fdc_status - descrete fdc card status
+//  myb3k_fdc_status - discrete fdc card status
 //-------------------------------------------------
 #define FDC_MSM_END_IR 0x01
-READ8_MEMBER( isa8_myb3k_fdc4710_device::myb3k_fdc_status )
+
+READ8_MEMBER( isa8_myb3k_fdc471x_device_base::myb3k_fdc_status )
 {
 	LOG("%s\n", FUNCNAME);
+
 	// TODO: return the multi sector mode interrupt status
 	return 0x00;
 }
 
-READ8_MEMBER( isa8_myb3k_fdc4711_device::myb3k_fdc_status )
+READ8_MEMBER( isa8_myb3k_fdc4712_device::myb3k_fdc_status )
 {
-	LOG("%s\n", FUNCNAME);
-	// TODO: return the multi sector mode interrupt status
-	return 0x00;
+	uint8_t status = isa8_myb3k_fdc471x_device_base::myb3k_fdc_status(space, offset, mem_mask);
+
+	auto floppy_connector = m_floppy_connectors[selected_drive];
+	floppy_image_device *floppy = nullptr;
+	
+	if (floppy_connector.found())
+		floppy = floppy_connector->get_device();
+
+	if (floppy != nullptr && !floppy->twosid_r())
+		status |= FDC_STATUS_DOUBLE_SIDED;
+
+	return status;
 }

--- a/src/devices/bus/isa/myb3k_fdc.h
+++ b/src/devices/bus/isa/myb3k_fdc.h
@@ -15,23 +15,55 @@
 #include "machine/wd_fdc.h"
 #include "formats/imd_dsk.h"
 
-class isa8_myb3k_fdc471x_base
+class isa8_myb3k_fdc471x_device_base :
+	public device_t,
+	public device_isa8_card_interface
 {
 protected:
-	enum {
-		FDC_MSM_MODE = 0x40,
-		FDC_DDEN = 0x20,
-		//FDC_MOTOR_ON = 0x10, // According to service manual but not schematics and BIOS
-		FDC_SIDE_SEL = 0x08,
-		FDC_MOTOR_ON = 0x04, // According to schematics but "Motor Cont" according to service manual
+	isa8_myb3k_fdc471x_device_base(const machine_config &mconfig, device_type type, const char *tag, device_t *owner, uint32_t clock);
+
+	// device-level overrides
+	virtual void device_add_mconfig(machine_config &config) override;
+	virtual void device_start() override;
+	virtual void device_reset() override { };
+
+	void map(address_map &map);
+
+	virtual uint8_t dack_r(int line) override;
+	virtual void dack_w(int line, uint8_t data) override;
+	// virtual void eop_w(int state) override;
+
+	virtual DECLARE_READ8_MEMBER(myb3k_inv_fdc_data_r);
+	virtual DECLARE_WRITE8_MEMBER(myb3k_inv_fdc_data_w);
+	virtual DECLARE_READ8_MEMBER(myb3k_fdc_status);
+	virtual DECLARE_WRITE8_MEMBER(myb3k_fdc_command);
+
+	DECLARE_WRITE_LINE_MEMBER( irq_w );
+	DECLARE_WRITE_LINE_MEMBER( drq_w );
+
+	required_device<mb8876_device> m_fdc;
+	optional_device_array<floppy_connector, 4> m_floppy_connectors;
+
+	offs_t io_base;
+	int dma_channel;
+
+	bool has_motor_control;
+
+	enum FDC_COMMAND {
 		FDC_DRIVE_SEL = 0x03,
+		FDC_MOTOR_ON = 0x04, // According to schematics but "Motor Cont" according to service manual
+		FDC_SIDE_SEL = 0x08,
+		//FDC_MOTOR_ON = 0x10, // According to service manual but not schematics and BIOS
+		FDC_DDEN = 0x20,
+		FDC_MSM_MODE = 0x40,
+	};
+
+	enum FDC_STATUS {
+		FDC_STATUS_DOUBLE_SIDED = 0x04,
 	};
 };
 
-class isa8_myb3k_fdc4710_device :
-	public device_t,
-	public device_isa8_card_interface,
-	public isa8_myb3k_fdc471x_base
+class isa8_myb3k_fdc4710_device : public isa8_myb3k_fdc471x_device_base
 {
 public:
 	// construction/destruction
@@ -43,33 +75,12 @@ protected:
 
 	// device-level overrides
 	virtual void device_add_mconfig(machine_config &config) override;
-	virtual void device_start() override;
-	virtual void device_reset() override;
-
-	virtual uint8_t dack_r(int line) override;
-	virtual void dack_w(int line, uint8_t data) override;
-	//  virtual void eop_w(int state) override;
-
-	DECLARE_READ8_MEMBER(myb3k_inv_fdc_data_r);
-	DECLARE_WRITE8_MEMBER(myb3k_inv_fdc_data_w);
-	DECLARE_READ8_MEMBER(myb3k_fdc_status);
-	DECLARE_WRITE8_MEMBER(myb3k_fdc_command);
-	void map(address_map &map);
-
-	required_device<mb8876_device> m_fdc;
-	required_device<floppy_connector> m_fdd0;
-	optional_device<floppy_connector> m_fdd1;
 
 private:
-	DECLARE_WRITE_LINE_MEMBER( irq_w );
-	DECLARE_WRITE_LINE_MEMBER( drq_w );
 	DECLARE_FLOPPY_FORMATS( myb3k_floppy_formats );
 };
 
-class isa8_myb3k_fdc4711_device :
-	public device_t,
-	public device_isa8_card_interface,
-	public isa8_myb3k_fdc471x_base
+class isa8_myb3k_fdc4711_device : public isa8_myb3k_fdc471x_device_base
 {
 public:
 	// construction/destruction
@@ -81,34 +92,36 @@ protected:
 
 	// device-level overrides
 	virtual void device_add_mconfig(machine_config &config) override;
-	virtual void device_start() override;
-	virtual void device_reset() override;
-
-	virtual uint8_t dack_r(int line) override;
-	virtual void dack_w(int line, uint8_t data) override;
-	// virtual void eop_w(int state) override;
-
-	DECLARE_READ8_MEMBER(myb3k_inv_fdc_data_r);
-	DECLARE_WRITE8_MEMBER(myb3k_inv_fdc_data_w);
-	DECLARE_READ8_MEMBER(myb3k_fdc_status);
-	DECLARE_WRITE8_MEMBER(myb3k_fdc_command);
-	void map(address_map &map);
-
-	required_device<fd1791_device> m_fdc;
-	required_device<floppy_connector> m_fdd0;
-	optional_device<floppy_connector> m_fdd1;
-	optional_device<floppy_connector> m_fdd2;
-	optional_device<floppy_connector> m_fdd3;
 
 private:
-	DECLARE_WRITE_LINE_MEMBER( irq_w );
-	DECLARE_WRITE_LINE_MEMBER( drq_w );
+	DECLARE_FLOPPY_FORMATS( myb3k_floppy_formats );
+};
+
+class isa8_myb3k_fdc4712_device : public isa8_myb3k_fdc471x_device_base
+{
+public:
+	// construction/destruction
+	isa8_myb3k_fdc4712_device(const machine_config &mconfig, const char *tag, device_t *owner, uint32_t clock);
+
+protected:
+	// construction/destruction
+	isa8_myb3k_fdc4712_device(const machine_config &mconfig, device_type type, const char *tag, device_t *owner, uint32_t clock);
+
+	// device-level overrides
+	virtual void device_add_mconfig(machine_config &config) override;
+
+	virtual DECLARE_WRITE8_MEMBER(myb3k_fdc_command) override;
+	virtual DECLARE_READ8_MEMBER(myb3k_fdc_status) override;
+
+	uint8_t selected_drive;
+
+private:
 	DECLARE_FLOPPY_FORMATS( myb3k_floppy_formats );
 };
 
 // device type definition
 DECLARE_DEVICE_TYPE(ISA8_MYB3K_FDC4710,      isa8_myb3k_fdc4710_device)
 DECLARE_DEVICE_TYPE(ISA8_MYB3K_FDC4711,      isa8_myb3k_fdc4711_device)
-//DECLARE_DEVICE_TYPE(ISA8_MYB3K_FDC4712,      isa8_myb3k_fdc4712_device)
+DECLARE_DEVICE_TYPE(ISA8_MYB3K_FDC4712,      isa8_myb3k_fdc4712_device)
 
 #endif // MAME_BUS_ISA_MYB3K_FDC_H

--- a/src/mame/drivers/myb3k.cpp
+++ b/src/mame/drivers/myb3k.cpp
@@ -928,6 +928,7 @@ static void stepone_isa_cards(device_slot_interface &device)
 	device.option_add("myb3k_com", ISA8_MYB3K_COM);
 	device.option_add("myb3k_fdc4710", ISA8_MYB3K_FDC4710);
 	device.option_add("myb3k_fdc4711", ISA8_MYB3K_FDC4711);
+	device.option_add("myb3k_fdc4712", ISA8_MYB3K_FDC4712);
 }
 
 void myb3k_state::myb3k(machine_config &config)


### PR DESCRIPTION
Adds support for FDC4712 8-inch floppy disk controller card for MyBrain 3000 (and clones).

As part of this work I've moved common functionality between the FDC471x cards into a base class `isa8_myb3k_fdc471x_device_base` (as suggested in the file header). There's a few things I'm not completely happy with in regards to the implementation:

- FDC4710 only supports connecting up to 2 disk drives. I've implemented this restriction with an `optional_device_array<floppy_connector, 4>` on the base class, with `isa8_myb3k_fdc4710_device::device_add_mconfig` only adding two floppy connectors, but I'm not sure if this is the right approach.
- Motor control support is toggled via `has_motor_control`, which is set in each device subclass.

There are probably other things as well - any direction as to what the correct approaches are would be much appreciated.

MB8876 is used for the FDC in the base class, as this is the chip I've observed on real hardware. 

Implementation of the card's status register was based on experimentation with real hardware (JB-3000 model). I believe the `FDC_STATUS_DOUBLE_SIDED` bit in the status register is specific to the FDC4712.

I've marked the FDC4712 as supporting 4 drives, as per the [Peripherals Summary](http://nivelleringslikaren.eu/stepone/Ericsson_StepOne_Peripherals_Summary.pdf). My disk drive unit (2 drives) only has one cable running to the computer, however there is a cut-out in the case which would seem to allow you to daisy-chain a second disk drive unit.