### PR TITLE
RS232: move some initialization to a device_reset() function

### DIFF
--- a/src/devices/bus/rs232/rs232.cpp
+++ b/src/devices/bus/rs232/rs232.cpp
@@ -93,6 +93,16 @@ void rs232_port_device::device_resolve_objects()
 	m_txc_handler.resolve_safe();
 }
 
+void rs232_port_device::device_reset()
+{
+	m_rxd_handler(m_rxd);
+	m_dcd_handler(m_dcd);
+	m_dsr_handler(m_dsr);
+	m_ri_handler(m_ri);
+	m_si_handler(m_si);
+	m_cts_handler(m_cts);
+}
+
 void rs232_port_device::device_start()
 {
 	save_item(NAME(m_rxd));
@@ -110,13 +120,6 @@ void rs232_port_device::device_start()
 	m_ri = 1;
 	m_si = 1;
 	m_cts = 1;
-
-	m_rxd_handler(1);
-	m_dcd_handler(1);
-	m_dsr_handler(1);
-	m_ri_handler(1);
-	m_si_handler(1);
-	m_cts_handler(1);
 }
 
 WRITE_LINE_MEMBER( rs232_port_device::write_txd )

--- a/src/devices/bus/rs232/rs232.h
+++ b/src/devices/bus/rs232/rs232.h
@@ -141,6 +141,7 @@ protected:
 	rs232_port_device(const machine_config &mconfig, device_type type, const char *tag, device_t *owner, uint32_t clock);
 
 	virtual void device_resolve_objects() override;
+	virtual void device_reset() override;
 	virtual void device_start() override;
 	virtual void device_config_complete() override;
 


### PR DESCRIPTION
Calling the line handlers, such as m_cts_handler() from the device_start() function is problematic as some of these handlers may wish to read ioports and that is not safe at this stage, so move these to a new device_reset() function.

When adding a write line function for a serial line, to route the line based on config options, it fails to initialize claiming that reading the ioport is not safe. It appears to have been due to the calls from the res232 device_start() function, and moving them to a device_reset() function worked around that.