### PR TITLE
new machines NOT WORKING (plug & play)

### DIFF
--- a/src/mame/mame.lst
+++ b/src/mame/mame.lst
@@ -31008,6 +31008,7 @@ gprnrs1
 gprnrs16
 ddrdismx                        // (c) 2006 Majesco / Konami [(c) 2001 Disney on title screen]
 ddrstraw                        // (c) 2006 Majesco / Konami
+ablping
 vgpocket
 vgpmini
 sy889


### PR DESCRIPTION
new machines NOT WORKING
-----
Ping Pong / Table Tennis / Super Ping Pong (PP1100, ABL TV Game) [David Haywood,  Morten Kirkegaard, Peter Wilhelmsen]

boots and runs, but no sound, seems to need an additional device at 410f emulating which may or may not be sound related, waits for a long time for it to finish sending streams of data there.  if you wait long enough controls do actually work as it appears the 'motion' control here just simulates a button press.  As pointed out, this seems to be an updated version of Gameinis' Ping Pong with improved gfx etc.