### PR TITLE
Changed call to emulator_info::draw_user_interface() from video.cpp to a virtual function invocation on ui_manager

### DIFF
--- a/src/emu/machine.cpp
+++ b/src/emu/machine.cpp
@@ -113,6 +113,7 @@ running_machine::running_machine(const machine_config &_config, machine_manager 
 		m_config(_config),
 		m_system(_config.gamedrv()),
 		m_manager(manager),
+		m_ui(nullptr),
 		m_current_phase(machine_phase::PREINIT),
 		m_paused(false),
 		m_hard_reset_pending(false),
@@ -206,6 +207,7 @@ void running_machine::start()
 	// create the video manager
 	m_video = std::make_unique<video_manager>(*this);
 	m_ui = manager().create_ui(*this);
+	m_ui->set_startup_text("Initializing...", true);
 
 	// initialize the base time (needed for doing record/playback)
 	::time(&m_base_time);

--- a/src/emu/main.h
+++ b/src/emu/main.h
@@ -57,7 +57,6 @@ public:
 	static void display_ui_chooser(running_machine& machine);
 	static int start_frontend(emu_options &options, osd_interface &osd, std::vector<std::string> &args);
 	static int start_frontend(emu_options &options, osd_interface &osd, int argc, char *argv[]);
-	static void draw_user_interface(running_machine& machine);
 	static void periodic_check();
 	static bool frame_hook();
 	static void layout_file_cb(util::xml::data_node const &layout);

--- a/src/emu/ui/uimain.h
+++ b/src/emu/ui/uimain.h
@@ -40,6 +40,8 @@ public:
 
 	virtual void menu_reset() { }
 
+	virtual void draw() = 0;
+
 	template <typename Format, typename... Params> void popup_time(int seconds, Format &&fmt, Params &&... args);
 
 protected:

--- a/src/emu/video.cpp
+++ b/src/emu/video.cpp
@@ -239,7 +239,7 @@ void video_manager::frame_update(bool from_debugger)
 	}
 
 	// draw the user interface
-	emulator_info::draw_user_interface(machine());
+	machine().ui().draw();
 
 	// if we're throttling, synchronize before rendering
 	attotime current_time = machine().time();

--- a/src/frontend/mame/mame.cpp
+++ b/src/frontend/mame/mame.cpp
@@ -288,8 +288,6 @@ ui_manager* mame_machine_manager::create_ui(running_machine& machine)
 
 	machine.add_notifier(MACHINE_NOTIFY_RESET, machine_notify_delegate(&mame_machine_manager::reset, this));
 
-	m_ui->set_startup_text("Initializing...", true);
-
 	return m_ui.get();
 }
 
@@ -343,11 +341,6 @@ int emulator_info::start_frontend(emu_options &options, osd_interface &osd, int 
 {
 	std::vector<std::string> args(argv, argv + argc);
 	return start_frontend(options, osd, args);
-}
-
-void emulator_info::draw_user_interface(running_machine& machine)
-{
-	mame_machine_manager::instance()->ui().update_and_render(machine.render().ui_container());
 }
 
 void emulator_info::periodic_check()

--- a/src/frontend/mame/ui/ui.cpp
+++ b/src/frontend/mame/ui/ui.cpp
@@ -379,17 +379,19 @@ void mame_ui_manager::set_startup_text(const char *text, bool force)
 
 
 //-------------------------------------------------
-//  update_and_render - update the UI and
-//  render it; called by video.c
+//  draw - update the UI and
+//  render it; called by video.cpp
 //-------------------------------------------------
 
-void mame_ui_manager::update_and_render(render_container &container)
+void mame_ui_manager::draw()
 {
+	render_container &container(m_machine.render().ui_container());
+
 	// always start clean
 	container.empty();
 
 	// if we're paused, dim the whole screen
-	if (machine().phase() >= machine_phase::RESET && (single_step() || machine().paused()))
+	if (m_machine.phase() >= machine_phase::RESET && (single_step() || machine().paused()))
 	{
 		int alpha = (1.0f - machine().options().pause_brightness()) * 255.0f;
 		if (ui::menu::stack_has_special_main_menu(machine()))

--- a/src/frontend/mame/ui/ui.h
+++ b/src/frontend/mame/ui/ui.h
@@ -194,7 +194,7 @@ public:
 
 	void display_startup_screens(bool first_time);
 	virtual void set_startup_text(const char *text, bool force) override;
-	void update_and_render(render_container &container);
+	virtual void draw() override;
 	render_font *get_font();
 	float get_line_height();
 	float get_char_width(char32_t ch);


### PR DESCRIPTION
The call to set_startup_text() also had to be moved out of ui_initialize() because this change requires m_ui to be specified on the running_machine object

This is a part of efforts to eliminate calls to mame_ui_manager::instance() and static functions on emulator_info, in favor of invocation on ui_manager (enabling worker_ui to change these behaviors by providing its own subclass of ui_manager)