### PR TITLE
rs232 null_modem: add DTR flow control

### DIFF
--- a/src/devices/bus/rs232/null_modem.cpp
+++ b/src/devices/bus/rs232/null_modem.cpp
@@ -18,7 +18,8 @@ null_modem_device::null_modem_device(const machine_config &mconfig, const char *
 	m_input_count(0),
 	m_input_index(0),
 	m_timer_poll(nullptr),
-	m_rts(0)
+	m_rts(0),
+	m_dtr(0)
 {
 }
 
@@ -36,9 +37,10 @@ static INPUT_PORTS_START(null_modem)
 	PORT_RS232_STOPBITS("RS232_STOPBITS", RS232_STOPBITS_1, "Stop Bits", null_modem_device, update_serial)
 
 	PORT_START("FLOW_CONTROL")
-	PORT_CONFNAME(0x01, 0x00, "Flow Control")
+	PORT_CONFNAME(0x03, 0x00, "Flow Control")
 	PORT_CONFSETTING(0x00, "Off")
-	PORT_CONFSETTING(0x01, "On")
+	PORT_CONFSETTING(0x01, "RTS")
+	PORT_CONFSETTING(0x02, "DTR")
 INPUT_PORTS_END
 
 ioport_constructor null_modem_device::device_input_ports() const
@@ -74,6 +76,7 @@ WRITE_LINE_MEMBER(null_modem_device::update_serial)
 	output_cts(0);
 
 	m_rts = 0;
+	m_dtr = 0;
 }
 
 void null_modem_device::device_reset()
@@ -105,17 +108,20 @@ void null_modem_device::queue()
 			m_input_count = m_stream->input(m_input_buffer, sizeof(m_input_buffer));
 		}
 
-		if (m_input_count != 0 && (m_rts == 0 || !m_flow->read()))
+		if (m_input_count != 0)
 		{
-			transmit_register_setup(m_input_buffer[m_input_index++]);
+			uint8_t fc = m_flow->read();
 
-			m_timer_poll->adjust(attotime::never);
+			if (fc == 0 || (fc == 1 && m_rts == 0) || (fc == 2 && m_dtr == 0))
+			{
+				transmit_register_setup(m_input_buffer[m_input_index++]);
+				m_timer_poll->adjust(attotime::never);
+				return;
+			}
 		}
-		else
-		{
-			int txbaud = convert_baud(m_rs232_txbaud->read());
-			m_timer_poll->adjust(attotime::from_hz(txbaud));
-		}
+
+		int txbaud = convert_baud(m_rs232_txbaud->read());
+		m_timer_poll->adjust(attotime::from_hz(txbaud));
 	}
 }
 

--- a/src/devices/bus/rs232/null_modem.h
+++ b/src/devices/bus/rs232/null_modem.h
@@ -16,6 +16,7 @@ public:
 
 	virtual WRITE_LINE_MEMBER( input_txd ) override { device_serial_interface::rx_w(state); }
 	virtual WRITE_LINE_MEMBER( input_rts ) override { m_rts = state; }
+	virtual WRITE_LINE_MEMBER( input_dtr ) override { m_dtr = state; }
 
 	DECLARE_WRITE_LINE_MEMBER(update_serial);
 
@@ -50,6 +51,7 @@ private:
 	uint32_t m_input_index;
 	emu_timer *m_timer_poll;
 	int m_rts;
+	int m_dtr;
 };
 
 DECLARE_DEVICE_TYPE(NULL_MODEM, null_modem_device)


### PR DESCRIPTION
Some terminals use the DTR output for hardware flow control, so add that as another option.

E.g. This allows the SWTPC 8212 terminal, which has only DTR hardware flow control, to work with the null modem bit banger. It might also be a useful option for terminals that can optionally use DTR flow control such as the QVT102 and others.