### PR TITLE
kaneko_spr.cpp : Fix drawing behavior

### DIFF
--- a/src/mame/drivers/expro02.cpp
+++ b/src/mame/drivers/expro02.cpp
@@ -390,7 +390,8 @@ uint32_t expro02_state::screen_update_backgrounds(screen_device &screen, bitmap_
 uint32_t expro02_state::screen_update(screen_device &screen, bitmap_ind16 &bitmap, const rectangle &cliprect)
 {
 	screen_update_backgrounds(screen, bitmap, cliprect);
-	m_kaneko_spr->render_sprites(bitmap,cliprect, screen.priority(), m_spriteram, m_spriteram.bytes());
+	m_kaneko_spr->render_sprites(cliprect, m_spriteram, m_spriteram.bytes());
+	m_kaneko_spr->copybitmap(bitmap, cliprect, screen.priority());
 	return 0;
 }
 

--- a/src/mame/drivers/galpanic_ms.cpp
+++ b/src/mame/drivers/galpanic_ms.cpp
@@ -154,7 +154,8 @@ uint32_t galspanic_ms_state::screen_update_backgrounds(screen_device &screen, bi
 uint32_t galspanic_ms_state::screen_update(screen_device &screen, bitmap_ind16 &bitmap, const rectangle &cliprect)
 {
 	screen_update_backgrounds(screen, bitmap, cliprect);
-//  m_kaneko_spr->render_sprites(bitmap,cliprect, screen.priority(), m_spriteram, m_spriteram.bytes());
+//  m_kaneko_spr->render_sprites(cliprect, m_spriteram, m_spriteram.bytes());
+//  m_kaneko_spr->copybitmap(bitmap, cliprect, screen.priority());
 	return 0;
 }
 

--- a/src/mame/drivers/kaneko16.cpp
+++ b/src/mame/drivers/kaneko16.cpp
@@ -86,7 +86,6 @@ Dip locations verified from manual for:
 
 [general]
 - interrupt timing/behaviour
-- replace sample bank copying with new ADDRESS MAP system for OKI and do banking like CPUs
 
 Non-Bugs (happen on real PCB)
 
@@ -308,9 +307,7 @@ void kaneko16_state::bakubrkr_map(address_map &map)
 {
 	map(0x000000, 0x07ffff).rom();     // ROM
 	map(0x100000, 0x10ffff).ram();     // Work RAM
-	map(0x400000, 0x40001f).r(FUNC(kaneko16_state::ym2149_r<0>)); // Sound
-	map(0x400000, 0x40001d).w(FUNC(kaneko16_state::ym2149_w<0>));
-	map(0x40001f, 0x40001f).w(FUNC(kaneko16_state::oki_bank0_w<7>)); // OKI bank Switch
+	map(0x400000, 0x40001f).rw(FUNC(kaneko16_state::ym2149_r<0>), FUNC(kaneko16_state::ym2149_w<0>)); // Sound
 	map(0x400200, 0x40021f).rw(FUNC(kaneko16_state::ym2149_r<1>), FUNC(kaneko16_state::ym2149_w<1>));          // Sound
 	map(0x400401, 0x400401).rw(m_oki[0], FUNC(okim6295_device::read), FUNC(okim6295_device::write));  //
 	map(0x500000, 0x503fff).m(m_view2[0], FUNC(kaneko_view2_tilemap_device::vram_map));
@@ -1659,6 +1656,8 @@ TIMER_DEVICE_CALLBACK_MEMBER(kaneko16_state::interrupt)
 	// main vblank interrupt
 	if (scanline == 224)
 	{
+		// 2 frame delayed normaly; differs per PCB?
+		m_kaneko_spr->render_sprites(m_screen->visible_area(), m_spriteram->buffer(), m_spriteram->bytes());
 		m_spriteram->copy();
 		m_maincpu->set_input_line(5, HOLD_LINE);
 	}
@@ -1789,6 +1788,7 @@ void kaneko16_state::bakubrkr(machine_config &config)
 
 	YM2149(config, m_ym2149[0], XTAL(12'000'000)/6); /* verified on pcb */
 	m_ym2149[0]->add_route(ALL_OUTPUTS, "mono", 1.0);
+	m_ym2149[0]->port_b_write_callback().set(FUNC(kaneko16_state::oki_bank0_w<7>)); /* outputs B:  OKI bank Switch */
 
 	YM2149(config, m_ym2149[1], XTAL(12'000'000)/6); /* verified on pcb */
 	m_ym2149[1]->add_route(ALL_OUTPUTS, "mono", 1.0);
@@ -2139,8 +2139,8 @@ TIMER_DEVICE_CALLBACK_MEMBER(kaneko16_shogwarr_state::shogwarr_interrupt)
 
 	if (scanline == 224)
 	{
-		m_spriteram->copy(); // TODO : shogwarr sprites are 1 frame delayed? reference : https://youtu.be/aj4ayOc4MuI
-		// the code for this interrupt is provided by the MCU..
+		m_kaneko_spr->render_sprites(m_screen->visible_area(), m_spriteram->buffer(), m_spriteram->bytes());
+		m_spriteram->copy();
 		m_maincpu->set_input_line(4, HOLD_LINE);
 	}
 
@@ -2923,7 +2923,6 @@ ROM_START( bloodwar )
 
 	ROM_REGION( 0x020000, "mcudata", 0 )            /* MCU Code */
 	ROM_LOAD16_WORD_SWAP( "ofd0x3.124",  0x000000, 0x020000, CRC(399f2005) SHA1(ff0370724770c35963953fd9596d9f808ba87d8f) )
-
 
 	ROM_REGION( 0x1e00000, "kan_spr", 0 )  /* Sprites */
 	ROM_LOAD       ( "of-200-0201.8",   0x0000000, 0x200000, CRC(bba63025) SHA1(daec5285469ee953f6f838fe3cb3903524e9ac39) )

--- a/src/mame/video/galpani2.cpp
+++ b/src/mame/video/galpani2.cpp
@@ -140,6 +140,10 @@ if (machine().input().code_pressed(KEYCODE_Z))
 	if (layers_ctrl & 0x1) copybg15(screen, bitmap, cliprect);
 	if (layers_ctrl & 0x2) copybg8(screen, bitmap, cliprect, 0);
 	if (layers_ctrl & 0x4) copybg8(screen, bitmap, cliprect, 1);
-	if (layers_ctrl & 0x8) m_kaneko_spr->render_sprites(bitmap, cliprect, screen.priority(), m_spriteram, m_spriteram.bytes());
+	if (layers_ctrl & 0x8)
+	{
+		m_kaneko_spr->render_sprites(cliprect, m_spriteram, m_spriteram.bytes());
+		m_kaneko_spr->copybitmap(bitmap, cliprect, screen.priority());
+	}
 	return 0;
 }

--- a/src/mame/video/kaneko16.cpp
+++ b/src/mame/video/kaneko16.cpp
@@ -83,7 +83,7 @@ u32 kaneko16_state::screen_update(screen_device &screen, bitmap_ind16 &bitmap, c
 	if (!m_disp_enable) return 0;
 
 	screen_update_common(screen, bitmap, cliprect);
-	m_kaneko_spr->render_sprites(bitmap,cliprect, screen.priority(), m_spriteram->buffer(), m_spriteram->bytes());
+	m_kaneko_spr->copybitmap(bitmap, cliprect, screen.priority());
 	return 0;
 }
 
@@ -229,6 +229,6 @@ u32 kaneko16_berlwall_state::screen_update(screen_device &screen, bitmap_rgb32 &
 	if (!m_disp_enable) return 0;
 
 	screen_update_common(screen, bitmap, cliprect);
-	m_kaneko_spr->render_sprites(bitmap,cliprect, screen.priority(), m_spriteram->buffer(), m_spriteram->bytes()/2);
+	m_kaneko_spr->copybitmap(bitmap, cliprect, screen.priority());
 	return 0;
 }

--- a/src/mame/video/kaneko_spr.h
+++ b/src/mame/video/kaneko_spr.h
@@ -46,15 +46,15 @@ public:
 	// (legacy) used in the bitmap clear functions
 	virtual int get_sprite_type(void) =0;
 
-	void render_sprites(bitmap_ind16 &bitmap, const rectangle &cliprect, bitmap_ind8 &priority_bitmap, u16* spriteram16, int spriteram16_bytes);
-	void render_sprites(bitmap_rgb32 &bitmap, const rectangle &cliprect, bitmap_ind8 &priority_bitmap, u16* spriteram16, int spriteram16_bytes);
+	void render_sprites(const rectangle &cliprect, u16* spriteram16, int spriteram16_bytes);
 
+	void copybitmap(bitmap_ind16 &bitmap, const rectangle &cliprect, bitmap_ind8 &priority_bitmap);
+	void copybitmap(bitmap_rgb32 &bitmap, const rectangle &cliprect, bitmap_ind8 &priority_bitmap);
 
 	template<class _BitmapClass>
-	void render_sprites_common(_BitmapClass &bitmap, const rectangle &cliprect, bitmap_ind8 &priority_bitmap, u16* spriteram16, int spriteram16_bytes);
+	void copybitmap_common(_BitmapClass &bitmap, const rectangle &cliprect, bitmap_ind8 &priority_bitmap);
 
 	void bootleg_draw_sprites(bitmap_ind16 &bitmap, const rectangle &cliprect, u16* spriteram16, int spriteram16_bytes);
-
 
 	u16 regs_r(offs_t offset);
 	void regs_w(offs_t offset, u16 data, u16 mem_mask);
@@ -97,21 +97,17 @@ private:
 	std::unique_ptr<struct tempsprite_t[]> m_first_sprite;
 	int m_keep_sprites;
 	bitmap_ind16 m_sprites_bitmap;
+	bitmap_ind8 m_sprites_maskmap;
 
 
-	template<class _BitmapClass>
-	void draw_sprites(_BitmapClass &bitmap, const rectangle &cliprect, bitmap_ind8 &priority_bitmap, u16* spriteram16, int spriteram16_bytes);
+	void draw_sprites(const rectangle &cliprect, u16* spriteram16, int spriteram16_bytes);
 
 
-	template<class _BitmapClass>
-	void draw_sprites_custom(_BitmapClass &dest_bmp,const rectangle &clip,gfx_element *gfx,
+	void draw_sprites_custom(const rectangle &clip,gfx_element *gfx,
 			u32 code,u32 color,bool flipx,bool flipy,int sx,int sy,
-			bitmap_ind8 &priority_bitmap, int priority);
+			int priority);
 
 	int parse_sprite_type012(int i, struct tempsprite_t *s, u16* spriteram16, int spriteram16_bytes);
-
-	void copybitmap(bitmap_ind16 &bitmap, const rectangle &cliprect);
-	void copybitmap(bitmap_rgb32 &bitmap, const rectangle &cliprect);
 };
 
 //extern const device_type KANEKO16_SPRITE;


### PR DESCRIPTION
Fix priority in enabled 'keep sprite' function, Split 'Copy temporary bitmap into screen bitmap' function and Getting sprite function
kaneko16.cpp : Fix sprite delay, Add notes, Correct explbrkr OKI bankswitching (tied into m_ym2149[0] port B), Remove outdated note