### PR TITLE
Changed the various usages of UI_*COLOR to be calls to src/frontend/mame/ui/moptions.h

### DIFF
--- a/src/frontend/mame/luaengine.cpp
+++ b/src/frontend/mame/luaengine.cpp
@@ -2067,7 +2067,7 @@ void lua_engine::initialize()
 						luaL_error(m_lua_state, "Error in param 1 to draw_text");
 						return;
 					}
-					rgb_t textcolor = UI_TEXT_COLOR;
+					rgb_t textcolor = mame_machine_manager::instance()->ui().options().text_color();
 					rgb_t bgcolor = 0;
 					if(color.is<uint32_t>())
 						textcolor = rgb_t(color.as<uint32_t>());

--- a/src/frontend/mame/luaengine.cpp
+++ b/src/frontend/mame/luaengine.cpp
@@ -2067,7 +2067,7 @@ void lua_engine::initialize()
 						luaL_error(m_lua_state, "Error in param 1 to draw_text");
 						return;
 					}
-					rgb_t textcolor = mame_machine_manager::instance()->ui().options().text_color();
+					rgb_t textcolor = mame_machine_manager::instance()->ui().colors().text_color();
 					rgb_t bgcolor = 0;
 					if(color.is<uint32_t>())
 						textcolor = rgb_t(color.as<uint32_t>());

--- a/src/frontend/mame/ui/auditmenu.cpp
+++ b/src/frontend/mame/ui/auditmenu.cpp
@@ -117,7 +117,7 @@ void menu_audit::custom_render(void *selectedref, float top, float bottom, float
 				std::begin(m_prompt), std::end(m_prompt),
 				x, x2, y - top, y - UI_BOX_TB_BORDER,
 				ui::text_layout::CENTER, ui::text_layout::NEVER, false,
-				UI_TEXT_COLOR, UI_GREEN_COLOR, 1.0f);
+				ui().options().text_color(), UI_GREEN_COLOR, 1.0f);
 		break;
 
 	case phase::AUDIT:

--- a/src/frontend/mame/ui/auditmenu.cpp
+++ b/src/frontend/mame/ui/auditmenu.cpp
@@ -117,7 +117,7 @@ void menu_audit::custom_render(void *selectedref, float top, float bottom, float
 				std::begin(m_prompt), std::end(m_prompt),
 				x, x2, y - top, y - UI_BOX_TB_BORDER,
 				ui::text_layout::CENTER, ui::text_layout::NEVER, false,
-				ui().options().text_color(), UI_GREEN_COLOR, 1.0f);
+				ui().colors().text_color(), UI_GREEN_COLOR, 1.0f);
 		break;
 
 	case phase::AUDIT:

--- a/src/frontend/mame/ui/custui.cpp
+++ b/src/frontend/mame/ui/custui.cpp
@@ -175,7 +175,7 @@ void menu_custom_ui::custom_render(void *selectedref, float top, float bottom, f
 			std::begin(text), std::end(text),
 			origx1, origx2, origy1 - top, origy1 - UI_BOX_TB_BORDER,
 			ui::text_layout::CENTER, ui::text_layout::TRUNCATE, false,
-			ui().options().text_color(), UI_GREEN_COLOR, 1.0f);
+			ui().colors().text_color(), UI_GREEN_COLOR, 1.0f);
 }
 
 //-------------------------------------------------
@@ -364,7 +364,7 @@ void menu_font_ui::custom_render(void *selectedref, float top, float bottom, flo
 			std::begin(toptext), std::end(toptext),
 			origx1, origx2, origy1 - top, origy1 - UI_BOX_TB_BORDER,
 			ui::text_layout::CENTER, ui::text_layout::TRUNCATE, false,
-			ui().options().text_color(), UI_GREEN_COLOR, 1.0f);
+			ui().colors().text_color(), UI_GREEN_COLOR, 1.0f);
 
 	if (uintptr_t(selectedref) == INFOS_SIZE)
 	{
@@ -373,7 +373,7 @@ void menu_font_ui::custom_render(void *selectedref, float top, float bottom, flo
 				std::begin(bottomtext), std::end(bottomtext),
 				origx1, origx2, origy2 + UI_BOX_TB_BORDER, origy2 + bottom,
 				ui::text_layout::LEFT, ui::text_layout::NEVER, false,
-				ui().options().text_color(), UI_GREEN_COLOR, m_info_size);
+				ui().colors().text_color(), UI_GREEN_COLOR, m_info_size);
 	}
 }
 
@@ -414,6 +414,9 @@ menu_colors_ui::~menu_colors_ui()
 		dec_color = string_format("%x", (uint32_t)m_color_table[index].color);
 		ui().options().set_value(m_color_table[index].option, dec_color.c_str(), OPTION_PRIORITY_CMDLINE);
 	}
+
+	// refresh our cached colors
+	ui().colors().refresh(ui().options());
 }
 
 //-------------------------------------------------
@@ -483,7 +486,7 @@ void menu_colors_ui::custom_render(void *selectedref, float top, float bottom, f
 			std::begin(toptext), std::end(toptext),
 			origx1, origx2, origy1 - top, origy1 - UI_BOX_TB_BORDER,
 			ui::text_layout::CENTER, ui::text_layout::TRUNCATE, false,
-			ui().options().text_color(), UI_GREEN_COLOR, 1.0f);
+			ui().colors().text_color(), UI_GREEN_COLOR, 1.0f);
 
 	// bottom text
 	// get the text for 'UI Select'
@@ -492,7 +495,7 @@ void menu_colors_ui::custom_render(void *selectedref, float top, float bottom, f
 			std::begin(bottomtext), std::end(bottomtext),
 			origx1, origx2, origy2 + UI_BOX_TB_BORDER, origy2 + bottom,
 			ui::text_layout::CENTER, ui::text_layout::TRUNCATE, false,
-			ui().options().text_color(), UI_RED_COLOR, 1.0f);
+			ui().colors().text_color(), UI_RED_COLOR, 1.0f);
 
 	// compute maxwidth
 	char const *const topbuf = _("Menu Preview");
@@ -535,7 +538,7 @@ void menu_colors_ui::custom_render(void *selectedref, float top, float bottom, f
 
 	// draw the text within it
 	ui().draw_text_full(container(), topbuf, x1, y1, x2 - x1, ui::text_layout::CENTER, ui::text_layout::NEVER,
-									mame_ui_manager::NORMAL, ui().options().text_color(), ui().options().text_bg_color(), nullptr, nullptr);
+									mame_ui_manager::NORMAL, ui().colors().text_color(), ui().colors().text_bg_color(), nullptr, nullptr);
 
 	// compute our bounds for menu preview
 	float line_height = ui().get_line_height();
@@ -808,7 +811,7 @@ void menu_rgb_ui::custom_render(void *selectedref, float top, float bottom, floa
 
 	// draw the text within it
 	ui().draw_text_full(container(), m_title.c_str(), x1, y1, x2 - x1, ui::text_layout::CENTER, ui::text_layout::NEVER,
-						mame_ui_manager::NORMAL, ui().options().text_color(), ui().options().text_bg_color());
+						mame_ui_manager::NORMAL, ui().colors().text_color(), ui().colors().text_bg_color());
 
 	std::string sampletxt(_("Color preview ="));
 	ui().draw_text_full(container(), sampletxt.c_str(), 0.0f, 0.0f, 1.0f, ui::text_layout::CENTER, ui::text_layout::NEVER,

--- a/src/frontend/mame/ui/custui.cpp
+++ b/src/frontend/mame/ui/custui.cpp
@@ -175,7 +175,7 @@ void menu_custom_ui::custom_render(void *selectedref, float top, float bottom, f
 			std::begin(text), std::end(text),
 			origx1, origx2, origy1 - top, origy1 - UI_BOX_TB_BORDER,
 			ui::text_layout::CENTER, ui::text_layout::TRUNCATE, false,
-			UI_TEXT_COLOR, UI_GREEN_COLOR, 1.0f);
+			ui().options().text_color(), UI_GREEN_COLOR, 1.0f);
 }
 
 //-------------------------------------------------
@@ -364,7 +364,7 @@ void menu_font_ui::custom_render(void *selectedref, float top, float bottom, flo
 			std::begin(toptext), std::end(toptext),
 			origx1, origx2, origy1 - top, origy1 - UI_BOX_TB_BORDER,
 			ui::text_layout::CENTER, ui::text_layout::TRUNCATE, false,
-			UI_TEXT_COLOR, UI_GREEN_COLOR, 1.0f);
+			ui().options().text_color(), UI_GREEN_COLOR, 1.0f);
 
 	if (uintptr_t(selectedref) == INFOS_SIZE)
 	{
@@ -373,14 +373,14 @@ void menu_font_ui::custom_render(void *selectedref, float top, float bottom, flo
 				std::begin(bottomtext), std::end(bottomtext),
 				origx1, origx2, origy2 + UI_BOX_TB_BORDER, origy2 + bottom,
 				ui::text_layout::LEFT, ui::text_layout::NEVER, false,
-				UI_TEXT_COLOR, UI_GREEN_COLOR, m_info_size);
+				ui().options().text_color(), UI_GREEN_COLOR, m_info_size);
 	}
 }
 
 //-------------------------------------------------
 //  ctor
 //-------------------------------------------------
-#define SET_COLOR_UI(var, opt) var[M##opt].color = opt; var[M##opt].option = OPTION_##opt
+#define SET_COLOR_UI(var, opt) var[M##opt].color = mui.options().rgb_value(OPTION_##opt); var[M##opt].option = OPTION_##opt
 
 menu_colors_ui::menu_colors_ui(mame_ui_manager &mui, render_container &container) : menu(mui, container)
 {
@@ -483,7 +483,7 @@ void menu_colors_ui::custom_render(void *selectedref, float top, float bottom, f
 			std::begin(toptext), std::end(toptext),
 			origx1, origx2, origy1 - top, origy1 - UI_BOX_TB_BORDER,
 			ui::text_layout::CENTER, ui::text_layout::TRUNCATE, false,
-			UI_TEXT_COLOR, UI_GREEN_COLOR, 1.0f);
+			ui().options().text_color(), UI_GREEN_COLOR, 1.0f);
 
 	// bottom text
 	// get the text for 'UI Select'
@@ -492,7 +492,7 @@ void menu_colors_ui::custom_render(void *selectedref, float top, float bottom, f
 			std::begin(bottomtext), std::end(bottomtext),
 			origx1, origx2, origy2 + UI_BOX_TB_BORDER, origy2 + bottom,
 			ui::text_layout::CENTER, ui::text_layout::TRUNCATE, false,
-			UI_TEXT_COLOR, UI_RED_COLOR, 1.0f);
+			ui().options().text_color(), UI_RED_COLOR, 1.0f);
 
 	// compute maxwidth
 	char const *const topbuf = _("Menu Preview");
@@ -535,7 +535,7 @@ void menu_colors_ui::custom_render(void *selectedref, float top, float bottom, f
 
 	// draw the text within it
 	ui().draw_text_full(container(), topbuf, x1, y1, x2 - x1, ui::text_layout::CENTER, ui::text_layout::NEVER,
-									mame_ui_manager::NORMAL, UI_TEXT_COLOR, UI_TEXT_BG_COLOR, nullptr, nullptr);
+									mame_ui_manager::NORMAL, ui().options().text_color(), ui().options().text_bg_color(), nullptr, nullptr);
 
 	// compute our bounds for menu preview
 	float line_height = ui().get_line_height();
