### PR TITLE
Cps1 bootleg, new sets + fixes

### DIFF
--- a/src/mame/drivers/cps1.cpp
+++ b/src/mame/drivers/cps1.cpp
@@ -1956,6 +1956,21 @@ static INPUT_PORTS_START( sf2amf )
 	PORT_DIPSETTING(    0x20, DEF_STR( Off ) )
 	PORT_DIPSETTING(    0x00, DEF_STR( On ) )
 INPUT_PORTS_END
+	
+/* SWB.6 enables turbo mode, SWB.4 and SWB.5 sets the speed */
+static INPUT_PORTS_START( sf2amfx )
+	PORT_INCLUDE( sf2hack )
+	
+	PORT_MODIFY("DSWB")
+	PORT_DIPNAME( 0x18, 0x18, "Game Speed" )   PORT_DIPLOCATION("SW(B):4,5")
+	PORT_DIPSETTING(    0x18, "Normal" )
+	PORT_DIPSETTING(    0x10, "Fast" )
+	PORT_DIPSETTING(    0x08, "Very Fast" )
+	PORT_DIPSETTING(    0x00, "Extremely Fast" )
+	PORT_DIPNAME( 0x20, 0x20, "Turbo Mode Enable" )   PORT_DIPLOCATION("SW(B):6")
+	PORT_DIPSETTING(    0x20, DEF_STR( Off ) )  // normal speed
+	PORT_DIPSETTING(    0x00, DEF_STR( On ) )   // the speed set by SWB.4 and SWB.5
+INPUT_PORTS_END
 
 static INPUT_PORTS_START( sf2accp2 )
 	PORT_INCLUDE( sf2 )
@@ -10058,7 +10073,7 @@ ROM_END
 
 /* This set is identical to sf2amf2 except for program roms, the pcb has some kind of mod around the rom area with cut traces
    and a17 pins of u221 and u195 bent out of their sockets and connected together with a wire.
-   Perhaps it is an "upgraded" sf2amf2 board ? */
+   Perhaps it's an "upgraded" sf2amf2 board ? */
 ROM_START( sf2amf3 )
 	ROM_REGION( CODE_SIZE, "maincpu", 0 )      /* 68000 code */
 	ROM_LOAD16_BYTE( "u222.bin", 0x000000, 0x80000, CRC(0d305e8b) SHA1(7094160abbf24c119a575d93e3fe1ab84b537de0) )
