### PR TITLE
Start work on C64 tapes

### DIFF
--- a/hash/amigaocs_flop.xml
+++ b/hash/amigaocs_flop.xml
@@ -2675,7 +2675,7 @@
 		<!-- budget, standalone -->
 		<!-- (Amiga, OCS, PAL) -->
 		<year>1989</year>
-		<publisher>Hit Squad</publisher>
+		<publisher>The Hit Squad</publisher>
 		<part name="flop1" interface="floppy_3_5">
 			<dataarea name="flop" size="1049612">
 				<rom name="(sps1159)arkanoid-revengeofdoh.ipf" size="1049612" crc="7ae40e8f" sha1="0f7d7c566e06c0b6f5737f136b419789f47ec625"/>
@@ -3748,7 +3748,7 @@
 		<!-- budget, standalone -->
 		<!-- (Amiga, OCS, PAL) -->
 		<year>1990</year>
-		<publisher>Hit Squad</publisher>
+		<publisher>The Hit Squad</publisher>
 		<part name="flop1" interface="floppy_3_5">
 			<dataarea name="flop" size="1049612">
 				<rom name="(sps1238)badlands.ipf" size="1049612" crc="000effe9" sha1="41d499320cdfb35c7b60fe4b1009e161d84d76a5"/>
@@ -4268,7 +4268,7 @@
 		<!-- budget, standalone -->
 		<!-- (Amiga, OCS, PAL) -->
 		<year>1989</year>
-		<publisher>Hit Squad</publisher>
+		<publisher>The Hit Squad</publisher>
 		<part name="flop1" interface="floppy_3_5">
 			<dataarea name="flop" size="1049612">
 				<rom name="(sps1730)batman-themovie.ipf" size="1049612" crc="d4e22fcb" sha1="f7d2d0ccfadf2831830351170747490de4a7f017"/>
@@ -4296,7 +4296,7 @@
 		<!-- budget, standalone -->
 		<!-- (Amiga, OCS, PAL) -->
 		<year>1988</year>
-		<publisher>Hit Squad</publisher>
+		<publisher>The Hit Squad</publisher>
 		<part name="flop1" interface="floppy_3_5">
 			<dataarea name="flop" size="1049180">
 				<rom name="(sps1939)batman-thecapedcrusader.ipf" size="1049180" crc="70902ecd" sha1="b92fd8a1a1912cc734af35956c99a5c244c695f4"/>
@@ -6878,7 +6878,7 @@
 		<!-- budget, standalone -->
 		<!-- (Amiga, OCS, PAL) -->
 		<year>1989</year>
-		<publisher>Hit Squad</publisher>
+		<publisher>The Hit Squad</publisher>
 		<part name="flop1" interface="floppy_3_5">
 			<dataarea name="flop" size="1049180">
 				<rom name="(sps1344)bubblebobble.ipf" size="1049180" crc="6dc5d808" sha1="55eca2f5936e5231418d8b741a272d26447f0054"/>
@@ -8061,7 +8061,7 @@
 		<!-- budget, standalone -->
 		<!-- (Amiga, OCS, PAL) -->
 		<year>1990</year>
-		<publisher>Hit Squad</publisher>
+		<publisher>The Hit Squad</publisher>
 		<part name="flop1" interface="floppy_3_5">
 			<dataarea name="flop" size="1049180">
 				<rom name="(sps2773)castlemaster.ipf" size="1049180" crc="05cb22c1" sha1="8d914f15ff9fb67272396d35c80b26087552b7d3"/>
@@ -8680,7 +8680,7 @@
 		<!-- budget, standalone -->
 		<!-- (Amiga, OCS, PAL) -->
 		<year>1989</year>
-		<publisher>Hit Squad</publisher>
+		<publisher>The Hit Squad</publisher>
 		<part name="flop1" interface="floppy_3_5">
 			<dataarea name="flop" size="1049612">
 				<rom name="(sps2209)chaseh.q..ipf" size="1049612" crc="609ba2b9" sha1="9d6891f313f7dfc48b6da21664751ee4c0f2a444"/>
@@ -11050,7 +11050,7 @@
 		<!-- budget, standalone -->
 		<!-- (Amiga, OCS, PAL) -->
 		<year>1988</year>
-		<publisher>Hit Squad</publisher>
+		<publisher>The Hit Squad</publisher>
 		<part name="flop1" interface="floppy_3_5">
 			<dataarea name="flop" size="1049180">
 				<rom name="(sps957)daleythompsonsolympicchallenge.ipf" size="1049180" crc="d669d368" sha1="53fb49531785ff8c5523cd0272b27ffe22d85d41"/>
@@ -21270,7 +21270,7 @@
 		<!-- budget, standalone -->
 		<!-- (Amiga, OCS, PAL) -->
 		<year>1988</year>
