### PR TITLE
add decaped PIC16C54 images to 2 unlicensed NES games (Block Force, 3-D Block)  [Caps0ff]

### DIFF
--- a/hash/nes.xml
+++ b/hash/nes.xml
@@ -60808,26 +60808,8 @@ preliminary proto for the PAL version, still running on NTSC systems) or the gfx
 	</software>
 
 <!-- nointro -->
-	<software name="3dblocka" cloneof="3dblock" supported="no">
-		<description>3-D Block (Asia, Hwang Shinwei)</description>
-		<year>1990</year>
-		<publisher>Hwang Shinwei</publisher>
-		<part name="cart" interface="nes_cart">
-			<feature name="slot" value="3dblock" />
-			<feature name="pcb" value="NES-CNROM" />
-			<feature name="mirroring" value="vertical" />
-			<dataarea name="prg" size="32768">
-				<rom name="3-d block (asia) (hwang shinwei) (unl).prg" size="32768" crc="86dba660" sha1="56cba51568b0f1458aa7e0de6575d1225e40f7a1" offset="00000" status="baddump" />
-			</dataarea>
-			<!-- 8k VRAM on cartridge -->
-			<dataarea name="vram" size="8192">
-			</dataarea>
-		</part>
-	</software>
-
-<!-- nointro -->
 	<software name="3dblock">
-		<description>3-D Block (Asia, RCM)</description>
+		<description>3-D Block (Asia, unprotected, RCM)</description>
 		<year>1990</year>
 		<publisher>RCM</publisher>
 		<part name="cart" interface="nes_cart">
@@ -60840,6 +60822,26 @@ preliminary proto for the PAL version, still running on NTSC systems) or the gfx
 			<!-- 8k VRAM on cartridge -->
 			<dataarea name="vram" size="8192">
 			</dataarea>
+		</part>
+	</software>
+
+	<software name="3dblocka" cloneof="3dblock" supported="no">
+		<description>3-D Block (Asia, protected set 1, Hwang Shinwei)</description>
+		<year>1990</year>
+		<publisher>Hwang Shinwei</publisher>
+		<part name="cart" interface="nes_cart">
+			<feature name="slot" value="3dblock" />
+			<feature name="pcb" value="NES-CNROM" />
+			<feature name="mirroring" value="vertical" />
+			<dataarea name="prg" size="32768">
+				<rom name="3-d block (asia) (hwang shinwei) (unl).prg" size="32768" crc="86dba660" sha1="56cba51568b0f1458aa7e0de6575d1225e40f7a1" offset="00000" />
+			</dataarea>
+			<!-- 8k VRAM on cartridge -->
+			<dataarea name="vram" size="8192">
+			</dataarea>
+			<dataarea name="pic16c54" size="32768">
+				<rom name="3d_block_pic16c54.bin" size="0x400" crc="116c9bdf" sha1="00fdd312986a1eebf4e115c87f4c9317b2d315f0" offset="00000" />
+			</dataarea>			
 		</part>
 	</software>
 
@@ -61227,7 +61229,7 @@ preliminary proto for the PAL version, still running on NTSC systems) or the gfx
 	</software>
 
 	<software name="blockfrc">
-		<description>Block Force (Asia, Ripped from Tetris Family 9 in 1?)</description>
+		<description>Block Force (Asia, unprotected, Ripped from Tetris Family 9 in 1?)</description>
 		<year>19??</year>
 		<publisher>Hwang Shinwei</publisher>
 		<part name="cart" interface="nes_cart">
@@ -61242,6 +61244,27 @@ preliminary proto for the PAL version, still running on NTSC systems) or the gfx
 			</dataarea>
 		</part>
 	</software>
+
+	<software name="blockfrca" supported="blockfrc">
+		<description>Block Force (Asia, protected)</description>
+		<year>19??</year>
+		<publisher>&lt;unknown&gt;</publisher>
+		<part name="cart" interface="nes_cart">
+			<feature name="slot" value="3dblock" />
+			<feature name="pcb" value="NES-NROM-256" />
+			<feature name="mirroring" value="vertical" />
+			<dataarea name="prg" size="32768">	
+				<rom name="square force (unl).prg" size="32768" crc="3c43939d" sha1="d326485501ac08b5c3815bfd8dff3979c97556c6" offset="00000" />
+			</dataarea>
+			<!-- 8k VRAM on cartridge -->
+			<dataarea name="vram" size="8192">
+			</dataarea>
+			<dataarea name="pic16c54" size="32768">
+				<rom name="block_force_pic16c54.bin" size="0x400" crc="590e426d" sha1="d6dbb81d0a9b6fbfeb22684a137c1618e2a3bd6c" offset="00000" />
+			</dataarea>				
+		</part>
+	</software>
+
 
 	<software name="bloodjur" supported="no">
 		<description>Blood of Jurassic (GD-98)</description>
