### PR TITLE
Enable precompiled header usage in the Visual Studio compiler

### DIFF
--- a/scripts/genie.lua
+++ b/scripts/genie.lua
@@ -80,7 +80,7 @@ end
 function precompiledheaders_novs()
 	precompiledheaders()
 	if string.sub(_ACTION,1,4) == "vs20" then
-		print("Disabling pch for Visual Studio")
+		--print("Disabling pch for Visual Studio")
 		flags {
 			"NoPCH"
 		}

--- a/scripts/genie.lua
+++ b/scripts/genie.lua
@@ -77,6 +77,16 @@ function precompiledheaders()
 	end
 end
 
+function precompiledheaders_novs()
+	precompiledheaders()
+	if string.sub(_ACTION,1,4) == "vs20" then
+		print("Disabling pch for Visual Studio")
+		flags {
+			"NoPCH"
+		}
+	end
+end
+
 function addprojectflags()
 	local version = str_to_version(_OPTIONS["gcc_version"])
 	if _OPTIONS["gcc"]~=nil and string.find(_OPTIONS["gcc"], "gcc") then
@@ -486,7 +496,6 @@ configuration { "vs20*" }
 		"/bigobj",
 	}
 	flags {
-		"NoPCH",
 		"ExtraWarnings",
 	}
 	if not _OPTIONS["NOWERROR"] then

--- a/scripts/src/devices.lua
+++ b/scripts/src/devices.lua
@@ -54,6 +54,8 @@ function devicesProject(_target, _subtarget)
 
 	dofile(path.join("src", "bus.lua"))
 
+	pchsource(MAME_DIR .. "src/devices/machine/timer.cpp")
+
 if #disasm_files > 0 then
 	project ("dasm")
 	uuid ("f2d28b0a-6da5-4f78-b629-d834aa00429d")
@@ -77,6 +79,14 @@ if #disasm_files > 0 then
 	files {
 		disasm_files
 	}
+
+	for key,value in pairs(disasm_files) do
+		if string.endswith(value, ".cpp") then
+			--print("calling pchsource with " .. value)
+			pchsource(value)
+			break
+		end
+	end
 
 	if #disasm_dependency > 0 then
 		dependency(disasm_dependency)

--- a/scripts/src/emu.lua
+++ b/scripts/src/emu.lua
@@ -259,6 +259,12 @@ files {
 	MAME_DIR .. "src/emu/video/rgbvmx.h",
 }
 
