### PR TITLE
toplevel makefile: fix 'cleansrc' target for Unix/Linux

### DIFF
--- a/makefile
+++ b/makefile
@@ -1685,13 +1685,13 @@ ifeq ($(OS),windows)
 	$(shell for /r src %%i in (*.hxx) do srcclean %%i >&2 )
 	$(shell for /r hash %%i in (*.xml) do srcclean %%i >&2 )
 else
-	$(shell find src/ -name *.c -exec ./srcclean {} >&2 ;)
-	$(shell find src/ -name *.h -exec ./srcclean {}  >&2 ;)
-	$(shell find src/ -name *.mak -exec ./srcclean {} >&2 ;)
-	$(shell find src/ -name *.lst -exec ./srcclean {} >&2 ;)
-	$(shell find src/ -name *.lay -exec ./srcclean {} >&2 ;)
-	$(shell find src/ -name *.hxx -exec ./srcclean {} >&2 ;)
-	$(shell find hash/ -name *.xml -exec ./srcclean {} >&2 ;)
+	@find src/ -name \*.c -exec ./srcclean {} \; >&2
+	@find src/ -name \*.h -exec ./srcclean {} \; >&2
+	@find src/ -name \*.mak -exec ./srcclean {} \; >&2
+	@find src/ -name \*.lst -exec ./srcclean {} \; >&2
+	@find src/ -name \*.lay -exec ./srcclean {} \; >&2
+	@find src/ -name \*.hxx -exec ./srcclean {} \; >&2
+	@find hash/ -name \*.xml -exec ./srcclean {} \; >&2
 endif
 
 #-------------------------------------------------


### PR DESCRIPTION
This fixes the 'cleansrc' operation on Unix/Linux.

With current version I'm getting this when running "`make cleansrc`":

```
$ make cleansrc
GCC 8 detected
Cleaning up tabs/spaces/end of lines....
Cleaned up src/devices/video/virge_pci.h:
7 line(s) with trailing whitespace trimmed
3 tab(s) expanded to spaces
Cleaned up src/devices/bus/isa/s3virge.h:
4 line(s) with trailing whitespace trimmed
Cleaned up src/devices/imagedev/wafadrive.h:
1 tab(s) expanded to spaces
Cleaned up src/mame/machine/pce_cd.h:
2 line(s) with trailing whitespace trimmed
2 tab(s) created from spaces
11 space(s) combined into tabs
Cleaned up src/mame/includes/pc9801.h:
1 line(s) with trailing whitespace trimmed
Cleaned up src/osd/windows/window.h:
10 tab(s) expanded to spaces
Cleaned up src/mame/layout/saitek_risc2500.lay:
3 line(s) with trailing whitespace trimmed
Cleaned up src/mame/machine/seibucop/seibucop_cmd.hxx:
1 line(s) with trailing whitespace trimmed
Cleaned up hash/spectrum_cass.xml:
282 line(s) with trailing whitespace trimmed
2 tab(s) expanded to spaces
Cleaned up hash/spectrum_wafadrive.xml:
1 line(s) with trailing whitespace trimmed
2 tab(s) expanded to spaces
Cleaned up hash/spectrum_betadisc_flop.xml:
27 line(s) with trailing whitespace trimmed
3 tab(s) expanded to spaces
Cleaned up hash/vsmile_cart.xml:
2 tab(s) created from spaces
8 space(s) combined into tabs
Cleaned up hash/specpls3_flop.xml:
1 line(s) with trailing whitespace trimmed
Cleaned up hash/spectrum_microdrive.xml:
1 line(s) with trailing whitespace trimmed
2 tab(s) expanded to spaces
Cleaned up hash/pentagon_cass.xml:
1 line(s) with trailing whitespace trimmed
$
```