### PR TITLE
IDE devices are now on bus/ata, build fix.

### DIFF
--- a/scripts/src/machine.lua
+++ b/scripts/src/machine.lua
@@ -2816,7 +2816,7 @@ end
 --
 ---------------------------------------------------
 
-if (BUSES["IDE"]~=null) or (BUSES["SCSI"]~=null) then
+if (BUSES["ATA"]~=null) or (BUSES["SCSI"]~=null) then
 	MACHINES["T10"] = true
 end
 


### PR DESCRIPTION
The recent move of the IDE devices to the ata bus broke the build linking for the swtpc09. This PR fixed that here. If this is not the appropriate fix then could someone please have a look at what is going wrong.