### PR TITLE
Fix Solaris 2.11 (non-Oracle)

### DIFF
--- a/makefile
+++ b/makefile
@@ -983,9 +983,7 @@ GCC_VERSION      := $(shell $(TOOLCHAIN)$(subst @,,$(OVERRIDE_CC)) -dumpversion 
 else
 GCC_VERSION      := $(shell $(TOOLCHAIN)$(subst @,,$(CC)) -dumpversion 2> /dev/null)
 endif
-ifneq ($(OS),solaris)
 CLANG_VERSION    := $(shell $(TOOLCHAIN)$(subst @,,$(CC))  --version  2> /dev/null | head -n 1 | grep -e 'version [0-9]\+\.[0-9]\+\(\.[0-9]\+\)\?' -o | grep -e '[0-9]\+\.[0-9]\+\(\.[0-9]\+\)\?' -o | tail -n 1)
-endif
 PYTHON_AVAILABLE := $(shell $(PYTHON) --version > /dev/null 2>&1 && echo python)
 GIT_AVAILABLE := $(shell git --version > /dev/null 2>&1 && echo git)
 endif
@@ -1367,11 +1365,10 @@ xcode4-ios: generate
 #-------------------------------------------------
 # gmake-solaris
 #-------------------------------------------------
-
-
+ifndef CLANG_VERSION
 $(PROJECTDIR)/$(MAKETYPE)-solaris/Makefile: makefile $(SCRIPTS) $(GENIE)
 	$(SILENT) $(GENIE) $(PARAMS) $(TARGET_PARAMS) --gcc=solaris --gcc_version=$(GCC_VERSION) $(MAKETYPE)
-
+endif
 .PHONY: solaris_x64
 solaris_x64: generate $(PROJECTDIR)/$(MAKETYPE)-solaris/Makefile
 	$(SILENT) $(MAKE) -C $(PROJECTDIR)/$(MAKETYPE)-solaris config=$(CONFIG)64 precompile
@@ -1382,6 +1379,26 @@ solaris: solaris_x86
 
 .PHONY: solaris_x86
 solaris_x86: generate $(PROJECTDIR)/$(MAKETYPE)-solaris/Makefile
+	$(SILENT) $(MAKE) -C $(PROJECTDIR)/$(MAKETYPE)-solaris config=$(CONFIG)32 precompile
+	$(SILENT) $(MAKE) -C $(PROJECTDIR)/$(MAKETYPE)-solaris config=$(CONFIG)32
+
+#-------------------------------------------------
+# gmake-solaris-clang
+#-------------------------------------------------
+ifdef CLANG_VERSION
+$(PROJECTDIR)/$(MAKETYPE)-solaris/Makefile: makefile $(SCRIPTS) $(GENIE)
+	$(SILENT) $(GENIE) $(PARAMS) $(TARGET_PARAMS) --gcc=solaris --gcc_version=$(CLANG_VERSION) $(MAKETYPE)
+endif
+.PHONY: solaris_x64_clang
+solaris_x64_clang: generate $(PROJECTDIR)/$(MAKETYPE)-solaris/Makefile
+	$(SILENT) $(MAKE) -C $(PROJECTDIR)/$(MAKETYPE)-solaris config=$(CONFIG)64 precompile
+	$(SILENT) $(MAKE) -C $(PROJECTDIR)/$(MAKETYPE)-solaris config=$(CONFIG)64
+
+.PHONY: solaris_clang
+solaris_clang: solaris_x86_clang
+
+.PHONY: solaris_x86_clang
+solaris_x86_clang: generate $(PROJECTDIR)/$(MAKETYPE)-solaris/Makefile
 	$(SILENT) $(MAKE) -C $(PROJECTDIR)/$(MAKETYPE)-solaris config=$(CONFIG)32 precompile
 	$(SILENT) $(MAKE) -C $(PROJECTDIR)/$(MAKETYPE)-solaris config=$(CONFIG)32
 

--- a/src/devices/cpu/g65816/g65816ds.h
+++ b/src/devices/cpu/g65816/g65816ds.h
@@ -16,6 +16,11 @@ All rights reserved.
 
 */
 
+#ifdef __sun
+#undef SEC
+#undef op
+#endif
+
 class g65816_disassembler : public util::disasm_interface
 {
 public:

--- a/src/devices/cpu/lh5801/5801dasm.h
+++ b/src/devices/cpu/lh5801/5801dasm.h
@@ -10,7 +10,9 @@
 
 #ifndef MAME_CPU_LH5801_5801DASM_H
 #define MAME_CPU_LH5801_5801DASM_H
-
+#ifdef __sun
+#undef SEC
+#endif
 #pragma once
 
 class lh5801_disassembler : public util::disasm_interface

--- a/src/devices/cpu/m37710/m7700ds.h
+++ b/src/devices/cpu/m37710/m7700ds.h
@@ -4,7 +4,9 @@
 
 #ifndef __M7700DS_H__
 #define __M7700DS_H__
-
+#ifdef __sun
+#undef SEC
+#endif
 /*
 
 Mitsubishi 7700 CPU Emulator v0.10

--- a/src/devices/cpu/m68000/m68kcpu.h
+++ b/src/devices/cpu/m68000/m68kcpu.h
@@ -17,11 +17,11 @@
 
 #pragma once
 
-#include <limits.h>
-
 #if defined(__sun__) && defined(__svr4__)
 #undef REG_SP
 #undef REG_PC
+#else
+#include <limits.h>
 #endif
 
 /* ======================================================================== */

--- a/src/emu/http.cpp
+++ b/src/emu/http.cpp
@@ -7,6 +7,10 @@ http.cpp
 HTTP server handling
 
 ***************************************************************************/
+#ifdef __sun
+#define ASIO_DISABLE_DEV_POLL
+#define ASIO_HAS_EPOLL
+#endif
 
 #include "emu.h"
 #include "server_ws_impl.hpp"

--- a/src/emu/save.h
+++ b/src/emu/save.h
@@ -267,7 +267,11 @@ public:
 // template specializations to enumerate the fundamental atomic types you are allowed to save
 ALLOW_SAVE_TYPE_AND_ARRAY(char)
 ALLOW_SAVE_TYPE          (bool); // std::vector<bool> may be packed internally
+#ifdef __sun
+ALLOW_SAVE_TYPE_AND_ARRAY(signed char)
+#else
 ALLOW_SAVE_TYPE_AND_ARRAY(s8)
+#endif
 ALLOW_SAVE_TYPE_AND_ARRAY(u8)
 ALLOW_SAVE_TYPE_AND_ARRAY(s16)
 ALLOW_SAVE_TYPE_AND_ARRAY(u16)

--- a/src/mame/machine/sec.h
+++ b/src/mame/machine/sec.h
@@ -3,6 +3,10 @@
 
 /* commands */
 
+#ifdef __sun
+#undef SEC
+#endif
+
 #define SEC_REQUEST_STATUS     (0x20)
 #define SEC_REQUEST_MARKET     (0x21)
 #define SEC_REQEUST_LAST_ERROR (0x22)

--- a/src/osd/modules/file/posixptty.cpp
+++ b/src/osd/modules/file/posixptty.cpp
@@ -29,6 +29,10 @@
 #include <pty.h>
 #elif defined(__HAIKU__)
 #include <bsd/pty.h>
+#elif defined(__sun)
+#include <sys/types.h>
+#include <stropts.h>
+#include <sys/conf.h>
 #endif
 
 
@@ -112,7 +116,7 @@ osd_file::error posix_open_ptty(std::uint32_t openflags, osd_file::ptr &file, st
 	else if (openflags & OPEN_FLAG_READ)
 		access |= O_RDONLY;
 	else
-		return error::INVALID_ACCESS;
+		return osd_file::error::INVALID_ACCESS;
 
 	int const masterfd = ::posix_openpt(access);
 	if (masterfd < 0)

--- a/src/osd/modules/font/font_sdl.cpp
+++ b/src/osd/modules/font/font_sdl.cpp
@@ -8,7 +8,7 @@
 #include "font_module.h"
 #include "modules/osdmodule.h"
 
-#if defined(SDLMAME_UNIX) && !defined(SDLMAME_MACOSX) && !defined(SDLMAME_SOLARIS) && !defined(SDLMAME_HAIKU) && !defined(SDLMAME_ANDROID)
+#if defined(SDLMAME_UNIX) && !defined(SDLMAME_MACOSX) && !defined(SDLMAME_HAIKU) && !defined(SDLMAME_ANDROID)
 
 #include "corestr.h"
 #include "corealloc.h"

--- a/src/osd/modules/output/network.cpp
+++ b/src/osd/modules/output/network.cpp
@@ -14,6 +14,11 @@
 
 #include "emu.h"
 
+#ifdef __sun
+#define ASIO_DISABLE_DEV_POLL
+#define ASIO_HAS_EPOLL
+#endif
+
 #include <thread>
 #include <set>
 #include "asio.h"


### PR DESCRIPTION
This is a patch that excludes third-party fixes, which I will attempt to get merged upstream, see #5508, #3205.