### PR TITLE
rainbow.cpp: add the patches in place to allow the "B" machine to boot to the "A" model

### DIFF
--- a/src/mame/drivers/rainbow.cpp
+++ b/src/mame/drivers/rainbow.cpp
@@ -912,23 +912,7 @@ void rainbow_base_state::machine_start()
 	save_item(NAME(m_irq_mask));
 }
 
-void rainbow_modelb_state::machine_start()
-{
-	rainbow_base_state::machine_start();
 
-	uint8_t *rom = memregion("maincpu")->base();
-	if (rom[0xf4000 + 0x3ffc] == 0x31) // 100-B (5.01)    0x35 would test for V5.05
-	{
-		rom[0xf4000 + 0x0303] = 0x00; // disable CRC check
-		rom[0xf4000 + 0x135e] = 0x00; // Floppy / RX-50 workaround: in case of Z80 RESPONSE FAILURE ($80 bit set in AL), do not block floppy access.
-
-		rom[0xf4000 + 0x198F] = 0xeb; // cond.JMP to uncond.JMP (disables error message 60...)
-
-		rom[0xf4000 + 0x315D] = 0x00; // AND DL,0 (make sure DL is zero before ROM_Initialize7201)
-		rom[0xf4000 + 0x315E] = 0xe2;
-		rom[0xf4000 + 0x315F] = 0x02;
-	}
-}
 
 void rainbow_base_state::rainbow8088_base_map(address_map &map)
 {
@@ -3406,21 +3390,33 @@ void rainbow_modelb_state::rainbow_modelb(machine_config &config)
 ROM_START(rainbow100a)
 	ROM_REGION(0x100000, "maincpu", 0)
 
-	ROM_LOAD("23-176e4-00.bin", 0xFA000, 0x2000, CRC(405e9619) SHA1(86604DCCEA84B46E05D705ABEDA25B12F7CC8C59)) // ROM (FA000-FBFFF) (E89) 8 K
-	ROM_LOAD("23-177e4-00.bin", 0xFC000, 0x2000, CRC(1ec72a66) SHA1(ED19944AE711E97D6BEC34C885BE04C4C3C95852)) // ROM (FC000-FDFFF) (E90) 8 K
+	ROM_LOAD("23-176e4-00.bin", 0xFA000, 0x2000, CRC(405e9619) SHA1(86604dccea84b46e05d705abeda25b12f7cc8c59)) // ROM (FA000-FBFFF) (E89) 8 K
+	ROM_LOAD("23-177e4-00.bin", 0xFC000, 0x2000, CRC(1ec72a66) SHA1(ed19944ae711e97d6bec34c885be04c4c3c95852)) // ROM (FC000-FDFFF) (E90) 8 K
+	ROM_FILL(0xfa26d, 1, 0x00) // [0xFA000 + 0x026d] disable CRC check   [100-A ROM] 
+	ROM_FILL(0xfadea, 1, 0x00) // [0xFA000 + 0x0dea] Floppy workaround: in case of Z80 RESPONSE FAILURE ($80 bit set in AL), don't block floppy access
+	ROM_FILL(0xfb421, 1, 0xeb) // [0xFA000 + 0x1421] cond.JMP to uncond.JMP (disables error message 60...)
+	ROM_FILL(0xfb911, 1, 0x00) // [0xf4000 + 0x1911] AND DL,0 (make sure DL is zero before ROM_Initialize7201)
+	ROM_FILL(0xfb912, 1, 0xe2) // [0xf4000 + 0x1912]
+	ROM_FILL(0xfb912, 1, 0x02) // [0xf4000 + 0x1912]
 
 	// SOCKETED LANGUAGE ROM (E91) with 1 single localization per ROM -
-	ROM_LOAD("23-092e4-00.bin", 0xFE000, 0x2000, CRC(C269175A) SHA1(E82CF69B811F1E376621277F81DB28E299FE06F0))  // ROM (FE000-FFFFF) (E91) 8 K - English (?)
+	ROM_LOAD("23-092e4-00.bin", 0xFE000, 0x2000, CRC(c269175a) SHA1(e82cf69b811f1e376621277f81db28e299fe06f0))  // ROM (FE000-FFFFF) (E91) 8 K - English (?)
 	// See also MP-01491-00 - PC100A FIELD MAINTENANCE SET. Appendix A of EK-RB100 Rainbow
 	// Technical Manual Addendum f.100A and 100B (Dec.84) lists 15 localizations / part numbers
 
 	ROM_REGION(0x1000, "chargen", 0) // [E98] 2732 (4 K) EPROM
-	ROM_LOAD("23-020e3-00.bin", 0x0000, 0x1000, CRC(1685e452) SHA1(bc299ff1cb74afcededf1a7beb9001188fdcf02f))
+	ROM_LOAD("23-020e3-00.bin", 0x0000, 0x1000, CRC(1685e452) SHA1(bc299ff1cb74afcededf1a7beb9001188fdcf02f)) // from Rainbow 100B, undumped
 
 	// Z80 ARBITRATION PROM
 	ROM_REGION(0x100, "prom", 0)
 	ROM_LOAD("23-090b1.mmi6308-ij.e11", 0x0000, 0x0100, CRC(cac3a7e3) SHA1(2d0468cda36fa287f705364c56dbf62f548d2e4c) ) // MMI 6308-IJ; Silkscreen stamp: "LM8413 // 090B1"; 256x8 Open Collector prom @E11, same prom is @E13 on 100-B
 ROM_END
+
+
+void rainbow_modelb_state::machine_start()
+{
+	rainbow_base_state::machine_start();
+}
 
 //----------------------------------------------------------------------------------------
 // ROM definition for 100-B (system module 70-19974-02, PSU H7842-D)
@@ -3438,6 +3434,13 @@ ROM_START(rainbow)
 	// BOOT ROM
 	ROM_LOAD("23-022e5-00.bin", 0xf0000, 0x4000, CRC(9d1332b4) SHA1(736306d2a36bd44f95a39b36ebbab211cc8fea6e))
 	ROM_RELOAD(0xf4000, 0x4000)
+	ROM_FILL(0xf4303, 1, 0x00) // [0xf4000 + 0x0303] disable CRC check   [100-A ROM] 
+	ROM_FILL(0xf535e, 1, 0x00) // [0xf4000 + 0x135e] Floppy workaround: in case of Z80 RESPONSE FAILURE ($80 bit set in AL), don't block floppy access
+	ROM_FILL(0xf598f, 1, 0xeb) // [0xf4000 + 0x198f] cond.JMP to uncond.JMP (disables error message 60...)
+	ROM_FILL(0xf715d, 1, 0x00) // [0xf4000 + 0x315d] AND DL,0 (make sure DL is zero before ROM_Initialize7201)
+	ROM_FILL(0xf715e, 1, 0xe2) // [0xf4000 + 0x315e]
+	ROM_FILL(0xf715f, 1, 0x02) // [0xf4000 + 0x315f]
+
 
 	// LANGUAGE ROM
 	ROM_LOAD("23-020e5-00.bin", 0xf8000, 0x4000, CRC(8638712f) SHA1(8269b0d95dc6efbe67d500dac3999df4838625d8)) // German, French, English

--- a/src/mame/drivers/rainbow.cpp
+++ b/src/mame/drivers/rainbow.cpp
@@ -3405,18 +3405,13 @@ ROM_START(rainbow100a)
 	// Technical Manual Addendum f.100A and 100B (Dec.84) lists 15 localizations / part numbers
 
 	ROM_REGION(0x1000, "chargen", 0) // [E98] 2732 (4 K) EPROM
-	ROM_LOAD("23-020e3-00.bin", 0x0000, 0x1000, CRC(1685e452) SHA1(bc299ff1cb74afcededf1a7beb9001188fdcf02f)) // from Rainbow 100B, undumped
+	ROM_LOAD("23-020e3-00.bin", 0x0000, 0x1000, CRC(1685e452) SHA1(bc299ff1cb74afcededf1a7beb9001188fdcf02f)) // from Rainbow 100B, Rainbow 100A version undumped
 
 	// Z80 ARBITRATION PROM
 	ROM_REGION(0x100, "prom", 0)
 	ROM_LOAD("23-090b1.mmi6308-ij.e11", 0x0000, 0x0100, CRC(cac3a7e3) SHA1(2d0468cda36fa287f705364c56dbf62f548d2e4c) ) // MMI 6308-IJ; Silkscreen stamp: "LM8413 // 090B1"; 256x8 Open Collector prom @E11, same prom is @E13 on 100-B
 ROM_END
 
-
-void rainbow_modelb_state::machine_start()
-{
-	rainbow_base_state::machine_start();
-}
 
 //----------------------------------------------------------------------------------------
 // ROM definition for 100-B (system module 70-19974-02, PSU H7842-D)


### PR DESCRIPTION
as well (Bavarese). 