### PR TITLE
mc6845 - configuration; row update paths; partial cursors.

### DIFF
--- a/src/devices/bus/a2bus/a2ultraterm.cpp
+++ b/src/devices/bus/a2bus/a2ultraterm.cpp
@@ -304,7 +304,7 @@ void a2bus_videx160_device::write_c800(uint16_t offset, uint8_t data)
 
 MC6845_UPDATE_ROW( a2bus_videx160_device::crtc_update_row )
 {
-	uint32_t  *p = &bitmap.pix32(y);
+	uint32_t  *p = &bitmap.pix32(y, hbp);
 	uint16_t  chr_base = ra;
 	int i;
 

--- a/src/devices/bus/a2bus/a2videoterm.cpp
+++ b/src/devices/bus/a2bus/a2videoterm.cpp
@@ -347,7 +347,7 @@ void a2bus_videx80_device::write_c800(uint16_t offset, uint8_t data)
 
 MC6845_UPDATE_ROW( a2bus_videx80_device::crtc_update_row )
 {
-	uint32_t  *p = &bitmap.pix32(y);
+	uint32_t  *p = &bitmap.pix32(y, hbp);
 	uint16_t  chr_base = ra; //( ra & 0x08 ) ? 0x800 | ( ra & 0x07 ) : ra;
 
 	for (int i = 0; i < x_count; i++)

--- a/src/devices/bus/acorn/system/vdu40.cpp
+++ b/src/devices/bus/acorn/system/vdu40.cpp
@@ -93,7 +93,7 @@ void acorn_vdu40_device::device_reset()
 
 MC6845_UPDATE_ROW(acorn_vdu40_device::crtc_update_row)
 {
-	uint32_t *p = &bitmap.pix32(y);
+	uint32_t *p = &bitmap.pix32(y, hbp);
 
 	m_trom->lose_w(1);
 	m_trom->lose_w(0);

--- a/src/devices/bus/acorn/system/vdu80.cpp
+++ b/src/devices/bus/acorn/system/vdu80.cpp
@@ -172,7 +172,7 @@ void acorn_vdu80_device::device_reset()
 MC6845_UPDATE_ROW(acorn_vdu80_device::crtc_update_row)
 {
 	uint8_t invert = BIT(m_links->read(), 1);
-	uint32_t *p = &bitmap.pix32(y);
+	uint32_t *p = &bitmap.pix32(y, hbp);
 
 	for (int column = 0; column < x_count; column++)
 	{

--- a/src/devices/bus/c64/xl80.cpp
+++ b/src/devices/bus/c64/xl80.cpp
@@ -103,7 +103,7 @@ MC6845_UPDATE_ROW( c64_xl80_device::crtc_update_row )
 			int x = (column * 8) + bit;
 			int color = BIT(data, 7) && de;
 
-			bitmap.pix32(vbp + y, hbp + x) = pen[color];
+			bitmap.pix32(y, hbp + x) = pen[color];
 
 			data <<= 1;
 		}
@@ -127,8 +127,6 @@ void c64_xl80_device::device_add_mconfig(machine_config &config)
 {
 	screen_device &screen(SCREEN(config, MC6845_SCREEN_TAG, SCREEN_TYPE_RASTER, rgb_t::white()));
 	screen.set_screen_update(HD46505SP_TAG, FUNC(hd6845s_device::screen_update));
-	screen.set_size(80*8, 24*8);
-	screen.set_visarea(0, 80*8-1, 0, 24*8-1);
 	screen.set_refresh_hz(50);
 
 	GFXDECODE(config, "gfxdecode", m_palette, gfx_c64_xl80);
@@ -136,7 +134,7 @@ void c64_xl80_device::device_add_mconfig(machine_config &config)
 
 	HD6845S(config, m_crtc, XTAL(14'318'181) / 8);
 	m_crtc->set_screen(MC6845_SCREEN_TAG);
-	m_crtc->set_show_border_area(true);
+	m_crtc->set_show_border_area(false);
 	m_crtc->set_char_width(8);
 	m_crtc->set_update_row_callback(FUNC(c64_xl80_device::crtc_update_row), this);
 }

--- a/src/devices/bus/comx35/clm.cpp
+++ b/src/devices/bus/comx35/clm.cpp
@@ -117,7 +117,7 @@ MC6845_UPDATE_ROW( comx_clm_device::crtc_update_row )
 		{
 			int x = (column * 8) + bit;
 
-			bitmap.pix32(vbp + y, hbp + x) = m_palette->pen(BIT(data, 7) && de);
+			bitmap.pix32(y, hbp + x) = m_palette->pen(BIT(data, 7) && de);
 
 			data <<= 1;
 		}
@@ -141,8 +141,6 @@ void comx_clm_device::device_add_mconfig(machine_config &config)
 {
 	screen_device &screen(SCREEN(config, MC6845_SCREEN_TAG, SCREEN_TYPE_RASTER, rgb_t::white()));
 	screen.set_screen_update(MC6845_TAG, FUNC(mc6845_device::screen_update));
-	screen.set_size(80*8, 24*8);
-	screen.set_visarea(0, 80*8-1, 0, 24*8-1);
 	screen.set_vblank_time(ATTOSECONDS_IN_USEC(2500));
 	screen.set_refresh_hz(50);
 
@@ -151,7 +149,7 @@ void comx_clm_device::device_add_mconfig(machine_config &config)
 
 	MC6845(config, m_crtc, XTAL(14'318'181)/7);
 	m_crtc->set_screen(MC6845_SCREEN_TAG);
-	m_crtc->set_show_border_area(true);
+	m_crtc->set_show_border_area(false);
 	m_crtc->set_char_width(8);
 	m_crtc->set_update_row_callback(FUNC(comx_clm_device::crtc_update_row), this);
 }

--- a/src/devices/bus/ecbbus/grip.cpp
+++ b/src/devices/bus/ecbbus/grip.cpp
@@ -187,7 +187,7 @@ MC6845_UPDATE_ROW( ecb_grip21_device::crtc_update_row )
 			int x = (column * 8) + bit;
 			int color = (m_flash ? 0 : BIT(data, bit)) && de;
 
-			bitmap.pix32(vbp + y, hbp + x) = m_palette->pen(color);
+			bitmap.pix32(y, hbp + x) = m_palette->pen(color);
 		}
 	}
 }
@@ -207,7 +207,7 @@ MC6845_UPDATE_ROW( ecb_grip21_device::grip5_update_row )
             int x = (column * 8) + bit;
             int color = m_flash ? 0 : BIT(data, bit);
 
-            bitmap.pix32(y, x) = palette[color];
+            bitmap.pix32(y, hbp + x) = palette[color];
         }
     }
 }
@@ -419,8 +419,6 @@ void ecb_grip21_device::device_add_mconfig(machine_config &config)
 	screen.set_refresh_hz(50);
 	screen.set_vblank_time(ATTOSECONDS_IN_USEC(2500)); // not accurate
 	screen.set_screen_update(MC6845_TAG, FUNC(mc6845_device::screen_update));
-	screen.set_size(640, 480);
-	screen.set_visarea(0, 640-1, 0, 480-1);
 
 	PALETTE(config, m_palette, palette_device::MONOCHROME);
 
@@ -433,7 +431,7 @@ void ecb_grip21_device::device_add_mconfig(machine_config &config)
 	// devices
 	MC6845(config, m_crtc, XTAL(16'000'000)/4);
 	m_crtc->set_screen(SCREEN_TAG);
-	m_crtc->set_show_border_area(true);
+	m_crtc->set_show_border_area(false);
 	m_crtc->set_char_width(8);
 	m_crtc->set_update_row_callback(FUNC(ecb_grip21_device::crtc_update_row), this);
 	m_crtc->out_de_callback().set(m_sti, FUNC(z80sti_device::i1_w));

--- a/src/devices/bus/einstein/pipe/tk02.cpp
+++ b/src/devices/bus/einstein/pipe/tk02.cpp
@@ -185,14 +185,14 @@ MC6845_UPDATE_ROW( tk02_device::crtc_update_row )
 		if (i == cursor_x)
 			data ^= 0xff;
 
-		bitmap.pix32(y, i * 8 + 0) = pen[BIT(data, 7)];
-		bitmap.pix32(y, i * 8 + 1) = pen[BIT(data, 6)];
-		bitmap.pix32(y, i * 8 + 2) = pen[BIT(data, 5)];
-		bitmap.pix32(y, i * 8 + 3) = pen[BIT(data, 4)];
-		bitmap.pix32(y, i * 8 + 4) = pen[BIT(data, 3)];
-		bitmap.pix32(y, i * 8 + 5) = pen[BIT(data, 2)];
-		bitmap.pix32(y, i * 8 + 6) = pen[BIT(data, 1)];
-		bitmap.pix32(y, i * 8 + 7) = pen[BIT(data, 0)];
+		bitmap.pix32(y, hbp + i * 8 + 0) = pen[BIT(data, 7)];
+		bitmap.pix32(y, hbp + i * 8 + 1) = pen[BIT(data, 6)];
+		bitmap.pix32(y, hbp + i * 8 + 2) = pen[BIT(data, 5)];
+		bitmap.pix32(y, hbp + i * 8 + 3) = pen[BIT(data, 4)];
+		bitmap.pix32(y, hbp + i * 8 + 4) = pen[BIT(data, 3)];
+		bitmap.pix32(y, hbp + i * 8 + 5) = pen[BIT(data, 2)];
+		bitmap.pix32(y, hbp + i * 8 + 6) = pen[BIT(data, 1)];
+		bitmap.pix32(y, hbp + i * 8 + 7) = pen[BIT(data, 0)];
 	}
 }
 

