### PR TITLE
YM2612 output updates, Add some Mega drive variations

### DIFF
--- a/src/devices/sound/2612intf.cpp
+++ b/src/devices/sound/2612intf.cpp
@@ -2,9 +2,9 @@
 // copyright-holders:Ernesto Corvi
 /***************************************************************************
 
-  2612intf.c
+  2612intf.cpp
 
-  The YM2612 emulator supports up to 2 chips.
+  The YM2612 emulator supports up to 3 chips.
   Each chip has the following connections:
   - Status Read / Control Write A
   - Port Read / Data Write A
@@ -61,7 +61,7 @@ void ym2612_device::timer_handler(int c,int count,int clock)
 
 void ym2612_device::sound_stream_update(sound_stream &stream, stream_sample_t **inputs, stream_sample_t **outputs, int samples)
 {
-	ym2612_update_one(m_chip, outputs, samples);
+	ym2612_update_one(m_chip, outputs, samples, m_output_bits);
 }
 
 
@@ -151,6 +151,7 @@ ym2612_device::ym2612_device(const machine_config &mconfig, const char *tag, dev
 ym2612_device::ym2612_device(const machine_config &mconfig, device_type type, const char *tag, device_t *owner, uint32_t clock)
 	: device_t(mconfig, type, tag, owner, clock)
 	, device_sound_interface(mconfig, *this)
+	, m_output_bits(9) // 9 bit internal DAC
 	, m_stream(nullptr)
 	, m_timer{ nullptr, nullptr }
 	, m_chip(nullptr)
@@ -158,10 +159,19 @@ ym2612_device::ym2612_device(const machine_config &mconfig, device_type type, co
 {
 }
 
-
+// CMOS variation, with Higher sound output impedance
 DEFINE_DEVICE_TYPE(YM3438, ym3438_device, "ym3438", "YM3438 OPN2C")
 
 ym3438_device::ym3438_device(const machine_config &mconfig, const char *tag, device_t *owner, uint32_t clock)
 	: ym2612_device(mconfig, YM3438, tag, owner, clock)
 {
+}
+
+// Low voltage, External DAC variation
+DEFINE_DEVICE_TYPE(YMF276, ymf276_device, "ymf276", "YMF276 OPN2L")
+
+ymf276_device::ymf276_device(const machine_config &mconfig, const char *tag, device_t *owner, uint32_t clock)
+	: ym2612_device(mconfig, YMF276, tag, owner, clock)
+{
+	m_output_bits = 16; // external DAC
 }

--- a/src/devices/sound/2612intf.h
+++ b/src/devices/sound/2612intf.h
@@ -35,6 +35,7 @@ protected:
 	// sound stream update overrides
 	virtual void sound_stream_update(sound_stream &stream, stream_sample_t **inputs, stream_sample_t **outputs, int samples) override;
 
+	u8              m_output_bits;
 private:
 	void irq_handler(int irq);
 	void timer_handler(int c, int count, int clock);
@@ -59,7 +60,15 @@ public:
 };
 
 
+class ymf276_device : public ym2612_device
+{
+public:
+	ymf276_device(const machine_config &mconfig, const char *tag, device_t *owner, uint32_t clock);
+};
+
+
 DECLARE_DEVICE_TYPE(YM2612, ym2612_device)
 DECLARE_DEVICE_TYPE(YM3438, ym3438_device)
+DECLARE_DEVICE_TYPE(YMF276, ymf276_device)
 
 #endif // MAME_SOUND_2612INTF_H

--- a/src/devices/sound/fm.h
+++ b/src/devices/sound/fm.h
@@ -176,7 +176,7 @@ void * ym2612_init(device_t *device, int baseclock, int rate,
 void ym2612_clock_changed(void *chip, int clock, int rate);
 void ym2612_shutdown(void *chip);
 void ym2612_reset_chip(void *chip);
-void ym2612_update_one(void *chip, FMSAMPLE **buffer, int length);
+void ym2612_update_one(void *chip, FMSAMPLE **buffer, int length, u8 output_bits);
 
 int ym2612_write(void *chip, int a,unsigned char v);
 unsigned char ym2612_read(void *chip,int a);

--- a/src/devices/sound/fm2612.cpp
+++ b/src/devices/sound/fm2612.cpp
@@ -2174,8 +2174,11 @@ static void init_tables(void)
 /*******************************************************************************/
 
 /* Generate samples for one of the YM2612s */
-void ym2612_update_one(void *chip, FMSAMPLE **buffer, int length)
+void ym2612_update_one(void *chip, FMSAMPLE **buffer, int length, u8 output_bits)
 {
+	// TODO : 'ladder' effects for Mega Drive/Genesis
+	const u8 output_shift = (output_bits > 14) ? 0 : (14 - output_bits);
+	const s32 output_nandmask = (1 << output_shift) - 1;
 	ym2612_state *F2612 = (ym2612_state *)chip;
 	fm2612_FM_OPN *OPN   = &F2612->OPN;
 	int32_t *out_fm = OPN->out_fm;
@@ -2208,7 +2211,10 @@ void ym2612_update_one(void *chip, FMSAMPLE **buffer, int length)
 			refresh_fc_eg_slot(OPN, &cch[2]->SLOT[SLOT3] , OPN->SL3.fc[0] , OPN->SL3.kcode[0] );
 			refresh_fc_eg_slot(OPN, &cch[2]->SLOT[SLOT4] , cch[2]->fc , cch[2]->kcode );
 		}