-		<publisher>Hit Squad</publisher>
+		<publisher>The Hit Squad</publisher>
 		<part name="flop1" interface="floppy_3_5">
 			<dataarea name="flop" size="1049180">
 				<rom name="(sps2063)ik+.ipf" size="1049180" crc="eefd220d" sha1="702c31441a3d9ff0c7c0d9959bd49e814b7c55c8"/>
@@ -26307,7 +26307,7 @@
 		<!-- budget, standalone -->
 		<!-- (Amiga, OCS, PAL) -->
 		<year>1988</year>
-		<publisher>Hit Squad</publisher>
+		<publisher>The Hit Squad</publisher>
 		<part name="flop1" interface="floppy_3_5">
 			<dataarea name="flop" size="1049180">
 				<rom name="(sps1144)lombardracrally.ipf" size="1049180" crc="ead0da67" sha1="cd266dd5c0319713ada9c47040478d814a6fc459"/>
@@ -29974,7 +29974,7 @@
 		<!-- budget, standalone -->
 		<!-- (Amiga, OCS, PAL) -->
 		<year>1990</year>
-		<publisher>Hit Squad</publisher>
+		<publisher>The Hit Squad</publisher>
 		<part name="flop1" interface="floppy_3_5">
 			<feature name="part_id" value="Disk 1" />
 			<dataarea name="flop" size="1049612">
@@ -32816,7 +32816,7 @@
 		<!-- budget, standalone -->
 		<!-- (Amiga, OCS, PAL) -->
 		<year>1989</year>
-		<publisher>Hit Squad</publisher>
+		<publisher>The Hit Squad</publisher>
 		<part name="flop1" interface="floppy_3_5">
 			<dataarea name="flop" size="1049612">
 				<rom name="(sps2898)populous.ipf" size="1049612" crc="ca5f9bca" sha1="60ecc33c2174a0f46eb7dcf1be92b54e5f7fcca5"/>
@@ -32859,7 +32859,7 @@
 		<!-- budget, addon -->
 		<!-- (Amiga, OCS, PAL) -->
 		<year>1989</year>
-		<publisher>Hit Squad</publisher>
+		<publisher>The Hit Squad</publisher>
 		<info name="usage" value="Requires &quot;Populous&quot; to work" />
 		<part name="flop1" interface="floppy_3_5">
 			<dataarea name="flop" size="1049612">
@@ -33085,7 +33085,7 @@
 		<!-- budget, standalone -->
 		<!-- (Amiga, OCS, PAL) -->
 		<year>1990</year>
-		<publisher>Hit Squad</publisher>
+		<publisher>The Hit Squad</publisher>
 		<part name="flop1" interface="floppy_3_5">
 			<dataarea name="flop" size="1049612">
 				<rom name="(sps1886)powermonger.ipf" size="1049612" crc="eb1d5709" sha1="96e63c59672b4808872b8c7bd1c70480a9e9714c"/>
@@ -33517,7 +33517,7 @@
 		<!-- budget, standalone -->
 		<!-- (Amiga, OCS, PAL) -->
 		<year>1989</year>
-		<publisher>Hit Squad</publisher>
+		<publisher>The Hit Squad</publisher>
 		<part name="flop1" interface="floppy_3_5">
 			<dataarea name="flop" size="991626">
 				<rom name="(sps1875)protennistour.ipf" size="991626" crc="fade8ee4" sha1="c50539ea55aa5d1b757f4893998dc481f096f238"/>
@@ -34359,7 +34359,7 @@
 		<!-- budget, standalone -->
 		<!-- (Amiga, OCS, PAL) -->
 		<year>1991</year>
-		<publisher>Hit Squad</publisher>
+		<publisher>The Hit Squad</publisher>
 		<part name="flop1" interface="floppy_3_5">
 			<dataarea name="flop" size="1049612">
 				<rom name="(sps2155)r.b.i.twobaseball.ipf" size="1049612" crc="015eab29" sha1="e9ccffea71659de928ef8961e3c140b919af2891"/>
@@ -34513,7 +34513,7 @@
 		<!-- budget, standalone -->
 		<!-- (Amiga, OCS, PAL) -->
 		<year>1989</year>
-		<publisher>Hit Squad</publisher>
+		<publisher>The Hit Squad</publisher>
 		<part name="flop1" interface="floppy_3_5">
 			<dataarea name="flop" size="1049612">
 				<rom name="(sps1311)rainbowislands.ipf" size="1049612" crc="741161ec" sha1="86680b4e0782bba651d068d58d0ea52c242e49cb"/>
@@ -34527,7 +34527,7 @@
 		<!-- budget, standalone -->
 		<!-- (Amiga, OCS, PAL) -->
 		<year>1989</year>
