### PR TITLE
nes,sms: Change the way screen is set for the light gun device

### DIFF
--- a/src/devices/bus/gamegear/ggext.cpp
+++ b/src/devices/bus/gamegear/ggext.cpp
@@ -8,6 +8,7 @@
 **********************************************************************/
 
 #include "emu.h"
+#include "screen.h"
 #include "ggext.h"
 // slot devices
 #include "smsctrladp.h"
@@ -58,6 +59,7 @@ device_gg_ext_port_interface::~device_gg_ext_port_interface()
 gg_ext_port_device::gg_ext_port_device(const machine_config &mconfig, const char *tag, device_t *owner, uint32_t clock) :
 	device_t(mconfig, GG_EXT_PORT, tag, owner, clock),
 	device_slot_interface(mconfig, *this),
+	m_screen(*this, finder_base::DUMMY_TAG),
 	m_device(nullptr),
 	m_th_pin_handler(*this)
 {

--- a/src/devices/bus/gamegear/ggext.h
+++ b/src/devices/bus/gamegear/ggext.h
@@ -65,6 +65,11 @@ public:
 
 	void th_pin_w(int state);
 
+	template <typename T> void set_screen_tag(T &&tag) { m_screen.set_tag(std::forward<T>(tag)); }
+
+	// for peripherals that interact with the machine's screen
+	required_device<screen_device> m_screen;
+
 //protected:
 	// device-level overrides
 	virtual void device_start() override;

--- a/src/devices/bus/gamegear/smsctrladp.cpp
+++ b/src/devices/bus/gamegear/smsctrladp.cpp
@@ -77,6 +77,7 @@ WRITE_LINE_MEMBER( sms_ctrl_adaptor_device::th_pin_w )
 void sms_ctrl_adaptor_device::device_add_mconfig(machine_config &config)
 {
 	SMS_CONTROL_PORT(config, m_subctrl_port, sms_control_port_devices, "joypad");
+	m_subctrl_port->set_screen_tag(m_port->m_screen);
 	m_subctrl_port->th_input_handler().set(FUNC(sms_ctrl_adaptor_device::th_pin_w));
 }
 

--- a/src/devices/bus/nes_ctrl/ctrl.cpp
+++ b/src/devices/bus/nes_ctrl/ctrl.cpp
@@ -41,6 +41,7 @@
 **********************************************************************/
 
 #include "emu.h"
+#include "screen.h"
 #include "ctrl.h"
 // slot devices
 #include "4score.h"
@@ -104,6 +105,7 @@ device_nes_control_port_interface::~device_nes_control_port_interface()
 nes_control_port_device::nes_control_port_device(const machine_config &mconfig, const char *tag, device_t *owner, uint32_t clock) :
 	device_t(mconfig, NES_CONTROL_PORT, tag, owner, clock),
 	device_slot_interface(mconfig, *this),
+	m_screen(*this, finder_base::DUMMY_TAG),
 	m_device(nullptr)
 {
 }

--- a/src/devices/bus/nes_ctrl/ctrl.h
+++ b/src/devices/bus/nes_ctrl/ctrl.h
@@ -67,10 +67,16 @@ public:
 	uint8_t read_bit34();
 	uint8_t read_exp(offs_t offset);
 	void write(uint8_t data);
+	template <typename T> void set_screen_tag(T &&tag) { m_screen.set_tag(std::forward<T>(tag)); }
+
+	// for peripherals that interact with the machine's screen
+	required_device<screen_device> m_screen;
 
 protected:
 	// device-level overrides
 	virtual void device_start() override;
+
+	// devices
 	device_nes_control_port_interface *m_device;
 };
 