-	}else refresh_fc_eg_chan( OPN, cch[2] );
+	}
+	else
+		refresh_fc_eg_chan( OPN, cch[2] );
+
 	refresh_fc_eg_chan( OPN, cch[3] );
 	refresh_fc_eg_chan( OPN, cch[4] );
 	refresh_fc_eg_chan( OPN, cch[5] );
@@ -2239,7 +2245,7 @@ void ym2612_update_one(void *chip, FMSAMPLE **buffer, int length)
 		chan_calc(F2612, OPN, cch[3]);
 		chan_calc(F2612, OPN, cch[4]);
 		if( F2612->dacen )
-			*cch[5]->connect4 += F2612->dacout;
+			*cch[5]->connect4 += F2612->dacout << 5;
 		else
 			chan_calc(F2612, OPN, cch[5]);
 
@@ -2275,18 +2281,18 @@ void ym2612_update_one(void *chip, FMSAMPLE **buffer, int length)
 		else if (out_fm[5] < -8192) out_fm[5] = -8192;
 
 		/* 6-channels mixing  */
-		lt  = ((out_fm[0]>>0) & OPN->pan[0]);
-		rt  = ((out_fm[0]>>0) & OPN->pan[1]);
-		lt += ((out_fm[1]>>0) & OPN->pan[2]);
-		rt += ((out_fm[1]>>0) & OPN->pan[3]);
-		lt += ((out_fm[2]>>0) & OPN->pan[4]);
-		rt += ((out_fm[2]>>0) & OPN->pan[5]);
-		lt += ((out_fm[3]>>0) & OPN->pan[6]);
-		rt += ((out_fm[3]>>0) & OPN->pan[7]);
-		lt += ((out_fm[4]>>0) & OPN->pan[8]);
-		rt += ((out_fm[4]>>0) & OPN->pan[9]);
-		lt += ((out_fm[5]>>0) & OPN->pan[10]);
-		rt += ((out_fm[5]>>0) & OPN->pan[11]);
+		lt  = (((out_fm[0]) & OPN->pan[0]) & ~output_nandmask);
+		rt  = (((out_fm[0]) & OPN->pan[1]) & ~output_nandmask);
+		lt += (((out_fm[1]) & OPN->pan[2]) & ~output_nandmask);
+		rt += (((out_fm[1]) & OPN->pan[3]) & ~output_nandmask);
+		lt += (((out_fm[2]) & OPN->pan[4]) & ~output_nandmask);
+		rt += (((out_fm[2]) & OPN->pan[5]) & ~output_nandmask);
+		lt += (((out_fm[3]) & OPN->pan[6]) & ~output_nandmask);
+		rt += (((out_fm[3]) & OPN->pan[7]) & ~output_nandmask);
+		lt += (((out_fm[4]) & OPN->pan[8]) & ~output_nandmask);
+		rt += (((out_fm[4]) & OPN->pan[9]) & ~output_nandmask);
+		lt += (((out_fm[5]) & OPN->pan[10]) & ~output_nandmask);
+		rt += (((out_fm[5]) & OPN->pan[11]) & ~output_nandmask);
 
 //      Limit( lt, MAXOUT, MINOUT );
 //      Limit( rt, MAXOUT, MINOUT );
@@ -2328,7 +2334,7 @@ void ym2612_postload(void *chip)
 		int r;
 
 		/* DAC data & port */
-		F2612->dacout = ((int)F2612->REGS[0x2a] - 0x80) << 6;   /* level unknown */
+		F2612->dacout = (((int)F2612->REGS[0x2a] - 0x80) << 1) | (BIT(F2612->REGS[0x2c], 3));
 		F2612->dacen  = F2612->REGS[0x2b] & 0x80;
 		/* OPN registers */
 		/* DT / MULTI , TL , KS / AR , AMON / DR , SR , SL / RR , SSG-EG */
