### PR TITLE
OPL3/4 busy cycle/mixing updates, device-fied YMF289B OPL3-L (Low voltage variation of OPL3)

### DIFF
--- a/src/devices/bus/msx_cart/moonsound.cpp
+++ b/src/devices/bus/msx_cart/moonsound.cpp
@@ -47,12 +47,10 @@ void msx_cart_moonsound_device::device_add_mconfig(machine_config &config)
 	m_ymf278b->irq_handler().set(FUNC(msx_cart_moonsound_device::irq_w));
 	m_ymf278b->add_route(0, "lspeaker", 0.50);
 	m_ymf278b->add_route(1, "rspeaker", 0.50);
-	m_ymf278b->add_route(2, "lspeaker", 0.50);
-	m_ymf278b->add_route(3, "rspeaker", 0.50);
-	m_ymf278b->add_route(4, "lspeaker", 0.40);
-	m_ymf278b->add_route(5, "rspeaker", 0.40);
-	m_ymf278b->add_route(6, "lspeaker", 0.40);
-	m_ymf278b->add_route(7, "rspeaker", 0.40);
+	m_ymf278b->add_route(2, "lspeaker", 0.40);
+	m_ymf278b->add_route(3, "rspeaker", 0.40);
+	m_ymf278b->add_route(4, "lspeaker", 0.50);
+	m_ymf278b->add_route(5, "rspeaker", 0.50);
 }
 
 

--- a/src/devices/sound/262intf.h
+++ b/src/devices/sound/262intf.h
@@ -4,6 +4,7 @@
 #define MAME_SOUND_262INTF_H
 
 #pragma once
+#include "ymf262.h"
 
 class ymf262_device : public device_t, public device_sound_interface
 {
@@ -16,7 +17,12 @@ public:
 	u8 read(offs_t offset);
 	void write(offs_t offset, u8 data);
 
+	// for VGMPlay data handling
+	bool busy() { return internal_busy(m_chip); }
+
 protected:
+	ymf262_device(const machine_config &mconfig, device_type type, const char *tag, device_t *owner, uint32_t clock);
+
 	// device-level overrides
 	virtual void device_post_load() override;
 	virtual void device_start() override;
@@ -29,7 +35,6 @@ protected:
 	// sound stream update overrides
 	virtual void sound_stream_update(sound_stream &stream, stream_sample_t **inputs, stream_sample_t **outputs, int samples) override;
 
-private:
 	void irq_handler(int irq);
 	void timer_handler(int c, const attotime &period);
 	void update_request() { m_stream->update(); }
@@ -40,11 +45,27 @@ private:
 
 	// internal state
 	sound_stream *  m_stream;
-	emu_timer *     m_timer[2];
+	emu_timer *     m_timer[OPL3_TIMER_MAX];
 	void *          m_chip;
 	devcb_write_line m_irq_handler;
 };
 
+class ymf289b_device : public ymf262_device
+{
+public:
+	ymf289b_device(const machine_config &mconfig, const char *tag, device_t *owner, uint32_t clock);
+
+protected:
+	// device-level overrides
+	virtual void device_start() override;
+	virtual void device_clock_changed() override;
+
+	// sound stream update overrides
+	virtual void sound_stream_update(sound_stream &stream, stream_sample_t **inputs, stream_sample_t **outputs, int samples) override;
+
+};
+
 DECLARE_DEVICE_TYPE(YMF262, ymf262_device)
+DECLARE_DEVICE_TYPE(YMF289B, ymf289b_device)
 
 #endif // MAME_SOUND_262INTF_H

--- a/src/devices/sound/ymf262.cpp
+++ b/src/devices/sound/ymf262.cpp
@@ -140,8 +140,9 @@ static FILE *sample[1];
 #endif
 
 
