### PR TITLE
ibm5150.xml: add UCSD p-System

### DIFF
--- a/hash/ibm5150.xml
+++ b/hash/ibm5150.xml
@@ -11676,6 +11676,64 @@ has been replaced with an all-zero block. -->
 		</part>
 	</software>
 
+	<software name="ucsdpsys">
+		<description>UCSD p-System</description>
+		<year>1982</year>
+		<publisher>IBM</publisher>
+		<!-- software reports version as IV.03 -->
+		<info name="version" value="IV.0 Release 1" />
+		<!-- Origin: BitSavers -->
+		<part name="flop1" interface="floppy_5_25">
+			<feature name="part_id" value="STARTUP:" />
+			<dataarea name="flop" size = "145805">
+				<rom name="STARTUP.IMD" size="145805" crc="7649f9e8" sha1="f84fe212e83064e574b00e24c412d486d1e89fb0"/>
+			</dataarea>
+		</part>
+		<part name="flop2" interface="floppy_5_25">
+			<feature name="part_id" value="SYSTEM2:" />
+			<dataarea name="flop" size = "148360">
+				<rom name="SYSTEM2.IMD" size="148360" crc="917fdc1d" sha1="aa871bc127168c2f17b528811e9bde4a0b75e209"/>
+			</dataarea>
+		</part>
+		<part name="flop3" interface="floppy_5_25">
+			<feature name="part_id" value="SYSTEM4:" />
+			<dataarea name="flop" size = "150404">
+				<rom name="SYSTEM4.IMD" size="150404" crc="84ca430c" sha1="f8886fe4bdd58cb0ea88cfe8bc5d801e2b29ba58"/>
+			</dataarea>
+		</part>
+		<part name="flop4" interface="floppy_5_25">
+			<feature name="part_id" value="UTILITY:" />
+			<dataarea name="flop" size = "124854">
+				<rom name="UTILITY.IMD" size="124854" crc="156f20c1" sha1="47d5f925380295959b16312f3db937607295f8da"/>
+			</dataarea>
+		</part>
+		<part name="flop5" interface="floppy_5_25">
+			<feature name="part_id" value="EXTRAS:" />
+			<dataarea name="flop" size = "157047">
+				<rom name="EXTRAS.IMD" size="157047" crc="8bc772f1" sha1="6f29de1cb08d07944e9a93dd98e749c1d3b5b7ca"/>
+			</dataarea>
+		</part>
+		<part name="flop6" interface="floppy_5_25">
+			<feature name="part_id" value="FORTRAN:" />
+			<dataarea name="flop" size = "112590">
+				<rom name="FORTRAN.IMD" size="112590" crc="192e0a52" sha1="c334ca3c13206dcd4296c90983fa1a67ce5e7654"/>
+			</dataarea>
+		</part>
+		<!-- Origin: z80.eu -->
+		<part name="flop7" interface="floppy_5_25">
+			<feature name="part_id" value="SYSTEM2: (alternate)" />
+			<dataarea name="flop" size = "163840">
+				<rom name="UCSD_IV_3_SYSTEM2.IMA" size="163840" crc="4c6c6da0" sha1="dfa4c31d143bb99ee6bf3b75f64eb65fa9f681a4"/>
+			</dataarea>
+		</part>
+		<part name="flop8" interface="floppy_5_25">
+			<feature name="part_id" value="PASCAL:" />
+			<dataarea name="flop" size = "163840">
+				<rom name="UCSD_IV_3_PASCAL.IMA" size="163840" crc="bdd699ba" sha1="df3392aa561a53148f193d070e84274f087127cf"/>
+			</dataarea>
+		</part>
+	</software>
+
 	<software name="ums2pe">
 		<description>UMS II: Nations at War - Planet Editor</description>
 		<year>1992</year>


### PR DESCRIPTION
UCSD p-System was one of the three original OS for the IBM PC. This software list addition is based on two sources:
- https://www.bitsavers.org/bits/IBM/PC/p-system/p-system_rel_1.zip (base system plus FORTRAN)
- http://www.z80.eu/downloads/IBMPC-UCSD.zip (alternate SYSTEM2 disk and PASCAL)

I've verified this works fine in MAME.