### PR TITLE
IE15 terminal: rework the RS232 interfaces

### DIFF
--- a/src/devices/bus/rs232/ie15.cpp
+++ b/src/devices/bus/rs232/ie15.cpp
@@ -5,26 +5,22 @@
 #include "ie15.h"
 
 ie15_terminal_device::ie15_terminal_device(const machine_config &mconfig, const char *tag, device_t *owner, uint32_t clock)
-	: ie15_device(mconfig, SERIAL_TERMINAL_IE15, tag, owner, clock)
+	: device_t(mconfig, SERIAL_TERMINAL_IE15, tag, owner, clock)
 	, device_rs232_port_interface(mconfig, *this)
-	, m_rs232_txbaud(*this, "RS232_TXBAUD")
-	, m_rs232_rxbaud(*this, "RS232_RXBAUD")
-	, m_rs232_startbits(*this, "RS232_STARTBITS")
-	, m_rs232_databits(*this, "RS232_DATABITS")
-	, m_rs232_parity(*this, "RS232_PARITY")
-	, m_rs232_stopbits(*this, "RS232_STOPBITS")
+	, m_ie15(*this, "ie15")
 {
 }
 
-static INPUT_PORTS_START(ie15_terminal)
-	PORT_INCLUDE(ie15)
+void ie15_terminal_device::device_add_mconfig(machine_config &config)
+{
+	IE15(config, m_ie15, 0);
 
-	PORT_RS232_BAUD("RS232_TXBAUD", RS232_BAUD_9600, "TX Baud", ie15_terminal_device, update_serial)
-	PORT_RS232_BAUD("RS232_RXBAUD", RS232_BAUD_9600, "RX Baud", ie15_terminal_device, update_serial)
-	PORT_RS232_STARTBITS("RS232_STARTBITS", RS232_STARTBITS_1, "Start Bits", ie15_terminal_device, update_serial)
-	PORT_RS232_DATABITS("RS232_DATABITS", RS232_DATABITS_8, "Data Bits", ie15_terminal_device, update_serial)
-	PORT_RS232_PARITY("RS232_PARITY", RS232_PARITY_NONE, "Parity", ie15_terminal_device, update_serial)
-	PORT_RS232_STOPBITS("RS232_STOPBITS", RS232_STOPBITS_1, "Stop Bits", ie15_terminal_device, update_serial)
+	m_ie15->rs232_conn_txd_handler().set(FUNC(ie15_terminal_device::output_rxd));
+	//m_ie15->rs232_conn_rts_handler().set(FUNC(ie15_terminal_device::route_term_rts));
+	//m_ie15->rs232_conn_dtr_handler().set(FUNC(ie15_terminal_device::route_term_dtr));
+}
+
+INPUT_PORTS_START(ie15_terminal)
 INPUT_PORTS_END
 
 ioport_constructor ie15_terminal_device::device_input_ports() const
@@ -32,59 +28,23 @@ ioport_constructor ie15_terminal_device::device_input_ports() const
 	return INPUT_PORTS_NAME(ie15_terminal);
 }
 
-WRITE_LINE_MEMBER(ie15_terminal_device::update_serial)
+WRITE_LINE_MEMBER(ie15_terminal_device::input_txd)
 {
-	int startbits = convert_startbits(m_rs232_startbits->read());
-	int databits = convert_databits(m_rs232_databits->read());
-	parity_t parity = convert_parity(m_rs232_parity->read());
-	stop_bits_t stopbits = convert_stopbits(m_rs232_stopbits->read());
+	m_ie15->rs232_conn_rxd_w(state);
+}
 
-	set_data_frame(startbits, databits, parity, stopbits);
+void ie15_terminal_device::device_start()
+{
+}
 
