### PR TITLE
Revise comment

### DIFF
--- a/src/mame/drivers/megaplay.cpp
+++ b/src/mame/drivers/megaplay.cpp
@@ -986,11 +986,3 @@ didn't have original Sega part numbers it's probably a converted TWC cart
 /* 11 */ GAME( 1993, mp_mazin, megaplay, megaplay, mp_mazin, mplay_state, init_megaplay, ROT0, "Sega",                  "Mazin Wars / Mazin Saga (Mega Play)", MACHINE_NOT_WORKING | MACHINE_IMPERFECT_GRAPHICS )
 
 /* ?? */ GAME( 1993, mp_col3,  megaplay, megaplay, megaplay, mplay_state, init_megaplay, ROT0, "Sega",                  "Columns III (Mega Play)", MACHINE_NOT_WORKING | MACHINE_IMPERFECT_GRAPHICS )
-
-
-/* Not confirmed to exist:
-
-system16.com used to list 'Streets of Rage', but this seems unlikely, as there are no gaps in
-the numbering prior to 'Streets of Rage 2'
-
-*/

--- a/src/mame/drivers/megaplay.cpp
+++ b/src/mame/drivers/megaplay.cpp
@@ -990,7 +990,7 @@ didn't have original Sega part numbers it's probably a converted TWC cart
 
 /* Not confirmed to exist:
 
-system16.com lists 'Streets of Rage' but this seems unlikely, there are no gaps in
+system16.com used to list 'Streets of Rage', but this seems unlikely, as there are no gaps in
 the numbering prior to 'Streets of Rage 2'
 
 */


### PR DESCRIPTION
Streets of Rage was previously listed at http://www.system16.com/hardware.php?id=707 but was removed between April 2016 and June 2017 judging by The Internet Archive's Wayback Machine:

https://web.archive.org/web/20160421233731/http://www.system16.com/hardware.php?id=707
https://web.archive.org/web/20170612023248/http://system16.com/hardware.php?id=707

The site now suggests, more sensibly, that the original Streets of Rage was only on the Mega-Tech system, not Megaplay.