-		<publisher>Hit Squad</publisher>
+		<publisher>The Hit Squad</publisher>
 		<part name="flop1" interface="floppy_3_5">
 			<dataarea name="flop" size="1049612">
 				<rom name="(sps2433)ramboiii.ipf" size="1049612" crc="d3aa03a2" sha1="129928fff3dc791c6ae9c441844275328776aa79"/>
@@ -34898,7 +34898,7 @@
 		<!-- budget, standalone -->
 		<!-- (Amiga, OCS, PAL) -->
 		<year>1989</year>
-		<publisher>Hit Squad</publisher>
+		<publisher>The Hit Squad</publisher>
 		<part name="flop1" interface="floppy_3_5">
 			<dataarea name="flop" size="1049180">
 				<rom name="(sps1154)redheat.ipf" size="1049180" crc="891a370d" sha1="d00b48e1888b783fab0a9f1735b7776e5452af51"/>
@@ -35020,7 +35020,7 @@
 		<!-- budget, standalone -->
 		<!-- (Amiga, OCS, PAL) -->
 		<year>1989</year>
-		<publisher>Hit Squad</publisher>
+		<publisher>The Hit Squad</publisher>
 		<part name="flop1" interface="floppy_3_5">
 			<dataarea name="flop" size="1049180">
 				<rom name="(sps2183)renegade.ipf" size="1049180" crc="8d20091a" sha1="a56e7725b46f858ef74e3acde4fdfc1600e93e8e"/>
@@ -35531,7 +35531,7 @@
 		<!-- budget, standalone -->
 		<!-- (Amiga, OCS, PAL) -->
 		<year>1989</year>
-		<publisher>Hit Squad</publisher>
+		<publisher>The Hit Squad</publisher>
 		<part name="flop1" interface="floppy_3_5">
 			<dataarea name="flop" size="1049612">
 				<rom name="(sps1621)robocop.ipf" size="1049612" crc="717a7ec8" sha1="dc825cb30b7e7cad3c9d4ec9ddd957300b658ba6"/>
@@ -44517,7 +44517,7 @@ Because according to available sources v1.1 was always boxed as 'European Champi
 		<!-- budget, standalone -->
 		<!-- (Amiga, OCS, PAL) -->
 		<year>1990</year>
-		<publisher>Hit Squad</publisher>
+		<publisher>The Hit Squad</publisher>
 		<part name="flop1" interface="floppy_3_5">
 			<dataarea name="flop" size="1049180">
 				<rom name="(sps1770)totalrecall.ipf" size="1049180" crc="f4381a36" sha1="ba5e84e9b6e0744dd8dc7b27d1eafb4a55dbae8e"/>
@@ -46226,7 +46226,7 @@ Because according to available sources v1.1 was always boxed as 'European Champi
 		<!-- budget, standalone -->
 		<!-- (Amiga, OCS, PAL) -->
 		<year>1989</year>
-		<publisher>Hit Squad</publisher>
+		<publisher>The Hit Squad</publisher>
 		<part name="flop1" interface="floppy_3_5">
 			<dataarea name="flop" size="1049180">
 				<rom name="(sps1155)voyager.ipf" size="1049180" crc="5fa8b34f" sha1="7d007a0ed3229e937f253bc009d42cc2b1679967"/>
@@ -47603,7 +47603,7 @@ Because according to available sources v1.1 was always boxed as 'European Champi
 		<!-- budget, standalone -->
 		<!-- (Amiga, OCS, PAL) -->
 		<year>1988</year>
-		<publisher>Hit Squad</publisher>
+		<publisher>The Hit Squad</publisher>
 		<part name="flop1" interface="floppy_3_5">
 			<dataarea name="flop" size="1049180">
 				<rom name="(sps1544)wizball.ipf" size="1049180" crc="047608f5" sha1="d36c7cb70340dc5bea09078e6c385450771cb69c"/>
@@ -48018,7 +48018,7 @@ Because according to available sources v1.1 was always boxed as 'European Champi
 		<!-- budget, standalone -->
 		<!-- (Amiga, OCS, PAL) -->
 		<year>1991</year>
-		<publisher>Hit Squad</publisher>
+		<publisher>The Hit Squad</publisher>
 		<part name="flop1" interface="floppy_3_5">
 			<feature name="part_id" value="Disk 1" />
 			<dataarea name="flop" size="852144">

--- a/hash/c64_cass.xml
+++ b/hash/c64_cass.xml
@@ -379,6 +379,26 @@
 		</part>
 	</software>
 
+	<software name="anglebl">
+		<description>Angle Ball</description>
+		<year>1987</year>
+		<publisher>Mastertronic Added Dimension</publisher>
+
+		<part name="anglebla" interface="cbm_cass">
+			<feature name="part_id" value="Side A"/>
+			<dataarea name="cass" size="267415">
+				<rom name="anglebla.tap" size="267415" crc="8a71c7cf" sha1="f60d649fd0087ae4692947750c56733159bffd2a"/>
+			</dataarea>
+		</part>
+
+		<part name="angleblb" interface="cbm_cass">
+			<feature name="part_id" value="Side B"/>
+			<dataarea name="cass" size="267414">
+				<rom name="angleblb.tap" size="267414" crc="8c58c3c3" sha1="f4db67b46dec798230fea7291445c1cbddf74c0d"/>
+			</dataarea>
+		</part>
+	</software>
+
 	<software name="annihiltr">
 		<description>Annihilator</description>
 		<year>1983</year>