--- a/src/devices/bus/nes_ctrl/hori.cpp
+++ b/src/devices/bus/nes_ctrl/hori.cpp
@@ -61,16 +61,22 @@ static void hori_adapter(device_slot_interface &device)
 
 void nes_horitwin_device::device_add_mconfig(machine_config &config)
 {
-	NES_CONTROL_PORT(config, "port1", hori_adapter, "joypad");
-	NES_CONTROL_PORT(config, "port2", hori_adapter, "joypad");
+	NES_CONTROL_PORT(config, m_port1, hori_adapter, "joypad");
+	NES_CONTROL_PORT(config, m_port2, hori_adapter, "joypad");
+	m_port1->set_screen_tag(m_port->m_screen);
+	m_port2->set_screen_tag(m_port->m_screen);
 }
 
 void nes_hori4p_device::device_add_mconfig(machine_config &config)
 {
-	NES_CONTROL_PORT(config, "port1", hori_adapter, "joypad");
-	NES_CONTROL_PORT(config, "port2", hori_adapter, "joypad");
-	NES_CONTROL_PORT(config, "port3", hori_adapter, "joypad");
-	NES_CONTROL_PORT(config, "port4", hori_adapter, "joypad");
+	NES_CONTROL_PORT(config, m_port1, hori_adapter, "joypad");
+	NES_CONTROL_PORT(config, m_port2, hori_adapter, "joypad");
+	NES_CONTROL_PORT(config, m_port3, hori_adapter, "joypad");
+	NES_CONTROL_PORT(config, m_port4, hori_adapter, "joypad");
+	m_port1->set_screen_tag(m_port->m_screen);
+	m_port2->set_screen_tag(m_port->m_screen);
+	m_port3->set_screen_tag(m_port->m_screen);
+	m_port4->set_screen_tag(m_port->m_screen);
 }
 
 

--- a/src/devices/bus/nes_ctrl/hori.h
+++ b/src/devices/bus/nes_ctrl/hori.h
@@ -30,7 +30,6 @@ public:
 protected:
 	// device-level overrides
 	virtual void device_start() override { }
-
 	virtual void device_add_mconfig(machine_config &config) override;
 
 	virtual uint8_t read_exp(offs_t offset) override;
@@ -53,9 +52,8 @@ public:
 protected:
 	// device-level overrides
 	virtual void device_start() override { }
-
-	virtual ioport_constructor device_input_ports() const override;
 	virtual void device_add_mconfig(machine_config &config) override;
+	virtual ioport_constructor device_input_ports() const override;
 
 	virtual uint8_t read_exp(offs_t offset) override;
 	virtual void write(uint8_t data) override;

--- a/src/devices/bus/nes_ctrl/joypad.cpp
+++ b/src/devices/bus/nes_ctrl/joypad.cpp
@@ -174,7 +174,8 @@ static void arcstick_daisy(device_slot_interface &device)
 void nes_arcstick_device::device_add_mconfig(machine_config &config)
 {
 	// expansion port to allow daisy chaining
-	NES_CONTROL_PORT(config, "subexp", arcstick_daisy, nullptr);
+	NES_CONTROL_PORT(config, m_daisychain, arcstick_daisy, nullptr);
+	m_daisychain->set_screen_tag(m_port->m_screen);
 }
 
 

--- a/src/devices/bus/nes_ctrl/zapper.cpp
+++ b/src/devices/bus/nes_ctrl/zapper.cpp
@@ -7,8 +7,8 @@
 **********************************************************************/
 
 #include "emu.h"
-#include "zapper.h"
 #include "screen.h"
+#include "zapper.h"
 
 //**************************************************************************
 //  DEVICE DEFINITIONS
@@ -48,7 +48,6 @@ ioport_constructor nes_zapper_device::device_input_ports() const
 
 nes_zapper_device::nes_zapper_device(const machine_config &mconfig, const char *tag, device_t *owner, uint32_t clock) :
 	device_t(mconfig, NES_ZAPPER, tag, owner, clock),
-	device_video_interface(mconfig, *this),
 	device_nes_control_port_interface(mconfig, *this),
 	m_lightx(*this, "ZAPPER_X"),
 	m_lighty(*this, "ZAPPER_Y"),
@@ -86,17 +85,17 @@ uint8_t nes_zapper_device::read_bit34()
 	int y = m_lighty->read();
 
 	// update the screen if necessary
-	if (!screen().vblank())
+	if (!m_port->m_screen->vblank())
 	{
-		int vpos = screen().vpos();
-		int hpos = screen().hpos();
+		int vpos = m_port->m_screen->vpos();
+		int hpos = m_port->m_screen->hpos();
 
 		if (vpos > y || (vpos == y && hpos >= x))
-			screen().update_now();
+			m_port->m_screen->update_now();
 	}
 
 	// get the pixel at the gun position