--- a/src/devices/bus/isa/aga.cpp
+++ b/src/devices/bus/isa/aga.cpp
@@ -302,7 +302,7 @@ MC6845_UPDATE_ROW( isa8_aga_device::mda_text_inten_update_row )
 {
 	const rgb_t *palette = m_palette->palette()->entry_list_raw();
 	uint8_t *videoram = m_videoram.get();
-	uint32_t  *p = &bitmap.pix32(y);
+	uint32_t  *p = &bitmap.pix32(y, hbp);
 	uint16_t  chr_base = ( ra & 0x08 ) ? 0x800 | ( ra & 0x07 ) : ra;
 	int i;
 
@@ -363,7 +363,7 @@ MC6845_UPDATE_ROW( isa8_aga_device::mda_text_blink_update_row )
 {
 	uint8_t *videoram = m_videoram.get();
 	const rgb_t *palette = m_palette->palette()->entry_list_raw();
-	uint32_t  *p = &bitmap.pix32(y);
+	uint32_t  *p = &bitmap.pix32(y, hbp);
 	uint16_t  chr_base = ( ra & 0x08 ) ? 0x800 | ( ra & 0x07 ) : ra;
 	int i;
 
@@ -425,7 +425,7 @@ MC6845_UPDATE_ROW( isa8_aga_device::cga_text_inten_update_row )
 {
 	uint8_t *videoram = m_videoram.get();
 	const rgb_t *palette = m_palette->palette()->entry_list_raw();
-	uint32_t  *p = &bitmap.pix32(y);
+	uint32_t  *p = &bitmap.pix32(y, hbp);
 	int i;
 
 	if ( y == 0 ) logerror("cga_text_inten_update_row\n");
@@ -456,7 +456,7 @@ MC6845_UPDATE_ROW( isa8_aga_device::cga_text_inten_alt_update_row )
 {
 	const rgb_t *palette = m_palette->palette()->entry_list_raw();
 	uint8_t *videoram = m_videoram.get();
-	uint32_t  *p = &bitmap.pix32(y);
+	uint32_t  *p = &bitmap.pix32(y, hbp);
 	int i;
 
 	if ( y == 0 ) logerror("cga_text_inten_alt_update_row\n");
@@ -486,7 +486,7 @@ MC6845_UPDATE_ROW( isa8_aga_device::cga_text_blink_update_row )
 {
 	const rgb_t *palette = m_palette->palette()->entry_list_raw();
 	uint8_t *videoram = m_videoram.get();
-	uint32_t  *p = &bitmap.pix32(y);
+	uint32_t  *p = &bitmap.pix32(y, hbp);
 	int i;
 
 	for ( i = 0; i < x_count; i++ ) {
@@ -520,7 +520,7 @@ MC6845_UPDATE_ROW( isa8_aga_device::cga_text_blink_alt_update_row )
 {
 	const rgb_t *palette = m_palette->palette()->entry_list_raw();
 	uint8_t *videoram = m_videoram.get();
-	uint32_t  *p = &bitmap.pix32(y);
+	uint32_t  *p = &bitmap.pix32(y, hbp);
 	int i;
 
 	if ( y == 0 ) logerror("cga_text_blink_alt_update_row\n");
@@ -556,7 +556,7 @@ MC6845_UPDATE_ROW( isa8_aga_device::cga_gfx_4bppl_update_row )
 {
 	const rgb_t *palette = m_palette->palette()->entry_list_raw();
 	uint8_t *videoram = m_videoram.get();
-	uint32_t  *p = &bitmap.pix32(y);
+	uint32_t  *p = &bitmap.pix32(y, hbp);
 	int i;
 
 	if ( y == 0 ) logerror("cga_gfx_4bppl_update_row\n");
@@ -582,7 +582,7 @@ MC6845_UPDATE_ROW( isa8_aga_device::cga_gfx_4bpph_update_row )
 {
 	uint8_t *videoram = m_videoram.get();
 	const rgb_t *palette = m_palette->palette()->entry_list_raw();
-	uint32_t  *p = &bitmap.pix32(y);
+	uint32_t  *p = &bitmap.pix32(y, hbp);
 	int i;
 
 	if ( y == 0 ) logerror("cga_gfx_4bpph_update_row\n");
@@ -616,7 +616,7 @@ MC6845_UPDATE_ROW( isa8_aga_device::cga_gfx_2bpp_update_row )
 {
 	uint8_t *videoram = m_videoram.get();
 	const rgb_t *palette = m_palette->palette()->entry_list_raw();
-	uint32_t  *p = &bitmap.pix32(y);
+	uint32_t  *p = &bitmap.pix32(y, hbp);
 	int i;
 
 //  if ( y == 0 ) logerror("cga_gfx_2bpp_update_row\n");
@@ -642,7 +642,7 @@ MC6845_UPDATE_ROW( isa8_aga_device::cga_gfx_1bpp_update_row )
 {
 	uint8_t *videoram = m_videoram.get();
 	const rgb_t *palette = m_palette->palette()->entry_list_raw();
-	uint32_t  *p = &bitmap.pix32(y);
+	uint32_t  *p = &bitmap.pix32(y, hbp);
 	uint8_t   fg = m_cga_color_select & 0x0F;
 	int i;
 

--- a/src/devices/bus/isa/cga.cpp
+++ b/src/devices/bus/isa/cga.cpp
@@ -692,15 +692,10 @@ MC6845_UPDATE_ROW( isa8_cga_device::cga_gfx_1bpp_update_row )
 WRITE_LINE_MEMBER( isa8_cga_device::hsync_changed )
 {
 	m_hsync = state ? 1 : 0;
-#if 0
-	/* This is not necessary if the device is linked to a screen,
-	 * and no other 6845 device does this, so disable these and
-	 * consider another approach if really necessary. */
 	if(state && !m_vsync)
 	{
 		m_screen->update_now();
 	}
-#endif
 }
 
 
@@ -710,12 +705,11 @@ WRITE_LINE_MEMBER( isa8_cga_device::vsync_changed )
 	{
 		m_framecnt++;
 	}
-#if 0
 	else
 	{
 		m_screen->reset_origin();
 	}
-#endif
+
 	m_vsync = state ? 9 : 0;
 }
 

--- a/src/devices/bus/isa/cga.h
+++ b/src/devices/bus/isa/cga.h
@@ -69,7 +69,7 @@ public:
 	uint8_t   m_color_select;  /* wo 0x3d9 */
 	//uint8_t   m_status;   //unused?     /* ro 0x3da */
 
-	int     m_update_row_type, m_y;
+	int     m_update_row_type;
 	uint8_t   m_palette_lut_2bpp[4];
 	offs_t  m_chr_gen_offset[4];
 	uint8_t   m_font_selection_mask;
@@ -88,7 +88,6 @@ public:
 private:
 	DECLARE_WRITE_LINE_MEMBER( hsync_changed );
 	DECLARE_WRITE_LINE_MEMBER( vsync_changed );
-	MC6845_RECONFIGURE(reconfigure);
 };
 
 // device type definition
@@ -279,7 +278,6 @@ public:
 	virtual DECLARE_WRITE8_MEMBER( io_write ) override;
 	virtual MC6845_UPDATE_ROW( crtc_update_row ) override;
 	MC6845_UPDATE_ROW( m24_gfx_1bpp_m24_update_row );
-	MC6845_RECONFIGURE(reconfigure);
 
 protected:
 	isa8_cga_m24_device(const machine_config &mconfig, device_type type, const char *tag, device_t *owner, uint32_t clock);

--- a/src/devices/bus/isa/mda.cpp
+++ b/src/devices/bus/isa/mda.cpp
@@ -215,7 +215,7 @@ void isa8_mda_device::device_reset()
 MC6845_UPDATE_ROW( isa8_mda_device::mda_text_inten_update_row )
 {
 	const rgb_t *palette = m_palette->palette()->entry_list_raw();
-	uint32_t  *p = &bitmap.pix32(y);
+	uint32_t  *p = &bitmap.pix32(y, hbp);
 	uint16_t  chr_base = ( ra & 0x08 ) ? 0x800 | ( ra & 0x07 ) : ra;
 	int i;
 
@@ -288,7 +288,7 @@ MC6845_UPDATE_ROW( isa8_mda_device::mda_text_inten_update_row )
 MC6845_UPDATE_ROW( isa8_mda_device::mda_text_blink_update_row )
 {
 	const rgb_t *palette = m_palette->palette()->entry_list_raw();
-	uint32_t  *p = &bitmap.pix32(y);
+	uint32_t  *p = &bitmap.pix32(y, hbp);
 	uint16_t  chr_base = ( ra & 0x08 ) ? 0x800 | ( ra & 0x07 ) : ra;
 	int i;
 
@@ -621,7 +621,7 @@ void isa8_hercules_device::device_reset()
 MC6845_UPDATE_ROW( isa8_hercules_device::hercules_gfx_update_row )
 {
 	const rgb_t *palette = m_palette->palette()->entry_list_raw();
-	uint32_t  *p = &bitmap.pix32(y);
+	uint32_t  *p = &bitmap.pix32(y, hbp);
 	uint16_t  gfx_base = ( ( m_mode_control & 0x80 ) ? 0x8000 : 0x0000 ) | ( ( ra & 0x03 ) << 13 );
 	int i;
 	if ( y == 0 ) MDA_LOG(1,"hercules_gfx_update_row",("\n"));
@@ -805,7 +805,7 @@ void isa8_ec1840_0002_device::device_reset()
 MC6845_UPDATE_ROW( isa8_ec1840_0002_device::mda_lowres_text_inten_update_row )
 {
 	const rgb_t *palette = m_palette->palette()->entry_list_raw();
-	uint32_t  *p = &bitmap.pix32(y);
+	uint32_t  *p = &bitmap.pix32(y, hbp);
 	uint16_t  chr_base = ra;
 	int i;
 
@@ -869,7 +869,7 @@ MC6845_UPDATE_ROW( isa8_ec1840_0002_device::mda_lowres_text_inten_update_row )
 MC6845_UPDATE_ROW( isa8_ec1840_0002_device::mda_lowres_text_blink_update_row )
 {
 	const rgb_t *palette = m_palette->palette()->entry_list_raw();
-	uint32_t  *p = &bitmap.pix32(y);
+	uint32_t  *p = &bitmap.pix32(y, hbp);
 	uint16_t  chr_base = ra;
 	int i;
 

--- a/src/devices/bus/mtx/sdx.cpp
+++ b/src/devices/bus/mtx/sdx.cpp
@@ -417,7 +417,7 @@ MC6845_UPDATE_ROW(mtx_sdxcpm_device::crtc_update_row)
 
 			int color = BIT(data, 7) ? fg : bg;
 
-			bitmap.pix32(y, x) = pen[de ? color : 0];
+			bitmap.pix32(y, hbp + x) = pen[de ? color : 0];
 
 			data <<= 1;
 		}

--- a/src/devices/bus/nasbus/avc.cpp
+++ b/src/devices/bus/nasbus/avc.cpp
@@ -120,7 +120,7 @@ MC6845_UPDATE_ROW( nascom_avc_device::crtc_update_row )
 		}
 
 		// plot the pixel
-		bitmap.pix32(y, x) = m_palette->pen_color((b << 2) | (g << 1) | (r << 0));
+		bitmap.pix32(y, hbp + x) = m_palette->pen_color((b << 2) | (g << 1) | (r << 0));
 	}
 }
 

--- a/src/devices/bus/svi3x8/slot/sv806.cpp
+++ b/src/devices/bus/svi3x8/slot/sv806.cpp
@@ -103,14 +103,14 @@ MC6845_UPDATE_ROW( sv806_device::crtc_update_row )
 		if (i == cursor_x)
 			data = 0xff;
 
-		bitmap.pix32(y, i * 8 + 0) = pen[BIT(data, 7)];
-		bitmap.pix32(y, i * 8 + 1) = pen[BIT(data, 6)];
-		bitmap.pix32(y, i * 8 + 2) = pen[BIT(data, 5)];
-		bitmap.pix32(y, i * 8 + 3) = pen[BIT(data, 4)];
-		bitmap.pix32(y, i * 8 + 4) = pen[BIT(data, 3)];
-		bitmap.pix32(y, i * 8 + 5) = pen[BIT(data, 2)];
-		bitmap.pix32(y, i * 8 + 6) = pen[BIT(data, 1)];
-		bitmap.pix32(y, i * 8 + 7) = pen[BIT(data, 0)];
+		bitmap.pix32(y, hbp + i * 8 + 0) = pen[BIT(data, 7)];
+		bitmap.pix32(y, hbp + i * 8 + 1) = pen[BIT(data, 6)];
+		bitmap.pix32(y, hbp + i * 8 + 2) = pen[BIT(data, 5)];
+		bitmap.pix32(y, hbp + i * 8 + 3) = pen[BIT(data, 4)];
+		bitmap.pix32(y, hbp + i * 8 + 4) = pen[BIT(data, 3)];
+		bitmap.pix32(y, hbp + i * 8 + 5) = pen[BIT(data, 2)];
+		bitmap.pix32(y, hbp + i * 8 + 6) = pen[BIT(data, 1)];
+		bitmap.pix32(y, hbp + i * 8 + 7) = pen[BIT(data, 0)];
 	}
 }
 

--- a/src/devices/bus/vic20/videopak.cpp
+++ b/src/devices/bus/vic20/videopak.cpp
@@ -77,7 +77,7 @@ MC6845_UPDATE_ROW( vic20_video_pak_device::crtc_update_row )
 			int x = (column * 8) + bit;
 			int color = BIT(data, 7) && de;
 
-			bitmap.pix32(vbp + y, hbp + x) = pen[color];
+			bitmap.pix32(y, hbp + x) = pen[color];
 
 			data <<= 1;
 		}
@@ -101,8 +101,6 @@ void vic20_video_pak_device::device_add_mconfig(machine_config &config)
 {
 	screen_device &screen(SCREEN(config, MC6845_SCREEN_TAG, SCREEN_TYPE_RASTER, rgb_t::white()));
 	screen.set_screen_update(MC6845_TAG, FUNC(mc6845_device::screen_update));
-	screen.set_size(80*8, 24*8);
-	screen.set_visarea(0, 80*8-1, 0, 24*8-1);
 	screen.set_refresh_hz(50);
 
 	GFXDECODE(config, "gfxdecode", m_palette, gfx_vic20_video_pak);
@@ -110,7 +108,7 @@ void vic20_video_pak_device::device_add_mconfig(machine_config &config)
 
 	MC6845(config, m_crtc, XTAL(14'318'181) / 8); // HD46505RP or similar
 	m_crtc->set_screen(MC6845_SCREEN_TAG);
-	m_crtc->set_show_border_area(true);
+	m_crtc->set_show_border_area(false);
 	m_crtc->set_char_width(8);
 	m_crtc->set_update_row_callback(FUNC(vic20_video_pak_device::crtc_update_row), this);
 }

--- a/src/devices/bus/wangpc/lvc.cpp
+++ b/src/devices/bus/wangpc/lvc.cpp
@@ -72,7 +72,7 @@ MC6845_UPDATE_ROW( wangpc_lvc_device::crtc_update_row )
 
 				if (column == cursor_x) color = 0x03;
 
-				bitmap.pix32(vbp + y, hbp + x) = de ? m_palette[color] : rgb_t::black();
+				bitmap.pix32(y, hbp + x) = de ? m_palette[color] : rgb_t::black();
 
 				data <<= 1;
 			}
@@ -94,7 +94,7 @@ MC6845_UPDATE_ROW( wangpc_lvc_device::crtc_update_row )
 
 				if (column == cursor_x) color = 0x03;
 
-				bitmap.pix32(vbp + y, hbp + x) = de ? m_palette[color] : rgb_t::black();
+				bitmap.pix32(y, hbp + x) = de ? m_palette[color] : rgb_t::black();
 
 				data <<= 1;
 			}
@@ -120,14 +120,12 @@ void wangpc_lvc_device::device_add_mconfig(machine_config &config)
 {
 	screen_device &screen(SCREEN(config, SCREEN_TAG, SCREEN_TYPE_RASTER));
 	screen.set_screen_update(MC6845_TAG, FUNC(mc6845_device::screen_update));
-	screen.set_size(80*8, 25*9);
-	screen.set_visarea(0, 80*8-1, 0, 25*9-1);
 	screen.set_vblank_time(ATTOSECONDS_IN_USEC(2500));
 	screen.set_refresh_hz(60);
 
 	MC6845_1(config, m_crtc, XTAL(14'318'181)/16);
 	m_crtc->set_screen(SCREEN_TAG);
-	m_crtc->set_show_border_area(true);
+	m_crtc->set_show_border_area(false);
 	m_crtc->set_char_width(8);
 	m_crtc->set_update_row_callback(FUNC(wangpc_lvc_device::crtc_update_row), this);
 	m_crtc->out_vsync_callback().set(FUNC(wangpc_lvc_device::vsync_w));

--- a/src/devices/video/mc6845.h
+++ b/src/devices/video/mc6845.h
@@ -235,9 +235,10 @@ protected:
 	void set_vsync(int state);
 	void set_cur(int state);
 	bool match_line();
+	bool check_cursor_visible(uint16_t ra, uint16_t line_addr);
 	void handle_line_timer();
 	virtual void update_cursor_state();
-	virtual uint8_t draw_scanline(int y, bitmap_rgb32 &bitmap, const rectangle &cliprect);
+	virtual void draw_scanline(int y, bitmap_rgb32 &bitmap, const rectangle &cliprect);
 
 	/************************
 	 interface CRTC - driver
@@ -447,7 +448,6 @@ protected:
 	int m_revision;
 
 	virtual void update_cursor_state() override;
-	virtual uint8_t draw_scanline(int y, bitmap_rgb32 &bitmap, const rectangle &cliprect) override;
 
 	static const device_timer_id TIMER_BLOCK_COPY = 9;
 

--- a/src/mame/drivers/5clown.cpp
+++ b/src/mame/drivers/5clown.cpp
@@ -553,7 +553,7 @@ MC6845_UPDATE_ROW(_5clown_state::update_row)
     x--- ----   Extra color for 7's.
 */
 
-	uint32_t *pix = &bitmap.pix32(y);
+	uint32_t *pix = &bitmap.pix32(y, hbp);
 	ra &= 0x07;
 
 	for (int x = 0; x < x_count; x++)

--- a/src/mame/drivers/alphatro.cpp
+++ b/src/mame/drivers/alphatro.cpp
@@ -340,11 +340,11 @@ MC6845_UPDATE_ROW( alphatro_state::crtc_update_row )
 {
 	const rgb_t *pens = m_palette->palette()->entry_list_raw();
 	bool palette = BIT(m_config->read(), 5);
-	if (y==0) m_flashcnt++;
+	if (y==vbp) m_flashcnt++;
 	bool inv;
 	u8 chr,gfx,attr,bg,fg;
 	u16 mem,x;
-	u32 *p = &bitmap.pix32(y);
+	u32 *p = &bitmap.pix32(y, hbp);
 
 	for (x = 0; x < x_count; x++)
 	{

--- a/src/mame/drivers/amusco.cpp
+++ b/src/mame/drivers/amusco.cpp
@@ -474,13 +474,17 @@ MC6845_ON_UPDATE_ADDR_CHANGED(amusco_state::crtc_addr)
 MC6845_UPDATE_ROW(amusco_state::update_row)
 {
 	// Latch blink state at start of first line, where cursor is always positioned
-	if (y == 0 && ma == 0 && m_blink_state != (cursor_x == 0))
+	if (y == vbp && ma == 0 && m_blink_state != (cursor_x == 0))
 	{
 		m_blink_state = (cursor_x == 0);
 		m_bg_tilemap->mark_all_dirty();
 	}
 
-	const rectangle rowrect(0, 8 * x_count - 1, y, y);
+	// The texture wraps and a scroll offset is applied to offset the
+	// texture to the visible area, offset from the border.
+	const rectangle rowrect(hbp + 0, hbp + 8 * x_count - 1, y, y);
+	m_bg_tilemap->set_scrollx(-hbp);
+	m_bg_tilemap->set_scrolly(-vbp);
 	m_bg_tilemap->draw(*m_screen, bitmap, rowrect, 0, 0);
 }
 
@@ -577,8 +581,6 @@ void amusco_state::amusco(machine_config &config)
 	SCREEN(config, m_screen, SCREEN_TYPE_RASTER);
 	m_screen->set_refresh_hz(60);
 	m_screen->set_vblank_time(ATTOSECONDS_IN_USEC(0));
-	m_screen->set_size(88*8, 27*10);                           // screen size: 88*8 27*10
-	m_screen->set_visarea(0*8, 74*8-1, 0*10, 24*10-1);    // visible scr: 74*8 24*10
 	m_screen->set_screen_update("crtc", FUNC(mc6845_device::screen_update));
 
 	GFXDECODE(config, m_gfxdecode, "palette", gfx_amusco);

--- a/src/mame/drivers/amust.cpp
+++ b/src/mame/drivers/amust.cpp
@@ -383,7 +383,7 @@ MC6845_UPDATE_ROW( amust_state::crtc_update_row )
 	const rgb_t *palette = m_palette->palette()->entry_list_raw();
 	u8 chr,gfx,inv;
 	u16 mem,x;
-	u32 *p = &bitmap.pix32(y);
+	u32 *p = &bitmap.pix32(y, hbp);
 
 	for (x = 0; x < x_count; x++)
 	{
@@ -444,8 +444,6 @@ void amust_state::amust(machine_config &config)
 	screen_device &screen(SCREEN(config, "screen", SCREEN_TYPE_RASTER, rgb_t::green()));
 	screen.set_refresh_hz(50);
 	screen.set_vblank_time(ATTOSECONDS_IN_USEC(2500)); /* not accurate */
-	screen.set_size(640, 480);
-	screen.set_visarea(0, 640-1, 0, 480-1);
 	screen.set_screen_update("crtc", FUNC(mc6845_device::screen_update));
 	PALETTE(config, m_palette, palette_device::MONOCHROME);
 	GFXDECODE(config, "gfxdecode", m_palette, gfx_amust);

--- a/src/mame/drivers/applix.cpp
+++ b/src/mame/drivers/applix.cpp
@@ -797,7 +797,7 @@ MC6845_UPDATE_ROW( applix_state::crtc_update_row )
 	// The 6845 cursor signal is not used at all.
 	rgb_t const *const palette = m_palette->palette()->entry_list_raw();
 	uint32_t const vidbase = (m_video_latch & 15) << 14 | (ra & 7) << 12;
-	uint32_t *p = &bitmap.pix32(y + vbp, hbp);
+	uint32_t *p = &bitmap.pix32(y, hbp);
 
 	for (uint16_t x = 0; x < x_count; x++)
 	{
@@ -877,8 +877,6 @@ void applix_state::applix(machine_config &config)
 	screen_device &screen(SCREEN(config, "screen", SCREEN_TYPE_RASTER));
 	screen.set_refresh_hz(50);
 	screen.set_vblank_time(ATTOSECONDS_IN_USEC(2500)); /* not accurate */
-	screen.set_size(640, 200);
-	screen.set_visarea_full();
 	screen.set_screen_update("crtc", FUNC(mc6845_device::screen_update));
 	PALETTE(config, m_palette, FUNC(applix_state::applix_palette), 16);
 
@@ -894,7 +892,7 @@ void applix_state::applix(machine_config &config)
 	/* Devices */
 	MC6845(config, m_crtc, 30_MHz_XTAL / 16); // MC6545 @ 1.875 MHz
 	m_crtc->set_screen("screen");
-	m_crtc->set_show_border_area(true);
+	m_crtc->set_show_border_area(false);
 	m_crtc->set_char_width(8);
 	m_crtc->set_update_row_callback(FUNC(applix_state::crtc_update_row), this);
 	m_crtc->set_begin_update_callback(FUNC(applix_state::crtc_update_border), this);

--- a/src/mame/drivers/applix.cpp
+++ b/src/mame/drivers/applix.cpp
@@ -892,7 +892,7 @@ void applix_state::applix(machine_config &config)
 	/* Devices */
 	MC6845(config, m_crtc, 30_MHz_XTAL / 16); // MC6545 @ 1.875 MHz
 	m_crtc->set_screen("screen");
-	m_crtc->set_show_border_area(false);
+	m_crtc->set_show_border_area(true);
 	m_crtc->set_char_width(8);
 	m_crtc->set_update_row_callback(FUNC(applix_state::crtc_update_row), this);
 	m_crtc->set_begin_update_callback(FUNC(applix_state::crtc_update_border), this);

--- a/src/mame/drivers/apricot.cpp
+++ b/src/mame/drivers/apricot.cpp
@@ -298,14 +298,14 @@ MC6845_UPDATE_ROW( apricot_state::crtc_update_row )
 			{
 				int color = fill ? 1 : BIT(data, x);
 				color ^= BIT(code, 15); // reverse?
-				bitmap.pix32(y, x + i*10) = pen[color ? 1 + BIT(code, 14) : 0];
+				bitmap.pix32(y, hbp + x + i*10) = pen[color ? 1 + BIT(code, 14) : 0];
 			}
 		}
 		else
 		{
 			// draw 16 pixels of the cell
 			for (int x = 0; x <= 16; x++)
-				bitmap.pix32(y, x + i*16) = pen[BIT(data, x)];
+				bitmap.pix32(y, hbp + x + i*16) = pen[BIT(data, x)];
 		}
 	}
 }
@@ -382,8 +382,6 @@ void apricot_state::apricot(machine_config &config)
 	// video hardware
 	screen_device &screen(SCREEN(config, "screen", SCREEN_TYPE_RASTER));
 	screen.set_color(rgb_t::green());
-	screen.set_size(800, 400);
-	screen.set_visarea(0, 800-1, 0, 400-1);
 	screen.set_refresh_hz(72);
 	screen.set_screen_update(FUNC(apricot_state::screen_update_apricot));
 

--- a/src/mame/drivers/apricotp.cpp
+++ b/src/mame/drivers/apricotp.cpp
@@ -593,7 +593,6 @@ void fp_state::fp(machine_config &config)
 	screen_crt.set_refresh_hz(50);
 	screen_crt.set_vblank_time(ATTOSECONDS_IN_USEC(2500)); /* not accurate */
 	screen_crt.set_screen_update(MC6845_TAG, FUNC(mc6845_device::screen_update));
-	screen_crt.set_size(640, 256);
 	screen_crt.set_visarea_full();
 
 	PALETTE(config, "palette").set_entries(16);

--- a/src/mame/drivers/banctec.cpp
+++ b/src/mame/drivers/banctec.cpp
@@ -90,7 +90,7 @@ MC6845_UPDATE_ROW( banctec_state::crtc_update_row )
 	const rgb_t *palette = m_palette->palette()->entry_list_raw();
 	u8 chr,gfx;
 	u16 mem,x;
-	u32 *p = &bitmap.pix32(y);
+	u32 *p = &bitmap.pix32(y, hbp);
 
 	for (x = 0; x < x_count; x++)
 	{

--- a/src/mame/drivers/bigbord2.cpp
+++ b/src/mame/drivers/bigbord2.cpp
@@ -519,7 +519,7 @@ MC6845_UPDATE_ROW( bigbord2_state::crtc_update_row )
 	const rgb_t *palette = m_palette->palette()->entry_list_raw();
 	u8 chr,gfx,attr;
 	uint16_t mem,x;
-	uint32_t *p = &bitmap.pix32(y);
+	uint32_t *p = &bitmap.pix32(y, hbp);
 	ra &= 15;
 	m_cnt++;
 

--- a/src/mame/drivers/bml3.cpp
+++ b/src/mame/drivers/bml3.cpp
@@ -590,7 +590,7 @@ MC6845_UPDATE_ROW( bml3_state::crtc_update_row )
 	if (interlace)
 	{
 		ra >>= 1;
-		if (y > 0x191) return;
+		if ((y - vbp) > 0x191) return;
 	}
 
 	// redundant initializers to keep compiler happy
@@ -650,9 +650,9 @@ MC6845_UPDATE_ROW( bml3_state::crtc_update_row )
 				else
 					pen = (dots[hf] >> (7-xi) & 1) ? color : bgcolor;
 
-				bitmap.pix32(y, x*8+xi) = palette[pen];
+				bitmap.pix32(y, hbp + x*8+xi) = palette[pen];
 				// when the mc6845 device gains full interlace&video support, replace the line above with the line below
-				// bitmap.pix32(y*(interlace+1)+hf, x*8+xi) = palette[pen];
+				// bitmap.pix32(y*(interlace+1)+hf, hbp + x*8+xi) = palette[pen];
 			}
 		}
 	}
@@ -925,8 +925,6 @@ void bml3_state::bml3_common(machine_config &config)
 	screen_device &screen(SCREEN(config, "screen", SCREEN_TYPE_RASTER));
 	screen.set_refresh_hz(60);
 	screen.set_vblank_time(ATTOSECONDS_IN_USEC(2400)); /* Service manual specifies "Raster return period" as 2.4 ms (p.64), although the total vertical non-displaying time seems to be 4 ms. */
-	screen.set_size(640, 400);
-	screen.set_visarea(0, 320-1, 0, 200-1);
 	screen.set_screen_update("crtc", FUNC(mc6845_device::screen_update));
 	PALETTE(config, m_palette, palette_device::BRG_3BIT);
 

--- a/src/mame/drivers/bw12.cpp
+++ b/src/mame/drivers/bw12.cpp
@@ -355,7 +355,7 @@ MC6845_UPDATE_ROW( bw12_state::crtc_update_row )
 			int x = (column * 8) + bit;
 			int color = BIT(data, 7) && de;
 
-			bitmap.pix32(vbp + y, hbp + x) = pen[color];
+			bitmap.pix32(y, hbp + x) = pen[color];
 
 			data <<= 1;
 		}
@@ -561,15 +561,13 @@ void bw12_state::common(machine_config &config)
 	screen.set_refresh_hz(60);
 	screen.set_vblank_time(ATTOSECONDS_IN_USEC(2500)); /* not accurate */
 	screen.set_screen_update(MC6845_TAG, FUNC(mc6845_device::screen_update));
-	screen.set_size(640, 200);
-	screen.set_visarea(0, 640-1, 0, 200-1);
 
 	GFXDECODE(config, "gfxdecode", m_palette, gfx_bw12);
 	PALETTE(config, m_palette, palette_device::MONOCHROME);
 
 	MC6845(config, m_crtc, XTAL(16'000'000)/8);
 	m_crtc->set_screen(SCREEN_TAG);
-	m_crtc->set_show_border_area(true);
+	m_crtc->set_show_border_area(false);
 	m_crtc->set_char_width(8);
 	m_crtc->set_update_row_callback(FUNC(bw12_state::crtc_update_row), this);
 

--- a/src/mame/drivers/c128.cpp
+++ b/src/mame/drivers/c128.cpp
@@ -1853,13 +1853,11 @@ void c128_state::pal(machine_config &config)
 	MOS8563(config, m_vdc, XTAL(16'000'000));
 	m_vdc->set_screen(SCREEN_VDC_TAG);
 	m_vdc->set_addrmap(0, &c128_state::vdc_videoram_map);
-	m_vdc->set_show_border_area(true);
+	m_vdc->set_show_border_area(false);
 	m_vdc->set_char_width(8);
 
 	screen_device &screen_vdc(SCREEN(config, SCREEN_VDC_TAG, SCREEN_TYPE_RASTER));
 	screen_vdc.set_refresh_hz(60);
-	screen_vdc.set_size(640, 200);
-	screen_vdc.set_visarea(0, 640-1, 0, 200-1);
 	screen_vdc.set_screen_update(MOS8563_TAG, FUNC(mos8563_device::screen_update));
 
 	mos8566_device &mos8566(MOS8566(config, MOS8566_TAG, XTAL(17'734'472)*2/4.5));

--- a/src/mame/drivers/camplynx.cpp
+++ b/src/mame/drivers/camplynx.cpp
@@ -750,7 +750,7 @@ MACHINE_RESET_MEMBER(camplynx_state, lynx128k)
 MC6845_UPDATE_ROW( camplynx_state::lynx48k_update_row )
 {
 	uint8_t r,g,b,x;
-	uint32_t green_bank, *p = &bitmap.pix32(y);
+	uint32_t green_bank, *p = &bitmap.pix32(y, hbp);
 	uint16_t mem = ((ma << 2) + (ra << 5)) & 0x1fff;
 
 	// determine green bank
@@ -779,7 +779,7 @@ MC6845_UPDATE_ROW( camplynx_state::lynx48k_update_row )
 MC6845_UPDATE_ROW( camplynx_state::lynx128k_update_row )
 {
 	uint8_t r,g,b,x;
-	uint32_t green_bank, *p = &bitmap.pix32(y);
+	uint32_t green_bank, *p = &bitmap.pix32(y, hbp);
 	uint16_t mem = ((ma << 2) + (ra << 6)) & 0x3fff;
 	// determine green bank
 	if (BIT(m_port80, 4))
@@ -878,8 +878,6 @@ void camplynx_state::lynx48k(machine_config &config)
 	screen_device &screen(SCREEN(config, "screen", SCREEN_TYPE_RASTER));
 	screen.set_refresh_hz(50);
 	screen.set_vblank_time(ATTOSECONDS_IN_USEC(2500)); /* not accurate */
-	screen.set_size(512, 480);
-	screen.set_visarea_full();
 	screen.set_screen_update("crtc", FUNC(mc6845_device::screen_update));
 
 	lynx_common(config);
@@ -927,8 +925,6 @@ void camplynx_state::lynx128k(machine_config &config)
 	screen_device &screen(SCREEN(config, "screen", SCREEN_TYPE_RASTER));
 	screen.set_refresh_hz(50);
 	screen.set_vblank_time(ATTOSECONDS_IN_USEC(2500)); /* not accurate */
-	screen.set_size(512, 480);
-	screen.set_visarea_full();
 	screen.set_screen_update("crtc", FUNC(mc6845_device::screen_update));
 
 	lynx_common(config);

--- a/src/mame/drivers/cardline.cpp
+++ b/src/mame/drivers/cardline.cpp
@@ -145,9 +145,9 @@ MC6845_UPDATE_ROW( cardline_state::crtc_update_row )
 			int fg_col = gfx[fg_tile * 64 + ra * 8 + i];
 
 			if (fg_col == 1)
-				bitmap.pix32(y, x) = palette[bg_pal_ofs + bg_col];
+				bitmap.pix32(y, hbp + x) = palette[bg_pal_ofs + bg_col];
 			else
-				bitmap.pix32(y, x) = palette[fg_pal_ofs + fg_col];
+				bitmap.pix32(y, hbp + x) = palette[fg_pal_ofs + fg_col];
 
 			x++;
 		}
@@ -349,10 +349,6 @@ void cardline_state::cardline(machine_config &config)
 	screen_device &screen(SCREEN(config, "screen", SCREEN_TYPE_RASTER));
 	screen.set_refresh_hz(60);
 	screen.set_vblank_time(ATTOSECONDS_IN_USEC(0));
-	screen.set_size(64*8, 35*8);
-	screen.set_visarea(0*8, 64*8-1, 0*8, 32*8-1);
-	//screen.set_screen_update(FUNC(cardline_state::screen_update_cardline));
-	//screen.set_palette(m_palette);
 	screen.set_screen_update("crtc", FUNC(mc6845_device::screen_update));
 
 	GFXDECODE(config, m_gfxdecode, m_palette, gfx_cardline);

--- a/src/mame/drivers/cbm2.cpp
+++ b/src/mame/drivers/cbm2.cpp
@@ -1430,7 +1430,7 @@ MC6845_UPDATE_ROW( cbm2_state::crtc_update_row )
 			if (cursor_x == column) color ^= 1;
 			color &= de;
 
-			bitmap.pix32(vbp + y, hbp + x++) = pen[color];
+			bitmap.pix32(y, hbp + x++) = pen[color];
 
 			if (bit < 8 || !m_graphics) data <<= 1;
 		}
@@ -2530,14 +2530,12 @@ void cbm2_state::cbm2lp_ntsc(machine_config &config)
 	screen.set_screen_update(MC68B45_TAG, FUNC(mc6845_device::screen_update));
 	screen.set_refresh_hz(60);
 	screen.set_vblank_time(ATTOSECONDS_IN_USEC(2500));
-	screen.set_size(768, 312);
-	screen.set_visarea(0, 768-1, 0, 312-1);
 
 	PALETTE(config, m_palette, palette_device::MONOCHROME);
 
 	MC6845(config, m_crtc, XTAL(18'000'000)/9);
 	m_crtc->set_screen(SCREEN_TAG);
-	m_crtc->set_show_border_area(true);
+	m_crtc->set_show_border_area(false);
 	m_crtc->set_char_width(9);
 	m_crtc->set_update_row_callback(FUNC(cbm2_state::crtc_update_row), this);
 

--- a/src/mame/drivers/cgenie.cpp
+++ b/src/mame/drivers/cgenie.cpp
@@ -446,7 +446,7 @@ void cgenie_state::cgenie(machine_config &config)
 
 	HD6845S(config, m_crtc, XTAL(17'734'470) / 16);
 	m_crtc->set_screen("screen");
-	m_crtc->set_show_border_area(false);
+	m_crtc->set_show_border_area(true);
 	m_crtc->set_char_width(8);
 	m_crtc->set_begin_update_callback(FUNC(cgenie_state::crtc_begin_update), this);
 	m_crtc->set_update_row_callback(FUNC(cgenie_state::crtc_update_row), this);

--- a/src/mame/drivers/cgenie.cpp
+++ b/src/mame/drivers/cgenie.cpp
@@ -6,8 +6,6 @@
 
     TODO:
     - System is too fast, there should be one wait cycle every five cycles?
-    - Adjust visible area so that the borders aren't that large (needs
-      MC6845 changes)
     - Verify BASIC and character set versions
 
 ***************************************************************************/
@@ -344,10 +342,10 @@ MC6845_UPDATE_ROW( cgenie_state::crtc_update_row )
 		{
 			const rgb_t map[] = { m_background_color, m_palette[8], m_palette[6], m_palette[5] };
 
-			bitmap.pix32(y + vbp, column * 4 + hbp + 0) = map[code >> 6 & 0x03];
-			bitmap.pix32(y + vbp, column * 4 + hbp + 1) = map[code >> 4 & 0x03];
-			bitmap.pix32(y + vbp, column * 4 + hbp + 2) = map[code >> 2 & 0x03];
-			bitmap.pix32(y + vbp, column * 4 + hbp + 3) = map[code >> 0 & 0x03];
+			bitmap.pix32(y, column * 4 + hbp + 0) = map[code >> 6 & 0x03];
+			bitmap.pix32(y, column * 4 + hbp + 1) = map[code >> 4 & 0x03];
+			bitmap.pix32(y, column * 4 + hbp + 2) = map[code >> 2 & 0x03];
+			bitmap.pix32(y, column * 4 + hbp + 3) = map[code >> 0 & 0x03];
 		}
 		else
 		{
@@ -367,7 +365,7 @@ MC6845_UPDATE_ROW( cgenie_state::crtc_update_row )
 
 			// 8 pixel chars
 			for (int p = 0; p < 8; p++)
-				bitmap.pix32(y + vbp, column * 8 + hbp + p) = BIT(gfx, 7 - p) ? m_palette[color] : m_background_color;
+				bitmap.pix32(y, column * 8 + hbp + p) = BIT(gfx, 7 - p) ? m_palette[color] : m_background_color;
 		}
 	}
 }
@@ -448,7 +446,7 @@ void cgenie_state::cgenie(machine_config &config)
 
 	HD6845S(config, m_crtc, XTAL(17'734'470) / 16);
 	m_crtc->set_screen("screen");
-	m_crtc->set_show_border_area(true);
+	m_crtc->set_show_border_area(false);
 	m_crtc->set_char_width(8);
 	m_crtc->set_begin_update_callback(FUNC(cgenie_state::crtc_begin_update), this);
 	m_crtc->set_update_row_callback(FUNC(cgenie_state::crtc_update_row), this);

--- a/src/mame/drivers/dim68k.cpp
+++ b/src/mame/drivers/dim68k.cpp
@@ -236,7 +236,7 @@ MC6845_UPDATE_ROW( dim68k_state::crtc_update_row )
 	const rgb_t *palette = m_palette->palette()->entry_list_raw();
 	u8 chr,gfx,x,xx,inv;
 	uint16_t chr16=0x2020; // set to spaces if screen is off
-	uint32_t *p = &bitmap.pix32(y);
+	uint32_t *p = &bitmap.pix32(y, hbp);
 	u8 screen_on = ~m_video_control & 4;
 	u8 dot8 = ~m_video_control & 40;
 
@@ -321,8 +321,6 @@ void dim68k_state::dim68k(machine_config &config)
 	screen.set_refresh_hz(50);
 	screen.set_vblank_time(ATTOSECONDS_IN_USEC(2500)); /* not accurate */
 	screen.set_screen_update("crtc", FUNC(mc6845_device::screen_update));
-	screen.set_size(640, 480);
-	screen.set_visarea(0, 640-1, 0, 250-1);
 	PALETTE(config, m_palette, palette_device::MONOCHROME);
 	GFXDECODE(config, "gfxdecode", m_palette, gfx_dim68k);
 

--- a/src/mame/drivers/dpb7000.cpp
+++ b/src/mame/drivers/dpb7000.cpp
@@ -547,7 +547,7 @@ MC6845_UPDATE_ROW(dpb7000_state::crtc_update_row)
 			int x = (column * 8) + bit;
 			int color = BIT(data, 7) && de;
 
-			bitmap.pix32(y, x) = pen[color];
+			bitmap.pix32(y, hbp + x) = pen[color];
 
 			data <<= 1;
 		}