@@ -2488,11 +2494,15 @@ int ym2612_write(void *chip, int a, uint8_t v)
 			{
 			case 0x2a:  /* DAC data (YM2612) */
 				ym2612_device::update_request(F2612->OPN.ST.device);
-				F2612->dacout = ((int)v - 0x80) << 6;   /* level unknown */
+				F2612->dacout = (F2612->dacout & 0x001) | (((int)v - 0x80) << 1);
 				break;
 			case 0x2b:  /* DAC Sel  (YM2612) */
 				/* b7 = dac enable */
 				F2612->dacen = v & 0x80;
+				break;
+			case 0x2c:  /* Test  (YM2612) */
+				/* b3 = dac lowest bit */
+				F2612->dacout = (F2612->dacout & ~0x001) | BIT(v, 3);
 				break;
 			default:    /* OPN section */
 				ym2612_device::update_request(F2612->OPN.ST.device);

--- a/src/mame/drivers/fmtowns.cpp
+++ b/src/mame/drivers/fmtowns.cpp
@@ -2837,10 +2837,19 @@ void towns_state::towns_base(machine_config &config)
 	/* sound hardware */
 	SPEAKER(config, "lspeaker").front_left();
 	SPEAKER(config, "rspeaker").front_right();
+
 	ym3438_device &fm(YM3438(config, "fm", 16000000 / 2)); // actual clock speed unknown
 	fm.irq_handler().set(FUNC(towns_state::towns_fm_irq));
 	fm.add_route(0, "lspeaker", 1.00);
 	fm.add_route(1, "rspeaker", 1.00);
+
+/*
+	// Later model uses YMF276 for FM
+	ymf276_device &fm(YMF276(config, "fm", 16000000 / 2)); // actual clock speed unknown
+	fm.irq_handler().set(FUNC(towns_state::towns_fm_irq));
+	fm.add_route(0, "lspeaker", 1.00);
+	fm.add_route(1, "rspeaker", 1.00);
+*/
 
 	rf5c68_device &pcm(RF5C68(config, "pcm", 16000000 / 2));  // actual clock speed unknown
 	pcm.set_end_callback(FUNC(towns_state::towns_pcm_irq));

--- a/src/mame/drivers/megadriv.cpp
+++ b/src/mame/drivers/megadriv.cpp
@@ -166,23 +166,7 @@ WRITE16_MEMBER(md_cons_state::mess_md_io_write_data_port)
  *************************************/
 
 
-static INPUT_PORTS_START( md )
-	PORT_START("CTRLSEL")   /* Controller selection */
-	PORT_CONFNAME( 0x0f, 0x00, "Player 1 Controller" )
-	PORT_CONFSETTING( 0x00, "Joystick 3 Buttons" )
-	PORT_CONFSETTING( 0x01, "Joystick 6 Buttons" )
-//  PORT_CONFSETTING( 0x02, "Sega Mouse" )
-/* there exists both a 2 buttons version of the Mouse (Jpn ver, to be used with RPGs, it
-    can aslo be used as trackball) and a 3 buttons version (US ver, no trackball feats.) */
-//  PORT_CONFSETTING( 0x03, "Sega Menacer" )
-//  PORT_CONFSETTING( 0x04, "Konami Justifier" )
-//  PORT_CONFSETTING( 0x05, "Team Player (Sega Multitap)" )
-//  PORT_CONFSETTING( 0x06, "4-Play (EA Multitap)" )
-//  PORT_CONFSETTING( 0x07, "J-Cart" )
-	PORT_CONFNAME( 0xf0, 0x00, "Player 2 Controller" )
-	PORT_CONFSETTING( 0x00, "Joystick 3 Buttons" )
-	PORT_CONFSETTING( 0x10, "Joystick 6 Buttons" )
-
+static INPUT_PORTS_START( md_base )
 	PORT_START("PAD1_3B")       /* Joypad 1 (3 button + start) NOT READ DIRECTLY */
 	PORT_BIT( 0x0001, IP_ACTIVE_LOW, IPT_JOYSTICK_UP ) PORT_8WAY PORT_PLAYER(1) PORT_CONDITION("CTRLSEL", 0x0f, EQUALS, 0x00)
 	PORT_BIT( 0x0002, IP_ACTIVE_LOW, IPT_JOYSTICK_DOWN ) PORT_8WAY PORT_PLAYER(1) PORT_CONDITION("CTRLSEL", 0x0f, EQUALS, 0x00)
@@ -239,6 +223,43 @@ static INPUT_PORTS_START( md )
 	PORT_BIT( 0x0001, IP_ACTIVE_HIGH, IPT_SERVICE1 ) PORT_NAME("Reset Button") PORT_IMPULSE(1) // reset, resets 68k (and..?)
 INPUT_PORTS_END
 
+static INPUT_PORTS_START( md )
+	PORT_INCLUDE( md_base )
+
+	PORT_START("CTRLSEL")   /* Controller selection */
+	PORT_CONFNAME( 0x0f, 0x00, "Player 1 Controller" )
+	PORT_CONFSETTING( 0x00, "Joystick 3 Buttons" )
+	PORT_CONFSETTING( 0x01, "Joystick 6 Buttons" )
+//  PORT_CONFSETTING( 0x02, "Sega Mouse" )
+/* there exists both a 2 buttons version of the Mouse (Jpn ver, to be used with RPGs, it
+    can aslo be used as trackball) and a 3 buttons version (US ver, no trackball feats.) */
+//  PORT_CONFSETTING( 0x03, "Sega Menacer" )
+//  PORT_CONFSETTING( 0x04, "Konami Justifier" )
+//  PORT_CONFSETTING( 0x05, "Team Player (Sega Multitap)" )
+//  PORT_CONFSETTING( 0x06, "4-Play (EA Multitap)" )
+//  PORT_CONFSETTING( 0x07, "J-Cart" )
+	PORT_CONFNAME( 0xf0, 0x00, "Player 2 Controller" )
+	PORT_CONFSETTING( 0x00, "Joystick 3 Buttons" )
+	PORT_CONFSETTING( 0x10, "Joystick 6 Buttons" )
+INPUT_PORTS_END
+
+static INPUT_PORTS_START( megajet )
+	PORT_INCLUDE( md_base )
+
+	PORT_START("CTRLSEL")   /* Fixed controller setting for Player 1 */
+	PORT_CONFNAME( 0x0f, 0x01, "Player 1 Controller" ) // Fixed
+	PORT_CONFSETTING( 0x01, "Joystick 6 Buttons" )
+	PORT_CONFNAME( 0xf0, 0x00, "Player 2 Controller" )
+	PORT_CONFSETTING( 0x00, "Joystick 3 Buttons" )
+	PORT_CONFSETTING( 0x10, "Joystick 6 Buttons" )
+INPUT_PORTS_END
+
+static INPUT_PORTS_START( gen_nomd )
+	PORT_INCLUDE( megajet )
+
+	PORT_MODIFY("RESET")     /* No reset button */
+	PORT_BIT( 0x0001, IP_ACTIVE_HIGH, IPT_UNUSED )
+INPUT_PORTS_END
 
 
 /*************************************
@@ -402,6 +423,19 @@ void md_cons_state::ms_megadpal(machine_config &config)
 	SOFTWARE_LIST(config, "cart_list").set_original("megadriv");
 }
 
+void md_cons_state::ms_megadriv2(machine_config &config)
+{
+	md2_ntsc(config);
+
+	MCFG_MACHINE_START_OVERRIDE(md_cons_state, ms_megadriv)
+	MCFG_MACHINE_RESET_OVERRIDE(md_cons_state, ms_megadriv)
+
+	subdevice<screen_device>("megadriv")->screen_vblank().set(FUNC(md_cons_state::screen_vblank_console));
+
+	MD_CART_SLOT(config, m_cart, md_cart, nullptr);
+	SOFTWARE_LIST(config, "cart_list").set_original("megadriv");
+}
+
 void md_cons_state::genesis_tmss(machine_config &config)
 {
 	ms_megadriv(config);
@@ -458,6 +492,16 @@ ROM_START(dcat16)
 	ROM_REGION(0x800000, "maincpu", ROMREGION_ERASEFF)
 	ROM_LOAD16_WORD_SWAP( "mg6025.u1", 0x0000,  0x800000, CRC(5453d673) SHA1(b9f8d849cbed81fe73525229f4897ccaeeb7a833) )
 
+	ROM_REGION( 0x10000, "soundcpu", ROMREGION_ERASEFF)
+ROM_END
+
+ROM_START(megajet)
+	ROM_REGION(MD_CPU_REGION_SIZE, "maincpu", ROMREGION_ERASEFF)
+	ROM_REGION( 0x10000, "soundcpu", ROMREGION_ERASEFF)
+ROM_END
+
+ROM_START(gen_nomd)
+	ROM_REGION(MD_CPU_REGION_SIZE, "maincpu", ROMREGION_ERASEFF)
 	ROM_REGION( 0x10000, "soundcpu", ROMREGION_ERASEFF)
 ROM_END
 
@@ -756,6 +800,27 @@ void md_cons_state::genesis_scd(machine_config &config)
 	SOFTWARE_LIST(config, "cd_list").set_original("segacd");
 }
 
+void md_cons_state::genesis2_scd(machine_config &config)
+{
+	md2_ntsc(config);
+
+	MCFG_MACHINE_START_OVERRIDE(md_cons_state, ms_megacd)
+	MCFG_MACHINE_RESET_OVERRIDE(md_cons_state, ms_megadriv)
+
+	subdevice<screen_device>("megadriv")->screen_vblank().set(FUNC(md_cons_state::screen_vblank_console));
+
+	SEGA_SEGACD_US(config, m_segacd, 0);
+	m_segacd->set_palette("gen_vdp:gfx_palette");
+	m_segacd->set_hostcpu(m_maincpu);
+	m_segacd->set_screen("megadriv");
+
+	config.set_perfect_quantum("segacd:segacd_68k"); // perfect sync to the fastest cpu
+
+	CDROM(config, "cdrom").set_interface("scd_cdrom");
+
+	SOFTWARE_LIST(config, "cd_list").set_original("segacd");
+}
+
 void md_cons_state::md_scd(machine_config &config)
 {
 	md_pal(config);
@@ -777,9 +842,51 @@ void md_cons_state::md_scd(machine_config &config)
 	SOFTWARE_LIST(config, "cd_list").set_original("megacd");
 }
 
+void md_cons_state::md2_scd(machine_config &config)
+{
+	md2_pal(config);
+
+	MCFG_MACHINE_START_OVERRIDE(md_cons_state, ms_megacd)
+	MCFG_MACHINE_RESET_OVERRIDE(md_cons_state, ms_megadriv)
+
+	subdevice<screen_device>("megadriv")->screen_vblank().set(FUNC(md_cons_state::screen_vblank_console));
+
+	SEGA_SEGACD_EUROPE(config, m_segacd, 0);
+	m_segacd->set_palette("gen_vdp:gfx_palette");
+	m_segacd->set_hostcpu(m_maincpu);
+	m_segacd->set_screen("megadriv");
+
+	config.set_perfect_quantum("segacd:segacd_68k"); // perfect sync to the fastest cpu
+
+	CDROM(config, "cdrom").set_interface("scd_cdrom");
+
+	SOFTWARE_LIST(config, "cd_list").set_original("megacd");
+}
+
 void md_cons_state::mdj_scd(machine_config &config)
 {
 	md_ntsc(config);
+
+	MCFG_MACHINE_START_OVERRIDE(md_cons_state, ms_megacd)
+	MCFG_MACHINE_RESET_OVERRIDE(md_cons_state, ms_megadriv)
+
+	subdevice<screen_device>("megadriv")->screen_vblank().set(FUNC(md_cons_state::screen_vblank_console));
+
+	SEGA_SEGACD_JAPAN(config, m_segacd, 0);
+	m_segacd->set_palette("gen_vdp:gfx_palette");
+	m_segacd->set_hostcpu(m_maincpu);
+	m_segacd->set_screen("megadriv");
+
+	config.set_perfect_quantum("segacd:segacd_68k"); // perfect sync to the fastest cpu
+
+	CDROM(config, "cdrom").set_interface("scd_cdrom");
+
+	SOFTWARE_LIST(config, "cd_list").set_original("megacdj");
+}
+
+void md_cons_state::md2j_scd(machine_config &config)
+{
+	md2_ntsc(config);
 
 	MCFG_MACHINE_START_OVERRIDE(md_cons_state, ms_megacd)
 	MCFG_MACHINE_RESET_OVERRIDE(md_cons_state, ms_megadriv)
@@ -1075,41 +1182,46 @@ ROM_END
 
 ***************************************************************************/
 
-/*    YEAR  NAME          PARENT    COMPAT  MACHINE          INPUT  CLASS          INIT       COMPANY   FULLNAME */
-CONS( 1989, genesis,      0,        0,      ms_megadriv,     md,    md_cons_state, init_genesis, "Sega",   "Genesis (USA, NTSC)",  MACHINE_SUPPORTS_SAVE )
-CONS( 1990, megadriv,     genesis,  0,      ms_megadpal,     md,    md_cons_state, init_md_eur,  "Sega",   "Mega Drive (Europe, PAL)", MACHINE_SUPPORTS_SAVE )
-CONS( 1988, megadrij,     genesis,  0,      ms_megadriv,     md,    md_cons_state, init_md_jpn,  "Sega",   "Mega Drive (Japan, NTSC)", MACHINE_SUPPORTS_SAVE )
+/*    YEAR  NAME          PARENT    COMPAT  MACHINE          INPUT     CLASS          INIT          COMPANY   FULLNAME */
+CONS( 1989, genesis,      0,        0,      ms_megadriv,     md,       md_cons_state, init_genesis, "Sega",   "Genesis (USA, NTSC)",  MACHINE_SUPPORTS_SAVE )
+CONS( 1990, megadriv,     genesis,  0,      ms_megadpal,     md,       md_cons_state, init_md_eur,  "Sega",   "Mega Drive (Europe, PAL)", MACHINE_SUPPORTS_SAVE )
+CONS( 1988, megadrij,     genesis,  0,      ms_megadriv,     md,       md_cons_state, init_md_jpn,  "Sega",   "Mega Drive (Japan, NTSC)", MACHINE_SUPPORTS_SAVE )
 
 // 1990+ models had the TMSS security chip, leave this as a clone, it reduces compatibility and nothing more.
-CONS( 1990, genesis_tmss, genesis,  0,      genesis_tmss,    md,    md_cons_state, init_genesis, "Sega",   "Genesis (USA, NTSC, with TMSS chip)",  MACHINE_SUPPORTS_SAVE )
-
+CONS( 1990, genesis_tmss, genesis,  0,      genesis_tmss,    md,       md_cons_state, init_genesis, "Sega",   "Genesis (USA, NTSC, with TMSS chip)",  MACHINE_SUPPORTS_SAVE )
 
 // the 32X plugged in the cart slot, games plugged into the 32x.  Maybe it should be handled as an expansion device?
-CONS( 1994, 32x,          0,        0,      genesis_32x,     md,    md_cons_state, init_genesis, "Sega",   "Genesis with 32X (USA, NTSC)", MACHINE_NOT_WORKING )
-CONS( 1994, 32xe,         32x,      0,      md_32x,          md,    md_cons_state, init_md_eur,  "Sega",   "Mega Drive with 32X (Europe, PAL)", MACHINE_NOT_WORKING )
-CONS( 1994, 32xj,         32x,      0,      mdj_32x,         md,    md_cons_state, init_md_jpn,  "Sega",   "Mega Drive with 32X (Japan, NTSC)", MACHINE_NOT_WORKING )
+CONS( 1994, 32x,          0,        0,      genesis_32x,     md,       md_cons_state, init_genesis, "Sega",   "Genesis with 32X (USA, NTSC)", MACHINE_NOT_WORKING )
+CONS( 1994, 32xe,         32x,      0,      md_32x,          md,       md_cons_state, init_md_eur,  "Sega",   "Mega Drive with 32X (Europe, PAL)", MACHINE_NOT_WORKING )
+CONS( 1994, 32xj,         32x,      0,      mdj_32x,         md,       md_cons_state, init_md_jpn,  "Sega",   "Mega Drive with 32X (Japan, NTSC)", MACHINE_NOT_WORKING )
 
 // the SegaCD plugged into the expansion port..
-CONS( 1992, segacd,       0,        0,      genesis_scd,     md,    md_cons_state, init_genesis, "Sega",   "Sega CD (USA, NTSC)", MACHINE_NOT_WORKING )
-CONS( 1993, megacd,       segacd,   0,      md_scd,          md,    md_cons_state, init_md_eur,  "Sega",   "Mega-CD (Europe, PAL)", MACHINE_NOT_WORKING )
-CONS( 1991, megacdj,      segacd,   0,      mdj_scd,         md,    md_cons_state, init_md_jpn,  "Sega",   "Mega-CD (Japan, NTSC)", MACHINE_NOT_WORKING ) // this bios doesn't work with our ram interleave needed by a few games?!
-CONS( 1991, megacda,      segacd,   0,      md_scd,          md,    md_cons_state, init_md_eur,  "Sega",   "Mega-CD (Asia, PAL)", MACHINE_NOT_WORKING )
-CONS( 1993, segacd2,      0,        0,      genesis_scd,     md,    md_cons_state, init_genesis, "Sega",   "Sega CD 2 (USA, NTSC)", MACHINE_NOT_WORKING )
-CONS( 1993, megacd2,      segacd2,  0,      md_scd,          md,    md_cons_state, init_md_eur,  "Sega",   "Mega-CD 2 (Europe, PAL)", MACHINE_NOT_WORKING )
-CONS( 1993, megacd2j,     segacd2,  0,      mdj_scd,         md,    md_cons_state, init_md_jpn,  "Sega",   "Mega-CD 2 (Japan, NTSC)", MACHINE_NOT_WORKING )
-CONS( 1994, aiwamcd,      segacd2,  0,      mdj_scd,         md,    md_cons_state, init_md_jpn,  "AIWA",   "Mega-CD CSD-G1M (Japan, NTSC)", MACHINE_NOT_WORKING )
-CONS( 1993, laseract,     0,        0,      genesis_scd,     md,    md_cons_state, init_genesis, "Pioneer","LaserActive (USA, NTSC)", MACHINE_NOT_WORKING )
-CONS( 1993, laseractj,    laseract, 0,      mdj_scd,         md,    md_cons_state, init_md_jpn,  "Pioneer","LaserActive (Japan, NTSC)", MACHINE_NOT_WORKING )
-CONS( 1993, xeye,         0,        0,      genesis_scd,     md,    md_cons_state, init_genesis, "JVC",    "X'eye (USA, NTSC)", MACHINE_NOT_WORKING )
-CONS( 1992, wmega,        xeye,     0,      mdj_scd,         md,    md_cons_state, init_md_jpn,  "Sega",   "Wondermega (Japan, NTSC)", MACHINE_NOT_WORKING )
-CONS( 1993, wmegam2,      xeye,     0,      mdj_scd,         md,    md_cons_state, init_md_jpn,  "Victor", "Wondermega M2 (Japan, NTSC)", MACHINE_NOT_WORKING )
-CONS( 1994, cdx,          0,        0,      genesis_scd,     md,    md_cons_state, init_genesis, "Sega",   "CDX (USA, NTSC)", MACHINE_NOT_WORKING )
-CONS( 1994, multmega,     cdx,      0,      md_scd,          md,    md_cons_state, init_md_eur,  "Sega",   "Multi-Mega (Europe, PAL)", MACHINE_NOT_WORKING )
+CONS( 1992, segacd,       0,        0,      genesis_scd,     md,       md_cons_state, init_genesis, "Sega",   "Sega CD (USA, NTSC)", MACHINE_NOT_WORKING )
+CONS( 1993, megacd,       segacd,   0,      md_scd,          md,       md_cons_state, init_md_eur,  "Sega",   "Mega-CD (Europe, PAL)", MACHINE_NOT_WORKING )
+CONS( 1991, megacdj,      segacd,   0,      mdj_scd,         md,       md_cons_state, init_md_jpn,  "Sega",   "Mega-CD (Japan, NTSC)", MACHINE_NOT_WORKING ) // this bios doesn't work with our ram interleave needed by a few games?!
+CONS( 1991, megacda,      segacd,   0,      md_scd,          md,       md_cons_state, init_md_eur,  "Sega",   "Mega-CD (Asia, PAL)", MACHINE_NOT_WORKING )
+CONS( 1993, segacd2,      0,        0,      genesis_scd,     md,       md_cons_state, init_genesis, "Sega",   "Sega CD 2 (USA, NTSC)", MACHINE_NOT_WORKING )
+CONS( 1993, megacd2,      segacd2,  0,      md_scd,          md,       md_cons_state, init_md_eur,  "Sega",   "Mega-CD 2 (Europe, PAL)", MACHINE_NOT_WORKING )
+CONS( 1993, megacd2j,     segacd2,  0,      mdj_scd,         md,       md_cons_state, init_md_jpn,  "Sega",   "Mega-CD 2 (Japan, NTSC)", MACHINE_NOT_WORKING )
+CONS( 1994, aiwamcd,      segacd2,  0,      mdj_scd,         md,       md_cons_state, init_md_jpn,  "AIWA",   "Mega-CD CSD-G1M (Japan, NTSC)", MACHINE_NOT_WORKING )
+CONS( 1993, laseract,     0,        0,      genesis_scd,     md,       md_cons_state, init_genesis, "Pioneer","LaserActive (USA, NTSC)", MACHINE_NOT_WORKING )
+CONS( 1993, laseractj,    laseract, 0,      mdj_scd,         md,       md_cons_state, init_md_jpn,  "Pioneer","LaserActive (Japan, NTSC)", MACHINE_NOT_WORKING )
+CONS( 1993, xeye,         0,        0,      genesis2_scd,    md,       md_cons_state, init_genesis, "JVC",    "X'eye (USA, NTSC)", MACHINE_NOT_WORKING )
+CONS( 1992, wmega,        xeye,     0,      mdj_scd,         md,       md_cons_state, init_md_jpn,  "Sega",   "Wondermega (Japan, NTSC)", MACHINE_NOT_WORKING )
+CONS( 1993, wmegam2,      xeye,     0,      md2j_scd,        md,       md_cons_state, init_md_jpn,  "Victor", "Wondermega M2 (Japan, NTSC)", MACHINE_NOT_WORKING )
+CONS( 1994, cdx,          0,        0,      genesis2_scd,    md,       md_cons_state, init_genesis, "Sega",   "CDX (USA, NTSC)", MACHINE_NOT_WORKING )
+CONS( 1994, multmega,     cdx,      0,      md2_scd,         md,       md_cons_state, init_md_eur,  "Sega",   "Multi-Mega (Europe, PAL)", MACHINE_NOT_WORKING )
 
 //32X plugged in the cart slot + SegaCD plugged into the expansion port..
-CONS( 1994, 32x_scd,      0,        0,      genesis_32x_scd, md,    md_cons_state, init_genesis, "Sega",   "Sega CD with 32X (USA, NTSC)", MACHINE_NOT_WORKING )
-CONS( 1995, 32x_mcd,      32x_scd,  0,      md_32x_scd,      md,    md_cons_state, init_md_eur,  "Sega",   "Mega-CD with 32X (Europe, PAL)", MACHINE_NOT_WORKING )
-CONS( 1994, 32x_mcdj,     32x_scd,  0,      mdj_32x_scd,     md,    md_cons_state, init_md_jpn,  "Sega",   "Mega-CD with 32X (Japan, NTSC)", MACHINE_NOT_WORKING )
+CONS( 1994, 32x_scd,      0,        0,      genesis_32x_scd, md,       md_cons_state, init_genesis, "Sega",   "Sega CD with 32X (USA, NTSC)", MACHINE_NOT_WORKING )
+CONS( 1995, 32x_mcd,      32x_scd,  0,      md_32x_scd,      md,       md_cons_state, init_md_eur,  "Sega",   "Mega-CD with 32X (Europe, PAL)", MACHINE_NOT_WORKING )
+CONS( 1994, 32x_mcdj,     32x_scd,  0,      mdj_32x_scd,     md,       md_cons_state, init_md_jpn,  "Sega",   "Mega-CD with 32X (Japan, NTSC)", MACHINE_NOT_WORKING )
+
+// handheld hardware
+CONS( 1995, gen_nomd,     0,        0,      ms_megadriv2,    gen_nomd, md_cons_state, init_genesis, "Sega",   "Genesis Nomad (USA Genesis handheld)",  MACHINE_SUPPORTS_SAVE )
+
+// handheld without LCD
+CONS( 1993, megajet,      gen_nomd, 0,      ms_megadriv2,    megajet,  md_cons_state, init_md_jpn,  "Sega",   "Mega Jet (Japan Mega Drive handheld)",  MACHINE_SUPPORTS_SAVE )
 
 /* clone hardware - not sure if this hardware is running some kind of emulator, or enhanced MD clone, or just custom banking */
-CONS( 200?, dcat16,       0,        0,      dcat16_megadriv, md,    md_cons_state, init_genesis, "Firecore",   "D-CAT16 (Mega Drive handheld)",  MACHINE_NOT_WORKING )
+CONS( 200?, dcat16,       0,        0,      dcat16_megadriv, md,       md_cons_state, init_genesis, "Firecore",   "D-CAT16 (Mega Drive handheld)",  MACHINE_NOT_WORKING )

--- a/src/mame/includes/megadriv.h
+++ b/src/mame/includes/megadriv.h
@@ -139,7 +139,9 @@ public:
 
 	void megadriv_timers(machine_config &config);
 	void md_ntsc(machine_config &config);
+	void md2_ntsc(machine_config &config);
 	void md_pal(machine_config &config);
+	void md2_pal(machine_config &config);
 	void md_bootleg(machine_config &config);
 	void dcat16_megadriv_base(machine_config &config);
 	void dcat16_megadriv_map(address_map &map);
@@ -201,11 +203,15 @@ public:
 	void md_32x_scd(machine_config &config);
 	void mdj_32x(machine_config &config);
 	void ms_megadriv(machine_config &config);
+	void ms_megadriv2(machine_config &config);
 	void mdj_scd(machine_config &config);
+	void md2j_scd(machine_config &config);
 	void md_32x(machine_config &config);
 	void genesis_32x(machine_config &config);
 	void md_scd(machine_config &config);
+	void md2_scd(machine_config &config);
 	void genesis_scd(machine_config &config);
+	void genesis2_scd(machine_config &config);
 	void genesis_tmss(machine_config &config);
 };
 

