### PR TITLE
Lua callback after sound update has generated new samples

### DIFF
--- a/src/emu/main.h
+++ b/src/emu/main.h
@@ -60,6 +60,7 @@ public:
 	static void draw_user_interface(running_machine& machine);
 	static void periodic_check();
 	static bool frame_hook();
+	static void sound_hook();
 	static void layout_file_cb(util::xml::data_node const &layout);
 	static bool standalone();
 };

--- a/src/emu/sound.cpp
+++ b/src/emu/sound.cpp
@@ -1152,6 +1152,9 @@ void sound_manager::update(void *ptr, int param)
 	for (auto &stream : m_stream_list)
 		stream->apply_sample_rate_changes();
 
+	// notify that new samples have been generated
+	emulator_info::sound_hook();
+
 	g_profiler.stop();
 }
 

--- a/src/frontend/mame/luaengine.h
+++ b/src/frontend/mame/luaengine.h
@@ -49,6 +49,7 @@ public:
 	std::vector<std::string> &get_menu() { return m_menu; }
 	void attach_notifiers();
 	void on_frame_done();
+	void on_sound_update();
 	void on_periodic();
 	bool on_missing_mandatory_image(const std::string &instance_name);
 	void on_machine_before_load_settings();

--- a/src/frontend/mame/mame.cpp
+++ b/src/frontend/mame/mame.cpp
@@ -413,6 +413,11 @@ bool emulator_info::frame_hook()
 	return mame_machine_manager::instance()->lua()->frame_hook();
 }
 
+void emulator_info::sound_hook()
+{
+	return mame_machine_manager::instance()->lua()->on_sound_update();
+}
+
 void emulator_info::layout_file_cb(util::xml::data_node const &layout)
 {
 	util::xml::data_node const *const mamelayout = layout.get_child("mamelayout");


### PR DESCRIPTION
New samples are generated independently from the video system, vblank, frames, etc. Sound update uses its own timer and fires [50 times per second](https://github.com/mamedev/mame/blob/master/src/emu/sound.cpp#L884). So if we want to grab the sound buffer, we need to do it 50 times per second as well.

This PR adds a callback that fires whenever audio has been updated and new samples have been generated. I tested it with this script and got the same output as from `-wavwrite`:

```lua
local function log(s, name)
    logfile = io.open(name, "ab") -- binary mode is required, otherwise junk gets appended along the way
    logfile:write(s)
    logfile:close()
end

emu.register_sound_update(function()
	local samples = manager:machine():sound():samples()
	log(samples, "check.wav")
end)
```