### PR TITLE
fmtowns.cpp: fix CDDA start/end position

### DIFF
--- a/src/mame/drivers/fmtowns.cpp
+++ b/src/mame/drivers/fmtowns.cpp
@@ -224,7 +224,7 @@ inline uint32_t towns_state::msf_to_lbafm(uint32_t val)  // because the CDROM co
 	f = bcd_to_byte(val & 0x0000ff);
 	s = (bcd_to_byte((val & 0x00ff00) >> 8));
 	m = (bcd_to_byte((val & 0xff0000) >> 16));
-	return ((m * (60 * 75)) + (s * 75) + f);
+	return ((m * (60 * 75)) + (s * 75) + f) - 150;
 }
 
 void towns_state::init_serial_rom()
@@ -1481,13 +1481,7 @@ void towns_state::towns_cdrom_read(cdrom_image_device* device)
 	m_towns_cd.lba_current = msf_to_lbafm(lba1);
 	m_towns_cd.lba_last = msf_to_lbafm(lba2);
 
-	// first track starts at 00:02:00 - this is hardcoded in the boot procedure
 	track = cdrom_get_track(device->get_cdrom_file(),m_towns_cd.lba_current);
-	if(track < 2)
-	{  // recalculate LBA
-		m_towns_cd.lba_current -= 150;
-		m_towns_cd.lba_last -= 150;
-	}
 
 	// parameter 7 = sector count?
 	// lemmings 2 sets this to 4 but hates 4 extra sectors being read


### PR DESCRIPTION
Currently all FM Towns software that uses CDDA starts and stops playing audio at the wrong position, 2 seconds ahead to be exact. This is more noticeable in some cases than others (e.g. the cutscenes in Vain Dream, Last Armageddon or the Emit series are completely out of sync), and is caused by the Towns CD-ROM controller using absolute addressing (starting from the beginning of the TOC area, or sector -150) while the CDDA device in MAME uses LBA addressing (starting from sector 0).

The current code already takes care of this, but just for track 1. This change applies the same principle to all CD read operations by substracting 150 sectors from the start/end positions on the MSF-to-LBA calculation.

Note that CD images improperly dumped without audio track pregaps might still start at the wrong position (just a different one). This is a separate issue that can only be solved by redumping them.