### PR TITLE
Ensuring that devices emitted by -listxml are sorted

### DIFF
--- a/src/frontend/mame/info.cpp
+++ b/src/frontend/mame/info.cpp
@@ -1951,3 +1951,13 @@ const char *info_xml_creator::get_merge_name(driver_enumerator &drivlist, const 
 
 	return nullptr;
 }
+
+
+//-------------------------------------------------
+//  device_type_compare::operator()
+//-------------------------------------------------
+
+bool info_xml_creator::device_type_compare::operator()(const std::add_pointer_t<device_type> &lhs, const std::add_pointer_t<device_type> &rhs) const
+{
+	return strcmp(lhs->shortname(), rhs->shortname()) < 0;
+}

--- a/src/frontend/mame/info.h
+++ b/src/frontend/mame/info.h
@@ -39,7 +39,13 @@ public:
 	void output(std::ostream &out, const std::function<bool(const char *shortname, bool &done)> &filter = { }, bool include_devices = true);
 
 private:
-	typedef std::unordered_set<std::add_pointer_t<device_type> > device_type_set;
+	class device_type_compare
+	{
+	public:
+		bool operator()(const std::add_pointer_t<device_type> &lhs, const std::add_pointer_t<device_type> &rhs) const;
+	};
+
+	typedef std::set<std::add_pointer_t<device_type>, device_type_compare> device_type_set;
 
 	// internal helper
 	void output_header(std::ostream &out);


### PR DESCRIPTION
This is primarily to make the output be deterministic.