### PR TITLE
Add bgfx artwork path for Emscripten build (nw)

### DIFF
--- a/scripts/src/main.lua
+++ b/scripts/src/main.lua
@@ -160,6 +160,7 @@ end
 				.. " --embed-file " .. _MAKE.esc(MAME_DIR) .. "bgfx/chains@bgfx/chains"
 				.. " --embed-file " .. _MAKE.esc(MAME_DIR) .. "bgfx/effects@bgfx/effects"
 				.. " --embed-file " .. _MAKE.esc(MAME_DIR) .. "bgfx/shaders/essl@bgfx/shaders/essl"
+				.. " --embed-file " .. _MAKE.esc(MAME_DIR) .. "artwork/bgfx@artwork/bgfx"
 				.. " --embed-file " .. _MAKE.esc(MAME_DIR) .. "artwork/slot-mask.png@artwork/slot-mask.png"
 
 			if _OPTIONS["SYMBOLS"]~=nil and _OPTIONS["SYMBOLS"]~="0" then


### PR DESCRIPTION
Fix that resolves a problem that some bgfx effects displays when selected since required resources aren't available.

The errors looks like this:

    Unable to load PNG 'artwork' from path 'bgfx/chains/hq4x.png'
    Unable to load chain bgfx/chains//hqx/hq4x.json, falling back to no post processing

The affected effects are hq2x, hq3x hq4x, crt-geom and crt-geom-deluxe.

Applying this change makes these effects load without explicit errors but the overall BGFX issue reported in #5833 still remains for almost all effects.