### PR TITLE
nmk16spr.cpp : Device-fied NMK 16 bit sprite hardware

### DIFF
--- a/scripts/target/mame/arcade.lua
+++ b/scripts/target/mame/arcade.lua
@@ -1362,9 +1362,6 @@ files {
 	MAME_DIR .. "src/mame/includes/ohmygod.h",
 	MAME_DIR .. "src/mame/video/ohmygod.cpp",
 	MAME_DIR .. "src/mame/drivers/patapata.cpp",
-	MAME_DIR .. "src/mame/drivers/powerins.cpp",
-	MAME_DIR .. "src/mame/includes/powerins.h",
-	MAME_DIR .. "src/mame/video/powerins.cpp",
 	MAME_DIR .. "src/mame/drivers/bowltry.cpp",
 }
 
@@ -3115,7 +3112,12 @@ files {
 	MAME_DIR .. "src/mame/machine/nmk004.cpp",
 	MAME_DIR .. "src/mame/machine/nmk004.h",
 	MAME_DIR .. "src/mame/video/nmk16.cpp",
+	MAME_DIR .. "src/mame/video/nmk16spr.cpp",
+	MAME_DIR .. "src/mame/video/nmk16spr.h",
 	MAME_DIR .. "src/mame/drivers/nmkmedal.cpp",
+	MAME_DIR .. "src/mame/drivers/powerins.cpp",
+	MAME_DIR .. "src/mame/includes/powerins.h",
+	MAME_DIR .. "src/mame/video/powerins.cpp",
 	MAME_DIR .. "src/mame/drivers/quizdna.cpp",
 	MAME_DIR .. "src/mame/includes/quizdna.h",
 	MAME_DIR .. "src/mame/video/quizdna.cpp",

--- a/src/mame/drivers/nmk16.cpp
+++ b/src/mame/drivers/nmk16.cpp
@@ -5508,6 +5508,7 @@ void afega_state::firehawk(machine_config &config)
 
 	/* video hardware */
 	set_hacky_screen_lowres(config);
+	m_spritegen->set_colpri_callback(FUNC(afega_state::get_colour_4bit), this);
 	m_spritegen->set_ext_callback(FUNC(afega_state::get_sprite_flip), this);
 	m_screen->set_screen_update(FUNC(afega_state::screen_update_firehawk));
 

--- a/src/mame/drivers/nmk16.cpp
+++ b/src/mame/drivers/nmk16.cpp
@@ -4106,8 +4106,9 @@ void nmk16_state::set_hacky_screen_lowres(machine_config &config)
 	m_screen->set_visarea(0*8, 32*8-1, 2*8, 30*8-1);
 	m_screen->set_palette(m_palette);
 
-	NMK_16BIT_SPRITE(config, m_spritegen, 384 * 263);
+	NMK_16BIT_SPRITE(config, m_spritegen, XTAL(12'000'000)/2);
 	m_spritegen->set_screen_size(384, 256);
+	m_spritegen->set_max_sprite_clock(384 * 263); // from hardware manual
 }
 
 void nmk16_state::set_hacky_screen_hires(machine_config &config)
@@ -4120,8 +4121,9 @@ void nmk16_state::set_hacky_screen_hires(machine_config &config)
 	m_screen->set_visarea(0*8, 48*8-1, 2*8, 30*8-1);
 	m_screen->set_palette(m_palette);
 
-	NMK_16BIT_SPRITE(config, m_spritegen, 512 * 263);
+	NMK_16BIT_SPRITE(config, m_spritegen, XTAL(16'000'000)/2);
 	m_spritegen->set_screen_size(384, 256);
+	m_spritegen->set_max_sprite_clock(512 * 263); // not verified?
 	m_spritegen->set_videoshift(64);
 }
 
@@ -4922,10 +4924,11 @@ void nmk16_state::manybloc(machine_config &config)
 	m_screen->set_screen_update(FUNC(nmk16_state::screen_update_macross));
 	m_screen->set_palette(m_palette);
 
-	NMK_16BIT_SPRITE(config, m_spritegen, 384 * 263);
+	NMK_16BIT_SPRITE(config, m_spritegen, XTAL(12'000'000)/2);
 	m_spritegen->set_colpri_callback(FUNC(nmk16_state::get_colour_4bit), this);
 	m_spritegen->set_ext_callback(FUNC(nmk16_state::get_sprite_flip), this);
 	m_spritegen->set_screen_size(256, 256);
+	m_spritegen->set_max_sprite_clock(384 * 263); // from hardware manual
 
 	GFXDECODE(config, m_gfxdecode, m_palette, gfx_tharrier);
 	PALETTE(config, m_palette).set_format(palette_device::RRRRGGGGBBBBRGBx, 512);

--- a/src/mame/drivers/nmk16.cpp
+++ b/src/mame/drivers/nmk16.cpp
@@ -4105,6 +4105,9 @@ void nmk16_state::set_hacky_screen_lowres(machine_config &config)
 	m_screen->set_size(256, 256);
 	m_screen->set_visarea(0*8, 32*8-1, 2*8, 30*8-1);
 	m_screen->set_palette(m_palette);
+
+	NMK_16BIT_SPRITE(config, m_spritegen, 384 * 263);
+	m_spritegen->set_screen_size(384, 256);
 }
 
 void nmk16_state::set_hacky_screen_hires(machine_config &config)
@@ -4116,6 +4119,10 @@ void nmk16_state::set_hacky_screen_hires(machine_config &config)
 	m_screen->set_size(512, 256);
 	m_screen->set_visarea(0*8, 48*8-1, 2*8, 30*8-1);
 	m_screen->set_palette(m_palette);
+
+	NMK_16BIT_SPRITE(config, m_spritegen, 512 * 263);
+	m_spritegen->set_screen_size(384, 256);
+	m_spritegen->set_videoshift(64);
 }
 
 // OSC : 10MHz, 12MHz, 4MHz, 4.9152MHz
@@ -4132,6 +4139,8 @@ void nmk16_state::tharrier(machine_config &config)
 
 	/* video hardware */
 	set_hacky_screen_lowres(config);
+	m_spritegen->set_colpri_callback(FUNC(nmk16_state::get_colour_4bit), this);
+	m_spritegen->set_ext_callback(FUNC(nmk16_state::get_sprite_flip), this);
 	m_screen->set_screen_update(FUNC(nmk16_state::screen_update_tharrier));
 
 	GFXDECODE(config, m_gfxdecode, m_palette, gfx_tharrier);
@@ -4169,6 +4178,7 @@ void nmk16_state::mustang(machine_config &config)
 
 	/* video hardware */
 	set_hacky_screen_lowres(config);
+	m_spritegen->set_colpri_callback(FUNC(nmk16_state::get_colour_4bit), this);
 	m_screen->set_screen_update(FUNC(nmk16_state::screen_update_macross));
 
 	GFXDECODE(config, m_gfxdecode, m_palette, gfx_macross);
@@ -4210,6 +4220,7 @@ void nmk16_state::mustangb(machine_config &config)
 
 	/* video hardware */
 	set_hacky_screen_lowres(config);
+	m_spritegen->set_colpri_callback(FUNC(nmk16_state::get_colour_4bit), this);
 	m_screen->set_screen_update(FUNC(nmk16_state::screen_update_macross));
 
 	GFXDECODE(config, m_gfxdecode, m_palette, gfx_macross);
