### PR TITLE
playch10: Fix order and screen_update code for both screens

### DIFF
--- a/src/mame/drivers/playch10.cpp
+++ b/src/mame/drivers/playch10.cpp
@@ -673,18 +673,18 @@ void playch10_state::playch10(machine_config &config)
 	PALETTE(config, "palette", FUNC(playch10_state::playch10_palette), 256);
 	config.set_default_layout(layout_playch10);
 
+	screen_device &bottom(SCREEN(config, "bottom", SCREEN_TYPE_RASTER));
+	bottom.set_refresh_hz(60);
+	bottom.set_size(32*8, 262);
+	bottom.set_visarea(0*8, 32*8-1, 0*8, 30*8-1);
+	bottom.set_screen_update(FUNC(playch10_state::screen_update_playch10_bottom));
+
 	screen_device &top(SCREEN(config, "top", SCREEN_TYPE_RASTER));
 	top.set_refresh_hz(60);
 	top.set_size(32*8, 262);
 	top.set_visarea(0*8, 32*8-1, 0*8, 30*8-1);
 	top.set_screen_update(FUNC(playch10_state::screen_update_playch10_top));
 	top.screen_vblank().set(FUNC(playch10_state::vblank_irq));
-
-	screen_device &bottom(SCREEN(config, "bottom", SCREEN_TYPE_RASTER));
-	bottom.set_refresh_hz(60);
-	bottom.set_size(32*8, 262);
-	bottom.set_visarea(0*8, 32*8-1, 0*8, 30*8-1);
-	bottom.set_screen_update(FUNC(playch10_state::screen_update_playch10_bottom));
 
 	PPU_2C03B(config, m_ppu, 0);
 	m_ppu->set_screen("bottom");

--- a/src/mame/video/playch10.cpp
+++ b/src/mame/video/playch10.cpp
@@ -127,9 +127,9 @@ uint32_t playch10_state::screen_update_playch10_top(screen_device &screen, bitma
 	if (m_pc10_bios != 1)
 		return screen_update_playch10_single(screen, bitmap, cliprect);
 
-	if (!m_pc10_dispmask)
-		/* render the ppu */
-		m_ppu->render(bitmap, 0, 0, 0, 0, cliprect);
+	/* When the bios is accessing vram, the video circuitry can't access it */
+	if (!m_pc10_sdcs)
+		m_bg_tilemap->draw(screen, bitmap, cliprect, 0, 0);
 	else
 		bitmap.fill(0, cliprect);
 
@@ -142,9 +142,9 @@ uint32_t playch10_state::screen_update_playch10_bottom(screen_device &screen, bi
 	if (m_pc10_bios != 1)
 		return screen_update_playch10_single(screen, bitmap, cliprect);
 
-	/* When the bios is accessing vram, the video circuitry can't access it */
-	if (!m_pc10_sdcs)
-		m_bg_tilemap->draw(screen, bitmap, cliprect, 0, 0);
+	if (!m_pc10_dispmask)
+		/* render the ppu */
+		m_ppu->render(bitmap, 0, 0, 0, 0, cliprect);
 	else
 		bitmap.fill(0, cliprect);
 


### PR DESCRIPTION
Data of the PPU (that manages the game/bottom screen) is incorrectly being used by the screen_update code of the "top" (selection) screen, and the screen_update code of the "bottom" screen is using the data of the selection screen. The problem was not noticed for games using the standard controller because the screen order is inverted in the machine config. This patch fix the screen_update codes and the screen order, what is necessary to fix the light gun problem of MT 7331: https://mametesters.org/view.php?id=7331