### PR TITLE
Changed mechanisms for overriding the mandatory file manager

### DIFF
--- a/src/emu/emuopts.cpp
+++ b/src/emu/emuopts.cpp
@@ -193,7 +193,6 @@ const options_entry emu_options::s_option_entries[] =
 	{ OPTION_BIOS,                                       nullptr,     OPTION_STRING,     "select the system BIOS to use" },
 	{ OPTION_CHEAT ";c",                                 "0",         OPTION_BOOLEAN,    "enable cheat subsystem" },
 	{ OPTION_SKIP_GAMEINFO,                              "0",         OPTION_BOOLEAN,    "skip displaying the system information screen at startup" },
-	{ OPTION_SKIP_MANDATORY_FILEMAN,                     "0",         OPTION_BOOLEAN,    "skip prompting the user for any mandatory images with the file manager at startup" },
 	{ OPTION_UI_FONT,                                    "default",   OPTION_STRING,     "specify a font to use" },
 	{ OPTION_UI,                                         "cabinet",   OPTION_STRING,     "type of UI (simple|cabinet)" },
 	{ OPTION_RAMSIZE ";ram",                             nullptr,     OPTION_STRING,     "size of RAM (if supported by driver)" },

--- a/src/emu/emuopts.h
+++ b/src/emu/emuopts.h
@@ -162,7 +162,6 @@
 #define OPTION_BIOS                 "bios"
 #define OPTION_CHEAT                "cheat"
 #define OPTION_SKIP_GAMEINFO        "skip_gameinfo"
-#define OPTION_SKIP_MANDATORY_FILEMAN   "skip_mandatory_fileman"
 #define OPTION_UI_FONT              "uifont"
 #define OPTION_UI                   "ui"
 #define OPTION_RAMSIZE              "ramsize"
@@ -438,7 +437,6 @@ public:
 	const char *bios() const { return value(OPTION_BIOS); }
 	bool cheat() const { return bool_value(OPTION_CHEAT); }
 	bool skip_gameinfo() const { return bool_value(OPTION_SKIP_GAMEINFO); }
-	bool skip_mandatory_fileman() const { return bool_value(OPTION_SKIP_MANDATORY_FILEMAN); }
 	const char *ui_font() const { return value(OPTION_UI_FONT); }
 	ui_option ui() const { return m_ui; }
 	const char *ram_size() const { return value(OPTION_RAMSIZE); }

--- a/src/frontend/mame/luaengine.h
+++ b/src/frontend/mame/luaengine.h
@@ -50,6 +50,7 @@ public:
 	void attach_notifiers();
 	void on_frame_done();
 	void on_periodic();
+	bool on_missing_mandatory_image(const std::string &instance_name);
 
 	template<typename T, typename U>
 	bool call_plugin(const std::string &name, const T in, U &out)
@@ -126,6 +127,7 @@ private:
 
 	void resume(void *ptr, int nparam);
 	void register_function(sol::function func, const char *id);
+	int enumerate_functions(const char *id, std::function<bool(const sol::protected_function &func)> &&callback);
 	bool execute_function(const char *id);
 	sol::object call_plugin(const std::string &name, sol::object in);
 

--- a/src/frontend/mame/mame.h
+++ b/src/frontend/mame/mame.h
@@ -50,6 +50,8 @@ public:
 
 	virtual void ui_initialize(running_machine& machine) override;
 
+	std::vector<std::reference_wrapper<const std::string>> missing_mandatory_images();
+
 	/* execute as configured by the OPTION_SYSTEMNAME option on the specified options */
 	int execute();
 	void start_luaengine();

--- a/src/frontend/mame/ui/info.cpp
+++ b/src/frontend/mame/ui/info.cpp
@@ -408,35 +408,6 @@ std::string machine_info::game_info_string() const
 
 
 //-------------------------------------------------
