### PR TITLE
Changes to LUA emu.register_prestart() and emu.register_start()

### DIFF
--- a/src/emu/machine.cpp
+++ b/src/emu/machine.cpp
@@ -329,6 +329,10 @@ int running_machine::run(bool quiet)
 		// display the startup screens
 		manager().ui_initialize(*this);
 
+		// invoke prestart and start callbacks
+		call_notifiers(MACHINE_NOTIFY_PRESTART);
+		call_notifiers(MACHINE_NOTIFY_START);
+
 		// perform a soft reset -- this takes us to the running phase
 		soft_reset();
 
@@ -767,15 +771,12 @@ void running_machine::toggle_pause()
 //  given type
 //-------------------------------------------------
 
-void running_machine::add_notifier(machine_notification event, machine_notify_delegate callback, bool first)
+void running_machine::add_notifier(machine_notification event, machine_notify_delegate callback)
 {
 	assert_always(m_current_phase == machine_phase::INIT, "Can only call add_notifier at init time!");
 
-	if(first)
-		m_notifier_list[event].push_front(std::make_unique<notifier_callback_item>(callback));
-
 	// exit notifiers are added to the head, and executed in reverse order
-	else if (event == MACHINE_NOTIFY_EXIT)
+	if (event == MACHINE_NOTIFY_EXIT)
 		m_notifier_list[event].push_front(std::make_unique<notifier_callback_item>(callback));
 
 	// all other notifiers are added to the tail, and executed in the order registered

--- a/src/emu/machine.h
+++ b/src/emu/machine.h
@@ -40,6 +40,8 @@ enum class machine_phase
 enum machine_notification
 {
 	MACHINE_NOTIFY_FRAME,
+	MACHINE_NOTIFY_PRESTART,
+	MACHINE_NOTIFY_START,
 	MACHINE_NOTIFY_RESET,
 	MACHINE_NOTIFY_PAUSE,
 	MACHINE_NOTIFY_RESUME,
@@ -218,7 +220,7 @@ public:
 	void pause();
 	void resume();
 	void toggle_pause();
-	void add_notifier(machine_notification event, machine_notify_delegate callback, bool first = false);
+	void add_notifier(machine_notification event, machine_notify_delegate callback);
 	void call_notifiers(machine_notification which);
 	void add_logerror_callback(logerror_callback callback);
 	void set_ui_active(bool active) { m_ui_active = active; }

--- a/src/frontend/mame/luaengine.cpp
+++ b/src/frontend/mame/luaengine.cpp
@@ -712,6 +712,11 @@ void lua_engine::on_machine_start()
 	execute_function("LUA_ON_START");
 }
 
+void lua_engine::on_machine_reset()
+{
+	execute_function("LUA_ON_RESET");
+}
+
 void lua_engine::on_machine_stop()
 {
 	execute_function("LUA_ON_STOP");
@@ -765,8 +770,9 @@ bool lua_engine::on_missing_mandatory_image(const std::string &instance_name)
 
 void lua_engine::attach_notifiers()
 {
-	machine().add_notifier(MACHINE_NOTIFY_RESET, machine_notify_delegate(&lua_engine::on_machine_prestart, this), true);
-	machine().add_notifier(MACHINE_NOTIFY_RESET, machine_notify_delegate(&lua_engine::on_machine_start, this));
+	machine().add_notifier(MACHINE_NOTIFY_PRESTART, machine_notify_delegate(&lua_engine::on_machine_prestart, this));
+	machine().add_notifier(MACHINE_NOTIFY_START, machine_notify_delegate(&lua_engine::on_machine_start, this));
+	machine().add_notifier(MACHINE_NOTIFY_RESET, machine_notify_delegate(&lua_engine::on_machine_reset, this));
 	machine().add_notifier(MACHINE_NOTIFY_EXIT, machine_notify_delegate(&lua_engine::on_machine_stop, this));
 	machine().add_notifier(MACHINE_NOTIFY_PAUSE, machine_notify_delegate(&lua_engine::on_machine_pause, this));
 	machine().add_notifier(MACHINE_NOTIFY_RESUME, machine_notify_delegate(&lua_engine::on_machine_resume, this));
@@ -799,8 +805,9 @@ void lua_engine::initialize()
  * emu.wait(len) - wait for len within coroutine
  * emu.lang_translate(str) - get translation for str if available
  *
- * emu.register_prestart(callback) - register callback before reset
- * emu.register_start(callback) - register callback after reset
+ * emu.register_prestart(callback) - register callback before start
+ * emu.register_start(callback) - register callback after start
+ * emu.register_reset(callback) - register callback after reset
  * emu.register_stop(callback) - register callback after stopping
  * emu.register_pause(callback) - register callback at pause
  * emu.register_resume(callback) - register callback at resume
@@ -843,6 +850,7 @@ void lua_engine::initialize()
 		};
 	emu["register_prestart"] = [this](sol::function func){ register_function(func, "LUA_ON_PRESTART"); };
 	emu["register_start"] = [this](sol::function func){ register_function(func, "LUA_ON_START"); };
+	emu["register_reset"] = [this](sol::function func) { register_function(func, "LUA_ON_RESET"); };
 	emu["register_stop"] = [this](sol::function func){ register_function(func, "LUA_ON_STOP"); };
 	emu["register_pause"] = [this](sol::function func){ register_function(func, "LUA_ON_PAUSE"); };
 	emu["register_resume"] = [this](sol::function func){ register_function(func, "LUA_ON_RESUME"); };

--- a/src/frontend/mame/luaengine.h
+++ b/src/frontend/mame/luaengine.h
@@ -120,6 +120,7 @@ private:
 
 	void on_machine_prestart();
 	void on_machine_start();
+	void on_machine_reset();
 	void on_machine_stop();
 	void on_machine_pause();
 	void on_machine_resume();


### PR DESCRIPTION
Specifically:
  1.  emu.register_prestart() and emu.register_start() were registering
      handlers for reset, not for start.  This changes these callbacks
      to happen on start.

      It should be noted that for LUA plugins, having a start handler is
      important because many objects like machine and ui are not
      properly set up when the plugin is invoked.

  2.  Created emu.register_reset() to have a bonafide reset handler

In my opinion, this should go further and we should get rid of
emu.register_prestart().  I'm uncomfortable making this change
unilaterally because it would be a breaking change

I want a LUA plugin expert to review these changes and my analysis