### PR TITLE
tv990: cursor fix

### DIFF
--- a/src/mame/drivers/tv990.cpp
+++ b/src/mame/drivers/tv990.cpp
@@ -219,12 +219,15 @@ uint32_t tv990_state::screen_update(screen_device &screen, bitmap_rgb32 &bitmap,
 			if((y < starty) || (y >= endy))
 				continue;
 
-			curchar = &vram[tvi1111_regs[i + 0x50]];
+			uint16_t row_offset = tvi1111_regs[i + 0x50];
+			curchar = &vram[row_offset];
 			int minx = tvi1111_regs[i + 0x30] >> 8;
 			int maxx = tvi1111_regs[i + 0x30] & 0xff;
 
 			if(maxx > m_width)
 				maxx = m_width;
+
+			uint16_t cursor_x = tvi1111_regs[0x16] - row_offset;
 
 			for (x = minx; x < maxx; x++)
 			{
@@ -237,8 +240,7 @@ uint32_t tv990_state::screen_update(screen_device &screen, bitmap_rgb32 &bitmap,
 
 				uint32_t palette[2];
 
-				int cursor_pos = tvi1111_regs[0x16] + 133;
-				if(BIT(tvi1111_regs[0x1b], 0) && (x == (cursor_pos % 134)) && (y == (cursor_pos / 134)))
+				if (BIT(tvi1111_regs[0x1b], 0) && x == cursor_x)
 				{
 					uint8_t attrchg;
 					if(tvi1111_regs[0x15] & 0xff00) // what does this really mean? it looks like a mask but that doesn't work in 8line char mode


### PR DESCRIPTION
The addresses of the rows in the vram do not increase monotonically
with the screen scan lines and the cursor address appears to follow
these addresses so the cursor row can not be computed from the
address. Rather compute the cursor column from the difference of the
cursor address offset and the address off of the start of the row, and
implicitly match the rows when comparing the columns. This might not be
perfect, but it is a big improvement and no issues have been spotted.