### PR TITLE
Explicitly use Ubuntu Trusty

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,7 @@ compiler:
 os:
   - linux
   - osx
+dist: trusty
 matrix:
   exclude:
     - os: osx


### PR DESCRIPTION
Due to ppas used the travis-ci only works with trusty. With xenial being the default as of August 2019 the builds fail most of the time. Request trusty explicitly until the CI configuration can be migrated to a more recent Ubuntu release.