### PR TITLE
Update Apple softlists to 11/9/2019

### DIFF
--- a/hash/apple2_flop_misc.xml
+++ b/hash/apple2_flop_misc.xml
@@ -774,6 +774,43 @@
 		<publisher>4AM</publisher>
 		<info name="usage" value="Defective disk image format, but is worked around by MAME's detection." />
 		<info name="release" value="2019-03-11"/>
+		<!--
+		* Initial release supports these games:
+		Beer Run (Sirius)
+		Bug Attack (Cavalier)
+		Choplifter (Broderbund) (*)
+		David's Midnight Magic (Broderbund) (*)
+		Dueling Digits (Broderbund)
+		Eggs-It (Gebelli)
+		Frogger (On-Line Systems) (*)
+		Gamma Goblins (Sirius)
+		Genetic Drift (Broderbund)
+		High Orbit (Gebelli)
+		Horizon V (Gebelli)
+		Jawbreaker ][ (On-Line Systems)
+		Juggler (IDSI)
+		Labyrinth (Broderbund)
+		Lazer Silk (Gebelli)
+		Lunar Leepers (On-Line Systems)
+		Neptune (Gebelli)
+		Orbitron (Sirius)
+		Pest Patrol (On-Line Systems)
+		Phaser Fire (Gebelli)
+		Quadrant 6112 (Sensible Software)
+		Red Alert (Broderbund)
+		Russki Duck (Gebelli)
+		Seafox (Broderbund)
+		Serpentine (Broderbund) (*)
+		Sky Blazer (Broderbund)
+		Space Eggs (Sirius)
+		Space Quarks (Broderbund)
+		Star Blazer (Broderbund)
+		Star Thief (Cavalier)
+		Trick Shot (IDSI)
+		Zenith (Gebelli)
+		(*) later re-released with different copy protection.
+		Only the first release requires Anti-M.
+		-->
 
 		<part name="flop1" interface="floppy_5_25">
 			<dataarea name="flop" size="143360">
@@ -788,6 +825,20 @@
 		<publisher>4AM</publisher>
 		<info name="usage" value="Defective disk image format, but is worked around by MAME's detection." />
 		<info name="release" value="2019-03-16"/>
+		<!-- 
+		* Support booting 13-sector disks
+		* Support booting disks on Apple //c and IIgs which would otherwise
+		time out looking for a boot sector (SpiraDisc, some early EA games)
+		* Bypass a peripheral scan in some games that would hang on some
+		peripherals	and crash others and require a hardware power cycle in
+		order to reboot	properly (SpiraDisc)
+		* Support multiple versions of "David's Midnight Magic"
+		* Remove "unsupported game" error, always continue booting
+		* Bypass prompt if launched from hard drive (press the open- or
+		closed-apple key on startup to show the prompt)
+		* Minimum requirements lowered to 48K Apple ][+ (still useful for
+		booting 13-sector disks)
+		-->
 
 		<part name="flop1" interface="floppy_5_25">
 			<dataarea name="flop" size="143360">
@@ -802,6 +853,11 @@
 		<publisher>4AM</publisher>
 		<info name="usage" value="Defective disk image format can't be properly detected in MAME due to non-ProDOS bootloader." />
 		<info name="release" value="2019-03-24"/>
+		<!--
+		* Support booting ProDOS on clones
+		* Additional patches for "Star Thief"
+		* Launch Anti-M program faster
+		-->
 
 		<part name="flop1" interface="floppy_5_25">
 			<dataarea name="flop" size="143360">
@@ -815,6 +871,10 @@
 		<year>2019</year>
 		<publisher>4AM</publisher>
 		<info name="release" value="2019-04-12"/>
+		<!--
+		* Support booting from drive 2
+		* Fix booting on MAME (See version 1.2 usage tag for details)
+		-->
 
 		<part name="flop1" interface="floppy_5_25">
 			<dataarea name="flop" size="143360">
@@ -828,6 +888,12 @@
 		<year>2019</year>
 		<publisher>4AM</publisher>
 		<info name="release" value="2019-05-24"/>
+		<!--
+		* Support "Computer Foosball"
+		* Fix a crash when booting early Spinnaker Software disks
+		(e.g. "Alphabet Zoo," "In Search of The Most Amazing Thing")
+		* Fix booting ProDOS disks from drive 2
+		-->
 
 		<part name="flop1" interface="floppy_5_25">
 			<dataarea name="flop" size="143360">
@@ -841,10 +907,30 @@
 		<year>2019</year>
 		<publisher>4AM</publisher>
 		<info name="release" value="2019-05-24"/>
+		<!--
+		* Support "Lady Tut"
+		-->
 
 		<part name="flop1" interface="floppy_5_25">
 			<dataarea name="flop" size="143360">
 				<rom name="anti-m-v1.5-2019-06-11.dsk" size="143360" crc="bacef478" sha1="826df7cb304ce5286cd1c2805fac888356898185" />
+			</dataarea>
+		</part>
+	</software>
+
+	<software name="antim16">
+		<description>Anti-M (version 1.6)</description>
+		<year>2019</year>
+		<publisher>4AM</publisher>
+		<info name="release" value="2019-11-09"/>
+		<!--
+		* Support Personal Software 13-sector disks 
+		("MicroChess 2.0," "Checker King," "Gammon Gambler")
+		-->
+
+		<part name="flop0" interface="floppy_5_25">
+			<dataarea name="flop" size="143360">
+				<rom name="anti-m-v1.6-2019-11-09.dsk" size="143360" crc="3f604ff3" sha1="6c556f9ade3973069570be1f76560d4730e083b8" />
 			</dataarea>
 		</part>
 	</software>

--- a/hash/apple2_flop_orig.xml
+++ b/hash/apple2_flop_orig.xml
@@ -8514,4 +8514,80 @@
 		</part>
 	</software>
 
+	<software name="wrdzappr">
+		<description>Word Zapper</description>
+		<year>1990</year>
+		<publisher>Micrograms Publishing</publisher>
+		<info name="release" value="2019-11-03"/>
+		<sharedfeat name="compatibility" value="A2P,A2E,A2EE,A2C,A2GS" />
+		<!-- It requires a 64K Apple ][+ or later. -->
+
+		<part name="flop1" interface="floppy_5_25">
+			<feature name="part_id" value="Disk 1 - Beginning"/>
+			<dataarea name="flop" size="235499">
+				<rom name="word zapper disk 1 - beginning.woz" size="235499" crc="1c20054b" sha1="2331dee02b4bdcfc7d93310e7cb8956eafd6e714" />
+			</dataarea>
+		</part>
+		<part name="flop2" interface="floppy_5_25">
+			<feature name="part_id" value="Disk 2 - Advanced"/>
+			<dataarea name="flop" size="235498">
+				<rom name="word zapper disk 2 - advanced.woz" size="235498" crc="6faf09df" sha1="b3591e7d5fb1a2cc4f86ec89a75bbc00e1d998b5" />
+			</dataarea>
+		</part>
+	</software>
+
+	<software name="brplzoom">
+		<description>Buck Rogers: Planet of Zoom</description>
+		<year>1984</year>
+		<publisher>Sega Enterprises</publisher>
+		<info name="release" value="2019-11-04"/>
+		<sharedfeat name="compatibility" value="A2,A2P,A2E,A2EE,A2C,A2GS" />
+		<!-- It runs on any Apple II with 48K. -->
+		<!-- Some emulators may have difficulty emulating this image due to its
+		extreme copy protection methods.-->
+
+		<part name="flop1" interface="floppy_5_25">
+			<dataarea name="flop" size="194851">
+				<rom name="buck rogers - planet of zoom.woz" size="194851" crc="436cb456" sha1="a652a9191fd0c6db7e83681fa2153aa14a79e1ce" />
+			</dataarea>
+		</part>
+	</software>
+
+	<software name="pharrevg">
+		<description>Pharaoh's Revenge</description>
+		<year>1988</year>
+		<publisher></publisher>
+		<info name="release" value="2019-11-04"/>
+		<sharedfeat name="compatibility" value="A2P,A2E,A2EE,A2C,A2GS" />
+		<!-- It requires a 64K Apple ][+ or later. -->
+
+		<part name="flop1" interface="floppy_5_25">
+			<feature name="part_id" value="Side A"/>
+			<dataarea name="flop" size="242161">
+				<rom name="pharaoh's revenge side a.woz" size="242161" crc="e6bef238" sha1="2d6d09716f1fc1c24b8c6658ff813d126122a544" />
+			</dataarea>
+		</part>
+		<part name="flop2" interface="floppy_5_25">
+			<dataarea name="flop" size="242161">
+				<rom name="pharaoh's revenge side b (boot).woz" size="242161" crc="9bb62483" sha1="c45c93711ad545687dae142e7505c5bff1c001d8" />
+			</dataarea>
+		</part>
+	</software>
+
+	<software name="mchess20">
+		<description>MicroChess (Version 2.0)</description>
+		<year>1978</year>
+		<publisher>Personal Software</publisher>
+		<info name="release" value="2019-11-09"/>
+		<sharedfeat name="compatibility" value="A2,A2P,A2E,A2EE,A2C,A2GS" />
+		<!-- It requires a 13-sector drive but otherwise runs on any
+		Apple ][ with 16K.-->
+
+		<part name="flop1" interface="floppy_5_25">
+			<dataarea name="flop" size="234771">
+				<rom name="microchess 2.0.woz" size="234771" crc="ee2d1774" sha1="57564599fccacb095d08380f73659ac96d828209" />
+			</dataarea>
+		</part>
+	</software>
+
 </softwarelist>

--- a/hash/apple2_flop_orig.xml
+++ b/hash/apple2_flop_orig.xml
@@ -8259,4 +8259,259 @@
 		</part>
 	</software>
 
+	<software name="eqsf1906">
+		<description>Earthquake: San Francisco 1906</description>
+		<year>1982</year>
+		<publisher>Adventure International</publisher>
+		<info name="release" value="2019-10-25"/>
+		<sharedfeat name="compatibility" value="A2P,A2E,A2EE,A2C,A2GS" />
+		<!-- It requires a 48K Apple ][+ or later. -->
+
+		<part name="flop1" interface="floppy_5_25">
+			<feature name="part_id" value="Side A (Boot)"/>
+			<dataarea name="flop" size="228182">
+				<rom name="earthquake - san francisco 1906 side a (boot).woz" size="228182" crc="bef86d69" sha1="6a866918312becdf7a12a0dceecf4fe892015768" />
+			</dataarea>
+		</part>
+		<part name="flop2" interface="floppy_5_25">
+			<feature name="part_id" value="Side B"/>
+			<dataarea name="flop" size="234838">
+				<rom name="earthquake - san francisco 1906 side b.woz" size="234838" crc="9b235ebd" sha1="979a55d9e0353f4e19bb9c051a4718e27b35afb4" />
+			</dataarea>
+		</part>
+	</software>
+
+	<software name="ijtmepdm">
+		<description>Indiana Jones and the Temple of Doom</description>
+		<year>1989</year>
+		<publisher>Mindscape</publisher>
+		<info name="release" value="2019-10-25"/>
+		<sharedfeat name="compatibility" value="A2E,A2EE,A2C,A2GS" />
+		<!-- It requires a 128K Apple //e or later. -->
+
+		<part name="flop1" interface="floppy_5_25">
+			<feature name="part_id" value="Side A"/>
+			<dataarea name="flop" size="234774">
+				<rom name="indiana jones and the temple of doom side a.woz" size="234774" crc="b2fd5a62" sha1="825cfc98c220a58a5bcc4a9d48c584bd5c8ddb2a" />
+			</dataarea>
+		</part>
+		<part name="flop2" interface="floppy_5_25">
+			<feature name="part_id" value="Side B"/>
+			<dataarea name="flop" size="234774">
+				<rom name="indiana jones and the temple of doom side b.woz" size="234774" crc="887d8284" sha1="a8d3fd906e10e7deddf33d8ec0b5b95e3c504d84" />
+			</dataarea>
+		</part>
+	</software>
+
+	<software name="ltlcmppl">
+		<description>Little Computer People</description>
+		<year>1985</year>
+		<publisher>Activision</publisher>
+		<info name="release" value="2019-10-25"/>
+		<sharedfeat name="compatibility" value="A2,A2P,A2E,A2EE,A2C,A2GS" />
+		<!-- It runs on any Apple II with 48K. -->
+
+		<part name="flop1" interface="floppy_5_25">
+			<feature name="part_id" value="Side A"/>
+			<dataarea name="flop" size="234752">
+				<rom name="little computer people side a.woz" size="234752" crc="2d34b263" sha1="d3c86984960e66b4a1bf988047b495d766973225" />
+			</dataarea>
+		</part>
+		<part name="flop2" interface="floppy_5_25">
+			<feature name="part_id" value="Side B"/>
+			<dataarea name="flop" size="234752">
+				<rom name="little computer people side b.woz" size="234752" crc="8103193f" sha1="3e1d682b2c0b925cb1ace58c66f446cd85922d2b" />
+			</dataarea>
+		</part>
+	</software>
+
+	<software name="pndrabox">
+		<description>Pandora's Box</description>
+		<year>1982</year>
+		<publisher>Datamost</publisher>
+		<info name="release" value="2019-10-25"/>
+		<sharedfeat name="compatibility" value="A2,A2P,A2E,A2EE,A2C,A2GS" />
+		<!-- It runs on any Apple II with 48K. -->
+
+		<part name="flop1" interface="floppy_5_25">
+			<dataarea name="flop" size="195431">
+				<rom name="pandora's box.woz" size="195431" crc="0740d7e5" sha1="374b821a534a8894fd8c773a0a76bab0b379e72b" />
+			</dataarea>
+		</part>
+	</software>
+
+	<software name="vidvegas">
+		<description>Video Vegas (Version 12501)</description>
+		<year>1985</year>
+		<publisher></publisher>
+		<info name="release" value="2019-10-25"/>
+		<sharedfeat name="compatibility" value="A2,A2P,A2E,A2EE,A2C,A2GS" />
+		<!-- It runs on any Apple II with 48K. -->
+
+		<part name="flop1" interface="floppy_5_25">
+			<dataarea name="flop" size="234702">
+				<rom name="video vegas.woz" size="234702" crc="f47a8783" sha1="2b8e0f911b4a98f0b0f009e2508c4e0a348736bd" />
+			</dataarea>
+		</part>
+	</software>
+
+	<software name="phmdrock">
+		<description>Physics of Model Rocketry</description>
+		<year>1987</year>
+		<publisher>Estes Industries</publisher>
+		<info name="release" value="2019-10-25"/>
+		<sharedfeat name="compatibility" value="A2P,A2E,A2EE,A2C,A2GS" />
+		<!-- It requires a 64K Apple ][+ or later. -->
+
+		<part name="flop1" interface="floppy_5_25">
+			<feature name="part_id" value="Side A"/>
+			<dataarea name="flop" size="235471">
+				<rom name="physics of model rocketry side a.woz" size="235471" crc="e9fb8526" sha1="85c5396950d7109288346aff2157e0837b5985ce" />
+			</dataarea>
+		</part>
+		<part name="flop2" interface="floppy_5_25">
+			<feature name="part_id" value="Side B"/>
+			<dataarea name="flop" size="235471">
+				<rom name="physics of model rocketry side b.woz" size="235471" crc="4c9e5642" sha1="746ef6765c1e807d54f25a121dcf6241d213ec4e" />
+			</dataarea>
+		</part>
+	</software>
+
+	<software name="pnctbbls">
+		<description>Punctuation: Building Better Language Skills</description>
+		<year>1991</year>
+		<publisher>Micrograms Publishing</publisher>
+		<info name="release" value="2019-10-26"/>
+		<sharedfeat name="compatibility" value="A2P,A2E,A2EE,A2C,A2GS" />
+		<!-- It requires a 64K Apple ][+ or later. -->
+
+		<part name="flop1" interface="floppy_5_25">
+			<dataarea name="flop" size="235489">
+				<rom name="punctuation - building better language skills.woz" size="235489" crc="0c41a2e0" sha1="dca8d539917b8c6f17bd5e9632828fb31044be9b" />
+			</dataarea>
+		</part>
+	</software>
+
+	<software name="howwest">
+		<description>How The West Was One + Three x Four</description>
+		<year>1987</year>
+		<publisher>Sunburst Communications</publisher>
+		<info name="release" value="2019-10-26"/>
+		<sharedfeat name="compatibility" value="A2P,A2E,A2EE,A2C,A2GS" />
+		<!-- It requires a 48K Apple ][+ or later. -->
+
+		<part name="flop1" interface="floppy_5_25">
+			<dataarea name="flop" size="235513">
+				<rom name="how the west was one + three x four.woz" size="235513" crc="d9222021" sha1="101db6d0c3f8ccd627522abc353e7e79a57204db" />
+			</dataarea>
+		</part>
+	</software>
+
+	<software name="deadlr26">
+		<description>Deadline (Release 26 / 821108)</description>
+		<year>1982</year>
+		<publisher>Infocom</publisher>
+		<info name="release" value="2019-10-30"/>
+		<sharedfeat name="compatibility" value="A2,A2P,A2E,A2EE,A2C,A2GS" />
+		<!-- It runs on any Apple II with 32K. -->
+
+		<part name="flop1" interface="floppy_5_25">
+			<dataarea name="flop" size="234828">
+				<rom name="deadline r26.woz" size="234828" crc="073b5fd9" sha1="44385e7f2a1b58867255db3ce2c255bac2d9628e" />
+			</dataarea>
+		</part>
+	</software>
+
+	<software name="gulfstrk">
+		<description>Gulf Strike</description>
+		<year>1985</year>
+		<publisher>The Avalon Hill</publisher>
+		<info name="release" value="2019-10-30"/>
+		<sharedfeat name="compatibility" value="A2,A2P,A2E,A2EE,A2C,A2GS" />
+		<!-- It runs on any Apple II with 48K. -->
+
+		<part name="flop1" interface="floppy_5_25">
+			<dataarea name="flop" size="234778">
+				<rom name="gulf strike.woz" size="234778" crc="96a4634b" sha1="1c0b551b093789d67557c8bc4f23201df6108127" />
+			</dataarea>
+		</part>
+	</software>
+
+	<software name="mghtmgc2">
+		<description>Might and Magic Book Two</description>
+		<year>1988</year>
+		<publisher>New World Computing</publisher>
+		<info name="release" value="2019-10-30"/>
+		<sharedfeat name="compatibility" value="A2E,A2EE,A2C,A2GS" />
+		<!-- It requires a 128K Apple //e or later. -->
+
+		<part name="flop1" interface="floppy_5_25">
+			<feature name="part_id" value="Disk A"/>
+			<dataarea name="flop" size="234818">
+				<rom name="might and magic book two disk a.woz" size="234818" crc="49f2fbba" sha1="4fe2badcaf85aa734927c29143f280094fb6f6dc" />
+			</dataarea>
+		</part>
+		<part name="flop2" interface="floppy_5_25">
+			<feature name="part_id" value="Disk B"/>
+			<dataarea name="flop" size="234818">
+				<rom name="might and magic book two disk b.woz" size="234818" crc="75376447" sha1="e6165d3544689d6ffc2a07bfa2feb3fbf4eb6761" />
+			</dataarea>
+		</part>
+		<part name="flop3" interface="floppy_5_25">
+			<feature name="part_id" value="Disk C"/>
+			<dataarea name="flop" size="234818">
+				<rom name="might and magic book two disk c.woz" size="234818" crc="eeac4b29" sha1="ba6156d8396055d6c01321cdce0a77420a095e63" />
+			</dataarea>
+		</part>
+		<part name="flop4" interface="floppy_5_25">
+			<feature name="part_id" value="Disk D"/>
+			<dataarea name="flop" size="234818">
+				<rom name="might and magic book two disk d.woz" size="234818" crc="25ea0800" sha1="055406125e4f8eb8ea68d0a2d3adcfe5619c2804" />
+			</dataarea>
+		</part>
+		<part name="flop5" interface="floppy_5_25">
+			<feature name="part_id" value="Disk E"/>
+			<dataarea name="flop" size="234818">
+				<rom name="might and magic book two disk e.woz" size="234818" crc="57a014a4" sha1="967a27fae812144cf15d6a77dc0667832277c782" />
+			</dataarea>
+		</part>
+		<part name="flop6" interface="floppy_5_25">
+			<feature name="part_id" value="Disk F"/>
+			<dataarea name="flop" size="234818">
+				<rom name="might and magic book two disk f.woz" size="234818" crc="bd68ba52" sha1="251394526324b1ea65c5fa6daf6def2467b7d16c" />
+			</dataarea>
+		</part>
+	</software>
+
+	<software name="rlmimpos">
+		<description>Realm of Impossibility</description>
+		<year>1986</year>
+		<publisher>Electronic Arts</publisher>
+		<info name="release" value="2019-10-31"/>
+		<sharedfeat name="compatibility" value="A2P,A2E,A2EE,A2C,A2GS" />
+		<!-- It requires a 64K Apple ][+ or later. -->
+
+		<part name="flop1" interface="floppy_5_25">
+			<dataarea name="flop" size="228113">
+				<rom name="realm of impossibility.woz" size="228113" crc="58ac103e" sha1="0373968235eae4a9a8e4381c635e2a01eefa7ed7" />
+			</dataarea>
+		</part>
+	</software>
+
+	<software name="appiledu">
+		<description>Appilot Edu-Disk</description>
+		<year>1978</year>
+		<publisher>MUSE Software</publisher>
+		<info name="release" value="2019-11-01"/>
+		<sharedfeat name="compatibility" value="A2" />
+		<!-- It requires an Apple ][ with Integer BASIC ROM and at least 32K.
+        Due to reliance on Integer ROM, it will not run on later models. -->
+
+		<part name="flop1" interface="floppy_5_25">
+			<dataarea name="flop" size="234809">
+				<rom name="appilot edu-disk.woz" size="234809" crc="d8c62a72" sha1="21d9518179cc8b9f32211b1252f36b49a6b1c5ff" />
+			</dataarea>
+		</part>
+	</software>
+
 </softwarelist>


### PR DESCRIPTION
This also includes metadata for the Anti-M releases, which I consider important to save since we have no way to know what will happen if GitHub or 4am should disappear at some point.