### PR TITLE
Fix invalid std::vector<> lookup in aviio.cpp

### DIFF
--- a/src/lib/util/aviio.cpp
+++ b/src/lib/util/aviio.cpp
@@ -3550,7 +3550,8 @@ avi_file::error avi_file_impl::soundbuf_flush(bool only_flush_full)
 	if (processedsamples > 0)
 	{
 		/* first account for the samples we processed */
-		std::memmove(&m_soundbuf[0], &m_soundbuf[processedsamples * stream->channels()], (m_soundbuf_samples - processedsamples) * bytes_per_sample);
+		if (m_soundbuf_samples > processedsamples)
+			std::memmove(&m_soundbuf[0], &m_soundbuf[processedsamples * stream->channels()], (m_soundbuf_samples - processedsamples) * bytes_per_sample);
 		for (int channel = 0; channel < stream->channels(); channel++)
 			m_soundbuf_chansamples[channel] -= processedsamples;
 	}


### PR DESCRIPTION
This fixes a case where:
* m_soundbuf_samples == processedsamples
* processedsamples > 0
* processedsamples * stream->channels() == m_soundbuf.size()

In this scenario, the std::memmove() would do nothing (moving zero bytes), but the operator[] on the second parameter to std::memmove() overflows the array.  This can be benign in optimized builds (because the third parameter to std::memmove() is 0), but on debugging builds this can cause an assert.