### PR TITLE
apply2 floppy format: bake in the track count

### DIFF
--- a/src/lib/formats/ap2_dsk.cpp
+++ b/src/lib/formats/ap2_dsk.cpp
@@ -496,19 +496,19 @@ static uint32_t apple2_get_track_size(floppy_image_legacy *floppy, int head, int
 LEGACY_FLOPPY_OPTIONS_START( apple2 )
 	LEGACY_FLOPPY_OPTION( apple2_do, "do,dsk,bin",  "Apple ][ DOS order disk image",    apple2_dsk_identify,    apple2_do_construct, nullptr,
 		HEADS([1])
-		TRACKS([APPLE2_TRACK_COUNT])
+		TRACKS([40]) // APPLE2_TRACK_COUNT
 		SECTORS([16])
 		SECTOR_LENGTH([256])
 		FIRST_SECTOR_ID([0]))
 	LEGACY_FLOPPY_OPTION( apple2_po, "po,dsk,bin",  "Apple ][ ProDOS order disk image", apple2_dsk_identify,    apple2_po_construct, nullptr,
 		HEADS([1])
-		TRACKS([APPLE2_TRACK_COUNT])
+		TRACKS([40]) // APPLE2_TRACK_COUNT
 		SECTORS([16])
 		SECTOR_LENGTH([256])
 		FIRST_SECTOR_ID([0]))
 	LEGACY_FLOPPY_OPTION( apple2_nib, "dsk,nib",    "Apple ][ Nibble order disk image", apple2_nib_identify,    apple2_nib_construct, nullptr,
 		HEADS([1])
-		TRACKS([APPLE2_TRACK_COUNT])
+		TRACKS([40]) // APPLE2_TRACK_COUNT
 		SECTORS([16])
 		SECTOR_LENGTH([256])
 		FIRST_SECTOR_ID([0]))


### PR DESCRIPTION
The APPLE2_TRACK_COUNT macro was not being expanded here, at least on gcc8.
This resulted in the string "APPLE2_TRACK_COUNT" being within the specification
and that in turn broke option_resolution::lookup_in_specification leading to
an assertion fail with the debug checks enabled. So bake in the numeric
constant to at least get things working again.

Not a pretty fix - has anyone got a better idea?