@@ -4242,6 +4253,7 @@ void nmk16_state::bioship(machine_config &config)
 
 	/* video hardware */
 	set_hacky_screen_lowres(config);
+	m_spritegen->set_colpri_callback(FUNC(nmk16_state::get_colour_4bit), this);
 	m_screen->set_screen_update(FUNC(nmk16_state::screen_update_strahl));
 
 	GFXDECODE(config, m_gfxdecode, m_palette, gfx_bioship);
@@ -4279,6 +4291,7 @@ void nmk16_state::vandyke(machine_config &config)
 
 	/* video hardware */
 	set_hacky_screen_lowres(config);
+	m_spritegen->set_colpri_callback(FUNC(nmk16_state::get_colour_4bit), this);
 	m_screen->set_screen_update(FUNC(nmk16_state::screen_update_macross));
 
 	GFXDECODE(config, m_gfxdecode, m_palette, gfx_macross);
@@ -4318,6 +4331,7 @@ void nmk16_state::vandykeb(machine_config &config)
 
 	/* video hardware */
 	set_hacky_screen_lowres(config);
+	m_spritegen->set_colpri_callback(FUNC(nmk16_state::get_colour_4bit), this);
 	m_screen->set_screen_update(FUNC(nmk16_state::screen_update_macross));
 
 	GFXDECODE(config, m_gfxdecode, m_palette, gfx_macross);
@@ -4382,6 +4396,7 @@ void nmk16_state::tdragonb(machine_config &config)    /* bootleg using Raiden so
 
 	/* video hardware */
 	set_hacky_screen_lowres(config);
+	m_spritegen->set_colpri_callback(FUNC(nmk16_state::get_colour_4bit), this);
 	m_screen->set_screen_update(FUNC(nmk16_state::screen_update_macross));
 
 	GFXDECODE(config, m_gfxdecode, m_palette, gfx_macross);
@@ -4414,6 +4429,7 @@ void nmk16_state::tdragon(machine_config &config)
 
 	/* video hardware */
 	set_hacky_screen_lowres(config);
+	m_spritegen->set_colpri_callback(FUNC(nmk16_state::get_colour_4bit), this);
 	m_screen->set_screen_update(FUNC(nmk16_state::screen_update_macross));
 
 	GFXDECODE(config, m_gfxdecode, m_palette, gfx_macross);
@@ -4460,6 +4476,7 @@ void nmk16_state::ssmissin(machine_config &config)
 
 	/* video hardware */
 	set_hacky_screen_lowres(config);
+	m_spritegen->set_colpri_callback(FUNC(nmk16_state::get_colour_4bit), this);
 	m_screen->set_screen_update(FUNC(nmk16_state::screen_update_macross));
 
 	GFXDECODE(config, m_gfxdecode, m_palette, gfx_macross);
@@ -4486,6 +4503,7 @@ void nmk16_state::strahl(machine_config &config)
 
 	/* video hardware */
 	set_hacky_screen_lowres(config);
+	m_spritegen->set_colpri_callback(FUNC(nmk16_state::get_colour_4bit), this);
 	m_screen->set_screen_update(FUNC(nmk16_state::screen_update_strahl));
 
 	GFXDECODE(config, m_gfxdecode, m_palette, gfx_strahl);
@@ -4523,6 +4541,7 @@ void nmk16_state::hachamf(machine_config &config)
 
 	/* video hardware */
 	set_hacky_screen_lowres(config);
+	m_spritegen->set_colpri_callback(FUNC(nmk16_state::get_colour_4bit), this);
 	m_screen->set_screen_update(FUNC(nmk16_state::screen_update_macross));
 
 	GFXDECODE(config, m_gfxdecode, m_palette, gfx_macross);
@@ -4567,6 +4586,7 @@ void nmk16_state::macross(machine_config &config)
 
 	/* video hardware */
 	set_hacky_screen_lowres(config);
+	m_spritegen->set_colpri_callback(FUNC(nmk16_state::get_colour_4bit), this);
 	m_screen->set_screen_update(FUNC(nmk16_state::screen_update_macross));
 
 	GFXDECODE(config, m_gfxdecode, m_palette, gfx_macross);
@@ -4604,6 +4624,7 @@ void nmk16_state::blkheart(machine_config &config)
 
 	/* video hardware */
 	set_hacky_screen_lowres(config);
+	m_spritegen->set_colpri_callback(FUNC(nmk16_state::get_colour_4bit), this);
 	m_screen->set_screen_update(FUNC(nmk16_state::screen_update_macross));
 
 	GFXDECODE(config, m_gfxdecode, m_palette, gfx_macross);
@@ -4641,6 +4662,7 @@ void nmk16_state::gunnail(machine_config &config)
 
 	/* video hardware */
 	set_hacky_screen_hires(config);
+	m_spritegen->set_colpri_callback(FUNC(nmk16_state::get_colour_4bit), this);
 	m_screen->set_screen_update(FUNC(nmk16_state::screen_update_macross));
 
 	GFXDECODE(config, m_gfxdecode, m_palette, gfx_macross);
@@ -4703,6 +4725,7 @@ void nmk16_state::macross2(machine_config &config)
 
 	/* video hardware */
 	set_hacky_screen_hires(config);
+	m_spritegen->set_colpri_callback(FUNC(nmk16_state::get_colour_5bit), this);
 	m_screen->set_screen_update(FUNC(nmk16_state::screen_update_macross));
 
 	GFXDECODE(config, m_gfxdecode, m_palette, gfx_macross2);
@@ -4746,6 +4769,7 @@ void nmk16_state::tdragon2(machine_config &config)
 
 	/* video hardware */
 	set_hacky_screen_hires(config);
+	m_spritegen->set_colpri_callback(FUNC(nmk16_state::get_colour_5bit), this);
 	m_screen->set_screen_update(FUNC(nmk16_state::screen_update_macross));
 
 	GFXDECODE(config, m_gfxdecode, m_palette, gfx_macross2);
@@ -4796,6 +4820,7 @@ void nmk16_state::raphero(machine_config &config)
 
 	/* video hardware */
 	set_hacky_screen_hires(config);
+	m_spritegen->set_colpri_callback(FUNC(nmk16_state::get_colour_5bit), this);
 	m_screen->set_screen_update(FUNC(nmk16_state::screen_update_macross));
 
 	GFXDECODE(config, m_gfxdecode, m_palette, gfx_macross2);
@@ -4835,6 +4860,7 @@ void nmk16_state::bjtwin(machine_config &config)
 
 	/* video hardware */
 	set_hacky_screen_hires(config);
+	m_spritegen->set_colpri_callback(FUNC(nmk16_state::get_colour_4bit), this);
 	m_screen->set_screen_update(FUNC(nmk16_state::screen_update_bjtwin));
 
 	GFXDECODE(config, m_gfxdecode, m_palette, gfx_bjtwin);
@@ -4893,8 +4919,13 @@ void nmk16_state::manybloc(machine_config &config)
 	m_screen->set_vblank_time(ATTOSECONDS_IN_USEC(2500)); /* not accurate */
 	m_screen->set_size(256, 256);
 	m_screen->set_visarea(0*8, 32*8-1, 1*8, 31*8-1);
