### PR TITLE
Fix asmjs build

### DIFF
--- a/scripts/src/3rdparty.lua
+++ b/scripts/src/3rdparty.lua
@@ -1209,8 +1209,8 @@ project "bimg"
 
 	configuration { }
 
-	if _OPTIONS["targetos"]=="macosx" or _OPTIONS["targetos"]=="linux" or _OPTIONS["targetos"]=="windows" then
-		if _OPTIONS["gcc"]~=nil and string.find(_OPTIONS["gcc"], "clang") then
+	if _OPTIONS["targetos"]=="macosx" or _OPTIONS["targetos"]=="linux" or _OPTIONS["targetos"]=="windows" or _OPTIONS["targetos"]=="asmjs" then
+		if _OPTIONS["gcc"]~=nil and (string.find(_OPTIONS["gcc"], "clang") or string.find(_OPTIONS["gcc"], "asmjs")) then
 			buildoptions_cpp {
 				"-Wno-unused-const-variable",
 			}

--- a/scripts/src/3rdparty.lua
+++ b/scripts/src/3rdparty.lua
@@ -1399,6 +1399,7 @@ end
 		MAME_DIR .. "3rdparty/bgfx/src/dxgi.cpp",
 		MAME_DIR .. "3rdparty/bgfx/src/glcontext_egl.cpp",
 		MAME_DIR .. "3rdparty/bgfx/src/glcontext_glx.cpp",
+		MAME_DIR .. "3rdparty/bgfx/src/glcontext_html5.cpp",
 		MAME_DIR .. "3rdparty/bgfx/src/glcontext_wgl.cpp",
 		MAME_DIR .. "3rdparty/bgfx/src/nvapi.cpp",
 		MAME_DIR .. "3rdparty/bgfx/src/renderer_d3d11.cpp",


### PR DESCRIPTION
Building asmjs fails after the BGFX update.

This PR isn't completely fixing the asmjs issue yet so consider it a work in progress. What has been done so far is a fix that suppresses a warning in BIMG which allows the MAME build to complete but there still linking related issues which needs to be resolved.

The linking issues are looking like this:

    warning: undefined symbol: _ZN4bgfx2gl9GlContext11makeCurrentEPNS0_11SwapChainGLE
    warning: undefined symbol: _ZN4bgfx2gl9GlContext15createSwapChainEPv
    warning: undefined symbol: _ZN4bgfx2gl9GlContext16destroySwapChainEPNS0_11SwapChainGLE
    warning: undefined symbol: _ZN4bgfx2gl9GlContext4swapEPNS0_11SwapChainGLE
    warning: undefined symbol: _ZN4bgfx2gl9GlContext6createEjj
    warning: undefined symbol: _ZN4bgfx2gl9GlContext6resizeEjjj
    warning: undefined symbol: _ZN4bgfx2gl9GlContext7destroyEv
    warning: undefined symbol: _ZNK4bgfx2gl9GlContext7getCapsEv
    ....

I believe a fix similar to what was done for Odroid (https://github.com/mamedev/mame/pull/5751) is required.