-	int txbaud = convert_baud(m_rs232_txbaud->read());
-	set_tra_rate(txbaud);
-
-	int rxbaud = convert_baud(m_rs232_rxbaud->read());
-	set_rcv_rate(rxbaud);
-
+void ie15_terminal_device::device_reset()
+{
 	output_rxd(1);
 
 	// TODO: make this configurable
 	output_dcd(0);
 	output_dsr(0);
 	output_cts(0);
-}
-
-void ie15_terminal_device::tra_callback()
-{
-	output_rxd(transmit_register_get_data_bit());
-}
-
-void ie15_terminal_device::tra_complete()
-{
-	ie15_device::tra_complete();
-}
-
-void ie15_terminal_device::rcv_complete()
-{
-	receive_register_extract();
-	term_write(get_received_char());
-}
-
-void ie15_terminal_device::device_start()
-{
-	ie15_device::device_start();
-}
-
-void ie15_terminal_device::device_reset()
-{
-	update_serial(0);
-	ie15_device::device_reset();
-}
-
-void ie15_terminal_device::device_timer(emu_timer &timer, device_timer_id id, int param, void *ptr)
-{
-	ie15_device::device_timer(timer, id, param, ptr);
 }
 
 DEFINE_DEVICE_TYPE(SERIAL_TERMINAL_IE15, ie15_terminal_device, "ie15_terminal", "IE15 Terminal")

--- a/src/devices/bus/rs232/ie15.h
+++ b/src/devices/bus/rs232/ie15.h
@@ -10,33 +10,21 @@
 #include "machine/ie15.h"
 
 
-class ie15_terminal_device : public ie15_device,
-	public device_rs232_port_interface
+class ie15_terminal_device : public device_t, public device_rs232_port_interface
 {
 public:
 	ie15_terminal_device(const machine_config &mconfig, const char *tag, device_t *owner, uint32_t clock);
 
-	virtual DECLARE_WRITE_LINE_MEMBER( input_txd ) override { ie15_device::serial_rx_callback(state); }
-
-	DECLARE_WRITE_LINE_MEMBER(update_serial);
+	virtual DECLARE_WRITE_LINE_MEMBER( input_txd ) override;
 
 protected:
-	virtual ioport_constructor device_input_ports() const override;
 	virtual void device_start() override;
 	virtual void device_reset() override;
-	virtual void device_timer(emu_timer &timer, device_timer_id id, int param, void *ptr) override;
-
-	virtual void tra_callback() override;
-	virtual void tra_complete() override;
-	virtual void rcv_complete() override;
+	virtual void device_add_mconfig(machine_config &config) override;
+	virtual ioport_constructor device_input_ports() const override;
 
 private:
-	required_ioport m_rs232_txbaud;
-	required_ioport m_rs232_rxbaud;
-	required_ioport m_rs232_startbits;
-	required_ioport m_rs232_databits;
-	required_ioport m_rs232_parity;
-	required_ioport m_rs232_stopbits;
+	required_device<ie15_device> m_ie15;
 };
 
 DECLARE_DEVICE_TYPE(SERIAL_TERMINAL_IE15, ie15_terminal_device)

--- a/src/devices/machine/ie15.cpp
+++ b/src/devices/machine/ie15.cpp
@@ -39,10 +39,18 @@ ie15_device::ie15_device(const machine_config &mconfig, device_type type, const 
 	, m_p_videoram(*this, "video")
 	, m_p_chargen(*this, "chargen")
 	, m_beeper(*this, "beeper")
-	, m_rs232(*this, "rs232")
 	, m_screen(*this, "screen")
 	, m_keyboard(*this, "keyboard")
 	, m_io_keyboard(*this, "io_keyboard")
+	, m_rs232_conn_txd_handler(*this)
+	, m_rs232_conn_dtr_handler(*this)
+	, m_rs232_conn_rts_handler(*this)
+	  // Until the UART is implemented
+	, m_rs232_txbaud(*this, "RS232_TXBAUD")
+	, m_rs232_rxbaud(*this, "RS232_RXBAUD")
+	, m_rs232_databits(*this, "RS232_DATABITS")
+	, m_rs232_parity(*this, "RS232_PARITY")
+	, m_rs232_stopbits(*this, "RS232_STOPBITS")
 {
 }
 
@@ -228,7 +236,7 @@ void ie15_device::device_timer(emu_timer &timer, device_timer_id id, int param, 
 	}
 }
 
