### PR TITLE
Disable UI startup screens for "-video none"

### DIFF
--- a/src/frontend/mame/ui/ui.cpp
+++ b/src/frontend/mame/ui/ui.cpp
@@ -30,6 +30,7 @@
 #include "ui/state.h"
 #include "ui/viewgfx.h"
 #include "imagedev/cassette.h"
+#include "../osd/modules/lib/osdobj_common.h"
 
 
 /***************************************************************************
@@ -283,10 +284,11 @@ void mame_ui_manager::display_startup_screens(bool first_time)
 	int str = machine().options().seconds_to_run();
 	bool show_gameinfo = !machine().options().skip_gameinfo();
 	bool show_warnings = true, show_mandatory_fileman = true;
+	bool video_none = strcmp(downcast<osd_options &>(machine().options()).video(), "none") == 0;
 
 	// disable everything if we are using -str for 300 or fewer seconds, or if we're the empty driver,
-	// or if we are debugging
-	if (!first_time || (str > 0 && str < 60*5) || &machine().system() == &GAME_NAME(___empty) || (machine().debug_flags & DEBUG_FLAG_ENABLED) != 0)
+	// or if we are debugging, or if there's no mame window to send inputs to
+	if (!first_time || (str > 0 && str < 60*5) || &machine().system() == &GAME_NAME(___empty) || (machine().debug_flags & DEBUG_FLAG_ENABLED) != 0 || video_none)
 		show_gameinfo = show_warnings = show_mandatory_fileman = false;
 
 #if defined(EMSCRIPTEN)


### PR DESCRIPTION
The UI startup screens are meant to be shown in the main window, but it doesn't exist in this case. For platforms with mandatory images it won't run without them anyway, so one just has to provide one. Game info screen can also be disabled in the options. But for machine warnings, there's no easy way to get past them, mostly because there's no window to accept user inputs. Maybe it can be done with lua, but it's not trivial. So I just disabled the blocking UI screens.

PS: This video mode is headless to some extent, and mame can be controlled via lua console just fine. There's even a command to shut down the emulator (`manager:machine():exit()`). So the warning saying `-video none doesn't make much sense without -seconds_to_run` is only partially true. This mode is quite usable overall.