### PR TITLE
m72.cpp: Re-redumped the GAL of "lohtb" [parramon]

### DIFF
--- a/src/mame/drivers/m72.cpp
+++ b/src/mame/drivers/m72.cpp
@@ -3010,7 +3010,7 @@ ROM_START( lohtb )
 	ROM_REGION( 0x10000, "samples", ROMREGION_ERASEFF ) /* -- no sample roms on bootleg, included with z80 code */
 
 	ROM_REGION( 0x0117, "plds", 0 )
-	ROM_LOAD( "gal16v8-25qp.ic3", 0x0000, 0x0117, CRC(12d20edf) SHA1(30eb2d0e58661fc16ff22c65cba3694f73220ae8) )
+	ROM_LOAD( "gal16v8-25qp.ic3", 0x0000, 0x0117, CRC(6acdfafb) SHA1(2ffd6f5a846e49fd2a8c7c7dfc9cf015406a44df) )
 ROM_END
 
 ROM_START( lohtb2 )


### PR DESCRIPTION
The last dump we did didn't work on the real hardware, so we've dumped it again with different equipment and this new dump works fine on the real PCB