### PR TITLE
fmtowns_cd.xml: additions, better dumps, updated missing list

### DIFF
--- a/hash/fmtowns_cd.xml
+++ b/hash/fmtowns_cd.xml
@@ -564,7 +564,7 @@ Robin Hood                                                    DynEd Japan       
 Rockpaedia Vol. 2: 1961-1970                                  Toshiba EMI                       ?          CD
 Round the World in 80 Days                                    DynEd Japan                       1993/12    SET(CD+FD)
 Royal Blood                                                   Koei                              1992/5     SET(CD+FD)
-S-DAPS Demo CD [DWDC492]                                      Data West                         1994/?     CD
+S-DAPS Demo CD [DWDC4922]                                     Data West                         1994/?     CD
 Saishin American Idiom Jiten                                  Sanshusha                         1990/2     CD
 Saishin Igaku Daijiten CD-ROM                                 Fujitsu                           1990/5     CD
 Saishin Igaku Daijiten Standard-ban CD-ROM                    Fujitsu                           1993/2     CD
@@ -665,7 +665,7 @@ Teo: Mou Hitotsu no Chikyuu Ver. 2                            Fujitsu Parex     
 Tera Towns                                                    Nihon Micom Hanbai                1989/5     CD
 Tera Towns 2                                                  Nihon Micom Hanbai                1993/4     CD
 That's Toukou                                                 Birdy Soft                        1993/12    CD