-WRITE_LINE_MEMBER(ie15_device::serial_rx_callback)
+WRITE_LINE_MEMBER(ie15_device::rs232_conn_rxd_w)
 {
 	device_serial_interface::rx_w(state);
 }
@@ -243,7 +251,7 @@ void ie15_device::rcv_complete()
 void ie15_device::tra_callback()
 {
 	uint8_t bit = transmit_register_get_data_bit();
-	m_rs232->write_txd(bit);
+	m_rs232_conn_txd_handler(bit);
 }
 
 void ie15_device::tra_complete()
@@ -282,6 +290,24 @@ WRITE8_MEMBER(ie15_device::serial_w)
 WRITE8_MEMBER(ie15_device::serial_speed_w)
 {
 	return;
+}
+
+WRITE_LINE_MEMBER(ie15_device::update_serial)
+{
+	int startbits = 1;
+	int databits = m_rs232_databits->read();
+	parity_t parity_table[] = { PARITY_NONE, PARITY_ODD, PARITY_EVEN, PARITY_MARK, PARITY_SPACE };
+	parity_t parity = parity_table[m_rs232_parity->read()];
+	stop_bits_t stopbits_table[] = { STOP_BITS_1, STOP_BITS_2 };
+	stop_bits_t stopbits = stopbits_table[m_rs232_stopbits->read()];
+
+	set_data_frame(startbits, databits, parity, stopbits);
+
+	int txbaud = m_rs232_txbaud->read();
+	set_tra_rate(txbaud);
+
+	int rxbaud = m_rs232_rxbaud->read();
+	set_rcv_rate(rxbaud);
 }
 
 READ8_MEMBER(ie15_device::flag_r)
@@ -375,6 +401,46 @@ INPUT_PORTS_START( ie15 )
 	PORT_DIPNAME(ie15_keyboard_device::IE_KB_LIN, ie15_keyboard_device::IE_KB_LIN, "LIN (Online)")
 	PORT_DIPSETTING(0x00, "Off")
 	PORT_DIPSETTING(ie15_keyboard_device::IE_KB_LIN, "On")
+
+	// Until the UART is implemented
+	PORT_START("RS232_RXBAUD")
+	PORT_CONFNAME(0xffff, 9600, "RX Baud") PORT_WRITE_LINE_DEVICE_MEMBER(DEVICE_SELF, ie15_device, update_serial)
+	PORT_CONFSETTING(300, "300")
+	PORT_CONFSETTING(600, "600")
+	PORT_CONFSETTING(1200, "1200")
+	PORT_CONFSETTING(2400, "2400")
+	PORT_CONFSETTING(4800, "4800")
+	PORT_CONFSETTING(9600, "9600")
+	PORT_CONFSETTING(19200, "19200")
+
+	PORT_START("RS232_TXBAUD")
+	PORT_CONFNAME(0xffff, 9600, "TX Baud") PORT_WRITE_LINE_DEVICE_MEMBER(DEVICE_SELF, ie15_device, update_serial)
+	PORT_CONFSETTING(300, "300")
+	PORT_CONFSETTING(600, "600")
+	PORT_CONFSETTING(1200, "1200")
+	PORT_CONFSETTING(2400, "2400")
+	PORT_CONFSETTING(4800, "4800")
+	PORT_CONFSETTING(9600, "9600")
+	PORT_CONFSETTING(19200, "19200")
+
+	PORT_START("RS232_DATABITS")
+	PORT_CONFNAME(0xf, 8, "Data Bits") PORT_WRITE_LINE_DEVICE_MEMBER(DEVICE_SELF, ie15_device, update_serial)
+	PORT_CONFSETTING(7, "7")
+	PORT_CONFSETTING(8, "8")
+
+	PORT_START("RS232_PARITY")
+	PORT_CONFNAME(0x7, 0, "Parity") PORT_WRITE_LINE_DEVICE_MEMBER(DEVICE_SELF, ie15_device, update_serial)
+	PORT_CONFSETTING(0, "None")
+	PORT_CONFSETTING(1, "Odd")
+	PORT_CONFSETTING(2, "Even")
+	PORT_CONFSETTING(3, "Mark")
+	PORT_CONFSETTING(4, "Space")
+
+	PORT_START("RS232_STOPBITS")
+	PORT_CONFNAME(0x3, 1, "Stop Bits") PORT_WRITE_LINE_DEVICE_MEMBER(DEVICE_SELF, ie15_device, update_serial)
+	PORT_CONFSETTING(1, "1")
+	PORT_CONFSETTING(2, "2")
+
 INPUT_PORTS_END
 
 WRITE16_MEMBER( ie15_device::kbd_put )
