### PR TITLE
Resolve [[nodiscard]] warning from c_str() call.

### DIFF
--- a/src/emu/rendfont.cpp
+++ b/src/emu/rendfont.cpp
@@ -374,7 +374,7 @@ private:
 
 void convert_command_glyph(std::string &str)
 {
-	str.c_str(); // force NUL-termination - we depend on it later
+	(void)str.c_str(); // force NUL-termination - we depend on it later
 	std::size_t const len(str.length());
 	std::vector<char> buf(2 * (len + 1));
 	std::size_t j(0);


### PR DESCRIPTION
In C++98/03, basic_string::c_str() was allowed to be a reallocation to insert the null terminator. MAME is ensuring this actually happens with a do-nothing call to c_str().

In C++11 and later, this is prohibited, and the string is mandated to be always null terminated. As a result Visual C++ marks c_str() with [[nodiscard]], triggering a warning here for discarding the result.

(I don't know of any C++03 implementation that actually reallocates here, but just in case this code actually targeted such an implementation I've just suppressed the warning for now. If MAME only targets C++11 or later, we should fix it by deleting the line.)