### PR TITLE
Fixed a compilation bug under clang-cl

### DIFF
--- a/src/lib/netlist/plib/putil.h
+++ b/src/lib/netlist/plib/putil.h
@@ -142,7 +142,7 @@ namespace plib
 		if (ss >> x)
 		{
 			auto pos(ss.tellg());
-			if (pos == -1LL)
+			if (pos == static_cast<decltype(pos)>(-1))
 				pos = len;
 			*idx = static_cast<std::size_t>(pos);
 		}

--- a/src/lib/netlist/plib/putil.h
+++ b/src/lib/netlist/plib/putil.h
@@ -142,7 +142,7 @@ namespace plib
 		if (ss >> x)
 		{
 			auto pos(ss.tellg());
-			if (pos == -1)
+			if (pos == -1LL)
 				pos = len;
 			*idx = static_cast<std::size_t>(pos);
 		}


### PR DESCRIPTION
Oddly, this problem does not seem to manifest under clang on gcc.godbolt.org.  I suspect that this might be related to the fact that sizeof(std::size_t) != sizeof(long) on Windows.