-//  mandatory_images - search for devices which
-//  need an image to be loaded
-//-------------------------------------------------
-
-std::string machine_info::mandatory_images() const
-{
-	std::ostringstream buf;
-	bool is_first = true;
-
-	// make sure that any required image has a mounted file
-	for (device_image_interface &image : image_interface_iterator(m_machine.root_device()))
-	{
-		if (image.must_be_loaded())
-		{
-			if (m_machine.options().image_option(image.instance_name()).value().empty())
-			{
-				if (is_first)
-					is_first = false;
-				else
-					buf << ", ";
-				buf << "\"" << image.instance_name() << "\"";
-			}
-		}
-	}
-	return buf.str();
-}
-
-
-//-------------------------------------------------
 //  get_screen_desc - returns the description for
 //  a given screen
 //-------------------------------------------------

--- a/src/frontend/mame/ui/info.h
+++ b/src/frontend/mame/ui/info.h
@@ -76,7 +76,6 @@ public:
 	// text generators
 	std::string warnings_string() const;
 	std::string game_info_string() const;
-	std::string mandatory_images() const;
 	std::string get_screen_desc(screen_device &screen) const;
 
 private:

--- a/src/frontend/mame/ui/ui.cpp
+++ b/src/frontend/mame/ui/ui.cpp
@@ -274,6 +274,26 @@ void mame_ui_manager::set_handler(ui_callback_type callback_type, const std::fun
 
 
 //-------------------------------------------------
+//  output_joined_collection
+//-------------------------------------------------
+
+template<typename TColl, typename TEmitMemberFunc, typename TEmitDelimFunc>
+static void output_joined_collection(const TColl &collection, TEmitMemberFunc emit_member, TEmitDelimFunc emit_delim)
+{
+	bool is_first = true;
+
+	for (const auto &member : collection)
+	{
+		if (is_first)
+			is_first = false;
+		else
+			emit_delim();
+		emit_member(member);
+	}
+}
+
+
+//-------------------------------------------------
 //  display_startup_screens - display the
 //  various startup screens
 //-------------------------------------------------
@@ -283,13 +303,13 @@ void mame_ui_manager::display_startup_screens(bool first_time)
 	const int maxstate = 3;
 	int str = machine().options().seconds_to_run();
 	bool show_gameinfo = !machine().options().skip_gameinfo();
-	bool show_warnings = true, show_mandatory_fileman = !machine().options().skip_mandatory_fileman();
+	bool show_warnings = true;
 	bool video_none = strcmp(downcast<osd_options &>(machine().options()).video(), "none") == 0;
 
 	// disable everything if we are using -str for 300 or fewer seconds, or if we're the empty driver,
 	// or if we are debugging, or if there's no mame window to send inputs to
 	if (!first_time || (str > 0 && str < 60*5) || &machine().system() == &GAME_NAME(___empty) || (machine().debug_flags & DEBUG_FLAG_ENABLED) != 0 || video_none)
-		show_gameinfo = show_warnings = show_mandatory_fileman = false;
+		show_gameinfo = show_warnings = false;
 
 #if defined(EMSCRIPTEN)
 	// also disable for the JavaScript port since the startup screens do not run asynchronously
@@ -326,12 +346,17 @@ void mame_ui_manager::display_startup_screens(bool first_time)
 			break;
 
 		case 2:
-			if (show_mandatory_fileman)
-				messagebox_text = machine_info().mandatory_images();
-			if (!messagebox_text.empty())
+			std::vector<std::reference_wrapper<const std::string>> mandatory_images = mame_machine_manager::instance()->missing_mandatory_images();
+			if (!mandatory_images.empty())
 			{
-				std::string warning = std::string(_("This driver requires images to be loaded in the following device(s): ")) + messagebox_text;
-				ui::menu_file_manager::force_file_manager(*this, machine().render().ui_container(), warning.c_str());
+				std::ostringstream warning;
+				warning << _("This driver requires images to be loaded in the following device(s): ");
+
+				output_joined_collection(mandatory_images,
+					[&warning](const std::reference_wrapper<const std::string> &img)	{ warning << "\"" << img.get() << "\""; },
+					[&warning]()														{ warning << ","; });
+
+				ui::menu_file_manager::force_file_manager(*this, machine().render().ui_container(), warning.str().c_str());
 			}
 			break;
 		}


### PR DESCRIPTION
- Removed the -skip_mandatory_fileman command line option

- Created an emu.register_mandatory_file_manager_override() LUA functionto allow LUA plugins to substitute the mandatory file manager