### PR TITLE
Remove up to one frame of input latency. 

### DIFF
--- a/src/emu/emuopts.cpp
+++ b/src/emu/emuopts.cpp
@@ -88,6 +88,7 @@ const options_entry emu_options::s_option_entries[] =
 	{ OPTION_SLEEP,                                      "1",         OPTION_BOOLEAN,    "enable sleeping, which gives time back to other applications when idle" },
 	{ OPTION_SPEED "(0.01-100)",                         "1.0",       OPTION_FLOAT,      "controls the speed of gameplay, relative to realtime; smaller numbers are slower" },
 	{ OPTION_REFRESHSPEED ";rs",                         "0",         OPTION_BOOLEAN,    "automatically adjust emulation speed to keep the emulated refresh rate slower than the host screen" },
+	{ OPTION_INSTANT_BLIT ";ib",                         "0",         OPTION_BOOLEAN,    "draws new frame before throttling to reduce input latency" },
 
 	// render options
 	{ nullptr,                                           nullptr,     OPTION_HEADER,     "CORE RENDER OPTIONS" },

--- a/src/emu/emuopts.cpp
+++ b/src/emu/emuopts.cpp
@@ -88,7 +88,7 @@ const options_entry emu_options::s_option_entries[] =
 	{ OPTION_SLEEP,                                      "1",         OPTION_BOOLEAN,    "enable sleeping, which gives time back to other applications when idle" },
 	{ OPTION_SPEED "(0.01-100)",                         "1.0",       OPTION_FLOAT,      "controls the speed of gameplay, relative to realtime; smaller numbers are slower" },
 	{ OPTION_REFRESHSPEED ";rs",                         "0",         OPTION_BOOLEAN,    "automatically adjust emulation speed to keep the emulated refresh rate slower than the host screen" },
-	{ OPTION_INSTANT_BLIT ";ib",                         "0",         OPTION_BOOLEAN,    "draws new frame before throttling to reduce input latency" },
+	{ OPTION_LOWLATENCY ";ll",                           "0",         OPTION_BOOLEAN,    "draws new frame before throttling to reduce input latency" },
 
 	// render options
 	{ nullptr,                                           nullptr,     OPTION_HEADER,     "CORE RENDER OPTIONS" },

--- a/src/emu/emuopts.h
+++ b/src/emu/emuopts.h
@@ -75,6 +75,7 @@
 #define OPTION_SLEEP                "sleep"
 #define OPTION_SPEED                "speed"
 #define OPTION_REFRESHSPEED         "refreshspeed"
+#define OPTION_INSTANT_BLIT         "instant_blit"
 
 // core render options
 #define OPTION_KEEPASPECT           "keepaspect"
@@ -352,6 +353,7 @@ public:
 	bool sleep() const { return m_sleep; }
 	float speed() const { return float_value(OPTION_SPEED); }
 	bool refresh_speed() const { return m_refresh_speed; }
+	bool instant_blit() const { return bool_value(OPTION_INSTANT_BLIT); }
 
 	// core render options
 	bool keep_aspect() const { return bool_value(OPTION_KEEPASPECT); }

--- a/src/emu/emuopts.h
+++ b/src/emu/emuopts.h
@@ -75,7 +75,7 @@
 #define OPTION_SLEEP                "sleep"
 #define OPTION_SPEED                "speed"
 #define OPTION_REFRESHSPEED         "refreshspeed"
-#define OPTION_INSTANT_BLIT         "instant_blit"
+#define OPTION_LOWLATENCY           "lowlatency"
 
 // core render options
 #define OPTION_KEEPASPECT           "keepaspect"
@@ -353,7 +353,7 @@ public:
 	bool sleep() const { return m_sleep; }
 	float speed() const { return float_value(OPTION_SPEED); }
 	bool refresh_speed() const { return m_refresh_speed; }
-	bool instant_blit() const { return bool_value(OPTION_INSTANT_BLIT); }
+	bool low_latency() const { return bool_value(OPTION_LOWLATENCY); }
 
 	// core render options
 	bool keep_aspect() const { return bool_value(OPTION_KEEPASPECT); }