@@ -808,7 +808,7 @@ void menu_rgb_ui::custom_render(void *selectedref, float top, float bottom, floa
 
 	// draw the text within it
 	ui().draw_text_full(container(), m_title.c_str(), x1, y1, x2 - x1, ui::text_layout::CENTER, ui::text_layout::NEVER,
-						mame_ui_manager::NORMAL, UI_TEXT_COLOR, UI_TEXT_BG_COLOR);
+						mame_ui_manager::NORMAL, ui().options().text_color(), ui().options().text_bg_color());
 
 	std::string sampletxt(_("Color preview ="));
 	ui().draw_text_full(container(), sampletxt.c_str(), 0.0f, 0.0f, 1.0f, ui::text_layout::CENTER, ui::text_layout::NEVER,

--- a/src/frontend/mame/ui/datmenu.cpp
+++ b/src/frontend/mame/ui/datmenu.cpp
@@ -180,7 +180,7 @@ void menu_dats_view::draw(uint32_t flags)
 	float y2 = visible_top + visible_main_menu_height + UI_BOX_TB_BORDER + extra_height;
 	float line = visible_top + float(m_visible_lines) * line_height;
 
-	ui().draw_outlined_box(container(), x1, y1, x2, y2, ui().options().background_color());
+	ui().draw_outlined_box(container(), x1, y1, x2, y2, ui().colors().background_color());
 
 	m_visible_lines = (std::min)(visible_items, m_visible_lines);
 	top_line = (std::max)(0, top_line);
@@ -200,16 +200,16 @@ void menu_dats_view::draw(uint32_t flags)
 		float const line_x1 = x2 - 0.5f * UI_LINE_WIDTH;
 		float const line_y1 = line_y + line_height;
 
-		rgb_t fgcolor = ui().options().text_color();
-		rgb_t bgcolor = ui().options().text_bg_color();
+		rgb_t fgcolor = ui().colors().text_color();
+		rgb_t bgcolor = ui().colors().text_bg_color();
 
 		if (!linenum && top_line)
 		{
 			// if we're on the top line, display the up arrow
 			if (mouse_in_rect(line_x0, line_y0, line_x1, line_y1))
 			{
-				fgcolor = ui().options().mouseover_color();
-				bgcolor = ui().options().mouseover_bg_color();
+				fgcolor = ui().colors().mouseover_color();
+				bgcolor = ui().colors().mouseover_bg_color();
 				highlight(line_x0, line_y0, line_x1, line_y1, bgcolor);
 				set_hover(HOVER_ARROW_UP);
 			}
@@ -223,8 +223,8 @@ void menu_dats_view::draw(uint32_t flags)
 			// if we're on the bottom line, display the down arrow
 			if (mouse_in_rect(line_x0, line_y0, line_x1, line_y1))
 			{
-				fgcolor = ui().options().mouseover_color();
-				bgcolor = ui().options().mouseover_bg_color();
+				fgcolor = ui().colors().mouseover_color();
+				bgcolor = ui().colors().mouseover_bg_color();
 				highlight(line_x0, line_y0, line_x1, line_y1, bgcolor);
 				set_hover(HOVER_ARROW_DOWN);
 			}
@@ -253,8 +253,8 @@ void menu_dats_view::draw(uint32_t flags)
 		float const line_y0 = line;
 		float const line_x1 = x2 - 0.5f * UI_LINE_WIDTH;
 		float const line_y1 = line + line_height;
-		rgb_t const fgcolor = ui().options().selected_color();
-		rgb_t const bgcolor = ui().options().selected_bg_color();
+		rgb_t const fgcolor = ui().colors().selected_color();
+		rgb_t const bgcolor = ui().colors().selected_bg_color();
 
 		if (mouse_in_rect(line_x0, line_y0, line_x1, line_y1) && is_selectable(pitem))
 			set_hover(count);
@@ -263,7 +263,7 @@ void menu_dats_view::draw(uint32_t flags)
 		{
 			container().add_line(
 					visible_left, line + 0.5f * line_height, visible_left + visible_width, line + 0.5f * line_height,
-					UI_LINE_WIDTH, ui().options().text_color(), PRIMFLAG_BLENDMODE(BLENDMODE_ALPHA));
+					UI_LINE_WIDTH, ui().colors().text_color(), PRIMFLAG_BLENDMODE(BLENDMODE_ALPHA));
 		}
 		else
 		{
@@ -315,7 +315,7 @@ void menu_dats_view::custom_render(void *selectedref, float top, float bottom, f
 	y1 += UI_BOX_TB_BORDER;
 
 	ui().draw_text_full(container(), driver.c_str(), x1, y1, x2 - x1, ui::text_layout::CENTER, ui::text_layout::NEVER,
-		mame_ui_manager::NORMAL, ui().options().text_color(), ui().options().text_bg_color(), nullptr, nullptr);
+		mame_ui_manager::NORMAL, ui().colors().text_color(), ui().colors().text_bg_color(), nullptr, nullptr);
 
 	maxwidth = 0;
 	for (auto & elem : m_items_list)
@@ -334,7 +334,7 @@ void menu_dats_view::custom_render(void *selectedref, float top, float bottom, f
 	y2 += ui().get_line_height() + 2.0f * UI_BOX_TB_BORDER;
 
 	// draw a box
-	ui().draw_outlined_box(container(), x1, y1, x2, y2, ui().options().background_color());
+	ui().draw_outlined_box(container(), x1, y1, x2, y2, ui().colors().background_color());
 
 	// take off the borders
 	y1 += UI_BOX_TB_BORDER;
@@ -344,11 +344,11 @@ void menu_dats_view::custom_render(void *selectedref, float top, float bottom, f
 	for (auto & elem : m_items_list)
 	{
 		x1 += space;
-		rgb_t fcolor = (m_actual == x) ? rgb_t(0xff, 0xff, 0xff, 0x00) : ui().options().text_color();
-		rgb_t bcolor = (m_actual == x) ? rgb_t(0xff, 0xff, 0xff, 0xff) : ui().options().text_bg_color();
+		rgb_t fcolor = (m_actual == x) ? rgb_t(0xff, 0xff, 0xff, 0x00) : ui().colors().text_color();
+		rgb_t bcolor = (m_actual == x) ? rgb_t(0xff, 0xff, 0xff, 0xff) : ui().colors().text_bg_color();
 		ui().draw_text_full(container(), elem.label.c_str(), x1, y1, 1.0f, ui::text_layout::LEFT, ui::text_layout::NEVER, mame_ui_manager::NONE, fcolor, bcolor, &width, nullptr);
 
-		if (bcolor != ui().options().text_bg_color())
+		if (bcolor != ui().colors().text_bg_color())
 			ui().draw_textured_box(container(), x1 - (space / 2), y1, x1 + width + (space / 2), y2, bcolor, rgb_t(255, 43, 43, 43),
 				hilight_main_texture(), PRIMFLAG_BLENDMODE(BLENDMODE_ALPHA) | PRIMFLAG_TEXWRAP(1));
 
@@ -380,7 +380,7 @@ void menu_dats_view::custom_render(void *selectedref, float top, float bottom, f
 
 	// draw the text within it
 	ui().draw_text_full(container(), revision.c_str(), x1, y1, x2 - x1, ui::text_layout::CENTER, ui::text_layout::TRUNCATE,
-		mame_ui_manager::NORMAL, ui().options().text_color(), ui().options().text_bg_color(), nullptr, nullptr);
+		mame_ui_manager::NORMAL, ui().colors().text_color(), ui().colors().text_bg_color(), nullptr, nullptr);
 }
 
 //-------------------------------------------------

--- a/src/frontend/mame/ui/datmenu.cpp
+++ b/src/frontend/mame/ui/datmenu.cpp
@@ -180,7 +180,7 @@ void menu_dats_view::draw(uint32_t flags)
 	float y2 = visible_top + visible_main_menu_height + UI_BOX_TB_BORDER + extra_height;
 	float line = visible_top + float(m_visible_lines) * line_height;
 
-	ui().draw_outlined_box(container(), x1, y1, x2, y2, UI_BACKGROUND_COLOR);
+	ui().draw_outlined_box(container(), x1, y1, x2, y2, ui().options().background_color());
 
 	m_visible_lines = (std::min)(visible_items, m_visible_lines);
 	top_line = (std::max)(0, top_line);
@@ -200,16 +200,16 @@ void menu_dats_view::draw(uint32_t flags)
 		float const line_x1 = x2 - 0.5f * UI_LINE_WIDTH;
 		float const line_y1 = line_y + line_height;
 
-		rgb_t fgcolor = UI_TEXT_COLOR;
-		rgb_t bgcolor = UI_TEXT_BG_COLOR;
+		rgb_t fgcolor = ui().options().text_color();
+		rgb_t bgcolor = ui().options().text_bg_color();
 
 		if (!linenum && top_line)
 		{
 			// if we're on the top line, display the up arrow
 			if (mouse_in_rect(line_x0, line_y0, line_x1, line_y1))
 			{
-				fgcolor = UI_MOUSEOVER_COLOR;
-				bgcolor = UI_MOUSEOVER_BG_COLOR;
+				fgcolor = ui().options().mouseover_color();
+				bgcolor = ui().options().mouseover_bg_color();
 				highlight(line_x0, line_y0, line_x1, line_y1, bgcolor);
 				set_hover(HOVER_ARROW_UP);
 			}
@@ -223,8 +223,8 @@ void menu_dats_view::draw(uint32_t flags)
 			// if we're on the bottom line, display the down arrow
 			if (mouse_in_rect(line_x0, line_y0, line_x1, line_y1))
 			{
-				fgcolor = UI_MOUSEOVER_COLOR;
-				bgcolor = UI_MOUSEOVER_BG_COLOR;
+				fgcolor = ui().options().mouseover_color();
+				bgcolor = ui().options().mouseover_bg_color();
 				highlight(line_x0, line_y0, line_x1, line_y1, bgcolor);
 				set_hover(HOVER_ARROW_DOWN);
 			}
@@ -253,8 +253,8 @@ void menu_dats_view::draw(uint32_t flags)
 		float const line_y0 = line;
 		float const line_x1 = x2 - 0.5f * UI_LINE_WIDTH;
 		float const line_y1 = line + line_height;
-		rgb_t const fgcolor = UI_SELECTED_COLOR;
-		rgb_t const bgcolor = UI_SELECTED_BG_COLOR;
+		rgb_t const fgcolor = ui().options().selected_color();
+		rgb_t const bgcolor = ui().options().selected_bg_color();
 
 		if (mouse_in_rect(line_x0, line_y0, line_x1, line_y1) && is_selectable(pitem))
 			set_hover(count);
@@ -263,7 +263,7 @@ void menu_dats_view::draw(uint32_t flags)
 		{
 			container().add_line(
 					visible_left, line + 0.5f * line_height, visible_left + visible_width, line + 0.5f * line_height,
-					UI_LINE_WIDTH, UI_TEXT_COLOR, PRIMFLAG_BLENDMODE(BLENDMODE_ALPHA));
+					UI_LINE_WIDTH, ui().options().text_color(), PRIMFLAG_BLENDMODE(BLENDMODE_ALPHA));
 		}
 		else
 		{
@@ -315,7 +315,7 @@ void menu_dats_view::custom_render(void *selectedref, float top, float bottom, f
 	y1 += UI_BOX_TB_BORDER;
 
 	ui().draw_text_full(container(), driver.c_str(), x1, y1, x2 - x1, ui::text_layout::CENTER, ui::text_layout::NEVER,
-		mame_ui_manager::NORMAL, UI_TEXT_COLOR, UI_TEXT_BG_COLOR, nullptr, nullptr);
+		mame_ui_manager::NORMAL, ui().options().text_color(), ui().options().text_bg_color(), nullptr, nullptr);
 
 	maxwidth = 0;
 	for (auto & elem : m_items_list)
@@ -334,7 +334,7 @@ void menu_dats_view::custom_render(void *selectedref, float top, float bottom, f
 	y2 += ui().get_line_height() + 2.0f * UI_BOX_TB_BORDER;
 
 	// draw a box
-	ui().draw_outlined_box(container(), x1, y1, x2, y2, UI_BACKGROUND_COLOR);
+	ui().draw_outlined_box(container(), x1, y1, x2, y2, ui().options().background_color());
 
 	// take off the borders
 	y1 += UI_BOX_TB_BORDER;
@@ -344,11 +344,11 @@ void menu_dats_view::custom_render(void *selectedref, float top, float bottom, f
 	for (auto & elem : m_items_list)
 	{
 		x1 += space;
-		rgb_t fcolor = (m_actual == x) ? rgb_t(0xff, 0xff, 0xff, 0x00) : UI_TEXT_COLOR;
-		rgb_t bcolor = (m_actual == x) ? rgb_t(0xff, 0xff, 0xff, 0xff) : UI_TEXT_BG_COLOR;
+		rgb_t fcolor = (m_actual == x) ? rgb_t(0xff, 0xff, 0xff, 0x00) : ui().options().text_color();
+		rgb_t bcolor = (m_actual == x) ? rgb_t(0xff, 0xff, 0xff, 0xff) : ui().options().text_bg_color();
 		ui().draw_text_full(container(), elem.label.c_str(), x1, y1, 1.0f, ui::text_layout::LEFT, ui::text_layout::NEVER, mame_ui_manager::NONE, fcolor, bcolor, &width, nullptr);
 
-		if (bcolor != UI_TEXT_BG_COLOR)
+		if (bcolor != ui().options().text_bg_color())
 			ui().draw_textured_box(container(), x1 - (space / 2), y1, x1 + width + (space / 2), y2, bcolor, rgb_t(255, 43, 43, 43),
 				hilight_main_texture(), PRIMFLAG_BLENDMODE(BLENDMODE_ALPHA) | PRIMFLAG_TEXWRAP(1));
 
@@ -380,7 +380,7 @@ void menu_dats_view::custom_render(void *selectedref, float top, float bottom, f
 
 	// draw the text within it
 	ui().draw_text_full(container(), revision.c_str(), x1, y1, x2 - x1, ui::text_layout::CENTER, ui::text_layout::TRUNCATE,
-		mame_ui_manager::NORMAL, UI_TEXT_COLOR, UI_TEXT_BG_COLOR, nullptr, nullptr);
+		mame_ui_manager::NORMAL, ui().options().text_color(), ui().options().text_bg_color(), nullptr, nullptr);
 }
 
 //-------------------------------------------------

--- a/src/frontend/mame/ui/dirmenu.cpp
+++ b/src/frontend/mame/ui/dirmenu.cpp
@@ -118,7 +118,7 @@ void menu_directory::custom_render(void *selectedref, float top, float bottom, f
 			std::begin(toptext), std::end(toptext),
 			origx1, origx2, origy1 - top, origy1 - UI_BOX_TB_BORDER,
 			ui::text_layout::CENTER, ui::text_layout::TRUNCATE, false,
-			UI_TEXT_COLOR, UI_GREEN_COLOR, 1.0f);
+			ui().options().text_color(), UI_GREEN_COLOR, 1.0f);
 }
 
 /**************************************************
@@ -196,12 +196,12 @@ void menu_display_actual::custom_render(void *selectedref, float top, float bott
 			std::begin(m_folders), std::end(m_folders),
 			origx1, origx2, origy1 - (3.0f * UI_BOX_TB_BORDER) - (m_folders.size() * lineheight), origy1 - UI_BOX_TB_BORDER,
 			ui::text_layout::CENTER, ui::text_layout::TRUNCATE, false,
-			UI_TEXT_COLOR, UI_BACKGROUND_COLOR, 1.0f));
+			ui().options().text_color(), ui().options().background_color(), 1.0f));
 	draw_text_box(
 			std::begin(m_heading), std::end(m_heading),
 			0.5f * (1.0f - maxwidth), 0.5f * (1.0f + maxwidth), origy1 - top, origy1 - top + lineheight + (2.0f * UI_BOX_TB_BORDER),
 			ui::text_layout::CENTER, ui::text_layout::TRUNCATE, false,
-			UI_TEXT_COLOR, UI_GREEN_COLOR, 1.0f);
+			ui().options().text_color(), UI_GREEN_COLOR, 1.0f);
 }
 
 /**************************************************
@@ -423,7 +423,7 @@ void menu_add_change_folder::custom_render(void *selectedref, float top, float b
 			std::begin(toptext), std::end(toptext),
 			origx1, origx2, origy1 - top, origy1 - UI_BOX_TB_BORDER,
 			ui::text_layout::CENTER, ui::text_layout::NEVER, false,
-			UI_TEXT_COLOR, UI_GREEN_COLOR, 1.0f);
+			ui().options().text_color(), UI_GREEN_COLOR, 1.0f);
 
 	// bottom text
 	char const *const bottomtext[] = { _("Press TAB to set") };
@@ -431,7 +431,7 @@ void menu_add_change_folder::custom_render(void *selectedref, float top, float b
 			std::begin(bottomtext), std::end(bottomtext),
 			origx1, origx2, origy2 + UI_BOX_TB_BORDER, origy2 + bottom,
 			ui::text_layout::CENTER, ui::text_layout::TRUNCATE, false,
-			UI_TEXT_COLOR, UI_RED_COLOR, 1.0f);
+			ui().options().text_color(), UI_RED_COLOR, 1.0f);
 }
 
 /**************************************************
@@ -515,7 +515,7 @@ void menu_remove_folder::custom_render(void *selectedref, float top, float botto
 			std::begin(toptext), std::end(toptext),
 			origx1, origx2, origy1 - top, origy1 - UI_BOX_TB_BORDER,
 			ui::text_layout::CENTER, ui::text_layout::TRUNCATE, false,
-			UI_TEXT_COLOR, UI_GREEN_COLOR, 1.0f);
+			ui().options().text_color(), UI_GREEN_COLOR, 1.0f);
 }
 
 } // namespace ui

--- a/src/frontend/mame/ui/dirmenu.cpp
+++ b/src/frontend/mame/ui/dirmenu.cpp
@@ -118,7 +118,7 @@ void menu_directory::custom_render(void *selectedref, float top, float bottom, f
 			std::begin(toptext), std::end(toptext),
 			origx1, origx2, origy1 - top, origy1 - UI_BOX_TB_BORDER,
 			ui::text_layout::CENTER, ui::text_layout::TRUNCATE, false,
-			ui().options().text_color(), UI_GREEN_COLOR, 1.0f);
+			ui().colors().text_color(), UI_GREEN_COLOR, 1.0f);
 }
 
 /**************************************************
@@ -196,12 +196,12 @@ void menu_display_actual::custom_render(void *selectedref, float top, float bott
 			std::begin(m_folders), std::end(m_folders),
 			origx1, origx2, origy1 - (3.0f * UI_BOX_TB_BORDER) - (m_folders.size() * lineheight), origy1 - UI_BOX_TB_BORDER,
 			ui::text_layout::CENTER, ui::text_layout::TRUNCATE, false,
-			ui().options().text_color(), ui().options().background_color(), 1.0f));
+			ui().colors().text_color(), ui().colors().background_color(), 1.0f));
 	draw_text_box(
 			std::begin(m_heading), std::end(m_heading),
 			0.5f * (1.0f - maxwidth), 0.5f * (1.0f + maxwidth), origy1 - top, origy1 - top + lineheight + (2.0f * UI_BOX_TB_BORDER),
 			ui::text_layout::CENTER, ui::text_layout::TRUNCATE, false,
-			ui().options().text_color(), UI_GREEN_COLOR, 1.0f);
+			ui().colors().text_color(), UI_GREEN_COLOR, 1.0f);
 }
 
 /**************************************************
@@ -423,7 +423,7 @@ void menu_add_change_folder::custom_render(void *selectedref, float top, float b
 			std::begin(toptext), std::end(toptext),
 			origx1, origx2, origy1 - top, origy1 - UI_BOX_TB_BORDER,
 			ui::text_layout::CENTER, ui::text_layout::NEVER, false,
-			ui().options().text_color(), UI_GREEN_COLOR, 1.0f);
+			ui().colors().text_color(), UI_GREEN_COLOR, 1.0f);
 
 	// bottom text
 	char const *const bottomtext[] = { _("Press TAB to set") };
@@ -431,7 +431,7 @@ void menu_add_change_folder::custom_render(void *selectedref, float top, float b
 			std::begin(bottomtext), std::end(bottomtext),
 			origx1, origx2, origy2 + UI_BOX_TB_BORDER, origy2 + bottom,
 			ui::text_layout::CENTER, ui::text_layout::TRUNCATE, false,
-			ui().options().text_color(), UI_RED_COLOR, 1.0f);
+			ui().colors().text_color(), UI_RED_COLOR, 1.0f);
 }
 
 /**************************************************
@@ -515,7 +515,7 @@ void menu_remove_folder::custom_render(void *selectedref, float top, float botto
 			std::begin(toptext), std::end(toptext),
 			origx1, origx2, origy1 - top, origy1 - UI_BOX_TB_BORDER,
 			ui::text_layout::CENTER, ui::text_layout::TRUNCATE, false,
-			ui().options().text_color(), UI_GREEN_COLOR, 1.0f);
+			ui().colors().text_color(), UI_GREEN_COLOR, 1.0f);
 }
 
 } // namespace ui

--- a/src/frontend/mame/ui/filesel.cpp
+++ b/src/frontend/mame/ui/filesel.cpp
@@ -83,7 +83,7 @@ void menu_file_selector::custom_render(void *selectedref, float top, float botto
 	extra_text_position(origx1, origx2, origy1, top, layout, -1, x1, y1, x2, y2);
 
 	// draw a box
-	ui().draw_outlined_box(container(), x1, y1, x2, y2, UI_BACKGROUND_COLOR);
+	ui().draw_outlined_box(container(), x1, y1, x2, y2, ui().options().background_color());
 
 	// take off the borders
 	x1 += UI_BOX_LR_BORDER;
@@ -100,8 +100,8 @@ void menu_file_selector::custom_render(void *selectedref, float top, float botto
 		m_hover_directory = m_current_directory.substr(0, target_dir_end + strlen(PATH_SEPARATOR));
 
 		// highlight the text in question
-		rgb_t fgcolor = UI_MOUSEOVER_COLOR;
-		rgb_t bgcolor = UI_MOUSEOVER_BG_COLOR;
+		rgb_t fgcolor = ui().options().mouseover_color();
+		rgb_t bgcolor = ui().options().mouseover_bg_color();
 		layout.restyle(target_dir_start, target_dir_end - target_dir_start, &fgcolor, &bgcolor);
 	}
 	else

--- a/src/frontend/mame/ui/filesel.cpp
+++ b/src/frontend/mame/ui/filesel.cpp
@@ -83,7 +83,7 @@ void menu_file_selector::custom_render(void *selectedref, float top, float botto
 	extra_text_position(origx1, origx2, origy1, top, layout, -1, x1, y1, x2, y2);
 
 	// draw a box
-	ui().draw_outlined_box(container(), x1, y1, x2, y2, ui().options().background_color());
+	ui().draw_outlined_box(container(), x1, y1, x2, y2, ui().colors().background_color());
 
 	// take off the borders
 	x1 += UI_BOX_LR_BORDER;
@@ -100,8 +100,8 @@ void menu_file_selector::custom_render(void *selectedref, float top, float botto
 		m_hover_directory = m_current_directory.substr(0, target_dir_end + strlen(PATH_SEPARATOR));
 
 		// highlight the text in question
-		rgb_t fgcolor = ui().options().mouseover_color();
-		rgb_t bgcolor = ui().options().mouseover_bg_color();
+		rgb_t fgcolor = ui().colors().mouseover_color();
+		rgb_t bgcolor = ui().colors().mouseover_bg_color();
 		layout.restyle(target_dir_start, target_dir_end - target_dir_start, &fgcolor, &bgcolor);
 	}
 	else

--- a/src/frontend/mame/ui/info.cpp
+++ b/src/frontend/mame/ui/info.cpp
@@ -58,18 +58,19 @@ constexpr std::pair<device_t::feature_type, char const *> FEATURE_NAMES[] = {
 //  machine_static_info - constructors
 //-------------------------------------------------
 
-machine_static_info::machine_static_info(machine_config const &config)
-	: machine_static_info(config, nullptr)
+machine_static_info::machine_static_info(const ui_options &options, machine_config const &config)
+	: machine_static_info(options, config, nullptr)
 {
 }
 
-machine_static_info::machine_static_info(machine_config const &config, ioport_list const &ports)
-	: machine_static_info(config, &ports)
+machine_static_info::machine_static_info(const ui_options &options, machine_config const &config, ioport_list const &ports)
+	: machine_static_info(options, config, &ports)
 {
 }
 
-machine_static_info::machine_static_info(machine_config const &config, ioport_list const *ports)
-	: m_flags(config.gamedrv().flags)
+machine_static_info::machine_static_info(const ui_options &options, machine_config const &config, ioport_list const *ports)
+	: m_options(options)
+	, m_flags(config.gamedrv().flags)
 	, m_unemulated_features(config.gamedrv().type.unemulated_features())
 	, m_imperfect_features(config.gamedrv().type.imperfect_features())
 	, m_has_bioses(false)
@@ -154,7 +155,7 @@ rgb_t machine_static_info::warnings_color() const
 	else if ((machine_flags() & MACHINE_WARNINGS) || unemulated_features() || imperfect_features())
 		return UI_YELLOW_COLOR;
 	else
-		return UI_BACKGROUND_COLOR;
+		return m_options.background_color();
 }
 
 
@@ -164,7 +165,7 @@ rgb_t machine_static_info::warnings_color() const
 //-------------------------------------------------
 
 machine_info::machine_info(running_machine &machine)
-	: machine_static_info(machine.config(), machine.ioport().ports())
+	: machine_static_info(dynamic_cast<mame_ui_manager *>(&machine.ui())->options(), machine.config(), machine.ioport().ports())
 	, m_machine(machine)
 {
 }

--- a/src/frontend/mame/ui/info.h
+++ b/src/frontend/mame/ui/info.h
@@ -21,7 +21,7 @@ class machine_static_info
 {
 public:
 	// construction
-	machine_static_info(machine_config const &config);
+	machine_static_info(const ui_options &options, machine_config const &config);
 
 	// overall emulation status
 	::machine_flags::type machine_flags() const { return m_flags; }
@@ -43,10 +43,12 @@ public:
 	rgb_t warnings_color() const;
 
 protected:
-	machine_static_info(machine_config const &config, ioport_list const &ports);
+	machine_static_info(const ui_options &options, machine_config const &config, ioport_list const &ports);
 
 private:
-	machine_static_info(machine_config const &config, ioport_list const *ports);
+	machine_static_info(const ui_options &options, machine_config const &config, ioport_list const *ports);
+
+	const ui_options &		m_options;
 
 	// overall feature status
 	::machine_flags::type   m_flags;

--- a/src/frontend/mame/ui/inputmap.cpp
+++ b/src/frontend/mame/ui/inputmap.cpp
@@ -644,7 +644,7 @@ void menu_settings_dip_switches::custom_render(void *selectedref, float top, flo
 	y2 = y1 + bottom;
 
 	// draw extra menu area
-	ui().draw_outlined_box(container(), x1, y1, x2, y2, ui().options().background_color());
+	ui().draw_outlined_box(container(), x1, y1, x2, y2, ui().colors().background_color());
 	y1 += (float)DIP_SWITCH_SPACING;
 
 	// iterate over DIP switches
@@ -698,7 +698,7 @@ void menu_settings_dip_switches::custom_render_one(float x1, float y1, float x2,
 						ui::text_layout::RIGHT,
 						ui::text_layout::NEVER,
 						mame_ui_manager::NORMAL,
-						ui().options().text_color(),
+						ui().colors().text_color(),
 						PRIMFLAG_BLENDMODE(BLENDMODE_ALPHA),
 						nullptr ,
 						nullptr);
@@ -714,7 +714,7 @@ void menu_settings_dip_switches::custom_render_one(float x1, float y1, float x2,
 		float innerx1;
 
 		/* first outline the switch */
-		ui().draw_outlined_box(container(), x1, y1, x1 + switch_field_width, y2, ui().options().background_color());
+		ui().draw_outlined_box(container(), x1, y1, x1 + switch_field_width, y2, ui().colors().background_color());
 
 		/* compute x1/x2 for the inner filled in switch */
 		innerx1 = x1 + (switch_field_width - switch_width) / 2;
@@ -724,13 +724,13 @@ void menu_settings_dip_switches::custom_render_one(float x1, float y1, float x2,
 		{
 			float innery1 = (dip->state & (1 << toggle)) ? y1_on : y1_off;
 			container().add_rect(innerx1, innery1, innerx1 + switch_width, innery1 + SINGLE_TOGGLE_SWITCH_HEIGHT,
-								(selectedmask & (1 << toggle)) ? ui().options().dipsw_color() : ui().options().text_color(),
+								(selectedmask & (1 << toggle)) ? ui().colors().dipsw_color() : ui().colors().text_color(),
 								PRIMFLAG_BLENDMODE(BLENDMODE_ALPHA));
 		}
 		else
 		{
 			container().add_rect(innerx1, y1_off, innerx1 + switch_width, y1_on + SINGLE_TOGGLE_SWITCH_HEIGHT,
-								ui().options().unavailable_color(),
+								ui().colors().unavailable_color(),
 								PRIMFLAG_BLENDMODE(BLENDMODE_ALPHA));
 		}
 

--- a/src/frontend/mame/ui/inputmap.cpp
+++ b/src/frontend/mame/ui/inputmap.cpp
@@ -644,7 +644,7 @@ void menu_settings_dip_switches::custom_render(void *selectedref, float top, flo
 	y2 = y1 + bottom;
 
 	// draw extra menu area
-	ui().draw_outlined_box(container(), x1, y1, x2, y2, UI_BACKGROUND_COLOR);
+	ui().draw_outlined_box(container(), x1, y1, x2, y2, ui().options().background_color());
 	y1 += (float)DIP_SWITCH_SPACING;
 
 	// iterate over DIP switches
@@ -698,7 +698,7 @@ void menu_settings_dip_switches::custom_render_one(float x1, float y1, float x2,
 						ui::text_layout::RIGHT,
 						ui::text_layout::NEVER,
 						mame_ui_manager::NORMAL,
-						UI_TEXT_COLOR,
+						ui().options().text_color(),
 						PRIMFLAG_BLENDMODE(BLENDMODE_ALPHA),
 						nullptr ,
 						nullptr);
@@ -714,7 +714,7 @@ void menu_settings_dip_switches::custom_render_one(float x1, float y1, float x2,
 		float innerx1;
 
 		/* first outline the switch */
-		ui().draw_outlined_box(container(), x1, y1, x1 + switch_field_width, y2, UI_BACKGROUND_COLOR);
+		ui().draw_outlined_box(container(), x1, y1, x1 + switch_field_width, y2, ui().options().background_color());
 
 		/* compute x1/x2 for the inner filled in switch */
 		innerx1 = x1 + (switch_field_width - switch_width) / 2;
@@ -724,13 +724,13 @@ void menu_settings_dip_switches::custom_render_one(float x1, float y1, float x2,
 		{
 			float innery1 = (dip->state & (1 << toggle)) ? y1_on : y1_off;
 			container().add_rect(innerx1, innery1, innerx1 + switch_width, innery1 + SINGLE_TOGGLE_SWITCH_HEIGHT,
-								(selectedmask & (1 << toggle)) ? UI_DIPSW_COLOR : UI_TEXT_COLOR,
+								(selectedmask & (1 << toggle)) ? ui().options().dipsw_color() : ui().options().text_color(),
 								PRIMFLAG_BLENDMODE(BLENDMODE_ALPHA));
 		}
 		else
 		{
 			container().add_rect(innerx1, y1_off, innerx1 + switch_width, y1_on + SINGLE_TOGGLE_SWITCH_HEIGHT,
-								UI_UNAVAILABLE_COLOR,
+								ui().options().unavailable_color(),
 								PRIMFLAG_BLENDMODE(BLENDMODE_ALPHA));
 		}
 

--- a/src/frontend/mame/ui/menu.cpp
+++ b/src/frontend/mame/ui/menu.cpp
@@ -614,7 +614,7 @@ void menu::draw(uint32_t flags)
 	float const x2 = visible_left + visible_width + UI_BOX_LR_BORDER;
 	float const y2 = visible_top + visible_main_menu_height + UI_BOX_TB_BORDER;
 	if (!customonly)
-		ui().draw_outlined_box(container(), x1, y1, x2, y2, ui().options().background_color());
+		ui().draw_outlined_box(container(), x1, y1, x2, y2, ui().colors().background_color());
 
 	if (top_line < 0 || is_first_selected())
 		top_line = 0;
@@ -652,10 +652,10 @@ void menu::draw(uint32_t flags)
 			auto const itemnum = top_line + linenum;
 			menu_item const &pitem = m_items[itemnum];
 			char const *const itemtext = pitem.text.c_str();
-			rgb_t fgcolor = ui().options().text_color();
-			rgb_t bgcolor = ui().options().text_bg_color();
-			rgb_t fgcolor2 = ui().options().subitem_color();
-			rgb_t fgcolor3 = ui().options().clone_color();
+			rgb_t fgcolor = ui().colors().text_color();
+			rgb_t bgcolor = ui().colors().text_bg_color();
+			rgb_t fgcolor2 = ui().colors().subitem_color();
+			rgb_t fgcolor3 = ui().colors().clone_color();
 			float const line_y0 = visible_top + (float)linenum * line_height;
 			float const line_y1 = line_y0 + line_height;
 
@@ -666,19 +666,19 @@ void menu::draw(uint32_t flags)
 			// if we're selected, draw with a different background
 			if (is_selected(itemnum))
 			{
-				fgcolor = fgcolor2 = fgcolor3 = ui().options().selected_color();
-				bgcolor = ui().options().selected_bg_color();
+				fgcolor = fgcolor2 = fgcolor3 = ui().colors().selected_color();
+				bgcolor = ui().colors().selected_bg_color();
 			}
 
 			// else if the mouse is over this item, draw with a different background
 			else if (itemnum == m_hover)
 			{
-				fgcolor = fgcolor2 = fgcolor3 = ui().options().mouseover_color();
-				bgcolor = ui().options().mouseover_bg_color();
+				fgcolor = fgcolor2 = fgcolor3 = ui().colors().mouseover_color();
+				bgcolor = ui().colors().mouseover_bg_color();
 			}
 
 			// if we have some background hilighting to do, add a quad behind everything else
-			if (bgcolor != ui().options().text_bg_color())
+			if (bgcolor != ui().colors().text_bg_color())
 				highlight(line_x0, line_y0, line_x1, line_y1, bgcolor);
 
 			if (linenum == 0 && show_top_arrow)
@@ -710,7 +710,7 @@ void menu::draw(uint32_t flags)
 			else if (pitem.type == menu_item_type::SEPARATOR)
 			{
 				// if we're just a divider, draw a line
-				container().add_line(visible_left, line_y0 + 0.5f * line_height, visible_left + visible_width, line_y0 + 0.5f * line_height, UI_LINE_WIDTH, ui().options().border_color(), PRIMFLAG_BLENDMODE(BLENDMODE_ALPHA));
+				container().add_line(visible_left, line_y0 + 0.5f * line_height, visible_left + visible_width, line_y0 + 0.5f * line_height, UI_LINE_WIDTH, ui().colors().border_color(), PRIMFLAG_BLENDMODE(BLENDMODE_ALPHA));
 			}
 			else if (pitem.subtext.empty())
 			{
@@ -718,8 +718,8 @@ void menu::draw(uint32_t flags)
 				if (pitem.flags & FLAG_UI_HEADING)
 				{
 					float heading_width = ui().get_string_width(itemtext);
-					container().add_line(visible_left, line_y0 + 0.5f * line_height, visible_left + ((visible_width - heading_width) / 2) - UI_BOX_LR_BORDER, line_y0 + 0.5f * line_height, UI_LINE_WIDTH, ui().options().border_color(), PRIMFLAG_BLENDMODE(BLENDMODE_ALPHA));
-					container().add_line(visible_left + visible_width - ((visible_width - heading_width) / 2) + UI_BOX_LR_BORDER, line_y0 + 0.5f * line_height, visible_left + visible_width, line_y0 + 0.5f * line_height, UI_LINE_WIDTH, ui().options().border_color(), PRIMFLAG_BLENDMODE(BLENDMODE_ALPHA));
+					container().add_line(visible_left, line_y0 + 0.5f * line_height, visible_left + ((visible_width - heading_width) / 2) - UI_BOX_LR_BORDER, line_y0 + 0.5f * line_height, UI_LINE_WIDTH, ui().colors().border_color(), PRIMFLAG_BLENDMODE(BLENDMODE_ALPHA));
+					container().add_line(visible_left + visible_width - ((visible_width - heading_width) / 2) + UI_BOX_LR_BORDER, line_y0 + 0.5f * line_height, visible_left + visible_width, line_y0 + 0.5f * line_height, UI_LINE_WIDTH, ui().colors().border_color(), PRIMFLAG_BLENDMODE(BLENDMODE_ALPHA));
 				}
 				ui().draw_text_full(container(), itemtext, effective_left, line_y0, effective_width,
 					ui::text_layout::CENTER, ui::text_layout::TRUNCATE, mame_ui_manager::NORMAL, fgcolor, bgcolor, nullptr, nullptr);
@@ -822,10 +822,10 @@ void menu::draw(uint32_t flags)
 				target_y - UI_BOX_TB_BORDER,
 				target_x + target_width + UI_BOX_LR_BORDER,
 				target_y + target_height + UI_BOX_TB_BORDER,
-				subitem_invert ? ui().options().selected_bg_color() : ui().options().background_color());
+				subitem_invert ? ui().colors().selected_bg_color() : ui().colors().background_color());
 
 		ui().draw_text_full(container(), pitem.subtext.c_str(), target_x, target_y, target_width,
-				ui::text_layout::RIGHT, ui::text_layout::WORD, mame_ui_manager::NORMAL, ui().options().selected_color(), ui().options().selected_bg_color(), nullptr, nullptr);
+				ui::text_layout::RIGHT, ui::text_layout::WORD, mame_ui_manager::NORMAL, ui().colors().selected_color(), ui().colors().selected_bg_color(), nullptr, nullptr);
 	}
 
 	// if there is something special to add, do it by calling the virtual method
@@ -882,9 +882,9 @@ void menu::draw_text_box()
 							target_y - UI_BOX_TB_BORDER,
 							target_x + target_width + gutter_width + UI_BOX_LR_BORDER,
 							target_y + target_height + UI_BOX_TB_BORDER,
-							(m_items[0].flags & FLAG_REDTEXT) ?  UI_RED_COLOR : ui().options().background_color());
+							(m_items[0].flags & FLAG_REDTEXT) ?  UI_RED_COLOR : ui().colors().background_color());
 	ui().draw_text_full(container(), text, target_x, target_y, target_width,
-			ui::text_layout::LEFT, ui::text_layout::WORD, mame_ui_manager::NORMAL, ui().options().text_color(), ui().options().text_bg_color(), nullptr, nullptr);
+			ui::text_layout::LEFT, ui::text_layout::WORD, mame_ui_manager::NORMAL, ui().colors().text_color(), ui().colors().text_bg_color(), nullptr, nullptr);
 
 	// draw the "return to prior menu" text with a hilight behind it
 	highlight(
@@ -892,9 +892,9 @@ void menu::draw_text_box()
 				target_y + target_height - line_height,
 				target_x + target_width - 0.5f * UI_LINE_WIDTH,
 				target_y + target_height,
-				ui().options().selected_bg_color());
+				ui().colors().selected_bg_color());
 	ui().draw_text_full(container(), backtext, target_x, target_y + target_height - line_height, target_width,
-		ui::text_layout::CENTER, ui::text_layout::TRUNCATE, mame_ui_manager::NORMAL, ui().options().selected_color(), ui().options().selected_bg_color(), nullptr, nullptr);
+		ui::text_layout::CENTER, ui::text_layout::TRUNCATE, mame_ui_manager::NORMAL, ui().colors().selected_color(), ui().colors().selected_bg_color(), nullptr, nullptr);
 
 	// artificially set the hover to the last item so a double-click exits
 	m_hover = m_items.size() - 1;
@@ -1334,7 +1334,7 @@ void menu::extra_text_draw_box(float origx1, float origx2, float origy, float ys
 	extra_text_position(origx1, origx2, origy, yspan, layout, direction, x1, y1, x2, y2);
 
 	// draw a box
-	ui().draw_outlined_box(container(), x1, y1, x2, y2, ui().options().background_color());
+	ui().draw_outlined_box(container(), x1, y1, x2, y2, ui().colors().background_color());
 
 	// take off the borders
 	x1 += UI_BOX_LR_BORDER;

--- a/src/frontend/mame/ui/menu.cpp
+++ b/src/frontend/mame/ui/menu.cpp
@@ -614,7 +614,7 @@ void menu::draw(uint32_t flags)
 	float const x2 = visible_left + visible_width + UI_BOX_LR_BORDER;
 	float const y2 = visible_top + visible_main_menu_height + UI_BOX_TB_BORDER;
 	if (!customonly)
-		ui().draw_outlined_box(container(), x1, y1, x2, y2, UI_BACKGROUND_COLOR);
+		ui().draw_outlined_box(container(), x1, y1, x2, y2, ui().options().background_color());
 
 	if (top_line < 0 || is_first_selected())
 		top_line = 0;
@@ -652,10 +652,10 @@ void menu::draw(uint32_t flags)
 			auto const itemnum = top_line + linenum;
 			menu_item const &pitem = m_items[itemnum];
 			char const *const itemtext = pitem.text.c_str();
-			rgb_t fgcolor = UI_TEXT_COLOR;
-			rgb_t bgcolor = UI_TEXT_BG_COLOR;
-			rgb_t fgcolor2 = UI_SUBITEM_COLOR;
-			rgb_t fgcolor3 = UI_CLONE_COLOR;
+			rgb_t fgcolor = ui().options().text_color();
+			rgb_t bgcolor = ui().options().text_bg_color();
+			rgb_t fgcolor2 = ui().options().subitem_color();
+			rgb_t fgcolor3 = ui().options().clone_color();
 			float const line_y0 = visible_top + (float)linenum * line_height;
 			float const line_y1 = line_y0 + line_height;
 
@@ -666,19 +666,19 @@ void menu::draw(uint32_t flags)
 			// if we're selected, draw with a different background
 			if (is_selected(itemnum))
 			{
-				fgcolor = fgcolor2 = fgcolor3 = UI_SELECTED_COLOR;
-				bgcolor = UI_SELECTED_BG_COLOR;
+				fgcolor = fgcolor2 = fgcolor3 = ui().options().selected_color();
+				bgcolor = ui().options().selected_bg_color();
 			}
 
 			// else if the mouse is over this item, draw with a different background
 			else if (itemnum == m_hover)
 			{
-				fgcolor = fgcolor2 = fgcolor3 = UI_MOUSEOVER_COLOR;
-				bgcolor = UI_MOUSEOVER_BG_COLOR;
+				fgcolor = fgcolor2 = fgcolor3 = ui().options().mouseover_color();
+				bgcolor = ui().options().mouseover_bg_color();
 			}
 
 			// if we have some background hilighting to do, add a quad behind everything else
-			if (bgcolor != UI_TEXT_BG_COLOR)
+			if (bgcolor != ui().options().text_bg_color())
 				highlight(line_x0, line_y0, line_x1, line_y1, bgcolor);
 
 			if (linenum == 0 && show_top_arrow)
@@ -710,7 +710,7 @@ void menu::draw(uint32_t flags)
 			else if (pitem.type == menu_item_type::SEPARATOR)
 			{
 				// if we're just a divider, draw a line
-				container().add_line(visible_left, line_y0 + 0.5f * line_height, visible_left + visible_width, line_y0 + 0.5f * line_height, UI_LINE_WIDTH, UI_BORDER_COLOR, PRIMFLAG_BLENDMODE(BLENDMODE_ALPHA));
+				container().add_line(visible_left, line_y0 + 0.5f * line_height, visible_left + visible_width, line_y0 + 0.5f * line_height, UI_LINE_WIDTH, ui().options().border_color(), PRIMFLAG_BLENDMODE(BLENDMODE_ALPHA));
 			}
 			else if (pitem.subtext.empty())
 			{
@@ -718,8 +718,8 @@ void menu::draw(uint32_t flags)
 				if (pitem.flags & FLAG_UI_HEADING)
 				{
 					float heading_width = ui().get_string_width(itemtext);
-					container().add_line(visible_left, line_y0 + 0.5f * line_height, visible_left + ((visible_width - heading_width) / 2) - UI_BOX_LR_BORDER, line_y0 + 0.5f * line_height, UI_LINE_WIDTH, UI_BORDER_COLOR, PRIMFLAG_BLENDMODE(BLENDMODE_ALPHA));
-					container().add_line(visible_left + visible_width - ((visible_width - heading_width) / 2) + UI_BOX_LR_BORDER, line_y0 + 0.5f * line_height, visible_left + visible_width, line_y0 + 0.5f * line_height, UI_LINE_WIDTH, UI_BORDER_COLOR, PRIMFLAG_BLENDMODE(BLENDMODE_ALPHA));
+					container().add_line(visible_left, line_y0 + 0.5f * line_height, visible_left + ((visible_width - heading_width) / 2) - UI_BOX_LR_BORDER, line_y0 + 0.5f * line_height, UI_LINE_WIDTH, ui().options().border_color(), PRIMFLAG_BLENDMODE(BLENDMODE_ALPHA));
+					container().add_line(visible_left + visible_width - ((visible_width - heading_width) / 2) + UI_BOX_LR_BORDER, line_y0 + 0.5f * line_height, visible_left + visible_width, line_y0 + 0.5f * line_height, UI_LINE_WIDTH, ui().options().border_color(), PRIMFLAG_BLENDMODE(BLENDMODE_ALPHA));
 				}
 				ui().draw_text_full(container(), itemtext, effective_left, line_y0, effective_width,
 					ui::text_layout::CENTER, ui::text_layout::TRUNCATE, mame_ui_manager::NORMAL, fgcolor, bgcolor, nullptr, nullptr);
@@ -822,10 +822,10 @@ void menu::draw(uint32_t flags)
 				target_y - UI_BOX_TB_BORDER,
 				target_x + target_width + UI_BOX_LR_BORDER,
 				target_y + target_height + UI_BOX_TB_BORDER,
-				subitem_invert ? UI_SELECTED_BG_COLOR : UI_BACKGROUND_COLOR);
+				subitem_invert ? ui().options().selected_bg_color() : ui().options().background_color());
 
 		ui().draw_text_full(container(), pitem.subtext.c_str(), target_x, target_y, target_width,
-				ui::text_layout::RIGHT, ui::text_layout::WORD, mame_ui_manager::NORMAL, UI_SELECTED_COLOR, UI_SELECTED_BG_COLOR, nullptr, nullptr);
+				ui::text_layout::RIGHT, ui::text_layout::WORD, mame_ui_manager::NORMAL, ui().options().selected_color(), ui().options().selected_bg_color(), nullptr, nullptr);
 	}
 
 	// if there is something special to add, do it by calling the virtual method
