### PR TITLE
Don't clear memory used to construct device objects

### DIFF
--- a/src/emu/device.h
+++ b/src/emu/device.h
@@ -205,7 +205,7 @@ private:
 	template <typename DeviceClass>
 	static std::unique_ptr<device_t> create_device(device_type_impl_base const &type, machine_config const &mconfig, char const *tag, device_t *owner, u32 clock)
 	{
-		return make_unique_clear<DeviceClass>(mconfig, tag, owner, clock);
+		return std::make_unique<DeviceClass>(mconfig, tag, owner, clock);
 	}
 
 	template <typename DriverClass>
@@ -298,7 +298,7 @@ public:
 	template <typename... Params>
 	std::unique_ptr<DeviceClass> create(machine_config &mconfig, char const *tag, device_t *owner, Params &&... args) const
 	{
-		return make_unique_clear<DeviceClass>(mconfig, tag, owner, std::forward<Params>(args)...);
+		return std::make_unique<DeviceClass>(mconfig, tag, owner, std::forward<Params>(args)...);
 	}
 
 	template <typename... Params> DeviceClass &operator()(machine_config &mconfig, char const *tag, Params &&... args) const;


### PR DESCRIPTION
As one step on the road to better standards conformance and compatibility with modern optimisers, we need to stop using `make_unique_clear` for structures/classes with constructors (see #5840).  This is one step in that direction.  I think we're all fully aware that this will break things, and they'll need to be fixed.  We saw some of the effects when GCC 6 changed the default lifetime DSE optimisation behaviour.

If anyone wants to start testing and applying necessary fixes, they can apply this locally, and make fixes on mainline.  I'll occasionally rebase this branch.  In general, the solution will be to initialise members in either the constructor or `device_start`.  Remember that you can initialise class data members at declaration rather than in the constructor initialiser list if it's more convenient.

The plan is at this point is to apply this after MAME 0.217 is released.  It would be nice if we can get some testing/fixes before then.