### PR TITLE
Follow up to previous listxml_refactor PR (nw)

### DIFF
--- a/src/frontend/mame/info.h
+++ b/src/frontend/mame/info.h
@@ -31,19 +31,12 @@ class driver_enumerator;
 class info_xml_creator
 {
 public:
-	enum class devices_disposition
-	{
-		NONE,
-		FILTERED,
-		ALL
-	};
-
 	// construction/destruction
 	info_xml_creator(emu_options const &options, bool dtd = true);
 
 	// output
 	void output(FILE *out, const std::vector<std::string> &patterns);
-	void output(FILE *out, const std::function<bool(const char *shortname, bool &done)> &filter, devices_disposition devdisp);
+	void output(FILE *out, const std::function<bool(const char *shortname, bool &done)> &filter = { }, bool include_devices = true);
 
 private:
 	typedef std::unordered_set<std::add_pointer_t<device_type> > device_type_set;

--- a/src/frontend/mame/ui/miscmenu.cpp
+++ b/src/frontend/mame/ui/miscmenu.cpp
@@ -602,13 +602,11 @@ void menu_export::handle()
 					};
 
 					// do we want to show devices?
-					info_xml_creator::devices_disposition devdisp = (uintptr_t(menu_event->itemref) == 1)
-						? info_xml_creator::devices_disposition::FILTERED
-						: info_xml_creator::devices_disposition::NONE;
+					bool include_devices = uintptr_t(menu_event->itemref) == 1;
 
 					// and do the dirty work
 					info_xml_creator creator(machine().options());
-					creator.output(pfile, filter, devdisp);
+					creator.output(pfile, filter, include_devices);
 					fclose(pfile);
 					machine().popmessage(_("%s.xml saved under ui folder."), filename.c_str());
 				}


### PR DESCRIPTION
Specifically, this simplifies that change by collapsing the newly introduced enum info_xml_creator::devices_disposition into a bool, more resembling what was there before.

It occurred to me that having a tristate was unnecessary, because the need for filtering could be expressed by a null std::function for the filter