@@ -882,9 +882,9 @@ void menu::draw_text_box()
 							target_y - UI_BOX_TB_BORDER,
 							target_x + target_width + gutter_width + UI_BOX_LR_BORDER,
 							target_y + target_height + UI_BOX_TB_BORDER,
-							(m_items[0].flags & FLAG_REDTEXT) ?  UI_RED_COLOR : UI_BACKGROUND_COLOR);
+							(m_items[0].flags & FLAG_REDTEXT) ?  UI_RED_COLOR : ui().options().background_color());
 	ui().draw_text_full(container(), text, target_x, target_y, target_width,
-			ui::text_layout::LEFT, ui::text_layout::WORD, mame_ui_manager::NORMAL, UI_TEXT_COLOR, UI_TEXT_BG_COLOR, nullptr, nullptr);
+			ui::text_layout::LEFT, ui::text_layout::WORD, mame_ui_manager::NORMAL, ui().options().text_color(), ui().options().text_bg_color(), nullptr, nullptr);
 
 	// draw the "return to prior menu" text with a hilight behind it
 	highlight(
@@ -892,9 +892,9 @@ void menu::draw_text_box()
 				target_y + target_height - line_height,
 				target_x + target_width - 0.5f * UI_LINE_WIDTH,
 				target_y + target_height,
-				UI_SELECTED_BG_COLOR);
+				ui().options().selected_bg_color());
 	ui().draw_text_full(container(), backtext, target_x, target_y + target_height - line_height, target_width,
-		ui::text_layout::CENTER, ui::text_layout::TRUNCATE, mame_ui_manager::NORMAL, UI_SELECTED_COLOR, UI_SELECTED_BG_COLOR, nullptr, nullptr);
+		ui::text_layout::CENTER, ui::text_layout::TRUNCATE, mame_ui_manager::NORMAL, ui().options().selected_color(), ui().options().selected_bg_color(), nullptr, nullptr);
 
 	// artificially set the hover to the last item so a double-click exits
 	m_hover = m_items.size() - 1;
