### PR TITLE
tilemap: revert changes to the tile scroll computations.

### DIFF
--- a/src/emu/tilemap.cpp
+++ b/src/emu/tilemap.cpp
@@ -953,8 +953,11 @@ g_profiler.start(PROFILER_TILEMAP_DRAW);
 
 	// flip the tilemap around the center of the visible area
 	rectangle visarea = screen.visible_area();
-	u32 width = visarea.right() - visarea.left() + 1;
-	u32 height = visarea.bottom() - visarea.top() + 1;
+	// These are not the width and height, rather 2 * left + width + 1,
+	// and 2 * top + height + 1, and these are inputs to the
+	// effective_*scroll functions used in the case of a flip.
+	u32 width = visarea.right() + visarea.left() + 1;
+	u32 height = visarea.bottom() + visarea.top() + 1;
 
 	// XY scrolling playfield
 	if (m_scrollrows == 1 && m_scrollcols == 1)


### PR DESCRIPTION
This reverts https://github.com/mamedev/mame/pull/5393 The original looks good, sorry. A comment has been added to the source to clarify the meaning of the 'width' and 'height' variables, which might be better understood to the `2 * left + width + 1` and `2 * top + height + 1`. These were only used as inputs to the `effective_*scroll()` functions and their use can be followed there.