-	rgb_t pix = screen().pixel(x, y);
+	rgb_t pix = m_port->m_screen->pixel(x, y);
 
 	// check if the cursor is over a bright pixel
 	// FIXME: still a gross hack

--- a/src/devices/bus/nes_ctrl/zapper.h
+++ b/src/devices/bus/nes_ctrl/zapper.h
@@ -21,7 +21,6 @@
 // ======================> nes_zapper_device
 
 class nes_zapper_device : public device_t,
-							public device_video_interface,
 							public device_nes_control_port_interface
 {
 public:

--- a/src/devices/bus/sms_ctrl/lphaser.cpp
+++ b/src/devices/bus/sms_ctrl/lphaser.cpp
@@ -19,9 +19,8 @@ Notes:
 **********************************************************************/
 
 #include "emu.h"
-#include "lphaser.h"
-
 #include "screen.h"
+#include "lphaser.h"
 
 
 
@@ -85,15 +84,11 @@ ioport_constructor sms_light_phaser_device::device_input_ports() const
 
 sms_light_phaser_device::sms_light_phaser_device(const machine_config &mconfig, const char *tag, device_t *owner, uint32_t clock) :
 	device_t(mconfig, SMS_LIGHT_PHASER, tag, owner, clock),
-	device_video_interface(mconfig, *this),
 	device_sms_control_port_interface(mconfig, *this),
 	m_lphaser_pins(*this, "CTRL_PORT"),
 	m_lphaser_x(*this, "LPHASER_X"),
 	m_lphaser_y(*this, "LPHASER_Y"), m_sensor_last_state(0), m_lphaser_timer(nullptr)
 {
-	// Workaround for failed validation that occurs when running on a driver
-	// with Sega Scope emulation, which adds 2 screens (left/right lenses).
-	set_screen(*this, ":screen");
 }
 
 
@@ -150,10 +145,10 @@ uint8_t sms_light_phaser_device::peripheral_r()
 int sms_light_phaser_device::bright_aim_area( emu_timer *timer, int lgun_x, int lgun_y )
 {
 	const int r_x_r = LGUN_RADIUS * LGUN_RADIUS;
-	const rectangle &visarea = screen().visible_area();
+	const rectangle &visarea = m_port->m_screen->visible_area();
 	rectangle aim_area;
-	int beam_x = screen().hpos();
-	int beam_y = screen().vpos();
+	int beam_x = m_port->m_screen->hpos();
+	int beam_y = m_port->m_screen->vpos();
 	int beam_x_orig = beam_x;
 	int beam_y_orig = beam_y;
 	int dy, result = 1;
@@ -231,8 +226,8 @@ int sms_light_phaser_device::bright_aim_area( emu_timer *timer, int lgun_x, int 
 				/* brightness of the lightgray color in the frame drawn by Light Phaser games */
 				const uint8_t sensor_min_brightness = 0x7f;
 
-				screen().update_now();
-				color = screen().pixel(beam_x, beam_y);
+				m_port->m_screen->update_now();
+				color = m_port->m_screen->pixel(beam_x, beam_y);
 
 				/* reference: http://www.w3.org/TR/AERT#color-contrast */
 				brightness = (color.r() * 0.299) + (color.g() * 0.587) + (color.b() * 0.114);
@@ -257,14 +252,14 @@ int sms_light_phaser_device::bright_aim_area( emu_timer *timer, int lgun_x, int 
 		}
 	}
 
-	timer->adjust(screen().time_until_pos(beam_y, beam_x));
+	timer->adjust(m_port->m_screen->time_until_pos(beam_y, beam_x));
 	return result;
 }
 
 
 uint16_t sms_light_phaser_device::screen_hpos_nonscaled(int scaled_hpos)
 {
-	const rectangle &visarea = screen().visible_area();
+	const rectangle &visarea = m_port->m_screen->visible_area();
 	int offset_x = (scaled_hpos * (visarea.max_x - visarea.min_x)) / 255;
 	return visarea.min_x + offset_x;
 }
@@ -272,7 +267,7 @@ uint16_t sms_light_phaser_device::screen_hpos_nonscaled(int scaled_hpos)
 
 uint16_t sms_light_phaser_device::screen_vpos_nonscaled(int scaled_vpos)
 {
-	const rectangle &visarea = screen().visible_area();
+	const rectangle &visarea = m_port->m_screen->visible_area();
 	int offset_y = (scaled_vpos * (visarea.max_y - visarea.min_y)) / 255;
 	return visarea.min_y + offset_y;
 }

--- a/src/devices/bus/sms_ctrl/lphaser.h
+++ b/src/devices/bus/sms_ctrl/lphaser.h
@@ -23,7 +23,6 @@
 // ======================> sms_light_phaser_device
 
 class sms_light_phaser_device : public device_t,
-							public device_video_interface,
 							public device_sms_control_port_interface
 {
 public:

--- a/src/devices/bus/sms_ctrl/multitap.cpp
+++ b/src/devices/bus/sms_ctrl/multitap.cpp
@@ -131,4 +131,8 @@ void sms_multitap_device::device_add_mconfig(machine_config &config)
 	SMS_CONTROL_PORT(config, m_subctrl2_port, sms_control_port_devices, "joypad");
 	SMS_CONTROL_PORT(config, m_subctrl3_port, sms_control_port_devices, "joypad");
 	SMS_CONTROL_PORT(config, m_subctrl4_port, sms_control_port_devices, "joypad");
+	m_subctrl1_port->set_screen_tag(m_port->m_screen);
+	m_subctrl2_port->set_screen_tag(m_port->m_screen);
+	m_subctrl3_port->set_screen_tag(m_port->m_screen);
+	m_subctrl4_port->set_screen_tag(m_port->m_screen);
 }

--- a/src/devices/bus/sms_ctrl/rfu.cpp
+++ b/src/devices/bus/sms_ctrl/rfu.cpp
@@ -135,5 +135,6 @@ WRITE_LINE_MEMBER( sms_rapid_fire_device::th_pin_w )
 void sms_rapid_fire_device::device_add_mconfig(machine_config &config)
 {
 	SMS_CONTROL_PORT(config, m_subctrl_port, sms_control_port_devices, "joypad");
+	m_subctrl_port->set_screen_tag(m_port->m_screen);
 	m_subctrl_port->th_input_handler().set(FUNC(sms_rapid_fire_device::th_pin_w));
 }

--- a/src/devices/bus/sms_ctrl/smsctrl.cpp
+++ b/src/devices/bus/sms_ctrl/smsctrl.cpp
@@ -7,6 +7,7 @@
 **********************************************************************/
 
 #include "emu.h"
+#include "screen.h"
 #include "smsctrl.h"
 
 // slot devices
@@ -65,6 +66,7 @@ device_sms_control_port_interface::~device_sms_control_port_interface()
 sms_control_port_device::sms_control_port_device(const machine_config &mconfig, const char *tag, device_t *owner, uint32_t clock) :
 	device_t(mconfig, SMS_CONTROL_PORT, tag, owner, clock),
 	device_slot_interface(mconfig, *this),
+	m_screen(*this, finder_base::DUMMY_TAG),
 	m_device(nullptr),
 	m_th_pin_handler(*this)
 {

--- a/src/devices/bus/sms_ctrl/smsctrl.h
+++ b/src/devices/bus/sms_ctrl/smsctrl.h
@@ -62,6 +62,11 @@ public:
 
 	void th_pin_w(int state);
 
+	template <typename T> void set_screen_tag(T &&tag) { m_screen.set_tag(std::forward<T>(tag)); }
+
+	// for peripherals that interact with the machine's screen
+	required_device<screen_device> m_screen;
+
 protected:
 	// device-level overrides
 	virtual void device_start() override;

--- a/src/mame/drivers/nes.cpp
+++ b/src/mame/drivers/nes.cpp
@@ -77,6 +77,8 @@ void nes_state::nes(machine_config &config)
 
 	NES_CONTROL_PORT(config, m_ctrl1, nes_control_port1_devices, "joypad");
 	NES_CONTROL_PORT(config, m_ctrl2, nes_control_port2_devices, "joypad");
+	m_ctrl1->set_screen_tag(m_screen);
+	m_ctrl2->set_screen_tag(m_screen);
 
 	NES_CART_SLOT(config, m_cartslot, NTSC_APU_CLOCK, nes_cart, nullptr);
 	SOFTWARE_LIST(config, "cart_list").set_original("nes");
@@ -112,6 +114,9 @@ void nes_state::famicom(machine_config &config)
 	NES_CONTROL_PORT(config.replace(), m_ctrl1, fc_control_port1_devices, "joypad");
 	NES_CONTROL_PORT(config.replace(), m_ctrl2, fc_control_port2_devices, "joypad");
 	NES_CONTROL_PORT(config, m_exp, fc_expansion_devices, nullptr);
+	m_ctrl1->set_screen_tag(m_screen);
+	m_ctrl2->set_screen_tag(m_screen);
+	m_exp->set_screen_tag(m_screen);
 
 	SOFTWARE_LIST(config, "flop_list").set_original("famicom_flop");
 	SOFTWARE_LIST(config, "cass_list").set_original("famicom_cass");
@@ -142,6 +147,9 @@ void nes_state::famipalc(machine_config &config)
 	NES_CONTROL_PORT(config.replace(), m_ctrl1, fc_control_port1_devices, "joypad");
 	NES_CONTROL_PORT(config.replace(), m_ctrl2, fc_control_port2_devices, "joypad");
 	NES_CONTROL_PORT(config, m_exp, fc_expansion_devices, nullptr);
+	m_ctrl1->set_screen_tag(m_screen);
+	m_ctrl2->set_screen_tag(m_screen);
+	m_exp->set_screen_tag(m_screen);
 
 	SOFTWARE_LIST(config, "cass_list").set_original("famicom_cass");
 }

--- a/src/mame/drivers/nes_vt.cpp
+++ b/src/mame/drivers/nes_vt.cpp
@@ -1395,6 +1395,8 @@ void nes_vt_state::nes_vt(machine_config &config)
 
 	NES_CONTROL_PORT(config, m_ctrl1, nes_control_port1_devices, "joypad");
 	NES_CONTROL_PORT(config, m_ctrl2, nes_control_port2_devices, "joypad");
+	m_ctrl1->set_screen_tag(m_screen);
+	m_ctrl2->set_screen_tag(m_screen);
 }
 
 void nes_vt_state::nes_vt_ddr(machine_config &config)