@@ -581,6 +601,26 @@
 		<part name="cass1" interface="cbm_cass">
 			<dataarea name="cass" size="578780">
 				<rom name="Back_to_the_Future.tap" size="578780" crc="e6eac89d" sha1="9c9272a7dee502d2ed0ff6166703e53a914e784a"/>
+			</dataarea>
+		</part>
+	</software>
+
+	<software name="ballcrz">
+		<description>Ball Crazy</description>
+		<year>1987</year>
+		<publisher>Mastertronic Added Dimension</publisher>
+
+		<part name="ballcrza" interface="cbm_cass">
+			<feature name="part_id" value="Side A"/>
+			<dataarea name="cass" size="531341">
+				<rom name="ballcrza.tap" size="531341" crc="e0b0dfce" sha1="d97966c12248724d0334c8ccfb03bfb877d92d03"/>
+			</dataarea>
+		</part>
+
+		<part name="ballcrzb" interface="cbm_cass">
+			<feature name="part_id" value="Side B"/>
+			<dataarea name="cass" size="528497">
+				<rom name="ballcrzb.tap" size="528497" crc="ddb141fb" sha1="d8e3ebaee70fcaa1b81d2ab02111bb7d0e033a4d"/>
 			</dataarea>
 		</part>
 	</software>
@@ -1538,6 +1578,26 @@
 		</part>
 	</software>
 
+	<software name="circus">
+		<description>Continental Circus</description>
+		<year>1991</year>
+		<publisher>Mastertronic Plus</publisher>
+
+		<part name="circusa" interface="cbm_cass">
+			<feature name="part_id" value="Side A"/>
+			<dataarea name="cass" size="569886">
+				<rom name="circusa.tap" size="569886" crc="d0f36a0b" sha1="bd09c14234c8c89fc391631f0fc949a7fd8a7922"/>
+			</dataarea>
+		</part>
+
+		<part name="circusb" interface="cbm_cass">
+			<feature name="part_id" value="Side B"/>
+			<dataarea name="cass" size="569886">
+				<rom name="circusb.tap" size="569886" crc="df7f4101" sha1="b07a48a3283936058f6e3147d41f34f3001ba650"/>
+			</dataarea>
+		</part>
+	</software>
+
 	<software name="corp">
 		<description>Corporation</description>
 		<year>1990</year>
@@ -2062,6 +2122,26 @@
 		<part name="cass1" interface="cbm_cass">
 			<dataarea name="cass" size="741073">
 				<rom name="Fast_Food.tap" size="741073" crc="6e0f6d68" sha1="a7e41c82248d1276abc1db92acc1e690e2ab68a5"/>
+			</dataarea>
+		</part>
+	</software>
+
+	<software name="feud">
+		<description>Feud</description>
+		<year>1987</year>
+		<publisher>Bulldog Software</publisher>
+
+		<part name="feuda" interface="cbm_cass">
+			<feature name="part_id" value="Side A"/>
+			<dataarea name="cass" size="611910">
+				<rom name="feuda.tap" size="611910" crc="9ac57691" sha1="ff53d728123469ce40c8c1553cb03912aa897e60"/>
+			</dataarea>
+		</part>
+
+		<part name="feudb" interface="cbm_cass">
+			<feature name="part_id" value="Side B"/>
+			<dataarea name="cass" size="611910">
+				<rom name="feudb.tap" size="611910" crc="0cbe87c1" sha1="b06e65952e8d2c8ee0b8cb227134136ba53b62b3"/>
 			</dataarea>
 		</part>
 	</software>
@@ -4263,6 +4343,26 @@
 		</part>
 	</software>
 
+	<software name="omahd">
+		<description>One Man and His Droid</description>
+		<year>1985</year>
+		<publisher>199 Range</publisher>
+
+		<part name="omahda" interface="cbm_cass">
+			<feature name="part_id" value="Side A"/>
+			<dataarea name="cass" size="611660">
+				<rom name="omahda.tap" size="611660" crc="6da4096b" sha1="263e452ba8e5f69411a873ba8ce1907f2610d24f"/>
+			</dataarea>
+		</part>
+
+		<part name="omahdb" interface="cbm_cass">
+			<feature name="part_id" value="Side B"/>
+			<dataarea name="cass" size="598097">
+				<rom name="omahdb.tap" size="598097" crc="30661926" sha1="60d822dc311a72b197483b79b29ea9daab4366de"/>
+			</dataarea>
+		</part>
+	</software>
+
 	<software name="opthunder">
 		<description>Operation Thunderbolt</description>
 		<year>19??</year>
