### PR TITLE
hh_sm510: confirm gnw_mmouse rom (nw)

### DIFF
--- a/src/mame/drivers/hh_sm510.cpp
+++ b/src/mame/drivers/hh_sm510.cpp
@@ -18,8 +18,8 @@ TODO:
 - improve display decay simulation? but SVG doesn't support setting brightness
   per segment, adding pwm_display_device right now has no added value
 - improve/redo SVGs of: gnw_mmouse, gnw_egg, exospace
-- confirm gnw_mmouse/gnw_egg rom (dumped from Soviet clone, but pretty
-  confident that it's same)
+- confirm gnw_egg rom (now using gnw_mmouse rom, but pretty confident that it's
+  the same)
 - confirm gnw_bfight rom (assumed to be the same as gnw_bfightn)
 - confirm gnw_climber rom (assumed to be the same as gnw_climbern)
 - dump/add purple version of gnw_judge
@@ -1315,7 +1315,7 @@ ROM_END
 
   Nintendo Game & Watch: Mickey Mouse (model MC-25), Egg (model EG-26)
   * PCB label MC-25 EG-26 (yes, both listed)
-  * Sharp SM5A label MC-25 51YD / ?
+  * Sharp SM5A label MC-25 51YD (no decap)
   * lcd screen with custom segments, 1-bit sound
 
   MC-25 and EG-26 are the same game, it's assumed that the latter was for
@@ -1440,7 +1440,7 @@ void gnw_mmouse_state::exospace(machine_config &config)
 
 ROM_START( gnw_mmouse )
 	ROM_REGION( 0x1000, "maincpu", 0 )
-	ROM_LOAD( "mc-25", 0x0000, 0x0740, BAD_DUMP CRC(cb820c32) SHA1(7e94fc255f32db725d5aa9e196088e490c1a1443) ) // dumped from Soviet clone
+	ROM_LOAD( "mc-25", 0x0000, 0x0740, CRC(cb820c32) SHA1(7e94fc255f32db725d5aa9e196088e490c1a1443) )
 
 	ROM_REGION( 102453, "screen", 0)
 	ROM_LOAD( "gnw_mmouse.svg", 0, 102453, BAD_DUMP CRC(88cc7c49) SHA1(c000d51d1b99750116b97f9bafc0314ea506366d) )
@@ -1448,7 +1448,7 @@ ROM_END
 
 ROM_START( gnw_egg )
 	ROM_REGION( 0x1000, "maincpu", 0 )
-	ROM_LOAD( "eg-26", 0x0000, 0x0740, BAD_DUMP CRC(cb820c32) SHA1(7e94fc255f32db725d5aa9e196088e490c1a1443) ) // dumped from Soviet clone
+	ROM_LOAD( "eg-26", 0x0000, 0x0740, BAD_DUMP CRC(cb820c32) SHA1(7e94fc255f32db725d5aa9e196088e490c1a1443) ) // dumped from MC-25
 
 	ROM_REGION( 102848, "screen", 0)
 	ROM_LOAD( "gnw_egg.svg", 0, 102848, BAD_DUMP CRC(742c2605) SHA1(984d430ad2ff47ad7a3f9b25b7d3f3d51b10cca5) )


### PR DESCRIPTION
Have now confirmed that the gnw_mmouse rom exactly matches the rom of the Soviet clone.