### PR TITLE
hp_ipc: fixed a bug in 1LL3 GPU

### DIFF
--- a/src/devices/video/hp1ll3.cpp
+++ b/src/devices/video/hp1ll3.cpp
@@ -539,10 +539,10 @@ bool hp1ll3_device::bitblt(uint16_t src_base_addr, unsigned src_width, unsigned 
 				 dst_rect.origin.x, dst_rect.origin.y, dst_rect.size.x, dst_rect.size.y,
 				 rop));
 	int src_x = src_p.x;
-	int dst_x = dst_rect.origin.x;
+	int dst_x = static_cast<int16_t>(dst_rect.origin.x);
 	int dst_width = dst_rect.size.x;
 	int src_y = src_p.y;
-	int dst_y = dst_rect.origin.y;
+	int dst_y = static_cast<int16_t>(dst_rect.origin.y);
 	int dst_height = dst_rect.size.y;
 	// Clip x-coordinates
 	clip_coord(src_width, src_x, clip_rect.origin.x, clip_rect.size.x, dst_x, dst_width);

--- a/src/mame/drivers/hp_ipc.cpp
+++ b/src/mame/drivers/hp_ipc.cpp
@@ -856,5 +856,5 @@ ROM_END
 #define rom_hp9808a rom_hp_ipc
 
 //    YEAR  NAME     PARENT  COMPAT  MACHINE  INPUT   CLASS         INIT        COMPANY            FULLNAME                            FLAGS
-COMP( 1985, hp_ipc,  0,      0,      hp_ipc,  hp_ipc, hp_ipc_state, empty_init, "Hewlett-Packard", "Integral Personal Computer 9807A", MACHINE_NO_SOUND | MACHINE_IMPERFECT_GRAPHICS)
+COMP( 1985, hp_ipc,  0,      0,      hp_ipc,  hp_ipc, hp_ipc_state, empty_init, "Hewlett-Packard", "Integral Personal Computer 9807A", MACHINE_NO_SOUND)
 COMP( 1985, hp9808a, 0,      0,      hp9808a, hp_ipc, hp_ipc_state, empty_init, "Hewlett-Packard", "Integral Personal Computer 9808A", MACHINE_NOT_WORKING)


### PR DESCRIPTION
Hi,
this commit fixes a bug in 1LL3 GPU emulation that caused cursor&sprite to disappear at top/left hand side of screen (i.e. when one of the coordinates is negative).
I also removed the "imperfect graphic" flag for HP IPC because, from my point of view, video emulation is as close as possible to the real hw.
Thanks.
--F.Ulivi
