### PR TITLE
Fix the audio cpu clock for the DE-0343 board

### DIFF
--- a/src/mame/drivers/supbtime.cpp
+++ b/src/mame/drivers/supbtime.cpp
@@ -330,7 +330,7 @@ void supbtime_state::supbtime(machine_config &config)
 	M68000(config, m_maincpu, XTAL(21'477'272) / 2);
 	m_maincpu->set_addrmap(AS_PROGRAM, &supbtime_state::supbtime_map);
 
-	H6280(config, m_audiocpu, XTAL(32'220'000) / 8);
+	H6280(config, m_audiocpu, XTAL(32'220'000) / 4);
 	m_audiocpu->set_addrmap(AS_PROGRAM, &supbtime_state::sound_map);
 	m_audiocpu->add_route(ALL_OUTPUTS, "mono", 0); // internal sound unused
 


### PR DESCRIPTION
The HuC6280 core seems to run at 8.055MHz rather than 16.110MHz.
Confirmed by DE-0343-4, Tumblepop.