@@ -63940,7 +63963,7 @@ have been all tagged as NES-TLROM at the moment, but it would be nice to add the
 from the NEStopia source, hence they would require confirmation. -->
 
 	<software name="3dblockb" cloneof="3dblock" supported="no">
-		<description>3-D Block (Asia, Alt 2)</description>
+		<description>3-D Block (Asia, protected set 2)</description>
 		<year>19??</year>
 		<publisher>&lt;unknown&gt;</publisher>
 		<part name="cart" interface="nes_cart">
@@ -63953,6 +63976,9 @@ from the NEStopia source, hence they would require confirmation. -->
 			<!-- 8k VRAM on cartridge -->
 			<dataarea name="vram" size="8192">
 			</dataarea>
+			<dataarea name="pic16c54" size="32768">
+				<rom name="3d_block_pic16c54.bin" size="0x400" crc="116c9bdf" sha1="00fdd312986a1eebf4e115c87f4c9317b2d315f0" offset="00000" />
+			</dataarea>						
 		</part>
 	</software>
 
@@ -65406,22 +65432,6 @@ All musics were removed in this game.
 			</dataarea>
 			<dataarea name="prg" size="32768">
 				<rom name="space boy (unl).prg" size="32768" crc="70db619a" sha1="8e87e75105baaed7c37b6c02241127ae1471c9e3" offset="00000" status="baddump" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="squaref" supported="no">
-		<description>Square Force (Asia)</description>
-		<year>19??</year>
-		<publisher>&lt;unknown&gt;</publisher>
-		<part name="cart" interface="nes_cart">
-			<feature name="slot" value="uxrom" />
-			<feature name="pcb" value="NES-UNROM" />
-			<dataarea name="prg" size="32768">
-				<rom name="square force (unl).prg" size="32768" crc="3c43939d" sha1="d326485501ac08b5c3815bfd8dff3979c97556c6" offset="00000" status="baddump" />
-			</dataarea>
-			<!-- 8k VRAM on cartridge -->
-			<dataarea name="vram" size="8192">
 			</dataarea>
 		</part>
 	</software>

--- a/src/devices/bus/nes/nes_carts.cpp
+++ b/src/devices/bus/nes/nes_carts.cpp
@@ -262,7 +262,7 @@ void nes_cart(device_slot_interface &device)
 	device.option_add_internal("gs2004",           NES_GS2004);
 	device.option_add_internal("gs2013",           NES_GS2013);
 	device.option_add_internal("tf9in1",           NES_TF9IN1);
-	device.option_add_internal("3dblock",          NES_3DBLOCK);    // NROM + IRQ?
+	device.option_add_internal("3dblock",          NES_3DBLOCK);    // NROM + IRQ? (has PIC16c54)
 	device.option_add_internal("racermate",        NES_RACERMATE);  // mapper 168
 	device.option_add_internal("agci_50282",       NES_AGCI_50282);
 	device.option_add_internal("dreamtech01",      NES_DREAMTECH01);

--- a/src/devices/bus/nes/rcm.cpp
+++ b/src/devices/bus/nes/rcm.cpp
@@ -66,7 +66,9 @@ nes_tf9_device::nes_tf9_device(const machine_config &mconfig, const char *tag, d
 }
 
 nes_3dblock_device::nes_3dblock_device(const machine_config &mconfig, const char *tag, device_t *owner, uint32_t clock)
-	: nes_nrom_device(mconfig, NES_3DBLOCK, tag, owner, clock), m_irq_count(0)
+	: nes_nrom_device(mconfig, NES_3DBLOCK, tag, owner, clock)
+	, m_irq_count(0)
+	//, m_protcpu(*this, "protcpu")
 {
 }
 
@@ -120,6 +122,12 @@ void nes_tf9_device::pcb_reset()
 	prg32(0);
 	chr8(0, m_chr_source);
 }
+
+void nes_3dblock_device::device_add_mconfig(machine_config &config)
+{
+	//PIC16C54(config, m_protcpu, 4000000); /* ? Mhz */
+}
+
 
 void nes_3dblock_device::device_start()
 {

--- a/src/devices/bus/nes/rcm.h
+++ b/src/devices/bus/nes/rcm.h
@@ -6,6 +6,7 @@
 #pragma once
 
 #include "nxrom.h"
+#include "cpu/pic16c5x/pic16c5x.h"
 
 
 // ======================> nes_gs2015_device
@@ -98,10 +99,14 @@ public:
 protected:
 	// device-level overrides
 	virtual void device_start() override;
+	virtual void device_add_mconfig(machine_config &config) override;
+
 
 private:
 	uint8_t m_reg[4];
 	uint8_t m_irq_count;
+
+	//required_device<pic16c54_device> m_protcpu;
 };
 
 


### PR DESCRIPTION

(note, I see nothing to get the ROM code loaded mapped to a PIC beyond making an even greater mess of the nes_slot.cpp / hxx spaghetti function or making it a device ROM rather than part of the softlist set, which would be incorrect, please tell me there is a better way(?) )