-The 4th Unit Series: Wyatt (Demo-you Disc) [DWFT2901+         Data West                         1992/?     SET(CD+FD)
+The 4th Unit Series: Wyatt (Demo-you Disc) [DWFT2901]         Data West                         1992/?     SET(CD+FD)
 The Book of MIDI                                              Fujitsu                           1992/9     CD
 The Lost Secret                                               DynEd Japan                       1993/7     SET(CD+FD)
 The Manhole 2                                                 Sun Denshi                        1993/5     ?

--- a/hash/fmtowns_cd.xml
+++ b/hash/fmtowns_cd.xml
@@ -194,17 +194,19 @@ FIRSTHAND ACCESS(Disc2)                                       DynEd Japan       
 FlexData Collection Vol. 1                                    Fujitsu                           1993/11    CD
 FM Towns Appli Jikkou Set                                     Fujitsu                           1993/6     CD
 FM Towns de Manabu School-Ace Alpha                           Fujitsu                           1993/4     CD
+FM Towns Free Soft Nyuumon Kit                                Shuwa System                      ?          CD
 FM Towns Free Ware Collection (EYE COM-ban)                   Fujitsu                           1989/11    CD
 FM Towns Paso-Rika Ver. 3                                     Maris                             1993/11    CD
 FM Towns Shougaku Ongaku (5-6-nensei You)                     Kyouiku Shuppan                   1991/5     SET(CD+FD)
 FM Towns World                                                Fujitsu                           1989/5     CD
 FM Towns-ban Dyna-pers                                        Dynaware                          1989/12    CD
 FreeColle Marty 1                                             Fujitsu                           1993/12    CD
-Fujitsu Air Warrior V1.2                                      Fujitsu                           1993/11    SET(CD+FD)
+* Fujitsu Air Warrior V1.2                                    Fujitsu                           1993/11    SET(CD+FD)
 * Fujitsu Air Warrior V1.1                                    Fujitsu                           1992/3     SET(CD+FD)
 Fujitsu Air Warrior V2.1                                      Fujitsu                           1995/4     SET(CD+FD)
 Fujitsu Habitat V1.1                                          Fujitsu                           1990/1     SET(CD+FD)
-Fujitsu Habitat V2.1                                          Fujitsu                           1994/5     SET(CD+FD)
+* Fujitsu Habitat V2.1 L10                                    Fujitsu                           1994/5     SET(CD+FD)
+Fujitsu Habitat V2.1 L11                                      Fujitsu                           1994/?     SET(CD+FD)
 Fukui Toshio no Otenki Map                                    Inter Limited Logic               1991/2     CD
 Functioning in Business Part 1                                DynEd Japan                       1992/7     SET(CD+FD)
 Functioning in Business Part 2                                DynEd Japan                       1992/7     SET(CD+FD)
@@ -300,7 +302,7 @@ Hyper Koto no Tabi: Kyoto                                     Nanken Koubou     
 Hyper Land: Doubutsu no Sekai                                 Datt Japan                        1993/3     CD
 Hyper Media NHK Zoku Kiso Eigo: Dai-1-kan                     CSK Research Institute (CRI)      1991/6     SET(CD+FD)
 Hyper Media NHK Zoku Kiso Eigo: Dai-2-kan                     CSK Research Institute (CRI)      1991/7     SET(CD+FD)
-Hyper Media NHK Zoku Kiso Eigo: Dai-3-kan                     CSK Research Institute (CRI)      1991/9     SET(CD+FD)
+* Hyper Media NHK Zoku Kiso Eigo: Dai-3-kan                   CSK Research Institute (CRI)      1991/9     SET(CD+FD)
 Hyper Note                                                    Datt Japan                        1991/12    SET(CD+FD)
 Hyper Photo DB                                                Fujitsu                           1993/9     CD
 Hyper Planet                                                  Datt Japan                        1990/9     SET(CD+FD)
@@ -342,6 +344,8 @@ Jouhou Gijutsu Yougo Shuu CD-ROM                              Fujitsu           
 JYB                                                           Cocktail Soft                     1993/4     CD
 Kadokawa Ruigo Shin Jiten CD-ROM                              Fujitsu                           1989/12    CD
 Kamigami no Daichi: Kojiki Gaiden                             Koei                              1993/10    SET(CD+FD)
+Kamimura Kei no Sexy Resort                                   Pink Elephant                     1992/9     CD
+Kamimura Kei no Sexy Telephone                                Pink Elephant                     1992/9     CD
 Kamiya Recliet Towns                                          Raison                            1990/10    CD
 Kanade V1.1                                                   Fujitsu                           1995/4     CD
 Kanji Hitsujun Soft Nazoraa 2                                 Infortech                         1994/5     CD
@@ -372,6 +376,9 @@ Koujien Daiyonban CD-ROM                                      Fujitsu           
 Kouryuuki                                                     Koei                              1993/10    SET(CD+FD)
 Kousoku Choujin                                               Foster                            1996/8     CD
 Kusuriyubi no Kyoukasho                                       Active                            1996/4     CD
+Kyouiku & FM Towns Vol. 1                                     Fujitsu                           ?          CD
+Kyouiku & FM Towns Vol. 2                                     Fujitsu                           ?          CD
+Kyouiku & FM Towns Vol. 3                                     Fujitsu                           ?          CD
 Kyouko no Ijiwaru!! Hachamecha Daishingeki                    Ponytail Soft                     1994/10    CD
 Lemon Cocktail Collection                                     Cocktail Soft                     1993/3     CD
 L'Empereur                                                    Koei                              1991/1     SET(CD+FD)
@@ -501,7 +508,7 @@ Nihongo Nyuumon Dai-4-kan                                     Infortech         
 Nihongo Nyuumon Dai-5-kan                                     Infortech                         1991/4     CD
 Nijiiro Denshoku Musume                                       ISC                               1994/8     CD
 Niko^2                                                        Wolf Team                         1991/11    CD
-Nobunaga no Yabou: Sengoku Gun'yuuden                         Koei                              1989/12    SET(CD+FD)
+* Nobunaga no Yabou: Sengoku Gun'yuuden                       Koei                              1989/12    SET(CD+FD)
 * Nobunaga no Yabou: Tenshouki                                Koei                              1995/3     SET(CD+FD)
 Nooch: Abakareta Inbou                                        Bombee Bonbon                     1992/11    ?
 Nostalgia 1907                                                Sur de Wave                       1992/5     CD
@@ -557,6 +564,7 @@ Robin Hood                                                    DynEd Japan       
 Rockpaedia Vol. 2: 1961-1970                                  Toshiba EMI                       ?          CD
 Round the World in 80 Days                                    DynEd Japan                       1993/12    SET(CD+FD)
 Royal Blood                                                   Koei                              1992/5     SET(CD+FD)
+S-DAPS Demo CD [DWDC492]                                      Data West                         1994/?     CD
 Saishin American Idiom Jiten                                  Sanshusha                         1990/2     CD
 Saishin Igaku Daijiten CD-ROM                                 Fujitsu                           1990/5     CD
 Saishin Igaku Daijiten Standard-ban CD-ROM                    Fujitsu                           1993/2     CD
@@ -588,7 +596,6 @@ Sexy PK World Cup Ban                                         Birdy Soft        
 Shakaika Database: Nihon no Bunka / Sangyou / Shizen          Nihon Kyouiku System              1991/12    CD
 Shamhat: The Holy Circlet                                     Data West                         1993/4     SET(CD+FD)
 Shamhat: The Holy Circlet (Marty-ban)                         Data West                         1993/4     SET(CD+FD)
-Shanghai                                                      ASCII                             1990/12    CD
 Shanghai: Banri no Choujou                                    Electronic Arts Victor            1995/9     CD
 Shijou Saikyou no Video Bible                                 System Sacom                      1989/12    CD
 Shiki wo Irodoru Nihon no Shouka: Aki-hen                     Toshiba EMI                       1991/10    CD
@@ -658,12 +665,12 @@ Teo: Mou Hitotsu no Chikyuu Ver. 2                            Fujitsu Parex     
 Tera Towns                                                    Nihon Micom Hanbai                1989/5     CD
 Tera Towns 2                                                  Nihon Micom Hanbai                1993/4     CD
 That's Toukou                                                 Birdy Soft                        1993/12    CD
+The 4th Unit Series: Wyatt (Demo-you Disc) [DWFT2901+         Data West                         1992/?     SET(CD+FD)
 The Book of MIDI                                              Fujitsu                           1992/9     CD
 The Lost Secret                                               DynEd Japan                       1993/7     SET(CD+FD)
 The Manhole 2                                                 Sun Denshi                        1993/5     ?
 The Playroom                                                  Fujitsu                           1995/2     CD
 The Sea in Your Eyes: Umi wo Mitsumete                        Inter Limited Logic               1995/4     CD
-* The Visitor                                                   Fujitsu                           1989/9     CD
 The Yachtman                                                  Raison                            1989/11    CD
 Theme Park                                                    Electronic Arts Victor            1995/9     CD
 Think Read: Chuugaku Series                                   Catena                            ?          SET(CD+FD)
@@ -682,10 +689,15 @@ Towns Cruising Chart                                          Raison            
 Towns E to Oto de Manabu Suugaku                              Rand Computer                     1993/3     CD
 Towns Family Genki Yohou                                      Kozu System                       1990/12    CD
 Towns Magazine Vol. 3                                         Fujitsu                           1995/4     CD×02
+Towns Magazine for School Vol. 4                              Fujitsu                           ?          CD
 Towns Meikyoku Master                                         Fujitsu Ooita Software Laboratory 1991/9     CD
 Towns Meikyoku Master (Marty-compatible)                      Fujitsu Ooita Software Laboratory 1993/3     CD
 Towns Spirit                                                  Uchida Youkou                     1993/4     CD
 Towns Spirit                                                  Uchida Youkou                     1993/4     CD
+Towns System Software V2.1 L20                                Fujitsu                           ?          CD
+Towns System Software V2.1 L30                                Fujitsu                           ?          CD
+Towns System Software V2.1 L31                                Fujitsu                           ?          CD
+Towns System Software V2.1 L40                                Fujitsu                           ?          CD
 Towns Telop                                                   Lambda System                     1989/5     SET(CD+FD)
 TownsFullcolor V1.1                                           Fujitsu                           1993/3     CD
 TownsFullcolor V2.1                                           Fujitsu                           1994/12    CD
@@ -707,8 +719,6 @@ True Heart                                                    Cocktail Soft     
 Tsubo Relaxation                                              Fujitsu Personal Computer Systems 1994/9     CD
 Twinkle Star                                                  Studio Twinkle                    1993/7     CD
 Two Shot Diary                                                Mink                              1994/10    CD
-Uemura Kei no Sexy Resort                                     Pink Elephant                     1992/9     CD
-Uemura Kei no Sexy Telephone                                  Pink Elephant                     1992/9     CD
 Ujibushi no Chiiku Game                                       Nihon Keisoku Souchi              1994/4     CD
 Unmei no Tobira                                               Fujitsu                           1992/9     CD
 URM: 15 Wakusei ni Umarete                                    Japan Home Video (JHV)            1994/12    CD
@@ -1041,30 +1051,6 @@ User/save disks that can be created from the game itself are not included.
 		</part>
 	</software>
 
-	<!-- Missing a floppy disk -->
-	<software name="win31l11" supported="no">
-		<!--
-		 Origin: Neo Kobe Collection
-		 <rom name="[OS] Windows 3.1 L11 (Track 1).bin" size="210974400" crc="f1c0baee" sha1="b6b3a75c06dda9f2c7df10703b2640871db84d34"/>
-		 <rom name="[OS] Windows 3.1 L11 (Track 2).bin" size="24296160" crc="84ca1c64" sha1="a5a76ce4664e31a431f0ede7fb595f68f91ea70e"/>
-		 <rom name="[OS] Windows 3.1 L11 (Track 3).bin" size="33280800" crc="c715fa2a" sha1="d1f949e98d6721569224f487662b4be4379930d1"/>
-		 <rom name="[OS] Windows 3.1 L11 (Track 4).bin" size="31203984" crc="ddc80416" sha1="e416686251a310ca37ab28d71422aa0a4b8aad5c"/>
-		 <rom name="[OS] Windows 3.1 L11 (Track 5).bin" size="33687696" crc="6dc2adb0" sha1="f15fbaa51ef779119ea20c2559b2942e0d660bea"/>
-		 <rom name="[OS] Windows 3.1 L11 (Track 6).bin" size="24484320" crc="6003c48f" sha1="06cf72ab1a8a97967cf505ebf63ababeb253f64d"/>
-		 <rom name="[OS] Windows 3.1 L11 (Track 7).bin" size="66366384" crc="14c119e5" sha1="f5fc90b31f35f2fff7fe2a71f66359baecb047dc"/>
-		 <rom name="[OS] Windows 3.1 L11 (Track 8).bin" size="41049456" crc="7ac70a73" sha1="a51becc2bb7686925441a2538f238aa151807006"/>
-		 <rom name="[OS] Windows 3.1 L11.cue" size="894" crc="ab55a50e" sha1="3abf8be459bea341e253641bd230091fa6b2d02d"/>
-		 -->
-		<description>Windows 3.1 L11</description>
-		<year>1994</year>
-		<publisher>Microsoft</publisher>
-		<part name="cdrom" interface="fmt_cdrom">
-			<diskarea name="cdrom">
-				<disk name="[os] windows 3.1 l11" sha1="94c9b88833a6ea2f39167981cdc45ed0ce407ecd" />
-			</diskarea>
-		</part>
-	</software>
-
 	<software name="win31l12">
 		<!--
 		 Origin: redump.org
@@ -1091,6 +1077,31 @@ User/save disks that can be created from the game itself are not included.
 			<feature name="part_id" value="Setup CD-ROM" />
 			<diskarea name="cdrom">
 				<disk name="microsoft windows version 3.1 l12 operating system (japan) (setup cd-rom)" sha1="6fc77133989a78df696cded58f0a96b5990a85c4" />
+			</diskarea>
+		</part>
+	</software>
+
+	<!-- Missing a floppy disk -->
+	<software name="win31l11" cloneof="win31l12" supported="no">
+		<!--
+		 Origin: Neo Kobe Collection
+		 <rom name="[OS] Windows 3.1 L11 (Track 1).bin" size="210974400" crc="f1c0baee" sha1="b6b3a75c06dda9f2c7df10703b2640871db84d34"/>
+		 <rom name="[OS] Windows 3.1 L11 (Track 2).bin" size="24296160" crc="84ca1c64" sha1="a5a76ce4664e31a431f0ede7fb595f68f91ea70e"/>
+		 <rom name="[OS] Windows 3.1 L11 (Track 3).bin" size="33280800" crc="c715fa2a" sha1="d1f949e98d6721569224f487662b4be4379930d1"/>
+		 <rom name="[OS] Windows 3.1 L11 (Track 4).bin" size="31203984" crc="ddc80416" sha1="e416686251a310ca37ab28d71422aa0a4b8aad5c"/>
+		 <rom name="[OS] Windows 3.1 L11 (Track 5).bin" size="33687696" crc="6dc2adb0" sha1="f15fbaa51ef779119ea20c2559b2942e0d660bea"/>
+		 <rom name="[OS] Windows 3.1 L11 (Track 6).bin" size="24484320" crc="6003c48f" sha1="06cf72ab1a8a97967cf505ebf63ababeb253f64d"/>
+		 <rom name="[OS] Windows 3.1 L11 (Track 7).bin" size="66366384" crc="14c119e5" sha1="f5fc90b31f35f2fff7fe2a71f66359baecb047dc"/>
+		 <rom name="[OS] Windows 3.1 L11 (Track 8).bin" size="41049456" crc="7ac70a73" sha1="a51becc2bb7686925441a2538f238aa151807006"/>
+		 <rom name="[OS] Windows 3.1 L11.cue" size="894" crc="ab55a50e" sha1="3abf8be459bea341e253641bd230091fa6b2d02d"/>
+		 -->
+		<description>Windows 3.1 L11</description>
+		<year>1994</year>
+		<publisher>Microsoft</publisher>
+		<part name="cdrom" interface="fmt_cdrom">
+			<feature name="part_id" value="Setup CD-ROM" />
+			<diskarea name="cdrom">
+				<disk name="[os] windows 3.1 l11" sha1="94c9b88833a6ea2f39167981cdc45ed0ce407ecd" />
 			</diskarea>
 		</part>
 	</software>
@@ -1314,11 +1325,16 @@ User/save disks that can be created from the game itself are not included.
 
 	<software name="merrygor">
 		<!--
-		Origin: Neo Kobe Collection
-		<rom name="The 4th Unit 6 - Merry-Go-Round.ccd" size="2093" crc="89f0b60f" sha1="f2e333c26461c37345da764d215677123dbdbeb6"/>
-		<rom name="The 4th Unit 6 - Merry-Go-Round.cue" size="368" crc="b85eee45" sha1="58ff66afc2f5098eb4b200e78243bca00c201f2b"/>
-		<rom name="The 4th Unit 6 - Merry-Go-Round.img" size="306964224" crc="e02f30f9" sha1="860ce4bafc860974f711889c2ccb4eb81e0c45f8"/>
-		<rom name="The 4th Unit 6 - Merry-Go-Round.sub" size="12529152" crc="115531c6" sha1="7c90f76dc92aa503a5599d74226919f2c60b1c73"/>
+		Origin: redump.org
+		<rom name="4th Unit Series, The - MerryGoRound (Japan) (Track 1).bin" size="73382400" crc="78fb12bc" sha1="e655ced2aa9b9c76abf9bbedf16f92a981148ceb"/>
+		<rom name="4th Unit Series, The - MerryGoRound (Japan) (Track 2).bin" size="5694192" crc="541f8932" sha1="3634ff039fe34ab1a26502fa65a89c4b4c4fd8e2"/>
+		<rom name="4th Unit Series, The - MerryGoRound (Japan) (Track 3).bin" size="15337392" crc="68b0f570" sha1="f04bb5f45a6f2cdd02e23fb104eaf0c1bef31376"/>
+		<rom name="4th Unit Series, The - MerryGoRound (Japan) (Track 4).bin" size="44831472" crc="b688810f" sha1="025c375604cdf47b88d4ca77efc1f9539c98c2a8"/>
+		<rom name="4th Unit Series, The - MerryGoRound (Japan) (Track 5).bin" size="31747296" crc="eff037a3" sha1="0932eea70e7bb4f919f12f6850b0d8f6c51c5a39"/>
+		<rom name="4th Unit Series, The - MerryGoRound (Japan) (Track 6).bin" size="49907088" crc="8f081075" sha1="abbde33eef04c73ebcb0ac96566a64f0453fb4e2"/>
+		<rom name="4th Unit Series, The - MerryGoRound (Japan) (Track 7).bin" size="40581408" crc="8cfa9046" sha1="bceb59b4848c85024eb16fd6ade075c8ba293ea1"/>
+		<rom name="4th Unit Series, The - MerryGoRound (Japan) (Track 8).bin" size="45482976" crc="ad34c312" sha1="7d603961bc0f77596ac705436af2a74f42c9dc7f"/>
+		<rom name="4th Unit Series, The - MerryGoRound (Japan).cue" size="1101" crc="6e3235af" sha1="8c429972b21f184797e89b657ace60f2f054b99d"/>
 		-->
 		<description>The 4th Unit 6 - Merry-Go-Round</description>
 		<year>1990</year>
@@ -1326,7 +1342,7 @@ User/save disks that can be created from the game itself are not included.
 		<info name="release" value="199012xx" />
 		<part name="cdrom" interface="fmt_cdrom">
 			<diskarea name="cdrom">
-				<disk name="the 4th unit 6 - merry-go-round" sha1="d254d7670bc2bdd396320aac687dba12906d49e2" />
+				<disk name="4th unit series, the - merrygoround (japan)" sha1="68d99ab70038c78b95d7d229a185ab5eea0d4073" />
 			</diskarea>
 		</part>
 	</software>
@@ -1613,22 +1629,40 @@ User/save disks that can be created from the game itself are not included.
 		</part>
 	</software>
 
-	<!-- Seems to be missing a floppy disk -->
-	<software name="airwar" supported="no">
+	<!-- Missing a floppy disk -->
+	<software name="airwar12" supported="no">
 		<!--
-		Origin: Neo Kobe Collection
-		<rom name="Fujitsu Air Warrior v1.1.ccd" size="903" crc="a5a83861" sha1="d8ded0b27ee1dfa2eada1f60433a8018d55fea36"/>
-		<rom name="Fujitsu Air Warrior v1.1.cue" size="170" crc="27c279a2" sha1="e5b13789e3b6f10864adbcf24dc1deeb9e183441"/>
-		<rom name="Fujitsu Air Warrior v1.1.img" size="32457600" crc="d7d942d7" sha1="5840ed26456b4dd0581efb3b8af7d4eb22057c7b"/>
-		<rom name="Fujitsu Air Warrior v1.1.sub" size="1324800" crc="131d530e" sha1="b81408e4a5c53f90de9d3f3355b4d806e4564d73"/>
+		Origin: redump.org
+		<rom name="Fujitsu Air Warrior V1.2 (Japan) (Track 1).bin" size="20815200" crc="f3a20852" sha1="2c09fa527fe06258103728e1fbbd01479b491c92"/>
+		<rom name="Fujitsu Air Warrior V1.2 (Japan) (Track 2).bin" size="22226400" crc="4eba18c7" sha1="bb4246ec0f99b0fca8c1d88f48b252e5fc63e2be"/>
+		<rom name="Fujitsu Air Warrior V1.2 (Japan).cue" size="234" crc="a3cbda9a" sha1="c2cc0bd45a8e2168a2f0ba513da529bc6f05ae54"/>
 		-->
-		<description>Air Warrior</description>
+		<description>Air Warrior V1.2</description>
+		<year>1993</year>
+		<publisher>富士通 (Fujitsu)</publisher>
+		<info name="release" value="199311xx" />
+		<part name="cdrom" interface="fmt_cdrom">
+			<diskarea name="cdrom">
+				<disk name="fujitsu air warrior v1.2 (japan)" sha1="cf653365d5ed02479885775d5e470f42d3cdc285" />
+			</diskarea>
+		</part>
+	</software>
+
+	<!-- Missing a floppy disk -->
+	<software name="airwar11" supported="no" cloneof="airwar12">
+		<!--
+		Origin: redump.org
+		<rom name="Fujitsu Air Warrior V1.1 (Japan) (Track 1).bin" size="10231200" crc="8ef3f105" sha1="ba8206707bd298bcf42ad401f22548c0461c59df"/>
+		<rom name="Fujitsu Air Warrior V1.1 (Japan) (Track 2).bin" size="22226400" crc="54edf4ee" sha1="8e4ce19d9ef4364e4e270e657e97d20931a640f0"/>
+		<rom name="Fujitsu Air Warrior V1.1 (Japan).cue" size="234" crc="42897fcb" sha1="a99fff4595e1c4d58d0763db8ab20213e56bbe89"/>
+		-->
+		<description>Air Warrior V1.1</description>
 		<year>1992</year>
 		<publisher>富士通 (Fujitsu)</publisher>
 		<info name="release" value="199203xx" />
 		<part name="cdrom" interface="fmt_cdrom">
 			<diskarea name="cdrom">
-				<disk name="fujitsu air warrior v1.1" sha1="9433549ab48af8471d308070548a65fd3ba3304d" />
+				<disk name="fujitsu air warrior v1.1 (japan)" sha1="3dc6a3ed33a1e2a061a3390853f16883ffc87835" />
 			</diskarea>
 		</part>
 	</software>
@@ -2678,6 +2712,43 @@ User/save disks that can be created from the game itself are not included.
 		</part>
 	</software>
 
+	<!-- Hangs after the mission intro -->
+	<software name="chasehqd" supported="no">
+		<!--
+		Origin: redump.org
+		<rom name="Taito Chase H.Q. (Japan) (Demo) (Track 01).bin" size="10231200" crc="9de3d763" sha1="1f1cbbc7bd2bdc4a7472cf8906bc112992028239"/>
+		<rom name="Taito Chase H.Q. (Japan) (Demo) (Track 02).bin" size="13053600" crc="db390cc2" sha1="fe2d74a4f3692c4677e012823832db0992adb277"/>
+		<rom name="Taito Chase H.Q. (Japan) (Demo) (Track 03).bin" size="15699600" crc="aa16ae29" sha1="a657c15a2a2ec32d3916d0dfa8d32b3b82f6062f"/>
+		<rom name="Taito Chase H.Q. (Japan) (Demo) (Track 04).bin" size="13230000" crc="71f1729c" sha1="ea86c0986c80e7a10dc5caa69349e83554a69fa2"/>
+		<rom name="Taito Chase H.Q. (Japan) (Demo) (Track 05).bin" size="10936800" crc="4de35a05" sha1="d4f4ca0d9026502fb0f30a52e67a59d1be316545"/>
+		<rom name="Taito Chase H.Q. (Japan) (Demo) (Track 06).bin" size="11113200" crc="5c35ad41" sha1="02a6e314956f1a981709613264d639f6f60b447e"/>
+		<rom name="Taito Chase H.Q. (Japan) (Demo) (Track 07).bin" size="10584000" crc="1afac5da" sha1="3afe1af6feeaea30cdd3e2ff1a498f4bfe300172"/>
+		<rom name="Taito Chase H.Q. (Japan) (Demo) (Track 08).bin" size="7761600" crc="ada7ae70" sha1="b6f9632b4d106aba29e6b5199cf62b781ceafbf6"/>
+		<rom name="Taito Chase H.Q. (Japan) (Demo) (Track 09).bin" size="12171600" crc="03df7ee4" sha1="35a067958aafbba2e8218d69d2403900bd69e627"/>
+		<rom name="Taito Chase H.Q. (Japan) (Demo) (Track 10).bin" size="13230000" crc="53b725aa" sha1="4bff463d3b7a57f3a53162f9cdc2e890ea7fdcb8"/>
+		<rom name="Taito Chase H.Q. (Japan) (Demo) (Track 11).bin" size="10936800" crc="4e02dc58" sha1="4621eadb70f96ab706f7a72c0d9dac205a5bec2e"/>
+		<rom name="Taito Chase H.Q. (Japan) (Demo) (Track 12).bin" size="4586400" crc="e3b05f13" sha1="abecca9000a0b0e055e89439b28f297e66db4d11"/>
+		<rom name="Taito Chase H.Q. (Japan) (Demo) (Track 13).bin" size="23990400" crc="4456a80e" sha1="0bc6eb6ad69037550b293b33a8519fc75167d881"/>
+		<rom name="Taito Chase H.Q. (Japan) (Demo) (Track 14).bin" size="1940400" crc="ac9b71d5" sha1="4480ba28a292fb981a590c19823258fbf53a8851"/>
+		<rom name="Taito Chase H.Q. (Japan) (Demo) (Track 15).bin" size="9172800" crc="4058ffd3" sha1="97344def98299156fb2487b9ab45d0ce42949087"/>
+		<rom name="Taito Chase H.Q. (Japan) (Demo) (Track 16).bin" size="7056000" crc="f67fceec" sha1="3b9ad43da62726182fd4aa38e4eb3b4f914ab40c"/>
+		<rom name="Taito Chase H.Q. (Japan) (Demo) (Track 17).bin" size="58388400" crc="4b16c7eb" sha1="89b88992159f3c4bc293dc8d8e539f4adb2b561b"/>
+		<rom name="Taito Chase H.Q. (Japan) (Demo) (Track 18).bin" size="35985600" crc="ed161821" sha1="e040fa55568fc05840c994baf4182ad823bb01a4"/>
+		<rom name="Taito Chase H.Q. (Japan) (Demo) (Track 19).bin" size="50450400" crc="c8033de0" sha1="d675677156417f39250214d094ce326f6108c5d0"/>
+		<rom name="Taito Chase H.Q. (Japan) (Demo).cue" size="2376" crc="1deb1062" sha1="7beed6f34758f64745cf9439f8b6f50ac841e0f0"/>
+		-->
+		<description>Taito Chase H.Q. (Demo)</description>
+		<year>1991</year>
+		<publisher>ビング (Ving)</publisher>
+		<info name="alt_title" value="TAITO チェイスＨＱ" />
+		<info name="release" value="1991xxxx" />
+		<part name="cdrom" interface="fmt_cdrom">
+			<diskarea name="cdrom">
+				<disk name="taito chase h.q. (japan) (demo)" sha1="531f1102be4e13ac9e8a90a040bb706ae9a2d12f" />
+			</diskarea>
+		</part>
+	</software>
+
 	<software name="chuumon">
 		<!--
 		Origin: P2P
@@ -3535,9 +3606,16 @@ User/save disks that can be created from the game itself are not included.
 
 	<software name="drgshock">
 		<!--
-		Origin: P2P
-		<rom name="Image.cue" size="381" crc="5bf84c71" sha1="a16d98615fb735b3e2f54e78c98159c6d7a137cd"/>
-		<rom name="Image.img" size="235011840" crc="c0c9d26f" sha1="6acfa1aa858f9cbbd1afea603af8af9b03236cda"/>
+		Origin: redump.org
+		<rom name="Dragon Shock (Japan) (Track 1).bin" size="3015264" crc="31baaa36" sha1="b07a15fb2580127057cd1c21d60964a2ef47b397"/>
+		<rom name="Dragon Shock (Japan) (Track 2).bin" size="3128160" crc="e0a7976f" sha1="d7d40feac004a2fc5791f6001d1295c56005636c"/>
+		<rom name="Dragon Shock (Japan) (Track 3).bin" size="39085536" crc="d6d669ef" sha1="a72211eefa615874dc4751f7fe45164c9e37551c"/>
+		<rom name="Dragon Shock (Japan) (Track 4).bin" size="34927200" crc="87a8024d" sha1="f3e120decf2498e5acad4681ff7ef0dc1d0ac53c"/>
+		<rom name="Dragon Shock (Japan) (Track 5).bin" size="51896880" crc="05a4dc45" sha1="2e0f15d0a868b6c184ed348abe9a26e6b47972f3"/>
+		<rom name="Dragon Shock (Japan) (Track 6).bin" size="39659424" crc="dd7acae1" sha1="f76cd967ecf1ed29ba5e05e85d55dfc6c7b5c7f3"/>
+		<rom name="Dragon Shock (Japan) (Track 7).bin" size="59418576" crc="e8e85b9f" sha1="4e3c4e1868b74baaaffc936cb0f987450043aa5d"/>
+		<rom name="Dragon Shock (Japan) (Track 8).bin" size="3880800" crc="56903d96" sha1="5baa34fe7687fe35e2b20baa307180850335bb07"/>
+		<rom name="Dragon Shock (Japan).cue" size="894" crc="d370a7a1" sha1="2b50567dcc852d82037f905a5164a20bd5edaff9"/>
 		-->
 		<description>Dragon Shock</description>
 		<year>1989</year>
@@ -3546,7 +3624,7 @@ User/save disks that can be created from the game itself are not included.
 		<info name="release" value="198911xx" />
 		<part name="cdrom" interface="fmt_cdrom">
 			<diskarea name="cdrom">
-				<disk name="drgshock" sha1="3cce3b9b985d523593d26ac7cf3040160df57aec" />
+				<disk name="dragon shock (japan)" sha1="d47577ee4bf566ad6b2fc51fc59a53600152be24" />
 			</diskarea>
 		</part>
 	</software>
@@ -4104,11 +4182,13 @@ User/save disks that can be created from the game itself are not included.
 
 	<software name="finalb">
 		<!--
-		Origin: Neo Kobe Collection
-		<rom name="Final Blow.ccd" size="1564" crc="5ecbb5e2" sha1="47d04eb6684c6f30fdbe50efe0f74705d975f653"/>
-		<rom name="Final Blow.cue" size="261" crc="70f06ea6" sha1="49a494578327d84b5801d1155fa8d24e0b6e84ec"/>
-		<rom name="Final Blow.img" size="248371200" crc="be352006" sha1="85df88e70eeb9467e8872d46041d1906c2880057"/>
-		<rom name="Final Blow.sub" size="10137600" crc="8ecea4ba" sha1="b23f0a830a2ce9d760cdda107bb7bce3ea89201e"/>
+		Origin: redump.org
+		<rom name="Final Blow (Japan) (Track 1).bin" size="10584000" crc="c0a5aaa2" sha1="5f7f7d208d7a20b08d01c805134e2078f7e0123c"/>
+		<rom name="Final Blow (Japan) (Track 2).bin" size="126302400" crc="a96520ab" sha1="c63b64e222287d486968cca6cab8023afacb5a5c"/>
+		<rom name="Final Blow (Japan) (Track 3).bin" size="32281200" crc="248970ae" sha1="9f08f37e207cf34c07b4b931c03819ec81ad3367"/>
+		<rom name="Final Blow (Japan) (Track 4).bin" size="29458800" crc="56e37ff0" sha1="7f262c50935e40a8dee07f5eda0204ec68e11051"/>
+		<rom name="Final Blow (Japan) (Track 5).bin" size="49744800" crc="591b2222" sha1="be9aa16e655b077631bb7b4b48773d9c47017212"/>
+		<rom name="Final Blow (Japan).cue" size="565" crc="b3e6c2a6" sha1="b0e54e262cf85eeb05c8b38e8f745cb575507b1a"/>
 		-->
 		<description>Final Blow</description>
 		<year>1990</year>
@@ -4117,7 +4197,7 @@ User/save disks that can be created from the game itself are not included.
 		<info name="release" value="199003xx" />
 		<part name="cdrom" interface="fmt_cdrom">
 			<diskarea name="cdrom">
-				<disk name="final blow" sha1="7f668c17d0b625888940ca896663b6591a15fa04" />
+				<disk name="final blow (japan)" sha1="8884cd2ba7b9d32bea083a15f222d79b06366874" />
 			</diskarea>
 		</part>
 	</software>
@@ -4496,6 +4576,29 @@ User/save disks that can be created from the game itself are not included.
 		<part name="cdrom" interface="fmt_cdrom">
 			<diskarea name="cdrom">
 				<disk name="freeware collection 3" sha1="60a1f6791c4304172f9b935fe61c736da6d6b3f6" />
+			</diskarea>
+		</part>
+	</software>
+
+	<!-- Missing a floppy disk -->
+	<software name="habitat" supported="no">
+		<!--
+		Origin: redump.org
+		<rom name="Fujitsu Habitat V2.1L10 (Japan) (Track 1).bin" size="101959200" crc="29a91a0f" sha1="ecff62e56a93cc5d357e012fe21f1ae6c9a2cf70"/>
+		<rom name="Fujitsu Habitat V2.1L10 (Japan) (Track 2).bin" size="47150544" crc="f61961ed" sha1="c89982352db456c812c486b59088656363cde992"/>
+		<rom name="Fujitsu Habitat V2.1L10 (Japan) (Track 3).bin" size="20551776" crc="7e452f3c" sha1="4a8fc3891643ffeff4ea74e4dbd50ad38cd29823"/>
+		<rom name="Fujitsu Habitat V2.1L10 (Japan) (Track 4).bin" size="41348160" crc="e9584558" sha1="64f765b0a12b79b6cff8d230a3ec60c50dc64661"/>
+		<rom name="Fujitsu Habitat V2.1L10 (Japan) (Track 5).bin" size="53148144" crc="2a6f67dc" sha1="6404d3e6218445db302055d068ac37b5404c0cf8"/>
+		<rom name="Fujitsu Habitat V2.1L10 (Japan).cue" size="607" crc="f6d04bc8" sha1="542e5319cdddd2148c7c5174c6012d533eb1e0f4"/>
+		-->
+		<description>Fujitsu Habitat V2.1L10</description>
+		<year>1994</year>
+		<publisher>富士通 (Fujitsu)</publisher>
+		<info name="alt_title" value="富士通 Habitat V2.1L10" />
+		<info name="release" value="199405xx" />
+		<part name="cdrom" interface="fmt_cdrom">
+			<diskarea name="cdrom">
+				<disk name="fujitsu habitat v2.1l10 (japan)" sha1="5704f482ca0bb17e0a01f82bfc4ea272a7534bda" />
 			</diskarea>
 		</part>
 	</software>
@@ -5175,6 +5278,79 @@ User/save disks that can be created from the game itself are not included.
 		<part name="cdrom" interface="fmt_cdrom">
 			<diskarea name="cdrom">
 				<disk name="hyper address" sha1="0b71c0bea2d66cf60f6c37cabc9284be794ff5cb" />
+			</diskarea>
+		</part>
+	</software>
+
+	<!-- Missing a floppy disk -->
+	<software name="nhkzkei3" supported="no">
+		<!--
+		Origin: redump.org
+		<rom name="Hyper Media NHK Zoku Kiso Eigo - Dai-3-kan (Japan) (Track 01).bin" size="104958000" crc="290cead4" sha1="bde72d367b1cf28f700208679b122ac9f06be903"/>
+		<rom name="Hyper Media NHK Zoku Kiso Eigo - Dai-3-kan (Japan) (Track 02).bin" size="4539360" crc="a23e111e" sha1="bb4df57de991012cb112853087a212addb2fa3f3"/>
+		<rom name="Hyper Media NHK Zoku Kiso Eigo - Dai-3-kan (Japan) (Track 03).bin" size="9090480" crc="25799205" sha1="f3121edca1f8c01b7524944e719f85641ea1a594"/>
+		<rom name="Hyper Media NHK Zoku Kiso Eigo - Dai-3-kan (Japan) (Track 04).bin" size="8486016" crc="6642a5b1" sha1="ceac40b7f2dac5eb93c9c21eda12ccf70f23d6d2"/>
+		<rom name="Hyper Media NHK Zoku Kiso Eigo - Dai-3-kan (Japan) (Track 05).bin" size="9765504" crc="13c0a13b" sha1="762f1a7f13744bbc9c0239e98e67c1c9f66eed5b"/>
+		<rom name="Hyper Media NHK Zoku Kiso Eigo - Dai-3-kan (Japan) (Track 06).bin" size="10038336" crc="d0676e9e" sha1="11b2dc575acad7bfec5dc080f05c251fb409eab8"/>
+		<rom name="Hyper Media NHK Zoku Kiso Eigo - Dai-3-kan (Japan) (Track 07).bin" size="8667120" crc="b194ffb7" sha1="d155cf276d2f2d07c3e4604f23999f008159219e"/>
+		<rom name="Hyper Media NHK Zoku Kiso Eigo - Dai-3-kan (Japan) (Track 08).bin" size="9201024" crc="16eea7db" sha1="77601bbaa2704cb12bf5b7fe9735a70d55d00228"/>
+		<rom name="Hyper Media NHK Zoku Kiso Eigo - Dai-3-kan (Japan) (Track 09).bin" size="10278240" crc="df3a9c1c" sha1="c689ba909110dc309e24adb1b5279b1dc9cbde3f"/>
+		<rom name="Hyper Media NHK Zoku Kiso Eigo - Dai-3-kan (Japan) (Track 10).bin" size="9302160" crc="efb560e2" sha1="90aed734b8fc9a431f8e440c780a21f50941b255"/>
+		<rom name="Hyper Media NHK Zoku Kiso Eigo - Dai-3-kan (Japan) (Track 11).bin" size="9560880" crc="ea961dae" sha1="138f61478191a1ca0b9b2f7b52763f0e4e9291d5"/>
+		<rom name="Hyper Media NHK Zoku Kiso Eigo - Dai-3-kan (Japan) (Track 12).bin" size="10925040" crc="e512bb96" sha1="453667a76674d40ae2a9211e6c3f0981ce8b573c"/>
+		<rom name="Hyper Media NHK Zoku Kiso Eigo - Dai-3-kan (Japan) (Track 13).bin" size="9215136" crc="a6d2d733" sha1="dcc43effe96c762b6f019b5fbf5f3e1d4af59cb5"/>
+		<rom name="Hyper Media NHK Zoku Kiso Eigo - Dai-3-kan (Japan) (Track 14).bin" size="7796880" crc="2360914d" sha1="1f9175d2ce7c81b8929c925cd9f0c12778444d79"/>
+		<rom name="Hyper Media NHK Zoku Kiso Eigo - Dai-3-kan (Japan) (Track 15).bin" size="8690640" crc="2bdc06eb" sha1="ffd137d50974385f725ab56f01c30be0f876b447"/>
+		<rom name="Hyper Media NHK Zoku Kiso Eigo - Dai-3-kan (Japan) (Track 16).bin" size="7636944" crc="5cbef51e" sha1="41aa0fe17e3dc520044d4f888534224aaaf4af39"/>
+		<rom name="Hyper Media NHK Zoku Kiso Eigo - Dai-3-kan (Japan) (Track 17).bin" size="8838816" crc="36f786b8" sha1="b469a435990b8c93eac760942c9435545dff4bf4"/>
+		<rom name="Hyper Media NHK Zoku Kiso Eigo - Dai-3-kan (Japan) (Track 18).bin" size="9208080" crc="c23ff5fd" sha1="86fbc03a74cfe255b2a2f240522d6a2377a91bf7"/>
+		<rom name="Hyper Media NHK Zoku Kiso Eigo - Dai-3-kan (Japan) (Track 19).bin" size="9400944" crc="2113824f" sha1="a6350b2bb9a7a336ac430b327a6ca015b8717ded"/>
+		<rom name="Hyper Media NHK Zoku Kiso Eigo - Dai-3-kan (Japan) (Track 20).bin" size="9426816" crc="8cdce8e9" sha1="1ada90c6954baaded5716840ff85bd5c8261287b"/>
+		<rom name="Hyper Media NHK Zoku Kiso Eigo - Dai-3-kan (Japan) (Track 21).bin" size="7554624" crc="25387b5b" sha1="5aac5e49cdc9989751fc51013ea9bb6e0325598b"/>
+		<rom name="Hyper Media NHK Zoku Kiso Eigo - Dai-3-kan (Japan) (Track 22).bin" size="10696896" crc="1585d38e" sha1="d1a5964690aa8a1dac85a0049f3db6d2a753ee9e"/>
+		<rom name="Hyper Media NHK Zoku Kiso Eigo - Dai-3-kan (Japan) (Track 23).bin" size="9360960" crc="8ef8ddd3" sha1="1641803986f286a4d34a02c62f1d30c714b885f4"/>
+		<rom name="Hyper Media NHK Zoku Kiso Eigo - Dai-3-kan (Japan) (Track 24).bin" size="7455840" crc="b1da423d" sha1="b34ffc2bf76d84cc7ddb138e6323941910759678"/>
+		<rom name="Hyper Media NHK Zoku Kiso Eigo - Dai-3-kan (Japan) (Track 25).bin" size="9161040" crc="3f5f7f40" sha1="26f4a9e1d11ca3629b14b45584459930dea4e97c"/>
+		<rom name="Hyper Media NHK Zoku Kiso Eigo - Dai-3-kan (Japan) (Track 26).bin" size="9083424" crc="db6b33c5" sha1="4e0c23a5260dca4969b48596a618e893948ff973"/>
+		<rom name="Hyper Media NHK Zoku Kiso Eigo - Dai-3-kan (Japan) (Track 27).bin" size="9015216" crc="d0a68e4b" sha1="ad6ec1a3f47d11d0fea48379f5d430c3cb6f539e"/>
+		<rom name="Hyper Media NHK Zoku Kiso Eigo - Dai-3-kan (Japan) (Track 28).bin" size="8267280" crc="e74857d2" sha1="8c0e59380d07d8f2688d7279ffbb98f0d3398c0c"/>
+		<rom name="Hyper Media NHK Zoku Kiso Eigo - Dai-3-kan (Japan) (Track 29).bin" size="8349600" crc="d01d19c0" sha1="975529c705fb557e9fd385b3cfe690ec7a332979"/>
+		<rom name="Hyper Media NHK Zoku Kiso Eigo - Dai-3-kan (Japan) (Track 30).bin" size="9506784" crc="c86a5abe" sha1="3b07fd1b29f562ef14b256e1fb0d9788210c7dd5"/>
+		<rom name="Hyper Media NHK Zoku Kiso Eigo - Dai-3-kan (Japan) (Track 31).bin" size="9544416" crc="5c2a4b96" sha1="0be0060e06eb1b518e9f9da91336b02462d635a2"/>
+		<rom name="Hyper Media NHK Zoku Kiso Eigo - Dai-3-kan (Japan) (Track 32).bin" size="8549520" crc="d140892c" sha1="69162bc5c8ae13377939d08d88ead589d351961d"/>
+		<rom name="Hyper Media NHK Zoku Kiso Eigo - Dai-3-kan (Japan) (Track 33).bin" size="9807840" crc="9a7d27f6" sha1="f7a0410cb4536b0c7213f832085e4274251c3607"/>
+		<rom name="Hyper Media NHK Zoku Kiso Eigo - Dai-3-kan (Japan) (Track 34).bin" size="10282944" crc="35c0e387" sha1="12c700a6bd945a5d133a5aea2224f184fef9d57d"/>
+		<rom name="Hyper Media NHK Zoku Kiso Eigo - Dai-3-kan (Japan) (Track 35).bin" size="7843920" crc="64346a43" sha1="ee86fbda608459724215d1838aba12dde3ad6617"/>
+		<rom name="Hyper Media NHK Zoku Kiso Eigo - Dai-3-kan (Japan) (Track 36).bin" size="10654560" crc="b4f4f17c" sha1="acdd1b9b33042b2907d63ef885fdf58b4c410543"/>
+		<rom name="Hyper Media NHK Zoku Kiso Eigo - Dai-3-kan (Japan) (Track 37).bin" size="9231600" crc="5d3c3593" sha1="b6c4789b41d4ec1d1ab0bbda5569f69867f86cd1"/>
+		<rom name="Hyper Media NHK Zoku Kiso Eigo - Dai-3-kan (Japan) (Track 38).bin" size="9796080" crc="d4747fb1" sha1="da93d4abcc7950f833ca47adcf29aa42da8653be"/>
+		<rom name="Hyper Media NHK Zoku Kiso Eigo - Dai-3-kan (Japan) (Track 39).bin" size="8356656" crc="6707d879" sha1="e496a9386e37b7a282c90918427d210185d30e61"/>
+		<rom name="Hyper Media NHK Zoku Kiso Eigo - Dai-3-kan (Japan) (Track 40).bin" size="10035984" crc="d03570f7" sha1="26a81460685ce008411eba19033bb017d90d103e"/>
+		<rom name="Hyper Media NHK Zoku Kiso Eigo - Dai-3-kan (Japan) (Track 41).bin" size="10078320" crc="f184fe8d" sha1="82ee1e593db73ef2a6ff21e67e977be014ad396b"/>
+		<rom name="Hyper Media NHK Zoku Kiso Eigo - Dai-3-kan (Japan) (Track 42).bin" size="9090480" crc="2156ccc7" sha1="f5845378178b7175e7e4a0ad6855bb20f37d509d"/>
+		<rom name="Hyper Media NHK Zoku Kiso Eigo - Dai-3-kan (Japan) (Track 43).bin" size="9438576" crc="4c69bdfb" sha1="a6b828158708d012b1bda7cc53c5a543c963802c"/>
+		<rom name="Hyper Media NHK Zoku Kiso Eigo - Dai-3-kan (Japan) (Track 44).bin" size="9400944" crc="10e3a558" sha1="df5656b92f372ebf944c194e5691c40687d2b2d7"/>
+		<rom name="Hyper Media NHK Zoku Kiso Eigo - Dai-3-kan (Japan) (Track 45).bin" size="9003456" crc="14320b70" sha1="523c61021834e7cf1f14d0fb0924e7366100b60a"/>
+		<rom name="Hyper Media NHK Zoku Kiso Eigo - Dai-3-kan (Japan) (Track 46).bin" size="10671024" crc="070a3421" sha1="39da0a004dcafd3902f4c58a0ca578106813676f"/>
+		<rom name="Hyper Media NHK Zoku Kiso Eigo - Dai-3-kan (Japan) (Track 47).bin" size="9137520" crc="eaaf49d9" sha1="d046a88177aca5329377eb792ae588f6c08a0683"/>
+		<rom name="Hyper Media NHK Zoku Kiso Eigo - Dai-3-kan (Japan) (Track 48).bin" size="9102240" crc="f53b6a6d" sha1="ba2616bda3356d964913a96e84d1e2415ccf9951"/>
+		<rom name="Hyper Media NHK Zoku Kiso Eigo - Dai-3-kan (Japan) (Track 49).bin" size="9262176" crc="49bf0ff3" sha1="2f52289b39658179b218eac751013c2f44dd4b53"/>
+		<rom name="Hyper Media NHK Zoku Kiso Eigo - Dai-3-kan (Japan) (Track 50).bin" size="11188464" crc="478919a1" sha1="a2f233afd331f53ba559d8aab784f8d0e19da09e"/>
+		<rom name="Hyper Media NHK Zoku Kiso Eigo - Dai-3-kan (Japan) (Track 51).bin" size="9219840" crc="954c4bfc" sha1="036a4e64a1d4ea53d8a14f55ec11959da17a5067"/>
+		<rom name="Hyper Media NHK Zoku Kiso Eigo - Dai-3-kan (Japan) (Track 52).bin" size="9156336" crc="443ed205" sha1="e8a03165f8f60572b7a1ac4cc7271b67b97d2e3a"/>
+		<rom name="Hyper Media NHK Zoku Kiso Eigo - Dai-3-kan (Japan) (Track 53).bin" size="8996400" crc="b82b8840" sha1="5ee3bc5d0dbea9997af84baf27595e500daf00db"/>
+		<rom name="Hyper Media NHK Zoku Kiso Eigo - Dai-3-kan (Japan) (Track 54).bin" size="9400944" crc="8d1f5bb6" sha1="da467c08bddb66f70fe4c66851b5ff73b273665b"/>
+		<rom name="Hyper Media NHK Zoku Kiso Eigo - Dai-3-kan (Japan) (Track 55).bin" size="4798080" crc="bb0d770f" sha1="1773a9c2476d78eb9f756c15442635b5e1845f1b"/>
+		<rom name="Hyper Media NHK Zoku Kiso Eigo - Dai-3-kan (Japan).cue" size="6738" crc="f38a27bc" sha1="1fba9639405c71d8f50bcd35c9cbbf689895a5a1"/>
+		-->
+		<description>Hyper Media NHK Zoku Kiso Eigo - Dai-3-kan</description>
+		<year>1991</year>
+		<publisher>CRI</publisher>
+		<info name="alt_title" value="ハイパー・メディア　ＮＨＫ続基礎英語　第３巻" />
+		<info name="release" value="199109xx" />
+		<part name="cdrom" interface="fmt_cdrom">
+			<diskarea name="cdrom">
+				<disk name="hyper media nhk zoku kiso eigo - dai-3-kan (japan)" sha1="96613434cfe144c0e0c575fd63694cb97d7a3dec" />
 			</diskarea>
 		</part>
 	</software>
@@ -7380,16 +7556,15 @@ User/save disks that can be created from the game itself are not included.
 
 	<software name="msdet1">
 		<!--
-		Origin: Neo Kobe Collection
-		<rom name="Ms. Detective File #1 (Disc 1).ccd" size="772" crc="92ccce73" sha1="717957cf8f02b585c5845347035cafca1be9613c"/>
-		<rom name="Ms. Detective File #1 (Disc 1).cue" size="94" crc="e01954bd" sha1="b4c12503fed544c825aeb9686fa9d5702c8d0672"/>
-		<rom name="Ms. Detective File #1 (Disc 1).img" size="361540032" crc="bdea9ba7" sha1="dee4ab701aba51df0ebd635131f0b040d5ab81d9"/>
-		<rom name="Ms. Detective File #1 (Disc 1).sub" size="14756736" crc="d02e1e88" sha1="8aa6ebe48b95a36b725748eb43b92d3c90aef63c"/>
+		Origin: redump.org
+		<rom name="Ms. Detective File 1 - Iwami Ginzan Satsujin Jiken (Japan) (Disc 1).bin" size="361540032" crc="bdea9ba7" sha1="dee4ab701aba51df0ebd635131f0b040d5ab81d9"/>
+		<rom name="Ms. Detective File 1 - Iwami Ginzan Satsujin Jiken (Japan) (Disc 1).cue" size="133" crc="95759928" sha1="b33e3fdf96c42840574b57b4790a217a6c6ad0f8"/>
 
-		<rom name="Ms. Detective File #1 (Disc 2).ccd" size="1342" crc="618e62dc" sha1="a3af3639243f8c9a43d3c127302379d898420fc9"/>
-		<rom name="Ms. Detective File #1 (Disc 2).cue" size="211" crc="c15f1362" sha1="71a2bbb3406714f8092cf094c5046f30a3036abc"/>
-		<rom name="Ms. Detective File #1 (Disc 2).img" size="518860608" crc="6579dddc" sha1="a9920e6d9c65f7ff412358d27e8565c60c0786a8"/>
-		<rom name="Ms. Detective File #1 (Disc 2).sub" size="21177984" crc="56eac6c0" sha1="ca2dea4d6d25e269edb950b9b6c033755baf10ae"/>
+		<rom name="Ms. Detective File 1 - Iwami Ginzan Satsujin Jiken (Japan) (Disc 2) (Track 1).bin" size="370926864" crc="8d084f92" sha1="289cac34e8ef0d41278f23548704e820724cf4ac"/>
+		<rom name="Ms. Detective File 1 - Iwami Ginzan Satsujin Jiken (Japan) (Disc 2) (Track 2).bin" size="58082640" crc="f95a3b7b" sha1="adb97bc92f3ef4cdb9bcdba89e1f472e4450bdec"/>
+		<rom name="Ms. Detective File 1 - Iwami Ginzan Satsujin Jiken (Japan) (Disc 2) (Track 3).bin" size="38459904" crc="291ad684" sha1="d752c440cdf1df9e4b02d9c59084b7940a2997c3"/>
+		<rom name="Ms. Detective File 1 - Iwami Ginzan Satsujin Jiken (Japan) (Disc 2) (Track 4).bin" size="51391200" crc="d6fb361d" sha1="4bc4fb46af534734b26b181a3add23ad85424324"/>
+		<rom name="Ms. Detective File 1 - Iwami Ginzan Satsujin Jiken (Japan) (Disc 2).cue" size="626" crc="ae3cacf9" sha1="24e2d849d2f58f6e7318db824930ba18f7b8f308"/>
 		-->
 		<description>Ms. Detective File #1 - Iwami Ginzan Satsujin Jiken</description>
 		<year>1992</year>
@@ -7398,12 +7573,12 @@ User/save disks that can be created from the game itself are not included.
 		<info name="release" value="199209xx" />
 		<part name="cdrom1" interface="fmt_cdrom">
 			<diskarea name="cdrom">
-				<disk name="ms. detective file #1 (disc 1)" sha1="314bf8187639251ce93e7a8c83a805732079fe79" />
+				<disk name="ms. detective file 1 - iwami ginzan satsujin jiken (japan) (disc 1)" sha1="03832ac67feccbffbcbff33728aa654065fbb549" />
 			</diskarea>
 		</part>
 		<part name="cdrom2" interface="fmt_cdrom">
 			<diskarea name="cdrom">
-				<disk name="ms. detective file #1 (disc 2)" sha1="2d45728ab1f6204c308ab7dee657cbaaef137229" />
+				<disk name="ms. detective file 1 - iwami ginzan satsujin jiken (japan) (disc 2)" sha1="8a4034b01081630e80033b777951c876f41ebc34" />
 			</diskarea>
 		</part>
 	</software>
@@ -7827,6 +8002,33 @@ User/save disks that can be created from the game itself are not included.
 		<part name="cdrom" interface="fmt_cdrom">
 			<diskarea name="cdrom">
 				<disk name="nobunaga no yabou - haou-den" sha1="0e2f9b942ba4f72961fc7dd5c3c9678eaa24b12d" />
+			</diskarea>
+		</part>
+	</software>
+
+	<!-- Missing a floppy disk -->
+	<software name="nobuseng" supported="no">
+		<!--
+		Origin: redump.org
+		<rom name="Nobunaga no Yabou Sengoku Gunyuuden with Soundware (Japan) (Track 1).bin" size="6703200" crc="e4a8c745" sha1="f166a8081c7a818e2f15a9e34ec4337f6fc98f38"/>
+		<rom name="Nobunaga no Yabou Sengoku Gunyuuden with Soundware (Japan) (Track 2).bin" size="54020736" crc="5a9cc9d6" sha1="7025923f0428e329e78974a0f042a9a4ae2bc75c"/>
+		<rom name="Nobunaga no Yabou Sengoku Gunyuuden with Soundware (Japan) (Track 3).bin" size="45511200" crc="51bf3097" sha1="da1d39592c9fca50e22f4f43fc6ad6aeb593a9a2"/>
+		<rom name="Nobunaga no Yabou Sengoku Gunyuuden with Soundware (Japan) (Track 4).bin" size="20996304" crc="4565f777" sha1="c9145841dcc61ef82e4cbcd8f07a7d0756adf13a"/>
+		<rom name="Nobunaga no Yabou Sengoku Gunyuuden with Soundware (Japan) (Track 5).bin" size="45228960" crc="5e61cd97" sha1="70799d81f94f0f923e898bcec1182e90b54252b3"/>
+		<rom name="Nobunaga no Yabou Sengoku Gunyuuden with Soundware (Japan) (Track 6).bin" size="131154576" crc="9ad99b96" sha1="c271118f94c1ba8c08797405beae8f33ccdc799e"/>
+		<rom name="Nobunaga no Yabou Sengoku Gunyuuden with Soundware (Japan) (Track 7).bin" size="47310480" crc="1b2de9ec" sha1="3b564f0a4c9a557db399721711a607e6691f2ec6"/>
+		<rom name="Nobunaga no Yabou Sengoku Gunyuuden with Soundware (Japan) (Track 8).bin" size="47926704" crc="4ef0a401" sha1="8ebb43971ea880db200126a89755b4acf31be78a"/>
+		<rom name="Nobunaga no Yabou Sengoku Gunyuuden with Soundware (Japan) (Track 9).bin" size="52637760" crc="76bde1f6" sha1="39198aa3e6a66d66acdfe919b6acded7fa3cb826"/>
+		<rom name="Nobunaga no Yabou Sengoku Gunyuuden with Soundware (Japan).cue" size="1396" crc="6d910da2" sha1="0b979c5bde29b36c0f93be6d5fa4270cd8aa4987"/>
+		-->
+		<description>Nobunaga no Yabou - Sengoku Gun'yuuden</description>
+		<year>1989</year>
+		<publisher>光栄 (Koei)</publisher>
+		<info name="alt_title" value="信長の野望 戦国群雄伝" />
+		<info name="release" value="198912xx" />
+		<part name="cdrom" interface="fmt_cdrom">
+			<diskarea name="cdrom">
+				<disk name="nobunaga no yabou sengoku gunyuuden with soundware (japan)" sha1="8a11e96c4386f95cc4a0b1efb2bebd9df3f5523d" />
 			</diskarea>
 		</part>
 	</software>
@@ -8804,11 +9006,21 @@ User/save disks that can be created from the game itself are not included.
 
 	<software name="rance3">
 		<!--
-		Origin: Neo Kobe Collection
-		<rom name="Rance III.ccd" size="2638" crc="0a1e4485" sha1="67384f9138485517faf112481a36747a3b497f55"/>
-		<rom name="Rance III.cue" size="859" crc="ae02c816" sha1="407148f09963dff95153662a4f46c61379d00b0d"/>
-		<rom name="Rance III.img" size="602231952" crc="3f27e7f4" sha1="5d5f5ccf8e02eb4cfb75fef9c6c39e24e953dd1b"/>
-		<rom name="Rance III.sub" size="24580896" crc="5fd3a83c" sha1="ed46131da5956d324f4b68a1f3590c4ac6a4ad6f"/>
+		Origin: redump.org
+		<rom name="Rance III - Leazas Kanraku (Japan) (Track 01).bin" size="73735200" crc="98794ac4" sha1="b7851a328357d75eba55c43ebf7c6ca173b334ca"/>
+		<rom name="Rance III - Leazas Kanraku (Japan) (Track 02).bin" size="42867552" crc="67096bc4" sha1="31d9c9a55150630a0853e2188577ca4dcd463289"/>
+		<rom name="Rance III - Leazas Kanraku (Japan) (Track 03).bin" size="44100000" crc="00b856d9" sha1="a788a79f8cc583c8b8d3291354a87c21985924bf"/>
+		<rom name="Rance III - Leazas Kanraku (Japan) (Track 04).bin" size="44100000" crc="7c1a0f6a" sha1="59c03333b038b5190f6ce4d4f948f2292dedcdb9"/>
+		<rom name="Rance III - Leazas Kanraku (Japan) (Track 05).bin" size="42336000" crc="2c7f6ba5" sha1="518b0cf44560a1334ba113c0a85e07ab181a8133"/>
+		<rom name="Rance III - Leazas Kanraku (Japan) (Track 06).bin" size="43570800" crc="a541b5c5" sha1="3ad16111a22190e21ab6e1ab1c26389a18e79e4d"/>
+		<rom name="Rance III - Leazas Kanraku (Japan) (Track 07).bin" size="44100000" crc="758652e4" sha1="fcde50d6cdb93f47198990ab5096280640b2dcf2"/>
+		<rom name="Rance III - Leazas Kanraku (Japan) (Track 08).bin" size="44100000" crc="ff01bd85" sha1="7721c9d5894b38174a36f95362b22109d3c94b3b"/>
+		<rom name="Rance III - Leazas Kanraku (Japan) (Track 09).bin" size="44100000" crc="1239f907" sha1="5e9a5b3eb790fab0ca85ed41eaadfbaf53cea554"/>
+		<rom name="Rance III - Leazas Kanraku (Japan) (Track 10).bin" size="45158400" crc="4e0c95f5" sha1="662e5593bc24a07503df8c5c0ceaa56074fa2db5"/>
+		<rom name="Rance III - Leazas Kanraku (Japan) (Track 11).bin" size="44100000" crc="e880f95a" sha1="3d405ab14cf370e58ac70b3273ce7b40f15c7a46"/>
+		<rom name="Rance III - Leazas Kanraku (Japan) (Track 12).bin" size="45864000" crc="af28af74" sha1="02eb6dd4799dc4d1c844456b2f13ac0f2b31f0ac"/>
+		<rom name="Rance III - Leazas Kanraku (Japan) (Track 13).bin" size="44100000" crc="1da7545c" sha1="86d49b379b0f1949574651dbc15a141386802f4c"/>
+		<rom name="Rance III - Leazas Kanraku (Japan).cue" size="1682" crc="f3734b25" sha1="569bb9c172514b5a994828171c5d60f4e549dec9"/>
 		-->
 		<description>Rance III - Leazas Kanraku</description>
 		<year>1992</year>
@@ -8817,7 +9029,7 @@ User/save disks that can be created from the game itself are not included.
 		<info name="release" value="199205xx" />
 		<part name="cdrom" interface="fmt_cdrom">
 			<diskarea name="cdrom">
-				<disk name="rance iii" sha1="abe5a360f7a7871406d6f80a1744915f875fcadb" />
+				<disk name="rance iii - leazas kanraku (japan)" sha1="4442afdf642a95a6b6279f7b483dad893d0668c8" />
 			</diskarea>
 		</part>
 	</software>
@@ -9381,6 +9593,31 @@ User/save disks that can be created from the game itself are not included.
 		</part>
 	</software>
 
+	<software name="shanghai">
+		<!--
+		Origin: redump.org
+		<rom name="Shanghai (Japan) (Track 1).bin" size="20815200" crc="1757434c" sha1="c24280c843a73e512f7436a88fd997eeb781ff85"/>
+		<rom name="Shanghai (Japan) (Track 2).bin" size="1058400" crc="84d0c0aa" sha1="ed7a49d82c2cd7c0ba78874b8059329b9342e191"/>
+		<rom name="Shanghai (Japan) (Track 3).bin" size="43394400" crc="e849a3d6" sha1="47720002180a983c93c174f8a7eede9265584e9b"/>
+		<rom name="Shanghai (Japan) (Track 4).bin" size="10054800" crc="ba782ef3" sha1="d92b888a41975636a359c789c279c1b0d6326ec1"/>
+		<rom name="Shanghai (Japan) (Track 5).bin" size="42865200" crc="e4619410" sha1="c522c7039ff203955cbd6467cdb7107f342f2250"/>
+		<rom name="Shanghai (Japan) (Track 6).bin" size="44100000" crc="4229fc10" sha1="7c8b477f847be6838a52fa023efd9894151db794"/>
+		<rom name="Shanghai (Japan) (Track 7).bin" size="44805600" crc="a93d7d49" sha1="34032b1180936bc70c1ce0f90a535a9b8f8cc867"/>
+		<rom name="Shanghai (Japan) (Track 8).bin" size="46569600" crc="71ab7bc3" sha1="03f3b3fa8df2d9fd67578d9ce9d75422c6137206"/>
+		<rom name="Shanghai (Japan).cue" size="862" crc="5af3e425" sha1="2d481e4ffc0057e947adc428e9eb13d9ddd11ac1"/>
+		-->
+		<description>Shanghai</description>
+		<year>1990</year>
+		<publisher>アスキー (ASCII)</publisher>
+		<info name="alt_title" value="上海" />
+		<info name="release" value="199012xx" />
+		<part name="cdrom" interface="fmt_cdrom">
+			<diskarea name="cdrom">
+				<disk name="shanghai (japan)" sha1="4c1bba4f7521d3fc5e89a8bb7a33a4923d0dc2db" />
+			</diskarea>
+		</part>
+	</software>
+
 	<software name="shangrl2">
 		<!--
 		Origin: Neo Kobe Collection
@@ -9403,11 +9640,9 @@ User/save disks that can be created from the game itself are not included.
 
 	<software name="sherlock">
 		<!--
-		Origin: Neo Kobe Collection
-		<rom name="Sherlock Holmes no Tantei Kouza.ccd" size="770" crc="e4b0ba67" sha1="01e97932723ddd96a3240a07bf35eb5109c2a57b"/>
-		<rom name="Sherlock Holmes no Tantei Kouza.cue" size="95" crc="87021bcd" sha1="5d76b568d612c69347b0bb21f19f3842e1cfd090"/>
-		<rom name="Sherlock Holmes no Tantei Kouza.img" size="719359200" crc="b99d4037" sha1="45bf55fd953f81e5dc241e40dc236e0a12403c3f"/>
-		<rom name="Sherlock Holmes no Tantei Kouza.sub" size="29361600" crc="eec3883e" sha1="f7155ecc42b6552b73124a262b29347f98d8ccd8"/>
+		Origin: redump.org
+		<rom name="Sherlock Holmes - Consulting Detective (Japan).bin" size="719359200" crc="f7a554af" sha1="0d0398ba9e04aca0bebcc2711a2513a246bc9e57"/>
+		<rom name="Sherlock Holmes - Consulting Detective (Japan).cue" size="112" crc="1058d448" sha1="2a13c1f15b85828c75b558f21117cb5c9c431ee2"/>
 		-->
 		<description>Sherlock Holmes - Consulting Detective</description>
 		<year>1991</year>
@@ -9416,7 +9651,7 @@ User/save disks that can be created from the game itself are not included.
 		<info name="release" value="199106xx" />
 		<part name="cdrom" interface="fmt_cdrom">
 			<diskarea name="cdrom">
-				<disk name="sherlock holmes no tantei kouza" sha1="df4dac06bc19ff169d9bdc958bfc25907aa7072e" />
+				<disk name="sherlock holmes - consulting detective (japan)" sha1="e0e0767fbde8bb455641666f7f2fe48c45e0048a" />
 			</diskarea>
 		</part>
 	</software>
@@ -10716,8 +10951,16 @@ User/save disks that can be created from the game itself are not included.
 	<software name="toutrun">
 		<!--
 		Origin: Neo Kobe Collection
-		<rom name="Turbo OutRun.bin" size="320871600" crc="034e98e6" sha1="3a0a476e0874697f745ae4f9c3b2c8bd7cc48892"/>
-		<rom name="Turbo OutRun.cue" size="427" crc="ebc64d8b" sha1="ab24153f572c8dbb4cda729b0d01b00221056c22"/>
+		<rom name="Turbo Outrun (Japan) (Track 1).bin" size="4939200" crc="05d56e54" sha1="ca13203bdfe5864658cb5ecd398e8f458be38a52"/>
+		<rom name="Turbo Outrun (Japan) (Track 2).bin" size="15876000" crc="34715674" sha1="ca620ec3cd4702e1535549e1098cb8c2c46fc33f"/>
+		<rom name="Turbo Outrun (Japan) (Track 3).bin" size="56977200" crc="f7228fa5" sha1="49d8f4a77cc1031aad28d5a48280cb3446a1cb34"/>
+		<rom name="Turbo Outrun (Japan) (Track 4).bin" size="13935600" crc="68672527" sha1="e62243aa8d7d55e210922047c46331dcc7eb89a3"/>
+		<rom name="Turbo Outrun (Japan) (Track 5).bin" size="32986800" crc="af1e5b5e" sha1="41a2109bf88f93fedf07fc7f06365e58fcd12a95"/>
+		<rom name="Turbo Outrun (Japan) (Track 6).bin" size="52743600" crc="593156b7" sha1="25d63aff7f6240a6236cdfebe2b113298acd94b0"/>
+		<rom name="Turbo Outrun (Japan) (Track 7).bin" size="52743600" crc="184abbdb" sha1="17f00edddd78676f244019f29d9e183d14023cf2"/>
+		<rom name="Turbo Outrun (Japan) (Track 8).bin" size="52038000" crc="ed1670d4" sha1="f73bc0b7bce424af1a279b49f80cca4141201c49"/>
+		<rom name="Turbo Outrun (Japan) (Track 9).bin" size="38984400" crc="1e02437f" sha1="b03af28a07d3b73033b1d9ae1654c87d078fe2eb"/>
+		<rom name="Turbo Outrun (Japan).cue" size="1031" crc="01f89c25" sha1="8477330e6768977a33c874d5899977b7a64879f9"/>
 		-->
 		<description>Turbo Out Run</description>
 		<year>1989</year>
@@ -10726,7 +10969,7 @@ User/save disks that can be created from the game itself are not included.
 		<info name="release" value="198912xx" />
 		<part name="cdrom" interface="fmt_cdrom">
 			<diskarea name="cdrom">
-				<disk name="turbo outrun" sha1="35a8ec4cf334ee803abfdadd798e1fccee644776" />
+				<disk name="turbo outrun (japan)" sha1="0085118e87c8b3bbdd7ab3dfa5233df3164f1511" />
 			</diskarea>
 		</part>
 	</software>
@@ -11207,26 +11450,26 @@ User/save disks that can be created from the game itself are not included.
 		</part>
 	</software>
 
-	<!-- iso + mp3 source, needs to be replaced with a proper dump -->
 	<software name="visitor">
 		<!--
-		Origin: Tokugawa Corporate Forums (DamienD)
-		<rom name="01-VISITOR.iso" size="19662848" crc="5f2f4bf9" sha1="360e1a4ccc267793fca2cee1787b77dbd7a44049"/>
-		<rom name="02-.mp3" size="1662976" crc="5a24da9c" sha1="879f65eb11b76355f8a07e5050ac10bca503664a"/>
-		<rom name="03-.mp3" size="583680" crc="46db53e6" sha1="5caff118126ac9d91e1ee81a879548650152a6b6"/>
-		<rom name="04-.mp3" size="454656" crc="2bfa0360" sha1="35ac0d9d937b936fbe46eb4ea39653b97b5c729f"/>
-		<rom name="05-.mp3" size="1273856" crc="59b5a2b2" sha1="371a0e18287c17c6157b9fa5f8b8d0dc8c8d3a4d"/>
-		<rom name="06-.mp3" size="835584" crc="d89c63ed" sha1="b98100d058d0ae24d3854b002eb8fc0555a68e54"/>
-		<rom name="07-.mp3" size="1167360" crc="267f39e2" sha1="a2e936180c57a17e581d6d14e8456d959f9f503b"/>
-		<rom name="08-.mp3" size="3223552" crc="beb2c596" sha1="c9cebb94441fb1c00e4e82bd9e0b85f07ac35dba"/>
-		<rom name="09-.mp3" size="4745216" crc="6e9cbd57" sha1="3be0b8033fc7bec633bb1f28e2ef9545c857c6a7"/>
-		<rom name="10-.mp3" size="892928" crc="0fe4ac83" sha1="5dc546baefed73d23a1f336e49c084ab2bd38d4b"/>
-		<rom name="11-.mp3" size="514048" crc="98f7a283" sha1="9cb3a1c9620c994c45416423d5be883079788988"/>
-		<rom name="12-.mp3" size="933888" crc="216032c7" sha1="d79f981eb7cd8f223e6d693933609d04ef65cf7d"/>
-		<rom name="13-.mp3" size="1378304" crc="fe8ce1e5" sha1="f9275c3a0b56b7d45a169c0d4974e521804d2756"/>
-		<rom name="14-.mp3" size="571392" crc="16b7345e" sha1="6e8a1bf598a33b16356802384641e3e15749a40d"/>
-		<rom name="15-.mp3" size="835584" crc="1f46762c" sha1="e76c192d23fb380af997280bb9f8502a2245055d"/>
-		<rom name="16-.mp3" size="860160" crc="a8c4e968" sha1="c1b4a36175d1fdd554a1e3f5db870dccc76b2a54"/>
+		Origin: redump.org
+		<rom name="Visitor, The (Japan) (Track 01).bin" size="22583904" crc="4259dacc" sha1="162529d77e662ee7d6794a6cbb3366fc34ea5d66"/>
+		<rom name="Visitor, The (Japan) (Track 02).bin" size="12355056" crc="8176b94a" sha1="63fc90829a0c71c8ca9ecf8e05e698511d468ff5"/>
+		<rom name="Visitor, The (Japan) (Track 03).bin" size="4261824" crc="e973c2ee" sha1="bf0f98dd232086dc97058816c065fa1c1a4723e7"/>
+		<rom name="Visitor, The (Japan) (Track 04).bin" size="3316320" crc="a25fff1b" sha1="37b3c537999e3782ae0f9a816e705a967e701dc5"/>
+		<rom name="Visitor, The (Japan) (Track 05).bin" size="9344496" crc="605ae38c" sha1="7b4c90e36f24661fa26bf595e7c92417897a69e3"/>
+		<rom name="Visitor, The (Japan) (Track 06).bin" size="6126960" crc="dda27ff0" sha1="baaf9b896261593c9a1eee9d018e3187295ec0b4"/>
+		<rom name="Visitor, The (Japan) (Track 07).bin" size="8554224" crc="91f45dcf" sha1="8e031eacf8ec1258ef2e726e711e96e7cb4a07e2"/>
+		<rom name="Visitor, The (Japan) (Track 08).bin" size="23679936" crc="0712eef9" sha1="2ca10ca773d5ecf0fe1931843fae55bafe03bfd5"/>
+		<rom name="Visitor, The (Japan) (Track 09).bin" size="34856640" crc="ef9eb392" sha1="085d2739d847e4a37cc7c6efc78e67510039b1e8"/>
+		<rom name="Visitor, The (Japan) (Track 10).bin" size="6538560" crc="01302694" sha1="b6a13d4541df6d22e3e6bfe3bf32408246fc1074"/>
+		<rom name="Visitor, The (Japan) (Track 11).bin" size="3756144" crc="75eb5b40" sha1="113fec3c7a22ae72bcff2940d80b170722197e09"/>
+		<rom name="Visitor, The (Japan) (Track 12).bin" size="6839616" crc="f05477e3" sha1="249ca8ed5253b8d169bfc209b69cd62e5832e6df"/>
+		<rom name="Visitor, The (Japan) (Track 13).bin" size="10113600" crc="dc6afb3c" sha1="00a98fff27b33e38b1d6720aab1ff38e4f2f8211"/>
+		<rom name="Visitor, The (Japan) (Track 14).bin" size="4174800" crc="7a7f46c8" sha1="beedcc1e71c1bfae4f2db175fe9872cf59079a8e"/>
+		<rom name="Visitor, The (Japan) (Track 15).bin" size="6119904" crc="dccf3d71" sha1="d5f45e03695455293ebc81df482693a45aa626bb"/>
+		<rom name="Visitor, The (Japan) (Track 16).bin" size="6745536" crc="a324ba12" sha1="814734fc850945de66db05fc866ffd9c053702b4"/>
+		<rom name="Visitor, The (Japan).cue" size="1822" crc="3e5273da" sha1="a3b2e80b01a36adf779a654d9e7c180916295b8d"/>
 		-->
 		<description>The Visitor</description>
 		<year>1989</year>
@@ -11235,7 +11478,7 @@ User/save disks that can be created from the game itself are not included.
 		<info name="release" value="198909xx" />
 		<part name="cdrom" interface="fmt_cdrom">
 			<diskarea name="cdrom">
-				<disk name="visitor" sha1="18f43caaf537a305004b5c2e8a4d032d98055966" status="baddump" />
+				<disk name="visitor, the (japan)" sha1="30845f0df52cc943e26c0bdfc162d1e814876af1" />
 			</diskarea>
 		</part>
 	</software>


### PR DESCRIPTION
- Replaced entries with dumps from the redump.org database, with proper track indexes and offset correction:

The 4th Unit 6 - Merry-Go-Round
Air Warrior V1.1
Dragon Shock
Final Blow
Ms. Detective File #1 - Iwami Ginzan Satsujin Jiken
Rance III - Leazas Kanraku
Sherlock Holmes - Consulting Detective
Turbo Out Run
The Visitor

- Added new working dumps from the redump.org database:

Shanghai

- Added new NOT working dumps from the redump.org database (most of these are missing floppy disks):

Air Warrior V1.2
Fujitsu Habitat V2.1L10
Hyper Media NHK Zoku Kiso Eigo: Dai-3-kan
Nobunaga no Yabou: Sengoku Gun'yuuden
Taito Chase H.Q. (Demo)

- Added a parent-clone relationship between the Windows 3.1 revisions

- Updated the missing list with some recently confirmed software