### PR TITLE
wd177x_dsk: generalize to allow custom track format variations

### DIFF
--- a/src/lib/formats/flex_dsk.cpp
+++ b/src/lib/formats/flex_dsk.cpp
@@ -1,18 +1,52 @@
 // license:BSD-3-Clause
-// copyright-holders:Barry Rodewald
+// copyright-holders:Barry Rodewald, 68bit
 /*
  * flex_dsk.c  -  FLEX compatible disk images
  *
  *  Created on: 24/06/2014
  *
- * TODO This format does not yet handle double density disks with a single
- * density track 0. FLEX DSK files are generally 'fixed' to have a consistent
- * number of sectors per track which makes them easier to work with and gains
- * more storage space, and tools and emulators generally only work with these
- * formats. For now use single density disks, or patch the ROM to load the
- * boot sector(s) in double density and patch the drivers to use double
- * density on track zero. Drivers developed for emulators commonly have other
- * issues and need work anyway.
+ * This FLEX floppy disk image support leverages the wd177x_format support
+ * with the few differences handled by format variations.
+ *
+ * FLEX numbers sectors on the second side of a track continuing from the
+ * first side, so there are separate formats for each head on double sided
+ * disk formats.
+ *
+ * FLEX on the 6809 typically encodes the first track, on both heads, in
+ * single density for double density disks. This simplifies the ROM boot code
+ * which need only handle single density. It might also have been a strategy
+ * at the time for reading both single and double density disks. So there are
+ * double density disk format variations that have the first track encoded in
+ * single density.
+ *
+ * However FLEX double density disks did not necessarily have the first sector
+ * encoded in single density. FLEX floppy disk drivers for the 6800 were
+ * typically just patched for double density support, with the controller
+ * jumpered for double density, and so did not encode the first sector in
+ * single density. Also there are many 'emulator' disk images distributed for
+ * which the first track has been padded to give a consistent number of
+ * sectors per track. So there are variations for which the first track is
+ * also encoded in double density.
+ *
+ * FLEX generally numbers sectors starting with ID 1, but there are exceptions
+ * for 6800 boot sectors where the first one or two sectors of track 0 and
+ * head 0 are numbered starting with ID 0 and so there are format variations
+ * for these. This strategy simplified the 6800 ROM boot loader, minimising
+ * its code size, which simply issues a multi-sector read and relies on a gap
+ * in the sector IDs to halt that operation. So if only one sector is to be
+ * loaded then the sector IDs are 0, 2, 3, ..., and if two sectors are to be
+ * loaded then the sector IDs are 0, 1, 3, 4, .... This strategy was abandoned
+ * for FLEX 6809 which numbers the boot sectors starting from ID 1 too.
+ *
+ * The formats below include interleaved sectors to improve performance. The
+ * interleave has been chosen to perform well on slower hardware and software
+ * combinations while still offering some performance improvement. Tighter
+ * interleaving may well be possible but it depends on the systems and
+ * software.
+ *
+ * Not all of the formats are practical on all hardware and software. E.g. The
+ * higher density formats can require data rates that the CPU can not keep up
+ * with.
  */
 
 #include "flex_dsk.h"
@@ -37,15 +71,6 @@ const char *flex_format::extensions() const
 	return "dsk";
 }
 
-int flex_format::identify(io_generic *io, uint32_t form_factor)
-{
-	int type = find_size(io, form_factor);
-
-	if (type != -1)
-		return 75;
-	return 0;
-}
-
 int flex_format::find_size(io_generic *io, uint32_t form_factor)
 {
 	uint64_t size = io_generic_size(io);
@@ -58,69 +83,7 @@ int flex_format::find_size(io_generic *io, uint32_t form_factor)
 	// Look at the system information sector.
 	io_generic_read(io, &info, 256 * 2, sizeof(struct sysinfo_sector));
 
-	LOG_FORMATS("FLEX floppy dsk size %d %d %d\n", (uint32_t)size, (uint32_t)size / 256, (uint32_t)size % 256);
-
-	LOG_FORMATS(" boot0:");
-	for (int i = 0; i < 16; i++) {
-	  LOG_FORMATS(" %02x", boot0[i]);
-	}
-	LOG_FORMATS("\n");
-
-	LOG_FORMATS(" boot1:");
-	for (int i = 0; i < 16; i++) {
-	  LOG_FORMATS(" %02x", boot1[i]);
-	}
-	LOG_FORMATS("\n");
-
-
-	// Check that the 'unused' area is actually unused.
-	LOG_FORMATS(" unused1:");
-	for (int i = 0; i < sizeof(info.unused1); i++) {
-	  LOG_FORMATS(" %02x", info.unused1[i]);
-	}
-	LOG_FORMATS("\n");
-
-	LOG_FORMATS(" disk_name: \"");
-	for (int i = 0; i < sizeof(info.disk_name); i++) {
-	  uint8_t ch = info.disk_name[i];
-	  if (ch < 0x20 || ch > 0x7f) {
-		LOG_FORMATS("[%02x]", ch);
-	  } else {
-		LOG_FORMATS("%c", ch);
-	  }
-	}
-	if (info.disk_ext[0] || info.disk_ext[1] || info.disk_ext[2]) {
-	  LOG_FORMATS(".");
-	  for (int i = 0; i < sizeof(info.disk_ext); i++) {
-		uint8_t ch = info.disk_ext[i];
-		if (ch < 0x20 || ch > 0x7f) {
-		  LOG_FORMATS("[%02x]", ch);
-		} else {
-		  LOG_FORMATS("%c", ch);
-		}
-	  }
-	}
-	LOG_FORMATS("\"\n");
-
-	LOG_FORMATS(" fc_start_trk %d, fc_start_sec %d\n", info.fc_start_trk, info.fc_start_sec);
-	LOG_FORMATS(" fc_end_trk: %d, fc_end_sec: %d\n", info.fc_end_trk, info.fc_end_sec);
-	LOG_FORMATS(" free: %02x %02x\n", info.free[0], info.free[0]);
-
-	LOG_FORMATS(" month %d day %d year %d\n", info.month, info.day, info.year);
-	LOG_FORMATS(" last_trk %d, last_sec %d\n", info.last_trk, info.last_sec);
-
-	LOG_FORMATS(" unused2:");
-	for (int i = 0; i < 16; i++) {
-	  LOG_FORMATS(" %02x", info.unused2[i]);
-	}
-	LOG_FORMATS("\n");
-
-#if 0
-	// Check that the first 'unused' area is zero filled.
-	// Unfortunately an occasional dsk image has non-zero values here.
-	for (int i = 0; i < sizeof(info.unused1); i++)
-		if (info.unused1[i] != 0) return -1;
-#endif
+	LOG_FORMATS("FLEX floppy dsk: size %d bytes, %d total sectors, %d remaining bytes, expected form factor %x\n", (uint32_t)size, (uint32_t)size / 256, (uint32_t)size % 256, form_factor);
 
 	// Consistency checks.
 	if (info.fc_start_trk > info.last_trk || info.fc_end_trk > info.last_trk)
@@ -130,15 +93,6 @@ int flex_format::find_size(io_generic *io, uint32_t form_factor)
 	if (info.month < 1 || info.month > 12 || info.day < 1 || info.day > 31)
 		return -1;
 
-	// FLEX sector numbers start at one generally, however the 6800 ROM
-	// boot loaders load the boot code from track zero, side zero,
-	// starting at sector zero. The boot code attempts to read multiple
-	// sectors and a gap in the sector numbering appears to be used to
-	// terminate the sequence. So if only one sector is to be loaded then
-	// the sector numbering is 0, 2, 3, .... If two sectors are to be
-	// loaded then the sector numbering is 0, 1, 3, 4 ... The boot loaders
-	// for 6809 FLEX systems appear to load from sector one so do not have
-	// this inconsistency to handle.
 	boot0_sector_id = 1;
 	boot1_sector_id = 2;
 
@@ -158,14 +112,10 @@ int flex_format::find_size(io_generic *io, uint32_t form_factor)
 			boot1_sector_id = 1;
 		}
 	}
-	LOG_FORMATS(" boot sector ids: %d %d\n",  boot0_sector_id, boot1_sector_id);
 
-	for(int i=0; formats[i].form_factor; i++) {
+	for (int i=0; formats[i].form_factor; i++) {
 		const format &f = formats[i];
-		if(form_factor != floppy_image::FF_UNKNOWN && form_factor != f.form_factor)
-			continue;
-
-		if(size != (uint64_t)compute_track_size(f) * f.track_count * f.head_count)
+		if (form_factor != floppy_image::FF_UNKNOWN && form_factor != f.form_factor)
 			continue;
 
 		// Check consistency with the sysinfo record sector.
@@ -175,170 +125,1133 @@ int flex_format::find_size(io_generic *io, uint32_t form_factor)
 		if (f.sector_count * f.head_count != info.last_sec)
 			continue;
 
+		unsigned int format_size = 0;
+		for (int track=0; track < f.track_count; track++) {
+			for (int head=0; head < f.head_count; head++) {
+				const format &tf = get_track_format(f, head, track);
+				format_size += compute_track_size(tf);
+			}
+		}
+
+		if (format_size != size)
+			continue;
+
+		// Check that the boot sector ID matches.
+		const format &ft0 = formats_track0[i];
+		if (ft0.form_factor) {
+			// There is a specialized track 0 format.
+			if (ft0.sector_base_id == -1) {
+				if (ft0.per_sector_id[0] != boot0_sector_id)
+					continue;
+			} else {
+				if (ft0.sector_base_id != boot0_sector_id)
+					continue;
+			}
+		} else {
+			// Otherwise check the default track format.
+			if (f.sector_base_id == -1) {
+				if (f.per_sector_id[0] != boot0_sector_id)
+					continue;
+			} else {
+				if (f.sector_base_id != boot0_sector_id)
+					continue;
+			}
+		}
+
+		LOG_FORMATS("FLEX matching format index %d\n", i);
 		return i;
 	}
 	return -1;
 }
 