@@ -1334,7 +1334,7 @@ void menu::extra_text_draw_box(float origx1, float origx2, float origy, float ys
 	extra_text_position(origx1, origx2, origy, yspan, layout, direction, x1, y1, x2, y2);
 
 	// draw a box
-	ui().draw_outlined_box(container(), x1, y1, x2, y2, UI_BACKGROUND_COLOR);
+	ui().draw_outlined_box(container(), x1, y1, x2, y2, ui().options().background_color());
 
 	// take off the borders
 	x1 += UI_BOX_LR_BORDER;

--- a/src/frontend/mame/ui/menu.h
+++ b/src/frontend/mame/ui/menu.h
@@ -246,7 +246,7 @@ protected:
 			ui().draw_text_full(
 					container(), get_c_str(*it),
 					x1, y1, x2 - x1, justify, wrap,
-					mame_ui_manager::NORMAL, fgcolor, ui().options().text_bg_color(),
+					mame_ui_manager::NORMAL, fgcolor, ui().colors().text_bg_color(),
 					nullptr, nullptr, text_size);
 			y1 += ui().get_line_height();
 		}

--- a/src/frontend/mame/ui/menu.h
+++ b/src/frontend/mame/ui/menu.h
@@ -246,7 +246,7 @@ protected:
 			ui().draw_text_full(
 					container(), get_c_str(*it),
 					x1, y1, x2 - x1, justify, wrap,
-					mame_ui_manager::NORMAL, fgcolor, UI_TEXT_BG_COLOR,
+					mame_ui_manager::NORMAL, fgcolor, ui().options().text_bg_color(),
 					nullptr, nullptr, text_size);
 			y1 += ui().get_line_height();
 		}

--- a/src/frontend/mame/ui/miscmenu.cpp
+++ b/src/frontend/mame/ui/miscmenu.cpp
@@ -804,7 +804,7 @@ void menu_machine_configure::custom_render(void *selectedref, float top, float b
 			std::begin(text), std::end(text),
 			origx1, origx2, origy1 - top, origy1 - UI_BOX_TB_BORDER,
 			ui::text_layout::CENTER, ui::text_layout::TRUNCATE, false,
-			UI_TEXT_COLOR, UI_GREEN_COLOR, 1.0f);
+			ui().options().text_color(), UI_GREEN_COLOR, 1.0f);
 }
 
 void menu_machine_configure::setup_bios()
@@ -920,7 +920,7 @@ void menu_plugins_configure::custom_render(void *selectedref, float top, float b
 			std::begin(toptext), std::end(toptext),
 			origx1, origx2, origy1 - top, origy1 - UI_BOX_TB_BORDER,
 			ui::text_layout::CENTER, ui::text_layout::TRUNCATE, false,
-			UI_TEXT_COLOR, UI_GREEN_COLOR, 1.0f);
+			ui().options().text_color(), UI_GREEN_COLOR, 1.0f);
 }
 
 } // namespace ui

--- a/src/frontend/mame/ui/miscmenu.cpp
+++ b/src/frontend/mame/ui/miscmenu.cpp
@@ -804,7 +804,7 @@ void menu_machine_configure::custom_render(void *selectedref, float top, float b
 			std::begin(text), std::end(text),
 			origx1, origx2, origy1 - top, origy1 - UI_BOX_TB_BORDER,
 			ui::text_layout::CENTER, ui::text_layout::TRUNCATE, false,
-			ui().options().text_color(), UI_GREEN_COLOR, 1.0f);
+			ui().colors().text_color(), UI_GREEN_COLOR, 1.0f);
 }
 
 void menu_machine_configure::setup_bios()
@@ -920,7 +920,7 @@ void menu_plugins_configure::custom_render(void *selectedref, float top, float b
 			std::begin(toptext), std::end(toptext),
 			origx1, origx2, origy1 - top, origy1 - UI_BOX_TB_BORDER,
 			ui::text_layout::CENTER, ui::text_layout::TRUNCATE, false,
-			ui().options().text_color(), UI_GREEN_COLOR, 1.0f);
+			ui().colors().text_color(), UI_GREEN_COLOR, 1.0f);
 }
 
 } // namespace ui

--- a/src/frontend/mame/ui/moptions.cpp
+++ b/src/frontend/mame/ui/moptions.cpp
@@ -88,3 +88,22 @@ ui_options::ui_options() : core_options()
 {
 	add_entries(ui_options::s_option_entries);
 }
+
+//-------------------------------------------------
+//  rgb_value - decode an RGB option
+//-------------------------------------------------
+
+rgb_t ui_options::rgb_value(const char *option) const
+{
+	// find the entry
+	core_options::entry::shared_ptr entry = get_entry(option);
+
+	// look up the value, and sanity check the result
+	const char *value = entry->value();
+	int len = strlen(value);
+	if (len != 8)
+		value = entry->default_value().c_str();
+
+	// convert to an rgb_t
+	return rgb_t((uint32_t)strtoul(value, nullptr, 16));
+}

--- a/src/frontend/mame/ui/moptions.h
+++ b/src/frontend/mame/ui/moptions.h
@@ -119,22 +119,25 @@ public:
 	int font_rows() const { return int_value(OPTION_FONT_ROWS); }
 	int hide_panels() const { return int_value(OPTION_HIDE_PANELS); }
 
-	const char *ui_border_color() const { return value(OPTION_UI_BORDER_COLOR); }
-	const char *ui_bg_color() const { return value(OPTION_UI_BACKGROUND_COLOR); }
-	const char *ui_gfx_bg_color() const { return value(OPTION_UI_GFXVIEWER_BG_COLOR); }
-	const char *ui_unavail_color() const { return value(OPTION_UI_UNAVAILABLE_COLOR); }
-	const char *ui_text_color() const { return value(OPTION_UI_TEXT_COLOR); }
-	const char *ui_text_bg_color() const { return value(OPTION_UI_TEXT_BG_COLOR); }
-	const char *ui_subitem_color() const { return value(OPTION_UI_SUBITEM_COLOR); }
-	const char *ui_clone_color() const { return value(OPTION_UI_CLONE_COLOR); }
-	const char *ui_selected_color() const { return value(OPTION_UI_SELECTED_COLOR); }
-	const char *ui_selected_bg_color() const { return value(OPTION_UI_SELECTED_BG_COLOR); }
-	const char *ui_mouseover_color() const { return value(OPTION_UI_MOUSEOVER_COLOR); }
-	const char *ui_mouseover_bg_color() const { return value(OPTION_UI_MOUSEOVER_BG_COLOR); }
-	const char *ui_mousedown_color() const { return value(OPTION_UI_MOUSEDOWN_COLOR); }
-	const char *ui_mousedown_bg_color() const { return value(OPTION_UI_MOUSEDOWN_BG_COLOR); }
-	const char *ui_dipsw_color() const { return value(OPTION_UI_DIPSW_COLOR); }
-	const char *ui_slider_color() const { return value(OPTION_UI_SLIDER_COLOR); }
+	rgb_t border_color() const { return rgb_value(OPTION_UI_BORDER_COLOR); }
+	rgb_t background_color() const { return rgb_value(OPTION_UI_BACKGROUND_COLOR); }
+	rgb_t gfxviewer_bg_color() const { return rgb_value(OPTION_UI_GFXVIEWER_BG_COLOR); }
+	rgb_t unavailable_color() const { return rgb_value(OPTION_UI_UNAVAILABLE_COLOR); }
+	rgb_t text_color() const { return rgb_value(OPTION_UI_TEXT_COLOR); }
+	rgb_t text_bg_color() const { return rgb_value(OPTION_UI_TEXT_BG_COLOR); }
+	rgb_t subitem_color() const { return rgb_value(OPTION_UI_SUBITEM_COLOR); }
+	rgb_t clone_color() const { return rgb_value(OPTION_UI_CLONE_COLOR); }
+	rgb_t selected_color() const { return rgb_value(OPTION_UI_SELECTED_COLOR); }
+	rgb_t selected_bg_color() const { return rgb_value(OPTION_UI_SELECTED_BG_COLOR); }
+	rgb_t mouseover_color() const { return rgb_value(OPTION_UI_MOUSEOVER_COLOR); }
+	rgb_t mouseover_bg_color() const { return rgb_value(OPTION_UI_MOUSEOVER_BG_COLOR); }
+	rgb_t mousedown_color() const { return rgb_value(OPTION_UI_MOUSEDOWN_COLOR); }
+	rgb_t mousedown_bg_color() const { return rgb_value(OPTION_UI_MOUSEDOWN_BG_COLOR); }
+	rgb_t dipsw_color() const { return rgb_value(OPTION_UI_DIPSW_COLOR); }
+	rgb_t slider_color() const { return rgb_value(OPTION_UI_SLIDER_COLOR); }
+
+	rgb_t rgb_value(const char *option) const;
+
 private:
 	static const options_entry s_option_entries[];
 };

--- a/src/frontend/mame/ui/optsmenu.cpp
+++ b/src/frontend/mame/ui/optsmenu.cpp
@@ -143,7 +143,7 @@ void menu_simple_game_options::custom_render(void *selectedref, float top, float
 			std::begin(toptext), std::end(toptext),
 			origx1, origx2, origy1 - top, origy1 - UI_BOX_TB_BORDER,
 			ui::text_layout::CENTER, ui::text_layout::TRUNCATE, false,
-			ui().options().text_color(), UI_GREEN_COLOR, 1.0f);
+			ui().colors().text_color(), UI_GREEN_COLOR, 1.0f);
 }
 
 

--- a/src/frontend/mame/ui/optsmenu.cpp
+++ b/src/frontend/mame/ui/optsmenu.cpp
@@ -143,7 +143,7 @@ void menu_simple_game_options::custom_render(void *selectedref, float top, float
 			std::begin(toptext), std::end(toptext),
 			origx1, origx2, origy1 - top, origy1 - UI_BOX_TB_BORDER,
 			ui::text_layout::CENTER, ui::text_layout::TRUNCATE, false,
-			UI_TEXT_COLOR, UI_GREEN_COLOR, 1.0f);
+			ui().options().text_color(), UI_GREEN_COLOR, 1.0f);
 }
 
 

--- a/src/frontend/mame/ui/selector.cpp
+++ b/src/frontend/mame/ui/selector.cpp
@@ -117,7 +117,7 @@ void menu_selector::custom_render(void *selectedref, float top, float bottom, fl
 			std::begin(tempbuf), std::end(tempbuf),
 			origx1, origx2, origy1 - top, origy1 - UI_BOX_TB_BORDER,
 			ui::text_layout::CENTER, ui::text_layout::TRUNCATE, false,
-			ui().options().text_color(), UI_GREEN_COLOR, 1.0f);
+			ui().colors().text_color(), UI_GREEN_COLOR, 1.0f);
 
 	// get the text for 'UI Select'
 	tempbuf[0] = string_format(_("Double click or press %1$s to select"), machine().input().seq_name(machine().ioport().type_seq(IPT_UI_SELECT, 0, SEQ_TYPE_STANDARD)));
@@ -125,7 +125,7 @@ void menu_selector::custom_render(void *selectedref, float top, float bottom, fl
 			std::begin(tempbuf), std::end(tempbuf),
 			origx1, origx2, origy2 + UI_BOX_TB_BORDER, origy2 + bottom,
 			ui::text_layout::CENTER, ui::text_layout::NEVER, false,
-			ui().options().text_color(), UI_RED_COLOR, 1.0f);
+			ui().colors().text_color(), UI_RED_COLOR, 1.0f);
 }
 
 //-------------------------------------------------

--- a/src/frontend/mame/ui/selector.cpp
+++ b/src/frontend/mame/ui/selector.cpp
@@ -117,7 +117,7 @@ void menu_selector::custom_render(void *selectedref, float top, float bottom, fl
 			std::begin(tempbuf), std::end(tempbuf),
 			origx1, origx2, origy1 - top, origy1 - UI_BOX_TB_BORDER,
 			ui::text_layout::CENTER, ui::text_layout::TRUNCATE, false,
-			UI_TEXT_COLOR, UI_GREEN_COLOR, 1.0f);
+			ui().options().text_color(), UI_GREEN_COLOR, 1.0f);
 
 	// get the text for 'UI Select'
 	tempbuf[0] = string_format(_("Double click or press %1$s to select"), machine().input().seq_name(machine().ioport().type_seq(IPT_UI_SELECT, 0, SEQ_TYPE_STANDARD)));
@@ -125,7 +125,7 @@ void menu_selector::custom_render(void *selectedref, float top, float bottom, fl
 			std::begin(tempbuf), std::end(tempbuf),
 			origx1, origx2, origy2 + UI_BOX_TB_BORDER, origy2 + bottom,
 			ui::text_layout::CENTER, ui::text_layout::NEVER, false,
-			UI_TEXT_COLOR, UI_RED_COLOR, 1.0f);
+			ui().options().text_color(), UI_RED_COLOR, 1.0f);
 }
 
 //-------------------------------------------------

--- a/src/frontend/mame/ui/selmenu.cpp
+++ b/src/frontend/mame/ui/selmenu.cpp
@@ -263,7 +263,7 @@ void menu_select_launch::software_parts::custom_render(void *selectedref, float 
 			std::begin(text), std::end(text),
 			origx1, origx2, origy1 - top, origy1 - UI_BOX_TB_BORDER,
 			ui::text_layout::CENTER, ui::text_layout::TRUNCATE, false,
-			UI_TEXT_COLOR, UI_GREEN_COLOR, 1.0f);
+			ui().options().text_color(), UI_GREEN_COLOR, 1.0f);
 }
 
 
@@ -369,7 +369,7 @@ void menu_select_launch::bios_selection::custom_render(void *selectedref, float 
 			std::begin(text), std::end(text),
 			origx1, origx2, origy1 - top, origy1 - UI_BOX_TB_BORDER,
 			ui::text_layout::CENTER, ui::text_layout::TRUNCATE, false,
-			UI_TEXT_COLOR, UI_GREEN_COLOR, 1.0f);
+			ui().options().text_color(), UI_GREEN_COLOR, 1.0f);
 }
 
 
@@ -540,7 +540,7 @@ menu_select_launch::system_flags const &menu_select_launch::get_system_flags(gam
 	// aggregate flags
 	emu_options clean_options;
 	machine_config const mconfig(driver, clean_options);
-	return m_flags.emplace(&driver, machine_static_info(mconfig)).first->second;
+	return m_flags.emplace(&driver, machine_static_info(ui().options(), mconfig)).first->second;
 }
 
 
@@ -595,7 +595,7 @@ void menu_select_launch::custom_render(void *selectedref, float top, float botto
 			tempbuf, tempbuf + 3,
 			origx1, origx2, origy1 - top, y1,
 			ui::text_layout::CENTER, ui::text_layout::NEVER, true,
-			UI_TEXT_COLOR, UI_BACKGROUND_COLOR, 1.0f);
+			ui().options().text_color(), ui().options().background_color(), 1.0f);
 
 	// draw toolbar
 	draw_toolbar(origx1, y1, origx2, origy1 - UI_BOX_TB_BORDER);
