### PR TITLE
nb1414m4.cpp, galivan.cpp : Fix displayed different from PCB

### DIFF
--- a/src/mame/includes/galivan.h
+++ b/src/mame/includes/galivan.h
@@ -52,12 +52,12 @@ private:
 	tilemap_t     *m_tx_tilemap;
 	uint16_t       m_scrollx;
 	uint16_t       m_scrolly;
-	uint8_t       m_galivan_scrollx[2],m_galivan_scrolly[2];
-	uint8_t       m_layers;
-	uint8_t       m_ninjemak_dispdisable;
+	uint8_t        m_galivan_scrollx[2],m_galivan_scrolly[2];
+	uint8_t        m_layers;
+	uint8_t        m_ninjemak_dispdisable;
 
-	uint8_t       m_shift_scroll; //youmab
-	uint32_t      m_shift_val;
+	uint8_t        m_shift_scroll; //youmab
+	uint32_t       m_shift_val;
 	DECLARE_WRITE8_MEMBER(galivan_sound_command_w);
 	DECLARE_READ8_MEMBER(soundlatch_clear_r);
 	DECLARE_READ8_MEMBER(IO_port_c0_r);

--- a/src/mame/machine/nb1414m4.cpp
+++ b/src/mame/machine/nb1414m4.cpp
@@ -124,10 +124,12 @@ void nb1414m4_device::credit_msg(uint8_t *vram)
 	dst = ((m_data[0x023]<<8)|(m_data[0x024]&0xff)) & 0x3fff;
 	dma(0x0025,dst,0x10,1,vram); /* credit */
 
-	dst = ((m_data[0x045]<<8)|(m_data[0x046]&0xff)) & 0x3fff;
-	dst++; // m_data is 0x5e, needs to be 0x5f ...
-	vram[dst+0x000] = (credit_count + 0x30); /* credit num */
-	vram[dst+0x400] = (m_data[0x48]);
+	/* credit num */
+	dst = ((m_data[0x045] << 8) | (m_data[0x046] & 0xff)) & 0x3fff;
+	vram[dst + 0x000] = (credit_count & 0xf0) ? (((credit_count & 0xf0) >> 4) + 0x30) : 0x20;
+	vram[dst + 0x400] = (m_data[0x48]);
+	vram[dst + 0x001] = ((credit_count & 0x0f) + 0x30);
+	vram[dst + 0x401] = (m_data[0x48]);
 
 	if (m_in_game)
 		return;