+pchsource(MAME_DIR .. "src/emu/main.cpp")
+-- 3 files do not inlcude emu.h
+nopch(MAME_DIR .. "src/emu/emualloc.cpp")
+nopch(MAME_DIR .. "src/emu/attotime.cpp")
+nopch(MAME_DIR .. "src/emu/debug/textbuf.cpp")
+
 dependency {
 	--------------------------------------------------
 	-- additional dependencies
@@ -306,6 +312,9 @@ includedirs {
 files {
 	MAME_DIR .. "src/emu/drivers/empty.cpp",
 }
+
+pchsource(MAME_DIR .. "src/emu/drivers/empty.cpp")
+
 dependency {
 	{ "$(OBJDIR)/src/emu/drivers/empty.o", "$(GCH)", true  },
 }

--- a/scripts/src/mame/frontend.lua
+++ b/scripts/src/mame/frontend.lua
@@ -166,3 +166,5 @@ files {
 	MAME_DIR .. "src/frontend/mame/ui/widgets.cpp",
 	MAME_DIR .. "src/frontend/mame/ui/widgets.h",
 }
+
+pchsource(MAME_DIR .. "src/frontend/mame/audit.cpp")

--- a/scripts/target/mame/arcade.lua
+++ b/scripts/target/mame/arcade.lua
@@ -913,7 +913,7 @@ function createMAMEProjects(_target, _subtarget, _name)
 	kind (LIBTYPE)
 	uuid (os.uuid("drv-" .. _target .."_" .. _subtarget .. "_" .._name))
 	addprojectflags()
-	precompiledheaders()
+	precompiledheaders_novs()
 
 	includedirs {
 		MAME_DIR .. "src/osd",

--- a/scripts/target/mame/dummy.lua
+++ b/scripts/target/mame/dummy.lua
@@ -18,7 +18,7 @@ function createProjects_mame_dummy(_target, _subtarget)
 	kind (LIBTYPE)
 	uuid (os.uuid("drv-mame_dummy"))
 	addprojectflags()
-	precompiledheaders()
+	precompiledheaders_novs()
 
 	includedirs {
 		MAME_DIR .. "src/osd",

--- a/scripts/target/mame/mess.lua
+++ b/scripts/target/mame/mess.lua
@@ -1288,7 +1288,7 @@ function createMESSProjects(_target, _subtarget, _name)
 	kind (LIBTYPE)
 	uuid (os.uuid("drv-" .. _target .."_" .. _subtarget .. "_" .._name))
 	addprojectflags()
-	precompiledheaders()
+	precompiledheaders_novs()
 
 	includedirs {
 		MAME_DIR .. "src/osd",

--- a/scripts/target/mame/nl.lua
+++ b/scripts/target/mame/nl.lua
@@ -108,7 +108,7 @@ function createProjects_mame_nl(_target, _subtarget)
 	kind (LIBTYPE)
 	uuid (os.uuid("drv-mame-nl"))
 	addprojectflags()
-	precompiledheaders()
+	precompiledheaders_novs()
 
 	includedirs {
 		MAME_DIR .. "src/osd",

--- a/scripts/target/mame/tiny.lua
+++ b/scripts/target/mame/tiny.lua
@@ -93,7 +93,7 @@ function createProjects_mame_tiny(_target, _subtarget)
 	kind (LIBTYPE)
 	uuid (os.uuid("drv-mame-tiny"))
 	addprojectflags()
-	precompiledheaders()
+	precompiledheaders_novs()
 
 	includedirs {
 		MAME_DIR .. "src/osd",

--- a/scripts/target/mame/virtual.lua
+++ b/scripts/target/mame/virtual.lua
@@ -101,7 +101,7 @@ function createVirtualProjects(_target, _subtarget, _name)
 	kind (LIBTYPE)
 	uuid (os.uuid("drv-" .. _target .."_" .. _subtarget .. "_" .._name))
 	addprojectflags()
-	precompiledheaders()
+	precompiledheaders_novs()
 
 	includedirs {
 		MAME_DIR .. "src/osd",

--- a/src/devices/cpu/bcp/bcpdasm.cpp
+++ b/src/devices/cpu/bcp/bcpdasm.cpp
@@ -6,6 +6,7 @@
 
 ***************************************************************************/
 
+#include "emu.h"
 #include "util/disasmintf.h"
 #include "bcpdasm.h"
 

--- a/src/devices/cpu/cr16b/cr16bdasm.cpp
+++ b/src/devices/cpu/cr16b/cr16bdasm.cpp
@@ -19,6 +19,7 @@
 
 ***************************************************************************/
 
+#include "emu.h"
 #include "util/disasmintf.h"
 #include "cr16bdasm.h"
 

--- a/src/devices/cpu/f2mc16/f2mc16dasm.cpp
+++ b/src/devices/cpu/f2mc16/f2mc16dasm.cpp
@@ -6,6 +6,7 @@
 
 ***************************************************************************/
 
+#include "emu.h"
 #include "util/disasmintf.h"
 #include "f2mc16dasm.h"
 

--- a/src/devices/cpu/hpc/hpcdasm.cpp
+++ b/src/devices/cpu/hpc/hpcdasm.cpp
@@ -10,6 +10,7 @@
 
 ***************************************************************************/
 
+#include "emu.h"
 #include "util/disasmintf.h"
 #include "hpcdasm.h"
 

--- a/src/devices/cpu/rii/riidasm.cpp
+++ b/src/devices/cpu/rii/riidasm.cpp
@@ -4,8 +4,10 @@
 
     ELAN Microelectronics RISC II (RII) Series disassembler
 
+
 ***************************************************************************/
 
+#include "emu.h"
 #include "util/disasmintf.h"
 #include "riidasm.h"
 


### PR DESCRIPTION
Precompiled headers are enabled only in the following library projects:
emu
frontend
precompile
dasm
optional