--- a/src/mame/machine/megadriv.cpp
+++ b/src/mame/machine/megadriv.cpp
@@ -945,6 +945,16 @@ void md_base_state::md_ntsc(machine_config &config)
 	m_ymsnd->add_route(1, "rspeaker", 0.50);
 }
 
+void md_base_state::md2_ntsc(machine_config &config)
+{
+	md_ntsc(config);
+
+	// Internalized YM3438 in VDP ASIC
+	YM3438(config.replace(), m_ymsnd, MASTER_CLOCK_NTSC/7); /* 7.67 MHz */
+	m_ymsnd->add_route(0, "lspeaker", 0.50);
+	m_ymsnd->add_route(1, "rspeaker", 0.50);
+}
+
 void md_cons_state::dcat16_megadriv_base(machine_config &config)
 {
 	md_ntsc(config);
@@ -995,7 +1005,17 @@ void md_base_state::md_pal(machine_config &config)
 	SPEAKER(config, "lspeaker").front_left();
 	SPEAKER(config, "rspeaker").front_right();
 
-	YM2612(config, m_ymsnd, MASTER_CLOCK_NTSC/7); /* 7.67 MHz */
+	YM2612(config, m_ymsnd, MASTER_CLOCK_PAL / 7); /* 7.67 MHz */
+	m_ymsnd->add_route(0, "lspeaker", 0.50);
+	m_ymsnd->add_route(1, "rspeaker", 0.50);
+}
+
+void md_base_state::md2_pal(machine_config &config)
+{
+	md_pal(config);
+
+	// Internalized YM3438 in VDP ASIC
+	YM3438(config.replace(), m_ymsnd, MASTER_CLOCK_NTSC/7); /* 7.67 MHz */
 	m_ymsnd->add_route(0, "lspeaker", 0.50);
 	m_ymsnd->add_route(1, "rspeaker", 0.50);
 }

