### PR TITLE
Allow updating version.cpp when IGNORE_GIT=1 is passed

### DIFF
--- a/makefile
+++ b/makefile
@@ -1644,14 +1644,14 @@ $(GENDIR)/git_desc: stale | $(GEN_FOLDERS)
 endif
 
 ifeq (posix,$(SHELLTYPE))
-$(GENDIR)/version.cpp: $(GENDIR)/git_desc | $(GEN_FOLDERS)
+$(GENDIR)/version.cpp: makefile $(GENDIR)/git_desc | $(GEN_FOLDERS)
 	@echo '#define BARE_BUILD_VERSION "0.214"' > $@
 	@echo 'extern const char bare_build_version[];' >> $@
 	@echo 'extern const char build_version[];' >> $@
 	@echo 'const char bare_build_version[] = BARE_BUILD_VERSION;' >> $@
 	@echo 'const char build_version[] = BARE_BUILD_VERSION " ($(NEW_GIT_VERSION))";' >> $@
 else
-$(GENDIR)/version.cpp: $(GENDIR)/git_desc
+$(GENDIR)/version.cpp: makefile $(GENDIR)/git_desc | $(GEN_FOLDERS)
 	@echo #define BARE_BUILD_VERSION "0.214" > $@
 	@echo extern const char bare_build_version[]; >> $@
 	@echo extern const char build_version[]; >> $@


### PR DESCRIPTION
Without this tweak it would only create the file if it doesn't exist, and wouldn't update an existing one.