### PR TITLE
misc changes (move princ to new driver - needs F2MC-16L CPU core, promote salter/gaelco stuff, manufacturer note in redclash.cpp)

### DIFF
--- a/scripts/target/mame/mess.lua
+++ b/scripts/target/mame/mess.lua
@@ -3508,6 +3508,7 @@ files {
 createMESSProjects(_target, _subtarget, "tomy")
 files {
 	MAME_DIR .. "src/mame/drivers/tutor.cpp",
+	MAME_DIR .. "src/mame/drivers/tomy_princ.cpp",
 }
 
 createMESSProjects(_target, _subtarget, "toshiba")

--- a/src/mame/drivers/gaelco2.cpp
+++ b/src/mame/drivers/gaelco2.cpp
@@ -2402,6 +2402,6 @@ GAME( 1999, play2000_50i,play2000,  play2000,         play2000, gaelco2_state, e
 GAME( 1999, play2000_40i,play2000,  play2000,         play2000, gaelco2_state, init_play2000,  ROT0, "Nova Desitec", "Play 2000 (Super Slot & Gran Tesoro) (v4.0i) (Italy)",  0 )
 
 // Gym equipment
-GAME( 1997, sltpcycl,   0,          saltcrdi,         saltcrdi, gaelco2_state, empty_init,     ROT0, "Salter Fitness / Gaelco", "Pro Cycle Tele Cardioline (Salter Fitness Bike V.1.0, Checksum 02AB)", MACHINE_NOT_WORKING ) // Same board and ROM as Pro Reclimber
-GAME( 1997, sltpstep,   0,          saltcrdi,         saltcrdi, gaelco2_state, empty_init,     ROT0, "Salter Fitness / Gaelco", "Pro Stepper Tele Cardioline (Salter Fitness Stepper V.1.0, Checksum F208)", MACHINE_NOT_WORKING )
+GAME( 1997, sltpcycl,   0,          saltcrdi,         saltcrdi, gaelco2_state, init_play2000,  ROT0, "Salter Fitness / Gaelco", "Pro Cycle Tele Cardioline (Salter Fitness Bike V.1.0, Checksum 02AB)", 0 ) // Same board and ROM as Pro Reclimber
+GAME( 1997, sltpstep,   0,          saltcrdi,         saltcrdi, gaelco2_state, init_play2000,  ROT0, "Salter Fitness / Gaelco", "Pro Stepper Tele Cardioline (Salter Fitness Stepper V.1.0, Checksum F208)", 0 )
 // there are other devices in Cardioline series but they don't use displays and aren't on Gaelco hardware

--- a/src/mame/drivers/prestige.cpp
+++ b/src/mame/drivers/prestige.cpp
@@ -109,7 +109,6 @@ public:
 	{ }
 
 	void prestige_base(machine_config &config);
-	void princ(machine_config &config);
 	void gl6000sl(machine_config &config);
 	void gjmovie(machine_config &config);
 	void snotec(machine_config &config);
@@ -839,14 +838,6 @@ void prestige_state::gjmovie(machine_config &config)
 	SOFTWARE_LIST(config, "cart_list").set_original("gjmovie");
 }
 
-void prestige_state::princ(machine_config &config)
-{
-	prestige_base(config);
-
-	config.device_remove("cartslot");
-	GENERIC_CARTSLOT(config, m_cart, generic_plain_slot, "princ_cart");
-	SOFTWARE_LIST(config, "cart_list").set_original("princ");
-}
 
 /* ROM definition */
 ROM_START( gl6000sl )
@@ -944,10 +935,6 @@ ROM_START( cars2lap )
 	ROM_LOAD("n25s16.u6", 0x00000, 0x200000, CRC(ec1ba96e) SHA1(51b8844ae77adf20f74f268d380d268c9ce19785))
 ROM_END
 
-ROM_START( princ )
-	ROM_REGION( 0x100000, "maincpu", 0 )
-	ROM_LOAD("29f800t.u4", 0x00000, 0x100000, CRC(30b6b864) SHA1(7ada3af85dd8dd3f95ca8965ad8e642c26445293))
-ROM_END
 
 
 /* Driver */
@@ -979,7 +966,3 @@ COMP( 2012, cars2lap, 0,       0,      prestige, prestige, prestige_state, empty
 // gl6600cx use a NSC1028 system-on-a-chip designed by National Semiconductor specifically for VTech
 // http://web.archive.org/web/19991127134657/http://www.national.com/news/item/0,1735,425,00.html
 COMP( 1999, gl6600cx, 0,       0,      prestige, prestige, prestige_state, empty_init, "VTech",  "Genius Leader 6600CX (Germany)",       MACHINE_IS_SKELETON )
-
-// TODO: move into a separate driver
-// Prin-C use a Fujitsu MB90611A MCU (F2MC-16L)
-COMP( ????, princ,    0,       0,      princ,    prestige, prestige_state, empty_init, "Tomy",   "Prin-C",                               MACHINE_IS_SKELETON )

--- a/src/mame/drivers/redclash.cpp
+++ b/src/mame/drivers/redclash.cpp
@@ -467,56 +467,7 @@ ROM_START( zerohouri )
 	ROM_LOAD( "z3.u6",  0x0040, 0x0020, CRC(27fa3a50) SHA1(7cf59b7a37c156640d6ea91554d1c4276c1780e0) ) /* MM6330, Unknown purpose */
 ROM_END
 
-
 ROM_START( redclash )
-	ROM_REGION(0x10000, "maincpu", 0 )
-	ROM_LOAD( "11.11c",       0x0000, 0x1000, CRC(695e070e) SHA1(8d0451a05572f62e0f282ab96bdd26d08b77a6c9) )
-	ROM_LOAD( "13.7c",        0x1000, 0x1000, CRC(c2090318) SHA1(71725cdf51aedf5f29fa1dd1a41ad5e62c9a580d) )
-	ROM_LOAD( "12.9c",        0x2000, 0x1000, CRC(b60e5ada) SHA1(37440f382c5e8852d804fa9837c36cc1e9d94d1d) )
-
-	ROM_REGION(0x0800, "gfx1", 0 )
-	ROM_LOAD( "6.12a",        0x0000, 0x0800, CRC(da9bbcc2) SHA1(4cbe03c7f5e99cc2f124e0089ea3c392156b5d92) )
-
-	ROM_REGION( 0x2000, "gfx2", 0 )
-	ROM_LOAD( "14.3e",        0x0000, 0x0800, CRC(483a1293) SHA1(e7812475c7509389bcf8fee35598e9894428eb37) )
-	ROM_CONTINUE(             0x1000, 0x0800 )
-	ROM_LOAD( "15.3d",        0x0800, 0x0800, CRC(c45d9601) SHA1(2f156ad61161d65284df0cc55eb1b3b990eb41cb) )
-	ROM_CONTINUE(             0x1800, 0x0800 )
-
-	ROM_REGION( 0x2000, "gfx3", ROMREGION_ERASE00 )
-	/* gfx data will be rearranged here for 8x8 sprites */
-
-	ROM_REGION( 0x0060, "proms", 0 )
-	ROM_LOAD( "1.12f",        0x0000, 0x0020, CRC(43989681) SHA1(0d471e6f499294f2f62f27392b8370e2af8e38a3) ) /* palette */
-	ROM_LOAD( "2.4a",         0x0020, 0x0020, CRC(9adabf46) SHA1(f3538fdbc4280b6be46a4d7ebb4c34bd1a1ce2b7) ) /* sprite color lookup table */
-	ROM_LOAD( "3.11e",        0x0040, 0x0020, CRC(27fa3a50) SHA1(7cf59b7a37c156640d6ea91554d1c4276c1780e0) ) /* ?? */
-ROM_END
-
-ROM_START( redclasha )
-	ROM_REGION(0x10000, "maincpu", 0 )
-	ROM_LOAD( "rc1.11c",      0x0000, 0x1000, CRC(5b62ff5a) SHA1(981d3c72f28b7d136a0bad9243d39fd1ba3abc97) )
-	ROM_LOAD( "rc3.7c",       0x1000, 0x1000, CRC(409c4ee7) SHA1(15c03a4093d7695751a143aa749229fcb7721f46) )
-	ROM_LOAD( "rc2.9c",       0x2000, 0x1000, CRC(5f215c9a) SHA1(c305f7be19f6a052c08feb0b63a0326b6a1bd808) )
-
-	ROM_REGION(0x0800, "gfx1", 0 )
-	ROM_LOAD( "rc6.12a",      0x0000, 0x0800, CRC(da9bbcc2) SHA1(4cbe03c7f5e99cc2f124e0089ea3c392156b5d92) )
-
-	ROM_REGION( 0x2000, "gfx2", 0 )
-	ROM_LOAD( "rc4.3e",       0x0000, 0x0800, CRC(64ca8b63) SHA1(5fd1ca9b81f66b4d2041674900718dc8c94c2a97) )
-	ROM_CONTINUE(             0x1000, 0x0800 )
-	ROM_LOAD( "rc5.3d",       0x0800, 0x0800, CRC(fce610a2) SHA1(0be829c6f6f5c3a19056ba1594141c1965c7aa2a) )
-	ROM_CONTINUE(             0x1800, 0x0800 )
-
-	ROM_REGION( 0x2000, "gfx3", ROMREGION_ERASE00 )
-	/* gfx data will be rearranged here for 8x8 sprites */
-
-	ROM_REGION( 0x0060, "proms", 0 )
-	ROM_LOAD( "1.12f",        0x0000, 0x0020, CRC(43989681) SHA1(0d471e6f499294f2f62f27392b8370e2af8e38a3) ) /* palette */
-	ROM_LOAD( "2.4a",         0x0020, 0x0020, CRC(9adabf46) SHA1(f3538fdbc4280b6be46a4d7ebb4c34bd1a1ce2b7) ) /* sprite color lookup table */
-	ROM_LOAD( "3.11e",        0x0040, 0x0020, CRC(27fa3a50) SHA1(7cf59b7a37c156640d6ea91554d1c4276c1780e0) ) /* ?? */
-ROM_END
-
-ROM_START( redclashk )
 	ROM_REGION(0x10000, "maincpu", 0 )
 	ROM_LOAD( "rc1.8c",       0x0000, 0x0800, CRC(fd90622a) SHA1(a65a32d519e7fee89b160f8152322df20b6af4ea) )
 	ROM_LOAD( "rc2.7c",       0x0800, 0x0800, CRC(c8f33440) SHA1(60d1faee415faa13102b8e744f444f1480b8bd73) )
@@ -541,6 +492,54 @@ ROM_START( redclashk )
 	ROM_LOAD( "1.12f",        0x0000, 0x0020, CRC(43989681) SHA1(0d471e6f499294f2f62f27392b8370e2af8e38a3) ) /* 6331.7e */
 	ROM_LOAD( "2.4a",         0x0020, 0x0020, CRC(9adabf46) SHA1(f3538fdbc4280b6be46a4d7ebb4c34bd1a1ce2b7) ) /* 6331.2r */
 	ROM_LOAD( "3.11e",        0x0040, 0x0020, CRC(27fa3a50) SHA1(7cf59b7a37c156640d6ea91554d1c4276c1780e0) ) /* 6331.6w */
+ROM_END
+
+ROM_START( redclasht )
+	ROM_REGION(0x10000, "maincpu", 0 )
+	ROM_LOAD( "11.11c",       0x0000, 0x1000, CRC(695e070e) SHA1(8d0451a05572f62e0f282ab96bdd26d08b77a6c9) )
+	ROM_LOAD( "13.7c",        0x1000, 0x1000, CRC(c2090318) SHA1(71725cdf51aedf5f29fa1dd1a41ad5e62c9a580d) )
+	ROM_LOAD( "12.9c",        0x2000, 0x1000, CRC(b60e5ada) SHA1(37440f382c5e8852d804fa9837c36cc1e9d94d1d) )
+
+	ROM_REGION(0x0800, "gfx1", 0 )
+	ROM_LOAD( "6.12a",        0x0000, 0x0800, CRC(da9bbcc2) SHA1(4cbe03c7f5e99cc2f124e0089ea3c392156b5d92) )
+
+	ROM_REGION( 0x2000, "gfx2", 0 )
+	ROM_LOAD( "14.3e",        0x0000, 0x0800, CRC(483a1293) SHA1(e7812475c7509389bcf8fee35598e9894428eb37) )
+	ROM_CONTINUE(             0x1000, 0x0800 )
+	ROM_LOAD( "15.3d",        0x0800, 0x0800, CRC(c45d9601) SHA1(2f156ad61161d65284df0cc55eb1b3b990eb41cb) )
+	ROM_CONTINUE(             0x1800, 0x0800 )
+
+	ROM_REGION( 0x2000, "gfx3", ROMREGION_ERASE00 )
+	/* gfx data will be rearranged here for 8x8 sprites */
+
+	ROM_REGION( 0x0060, "proms", 0 )
+	ROM_LOAD( "1.12f",        0x0000, 0x0020, CRC(43989681) SHA1(0d471e6f499294f2f62f27392b8370e2af8e38a3) ) /* palette */
+	ROM_LOAD( "2.4a",         0x0020, 0x0020, CRC(9adabf46) SHA1(f3538fdbc4280b6be46a4d7ebb4c34bd1a1ce2b7) ) /* sprite color lookup table */
+	ROM_LOAD( "3.11e",        0x0040, 0x0020, CRC(27fa3a50) SHA1(7cf59b7a37c156640d6ea91554d1c4276c1780e0) ) /* ?? */
+ROM_END
+
+ROM_START( redclashta )
+	ROM_REGION(0x10000, "maincpu", 0 )
+	ROM_LOAD( "rc1.11c",      0x0000, 0x1000, CRC(5b62ff5a) SHA1(981d3c72f28b7d136a0bad9243d39fd1ba3abc97) )
+	ROM_LOAD( "rc3.7c",       0x1000, 0x1000, CRC(409c4ee7) SHA1(15c03a4093d7695751a143aa749229fcb7721f46) )
+	ROM_LOAD( "rc2.9c",       0x2000, 0x1000, CRC(5f215c9a) SHA1(c305f7be19f6a052c08feb0b63a0326b6a1bd808) )
+
+	ROM_REGION(0x0800, "gfx1", 0 )
+	ROM_LOAD( "rc6.12a",      0x0000, 0x0800, CRC(da9bbcc2) SHA1(4cbe03c7f5e99cc2f124e0089ea3c392156b5d92) )
+
+	ROM_REGION( 0x2000, "gfx2", 0 )
+	ROM_LOAD( "rc4.3e",       0x0000, 0x0800, CRC(64ca8b63) SHA1(5fd1ca9b81f66b4d2041674900718dc8c94c2a97) )
+	ROM_CONTINUE(             0x1000, 0x0800 )
+	ROM_LOAD( "rc5.3d",       0x0800, 0x0800, CRC(fce610a2) SHA1(0be829c6f6f5c3a19056ba1594141c1965c7aa2a) )
+	ROM_CONTINUE(             0x1800, 0x0800 )
+
+	ROM_REGION( 0x2000, "gfx3", ROMREGION_ERASE00 )
+	/* gfx data will be rearranged here for 8x8 sprites */
+
+	ROM_REGION( 0x0060, "proms", 0 )
+	ROM_LOAD( "1.12f",        0x0000, 0x0020, CRC(43989681) SHA1(0d471e6f499294f2f62f27392b8370e2af8e38a3) ) /* palette */
+	ROM_LOAD( "2.4a",         0x0020, 0x0020, CRC(9adabf46) SHA1(f3538fdbc4280b6be46a4d7ebb4c34bd1a1ce2b7) ) /* sprite color lookup table */
+	ROM_LOAD( "3.11e",        0x0040, 0x0020, CRC(27fa3a50) SHA1(7cf59b7a37c156640d6ea91554d1c4276c1780e0) ) /* ?? */
 ROM_END
 
 // 2 PCB set (K-00A and K-00B)
@@ -587,8 +586,7 @@ GAME( 1980, zerohour,  0,        zerohour, zerohour, redclash_state, init_redcla
 GAME( 1980, zerohoura, zerohour, zerohour, zerohour, redclash_state, init_redclash, ROT270, "Universal",                   "Zero Hour (set 2)",      MACHINE_NO_SOUND | MACHINE_WRONG_COLORS | MACHINE_IMPERFECT_GRAPHICS | MACHINE_SUPPORTS_SAVE )
 GAME( 1980, zerohouri, zerohour, zerohour, zerohour, redclash_state, init_redclash, ROT270, "bootleg (Inder SA)",          "Zero Hour (Inder)",      MACHINE_NO_SOUND | MACHINE_WRONG_COLORS | MACHINE_IMPERFECT_GRAPHICS | MACHINE_SUPPORTS_SAVE )
 
-// Red Clash seems to be a Kaneko game? (There is the Cat 'Neko' logo in the bottom corner of all sets, and the Suntronics set doesn't even mentioning Tehkan)  This should be verified, and if true these should be reparented.
-GAME( 1981, redclash,  0,        redclash, redclash, redclash_state, init_redclash, ROT270, "Tehkan",                      "Red Clash (set 1)",      MACHINE_NO_SOUND | MACHINE_WRONG_COLORS | MACHINE_IMPERFECT_GRAPHICS | MACHINE_SUPPORTS_SAVE )
-GAME( 1981, redclasha, redclash, redclash, redclash, redclash_state, init_redclash, ROT270, "Tehkan",                      "Red Clash (set 2)",      MACHINE_NO_SOUND | MACHINE_WRONG_COLORS | MACHINE_IMPERFECT_GRAPHICS | MACHINE_SUPPORTS_SAVE )
-GAME( 1981, redclashk, redclash, redclash, redclash, redclash_state, init_redclash, ROT270, "Tehkan (Kaneko license)",     "Red Clash (Kaneko)",     MACHINE_NO_SOUND | MACHINE_WRONG_COLORS | MACHINE_IMPERFECT_GRAPHICS | MACHINE_SUPPORTS_SAVE )
-GAME( 1982, redclashs, redclash, redclash, redclash, redclash_state, init_redclash, ROT270, "Tehkan (Suntronics license)", "Red Clash (Suntronics)", MACHINE_NO_SOUND | MACHINE_WRONG_COLORS | MACHINE_IMPERFECT_GRAPHICS | MACHINE_SUPPORTS_SAVE )
+GAME( 1981, redclash,   0,        redclash, redclash, redclash_state, init_redclash, ROT270, "Kaneko",                      "Red Clash",                 MACHINE_NO_SOUND | MACHINE_WRONG_COLORS | MACHINE_IMPERFECT_GRAPHICS | MACHINE_SUPPORTS_SAVE )
+GAME( 1981, redclasht,  redclash, redclash, redclash, redclash_state, init_redclash, ROT270, "Kaneko (Tehkan license)",     "Red Clash (Tehkan, set 1)", MACHINE_NO_SOUND | MACHINE_WRONG_COLORS | MACHINE_IMPERFECT_GRAPHICS | MACHINE_SUPPORTS_SAVE )
+GAME( 1981, redclashta, redclash, redclash, redclash, redclash_state, init_redclash, ROT270, "Kaneko (Tehkan license)",     "Red Clash (Tehkan, set 2)", MACHINE_NO_SOUND | MACHINE_WRONG_COLORS | MACHINE_IMPERFECT_GRAPHICS | MACHINE_SUPPORTS_SAVE )
+GAME( 1982, redclashs,  redclash, redclash, redclash, redclash_state, init_redclash, ROT270, "Kaneko (Suntronics license)", "Red Clash (Suntronics)",    MACHINE_NO_SOUND | MACHINE_WRONG_COLORS | MACHINE_IMPERFECT_GRAPHICS | MACHINE_SUPPORTS_SAVE )

--- a/src/mame/drivers/redclash.cpp
+++ b/src/mame/drivers/redclash.cpp
@@ -586,6 +586,8 @@ void redclash_state::init_redclash()
 GAME( 1980, zerohour,  0,        zerohour, zerohour, redclash_state, init_redclash, ROT270, "Universal",                   "Zero Hour (set 1)",      MACHINE_NO_SOUND | MACHINE_WRONG_COLORS | MACHINE_IMPERFECT_GRAPHICS | MACHINE_SUPPORTS_SAVE )
 GAME( 1980, zerohoura, zerohour, zerohour, zerohour, redclash_state, init_redclash, ROT270, "Universal",                   "Zero Hour (set 2)",      MACHINE_NO_SOUND | MACHINE_WRONG_COLORS | MACHINE_IMPERFECT_GRAPHICS | MACHINE_SUPPORTS_SAVE )
 GAME( 1980, zerohouri, zerohour, zerohour, zerohour, redclash_state, init_redclash, ROT270, "bootleg (Inder SA)",          "Zero Hour (Inder)",      MACHINE_NO_SOUND | MACHINE_WRONG_COLORS | MACHINE_IMPERFECT_GRAPHICS | MACHINE_SUPPORTS_SAVE )
+
+// Red Clash seems to be a Kaneko game? (There is the Cat 'Neko' logo in the bottom corner of all sets, and the Suntronics set doesn't even mentioning Tehkan)  This should be verified, and if true these should be reparented.
 GAME( 1981, redclash,  0,        redclash, redclash, redclash_state, init_redclash, ROT270, "Tehkan",                      "Red Clash (set 1)",      MACHINE_NO_SOUND | MACHINE_WRONG_COLORS | MACHINE_IMPERFECT_GRAPHICS | MACHINE_SUPPORTS_SAVE )
 GAME( 1981, redclasha, redclash, redclash, redclash, redclash_state, init_redclash, ROT270, "Tehkan",                      "Red Clash (set 2)",      MACHINE_NO_SOUND | MACHINE_WRONG_COLORS | MACHINE_IMPERFECT_GRAPHICS | MACHINE_SUPPORTS_SAVE )
 GAME( 1981, redclashk, redclash, redclash, redclash, redclash_state, init_redclash, ROT270, "Tehkan (Kaneko license)",     "Red Clash (Kaneko)",     MACHINE_NO_SOUND | MACHINE_WRONG_COLORS | MACHINE_IMPERFECT_GRAPHICS | MACHINE_SUPPORTS_SAVE )

--- a/src/mame/drivers/tomy_princ.cpp
+++ b/src/mame/drivers/tomy_princ.cpp
@@ -1,0 +1,65 @@
+// license:BSD-3-Clause
+// copyright-holders:David Haywood
+
+/************************************************************************
+
+ Prin-C use a Fujitsu MB90611A MCU (F2MC-16L)
+
+************************************************************************/
+
+#include "emu.h"
+#include "screen.h"
+#include "speaker.h"
+#include "bus/generic/slot.h"
+#include "bus/generic/carts.h"
+
+class tomy_princ_state : public driver_device
+{
+public:
+	tomy_princ_state(const machine_config &mconfig, device_type type, const char *tag) :
+		driver_device(mconfig, type, tag)
+		, m_cart(*this, "cartslot")
+		, m_screen(*this, "screen")
+	{ }
+
+	void tomy_princ(machine_config &config);
+
+protected:
+
+private:
+	required_device<generic_slot_device> m_cart;
+	required_device<screen_device> m_screen;
+
+	uint32_t screen_update_tomy_princ(screen_device &screen, bitmap_rgb32 &bitmap, const rectangle &cliprect);
+};
+
+
+uint32_t tomy_princ_state::screen_update_tomy_princ(screen_device &screen, bitmap_rgb32 &bitmap, const rectangle &cliprect)
+{
+	return 0;
+}
+
+static INPUT_PORTS_START( tomy_princ )
+INPUT_PORTS_END
+
+void tomy_princ_state::tomy_princ(machine_config &config)
+{
+	// F2MC-16L based CPU
+
+	SCREEN(config, m_screen, SCREEN_TYPE_RASTER);
+	m_screen->set_refresh_hz(60);
+	m_screen->set_vblank_time(ATTOSECONDS_IN_USEC(2500)); /* not accurate */
+	m_screen->set_screen_update(FUNC(tomy_princ_state::screen_update_tomy_princ));
+	m_screen->set_size(256, 256);
+	m_screen->set_visarea(0, 256-1, 0, 256-1);
+
+	GENERIC_CARTSLOT(config, m_cart, generic_plain_slot, "princ_cart");
+	SOFTWARE_LIST(config, "cart_list").set_original("princ");
+}
+
+ROM_START( princ )
+	ROM_REGION( 0x100000, "maincpu", 0 )
+	ROM_LOAD("29f800t.u4", 0x00000, 0x100000, CRC(30b6b864) SHA1(7ada3af85dd8dd3f95ca8965ad8e642c26445293))
+ROM_END
+
+COMP( ????, princ,    0,       0,      tomy_princ,    tomy_princ, tomy_princ_state, empty_init, "Tomy", "Prin-C", MACHINE_IS_SKELETON )

--- a/src/mame/drivers/tomy_princ.cpp
+++ b/src/mame/drivers/tomy_princ.cpp
@@ -62,4 +62,4 @@ ROM_START( princ )
 	ROM_LOAD("29f800t.u4", 0x00000, 0x100000, CRC(30b6b864) SHA1(7ada3af85dd8dd3f95ca8965ad8e642c26445293))
 ROM_END
 
-COMP( ????, princ,    0,       0,      tomy_princ,    tomy_princ, tomy_princ_state, empty_init, "Tomy", "Prin-C", MACHINE_IS_SKELETON )
+COMP( 1996?, princ,    0,       0,      tomy_princ,    tomy_princ, tomy_princ_state, empty_init, "Tomy", "Prin-C", MACHINE_IS_SKELETON )

--- a/src/mame/mame.lst
+++ b/src/mame/mame.lst
@@ -33604,10 +33604,10 @@ redalert                        // M27 (c) 1981 + "GDI presents"
 ww3                             // M27 (c) 1981
 
 @source:redclash.cpp
-redclash                        // (c) 1981 Tehkan
-redclasha                       // (c) 1981 Tehkan
-redclashk                       // (c) Kaneko (bootleg?)
-redclashs                       // (c) Suntronics (licensed?)
+redclash                        // (c) Kaneko
+redclasht                       // (c) 1981 Tehkan
+redclashta                      // (c) 1981 Tehkan
+redclashs                       // (c) Suntronics
 zerohour                        // 8011 (c) Universal
 zerohoura                       // 8011 (c) Universal
 zerohouri                       //

--- a/src/mame/mame.lst
+++ b/src/mame/mame.lst
@@ -33000,7 +33000,6 @@ prestige                        // PreComputer Prestige Elite
 snotec                          // Bandai Super Note Club (Japan)
 snotecex                        // Bandai Super Note Club EX (Japan)
 snotecu                         // Bandai Super Note Club U (Japan)
-princ                           // Tomy Prin-C (Japan)
 
 @source:primo.cpp
 primoa32                        // Primo A-32
@@ -38270,6 +38269,9 @@ tokims
 
 @source:tomcat.cpp
 tomcat                          // (proto)          (c) 1985
+
+@source:tomy_princ.cpp
+princ                           // Tomy Prin-C (Japan)
 
 @source:tonton.cpp
 tonton                          // (c) 199? Success / Taiyo Jidoki.

--- a/src/mame/mess.flt
+++ b/src/mame/mess.flt
@@ -822,6 +822,7 @@ tmc1800.cpp
 tmc2000e.cpp
 tmc600.cpp
 tosh1000.cpp
+tomy_princ.cpp
 tr175.cpp
 tr606.cpp
 tranz330.cpp


### PR DESCRIPTION
- move princ out of prestige.cpp (it should have never been put there) and into a new driver
- fix graphic alignment on the salter gym machines, also promote htem both to working (the hang I saw before on cycle doesn't seem to happen now)
- re-parented the Red Clash sets based on evidence suggesting it is a Kaneko game

note, princ uses a F2MC-16L based CPU, I don't believe we have a core, but there are plenty of docs available should somebody want to write a disassembler at least.