### PR TITLE
Don't force throttling while paused

### DIFF
--- a/src/emu/video.cpp
+++ b/src/emu/video.cpp
@@ -808,7 +808,7 @@ int video_manager::effective_frameskip() const
 inline bool video_manager::effective_throttle() const
 {
 	// if we're paused, or if the UI is active, we always throttle
-	if (machine().paused()) //|| machine().ui().is_menu_active())
+	if (machine().paused() && !machine().options().update_in_pause()) //|| machine().ui().is_menu_active())
 		return true;
 
 	// if we're fast forwarding, we don't throttle


### PR DESCRIPTION
This tweak allows the user to decide if throttling should be forced while paused. Of course if we're just talking about the paused state, this makes no sense, but when we're frame-stepping, we might want throttling to go away.

I used an obscure option that's only checked in a single place and intended for debug use. Its nature seems to fit my purpose quite well, and it's also used along with `machine().paused()` in that one place that had it, exactly like I do here.

In my case, I control MAME remotely via luaengine and I have a periodic callback that advances a frame (among other things). When throttling is forced during pause, I can only get 50% speed with this method, even if I send `-video none -nothrottle`. Using frame advance on periodic callbacks seems to be required not to mess with the lua thread (not sure what exactly goes wrong there, it's just crashing in various places in lua source files). With this change, I can run at full unthrottled speed even during frame-advancing.