### PR TITLE
Fix the main cpu clock for the DE-0343 board

### DIFF
--- a/src/mame/drivers/supbtime.cpp
+++ b/src/mame/drivers/supbtime.cpp
@@ -327,7 +327,7 @@ GFXDECODE_END
 
 void supbtime_state::supbtime(machine_config &config)
 {
-	M68000(config, m_maincpu, XTAL(28'000'000) / 2);
+	M68000(config, m_maincpu, XTAL(21'477'272) / 2);
 	m_maincpu->set_addrmap(AS_PROGRAM, &supbtime_state::supbtime_map);
 
 	H6280(config, m_audiocpu, XTAL(32'220'000) / 8);


### PR DESCRIPTION
The 68000 core, DATA EAST chip 59, should run at 10.738636MHz.
This is confirmed by DE-0343-4, Tumblepop. Pin 57 is for the clock.