--- a/src/mame/drivers/duet16.cpp
+++ b/src/mame/drivers/duet16.cpp
@@ -233,7 +233,7 @@ MC6845_UPDATE_ROW(duet16_state::crtc_update_row)
 				color = m_pal->pen_color((BIT(g2, 7 - xi) << 2) | (BIT(g1, 7 - xi) << 1) | BIT(g0, 7 - xi));
 			else
 				color = 0;
-			bitmap.pix32(y, (i * 8) + xi) = color;
+			bitmap.pix32(y, hbp + (i * 8) + xi) = color;
 		}
 	}
 }
@@ -421,6 +421,7 @@ void duet16_state::duet16(machine_config &config)
 	FLOPPY_CONNECTOR(config, "fdc:1", duet16_floppies, "525qd", floppy_image_device::default_floppy_formats, true);
 
 	hd6845s_device &crtc(HD6845S(config, "crtc", 2000000)); // "46505S" on schematics
+	crtc.set_show_border_area(false);
 	crtc.set_char_width(8);
 	crtc.set_update_row_callback(FUNC(duet16_state::crtc_update_row), this);
 
@@ -431,8 +432,6 @@ void duet16_state::duet16(machine_config &config)
 
 	SCREEN(config, m_screen, SCREEN_TYPE_RASTER);
 	m_screen->set_refresh_hz(60);
-	m_screen->set_size(640, 480);
-	m_screen->set_visarea_full();
 	m_screen->set_screen_update("crtc", FUNC(hd6845s_device::screen_update));
 
 	MSM58321(config, m_rtc, 32768_Hz_XTAL);

--- a/src/mame/drivers/ec65.cpp
+++ b/src/mame/drivers/ec65.cpp
@@ -116,7 +116,7 @@ MC6845_UPDATE_ROW( ec65_state::crtc_update_row )
 	const rgb_t *palette = m_palette->palette()->entry_list_raw();
 	uint8_t chr,gfx,inv;
 	uint16_t mem,x;