-// FLEX numbers sectors on the second side of a track continuing from the
-// first side which is a variation not handled by the generic code.
-//
-// FLEX generally numbers sectors starting at 1, however the 6800 boot sectors
-// are numbers starting at zero.
-//
-void flex_format::build_sector_description(const format &f, uint8_t *sectdata, desc_s *sectors, int track, int head) const
+const wd177x_format::format &flex_format::get_track_format(const format &f, int head, int track)
 {
-	if(f.sector_base_id == -1) {
-		for(int i=0; i<f.sector_count; i++) {
-			int cur_offset = 0;
-			for(int j=0; j<f.sector_count; j++)
-				if(f.per_sector_id[j] < f.per_sector_id[i])
-					cur_offset += f.sector_base_size ? f.sector_base_size : f.per_sector_size[j];
-			sectors[i].data = sectdata + cur_offset;
-			sectors[i].size = f.sector_base_size ? f.sector_base_size : f.per_sector_size[i];
-			uint8_t sector_id = f.per_sector_id[i];
-			if (track == 0 && head == 0 && sector_id <= 2) {
-				if (sector_id == 0)
-					sector_id = boot0_sector_id;
-				else
-					sector_id = boot1_sector_id;
-			}
-			sectors[i].sector_id = f.sector_count * head + sector_id;
-		}
-	} else {
-		int cur_offset = 0;
-		for(int i=0; i<f.sector_count; i++) {
-			sectors[i].data = sectdata + cur_offset;
-			sectors[i].size = f.sector_base_size ? f.sector_base_size : f.per_sector_size[i];
-			cur_offset += sectors[i].size;
-			uint8_t sector_id = i + f.sector_base_id;
-			if (track == 0 && head == 0 && i < 2) {
-				if (i == 0)
-					sector_id = boot0_sector_id;
-				else
-					sector_id = boot1_sector_id;
-			}
-			sectors[i].sector_id = f.sector_count * head + sector_id;
+	int n = -1;
+
+	for (int i = 0; formats[i].form_factor; i++) {
+		if (&formats[i] == &f) {
+			n = i;
+			break;
 		}
 	}
-}
 
-// For FLEX just use track 1 rather than the generic code that looks a track
-// 0. This is enough to avoid the odd sector numbering for the boot sectors,
-// while following the generic code.
-void flex_format::check_compatibility(floppy_image *image, std::vector<int> &candidates)
-{
-	uint8_t bitstream[500000/8];
-	uint8_t sectdata[50000];
-	desc_xs sectors[256];
-	int track_size;
-
-	// Extract the sectors
-	generate_bitstream_from_track(1, 0, formats[candidates[0]].cell_size, bitstream, track_size, image);
-
-	switch (formats[candidates[0]].encoding)
-	{
-	case floppy_image::FM:
-		extract_sectors_from_bitstream_fm_pc(bitstream, track_size, sectors, sectdata, sizeof(sectdata));
-		break;
-	case floppy_image::MFM:
-		extract_sectors_from_bitstream_mfm_pc(bitstream, track_size, sectors, sectdata, sizeof(sectdata));
-		break;
+	if (n < 0) {
+		LOG_FORMATS("Error format not found\n");
+		return f;
 	}
 
-	// Check compatibility with every candidate, copy in-place
-	int *ok_cands = &candidates[0];
-	for(unsigned int i=0; i != candidates.size(); i++) {
-		const format &f = formats[candidates[i]];
-		int ns = 0;
-		for(int j=0; j<256; j++)
-			if(sectors[j].data) {
-				int sid;
-				if(f.sector_base_id == -1) {
-					for(sid=0; sid < f.sector_count; sid++)
-						if(f.per_sector_id[sid] == j)
-							break;
-				} else
-					sid = j - f.sector_base_id;
-				if(sid < 0 || sid > f.sector_count)
-					goto fail;
-				if(f.sector_base_size) {
-					if(sectors[j].size != f.sector_base_size)
-						goto fail;
-				} else {
-					if(sectors[j].size != f.per_sector_size[sid])
-						goto fail;
-				}
-				ns++;
+	if (head >= f.head_count) {
+		LOG_FORMATS("Error invalid head %d\n", head);
+		return f;
+	}
+
+	if (track >= f.track_count) {
+		LOG_FORMATS("Error invalid track %d\n", track);
+		return f;
+	}
+
+	if (track > 0) {
+		if (head == 1) {
+			const format &fh1 = formats_head1[n];
+			if (!fh1.form_factor) {
+				LOG_FORMATS("Error expected a head 1 format\n");
+				return f;
 			}
-		if(ns == f.sector_count)
-			*ok_cands++ = candidates[i];
-	fail:
-		;
+			return fh1;
+		}
+		return f;
 	}
-	candidates.resize(ok_cands - &candidates[0]);
+
+	// Track 0
+
+	if (head == 1) {
+		const format &fh1t0 = formats_head1_track0[n];
+		if (fh1t0.form_factor) {
+			return fh1t0;
+		}
+		const format &fh1 = formats_head1[n];
+		if (fh1.form_factor) {
+			return fh1;
+		}
+		LOG_FORMATS("Error expected a head 1 format\n");
+		return f;
+	}
+
+	// Head 0
+
+	const format &ft0 = formats_track0[n];
+	if (ft0.form_factor) {
+		return ft0;
+	}
+
+	return f;
 }
+
 
 const flex_format::format flex_format::formats[] = {
-	{ // 87.5K 5 1/4 inch single density - gaps unverified
+	{ // 0 87.5K 5 1/4 inch single density
 		floppy_image::FF_525, floppy_image::SSSD, floppy_image::FM,
-		4000, 10, 35, 1, 256, {}, 1, {}, 40, 16, 11
+		4000, 10, 35, 1, 256, {}, -1, {1, 4, 7, 10, 3, 6, 9, 2, 5, 8}, 40, 16, 11
 	},
-	{ // 100K 5 1/4 inch single density - gaps unverified
+	{ // 1 87.5K 5 1/4 inch single density, 6800 one boot sector
 		floppy_image::FF_525, floppy_image::SSSD, floppy_image::FM,
-		4000, 10, 40, 1, 256, {}, 1, {}, 40, 16, 11
+		4000, 10, 35, 1, 256, {}, -1, {1, 4, 7, 10, 3, 6, 9, 2, 5, 8}, 40, 16, 11
 	},
-	{ // 200K 5 1/4 inch single density - gaps unverified
+	{ // 2 87.5K 5 1/4 inch single density, 6800 two boot sectors
 		floppy_image::FF_525, floppy_image::SSSD, floppy_image::FM,
-		4000, 10, 80, 1, 256, {}, 1, {}, 40, 16, 11
+		4000, 10, 35, 1, 256, {}, -1, {1, 4, 7, 10, 3, 6, 9, 2, 5, 8}, 40, 16, 11
 	},
-	{ // 175K 5 1/4 inch single density - gaps unverified
+	{ // 3 100K 5 1/4 inch single density
+		floppy_image::FF_525, floppy_image::SSSD, floppy_image::FM,
+		4000, 10, 40, 1, 256, {}, -1, {1, 4, 7, 10, 3, 6, 9, 2, 5, 8}, 40, 16, 11
+	},
+	{ // 4 100K 5 1/4 inch single density, 6800 one boot sector
+		floppy_image::FF_525, floppy_image::SSSD, floppy_image::FM,
+		4000, 10, 40, 1, 256, {}, -1, {1, 4, 7, 10, 3, 6, 9, 2, 5, 8}, 40, 16, 11
+	},
+	{ // 5 100K 5 1/4 inch single density, 6800 two boot sectors
+		floppy_image::FF_525, floppy_image::SSSD, floppy_image::FM,
+		4000, 10, 40, 1, 256, {}, -1, {1, 4, 7, 10, 3, 6, 9, 2, 5, 8}, 40, 16, 11
+	},
+	{ // 6 200K 5 1/4 inch single density
+		floppy_image::FF_525, floppy_image::SSSD, floppy_image::FM,
+		4000, 10, 80, 1, 256, {}, -1, {1, 4, 7, 10, 3, 6, 9, 2, 5, 8}, 40, 16, 11
+	},
+	{ // 7 200K 5 1/4 inch single density, 6800 one boot sector
+		floppy_image::FF_525, floppy_image::SSSD, floppy_image::FM,
+		4000, 10, 80, 1, 256, {}, -1, {1, 4, 7, 10, 3, 6, 9, 2, 5, 8}, 40, 16, 11
+	},
+	{ // 8 200K 5 1/4 inch single density, 6800 two boot sectors
+		floppy_image::FF_525, floppy_image::SSSD, floppy_image::FM,
+		4000, 10, 80, 1, 256, {}, -1, {1, 4, 7, 10, 3, 6, 9, 2, 5, 8}, 40, 16, 11
+	},
+	{ // 9 175K 5 1/4 inch single density
 		floppy_image::FF_525, floppy_image::DSSD, floppy_image::FM,
-		4000, 10, 35, 2, 256, {}, 1, {}, 40, 16, 11
+		4000, 10, 35, 2, 256, {}, -1, {1, 4, 7, 10, 3, 6, 9, 2, 5, 8}, 40, 16, 11
 	},
-	{ // 200K 5 1/4 inch single density - gaps unverified
+	{ // 10 175K 5 1/4 inch single density, 6800 one boot sector
 		floppy_image::FF_525, floppy_image::DSSD, floppy_image::FM,
-		4000, 10, 40, 2, 256, {}, 1, {}, 40, 16, 11
+		4000, 10, 35, 2, 256, {}, -1, {1, 4, 7, 10, 3, 6, 9, 2, 5, 8}, 40, 16, 11
 	},
-	{ // 400K 5 1/4 inch single density - gaps unverified
+	{ // 11 175K 5 1/4 inch single density, 6800 two boot sectors
 		floppy_image::FF_525, floppy_image::DSSD, floppy_image::FM,
-		4000, 10, 80, 2, 256, {}, 1, {}, 40, 16, 11
+		4000, 10, 35, 2, 256, {}, -1, {1, 4, 7, 10, 3, 6, 9, 2, 5, 8}, 40, 16, 11
 	},
-	{ // 320K 5 1/4 inch double density - gaps unverified
+	{ // 12 200K 5 1/4 inch single density
+		floppy_image::FF_525, floppy_image::DSSD, floppy_image::FM,
+		4000, 10, 40, 2, 256, {}, -1, {1, 4, 7, 10, 3, 6, 9, 2, 5, 8}, 40, 16, 11
+	},
+	{ // 13 200K 5 1/4 inch single density, 6800 one boot sector
+		floppy_image::FF_525, floppy_image::DSSD, floppy_image::FM,
+		4000, 10, 40, 2, 256, {}, -1, {1, 4, 7, 10, 3, 6, 9, 2, 5, 8}, 40, 16, 11
+	},
+	{ // 14 200K 5 1/4 inch single density, 6800 two boot sectors
+		floppy_image::FF_525, floppy_image::DSSD, floppy_image::FM,
+		4000, 10, 40, 2, 256, {}, -1, {1, 4, 7, 10, 3, 6, 9, 2, 5, 8}, 40, 16, 11
+	},
+	{ // 15 400K 5 1/4 inch single density
+		floppy_image::FF_525, floppy_image::DSSD, floppy_image::FM,
+		4000, 10, 80, 2, 256, {}, -1, {1, 4, 7, 10, 3, 6, 9, 2, 5, 8}, 40, 16, 11
+	},
+	{ // 16 400K 5 1/4 inch single density, 6800 one boot sector
+		floppy_image::FF_525, floppy_image::DSSD, floppy_image::FM,
+		4000, 10, 80, 2, 256, {}, -1, {1, 4, 7, 10, 3, 6, 9, 2, 5, 8}, 40, 16, 11
+	},
+	{ // 17 400K 5 1/4 inch single density, 6800 two boot sectors
+		floppy_image::FF_525, floppy_image::DSSD, floppy_image::FM,
+		4000, 10, 80, 2, 256, {}, -1, {1, 4, 7, 10, 3, 6, 9, 2, 5, 8}, 40, 16, 11
+	},
+	{ // 18 155.5K 5 1/4 inch double density (single density track 0)
 		floppy_image::FF_525, floppy_image::SSDD, floppy_image::MFM,
-		2000, 18, 40, 1, 256, {}, 1, {}, 80, 22, 24
+		2000, 18, 35, 1, 256, {}, -1, {1, 6, 11, 16, 3, 8, 13, 18, 5, 10, 15, 2, 7, 12, 17, 4, 9, 14}, 80, 22, 24
 	},
-	{ // 320K 5 1/4 inch double density - gaps unverified
+	{ // 19 155.5K 5 1/4 inch double density (single density track 0), 6800 one boot sector
+		floppy_image::FF_525, floppy_image::SSDD, floppy_image::MFM,
+		2000, 18, 35, 1, 256, {}, -1, {1, 6, 11, 16, 3, 8, 13, 18, 5, 10, 15, 2, 7, 12, 17, 4, 9, 14}, 80, 22, 24
+	},
+	{ // 20 155.5K 5 1/4 inch double density (single density track 0), 6800 two boot sectors
+		floppy_image::FF_525, floppy_image::SSDD, floppy_image::MFM,
+		2000, 18, 35, 1, 256, {}, -1, {1, 6, 11, 16, 3, 8, 13, 18, 5, 10, 15, 2, 7, 12, 17, 4, 9, 14}, 80, 22, 24
+	},
+	{ // 21 157.5K 5 1/4 inch double density
+		floppy_image::FF_525, floppy_image::SSDD, floppy_image::MFM,
+		2000, 18, 35, 1, 256, {}, -1, {1, 6, 11, 16, 3, 8, 13, 18, 5, 10, 15, 2, 7, 12, 17, 4, 9, 14}, 80, 22, 24
+	},
+	{ // 22 157.5K 5 1/4 inch double density, 6800 one boot sector
+		floppy_image::FF_525, floppy_image::SSDD, floppy_image::MFM,
+		2000, 18, 35, 1, 256, {}, -1, {1, 6, 11, 16, 3, 8, 13, 18, 5, 10, 15, 2, 7, 12, 17, 4, 9, 14}, 80, 22, 24
+	},
+	{ // 23 157.5K 5 1/4 inch double density, 6800 two boot sectors
+		floppy_image::FF_525, floppy_image::SSDD, floppy_image::MFM,
+		2000, 18, 35, 1, 256, {}, -1, {1, 6, 11, 16, 3, 8, 13, 18, 5, 10, 15, 2, 7, 12, 17, 4, 9, 14}, 80, 22, 24
+	},
+	{ // 24 311K 5 1/4 inch double density (single density track 0)
 		floppy_image::FF_525, floppy_image::DSDD, floppy_image::MFM,
-		2000, 18, 40, 2, 256, {}, 1, {}, 80, 22, 24
+		2000, 18, 35, 2, 256, {}, -1, {1, 6, 11, 16, 3, 8, 13, 18, 5, 10, 15, 2, 7, 12, 17, 4, 9, 14}, 80, 22, 24
 	},
-	{ // 360K 5 1/4 inch quad density - gaps unverified
+	{ // 25 311K 5 1/4 inch double density (single density track 0), 6800 one boot sector
+		floppy_image::FF_525, floppy_image::DSDD, floppy_image::MFM,
+		2000, 18, 35, 2, 256, {}, -1, {1, 6, 11, 16, 3, 8, 13, 18, 5, 10, 15, 2, 7, 12, 17, 4, 9, 14}, 80, 22, 24
+	},
+	{ // 26 311K 5 1/4 inch double density (single density track 0), 6800 two boot sectors
+		floppy_image::FF_525, floppy_image::DSDD, floppy_image::MFM,
+		2000, 18, 35, 2, 256, {}, -1, {1, 6, 11, 16, 3, 8, 13, 18, 5, 10, 15, 2, 7, 12, 17, 4, 9, 14}, 80, 22, 24
+	},
+	{ // 27 315K 5 1/4 inch double density
+		floppy_image::FF_525, floppy_image::DSDD, floppy_image::MFM,
+		2000, 18, 35, 2, 256, {}, -1, {1, 6, 11, 16, 3, 8, 13, 18, 5, 10, 15, 2, 7, 12, 17, 4, 9, 14}, 80, 22, 24
+	},
+	{ // 28 315K 5 1/4 inch double density, 6800 one boot sector
+		floppy_image::FF_525, floppy_image::DSDD, floppy_image::MFM,
+		2000, 18, 35, 2, 256, {}, -1, {1, 6, 11, 16, 3, 8, 13, 18, 5, 10, 15, 2, 7, 12, 17, 4, 9, 14}, 80, 22, 24
+	},
+	{ // 29 315K 5 1/4 inch double density, 6800 two boot sectors
+		floppy_image::FF_525, floppy_image::DSDD, floppy_image::MFM,
+		2000, 18, 35, 2, 256, {}, -1, {1, 6, 11, 16, 3, 8, 13, 18, 5, 10, 15, 2, 7, 12, 17, 4, 9, 14}, 80, 22, 24
+	},
+	{ // 30 178K 5 1/4 inch double density (single density track 0)
+		floppy_image::FF_525, floppy_image::SSDD, floppy_image::MFM,
+		2000, 18, 40, 1, 256, {}, -1, {1, 6, 11, 16, 3, 8, 13, 18, 5, 10, 15, 2, 7, 12, 17, 4, 9, 14}, 80, 22, 24
+	},
+	{ // 31 178K 5 1/4 inch double density (single density track 0), 6800 one boot sector
+		floppy_image::FF_525, floppy_image::SSDD, floppy_image::MFM,
+		2000, 18, 40, 1, 256, {}, -1, {1, 6, 11, 16, 3, 8, 13, 18, 5, 10, 15, 2, 7, 12, 17, 4, 9, 14}, 80, 22, 24
+	},
+	{ // 32 178K 5 1/4 inch double density (single density track 0), 6800 two boot sectors
+		floppy_image::FF_525, floppy_image::SSDD, floppy_image::MFM,
+		2000, 18, 40, 1, 256, {}, -1, {1, 6, 11, 16, 3, 8, 13, 18, 5, 10, 15, 2, 7, 12, 17, 4, 9, 14}, 80, 22, 24
+	},
+	{ // 33 180K 5 1/4 inch double density
+		floppy_image::FF_525, floppy_image::SSDD, floppy_image::MFM,
+		2000, 18, 40, 1, 256, {}, -1, {1, 6, 11, 16, 3, 8, 13, 18, 5, 10, 15, 2, 7, 12, 17, 4, 9, 14}, 80, 22, 24
+	},
+	{ // 34 180K 5 1/4 inch double density, 6800 one boot sector
+		floppy_image::FF_525, floppy_image::SSDD, floppy_image::MFM,
+		2000, 18, 40, 1, 256, {}, -1, {1, 6, 11, 16, 3, 8, 13, 18, 5, 10, 15, 2, 7, 12, 17, 4, 9, 14}, 80, 22, 24
+	},
+	{ // 35 180K 5 1/4 inch double density, 6800 two boot sectors
+		floppy_image::FF_525, floppy_image::SSDD, floppy_image::MFM,
+		2000, 18, 40, 1, 256, {}, -1, {1, 6, 11, 16, 3, 8, 13, 18, 5, 10, 15, 2, 7, 12, 17, 4, 9, 14}, 80, 22, 24
+	},
+	{ // 36 356K 5 1/4 inch double density (single density track 0)
+		floppy_image::FF_525, floppy_image::DSDD, floppy_image::MFM,
+		2000, 18, 40, 2, 256, {}, -1, {1, 6, 11, 16, 3, 8, 13, 18, 5, 10, 15, 2, 7, 12, 17, 4, 9, 14}, 80, 22, 24
+	},
+	{ // 37 356K 5 1/4 inch double density (single density track 0), 6800 one boot sector
+		floppy_image::FF_525, floppy_image::DSDD, floppy_image::MFM,
+		2000, 18, 40, 2, 256, {}, -1, {1, 6, 11, 16, 3, 8, 13, 18, 5, 10, 15, 2, 7, 12, 17, 4, 9, 14}, 80, 22, 24
+	},
+	{ // 38 356K 5 1/4 inch double density (single density track 0), 6800 two boot sectors
+		floppy_image::FF_525, floppy_image::DSDD, floppy_image::MFM,
+		2000, 18, 40, 2, 256, {}, -1, {1, 6, 11, 16, 3, 8, 13, 18, 5, 10, 15, 2, 7, 12, 17, 4, 9, 14}, 80, 22, 24
+	},
+	{ // 39 360K 5 1/4 inch double density
+		floppy_image::FF_525, floppy_image::DSDD, floppy_image::MFM,
+		2000, 18, 40, 2, 256, {}, -1, {1, 6, 11, 16, 3, 8, 13, 18, 5, 10, 15, 2, 7, 12, 17, 4, 9, 14}, 80, 22, 24
+	},
+	{ // 40 360K 5 1/4 inch double density, 6800 one boot sector
+		floppy_image::FF_525, floppy_image::DSDD, floppy_image::MFM,
+		2000, 18, 40, 2, 256, {}, -1, {1, 6, 11, 16, 3, 8, 13, 18, 5, 10, 15, 2, 7, 12, 17, 4, 9, 14}, 80, 22, 24
+	},
+	{ // 41 360K 5 1/4 inch double density, 6800 two boot sectors
+		floppy_image::FF_525, floppy_image::DSDD, floppy_image::MFM,
+		2000, 18, 40, 2, 256, {}, -1, {1, 6, 11, 16, 3, 8, 13, 18, 5, 10, 15, 2, 7, 12, 17, 4, 9, 14}, 80, 22, 24
+	},
+	{ // 42 358K 5 1/4 inch quad density (single density track 0)
 		floppy_image::FF_525, floppy_image::SSQD, floppy_image::MFM,
-		2000, 18, 80, 1, 256, {}, 1, {}, 80, 22, 24
+		2000, 18, 80, 1, 256, {}, -1, {1, 6, 11, 16, 3, 8, 13, 18, 5, 10, 15, 2, 7, 12, 17, 4, 9, 14}, 80, 22, 24
 	},
-	{ // 720K 5 1/4 inch quad density - gaps unverified
+	{ // 43 358K 5 1/4 inch quad density (single density track 0), 6800 one boot sector
+		floppy_image::FF_525, floppy_image::SSQD, floppy_image::MFM,
+		2000, 18, 80, 1, 256, {}, -1, {1, 6, 11, 16, 3, 8, 13, 18, 5, 10, 15, 2, 7, 12, 17, 4, 9, 14}, 80, 22, 24
+	},
+	{ // 44 358K 5 1/4 inch quad density (single density track 0), 6800 two boot sectors
+		floppy_image::FF_525, floppy_image::SSQD, floppy_image::MFM,
+		2000, 18, 80, 1, 256, {}, -1, {1, 6, 11, 16, 3, 8, 13, 18, 5, 10, 15, 2, 7, 12, 17, 4, 9, 14}, 80, 22, 24
+	},
+	{ // 45 360K 5 1/4 inch quad density
+		floppy_image::FF_525, floppy_image::SSQD, floppy_image::MFM,
+		2000, 18, 80, 1, 256, {}, -1, {1, 6, 11, 16, 3, 8, 13, 18, 5, 10, 15, 2, 7, 12, 17, 4, 9, 14}, 80, 22, 24
+	},
+	{ // 46 360K 5 1/4 inch quad density, 6800 one boot sector
+		floppy_image::FF_525, floppy_image::SSQD, floppy_image::MFM,
+		2000, 18, 80, 1, 256, {}, -1, {1, 6, 11, 16, 3, 8, 13, 18, 5, 10, 15, 2, 7, 12, 17, 4, 9, 14}, 80, 22, 24
+	},
+	{ // 47 360K 5 1/4 inch quad density, 6800 two boot sectors
+		floppy_image::FF_525, floppy_image::SSQD, floppy_image::MFM,
+		2000, 18, 80, 1, 256, {}, -1, {1, 6, 11, 16, 3, 8, 13, 18, 5, 10, 15, 2, 7, 12, 17, 4, 9, 14}, 80, 22, 24
+	},
+	{ // 48 716K 5 1/4 inch quad density (single density track 0)
 		floppy_image::FF_525, floppy_image::DSQD, floppy_image::MFM,
-		2000, 18, 80, 2, 256, {}, 1, {}, 80, 22, 24
+		2000, 18, 80, 2, 256, {}, -1, {1, 6, 11, 16, 3, 8, 13, 18, 5, 10, 15, 2, 7, 12, 17, 4, 9, 14}, 80, 22, 24
 	},
-	{ // 288.75K 8 inch single density - gaps unverified
+	{ // 49 716K 5 1/4 inch quad density (single density track 0), 6800 one boot sector
+		floppy_image::FF_525, floppy_image::DSQD, floppy_image::MFM,
+		2000, 18, 80, 2, 256, {}, -1, {1, 6, 11, 16, 3, 8, 13, 18, 5, 10, 15, 2, 7, 12, 17, 4, 9, 14}, 80, 22, 24
+	},
+	{ // 50 716K 5 1/4 inch quad density (single density track 0), 6800 two boot sectors
+		floppy_image::FF_525, floppy_image::DSQD, floppy_image::MFM,
+		2000, 18, 80, 2, 256, {}, -1, {1, 6, 11, 16, 3, 8, 13, 18, 5, 10, 15, 2, 7, 12, 17, 4, 9, 14}, 80, 22, 24
+	},
+	{ // 51 720K 5 1/4 inch quad density
+		floppy_image::FF_525, floppy_image::DSQD, floppy_image::MFM,
+		2000, 18, 80, 2, 256, {}, -1, {1, 6, 11, 16, 3, 8, 13, 18, 5, 10, 15, 2, 7, 12, 17, 4, 9, 14}, 80, 22, 24
+	},
+	{ // 52 720K 5 1/4 inch quad density, 6800 one boot sector
+		floppy_image::FF_525, floppy_image::DSQD, floppy_image::MFM,
+		2000, 18, 80, 2, 256, {}, -1, {1, 6, 11, 16, 3, 8, 13, 18, 5, 10, 15, 2, 7, 12, 17, 4, 9, 14}, 80, 22, 24
+	},
+	{ // 53 720K 5 1/4 inch quad density, 6800 two boot sectors
+		floppy_image::FF_525, floppy_image::DSQD, floppy_image::MFM,
+		2000, 18, 80, 2, 256, {}, -1, {1, 6, 11, 16, 3, 8, 13, 18, 5, 10, 15, 2, 7, 12, 17, 4, 9, 14}, 80, 22, 24
+	},
+	{ // 54 288.75K 8 inch single density
 		floppy_image::FF_8, floppy_image::SSSD, floppy_image::FM,
-		2000, 15, 77, 1, 256, {}, 1, {}, 40, 12, 12
+		2000, 15, 77, 1, 256, {}, -1, {1, 3, 5, 7, 9, 11, 13, 15, 2, 4, 6, 8, 10, 12, 14}, 40, 12, 12
 	},
-	{ // 577.5K 8 inch single density - gaps unverified
+	{ // 55 288.75K 8 inch single density, 6800 one boot sector
+		floppy_image::FF_8, floppy_image::SSSD, floppy_image::FM,
+		2000, 15, 77, 1, 256, {}, -1, {1, 3, 5, 7, 9, 11, 13, 15, 2, 4, 6, 8, 10, 12, 14}, 40, 12, 12
+	},
+	{ // 56 288.75K 8 inch single density, 6800 two boot sectors
+		floppy_image::FF_8, floppy_image::SSSD, floppy_image::FM,
+		2000, 15, 77, 1, 256, {}, -1, {1, 3, 5, 7, 9, 11, 13, 15, 2, 4, 6, 8, 10, 12, 14}, 40, 12, 12
+	},
+	{ // 57 577.5K 8 inch single density
 		floppy_image::FF_8, floppy_image::DSSD, floppy_image::FM,
-		2000, 15, 77, 2, 256, {}, 1, {}, 40, 12, 12
+		2000, 15, 77, 2, 256, {}, -1, {1, 3, 5, 7, 9, 11, 13, 15, 2, 4, 6, 8, 10, 12, 14}, 40, 12, 12
 	},
-	{ // 500.5K 8 inch double density - gaps unverified
+	{ // 58 577.5K 8 inch single density, 6800 one boot sector
+		floppy_image::FF_8, floppy_image::DSSD, floppy_image::FM,
+		2000, 15, 77, 2, 256, {}, -1, {1, 3, 5, 7, 9, 11, 13, 15, 2, 4, 6, 8, 10, 12, 14}, 40, 12, 12
+	},
+	{ // 59 577.5K 8 inch single density, 6800 two boot sectors
+		floppy_image::FF_8, floppy_image::DSSD, floppy_image::FM,
+		2000, 15, 77, 2, 256, {}, -1, {1, 3, 5, 7, 9, 11, 13, 15, 2, 4, 6, 8, 10, 12, 14}, 40, 12, 12
+	},
+	{ // 60 497.75K 8 inch double density (single density track 0)
 		floppy_image::FF_8, floppy_image::SSDD, floppy_image::MFM,
-		1000, 26, 77, 1, 256, {}, 1, {}, 80, 22, 24
+		1000, 26, 77, 1, 256, {}, -1, {1, 20, 13, 6, 25, 18, 11, 4, 23, 16, 9, 2, 21, 14, 7, 26, 19, 12, 5, 24, 17, 10, 3, 22, 15, 8}, 80, 22, 24
 	},
-	{ // 1001K 8 inch double density - gaps unverified
+	{ // 61 497.75K 8 inch double density (single density track 0), 6800 one boot sector
+		floppy_image::FF_8, floppy_image::SSDD, floppy_image::MFM,
+		1000, 26, 77, 1, 256, {}, -1, {1, 20, 13, 6, 25, 18, 11, 4, 23, 16, 9, 2, 21, 14, 7, 26, 19, 12, 5, 24, 17, 10, 3, 22, 15, 8}, 80, 22, 24
+	},
+	{ // 62 497.75K 8 inch double density (single density track 0), 6800 two boot sectors
+		floppy_image::FF_8, floppy_image::SSDD, floppy_image::MFM,
+		1000, 26, 77, 1, 256, {}, -1, {1, 20, 13, 6, 25, 18, 11, 4, 23, 16, 9, 2, 21, 14, 7, 26, 19, 12, 5, 24, 17, 10, 3, 22, 15, 8}, 80, 22, 24
+	},
+	{ // 63 500.5K 8 inch double density
+		floppy_image::FF_8, floppy_image::SSDD, floppy_image::MFM,
+		1000, 26, 77, 1, 256, {}, -1, {1, 20, 13, 6, 25, 18, 11, 4, 23, 16, 9, 2, 21, 14, 7, 26, 19, 12, 5, 24, 17, 10, 3, 22, 15, 8}, 80, 22, 24
+	},
+	{ // 64 500.5K 8 inch double density, 6800 one boot sector
+		floppy_image::FF_8, floppy_image::SSDD, floppy_image::MFM,
+		1000, 26, 77, 1, 256, {}, -1, {1, 20, 13, 6, 25, 18, 11, 4, 23, 16, 9, 2, 21, 14, 7, 26, 19, 12, 5, 24, 17, 10, 3, 22, 15, 8}, 80, 22, 24
+	},
+	{ // 65 500.5K 8 inch double density, 6800 two boot sectors
+		floppy_image::FF_8, floppy_image::SSDD, floppy_image::MFM,
+		1000, 26, 77, 1, 256, {}, -1, {1, 20, 13, 6, 25, 18, 11, 4, 23, 16, 9, 2, 21, 14, 7, 26, 19, 12, 5, 24, 17, 10, 3, 22, 15, 8}, 80, 22, 24
+	},
+	{ // 66 995.5K 8 inch double density (single density track 0)
 		floppy_image::FF_8, floppy_image::DSDD, floppy_image::MFM,
-		1000, 26, 77, 2, 256, {}, 1, {}, 80, 22, 24
+		1000, 26, 77, 2, 256, {}, -1, {1, 20, 13, 6, 25, 18, 11, 4, 23, 16, 9, 2, 21, 14, 7, 26, 19, 12, 5, 24, 17, 10, 3, 22, 15, 8}, 80, 22, 24
 	},
-	{   /* 1440K 3 1/2 inch high density */
+	{ // 67 995.5K 8 inch double density (single density track 0), 6800 one boot sector
+		floppy_image::FF_8, floppy_image::DSDD, floppy_image::MFM,
+		1000, 26, 77, 2, 256, {}, -1, {1, 20, 13, 6, 25, 18, 11, 4, 23, 16, 9, 2, 21, 14, 7, 26, 19, 12, 5, 24, 17, 10, 3, 22, 15, 8}, 80, 22, 24
+	},
+	{ // 68 995.5K 8 inch double density (single density track 0), 6800 two boot sectors
+		floppy_image::FF_8, floppy_image::DSDD, floppy_image::MFM,
+		1000, 26, 77, 2, 256, {}, -1, {1, 20, 13, 6, 25, 18, 11, 4, 23, 16, 9, 2, 21, 14, 7, 26, 19, 12, 5, 24, 17, 10, 3, 22, 15, 8}, 80, 22, 24
+	},
+	{ // 69 1001K 8 inch double density
+		floppy_image::FF_8, floppy_image::DSDD, floppy_image::MFM,
+		1000, 26, 77, 2, 256, {}, -1, {1, 20, 13, 6, 25, 18, 11, 4, 23, 16, 9, 2, 21, 14, 7, 26, 19, 12, 5, 24, 17, 10, 3, 22, 15, 8}, 80, 22, 24
+	},
+	{ // 70 1001K 8 inch double density, 6800 one boot sector
+		floppy_image::FF_8, floppy_image::DSDD, floppy_image::MFM,
+		1000, 26, 77, 2, 256, {}, -1, {1, 20, 13, 6, 25, 18, 11, 4, 23, 16, 9, 2, 21, 14, 7, 26, 19, 12, 5, 24, 17, 10, 3, 22, 15, 8}, 80, 22, 24
+	},
+	{ // 71 1001K 8 inch double density, 6800 two boot sectors
+		floppy_image::FF_8, floppy_image::DSDD, floppy_image::MFM,
+		1000, 26, 77, 2, 256, {}, -1, {1, 20, 13, 6, 25, 18, 11, 4, 23, 16, 9, 2, 21, 14, 7, 26, 19, 12, 5, 24, 17, 10, 3, 22, 15, 8}, 80, 22, 24
+	},
+	{ // 72 1440K 3 1/2 inch high density (single density track 0)
 		floppy_image::FF_35,  floppy_image::DSHD, floppy_image::MFM,
-		1000, 36, 80, 2, 256, {}, 1, {}, 80, 22, 24
+		1000, 36, 80, 2, 256, {}, -1, {1, 26, 15, 4, 29, 18, 7, 32, 21, 10, 35, 24, 13, 2, 27, 16, 5, 30, 19, 8, 33, 22, 11, 36, 25, 14, 3, 28, 17, 6, 31, 20, 9, 34, 23, 12}, 80, 22, 24
+	},
+	{ // 73 1440K 3 1/2 inch high density (single density track 0), 6800 one boot sector
+		floppy_image::FF_35,  floppy_image::DSHD, floppy_image::MFM,
+		1000, 36, 80, 2, 256, {}, -1, {1, 26, 15, 4, 29, 18, 7, 32, 21, 10, 35, 24, 13, 2, 27, 16, 5, 30, 19, 8, 33, 22, 11, 36, 25, 14, 3, 28, 17, 6, 31, 20, 9, 34, 23, 12}, 80, 22, 24
+	},
+	{ // 74 1440K 3 1/2 inch high density (single density track 0), 6800 two boot sectors
+		floppy_image::FF_35,  floppy_image::DSHD, floppy_image::MFM,
+		1000, 36, 80, 2, 256, {}, -1, {1, 26, 15, 4, 29, 18, 7, 32, 21, 10, 35, 24, 13, 2, 27, 16, 5, 30, 19, 8, 33, 22, 11, 36, 25, 14, 3, 28, 17, 6, 31, 20, 9, 34, 23, 12}, 80, 22, 24
+	},
+	{ // 75 1440K 3 1/2 inch high density.
+		floppy_image::FF_35,  floppy_image::DSHD, floppy_image::MFM,
+		1000, 36, 80, 2, 256, {}, -1, {1, 26, 15, 4, 29, 18, 7, 32, 21, 10, 35, 24, 13, 2, 27, 16, 5, 30, 19, 8, 33, 22, 11, 36, 25, 14, 3, 28, 17, 6, 31, 20, 9, 34, 23, 12}, 80, 22, 24
+	},
+	{ // 76 1440K 3 1/2 inch high density, 6800 one boot sector
+		floppy_image::FF_35,  floppy_image::DSHD, floppy_image::MFM,
+		1000, 36, 80, 2, 256, {}, -1, {1, 26, 15, 4, 29, 18, 7, 32, 21, 10, 35, 24, 13, 2, 27, 16, 5, 30, 19, 8, 33, 22, 11, 36, 25, 14, 3, 28, 17, 6, 31, 20, 9, 34, 23, 12}, 80, 22, 24
+	},
+	{ // 77 1440K 3 1/2 inch high density, 6800 two boot sectors
+		floppy_image::FF_35,  floppy_image::DSHD, floppy_image::MFM,
+		1000, 36, 80, 2, 256, {}, -1, {1, 26, 15, 4, 29, 18, 7, 32, 21, 10, 35, 24, 13, 2, 27, 16, 5, 30, 19, 8, 33, 22, 11, 36, 25, 14, 3, 28, 17, 6, 31, 20, 9, 34, 23, 12}, 80, 22, 24
+	},
+	{}
+};
+
+const flex_format::format flex_format::formats_head1[] = {
+	{ // 0 87.5K 5 1/4 inch single density
+	},
+	{ // 1 87.5K 5 1/4 inch single density, 6800 one boot sector
+	},
+	{ // 2 87.5K 5 1/4 inch single density, 6800 two boot sectors
+	},
+	{ // 3 100K 5 1/4 inch single density
+	},
+	{ // 4 100K 5 1/4 inch single density, 6800 one boot sector
+	},
+	{ // 5 100K 5 1/4 inch single density, 6800 two boot sectors
+	},
+	{ // 6 200K 5 1/4 inch single density
+	},
+	{ // 7 200K 5 1/4 inch single density, 6800 one boot sector
+	},
+	{ // 8 200K 5 1/4 inch single density, 6800 two boot sectors
+	},
+	{ // 9 175K 5 1/4 inch single density
+		floppy_image::FF_525, floppy_image::DSSD, floppy_image::FM,
+		4000, 10, 35, 2, 256, {}, -1, {11, 14, 17, 20, 13, 16, 19, 12, 15, 18}, 40, 16, 11
+	},
+	{ // 10 175K 5 1/4 inch single density, 6800 one boot sector
+		floppy_image::FF_525, floppy_image::DSSD, floppy_image::FM,
+		4000, 10, 35, 2, 256, {}, -1, {11, 14, 17, 20, 13, 16, 19, 12, 15, 18}, 40, 16, 11
+	},
+	{ // 11 175K 5 1/4 inch single density, 6800 two boot sectors
+		floppy_image::FF_525, floppy_image::DSSD, floppy_image::FM,
+		4000, 10, 35, 2, 256, {}, -1, {11, 14, 17, 20, 13, 16, 19, 12, 15, 18}, 40, 16, 11
+	},
+	{ // 12 200K 5 1/4 inch single density
+		floppy_image::FF_525, floppy_image::DSSD, floppy_image::FM,
+		4000, 10, 40, 2, 256, {}, -1, {11, 14, 17, 20, 13, 16, 19, 12, 15, 18}, 40, 16, 11
+	},
+	{ // 13 200K 5 1/4 inch single density, 6800 one boot sector
+		floppy_image::FF_525, floppy_image::DSSD, floppy_image::FM,
+		4000, 10, 40, 2, 256, {}, -1, {11, 14, 17, 20, 13, 16, 19, 12, 15, 18}, 40, 16, 11
+	},
+	{ // 14 200K 5 1/4 inch single density, 6800 two boot sectors
+		floppy_image::FF_525, floppy_image::DSSD, floppy_image::FM,
+		4000, 10, 40, 2, 256, {}, -1, {11, 14, 17, 20, 13, 16, 19, 12, 15, 18}, 40, 16, 11
+	},
+	{ // 15 400K 5 1/4 inch single density
+		floppy_image::FF_525, floppy_image::DSSD, floppy_image::FM,
+		4000, 10, 80, 2, 256, {}, -1, {11, 14, 17, 20, 13, 16, 19, 12, 15, 18}, 40, 16, 11
+	},
+	{ // 16 400K 5 1/4 inch single density, 6800 one boot sector
+		floppy_image::FF_525, floppy_image::DSSD, floppy_image::FM,
+		4000, 10, 80, 2, 256, {}, -1, {11, 14, 17, 20, 13, 16, 19, 12, 15, 18}, 40, 16, 11
+	},
+	{ // 17 400K 5 1/4 inch single density, 6800 two boot sectors
+		floppy_image::FF_525, floppy_image::DSSD, floppy_image::FM,
+		4000, 10, 80, 2, 256, {}, -1, {11, 14, 17, 20, 13, 16, 19, 12, 15, 18}, 40, 16, 11
+	},
+	{ // 18 155.5K 5 1/4 inch double density (single density track 0)
+	},
+	{ // 19 155.5K 5 1/4 inch double density (single density track 0), 6800 one boot sector
+	},
+	{ // 20 155.5K 5 1/4 inch double density (single density track 0), 6800 two boot sectors
+	},
+	{ // 21 157.5K 5 1/4 inch double density
+	},
+	{ // 22 157.5K 5 1/4 inch double density, 6800 one boot sector
+	},
+	{ // 23 157.5K 5 1/4 inch double density, 6800 two boot sectors
+	},
+	{ // 24 311K 5 1/4 inch double density (single density track 0)
+		floppy_image::FF_525, floppy_image::DSDD, floppy_image::MFM,
+		2000, 18, 35, 2, 256, {}, -1, {19, 24, 29, 34, 21, 26, 31, 36, 23, 28, 33, 20, 25, 30, 35, 22, 27, 32}, 80, 22, 24
+	},
+	{ // 25 311K 5 1/4 inch double density (single density track 0), 6800 one boot sector
+		floppy_image::FF_525, floppy_image::DSDD, floppy_image::MFM,
+		2000, 18, 35, 2, 256, {}, -1, {19, 24, 29, 34, 21, 26, 31, 36, 23, 28, 33, 20, 25, 30, 35, 22, 27, 32}, 80, 22, 24
+	},
+	{ // 26 311K 5 1/4 inch double density (single density track 0), 6800 two boot sectors
+		floppy_image::FF_525, floppy_image::DSDD, floppy_image::MFM,
+		2000, 18, 35, 2, 256, {}, -1, {19, 24, 29, 34, 21, 26, 31, 36, 23, 28, 33, 20, 25, 30, 35, 22, 27, 32}, 80, 22, 24
+	},
+	{ // 27 315K 5 1/4 inch double density
+		floppy_image::FF_525, floppy_image::DSDD, floppy_image::MFM,
+		2000, 18, 35, 2, 256, {}, -1, {19, 24, 29, 34, 21, 26, 31, 36, 23, 28, 33, 20, 25, 30, 35, 22, 27, 32}, 80, 22, 24
+	},
+	{ // 28 315K 5 1/4 inch double density, 6800 one boot sector
+		floppy_image::FF_525, floppy_image::DSDD, floppy_image::MFM,
+		2000, 18, 35, 2, 256, {}, -1, {19, 24, 29, 34, 21, 26, 31, 36, 23, 28, 33, 20, 25, 30, 35, 22, 27, 32}, 80, 22, 24
+	},
+	{ // 29 315K 5 1/4 inch double density, 6800 two boot sectors
+		floppy_image::FF_525, floppy_image::DSDD, floppy_image::MFM,
+		2000, 18, 35, 2, 256, {}, -1, {19, 24, 29, 34, 21, 26, 31, 36, 23, 28, 33, 20, 25, 30, 35, 22, 27, 32}, 80, 22, 24
+	},
+	{ // 30 178K 5 1/4 inch double density (single density track 0)
+	},
+	{ // 31 178K 5 1/4 inch double density (single density track 0), 6800 one boot sector
+	},
+	{ // 32 178K 5 1/4 inch double density (single density track 0), 6800 two boot sectors
+	},
+	{ // 33 180K 5 1/4 inch double density
+	},
+	{ // 34 180K 5 1/4 inch double density, 6800 one boot sector
+	},
+	{ // 35 180K 5 1/4 inch double density, 6800 two boot sectors
+	},
+	{ // 36 356K 5 1/4 inch double density (single density track 0)
+		floppy_image::FF_525, floppy_image::DSDD, floppy_image::MFM,
+		2000, 18, 40, 2, 256, {}, -1, {19, 24, 29, 34, 21, 26, 31, 36, 23, 28, 33, 20, 25, 30, 35, 22, 27, 32}, 80, 22, 24
+	},
+	{ // 37 356K 5 1/4 inch double density (single density track 0), 6800 one boot sector
+		floppy_image::FF_525, floppy_image::DSDD, floppy_image::MFM,
+		2000, 18, 40, 2, 256, {}, -1, {19, 24, 29, 34, 21, 26, 31, 36, 23, 28, 33, 20, 25, 30, 35, 22, 27, 32}, 80, 22, 24
+	},
+	{ // 38 356K 5 1/4 inch double density (single density track 0), 6800 two boot sectors
+		floppy_image::FF_525, floppy_image::DSDD, floppy_image::MFM,
+		2000, 18, 40, 2, 256, {}, -1, {19, 24, 29, 34, 21, 26, 31, 36, 23, 28, 33, 20, 25, 30, 35, 22, 27, 32}, 80, 22, 24
+	},
+	{ // 39 360K 5 1/4 inch double density
+		floppy_image::FF_525, floppy_image::DSDD, floppy_image::MFM,
+		2000, 18, 40, 2, 256, {}, -1, {19, 24, 29, 34, 21, 26, 31, 36, 23, 28, 33, 20, 25, 30, 35, 22, 27, 32}, 80, 22, 24
+	},
+	{ // 40 360K 5 1/4 inch double density, 6800 one boot sector
+		floppy_image::FF_525, floppy_image::DSDD, floppy_image::MFM,
+		2000, 18, 40, 2, 256, {}, -1, {19, 24, 29, 34, 21, 26, 31, 36, 23, 28, 33, 20, 25, 30, 35, 22, 27, 32}, 80, 22, 24
+	},
+	{ // 41 360K 5 1/4 inch double density, 6800 two boot sectors
+		floppy_image::FF_525, floppy_image::DSDD, floppy_image::MFM,
+		2000, 18, 40, 2, 256, {}, -1, {19, 24, 29, 34, 21, 26, 31, 36, 23, 28, 33, 20, 25, 30, 35, 22, 27, 32}, 80, 22, 24
+	},
+	{ // 42 358K 5 1/4 inch quad density (single density track 0)
+	},
+	{ // 43 358K 5 1/4 inch quad density (single density track 0), 6800 one boot sector
+	},
+	{ // 44 358K 5 1/4 inch quad density (single density track 0), 6800 two boot sectors
+	},
+	{ // 45 360K 5 1/4 inch quad density
+	},
+	{ // 46 360K 5 1/4 inch quad density, 6800 one boot sector
+	},
+	{ // 47 360K 5 1/4 inch quad density, 6800 two boot sectors
+	},
+	{ // 48 716K 5 1/4 inch quad density (single density track 0)
+		floppy_image::FF_525, floppy_image::DSQD, floppy_image::MFM,
+		2000, 18, 80, 2, 256, {}, -1, {19, 24, 29, 34, 21, 26, 31, 36, 23, 28, 33, 20, 25, 30, 35, 22, 27, 32}, 80, 22, 24
+	},
+	{ // 49 716K 5 1/4 inch quad density (single density track 0), 6800 one boot sector
+		floppy_image::FF_525, floppy_image::DSQD, floppy_image::MFM,
+		2000, 18, 80, 2, 256, {}, -1, {19, 24, 29, 34, 21, 26, 31, 36, 23, 28, 33, 20, 25, 30, 35, 22, 27, 32}, 80, 22, 24
+	},
+	{ // 50 716K 5 1/4 inch quad density (single density track 0), 6800 two boot sectors
+		floppy_image::FF_525, floppy_image::DSQD, floppy_image::MFM,
+		2000, 18, 80, 2, 256, {}, -1, {19, 24, 29, 34, 21, 26, 31, 36, 23, 28, 33, 20, 25, 30, 35, 22, 27, 32}, 80, 22, 24
+	},
+	{ // 51 720K 5 1/4 inch quad density
+		floppy_image::FF_525, floppy_image::DSQD, floppy_image::MFM,
+		2000, 18, 80, 2, 256, {}, -1, {19, 24, 29, 34, 21, 26, 31, 36, 23, 28, 33, 20, 25, 30, 35, 22, 27, 32}, 80, 22, 24
+	},
+	{ // 52 720K 5 1/4 inch quad density, 6800 one boot sector
+		floppy_image::FF_525, floppy_image::DSQD, floppy_image::MFM,
+		2000, 18, 80, 2, 256, {}, -1, {19, 24, 29, 34, 21, 26, 31, 36, 23, 28, 33, 20, 25, 30, 35, 22, 27, 32}, 80, 22, 24
+	},
+	{ // 53 720K 5 1/4 inch quad density, 6800 two boot sectors
+		floppy_image::FF_525, floppy_image::DSQD, floppy_image::MFM,
+		2000, 18, 80, 2, 256, {}, -1, {19, 24, 29, 34, 21, 26, 31, 36, 23, 28, 33, 20, 25, 30, 35, 22, 27, 32}, 80, 22, 24
+	},
+	{ // 54 288.75K 8 inch single density
+	},
+	{ // 55 288.75K 8 inch single density, 6800 one boot sector
+	},
+	{ // 56 288.75K 8 inch single density, 6800 two boot sectors
+	},
+	{ // 57 577.5K 8 inch single density
+		floppy_image::FF_8, floppy_image::DSSD, floppy_image::FM,
+		2000, 15, 77, 2, 256, {}, -1, {16, 18, 20, 22, 24, 26, 28, 30, 17, 19, 21, 23, 25, 27, 29}, 40, 12, 12
+	},
+	{ // 58 577.5K 8 inch single density, 6800 one boot sector
+		floppy_image::FF_8, floppy_image::DSSD, floppy_image::FM,
+		2000, 15, 77, 2, 256, {}, -1, {16, 18, 20, 22, 24, 26, 28, 30, 17, 19, 21, 23, 25, 27, 29}, 40, 12, 12
+	},
+	{ // 59 577.5K 8 inch single density, 6800 two boot sectors
+		floppy_image::FF_8, floppy_image::DSSD, floppy_image::FM,
+		2000, 15, 77, 2, 256, {}, -1, {16, 18, 20, 22, 24, 26, 28, 30, 17, 19, 21, 23, 25, 27, 29}, 40, 12, 12
+	},
+	{ // 60 497.75K 8 inch single density (single density track 0)
+	},
+	{ // 61 497.75K 8 inch single density (single density track 0), 6800 one boot sector
+	},
+	{ // 62 497.75K 8 inch single density (single density track 0), 6800 two boot sectors
+	},
+	{ // 63 500.5K 8 inch double density
+	},
+	{ // 64 500.5K 8 inch double density, 6800 one boot sector
+	},
+	{ // 65 500.5K 8 inch double density, 6800 two boot sectors
+	},
+	{ // 66 995.5K 8 inch double density (single density track 0)
+		floppy_image::FF_8, floppy_image::DSDD, floppy_image::MFM,
+		1000, 26, 77, 2, 256, {}, -1, {27, 46, 39, 32, 51, 44, 37, 30, 49, 42, 35, 28, 47, 40, 33, 52, 45, 38, 31, 50, 43, 36, 29, 48, 41, 34}, 80, 22, 24
+	},
+	{ // 67 995.5K 8 inch double density (single density track 0), 6800 one boot sector
+		floppy_image::FF_8, floppy_image::DSDD, floppy_image::MFM,
+		1000, 26, 77, 2, 256, {}, -1, {27, 46, 39, 32, 51, 44, 37, 30, 49, 42, 35, 28, 47, 40, 33, 52, 45, 38, 31, 50, 43, 36, 29, 48, 41, 34}, 80, 22, 24
+	},
+	{ // 68 995.5K 8 inch double density (single density track 0), 6800 two boot sectors
+		floppy_image::FF_8, floppy_image::DSDD, floppy_image::MFM,
+		1000, 26, 77, 2, 256, {}, -1, {27, 46, 39, 32, 51, 44, 37, 30, 49, 42, 35, 28, 47, 40, 33, 52, 45, 38, 31, 50, 43, 36, 29, 48, 41, 34}, 80, 22, 24
+	},
+	{ // 69 1001K 8 inch double density
+		floppy_image::FF_8, floppy_image::DSDD, floppy_image::MFM,
+		1000, 26, 77, 2, 256, {}, -1, {27, 46, 39, 32, 51, 44, 37, 30, 49, 42, 35, 28, 47, 40, 33, 52, 45, 38, 31, 50, 43, 36, 29, 48, 41, 34}, 80, 22, 24
+	},
+	{ // 70 1001K 8 inch double density, 6800 one boot sector
+		floppy_image::FF_8, floppy_image::DSDD, floppy_image::MFM,
+		1000, 26, 77, 2, 256, {}, -1, {27, 46, 39, 32, 51, 44, 37, 30, 49, 42, 35, 28, 47, 40, 33, 52, 45, 38, 31, 50, 43, 36, 29, 48, 41, 34}, 80, 22, 24
+	},
+	{ // 71 1001K 8 inch double density, 6800 two boot sectors
+		floppy_image::FF_8, floppy_image::DSDD, floppy_image::MFM,
+		1000, 26, 77, 2, 256, {}, -1, {27, 46, 39, 32, 51, 44, 37, 30, 49, 42, 35, 28, 47, 40, 33, 52, 45, 38, 31, 50, 43, 36, 29, 48, 41, 34}, 80, 22, 24
+	},
+	{ // 72 1440K 3 1/2 inch high density (single density track 0)
+		floppy_image::FF_35,  floppy_image::DSHD, floppy_image::MFM,
+		1000, 36, 80, 2, 256, {}, -1, {37, 62, 51, 40, 65, 54, 43, 68, 57, 46, 71, 60, 49, 38, 63, 52, 41, 66, 55, 44, 69, 58, 47, 72, 61, 50, 39, 64, 53, 42, 67, 56, 45, 70, 59, 48}, 80, 22, 24
+	},
+	{ // 73 1440K 3 1/2 inch high density (single density track 0), 6800 one boot sector
+		floppy_image::FF_35,  floppy_image::DSHD, floppy_image::MFM,
+		1000, 36, 80, 2, 256, {}, -1, {37, 62, 51, 40, 65, 54, 43, 68, 57, 46, 71, 60, 49, 38, 63, 52, 41, 66, 55, 44, 69, 58, 47, 72, 61, 50, 39, 64, 53, 42, 67, 56, 45, 70, 59, 48}, 80, 22, 24
+	},
+	{ // 74 1440K 3 1/2 inch high density (single density track 0), 6800 two boot sectors
+		floppy_image::FF_35,  floppy_image::DSHD, floppy_image::MFM,
+		1000, 36, 80, 2, 256, {}, -1, {37, 62, 51, 40, 65, 54, 43, 68, 57, 46, 71, 60, 49, 38, 63, 52, 41, 66, 55, 44, 69, 58, 47, 72, 61, 50, 39, 64, 53, 42, 67, 56, 45, 70, 59, 48}, 80, 22, 24
+	},
+	{ // 75 1440K 3 1/2 inch high density
+		floppy_image::FF_35,  floppy_image::DSHD, floppy_image::MFM,
+		1000, 36, 80, 2, 256, {}, -1, {37, 62, 51, 40, 65, 54, 43, 68, 57, 46, 71, 60, 49, 38, 63, 52, 41, 66, 55, 44, 69, 58, 47, 72, 61, 50, 39, 64, 53, 42, 67, 56, 45, 70, 59, 48}, 80, 22, 24
+	},
+	{ // 76 1440K 3 1/2 inch high density, 6800 one boot sector
+		floppy_image::FF_35,  floppy_image::DSHD, floppy_image::MFM,
+		1000, 36, 80, 2, 256, {}, -1, {37, 62, 51, 40, 65, 54, 43, 68, 57, 46, 71, 60, 49, 38, 63, 52, 41, 66, 55, 44, 69, 58, 47, 72, 61, 50, 39, 64, 53, 42, 67, 56, 45, 70, 59, 48}, 80, 22, 24
+	},
+	{ // 77 1440K 3 1/2 inch high density, 6800 two boot sectors
+		floppy_image::FF_35,  floppy_image::DSHD, floppy_image::MFM,
+		1000, 36, 80, 2, 256, {}, -1, {37, 62, 51, 40, 65, 54, 43, 68, 57, 46, 71, 60, 49, 38, 63, 52, 41, 66, 55, 44, 69, 58, 47, 72, 61, 50, 39, 64, 53, 42, 67, 56, 45, 70, 59, 48}, 80, 22, 24
+	},
+	{}
+};
+
+const flex_format::format flex_format::formats_track0[] = {
+	{ // 0 87.5K 5 1/4 inch single density
+	},
+	{ // 1 87.5K 5 1/4 inch single density, 6800 one boot sector
+		floppy_image::FF_525, floppy_image::SSSD, floppy_image::FM,
+		4000, 10, 35, 1, 256, {}, -1, {0, 4, 7, 10, 3, 6, 9, 2, 5, 8}, 40, 16, 11
+	},
+	{ // 2 87.5K 5 1/4 inch single density, 6800 two boot sectors
+		floppy_image::FF_525, floppy_image::SSSD, floppy_image::FM,
+		4000, 10, 35, 1, 256, {}, -1, {0, 4, 7, 10, 3, 6, 9, 1, 5, 8}, 40, 16, 11
+	},
+	{ // 3 100K 5 1/4 inch single density
+	},
+	{ // 4 100K 5 1/4 inch single density, 6800 one boot sector
+		floppy_image::FF_525, floppy_image::SSSD, floppy_image::FM,
+		4000, 10, 40, 1, 256, {}, -1, {0, 4, 7, 10, 3, 6, 9, 2, 5, 8}, 40, 16, 11
+	},
+	{ // 5 100K 5 1/4 inch single density, 6800 two boot sectors
+		floppy_image::FF_525, floppy_image::SSSD, floppy_image::FM,
+		4000, 10, 40, 1, 256, {}, -1, {0, 4, 7, 10, 3, 6, 9, 1, 5, 8}, 40, 16, 11
+	},
+	{ // 6 200K 5 1/4 inch single density
+	},
+	{ // 7 200K 5 1/4 inch single density, 6800 one boot sector
+		floppy_image::FF_525, floppy_image::SSSD, floppy_image::FM,
+		4000, 10, 80, 1, 256, {}, -1, {0, 4, 7, 10, 3, 6, 9, 2, 5, 8}, 40, 16, 11
+	},
+	{ // 8 200K 5 1/4 inch single density, 6800 two boot sectors
+		floppy_image::FF_525, floppy_image::SSSD, floppy_image::FM,
+		4000, 10, 80, 1, 256, {}, -1, {0, 4, 7, 10, 3, 6, 9, 1, 5, 8}, 40, 16, 11
+	},
+	{ // 9 175K 5 1/4 inch single density
+	},
+	{ // 10 175K 5 1/4 inch single density, 6800 one boot sector
+		floppy_image::FF_525, floppy_image::DSSD, floppy_image::FM,
+		4000, 10, 35, 2, 256, {}, -1, {0, 4, 7, 10, 3, 6, 9, 2, 5, 8}, 40, 16, 11
+	},
+	{ // 11 175K 5 1/4 inch single density, 6800 two boot sectors
+		floppy_image::FF_525, floppy_image::DSSD, floppy_image::FM,
+		4000, 10, 35, 2, 256, {}, -1, {0, 4, 7, 10, 3, 6, 9, 1, 5, 8}, 40, 16, 11
+	},
+	{ // 12 200K 5 1/4 inch single density
+	},
+	{ // 13 200K 5 1/4 inch single densityo, 6800 one boot sector
+		floppy_image::FF_525, floppy_image::DSSD, floppy_image::FM,
+		4000, 10, 40, 2, 256, {}, -1, {0, 4, 7, 10, 3, 6, 9, 2, 5, 8}, 40, 16, 11
+	},
+	{ // 14 200K 5 1/4 inch single density, 6800 two boot sectors
+		floppy_image::FF_525, floppy_image::DSSD, floppy_image::FM,
+		4000, 10, 40, 2, 256, {}, -1, {0, 4, 7, 10, 3, 6, 9, 1, 5, 8}, 40, 16, 11
+	},
+	{ // 15 400K 5 1/4 inch single density
+	},
+	{ // 16 400K 5 1/4 inch single density, 6800 one boot sector
+		floppy_image::FF_525, floppy_image::DSSD, floppy_image::FM,
+		4000, 10, 80, 2, 256, {}, -1, {0, 4, 7, 10, 3, 6, 9, 2, 5, 8}, 40, 16, 11
+	},
+	{ // 17 400K 5 1/4 inch single density, 6800 two boot sectors
+		floppy_image::FF_525, floppy_image::DSSD, floppy_image::FM,
+		4000, 10, 80, 2, 256, {}, -1, {0, 4, 7, 10, 3, 6, 9, 1, 5, 8}, 40, 16, 11
+	},
+	{ // 18 155.5K 5 1/4 inch double density (single density track 0)
+		floppy_image::FF_525, floppy_image::SSSD, floppy_image::FM,
+		4000, 10, 35, 1, 256, {}, -1, {1, 4, 7, 10, 3, 6, 9, 2, 5, 8}, 40, 16, 11
+	},
+	{ // 19 155.5K 5 1/4 inch double density (single density track 0), 6800 one boot sector
+		floppy_image::FF_525, floppy_image::SSSD, floppy_image::FM,
+		4000, 10, 35, 1, 256, {}, -1, {0, 4, 7, 10, 3, 6, 9, 2, 5, 8}, 40, 16, 11
+	},
+	{ // 20 155.5K 5 1/4 inch double density (single density track 0), 6800 two boot sectors
+		floppy_image::FF_525, floppy_image::SSSD, floppy_image::FM,
+		4000, 10, 35, 1, 256, {}, -1, {0, 4, 7, 10, 3, 6, 9, 1, 5, 8}, 40, 16, 11
+	},
+	{ // 21 157.5K 5 1/4 inch double density
+	},
+	{ // 22 157.5K 5 1/4 inch double density, 6800 one boot sector
+		floppy_image::FF_525, floppy_image::SSDD, floppy_image::MFM,
+		2000, 18, 35, 1, 256, {}, -1, {0, 6, 11, 16, 3, 8, 13, 18, 5, 10, 15, 2, 7, 12, 17, 4, 9, 14}, 80, 22, 24
+	},
+	{ // 23 157.5K 5 1/4 inch double density, 6800 two boot sectors
+		floppy_image::FF_525, floppy_image::SSDD, floppy_image::MFM,
+		2000, 18, 35, 1, 256, {}, -1, {0, 6, 11, 16, 3, 8, 13, 18, 5, 10, 15, 1, 7, 12, 17, 4, 9, 14}, 80, 22, 24
+	},
+	{ // 24 311K 5 1/4 inch double density (single density track 0)
+		floppy_image::FF_525, floppy_image::DSSD, floppy_image::FM,
+		4000, 10, 35, 2, 256, {}, -1, {1, 4, 7, 10, 3, 6, 9, 2, 5, 8}, 40, 16, 11
+	},
+	{ // 25 311K 5 1/4 inch double density (single density track 0), 6800 one boot sector
+		floppy_image::FF_525, floppy_image::DSSD, floppy_image::FM,
+		4000, 10, 35, 2, 256, {}, -1, {0, 4, 7, 10, 3, 6, 9, 2, 5, 8}, 40, 16, 11
+	},
+	{ // 26 311K 5 1/4 inch double density (single density track 0), 6800 two boot sectors
+		floppy_image::FF_525, floppy_image::DSSD, floppy_image::FM,
+		4000, 10, 35, 2, 256, {}, -1, {0, 4, 7, 10, 3, 6, 9, 1, 5, 8}, 40, 16, 11
+	},
+	{ // 27 315K 5 1/4 inch double density
+	},
+	{ // 28 315K 5 1/4 inch double density, 6800 one boot sector
+		floppy_image::FF_525, floppy_image::DSDD, floppy_image::MFM,
+		2000, 18, 35, 2, 256, {}, -1, {0, 6, 11, 16, 3, 8, 13, 18, 5, 10, 15, 2, 7, 12, 17, 4, 9, 14}, 80, 22, 24
+	},
+	{ // 29 315K 5 1/4 inch double density, 6800 two boot sectors
+		floppy_image::FF_525, floppy_image::DSDD, floppy_image::MFM,
+		2000, 18, 35, 2, 256, {}, -1, {0, 6, 11, 16, 3, 8, 13, 18, 5, 10, 15, 1, 7, 12, 17, 4, 9, 14}, 80, 22, 24
+	},
+	{ // 30 178K 5 1/4 inch double density (single density track 0)
+		floppy_image::FF_525, floppy_image::SSSD, floppy_image::FM,
+		4000, 10, 40, 1, 256, {}, -1, {1, 4, 7, 10, 3, 6, 9, 2, 5, 8}, 40, 16, 11
+	},
+	{ // 31 178K 5 1/4 inch double density (single density track 0), 6800 one boot sector
+		floppy_image::FF_525, floppy_image::SSSD, floppy_image::FM,
+		4000, 10, 40, 1, 256, {}, -1, {0, 4, 7, 10, 3, 6, 9, 2, 5, 8}, 40, 16, 11
+	},
+	{ // 32 178K 5 1/4 inch double density (single density track 0), 6800 two boot sectors
+		floppy_image::FF_525, floppy_image::SSSD, floppy_image::FM,
+		4000, 10, 40, 1, 256, {}, -1, {0, 4, 7, 10, 3, 6, 9, 1, 5, 8}, 40, 16, 11
+	},
+	{ // 33 180K 5 1/4 inch double density
+	},
+	{ // 34 180K 5 1/4 inch double density, 6800 one boot sector
+		floppy_image::FF_525, floppy_image::SSDD, floppy_image::MFM,
+		2000, 18, 40, 1, 256, {}, -1, {0, 6, 11, 16, 3, 8, 13, 18, 5, 10, 15, 2, 7, 12, 17, 4, 9, 14}, 80, 22, 24
+	},
+	{ // 35 180K 5 1/4 inch double density, 6800 two boot sectors
+		floppy_image::FF_525, floppy_image::SSDD, floppy_image::MFM,
+		2000, 18, 40, 1, 256, {}, -1, {0, 6, 11, 16, 3, 8, 13, 18, 5, 10, 15, 1, 7, 12, 17, 4, 9, 14}, 80, 22, 24
+	},
+	{ // 36 356K 5 1/4 inch double density (single density track 0)
+		floppy_image::FF_525, floppy_image::DSSD, floppy_image::FM,
+		4000, 10, 40, 2, 256, {}, -1, {1, 4, 7, 10, 3, 6, 9, 2, 5, 8}, 40, 16, 11
+	},
+	{ // 37 356K 5 1/4 inch double density (single density track 0), 6800 one boot sector
+		floppy_image::FF_525, floppy_image::DSSD, floppy_image::FM,
+		4000, 10, 40, 2, 256, {}, -1, {0, 4, 7, 10, 3, 6, 9, 2, 5, 8}, 40, 16, 11
+	},
+	{ // 38 356K 5 1/4 inch double density (single density track 0), 6800 two boot sectors
+		floppy_image::FF_525, floppy_image::DSSD, floppy_image::FM,
+		4000, 10, 40, 2, 256, {}, -1, {0, 4, 7, 10, 3, 6, 9, 1, 5, 8}, 40, 16, 11
+	},
+	{ // 39 360K 5 1/4 inch double density
+	},
+	{ // 40 360K 5 1/4 inch double density, 6800 one boot sector
+		floppy_image::FF_525, floppy_image::DSDD, floppy_image::MFM,
+		2000, 18, 40, 2, 256, {}, -1, {0, 6, 11, 16, 3, 8, 13, 18, 5, 10, 15, 2, 7, 12, 17, 4, 9, 14}, 80, 22, 24
+	},
+	{ // 41 360K 5 1/4 inch double density, 6800 two boot sectors
+		floppy_image::FF_525, floppy_image::DSDD, floppy_image::MFM,
+		2000, 18, 40, 2, 256, {}, -1, {0, 6, 11, 16, 3, 8, 13, 18, 5, 10, 15, 1, 7, 12, 17, 4, 9, 14}, 80, 22, 24
+	},
+	{ // 42 358K 5 1/4 inch quad density (single density track 0)
+		floppy_image::FF_525, floppy_image::SSSD, floppy_image::FM,
+		4000, 10, 80, 1, 256, {}, -1, {1, 4, 7, 10, 3, 6, 9, 2, 5, 8}, 40, 16, 11
+	},
+	{ // 43 358K 5 1/4 inch quad density (single density track 0), 6800 one boot sector
+		floppy_image::FF_525, floppy_image::SSSD, floppy_image::FM,
+		4000, 10, 80, 1, 256, {}, -1, {0, 4, 7, 10, 3, 6, 9, 2, 5, 8}, 40, 16, 11
+	},
+	{ // 44 358K 5 1/4 inch quad density (single density track 0), 6800 two boot sectors
+		floppy_image::FF_525, floppy_image::SSSD, floppy_image::FM,
+		4000, 10, 80, 1, 256, {}, -1, {0, 4, 7, 10, 3, 6, 9, 1, 5, 8}, 40, 16, 11
+	},
+	{ // 45 360K 5 1/4 inch quad density
+	},
+	{ // 46 360K 5 1/4 inch quad density, 6800 one boot sector
+		floppy_image::FF_525, floppy_image::SSQD, floppy_image::MFM,
+		2000, 18, 80, 1, 256, {}, -1, {0, 6, 11, 16, 3, 8, 13, 18, 5, 10, 15, 2, 7, 12, 17, 4, 9, 14}, 80, 22, 24
+	},
+	{ // 47 360K 5 1/4 inch quad density, 6800 two boot sectors
+		floppy_image::FF_525, floppy_image::SSQD, floppy_image::MFM,
+		2000, 18, 80, 1, 256, {}, -1, {0, 6, 11, 16, 3, 8, 13, 18, 5, 10, 15, 1, 7, 12, 17, 4, 9, 14}, 80, 22, 24
+	},
+	{ // 48 716K 5 1/4 inch quad density (single density track 0)
+		floppy_image::FF_525, floppy_image::DSSD, floppy_image::FM,
+		4000, 10, 80, 2, 256, {}, -1, {1, 4, 7, 10, 3, 6, 9, 2, 5, 8}, 40, 16, 11
+	},
+	{ // 49 716K 5 1/4 inch quad density (single density track 0), 6800 one boot sector
+		floppy_image::FF_525, floppy_image::DSSD, floppy_image::FM,
+		4000, 10, 80, 2, 256, {}, -1, {0, 4, 7, 10, 3, 6, 9, 2, 5, 8}, 40, 16, 11
+	},
+	{ // 50 716K 5 1/4 inch quad density (single density track 0), 6800 two boot sectors
+		floppy_image::FF_525, floppy_image::DSSD, floppy_image::FM,
+		4000, 10, 80, 2, 256, {}, -1, {0, 4, 7, 10, 3, 6, 9, 1, 5, 8}, 40, 16, 11
+	},
+	{ // 51 720K 5 1/4 inch quad density
+	},
+	{ // 52 720K 5 1/4 inch quad density, 6800 one boot sector
+		floppy_image::FF_525, floppy_image::DSQD, floppy_image::MFM,
+		2000, 18, 80, 2, 256, {}, -1, {0, 6, 11, 16, 3, 8, 13, 18, 5, 10, 15, 2, 7, 12, 17, 4, 9, 14}, 80, 22, 24
+	},
+	{ // 53 720K 5 1/4 inch quad density, 6800 two boot sectors
+		floppy_image::FF_525, floppy_image::DSQD, floppy_image::MFM,
+		2000, 18, 80, 2, 256, {}, -1, {0, 6, 11, 16, 3, 8, 13, 18, 5, 10, 15, 1, 7, 12, 17, 4, 9, 14}, 80, 22, 24
+	},
+	{ // 54 288.75K 8 inch single density
+	},
+	{ // 55 288.75K 8 inch single density, 6800 one boot sector
+	},
+	{ // 56 288.75K 8 inch single density, 6800 two boot sectors
+	},
+	{ // 57 577.5K 8 inch single density
+	},
+	{ // 58 577.5K 8 inch single density, 6800 one boot sector
+		floppy_image::FF_8, floppy_image::DSSD, floppy_image::FM,
+		2000, 15, 77, 2, 256, {}, -1, {0, 3, 5, 7, 9, 11, 13, 15, 2, 4, 6, 8, 10, 12, 14}, 40, 12, 12
+	},
+	{ // 59 577.5K 8 inch single density, 6800 two boot sectors
+		floppy_image::FF_8, floppy_image::DSSD, floppy_image::FM,
+		2000, 15, 77, 2, 256, {}, -1, {0, 3, 5, 7, 9, 11, 13, 15, 1, 4, 6, 8, 10, 12, 14}, 40, 12, 12
+	},
+	{ // 60 497.75K 8 inch double density (single density track 0)
+		floppy_image::FF_8, floppy_image::SSSD, floppy_image::FM,
+		2000, 15, 77, 1, 256, {}, -1, {1, 3, 5, 7, 9, 11, 13, 15, 2, 4, 6, 8, 10, 12, 14}, 40, 12, 12
+	},
+	{ // 61 497.75K 8 inch double density (single density track 0), 6800 one boot sector
+		floppy_image::FF_8, floppy_image::SSSD, floppy_image::FM,
+		2000, 15, 77, 1, 256, {}, -1, {0, 3, 5, 7, 9, 11, 13, 15, 2, 4, 6, 8, 10, 12, 14}, 40, 12, 12
+	},
+	{ // 62 497.75K 8 inch double density (single density track 0), 6800 two boot sectors
+		floppy_image::FF_8, floppy_image::SSSD, floppy_image::FM,
+		2000, 15, 77, 1, 256, {}, -1, {0, 3, 5, 7, 9, 11, 13, 15, 1, 4, 6, 8, 10, 12, 14}, 40, 12, 12
+	},
+	{ // 63 500.5K 8 inch double density
+	},
+	{ // 64 500.5K 8 inch double density, 6800 one boot sector
+		floppy_image::FF_8, floppy_image::SSDD, floppy_image::MFM,
+		1000, 26, 77, 1, 256, {}, -1, {0, 20, 13, 6, 25, 18, 11, 4, 23, 16, 9, 2, 21, 14, 7, 26, 19, 12, 5, 24, 17, 10, 3, 22, 15, 8}, 80, 22, 24
+	},
+	{ // 65 500.5K 8 inch double density, 6800 two boot sectors
+		floppy_image::FF_8, floppy_image::SSDD, floppy_image::MFM,
+		1000, 26, 77, 1, 256, {}, -1, {0, 20, 13, 6, 25, 18, 11, 4, 23, 16, 9, 1, 21, 14, 7, 26, 19, 12, 5, 24, 17, 10, 3, 22, 15, 8}, 80, 22, 24
+	},
+	{ // 66 995.5K 8 inch double density (single density track 0)
+		floppy_image::FF_8, floppy_image::DSSD, floppy_image::FM,
+		2000, 15, 77, 2, 256, {}, -1, {1, 3, 5, 7, 9, 11, 13, 15, 2, 4, 6, 8, 10, 12, 14}, 40, 12, 12
+	},
+	{ // 67 995.5K 8 inch double density (single density track 0), 6800 one boot sector
+		floppy_image::FF_8, floppy_image::DSSD, floppy_image::FM,
+		2000, 15, 77, 2, 256, {}, -1, {0, 3, 5, 7, 9, 11, 13, 15, 2, 4, 6, 8, 10, 12, 14}, 40, 12, 12
+	},
+	{ // 68 995.5K 8 inch double density (single density track 0), 6800 two boot sectors
+		floppy_image::FF_8, floppy_image::DSSD, floppy_image::FM,
+		2000, 15, 77, 2, 256, {}, -1, {0, 3, 5, 7, 9, 11, 13, 15, 1, 4, 6, 8, 10, 12, 14}, 40, 12, 12
+	},
+	{ // 69 1001K 8 inch double density
+	},
+	{ // 70 1001K 8 inch double density, 6800 one boot sector
+		floppy_image::FF_8, floppy_image::DSDD, floppy_image::MFM,
+		1000, 26, 77, 2, 256, {}, -1, {0, 20, 13, 6, 25, 18, 11, 4, 23, 16, 9, 2, 21, 14, 7, 26, 19, 12, 5, 24, 17, 10, 3, 22, 15, 8}, 80, 22, 24
+	},
+	{ // 71 1001K 8 inch double density, 6800 two boot sectors
+		floppy_image::FF_8, floppy_image::DSDD, floppy_image::MFM,
+		1000, 26, 77, 2, 256, {}, -1, {0, 20, 13, 6, 25, 18, 11, 4, 23, 16, 9, 1, 21, 14, 7, 26, 19, 12, 5, 24, 17, 10, 3, 22, 15, 8}, 80, 22, 24
+	},
+	{ // 72 1440K 3 1/2 inch high density (single density track 0)
+		floppy_image::FF_35,  floppy_image::DSSD, floppy_image::FM,
+		2000, 18, 80, 2, 256, {}, -1, {1, 6, 11, 16, 3, 8, 13, 18, 5, 10, 15, 2, 7, 12, 17, 4, 9, 14}, 40, 12, 12
+	},
+	{ // 73 1440K 3 1/2 inch high density (single density track 0), 6800 one boot sector
+		floppy_image::FF_35,  floppy_image::DSSD, floppy_image::FM,
+		2000, 18, 80, 2, 256, {}, -1, {0, 6, 11, 16, 3, 8, 13, 18, 5, 10, 15, 2, 7, 12, 17, 4, 9, 14}, 40, 12, 12
+	},
+	{ // 74 1440K 3 1/2 inch high density (single density track 0), 6800 two boot sectors
+		floppy_image::FF_35,  floppy_image::DSSD, floppy_image::FM,
+		2000, 18, 80, 2, 256, {}, -1, {0, 6, 11, 16, 3, 8, 13, 18, 5, 10, 15, 1, 7, 12, 17, 4, 9, 14}, 40, 12, 12
+	},
+	{ // 75 1440K 3 1/2 inch high density
+	},
+	{ // 76 1440K 3 1/2 inch high density, 6800 one boot sector
+		floppy_image::FF_35,  floppy_image::DSHD, floppy_image::MFM,
+		1000, 36, 80, 2, 256, {}, -1, {0, 26, 15, 4, 29, 18, 7, 32, 21, 10, 35, 24, 13, 2, 27, 16, 5, 30, 19, 8, 33, 22, 11, 36, 25, 14, 3, 28, 17, 6, 31, 20, 9, 34, 23, 12}, 80, 22, 24
+	},
+	{ // 77 1440K 3 1/2 inch high density, 6800 two boot sectors
+		floppy_image::FF_35,  floppy_image::DSHD, floppy_image::MFM,
+		1000, 36, 80, 2, 256, {}, -1, {0, 26, 15, 4, 29, 18, 7, 32, 21, 10, 35, 24, 13, 1, 27, 16, 5, 30, 19, 8, 33, 22, 11, 36, 25, 14, 3, 28, 17, 6, 31, 20, 9, 34, 23, 12}, 80, 22, 24
+	},
+	{}
+};
+
+const flex_format::format flex_format::formats_head1_track0[] = {
+	{ // 0 87.5K 5 1/4 inch single density
+	},
+	{ // 1 87.5K 5 1/4 inch single density, 6800 one boot sector
+	},
+	{ // 2 87.5K 5 1/4 inch single density, 6800 two boot sectors
+	},
+	{ // 3 100K 5 1/4 inch single density
+	},
+	{ // 4 100K 5 1/4 inch single density, 6800 one boot sector
+	},
+	{ // 5 100K 5 1/4 inch single density, 6800 two boot sectors
+	},
+	{ // 6 200K 5 1/4 inch single density
+	},
+	{ // 7 200K 5 1/4 inch single density, 6800 one boot sector
+	},
+	{ // 8 200K 5 1/4 inch single density, 6800 two boot sectors
+	},
+	{ // 9 175K 5 1/4 inch single density
+	},
+	{ // 10 175K 5 1/4 inch single density, 6800 one boot sector
+	},
+	{ // 11 175K 5 1/4 inch single density, 6800 two boot sectors
+	},
+	{ // 12 200K 5 1/4 inch single density
+	},
+	{ // 13 200K 5 1/4 inch single density, 6800 one boot sector
+	},
+	{ // 14 200K 5 1/4 inch single density, 6800 two boot sectors
+	},
+	{ // 15 400K 5 1/4 inch single density
+	},
+	{ // 16 400K 5 1/4 inch single density, 6800 one boot sector
+	},
+	{ // 17 400K 5 1/4 inch single density, 6800 two boot sectors
+	},
+	{ // 18 155.5K 5 1/4 inch double density (single density track 0)
+	},
+	{ // 19 155.5K 5 1/4 inch double density (single density track 0), 6800 one boot sector
+	},
+	{ // 20 155.5K 5 1/4 inch double density (single density track 0), 6800 two boot sectors
+	},
+	{ // 21 157.5K 5 1/4 inch double density
+	},
+	{ // 22 157.5K 5 1/4 inch double density
+	},
+	{ // 23 157.5K 5 1/4 inch double density
+	},
+	{ // 24 311K 5 1/4 inch double density (single density track 0)
+		floppy_image::FF_525, floppy_image::DSSD, floppy_image::FM,
+		4000, 10, 35, 2, 256, {}, -1, {11, 14, 17, 20, 13, 16, 19, 12, 15, 18}, 40, 16, 11
+	},
+	{ // 25 311K 5 1/4 inch double density (single density track 0), 6800 one boot sector
+		floppy_image::FF_525, floppy_image::DSSD, floppy_image::FM,
+		4000, 10, 35, 2, 256, {}, -1, {11, 14, 17, 20, 13, 16, 19, 12, 15, 18}, 40, 16, 11
+	},
+	{ // 26 311K 5 1/4 inch double density (single density track 0), 6800 two boot sectors
+		floppy_image::FF_525, floppy_image::DSSD, floppy_image::FM,
+		4000, 10, 35, 2, 256, {}, -1, {11, 14, 17, 20, 13, 16, 19, 12, 15, 18}, 40, 16, 11
+	},
+	{ // 27 315K 5 1/4 inch double density
+	},
+	{ // 28 315K 5 1/4 inch double density, 6800 one boot sector
+	},
+	{ // 29 315K 5 1/4 inch double density, 6800 two boot sectors
+	},
+	{ // 30 178K 5 1/4 inch double density (single density track 0)
+	},
+	{ // 31 178K 5 1/4 inch double density (single density track 0), 6800 one boot sector
+	},
+	{ // 32 178K 5 1/4 inch double density (single density track 0), 6800 two boot sectors
+	},
+	{ // 33 180K 5 1/4 inch double density
+	},
+	{ // 34 180K 5 1/4 inch double density, 6800 one boot sector
+	},
+	{ // 35 180K 5 1/4 inch double density, 6800 two boot sectors
+	},
+	{ // 36 356K 5 1/4 inch double density (single density track 0)
+		floppy_image::FF_525, floppy_image::DSSD, floppy_image::FM,
+		4000, 10, 40, 2, 256, {}, -1, {11, 14, 17, 20, 13, 16, 19, 12, 15, 18}, 40, 16, 11
+	},
+	{ // 37 356K 5 1/4 inch double density (single density track 0), 6800 one boot sector
+		floppy_image::FF_525, floppy_image::DSSD, floppy_image::FM,
+		4000, 10, 40, 2, 256, {}, -1, {11, 14, 17, 20, 13, 16, 19, 12, 15, 18}, 40, 16, 11
+	},
+	{ // 38 356K 5 1/4 inch double density (single density track 0), 6800 two boot sectors
+		floppy_image::FF_525, floppy_image::DSSD, floppy_image::FM,
+		4000, 10, 40, 2, 256, {}, -1, {11, 14, 17, 20, 13, 16, 19, 12, 15, 18}, 40, 16, 11
+	},
+	{ // 39 360K 5 1/4 inch double density
+	},
+	{ // 40 360K 5 1/4 inch double density, 6800 one boot sector
+	},
+	{ // 41 360K 5 1/4 inch double density, 6800 two boot sectors
+	},
+	{ // 42 358K 5 1/4 inch quad density (single density track 0)
+	},
+	{ // 43 358K 5 1/4 inch quad density (single density track 0), 6800 one boot sector
+	},
+	{ // 44 358K 5 1/4 inch quad density (single density track 0), 6800 two boot sectors
+	},
+	{ // 45 360K 5 1/4 inch quad density
+	},
+	{ // 46 360K 5 1/4 inch quad density, 6800 one boot sector
+	},
+	{ // 47 360K 5 1/4 inch quad density, 6800 two boot sectors
+	},
+	{ // 48 716K 5 1/4 inch quad density (single density track 0)
+		floppy_image::FF_525, floppy_image::DSSD, floppy_image::FM,
+		4000, 10, 80, 2, 256, {}, -1, {11, 14, 17, 20, 13, 16, 19, 12, 15, 18}, 40, 16, 11
+	},
+	{ // 49 716K 5 1/4 inch quad density (single density track 0), 6800 one boot sector
+		floppy_image::FF_525, floppy_image::DSSD, floppy_image::FM,
+		4000, 10, 80, 2, 256, {}, -1, {11, 14, 17, 20, 13, 16, 19, 12, 15, 18}, 40, 16, 11
+	},
+	{ // 50 716K 5 1/4 inch quad density (single density track 0), 6800 two boot sectors
+		floppy_image::FF_525, floppy_image::DSSD, floppy_image::FM,
+		4000, 10, 80, 2, 256, {}, -1, {11, 14, 17, 20, 13, 16, 19, 12, 15, 18}, 40, 16, 11
+	},
+	{ // 51 720K 5 1/4 inch quad density
+	},
+	{ // 52 720K 5 1/4 inch quad density, 6800 one boot sector
+	},
+	{ // 53 720K 5 1/4 inch quad density, 6800 two boot sectors
+	},
+	{ // 54 288.75K 8 inch single density
+	},
+	{ // 55 288.75K 8 inch single density, 6800 one boot sector
+	},
+	{ // 56 288.75K 8 inch single density, 6800 two boot sectors
+	},
+	{ // 57 577.5K 8 inch single density
+	},
+	{ // 58 577.5K 8 inch single density, 6800 one boot sector
+	},
+	{ // 59 577.5K 8 inch single density, 6800 two boot sectors
+	},
+	{ // 60 497.75K 8 inch double density (single density track 0)
+	},
+	{ // 61 497.75K 8 inch double density (single density track 0), 6800 one boot sector
+	},
+	{ // 62 497.75K 8 inch double density (single density track 0), 6800 two boot sectors
+	},
+	{ // 63 500.5K 8 inch double density
+	},
+	{ // 64 500.5K 8 inch double density, 6800 one boot sector
+	},
+	{ // 65 500.5K 8 inch double density, 6800 two boot sectors
+	},
+	{ // 66 995.5K 8 inch double density (single density track 0)
+		floppy_image::FF_8, floppy_image::DSSD, floppy_image::FM,
+		2000, 15, 77, 2, 256, {}, -1, {16, 18, 20, 22, 24, 26, 28, 30, 17, 19, 21, 23, 25, 27, 29}, 40, 12, 12
+	},
+	{ // 67 995.5K 8 inch double density (single density track 0), 6800 one boot sector
+		floppy_image::FF_8, floppy_image::DSSD, floppy_image::FM,
+		2000, 15, 77, 2, 256, {}, -1, {16, 18, 20, 22, 24, 26, 28, 30, 17, 19, 21, 23, 25, 27, 29}, 40, 12, 12
+	},
+	{ // 68 995.5K 8 inch double density (single density track 0), 6800 two boot sectors
+		floppy_image::FF_8, floppy_image::DSSD, floppy_image::FM,
+		2000, 15, 77, 2, 256, {}, -1, {16, 18, 20, 22, 24, 26, 28, 30, 17, 19, 21, 23, 25, 27, 29}, 40, 12, 12
+	},
+	{ // 69 1001K 8 inch double density
+	},
+	{ // 70 1001K 8 inch double density, 6800 one boot sector
+	},
+	{ // 71 1001K 8 inch double density, 6800 two boot sectors
+	},
+	{ // 72 1440K 3 1/2 inch high density (single density track 0)
+		floppy_image::FF_35,  floppy_image::DSSD, floppy_image::FM,
+		2000, 18, 80, 2, 256, {}, -1, {19, 24, 29, 34, 21, 26, 31, 36, 23, 28, 33, 20, 25, 30, 35, 22, 27, 32}, 80, 22, 24
+	},
+	{ // 73 1440K 3 1/2 inch high density (single density track 0), 6800 one boot sector
+		floppy_image::FF_35,  floppy_image::DSSD, floppy_image::FM,
+		2000, 18, 80, 2, 256, {}, -1, {19, 24, 29, 34, 21, 26, 31, 36, 23, 28, 33, 20, 25, 30, 35, 22, 27, 32}, 80, 22, 24
+	},
+	{ // 74 1440K 3 1/2 inch high density (single density track 0), 6800 two boot sectors
+		floppy_image::FF_35,  floppy_image::DSSD, floppy_image::FM,
+		2000, 18, 80, 2, 256, {}, -1, {19, 24, 29, 34, 21, 26, 31, 36, 23, 28, 33, 20, 25, 30, 35, 22, 27, 32}, 80, 22, 24
+	},
+	{ // 75 1440K 3 1/2 inch high density
+	},
+	{ // 76 1440K 3 1/2 inch high density, 6800 one boot sector
+	},
+	{ // 77 1440K 3 1/2 inch high density, 6800 two boot sectors
 	},
 	{}
 };

--- a/src/lib/formats/flex_dsk.h
+++ b/src/lib/formats/flex_dsk.h
@@ -21,10 +21,8 @@ public:
 	virtual const char *name() const override;
 	virtual const char *description() const override;
 	virtual const char *extensions() const override;
-	virtual int identify(io_generic *io, uint32_t form_factor) override;
 	virtual int find_size(io_generic *io, uint32_t form_factor) override;
-	virtual void build_sector_description(const format &f, uint8_t *sectdata, desc_s *sectors, int track, int head) const override;
-	virtual void check_compatibility(floppy_image *image, std::vector<int> &candidates) override;
+	virtual const wd177x_format::format &get_track_format(const format &f, int head, int track) override;
 
 private:
 	struct sysinfo_sector
@@ -46,6 +44,9 @@ private:
 		uint8_t unused2[216];
 	} info;
 	static const format formats[];
+	static const format formats_head1[];
+	static const format formats_track0[];
+	static const format formats_head1_track0[];
 
 	uint8_t boot0_sector_id;
 	uint8_t boot1_sector_id;

--- a/src/lib/formats/os9_dsk.cpp
+++ b/src/lib/formats/os9_dsk.cpp
@@ -1,5 +1,5 @@
 // license:BSD-3-Clause
-// copyright-holders:tim lindner
+// copyright-holders:tim lindner, 68bit
 /*********************************************************************
 
     formats/os9_dsk.c
@@ -12,13 +12,42 @@
     Available: http://www.colorcomputerarchive.com/coco/Documents/Manuals/
         Operating Systems/OS-9 Level 2 Manual (Tandy).pdf
 
+    Some OS9 floppy drivers use a base sector ID of zero, for example SWTPC
+    and Gimix OS9, and some drivers use a base sector ID of one, for example
+    COCO OS9. The disk images do not encode the sector IDs so it is a
+    challenge to detect this base ID by looking at the disk content.
+
+    The OS9 disk header, at LSN0, does not necessarily encode the base sector
+    ID either. However it may optionally include a block of the device
+    descriptor information from when it was formatted and although this
+    optional content can vary across OS9 variants it appears to be regular
+    enough for COCO compatible formats to reply on it to identify a COCO
+    compatible disk and determine the base sector ID for these. All non-COCO
+    formats are assumed to have a base sector ID of zero and not exceptions to
+    this have been noted.
+
+    Commonly the 'coco' bit, bit 5, in the optional 'type' byte is set in COCO
+    format disks. Alternatively some OS9 formats set bit 7 of the optional
+    'density' byte to indicate a COCO format disk, for example some Gimix
+    drivers with COCO support. Some of the other optional information also can
+    be checked for consistency to better identify the format.
+
+    Some formats encode the first track, on the first head only, in single
+    density even when the remainder of the disk is encoded in double density,
+    and this can typically be identified from the disk geometry and the image
+    size and the total number of logical sectors written in the header.
+    E.g. At least some versions of OS9 for the SWTPC and the Gimix encode this
+    first track in single density whereas COCO format disks are typically all
+    double density. The number of sectors on track zero is also typically
+    encoded in the optional header information and can be checked for
+    consistency.
+
 *********************************************************************/
 
 #include "emu.h"
 #include "formats/os9_dsk.h"
 
 #include "formats/imageutl.h"
-
 
 os9_format::os9_format() : wd177x_format(formats)
 {
@@ -52,57 +81,486 @@ int os9_format::find_size(io_generic *io, uint32_t form_factor)
 {
 	uint64_t size = io_generic_size(io);
 
-	uint8_t os9_header[0x20];
-	io_generic_read(io, os9_header, 0, 0x20);
+	uint8_t os9_header[0x60];
+	io_generic_read(io, os9_header, 0, sizeof(os9_header));
 
 	int os9_total_sectors = pick_integer_be(os9_header, 0x00, 3);
 	int os9_heads = BIT(os9_header[0x10], 0) ? 2 : 1;
 	int os9_sectors = pick_integer_be(os9_header, 0x11, 2);
 
-	if (os9_total_sectors > 0 && os9_heads > 0 && os9_sectors > 0) {
-		int os9_tracks = os9_total_sectors / os9_sectors / os9_heads;
+	if (os9_total_sectors <= 0 || os9_heads <= 0 || os9_sectors <= 0)
+		return -1;
 
-		// now let's see if we have valid info
-		if ((os9_tracks * os9_heads * os9_sectors * 256) == size) {
-			for (int i=0; formats[i].form_factor; i++) {
-				const format &f = formats[i];
+	// The optional header information, which may contain a copy of the
+	// device descriptor used to format the disk. COCO format disks are
+	// expected to include this optional information.
+	int opt_dtype = os9_header[0x3f + 0];
+	int opt_type = os9_header[0x3f + 3];
+	int opt_density = os9_header[0x3f + 4];
+	int opt_cylinders = pick_integer_be(os9_header, 0x3f + 5, 2);
+	int opt_sides = os9_header[0x3f + 7];
+	int opt_sectors_per_track = pick_integer_be(os9_header, 0x3f + 9, 2);
+	int opt_track0_sectors = pick_integer_be(os9_header, 0x3f + 11, 2);
+	int opt_interleave = os9_header[0x3f + 13];
 
-				if (form_factor != floppy_image::FF_UNKNOWN && form_factor != f.form_factor)
-					continue;
+	int opt_mfm = BIT(opt_density, 0);
 
-				if ((os9_tracks == f.track_count) && (os9_heads == f.head_count) && (os9_sectors == f.sector_count))
-					return i;
+	// The NitrOS9 rb1773 driver uses bit 1 of opt_type to distinguish
+	// between a sector base ID of zero or one, so recognise that here.
+	int opt_sector_base_id = BIT(opt_type, 1) ? 0 : 1;
+	int opt_sector_size = BIT(opt_type, 2) ? 512 : 256;
+	int opt_coco = BIT(opt_type, 5);
+
+	// Some OS9 versions appear to use bit 7 of the opt_density rather
+	// than bit 5 of opt_type to signify a COCO format disk. E.g. Gimix
+	// OS9 is documented to use this bit and had a floppy driver that
+	// could read both non-COCO and COCO format disks.
+	if (BIT(opt_density, 7))
+		opt_coco = 1;
+
+	// COCO format disks are expected for have an opt_dtype of 1.
+	if (opt_dtype != 1)
+		opt_coco = 0;
+
+	for (int i=0; formats[i].form_factor; i++) {
+		const format &f = formats[i];
+		if (form_factor != floppy_image::FF_UNKNOWN && form_factor != f.form_factor)
+			continue;
+
+		if ((os9_heads != f.head_count) || (os9_sectors != f.sector_count)) {
+			continue;
+		}
+
+		unsigned int format_size = 0;
+		for (int track=0; track < f.track_count; track++) {
+			for (int head=0; head < f.head_count; head++) {
+				const format &tf = get_track_format(f, head, track);
+				format_size += compute_track_size(tf);
 			}
 		}
-	}
 
+		if (format_size != size)
+			continue;
+
+		if (format_size < os9_total_sectors * 256)
+			continue;
+
+		// Accept the format if the total number of sectors used is
+		// consistent with at least 10 sectors being used on track
+		// zero, as happens when the driver or descriptor is coded for
+		// a single density track zero with 10 sectors and so uses
+		// only 10 of these track zero sectors.
+
+		if (f.sector_count < 10 || format_size > (os9_total_sectors + f.sector_count - 10) * 256)
+			continue;
+
+		const format &tf = get_track_format(f, 0, 0);
+
+		if (opt_coco) {
+			// Looks like a COCO format disk.
+
+			// Check the sector base ID.
+			if (f.sector_base_id != opt_sector_base_id &&
+				(f.sector_base_id != -1 || f.per_sector_id[0] != opt_sector_base_id))
+				continue;
+			if (tf.sector_base_id != opt_sector_base_id &&
+				(tf.sector_base_id != -1 || tf.per_sector_id[0] != opt_sector_base_id))
+				continue;
+
+			// Check some other optional fields for consistency.
+
+			// If the device descriptor is not MFM capable then
+			// the disk it not expected to be MFM encoded.
+			if (opt_mfm == 0 && f.encoding == floppy_image::MFM)
+				continue;
+
+			// Should not be more cylinders than suppored in the
+			// device descriptor.
+			if (f.track_count > opt_cylinders)
+				continue;
+
+			// Should not be more heads than suppored in the
+			// device descriptor.
+			if (f.head_count > opt_sides)
+				continue;
+
+			// Should not be more sectors per track than supported
+			// in the device descriptor.
+			if (f.sector_count > opt_sectors_per_track ||
+				tf.sector_count > opt_track0_sectors) {
+				continue;
+			}
+
+			// The sector size should be consistent.
+			if (opt_sector_size != f.sector_base_size)
+				continue;
+
+			// The sector interleave should not be greater than
+			// the number of sectors.
+			if (opt_interleave > f.sector_count)
+				continue;
+		}
+		else
+		{
+			// Not a recognizable COCO OS9 format.  The options
+			// can not be relied on here, they are driver
+			// dependent, and the sector base ID is assumed to be
+			// zero. Check that format sector base ID is zero.
+			if (f.sector_base_id != 0 && (f.sector_base_id != -1 || f.per_sector_id[0] != 0))
+				continue;
+			if (tf.sector_base_id != 0 && (tf.sector_base_id != -1 || tf.per_sector_id[0] != 0))
+				continue;
+		}
+
+		LOG_FORMATS("OS9 matching format index %d\n", i);
+		return i;
+	}
 	return -1;
 }
 
+const wd177x_format::format &os9_format::get_track_format(const format &f, int head, int track)
+{
+	int n = -1;
+
+	for (int i = 0; formats[i].form_factor; i++) {
+		if (&formats[i] == &f) {
+			n = i;
+			break;
+		}
+	}
+
+	if (n < 0) {
+		LOG_FORMATS("Error format not found\n");
+		return f;
+	}
+
+	if (head >= f.head_count) {
+		LOG_FORMATS("Error invalid head %d\n", head);
+		return f;
+	}
+
+	if (track >= f.track_count) {
+		LOG_FORMATS("Error invalid track %d\n", track);
+		return f;
+	}
+
+	if (track == 0 && head == 0) {
+		const format &t0 = formats_track0[n];
+		if (t0.form_factor)
+			return t0;
+	}
+
+	return f;
+}
+
 const os9_format::format os9_format::formats[] = {
-	{   //  5"25 160K double density
+	// COCO formats, with a sector base ID of one.
+
+	{ // 0 157.5K 5"25 double density
 		floppy_image::FF_525, floppy_image::SSDD, floppy_image::MFM,
 		2000, 18, 35, 1, 256, {}, -1, {1, 7, 13, 2, 8, 14, 3, 9, 15, 4, 10, 16, 5, 11, 17, 6, 12, 18}, 18, 28, 20
 	},
-	{   //  5"25 160K double density
+	{ // 1 315K 5"25 double density
 		floppy_image::FF_525, floppy_image::DSDD, floppy_image::MFM,
 		2000, 18, 35, 2, 256, {}, -1, {1, 7, 13, 2, 8, 14, 3, 9, 15, 4, 10, 16, 5, 11, 17, 6, 12, 18}, 18, 28, 20
 	},
-	{   //  5"25 160K double density
+	{ // 2 180K 5"25 double density
 		floppy_image::FF_525, floppy_image::SSDD, floppy_image::MFM,
 		2000, 18, 40, 1, 256, {}, -1, {1, 7, 13, 2, 8, 14, 3, 9, 15, 4, 10, 16, 5, 11, 17, 6, 12, 18}, 18, 28, 20
 	},
-	{   //  5"25 160K double density
+	{ // 3 360K 5"25 double density
 		floppy_image::FF_525, floppy_image::DSDD, floppy_image::MFM,
 		2000, 18, 40, 2, 256, {}, -1, {1, 7, 13, 2, 8, 14, 3, 9, 15, 4, 10, 16, 5, 11, 17, 6, 12, 18}, 18, 28, 20
 	},
-	{   //  5"25 160K double density
+	{ // 4 360K 5"25 double density
 		floppy_image::FF_525, floppy_image::SSDD, floppy_image::MFM,
 		2000, 18, 80, 1, 256, {}, -1, {1, 7, 13, 2, 8, 14, 3, 9, 15, 4, 10, 16, 5, 11, 17, 6, 12, 18}, 18, 28, 20
 	},
-	{   //  5"25 160K double density
+	{ // 5 720K 5"25 double density
 		floppy_image::FF_525, floppy_image::DSDD, floppy_image::MFM,
 		2000, 18, 80, 2, 256, {}, -1, {1, 7, 13, 2, 8, 14, 3, 9, 15, 4, 10, 16, 5, 11, 17, 6, 12, 18}, 18, 28, 20
+	},
+
+	// Non-COCO formats, with a sector base ID of zero.
+
+	{ // 6 87.5K 5 1/4 inch single density
+		floppy_image::FF_525, floppy_image::SSSD, floppy_image::FM,
+		4000, 10, 35, 1, 256, {}, -1, {0, 3, 6, 9, 2, 5, 8, 1, 4, 7}, 40, 16, 11
+	},
+	{ // 7 100K 5 1/4 inch single density
+		floppy_image::FF_525, floppy_image::SSSD, floppy_image::FM,
+		4000, 10, 40, 1, 256, {}, -1, {0, 3, 6, 9, 2, 5, 8, 1, 4, 7}, 40, 16, 11
+	},
+	{ // 8 200K 5 1/4 inch single density
+		floppy_image::FF_525, floppy_image::SSSD, floppy_image::FM,
+		4000, 10, 80, 1, 256, {}, -1, {0, 3, 6, 9, 2, 5, 8, 1, 4, 7}, 40, 16, 11
+	},
+	{ // 9 175K 5 1/4 inch single density
+		floppy_image::FF_525, floppy_image::DSSD, floppy_image::FM,
+		4000, 10, 35, 2, 256, {}, -1, {0, 3, 6, 9, 2, 5, 8, 1, 4, 7}, 40, 16, 11
+	},
+	{ // 10 200K 5 1/4 inch single density
+		floppy_image::FF_525, floppy_image::DSSD, floppy_image::FM,
+		4000, 10, 40, 2, 256, {}, -1, {0, 3, 6, 9, 2, 5, 8, 1, 4, 7}, 40, 16, 11
+	},
+	{ // 11 400K 5 1/4 inch single density
+		floppy_image::FF_525, floppy_image::DSSD, floppy_image::FM,
+		4000, 10, 80, 2, 256, {}, -1, {0, 3, 6, 9, 2, 5, 8, 1, 4, 7}, 40, 16, 11
+	},
+	{ // 12 138.5K 5 1/4 inch double density (single density track 0)
+		floppy_image::FF_525, floppy_image::DSDD, floppy_image::MFM,
+		2000, 16, 35, 1, 256, {}, -1, {0, 3, 6, 9, 12, 15, 2, 5, 8, 11, 14, 1, 4, 7, 10, 13}, 18, 28, 20
+	},
+	{ // 13 140K 5 1/4 inch double density
+		floppy_image::FF_525, floppy_image::DSDD, floppy_image::MFM,
+		2000, 16, 35, 1, 256, {}, -1, {0, 3, 6, 9, 12, 15, 2, 5, 8, 11, 14, 1, 4, 7, 10, 13}, 18, 28, 20
+	},
+	{ // 14 278.5K 5 1/4 inch double density (single density track 0)
+		floppy_image::FF_525, floppy_image::DSDD, floppy_image::MFM,
+		2000, 16, 35, 2, 256, {}, -1, {0, 3, 6, 9, 12, 15, 2, 5, 8, 11, 14, 1, 4, 7, 10, 13}, 18, 28, 20
+	},
+	{ // 15 280K 5 1/4 inch double density
+		floppy_image::FF_525, floppy_image::DSDD, floppy_image::MFM,
+		2000, 16, 35, 2, 256, {}, -1, {0, 3, 6, 9, 12, 15, 2, 5, 8, 11, 14, 1, 4, 7, 10, 13}, 18, 28, 20
+	},
+	{ // 16 158.5K 5 1/4 inch double density (single density track 0)
+		floppy_image::FF_525, floppy_image::DSDD, floppy_image::MFM,
+		2000, 16, 40, 1, 256, {}, -1, {0, 3, 6, 9, 12, 15, 2, 5, 8, 11, 14, 1, 4, 7, 10, 13}, 18, 28, 20
+	},
+	{ // 17 160K 5 1/4 inch double density
+		floppy_image::FF_525, floppy_image::DSDD, floppy_image::MFM,
+		2000, 16, 40, 1, 256, {}, -1, {0, 3, 6, 9, 12, 15, 2, 5, 8, 11, 14, 1, 4, 7, 10, 13}, 18, 28, 20
+	},
+	{ // 18 318.5K 5 1/4 inch double density (single density track 0)
+		floppy_image::FF_525, floppy_image::DSDD, floppy_image::MFM,
+		2000, 16, 40, 2, 256, {}, -1, {0, 3, 6, 9, 12, 15, 2, 5, 8, 11, 14, 1, 4, 7, 10, 13}, 18, 28, 20
+	},
+	{ // 19 320K 5 1/4 inch double density
+		floppy_image::FF_525, floppy_image::DSDD, floppy_image::MFM,
+		2000, 16, 40, 2, 256, {}, -1, {0, 3, 6, 9, 12, 15, 2, 5, 8, 11, 14, 1, 4, 7, 10, 13}, 18, 28, 20
+	},
+	{ // 20 318.5K 5 1/4 inch double density (single density track 0)
+		floppy_image::FF_525, floppy_image::DSDD, floppy_image::MFM,
+		2000, 16, 80, 1, 256, {}, -1, {0, 3, 6, 9, 12, 15, 2, 5, 8, 11, 14, 1, 4, 7, 10, 13}, 18, 28, 20
+	},
+	{ // 21 320K 5 1/4 inch double density
+		floppy_image::FF_525, floppy_image::DSDD, floppy_image::MFM,
+		2000, 16, 80, 1, 256, {}, -1, {0, 3, 6, 9, 12, 15, 2, 5, 8, 11, 14, 1, 4, 7, 10, 13}, 18, 28, 20
+	},
+	{ // 22 638.5 5 1/4 inch double density (single density track 0)
+		floppy_image::FF_525, floppy_image::DSDD, floppy_image::MFM,
+		2000, 16, 80, 2, 256, {}, -1, {0, 3, 6, 9, 12, 15, 2, 5, 8, 11, 14, 1, 4, 7, 10, 13}, 18, 28, 20
+	},
+	{ // 23 640K 5 1/4 inch double density
+		floppy_image::FF_525, floppy_image::DSDD, floppy_image::MFM,
+		2000, 16, 80, 2, 256, {}, -1, {0, 3, 6, 9, 12, 15, 2, 5, 8, 11, 14, 1, 4, 7, 10, 13}, 18, 28, 20
+	},
+	{ // 24 155.5K 5 1/4 inch double density (single density track 0)
+		floppy_image::FF_525, floppy_image::SSDD, floppy_image::MFM,
+		2000, 18, 35, 1, 256, {}, -1, {0, 5, 10, 15, 2, 7, 12, 17, 4, 9, 14, 1, 6, 11, 16, 3, 8, 13}, 80, 22, 24
+	},
+	{ // 25 157.5K 5 1/4 inch double density
+		floppy_image::FF_525, floppy_image::SSDD, floppy_image::MFM,
+		2000, 18, 35, 1, 256, {}, -1, {0, 5, 10, 15, 2, 7, 12, 17, 4, 9, 14, 1, 6, 11, 16, 3, 8, 13}, 80, 22, 24
+	},
+	{ // 26 311K 5 1/4 inch double density (single density track 0)
+		floppy_image::FF_525, floppy_image::DSDD, floppy_image::MFM,
+		2000, 18, 35, 2, 256, {}, -1, {0, 5, 10, 15, 2, 7, 12, 17, 4, 9, 14, 1, 6, 11, 16, 3, 8, 13}, 80, 22, 24
+	},
+	{ // 27 315K 5 1/4 inch double density
+		floppy_image::FF_525, floppy_image::DSDD, floppy_image::MFM,
+		2000, 18, 35, 2, 256, {}, -1, {0, 5, 10, 15, 2, 7, 12, 17, 4, 9, 14, 1, 6, 11, 16, 3, 8, 13}, 80, 22, 24
+	},
+	{ // 28 178K 5 1/4 inch double density (single density track 0)
+		floppy_image::FF_525, floppy_image::SSDD, floppy_image::MFM,
+		2000, 18, 40, 1, 256, {}, -1, {0, 5, 10, 15, 2, 7, 12, 17, 4, 9, 14, 1, 6, 11, 16, 3, 8, 13}, 80, 22, 24
+	},
+	{ // 29 180K 5 1/4 inch double density
+		floppy_image::FF_525, floppy_image::SSDD, floppy_image::MFM,
+		2000, 18, 40, 1, 256, {}, -1, {0, 5, 10, 15, 2, 7, 12, 17, 4, 9, 14, 1, 6, 11, 16, 3, 8, 13}, 80, 22, 24
+	},
+	{ // 30 356K 5 1/4 inch double density (single density track 0)
+		floppy_image::FF_525, floppy_image::DSDD, floppy_image::MFM,
+		2000, 18, 40, 2, 256, {}, -1, {0, 5, 10, 15, 2, 7, 12, 17, 4, 9, 14, 1, 6, 11, 16, 3, 8, 13}, 80, 22, 24
+	},
+	{ // 31 360K 5 1/4 inch double density
+		floppy_image::FF_525, floppy_image::DSDD, floppy_image::MFM,
+		2000, 18, 40, 2, 256, {}, -1, {0, 5, 10, 15, 2, 7, 12, 17, 4, 9, 14, 1, 6, 11, 16, 3, 8, 13}, 80, 22, 24
+	},
+	{ // 32 358K 5 1/4 inch quad density (single density track 0)
+		floppy_image::FF_525, floppy_image::SSQD, floppy_image::MFM,
+		2000, 18, 80, 1, 256, {}, -1, {0, 5, 10, 15, 2, 7, 12, 17, 4, 9, 14, 1, 6, 11, 16, 3, 8, 13}, 80, 22, 24
+	},
+	{ // 33 360K 5 1/4 inch quad density
+		floppy_image::FF_525, floppy_image::SSQD, floppy_image::MFM,
+		2000, 18, 80, 1, 256, {}, -1, {0, 5, 10, 15, 2, 7, 12, 17, 4, 9, 14, 1, 6, 11, 16, 3, 8, 13}, 80, 22, 24
+	},
+	{ // 34 716K 5 1/4 inch quad density (single density track 0)
+		floppy_image::FF_525, floppy_image::DSQD, floppy_image::MFM,
+		2000, 18, 80, 2, 256, {}, -1, {0, 5, 10, 15, 2, 7, 12, 17, 4, 9, 14, 1, 6, 11, 16, 3, 8, 13}, 80, 22, 24
+	},
+	{ // 35 720K 5 1/4 inch quad density
+		floppy_image::FF_525, floppy_image::DSQD, floppy_image::MFM,
+		2000, 18, 80, 2, 256, {}, -1, {0, 5, 10, 15, 2, 7, 12, 17, 4, 9, 14, 1, 6, 11, 16, 3, 8, 13}, 80, 22, 24
+	},
+	{ // 36 288.75K 8 inch single density
+		floppy_image::FF_8, floppy_image::SSSD, floppy_image::FM,
+		2000, 15, 77, 1, 256, {}, -1, {0, 2, 4, 6, 8, 10, 12, 14, 1, 3, 5, 7, 9, 11, 13}, 40, 12, 12
+	},
+	{ // 37 577.5K 8 inch single density
+		floppy_image::FF_8, floppy_image::DSSD, floppy_image::FM,
+		2000, 15, 77, 2, 256, {}, -1, {0, 2, 4, 6, 8, 10, 12, 14, 1, 3, 5, 7, 9, 11, 13}, 40, 12, 12
+	},
+	{ // 38 497.75K 8 inch double density (single density track 0)
+		floppy_image::FF_8, floppy_image::SSDD, floppy_image::MFM,
+		1000, 26, 77, 1, 256, {}, -1, {0, 19, 12, 5, 24, 17, 10, 3, 22, 15, 8, 1, 20, 13, 6, 25, 18, 11, 4, 23, 16, 9, 2, 21, 14, 7}, 80, 22, 24
+	},
+	{ // 39 500.5K 8 inch double density
+		floppy_image::FF_8, floppy_image::SSDD, floppy_image::MFM,
+		1000, 26, 77, 1, 256, {}, -1, {0, 19, 12, 5, 24, 17, 10, 3, 22, 15, 8, 1, 20, 13, 6, 25, 18, 11, 4, 23, 16, 9, 2, 21, 14, 7}, 80, 22, 24
+	},
+	{ // 40 995.5K 8 inch double density (single density track 0)
+		floppy_image::FF_8, floppy_image::DSDD, floppy_image::MFM,
+		1000, 26, 77, 2, 256, {}, -1, {0, 19, 12, 5, 24, 17, 10, 3, 22, 15, 8, 1, 20, 13, 6, 25, 18, 11, 4, 23, 16, 9, 2, 21, 14, 7}, 80, 22, 24
+	},
+	{ // 41 1001K 8 inch double density
+		floppy_image::FF_8, floppy_image::DSDD, floppy_image::MFM,
+		1000, 26, 77, 2, 256, {}, -1, {0, 19, 12, 5, 24, 17, 10, 3, 22, 15, 8, 1, 20, 13, 6, 25, 18, 11, 4, 23, 16, 9, 2, 21, 14, 7}, 80, 22, 24
+	},
+	{ // 42 1440K 3 1/2 inch high density (single density track 0)
+		floppy_image::FF_35,  floppy_image::DSHD, floppy_image::MFM,
+		1000, 36, 80, 2, 256, {}, -1, {0, 25, 14, 3, 28, 17, 6, 31, 20, 9, 34, 23, 12, 1, 26, 15, 4, 29, 18, 7, 32, 21, 10, 35, 24, 13, 2, 27, 16, 5, 30, 19, 8, 33, 22, 11}, 80, 22, 24
+	},
+	{ // 43 1440K 3 1/2 inch high density.
+		floppy_image::FF_35,  floppy_image::DSHD, floppy_image::MFM,
+		1000, 36, 80, 2, 256, {}, -1, {0, 25, 14, 3, 28, 17, 6, 31, 20, 9, 34, 23, 12, 1, 26, 15, 4, 29, 18, 7, 32, 21, 10, 35, 24, 13, 2, 27, 16, 5, 30, 19, 8, 33, 22, 11}, 80, 22, 24
+	},
+	{}
+};
+
+const os9_format::format os9_format::formats_track0[] = {
+	// COCO formats, with a sector base ID of one.
+
+	{ // 0 157.5K 5"25 double density
+	},
+	{ // 1 315K 5"25 double density
+	},
+	{ // 2 180K 5"25 double density
+	},
+	{ // 3 360K 5"25 double density
+	},
+	{ // 4 360K 5"25 double density
+	},
+	{ // 5 720K 5"25 double density
+	},
+
+	// Non-COCO formats, with a sector base ID of zero.
+
+	{ // 6 87.5K 5 1/4 inch single density
+	},
+	{ // 7 100K 5 1/4 inch single density
+	},
+	{ // 8 200K 5 1/4 inch single density
+	},
+	{ // 9 175K 5 1/4 inch single density
+	},
+	{ // 10 200K 5 1/4 inch single density
+	},
+	{ // 11 400K 5 1/4 inch single density
+	},
+	{ // 12 138.5K 5 1/4 inch double density (single density track 0)
+		floppy_image::FF_525, floppy_image::SSSD, floppy_image::FM,
+		4000, 10, 35, 1, 256, {}, -1, {0, 3, 6, 9, 2, 5, 8, 1, 4, 7}, 40, 16, 11
+	},
+	{ // 13 140K 5 1/4 inch double density
+	},
+	{ // 14 278.5K 5 1/4 inch double density (single density track 0)
+		floppy_image::FF_525, floppy_image::SSSD, floppy_image::FM,
+		4000, 10, 35, 2, 256, {}, -1, {0, 3, 6, 9, 2, 5, 8, 1, 4, 7}, 40, 16, 11
+	},
+	{ // 15 280K 5 1/4 inch double density
+	},
+	{ // 16 158.5K 5 1/4 inch double density (single density track 0)
+		floppy_image::FF_525, floppy_image::SSSD, floppy_image::FM,
+		4000, 10, 40, 1, 256, {}, -1, {0, 3, 6, 9, 2, 5, 8, 1, 4, 7}, 40, 16, 11
+	},
+	{ // 17 160K 5 1/4 inch double density
+	},
+	{ // 18 318.5K 5 1/4 inch double density (single density track 0)
+		floppy_image::FF_525, floppy_image::SSSD, floppy_image::FM,
+		4000, 10, 40, 2, 256, {}, -1, {0, 3, 6, 9, 2, 5, 8, 1, 4, 7}, 40, 16, 11
+	},
+	{ // 19 320K 5 1/4 inch double density
+	},
+	{ // 20 318.5K 5 1/4 inch double density (single density track 0)
+		floppy_image::FF_525, floppy_image::SSSD, floppy_image::FM,
+		4000, 10, 80, 1, 256, {}, -1, {0, 3, 6, 9, 2, 5, 8, 1, 4, 7}, 40, 16, 11
+	},
+	{ // 21 320K 5 1/4 inch double density
+	},
+	{ // 22 638.5 5 1/4 inch double density (single density track 0)
+		floppy_image::FF_525, floppy_image::SSSD, floppy_image::FM,
+		4000, 10, 80, 2, 256, {}, -1, {0, 3, 6, 9, 2, 5, 8, 1, 4, 7}, 40, 16, 11
+	},
+	{ // 23 640K 5 1/4 inch double density
+	},
+	{ // 24 155.5K 5 1/4 inch double density (single density track 0)
+		floppy_image::FF_525, floppy_image::SSSD, floppy_image::FM,
+		4000, 10, 35, 1, 256, {}, -1, {0, 3, 6, 9, 2, 5, 8, 1, 4, 7}, 40, 16, 11
+	},
+	{ // 25 157.5K 5 1/4 inch double density
+	},
+	{ // 26 311K 5 1/4 inch double density (single density track 0)
+		floppy_image::FF_525, floppy_image::SSSD, floppy_image::FM,
+		4000, 10, 35, 2, 256, {}, -1, {0, 3, 6, 9, 2, 5, 8, 1, 4, 7}, 40, 16, 11
+	},
+	{ // 27 315K 5 1/4 inch double density
+	},
+	{ // 28 178K 5 1/4 inch double density (single density track 0)
+		floppy_image::FF_525, floppy_image::SSSD, floppy_image::FM,
+		4000, 10, 40, 1, 256, {}, -1, {0, 3, 6, 9, 2, 5, 8, 1, 4, 7}, 40, 16, 11
+	},
+	{ // 29 180K 5 1/4 inch double density
+	},
+	{ // 30 356K 5 1/4 inch double density (single density track 0)
+		floppy_image::FF_525, floppy_image::SSSD, floppy_image::FM,
+		4000, 10, 40, 2, 256, {}, -1, {0, 3, 6, 9, 2, 5, 8, 1, 4, 7}, 40, 16, 11
+	},
+	{ // 31 360K 5 1/4 inch double density
+	},
+	{ // 32 358K 5 1/4 inch quad density (single density track 0)
+		floppy_image::FF_525, floppy_image::SSSD, floppy_image::FM,
+		4000, 10, 80, 1, 256, {}, -1, {0, 3, 6, 9, 2, 5, 8, 1, 4, 7}, 40, 16, 11
+	},
+	{ // 33 360K 5 1/4 inch quad density
+	},
+	{ // 34 716K 5 1/4 inch quad density (single density track 0)
+		floppy_image::FF_525, floppy_image::SSSD, floppy_image::FM,
+		4000, 10, 80, 2, 256, {}, -1, {0, 3, 6, 9, 2, 5, 8, 1, 4, 7}, 40, 16, 11
+	},
+	{ // 35 720K 5 1/4 inch quad density
+	},
+	{ // 36 288.75K 8 inch single density
+	},
+	{ // 37 577.5K 8 inch single density
+	},
+	{ // 38 497.75K 8 inch double density (single density track 0)
+		floppy_image::FF_8, floppy_image::DSSD, floppy_image::FM,
+		2000, 15, 77, 1, 256, {}, -1, {0, 2, 4, 6, 8, 10, 12, 14, 1, 3, 5, 7, 9, 11, 13}, 40, 12, 12
+	},
+	{ // 39 500.5K 8 inch double density
+	},
+	{ // 40 995.5K 8 inch double density (single density track 0)
+		floppy_image::FF_8, floppy_image::DSSD, floppy_image::FM,
+		2000, 15, 77, 2, 256, {}, -1, {0, 2, 4, 6, 8, 10, 12, 14, 1, 3, 5, 7, 9, 11, 13}, 40, 12, 12
+	},
+	{ // 41 1001K 8 inch double density
+	},
+	{ // 42 1440K 3 1/2 inch high density (single density track 0)
+		floppy_image::FF_35,  floppy_image::DSSD, floppy_image::FM,
+		2000, 18, 80, 2, 256, {}, -1, {0, 5, 10, 15, 2, 7, 12, 17, 4, 9, 14, 1, 6, 11, 16, 3, 8, 13}, 40, 12, 12
+	},
+	{ // 43 1440K 3 1/2 inch high density.
 	},
 	{}
 };

--- a/src/lib/formats/os9_dsk.h
+++ b/src/lib/formats/os9_dsk.h
@@ -1,5 +1,5 @@
 // license:BSD-3-Clause
-// copyright-holders:tim lindner
+// copyright-holders:tim lindner, 68bit
 /*********************************************************************
 
     formats/os9_dsk.h
@@ -18,14 +18,16 @@ class os9_format : public wd177x_format {
 public:
 	os9_format();
 
-	virtual int identify(io_generic *io, uint32_t form_factor) override;
-	virtual int find_size(io_generic *io, uint32_t form_factor) override;
 	virtual const char *name() const override;
 	virtual const char *description() const override;
 	virtual const char *extensions() const override;
+	virtual int identify(io_generic *io, uint32_t form_factor) override;
+	virtual int find_size(io_generic *io, uint32_t form_factor) override;
+	virtual const wd177x_format::format &get_track_format(const format &f, int head, int track) override;
 
 private:
 	static const format formats[];
+	static const format formats_track0[];
 };
 
 extern const floppy_format_type FLOPPY_OS9_FORMAT;

--- a/src/lib/formats/wd177x_dsk.h
+++ b/src/lib/formats/wd177x_dsk.h
@@ -48,6 +48,7 @@ protected:
 
 	const format *formats;
 
+	virtual const wd177x_format::format &get_track_format(const format &f, int head, int track);
 	virtual floppy_image_format_t::desc_e* get_desc_fm(const format &f, int &current_size, int &end_gap_index);
 	virtual floppy_image_format_t::desc_e* get_desc_mfm(const format &f, int &current_size, int &end_gap_index);
 	virtual int find_size(io_generic *io, uint32_t form_factor);

--- a/src/tools/floptool.cpp
+++ b/src/tools/floptool.cpp
@@ -56,6 +56,8 @@
 #include "formats/aim_dsk.h"
 #include "formats/m20_dsk.h"
 
+#include "formats/os9_dsk.h"
+
 #include "formats/flex_dsk.h"
 #include "formats/uniflex_dsk.h"
 
@@ -104,6 +106,8 @@ static floppy_format_type floppy_formats[] = {
 	FLOPPY_DVK_MX_FORMAT,
 	FLOPPY_AIM_FORMAT,
 	FLOPPY_M20_FORMAT,
+
+	FLOPPY_OS9_FORMAT,
 
 	FLOPPY_FLEX_FORMAT,
 	FLOPPY_UNIFLEX_FORMAT


### PR DESCRIPTION
Add a get_track_format() method that can be overridden to supply format
variations for any track and head. The code is generalised to account for such
variations. The default method returns the passed format, so this change is
neutral for existing formats.

Simplify the FLEX DSK format code. There are now simply format variation
descriptions for the second track that have the sector ID continuing in
sequence from the first track, rather than specialized code.

Extend the FLEX format to support variations in the sectors ID of the first
two sectors. The FLEX 6800 boot sectors have IDs based at zero rather than
one. Extend the FLEX format to support variations for which the first track,
on both sides, is single density on an otherwise double density disk which was
historically a common format.

Extend the OS9 disk format to support variations for which the first track, on
only the first side, is single density on an otherwise double density
disk. OS9 for the SWTPC and Gimix typically used such formats.

Extend the OS9 disk format to support variations with a base sector ID of zero
in contrast to the existing COCO OS9 format which uses a based sector ID of
one. The OS9 format identification code is extended to rely on the optional
information stored in the OS9 LSN0 header to identify COCO format disks, and
all COCO format disks appear to have this optional information in a regular
enough format.

The FLEX and OS9 improvements are bundled in to show the use case for this change to wd177x_dsk, and to give some examples. It appears likely that some other formats could be simplified to leverage these changes. The approach to extending wd177x_dsk is intended to minimize the changes to other users of that code, and they require no change. Perhaps another pass over this code might abstract it differently, but could we see if this change lands without breaking anything as a first step.

It has been tested on a good range of OS9 disks, COCO, Dragon, Nitros9, SWTPC, Gimix. PRs for the SWTPC OS9 support and fixes for Gimix will follow. The FLEX disk improvements have been tested on SWTPC and Gimix.