--- a/src/mame/machine/megadriv.cpp
+++ b/src/mame/machine/megadriv.cpp
@@ -1015,7 +1015,7 @@ void md_base_state::md2_pal(machine_config &config)
 	md_pal(config);
 
 	// Internalized YM3438 in VDP ASIC
-	YM3438(config.replace(), m_ymsnd, MASTER_CLOCK_NTSC/7); /* 7.67 MHz */
+	YM3438(config.replace(), m_ymsnd, MASTER_CLOCK_PAL / 7); /* 7.67 MHz */
 	m_ymsnd->add_route(0, "lspeaker", 0.50);
 	m_ymsnd->add_route(1, "rspeaker", 0.50);
 }

--- a/src/mame/mame.lst
+++ b/src/mame/mame.lst
@@ -21688,6 +21688,8 @@ wmega                           // 1992 Sega Wondermega (Japan)
 wmegam2                         // 1993 Victor Wondermega M2 (Japan)
 xeye                            // 1993 JVC X'eye (USA)
 dcat16                          //
+gen_nomd                        // 1995 Sega Genesis Nomad (USA)
+megajet                         // 1993 Sega Mega Jet (Japan)
 
 @source:megadriv_acbl.cpp
 aladmdb                         // MegaDrive-based hack


### PR DESCRIPTION
2612intf.cpp : Fix output bits, Device-fied YMF276, Add notes
fm2612.cpp : Add output bit variation, Fix DAC calculation
fmtowns.cpp : Add YMF276 placeholder for later model use this
megadriv.cpp : Add config for when YM3438 is integreated in ASIC, Add handheld variations, Fix PAL sound clock