--- a/src/emu/video.cpp
+++ b/src/emu/video.cpp
@@ -227,15 +227,18 @@ void video_manager::frame_update(bool from_debugger)
 	// draw the user interface
 	emulator_info::draw_user_interface(machine());
 
-	// if we're throttling, synchronize before rendering
-	attotime current_time = machine().time();
-	if (!from_debugger && !skipped_it && effective_throttle())
-		update_throttle(current_time);
-
 	// ask the OSD to update
 	g_profiler.start(PROFILER_BLIT);
 	machine().osd().update(!from_debugger && skipped_it);
 	g_profiler.stop();
+
+	// if we're throttling, synchronize after rendering
+	attotime current_time = machine().time();
+	if (!from_debugger && !skipped_it && effective_throttle())
+		update_throttle(current_time);
+
+	// get most recent input now
+	machine().osd().input_update();
 
 	emulator_info::periodic_check();
 

--- a/src/emu/video.cpp
+++ b/src/emu/video.cpp
@@ -91,7 +91,7 @@ video_manager::video_manager(running_machine &machine)
 	, m_seconds_to_run(machine.options().seconds_to_run())
 	, m_auto_frameskip(machine.options().auto_frameskip())
 	, m_speed(original_speed_setting())
-	, m_instant_blit(machine.options().instant_blit())
+	, m_low_latency(machine.options().low_latency())
 	, m_empty_skip_count(0)
 	, m_frameskip_level(machine.options().frameskip())
 	, m_frameskip_counter(0)
@@ -230,7 +230,7 @@ void video_manager::frame_update(bool from_debugger)
 
 	// if we're throttling, synchronize before rendering
 	attotime current_time = machine().time();
-	if (!from_debugger && !skipped_it && !m_instant_blit && effective_throttle())
+	if (!from_debugger && !skipped_it && !m_low_latency && effective_throttle())
 		update_throttle(current_time);
 
 	// ask the OSD to update
@@ -238,8 +238,8 @@ void video_manager::frame_update(bool from_debugger)
 	machine().osd().update(!from_debugger && skipped_it);
 	g_profiler.stop();
 
-	// we throttle after rendering instead of before, if instant blitting is enabled
-	if (!from_debugger && !skipped_it && m_instant_blit && effective_throttle())
+	// we synchronize after rendering instead of before, if low latency mode is enabled
+	if (!from_debugger && !skipped_it && m_low_latency && effective_throttle())
 		update_throttle(current_time);
 
 	// get most recent input now

--- a/src/emu/video.h
+++ b/src/emu/video.h
@@ -163,6 +163,7 @@ private:
 	u32                 m_seconds_to_run;           // number of seconds to run before quitting
 	bool                m_auto_frameskip;           // flag: true if we're automatically frameskipping
 	u32                 m_speed;                    // overall speed (*1000)
+	bool                m_instant_blit;             // flag: true if we are throttling after blitting
 
 	// frameskipping
 	u8                  m_empty_skip_count;         // number of empty frames we have skipped

--- a/src/emu/video.h
+++ b/src/emu/video.h
@@ -163,7 +163,7 @@ private:
 	u32                 m_seconds_to_run;           // number of seconds to run before quitting
 	bool                m_auto_frameskip;           // flag: true if we're automatically frameskipping
 	u32                 m_speed;                    // overall speed (*1000)
-	bool                m_instant_blit;             // flag: true if we are throttling after blitting
+	bool                m_low_latency;              // flag: true if we are throttling after blitting
 
 	// frameskipping
 	u8                  m_empty_skip_count;         // number of empty frames we have skipped

--- a/src/osd/mac/osdmac.h
+++ b/src/osd/mac/osdmac.h
@@ -44,7 +44,7 @@ public:
 	// general overridables
 	virtual void init(running_machine &machine) override;
 	virtual void update(bool skip_redraw) override;
-	virtual void input_update(void) override;
+	virtual void input_update() override;
 
 	// input overridables
 	virtual void customize_input_type_list(simple_list<input_type_entry> &typelist) override;

--- a/src/osd/mac/osdmac.h
+++ b/src/osd/mac/osdmac.h
@@ -44,6 +44,7 @@ public:
 	// general overridables
 	virtual void init(running_machine &machine) override;
 	virtual void update(bool skip_redraw) override;
