### PR TITLE
bgfx: fix issue with changing screen effects

### DIFF
--- a/src/osd/modules/render/bgfx/chain.cpp
+++ b/src/osd/modules/render/bgfx/chain.cpp
@@ -168,5 +168,6 @@ void bgfx_chain::prepend_converter(bgfx_effect *effect, chain_manager &chains)
 
 	const uint32_t screen_width = chains.targets().width(TARGET_STYLE_GUEST, m_screen_index);
 	const uint32_t screen_height = chains.targets().height(TARGET_STYLE_GUEST, m_screen_index);
+	m_targets.destroy_target("screen", m_screen_index);
 	m_targets.create_target("screen", bgfx::TextureFormat::RGBA8, screen_width, screen_height, TARGET_STYLE_GUEST, true, false, 1, m_screen_index);
 }


### PR DESCRIPTION
This PR resolves an issue that happens when changing BGFX screen effects too many times. In my environment, MAME either crashes (Vulcan) or gives a black screen (OpenGL) after:
 * Starting MAME
 * Bringing up the in-game menu
 * Selecting Slider Controls and hover on "Window 0, Screen 0 Effect"
 * Traverse all effects back and forth a number of times by holding right or left key

The following commands was used to start the system:

Vulkan: `./mame64 -window -video bgfx -bgfx_backend vulkan -bgfx_screen_chains none [game]`

OpenGL: `./mame64 -window -video bgfx -bgfx_backend opengl -bgfx_screen_chains none [game]`

The games outrun and ridgerac are among the games tested and where the proposed fix resolves the issue