### PR TITLE
mb8421.cpp : Support variable size and data width, Use template for base device, Add notes

### DIFF
--- a/src/devices/machine/mb8421.cpp
+++ b/src/devices/machine/mb8421.cpp
@@ -33,10 +33,10 @@ DEFINE_DEVICE_TYPE(MB8421_MB8431_16BIT, mb8421_mb8431_16_device, "mb8421_mb8431_
 //  dual_port_mailbox_ram_base - constructor
 //-------------------------------------------------
 
-dual_port_mailbox_ram_base::dual_port_mailbox_ram_base(const machine_config &mconfig, device_type type, const char *tag, device_t *owner, u32 clock, size_t ram_size, u8 data_bits)
+dual_port_mailbox_ram_base::dual_port_mailbox_ram_base(const machine_config &mconfig, device_type type, const char *tag, device_t *owner, u32 clock, size_t addr_bits, u8 data_bits)
 	: device_t(mconfig, type, tag, owner, clock)
 	, m_data_mask((1 << data_bits) - 1)
-	, m_ram_size(ram_size)
+	, m_ram_size(1 << addr_bits)
 	, m_ram_mask(m_ram_size - 1)
 	, m_int_addr_left(m_ram_mask - 1) // max RAM word size - 2
 	, m_int_addr_right(m_ram_mask) // max RAM word size - 1
@@ -49,8 +49,8 @@ dual_port_mailbox_ram_base::dual_port_mailbox_ram_base(const machine_config &mco
 //  dual_port_mailbox_ram_8bit_base - constructor
 //-------------------------------------------------
 
-dual_port_mailbox_ram_8bit_base::dual_port_mailbox_ram_8bit_base(const machine_config &mconfig, device_type type, const char *tag, device_t *owner, u32 clock, size_t ram_size, u8 data_bits)
-	: dual_port_mailbox_ram_base(mconfig, type, tag, owner, clock, ram_size, data_bits)
+dual_port_mailbox_ram_8bit_base::dual_port_mailbox_ram_8bit_base(const machine_config &mconfig, device_type type, const char *tag, device_t *owner, u32 clock, size_t addr_bits, u8 data_bits)
+	: dual_port_mailbox_ram_base(mconfig, type, tag, owner, clock, addr_bits, data_bits)
 {
 }
 
@@ -58,8 +58,8 @@ dual_port_mailbox_ram_8bit_base::dual_port_mailbox_ram_8bit_base(const machine_c
 //  dual_port_mailbox_ram_16bit_base - constructor
 //-------------------------------------------------
 
-dual_port_mailbox_ram_16bit_base::dual_port_mailbox_ram_16bit_base(const machine_config &mconfig, device_type type, const char *tag, device_t *owner, u32 clock, size_t ram_size, u8 data_bits)
-	: dual_port_mailbox_ram_base(mconfig, type, tag, owner, clock, ram_size >> 1, data_bits)
+dual_port_mailbox_ram_16bit_base::dual_port_mailbox_ram_16bit_base(const machine_config &mconfig, device_type type, const char *tag, device_t *owner, u32 clock, size_t addr_bits, u8 data_bits)
+	: dual_port_mailbox_ram_base(mconfig, type, tag, owner, clock, addr_bits, data_bits)
 {
 }
 
@@ -68,7 +68,7 @@ dual_port_mailbox_ram_16bit_base::dual_port_mailbox_ram_16bit_base(const machine
 //-------------------------------------------------
 
 cy7c131_device::cy7c131_device(const machine_config &mconfig, const char *tag, device_t *owner, u32 clock)
-	: dual_port_mailbox_ram_8bit_base(mconfig, CY7C131, tag, owner, clock, 0x400)
+	: dual_port_mailbox_ram_8bit_base(mconfig, CY7C131, tag, owner, clock, 10, 8) // 1kx8
 {
 }
 
@@ -77,7 +77,7 @@ cy7c131_device::cy7c131_device(const machine_config &mconfig, const char *tag, d
 //-------------------------------------------------
 
 idt7130_device::idt7130_device(const machine_config &mconfig, const char *tag, device_t *owner, u32 clock)
-	: dual_port_mailbox_ram_8bit_base(mconfig, IDT7130, tag, owner, clock, 0x400)
+	: dual_port_mailbox_ram_8bit_base(mconfig, IDT7130, tag, owner, clock, 10, 8) // 1kx8
 {
 }
 
@@ -86,7 +86,7 @@ idt7130_device::idt7130_device(const machine_config &mconfig, const char *tag, d
 //-------------------------------------------------
 
 mb8421_device::mb8421_device(const machine_config &mconfig, const char *tag, device_t *owner, u32 clock)
-	: dual_port_mailbox_ram_8bit_base(mconfig, MB8421, tag, owner, clock, 0x800)
+	: dual_port_mailbox_ram_8bit_base(mconfig, MB8421, tag, owner, clock, 11, 8) // 2kx8
 {
 }
 
@@ -95,7 +95,7 @@ mb8421_device::mb8421_device(const machine_config &mconfig, const char *tag, dev
 //-------------------------------------------------
 
 idt71321_device::idt71321_device(const machine_config &mconfig, const char *tag, device_t *owner, u32 clock)
-	: dual_port_mailbox_ram_8bit_base(mconfig, IDT71321, tag, owner, clock, 0x800)
+	: dual_port_mailbox_ram_8bit_base(mconfig, IDT71321, tag, owner, clock, 11, 8) // 2kx8
 {
 }
 
@@ -104,7 +104,7 @@ idt71321_device::idt71321_device(const machine_config &mconfig, const char *tag,
 //-------------------------------------------------
 
 mb8421_mb8431_16_device::mb8421_mb8431_16_device(const machine_config &mconfig, const char *tag, device_t *owner, u32 clock)
-	: dual_port_mailbox_ram_16bit_base(mconfig, MB8421_MB8431_16BIT, tag, owner, clock, 0x1000)
+	: dual_port_mailbox_ram_16bit_base(mconfig, MB8421_MB8431_16BIT, tag, owner, clock, 11, 16) // 2kx16
 {
 }
 

--- a/src/devices/machine/mb8421.cpp
+++ b/src/devices/machine/mb8421.cpp
@@ -20,12 +20,14 @@
 #include "emu.h"
 #include "machine/mb8421.h"
 
-
-DEFINE_DEVICE_TYPE(MB8421, mb8421_device, "mb8421", "MB8421 8-bit Dual-Port SRAM with Interrupts")
-DEFINE_DEVICE_TYPE(IDT7130, idt7130_device, "idt7130", "IDT7130 8-bit Dual-Port SRAM with Interrupts")
-DEFINE_DEVICE_TYPE(CY7C131, cy7c131_device, "cy7c131", "CY7C131 8-bit Dual-Port SRAM with Interrupts")
-DEFINE_DEVICE_TYPE(IDT71321, idt71321_device, "idt71321", "IDT71321 8-bit Dual-Port SRAM with Interrupts")
-DEFINE_DEVICE_TYPE(MB8421_MB8431_16BIT, mb8421_mb8431_16_device, "mb8421_mb8431_16", "MB8421/MB8431 16-bit Dual-Port SRAM with Interrupts")
+// 1Kx8
+DEFINE_DEVICE_TYPE(IDT7130,             idt7130_device,          "idt7130",          "IDT 7130 8-bit Dual-Port SRAM with Interrupts")
+DEFINE_DEVICE_TYPE(CY7C131,             cy7c131_device,          "cy7c131",          "Cypress CY7C131 8-bit Dual-Port SRAM with Interrupts")
+// 2Kx8
+DEFINE_DEVICE_TYPE(MB8421,              mb8421_device,           "mb8421",           "Fujitsu MB8421 8-bit Dual-Port SRAM with Interrupts")
+DEFINE_DEVICE_TYPE(IDT71321,            idt71321_device,         "idt71321",         "IDT 71321 8-bit Dual-Port SRAM with Interrupts")
+// 2Kx16
+DEFINE_DEVICE_TYPE(MB8421_MB8431_16BIT, mb8421_mb8431_16_device, "mb8421_mb8431_16", "Fujitsu MB8421/MB8431 16-bit Dual-Port SRAM with Interrupts")
 
 //-------------------------------------------------
 //  dual_port_mailbox_ram_base - constructor

--- a/src/devices/machine/mb8421.cpp
+++ b/src/devices/machine/mb8421.cpp
@@ -29,7 +29,7 @@ DEFINE_DEVICE_TYPE(MB8421_MB8431_16BIT, mb8421_mb8431_16_device, "mb8421_mb8431_
 //  mb8421_master_device - constructor
 //-------------------------------------------------
 
-mb8421_master_device::mb8421_master_device(const machine_config &mconfig, device_type type, const char *tag, device_t *owner, u32 clock, size_t ram_size, u64 data_mask)
+mb8421_master_device::mb8421_master_device(const machine_config &mconfig, device_type type, const char *tag, device_t *owner, u32 clock, size_t ram_size, u64 data_bits)
 	: device_t(mconfig, type, tag, owner, clock)
 	, m_intl_callback(*this)
 	, m_intr_callback(*this)
@@ -38,15 +38,15 @@ mb8421_master_device::mb8421_master_device(const machine_config &mconfig, device
 	m_ram_mask = ram_size - 1;
 	m_int_addr_left = ram_size - 2;
 	m_int_addr_right = ram_size - 1;
-	m_data_mask = data_mask;
+	m_data_mask = (1 << data_bits) - 1;
 }
 
 //-------------------------------------------------
 //  mb8421_master_8bit_device - constructor
 //-------------------------------------------------
 
-mb8421_master_8bit_device::mb8421_master_8bit_device(const machine_config &mconfig, device_type type, const char *tag, device_t *owner, u32 clock, size_t ram_size, u8 data_mask)
-	: mb8421_master_device(mconfig, type, tag, owner, clock, ram_size, data_mask)
+mb8421_master_8bit_device::mb8421_master_8bit_device(const machine_config &mconfig, device_type type, const char *tag, device_t *owner, u32 clock, size_t ram_size, u8 data_bits)
+	: mb8421_master_device(mconfig, type, tag, owner, clock, ram_size, data_bits)
 {
 }
 
@@ -54,8 +54,8 @@ mb8421_master_8bit_device::mb8421_master_8bit_device(const machine_config &mconf
 //  mb8421_master_16bit_device - constructor
 //-------------------------------------------------
 
-mb8421_master_16bit_device::mb8421_master_16bit_device(const machine_config &mconfig, device_type type, const char *tag, device_t *owner, u32 clock, size_t ram_size, u16 data_mask)
-	: mb8421_master_device(mconfig, type, tag, owner, clock, ram_size >> 1, data_mask)
+mb8421_master_16bit_device::mb8421_master_16bit_device(const machine_config &mconfig, device_type type, const char *tag, device_t *owner, u32 clock, size_t ram_size, u8 data_bits)
+	: mb8421_master_device(mconfig, type, tag, owner, clock, ram_size >> 1, data_bits)
 {
 }
 

--- a/src/devices/machine/mb8421.cpp
+++ b/src/devices/machine/mb8421.cpp
@@ -21,11 +21,11 @@
 #include "machine/mb8421.h"
 
 // 1Kx8
-DEFINE_DEVICE_TYPE(IDT7130,             idt7130_device,          "idt7130",          "IDT 7130 8-bit Dual-Port SRAM with Interrupts")
 DEFINE_DEVICE_TYPE(CY7C131,             cy7c131_device,          "cy7c131",          "Cypress CY7C131 8-bit Dual-Port SRAM with Interrupts")
+DEFINE_DEVICE_TYPE(IDT7130,             idt7130_device,          "idt7130",          "IDT 7130 8-bit Dual-Port SRAM with Interrupts")
 // 2Kx8
-DEFINE_DEVICE_TYPE(MB8421,              mb8421_device,           "mb8421",           "Fujitsu MB8421 8-bit Dual-Port SRAM with Interrupts")
 DEFINE_DEVICE_TYPE(IDT71321,            idt71321_device,         "idt71321",         "IDT 71321 8-bit Dual-Port SRAM with Interrupts")
+DEFINE_DEVICE_TYPE(MB8421,              mb8421_device,           "mb8421",           "Fujitsu MB8421 8-bit Dual-Port SRAM with Interrupts")
 // 2Kx16
 DEFINE_DEVICE_TYPE(MB8421_MB8431_16BIT, mb8421_mb8431_16_device, "mb8421_mb8431_16", "Fujitsu MB8421/MB8431 16-bit Dual-Port SRAM with Interrupts")
 
@@ -33,7 +33,8 @@ DEFINE_DEVICE_TYPE(MB8421_MB8431_16BIT, mb8421_mb8431_16_device, "mb8421_mb8431_
 //  dual_port_mailbox_ram_base - constructor
 //-------------------------------------------------
 
-dual_port_mailbox_ram_base::dual_port_mailbox_ram_base(const machine_config &mconfig, device_type type, const char *tag, device_t *owner, u32 clock, size_t addr_bits, u8 data_bits)
+template <typename Type>
+dual_port_mailbox_ram_base<Type>::dual_port_mailbox_ram_base(const machine_config &mconfig, device_type type, const char *tag, device_t *owner, u32 clock, size_t addr_bits, u8 data_bits)
 	: device_t(mconfig, type, tag, owner, clock)
 	, m_data_mask((1 << data_bits) - 1)
 	, m_ram_size(1 << addr_bits)
@@ -42,24 +43,7 @@ dual_port_mailbox_ram_base::dual_port_mailbox_ram_base(const machine_config &mco
 	, m_int_addr_right(m_ram_mask) // max RAM word size - 1
 	, m_intl_callback(*this)
 	, m_intr_callback(*this)
-{
-}
-
-//-------------------------------------------------
-//  dual_port_mailbox_ram_8bit_base - constructor
-//-------------------------------------------------
-
-dual_port_mailbox_ram_8bit_base::dual_port_mailbox_ram_8bit_base(const machine_config &mconfig, device_type type, const char *tag, device_t *owner, u32 clock, size_t addr_bits, u8 data_bits)
-	: dual_port_mailbox_ram_base(mconfig, type, tag, owner, clock, addr_bits, data_bits)
-{
-}
-
-//-------------------------------------------------
-//  dual_port_mailbox_ram_16bit_base - constructor
-//-------------------------------------------------
-
-dual_port_mailbox_ram_16bit_base::dual_port_mailbox_ram_16bit_base(const machine_config &mconfig, device_type type, const char *tag, device_t *owner, u32 clock, size_t addr_bits, u8 data_bits)
-	: dual_port_mailbox_ram_base(mconfig, type, tag, owner, clock, addr_bits, data_bits)
+	, m_ram(nullptr)
 {
 }
 
@@ -68,7 +52,7 @@ dual_port_mailbox_ram_16bit_base::dual_port_mailbox_ram_16bit_base(const machine
 //-------------------------------------------------
 
 cy7c131_device::cy7c131_device(const machine_config &mconfig, const char *tag, device_t *owner, u32 clock)
-	: dual_port_mailbox_ram_8bit_base(mconfig, CY7C131, tag, owner, clock, 10, 8) // 1kx8
+	: dual_port_mailbox_ram_base<u8>(mconfig, CY7C131, tag, owner, clock, 10, 8) // 1kx8
 {
 }
 
@@ -77,16 +61,7 @@ cy7c131_device::cy7c131_device(const machine_config &mconfig, const char *tag, d
 //-------------------------------------------------
 
 idt7130_device::idt7130_device(const machine_config &mconfig, const char *tag, device_t *owner, u32 clock)
-	: dual_port_mailbox_ram_8bit_base(mconfig, IDT7130, tag, owner, clock, 10, 8) // 1kx8
-{
-}
-
-//-------------------------------------------------
-//  mb8421_device - constructor
-//-------------------------------------------------
-
-mb8421_device::mb8421_device(const machine_config &mconfig, const char *tag, device_t *owner, u32 clock)
-	: dual_port_mailbox_ram_8bit_base(mconfig, MB8421, tag, owner, clock, 11, 8) // 2kx8
+	: dual_port_mailbox_ram_base<u8>(mconfig, IDT7130, tag, owner, clock, 10, 8) // 1kx8
 {
 }
 
@@ -95,7 +70,16 @@ mb8421_device::mb8421_device(const machine_config &mconfig, const char *tag, dev
 //-------------------------------------------------
 
 idt71321_device::idt71321_device(const machine_config &mconfig, const char *tag, device_t *owner, u32 clock)
-	: dual_port_mailbox_ram_8bit_base(mconfig, IDT71321, tag, owner, clock, 11, 8) // 2kx8
+	: dual_port_mailbox_ram_base<u8>(mconfig, IDT71321, tag, owner, clock, 11, 8) // 2kx8
+{
+}
+
+//-------------------------------------------------
+//  mb8421_device - constructor
+//-------------------------------------------------
+
+mb8421_device::mb8421_device(const machine_config &mconfig, const char *tag, device_t *owner, u32 clock)
+	: dual_port_mailbox_ram_base<u8>(mconfig, MB8421, tag, owner, clock, 11, 8) // 2kx8
 {
 }
 
@@ -104,7 +88,7 @@ idt71321_device::idt71321_device(const machine_config &mconfig, const char *tag,
 //-------------------------------------------------
 
 mb8421_mb8431_16_device::mb8421_mb8431_16_device(const machine_config &mconfig, const char *tag, device_t *owner, u32 clock)
-	: dual_port_mailbox_ram_16bit_base(mconfig, MB8421_MB8431_16BIT, tag, owner, clock, 11, 16) // 2kx16
+	: dual_port_mailbox_ram_base<u16>(mconfig, MB8421_MB8431_16BIT, tag, owner, clock, 11, 16) // 2kx16
 {
 }
 
@@ -114,7 +98,8 @@ mb8421_mb8431_16_device::mb8421_mb8431_16_device(const machine_config &mconfig, 
 //  initial conditions at start time
 //-------------------------------------------------
 
-void dual_port_mailbox_ram_base::device_resolve_objects()
+template <typename Type>
+void dual_port_mailbox_ram_base<Type>::device_resolve_objects()
 {
 	// resolve callbacks
 	m_intl_callback.resolve_safe();
@@ -125,17 +110,10 @@ void dual_port_mailbox_ram_base::device_resolve_objects()
 //  device_start - device-specific startup
 //-------------------------------------------------
 
-void dual_port_mailbox_ram_8bit_base::device_start()
+template <typename Type>
+void dual_port_mailbox_ram_base<Type>::device_start()
 {
-	m_ram = make_unique_clear<u8[]>(m_ram_size);
-
-	// state save
-	save_pointer(NAME(m_ram), m_ram_size);
-}
-
-void dual_port_mailbox_ram_16bit_base::device_start()
-{
-	m_ram = make_unique_clear<u16[]>(m_ram_size);
+	m_ram = make_unique_clear<Type[]>(m_ram_size);
 
 	// state save
 	save_pointer(NAME(m_ram), m_ram_size);
@@ -145,105 +123,9 @@ void dual_port_mailbox_ram_16bit_base::device_start()
 //  device_reset - device-specific reset
 //-------------------------------------------------
 
-void dual_port_mailbox_ram_base::device_reset()
+template <typename Type>
+void dual_port_mailbox_ram_base<Type>::device_reset()
 {
 	m_intl_callback(CLEAR_LINE);
 	m_intr_callback(CLEAR_LINE);
-}
-
-//-------------------------------------------------
-//  update_intr - update interrupt lines upon
-//  read or write accesses to special locations
-//-------------------------------------------------
-
-template<read_or_write row, bool is_right>
-void dual_port_mailbox_ram_base::update_intr(offs_t offset)
-{
-	if (machine().side_effects_disabled())
-		return;
-
-	if (row == read_or_write::WRITE && offset == (is_right ? m_int_addr_left : m_int_addr_right))
-		(is_right ? m_intl_callback : m_intr_callback)(ASSERT_LINE);
-	else if (row == read_or_write::READ && offset == (is_right ? m_int_addr_right : m_int_addr_left))
-		(is_right ? m_intr_callback : m_intl_callback)(CLEAR_LINE);
-}
-
-//-------------------------------------------------
-//  left_w - write access for left-side bus
-//  (write to 7FF asserts INTR)
-//-------------------------------------------------
-
-void dual_port_mailbox_ram_8bit_base::left_w(offs_t offset, u8 data)
-{
-	offset &= m_ram_mask;
-	data &= m_data_mask;
-	m_ram[offset] = data;
-	update_intr<read_or_write::WRITE, false>(offset);
-}
-
-void dual_port_mailbox_ram_16bit_base::left_w(offs_t offset, u16 data, u16 mem_mask)
-{
-	offset &= m_ram_mask;
-	data &= m_data_mask;
-	COMBINE_DATA(&m_ram[offset]);
-	update_intr<read_or_write::WRITE, false>(offset);
-}
-
-//-------------------------------------------------
-//  left_r - read access for left-side bus
-//  (read from 7FE acknowledges INTL)
-//-------------------------------------------------
-
-u8 dual_port_mailbox_ram_8bit_base::left_r(offs_t offset)
-{
-	offset &= m_ram_mask;
-	update_intr<read_or_write::READ, false>(offset);
-	return m_ram[offset];
-}
-
-u16 dual_port_mailbox_ram_16bit_base::left_r(offs_t offset, u16 mem_mask)
-{
-	offset &= m_ram_mask;
-	update_intr<read_or_write::READ, false>(offset);
-	return m_ram[offset];
-}
-
-//-------------------------------------------------
-//  right_w - write access for right-side bus
-//  (write to 7FE asserts INTL)
-//-------------------------------------------------
-
-void dual_port_mailbox_ram_8bit_base::right_w(offs_t offset, u8 data)
-{
-	offset &= m_ram_mask;
-	data &= m_data_mask;
-	m_ram[offset] = data;
-	update_intr<read_or_write::WRITE, true>(offset);
-}
-
-void dual_port_mailbox_ram_16bit_base::right_w(offs_t offset, u16 data, u16 mem_mask)
-{
-	offset &= m_ram_mask;
-	data &= m_data_mask;
-	COMBINE_DATA(&m_ram[offset]);
-	update_intr<read_or_write::WRITE, true>(offset);
-}
-
-//-------------------------------------------------
-//  right_r - read access for right-side bus
-//  (read from 7FF acknowledges INTR)
-//-------------------------------------------------
-
-u8 dual_port_mailbox_ram_8bit_base::right_r(offs_t offset)
-{
-	offset &= m_ram_mask;
-	update_intr<read_or_write::READ, true>(offset);
-	return m_ram[offset];
-}
-
-u16 dual_port_mailbox_ram_16bit_base::right_r(offs_t offset, u16 mem_mask)
-{
-	offset &= m_ram_mask;
-	update_intr<read_or_write::READ, true>(offset);
-	return m_ram[offset];
 }

--- a/src/devices/machine/mb8421.cpp
+++ b/src/devices/machine/mb8421.cpp
@@ -20,6 +20,21 @@
 #include "emu.h"
 #include "machine/mb8421.h"
 
+template class dual_port_mailbox_ram_base<u8, 10, 8>;
+template class dual_port_mailbox_ram_base<u8, 11, 8>;
+template class dual_port_mailbox_ram_base<u16, 11, 16>;
+
+template <typename Type, unsigned AddrBits, unsigned DataBits>
+constexpr Type dual_port_mailbox_ram_base<Type, AddrBits, DataBits>::DATA_MASK;
+template <typename Type, unsigned AddrBits, unsigned DataBits>
+constexpr size_t dual_port_mailbox_ram_base<Type, AddrBits, DataBits>::RAM_SIZE;
+template <typename Type, unsigned AddrBits, unsigned DataBits>
+constexpr offs_t dual_port_mailbox_ram_base<Type, AddrBits, DataBits>::ADDR_MASK;
+template <typename Type, unsigned AddrBits, unsigned DataBits>
+constexpr offs_t dual_port_mailbox_ram_base<Type, AddrBits, DataBits>::INT_ADDR_LEFT;
+template <typename Type, unsigned AddrBits, unsigned DataBits>
+constexpr offs_t dual_port_mailbox_ram_base<Type, AddrBits, DataBits>::INT_ADDR_RIGHT;
+
 // 1Kx8
 DEFINE_DEVICE_TYPE(CY7C131,             cy7c131_device,          "cy7c131",          "Cypress CY7C131 8-bit Dual-Port SRAM with Interrupts")
 DEFINE_DEVICE_TYPE(IDT7130,             idt7130_device,          "idt7130",          "IDT 7130 8-bit Dual-Port SRAM with Interrupts")
@@ -28,99 +43,3 @@ DEFINE_DEVICE_TYPE(IDT71321,            idt71321_device,         "idt71321",    
 DEFINE_DEVICE_TYPE(MB8421,              mb8421_device,           "mb8421",           "Fujitsu MB8421 8-bit Dual-Port SRAM with Interrupts")
 // 2Kx16
 DEFINE_DEVICE_TYPE(MB8421_MB8431_16BIT, mb8421_mb8431_16_device, "mb8421_mb8431_16", "Fujitsu MB8421/MB8431 16-bit Dual-Port SRAM with Interrupts")
-
-//-------------------------------------------------
-//  dual_port_mailbox_ram_base - constructor
-//-------------------------------------------------
-
-template <typename Type, unsigned AddrBits, unsigned DataBits>
-dual_port_mailbox_ram_base<Type, AddrBits, DataBits>::dual_port_mailbox_ram_base(const machine_config &mconfig, device_type type, const char *tag, device_t *owner, u32 clock)
-	: device_t(mconfig, type, tag, owner, clock)
-	, m_intl_callback(*this)
-	, m_intr_callback(*this)
-	, m_ram(nullptr)
-{
-}
-
-//-------------------------------------------------
-//  cy7c131_device - constructor
-//-------------------------------------------------
-
-cy7c131_device::cy7c131_device(const machine_config &mconfig, const char *tag, device_t *owner, u32 clock)
-	: dual_port_mailbox_ram_base<u8, 10, 8>(mconfig, CY7C131, tag, owner, clock) // 1kx8
-{
-}
-
-//-------------------------------------------------
-//  idt7130_device - constructor
-//-------------------------------------------------
-
-idt7130_device::idt7130_device(const machine_config &mconfig, const char *tag, device_t *owner, u32 clock)
-	: dual_port_mailbox_ram_base<u8, 10, 8>(mconfig, IDT7130, tag, owner, clock) // 1kx8
-{
-}
-
-//-------------------------------------------------
-//  idt71321_device - constructor
-//-------------------------------------------------
-
-idt71321_device::idt71321_device(const machine_config &mconfig, const char *tag, device_t *owner, u32 clock)
-	: dual_port_mailbox_ram_base<u8, 11, 8>(mconfig, IDT71321, tag, owner, clock) // 2kx8
-{
-}
-
-//-------------------------------------------------
-//  mb8421_device - constructor
-//-------------------------------------------------
-
-mb8421_device::mb8421_device(const machine_config &mconfig, const char *tag, device_t *owner, u32 clock)
-	: dual_port_mailbox_ram_base<u8, 11, 8>(mconfig, MB8421, tag, owner, clock) // 2kx8
-{
-}
-
-//-------------------------------------------------
-//  mb8421_mb8431_16_device - constructor
-//-------------------------------------------------
-
-mb8421_mb8431_16_device::mb8421_mb8431_16_device(const machine_config &mconfig, const char *tag, device_t *owner, u32 clock)
-	: dual_port_mailbox_ram_base<u16, 11, 16>(mconfig, MB8421_MB8431_16BIT, tag, owner, clock) // 2kx16
-{
-}
-
-//-------------------------------------------------
-//  device_resolve_objects - resolve objects that
-//  may be needed for other devices to set
-//  initial conditions at start time
-//-------------------------------------------------
-
-template <typename Type, unsigned AddrBits, unsigned DataBits>
-void dual_port_mailbox_ram_base<Type, AddrBits, DataBits>::device_resolve_objects()
-{
-	// resolve callbacks
-	m_intl_callback.resolve_safe();
-	m_intr_callback.resolve_safe();
-}
-
-//-------------------------------------------------
-//  device_start - device-specific startup
-//-------------------------------------------------
-
-template <typename Type, unsigned AddrBits, unsigned DataBits>
-void dual_port_mailbox_ram_base<Type, AddrBits, DataBits>::device_start()
-{
-	m_ram = make_unique_clear<Type[]>(RAM_SIZE);
-
-	// state save
-	save_pointer(NAME(m_ram), RAM_SIZE);
-}
-
-//-------------------------------------------------
-//  device_reset - device-specific reset
-//-------------------------------------------------
-
-template <typename Type, unsigned AddrBits, unsigned DataBits>
-void dual_port_mailbox_ram_base<Type, AddrBits, DataBits>::device_reset()
-{
-	m_intl_callback(CLEAR_LINE);
-	m_intr_callback(CLEAR_LINE);
-}

--- a/src/devices/machine/mb8421.cpp
+++ b/src/devices/machine/mb8421.cpp
@@ -33,14 +33,9 @@ DEFINE_DEVICE_TYPE(MB8421_MB8431_16BIT, mb8421_mb8431_16_device, "mb8421_mb8431_
 //  dual_port_mailbox_ram_base - constructor
 //-------------------------------------------------
 
-template <typename Type>
-dual_port_mailbox_ram_base<Type>::dual_port_mailbox_ram_base(const machine_config &mconfig, device_type type, const char *tag, device_t *owner, u32 clock, size_t addr_bits, u8 data_bits)
+template <typename Type, unsigned AddrBits, unsigned DataBits>
+dual_port_mailbox_ram_base<Type, AddrBits, DataBits>::dual_port_mailbox_ram_base(const machine_config &mconfig, device_type type, const char *tag, device_t *owner, u32 clock)
 	: device_t(mconfig, type, tag, owner, clock)
-	, m_data_mask((1 << data_bits) - 1)
-	, m_ram_size(1 << addr_bits)
-	, m_ram_mask(m_ram_size - 1)
-	, m_int_addr_left(m_ram_mask - 1) // max RAM word size - 2
-	, m_int_addr_right(m_ram_mask) // max RAM word size - 1
 	, m_intl_callback(*this)
 	, m_intr_callback(*this)
 	, m_ram(nullptr)
@@ -52,7 +47,7 @@ dual_port_mailbox_ram_base<Type>::dual_port_mailbox_ram_base(const machine_confi
 //-------------------------------------------------
 
 cy7c131_device::cy7c131_device(const machine_config &mconfig, const char *tag, device_t *owner, u32 clock)
-	: dual_port_mailbox_ram_base<u8>(mconfig, CY7C131, tag, owner, clock, 10, 8) // 1kx8
+	: dual_port_mailbox_ram_base<u8, 10, 8>(mconfig, CY7C131, tag, owner, clock) // 1kx8
 {
 }
 
@@ -61,7 +56,7 @@ cy7c131_device::cy7c131_device(const machine_config &mconfig, const char *tag, d
 //-------------------------------------------------
 
 idt7130_device::idt7130_device(const machine_config &mconfig, const char *tag, device_t *owner, u32 clock)
-	: dual_port_mailbox_ram_base<u8>(mconfig, IDT7130, tag, owner, clock, 10, 8) // 1kx8
+	: dual_port_mailbox_ram_base<u8, 10, 8>(mconfig, IDT7130, tag, owner, clock) // 1kx8
 {
 }
 
@@ -70,7 +65,7 @@ idt7130_device::idt7130_device(const machine_config &mconfig, const char *tag, d
 //-------------------------------------------------
 
 idt71321_device::idt71321_device(const machine_config &mconfig, const char *tag, device_t *owner, u32 clock)
-	: dual_port_mailbox_ram_base<u8>(mconfig, IDT71321, tag, owner, clock, 11, 8) // 2kx8
+	: dual_port_mailbox_ram_base<u8, 11, 8>(mconfig, IDT71321, tag, owner, clock) // 2kx8
 {
 }
 
@@ -79,7 +74,7 @@ idt71321_device::idt71321_device(const machine_config &mconfig, const char *tag,
 //-------------------------------------------------
 
 mb8421_device::mb8421_device(const machine_config &mconfig, const char *tag, device_t *owner, u32 clock)
-	: dual_port_mailbox_ram_base<u8>(mconfig, MB8421, tag, owner, clock, 11, 8) // 2kx8
+	: dual_port_mailbox_ram_base<u8, 11, 8>(mconfig, MB8421, tag, owner, clock) // 2kx8
 {
 }
 
@@ -88,7 +83,7 @@ mb8421_device::mb8421_device(const machine_config &mconfig, const char *tag, dev
 //-------------------------------------------------
 
 mb8421_mb8431_16_device::mb8421_mb8431_16_device(const machine_config &mconfig, const char *tag, device_t *owner, u32 clock)
-	: dual_port_mailbox_ram_base<u16>(mconfig, MB8421_MB8431_16BIT, tag, owner, clock, 11, 16) // 2kx16
+	: dual_port_mailbox_ram_base<u16, 11, 16>(mconfig, MB8421_MB8431_16BIT, tag, owner, clock) // 2kx16
 {
 }
 
@@ -98,8 +93,8 @@ mb8421_mb8431_16_device::mb8421_mb8431_16_device(const machine_config &mconfig, 
 //  initial conditions at start time
 //-------------------------------------------------
 
-template <typename Type>
-void dual_port_mailbox_ram_base<Type>::device_resolve_objects()
+template <typename Type, unsigned AddrBits, unsigned DataBits>
+void dual_port_mailbox_ram_base<Type, AddrBits, DataBits>::device_resolve_objects()
 {
 	// resolve callbacks
 	m_intl_callback.resolve_safe();
@@ -110,21 +105,21 @@ void dual_port_mailbox_ram_base<Type>::device_resolve_objects()
 //  device_start - device-specific startup
 //-------------------------------------------------
 
-template <typename Type>
-void dual_port_mailbox_ram_base<Type>::device_start()
+template <typename Type, unsigned AddrBits, unsigned DataBits>
+void dual_port_mailbox_ram_base<Type, AddrBits, DataBits>::device_start()
 {
-	m_ram = make_unique_clear<Type[]>(m_ram_size);
+	m_ram = make_unique_clear<Type[]>(RAM_SIZE);
 
 	// state save
-	save_pointer(NAME(m_ram), m_ram_size);
+	save_pointer(NAME(m_ram), RAM_SIZE);
 }
 
 //-------------------------------------------------
 //  device_reset - device-specific reset
 //-------------------------------------------------
 
-template <typename Type>
-void dual_port_mailbox_ram_base<Type>::device_reset()
+template <typename Type, unsigned AddrBits, unsigned DataBits>
+void dual_port_mailbox_ram_base<Type, AddrBits, DataBits>::device_reset()
 {
 	m_intl_callback(CLEAR_LINE);
 	m_intr_callback(CLEAR_LINE);

--- a/src/devices/machine/mb8421.cpp
+++ b/src/devices/machine/mb8421.cpp
@@ -29,7 +29,7 @@ DEFINE_DEVICE_TYPE(MB8421_MB8431_16BIT, mb8421_mb8431_16_device, "mb8421_mb8431_
 //  mb8421_master_device - constructor
 //-------------------------------------------------
 
-mb8421_master_device::mb8421_master_device(const machine_config &mconfig, device_type type, const char *tag, device_t *owner, u32 clock, size_t ram_size, u64 data_bits)
+mb8421_master_device::mb8421_master_device(const machine_config &mconfig, device_type type, const char *tag, device_t *owner, u32 clock, size_t ram_size, u8 data_bits)
 	: device_t(mconfig, type, tag, owner, clock)
 	, m_intl_callback(*this)
 	, m_intr_callback(*this)

--- a/src/devices/machine/mb8421.h
+++ b/src/devices/machine/mb8421.h
@@ -85,7 +85,7 @@ public:
 	DECLARE_READ_LINE_MEMBER(busy_r) { return 0; } // _BUSY pin - not emulated
 
 protected:
-	mb8421_master_device(const machine_config &mconfig, device_type type, const char *tag, device_t *owner, u32 clock, size_t ram_size, u64 data_mask = ~0);
+	mb8421_master_device(const machine_config &mconfig, device_type type, const char *tag, device_t *owner, u32 clock, size_t ram_size, u8 data_bits);
 
 	// device-level overrides
 	virtual void device_resolve_objects() override;
@@ -121,7 +121,7 @@ public:
   u8 ram_r(offs_t offset) { return m_ram[offset] & m_data_mask; }
 
 protected:
-	mb8421_master_8bit_device(const machine_config &mconfig, device_type type, const char *tag, device_t *owner, u32 clock, size_t ram_size, u8 data_mask = ~0);
+	mb8421_master_8bit_device(const machine_config &mconfig, device_type type, const char *tag, device_t *owner, u32 clock, size_t ram_size, u8 data_bits = 8);
 
 	// device-level overrides
 	virtual void device_start() override;
@@ -146,7 +146,7 @@ public:
   u16 ram_r(offs_t offset) { return m_ram[offset] & m_data_mask; }
 
 protected:
-	mb8421_master_16bit_device(const machine_config &mconfig, device_type type, const char *tag, device_t *owner, u32 clock, size_t ram_size, u16 data_mask = ~0);
+	mb8421_master_16bit_device(const machine_config &mconfig, device_type type, const char *tag, device_t *owner, u32 clock, size_t ram_size, u8 data_bits = 16);
 
 	// device-level overrides
 	virtual void device_start() override;

--- a/src/devices/machine/mb8421.h
+++ b/src/devices/machine/mb8421.h
@@ -90,7 +90,7 @@ public:
 	DECLARE_READ_LINE_MEMBER(busy_r) { return 0; } // _BUSY pin - not emulated
 
 protected:
-	dual_port_mailbox_ram_base(const machine_config &mconfig, device_type type, const char *tag, device_t *owner, u32 clock, size_t ram_size, u8 data_bits);
+	dual_port_mailbox_ram_base(const machine_config &mconfig, device_type type, const char *tag, device_t *owner, u32 clock, size_t addr_bits, u8 data_bits);
 
 	// device-level overrides
 	virtual void device_resolve_objects() override;
@@ -123,7 +123,7 @@ public:
 	u8 right_r(offs_t offset);
 
 protected:
-	dual_port_mailbox_ram_8bit_base(const machine_config &mconfig, device_type type, const char *tag, device_t *owner, u32 clock, size_t ram_size, u8 data_bits = 8);
+	dual_port_mailbox_ram_8bit_base(const machine_config &mconfig, device_type type, const char *tag, device_t *owner, u32 clock, size_t addr_bits, u8 data_bits = 8);
 
 	// device-level overrides
 	virtual void device_start() override;
@@ -145,7 +145,7 @@ public:
 	u16 right_r(offs_t offset, u16 mem_mask = ~0);
 
 protected:
-	dual_port_mailbox_ram_16bit_base(const machine_config &mconfig, device_type type, const char *tag, device_t *owner, u32 clock, size_t ram_size, u8 data_bits = 16);
+	dual_port_mailbox_ram_16bit_base(const machine_config &mconfig, device_type type, const char *tag, device_t *owner, u32 clock, size_t addr_bits, u8 data_bits = 16);
 
 	// device-level overrides
 	virtual void device_start() override;

--- a/src/devices/machine/mb8421.h
+++ b/src/devices/machine/mb8421.h
@@ -99,7 +99,7 @@ protected:
 	// internal helpers
 	template<read_or_write row, bool is_right> void update_intr(offs_t offset);
 
-	const u64 m_data_mask; // for 9/18/36bit RAMs
+	const u64 m_data_mask; // for DPRAMs with 9/18/36bit data buses
 	const size_t m_ram_size;
 	const size_t m_ram_mask;
 	const size_t m_int_addr_left;

--- a/src/devices/machine/mb8421.h
+++ b/src/devices/machine/mb8421.h
@@ -94,11 +94,11 @@ protected:
 	// internal helpers
 	template<read_or_write row, bool is_right> void update_intr(offs_t offset);
 
-  u64 m_data_mask; // for 9/18/36bit rams
-  size_t m_ram_size;
-  size_t m_ram_mask;
-  size_t m_int_addr_left;
-  size_t m_int_addr_right;
+	u64 m_data_mask; // for 9/18/36bit rams
+	size_t m_ram_size;
+	size_t m_ram_mask;
+	size_t m_int_addr_left;
+	size_t m_int_addr_right;
 
 private:
 	devcb_write_line m_intl_callback;
@@ -117,8 +117,8 @@ public:
 	void right_w(offs_t offset, u8 data);
 	u8 right_r(offs_t offset);
 
-  void ram_w(offs_t offset, u8 data) { m_ram[offset] = data & m_data_mask; }
-  u8 ram_r(offs_t offset) { return m_ram[offset] & m_data_mask; }
+	void ram_w(offs_t offset, u8 data) { m_ram[offset] = data & m_data_mask; }
+	u8 ram_r(offs_t offset) { return m_ram[offset] & m_data_mask; }
 
 protected:
 	mb8421_master_8bit_device(const machine_config &mconfig, device_type type, const char *tag, device_t *owner, u32 clock, size_t ram_size, u8 data_bits = 8);
@@ -142,8 +142,8 @@ public:
 	void right_w(offs_t offset, u16 data, u16 mem_mask = ~0);
 	u16 right_r(offs_t offset, u16 mem_mask = ~0);
 
-  void ram_w(offs_t offset, u16 data, u16 mem_mask = ~0) { data &= m_data_mask; mem_mask &= m_data_mask; COMBINE_DATA(&m_ram[offset]); }
-  u16 ram_r(offs_t offset) { return m_ram[offset] & m_data_mask; }
+	void ram_w(offs_t offset, u16 data, u16 mem_mask = ~0) { data &= m_data_mask; mem_mask &= m_data_mask; COMBINE_DATA(&m_ram[offset]); }
+	u16 ram_r(offs_t offset) { return m_ram[offset] & m_data_mask; }
 
 protected:
 	mb8421_master_16bit_device(const machine_config &mconfig, device_type type, const char *tag, device_t *owner, u32 clock, size_t ram_size, u8 data_bits = 16);

--- a/src/devices/machine/mb8421.h
+++ b/src/devices/machine/mb8421.h
@@ -115,7 +115,7 @@ private:
 class dual_port_mailbox_ram_8bit_base : public dual_port_mailbox_ram_base
 {
 public:
-	u8 peek(offs_t offset) const { return m_ram[offset]; }
+	u8 peek(offs_t offset) const { return m_ram[offset & m_ram_mask]; }
 
 	void left_w(offs_t offset, u8 data);
 	u8 left_r(offs_t offset);
@@ -137,7 +137,7 @@ private:
 class dual_port_mailbox_ram_16bit_base : public dual_port_mailbox_ram_base
 {
 public:
-	u16 peek(offs_t offset) const { return m_ram[offset]; }
+	u16 peek(offs_t offset) const { return m_ram[offset & m_ram_mask]; }
 
 	void left_w(offs_t offset, u16 data, u16 mem_mask = ~0);
 	u16 left_r(offs_t offset, u16 mem_mask = ~0);

--- a/src/mame/drivers/esqmr.cpp
+++ b/src/mame/drivers/esqmr.cpp
@@ -280,7 +280,7 @@ void esqmr_state::mr(machine_config &config)
 	duart.a_tx_cb().set(FUNC(esqmr_state::duart_tx_a));
 	duart.b_tx_cb().set(FUNC(esqmr_state::duart_tx_b));
 
-    //IDT7130(config, "dpram"); // present in PCB, but unknown purpose (mcu communication?)
+	//IDT7130(config, "dpram"); // present in PCB, but unknown purpose (mcu communication?)
 
 	ESQPANEL2X40_VFX(config, m_panel);
 	m_panel->write_tx().set(duart, FUNC(mc68340_serial_module_device::rx_b_w));

--- a/src/mame/drivers/esqmr.cpp
+++ b/src/mame/drivers/esqmr.cpp
@@ -206,6 +206,7 @@
 #include "machine/68340ser.h"
 #include "sound/es5506.h"
 #include "machine/esqpanel.h"
+//#include "machine/mb8421.h"
 
 #include "speaker.h"
 
@@ -278,6 +279,8 @@ void esqmr_state::mr(machine_config &config)
 	duart.set_clocks(500000, 500000, 1000000, 1000000);
 	duart.a_tx_cb().set(FUNC(esqmr_state::duart_tx_a));
 	duart.b_tx_cb().set(FUNC(esqmr_state::duart_tx_b));
+
+    //IDT7130(config, "dpram"); // present in PCB, but unknown purpose (mcu communication?)
 
 	ESQPANEL2X40_VFX(config, m_panel);
 	m_panel->write_tx().set(duart, FUNC(mc68340_serial_module_device::rx_b_w));


### PR DESCRIPTION
twinkle.cpp, firebeat.cpp : Device-fied CY7C131 Dual port SRAM, Add notes
esqmr.cpp : Add IDT7130 Dual port SRAM placeholder, Add notes