### PR TITLE
fmtowns: bring machine configurations a bit closer to real hardware

### DIFF
--- a/src/mame/drivers/fmtowns.cpp
+++ b/src/mame/drivers/fmtowns.cpp
@@ -498,7 +498,7 @@ READ8_MEMBER(towns_state::towns_floppy_r)
 			case 2:
 				ret |= 0x0c;
 				if(m_flop[1]->get_device() && m_flop[1]->get_device()->exists())
-						ret |= 0x03;
+					ret |= 0x03;
 				break;
 			case 3:
 			case 4:

--- a/src/mame/drivers/fmtowns.cpp
+++ b/src/mame/drivers/fmtowns.cpp
@@ -493,12 +493,14 @@ READ8_MEMBER(towns_state::towns_floppy_r)
 			case 1:
 				ret |= 0x0c;
 				if(m_flop[0]->get_device())
-					ret |= 0x03;
+					if(m_flop[0]->get_device()->exists())
+						ret |= 0x03;
 				break;
 			case 2:
 				ret |= 0x0c;
 				if(m_flop[1]->get_device())
-					ret |= 0x03;
+					if(m_flop[1]->get_device()->exists())
+						ret |= 0x03;
 				break;
 			case 3:
 			case 4:

--- a/src/mame/drivers/fmtowns.cpp
+++ b/src/mame/drivers/fmtowns.cpp
@@ -492,14 +492,12 @@ READ8_MEMBER(towns_state::towns_floppy_r)
 			{
 			case 1:
 				ret |= 0x0c;
-				if(m_flop[0]->get_device())
-					if(m_flop[0]->get_device()->exists())
-						ret |= 0x03;
+				if(m_flop[0]->get_device() && m_flop[0]->get_device()->exists())
+					ret |= 0x03;
 				break;
 			case 2:
 				ret |= 0x0c;
-				if(m_flop[1]->get_device())
-					if(m_flop[1]->get_device()->exists())
+				if(m_flop[1]->get_device() && m_flop[1]->get_device()->exists())
 						ret |= 0x03;
 				break;
 			case 3:
@@ -2908,13 +2906,13 @@ void towns16_state::townsux(machine_config &config)
 
 	FMSCSI(config, m_scsi, 0);
 	m_scsi->set_scsi_port("scsi");
-	m_scsi->irq_handler().set(FUNC(towns_state::towns_scsi_irq));
-	m_scsi->drq_handler().set(FUNC(towns_state::towns_scsi_drq));
+	m_scsi->irq_handler().set(FUNC(towns16_state::towns_scsi_irq));
+	m_scsi->drq_handler().set(FUNC(towns16_state::towns_scsi_drq));
 
-	m_dma[0]->dma_read_callback<1>().set(FUNC(towns_state::towns_scsi_dma_r));
-	m_dma[0]->dma_write_callback<1>().set(FUNC(towns_state::towns_scsi_dma_w));
-	m_dma[1]->dma_read_callback<1>().set(FUNC(towns_state::towns_scsi_dma_r));
-	m_dma[1]->dma_write_callback<1>().set(FUNC(towns_state::towns_scsi_dma_w));
+	m_dma[0]->dma_read_callback<1>().set(FUNC(towns16_state::towns_scsi_dma_r));
+	m_dma[0]->dma_write_callback<1>().set(FUNC(towns16_state::towns_scsi_dma_w));
+	m_dma[1]->dma_read_callback<1>().set(FUNC(towns16_state::towns_scsi_dma_r));
+	m_dma[1]->dma_write_callback<1>().set(FUNC(towns16_state::towns_scsi_dma_w));
 
 	// 2 MB onboard, one SIMM slot with 2-8 MB
 	m_ram->set_default_size("2M").set_extra_options("4M,6M,10M");

--- a/src/mame/includes/fmtowns.h
+++ b/src/mame/includes/fmtowns.h
@@ -141,11 +141,7 @@ class towns_state : public driver_device
 	void townsmx(machine_config &config);
 	void townssj(machine_config &config);
 
-	DECLARE_WRITE_LINE_MEMBER(towns_scsi_irq);
-	DECLARE_WRITE_LINE_MEMBER(towns_scsi_drq);
 	INTERRUPT_GEN_MEMBER(towns_vsync_irq);
-	DECLARE_READ16_MEMBER(towns_scsi_dma_r);
-	DECLARE_WRITE16_MEMBER(towns_scsi_dma_w);
 	
 protected:
 	uint16_t m_towns_machine_id;  // default is 0x0101
@@ -168,6 +164,11 @@ protected:
 	optional_device<fmscsi_device> m_scsi;
 	required_device_array<floppy_connector, 2> m_flop;
 	DECLARE_FLOPPY_FORMATS(floppy_formats);
+
+	DECLARE_WRITE_LINE_MEMBER(towns_scsi_irq);
+	DECLARE_WRITE_LINE_MEMBER(towns_scsi_drq);
+	DECLARE_READ16_MEMBER(towns_scsi_dma_r);
+	DECLARE_WRITE16_MEMBER(towns_scsi_dma_w);
 
 private:
 	/* devices */

--- a/src/mame/includes/fmtowns.h
+++ b/src/mame/includes/fmtowns.h
@@ -93,15 +93,16 @@ class towns_state : public driver_device
 		: driver_device(mconfig, type, tag)
 		, m_ram(*this, RAM_TAG)
 		, m_maincpu(*this, "maincpu")
+		, m_dma(*this, "dma_%u", 1U)
+		, m_scsi(*this, "fmscsi")
+		, m_flop(*this, "fdc:%u", 0U)
 		, m_speaker(*this, "speaker")
 		, m_pic_master(*this, "pic8259_master")
 		, m_pic_slave(*this, "pic8259_slave")
 		, m_pit(*this, "pit")
-		, m_dma(*this, "dma_%u", 1U)
 		, m_palette(*this, "palette256")
 		, m_palette16(*this, "palette16_%u", 0U)
 		, m_fdc(*this, "fdc")
-		, m_flop(*this, "fdc:%u", 0U)
 		, m_icmemcard(*this, "icmemcard")
 		, m_i8251(*this, "i8251")
 		, m_rs232(*this, "rs232c")
@@ -110,7 +111,6 @@ class towns_state : public driver_device
 		, m_dma_1(*this, "dma_1")
 		, m_cdrom(*this, "cdrom")
 		, m_cdda(*this, "cdda")
-		, m_scsi(*this, "fmscsi")
 		, m_bank_cb000_r(*this, "bank_cb000_r")
 		, m_bank_cb000_w(*this, "bank_cb000_w")
 		, m_bank_f8000_r(*this, "bank_f8000_r")
@@ -138,10 +138,15 @@ class towns_state : public driver_device
 	void towns(machine_config &config);
 	void townsftv(machine_config &config);
 	void townshr(machine_config &config);
+	void townsmx(machine_config &config);
 	void townssj(machine_config &config);
 
+	DECLARE_WRITE_LINE_MEMBER(towns_scsi_irq);
+	DECLARE_WRITE_LINE_MEMBER(towns_scsi_drq);
 	INTERRUPT_GEN_MEMBER(towns_vsync_irq);
-
+	DECLARE_READ16_MEMBER(towns_scsi_dma_r);
+	DECLARE_WRITE16_MEMBER(towns_scsi_dma_w);
+	
 protected:
 	uint16_t m_towns_machine_id;  // default is 0x0101
 
@@ -149,6 +154,8 @@ protected:
 	void pcm_mem(address_map &map);
 	void towns16_io(address_map &map);
 	void towns_io(address_map &map);
+	void towns2_io(address_map &map);
+	void townsux_io(address_map &map);
 	void towns_mem(address_map &map);
 	void ux_mem(address_map &map);
 
@@ -156,6 +163,11 @@ protected:
 
 	required_device<ram_device> m_ram;
 	required_device<cpu_device> m_maincpu;
+	
+	required_device_array<upd71071_device, 2> m_dma;
+	optional_device<fmscsi_device> m_scsi;
+	required_device_array<floppy_connector, 2> m_flop;
+	DECLARE_FLOPPY_FORMATS(floppy_formats);
 
 private:
 	/* devices */
@@ -163,11 +175,9 @@ private:
 	required_device<pic8259_device> m_pic_master;
 	required_device<pic8259_device> m_pic_slave;
 	required_device<pit8253_device> m_pit;
-	required_device_array<upd71071_device, 2> m_dma;
 	required_device<palette_device> m_palette;
 	required_device_array<palette_device, 2> m_palette16;
 	required_device<mb8877_device> m_fdc;
-	required_device_array<floppy_connector, 2> m_flop;
 	required_device<fmt_icmem_device> m_icmemcard;
 	required_device<i8251_device> m_i8251;
 	required_device<rs232_port_device> m_rs232;
@@ -176,7 +186,6 @@ private:
 	required_device<upd71071_device> m_dma_1;
 	required_device<cdrom_image_device> m_cdrom;
 	required_device<cdda_device> m_cdda;
-	required_device<fmscsi_device> m_scsi;
 
 	required_memory_bank m_bank_cb000_r;
 	required_memory_bank m_bank_cb000_w;
@@ -400,14 +409,11 @@ private:
 	TIMER_CALLBACK_MEMBER(towns_cdrom_read_byte);
 	TIMER_CALLBACK_MEMBER(towns_sprite_done);
 	TIMER_CALLBACK_MEMBER(towns_vblank_end);
-	DECLARE_WRITE_LINE_MEMBER(towns_scsi_irq);
-	DECLARE_WRITE_LINE_MEMBER(towns_scsi_drq);
 	DECLARE_WRITE_LINE_MEMBER(towns_pit_out0_changed);
 	DECLARE_WRITE_LINE_MEMBER(towns_pit_out1_changed);
 	DECLARE_WRITE_LINE_MEMBER(pit2_out1_changed);
 	DECLARE_READ8_MEMBER(get_slave_ack);
 	DECLARE_WRITE_LINE_MEMBER(towns_fm_irq);
-	DECLARE_FLOPPY_FORMATS(floppy_formats);
 	void towns_crtc_refresh_mode();
 	void towns_update_kanji_offset();
 	void towns_update_palette();
@@ -428,8 +434,6 @@ private:
 	void towns_cdrom_set_irq(int line,int state);
 	uint8_t towns_cd_get_track();
 	DECLARE_READ16_MEMBER(towns_cdrom_dma_r);
-	DECLARE_READ16_MEMBER(towns_scsi_dma_r);
-	DECLARE_WRITE16_MEMBER(towns_scsi_dma_w);
 };
 
 class towns16_state : public towns_state


### PR DESCRIPTION
This PR tries to better approximate what actual FM Towns machines are like, in terms of devices/configurations. The details are in the commit text, but the most important changes are the removal of the integrated SCSI controller on the first-gen models and the Marty (they don't have one in real life), and RAM options that reflect the actual onboard/SIMM combinations for each model. It also includes a couple of bugfixes and sanity checks to prevent emulator crashes I've found along the way.

This is the first time I mess around with devices and machine configurations, so feel free to criticize or suggest improvements.

Sources used:

http://www.mahoroba.ne.jp/~kazstary_/usage/simmfaq.txt
http://labo.main.jp/newage/towns/fmt_model.html
https://assemblergames.com/threads/fm-towns-marty-non-pcmcia-ram-expansion.65594/

As an aside, I may be able to acquire a Model 2 computer in the next few weeks/months and dump the ROMs, which would allow us to finally have actual emulation of the first-gen models from 1989, but I can't guarantee anything yet.