### PR TITLE
Changes input_manager::code_check_axis() to ignore axis reads of zero

### DIFF
--- a/src/emu/input.cpp
+++ b/src/emu/input.cpp
@@ -865,6 +865,11 @@ bool input_manager::code_check_axis(input_device_item &item, input_code code)
 		(curval == INPUT_ABSOLUTE_MAX || curval == INPUT_ABSOLUTE_MIN))
 		return false;
 
+	// if either curval is zero, then we're probably comparing against a case
+	// where we lost acquisition of the device, so this check doesn't count
+	if (curval == 0)
+		return false;
+
 	// compute the diff against memory
 	s32 diff = curval - item.memory();
 	if (diff < 0)


### PR DESCRIPTION
Reads of analog devices will yield 0 when devices are unacquired.  This is because of logic in the various devices like this:

	void dinput_mouse_device::reset()
	{
		memset(&mouse, 0, sizeof(mouse));
	}

However, input_manager::code_check_axis() is not sensitive to this and the calculation of the diff was not factoring this in.  This would mean that from the perspective of this code, [un]acquisitions would be read as a large "jerk" in the readings.  This change causes checks against zero specifically to be dropped.

In practice, this was not causing problems for normal MAME because devices would only be lost if the user did something odd (e.g. - an Alt+Tab).  With the BletchMAME front end, this was happening more frequently because of interactions between the various input dialogs and DirectWrite.

I welcome scrutiny for this change.