+	virtual void input_update(void) override;
 
 	// input overridables
 	virtual void customize_input_type_list(simple_list<input_type_entry> &typelist) override;

--- a/src/osd/mac/video.cpp
+++ b/src/osd/mac/video.cpp
@@ -117,11 +117,11 @@ void mac_osd_interface::update(bool skip_redraw)
 //  input_update
 //============================================================
 
-void mac_osd_interface::input_update(void)
+void mac_osd_interface::input_update()
 {
 	// poll the joystick values here
-	downcast<mac_osd_interface&>(machine().osd()).process_events_buf();
-	downcast<mac_osd_interface&>(machine().osd()).poll_inputs(machine());
+	process_events_buf();
+	poll_inputs(machine());
 	check_osd_inputs(machine());
 }
 

--- a/src/osd/mac/video.cpp
+++ b/src/osd/mac/video.cpp
@@ -108,13 +108,21 @@ void mac_osd_interface::update(bool skip_redraw)
 //      profiler_mark(PROFILER_END);
 	}
 
-	// poll the joystick values here
-	downcast<mac_osd_interface&>(machine().osd()).poll_inputs(machine());
-
-	check_osd_inputs(machine());
 	// if we're running, disable some parts of the debugger
 	if ((machine().debug_flags & DEBUG_FLAG_OSD_ENABLED) != 0)
 		debugger_update();
+}
+
+//============================================================
+//  input_update
+//============================================================
+
+void mac_osd_interface::input_update(void)
+{
+	// poll the joystick values here
+	downcast<mac_osd_interface&>(machine().osd()).process_events_buf();
+	downcast<mac_osd_interface&>(machine().osd()).poll_inputs(machine());
+	check_osd_inputs(machine());
 }
 
 //============================================================

--- a/src/osd/mac/window.cpp
+++ b/src/osd/mac/window.cpp
@@ -499,9 +499,6 @@ void mac_window_info::update()
 
 			// and redraw now
 
-			// Some configurations require events to be polled in the worker thread
-			downcast< mac_osd_interface& >(machine().osd()).process_events_buf();
-
 			// Check whether window has vector screens
 
 			{

--- a/src/osd/osdepend.h
+++ b/src/osd/osdepend.h
@@ -64,7 +64,7 @@ public:
 	// general overridables
 	virtual void init(running_machine &machine) = 0;
 	virtual void update(bool skip_redraw) = 0;
-	virtual void input_update(void) = 0;
+	virtual void input_update() = 0;
 	virtual void set_verbose(bool print_verbose) = 0;
 
 	// debugger overridables

--- a/src/osd/osdepend.h
+++ b/src/osd/osdepend.h
@@ -64,6 +64,7 @@ public:
 	// general overridables
 	virtual void init(running_machine &machine) = 0;
 	virtual void update(bool skip_redraw) = 0;
+	virtual void input_update(void) = 0;
 	virtual void set_verbose(bool print_verbose) = 0;
 
 	// debugger overridables

--- a/src/osd/sdl/osdsdl.h
+++ b/src/osd/sdl/osdsdl.h
@@ -124,6 +124,7 @@ public:
 	// general overridables
 	virtual void init(running_machine &machine) override;
 	virtual void update(bool skip_redraw) override;
+	virtual void input_update(void) override;
 
 	// input overridables
 	virtual void customize_input_type_list(simple_list<input_type_entry> &typelist) override;

--- a/src/osd/sdl/osdsdl.h
+++ b/src/osd/sdl/osdsdl.h
@@ -124,7 +124,7 @@ public:
 	// general overridables
 	virtual void init(running_machine &machine) override;
 	virtual void update(bool skip_redraw) override;
-	virtual void input_update(void) override;
+	virtual void input_update() override;
 
 	// input overridables
 	virtual void customize_input_type_list(simple_list<input_type_entry> &typelist) override;

--- a/src/osd/sdl/video.cpp
+++ b/src/osd/sdl/video.cpp
@@ -118,11 +118,11 @@ void sdl_osd_interface::update(bool skip_redraw)
 //  input_update
 //============================================================
 
-void sdl_osd_interface::input_update(void)
+void sdl_osd_interface::input_update()
 {
 	// poll the joystick values here
-	downcast<sdl_osd_interface&>(machine().osd()).process_events_buf();
-	downcast<sdl_osd_interface&>(machine().osd()).poll_inputs(machine());
+	process_events_buf();
+	poll_inputs(machine());
 	check_osd_inputs(machine());
 }
 

--- a/src/osd/sdl/video.cpp
+++ b/src/osd/sdl/video.cpp
@@ -109,13 +109,21 @@ void sdl_osd_interface::update(bool skip_redraw)
 //      profiler_mark(PROFILER_END);
 	}
 