-	uint32_t *p = &bitmap.pix32(y);
+	uint32_t *p = &bitmap.pix32(y, hbp);
 
 	for (x = 0; x < x_count; x++)
 	{
@@ -167,8 +167,6 @@ void ec65_state::ec65(machine_config &config)
 	screen_device &screen(SCREEN(config, "screen", SCREEN_TYPE_RASTER));
 	screen.set_refresh_hz(60);
 	screen.set_vblank_time(ATTOSECONDS_IN_USEC(2500)); /* not accurate */
-	screen.set_size(640, 200);
-	screen.set_visarea_full();
 	screen.set_screen_update(MC6845_TAG, FUNC(mc6845_device::screen_update));
 
 	GFXDECODE(config, "gfxdecode", m_palette, gfx_ec65);
@@ -206,8 +204,6 @@ void ec65k_state::ec65k(machine_config &config)
 	screen_device &screen(SCREEN(config, "screen", SCREEN_TYPE_RASTER));
 	screen.set_refresh_hz(60);
 	screen.set_vblank_time(ATTOSECONDS_IN_USEC(2500)); /* not accurate */
-	screen.set_size(640, 200);
-	screen.set_visarea_full();
 	screen.set_screen_update(MC6845_TAG, FUNC(mc6845_device::screen_update));
 
 	GFXDECODE(config, "gfxdecode", "palette", gfx_ec65);

--- a/src/mame/drivers/esprit.cpp
+++ b/src/mame/drivers/esprit.cpp
@@ -83,7 +83,7 @@ INPUT_PORTS_END
 MC6845_UPDATE_ROW(esprit_state::crtc_update_row)
 {
 	const rgb_t *pens = m_palette->palette()->entry_list_raw();
-	uint32_t *p = &bitmap.pix32(y);
+	uint32_t *p = &bitmap.pix32(y, hbp);
 
 	for (uint16_t x = 0; x < x_count; x++)
 	{

--- a/src/mame/drivers/excali64.cpp
+++ b/src/mame/drivers/excali64.cpp
@@ -517,7 +517,7 @@ MC6845_UPDATE_ROW( excali64_state::update_row )
 	uint8_t chr,gfx,col,bg,fg;
 	uint16_t mem,x;
 	uint8_t col_base = BIT(m_sys_status, 3) ? 16 : 0;
-	uint32_t *p = &bitmap.pix32(y);
+	uint32_t *p = &bitmap.pix32(y, hbp);
 
 	for (x = 0; x < x_count; x++)
 	{
@@ -584,8 +584,6 @@ void excali64_state::excali64(machine_config &config)
 	screen_device &screen(SCREEN(config, "screen", SCREEN_TYPE_RASTER));
 	screen.set_refresh_hz(50);
 	screen.set_vblank_time(ATTOSECONDS_IN_USEC(2500)); /* not accurate */
-	screen.set_size(80*8, 24*12);
-	screen.set_visarea_full();
 	screen.set_screen_update("crtc", FUNC(mc6845_device::screen_update));
 
 	PALETTE(config, m_palette, FUNC(excali64_state::excali64_palette), 40);

--- a/src/mame/drivers/facit4440.cpp
+++ b/src/mame/drivers/facit4440.cpp
@@ -148,7 +148,7 @@ WRITE_LINE_MEMBER(facit4440_state::vsync_w)
 MC6845_UPDATE_ROW(facit4440_state::update_row)
 {
 	offs_t base = ma / 5 * 6;
-	u32 *px = &bitmap.pix32(y);
+	u32 *px = &bitmap.pix32(y, hbp);
 
 	for (int i = 0; i < x_count; i++)
 	{

--- a/src/mame/drivers/fanucspmg.cpp
+++ b/src/mame/drivers/fanucspmg.cpp
@@ -846,7 +846,7 @@ WRITE8_MEMBER(fanucspmg_state::memory_write_byte)
 
 MC6845_UPDATE_ROW( fanucspmg_state::crtc_update_row )
 {
-	uint32_t  *p = &bitmap.pix32(y);
+	uint32_t  *p = &bitmap.pix32(y, hbp);
 	int i;
 	uint8_t *chargen = m_chargen->base();
 
@@ -894,7 +894,7 @@ MC6845_UPDATE_ROW( fanucspmg_state::crtc_update_row )
 
 MC6845_UPDATE_ROW( fanucspmg_state::crtc_update_row_mono )
 {
-	uint32_t  *p = &bitmap.pix32(y);
+	uint32_t  *p = &bitmap.pix32(y, hbp);
 	int i;
 	uint8_t *chargen = m_chargen->base();
 

--- a/src/mame/drivers/flipjack.cpp
+++ b/src/mame/drivers/flipjack.cpp
@@ -174,8 +174,8 @@ MC6845_UPDATE_ROW(flipjack_state::update_row)
 {
 	const bool flip = !BIT(m_layer, 0);
 	const uint16_t row_base = ((ma & 0x03e0) << 3 | (ra & 7) << 5) ^ (flip ? 0x1fff : 0);
-	uint32_t *const pbegin = &bitmap.pix32(y);
-	uint32_t *const pend = &bitmap.pix32(y, x_count * 8);
+	uint32_t *const pbegin = &bitmap.pix32(y, hbp);
+	uint32_t *const pend = &bitmap.pix32(y, hbp + x_count * 8);
 
 	std::fill(pbegin, pend, rgb_t::black());
 

--- a/src/mame/drivers/fp1100.cpp
+++ b/src/mame/drivers/fp1100.cpp
@@ -138,7 +138,7 @@ MC6845_UPDATE_ROW( fp1100_state::crtc_update_row )
 	const rgb_t *palette = m_palette->palette()->entry_list_raw();
 	uint8_t r,g,b,col,i;
 	uint16_t mem,x;
-	uint32_t *p = &bitmap.pix32(y);
+	uint32_t *p = &bitmap.pix32(y, hbp);
 
 	if (BIT(m_upd7801.porta, 4))
 	{ // green screen

--- a/src/mame/drivers/fs3216.cpp
+++ b/src/mame/drivers/fs3216.cpp
@@ -141,7 +141,7 @@ void fs3216_state::machine_reset()
 
 MC6845_UPDATE_ROW(fs3216_state::crt_update_row)
 {
-	u32 *px = &bitmap.pix32(y);
+	u32 *px = &bitmap.pix32(y, hbp);
 
 	for (int i = 0; i < x_count; i++)
 	{

--- a/src/mame/drivers/goupil.cpp
+++ b/src/mame/drivers/goupil.cpp
@@ -489,7 +489,7 @@ WRITE_LINE_MEMBER( goupil_g1_state::via_video_ca2_w )
 MC6845_UPDATE_ROW(goupil_g2_state::crtc_update_row)
 {
 	rgb_t const *const palette = m_palette->palette()->entry_list_raw();
-	uint32_t *p = &bitmap.pix32(y);
+	uint32_t *p = &bitmap.pix32(y, hbp);
 	for (uint8_t x = 0; x < x_count; ++x)
 	{
 		uint16_t const offset = ( 0x400 + ( ma + x ) ) & 0x7FF;
@@ -594,8 +594,6 @@ void goupil_g2_state::goupil_g2(machine_config &config)
 	m_visu24x80_ram->set_default_size("2K");    // visu24x80 2K ram
 
 	m_screen->set_screen_update("crtc", FUNC(mc6845_device::screen_update));
-	m_screen->set_size((80*8), (24*(8+4)));
-	m_screen->set_visarea(0, (80*8)-1, 0, (24*(8+4))-1);
 
 	PALETTE(config, m_palette, palette_device::MONOCHROME_HIGHLIGHT);
 

--- a/src/mame/drivers/gts3a.cpp
+++ b/src/mame/drivers/gts3a.cpp
@@ -324,7 +324,7 @@ MC6845_UPDATE_ROW( gts3a_state::crtc_update_row )
 	const rgb_t *palette = m_palette->palette()->entry_list_raw();
 	uint8_t gfx=0;
 	uint16_t mem,x;
-	uint32_t *p = &bitmap.pix32(y);
+	uint32_t *p = &bitmap.pix32(y, hbp);
 
 	for (x = 0; x < x_count; x++)
 	{

--- a/src/mame/drivers/h19.cpp
+++ b/src/mame/drivers/h19.cpp
@@ -472,7 +472,7 @@ WRITE_LINE_MEMBER(h19_state::mm5740_data_ready_w)
 MC6845_UPDATE_ROW( h19_state::crtc_update_row )
 {
 	const rgb_t *palette = m_palette->palette()->entry_list_raw();
-	uint32_t *p = &bitmap.pix32(y);
+	uint32_t *p = &bitmap.pix32(y, hbp);
 
 	for (uint16_t x = 0; x < x_count; x++)
 	{
@@ -533,15 +533,13 @@ void h19_state::h19(machine_config &config)
 	screen.set_refresh_hz(60);   // TODO- this is adjustable by dipswitch.
 	screen.set_vblank_time(ATTOSECONDS_IN_USEC(2500)); /* not accurate */
 	screen.set_screen_update("crtc", FUNC(mc6845_device::screen_update));
-	screen.set_size(640, 250);
-	screen.set_visarea(0, 640 - 1, 0, 250 - 1);
 
 	GFXDECODE(config, "gfxdecode", m_palette, gfx_h19);
 	PALETTE(config, "palette", palette_device::MONOCHROME);
 
 	MC6845(config, m_crtc, MC6845_CLOCK);
 	m_crtc->set_screen("screen");
-	m_crtc->set_show_border_area(true);
+	m_crtc->set_show_border_area(false);
 	m_crtc->set_char_width(8);
 	m_crtc->set_update_row_callback(FUNC(h19_state::crtc_update_row), this);
 	m_crtc->out_vsync_callback().set_inputline(m_maincpu, INPUT_LINE_NMI); // frame pulse

--- a/src/mame/drivers/hp16500.cpp
+++ b/src/mame/drivers/hp16500.cpp
@@ -143,7 +143,7 @@ WRITE_LINE_MEMBER( hp16500_state::vsync_changed )
 
 MC6845_UPDATE_ROW( hp16500_state::crtc_update_row )
 {
-	uint32_t *p = &bitmap.pix32(y);
+	uint32_t *p = &bitmap.pix32(y, hbp);
 	int i, pos;
 
 	pos =  y * 144;
@@ -165,7 +165,7 @@ MC6845_UPDATE_ROW( hp16500_state::crtc_update_row )
 
 MC6845_UPDATE_ROW( hp16500_state::crtc_update_row_1650 )
 {
-	uint32_t *p = &bitmap.pix32(y);
+	uint32_t *p = &bitmap.pix32(y, hbp);
 	int i, pos;
 
 	pos =  y * 148;

--- a/src/mame/drivers/itt1700.cpp
+++ b/src/mame/drivers/itt1700.cpp
@@ -51,7 +51,7 @@ private:
 
 MC6845_UPDATE_ROW(itt1700_state::update_row)
 {
-	u32 *px = &bitmap.pix32(y);
+	u32 *px = &bitmap.pix32(y, hbp);
 	u16 page = 0x800;
 
 	for (int i = 0; i < x_count; i++)

--- a/src/mame/drivers/kaypro.cpp
+++ b/src/mame/drivers/kaypro.cpp
@@ -298,8 +298,6 @@ void kaypro_state::kaypro484(machine_config &config)
 	SCREEN(config, m_screen, SCREEN_TYPE_RASTER);
 	m_screen->set_refresh_hz(60);
 	m_screen->set_vblank_time(ATTOSECONDS_IN_USEC(0));
-	m_screen->set_size(80*8, 25*16);
-	m_screen->set_visarea(0,80*8-1,0,25*16-1);
 	m_screen->set_screen_update(FUNC(kaypro_state::screen_update_kaypro484));
 
 	MCFG_VIDEO_START_OVERRIDE(kaypro_state, kaypro )
@@ -315,7 +313,7 @@ void kaypro_state::kaypro484(machine_config &config)
 	MC6845(config, m_crtc, 2000000); // comes out of ULA - needs to be measured
 	m_crtc->set_screen(m_screen);
 	m_crtc->set_show_border_area(false);
-	m_crtc->set_char_width(7);
+	m_crtc->set_char_width(8);
 	m_crtc->set_update_row_callback(FUNC(kaypro_state::kaypro484_update_row), this);
 
 	QUICKLOAD(config, "quickload", "com,cpm", attotime::from_seconds(3)).set_load_callback(FUNC(kaypro_state::quickload_cb), this);

--- a/src/mame/drivers/kdt6.cpp
+++ b/src/mame/drivers/kdt6.cpp
@@ -314,7 +314,7 @@ MC6845_UPDATE_ROW( kdt6_state::crtc_update_row )
 			for (int x = 0; x < 8; x++)
 			{
 				int color = BIT(data, 7 - x);
-				bitmap.pix32(y, x + i*8) = pen[blink ? 0 : (color ^ inverse)];
+				bitmap.pix32(y, hbp + x + i*8) = pen[blink ? 0 : (color ^ inverse)];
 			}
 		}
 		else
@@ -324,7 +324,7 @@ MC6845_UPDATE_ROW( kdt6_state::crtc_update_row )
 
 			// draw 8 pixels of the cell
 			for (int x = 0; x < 8; x++)
-				bitmap.pix32(y, x + i*8) = pen[BIT(data, 7 - x)];
+				bitmap.pix32(y, hbp + x + i*8) = pen[BIT(data, 7 - x)];
 		}
 	}
 }

--- a/src/mame/drivers/laserbas.cpp
+++ b/src/mame/drivers/laserbas.cpp
@@ -138,22 +138,23 @@ TIMER_DEVICE_CALLBACK_MEMBER(  laserbas_state::laserbas_scanline )
 MC6845_UPDATE_ROW( laserbas_state::crtc_update_row )
 {
 	int x = 0;
-	int x_max = 0x100;
+	int x_end = 0x100; /* x_count * 8 ? */
 	int dx = 1;
 
+	m_flipscreen = 0;
 	if (m_flipscreen)
 	{
-		y = 0xdf - y;
+		y = 0xdf - (y - vbp) + vbp;
 		x = 0xff;
-		x_max = -1;
+		x_end = -1;
 		dx = -1;
 	}
 
-	int pixaddr = y << 8;
+	int pixaddr = (y - vbp) << 8;
 	const rgb_t *palette = m_palette->palette()->entry_list_raw();
-	uint32_t *b = &bitmap.pix32(y);
+	uint32_t *b = &bitmap.pix32(y, hbp);
 
-	while (x != x_max)
+	while (x != x_end)
 	{
 		int offset = (pixaddr >> 1) & 0x7fff;
 		int shift = (pixaddr & 1) * 4; // two 4 bit pixels in one byte

--- a/src/mame/drivers/lola8a.cpp
+++ b/src/mame/drivers/lola8a.cpp
@@ -231,7 +231,7 @@ MC6845_UPDATE_ROW( lola8a_state::crtc_update_row )
 	const rgb_t *palette = m_palette->palette()->entry_list_raw();
 	u8 x,gfx;
 	u16 mem;
-	u32 *p = &bitmap.pix32(y);
+	u32 *p = &bitmap.pix32(y, hbp);
 	ma &= 0x7ff;
 
 	for (x = 0; x < x_count; x++)
@@ -307,8 +307,6 @@ void lola8a_state::lola8a(machine_config &config)
 	screen.set_refresh_hz(50);
 	screen.set_vblank_time(ATTOSECONDS_IN_USEC(2500)); /* not accurate */
 	screen.set_screen_update(HD46505SP_TAG, FUNC(hd6845s_device::screen_update));
-	screen.set_size(640, 480);
-	screen.set_visarea(0, 640-1, 0, 480-1);
 
 	hd6845s_device &crtc(HD6845S(config, HD46505SP_TAG, XTAL(8'000'000) / 8)); // HD6845 == HD46505S
 	crtc.set_screen("screen");

--- a/src/mame/drivers/m20.cpp
+++ b/src/mame/drivers/m20.cpp
@@ -129,7 +129,7 @@ private:
 
 MC6845_UPDATE_ROW( m20_state::update_row )
 {
-	uint32_t  *p = &bitmap.pix32(y);
+	uint32_t  *p = &bitmap.pix32(y, hbp);
 	const rgb_t *palette = m_palette->palette()->entry_list_raw();
 	int i, j;
 
@@ -805,8 +805,6 @@ void m20_state::m20(machine_config &config)
 	screen_device &screen(SCREEN(config, "screen", SCREEN_TYPE_RASTER));
 	screen.set_refresh_hz(60);
 	screen.set_vblank_time(ATTOSECONDS_IN_USEC(2500)); /* not accurate */
-	screen.set_size(512, 256);
-	screen.set_visarea(0, 512-1, 0, 256-1);
 	screen.set_screen_update("crtc", FUNC(mc6845_device::screen_update));
 	PALETTE(config, m_palette, palette_device::MONOCHROME);
 

--- a/src/mame/drivers/m3.cpp
+++ b/src/mame/drivers/m3.cpp
@@ -65,7 +65,7 @@ MC6845_UPDATE_ROW( m3_state::crtc_update_row )
 	const rgb_t *pens = m_palette->palette()->entry_list_raw();
 	uint8_t chr,gfx,inv;
 	uint16_t mem,x;
-	uint32_t *p = &bitmap.pix32(y);
+	uint32_t *p = &bitmap.pix32(y, hbp);
 
 	for (x = 0; x < x_count; x++)
 	{
@@ -126,8 +126,6 @@ void m3_state::m3(machine_config &config)
 	screen.set_refresh_hz(60);
 	screen.set_vblank_time(ATTOSECONDS_IN_USEC(2500)); // not correct
 	screen.set_screen_update("crtc", FUNC(mc6845_device::screen_update));
-	screen.set_size(640, 480);
-	screen.set_visarea(0, 639, 0, 479);
 	GFXDECODE(config, "gfxdecode", m_palette, gfx_f4disp);
 	PALETTE(config, m_palette, palette_device::MONOCHROME);
 

--- a/src/mame/drivers/mbc200.cpp
+++ b/src/mame/drivers/mbc200.cpp
@@ -269,7 +269,7 @@ MC6845_UPDATE_ROW( mbc200_state::update_row )
 	const rgb_t *palette = m_palette->palette()->entry_list_raw();
 	uint8_t gfx;
 	uint16_t mem,x;
-	uint32_t *p = &bitmap.pix32(y);
+	uint32_t *p = &bitmap.pix32(y, hbp);
 
 	for (x = 0; x < x_count; x++)
 	{
@@ -317,8 +317,6 @@ void mbc200_state::mbc200(machine_config &config)
 	screen_device &screen(SCREEN(config, "screen", SCREEN_TYPE_RASTER));
 	screen.set_refresh_hz(50);
 	screen.set_vblank_time(ATTOSECONDS_IN_USEC(2500)); /* not accurate */
-	screen.set_size(640, 400);
-	screen.set_visarea(0, 640-1, 0, 400-1);
 	screen.set_screen_update("crtc", FUNC(hd6845s_device::screen_update));
 	GFXDECODE(config, "gfxdecode", m_palette, gfx_mbc200);
 	PALETTE(config, m_palette, palette_device::MONOCHROME);

--- a/src/mame/drivers/mbee.cpp
+++ b/src/mame/drivers/mbee.cpp
@@ -663,8 +663,6 @@ void mbee_state::mbee(machine_config &config)
 	SCREEN(config, m_screen, SCREEN_TYPE_RASTER);
 	m_screen->set_refresh_hz(50);
 	m_screen->set_vblank_time(ATTOSECONDS_IN_USEC(250)); /* not accurate */
-	m_screen->set_size(64*8, 19*16);           /* need at least 17 lines for NET */
-	m_screen->set_visarea(0*8, 64*8-1, 0, 19*16-1);
 	m_screen->set_screen_update(FUNC(mbee_state::screen_update_mbee));
 
 	GFXDECODE(config, "gfxdecode", m_palette, gfx_mono);

--- a/src/mame/drivers/merit.cpp
+++ b/src/mame/drivers/merit.cpp
@@ -1433,7 +1433,6 @@ void merit_state::pitboss(machine_config &config)
 	mc6845_device &crtc(MC6845(config, "crtc", CRTC_CLOCK));
 	crtc.set_screen(m_screen);
 	crtc.set_show_border_area(false);
-	crtc.set_show_border_area(true);
 	crtc.set_char_width(8);
 	crtc.set_begin_update_callback(FUNC(merit_state::crtc_begin_update), this);
 	crtc.set_update_row_callback(FUNC(merit_state::crtc_update_row), this);

--- a/src/mame/drivers/merit.cpp
+++ b/src/mame/drivers/merit.cpp
@@ -333,7 +333,7 @@ MC6845_UPDATE_ROW( merit_state::crtc_update_row )
 				col |= 0x03;
 
 			col = m_ram_palette[col & 0x3ff];
-			bitmap.pix32(y, x) = m_pens[col ? col & (NUM_PENS-1) : (m_lscnblk ? 8 : 0)];
+			bitmap.pix32(y, hbp + x) = m_pens[col ? col & (NUM_PENS-1) : (m_lscnblk ? 8 : 0)];
 
 			x++;
 		}
@@ -1433,6 +1433,7 @@ void merit_state::pitboss(machine_config &config)
 	mc6845_device &crtc(MC6845(config, "crtc", CRTC_CLOCK));
 	crtc.set_screen(m_screen);
 	crtc.set_show_border_area(false);
+	crtc.set_show_border_area(true);
 	crtc.set_char_width(8);
 	crtc.set_begin_update_callback(FUNC(merit_state::crtc_begin_update), this);
 	crtc.set_update_row_callback(FUNC(merit_state::crtc_update_row), this);

--- a/src/mame/drivers/miniboy7.cpp
+++ b/src/mame/drivers/miniboy7.cpp
@@ -332,9 +332,9 @@ MC6845_UPDATE_ROW( miniboy7_state::crtc_update_row )
 			uint8_t color_b = m_proms[offset_b] & 0x0f;
 
 			if (color_a && (m_gpri || !color_b))          // videoram A has priority
-				bitmap.pix32(y, (cx << 3) + px) = palette[offset_a];
+				bitmap.pix32(y, hbp + (cx << 3) + px) = palette[offset_a];
 			else if (color_b && (!m_gpri || !color_a))    // videoram B has priority
-				bitmap.pix32(y, (cx << 3) + px) = palette[offset_b];
+				bitmap.pix32(y, hbp + (cx << 3) + px) = palette[offset_b];
 		}
 	}
 }
@@ -670,8 +670,6 @@ void miniboy7_state::miniboy7(machine_config &config)
 	screen_device &screen(SCREEN(config, "screen", SCREEN_TYPE_RASTER));
 	screen.set_refresh_hz(60);
 	screen.set_vblank_time(ATTOSECONDS_IN_USEC(0));
-	screen.set_size((47+1)*8, (39+1)*8);             // taken from MC6845, registers 00 & 04 (normally programmed with value - 1).
-	screen.set_visarea(0*8, 37*8-1, 0*8, 37*8-1);    // taken from MC6845, registers 01 & 06.
 	screen.set_screen_update("crtc", FUNC(mc6845_device::screen_update));
 
 	GFXDECODE(config, m_gfxdecode, m_palette, gfx_miniboy7);

--- a/src/mame/drivers/multi16.cpp
+++ b/src/mame/drivers/multi16.cpp
@@ -101,7 +101,7 @@ MC6845_UPDATE_ROW(multi16_state::crtc_update_row)
 			color |= BIT(data_g, 7 - x) << 1;
 			color |= BIT(data_b, 7 - x) << 2;
 
-			bitmap.pix32(y, x + i * 8) = m_palette->pens()[color];
+			bitmap.pix32(y, hbp + x + i * 8) = m_palette->pens()[color];
 		}
 	}
 }

--- a/src/mame/drivers/multi8.cpp
+++ b/src/mame/drivers/multi8.cpp
@@ -117,8 +117,8 @@ MC6845_UPDATE_ROW( multi8_state::crtc_update_row )
 {
 	const rgb_t *palette = m_palette->palette()->entry_list_raw();
 	uint8_t i,chr,gfx=0,color,pen,attr;
-	uint16_t mem = y*80,x;
-	uint32_t *p = &bitmap.pix32(y);
+	uint16_t mem = (y - vbp) * 80, x;  /* Could it better use ma? */
+	uint32_t *p = &bitmap.pix32(y, hbp);
 
 	for(x = 0; x < x_count; x++)
 	{
@@ -146,7 +146,7 @@ MC6845_UPDATE_ROW( multi8_state::crtc_update_row )
 	u8 x_width = BIT(m_display_reg, 6) ? 80 : 40;
 	u8 x_step = BIT(m_display_reg, 6) ? 1 : 2;
 	mem = 0xc000 + ma;
-	p = &bitmap.pix32(y);
+	p = &bitmap.pix32(y, hbp);
 
 	for(x = 0; x < x_width; x++)
 	{
@@ -625,8 +625,6 @@ void multi8_state::multi8(machine_config &config)
 	screen_device &screen(SCREEN(config, "screen", SCREEN_TYPE_RASTER));
 	screen.set_refresh_hz(60);
 	screen.set_vblank_time(ATTOSECONDS_IN_USEC(2500)); /* not accurate */
-	screen.set_size(640, 200);
-	screen.set_visarea(0, 320-1, 0, 200-1);
 	screen.set_screen_update("crtc", FUNC(mc6845_device::screen_update));
 
 	PALETTE(config, m_palette, palette_device::BRG_3BIT);

--- a/src/mame/drivers/mx2178.cpp
+++ b/src/mame/drivers/mx2178.cpp
@@ -87,7 +87,7 @@ MC6845_UPDATE_ROW( mx2178_state::crtc_update_row )
 	const rgb_t *pens = m_palette->palette()->entry_list_raw();
 	uint8_t chr,gfx;
 	uint16_t mem,x;
-	uint32_t *p = &bitmap.pix32(y);
+	uint32_t *p = &bitmap.pix32(y, hbp);
 
 	for (x = 0; x < x_count; x++)
 	{

--- a/src/mame/drivers/myb3k.cpp
+++ b/src/mame/drivers/myb3k.cpp
@@ -305,7 +305,7 @@ MC6845_UPDATE_ROW( myb3k_state::crtc_update_row )
 		{
 			for (int pxl = 0; pxl < 8; pxl++)
 			{
-				bitmap.pix32(y, ( x_pos * 8) + pxl) = rgb_t::black();
+				bitmap.pix32(y, hbp + ( x_pos * 8) + pxl) = rgb_t::black();
 			}
 		}
 		else
@@ -332,7 +332,7 @@ MC6845_UPDATE_ROW( myb3k_state::crtc_update_row )
 						//pind ^= ((cursor_x != -1 && x_pos == cursor_x && ra == 7) ? 7 : 0);
 
 						/* Create the grey scale */
-						bitmap.pix32(y, ( x_pos * 8) + pxl) = (*m_pal)[pind & 0x07];
+						bitmap.pix32(y, hbp + ( x_pos * 8) + pxl) = (*m_pal)[pind & 0x07];
 					}
 				}
 				break;
@@ -372,7 +372,7 @@ MC6845_UPDATE_ROW( myb3k_state::crtc_update_row )
 						pind ^= ((cursor_x != -1 && x_pos == cursor_x && ra == 7) ? 7 : 0);
 
 						/* Pick up the color */
-						bitmap.pix32(y, ( x_pos * 8) + pxl) = (*m_pal)[pind & 0x07];
+						bitmap.pix32(y, hbp + ( x_pos * 8) + pxl) = (*m_pal)[pind & 0x07];
 					}
 				}
 				break;
@@ -394,11 +394,11 @@ MC6845_UPDATE_ROW( myb3k_state::crtc_update_row )
 					{
 						if ((pdat & (0x80 >> pxl)) != 0)
 						{
-							bitmap.pix32(y, ( x_pos * 8) + pxl) = (*m_pal)[0x07];
+							bitmap.pix32(y, hbp + ( x_pos * 8) + pxl) = (*m_pal)[0x07];
 						}
 						else
 						{
-							bitmap.pix32(y, ( x_pos * 8) + pxl) = rgb_t::black();
+							bitmap.pix32(y, hbp + ( x_pos * 8) + pxl) = rgb_t::black();
 						}
 					}
 				}
@@ -453,24 +453,21 @@ WRITE8_MEMBER( myb3k_state::myb3k_video_mode_w )
 	case 0: // Disambiguity between reality and the service manual. Reality is 640x200 in 8 color or tones!
 			{
 			LOGVMOD(" - 640x200 on 80x25  \n");
-			rectangle rect(0, 640 - 1, 0, 200 - 1);
-			m_screen->configure(640, 200, rect, HZ_TO_ATTOSECONDS(50));
+			m_crtc->set_char_width(16);
 			break;
 		}
 
 	case 1: /* 320x200 */
 		{
 			LOGVMOD(" - 320x200, 40 char, 8 color or 8 tones of green...\n");
-			rectangle rect(0, 320 - 1, 0, 200 - 1);
-			m_screen->configure(320, 200, rect, HZ_TO_ATTOSECONDS(50));
+			m_crtc->set_char_width(8);
 		}
 		break;
 
 	case 2: /* 640x200 - boots up in this mode */
 		{
 			LOGVMOD(" - 640x200, 80 char, white on black...\n");
-			rectangle rect(0, 640 - 1, 0, 200 - 1);
-			m_screen->configure(640, 200, rect, HZ_TO_ATTOSECONDS(50));
+			m_crtc->set_char_width(16);
 		}
 		break;
 
@@ -485,16 +482,14 @@ WRITE8_MEMBER( myb3k_state::myb3k_video_mode_w )
 	case 5: /* 320x400 */
 		{
 			LOGVMOD("320x400, 40 char, white on black\n");
-			rectangle rect(0, 320 - 1, 0, 400 - 1);
-			m_screen->configure(320, 400, rect, HZ_TO_ATTOSECONDS(50));
+			m_crtc->set_char_width(8);
 		}
 		break;
 
 	case 6: /* 640x400 */
 		{
 			LOGVMOD("640x400, 80 char, white on black\n");
-			rectangle rect(0, 640 - 1, 0, 400 - 1);
-			m_screen->configure(640, 400, rect, HZ_TO_ATTOSECONDS(50));
+			m_crtc->set_char_width(16);
 		}
 		break;
 

--- a/src/mame/drivers/mycom.cpp
+++ b/src/mame/drivers/mycom.cpp
@@ -139,7 +139,7 @@ MC6845_UPDATE_ROW( mycom_state::crtc_update_row )
 	const rgb_t *palette = m_palette->palette()->entry_list_raw();
 	uint8_t chr,gfx=0,z;
 	uint16_t mem,x;
-	uint32_t *p = &bitmap.pix32(y);
+	uint32_t *p = &bitmap.pix32(y, hbp);
 
 	if (m_0a & 0x40)
 	{
@@ -534,8 +534,6 @@ void mycom_state::mycom(machine_config &config)
 	screen.set_refresh_hz(60);
 	screen.set_vblank_time(ATTOSECONDS_IN_USEC(2500)); /* not accurate */
 	screen.set_screen_update("crtc", FUNC(mc6845_device::screen_update));
-	screen.set_size(640, 480);
-	screen.set_visarea(0, 320-1, 0, 192-1);
 	PALETTE(config, m_palette, palette_device::MONOCHROME);
 	GFXDECODE(config, "gfxdecode", m_palette, gfx_mycom);
 

--- a/src/mame/drivers/ngen.cpp
+++ b/src/mame/drivers/ngen.cpp
@@ -759,17 +759,18 @@ WRITE8_MEMBER(ngen_state::dma_write_word)
 
 MC6845_UPDATE_ROW( ngen_state::crtc_update_row )
 {
-	uint16_t addr = ma;
+	int x = 0;
 
-	for(int x=0;x<bitmap.width();x+=9)
+	for (int column = 0; column < x_count; column++)
 	{
-		uint8_t ch = m_vram.read16(addr++) & 0xff;
-		for(int z=0;z<9;z++)
+		uint16_t addr = (ma + column) & 0x1fff;
+		uint8_t ch = m_vram.read16(addr) & 0xff;
+		for (int z=0; z<9; z++)
 		{
-			if(BIT(m_fontram.read16(ch*16+ra),8-z))
-				bitmap.pix32(y,x+z) = rgb_t(0,0xff,0);
+			if (BIT(m_fontram.read16(ch*16+ra),8-z))
+				bitmap.pix32(y, hbp + x++) = rgb_t(0,0xff,0);
 			else
-				bitmap.pix32(y,x+z) = rgb_t(0,0,0);
+				bitmap.pix32(y, hbp + x++) = rgb_t(0,0,0);
 		}
 	}
 }
@@ -990,8 +991,6 @@ void ngen_state::ngen(machine_config &config)
 
 	// video board
 	screen_device &screen(SCREEN(config, "screen", SCREEN_TYPE_RASTER));
-	screen.set_size(720, 348);
-	screen.set_visarea(0, 719, 0, 347);
 	screen.set_refresh_hz(60);
 	screen.set_screen_update("crtc", FUNC(mc6845_device::screen_update));
 
@@ -1103,8 +1102,6 @@ void ngen386_state::ngen386(machine_config &config)
 
 	// video board
 	screen_device &screen(SCREEN(config, "screen", SCREEN_TYPE_RASTER));
-	screen.set_size(720, 348);
-	screen.set_visarea(0, 719, 0, 347);
 	screen.set_refresh_hz(60);
 	screen.set_screen_update("crtc", FUNC(mc6845_device::screen_update));
 

--- a/src/mame/drivers/nyny.cpp
+++ b/src/mame/drivers/nyny.cpp
@@ -316,7 +316,7 @@ MC6845_UPDATE_ROW( nyny_state::crtc_update_row )
 			else
 				color = bit2 ? color2 : 0;
 
-			bitmap.pix32(y, x) = m_palette->pen_color(color);
+			bitmap.pix32(y, hbp + x) = m_palette->pen_color(color);
 
 			x += 1;
 		}

--- a/src/mame/drivers/othello.cpp
+++ b/src/mame/drivers/othello.cpp
@@ -143,7 +143,7 @@ MC6845_UPDATE_ROW( othello_state::crtc_update_row )
 
 		for(int x = 0; x < TILE_WIDTH; ++x)
 		{
-			bitmap.pix32(y, (cx * TILE_WIDTH + x) ^ 1) = palette[tmp & 0x0f];
+			bitmap.pix32(y, hbp + ((+ cx * TILE_WIDTH + x) ^ 1)) = palette[tmp & 0x0f];
 			tmp >>= 4;
 		}
 	}
@@ -413,8 +413,6 @@ void othello_state::othello(machine_config &config)
 	screen_device &screen(SCREEN(config, "screen", SCREEN_TYPE_RASTER));
 	screen.set_refresh_hz(60);
 	screen.set_vblank_time(ATTOSECONDS_IN_USEC(0));
-	screen.set_size(64*6, 64*8);
-	screen.set_visarea(0*8, 64*6-1, 0*8, 64*8-1);
 	screen.set_screen_update("crtc", FUNC(hd6845s_device::screen_update));
 
 	PALETTE(config, m_palette, FUNC(othello_state::othello_palette), 0x10);

--- a/src/mame/drivers/pasopia.cpp
+++ b/src/mame/drivers/pasopia.cpp
@@ -96,7 +96,7 @@ MC6845_UPDATE_ROW( pasopia_state::crtc_update_row )
 	const rgb_t *palette = m_palette->palette()->entry_list_raw();
 	uint8_t chr,gfx,fg=7,bg=0; // colours need to be determined
 	uint16_t mem,x;
-	uint32_t *p = &bitmap.pix32(y);
+	uint32_t *p = &bitmap.pix32(y, hbp);
 
 	for (x = 0; x < x_count; x++)
 	{
@@ -299,8 +299,6 @@ void pasopia_state::pasopia(machine_config &config)
 	screen_device &screen(SCREEN(config, "screen", SCREEN_TYPE_RASTER));
 	screen.set_refresh_hz(60);
 	screen.set_vblank_time(ATTOSECONDS_IN_USEC(2500)); /* not accurate */
-	screen.set_size(640, 480);
-	screen.set_visarea(0, 640-1, 0, 480-1);
 	screen.set_screen_update("crtc", FUNC(mc6845_device::screen_update));
 	GFXDECODE(config, "gfxdecode", m_palette, gfx_pasopia);
 	PALETTE(config, m_palette).set_entries(8);

--- a/src/mame/drivers/peoplepc.cpp
+++ b/src/mame/drivers/peoplepc.cpp
@@ -101,13 +101,13 @@ MC6845_UPDATE_ROW(peoplepc_state::update_row)
 			uint8_t data = m_gvram[offset] >> (offset & 1 ? 8 : 0);
 
 			for(j = 8; j >= 0; j--)
-				bitmap.pix32(y, (i * 8) + j) = palette[( data & 1 << j ) ? 1 : 0];
+				bitmap.pix32(y, hbp + (i * 8) + j) = palette[( data & 1 << j ) ? 1 : 0];
 		}
 		else
 		{
 			uint8_t data = m_charram[(m_cvram[(ma + i) & 0x3fff] & 0x7f) * 32 + ra];
 			for(j = 0; j < 8; j++)
-				bitmap.pix32(y, (i * 8) + j) = palette[(data & (1 << j)) ? 1 : 0];
+				bitmap.pix32(y, hbp + (i * 8) + j) = palette[(data & (1 << j)) ? 1 : 0];
 		}
 	}
 }

--- a/src/mame/drivers/pet.cpp
+++ b/src/mame/drivers/pet.cpp
@@ -1381,7 +1381,6 @@ MC6845_UPDATE_ROW( pet80_state::pet80_update_row )
 	int x = 0;
 	int char_rom_mask = m_char_rom->bytes() - 1;
 	const pen_t *pen = m_palette->pens();
-	hbp = 80;
 
 	for (int column = 0; column < x_count; column++)
 	{
@@ -1401,7 +1400,7 @@ MC6845_UPDATE_ROW( pet80_state::pet80_update_row )
 		for (int bit = 0; bit < 8; bit++, data <<= 1)
 		{
 			int video = (!((BIT(data, 7) ^ BIT(lsd, 7)) && no_row) ^ invert) && de;
-			bitmap.pix32(vbp + y, hbp + x++) = pen[video];
+			bitmap.pix32(y, hbp + x++) = pen[video];
 		}
 
 		// odd character
@@ -1414,7 +1413,7 @@ MC6845_UPDATE_ROW( pet80_state::pet80_update_row )
 		for (int bit = 0; bit < 8; bit++, data <<= 1)
 		{
 			int video = (!((BIT(data, 7) ^ BIT(lsd, 7)) && no_row) ^ invert) && de;
-			bitmap.pix32(vbp + y, hbp + x++) = pen[video];
+			bitmap.pix32(y, hbp + x++) = pen[video];
 		}
 	}
 }
@@ -1429,7 +1428,6 @@ MC6845_UPDATE_ROW( pet_state::pet40_update_row )
 	int x = 0;
 	int char_rom_mask = m_char_rom->bytes() - 1;
 	const pen_t *pen = m_palette->pens();
-	hbp = 41;
 
 	for (int column = 0; column < x_count; column++)
 	{
@@ -1447,7 +1445,7 @@ MC6845_UPDATE_ROW( pet_state::pet40_update_row )
 		for (int bit = 0; bit < 8; bit++, data <<= 1)
 		{
 			int video = (!((BIT(data, 7) ^ BIT(lsd, 7)) && no_row) ^ invert) && de;
-			bitmap.pix32(vbp + y, hbp + x++) = pen[video];
+			bitmap.pix32(y, hbp + x++) = pen[video];
 		}
 	}
 }
@@ -1483,7 +1481,7 @@ MC6845_UPDATE_ROW( pet80_state::cbm8296_update_row )
 		for (int bit = 0; bit < 8; bit++, data <<= 1)
 		{
 			int video = (((BIT(data, 7) ^ BIT(lsd, 7)) && no_row) && de);
-			bitmap.pix32(vbp + y, hbp + x++) = pen[video];
+			bitmap.pix32(y, hbp + x++) = pen[video];
 		}
 
 		// odd character
@@ -1496,7 +1494,7 @@ MC6845_UPDATE_ROW( pet80_state::cbm8296_update_row )
 		for (int bit = 0; bit < 8; bit++, data <<= 1)
 		{
 			int video = (((BIT(data, 7) ^ BIT(lsd, 7)) && no_row) && de);
-			bitmap.pix32(vbp + y, hbp + x++) = pen[video];
+			bitmap.pix32(y, hbp + x++) = pen[video];
 		}
 	}
 }
@@ -1887,14 +1885,12 @@ void pet2001b_state::pet4032f(machine_config &config)
 	// video hardware
 	m_screen->set_refresh_hz(60);
 	m_screen->set_vblank_time(ATTOSECONDS_IN_USEC(2500));
-	m_screen->set_size(320, 250);
-	m_screen->set_visarea(0, 320 - 1, 0, 250 - 1);
 	m_screen->set_screen_update(MC6845_TAG, FUNC(mc6845_device::screen_update));
 	m_sync_period = attotime::never;
 
 	MC6845(config, m_crtc, XTAL(16'000'000)/16);
 	m_crtc->set_screen(SCREEN_TAG);
-	m_crtc->set_show_border_area(true);
+	m_crtc->set_show_border_area(false);
 	m_crtc->set_char_width(8);
 	m_crtc->set_begin_update_callback(FUNC(pet_state::pet_begin_update), this);
 	m_crtc->set_update_row_callback(FUNC(pet_state::pet40_update_row), this);
@@ -1943,14 +1939,12 @@ void pet_state::cbm4032f(machine_config &config)
 	// video hardware
 	m_screen->set_refresh_hz(50);
 	m_screen->set_vblank_time(ATTOSECONDS_IN_USEC(2500));
-	m_screen->set_size(320, 250);
-	m_screen->set_visarea(0, 320 - 1, 0, 250 - 1);
 	m_screen->set_screen_update(MC6845_TAG, FUNC(mc6845_device::screen_update));
 	m_sync_period = attotime::never;
 
 	MC6845(config, m_crtc, XTAL(16'000'000)/16);
 	m_crtc->set_screen(SCREEN_TAG);
-	m_crtc->set_show_border_area(true);
+	m_crtc->set_show_border_area(false);
 	m_crtc->set_char_width(8);
 	m_crtc->set_begin_update_callback(FUNC(pet_state::pet_begin_update), this);
 	m_crtc->set_update_row_callback(FUNC(pet_state::pet40_update_row), this);
@@ -2010,13 +2004,11 @@ void pet80_state::pet80(machine_config &config)
 	screen.set_color(rgb_t::green());
 	screen.set_refresh_hz(60);
 	screen.set_vblank_time(ATTOSECONDS_IN_USEC(2500));
-	screen.set_size(640, 250);
-	screen.set_visarea(0, 640 - 1, 0, 250 - 1);
 	screen.set_screen_update(MC6845_TAG, FUNC(mc6845_device::screen_update));
 
 	MC6845(config, m_crtc, XTAL(16'000'000)/16);
 	m_crtc->set_screen(SCREEN_TAG);
-	m_crtc->set_show_border_area(true);
+	m_crtc->set_show_border_area(false);
 	m_crtc->set_char_width(2*8);
 	m_crtc->set_begin_update_callback(FUNC(pet_state::pet_begin_update), this);
 	m_crtc->set_update_row_callback(FUNC(pet80_state::pet80_update_row), this);
@@ -2071,7 +2063,7 @@ void cbm8296_state::cbm8296(machine_config &config)
 	PLS100(config, PLA2_TAG);
 
 	m_crtc->set_clock(XTAL(16'000'000)/16);
-	m_crtc->set_show_border_area(true);
+	m_crtc->set_show_border_area(false);
 	m_crtc->set_char_width(2*8);
 	m_crtc->set_update_row_callback(FUNC(pet80_state::cbm8296_update_row), this);
 	m_crtc->out_vsync_callback().set(M6520_1_TAG, FUNC(pia6821_device::cb1_w));

--- a/src/mame/drivers/pg685.cpp
+++ b/src/mame/drivers/pg685.cpp
@@ -339,7 +339,7 @@ void pg685_state::video_start()
 MC6845_UPDATE_ROW( pg685_state::crtc_update_row )
 {
 	static const uint32_t palette[2] = { 0x00d000, 0 };
-	uint32_t  *p = &bitmap.pix32(y);
+	uint32_t  *p = &bitmap.pix32(y, hbp);
 	uint16_t  chr_base = ra;
 	int i;
 	uint8_t *vram = (uint8_t *)m_vram.target();
@@ -367,7 +367,7 @@ MC6845_UPDATE_ROW( pg685_state::crtc_update_row )
 MC6845_UPDATE_ROW( pg685_state::crtc_update_row_oua12 )
 {
 	static const uint32_t palette[2] = { 0x00d000, 0 };
-	uint32_t  *p = &bitmap.pix32(y);
+	uint32_t  *p = &bitmap.pix32(y, hbp);
 	uint16_t  chr_base = ra;
 	int i;
 	uint16_t *vram = (uint16_t *)m_vram16.target();

--- a/src/mame/drivers/pyl601.cpp
+++ b/src/mame/drivers/pyl601.cpp
@@ -427,7 +427,7 @@ MC6845_UPDATE_ROW( pyl601_state::pyl601_update_row )
 			{
 				int x = (column * 8) + bit;
 
-				bitmap.pix32(y, x) = palette[BIT(data, 7)];
+				bitmap.pix32(y, hbp + x) = palette[BIT(data, 7)];
 
 				data <<= 1;
 			}
@@ -440,7 +440,7 @@ MC6845_UPDATE_ROW( pyl601_state::pyl601_update_row )
 			data = m_ram->pointer()[(((ma + i) << 3) | (ra & 0x07)) & 0xffff];
 			for (bit = 0; bit < 8; bit++)
 			{
-				bitmap.pix32(y, (i * 8) + bit) = palette[BIT(data, 7)];
+				bitmap.pix32(y, hbp + (i * 8) + bit) = palette[BIT(data, 7)];
 				data <<= 1;
 			}
 		}
@@ -467,7 +467,7 @@ MC6845_UPDATE_ROW( pyl601_state::pyl601a_update_row )
 			{
 				int x = (column * 8) + bit;
 
-				bitmap.pix32(y, x) = palette[BIT(data, 7)];
+				bitmap.pix32(y, hbp + x) = palette[BIT(data, 7)];
 
 				data <<= 1;
 			}
@@ -480,7 +480,7 @@ MC6845_UPDATE_ROW( pyl601_state::pyl601a_update_row )
 			data = m_ram->pointer()[(((ma + i) << 3) | (ra & 0x07)) & 0xffff];
 			for (bit = 0; bit < 8; bit++)
 			{
-				bitmap.pix32(y, (i * 8) + bit) = palette[BIT(data, 7)];
+				bitmap.pix32(y, hbp + (i * 8) + bit) = palette[BIT(data, 7)];
 				data <<= 1;
 			}
 		}
@@ -555,8 +555,6 @@ void pyl601_state::pyl601(machine_config &config)
 	screen_device &screen(SCREEN(config, "screen", SCREEN_TYPE_RASTER, rgb_t::green()));
 	screen.set_refresh_hz(50);
 	screen.set_vblank_time(ATTOSECONDS_IN_USEC(2500)); /* not accurate */
-	screen.set_size(640, 200);
-	screen.set_visarea(0, 640 - 1, 0, 200 - 1);
 	screen.set_screen_update("crtc", FUNC(mc6845_device::screen_update));
 	GFXDECODE(config, "gfxdecode", m_palette, gfx_pyl601);
 	PALETTE(config, m_palette, palette_device::MONOCHROME);

--- a/src/mame/drivers/qvt102.cpp
+++ b/src/mame/drivers/qvt102.cpp
@@ -462,7 +462,7 @@ MC6845_UPDATE_ROW( qvt102_state::crtc_update_row )
 			p = !(p & !((BIT(attr, 3) & (ra == 11)))); // underline
 			p = p ^ (BIT(attr, 2) ^ ((x == cursor_x) | BIT(m_latch, 2))); // reverse
 
-			bitmap.pix32(y, x*9 + (8-i)) = palette[p ? 2 - half : 0];
+			bitmap.pix32(y, hbp + x*9 + (8-i)) = palette[p ? 2 - half : 0];
 		}
 
 	}

--- a/src/mame/drivers/qvt190.cpp
+++ b/src/mame/drivers/qvt190.cpp
@@ -60,11 +60,11 @@ MC6845_UPDATE_ROW(qvt190_state::update_row)
 		uint8_t chr = m_videoram[mem];
 		uint16_t gfx = m_p_chargen[(chr << 4) | ra];
 
-		if (x == cursor_x)
+		if (x == cursor_x && de)
 			gfx = ~gfx;
 
 		for (int i = 0; i < 9; i++)
-			bitmap.pix32(y, x*9 + (8-i)) = palette[BIT(gfx, i) ? 2 : 0];
+			bitmap.pix32(y, hbp + x*9 + (8-i)) = palette[BIT(gfx, i) ? 2 : 0];
 	}
 }
 
@@ -134,6 +134,7 @@ void qvt190_state::qvt190(machine_config &config)
 
 	mc6845_device &crtc(MC6845(config, "crtc", 16.6698_MHz_XTAL / 9));
 	crtc.set_screen("screen");
+	crtc.set_show_border_area(false);
 	crtc.set_char_width(9);
 	crtc.set_update_row_callback(FUNC(qvt190_state::update_row), this);
 }

--- a/src/mame/drivers/r2dtank.cpp
+++ b/src/mame/drivers/r2dtank.cpp
@@ -308,7 +308,7 @@ MC6845_UPDATE_ROW( r2dtank_state::crtc_update_row )
 			}
 
 			color = bit ? fore_color : 0;