@@ -5253,6 +5353,26 @@
 		<part name="cass1" interface="cbm_cass">
 			<dataarea name="cass" size="229645">
 				<rom name="Robin_to_the_Rescue.tap" size="229645" crc="cf705e34" sha1="dcf6d4beafd1f42f13158bf9944c5ace2e035b12"/>
+			</dataarea>
+		</part>
+	</software>
+
+	<software name="robocop">
+		<description>Robocop</description>
+		<year>1988</year>
+		<publisher>The Hit Squad</publisher>
+
+		<part name="robocopa" interface="cbm_cass">
+			<feature name="part_id" value="Side A"/>
+			<dataarea name="cass" size="1510854">
+				<rom name="robocopa.tap" size="1510854" crc="66624f2c" sha1="e8d137e6a345c0e3cafd1bf56eb7215a7a6dc597"/>
+			</dataarea>
+		</part>
+
+		<part name="robocopb" interface="cbm_cass">
+			<feature name="part_id" value="Side B"/>
+			<dataarea name="cass" size="1510854">
+				<rom name="robocopb.tap" size="1510854" crc="a018d08f" sha1="b4730e17a2566994c017dcfe893968375c30d3ec"/>
 			</dataarea>
 		</part>
 	</software>

--- a/hash/c64_cass.xml
+++ b/hash/c64_cass.xml
@@ -3811,7 +3811,7 @@
 	<software name="lotus">
 		<description>Lotus Esprit Turbo Challenge</description>
 		<year>19??</year>
-		<publisher>Gremlin Graphics (GBH)</publisher>
+		<publisher>GBH</publisher>
 
 		<part name="cass1" interface="cbm_cass">
 			<feature name="part_id" value="Side 1"/>
@@ -3975,7 +3975,7 @@
 	<software name="missomega">
 		<description>Mission Omega</description>
 		<year>1989</year>
-		<publisher>Grandslam (Bug Byte)</publisher>
+		<publisher>Bug Byte</publisher>
 
 		<part name="cass1" interface="cbm_cass">
 			<dataarea name="cass" size="520994">
@@ -6233,7 +6233,7 @@
 	<software name="spokerc" cloneof="spoker">
 		<description>Strip Poker (CDS)</description>
 		<year>19??</year>
-		<publisher>CDS Software (Blue Ribbon)</publisher>
+		<publisher>Blue Ribbon</publisher>
 
 		<part name="cass1" interface="cbm_cass">
 			<feature name="part_id" value="Side 1: Suzi"/>

--- a/hash/c64_cass.xml
+++ b/hash/c64_cass.xml
@@ -2,7 +2,8 @@
 <!DOCTYPE softwarelist SYSTEM "softwarelist.dtd">
 
 <!-- The majority of this list was sourced from The Ultimate Tape Archive V1.0 released 11th December 2018. -->
-<!-- Others based on c64tapes.org dumps -->
+<!-- Some others are based on c64tapes.org dumps -->
+<!-- Some are based on the C64 Tape Archive at https://archive.org/download/c64tapes/index.htm -->
 
 <softwarelist name="c64_cass" description="Commodore 64 cassettes">
 
@@ -70,6 +71,46 @@
 		<part name="cass2" interface="cbm_cass">
 			<dataarea name="cass" size="540664">
 				<rom name="1985_-_The_Day_After_a2.tap" size="540664" crc="8dcdb246" sha1="f5551c42c206c8ff90986b645822a486209c5ba0"/>
+			</dataarea>
+		</part>
+	</software>
+
+	<software name="3dpinbl">
+		<description>3D Pinball</description>
+		<year>1989</year>
+		<publisher>Mastertronic Plus</publisher>
+
+		<part name="3dpinbla" interface="cbm_cass">
+			<feature name="part_id" value="Side A"/>
+			<dataarea name="cass" size="192466">
+				<rom name="3dpinbla.tap" size="192466" crc="fa7d00d8" sha1="9e547ac4ee11b6b6f034f4cac5c31079c23373b3"/>
+			</dataarea>
+		</part>
+
+		<part name="3dpinblb" interface="cbm_cass">
+			<feature name="part_id" value="Side B"/>
+			<dataarea name="cass" size="192466">
+				<rom name="3dpinblb.tap" size="192466" crc="f91f841d" sha1="2ed915985ef8192df097b420b17dfbe87ed358bb"/>
+			</dataarea>
+		</part>
+	</software>
+
+	<software name="a3dpool">
+		<description>American 3D Pool</description>
+		<year>1991</year>
+		<publisher>Zeppelin Games</publisher>
+
+		<part name="a3dpoola" interface="cbm_cass">
+			<feature name="part_id" value="Side A"/>
+			<dataarea name="cass" size="861564">
+				<rom name="a3dpoola.tap" size="861564" crc="3381e127" sha1="a3cca3ad5638f9e2e08b223cfd2526f72fdeb063"/>
+			</dataarea>
+		</part>
+
+		<part name="a3dpoolb" interface="cbm_cass">
+			<feature name="part_id" value="Side B"/>
+			<dataarea name="cass" size="867657">
+				<rom name="a3dpoolb.tap" size="867657" crc="acc6f5fe" sha1="f21761d9d86e1bc98ea081a7405193e1eae6e30e"/>
 			</dataarea>
 		</part>
 	</software>