@@ -13529,8 +13544,8 @@ GAME( 1992, sf2acc,      sf2ce,    cps1_12MHz, sf2,      cps_state, init_cps1,  
 GAME( 1992, sf2acca,     sf2ce,    cps1_12MHz, sf2,      cps_state, init_cps1,     ROT0,   "bootleg", "Street Fighter II': Champion Edition (Accelerator!, bootleg, set 2)", MACHINE_SUPPORTS_SAVE )          // 920313 - based on World version
 GAME( 1992, sf2accp2,    sf2ce,    cps1_12MHz, sf2accp2, cps_state, init_cps1,     ROT0,   "bootleg (Testron)", "Street Fighter II': Champion Edition (Accelerator Pt.II, bootleg)", MACHINE_SUPPORTS_SAVE )        // 920313 - based on World version
 GAME( 1992, sf2amf,      sf2ce,    cps1_12MHz, sf2amf,   cps_state, init_sf2hack,  ROT0,   "bootleg", "Street Fighter II': Champion Edition (Alpha Magic-F, bootleg)", MACHINE_NOT_WORKING | MACHINE_SUPPORTS_SAVE )     // 920313 - based on World version
-GAME( 1992, sf2amf2,     sf2ce,    cps1_12MHz, sf2hack,  cps_state, init_sf2hack,  ROT0,   "bootleg", "Street Fighter II': Champion Edition (L735 Test Rom, bootleg, set 1)", MACHINE_SUPPORTS_SAVE )     // 920313 - based on World version
-GAME( 1992, sf2amf3,     sf2ce,    cps1_12MHz, sf2hack,  cps_state, init_sf2hack,  ROT0,   "bootleg", "Street Fighter II': Champion Edition (L735 Test Rom, bootleg, set 2)", MACHINE_SUPPORTS_SAVE )     // 920313 - based on World version
+GAME( 1992, sf2amf2,     sf2ce,    cps1_12MHz, sf2amfx,  cps_state, init_sf2hack,  ROT0,   "bootleg", "Street Fighter II': Champion Edition (L735 Test Rom, bootleg, set 1)", MACHINE_SUPPORTS_SAVE )     // 920313 - based on World version
+GAME( 1992, sf2amf3,     sf2ce,    cps1_10MHz, sf2amfx,  cps_state, init_sf2hack,  ROT0,   "bootleg", "Street Fighter II': Champion Edition (L735 Test Rom, bootleg, set 2)", MACHINE_SUPPORTS_SAVE )     // 920313 - based on World version, confirmed 10MHz
 GAME( 1992, sf2dkot2,    sf2ce,    cps1_12MHz, sf2,      cps_state, init_cps1,     ROT0,   "bootleg", "Street Fighter II': Champion Edition (Double K.O. Turbo II, bootleg)", MACHINE_SUPPORTS_SAVE ) // 902140 !!! - based on USA version
 GAME( 1992, sf2level,    sf2ce,    sf2m3,      sf2level, cps_state, init_cps1,     ROT0,   "bootleg", "Street Fighter II': Champion Edition (bootleg with level selection)", MACHINE_SUPPORTS_SAVE ) // 920322 - based on USA version
 GAME( 1992, sf2ceblp,    sf2ce,    cps1_10MHz, sf2,      cps_state, init_sf2ceblp, ROT0,   "bootleg", "Street Fighter II': Champion Edition (protected bootleg on non-dash board)", MACHINE_SUPPORTS_SAVE )          // 920313 - based on USA version

--- a/src/mame/drivers/cps1.cpp
+++ b/src/mame/drivers/cps1.cpp
@@ -10016,12 +10016,11 @@ ROM_END
 
 ROM_START( sf2amf2 )
 	ROM_REGION( CODE_SIZE, "maincpu", 0 )      /* 68000 code */
-	ROM_LOAD16_BYTE( "m5m27c401.u222",          0x000000, 0x80000, CRC(03991fba) SHA1(6c42bf15248640fdb3e98fb01b0a870649deb410) ) // ==  5.amf                 sf2amf
-	ROM_LOAD16_BYTE( "m5m27c401.u196",          0x000001, 0x80000, CRC(39f15a1e) SHA1(901c4fea76bf5bff7330ed07ffde54cdccdaa680) ) // ==  4.amf                 sf2amf
+	ROM_LOAD16_BYTE( "m5m27c401.u222",          0x000000, 0x80000, CRC(03991fba) SHA1(6c42bf15248640fdb3e98fb01b0a870649deb410) ) // ==  5.amf  sf2amf
+	ROM_LOAD16_BYTE( "m5m27c401.u196",          0x000001, 0x80000, CRC(39f15a1e) SHA1(901c4fea76bf5bff7330ed07ffde54cdccdaa680) ) // ==  4.amf  sf2amf
 
 	ROM_LOAD16_BYTE( "27020.u221",   0x100000, 0x40000, CRC(aa4d55a6) SHA1(8fd1c21816886a7734aae42e9336d5f66ddab7bc) ) // different
 	ROM_LOAD16_BYTE( "27020.u195",   0x100001, 0x40000, CRC(2bffa6f9) SHA1(eb1222356d89849edb08ea1898399cf90cf127f5) ) // different
-
 
 	ROM_REGION( 0x600000, "gfx", 0 )
 	ROM_LOAD64_WORD( "fun-u70.bin", 0x000004, 0x80000, CRC(a94a8b19) SHA1(49ba9e6032a0b33d7db9fe609710575f2f75e695) )  // different
@@ -10044,6 +10043,50 @@ ROM_START( sf2amf2 )
 	ROM_LOAD64_BYTE( "grp2.u30",    0x400005, 0x10000, CRC(bf0cd819) SHA1(f04a098fce07949277268327871c5e5520e3bb3c) )  // different
 	ROM_CONTINUE(                   0x400001, 0x10000 )
 	ROM_LOAD64_BYTE( "grp4.u28",    0x400007, 0x10000, CRC(76f9f91f) SHA1(58a34062d2c8378558a7f1629140330279af9a43) )  // different
+	ROM_CONTINUE(                   0x400003, 0x10000 )
+
+	ROM_REGION( 0x18000, "audiocpu", 0 ) /* 64k for the audio CPU (+banks) */
+	ROM_LOAD( "27512.u191", 0x00000, 0x08000, CRC(a4823a1b) SHA1(7b6bf59dfd578bfbbdb64c27988796783442d659) )
+	ROM_CONTINUE(           0x10000, 0x08000 )
+
+	ROM_REGION( 0x20000, "user1", 0 ) /* unknown (bootleg priority?) */
+	ROM_LOAD( "27512.u133", 0x00000, 0x10000, CRC(13ea1c44) SHA1(5b05fe4c3920e33d94fac5f59e09ff14b3e427fe) )
+
+	ROM_REGION( 0x40000, "oki", 0 ) /* Samples */
+	ROM_LOAD( "fun-u210.bin", 0x00000, 0x40000, CRC(6cfffb11) SHA1(995526183ffd35f92e9096500a3fe6237faaa2dd) )
+ROM_END
+
+/* This set is identical to sf2amf2 except for program roms, the pcb has some kind of mod around the rom area with cut traces
+   and a17 pins of u221 and u195 bent out of their sockets and connected together with a wire.
+   Perhaps it is an "upgraded" sf2amf2 board ? */
+ROM_START( sf2amf3 )
+	ROM_REGION( CODE_SIZE, "maincpu", 0 )      /* 68000 code */
+	ROM_LOAD16_BYTE( "u222.bin", 0x000000, 0x80000, CRC(0d305e8b) SHA1(7094160abbf24c119a575d93e3fe1ab84b537de0) )
+	ROM_LOAD16_BYTE( "u196.bin", 0x000001, 0x80000, CRC(137d8665) SHA1(cf4805a11ab614ce5b7e1302ac14ba50fb01e5f4) )
+	ROM_LOAD16_BYTE( "u221.bin", 0x100000, 0x40000, CRC(0b3fe5dd) SHA1(9b66cb867da61595f53d1c9e6b48c6bb7e06e1e0) )
+	ROM_LOAD16_BYTE( "u195.bin", 0x100001, 0x40000, CRC(dbee7b18) SHA1(e56af12fc9d30e92d37e688ff621ea09abb94b53) )
+
+	ROM_REGION( 0x600000, "gfx", 0 )
+	ROM_LOAD64_WORD( "fun-u70.bin", 0x000004, 0x80000, CRC(a94a8b19) SHA1(49ba9e6032a0b33d7db9fe609710575f2f75e695) )
+	ROM_CONTINUE(                   0x000000, 0x80000)
+	ROM_LOAD64_WORD( "fun-u68.bin", 0x000006, 0x80000, CRC(0405f21f) SHA1(dbebd2c2c46d5aae8db905f2eb51abd4a5c4ea97) )
+	ROM_CONTINUE(                   0x000002, 0x80000)
+	ROM_LOAD64_WORD( "fun-u69.bin", 0x200004, 0x80000, CRC(05dc2043) SHA1(d16b89a48d2dd7cdfafc79567ce1e230d4bd41c1) )
+	ROM_CONTINUE(                   0x200000, 0x80000)
+	ROM_LOAD64_WORD( "fun-u67.bin", 0x200006, 0x80000, CRC(055b64f1) SHA1(3dd68f52b81ed1b300b65c900ef6bfe435d41e4b) )
+	ROM_CONTINUE(                   0x200002, 0x80000)
+	ROM_LOAD64_WORD( "fun-u19.bin", 0x400004, 0x80000, CRC(1a518609) SHA1(18ffca70d6cefb399ba6e3008e5c29dc37de52a0) )
+	ROM_CONTINUE(                   0x400000, 0x80000)
+	ROM_LOAD64_WORD( "fun-u18.bin", 0x400006, 0x80000, CRC(84f9354f) SHA1(ecc190950b1f45b268da380c17859a8d0715b58f) )
+	ROM_CONTINUE(                   0x400002, 0x80000)
+	/* extra gfx layer roms loaded over the former ones to remove the capcom copyright logo */
+	ROM_LOAD64_BYTE( "grp1.u31",    0x400004, 0x10000, CRC(6de44671) SHA1(dc6abba639e0c27033e391c7438d88dc89a93351) )
+	ROM_CONTINUE(                   0x400000, 0x10000 )
+	ROM_LOAD64_BYTE( "grp3.u29",    0x400006, 0x10000, CRC(e8f14362) SHA1(a20eb75e322011e2a8d8bf2acebe713bef3d3941) )
+	ROM_CONTINUE(                   0x400002, 0x10000 )
+	ROM_LOAD64_BYTE( "grp2.u30",    0x400005, 0x10000, CRC(bf0cd819) SHA1(f04a098fce07949277268327871c5e5520e3bb3c) )
+	ROM_CONTINUE(                   0x400001, 0x10000 )
+	ROM_LOAD64_BYTE( "grp4.u28",    0x400007, 0x10000, CRC(76f9f91f) SHA1(58a34062d2c8378558a7f1629140330279af9a43) )
 	ROM_CONTINUE(                   0x400003, 0x10000 )
 
 	ROM_REGION( 0x18000, "audiocpu", 0 ) /* 64k for the audio CPU (+banks) */
@@ -13486,7 +13529,8 @@ GAME( 1992, sf2acc,      sf2ce,    cps1_12MHz, sf2,      cps_state, init_cps1,  
 GAME( 1992, sf2acca,     sf2ce,    cps1_12MHz, sf2,      cps_state, init_cps1,     ROT0,   "bootleg", "Street Fighter II': Champion Edition (Accelerator!, bootleg, set 2)", MACHINE_SUPPORTS_SAVE )          // 920313 - based on World version
 GAME( 1992, sf2accp2,    sf2ce,    cps1_12MHz, sf2accp2, cps_state, init_cps1,     ROT0,   "bootleg (Testron)", "Street Fighter II': Champion Edition (Accelerator Pt.II, bootleg)", MACHINE_SUPPORTS_SAVE )        // 920313 - based on World version
 GAME( 1992, sf2amf,      sf2ce,    cps1_12MHz, sf2amf,   cps_state, init_sf2hack,  ROT0,   "bootleg", "Street Fighter II': Champion Edition (Alpha Magic-F, bootleg)", MACHINE_NOT_WORKING | MACHINE_SUPPORTS_SAVE )     // 920313 - based on World version
-GAME( 1992, sf2amf2,     sf2ce,    cps1_12MHz, sf2hack,  cps_state, init_sf2hack,  ROT0,   "bootleg", "Street Fighter II': Champion Edition (L735 Test Rom, bootleg)", MACHINE_SUPPORTS_SAVE )     // 920313 - based on World version
+GAME( 1992, sf2amf2,     sf2ce,    cps1_12MHz, sf2hack,  cps_state, init_sf2hack,  ROT0,   "bootleg", "Street Fighter II': Champion Edition (L735 Test Rom, bootleg, set 1)", MACHINE_SUPPORTS_SAVE )     // 920313 - based on World version
+GAME( 1992, sf2amf3,     sf2ce,    cps1_12MHz, sf2hack,  cps_state, init_sf2hack,  ROT0,   "bootleg", "Street Fighter II': Champion Edition (L735 Test Rom, bootleg, set 2)", MACHINE_SUPPORTS_SAVE )     // 920313 - based on World version
 GAME( 1992, sf2dkot2,    sf2ce,    cps1_12MHz, sf2,      cps_state, init_cps1,     ROT0,   "bootleg", "Street Fighter II': Champion Edition (Double K.O. Turbo II, bootleg)", MACHINE_SUPPORTS_SAVE ) // 902140 !!! - based on USA version
 GAME( 1992, sf2level,    sf2ce,    sf2m3,      sf2level, cps_state, init_cps1,     ROT0,   "bootleg", "Street Fighter II': Champion Edition (bootleg with level selection)", MACHINE_SUPPORTS_SAVE ) // 920322 - based on USA version
 GAME( 1992, sf2ceblp,    sf2ce,    cps1_10MHz, sf2,      cps_state, init_sf2ceblp, ROT0,   "bootleg", "Street Fighter II': Champion Edition (protected bootleg on non-dash board)", MACHINE_SUPPORTS_SAVE )          // 920313 - based on USA version

--- a/src/mame/drivers/fcrash.cpp
+++ b/src/mame/drivers/fcrash.cpp
@@ -81,7 +81,9 @@ sf2mdta, sf2ceb: scroll 2X has strange 0x200 writes that cause missing fighters'
 sgyxz, wofabl: garbage left behind. A priority problem can be seen in 3rd demo where
        the fighters walk through the crowd instead of behind.
 
-slampic: no sound. A priority problem between sprites and crowd.
+slampic: no sound. Some minor gfx issues (sprites on character select screen)
+
+slampic2: no sound. All gfx issues confirmed present on real board.
 
 */
 
@@ -581,7 +583,7 @@ void cps_state::fcrash_render_sprites( screen_device &screen, bitmap_ind16 &bitm
 	int base = m_sprite_base / 2;
 	int num_sprites = m_gfxdecode->gfx(2)->elements();
 	int last_sprite_offset = 0x1ffc;
-	uint16_t *sprite_ram = m_sprite_ram; //m_gfxram;
+	uint16_t *sprite_ram = m_gfxram;
 	uint16_t tileno,colour,xpos,ypos;
 	bool flipx, flipy;
 
@@ -933,9 +935,6 @@ void cps_state::slampic_map(address_map &map)
 	map(0x880000, 0x880001).nopw(); //.w(FUNC(cps_state::cps1_soundlatch_w));    /* Sound command */
 	map(0x900000, 0x92ffff).ram().w(FUNC(cps_state::cps1_gfxram_w)).share("gfxram");
 	map(0x980000, 0x98000d).w(FUNC(cps_state::slampic_layer_w));
-	
-	map(0x990000, 0x993fff).ram().share("spriteram");
-	
 	map(0xf00000, 0xf0ffff).r(FUNC(cps_state::qsound_rom_r));          /* Slammasters protection */
 	map(0xf18000, 0xf19fff).ram();
 	map(0xf1c000, 0xf1c001).portr("IN2");            /* Player 3 controls (later games) */
@@ -2480,8 +2479,8 @@ ROM_END
 
 void cps_state::init_dinopic()
 {
-	//m_bootleg_sprite_ram = std::make_unique<uint16_t[]>(0x2000);
-	//m_maincpu->space(AS_PROGRAM).install_ram(0x990000, 0x993fff, m_bootleg_sprite_ram.get());
+	m_bootleg_sprite_ram = std::make_unique<uint16_t[]>(0x2000);
+	m_maincpu->space(AS_PROGRAM).install_ram(0x990000, 0x993fff, m_bootleg_sprite_ram.get());
 	init_cps1();
 }
 
@@ -3209,7 +3208,7 @@ MACHINE_START_MEMBER(cps_state, slampic)
 	m_layer_scroll3x_offset = 0x40;
 	m_sprite_base = 0x1000;
 	m_sprite_list_end_marker = 0x8000;
-	m_sprite_x_offset = 0;
+	m_sprite_x_offset = 2;
 }
 
 void cps_state::slampic(machine_config &config)
@@ -3395,7 +3394,7 @@ ROM_END
 	
 	RAM
 	2x  NEC D431000ACZ-70L   main ram   1Mbit (128Kx8) SRAM 70ns
-	2x  SRM20256LM12         gfx?       256Kbit (32Kx8) SRAM 120ns SOP28   (mounted on tiny SOP->DIP adapter pcbs)
+	2x  SRM20256LM12         gfx?       256Kbit (32Kx8) SRAM 120ns SOP28   (mounted on SOP->DIP adapter pcbs)
 	6x  T6116S45L            gfx?       16Kbit (2Kx8) SRAM 45ns
 	4x  T6116S35L            gfx?       16Kbit (2Kx8) SRAM 35ns
 	
@@ -3441,8 +3440,8 @@ ROM_END
 	9   coin
 	10  start
 	
-	player 3 btn 3: jamma 25  (non-std, player 1 btn 4/neogeo btn D)
-	player 4 btn 4: jamma ac  (non-std, player 2 btn 4/neogeo btn D)
+	player 3 btn 3:  jamma 25  (non-std, player 1 btn 4/neogeo btn D)
+	player 4 btn 4:  jamma ac  (non-std, player 2 btn 4/neogeo btn D)
 	
 	
 	h/w issues compared to original game (slammast)
@@ -3680,12 +3679,12 @@ READ16_MEMBER(cps_state::slampic2_cps_a_r)
 
 WRITE16_MEMBER(cps_state::slampic2_sound_w)
 {
-	logerror("Sound command: %04x\n", data);
+	//logerror("Sound command: %04x\n", data);
 }
 
 WRITE16_MEMBER(cps_state::slampic2_sound2_w)
 {
-	logerror("Sound2 command: %04x\n", data);
+	//logerror("Sound2 command: %04x\n", data);
 }
 
 static INPUT_PORTS_START( slampic2 )
@@ -3845,7 +3844,7 @@ ROM_START( slampic2 )
 	// ROM_LOAD64_BYTE( "rom4.bin",  0x600003, 0x40000, CRC(9683dd30) SHA1(8b258b386baff5e06a9b7f176c49507f7e531b95) )  // ~ 14.bin
 	// ROM_CONTINUE(                 0x600007, 0x40000)
 
-	ROM_REGION( 0x2000, "audiocpu", 0 )
+	ROM_REGION( 0x2000, "audiocpu", 0 ) // NO DUMP  -  protected PIC
 	ROM_LOAD( "pic_u33.bin", 0x0000, 0x1007, BAD_DUMP CRC(6dba4094) SHA1(ca3362de83205fc6563d16a59b8e6e4bb7ebf4a6) )
 	
 	ROM_REGION( 0x140000, "oki", 0 )
@@ -3916,8 +3915,8 @@ GAME( 1992, sf2b2,     sf2,      sf2b,      sf2mdt,   cps_state, init_sf2mdtb,  
 
 GAME( 1992, sf2m9,     sf2ce,    sf2m1,     sf2,      cps_state, init_sf2m1,    ROT0,   "bootleg", "Street Fighter II': Champion Edition (M9, bootleg)",  MACHINE_IMPERFECT_GRAPHICS | MACHINE_SUPPORTS_SAVE ) // 920313 ETC
 
-GAME( 1993, slampic,   slammast, slampic,   slampic,  cps_state, init_dinopic,  ROT0,   "bootleg", "Saturday Night Slam Masters (bootleg with PIC16c57)", MACHINE_IMPERFECT_GRAPHICS | MACHINE_NO_SOUND | MACHINE_SUPPORTS_SAVE ) // 930713 ETC
-GAME( 1993, slampic2,  0,        slampic2,  slampic2, cps_state, init_slampic2, ROT0,   "bootleg", "Saturday Night Slam Masters (bootleg with PIC16c57, set 2)", MACHINE_NO_SOUND | MACHINE_SUPPORTS_SAVE )                       // 930713 ETC
+GAME( 1993, slampic,   slammast, slampic,   slampic,  cps_state, init_dinopic,  ROT0,   "bootleg", "Saturday Night Slam Masters (bootleg with PIC16c57, set 1)", MACHINE_IMPERFECT_GRAPHICS | MACHINE_NO_SOUND | MACHINE_SUPPORTS_SAVE ) // 930713 ETC
+GAME( 1993, slampic2,  0,        slampic2,  slampic2, cps_state, init_slampic2, ROT0,   "bootleg", "Saturday Night Slam Masters (bootleg with PIC16c57, set 2)", MACHINE_NO_SOUND | MACHINE_SUPPORTS_SAVE ) // 930713 ETC
 
 GAME( 1999, sgyxz,     wof,      sgyxz,     sgyxz,    cps_state, init_cps1,     ROT0,   "bootleg (All-In Electronic)", "Warriors of Fate ('sgyxz' bootleg)", MACHINE_IMPERFECT_GRAPHICS | MACHINE_SUPPORTS_SAVE )   // 921005 - Sangokushi 2
 GAME( 1999, wofabl,    wof,      wofabl,    wofabl,   cps_state, init_wofabl,   ROT0,   "bootleg", "Sangokushi II (bootleg)", MACHINE_NOT_WORKING | MACHINE_IMPERFECT_GRAPHICS | MACHINE_SUPPORTS_SAVE )   // heavy graphics glitches - 921005 - Sangokushi 2

--- a/src/mame/includes/cps1.h
+++ b/src/mame/includes/cps1.h
@@ -130,6 +130,8 @@ protected:
 		, m_region_stars(*this, "stars")
 		, m_led_cboard(*this, "led_cboard%u", 0U)
 		, bootleg_sprite_renderer(fcrash_render_sprites)
+		
+		, m_sprite_ram(*this, "spriteram")
 	{ }
 
 public:
@@ -243,6 +245,7 @@ public:
 	DECLARE_WRITE16_MEMBER(sf2mdta_layer_w);
 	DECLARE_WRITE16_MEMBER(sf2b_layer_w);
 	DECLARE_WRITE16_MEMBER(slampic_layer_w);
+	DECLARE_WRITE16_MEMBER(slampic_layer2_w);
 	DECLARE_READ16_MEMBER(slampic2_cps_a_r);
 	DECLARE_WRITE16_MEMBER(slampic2_sound_w);
 	DECLARE_WRITE16_MEMBER(slampic2_sound2_w);
@@ -419,6 +422,7 @@ protected:
 	
 	// fcrash
 	void (cps_state::*bootleg_sprite_renderer)(screen_device &screen, bitmap_ind16 &bitmap, const rectangle &cliprect);
+	optional_shared_ptr<uint16_t> m_sprite_ram;
 };
 
 class cps2_state : public cps_state

--- a/src/mame/includes/cps1.h
+++ b/src/mame/includes/cps1.h
@@ -130,8 +130,6 @@ protected:
 		, m_region_stars(*this, "stars")
 		, m_led_cboard(*this, "led_cboard%u", 0U)
 		, bootleg_sprite_renderer(fcrash_render_sprites)
-		
-		, m_sprite_ram(*this, "spriteram")
 	{ }
 
 public:
@@ -422,7 +420,6 @@ protected:
 	
 	// fcrash
 	void (cps_state::*bootleg_sprite_renderer)(screen_device &screen, bitmap_ind16 &bitmap, const rectangle &cliprect);
-	optional_shared_ptr<uint16_t> m_sprite_ram;
 };
 
 class cps2_state : public cps_state

--- a/src/mame/includes/cps1.h
+++ b/src/mame/includes/cps1.h
@@ -129,6 +129,7 @@ protected:
 		, m_soundlatch2(*this, "soundlatch2")
 		, m_region_stars(*this, "stars")
 		, m_led_cboard(*this, "led_cboard%u", 0U)
+		, bootleg_sprite_renderer(fcrash_render_sprites)
 	{ }
 
 public:
@@ -217,6 +218,7 @@ public:
 	void init_sf2mdtb();
 	void init_sf2b();
 	void init_slampic();
+	void init_slampic2();
 	void init_wofabl();
 	DECLARE_MACHINE_START(fcrash);
 	DECLARE_MACHINE_RESET(fcrash);
@@ -228,6 +230,7 @@ public:
 	DECLARE_MACHINE_START(punipic);
 	DECLARE_MACHINE_START(sf2mdt);
 	DECLARE_MACHINE_START(slampic);
+	DECLARE_MACHINE_START(slampic2);
 	DECLARE_MACHINE_START(sgyxz);
 	DECLARE_WRITE16_MEMBER(cawingbl_soundlatch_w);
 	DECLARE_WRITE16_MEMBER(dinopic_layer_w);
@@ -240,6 +243,9 @@ public:
 	DECLARE_WRITE16_MEMBER(sf2mdta_layer_w);
 	DECLARE_WRITE16_MEMBER(sf2b_layer_w);
 	DECLARE_WRITE16_MEMBER(slampic_layer_w);
+	DECLARE_READ16_MEMBER(slampic2_cps_a_r);
+	DECLARE_WRITE16_MEMBER(slampic2_sound_w);
+	DECLARE_WRITE16_MEMBER(slampic2_sound2_w);
 	DECLARE_WRITE16_MEMBER(fcrash_soundlatch_w);
 	DECLARE_WRITE8_MEMBER(fcrash_snd_bankswitch_w);
 	DECLARE_WRITE8_MEMBER(sf2mdt_snd_bankswitch_w);
@@ -250,6 +256,7 @@ public:
 	uint32_t screen_update_fcrash(screen_device &screen, bitmap_ind16 &bitmap, const rectangle &cliprect);
 	void fcrash_update_transmasks();
 	void fcrash_render_sprites(screen_device &screen, bitmap_ind16 &bitmap, const rectangle &cliprect);
+	void slampic2_render_sprites(screen_device &screen, bitmap_ind16 &bitmap, const rectangle &cliprect);
 	void fcrash_render_layer(screen_device &screen, bitmap_ind16 &bitmap, const rectangle &cliprect, int layer, int primask);
 	void fcrash_render_high_layer(screen_device &screen, bitmap_ind16 &bitmap, const rectangle &cliprect, int layer);
 	void fcrash_build_palette();
@@ -282,6 +289,7 @@ public:
 	void punipic(machine_config &config);
 	void dinopic(machine_config &config);
 	void slampic(machine_config &config);
+	void slampic2(machine_config &config);
 	void sf2b(machine_config &config);
 	void knightsb(machine_config &config);
 	void fcrash(machine_config &config);
@@ -318,6 +326,7 @@ public:
 	void sgyxz_sound_map(address_map &map);
 	void wofabl_map(address_map &map);
 	void slampic_map(address_map &map);
+	void slampic2_map(address_map &map);
 	void sound_map(address_map &map);
 	void sub_map(address_map &map);
 	void varthb_map(address_map &map);
@@ -334,7 +343,7 @@ protected:
 	uint16_t *     m_scroll3;
 	uint16_t *     m_obj;
 	uint16_t *     m_other;
-	std::unique_ptr<uint16_t[]>     m_buffered_obj;
+	std::unique_ptr<uint16_t[]> m_buffered_obj;
 	optional_shared_ptr<uint8_t> m_qsound_sharedram1;
 	optional_shared_ptr<uint8_t> m_qsound_sharedram2;
 	std::unique_ptr<uint8_t[]> m_decrypt_kabuki;
@@ -378,12 +387,12 @@ protected:
 	int          m_palette_align;
 	int          m_palette_size;
 	int          m_stars_rom_size;
-	uint8_t        m_empty_tile[32*32];
+	uint8_t      m_empty_tile[32*32];
 	int          m_cps_version;
 
 	/* fcrash video config */
-	uint8_t        m_layer_enable_reg;
-	uint8_t        m_layer_mask_reg[4];
+	uint8_t      m_layer_enable_reg;
+	uint8_t      m_layer_mask_reg[4];
 	int          m_layer_scroll1x_offset;
 	int          m_layer_scroll2x_offset;
 	int          m_layer_scroll3x_offset;
@@ -407,6 +416,9 @@ protected:
 	optional_device<generic_latch_8_device> m_soundlatch2;
 	optional_memory_region m_region_stars;
 	output_finder<3> m_led_cboard;
+	
+	// fcrash
+	void (cps_state::*bootleg_sprite_renderer)(screen_device &screen, bitmap_ind16 &bitmap, const rectangle &cliprect);
 };
 
 class cps2_state : public cps_state