--- a/src/mame/machine/nb1414m4.cpp
+++ b/src/mame/machine/nb1414m4.cpp
@@ -46,6 +46,8 @@ nb1414m4_device::nb1414m4_device(const machine_config &mconfig, const char *tag,
 
 void nb1414m4_device::device_start()
 {
+	m_in_game = false;
+	save_item(NAME(m_in_game));
 }
 
 //-------------------------------------------------
@@ -54,6 +56,7 @@ void nb1414m4_device::device_start()
 
 void nb1414m4_device::device_reset()
 {
+	m_in_game = false;
 }
 
 /*****************************************************************************
@@ -71,7 +74,7 @@ void nb1414m4_device::dma(uint16_t src, uint16_t dst, uint16_t size, uint8_t con
 
 		vram[i+dst+0x000] = (condition) ? (m_data[i+(0)+src] & 0xff) : 0x20;
 
-		vram[i+dst+0x400] = m_data[i+(size)+src] & 0xff;
+		vram[i+dst+0x400] = (condition) ? (m_data[i+(size)+src] & 0xff) : m_data[0x13];
 	}
 }
 
@@ -91,6 +94,9 @@ void nb1414m4_device::fill(uint16_t dst, uint8_t tile, uint8_t pal, uint8_t *vra
 
 void nb1414m4_device::insert_coin_msg(uint8_t *vram)
 {
+	if (m_in_game)
+		return;
+
 	int credit_count = (vram[0xf] & 0xff);
 	uint8_t fl_cond = screen().frame_number() & 0x10; /* for insert coin "flickering" */
 	uint16_t dst;
@@ -122,6 +128,9 @@ void nb1414m4_device::credit_msg(uint8_t *vram)
 	dst++; // m_data is 0x5e, needs to be 0x5f ...
 	vram[dst+0x000] = (credit_count + 0x30); /* credit num */
 	vram[dst+0x400] = (m_data[0x48]);
+
+	if (m_in_game)
+		return;
 
 	if(credit_count == 1) /* ONE PLAYER ONLY */
 	{
@@ -158,7 +167,7 @@ void nb1414m4_device::kozure_score_msg(uint16_t dst, uint8_t src_base, uint8_t *
 		vram[i+dst+0x0400] = m_data[0x10f+(src_base*0x1c)+i];
 	}
 
-	vram[6+dst+0x0000] = 0x30;
+	vram[6+dst+0x0000] = vram[5+dst+0x0000] == 0x20 ? 0x20 : 0x30;
 	vram[6+dst+0x0400] = m_data[0x10f+(src_base*0x1c)+6];
 	vram[7+dst+0x0000] = 0x30;
 	vram[7+dst+0x0400] = m_data[0x10f+(src_base*0x1c)+7];
@@ -168,15 +177,16 @@ void nb1414m4_device::kozure_score_msg(uint16_t dst, uint8_t src_base, uint8_t *
 void nb1414m4_device::_0200(uint16_t mcu_cmd, uint8_t *vram)
 {
 	uint16_t dst;
+	m_in_game = mcu_cmd & 0x80;
 
 	dst = (m_data[0x330+((mcu_cmd & 0xf)*2)]<<8)|(m_data[0x331+((mcu_cmd & 0xf)*2)]&0xff);
 
 	dst &= 0x3fff;
 
 	if(dst & 0x7ff) // fill
-		fill(0x0000,m_data[dst & 0x3fff],m_data[dst+1],vram);
+		fill(0x0000,m_data[dst],m_data[dst+1],vram);
 	else // src -> dst
-		dma(dst & 0x3fff,0x0000,0x400,1,vram);
+		dma(dst,0x0000,0x400,1,vram);
 }
 
 /*
@@ -271,24 +281,23 @@ void nb1414m4_device::_0e00(uint16_t mcu_cmd, uint8_t *vram)
 	dst = ((m_data[0xdf]<<8)|(m_data[0xe0]&0xff)) & 0x3fff;
 	dma(0x00e1,dst,8,1,vram); /* hi-score */
 
-	if(mcu_cmd & 0x04)
+	dst = ((m_data[0xfb]<<8)|(m_data[0xfc]&0xff)) & 0x3fff;
+	dma(0x00fd,dst,8,!(mcu_cmd & 1),vram); /* 1p-msg */
+	dst = ((m_data[0x10d]<<8)|(m_data[0x10e]&0xff)) & 0x3fff;
+	kozure_score_msg(dst,0,vram); /* 1p score */
+
+	if(mcu_cmd & 0x80)
 	{
-		dst = ((m_data[0xfb]<<8)|(m_data[0xfc]&0xff)) & 0x3fff;
-		dma(0x00fd,dst,8,!(mcu_cmd & 1),vram); /* 1p-msg */
-		dst = ((m_data[0x10d]<<8)|(m_data[0x10e]&0xff)) & 0x3fff;
-		kozure_score_msg(dst,0,vram); /* 1p score */
-		if(mcu_cmd & 0x80)
-		{
-			dst = ((m_data[0x117]<<8)|(m_data[0x118]&0xff)) & 0x3fff;
-			dma(0x0119,dst,8,!(mcu_cmd & 2),vram); /* 2p-msg */
-			dst = ((m_data[0x129]<<8)|(m_data[0x12a]&0xff)) & 0x3fff;
-			kozure_score_msg(dst,1,vram); /* 2p score */
-		}
+		dst = ((m_data[0x117]<<8)|(m_data[0x118]&0xff)) & 0x3fff;
+		dma(0x0119,dst,8,!(mcu_cmd & 2),vram); /* 2p-msg */
+		dst = ((m_data[0x129]<<8)|(m_data[0x12a]&0xff)) & 0x3fff;
+		kozure_score_msg(dst,1,vram); /* 2p score */
 	}
-	else
+
+	if((mcu_cmd & 0x04) == 0)
 	{
 		dst = ((m_data[0x133]<<8)|(m_data[0x134]&0xff)) & 0x3fff;
-		dma(0x0135,dst,0x10,!(mcu_cmd & 1),vram); /* game over */
+		dma(0x0135,dst,0x10,1,vram); /* game over */
 		insert_coin_msg(vram);
 		if((mcu_cmd & 0x18) == 0) // TODO: either one of these two disables credit display
 			credit_msg(vram);

--- a/src/mame/machine/nb1414m4.cpp
+++ b/src/mame/machine/nb1414m4.cpp
@@ -127,7 +127,7 @@ void nb1414m4_device::credit_msg(uint8_t *vram)
 	/* credit num */
 	dst = ((m_data[0x045]<<8)|(m_data[0x046]&0xff)) & 0x3fff;
 	vram[dst+0x000] = (credit_count & 0xf0) ? (((credit_count & 0xf0)>>4) + 0x30) : 0x20;
-	vram[dst+0x400] = (m_data[0x48]);
+	vram[dst+0x400] = (m_data[0x47]);
 	vram[dst+0x001] = ((credit_count & 0x0f) + 0x30);
 	vram[dst+0x401] = (m_data[0x48]);
 

--- a/src/mame/machine/nb1414m4.cpp
+++ b/src/mame/machine/nb1414m4.cpp
@@ -125,11 +125,11 @@ void nb1414m4_device::credit_msg(uint8_t *vram)
 	dma(0x0025,dst,0x10,1,vram); /* credit */
 
 	/* credit num */
-	dst = ((m_data[0x045] << 8) | (m_data[0x046] & 0xff)) & 0x3fff;
-	vram[dst + 0x000] = (credit_count & 0xf0) ? (((credit_count & 0xf0) >> 4) + 0x30) : 0x20;
-	vram[dst + 0x400] = (m_data[0x48]);
-	vram[dst + 0x001] = ((credit_count & 0x0f) + 0x30);
-	vram[dst + 0x401] = (m_data[0x48]);
+	dst = ((m_data[0x045]<<8)|(m_data[0x046]&0xff)) & 0x3fff;
+	vram[dst+0x000] = (credit_count & 0xf0) ? (((credit_count & 0xf0)>>4) + 0x30) : 0x20;
+	vram[dst+0x400] = (m_data[0x48]);
+	vram[dst+0x001] = ((credit_count & 0x0f) + 0x30);
+	vram[dst+0x401] = (m_data[0x48]);
 
 	if (m_in_game)
 		return;

--- a/src/mame/machine/nb1414m4.cpp
+++ b/src/mame/machine/nb1414m4.cpp
@@ -177,7 +177,10 @@ void nb1414m4_device::kozure_score_msg(uint16_t dst, uint8_t src_base, uint8_t *
 void nb1414m4_device::_0200(uint16_t mcu_cmd, uint8_t *vram)
 {
 	uint16_t dst;
-	m_in_game = mcu_cmd & 0x80;
+
+	// In any game, this bit is set when now playing.
+	// If it is set, "INSERT COIN" etc. are not displayed.
+	m_in_game = (mcu_cmd & 0x80) != 0;
 
 	dst = (m_data[0x330+((mcu_cmd & 0xf)*2)]<<8)|(m_data[0x331+((mcu_cmd & 0xf)*2)]&0xff);
 

--- a/src/mame/machine/nb1414m4.h
+++ b/src/mame/machine/nb1414m4.h
@@ -30,7 +30,7 @@ private:
 	void _0e00(uint16_t mcu_cmd, uint8_t *vram);
 
 	required_region_ptr<uint8_t> m_data;
-
+	bool m_in_game;
 };
 
 DECLARE_DEVICE_TYPE(NB1414M4, nb1414m4_device)

--- a/src/mame/video/galivan.cpp
+++ b/src/mame/video/galivan.cpp
@@ -192,12 +192,12 @@ TILE_GET_INFO_MEMBER(galivan_state::ninjemak_get_bg_tile_info)
 
 TILE_GET_INFO_MEMBER(galivan_state::ninjemak_get_tx_tile_info)
 {
-	int attr = m_videoram[tile_index + 0x400];
-	int code = m_videoram[tile_index] | ((attr & 0x03) << 8);
-
-	if(tile_index < 0x12) /* don't draw the NB1414M4 params! TODO: could be a better fix */
-		code = attr = 0x01;
-
+	uint16_t index = tile_index;
+	if (index < 0x12) /* don't draw the NB1414M4 params! TODO: could be a better fix */
+		index = 0x12;
+		
+	int attr = m_videoram[index + 0x400];
+	int code = m_videoram[index] | ((attr & 0x03) << 8);
 	SET_TILE_INFO_MEMBER(0,
 			code,
 			(attr & 0x1c) >> 2,     /* seems correct ? */


### PR DESCRIPTION
### Fixed issues :

ninjemak and clones
- "INSERT COIN" is displayed on the continue screen
- Dusts appear in the lower left
- Appear dusts with "ONE PLAYER ONLY" and "ONE OR TWO PLAYERS" (ninjemak and youma2 only)
- Credits number does not display correctly when more 10 credits
- 1P and 2P scores are not displayed in attract demo
- Score 0 displayed as "00" ("0" is correct)

kozure
- "GAME OVER" is blinking
- “1-UP” stops blinking when game over
- "INSERT COIN" is displayed when game over
- 1P and 2P scores are not displayed in attract demo
- Score 0 displayed as "00" ("0" is correct)

terraf and clones
- "INSERT COIN" is displayed on the continue screen

### Sources changed : 

galivan.cpp
- TILE_GET_INFO_MEMBER(ninjemak_get_tx_tile_info) : Fixed dusts in lower left (This is for hide custom chip communication).

galivan.h
- Fixed code indentation.

nb1414m4.cpp
- dma() : Fixed text attribute reference when erasing of blinking.
- kozure_score_msg() : When score is 0, the tens place is blank.
- insert_coin_msg(), credit_msg() : If the in-game flag is on, "INSERT COIN" etc. is not displayed.
- credit_msg() : Supports display of 2 digits of credits.
- _0200() : Get the in-game flag bit from sent at command.
- _0200() : Removed duplicate bit operations to make code easier to read.
- _0e00() : Draw the score when the game over display bit is set.
- _0e00() : The blinking bit is no longer applied to game over.