### PR TITLE
Changed osd_get_clipboard_text() to return std::string

### DIFF
--- a/src/emu/natkeyboard.cpp
+++ b/src/emu/natkeyboard.cpp
@@ -585,17 +585,10 @@ void natural_keyboard::post_coded(const std::string &text, const attotime &rate)
 void natural_keyboard::paste()
 {
 	// retrieve the clipboard text
-	char *text = osd_get_clipboard_text();
+	std::string text = osd_get_clipboard_text();
 
-	// was a result returned?
-	if (text != nullptr)
-	{
-		// post the text
-		post_utf8(text);
-
-		// free the string
-		free(text);
-	}
+	// post the text
+	post_utf8(text);
 }
 
 

--- a/src/frontend/mame/ui/ui.cpp
+++ b/src/frontend/mame/ui/ui.cpp
@@ -917,15 +917,8 @@ void mame_ui_manager::decrease_frameskip()
 
 bool mame_ui_manager::can_paste()
 {
-	// retrieve the clipboard text
-	char *text = osd_get_clipboard_text();
-
-	// free the string if allocated
-	if (text != nullptr)
-		free(text);
-
-	// did we have text?
-	return text != nullptr;
+	// check to see if the clipboard is not empty
+	return !osd_get_clipboard_text().empty();
 }
 
 

--- a/src/osd/modules/lib/osdlib.h
+++ b/src/osd/modules/lib/osdlib.h
@@ -54,14 +54,9 @@ int osd_setenv(const char *name, const char *value, int overwrite);
 
 
 /*-----------------------------------------------------------------------------
-    osd_get_clipboard_text: retrieves text from the clipboard
-
-    Return value:
-
-        the returned string needs to be free-ed!
+	osd_get_clipboard_text: retrieves text from the clipboard
 -----------------------------------------------------------------------------*/
-
-char *osd_get_clipboard_text(void);
+std::string osd_get_clipboard_text(void);
 
 /*-----------------------------------------------------------------------------
     dynamic_module: load functions from optional shared libraries

--- a/src/osd/modules/lib/osdlib_macosx.cpp
+++ b/src/osd/modules/lib/osdlib_macosx.cpp
@@ -116,14 +116,15 @@ void osd_break_into_debugger(const char *message)
 //  osd_get_clipboard_text
 //============================================================
 
-char *osd_get_clipboard_text(void)
+std::string osd_get_clipboard_text(void)
 {
+	std::string result;
 	OSStatus err;
 
 	PasteboardRef pasteboard_ref;
 	err = PasteboardCreate(kPasteboardClipboard, &pasteboard_ref);
 	if (err)
-		return nullptr;
+		return result;
 
 	PasteboardSynchronize(pasteboard_ref);
 
@@ -171,10 +172,10 @@ char *osd_get_clipboard_text(void)
 				CFIndex const length = CFDataGetLength(data_ref);
 				CFRange const range = CFRangeMake(0, length);
 
-				result = reinterpret_cast<char *>(malloc(length + 1));
+				result.resize(length);
 				if (result)
 				{
-					CFDataGetBytes(data_ref, range, reinterpret_cast<unsigned char *>(result));
+					CFDataGetBytes(data_ref, range, reinterpret_cast<unsigned char *>(&result[0]));
 					result[length] = 0;
 				}
 

--- a/src/osd/modules/lib/osdlib_macosx.cpp
+++ b/src/osd/modules/lib/osdlib_macosx.cpp
@@ -119,6 +119,7 @@ void osd_break_into_debugger(const char *message)
 std::string osd_get_clipboard_text(void)
 {
 	std::string result;
+	bool has_result = false;
 	OSStatus err;
 
 	PasteboardRef pasteboard_ref;
@@ -131,8 +132,7 @@ std::string osd_get_clipboard_text(void)
 	ItemCount item_count;
 	err = PasteboardGetItemCount(pasteboard_ref, &item_count);
 
-	char *result = nullptr; // core expects a malloced C string of uft8 data
-	for (UInt32 item_index = 1; (item_index <= item_count) && !result; item_index++)
+	for (UInt32 item_index = 1; (item_index <= item_count) && !has_result; item_index++)
 	{
 		PasteboardItemID item_id;
 		err = PasteboardGetItemIdentifier(pasteboard_ref, item_index, &item_id);
@@ -145,7 +145,7 @@ std::string osd_get_clipboard_text(void)
 			continue;
 
 		CFIndex const flavor_count = CFArrayGetCount(flavor_type_array);
-		for (CFIndex flavor_index = 0; (flavor_index < flavor_count) && !result; flavor_index++)
+		for (CFIndex flavor_index = 0; (flavor_index < flavor_count) && !has_result; flavor_index++)
 		{
 			CFStringRef const flavor_type = (CFStringRef)CFArrayGetValueAtIndex(flavor_type_array, flavor_index);
 
@@ -173,11 +173,8 @@ std::string osd_get_clipboard_text(void)
 				CFRange const range = CFRangeMake(0, length);
 
 				result.resize(length);
-				if (result)
-				{
-					CFDataGetBytes(data_ref, range, reinterpret_cast<unsigned char *>(&result[0]));
-					result[length] = 0;
-				}
+				CFDataGetBytes(data_ref, range, reinterpret_cast<unsigned char *>(&result[0]));
+				has_result = true;
 
 				CFRelease(data_ref);
 			}

--- a/src/osd/modules/lib/osdlib_unix.cpp
+++ b/src/osd/modules/lib/osdlib_unix.cpp
@@ -100,24 +100,23 @@ void osd_break_into_debugger(const char *message)
 }
 
 #ifdef SDLMAME_ANDROID
-char *osd_get_clipboard_text(void)
+std::string osd_get_clipboard_text(void)
 {
-	return nullptr;
+	return std::string();
 }
 #else
 //============================================================
 //  osd_get_clipboard_text
 //============================================================
 
-char *osd_get_clipboard_text(void)
+std::string osd_get_clipboard_text(void)
 {
-	char *result = nullptr;
+	std::string result;
 
 	if (SDL_HasClipboardText())
 	{
 		char *temp = SDL_GetClipboardText();
-		result = (char *) malloc(strlen(temp) + 1);
-		strcpy(result, temp);
+		result.assign(temp);
 		SDL_free(temp);
 	}
 	return result;

--- a/src/osd/osdcore.h
+++ b/src/osd/osdcore.h
@@ -752,13 +752,8 @@ void osd_break_into_debugger(const char *message);
 
 /*-----------------------------------------------------------------------------
     osd_get_clipboard_text: retrieves text from the clipboard
-
-    Return value:
-
-        the returned string needs to be osd_free()-ed!
-
 -----------------------------------------------------------------------------*/
-char *osd_get_clipboard_text(void);
+std::string osd_get_clipboard_text(void);
 
 
 /***************************************************************************


### PR DESCRIPTION
This change has only been tested on Windows.  The Un*x/Mac versions were
made blindly; they might not even build.  This needs to be checked prior
to merging.