-#define OPL3_TYPE_YMF262 (0)    /* 36 operators, 8 waveforms */
-
+#define OPL3_TYPE_YMF262  (0)    /* 36 operators, 8 waveforms */
+#define OPL3_TYPE_YMF289B (1)    /* 36 operators, 8 waveforms, Low voltage */
+//#define INTERNAL_BUSY_ENABLE 1 /* Enable internal busy flags */
 
 struct OPL3_SLOT
 {
@@ -223,6 +224,7 @@ struct OPL3_CH
 /* OPL3 state */
 struct OPL3
 {
+	uint8_t regs[256*2];
 	OPL3_CH P_CH[18];               /* OPL3 chips have 18 channels  */
 
 	uint32_t  pan[18*4];              /* channels output masks (0xffffffff = enable); 4 masks per one channel */
@@ -255,6 +257,9 @@ struct OPL3
 	uint32_t  noise_f;                /* current noise period         */
 
 	uint8_t   OPL3_mode;              /* OPL3 extension enable flag   */
+	uint8_t   OPL3L_mode;             /* OPL3L extension enable flag   */
+	uint8_t   pwrdn;                  /* power down flag */
+	uint8_t   clr;                    /* data clear flag */
 
 	uint8_t   rhythm;                 /* Rhythm mode                  */
 
@@ -264,6 +269,7 @@ struct OPL3
 	uint32_t  address;                /* address register             */
 	uint8_t   status;                 /* status flag                  */
 	uint8_t   statusmask;             /* status mask                  */
+	uint8_t   busy;                   /* busy status */
 
 	uint8_t   nts;                    /* NTS (note select)            */
 
@@ -278,9 +284,11 @@ struct OPL3
 	uint8_t type;                     /* chip type                    */
 	int clock;                      /* master clock  (Hz)           */
 	int rate;                       /* sampling rate (Hz)           */
+	uint8_t busy_cycle;             /* busy cycle ((master clock/cycle) Hz) */
 	double freqbase;                /* frequency base               */
 	attotime TimerBase;         /* Timer base time (==sampling time)*/
 	device_t *device;
+	double divider;
 
 	/* Optional handlers */
 	void SetTimerHandler(OPL3_TIMERHANDLER handler, device_t *device)
@@ -638,10 +646,10 @@ static inline void OPL3_SLOT_CONNECT(OPL3 *chip, OPL3_SLOT *slot) {
 	}
 }
 
-static inline int limit( int val, int max, int min ) {
-	if ( val > max )
+static inline int limit(int val, int max, int min) {
+	if (val > max)
 		val = max;
-	else if ( val < min )
+	else if (val < min)
 		val = min;
 
 	return val;
@@ -653,13 +661,13 @@ static inline void OPL3_STATUS_SET(OPL3 *chip,int flag)
 {
 	/* set status flag masking out disabled IRQs */
 	chip->status |= (flag & chip->statusmask);
-	if(!(chip->status & 0x80))
+	if (!(chip->status & 0x80))
 	{
-		if(chip->status & 0x7f)
+		if (chip->status & 0x7f)
 		{   /* IRQ on */
 			chip->status |= 0x80;
 			/* callback user interrupt handler (IRQ is OFF to ON) */
-			if(chip->IRQHandler) (chip->IRQHandler)(chip->IRQParam,1);
+			if (chip->IRQHandler) (chip->IRQHandler)(chip->IRQParam,1);
 		}
 	}
 }
@@ -669,13 +677,13 @@ static inline void OPL3_STATUS_RESET(OPL3 *chip,int flag)
 {
 	/* reset status flag */
 	chip->status &= ~flag;
-	if(chip->status & 0x80)
+	if (chip->status & 0x80)
 	{
 		if (!(chip->status & 0x7f))
 		{
 			chip->status &= 0x7f;
 			/* callback user interrupt handler (IRQ is ON to OFF) */
-			if(chip->IRQHandler) (chip->IRQHandler)(chip->IRQParam,0);
+			if (chip->IRQHandler) (chip->IRQHandler)(chip->IRQParam,0);
 		}
 	}
 }
@@ -697,7 +705,7 @@ static inline void advance_lfo(OPL3 *chip)
 
 	/* LFO */
 	chip->lfo_am_cnt += chip->lfo_am_inc;
-	if (chip->lfo_am_cnt >= ((uint32_t)LFO_AM_TAB_ELEMENTS<<LFO_SH) ) /* lfo_am_table is 210 elements long */
+	if (chip->lfo_am_cnt >= ((uint32_t)LFO_AM_TAB_ELEMENTS<<LFO_SH)) /* lfo_am_table is 210 elements long */
 		chip->lfo_am_cnt -= ((uint32_t)LFO_AM_TAB_ELEMENTS<<LFO_SH);
 
 	tmp = lfo_am_table[ chip->lfo_am_cnt >> LFO_SH ];
@@ -732,11 +740,11 @@ static inline void advance(OPL3 *chip)
 			op  = &CH->SLOT[i&1];
 #if 1
 			/* Envelope Generator */
-			switch(op->state)
+			switch (op->state)
 			{
 			case EG_ATT:    /* attack phase */
-//              if ( !(chip->eg_cnt & ((1<<op->eg_sh_ar)-1) ) )
-				if ( !(chip->eg_cnt & op->eg_m_ar) )
+//              if (!(chip->eg_cnt & ((1<<op->eg_sh_ar)-1)))
+				if (!(chip->eg_cnt & op->eg_m_ar))
 				{
 					op->volume += (~op->volume *
 												(eg_inc[op->eg_sel_ar + ((chip->eg_cnt>>op->eg_sh_ar)&7)])
@@ -752,12 +760,12 @@ static inline void advance(OPL3 *chip)
 			break;
 
 			case EG_DEC:    /* decay phase */
-//              if ( !(chip->eg_cnt & ((1<<op->eg_sh_dr)-1) ) )
-				if ( !(chip->eg_cnt & op->eg_m_dr) )
+//              if (!(chip->eg_cnt & ((1<<op->eg_sh_dr)-1)))
+				if (!(chip->eg_cnt & op->eg_m_dr))
 				{
 					op->volume += eg_inc[op->eg_sel_dr + ((chip->eg_cnt>>op->eg_sh_dr)&7)];
 
-					if ( op->volume >= op->sl )
+					if (op->volume >= op->sl)
 						op->state = EG_SUS;
 
 				}
@@ -769,19 +777,19 @@ static inline void advance(OPL3 *chip)
 				one can change percusive/non-percussive modes on the fly and
 				the chip will remain in sustain phase - verified on real YM3812 */
 
-				if(op->eg_type)     /* non-percussive mode */
+				if (op->eg_type)     /* non-percussive mode */
 				{
 									/* do nothing */
 				}
 				else                /* percussive mode */
 				{
 					/* during sustain phase chip adds Release Rate (in percussive mode) */
-//                  if ( !(chip->eg_cnt & ((1<<op->eg_sh_rr)-1) ) )
-					if ( !(chip->eg_cnt & op->eg_m_rr) )
+//                  if (!(chip->eg_cnt & ((1<<op->eg_sh_rr)-1)))
+					if (!(chip->eg_cnt & op->eg_m_rr))
 					{
 						op->volume += eg_inc[op->eg_sel_rr + ((chip->eg_cnt>>op->eg_sh_rr)&7)];
 
-						if ( op->volume >= MAX_ATT_INDEX )
+						if (op->volume >= MAX_ATT_INDEX)
 							op->volume = MAX_ATT_INDEX;
 					}
 					/* else do nothing in sustain phase */
@@ -789,12 +797,12 @@ static inline void advance(OPL3 *chip)
 			break;
 
 			case EG_REL:    /* release phase */
-//              if ( !(chip->eg_cnt & ((1<<op->eg_sh_rr)-1) ) )
-				if ( !(chip->eg_cnt & op->eg_m_rr) )
+//              if (!(chip->eg_cnt & ((1<<op->eg_sh_rr)-1)))
+				if (!(chip->eg_cnt & op->eg_m_rr))
 				{
 					op->volume += eg_inc[op->eg_sel_rr + ((chip->eg_cnt>>op->eg_sh_rr)&7)];
 
-					if ( op->volume >= MAX_ATT_INDEX )
+					if (op->volume >= MAX_ATT_INDEX)
 					{
 						op->volume = MAX_ATT_INDEX;
 						op->state = EG_OFF;
@@ -816,20 +824,20 @@ static inline void advance(OPL3 *chip)
 		op  = &CH->SLOT[i&1];
 
 		/* Phase Generator */
-		if(op->vib)
+		if (op->vib)
 		{
 			uint8_t block;
 			unsigned int block_fnum = CH->block_fnum;
 
-			unsigned int fnum_lfo   = (block_fnum&0x0380) >> 7;
+			unsigned int fnum_lfo   = (block_fnum & 0x0380) >> 7;
 
 			signed int lfo_fn_table_index_offset = lfo_pm_table[chip->LFO_PM + 16*fnum_lfo ];
 
 			if (lfo_fn_table_index_offset)  /* LFO phase modulation active */
 			{
 				block_fnum += lfo_fn_table_index_offset;
-				block = (block_fnum&0x1c00) >> 10;
-				op->Cnt += (chip->fn_tab[block_fnum&0x03ff] >> (7-block)) * op->mul;
+				block = (block_fnum & 0x1c00) >> 10;
+				op->Cnt += (chip->fn_tab[block_fnum & 0x03ff] >> (7-block)) * op->mul;
 			}
 			else    /* LFO phase modulation  = zero */
 			{
@@ -860,7 +868,7 @@ static inline void advance(OPL3 *chip)
 	{
 		/*
 		uint32_t j;
-		j = ( (chip->noise_rng) ^ (chip->noise_rng>>14) ^ (chip->noise_rng>>15) ^ (chip->noise_rng>>22) ) & 1;
+		j = ((chip->noise_rng) ^ (chip->noise_rng>>14) ^ (chip->noise_rng>>15) ^ (chip->noise_rng>>22)) & 1;
 		chip->noise_rng = (j<<22) | (chip->noise_rng>>1);
 		*/
 
@@ -884,7 +892,7 @@ static inline signed int op_calc(uint32_t phase, unsigned int env, signed int pm
 {
 	uint32_t p;
 
-	p = (env<<4) + sin_tab[wave_tab + ((((signed int)((phase & ~FREQ_MASK) + (pm<<16))) >> FREQ_SH ) & SIN_MASK) ];
+	p = (env<<4) + sin_tab[wave_tab + ((((signed int)((phase & ~FREQ_MASK) + (pm<<16))) >> FREQ_SH) & SIN_MASK) ];
 
 	if (p >= TL_TAB_LEN)
 		return 0;
@@ -907,7 +915,7 @@ static inline signed int op_calc1(uint32_t phase, unsigned int env, signed int p
 
 /* calculate output of a standard 2 operator channel
  (or 1st part of a 4-op channel) */
-static inline void chan_calc( OPL3 *chip, OPL3_CH *CH )
+static inline void chan_calc(OPL3 *chip, OPL3_CH *CH)
 {
 	OPL3_SLOT *SLOT;
 	unsigned int env;
@@ -926,12 +934,12 @@ static inline void chan_calc( OPL3 *chip, OPL3_CH *CH )
 	{
 		if (!SLOT->FB)
 			out = 0;
-		SLOT->op1_out[1] = op_calc1(SLOT->Cnt, env, (out<<SLOT->FB), SLOT->wavetable );
+		SLOT->op1_out[1] = op_calc1(SLOT->Cnt, env, (out<<SLOT->FB), SLOT->wavetable);
 	}
 	if (SLOT->connect) {
 		*SLOT->connect += SLOT->op1_out[1];
 	}
-//logerror("out0=%5i vol0=%4i ", SLOT->op1_out[1], env );
+//logerror("out0=%5i vol0=%4i ", SLOT->op1_out[1], env);
 
 	/* SLOT 2 */
 	SLOT++;
@@ -939,12 +947,12 @@ static inline void chan_calc( OPL3 *chip, OPL3_CH *CH )
 	if ((env < ENV_QUIET) && SLOT->connect)
 		*SLOT->connect += op_calc(SLOT->Cnt, env, chip->phase_modulation, SLOT->wavetable);
 
-//logerror("out1=%5i vol1=%4i\n", op_calc(SLOT->Cnt, env, chip->phase_modulation, SLOT->wavetable), env );
+//logerror("out1=%5i vol1=%4i\n", op_calc(SLOT->Cnt, env, chip->phase_modulation, SLOT->wavetable), env);
 
 }
 
 /* calculate output of a 2nd part of 4-op channel */
-static inline void chan_calc_ext( OPL3 *chip, OPL3_CH *CH )
+static inline void chan_calc_ext(OPL3 *chip, OPL3_CH *CH)
 {
 	OPL3_SLOT *SLOT;
 	unsigned int env;
@@ -955,7 +963,7 @@ static inline void chan_calc_ext( OPL3 *chip, OPL3_CH *CH )
 	SLOT = &CH->SLOT[SLOT1];
 	env  = volume_calc(SLOT);
 	if (env < ENV_QUIET && SLOT->connect)
-		*SLOT->connect += op_calc(SLOT->Cnt, env, chip->phase_modulation2, SLOT->wavetable );
+		*SLOT->connect += op_calc(SLOT->Cnt, env, chip->phase_modulation2, SLOT->wavetable);
 
 	/* SLOT 2 */
 	SLOT++;
@@ -1002,7 +1010,7 @@ number   number    BLK/FNUM2 FNUM    Drum  Hat   Drum  Tom  Cymbal
 
 /* calculate rhythm */
 
-static inline void chan_calc_rhythm( OPL3 *chip, OPL3_CH *CH, unsigned int noise )
+static inline void chan_calc_rhythm(OPL3 *chip, OPL3_CH *CH, unsigned int noise)
 {
 	OPL3_SLOT *SLOT;
 	signed int *chanout = chip->chanout;
@@ -1031,17 +1039,17 @@ static inline void chan_calc_rhythm( OPL3 *chip, OPL3_CH *CH, unsigned int noise
 	//else ignore output of operator 1
 
 	SLOT->op1_out[1] = 0;
-	if( env < ENV_QUIET )
+	if (env < ENV_QUIET)
 	{
 		if (!SLOT->FB)
 			out = 0;
-		SLOT->op1_out[1] = op_calc1(SLOT->Cnt, env, (out<<SLOT->FB), SLOT->wavetable );
+		SLOT->op1_out[1] = op_calc1(SLOT->Cnt, env, (out<<SLOT->FB), SLOT->wavetable);
 	}
 
 	/* SLOT 2 */
 	SLOT++;
 	env = volume_calc(SLOT);
-	if( env < ENV_QUIET )
+	if (env < ENV_QUIET)
 		chanout[6] += op_calc(SLOT->Cnt, env, chip->phase_modulation, SLOT->wavetable) * 2;
 
 
@@ -1064,7 +1072,7 @@ static inline void chan_calc_rhythm( OPL3 *chip, OPL3_CH *CH, unsigned int noise
 
 	/* High Hat (verified on real YM3812) */
 	env = volume_calc(SLOT7_1);
-	if( env < ENV_QUIET )
+	if (env < ENV_QUIET)
 	{
 		/* high hat phase generation:
 		    phase = d0 or 234 (based on frequency only)
@@ -1096,7 +1104,7 @@ static inline void chan_calc_rhythm( OPL3 *chip, OPL3_CH *CH, unsigned int noise
 
 		/* when phase & 0x200 is set and noise=1 then phase = 0x200|0xd0 */
 		/* when phase & 0x200 is set and noise=0 then phase = 0x200|(0xd0>>2), ie no change */
-		if (phase&0x200)
+		if (phase & 0x200)
 		{
 			if (noise)
 				phase = 0x200|0xd0;
@@ -1114,7 +1122,7 @@ static inline void chan_calc_rhythm( OPL3 *chip, OPL3_CH *CH, unsigned int noise
 
 	/* Snare Drum (verified on real YM3812) */
 	env = volume_calc(SLOT7_2);
-	if( env < ENV_QUIET )
+	if (env < ENV_QUIET)
 	{
 		/* base frequency derived from operator 1 in channel 7 */
 		unsigned char bit8 = ((SLOT7_1->Cnt>>FREQ_SH)>>8)&1;
@@ -1135,12 +1143,12 @@ static inline void chan_calc_rhythm( OPL3 *chip, OPL3_CH *CH, unsigned int noise
 
 	/* Tom Tom (verified on real YM3812) */
 	env = volume_calc(SLOT8_1);
-	if( env < ENV_QUIET )
+	if (env < ENV_QUIET)
 		chanout[8] += op_calc(SLOT8_1->Cnt, env, 0, SLOT8_1->wavetable) * 2;
 
 	/* Top Cymbal (verified on real YM3812) */
 	env = volume_calc(SLOT8_2);
-	if( env < ENV_QUIET )
+	if (env < ENV_QUIET)
 	{
 		/* base frequency derived from operator 1 in channel 7 */
 		unsigned char bit7 = ((SLOT7_1->Cnt>>FREQ_SH)>>7)&1;
@@ -1204,12 +1212,12 @@ static int init_tables(void)
 	#if 0
 			logerror("tl %04i", x*2);
 			for (i=0; i<13; i++)
-				logerror(", [%02i] %5i", i*2, tl_tab[ x*2 +0 + i*2*TL_RES_LEN ] ); /* positive */
+				logerror(", [%02i] %5i", i*2, tl_tab[ x*2 +0 + i*2*TL_RES_LEN ]); /* positive */
 			logerror("\n");
 
 			logerror("tl %04i", x*2);
 			for (i=0; i<13; i++)
-				logerror(", [%02i] %5i", i*2, tl_tab[ x*2 +1 + i*2*TL_RES_LEN ] ); /* negative */
+				logerror(", [%02i] %5i", i*2, tl_tab[ x*2 +1 + i*2*TL_RES_LEN ]); /* negative */
 			logerror("\n");
 	#endif
 	}
@@ -1217,7 +1225,7 @@ static int init_tables(void)
 	for (i=0; i<SIN_LEN; i++)
 	{
 		/* non-standard sinus */
-		m = sin( ((i*2)+1) * M_PI / SIN_LEN ); /* checked against the real chip */
+		m = sin(((i*2)+1) * M_PI / SIN_LEN); /* checked against the real chip */
 
 		/* we never reach zero here due to ((i*2)+1) */
 
@@ -1234,9 +1242,9 @@ static int init_tables(void)
 		else
 			n = n>>1;
 
-		sin_tab[ i ] = n*2 + (m>=0.0? 0: 1 );
+		sin_tab[ i ] = n*2 + (m>=0.0? 0: 1);
 
-		/*logerror("YMF262.C: sin [%4i (hex=%03x)]= %4i (tl_tab value=%5i)\n", i, i, sin_tab[i], tl_tab[sin_tab[i]] );*/
+		/*logerror("YMF262.C: sin [%4i (hex=%03x)]= %4i (tl_tab value=%5i)\n", i, i, sin_tab[i], tl_tab[sin_tab[i]]);*/
 	}
 
 	for (i=0; i<SIN_LEN; i++)
@@ -1246,7 +1254,7 @@ static int init_tables(void)
 		/*             /  \____/  \____*/
 		/* output only first half of the sinus waveform (positive one) */
 
-		if (i & (1<<(SIN_BITS-1)) )
+		if (i & (1<<(SIN_BITS-1)))
 			sin_tab[1*SIN_LEN+i] = TL_TAB_LEN;
 		else
 			sin_tab[1*SIN_LEN+i] = sin_tab[i];
@@ -1261,7 +1269,7 @@ static int init_tables(void)
 		/*             / |_/ |_/ |_/ |_*/
 		/* abs(output only first quarter of the sinus waveform) */
 
-		if (i & (1<<(SIN_BITS-2)) )
+		if (i & (1<<(SIN_BITS-2)))
 			sin_tab[3*SIN_LEN+i] = TL_TAB_LEN;
 		else
 			sin_tab[3*SIN_LEN+i] = sin_tab[i & (SIN_MASK>>2)];
@@ -1271,7 +1279,7 @@ static int init_tables(void)
 		/*               \/      \/    */
 		/* output whole sinus waveform in half the cycle(step=2) and output 0 on the other half of cycle */
 
-		if (i & (1<<(SIN_BITS-1)) )
+		if (i & (1<<(SIN_BITS-1)))
 			sin_tab[4*SIN_LEN+i] = TL_TAB_LEN;
 		else
 			sin_tab[4*SIN_LEN+i] = sin_tab[i*2];
@@ -1281,7 +1289,7 @@ static int init_tables(void)
 		/*                             */
 		/* output abs(whole sinus) waveform in half the cycle(step=2) and output 0 on the other half of cycle */
 
-		if (i & (1<<(SIN_BITS-1)) )
+		if (i & (1<<(SIN_BITS-1)))
 			sin_tab[5*SIN_LEN+i] = TL_TAB_LEN;
 		else
 			sin_tab[5*SIN_LEN+i] = sin_tab[(i*2) & (SIN_MASK>>1) ];
@@ -1291,7 +1299,7 @@ static int init_tables(void)
 		/*                 ____    ____*/
 		/* output maximum in half the cycle and output minimum on the other half of cycle */
 
-		if (i & (1<<(SIN_BITS-1)) )
+		if (i & (1<<(SIN_BITS-1)))
 			sin_tab[6*SIN_LEN+i] = 1;   /* negative */
 		else
 			sin_tab[6*SIN_LEN+i] = 0;   /* positive */
@@ -1301,7 +1309,7 @@ static int init_tables(void)
 		/*                   \|      \|*/
 		/* output sawtooth waveform    */
 
-		if (i & (1<<(SIN_BITS-1)) )
+		if (i & (1<<(SIN_BITS-1)))
 			x = ((SIN_LEN-1)-i)*16 + 1; /* negative: from 8177 to 1 */
 		else
 			x = i*16;   /*positive: from 0 to 8176 */
@@ -1311,15 +1319,15 @@ static int init_tables(void)
 
 		sin_tab[7*SIN_LEN+i] = x;
 
-		//logerror("YMF262.C: sin1[%4i]= %4i (tl_tab value=%5i)\n", i, sin_tab[1*SIN_LEN+i], tl_tab[sin_tab[1*SIN_LEN+i]] );
-		//logerror("YMF262.C: sin2[%4i]= %4i (tl_tab value=%5i)\n", i, sin_tab[2*SIN_LEN+i], tl_tab[sin_tab[2*SIN_LEN+i]] );
-		//logerror("YMF262.C: sin3[%4i]= %4i (tl_tab value=%5i)\n", i, sin_tab[3*SIN_LEN+i], tl_tab[sin_tab[3*SIN_LEN+i]] );
-		//logerror("YMF262.C: sin4[%4i]= %4i (tl_tab value=%5i)\n", i, sin_tab[4*SIN_LEN+i], tl_tab[sin_tab[4*SIN_LEN+i]] );
-		//logerror("YMF262.C: sin5[%4i]= %4i (tl_tab value=%5i)\n", i, sin_tab[5*SIN_LEN+i], tl_tab[sin_tab[5*SIN_LEN+i]] );
-		//logerror("YMF262.C: sin6[%4i]= %4i (tl_tab value=%5i)\n", i, sin_tab[6*SIN_LEN+i], tl_tab[sin_tab[6*SIN_LEN+i]] );
-		//logerror("YMF262.C: sin7[%4i]= %4i (tl_tab value=%5i)\n", i, sin_tab[7*SIN_LEN+i], tl_tab[sin_tab[7*SIN_LEN+i]] );
+		//logerror("YMF262.C: sin1[%4i]= %4i (tl_tab value=%5i)\n", i, sin_tab[1*SIN_LEN+i], tl_tab[sin_tab[1*SIN_LEN+i]]);
+		//logerror("YMF262.C: sin2[%4i]= %4i (tl_tab value=%5i)\n", i, sin_tab[2*SIN_LEN+i], tl_tab[sin_tab[2*SIN_LEN+i]]);
+		//logerror("YMF262.C: sin3[%4i]= %4i (tl_tab value=%5i)\n", i, sin_tab[3*SIN_LEN+i], tl_tab[sin_tab[3*SIN_LEN+i]]);
+		//logerror("YMF262.C: sin4[%4i]= %4i (tl_tab value=%5i)\n", i, sin_tab[4*SIN_LEN+i], tl_tab[sin_tab[4*SIN_LEN+i]]);
+		//logerror("YMF262.C: sin5[%4i]= %4i (tl_tab value=%5i)\n", i, sin_tab[5*SIN_LEN+i], tl_tab[sin_tab[5*SIN_LEN+i]]);
+		//logerror("YMF262.C: sin6[%4i]= %4i (tl_tab value=%5i)\n", i, sin_tab[6*SIN_LEN+i], tl_tab[sin_tab[6*SIN_LEN+i]]);
+		//logerror("YMF262.C: sin7[%4i]= %4i (tl_tab value=%5i)\n", i, sin_tab[7*SIN_LEN+i], tl_tab[sin_tab[7*SIN_LEN+i]]);
 	}
-	/*logerror("YMF262.C: ENV_QUIET= %08x (dec*8=%i)\n", ENV_QUIET, ENV_QUIET*8 );*/
+	/*logerror("YMF262.C: ENV_QUIET= %08x (dec*8=%i)\n", ENV_QUIET, ENV_QUIET*8);*/
 
 #ifdef SAVE_SAMPLE
 	sample[0]=fopen("sampsum.pcm","wb");
@@ -1328,7 +1336,7 @@ static int init_tables(void)
 	return 1;
 }
 
-static void OPLCloseTable( void )
+static void OPLCloseTable(void)
 {
 #ifdef SAVE_SAMPLE
 	fclose(sample[0]);
@@ -1342,41 +1350,41 @@ static void OPL3_initalize(OPL3 *chip)
 	int i;
 
 	/* frequency base */
-	chip->freqbase  = (chip->rate) ? ((double)chip->clock / (8.0*36)) / chip->rate  : 0;
+	chip->freqbase  = (chip->rate) ? ((double)chip->clock / chip->divider) / chip->rate  : 0;
 #if 0
-	chip->rate = (double)chip->clock / (8.0*36);
+	chip->rate = (double)chip->clock / chip->divider;
 	chip->freqbase  = 1.0;
 #endif
 
 	/* logerror("YMF262: freqbase=%f\n", chip->freqbase); */
 
 	/* Timer base time */
-	chip->TimerBase = chip->clock ? attotime::from_hz(chip->clock) * (8 * 36) : attotime::zero;
+	chip->TimerBase = chip->clock ? attotime::from_hz(chip->clock) * (int(chip->divider)) : attotime::zero;
 
 	/* make fnumber -> increment counter table */
-	for( i=0 ; i < 1024 ; i++ )
+	for (i=0 ; i < 1024 ; i++)
 	{
 		/* opn phase increment counter = 20bit */
-		chip->fn_tab[i] = (uint32_t)( (double)i * 64 * chip->freqbase * (1<<(FREQ_SH-10)) ); /* -10 because chip works with 10.10 fixed point, while we use 16.16 */
+		chip->fn_tab[i] = (uint32_t)((double)i * 64 * chip->freqbase * (1<<(FREQ_SH-10))); /* -10 because chip works with 10.10 fixed point, while we use 16.16 */
 #if 0
 		logerror("YMF262.C: fn_tab[%4i] = %08x (dec=%8i)\n",
-					i, chip->fn_tab[i]>>6, chip->fn_tab[i]>>6 );
+					i, chip->fn_tab[i]>>6, chip->fn_tab[i]>>6);
 #endif
 	}
 
 #if 0
-	for( i=0 ; i < 16 ; i++ )
+	for (i=0 ; i < 16 ; i++)
 	{
 		logerror("YMF262.C: sl_tab[%i] = %08x\n",
-			i, sl_tab[i] );
+			i, sl_tab[i]);
 	}
-	for( i=0 ; i < 8 ; i++ )
+	for (i=0 ; i < 8 ; i++)
 	{
 		int j;
 		logerror("YMF262.C: ksl_tab[oct=%2i] =",i);
 		for (j=0; j<16; j++)
 		{
-			logerror("%08x ", static_cast<uint32_t>(ksl_tab[i*16+j]) );
+			logerror("%08x ", static_cast<uint32_t>(ksl_tab[i*16+j]));
 		}
 		logerror("\n");
 	}
@@ -1385,7 +1393,7 @@ static void OPL3_initalize(OPL3 *chip)
 
 	/* Amplitude modulation: 27 output levels (triangle waveform); 1 level takes one of: 192, 256 or 448 samples */
 	/* One entry from LFO_AM_TABLE lasts for 64 samples */
-	chip->lfo_am_inc = (1.0 / 64.0 ) * (1<<LFO_SH) * chip->freqbase;
+	chip->lfo_am_inc = (1.0 / 64.0) * (1<<LFO_SH) * chip->freqbase;
 
 	/* Vibrato: 8 output levels (triangle waveform); 1 level takes 1024 samples */
 	chip->lfo_pm_inc = (1.0 / 1024.0) * (1<<LFO_SH) * chip->freqbase;
@@ -1396,7 +1404,7 @@ static void OPL3_initalize(OPL3 *chip)
 	chip->noise_f = (1.0 / 1.0) * (1<<FREQ_SH) * chip->freqbase;
 
 	chip->eg_timer_add  = (1<<EG_SH)  * chip->freqbase;
-	chip->eg_timer_overflow = ( 1 ) * (1<<EG_SH);
+	chip->eg_timer_overflow = (1) * (1<<EG_SH);
 	/*logerror("YMF262init eg_timer_add=%8x eg_timer_overflow=%8x\n", chip->eg_timer_add, chip->eg_timer_overflow);*/
 
 }
@@ -1412,7 +1420,7 @@ static void OPL3_clock_changed(OPL3 *chip, int clock, int rate)
 
 static inline void FM_KEYON(OPL3_SLOT *SLOT, uint32_t key_set)
 {
-	if( !SLOT->key )
+	if (!SLOT->key)
 	{
 		/* restart Phase Generator */
 		SLOT->Cnt = 0;
@@ -1424,11 +1432,11 @@ static inline void FM_KEYON(OPL3_SLOT *SLOT, uint32_t key_set)
 
 static inline void FM_KEYOFF(OPL3_SLOT *SLOT, uint32_t key_clr)
 {
-	if( SLOT->key )
+	if (SLOT->key)
 	{
 		SLOT->key &= key_clr;
 
-		if( !SLOT->key )
+		if (!SLOT->key)
 		{
 			/* phase -> Release */
 			if (SLOT->state>EG_REL)
@@ -1446,7 +1454,7 @@ static inline void CALC_FCSLOT(OPL3_CH *CH,OPL3_SLOT *SLOT)
 	SLOT->Incr = CH->fc * SLOT->mul;
 	ksr = CH->kcode >> SLOT->KSR;
 
-	if( SLOT->ksr != ksr )
+	if (SLOT->ksr != ksr)
 	{
 		SLOT->ksr = ksr;
 
@@ -1478,11 +1486,11 @@ static inline void set_mul(OPL3 *chip,int slot,int v)
 	OPL3_CH   *CH   = &chip->P_CH[slot/2];
 	OPL3_SLOT *SLOT = &CH->SLOT[slot&1];
 
-	SLOT->mul     = mul_tab[v&0x0f];
-	SLOT->KSR     = (v&0x10) ? 0 : 2;
-	SLOT->eg_type = (v&0x20);
-	SLOT->vib     = (v&0x40);
-	SLOT->AMmask  = (v&0x80) ? ~0 : 0;
+	SLOT->mul     = mul_tab[v & 0x0f];
+	SLOT->KSR     = (v & 0x10) ? 0 : 2;
+	SLOT->eg_type = (v & 0x20);
+	SLOT->vib     = (v & 0x40);
+	SLOT->AMmask  = (v & 0x80) ? ~0 : 0;
 
 	if (chip->OPL3_mode & 1)
 	{
@@ -1497,7 +1505,7 @@ static inline void set_mul(OPL3 *chip,int slot,int v)
 		//if this is one of the slots of 2nd channel forming up a 4-op channel
 		//update it using channel data of 1st channel of a pair
 		//else normal 2 operator function
-		switch(chan_no)
+		switch (chan_no)
 		{
 		case 0: case 1: case 2:
 		case 9: case 10: case 11:
@@ -1545,7 +1553,7 @@ static inline void set_ksl_tl(OPL3 *chip,int slot,int v)
 	OPL3_SLOT *SLOT = &CH->SLOT[slot&1];
 
 	SLOT->ksl = ksl_shift[v >> 6];
-	SLOT->TL  = (v&0x3f)<<(ENV_BITS-1-7); /* 7 bits TL (bit 6 = always 0) */
+	SLOT->TL  = (v & 0x3f)<<(ENV_BITS-1-7); /* 7 bits TL (bit 6 = always 0) */
 
 	if (chip->OPL3_mode & 1)
 	{
@@ -1560,7 +1568,7 @@ static inline void set_ksl_tl(OPL3 *chip,int slot,int v)
 		//if this is one of the slots of 2nd channel forming up a 4-op channel
 		//update it using channel data of 1st channel of a pair
 		//else normal 2 operator function
-		switch(chan_no)
+		switch (chan_no)
 		{
 		case 0: case 1: case 2:
 		case 9: case 10: case 11:
@@ -1608,7 +1616,7 @@ static inline void set_ar_dr(OPL3 *chip,int slot,int v)
 	OPL3_CH   *CH   = &chip->P_CH[slot/2];
 	OPL3_SLOT *SLOT = &CH->SLOT[slot&1];
 
-	SLOT->ar = (v>>4)  ? 16 + ((v>>4)  <<2) : 0;
+	SLOT->ar = (v >> 4)  ? 16 + ((v >> 4)  <<2) : 0;
 
 	if ((SLOT->ar + SLOT->ksr) < 16+60) /* verified on real YMF262 - all 15 x rates take "zero" time */
 	{
@@ -1623,7 +1631,7 @@ static inline void set_ar_dr(OPL3 *chip,int slot,int v)
 		SLOT->eg_sel_ar = 13*RATE_STEPS;
 	}
 
-	SLOT->dr    = (v&0x0f)? 16 + ((v&0x0f)<<2) : 0;
+	SLOT->dr    = (v & 0x0f)? 16 + ((v & 0x0f)<<2) : 0;
 	SLOT->eg_sh_dr  = eg_rate_shift [SLOT->dr + SLOT->ksr ];
 	SLOT->eg_m_dr   = (1<<SLOT->eg_sh_dr)-1;
 	SLOT->eg_sel_dr = eg_rate_select[SLOT->dr + SLOT->ksr ];
@@ -1635,9 +1643,9 @@ static inline void set_sl_rr(OPL3 *chip,int slot,int v)
 	OPL3_CH   *CH   = &chip->P_CH[slot/2];
 	OPL3_SLOT *SLOT = &CH->SLOT[slot&1];
 
-	SLOT->sl  = sl_tab[ v>>4 ];
+	SLOT->sl  = sl_tab[ v >> 4 ];
 
-	SLOT->rr  = (v&0x0f)? 16 + ((v&0x0f)<<2) : 0;
+	SLOT->rr  = (v & 0x0f)? 16 + ((v & 0x0f)<<2) : 0;
 	SLOT->eg_sh_rr  = eg_rate_shift [SLOT->rr + SLOT->ksr ];
 	SLOT->eg_m_rr   = (1<<SLOT->eg_sh_rr)-1;
 	SLOT->eg_sel_rr = eg_rate_select[SLOT->rr + SLOT->ksr ];
@@ -1659,63 +1667,69 @@ static void update_channels(OPL3 *chip, OPL3_CH *CH)
 }
 
 /* write a value v to register r on OPL chip */
-static void OPL3WriteReg(OPL3 *chip, int r, int v)
+static void OPL3WriteReg(OPL3 *chip, u16 r, u8 v)
 {
+	int reg_addr = r & 0x1ff;
+	chip->regs[reg_addr] = v;
 	OPL3_CH *CH;
 	unsigned int ch_offset = 0;
 	int slot;
 	int block_fnum;
 
-	if(r&0x100)
+	if (r & 0x100)
 	{
-		switch(r)
+		switch (r)
 		{
 		case 0x101: /* test register */
 			return;
 
 		case 0x104: /* 6 channels enable */
+			chip->regs[reg_addr] &= 0x3f;
 			{
 				uint8_t prev;
 
 				CH = &chip->P_CH[0];    /* channel 0 */
 				prev = CH->extended;
-				CH->extended = (v>>0) & 1;
-				if(prev != CH->extended)
+				CH->extended = (v >> 0) & 1;
+				if (prev != CH->extended)
 					update_channels(chip, CH);
 				CH++;                   /* channel 1 */
 				prev = CH->extended;
-				CH->extended = (v>>1) & 1;
-				if(prev != CH->extended)
+				CH->extended = (v >> 1) & 1;
+				if (prev != CH->extended)
 					update_channels(chip, CH);
 				CH++;                   /* channel 2 */
 				prev = CH->extended;
-				CH->extended = (v>>2) & 1;
-				if(prev != CH->extended)
+				CH->extended = (v >> 2) & 1;
+				if (prev != CH->extended)
 					update_channels(chip, CH);
 
 
 				CH = &chip->P_CH[9];    /* channel 9 */
 				prev = CH->extended;
-				CH->extended = (v>>3) & 1;
-				if(prev != CH->extended)
+				CH->extended = (v >> 3) & 1;
+				if (prev != CH->extended)
 					update_channels(chip, CH);
 				CH++;                   /* channel 10 */
 				prev = CH->extended;
-				CH->extended = (v>>4) & 1;
-				if(prev != CH->extended)
+				CH->extended = (v >> 4) & 1;
+				if (prev != CH->extended)
 					update_channels(chip, CH);
 				CH++;                   /* channel 11 */
 				prev = CH->extended;
-				CH->extended = (v>>5) & 1;
-				if(prev != CH->extended)
+				CH->extended = (v >> 5) & 1;
+				if (prev != CH->extended)
 					update_channels(chip, CH);
 
 			}
 			return;
 
 		case 0x105: /* OPL3 extensions enable register */
+			chip->regs[reg_addr] &= 0x07;
 
-			chip->OPL3_mode = v&0x01;   /* OPL3 mode when bit0=1 otherwise it is OPL2 mode */
+			chip->OPL3_mode = v & 0x01;   /* OPL3 mode when bit0=1 otherwise it is OPL2 mode */
+			if (chip->type == OPL3_TYPE_YMF289B)
+				chip->OPL3L_mode = (v & 0x04) >> 2;
 
 			/* following behaviour was tested on real YMF262,
 			switching OPL3/OPL2 modes on the fly:
@@ -1727,9 +1741,22 @@ static void OPL3WriteReg(OPL3 *chip, int r, int v)
 
 			return;
 
+		case 0x108:
+			chip->regs[reg_addr] &= 0x07;
+			if (chip->type == OPL3_TYPE_YMF289B && chip->OPL3L_mode)
+			{
+				/*PD0,1 (power down bits) in bit 0,1, clr (clear data registers) in bit 2*/
+				chip->pwrdn = v & 0x03;
+				chip->clr = (v & 0x04) >> 2;
+				chip->device->logerror("YMF262: write to unimplemented register (set#2): %03x value=%02x\n",r,v);
+			}
+			return;
 		default:
 			if (r < 0x120)
+			{
+				chip->regs[reg_addr] &= 0;
 				chip->device->logerror("YMF262: write to unknown register (set#2): %03x value=%02x\n",r,v);
+			}
 		break;
 		}
 
@@ -1740,11 +1767,10 @@ static void OPL3WriteReg(OPL3 *chip, int r, int v)
 	r &= 0xff;
 	v &= 0xff;
 
-
-	switch(r&0xe0)
+	switch (r & 0xe0)
 	{
 	case 0x00:  /* 00-1f:control */
-		switch(r&0x1f)
+		switch (r & 0x1f)
 		{
 		case 0x01:  /* test register */
 		break;
@@ -1755,79 +1781,101 @@ static void OPL3WriteReg(OPL3 *chip, int r, int v)
 			chip->T[1] = (256-v)*16;
 		break;
 		case 0x04:  /* IRQ clear / mask and Timer enable */
-			if(v&0x80)
+			chip->regs[reg_addr] &= 0xe3;
+			if (v & 0x80)
 			{   /* IRQ flags clear */
 				OPL3_STATUS_RESET(chip,0x60);
 			}
 			else
 			{   /* set IRQ mask ,timer enable */
 				uint8_t st1 = v & 1;
-				uint8_t st2 = (v>>1) & 1;
+				uint8_t st2 = (v >> 1) & 1;
 
 				/* IRQRST,T1MSK,t2MSK,x,x,x,ST2,ST1 */
 				OPL3_STATUS_RESET(chip, v & 0x60);
-				OPL3_STATUSMASK_SET(chip, (~v) & 0x60 );
+				OPL3_STATUSMASK_SET(chip, (~v) & 0x60);
 
 				/* timer 2 */
-				if(chip->st[1] != st2)
+				if (chip->st[1] != st2)
 				{
 					attotime period = st2 ? chip->TimerBase * chip->T[1] : attotime::zero;
 					chip->st[1] = st2;
-					if (chip->timer_handler) (chip->timer_handler)(chip->TimerParam,1,period);
+					if (chip->timer_handler) (chip->timer_handler)(chip->TimerParam,OPL3_TIMER_2,period);
 				}
 				/* timer 1 */
-				if(chip->st[0] != st1)
+				if (chip->st[0] != st1)
 				{
 					attotime period = st1 ? chip->TimerBase * chip->T[0] : attotime::zero;
 					chip->st[0] = st1;
-					if (chip->timer_handler) (chip->timer_handler)(chip->TimerParam,0,period);
+					if (chip->timer_handler) (chip->timer_handler)(chip->TimerParam,OPL3_TIMER_1,period);
 				}
 			}
 		break;
 		case 0x08:  /* x,NTS,x,x, x,x,x,x */
+			chip->regs[reg_addr] &= 0x40;
 			chip->nts = v;
 		break;
 
 		default:
+			chip->regs[reg_addr] &= 0x00;
 			chip->device->logerror("YMF262: write to unknown register: %02x value=%02x\n",r,v);
 		break;
 		}
 		break;
 	case 0x20:  /* am ON, vib ON, ksr, eg_type, mul */
-		slot = slot_array[r&0x1f];
-		if(slot < 0) return;
+		slot = slot_array[r & 0x1f];
+		if (slot < 0)
+		{
+			chip->regs[reg_addr] &= 0x00;
+			return;
+		}
 		set_mul(chip, slot + ch_offset*2, v);
 	break;
 	case 0x40:
-		slot = slot_array[r&0x1f];
-		if(slot < 0) return;
+		slot = slot_array[r & 0x1f];
+		if (slot < 0)
+		{
+			chip->regs[reg_addr] &= 0x00;
+			return;
+		}
 		set_ksl_tl(chip, slot + ch_offset*2, v);
 	break;
 	case 0x60:
-		slot = slot_array[r&0x1f];
-		if(slot < 0) return;
+		slot = slot_array[r & 0x1f];
+		if (slot < 0)
+		{
+			chip->regs[reg_addr] &= 0x00;
+			return;
+		}
 		set_ar_dr(chip, slot + ch_offset*2, v);
 	break;
 	case 0x80:
-		slot = slot_array[r&0x1f];
-		if(slot < 0) return;
+		slot = slot_array[r & 0x1f];
+		if (slot < 0)
+		{
+			chip->regs[reg_addr] &= 0x00;
+			return;
+		}
 		set_sl_rr(chip, slot + ch_offset*2, v);
 	break;
 	case 0xa0:
 		if (r == 0xbd)          /* am depth, vibrato depth, r,bd,sd,tom,tc,hh */
 		{
 			if (ch_offset != 0) /* 0xbd register is present in set #1 only */
+			{
+				chip->regs[reg_addr] &= 0x00;
 				return;
+			}
 
 			chip->lfo_am_depth = v & 0x80;
-			chip->lfo_pm_depth_range = (v&0x40) ? 8 : 0;
+			chip->lfo_pm_depth_range = (v & 0x40) ? 8 : 0;
 
-			chip->rhythm = v&0x3f;
+			chip->rhythm = v & 0x3f;
 
-			if(chip->rhythm&0x20)
+			if (chip->rhythm & 0x20)
 			{
 				/* BD key on/off */
-				if(v&0x10)
+				if (v & 0x10)
 				{
 					FM_KEYON (&chip->P_CH[6].SLOT[SLOT1], 2);
 					FM_KEYON (&chip->P_CH[6].SLOT[SLOT2], 2);
@@ -1838,16 +1886,16 @@ static void OPL3WriteReg(OPL3 *chip, int r, int v)
 					FM_KEYOFF(&chip->P_CH[6].SLOT[SLOT2],~2);
 				}
 				/* HH key on/off */
-				if(v&0x01) FM_KEYON (&chip->P_CH[7].SLOT[SLOT1], 2);
+				if (v & 0x01) FM_KEYON (&chip->P_CH[7].SLOT[SLOT1], 2);
 				else       FM_KEYOFF(&chip->P_CH[7].SLOT[SLOT1],~2);
 				/* SD key on/off */
-				if(v&0x08) FM_KEYON (&chip->P_CH[7].SLOT[SLOT2], 2);
+				if (v & 0x08) FM_KEYON (&chip->P_CH[7].SLOT[SLOT2], 2);
 				else       FM_KEYOFF(&chip->P_CH[7].SLOT[SLOT2],~2);
 				/* TOM key on/off */
-				if(v&0x04) FM_KEYON (&chip->P_CH[8].SLOT[SLOT1], 2);
+				if (v & 0x04) FM_KEYON (&chip->P_CH[8].SLOT[SLOT1], 2);
 				else       FM_KEYOFF(&chip->P_CH[8].SLOT[SLOT1],~2);
 				/* TOP-CY key on/off */
-				if(v&0x02) FM_KEYON (&chip->P_CH[8].SLOT[SLOT2], 2);
+				if (v & 0x02) FM_KEYON (&chip->P_CH[8].SLOT[SLOT2], 2);
 				else       FM_KEYOFF(&chip->P_CH[8].SLOT[SLOT2],~2);
 			}
 			else
@@ -1868,20 +1916,25 @@ static void OPL3WriteReg(OPL3 *chip, int r, int v)
 		}
 
 		/* keyon,block,fnum */
-		if( (r&0x0f) > 8) return;
-		CH = &chip->P_CH[(r&0x0f) + ch_offset];
+		if ((r & 0x0f) > 8)
+		{
+			chip->regs[reg_addr] &= 0x00;
+			return;
+		}
+		CH = &chip->P_CH[(r & 0x0f) + ch_offset];
 
-		if(!(r&0x10))
+		if (!(r & 0x10))
 		{   /* a0-a8 */
-			block_fnum  = (CH->block_fnum&0x1f00) | v;
+			block_fnum  = (CH->block_fnum & 0x1f00) | v;
 		}
 		else
 		{   /* b0-b8 */
-			block_fnum = ((v&0x1f)<<8) | (CH->block_fnum&0xff);
+			chip->regs[reg_addr] &= 0x3f;
+			block_fnum = ((v & 0x1f)<<8) | (CH->block_fnum & 0xff);
 
 			if (chip->OPL3_mode & 1)
 			{
-				int chan_no = (r&0x0f) + ch_offset;
+				int chan_no = (r & 0x0f) + ch_offset;
 
 				/* in OPL3 mode */
 				//DO THIS:
@@ -1891,7 +1944,7 @@ static void OPL3WriteReg(OPL3 *chip, int r, int v)
 				//OR THIS:
 				//if this is 2nd channel forming up 4-op channel just do nothing
 				//else normal 2 operator function keyon/off
-				switch(chan_no)
+				switch (chan_no)
 				{
 				case 0: case 1: case 2:
 				case 9: case 10: case 11:
@@ -1899,7 +1952,7 @@ static void OPL3WriteReg(OPL3 *chip, int r, int v)
 					{
 						//if this is 1st channel forming up a 4-op channel
 						//ALSO keyon/off slots of 2nd channel forming up 4-op channel
-						if(v&0x20)
+						if (v & 0x20)
 						{
 							FM_KEYON (&CH->SLOT[SLOT1], 1);
 							FM_KEYON (&CH->SLOT[SLOT2], 1);
@@ -1917,7 +1970,7 @@ static void OPL3WriteReg(OPL3 *chip, int r, int v)
 					else
 					{
 						//else normal 2 operator function keyon/off
-						if(v&0x20)
+						if (v & 0x20)
 						{
 							FM_KEYON (&CH->SLOT[SLOT1], 1);
 							FM_KEYON (&CH->SLOT[SLOT2], 1);
@@ -1939,7 +1992,7 @@ static void OPL3WriteReg(OPL3 *chip, int r, int v)
 					else
 					{
 						//else normal 2 operator function keyon/off
-						if(v&0x20)
+						if (v & 0x20)
 						{
 							FM_KEYON (&CH->SLOT[SLOT1], 1);
 							FM_KEYON (&CH->SLOT[SLOT2], 1);
@@ -1953,7 +2006,7 @@ static void OPL3WriteReg(OPL3 *chip, int r, int v)
 				break;
 
 				default:
-					if(v&0x20)
+					if (v & 0x20)
 					{
 						FM_KEYON (&CH->SLOT[SLOT1], 1);
 						FM_KEYON (&CH->SLOT[SLOT2], 1);
@@ -1968,7 +2021,7 @@ static void OPL3WriteReg(OPL3 *chip, int r, int v)
 			}
 			else
 			{
-				if(v&0x20)
+				if (v & 0x20)
 				{
 					FM_KEYON (&CH->SLOT[SLOT1], 1);
 					FM_KEYON (&CH->SLOT[SLOT2], 1);
@@ -1981,29 +2034,29 @@ static void OPL3WriteReg(OPL3 *chip, int r, int v)
 			}
 		}
 		/* update */
-		if(CH->block_fnum != block_fnum)
+		if (CH->block_fnum != block_fnum)
 		{
 			uint8_t block  = block_fnum >> 10;
 
 			CH->block_fnum = block_fnum;
 
 			CH->ksl_base = static_cast<uint32_t>(ksl_tab[block_fnum>>6]);
-			CH->fc       = chip->fn_tab[block_fnum&0x03ff] >> (7-block);
+			CH->fc       = chip->fn_tab[block_fnum & 0x03ff] >> (7-block);
 
 			/* BLK 2,1,0 bits -> bits 3,2,1 of kcode */
-			CH->kcode    = (CH->block_fnum&0x1c00)>>9;
+			CH->kcode    = (CH->block_fnum & 0x1c00)>>9;
 
 			/* the info below is actually opposite to what is stated in the Manuals (verifed on real YMF262) */
 			/* if notesel == 0 -> lsb of kcode is bit 10 (MSB) of fnum  */
 			/* if notesel == 1 -> lsb of kcode is bit 9 (MSB-1) of fnum */
-			if (chip->nts&0x40)
-				CH->kcode |= (CH->block_fnum&0x100)>>8; /* notesel == 1 */
+			if (chip->nts & 0x40)
+				CH->kcode |= (CH->block_fnum & 0x100)>>8; /* notesel == 1 */
 			else
-				CH->kcode |= (CH->block_fnum&0x200)>>9; /* notesel == 0 */
+				CH->kcode |= (CH->block_fnum & 0x200)>>9; /* notesel == 0 */
 
 			if (chip->OPL3_mode & 1)
 			{
-				int chan_no = (r&0x0f) + ch_offset;
+				int chan_no = (r & 0x0f) + ch_offset;
 				/* in OPL3 mode */
 				//DO THIS:
 				//if this is 1st channel forming up a 4-op channel
@@ -2012,7 +2065,7 @@ static void OPL3WriteReg(OPL3 *chip, int r, int v)
 				//OR THIS:
 				//if this is 2nd channel forming up 4-op channel just do nothing
 				//else normal 2 operator function keyon/off
-				switch(chan_no)
+				switch (chan_no)
 				{
 				case 0: case 1: case 2:
 				case 9: case 10: case 11:
@@ -2093,13 +2146,17 @@ static void OPL3WriteReg(OPL3 *chip, int r, int v)
 
 	case 0xc0:
 		/* CH.D, CH.C, CH.B, CH.A, FB(3bits), C */
-		if( (r&0xf) > 8) return;
-
-		CH = &chip->P_CH[(r&0xf) + ch_offset];
-
-		if( chip->OPL3_mode & 1 )
+		if ((r & 0xf) > 8)
 		{
-			int base = ((r&0xf) + ch_offset) * 4;
+			chip->regs[reg_addr] &= 0x00;
+			return;
+		}
+
+		CH = &chip->P_CH[(r & 0xf) + ch_offset];
+
+		if (chip->OPL3_mode & 1)
+		{
+			int base = ((r & 0xf) + ch_offset) * 4;
 
 			/* OPL3 mode */
 			chip->pan[ base    ] = (v & 0x10) ? ~0 : 0; /* ch.A */
@@ -2109,7 +2166,7 @@ static void OPL3WriteReg(OPL3 *chip, int r, int v)
 		}
 		else
 		{
-			int base = ((r&0xf) + ch_offset) * 4;
+			int base = ((r & 0xf) + ch_offset) * 4;
 
 			/* OPL2 mode - always enabled */
 			chip->pan[ base    ] = ~0;      /* ch.A */
@@ -2118,23 +2175,23 @@ static void OPL3WriteReg(OPL3 *chip, int r, int v)
 			chip->pan[ base +3 ] = ~0;      /* ch.D */
 		}
 
-		chip->pan_ctrl_value[ (r&0xf) + ch_offset ] = v;    /* store control value for OPL3/OPL2 mode switching on the fly */
+		chip->pan_ctrl_value[ (r & 0xf) + ch_offset ] = v;    /* store control value for OPL3/OPL2 mode switching on the fly */
 
-		CH->SLOT[SLOT1].FB  = (v>>1)&7 ? ((v>>1)&7) + 7 : 0;
+		CH->SLOT[SLOT1].FB  = (v >> 1)&7 ? ((v >> 1)&7) + 7 : 0;
 		CH->SLOT[SLOT1].CON = v&1;
 
-		if( chip->OPL3_mode & 1 )
+		if (chip->OPL3_mode & 1)
 		{
-			int chan_no = (r&0x0f) + ch_offset;
+			int chan_no = (r & 0x0f) + ch_offset;
 
-			switch(chan_no)
+			switch (chan_no)
 			{
 			case 0: case 1: case 2:
 			case 9: case 10: case 11:
 				if (CH->extended)
 				{
 					uint8_t conn = (CH->SLOT[SLOT1].CON<<1) | ((CH+3)->SLOT[SLOT1].CON<<0);
-					switch(conn)
+					switch (conn)
 					{
 					case 0:
 						/* 1 -> 2 -> 3 -> 4 - out */
@@ -2180,8 +2237,8 @@ static void OPL3WriteReg(OPL3 *chip, int r, int v)
 				else
 				{
 					/* 2 operators mode */
-					CH->SLOT[SLOT1].conn_enum = CH->SLOT[SLOT1].CON ? CONN_CHAN0 + (r&0xf)+ch_offset : CONN_PHASEMOD;
-					CH->SLOT[SLOT2].conn_enum = CONN_CHAN0 + (r&0xf)+ch_offset;
+					CH->SLOT[SLOT1].conn_enum = CH->SLOT[SLOT1].CON ? CONN_CHAN0 + (r & 0xf)+ch_offset : CONN_PHASEMOD;
+					CH->SLOT[SLOT2].conn_enum = CONN_CHAN0 + (r & 0xf)+ch_offset;
 					OPL3_SLOT_CONNECT(chip, &CH->SLOT[SLOT1]);
 					OPL3_SLOT_CONNECT(chip, &CH->SLOT[SLOT2]);
 				}
@@ -2192,7 +2249,7 @@ static void OPL3WriteReg(OPL3 *chip, int r, int v)
 				if ((CH-3)->extended)
 				{
 					uint8_t conn = ((CH-3)->SLOT[SLOT1].CON<<1) | (CH->SLOT[SLOT1].CON<<0);
-					switch(conn)
+					switch (conn)
 					{
 					case 0:
 						/* 1 -> 2 -> 3 -> 4 - out */
@@ -2238,8 +2295,8 @@ static void OPL3WriteReg(OPL3 *chip, int r, int v)
 				else
 				{
 					/* 2 operators mode */
-					CH->SLOT[SLOT1].conn_enum = CH->SLOT[SLOT1].CON ? CONN_CHAN0 + (r&0xf)+ch_offset : CONN_PHASEMOD;
-					CH->SLOT[SLOT2].conn_enum = CONN_CHAN0 + (r&0xf)+ch_offset;
+					CH->SLOT[SLOT1].conn_enum = CH->SLOT[SLOT1].CON ? CONN_CHAN0 + (r & 0xf)+ch_offset : CONN_PHASEMOD;
+					CH->SLOT[SLOT2].conn_enum = CONN_CHAN0 + (r & 0xf)+ch_offset;
 					OPL3_SLOT_CONNECT(chip, &CH->SLOT[SLOT1]);
 					OPL3_SLOT_CONNECT(chip, &CH->SLOT[SLOT2]);
 				}
@@ -2247,8 +2304,8 @@ static void OPL3WriteReg(OPL3 *chip, int r, int v)
 
 			default:
 					/* 2 operators mode */
-					CH->SLOT[SLOT1].conn_enum = CH->SLOT[SLOT1].CON ? CONN_CHAN0 + (r&0xf)+ch_offset : CONN_PHASEMOD;
-					CH->SLOT[SLOT2].conn_enum = CONN_CHAN0 + (r&0xf)+ch_offset;
+					CH->SLOT[SLOT1].conn_enum = CH->SLOT[SLOT1].CON ? CONN_CHAN0 + (r & 0xf)+ch_offset : CONN_PHASEMOD;
+					CH->SLOT[SLOT2].conn_enum = CONN_CHAN0 + (r & 0xf)+ch_offset;
 					OPL3_SLOT_CONNECT(chip, &CH->SLOT[SLOT1]);
 					OPL3_SLOT_CONNECT(chip, &CH->SLOT[SLOT2]);
 			break;
@@ -2257,16 +2314,21 @@ static void OPL3WriteReg(OPL3 *chip, int r, int v)
 		else
 		{
 			/* OPL2 mode - always 2 operators mode */
-			CH->SLOT[SLOT1].conn_enum = CH->SLOT[SLOT1].CON ? CONN_CHAN0 + (r&0xf)+ch_offset : CONN_PHASEMOD;
-			CH->SLOT[SLOT2].conn_enum = CONN_CHAN0 + (r&0xf)+ch_offset;
+			CH->SLOT[SLOT1].conn_enum = CH->SLOT[SLOT1].CON ? CONN_CHAN0 + (r & 0xf)+ch_offset : CONN_PHASEMOD;
+			CH->SLOT[SLOT2].conn_enum = CONN_CHAN0 + (r & 0xf)+ch_offset;
 			OPL3_SLOT_CONNECT(chip, &CH->SLOT[SLOT1]);
 			OPL3_SLOT_CONNECT(chip, &CH->SLOT[SLOT2]);
 		}
 	break;
 
 	case 0xe0: /* waveform select */
-		slot = slot_array[r&0x1f];
-		if(slot < 0) return;
+		chip->regs[reg_addr] &= 0x07;
+		slot = slot_array[r & 0x1f];
+		if (slot < 0)
+		{
+			chip->regs[reg_addr] &= 0x00;
+			return;
+		}
 
 		slot += ch_offset*2;
 
@@ -2278,7 +2340,7 @@ static void OPL3WriteReg(OPL3 *chip, int r, int v)
 		CH->SLOT[slot&1].waveform_number = v;
 
 		/* ... but select only waveforms 0-3 in OPL2 mode */
-		if( !(chip->OPL3_mode & 1) )
+		if (!(chip->OPL3_mode & 1))
 		{
 			v &= 3; /* we're in OPL2 mode */
 		}
@@ -2291,11 +2353,11 @@ static void OPL3WriteReg(OPL3 *chip, int r, int v)
 static int OPL3_LockTable(device_t *device)
 {
 	num_lock++;
-	if(num_lock>1) return 0;
+	if (num_lock>1) return 0;
 
 	/* first time */
 
-	if( !init_tables() )
+	if (!init_tables())
 	{
 		num_lock--;
 		return -1;
@@ -2306,8 +2368,8 @@ static int OPL3_LockTable(device_t *device)
 
 static void OPL3_UnLockTable(void)
 {
-	if(num_lock) num_lock--;
-	if(num_lock) return;
+	if (num_lock) num_lock--;
+	if (num_lock) return;
 
 	/* last time */
 	OPLCloseTable();
@@ -2335,19 +2397,19 @@ static void OPL3ResetChip(OPL3 *chip)
 
 
 //FIX IT (dont change CH.D, CH.C, CH.B and CH.A in C0-C8 registers)
-	for(c = 0xff ; c >= 0x20 ; c-- )
+	for (c = 0xff ; c >= 0x20 ; c--)
 		OPL3WriteReg(chip,c,0);
 //FIX IT (dont change CH.D, CH.C, CH.B and CH.A in C0-C8 registers)
-	for(c = 0x1ff ; c >= 0x120 ; c-- )
+	for (c = 0x1ff ; c >= 0x120 ; c--)
 		OPL3WriteReg(chip,c,0);
 
 
 
 	/* reset operator parameters */
-	for( c = 0 ; c < 9*2 ; c++ )
+	for (c = 0 ; c < 9*2 ; c++)
 	{
 		OPL3_CH *CH = &chip->P_CH[c];
-		for(s = 0 ; s < 2 ; s++ )
+		for (s = 0 ; s < 2 ; s++)
 		{
 			CH->SLOT[s].state     = EG_OFF;
 			CH->SLOT[s].volume    = MAX_ATT_INDEX;
@@ -2358,7 +2420,7 @@ static void OPL3ResetChip(OPL3 *chip)
 /* Create one of virtual YMF262 */
 /* 'clock' is chip clock in Hz  */
 /* 'rate'  is sampling rate  */
-static OPL3 *OPL3Create(device_t *device, int clock, int rate, int type)
+static OPL3 *OPL3Create(device_t *device, int clock, int rate, int type, double divider, int busy_cycle)
 {
 	OPL3 *chip;
 
@@ -2369,6 +2431,8 @@ static OPL3 *OPL3Create(device_t *device, int clock, int rate, int type)
 
 	chip->device = device;
 	chip->type  = type;
+	chip->divider = divider;
+	chip->busy_cycle = busy_cycle;
 	OPL3_clock_changed(chip, clock, rate);
 
 	/* reset chip */
@@ -2385,13 +2449,26 @@ static void OPL3Destroy(OPL3 *chip)
 
 
 /* YMF262 I/O interface */
-static int OPL3Write(OPL3 *chip, int a, int v)
+static int OPL3Write(OPL3 *chip, u8 a, u8 v)
 {
+#ifdef INTERNAL_BUSY_ENABLE
+	if (chip->busy)
+		return chip->status>>7;
+#endif
+
 	/* data bus is 8 bits */
 	v &= 0xff;
 
+	if (chip->busy_cycle)
+	{
+		if (chip->timer_handler)
+		{
+			chip->busy = 1;
+			(chip->timer_handler)(chip->TimerParam,OPL3_TIMER_BUSY,attotime::from_hz(chip->clock / chip->busy_cycle));
+		}
+	}
 
-	switch(a&3)
+	switch (a & 3)
 	{
 	case 0: /* address port 0 (register set #1) */
 		chip->address = v;
@@ -2399,7 +2476,7 @@ static int OPL3Write(OPL3 *chip, int a, int v)
 
 	case 1: /* data port - ignore A1 */
 	case 3: /* data port - ignore A1 */
-		if(chip->UpdateHandler) chip->UpdateHandler(chip->UpdateParam,0);
+		if (chip->UpdateHandler) chip->UpdateHandler(chip->UpdateParam,0);
 		OPL3WriteReg(chip,chip->address,v);
 	break;
 
@@ -2414,7 +2491,7 @@ static int OPL3Write(OPL3 *chip, int a, int v)
 		   verified on registers from set#2: 0x01, 0x04, 0x20-0xef
 		   The only exception is register 0x05.
 		*/
-		if( chip->OPL3_mode & 1 )
+		if (chip->OPL3_mode & 1)
 		{
 			/* OPL3 mode */
 				chip->address = v | 0x100;
@@ -2422,7 +2499,7 @@ static int OPL3Write(OPL3 *chip, int a, int v)
 		else
 		{
 			/* in OPL2 mode the only accessible in set #2 is register 0x05 */
-			if( v==5 )
+			if (v==5)
 				chip->address = v | 0x100;
 			else
 				chip->address = v;  /* verified range: 0x01, 0x04, 0x20-0xef(set #2 becomes set #1 in opl2 mode) */
@@ -2435,10 +2512,17 @@ static int OPL3Write(OPL3 *chip, int a, int v)
 
 static unsigned char OPL3Read(OPL3 *chip,int a)
 {
-	if( a==0 )
+	if (a == 0)
 	{
 		/* status port */
-		return chip->status;
+		u8 ret = chip->status;
+		if ((chip->type == OPL3_TYPE_YMF289B) && chip->OPL3L_mode && chip->busy)
+			ret |= 0x5;
+		return ret;
+	}
+	else if ((chip->type == OPL3_TYPE_YMF289B) && (a & 1))
+	{
+		return chip->regs[chip->address];
 	}
 
 	return 0x00;    /* verified on real YMF262 */
@@ -2448,11 +2532,16 @@ static unsigned char OPL3Read(OPL3 *chip,int a)
 
 static int OPL3TimerOver(OPL3 *chip,int c)
 {
-	if( c )
+	if (c == OPL3_TIMER_BUSY) // busy
+	{
+		chip->busy = 0;
+		return chip->status>>7;
+	}
+	else if (c == OPL3_TIMER_2)
 	{   /* Timer B */
 		OPL3_STATUS_SET(chip,0x20);
 	}
-	else
+	else if (c == OPL3_TIMER_1)
 	{   /* Timer A */
 		OPL3_STATUS_SET(chip,0x40);
 	}
@@ -2514,6 +2603,8 @@ static void OPL3_save_state(OPL3 *chip, device_t *device) {
 		}
 	}
 
+	device->save_item(NAME(chip->regs));
+
 	device->save_item(NAME(chip->pan));
 	device->save_item(NAME(chip->pan_ctrl_value));
 
@@ -2521,6 +2612,7 @@ static void OPL3_save_state(OPL3 *chip, device_t *device) {
 	device->save_item(NAME(chip->lfo_pm_depth_range));
 
 	device->save_item(NAME(chip->OPL3_mode));
+	device->save_item(NAME(chip->OPL3L_mode));
 	device->save_item(NAME(chip->rhythm));
 
 	device->save_item(NAME(chip->T));
@@ -2529,13 +2621,28 @@ static void OPL3_save_state(OPL3 *chip, device_t *device) {
 	device->save_item(NAME(chip->address));
 	device->save_item(NAME(chip->status));
 	device->save_item(NAME(chip->statusmask));
+	device->save_item(NAME(chip->busy));
 
 	device->save_item(NAME(chip->nts));
 }
 
-void * ymf262_init(device_t *device, int clock, int rate)
+bool internal_busy(void *chip)
 {
-	void *chip = OPL3Create(device,clock,rate,OPL3_TYPE_YMF262);
+	OPL3 *opl3 = (OPL3 *)chip;
+	return opl3->busy;
+}
+
+void * ymf262_init(device_t *device, int clock, int rate, double divider, int busy_cycle)
+{
+	void *chip = OPL3Create(device,clock,rate,OPL3_TYPE_YMF262,divider,busy_cycle);
+	OPL3_save_state((OPL3 *)chip, device);
+
+	return chip;
+}
+
+void * ymf289b_init(device_t *device, int clock, int rate, double divider, int busy_cycle)
+{
+	void *chip = OPL3Create(device,clock,rate,OPL3_TYPE_YMF289B,divider,busy_cycle);
 	OPL3_save_state((OPL3 *)chip, device);
 
 	return chip;
@@ -2578,6 +2685,8 @@ unsigned char ymf262_read(void *chip, int a)
 	/* YMF262(OPL3) always returns bit2 and bit1 in LOW state */
 	/* which can be used to identify the chip */
 
+	/* YMF289B(OPL3-L) has readable registers */
+
 	/* YMF278(OPL4) returns bit2 in LOW and bit1 in HIGH state ??? info from manual - not verified */
 
 	return OPL3Read((OPL3 *)chip, a);
@@ -2613,14 +2722,14 @@ void ymf262_update_one(void *_chip, OPL3SAMPLE **buffers, int length)
 	int i;
 	OPL3        *chip  = (OPL3 *)_chip;
 	signed int *chanout = chip->chanout;
-	uint8_t       rhythm = chip->rhythm&0x20;
+	uint8_t       rhythm = chip->rhythm & 0x20;
 
 	OPL3SAMPLE  *ch_a = buffers[0]; // DO2 (mixed) left output for OPL4
 	OPL3SAMPLE  *ch_b = buffers[1]; // DO2 (mixed) right output for OPL4
 	OPL3SAMPLE  *ch_c = buffers[2]; // DO0 (FM only) left output for OPL4
 	OPL3SAMPLE  *ch_d = buffers[3]; // DO0 (FM only) right output for OPL4
 
-	for( i=0; i < length ; i++ )
+	for (i=0; i < length ; i++)
 	{
 		int a,b,c,d;
 
@@ -2652,7 +2761,7 @@ void ymf262_update_one(void *_chip, OPL3SAMPLE **buffers, int length)
 			chan_calc(chip, &chip->P_CH[5]);        /* standard 2op ch#5 */
 
 
-		if(!rhythm)
+		if (!rhythm)
 		{
 			chan_calc(chip, &chip->P_CH[6]);
 			chan_calc(chip, &chip->P_CH[7]);
@@ -2660,7 +2769,7 @@ void ymf262_update_one(void *_chip, OPL3SAMPLE **buffers, int length)
 		}
 		else        /* Rhythm part */
 		{
-			chan_calc_rhythm(chip, &chip->P_CH[0], (chip->noise_rng>>0)&1 );
+			chan_calc_rhythm(chip, &chip->P_CH[0], (chip->noise_rng>>0)&1);
 		}
 
 	/* register set #2 */
@@ -2778,13 +2887,13 @@ void ymf262_update_one(void *_chip, OPL3SAMPLE **buffers, int length)
 		d >>= FINAL_SH;
 
 		/* limit check */
-		a = limit( a , MAXOUT, MINOUT );
-		b = limit( b , MAXOUT, MINOUT );
-		c = limit( c , MAXOUT, MINOUT );
-		d = limit( d , MAXOUT, MINOUT );
+		a = limit(a , MAXOUT, MINOUT);
+		b = limit(b , MAXOUT, MINOUT);
+		c = limit(c , MAXOUT, MINOUT);
+		d = limit(d , MAXOUT, MINOUT);
 
 		#ifdef SAVE_SAMPLE
-		if (which==0)
+		if (which == 0)
 		{
 			SAVE_ALL_CHANNELS
 		}
@@ -2795,6 +2904,155 @@ void ymf262_update_one(void *_chip, OPL3SAMPLE **buffers, int length)
 		ch_b[i] = b;
 		ch_c[i] = c;
 		ch_d[i] = d;
+
+		advance(chip);
+	}
+
+}
+
+void ymf289b_update_one(void *_chip, OPL3SAMPLE **buffers, int length)
+{
+	int i;
+	OPL3        *chip  = (OPL3 *)_chip;
+	signed int *chanout = chip->chanout;
+	uint8_t       rhythm = chip->rhythm & 0x20;
+
+	OPL3SAMPLE  *ch_a = buffers[0]; // Only 2 outputs in YMF289B
+	OPL3SAMPLE  *ch_b = buffers[1];
+
+	for (i=0; i < length ; i++)
+	{
+		int a,b;
+
+		advance_lfo(chip);
+
+		/* clear channel outputs */
+		memset(chip->chanout, 0, sizeof(chip->chanout));
+
+#if 1
+	/* register set #1 */
+		chan_calc(chip, &chip->P_CH[0]);            /* extended 4op ch#0 part 1 or 2op ch#0 */
+		if (chip->P_CH[0].extended)
+			chan_calc_ext(chip, &chip->P_CH[3]);    /* extended 4op ch#0 part 2 */
+		else
+			chan_calc(chip, &chip->P_CH[3]);        /* standard 2op ch#3 */
+
+
+		chan_calc(chip, &chip->P_CH[1]);            /* extended 4op ch#1 part 1 or 2op ch#1 */
+		if (chip->P_CH[1].extended)
+			chan_calc_ext(chip, &chip->P_CH[4]);    /* extended 4op ch#1 part 2 */
+		else
+			chan_calc(chip, &chip->P_CH[4]);        /* standard 2op ch#4 */
+
+
+		chan_calc(chip, &chip->P_CH[2]);            /* extended 4op ch#2 part 1 or 2op ch#2 */
+		if (chip->P_CH[2].extended)
+			chan_calc_ext(chip, &chip->P_CH[5]);    /* extended 4op ch#2 part 2 */
+		else
+			chan_calc(chip, &chip->P_CH[5]);        /* standard 2op ch#5 */
+
+
+		if (!rhythm)
+		{
+			chan_calc(chip, &chip->P_CH[6]);
+			chan_calc(chip, &chip->P_CH[7]);
+			chan_calc(chip, &chip->P_CH[8]);
+		}
+		else        /* Rhythm part */
+		{
+			chan_calc_rhythm(chip, &chip->P_CH[0], (chip->noise_rng>>0)&1);
+		}
+
+	/* register set #2 */
+		chan_calc(chip, &chip->P_CH[ 9]);
+		if (chip->P_CH[9].extended)
+			chan_calc_ext(chip, &chip->P_CH[12]);
+		else
+			chan_calc(chip, &chip->P_CH[12]);
+
+
+		chan_calc(chip, &chip->P_CH[10]);
+		if (chip->P_CH[10].extended)
+			chan_calc_ext(chip, &chip->P_CH[13]);
+		else
+			chan_calc(chip, &chip->P_CH[13]);
+
+
+		chan_calc(chip, &chip->P_CH[11]);
+		if (chip->P_CH[11].extended)
+			chan_calc_ext(chip, &chip->P_CH[14]);
+		else
+			chan_calc(chip, &chip->P_CH[14]);
+
+
+		/* channels 15,16,17 are fixed 2-operator channels only */
+		chan_calc(chip, &chip->P_CH[15]);
+		chan_calc(chip, &chip->P_CH[16]);
+		chan_calc(chip, &chip->P_CH[17]);
+#endif
+
+		/* accumulator register set #1 */
+		a =  chanout[0] & chip->pan[0];
+		b =  chanout[0] & chip->pan[1];
+#if 1
+		a += chanout[1] & chip->pan[4];
+		b += chanout[1] & chip->pan[5];
+		a += chanout[2] & chip->pan[8];
+		b += chanout[2] & chip->pan[9];
+
+		a += chanout[3] & chip->pan[12];
+		b += chanout[3] & chip->pan[13];
+		a += chanout[4] & chip->pan[16];
+		b += chanout[4] & chip->pan[17];
+		a += chanout[5] & chip->pan[20];
+		b += chanout[5] & chip->pan[21];
+
+		a += chanout[6] & chip->pan[24];
+		b += chanout[6] & chip->pan[25];
+		a += chanout[7] & chip->pan[28];
+		b += chanout[7] & chip->pan[29];
+		a += chanout[8] & chip->pan[32];
+		b += chanout[8] & chip->pan[33];
+
+		/* accumulator register set #2 */
+		a += chanout[9] & chip->pan[36];
+		b += chanout[9] & chip->pan[37];
+		a += chanout[10] & chip->pan[40];
+		b += chanout[10] & chip->pan[41];
+		a += chanout[11] & chip->pan[44];
+		b += chanout[11] & chip->pan[45];
+
+		a += chanout[12] & chip->pan[48];
+		b += chanout[12] & chip->pan[49];
+		a += chanout[13] & chip->pan[52];
+		b += chanout[13] & chip->pan[53];
+		a += chanout[14] & chip->pan[56];
+		b += chanout[14] & chip->pan[57];
+
+		a += chanout[15] & chip->pan[60];
+		b += chanout[15] & chip->pan[61];
+		a += chanout[16] & chip->pan[64];
+		b += chanout[16] & chip->pan[65];
+		a += chanout[17] & chip->pan[68];
+		b += chanout[17] & chip->pan[69];
+#endif
+		a >>= FINAL_SH;
+		b >>= FINAL_SH;
+
+		/* limit check */
+		a = limit(a , MAXOUT, MINOUT);
+		b = limit(b , MAXOUT, MINOUT);
+
+		#ifdef SAVE_SAMPLE
+		if (which == 0)
+		{
+			SAVE_ALL_CHANNELS
+		}
+		#endif
+
+		/* store to sound buffer */
+		ch_a[i] = a;
+		ch_b[i] = b;
 
 		advance(chip);
 	}

--- a/src/devices/sound/ymf262.h
+++ b/src/devices/sound/ymf262.h
@@ -7,6 +7,10 @@
 
 /* select number of output bits: 8 or 16 */
 #define OPL3_SAMPLE_BITS 16
+#define OPL3_TIMER_1 0
+#define OPL3_TIMER_2 1
+#define OPL3_TIMER_BUSY 2
+#define OPL3_TIMER_MAX 3
 
 typedef stream_sample_t OPL3SAMPLE;
 /*
@@ -22,8 +26,9 @@ typedef void (*OPL3_TIMERHANDLER)(device_t *device,int timer,const attotime &per
 typedef void (*OPL3_IRQHANDLER)(device_t *device,int irq);
 typedef void (*OPL3_UPDATEHANDLER)(device_t *device,int min_interval_us);
 
+bool internal_busy(void *chip);
 
-void *ymf262_init(device_t *device, int clock, int rate);
+void *ymf262_init(device_t *device, int clock, int rate, double divider, int busy_cycle);
 void ymf262_clock_changed(void *chip, int clock, int rate);
 void ymf262_post_load(void *chip);
 void ymf262_shutdown(void *chip);
@@ -32,6 +37,9 @@ int  ymf262_write(void *chip, int a, int v);
 unsigned char ymf262_read(void *chip, int a);
 int  ymf262_timer_over(void *chip, int c);
 void ymf262_update_one(void *chip, OPL3SAMPLE **buffers, int length);
+
+void *ymf289b_init(device_t *device, int clock, int rate, double divider, int busy_cycle);
+void ymf289b_update_one(void *chip, OPL3SAMPLE **buffers, int length);
 
 void ymf262_set_timer_handler(void *chip, OPL3_TIMERHANDLER TimerHandler, device_t *device);
 void ymf262_set_irq_handler(void *chip, OPL3_IRQHANDLER IRQHandler, device_t *device);

--- a/src/devices/sound/ymf278b.cpp
+++ b/src/devices/sound/ymf278b.cpp
@@ -215,25 +215,30 @@ void ymf278b_device::compute_envelope(YMF278BSlot *slot)
 
 void ymf278b_device::sound_stream_update(sound_stream &stream, stream_sample_t **inputs, stream_sample_t **outputs, int samples)
 {
+	/*
+		Output layout
+		0 DO2 PCM L + FM CHA
+		1 DO2 PCM R + FM CHB
+		2 DO0 FM CHC
+		3 DO0 FM CHD
+		4 DO1 PCM L
+		5 DO1 PCM R
+	*/
+
 	int i, j;
 	YMF278BSlot *slot;
 	int16_t sample = 0;
 	int32_t *mixp;
 	int32_t vl, vr;
 
-	if (&stream == m_stream_ymf262)
+	ymf262_update_one(m_ymf262, outputs, samples);
+	vl = m_mix_level[m_fm_l];
+	vr = m_mix_level[m_fm_r];
+	for (i = 0; i < samples; i++)
 	{
-		// TODO : FM only output is DO0, DO2 is actually mixed FM+PCM outputs
-		ymf262_update_one(m_ymf262, outputs, samples);
-		vl = m_mix_level[m_fm_l];
-		vr = m_mix_level[m_fm_r];
-		for (i = 0; i < samples; i++)
-		{
-			// DO2 mixing
-			outputs[0][i] = (outputs[0][i] * vl) >> 16;
-			outputs[1][i] = (outputs[1][i] * vr) >> 16;
-		}
-		return;
+		// DO2 mixing
+		outputs[0][i] = (outputs[0][i] * vl) >> 16;
+		outputs[1][i] = (outputs[1][i] * vr) >> 16;
 	}
 
 	std::fill(m_mix_buffer.begin(), m_mix_buffer.end(), 0);
@@ -321,10 +326,10 @@ void ymf278b_device::sound_stream_update(sound_stream &stream, stream_sample_t *
 	vr = m_mix_level[m_pcm_r];
 	for (i = 0; i < samples; i++)
 	{
-		outputs[0][i] = (*mixp++ * vl) >> 16;
-		outputs[1][i] = (*mixp++ * vr) >> 16;
-		outputs[2][i] = *mixp++;
-		outputs[3][i] = *mixp++;
+		outputs[0][i] += (*mixp++ * vl) >> 16;
+		outputs[1][i] += (*mixp++ * vr) >> 16;
+		outputs[4][i] = *mixp++;
+		outputs[5][i] = *mixp++;
 	}
 }
 
@@ -889,9 +894,7 @@ void ymf278b_device::device_clock_changed()
 
 	// YMF262 related
 
-	int ymf262_clock = clock() / (19/8.0);
-	ymf262_clock_changed(m_ymf262, ymf262_clock, ymf262_clock / 288);
-	m_stream_ymf262->set_sample_rate(ymf262_clock / 288);
+	ymf262_clock_changed(m_ymf262, m_clock, m_rate);
 }
 
 void ymf278b_device::rom_bank_updated()
@@ -1014,7 +1017,7 @@ void ymf278b_device::device_start()
 		m_slots[i].num = i;
 	}
 
-	m_stream = machine().sound().stream_alloc(*this, 0, 4, m_rate);
+	m_stream = machine().sound().stream_alloc(*this, 0, 6, m_rate);
 	m_mix_buffer.resize(m_rate*4,0);
 
 	// rate tables
@@ -1044,12 +1047,9 @@ void ymf278b_device::device_start()
 	// YMF262 related
 
 	/* stream system initialize */
-	int ymf262_clock = clock() / (19/8.0);
-	m_ymf262 = ymf262_init(this, ymf262_clock, ymf262_clock / 288);
+	m_ymf262 = ymf262_init(this, m_clock, m_rate, 684.0, 0/*56 external*/);
 	if (!m_ymf262)
 		throw emu_fatalerror("ymf278b_device(%s): Error creating YMF262 chip", tag());
-
-	m_stream_ymf262 = machine().sound().stream_alloc(*this, 0, 4, ymf262_clock / 288);
 
 	/* YMF262 setup */
 	ymf262_set_timer_handler (m_ymf262, ymf278b_device::static_timer_handler, this);

--- a/src/devices/sound/ymf278b.h
+++ b/src/devices/sound/ymf278b.h
@@ -17,6 +17,9 @@ public:
 	u8 read(offs_t offset);
 	void write(offs_t offset, u8 data);
 
+	// for VGMPlay data handling
+	bool busy() { return m_status_ld | m_status_busy; }
+
 protected:
 	// device-level overrides
 	virtual void device_post_load() override;
@@ -88,7 +91,7 @@ private:
 	void precompute_rate_tables();
 	void register_save_state();
 
-	void update_request() { m_stream_ymf262->update(); }
+	void update_request() { m_stream->update(); }
 
 	static void static_irq_handler(device_t *param, int irq) { }
 	static void static_timer_handler(device_t *param, int c, const attotime &period) { }
@@ -134,7 +137,6 @@ private:
 
 	// ymf262
 	void *m_ymf262;
-	sound_stream * m_stream_ymf262;
 };
 
 DECLARE_DEVICE_TYPE(YMF278B, ymf278b_device)

--- a/src/mame/drivers/fuukifg3.cpp
+++ b/src/mame/drivers/fuukifg3.cpp
@@ -557,12 +557,10 @@ void fuuki32_state::fuuki32(machine_config &config)
 	ymf.irq_handler().set_inputline("soundcpu", 0);
 	ymf.add_route(0, "lspeaker", 0.50);
 	ymf.add_route(1, "rspeaker", 0.50);
-	ymf.add_route(2, "lspeaker", 0.50);
-	ymf.add_route(3, "rspeaker", 0.50);
-	ymf.add_route(4, "lspeaker", 0.40);
-	ymf.add_route(5, "rspeaker", 0.40);
-	ymf.add_route(6, "lspeaker", 0.40);
-	ymf.add_route(7, "rspeaker", 0.40);
+	ymf.add_route(2, "lspeaker", 0.40);
+	ymf.add_route(3, "rspeaker", 0.40);
+	ymf.add_route(4, "lspeaker", 0.50);
+	ymf.add_route(5, "rspeaker", 0.50);
 }
 
 /***************************************************************************

--- a/src/mame/drivers/psikyo4.cpp
+++ b/src/mame/drivers/psikyo4.cpp
@@ -648,8 +648,6 @@ void psikyo4_state::ps4big(machine_config &config)
 	ymf.add_route(3, "lspeaker", 1.0);
 	ymf.add_route(4, "rspeaker", 1.0);
 	ymf.add_route(5, "lspeaker", 1.0);
-	ymf.add_route(6, "rspeaker", 1.0);
-	ymf.add_route(7, "lspeaker", 1.0);
 }
 
 void psikyo4_state::ps4small(machine_config &config)


### PR DESCRIPTION
ymf262.cpp : Implement clock divider and busy cycle difference
262intf.cpp, ymf262.cpp : Implement YMF289B device behavior, Implement internal busy timer, Add notes, Fix some spacings
ymf278b.cpp : Correct clock divider and output rate for FM synthesizer, Correct sound mixing behavior
vgmplay.cpp : Avoid busy flag for ymf262, ymf278b, Fix ymf278b volume, Implement restart behavior

YMF289B used in some PC soundcards, instead YMF262.