### PR TITLE
Miscellaneous LUA functionality

### DIFF
--- a/src/emu/machine.cpp
+++ b/src/emu/machine.cpp
@@ -308,6 +308,7 @@ int running_machine::run(bool quiet)
 		start();
 
 		// load the configuration settings
+		manager().before_load_settings(*this);
 		m_configuration->load_settings();
 
 		// disallow save state registrations starting here.

--- a/src/emu/main.h
+++ b/src/emu/main.h
@@ -85,6 +85,7 @@ public:
 	virtual void create_custom(running_machine& machine) { }
 	virtual void load_cheatfiles(running_machine& machine) { }
 	virtual void ui_initialize(running_machine& machine) { }
+	virtual void before_load_settings(running_machine &machine) { }
 
 	virtual void update_machine() { }
 

--- a/src/frontend/mame/luaengine.h
+++ b/src/frontend/mame/luaengine.h
@@ -51,6 +51,7 @@ public:
 	void on_frame_done();
 	void on_periodic();
 	bool on_missing_mandatory_image(const std::string &instance_name);
+	void on_machine_before_load_settings();
 
 	template<typename T, typename U>
 	bool call_plugin(const std::string &name, const T in, U &out)

--- a/src/frontend/mame/mame.cpp
+++ b/src/frontend/mame/mame.cpp
@@ -323,6 +323,11 @@ void mame_machine_manager::ui_initialize(running_machine& machine)
 	m_ui->display_startup_screens(m_firstrun);
 }
 
+void mame_machine_manager::before_load_settings(running_machine& machine)
+{
+	m_lua->on_machine_before_load_settings();
+}
+
 void mame_machine_manager::create_custom(running_machine& machine)
 {
 	// start the inifile manager

--- a/src/frontend/mame/mame.h
+++ b/src/frontend/mame/mame.h
@@ -50,6 +50,8 @@ public:
 
 	virtual void ui_initialize(running_machine& machine) override;
 
+	virtual void before_load_settings(running_machine& machine) override;
+
 	std::vector<std::reference_wrapper<const std::string>> missing_mandatory_images();
 
 	/* execute as configured by the OPTION_SYSTEMNAME option on the specified options */


### PR DESCRIPTION
  - Created emu.register_before_load_settings(), to allow LUA scripts to
    override default input port values before settings are loaded

  - New ioport_field methods/props ([set_]default_input_seq(), port)