### PR TITLE
Fix intvoice not working since 207

### DIFF
--- a/src/devices/bus/intv/voice.cpp
+++ b/src/devices/bus/intv/voice.cpp
@@ -98,7 +98,7 @@ const tiny_rom_entry *intv_voice_device::device_rom_region() const
 
 uint16_t intv_voice_device::read_speech(offs_t offset)
 {
-	return 0xff00 | m_speech->spb640_r(offset);
+	return m_speech->spb640_r(offset);
 }
 
 /*-------------------------------------------------
@@ -107,7 +107,7 @@ uint16_t intv_voice_device::read_speech(offs_t offset)
 
 void intv_voice_device::write_speech(offs_t offset, uint16_t data)
 {
-	m_speech->spb640_w(offset, data & 0x00ff);
+	m_speech->spb640_w(offset, data);
 }
 
 


### PR DESCRIPTION
Voice reads and writes were clipped to 8 bits when they needed to be 16 bit.  This fixes Mame Testers issue #7336.