### PR TITLE
HD6845: specialize the cursor emulation

### DIFF
--- a/src/devices/video/mc6845.h
+++ b/src/devices/video/mc6845.h
@@ -235,7 +235,7 @@ protected:
 	void set_vsync(int state);
 	void set_cur(int state);
 	bool match_line();
-	bool check_cursor_visible(uint16_t ra, uint16_t line_addr);
+	virtual bool check_cursor_visible(uint16_t ra, uint16_t line_addr);
 	void handle_line_timer();
 	virtual void update_cursor_state();
 	virtual uint8_t draw_scanline(int y, bitmap_rgb32 &bitmap, const rectangle &cliprect);
@@ -331,6 +331,7 @@ public:
 protected:
 	virtual void device_start() override;
 	virtual void device_reset() override;
+	virtual bool check_cursor_visible(uint16_t ra, uint16_t line_addr) override;
 };
 
 class sy6545_1_device : public mc6845_device


### PR DESCRIPTION
For the HD6845 the cursor does not wrap around as it does for the MC6845.

Thank you for exploring this. This might not deal with all edge cases, but appears to address the reported regressions, and attempts to take into account results of hardware testing.