--- a/hash/c64_cass.xml
+++ b/hash/c64_cass.xml
@@ -5421,6 +5421,26 @@
 		</part>
 	</software>
 
+	<software name="rockfrd">
+		<description>Rockford / Back to Reality</description>
+		<year>1987</year>
+		<publisher>Mastertronic Added Dimension</publisher>
+
+		<part name="breality" interface="cbm_cass">
+			<feature name="part_id" value="Back to Reality"/>
+			<dataarea name="cass" size="570317">
+				<rom name="breality.tap" size="570317" crc="2f561e28" sha1="ed091ed18ac721772d567d2a6e24cef44a3a3b7a"/>
+			</dataarea>
+		</part>
+
+		<part name="rockford" interface="cbm_cass">
+			<feature name="part_id" value="Rockford"/>
+			<dataarea name="cass" size="333295">
+				<rom name="rockford.tap" size="333295" crc="ec352a42" sha1="b74140b6c605c914f5d983eabff74b38167c1777"/>
+			</dataarea>
+		</part>
+	</software>
+
 	<software name="rollarnd">
 		<description>Rollaround</description>
 		<year>1988</year>

--- a/hash/c64_cass.xml
+++ b/hash/c64_cass.xml
@@ -138,7 +138,7 @@
 	<software name="5thgear">
 		<description>5th Gear</description>
 		<year>1988</year>
-		<publisher>Hewson (Rack IT)</publisher>
+		<publisher>Rack It</publisher>
 
 		<part name="cass1" interface="cbm_cass">
 			<dataarea name="cass" size="556826">
@@ -340,7 +340,7 @@
 	<software name="anarchy">
 		<description>Anarchy</description>
 		<year>1987</year>
-		<publisher>Hewson (Rack IT)</publisher>
+		<publisher>Rack It</publisher>
 
 		<part name="cass1" interface="cbm_cass">
 			<dataarea name="cass" size="386234">
@@ -718,7 +718,7 @@
 	<software name="bvalley">
 		<description>Battle Valley</description>
 		<year>1987</year>
-		<publisher>Hewson (Rack IT)</publisher>
+		<publisher>Rack It</publisher>
 
 		<part name="cass1" interface="cbm_cass">
 			<dataarea name="cass" size="446958">
@@ -2715,7 +2715,7 @@
 	<software name="golfmstr">
 		<description>Golf Master</description>
 		<year>19??</year>
-		<publisher>Hewson (Rack IT)</publisher>
+		<publisher>Rack It</publisher>
 
 		<part name="cass1" interface="cbm_cass">
 			<dataarea name="cass" size="395010">
@@ -5520,7 +5520,7 @@
 	<software name="scorpion">
 		<description>Scorpion</description>
 		<year>1988</year>
-		<publisher>Hewson (Rack IT)</publisher>
+		<publisher>Rack It</publisher>
 
 		<part name="cass1" interface="cbm_cass">
 			<dataarea name="cass" size="581494">
@@ -5652,7 +5652,7 @@
 	<software name="slayer">
 		<description>Slayer</description>
 		<year>1988</year>
-		<publisher>Hewson (Rack IT)</publisher>
+		<publisher>Rack It</publisher>
 
 		<part name="cass1" interface="cbm_cass">
 			<dataarea name="cass" size="558266">
@@ -6037,7 +6037,7 @@
 	<software name="steel">
 		<description>Steel</description>
 		<year>1988</year>
-		<publisher>Hewson (Rack IT)</publisher>
+		<publisher>Rack It</publisher>
 
 		<part name="cass1" interface="cbm_cass">
 			<dataarea name="cass" size="420211">
@@ -6643,7 +6643,7 @@
 	<software name="thndforc">
 		<description>Thunderforce</description>
 		<year>1987</year>
-		<publisher>Hewson (Rack IT)</publisher>
+		<publisher>Rack It</publisher>
 
 		<part name="cass1" interface="cbm_cass">
 			<dataarea name="cass" size="591004">

--- a/hash/c64_cass.xml
+++ b/hash/c64_cass.xml
@@ -567,7 +567,7 @@
 	<software name="batman">
 		<description>Batman</description>
 		<year>1991</year>