--- a/src/mame/mame.lst
+++ b/src/mame/mame.lst
@@ -10558,6 +10558,7 @@ sf2acca                         // hack
 sf2accp2                        // hack
 sf2amf                          // bootleg
 sf2amf2                         // bootleg
+sf2amf3                         // bootleg
 sf2bhh                          // hack
 sf2ce                           // 13/05/1992 (c) 1992 (World)
 sf2ceblp                        // hack

--- a/src/mame/mame.lst
+++ b/src/mame/mame.lst
@@ -13190,6 +13190,7 @@ sf2mdta                         // bootleg
 sf2mdtb                         // bootleg
 sgyxz                           // bootleg (All-In Electronics)
 slampic                         // bootleg
+slampic2                        // bootleg
 varthb                          // bootleg
 wofabl                          // bootleg
 

--- a/src/mame/video/cps1.cpp
+++ b/src/mame/video/cps1.cpp
@@ -1620,7 +1620,7 @@ static const struct CPS1config cps1_config_table[]=
 	{"punisherbz",  CPS_B_21_DEF, mapper_PS63B },   /* Chinese bootleg */
 	{"slammast",    CPS_B_21_QS4, mapper_MB63B },
 	{"slammastu",   CPS_B_21_QS4, mapper_MB63B },
-	{"slampic",     CPS_B_21_QS4, mapper_MB63B },
+	{"slampic",     CPS_B_21_QS4, mapper_sfzch },
 	{"slampic2",    CPS_B_21_QS4, mapper_sfzch },  // default cps2 mapper breaks scroll layers
 	{"mbomberj",    CPS_B_21_QS4, mapper_MB63B },
 	{"mbombrd",     CPS_B_21_QS5, mapper_MB63B },

