### PR TITLE
Avoiding asserts and cleanup of some comments

### DIFF
--- a/src/mame/drivers/eispc.cpp
+++ b/src/mame/drivers/eispc.cpp
@@ -23,20 +23,20 @@
  * Internal Options: Up to 640K RAM through add-on RAM card
  * Misc: The hardware was not 100% PC compatible so non BIOS based software would not always run. 50.000+ units sold
  *
- * TODO:s in selection
+ * TODO
  * - Complete the Ericsson 1070 MDA ISA board and test all the graphics modes including 640x400 (aka HR)
  * - Add the Ericsson 1065 HDC and boot from a hard drive
  * - Implement the descrete baudrate generator
  * - Implement logic around enabling/resetting NMI and ISA bus I/O CHK
  *
- * Credits: The driver code is inspired from m24.cpp, myb3k.cpp and genpc.cpp. Information about the EPC has
+ * CREDITS  The driver code is inspired from m24.cpp, myb3k.cpp and genpc.cpp. Information about the EPC has
  *          been contributed by many, mainly the people at Dalby Computer museum http://www.datormuseum.se/
  *          A dead pcb was donated by rfka01 and rom dumps by ZnaxQue@sweclockers.com
  *
  ************************************************************************************************************/
 /*
- Links:
- ------
+ Links
+ -----
 
  */
 

--- a/src/mame/machine/eispc_kb.cpp
+++ b/src/mame/machine/eispc_kb.cpp
@@ -272,15 +272,15 @@ WRITE_LINE_MEMBER(eispc_keyboard_device::rst_line_w)
 {
 	if (state == CLEAR_LINE)
 	{
-		m_mcu->resume(SUSPEND_REASON_RESET);
-		//m_mcu->set_input_line(INPUT_LINE_RESET, CLEAR_LINE);
+		//m_mcu->resume(SUSPEND_REASON_RESET);
+		m_mcu->set_input_line(INPUT_LINE_RESET, CLEAR_LINE);
 		LOGRST("KBD: Keyboard mcu reset line is cleared\n");
 	}
 	else
 	{
 		// set_input_line suspends with a true argument which causes "Keyboard error" 
-		m_mcu->suspend(SUSPEND_REASON_RESET, false);  // This causes an assert later when DEBUG==1
-		//m_mcu->set_input_line(INPUT_LINE_RESET, ASSERT_LINE);
+		//m_mcu->suspend(SUSPEND_REASON_RESET, false);  // This causes an assert later when DEBUG==1
+		m_mcu->set_input_line(INPUT_LINE_RESET, ASSERT_LINE);
 		LOGRST("KBD: Keyboard mcu reset line is asserted\n");
 	}
 


### PR DESCRIPTION
I go for the controlled keyboard error rather than triggering asserts when DEBUG=1, it is a not working machine still so not status change this time