### PR TITLE
ins8250: fix cleared pending THRE interrupt

### DIFF
--- a/src/devices/machine/ins8250.cpp
+++ b/src/devices/machine/ins8250.cpp
@@ -434,8 +434,11 @@ u8 ins8250_uart_device::ins8250_r(offs_t offset)
 			data = m_regs.iir;
 			/* The documentation says that reading this register will
 			clear the int if this is the source of the int */
-			if (!machine().side_effects_disabled() && (m_regs.ier & COM_INT_PENDING_TRANSMITTER_HOLDING_REGISTER_EMPTY))
-				clear_int(COM_INT_PENDING_TRANSMITTER_HOLDING_REGISTER_EMPTY);
+			if (!machine().side_effects_disabled())
+			{
+				if (m_regs.iir == 0x02)
+					clear_int(COM_INT_PENDING_TRANSMITTER_HOLDING_REGISTER_EMPTY);
+			}
 			break;
 		case 3:
 			data = m_regs.lcr;


### PR DESCRIPTION
The code notes that reading the iir register "will clear the int if this is the source of the int" and the code cleared a pending THRE interrupt if it was *pending*. This causes a lost THRE interrupt for the SWTPC 8121 terminal firmware and this locks up the TX side of the terminal. This occurred regularly when the ISR read this register upon a higher priority RX pending interrupt. The documented operation has been reinterpreted as only clearly the THRE interrupt if THRE is the highest priority interrupt and so is the pending interrupt *causing* the interrupt. This fixes that lost THRE interrupt for the SWTPC 8121 terminal.