### PR TITLE
Fix AVI framerate

### DIFF
--- a/src/emu/machine.cpp
+++ b/src/emu/machine.cpp
@@ -265,6 +265,15 @@ void running_machine::start()
 	save().register_postload(save_prepost_delegate(FUNC(running_machine::postload_all_devices), this));
 	manager().load_cheatfiles(*this);
 
+	// start recording movie if specified
+	const char *filename = options().mng_write();
+	if (filename[0] != 0)
+		m_video->begin_recording(filename, video_manager::MF_MNG);
+
+	filename = options().avi_write();
+	if (filename[0] != 0)
+		m_video->begin_recording(filename, video_manager::MF_AVI);
+
 	// if we're coming in with a savegame request, process it now
 	const char *savegame = options().state();
 	if (savegame[0] != 0)

--- a/src/emu/video.cpp
+++ b/src/emu/video.cpp
@@ -166,16 +166,7 @@ video_manager::video_manager(running_machine &machine)
 	// extract snap resolution if present
 	if (sscanf(machine.options().snap_size(), "%dx%d", &m_snap_width, &m_snap_height) != 2)
 		m_snap_width = m_snap_height = 0;
-
-	// start recording movie if specified
-	const char *filename = machine.options().mng_write();
-	if (filename[0] != 0)
-		begin_recording(filename, MF_MNG);
-
-	filename = machine.options().avi_write();
-	if (filename[0] != 0)
-		begin_recording(filename, MF_AVI);
-
+	
 	// if no screens, create a periodic timer to drive updates
 	if (no_screens)
 	{


### PR DESCRIPTION
MAME was setting up AVI before devices have properly launched, so default 60fps was used, which resulted in skipped frames in the video if machine's framerate is above 60 (btoads), and presumably duplicate frames for machines below 60fps (haven't tested).

Now every frame that is generated is also present in the video.

Test script (dump avi with framecount display):

```lua
local function getscreen()
    for k,v in pairs(manager:machine().screens) do return v end
end

local screen = getscreen()

local function framecount()
	str = "frame: " .. screen:frame_number()
	print(str)
	screen:draw_text(0, 0, str, 0xffffffff, 0xff000000)
end

emu.register_frame_done(framecount)
```