### PR TITLE
workaround to fix cross compilation to x86 from a x64 host

### DIFF
--- a/makefile
+++ b/makefile
@@ -293,6 +293,21 @@ else
 UNAME    := $(shell uname -mps)
 TARGETOS := $(OS)
 
+#-------------------------------------------------
+# determine the whether -m32, -m64 or nothing
+# should be passed to gcc when building genie
+#-------------------------------------------------
+
+ifeq ($(ARCHITECTURE),_x86)
+MPARAM := -m32
+else
+ifeq ($(ARCHITECTURE),_x64)
+MPARAM := -m64
+else
+MPARAM :=
+endif
+endif
+
 ARCHITECTURE := _x86
 
 ifeq ($(firstword $(filter x86_64,$(UNAME))),x86_64)
@@ -404,21 +419,6 @@ endif
 CC := $(SILENT)gcc
 LD := $(SILENT)g++
 CXX:= $(SILENT)g++
-
-#-------------------------------------------------
-# determine the whether -m32, -m64 or nothing
-# should be passed to gcc when building genie
-#-------------------------------------------------
-
-ifeq ($(ARCHITECTURE),_x86)
-MPARAM := -m32
-else
-ifeq ($(ARCHITECTURE),_x64)
-MPARAM := -m64
-else
-MPARAM :=
-endif
-endif
 
 #-------------------------------------------------
 # specify OSD layer: windows, sdl, etc.


### PR DESCRIPTION
Quick workaround to have cross compilation back after genie update.  Move the MPARAM logic up to execute before PTR64 tests.

Not the best fix, but I'm not willing to rewrite a good part of mame makefile to have a better cross compile setup (I think we should differentiate host arch from target arch).

See details in https://github.com/mamedev/mame/pull/5631#issuecomment-552403142.

Thanks!