-			bitmap.pix32(y, x) = m_palette->pen_color(color);
+			bitmap.pix32(y, hbp + x) = m_palette->pen_color(color);
 
 			x = x + 1;
 		}

--- a/src/mame/drivers/sapi1.cpp
+++ b/src/mame/drivers/sapi1.cpp
@@ -455,7 +455,7 @@ MC6845_UPDATE_ROW( sapi1_state::crtc_update_row )
 	const rgb_t *palette = m_palette->palette()->entry_list_raw();
 	uint8_t chr,gfx,inv;
 	uint16_t mem,x;
-	uint32_t *p = &bitmap.pix32(y);
+	uint32_t *p = &bitmap.pix32(y, hbp);
 
 	for (x = 0; x < x_count; x++)
 	{

--- a/src/mame/drivers/slotcarn.cpp
+++ b/src/mame/drivers/slotcarn.cpp
@@ -154,7 +154,7 @@ MC6845_UPDATE_ROW( slotcarn_state::crtc_update_row )
 				col |= 0x03;
 
 			col = m_ram_palette[col & 0x3ff];
-			bitmap.pix32(y, x) = m_pens[col ? col & (NUM_PENS-1) : (lscnblk ? 8 : 0)];
+			bitmap.pix32(y, hbp + x) = m_pens[col ? col & (NUM_PENS-1) : (lscnblk ? 8 : 0)];
 
 			x++;
 		}