-		<publisher>Hit Squad</publisher>
+		<publisher>The Hit Squad</publisher>
 
 		<part name="cass1" interface="cbm_cass">
 			<feature name="part_id" value="Side 1"/>
@@ -1069,7 +1069,7 @@
 	<software name="bublbobl">
 		<description>Bubble Bobble</description>
 		<year>1991</year>
-		<publisher>Hit Squad</publisher>
+		<publisher>The Hit Squad</publisher>
 
 		<part name="cass1" interface="cbm_cass">
 			<dataarea name="cass" size="763836">
@@ -1554,7 +1554,7 @@
 	<software name="crazycar">
 		<description>Crazy Cars</description>
 		<year>1989</year>
-		<publisher>Hit Squad</publisher>
+		<publisher>The Hit Squad</publisher>
 
 		<part name="cass1" interface="cbm_cass">
 			<dataarea name="cass" size="813145">
@@ -1710,7 +1710,7 @@
 	<software name="daleydech" cloneof="daleydec">
 		<description>Daley Thompson's Decathlon (Hit Squad)</description>
 		<year>1989</year>
-		<publisher>Hit Squad</publisher>
+		<publisher>The Hit Squad</publisher>
 
 		<part name="cass1" interface="cbm_cass">
 			<dataarea name="cass" size="582574">
@@ -1920,7 +1920,7 @@
 	<software name="enduro">
 		<description>Enduro Racer</description>
 		<year>1989</year>
-		<publisher>Hit Squad</publisher>
+		<publisher>The Hit Squad</publisher>
 
 		<part name="cass1" interface="cbm_cass">
 			<dataarea name="cass" size="495807">
@@ -2319,7 +2319,7 @@
 	<software name="fs2_6to8">
 		<description>Fun School 2 for 6-8 Year Olds</description>
 		<year>1992</year>
-		<publisher>Hit Squad</publisher>
+		<publisher>The Hit Squad</publisher>
 
 		<part name="cass1" interface="cbm_cass">
 			<feature name="part_id" value="Side A: Train / Maze / Shopping / Treasure"/>
@@ -2698,7 +2698,7 @@
 	<software name="gryzor">
 		<description>Gryzor</description>
 		<year>19??</year>
-		<publisher>Hit Squad</publisher>
+		<publisher>The Hit Squad</publisher>
 
 		<part name="cass1" interface="cbm_cass">
 			<dataarea name="cass" size="738562">
@@ -3168,7 +3168,7 @@
 	<software name="lic2kill">
 		<description>James Bond 007: Licence To Kill</description>
 		<year>19??</year>
-		<publisher>Hit Squad</publisher>
+		<publisher>The Hit Squad</publisher>
 
 		<part name="cass1" interface="cbm_cass">
 			<dataarea name="cass" size="514499">
@@ -4095,7 +4095,7 @@
 	<software name="tnzs">
 		<description>The Newzealand Story</description>
 		<year>1991</year>
-		<publisher>Hit Squad</publisher>
+		<publisher>The Hit Squad</publisher>
 
 		<part name="cass1" interface="cbm_cass">
 			<feature name="part_id" value="Side 1"/>
@@ -4225,7 +4225,7 @@
 	<software name="opthunder">
 		<description>Operation Thunderbolt</description>
 		<year>19??</year>
-		<publisher>Hit Squad</publisher>
+		<publisher>The Hit Squad</publisher>
 
 		<part name="cass1" interface="cbm_cass">
 			<feature name="part_id" value="Side 1"/>
@@ -4245,7 +4245,7 @@
 	<software name="opwolf">
 		<description>Operation Wolf</description>
 		<year>1990</year>
-		<publisher>Hit Squad</publisher>
+		<publisher>The Hit Squad</publisher>
 
 		<part name="cass1" interface="cbm_cass">
 			<dataarea name="cass" size="720182">
@@ -4402,7 +4402,7 @@
 	<software name="parallax">
 		<description>Parallax</description>
 		<year>1990</year>
-		<publisher>Hit Squad</publisher>
+		<publisher>The Hit Squad</publisher>
 
 		<part name="cass1" interface="cbm_cass">
 			<dataarea name="cass" size="702891">
@@ -4516,7 +4516,7 @@
 	<software name="platoon">
 		<description>Platoon</description>
 		<year>1990</year>
-		<publisher>Hit Squad</publisher>
+		<publisher>The Hit Squad</publisher>
 
 		<part name="cass1" interface="cbm_cass">
 			<feature name="part_id" value="Side A"/>
@@ -4937,7 +4937,7 @@
 	<software name="rbisland">
 		<description>Rainbow Islands</description>
 		<year>1992</year>
-		<publisher>Hit Squad</publisher>
+		<publisher>The Hit Squad</publisher>
 
 		<part name="cass1" interface="cbm_cass">
 			<feature name="part_id" value="Side 1"/>
