### PR TITLE
Expose sound buffer and samplerate to luaengine

### DIFF
--- a/src/emu/sound.cpp
+++ b/src/emu/sound.cpp
@@ -844,6 +844,7 @@ sound_manager::sound_manager(running_machine &machine)
 		m_finalmix(machine.sample_rate()),
 		m_leftmix(machine.sample_rate()),
 		m_rightmix(machine.sample_rate()),
+		m_samples_this_update(0),
 		m_muted(0),
 		m_attenuation(0),
 		m_nosound_mode(machine.osd().no_sound()),
@@ -1089,16 +1090,16 @@ void sound_manager::update(void *ptr, int param)
 	g_profiler.start(PROFILER_SOUND);
 
 	// force all the speaker streams to generate the proper number of samples
-	int samples_this_update = 0;
+	m_samples_this_update = 0;
 	for (speaker_device &speaker : speaker_device_iterator(machine().root_device()))
-		speaker.mix(&m_leftmix[0], &m_rightmix[0], samples_this_update, (m_muted & MUTE_REASON_SYSTEM));
+		speaker.mix(&m_leftmix[0], &m_rightmix[0], m_samples_this_update, (m_muted & MUTE_REASON_SYSTEM));
 
 	// now downmix the final result
 	u32 finalmix_step = machine().video().speed_factor();
 	u32 finalmix_offset = 0;
 	s16 *finalmix = &m_finalmix[0];
 	int sample;
-	for (sample = m_finalmix_leftover; sample < samples_this_update * 1000; sample += finalmix_step)
+	for (sample = m_finalmix_leftover; sample < m_samples_this_update * 1000; sample += finalmix_step)
 	{
 		int sampindex = sample / 1000;
 
@@ -1118,7 +1119,7 @@ void sound_manager::update(void *ptr, int param)
 			samp = 32767;
 		finalmix[finalmix_offset++] = samp;
 	}
-	m_finalmix_leftover = sample - samples_this_update * 1000;
+	m_finalmix_leftover = sample - m_samples_this_update * 1000;
 
 	// play the result
 	if (finalmix_offset > 0)
@@ -1152,4 +1153,19 @@ void sound_manager::update(void *ptr, int param)
 		stream->apply_sample_rate_changes();
 
 	g_profiler.stop();
+}
+
+
+//-------------------------------------------------
+//  samples - fills the specified buffer with
+//  16-bit stereo audio samples generated during
+//  the current frame
+//-------------------------------------------------
+
+void sound_manager::samples(s16 *buffer)
+{
+	for (int sample = 0; sample < m_samples_this_update * 2; sample++)
+	{
+		*buffer++ = m_finalmix[sample];
+	}
 }

--- a/src/emu/sound.h
+++ b/src/emu/sound.h
@@ -198,6 +198,8 @@ public:
 	const std::vector<std::unique_ptr<sound_stream>> &streams() const { return m_stream_list; }
 	attotime last_update() const { return m_last_update; }
 	attoseconds_t update_attoseconds() const { return m_update_attoseconds; }
+	int sample_count() const { return m_samples_this_update; }
+	void samples(s16 *buffer);
 
 	// stream creation
 	sound_stream *stream_alloc(device_t &device, int inputs, int outputs, int sample_rate, stream_update_delegate callback = stream_update_delegate());
@@ -233,6 +235,7 @@ private:
 	std::vector<s16>    m_finalmix;
 	std::vector<s32>    m_leftmix;
 	std::vector<s32>    m_rightmix;
+	int                 m_samples_this_update;
 
 	u8                  m_muted;
 	int                 m_attenuation;

--- a/src/frontend/mame/luaengine.cpp
+++ b/src/frontend/mame/luaengine.cpp
@@ -2011,7 +2011,7 @@ void lua_engine::initialize()
 			"ui_mute", &sound_manager::ui_mute,
 			"debugger_mute", &sound_manager::debugger_mute,
 			"system_mute", &sound_manager::system_mute,
