### PR TITLE
myb3k_fdc.cpp: Use FD1791 for FDC4711

### DIFF
--- a/src/devices/bus/isa/myb3k_fdc.cpp
+++ b/src/devices/bus/isa/myb3k_fdc.cpp
@@ -106,7 +106,7 @@ void isa8_myb3k_fdc4710_device::device_add_mconfig(machine_config &config)
 /* Main difference from fdc4710 is that a Hitachi HA16632AP has replaced the discrete VFO enabling 720Kb disks */
 void isa8_myb3k_fdc4711_device::device_add_mconfig(machine_config &config)
 {
-	MB8876(config, m_fdc, XTAL(15'974'400) / 16);
+	FD1791(config, m_fdc, XTAL(15'974'400) / 16);
 	FLOPPY_CONNECTOR(config, m_floppy_connectors[0], myb3k_qd_floppies, "525qd", isa8_myb3k_fdc4711_device::myb3k_floppy_formats);
 	FLOPPY_CONNECTOR(config, m_floppy_connectors[1], myb3k_qd_floppies, "525qd", isa8_myb3k_fdc4711_device::myb3k_floppy_formats);
 	FLOPPY_CONNECTOR(config, m_floppy_connectors[2], myb3k_qd_floppies, "525qd", isa8_myb3k_fdc4711_device::myb3k_floppy_formats);

--- a/src/devices/bus/isa/myb3k_fdc.h
+++ b/src/devices/bus/isa/myb3k_fdc.h
@@ -41,7 +41,7 @@ protected:
 	DECLARE_WRITE_LINE_MEMBER( irq_w );
 	DECLARE_WRITE_LINE_MEMBER( drq_w );
 
-	required_device<mb8876_device> m_fdc;
+	required_device<wd_fdc_device_base> m_fdc;
 	optional_device_array<floppy_connector, 4> m_floppy_connectors;
 
 	offs_t io_base;


### PR DESCRIPTION
As pointed out in #5256, the FDC4711 card uses an FD1791 chip as opposed to the MB8876A used on the FDC4710 and FDC4712. 