--- a/src/mame/video/cps1.cpp
+++ b/src/mame/video/cps1.cpp
@@ -1620,7 +1620,7 @@ static const struct CPS1config cps1_config_table[]=
 	{"punisherbz",  CPS_B_21_DEF, mapper_PS63B },   /* Chinese bootleg */
 	{"slammast",    CPS_B_21_QS4, mapper_MB63B },
 	{"slammastu",   CPS_B_21_QS4, mapper_MB63B },
-	{"slampic",     CPS_B_21_QS4, mapper_sfzch },
+	{"slampic",     CPS_B_21_QS4, mapper_MB63B },
 	{"slampic2",    CPS_B_21_QS4, mapper_sfzch },  // default cps2 mapper breaks scroll layers
 	{"mbomberj",    CPS_B_21_QS4, mapper_MB63B },
 	{"mbombrd",     CPS_B_21_QS5, mapper_MB63B },

--- a/src/mame/video/cps1.cpp
+++ b/src/mame/video/cps1.cpp
@@ -1560,6 +1560,7 @@ static const struct CPS1config cps1_config_table[]=
 	{"sf2accp2",    CPS_B_21_DEF, mapper_S9263B, 0x36 },
 	{"sf2amf",      CPS_B_21_DEF, mapper_S9263B, 0x36, 0, 0, 1 }, // probably wrong but this set is not completely dumped anyway
 	{"sf2amf2",     CPS_B_21_DEF, mapper_S9263B, 0x36, 0, 0, 1 },