--- a/src/mame/drivers/spc1500.cpp
+++ b/src/mame/drivers/spc1500.cpp
@@ -536,8 +536,9 @@ MC6845_UPDATE_ROW(spc1500_state::crtc_update_row)
 	int i;
 	int j;
 	int h1, h2, h3;
-	uint32_t  *p = &bitmap.pix32(y);
+	uint32_t  *p = &bitmap.pix32(y, hbp);
 
+	y -= vbp; /* Could it better use ma? */
 	unsigned char cho[] ={1,1,1,1,1,1,1,1,0,0,1,1,1,3,5,5,0,0,5,3,3,5,5,5,0,0,3,3,5,1};
 	unsigned char jong[]={0,0,0,1,1,1,1,1,0,0,1,1,1,2,2,2,0,0,2,2,2,2,2,2,0,0,2,2,1,1};
 	bool inv = false;
@@ -890,8 +891,6 @@ void spc1500_state::spc1500(machine_config &config)
 	screen_device &screen(SCREEN(config, "screen", SCREEN_TYPE_RASTER));
 	screen.set_refresh_hz(60);
 	screen.set_vblank_time(ATTOSECONDS_IN_USEC(2500)); /* not accurate */
-	screen.set_size(640, 400);
-	screen.set_visarea(0,640-1,0,400-1);
 	screen.set_screen_update("mc6845", FUNC(mc6845_device::screen_update));
 
 	PALETTE(config, m_palette, FUNC(spc1500_state::spc_palette), 8);
@@ -901,7 +900,6 @@ void spc1500_state::spc1500(machine_config &config)
 	m_vdg->set_show_border_area(false);
 	m_vdg->set_char_width(8);
 	m_vdg->set_update_row_callback(FUNC(spc1500_state::crtc_update_row), this);
-	m_vdg->set_reconfigure_callback(FUNC(spc1500_state::crtc_reconfig), this);
 
 	MCFG_VIDEO_START_OVERRIDE(spc1500_state, spc)
 

--- a/src/mame/drivers/spiders.cpp
+++ b/src/mame/drivers/spiders.cpp
@@ -324,7 +324,7 @@ MC6845_UPDATE_ROW( spiders_state::crtc_update_row )
 				data3 = data3 >> 1;
 			}
 
-			bitmap.pix32(y, x) = m_palette->pen_color(color);
+			bitmap.pix32(y, hbp + x) = m_palette->pen_color(color);
 
 			x = x + 1;
 		}

--- a/src/mame/drivers/ssingles.cpp
+++ b/src/mame/drivers/ssingles.cpp
@@ -245,7 +245,7 @@ MC6845_UPDATE_ROW( ssingles_state::ssingles_update_row )
 
 		for (int x = 7; x >= 0; --x)
 		{
-			bitmap.pix32(y, (cx << 3) | x) = m_pens[palette + ((b1 & 1) | ((b0 & 1) << 1))];
+			bitmap.pix32(y, hbp + ((cx << 3) | x)) = m_pens[palette + ((b1 & 1) | ((b0 & 1) << 1))];
 			b0 >>= 1;
 			b1 >>= 1;
 		}
@@ -281,7 +281,7 @@ MC6845_UPDATE_ROW( ssingles_state::atamanot_update_row )
 
 		for (int x = 7; x >= 0; --x)
 		{
-			bitmap.pix32(y, (cx << 3) | x) = m_pens[palette + ((b1 & 1) | ((b0 & 1) << 1))];
+			bitmap.pix32(y, hbp + ((cx << 3) | x)) = m_pens[palette + ((b1 & 1) | ((b0 & 1) << 1))];
 			b0 >>= 1;
 			b1 >>= 1;
 		}

--- a/src/mame/drivers/super80.cpp
+++ b/src/mame/drivers/super80.cpp
@@ -809,8 +809,6 @@ void super80_state::super80v(machine_config &config)
 
 	SCREEN(config, m_screen, SCREEN_TYPE_RASTER);
 	m_screen->set_refresh_hz(50);
-	m_screen->set_size(SUPER80V_SCREEN_WIDTH, SUPER80V_SCREEN_HEIGHT);
-	m_screen->set_visarea(0, SUPER80V_SCREEN_WIDTH-1, 0, SUPER80V_SCREEN_HEIGHT-1);
 	m_screen->set_screen_update(FUNC(super80_state::screen_update_super80v));
 	m_screen->screen_vblank().set(FUNC(super80_state::screen_vblank_super80m));
 

--- a/src/mame/drivers/sys9002.cpp
+++ b/src/mame/drivers/sys9002.cpp
@@ -80,7 +80,7 @@ MC6845_UPDATE_ROW( sys9002_state::crtc_update_row )
 	const rgb_t *pens = m_palette->palette()->entry_list_raw();
 	uint8_t chr,gfx;
 	uint16_t mem,x;
