### PR TITLE
315_5124: Adjust horizontal screen positions

### DIFF
--- a/src/devices/bus/sega8/sega8_slot.cpp
+++ b/src/devices/bus/sega8/sega8_slot.cpp
@@ -302,17 +302,17 @@ void sega8_cart_slot_device::set_lphaser_xoffset( uint8_t *rom, int size )
 	if (size >= 0x8000)
 	{
 		if (!memcmp(&rom[0x7ff0], signatures[0], 16) || !memcmp(&rom[0x7ff0], signatures[1], 16))
-			xoff = 26;
+			xoff = 9;
 		else if (!memcmp(&rom[0x7ff0], signatures[2], 16))
-			xoff = 36;
+			xoff = 19;
 		else if (!memcmp(&rom[0x7ff0], signatures[3], 16))
-			xoff = 32;
+			xoff = 15;
 		else if (!memcmp(&rom[0x7ff0], signatures[4], 16))
-			xoff = 30;
+			xoff = 13;
 		else if (!memcmp(&rom[0x7ff0], signatures[5], 16))
-			xoff = 39;
+			xoff = 22;
 		else if (!memcmp(&rom[0x7ff0], signatures[6], 16))
-			xoff = 38;
+			xoff = 21;
 	}
 
 	m_cart->set_lphaser_xoffs(xoff);

--- a/src/devices/video/315_5124.cpp
+++ b/src/devices/video/315_5124.cpp
@@ -24,23 +24,22 @@ SMS Display Timing
 ------------------
     For more information, please see:
     - http://cgfm2.emuviews.com/txt/msvdp.txt
-    - http://www.smspower.org/forums/viewtopic.php?p=44198
+    - http://www.smspower.org/forums/viewtopic.php?p=37142
+    - http://www.smspower.org/forums/viewtopic.php?p=92925
 
 A scanline contains the following sections:
-  - horizontal sync     9  E9-ED   => HSYNC high
-  - left blanking       2  ED-EE
-  - color burst        14  EE-F5   => increment line counter/generate interrupts/etc
-  - left blanking       8  F5-F9
-  - left border        13  F9-FF
-  - active display    256  00-7F
-  - right border       15  80-87
-  - right blanking      8  87-8B
-  - horizontal sync    17  8B-93   => HSYNC low
+  - horizontal sync    26  E9-F5   => HSYNC low
+  - left blanking       2  F6-F6   => HSYNC high
+  - color burst        14  F7-FD
+  - left blanking       8  FE-01
+  - left border        13  02-08
+  - active display    256  08-88
+  - right border       15  88-8F
+  - right blanking      8  90-93
 
-  Although the processing done for a section happens when HCount is in the
-  specified range (e.g. 00-7F for active display), probably there is a delay
-  until its signal is shown on screen, as happens on the TMS9918 chip
-  according to this timing diagram:
+  Probably the processing done for the active display occurs when HCount
+  is in the 00-7F range and there is a delay until its signal is shown on
+  screen, as happens on the TMS9918 chip according to this timing diagram:
       http://www.smspower.org/Development/TMS9918MasterTimingDiagram
 
 
@@ -110,8 +109,8 @@ static constexpr u8 line_315_5377[8] = { 26, 26, 27, 28 /* not verified */, 24, 
 #define DISPLAY_DISABLED_HPOS 24 /* not verified, works if above 18 (for 'pstrike2') and below 25 (for 'fantdizzy') */
 #define DISPLAY_CB_HPOS       2  /* fixes 'roadrash' (SMS game) title scrolling, due to line counter reload timing */
 
-#define DRAW_TIME_GG          94      /* 9 + 2 + 14 + 8 + 13 + 96/2 */
-#define DRAW_TIME_SMS         46      /* 9 + 2 + 14 + 8 + 13 */
+#define DRAW_TIME_GG         111      /* 26 + 2 + 14 + 8 + 13 + 96/2 */
+#define DRAW_TIME_SMS         63      /* 26 + 2 + 14 + 8 + 13 */
 
 
 DEFINE_DEVICE_TYPE(SEGA315_5124, sega315_5124_device, "sega315_5124", "Sega 315-5124 SMS1 VDP")
@@ -382,14 +381,12 @@ u8 sega315_5124_device::hcount_read()
 
 void sega315_5124_device::hcount_latch()
 {
-	const int active_scr_start = 46;      /* 9 + 2 + 14 + 8 + 13 */
-
 	/* The hcount value returned by the VDP seems to be based on the previous hpos */
 	int hclock = screen().hpos() - 1;
 	if (hclock < 0)
 		hclock += WIDTH;
 
-	m_hcounter = ((hclock - active_scr_start) >> 1) & 0xff;
+	m_hcounter = ((hclock - 46) >> 1) & 0xff;
 	m_hcounter_latched = true;
 }
 

--- a/src/devices/video/315_5124.h
+++ b/src/devices/video/315_5124.h
@@ -36,7 +36,7 @@ public:
 	static constexpr unsigned WIDTH                      = 342;    /* 342 pixels */
 	static constexpr unsigned HEIGHT_NTSC                = 262;    /* 262 lines */
 	static constexpr unsigned HEIGHT_PAL                 = 313;    /* 313 lines */
-	static constexpr unsigned LBORDER_START              = 9 + 2 + 14 + 8;
+	static constexpr unsigned LBORDER_START              = 26 + 2 + 14 + 8;
 	static constexpr unsigned LBORDER_WIDTH              = 13;     /* 13 pixels */
 	static constexpr unsigned RBORDER_WIDTH              = 15;     /* 15 pixels */
 	static constexpr unsigned TBORDER_START              = 3 + 13;

--- a/src/mame/machine/sms.cpp
+++ b/src/mame/machine/sms.cpp
@@ -974,7 +974,7 @@ void sms_state::setup_media_slots()
 			m_lphaser_x_offs = m_smsexpslot->get_lphaser_xoffs();
 
 		if (m_lphaser_x_offs == -1)
-			m_lphaser_x_offs = 36;
+			m_lphaser_x_offs = 19;
 	}
 }
 


### PR DESCRIPTION
When Charles MacDonald documented the horizontal display timing of the 315-5124 chip (SMS VDP) in his msvdp-20021112.txt document, he calculated the HCount values based on the active display start value, that he assumed to be 0x00. For example, the horizontal sync starts 279 pixels after the active screen start position, then its HCount value was documented as 0x8B. There's some documentation in MAME's 315_5124.cpp file that follows the same assumption. More recently, when he did some tests on a Japanese SMS (http://www.smspower.org/forums/viewtopic.php?p=92925), he discovered that horizontal sync starts at HCount 0xE9 instead 0x8B. This pull request changes the 315_5124.cpp documentation of the horizontal timings to new HCount values based on the discovered horizontal sync start value and make adjustments for the drawing times and light gun offsets to reflect these changes.