### PR TITLE
Correct DEC0 sound cpu type

### DIFF
--- a/src/mame/drivers/dec0.cpp
+++ b/src/mame/drivers/dec0.cpp
@@ -337,6 +337,7 @@ Notes:
 #include "includes/dec0.h"
 
 #include "cpu/m68000/m68000.h"
+#include "cpu/m6502/m65c02.h"
 #include "cpu/m6502/m6502.h"
 #include "cpu/z80/z80.h"
 #include "cpu/m6805/m68705.h"
@@ -1777,7 +1778,7 @@ void dec0_state::dec0(machine_config &config)
 	m_maincpu->set_addrmap(AS_PROGRAM, &dec0_state::dec0_map);
 	m_maincpu->set_vblank_int("screen", FUNC(dec0_state::irq6_line_assert)); /* VBL */
 
-	M6502(config, m_audiocpu, XTAL(12'000'000) / 8);
+	M65C02(config, m_audiocpu, XTAL(12'000'000) / 8);
 	m_audiocpu->set_addrmap(AS_PROGRAM, &dec0_state::dec0_s_map);
 
 	/* video hardware */


### PR DESCRIPTION
Found out that all DEC0 games uses a RICOH 65C02 CPU for audio. Also MAME's dec0 driver listed a RP65C02
in the PCB info. The bootlegs uses a normal M6502.

Some examples:

"Bad Dudes vs. Dragonninja"
https://www.picclickimg.com/00/s/MTIwMFgxNjAw/z/fVoAAOSwyNtdRpmA/$/Data-East-Bad-Dudes-VS-Dragon-Ninja-Jamma-_57.jpg

"Birdie Try" 
ebay: https://www.ebay.com/itm/333294281101 + PCB = https://i.ebayimg.com/images/g/34IAAOSwlyxdUF4X/s-l1600.jpg

"Hippodrome / Fighting Fantasy"
https://www.picclickimg.com/00/s/OTA0WDE2MDA=/z/CBwAAOSw-itXq1Or/$/HIPPODROME-1989-Data-East-Guaranteed-Working-_57.jpg
http://www.wolfgangrobel.de/arcadetalk/img_pcbs/fightingfantasy1.jpg

"Heavy Barrel"
https://wiki.arcadeotaku.com/w/Heavy_Barrel_Repair_Logs