### PR TITLE
ins8250: reverted BAUDOUT pin support and documented findings in eispc.cpp

### DIFF
--- a/src/devices/machine/ins8250.cpp
+++ b/src/devices/machine/ins8250.cpp
@@ -100,8 +100,6 @@ History:
 #include <algorithm>
 
 //#define VERBOSE 1
-//#define LOG_OUTPUT_STREAM std::cout
-
 #include "logmacro.h"
 
 DEFINE_DEVICE_TYPE(INS8250,  ins8250_device, "ins8250",  "National Semiconductor INS8250 UART")
@@ -119,9 +117,6 @@ ins8250_uart_device::ins8250_uart_device(const machine_config &mconfig, device_t
 	, m_out_int_cb(*this)
 	, m_out_out1_cb(*this)
 	, m_out_out2_cb(*this)
-	, m_out_baudout_cb(*this)
-	, m_brg_clock(true)
-	, m_txd(1)
 	, m_rxd(1)
 	, m_dcd(1)
 	, m_dsr(1)
@@ -250,34 +245,16 @@ READ_LINE_MEMBER(ins8250_uart_device::intrpt_r)
 	return !BIT(m_regs.iir, 0);
 }
 
-TIMER_CALLBACK_MEMBER(ins8250_uart_device::brg_clock)
-{
-	bool state = m_brg_clock;
-	if (!is_transmit_register_empty())
-	{
-		device_serial_interface::tx_clock_w(m_brg_clock);
-		m_brg_clock = !state;
-	}
-	if (is_receive_register_synchronized())
-	{
-		if (m_out_baudout_cb.isnull())
-		{
-			device_serial_interface::rx_clock_w(m_brg_clock);
-		}
-		else
-		{
-			m_out_baudout_cb(m_brg_clock);
-		}
-		m_brg_clock = !state;
-	}
-	m_brg->adjust(((clock() && (m_regs.dl) ? (attotime::from_hz(clock()) * m_regs.dl * 16) : attotime::never) / 2));
-}
-
 // Baud rate generator is reset after writing to either byte of divisor latch
 void ins8250_uart_device::update_baud_rate()
 {
 	LOG("%.1f baud selected (divisor = %d)\n", double(clock()) / (m_regs.dl * 16), m_regs.dl);
-	m_brg->adjust(((clock() && (m_regs.dl) ? (attotime::from_hz(clock()) * m_regs.dl * 16) : attotime::never) / 2));
+	set_rate(clock(), m_regs.dl * 16);
+
+	// FIXME: Baud rate generator should not affect transmitter or receiver, but device_serial_interface resets them regardless.
+	// If the transmitter is still running at this time and we don't flush it, the shift register will never be emptied!
+	if (!(m_regs.lsr & INS8250_LSR_TSRE))
+		tra_complete();
 }
 
 void ins8250_uart_device::ins8250_w(offs_t offset, u8 data)
@@ -627,11 +604,6 @@ void ins8250_uart_device::update_msr()
 		trigger_int(COM_INT_PENDING_MODEM_STATUS_REGISTER);
 }
 
-WRITE_LINE_MEMBER(ins8250_uart_device::rclk_w)
-{
-	device_serial_interface::rx_clock_w(state);
-}
-
 WRITE_LINE_MEMBER(ins8250_uart_device::dcd_w)
 {
 	m_dcd = state;
@@ -672,10 +644,9 @@ void ins8250_uart_device::device_start()
 	m_out_int_cb.resolve_safe();
 	m_out_out1_cb.resolve_safe();
 	m_out_out2_cb.resolve_safe();
-	m_out_baudout_cb.resolve();
 	set_tra_rate(0);
 	set_rcv_rate(0);
-	m_brg = device().machine().scheduler().timer_alloc(timer_expired_delegate(FUNC(ins8250_uart_device::brg_clock), this));
+
 	save_item(NAME(m_regs.thr));
 	save_item(NAME(m_regs.rbr));
 	save_item(NAME(m_regs.ier));
@@ -688,7 +659,6 @@ void ins8250_uart_device::device_start()
 	save_item(NAME(m_regs.msr));
 	save_item(NAME(m_regs.scr));
 	save_item(NAME(m_int_pending));
-	save_item(NAME(m_brg_clock));
 	save_item(NAME(m_txd));
 	save_item(NAME(m_rxd));
 	save_item(NAME(m_dcd));
@@ -710,14 +680,12 @@ void ins8250_uart_device::device_reset()
 	update_interrupt();
 	receive_register_reset();
 	transmit_register_reset();
-	m_brg_clock = true;
 	m_txd = 1;
 	m_out_tx_cb(1);
 	m_out_rts_cb(1);
 	m_out_dtr_cb(1);
 	m_out_out1_cb(1);
 	m_out_out2_cb(1);
-	if (!m_out_baudout_cb.isnull()) m_out_baudout_cb(1);
 }
 
 void ns16550_device::device_start()

