### PR TITLE
Changing LUA code to get mame_ui_manager by dynamic cast rather than mame_machine_manager::instance()->ui()

### DIFF
--- a/src/frontend/mame/luaengine.cpp
+++ b/src/frontend/mame/luaengine.cpp
@@ -2470,6 +2470,6 @@ mame_ui_manager *lua_engine::mame_ui()
 {
 	mame_ui_manager *ui = dynamic_cast<mame_ui_manager *>(&machine().ui());
 	if (!ui)
-		luaL_error(m_lua_state, "Functionaliry requires built in MAME UI");
+		luaL_error(m_lua_state, "Functionality requires built in MAME UI");
 	return ui;
 }

--- a/src/frontend/mame/luaengine.h
+++ b/src/frontend/mame/luaengine.h
@@ -28,6 +28,7 @@
 #include "sol2/sol.hpp"
 
 struct lua_State;
+class mame_ui_manager;
 
 class lua_engine
 {
@@ -166,6 +167,8 @@ private:
 		bool busy;
 		bool yield;
 	};
+
+	mame_ui_manager *mame_ui();
 };
 
 #endif // MAME_FRONTEND_MAME_LUAENGINE_H


### PR DESCRIPTION
Dynamic casts are never one's first choice, but this is superior to
grabbing a global singleton.  Upon merging more worker_ui changes, it
will be possible for machine().ui() to be an implementation of
ui_manager distinct from mame_ui_manager, so this code is being changed
to gracefully handle this scenario.  Plus, global singletons like
mame_machine_manager::instance are just plain ugly.

Lastly, I would like someone familiar with the LUA integration to look
at this, not just for correctness, but to validate my approach of
keeping LUA's mame_machine_manager::ui() equivalent returning the
mame_ui_manager while changing how it is implemented.  Even if getting
rid of mame_machine_manager::ui() is the right way to go, there is an
argument to be made that we should change the LUA integration even if it
breaks compatibility with existing scripts (though obviously I did not
take that approach).