@@ -606,7 +606,7 @@ void menu_select_launch::custom_render(void *selectedref, float top, float botto
 	get_selection(swinfo, driver);
 
 	bool isstar = false;
-	rgb_t color = UI_BACKGROUND_COLOR;
+	rgb_t color = ui().options().background_color();
 	if (swinfo && ((swinfo->startempty != 1) || !driver))
 	{
 		isstar = mame_machine_manager::instance()->favorite().is_favorite_system_software(*swinfo);
@@ -706,7 +706,7 @@ void menu_select_launch::custom_render(void *selectedref, float top, float botto
 			std::begin(tempbuf), std::end(tempbuf),
 			origx1, origx2, origy2 + UI_BOX_TB_BORDER, origy2 + bottom,
 			ui::text_layout::CENTER, ui::text_layout::NEVER, true,
-			UI_TEXT_COLOR, color, 1.0f);
+			ui().options().text_color(), color, 1.0f);
 
 	// is favorite? draw the star
 	if (isstar)
@@ -808,22 +808,22 @@ void menu_select_launch::draw_common_arrow(float origx1, float origy1, float ori
 	float const al_y1 = origy1 + 0.9f * line_height;
 
 	rgb_t fgcolor_right, fgcolor_left;
-	fgcolor_right = fgcolor_left = UI_TEXT_COLOR;
+	fgcolor_right = fgcolor_left = ui().options().text_color();
 
 	// set hover
 	if (mouse_in_rect(ar_x0, ar_y0, ar_x1, ar_y1) && current != dmax)
 	{
-		ui().draw_textured_box(container(), ar_x0 + 0.01f, ar_y0, ar_x1 - 0.01f, ar_y1, UI_MOUSEOVER_BG_COLOR, rgb_t(43, 43, 43),
+		ui().draw_textured_box(container(), ar_x0 + 0.01f, ar_y0, ar_x1 - 0.01f, ar_y1, ui().options().mouseover_bg_color(), rgb_t(43, 43, 43),
 				hilight_main_texture(), PRIMFLAG_BLENDMODE(BLENDMODE_ALPHA) | PRIMFLAG_TEXWRAP(1));
 		set_hover(HOVER_UI_RIGHT);
-		fgcolor_right = UI_MOUSEOVER_COLOR;
+		fgcolor_right = ui().options().mouseover_color();
 	}
 	else if (mouse_in_rect(al_x0, al_y0, al_x1, al_y1) && current != dmin)
 	{
-		ui().draw_textured_box(container(), al_x0 + 0.01f, al_y0, al_x1 - 0.01f, al_y1, UI_MOUSEOVER_BG_COLOR, rgb_t(43, 43, 43),
+		ui().draw_textured_box(container(), al_x0 + 0.01f, al_y0, al_x1 - 0.01f, al_y1, ui().options().mouseover_bg_color(), rgb_t(43, 43, 43),
 				hilight_main_texture(), PRIMFLAG_BLENDMODE(BLENDMODE_ALPHA) | PRIMFLAG_TEXWRAP(1));
 		set_hover(HOVER_UI_LEFT);
-		fgcolor_left = UI_MOUSEOVER_COLOR;
+		fgcolor_left = ui().options().mouseover_color();
 	}
 
 	// apply arrow
@@ -847,15 +847,15 @@ void menu_select_launch::draw_common_arrow(float origx1, float origy1, float ori
 
 void menu_select_launch::draw_info_arrow(int ub, float origx1, float origx2, float oy1, float line_height, float text_size, float ud_arrow_width)
 {
-	rgb_t fgcolor = UI_TEXT_COLOR;
+	rgb_t fgcolor = ui().options().text_color();
 	uint32_t orientation = (!ub) ? ROT0 : ROT0 ^ ORIENTATION_FLIP_Y;
 
 	if (mouse_in_rect(origx1, oy1, origx2, oy1 + (line_height * text_size)))
 	{
-		ui().draw_textured_box(container(), origx1 + 0.01f, oy1, origx2 - 0.01f, oy1 + (line_height * text_size), UI_MOUSEOVER_BG_COLOR,
+		ui().draw_textured_box(container(), origx1 + 0.01f, oy1, origx2 - 0.01f, oy1 + (line_height * text_size), ui().options().mouseover_bg_color(),
 				rgb_t(43, 43, 43), hilight_main_texture(), PRIMFLAG_BLENDMODE(BLENDMODE_ALPHA) | PRIMFLAG_TEXWRAP(1));
 		set_hover((!ub) ? HOVER_DAT_UP : HOVER_DAT_DOWN);
-		fgcolor = UI_MOUSEOVER_COLOR;
+		fgcolor = ui().options().mouseover_color();
 	}
 
 	draw_arrow(0.5f * (origx1 + origx2) - 0.5f * (ud_arrow_width * text_size), oy1 + 0.25f * (line_height * text_size),
@@ -905,7 +905,7 @@ float menu_select_launch::draw_left_panel(
 	float const origy1(y1);
 	float const origy2(y2);
 	x2 = x1 + left_width + 2.0f * UI_BOX_LR_BORDER;
-	ui().draw_outlined_box(container(), x1, y1, x2, y2, UI_BACKGROUND_COLOR);
+	ui().draw_outlined_box(container(), x1, y1, x2, y2, ui().options().background_color());
 	x1 += UI_BOX_LR_BORDER;
 	x2 -= UI_BOX_LR_BORDER;
 	y1 += UI_BOX_TB_BORDER;
@@ -931,12 +931,12 @@ float menu_select_launch::draw_left_panel(
 		}
 
 		// handle mouse hover in passing
-		rgb_t bgcolor = UI_TEXT_BG_COLOR;
-		rgb_t fgcolor = UI_TEXT_COLOR;
+		rgb_t bgcolor = ui().options().text_bg_color();
+		rgb_t fgcolor = ui().options().text_color();
 		if (mouse_in_rect(x1, y1, x2, y1 + line_height_max))
 		{
-			bgcolor = UI_MOUSEOVER_BG_COLOR;
-			fgcolor = UI_MOUSEOVER_COLOR;
+			bgcolor = ui().options().mouseover_bg_color();
+			fgcolor = ui().options().mouseover_color();
 			set_hover(HOVER_FILTER_FIRST + filter);
 			highlight(x1, y1, x2, y1 + line_height_max, bgcolor);
 		}
@@ -979,10 +979,10 @@ float menu_select_launch::draw_left_panel(
 
 	ui().draw_outlined_box(container(), x1, y1, x2, y2, rgb_t(0xef, 0x12, 0x47, 0x7b));
 
-	rgb_t fgcolor = UI_TEXT_COLOR;
+	rgb_t fgcolor = ui().options().text_color();
 	if (mouse_in_rect(x1, y1, x2, y2))
 	{
-		fgcolor = UI_MOUSEOVER_COLOR;
+		fgcolor = ui().options().mouseover_color();
 		set_hover(HOVER_LPANEL_ARROW);
 	}
 
@@ -1206,7 +1206,7 @@ void menu_select_launch::draw_toolbar(float x1, float y1, float x2, float y2)
 				set_hover(HOVER_B_FAV + z);
 				color = rgb_t::white();
 				float ypos = y2 + ui().get_line_height() + 2.0f * UI_BOX_TB_BORDER;
-				ui().draw_text_box(container(), _(hover_msg[z]), ui::text_layout::CENTER, 0.5f, ypos, UI_BACKGROUND_COLOR);
+				ui().draw_text_box(container(), _(hover_msg[z]), ui::text_layout::CENTER, 0.5f, ypos, ui().options().background_color());
 			}
 
 			container().add_quad(x1, y1, x2, y2, color, t_texture[z].get(), PRIMFLAG_BLENDMODE(BLENDMODE_ALPHA));
@@ -1800,7 +1800,7 @@ void menu_select_launch::draw(uint32_t flags)
 	x1 = visible_left - UI_BOX_LR_BORDER;
 	x2 = visible_left + visible_width + UI_BOX_LR_BORDER;
 	float line = visible_top + (float(m_visible_lines) * line_height);
-	ui().draw_outlined_box(container(), x1, y1, x2, y2, UI_BACKGROUND_COLOR);
+	ui().draw_outlined_box(container(), x1, y1, x2, y2, ui().options().background_color());
 
 	if (visible_items < m_visible_lines)
 		m_visible_lines = visible_items;
@@ -1823,9 +1823,9 @@ void menu_select_launch::draw(uint32_t flags)
 		int itemnum = top_line + linenum;
 		const menu_item &pitem = item(itemnum);
 		const char *itemtext = pitem.text.c_str();
-		rgb_t fgcolor = UI_TEXT_COLOR;
-		rgb_t bgcolor = UI_TEXT_BG_COLOR;
-		rgb_t fgcolor3 = UI_CLONE_COLOR;
+		rgb_t fgcolor = ui().options().text_color();
+		rgb_t bgcolor = ui().options().text_bg_color();
+		rgb_t fgcolor3 = ui().options().clone_color();
 		float line_x0 = x1 + 0.5f * UI_LINE_WIDTH;
 		float line_y0 = line_y;
 		float line_x1 = x2 - 0.5f * UI_LINE_WIDTH;
@@ -1850,14 +1850,14 @@ void menu_select_launch::draw(uint32_t flags)
 		else if (itemnum == hover())
 		{
 			// else if the mouse is over this item, draw with a different background
-			fgcolor = fgcolor3 = UI_MOUSEOVER_COLOR;
-			bgcolor = UI_MOUSEOVER_BG_COLOR;
+			fgcolor = fgcolor3 = ui().options().mouseover_color();
+			bgcolor = ui().options().mouseover_bg_color();
 			highlight(line_x0, line_y0, line_x1, line_y1, bgcolor);
 		}
 		else if (pitem.ref == m_prev_selected)
 		{
-			fgcolor = fgcolor3 = UI_MOUSEOVER_COLOR;
-			bgcolor = UI_MOUSEOVER_BG_COLOR;
+			fgcolor = fgcolor3 = ui().options().mouseover_color();
+			bgcolor = ui().options().mouseover_bg_color();
 			ui().draw_textured_box(container(), line_x0 + 0.01f, line_y0, line_x1 - 0.01f, line_y1, bgcolor, rgb_t(43, 43, 43),
 					hilight_main_texture(), PRIMFLAG_BLENDMODE(BLENDMODE_ALPHA) | PRIMFLAG_TEXWRAP(1));
 		}
@@ -1884,7 +1884,7 @@ void menu_select_launch::draw(uint32_t flags)
 		{
 			// if we're just a divider, draw a line
 			container().add_line(visible_left, line_y + 0.5f * line_height, visible_left + visible_width, line_y + 0.5f * line_height,
-					UI_LINE_WIDTH, UI_TEXT_COLOR, PRIMFLAG_BLENDMODE(BLENDMODE_ALPHA));
+					UI_LINE_WIDTH, ui().options().text_color(), PRIMFLAG_BLENDMODE(BLENDMODE_ALPHA));
 		}
 		else if (pitem.subtext.empty())
 		{
@@ -1946,8 +1946,8 @@ void menu_select_launch::draw(uint32_t flags)
 		float line_y0 = line;
 		float line_x1 = x2 - 0.5f * UI_LINE_WIDTH;
 		float line_y1 = line + line_height;
-		rgb_t fgcolor = UI_TEXT_COLOR;
-		rgb_t bgcolor = UI_TEXT_BG_COLOR;
+		rgb_t fgcolor = ui().options().text_color();
+		rgb_t bgcolor = ui().options().text_bg_color();
 
 		if (mouse_in_rect(line_x0, line_y0, line_x1, line_y1) && is_selectable(pitem))
 			set_hover(count);
@@ -1963,15 +1963,15 @@ void menu_select_launch::draw(uint32_t flags)
 		// else if the mouse is over this item, draw with a different background
 		else if (count == hover())
 		{
-			fgcolor = UI_MOUSEOVER_COLOR;
-			bgcolor = UI_MOUSEOVER_BG_COLOR;
+			fgcolor = ui().options().mouseover_color();
+			bgcolor = ui().options().mouseover_bg_color();
 			highlight(line_x0, line_y0, line_x1, line_y1, bgcolor);
 		}
 
 		if (pitem.type == menu_item_type::SEPARATOR)
 		{
 			container().add_line(visible_left, line + 0.5f * line_height, visible_left + visible_width, line + 0.5f * line_height,
-					UI_LINE_WIDTH, UI_TEXT_COLOR, PRIMFLAG_BLENDMODE(BLENDMODE_ALPHA));
+					UI_LINE_WIDTH, ui().options().text_color(), PRIMFLAG_BLENDMODE(BLENDMODE_ALPHA));
 		}
 		else
 		{
@@ -2026,10 +2026,10 @@ void menu_select_launch::draw_right_panel(float origx1, float origy1, float orig
 
 	ui().draw_outlined_box(container(), origx1, origy1, origx2, origy2, rgb_t(0xEF, 0x12, 0x47, 0x7B));
 
-	rgb_t fgcolor(UI_TEXT_COLOR);
+	rgb_t fgcolor(ui().options().text_color());
 	if (mouse_in_rect(origx1, origy1, x2, origy2))
 	{
-		fgcolor = UI_MOUSEOVER_COLOR;
+		fgcolor = ui().options().mouseover_color();
 		set_hover(HOVER_RPANEL_ARROW);
 	}
 
@@ -2059,10 +2059,10 @@ float menu_select_launch::draw_right_box_title(float x1, float y1, float x2, flo
 	float const midl = (x2 - x1) * 0.5f;
 
 	// add outlined box for options
-	ui().draw_outlined_box(container(), x1, y1, x2, y2, UI_BACKGROUND_COLOR);
+	ui().draw_outlined_box(container(), x1, y1, x2, y2, ui().options().background_color());
 
 	// add separator line
-	container().add_line(x1 + midl, y1, x1 + midl, y1 + line_height, UI_LINE_WIDTH, UI_BORDER_COLOR, PRIMFLAG_BLENDMODE(BLENDMODE_ALPHA));
+	container().add_line(x1 + midl, y1, x1 + midl, y1 + line_height, UI_LINE_WIDTH, ui().options().border_color(), PRIMFLAG_BLENDMODE(BLENDMODE_ALPHA));
 
 	std::string buffer[RP_LAST + 1];
 	buffer[RP_IMAGES] = _("Images");
@@ -2079,15 +2079,15 @@ float menu_select_launch::draw_right_box_title(float x1, float y1, float x2, flo
 
 	for (int cells = RP_FIRST; cells <= RP_LAST; ++cells)
 	{
-		rgb_t bgcolor = UI_TEXT_BG_COLOR;
-		rgb_t fgcolor = UI_TEXT_COLOR;
+		rgb_t bgcolor = ui().options().text_bg_color();
+		rgb_t fgcolor = ui().options().text_color();
 
 		if (mouse_in_rect(x1, y1, x1 + midl, y1 + line_height))
 		{
 			if (ui_globals::rpanel != cells)
 			{
-				bgcolor = UI_MOUSEOVER_BG_COLOR;
-				fgcolor = UI_MOUSEOVER_COLOR;
+				bgcolor = ui().options().mouseover_bg_color();
+				fgcolor = ui().options().mouseover_color();
 				set_hover(HOVER_RP_FIRST + cells);
 			}
 		}
@@ -2095,9 +2095,9 @@ float menu_select_launch::draw_right_box_title(float x1, float y1, float x2, flo
 		if (ui_globals::rpanel != cells)
 		{
 			container().add_line(x1, y1 + line_height, x1 + midl, y1 + line_height, UI_LINE_WIDTH,
-					UI_BORDER_COLOR, PRIMFLAG_BLENDMODE(BLENDMODE_ALPHA));
-			if (fgcolor != UI_MOUSEOVER_COLOR)
-				fgcolor = UI_CLONE_COLOR;
+					ui().options().border_color(), PRIMFLAG_BLENDMODE(BLENDMODE_ALPHA));
+			if (fgcolor != ui().options().mouseover_color())
+				fgcolor = ui().options().clone_color();
 		}
 
 		if (m_focus == focused_menu::RIGHTTOP && ui_globals::rpanel == cells)
@@ -2107,7 +2107,7 @@ float menu_select_launch::draw_right_box_title(float x1, float y1, float x2, flo
 			ui().draw_textured_box(container(), x1 + UI_LINE_WIDTH, y1 + UI_LINE_WIDTH, x1 + midl - UI_LINE_WIDTH, y1 + line_height,
 					bgcolor, rgb_t(43, 43, 43), hilight_main_texture(), PRIMFLAG_BLENDMODE(BLENDMODE_ALPHA) | PRIMFLAG_TEXWRAP(1));
 		}
-		else if (bgcolor == UI_MOUSEOVER_BG_COLOR)
+		else if (bgcolor == ui().options().mouseover_bg_color())
 		{
 			container().add_rect(x1 + UI_LINE_WIDTH, y1 + UI_LINE_WIDTH, x1 + midl - UI_LINE_WIDTH, y1 + line_height,
 					bgcolor, PRIMFLAG_BLENDMODE(BLENDMODE_ALPHA) | PRIMFLAG_TEXWRAP(1));
@@ -2292,8 +2292,8 @@ std::string menu_select_launch::arts_render_common(float origx1, float origy1, f
 		title_size = (std::max)(text_length + 0.01f, title_size);
 	}
 
-	rgb_t const fgcolor = (m_focus == focused_menu::RIGHTBOTTOM) ? rgb_t(0xff, 0xff, 0x00) : UI_TEXT_COLOR;
-	rgb_t const bgcolor = (m_focus == focused_menu::RIGHTBOTTOM) ? rgb_t(0xff, 0xff, 0xff) : UI_TEXT_BG_COLOR;
+	rgb_t const fgcolor = (m_focus == focused_menu::RIGHTBOTTOM) ? rgb_t(0xff, 0xff, 0x00) : ui().options().text_color();
+	rgb_t const bgcolor = (m_focus == focused_menu::RIGHTBOTTOM) ? rgb_t(0xff, 0xff, 0xff) : ui().options().text_bg_color();
 	float const middle = origx2 - origx1;
 
 	// check size
@@ -2301,7 +2301,7 @@ std::string menu_select_launch::arts_render_common(float origx1, float origy1, f
 	float const tmp_size = (sc > middle) ? ((middle - 2.0f * gutter_width) / sc) : 1.0f;
 	title_size *= tmp_size;
 
-	if (bgcolor != UI_TEXT_BG_COLOR)
+	if (bgcolor != ui().options().text_bg_color())
 	{
 		ui().draw_textured_box(
 				container(),
@@ -2499,10 +2499,10 @@ float menu_select_launch::draw_collapsed_left_panel(float x1, float y1, float x2
 
 	ui().draw_outlined_box(container(), x1, y1, x2, y2, rgb_t(0xef, 0x12, 0x47, 0x7b)); // FIXME: magic numbers in colour?
 
-	rgb_t fgcolor = UI_TEXT_COLOR;
+	rgb_t fgcolor = ui().options().text_color();
 	if (mouse_in_rect(x1, y1, x2, y2))
 	{
-		fgcolor = UI_MOUSEOVER_COLOR;
+		fgcolor = ui().options().mouseover_color();
 		set_hover(HOVER_LPANEL_ARROW);
 	}
 
@@ -2618,14 +2618,14 @@ void menu_select_launch::infos_render(float origx1, float origy1, float origx2, 
 				container(), name,
 				origx1, origy1, origx2 - origx1,
 				ui::text_layout::CENTER, ui::text_layout::NEVER,
-				mame_ui_manager::NONE, UI_TEXT_COLOR, UI_TEXT_BG_COLOR,
+				mame_ui_manager::NONE, ui().options().text_color(), ui().options().text_bg_color(),
 				&txt_length, nullptr);
 		txt_length += 0.01f;
 		title_size = (std::max)(txt_length, title_size);
 	}
 
-	rgb_t fgcolor = UI_TEXT_COLOR;
-	rgb_t bgcolor = UI_TEXT_BG_COLOR;
+	rgb_t fgcolor = ui().options().text_color();
+	rgb_t bgcolor = ui().options().text_bg_color();
 	if (get_focus() == focused_menu::RIGHTBOTTOM)
 	{
 		fgcolor = rgb_t(0xff, 0xff, 0xff, 0x00);
@@ -2639,7 +2639,7 @@ void menu_select_launch::infos_render(float origx1, float origy1, float origx2, 
 	float tmp_size = (sc > middle) ? ((middle - 2.0f * gutter_width) / sc) : 1.0f;
 	title_size *= tmp_size;
 
-	if (bgcolor != UI_TEXT_BG_COLOR)
+	if (bgcolor != ui().options().text_bg_color())
 	{
 		ui().draw_textured_box(container(), origx1 + ((middle - title_size) * 0.5f), origy1, origx1 + ((middle + title_size) * 0.5f),
 				origy1 + line_height, bgcolor, rgb_t(255, 43, 43, 43), hilight_main_texture(), PRIMFLAG_BLENDMODE(BLENDMODE_ALPHA) | PRIMFLAG_TEXWRAP(1));
@@ -2718,14 +2718,14 @@ void menu_select_launch::infos_render(float origx1, float origy1, float origx2, 
 					container(), leftcol.c_str(),
 					origx1 + gutter_width, oy1, sc,
 					ui::text_layout::LEFT, ui::text_layout::TRUNCATE,
-					mame_ui_manager::NORMAL, UI_TEXT_COLOR, UI_TEXT_BG_COLOR,
+					mame_ui_manager::NORMAL, ui().options().text_color(), ui().options().text_bg_color(),
 					nullptr, nullptr,
 					tmp_size3);
 			ui().draw_text_full(
 					container(), rightcol.c_str(),
 					origx1 + gutter_width, oy1, sc,
 					ui::text_layout::RIGHT, ui::text_layout::TRUNCATE,
-					mame_ui_manager::NORMAL, UI_TEXT_COLOR, UI_TEXT_BG_COLOR,
+					mame_ui_manager::NORMAL, ui().options().text_color(), ui().options().text_bg_color(),
 					nullptr, nullptr,
 					tmp_size3);
 		}
@@ -2738,7 +2738,7 @@ void menu_select_launch::infos_render(float origx1, float origy1, float origx2, 
 					container(), tempbuf.c_str(),
 					origx1 + gutter_width, oy1, origx2 - origx1,
 					ui::text_layout::LEFT, ui::text_layout::TRUNCATE,
-					mame_ui_manager::NORMAL, UI_TEXT_COLOR, UI_TEXT_BG_COLOR,
+					mame_ui_manager::NORMAL, ui().options().text_color(), ui().options().text_bg_color(),
 					nullptr, nullptr,
 					tmp_size3);
 		}
@@ -2748,7 +2748,7 @@ void menu_select_launch::infos_render(float origx1, float origy1, float origx2, 
 					container(), tempbuf.c_str(),
 					origx1 + gutter_width, oy1, origx2 - origx1,
 					ui::text_layout::LEFT, ui::text_layout::TRUNCATE,
-					mame_ui_manager::NORMAL, UI_TEXT_COLOR, UI_TEXT_BG_COLOR,
+					mame_ui_manager::NORMAL, ui().options().text_color(), ui().options().text_bg_color(),
 					nullptr, nullptr,
 					text_size);
 		}

--- a/src/frontend/mame/ui/selmenu.cpp
+++ b/src/frontend/mame/ui/selmenu.cpp
@@ -263,7 +263,7 @@ void menu_select_launch::software_parts::custom_render(void *selectedref, float 
 			std::begin(text), std::end(text),
 			origx1, origx2, origy1 - top, origy1 - UI_BOX_TB_BORDER,
 			ui::text_layout::CENTER, ui::text_layout::TRUNCATE, false,
-			ui().options().text_color(), UI_GREEN_COLOR, 1.0f);
+			ui().colors().text_color(), UI_GREEN_COLOR, 1.0f);
 }
 
 
@@ -369,7 +369,7 @@ void menu_select_launch::bios_selection::custom_render(void *selectedref, float 
 			std::begin(text), std::end(text),
 			origx1, origx2, origy1 - top, origy1 - UI_BOX_TB_BORDER,
 			ui::text_layout::CENTER, ui::text_layout::TRUNCATE, false,
-			ui().options().text_color(), UI_GREEN_COLOR, 1.0f);
+			ui().colors().text_color(), UI_GREEN_COLOR, 1.0f);
 }
 
 
@@ -595,7 +595,7 @@ void menu_select_launch::custom_render(void *selectedref, float top, float botto
 			tempbuf, tempbuf + 3,
 			origx1, origx2, origy1 - top, y1,
 			ui::text_layout::CENTER, ui::text_layout::NEVER, true,
-			ui().options().text_color(), ui().options().background_color(), 1.0f);
+			ui().colors().text_color(), ui().colors().background_color(), 1.0f);
 
 	// draw toolbar
 	draw_toolbar(origx1, y1, origx2, origy1 - UI_BOX_TB_BORDER);
@@ -606,7 +606,7 @@ void menu_select_launch::custom_render(void *selectedref, float top, float botto
 	get_selection(swinfo, driver);
 
 	bool isstar = false;
-	rgb_t color = ui().options().background_color();
+	rgb_t color = ui().colors().background_color();
 	if (swinfo && ((swinfo->startempty != 1) || !driver))
 	{
 		isstar = mame_machine_manager::instance()->favorite().is_favorite_system_software(*swinfo);
@@ -706,7 +706,7 @@ void menu_select_launch::custom_render(void *selectedref, float top, float botto
 			std::begin(tempbuf), std::end(tempbuf),
 			origx1, origx2, origy2 + UI_BOX_TB_BORDER, origy2 + bottom,
 			ui::text_layout::CENTER, ui::text_layout::NEVER, true,
-			ui().options().text_color(), color, 1.0f);
+			ui().colors().text_color(), color, 1.0f);
 
 	// is favorite? draw the star
 	if (isstar)
@@ -808,22 +808,22 @@ void menu_select_launch::draw_common_arrow(float origx1, float origy1, float ori
 	float const al_y1 = origy1 + 0.9f * line_height;
 
 	rgb_t fgcolor_right, fgcolor_left;
-	fgcolor_right = fgcolor_left = ui().options().text_color();
+	fgcolor_right = fgcolor_left = ui().colors().text_color();
 
 	// set hover
 	if (mouse_in_rect(ar_x0, ar_y0, ar_x1, ar_y1) && current != dmax)
 	{
-		ui().draw_textured_box(container(), ar_x0 + 0.01f, ar_y0, ar_x1 - 0.01f, ar_y1, ui().options().mouseover_bg_color(), rgb_t(43, 43, 43),
+		ui().draw_textured_box(container(), ar_x0 + 0.01f, ar_y0, ar_x1 - 0.01f, ar_y1, ui().colors().mouseover_bg_color(), rgb_t(43, 43, 43),
 				hilight_main_texture(), PRIMFLAG_BLENDMODE(BLENDMODE_ALPHA) | PRIMFLAG_TEXWRAP(1));
 		set_hover(HOVER_UI_RIGHT);
-		fgcolor_right = ui().options().mouseover_color();
+		fgcolor_right = ui().colors().mouseover_color();
 	}
 	else if (mouse_in_rect(al_x0, al_y0, al_x1, al_y1) && current != dmin)
 	{
-		ui().draw_textured_box(container(), al_x0 + 0.01f, al_y0, al_x1 - 0.01f, al_y1, ui().options().mouseover_bg_color(), rgb_t(43, 43, 43),
+		ui().draw_textured_box(container(), al_x0 + 0.01f, al_y0, al_x1 - 0.01f, al_y1, ui().colors().mouseover_bg_color(), rgb_t(43, 43, 43),
 				hilight_main_texture(), PRIMFLAG_BLENDMODE(BLENDMODE_ALPHA) | PRIMFLAG_TEXWRAP(1));
 		set_hover(HOVER_UI_LEFT);
-		fgcolor_left = ui().options().mouseover_color();
+		fgcolor_left = ui().colors().mouseover_color();
 	}
 
 	// apply arrow
@@ -847,15 +847,15 @@ void menu_select_launch::draw_common_arrow(float origx1, float origy1, float ori
 
 void menu_select_launch::draw_info_arrow(int ub, float origx1, float origx2, float oy1, float line_height, float text_size, float ud_arrow_width)
 {
-	rgb_t fgcolor = ui().options().text_color();
+	rgb_t fgcolor = ui().colors().text_color();
 	uint32_t orientation = (!ub) ? ROT0 : ROT0 ^ ORIENTATION_FLIP_Y;
 
 	if (mouse_in_rect(origx1, oy1, origx2, oy1 + (line_height * text_size)))
 	{
-		ui().draw_textured_box(container(), origx1 + 0.01f, oy1, origx2 - 0.01f, oy1 + (line_height * text_size), ui().options().mouseover_bg_color(),
+		ui().draw_textured_box(container(), origx1 + 0.01f, oy1, origx2 - 0.01f, oy1 + (line_height * text_size), ui().colors().mouseover_bg_color(),
 				rgb_t(43, 43, 43), hilight_main_texture(), PRIMFLAG_BLENDMODE(BLENDMODE_ALPHA) | PRIMFLAG_TEXWRAP(1));
 		set_hover((!ub) ? HOVER_DAT_UP : HOVER_DAT_DOWN);
-		fgcolor = ui().options().mouseover_color();
+		fgcolor = ui().colors().mouseover_color();
 	}
 
 	draw_arrow(0.5f * (origx1 + origx2) - 0.5f * (ud_arrow_width * text_size), oy1 + 0.25f * (line_height * text_size),
@@ -905,7 +905,7 @@ float menu_select_launch::draw_left_panel(
 	float const origy1(y1);
 	float const origy2(y2);
 	x2 = x1 + left_width + 2.0f * UI_BOX_LR_BORDER;
-	ui().draw_outlined_box(container(), x1, y1, x2, y2, ui().options().background_color());
+	ui().draw_outlined_box(container(), x1, y1, x2, y2, ui().colors().background_color());
 	x1 += UI_BOX_LR_BORDER;
 	x2 -= UI_BOX_LR_BORDER;
 	y1 += UI_BOX_TB_BORDER;
@@ -931,12 +931,12 @@ float menu_select_launch::draw_left_panel(
 		}
 
 		// handle mouse hover in passing
-		rgb_t bgcolor = ui().options().text_bg_color();
-		rgb_t fgcolor = ui().options().text_color();
+		rgb_t bgcolor = ui().colors().text_bg_color();
+		rgb_t fgcolor = ui().colors().text_color();
 		if (mouse_in_rect(x1, y1, x2, y1 + line_height_max))
 		{
-			bgcolor = ui().options().mouseover_bg_color();
-			fgcolor = ui().options().mouseover_color();
+			bgcolor = ui().colors().mouseover_bg_color();
+			fgcolor = ui().colors().mouseover_color();
 			set_hover(HOVER_FILTER_FIRST + filter);
 			highlight(x1, y1, x2, y1 + line_height_max, bgcolor);
 		}
@@ -979,10 +979,10 @@ float menu_select_launch::draw_left_panel(
 
 	ui().draw_outlined_box(container(), x1, y1, x2, y2, rgb_t(0xef, 0x12, 0x47, 0x7b));
 
-	rgb_t fgcolor = ui().options().text_color();
+	rgb_t fgcolor = ui().colors().text_color();
 	if (mouse_in_rect(x1, y1, x2, y2))
 	{
-		fgcolor = ui().options().mouseover_color();
+		fgcolor = ui().colors().mouseover_color();
 		set_hover(HOVER_LPANEL_ARROW);
 	}
 
@@ -1206,7 +1206,7 @@ void menu_select_launch::draw_toolbar(float x1, float y1, float x2, float y2)
 				set_hover(HOVER_B_FAV + z);
 				color = rgb_t::white();
 				float ypos = y2 + ui().get_line_height() + 2.0f * UI_BOX_TB_BORDER;
-				ui().draw_text_box(container(), _(hover_msg[z]), ui::text_layout::CENTER, 0.5f, ypos, ui().options().background_color());
+				ui().draw_text_box(container(), _(hover_msg[z]), ui::text_layout::CENTER, 0.5f, ypos, ui().colors().background_color());
 			}
 
 			container().add_quad(x1, y1, x2, y2, color, t_texture[z].get(), PRIMFLAG_BLENDMODE(BLENDMODE_ALPHA));
@@ -1800,7 +1800,7 @@ void menu_select_launch::draw(uint32_t flags)
 	x1 = visible_left - UI_BOX_LR_BORDER;
 	x2 = visible_left + visible_width + UI_BOX_LR_BORDER;
 	float line = visible_top + (float(m_visible_lines) * line_height);
-	ui().draw_outlined_box(container(), x1, y1, x2, y2, ui().options().background_color());
+	ui().draw_outlined_box(container(), x1, y1, x2, y2, ui().colors().background_color());
 
 	if (visible_items < m_visible_lines)
 		m_visible_lines = visible_items;
@@ -1823,9 +1823,9 @@ void menu_select_launch::draw(uint32_t flags)
 		int itemnum = top_line + linenum;
 		const menu_item &pitem = item(itemnum);
 		const char *itemtext = pitem.text.c_str();
-		rgb_t fgcolor = ui().options().text_color();
-		rgb_t bgcolor = ui().options().text_bg_color();
-		rgb_t fgcolor3 = ui().options().clone_color();
+		rgb_t fgcolor = ui().colors().text_color();
+		rgb_t bgcolor = ui().colors().text_bg_color();
+		rgb_t fgcolor3 = ui().colors().clone_color();
 		float line_x0 = x1 + 0.5f * UI_LINE_WIDTH;
 		float line_y0 = line_y;
 		float line_x1 = x2 - 0.5f * UI_LINE_WIDTH;
@@ -1851,13 +1851,13 @@ void menu_select_launch::draw(uint32_t flags)
 		{
 			// else if the mouse is over this item, draw with a different background
 			fgcolor = fgcolor3 = ui().options().mouseover_color();
-			bgcolor = ui().options().mouseover_bg_color();
+			bgcolor = ui().colors().mouseover_bg_color();
 			highlight(line_x0, line_y0, line_x1, line_y1, bgcolor);
 		}
 		else if (pitem.ref == m_prev_selected)
 		{
 			fgcolor = fgcolor3 = ui().options().mouseover_color();
-			bgcolor = ui().options().mouseover_bg_color();
+			bgcolor = ui().colors().mouseover_bg_color();
 			ui().draw_textured_box(container(), line_x0 + 0.01f, line_y0, line_x1 - 0.01f, line_y1, bgcolor, rgb_t(43, 43, 43),
 					hilight_main_texture(), PRIMFLAG_BLENDMODE(BLENDMODE_ALPHA) | PRIMFLAG_TEXWRAP(1));
 		}
@@ -1884,7 +1884,7 @@ void menu_select_launch::draw(uint32_t flags)
 		{
 			// if we're just a divider, draw a line
 			container().add_line(visible_left, line_y + 0.5f * line_height, visible_left + visible_width, line_y + 0.5f * line_height,
-					UI_LINE_WIDTH, ui().options().text_color(), PRIMFLAG_BLENDMODE(BLENDMODE_ALPHA));
+					UI_LINE_WIDTH, ui().colors().text_color(), PRIMFLAG_BLENDMODE(BLENDMODE_ALPHA));
 		}
 		else if (pitem.subtext.empty())
 		{
@@ -1946,8 +1946,8 @@ void menu_select_launch::draw(uint32_t flags)
 		float line_y0 = line;
 		float line_x1 = x2 - 0.5f * UI_LINE_WIDTH;
 		float line_y1 = line + line_height;
-		rgb_t fgcolor = ui().options().text_color();
-		rgb_t bgcolor = ui().options().text_bg_color();
+		rgb_t fgcolor = ui().colors().text_color();
+		rgb_t bgcolor = ui().colors().text_bg_color();
 
 		if (mouse_in_rect(line_x0, line_y0, line_x1, line_y1) && is_selectable(pitem))
 			set_hover(count);
@@ -1964,14 +1964,14 @@ void menu_select_launch::draw(uint32_t flags)
 		else if (count == hover())
 		{
 			fgcolor = ui().options().mouseover_color();
-			bgcolor = ui().options().mouseover_bg_color();
+			bgcolor = ui().colors().mouseover_bg_color();
 			highlight(line_x0, line_y0, line_x1, line_y1, bgcolor);
 		}
 
 		if (pitem.type == menu_item_type::SEPARATOR)
 		{
 			container().add_line(visible_left, line + 0.5f * line_height, visible_left + visible_width, line + 0.5f * line_height,
-					UI_LINE_WIDTH, ui().options().text_color(), PRIMFLAG_BLENDMODE(BLENDMODE_ALPHA));
+					UI_LINE_WIDTH, ui().colors().text_color(), PRIMFLAG_BLENDMODE(BLENDMODE_ALPHA));
 		}
 		else
 		{
@@ -2026,7 +2026,7 @@ void menu_select_launch::draw_right_panel(float origx1, float origy1, float orig
 
 	ui().draw_outlined_box(container(), origx1, origy1, origx2, origy2, rgb_t(0xEF, 0x12, 0x47, 0x7B));
 
-	rgb_t fgcolor(ui().options().text_color());
+	rgb_t fgcolor(ui().colors().text_color());
 	if (mouse_in_rect(origx1, origy1, x2, origy2))
 	{
 		fgcolor = ui().options().mouseover_color();
@@ -2059,10 +2059,10 @@ float menu_select_launch::draw_right_box_title(float x1, float y1, float x2, flo
 	float const midl = (x2 - x1) * 0.5f;
 
 	// add outlined box for options
-	ui().draw_outlined_box(container(), x1, y1, x2, y2, ui().options().background_color());
+	ui().draw_outlined_box(container(), x1, y1, x2, y2, ui().colors().background_color());
 
 	// add separator line
-	container().add_line(x1 + midl, y1, x1 + midl, y1 + line_height, UI_LINE_WIDTH, ui().options().border_color(), PRIMFLAG_BLENDMODE(BLENDMODE_ALPHA));
+	container().add_line(x1 + midl, y1, x1 + midl, y1 + line_height, UI_LINE_WIDTH, ui().colors().border_color(), PRIMFLAG_BLENDMODE(BLENDMODE_ALPHA));
 
 	std::string buffer[RP_LAST + 1];
 	buffer[RP_IMAGES] = _("Images");
@@ -2079,14 +2079,14 @@ float menu_select_launch::draw_right_box_title(float x1, float y1, float x2, flo
 
 	for (int cells = RP_FIRST; cells <= RP_LAST; ++cells)
 	{
-		rgb_t bgcolor = ui().options().text_bg_color();
-		rgb_t fgcolor = ui().options().text_color();
+		rgb_t bgcolor = ui().colors().text_bg_color();
+		rgb_t fgcolor = ui().colors().text_color();
 
 		if (mouse_in_rect(x1, y1, x1 + midl, y1 + line_height))
 		{
 			if (ui_globals::rpanel != cells)
 			{
-				bgcolor = ui().options().mouseover_bg_color();
+				bgcolor = ui().colors().mouseover_bg_color();
 				fgcolor = ui().options().mouseover_color();
 				set_hover(HOVER_RP_FIRST + cells);
 			}
@@ -2095,9 +2095,9 @@ float menu_select_launch::draw_right_box_title(float x1, float y1, float x2, flo
 		if (ui_globals::rpanel != cells)
 		{
 			container().add_line(x1, y1 + line_height, x1 + midl, y1 + line_height, UI_LINE_WIDTH,
-					ui().options().border_color(), PRIMFLAG_BLENDMODE(BLENDMODE_ALPHA));
-			if (fgcolor != ui().options().mouseover_color())
-				fgcolor = ui().options().clone_color();
+					ui().colors().border_color(), PRIMFLAG_BLENDMODE(BLENDMODE_ALPHA));
+			if (fgcolor != ui().colors().mouseover_color())
+				fgcolor = ui().colors().clone_color();
 		}
 
 		if (m_focus == focused_menu::RIGHTTOP && ui_globals::rpanel == cells)
@@ -2107,7 +2107,7 @@ float menu_select_launch::draw_right_box_title(float x1, float y1, float x2, flo
 			ui().draw_textured_box(container(), x1 + UI_LINE_WIDTH, y1 + UI_LINE_WIDTH, x1 + midl - UI_LINE_WIDTH, y1 + line_height,
 					bgcolor, rgb_t(43, 43, 43), hilight_main_texture(), PRIMFLAG_BLENDMODE(BLENDMODE_ALPHA) | PRIMFLAG_TEXWRAP(1));
 		}
-		else if (bgcolor == ui().options().mouseover_bg_color())
+		else if (bgcolor == ui().colors().mouseover_bg_color())
 		{
 			container().add_rect(x1 + UI_LINE_WIDTH, y1 + UI_LINE_WIDTH, x1 + midl - UI_LINE_WIDTH, y1 + line_height,
 					bgcolor, PRIMFLAG_BLENDMODE(BLENDMODE_ALPHA) | PRIMFLAG_TEXWRAP(1));
@@ -2292,8 +2292,8 @@ std::string menu_select_launch::arts_render_common(float origx1, float origy1, f
 		title_size = (std::max)(text_length + 0.01f, title_size);
 	}
 
-	rgb_t const fgcolor = (m_focus == focused_menu::RIGHTBOTTOM) ? rgb_t(0xff, 0xff, 0x00) : ui().options().text_color();
-	rgb_t const bgcolor = (m_focus == focused_menu::RIGHTBOTTOM) ? rgb_t(0xff, 0xff, 0xff) : ui().options().text_bg_color();
+	rgb_t const fgcolor = (m_focus == focused_menu::RIGHTBOTTOM) ? rgb_t(0xff, 0xff, 0x00) : ui().colors().text_color();
+	rgb_t const bgcolor = (m_focus == focused_menu::RIGHTBOTTOM) ? rgb_t(0xff, 0xff, 0xff) : ui().colors().text_bg_color();
 	float const middle = origx2 - origx1;
 
 	// check size
@@ -2301,7 +2301,7 @@ std::string menu_select_launch::arts_render_common(float origx1, float origy1, f
 	float const tmp_size = (sc > middle) ? ((middle - 2.0f * gutter_width) / sc) : 1.0f;
 	title_size *= tmp_size;
 
-	if (bgcolor != ui().options().text_bg_color())
+	if (bgcolor != ui().colors().text_bg_color())
 	{
 		ui().draw_textured_box(
 				container(),
@@ -2499,7 +2499,7 @@ float menu_select_launch::draw_collapsed_left_panel(float x1, float y1, float x2
 
 	ui().draw_outlined_box(container(), x1, y1, x2, y2, rgb_t(0xef, 0x12, 0x47, 0x7b)); // FIXME: magic numbers in colour?
 
-	rgb_t fgcolor = ui().options().text_color();
+	rgb_t fgcolor = ui().colors().text_color();
 	if (mouse_in_rect(x1, y1, x2, y2))
 	{
 		fgcolor = ui().options().mouseover_color();
@@ -2618,14 +2618,14 @@ void menu_select_launch::infos_render(float origx1, float origy1, float origx2, 
 				container(), name,
 				origx1, origy1, origx2 - origx1,
 				ui::text_layout::CENTER, ui::text_layout::NEVER,
-				mame_ui_manager::NONE, ui().options().text_color(), ui().options().text_bg_color(),
+				mame_ui_manager::NONE, ui().colors().text_color(), ui().colors().text_bg_color(),
 				&txt_length, nullptr);
 		txt_length += 0.01f;
 		title_size = (std::max)(txt_length, title_size);
 	}
 
-	rgb_t fgcolor = ui().options().text_color();
-	rgb_t bgcolor = ui().options().text_bg_color();
+	rgb_t fgcolor = ui().colors().text_color();
+	rgb_t bgcolor = ui().colors().text_bg_color();
 	if (get_focus() == focused_menu::RIGHTBOTTOM)
 	{
 		fgcolor = rgb_t(0xff, 0xff, 0xff, 0x00);
@@ -2639,7 +2639,7 @@ void menu_select_launch::infos_render(float origx1, float origy1, float origx2, 
 	float tmp_size = (sc > middle) ? ((middle - 2.0f * gutter_width) / sc) : 1.0f;
 	title_size *= tmp_size;
 
-	if (bgcolor != ui().options().text_bg_color())
+	if (bgcolor != ui().colors().text_bg_color())
 	{
 		ui().draw_textured_box(container(), origx1 + ((middle - title_size) * 0.5f), origy1, origx1 + ((middle + title_size) * 0.5f),
 				origy1 + line_height, bgcolor, rgb_t(255, 43, 43, 43), hilight_main_texture(), PRIMFLAG_BLENDMODE(BLENDMODE_ALPHA) | PRIMFLAG_TEXWRAP(1));
@@ -2718,14 +2718,14 @@ void menu_select_launch::infos_render(float origx1, float origy1, float origx2, 
 					container(), leftcol.c_str(),
 					origx1 + gutter_width, oy1, sc,
 					ui::text_layout::LEFT, ui::text_layout::TRUNCATE,
-					mame_ui_manager::NORMAL, ui().options().text_color(), ui().options().text_bg_color(),
+					mame_ui_manager::NORMAL, ui().colors().text_color(), ui().colors().text_bg_color(),
 					nullptr, nullptr,
 					tmp_size3);
 			ui().draw_text_full(
 					container(), rightcol.c_str(),
 					origx1 + gutter_width, oy1, sc,
 					ui::text_layout::RIGHT, ui::text_layout::TRUNCATE,
-					mame_ui_manager::NORMAL, ui().options().text_color(), ui().options().text_bg_color(),
+					mame_ui_manager::NORMAL, ui().colors().text_color(), ui().colors().text_bg_color(),
 					nullptr, nullptr,
 					tmp_size3);
 		}
@@ -2738,7 +2738,7 @@ void menu_select_launch::infos_render(float origx1, float origy1, float origx2, 
 					container(), tempbuf.c_str(),
 					origx1 + gutter_width, oy1, origx2 - origx1,
 					ui::text_layout::LEFT, ui::text_layout::TRUNCATE,
-					mame_ui_manager::NORMAL, ui().options().text_color(), ui().options().text_bg_color(),
+					mame_ui_manager::NORMAL, ui().colors().text_color(), ui().colors().text_bg_color(),
 					nullptr, nullptr,
 					tmp_size3);
 		}
@@ -2748,7 +2748,7 @@ void menu_select_launch::infos_render(float origx1, float origy1, float origx2, 
 					container(), tempbuf.c_str(),
 					origx1 + gutter_width, oy1, origx2 - origx1,
 					ui::text_layout::LEFT, ui::text_layout::TRUNCATE,
-					mame_ui_manager::NORMAL, ui().options().text_color(), ui().options().text_bg_color(),
+					mame_ui_manager::NORMAL, ui().colors().text_color(), ui().colors().text_bg_color(),
 					nullptr, nullptr,
 					text_size);
 		}

--- a/src/frontend/mame/ui/simpleselgame.cpp
+++ b/src/frontend/mame/ui/simpleselgame.cpp
@@ -42,7 +42,7 @@ simple_menu_select_game::simple_menu_select_game(mame_ui_manager &mui, render_co
 	, m_cached_driver(nullptr)
 	, m_cached_flags(machine_flags::NOT_WORKING)
 	, m_cached_unemulated(device_t::feature::NONE), m_cached_imperfect(device_t::feature::NONE)
-	, m_cached_color(UI_BACKGROUND_COLOR)
+	, m_cached_color(ui().options().background_color())
 {
 	build_driver_list();
 	if (gamename)
@@ -304,7 +304,7 @@ void simple_menu_select_game::custom_render(void *selectedref, float top, float 
 			tempbuf, tempbuf + 1,
 			origx1, origx2, origy1 - top, origy1 - UI_BOX_TB_BORDER,
 			ui::text_layout::CENTER, ui::text_layout::TRUNCATE, false,
-			UI_TEXT_COLOR, UI_BACKGROUND_COLOR, 1.0f);
+			ui().options().text_color(), ui().options().background_color(), 1.0f);
 
 	// determine the text to render below
 	driver = ((uintptr_t)selectedref > skip_main_items) ? (const game_driver *)selectedref : nullptr;
@@ -323,7 +323,7 @@ void simple_menu_select_game::custom_render(void *selectedref, float top, float 
 		if (driver != m_cached_driver)
 		{
 			emu_options clean_options;
-			machine_static_info const info(machine_config(*driver, clean_options));
+			machine_static_info const info(ui().options(), machine_config(*driver, clean_options));
 			m_cached_driver = driver;
 			m_cached_flags = info.machine_flags();
 			m_cached_unemulated = info.unemulated_features();
@@ -386,7 +386,7 @@ void simple_menu_select_game::custom_render(void *selectedref, float top, float 
 			tempbuf, tempbuf + 4,
 			origx1, origx2, origy2 + UI_BOX_TB_BORDER, origy2 + bottom,
 			ui::text_layout::CENTER, ui::text_layout::TRUNCATE, true,
-			UI_TEXT_COLOR, driver ? m_cached_color : UI_BACKGROUND_COLOR, 1.0f);
+			ui().options().text_color(), driver ? m_cached_color : ui().options().background_color(), 1.0f);
 }
 
 

--- a/src/frontend/mame/ui/simpleselgame.cpp
+++ b/src/frontend/mame/ui/simpleselgame.cpp
@@ -42,7 +42,7 @@ simple_menu_select_game::simple_menu_select_game(mame_ui_manager &mui, render_co
 	, m_cached_driver(nullptr)
 	, m_cached_flags(machine_flags::NOT_WORKING)
 	, m_cached_unemulated(device_t::feature::NONE), m_cached_imperfect(device_t::feature::NONE)
-	, m_cached_color(ui().options().background_color())
+	, m_cached_color(ui().colors().background_color())
 {
 	build_driver_list();
 	if (gamename)
@@ -304,7 +304,7 @@ void simple_menu_select_game::custom_render(void *selectedref, float top, float 
 			tempbuf, tempbuf + 1,
 			origx1, origx2, origy1 - top, origy1 - UI_BOX_TB_BORDER,
 			ui::text_layout::CENTER, ui::text_layout::TRUNCATE, false,
-			ui().options().text_color(), ui().options().background_color(), 1.0f);
+			ui().colors().text_color(), ui().colors().background_color(), 1.0f);
 
 	// determine the text to render below
 	driver = ((uintptr_t)selectedref > skip_main_items) ? (const game_driver *)selectedref : nullptr;
@@ -386,7 +386,7 @@ void simple_menu_select_game::custom_render(void *selectedref, float top, float 
 			tempbuf, tempbuf + 4,
 			origx1, origx2, origy2 + UI_BOX_TB_BORDER, origy2 + bottom,
 			ui::text_layout::CENTER, ui::text_layout::TRUNCATE, true,
-			ui().options().text_color(), driver ? m_cached_color : ui().options().background_color(), 1.0f);
+			ui().colors().text_color(), driver ? m_cached_color : ui().colors().background_color(), 1.0f);
 }
 
 

--- a/src/frontend/mame/ui/sliders.cpp
+++ b/src/frontend/mame/ui/sliders.cpp
@@ -230,7 +230,7 @@ void menu_sliders::custom_render(void *selectedref, float top, float bottom, flo
 		x2 = 1.0f - UI_BOX_LR_BORDER;
 
 		// draw extra menu area
-		ui().draw_outlined_box(container(), x1, y1, x2, y2, ui().options().background_color());
+		ui().draw_outlined_box(container(), x1, y1, x2, y2, ui().colors().background_color());
 		y1 += UI_BOX_TB_BORDER;
 
 		// determine the text height
@@ -250,19 +250,19 @@ void menu_sliders::custom_render(void *selectedref, float top, float bottom, flo
 		current_x = bar_left + bar_width * percentage;
 
 		// fill in the percentage
-		container().add_rect(bar_left, bar_top, current_x, bar_bottom, ui().options().slider_color(), PRIMFLAG_BLENDMODE(BLENDMODE_ALPHA));
+		container().add_rect(bar_left, bar_top, current_x, bar_bottom, ui().colors().slider_color(), PRIMFLAG_BLENDMODE(BLENDMODE_ALPHA));
 
 		// draw the top and bottom lines
-		container().add_line(bar_left, bar_top, bar_left + bar_width, bar_top, UI_LINE_WIDTH, ui().options().border_color(), PRIMFLAG_BLENDMODE(BLENDMODE_ALPHA));
-		container().add_line(bar_left, bar_bottom, bar_left + bar_width, bar_bottom, UI_LINE_WIDTH, ui().options().border_color(), PRIMFLAG_BLENDMODE(BLENDMODE_ALPHA));
+		container().add_line(bar_left, bar_top, bar_left + bar_width, bar_top, UI_LINE_WIDTH, ui().colors().border_color(), PRIMFLAG_BLENDMODE(BLENDMODE_ALPHA));
+		container().add_line(bar_left, bar_bottom, bar_left + bar_width, bar_bottom, UI_LINE_WIDTH, ui().colors().border_color(), PRIMFLAG_BLENDMODE(BLENDMODE_ALPHA));
 
 		// draw default marker
-		container().add_line(default_x, bar_area_top, default_x, bar_top, UI_LINE_WIDTH, ui().options().border_color(), PRIMFLAG_BLENDMODE(BLENDMODE_ALPHA));
-		container().add_line(default_x, bar_bottom, default_x, bar_area_top + bar_area_height, UI_LINE_WIDTH, ui().options().border_color(), PRIMFLAG_BLENDMODE(BLENDMODE_ALPHA));
+		container().add_line(default_x, bar_area_top, default_x, bar_top, UI_LINE_WIDTH, ui().colors().border_color(), PRIMFLAG_BLENDMODE(BLENDMODE_ALPHA));
+		container().add_line(default_x, bar_bottom, default_x, bar_area_top + bar_area_height, UI_LINE_WIDTH, ui().colors().border_color(), PRIMFLAG_BLENDMODE(BLENDMODE_ALPHA));
 
 		// draw the actual text
 		ui().draw_text_full(container(), tempstring.c_str(), x1 + UI_BOX_LR_BORDER, y1 + line_height, x2 - x1 - 2.0f * UI_BOX_LR_BORDER,
-					ui::text_layout::CENTER, ui::text_layout::WORD, mame_ui_manager::NORMAL, ui().options().text_color(), ui().options().text_bg_color(), nullptr, &text_height);
+					ui::text_layout::CENTER, ui::text_layout::WORD, mame_ui_manager::NORMAL, ui().colors().text_color(), ui().colors().text_bg_color(), nullptr, &text_height);
 	}
 }
 

--- a/src/frontend/mame/ui/sliders.cpp
+++ b/src/frontend/mame/ui/sliders.cpp
@@ -230,7 +230,7 @@ void menu_sliders::custom_render(void *selectedref, float top, float bottom, flo
 		x2 = 1.0f - UI_BOX_LR_BORDER;
 
 		// draw extra menu area
-		ui().draw_outlined_box(container(), x1, y1, x2, y2, UI_BACKGROUND_COLOR);
+		ui().draw_outlined_box(container(), x1, y1, x2, y2, ui().options().background_color());
 		y1 += UI_BOX_TB_BORDER;
 
 		// determine the text height
@@ -250,19 +250,19 @@ void menu_sliders::custom_render(void *selectedref, float top, float bottom, flo
 		current_x = bar_left + bar_width * percentage;
 
 		// fill in the percentage
-		container().add_rect(bar_left, bar_top, current_x, bar_bottom, UI_SLIDER_COLOR, PRIMFLAG_BLENDMODE(BLENDMODE_ALPHA));
+		container().add_rect(bar_left, bar_top, current_x, bar_bottom, ui().options().slider_color(), PRIMFLAG_BLENDMODE(BLENDMODE_ALPHA));
 
 		// draw the top and bottom lines
-		container().add_line(bar_left, bar_top, bar_left + bar_width, bar_top, UI_LINE_WIDTH, UI_BORDER_COLOR, PRIMFLAG_BLENDMODE(BLENDMODE_ALPHA));
-		container().add_line(bar_left, bar_bottom, bar_left + bar_width, bar_bottom, UI_LINE_WIDTH, UI_BORDER_COLOR, PRIMFLAG_BLENDMODE(BLENDMODE_ALPHA));
+		container().add_line(bar_left, bar_top, bar_left + bar_width, bar_top, UI_LINE_WIDTH, ui().options().border_color(), PRIMFLAG_BLENDMODE(BLENDMODE_ALPHA));
+		container().add_line(bar_left, bar_bottom, bar_left + bar_width, bar_bottom, UI_LINE_WIDTH, ui().options().border_color(), PRIMFLAG_BLENDMODE(BLENDMODE_ALPHA));
 
 		// draw default marker
-		container().add_line(default_x, bar_area_top, default_x, bar_top, UI_LINE_WIDTH, UI_BORDER_COLOR, PRIMFLAG_BLENDMODE(BLENDMODE_ALPHA));
-		container().add_line(default_x, bar_bottom, default_x, bar_area_top + bar_area_height, UI_LINE_WIDTH, UI_BORDER_COLOR, PRIMFLAG_BLENDMODE(BLENDMODE_ALPHA));
+		container().add_line(default_x, bar_area_top, default_x, bar_top, UI_LINE_WIDTH, ui().options().border_color(), PRIMFLAG_BLENDMODE(BLENDMODE_ALPHA));
+		container().add_line(default_x, bar_bottom, default_x, bar_area_top + bar_area_height, UI_LINE_WIDTH, ui().options().border_color(), PRIMFLAG_BLENDMODE(BLENDMODE_ALPHA));
 
 		// draw the actual text
 		ui().draw_text_full(container(), tempstring.c_str(), x1 + UI_BOX_LR_BORDER, y1 + line_height, x2 - x1 - 2.0f * UI_BOX_LR_BORDER,
-					ui::text_layout::CENTER, ui::text_layout::WORD, mame_ui_manager::NORMAL, UI_TEXT_COLOR, UI_TEXT_BG_COLOR, nullptr, &text_height);
+					ui::text_layout::CENTER, ui::text_layout::WORD, mame_ui_manager::NORMAL, ui().options().text_color(), ui().options().text_bg_color(), nullptr, &text_height);
 	}
 }
 

--- a/src/frontend/mame/ui/slotopt.cpp
+++ b/src/frontend/mame/ui/slotopt.cpp
@@ -222,7 +222,7 @@ void menu_slot_devices::custom_render(void *selectedref, float top, float bottom
 				std::begin(text), std::end(text),
 				origx1, origx2, origy2 + UI_BOX_TB_BORDER, origy2 + bottom,
 				ui::text_layout::CENTER, ui::text_layout::TRUNCATE, false,
-				ui().options().text_color(), ui().options().background_color(), 1.0f);
+				ui().colors().text_color(), ui().colors().background_color(), 1.0f);
 	}
 }
 

--- a/src/frontend/mame/ui/slotopt.cpp
+++ b/src/frontend/mame/ui/slotopt.cpp
@@ -222,7 +222,7 @@ void menu_slot_devices::custom_render(void *selectedref, float top, float bottom
 				std::begin(text), std::end(text),
 				origx1, origx2, origy2 + UI_BOX_TB_BORDER, origy2 + bottom,
 				ui::text_layout::CENTER, ui::text_layout::TRUNCATE, false,
-				UI_TEXT_COLOR, UI_BACKGROUND_COLOR, 1.0f);
+				ui().options().text_color(), ui().options().background_color(), 1.0f);
 	}
 }
 

--- a/src/frontend/mame/ui/sndmenu.cpp
+++ b/src/frontend/mame/ui/sndmenu.cpp
@@ -151,7 +151,7 @@ void menu_sound_options::custom_render(void *selectedref, float top, float botto
 			std::begin(toptext), std::end(toptext),
 			origx1, origx2, origy1 - top, origy1 - UI_BOX_TB_BORDER,
 			ui::text_layout::CENTER, ui::text_layout::TRUNCATE, false,
-			ui().options().text_color(), UI_GREEN_COLOR, 1.0f);
+			ui().colors().text_color(), UI_GREEN_COLOR, 1.0f);
 }
 
 } // namespace ui

--- a/src/frontend/mame/ui/sndmenu.cpp
+++ b/src/frontend/mame/ui/sndmenu.cpp
@@ -151,7 +151,7 @@ void menu_sound_options::custom_render(void *selectedref, float top, float botto
 			std::begin(toptext), std::end(toptext),
 			origx1, origx2, origy1 - top, origy1 - UI_BOX_TB_BORDER,
 			ui::text_layout::CENTER, ui::text_layout::TRUNCATE, false,
-			UI_TEXT_COLOR, UI_GREEN_COLOR, 1.0f);
+			ui().options().text_color(), UI_GREEN_COLOR, 1.0f);
 }
 
 } // namespace ui

--- a/src/frontend/mame/ui/submenu.cpp
+++ b/src/frontend/mame/ui/submenu.cpp
@@ -429,7 +429,7 @@ void submenu::custom_render(void *selectedref, float top, float bottom, float or
 			std::begin(toptext), std::end(toptext),
 			origx1, origx2, origy1 - top, origy1 - UI_BOX_TB_BORDER,
 			ui::text_layout::CENTER, ui::text_layout::TRUNCATE, false,
-			UI_TEXT_COLOR, UI_GREEN_COLOR, 1.0f);
+			ui().options().text_color(), UI_GREEN_COLOR, 1.0f);
 
 	if (selectedref)
 	{
@@ -441,7 +441,7 @@ void submenu::custom_render(void *selectedref, float top, float bottom, float or
 					std::begin(bottomtext), std::end(bottomtext),
 					origx1, origx2, origy2 + UI_BOX_TB_BORDER, origy2 + bottom,
 					ui::text_layout::CENTER, ui::text_layout::TRUNCATE, false,
-					UI_TEXT_COLOR, UI_RED_COLOR, 1.0f);
+					ui().options().text_color(), UI_RED_COLOR, 1.0f);
 		}
 	}
 }

--- a/src/frontend/mame/ui/submenu.cpp
+++ b/src/frontend/mame/ui/submenu.cpp
@@ -429,7 +429,7 @@ void submenu::custom_render(void *selectedref, float top, float bottom, float or
 			std::begin(toptext), std::end(toptext),
 			origx1, origx2, origy1 - top, origy1 - UI_BOX_TB_BORDER,
 			ui::text_layout::CENTER, ui::text_layout::TRUNCATE, false,
-			ui().options().text_color(), UI_GREEN_COLOR, 1.0f);
+			ui().colors().text_color(), UI_GREEN_COLOR, 1.0f);
 
 	if (selectedref)
 	{
@@ -441,7 +441,7 @@ void submenu::custom_render(void *selectedref, float top, float bottom, float or
 					std::begin(bottomtext), std::end(bottomtext),
 					origx1, origx2, origy2 + UI_BOX_TB_BORDER, origy2 + bottom,
 					ui::text_layout::CENTER, ui::text_layout::TRUNCATE, false,
-					ui().options().text_color(), UI_RED_COLOR, 1.0f);
+					ui().colors().text_color(), UI_RED_COLOR, 1.0f);
 		}
 	}
 }

--- a/src/frontend/mame/ui/ui.cpp
+++ b/src/frontend/mame/ui/ui.cpp
@@ -515,7 +515,7 @@ float mame_ui_manager::get_string_width(const char *s, float text_size)
 
 void mame_ui_manager::draw_outlined_box(render_container &container, float x0, float y0, float x1, float y1, rgb_t backcolor)
 {
-	draw_outlined_box(container, x0, y0, x1, y1, options().border_color(), backcolor);
+	draw_outlined_box(container, x0, y0, x1, y1, colors().border_color(), backcolor);
 }
 
 

--- a/src/frontend/mame/ui/ui.cpp
+++ b/src/frontend/mame/ui/ui.cpp
@@ -287,7 +287,7 @@ void mame_ui_manager::display_startup_screens(bool first_time)
 	for (int state = 0; state < maxstate && !machine().scheduled_event_pending() && !ui::menu::stack_has_special_main_menu(machine()); state++)
 	{
 		// default to standard colors
-		messagebox_backcolor = options().background_color();
+		messagebox_backcolor = colors().background_color();
 		messagebox_text.clear();
 
 		// pick the next state
@@ -354,7 +354,7 @@ void mame_ui_manager::set_startup_text(const char *text, bool force)
 
 	// copy in the new text
 	messagebox_text.assign(text);
-	messagebox_backcolor = options().background_color();
+	messagebox_backcolor = colors().background_color();
 
 	// don't update more than 4 times/second
 	if (force || (curtime - lastupdatetime) > osd_ticks_per_second() / 4)
@@ -413,7 +413,7 @@ void mame_ui_manager::update_and_render(render_container &container)
 			if (mouse_target->map_point_container(mouse_target_x, mouse_target_y, container, mouse_x, mouse_y))
 			{
 				const float cursor_size = 0.6 * get_line_height();
-				container.add_quad(mouse_x, mouse_y, mouse_x + cursor_size * container.manager().ui_aspect(&container), mouse_y + cursor_size, options().text_color(), m_mouse_arrow_texture, PRIMFLAG_ANTIALIAS(1) | PRIMFLAG_BLENDMODE(BLENDMODE_ALPHA));
+				container.add_quad(mouse_x, mouse_y, mouse_x + cursor_size * container.manager().ui_aspect(&container), mouse_y + cursor_size, colors().text_color(), m_mouse_arrow_texture, PRIMFLAG_ANTIALIAS(1) | PRIMFLAG_BLENDMODE(BLENDMODE_ALPHA));
 			}
 		}
 	}
@@ -541,7 +541,7 @@ void mame_ui_manager::draw_outlined_box(render_container &container, float x0, f
 
 void mame_ui_manager::draw_text(render_container &container, const char *buf, float x, float y)
 {
-	draw_text_full(container, buf, x, y, 1.0f - x, ui::text_layout::LEFT, ui::text_layout::WORD, mame_ui_manager::NORMAL, options().text_color(), options().text_bg_color(), nullptr, nullptr);
+	draw_text_full(container, buf, x, y, 1.0f - x, ui::text_layout::LEFT, ui::text_layout::WORD, mame_ui_manager::NORMAL, colors().text_color(), colors().text_bg_color(), nullptr, nullptr);
 }
 
 
@@ -629,7 +629,7 @@ void mame_ui_manager::draw_text_box(render_container &container, ui::text_layout
 
 void mame_ui_manager::draw_message_window(render_container &container, const char *text)
 {
-	draw_text_box(container, text, ui::text_layout::text_justify::LEFT, 0.5f, 0.5f, options().background_color());
+	draw_text_box(container, text, ui::text_layout::text_justify::LEFT, 0.5f, 0.5f, colors().background_color());
 }
 
 
@@ -1008,7 +1008,7 @@ void mame_ui_manager::image_handler_ingame()
 		{
 			float x = 0.2f;
 			float y = 0.5f * get_line_height() + 2.0f * UI_BOX_TB_BORDER;
-			draw_text_box(machine().render().ui_container(), layout, x, y, options().background_color());
+			draw_text_box(machine().render().ui_container(), layout, x, y, colors().background_color());
 		}
 	}
 }
@@ -2073,7 +2073,7 @@ void mame_ui_manager::popup_time_string(int seconds, std::string message)
 {
 	// extract the text
 	messagebox_poptext = message;
-	messagebox_backcolor = options().background_color();
+	messagebox_backcolor = colors().background_color();
 
 	// set a timer
 	m_popup_text_end = osd_ticks() + osd_ticks_per_second() * seconds;

--- a/src/frontend/mame/ui/ui.cpp
+++ b/src/frontend/mame/ui/ui.cpp
@@ -178,6 +178,7 @@ void mame_ui_manager::init()
 	ui_gfx_init(machine());
 
 	get_font_rows(&machine());
+	m_ui_colors.refresh(options());
 
 	// more initialization
 	using namespace std::placeholders;
@@ -2190,4 +2191,24 @@ void mame_ui_manager::save_main_option()
 void mame_ui_manager::menu_reset()
 {
 	ui::menu::stack_reset(machine());
+}
+
+void ui_colors::refresh(const ui_options &options)
+{
+	m_border_color = options.border_color();
+	m_background_color = options.background_color();
+	m_gfxviewer_bg_color = options.gfxviewer_bg_color();
+	m_unavailable_color = options.unavailable_color();
+	m_text_color = options.text_color();
+	m_text_bg_color = options.text_bg_color();
+	m_subitem_color = options.subitem_color();
+	m_clone_color = options.clone_color();
+	m_selected_color = options.selected_color();
+	m_selected_bg_color = options.selected_bg_color();
+	m_mouseover_color = options.mouseover_color();
+	m_mouseover_bg_color = options.mouseover_bg_color();
+	m_mousedown_color = options.mousedown_color();
+	m_mousedown_bg_color = options.mousedown_bg_color();
+	m_dipsw_color = options.dipsw_color();
+	m_slider_color = options.slider_color();
 }

--- a/src/frontend/mame/ui/ui.h
+++ b/src/frontend/mame/ui/ui.h
@@ -123,6 +123,49 @@ enum class ui_callback_type
 	VIEWER
 };
 
+// ======================> ui_colors
+
+class ui_colors
+{
+public:
+	rgb_t border_color() const { return m_border_color; }
+	rgb_t background_color() const { return m_background_color; }
+	rgb_t gfxviewer_bg_color() const { return m_gfxviewer_bg_color; }
+	rgb_t unavailable_color() const { return m_unavailable_color; }
+	rgb_t text_color() const { return m_text_color; }
+	rgb_t text_bg_color() const { return m_text_bg_color; }
+	rgb_t subitem_color() const { return m_subitem_color; }
+	rgb_t clone_color() const { return m_clone_color; }
+	rgb_t selected_color() const { return m_selected_color; }
+	rgb_t selected_bg_color() const { return m_selected_bg_color; }
+	rgb_t mouseover_color() const { return m_mouseover_color; }
+	rgb_t mouseover_bg_color() const { return m_mouseover_bg_color; }
+	rgb_t mousedown_color() const { return m_mousedown_color; }
+	rgb_t mousedown_bg_color() const { return m_mousedown_bg_color; }
+	rgb_t dipsw_color() const { return m_dipsw_color; }
+	rgb_t slider_color() const { return m_slider_color; }
+
+	void refresh(const ui_options &options);
+
+private:
+	rgb_t m_border_color;
+	rgb_t m_background_color;
+	rgb_t m_gfxviewer_bg_color;
+	rgb_t m_unavailable_color;
+	rgb_t m_text_color;
+	rgb_t m_text_bg_color;
+	rgb_t m_subitem_color;
+	rgb_t m_clone_color;
+	rgb_t m_selected_color;
+	rgb_t m_selected_bg_color;
+	rgb_t m_mouseover_color;
+	rgb_t m_mouseover_bg_color;
+	rgb_t m_mousedown_color;
+	rgb_t m_mousedown_bg_color;
+	rgb_t m_dipsw_color;
+	rgb_t m_slider_color;
+};
+
 // ======================> mame_ui_manager
 
 class mame_ui_manager : public ui_manager, public slider_changed_notifier
@@ -145,6 +188,7 @@ public:
 	running_machine &machine() const { return m_machine; }
 	bool single_step() const { return m_single_step; }
 	ui_options &options() { return m_ui_options; }
+	ui_colors &colors() { return m_ui_colors; }
 	ui::machine_info &machine_info() const { assert(m_machine_info); return *m_machine_info; }
 
 	// setters
@@ -231,6 +275,7 @@ private:
 	render_texture *        m_mouse_arrow_texture;
 	bool                    m_mouse_show;
 	ui_options              m_ui_options;
+	ui_colors				m_ui_colors;
 
 	std::unique_ptr<ui::machine_info> m_machine_info;
 

--- a/src/frontend/mame/ui/ui.h
+++ b/src/frontend/mame/ui/ui.h
@@ -50,22 +50,6 @@ class machine_info;
 #define UI_GREEN_COLOR          rgb_t(0xef,0x10,0x60,0x10)
 #define UI_YELLOW_COLOR         rgb_t(0xef,0x60,0x60,0x10)
 #define UI_RED_COLOR            rgb_t(0xf0,0x60,0x10,0x10)
-#define UI_BORDER_COLOR         decode_ui_color(0)
-#define UI_BACKGROUND_COLOR     decode_ui_color(1)
-#define UI_GFXVIEWER_BG_COLOR   decode_ui_color(2)
-#define UI_UNAVAILABLE_COLOR    decode_ui_color(3)
-#define UI_TEXT_COLOR           decode_ui_color(4)
-#define UI_TEXT_BG_COLOR        decode_ui_color(5)
-#define UI_SUBITEM_COLOR        decode_ui_color(6)
-#define UI_CLONE_COLOR          decode_ui_color(7)
-#define UI_SELECTED_COLOR       decode_ui_color(8)
-#define UI_SELECTED_BG_COLOR    decode_ui_color(9)
-#define UI_MOUSEOVER_COLOR      decode_ui_color(10)
-#define UI_MOUSEOVER_BG_COLOR   decode_ui_color(11)
-#define UI_MOUSEDOWN_COLOR      decode_ui_color(12)
-#define UI_MOUSEDOWN_BG_COLOR   decode_ui_color(13)
-#define UI_DIPSW_COLOR          decode_ui_color(14)
-#define UI_SLIDER_COLOR         decode_ui_color(15)
 
 /* cancel return value for a UI handler */
 #define UI_HANDLER_CANCEL       ((uint32_t)~0)
@@ -305,7 +289,6 @@ private:
 /***************************************************************************
     FUNCTION PROTOTYPES
 ***************************************************************************/
-rgb_t decode_ui_color(int id, running_machine *machine = nullptr);
 int get_font_rows(running_machine *machine = nullptr);
 
 template <typename Format, typename... Params>

--- a/src/frontend/mame/ui/utils.cpp
+++ b/src/frontend/mame/ui/utils.cpp
@@ -358,7 +358,7 @@ private:
 					std::begin(text), std::end(text),
 					x, x2, y - top, y - UI_BOX_TB_BORDER,
 					ui::text_layout::CENTER, ui::text_layout::NEVER, false,
-					UI_TEXT_COLOR, UI_GREEN_COLOR, 1.0f);
+					ui().options().text_color(), UI_GREEN_COLOR, 1.0f);
 		}
 
 	private:
@@ -968,7 +968,7 @@ private:
 					std::begin(text), std::end(text),
 					x, x2, y - top, y - UI_BOX_TB_BORDER,
 					ui::text_layout::CENTER, ui::text_layout::NEVER, false,
-					UI_TEXT_COLOR, UI_GREEN_COLOR, 1.0f);
+					ui().options().text_color(), UI_GREEN_COLOR, 1.0f);
 		}
 
 	private:

--- a/src/frontend/mame/ui/utils.cpp
+++ b/src/frontend/mame/ui/utils.cpp
@@ -358,7 +358,7 @@ private:
 					std::begin(text), std::end(text),
 					x, x2, y - top, y - UI_BOX_TB_BORDER,
 					ui::text_layout::CENTER, ui::text_layout::NEVER, false,
-					ui().options().text_color(), UI_GREEN_COLOR, 1.0f);
+					ui().colors().text_color(), UI_GREEN_COLOR, 1.0f);
 		}
 
 	private:
