### PR TITLE
Fix build for nonstandard compiler versions like '8.3-win32'

### DIFF
--- a/scripts/genie.lua
+++ b/scripts/genie.lua
@@ -42,6 +42,9 @@ function str_to_version(str)
 	end
 	local cnt = 10000
 	for word in string.gmatch(str, '([^.]+)') do
+		if(tonumber(word) == nil) then
+			return val
+		end
 		val = val + tonumber(word) * cnt
 		cnt = cnt / 100
 	end


### PR DESCRIPTION
Fixes cross-compiling for Windows from a Debian testing machine.