### PR TITLE
Add MIDI floppy softlist

### DIFF
--- a/hash/midi_flop.xml
+++ b/hash/midi_flop.xml
@@ -8,7 +8,7 @@
         <publisher>Melo-Disc</publisher> <!-- Distributed by Roland Scandinavia -->
         <part name="flop1" interface="floppy_3_5">
             <dataarea name="flop" size="329738">
-                <rom name="dansbandshits nr 3.img" size="329738" crc="5a8ec4b1" sha1="b9894ef4d15457c7f77234fb383afa55603a0dd5"/>
+                <rom name="dansbandshits nr 3.imd" size="329738" crc="5a8ec4b1" sha1="b9894ef4d15457c7f77234fb383afa55603a0dd5"/>
             </dataarea>
         </part>
     </software>

--- a/hash/midi_flop.xml
+++ b/hash/midi_flop.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0"?>
+<!DOCTYPE softwarelist SYSTEM "softwarelist.dtd">
+<softwarelist name="midi_flop" description="Standard MIDI floppy disks">
+
+    <software name="dansband3">
+        <description>Dansbandshits nr 3 (Sweden)</description>
+        <year>1996</year>
+        <publisher>Melo-Disc</publisher> <!-- Distributed by Roland Scandinavia -->
+        <part name="flop1" interface="floppy_3_5">
+            <dataarea name="flop" size="737280">
+                <rom name="dansbandshits nr 3.img" size="737280" crc="47e7f04b" sha1="d98c881686d75f2504f04f7a0c20282c07cc439c"/>
+            </dataarea>
+        </part>
+    </software>
+
+</softwarelist>

--- a/hash/midi_flop.xml
+++ b/hash/midi_flop.xml
@@ -7,8 +7,8 @@
         <year>1996</year>
         <publisher>Melo-Disc</publisher> <!-- Distributed by Roland Scandinavia -->
         <part name="flop1" interface="floppy_3_5">
-            <dataarea name="flop" size="737280">
-                <rom name="dansbandshits nr 3.img" size="737280" crc="47e7f04b" sha1="d98c881686d75f2504f04f7a0c20282c07cc439c"/>
+            <dataarea name="flop" size="329738">
+                <rom name="dansbandshits nr 3.img" size="329738" crc="5a8ec4b1" sha1="b9894ef4d15457c7f77234fb383afa55603a0dd5"/>
             </dataarea>
         </part>
     </software>

--- a/src/mame/drivers/atpci.cpp
+++ b/src/mame/drivers/atpci.cpp
@@ -102,6 +102,7 @@ void at586_state::at_softlists(machine_config &config)
 	SOFTWARE_LIST(config, "pc_disk_list").set_original("ibm5150");
 	SOFTWARE_LIST(config, "at_disk_list").set_original("ibm5170");
 	SOFTWARE_LIST(config, "at_cdrom_list").set_original("ibm5170_cdrom");
+	SOFTWARE_LIST(config, "midi_disk_list").set_compatible("midi_flop");
 }
 
 void at586_state::at586(machine_config &config)

--- a/src/mame/drivers/ct486.cpp
+++ b/src/mame/drivers/ct486.cpp
@@ -188,6 +188,7 @@ void ct486_state::ct486(machine_config &config)
 	SOFTWARE_LIST(config, "pc_disk_list").set_original("ibm5150");
 	SOFTWARE_LIST(config, "at_disk_list").set_original("ibm5170");
 	SOFTWARE_LIST(config, "at_cdrom_list").set_original("ibm5170_cdrom");
+	SOFTWARE_LIST(config, "midi_disk_list").set_compatible("midi_flop");
 }
 
 

--- a/src/mame/drivers/ps2.cpp
+++ b/src/mame/drivers/ps2.cpp
@@ -40,6 +40,7 @@ void ps2_state::at_softlists(machine_config &config)
 	SOFTWARE_LIST(config, "pc_disk_list").set_original("ibm5150");
 	SOFTWARE_LIST(config, "at_disk_list").set_original("ibm5170");
 	SOFTWARE_LIST(config, "at_cdrom_list").set_original("ibm5170_cdrom");
+	SOFTWARE_LIST(config, "midi_disk_list").set_compatible("midi_flop");
 }
 
 void ps2_state::ps2_16_map(address_map &map)

--- a/src/mame/machine/at.cpp
+++ b/src/mame/machine/at.cpp
@@ -52,6 +52,7 @@ void at_mb_device::at_softlists(machine_config &config)
 	SOFTWARE_LIST(config, "pc_disk_list").set_original("ibm5150");
 	SOFTWARE_LIST(config, "at_disk_list").set_original("ibm5170");
 	SOFTWARE_LIST(config, "at_cdrom_list").set_original("ibm5170_cdrom");
+	SOFTWARE_LIST(config, "midi_disk_list").set_compatible("midi_flop");
 }
 
 void at_mb_device::device_add_mconfig(machine_config &config)


### PR DESCRIPTION
A weird list this one. This is a "software" list for standard MIDI floppy disks. Content is dumped by me from my own disk.

This should be possible to enable for any MIDI-compatible synthesizer with 3.5" drive. Please tell me of any such drivers and I'll attempt to hook it up for them. I could only think of the SQ-80, but the floppy drive doesn't seem to be working yet for it.