### PR TITLE
mc6845: address cursor display edge case in interlaced mode.

### DIFF
--- a/src/devices/video/mc6845.cpp
+++ b/src/devices/video/mc6845.cpp
@@ -705,9 +705,17 @@ bool mc6845_device::check_cursor_visible(uint16_t ra, uint16_t line_addr)
 	}
 
 	uint16_t cursor_start_ras = m_cursor_start_ras & 0x1f;
-	uint16_t max_ras_addr = m_max_ras_addr  + (MODE_INTERLACE_AND_VIDEO ? m_interlace_adjust : m_noninterlace_adjust);
+	uint16_t max_ras_addr = m_max_ras_addr + (MODE_INTERLACE_AND_VIDEO ? m_interlace_adjust : m_noninterlace_adjust) - 1;
 
 	if (cursor_start_ras > max_ras_addr)
+	{
+		// No cursor possible.
+		return false;
+	}
+
+	// See the 'apricot' boot screen, it probably expects no cursor.
+	// TODO explore the edge cases in the 'interlace and video' mode.
+	if (MODE_INTERLACE_AND_VIDEO && cursor_start_ras >= max_ras_addr)
 	{
 		// No cursor possible.
 		return false;


### PR DESCRIPTION
It appears that the cursor is not displayed when the start raster address is equal to the maximum raster address in the 'interlace and video' mode. At least this addresses a claimed regression in the 'apricot' machine. To be explored further on hardware.

The maximum raster address was also off by one in these calculations.

Addressing regressions noted in https://github.com/mamedev/mame/pull/5562 and thank you again for the reports and patience.