### PR TITLE
Add gcc build to appveyor

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -37,7 +37,7 @@ for:
       only:
         - BUILD: GCC
     build_script:
-      - bash -lc "exec 0</dev/null && cd $APPVEYOR_BUILD_FOLDER && export MINGW64=/mingw64 && make SUBTARGET=tiny PTR64=1 OPTIMIZE=0 IGNORE_GIT=1 -j4"
+      - bash -lc "exec 0</dev/null && cd $APPVEYOR_BUILD_FOLDER && export MINGW64=/mingw64 && make SUBTARGET=tiny PTR64=1 OPTIMIZE=0 ARCHOPTS=-Wa,-mbig-obj IGNORE_GIT=1 -j4"
     test_script:
       - \projects\mame\mametiny64.exe -validate
     after_test:

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -37,7 +37,12 @@ for:
       only:
         - BUILD: GCC
     build_script:
-      - bash -lc "exec 0</dev/null && cd $APPVEYOR_BUILD_FOLDER && export MINGW64=/mingw64 && make SUBTARGET=tiny PTR64=1 OPTIMIZE=0 DEBUG=1 ARCHOPTS=-Wa,-mbig-obj -j4"
+      - bash -lc "exec 0</dev/null && cd $APPVEYOR_BUILD_FOLDER && export MINGW64=/mingw64 && make SUBTARGET=tiny PTR64=1 OPTIMIZE=0 IGNORE_GIT=1 -j4"
+    test_script:
+      - \projects\mame\mametiny64.exe -validate
+    after_test:
+      - 7z a mametiny64-appveyor-%APPVEYOR_REPO_BRANCH%-%APPVEYOR_REPO_COMMIT%-%APPVEYOR_BUILD_NUMBER%.7z %APPVEYOR_BUILD_FOLDER%\*.exe %APPVEYOR_BUILD_FOLDER%\artwork %APPVEYOR_BUILD_FOLDER%\bgfx %APPVEYOR_BUILD_FOLDER%\ctrlr %APPVEYOR_BUILD_FOLDER%\docs %APPVEYOR_BUILD_FOLDER%\hash %APPVEYOR_BUILD_FOLDER%\hlsl %APPVEYOR_BUILD_FOLDER%\ini %APPVEYOR_BUILD_FOLDER%\language %APPVEYOR_BUILD_FOLDER%\nl_examples %APPVEYOR_BUILD_FOLDER%\plugins %APPVEYOR_BUILD_FOLDER%\roms %APPVEYOR_BUILD_FOLDER%\samples
+      - appveyor PushArtifact mametiny64-appveyor-%APPVEYOR_REPO_BRANCH%-%APPVEYOR_REPO_COMMIT%-%APPVEYOR_BUILD_NUMBER%.7z
 
 test_script:
   - \projects\mame\mametiny64d.exe -validate

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -8,6 +8,20 @@ image:
 shallow_clone: true
 clone_depth: 1
 
+environment:
+  matrix:
+    - BUILD: GCC
+    - BUILD: MSVC
+
+matrix:
+  exclude:
+    - image: Visual Studio 2017 Preview
+      BUILD: GCC
+    - image: Visual Studio 2019 Preview
+      BUILD: GCC
+    - image: Previous Visual Studio 2017
+      BUILD: GCC
+
 install:
   - set "PATH=C:\msys64\usr\bin;C:\msys64\mingw64\bin;C:\Windows\System32;C:\Windows;%PATH%"
   - set MSYSTEM=MINGW64
@@ -16,6 +30,14 @@ install:
 build_script:
   - bash -lc "exec 0</dev/null && cd $APPVEYOR_BUILD_FOLDER && make SUBTARGET=tiny PTR64=1 TOOLS=1 OPTIMIZE=0 vs2017 -j4"
   - msbuild "build\projects\windows\mametiny\vs2017\mametiny.sln" /m /p:ContinueOnError=false /p:StopOnFirstFailure=true /property:Configuration=Debug /property:Platform=x64 /logger:"C:\Program Files\AppVeyor\BuildAgent\Appveyor.MSBuildLogger.dll"
+
+for:
+  -
+    matrix:
+      only:
+        - BUILD: GCC
+    build_script:
+      - bash -lc "exec 0</dev/null && cd $APPVEYOR_BUILD_FOLDER && export MINGW64=/mingw64 && make SUBTARGET=tiny PTR64=1 OPTIMIZE=0 DEBUG=1 ARCHOPTS=-Wa,-mbig-obj -j4"
 
 test_script:
   - \projects\mame\mametiny64d.exe -validate


### PR DESCRIPTION
As tea-ci has been broken for quite a while now, there has been no MINGW CI available. MINGW builds can be done in appveyor too. Tools build had to be disabled as it takes longer than the allowed 60 minutes. Wa,-mbig-obj was added to avoid "file too big" errors.