### PR TITLE
Make shaders fixes

### DIFF
--- a/src/osd/modules/render/bgfx/shaders/makefile
+++ b/src/osd/modules/render/bgfx/shaders/makefile
@@ -15,24 +15,24 @@ endif
 $(SUBDIRS):
 	@echo $@
 ifeq ($(OS),windows)
-	$(SILENT) $(MAKE) -s --no-print-directory TARGET=0 SHADERS_DIR=$@/ clean all SILENT="$(SILENT)"
-	$(SILENT) $(MAKE) -s --no-print-directory TARGET=1 SHADERS_DIR=$@/ clean all SILENT="$(SILENT)"
+	$(SILENT) $(MAKE) --no-print-directory TARGET=0 SHADERS_DIR=$@/ clean all SILENT="$(SILENT)"
+	$(SILENT) $(MAKE) --no-print-directory TARGET=1 SHADERS_DIR=$@/ clean all SILENT="$(SILENT)"
 endif
-	$(SILENT) $(MAKE) -s --no-print-directory TARGET=2 SHADERS_DIR=$@/ clean all SILENT="$(SILENT)"
-	$(SILENT) $(MAKE) -s --no-print-directory TARGET=3 SHADERS_DIR=$@/ clean all SILENT="$(SILENT)"
-	$(SILENT) $(MAKE) -s --no-print-directory TARGET=4 SHADERS_DIR=$@/ clean all SILENT="$(SILENT)"
-	$(SILENT) $(MAKE) -s --no-print-directory TARGET=5 SHADERS_DIR=$@/ clean all SILENT="$(SILENT)"
-	$(SILENT) $(MAKE) -s --no-print-directory TARGET=7 SHADERS_DIR=$@/ clean all SILENT="$(SILENT)"
+	$(SILENT) $(MAKE) --no-print-directory TARGET=2 SHADERS_DIR=$@/ clean all SILENT="$(SILENT)"
+	$(SILENT) $(MAKE) --no-print-directory TARGET=3 SHADERS_DIR=$@/ clean all SILENT="$(SILENT)"
+	$(SILENT) $(MAKE) --no-print-directory TARGET=4 SHADERS_DIR=$@/ clean all SILENT="$(SILENT)"
+	$(SILENT) $(MAKE) --no-print-directory TARGET=5 SHADERS_DIR=$@/ clean all SILENT="$(SILENT)"
+	$(SILENT) $(MAKE) --no-print-directory TARGET=7 SHADERS_DIR=$@/ clean all SILENT="$(SILENT)"
 
 main:
 ifeq ($(OS),windows)
-	$(SILENT) $(MAKE) -s --no-print-directory TARGET=0 clean all SILENT="$(SILENT)"
-	$(SILENT) $(MAKE) -s --no-print-directory TARGET=1 clean all SILENT="$(SILENT)"
+	$(SILENT) $(MAKE) --no-print-directory TARGET=0 clean all SILENT="$(SILENT)"
+	$(SILENT) $(MAKE) --no-print-directory TARGET=1 clean all SILENT="$(SILENT)"
 endif
-	$(SILENT) $(MAKE) -s --no-print-directory TARGET=2 clean all SILENT="$(SILENT)"
-	$(SILENT) $(MAKE) -s --no-print-directory TARGET=3 clean all SILENT="$(SILENT)"
-	$(SILENT) $(MAKE) -s --no-print-directory TARGET=4 clean all SILENT="$(SILENT)"
-	$(SILENT) $(MAKE) -s --no-print-directory TARGET=5 clean all SILENT="$(SILENT)"
-	$(SILENT) $(MAKE) -s --no-print-directory TARGET=7 clean all SILENT="$(SILENT)"
+	$(SILENT) $(MAKE) --no-print-directory TARGET=2 clean all SILENT="$(SILENT)"
+	$(SILENT) $(MAKE) --no-print-directory TARGET=3 clean all SILENT="$(SILENT)"
+	$(SILENT) $(MAKE) --no-print-directory TARGET=4 clean all SILENT="$(SILENT)"
+	$(SILENT) $(MAKE) --no-print-directory TARGET=5 clean all SILENT="$(SILENT)"
+	$(SILENT) $(MAKE) --no-print-directory TARGET=7 clean all SILENT="$(SILENT)"
 
 .PHONY: main rebuild $(SUBDIRS)

--- a/src/osd/modules/render/bgfx/shaders/makefile
+++ b/src/osd/modules/render/bgfx/shaders/makefile
@@ -12,6 +12,7 @@ SUBDIRS := $(patsubst .,,$(patsubst ./,,$(shell find . -type d)))
 rebuild: main $(SUBDIRS)
 endif
 
+.NOTPARALLEL:
 $(SUBDIRS):
 	@echo $@
 ifeq ($(OS),windows)


### PR DESCRIPTION
Replacing make with $(MAKE) has uncovered the fact that current shaders build set-up is not compatible with parrallel builds.
Also, -s needs to be removed for VERBOSE=1 to have the desired effect.