--- a/src/devices/machine/ins8250.h
+++ b/src/devices/machine/ins8250.h
@@ -26,12 +26,10 @@ public:
 	auto out_int_callback() { return m_out_int_cb.bind(); }
 	auto out_out1_callback() { return m_out_out1_cb.bind(); }
 	auto out_out2_callback() { return m_out_out2_cb.bind(); }
-	auto out_baudout_callback() { return m_out_baudout_cb.bind(); }
 
 	void ins8250_w(offs_t offset, u8 data);
 	u8 ins8250_r(offs_t offset);
 
-	DECLARE_WRITE_LINE_MEMBER(rclk_w);
 	DECLARE_WRITE_LINE_MEMBER(dcd_w);
 	DECLARE_WRITE_LINE_MEMBER(dsr_w);
 	DECLARE_WRITE_LINE_MEMBER(ri_w);
@@ -88,11 +86,6 @@ private:
 	devcb_write_line    m_out_int_cb;
 	devcb_write_line    m_out_out1_cb;
 	devcb_write_line    m_out_out2_cb;
-	devcb_write_line    m_out_baudout_cb;
-
-	emu_timer *m_brg;
-	TIMER_CALLBACK_MEMBER(brg_clock);
-	bool m_brg_clock;
 
 	void update_interrupt();
 	void update_msr();

--- a/src/mame/drivers/eispc.cpp
+++ b/src/mame/drivers/eispc.cpp
@@ -536,7 +536,11 @@ TIMER_CALLBACK_MEMBER(epc_state::rxtxclk_w)
 	m_kbd8251->write_rxc(m_8251rxtx_clk_state);
 	m_kbd8251->write_txc(m_8251rxtx_clk_state);
 
-	if (!m_8251dtr_state) m_uart->rclk_w(m_8251rxtx_clk_state);
+	// The EPC PCB has an option to support a custom receive clock for the INS8250 apart from the TX clock through a mux controlled
+	// by the DTR pin of the I8251. The ins8250 device doesn't support RCLK as it is considerd implicitly as the same as BAUDOUT
+	// First attempt to support this in INS8250 by lifting out the BRG from deserial was reverted due to lots of regressions.
+	// We probably need to remove diserial dependencies completely from ins8250 or implement BRG hooks in diserial.cpp.  
+	// if (!m_8251dtr_state) m_uart->rclk_w(m_8251rxtx_clk_state); // TODO: fix RCLK support in INS8250
 
 	m_8251rxtx_clk_state = !m_8251rxtx_clk_state;
 
@@ -852,7 +856,7 @@ void epc_state::epc(machine_config &config)
 	});
 	m_kbd8251->dtr_handler().set([this](bool state) // Controls RCLK for INS8250, either 19.2KHz or INS8250 BAUDOUT
 	{
-		LOGCOM("KBD DTR: %d\n", state ? 1 : 0); // TODO: Implement clock selection mux, need to check what state does what
+		LOGCOM("KBD DTR: %d\n", state ? 1 : 0);
 		m_8251dtr_state = state;
 	});
 
@@ -934,7 +938,7 @@ void epc_state::epc(machine_config &config)
 	FLOPPY_CONNECTOR(config, m_floppy_connectors[1], epc_sd_floppies, "525sd", epc_floppy_formats);
 	//SOFTWARE_LIST(config, "epc_flop_list").set_original("epc_flop");
 
-	// system board UART TODO: Implement the descrete "Baud Rate Clock" from schematics that generates clocks for the 8250
+	// system board UART
 	INS8250(config, m_uart, XTAL(18'432'000) / 10); // TEW crystal marked X2 verified. TODO: Let 8051 DTR control RCLK (see above)
 	m_uart->out_tx_callback().set("com1", FUNC(rs232_port_device::write_txd));
 	m_uart->out_dtr_callback().set("com1", FUNC(rs232_port_device::write_dtr));
@@ -946,7 +950,7 @@ void epc_state::epc(machine_config &config)
 		if ((m_io_j10->read() & 0x30) == 0x20) { LOGCOM("UART IRQ4: %d\n", state); m_pic8259->ir4_w(state); } // Factory setting
 		if ((m_io_j10->read() & 0xc0) == 0x80) { LOGCOM("UART IRQ7: %d\n", state); m_pic8259->ir7_w(state); }
 	});
-	m_uart->out_baudout_callback().set([this](int state){ if (m_8251dtr_state) m_uart->rclk_w(state); });
+	// m_uart->out_baudout_callback().set([this](int state){ if (m_8251dtr_state) m_uart->rclk_w(state); }); // TODO: Fix INS8250 BAUDOUT pin support
 
 	rs232_port_device &rs232(RS232_PORT(config, "com1", default_rs232_devices, nullptr));
 	rs232.rxd_handler().set(m_uart, FUNC(ins8250_uart_device::rx_w));


### PR DESCRIPTION
Sadly there were lots if regression side effects of my simple attempt to add this feature that I don't have time to sort out at the moment, so I revert it.