### PR TITLE
m6502: Eliminate the disable_cache hack (nw)

### DIFF
--- a/src/devices/cpu/m6502/deco16.cpp
+++ b/src/devices/cpu/m6502/deco16.cpp
@@ -33,10 +33,7 @@ std::unique_ptr<util::disasm_interface> deco16_device::create_disassembler()
 
 void deco16_device::device_start()
 {
-	if(cache_disabled)
-		mintf = std::make_unique<mi_default_nd>();
-	else
-		mintf = std::make_unique<mi_default_normal>();
+	mintf = std::make_unique<mi_default>();
 
 	init();
 

--- a/src/devices/cpu/m6502/m4510.cpp
+++ b/src/devices/cpu/m6502/m4510.cpp
@@ -37,10 +37,7 @@ std::unique_ptr<util::disasm_interface> m4510_device::create_disassembler()
 
 void m4510_device::device_start()
 {
-	if(cache_disabled)
-		mintf = std::make_unique<mi_4510_nd>(this);
-	else
-		mintf = std::make_unique<mi_4510_normal>(this);
+	mintf = std::make_unique<mi_4510>(this);
 
 	m65ce02_device::init();
 
@@ -70,43 +67,29 @@ bool m4510_device::memory_translate(int spacenum, int intention, offs_t &address
 	return true;
 }
 
-m4510_device::mi_4510_normal::mi_4510_normal(m4510_device *_base)
+m4510_device::mi_4510::mi_4510(m4510_device *_base)
 {
 	base = _base;
 }
 
-uint8_t m4510_device::mi_4510_normal::read(uint16_t adr)
+uint8_t m4510_device::mi_4510::read(uint16_t adr)
 {
 	return program->read_byte(base->map(adr));
 }
 
-uint8_t m4510_device::mi_4510_normal::read_sync(uint16_t adr)
+uint8_t m4510_device::mi_4510::read_sync(uint16_t adr)
 {
 	return scache->read_byte(base->map(adr));
 }
 
-uint8_t m4510_device::mi_4510_normal::read_arg(uint16_t adr)
+uint8_t m4510_device::mi_4510::read_arg(uint16_t adr)
 {
 	return cache->read_byte(base->map(adr));
 }
 
-void m4510_device::mi_4510_normal::write(uint16_t adr, uint8_t val)
+void m4510_device::mi_4510::write(uint16_t adr, uint8_t val)
 {
 	program->write_byte(base->map(adr), val);
-}
-
-m4510_device::mi_4510_nd::mi_4510_nd(m4510_device *_base) : mi_4510_normal(_base)
-{
-}
-
-uint8_t m4510_device::mi_4510_nd::read_sync(uint16_t adr)
-{
-	return sprogram->read_byte(base->map(adr));
-}
-
-uint8_t m4510_device::mi_4510_nd::read_arg(uint16_t adr)
-{
-	return program->read_byte(base->map(adr));
 }
 
 #include "cpu/m6502/m4510.hxx"

--- a/src/devices/cpu/m6502/m4510.h
+++ b/src/devices/cpu/m6502/m4510.h
@@ -31,24 +31,16 @@ protected:
 	uint8_t map_enable;
 	bool nomap;
 
-	class mi_4510_normal : public memory_interface {
+	class mi_4510 : public memory_interface {
 	public:
 		m4510_device *base;
 
-		mi_4510_normal(m4510_device *base);
-		virtual ~mi_4510_normal() {}
+		mi_4510(m4510_device *base);
+		virtual ~mi_4510() {}
 		virtual uint8_t read(uint16_t adr) override;
 		virtual uint8_t read_sync(uint16_t adr) override;
 		virtual uint8_t read_arg(uint16_t adr) override;
 		virtual void write(uint16_t adr, uint8_t val) override;
-	};
-
-	class mi_4510_nd : public mi_4510_normal {
-	public:
-		mi_4510_nd(m4510_device *base);
-		virtual ~mi_4510_nd() {}
-		virtual uint8_t read_sync(uint16_t adr) override;
-		virtual uint8_t read_arg(uint16_t adr) override;
 	};
 
 	virtual void device_start() override;

--- a/src/devices/cpu/m6502/m6502.cpp
+++ b/src/devices/cpu/m6502/m6502.cpp
@@ -27,15 +27,11 @@ m6502_device::m6502_device(const machine_config &mconfig, device_type type, cons
 	sprogram_config("decrypted_opcodes", ENDIANNESS_LITTLE, 8, 16), PPC(0), NPC(0), PC(0), SP(0), TMP(0), TMP2(0), A(0), X(0), Y(0), P(0), IR(0), inst_state_base(0), mintf(nullptr),
 	inst_state(0), inst_substate(0), icount(0), nmi_state(false), irq_state(false), apu_irq_state(false), v_state(false), irq_taken(false), sync(false), inhibit_interrupts(false)
 {
-	cache_disabled = false;
 }
 
 void m6502_device::device_start()
 {
-	if(cache_disabled)
-		mintf = std::make_unique<mi_default_nd>();
-	else
-		mintf = std::make_unique<mi_default_normal>();
+	mintf = std::make_unique<mi_default>();
 
 	init();
 }
@@ -524,36 +520,26 @@ void m6502_device::memory_interface::write_9(uint16_t adr, uint8_t val)
 }
 
 
-uint8_t m6502_device::mi_default_normal::read(uint16_t adr)
+uint8_t m6502_device::mi_default::read(uint16_t adr)
 {
 	return program->read_byte(adr);
 }
 
-uint8_t m6502_device::mi_default_normal::read_sync(uint16_t adr)
+uint8_t m6502_device::mi_default::read_sync(uint16_t adr)
 {
 	return scache->read_byte(adr);
 }
 
-uint8_t m6502_device::mi_default_normal::read_arg(uint16_t adr)
+uint8_t m6502_device::mi_default::read_arg(uint16_t adr)
 {
 	return cache->read_byte(adr);
 }
 
-
-void m6502_device::mi_default_normal::write(uint16_t adr, uint8_t val)
+void m6502_device::mi_default::write(uint16_t adr, uint8_t val)
 {
 	program->write_byte(adr, val);
 }
 
-uint8_t m6502_device::mi_default_nd::read_sync(uint16_t adr)
-{
-	return sprogram->read_byte(adr);
-}
-
-uint8_t m6502_device::mi_default_nd::read_arg(uint16_t adr)
-{
-	return program->read_byte(adr);
-}
 
 m6502_mcu_device::m6502_mcu_device(const machine_config &mconfig, device_type type, const char *tag, device_t *owner, uint32_t clock) :
 	m6502_device(mconfig, type, tag, owner, clock)

--- a/src/devices/cpu/m6502/m6502.h
+++ b/src/devices/cpu/m6502/m6502.h
@@ -23,7 +23,6 @@ public:
 	m6502_device(const machine_config &mconfig, const char *tag, device_t *owner, uint32_t clock);
 
 	bool get_sync() const { return sync; }
-	void disable_cache() { cache_disabled = true; }
 
 	auto sync_cb() { return sync_w.bind(); }
 
@@ -46,20 +45,13 @@ protected:
 		virtual void write_9(uint16_t adr, uint8_t val);
 	};
 
-	class mi_default_normal : public memory_interface {
+	class mi_default : public memory_interface {
 	public:
-		virtual ~mi_default_normal() {}
+		virtual ~mi_default() {}
 		virtual uint8_t read(uint16_t adr) override;
 		virtual uint8_t read_sync(uint16_t adr) override;
 		virtual uint8_t read_arg(uint16_t adr) override;
 		virtual void write(uint16_t adr, uint8_t val) override;
-	};
-
-	class mi_default_nd : public mi_default_normal {
-	public:
-		virtual ~mi_default_nd() {}
-		virtual uint8_t read_sync(uint16_t adr) override;
-		virtual uint8_t read_arg(uint16_t adr) override;
 	};
 
 	enum {
@@ -122,7 +114,7 @@ protected:
 	int inst_state, inst_substate;
 	int icount, bcount, count_before_instruction_step;
 	bool nmi_state, irq_state, apu_irq_state, v_state;
-	bool irq_taken, sync, cache_disabled, inhibit_interrupts;
+	bool irq_taken, sync, inhibit_interrupts;
 
 	uint8_t read(uint16_t adr) { return mintf->read(adr); }
 	uint8_t read_9(uint16_t adr) { return mintf->read_9(adr); }

--- a/src/devices/cpu/m6502/m6504.cpp
+++ b/src/devices/cpu/m6502/m6504.cpp
@@ -22,40 +22,27 @@ m6504_device::m6504_device(const machine_config &mconfig, const char *tag, devic
 
 void m6504_device::device_start()
 {
-	if(cache_disabled)
-		mintf = std::make_unique<mi_6504_nd>();
-	else
-		mintf = std::make_unique<mi_6504_normal>();
+	mintf = std::make_unique<mi_6504>();
 
 	init();
 }
 
-uint8_t m6504_device::mi_6504_normal::read(uint16_t adr)
+uint8_t m6504_device::mi_6504::read(uint16_t adr)
 {
 	return program->read_byte(adr & 0x1fff);
 }
 
-uint8_t m6504_device::mi_6504_normal::read_sync(uint16_t adr)
+uint8_t m6504_device::mi_6504::read_sync(uint16_t adr)
 {
 	return scache->read_byte(adr & 0x1fff);
 }
 
-uint8_t m6504_device::mi_6504_normal::read_arg(uint16_t adr)
+uint8_t m6504_device::mi_6504::read_arg(uint16_t adr)
 {
 	return cache->read_byte(adr & 0x1fff);
 }
 
-void m6504_device::mi_6504_normal::write(uint16_t adr, uint8_t val)
+void m6504_device::mi_6504::write(uint16_t adr, uint8_t val)
 {
 	program->write_byte(adr & 0x1fff, val);
-}
-
-uint8_t m6504_device::mi_6504_nd::read_sync(uint16_t adr)
-{
-	return sprogram->read_byte(adr & 0x1fff);
-}
-
-uint8_t m6504_device::mi_6504_nd::read_arg(uint16_t adr)
-{
-	return program->read_byte(adr & 0x1fff);
 }

--- a/src/devices/cpu/m6502/m6504.h
+++ b/src/devices/cpu/m6502/m6504.h
@@ -18,20 +18,13 @@ public:
 	m6504_device(const machine_config &mconfig, const char *tag, device_t *owner, uint32_t clock);
 
 protected:
-	class mi_6504_normal : public memory_interface {
+	class mi_6504 : public memory_interface {
 	public:
-		virtual ~mi_6504_normal() {}
+		virtual ~mi_6504() {}
 		virtual uint8_t read(uint16_t adr) override;
 		virtual uint8_t read_sync(uint16_t adr) override;
 		virtual uint8_t read_arg(uint16_t adr) override;
 		virtual void write(uint16_t adr, uint8_t val) override;
-	};
-
-	class mi_6504_nd : public mi_6504_normal {
-	public:
-		virtual ~mi_6504_nd() {}
-		virtual uint8_t read_sync(uint16_t adr) override;
-		virtual uint8_t read_arg(uint16_t adr) override;
 	};
 
 	virtual void device_start() override;

--- a/src/devices/cpu/m6502/m6507.cpp
+++ b/src/devices/cpu/m6502/m6507.cpp
@@ -22,40 +22,27 @@ m6507_device::m6507_device(const machine_config &mconfig, const char *tag, devic
 
 void m6507_device::device_start()
 {
-	if(cache_disabled)
-		mintf = std::make_unique<mi_6507_nd>();
-	else
-		mintf = std::make_unique<mi_6507_normal>();
+	mintf = std::make_unique<mi_6507>();
 
 	init();
 }
 
-uint8_t m6507_device::mi_6507_normal::read(uint16_t adr)
+uint8_t m6507_device::mi_6507::read(uint16_t adr)
 {
 	return program->read_byte(adr & 0x1fff);
 }
 
-uint8_t m6507_device::mi_6507_normal::read_sync(uint16_t adr)
+uint8_t m6507_device::mi_6507::read_sync(uint16_t adr)
 {
 	return scache->read_byte(adr & 0x1fff);
 }
 
-uint8_t m6507_device::mi_6507_normal::read_arg(uint16_t adr)
+uint8_t m6507_device::mi_6507::read_arg(uint16_t adr)
 {
 	return cache->read_byte(adr & 0x1fff);
 }
 
-void m6507_device::mi_6507_normal::write(uint16_t adr, uint8_t val)
+void m6507_device::mi_6507::write(uint16_t adr, uint8_t val)
 {
 	program->write_byte(adr & 0x1fff, val);
-}
-
-uint8_t m6507_device::mi_6507_nd::read_sync(uint16_t adr)
-{
-	return sprogram->read_byte(adr & 0x1fff);
-}
-
-uint8_t m6507_device::mi_6507_nd::read_arg(uint16_t adr)
-{
-	return program->read_byte(adr & 0x1fff);
 }

--- a/src/devices/cpu/m6502/m6507.h
+++ b/src/devices/cpu/m6502/m6507.h
@@ -18,20 +18,13 @@ public:
 	m6507_device(const machine_config &mconfig, const char *tag, device_t *owner, uint32_t clock);
 
 protected:
-	class mi_6507_normal : public memory_interface {
+	class mi_6507 : public memory_interface {
 	public:
-		virtual ~mi_6507_normal() {}
+		virtual ~mi_6507() {}
 		virtual uint8_t read(uint16_t adr) override;
 		virtual uint8_t read_sync(uint16_t adr) override;
 		virtual uint8_t read_arg(uint16_t adr) override;
 		virtual void write(uint16_t adr, uint8_t val) override;
-	};
-
-	class mi_6507_nd : public mi_6507_normal {
-	public:
-		virtual ~mi_6507_nd() {}
-		virtual uint8_t read_sync(uint16_t adr) override;
-		virtual uint8_t read_arg(uint16_t adr) override;
 	};
 
 	virtual void device_start() override;

--- a/src/devices/cpu/m6502/m6509.cpp
+++ b/src/devices/cpu/m6502/m6509.cpp
@@ -25,10 +25,7 @@ m6509_device::m6509_device(const machine_config &mconfig, const char *tag, devic
 
 void m6509_device::device_start()
 {
-	if(cache_disabled)
-		mintf = std::make_unique<mi_6509_nd>(this);
-	else
-		mintf = std::make_unique<mi_6509_normal>(this);
+	mintf = std::make_unique<mi_6509>(this);
 
 	init();
 
@@ -55,12 +52,12 @@ std::unique_ptr<util::disasm_interface> m6509_device::create_disassembler()
 	return std::make_unique<m6509_disassembler>();
 }
 
-m6509_device::mi_6509_normal::mi_6509_normal(m6509_device *_base)
+m6509_device::mi_6509::mi_6509(m6509_device *_base)
 {
 	base = _base;
 }
 
-uint8_t m6509_device::mi_6509_normal::read(uint16_t adr)
+uint8_t m6509_device::mi_6509::read(uint16_t adr)
 {
 	uint8_t res = program->read_byte(base->adr_in_bank_i(adr));
 	if(adr == 0x0000)
@@ -70,7 +67,7 @@ uint8_t m6509_device::mi_6509_normal::read(uint16_t adr)
 	return res;
 }
 
-uint8_t m6509_device::mi_6509_normal::read_sync(uint16_t adr)
+uint8_t m6509_device::mi_6509::read_sync(uint16_t adr)
 {
 	uint8_t res = scache->read_byte(base->adr_in_bank_i(adr));
 	if(adr == 0x0000)
@@ -80,7 +77,7 @@ uint8_t m6509_device::mi_6509_normal::read_sync(uint16_t adr)
 	return res;
 }
 
-uint8_t m6509_device::mi_6509_normal::read_arg(uint16_t adr)
+uint8_t m6509_device::mi_6509::read_arg(uint16_t adr)
 {
 	uint8_t res = cache->read_byte(base->adr_in_bank_i(adr));
 	if(adr == 0x0000)
@@ -90,7 +87,7 @@ uint8_t m6509_device::mi_6509_normal::read_arg(uint16_t adr)
 	return res;
 }
 
-uint8_t m6509_device::mi_6509_normal::read_9(uint16_t adr)
+uint8_t m6509_device::mi_6509::read_9(uint16_t adr)
 {
 	uint8_t res = program->read_byte(base->adr_in_bank_y(adr));
 	if(adr == 0x0000)
@@ -100,7 +97,7 @@ uint8_t m6509_device::mi_6509_normal::read_9(uint16_t adr)
 	return res;
 }
 
-void m6509_device::mi_6509_normal::write(uint16_t adr, uint8_t val)
+void m6509_device::mi_6509::write(uint16_t adr, uint8_t val)
 {
 	program->write_byte(base->adr_in_bank_i(adr), val);
 	if(adr == 0x0000)
@@ -109,37 +106,13 @@ void m6509_device::mi_6509_normal::write(uint16_t adr, uint8_t val)
 		base->bank_y_w(val);
 }
 
-void m6509_device::mi_6509_normal::write_9(uint16_t adr, uint8_t val)
+void m6509_device::mi_6509::write_9(uint16_t adr, uint8_t val)
 {
 	program->write_byte(base->adr_in_bank_y(adr), val);
 	if(adr == 0x0000)
 		base->bank_i_w(val);
 	else if(adr == 0x0001)
 		base->bank_y_w(val);
-}
-
-m6509_device::mi_6509_nd::mi_6509_nd(m6509_device *_base) : mi_6509_normal(_base)
-{
-}
-
-uint8_t m6509_device::mi_6509_nd::read_sync(uint16_t adr)
-{
-	uint8_t res = sprogram->read_byte(base->adr_in_bank_i(adr));
-	if(adr == 0x0000)
-		res = base->bank_i_r();
-	else if(adr == 0x0001)
-		res = base->bank_y_r();
-	return res;
-}
-
-uint8_t m6509_device::mi_6509_nd::read_arg(uint16_t adr)
-{
-	uint8_t res = program->read_byte(base->adr_in_bank_i(adr));
-	if(adr == 0x0000)
-		res = base->bank_i_r();
-	else if(adr == 0x0001)
-		res = base->bank_y_r();
-	return res;
 }
 
 #include "cpu/m6502/m6509.hxx"

--- a/src/devices/cpu/m6502/m6509.h
+++ b/src/devices/cpu/m6502/m6509.h
@@ -22,26 +22,18 @@ public:
 	virtual void do_exec_partial() override;
 
 protected:
-	class mi_6509_normal : public memory_interface {
+	class mi_6509 : public memory_interface {
 	public:
 		m6509_device *base;
 
-		mi_6509_normal(m6509_device *base);
-		virtual ~mi_6509_normal() {}
+		mi_6509(m6509_device *base);
+		virtual ~mi_6509() {}
 		virtual uint8_t read(uint16_t adr) override;
 		virtual uint8_t read_9(uint16_t adr) override;
 		virtual uint8_t read_sync(uint16_t adr) override;
 		virtual uint8_t read_arg(uint16_t adr) override;
 		virtual void write(uint16_t adr, uint8_t val) override;
 		virtual void write_9(uint16_t adr, uint8_t val) override;
-	};
-
-	class mi_6509_nd : public mi_6509_normal {
-	public:
-		mi_6509_nd(m6509_device *base);
-		virtual ~mi_6509_nd() {}
-		virtual uint8_t read_sync(uint16_t adr) override;
-		virtual uint8_t read_arg(uint16_t adr) override;
 	};
 
 	virtual void device_start() override;

--- a/src/devices/cpu/m6502/m6510.cpp
+++ b/src/devices/cpu/m6502/m6510.cpp
@@ -57,10 +57,7 @@ void m6510_device::init_port()
 
 void m6510_device::device_start()
 {
-	if(cache_disabled)
-		mintf = std::make_unique<mi_6510_nd>(this);
-	else
-		mintf = std::make_unique<mi_6510_normal>(this);
+	mintf = std::make_unique<mi_6510>(this);
 
 	init();
 	init_port();
@@ -109,12 +106,12 @@ void m6510_device::port_w(uint8_t data)
 }
 
 
-m6510_device::mi_6510_normal::mi_6510_normal(m6510_device *_base)
+m6510_device::mi_6510::mi_6510(m6510_device *_base)
 {
 	base = _base;
 }
 
-uint8_t m6510_device::mi_6510_normal::read(uint16_t adr)
+uint8_t m6510_device::mi_6510::read(uint16_t adr)
 {
 	uint8_t res = program->read_byte(adr);
 	if(adr == 0x0000)
@@ -124,7 +121,7 @@ uint8_t m6510_device::mi_6510_normal::read(uint16_t adr)
 	return res;
 }
 
-uint8_t m6510_device::mi_6510_normal::read_sync(uint16_t adr)
+uint8_t m6510_device::mi_6510::read_sync(uint16_t adr)
 {
 	uint8_t res = scache->read_byte(adr);
 	if(adr == 0x0000)
@@ -134,7 +131,7 @@ uint8_t m6510_device::mi_6510_normal::read_sync(uint16_t adr)
 	return res;
 }
 
-uint8_t m6510_device::mi_6510_normal::read_arg(uint16_t adr)
+uint8_t m6510_device::mi_6510::read_arg(uint16_t adr)
 {
 	uint8_t res = cache->read_byte(adr);
 	if(adr == 0x0000)
@@ -144,37 +141,13 @@ uint8_t m6510_device::mi_6510_normal::read_arg(uint16_t adr)
 	return res;
 }
 
-void m6510_device::mi_6510_normal::write(uint16_t adr, uint8_t val)
+void m6510_device::mi_6510::write(uint16_t adr, uint8_t val)
 {
 	program->write_byte(adr, val);
 	if(adr == 0x0000)
 		base->dir_w(val);
 	else if(adr == 0x0001)
 		base->port_w(val);
-}
-
-m6510_device::mi_6510_nd::mi_6510_nd(m6510_device *_base) : mi_6510_normal(_base)
-{
-}
-
-uint8_t m6510_device::mi_6510_nd::read_sync(uint16_t adr)
-{
-	uint8_t res = sprogram->read_byte(adr);
-	if(adr == 0x0000)
-		res = base->dir_r();
-	else if(adr == 0x0001)
-		res = base->port_r();
-	return res;
-}
-
-uint8_t m6510_device::mi_6510_nd::read_arg(uint16_t adr)
-{
-	uint8_t res = program->read_byte(adr);
-	if(adr == 0x0000)
-		res = base->dir_r();
-	else if(adr == 0x0001)
-		res = base->port_r();
-	return res;
 }
 
 
@@ -185,10 +158,7 @@ m6508_device::m6508_device(const machine_config &mconfig, const char *tag, devic
 
 void m6508_device::device_start()
 {
-	if(cache_disabled)
-		mintf = std::make_unique<mi_6508_nd>(this);
-	else
-		mintf = std::make_unique<mi_6508_normal>(this);
+	mintf = std::make_unique<mi_6508>(this);
 
 	init();
 	init_port();
@@ -198,12 +168,12 @@ void m6508_device::device_start()
 }
 
 
-m6508_device::mi_6508_normal::mi_6508_normal(m6508_device *_base)
+m6508_device::mi_6508::mi_6508(m6508_device *_base)
 {
 	base = _base;
 }
 
-uint8_t m6508_device::mi_6508_normal::read(uint16_t adr)
+uint8_t m6508_device::mi_6508::read(uint16_t adr)
 {
 	uint8_t res = program->read_byte(adr);
 	if(adr == 0x0000)
@@ -215,7 +185,7 @@ uint8_t m6508_device::mi_6508_normal::read(uint16_t adr)
 	return res;
 }
 
-uint8_t m6508_device::mi_6508_normal::read_sync(uint16_t adr)
+uint8_t m6508_device::mi_6508::read_sync(uint16_t adr)
 {
 	uint8_t res = scache->read_byte(adr);
 	if(adr == 0x0000)
@@ -227,7 +197,7 @@ uint8_t m6508_device::mi_6508_normal::read_sync(uint16_t adr)
 	return res;
 }
 
-uint8_t m6508_device::mi_6508_normal::read_arg(uint16_t adr)
+uint8_t m6508_device::mi_6508::read_arg(uint16_t adr)
 {
 	uint8_t res = cache->read_byte(adr);
 	if(adr == 0x0000)
@@ -239,7 +209,7 @@ uint8_t m6508_device::mi_6508_normal::read_arg(uint16_t adr)
 	return res;
 }
 
-void m6508_device::mi_6508_normal::write(uint16_t adr, uint8_t val)
+void m6508_device::mi_6508::write(uint16_t adr, uint8_t val)
 {
 	program->write_byte(adr, val);
 	if(adr == 0x0000)
@@ -248,34 +218,6 @@ void m6508_device::mi_6508_normal::write(uint16_t adr, uint8_t val)
 		base->port_w(val);
 	else if(adr < 0x0200)
 		base->ram_page[adr & 0x00ff] = val;
-}
-
-m6508_device::mi_6508_nd::mi_6508_nd(m6508_device *_base) : mi_6508_normal(_base)
-{
-}
-
-uint8_t m6508_device::mi_6508_nd::read_sync(uint16_t adr)
-{
-	uint8_t res = sprogram->read_byte(adr);
-	if(adr == 0x0000)
-		res = base->dir_r();
-	else if(adr == 0x0001)
-		res = base->port_r();
-	else if(adr < 0x0200)
-		res = base->ram_page[adr & 0x00ff];
-	return res;
-}
-
-uint8_t m6508_device::mi_6508_nd::read_arg(uint16_t adr)
-{
-	uint8_t res = program->read_byte(adr);
-	if(adr == 0x0000)
-		res = base->dir_r();
-	else if(adr == 0x0001)
-		res = base->port_r();
-	else if(adr < 0x0200)
-		res = base->ram_page[adr & 0x00ff];
-	return res;
 }
 
 

--- a/src/devices/cpu/m6502/m6510.h
+++ b/src/devices/cpu/m6502/m6510.h
@@ -31,24 +31,16 @@ public:
 protected:
 	m6510_device(const machine_config &mconfig, device_type type, const char *tag, device_t *owner, uint32_t clock);
 
-	class mi_6510_normal : public memory_interface {
+	class mi_6510 : public memory_interface {
 	public:
 		m6510_device *base;
 
-		mi_6510_normal(m6510_device *base);
-		virtual ~mi_6510_normal() {}
+		mi_6510(m6510_device *base);
+		virtual ~mi_6510() {}
 		virtual uint8_t read(uint16_t adr) override;
 		virtual uint8_t read_sync(uint16_t adr) override;
 		virtual uint8_t read_arg(uint16_t adr) override;
 		virtual void write(uint16_t adr, uint8_t val) override;
-	};
-
-	class mi_6510_nd : public mi_6510_normal {
-	public:
-		mi_6510_nd(m6510_device *base);
-		virtual ~mi_6510_nd() {}
-		virtual uint8_t read_sync(uint16_t adr) override;
-		virtual uint8_t read_arg(uint16_t adr) override;
 	};
 
 	devcb_read8  read_port;
@@ -88,24 +80,16 @@ public:
 protected:
 	virtual void device_start() override;
 
-	class mi_6508_normal : public memory_interface {
+	class mi_6508 : public memory_interface {
 	public:
 		m6508_device *base;
 
-		mi_6508_normal(m6508_device *base);
-		virtual ~mi_6508_normal() {}
+		mi_6508(m6508_device *base);
+		virtual ~mi_6508() {}
 		virtual uint8_t read(uint16_t adr) override;
 		virtual uint8_t read_sync(uint16_t adr) override;
 		virtual uint8_t read_arg(uint16_t adr) override;
 		virtual void write(uint16_t adr, uint8_t val) override;
-	};
-
-	class mi_6508_nd : public mi_6508_normal {
-	public:
-		mi_6508_nd(m6508_device *base);
-		virtual ~mi_6508_nd() {}
-		virtual uint8_t read_sync(uint16_t adr) override;
-		virtual uint8_t read_arg(uint16_t adr) override;
 	};
 
 	std::unique_ptr<uint8_t[]> ram_page;

--- a/src/devices/cpu/m6502/m65ce02.cpp
+++ b/src/devices/cpu/m6502/m65ce02.cpp
@@ -44,10 +44,7 @@ void m65ce02_device::init()
 
 void m65ce02_device::device_start()
 {
-	if(cache_disabled)
-		mintf = std::make_unique<mi_default_nd>();
-	else
-		mintf = std::make_unique<mi_default_normal>();
+	mintf = std::make_unique<mi_default>();
 
 	init();
 }

--- a/src/devices/cpu/m6502/xavix.cpp
+++ b/src/devices/cpu/m6502/xavix.cpp
@@ -71,10 +71,7 @@ offs_t xavix_device::pc_to_external(u16 pc)
 
 void xavix_device::device_start()
 {
-	if(cache_disabled)
-		mintf = std::make_unique<mi_xavix_nd>(this);
-	else
-		mintf = std::make_unique<mi_xavix_normal>(this);
+	mintf = std::make_unique<mi_xavix>(this);
 
 	// bind delegates
 	m_vector_callback.resolve();
@@ -104,7 +101,7 @@ void xavix_device::device_reset()
 
 
 
-xavix_device::mi_xavix_normal::mi_xavix_normal(xavix_device *_base)
+xavix_device::mi_xavix::mi_xavix(xavix_device *_base)
 {
 	base = _base;
 }
@@ -165,20 +162,20 @@ inline uint8_t xavix_device::read_full_data(uint8_t databank, uint16_t adr)
 }
 
 // data reads
-inline uint8_t xavix_device::mi_xavix_normal::read(uint16_t adr)
+inline uint8_t xavix_device::mi_xavix::read(uint16_t adr)
 {
 	uint8_t databank = base->get_databank();
 	return base->read_full_data(databank, adr);
 }
 
 // opcode reads
-uint8_t xavix_device::mi_xavix_normal::read_sync(uint16_t adr)
+uint8_t xavix_device::mi_xavix::read_sync(uint16_t adr)
 {
 	return scache->read_byte(base->adr_with_codebank(adr));
 }
 
 // oprand reads
-uint8_t xavix_device::mi_xavix_normal::read_arg(uint16_t adr)
+uint8_t xavix_device::mi_xavix::read_arg(uint16_t adr)
 {
 	return cache->read_byte(base->adr_with_codebank(adr));
 }
@@ -269,24 +266,10 @@ inline void xavix_device::write_full_data(uint8_t databank, uint16_t adr, uint8_
 	}
 }
 
-void xavix_device::mi_xavix_normal::write(uint16_t adr, uint8_t val)
+void xavix_device::mi_xavix::write(uint16_t adr, uint8_t val)
 {
 	uint8_t databank = base->get_databank();
 	base->write_full_data(databank, adr, val);
-}
-
-xavix_device::mi_xavix_nd::mi_xavix_nd(xavix_device *_base) : mi_xavix_normal(_base)
-{
-}
-
-uint8_t xavix_device::mi_xavix_nd::read_sync(uint16_t adr)
-{
-	return sprogram->read_byte(base->adr_with_codebank(adr));
-}
-
-uint8_t xavix_device::mi_xavix_nd::read_arg(uint16_t adr)
-{
-	return program->read_byte(base->adr_with_codebank(adr));
 }
 
 void xavix_device::set_codebank(uint8_t bank)

--- a/src/devices/cpu/m6502/xavix.h
+++ b/src/devices/cpu/m6502/xavix.h
@@ -147,26 +147,17 @@ public:
 	void write_full_data(uint32_t addr, uint8_t val);
 
 protected:
-	class mi_xavix_normal : public memory_interface {
+	class mi_xavix : public memory_interface {
 	public:
 		xavix_device *base;
 
-		mi_xavix_normal(xavix_device *base);
-		virtual ~mi_xavix_normal() {}
+		mi_xavix(xavix_device *base);
+		virtual ~mi_xavix() {}
 
 		virtual uint8_t read(uint16_t adr) override;
 		virtual uint8_t read_sync(uint16_t adr) override;
 		virtual uint8_t read_arg(uint16_t adr) override;
 		virtual void write(uint16_t adr, uint8_t val) override;
-	};
-
-	class mi_xavix_nd : public mi_xavix_normal {
-	public:
-		mi_xavix_nd(xavix_device *base);
-		virtual ~mi_xavix_nd() {}
-
-		virtual uint8_t read_sync(uint16_t adr) override;
-		virtual uint8_t read_arg(uint16_t adr) override;
 	};
 
 	uint8_t m_databank;

--- a/src/mame/drivers/a2600.cpp
+++ b/src/mame/drivers/a2600.cpp
@@ -509,7 +509,6 @@ void a2600_state::a2600(machine_config &config)
 {
 	/* basic machine hardware */
 	M6507(config, m_maincpu, MASTER_CLOCK_NTSC / 3);
-	m_maincpu->disable_cache();
 	m_maincpu->set_addrmap(AS_PROGRAM, &a2600_state::a2600_mem);
 
 	/* video hardware */
@@ -556,7 +555,6 @@ void a2600_state::a2600p(machine_config &config)
 	/* basic machine hardware */
 	M6507(config, m_maincpu, MASTER_CLOCK_PAL / 3);
 	m_maincpu->set_addrmap(AS_PROGRAM, &a2600_state::a2600_mem);
-	m_maincpu->disable_cache();
 
 	/* video hardware */
 	TIA_PAL_VIDEO(config, m_tia, 0, "tia");

--- a/src/mame/drivers/c128.cpp
+++ b/src/mame/drivers/c128.cpp
@@ -1634,7 +1634,6 @@ void c128_state::ntsc(machine_config &config)
 	m_maincpu->set_addrmap(AS_IO, &c128_state::z80_io);
 
 	M8502(config, m_subcpu, XTAL(14'318'181)*2/3.5/8);
-	m_subcpu->disable_cache(); // address decoding is 100% dynamic, no RAM/ROM banks
 	m_subcpu->read_callback().set(FUNC(c128_state::cpu_r));
 	m_subcpu->write_callback().set(FUNC(c128_state::cpu_w));
 	m_subcpu->set_pulls(0x07, 0x20);
@@ -1820,7 +1819,6 @@ void c128_state::pal(machine_config &config)
 	m_maincpu->set_addrmap(AS_IO, &c128_state::z80_io);
 
 	M8502(config, m_subcpu, XTAL(17'734'472)*2/4.5/8);
-	m_subcpu->disable_cache(); // address decoding is 100% dynamic, no RAM/ROM banks
 	m_subcpu->read_callback().set(FUNC(c128_state::cpu_r));
 	m_subcpu->write_callback().set(FUNC(c128_state::cpu_w));
 	m_subcpu->set_pulls(0x07, 0x20);

--- a/src/mame/drivers/c64.cpp
+++ b/src/mame/drivers/c64.cpp
@@ -1441,7 +1441,6 @@ void c64_state::ntsc(machine_config &config)
 	// basic hardware
 	M6510(config, m_maincpu, XTAL(14'318'181)/14);
 	m_maincpu->set_addrmap(AS_PROGRAM, &c64_state::c64_mem);
-	m_maincpu->disable_cache(); // address decoding is 100% dynamic, no RAM/ROM banks
 	m_maincpu->read_callback().set(FUNC(c64_state::cpu_r));
 	m_maincpu->write_callback().set(FUNC(c64_state::cpu_w));
 	m_maincpu->set_pulls(0x17, 0xc8);
@@ -1613,7 +1612,6 @@ void c64_state::pal(machine_config &config)
 	// basic hardware
 	M6510(config, m_maincpu, XTAL(17'734'472)/18);
 	m_maincpu->set_addrmap(AS_PROGRAM, &c64_state::c64_mem);
-	m_maincpu->disable_cache(); // address decoding is 100% dynamic, no RAM/ROM banks
 	m_maincpu->read_callback().set(FUNC(c64_state::cpu_r));
 	m_maincpu->write_callback().set(FUNC(c64_state::cpu_w));
 	m_maincpu->set_pulls(0x17, 0xc8);
@@ -1761,7 +1759,6 @@ void c64gs_state::pal_gs(machine_config &config)
 	// basic hardware
 	M6510(config, m_maincpu, XTAL(17'734'472)/18);
 	m_maincpu->set_addrmap(AS_PROGRAM, &c64gs_state::c64_mem);
-	m_maincpu->disable_cache(); // address decoding is 100% dynamic, no RAM/ROM banks
 	m_maincpu->read_callback().set(FUNC(c64gs_state::cpu_r));
 	m_maincpu->write_callback().set(FUNC(c64gs_state::cpu_w));
 	m_maincpu->set_pulls(0x07, 0xc0);

--- a/src/mame/drivers/cbm2.cpp
+++ b/src/mame/drivers/cbm2.cpp
@@ -2248,7 +2248,6 @@ void p500_state::p500_ntsc(machine_config &config)
 
 	// basic hardware
 	M6509(config, m_maincpu, XTAL(14'318'181)/14);
-	m_maincpu->disable_cache(); // address decoding is 100% dynamic, no RAM/ROM banks
 	m_maincpu->set_addrmap(AS_PROGRAM, &p500_state::p500_mem);
 	config.set_perfect_quantum(m_maincpu);
 
@@ -2382,7 +2381,6 @@ void p500_state::p500_pal(machine_config &config)
 
 	// basic hardware
 	M6509(config, m_maincpu, XTAL(17'734'472)/18);
-	m_maincpu->disable_cache(); // address decoding is 100% dynamic, no RAM/ROM banks
 	m_maincpu->set_addrmap(AS_PROGRAM, &p500_state::p500_mem);
 	config.set_perfect_quantum(m_maincpu);
 
@@ -2513,7 +2511,6 @@ void cbm2_state::cbm2lp_ntsc(machine_config &config)
 
 	// basic hardware
 	M6509(config, m_maincpu, XTAL(18'000'000)/9);
-	m_maincpu->disable_cache(); // address decoding is 100% dynamic, no RAM/ROM banks
 	m_maincpu->set_addrmap(AS_PROGRAM, &cbm2_state::cbm2_mem);
 	config.set_perfect_quantum(m_maincpu);
 

--- a/src/mame/drivers/pet.cpp
+++ b/src/mame/drivers/pet.cpp
@@ -1733,7 +1733,6 @@ void pet_state::pet(machine_config &config)
 	// basic machine hardware
 	M6502(config, m_maincpu, XTAL(8'000'000)/8);
 	m_maincpu->set_addrmap(AS_PROGRAM, &pet_state::pet2001_mem);
-	m_maincpu->disable_cache(); // address decoding is 100% dynamic, no RAM/ROM banks
 
 	// video hardware
 	SCREEN(config, m_screen, SCREEN_TYPE_RASTER);
@@ -2003,7 +2002,6 @@ void pet80_state::pet80(machine_config &config)
 	// basic machine hardware
 	M6502(config, m_maincpu, XTAL(16'000'000)/16);
 	m_maincpu->set_addrmap(AS_PROGRAM, &pet_state::pet2001_mem);
-	m_maincpu->disable_cache(); // address decoding is 100% dynamic, no RAM/ROM banks
 
 	// video hardware
 	screen_device &screen(SCREEN(config, SCREEN_TAG, SCREEN_TYPE_RASTER));

--- a/src/mame/drivers/plus4.cpp
+++ b/src/mame/drivers/plus4.cpp
@@ -844,7 +844,6 @@ void plus4_state::plus4(machine_config &config)
 	// basic machine hardware
 	M7501(config, m_maincpu, 0);
 	m_maincpu->set_addrmap(AS_PROGRAM, &plus4_state::plus4_mem);
-	m_maincpu->disable_cache(); // address decoding is 100% dynamic, no RAM/ROM banks
 	m_maincpu->read_callback().set(FUNC(plus4_state::cpu_r));
 	m_maincpu->write_callback().set(FUNC(plus4_state::cpu_w));
 	m_maincpu->set_pulls(0x00, 0xc0);

--- a/src/mame/drivers/tvboy.cpp
+++ b/src/mame/drivers/tvboy.cpp
@@ -81,7 +81,6 @@ void tvboy_state::tvboyii(machine_config &config)
 	/* basic machine hardware */
 	M6507(config, m_maincpu, MASTER_CLOCK_PAL / 3);
 	m_maincpu->set_addrmap(AS_PROGRAM, &tvboy_state::tvboy_mem);
-	m_maincpu->disable_cache();
 
 	/* video hardware */
 	TIA_PAL_VIDEO(config, m_tia, 0, "tia");

--- a/src/mame/drivers/vic10.cpp
+++ b/src/mame/drivers/vic10.cpp
@@ -644,7 +644,6 @@ void vic10_state::vic10(machine_config &config)
 	// basic hardware
 	M6510(config, m_maincpu, XTAL(8'000'000)/8);
 	m_maincpu->set_addrmap(AS_PROGRAM, &vic10_state::vic10_mem);
-	m_maincpu->disable_cache(); // address decoding is 100% dynamic, no RAM/ROM banks
 	m_maincpu->read_callback().set(FUNC(vic10_state::cpu_r));
 	m_maincpu->write_callback().set(FUNC(vic10_state::cpu_w));
 	m_maincpu->set_pulls(0x10, 0x20);

--- a/src/mame/drivers/vic20.cpp
+++ b/src/mame/drivers/vic20.cpp
@@ -860,7 +860,6 @@ void vic20_state::add_clocked_devices(machine_config &config, uint32_t clock)
 	// basic machine hardware
 	M6502(config, m_maincpu, clock);
 	m_maincpu->set_addrmap(AS_PROGRAM, &vic20_state::vic20_mem);
-	m_maincpu->disable_cache(); // address decoding is 100% dynamic, no RAM/ROM banks
 
 	VIA6522(config, m_via1, clock);
 	m_via1->readpa_handler().set(FUNC(vic20_state::via1_pa_r));

--- a/src/mame/drivers/xavix.cpp
+++ b/src/mame/drivers/xavix.cpp
@@ -1234,7 +1234,6 @@ void xavix_state::xavix(machine_config &config)
 	m_maincpu->set_addrmap(AS_PROGRAM, &xavix_state::xavix_map);
 	m_maincpu->set_addrmap(5, &xavix_state::xavix_lowbus_map);
 	m_maincpu->set_addrmap(6, &xavix_state::xavix_extbus_map);
-	m_maincpu->disable_cache();
 	m_maincpu->set_vblank_int("screen", FUNC(xavix_state::interrupt));
 	m_maincpu->set_vector_callback(FUNC(xavix_state::get_vectors));
 
@@ -1364,7 +1363,6 @@ void xavix_state::xavix2000(machine_config &config)
 	m_maincpu->set_addrmap(AS_PROGRAM, &xavix_state::xavix_map);
 	m_maincpu->set_addrmap(5, &xavix_state::xavix_lowbus_map);
 	m_maincpu->set_addrmap(6, &xavix_state::xavix_extbus_map);
-	m_maincpu->disable_cache();
 	m_maincpu->set_vblank_int("screen", FUNC(xavix_state::interrupt));
 	m_maincpu->set_vector_callback(FUNC(xavix_state::get_vectors));
 
@@ -1379,7 +1377,6 @@ void xavix_state::xavix2002(machine_config &config)
 	m_maincpu->set_addrmap(AS_PROGRAM, &xavix_state::xavix_map);
 	m_maincpu->set_addrmap(5, &xavix_state::superxavix_lowbus_map); // has extra video, io etc.
 	m_maincpu->set_addrmap(6, &xavix_state::xavix_extbus_map);
-	m_maincpu->disable_cache();
 	m_maincpu->set_vblank_int("screen", FUNC(xavix_state::interrupt));
 	m_maincpu->set_vector_callback(FUNC(xavix_state::get_vectors));
 

--- a/src/mame/machine/deco222.h
+++ b/src/mame/machine/deco222.h
@@ -13,7 +13,7 @@ public:
 	deco_222_device(const machine_config &mconfig, const char *tag, device_t *owner, uint32_t clock);
 
 protected:
-	class mi_decrypt : public mi_default_normal {
+	class mi_decrypt : public mi_default {
 	public:
 		bool had_written;
 
@@ -41,7 +41,7 @@ public:
 	deco_c10707_device(const machine_config &mconfig, const char *tag, device_t *owner, uint32_t clock);
 
 protected:
-	class mi_decrypt : public mi_default_normal {
+	class mi_decrypt : public mi_default {
 	public:
 		bool had_written;
 

--- a/src/mame/machine/decocpu6.h
+++ b/src/mame/machine/decocpu6.h
@@ -13,7 +13,7 @@ public:
 	deco_cpu6_device(const machine_config &mconfig, const char *tag, device_t *owner, uint32_t clock);
 
 protected:
-	class mi_decrypt : public mi_default_normal {
+	class mi_decrypt : public mi_default {
 	public:
 		virtual ~mi_decrypt() {}
 		virtual uint8_t read_sync(uint16_t adr) override;

--- a/src/mame/machine/decocpu7.h
+++ b/src/mame/machine/decocpu7.h
@@ -13,7 +13,7 @@ public:
 	deco_cpu7_device(const machine_config &mconfig, const char *tag, device_t *owner, uint32_t clock);
 
 protected:
-	class mi_decrypt : public mi_default_normal {
+	class mi_decrypt : public mi_default {
 	public:
 		bool had_written;
 

--- a/src/mame/machine/m6502_vtscr.h
+++ b/src/mame/machine/m6502_vtscr.h
@@ -24,7 +24,7 @@ public:
 	void set_scramble(bool scr);
 
 protected:
-	class mi_decrypt : public mi_default_normal {
+	class mi_decrypt : public mi_default {
 	public:
 
 		bool m_scramble_en = false;


### PR DESCRIPTION
Now that `direct_read_data` has been replaced with `memory_access_cache`, which is better equipped to deal with dynamic banking, there should be all the more reason to put an end to this pernicious antipattern.