-			"samples", [this](sound_manager &sm, sol::this_state s) {
+			"samples", [](sound_manager &sm, sol::this_state s) {
 					lua_State *L = s;
 					luaL_Buffer buff;
 					s32 count = sm.sample_count() * 2 * 2; // 2 channels, 2 bytes per sample

--- a/src/frontend/mame/luaengine.cpp
+++ b/src/frontend/mame/luaengine.cpp
@@ -1253,6 +1253,7 @@ void lua_engine::initialize()
  *
  * machine:system() - get game_driver for running driver
  * machine:video() - get video_manager
+ * machine:sound() - get sound_manager
  * machine:render() - get render_manager
  * machine:ioport() - get ioport_manager
  * machine:parameters() - get parameter_manager
@@ -1264,6 +1265,7 @@ void lua_engine::initialize()
  * machine:debugger() - get debugger_manager
  *
  * machine.paused - get paused state
+ * machine.samplerate - get audio sample rate
  *
  * machine.devices[] - get device table (k=tag, v=device_t)
  * machine.screens[] - get screens table (k=tag, v=screen_device)
@@ -1293,6 +1295,7 @@ void lua_engine::initialize()
 					return sol::make_object(sol(), &m.debugger());
 				},
 			"paused", sol::property(&running_machine::paused),
+			"samplerate", sol::property(&running_machine::sample_rate),
 			"devices", sol::property([this](running_machine &m) {
 					std::function<void(device_t &, sol::table)> tree;
 					sol::table table = sol().create_table();
@@ -1995,15 +1998,28 @@ void lua_engine::initialize()
  * sound:stop_recording() - end audio recording
  * sound:ui_mute(turn_off) - turns on/off UI sound
  * sound:system_mute() - turns on/off system sound
- * sound:attenuation - sound attenuation
+ * sound:samples() - get current frame's audio buffer contents in binary form as string
+ *
+ * sound.attenuation - sound attenuation
  */
+
 	sol().registry().new_usertype<sound_manager>("sound", "new", sol::no_constructor,
 			"start_recording", &sound_manager::start_recording,
 			"stop_recording", &sound_manager::stop_recording,
 			"ui_mute", &sound_manager::ui_mute,
 			"debugger_mute", &sound_manager::debugger_mute,
 			"system_mute", &sound_manager::system_mute,
+			"samples", [this](sound_manager &sm, sol::this_state s) {
+					lua_State *L = s;
+					luaL_Buffer buff;
+					s32 count = sm.sample_count() * 2 * 2; // 2 channels, 2 bytes per sample
+					s16 *ptr = (s16 *)luaL_buffinitsize(L, &buff, count);
+					sm.samples(ptr);
+					luaL_pushresultsize(&buff, count);
+					return sol::make_reference(L, sol::stack_reference(L, -1));
+				},
 			"attenuation", sol::property(&sound_manager::attenuation, &sound_manager::set_attenuation));
+
 
 /*  input_manager library
  *

--- a/src/frontend/mame/luaengine.cpp
+++ b/src/frontend/mame/luaengine.cpp
@@ -1742,15 +1742,16 @@ void lua_engine::initialize()
 					return port_table;
 				}));
 
-/*  natkeyboard library
+/*  natural_keyboard library
  *
  * manager:machine():ioport():natkeyboard()
  *
- * natkeyboard.empty - is the natural keyboard buffer empty?
- * natkeyboard.in_use - is the natural keyboard in use?
  * natkeyboard:paste() - paste clipboard data
  * natkeyboard:post() - post data to natural keyboard
  * natkeyboard:post_coded() - post data to natural keyboard
+ *
+ * natkeyboard.empty - is the natural keyboard buffer empty?
+ * natkeyboard.in_use - is the natural keyboard in use?
  */
 
 	sol().registry().new_usertype<natural_keyboard>("natkeyboard", "new", sol::no_constructor,
@@ -1759,6 +1760,7 @@ void lua_engine::initialize()
 			"paste", &natural_keyboard::paste,
 			"post", [](natural_keyboard &nat, const std::string &text)          { nat.post_utf8(text); },
 			"post_coded", [](natural_keyboard &nat, const std::string &text)    { nat.post_coded(text); });
+
 
 /*  ioport_port library
  *

--- a/src/frontend/mame/ui/ui.cpp
+++ b/src/frontend/mame/ui/ui.cpp
@@ -304,7 +304,7 @@ void mame_ui_manager::display_startup_screens(bool first_time)
 	int str = machine().options().seconds_to_run();
 	bool show_gameinfo = !machine().options().skip_gameinfo();
 	bool show_warnings = true, show_mandatory_fileman = true;
-	bool video_none = strcmp(downcast<osd_options &>(machine().options()).video(), "none") == 0;
+	bool video_none = strcmp(downcast<osd_options &>(machine().options()).video(), OSDOPTVAL_NONE) == 0;
 
 	// disable everything if we are using -str for 300 or fewer seconds, or if we're the empty driver,
 	// or if we are debugging, or if there's no mame window to send inputs to


### PR DESCRIPTION
```lua
manager:machine():sound():samples()
manager:machine().samplerate
```

Obtaining samples enables me to output it along with video buffer and even record a video externally. These videos show that I'm correctly grabbing the audio buffer:
https://www.youtube.com/watch?v=WQTMy-zdXqM
https://www.youtube.com/watch?v=IiNi8HvgIGA

I had to make `samples_this_update` a class member so that it persists until the next frame and can be exposed to other classes. There doesn't seem to be a way to know this information until mixing is done for a given frame. In my case luaengine needs it in order to know the size of the buffer it should allocate.

Couple instances of tiny cleanup is also included.