### PR TITLE
add a 'post opcode fetch' to spectrum expansion bus so that interface 1 enable / disable works correctly

### DIFF
--- a/src/devices/bus/spectrum/exp.cpp
+++ b/src/devices/bus/spectrum/exp.cpp
@@ -108,6 +108,16 @@ void spectrum_expansion_slot_device::opcode_fetch(offs_t offset)
 }
 
 //-------------------------------------------------
+// fetch_r
+//-------------------------------------------------
+
+void spectrum_expansion_slot_device::opcode_fetch_post(offs_t offset)
+{
+	if (m_card)
+		 m_card->opcode_fetch_post(offset);
+}
+
+//-------------------------------------------------
 //  iorq_r
 //-------------------------------------------------
 

--- a/src/devices/bus/spectrum/exp.h
+++ b/src/devices/bus/spectrum/exp.h
@@ -74,6 +74,7 @@ public:
 	auto nmi_handler() { return m_nmi_handler.bind(); }
 
 	void opcode_fetch(offs_t offset);
+	void opcode_fetch_post(offs_t offset);
 	uint8_t mreq_r(offs_t offset);
 	void mreq_w(offs_t offset, uint8_t data);
 	uint8_t iorq_r(offs_t offset);
@@ -107,6 +108,7 @@ public:
 
 	// reading and writing
 	virtual void opcode_fetch(offs_t offset) { };
+	virtual void opcode_fetch_post(offs_t offset) { };
 	virtual uint8_t mreq_r(offs_t offset) { return 0xff; }
 	virtual void mreq_w(offs_t offset, uint8_t data) { }
 	virtual uint8_t iorq_r(offs_t offset) { return 0xff; }

--- a/src/devices/bus/spectrum/intf1.cpp
+++ b/src/devices/bus/spectrum/intf1.cpp
@@ -106,6 +106,9 @@ READ_LINE_MEMBER(spectrum_intf1_device::romcs)
 	return m_romcs | m_exp->romcs();
 }
 
+// the Interface 1 looks for specific bus conditions to enable / disable the expansion overlay ROM
+
+// the enable must occur BEFORE the opcode is fetched, as the opcode must be fetched from the expansion ROM
 void spectrum_intf1_device::opcode_fetch(offs_t offset)
 {
 	m_exp->opcode_fetch(offset);
@@ -117,12 +120,26 @@ void spectrum_intf1_device::opcode_fetch(offs_t offset)
 		case 0x0008: case 0x1708:
 			m_romcs = 1;
 			break;
+		}
+	}
+}
+
+// the disable must occur AFTER the opcode fetch, or the incorrect opcode is fetched for 0x0700
+void spectrum_intf1_device::opcode_fetch_post(offs_t offset)
+{
+	m_exp->opcode_fetch_post(offset);
+
+	if (!machine().side_effects_disabled())
+	{
+		switch (offset)
+		{
 		case 0x0700:
 			m_romcs = 0;
 			break;
 		}
 	}
 }
+
 
 uint8_t spectrum_intf1_device::mreq_r(offs_t offset)
 {

--- a/src/devices/bus/spectrum/intf1.h
+++ b/src/devices/bus/spectrum/intf1.h
@@ -37,6 +37,7 @@ protected:
 	virtual const tiny_rom_entry *device_rom_region() const override;
 
 	virtual void opcode_fetch(offs_t offset) override;
+	virtual void opcode_fetch_post(offs_t offset) override;
 	virtual uint8_t mreq_r(offs_t offset) override;
 	virtual void mreq_w(offs_t offset, uint8_t data) override;
 	virtual uint8_t iorq_r(offs_t offset) override;

--- a/src/mame/drivers/spec128.cpp
+++ b/src/mame/drivers/spec128.cpp
@@ -169,7 +169,16 @@ READ8_MEMBER(spectrum_state::spectrum_128_opcode_fetch_r)
 {
 	/* this allows expansion devices to act upon opcode fetches from MEM addresses */
 	if (BIT(m_port_7ffd_data, 4))
+	{
+		/* this allows expansion devices to act upon opcode fetches from MEM addresses
+		   for example, interface1 detection fetches requires fetches at 0008 / 0708 to
+		   enable paged ROM and then fetches at 0700 to disable it
+		*/
 		m_exp->opcode_fetch(offset);
+		uint8_t retval = m_maincpu->space(AS_PROGRAM).read_byte(offset);
+		m_exp->opcode_fetch_post(offset);
+		return retval;
+	}
 
 	return m_maincpu->space(AS_PROGRAM).read_byte(offset);
 }

--- a/src/mame/drivers/spectrum.cpp
+++ b/src/mame/drivers/spectrum.cpp
@@ -293,10 +293,14 @@ SamRam
 
 READ8_MEMBER(spectrum_state::opcode_fetch_r)
 {
-	/* this allows expansion devices to act upon opcode fetches from MEM addresses */
+	/* this allows expansion devices to act upon opcode fetches from MEM addresses
+	   for example, interface1 detection fetches requires fetches at 0008 / 0708 to
+	   enable paged ROM and then fetches at 0700 to disable it
+	*/
 	m_exp->opcode_fetch(offset);
-
-	return m_maincpu->space(AS_PROGRAM).read_byte(offset);
+	uint8_t retval = m_maincpu->space(AS_PROGRAM).read_byte(offset);
+	m_exp->opcode_fetch_post(offset);
+	return retval;
 }
 
 WRITE8_MEMBER(spectrum_state::spectrum_rom_w)


### PR DESCRIPTION
this mimics behaviour found in other emulators, stops nonsense commands from triggering nonsense save operations with interface1 installed which was caused by the rom banking out too early.