-	uint32_t *p = &bitmap.pix32(y);
+	uint32_t *p = &bitmap.pix32(y, hbp);
 
 	for (x = 0; x < x_count; x++)
 	{
@@ -133,8 +133,6 @@ void sys9002_state::sys9002(machine_config &config)
 	screen.set_refresh_hz(60);
 	screen.set_vblank_time(ATTOSECONDS_IN_USEC(2500)); // not correct
 	screen.set_screen_update("crtc", FUNC(mc6845_device::screen_update));
-	screen.set_size(32*8, 32*8);
-	screen.set_visarea(0*8, 32*8-1, 2*8, 30*8-1);
 	//GFXDECODE(config, "gfxdecode", m_palette, gfx_mx2178);
 	PALETTE(config, m_palette, palette_device::MONOCHROME);
 

--- a/src/mame/drivers/tapatune.cpp
+++ b/src/mame/drivers/tapatune.cpp
@@ -178,7 +178,7 @@ MC6845_BEGIN_UPDATE( tapatune_state::crtc_begin_update )
 
 MC6845_UPDATE_ROW( tapatune_state::crtc_update_row )
 {
-	uint32_t *dest = &bitmap.pix32(y);
+	uint32_t *dest = &bitmap.pix32(y, hbp);
 	offs_t offs = (ma*2 + ra*0x40)*4;
 
 	uint8_t *videoram = reinterpret_cast<uint8_t *>(m_videoram.target());

--- a/src/mame/drivers/tavernie.cpp
+++ b/src/mame/drivers/tavernie.cpp
@@ -222,7 +222,7 @@ MC6845_UPDATE_ROW( tavernie_state::crtc_update_row )
 	const rgb_t *palette = m_palette->palette()->entry_list_raw();
 	uint8_t chr,gfx=0;
 	uint16_t mem,x;
-	uint32_t *p = &bitmap.pix32(y);
+	uint32_t *p = &bitmap.pix32(y, hbp);
 
 	for (x = 0; x < x_count; x++)
 	{
@@ -373,8 +373,6 @@ void tavernie_state::ivg09(machine_config &config)
 	screen_device &screen(SCREEN(config, "screen", SCREEN_TYPE_RASTER));
 	screen.set_refresh_hz(50);
 	screen.set_vblank_time(ATTOSECONDS_IN_USEC(2500)); /* not accurate */
-	screen.set_size(80*8, 25*10);
-	screen.set_visarea(0, 80*8-1, 0, 25*10-1);
 	screen.set_screen_update("crtc", FUNC(mc6845_device::screen_update));
 	PALETTE(config, m_palette, palette_device::MONOCHROME);
 	config.set_default_layout(layout_tavernie);

--- a/src/mame/drivers/trs80m2.cpp
+++ b/src/mame/drivers/trs80m2.cpp
@@ -409,7 +409,7 @@ MC6845_UPDATE_ROW( trs80m2_state::crtc_update_row )
 			int dout = BIT(data, 7);
 			int color = (dcursor ^ drevid ^ dout) && de;
 
-			bitmap.pix32(vbp + y, hbp + x++) = pen[color];
+			bitmap.pix32(y, hbp + x++) = pen[color];
 
 			data <<= 1;
 		}
@@ -720,14 +720,12 @@ void trs80m2_state::trs80m2(machine_config &config)
 	screen.set_refresh_hz(60);
 	screen.set_vblank_time(ATTOSECONDS_IN_USEC(0));
 	screen.set_screen_update(FUNC(trs80m2_state::screen_update));
-	screen.set_size(640, 480);
-	screen.set_visarea(0, 639, 0, 479);
 
 	PALETTE(config, m_palette, palette_device::MONOCHROME);
 
 	MC6845(config, m_crtc, 12.48_MHz_XTAL / 8);
 	m_crtc->set_screen(SCREEN_TAG);
-	m_crtc->set_show_border_area(true);
+	m_crtc->set_show_border_area(false);
 	m_crtc->set_char_width(8);
 	m_crtc->set_update_row_callback(FUNC(trs80m2_state::crtc_update_row), this);
 	m_crtc->out_de_callback().set(FUNC(trs80m2_state::de_w));
@@ -812,14 +810,12 @@ void trs80m16_state::trs80m16(machine_config &config)
 	screen.set_refresh_hz(60);
 	screen.set_vblank_time(ATTOSECONDS_IN_USEC(0));
 	screen.set_screen_update(FUNC(trs80m2_state::screen_update));
-	screen.set_size(640, 480);
-	screen.set_visarea(0, 639, 0, 479);
 
 	PALETTE(config, m_palette, palette_device::MONOCHROME);
 
 	MC6845(config, m_crtc, 12.48_MHz_XTAL / 8);
 	m_crtc->set_screen(SCREEN_TAG);
-	m_crtc->set_show_border_area(true);
+	m_crtc->set_show_border_area(false);
 	m_crtc->set_char_width(8);
 	m_crtc->set_update_row_callback(FUNC(trs80m2_state::crtc_update_row), this);
 	m_crtc->out_de_callback().set(FUNC(trs80m2_state::de_w));

--- a/src/mame/drivers/ts803.cpp
+++ b/src/mame/drivers/ts803.cpp
@@ -330,7 +330,7 @@ MC6845_UPDATE_ROW( ts803_state::crtc_update_row )
 	const rgb_t *pens = m_palette->palette()->entry_list_raw();
 	uint8_t chr,gfx,inv;
 	uint16_t mem,x;
-	uint32_t *p = &bitmap.pix32(y);
+	uint32_t *p = &bitmap.pix32(y, hbp);
 
 	for (x = 0; x < x_count; x++)
 	{
@@ -432,8 +432,6 @@ void ts803_state::ts803(machine_config &config)
 	/* video hardware */
 	screen_device &screen(SCREEN(config, "screen", SCREEN_TYPE_RASTER, rgb_t::green()));
 	screen.set_refresh_hz(60);
-	screen.set_size(640,240);
-	screen.set_visarea(0, 640-1, 0, 240-1);
 	screen.set_screen_update("crtc", FUNC(sy6545_1_device::screen_update));
 	PALETTE(config, m_palette, palette_device::MONOCHROME);
 

--- a/src/mame/drivers/tv910.cpp
+++ b/src/mame/drivers/tv910.cpp
@@ -465,7 +465,7 @@ void tv910_state::vbl_ack_w(uint8_t data)
 
 MC6845_UPDATE_ROW( tv910_state::crtc_update_row )
 {
-	uint32_t  *p = &bitmap.pix32(y);
+	uint32_t  *p = &bitmap.pix32(y, hbp);
 	uint16_t  chr_base = (ra & 7) | m_charset->read() << 10;
 	uint8_t   chr = m_vram[0x7ff];
 	uint8_t   att = (chr & 0xf0) == 0x90 ? chr & 0x0f : 0;

--- a/src/mame/drivers/tv950.cpp
+++ b/src/mame/drivers/tv950.cpp
@@ -259,7 +259,7 @@ MC6845_UPDATE_ROW( tv950_state::crtc_update_row )
 	else
 		m_attr_screen = m_attr_row;
 
-	uint32_t *p = &bitmap.pix32(m_row);
+	uint32_t *p = &bitmap.pix32(y, hbp);
 	rgb_t fg(255,255,255,255);
 	rgb_t bg(0,0,0,0);
 

--- a/src/mame/drivers/tvc.cpp
+++ b/src/mame/drivers/tvc.cpp
@@ -643,7 +643,7 @@ void tvc_state::machine_reset()
 MC6845_UPDATE_ROW( tvc_state::crtc_update_row )
 {
 	const rgb_t *palette = m_palette->palette()->entry_list_raw();
-	uint32_t  *p = &bitmap.pix32(y);
+	uint32_t  *p = &bitmap.pix32(y, hbp);
 	uint8_t *vram = m_vram->base() + ((m_vram_bank & 0x30)<<10);
 	uint16_t offset = ((ma*4 + ra*0x40) & 0x3fff);
 	int i;
@@ -777,8 +777,6 @@ void tvc_state::tvc(machine_config &config)
 	screen_device &screen(SCREEN(config, "screen", SCREEN_TYPE_RASTER));
 	screen.set_refresh_hz(50);
 	screen.set_vblank_time(ATTOSECONDS_IN_USEC(2500)); /* not accurate */
-	screen.set_size(512, 240);
-	screen.set_visarea(0, 512 - 1, 0, 240 - 1);
 	screen.set_screen_update("crtc", FUNC(mc6845_device::screen_update));
 
 	PALETTE(config, m_palette, FUNC(tvc_state::tvc_palette), 16);

--- a/src/mame/drivers/v6809.cpp
+++ b/src/mame/drivers/v6809.cpp
@@ -170,7 +170,7 @@ MC6845_UPDATE_ROW( v6809_state::crtc_update_row )
 	const rgb_t *palette = m_palette->palette()->entry_list_raw();
 	uint8_t chr,gfx;
 	uint16_t mem,x;
-	uint32_t *p = &bitmap.pix32(y);
+	uint32_t *p = &bitmap.pix32(y, hbp);
 
 	for (x = 0; x < x_count; x++)
 	{
@@ -293,8 +293,6 @@ void v6809_state::v6809(machine_config &config)
 	screen_device &screen(SCREEN(config, "screen", SCREEN_TYPE_RASTER));
 	screen.set_refresh_hz(50);
 	screen.set_vblank_time(ATTOSECONDS_IN_USEC(2500)); /* not accurate */
-	screen.set_size(640, 480);
-	screen.set_visarea(0, 640-1, 0, 480-1);
 	screen.set_screen_update("crtc", FUNC(sy6545_1_device::screen_update));
 	PALETTE(config, m_palette, palette_device::MONOCHROME);
 	GFXDECODE(config, "gfxdecode", m_palette, gfx_v6809);

--- a/src/mame/drivers/victor9k.cpp
+++ b/src/mame/drivers/victor9k.cpp
@@ -306,7 +306,7 @@ MC6845_UPDATE_ROW( victor9k_state::crtc_update_row )
 				color = palette[pen];
 			}
 
-			bitmap.pix32(vbp + y, x++) = color;
+			bitmap.pix32(y, x++) = color;
 		}
 
 		aa += 2;
@@ -692,14 +692,12 @@ void victor9k_state::victor9k(machine_config &config)
 	screen.set_refresh_hz(50);
 	screen.set_vblank_time(ATTOSECONDS_IN_USEC(2500)); // not accurate
 	screen.set_screen_update(HD46505S_TAG, FUNC(hd6845s_device::screen_update));
-	screen.set_size(640, 480);
-	screen.set_visarea(0, 640-1, 0, 480-1);
 
 	PALETTE(config, m_palette, FUNC(victor9k_state::victor9k_palette), 16);
 
 	HD6845S(config, m_crtc, XTAL(30'000'000)/10); // HD6845 == HD46505S
 	m_crtc->set_screen(SCREEN_TAG);
-	m_crtc->set_show_border_area(true);
+	m_crtc->set_show_border_area(false);
 	m_crtc->set_char_width(10);
 	m_crtc->set_update_row_callback(FUNC(victor9k_state::crtc_update_row), this);
 	m_crtc->out_vsync_callback().set(FUNC(victor9k_state::vert_w));

--- a/src/mame/drivers/vk100.cpp
+++ b/src/mame/drivers/vk100.cpp
@@ -1025,7 +1025,7 @@ MC6845_UPDATE_ROW( vk100_state::crtc_update_row )
 		// display a 12-bit wide chunk
 		for (int j = 0; j < 12; j++)
 		{
-			bitmap.pix32(y, (12*i)+j) = (((block&(0x0001<<j))?1:0)^(m_vgSOPS&1))?fgColor:bgColor;
+			bitmap.pix32(y, hbp + (12*i)+j) = (((block&(0x0001<<j))?1:0)^(m_vgSOPS&1))?fgColor:bgColor;
 		}
 	}
 }

--- a/src/mame/drivers/z100.cpp
+++ b/src/mame/drivers/z100.cpp
@@ -309,7 +309,7 @@ void z100_state::memory_ctrl_w(uint8_t data)
 
 MC6845_UPDATE_ROW(z100_state::update_row)
 {
-	uint32_t *const pix = &bitmap.pix32(y);
+	uint32_t *const pix = &bitmap.pix32(y, hbp);
 	const uint16_t amask = m_vram_config->read() ? 0xfff : 0x7ff;
 
 	for (int x = 0; x < x_count; x++)

--- a/src/mame/drivers/zrt80.cpp
+++ b/src/mame/drivers/zrt80.cpp
@@ -221,7 +221,7 @@ MC6845_UPDATE_ROW( zrt80_state::crtc_update_row )
 	const rgb_t *palette = m_palette->palette()->entry_list_raw();
 	uint8_t chr,gfx,inv;
 	uint16_t mem,x;
-	uint32_t *p = &bitmap.pix32(y);
+	uint32_t *p = &bitmap.pix32(y, hbp);
 	uint8_t polarity = ioport("DIPSW1")->read() & 4 ? 0xff : 0;
 
 	for (x = 0; x < x_count; x++)
@@ -287,8 +287,6 @@ void zrt80_state::zrt80(machine_config &config)
 	screen.set_color(rgb_t::green());
 	screen.set_refresh_hz(60);
 	screen.set_vblank_time(ATTOSECONDS_IN_USEC(2500)); /* not accurate */
-	screen.set_size(640, 200);
-	screen.set_visarea(0, 640-1, 0, 200-1);
 	screen.set_screen_update("crtc", FUNC(mc6845_device::screen_update));
 
 	GFXDECODE(config, "gfxdecode", m_palette, gfx_zrt80);

--- a/src/mame/includes/hnayayoi.h
+++ b/src/mame/includes/hnayayoi.h
@@ -63,7 +63,7 @@ private:
 	MC6845_UPDATE_ROW(untoucha_update_row);
 	void common_vh_start( int num_pixmaps );
 	void copy_pixel( int x, int y, int pen );
-	void draw_layer_interleaved(bitmap_rgb32 &bitmap, const rectangle &cliprect, uint16_t row, uint16_t y, uint8_t x_count, int left_pixmap, int right_pixmap, int palbase, bool transp);
+	void draw_layer_interleaved(bitmap_rgb32 &bitmap, const rectangle &cliprect, uint16_t row, uint16_t y, uint16_t hbp, uint8_t x_count, int left_pixmap, int right_pixmap, int palbase, bool transp);
 	DECLARE_WRITE_LINE_MEMBER(irqhandler);
 	required_device<cpu_device> m_maincpu;
 	required_device<ls259_device> m_mainlatch;

--- a/src/mame/includes/kaypro.h
+++ b/src/mame/includes/kaypro.h
@@ -79,11 +79,8 @@ public:
 	void kaypro_map(address_map &map);
 	void kayproii_io(address_map &map);
 private:
-	void mc6845_cursor_configure();
-	void mc6845_screen_configure();
 	virtual void device_timer(emu_timer &timer, device_timer_id id, int param, void *ptr) override;
 
-	uint8_t m_mc6845_cursor[16];
 	uint8_t m_mc6845_reg[32];
 	uint8_t m_mc6845_ind;
 	uint8_t m_framecnt;

--- a/src/mame/machine/dragon.cpp
+++ b/src/mame/machine/dragon.cpp
@@ -220,7 +220,7 @@ MC6845_UPDATE_ROW(d64plus_state::crtc_update_row)
 		for (int bit = 0; bit < 8; bit++)
 		{
 			int x = (column * 8) + bit;
-			bitmap.pix32(y, x) = m_palette->pen(BIT(data, 7) && de);
+			bitmap.pix32(y, hbp + x) = m_palette->pen(BIT(data, 7) && de);
 			data <<= 1;
 		}
 	}

--- a/src/mame/machine/osborne1.cpp
+++ b/src/mame/machine/osborne1.cpp
@@ -500,7 +500,7 @@ MC6845_UPDATE_ROW(osborne1nv_state::crtc_update_row)
 {
 	rgb_t const *const palette = m_palette->palette()->entry_list_raw();
 	uint16_t const base = (ma >> 1) & 0xF80;
-	uint32_t *p = &bitmap.pix32(y);
+	uint32_t *p = &bitmap.pix32(y, hbp);
 	for (uint8_t x = 0; x < x_count; ++x)
 	{
 		uint16_t const offset = base | ((ma + x) & 0x7F);

--- a/src/mame/video/abc1600.cpp
+++ b/src/mame/video/abc1600.cpp
@@ -183,7 +183,7 @@ MC6845_UPDATE_ROW(abc1600_mover_device::crtc_update_row)
 			{
 				int color = ((BIT(data, 15) ^ PIX_POL) && !BLANK) && de;
 
-				bitmap.pix32(vbp + y, hbp + x++) = pen[color];
+				bitmap.pix32(y, hbp + x++) = pen[color];
 
 				data <<= 1;
 			}
@@ -211,7 +211,7 @@ void abc1600_mover_device::device_add_mconfig(machine_config &config)
 
 	SY6845E(config, m_crtc, XTAL(64'000'000)/32);
 	m_crtc->set_screen(SCREEN_TAG);
-	m_crtc->set_show_border_area(true);
+	m_crtc->set_show_border_area(false);
 	m_crtc->set_char_width(32);
 	m_crtc->set_update_row_callback(FUNC(abc1600_mover_device::crtc_update_row), this);
 	m_crtc->set_on_update_addr_change_callback(FUNC(abc1600_mover_device::crtc_update), this);

--- a/src/mame/video/abc800.cpp
+++ b/src/mame/video/abc800.cpp
@@ -12,8 +12,10 @@
 
 
 
-// these are needed because the MC6845 emulation does
-// not position the active display area correctly
+// These are needed because the MC6845 emulation implements the borders,
+// but the offsets to the displayable area, vbp and hbp, are not available
+// to the screen_update function. The high resolution screen update code
+// might be better integrated into abc800m_update_row.
 #define HORIZONTAL_PORCH_HACK   115
 #define VERTICAL_PORCH_HACK     29
 
@@ -220,8 +222,6 @@ MC6845_UPDATE_ROW( abc800m_state::abc800m_update_row )
 	int column;
 	rgb_t fgpen = m_palette->pen(1);
 
-	y += vbp;
-
 	for (column = 0; column < x_count; column++)
 	{
 		int bit;
@@ -281,7 +281,7 @@ void abc800m_state::abc800m_video(machine_config &config)
 {
 	mc6845_device &mc6845(MC6845(config, MC6845_TAG, ABC800_CCLK));
 	mc6845.set_screen(SCREEN_TAG);
-	mc6845.set_show_border_area(true);
+	mc6845.set_show_border_area(false);
 	mc6845.set_char_width(ABC800_CHAR_WIDTH);
 	mc6845.set_update_row_callback(FUNC(abc800m_state::abc800m_update_row), this);
 	mc6845.out_vsync_callback().set(m_dart, FUNC(z80dart_device::rib_w)).invert();

--- a/src/mame/video/abc802.cpp
+++ b/src/mame/video/abc802.cpp
@@ -61,8 +61,6 @@ MC6845_UPDATE_ROW( abc802_state::abc802_update_row )
 
 	int rf = 0, rc = 0, rg = 0;
 
-	y += vbp;
-
 	for (int column = 0; column < x_count; column++)
 	{
 		uint8_t code = m_char_ram[(ma + column) & 0x7ff];
@@ -124,7 +122,7 @@ MC6845_UPDATE_ROW( abc802_state::abc802_update_row )
 			{
 				for (int bit = 0; bit < ABC800_CHAR_WIDTH; bit++)
 				{
-					int x = hbp + ((column + 3) * ABC800_CHAR_WIDTH) + bit;
+					int x = hbp + (column * ABC800_CHAR_WIDTH) + bit;
 					int color = (BIT(data, 7) ^ ri) && de;
 
 					bitmap.pix32(y, x) = pen[color];
@@ -136,7 +134,7 @@ MC6845_UPDATE_ROW( abc802_state::abc802_update_row )
 			{
 				for (int bit = 0; bit < ABC800_CHAR_WIDTH; bit++)
 				{
-					int x = hbp + ((column + 3) * ABC800_CHAR_WIDTH) + (bit << 1);
+					int x = hbp + (column * ABC800_CHAR_WIDTH) + (bit << 1);
 					int color = (BIT(data, 7) ^ ri) && de;
 
 					bitmap.pix32(y, x) = pen[color];
@@ -182,7 +180,7 @@ void abc802_state::abc802_video(machine_config &config)
 {
 	mc6845_device &mc6845(MC6845(config, MC6845_TAG, ABC800_CCLK));
 	mc6845.set_screen(SCREEN_TAG);
-	mc6845.set_show_border_area(true);
+	mc6845.set_show_border_area(false);
 	mc6845.set_char_width(ABC800_CHAR_WIDTH);
 	mc6845.set_update_row_callback(FUNC(abc802_state::abc802_update_row), this);
 	mc6845.out_vsync_callback().set(FUNC(abc802_state::vs_w));

--- a/src/mame/video/abc806.cpp
+++ b/src/mame/video/abc806.cpp
@@ -229,7 +229,7 @@ MC6845_UPDATE_ROW( abc806_state::abc806_update_row )
 	int e6 = m_40;
 	int th = 0;
 
-	y += m_sync + vbp;
+	y += m_sync;
 
 	for (int column = 0; column < x_count; column++)
 	{
@@ -299,7 +299,7 @@ MC6845_UPDATE_ROW( abc806_state::abc806_update_row )
 
 		uint16_t chargen_addr = (th << 12) | (data << 4) | rad_data;
 		uint8_t chargen_data = m_char_rom->base()[chargen_addr & 0xfff] << 2;
-		int x = hbp + (column + 4) * ABC800_CHAR_WIDTH;
+		int x = hbp + column * ABC800_CHAR_WIDTH;
 
 		for (int bit = 0; bit < ABC800_CHAR_WIDTH; bit++)
 		{
@@ -481,7 +481,7 @@ void abc806_state::abc806_video(machine_config &config)
 {
 	MC6845(config, m_crtc, ABC800_CCLK);
 	m_crtc->set_screen(SCREEN_TAG);
-	m_crtc->set_show_border_area(true);
+	m_crtc->set_show_border_area(false);
 	m_crtc->set_char_width(ABC800_CHAR_WIDTH);
 	m_crtc->set_update_row_callback(FUNC(abc806_state::abc806_update_row), this);
 	m_crtc->out_hsync_callback().set(FUNC(abc806_state::hs_w));

--- a/src/mame/video/aussiebyte.cpp
+++ b/src/mame/video/aussiebyte.cpp
@@ -169,7 +169,7 @@ MC6845_UPDATE_ROW( aussiebyte_state::crtc_update_row )
 	const rgb_t *palette = m_palette->palette()->entry_list_raw();
 	uint8_t chr,gfx,attr;
 	uint16_t mem,x;
-	uint32_t *p = &bitmap.pix32(y);
+	uint32_t *p = &bitmap.pix32(y, hbp);
 	ra &= 15;
 	m_cnt++;
 

--- a/src/mame/video/bbc.cpp
+++ b/src/mame/video/bbc.cpp
@@ -235,7 +235,7 @@ MC6845_UPDATE_ROW( bbc_state::crtc_update_row )
 
 				rgb_t rgb = out_rgb(rgb_t(r, g, b));
 
-				bitmap.pix32(y, (x_pos*m_pixels_per_byte) + pixelno) = de ? rgb : rgb_t::black();
+				bitmap.pix32(y, hbp + (x_pos*m_pixels_per_byte) + pixelno) = de ? rgb : rgb_t::black();
 			}
 		}
 	}
@@ -251,7 +251,7 @@ MC6845_UPDATE_ROW( bbc_state::crtc_update_row )
 
 				col ^= ((cursor_x != -1 && x_pos >= cursor_x && x_pos < (cursor_x + m_cursor_size)) ? 7 : 0);
 
-				bitmap.pix32(y, (x_pos*m_pixels_per_byte) + pixelno) = de ? out_rgb(palette[col]) : rgb_t::black();
+				bitmap.pix32(y, hbp + (x_pos*m_pixels_per_byte) + pixelno) = de ? out_rgb(palette[col]) : rgb_t::black();
 				i = (i << 1) | 1;
 			}
 		}

--- a/src/mame/video/decodmd2.cpp
+++ b/src/mame/video/decodmd2.cpp
@@ -111,7 +111,7 @@ MC6845_UPDATE_ROW( decodmd_type2_device::crtc_update_row )
 		for (int dot = 0; dot < 8; dot++)
 		{
 			intensity = ((RAM[addr] >> (7-dot) & 0x01) << 1) | (RAM[addr + 0x200] >> (7-dot) & 0x01);
-			bitmap.pix32(y, x + dot) = rgb_t(0x3f * intensity, 0x2a * intensity, 0x00);
+			bitmap.pix32(y, hbp + x + dot) = rgb_t(0x3f * intensity, 0x2a * intensity, 0x00);
 		}
 		addr++;
 	}

--- a/src/mame/video/decodmd3.cpp
+++ b/src/mame/video/decodmd3.cpp
@@ -110,12 +110,12 @@ MC6845_UPDATE_ROW( decodmd_type3_device::crtc_update_row )
 		for (int dot = 0; dot < 8; dot++)
 		{
 			intensity = ((RAM[addr + 1] >> (7-dot) & 0x01) << 1) | (RAM[addr + 0x801] >> (7-dot) & 0x01);
-			bitmap.pix32(y, x + dot) = rgb_t(0x3f * intensity, 0x2a * intensity, 0x00);
+			bitmap.pix32(y, hbp + x + dot) = rgb_t(0x3f * intensity, 0x2a * intensity, 0x00);
 		}
 		for (int dot = 8; dot < 16; dot++)
 		{
 			intensity = ((RAM[addr] >> (15-dot) & 0x01) << 1) | (RAM[addr + 0x800] >> (15-dot) & 0x01);
-			bitmap.pix32(y, x + dot) = rgb_t(0x3f * intensity, 0x2a * intensity, 0x00);
+			bitmap.pix32(y, hbp + x + dot) = rgb_t(0x3f * intensity, 0x2a * intensity, 0x00);
 		}
 		addr += 2;
 	}

--- a/src/mame/video/dgn_beta.cpp
+++ b/src/mame/video/dgn_beta.cpp
@@ -102,7 +102,7 @@ MC6845_UPDATE_ROW( dgn_beta_state::crtc_update_row )
 {
 	const rgb_t *palette = m_palette->palette()->entry_list_raw();
 	uint8_t *videoram = m_videoram;
-	uint32_t  *p = &bitmap.pix32(y);
+	uint32_t  *p = &bitmap.pix32(y, hbp);
 	int i;
 	if(IsTextMode)
 	{

--- a/src/mame/video/hnayayoi.cpp
+++ b/src/mame/video/hnayayoi.cpp
@@ -199,11 +199,11 @@ WRITE8_MEMBER(hnayayoi_state::hnayayoi_palbank_w)
 }
 
 
-void hnayayoi_state::draw_layer_interleaved(bitmap_rgb32 &bitmap, const rectangle &cliprect, uint16_t row, uint16_t y, uint8_t x_count, int left_pixmap, int right_pixmap, int palbase, bool transp)
+void hnayayoi_state::draw_layer_interleaved(bitmap_rgb32 &bitmap, const rectangle &cliprect, uint16_t row, uint16_t y, uint16_t hbp, uint8_t x_count, int left_pixmap, int right_pixmap, int palbase, bool transp)
 {
 	uint8_t *src1 = &m_pixmap[left_pixmap][(row & 255) * 256];
 	uint8_t *src2 = &m_pixmap[right_pixmap][(row & 255) * 256];
-	uint32_t *dst = &bitmap.pix32(y);
+	uint32_t *dst = &bitmap.pix32(y, hbp);
 
 	const pen_t *pal = &m_palette->pens()[palbase * 16];
 
@@ -233,8 +233,8 @@ MC6845_UPDATE_ROW(hnayayoi_state::hnayayoi_update_row)
 	int col0 = (m_palbank >>  0) & 0x0f;
 	int col1 = (m_palbank >>  4) & 0x0f;
 
-	draw_layer_interleaved(bitmap, cliprect, y, y, x_count, 3, 2, col1, false);
-	draw_layer_interleaved(bitmap, cliprect, y, y, x_count, 1, 0, col0, true);
+	draw_layer_interleaved(bitmap, cliprect, y - vbp, y, hbp, x_count, 3, 2, col1, false);
+	draw_layer_interleaved(bitmap, cliprect, y - vbp, y, hbp, x_count, 1, 0, col0, true);
 }
 
 
@@ -245,8 +245,8 @@ MC6845_UPDATE_ROW(hnayayoi_state::untoucha_update_row)
 	int col2 = (m_palbank >>  8) & 0x0f;
 	int col3 = (m_palbank >> 12) & 0x0f;
 
-	draw_layer_interleaved(bitmap, cliprect, y + 16, y, x_count, 7, 6, col3, false);
-	draw_layer_interleaved(bitmap, cliprect, y + 16, y, x_count, 5, 4, col2, true);
-	draw_layer_interleaved(bitmap, cliprect, y + 16, y, x_count, 3, 2, col1, true);
-	draw_layer_interleaved(bitmap, cliprect, y + 16, y, x_count, 1, 0, col0, true);
+	draw_layer_interleaved(bitmap, cliprect, y - vbp + 16, y, hbp, x_count, 7, 6, col3, false);
+	draw_layer_interleaved(bitmap, cliprect, y - vbp + 16, y, hbp, x_count, 5, 4, col2, true);
+	draw_layer_interleaved(bitmap, cliprect, y - vbp + 16, y, hbp, x_count, 3, 2, col1, true);
+	draw_layer_interleaved(bitmap, cliprect, y - vbp + 16, y, hbp, x_count, 1, 0, col0, true);
 }

--- a/src/mame/video/kaypro.cpp
+++ b/src/mame/video/kaypro.cpp
@@ -138,14 +138,14 @@ uint32_t kaypro_state::screen_update_kaypro484(screen_device &screen, bitmap_rgb
 MC6845_UPDATE_ROW( kaypro_state::kaypro484_update_row )
 {
 	const rgb_t *palette = m_palette->palette()->entry_list_raw();
-	uint32_t *p = &bitmap.pix32(y);
+	uint32_t *p = &bitmap.pix32(y, hbp);
 	uint16_t x;
 	uint8_t gfx,fg,bg;
 
 	for (x = 0; x < x_count; x++)               // for each character
 	{
 		uint8_t inv=0;
-		//      if (x == cursor_x) inv=0xff;    /* uncomment when mame fixed */
+		if (x == cursor_x) inv = 0xff;
 		uint16_t mem = (ma + x) & 0x7ff;
 		uint8_t chr = m_p_videoram[mem];
 		uint8_t attr = m_p_videoram[mem | 0x800];
@@ -177,10 +177,6 @@ MC6845_UPDATE_ROW( kaypro_state::kaypro484_update_row )
 		if ( (BIT(attr, 2)) & (BIT(m_framecnt, 3)) )
 			fg = bg;
 
-		/* process cursor */
-		if (x == cursor_x)
-			inv ^= m_mc6845_cursor[ra];
-
 		/* get pattern of pixels for that character scanline */
 		if ( (ra == 15) & (BIT(attr, 3)) )  /* underline */
 			gfx = 0xff;
@@ -198,58 +194,6 @@ MC6845_UPDATE_ROW( kaypro_state::kaypro484_update_row )
 		*p++ = palette[BIT( gfx, 0 ) ? fg : bg];
 	}
 }
-
-/************************************* MC6845 SUPPORT ROUTINES ***************************************/
-
-/* The 6845 can produce a variety of cursor shapes - all are emulated here - remove when mame fixed */
-void kaypro_state::mc6845_cursor_configure()
-{
-	uint8_t i,curs_type=0,r9,r10,r11;
-
-	/* curs_type holds the general cursor shape to be created
-	    0 = no cursor
-	    1 = partial cursor (only shows on a block of scan lines)
-	    2 = full cursor
-	    3 = two-part cursor (has a part at the top and bottom with the middle blank) */
-
-	for ( i = 0; i < ARRAY_LENGTH(m_mc6845_cursor); i++) m_mc6845_cursor[i] = 0;        // prepare cursor by erasing old one
-
-	r9  = m_mc6845_reg[9];                  // number of scan lines - 1
-	r10 = m_mc6845_reg[10] & 0x1f;              // cursor start line = last 5 bits
-	r11 = m_mc6845_reg[11]+1;                   // cursor end line incremented to suit for-loops below
-
-	/* decide the curs_type by examining the registers */
-	if (r10 < r11) curs_type=1;             // start less than end, show start to end
-	else
-	if (r10 == r11) curs_type=2;                // if equal, show full cursor
-	else curs_type=3;                   // if start greater than end, it's a two-part cursor
-
-	if ((r11 - 1) > r9) curs_type=2;            // if end greater than scan-lines, show full cursor
-	if (r10 > r9) curs_type=0;              // if start greater than scan-lines, then no cursor
-	if (r11 > 16) r11=16;                   // truncate 5-bit register to fit our 4-bit hardware
-
-	/* create the new cursor */
-	if (curs_type > 1) for (i = 0;i < ARRAY_LENGTH(m_mc6845_cursor);i++) m_mc6845_cursor[i]=0xff; // turn on full cursor
-
-	if (curs_type == 1) for (i = r10;i < r11;i++) m_mc6845_cursor[i]=0xff; // for each line that should show, turn on that scan line
-
-	if (curs_type == 3) for (i = r11; i < r10;i++) m_mc6845_cursor[i]=0; // now take a bite out of the middle
-}
-
-/* Resize the screen within the limits of the hardware. Expand the image to fill the screen area.
-    Standard screen is 640 x 400 = 0x7d0 bytes. */
-
-void kaypro_state::mc6845_screen_configure()
-{
-	uint16_t width = m_mc6845_reg[1]*8-1;                         // width in pixels
-	uint16_t height = m_mc6845_reg[6]*(m_mc6845_reg[9]+1)-1;                  // height in pixels
-	uint16_t bytes = m_mc6845_reg[1]*m_mc6845_reg[6]-1;                       // video ram needed -1
-
-	/* Resize the screen */
-	if ((width < 640) && (height < 400) && (bytes < 0x800)) /* bounds checking to prevent an assert or violation */
-		m_screen->set_visible_area(0, width, 0, height);
-}
-
 
 /**************************** I/O PORTS *****************************************************************/
 
@@ -276,12 +220,6 @@ WRITE8_MEMBER( kaypro_state::kaypro484_register_w )
 		m_mc6845_reg[m_mc6845_ind] = data;
 
 	m_crtc->register_w(data);
-
-	if ((m_mc6845_ind == 1) || (m_mc6845_ind == 6) || (m_mc6845_ind == 9))
-		mc6845_screen_configure();          /* adjust screen size */
-
-	if ((m_mc6845_ind > 8) && (m_mc6845_ind < 12))
-		mc6845_cursor_configure();      /* adjust cursor shape - remove when mame fixed */
 
 	if ((m_mc6845_ind > 17) && (m_mc6845_ind < 20))
 		m_mc6845_video_address = m_mc6845_reg[19] | ((m_mc6845_reg[18] & 0x3f) << 8);   /* internal ULA address */

--- a/src/mame/video/mbc55x.cpp
+++ b/src/mame/video/mbc55x.cpp
@@ -147,7 +147,7 @@ MC6845_UPDATE_ROW( mbc55x_state::crtc_update_row )
 
 			colour=(rb<<2) | (gb<<1) | (bb<<0);
 
-			bitmap.pix32(y, (x_pos*8)+pixelno)=palette[colour];
+			bitmap.pix32(y, hbp + (x_pos*8)+pixelno)=palette[colour];
 			//logerror("set pixel (%d,%d)=%d\n",y, ((x_pos*8)+pixelno),colour);
 			bitno=bitno>>1;
 			shifts--;

--- a/src/mame/video/mbee.cpp
+++ b/src/mame/video/mbee.cpp
@@ -340,7 +340,7 @@ MC6845_UPDATE_ROW( mbee_state::crtc_update_row )
 	if (!monopal && !m_p_colorram)
 		monopal = 2;
 
-	uint32_t *p = &bitmap.pix32(y);
+	uint32_t *p = &bitmap.pix32(y, hbp);
 	uint8_t inv, attr=0, gfx, fg=96+monopal, bg=96, col=0;
 	uint16_t mem, x, chr;
 

--- a/src/mame/video/pc_t1t.cpp
+++ b/src/mame/video/pc_t1t.cpp
@@ -186,7 +186,7 @@ void pc_t1t_device::pcjr_palette(palette_device &palette) const
 MC6845_UPDATE_ROW( pc_t1t_device::t1000_text_inten_update_row )
 {
 	const rgb_t *palette = m_palette->palette()->entry_list_raw();
-	uint32_t  *p = &bitmap.pix32(y);
+	uint32_t  *p = &bitmap.pix32(y, hbp);
 
 	if ( y == 0 ) logerror("t1000_text_inten_update_row\n");
 	for (int i = 0; i < x_count; i++)
@@ -218,7 +218,7 @@ MC6845_UPDATE_ROW( pc_t1t_device::t1000_text_inten_update_row )
 MC6845_UPDATE_ROW( pc_t1t_device::t1000_text_blink_update_row )
 {
 	const rgb_t *palette = m_palette->palette()->entry_list_raw();
-	uint32_t  *p = &bitmap.pix32(y);
+	uint32_t  *p = &bitmap.pix32(y, hbp);
 
 	for (int i = 0; i < x_count; i++)
 	{
@@ -258,7 +258,7 @@ MC6845_UPDATE_ROW( pc_t1t_device::t1000_text_blink_update_row )
 MC6845_UPDATE_ROW( pcvideo_pcjr_device::pcjx_text_update_row )
 {
 	const rgb_t *palette = m_palette->palette()->entry_list_raw();
-	uint32_t  *p = &bitmap.pix32(y);
+	uint32_t  *p = &bitmap.pix32(y, hbp);
 	int i;
 
 	for ( i = 0; i < x_count; i++ )
@@ -299,7 +299,7 @@ MC6845_UPDATE_ROW( pcvideo_pcjr_device::pcjx_text_update_row )
 MC6845_UPDATE_ROW( pc_t1t_device::t1000_gfx_4bpp_update_row )
 {
 	const rgb_t *palette = m_palette->palette()->entry_list_raw();
-	uint32_t  *p = &bitmap.pix32(y);
+	uint32_t  *p = &bitmap.pix32(y, hbp);
 	uint8_t   *vid = m_displayram + ( ra << 13 );
 	int i;
 
@@ -326,7 +326,7 @@ MC6845_UPDATE_ROW( pc_t1t_device::t1000_gfx_4bpp_update_row )
 MC6845_UPDATE_ROW( pc_t1t_device::t1000_gfx_2bpp_update_row )
 {
 	const rgb_t *palette = m_palette->palette()->entry_list_raw();
-	uint32_t  *p = &bitmap.pix32(y);
+	uint32_t  *p = &bitmap.pix32(y, hbp);
 	uint8_t   *vid = m_displayram + ( ra << 13 );
 	int i;
 
@@ -353,7 +353,7 @@ MC6845_UPDATE_ROW( pc_t1t_device::t1000_gfx_2bpp_update_row )
 MC6845_UPDATE_ROW( pcvideo_pcjr_device::pcjr_gfx_2bpp_high_update_row )
 {
 	const rgb_t *palette = m_palette->palette()->entry_list_raw();
-	uint32_t  *p = &bitmap.pix32(y);
+	uint32_t  *p = &bitmap.pix32(y, hbp);
 	uint8_t   *vid = m_displayram + ( ra << 13 );
 	int i;
 
@@ -378,7 +378,7 @@ MC6845_UPDATE_ROW( pcvideo_pcjr_device::pcjr_gfx_2bpp_high_update_row )
 MC6845_UPDATE_ROW( pc_t1t_device::t1000_gfx_2bpp_tga_update_row )
 {
 	const rgb_t *palette = m_palette->palette()->entry_list_raw();
-	uint32_t  *p = &bitmap.pix32(y);
+	uint32_t  *p = &bitmap.pix32(y, hbp);
 	uint8_t   *vid = m_displayram + ( ra << 13 );
 	int i;
 
@@ -405,7 +405,7 @@ MC6845_UPDATE_ROW( pc_t1t_device::t1000_gfx_2bpp_tga_update_row )
 MC6845_UPDATE_ROW( pc_t1t_device::t1000_gfx_1bpp_update_row )
 {
 	const rgb_t *palette = m_palette->palette()->entry_list_raw();
-	uint32_t  *p = &bitmap.pix32(y);
+	uint32_t  *p = &bitmap.pix32(y, hbp);
 	uint8_t   *vid = m_displayram + ( ra << 13 );
 	uint8_t   fg = m_palette_base + m_reg.data[0x11];
 	uint8_t   bg = m_palette_base + m_reg.data[0x10];

--- a/src/mame/video/qix.cpp
+++ b/src/mame/video/qix.cpp
@@ -280,7 +280,7 @@ MC6845_BEGIN_UPDATE( qix_state::crtc_begin_update )
 
 MC6845_UPDATE_ROW( qix_state::crtc_update_row )
 {
-	uint32_t *dest = &bitmap.pix32(y);
+	uint32_t *dest = &bitmap.pix32(y, hbp);
 	pen_t *pens = &m_pens[m_palette_bank << 8];
 
 	/* the memory is hooked up to the MA, RA lines this way */

--- a/src/mame/video/super80.cpp
+++ b/src/mame/video/super80.cpp
@@ -396,7 +396,7 @@ uint32_t super80_state::screen_update_super80v(screen_device &screen, bitmap_rgb
 MC6845_UPDATE_ROW( super80_state::crtc_update_row )
 {
 	const rgb_t *palette = m_palette->palette()->entry_list_raw();
-	uint32_t *p = &bitmap.pix32(y);
+	uint32_t *p = &bitmap.pix32(y, hbp);
 
 	for (uint16_t x = 0; x < x_count; x++)               // for each character
 	{

--- a/src/mame/video/v1050.cpp
+++ b/src/mame/video/v1050.cpp
@@ -82,7 +82,7 @@ MC6845_UPDATE_ROW( v1050_state::crtc_update_row )
 			/* display blank */
 			if (attr & V1050_ATTR_BLANK) color = 0;
 
-			bitmap.pix32(vbp + y, hbp + x) = m_palette->pen(de ? color : 0);
+			bitmap.pix32(y, hbp + x) = m_palette->pen(de ? color : 0);
 
 			data <<= 1;
 		}
@@ -113,7 +113,7 @@ void v1050_state::v1050_video(machine_config &config)
 {
 	HD6845S(config, m_crtc, 15.36_MHz_XTAL/8); // HD6845SP according to Programmer's Technical Document
 	m_crtc->set_screen(SCREEN_TAG);
-	m_crtc->set_show_border_area(true);
+	m_crtc->set_show_border_area(false);
 	m_crtc->set_char_width(8);
 	m_crtc->set_update_row_callback(FUNC(v1050_state::crtc_update_row), this);
 	m_crtc->out_vsync_callback().set(FUNC(v1050_state::crtc_vs_w));
@@ -122,8 +122,6 @@ void v1050_state::v1050_video(machine_config &config)
 	screen.set_screen_update(H46505_TAG, FUNC(hd6845s_device::screen_update));
 	screen.set_refresh_hz(60);
 	screen.set_vblank_time(ATTOSECONDS_IN_USEC(2500));
-	screen.set_size(640, 400);
-	screen.set_visarea(0,640-1, 0, 400-1);
 
 	PALETTE(config, m_palette, palette_device::MONOCHROME_HIGHLIGHT);
 }


### PR DESCRIPTION
This patch proposes a change to the mc6845 driver. There are a range of issues in uses of this driver, it looks frustrating for machine coders, and it appears in need of such a cleanup, but it touches a lot of machines making it a difficult proposal. An attempt to test as many as possible has been made, but it is not possible to test all modes on all machines, so help testing this would be appreciated - that is if people think such a change is necessary. It is expected to improve many machines, with proper screen configuration and that should work with or without borders, it should avoid some artifacts in race conditions, and partial cursors should work for all the dependent machines now. A large block of machines that use the mc6845 driver but do not rely on it's configuration code or row update paths are not expected to be at risk of regression.

1. Clarify the border offsets and make uses of the mc6845 driver consistent.

The most consistent definition of the border placement appears to be that the
displayable characters are always offset for the border and that only the
screen visual clip area changes with or without a border. With this definition
only the screen visual area changes when the machine chooses to display the
border or not, and the machines do not need special cases in either case. The
configuration is refactored into the mc6845 driver in most cases.

The other possible definition would have been to offset the displayable
characters from the origin of the screen pixmap only when displaying the
border, and otherwise place it at the origin. This would appear to place a
greater burden on each machine.

This change requires updates to the majority of the uses of the mc6845 driver
configuration paths and in particular the driver row update paths.

There are a large block of machines that do not use these paths. These
machines do not associate a screen with the mc6845 driver and do not use the
driver row update code paths, rather these machines implement their own screen
update function. This includes a lot of games. These are expected to be low
risk for regressions and only a selection have been tested.

There are a lot of machines that do use the driver configuration and row
update code paths, so this change affects a lot of machines. Most have been
tested except a few for which roms or software was not available or that were
just skeletons. For system that would at least configure the mc6845 these were
tested by writing to the display memory area.

In many cases it was only necessary to include a horizontal border offset in
the row update function. These are low risk for regression or at a least a low
risk for machine specific regressions.

Some machine row update functions included a vertical offset which was not
appropriate and was removed. The 'y' value passed to the row update function
is now clearly defined as an offset in the target bitmap so already includes
an offset for the border.

Many machines attempted to show the border. It is expected that this was
largely because the configuration was not working properly and the driver
definitions were frustrating. These have been modified to not show the border
which seems an appropriate default for these machines, and in any case these
should also work with the border shown. Showing the border, or not, might be
considered for a configuration option now as it simply changes the screen
visual clip area.

Many machines manually defined the screen size and visarea. In some cases they
did not even associate a screen with the mc6845 driver to avoid the driver
mis-configuring the screen. This is no longer necessary to most of them and
these definitions have been removed. The mc6845 driver should now correctly
configure the screen, and even if the machine runs some non-standard code
defining a different screen size etc. Most of these were tested and configured
properly and clipped the border properly.

A few machines had complex code to work around the configuration problems and
these have been clean up and can now rely on the mc6845 driver.

There remain only a couple of machines for which the driver configuration does
not work, and these appear to be targeting LCD screens etc that might not
follow CRT timing. These need to avoid associating a screen with the driver
and define their own screen size and visual area. Perhaps these would have
been better off using their own screen update functions rather than the driver
row update code paths, but these have been tested and still appear to work.

2. The mc6845 driver and a few machines mixed driver state with the
screen update path state, and this has been separated.

The screen update paths run off their the screen timers, and might update as
little as part of a row. So it is not appropriate for the driver or machine
state to be updating the driver state on screen updates. When the screen was
updating only part of a line, and calls the driver multiple times per line,
the driver was advancing an address on each causing artifacts - it was not
workable.

If some synchronisation is required between the screen updates and the machine
state then some more thought will be need to get this driver working with that
properly.

The mc6845 driver was updating the current display address from the screen
update code paths which appeared to be visible to the machine. The screen
update no longer modifies that machine state, calculating the display address
from the requested row.

The CGA driver stood out in this issue and need some rewriting. This raises
questions about the coordination of the screen update paths with the driver
state, the drivers row and sync state etc. Some graphical CGA code was test and
it appear to still run ok, but perhaps there had been some attempt to make the
screen updates more responsive for this driver, but it seemed only for the CGA
driver?

3. Partial cursors have been implement.

The mc6845 driver now implements partial cursors. It appears the only one
machine, the kaypro, had implemented partial cursors and that machines code
has been cleaned up now that the driver supports this.