-	m_screen->set_screen_update(FUNC(nmk16_state::screen_update_manybloc));
+	m_screen->set_screen_update(FUNC(nmk16_state::screen_update_macross));
 	m_screen->set_palette(m_palette);
+
+	NMK_16BIT_SPRITE(config, m_spritegen, 384 * 263);
+	m_spritegen->set_colpri_callback(FUNC(nmk16_state::get_colour_4bit), this);
+	m_spritegen->set_ext_callback(FUNC(nmk16_state::get_sprite_flip), this);
+	m_spritegen->set_screen_size(256, 256);
 
 	GFXDECODE(config, m_gfxdecode, m_palette, gfx_tharrier);
 	PALETTE(config, m_palette).set_format(palette_device::RRRRGGGGBBBBRGBx, 512);
@@ -4937,6 +4968,7 @@ void nmk16_tomagic_state::tomagic(machine_config &config)
 
 	/* video hardware */
 	set_hacky_screen_hires(config);
+	m_spritegen->set_colpri_callback(FUNC(nmk16_tomagic_state::get_colour_4bit), this);
 	m_screen->set_screen_update(FUNC(nmk16_state::screen_update_macross));
 
 	GFXDECODE(config, m_gfxdecode, m_palette, gfx_macross);
@@ -5393,6 +5425,8 @@ void afega_state::stagger1(machine_config &config)
 
 	/* video hardware */
 	set_hacky_screen_lowres(config);
+	m_spritegen->set_colpri_callback(FUNC(afega_state::get_colour_4bit), this);
+	m_spritegen->set_ext_callback(FUNC(afega_state::get_sprite_flip), this);
 	m_screen->set_screen_update(FUNC(afega_state::screen_update_afega));
 
 	GFXDECODE(config, m_gfxdecode, m_palette, gfx_macross);
@@ -5474,6 +5508,7 @@ void afega_state::firehawk(machine_config &config)
 
 	/* video hardware */
 	set_hacky_screen_lowres(config);
+	m_spritegen->set_ext_callback(FUNC(afega_state::get_sprite_flip), this);
 	m_screen->set_screen_update(FUNC(afega_state::screen_update_firehawk));
 
 	GFXDECODE(config, m_gfxdecode, m_palette, gfx_grdnstrm);
@@ -5512,6 +5547,7 @@ void nmk16_state::twinactn(machine_config &config)
 
 	/* video hardware */
 	set_hacky_screen_lowres(config);
+	m_spritegen->set_colpri_callback(FUNC(nmk16_state::get_colour_4bit), this);
 	m_screen->set_screen_update(FUNC(nmk16_state::screen_update_macross));
 
 	GFXDECODE(config, m_gfxdecode, m_palette, gfx_macross);

