### PR TITLE
Fix waitvsync for bgfx vulkan backend. [Couriersud]

### DIFF
--- a/3rdparty/bgfx/src/renderer_vk.cpp
+++ b/3rdparty/bgfx/src/renderer_vk.cpp
@@ -2761,6 +2761,45 @@ VK_IMPORT_DEVICE
 					releaseSwapchainFramebuffer();
 					releaseSwapchain();
 
+#if 1
+					uint32_t numPresentModes(10);
+					VkPresentModeKHR presentModes[10];
+					vkGetPhysicalDeviceSurfacePresentModesKHR(m_physicalDevice, m_surface, &numPresentModes, presentModes);
+
+					// find the best match...
+					uint32_t presentModeIdx = numPresentModes;
+					VkPresentModeKHR preferredPresentMode[] = {
+						VK_PRESENT_MODE_FIFO_KHR,
+						VK_PRESENT_MODE_FIFO_RELAXED_KHR,
+						VK_PRESENT_MODE_MAILBOX_KHR,
+						VK_PRESENT_MODE_IMMEDIATE_KHR,
+					};
+					bool has_vsync[] = {true, true, true, false};
+					bool vsync = (flags & BGFX_RESET_VSYNC ? true : false);
+
+					for (uint32_t ii = 0; ii < BX_COUNTOF(preferredPresentMode); ++ii)
+					{
+						for (uint32_t jj = 0; jj < numPresentModes; ++jj)
+						{
+							if ((presentModes[jj] == preferredPresentMode[ii]) && (vsync == has_vsync[ii]))
+							{
+								presentModeIdx = jj;
+								BX_TRACE("present mode: %d", (int)preferredPresentMode[ii]);
+								break;
+							}
+						}
+						if (presentModeIdx < numPresentModes)
+						{
+							break;
+						}
+					}
+					if (presentModeIdx == numPresentModes)
+					{
+						presentModeIdx = 0;
+					}
+					m_sci.presentMode = presentModes[presentModeIdx];
+					//bx::printf("%d %d %d %d %d\n", flags, BGFX_RESET_VSYNC, presentModeIdx, presentModes[presentModeIdx], numPresentModes);
+#endif
 					VkSurfaceCapabilitiesKHR surfaceCapabilities;
 					VK_CHECK(vkGetPhysicalDeviceSurfaceCapabilitiesKHR(m_physicalDevice, m_surface, &surfaceCapabilities) );
 


### PR DESCRIPTION
Currently waitvsync is broken in the bgfx vulkan backend.
The option is just ignored and a mode waiting for vsync is selected.
This also breaks throttle. -nothrottle doesn't work.

These changes fix this. If available a non-syncing mode is used if
-nowaitvsync is used.