+	{"sf2amf3",     CPS_B_21_DEF, mapper_S9263B, 0x36, 0, 0, 1 },
 	{"sf2dkot2",    CPS_B_21_DEF, mapper_S9263B, 0x36 },
 	{"sf2level",    HACK_B_1,     mapper_S9263B, 0,    0, 0, 2 },
 	{"sf2m1",       CPS_B_21_DEF, mapper_S9263B, 0x36 },

--- a/src/mame/video/cps1.cpp
+++ b/src/mame/video/cps1.cpp
@@ -1406,6 +1406,7 @@ static const struct gfx_range mapper_pokonyan_table[] =
 	{ 0 }
 };
 
+// a game without an entry here defaults to cps2 mapper (eg. some games in fcrash.cpp)
 static const struct CPS1config cps1_config_table[]=
 {
 	/* name         CPSB          gfx mapper   in2  in3  out2   kludge */
@@ -1620,6 +1621,7 @@ static const struct CPS1config cps1_config_table[]=
 	{"slammast",    CPS_B_21_QS4, mapper_MB63B },
 	{"slammastu",   CPS_B_21_QS4, mapper_MB63B },
 	{"slampic",     CPS_B_21_QS4, mapper_MB63B },
+	{"slampic2",    CPS_B_21_QS4, mapper_sfzch },  // default cps2 mapper breaks scroll layers
 	{"mbomberj",    CPS_B_21_QS4, mapper_MB63B },
 	{"mbombrd",     CPS_B_21_QS5, mapper_MB63B },
 	{"mbombrdj",    CPS_B_21_QS5, mapper_MB63B },


### PR DESCRIPTION
added new Street Fighter II Alpha Magic-F bootleg set (sf2amf3), working
added new Saturday Night Slam Masters bootleg set (slampic2), working, no sound (protected PIC)
existing slampic set: fixed most graphics issues, a few very minor issues remain, so will leave MIG flag for now 
existing slampic set: fixed player 4 input
existing sf2amf2 set: add some dipsw settings