### PR TITLE
fmtowns.cpp: fix crash regression in System Sacom games

### DIFF
--- a/src/mame/video/fmtowns.cpp
+++ b/src/mame/video/fmtowns.cpp
@@ -532,7 +532,7 @@ void towns_state::towns_update_palette()
 	{
 		case 0x00:
 		case 0x20:
-			m_palette16[(m_video.towns_video_reg[1] & 0x20) >> 5]->set_pen_color(entry, r, g, b);
+			m_palette16[(m_video.towns_video_reg[1] & 0x20) >> 5]->set_pen_color(entry & 0x0f, r, g, b);
 			break;
 		case 0x10:
 		case 0x30:


### PR DESCRIPTION
This fixes a regression introduced with commit bb32d72c7e68d4b34a94e1250f1440394d473f7d that causes semi-random emulator crashes (at least in non-debug builds) in 38-man Kilo no Kokuu and Yami no Ketsuzoku Special. Apparently they are trying to set colors for palette indexes higher than 15 in 16-color mode, and the m_entry_color array goes out of bounds.

I'm not sure if the hardware discards everything but the 4 least significant bits of the palette index, or if it ignores the color change completely, but it doesn't seem to make any difference in practice, so I'm assuming the former.