### PR TITLE
[snes] Fix 5a22/spc700 clock cycles

### DIFF
--- a/src/devices/cpu/g65816/g65816.cpp
+++ b/src/devices/cpu/g65816/g65816.cpp
@@ -895,9 +895,7 @@ void g65816_device::device_start()
 
 	machine().save().register_postload(save_prepost_delegate(FUNC(g65816_device::g65816_restore_state), this));
 
-	m_rw8_cycles = 1;
-	m_rw16_cycles = 2;
-	m_rw24_cycles = 3;
+	m_divider = 1;
 
 	state_add( G65816_PC,        "PC", m_debugger_temp).callimport().callexport().formatstr("%06X");
 	state_add( G65816_S,         "S", m_s).callimport().formatstr("%04X");
@@ -1031,14 +1029,14 @@ int g65816_device::bus_5A22_cycle_burst(unsigned addr)
 
 	if(addr & 0x408000) {
 		if(addr & 0x800000)
-			return (m_fastROM & 1) ? 6 : 8;
+			return (m_fastROM & 1) ? 0 : 2;
 
-		return 8;
+		return 2;
 	}
-	if((addr + 0x6000) & 0x4000) return 8;
-	if((addr - 0x4000) & 0x7e00) return 6;
+	if((addr + 0x6000) & 0x4000) return 2;
+	if((addr - 0x4000) & 0x7e00) return 0;
 
-	return 12;
+	return 6;
 }
 
 
@@ -1048,9 +1046,7 @@ void _5a22_device::device_start()
 
 	state_add( _5A22_FASTROM, "fastROM", m_debugger_temp).mask(0x01).callimport().callexport().formatstr("%01X");
 
-	m_rw8_cycles = 0;
-	m_rw16_cycles = 0;
-	m_rw24_cycles = 0;
+	m_divider = 6;
 }
 
 void _5a22_device::state_import(const device_state_entry &entry)

--- a/src/devices/cpu/g65816/g65816.h
+++ b/src/devices/cpu/g65816/g65816.h
@@ -246,7 +246,7 @@ protected:
 	unsigned m_destination;
 	int m_ICount;
 	int m_cpu_type;
-	uint8_t m_rw8_cycles, m_rw16_cycles, m_rw24_cycles;
+	uint8_t m_divider;
 	uint32_t m_debugger_temp;
 
 	/* 5A22 specific registers */

--- a/src/devices/cpu/g65816/g65816cm.h
+++ b/src/devices/cpu/g65816/g65816cm.h
@@ -117,16 +117,16 @@
 /* ======================================================================== */
 
 #define CLK_OP          1
-#define CLK_R8          m_rw8_cycles
-#define CLK_R16         m_rw16_cycles
-#define CLK_R24         m_rw24_cycles
-#define CLK_W8          m_rw8_cycles
-#define CLK_W16         m_rw16_cycles
-#define CLK_W24         m_rw24_cycles
-#define CLK_RMW8        m_rw8_cycles+m_rw8_cycles + 1
-#define CLK_RMW16       m_rw16_cycles+m_rw16_cycles + 1
+#define CLK_R8          1
+#define CLK_R16         2
+#define CLK_R24         3
+#define CLK_W8          1
+#define CLK_W16         2
+#define CLK_W24         3
+#define CLK_RMW8        3
+#define CLK_RMW16       5
 
-#define CLK_IMPLIED     1
+
 #define CLK_IMPLIED     1
 #define CLK_RELATIVE_8  1
 #define CLK_RELATIVE_16 2
@@ -169,7 +169,7 @@
 #define CLK_W_S         2
 #define CLK_W_SIY       5
 
-#define CLK(A)          CLOCKS -= A
+#define CLK(A)          CLOCKS -= ((A)*(m_divider))
 #define CLK_BUS(A)      CLOCKS -= A
 #define USE_ALL_CLKS()  CLOCKS = 0
 

--- a/src/devices/cpu/spc700/spc700.cpp
+++ b/src/devices/cpu/spc700/spc700.cpp
@@ -247,7 +247,8 @@ device_memory_interface::space_config_vector spc700_device::memory_space_config(
 /* ======================================================================== */
 
 /* Use up clock cycles */
-#define CLK(A) CLOCKS -= (A)
+#define CLK_DIVIDER 2
+#define CLK(A) CLOCKS -= ((A)*(CLK_DIVIDER))
 #define CLK_ALL() CLOCKS = 0
 
 


### PR DESCRIPTION
Resolve MT06901 and MT07419
Also it fixes other games like Cliffhanger, Taekwon-Do and Super Tekkyuu Fight