### PR TITLE
swtpc09: add hard disk support for the DMAF3 controller

### DIFF
--- a/src/devices/machine/wd1000.cpp
+++ b/src/devices/machine/wd1000.cpp
@@ -470,10 +470,7 @@ WRITE8_MEMBER( wd1000_device::write )
 		//   bit 6,5  : sector size (0: 256, 1: 512, 3: 128)
 		//   bit 4,3  : drive select (0,1,2,3)
 		//   bit 2,1,0: head select (0-7)
-		uint8_t ecc = BIT(data, 7);
-		uint8_t sec_size = (data & 0x60) >> 5;
 		uint8_t drive = (data & 0x18) >> 3;
-		uint8_t head = data & 0x7;
 		m_sdh = data;
 
 		// Update the drive ready flag in the status register which
@@ -564,7 +561,6 @@ void wd1000_device::cmd_restore()
 void wd1000_device::cmd_read_sector()
 {
 	hard_disk_file *file = m_drives[drive()].drive->get_hard_disk_file();
-	hard_disk_info *info = hard_disk_get_info(file);
 	uint8_t dma = BIT(m_command, 3);
 
 	hard_disk_read(file, get_lbasector(), m_buffer);


### PR DESCRIPTION
This uses the WD1000 driver.

The DMAF2/3 6844 DMA support had to be improved to support multiple channels,
and now supports a separate high addresses for each channel. It now also
support addresses increasing or decreasing. These controllers use different
DMA channels for the floppy and the hard disk, and also a tape archiver which
is not yet implemented.

This gets UniFLEX running using a hard disk for storage, and does not appear
to regress the floppy support or other variants using the DMAF2.

Also cleans some debug remnants from the wd1000 code.