### PR TITLE
Continuous integration improvements

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -29,7 +29,7 @@ for:
       - set MSYSTEM=MINGW64
       - bash -lc "pacman -Syu --noconfirm"
     build_script:
-      - bash -lc "exec 0</dev/null && cd $APPVEYOR_BUILD_FOLDER && export MINGW64=/mingw64 && make SUBTARGET=tiny PTR64=1 OPTIMIZE=0 ARCHOPTS=-Wa,-mbig-obj IGNORE_GIT=1 -j3"
+      - bash -lc "exec 0</dev/null && cd $APPVEYOR_BUILD_FOLDER && export MINGW64=/mingw64 && make SUBTARGET=tiny PTR64=1 TOOLS=1 OPTIMIZE=1 IGNORE_GIT=1 -j3"
     test_script:
       - \projects\mame\mametiny64.exe -validate
     after_test:

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -13,7 +13,6 @@ environment:
 install:
   - set "PATH=C:\msys64\usr\bin;C:\msys64\mingw64\bin;C:\Windows\System32;C:\Windows;%PATH%"
   - set MSYSTEM=MINGW64
-  - set PreferredToolArchitecture=x64
 
 build_script:
   - bash -lc "exec 0</dev/null && cd $APPVEYOR_BUILD_FOLDER && export MINGW64=/mingw64 && make SUBTARGET=tiny PTR64=1 TOOLS=1 OPTIMIZE=0 vs2019 -j3"

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -18,11 +18,6 @@ install:
 build_script:
   - bash -lc "exec 0</dev/null && cd $APPVEYOR_BUILD_FOLDER && export MINGW64=/mingw64 && make SUBTARGET=tiny PTR64=1 TOOLS=1 OPTIMIZE=0 vs2019 -j3"
   - msbuild "build\projects\windows\mametiny\vs2019\mametiny.sln" /m /p:ContinueOnError=false /p:StopOnFirstFailure=true /property:Configuration=Debug /property:Platform=x64 /logger:"C:\Program Files\AppVeyor\BuildAgent\Appveyor.MSBuildLogger.dll"
-
-matrix:
-  allow_failures:
-    - BUILD: MSVC
-
 for:
   -
     matrix:

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -1,5 +1,6 @@
 version: 1.0.{build}
 image:
+  - Visual Studio 2017
   - Visual Studio 2019
 
 shallow_clone: true
@@ -9,6 +10,13 @@ environment:
   matrix:
     - BUILD: GCC
     - BUILD: MSVC
+
+matrix:
+  exclude:
+    - image: Visual Studio 2017
+      BUILD: MSVC
+    - image: Visual Studio 2019
+      BUILD: GCC
 
 install:
   - set "PATH=C:\msys64\usr\bin;C:\msys64\mingw64\bin;C:\Windows\System32;C:\Windows;%PATH%"

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -36,6 +36,7 @@ for:
       - set "PATH=C:\msys64\usr\bin;C:\msys64\mingw64\bin;C:\Windows\System32;C:\Windows;%PATH%"
       - set MSYSTEM=MINGW64
       - bash -lc "pacman -Syu --noconfirm"
+      - bash -lc "pacman -Syu --noconfirm"
     build_script:
       - bash -lc "exec 0</dev/null && cd $APPVEYOR_BUILD_FOLDER && export MINGW64=/mingw64 && make SUBTARGET=tiny PTR64=1 TOOLS=1 OPTIMIZE=1 IGNORE_GIT=1 -j3"
     test_script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,11 +17,11 @@ env:
 script:
   - if [ $TRAVIS_OS_NAME == 'linux' ]; then
     if [ $CC == 'clang' ]; then
-    make -j2 IGNORE_GIT=1 OVERRIDE_CXX="clang++-3.6" OVERRIDE_CC="clang-3.6" && ./$MAME -validate;
-    else make -j4 IGNORE_GIT=1 OPTIMIZE=0 OVERRIDE_CC="gcc-9" OVERRIDE_CXX="g++-9" && ./$MAME -validate;
+    make -j2 IGNORE_GIT=1 OVERRIDE_CXX="clang++-3.6" OVERRIDE_CC="clang-3.6" TOOLS=1 && ./$MAME -validate;
+    else make -j4 IGNORE_GIT=1 OPTIMIZE=0 OVERRIDE_CC="gcc-9" OVERRIDE_CXX="g++-9" TOOLS=1 && ./$MAME -validate;
     fi
     elif [ $TRAVIS_OS_NAME == 'osx' ]; then
-    unset LDOPTS && make -j2 OPTIMIZE=0 USE_LIBSDL=1 && ./$MAME -validate;
+    unset LDOPTS && make -j2 OPTIMIZE=0 USE_LIBSDL=1 TOOLS=1 && ./$MAME -validate;
     fi
 sudo: required
 before_install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,7 @@ os:
   - linux
   - osx
 dist: bionic
+osx_image: xcode11
 matrix:
   exclude:
     - os: osx

--- a/3rdparty/genie/src/actions/vstudio/vstudio_vcxproj.lua
+++ b/3rdparty/genie/src/actions/vstudio/vstudio_vcxproj.lua
@@ -66,7 +66,7 @@
 		else
 			_p(2, '<Keyword>Win32Proj</Keyword>')
 		end
-		if _ACTION:sub(3) == "2015" or _ACTION:sub(3) == "2017" or _ACTION:sub(3) == "llvm" then
+		if _ACTION:sub(3) == "2015" or _ACTION:sub(3) == "2017" or _ACTION:sub(3) == "2019" or _ACTION:sub(3) == "llvm" then
 			_p(2,'<PreferredToolArchitecture>x64</PreferredToolArchitecture>')
 		end
 		if (_ACTION:sub(3) == "2017" or _ACTION:sub(3) == "llvm")

--- a/scripts/src/tools.lua
+++ b/scripts/src/tools.lua
@@ -133,6 +133,15 @@ files {
 configuration { "mingw*" or "vs*" }
 	targetextension ".exe"
 
+-- workaround for https://developercommunity.visualstudio.com/content/problem/752372/vs2019-v1631-c-internal-compiler-error-when-zi-opt.html
+-- should be fixed in 16.5
+configuration { "Debug", "vs2019" }
+	if _OPTIONS["vs"]==nil then
+		flags {
+			"NoEditAndContinue",
+		}
+	end
+
 configuration { }
 
 strip()
@@ -748,6 +757,15 @@ files {
 
 configuration { "mingw*" or "vs*" }
 	targetextension ".exe"
+
+-- workaround for https://developercommunity.visualstudio.com/content/problem/752372/vs2019-v1631-c-internal-compiler-error-when-zi-opt.html
+-- should be fixed in 16.5
+configuration { "Debug", "vs2019" }
+	if _OPTIONS["vs"]==nil then
+		flags {
+			"NoEditAndContinue",
+		}
+	end
 
 configuration { }
 


### PR DESCRIPTION
As the only remaining build failures only affect debug build of tools, tweak the configuration so that the build can actually complete:
* disable tools build
* switch to release build while disabling optimization
* no longer allow msvc build to fail