### PR TITLE
Use C++17

### DIFF
--- a/3rdparty/bgfx/src/renderer_d3d12.h
+++ b/3rdparty/bgfx/src/renderer_d3d12.h
@@ -21,7 +21,7 @@
 #if defined(__MINGW32__) // BK - temp workaround for MinGW until I nuke d3dx12 usage.
 extern "C++" {
 	__extension__ template<typename Ty>
-	const GUID& __mingw_uuidof();
+	constexpr const GUID& __mingw_uuidof();
 
 	template<>
 	const GUID& __mingw_uuidof<ID3D12Device>()

--- a/scripts/genie.lua
+++ b/scripts/genie.lua
@@ -14,7 +14,7 @@ newoption {
 premake.check_paths = true
 premake.make.override = { "TARGET" }
 
-premake.xcode.parameters = { 'CLANG_CXX_LANGUAGE_STANDARD = "c++14"', 'CLANG_CXX_LIBRARY = "libc++"' }
+premake.xcode.parameters = { 'CLANG_CXX_LIBRARY = "libc++"' }
 
 MAME_DIR = (path.getabsolute("..") .. "/")
 --MAME_DIR = string.gsub(MAME_DIR, "(%s)", "\\%1")
@@ -489,6 +489,7 @@ language "C++"
 
 flags {
 	"StaticRuntime",
+	"Cpp17",
 }
 
 configuration { "vs20*" }
@@ -774,14 +775,6 @@ if string.find(_OPTIONS["gcc"], "clang") and ((version < 30500) or (_OPTIONS["ta
 
 	buildoptions_objcpp {
 		"-std=c++1y",
-	}
-else
-	buildoptions_cpp {
-		"-std=c++14",
-	}
-
-	buildoptions_objcpp {
-		"-std=c++14",
 	}
 end
 -- this speeds it up a bit by piping between the preprocessor/compiler/assembler
@@ -1173,9 +1166,6 @@ configuration { "asmjs" }
 		"-Wno-implicit-function-declaration",
 		"-s USE_SDL_TTF=2",
 	}
-	buildoptions_cpp {
-		"-std=c++14",
-	}
 	linkoptions {
 		"-Wl,--start-group",
 	}
@@ -1189,7 +1179,6 @@ configuration { "android*" }
 		"-Wno-incompatible-ms-struct",
 	}
 	buildoptions_cpp {
-		"-std=c++14",
 		"-Wno-extern-c-compat",
 		"-Wno-tautological-constant-out-of-range-compare",
 		"-Wno-tautological-pointer-compare",
@@ -1205,9 +1194,6 @@ configuration { "pnacl" }
 	buildoptions {
 		"-std=gnu89",
 		"-Wno-inline-new-delete",
-	}
-	buildoptions_cpp {
-		"-std=c++14",
 	}
 	archivesplit_size "20"
 

--- a/src/emu/debug/dvdisasm.cpp
+++ b/src/emu/debug/dvdisasm.cpp
@@ -35,8 +35,6 @@ debug_view_disasm_source::debug_view_disasm_source(const char *name, device_t &d
 //  DEBUG VIEW DISASM
 //**************************************************************************
 
-const int debug_view_disasm::DEFAULT_DASM_LINES, debug_view_disasm::DEFAULT_DASM_WIDTH, debug_view_disasm::DASM_MAX_BYTES;
-
 
 //-------------------------------------------------
 //  debug_view_disasm - constructor

--- a/src/emu/debug/dvstate.cpp
+++ b/src/emu/debug/dvstate.cpp
@@ -16,13 +16,6 @@
 #include "screen.h"
 
 
-const int debug_view_state::REG_DIVIDER;
-const int debug_view_state::REG_CYCLES;
-const int debug_view_state::REG_BEAMX;
-const int debug_view_state::REG_BEAMY;
-const int debug_view_state::REG_FRAME;
-
-
 //**************************************************************************
 //  DEBUG VIEW STATE SOURCE
 //**************************************************************************

--- a/src/lib/util/hash.cpp
+++ b/src/lib/util/hash.cpp
@@ -20,15 +20,9 @@ namespace util {
 //  GLOBAL VARIABLES
 //**************************************************************************
 
-char const hash_collection::HASH_CRC;
-char const hash_collection::HASH_SHA1;
-
 char const *const hash_collection::HASH_TYPES_CRC = "R";
 char const *const hash_collection::HASH_TYPES_CRC_SHA1 = "RS";
 char const *const hash_collection::HASH_TYPES_ALL = "RS";
-
-char const hash_collection::FLAG_NO_DUMP;
-char const hash_collection::FLAG_BAD_DUMP;
 
 
 


### PR DESCRIPTION
This will allow to upgrade sol2 to version 3, which got lots of nice features since 3 years ago when mame incorporated it. And sol3 will allow to significantly reduce memory usage when compiling `luaengine.cpp`. Which, in turn, may unbreak 32bit build.

Not sure if `"-std=c++1y"`s were meant to stay. On Windows, I tried MSVC with pacman and GCC with arcade subtarget, both compile.