@@ -390,6 +456,13 @@ WRITE16_MEMBER( ie15_device::kbd_put )
 	}
 }
 
+void ie15_device::device_resolve_objects()
+{
+	//m_rs232_conn_dtr_handler.resolve_safe();
+	//m_rs232_conn_rts_handler.resolve_safe();
+	m_rs232_conn_txd_handler.resolve_safe();
+}
+
 void ie15_device::device_start()
 {
 	m_hblank_timer = timer_alloc(TIMER_HBLANK);
@@ -402,6 +475,8 @@ void ie15_device::device_start()
 
 void ie15_device::device_reset()
 {
+	update_serial(0);
+
 	memset(&m_video, 0, sizeof(m_video));
 	m_kb_ruslat = m_long_beep = m_kb_control = m_kb_data = m_kb_flag0 = 0;
 	m_kb_flag = IE_TRUE;
@@ -579,9 +654,6 @@ void ie15_device::ie15core(machine_config &config)
 
 	/* Devices */
 	IE15_KEYBOARD(config, m_keyboard, 0).keyboard_cb().set(FUNC(ie15_device::kbd_put));
-
-	RS232_PORT(config, m_rs232, default_rs232_devices, "null_modem");
-	m_rs232->rxd_handler().set(FUNC(ie15_device::serial_rx_callback));
 
 	SPEAKER(config, "mono").front_center();
 	BEEP(config, m_beeper, 2400);

--- a/src/devices/machine/ie15.h
+++ b/src/devices/machine/ie15.h
@@ -39,13 +39,22 @@ class ie15_device : public device_t, public device_serial_interface
 public:
 	ie15_device(const machine_config &mconfig, const char *tag, device_t *owner, uint32_t clock);
 
-	DECLARE_WRITE8_MEMBER(write) { term_write(data); }
+	// Interface to a RS232 connection.
+	auto rs232_conn_txd_handler() { return m_rs232_conn_txd_handler.bind(); }
+	auto rs232_conn_dtr_handler() { return m_rs232_conn_dtr_handler.bind(); }
+	auto rs232_conn_rts_handler() { return m_rs232_conn_rts_handler.bind(); }
+	DECLARE_WRITE_LINE_MEMBER(rs232_conn_dcd_w);
+	DECLARE_WRITE_LINE_MEMBER(rs232_conn_dsr_w);
+	DECLARE_WRITE_LINE_MEMBER(rs232_conn_ri_w);
+	DECLARE_WRITE_LINE_MEMBER(rs232_conn_cts_w);
+	DECLARE_WRITE_LINE_MEMBER(rs232_conn_rxd_w);
 
-	DECLARE_WRITE_LINE_MEMBER(serial_rx_callback);
+	DECLARE_WRITE_LINE_MEMBER(update_serial);
 
 protected:
 	ie15_device(const machine_config &mconfig, device_type type, const char *tag, device_t *owner, uint32_t clock);
 
+	virtual void device_resolve_objects() override;
 	virtual void device_start() override;
 	virtual void device_reset() override;
 	virtual void device_timer(emu_timer &timer, device_timer_id id, int param, void *ptr) override;
@@ -57,8 +66,6 @@ protected:
 	virtual void rcv_complete() override;
 	virtual void tra_callback() override;
 	virtual void tra_complete() override;
-
-	void term_write(uint8_t data) { m_serial_rx_char = data; m_serial_rx_ready = IE_FALSE; }
 
 private:
 	static const device_timer_id TIMER_HBLANK = 0;
@@ -129,10 +136,20 @@ private:
 	required_region_ptr<u8> m_p_videoram;
 	required_region_ptr<u8> m_p_chargen;
 	required_device<beep_device> m_beeper;
-	required_device<rs232_port_device> m_rs232;
 	required_device<screen_device> m_screen;
 	required_device<ie15_keyboard_device> m_keyboard;
 	required_ioport m_io_keyboard;
+
+	devcb_write_line m_rs232_conn_txd_handler;
+	devcb_write_line m_rs232_conn_dtr_handler;
+	devcb_write_line m_rs232_conn_rts_handler;
+
+	// Until the UART is implemented
+	required_ioport m_rs232_txbaud;
+	required_ioport m_rs232_rxbaud;
+	required_ioport m_rs232_databits;
+	required_ioport m_rs232_parity;
+	required_ioport m_rs232_stopbits;
 };
 
 DECLARE_DEVICE_TYPE(IE15, ie15_device)

--- a/src/mame/drivers/ie15.cpp
+++ b/src/mame/drivers/ie15.cpp
@@ -15,26 +15,40 @@
 #include "emu.h"
 #include "machine/ie15_kbd.h"
 #include "machine/ie15.h"
+#include "bus/rs232/rs232.h"
 
 
 class ie15_state : public driver_device
 {
 public:
 	ie15_state(const machine_config &mconfig, device_type type, const char *tag) :
-		driver_device(mconfig, type, tag),
-		m_ie15(*this, "ie15")
+		driver_device(mconfig, type, tag)
+		, m_ie15(*this, "ie15")
+		, m_rs232(*this, "rs232")
 	{ }
 
 	void ie15(machine_config &config);
 
 private:
 	required_device<ie15_device> m_ie15;
+	required_device<rs232_port_device> m_rs232;
 };
 
 
 void ie15_state::ie15(machine_config &config)
 {
 	IE15(config, m_ie15, 0);
+
+	rs232_port_device &rs232(RS232_PORT(config, "rs232", default_rs232_devices, nullptr));
+	//rs232.dcd_handler().set("ie15", FUNC(ie15_device::rs232_conn_dcd_w));
+	//rs232.dsr_handler().set("ie15", FUNC(ie15_device::rs232_conn_dsr_w));
+	//rs232.ri_handler().set("ie15", FUNC(ie15_device::rs232_conn_ri_w));
+	//rs232.cts_handler().set("ie15", FUNC(ie15_device::rs232_conn_cts_w));
+	rs232.rxd_handler().set("ie15", FUNC(ie15_device::rs232_conn_rxd_w));
+
+	m_ie15->rs232_conn_txd_handler().set("rs232", FUNC(rs232_port_device::write_txd));
+	m_ie15->rs232_conn_dtr_handler().set("rs232", FUNC(rs232_port_device::write_dtr));
+	m_ie15->rs232_conn_rts_handler().set("rs232", FUNC(rs232_port_device::write_rts));
 }
 
 


### PR DESCRIPTION
The RS232 port has been moved out of the ie15 device. It is only needed in stand alone operation, and not when connected to the rs232 bus, it was odd leaving it in there, odd to still have an rs232 port slot option when running stand alone.

The IE15 UART implementation has been removed from the rs232 bus code and back into the ie15 device code. This leaves the rs232 bus code dealing with only serial data, and not the parallel data, and that should make it easier in future to have a common interface to RS232 terminals.

This is to illustrate some points raised in PR https://github.com/mamedev/mame/pull/5729 the SWTPC 8212 terminal proposal. This IE15 terminal proposal uses the same interface function names, and interfaces to the ie15 device using only serial data as is done for the swtpc8212 which has an implemented UART. If people agree that this is a move in the right direction then you might please consider merge this. Not claiming that his pushes the IE15 implementation along, it is just a proposed source code cleanup.