### PR TITLE
MC6845: correct cursor.

### DIFF
--- a/src/devices/video/mc6845.cpp
+++ b/src/devices/video/mc6845.cpp
@@ -705,8 +705,9 @@ bool mc6845_device::check_cursor_visible(uint16_t ra, uint16_t line_addr)
 	}
 
 	uint16_t cursor_start_ras = m_cursor_start_ras & 0x1f;
+	uint16_t max_ras_addr = m_max_ras_addr  + (MODE_INTERLACE_AND_VIDEO ? m_interlace_adjust : m_noninterlace_adjust);
 
-	if (cursor_start_ras > m_max_ras_addr)
+	if (cursor_start_ras > max_ras_addr)
 	{
 		// No cursor possible.
 		return false;
@@ -714,6 +715,11 @@ bool mc6845_device::check_cursor_visible(uint16_t ra, uint16_t line_addr)
 
 	if (cursor_start_ras <= m_cursor_end_ras)
 	{
+		if (m_cursor_end_ras > max_ras_addr)
+		{
+			// Full cursor.
+			return true;
+		}
 		// Cursor from start to end inclusive.
 		return (ra >= cursor_start_ras) && (ra <= m_cursor_end_ras);
 	}


### PR DESCRIPTION
The MC6845 shows a full cursor if the cursor end raster address is greater than the maximum raster address, restore that case in general.

The issue on the BBC, that uses the HD6845S, might be the use of the maximum raster address here, it appears to be programmed differently on the HD6845S and also to depend on the interlaced mode. This patch fixes the BBC while preserving the cursor emulation for the MC6845.

If the HD6845S varies in other ways here then please can that be a special case rather than regressing all the 6845 variations. Lets document the differences. Thank you for reporting the regression on the BBC.