### PR TITLE
nb1414m4.cpp : Fixed corrupted ninjemak continue screen

### DIFF
--- a/src/mame/machine/nb1414m4.cpp
+++ b/src/mame/machine/nb1414m4.cpp
@@ -47,7 +47,11 @@ nb1414m4_device::nb1414m4_device(const machine_config &mconfig, const char *tag,
 
 void nb1414m4_device::device_start()
 {
+	m_previous_0200_command = 0xffff;
+	m_previous_0200_command_frame = 0;
 	m_in_game = false;
+	save_item(NAME(m_previous_0200_command));
+	save_item(NAME(m_previous_0200_command_frame));
 	save_item(NAME(m_in_game));
 }
 

--- a/src/mame/machine/nb1414m4.h
+++ b/src/mame/machine/nb1414m4.h
@@ -31,6 +31,8 @@ private:
 	void _0e00(uint16_t mcu_cmd, uint8_t *vram);
 
 	required_region_ptr<uint8_t> m_data;
+	uint16_t m_previous_0200_command;
+	uint64_t m_previous_0200_command_frame;
 	bool m_in_game;
 };
 


### PR DESCRIPTION
This request was separated from #5996.

Fixed issue :
ninjemak and clones
- The continue screen is corrupt (https://mametesters.org/view.php?id=4344)
