### PR TITLE
deco_mlc.cpp : Correct 5bpp tile decoding, Reduce memory usage, Updates

### DIFF
--- a/src/mame/drivers/deco_mlc.cpp
+++ b/src/mame/drivers/deco_mlc.cpp
@@ -267,7 +267,6 @@ READ32_MEMBER( deco_mlc_state::spriteram_r )
 
 WRITE32_MEMBER( deco_mlc_state::spriteram_w )
 {
-	mem_mask &= 0x0000ffff;
 	if (ACCESSING_BITS_0_15)
 	{
 		data &= 0x0000ffff;

--- a/src/mame/drivers/deco_mlc.cpp
+++ b/src/mame/drivers/deco_mlc.cpp
@@ -452,6 +452,7 @@ INPUT_PORTS_END
 
 /******************************************************************************/
 
+// 1bpp bitplane layout
 static const gfx_layout spritelayout_1bpp =
 {
 	16,16,
@@ -462,6 +463,20 @@ static const gfx_layout spritelayout_1bpp =
 	{ STEP16(0,16) },
 	16*16
 };
+
+/*
+// 2bpp bitplane layout (commonly used)
+static const gfx_layout spritelayout_2bpp =
+{
+	16,16,
+	RGN_FRAC(1,1),
+	2,
+	{ 16, 0 },
+	{ STEP16(15,-1) },
+	{ STEP16(0,16*2) },
+	16*16*2
+};
+*/
 
 static const gfx_layout spritelayout_4bpp =
 {

--- a/src/mame/includes/deco_mlc.h
+++ b/src/mame/includes/deco_mlc.h
@@ -26,10 +26,11 @@ public:
 		m_irq_ram(*this, "irq_ram"),
 		m_clip_ram(*this, "clip_ram"),
 		m_vram(*this, "vram"),
-		m_gfx2(*this,"gfx2")
+		m_vrom(*this,"vrom")
 		{ }
 
 	void init_mlc();
+	void init_mlc_5bpp();
 	void init_avengrgs();
 
 	void mlc(machine_config &config);
@@ -56,7 +57,7 @@ private:
 	required_shared_ptr<u32> m_clip_ram;
 	required_shared_ptr<u32> m_vram;
 
-	required_region_ptr<u8> m_gfx2;
+	required_region_ptr<u8> m_vrom;
 
 	int m_irqLevel;
 	u32 m_mlc_raster_table_1[4*256];
@@ -96,9 +97,10 @@ private:
 	void draw_sprites( const rectangle &cliprect, int scanline, u32* dest, u8* pri);
 	void drawgfxzoomline(u32* dest, u8* pri,const rectangle &clip,gfx_element *gfx,
 		u32 code1,u32 code2, u32 color,int flipx,int sx,
-		int transparent_color,int use8bpp,
+		int transparent_mask,int use8bpp,
 		int scalex, int srcline, int shadowMode);
 	void descramble_sound();
+	void expand_5bpptile();
 
 	void avengrgs_map(address_map &map);
 	void decomlc_map(address_map &map);


### PR DESCRIPTION
Fix naming, Spacing, Add notes, Add raw params for screen (same as deco32?), Fix transparency behavior (in avengrgs 8bpp case, (0 & 0xf) of 8bpp pixel is transparency)
Fix palette entry related to palette RAM size