### PR TITLE
Revert "sound/2612intf.cpp : Add YMF276 device, Clamp output related to internal 9-bit DAC, Add notes"

### DIFF
--- a/src/devices/sound/2612intf.cpp
+++ b/src/devices/sound/2612intf.cpp
@@ -2,9 +2,9 @@
 // copyright-holders:Ernesto Corvi
 /***************************************************************************
 
-  2612intf.cpp
+  2612intf.c
 
-  The YM2612 emulator supports up to 3 chips.
+  The YM2612 emulator supports up to 2 chips.
   Each chip has the following connections:
   - Status Read / Control Write A
   - Port Read / Data Write A
@@ -59,23 +59,9 @@ void ym2612_device::timer_handler(int c,int count,int clock)
 //  sound_stream_update - handle a stream update
 //-------------------------------------------------
 
-// YM2612, YM3438 has internal 9-bit DAC
 void ym2612_device::sound_stream_update(sound_stream &stream, stream_sample_t **inputs, stream_sample_t **outputs, int samples)
 {
 	ym2612_update_one(m_chip, outputs, samples);
-	// Clamp into 9-bit, TODO : Mega Drive/Genesis 'Ladder' effect?
-	for (int s = 0; s < samples; s++)
-	{
-		outputs[0][s] &= 0xff80;
-		outputs[1][s] &= 0xff80;
-	}
-}
-
-// YMF276 needs external DAC
-void ymf276_device::sound_stream_update(sound_stream &stream, stream_sample_t **inputs, stream_sample_t **outputs, int samples)
-{
-	ym2612_update_one(m_chip, outputs, samples);
-	// 16 bit output?
 }
 
 
@@ -165,9 +151,9 @@ ym2612_device::ym2612_device(const machine_config &mconfig, const char *tag, dev
 ym2612_device::ym2612_device(const machine_config &mconfig, device_type type, const char *tag, device_t *owner, uint32_t clock)
 	: device_t(mconfig, type, tag, owner, clock)
 	, device_sound_interface(mconfig, *this)
-	, m_chip(nullptr)
 	, m_stream(nullptr)
 	, m_timer{ nullptr, nullptr }
+	, m_chip(nullptr)
 	, m_irq_handler(*this)
 {
 }
@@ -177,13 +163,5 @@ DEFINE_DEVICE_TYPE(YM3438, ym3438_device, "ym3438", "YM3438 OPN2C")
 
 ym3438_device::ym3438_device(const machine_config &mconfig, const char *tag, device_t *owner, uint32_t clock)
 	: ym2612_device(mconfig, YM3438, tag, owner, clock)
-{
-}
-
-
-DEFINE_DEVICE_TYPE(YMF276, ymf276_device, "ymf276", "YMF276 OPN2L")
-
-ymf276_device::ymf276_device(const machine_config &mconfig, const char *tag, device_t *owner, uint32_t clock)
-	: ym2612_device(mconfig, YMF276, tag, owner, clock)
 {
 }

--- a/src/devices/sound/2612intf.h
+++ b/src/devices/sound/2612intf.h
@@ -35,7 +35,6 @@ protected:
 	// sound stream update overrides
 	virtual void sound_stream_update(sound_stream &stream, stream_sample_t **inputs, stream_sample_t **outputs, int samples) override;
 
-	void *          m_chip;
 private:
 	void irq_handler(int irq);
 	void timer_handler(int c, int count, int clock);
@@ -48,6 +47,7 @@ private:
 
 	sound_stream *  m_stream;
 	emu_timer *     m_timer[2];
+	void *          m_chip;
 	devcb_write_line m_irq_handler;
 };
 
@@ -59,20 +59,7 @@ public:
 };
 
 
-class ymf276_device : public ym2612_device
-{
-public:
-	ymf276_device(const machine_config &mconfig, const char *tag, device_t *owner, uint32_t clock);
-
-protected:
-	// sound stream update overrides
-	virtual void sound_stream_update(sound_stream &stream, stream_sample_t **inputs, stream_sample_t **outputs, int samples) override;
-
-};
-
-
 DECLARE_DEVICE_TYPE(YM2612, ym2612_device)
 DECLARE_DEVICE_TYPE(YM3438, ym3438_device)
-DECLARE_DEVICE_TYPE(YMF276, ymf276_device)
 
 #endif // MAME_SOUND_2612INTF_H

--- a/src/mame/drivers/fmtowns.cpp
+++ b/src/mame/drivers/fmtowns.cpp
@@ -9,7 +9,7 @@
 
     CPU:  various AMD x86 CPUs, originally 80386DX (80387 available as an add-on).
           later models use 80386SX, 80486 and Pentium CPUs
-    Sound:  Yamaha YM3438 (Some later model uses YMF276; Low voltage, External DAC variation of YM3438)
+    Sound:  Yamaha YM3438
             Ricoh RF5c68
             CD-DA
     Video:  Custom


### PR DESCRIPTION
Reverts mamedev/mame#6127