### PR TITLE
Moving single stepping logic from mame_ui_manager to video_manager

### DIFF
--- a/scripts/src/emu.lua
+++ b/scripts/src/emu.lua
@@ -211,6 +211,8 @@ files {
 	MAME_DIR .. "src/emu/validity.h",
 	MAME_DIR .. "src/emu/video.cpp",
 	MAME_DIR .. "src/emu/video.h",
+	MAME_DIR .. "src/emu/frame.cpp",
+	MAME_DIR .. "src/emu/frame.h",
 	MAME_DIR .. "src/emu/xtal.cpp",
 	MAME_DIR .. "src/emu/xtal.h",
 	MAME_DIR .. "src/emu/rendersw.hxx",

--- a/src/emu/emu.h
+++ b/src/emu/emu.h
@@ -96,6 +96,7 @@
 #include "drawgfx.h"
 #include "tilemap.h"
 #include "video.h"
+#include "./frame.h"
 
 // sound-related
 #include "sound.h"

--- a/src/emu/emufwd.h
+++ b/src/emu/emufwd.h
@@ -246,4 +246,7 @@ class validity_checker;
 // declared in video.h
 class video_manager;
 
+// declared in frame.h
+class frame_manager;
+
 #endif // MAME_EMU_EMUFWD_H

--- a/src/emu/frame.cpp
+++ b/src/emu/frame.cpp
@@ -1,0 +1,173 @@
+// license:BSD-3-Clause
+// copyright-holders:Aaron Giles
+/***************************************************************************
+
+    frame.cpp
+
+	Core MAME frame handling routines.
+
+***************************************************************************/
+
+#include "emu.h"
+#include "machine.h"
+#include "emuopts.h"
+
+
+//**************************************************************************
+//  GLOBAL VARIABLES
+//**************************************************************************
+
+// frameskipping tables
+const bool frame_manager::s_skiptable[FRAMESKIP_LEVELS][FRAMESKIP_LEVELS] =
+{
+	{ false, false, false, false, false, false, false, false, false, false, false, false },
+	{ false, false, false, false, false, false, false, false, false, false, false, true  },
+	{ false, false, false, false, false, true , false, false, false, false, false, true  },
+	{ false, false, false, true , false, false, false, true , false, false, false, true  },
+	{ false, false, true , false, false, true , false, false, true , false, false, true  },
+	{ false, true , false, false, true , false, true , false, false, true , false, true  },
+	{ false, true , false, true , false, true , false, true , false, true , false, true  },
+	{ false, true , false, true , true , false, true , false, true , true , false, true  },
+	{ false, true , true , false, true , true , false, true , true , false, true , true  },
+	{ false, true , true , true , false, true , true , true , false, true , true , true  },
+	{ false, true , true , true , true , true , false, true , true , true , true , true  },
+	{ false, true , true , true , true , true , true , true , true , true , true , true  }
+};
+
+
+//**************************************************************************
+//  FRAME MANAGER
+//**************************************************************************
+
+//-------------------------------------------------
+//  frame_manager - constructor
+//-------------------------------------------------
+
+frame_manager::frame_manager(running_machine &machine)
+	: m_machine(machine)
+	, m_empty_skip_count(0)
+	, m_frameskip_level(machine.options().frameskip())
+	, m_frameskip_counter(0)
+	, m_frameskip_adjust(0)
+	, m_skipping_this_frame(false)
+	, m_average_oversleep(0)
+	, m_single_step(false)
+{
+}
+
+
+//-------------------------------------------------
+//  update_frameskip - update frameskipping
+//  counters and periodically update autoframeskip
+//-------------------------------------------------
+
+void frame_manager::update_frameskip()
+{
+	// if we're throttling and autoframeskip is on, adjust
+	if (machine().video().effective_throttle() && machine().video().effective_autoframeskip() && m_frameskip_counter == 0)
+	{
+		// calibrate the "adjusted speed" based on the target
+		double adjusted_speed_percent = machine().video().speed_percent() / (double)machine().video().throttle_rate();
+
+		// if we're too fast, attempt to increase the frameskip
+		double speed = machine().video().speed_factor() * 0.001;
+		if (adjusted_speed_percent >= 0.995 * speed)
+		{
+			// but only after 3 consecutive frames where we are too fast
+			if (++m_frameskip_adjust >= 3)
+			{
+				m_frameskip_adjust = 0;
+				if (m_frameskip_level > 0)
+					m_frameskip_level--;
+			}
+		}
+
+		// if we're too slow, attempt to increase the frameskip
+		else
+		{
+			// if below 80% speed, be more aggressive
+			if (adjusted_speed_percent < 0.80 *  speed)
+				m_frameskip_adjust -= (0.90 * speed - machine().video().speed_percent()) / 0.05;
+
+			// if we're close, only force it up to frameskip 8
+			else if (m_frameskip_level < 8)
+				m_frameskip_adjust--;
+
+			// perform the adjustment
+			while (m_frameskip_adjust <= -2)
+			{
+				m_frameskip_adjust += 2;
+				if (m_frameskip_level < MAX_FRAMESKIP)
+					m_frameskip_level++;
+			}
+		}
+	}
+
+	// increment the frameskip counter and determine if we will skip the next frame
+	m_frameskip_counter = (m_frameskip_counter + 1) % FRAMESKIP_LEVELS;
+	m_skipping_this_frame = s_skiptable[machine().video().effective_frameskip()][m_frameskip_counter];
+}
+
+
+//-------------------------------------------------
+//  set_frameskip - set the current actual
+//  frameskip (-1 means autoframeskip)
+//-------------------------------------------------
+
+void frame_manager::set_frameskip(int frameskip)
+{
+	// -1 means autoframeskip
+	if (frameskip == -1)
+	{
+		m_auto_frameskip = true;
+		m_frameskip_level = 0;
+	}
+
+	// any other level is a direct control
+	else if (frameskip >= 0 && frameskip <= MAX_FRAMESKIP)
+	{
+		m_auto_frameskip = false;
+		m_frameskip_level = frameskip;
+	}
+}
+
+
+bool frame_manager::frame_update()
+{
+	// only render sound and video if we're in the running phase
+	machine_phase const phase = machine().phase();
+	bool skipped_it = m_skipping_this_frame;
+	if (phase == machine_phase::RUNNING && (!machine().paused() || machine().options().update_in_pause()))
+	{
+		bool anything_changed = machine().video().finish_screen_updates();
+
+		// if none of the screens changed and we haven't skipped too many frames in a row,
+		// mark this frame as skipped to prevent throttling; this helps for games that
+		// don't update their screen at the monitor refresh rate
+		if (!anything_changed && !m_auto_frameskip && m_frameskip_level == 0 && m_empty_skip_count++ < 3)
+			skipped_it = true;
+		else
+			m_empty_skip_count = 0;
+	}
+
+	// if we're single-stepping, pause now
+	if (m_single_step)
+	{
+		machine().pause();
+		m_single_step = false;
+	}
+
+	return skipped_it;
+}
+
+
+//-------------------------------------------------
+//  step_single_frame
+//-------------------------------------------------
+
+void frame_manager::step_single_frame()
+{
+	machine().rewind_capture();
+	m_single_step = true;
+	machine().resume();
+}

--- a/src/emu/frame.h
+++ b/src/emu/frame.h
@@ -1,0 +1,86 @@
+// license:BSD-3-Clause
+// copyright-holders:Aaron Giles
+/***************************************************************************
+
+    video.h
+
+    Core MAME frame handling routines.
+
+***************************************************************************/
+
+#pragma once
+
+#ifndef __EMU_H__
+#error Dont include this file directly; include emu.h instead.
+#endif
+
+#ifndef MAME_EMU_FRAME_H
+#define MAME_EMU_FRAME_H
+
+
+//**************************************************************************
+//  CONSTANTS
+//**************************************************************************
+
+// number of levels of frameskipping supported
+constexpr int FRAMESKIP_LEVELS = 12;
+constexpr int MAX_FRAMESKIP = FRAMESKIP_LEVELS - 2;
+
+
+//**************************************************************************
+//  TYPE DEFINITIONS
+//**************************************************************************
+
+class running_machine;
+
+// ======================> frame_manager
+
+class frame_manager
+{
+public:
+	// construction/destruction
+	frame_manager(running_machine &machine);
+
+	// getters
+	running_machine &machine() const { return m_machine; }
+	bool skip_this_frame() const { return m_skipping_this_frame; }
+	int frameskip() const { return m_auto_frameskip ? -1 : m_frameskip_level; }
+	osd_ticks_t average_oversleep() const { return m_average_oversleep; }
+	bool auto_frameskip() const { return m_auto_frameskip; }
+	u8 frameskip_level() const { return m_frameskip_level; }
+
+	// setters
+	void set_frameskip(int frameskip);
+	void set_average_oversleep(osd_ticks_t value) { m_average_oversleep = value; }
+
+	// speed and throttling helpers
+	void update_frameskip();
+
+	// single stepping
+	void step_single_frame();
+	bool is_single_stepping() const { return m_single_step; }
+
+	bool frame_update();
+
+private:
+	// internal state
+	running_machine &	m_machine;                  // reference to our machine
+
+	// frameskipping
+	u8                  m_empty_skip_count;         // number of empty frames we have skipped
+	u8                  m_frameskip_level;          // current frameskip level
+	u8                  m_frameskip_counter;        // counter that counts through the frameskip steps
+	s8                  m_frameskip_adjust;
+	bool                m_skipping_this_frame;      // flag: true if we are skipping the current frame
+	osd_ticks_t         m_average_oversleep;        // average number of ticks the OSD oversleeps
+
+	// configuration
+	bool                m_auto_frameskip;           // flag: true if we're automatically frameskipping
+
+	// single stepping
+	bool                m_single_step;				// are we currently single stepping?
+
+	static const bool   s_skiptable[FRAMESKIP_LEVELS][FRAMESKIP_LEVELS];
+};
+
+#endif // MAME_EMU_FRAME_H

--- a/src/emu/machine.cpp
+++ b/src/emu/machine.cpp
@@ -203,8 +203,9 @@ void running_machine::start()
 	// init the osd layer
 	m_manager.osd().init(*this);
 
-	// create the video manager
+	// create the video manager, frame manager, and UI
 	m_video = std::make_unique<video_manager>(*this);
+	m_frame = std::make_unique<frame_manager>(*this);
 	m_ui = manager().create_ui(*this);
 
 	// initialize the base time (needed for doing record/playback)

--- a/src/emu/machine.h
+++ b/src/emu/machine.h
@@ -176,6 +176,7 @@ public:
 	input_manager &input() const { assert(m_input != nullptr); return *m_input; }
 	sound_manager &sound() const { assert(m_sound != nullptr); return *m_sound; }
 	video_manager &video() const { assert(m_video != nullptr); return *m_video; }
+	frame_manager &frame() const { assert(m_frame != nullptr); return *m_frame; }
 	network_manager &network() const { assert(m_network != nullptr); return *m_network; }
 	bookkeeping_manager &bookkeeping() const { assert(m_network != nullptr); return *m_bookkeeping; }
 	configuration_manager  &configuration() const { assert(m_configuration != nullptr); return *m_configuration; }
@@ -320,6 +321,7 @@ private:
 	std::unique_ptr<input_manager> m_input;            // internal data from input.cpp
 	std::unique_ptr<sound_manager> m_sound;            // internal data from sound.cpp
 	std::unique_ptr<video_manager> m_video;            // internal data from video.cpp
+	std::unique_ptr<frame_manager> m_frame;            // internal data from frame.cpp
 	ui_manager *m_ui;                                  // internal data from ui.cpp
 	std::unique_ptr<ui_input_manager> m_ui_input;      // internal data from uiinput.cpp
 	std::unique_ptr<tilemap_manager> m_tilemap;        // internal data from tilemap.cpp

--- a/src/emu/screen.cpp
+++ b/src/emu/screen.cpp
@@ -1044,7 +1044,7 @@ bool screen_device::update_partial(int scanline)
 	if (!(m_video_attributes & VIDEO_ALWAYS_UPDATE))
 	{
 		// if skipping this frame, bail
-		if (machine().video().skip_this_frame())
+		if (machine().frame().skip_this_frame())
 		{
 			LOG_PARTIAL_UPDATES(("skipped due to frameskipping\n"));
 			return false;
@@ -1121,7 +1121,7 @@ void screen_device::update_now()
 	if (!(m_video_attributes & VIDEO_ALWAYS_UPDATE))
 	{
 		// if skipping this frame, bail
-		if (machine().video().skip_this_frame())
+		if (machine().frame().skip_this_frame())
 		{
 			LOG_PARTIAL_UPDATES(("skipped due to frameskipping\n"));
 			return;
@@ -1523,7 +1523,7 @@ bool screen_device::update_quads()
 		if (m_type != SCREEN_TYPE_VECTOR && (m_video_attributes & VIDEO_SELF_RENDER) == 0)
 		{
 			// if we're not skipping the frame and if the screen actually changed, then update the texture
-			if (!machine().video().skip_this_frame() && m_changed)
+			if (!machine().frame().skip_this_frame() && m_changed)
 			{
 				m_texture[m_curbitmap]->set_bitmap(m_bitmap[m_curbitmap], m_visarea, m_bitmap[m_curbitmap].texformat());
 				m_curtexture = m_curbitmap;

--- a/src/emu/video.cpp
+++ b/src/emu/video.cpp
@@ -97,6 +97,7 @@ video_manager::video_manager(running_machine &machine)
 	, m_frameskip_adjust(0)
 	, m_skipping_this_frame(false)
 	, m_average_oversleep(0)
+	, m_single_step(false)
 	, m_snap_target(nullptr)
 	, m_snap_native(true)
 	, m_snap_width(0)
@@ -236,6 +237,13 @@ void video_manager::frame_update(bool from_debugger)
 			skipped_it = true;
 		else
 			m_empty_skip_count = 0;
+	}
+
+	// if we're single-stepping, pause now
+	if (m_single_step)
+	{
+		machine().pause();
+		m_single_step = false;
 	}
 
 	// draw the user interface
@@ -1568,4 +1576,16 @@ void video_manager::end_recording(movie_format format)
 			osd_printf_error("Unknown movie format: %d\n", format);
 			break;
 	}
+}
+
+
+//-------------------------------------------------
+//  single_step
+//-------------------------------------------------
+
+void video_manager::single_step()
+{
+	machine().rewind_capture();
+	m_single_step = true;
+	machine().resume();
 }

--- a/src/emu/video.h
+++ b/src/emu/video.h
@@ -74,6 +74,10 @@ public:
 	void toggle_record_avi() { toggle_record_movie(MF_AVI); }
 	osd_file::error open_next(emu_file &file, const char *extension, uint32_t index = 0);
 
+	// single stepping
+	void single_step();
+	bool is_single_stepping() const { return m_single_step; }
+
 	// render a frame
 	void frame_update(bool from_debugger = false);
 
@@ -169,6 +173,10 @@ private:
 	s8                  m_frameskip_adjust;
 	bool                m_skipping_this_frame;      // flag: true if we are skipping the current frame
 	osd_ticks_t         m_average_oversleep;        // average number of ticks the OSD oversleeps
+
+	// single stepping
+	bool                m_single_step;				// are we currently single stepping?
+
 
 	// snapshot stuff
 	render_target *     m_snap_target;              // screen shapshot target

--- a/src/frontend/mame/luaengine.cpp
+++ b/src/frontend/mame/luaengine.cpp
@@ -779,8 +779,7 @@ void lua_engine::initialize()
 	emu["pause"] = [this](){ return machine().pause(); };
 	emu["unpause"] = [this](){ return machine().resume(); };
 	emu["step"] = [this]() {
-			mame_machine_manager::instance()->ui().set_single_step(true);
-			machine().resume();
+			machine().video().single_step();
 		};
 	emu["register_prestart"] = [this](sol::function func){ register_function(func, "LUA_ON_PRESTART"); };
 	emu["register_start"] = [this](sol::function func){ register_function(func, "LUA_ON_START"); };
@@ -2162,7 +2161,6 @@ void lua_engine::initialize()
  * ui:get_string_width(str, scale) - get str width with ui font at scale factor of current font size
  * ui:get_char_width(char) - get width of utf8 glyph char with ui font
  *
- * ui.single_step
  * ui.show_fps - fps display enabled
  * ui.show_profiler - profiler display enabled
  */
@@ -2172,7 +2170,6 @@ void lua_engine::initialize()
 			"options", [](mame_ui_manager &m) { return static_cast<core_options *>(&m.options()); },
 			"show_fps", sol::property(&mame_ui_manager::show_fps, &mame_ui_manager::set_show_fps),
 			"show_profiler", sol::property(&mame_ui_manager::show_profiler, &mame_ui_manager::set_show_profiler),
-			"single_step", sol::property(&mame_ui_manager::single_step, &mame_ui_manager::set_single_step),
 			"get_line_height", &mame_ui_manager::get_line_height,
 			"get_string_width", &mame_ui_manager::get_string_width,
 			// sol converts char32_t to a string

--- a/src/frontend/mame/luaengine.cpp
+++ b/src/frontend/mame/luaengine.cpp
@@ -779,7 +779,7 @@ void lua_engine::initialize()
 	emu["pause"] = [this](){ return machine().pause(); };
 	emu["unpause"] = [this](){ return machine().resume(); };
 	emu["step"] = [this]() {
-			machine().video().single_step();
+			machine().frame().step_single_frame();
 		};
 	emu["register_prestart"] = [this](sol::function func){ register_function(func, "LUA_ON_PRESTART"); };
 	emu["register_start"] = [this](sol::function func){ register_function(func, "LUA_ON_START"); };
@@ -1192,6 +1192,7 @@ void lua_engine::initialize()
  *
  * machine:system() - get game_driver for running driver
  * machine:video() - get video_manager
+ * machine:frame() - get frame_manager
  * machine:render() - get render_manager
  * machine:ioport() - get ioport_manager
  * machine:parameters() - get parameter_manager
@@ -1217,6 +1218,7 @@ void lua_engine::initialize()
 			"load", &running_machine::schedule_load,
 			"system", &running_machine::system,
 			"video", &running_machine::video,
+			"frame", &running_machine::frame,
 			"render", &running_machine::render,
 			"ioport", &running_machine::ioport,
 			"parameters", &running_machine::parameters,
@@ -1815,12 +1817,10 @@ void lua_engine::initialize()
  * video:end_recording() - stop AVI recording
  * video:is_recording() - get recording status
  * video:snapshot() - save shot of all screens
- * video:skip_this_frame() - is current frame going to be skipped
  * video:speed_factor() - get speed factor
  * video:speed_percent() - get percent from realtime
  * video:frame_update()
  *
- * video.frameskip - current frameskip
  * video.throttled - throttle state
  * video.throttle_rate - throttle rate
  */
@@ -1843,13 +1843,23 @@ void lua_engine::initialize()
 				},
 			"snapshot", &video_manager::save_active_screen_snapshots,
 			"is_recording", &video_manager::is_recording,
-			"skip_this_frame", &video_manager::skip_this_frame,
 			"speed_factor", &video_manager::speed_factor,
 			"speed_percent", &video_manager::speed_percent,
 			"frame_update", &video_manager::frame_update,
-			"frameskip", sol::property(&video_manager::frameskip, &video_manager::set_frameskip),
 			"throttled", sol::property(&video_manager::throttled, &video_manager::set_throttled),
 			"throttle_rate", sol::property(&video_manager::throttle_rate, &video_manager::set_throttle_rate));
+
+/*  frame_manager library
+ *
+ * manager:machine():frame()
+ *
+ * frame:skip_this_frame() - is current frame going to be skipped
+ *
+ * frame.frameskip - current frameskip
+ */
+	sol().registry().new_usertype<frame_manager>("frame", "new", sol::no_constructor,
+			"skip_this_frame", &frame_manager::skip_this_frame,
+			"frameskip", sol::property(&frame_manager::frameskip, &frame_manager::set_frameskip));
 
 
 /*  input_manager library

--- a/src/frontend/mame/ui/ui.cpp
+++ b/src/frontend/mame/ui/ui.cpp
@@ -394,7 +394,7 @@ void mame_ui_manager::update_and_render(render_container &container)
 	container.empty();
 
 	// if we're paused, dim the whole screen
-	if (machine().phase() >= machine_phase::RESET && (machine().video().is_single_stepping() || machine().paused()))
+	if (machine().phase() >= machine_phase::RESET && (machine().frame().is_single_stepping() || machine().paused()))
 	{
 		int alpha = (1.0f - machine().options().pause_brightness()) * 255.0f;
 		if (ui::menu::stack_has_special_main_menu(machine()))
@@ -862,10 +862,10 @@ void mame_ui_manager::process_natural_keyboard()
 void mame_ui_manager::increase_frameskip()
 {
 	// get the current value and increment it
-	int newframeskip = machine().video().frameskip() + 1;
+	int newframeskip = machine().frame().frameskip() + 1;
 	if (newframeskip > MAX_FRAMESKIP)
 		newframeskip = -1;
-	machine().video().set_frameskip(newframeskip);
+	machine().frame().set_frameskip(newframeskip);
 
 	// display the FPS counter for 2 seconds
 	show_fps_temp(2.0);
@@ -879,10 +879,10 @@ void mame_ui_manager::increase_frameskip()
 void mame_ui_manager::decrease_frameskip()
 {
 	// get the current value and decrement it
-	int newframeskip = machine().video().frameskip() - 1;
+	int newframeskip = machine().frame().frameskip() - 1;
 	if (newframeskip < -1)
 		newframeskip = MAX_FRAMESKIP;
-	machine().video().set_frameskip(newframeskip);
+	machine().frame().set_frameskip(newframeskip);
 
 	// display the FPS counter for 2 seconds
 	show_fps_temp(2.0);
@@ -1191,7 +1191,7 @@ uint32_t mame_ui_manager::handler_ingame(render_container &container)
 
 	// pause single step
 	if (machine().ui_input().pressed(IPT_UI_PAUSE_SINGLE))
-		machine().video().single_step();
+		machine().frame().step_single_frame();
 
 	// rewind single step
 	if (machine().ui_input().pressed(IPT_UI_REWIND_SINGLE))

--- a/src/frontend/mame/ui/ui.h
+++ b/src/frontend/mame/ui/ui.h
@@ -159,12 +159,8 @@ public:
 
 	// getters
 	running_machine &machine() const { return m_machine; }
-	bool single_step() const { return m_single_step; }
 	ui_options &options() { return m_ui_options; }
 	ui::machine_info &machine_info() const { assert(m_machine_info); return *m_machine_info; }
-
-	// setters
-	void set_single_step(bool single_step) { m_single_step = single_step; }
 
 	// methods
 	void initialize(running_machine &machine);
@@ -237,7 +233,6 @@ private:
 	std::function<uint32_t (render_container &)> m_handler_callback;
 	ui_callback_type        m_handler_callback_type;
 	uint32_t                  m_handler_param;
-	bool                    m_single_step;
 	bool                    m_showfps;
 	osd_ticks_t             m_showfps_end;
 	bool                    m_show_profiler;

--- a/src/lib/netlist/nl_base.h
+++ b/src/lib/netlist/nl_base.h
@@ -651,7 +651,11 @@ namespace netlist
 			}
 
 			void push_to_queue(netlist_time delay) NL_NOEXCEPT;
+#ifdef _MSC_VER
+			bool is_queued() const noexcept { return false; }
+#else
 			bool is_queued() const noexcept { return m_in_queue == queue_status::QUEUED; }
+#endif
 
 			template <bool KEEP_STATS>
 			void update_devs() NL_NOEXCEPT;
@@ -1705,6 +1709,7 @@ namespace netlist
 		{
 			m_list_active.push_front(&term);
 			railterminal().device().do_inc_active();
+#ifndef _MSC_VER
 			if (m_in_queue == queue_status::DELAYED_DUE_TO_INACTIVE)
 			{
 				if (m_next_scheduled_time > exec().time())
@@ -1720,6 +1725,7 @@ namespace netlist
 				update_inputs();
 			}
 			else
+#endif
 				term.set_copied_input(m_cur_Q);
 		}
 		else

--- a/src/lib/netlist/plib/parray.h
+++ b/src/lib/netlist/plib/parray.h
@@ -24,7 +24,7 @@ namespace plib {
 	struct sizeabs
 	{
 		static constexpr std::size_t ABS() { return (SIZE < 0) ? static_cast<std::size_t>(0 - SIZE) : static_cast<std::size_t>(SIZE); }
-		using container = typename std::array<FT, ABS()> ;
+		using container = typename std::array<FT, 666> ;
 	};
 
 	template <typename FT>

--- a/src/mame/video/cave.cpp
+++ b/src/mame/video/cave.cpp
@@ -1508,7 +1508,7 @@ void cave_state::get_sprite_info(int chip)
 
 	if (m_kludge == 3)   /* mazinger metmqstr */
 	{
-		if (machine().video().skip_this_frame() == 0)
+		if (machine().frame().skip_this_frame() == 0)
 		{
 			m_spriteram_bank[chip] = m_spriteram_bank_delay[chip];
 			(this->*m_get_sprite_info)(chip);
@@ -1517,7 +1517,7 @@ void cave_state::get_sprite_info(int chip)
 	}
 	else
 	{
-		if (machine().video().skip_this_frame() == 0)
+		if (machine().frame().skip_this_frame() == 0)
 		{
 			m_spriteram_bank[chip] = (m_videoregs[chip][4] & 3) % spriteram_bankmax;
 			(this->*m_get_sprite_info)(chip);

--- a/src/mame/video/gaelco3d.cpp
+++ b/src/mame/video/gaelco3d.cpp
@@ -378,7 +378,7 @@ WRITE32_MEMBER(gaelco3d_state::gaelco3d_render_w)
 		fatalerror("Out of polygon buffer &space!\n");
 
 	/* if we've accumulated a completed poly set of data, queue it */
-	if (!machine().video().skip_this_frame())
+	if (!machine().frame().skip_this_frame())
 	{
 		if (m_polydata_count >= 18 && (m_polydata_count % 2) == 1 && IS_POLYEND(m_polydata_buffer[m_polydata_count - 2]))
 		{

--- a/src/mame/video/namcos22.cpp
+++ b/src/mame/video/namcos22.cpp
@@ -734,7 +734,7 @@ void namcos22_state::register_normals(int addr, float m[4][4])
 
 void namcos22_state::draw_direct_poly(const u16 *src)
 {
-	if (machine().video().skip_this_frame())
+	if (machine().frame().skip_this_frame())
 		return;
 
 	int polys_enabled = m_is_ss22 ? nthbyte(m_mixer, 0x1f) & 1 : 1;
@@ -1446,7 +1446,7 @@ WRITE_LINE_MEMBER(namcos22_state::screen_vblank)
 		// still need to determine active state if frame was skipped
 		if (m_skipped_this_frame)
 			render_frame_active();
-		m_skipped_this_frame = machine().video().skip_this_frame();
+		m_skipped_this_frame = machine().frame().skip_this_frame();
 	}
 }
 

--- a/src/mame/video/taito_f3.cpp
+++ b/src/mame/video/taito_f3.cpp
@@ -441,7 +441,7 @@ WRITE_LINE_MEMBER(taito_f3_state::screen_vblank)
 	{
 		if (m_sprite_lag==2)
 		{
-			if (machine().video().skip_this_frame() == 0)
+			if (machine().frame().skip_this_frame() == 0)
 			{
 				get_sprite_info(m_spriteram16_buffered.get());
 			}
@@ -449,7 +449,7 @@ WRITE_LINE_MEMBER(taito_f3_state::screen_vblank)
 		}
 		else if (m_sprite_lag == 1)
 		{
-			if (machine().video().skip_this_frame() == 0)
+			if (machine().frame().skip_this_frame() == 0)
 			{
 				get_sprite_info(m_spriteram.target());
 			}


### PR DESCRIPTION
The logic to step single frames was essentially implemented in
mame_ui_manager, and having this logic here has a negative impact on the
ability to use it in worker_ui, which provides an alternative
implementation of ui_manager.

This change also has the effect of removing the single step property
from luaengine, which is positive because in practice it should have
been seen as an implenentation detail.