-	// poll the joystick values here
-	downcast<sdl_osd_interface&>(machine().osd()).poll_inputs(machine());
-
-	check_osd_inputs(machine());
 	// if we're running, disable some parts of the debugger
 	if ((machine().debug_flags & DEBUG_FLAG_OSD_ENABLED) != 0)
 		debugger_update();
+}
+
+//============================================================
+//  input_update
+//============================================================
+
+void sdl_osd_interface::input_update(void)
+{
+	// poll the joystick values here
+	downcast<sdl_osd_interface&>(machine().osd()).process_events_buf();
+	downcast<sdl_osd_interface&>(machine().osd()).poll_inputs(machine());
+	check_osd_inputs(machine());
 }
 
 //============================================================

--- a/src/osd/sdl/window.cpp
+++ b/src/osd/sdl/window.cpp
@@ -604,9 +604,6 @@ void sdl_window_info::update()
 
 			// and redraw now
 
-			// Some configurations require events to be polled in the worker thread
-			downcast< sdl_osd_interface& >(machine().osd()).process_events_buf();
-
 			// Check whether window has vector screens
 
 			{

--- a/src/osd/uwp/video.cpp
+++ b/src/osd/uwp/video.cpp
@@ -103,15 +103,22 @@ void windows_osd_interface::update(bool skip_redraw)
 //      profiler_mark(PROFILER_END);
 	}
 
-	// poll the joystick values here
-	winwindow_process_events(machine(), true, false);
-	poll_input(machine());
-	check_osd_inputs();
 	// if we're running, disable some parts of the debugger
 	if ((machine().debug_flags & DEBUG_FLAG_OSD_ENABLED) != 0)
 		debugger_update();
 }
 
+//============================================================
+//  input_update
+//============================================================
+
+void windows_osd_interface::input_update(void)
+{
+	// poll the joystick values here
+	winwindow_process_events(machine(), true, false);
+	poll_input(machine());
+	check_osd_inputs();
+}
 
 //============================================================
 //  check_osd_inputs

--- a/src/osd/uwp/video.cpp
+++ b/src/osd/uwp/video.cpp
@@ -112,7 +112,7 @@ void windows_osd_interface::update(bool skip_redraw)
 //  input_update
 //============================================================
 
-void windows_osd_interface::input_update(void)
+void windows_osd_interface::input_update()
 {
 	// poll the joystick values here
 	winwindow_process_events(machine(), true, false);

--- a/src/osd/windows/video.cpp
+++ b/src/osd/windows/video.cpp
@@ -95,15 +95,23 @@ void windows_osd_interface::update(bool skip_redraw)
 //      profiler_mark(PROFILER_END);
 	}
 
-	// poll the joystick values here
-	winwindow_process_events(machine(), true, false);
-	poll_input(machine());
-	check_osd_inputs();
 	// if we're running, disable some parts of the debugger
 	if ((machine().debug_flags & DEBUG_FLAG_OSD_ENABLED) != 0)
 		debugger_update();
 }
 
+
+//============================================================
+//  input_update
+//============================================================
+
+void windows_osd_interface::input_update(void)
+{
+	// poll the joystick values here
+	winwindow_process_events(machine(), true, false);
+	poll_input(machine());
+	check_osd_inputs();
+}
 
 //============================================================
 //  check_osd_inputs

--- a/src/osd/windows/video.cpp
+++ b/src/osd/windows/video.cpp
@@ -105,7 +105,7 @@ void windows_osd_interface::update(bool skip_redraw)
 //  input_update
 //============================================================
 