@@ -4969,7 +4969,7 @@
 	<software name="rambo3">
 		<description>Rambo III</description>
 		<year>19??</year>
-		<publisher>Hit Squad</publisher>
+		<publisher>The Hit Squad</publisher>
 
 		<part name="cass1" interface="cbm_cass">
 			<feature name="part_id" value="Side 1"/>
@@ -4989,7 +4989,7 @@
 	<software name="rambo2">
 		<description>Rambo: First Blood Part II</description>
 		<year>1989</year>
-		<publisher>Hit Squad</publisher>
+		<publisher>The Hit Squad</publisher>
 
 		<part name="cass1" interface="cbm_cass">
 			<dataarea name="cass" size="642762">
@@ -5021,7 +5021,7 @@
 	<software name="redheat">
 		<description>Red Heat</description>
 		<year>1989</year>
-		<publisher>Hit Squad</publisher>
+		<publisher>The Hit Squad</publisher>
 
 		<part name="cass1" interface="cbm_cass">
 			<dataarea name="cass" size="726358">
@@ -5045,7 +5045,7 @@
 	<software name="renegade">
 		<description>Renegade</description>
 		<year>19??</year>
-		<publisher>Hit Squad</publisher>
+		<publisher>The Hit Squad</publisher>
 
 		<part name="cass1" interface="cbm_cass">
 			<dataarea name="cass" size="500294">
@@ -5810,7 +5810,7 @@
 	<software name="cobra">
 		<description>Stallone: Cobra</description>
 		<year>1989</year>
-		<publisher>Hit Squad</publisher>
+		<publisher>The Hit Squad</publisher>
 
 		<part name="cass1" interface="cbm_cass">
 			<dataarea name="cass" size="524590">
@@ -5822,7 +5822,7 @@
 	<software name="rotj">
 		<description>Star Wars: Return of the Jedi</description>
 		<year>19??</year>
-		<publisher>Hit Squad</publisher>
+		<publisher>The Hit Squad</publisher>
 
 		<part name="cass1" interface="cbm_cass">
 			<dataarea name="cass" size="622110">
@@ -6256,7 +6256,7 @@
 	<software name="shangon">
 		<description>Super Hang On</description>
 		<year>1990</year>
-		<publisher>Hit Squad</publisher>
+		<publisher>The Hit Squad</publisher>
 
 		<part name="cass1" interface="cbm_cass">
 			<feature name="part_id" value="Side 1: Africa and Asia"/>
@@ -6760,7 +6760,7 @@
 	<software name="thevindc">
 		<description>The Vindicator</description>
 		<year>1990</year>
-		<publisher>Hit Squad</publisher>
+		<publisher>The Hit Squad</publisher>
 
 		<part name="cass1" interface="cbm_cass">
 			<dataarea name="cass" size="1508734">
@@ -6922,7 +6922,7 @@
 	<software name="wizball">
 		<description>Wizball</description>
 		<year>1989</year>
-		<publisher>Hit Squad</publisher>
+		<publisher>The Hit Squad</publisher>
 
 		<part name="cass1" interface="cbm_cass">
 			<dataarea name="cass" size="567846">
@@ -6966,7 +6966,7 @@
 	<software name="wsb">
 		<description>World Series Baseball</description>
 		<year>1989</year>
-		<publisher>Hit Squad</publisher>
+		<publisher>The Hit Squad</publisher>
 
 		<part name="cass1" interface="cbm_cass">
 			<dataarea name="cass" size="402702">

--- a/hash/ibm5170_cdrom.xml
+++ b/hash/ibm5170_cdrom.xml
@@ -1981,7 +1981,7 @@
 	<software name="f29ret" supported="no">
 		<description>F-29 Retaliator</description>
 		<year>1995</year>
-		<publisher>Hit Squad</publisher>
+		<publisher>The Hit Squad</publisher>
 
 		<part name="cdrom" interface="cdrom">
 			<diskarea name="cdrom">


### PR DESCRIPTION
This has two commits: one simply tidies up the name of Ocean's label The Hit Squad; the other one tentatively adds in some more tape dumps.

These dumps are [verified good](https://archive.org/download/c64tapes/the_list.htm) by the Tapclean software.  Where there are duplicates between The Ultimate Tape Archive and the C64 Tape Archive, the payload's "magic CRC32" matches, but the overall files' CRC32s and SHA1s don't, which I believe is to be expected, given the nature of the medium.  (At the end of the day, this isn't a 1:1 mapping of binary data like in a ROM chip; it's counting clock cycles between a pulse wave flipping on a Compact Cassette tape, stylised to compensate for wow and flutter, wrapped up in a custom format with its own headers.)  So I'm ignoring duplicates, even though the whole-file hashes don't match.

If this is all OK, I'll add more later.  There were some quite stellar games released on tape.