### PR TITLE
Fix segfault when trying to access some image option that does not exists

### DIFF
--- a/src/emu/emuopts.h
+++ b/src/emu/emuopts.h
@@ -480,6 +480,7 @@ public:
 	bool has_slot_option(const std::string &device_name) const { return find_slot_option(device_name) ? true : false; }
 	const ::image_option &image_option(const std::string &device_name) const;
 	::image_option &image_option(const std::string &device_name);
+	bool has_image_option(const std::string &device_name) const { return m_image_options.find(device_name) != m_image_options.end(); }
 
 protected:
 	virtual void command_argument_processed() override;

--- a/src/emu/image.cpp
+++ b/src/emu/image.cpp
@@ -196,7 +196,8 @@ void image_manager::options_extract()
 		//      Note that as a part of #2, we cannot extract the option when the image in question is a part of an
 		//      active reset_on_load; hence the check for is_reset_and_loading() (see issue #2414)
 		if (!image.is_reset_on_load()
-			|| (!image.exists() && !image.is_reset_and_loading() && !machine().options().image_option(image.instance_name()).value().empty()))
+			|| (!image.exists() && !image.is_reset_and_loading()
+				&& machine().options().has_image_option(image.instance_name()) && !machine().options().image_option(image.instance_name()).value().empty()))
 		{
 			// we have to assemble the image option differently for software lists and for normal images
 			std::string image_opt;
@@ -211,7 +212,7 @@ void image_manager::options_extract()
 			}
 
 			// and set the option (provided that it hasn't been removed out from under us)
-			if (machine().options().exists(image.instance_name()))
+			if (machine().options().exists(image.instance_name()) && machine().options().has_image_option(image.instance_name()))
 				machine().options().image_option(image.instance_name()).specify(std::move(image_opt));
 		}
 	}


### PR DESCRIPTION
Fixing MameTesters 07377, 06880, 06677 and 06655.

(This does not fix the underlying problem which is discussed in #2555).