-void windows_osd_interface::input_update(void)
+void windows_osd_interface::input_update()
 {
 	// poll the joystick values here
 	winwindow_process_events(machine(), true, false);

--- a/src/osd/windows/winmain.h
+++ b/src/osd/windows/winmain.h
@@ -280,7 +280,7 @@ public:
 	// general overridables
 	virtual void init(running_machine &machine) override;
 	virtual void update(bool skip_redraw) override;
-	virtual void input_update(void) override;
+	virtual void input_update() override;
 
 	// input overrideables
 	virtual void customize_input_type_list(simple_list<input_type_entry> &typelist) override;

--- a/src/osd/windows/winmain.h
+++ b/src/osd/windows/winmain.h
@@ -280,6 +280,7 @@ public:
 	// general overridables
 	virtual void init(running_machine &machine) override;
 	virtual void update(bool skip_redraw) override;
+	virtual void input_update(void) override;
 
 	// input overrideables
 	virtual void customize_input_type_list(simple_list<input_type_entry> &typelist) override;


### PR DESCRIPTION
**Remove up to one frame of input latency. Makes MAME virtually lagless on VRR monitors.**

MAME has currently two sources of input latency:

1.- Main loop arrangement: inputs are not polled at the optimal moment.
2.- Frame buffering associated to v-sync.

Fixing (1) is very straight-forward and is the purpose of this patch.
Fixing (2) is a complex task, that requires direct raster polling (GroovyMAME) or backend specific features (waitable object swapchain).

Modern VRR screens don't require v-sync, so fixing (1) is all we need to get latency as low as it gets.

The existing design polls input too early, before throttling:

- Emulate frame 1
- Render + poll input
- Throttle
- Emulate frame 2
- ...

When it's time is to emulate frame 2, input information is nearly one frame too old. In order to minimize this issue, we need to poll input as late as possible, before starting the emulation of frame #2:

- Emulate frame 1
- Render
- Throttle
- Poll input
- Emulate frame 2
- ...

Currently input polling is called directly from the video update function. So we need to move that to a separate function so both things can be called independently.

**Latency tests**

In the past, we've done lots of gameplay's input latency measurements from high speed camera footage, using a LED wired to a button to get accurate results. This method is extremely time consuming and incovenient.

Fortunately, **Radek Dutkiewicz (oomek)** has gently donated one of his prototype **Game Input Lag Testers (G.I.L.T.)**, which I'm currently beta-testing. Thanks to this device I can do several latency tests in minutes, accurately tracking how specific source changes impact latency.

G.I.L.T interfaces with MAME by means of a LUA script: https://github.com/oomek/GILT

Here are the results, before and after this modification, on different video backends:

```
						latency in ms*		
						before	after	difference
mame64 sf2 -video bgfx -bgfx_backend d3d11	19,99	4,16	15,83
mame64 sf2 -video bgfx -bgfx_backend opengl	20,12	4,53	15,59
mame64 sf2 -video bgfx -bgfx_backend vulkan	22,17	6,46	15,71
mame64 sf2 -video d3d				19,57	4,06	15,51
mame64 sf2 -video opengl			19,55	4,06	15,49
```

* 1 frame = 16.77ms

Testing system:
Windows 10, 1903
AMD Ryzen 7 2700X
Radeon RX Vega 56 - Adrenaline 19.9.2
LG 32UD99 (UHD 4K) - Freesync ON

[Download test results here](https://drive.google.com/open?id=17EdQ17NvVxUOFw7dW-Hpdul18143vQPJ)


These tests show a consistent reduction of almost one frame of latency in all renderers. Sub-frame latency figures indicate next-frame response, closely matching original hardware behaviour.

The longer the emulator stays idle (throttling), the greater latency reduction achieved. In other words, systems that are emulated faster will have less latency. The optimal benefit is obtained with v-sync off (e.g. VRR) where all throttling is based on CPU.

With v-sync on, there's still some potential benefit too, but it depends of how long the emulator stays in throttling, which in turn depends on how the game's refresh aligns with the screen's refresh. However, if throttling is disabled with v-sync on (-nothrottle -waitvsync), like it's usually done to achieve smooth scrolling, there will be no benefit, since inputs will be polled immediately after rendering. Latency figures with vsync-on are terrible nevertheless.

Tests have been performed on Windows 10, Linux (Doozer and I) and Mac (keilmillerjr). UWP has not been tested.
