### PR TITLE
skyfox.cpp : Improve background based on PCB

### DIFF
--- a/src/mame/drivers/skyfox.cpp
+++ b/src/mame/drivers/skyfox.cpp
@@ -55,7 +55,7 @@ void skyfox_state::skyfox_map(address_map &map)
 	map(0x0000, 0xbfff).rom();
 	map(0xc000, 0xcfff).ram();
 	map(0xd000, 0xd3ff).ram().share("spriteram");
-	map(0xd400, 0xdfff).ram(); // ?
+	map(0xd400, 0xdfff).ram().share("bgram"); // Probably for background
 	map(0xe000, 0xe000).portr("INPUTS");
 	map(0xe001, 0xe001).portr("DSW0");
 	map(0xe002, 0xe002).portr("DSW1");
@@ -204,21 +204,13 @@ GFXDECODE_END
 
 /* Scroll the background on every vblank (guess). */
 
-INTERRUPT_GEN_MEMBER(skyfox_state::skyfox_interrupt)
-{
-	/* Scroll the bg */
-	m_bg_pos += (m_bg_ctrl >> 1) & 0x7; // maybe..
-}
-
 void skyfox_state::machine_start()
 {
-	save_item(NAME(m_bg_pos));
 	save_item(NAME(m_bg_ctrl));
 }
 
 void skyfox_state::machine_reset()
 {
-	m_bg_pos = 0;
 	m_bg_ctrl = 0;
 }
 
@@ -227,7 +219,6 @@ void skyfox_state::skyfox(machine_config &config)
 	/* basic machine hardware */
 	Z80(config, m_maincpu, XTAL(8'000'000)/2); /* Verified at 4MHz */
 	m_maincpu->set_addrmap(AS_PROGRAM, &skyfox_state::skyfox_map);
-	m_maincpu->set_vblank_int("screen", FUNC(skyfox_state::skyfox_interrupt));
 
 	Z80(config, m_audiocpu, XTAL(14'318'181)/8); /* Verified at 1.789772MHz */
 	m_audiocpu->set_addrmap(AS_PROGRAM, &skyfox_state::skyfox_sound_map);
@@ -242,7 +233,7 @@ void skyfox_state::skyfox(machine_config &config)
 	m_screen->set_palette(m_palette);
 
 	GFXDECODE(config, m_gfxdecode, m_palette, gfx_skyfox);
-	PALETTE(config, m_palette, FUNC(skyfox_state::skyfox_palette), 256+256); // 256 static colors (+256 for the background??)
+	PALETTE(config, m_palette, FUNC(skyfox_state::skyfox_palette), 256); // 256 static colors
 
 	/* sound hardware */
 	SPEAKER(config, "mono").front_center();

--- a/src/mame/drivers/skyfox.cpp
+++ b/src/mame/drivers/skyfox.cpp
@@ -33,7 +33,7 @@ Verified Dip locations and recommended settings with manual
 
 ***************************************************************************/
 