@@ -968,7 +968,7 @@ private:
 					std::begin(text), std::end(text),
 					x, x2, y - top, y - UI_BOX_TB_BORDER,
 					ui::text_layout::CENTER, ui::text_layout::NEVER, false,
-					ui().options().text_color(), UI_GREEN_COLOR, 1.0f);
+					ui().colors().text_color(), UI_GREEN_COLOR, 1.0f);
 		}
 
 	private:

--- a/src/frontend/mame/ui/viewgfx.cpp
+++ b/src/frontend/mame/ui/viewgfx.cpp
@@ -437,7 +437,7 @@ static void palette_handler(mame_ui_manager &mui, render_container &container, u
 		x0 = boxbounds.x0 - (0.5f - 0.5f * (titlewidth + chwidth));
 
 	// go ahead and draw the outer box now
-	mui.draw_outlined_box(container, boxbounds.x0 - x0, boxbounds.y0, boxbounds.x1 + x0, boxbounds.y1, mui.options().gfxviewer_bg_color());
+	mui.draw_outlined_box(container, boxbounds.x0 - x0, boxbounds.y0, boxbounds.x1 + x0, boxbounds.y1, mui.colors().gfxviewer_bg_color());
 
 	// draw the title
 	x0 = 0.5f - 0.5f * titlewidth;
@@ -731,7 +731,7 @@ static void gfxset_handler(mame_ui_manager &mui, render_container &container, ui
 		x0 = boxbounds.x0 - (0.5f - 0.5f * (titlewidth + chwidth));
 
 	// go ahead and draw the outer box now
-	mui.draw_outlined_box(container, boxbounds.x0 - x0, boxbounds.y0, boxbounds.x1 + x0, boxbounds.y1, mui.options().gfxviewer_bg_color());
+	mui.draw_outlined_box(container, boxbounds.x0 - x0, boxbounds.y0, boxbounds.x1 + x0, boxbounds.y1, mui.colors().gfxviewer_bg_color());
 
 	// draw the title
 	x0 = 0.5f - 0.5f * titlewidth;
@@ -1140,7 +1140,7 @@ static void tilemap_handler(mame_ui_manager &mui, render_container &container, u
 	}
 
 	// go ahead and draw the outer box now
-	mui.draw_outlined_box(container, boxbounds.x0, boxbounds.y0, boxbounds.x1, boxbounds.y1, mui.options().gfxviewer_bg_color());
+	mui.draw_outlined_box(container, boxbounds.x0, boxbounds.y0, boxbounds.x1, boxbounds.y1, mui.colors().gfxviewer_bg_color());
 
 	// draw the title
 	x0 = 0.5f - 0.5f * titlewidth;

--- a/src/frontend/mame/ui/viewgfx.cpp
+++ b/src/frontend/mame/ui/viewgfx.cpp
@@ -437,7 +437,7 @@ static void palette_handler(mame_ui_manager &mui, render_container &container, u
 		x0 = boxbounds.x0 - (0.5f - 0.5f * (titlewidth + chwidth));
 
 	// go ahead and draw the outer box now
-	mui.draw_outlined_box(container, boxbounds.x0 - x0, boxbounds.y0, boxbounds.x1 + x0, boxbounds.y1, UI_GFXVIEWER_BG_COLOR);
+	mui.draw_outlined_box(container, boxbounds.x0 - x0, boxbounds.y0, boxbounds.x1 + x0, boxbounds.y1, mui.options().gfxviewer_bg_color());
 
 	// draw the title
 	x0 = 0.5f - 0.5f * titlewidth;
@@ -731,7 +731,7 @@ static void gfxset_handler(mame_ui_manager &mui, render_container &container, ui
 		x0 = boxbounds.x0 - (0.5f - 0.5f * (titlewidth + chwidth));
 
 	// go ahead and draw the outer box now
-	mui.draw_outlined_box(container, boxbounds.x0 - x0, boxbounds.y0, boxbounds.x1 + x0, boxbounds.y1, UI_GFXVIEWER_BG_COLOR);
+	mui.draw_outlined_box(container, boxbounds.x0 - x0, boxbounds.y0, boxbounds.x1 + x0, boxbounds.y1, mui.options().gfxviewer_bg_color());
 
 	// draw the title
 	x0 = 0.5f - 0.5f * titlewidth;
@@ -1140,7 +1140,7 @@ static void tilemap_handler(mame_ui_manager &mui, render_container &container, u
 	}
 
 	// go ahead and draw the outer box now
-	mui.draw_outlined_box(container, boxbounds.x0, boxbounds.y0, boxbounds.x1, boxbounds.y1, UI_GFXVIEWER_BG_COLOR);
+	mui.draw_outlined_box(container, boxbounds.x0, boxbounds.y0, boxbounds.x1, boxbounds.y1, mui.options().gfxviewer_bg_color());
 
 	// draw the title
 	x0 = 0.5f - 0.5f * titlewidth;


### PR DESCRIPTION
The various UI_*COLOR macros were implemented as calls to
decode_ui_color, which cached the values for the various options in a
static array, which was obviously a gross hack.

This refactoring is strategic because I am trying to confine awareness
of mame_ui_manager to code in src/frontend/mame/ui, and the
implementation of decode_ui_color() relied on the ability to access
mame_ui_manager as a singleton from outside this code.