@@ -1403,6 +1405,8 @@ void nes_vt_state::nes_vt_ddr(machine_config &config)
 
 	NES_CONTROL_PORT(config, m_ctrl1, majesco_control_port1_devices, "ddr");
 	NES_CONTROL_PORT(config, m_ctrl2, majesco_control_port2_devices, nullptr);
+	m_ctrl1->set_screen_tag(m_screen);
+	m_ctrl2->set_screen_tag(m_screen);
 }
 
 void nes_vt_state::nes_vt_hum(machine_config &config)

--- a/src/mame/drivers/sms.cpp
+++ b/src/mame/drivers/sms.cpp
@@ -502,9 +502,11 @@ void sms_state::sms_base(machine_config &config)
 	SOFTWARE_LIST(config, "cart_list").set_original("sms");
 
 	SMS_CONTROL_PORT(config, m_port_ctrl1, sms_control_port_devices, "joypad");
+	m_port_ctrl1->set_screen_tag(m_main_scr);
 	m_port_ctrl1->th_input_handler().set(FUNC(sms_state::sms_ctrl1_th_input));
 
 	SMS_CONTROL_PORT(config, m_port_ctrl2, sms_control_port_devices, "joypad");
+	m_port_ctrl2->set_screen_tag(m_main_scr);
 	m_port_ctrl2->th_input_handler().set(FUNC(sms_state::sms_ctrl2_th_input));
 }
 
@@ -991,6 +993,7 @@ void sms_state::gamegear(machine_config &config)
 	SOFTWARE_LIST(config, "cart_list").set_original("gamegear");
 
 	GG_EXT_PORT(config, m_port_gg_ext, gg_ext_port_devices, nullptr);
+	m_port_gg_ext->set_screen_tag(m_main_scr);
 	m_port_gg_ext->th_input_handler().set(FUNC(sms_state::gg_ext_th_input));
 
 	m_is_gamegear = true;


### PR DESCRIPTION
Currently the light gun device is making an assumption about the screen used by the host system. This patch moves to the host system the responsibility to define the screen used by the light gun.