### PR TITLE
asmjs: can not ignore errors on missing libraries

### DIFF
--- a/scripts/genie.lua
+++ b/scripts/genie.lua
@@ -1183,7 +1183,6 @@ configuration { "asmjs" }
 	}
 	linkoptions {
 		"-Wl,--start-group",
-		"-s ERROR_ON_MISSING_LIBRARIES=0"
 	}
 	archivesplit_size "20"
 

--- a/scripts/src/osd/sdl.lua
+++ b/scripts/src/osd/sdl.lua
@@ -38,7 +38,7 @@ function maintargetosdoptions(_target,_subtarget)
 		}
 	end
 
-	if BASE_TARGETOS=="unix" and _OPTIONS["targetos"]~="macosx" and _OPTIONS["targetos"]~="android" then
+	if BASE_TARGETOS=="unix" and _OPTIONS["targetos"]~="macosx" and _OPTIONS["targetos"]~="android" and _OPTIONS["targetos"]~="asmjs" then
 		links {
 			"SDL2_ttf",
 		}

--- a/scripts/src/osd/sdl.lua
+++ b/scripts/src/osd/sdl.lua
@@ -328,7 +328,7 @@ if BASE_TARGETOS=="unix" then
 					"socket",
 					"nsl",
 				}
-			else
+			elseif _OPTIONS["targetos"]~="asmjs" then
 				links {
 					"util",
 				}


### PR DESCRIPTION
The current Emscripten release is not happy with the use of "-s ERROR_ON_MISSING_LIBRARIES=0" as a link option, it gives an error stating that all libraries must now be present, so remove that use.

This leaves a missing 'util' library. This did not appear to be needed on the few builds I have tried, and this patch avoids adding this library for asmjs.

I still get an error `emcc: cannot find library "SDL2_ttf`. Simply removing that library at the linking stage allows it to proceed, and I don't see any related missing symbols. Not sure about this one, emscripten does build this one and cache it.

Has anyone else seen these problems and know more?