### PR TITLE
 Correct device description

### DIFF
--- a/src/mame/arcade.flt
+++ b/src/mame/arcade.flt
@@ -1122,6 +1122,7 @@ slotcarn.cpp
 smsmcorp.cpp
 sms_bootleg.cpp
 snesb.cpp
+snesb51.cpp
 snk.cpp
 snk6502.cpp
 snk68.cpp

--- a/src/mame/machine/deco_irq.cpp
+++ b/src/mame/machine/deco_irq.cpp
@@ -29,7 +29,7 @@
 //  DEVICE DEFINITIONS
 //**************************************************************************
 
-DEFINE_DEVICE_TYPE(DECO_IRQ, deco_irq_device, "deco_irq", "Data East IRQ Controller")
+DEFINE_DEVICE_TYPE(DECO_IRQ, deco_irq_device, "deco_irq", "DECO IRQ Controller")
 
 
 //**************************************************************************

--- a/src/mame/video/deco_ace.cpp
+++ b/src/mame/video/deco_ace.cpp
@@ -59,7 +59,7 @@
 #include <algorithm>
 
 
-DEFINE_DEVICE_TYPE(DECO_ACE, deco_ace_device, "deco_ace", "Data East 99 'ACE' Chip")
+DEFINE_DEVICE_TYPE(DECO_ACE, deco_ace_device, "deco_ace", "DECO 99 'ACE' Chip")
 
 deco_ace_device::deco_ace_device(const machine_config &mconfig, const char *tag, device_t *owner, uint32_t clock)
 	: device_t(mconfig, DECO_ACE, tag, owner, clock),


### PR DESCRIPTION
Changed Data East --> DECO like all other Data East devices in MAME:
DECO 104 Protection
DECO 146 Protection
DECO 52 Sprite
DECO 55 / 56 / 74 / 141 Tilemap Generator
DECO BAC06 Tilemap
DECO Cassette Tape
DECO Common Video Functions
DECO Karnov Sprites
DECO MXC06 Sprite
DECO RM-C3 PALETTE
DECO Zooming Sprites