-WRITE8_MEMBER(skyfox_state::skyfox_vregs_w)
+WRITE8_MEMBER(skyfox_state::output_w)
 {
 	switch (offset)
 	{
@@ -55,11 +55,12 @@ void skyfox_state::skyfox_map(address_map &map)
 	map(0x0000, 0xbfff).rom();
 	map(0xc000, 0xcfff).ram();
 	map(0xd000, 0xd3ff).ram().share("spriteram");
-	map(0xd400, 0xdfff).ram().share("bgram"); // Probably for background
+	map(0xd400, 0xd4ff).ram().share("bgram"); // For background stars
+	map(0xd500, 0xdfff).ram();
 	map(0xe000, 0xe000).portr("INPUTS");
 	map(0xe001, 0xe001).portr("DSW0");
 	map(0xe002, 0xe002).portr("DSW1");
-	map(0xe008, 0xe00f).w(FUNC(skyfox_state::skyfox_vregs_w));
+	map(0xe008, 0xe00f).w(FUNC(skyfox_state::output_w));
 	map(0xf001, 0xf001).portr("DSW2");
 }
 

--- a/src/mame/includes/skyfox.h
+++ b/src/mame/includes/skyfox.h
@@ -25,7 +25,8 @@ public:
 		m_screen(*this, "screen"),
 		m_palette(*this, "palette"),
 		m_soundlatch(*this, "soundlatch"),
-		m_spriteram(*this, "spriteram")
+		m_spriteram(*this, "spriteram"),
+		m_bgram(*this, "bgram")
 	{ }
 
 	void skyfox(machine_config &config);
@@ -43,8 +44,8 @@ private:
 	required_device<palette_device> m_palette;
 	required_device<generic_latch_8_device> m_soundlatch;
 	required_shared_ptr<uint8_t> m_spriteram;
+	required_shared_ptr<uint8_t> m_bgram;
 
-	int m_bg_pos;
 	int m_bg_ctrl;
 
 	DECLARE_WRITE8_MEMBER(skyfox_vregs_w);

--- a/src/mame/includes/skyfox.h
+++ b/src/mame/includes/skyfox.h
@@ -48,12 +48,11 @@ private:
 
 	int m_bg_ctrl;
 
-	DECLARE_WRITE8_MEMBER(skyfox_vregs_w);
+	DECLARE_WRITE8_MEMBER(output_w);
 	virtual void machine_start() override;
 	virtual void machine_reset() override;
 	void skyfox_palette(palette_device &palette) const;
 	uint32_t screen_update_skyfox(screen_device &screen, bitmap_ind16 &bitmap, const rectangle &cliprect);
-	INTERRUPT_GEN_MEMBER(skyfox_interrupt);
 	void draw_sprites( bitmap_ind16 &bitmap, const rectangle &cliprect );
 	void draw_background(bitmap_ind16 &bitmap, const rectangle &cliprect);
 

--- a/src/mame/video/skyfox.cpp
+++ b/src/mame/video/skyfox.cpp
@@ -221,25 +221,6 @@ void skyfox_state::draw_background(bitmap_ind16 &bitmap, const rectangle &clipre
 		if (((m_bg_ctrl >> 4) & 0x3) != pen % 4 || !shining)
 			bitmap.pix16(y % 256, x % 512) = pen;
 	}
-
-#if 0
-	/* For debug: check the background work memory */
-	char buf[128];
-	std::string str;
-	sprintf(buf, "m_bg_ctrl = %02x\n", m_bg_ctrl);
-	str += buf;
-	for (int i = 0; i < 0x10; i++)
-	{
-		int ramoffset = 0xe0 + ((i >> 2) & 0xf) * 2;
-		sprintf(buf, "%02x, %02x", m_bgram[ramoffset], m_bgram[ramoffset + 1]);
-		str += buf;
-		if (i % 4 == 3)
-			str += "\n";
-		else
-			str += " | ";
-	}
-	popmessage("%s", str.c_str());
-#endif
 }
 
 

--- a/src/mame/video/skyfox.cpp
+++ b/src/mame/video/skyfox.cpp
@@ -208,9 +208,9 @@ void skyfox_state::draw_background(bitmap_ind16 &bitmap, const rectangle &clipre
 
 		/* Looks like good, but was written with intuition, Probably not perfect */
 		int pen = rom[offs];
-		int x = rom[offs + 1] * 2 + (i & 1) + pos;
-		int y = (i / 16) + pen % 4;
-		x += 96;
+		int x = rom[offs + 1] * 2 + ((i >> 4) & 1) + pos;
+		int y = (i >> 4);
+		x += 0x60; // Adjustment based on PCB display
 
 		if (m_bg_ctrl & 1) // flipscreen
 		{
@@ -218,7 +218,7 @@ void skyfox_state::draw_background(bitmap_ind16 &bitmap, const rectangle &clipre
 			y = 256     - (y % 256);
 		}
 
-		if (((m_bg_ctrl >> 4) & 0x3) != pen % 4 || !shining)
+		if (((m_bg_ctrl >> 4) & 3) != (pen & 3) || !shining)
 			bitmap.pix16(y % 256, x % 512) = pen;
 	}
 }

--- a/src/mame/video/skyfox.cpp
+++ b/src/mame/video/skyfox.cpp
@@ -149,8 +149,8 @@ void skyfox_state::draw_sprites( bitmap_ind16 &bitmap, const rectangle &cliprect
 
 		if (m_bg_ctrl & 1) // flipscreen
 		{
-			x = width  - x - (n - 1) * 8;
-			y = height - y - (n - 1) * 8;
+			x = width  - x - n * 8;
+			y = height - y - n * 8;
 			flipx = !flipx;
 			flipy = !flipy;
 		}
@@ -212,11 +212,8 @@ void skyfox_state::draw_background(bitmap_ind16 &bitmap, const rectangle &clipre
 		int y = (i >> 4);
 		x += 0x60; // Adjustment based on PCB display
 
-		if (m_bg_ctrl & 1) // flipscreen
-		{
-			x = 512 * 2 - (x % (512 * 2));
-			y = 256     - (y % 256);
-		}
+		// When flipscreen is enabled, direction of background scroll is reversed by the in-game subroutine.
+		// This PCB seems does not support background flip.
 
 		if (((m_bg_ctrl >> 4) & 3) != (pen & 3) || !shining)
 			bitmap.pix16(y % 256, x % 512) = pen;


### PR DESCRIPTION
The previous background implementation was completely wrong.
I found stars position stored in memory.
I used this to rewrite the background drawing code.

Reference PCB video:
- https://www.youtube.com/watch?v=oyE1CfcVrDc
- https://www.youtube.com/watch?v=5QhTNrNH-CU
- https://www.nicovideo.jp/watch/sm13578374
- https://www.nicovideo.jp/watch/sm13692186