### PR TITLE
fmtowns_cd.xml: additions, replacements and cleanups

### DIFF
--- a/hash/fmtowns_cd.xml
+++ b/hash/fmtowns_cd.xml
@@ -62,7 +62,6 @@ Car Marty Exciting CD                                         Fujitsu Ten       
 Car Marty Exciting CD                                         Fujitsu Ten                       1994/3     CD×2
 Car Marty Exciting CD                                         Fujitsu Ten                       1994/6     CD×2
 Castles 2: Bretagne Touitsu Senki                             Victor Entertainment              1993/10    SET(CD+FD)
-Cat's Part-1                                                  Cat's Pro                         1993/4     CD
 CB Trainer Data Library V1.1 L10                              Fujitsu                           1993/5     CD
 CB Trainer Jikkou System V2.1                                 Fujitsu                           1994/9     ?
 CB Trainer V1.1                                               Fujitsu                           1993/5     CD
@@ -133,7 +132,6 @@ Diamond Players                                               Wolf Team         
 Dick                                                          Amorphous                         1996/1     CD
 Digital Pinup Girls Vol. 2                                    Transpegasus Limited              1993/6     CD
 Doki Doki Vacation                                            Cocktail Soft                     1995/3     SET(CD+FD)
-Dor Best Selection Gekan                                      D.O.                              1993/5     CD×02
 Do-Re-Mi Canvas                                               Tokyo Shoseki                     1994/12    CD
 Dracula Hakushaku                                             Fairytale                         1993/3     CD
 Dragon Souseiki                                               Basho House                       1993/12    CD
@@ -235,7 +233,6 @@ Ginga Uchuu Odyssey 1                                         Fujitsu           
 Ginga Uchuu Odyssey 2                                         Fujitsu                           1992/4     CD
 Ginga Uchuu Odyssey 2                                         Fujitsu                           1991/3     CD
 Ginga Yuukyou Densetsu Tobakker                               Ponytail Soft                     1995/11    CD
-Gokko Vol. 1: Doctor                                          Mink                              1994/11    CD
 Gokko Vol. 2: School Gal's                                    Mink                              1994/12    CD
 Gokuraku Mandala                                              Fairytale                         1994/2     CD
 Gomen ne Angel: Yokohama Monogatari                           JAST                              1992/1     ?
@@ -398,7 +395,6 @@ M Talk                                                        Fujitsu Office Kik
 Mahjong Bishoujoden Ripple                                    Foresight                         1995/2     CD
 Mahjong Gensoukyoku 2                                         Active                            1993/9     CD
 Mahjong Gensoukyoku III                                       Active                            1995/11    CD
-Mahjong Gokuu                                                 ASCII                             1989/4     CD
 Mahjong Musashi                                               Cosmos Computer                   1989/10    CD
 Manami no Dokomade Iku no?                                    Wendy Magazine                    1995/5     CD
 Manami no Dokomade Iku no? 2: Return of the Kuro Pack         Wendy Magazine                    1995/5     CD
@@ -645,7 +641,6 @@ Super Kakitaoshi                                              Nikkonren Kikaku  
 Super Zurukamashi                                             Nikkonren Kikaku                  1993/?     SET(CD+FD)
 Suzaku                                                        Wolf Team                         1992/10    SET(CD+FD)
 Tactical Tank Corps DX                                        GAM                               1995/2     SET(CD+FD)
-Taiken Shiyou! Marty Channel                                  Fujitsu                           1993/2     SET(CD+FD)
 Taiken Shiyou! Marty Channel 2                                Fujitsu                           1993/6     CD×02
 Takken Ou                                                     Techno Business                   1994/10    CD
 Tamashii no Mon: Dante "Shinkyoku" yori                       Koei                              1993/6     SET(CD+FD)
@@ -1136,6 +1131,8 @@ User/save disks that can be created from the game itself are not included.
 		<description>Towns Hyakunin Isshu</description>
 		<year>1989</year>
 		<publisher>富士通 (Fujitsu)</publisher>
+		<info name="alt_title" value="ＴＯＷＮＳ百人一首" />
+		<info name="release" value="198911xx" />
 		<info name="usage" value="Requires HDD installation"/>
 		<part name="cdrom" interface="fmt_cdrom">
 			<diskarea name="cdrom">
@@ -1153,6 +1150,7 @@ User/save disks that can be created from the game itself are not included.
 		<description>3x3 Eyes - Sanjiyan Henjou</description>
 		<year>1993</year>
 		<publisher>日本クリエイト (Nihon Create)</publisher>
+		<info name="alt_title" value="３×３ＥＹＥＳ 三只眼變成" />
 		<info name="release" value="199310xx" />
 		<part name="cdrom" interface="fmt_cdrom">
 			<diskarea name="cdrom">
@@ -1170,6 +1168,7 @@ User/save disks that can be created from the game itself are not included.
 		<description>4D Boxing</description>
 		<year>1992</year>
 		<publisher>エレクトロニック・アーツ・ビクター (Electronic Arts Victor)</publisher>
+		<info name="alt_title" value="4D ボクシング" />
 		<info name="release" value="199212xx" />
 		<part name="cdrom" interface="fmt_cdrom">
 			<diskarea name="cdrom">
@@ -1202,6 +1201,7 @@ User/save disks that can be created from the game itself are not included.
 		<description>4D Driving</description>
 		<year>1993</year>
 		<publisher>エレクトロニック・アーツ・ビクター (Electronic Arts Victor)</publisher>
+		<info name="alt_title" value="4D ドライビング" />
 		<info name="release" value="199303xx" />
 		<part name="cdrom" interface="fmt_cdrom">
 			<diskarea name="cdrom">
@@ -1221,6 +1221,7 @@ User/save disks that can be created from the game itself are not included.
 		<description>4D Tennis</description>
 		<year>1993</year>
 		<publisher>エレクトロニック・アーツ・ビクター (Electronic Arts Victor)</publisher>
+		<info name="alt_title" value="4D テニス" />
 		<info name="release" value="199307xx" />
 		<part name="cdrom" interface="fmt_cdrom">
 			<diskarea name="cdrom">
@@ -1289,11 +1290,20 @@ User/save disks that can be created from the game itself are not included.
 
 	<software name="dagain">
 		<!--
-		Origin: Neo Kobe Collection
-		<rom name="The 4th Unit 5 - D-Again.ccd" size="2865" crc="deeee269" sha1="dacd4339ebf7b47b96166f747be3dc7102a5ea7e"/>
-		<rom name="The 4th Unit 5 - D-Again.cue" size="520" crc="cb94b8c2" sha1="8fe745834c8de501f02bb55a529f45ab14fc3caf"/>
-		<rom name="The 4th Unit 5 - D-Again.img" size="371886480" crc="70c2e2bd" sha1="be920e5e1f1bfcb8492ecf06342029999ee088e2"/>
-		<rom name="The 4th Unit 5 - D-Again.sub" size="15179040" crc="0e12788a" sha1="bacc25e3cda1f26b09a9fb4d17662975f5da05f8"/>
+		Origin: redump.org
+		<rom name="4th Unit Act. 5, The - D-Again (Japan) (Track 01).bin" size="84323904" crc="21d1cbf5" sha1="95b02e7aa693ce0795abf6044a715f416f63e0d1"/>
+		<rom name="4th Unit Act. 5, The - D-Again (Japan) (Track 02).bin" size="16576896" crc="e1dac7a1" sha1="a5c69ece79f00f9b98e6d72e0efd1f2b577ba3ff"/>
+		<rom name="4th Unit Act. 5, The - D-Again (Japan) (Track 03).bin" size="36561840" crc="274e2577" sha1="8bc7e92dc24a90c280c558fc153b4ca11158e1a2"/>
+		<rom name="4th Unit Act. 5, The - D-Again (Japan) (Track 04).bin" size="2203824" crc="f4a33665" sha1="7f08aa91932e08d9cc5675c8f4cb37c50041278f"/>
+		<rom name="4th Unit Act. 5, The - D-Again (Japan) (Track 05).bin" size="61276656" crc="87f259ec" sha1="9b1c83b6fe68f6ee6fbfdd7cbf26459200d15410"/>
+		<rom name="4th Unit Act. 5, The - D-Again (Japan) (Track 06).bin" size="26271840" crc="a904aa49" sha1="8e34d609ad4c75a8bfe57c8cab93e1e1555d95d5"/>
+		<rom name="4th Unit Act. 5, The - D-Again (Japan) (Track 07).bin" size="25570944" crc="24b6ba8e" sha1="a64412c712d28fe0272cec2635756412a779664b"/>
+		<rom name="4th Unit Act. 5, The - D-Again (Japan) (Track 08).bin" size="20151936" crc="ccfce28a" sha1="b7a9b784b944d9d6ed5c5c1104d8cf770f9262fa"/>
+		<rom name="4th Unit Act. 5, The - D-Again (Japan) (Track 09).bin" size="38895024" crc="42f606d9" sha1="7425b858aa29309f725dd435d8b7858ed18320c4"/>
+		<rom name="4th Unit Act. 5, The - D-Again (Japan) (Track 10).bin" size="49410816" crc="f2a22ca7" sha1="0bc5a4d6bf5e8bb5651bc61c28f3575fce73c04f"/>
+		<rom name="4th Unit Act. 5, The - D-Again (Japan) (Track 11).bin" size="6432720" crc="c317fe28" sha1="f6854822d48e7334a331c292e890d34604245238"/>
+		<rom name="4th Unit Act. 5, The - D-Again (Japan) (Track 12).bin" size="4210080" crc="098e0d4f" sha1="9ffdd6e14f0e80dec878271c2a0b5a4bb995fcba"/>
+		<rom name="4th Unit Act. 5, The - D-Again (Japan).cue" size="1578" crc="4ac46f84" sha1="b21f37d01a15615cee1d178f7ab55e53e111e66f"/>
 		-->
 		<description>The 4th Unit 5 - D-Again</description>
 		<year>1990</year>
@@ -1301,7 +1311,7 @@ User/save disks that can be created from the game itself are not included.
 		<info name="release" value="199004xx" />
 		<part name="cdrom" interface="fmt_cdrom">
 			<diskarea name="cdrom">
-				<disk name="the 4th unit 5 - d-again" sha1="35ee819833c34bb963c4c167839be947f6433fb4" />
+				<disk name="4th unit act. 5, the - d-again (japan)" sha1="f6c642be482b76d04936b7fd6d76aeb14e1055a8" />
 			</diskarea>
 		</part>
 	</software>
@@ -1327,11 +1337,15 @@ User/save disks that can be created from the game itself are not included.
 
 	<software name="wyatt">
 		<!--
-		Origin: Neo Kobe Collection
-		<rom name="The 4th Unit 7 - Wyatt.ccd" size="1918" crc="3f8f70ba" sha1="0e23516693f3ed1165e6819367604e5a6ac50f8e"/>
-		<rom name="The 4th Unit 7 - Wyatt.cue" size="320" crc="a59b3773" sha1="7b417e3743434b8e2e210109466ecb30a2ceffef"/>
-		<rom name="The 4th Unit 7 - Wyatt.img" size="579899712" crc="f6ff2208" sha1="2ca5d141a3f17c03362699dc032310d15a5ba6f7"/>
-		<rom name="The 4th Unit 7 - Wyatt.sub" size="23669376" crc="a317d739" sha1="a7f01abfcea8b0a7b9bfee62e35136a2335fee27"/>
+		Origin: redump.org
+		<rom name="4th Unit Series, The - Wyatt (Japan) (Track 1).bin" size="367631712" crc="b3f6408a" sha1="635670cdb9b688008fc498b92306505481284ace"/>
+		<rom name="4th Unit Series, The - Wyatt (Japan) (Track 2).bin" size="72465120" crc="935403ca" sha1="a37a03543679cd1676eecf842a20b54d72fb4a95"/>
+		<rom name="4th Unit Series, The - Wyatt (Japan) (Track 3).bin" size="6032880" crc="3b114fb8" sha1="c12fbd4247d3cf9f19c9c026139aa9e3bde5db8a"/>
+		<rom name="4th Unit Series, The - Wyatt (Japan) (Track 4).bin" size="40372080" crc="ad50d07a" sha1="b8aca91a4ebc288aa0f138b5c9c9c8b762da7c80"/>
+		<rom name="4th Unit Series, The - Wyatt (Japan) (Track 5).bin" size="23054304" crc="9c8e5926" sha1="6b999e5c4415af5d11167084792aedd37b1316c8"/>
+		<rom name="4th Unit Series, The - Wyatt (Japan) (Track 6).bin" size="40322688" crc="5906d49b" sha1="ec8dac75569b9520a5f4e24081f6202a2817405c"/>
+		<rom name="4th Unit Series, The - Wyatt (Japan) (Track 7).bin" size="30020928" crc="19025f60" sha1="6819b5c966345ff47c41d920425bddeb72c3dc62"/>
+		<rom name="4th Unit Series, The - Wyatt (Japan).cue" size="777" crc="5a84ad3f" sha1="a77fbe33c599ccdf22012222e093f94710e91a74"/>
 		-->
 		<description>The 4th Unit 7 - Wyatt</description>
 		<year>1992</year>
@@ -1345,7 +1359,7 @@ User/save disks that can be created from the game itself are not included.
 		</part>
 		<part name="cdrom" interface="fmt_cdrom">
 			<diskarea name="cdrom">
-				<disk name="the 4th unit 7 - wyatt" sha1="e99d2537e5dc4fb2d890a16b67b115f19ff5391c" />
+				<disk name="4th unit series, the - wyatt (japan)" sha1="a3f06ad5e23147bff643ac404897eb4f224d6301" />
 			</diskarea>
 		</part>
 	</software>
@@ -1392,6 +1406,7 @@ User/save disks that can be created from the game itself are not included.
 		<description>38-man Kilo no Kokuu</description>
 		<year>1989</year>
 		<publisher>システムサコム (System Sacom)</publisher>
+		<info name="alt_title" value="38万キロの虚空" />
 		<info name="release" value="198912xx" />
 		<part name="flop1" interface="floppy_3_5">
 			<feature name="part_id" value="Utility Disk" />
@@ -1417,6 +1432,7 @@ User/save disks that can be created from the game itself are not included.
 		<description>A Ressha de Ikou III</description>
 		<year>1991</year>
 		<publisher>アートディンク (Artdink)</publisher>
+		<info name="alt_title" value="A列車で行こうIII" />
 		<info name="release" value="199104xx" />
 		<part name="cdrom" interface="fmt_cdrom">
 			<diskarea name="cdrom">
@@ -1436,6 +1452,7 @@ User/save disks that can be created from the game itself are not included.
 		<description>A Ressha de Ikou IV</description>
 		<year>1993</year>
 		<publisher>アートディンク (Artdink)</publisher>
+		<info name="alt_title" value="A列車で行こうIV" />
 		<info name="release" value="199312xx" />
 		<part name="flop1" interface="floppy_3_5">
 			<feature name="part_id" value="System Disk" />
@@ -1462,6 +1479,7 @@ User/save disks that can be created from the game itself are not included.
 		<description>Abel - Shin Mokushiroku Taisen</description>
 		<year>1995</year>
 		<publisher>ファミリーソフト (Family Soft)</publisher>
+		<info name="alt_title" value="ＡＢＥＬ 真・黙示録大戦" />
 		<info name="release" value="199511xx" />
 		<part name="cdrom" interface="fmt_cdrom">
 			<diskarea name="cdrom">
@@ -1481,6 +1499,7 @@ User/save disks that can be created from the game itself are not included.
 		<description>Advantage Tennis</description>
 		<year>1992</year>
 		<publisher>富士通 (Fujitsu)</publisher>
+		<info name="alt_title" value="アドバンテージテニス" />
 		<info name="release" value="199210xx" />
 		<part name="cdrom" interface="fmt_cdrom">
 			<diskarea name="cdrom">
@@ -1501,6 +1520,7 @@ User/save disks that can be created from the game itself are not included.
 		<description>Aeternam</description>
 		<year>1993</year>
 		<publisher>富士通 (Fujitsu)</publisher>
+		<info name="alt_title" value="エターナム" />
 		<info name="release" value="199303xx" />
 		<part name="cdrom" interface="fmt_cdrom">
 			<diskarea name="cdrom">
@@ -1521,6 +1541,7 @@ User/save disks that can be created from the game itself are not included.
 		<description>After Burner</description>
 		<year>1989</year>
 		<publisher>CRI</publisher>
+		<info name="alt_title" value="アフターバーナー" />
 		<info name="release" value="198911xx" />
 		<part name="cdrom" interface="fmt_cdrom">
 			<diskarea name="cdrom">
@@ -1538,6 +1559,7 @@ User/save disks that can be created from the game itself are not included.
 		<description>After Burner III</description>
 		<year>1992</year>
 		<publisher>CRI</publisher>
+		<info name="alt_title" value="アフターバーナーIII" />
 		<info name="release" value="199206xx" />
 		<part name="cdrom" interface="fmt_cdrom">
 			<diskarea name="cdrom">
@@ -1560,6 +1582,7 @@ User/save disks that can be created from the game itself are not included.
 		<description>Air Combat II Special</description>
 		<year>1993</year>
 		<publisher>ビクター音楽産業 (Victor Musical Industries)</publisher>
+		<info name="alt_title" value="エアーコンバット2スペシャル" />
 		<info name="release" value="199303xx" />
 		<part name="cdrom" interface="fmt_cdrom">
 			<diskarea name="cdrom">
@@ -1579,6 +1602,8 @@ User/save disks that can be created from the game itself are not included.
 		<description>Air Management - Oozora ni Kakeru</description>
 		<year>1992</year>
 		<publisher>光栄 (Koei)</publisher>
+		<info name="alt_title" value="エアマネジメント 大空に賭ける" />
+		<info name="release" value="199209xx" />
 		<part name="flop1" interface="floppy_3_5">
 			<feature name="part_id" value="User Disk" />
 			<dataarea name="flop" size="1261568">
@@ -1604,6 +1629,7 @@ User/save disks that can be created from the game itself are not included.
 		<description>Air Warrior</description>
 		<year>1992</year>
 		<publisher>富士通 (Fujitsu)</publisher>
+		<info name="release" value="199203xx" />
 		<part name="cdrom" interface="fmt_cdrom">
 			<diskarea name="cdrom">
 				<disk name="fujitsu air warrior v1.1" sha1="9433549ab48af8471d308070548a65fd3ba3304d" />
@@ -1622,6 +1648,7 @@ User/save disks that can be created from the game itself are not included.
 		<description>Alice no Yakata CD</description>
 		<year>1991</year>
 		<publisher>アリスソフト (AliceSoft)</publisher>
+		<info name="alt_title" value="アリスの館CD" />
 		<info name="release" value="199107xx" />
 		<part name="cdrom" interface="fmt_cdrom">
 			<diskarea name="cdrom">
@@ -1641,6 +1668,7 @@ User/save disks that can be created from the game itself are not included.
 		<description>Alice no Yakata II</description>
 		<year>1992</year>
 		<publisher>アリスソフト (AliceSoft)</publisher>
+		<info name="alt_title" value="アリスの館2" />
 		<info name="release" value="199210xx" />
 		<part name="cdrom" interface="fmt_cdrom">
 			<diskarea name="cdrom">
@@ -1661,6 +1689,7 @@ User/save disks that can be created from the game itself are not included.
 		<description>Alice no Yakata III</description>
 		<year>1995</year>
 		<publisher>アリスソフト (AliceSoft)</publisher>
+		<info name="alt_title" value="アリスの館3" />
 		<info name="release" value="199506xx" />
 		<info name="usage" value="Requires HDD installation"/>
 		<part name="cdrom" interface="fmt_cdrom">
@@ -1679,6 +1708,7 @@ User/save disks that can be created from the game itself are not included.
 		<description>Alone in the Dark</description>
 		<year>1993</year>
 		<publisher>アローマイクロテックス (Arrow Micro-Techs)</publisher>
+		<info name="alt_title" value="アローン・イン・ザ・ダーク" />
 		<info name="release" value="199312xx" />
 		<part name="cdrom" interface="fmt_cdrom">
 			<diskarea name="cdrom">
@@ -1698,6 +1728,7 @@ User/save disks that can be created from the game itself are not included.
 		<description>Alone in the Dark 2</description>
 		<year>1994</year>
 		<publisher>アローマイクロテックス (Arrow Micro-Techs)</publisher>
+		<info name="alt_title" value="アローン・イン・ザ・ダーク2" />
 		<info name="release" value="199412xx" />
 		<info name="usage" value="Requires HDD installation"/>
 		<part name="cdrom" interface="fmt_cdrom">
@@ -1718,6 +1749,7 @@ User/save disks that can be created from the game itself are not included.
 		<description>Alshark</description>
 		<year>1993</year>
 		<publisher>ライトスタッフ (Right Stuff)</publisher>
+		<info name="alt_title" value="アルシャーク" />
 		<info name="release" value="199305xx" />
 		<part name="cdrom" interface="fmt_cdrom">
 			<diskarea name="cdrom">
@@ -1735,6 +1767,7 @@ User/save disks that can be created from the game itself are not included.
 		<description>Amaranth III</description>
 		<year>1994</year>
 		<publisher>風雅システム (Fuga System)</publisher>
+		<info name="alt_title" value="アマランスIII" />
 		<info name="release" value="199411xx" />
 		<part name="cdrom" interface="fmt_cdrom">
 			<diskarea name="cdrom">
@@ -1751,9 +1784,10 @@ User/save disks that can be created from the game itself are not included.
 		<rom name="Ambivalenz.img" size="10595760" crc="3999462d" sha1="a3584dc190815874cb84aa559c96d8c14c1d87c8"/>
 		<rom name="Ambivalenz.sub" size="432480" crc="ab867f43" sha1="4d2adab927a143a5496f913337507ecfc0a1943a"/>
 		-->
-		<description>AmbivalenZ</description>
+		<description>AmbivalenZ - Niritsu Haihan</description>
 		<year>1994</year>
 		<publisher>アリスソフト (AliceSoft)</publisher>
+		<info name="alt_title" value="AmbivalenZ ～二律背反～" />
 		<info name="release" value="199404xx" />
 		<part name="flop1" interface="floppy_3_5">
 			<feature name="part_id" value="Boot Disk" />
@@ -1779,6 +1813,7 @@ User/save disks that can be created from the game itself are not included.
 		<description>America Oudan Ultra Quiz</description>
 		<year>1994</year>
 		<publisher>富士通 (Fujitsu)</publisher>
+		<info name="alt_title" value="アメリカ横断ウルトラクイズ" />
 		<info name="release" value="199411xx" />
 		<part name="cdrom" interface="fmt_cdrom">
 			<diskarea name="cdrom">
@@ -1812,6 +1847,7 @@ User/save disks that can be created from the game itself are not included.
 		<description>Angel</description>
 		<year>1993</year>
 		<publisher>カクテル・ソフト (Cocktail Soft)</publisher>
+		<info name="alt_title" value="エンジェル" />
 		<info name="release" value="199310xx" />
 		<part name="cdrom" interface="fmt_cdrom">
 			<diskarea name="cdrom">
@@ -1831,6 +1867,7 @@ User/save disks that can be created from the game itself are not included.
 		<description>Angel Halo</description>
 		<year>1996</year>
 		<publisher>アクティブ (Active)</publisher>
+		<info name="alt_title" value="エンジェル・ハイロウ" />
 		<info name="release" value="199610xx" />
 		<part name="cdrom" interface="fmt_cdrom">
 			<diskarea name="cdrom">
@@ -1847,6 +1884,7 @@ User/save disks that can be created from the game itself are not included.
 		<description>AnotherTOWNS - Anata~ Free Software Collection</description>
 		<year>1999?</year>
 		<publisher>&lt;doujin&gt;</publisher>
+		<info name="alt_title" value="AnotherTOWNS あなた～ フリーソフトウェアコレクション" />
 		<info name="usage" value="Requires 32 MB of RAM" />
 		<part name="cdrom" interface="fmt_cdrom">
 			<diskarea name="cdrom">
@@ -1886,7 +1924,7 @@ User/save disks that can be created from the game itself are not included.
 		<description>Appare CD Vol. 2 - Houou no Maki</description>
 		<year>1995</year>
 		<publisher>ソフトバンク (Softbank)</publisher>
-		<info name="alt_title" value="天晴CD Vol.1 鳳凰の巻" />
+		<info name="alt_title" value="天晴CD Vol.2 鳳凰の巻" />
 		<info name="release" value="199408xx" />
 		<part name="cdrom" interface="fmt_cdrom">
 			<diskarea name="cdrom">
@@ -1906,6 +1944,7 @@ User/save disks that can be created from the game itself are not included.
 		<description>Aoki Ookami to Shiroki Mejika - Genchou Hishi</description>
 		<year>1993</year>
 		<publisher>光栄 (Koei)</publisher>
+		<info name="alt_title" value="蒼き狼と白き牝鹿 元朝秘史" />
 		<info name="release" value="199302xx" />
 		<part name="cdrom" interface="fmt_cdrom">
 			<diskarea name="cdrom">
@@ -1922,9 +1961,10 @@ User/save disks that can be created from the game itself are not included.
 		<rom name="Arabesque.img" size="584413200" crc="b9abe5c0" sha1="3f7494d07e9ef8493e801932e3ae39f334b43824"/>
 		<rom name="Arabesque.sub" size="23853600" crc="01f20a90" sha1="c244dedc2946a534932aed7d886fb3f56ab38c9f"/>
 		-->
-		<description>Arabesque</description>
+		<description>Arabesque - Shoujo-tachi no Orinasu Ai no Monogatari</description>
 		<year>1994</year>
 		<publisher>フェアリーテール (Fairytale)</publisher>
+		<info name="alt_title" value="ア・ラ・ベ・ス・ク ～少女たちの織りなす愛の物語～" />
 		<info name="release" value="199404xx" />
 		<part name="cdrom" interface="fmt_cdrom">
 			<diskarea name="cdrom">
@@ -1961,6 +2001,7 @@ User/save disks that can be created from the game itself are not included.
 		<description>Asuka 120% Burning Fest. Excellent</description>
 		<year>1994</year>
 		<publisher>ファミリーソフト (Family Soft)</publisher>
+		<info name="alt_title" value="あすか 120% BURNING Fest. エクセレント" />
 		<info name="release" value="199412xx" />
 		<part name="flop1" interface="floppy_3_5">
 			<feature name="part_id" value="Boot Disk" />
@@ -1986,6 +2027,8 @@ User/save disks that can be created from the game itself are not included.
 		<description>The Atlas</description>
 		<year>1991</year>
 		<publisher>アートディンク (Artdink)</publisher>
+		<info name="alt_title" value="ジ・アトラス" />
+		<info name="release" value="199110xx" />
 		<part name="cdrom" interface="fmt_cdrom">
 			<diskarea name="cdrom">
 				<disk name="the atlas" sha1="31378695a7eb7fe953e51463829468f214f2a2f4" />
@@ -2001,9 +2044,10 @@ User/save disks that can be created from the game itself are not included.
 		<rom name="The Atlas 2.img" size="503727840" crc="981612c5" sha1="db130981baf04ce5c2680a90801eeda10ec95f45"/>
 		<rom name="The Atlas 2.sub" size="20560320" crc="40257fb7" sha1="7b6e7232af9c218d07e4dd98863b6e81c0faf670"/>
 		-->
-		<description>The Atlas 2</description>
+		<description>The Atlas II</description>
 		<year>1993</year>
 		<publisher>アートディンク (Artdink)</publisher>
+		<info name="alt_title" value="ジ・アトラスII" />
 		<info name="release" value="199305xx" />
 		<part name="flop1" interface="floppy_3_5">
 			<feature name="part_id" value="System Disk" />
@@ -2051,6 +2095,8 @@ User/save disks that can be created from the game itself are not included.
 		<description>Hatchake Ayayo-san 1-2-3</description>
 		<year>1993</year>
 		<publisher>ハード (Hard)</publisher>
+		<info name="alt_title" value="はっちゃけあやよさん 1-2-3" />
+		<info name="release" value="199307xx" />
 		<part name="cdrom" interface="fmt_cdrom">
 			<diskarea name="cdrom">
 				<disk name="hatchake ayayo-san 1-2-3" sha1="b9d11ce0cdcb144cbda9f9fdb2c9b7b02b8400a5" />
@@ -2069,6 +2115,7 @@ User/save disks that can be created from the game itself are not included.
 		<description>Ayumi-chan Monogatari</description>
 		<year>1993</year>
 		<publisher>アリスソフト (AliceSoft)</publisher>
+		<info name="alt_title" value="あゆみちゃん物語" />
 		<info name="release" value="199310xx" />
 		<part name="flop1" interface="floppy_3_5">
 			<feature name="part_id" value="Boot Disk?" />
@@ -2094,6 +2141,7 @@ User/save disks that can be created from the game itself are not included.
 		<description>Ayumi-chan Monogatari Jissha-ban</description>
 		<year>1995</year>
 		<publisher>Core Magazine</publisher>
+		<info name="alt_title" value="あゆみちゃん物語 実写版" />
 		<info name="release" value="199501xx" />
 		<part name="cdrom" interface="fmt_cdrom">
 			<diskarea name="cdrom">
@@ -2127,6 +2175,7 @@ User/save disks that can be created from the game itself are not included.
 		<description>Azure</description>
 		<year>1993</year>
 		<publisher>ファミリーソフト (Family Soft)</publisher>
+		<info name="alt_title" value="アジャ" />
 		<info name="release" value="199302xx" />
 		<part name="cdrom" interface="fmt_cdrom">
 			<diskarea name="cdrom">
@@ -2165,7 +2214,7 @@ User/save disks that can be created from the game itself are not included.
 		<description>Ballade for Maria</description>
 		<year>1995</year>
 		<publisher>フェアリーテール (Fairytale)</publisher>
-		<info name="alt_title" value="Maria ni Sasageru Ballade" />
+		<info name="alt_title" value="マリアに捧げるバラード" />
 		<info name="release" value="199506xx" />
 		<part name="flop1" interface="floppy_3_5">
 			<feature name="part_id" value="User Disk" />
@@ -2230,6 +2279,7 @@ User/save disks that can be created from the game itself are not included.
 		<description>Beast 3</description>
 		<year>1994</year>
 		<publisher>バーディーソフト (Birdy Soft)</publisher>
+		<info name="alt_title" value="ビースト3" />
 		<info name="release" value="199403xx" />
 		<part name="cdrom" interface="fmt_cdrom">
 			<diskarea name="cdrom">
@@ -2287,6 +2337,7 @@ User/save disks that can be created from the game itself are not included.
 		<description>Bible Master</description>
 		<year>1993</year>
 		<publisher>グローディア (Glodia)</publisher>
+		<info name="alt_title" value="バイブル マスター" />
 		<info name="release" value="199312xx" />
 		<part name="flop1" interface="floppy_3_5">
 			<feature name="part_id" value="System Disk" />
@@ -2311,6 +2362,7 @@ User/save disks that can be created from the game itself are not included.
 		<description>Blandia Plus</description>
 		<year>1994</year>
 		<publisher>ビング (Ving)</publisher>
+		<info name="alt_title" value="ブランディア・プラス" />
 		<info name="release" value="199409xx" />
 		<part name="cdrom" interface="fmt_cdrom">
 			<diskarea name="cdrom">
@@ -2347,6 +2399,7 @@ User/save disks that can be created from the game itself are not included.
 		<description>Bomberman - Panic Bomber</description>
 		<year>1995</year>
 		<publisher>アスキー (ASCII)</publisher>
+		<info name="alt_title" value="ボンバーマンぱにっくボンバー" />
 		<info name="release" value="199504xx" />
 		<part name="cdrom" interface="fmt_cdrom">
 			<diskarea name="cdrom">
@@ -2366,6 +2419,7 @@ User/save disks that can be created from the game itself are not included.
 		<description>The Best Play Baseball</description>
 		<year>1992</year>
 		<publisher>アスキー (ASCII)</publisher>
+		<info name="alt_title" value="ベストプレーベースボール" />
 		<info name="release" value="199204xx" />
 		<part name="cdrom" interface="fmt_cdrom">
 			<diskarea name="cdrom">
@@ -2385,6 +2439,7 @@ User/save disks that can be created from the game itself are not included.
 		<description>Branmarker</description>
 		<year>1991</year>
 		<publisher>ディー・オー (D.O.)</publisher>
+		<info name="alt_title" value="ブランマーカー" />
 		<info name="release" value="199311xx" />
 		<part name="cdrom" interface="fmt_cdrom">
 			<diskarea name="cdrom">
@@ -2406,6 +2461,7 @@ User/save disks that can be created from the game itself are not included.
 		<description>Branmarker 2</description>
 		<year>1995</year>
 		<publisher>ディー・オー (D.O.)</publisher>
+		<info name="alt_title" value="ブランマーカー２" />
 		<part name="cdrom1" interface="fmt_cdrom">
 			<feature name="part_id" value="Game Disc" />
 			<diskarea name="cdrom">
@@ -2431,6 +2487,7 @@ User/save disks that can be created from the game itself are not included.
 		<description>Bubble Bobble</description>
 		<year>1990</year>
 		<publisher>ビング (Ving)</publisher>
+		<info name="alt_title" value="バブルボブル" />
 		<info name="release" value="199010xx" />
 		<part name="cdrom" interface="fmt_cdrom">
 			<diskarea name="cdrom">
@@ -2450,6 +2507,7 @@ User/save disks that can be created from the game itself are not included.
 		<description>Burai Joukan</description>
 		<year>1990</year>
 		<publisher>リバーヒルソフト (Riverhill Soft)</publisher>
+		<info name="alt_title" value="ブライ -上巻-" />
 		<info name="release" value="199004xx" />
 		<part name="cdrom" interface="fmt_cdrom">
 			<diskarea name="cdrom">
@@ -2469,6 +2527,7 @@ User/save disks that can be created from the game itself are not included.
 		<description>Burai Kanketsu-hen</description>
 		<year>1991</year>
 		<publisher>リバーヒルソフト (Riverhill Soft)</publisher>
+		<info name="alt_title" value="ブライ -完結編-" />
 		<info name="release" value="199105xx" />
 		<part name="cdrom" interface="fmt_cdrom">
 			<diskarea name="cdrom">
@@ -2507,6 +2566,7 @@ User/save disks that can be created from the game itself are not included.
 		<description>Cal Gaiden - Tiny Steps Behind the Cal</description>
 		<year>1993</year>
 		<publisher>バーディーソフト (Birdy Soft)</publisher>
+		<info name="alt_title" value="タイニィステップ CAL外伝" />
 		<info name="release" value="199307xx" />
 		<part name="cdrom" interface="fmt_cdrom">
 			<diskarea name="cdrom">
@@ -2526,6 +2586,7 @@ User/save disks that can be created from the game itself are not included.
 		<description>Can Can Bunny Extra</description>
 		<year>1993</year>
 		<publisher>カクテル・ソフト (Cocktail Soft)</publisher>
+		<info name="alt_title" value="きゃんきゃんバニー・エクストラ" />
 		<info name="release" value="199309xx" />
 		<part name="cdrom" interface="fmt_cdrom">
 			<diskarea name="cdrom">
@@ -2545,10 +2606,38 @@ User/save disks that can be created from the game itself are not included.
 		<description>Castles</description>
 		<year>1992</year>
 		<publisher>ビクター音楽産業 (Victor Musical Industries)</publisher>
+		<info name="alt_title" value="キャッスルズ" />
 		<info name="release" value="199210xx" />
 		<part name="cdrom" interface="fmt_cdrom">
 			<diskarea name="cdrom">
 				<disk name="castles" sha1="411c2753dbbef40b91bc6cd922f82eda27820280" />
+			</diskarea>
+		</part>
+	</software>
+
+	<software name="catsp1">
+		<!--
+		Origin: redump.org
+		<rom name="Cat's Part-1 (Japan) (Track 01).bin" size="10231200" crc="f71d64fc" sha1="32013aba4e66208419cf126bb705f0da65e7845b"/>
+		<rom name="Cat's Part-1 (Japan) (Track 02).bin" size="2116800" crc="aade3364" sha1="370892f9f51d99115f255aac310ff73cc15e48ae"/>
+		<rom name="Cat's Part-1 (Japan) (Track 03).bin" size="43923600" crc="d7672015" sha1="012c5c1dda1785d242bc30e93dcb06759fef5123"/>
+		<rom name="Cat's Part-1 (Japan) (Track 04).bin" size="46393200" crc="ff264551" sha1="839a88e2372462708caeabc9676e316a415ad825"/>
+		<rom name="Cat's Part-1 (Japan) (Track 05).bin" size="49392000" crc="7053b422" sha1="61086fc72a6586fa4d4e95675e3fde3a5123236f"/>
+		<rom name="Cat's Part-1 (Japan) (Track 06).bin" size="48157200" crc="f2c22dc1" sha1="be96391399e96b8ee7b56c142a429605541f9d37"/>
+		<rom name="Cat's Part-1 (Japan) (Track 07).bin" size="48510000" crc="37ef0363" sha1="3e3d43a4ae238eca5de9dd25781f65add8c8227e"/>
+		<rom name="Cat's Part-1 (Japan) (Track 08).bin" size="47098800" crc="ce57c58e" sha1="5fbef6a6258a8fe4981cc1893b10f441a810b30a"/>
+		<rom name="Cat's Part-1 (Japan) (Track 09).bin" size="52214400" crc="73ce2239" sha1="d682ca3ffea031068080b7341695aa358669fdff"/>
+		<rom name="Cat's Part-1 (Japan) (Track 10).bin" size="48333600" crc="72dcc7ba" sha1="e9186cc354460dd798f503359ca8d09ada3767a0"/>
+		<rom name="Cat's Part-1 (Japan).cue" size="1132" crc="ed1c74a2" sha1="ab8da3ec0231343814a525ffeac192e00840f50f"/>
+		-->
+		<description>Cat's Part-1</description>
+		<year>1993</year>
+		<publisher>Cat's Pro.</publisher>
+		<info name="alt_title" value="キャッツ・パート１" />
+		<info name="release" value="199304xx" />
+		<part name="cdrom" interface="fmt_cdrom">
+			<diskarea name="cdrom">
+				<disk name="cat's part-1 (japan)" sha1="8985f14c6c8647ee8457e01c02f6b5d9672b0061" />
 			</diskarea>
 		</part>
 	</software>
@@ -2564,6 +2653,7 @@ User/save disks that can be created from the game itself are not included.
 		<description>Centurion</description>
 		<year>1993</year>
 		<publisher>エレクトロニック・アーツ・ビクター (Electronic Arts Victor)</publisher>
+		<info name="alt_title" value="センチュリオン" />
 		<info name="release" value="199311xx" />
 		<part name="cdrom" interface="fmt_cdrom">
 			<diskarea name="cdrom">
@@ -2583,6 +2673,7 @@ User/save disks that can be created from the game itself are not included.
 		<description>Taito Chase H.Q.</description>
 		<year>1991</year>
 		<publisher>ビング (Ving)</publisher>
+		<info name="alt_title" value="TAITO チェイスＨＱ" />
 		<info name="release" value="199108xx" />
 		<part name="cdrom" interface="fmt_cdrom">
 			<diskarea name="cdrom">
@@ -2602,6 +2693,7 @@ User/save disks that can be created from the game itself are not included.
 		<description>Chuumon no Ooi Ryouriten</description>
 		<year>1990</year>
 		<publisher>トップビジネスシステム (Top Business System)</publisher>
+		<info name="alt_title" value="注文の多い料理店" />
 		<info name="release" value="199108xx" />
 		<part name="cdrom" interface="fmt_cdrom">
 			<diskarea name="cdrom">
@@ -2621,6 +2713,7 @@ User/save disks that can be created from the game itself are not included.
 		<description>Classic Road</description>
 		<year>1994</year>
 		<publisher>ビクター音楽産業 (Victor Musical Industries)</publisher>
+		<info name="alt_title" value="クラシック・ロード" />
 		<info name="release" value="199402xx" />
 		<part name="cdrom" interface="fmt_cdrom">
 			<diskarea name="cdrom">
@@ -2641,6 +2734,7 @@ User/save disks that can be created from the game itself are not included.
 		<description>The Case of the Cautious Condor</description>
 		<year>1989</year>
 		<publisher>東芝EMI (Toshiba EMI)</publisher>
+		<info name="release" value="198911xx" />
 		<part name="cdrom" interface="fmt_cdrom">
 			<diskarea name="cdrom">
 				<disk name="the case of the cautious condor" sha1="b922563e2617dc46b3aac534c3ee81039a3953c7" />
@@ -2656,9 +2750,10 @@ User/save disks that can be created from the game itself are not included.
 		<rom name="Crystal Rinal.img" size="638017632" crc="8ade36c3" sha1="c162e4bcd0904d5e76961bfb76681feb6ee878cf"/>
 		<rom name="Crystal Rinal.sub" size="26041536" crc="6b193e73" sha1="e676ea802ccbe4d1748ac3bc8402f30a5c9bdeed"/>
 		-->
-		<description>Crystal Rinal</description>
+		<description>Crystal Rinal - Ouma no Meikyuu</description>
 		<year>1994</year>
 		<publisher>ディー・オー (D.O.)</publisher>
+		<info name="alt_title" value="クリスタルリナール －逢魔の迷宮－" />
 		<info name="release" value="199408xx" />
 		<part name="cdrom" interface="fmt_cdrom">
 			<diskarea name="cdrom">
@@ -2678,6 +2773,7 @@ User/save disks that can be created from the game itself are not included.
 		<description>Custom Mate 2 &amp; Itsuka dokoka de</description>
 		<year>1995</year>
 		<publisher>カクテル・ソフト (Cocktail Soft)</publisher>
+		<info name="alt_title" value="カスタムメイト２＆いつかどこかで" />
 		<info name="release" value="199508xx" />
 		<part name="flop1" interface="floppy_3_5">
 			<feature name="part_id" value="Save Disk" />
@@ -2701,6 +2797,7 @@ User/save disks that can be created from the game itself are not included.
 		<description>Cybercity</description>
 		<year>1989</year>
 		<publisher>日本テレネット (Nihon Telenet)</publisher>
+		<info name="alt_title" value="サイバーシティ" />
 		<info name="release" value="198903xx" />
 		<part name="flop1" interface="floppy_3_5">
 			<feature name="part_id" value="Boot Disk" />
@@ -2727,6 +2824,7 @@ User/save disks that can be created from the game itself are not included.
 		<description>Cyberia</description>
 		<year>1995</year>
 		<publisher>富士通 (Fujitsu)</publisher>
+		<info name="alt_title" value="サイベリア" />
 		<info name="release" value="199505xx" />
 		<info name="usage" value="Requires HDD installation"/>
 		<part name="cdrom" interface="fmt_cdrom">
@@ -2764,6 +2862,7 @@ User/save disks that can be created from the game itself are not included.
 		<description>D.P.S. Zenbu</description>
 		<year>1995</year>
 		<publisher>アリスソフト (AliceSoft)</publisher>
+		<info name="alt_title" value="DPS全部" />
 		<part name="cdrom" interface="fmt_cdrom">
 			<diskarea name="cdrom">
 				<disk name="d.p.s. zenbu" sha1="0dfb4343e175a124795974183c17356530231b85" />
@@ -2782,6 +2881,7 @@ User/save disks that can be created from the game itself are not included.
 		<description>Daikoukai Jidai</description>
 		<year>1990</year>
 		<publisher>光栄 (Koei)</publisher>
+		<info name="alt_title" value="大航海時代" />
 		<info name="release" value="199011xx" />
 		<part name="flop1" interface="floppy_3_5">
 			<feature name="part_id" value="Save Disk" />
@@ -2807,6 +2907,7 @@ User/save disks that can be created from the game itself are not included.
 		<description>Daikoukai Jidai II</description>
 		<year>1993</year>
 		<publisher>光栄 (Koei)</publisher>
+		<info name="alt_title" value="大航海時代II" />
 		<info name="release" value="199304xx" />
 		<part name="flop1" interface="floppy_3_5">
 			<feature name="part_id" value="Save Disk" />
@@ -2832,6 +2933,7 @@ User/save disks that can be created from the game itself are not included.
 		<description>Daisenryaku III '90</description>
 		<year>1991</year>
 		<publisher>ペガサスジャパン (Pegasus Japan)</publisher>
+		<info name="alt_title" value="大戦略III'90" />
 		<info name="release" value="199112xx" />
 		<part name="flop1" interface="floppy_3_5">
 			<feature name="part_id" value="Game Disk" />
@@ -2869,6 +2971,7 @@ User/save disks that can be created from the game itself are not included.
 		<description>Dalk</description>
 		<year>1993</year>
 		<publisher>アリスソフト (AliceSoft)</publisher>
+		<info name="alt_title" value="ダルク" />
 		<info name="release" value="199304xx" />
 		<part name="flop1" interface="floppy_3_5">
 			<feature name="part_id" value="Boot Disk" />
@@ -2911,6 +3014,7 @@ User/save disks that can be created from the game itself are not included.
 		<description>De.FaNa</description>
 		<year>1995</year>
 		<publisher>姫屋ソフト (Himeya Soft)</publisher>
+		<info name="alt_title" value="デ・ファーナ" />
 		<info name="release" value="199511xx" />
 		<part name="cdrom" interface="fmt_cdrom">
 			<diskarea name="cdrom">
@@ -2931,6 +3035,7 @@ User/save disks that can be created from the game itself are not included.
 		<year>1994?</year>
 		<publisher>アイリスプラン (Ilis Plan)</publisher>
 		<info name="alt_title" value="デビューします･･･２ 野上アキ" />
+		<info name="release" value="199407xx" />
 		<part name="cdrom" interface="fmt_cdrom">
 			<diskarea name="cdrom">
 				<disk name="debut2" sha1="8490214513d8533565d50fb9b5e0aaf0cf344d21" />
@@ -2949,6 +3054,7 @@ User/save disks that can be created from the game itself are not included.
 		<description>Dead Force</description>
 		<year>1995</year>
 		<publisher>風雅システム (Fuga System)</publisher>
+		<info name="alt_title" value="デッドフォース" />
 		<info name="release" value="199506xx" />
 		<part name="cdrom" interface="fmt_cdrom">
 			<diskarea name="cdrom">
@@ -2968,6 +3074,7 @@ User/save disks that can be created from the game itself are not included.
 		<description>Dead of the Brain</description>
 		<year>1993</year>
 		<publisher>フェアリーテール (Fairytale)</publisher>
+		<info name="alt_title" value="デッド・オブ・ザ・ブレイン" />
 		<info name="release" value="199302xx" />
 		<part name="cdrom" interface="fmt_cdrom">
 			<diskarea name="cdrom">
@@ -2987,6 +3094,7 @@ User/save disks that can be created from the game itself are not included.
 		<description>Death Brade</description>
 		<year>1992</year>
 		<publisher>KID</publisher>
+		<info name="alt_title" value="デスブレイド" />
 		<info name="release" value="199211xx" />
 		<part name="cdrom" interface="fmt_cdrom">
 			<diskarea name="cdrom">
@@ -3006,6 +3114,7 @@ User/save disks that can be created from the game itself are not included.
 		<description>Deep</description>
 		<year>1995</year>
 		<publisher>ジャスト (Jast)</publisher>
+		<info name="alt_title" value="ディープ" />
 		<info name="release" value="199503xx" />
 		<part name="flop1" interface="floppy_3_5">
 			<feature name="part_id" value="Boot Disk" />
@@ -3048,6 +3157,7 @@ User/save disks that can be created from the game itself are not included.
 		<description>Dengeki Nurse</description>
 		<year>1992</year>
 		<publisher>カクテル・ソフト (Cocktail Soft)</publisher>
+		<info name="alt_title" value="電撃ナース" />
 		<info name="release" value="199212xx" />
 		<part name="cdrom" interface="fmt_cdrom">
 			<diskarea name="cdrom">
@@ -3067,6 +3177,7 @@ User/save disks that can be created from the game itself are not included.
 		<description>Derby Stallion</description>
 		<year>1993</year>
 		<publisher>アスキー (ASCII)</publisher>
+		<info name="alt_title" value="ダービースタリオン" />
 		<info name="release" value="199402xx" />
 		<part name="cdrom" interface="fmt_cdrom">
 			<diskarea name="cdrom">
@@ -3086,6 +3197,7 @@ User/save disks that can be created from the game itself are not included.
 		<description>Desire - Haitoku no Rasen</description>
 		<year>1994</year>
 		<publisher>シーズウェア (C's Ware)</publisher>
+		<info name="alt_title" value="デザイア 背徳の螺旋" />
 		<info name="release" value="199411xx" />
 		<part name="cdrom" interface="fmt_cdrom">
 			<diskarea name="cdrom">
@@ -3122,6 +3234,7 @@ User/save disks that can be created from the game itself are not included.
 		<description>Die Gekirin</description>
 		<year>1995</year>
 		<publisher>日本アプリケーション (Nihon Application)</publisher>
+		<info name="alt_title" value="大逆鱗" />
 		<info name="release" value="199511xx" />
 		<part name="cdrom" interface="fmt_cdrom">
 			<diskarea name="cdrom">
@@ -3178,9 +3291,42 @@ User/save disks that can be created from the game itself are not included.
 		<description>Doki Doki Disk CD-ban Dai-1-kan: Club D.O. Jimukyoku</description>
 		<year>1994</year>
 		<publisher>ディー・オー (D.O.)</publisher>
+		<info name="alt_title" value="どきどきディスクＣＤ版　第１巻　クラブＤ．Ｏ．事務局" />
 		<part name="cdrom" interface="fmt_cdrom">
 			<diskarea name="cdrom">
 				<disk name="doki doki disk cd vol.1" sha1="b11bdae6dccb9799535baee0d0e257507037b614" />
+			</diskarea>
+		</part>
+	</software>
+
+	<software name="dorbestg">
+		<!--
+		Origin: redump.org
+		<rom name="DOR - Best Selection - Gekan (Japan) (Disc 1) (Track 1).bin" size="21168000" crc="a5d4084b" sha1="0261fbda8aaab5b1cb8030aeb3da49d7e327e9dc"/>
+		<rom name="DOR - Best Selection - Gekan (Japan) (Disc 1) (Track 2).bin" size="104546400" crc="326750bd" sha1="ca6700f068f3ee54a4965a8403f2031953005439"/>
+		<rom name="DOR - Best Selection - Gekan (Japan) (Disc 1) (Track 3).bin" size="5073264" crc="008348a4" sha1="b1105a798acccb914dc0e3dca5f572588f39a995"/>
+		<rom name="DOR - Best Selection - Gekan (Japan) (Disc 1) (Track 4).bin" size="385182336" crc="15388cfd" sha1="48fa2c90e99bb5c2cd78ede8a84ccc010e951336"/>
+		<rom name="DOR - Best Selection - Gekan (Japan) (Disc 1) (Track 5).bin" size="12799584" crc="32ebdf0e" sha1="5ce1d40275c824a69b35a5ee95ca8c8958b9ed6d"/>
+		<rom name="DOR - Best Selection - Gekan (Japan) (Disc 1).cue" size="700" crc="bcda739a" sha1="00459de4a4e87ad3ace26e96fb7d3c56dac45d3a"/>
+
+		<rom name="DOR - Best Selection - Gekan (Japan) (Disc 2) (Track 1).bin" size="21168000" crc="2ffdafad" sha1="3b6554e41c2ec418ee1b8d7480d3f8e9af0d78ad"/>
+		<rom name="DOR - Best Selection - Gekan (Japan) (Disc 2) (Track 2).bin" size="446884704" crc="0a361b0c" sha1="109dbaafe80f4fe333d0e8030445fb3832749e84"/>
+		<rom name="DOR - Best Selection - Gekan (Japan) (Disc 2) (Track 3).bin" size="34604976" crc="6eb96c96" sha1="567ebd9501004638481f70df15d5f132e7ed80e9"/>
+		<rom name="DOR - Best Selection - Gekan (Japan) (Disc 2).cue" size="422" crc="5a3e3b2b" sha1="11cbe78871929ac84243fa743ceb146772c49cdd"/>
+		-->
+		<description>DOR Best Selection Gekan</description>
+		<year>1993</year>
+		<publisher>ディー・オー (D.O.)</publisher>
+		<info name="alt_title" value="ＤＯＲ ～ ベストセレクション ～ 下巻" />
+		<info name="release" value="199305xx" />
+		<part name="cdrom1" interface="fmt_cdrom">
+			<diskarea name="cdrom">
+				<disk name="dor - best selection - gekan (japan) (disc 1)" sha1="b5589543eb983def1db44c123f8c9b145adf527b" />
+			</diskarea>
+		</part>
+		<part name="cdrom2" interface="fmt_cdrom">
+			<diskarea name="cdrom">
+				<disk name="dor - best selection - gekan (japan) (disc 2)" sha1="dfc103e319c6cac2f4221eaff7d84db86801a25e" />
 			</diskarea>
 		</part>
 	</software>
@@ -3201,6 +3347,8 @@ User/save disks that can be created from the game itself are not included.
 		<description>DOR Best Selection Joukan</description>
 		<year>1993</year>
 		<publisher>ディー・オー (D.O.)</publisher>
+		<info name="alt_title" value="ＤＯＲ ～ ベストセレクション ～ 上巻" />
+		<info name="release" value="199304xx" />
 		<part name="cdrom1" interface="fmt_cdrom">
 			<diskarea name="cdrom">
 				<disk name="dor best selection joukan (disc 1)" sha1="4384e5214835b93d4cb60762913dc01a29294bb6" />
@@ -3262,6 +3410,7 @@ User/save disks that can be created from the game itself are not included.
 		<description>DOR Special Edition Sakigake</description>
 		<year>1993</year>
 		<publisher>ディー・オー (D.O.)</publisher>
+		<info name="alt_title" value="DOR SPECIAL EDITION 魁" />
 		<info name="release" value="199306xx" />
 		<part name="cdrom" interface="fmt_cdrom">
 			<diskarea name="cdrom">
@@ -3281,6 +3430,7 @@ User/save disks that can be created from the game itself are not included.
 		<description>Doukyuusei</description>
 		<year>1992</year>
 		<publisher>エルフ (Elf)</publisher>
+		<info name="alt_title" value="同級生" />
 		<info name="release" value="199303xx" />
 		<part name="cdrom" interface="fmt_cdrom">
 			<diskarea name="cdrom">
@@ -3300,6 +3450,7 @@ User/save disks that can be created from the game itself are not included.
 		<description>Doukyuusei 2</description>
 		<year>1995</year>
 		<publisher>エルフ (Elf)</publisher>
+		<info name="alt_title" value="同級生2" />
 		<info name="release" value="199502xx" />
 		<part name="cdrom" interface="fmt_cdrom">
 			<diskarea name="cdrom">
@@ -3319,6 +3470,7 @@ User/save disks that can be created from the game itself are not included.
 		<description>Dragon Half</description>
 		<year>1994</year>
 		<publisher>マイクロキャビン (Micro Cabin)</publisher>
+		<info name="alt_title" value="ドラゴンハーフ" />
 		<info name="release" value="199404xx" />
 		<part name="cdrom" interface="fmt_cdrom">
 			<diskarea name="cdrom">
@@ -3336,6 +3488,7 @@ User/save disks that can be created from the game itself are not included.
 		<description>Dragon Knight III</description>
 		<year>1992</year>
 		<publisher>エルフ (Elf)</publisher>
+		<info name="alt_title" value="ドラゴンナイトIII" />
 		<info name="release" value="199202xx" />
 		<part name="cdrom" interface="fmt_cdrom">
 			<diskarea name="cdrom">
@@ -3355,6 +3508,7 @@ User/save disks that can be created from the game itself are not included.
 		<description>Dragon Knight 4</description>
 		<year>1994</year>
 		<publisher>エルフ (Elf)</publisher>
+		<info name="alt_title" value="ドラゴンナイト4" />
 		<info name="release" value="199404xx" />
 		<part name="cdrom" interface="fmt_cdrom">
 			<diskarea name="cdrom">
@@ -3374,6 +3528,7 @@ User/save disks that can be created from the game itself are not included.
 		<description>Dragons of Flame</description>
 		<year>1992</year>
 		<publisher>ポニーキャニオン (Pony Canyon)</publisher>
+		<info name="alt_title" value="ドラゴン・オブ・フレイム" />
 		<info name="release" value="199201xx" />
 		<part name="cdrom" interface="fmt_cdrom">
 			<diskarea name="cdrom">
@@ -3391,6 +3546,7 @@ User/save disks that can be created from the game itself are not included.
 		<description>Dragon Shock</description>
 		<year>1989</year>
 		<publisher>ログ (Log)</publisher>
+		<info name="alt_title" value="ドラゴンショック" />
 		<info name="release" value="198911xx" />
 		<part name="cdrom" interface="fmt_cdrom">
 			<diskarea name="cdrom">
@@ -3410,6 +3566,7 @@ User/save disks that can be created from the game itself are not included.
 		<description>Drakkhen</description>
 		<year>1990</year>
 		<publisher>富士通 (Fujitsu)</publisher>
+		<info name="alt_title" value="ドラッケン" />
 		<info name="release" value="199011xx" />
 		<part name="cdrom" interface="fmt_cdrom">
 			<diskarea name="cdrom">
@@ -3427,6 +3584,7 @@ User/save disks that can be created from the game itself are not included.
 		<description>Dungeon Master</description>
 		<year>1989</year>
 		<publisher>富士通 (Fujitsu)</publisher>
+		<info name="alt_title" value="ダンジョンマスター" />
 		<info name="release" value="198911xx" />
 		<part name="cdrom" interface="fmt_cdrom">
 			<diskarea name="cdrom">
@@ -3446,6 +3604,7 @@ User/save disks that can be created from the game itself are not included.
 		<description>Dungeon Master II - Skullkeep</description>
 		<year>1994</year>
 		<publisher>ビクター音楽産業 (Victor Musical Industries)</publisher>
+		<info name="alt_title" value="ダンジョンマスターII スカルキープ" />
 		<info name="release" value="199401xx" />
 		<part name="cdrom" interface="fmt_cdrom">
 			<diskarea name="cdrom">
@@ -3482,6 +3641,7 @@ User/save disks that can be created from the game itself are not included.
 		<description>Eimmy to Yobanaide</description>
 		<year>1995</year>
 		<publisher>シーズウェア (C's Ware)</publisher>
+		<info name="alt_title" value="エイミーと呼ばないでっ" />
 		<info name="release" value="199508xx" />
 		<part name="cdrom" interface="fmt_cdrom">
 			<diskarea name="cdrom">
@@ -3501,6 +3661,7 @@ User/save disks that can be created from the game itself are not included.
 		<description>Elfish</description>
 		<year>1994</year>
 		<publisher>富士通 (Fujitsu)</publisher>
+		<info name="alt_title" value="エル・フィッシュ" />
 		<info name="release" value="199407xx" />
 		<info name="usage" value="Requires HDD installation and an FPU"/>
 		<part name="cdrom" interface="fmt_cdrom">
@@ -3521,6 +3682,7 @@ User/save disks that can be created from the game itself are not included.
 		<description>Elfish Lite</description>
 		<year>1993</year>
 		<publisher>富士通 (Fujitsu)</publisher>
+		<info name="alt_title" value="エル・フィッシュ LITE" />
 		<info name="release" value="199311xx" />
 		<part name="cdrom" interface="fmt_cdrom">
 			<diskarea name="cdrom">
@@ -3537,9 +3699,10 @@ User/save disks that can be created from the game itself are not included.
 		<rom name="Elm Knight.img" size="504504000" crc="585630e6" sha1="14220511daa03d2f06df2336d0559de7c1686fb7"/>
 		<rom name="Elm Knight.sub" size="20592000" crc="97e181cd" sha1="be2b903d21937d303462a0b42f42408acb89f942"/>
 		-->
-		<description>Elm Knight</description>
+		<description>Elm Knight - A Living Body Armor</description>
 		<year>1992</year>
 		<publisher>マイクロキャビン (Micro Cabin)</publisher>
+		<info name="alt_title" value="エルムナイト" />
 		<info name="release" value="199211xx" />
 		<part name="cdrom" interface="fmt_cdrom">
 			<diskarea name="cdrom">
@@ -3559,6 +3722,7 @@ User/save disks that can be created from the game itself are not included.
 		<description>Emerald Dragon</description>
 		<year>1992</year>
 		<publisher>グローディア (Glodia)</publisher>
+		<info name="alt_title" value="エメラルド・ドラゴン" />
 		<info name="release" value="199205xx" />
 		<part name="flop1" interface="floppy_3_5">
 			<feature name="part_id" value="System Disk" />
@@ -3774,6 +3938,7 @@ User/save disks that can be created from the game itself are not included.
 		<description>Etsuraku no Gakuen</description>
 		<year>1994</year>
 		<publisher>シーズウェア (C's Ware)</publisher>
+		<info name="alt_title" value="悦楽の学園" />
 		<info name="release" value="199408xx" />
 		<part name="cdrom" interface="fmt_cdrom">
 			<diskarea name="cdrom">
@@ -3793,6 +3958,7 @@ User/save disks that can be created from the game itself are not included.
 		<description>Europa Sensen</description>
 		<year>1992</year>
 		<publisher>光栄 (Koei)</publisher>
+		<info name="alt_title" value="ヨーロッパ戦線" />
 		<info name="release" value="199207xx" />
 		<part name="flop1" interface="floppy_3_5">
 			<feature name="part_id" value="User Disk" />
@@ -3818,6 +3984,7 @@ User/save disks that can be created from the game itself are not included.
 		<description>Evolution</description>
 		<year>1989</year>
 		<publisher>システムサコム (System Sacom)</publisher>
+		<info name="alt_title" value="エヴォリューション" />
 		<info name="release" value="198903xx" />
 		<part name="cdrom" interface="fmt_cdrom">
 			<diskarea name="cdrom">
@@ -3836,6 +4003,7 @@ User/save disks that can be created from the game itself are not included.
 		<description>Excellent 10</description>
 		<year>1990</year>
 		<publisher>アモルファス (Amorphous)</publisher>
+		<info name="alt_title" value="エクセレント10" />
 		<info name="release" value="199010xx" />
 		<part name="cdrom" interface="fmt_cdrom">
 			<diskarea name="cdrom">
@@ -3911,6 +4079,7 @@ User/save disks that can be created from the game itself are not included.
 		<description>Eye of the Beholder II - The Legend of Darkmoon</description>
 		<year>1993</year>
 		<publisher>サイベル (Cybelle)</publisher>
+		<info name="alt_title" value="アイ・オブ・ザ・ビホルダー2 ザ・レジェンド・オブ・ダークムーン" />
 		<info name="release" value="199311xx" />
 		<part name="cdrom" interface="fmt_cdrom">
 			<diskarea name="cdrom">
@@ -3949,6 +4118,7 @@ User/save disks that can be created from the game itself are not included.
 		<description>Final Blow</description>
 		<year>1990</year>
 		<publisher>ビング (Ving)</publisher>
+		<info name="alt_title" value="ファイナル・ブロー" />
 		<info name="release" value="199003xx" />
 		<part name="cdrom" interface="fmt_cdrom">
 			<diskarea name="cdrom">
@@ -3968,6 +4138,7 @@ User/save disks that can be created from the game itself are not included.
 		<description>Flashback</description>
 		<year>1994</year>
 		<publisher>ビクター音楽産業 (Victor Musical Industries)</publisher>
+		<info name="alt_title" value="フラッシュバック" />
 		<info name="release" value="199404xx" />
 		<part name="cdrom" interface="fmt_cdrom">
 			<diskarea name="cdrom">
@@ -3986,6 +4157,8 @@ User/save disks that can be created from the game itself are not included.
 		<description>FM Towns Hyper CD Demo Futoppara No. 1</description>
 		<year>1989</year>
 		<publisher>SoftBank</publisher>
+		<info name="alt_title" value="太っ腹 Ｎｏ．１" />
+		<info name="release" value="198907xx" />
 		<part name="cdrom" interface="fmt_cdrom">
 			<diskarea name="cdrom">
 				<disk name="fm towns hyper cd demo futoppara no. 1" sha1="14733896afea395ff24a3ac7109f32d1e3edca76" />
@@ -4004,6 +4177,7 @@ User/save disks that can be created from the game itself are not included.
 		<description>FM Towns Super Technology Demo 1993</description>
 		<year>1993</year>
 		<publisher>富士通 (Fujitsu)</publisher>
+		<info name="release" value="199311xx" />
 		<part name="cdrom" interface="fmt_cdrom">
 			<diskarea name="cdrom">
 				<disk name="fm towns super technology demo 1993" sha1="4a685d1a33f7d75956ec0da7429c8d24b98fd014" />
@@ -4021,8 +4195,9 @@ User/save disks that can be created from the game itself are not included.
 		<rom name="Fractal Engine Demo.sub" size="2591808" crc="798b9b74" sha1="d20541b959e44fb545810912d35b849fa4ec4577"/>
 		-->
 		<description>Fractal Engine Demo</description>
-		<year>1991</year>
+		<year>1992</year>
 		<publisher>富士通 (Fujitsu)</publisher>
+		<info name="release" value="199202xx" />
 		<part name="cdrom" interface="fmt_cdrom">
 			<diskarea name="cdrom">
 				<disk name="fractal engine demo" sha1="97c2b8955b99b309a1f7bb6333eef3da0577d195" />
@@ -4082,6 +4257,7 @@ User/save disks that can be created from the game itself are not included.
 		<description>Free Software Collection 4</description>
 		<year>1991</year>
 		<publisher>富士通 (Fujitsu)</publisher>
+		<info name="release" value="199111xx" />
 		<part name="cdrom1" interface="fmt_cdrom">
 			<diskarea name="cdrom">
 				<disk name="free software collection 4 (disc 1 - red)" sha1="cc4b609ffd2b2e5fe216fab1eee3c22acda173fd" />
@@ -4105,6 +4281,7 @@ User/save disks that can be created from the game itself are not included.
 		<description>Free Software Collection 5</description>
 		<year>1992</year>
 		<publisher>富士通 (Fujitsu)</publisher>
+		<info name="release" value="199205xx" />
 		<part name="cdrom" interface="fmt_cdrom">
 			<diskarea name="cdrom">
 				<disk name="free software collection 5" sha1="c342415c976b27dfa84065fc139c068440027bfa" />
@@ -4123,6 +4300,7 @@ User/save disks that can be created from the game itself are not included.
 		<description>Free Software Collection 6</description>
 		<year>1993</year>
 		<publisher>富士通 (Fujitsu)</publisher>
+		<info name="release" value="199306xx" />
 		<part name="cdrom" interface="fmt_cdrom">
 			<diskarea name="cdrom">
 				<disk name="free software collection 6" sha1="02f5d485d0be0cce79c6c535e2e14e22769d6110" />
@@ -4141,6 +4319,7 @@ User/save disks that can be created from the game itself are not included.
 		<description>Free Software Collection 7</description>
 		<year>1993</year>
 		<publisher>富士通 (Fujitsu)</publisher>
+		<info name="release" value="199312xx" />
 		<part name="cdrom" interface="fmt_cdrom">
 			<diskarea name="cdrom">
 				<disk name="free software collection 7" sha1="89886e68a793ebd0295c437e9272ca2b285f6ddb" />
@@ -4159,6 +4338,7 @@ User/save disks that can be created from the game itself are not included.
 		<description>Free Software Collection 8</description>
 		<year>1994</year>
 		<publisher>富士通 (Fujitsu)</publisher>
+		<info name="release" value="199406xx" />
 		<part name="cdrom" interface="fmt_cdrom">
 			<diskarea name="cdrom">
 				<disk name="free software collection 8" sha1="bdae35dab6691274f66654c85cc6fbe9db22a16a" />
@@ -4177,6 +4357,7 @@ User/save disks that can be created from the game itself are not included.
 		<description>Free Software Collection 9</description>
 		<year>1994</year>
 		<publisher>富士通 (Fujitsu)</publisher>
+		<info name="release" value="199412xx" />
 		<part name="cdrom" interface="fmt_cdrom">
 			<diskarea name="cdrom">
 				<disk name="free software collection 9" sha1="13a1990a9aa59e3b186eeffa8162ee1ecd487c0b" />
@@ -4195,6 +4376,7 @@ User/save disks that can be created from the game itself are not included.
 		<description>Free Software Collection 10</description>
 		<year>1995</year>
 		<publisher>富士通 (Fujitsu)</publisher>
+		<info name="release" value="199506xx" />
 		<part name="cdrom" interface="fmt_cdrom">
 			<diskarea name="cdrom">
 				<disk name="free software collection 10" sha1="d0624c4b4c2a02b2a808e905f10d827efbedb4d2" />
@@ -4213,6 +4395,7 @@ User/save disks that can be created from the game itself are not included.
 		<description>Free Software Collection 11</description>
 		<year>1995</year>
 		<publisher>富士通 (Fujitsu)</publisher>
+		<info name="release" value="199506xx" />
 		<part name="cdrom" interface="fmt_cdrom">
 			<diskarea name="cdrom">
 				<disk name="free software collection 11" sha1="81a0100b41153fbaac04a37a21407b40a57bf568" />
@@ -4231,6 +4414,7 @@ User/save disks that can be created from the game itself are not included.
 		<description>Hishouzame / Flying Shark</description>
 		<year>1993</year>
 		<publisher>ビング (Ving)</publisher>
+		<info name="alt_title" value="飛翔鮫" />
 		<info name="release" value="199309xx" />
 		<part name="cdrom" interface="fmt_cdrom">
 			<diskarea name="cdrom">
@@ -4250,6 +4434,7 @@ User/save disks that can be created from the game itself are not included.
 		<description>Uchuu Kaitou Funny Bee</description>
 		<year>1994</year>
 		<publisher>アリスソフト (AliceSoft)</publisher>
+		<info name="alt_title" value="宇宙怪盗ファニービー" />
 		<info name="release" value="199409xx" />
 		<part name="flop1" interface="floppy_3_5">
 			<dataarea name="flop" size="1261568">
@@ -4274,6 +4459,7 @@ User/save disks that can be created from the game itself are not included.
 		<description>Freeware Collection 1</description>
 		<year>1989</year>
 		<publisher>富士通 (Fujitsu)</publisher>
+		<info name="release" value="198911xx" />
 		<part name="cdrom" interface="fmt_cdrom">
 			<diskarea name="cdrom">
 				<disk name="freeware collection 1" sha1="56c2e66737e1f6611635eb60d50e426b3abf5685" />
@@ -4292,6 +4478,7 @@ User/save disks that can be created from the game itself are not included.
 		<description>Freeware Collection 2</description>
 		<year>1990</year>
 		<publisher>富士通 (Fujitsu)</publisher>
+		<info name="release" value="199006xx" />
 		<part name="cdrom" interface="fmt_cdrom">
 			<diskarea name="cdrom">
 				<disk name="freeware collection 2" sha1="294f91412f95e100f4bd2c39097dbf3ed81b2e3c" />
@@ -4310,6 +4497,7 @@ User/save disks that can be created from the game itself are not included.
 		<description>Freeware Collection 3</description>
 		<year>1991</year>
 		<publisher>富士通 (Fujitsu)</publisher>
+		<info name="release" value="199103xx" />
 		<part name="cdrom" interface="fmt_cdrom">
 			<diskarea name="cdrom">
 				<disk name="freeware collection 3" sha1="60a1f6791c4304172f9b935fe61c736da6d6b3f6" />
@@ -4328,6 +4516,7 @@ User/save disks that can be created from the game itself are not included.
 		<description>Gakuen King: Hidehiko Gakkou wo Tsukuru</description>
 		<year>1996</year>
 		<publisher>アリスソフト (AliceSoft)</publisher>
+		<info name="alt_title" value="学園KING -日出彦学校を作る-" />
 		<info name="release" value="199606xx" />
 		<info name="usage" value="Requires HDD installation"/>
 		<part name="cdrom" interface="fmt_cdrom">
@@ -4355,6 +4544,7 @@ User/save disks that can be created from the game itself are not included.
 		<description>Galaxy Force II</description>
 		<year>1991</year>
 		<publisher>CRI</publisher>
+		<info name="alt_title" value="ギャラクシーフォースII" />
 		<info name="release" value="199103xx" />
 		<part name="cdrom" interface="fmt_cdrom">
 			<diskarea name="cdrom">
@@ -4374,6 +4564,7 @@ User/save disks that can be created from the game itself are not included.
 		<description>Game Technopolis Super Collection 1</description>
 		<year>1992</year>
 		<publisher>徳間書店 (Tokuma Shoten)</publisher>
+		<info name="alt_title" value="GAMEテクノポリス スーパーコレクション1" />
 		<part name="cdrom" interface="fmt_cdrom">
 			<diskarea name="cdrom">
 				<disk name="game technopolis super collection 1" sha1="c35229967fd790450d36c9ec1e4c70b9d3d7d336" />
@@ -4390,6 +4581,7 @@ User/save disks that can be created from the game itself are not included.
 		<description>Game Technopolis Super Collection 2</description>
 		<year>1993</year>
 		<publisher>徳間書店 (Tokuma Shoten)</publisher>
+		<info name="alt_title" value="GAMEテクノポリス スーパーコレクション2" />
 		<part name="cdrom" interface="fmt_cdrom">
 			<diskarea name="cdrom">
 				<disk name="game technopolis super collection 2" sha1="71e1cb211ed1055086162de74fd265498a986546" />
@@ -4417,6 +4609,7 @@ User/save disks that can be created from the game itself are not included.
 		<description>Gekirin - Ushinawareshi Houken</description>
 		<year>1994</year>
 		<publisher>日本アプリケーション (Nihon Application)</publisher>
+		<info name="alt_title" value="ＧＥＫＩＲＩＮ 失なわれし宝剣" />
 		<info name="release" value="199412xx" />
 		<part name="cdrom" interface="fmt_cdrom">
 			<diskarea name="cdrom">
@@ -4457,6 +4650,7 @@ User/save disks that can be created from the game itself are not included.
 		<description>Gendai Daisenryaku EX Special</description>
 		<year>1994</year>
 		<publisher>ビング (Ving)</publisher>
+		<info name="alt_title" value="現代大戦略ＥＸスペシャル" />
 		<info name="release" value="199409xx" />
 		<part name="cdrom" interface="fmt_cdrom">
 			<diskarea name="cdrom">
@@ -4468,18 +4662,17 @@ User/save disks that can be created from the game itself are not included.
 	<software name="genocsq">
 		<!--
 		Origin: Neo Kobe Collection
-		<rom name="Genocide Square.ccd" size="784" crc="2303a876" sha1="84d16ece4ee8f14ae03f0f45228fc617c6d2efdd"/>
-		<rom name="Genocide Square.cue" size="81" crc="fe5b85ca" sha1="8690f33cafda001068d08a93beb5899740d9f36d"/>
-		<rom name="Genocide Square.img" size="41987904" crc="69fa846b" sha1="3359c5f0c65dfe66797aec59121ab3f2d9f05137"/>
-		<rom name="Genocide Square.sub" size="1713792" crc="d32de9d3" sha1="647dcabf4efa2014a85d0a9db5b374051ed2182c"/>
+		<rom name="Genocide^2 - Genocide Square (Japan).bin" size="41983200" crc="d4b6968f" sha1="19c1b7395c5f3a6f292efb4fea8d4142e7fed275"/>
+		<rom name="Genocide^2 - Genocide Square (Japan).cue" size="125" crc="fa95ebbc" sha1="79557cd7745b602214802af19b809e92d0d11b8a"/>
 		-->
 		<description>Genocide Square</description>
 		<year>1993</year>
 		<publisher>Zoom</publisher>
+		<info name="alt_title" value="ジェノサイド・スクウエア" />
 		<info name="release" value="199304xx" />
 		<part name="cdrom" interface="fmt_cdrom">
 			<diskarea name="cdrom">
-				<disk name="genocide square" sha1="2b9e586bdf24e546c1de001bffee82cc399e47ae" />
+				<disk name="genocide^2 - genocide square (japan)" sha1="0bb72510a65ed2110efdd913889506776120b7ef" />
 			</diskarea>
 		</part>
 	</software>
@@ -4495,6 +4688,7 @@ User/save disks that can be created from the game itself are not included.
 		<description>Giga Mortion</description>
 		<year>1995</year>
 		<publisher>インターハート (Interheart)</publisher>
+		<info name="alt_title" value="戯画もーしょん" />
 		<info name="release" value="199503xx" />
 		<part name="cdrom" interface="fmt_cdrom">
 			<diskarea name="cdrom">
@@ -4512,6 +4706,7 @@ User/save disks that can be created from the game itself are not included.
 		<description>Ginga Eiyuu Densetsu III SP</description>
 		<year>1993</year>
 		<publisher>ボーステック (Bothtec)</publisher>
+		<info name="alt_title" value="銀河英雄伝説III SP" />
 		<info name="release" value="199312xx" />
 		<part name="flop1" interface="floppy_3_5">
 			<feature name="part_id" value="Game Disk" />
@@ -4537,6 +4732,7 @@ User/save disks that can be created from the game itself are not included.
 		<description>Goh II Towns Special</description>
 		<year>1993</year>
 		<publisher>ウルフチーム (WolfTeam)</publisher>
+		<info name="alt_title" value="轟2タウンズスペシャル" />
 		<info name="release" value="198909xx" />
 		<part name="flop1" interface="floppy_3_5">
 			<feature name="part_id" value="System Disk" />
@@ -4547,6 +4743,23 @@ User/save disks that can be created from the game itself are not included.
 		<part name="cdrom" interface="fmt_cdrom">
 			<diskarea name="cdrom">
 				<disk name="goh ii towns special" sha1="bb065fe7e0ea80d9da2b2e3b7c4a8f107ff24b6e" />
+			</diskarea>
+		</part>
+	</software>
+
+	<software name="gokko1">
+		<!--
+		Origin: redump.org
+		<rom name="Gokko Vol. 01 - Doctor (Japan).bin" size="158407200" crc="99b1173f" sha1="1c03184f7cbeb082162259f1c8f916ba38add701"/>
+		<rom name="Gokko Vol. 01 - Doctor (Japan).cue" size="119" crc="0e8f1639" sha1="ab49401a30589cb5e4d3ce23133a85e0d92e47b2"/>
+		-->
+		<description>Gokko Vol. 01 - Doctor</description>
+		<year>1994</year>
+		<publisher>ミンク (Mink)</publisher>
+		<info name="release" value="199411xx" />
+		<part name="cdrom" interface="fmt_cdrom">
+			<diskarea name="cdrom">
+				<disk name="gokko vol. 01 - doctor (japan)" sha1="aef878a0937ec2e9350467de8f94cc3118cd7420" />
 			</diskarea>
 		</part>
 	</software>
@@ -4577,9 +4790,10 @@ User/save disks that can be created from the game itself are not included.
 		<rom name="Image.sub" size="12541440" crc="916d6a80" sha1="e37fd45a1c4abc83f355bcfeedab75f07645ec50"/>
 		-->
 		<description>Märchen Toshokan - Grimm Douwa - Akazukin</description>
-		<year>1989?</year>
+		<year>1989</year>
 		<publisher>ぎょうせい (Gyousei)</publisher>
 		<info name="alt_title" value="メルヘン図書館　グリム童話　赤ずきん" />
+		<info name="release" value="198912xx" />
 		<part name="cdrom" interface="fmt_cdrom">
 			<diskarea name="cdrom">
 				<disk name="grimm" sha1="78e0cbc80ad750219b9cf247052e1018a57c4f78" />
@@ -4593,9 +4807,10 @@ User/save disks that can be created from the game itself are not included.
 		<rom name="gulfwar.cue" size="73" crc="b26630b6" sha1="e30f87162664eb70b085517809b7dcddde4d4ea6"/>
 		<rom name="gulfwar.bin" size="10231200" crc="d93096ec" sha1="f570fce35e8f5beafa3e373cbae67b58aadce3db"/>
 		-->
-		<description>Gulf War Soukouden</description>
+		<description>Gulf War - Soukouden</description>
 		<year>1993</year>
 		<publisher>ウルフチーム (WolfTeam)</publisher>
+		<info name="alt_title" value="ＧＵＬＦ ＷＡＲ 蒼鋼伝" />
 		<info name="release" value="199312xx" />
 		<part name="flop1" interface="floppy_3_5">
 			<feature name="part_id" value="System Disk" />
@@ -4621,6 +4836,7 @@ User/save disks that can be created from the game itself are not included.
 		<description>Gunblaze</description>
 		<year>1994</year>
 		<publisher>アクティブ (Active)</publisher>
+		<info name="alt_title" value="ガンブレイズ" />
 		<info name="release" value="199412xx" />
 		<part name="cdrom" interface="fmt_cdrom">
 			<diskarea name="cdrom">
@@ -4640,6 +4856,7 @@ User/save disks that can be created from the game itself are not included.
 		<description>Mobile Suit Gundam - Hyper Classic Operation</description>
 		<year>1992</year>
 		<publisher>ファミリーソフト (Family Soft)</publisher>
+		<info name="alt_title" value="機動戦士ガンダム ハイパー クラシック オペレーション" />
 		<info name="release" value="199208xx" />
 		<part name="cdrom" interface="fmt_cdrom">
 			<diskarea name="cdrom">
@@ -4659,6 +4876,7 @@ User/save disks that can be created from the game itself are not included.
 		<description>Mobile Suit Gundam - Hyper Desert Operation</description>
 		<year>1992</year>
 		<publisher>ファミリーソフト (Family Soft)</publisher>
+		<info name="alt_title" value="機動戦士ガンダム ハイパー デザート オペレーション" />
 		<info name="release" value="199209xx" />
 		<part name="cdrom" interface="fmt_cdrom">
 			<diskarea name="cdrom">
@@ -4670,9 +4888,15 @@ User/save disks that can be created from the game itself are not included.
 	<!-- Some graphics issues -->
 	<software name="gunship" supported="partial">
 		<!--
-		Origin: Neo Kobe Collection
-		<rom name="Gunship - The Helicopter Simulation.cue" size="370" crc="258b11b0" sha1="146fb88fc218b94c5b04c8eb08fd04d4523dde44"/>
-		<rom name="Gunship - The Helicopter Simulation.img" size="376437600" crc="989f159f" sha1="74d836bff0beabbcd76a4c9a6362136c38cb2641"/>
+		Origin: redump.org
+		<rom name="Gunship - The Helicopter Simulation (Japan) (Track 1).bin" size="20815200" crc="11dc9417" sha1="7431efb87370ecbc9e253d2610151ff78367a0d5"/>
+		<rom name="Gunship - The Helicopter Simulation (Japan) (Track 2).bin" size="28753200" crc="f2bee3a0" sha1="7ba32d8ce9090f73f59af0bc91c80f3dfead9e1b"/>
+		<rom name="Gunship - The Helicopter Simulation (Japan) (Track 3).bin" size="89434800" crc="78451865" sha1="6d586be33bcd39bd610024757cd3aa0910eb486b"/>
+		<rom name="Gunship - The Helicopter Simulation (Japan) (Track 4).bin" size="61563600" crc="50e4bb52" sha1="5aa021a29a3197517d3c4cc3f4b61f5ac27ce482"/>
+		<rom name="Gunship - The Helicopter Simulation (Japan) (Track 5).bin" size="56095200" crc="1af48533" sha1="5136bf39209a190c878fd9e2af00714165a88da8"/>
+		<rom name="Gunship - The Helicopter Simulation (Japan) (Track 6).bin" size="55566000" crc="a91a7232" sha1="aac6a6fb44335e4350e163b2d34be57f19e5b8ca"/>
+		<rom name="Gunship - The Helicopter Simulation (Japan) (Track 7).bin" size="64209600" crc="bc482cd2" sha1="d13e9d3480b661d10ba7e068f82c13eaa854089b"/>
+		<rom name="Gunship - The Helicopter Simulation (Japan).cue" size="941" crc="4a7fb9ec" sha1="601034b82359eedd8513e0dce3143a92c033c8f4"/>
 		-->
 		<description>Gunship - The Helicopter Simulation</description>
 		<year>1990</year>
@@ -4680,7 +4904,7 @@ User/save disks that can be created from the game itself are not included.
 		<info name="release" value="199010xx" />
 		<part name="cdrom" interface="fmt_cdrom">
 			<diskarea name="cdrom">
-				<disk name="gunship - the helicopter simulation" sha1="27c9e702097d1663302dc10fd5dccdd9ba8d6fc8" />
+				<disk name="gunship - the helicopter simulation (japan)" sha1="d60b20686c1e4ed6f791d890f397fabcc3950e32" />
 			</diskarea>
 		</part>
 	</software>
@@ -4696,6 +4920,7 @@ User/save disks that can be created from the game itself are not included.
 		<description>Hana no Kioku</description>
 		<year>1995</year>
 		<publisher>フォスター (Foster)</publisher>
+		<info name="alt_title" value="花の記憶" />
 		<info name="release" value="199512xx" />
 		<part name="cdrom" interface="fmt_cdrom">
 			<diskarea name="cdrom">
@@ -4715,6 +4940,7 @@ User/save disks that can be created from the game itself are not included.
 		<description>Hanafuda de Pon!</description>
 		<year>1996</year>
 		<publisher>アクティブ (Active)</publisher>
+		<info name="alt_title" value="花札でPON！" />
 		<info name="release" value="199607xx" />
 		<part name="flop1" interface="floppy_3_5">
 			<feature name="part_id" value="Boot Disk" />
@@ -4757,9 +4983,10 @@ User/save disks that can be created from the game itself are not included.
 		<rom name="Heart de Ron!!.img" size="439953360" crc="ed1e3f58" sha1="746444998a41a1d722b09a6cecd0097a1c909cdb"/>
 		<rom name="Heart de Ron!!.sub" size="17957280" crc="5de2c580" sha1="84abf50f739bb620c2171029e5564aa6210ec7f9"/>
 		-->
-		<description>Heart de Ron!!</description>
+		<description>Zen Nihon Bishoujo Mahjong Senshuken Taikai - Heart de Ron!!</description>
 		<year>1995</year>
 		<publisher>ディー・オー (D.O.)</publisher>
+		<info name="alt_title" value="全日本美少女麻雀選手権大会 ハートでロン！！" />
 		<info name="release" value="199503xx" />
 		<part name="cdrom" interface="fmt_cdrom">
 			<diskarea name="cdrom">
@@ -4779,6 +5006,7 @@ User/save disks that can be created from the game itself are not included.
 		<description>High C Compiler Multimedia Development Kit v1.7 L13</description>
 		<year>1995</year>
 		<publisher>富士通 (Fujitsu)</publisher>
+		<info name="release" value="199503xx" />
 		<part name="cdrom" interface="fmt_cdrom">
 			<diskarea name="cdrom">
 				<disk name="high c compiler multimedia development kit v1.7 l13" sha1="1755383d812fe07b4ad2cd0b44c111cb14b25ae7" />
@@ -4823,6 +5051,8 @@ User/save disks that can be created from the game itself are not included.
 		<description>Hiouden II</description>
 		<year>1994</year>
 		<publisher>ウルフチーム (WolfTeam)</publisher>
+		<info name="alt_title" value="緋王伝II" />
+		<info name="release" value="199403xx" />
 		<!--
 		Note from the dumper:
 
@@ -4855,6 +5085,7 @@ User/save disks that can be created from the game itself are not included.
 		<description>Hoshi no Suna Monogatari</description>
 		<year>1992</year>
 		<publisher>ディー・オー (D.O.)</publisher>
+		<info name="alt_title" value="星の砂物語" />
 		<info name="release" value="199209xx" />
 		<part name="cdrom" interface="fmt_cdrom">
 			<diskarea name="cdrom">
@@ -4874,6 +5105,7 @@ User/save disks that can be created from the game itself are not included.
 		<description>Hoshi no Suna Monogatari 2</description>
 		<year>1992</year>
 		<publisher>ディー・オー (D.O.)</publisher>
+		<info name="alt_title" value="星の砂物語2" />
 		<info name="release" value="199210xx" />
 		<part name="cdrom" interface="fmt_cdrom">
 			<diskarea name="cdrom">
@@ -4893,6 +5125,7 @@ User/save disks that can be created from the game itself are not included.
 		<description>Hoshi no Suna Monogatari 3</description>
 		<year>1995</year>
 		<publisher>ディー・オー (D.O.)</publisher>
+		<info name="alt_title" value="星の砂物語3" />
 		<info name="release" value="199508xx" />
 		<part name="cdrom" interface="fmt_cdrom">
 			<diskarea name="cdrom">
@@ -4912,6 +5145,7 @@ User/save disks that can be created from the game itself are not included.
 		<description>Hyper Address</description>
 		<year>1990</year>
 		<publisher>ダットジャパン (Datt Japan)</publisher>
+		<info name="release" value="199003xx" />
 		<part name="flop1" interface="floppy_3_5">
 			<feature name="part_id" value="System Disk" />
 			<dataarea name="flop" size="1261568">
@@ -4938,6 +5172,7 @@ User/save disks that can be created from the game itself are not included.
 		<description>Hyper Ocean</description>
 		<year>1993</year>
 		<publisher>ダットジャパン (Datt Japan)</publisher>
+		<info name="release" value="199304xx" />
 		<part name="cdrom" interface="fmt_cdrom">
 			<diskarea name="cdrom">
 				<disk name="hyper ocean" sha1="4aeb8ac2f4432832d46668e2a5572260a946724c" />
@@ -4956,6 +5191,7 @@ User/save disks that can be created from the game itself are not included.
 		<description>Idol Project</description>
 		<year>1995</year>
 		<publisher>ケイエスエス (KSS)</publisher>
+		<info name="alt_title" value="アイドル プロジェクト" />
 		<info name="release" value="199507xx" />
 		<part name="flop1" interface="floppy_3_5">
 			<feature name="part_id" value="System Disk" />
@@ -4981,6 +5217,7 @@ User/save disks that can be created from the game itself are not included.
 		<description>If 2</description>
 		<year>1993</year>
 		<publisher>アクティブ (Active)</publisher>
+		<info name="alt_title" value="イフ2" />
 		<info name="release" value="19931119" />
 		<part name="cdrom" interface="fmt_cdrom">
 			<diskarea name="cdrom">
@@ -5000,6 +5237,7 @@ User/save disks that can be created from the game itself are not included.
 		<description>Igo II</description>
 		<year>1989</year>
 		<publisher>アスキー (ASCII)</publisher>
+		<info name="alt_title" value="囲碁II" />
 		<part name="cdrom" interface="fmt_cdrom">
 			<diskarea name="cdrom">
 				<disk name="go ii" sha1="74ad3665b97bf25ea91a7d7dd344de8bff845be0" />
@@ -5022,6 +5260,7 @@ User/save disks that can be created from the game itself are not included.
 		<description>Igo Doujou - Honkakuha Yose Tsumego Shinan</description>
 		<year>1989</year>
 		<publisher>富士通 (Fujitsu)</publisher>
+		<info name="alt_title" value="囲碁道場 本格派寄せ・詰碁指南" />
 		<info name="release" value="198903xx" />
 		<part name="cdrom" interface="fmt_cdrom">
 			<diskarea name="cdrom">
@@ -5039,6 +5278,7 @@ User/save disks that can be created from the game itself are not included.
 		<description>Image Fight</description>
 		<year>1990</year>
 		<publisher>ビング (Ving)</publisher>
+		<info name="alt_title" value="イメージファイト" />
 		<info name="release" value="199011xx" />
 		<part name="cdrom" interface="fmt_cdrom">
 			<diskarea name="cdrom">
@@ -5058,6 +5298,7 @@ User/save disks that can be created from the game itself are not included.
 		<description>The Incredible Machine</description>
 		<year>1994</year>
 		<publisher>サイベル (Cybelle)</publisher>
+		<info name="alt_title" value="インクレディブル・マシーン" />
 		<info name="release" value="199404xx" />
 		<part name="cdrom" interface="fmt_cdrom">
 			<diskarea name="cdrom">
@@ -5133,6 +5374,7 @@ User/save disks that can be created from the game itself are not included.
 		<description>Infestation - Chinmoku no Wakusei</description>
 		<year>1992</year>
 		<publisher>ビクター音楽産業 (Victor Musical Industries)</publisher>
+		<info name="alt_title" value="インフェステーション 沈黙の惑星" />
 		<info name="release" value="199203xx" />
 		<part name="cdrom" interface="fmt_cdrom">
 			<diskarea name="cdrom">
@@ -5152,6 +5394,7 @@ User/save disks that can be created from the game itself are not included.
 		<description>Inindou - Datou Nobunaga</description>
 		<year>1992</year>
 		<publisher>光栄 (Koei)</publisher>
+		<info name="alt_title" value="伊忍道・打倒信長" />
 		<info name="release" value="199202xx" />
 		<part name="flop1" interface="floppy_3_5">
 			<feature name="part_id" value="User Disk" />
@@ -5177,6 +5420,7 @@ User/save disks that can be created from the game itself are not included.
 		<description>Injuu Gakuen - La Blue Girl</description>
 		<year>1994</year>
 		<publisher>DEZ</publisher>
+		<info name="alt_title" value="淫獣学園 Laブルーガール" />
 		<info name="release" value="199407xx" />
 		<part name="cdrom" interface="fmt_cdrom">
 			<diskarea name="cdrom">
@@ -5196,6 +5440,7 @@ User/save disks that can be created from the game itself are not included.
 		<description>Ishidou</description>
 		<year>1990</year>
 		<publisher>富士通 (Fujitsu)</publisher>
+		<info name="alt_title" value="石道" />
 		<info name="release" value="199006xx" />
 		<part name="cdrom" interface="fmt_cdrom">
 			<diskarea name="cdrom">
@@ -5253,6 +5498,7 @@ User/save disks that can be created from the game itself are not included.
 		<description>Jan Jaka Jan</description>
 		<year>1992</year>
 		<publisher>エルフ (Elf)</publisher>
+		<info name="alt_title" value="雀ジャカ雀" />
 		<info name="release" value="199301xx" />
 		<part name="cdrom" interface="fmt_cdrom">
 			<diskarea name="cdrom">
@@ -5273,6 +5519,7 @@ User/save disks that can be created from the game itself are not included.
 		<description>Jangou 4</description>
 		<year>1994</year>
 		<publisher>ビクター音楽産業 (Victor Musical Industries)</publisher>
+		<info name="alt_title" value="雀豪４" />
 		<info name="release" value="199411xx" />
 		<part name="cdrom" interface="fmt_cdrom">
 			<diskarea name="cdrom">
@@ -5292,6 +5539,7 @@ User/save disks that can be created from the game itself are not included.
 		<description>Jankirou</description>
 		<year>1994</year>
 		<publisher>フェアリーテール (Fairytale)</publisher>
+		<info name="alt_title" value="雀妃楼" />
 		<info name="release" value="199406xx" />
 		<part name="cdrom" interface="fmt_cdrom">
 			<diskarea name="cdrom">
@@ -5311,6 +5559,7 @@ User/save disks that can be created from the game itself are not included.
 		<description>Jealousy</description>
 		<year>1995</year>
 		<publisher>インターハート (Interheart)</publisher>
+		<info name="alt_title" value="ジェラシー" />
 		<info name="release" value="199507xx" />
 		<part name="cdrom" interface="fmt_cdrom">
 			<diskarea name="cdrom">
@@ -5347,6 +5596,7 @@ User/save disks that can be created from the game itself are not included.
 		<description>Joshikousei Shoujo Hatsunetsu</description>
 		<year>1993</year>
 		<publisher>Byakuya-Shobo</publisher>
+		<info name="alt_title" value="女子高生少女発熱" />
 		<info name="release" value="199312xx" />
 		<part name="cdrom" interface="fmt_cdrom">
 			<diskarea name="cdrom">
@@ -5364,6 +5614,7 @@ User/save disks that can be created from the game itself are not included.
 		<description>Joshikou Seifuku Monogatari</description>
 		<year>1995</year>
 		<publisher>ケイエスエス (KSS)</publisher>
+		<info name="alt_title" value="女子校制服物語" />
 		<info name="release" value="199504xx" />
 		<part name="flop1" interface="floppy_3_5">
 			<dataarea name="flop" size="1261568">
@@ -5388,6 +5639,7 @@ User/save disks that can be created from the game itself are not included.
 		<description>Joshua</description>
 		<year>1992</year>
 		<publisher>パンサーソフトウェア (Panther Software)</publisher>
+		<info name="alt_title" value="ジョシュア" />
 		<info name="release" value="199211xx" />
 		<part name="cdrom" interface="fmt_cdrom">
 			<diskarea name="cdrom">
@@ -5407,6 +5659,7 @@ User/save disks that can be created from the game itself are not included.
 		<description>Kid Pix</description>
 		<year>1992</year>
 		<publisher>富士通 (Fujitsu)</publisher>
+		<info name="release" value="199208xx" />
 		<part name="cdrom" interface="fmt_cdrom">
 			<diskarea name="cdrom">
 				<disk name="kid pix" sha1="090939e80a209292d6b606e3e7b2b44bbd3585be" />
@@ -5423,6 +5676,7 @@ User/save disks that can be created from the game itself are not included.
 		<description>Kigen - Kagayaki no Hasha</description>
 		<year>1992</year>
 		<publisher>リバーヒルソフト (Riverhill Soft)</publisher>
+		<info name="alt_title" value="ＫＩＧＥＮ 輝きの覇者" />
 		<info name="release" value="199205xx" />
 		<part name="cdrom" interface="fmt_cdrom">
 			<diskarea name="cdrom">
@@ -5442,6 +5696,7 @@ User/save disks that can be created from the game itself are not included.
 		<description>Kindan no Ketsuzoku</description>
 		<year>1993</year>
 		<publisher>シーズウェア (C's Ware)</publisher>
+		<info name="alt_title" value="禁断の血族" />
 		<info name="release" value="199407xx" />
 		<part name="cdrom" interface="fmt_cdrom">
 			<diskarea name="cdrom">
@@ -5458,9 +5713,10 @@ User/save disks that can be created from the game itself are not included.
 		<rom name="King&apos;s Bounty.img" size="386494752" crc="cdcf960b" sha1="d31f3214ab0bbb229c9f79ef3f7752d5fcb8cc7e"/>
 		<rom name="King&apos;s Bounty.sub" size="15775296" crc="d291d35c" sha1="66a469ec41ade7ebe882905efbe316c94c790764"/>
 		-->
-		<description>King's Bounty</description>
+		<description>King's Bounty - Nusumareta Chitsujo</description>
 		<year>1994</year>
 		<publisher>スタークラフト (Starcraft)</publisher>
+		<info name="alt_title" value="キングス バウンティ 盗まれた秩序" />
 		<info name="release" value="199407xx" />
 		<part name="cdrom" interface="fmt_cdrom">
 			<diskarea name="cdrom">
@@ -5502,6 +5758,7 @@ User/save disks that can be created from the game itself are not included.
 		<description>Kiwame</description>
 		<year>1992</year>
 		<publisher>ログ (Log)</publisher>
+		<info name="alt_title" value="極" />
 		<info name="release" value="199210xx" />
 		<part name="cdrom" interface="fmt_cdrom">
 			<diskarea name="cdrom">
@@ -5521,6 +5778,7 @@ User/save disks that can be created from the game itself are not included.
 		<description>Kiwame II</description>
 		<year>1994</year>
 		<publisher>ログ (Log)</publisher>
+		<info name="alt_title" value="極II" />
 		<info name="release" value="199406xx" />
 		<part name="cdrom" interface="fmt_cdrom">
 			<diskarea name="cdrom">
@@ -5540,6 +5798,7 @@ User/save disks that can be created from the game itself are not included.
 		<description>Koko wa Rakuensou</description>
 		<year>1996</year>
 		<publisher>フォスター (Foster)</publisher>
+		<info name="alt_title" value="ここは楽園荘" />
 		<info name="release" value="199603xx" />
 		<part name="cdrom" interface="fmt_cdrom">
 			<diskarea name="cdrom">
@@ -5557,6 +5816,7 @@ User/save disks that can be created from the game itself are not included.
 		<description>Koko wa Rakuensou 2</description>
 		<year>1996</year>
 		<publisher>フォスター (Foster)</publisher>
+		<info name="alt_title" value="ここは楽園荘2" />
 		<info name="release" value="199604xx" />
 		<part name="cdrom" interface="fmt_cdrom">
 			<diskarea name="cdrom">
@@ -5604,18 +5864,37 @@ User/save disks that can be created from the game itself are not included.
 		</part>
 	</software>
 
-	<!-- Fails to boot, doesn't seem to recognize the CD -->
-	<software name="kyrandia" supported="no">
+	<software name="kyrandia">
 		<!--
-		Origin: Neo Kobe Collection
-		<rom name="The Legend of Kyrandia.ccd" size="4894" crc="3a8bbbfb" sha1="132f7535d204a731423b497729d3b7e01f35eefd"/>
-		<rom name="The Legend of Kyrandia.cue" size="970" crc="bbd1692c" sha1="ca251c8dfedd607349451a81ef0b2adaf2a61bcf"/>
-		<rom name="The Legend of Kyrandia.img" size="561895152" crc="8f8bb29e" sha1="15d73a824957614af96bac3467c37f576a50390f"/>
-		<rom name="The Legend of Kyrandia.sub" size="22934496" crc="0638eedb" sha1="76d14925a9f668100d2e55f610b56cacf6fbb292"/>
+		Origin: redump.org
+		<rom name="Legend of Kyrandia, The (Japan) (En,Ja) (FM Towns) (Track 01).bin" size="9403296" crc="22887101" sha1="310f10bc63da750541b513913990708daf57e14f"/>
+		<rom name="Legend of Kyrandia, The (Japan) (En,Ja) (FM Towns) (Track 02).bin" size="29752800" crc="25626629" sha1="174ff1838863decc1d0d85aa96e4a25cc051f7ac"/>
+		<rom name="Legend of Kyrandia, The (Japan) (En,Ja) (FM Towns) (Track 03).bin" size="28129920" crc="9118b9ea" sha1="eda13c04ef5fd2e540f2b313c3ede040dc039511"/>
+		<rom name="Legend of Kyrandia, The (Japan) (En,Ja) (FM Towns) (Track 04).bin" size="20991600" crc="e947027f" sha1="c6daed40f17f86b33515126e1dd693d663c4abc5"/>
+		<rom name="Legend of Kyrandia, The (Japan) (En,Ja) (FM Towns) (Track 05).bin" size="17146080" crc="f72d5f33" sha1="29e574677f57f994d2379d7d3694b9aff24deff8"/>
+		<rom name="Legend of Kyrandia, The (Japan) (En,Ja) (FM Towns) (Track 06).bin" size="25013520" crc="bcbf759a" sha1="44a4fd681e291cfc524293f44cf053d848b00391"/>
+		<rom name="Legend of Kyrandia, The (Japan) (En,Ja) (FM Towns) (Track 07).bin" size="18340896" crc="39ec5b66" sha1="670f639a9ef064c9673d818a8ba3753ed4aec2fb"/>
+		<rom name="Legend of Kyrandia, The (Japan) (En,Ja) (FM Towns) (Track 08).bin" size="21266784" crc="26bc5a4b" sha1="007241398eb076c30830f9ce3ca019c457f269ad"/>
+		<rom name="Legend of Kyrandia, The (Japan) (En,Ja) (FM Towns) (Track 09).bin" size="34720224" crc="7de82006" sha1="71a7f245dc1f6b78aa5f78bba1ac4d906ff12855"/>
+		<rom name="Legend of Kyrandia, The (Japan) (En,Ja) (FM Towns) (Track 10).bin" size="28607376" crc="1d50f9dc" sha1="be14acaa770940026a2f395acb3652be8e071bbb"/>
+		<rom name="Legend of Kyrandia, The (Japan) (En,Ja) (FM Towns) (Track 11).bin" size="31575600" crc="2ced7636" sha1="b5859fa5105992ec149bf591169c0cf253196724"/>
+		<rom name="Legend of Kyrandia, The (Japan) (En,Ja) (FM Towns) (Track 12).bin" size="15424416" crc="98c26745" sha1="ddf835c2034de1e0c1180b0cfa3161a2623d756d"/>
+		<rom name="Legend of Kyrandia, The (Japan) (En,Ja) (FM Towns) (Track 13).bin" size="21960624" crc="3992269a" sha1="c874ca23da50011a23db06c8c25fdaca1ae0e2aa"/>
+		<rom name="Legend of Kyrandia, The (Japan) (En,Ja) (FM Towns) (Track 14).bin" size="78415680" crc="cdd6d402" sha1="c6f583afdd17a59133a2112075551322bdbe883d"/>
+		<rom name="Legend of Kyrandia, The (Japan) (En,Ja) (FM Towns) (Track 15).bin" size="27612480" crc="8cf681bd" sha1="3ceeb4d3afdfd12a1c3641f42a2e106b65342c21"/>
+		<rom name="Legend of Kyrandia, The (Japan) (En,Ja) (FM Towns) (Track 16).bin" size="45593520" crc="4a57c679" sha1="bb29d4153db1864b6aca7f583256f1993c94b4c0"/>
+		<rom name="Legend of Kyrandia, The (Japan) (En,Ja) (FM Towns) (Track 17).bin" size="12430320" crc="523cd6db" sha1="6a24ffe7b532fa3c6b7fe8e27129ab179701bba7"/>
+		<rom name="Legend of Kyrandia, The (Japan) (En,Ja) (FM Towns) (Track 18).bin" size="8624784" crc="dc9d19ca" sha1="cb6ba4f6a592b769e13bb8950da6c47be6bac9fd"/>
+		<rom name="Legend of Kyrandia, The (Japan) (En,Ja) (FM Towns) (Track 19).bin" size="10614576" crc="8a1bfb3f" sha1="3cb83119ea14bb7220da4a15e12c20f264b23852"/>
+		<rom name="Legend of Kyrandia, The (Japan) (En,Ja) (FM Towns) (Track 20).bin" size="14229600" crc="fd2fc7cc" sha1="efdf399475a4e1fd330e5bf0c627d82a781942f7"/>
+		<rom name="Legend of Kyrandia, The (Japan) (En,Ja) (FM Towns) (Track 21).bin" size="12136320" crc="973875fa" sha1="5e887dd49336fab522991343ee68b999fa7fc690"/>
+		<rom name="Legend of Kyrandia, The (Japan) (En,Ja) (FM Towns) (Track 22).bin" size="49904736" crc="f4fc1800" sha1="3e14d6e4d3143f51dd4b20b29617748bf669ea48"/>
+		<rom name="Legend of Kyrandia, The (Japan) (En,Ja) (FM Towns).cue" size="2712" crc="70fc0d7c" sha1="87dc680b9ddf6004000e6d6a8078defc0106a45b"/>
 		-->
 		<description>The Legend of Kyrandia</description>
 		<year>1993</year>
 		<publisher>スタークラフト (Starcraft)</publisher>
+		<info name="alt_title" value="レジェンド・オブ・キランディア" />
 		<info name="release" value="199310xx" />
 		<part name="flop1" interface="floppy_3_5">
 			<feature name="part_id" value="User Disk" />
@@ -5625,23 +5904,109 @@ User/save disks that can be created from the game itself are not included.
 		</part>
 		<part name="cdrom" interface="fmt_cdrom">
 			<diskarea name="cdrom">
-				<disk name="the legend of kyrandia" sha1="0598efd2a0144568bce75c5a9462b6ae76c5c89b" />
+				<disk name="legend of kyrandia, the (japan) (en,ja) (fm towns)" sha1="7d4c3b1998abd6e19ea22548e53e55dfbb638613" />
 			</diskarea>
 		</part>
 	</software>
 
 	<software name="kyrand2">
 		<!--
-		Origin: Neo Kobe Collection
-		<rom name="The Legend of Kyrandia 2.cue" size="3557" crc="026fe47d" sha1="47fc6d71fa56421115f59791322fe54a41f4f863"/>
-		<rom name="The Legend of Kyrandia 2.img" size="494331600" crc="77d255b4" sha1="21f426eb2e0900a5df98fe714bd6608c82fae2a6"/>
+		Origin: redump.org
+		<rom name="Kyrandia II - The Hand of Fate (Japan) (En,Ja) (Track 01).bin" size="21497280" crc="7b4c8e55" sha1="aeaa1b5e9ef1603816adc6a83d09692a92c51c35"/>
+		<rom name="Kyrandia II - The Hand of Fate (Japan) (En,Ja) (Track 02).bin" size="2232048" crc="ef9ca1ea" sha1="27752a1ce61b9d6e09ea0580c2b0f2420940d746"/>
+		<rom name="Kyrandia II - The Hand of Fate (Japan) (En,Ja) (Track 03).bin" size="4250064" crc="a82e0579" sha1="cfaa9a975d98762cdb1c7c126f990a5eff449ac7"/>
+		<rom name="Kyrandia II - The Hand of Fate (Japan) (En,Ja) (Track 04).bin" size="6216336" crc="da028093" sha1="c2fdab3ee7a3f4500b2d01e510e101b965722a23"/>
+		<rom name="Kyrandia II - The Hand of Fate (Japan) (En,Ja) (Track 05).bin" size="5468400" crc="7afb13ce" sha1="5be415470bb0ca76db6638396a8f3cc9b2633864"/>
+		<rom name="Kyrandia II - The Hand of Fate (Japan) (En,Ja) (Track 06).bin" size="1912176" crc="6edadcda" sha1="b53c2801c2762271dab43a592264e5950b663858"/>
+		<rom name="Kyrandia II - The Hand of Fate (Japan) (En,Ja) (Track 07).bin" size="4915680" crc="c1a1263f" sha1="d27d151b9dbbed677728614ca59655a1bf927b95"/>
+		<rom name="Kyrandia II - The Hand of Fate (Japan) (En,Ja) (Track 08).bin" size="1138368" crc="615160a3" sha1="544ed16e1a1a32ee5c1244bd101be524ec03b149"/>
+		<rom name="Kyrandia II - The Hand of Fate (Japan) (En,Ja) (Track 09).bin" size="23188368" crc="55a010a0" sha1="9b1c0e453277a6658c910d57abff3b18172b997d"/>
+		<rom name="Kyrandia II - The Hand of Fate (Japan) (En,Ja) (Track 10).bin" size="926688" crc="5b2d8b1d" sha1="ea6ad420b39e8416fc6d907f30f785521d587452"/>
+		<rom name="Kyrandia II - The Hand of Fate (Japan) (En,Ja) (Track 11).bin" size="4475856" crc="e3e87434" sha1="ffb13575b61a0f994bb2094f7fcb633acaf8c601"/>
+		<rom name="Kyrandia II - The Hand of Fate (Japan) (En,Ja) (Track 12).bin" size="23360064" crc="dff9bb0b" sha1="d4bba6ed79af45adc8c34651e6b82e71193aac43"/>
+		<rom name="Kyrandia II - The Hand of Fate (Japan) (En,Ja) (Track 13).bin" size="4057200" crc="a37f9d7f" sha1="cee68394f4d20221cd9f6e502a2da94b5ddafa23"/>
+		<rom name="Kyrandia II - The Hand of Fate (Japan) (En,Ja) (Track 14).bin" size="23181312" crc="5959270e" sha1="b9346256aa81dbd30b30e7f320e0a8aa07ae73ff"/>
+		<rom name="Kyrandia II - The Hand of Fate (Japan) (En,Ja) (Track 15).bin" size="9730224" crc="865c853c" sha1="2a84838d9159e3242f3fe53b794cf6b4497fed47"/>
+		<rom name="Kyrandia II - The Hand of Fate (Japan) (En,Ja) (Track 16).bin" size="6054048" crc="5bfae10d" sha1="c413532f82820c5742cb1fb715a9c25a38432739"/>
+		<rom name="Kyrandia II - The Hand of Fate (Japan) (En,Ja) (Track 17).bin" size="13580448" crc="c53ccbe3" sha1="01d1fdf76edd445101f4246304f34a43b5be5c61"/>
+		<rom name="Kyrandia II - The Hand of Fate (Japan) (En,Ja) (Track 18).bin" size="8681232" crc="cd2265ac" sha1="26e4da16fcec525df53b2284c147609bc2a02dc6"/>
+		<rom name="Kyrandia II - The Hand of Fate (Japan) (En,Ja) (Track 19).bin" size="1399440" crc="84da91fb" sha1="1d5dd00e0eef6564a94012708ec7bb065a753504"/>
+		<rom name="Kyrandia II - The Hand of Fate (Japan) (En,Ja) (Track 20).bin" size="18105696" crc="3c9c20c1" sha1="90a912369650885d92c9806b006c74947db8e0f9"/>
+		<rom name="Kyrandia II - The Hand of Fate (Japan) (En,Ja) (Track 21).bin" size="23193072" crc="a883dcb7" sha1="0afc53918a919131811a37225dde9139477613b5"/>
+		<rom name="Kyrandia II - The Hand of Fate (Japan) (En,Ja) (Track 22).bin" size="4633440" crc="c1ead2de" sha1="0ae5fe871a80e7453ea0c4ff430fcfeb2e1c9b09"/>
+		<rom name="Kyrandia II - The Hand of Fate (Japan) (En,Ja) (Track 23).bin" size="3699696" crc="afe7a7d5" sha1="503e245a620d082a88e3a3e294606d1c4d19a775"/>
+		<rom name="Kyrandia II - The Hand of Fate (Japan) (En,Ja) (Track 24).bin" size="921984" crc="93cf7f1d" sha1="e78e1a69c99a73ecb92b4810f7f9ca2106c1b85e"/>
+		<rom name="Kyrandia II - The Hand of Fate (Japan) (En,Ja) (Track 25).bin" size="10830960" crc="e31aa333" sha1="e6b1df33d69f6e88099549652dea861fa91bae6c"/>
+		<rom name="Kyrandia II - The Hand of Fate (Japan) (En,Ja) (Track 26).bin" size="921984" crc="70c79d9a" sha1="7a48fd6dc05bed323a5f3cbeadfa7cc8844f53f9"/>
+		<rom name="Kyrandia II - The Hand of Fate (Japan) (En,Ja) (Track 27).bin" size="921984" crc="689674d2" sha1="3d77710db257ba3b9c7b5754509edd1c2b6e7824"/>
+		<rom name="Kyrandia II - The Hand of Fate (Japan) (En,Ja) (Track 28).bin" size="1453536" crc="367ef133" sha1="8a5316fc905f883b788f92c5f8d79f685139e34a"/>
+		<rom name="Kyrandia II - The Hand of Fate (Japan) (En,Ja) (Track 29).bin" size="9821952" crc="606574dc" sha1="ecec2404ede378e774f80fe109f25a59ceb154a5"/>
+		<rom name="Kyrandia II - The Hand of Fate (Japan) (En,Ja) (Track 30).bin" size="5498976" crc="31266f0c" sha1="4722aad82819bd53975418a2692c1e34bee1113d"/>
+		<rom name="Kyrandia II - The Hand of Fate (Japan) (En,Ja) (Track 31).bin" size="1427664" crc="754f4e26" sha1="cb7299c02fe682f200db54b6727c14d21e49c682"/>
+		<rom name="Kyrandia II - The Hand of Fate (Japan) (En,Ja) (Track 32).bin" size="2770656" crc="a2bee329" sha1="5f5019335cc536b394e4d02a61e20e86ad329e22"/>
+		<rom name="Kyrandia II - The Hand of Fate (Japan) (En,Ja) (Track 33).bin" size="5969376" crc="e7a7dcb4" sha1="10bb6691899b6d2c99107ee41100f4296ceb6fa2"/>
+		<rom name="Kyrandia II - The Hand of Fate (Japan) (En,Ja) (Track 34).bin" size="3949008" crc="b6d4f720" sha1="21927892dce8440d93fe1c4ed96b2ca09cccecb8"/>
+		<rom name="Kyrandia II - The Hand of Fate (Japan) (En,Ja) (Track 35).bin" size="1020768" crc="3d7017ab" sha1="7ca7e84a54b38cb18fa6db5f458ed70d42e26411"/>
+		<rom name="Kyrandia II - The Hand of Fate (Japan) (En,Ja) (Track 36).bin" size="3445680" crc="ca144940" sha1="57873736d68b7137798a60dd7fd77098aa8c861c"/>
+		<rom name="Kyrandia II - The Hand of Fate (Japan) (En,Ja) (Track 37).bin" size="921984" crc="21167d09" sha1="f19d641cbad8af4c85a3494ec461f8b7e30dd3c4"/>
+		<rom name="Kyrandia II - The Hand of Fate (Japan) (En,Ja) (Track 38).bin" size="2763600" crc="6ba724af" sha1="e2ca2fe817551ac401c5b4bfd5facc464983f661"/>
+		<rom name="Kyrandia II - The Hand of Fate (Japan) (En,Ja) (Track 39).bin" size="4675776" crc="5c4b494e" sha1="cb4bff30aba6f3e21de90b40e3707ae6910850ff"/>
+		<rom name="Kyrandia II - The Hand of Fate (Japan) (En,Ja) (Track 40).bin" size="10776864" crc="53c3c4b3" sha1="21f6f64f2f97095be2f1840ed658683add6d83c3"/>
+		<rom name="Kyrandia II - The Hand of Fate (Japan) (En,Ja) (Track 41).bin" size="8998752" crc="deaa905d" sha1="f1f3ab7222dfe9553fe35694098d71a45f020289"/>
+		<rom name="Kyrandia II - The Hand of Fate (Japan) (En,Ja) (Track 42).bin" size="3363360" crc="cfa4ba9b" sha1="27d41250e94cc7b79af76ef08ce7c41857807769"/>
+		<rom name="Kyrandia II - The Hand of Fate (Japan) (En,Ja) (Track 43).bin" size="11115552" crc="8176e485" sha1="69eba59a0e0180b61df2c44eeb126e25b7f5fdbe"/>
+		<rom name="Kyrandia II - The Hand of Fate (Japan) (En,Ja) (Track 44).bin" size="921984" crc="1c7d81af" sha1="ff09665a9df01e5c600dcd20305902c005587124"/>
+		<rom name="Kyrandia II - The Hand of Fate (Japan) (En,Ja) (Track 45).bin" size="1176000" crc="1dff4b9d" sha1="b720cf9d7356875c6465ef41c847c3b7eb6e66fe"/>
+		<rom name="Kyrandia II - The Hand of Fate (Japan) (En,Ja) (Track 46).bin" size="2911776" crc="bcf84349" sha1="9349102731c039a37b2a011198f576e4d1c18962"/>
+		<rom name="Kyrandia II - The Hand of Fate (Japan) (En,Ja) (Track 47).bin" size="9015216" crc="b0c4e1c8" sha1="e5afbaed4695b6d987541e9b6f72f7faf64a9883"/>
+		<rom name="Kyrandia II - The Hand of Fate (Japan) (En,Ja) (Track 48).bin" size="3909024" crc="80412dd3" sha1="819ccfb40742e5cebe08d24b28a11f3a1f21b784"/>
+		<rom name="Kyrandia II - The Hand of Fate (Japan) (En,Ja) (Track 49).bin" size="1232448" crc="fd52aea3" sha1="38664d1a1e57352e7be6f76051baa17738df3872"/>
+		<rom name="Kyrandia II - The Hand of Fate (Japan) (En,Ja) (Track 50).bin" size="4155984" crc="3a8ad87d" sha1="34ac6336e716080585f40fec70d3a928ef88f285"/>
+		<rom name="Kyrandia II - The Hand of Fate (Japan) (En,Ja) (Track 51).bin" size="9231600" crc="8a083b31" sha1="cc97bddb6b8f5b316188fff64d47e0514b08c0d9"/>
+		<rom name="Kyrandia II - The Hand of Fate (Japan) (En,Ja) (Track 52).bin" size="2403744" crc="6d666afc" sha1="293c8289cb710ce17525155ba4c4a78712c7a039"/>
+		<rom name="Kyrandia II - The Hand of Fate (Japan) (En,Ja) (Track 53).bin" size="921984" crc="c92c7e92" sha1="1138fd0b3b4fbb5cba9d6ed480add3046b7ef6ab"/>
+		<rom name="Kyrandia II - The Hand of Fate (Japan) (En,Ja) (Track 54).bin" size="1404144" crc="8335ecc0" sha1="06394d092fcd32576d5dbee4a27742e913378fb3"/>
+		<rom name="Kyrandia II - The Hand of Fate (Japan) (En,Ja) (Track 55).bin" size="7507584" crc="5f6d0448" sha1="c9bfd191d5c1ffec206f3932a7cc532048791b76"/>
+		<rom name="Kyrandia II - The Hand of Fate (Japan) (En,Ja) (Track 56).bin" size="6042288" crc="bedab585" sha1="83e6ba3b2e07a92b40a4c88e557d05f086c1b597"/>
+		<rom name="Kyrandia II - The Hand of Fate (Japan) (En,Ja) (Track 57).bin" size="7394688" crc="d6f9bdc4" sha1="068fbd0d4a15a2375963b5d3c15a4f8ab4f7e7c3"/>
+		<rom name="Kyrandia II - The Hand of Fate (Japan) (En,Ja) (Track 58).bin" size="3577392" crc="04a1b0da" sha1="dbc101f385d782af06acb9d14dee9d32af10fc80"/>
+		<rom name="Kyrandia II - The Hand of Fate (Japan) (En,Ja) (Track 59).bin" size="3351600" crc="ed89e958" sha1="2c739031c10bba0953b24a220d956597e91bd909"/>
+		<rom name="Kyrandia II - The Hand of Fate (Japan) (En,Ja) (Track 60).bin" size="9278640" crc="71f7054f" sha1="f3d6a59ab2363b19715ebebda9578095f4a68c0e"/>
+		<rom name="Kyrandia II - The Hand of Fate (Japan) (En,Ja) (Track 61).bin" size="1157184" crc="b1651bcd" sha1="b46bf70c48666850a73c8d8d6a44aa6a17fb1c4b"/>
+		<rom name="Kyrandia II - The Hand of Fate (Japan) (En,Ja) (Track 62).bin" size="5162640" crc="7f03a913" sha1="c5b517fb7270b130f68c1a9b03748e6027990d6d"/>
+		<rom name="Kyrandia II - The Hand of Fate (Japan) (En,Ja) (Track 63).bin" size="3974880" crc="ec7ba080" sha1="46556d2b3cff97c2e35e8f6cd1bbc7cf63c2e7ac"/>
+		<rom name="Kyrandia II - The Hand of Fate (Japan) (En,Ja) (Track 64).bin" size="6465648" crc="9f5204b9" sha1="5c4060d2e5ad5422b8b061bb82d08d2e320efbbe"/>
+		<rom name="Kyrandia II - The Hand of Fate (Japan) (En,Ja) (Track 65).bin" size="4468800" crc="5bd23479" sha1="9f7b6178a10200999d48dcada66945a97bad18c4"/>
+		<rom name="Kyrandia II - The Hand of Fate (Japan) (En,Ja) (Track 66).bin" size="4901568" crc="09c0801d" sha1="9a23efceaf3fa129a833a39e4b79b52efc721ca9"/>
+		<rom name="Kyrandia II - The Hand of Fate (Japan) (En,Ja) (Track 67).bin" size="1380624" crc="0887c716" sha1="1420ea78d12875e25223569a16363b7007a83a13"/>
+		<rom name="Kyrandia II - The Hand of Fate (Japan) (En,Ja) (Track 68).bin" size="1660512" crc="076b1915" sha1="9f183d2c9eedf3e1425d076f13d3afd7673a1094"/>
+		<rom name="Kyrandia II - The Hand of Fate (Japan) (En,Ja) (Track 69).bin" size="2566032" crc="21e25eaa" sha1="7db8fe1b10a540c51367d8e1fb3c66f24a7ab3cb"/>
+		<rom name="Kyrandia II - The Hand of Fate (Japan) (En,Ja) (Track 70).bin" size="6084624" crc="d3d601c1" sha1="a2fc68a49d439818d527d7079f242552a47e6311"/>
+		<rom name="Kyrandia II - The Hand of Fate (Japan) (En,Ja) (Track 71).bin" size="1361808" crc="92bc58de" sha1="70cefcc361f594278ed1be724cdafb01a6fa8dcb"/>
+		<rom name="Kyrandia II - The Hand of Fate (Japan) (En,Ja) (Track 72).bin" size="3024672" crc="a3a98b17" sha1="4b73ef2b06a9dd1a034684bb2b0a5bebcba1b525"/>
+		<rom name="Kyrandia II - The Hand of Fate (Japan) (En,Ja) (Track 73).bin" size="2309664" crc="e46b84f2" sha1="11c07e82fa59c1ffabf017722e51ba55edcfc123"/>
+		<rom name="Kyrandia II - The Hand of Fate (Japan) (En,Ja) (Track 74).bin" size="12978336" crc="73b82228" sha1="eb99b0e5c285ded4440ef175ba6baf25d22f6db0"/>
+		<rom name="Kyrandia II - The Hand of Fate (Japan) (En,Ja) (Track 75).bin" size="14323680" crc="8a7d593d" sha1="100d913541fc06d3ab4a8c61919e5a1008800f21"/>
+		<rom name="Kyrandia II - The Hand of Fate (Japan) (En,Ja) (Track 76).bin" size="1046640" crc="181f742a" sha1="8fcb72bf5a41f6d38ef7cd20e3c3b96c5f60a54f"/>
+		<rom name="Kyrandia II - The Hand of Fate (Japan) (En,Ja) (Track 77).bin" size="9967776" crc="54f13826" sha1="a1acbcdc891e1fd5bda61965f104bd9606273e90"/>
+		<rom name="Kyrandia II - The Hand of Fate (Japan) (En,Ja) (Track 78).bin" size="1368864" crc="54323161" sha1="82627be19eb301bf277f3cc5ea9b32e6efc3009e"/>
+		<rom name="Kyrandia II - The Hand of Fate (Japan) (En,Ja) (Track 79).bin" size="1437072" crc="6ca3ae2b" sha1="57499eb86ab514fcabe647fc8a1f95e8482f010e"/>
+		<rom name="Kyrandia II - The Hand of Fate (Japan) (En,Ja) (Track 80).bin" size="921984" crc="0acd8735" sha1="1f7ae50479f31baf62cfe7783b4f633adff65148"/>
+		<rom name="Kyrandia II - The Hand of Fate (Japan) (En,Ja) (Track 81).bin" size="1044288" crc="13b91a77" sha1="b88c4fc107d318685c1582ca7588cc40680faf03"/>
+		<rom name="Kyrandia II - The Hand of Fate (Japan) (En,Ja) (Track 82).bin" size="1698144" crc="f0d751d3" sha1="1c4f47e00f780f93ebca98dd322b236ce3769fca"/>
+		<rom name="Kyrandia II - The Hand of Fate (Japan) (En,Ja) (Track 83).bin" size="4689888" crc="70ebb92b" sha1="be984ea4051e34ed8407833b6675b16d78fefaad"/>
+		<rom name="Kyrandia II - The Hand of Fate (Japan) (En,Ja) (Track 84).bin" size="8758848" crc="e79b3017" sha1="9c20f221b868719903a2c4bba8fa7fb86c88d752"/>
+		<rom name="Kyrandia II - The Hand of Fate (Japan) (En,Ja) (Track 85).bin" size="9673776" crc="ffebbf69" sha1="99eb4ed3f43253ced480a1f6abbe034d0a5cb13c"/>
+		<rom name="Kyrandia II - The Hand of Fate (Japan) (En,Ja).cue" size="10081" crc="f0638de6" sha1="688f3ba53bf9ae95a2613d888590b25b0692fb69"/>
 		-->
 		<description>Kyrandia II - The Hand of Fate</description>
 		<year>1995</year>
 		<publisher>スタークラフト (Starcraft)</publisher>
+		<info name="alt_title" value="キランディア2 運命の手" />
+		<info name="release" value="199510xx" />
 		<part name="cdrom" interface="fmt_cdrom">
 			<diskarea name="cdrom">
-				<disk name="the legend of kyrandia 2" sha1="245b1de4313891f5a6bd68104b03b24a3c7200e2" />
+				<disk name="kyrandia ii - the hand of fate (japan) (en,ja)" sha1="adef11bcdd2398cb14c509f572a65fb4f849cf17" />
 			</diskarea>
 		</part>
 	</software>
@@ -5656,6 +6021,7 @@ User/save disks that can be created from the game itself are not included.
 		<description>Kyuukyoku Tiger</description>
 		<year>1994</year>
 		<publisher>ビング (Ving)</publisher>
+		<info name="alt_title" value="究極タイガー" />
 		<info name="release" value="199402xx" />
 		<part name="cdrom" interface="fmt_cdrom">
 			<diskarea name="cdrom">
@@ -5696,6 +6062,7 @@ User/save disks that can be created from the game itself are not included.
 		<description>Lands of Lore - The Throne of Chaos</description>
 		<year>1993</year>
 		<publisher>スタークラフト (Starcraft)</publisher>
+		<info name="alt_title" value="ランズ オブ ロア" />
 		<info name="release" value="199501xx" />
 		<part name="cdrom" interface="fmt_cdrom">
 			<diskarea name="cdrom">
@@ -5707,39 +6074,198 @@ User/save disks that can be created from the game itself are not included.
 	<!-- Runs too fast -->
 	<software name="lastarmg" supported="partial">
 		<!--
-		Origin: Neo Kobe Collection
-		<rom name="Last Armageddon CD Special (Disc A).ccd" size="11707" crc="b17278f6" sha1="e086fc5d958b79b9c67bac10cd16c6e47d15f61c"/>
-		<rom name="Last Armageddon CD Special (Disc A).cue" size="2371" crc="11f95129" sha1="d028c2eb690d1b771695b14ad78bdb2da8a1eccd"/>
-		<rom name="Last Armageddon CD Special (Disc A).img" size="626055360" crc="f7afc0b0" sha1="80c6382a46a615e3b2c7519c2618c92ea15275d9"/>
-		<rom name="Last Armageddon CD Special (Disc A).sub" size="25553280" crc="9bccc57a" sha1="f9d0c29a715562e7f2cc2b5f8fab3d25df51f4e0"/>
+		Origin: redump.org
+		<rom name="Last Armageddon - CD Special (Japan) (Disc A) (Track 01).bin" size="11308416" crc="406550a5" sha1="3be67ec6d4da8c0c34d8be3f1ba05f28a38cbc13"/>
+		<rom name="Last Armageddon - CD Special (Japan) (Disc A) (Track 02).bin" size="14787024" crc="8981393b" sha1="b6b7e24deb9a8f2bcecf5968b0729e804b343c0c"/>
+		<rom name="Last Armageddon - CD Special (Japan) (Disc A) (Track 03).bin" size="4480560" crc="caccdfd9" sha1="62f773da81c6a839bf70a524e2293af9f8d94f24"/>
+		<rom name="Last Armageddon - CD Special (Japan) (Disc A) (Track 04).bin" size="1046640" crc="b69d47d2" sha1="b360af425f9ff4a3cafb616a5a1226d082041f36"/>
+		<rom name="Last Armageddon - CD Special (Japan) (Disc A) (Track 05).bin" size="97819680" crc="0e88319c" sha1="5b61c4e472dacf408405413ff7460cb394971e83"/>
+		<rom name="Last Armageddon - CD Special (Japan) (Disc A) (Track 06).bin" size="5162640" crc="dba7f681" sha1="1123ef3189ed416eb1b4ca80f1116ab18758892f"/>
+		<rom name="Last Armageddon - CD Special (Japan) (Disc A) (Track 07).bin" size="2892960" crc="132c2453" sha1="5a9374e1b352eb8b8bb5117696e26f6357b9c18a"/>
+		<rom name="Last Armageddon - CD Special (Japan) (Disc A) (Track 08).bin" size="1446480" crc="aab8feb1" sha1="e07965b2561b80b1887339ff3740e8a4cf76ca95"/>
+		<rom name="Last Armageddon - CD Special (Japan) (Disc A) (Track 09).bin" size="14453040" crc="aee6557b" sha1="69b3e4a0f781d7433729d514b7d30712dcbea429"/>
+		<rom name="Last Armageddon - CD Special (Japan) (Disc A) (Track 10).bin" size="13688640" crc="6bf1beca" sha1="bbece00ebad996091ecf4800ac93dfc41b02c016"/>
+		<rom name="Last Armageddon - CD Special (Japan) (Disc A) (Track 11).bin" size="13923840" crc="699fa932" sha1="3855a18d6bc329ac41ec5b42c08b43e001a6edd9"/>
+		<rom name="Last Armageddon - CD Special (Japan) (Disc A) (Track 12).bin" size="27459600" crc="2e88a683" sha1="34ebfcfae01e0238d18a338f9d5298a88d2b0eb7"/>
+		<rom name="Last Armageddon - CD Special (Japan) (Disc A) (Track 13).bin" size="8314320" crc="206ce02e" sha1="170b6f250935874a9ce64159b919955d1044648e"/>
+		<rom name="Last Armageddon - CD Special (Japan) (Disc A) (Track 14).bin" size="8549520" crc="559e7c6a" sha1="2cbc91a8d70839d19d80fb06222645559ba332b2"/>
+		<rom name="Last Armageddon - CD Special (Japan) (Disc A) (Track 15).bin" size="7738080" crc="5f127feb" sha1="0370ce4ee374ad97a852477769aaeed7278e8f61"/>
+		<rom name="Last Armageddon - CD Special (Japan) (Disc A) (Track 16).bin" size="5797680" crc="e31f9c85" sha1="bfe35e37aa9978544da5a4935a0c8f72bd2afc55"/>
+		<rom name="Last Armageddon - CD Special (Japan) (Disc A) (Track 17).bin" size="4163040" crc="dad3aba1" sha1="e137c1868c5713f49b58ec1ccf6f92ea612ef8c1"/>
+		<rom name="Last Armageddon - CD Special (Japan) (Disc A) (Track 18).bin" size="1481760" crc="3dbdc726" sha1="e14362512a76f8256e93abe780b0f1c45da0f8bb"/>
+		<rom name="Last Armageddon - CD Special (Japan) (Disc A) (Track 19).bin" size="7444080" crc="731ab02b" sha1="02c959d6540fc6df76c3c6b9c469f7efbcb4dfb2"/>
+		<rom name="Last Armageddon - CD Special (Japan) (Disc A) (Track 20).bin" size="7244160" crc="f7f21d37" sha1="e398bfd7e18f0a43cb354b24652aaa00d59eacb7"/>
+		<rom name="Last Armageddon - CD Special (Japan) (Disc A) (Track 21).bin" size="7114800" crc="f4d3e7c4" sha1="817c1484a2c597882180fe7fe8d8c5fd0f69c04c"/>
+		<rom name="Last Armageddon - CD Special (Japan) (Disc A) (Track 22).bin" size="24437280" crc="a77d2c41" sha1="0aa6e4a8005edffd30490cd5ad257e2aa933b837"/>
+		<rom name="Last Armageddon - CD Special (Japan) (Disc A) (Track 23).bin" size="5280240" crc="c5ce22b2" sha1="86ce5e4f62b13869b7b25347592d114d42ec2a12"/>
+		<rom name="Last Armageddon - CD Special (Japan) (Disc A) (Track 24).bin" size="20791680" crc="c6542945" sha1="313526e7efee5337242aa673107bce1d04a58f47"/>
+		<rom name="Last Armageddon - CD Special (Japan) (Disc A) (Track 25).bin" size="12759600" crc="389f080b" sha1="831912270a84906ae54b42e04eca569ffec007b3"/>
+		<rom name="Last Armageddon - CD Special (Japan) (Disc A) (Track 26).bin" size="12936000" crc="3f1fe5a9" sha1="3c5065e404c26ec54d76d7da67eaa892208b3523"/>
+		<rom name="Last Armageddon - CD Special (Japan) (Disc A) (Track 27).bin" size="5127360" crc="c2e1cb34" sha1="54841b8142133130b9908b0f15e101576fa31806"/>
+		<rom name="Last Armageddon - CD Special (Japan) (Disc A) (Track 28).bin" size="6373920" crc="517c9a0c" sha1="6fae9211fd5018800a2479a635bf2871054d009d"/>
+		<rom name="Last Armageddon - CD Special (Japan) (Disc A) (Track 29).bin" size="6879600" crc="d5ca5eb3" sha1="50ab51eab09fccc7029fffb6e41b1add3907cc02"/>
+		<rom name="Last Armageddon - CD Special (Japan) (Disc A) (Track 30).bin" size="2916480" crc="fdad0606" sha1="f666e5e5aba2b35e83a4792bc6ee35917db71aa5"/>
+		<rom name="Last Armageddon - CD Special (Japan) (Disc A) (Track 31).bin" size="1411200" crc="78fa9d78" sha1="c85a8bd1c5ae585d0708ab7dae33ecfbe0949e90"/>
+		<rom name="Last Armageddon - CD Special (Japan) (Disc A) (Track 32).bin" size="2140320" crc="05975734" sha1="010468afb195a6b0b5b64db67df051c0b5228be4"/>
+		<rom name="Last Armageddon - CD Special (Japan) (Disc A) (Track 33).bin" size="1740480" crc="4a20f31e" sha1="d94e4436ad173f298af7c9a7e9a77e34a5abd44f"/>
+		<rom name="Last Armageddon - CD Special (Japan) (Disc A) (Track 34).bin" size="2399040" crc="61d08ce7" sha1="35314deeeeff44e833a2a02332be2463755960c4"/>
+		<rom name="Last Armageddon - CD Special (Japan) (Disc A) (Track 35).bin" size="3610320" crc="7f651d86" sha1="f718786833134695fdf05dfa6c82e360f418a394"/>
+		<rom name="Last Armageddon - CD Special (Japan) (Disc A) (Track 36).bin" size="3986640" crc="8454a50a" sha1="670f59f25c0935ad7fe0459bdc2a97178849625c"/>
+		<rom name="Last Armageddon - CD Special (Japan) (Disc A) (Track 37).bin" size="2328480" crc="ab566113" sha1="23cf2c6f09ba5e1a1a6aa41c1d690a0a9a517266"/>
+		<rom name="Last Armageddon - CD Special (Japan) (Disc A) (Track 38).bin" size="3292800" crc="60a72dd6" sha1="168cebe9d7fee39d13531af7e76dab3e6ba98585"/>
+		<rom name="Last Armageddon - CD Special (Japan) (Disc A) (Track 39).bin" size="2904720" crc="dbf19893" sha1="1eb90f148cc637324c48b5ba8bcbc952212a413c"/>
+		<rom name="Last Armageddon - CD Special (Japan) (Disc A) (Track 40).bin" size="5103840" crc="7e2e85eb" sha1="5fdfb1857916d0d6bc2ba35629a117df9e432a0f"/>
+		<rom name="Last Armageddon - CD Special (Japan) (Disc A) (Track 41).bin" size="5480160" crc="8aed2aac" sha1="c738fe5565ed90fd955a2282b978ea766034042d"/>
+		<rom name="Last Armageddon - CD Special (Japan) (Disc A) (Track 42).bin" size="4492320" crc="80a0ef84" sha1="de1a5e374870b52d43286866f6a70a17633a6f67"/>
+		<rom name="Last Armageddon - CD Special (Japan) (Disc A) (Track 43).bin" size="15511440" crc="fc060a0b" sha1="fa53694acd40e647d38e490bc64cd90e3ff52e61"/>
+		<rom name="Last Armageddon - CD Special (Japan) (Disc A) (Track 44).bin" size="19768560" crc="584caa3b" sha1="a8751ed48538b21e955ee71983d75840a97ad60e"/>
+		<rom name="Last Armageddon - CD Special (Japan) (Disc A) (Track 45).bin" size="19239360" crc="d1330e1a" sha1="c9b84e1e256e90725708ad26dc81ffbf5b54afa2"/>
+		<rom name="Last Armageddon - CD Special (Japan) (Disc A) (Track 46).bin" size="2199120" crc="dcc5b681" sha1="1d90ea3b5fdf4c6727d79f6720fbebe575db8ad9"/>
+		<rom name="Last Armageddon - CD Special (Japan) (Disc A) (Track 47).bin" size="9572640" crc="73963119" sha1="014691ebb0f3e67d5a28b75fe8760c7866a1534e"/>
+		<rom name="Last Armageddon - CD Special (Japan) (Disc A) (Track 48).bin" size="2528400" crc="0ac4aa16" sha1="f21d7da0947a4e976007e128da866d70e26135e2"/>
+		<rom name="Last Armageddon - CD Special (Japan) (Disc A) (Track 49).bin" size="2293200" crc="f093ba15" sha1="0bdd313f18535982bd21058250a04dacdaa1866c"/>
+		<rom name="Last Armageddon - CD Special (Japan) (Disc A) (Track 50).bin" size="3222240" crc="eee2d4c9" sha1="dda142c1cbd3c93e3113b23805b863bcd334dae8"/>
+		<rom name="Last Armageddon - CD Special (Japan) (Disc A) (Track 51).bin" size="11454240" crc="4af9cf09" sha1="db85bd0184bcc164e28eb471a2ce48cbfad51950"/>
+		<rom name="Last Armageddon - CD Special (Japan) (Disc A) (Track 52).bin" size="35938560" crc="ff7416a7" sha1="7c1df449db0e3bf6c9ee2e1a27bec9c232e8db29"/>
+		<rom name="Last Armageddon - CD Special (Japan) (Disc A) (Track 53).bin" size="34492080" crc="fcdd6a72" sha1="f11902c38f06ee3a163f4dc9d298516a748db8e6"/>
+		<rom name="Last Armageddon - CD Special (Japan) (Disc A) (Track 54).bin" size="36126720" crc="19d169d4" sha1="aba11224131703f547fea9598a4bc65afab2fa66"/>
+		<rom name="Last Armageddon - CD Special (Japan) (Disc A) (Track 55).bin" size="4386480" crc="0136649a" sha1="1025e95b7a1e93413cc4053991fc9eb600a588f3"/>
+		<rom name="Last Armageddon - CD Special (Japan) (Disc A) (Track 56).bin" size="8573040" crc="f062ef58" sha1="7e1256c8f4374ca355c9e0e8cdd2b0fef3d19318"/>
+		<rom name="Last Armageddon - CD Special (Japan) (Disc A) (Track 57).bin" size="8502480" crc="908b5582" sha1="7bc186c10be336e6cc0214878b5d9c0bd9902668"/>
+		<rom name="Last Armageddon - CD Special (Japan) (Disc A) (Track 58).bin" size="9537360" crc="67a21e61" sha1="1cd3cb610dc277db4da93b6971ad1ee8877e7bfb"/>
+		<rom name="Last Armageddon - CD Special (Japan) (Disc A).cue" size="8102" crc="63527748" sha1="75d776c155f347ec490c7b486fe948fc50019641"/>
 
-		<rom name="Last Armageddon CD Special (Disc B).ccd" size="9770" crc="c7552db3" sha1="659bc33125543a314afa8abec62ef2932d1199f7"/>
-		<rom name="Last Armageddon CD Special (Disc B).cue" size="1971" crc="821f4e8d" sha1="117c848b6b06003e4172cd5d1fa216d66a3d01e1"/>
-		<rom name="Last Armageddon CD Special (Disc B).img" size="565867680" crc="fbd50925" sha1="66b21f09765030f8fa00da6f8bafc13ac2d10542"/>
-		<rom name="Last Armageddon CD Special (Disc B).sub" size="23096640" crc="e87cb85f" sha1="f70cd4b49a6ae026f547bf142bacb81a37c29268"/>
+		<rom name="Last Armageddon - CD Special (Japan) (Disc B) (Track 01).bin" size="10743936" crc="8fb2adcb" sha1="62a12d16ecc802e302d994163771f3c977aed57d"/>
+		<rom name="Last Armageddon - CD Special (Japan) (Disc B) (Track 02).bin" size="14622384" crc="72b0d049" sha1="d5e6cdeaaec659e13efa3341b4f9565f1b0ca518"/>
+		<rom name="Last Armageddon - CD Special (Japan) (Disc B) (Track 03).bin" size="4515840" crc="438f0c93" sha1="944beab889f087ddc7ca90b86334012feb234e2f"/>
+		<rom name="Last Armageddon - CD Special (Japan) (Disc B) (Track 04).bin" size="987840" crc="fb816328" sha1="1c61868ff4e3cb303ecca342ce0430bee7289f7d"/>
+		<rom name="Last Armageddon - CD Special (Japan) (Disc B) (Track 05).bin" size="6326880" crc="2ce892ec" sha1="1ce888896e9fa6d2fe032c33eacb8180d8efe023"/>
+		<rom name="Last Armageddon - CD Special (Japan) (Disc B) (Track 06).bin" size="5750640" crc="ac9a9eee" sha1="95eaa018f27309daf793a37143596290f1bebcfb"/>
+		<rom name="Last Armageddon - CD Special (Japan) (Disc B) (Track 07).bin" size="5821200" crc="2350fda8" sha1="dc5d94759959b8aaeb2110bff43fe027ebffcf72"/>
+		<rom name="Last Armageddon - CD Special (Japan) (Disc B) (Track 08).bin" size="1646400" crc="6378af87" sha1="d1a30c4695db4bc3cfbc207001fa2c4e3782d39e"/>
+		<rom name="Last Armageddon - CD Special (Japan) (Disc B) (Track 09).bin" size="12112800" crc="18bc574b" sha1="49f72028802f70fb11f8dd2a2e5e8434370471b6"/>
+		<rom name="Last Armageddon - CD Special (Japan) (Disc B) (Track 10).bin" size="11842320" crc="3bdc5477" sha1="2be939562455ee3fd855b6fcf009599499e8efc8"/>
+		<rom name="Last Armageddon - CD Special (Japan) (Disc B) (Track 11).bin" size="11948160" crc="5cbc5b91" sha1="7844e41c32bbe0848250286a5058f3af63e956d1"/>
+		<rom name="Last Armageddon - CD Special (Japan) (Disc B) (Track 12).bin" size="28118160" crc="0b5765c5" sha1="6266ed60c430f0db3f46c7db2df4483edab9d0a4"/>
+		<rom name="Last Armageddon - CD Special (Japan) (Disc B) (Track 13).bin" size="18298560" crc="ccc17958" sha1="00b471cac3b02a34f815e8f86f929bbde1beafbf"/>
+		<rom name="Last Armageddon - CD Special (Japan) (Disc B) (Track 14).bin" size="12536160" crc="5e930210" sha1="e5850fcef0a16b80e29291e5dee1c1cd68d5722c"/>
+		<rom name="Last Armageddon - CD Special (Japan) (Disc B) (Track 15).bin" size="19145280" crc="5a183fb3" sha1="71aa2a9ab760a1dc5932d6f8f41217e282d04613"/>
+		<rom name="Last Armageddon - CD Special (Japan) (Disc B) (Track 16).bin" size="20297760" crc="9f97f502" sha1="7de0609db2d1d55a70432f7a28ce21aa98224f99"/>
+		<rom name="Last Armageddon - CD Special (Japan) (Disc B) (Track 17).bin" size="14311920" crc="66a34922" sha1="9febd897a594ed1ce5ec67f2936a7b8344c485ff"/>
+		<rom name="Last Armageddon - CD Special (Japan) (Disc B) (Track 18).bin" size="18004560" crc="984fd24e" sha1="9577c7327a2f84172c15cdc0514e3c38399dc183"/>
+		<rom name="Last Armageddon - CD Special (Japan) (Disc B) (Track 19).bin" size="20544720" crc="71297cf8" sha1="0d722e491a6814f9eab059397a84686391926636"/>
+		<rom name="Last Armageddon - CD Special (Japan) (Disc B) (Track 20).bin" size="11501280" crc="c6a00a7f" sha1="fd16daa1aa77b022069629e92c4931e8215a8193"/>
+		<rom name="Last Armageddon - CD Special (Japan) (Disc B) (Track 21).bin" size="23567040" crc="d486a7a4" sha1="5a33e6b7ae89cb19008b68ee29b0ca4e2e83942b"/>
+		<rom name="Last Armageddon - CD Special (Japan) (Disc B) (Track 22).bin" size="11418960" crc="8c32270d" sha1="5905b6fa27febc4d9089e6507fe773351ece2e3a"/>
+		<rom name="Last Armageddon - CD Special (Japan) (Disc B) (Track 23).bin" size="12148080" crc="c77f0111" sha1="94ed6cb5bfcc2f28b0ffb7b3d9651717b74dfc31"/>
+		<rom name="Last Armageddon - CD Special (Japan) (Disc B) (Track 24).bin" size="10619280" crc="8dbc4b9c" sha1="23a54cab9f380646ffaab928d2662b5516f784a7"/>
+		<rom name="Last Armageddon - CD Special (Japan) (Disc B) (Track 25).bin" size="3739680" crc="a2d48f23" sha1="c7a853b55ba23a2cfab1acd0e89f359602a9f2a4"/>
+		<rom name="Last Armageddon - CD Special (Japan) (Disc B) (Track 26).bin" size="2928240" crc="c3a8a816" sha1="b724a080294d31122acea30301a7b12675f9ce8c"/>
+		<rom name="Last Armageddon - CD Special (Japan) (Disc B) (Track 27).bin" size="8737680" crc="dadb9196" sha1="7296e41e1b6b2d00884581c332e8253cffcf92f2"/>
+		<rom name="Last Armageddon - CD Special (Japan) (Disc B) (Track 28).bin" size="2622480" crc="89e548c4" sha1="294f8a5852edb3428b52badb50cac6ddadf5c367"/>
+		<rom name="Last Armageddon - CD Special (Japan) (Disc B) (Track 29).bin" size="6303360" crc="edeb92e7" sha1="231f53124c06e4314c3529d3fc39ecff0cfeb060"/>
+		<rom name="Last Armageddon - CD Special (Japan) (Disc B) (Track 30).bin" size="9478560" crc="77f96afd" sha1="dd46ac1cd7c2f89cb9615293e8b12e83d110aea6"/>
+		<rom name="Last Armageddon - CD Special (Japan) (Disc B) (Track 31).bin" size="19415760" crc="b792a95d" sha1="409d88ff7137d8b7f0ae718cba7545b5e29af8f3"/>
+		<rom name="Last Armageddon - CD Special (Japan) (Disc B) (Track 32).bin" size="19650960" crc="466c245a" sha1="026ec326cf7926bbdd8bd7749f9f026cb2e519b3"/>
+		<rom name="Last Armageddon - CD Special (Japan) (Disc B) (Track 33).bin" size="16287600" crc="a1e3d381" sha1="327851faf6e2d383ad2a4d0037799a08eb29d25b"/>
+		<rom name="Last Armageddon - CD Special (Japan) (Disc B) (Track 34).bin" size="2175600" crc="f99b9b90" sha1="4ace8234683ddee9251026c13dd75df1baac5299"/>
+		<rom name="Last Armageddon - CD Special (Japan) (Disc B) (Track 35).bin" size="2551920" crc="ae8b18d0" sha1="a7539ee47643e68503264f40fb8e3e748aee536f"/>
+		<rom name="Last Armageddon - CD Special (Japan) (Disc B) (Track 36).bin" size="2105040" crc="397047c4" sha1="63c7b67cc5f45262bc07f105489681d34e894c82"/>
+		<rom name="Last Armageddon - CD Special (Japan) (Disc B) (Track 37).bin" size="2316720" crc="1d71cf31" sha1="9e7d86ef6a7456b95024859778505286e42ae8fe"/>
+		<rom name="Last Armageddon - CD Special (Japan) (Disc B) (Track 38).bin" size="2751840" crc="07e64506" sha1="713978e5dab4261743bc52d48205f9c0884af696"/>
+		<rom name="Last Armageddon - CD Special (Japan) (Disc B) (Track 39).bin" size="2128560" crc="7905bf61" sha1="ea30111f5488b905d318856e849ae5d2ba331715"/>
+		<rom name="Last Armageddon - CD Special (Japan) (Disc B) (Track 40).bin" size="5103840" crc="c595671d" sha1="77935b293e5676a9b1fde9e1bcf46f49fa5ed227"/>
+		<rom name="Last Armageddon - CD Special (Japan) (Disc B) (Track 41).bin" size="4833360" crc="842fc018" sha1="117168caf483259e3a673cd57290b15301038ba2"/>
+		<rom name="Last Armageddon - CD Special (Japan) (Disc B) (Track 42).bin" size="5033280" crc="c4934748" sha1="4e2d019f3589b5569417e2ef4570c5c7acc73740"/>
+		<rom name="Last Armageddon - CD Special (Japan) (Disc B) (Track 43).bin" size="21179760" crc="d9513d8a" sha1="461fccbc7f13d06cc396de784475ab3002d71ecd"/>
+		<rom name="Last Armageddon - CD Special (Japan) (Disc B) (Track 44).bin" size="6491520" crc="cecd7d57" sha1="70937a21392e1f8547f985bf00f0016bed08c579"/>
+		<rom name="Last Armageddon - CD Special (Japan) (Disc B) (Track 45).bin" size="7197120" crc="2ff1df29" sha1="e492df0537932b6c9f377c0894dd6cd2fc11566f"/>
+		<rom name="Last Armageddon - CD Special (Japan) (Disc B) (Track 46).bin" size="7632240" crc="673d1cd2" sha1="80c6c2752bcaefea06ef6540782ff06446bc894b"/>
+		<rom name="Last Armageddon - CD Special (Japan) (Disc B) (Track 47).bin" size="5633040" crc="60a3ae21" sha1="d77f327d28c6ee3a008d4773e2f9f0d5e34f1ccd"/>
+		<rom name="Last Armageddon - CD Special (Japan) (Disc B) (Track 48).bin" size="92739360" crc="6368cb72" sha1="956679907f8c259f0bf92dc0fd67de39c1ef8082"/>
+		<rom name="Last Armageddon - CD Special (Japan) (Disc B).cue" size="6702" crc="d28fca65" sha1="8acb7f99a773f82f6a0839053ac0089e5ff141b5"/>
 
-		<rom name="Last Armageddon CD Special (Disc C).ccd" size="11696" crc="50629811" sha1="aede503ae7b1636db19c80fe6a84a002fbba5acf"/>
-		<rom name="Last Armageddon CD Special (Disc C).cue" size="2371" crc="85c25c61" sha1="0f847ac7ec60ed5f8e141002ae88cd37081bc480"/>
-		<rom name="Last Armageddon CD Special (Disc C).img" size="776265840" crc="3206af43" sha1="4e5fdb415700cd418f80a9314289fd9bae3bc9e5"/>
-		<rom name="Last Armageddon CD Special (Disc C).sub" size="31684320" crc="a90ea85d" sha1="9a4e042bb2429ff068965236f362373f90ff61ee"/>
+		<rom name="Last Armageddon - CD Special (Japan) (Disc C) (Track 01).bin" size="10743936" crc="194ee45a" sha1="ae75b8b41ce2cf5f3e1d2c4ca24825c3a4fbc40f"/>
+		<rom name="Last Armageddon - CD Special (Japan) (Disc C) (Track 02).bin" size="14610624" crc="ea4d2438" sha1="06b9a92cd02d859cd3ab00f2627a85dc2526c14b"/>
+		<rom name="Last Armageddon - CD Special (Japan) (Disc C) (Track 03).bin" size="4468800" crc="09e0836e" sha1="5fa17ea625d6d123004c9862947fb222f9e3dcb6"/>
+		<rom name="Last Armageddon - CD Special (Japan) (Disc C) (Track 04).bin" size="1070160" crc="ec28919c" sha1="734fb993655fdfdd2d60ed7ec547703f66451a93"/>
+		<rom name="Last Armageddon - CD Special (Japan) (Disc C) (Track 05).bin" size="16816800" crc="fa789079" sha1="cbc74fa6291fb65d1864bc1d460585984483f706"/>
+		<rom name="Last Armageddon - CD Special (Japan) (Disc C) (Track 06).bin" size="14958720" crc="259bab73" sha1="8de884efbb412de1ee8c94995878bec77466474f"/>
+		<rom name="Last Armageddon - CD Special (Japan) (Disc C) (Track 07).bin" size="21120960" crc="006ea0df" sha1="002743e3618aac2372087cdedd94dd331d87acdc"/>
+		<rom name="Last Armageddon - CD Special (Japan) (Disc C) (Track 08).bin" size="1458240" crc="641346bc" sha1="d045fb9d1fcaf89bbd3154bb0cd624ada264763e"/>
+		<rom name="Last Armageddon - CD Special (Japan) (Disc C) (Track 09).bin" size="21273840" crc="7f594988" sha1="f3e8002db4585e750b7b41cb9378a90c93a7a849"/>
+		<rom name="Last Armageddon - CD Special (Japan) (Disc C) (Track 10).bin" size="27894720" crc="dace5e15" sha1="24bc14488bc8b6487e701c0ce9a363127a5aaa31"/>
+		<rom name="Last Armageddon - CD Special (Japan) (Disc C) (Track 11).bin" size="11583600" crc="053f73ce" sha1="789dc23986d57765b06ede8ccdf8381f36f68c31"/>
+		<rom name="Last Armageddon - CD Special (Japan) (Disc C) (Track 12).bin" size="5127360" crc="da54fe7e" sha1="ea94ffe883034549b419dc43acceae60cd73c792"/>
+		<rom name="Last Armageddon - CD Special (Japan) (Disc C) (Track 13).bin" size="27541920" crc="8c9c3b2d" sha1="cc4d29260f8e53b819602990c69a031a8993f1e1"/>
+		<rom name="Last Armageddon - CD Special (Japan) (Disc C) (Track 14).bin" size="7232400" crc="4ed31939" sha1="da7218825f6b87c281855c342eb3472450886245"/>
+		<rom name="Last Armageddon - CD Special (Japan) (Disc C) (Track 15).bin" size="4539360" crc="c17db487" sha1="888d65e5f8d2c3f0e6b717aed3117dfe331d7ae2"/>
+		<rom name="Last Armageddon - CD Special (Japan) (Disc C) (Track 16).bin" size="24754800" crc="5b660686" sha1="ba34951173f5ce9803c550769ebf647f9eeff739"/>
+		<rom name="Last Armageddon - CD Special (Japan) (Disc C) (Track 17).bin" size="6444480" crc="c44bf10c" sha1="3bbdf061731227aa4b826c1b79d918a473569b53"/>
+		<rom name="Last Armageddon - CD Special (Japan) (Disc C) (Track 18).bin" size="4950960" crc="5a5254cc" sha1="13e4a1f63a9924e29dd5acd7f9d8989a38e69fa0"/>
+		<rom name="Last Armageddon - CD Special (Japan) (Disc C) (Track 19).bin" size="19897920" crc="7101b83a" sha1="749729cc7f93802ca1da89749a4826707f5a9975"/>
+		<rom name="Last Armageddon - CD Special (Japan) (Disc C) (Track 20).bin" size="6209280" crc="33d711cd" sha1="771b8537390395cd1387c7b7c9392930a58c0a76"/>
+		<rom name="Last Armageddon - CD Special (Japan) (Disc C) (Track 21).bin" size="6585600" crc="d6b8d99c" sha1="f4a8e3ab2c936c347726870626bfb1df64d349ec"/>
+		<rom name="Last Armageddon - CD Special (Japan) (Disc C) (Track 22).bin" size="18051600" crc="d3bdd9c9" sha1="4f0810be0e3421e604f8ddb8b9782b6849c764e9"/>
+		<rom name="Last Armageddon - CD Special (Japan) (Disc C) (Track 23).bin" size="6221040" crc="6c507869" sha1="ddb7e696155ccc9033dc46ed5469b9a9b6663a75"/>
+		<rom name="Last Armageddon - CD Special (Japan) (Disc C) (Track 24).bin" size="7655760" crc="5d99694b" sha1="4aaeec7df825b35a2f134424127d0a699dd5f9c5"/>
+		<rom name="Last Armageddon - CD Special (Japan) (Disc C) (Track 25).bin" size="9866640" crc="a356da7b" sha1="06d0ac519ad0ca4faf41d12757866bb07e6175fd"/>
+		<rom name="Last Armageddon - CD Special (Japan) (Disc C) (Track 26).bin" size="9866640" crc="77b1da90" sha1="f917fd4a841c2ea6111cb39352beaeb4cc86237b"/>
+		<rom name="Last Armageddon - CD Special (Japan) (Disc C) (Track 27).bin" size="10395840" crc="502533d6" sha1="89f1df01fb3eda0e08bed4688ae4fca26d6a034f"/>
+		<rom name="Last Armageddon - CD Special (Japan) (Disc C) (Track 28).bin" size="10125360" crc="663d1682" sha1="090b73fe9de466ba09745ccbacba575535bbcfe9"/>
+		<rom name="Last Armageddon - CD Special (Japan) (Disc C) (Track 29).bin" size="6691440" crc="9b7003d2" sha1="ce59e62c1f9289ddda34263e893e1f1b2c413a96"/>
+		<rom name="Last Armageddon - CD Special (Japan) (Disc C) (Track 30).bin" size="4351200" crc="eccaff1a" sha1="2920689f94c370a289a04e8d0068bdd1cd468a07"/>
+		<rom name="Last Armageddon - CD Special (Japan) (Disc C) (Track 31).bin" size="25284000" crc="6cece2fc" sha1="b3557ce0938113c6ccf42b288867b4b4a53d80f9"/>
+		<rom name="Last Armageddon - CD Special (Japan) (Disc C) (Track 32).bin" size="15335040" crc="b98691db" sha1="b3f3e912559750f0ae2684e47bd12b856b741e6d"/>
+		<rom name="Last Armageddon - CD Special (Japan) (Disc C) (Track 33).bin" size="14841120" crc="018a2c6f" sha1="79eb51b2f3aeed1697f2ac645d889fdefbde56cc"/>
+		<rom name="Last Armageddon - CD Special (Japan) (Disc C) (Track 34).bin" size="15182160" crc="a0a0da06" sha1="4e109900348371f3482a1adf5794331ddd3fdcd8"/>
+		<rom name="Last Armageddon - CD Special (Japan) (Disc C) (Track 35).bin" size="5915280" crc="96da780f" sha1="5a313261668c0dbefcbd6b95dbe5d2abe2e6dc2c"/>
+		<rom name="Last Armageddon - CD Special (Japan) (Disc C) (Track 36).bin" size="3328080" crc="d5e780d7" sha1="2c34861c43effaa18367fdc3fcd742c56d59a65d"/>
+		<rom name="Last Armageddon - CD Special (Japan) (Disc C) (Track 37).bin" size="49462560" crc="fa015668" sha1="63daa42cfad67a459909d201112a324dac5d054a"/>
+		<rom name="Last Armageddon - CD Special (Japan) (Disc C) (Track 38).bin" size="8490720" crc="cb597330" sha1="f5cd0c0e155687e79df272339a99060ab60ada68"/>
+		<rom name="Last Armageddon - CD Special (Japan) (Disc C) (Track 39).bin" size="2046240" crc="c12c3fbe" sha1="2c7ffd0ef6b01ad98e03110d7bc2fd9fe860a9ed"/>
+		<rom name="Last Armageddon - CD Special (Japan) (Disc C) (Track 40).bin" size="16957920" crc="5044c3a5" sha1="75f99ad8c79653e937f6cad1440c3f0a0f739c90"/>
+		<rom name="Last Armageddon - CD Special (Japan) (Disc C) (Track 41).bin" size="16675680" crc="f60aaa7e" sha1="150feb53e64c9de7411cb66b133d58ffd1568b96"/>
+		<rom name="Last Armageddon - CD Special (Japan) (Disc C) (Track 42).bin" size="19650960" crc="9ceb4a39" sha1="825382ea7c56196256a897ca9469ae07ae40fa7a"/>
+		<rom name="Last Armageddon - CD Special (Japan) (Disc C) (Track 43).bin" size="15158640" crc="3bc9d135" sha1="b9712a5bb3dcb9f393db568e54060e663ed55356"/>
+		<rom name="Last Armageddon - CD Special (Japan) (Disc C) (Track 44).bin" size="4903920" crc="f84dbf2a" sha1="96487fa3eaf86bde38b6a6f3059e69bd67415de1"/>
+		<rom name="Last Armageddon - CD Special (Japan) (Disc C) (Track 45).bin" size="5327280" crc="f54e4cbf" sha1="eea286c87317dc5258fed699ab9d0e7cf8ce4468"/>
+		<rom name="Last Armageddon - CD Special (Japan) (Disc C) (Track 46).bin" size="6503280" crc="24e2af0e" sha1="24f986dbaa2cd5744762334189f88e8dee706ff8"/>
+		<rom name="Last Armageddon - CD Special (Japan) (Disc C) (Track 47).bin" size="14476560" crc="bf84b500" sha1="65e271e0a01eef5f367e843f1b1571706ab97d63"/>
+		<rom name="Last Armageddon - CD Special (Japan) (Disc C) (Track 48).bin" size="19051200" crc="0608d53b" sha1="2155c12a73a89fa70490ced1496f022104917d1a"/>
+		<rom name="Last Armageddon - CD Special (Japan) (Disc C) (Track 49).bin" size="12089280" crc="a28090b9" sha1="412a6a74b4d250ee4ed155f5c89291d8d7cde4d6"/>
+		<rom name="Last Armageddon - CD Special (Japan) (Disc C) (Track 50).bin" size="12700800" crc="41c56c5c" sha1="a6858ffd1197cb718e7e57f2a62215cda7509542"/>
+		<rom name="Last Armageddon - CD Special (Japan) (Disc C) (Track 51).bin" size="12371520" crc="891529a9" sha1="ea48086e975d50b58a682c1107a9b857edaf43e7"/>
+		<rom name="Last Armageddon - CD Special (Japan) (Disc C) (Track 52).bin" size="24919440" crc="818372c7" sha1="f58597afdc0b0ce03346916432a1bbf311c4123e"/>
+		<rom name="Last Armageddon - CD Special (Japan) (Disc C) (Track 53).bin" size="25201680" crc="80a5f8c4" sha1="01949b5701149d9369db0c1b47041b0cd17a3656"/>
+		<rom name="Last Armageddon - CD Special (Japan) (Disc C) (Track 54).bin" size="25295760" crc="1dc258fa" sha1="587c966c8e248cc4527fc6f255c83ee86fdbcb6f"/>
+		<rom name="Last Armageddon - CD Special (Japan) (Disc C) (Track 55).bin" size="12818400" crc="daa1fd12" sha1="bc940e8125d5423ee852bcfbed1792cd15c3cc37"/>
+		<rom name="Last Armageddon - CD Special (Japan) (Disc C) (Track 56).bin" size="16334640" crc="203aa93f" sha1="f675d2cb27b72420167a2b778f2cc3e892d30c3c"/>
+		<rom name="Last Armageddon - CD Special (Japan) (Disc C) (Track 57).bin" size="16440480" crc="ea4a73ce" sha1="8e1bfa186187b4b15c89d25594e54c9018257080"/>
+		<rom name="Last Armageddon - CD Special (Japan) (Disc C) (Track 58).bin" size="16993200" crc="0b632237" sha1="b1c46c6150465fbfd41a5bfc6990821d371045bc"/>
+		<rom name="Last Armageddon - CD Special (Japan) (Disc C).cue" size="8102" crc="a12dffd2" sha1="30d242d77f012eb1a8c4d5d36e0c56e833631e9d"/>
 		-->
 		<description>Last Armageddon CD Special</description>
 		<year>1989</year>
 		<publisher>ブレイングレイ (Brain Grey)</publisher>
+		<info name="alt_title" value="ラスト・ハルマゲドン CDスペシャル" />
 		<info name="release" value="198907xx" />
 		<part name="cdrom1" interface="fmt_cdrom">
+			<feature name="part_id" value="Disc A"/>
 			<diskarea name="cdrom">
-				<disk name="last armageddon cd special (disc a)" sha1="bc7c8f3535bbd095ca65c50bbad55cea726d952c" />
+				<disk name="last armageddon - cd special (japan) (disc a)" sha1="694cb566bfce4a88c795f6f63568371c5fae2ae3" />
 			</diskarea>
 		</part>
 		<part name="cdrom2" interface="fmt_cdrom">
+			<feature name="part_id" value="Disc B"/>
 			<diskarea name="cdrom">
-				<disk name="last armageddon cd special (disc b)" sha1="f5828654e32a810f1ba1b743180b55e9f02e1df1" />
+				<disk name="last armageddon - cd special (japan) (disc b)" sha1="fa16e09019c1228a9351541b88ded3d32b834ffd" />
 			</diskarea>
 		</part>
 		<part name="cdrom3" interface="fmt_cdrom">
+			<feature name="part_id" value="Disc C"/>
 			<diskarea name="cdrom">
-				<disk name="last armageddon cd special (disc c)" sha1="b300dccabeab74d9aa7277f0d04a6d89200cd1a9" />
+				<disk name="last armageddon - cd special (japan) (disc c)" sha1="8e8fbf6cdcebadb056982e7b5b1033e7ace04ccb" />
 			</diskarea>
 		</part>
 	</software>
@@ -5756,6 +6282,7 @@ User/save disks that can be created from the game itself are not included.
 		<description>Last Survivor</description>
 		<year>1990</year>
 		<publisher>CRI</publisher>
+		<info name="alt_title" value="ラストサバイバー" />
 		<info name="release" value="199011xx" />
 		<part name="cdrom" interface="fmt_cdrom">
 			<diskarea name="cdrom">
@@ -5775,6 +6302,7 @@ User/save disks that can be created from the game itself are not included.
 		<description>Lunatic Dawn II</description>
 		<year>1994</year>
 		<publisher>アートディンク (Artdink)</publisher>
+		<info name="alt_title" value="ルナティックドーンII" />
 		<info name="release" value="199411xx" />
 		<part name="flop1" interface="floppy_3_5">
 			<feature name="part_id" value="User Disk" />
@@ -5800,6 +6328,7 @@ User/save disks that can be created from the game itself are not included.
 		<description>Lemmings</description>
 		<year>1992</year>
 		<publisher>イマジニア (Imagineer)</publisher>
+		<info name="alt_title" value="レミングス" />
 		<info name="release" value="199204xx" />
 		<part name="cdrom" interface="fmt_cdrom">
 			<diskarea name="cdrom">
@@ -5820,6 +6349,7 @@ User/save disks that can be created from the game itself are not included.
 		<description>Lemmings 2 - The Tribes (Japanese)</description>
 		<year>1994</year>
 		<publisher>富士通 (Fujitsu)</publisher>
+		<info name="alt_title" value="レミングス2 ザ・トライブス" />
 		<info name="release" value="199406xx" />
 		<part name="cdrom" interface="fmt_cdrom">
 			<diskarea name="cdrom">
@@ -5839,6 +6369,7 @@ User/save disks that can be created from the game itself are not included.
 		<description>Lesser Mern</description>
 		<year>1992</year>
 		<publisher>パンサーソフトウェア (Panther Software)</publisher>
+		<info name="alt_title" value="レッサーメルン" />
 		<info name="release" value="199210xx" />
 		<part name="cdrom" interface="fmt_cdrom">
 			<diskarea name="cdrom">
@@ -5855,9 +6386,11 @@ User/save disks that can be created from the game itself are not included.
 		<rom name="Lettuce Cooking.img" size="424418400" crc="fda5d051" sha1="eda9796ebae2c873968c711e5a2f1849dd15f113"/>
 		<rom name="Lettuce Cooking.sub" size="17323200" crc="a4b8fb65" sha1="962f48ba162b45524e9c56616dc9f0fde9c5d713"/>
 		-->
-		<description>Lettuce Cooking</description>
+		<description>Lettuce Cooking 1 - 365-nichi, Kyou no Ippin</description>
 		<year>1989</year>
 		<publisher>Seibu Time</publisher>
+		<info name="alt_title" value="レタス・クッキング1 365日、今日の一品" />
+		<info name="release" value="198911xx" />
 		<part name="flop1" interface="floppy_3_5">
 			<dataarea name="flop" size="1261568">
 				<rom name="lettuce cooking.bin" size="1261568" crc="76845bb0" sha1="9d7227621f94375c105e3ee8f2cc7d5ebdd60147" offset="000000" />
@@ -5881,6 +6414,7 @@ User/save disks that can be created from the game itself are not included.
 		<description>Libido7</description>
 		<year>1994</year>
 		<publisher>リビドー (Libido)</publisher>
+		<info name="alt_title" value="リビドー７" />
 		<info name="release" value="199407xx" />
 		<part name="cdrom" interface="fmt_cdrom">
 			<diskarea name="cdrom">
@@ -5901,6 +6435,7 @@ User/save disks that can be created from the game itself are not included.
 		<description>Life &amp; Death</description>
 		<year>1992</year>
 		<publisher>ビング (Ving)</publisher>
+		<info name="alt_title" value="ライフ＆デス" />
 		<info name="release" value="199201xx" />
 		<part name="cdrom" interface="fmt_cdrom">
 			<diskarea name="cdrom">
@@ -5920,6 +6455,7 @@ User/save disks that can be created from the game itself are not included.
 		<description>Life &amp; Death II - The Brain</description>
 		<year>1992</year>
 		<publisher>ビング (Ving)</publisher>
+		<info name="alt_title" value="ライフ＆デスII" />
 		<info name="release" value="199211xx" />
 		<part name="cdrom" interface="fmt_cdrom">
 			<diskarea name="cdrom">
@@ -5937,6 +6473,7 @@ User/save disks that can be created from the game itself are not included.
 		<description>Golf Links 386 Pro</description>
 		<year>1995</year>
 		<publisher>サイベル (Cybelle)</publisher>
+		<info name="alt_title" value="ゴルフ・リンクス３８６プロ" />
 		<info name="release" value="199502xx" />
 		<info name="usage" value="Requires HDD installation"/>
 		<part name="cdrom" interface="fmt_cdrom">
@@ -5957,6 +6494,7 @@ User/save disks that can be created from the game itself are not included.
 		<description>Record of Lodoss War - Haiiro no Majo</description>
 		<year>1994</year>
 		<publisher>ハミングバード (HummingBird)</publisher>
+		<info name="alt_title" value="ロードス島戦記 灰色の魔女" />
 		<info name="release" value="199404xx" />
 		<part name="flop1" interface="floppy_3_5">
 			<feature name="part_id" value="System Disk" />
@@ -6038,6 +6576,7 @@ User/save disks that can be created from the game itself are not included.
 		<description>Libble Rabble</description>
 		<year>1994</year>
 		<publisher>電波新聞社 (Dempa Shinbunsha)</publisher>
+		<info name="alt_title" value="リブルラブル" />
 		<info name="release" value="199403xx" />
 		<part name="cdrom" interface="fmt_cdrom">
 			<diskarea name="cdrom">
@@ -6083,6 +6622,7 @@ User/save disks that can be created from the game itself are not included.
 		<description>Lupin Sansei - Hong Kong no Mashu - Fukushuu wa Meikyuu no Hate ni</description>
 		<year>1990</year>
 		<publisher>CRI</publisher>
+		<info name="alt_title" value="ルパン三世-香港の魔手 「復讐は迷宮の果てに」" />
 		<info name="release" value="199006xx" />
 		<part name="cdrom" interface="fmt_cdrom">
 			<diskarea name="cdrom">
@@ -6104,9 +6644,10 @@ User/save disks that can be created from the game itself are not included.
 		<rom name="track02.bin" size="46440240" crc="86880e8e" sha1="993e093917fe104ded87eaf095b51899c079a14f"/>
 		<rom name="track03.bin" size="44624496" crc="d5316f23" sha1="66e68d599ab81bd1b9f76a4a3ba5f5bb577b0910"/>
 		-->
-		<description>Legends of Valour</description>
+		<description>Legends of Valour - Gouyuu no Densetsu</description>
 		<year>1994</year>
 		<publisher>ビング (Ving)</publisher>
+		<info name="alt_title" value="レジェンド・オブ・バロア ～豪勇の伝説～" />
 		<info name="release" value="199403xx" />
 		<part name="cdrom" interface="fmt_cdrom">
 			<diskarea name="cdrom">
@@ -6126,6 +6667,7 @@ User/save disks that can be created from the game itself are not included.
 		<description>Mad Paradox</description>
 		<year>1994</year>
 		<publisher>クィーンソフト (Queensoft)</publisher>
+		<info name="alt_title" value="マッドパラドックス" />
 		<info name="release" value="199402xx" />
 		<part name="cdrom" interface="fmt_cdrom">
 			<diskarea name="cdrom">
@@ -6146,6 +6688,7 @@ User/save disks that can be created from the game itself are not included.
 		<description>Mad Stalker</description>
 		<year>1994</year>
 		<publisher>ファミリーソフト (Family Soft)</publisher>
+		<info name="alt_title" value="マッドストーカー" />
 		<info name="release" value="199407xx" />
 		<part name="cdrom" interface="fmt_cdrom">
 			<diskarea name="cdrom">
@@ -6166,6 +6709,7 @@ User/save disks that can be created from the game itself are not included.
 		<description>Madou Gakuin R</description>
 		<year>1994</year>
 		<publisher>フォーサイト (Foresight)</publisher>
+		<info name="alt_title" value="魔導学院Ｒ" />
 		<info name="release" value="199411xx" />
 		<part name="cdrom" interface="fmt_cdrom">
 			<diskarea name="cdrom">
@@ -6176,19 +6720,32 @@ User/save disks that can be created from the game itself are not included.
 
 	<software name="mjdepon">
 		<!--
-		Origin: Neo Kobe Collection
-		<rom name="Mahjong de Pon!.ccd" size="3410" crc="2c6f9c3a" sha1="345140cdfe2dced80d7dccee798cea13ee8d7a58"/>
-		<rom name="Mahjong de Pon!.cue" size="631" crc="96651093" sha1="609f56161fd6e17522e3200a1207319bcce7b478"/>
-		<rom name="Mahjong de Pon!.img" size="247331616" crc="b973c373" sha1="f29afc379f24e00b5d0719ef962feabb6ec97187"/>
-		<rom name="Mahjong de Pon!.sub" size="10095168" crc="7c68bfd2" sha1="0bfab2bf3cd775663dbc33133aea2d043fb74a7f"/>
+		Origin: redump.org
+		<rom name="Mahjong de Pon! (Japan) (Track 01).bin" size="16421664" crc="cbdf74ed" sha1="74ae179088e5e549f487bc844b5220ccd5666ca0"/>
+		<rom name="Mahjong de Pon! (Japan) (Track 02).bin" size="21520800" crc="2badd8fc" sha1="0b8066a8d74e446f15a97bc97b9b05eed5c390ba"/>
+		<rom name="Mahjong de Pon! (Japan) (Track 03).bin" size="34927200" crc="c2621921" sha1="be4518ca76b4a093ba9f27d4b35ca4d5049971f9"/>
+		<rom name="Mahjong de Pon! (Japan) (Track 04).bin" size="10936800" crc="0474ca45" sha1="79ea76bd1e0dade9aa2018b4ef73bd8d02969a0f"/>
+		<rom name="Mahjong de Pon! (Japan) (Track 05).bin" size="26989200" crc="163bb41c" sha1="4492c1e8a1c66dc9ffca81bfc1719af973c7870d"/>
+		<rom name="Mahjong de Pon! (Japan) (Track 06).bin" size="10584000" crc="bfaadfeb" sha1="420bef04eb402323ed2a46db452917042d7dfed6"/>
+		<rom name="Mahjong de Pon! (Japan) (Track 07).bin" size="26283600" crc="a936f2a4" sha1="9014257e17d4d9fa2130c80ac7a97f2070d870f5"/>
+		<rom name="Mahjong de Pon! (Japan) (Track 08).bin" size="10407600" crc="78201ff5" sha1="29e1cec86732b525f59f9ac30371de5c395b32b7"/>
+		<rom name="Mahjong de Pon! (Japan) (Track 09).bin" size="26460000" crc="937abcb7" sha1="f8a84bb330695ed4e16a46bec6f040282a55de0b"/>
+		<rom name="Mahjong de Pon! (Japan) (Track 10).bin" size="8290800" crc="daee42b7" sha1="bab67ba1394672afa227940e1380735c0c0e0ba4"/>
+		<rom name="Mahjong de Pon! (Japan) (Track 11).bin" size="8467200" crc="968aaf37" sha1="a3964b2474c9f4fe8ede0159b878c8b1c4d8e13d"/>
+		<rom name="Mahjong de Pon! (Japan) (Track 12).bin" size="8467200" crc="5bbe7d16" sha1="5810b129215010e42334c23787c0c0ad1583c406"/>
+		<rom name="Mahjong de Pon! (Japan) (Track 13).bin" size="11642400" crc="96958c55" sha1="16ee2cdee03dfb96608868284276cf8fca97434f"/>
+		<rom name="Mahjong de Pon! (Japan) (Track 14).bin" size="11818800" crc="8ed5bad8" sha1="16e9b001142de022776165749b5141592f175c91"/>
+		<rom name="Mahjong de Pon! (Japan) (Track 15).bin" size="14114352" crc="1a6683a7" sha1="b1ed8c28b8656ce463cf6ef5eaade83dd7ff627b"/>
+		<rom name="Mahjong de Pon! (Japan).cue" size="1775" crc="e6451e66" sha1="1b1096501add7f3c4cfe4a0316644fa9e02c343d"/>
 		-->
 		<description>Mahjong de Pon!</description>
 		<year>1994</year>
 		<publisher>アクティブ (Active)</publisher>
+		<info name="alt_title" value="麻雀でPON！" />
 		<info name="release" value="199404xx" />
 		<part name="cdrom" interface="fmt_cdrom">
 			<diskarea name="cdrom">
-				<disk name="mahjong de pon!" sha1="58c4ae95a830294baa1a448c328d53c1d0a6002b" />
+				<disk name="mahjong de pon! (japan)" sha1="a6332b3d1f893621f25f035b538cb14a6e5d946e" />
 			</diskarea>
 		</part>
 	</software>
@@ -6204,6 +6761,8 @@ User/save disks that can be created from the game itself are not included.
 		<description>Mahjong Hou Tei Rao Yui</description>
 		<year>1995</year>
 		<publisher>クィーンソフト (Queensoft)</publisher>
+		<info name="alt_title" value="麻雀河底撈魚" />
+		<info name="release" value="199508xx" />
 		<part name="cdrom" interface="fmt_cdrom">
 			<diskarea name="cdrom">
 				<disk name="mahjong houteiraoyui" sha1="a89200b37fee06bfa727a85433705b2a2ad95e6d" />
@@ -6220,6 +6779,7 @@ User/save disks that can be created from the game itself are not included.
 		<description>Mahou Daisakusen</description>
 		<year>1995</year>
 		<publisher>エレクトロニック・アーツ・ビクター (Electronic Arts Victor)</publisher>
+		<info name="alt_title" value="魔法大作戦" />
 		<info name="release" value="199502xx" />
 		<part name="cdrom" interface="fmt_cdrom">
 			<diskarea name="cdrom">
@@ -6239,6 +6799,7 @@ User/save disks that can be created from the game itself are not included.
 		<description>Mandala-ke Ichizoku</description>
 		<year>1995</year>
 		<publisher>フォーサイト (Foresight)</publisher>
+		<info name="alt_title" value="曼陀羅家一族" />
 		<info name="release" value="199503xx" />
 		<part name="cdrom" interface="fmt_cdrom">
 			<diskarea name="cdrom">
@@ -6258,6 +6819,7 @@ User/save disks that can be created from the game itself are not included.
 		<description>Many Colors</description>
 		<year>1993</year>
 		<publisher>アモルファス (Amorphous)</publisher>
+		<info name="release" value="199302xx" />
 		<part name="cdrom" interface="fmt_cdrom">
 			<diskarea name="cdrom">
 				<disk name="many colors" sha1="392e9a0faebb7ec2bc56fc0cfdc6ca800f610dd0" />
@@ -6274,6 +6836,7 @@ User/save disks that can be created from the game itself are not included.
 		<description>Marble Madness</description>
 		<year>1991</year>
 		<publisher>ホームデータ (Home Data)</publisher>
+		<info name="alt_title" value="マーブルマッドネス" />
 		<info name="release" value="199106xx" />
 		<part name="cdrom" interface="fmt_cdrom">
 			<diskarea name="cdrom">
@@ -6291,6 +6854,7 @@ User/save disks that can be created from the game itself are not included.
 		<description>Marine Philt</description>
 		<year>1993</year>
 		<publisher>フェアリーテール (Fairytale)</publisher>
+		<info name="alt_title" value="マリンフィルト" />
 		<info name="release" value="199304xx" />
 		<part name="cdrom" interface="fmt_cdrom">
 			<diskarea name="cdrom">
@@ -6310,6 +6874,7 @@ User/save disks that can be created from the game itself are not included.
 		<description>The Manhole</description>
 		<year>1990</year>
 		<publisher>富士通 (Fujitsu)</publisher>
+		<info name="alt_title" value="マンホール" />
 		<info name="release" value="199008xx" />
 		<part name="cdrom" interface="fmt_cdrom">
 			<diskarea name="cdrom">
@@ -6327,6 +6892,7 @@ User/save disks that can be created from the game itself are not included.
 		<description>Muscle Bomber - The Body Explosion</description>
 		<year>1993</year>
 		<publisher>カプコン (Capcom)</publisher>
+		<info name="alt_title" value="マッスルボマー" />
 		<info name="release" value="199311xx" />
 		<part name="cdrom" interface="fmt_cdrom">
 			<diskarea name="cdrom">
@@ -6346,6 +6912,7 @@ User/save disks that can be created from the game itself are not included.
 		<description>Microcosm</description>
 		<year>1993</year>
 		<publisher>富士通 (Fujitsu)</publisher>
+		<info name="alt_title" value="マイクロコズム" />
 		<info name="release" value="199303xx" />
 		<part name="cdrom" interface="fmt_cdrom">
 			<diskarea name="cdrom">
@@ -6365,6 +6932,7 @@ User/save disks that can be created from the game itself are not included.
 		<description>Mega Lo Mania</description>
 		<year>1993</year>
 		<publisher>イマジニア (Imagineer)</publisher>
+		<info name="alt_title" value="メガロマニア" />
 		<info name="release" value="199303xx" />
 		<part name="cdrom" interface="fmt_cdrom">
 			<diskarea name="cdrom">
@@ -6383,9 +6951,10 @@ User/save disks that can be created from the game itself are not included.
 		<rom name="menzoberranzan.bin" size="370185984" crc="61345a1c" sha1="661123e1dbb18e4045eae74556de67a6c781a163"/>
 		<rom name="menzoberranzan.cue" size="75" crc="1e99387a" sha1="7f6a15d15560b6be599a0ee77e081049794f3405"/>
 		-->
-		<description>Menzoberranzan</description>
+		<description>Menzoberranzan - Yami no Monshou</description>
 		<year>1996</year>
 		<publisher>ケイエスエス (KSS)</publisher>
+		<info name="alt_title" value="メンゾベランザン 闇の紋章" />
 		<info name="release" value="199601xx" />
 		<info name="usage" value="Requires HDD installation"/>
 		<part name="cdrom" interface="fmt_cdrom">
@@ -6406,6 +6975,7 @@ User/save disks that can be created from the game itself are not included.
 		<description>Metal Eye</description>
 		<year>1993</year>
 		<publisher>エルフ (Elf)</publisher>
+		<info name="alt_title" value="メタルアイ" />
 		<info name="release" value="199307xx" />
 		<part name="cdrom" interface="fmt_cdrom">
 			<diskarea name="cdrom">
@@ -6425,6 +6995,7 @@ User/save disks that can be created from the game itself are not included.
 		<description>Metal Eye 2</description>
 		<year>1994</year>
 		<publisher>エルフ (Elf)</publisher>
+		<info name="alt_title" value="メタルアイ2" />
 		<info name="release" value="199409xx" />
 		<part name="cdrom" interface="fmt_cdrom">
 			<diskarea name="cdrom">
@@ -6444,6 +7015,7 @@ User/save disks that can be created from the game itself are not included.
 		<description>My Fair Lady CAN II - Elementary</description>
 		<year>1990</year>
 		<publisher>CRI</publisher>
+		<info name="release" value="199009xx" />
 		<part name="cdrom" interface="fmt_cdrom">
 			<diskarea name="cdrom">
 				<disk name="my fair lady can ii - elementary" sha1="49e0d2a348b405d01b9790267f70a108b69cac8b" />
@@ -6462,6 +7034,7 @@ User/save disks that can be created from the game itself are not included.
 		<description>Mugen Houyou</description>
 		<year>1995</year>
 		<publisher>アリスソフト (AliceSoft)</publisher>
+		<info name="alt_title" value="夢幻泡影" />
 		<info name="usage" value="Requires HDD installation"/>
 		<part name="cdrom" interface="fmt_cdrom">
 			<diskarea name="cdrom">
@@ -6481,6 +7054,7 @@ User/save disks that can be created from the game itself are not included.
 		<description>Mirage</description>
 		<year>1992</year>
 		<publisher>ディスカバリー (Discovery)</publisher>
+		<info name="alt_title" value="ミラージュ" />
 		<info name="release" value="199201xx" />
 		<part name="cdrom" interface="fmt_cdrom">
 			<diskarea name="cdrom">
@@ -6500,6 +7074,7 @@ User/save disks that can be created from the game itself are not included.
 		<description>Mirrors</description>
 		<year>1992</year>
 		<publisher>Apros</publisher>
+		<info name="alt_title" value="ミラーズ" />
 		<info name="release" value="199206xx" />
 		<part name="cdrom" interface="fmt_cdrom">
 			<diskarea name="cdrom">
@@ -6510,18 +7085,38 @@ User/save disks that can be created from the game itself are not included.
 
 	<software name="misty">
 		<!--
-		Origin: Neo Kobe Collection
-		<rom name="Misty.ccd" size="4918" crc="df323273" sha1="7f9cfa1e668514f2cdff034395c0fd32f00a0feb"/>
-		<rom name="Misty.cue" size="1281" crc="c4e6648e" sha1="fcbe10d481f8b5bc05e6a2e31b8ff80f865723e6"/>
-		<rom name="Misty.img" size="721405440" crc="099f42c7" sha1="2f38d15475d0be48c2cc6fe5638345cbe24083fb"/>
-		<rom name="Misty.sub" size="29445120" crc="5db8312c" sha1="230917227eb470c89f702b6016442a95dba27d37"/>
+		Origin: redump.org
+		<rom name="Misty - Meitantei Toujou (Japan) (Track 01).bin" size="88552800" crc="31c40a18" sha1="5396950e49cfb61afbdfbb3196a928fb3163c767"/>
+		<rom name="Misty - Meitantei Toujou (Japan) (Track 02).bin" size="21967680" crc="1990eb30" sha1="7847a31f950050d6f5f1f8ae917e3c76891d292b"/>
+		<rom name="Misty - Meitantei Toujou (Japan) (Track 03).bin" size="20580000" crc="8d15ec66" sha1="76750b616064e61b3b7c21cf1c8c018ad941bcfa"/>
+		<rom name="Misty - Meitantei Toujou (Japan) (Track 04).bin" size="34456800" crc="dbd4431b" sha1="6d6ae662d2e707069b798c0b918be4f55919fa79"/>
+		<rom name="Misty - Meitantei Toujou (Japan) (Track 05).bin" size="22614480" crc="08844c34" sha1="ca71b169c6fe40e23d8ba696b01d3d43a904a401"/>
+		<rom name="Misty - Meitantei Toujou (Japan) (Track 06).bin" size="49627200" crc="4a9b9e30" sha1="07bc556dba8a605e9646593604e54bb257de69e3"/>
+		<rom name="Misty - Meitantei Toujou (Japan) (Track 07).bin" size="31211040" crc="46c25670" sha1="df86b92a9e397332093d7149647578ebe541f560"/>
+		<rom name="Misty - Meitantei Toujou (Japan) (Track 08).bin" size="24131520" crc="17a83f94" sha1="c730da2aecf5449e2aec76c6c899da3019970f43"/>
+		<rom name="Misty - Meitantei Toujou (Japan) (Track 09).bin" size="14558880" crc="363ef8a1" sha1="0e406483c4fb64c07cce4eeb5654975040f1c24e"/>
+		<rom name="Misty - Meitantei Toujou (Japan) (Track 10).bin" size="43265040" crc="7cef2fcd" sha1="01569c849ee9eb559c05246693ad07cf6fc8968d"/>
+		<rom name="Misty - Meitantei Toujou (Japan) (Track 11).bin" size="23684640" crc="80a808b3" sha1="0a7b5090e2667a0685e0e51d94b46b403067d02c"/>
+		<rom name="Misty - Meitantei Toujou (Japan) (Track 12).bin" size="18874800" crc="7abb773c" sha1="9f0a41735deeb5d730bbb53ee526e9ec5758619e"/>
+		<rom name="Misty - Meitantei Toujou (Japan) (Track 13).bin" size="17157840" crc="2dc21fcd" sha1="33a6b4f6ca274a5055f21d1c611a3d85b6505e49"/>
+		<rom name="Misty - Meitantei Toujou (Japan) (Track 14).bin" size="65973600" crc="04b6c98b" sha1="552581edcd9773e89e5c102b8626410072320ca2"/>
+		<rom name="Misty - Meitantei Toujou (Japan) (Track 15).bin" size="64080240" crc="5ee69bae" sha1="79f39e3cf73d214141fae4789bd07f722a60cbfc"/>
+		<rom name="Misty - Meitantei Toujou (Japan) (Track 16).bin" size="66738000" crc="89f69a4f" sha1="e1f12812a6d924e07bf2c2b0309e6e969c843f7a"/>
+		<rom name="Misty - Meitantei Toujou (Japan) (Track 17).bin" size="48580560" crc="5c0ec450" sha1="77944036ea4cad6aa39a0ac1f8761edfbc46c3aa"/>
+		<rom name="Misty - Meitantei Toujou (Japan) (Track 18).bin" size="29517600" crc="4a66008d" sha1="f298b4e127dce017babfffffc8826d0a55f3ce5d"/>
+		<rom name="Misty - Meitantei Toujou (Japan) (Track 19).bin" size="25142880" crc="bfdff8fb" sha1="51a08d9e9d6d09c6df50d3f29f394045f2e01c32"/>
+		<rom name="Misty - Meitantei Toujou (Japan) (Track 20).bin" size="6573840" crc="f976fcdd" sha1="c32bf1f6b9079dd1efbf9227379b6017a95cb717"/>
+		<rom name="Misty - Meitantei Toujou (Japan) (Track 21).bin" size="4116000" crc="25f640f9" sha1="88fb6116a0cccb53cc09422cdca32ef2be9d37e9"/>
+		<rom name="Misty - Meitantei Toujou (Japan).cue" size="2649" crc="67548b3d" sha1="33bb4498304c23043022cb10f9827fcb1e8b0f32"/>
 		-->
-		<description>Misty</description>
-		<year>1991</year>
+		<description>Misty - Meitantei Toujou</description>
+		<year>1989</year>
 		<publisher>データウエスト (Data West)</publisher>
+		<info name="alt_title" value="Ｍｉｓｔｙ 名探偵登場" />
+		<info name="release" value="198906xx" />
 		<part name="cdrom" interface="fmt_cdrom">
 			<diskarea name="cdrom">
-				<disk name="misty" sha1="77b69d046829ec088621bbd47d2fbaacaa5e21a6" />
+				<disk name="misty - meitantei toujou (japan)" sha1="5b699202a0b77cd9e13bceaa41c01e675043e013" />
 			</diskarea>
 		</part>
 	</software>
@@ -6538,6 +7133,7 @@ User/save disks that can be created from the game itself are not included.
 		<description>Might and Magic III - Isles of Terra</description>
 		<year>1992</year>
 		<publisher>スタークラフト (Starcraft)</publisher>
+		<info name="alt_title" value="マイト＆マジックIII" />
 		<info name="release" value="199210xx" />
 		<part name="cdrom" interface="fmt_cdrom">
 			<diskarea name="cdrom">
@@ -6555,6 +7151,7 @@ User/save disks that can be created from the game itself are not included.
 		<description>Might and Magic - Clouds of Xeen</description>
 		<year>1993</year>
 		<publisher>スタークラフト (Starcraft)</publisher>
+		<info name="alt_title" value="クラウズ・オブ・ジーン" />
 		<info name="release" value="199309xx" />
 		<part name="cdrom" interface="fmt_cdrom">
 			<diskarea name="cdrom">
@@ -6572,6 +7169,7 @@ User/save disks that can be created from the game itself are not included.
 		<description>Might and Magic - Darkside of Xeen</description>
 		<year>1994</year>
 		<publisher>スタークラフト (Starcraft)</publisher>
+		<info name="alt_title" value="ダークサイド・オブ・ジーン" />
 		<info name="release" value="199405xx" />
 		<part name="cdrom" interface="fmt_cdrom">
 			<diskarea name="cdrom">
@@ -6653,6 +7251,7 @@ User/save disks that can be created from the game itself are not included.
 		<description>The Secret of Monkey Island</description>
 		<year>1992</year>
 		<publisher>ビクター音楽産業 (Victor Musical Industries)</publisher>
+		<info name="alt_title" value="モンキーアイランド" />
 		<info name="release" value="199209xx" />
 		<part name="cdrom" interface="fmt_cdrom">
 			<diskarea name="cdrom">
@@ -6674,6 +7273,7 @@ User/save disks that can be created from the game itself are not included.
 		<description>Monkey Island 2 - LeChuck's Revenge</description>
 		<year>1994</year>
 		<publisher>ビクター音楽産業 (Victor Musical Industries)</publisher>
+		<info name="alt_title" value="モンキーアイランド２ ～ル・チャックの逆襲～" />
 		<info name="release" value="199402xx" />
 		<part name="cdrom" interface="fmt_cdrom">
 			<diskarea name="cdrom">
@@ -6693,6 +7293,7 @@ User/save disks that can be created from the game itself are not included.
 		<description>Moonlight-chan Rinshan</description>
 		<year>1993</year>
 		<publisher>ディー・オー (D.O.)</publisher>
+		<info name="alt_title" value="Ｍゥーンライトちゃんリンしゃん" />
 		<info name="release" value="199303xx" />
 		<part name="cdrom" interface="fmt_cdrom">
 			<diskarea name="cdrom">
@@ -6712,6 +7313,7 @@ User/save disks that can be created from the game itself are not included.
 		<description>Morita Shougi II</description>
 		<year>1989</year>
 		<publisher>エニックス (Enix)</publisher>
+		<info name="alt_title" value="森田将棋II" />
 		<info name="release" value="198903xx" />
 		<part name="cdrom" interface="fmt_cdrom">
 			<diskarea name="cdrom">
@@ -6736,6 +7338,7 @@ User/save disks that can be created from the game itself are not included.
 		<description>Ms. Detective File #1 - Iwami Ginzan Satsujin Jiken</description>
 		<year>1992</year>
 		<publisher>データウエスト (Data West)</publisher>
+		<info name="alt_title" value="Ms.DETECTIVE ファイル#1 「石見銀山殺人事件」" />
 		<info name="release" value="199209xx" />
 		<part name="cdrom1" interface="fmt_cdrom">
 			<diskarea name="cdrom">
@@ -6761,6 +7364,7 @@ User/save disks that can be created from the game itself are not included.
 		<description>Ms. Detective File #2 - Sugata-naki Irainin</description>
 		<year>1993</year>
 		<publisher>データウエスト (Data West)</publisher>
+		<info name="alt_title" value="Ms.DETECTIVE ファイル#2 「姿なき依頼人」" />
 		<info name="release" value="199310xx" />
 		<part name="cdrom" interface="fmt_cdrom">
 			<diskarea name="cdrom">
@@ -6800,6 +7404,7 @@ User/save disks that can be created from the game itself are not included.
 		<description>Mujintou Monogatari</description>
 		<year>1995</year>
 		<publisher>ケイエスエス (KSS)</publisher>
+		<info name="alt_title" value="無人島物語" />
 		<info name="release" value="199509xx" />
 		<part name="cdrom" interface="fmt_cdrom">
 			<diskarea name="cdrom">
@@ -6820,6 +7425,7 @@ User/save disks that can be created from the game itself are not included.
 		<description>Murder Club DX</description>
 		<year>1992</year>
 		<publisher>リバーヒルソフト (Riverhill Soft)</publisher>
+		<info name="alt_title" value="マーダークラブＤＸ" />
 		<info name="release" value="199205xx" />
 		<part name="cdrom" interface="fmt_cdrom">
 			<diskarea name="cdrom">
@@ -6840,6 +7446,7 @@ User/save disks that can be created from the game itself are not included.
 		<description>Mixed-Up Mother Goose</description>
 		<year>1991</year>
 		<publisher>シエラオンラインジャパン (Sierra On-Line Japan)</publisher>
+		<info name="alt_title" value="MIXED-UP MOTHER GOOSE おかしなマザーグース" />
 		<info name="release" value="199102xx" />
 		<part name="cdrom" interface="fmt_cdrom">
 			<diskarea name="cdrom">
@@ -6878,6 +7485,7 @@ User/save disks that can be created from the game itself are not included.
 		<description>Musium Towns</description>
 		<year>1993</year>
 		<publisher>ビクター音楽産業 (Victor Musical Industries)</publisher>
+		<info name="release" value="199309xx" />
 		<part name="cdrom" interface="fmt_cdrom">
 			<diskarea name="cdrom">
 				<disk name="musium towns" sha1="350c5c1f5e36ef48875fc9abbdecf3fc82c50dbf" />
@@ -6925,6 +7533,7 @@ User/save disks that can be created from the game itself are not included.
 		<description>Fushigi no Umi no Nadia</description>
 		<year>1993</year>
 		<publisher>ガイナックス (Gainax)</publisher>
+		<info name="alt_title" value="ふしぎの海のナディア" />
 		<info name="release" value="199302xx" />
 		<part name="cdrom1" interface="fmt_cdrom">
 			<feature name="part_id" value="Disk A - Unidentified Noise"/>
@@ -6957,6 +7566,7 @@ User/save disks that can be created from the game itself are not included.
 		<description>Necronomicon</description>
 		<year>1994</year>
 		<publisher>フェアリーテール (Fairytale)</publisher>
+		<info name="alt_title" value="ネクロノミコン" />
 		<info name="release" value="199408xx" />
 		<part name="cdrom" interface="fmt_cdrom">
 			<diskarea name="cdrom">
@@ -6980,6 +7590,7 @@ User/save disks that can be created from the game itself are not included.
 		<description>New 3D Golf Simulation - Harukanaru Augusta</description>
 		<year>1990</year>
 		<publisher>ティーアンドイーソフト (T&amp;E Soft)</publisher>
+		<info name="alt_title" value="遙かなるオーガスタ" />
 		<info name="release" value="199001xx" />
 		<part name="flop1" interface="floppy_3_5">
 			<feature name="part_id" value="System Disk" />
@@ -7004,6 +7615,7 @@ User/save disks that can be created from the game itself are not included.
 		<description>NHK Jissen Eikaiwa</description>
 		<year>1991</year>
 		<publisher>CRC総合研究所 (CRC Sougou Kenkyuusho)</publisher>
+		<info name="alt_title" value="ＮＨＫ実践英会話" />
 		<info name="release" value="199108xx" />
 		<part name="cdrom" interface="fmt_cdrom">
 			<diskarea name="cdrom">
@@ -7021,6 +7633,7 @@ User/save disks that can be created from the game itself are not included.
 		<description>Nihon Mukashibanashi</description>
 		<year>1990</year>
 		<publisher>Gyousei</publisher>
+		<info name="alt_title" value="日本昔ばなし" />
 		<info name="release" value="199011xx" />
 		<part name="cdrom" interface="fmt_cdrom">
 			<diskarea name="cdrom">
@@ -7040,6 +7653,8 @@ User/save disks that can be created from the game itself are not included.
 		<description>Nihon no Rekishi - Kizoku-hen</description>
 		<year>1990</year>
 		<publisher>CRI</publisher>
+		<info name="alt_title" value="日本の歴史 貴族編" />
+		<info name="release" value="199009xx" />
 		<part name="cdrom" interface="fmt_cdrom">
 			<diskarea name="cdrom">
 				<disk name="nihon no rekishi - kizoku-hen" sha1="1bf433fc57cba5d452088b69c3b63d1be8ff9e1c" />
@@ -7058,6 +7673,8 @@ User/save disks that can be created from the game itself are not included.
 		<description>Nihon no Rekishi - Kodai-hen</description>
 		<year>1990</year>
 		<publisher>CRI</publisher>
+		<info name="alt_title" value="日本の歴史 古代編" />
+		<info name="release" value="199007xx" />
 		<part name="cdrom" interface="fmt_cdrom">
 			<diskarea name="cdrom">
 				<disk name="nihon no rekishi - kodai-hen" sha1="994b5f62b4c1ff2cd439948f12c52fa6d63cb8dc" />
@@ -7076,6 +7693,8 @@ User/save disks that can be created from the game itself are not included.
 		<description>Nihon no Yachou</description>
 		<year>1990</year>
 		<publisher>富士通 (Fujitsu)</publisher>
+		<info name="alt_title" value="日本の野鳥" />
+		<info name="release" value="199003xx" />
 		<part name="cdrom" interface="fmt_cdrom">
 			<diskarea name="cdrom">
 				<disk name="nihon no yachou" sha1="561a61de28e33c514f7e661632cdb58c5dc2eddf" />
@@ -7096,6 +7715,7 @@ User/save disks that can be created from the game itself are not included.
 		<description>Ningyou Tsukai</description>
 		<year>1993</year>
 		<publisher>フォレスト (Forest)</publisher>
+		<info name="alt_title" value="人形使い" />
 		<info name="release" value="199310xx" />
 		<part name="cdrom" interface="fmt_cdrom">
 			<diskarea name="cdrom">
@@ -7112,9 +7732,10 @@ User/save disks that can be created from the game itself are not included.
 		<rom name="nobubus.img" size="598174752" crc="8987d4a8" sha1="2874039535353d4b87f99f69af90aca07105d4df"/>
 		<rom name="nobubus.sub" size="24415296" crc="88ce164a" sha1="05ef1727a1c6b21497e9a6ebe377c9e05ee2b8fa"/>
 		-->
-		<description>Nobunaga no Yabou - Bushou Fuunroku</description>
+		<description>Nobunaga no Yabou - Bushou Fuuunroku</description>
 		<year>1991</year>
 		<publisher>光栄 (Koei)</publisher>
+		<info name="alt_title" value="信長の野望 武将風雲録" />
 		<info name="release" value="199107xx" />
 		<part name="flop1" interface="floppy_3_5">
 			<feature name="part_id" value="User Disk" />
@@ -7140,6 +7761,7 @@ User/save disks that can be created from the game itself are not included.
 		<description>Nobunaga no Yabou - Haouden</description>
 		<year>1993</year>
 		<publisher>光栄 (Koei)</publisher>
+		<info name="alt_title" value="信長の野望 覇王伝" />
 		<info name="release" value="199304xx" />
 		<part name="flop1" interface="floppy_3_5">
 			<dataarea name="flop" size="1261568">
@@ -7163,6 +7785,7 @@ User/save disks that can be created from the game itself are not included.
 		<description>Nobunaga no Yabou - Tenshouki</description>
 		<year>1995</year>
 		<publisher>光栄 (Koei)</publisher>
+		<info name="alt_title" value="信長の野望 天翔記" />
 		<info name="release" value="199503xx" />
 		<part name="cdrom" interface="fmt_cdrom">
 			<diskarea name="cdrom">
@@ -7179,9 +7802,10 @@ User/save disks that can be created from the game itself are not included.
 		<rom name="Nova.img" size="466930800" crc="e052374a" sha1="eb36eccdfb9b3df08eb880792409a2fc22145bd7"/>
 		<rom name="Nova.sub" size="19058400" crc="eb8ea499" sha1="669261426efdd192d26a2066a28c63d927a63f06"/>
 		-->
-		<description>Nova</description>
+		<description>Nova - Miirareta Shitai</description>
 		<year>1993</year>
 		<publisher>Cat's Pro.</publisher>
+		<info name="alt_title" value="ノ・ヴァ～魅入られた肢体" />
 		<info name="release" value="199307xx" />
 		<part name="cdrom" interface="fmt_cdrom">
 			<diskarea name="cdrom">
@@ -7201,6 +7825,7 @@ User/save disks that can be created from the game itself are not included.
 		<description>Okiraku TownsGEAR</description>
 		<year>1994</year>
 		<publisher>Softbank</publisher>
+		<info name="alt_title" value="お気楽 TownsGEAR" />
 		<part name="cdrom" interface="fmt_cdrom">
 			<diskarea name="cdrom">
 				<disk name="okiraku towns gear" sha1="a614a4471c91a19fe33bf903a5f699907bad813e" />
@@ -7238,6 +7863,7 @@ User/save disks that can be created from the game itself are not included.
 		<description>Okumanchouja II</description>
 		<year>1991</year>
 		<publisher>コスモス・コンピュータ (Cosmos Computer)</publisher>
+		<info name="alt_title" value="億万長者II" />
 		<info name="release" value="199107xx" />
 		<part name="cdrom" interface="fmt_cdrom">
 			<diskarea name="cdrom">
@@ -7257,6 +7883,7 @@ User/save disks that can be created from the game itself are not included.
 		<description>Operation Wolf</description>
 		<year>1990</year>
 		<publisher>ビング (Ving)</publisher>
+		<info name="alt_title" value="オペレーション・ウルフ" />
 		<info name="release" value="199004xx" />
 		<part name="cdrom" interface="fmt_cdrom">
 			<diskarea name="cdrom">
@@ -7297,6 +7924,8 @@ User/save disks that can be created from the game itself are not included.
 		<description>Oshare Cooking</description>
 		<year>1989</year>
 		<publisher>ミサワホーム総合研究所 (Misawa Home Sougou Kenkyuusho)</publisher>
+		<info name="alt_title" value="おしゃれクッキング" />
+		<info name="release" value="198912xx" />
 		<part name="cdrom" interface="fmt_cdrom">
 			<diskarea name="cdrom">
 				<disk name="oshare cooking" sha1="d6175d9a81760fbd9e497e6a396dbaf2aad6d57c" />
@@ -7313,6 +7942,7 @@ User/save disks that can be created from the game itself are not included.
 		<description>Oshare Cooking II</description>
 		<year>1990</year>
 		<publisher>ミサワホーム総合研究所 (Misawa Home Sougou Kenkyuusho)</publisher>
+		<info name="alt_title" value="おしゃれクッキングII" />
 		<info name="release" value="199011xx" />
 		<part name="cdrom" interface="fmt_cdrom">
 			<diskarea name="cdrom">
@@ -7328,9 +7958,10 @@ User/save disks that can be created from the game itself are not included.
 		<rom name="Ougon no Rashimban.cue" size="1426" crc="8a96f578" sha1="7bc3da97c04ec392bb113ce03c437e278aa2bd70"/>
 		<rom name="Ougon no Rashimban.img" size="380694720" crc="e9badbda" sha1="b5cb62cef2379be9bd61009eb19ab571d3a9df50"/>
 		-->
-		<description>Ougon no Rashinban</description>
+		<description>Ougon no Rashinban - Shouyomaru San Francisco Kouro Satsujin Jiken</description>
 		<year>1991</year>
 		<publisher>リバーヒルソフト (Riverhill Soft)</publisher>
+		<info name="alt_title" value="黄金の羅針盤 翔洋丸桑港航路殺人事件" />
 		<info name="release" value="199104xx" />
 		<part name="cdrom" interface="fmt_cdrom">
 			<diskarea name="cdrom">
@@ -7351,6 +7982,7 @@ User/save disks that can be created from the game itself are not included.
 		<description>Panzer Division - Kikou Shidan</description>
 		<year>1990</year>
 		<publisher>アートディンク (Artdink)</publisher>
+		<info name="alt_title" value="機甲師団" />
 		<info name="release" value="199012xx" />
 		<part name="cdrom" interface="fmt_cdrom">
 			<diskarea name="cdrom">
@@ -7435,6 +8067,7 @@ User/save disks that can be created from the game itself are not included.
 		<description>Planet's Edge</description>
 		<year>1993</year>
 		<publisher>ビング (Ving)</publisher>
+		<info name="alt_title" value="プラネッツ・エッジ" />
 		<info name="release" value="199309xx" />
 		<part name="cdrom" interface="fmt_cdrom">
 			<diskarea name="cdrom">
@@ -7454,6 +8087,7 @@ User/save disks that can be created from the game itself are not included.
 		<description>Princess Maker 2</description>
 		<year>1994</year>
 		<publisher>ガイナックス (Gainax)</publisher>
+		<info name="alt_title" value="プリンセスメーカー２" />
 		<info name="release" value="199409xx" />
 		<part name="cdrom" interface="fmt_cdrom">
 			<diskarea name="cdrom">
@@ -7472,7 +8106,8 @@ User/save disks that can be created from the game itself are not included.
 		-->
 		<description>Ponkan</description>
 		<year>1994</year>
-		<publisher>ポニーテールソフト (PonyTale Soft)</publisher>
+		<publisher>ポニーテールソフト (Ponytail Soft)</publisher>
+		<info name="alt_title" value="ポンカン" />
 		<info name="release" value="199407xx" />
 		<part name="cdrom" interface="fmt_cdrom">
 			<diskarea name="cdrom">
@@ -7492,6 +8127,7 @@ User/save disks that can be created from the game itself are not included.
 		<description>Populous &amp; The Promised Lands</description>
 		<year>1990</year>
 		<publisher>イマジニア (Imagineer)</publisher>
+		<info name="alt_title" value="ポピュラス" />
 		<info name="release" value="199007xx" />
 		<part name="cdrom" interface="fmt_cdrom">
 			<diskarea name="cdrom">
@@ -7518,6 +8154,7 @@ User/save disks that can be created from the game itself are not included.
 		<description>Power Dolls</description>
 		<year>1994</year>
 		<publisher>工画堂 (Kogado)</publisher>
+		<info name="alt_title" value="パワードール" />
 		<info name="release" value="199407xx" />
 		<part name="flop1" interface="floppy_3_5">
 			<feature name="part_id" value="User Disk" />
@@ -7549,6 +8186,7 @@ User/save disks that can be created from the game itself are not included.
 		<description>Power Dolls 2</description>
 		<year>1995</year>
 		<publisher>工画堂 (Kogado)</publisher>
+		<info name="alt_title" value="パワードール2" />
 		<info name="release" value="199511xx" />
 		<part name="cdrom" interface="fmt_cdrom">
 			<diskarea name="cdrom">
@@ -7568,6 +8206,7 @@ User/save disks that can be created from the game itself are not included.
 		<description>Powermonger</description>
 		<year>1992</year>
 		<publisher>イマジニア (Imagineer)</publisher>
+		<info name="alt_title" value="パワーモンガー" />
 		<info name="release" value="199205xx" />
 		<part name="flop1" interface="floppy_3_5">
 			<feature name="part_id" value="Boot Disk (En)" />
@@ -7599,6 +8238,7 @@ User/save disks that can be created from the game itself are not included.
 		<description>Prince of Persia</description>
 		<year>1992</year>
 		<publisher>リバーヒルソフト (Riverhill Soft)</publisher>
+		<info name="alt_title" value="プリンス・オブ・ペルシャ" />
 		<info name="release" value="199206xx" />
 		<part name="cdrom" interface="fmt_cdrom">
 			<diskarea name="cdrom">
@@ -7616,6 +8256,7 @@ User/save disks that can be created from the game itself are not included.
 		<description>Prince of Persia 2 - The Shadow and the Flame</description>
 		<year>1994</year>
 		<publisher>インタープログ (Interprog)</publisher>
+		<info name="alt_title" value="プリンス・オブ・ペルシャ2 ザ・シャドウ アンド ザ・フレーム" />
 		<info name="release" value="199407xx" />
 		<part name="cdrom" interface="fmt_cdrom">
 			<diskarea name="cdrom">
@@ -7635,6 +8276,7 @@ User/save disks that can be created from the game itself are not included.
 		<description>Pro Student G</description>
 		<year>1993</year>
 		<publisher>アリスソフト (AliceSoft)</publisher>
+		<info name="alt_title" value="ぷろすちゅーでんとG" />
 		<info name="release" value="199307xx" />
 		<part name="flop1" interface="floppy_3_5">
 			<feature name="part_id" value="Boot Disk" />
@@ -7645,6 +8287,24 @@ User/save disks that can be created from the game itself are not included.
 		<part name="cdrom" interface="fmt_cdrom">
 			<diskarea name="cdrom">
 				<disk name="pro student g" sha1="a7675c732045804fbaf292a191eb1967f98894a4" />
+			</diskarea>
+		</part>
+	</software>
+
+	<software name="pmjgoku">
+		<!--
+		Origin: redump.org
+		<rom name="Professional Mahjong Goku (Japan).bin" size="105487200" crc="52754556" sha1="c25015ed2646b99c3b42b3549ffb68e8384fddd6"/>
+		<rom name="Professional Mahjong Goku (Japan).cue" size="99" crc="5a5bfce8" sha1="99e3b836549b2f63fe7362276e2bb4bbb5f8b38a"/>
+		-->
+		<description>Professional Mahjong Goku</description>
+		<year>1989</year>
+		<publisher>アスキー (ASCII)</publisher>
+		<info name="alt_title" value="プロフェッショナル麻雀悟空" />
+		<info name="release" value="198904xx" />
+		<part name="cdrom" interface="fmt_cdrom">
+			<diskarea name="cdrom">
+				<disk name="professional mahjong goku (japan)" sha1="ac2a9cb0503e09342e8737dfed58daa05b34914b" />
 			</diskarea>
 		</part>
 	</software>
@@ -7661,6 +8321,7 @@ User/save disks that can be created from the game itself are not included.
 		<description>Provvidenza - Legenda la Spada di Alfa</description>
 		<year>1991</year>
 		<publisher>Sofcom</publisher>
+		<info name="alt_title" value="プロビデンツァ Legenda la Spada di Alfa" />	
 		<info name="release" value="199109xx" />
 		<part name="cdrom" interface="fmt_cdrom">
 			<diskarea name="cdrom">
@@ -7678,9 +8339,10 @@ User/save disks that can be created from the game itself are not included.
 		<rom name="Psychic Detective Series Vol. 1 - Invitation (Track 4).bin" size="4233600" crc="4580866a" sha1="aaefaba5020efb03452df764e2897d0f278e3151"/>
 		<rom name="Psychic Detective Series Vol. 1 - Invitation.cue" size="534" crc="3312b6bd" sha1="4a420300e0aebd9b7e971047c9ecddf0ce5ba43f"/>
 		-->
-		<description>Psychic Detective Series Vol. 1 - Invitation</description>
+		<description>Psychic Detective Series Vol. 1 - Invitation - Kage kara no Shoutaijou</description>
 		<year>1989</year>
 		<publisher>データウエスト (Data West)</publisher>
+		<info name="alt_title" value="サイキック・ディテクティヴ・シリーズ　Vol. 1　インビテーション　影からの招待状" />
 		<info name="release" value="198903xx" />
 		<part name="cdrom" interface="fmt_cdrom">
 			<diskarea name="cdrom">
@@ -7715,6 +8377,8 @@ User/save disks that can be created from the game itself are not included.
 		<description>Psychic Detective Series Vol. 2 - Memories</description>
 		<year>1989</year>
 		<publisher>データウエスト (Data West)</publisher>
+		<info name="alt_title" value="サイキック・ディテクティヴ・シリーズ　Vol.2　メモリーズ" />
+		<info name="release" value="198910xx" />
 		<part name="cdrom" interface="fmt_cdrom">
 			<diskarea name="cdrom">
 				<disk name="psychic detective series vol. 2 - memories" sha1="dc3d92414e77cf0220e10f46a92e2c24d07daa82" />
@@ -7738,6 +8402,7 @@ User/save disks that can be created from the game itself are not included.
 		<description>Psychic Detective Series Vol. 3 - Aya</description>
 		<year>1990</year>
 		<publisher>データウエスト (Data West)</publisher>
+		<info name="alt_title" value="サイキック・ディテクティヴ・シリーズ　Vol.3　アヤ" />
 		<info name="release" value="199006xx" />
 		<part name="cdrom" interface="fmt_cdrom">
 			<diskarea name="cdrom">
@@ -7762,6 +8427,7 @@ User/save disks that can be created from the game itself are not included.
 		<description>Psychic Detective Series Vol. 4 - Orgel</description>
 		<year>1991</year>
 		<publisher>データウエスト (Data West)</publisher>
+		<info name="alt_title" value="サイキック・ディテクティヴ・シリーズ　Vol.4　オルゴール" />
 		<info name="release" value="199104xx" />
 		<part name="flop1" interface="floppy_3_5">
 			<dataarea name="flop" size="1261568">
@@ -7786,6 +8452,7 @@ User/save disks that can be created from the game itself are not included.
 		<description>Psychic Detective Series Vol. 5 - Nightmare</description>
 		<year>1991</year>
 		<publisher>データウエスト (Data West)</publisher>
+		<info name="alt_title" value="サイキック・ディテクティヴ・シリーズ　Vol.5　ナイトメア" />
 		<info name="release" value="199111xx" />
 		<part name="flop1" interface="floppy_3_5">
 			<feature name="part_id" value="System Disk" />
@@ -7815,6 +8482,7 @@ User/save disks that can be created from the game itself are not included.
 		<description>Psychic Detective Series Final - Solitude Joukan</description>
 		<year>1992</year>
 		<publisher>データウエスト (Data West)</publisher>
+		<info name="alt_title" value="サイキック・ディテクティヴ・シリーズ・ファイナル　「ソリチュード（上巻）」" />
 		<info name="release" value="199212xx" />
 		<part name="flop1" interface="floppy_3_5">
 			<dataarea name="flop" size="1261568">
@@ -7841,6 +8509,7 @@ User/save disks that can be created from the game itself are not included.
 		<description>Psychic Detective Series Final - Solitude Gekan</description>
 		<year>1993</year>
 		<publisher>データウエスト (Data West)</publisher>
+		<info name="alt_title" value="サイキック・ディテクティヴシリーズ・ファイナル　「ソリチュード（下巻）」" />
 		<info name="release" value="199303xx" />
 		<part name="flop1" interface="floppy_3_5">
 			<dataarea name="flop" size="1261568">
@@ -7890,6 +8559,7 @@ User/save disks that can be created from the game itself are not included.
 		<description>Pu-Li-Ru-La</description>
 		<year>1994</year>
 		<publisher>ビング (Ving)</publisher>
+		<info name="alt_title" value="プリルラ" />
 		<info name="release" value="199411xx" />
 		<part name="cdrom" interface="fmt_cdrom">
 			<diskarea name="cdrom">
@@ -7907,6 +8577,7 @@ User/save disks that can be created from the game itself are not included.
 		<description>Tom Snyder's Puppy Love 2</description>
 		<year>1993</year>
 		<publisher>富士通 (Fujitsu)</publisher>
+		<info name="alt_title" value="Tom Snyder's パピーラブ２" />
 		<info name="release" value="199303xx" />
 		<part name="cdrom" interface="fmt_cdrom">
 			<diskarea name="cdrom">
@@ -7917,19 +8588,35 @@ User/save disks that can be created from the game itself are not included.
 
 	<software name="puyopuyo">
 		<!--
-		Origin: Neo Kobe Collection
-		<rom name="Puyo Puyo.ccd" size="4259" crc="e2b3f2be" sha1="567df133d13d3abe0c6227a29d49ac80787a7dc8"/>
-		<rom name="Puyo Puyo.cue" size="1102" crc="022456a9" sha1="1c603f1a5aea3941f7b3a627bf48e2cd0d85a651"/>
-		<rom name="Puyo Puyo.img" size="391873776" crc="ff838cce" sha1="dcc77d9d7f4165e10f3d960b9712b53403fcb74f"/>
-		<rom name="Puyo Puyo.sub" size="15994848" crc="5276d1c5" sha1="4340ce4d40e58c30acb7b487e47349daa1348852"/>
+		Origin: redump.org
+		<rom name="Puyo Puyo (Japan) (Track 01).bin" size="3349248" crc="4cbe92ad" sha1="04093aebf86a83299fd6927c53d52b3b6971b394"/>
+		<rom name="Puyo Puyo (Japan) (Track 02).bin" size="9892512" crc="caeda607" sha1="e5848125ce4298c2c96968081bb8c168aff9d3a0"/>
+		<rom name="Puyo Puyo (Japan) (Track 03).bin" size="11974032" crc="fe47cebb" sha1="a31f4f0797204c4643f1f54243df72bab778e7e7"/>
+		<rom name="Puyo Puyo (Japan) (Track 04).bin" size="25862592" crc="67d0cc3c" sha1="d761e215ad15f81797b8125b28a33f977933dfa9"/>
+		<rom name="Puyo Puyo (Japan) (Track 05).bin" size="3558576" crc="ae6aff06" sha1="f4b44c901f8e32079ea8c6475092c082da00b8e8"/>
+		<rom name="Puyo Puyo (Japan) (Track 06).bin" size="20558832" crc="2336f88d" sha1="7e63e4a522865f05c2114b2a8422dafd55dba17b"/>
+		<rom name="Puyo Puyo (Japan) (Track 07).bin" size="23223648" crc="746ae414" sha1="8bf3f896d3ccc84f75cb1d89f86a5218dd58584f"/>
+		<rom name="Puyo Puyo (Japan) (Track 08).bin" size="28971936" crc="0522e37e" sha1="08e3c1abd87893e368b1baaf0cc17bc1ff89399a"/>
+		<rom name="Puyo Puyo (Japan) (Track 09).bin" size="19239360" crc="de445898" sha1="fd7d942e697e35d983a22399861f33769f604d79"/>
+		<rom name="Puyo Puyo (Japan) (Track 10).bin" size="1747536" crc="c0124677" sha1="969f123530afd25ceb53e2d29c2385cf1b25e363"/>
+		<rom name="Puyo Puyo (Japan) (Track 11).bin" size="30110304" crc="718e059d" sha1="56416053e6734c63d9ed1cd5436a3c8698323e8d"/>
+		<rom name="Puyo Puyo (Japan) (Track 12).bin" size="32650464" crc="f0c56558" sha1="06f72f236379f41fbf4177e68d6c3bc1d730fa54"/>
+		<rom name="Puyo Puyo (Japan) (Track 13).bin" size="27588960" crc="da321a45" sha1="df5e3835075d604154f2313927acb79fb31a5ace"/>
+		<rom name="Puyo Puyo (Japan) (Track 14).bin" size="19124112" crc="67ef0178" sha1="647d41c82fff80296ec0f7313a133da12e035073"/>
+		<rom name="Puyo Puyo (Japan) (Track 15).bin" size="3311616" crc="2a91ec58" sha1="5ce0f9c1a6ff11df7782794e0d3ade606be1e2e3"/>
+		<rom name="Puyo Puyo (Japan) (Track 16).bin" size="3302208" crc="3612b231" sha1="441f30fe535b65c5299e9711c0ed610afc2fe6e7"/>
+		<rom name="Puyo Puyo (Japan) (Track 17).bin" size="25876704" crc="0c0cba16" sha1="e4cca55ba7927f9b1e65745e54c5e9754fae2a3e"/>
+		<rom name="Puyo Puyo (Japan) (Track 18).bin" size="101531136" crc="cd750a90" sha1="53d3f1b587c94454ee7adcaa3797c4672dbbf50b"/>
+		<rom name="Puyo Puyo (Japan).cue" size="2021" crc="1f79c59e" sha1="fe3c1138a20370ebd20683aca452492eee2720a9"/>
 		-->
 		<description>Puyo Puyo</description>
 		<year>1994</year>
 		<publisher>CRI</publisher>
+		<info name="alt_title" value="ぷよぷよ" />
 		<info name="release" value="199403xx" />
 		<part name="cdrom" interface="fmt_cdrom">
 			<diskarea name="cdrom">
-				<disk name="puyo puyo" sha1="46c7dcf22b24e4438370cfee7e75d6c075f0b26a" />
+				<disk name="puyo puyo (japan)" sha1="1916f4a364a42c9ea81e0deaa971bcebc1d8f49d" />
 			</diskarea>
 		</part>
 	</software>
@@ -7942,6 +8629,7 @@ User/save disks that can be created from the game itself are not included.
 		<description>Puzznic</description>
 		<year>1990</year>
 		<publisher>ビング (Ving)</publisher>
+		<info name="alt_title" value="パズニック" />
 		<info name="release" value="199007xx" />
 		<part name="cdrom" interface="fmt_cdrom">
 			<diskarea name="cdrom">
@@ -7969,7 +8657,6 @@ User/save disks that can be created from the game itself are not included.
 		</part>
 	</software>
 
-	<!-- works well on fmtmarty, keyboard seems to interfere with movements on fmtowns -->
 	<software name="raiden">
 		<!--
 		Origin: Neo Kobe Collection
@@ -7981,6 +8668,7 @@ User/save disks that can be created from the game itself are not included.
 		<description>Raiden Densetsu / Raiden Trad</description>
 		<year>1991</year>
 		<publisher>KID</publisher>
+		<info name="alt_title" value="雷電伝説" />
 		<info name="release" value="199111xx" />
 		<part name="cdrom" interface="fmt_cdrom">
 			<diskarea name="cdrom">
@@ -8000,6 +8688,7 @@ User/save disks that can be created from the game itself are not included.
 		<description>Ikazuchi no Senshi Raidy</description>
 		<year>1994</year>
 		<publisher>ジックス (ZyX)</publisher>
+		<info name="alt_title" value="雷の戦士ライディ" />
 		<part name="cdrom" interface="fmt_cdrom">
 			<diskarea name="cdrom">
 				<disk name="ikazuchi no senshi raidy" sha1="da27ad369e6a084c2b9b17401c9ccd7b7f5370cf" />
@@ -8027,6 +8716,7 @@ User/save disks that can be created from the game itself are not included.
 		<description>Ikazuchi no Senshi Raidy 2</description>
 		<year>1996</year>
 		<publisher>ジックス (ZyX)</publisher>
+		<info name="alt_title" value="雷の戦士ライディ2" />
 		<info name="release" value="199603xx" />
 		<part name="cdrom" interface="fmt_cdrom">
 			<diskarea name="cdrom">
@@ -8047,6 +8737,7 @@ User/save disks that can be created from the game itself are not included.
 		<description>Railroad Tycoon</description>
 		<year>1993</year>
 		<publisher>マイクロプローズジャパン (MicroProse Japan)</publisher>
+		<info name="alt_title" value="レイルロードタイクーン" />
 		<info name="release" value="199312xx" />
 		<part name="cdrom" interface="fmt_cdrom">
 			<diskarea name="cdrom">
@@ -8066,6 +8757,7 @@ User/save disks that can be created from the game itself are not included.
 		<description>Rance III - Leazas Kanraku</description>
 		<year>1992</year>
 		<publisher>アリスソフト (AliceSoft)</publisher>
+		<info name="alt_title" value="Rance3 リーザス陥落" />
 		<info name="release" value="199205xx" />
 		<part name="cdrom" interface="fmt_cdrom">
 			<diskarea name="cdrom">
@@ -8085,6 +8777,7 @@ User/save disks that can be created from the game itself are not included.
 		<description>Rance IV - Kyoudan no Isan</description>
 		<year>1994</year>
 		<publisher>アリスソフト (AliceSoft)</publisher>
+		<info name="alt_title" value="Rance4 ～教団の遺産～" />
 		<info name="release" value="199403xx" />
 		<part name="flop1" interface="floppy_3_5">
 			<feature name="part_id" value="Boot Disk" />
@@ -8110,6 +8803,7 @@ User/save disks that can be created from the game itself are not included.
 		<description>Rance 4.1 - Okusuri Koujou wo Sukue!</description>
 		<year>1995</year>
 		<publisher>アリスソフト (AliceSoft)</publisher>
+		<info name="alt_title" value="ランス4.1～お薬工場を救え！～" />
 		<info name="release" value="199512xx" />
 		<info name="usage" value="Requires HDD installation"/>
 		<part name="cdrom" interface="fmt_cdrom">
@@ -8130,6 +8824,7 @@ User/save disks that can be created from the game itself are not included.
 		<description>Rance 4.2 - Angel-gumi</description>
 		<year>1995</year>
 		<publisher>アリスソフト (AliceSoft)</publisher>
+		<info name="alt_title" value="ランス4.2～エンジェル組～" />
 		<info name="release" value="199512xx" />
 		<info name="usage" value="Requires HDD installation"/>
 		<part name="cdrom" interface="fmt_cdrom">
@@ -8147,9 +8842,10 @@ User/save disks that can be created from the game itself are not included.
 		<rom name="Ravenloft.img" size="391255200" crc="9daeb746" sha1="5f1f36bd5ec99d5518f71a9c1fa6690e725f72bd"/>
 		<rom name="Ravenloft.sub" size="15969600" crc="bed73e3c" sha1="22c0d57c6248bec8f1664801af259fd69c407b13"/>
 		-->
-		<description>Ravenloft</description>
+		<description>Ravenloft - Aku no Keshin</description>
 		<year>1995</year>
 		<publisher>ビング (Ving)</publisher>
+		<info name="alt_title" value="Ｒａｖｅｎｌｏｆｔ ～悪の化身～" />
 		<info name="release" value="199504xx" />
 		<part name="cdrom" interface="fmt_cdrom">
 			<diskarea name="cdrom">
@@ -8169,6 +8865,7 @@ User/save disks that can be created from the game itself are not included.
 		<description>Rayxanber</description>
 		<year>1990</year>
 		<publisher>データウエスト (Data West)</publisher>
+		<info name="alt_title" value="ライザンバー" />
 		<info name="release" value="199004xx" />
 		<part name="cdrom" interface="fmt_cdrom">
 			<diskarea name="cdrom">
@@ -8192,6 +8889,7 @@ User/save disks that can be created from the game itself are not included.
 		<description>Rainbow Islands Extra</description>
 		<year>1992</year>
 		<publisher>ビング (Ving)</publisher>
+		<info name="alt_title" value="レインボーアイランド EXTRA" />
 		<info name="release" value="199204xx" />
 		<part name="cdrom" interface="fmt_cdrom">
 			<diskarea name="cdrom">
@@ -8211,6 +8909,7 @@ User/save disks that can be created from the game itself are not included.
 		<description>Regional Power II</description>
 		<year>1992</year>
 		<publisher>コスモス・コンピュータ (Cosmos Computer)</publisher>
+		<info name="alt_title" value="レジオナルパワー2" />
 		<info name="release" value="199209xx" />
 		<part name="cdrom" interface="fmt_cdrom">
 			<diskarea name="cdrom">
@@ -8234,6 +8933,7 @@ User/save disks that can be created from the game itself are not included.
 		<description>Rejection - Den-no Senshi</description>
 		<year>1992</year>
 		<publisher>シュールド・ウェーブ (Sur De Wave)</publisher>
+		<info name="alt_title" value="電脳少女" />
 		<info name="release" value="199212xx" />
 		<part name="cdrom" interface="fmt_cdrom">
 			<diskarea name="cdrom">
@@ -8253,6 +8953,7 @@ User/save disks that can be created from the game itself are not included.
 		<description>Return to Zork</description>
 		<year>1994</year>
 		<publisher>データウエスト (Data West)</publisher>
+		<info name="alt_title" value="リターントゥゾーク" />
 		<info name="release" value="199410xx" />
 		<info name="usage" value="Requires HDD installation"/>
 		<part name="cdrom" interface="fmt_cdrom">
@@ -8273,6 +8974,7 @@ User/save disks that can be created from the game itself are not included.
 		<description>Ring Out!!</description>
 		<year>1995</year>
 		<publisher>ジックス (ZyX)</publisher>
+		<info name="alt_title" value="リングアウト" />
 		<info name="release" value="199506xx" />
 		<part name="cdrom" interface="fmt_cdrom">
 			<diskarea name="cdrom">
@@ -8310,6 +9012,7 @@ User/save disks that can be created from the game itself are not included.
 		<description>Rocket Ranger</description>
 		<year>1990</year>
 		<publisher>ポニーキャニオン (Pony Canyon)</publisher>
+		<info name="release" value="199005xx" />
 		<part name="cdrom" interface="fmt_cdrom">
 			<diskarea name="cdrom">
 				<disk name="rocket ranger" sha1="faee63cd159d68240360149887702560dedff780" />
@@ -8328,6 +9031,7 @@ User/save disks that can be created from the game itself are not included.
 		<description>Ryuutouden</description>
 		<year>1994</year>
 		<publisher>富士通 (Fujitsu)</publisher>
+		<info name="alt_title" value="龍闘伝" />
 		<info name="release" value="199005xx" />
 		<part name="cdrom" interface="fmt_cdrom">
 			<diskarea name="cdrom">
@@ -8368,6 +9072,7 @@ User/save disks that can be created from the game itself are not included.
 		<year>1990</year>
 		<publisher>光栄 (Koei)</publisher>
 		<info name="alt_title" value="三国志II" />
+		<info name="release" value="199006xx" />
 		<part name="flop1" interface="floppy_3_5">
 			<dataarea name="flop" size="1281968">
 				<rom name="sango2.d88" size="1281968" crc="40a7015d" sha1="79ae6709d7ee2c7f35c07f967e032f790565278b" offset="000000" />
@@ -8391,6 +9096,7 @@ User/save disks that can be created from the game itself are not included.
 		<year>1992</year>
 		<publisher>光栄 (Koei)</publisher>
 		<info name="alt_title" value="三国志Ⅲ" />
+		<info name="release" value="199206xx" />
 		<part name="cdrom" interface="fmt_cdrom">
 			<diskarea name="cdrom">
 				<disk name="sangoku3" sha1="613793fb3915b6a3b2b2634584604bd50a9151d8" />
@@ -8428,6 +9134,7 @@ User/save disks that can be created from the game itself are not included.
 		<description>Sayaka &amp; Miho</description>
 		<year>1994</year>
 		<publisher>フェアリーテール (Fairytale)</publisher>
+		<info name="alt_title" value="沙也香＆美穂" />
 		<info name="release" value="199409xx" />
 		<part name="cdrom" interface="fmt_cdrom">
 			<diskarea name="cdrom">
@@ -8462,13 +9169,32 @@ User/save disks that can be created from the game itself are not included.
 		<rom name="Scavenger 4.img" size="528847200" crc="177b3405" sha1="5738450c2f212634341c4d540c5350ec1c60f35a"/>
 		<rom name="Scavenger 4.sub" size="21585600" crc="e8c0f2a6" sha1="b6a7f3f5d155f80d813fad9228f3be2eebdb0227"/>
 		-->
-		<description>Scavenger 4</description>
+		<description>Scavenger 4 (1993-12-16)</description>
 		<year>1993</year>
 		<publisher>富士通 (Fujitsu)</publisher>
-		<info name="release" value="199311xx" />
+		<info name="alt_title" value="スカベンジャー４" />
+		<info name="release" value="199312xx" />
 		<part name="cdrom" interface="fmt_cdrom">
 			<diskarea name="cdrom">
 				<disk name="scavenger 4" sha1="a78fff2a22e995afb7cbadcec026caf65ac3490e" />
+			</diskarea>
+		</part>
+	</software>
+
+	<software name="scav4o" cloneof="scav4" supported="no">
+		<!--
+		Origin: redump.org
+		<rom name="Scavenger 4 (Japan).bin" size="528844848" crc="e4962f69" sha1="082ab4b5b471bc9f8b9a890b8d8fbdf0aece8f0d"/>
+		<rom name="Scavenger 4 (Japan).cue" size="108" crc="3c19efb7" sha1="d37833c44a86d1512d5def2683c3a08995d5bab2"/>
+		-->
+		<description>Scavenger 4 (1993-11-11)</description>
+		<year>1993</year>
+		<publisher>富士通 (Fujitsu)</publisher>
+		<info name="alt_title" value="スカベンジャー４" />
+		<info name="release" value="199311xx" />
+		<part name="cdrom" interface="fmt_cdrom">
+			<diskarea name="cdrom">
+				<disk name="scavenger 4 (japan)" sha1="cd3018dc93541f3fd6489d51e5b3ad88c1cdd4a4" />
 			</diskarea>
 		</part>
 	</software>
@@ -8484,6 +9210,8 @@ User/save disks that can be created from the game itself are not included.
 		<description>Scholar Movie Magazine</description>
 		<year>1994</year>
 		<publisher>King Records</publisher>
+		<info name="alt_title" value="スコラ MOVIE MAGAZINE" />
+		<info name="release" value="199403xx" />
 		<part name="flop1" interface="floppy_3_5">
 			<feature name="part_id" value="Boot Disk" />
 			<dataarea name="flop" size="1261568">
@@ -8508,6 +9236,7 @@ User/save disks that can be created from the game itself are not included.
 		<description>Schwarzschild</description>
 		<year>1991</year>
 		<publisher>工画堂 (Kogado)</publisher>
+		<info name="alt_title" value="シュヴァルツシルト" />
 		<info name="release" value="199111xx" />
 		<part name="flop1" interface="floppy_3_5">
 			<feature name="part_id" value="Game Disk" />
@@ -8524,19 +9253,28 @@ User/save disks that can be created from the game itself are not included.
 
 	<software name="schwarz4">
 		<!--
-		Origin: Neo Kobe Collection
-		<rom name="Schwarzschild IV.ccd" size="2662" crc="f86ebf8a" sha1="2cd8c8a109d20a725d33d304bf0a50dda3626f09"/>
-		<rom name="Schwarzschild IV.cue" size="472" crc="404c6385" sha1="de575b8a57fcc3671f6839e63f780ffec6cd5eb1"/>
-		<rom name="Schwarzschild IV.img" size="607168800" crc="0ed248e9" sha1="3cf6f3ec265c8378fee2699d26ec401c05dfd905"/>
-		<rom name="Schwarzschild IV.sub" size="24782400" crc="3c6b5926" sha1="9d434f932bbcc63b49afb7b1b5c4e86786a6cafd"/>
+		Origin: redump.org
+		<rom name="Schwarzschild IV - The Cradle End (Japan) (Track 01).bin" size="20815200" crc="3e101f85" sha1="1eaee58ca791993c1c75b91a2a72c3bb7f37e9f9"/>
+		<rom name="Schwarzschild IV - The Cradle End (Japan) (Track 02).bin" size="9349200" crc="29c775d4" sha1="a932a8c2b1d96c0d3288729d0262efaa486fbc6e"/>
+		<rom name="Schwarzschild IV - The Cradle End (Japan) (Track 03).bin" size="58917600" crc="4febb8bd" sha1="9d9c93307053c79926095bcf36bb3049d3c4584e"/>
+		<rom name="Schwarzschild IV - The Cradle End (Japan) (Track 04).bin" size="59094000" crc="335f4f19" sha1="7a48ca61da0c632d1f8e2db6b07578caa5ec9f63"/>
+		<rom name="Schwarzschild IV - The Cradle End (Japan) (Track 05).bin" size="81320400" crc="5ea12ab7" sha1="4033d0d57af0b97040cf8d73dca07d69f44dea6b"/>
+		<rom name="Schwarzschild IV - The Cradle End (Japan) (Track 06).bin" size="76381200" crc="439756a8" sha1="85d917d234171ebbf644091298b059ba59d60df6"/>
+		<rom name="Schwarzschild IV - The Cradle End (Japan) (Track 07).bin" size="112190400" crc="78084d7d" sha1="847b3806448270d572d06e3bf8bb8dae02c860c0"/>
+		<rom name="Schwarzschild IV - The Cradle End (Japan) (Track 08).bin" size="50803200" crc="b113d211" sha1="1eac86c55e49f43eb3624a987870d33cc220263a"/>
+		<rom name="Schwarzschild IV - The Cradle End (Japan) (Track 09).bin" size="49039200" crc="c79b7df2" sha1="b889cd06b47afdcfb323b9e119c96334821a237f"/>
+		<rom name="Schwarzschild IV - The Cradle End (Japan) (Track 10).bin" size="51332400" crc="bc4c2f78" sha1="c15a059b10acd1af132a590a2e92114f12406298"/>
+		<rom name="Schwarzschild IV - The Cradle End (Japan) (Track 11).bin" size="37926000" crc="3922209d" sha1="f1e77d4e8bb97c42711e8b00cc0c367e13c195a4"/>
+		<rom name="Schwarzschild IV - The Cradle End (Japan).cue" size="1501" crc="f997968b" sha1="7cee9b6ca00c953b7c30b82116afa927972f20f2"/>
 		-->
-		<description>Schwarzschild IV</description>
+		<description>Schwarzschild IV - The Cradle End</description>
 		<year>1993</year>
 		<publisher>工画堂 (Kogado)</publisher>
+		<info name="alt_title" value="シュヴァルツシルト4 THE CRADLE END" />
 		<info name="release" value="199312xx" />
 		<part name="cdrom" interface="fmt_cdrom">
 			<diskarea name="cdrom">
-				<disk name="schwarzschild iv" sha1="813091a4a7fe385da8014f6d3e22a06dc5ec275e" />
+				<disk name="schwarzschild iv - the cradle end (japan)" sha1="6c7e0fba4eaa4d68f375976ff25eaa62bad2bce5" />
 			</diskarea>
 		</part>
 	</software>
@@ -8572,6 +9310,8 @@ User/save disks that can be created from the game itself are not included.
 		<description>Shangrlia 2</description>
 		<year>1993</year>
 		<publisher>エルフ (Elf)</publisher>
+		<info name="alt_title" value="シャングリラ2" />
+		<info name="release" value="199410xx" />
 		<part name="cdrom" interface="fmt_cdrom">
 			<diskarea name="cdrom">
 				<disk name="shangrlia 2" sha1="b774d673f3a49912e6ed857865b8a7a99b368b06" />
@@ -8590,6 +9330,7 @@ User/save disks that can be created from the game itself are not included.
 		<description>Sherlock Holmes - Consulting Detective</description>
 		<year>1991</year>
 		<publisher>富士通 (Fujitsu)</publisher>
+		<info name="alt_title" value="シャーロックホームズの探偵講座" />
 		<info name="release" value="199106xx" />
 		<part name="cdrom" interface="fmt_cdrom">
 			<diskarea name="cdrom">
@@ -8609,6 +9350,7 @@ User/save disks that can be created from the game itself are not included.
 		<description>Shinc</description>
 		<year>1993</year>
 		<publisher>リビドー (Libido)</publisher>
+		<info name="alt_title" value="シンク" />
 		<info name="release" value="199304xx" />
 		<part name="cdrom" interface="fmt_cdrom">
 			<diskarea name="cdrom">
@@ -8628,6 +9370,8 @@ User/save disks that can be created from the game itself are not included.
 		<description>Shounen Magazine History</description>
 		<year>1992</year>
 		<publisher>ダットジャパン (Datt Japan)</publisher>
+		<info name="alt_title" value="少年マガジンヒストリー" />
+		<info name="release" value="199211xx" />
 		<part name="cdrom" interface="fmt_cdrom">
 			<diskarea name="cdrom">
 				<disk name="shounen magazine history" sha1="f453ee25f0f0da3ca23bbbd09632aa63f7a7d2fb" />
@@ -8644,6 +9388,7 @@ User/save disks that can be created from the game itself are not included.
 		<description>SimAnt</description>
 		<year>1993</year>
 		<publisher>イマジニア (Imagineer)</publisher>
+		<info name="alt_title" value="シムアント" />
 		<info name="release" value="199302xx" />
 		<part name="cdrom" interface="fmt_cdrom">
 			<diskarea name="cdrom">
@@ -8663,6 +9408,7 @@ User/save disks that can be created from the game itself are not included.
 		<description>SimCity</description>
 		<year>1990</year>
 		<publisher>富士通 (Fujitsu)</publisher>
+		<info name="alt_title" value="シムシティ" />
 		<info name="release" value="199003xx" />
 		<part name="cdrom" interface="fmt_cdrom">
 			<diskarea name="cdrom">
@@ -8684,6 +9430,7 @@ User/save disks that can be created from the game itself are not included.
 		<description>SimCity 2000</description>
 		<year>1994</year>
 		<publisher>富士通 (Fujitsu)</publisher>
+		<info name="alt_title" value="シムシティ2000" />
 		<info name="release" value="199412xx" />
 		<part name="cdrom" interface="fmt_cdrom">
 			<diskarea name="cdrom">
@@ -8703,6 +9450,7 @@ User/save disks that can be created from the game itself are not included.
 		<description>SimEarth</description>
 		<year>1991</year>
 		<publisher>イマジニア (Imagineer)</publisher>
+		<info name="alt_title" value="シムアース" />
 		<info name="release" value="199109xx" />
 		<part name="cdrom" interface="fmt_cdrom">
 			<diskarea name="cdrom">
@@ -8722,6 +9470,7 @@ User/save disks that can be created from the game itself are not included.
 		<description>SimFarm</description>
 		<year>1994</year>
 		<publisher>富士通 (Fujitsu)</publisher>
+		<info name="alt_title" value="シムファーム" />
 		<info name="release" value="199409xx" />
 		<part name="cdrom" interface="fmt_cdrom">
 			<diskarea name="cdrom">
@@ -8732,19 +9481,78 @@ User/save disks that can be created from the game itself are not included.
 
 	<software name="silentmb">
 		<!--
-		Origin: Neo Kobe Collection
-		<rom name="Silent Mobius.ccd" size="10273" crc="a34a97b0" sha1="40cb769bed333c61e1835ce9cfdf3efba572c9a3"/>
-		<rom name="Silent Mobius.cue" size="3958" crc="a5277b33" sha1="8a8783a886b0394d825da2e13d0355430ecd7a37"/>
-		<rom name="Silent Mobius.img" size="605407152" crc="5af4a4ff" sha1="c7684e48842f3d341d0326e04a0804fee8e8d84a"/>
-		<rom name="Silent Mobius.sub" size="24710496" crc="504653ce" sha1="db15498da30eecb41b6f5b845a52b71cbc4b956a"/>
+		Origin: redump.org
+		<rom name="Silent Moebius - Case - Titanic (Japan) (Track 01).bin" size="105840000" crc="1583ce5a" sha1="252fdf9bc6bcf119919772f331e44e18a421d779"/>
+		<rom name="Silent Moebius - Case - Titanic (Japan) (Track 02).bin" size="11491872" crc="56eafc2a" sha1="692cc0fd5dcf6019de5e84a328d7ca270c64b403"/>
+		<rom name="Silent Moebius - Case - Titanic (Japan) (Track 03).bin" size="14410704" crc="dc993f71" sha1="9b6c00a1d7e49eca20e8152913fa52eec34024a0"/>
+		<rom name="Silent Moebius - Case - Titanic (Japan) (Track 04).bin" size="11807040" crc="87884ab9" sha1="a5304b1e6967e111354dda9fac0f42c692b2b075"/>
+		<rom name="Silent Moebius - Case - Titanic (Japan) (Track 05).bin" size="11701200" crc="4aeb995f" sha1="c56220bf609f730e78c5ac4ed5d388df213833b1"/>
+		<rom name="Silent Moebius - Case - Titanic (Japan) (Track 06).bin" size="7086576" crc="4d44782d" sha1="c788862499d0bc27ba068a87a82fd797182a0d79"/>
+		<rom name="Silent Moebius - Case - Titanic (Japan) (Track 07).bin" size="7119504" crc="6fd16982" sha1="1e399c5f36bd1742aded586913b4597b61a1189f"/>
+		<rom name="Silent Moebius - Case - Titanic (Japan) (Track 08).bin" size="6968976" crc="02b7edd2" sha1="51d9cbac86ab9b9491d08d8ade7d2e97b5e3cad9"/>
+		<rom name="Silent Moebius - Case - Titanic (Japan) (Track 09).bin" size="6837264" crc="1ac775a2" sha1="0ac0e630d9f366d3e8bbe10fe763e03eae59b01f"/>
+		<rom name="Silent Moebius - Case - Titanic (Japan) (Track 10).bin" size="9019920" crc="a41e5287" sha1="831429cf346eff54746eb98a2a247b65264aba80"/>
+		<rom name="Silent Moebius - Case - Titanic (Japan) (Track 11).bin" size="13077120" crc="4adee65b" sha1="7eba7c2929fed5a06fd38460ab75278b837150c2"/>
+		<rom name="Silent Moebius - Case - Titanic (Japan) (Track 12).bin" size="4410000" crc="d1b6478e" sha1="f03a7a97fbb837ee694467892032e7dbcdfe5fa4"/>
+		<rom name="Silent Moebius - Case - Titanic (Japan) (Track 13).bin" size="2876496" crc="27de2990" sha1="26ba6c0c525d7b9b7bf927d43f7c35cd28835711"/>
+		<rom name="Silent Moebius - Case - Titanic (Japan) (Track 14).bin" size="2904720" crc="4868ac80" sha1="9e3d2d6388e3d843e7372237fde2a6d64ff5916b"/>
+		<rom name="Silent Moebius - Case - Titanic (Japan) (Track 15).bin" size="2728320" crc="f30b80db" sha1="67f79e6da6fb87a06b92a00e71b694ce1d929fa6"/>
+		<rom name="Silent Moebius - Case - Titanic (Japan) (Track 16).bin" size="8542464" crc="1fe62160" sha1="046204153171d5fad9e994881268d1d26b9806ea"/>
+		<rom name="Silent Moebius - Case - Titanic (Japan) (Track 17).bin" size="10226496" crc="c3d2f6f2" sha1="6b18822cd4c169e10b9f0cda756c6ef70770982b"/>
+		<rom name="Silent Moebius - Case - Titanic (Japan) (Track 18).bin" size="10306464" crc="fc03fdef" sha1="93304f1f71a9059bc59dc5100b308ff548d08663"/>
+		<rom name="Silent Moebius - Case - Titanic (Japan) (Track 19).bin" size="14260176" crc="4889e913" sha1="041b5aec198ce829eeafea60696ef6ef0df7332f"/>
+		<rom name="Silent Moebius - Case - Titanic (Japan) (Track 20).bin" size="3798480" crc="3fd4f59c" sha1="28dbe86df80b12c059515e1b043863a3cf2813c7"/>
+		<rom name="Silent Moebius - Case - Titanic (Japan) (Track 21).bin" size="24571344" crc="6b16b087" sha1="95d45e8187d04fcbf2801f40091b5201914ea29b"/>
+		<rom name="Silent Moebius - Case - Titanic (Japan) (Track 22).bin" size="8102640" crc="00773b75" sha1="e031a4ec98e4e585a0a29b0b2103033d7a763d7d"/>
+		<rom name="Silent Moebius - Case - Titanic (Japan) (Track 23).bin" size="3716160" crc="c88e834f" sha1="852b9a29286f7e6a75005fc0f1d0920907072138"/>
+		<rom name="Silent Moebius - Case - Titanic (Japan) (Track 24).bin" size="24213840" crc="8dd7f6e7" sha1="6f6d87881d1585803356e1b9a1e2ffcd2274eaff"/>
+		<rom name="Silent Moebius - Case - Titanic (Japan) (Track 25).bin" size="3951360" crc="f096ea5f" sha1="bd0f6218261b0695a0f2ef35640d76a360e89aa2"/>
+		<rom name="Silent Moebius - Case - Titanic (Japan) (Track 26).bin" size="4076016" crc="9ac55355" sha1="dfda1cd22919ac8eecb2c66ab082718863757dea"/>
+		<rom name="Silent Moebius - Case - Titanic (Japan) (Track 27).bin" size="4097184" crc="7071cb64" sha1="d76973567ad51c035061c60ac6186ff64acc2104"/>
+		<rom name="Silent Moebius - Case - Titanic (Japan) (Track 28).bin" size="6134016" crc="1c2f3c26" sha1="7b4f9649ea4b19eceac15bd67bd59d8338e53434"/>
+		<rom name="Silent Moebius - Case - Titanic (Japan) (Track 29).bin" size="5919984" crc="5ea0ca80" sha1="8e7c94cd1b17ce76c8f6c66e5297e6c76387c304"/>
+		<rom name="Silent Moebius - Case - Titanic (Japan) (Track 30).bin" size="4899216" crc="cee92a50" sha1="9de431f5f08b36093fa79ddc74192c715323374a"/>
+		<rom name="Silent Moebius - Case - Titanic (Japan) (Track 31).bin" size="6385680" crc="fff6ba93" sha1="50ca7b7787499d29d1ffcf0c5be875cb37831793"/>
+		<rom name="Silent Moebius - Case - Titanic (Japan) (Track 32).bin" size="6491520" crc="154a5a7d" sha1="03be9cd5f59c1ca0f948966869095c268c3a6857"/>
+		<rom name="Silent Moebius - Case - Titanic (Japan) (Track 33).bin" size="4238304" crc="c18a3d60" sha1="530c14b90c4adad05cb5ea1defeb4206bf5f7476"/>
+		<rom name="Silent Moebius - Case - Titanic (Japan) (Track 34).bin" size="4123056" crc="3d811450" sha1="19066b6666daa514bdad7e7c6c309f1b12398271"/>
+		<rom name="Silent Moebius - Case - Titanic (Japan) (Track 35).bin" size="3956064" crc="0c114943" sha1="21eb36a75302cf09e69614ceb6fe04e578a6ebf3"/>
+		<rom name="Silent Moebius - Case - Titanic (Japan) (Track 36).bin" size="4087776" crc="73c85c86" sha1="fbe36b70a392b157f73c955bd9a3bee212a43273"/>
+		<rom name="Silent Moebius - Case - Titanic (Japan) (Track 37).bin" size="4508784" crc="02d2824c" sha1="e6fd00641b8565eb7766aa585c0dd4dd8b24ed15"/>
+		<rom name="Silent Moebius - Case - Titanic (Japan) (Track 38).bin" size="38768016" crc="53002253" sha1="2a06c219e66db02ec1925c2f8c89fe334515ab94"/>
+		<rom name="Silent Moebius - Case - Titanic (Japan) (Track 39).bin" size="11736480" crc="09336cf5" sha1="fac55b95d6c55ee43341e3202ab39583f3f1d724"/>
+		<rom name="Silent Moebius - Case - Titanic (Japan) (Track 40).bin" size="21031584" crc="c0771301" sha1="fdb7cf3babeb68ac5493a7766ebb502e09f3598e"/>
+		<rom name="Silent Moebius - Case - Titanic (Japan) (Track 41).bin" size="6592656" crc="f366d850" sha1="9717048932b66c18b6666d7e082bb4a56eccaabb"/>
+		<rom name="Silent Moebius - Case - Titanic (Japan) (Track 42).bin" size="1945104" crc="94eada6f" sha1="61807498beb7bbf15da6eabb83da8acf89e9de1e"/>
+		<rom name="Silent Moebius - Case - Titanic (Japan) (Track 43).bin" size="6221040" crc="70b7253b" sha1="e29e4e16beef6c16da161019938cf8cbba11677f"/>
+		<rom name="Silent Moebius - Case - Titanic (Japan) (Track 44).bin" size="1975680" crc="855ace76" sha1="674756ed6037773da241638bc4123c75c639be44"/>
+		<rom name="Silent Moebius - Case - Titanic (Japan) (Track 45).bin" size="6268080" crc="b5dbc895" sha1="b8018a49435e142405223fc90be0703030e426b6"/>
+		<rom name="Silent Moebius - Case - Titanic (Japan) (Track 46).bin" size="1928640" crc="1313c5e4" sha1="d15363b6adf0a2e1c8a32877315c943b924b0e6d"/>
+		<rom name="Silent Moebius - Case - Titanic (Japan) (Track 47).bin" size="6362160" crc="99a6b8e8" sha1="1dae8aa5ca52106667b748a30549d621e78ffc27"/>
+		<rom name="Silent Moebius - Case - Titanic (Japan) (Track 48).bin" size="2116800" crc="9448e645" sha1="14c5ae7ed0721c450717ba5418a3926ab5e4e28b"/>
+		<rom name="Silent Moebius - Case - Titanic (Japan) (Track 49).bin" size="4652256" crc="4720d42a" sha1="f98e6a93580da05cafe7442775a4a9efd37b3e6f"/>
+		<rom name="Silent Moebius - Case - Titanic (Japan) (Track 50).bin" size="6460944" crc="c100c436" sha1="617d6bea89947a0b44137010a1ffc650e16e5c0d"/>
+		<rom name="Silent Moebius - Case - Titanic (Japan) (Track 51).bin" size="3739680" crc="ca5082b7" sha1="69b4375dd70ba6426b2d481b2def47c37659b511"/>
+		<rom name="Silent Moebius - Case - Titanic (Japan) (Track 52).bin" size="4080720" crc="f58c93ca" sha1="2fb9b2f93bdc745c163e021dbd9c40738c4becff"/>
+		<rom name="Silent Moebius - Case - Titanic (Japan) (Track 53).bin" size="15259776" crc="0b2388dd" sha1="4e391f2cfb43d677ee9bef7396c788ccd332014c"/>
+		<rom name="Silent Moebius - Case - Titanic (Japan) (Track 54).bin" size="1705200" crc="a9073e9e" sha1="6152f394e64835d31b5e7fcc818668d46cb4e452"/>
+		<rom name="Silent Moebius - Case - Titanic (Japan) (Track 55).bin" size="9036384" crc="7a8d86f8" sha1="ebad24fe0e922f984d3d23de4c302cafb7899a24"/>
+		<rom name="Silent Moebius - Case - Titanic (Japan) (Track 56).bin" size="27977040" crc="1a566f76" sha1="d3ac35c222c149f2c03feee80e7eded02a5a8b3f"/>
+		<rom name="Silent Moebius - Case - Titanic (Japan) (Track 57).bin" size="13465200" crc="c379b56e" sha1="ff25a6d7b40b2f7cb87f653fd93dcb63812531b2"/>
+		<rom name="Silent Moebius - Case - Titanic (Japan) (Track 58).bin" size="9885456" crc="60c08ff6" sha1="a6e3b10d928e077668ed60d5faafb55d364b5086"/>
+		<rom name="Silent Moebius - Case - Titanic (Japan) (Track 59).bin" size="3139920" crc="0d66bc9d" sha1="a814c8bcd454f12267b50022be7e2e7d6c8e025d"/>
+		<rom name="Silent Moebius - Case - Titanic (Japan) (Track 60).bin" size="3445680" crc="f93d6a05" sha1="6df0da34ed6bca99567f489ca60794527a8e633f"/>
+		<rom name="Silent Moebius - Case - Titanic (Japan) (Track 61).bin" size="8725920" crc="2f0a3577" sha1="667337d684db91152feaf94c146d972f81e7a2c2"/>
+		<rom name="Silent Moebius - Case - Titanic (Japan).cue" size="8179" crc="49547777" sha1="1af78be06b6d5caf7a2819cec1fe168940fbc9d4"/>
 		-->
 		<description>Silent Möbius</description>
 		<year>1991</year>
 		<publisher>ガイナックス (Gainax)</publisher>
+		<info name="alt_title" value="サイレントメビウス" />
 		<info name="release" value="199109xx" />
 		<part name="cdrom" interface="fmt_cdrom">
 			<diskarea name="cdrom">
-				<disk name="silent mobius" sha1="87a224ff3507b6ce8bc14a8f3a860ba07dcbabdf" />
+				<disk name="silent moebius - case - titanic (japan)" sha1="a9e5cb2f1968e381d704b6e37b5c1a55cc50375f" />
 			</diskarea>
 		</part>
 	</software>
@@ -8760,6 +9568,7 @@ User/save disks that can be created from the game itself are not included.
 		<description>Sotsugyou '93 - Graduation</description>
 		<year>1993</year>
 		<publisher>JHV</publisher>
+		<info name="alt_title" value="卒業 '９３" />
 		<info name="release" value="199310xx" />
 		<part name="flop1" interface="floppy_3_5">
 			<feature name="part_id" value="Play Disk" />
@@ -8776,19 +9585,59 @@ User/save disks that can be created from the game itself are not included.
 
 	<software name="splatth">
 		<!--
-		Origin: Neo Kobe Collection
-		<rom name="Splatterhouse.ccd" size="9427" crc="efe69150" sha1="ac8051d7d200dae6685681963e3fe0511d619ed6"/>
-		<rom name="Splatterhouse.cue" size="2593" crc="21229fde" sha1="00fbc0e25575ea4dd77c37a127d27068f6dbb46d"/>
-		<rom name="Splatterhouse.img" size="649857600" crc="9ceca1c0" sha1="95f708cb900a08f92d5ea31d89470b23bb173c91"/>
-		<rom name="Splatterhouse.sub" size="26524800" crc="6c0d9c84" sha1="db16a94f7012d6bb962a422513f8ef4b2e33ca9d"/>
+		Origin: redump.org
+		<rom name="Splatterhouse (Japan) (Track 01).bin" size="20462400" crc="4e110419" sha1="f0910f45104f5007f1a13fb155c0003359bfdf46"/>
+		<rom name="Splatterhouse (Japan) (Track 02).bin" size="4939200" crc="74fb2f36" sha1="5d6a8db4a80139453bed939856c5e57dcac80443"/>
+		<rom name="Splatterhouse (Japan) (Track 03).bin" size="4762800" crc="04513f6d" sha1="38b03eee8b2335f2aa59d53ef3303826ec78888d"/>
+		<rom name="Splatterhouse (Japan) (Track 04).bin" size="10936800" crc="7548ed12" sha1="b7e04186c59c6ec5be61d86e06073841054ff5c6"/>
+		<rom name="Splatterhouse (Japan) (Track 05).bin" size="4410000" crc="b3bce617" sha1="40fd96706842cd5fe4d0d9ce70b838b5c5ca5311"/>
+		<rom name="Splatterhouse (Japan) (Track 06).bin" size="26636400" crc="2dc67b0b" sha1="7541b63de7b1d3ee15e7907080d954ba29d506e1"/>
+		<rom name="Splatterhouse (Japan) (Track 07).bin" size="8820000" crc="f490ab49" sha1="7ad5d9338bb8d05350e2b7950a2ada387b139503"/>
+		<rom name="Splatterhouse (Japan) (Track 08).bin" size="2116800" crc="90792f1c" sha1="25efe560da153995ff582ddc953c2e01c1b88c75"/>
+		<rom name="Splatterhouse (Japan) (Track 09).bin" size="15346800" crc="cd3f060e" sha1="c33a68bbcce4dea24589071445c7a1fb1f6c1481"/>
+		<rom name="Splatterhouse (Japan) (Track 10).bin" size="19933200" crc="71c2ecf3" sha1="aa53c9cc47f57e18220aad0ec0d269984601f6de"/>
+		<rom name="Splatterhouse (Japan) (Track 11).bin" size="17992800" crc="26019ce1" sha1="2149f04606f3af683a20eb700a63daeb1c6a9e75"/>
+		<rom name="Splatterhouse (Japan) (Track 12).bin" size="18698400" crc="b4b90ecf" sha1="a8089a602a0076d2b70481768d5ad553fe0a71ce"/>
+		<rom name="Splatterhouse (Japan) (Track 13).bin" size="18698400" crc="9005cb38" sha1="bd4c1bebd5a429835c4ca61f61a69e08184ca76f"/>
+		<rom name="Splatterhouse (Japan) (Track 14).bin" size="4235952" crc="bc774975" sha1="20014d75c85bcb1ba594a0a52661532c755f7940"/>
+		<rom name="Splatterhouse (Japan) (Track 15).bin" size="1938048" crc="2c4ebfe5" sha1="461deacce5ced4feab1becd226e6cf3f82cd6234"/>
+		<rom name="Splatterhouse (Japan) (Track 16).bin" size="33692400" crc="3f358c51" sha1="01c33e1e49359edfb2ef2c083c1817b929d2b4c0"/>
+		<rom name="Splatterhouse (Japan) (Track 17).bin" size="24519600" crc="6e956f80" sha1="50a0762a8960367df28df6be7e5c5f831accddc8"/>
+		<rom name="Splatterhouse (Japan) (Track 18).bin" size="1940400" crc="2fcd80c8" sha1="eda70f8161d415674b11f794d6bf1c4fefe14a1a"/>
+		<rom name="Splatterhouse (Japan) (Track 19).bin" size="17992800" crc="f21feeea" sha1="0a2cff62a1bf70b2981e4c3630d46c6b72db707d"/>
+		<rom name="Splatterhouse (Japan) (Track 20).bin" size="13053600" crc="2ae64ae2" sha1="baad3d94ba0bb71c9ea4716f5605c5a51ae25579"/>
+		<rom name="Splatterhouse (Japan) (Track 21).bin" size="20638800" crc="3dee0786" sha1="de76a432135738093b039ab11460bfdba7fa980c"/>
+		<rom name="Splatterhouse (Japan) (Track 22).bin" size="34221600" crc="5360715a" sha1="3081dca3589747b13bdfc397f36280ac9f6c46d5"/>
+		<rom name="Splatterhouse (Japan) (Track 23).bin" size="7232400" crc="9335dc2e" sha1="20b32bccb8cf39dc6a4cbb5a78acb4b7cac6eb85"/>
+		<rom name="Splatterhouse (Japan) (Track 24).bin" size="16052400" crc="addb0e28" sha1="98dca7b425e191eb97d38a2c8d3636c355e9671a"/>
+		<rom name="Splatterhouse (Japan) (Track 25).bin" size="1940400" crc="46cf0742" sha1="2d326dacae423fc9d65461660c0a7c51ec989312"/>
+		<rom name="Splatterhouse (Japan) (Track 26).bin" size="31046400" crc="12169935" sha1="69d1936a6d34d3f841c03bf5650936be05fe5b2e"/>
+		<rom name="Splatterhouse (Japan) (Track 27).bin" size="4586400" crc="b3666811" sha1="e832a43fa1fdb5101a01c6d772e668a70b1471c8"/>
+		<rom name="Splatterhouse (Japan) (Track 28).bin" size="2469600" crc="019f3cdb" sha1="aab86004bed754a3de6bfa5d95f87637e5727fdd"/>
+		<rom name="Splatterhouse (Japan) (Track 29).bin" size="30340800" crc="afe4c268" sha1="e3ebd949e8d505883d47fd9e925892bf511d413b"/>
+		<rom name="Splatterhouse (Japan) (Track 30).bin" size="5997600" crc="0928755c" sha1="46ee95b3d4d7cb8576062fbe51f4e9dd02bfea62"/>
+		<rom name="Splatterhouse (Japan) (Track 31).bin" size="25754400" crc="03cee54a" sha1="9da63602324f8a151022eeb468746fa4b098a53e"/>
+		<rom name="Splatterhouse (Japan) (Track 32).bin" size="1764000" crc="cfd8d046" sha1="ea0f46d5f4b362c905221a24f8b4a837173d1d58"/>
+		<rom name="Splatterhouse (Japan) (Track 33).bin" size="27342000" crc="b41119e1" sha1="172911a47daf553b7ba0818341607962252e6d0e"/>
+		<rom name="Splatterhouse (Japan) (Track 34).bin" size="21873600" crc="957e44f2" sha1="7753d370411c8fabff1806409ff56dc19cdf7199"/>
+		<rom name="Splatterhouse (Japan) (Track 35).bin" size="1940400" crc="5e2dd35b" sha1="03c471eb684d8b7cd37a0c27d0f99ca6f1a853ce"/>
+		<rom name="Splatterhouse (Japan) (Track 36).bin" size="18169200" crc="c23573b1" sha1="8265ae8bb8c026ec4ea1e1c4b1d827fdf49eef58"/>
+		<rom name="Splatterhouse (Japan) (Track 37).bin" size="1940400" crc="790cb868" sha1="d99b649cebb001b1744f21b8d78ed7fb19322046"/>
+		<rom name="Splatterhouse (Japan) (Track 38).bin" size="24166800" crc="27fa445c" sha1="0d1338b9eb8ee9ebbab827fc6f9481140bb3483d"/>
+		<rom name="Splatterhouse (Japan) (Track 39).bin" size="3880800" crc="8f9f6502" sha1="7d2b89c874c7873eb7c25f02624c8d195ed314bb"/>
+		<rom name="Splatterhouse (Japan) (Track 40).bin" size="43747200" crc="aed8a449" sha1="04388d484ded57f6ea4d3927e3ee9210154b4e8a"/>
+		<rom name="Splatterhouse (Japan) (Track 41).bin" size="3528000" crc="b9bfb654" sha1="825c2cede60ec8e83914c7c7826437f9be361424"/>
+		<rom name="Splatterhouse (Japan) (Track 42).bin" size="50097600" crc="3fd4de5c" sha1="1c4a1d41115c795a5cbec89a6d7e3be353166c19"/>
+		<rom name="Splatterhouse (Japan).cue" size="4877" crc="a7c63215" sha1="c625a4e01367fc37bcfca83945a56ab973f40afa"/>
 		-->
 		<description>Splatterhouse</description>
 		<year>1992</year>
 		<publisher>ビング (Ving)</publisher>
+		<info name="alt_title" value="スプラッターハウス" />
 		<info name="release" value="199206xx" />
 		<part name="cdrom" interface="fmt_cdrom">
 			<diskarea name="cdrom">
-				<disk name="splatterhouse" sha1="ddd73172589f840d6feb5f55c17a011f2aa87c77" />
+				<disk name="splatterhouse (japan)" sha1="77c982a3fa1417cba7ce705a455e212e7c342dcd" />
 			</diskarea>
 		</part>
 	</software>
@@ -8824,6 +9673,7 @@ User/save disks that can be created from the game itself are not included.
 		<description>Super Odyssey</description>
 		<year>1989</year>
 		<publisher>ウェーブトレイン (Wave Train)</publisher>
+		<info name="alt_title" value="スーパーオデッセイ" />
 		<info name="release" value="198912xx" />
 		<part name="cdrom" interface="fmt_cdrom">
 			<diskarea name="cdrom">
@@ -8880,6 +9730,7 @@ User/save disks that can be created from the game itself are not included.
 		<description>Shadow of the Beast - Mashou no Okite</description>
 		<year>1991</year>
 		<publisher>ビクター音楽産業 (Victor Musical Industries)</publisher>
+		<info name="alt_title" value="シャドー・オブ・ザ・ビースト 魔性の掟" />
 		<info name="release" value="199109xx" />
 		<part name="cdrom" interface="fmt_cdrom">
 			<diskarea name="cdrom">
@@ -8911,6 +9762,7 @@ User/save disks that can be created from the game itself are not included.
 		<description>Shadow of the Beast II - Juushin no Jubaku</description>
 		<year>1993</year>
 		<publisher>ビクター音楽産業 (Victor Musical Industries)</publisher>
+		<info name="alt_title" value="シャドー・オブ・ザ・ビースト2 獣神の呪縛" />
 		<info name="release" value="199306xx" />
 		<part name="cdrom" interface="fmt_cdrom">
 			<diskarea name="cdrom">
@@ -8930,6 +9782,7 @@ User/save disks that can be created from the game itself are not included.
 		<description>Super Real Mahjong PII &amp; PIII</description>
 		<year>1992</year>
 		<publisher>ビング (Ving)</publisher>
+		<info name="alt_title" value="スーパーリアル麻雀PII＆PIII" />
 		<info name="release" value="199204xx" />
 		<part name="cdrom" interface="fmt_cdrom">
 			<diskarea name="cdrom">
@@ -8947,8 +9800,8 @@ User/save disks that can be created from the game itself are not included.
 		<description>Super Real Mahjong PII &amp; PIII +</description>
 		<year>1993</year>
 		<publisher>ビング (Ving)</publisher>
-		<info name="release" value="199303xx" />
 		<info name="alt_title" value="スーパーリアル麻雀PII＆PIII＋" />
+		<info name="release" value="199303xx" />
 		<part name="cdrom" interface="fmt_cdrom">
 			<diskarea name="cdrom">
 				<disk name="super real mahjong pii &amp; piii +" sha1="771be8adecbb5798bb1cd79942854937c337c262" />
@@ -8967,6 +9820,7 @@ User/save disks that can be created from the game itself are not included.
 		<description>Super Real Mahjong PIV</description>
 		<year>1994</year>
 		<publisher>ビング (Ving)</publisher>
+		<info name="alt_title" value="スーパーリアル麻雀PIV" />
 		<info name="release" value="199405xx" />
 		<part name="cdrom" interface="fmt_cdrom">
 			<diskarea name="cdrom">
@@ -8984,6 +9838,7 @@ User/save disks that can be created from the game itself are not included.
 		<description>Space Rogue</description>
 		<year>1990</year>
 		<publisher>ウェーブトレイン (Wave Train)</publisher>
+		<info name="alt_title" value="スペースローグ" />
 		<info name="release" value="199007xx" />
 		<part name="cdrom" interface="fmt_cdrom">
 			<diskarea name="cdrom">
@@ -9005,6 +9860,7 @@ User/save disks that can be created from the game itself are not included.
 		<description>Space Rogue (no disc check)</description>
 		<year>1990</year>
 		<publisher>ウェーブトレイン (Wave Train)</publisher>
+		<info name="alt_title" value="スペースローグ" />
 		<info name="release" value="199007xx" />
 		<part name="cdrom" interface="fmt_cdrom">
 			<diskarea name="cdrom">
@@ -9024,6 +9880,7 @@ User/save disks that can be created from the game itself are not included.
 		<description>Super Street Fighter II - The New Challengers</description>
 		<year>1994</year>
 		<publisher>カプコン (Capcom)</publisher>
+		<info name="alt_title" value="スーパーストリートファイターII" />
 		<info name="release" value="199410xx" />
 		<part name="cdrom" interface="fmt_cdrom">
 			<diskarea name="cdrom">
@@ -9059,6 +9916,7 @@ User/save disks that can be created from the game itself are not included.
 		<description>Super Shanghai - Dragon's Eye</description>
 		<year>1991</year>
 		<publisher>HOT・B</publisher>
+		<info name="alt_title" value="スーパー上海ドラゴンズアイ" />
 		<info name="release" value="199111xx" />
 		<part name="cdrom" interface="fmt_cdrom">
 			<diskarea name="cdrom">
@@ -9079,6 +9937,7 @@ User/save disks that can be created from the game itself are not included.
 		<description>Samurai Spirits</description>
 		<year>1995</year>
 		<publisher>JHV</publisher>
+		<info name="alt_title" value="サムライスピリッツ" />
 		<info name="release" value="199509xx" />
 		<part name="flop1" interface="floppy_3_5">
 			<feature name="part_id" value="Boot Disk" />
@@ -9104,6 +9963,7 @@ User/save disks that can be created from the game itself are not included.
 		<description>Super Shooting Towns</description>
 		<year>1991</year>
 		<publisher>アモルファス (Amorphous)</publisher>
+		<info name="alt_title" value="スーパーシューティングTOWNS" />
 		<info name="release" value="199112xx" />
 		<part name="cdrom" interface="fmt_cdrom">
 			<diskarea name="cdrom">
@@ -9123,6 +9983,7 @@ User/save disks that can be created from the game itself are not included.
 		<description>Star Cruiser II - The Odysseus Project</description>
 		<year>1994</year>
 		<publisher>JHV</publisher>
+		<info name="alt_title" value="スタークルーザーII" />
 		<info name="release" value="199404xx" />
 		<part name="flop1" interface="floppy_3_5">
 			<feature name="part_id" value="User Disk" />
@@ -9148,6 +10009,7 @@ User/save disks that can be created from the game itself are not included.
 		<description>Strike Commander</description>
 		<year>1994</year>
 		<publisher>エレクトロニック・アーツ・ビクター (Electronic Arts Victor)</publisher>
+		<info name="alt_title" value="ストライク・コマンダー" />
 		<info name="release" value="199408xx" />
 		<part name="cdrom" interface="fmt_cdrom">
 			<diskarea name="cdrom">
@@ -9167,6 +10029,7 @@ User/save disks that can be created from the game itself are not included.
 		<description>Strike Commander Plus</description>
 		<year>1995</year>
 		<publisher>エレクトロニック・アーツ・ビクター (Electronic Arts Victor)</publisher>
+		<info name="alt_title" value="ストライク・コマンダーPLUS" />
 		<info name="release" value="199504xx" />
 		<part name="cdrom" interface="fmt_cdrom">
 			<diskarea name="cdrom">
@@ -9183,9 +10046,10 @@ User/save disks that can be created from the game itself are not included.
 		<rom name="Stronghold.img" size="10231200" crc="d6331e64" sha1="aa09a63e13b2a7ebbc2aab50636e74d524eaef11"/>
 		<rom name="Stronghold.sub" size="417600" crc="85c37af1" sha1="278b6233d247a22ff5702f40c5cb2fccddbb46e6"/>
 		-->
-		<description>Stronghold</description>
+		<description>Stronghold - Koutei no Yousai</description>
 		<year>1994</year>
 		<publisher>ビング (Ving)</publisher>
+		<info name="alt_title" value="ストロングホールド ～皇帝の要塞～" />
 		<info name="release" value="199406xx" />
 		<part name="cdrom" interface="fmt_cdrom">
 			<diskarea name="cdrom">
@@ -9204,6 +10068,7 @@ User/save disks that can be created from the game itself are not included.
 		<description>Suikoden - Tenmei no Chikai</description>
 		<year>1990</year>
 		<publisher>光栄 (Koei)</publisher>
+		<info name="alt_title" value="水滸伝・天命の誓い" />
 		<info name="release" value="199002xx" />
 		<part name="cdrom" interface="fmt_cdrom">
 			<diskarea name="cdrom">
@@ -9225,6 +10090,7 @@ User/save disks that can be created from the game itself are not included.
 		<description>Syndicate</description>
 		<year>1994</year>
 		<publisher>エレクトロニック・アーツ・ビクター (Electronic Arts Victor)</publisher>
+		<info name="alt_title" value="シンジケート" />
 		<info name="release" value="199407xx" />
 		<part name="cdrom" interface="fmt_cdrom">
 			<diskarea name="cdrom">
@@ -9251,6 +10117,35 @@ User/save disks that can be created from the game itself are not included.
 		</part>
 	</software>
 
+	<software name="martych">
+		<!--
+		Origin: redump.org
+		<rom name="Taiken Shiyou! Marty Channel (Japan) (Track 01).bin" size="211327200" crc="ad7b961c" sha1="471e0eb616fdbe75e1febac4e26188a02196ed48"/>
+		<rom name="Taiken Shiyou! Marty Channel (Japan) (Track 02).bin" size="12025776" crc="4e7dc8b7" sha1="2075a4b5956a2886b99379264b6e2d9bf2f042d9"/>
+		<rom name="Taiken Shiyou! Marty Channel (Japan) (Track 03).bin" size="6522096" crc="7601977b" sha1="1dc37f00fe8d5cdf31d5df1862a99e87e62b5969"/>
+		<rom name="Taiken Shiyou! Marty Channel (Japan) (Track 04).bin" size="6444480" crc="4fa5d777" sha1="9f95e5e5159224719ea80df5d45b512598d44c2e"/>
+		<rom name="Taiken Shiyou! Marty Channel (Japan) (Track 05).bin" size="48216000" crc="db956c56" sha1="6fd2d4d50d857ad7803627440035ed32ab1a31e6"/>
+		<rom name="Taiken Shiyou! Marty Channel (Japan) (Track 06).bin" size="11289600" crc="98e6fbda" sha1="1319801d6a9558f343f6b0e260cc49550d0e1dea"/>
+		<rom name="Taiken Shiyou! Marty Channel (Japan) (Track 07).bin" size="25225200" crc="bc51be3c" sha1="d776ff3b341d835cc3f9fba78431991d0d0ad09e"/>
+		<rom name="Taiken Shiyou! Marty Channel (Japan) (Track 08).bin" size="43218000" crc="8c2cf5eb" sha1="52e517929a8bc7c30893bc08cd4695e98c57d080"/>
+		<rom name="Taiken Shiyou! Marty Channel (Japan) (Track 09).bin" size="11818800" crc="e6bc779b" sha1="6454a1f1fb84e0337c2ad40c8c160cf63373ab1c"/>
+		<rom name="Taiken Shiyou! Marty Channel (Japan) (Track 10).bin" size="5292000" crc="f0adeda6" sha1="d68af02f4f95fc0a4cfa9222cf033519a548310d"/>
+		<rom name="Taiken Shiyou! Marty Channel (Japan) (Track 11).bin" size="33339600" crc="4708305e" sha1="51f2c748119371fcd881bb5f5f40df46f08bcc9d"/>
+		<rom name="Taiken Shiyou! Marty Channel (Japan) (Track 12).bin" size="2822400" crc="914895af" sha1="dbc172e071c1a07832f32ccf631b48732b55f788"/>
+		<rom name="Taiken Shiyou! Marty Channel (Japan).cue" size="1577" crc="e57f5ab7" sha1="51efc40bee392914b1ba386368e6a5d7a50287d7"/>
+		-->
+		<description>Taiken Shiyou! Marty Channel</description>
+		<year>1993</year>
+		<publisher>富士通 (Fujitsu)</publisher>
+		<info name="alt_title" value="体験しよう！マーティチャンネル" />
+		<info name="release" value="199302xx" />
+		<part name="cdrom" interface="fmt_cdrom">
+			<diskarea name="cdrom">
+				<disk name="taiken shiyou! marty channel (japan)" sha1="d1577643f6bdf903c22877f7de6c450c5bed8730" />
+			</diskarea>
+		</part>
+	</software>
+
 	<software name="taikoris">
 		<!--
 		Origin: Neo Kobe Collection
@@ -9262,6 +10157,7 @@ User/save disks that can be created from the game itself are not included.
 		<description>Taikou Risshiden</description>
 		<year>1992</year>
 		<publisher>光栄 (Koei)</publisher>
+		<info name="alt_title" value="太閤立志伝" />
 		<info name="release" value="199205xx" />
 		<part name="cdrom" interface="fmt_cdrom">
 			<diskarea name="cdrom">
@@ -9281,6 +10177,7 @@ User/save disks that can be created from the game itself are not included.
 		<description>Takamizawa Kyosuke - Nekketsu!! Kyouiku Kenshuu</description>
 		<year>1995</year>
 		<publisher>ジックス (ZyX)</publisher>
+		<info name="alt_title" value="高見沢恭介 熱血！！教育研修" />
 		<info name="release" value="199501xx" />
 		<part name="cdrom" interface="fmt_cdrom">
 			<diskarea name="cdrom">
@@ -9300,6 +10197,7 @@ User/save disks that can be created from the game itself are not included.
 		<description>Tanjou - Debut</description>
 		<year>1994</year>
 		<publisher>データウエスト (Data West)</publisher>
+		<info name="alt_title" value="誕生 ～Ｄｅｂｕｔ～" />
 		<info name="release" value="199404xx" />
 		<part name="flop1" interface="floppy_3_5">
 			<feature name="part_id" value="Key Disk" />
@@ -9325,6 +10223,7 @@ User/save disks that can be created from the game itself are not included.
 		<description>Tatsujin Ou</description>
 		<year>1993</year>
 		<publisher>ビング (Ving)</publisher>
+		<info name="alt_title" value="達人王" />
 		<info name="release" value="199304xx" />
 		<part name="cdrom" interface="fmt_cdrom">
 			<diskarea name="cdrom">
@@ -9418,6 +10317,7 @@ User/save disks that can be created from the game itself are not included.
 		<description>Tenka Gomen</description>
 		<year>1994</year>
 		<publisher>アートディンク (Artdink)</publisher>
+		<info name="alt_title" value="天下御免" />
 		<info name="release" value="199406xx" />
 		<part name="flop1" interface="floppy_3_5">
 			<feature name="part_id" value="System Disk" />
@@ -9440,9 +10340,11 @@ User/save disks that can be created from the game itself are not included.
 		<rom name="The Date.img" size="409777200" crc="0a716a03" sha1="488cb7fb1d8bec43aab898415db7db5d34d4e357"/>
 		<rom name="The Date.sub" size="16725600" crc="976e582f" sha1="8338e4a5208abbdb6cbd9c1da80920628853e8e9"/>
 		-->
-		<description>The Date</description>
+		<description>The Date - Kore de Kanojo wa Boku no Mono!</description>
 		<year>1990</year>
 		<publisher>JAMP</publisher>
+		<info name="alt_title" value="ザ・デート これで彼女はぼくのもの！" />
+		<info name="release" value="199002xx" />
 		<part name="cdrom" interface="fmt_cdrom">
 			<diskarea name="cdrom">
 				<disk name="the date" sha1="da0894abef4eb1a88c0aff9731f1121464014741" />
@@ -9462,6 +10364,7 @@ User/save disks that can be created from the game itself are not included.
 		<description>The Horde</description>
 		<year>1995</year>
 		<publisher>アローマイクロテックス (Arrow Micro-Techs)</publisher>
+		<info name="alt_title" value="ザ・ホード" />
 		<info name="release" value="199504xx" />
 		<info name="usage" value="Requires HDD installation"/>
 		<part name="cdrom" interface="fmt_cdrom">
@@ -9492,6 +10395,7 @@ User/save disks that can be created from the game itself are not included.
 		<description>Titan</description>
 		<year>1989</year>
 		<publisher>富士通 (Fujitsu)</publisher>
+		<info name="alt_title" value="タイタン" />
 		<info name="release" value="198911xx" />
 		<part name="cdrom" interface="fmt_cdrom">
 			<diskarea name="cdrom">
@@ -9511,6 +10415,7 @@ User/save disks that can be created from the game itself are not included.
 		<description>The New Zealand Story</description>
 		<year>1989</year>
 		<publisher>ビング (Ving)</publisher>
+		<info name="alt_title" value="ニュージーランドストーリー" />
 		<info name="release" value="198908xx" />
 		<part name="cdrom" interface="fmt_cdrom">
 			<diskarea name="cdrom">
@@ -9528,9 +10433,10 @@ User/save disks that can be created from the game itself are not included.
 		<rom name="Tokio.img" size="675506160" crc="4b68b3fe" sha1="26595128de9848ad53ae565a282d7308ea642b50"/>
 		<rom name="Tokio.sub" size="27571680" crc="2c0b48b3" sha1="ba27324c973cff63f27892795cf9b4fc6471a780"/>
 		-->
-		<description>Tokio</description>
+		<description>Tokio - Tokyo-to Dai-24-ku</description>
 		<year>1992</year>
 		<publisher>アートディンク (Artdink)</publisher>
+		<info name="alt_title" value="トキオ 東京都第24区" />
 		<info name="release" value="199212xx" />
 		<part name="flop1" interface="floppy_3_5">
 			<feature name="part_id" value="System Disk" />
@@ -9557,6 +10463,7 @@ User/save disks that can be created from the game itself are not included.
 		<description>Toushin Toshi II</description>
 		<year>1995</year>
 		<publisher>アリスソフト (AliceSoft)</publisher>
+		<info name="alt_title" value="闘神都市II" />
 		<info name="release" value="199504xx" />
 		<info name="usage" value="Requires HDD installation"/>
 		<part name="cdrom" interface="fmt_cdrom">
@@ -9577,6 +10484,7 @@ User/save disks that can be created from the game itself are not included.
 		<description>Toushin Toshi II - Soshite, Sorekara...</description>
 		<year>1995</year>
 		<publisher>アリスソフト (AliceSoft)</publisher>
+		<info name="alt_title" value="闘神都市II そして、それから…" />
 		<info name="release" value="199512xx" />
 		<info name="usage" value="Requires HDD installation"/>
 		<part name="cdrom" interface="fmt_cdrom">
@@ -9596,6 +10504,7 @@ User/save disks that can be created from the game itself are not included.
 		<description>The Queen of Duellist</description>
 		<year>1993</year>
 		<publisher>アグミックス (Agumix)</publisher>
+		<info name="alt_title" value="クイーン・オブ・デュエリスト" />
 		<info name="release" value="199306xx" />
 		<part name="flop1" interface="floppy_3_5">
 			<feature name="part_id" value="User Disk" />
@@ -9619,6 +10528,7 @@ User/save disks that can be created from the game itself are not included.
 		<description>The Queen of Duellist Gaiden Alpha Light</description>
 		<year>1994</year>
 		<publisher>アグミックス (Agumix)</publisher>
+		<info name="alt_title" value="クイーン・オブ・デュエリスト外伝＋外伝αLIGHT" />
 		<info name="release" value="199404xx" />
 		<part name="flop1" interface="floppy_3_5">
 			<feature name="part_id" value="User Disk" />
@@ -9660,10 +10570,11 @@ User/save disks that can be created from the game itself are not included.
 		<rom name="Image.img" size="608556480" crc="c82fca28" sha1="bf441c81187a2c1e8bff0b96b10e99e3841d12e0"/>
 		<rom name="Image.sub" size="24839040" crc="13770962" sha1="e8cc6e3bad3f0d26eb730f41208358e789ba0114"/>
 		-->
-		<description>That's Toukou - Natsu no Daitokushuugou</description>
+		<description>That's Toukou - Natsu no Daitokushuu</description>
 		<year>1994?</year>
 		<publisher>バーディーソフト (Birdy Soft)</publisher>
-		<info name="alt_title" value="THAT'S 投稿 夏の大特集号" />
+		<info name="alt_title" value="THAT'S 投稿 夏の大特集" />
+		<info name="release" value="199409xx" />
 		<part name="cdrom" interface="fmt_cdrom">
 			<diskarea name="cdrom">
 				<disk name="toukoun" sha1="d5f81c0d5fc7dd61573ea09233ef83aa98d6c6b6" />
@@ -9680,6 +10591,7 @@ User/save disks that can be created from the game itself are not included.
 		<description>Turbo Out Run</description>
 		<year>1989</year>
 		<publisher>CRI</publisher>
+		<info name="alt_title" value="ターボアウトラン" />
 		<info name="release" value="198912xx" />
 		<part name="cdrom" interface="fmt_cdrom">
 			<diskarea name="cdrom">
@@ -9720,6 +10632,7 @@ User/save disks that can be created from the game itself are not included.
 		<description>Towns Magazine Vol. 2</description>
 		<year>1994</year>
 		<publisher>富士通 (Fujitsu)</publisher>
+		<info name="release" value="199411xx" />
 		<part name="cdrom1" interface="fmt_cdrom">
 			<diskarea name="cdrom">
 				<disk name="towns magazine vol. 2 (disc 1)" sha1="65d208a41d0089eb11f7607e0a78fba60fbdbaa4" />
@@ -9741,6 +10654,7 @@ User/save disks that can be created from the game itself are not included.
 		<description>TownsPAINT V1.1 L20</description>
 		<year>1990</year>
 		<publisher>富士通 (Fujitsu)</publisher>
+		<info name="release" value="199411xx" />
 		<part name="cdrom" interface="fmt_cdrom">
 			<diskarea name="cdrom">
 				<disk name="townspaint" sha1="ac943aca97da28d24c07ed0c7118b15bc237befb" />
@@ -9759,6 +10673,7 @@ User/save disks that can be created from the game itself are not included.
 		<description>Trigger</description>
 		<year>1994</year>
 		<publisher>ジックス (ZyX)</publisher>
+		<info name="alt_title" value="トリガー" />
 		<info name="release" value="199406xx" />
 		<part name="cdrom" interface="fmt_cdrom">
 			<diskarea name="cdrom">
@@ -9789,9 +10704,10 @@ User/save disks that can be created from the game itself are not included.
 		<rom name="track13.bin" size="6879600" crc="c2191ed4" sha1="7bf96bff35197f435dc5f248f538097073cd06db"/>
 		<rom name="tunnels and trolls.cue" size="1710" crc="a7fbc735" sha1="32aa1fe7d45d852f53ac99a8906296677d22faa9"/>
 		-->
-		<description>Tunnels and Trolls</description>
+		<description>Tunnels and Trolls - Khazan no Senshi-tachi</description>
 		<year>1990</year>
 		<publisher>スタークラフト (Starcraft)</publisher>
+		<info name="alt_title" value="トンネルズ・アンド・トロールズ カザンの戦士たち" />
 		<info name="release" value="199011xx" />
 		<part name="cdrom" interface="fmt_cdrom">
 			<diskarea name="cdrom">
@@ -9809,6 +10725,7 @@ User/save disks that can be created from the game itself are not included.
 		<description>Ultima IV - Quest of the Avatar</description>
 		<year>1992</year>
 		<publisher>富士通 (Fujitsu)</publisher>
+		<info name="alt_title" value="ウルティマIV Quest of the Avatar" />
 		<info name="release" value="199204xx" />
 		<part name="cdrom" interface="fmt_cdrom">
 			<diskarea name="cdrom">
@@ -9828,6 +10745,7 @@ User/save disks that can be created from the game itself are not included.
 		<description>Ultima V - Warriors of Destiny</description>
 		<year>1992</year>
 		<publisher>富士通 (Fujitsu)</publisher>
+		<info name="alt_title" value="ウルティマV Warriors of Destiny" />
 		<info name="release" value="199208xx" />
 		<part name="cdrom" interface="fmt_cdrom">
 			<diskarea name="cdrom">
@@ -9847,6 +10765,7 @@ User/save disks that can be created from the game itself are not included.
 		<description>Ultima VI - The False Prophet</description>
 		<year>1991</year>
 		<publisher>富士通 (Fujitsu)</publisher>
+		<info name="alt_title" value="ウルティマVI 偽りの予言者" />
 		<info name="release" value="199112xx" />
 		<part name="cdrom" interface="fmt_cdrom">
 			<diskarea name="cdrom">
@@ -9866,6 +10785,7 @@ User/save disks that can be created from the game itself are not included.
 		<description>Ultima Trilogy I-II-III</description>
 		<year>1990</year>
 		<publisher>富士通 (Fujitsu)</publisher>
+		<info name="alt_title" value="ウルティマトリロジー Ⅰ・Ⅱ・Ⅲ" />
 		<info name="release" value="199010xx" />
 		<part name="cdrom" interface="fmt_cdrom">
 			<diskarea name="cdrom">
@@ -9885,6 +10805,7 @@ User/save disks that can be created from the game itself are not included.
 		<description>Ultima Underworld - The Stygian Abyss</description>
 		<year>1993</year>
 		<publisher>エレクトロニック・アーツ・ビクター (Electronic Arts Victor)</publisher>
+		<info name="alt_title" value="ウルティマアンダーワールド" />
 		<info name="release" value="199312xx" />
 		<part name="cdrom" interface="fmt_cdrom">
 			<diskarea name="cdrom">
@@ -9895,21 +10816,18 @@ User/save disks that can be created from the game itself are not included.
 
 	<software name="ultuw2">
 		<!--
-		Origin: Neo Kobe Collection
-		<rom name="Ultima Underworld 2.mdf" size="67140192" crc="2f005f36" sha1="fbdd8df467050403bc7047239418284ab4173847"/>
-		<rom name="Ultima Underworld 2.mds" size="486" crc="ad984380" sha1="204aeb2f016ed8f5375cbaca9b6ca2afb935056b"/>
-
-		*after conversion with IsoBuster+EAC *
-		<rom name="ultima underworld 2.bin" size="67140192" crc="2f005f36" sha1="fbdd8df467050403bc7047239418284ab4173847"/>
-		<rom name="ultima underworld 2.cue" size="80" crc="d6b87614" sha1="1f12d627578632ef2e9e7667e27cf1ebb7744263"/>
+		Origin: redump.org
+		<rom name="Ultima Underworld II - Labyrinth of Worlds (Japan).bin" size="67140192" crc="2f005f36" sha1="fbdd8df467050403bc7047239418284ab4173847"/>
+		<rom name="Ultima Underworld II - Labyrinth of Worlds (Japan).cue" size="139" crc="b7c67200" sha1="b4622c782b6e94a0c63831414299466de14a8e41"/>
 		-->
 		<description>Ultima Underworld II - Labyrinth of Worlds</description>
 		<year>1995</year>
 		<publisher>エレクトロニック・アーツ・ビクター (Electronic Arts Victor)</publisher>
+		<info name="alt_title" value="ウルティマアンダーワールド2" />
 		<info name="release" value="199502xx" />
 		<part name="cdrom" interface="fmt_cdrom">
 			<diskarea name="cdrom">
-				<disk name="ultima underworld 2" sha1="dd93343e311ad7fe5f933a004b346ff6429855f5" />
+				<disk name="ultima underworld ii - labyrinth of worlds (japan)" sha1="fd21d3240408860955089b1ccd5b2f3a15c498cc" />
 			</diskarea>
 		</part>
 	</software>
@@ -9922,9 +10840,10 @@ User/save disks that can be created from the game itself are not included.
 		<rom name="Uwaki na Anata.img" size="329837424" crc="83d4184b" sha1="472e75e5585630c6b3c9da876f51427f76b01de9"/>
 		<rom name="Uwaki na Anata.sub" size="13462752" crc="e93ef365" sha1="022b39a867b7f36d042822d5b982e41f43c0359f"/>
 		-->
-		<description>Uwaki na Anata</description>
+		<description>Uwaki na Anata - Switch wo Irete</description>
 		<year>1994</year>
 		<publisher>HOP</publisher>
+		<info name="alt_title" value="浮気なあ・な・たスイッチをい・れ・て" />
 		<info name="release" value="199406xx" />
 		<part name="flop1" interface="floppy_3_5">
 			<feature name="part_id" value="Boot Disk" />
@@ -9951,6 +10870,7 @@ User/save disks that can be created from the game itself are not included.
 		<description>Vain Dream</description>
 		<year>1993</year>
 		<publisher>グローディア (Glodia)</publisher>
+		<info name="alt_title" value="ヴェインドリーム" />
 		<info name="release" value="199304xx" />
 		<part name="flop1" interface="floppy_3_5">
 			<feature name="part_id" value="System Disk" />
@@ -9977,6 +10897,7 @@ User/save disks that can be created from the game itself are not included.
 		<description>Vain Dream II</description>
 		<year>1993</year>
 		<publisher>グローディア (Glodia)</publisher>
+		<info name="alt_title" value="ヴェインドリームII" />
 		<info name="release" value="199309xx" />
 		<part name="flop1" interface="floppy_3_5">
 			<feature name="part_id" value="System Disk" />
@@ -10003,6 +10924,7 @@ User/save disks that can be created from the game itself are not included.
 		<description>Vastness - Kuukyo no Ikenie-tachi</description>
 		<year>1993</year>
 		<publisher>CD Bros.</publisher>
+		<info name="alt_title" value="ヴアーストニス 空虚の生贄達" />
 		<info name="release" value="199309xx" />
 		<part name="cdrom" interface="fmt_cdrom">
 			<diskarea name="cdrom">
@@ -10024,6 +10946,7 @@ User/save disks that can be created from the game itself are not included.
 		<description>Veil of Darkness</description>
 		<year>1994</year>
 		<publisher>ビング (Ving)</publisher>
+		<info name="alt_title" value="ヴェイル オブ ダークネス ～呪われた予言～" />
 		<info name="release" value="199408xx" />
 		<part name="cdrom" interface="fmt_cdrom">
 			<diskarea name="cdrom">
@@ -10041,6 +10964,8 @@ User/save disks that can be created from the game itself are not included.
 		<description>Video Koubou V1.3 L10</description>
 		<year>1993</year>
 		<publisher>富士通 (Fujitsu)</publisher>
+		<info name="alt_title" value="ビデオ工房 V1.3 L10" />
+		<info name="release" value="199402xx" />
 		<part name="flop1" interface="floppy_3_5">
 		<!--
 		Note from the dumper:
@@ -10073,6 +10998,7 @@ User/save disks that can be created from the game itself are not included.
 		<description>Viewpoint</description>
 		<year>1993</year>
 		<publisher>ビング (Ving)</publisher>
+		<info name="alt_title" value="ビューポイント" />
 		<info name="release" value="199311xx" />
 		<part name="cdrom" interface="fmt_cdrom">
 			<diskarea name="cdrom">
@@ -10136,6 +11062,7 @@ User/save disks that can be created from the game itself are not included.
 		<description>Virtuacall</description>
 		<year>1995</year>
 		<publisher>フェアリーテール (Fairytale)</publisher>
+		<info name="alt_title" value="バーチャコール" />
 		<info name="release" value="199503xx" />
 		<part name="flop1" interface="floppy_3_5">
 			<feature name="part_id" value="Save Disk" />
@@ -10174,6 +11101,7 @@ User/save disks that can be created from the game itself are not included.
 		<description>The Visitor</description>
 		<year>1989</year>
 		<publisher>富士通 (Fujitsu)</publisher>
+		<info name="alt_title" value="ビジター 訪問者" />
 		<info name="release" value="198909xx" />
 		<part name="cdrom" interface="fmt_cdrom">
 			<diskarea name="cdrom">
@@ -10191,6 +11119,7 @@ User/save disks that can be created from the game itself are not included.
 		<description>Volfied</description>
 		<year>1991</year>
 		<publisher>ビング (Ving)</publisher>
+		<info name="alt_title" value="ヴォルフィード" />
 		<info name="release" value="199112xx" />
 		<part name="cdrom" interface="fmt_cdrom">
 			<diskarea name="cdrom">
@@ -10210,6 +11139,7 @@ User/save disks that can be created from the game itself are not included.
 		<description>Wakoku Seiha Den</description>
 		<year>1994</year>
 		<publisher>Mic</publisher>
+		<info name="alt_title" value="倭国制覇伝" />
 		<info name="release" value="199404xx" />
 		<part name="cdrom" interface="fmt_cdrom">
 			<diskarea name="cdrom">
@@ -10245,6 +11175,7 @@ User/save disks that can be created from the game itself are not included.
 		<description>Wing Commander Armada</description>
 		<year>1995</year>
 		<publisher>エレクトロニック・アーツ・ビクター (Electronic Arts Victor)</publisher>
+		<info name="alt_title" value="ウイングコマンダーアルマダ" />
 		<info name="release" value="199507xx" />
 		<info name="usage" value="Requires HDD installation and 8 MB of RAM"/>
 		<part name="cdrom" interface="fmt_cdrom">
@@ -10257,19 +11188,60 @@ User/save disks that can be created from the game itself are not included.
 	<!-- No CDDA sound -->
 	<software name="wingcomm" supported="partial">
 		<!--
-		Origin: Neo Kobe Collection
-		<rom name="Wing Commander.ccd" size="8792" crc="7d3209e5" sha1="23441501ac6bcd70520b904987c05dc72dd0d2e2"/>
-		<rom name="Wing Commander.cue" size="1750" crc="faae9a20" sha1="ceb6966ce035d9a21616c8d29722ea3da7848579"/>
-		<rom name="Wing Commander.img" size="597114000" crc="d5be8a45" sha1="6d03363605925a41b5c5c80a43a8cc32bb585c73"/>
-		<rom name="Wing Commander.sub" size="24372000" crc="df14155f" sha1="c2ec744fb13ddbb4f039cc88e26eb3dfeb8ae0c2"/>
+		Origin: redump.org
+		<rom name="Wing Commander (Japan) (Track 01).bin" size="31399200" crc="5e851e7f" sha1="bf0d61314a26b1af8346a8af56220afde20612ef"/>
+		<rom name="Wing Commander (Japan) (Track 02).bin" size="5115600" crc="e14355c5" sha1="7d7db01356c45b56892826d889f066dc7d221e19"/>
+		<rom name="Wing Commander (Japan) (Track 03).bin" size="53978400" crc="c36f6de8" sha1="14d51169db962024b8bfe88fc62022a449ec7729"/>
+		<rom name="Wing Commander (Japan) (Track 04).bin" size="35985600" crc="89f84abc" sha1="3c418749221b88dd37599d40b857a275996fc983"/>
+		<rom name="Wing Commander (Japan) (Track 05).bin" size="34750800" crc="49e26ba2" sha1="de288e3925d1668152fc29793c3d54f891b6e096"/>
+		<rom name="Wing Commander (Japan) (Track 06).bin" size="44629200" crc="c44deed4" sha1="91ca0c3b6a2cf23acc865314017e7f10cd04eab6"/>
+		<rom name="Wing Commander (Japan) (Track 07).bin" size="4057200" crc="95881f03" sha1="96a6343250951bec61865b1f40402b7d6fa38a0d"/>
+		<rom name="Wing Commander (Japan) (Track 08).bin" size="11818800" crc="788c6390" sha1="b426096f8bc8dad252242ae4273c8c9067b7d3f9"/>
+		<rom name="Wing Commander (Japan) (Track 09).bin" size="3351600" crc="0c1d192b" sha1="de9ace51da25e52d38e75c025d0a8b23ddb10a80"/>
+		<rom name="Wing Commander (Japan) (Track 10).bin" size="5292000" crc="b98ea3b0" sha1="b34eaf573aa35430078fa2c33cd768af6b8a8807"/>
+		<rom name="Wing Commander (Japan) (Track 11).bin" size="9525600" crc="38b02380" sha1="9a6aa4a58936c2e317b1c97269410a743c809639"/>
+		<rom name="Wing Commander (Japan) (Track 12).bin" size="18522000" crc="2b7fbdfe" sha1="7171df5b55def79df32bc46c7f98be612422b58f"/>
+		<rom name="Wing Commander (Japan) (Track 13).bin" size="11818800" crc="7f631b34" sha1="6348a699bf8fc0bd384c8138fb0a8427b96d7757"/>
+		<rom name="Wing Commander (Japan) (Track 14).bin" size="10231200" crc="c2824a94" sha1="7df605a060dd9fb8e9cb14577f9fe13c52217945"/>
+		<rom name="Wing Commander (Japan) (Track 15).bin" size="12348000" crc="24050055" sha1="25749392f0c5cea535357bc76ae51efae35b05fb"/>
+		<rom name="Wing Commander (Japan) (Track 16).bin" size="3880800" crc="adaeac8b" sha1="9233efb27723631671bd5029707c6d1b166b8e81"/>
+		<rom name="Wing Commander (Japan) (Track 17).bin" size="8820000" crc="6ee5fca3" sha1="d17645ce6049befd9ff9e15d517a2e85a3e701ab"/>
+		<rom name="Wing Commander (Japan) (Track 18).bin" size="13230000" crc="308ba39a" sha1="ea5de837115d0473b3c7d4955b18c71a5d69923f"/>
+		<rom name="Wing Commander (Japan) (Track 19).bin" size="23461200" crc="577cc421" sha1="31911547b91af95d21bcdc125908b9ce2cecf9ef"/>
+		<rom name="Wing Commander (Japan) (Track 20).bin" size="2822400" crc="806010be" sha1="4ceacb780ed8e89bf84e54e72e25565e53c35d28"/>
+		<rom name="Wing Commander (Japan) (Track 21).bin" size="12524400" crc="e1319c7e" sha1="3ba5e5812970d76f9e1b1255375c5d9e60201a00"/>
+		<rom name="Wing Commander (Japan) (Track 22).bin" size="11289600" crc="29bbd30b" sha1="71ff3a8b2fd8f410ffdad00928058d1807452488"/>
+		<rom name="Wing Commander (Japan) (Track 23).bin" size="9878400" crc="ee14c1f7" sha1="c633aa0a57427cad4fe77c4a0aade5ccc0772a8d"/>
+		<rom name="Wing Commander (Japan) (Track 24).bin" size="3175200" crc="0b1d85c0" sha1="a26b755d26f109228fb61efc572cc6265af33614"/>
+		<rom name="Wing Commander (Japan) (Track 25).bin" size="5292000" crc="d55b1806" sha1="409309567189821eaf97f5bcaa56e72fec862fd0"/>
+		<rom name="Wing Commander (Japan) (Track 26).bin" size="4057200" crc="8c406987" sha1="d8c2d282c5c2e5addacd7d3792d420ab5149bfa6"/>
+		<rom name="Wing Commander (Japan) (Track 27).bin" size="11289600" crc="83e98a71" sha1="c637b127ee3189facb8dabdf86531ae2db5d2e34"/>
+		<rom name="Wing Commander (Japan) (Track 28).bin" size="12348000" crc="62b644c0" sha1="29933ed1128109e9ea1d180a6ea1b5ca12e624e8"/>
+		<rom name="Wing Commander (Japan) (Track 29).bin" size="11818800" crc="6b97ffc6" sha1="e28e6443db86afa74f48236032ddfa6e24e3e6ed"/>
+		<rom name="Wing Commander (Japan) (Track 30).bin" size="4233600" crc="1e8aa02a" sha1="40925f697011dba22b67f3819d1b2fffe1b8be6e"/>
+		<rom name="Wing Commander (Japan) (Track 31).bin" size="9525600" crc="4c813c54" sha1="4d7c96fed23ee45d82b2a18ad653a9e4cd6b6c53"/>
+		<rom name="Wing Commander (Japan) (Track 32).bin" size="11642400" crc="b0243dc0" sha1="5f5f76daaa6bc04c35af00dce4b44b2ab7a20bbf"/>
+		<rom name="Wing Commander (Japan) (Track 33).bin" size="16405200" crc="1ce09433" sha1="2e3ccc1a5f36fa0ea21d5a692fcec5ce0cba7a3b"/>
+		<rom name="Wing Commander (Japan) (Track 34).bin" size="19580400" crc="9e77f19b" sha1="11f4478ec6b719342fe67976c356eaad362a63be"/>
+		<rom name="Wing Commander (Japan) (Track 35).bin" size="9525600" crc="cb1025d4" sha1="4b83699ecbf1b9b03bc3b4465d2345e016e20b6f"/>
+		<rom name="Wing Commander (Japan) (Track 36).bin" size="9702000" crc="b236351c" sha1="b351232770f9570971e2b7f86e5d23d1acf331ee"/>
+		<rom name="Wing Commander (Japan) (Track 37).bin" size="12171600" crc="92e9d9ea" sha1="e418ad24679535476375ac5160eba59aeada9b33"/>
+		<rom name="Wing Commander (Japan) (Track 38).bin" size="8996400" crc="f7c40b63" sha1="9eed433fa062a3e65f812017747e7684e3d5fe20"/>
+		<rom name="Wing Commander (Japan) (Track 39).bin" size="10231200" crc="dd6b5b73" sha1="16d76d6225b72cae3c7420548e3e2a065218bdbb"/>
+		<rom name="Wing Commander (Japan) (Track 40).bin" size="18522000" crc="2b823837" sha1="703625f6c7329dbcdd0c9e43869ca981549dcc75"/>
+		<rom name="Wing Commander (Japan) (Track 41).bin" size="11113200" crc="7c0eff1b" sha1="ecf777ad0922b5e63c861223fd960cfb54c93553"/>
+		<rom name="Wing Commander (Japan) (Track 42).bin" size="7585200" crc="d9798535" sha1="473a689b4ba8e5a99275227738f458bd9a06823f"/>
+		<rom name="Wing Commander (Japan) (Track 43).bin" size="21168000" crc="374375a5" sha1="2aadbdfa0afc8019c6e2c08181a46f1ec3c17753"/>
+		<rom name="Wing Commander (Japan).cue" size="5013" crc="1051e032" sha1="c958bc3cf2b983c319426cf9d44941f48d063938"/>
 		-->
 		<description>Wing Commander</description>
 		<year>1992</year>
 		<publisher>富士通 (Fujitsu)</publisher>
+		<info name="alt_title" value="ウイングコマンダー" />
 		<info name="release" value="199212xx" />
 		<part name="cdrom" interface="fmt_cdrom">
 			<diskarea name="cdrom">
-				<disk name="wing commander" sha1="0d2b8647d02e025a2a397f218d1eb104eae64c5b" />
+				<disk name="wing commander (japan)" sha1="bc66292d4304cba0d4915e573769ea525fe4d662" />
 			</diskarea>
 		</part>
 	</software>
@@ -10284,6 +11256,7 @@ User/save disks that can be created from the game itself are not included.
 		<description>Wing Commander - Secret Missions</description>
 		<year>1994</year>
 		<publisher>富士通 (Fujitsu)</publisher>
+		<info name="alt_title" value="ウィング・コマンダー シークレット・ミッション" />
 		<info name="release" value="199411xx" />
 		<info name="usage" value="Requires HDD installation"/>
 		<part name="cdrom" interface="fmt_cdrom">
@@ -10303,6 +11276,7 @@ User/save disks that can be created from the game itself are not included.
 		<description>Wing Commander II and Special Operations</description>
 		<year>1995</year>
 		<publisher>エレクトロニック・アーツ・ビクター (Electronic Arts Victor)</publisher>
+		<info name="alt_title" value="ウィング・コマンダーII" />
 		<info name="release" value="199507xx" />
 		<part name="cdrom" interface="fmt_cdrom">
 			<diskarea name="cdrom">
@@ -10313,9 +11287,26 @@ User/save disks that can be created from the game itself are not included.
 
 	<software name="wizardr5">
 		<!--
-		Origin: Neo Kobe Collection
-		<rom name="Wizardry V - Heart of the Maelstrom.mdf" size="242197200" crc="fe7c9dfa" sha1="45c01ea042b534a4b91fb0aeb5b4e5af4a510cb3"/>
-		<rom name="Wizardry V - Heart of the Maelstrom.mds" size="1982" crc="eff072ba" sha1="ebfb946672e85270336f864d9a67c83dfb4a2c2e"/>
+		Origin: redump.org
+		<rom name="Wizardry V - Heart of the Maelstrom (Japan) (Track 01).bin" size="20815200" crc="dfc9c04a" sha1="ec00c90a0d2545fe749c5e88987832d770159ba6"/>
+		<rom name="Wizardry V - Heart of the Maelstrom (Japan) (Track 02).bin" size="12818400" crc="ef806602" sha1="614459167715cb24557f823f2a7783b2f25330e1"/>
+		<rom name="Wizardry V - Heart of the Maelstrom (Japan) (Track 03).bin" size="16635696" crc="7165b51c" sha1="d1ae7c351cab062c903bdd3d35d96140957780d2"/>
+		<rom name="Wizardry V - Heart of the Maelstrom (Japan) (Track 04).bin" size="12994800" crc="136c0934" sha1="0fa168b30032e4ae77b5dbb53b230ea3291498ac"/>
+		<rom name="Wizardry V - Heart of the Maelstrom (Japan) (Track 05).bin" size="17209584" crc="9924f290" sha1="95c83a5a27dc17be34bf034e3d04099cf2f84cd3"/>
+		<rom name="Wizardry V - Heart of the Maelstrom (Japan) (Track 06).bin" size="29077776" crc="ce73fd96" sha1="23fba8f1d8ad1f8ad21b7ae72f490a63b66be1c0"/>
+		<rom name="Wizardry V - Heart of the Maelstrom (Japan) (Track 07).bin" size="18538464" crc="233c6ce8" sha1="7d7354dbc04fc2b86e0b389e78c3c9d26d455f62"/>
+		<rom name="Wizardry V - Heart of the Maelstrom (Japan) (Track 08).bin" size="18129216" crc="ea8f3280" sha1="0f3d5c4509668024acd65e5ad1e90af05c69d880"/>
+		<rom name="Wizardry V - Heart of the Maelstrom (Japan) (Track 09).bin" size="9365664" crc="c4e095d4" sha1="502bc697a9b90a09198072fec8c6dca2e250839c"/>
+		<rom name="Wizardry V - Heart of the Maelstrom (Japan) (Track 10).bin" size="15711360" crc="5a8396ac" sha1="0691f057750439980bf39f43a806143dcfeaf1da"/>
+		<rom name="Wizardry V - Heart of the Maelstrom (Japan) (Track 11).bin" size="11720016" crc="4f483430" sha1="db3357dfdb770a87a7b3d20bf771cb9b1d04f604"/>
+		<rom name="Wizardry V - Heart of the Maelstrom (Japan) (Track 12).bin" size="11783520" crc="addd7952" sha1="ab431c4b10f65165a843ade39b3404b93d0f687a"/>
+		<rom name="Wizardry V - Heart of the Maelstrom (Japan) (Track 13).bin" size="38177664" crc="94eb153a" sha1="1270de080fc469e978b6875812444fa20d901e7c"/>
+		<rom name="Wizardry V - Heart of the Maelstrom (Japan) (Track 14).bin" size="1735776" crc="2961b388" sha1="af756fd690bc0cbd02f4e219855d4ff3d218b296"/>
+		<rom name="Wizardry V - Heart of the Maelstrom (Japan) (Track 15).bin" size="2415504" crc="0a7bde25" sha1="3dbb3dd3081fdd689e126ac19abcc165ff56cf32"/>
+		<rom name="Wizardry V - Heart of the Maelstrom (Japan) (Track 16).bin" size="1524096" crc="265641e1" sha1="388bb7c63030c8cd3f40479d105c5178d4cc2ae3"/>
+		<rom name="Wizardry V - Heart of the Maelstrom (Japan) (Track 17).bin" size="2058000" crc="d8557c20" sha1="519322f947b6f565f2071bd064897b6eb9a5479e"/>
+		<rom name="Wizardry V - Heart of the Maelstrom (Japan) (Track 18).bin" size="1839264" crc="be55595f" sha1="e426b0912b5f5d224f79e3a20548624cc20511c3"/>
+		<rom name="Wizardry V - Heart of the Maelstrom (Japan).cue" size="2466" crc="53379c46" sha1="bc771e926ec17b41890bcbcbea3f1ef26a470075"/>
 		-->
 		<description>Wizardry V - Heart of the Maelstrom</description>
 		<year>1990</year>
@@ -10329,7 +11320,7 @@ User/save disks that can be created from the game itself are not included.
 		</part>
 		<part name="cdrom" interface="fmt_cdrom">
 			<diskarea name="cdrom">
-				<disk name="wizardry v - heart of the maelstrom" sha1="c6b378bd12cba4c353e023218c0c1da0d6305f7a" />
+				<disk name="wizardry v - heart of the maelstrom (japan)" sha1="1b3da896d590292d6b9b1c9119f75f3e7ee6fbcb" />
 			</diskarea>
 		</part>
 	</software>
@@ -10390,9 +11381,10 @@ User/save disks that can be created from the game itself are not included.
 		<rom name="Wrestle Angels 3.img" size="146586048" crc="9dbc67f2" sha1="b997acc457d71c74935bcbbfa2f394adda77774b"/>
 		<rom name="Wrestle Angels 3.sub" size="5983104" crc="11cac79b" sha1="9c812343a72770a9c8da1ecdeceba71746565522"/>
 		-->
-		<description>Wrestle Angels 3</description>
+		<description>Wrestle Angels 3 - Mezasu wa Saikyou Dantai!</description>
 		<year>1994</year>
 		<publisher>グレイト (Great)</publisher>
+		<info name="alt_title" value="レッスル エンジェルス 3 目指すは最強団体！" />
 		<info name="release" value="199408xx" />
 		<part name="flop1" interface="floppy_3_5">
 			<feature name="part_id" value="Save Disk" />
@@ -10418,6 +11410,7 @@ User/save disks that can be created from the game itself are not included.
 		<description>Wrestle Angels Special</description>
 		<year>1994</year>
 		<publisher>グレイト (Great)</publisher>
+		<info name="alt_title" value="レッスル エンジェルス スペシャル" />
 		<info name="release" value="199410xx" />
 		<part name="flop1" interface="floppy_3_5">
 			<feature name="part_id" value="User Disk" />
@@ -10443,6 +11436,7 @@ User/save disks that can be created from the game itself are not included.
 		<description>Where in the World is Carmen Sandiego?</description>
 		<year>1993</year>
 		<publisher>富士通 (Fujitsu)</publisher>
+		<info name="alt_title" value="カルメン・サンディエゴを探せ! -世界編-" />
 		<info name="release" value="199304xx" />
 		<part name="cdrom" interface="fmt_cdrom">
 			<diskarea name="cdrom">
@@ -10462,6 +11456,7 @@ User/save disks that can be created from the game itself are not included.
 		<description>Words Worth</description>
 		<year>1993</year>
 		<publisher>エルフ (Elf)</publisher>
+		<info name="alt_title" value="ワーズ・ワース" />
 		<info name="release" value="199309xx" />
 		<part name="cdrom" interface="fmt_cdrom">
 			<diskarea name="cdrom">
@@ -10481,6 +11476,7 @@ User/save disks that can be created from the game itself are not included.
 		<description>Xak II - Rising of the Redmoon</description>
 		<year>1991</year>
 		<publisher>マイクロキャビン (Micro Cabin)</publisher>
+		<info name="alt_title" value="サークII ライジング・オブ・ザ・レッドムーン" />
 		<info name="release" value="199107xx" />
 		<part name="cdrom" interface="fmt_cdrom">
 			<diskarea name="cdrom">
@@ -10500,6 +11496,7 @@ User/save disks that can be created from the game itself are not included.
 		<description>Xak III - The Eternal Recurrence</description>
 		<year>1993</year>
 		<publisher>マイクロキャビン (Micro Cabin)</publisher>
+		<info name="alt_title" value="サークIII ジ・エターナル・リカーレンス" />
 		<info name="release" value="199309xx" />
 		<part name="cdrom" interface="fmt_cdrom">
 			<diskarea name="cdrom">
@@ -10519,6 +11516,7 @@ User/save disks that can be created from the game itself are not included.
 		<description>Xenon</description>
 		<year>1995</year>
 		<publisher>シーズウェア (C's Ware)</publisher>
+		<info name="alt_title" value="XENON ～無限の肢体～" />
 		<info name="release" value="199503xx" />
 		<part name="cdrom" interface="fmt_cdrom">
 			<diskarea name="cdrom">
@@ -10540,6 +11538,7 @@ User/save disks that can be created from the game itself are not included.
 		<year>1995</year>
 		<publisher>インターリミテッドロジック (Inter Limited Logic)</publisher>
 		<info name="alt_title" value="ヤマネの棲む森" />
+		<info name="release" value="199506xx" />
 		<part name="cdrom" interface="fmt_cdrom">
 			<diskarea name="cdrom">
 				<disk name="yamane" sha1="4a672f5b90f0fb81238915b60a4e093e672dd2dd" />
@@ -10558,6 +11557,7 @@ User/save disks that can be created from the game itself are not included.
 		<description>Yami no Ketsuzoku Special</description>
 		<year>1991</year>
 		<publisher>システムサコム (System Sacom)</publisher>
+		<info name="alt_title" value="闇の血族 スペシャル" />
 		<info name="release" value="199106xx" />
 		<part name="flop1" interface="floppy_3_5">
 			<feature name="part_id" value="User Disk" />
@@ -10584,6 +11584,7 @@ User/save disks that can be created from the game itself are not included.
 		<description>Youjuu Senki - A.D. 2048</description>
 		<year>1993</year>
 		<publisher>ディー・オー (D.O.)</publisher>
+		<info name="alt_title" value="妖獣戦記 -A.D.2048-" />
 		<info name="release" value="199311xx" />
 		<part name="cdrom" interface="fmt_cdrom">
 			<diskarea name="cdrom">
@@ -10601,10 +11602,10 @@ User/save disks that can be created from the game itself are not included.
 		<rom name="Image.img" size="649808208" crc="16f70c96" sha1="29b587dbcdaae2d471b7c13c1ce5c5825bc86eaf"/>
 		<rom name="Image.sub" size="26522784" crc="af8cb6ad" sha1="f77df38b35d73e8bc3e20033a8878af0e9c03ea8"/>
 		-->
-		<description>Youjuu Senki 2 - Reimei no Senshi</description>
+		<description>Youjuu Senki 2 - Reimei no Senshi-tachi</description>
 		<year>1993</year>
 		<publisher>ディー・オー (D.O.)</publisher>
-		<info name="alt_title" value="妖獣戦記2 黎明の戦士" />
+		<info name="alt_title" value="妖獣戦記2 黎明の戦士たち" />
 		<info name="release" value="199402xx" />
 		<part name="cdrom" interface="fmt_cdrom">
 			<diskarea name="cdrom">
@@ -10624,6 +11625,7 @@ User/save disks that can be created from the game itself are not included.
 		<description>Yumimi Mix</description>
 		<year>1993</year>
 		<publisher>CRI</publisher>
+		<info name="alt_title" value="ゆみみみっくす" />
 		<info name="release" value="199312xx" />
 		<part name="cdrom" interface="fmt_cdrom">
 			<diskarea name="cdrom">
@@ -10643,6 +11645,7 @@ User/save disks that can be created from the game itself are not included.
 		<description>Yuuwaku</description>
 		<year>1996</year>
 		<publisher>ティーツー (T2)</publisher>
+		<info name="alt_title" value="誘惑" />
 		<info name="release" value="199605xx" />
 		<part name="flop1" interface="floppy_3_5">
 			<feature name="part_id" value="User Disk" />
@@ -10690,6 +11693,7 @@ User/save disks that can be created from the game itself are not included.
 		<description>Zan II - Towns Special</description>
 		<year>1992</year>
 		<publisher>ウルフチーム (WolfTeam)</publisher>
+		<info name="alt_title" value="斬2タウンズスペシャル" />
 		<info name="release" value="199204xx" />
 		<part name="flop1" interface="floppy_3_5">
 			<feature name="part_id" value="User Disk" />
@@ -10742,6 +11746,8 @@ User/save disks that can be created from the game itself are not included.
 		<description>Zatsuon Ryouiki</description>
 		<year>1995</year>
 		<publisher>ディー・オー (D.O.)</publisher>
+		<info name="alt_title" value="雑音領域" />
+		<info name="release" value="199502xx" />
 		<part name="cdrom" interface="fmt_cdrom">
 			<diskarea name="cdrom">
 				<disk name="zatsuon ryouiki" sha1="f61c4277ef4a2ec49f127d6b798e30d9b7b0b3af" />
@@ -10760,6 +11766,7 @@ User/save disks that can be created from the game itself are not included.
 		<description>Zenith</description>
 		<year>1995</year>
 		<publisher>姫屋ソフト (Himeya Soft)</publisher>
+		<info name="alt_title" value="ゼニス" />
 		<info name="release" value="199502xx" />
 		<part name="cdrom" interface="fmt_cdrom">
 			<diskarea name="cdrom">
@@ -10779,6 +11786,7 @@ User/save disks that can be created from the game itself are not included.
 		<description>Zoku Dungeon Master - Chaos no Gyakushuu</description>
 		<year>1990</year>
 		<publisher>ビクター音楽産業 (Victor Musical Industries)</publisher>
+		<info name="alt_title" value="続ダンジョン・マスター カオスの逆襲" />
 		<info name="release" value="199012xx" />
 		<part name="cdrom" interface="fmt_cdrom">
 			<diskarea name="cdrom">


### PR DESCRIPTION
- Added new items from the redump.org database:

Cat's Part-1
DOR Best Selection Gekan
Gokko Vol. 1 - Doctor
Professional Mahjong Goku
Scavenger 4 (1993-11-11)
Taiken Shiyou! Marty Channel

- Replaced the following items with images that match the redump.org database. In many cases the existing images had no offset correction (which leads to small chunks of audio data at the start/end of the disc being missing) and no proper pregaps, so these should be better.

The 4th Unit 5 - D-Again
The 4th Unit 7 - Wyatt
Genocide Square
Gunship - The Helicopter Simulation
The Legend of Kyrandia (promoted to working due to this change)
Kyrandia II - The Hand of Fate
Last Armageddon CD Special
Mahjong de Pon!
Misty - Meitantei Toujou
Puyo Puyo
Schwarzschild IV - The Cradle End
Silent Möbius
Splatterhouse
Ultima Underworld II - Labyrinth of Worlds
Wing Commander
Wizardry V - Heart of the Maelstrom

- Added alt_titles and release dates for almost everything

- Miscellaneous metadata fixes