### PR TITLE
Fixes timing issues with ds5002fp

### DIFF
--- a/src/mame/drivers/gaelco2.cpp
+++ b/src/mame/drivers/gaelco2.cpp
@@ -842,7 +842,8 @@ void gaelco2_state::play2000(machine_config &config)
 	m_maincpu->set_vblank_int("screen", FUNC(gaelco2_state::irq6_line_hold));
 
 	GAELCO_DS5002FP(config, "gaelco_ds5002fp", XTAL(32'000'000) / 2).set_addrmap(0, &gaelco2_state::mcu_hostmem_map); /* 16 MHz */
-
+	config.set_perfect_quantum("gaelco_ds5002fp:mcu");
+	
 	/* video hardware */
 	BUFFERED_SPRITERAM16(config, m_spriteram);
 
@@ -1219,6 +1220,7 @@ void gaelco2_state::alighunt_d5002fp(machine_config &config)
 {
 	alighunt(config);
 	GAELCO_DS5002FP(config, "gaelco_ds5002fp", XTAL(24'000'000) / 2).set_addrmap(0, &gaelco2_state::mcu_hostmem_map); /* 12 MHz */
+	config.set_perfect_quantum("gaelco_ds5002fp:mcu");
 }
 
 /*
@@ -1535,6 +1537,7 @@ void gaelco2_state::touchgo_d5002fp(machine_config &config)
 {
 	touchgo(config);
 	GAELCO_DS5002FP(config, "gaelco_ds5002fp", XTAL(32'000'000) / 2).set_addrmap(0, &gaelco2_state::mcu_hostmem_map); /* 16 MHz */
+	config.set_perfect_quantum("gaelco_ds5002fp:mcu");
 }
 
 /*
@@ -2128,7 +2131,8 @@ void wrally2_state::wrally2(machine_config &config)
 	m_maincpu->set_vblank_int("lscreen", FUNC(gaelco2_state::irq6_line_hold));
 
 	GAELCO_DS5002FP(config, "gaelco_ds5002fp", XTAL(26'000'000) / 2).set_addrmap(0, &wrally2_state::mcu_hostmem_map); /* 13 MHz */
-
+	config.set_perfect_quantum("gaelco_ds5002fp:mcu");
+	
 	LS259(config, m_mainlatch); // IC6
 	m_mainlatch->q_out_cb<0>().set(FUNC(gaelco2_state::coin1_counter_w));
 	m_mainlatch->q_out_cb<1>().set(FUNC(gaelco2_state::coin2_counter_w));


### PR DESCRIPTION
Adds config.set_perfect_quantum("gaelco_ds5002fp:mcu") (missing? removed?) to drivers using the ds5002fp to correct timing issues.