--- a/src/mame/drivers/powerins.cpp
+++ b/src/mame/drivers/powerins.cpp
@@ -280,22 +280,26 @@ void powerins_state::init_powerinsc()
 void powerins_state::powerins(machine_config &config)
 {
 	/* basic machine hardware */
-	M68000(config, m_maincpu, 12000000);   /* 12MHz */
+	M68000(config, m_maincpu, XTAL(12'000'000));   /* 12MHz */
 	m_maincpu->set_addrmap(AS_PROGRAM, &powerins_state::powerins_map);
 
-	Z80(config, m_soundcpu, 6000000); /* 6 MHz */
+	Z80(config, m_soundcpu, XTAL(12'000'000) / 2); /* 6 MHz */
 	m_soundcpu->set_addrmap(AS_PROGRAM, &powerins_state::powerins_sound_map);
 	m_soundcpu->set_addrmap(AS_IO, &powerins_state::powerins_sound_io_map);
 
 	/* video hardware */
 	SCREEN(config, m_screen, SCREEN_TYPE_RASTER);
-	m_screen->set_refresh_hz(56);
-	m_screen->set_vblank_time(ATTOSECONDS_IN_USEC(0));
-	m_screen->set_size(320, 256);
-	m_screen->set_visarea(0, 320-1, 0+16, 256-16-1);
+	m_screen->set_raw(XTAL(14'000'000) / 2, 448, 0, 320, 278, 16, 240); // confirmed
 	m_screen->set_screen_update(FUNC(powerins_state::screen_update));
 	m_screen->screen_vblank().set(FUNC(powerins_state::screen_vblank));
 	m_screen->set_palette(m_palette);
+
+	NMK_16BIT_SPRITE(config, m_spritegen, 448 * 263);
+	m_spritegen->set_colpri_callback(FUNC(powerins_state::get_colour_6bit), this);
+	m_spritegen->set_ext_callback(FUNC(powerins_state::get_flip_extcode), this);
+	m_spritegen->set_mask(0x3ff, 0x3ff);
+	m_spritegen->set_screen_size(320, 256);
+	m_spritegen->set_videoshift(32);
 
 	GFXDECODE(config, m_gfxdecode, m_palette, gfx_powerins);
 	PALETTE(config, m_palette).set_format(palette_device::RRRRGGGGBBBBRGBx, 2048);
@@ -305,15 +309,15 @@ void powerins_state::powerins(machine_config &config)
 
 	GENERIC_LATCH_8(config, "soundlatch");
 
-	okim6295_device &oki1(OKIM6295(config, "oki1", 4000000, okim6295_device::PIN7_LOW));
-	oki1.add_route(ALL_OUTPUTS, "mono", 0.15);
-
-	okim6295_device &oki2(OKIM6295(config, "oki2", 4000000, okim6295_device::PIN7_LOW));
-	oki2.add_route(ALL_OUTPUTS, "mono", 0.15);
-
-	ym2203_device &ym2203(YM2203(config, "ym2203", 12000000 / 8));
+	ym2203_device &ym2203(YM2203(config, "ym2203", XTAL(12'000'000) / 8));
 	ym2203.irq_handler().set_inputline(m_soundcpu, 0);
 	ym2203.add_route(ALL_OUTPUTS, "mono", 2.0);
+
+	okim6295_device &oki1(OKIM6295(config, "oki1", XTAL(16'000'000) / 4, okim6295_device::PIN7_LOW));
+	oki1.add_route(ALL_OUTPUTS, "mono", 0.15);
+
+	okim6295_device &oki2(OKIM6295(config, "oki2", XTAL(16'000'000) / 4, okim6295_device::PIN7_LOW));
+	oki2.add_route(ALL_OUTPUTS, "mono", 0.15);
 
 	nmk112_device &nmk112(NMK112(config, "nmk112", 0));
 	nmk112.set_rom0_tag("oki1");

--- a/src/mame/drivers/powerins.cpp
+++ b/src/mame/drivers/powerins.cpp
@@ -294,11 +294,12 @@ void powerins_state::powerins(machine_config &config)
 	m_screen->screen_vblank().set(FUNC(powerins_state::screen_vblank));
 	m_screen->set_palette(m_palette);
 
-	NMK_16BIT_SPRITE(config, m_spritegen, 448 * 263);
+	NMK_16BIT_SPRITE(config, m_spritegen, XTAL(14'000'000) / 2);
 	m_spritegen->set_colpri_callback(FUNC(powerins_state::get_colour_6bit), this);
 	m_spritegen->set_ext_callback(FUNC(powerins_state::get_flip_extcode), this);
 	m_spritegen->set_mask(0x3ff, 0x3ff);
 	m_spritegen->set_screen_size(320, 256);
+	m_spritegen->set_max_sprite_clock(448 * 263); // not verified?
 	m_spritegen->set_videoshift(32);
 
 	GFXDECODE(config, m_gfxdecode, m_palette, gfx_powerins);

--- a/src/mame/includes/nmk16.h
+++ b/src/mame/includes/nmk16.h
@@ -63,7 +63,6 @@ public:
 	void acrobatm(machine_config &config);
 	void strahl(machine_config &config);
 	void tdragon3h(machine_config &config);
-	void atombjt(machine_config &config);
 	void hachamf_prot(machine_config &config);
 	void macross(machine_config &config);
 	void mustangb(machine_config &config);
@@ -82,7 +81,6 @@ public:
 	void init_banked_audiocpu();
 	void init_gunnailb();
 	void init_bjtwin();
-	void init_atombjt();
 
 	DECLARE_VIDEO_START(gunnail);
 	TIMER_DEVICE_CALLBACK_MEMBER(nmk16_scanline);
@@ -166,7 +164,6 @@ protected:
 	void set_hacky_interrupt_timing(machine_config &config);
 	void set_hacky_screen_lowres(machine_config &config);
 	void set_hacky_screen_hires(machine_config &config);
-	void set_common_sprites(machine_config &config);
 
 	TILEMAP_MAPPER_MEMBER(tilemap_scan_pages);
 	template<unsigned Layer, unsigned Gfx> TILE_GET_INFO_MEMBER(common_get_bg_tile_info);
@@ -201,7 +198,6 @@ protected:
 	void decode_ssmissin();
 
 	void acrobatm_map(address_map &map);
-	void atombjt_map(address_map &map);
 	void bioship_map(address_map &map);
 	void bjtwin_map(address_map &map);
 	void gunnail_map(address_map &map);

--- a/src/mame/includes/nmk16.h
+++ b/src/mame/includes/nmk16.h
@@ -11,6 +11,7 @@
 #include "machine/nmk004.h"
 #include "machine/timer.h"
 #include "sound/okim6295.h"
+#include "video/nmk16spr.h"
 #include "emupal.h"
 #include "screen.h"
 #include "tilemap.h"
@@ -26,6 +27,7 @@ public:
 		m_gfxdecode(*this, "gfxdecode"),
 		m_screen(*this, "screen"),
 		m_palette(*this, "palette"),
+		m_spritegen(*this, "spritegen"),
 		m_nmk004(*this, "nmk004"),
 		m_soundlatch(*this, "soundlatch"),
 		m_bgvideoram(*this, "bgvideoram%u", 0U),
@@ -99,6 +101,7 @@ protected:
 	required_device<gfxdecode_device> m_gfxdecode;
 	required_device<screen_device> m_screen;
 	required_device<palette_device> m_palette;
+	required_device<nmk_16bit_sprite_device> m_spritegen;
 	optional_device<nmk004_device> m_nmk004;
 	optional_device<generic_latch_8_device> m_soundlatch;
 
@@ -163,6 +166,7 @@ protected:
 	void set_hacky_interrupt_timing(machine_config &config);
 	void set_hacky_screen_lowres(machine_config &config);
 	void set_hacky_screen_hires(machine_config &config);
+	void set_common_sprites(machine_config &config);
 
 	TILEMAP_MAPPER_MEMBER(tilemap_scan_pages);
 	template<unsigned Layer, unsigned Gfx> TILE_GET_INFO_MEMBER(common_get_bg_tile_info);
@@ -174,18 +178,17 @@ protected:
 	DECLARE_VIDEO_START(strahl);
 	DECLARE_VIDEO_START(macross2);
 	DECLARE_VIDEO_START(bjtwin);
+	void get_colour_4bit(u32 &colour, u32 &pri_mask);
+	void get_colour_5bit(u32 &colour, u32 &pri_mask);
+	void get_sprite_flip(u16 attr, int &flipx, int &flipy, int &code);
 	u32 screen_update_tharrier(screen_device &screen, bitmap_ind16 &bitmap, const rectangle &cliprect);
-	u32 screen_update_manybloc(screen_device &screen, bitmap_ind16 &bitmap, const rectangle &cliprect);
 	u32 screen_update_strahl(screen_device &screen, bitmap_ind16 &bitmap, const rectangle &cliprect);
 	u32 screen_update_bjtwin(screen_device &screen, bitmap_ind16 &bitmap, const rectangle &cliprect);
 	TIMER_DEVICE_CALLBACK_MEMBER(tdragon_mcu_sim);
 	TIMER_DEVICE_CALLBACK_MEMBER(hachamf_mcu_sim);
 	TIMER_DEVICE_CALLBACK_MEMBER(manybloc_scanline);
 	void video_init();
-	inline void draw_sprite(bitmap_ind16 &bitmap, const rectangle &cliprect, u16 *spr);
-	inline void draw_sprite_flipsupported(bitmap_ind16 &bitmap, const rectangle &cliprect, u16 *spr);
-	void draw_sprites(bitmap_ind16 &bitmap, const rectangle &cliprect);
-	void draw_sprites_flipsupported(bitmap_ind16 &bitmap, const rectangle &cliprect);
+	void draw_sprites(screen_device &screen, bitmap_ind16 &bitmap, const rectangle &cliprect);
 	void bg_update(screen_device &screen, bitmap_ind16 &bitmap, const rectangle &cliprect, int layer = 0);
 	void tx_update(screen_device &screen, bitmap_ind16 &bitmap, const rectangle &cliprect);
 	void mcu_run(u8 dsw_setting);

--- a/src/mame/includes/powerins.h
+++ b/src/mame/includes/powerins.h
@@ -3,6 +3,7 @@
 #ifndef MAME_INCLUDES_POWERINS_H
 #define MAME_INCLUDES_POWERINS_H
 
+#include "video/nmk16spr.h"
 #include "emupal.h"
 #include "screen.h"
 #include "tilemap.h"
@@ -17,6 +18,7 @@ public:
 		m_gfxdecode(*this, "gfxdecode"),
 		m_screen(*this, "screen"),
 		m_palette(*this, "palette"),
+		m_spritegen(*this, "spritegen"),
 		m_vctrl_0(*this, "vctrl_0"),
 		m_vram(*this, "vram_%u", 0U),
 		m_spriteram(*this, "spriteram"),
@@ -36,6 +38,7 @@ private:
 	required_device<gfxdecode_device> m_gfxdecode;
 	required_device<screen_device> m_screen;
 	required_device<palette_device> m_palette;
+	required_device<nmk_16bit_sprite_device> m_spritegen;
 
 	required_shared_ptr<uint16_t> m_vctrl_0;
 	required_shared_ptr_array<uint16_t, 2> m_vram;
@@ -64,8 +67,9 @@ private:
 
 	virtual void video_start() override;
 
+	void get_colour_6bit(u32 &colour, u32 &pri_mask);
+	void get_flip_extcode(u16 attr, int &flipx, int &flipy, int &code);
 	uint32_t screen_update(screen_device &screen, bitmap_ind16 &bitmap, const rectangle &cliprect);
-	void draw_sprites(bitmap_ind16 &bitmap,const rectangle &cliprect);
 	void powerins_map(address_map &map);
 	void powerins_sound_io_map(address_map &map);
 	void powerins_sound_map(address_map &map);

--- a/src/mame/video/nmk16spr.cpp
+++ b/src/mame/video/nmk16spr.cpp
@@ -43,6 +43,7 @@ nmk_16bit_sprite_device::nmk_16bit_sprite_device(const machine_config &mconfig, 
 	, m_videoshift(0)
 	, m_xmask(0x1ff), m_ymask(0x1ff)
 	, m_screen_width(384), m_screen_height(256)
+	, m_max_sprite_clock(384 * 263)
 {
 }
 
@@ -58,7 +59,7 @@ void nmk_16bit_sprite_device::draw_sprites(screen_device &screen, bitmap_ind16 &
 	for (int offs = 0; offs < size; offs += 8)
 	{
 		clk += 16; // 16 clock per each sprites
-		if (clk >= clock())
+		if (clk >= m_max_sprite_clock)
 			break;
 
 		if (!(spriteram[offs + 0] & 0x0001))
@@ -81,7 +82,7 @@ void nmk_16bit_sprite_device::draw_sprites(screen_device &screen, bitmap_ind16 &
 			m_ext_cb(spriteram[offs + 1], flipx, flipy, code);
 
 		clk += 128 * w * h; // 128 clock per each 16x16 tile
-		if (clk >= clock())
+		if (clk >= m_max_sprite_clock)
 			break;
 
 		int delta = 16;

--- a/src/mame/video/nmk16spr.cpp
+++ b/src/mame/video/nmk16spr.cpp
@@ -1,0 +1,267 @@
+// license:BSD-3-Clause
+// copyright-holders:Mirko Buffoni,Nicola Salmoria,Bryan McPhail,David Haywood,R. Belmont,Alex Marshall,Angelo Salese,Luca Elia
+// thanks-to:Richard Bush
+/*
+	NMK 16 bit sprite hardware
+
+	Configured in NMK008 + one or more NMK009s or TTL logics or FPGA
+
+	From hardware manual : http://upl-gravedigger.boo.jp/pcb_info/pcb_manual_7.jpg
+
+	used by:
+	nmk16.cpp
+	powerins.cpp
+
+	Sprite format (16 byte per each sprite):
+
+	Offset Bits              Description
+	       fedcba98 76543210
+	00     -------- -------s Visible
+	02     ---x---- -------- Flip X (powerins)
+	       ------x- -------- Flip Y (manybloc)
+		   -------x -------- Flip X (manybloc) or Code hi bits (powerins)
+		   -------- xxxx---- Number of tiles along Y, minus 1 (1-16)
+		   -------- ----xxxx Number of tiles along X, minus 1 (1-16)
+	04     -------- -------- Unused
+	06     xxxxxxxx xxxxxxxx Code (low 15 bit for powerins)
+	08     ------xx xxxxxxxx X (10 bit for powerins, 9 bit for others)
+	0a     -------- -------- Unused
+	0c     ------xx xxxxxxxx Y (10 bit for powerins, 9 bit for others)
+	0e     -------- --xxxxxx Palette select (differ bits per game (4/5/6 bits))
+*/
+
+
+#include "emu.h"
+#include "nmk16spr.h"
+
+
+DEFINE_DEVICE_TYPE(NMK_16BIT_SPRITE, nmk_16bit_sprite_device, "nmk16spr", "NMK 16 bit Sprite hardware")
+
+nmk_16bit_sprite_device::nmk_16bit_sprite_device(const machine_config &mconfig, const char *tag, device_t *owner, uint32_t clock)
+	: device_t(mconfig, NMK_16BIT_SPRITE, tag, owner, clock)
+	, m_flip_screen(false)
+	, m_videoshift(0)
+	, m_xmask(0x1ff), m_ymask(0x1ff)
+	, m_screen_width(384), m_screen_height(256)
+{
+}
+
+// this implementation was originally from nmk16.cpp
+void nmk_16bit_sprite_device::draw_sprites(screen_device &screen, bitmap_ind16 &bitmap, const rectangle &cliprect, gfx_element *gfx, u16* spriteram, int size)
+{
+	const bool priority = !m_colpri_cb.isnull();
+	struct sprite_t *sprite_ptr = m_spritelist.get();
+	const int xpos_max = m_xmask + 1;
+	const int ypos_max = m_ymask + 1;
+
+	u32 clk = 0;
+	for (int offs = 0; offs < size; offs += 8)
+	{
+		clk += 16; // 16 clock per each sprites
+		if (clk >= clock())
+			break;
+
+		if (!(spriteram[offs + 0] & 0x0001))
+			continue;
+
+		// extract parameters
+		u32 pri_mask = 0;
+		int sx          = (spriteram[offs + 4] & m_xmask) + m_videoshift;
+		int sy          =  spriteram[offs + 6] & m_ymask;
+		int code        =  spriteram[offs + 3];
+		u32 colour      =  spriteram[offs + 7];
+		if (priority)
+			m_colpri_cb(colour, pri_mask);
+
+		const int w     =  spriteram[offs + 1] & 0x00f;
+		const int h     = (spriteram[offs + 1] & 0x0f0) >> 4;
+		int flipy       = 0;
+		int flipx       = 0;
+		if (!m_ext_cb.isnull())
+			m_ext_cb(spriteram[offs + 1], flipx, flipy, code);
+
+		clk += 128 * w * h; // 128 clock per each 16x16 tile
+		if (clk >= clock())
+			break;
+
+		int delta = 16;
+
+		if (m_flip_screen)
+		{
+			sx = m_screen_width - 16 - sx;
+			sy = m_screen_height - 16 - sy;
+			delta = -delta;
+		}
+
+		// calculate accumulators
+		const int flipx_global = flipx ^ m_flip_screen;
+		const int flipy_global = flipy ^ m_flip_screen;
+
+		const int xinc = delta * (flipx ? -1 : 1);
+		const int yinc = delta * (flipy ? -1 : 1);
+
+		int xx_base = w;
+		int yy = h;
+
+		sx += flipx ? (delta * w) : 0;
+		sy += flipy ? (delta * h) : 0;
+
+		// restrict to cliprect
+		if (m_flip_screen)
+		{
+			if (sx < cliprect.min_x - 0xf) sx += xpos_max;
+			if (sx > cliprect.max_x)
+			{
+				const int pixels = (sx - cliprect.max_x) / 16;
+				code += pixels;
+				sx += pixels * xinc;
+				xx_base -= pixels;
+			}
+
+			if (sy < cliprect.min_y - 0xf) sy += ypos_max;
+			if (sy > cliprect.max_y)
+			{
+				const int pixels = (sy - cliprect.max_y) / 16;
+				code += pixels * (w + 1);
+				sy += pixels * yinc;
+				yy -= pixels;
+			}
+		}
+		else
+		{
+			if (sx > cliprect.max_x) sx -= xpos_max;
+			if (sx < cliprect.min_x - 0xf)
+			{
+				const int pixels = ((cliprect.min_x - 0xf) - sx) / 16;
+				code += pixels;
+				sx += pixels * xinc;
+				xx_base -= pixels;
+			}
+
+			if (sy > cliprect.max_y) sy -= ypos_max;
+			if (sy < cliprect.min_y - 0xf)
+			{
+				const int pixels = ((cliprect.min_y - 0xf) - sy) / 16;
+				code += pixels * (w + 1);
+				sy += pixels * yinc;
+				yy -= pixels;
+			}
+		}
+		if ((xx_base < 0) || (yy < 0))
+			continue;
+
+		// draw single sprite
+		do
+		{
+			// wraparound Y
+			if (yinc > 0)
+			{
+				if (sy > cliprect.max_y) sy -= ypos_max;
+				if (sy < cliprect.min_y - 0xf)
+				{
+					const int pixels = ((cliprect.min_y - 0xf) - sy) / 16;
+					code += pixels * (w + 1);
+					sy += pixels * yinc;
+					yy -= pixels;
+				}
+			}
+			else if (yinc < 0)
+			{
+				if (sy < cliprect.min_y - 0xf) sy += ypos_max;
+				if (sy > cliprect.max_y)
+				{
+					const int pixels = (sy - cliprect.max_y) / 16;
+					code += pixels * (w + 1);
+					sy += pixels * yinc;
+					yy -= pixels;
+				}
+			}
+			if (yy < 0)
+				continue;
+
+			int x = sx;
+			int xx = xx_base;
+			int codecol = code;
+			do
+			{
+				// wraparound X
+				if (xinc > 0)
+				{
+					if (x > cliprect.max_x) x -= xpos_max;
+					if (x < cliprect.min_x - 0xf)
+					{
+						const int pixels = ((cliprect.min_x - 0xf) - x) / 16;
+						codecol += pixels;
+						x += pixels * xinc;
+						xx -= pixels;
+					}
+				}
+				else if (xinc < 0)
+				{
+					if (x < cliprect.min_x - 0xf) x += xpos_max;
+					if (x > cliprect.max_x)
+					{
+						const int pixels = (x - cliprect.max_x) / 16;
+						codecol += pixels;
+						x += pixels * xinc;
+						xx -= pixels;
+					}
+				}
+				if (xx < 0)
+					continue;
+
+				if (priority)
+				{
+					sprite_ptr->code = codecol;
+					sprite_ptr->colour = colour;
+					sprite_ptr->flipx = flipx_global;
+					sprite_ptr->flipy = flipy_global;
+					sprite_ptr->x = x;
+					sprite_ptr->y = sy;
+					sprite_ptr->pri_mask = pri_mask;
+					sprite_ptr++;
+				}
+				else
+				{
+					gfx->transpen(bitmap, cliprect,
+						codecol,
+						colour,
+						flipx_global, flipy_global,
+						x, sy, 15);
+				}
+				codecol++;
+				x += xinc;
+			} while (--xx >= 0);
+			code += (w + 1);
+			sy += yinc;
+		} while (--yy >= 0);
+	}
+
+	if (priority)
+	{
+		while (sprite_ptr != m_spritelist.get())
+		{
+			sprite_ptr--;
+
+			gfx->prio_transpen(bitmap, cliprect,
+					sprite_ptr->code,
+					sprite_ptr->colour,
+					sprite_ptr->flipx, sprite_ptr->flipy,
+					sprite_ptr->x, sprite_ptr->y, screen.priority(), sprite_ptr->pri_mask, 15);
+		}
+	}
+}
+
+void nmk_16bit_sprite_device::device_start()
+{
+	m_colpri_cb.bind_relative_to(*owner());
+	m_ext_cb.bind_relative_to(*owner());
+	m_flip_screen = false;
+	m_spritelist = make_unique_clear<struct sprite_t[]>((0x1000/0x10) * 16 * 16);
+
+	save_item(NAME(m_flip_screen));
+}
+
+void nmk_16bit_sprite_device::device_reset()
+{
+}

--- a/src/mame/video/nmk16spr.h
+++ b/src/mame/video/nmk16spr.h
@@ -22,6 +22,7 @@ public:
 	void set_videoshift(int shift) { m_videoshift = shift; }
 	void set_mask(int xmask, int ymask) { m_xmask = xmask, m_ymask = ymask; }
 	void set_screen_size(int width, int height) { m_screen_width = width, m_screen_height = height; }
+	void set_max_sprite_clock(u32 max) { m_max_sprite_clock = max; }
 
 	void draw_sprites(screen_device &screen, bitmap_ind16 &bitmap, const rectangle &cliprect, gfx_element *gfx, u16* spriteram, int size);
 	void set_flip_screen(bool flip) { m_flip_screen = flip; }
@@ -45,6 +46,7 @@ private:
 	int m_videoshift;
 	int m_xmask, m_ymask;
 	int m_screen_width, m_screen_height;
+	u32 m_max_sprite_clock;
 	std::unique_ptr<struct sprite_t[]> m_spritelist;
 };
 

--- a/src/mame/video/nmk16spr.h
+++ b/src/mame/video/nmk16spr.h
@@ -42,7 +42,7 @@ private:
 	nmk16_spr_colpri_cb_delegate m_colpri_cb;  // callback for colour, priority
 	nmk16_spr_ext_cb_delegate m_ext_cb;        // callback for flipx, flipy or code bit modification
 	bool m_flip_screen;                        // flip screen
-	int m_videoshift;                          // video shifting needs for more than 256 horizontal screen pixels
+	int m_videoshift;                          // x offset needs for more than 256 horizontal screen pixels
 	int m_xmask, m_ymask;                      // x,y position masking
 	int m_screen_width, m_screen_height;       // screen size related to flipscreen
 	u32 m_max_sprite_clock;                    // max sprite cycles, related to screen total size?

--- a/src/mame/video/nmk16spr.h
+++ b/src/mame/video/nmk16spr.h
@@ -39,14 +39,14 @@ private:
 		bool flipx, flipy;
 		u32 pri_mask;
 	};
-	colpri_cb_delegate m_colpri_cb;  // callback for colour, priority
-	ext_cb_delegate m_ext_cb;        // callback for flipx, flipy or code bit modification
-	bool m_flip_screen;                        // flip screen
-	int m_videoshift;                          // x offset needs for more than 256 horizontal screen pixels
-	int m_xmask, m_ymask;                      // x,y position masking
-	int m_screen_width, m_screen_height;       // screen size related to flipscreen
-	u32 m_max_sprite_clock;                    // max sprite cycles, related to screen total size?
-	std::unique_ptr<struct sprite_t[]> m_spritelist;
+	colpri_cb_delegate m_colpri_cb;                  // callback for colour, priority
+	ext_cb_delegate m_ext_cb;                        // callback for flipx, flipy or code bit modification
+	bool m_flip_screen;                              // flip screen
+	int m_videoshift;                                // x offset needs for more than 256 horizontal screen pixels
+	int m_xmask, m_ymask;                            // x,y position masking
+	int m_screen_width, m_screen_height;             // screen size related to flipscreen
+	u32 m_max_sprite_clock;                          // max sprite cycles, related to screen total size?
+	std::unique_ptr<struct sprite_t[]> m_spritelist; // sprite list caches
 };
 
 DECLARE_DEVICE_TYPE(NMK_16BIT_SPRITE, nmk_16bit_sprite_device)

--- a/src/mame/video/nmk16spr.h
+++ b/src/mame/video/nmk16spr.h
@@ -8,17 +8,17 @@
 
 #include "screen.h"
 
-typedef device_delegate<void (u32 &colour, u32 &pri_mask)> nmk16_spr_colpri_cb_delegate;
-typedef device_delegate<void (u16 attr, int &flipx, int &flipy, int &code)> nmk16_spr_ext_cb_delegate;
-
 class nmk_16bit_sprite_device : public device_t
 {
 public:
 	nmk_16bit_sprite_device(const machine_config &mconfig, const char *tag, device_t *owner, uint32_t clock);
 
+	typedef device_delegate<void (u32 &colour, u32 &pri_mask)> nmk16_spr_colpri_cb_delegate;
+	typedef device_delegate<void (u16 attr, int &flipx, int &flipy, int &code)> nmk16_spr_ext_cb_delegate;
+
 	// configuration
-	template <typename... T> void set_colpri_callback(T &&... args) { m_colpri_cb = nmk16_spr_colpri_cb_delegate(std::forward<T>(args)...); }
-	template <typename... T> void set_ext_callback(T &&... args) { m_ext_cb = nmk16_spr_ext_cb_delegate(std::forward<T>(args)...); }
+	template <typename... T> void set_colpri_callback(T &&... args) { m_colpri_cb = nmk_16bit_sprite_device::nmk16_spr_colpri_cb_delegate(std::forward<T>(args)...); }
+	template <typename... T> void set_ext_callback(T &&... args) { m_ext_cb = nmk_16bit_sprite_device::nmk16_spr_ext_cb_delegate(std::forward<T>(args)...); }
 	void set_videoshift(int shift) { m_videoshift = shift; }
 	void set_mask(int xmask, int ymask) { m_xmask = xmask, m_ymask = ymask; }
 	void set_screen_size(int width, int height) { m_screen_width = width, m_screen_height = height; }

--- a/src/mame/video/nmk16spr.h
+++ b/src/mame/video/nmk16spr.h
@@ -1,0 +1,53 @@
+// license:BSD-3-Clause
+// copyright-holders:Mirko Buffoni,Nicola Salmoria,Bryan McPhail,David Haywood,R. Belmont,Alex Marshall,Angelo Salese,Luca Elia
+// thanks-to:Richard Bush
+#ifndef MAME_VIDEO_NMK16SPR_H
+#define MAME_VIDEO_NMK16SPR_H
+
+#pragma once
+
+#include "screen.h"
+
+typedef device_delegate<void (u32 &colour, u32 &pri_mask)> nmk16_spr_colpri_cb_delegate;
+typedef device_delegate<void (u16 attr, int &flipx, int &flipy, int &code)> nmk16_spr_ext_cb_delegate;
+
+class nmk_16bit_sprite_device : public device_t
+{
+public:
+	nmk_16bit_sprite_device(const machine_config &mconfig, const char *tag, device_t *owner, uint32_t clock);
+
+	// configuration
+	template <typename... T> void set_colpri_callback(T &&... args) { m_colpri_cb = nmk16_spr_colpri_cb_delegate(std::forward<T>(args)...); }
+	template <typename... T> void set_ext_callback(T &&... args) { m_ext_cb = nmk16_spr_ext_cb_delegate(std::forward<T>(args)...); }
+	void set_videoshift(int shift) { m_videoshift = shift; }
+	void set_mask(int xmask, int ymask) { m_xmask = xmask, m_ymask = ymask; }
+	void set_screen_size(int width, int height) { m_screen_width = width, m_screen_height = height; }
+
+	void draw_sprites(screen_device &screen, bitmap_ind16 &bitmap, const rectangle &cliprect, gfx_element *gfx, u16* spriteram, int size);
+	void set_flip_screen(bool flip) { m_flip_screen = flip; }
+
+protected:
+	virtual void device_start() override;
+	virtual void device_reset() override;
+
+private:
+	struct sprite_t
+	{
+		int height;
+		u32 code, colour;
+		int x, y;
+		bool flipx, flipy;
+		u32 pri_mask;
+	};
+	nmk16_spr_colpri_cb_delegate m_colpri_cb;
+	nmk16_spr_ext_cb_delegate m_ext_cb;
+	bool m_flip_screen;
+	int m_videoshift;
+	int m_xmask, m_ymask;
+	int m_screen_width, m_screen_height;
+	std::unique_ptr<struct sprite_t[]> m_spritelist;
+};
+
+DECLARE_DEVICE_TYPE(NMK_16BIT_SPRITE, nmk_16bit_sprite_device)
+
+#endif // MAME_VIDEO_NMK16SPR_H

--- a/src/mame/video/nmk16spr.h
+++ b/src/mame/video/nmk16spr.h
@@ -22,7 +22,7 @@ public:
 	void set_videoshift(int shift) { m_videoshift = shift; }
 	void set_mask(int xmask, int ymask) { m_xmask = xmask, m_ymask = ymask; }
 	void set_screen_size(int width, int height) { m_screen_width = width, m_screen_height = height; }
-	void set_max_sprite_clock(u32 max) { m_max_sprite_clock = max; } // related to screen total size?
+	void set_max_sprite_clock(u32 max) { m_max_sprite_clock = max; }
 
 	void draw_sprites(screen_device &screen, bitmap_ind16 &bitmap, const rectangle &cliprect, gfx_element *gfx, u16* spriteram, int size);
 	void set_flip_screen(bool flip) { m_flip_screen = flip; }
@@ -34,19 +34,18 @@ protected:
 private:
 	struct sprite_t
 	{
-		int height;
 		u32 code, colour;
 		int x, y;
 		bool flipx, flipy;
 		u32 pri_mask;
 	};
-	nmk16_spr_colpri_cb_delegate m_colpri_cb;
-	nmk16_spr_ext_cb_delegate m_ext_cb;
-	bool m_flip_screen;
-	int m_videoshift;
-	int m_xmask, m_ymask;
-	int m_screen_width, m_screen_height;
-	u32 m_max_sprite_clock;
+	nmk16_spr_colpri_cb_delegate m_colpri_cb;  // callback for colour, priority
+	nmk16_spr_ext_cb_delegate m_ext_cb;        // callback for flipx, flipy or code bit modification
+	bool m_flip_screen;                        // flip screen
+	int m_videoshift;                          // video shifting needs for more than 256 horizontal screen pixels
+	int m_xmask, m_ymask;                      // x,y position masking
+	int m_screen_width, m_screen_height;       // screen size related to flipscreen
+	u32 m_max_sprite_clock;                    // max sprite cycles, related to screen total size?
 	std::unique_ptr<struct sprite_t[]> m_spritelist;
 };
 

--- a/src/mame/video/nmk16spr.h
+++ b/src/mame/video/nmk16spr.h
@@ -22,7 +22,7 @@ public:
 	void set_videoshift(int shift) { m_videoshift = shift; }
 	void set_mask(int xmask, int ymask) { m_xmask = xmask, m_ymask = ymask; }
 	void set_screen_size(int width, int height) { m_screen_width = width, m_screen_height = height; }
-	void set_max_sprite_clock(u32 max) { m_max_sprite_clock = max; }
+	void set_max_sprite_clock(u32 max) { m_max_sprite_clock = max; } // related to screen total size?
 
 	void draw_sprites(screen_device &screen, bitmap_ind16 &bitmap, const rectangle &cliprect, gfx_element *gfx, u16* spriteram, int size);
 	void set_flip_screen(bool flip) { m_flip_screen = flip; }

--- a/src/mame/video/nmk16spr.h
+++ b/src/mame/video/nmk16spr.h
@@ -13,12 +13,12 @@ class nmk_16bit_sprite_device : public device_t
 public:
 	nmk_16bit_sprite_device(const machine_config &mconfig, const char *tag, device_t *owner, uint32_t clock);
 
-	typedef device_delegate<void (u32 &colour, u32 &pri_mask)> nmk16_spr_colpri_cb_delegate;
-	typedef device_delegate<void (u16 attr, int &flipx, int &flipy, int &code)> nmk16_spr_ext_cb_delegate;
+	typedef device_delegate<void (u32 &colour, u32 &pri_mask)> colpri_cb_delegate;
+	typedef device_delegate<void (u16 attr, int &flipx, int &flipy, int &code)> ext_cb_delegate;
 
 	// configuration
-	template <typename... T> void set_colpri_callback(T &&... args) { m_colpri_cb = nmk_16bit_sprite_device::nmk16_spr_colpri_cb_delegate(std::forward<T>(args)...); }
-	template <typename... T> void set_ext_callback(T &&... args) { m_ext_cb = nmk_16bit_sprite_device::nmk16_spr_ext_cb_delegate(std::forward<T>(args)...); }
+	template <typename... T> void set_colpri_callback(T &&... args) { m_colpri_cb = nmk_16bit_sprite_device::colpri_cb_delegate(std::forward<T>(args)...); }
+	template <typename... T> void set_ext_callback(T &&... args) { m_ext_cb = nmk_16bit_sprite_device::ext_cb_delegate(std::forward<T>(args)...); }
 	void set_videoshift(int shift) { m_videoshift = shift; }
 	void set_mask(int xmask, int ymask) { m_xmask = xmask, m_ymask = ymask; }
 	void set_screen_size(int width, int height) { m_screen_width = width, m_screen_height = height; }
@@ -39,8 +39,8 @@ private:
 		bool flipx, flipy;
 		u32 pri_mask;
 	};
-	nmk16_spr_colpri_cb_delegate m_colpri_cb;  // callback for colour, priority
-	nmk16_spr_ext_cb_delegate m_ext_cb;        // callback for flipx, flipy or code bit modification
+	colpri_cb_delegate m_colpri_cb;  // callback for colour, priority
+	ext_cb_delegate m_ext_cb;        // callback for flipx, flipy or code bit modification
 	bool m_flip_screen;                        // flip screen
 	int m_videoshift;                          // x offset needs for more than 256 horizontal screen pixels
 	int m_xmask, m_ymask;                      // x,y position masking

--- a/src/mame/video/powerins.cpp
+++ b/src/mame/video/powerins.cpp
@@ -54,6 +54,7 @@ Note:   if MAME_DEBUG is defined, pressing Z with:
 WRITE8_MEMBER(powerins_state::flipscreen_w)
 {
 	flip_screen_set(data & 1);
+	m_spritegen->set_flip_screen(flip_screen());
 }
 
 WRITE8_MEMBER(powerins_state::tilebank_w)
@@ -201,66 +202,16 @@ Offset:     Format:                 Value:
 ------------------------------------------------------------------------ */
 
 
-void powerins_state::draw_sprites(bitmap_ind16 &bitmap,const rectangle &cliprect)
+void powerins_state::get_colour_6bit(u32 &colour, u32 &pri_mask)
 {
-	uint16_t *source = m_spritebuffer[1].get();
-	uint16_t *finish = m_spritebuffer[1].get() + 0x1000/2;
+	colour &= 0x3f;
+	pri_mask |= GFX_PMASK_2; // under foreground
+}
 
-	int screen_w = m_screen->width();
-	int screen_h = m_screen->height();
-
-	for ( ; source < finish; source += 16/2 )
-	{
-		int x,y,inc;
-
-		int attr    =   source[ 0x0/2 ];
-		int size    =   source[ 0x2/2 ];
-		int code    =   source[ 0x6/2 ];
-		int sx      =   source[ 0x8/2 ];
-		int sy      =   source[ 0xc/2 ];
-		int color   =   source[ 0xe/2 ];
-
-		int flipx   =   size & 0x1000;
-		int flipy   =   0;  // ??
-
-		int dimx    =   ((size >> 0) & 0xf ) + 1;
-		int dimy    =   ((size >> 4) & 0xf ) + 1;
-
-		if (!(attr&1)) continue;
-
-		sx = (sx & 0x1ff) - (sx & 0x200);
-		sy = (sy & 0x1ff) - (sy & 0x200);
-
-		/* Handle flip_screen. Apply a global offset of 32 pixels along x too */
-
-		if (flip_screen())
-		{
-			sx = screen_w - sx - dimx*16 - 32;  flipx = !flipx;
-			sy = screen_h - sy - dimy*16;       flipy = !flipy;
-			code += dimx*dimy-1;            inc = -1;
-		}
-		else
-		{
-			sx += 32;                       inc = +1;
-		}
-
-		code = (code & 0x7fff) | ( (size & 0x0100) << 7 );
-
-		for (x = 0 ; x < dimx ; x++)
-		{
-			for (y = 0 ; y < dimy ; y++)
-			{
-				m_gfxdecode->gfx(2)->transpen(bitmap,cliprect,
-						code,
-						color,
-						flipx, flipy,
-						sx + x*16,
-						sy + y*16,15);
-
-				code += inc;
-			}
-		}
-	}
+void powerins_state::get_flip_extcode(u16 attr, int &flipx, int &flipy, int &code)
+{
+	flipx = (attr & 0x1000) >> 12;
+	code = (code & 0x7fff) | ((attr & 0x100) << 7);
 }
 
 
@@ -298,10 +249,11 @@ if (machine().input().code_pressed(KEYCODE_Z))
 }
 #endif
 
-	if (layers_ctrl&1)      m_tilemap[0]->draw(screen, bitmap, cliprect, 0, 0);
+	screen.priority().fill(0, cliprect);
+	if (layers_ctrl&1)      m_tilemap[0]->draw(screen, bitmap, cliprect, 0, 1);
 	else                    bitmap.fill(0, cliprect);
-	if (layers_ctrl&8)      draw_sprites(bitmap,cliprect);
-	if (layers_ctrl&2)      m_tilemap[1]->draw(screen, bitmap, cliprect, 0, 0);
+	if (layers_ctrl&2)      m_tilemap[1]->draw(screen, bitmap, cliprect, 0, 2);
+	if (layers_ctrl&8)      m_spritegen->draw_sprites(screen, bitmap, cliprect, m_gfxdecode->gfx(2), m_spritebuffer[1].get(), 0x1000/2);
 	return 0;
 }
 


### PR DESCRIPTION
Original source by nmk16.cpp, with Fix flipped case, Allow pdrawgfx drawing
nmk16.cpp, powerins.cpp : Convert sprite draw routine into nmk16spr.cpp
nmk16.cpp : Fix manybloc flipped screen, Remove unused
powerins.cpp : Verify clock related to on-board XTALs, Add screen raw params