### PR TITLE
Gimix: improve IRQs, OS9 improvements, four floppies,

### DIFF
--- a/src/mame/drivers/gimix.cpp
+++ b/src/mame/drivers/gimix.cpp
@@ -1,5 +1,5 @@
 // license:BSD-3-Clause
-// copyright-holders:Barry Rodewald, Robbbert
+// copyright-holders:Barry Rodewald, Robbbert, 68bit
 /*
     Gimix 6809-Based Computers
 
@@ -12,18 +12,18 @@
 
     Information Link:  http://www.backglass.org/duncan/gimix/
 
-    TODO:  Everything
+    TODO: Hard disk support
 
     Usage:
     System boots into GMXBUG-09
     To boot Flex, insert the Flex system disk (3.3 or later, must support the DMA disk controller), type U and press enter.
-    To boot OS-9, insert the OS-9 system disk, type O, and press Enter.
-    Note that booting OS-9 doesn't currently work without a timer hack.
+    To boot OS-9, select ROM version, insert the OS-9 system disk, type O, and press Enter.
 */
 
 #include "emu.h"
 #include "cpu/m6809/m6809.h"
 #include "imagedev/floppy.h"
+#include "machine/input_merger.h"
 #include "machine/mm58167.h"
 #include "machine/6840ptm.h"
 #include "machine/6821pia.h"
@@ -33,8 +33,8 @@
 #include "machine/wd_fdc.h"
 #include "machine/bankdev.h"
 #include "machine/ram.h"
-#include "machine/timer.h"
 #include "formats/flex_dsk.h"
+#include "formats/os9_dsk.h"
 #include "softlist.h"
 
 #define DMA_DRQ         (m_dma_status & 0x80)
@@ -67,9 +67,12 @@ public:
 	gimix_state(const machine_config &mconfig, device_type type, const char *tag)
 		: driver_device(mconfig, type, tag)
 		, m_maincpu(*this, "maincpu")
+		, m_irqs(*this, "irqs")
 		, m_fdc(*this, "fdc")
 		, m_floppy0(*this, "fdc:0")
 		, m_floppy1(*this, "fdc:1")
+		, m_floppy2(*this, "fdc:2")
+		, m_floppy3(*this, "fdc:3")
 		, m_ram(*this, RAM_TAG)
 		, m_rom(*this, "roms")
 		, m_acia1(*this, "acia1")
@@ -85,11 +88,8 @@ public:
 
 	void gimix(machine_config &config);
 
-	DECLARE_INPUT_CHANGED_MEMBER(drive_size_cb);
-
 private:
 	DECLARE_WRITE8_MEMBER(system_w);
-	DECLARE_WRITE_LINE_MEMBER(irq_w);
 	DECLARE_WRITE_LINE_MEMBER(fdc_irq_w);
 	DECLARE_WRITE_LINE_MEMBER(fdc_drq_w);
 	DECLARE_READ8_MEMBER(dma_r);
@@ -100,13 +100,17 @@ private:
 	DECLARE_WRITE8_MEMBER(pia_pa_w);
 	DECLARE_READ8_MEMBER(pia_pb_r);
 	DECLARE_WRITE8_MEMBER(pia_pb_w);
-	TIMER_DEVICE_CALLBACK_MEMBER(test_timer_w);
 
 	DECLARE_FLOPPY_FORMATS(floppy_formats);
 
 	void gimix_banked_mem(address_map &map);
 	void gimix_mem(address_map &map);
 
+	// disassembly override
+	offs_t os9_dasm_override(std::ostream &stream, offs_t pc, const util::disasm_interface::data_buffer &opcodes, const util::disasm_interface::data_buffer &params);
+	offs_t dasm_override(std::ostream &stream, offs_t pc, const util::disasm_interface::data_buffer &opcodes, const util::disasm_interface::data_buffer &params);
+
+	bool m_fpla_sw_latch;
 	uint8_t m_term_data;
 	uint8_t m_dma_status;
 	uint8_t m_dma_ctrl;
@@ -118,6 +122,8 @@ private:
 	uint8_t m_selected_drive;
 	bool m_floppy0_ready;
 	bool m_floppy1_ready;
+	bool m_floppy2_ready;
+	bool m_floppy3_ready;
 
 	uint8_t m_pia1_pa;
 	uint8_t m_pia1_pb;
@@ -129,9 +135,12 @@ private:
 	void refresh_memory();
 
 	required_device<cpu_device> m_maincpu;
+	required_device<input_merger_device> m_irqs;
 	required_device<fd1797_device> m_fdc;
 	required_device<floppy_connector> m_floppy0;
 	required_device<floppy_connector> m_floppy1;
+	required_device<floppy_connector> m_floppy2;
+	required_device<floppy_connector> m_floppy3;
 	required_device<ram_device> m_ram;
 	required_memory_region m_rom;
 	required_device<acia6850_device> m_acia1;
@@ -178,7 +187,7 @@ void gimix_state::gimix_mem(address_map &map)
 
 static INPUT_PORTS_START( gimix )
 	PORT_START("dma_s2")
-	PORT_DIPNAME(0x00000100,0x00000000,"5.25\" / 8\" floppy drive 0") PORT_DIPLOCATION("S2:9") PORT_CHANGED_MEMBER(DEVICE_SELF,gimix_state,drive_size_cb,0)
+	PORT_DIPNAME(0x00000100,0x00000000,"5.25\" / 8\" floppy drive 0") PORT_DIPLOCATION("S2:9")
 	PORT_DIPSETTING(0x00000000,"5.25\"")
 	PORT_DIPSETTING(0x00000100,"8\"")
 
@@ -201,6 +210,7 @@ WRITE8_MEMBER( gimix_state::system_w )
 			m_rombank1->set_entry(2);
 			m_rombank2->set_entry(3);
 			m_fixedrombank->set_entry(2);
+			m_fpla_sw_latch = true;
 			logerror("SYS: FPLA software latch set\n");
 		}
 		else
@@ -208,6 +218,7 @@ WRITE8_MEMBER( gimix_state::system_w )
 			m_rombank1->set_entry(0);
 			m_rombank2->set_entry(1);
 			m_fixedrombank->set_entry(0);
+			m_fpla_sw_latch = false;
 			logerror("SYS: FPLA software latch reset\n");
 		}
 		m_task = data & 0x0f;
@@ -253,24 +264,67 @@ WRITE8_MEMBER(gimix_state::dma_w)
 		m_dma_drive_select = data;
 		m_fdc->dden_w(DMA_DENSITY ? 1 : 0);
 		if(data & 0x40)  // 8" / 5.25" connector select
+		{
+			// 8 inch
 			m_dma_status |= 0x04;
+			m_fdc->set_unscaled_clock(8_MHz_XTAL / 4); // (2MHz)
+		}
 		else
+		{
+			// 5.25 inch
 			m_dma_status &= ~0x04;
+			m_fdc->set_unscaled_clock(8_MHz_XTAL / 8); // (1MHz)
+		}
+
 		if(data & 0x01)
 		{
-			m_fdc->set_floppy(m_floppy0->get_device());
 			m_selected_drive = 1;
-			m_floppy1->get_device()->mon_w(1);  // switch off the motor of other drives...
+			m_fdc->set_floppy(m_floppy0->get_device());
+		}
+		else if(data & 0x02)
+		{
+			m_selected_drive = 2;
+			m_fdc->set_floppy(m_floppy1->get_device());
+		}
+		else if(data & 0x04)
+		{
+			m_selected_drive = 3;
+			m_fdc->set_floppy(m_floppy2->get_device());
+		}
+		else if(data & 0x08)
+		{
+			m_selected_drive = 4;
+			m_fdc->set_floppy(m_floppy3->get_device());
+		}
+		else
+		{
+			m_selected_drive = 0;
+			m_fdc->set_floppy(nullptr);
+		}
+
+		if(m_selected_drive != 1)
+		{
+			m_floppy0->get_device()->mon_w(1);
+			m_floppy0_ready = false;
+			logerror("FDC: Floppy drive 0 motor off\n");
+		}
+		if(m_selected_drive != 2)
+		{
+			m_floppy1->get_device()->mon_w(1);
 			m_floppy1_ready = false;
 			logerror("FDC: Floppy drive 1 motor off\n");
 		}
-		if(data & 0x02)
+		if(m_selected_drive != 3)
 		{
-			m_fdc->set_floppy(m_floppy1->get_device());
-			m_selected_drive = 2;
-			m_floppy0->get_device()->mon_w(1);  // switch off the motor of other drives...
-			m_floppy0_ready = false;
-			logerror("FDC: Floppy drive 0 motor off\n");
+			m_floppy2->get_device()->mon_w(1);
+			m_floppy2_ready = false;
+			logerror("FDC: Floppy drive 2 motor off\n");
+		}
+		if(m_selected_drive != 4)
+		{
+			m_floppy3->get_device()->mon_w(1);
+			m_floppy3_ready = false;
+			logerror("FDC: Floppy drive 3 motor off\n");
 		}
 		break;
 	case 1:
@@ -286,6 +340,10 @@ WRITE8_MEMBER(gimix_state::dma_w)
 				m_floppy0->get_device()->ss_w(1);
 			if(m_selected_drive == 2)
 				m_floppy1->get_device()->ss_w(1);
+			if(m_selected_drive == 3)
+				m_floppy2->get_device()->ss_w(1);
+			if(m_selected_drive == 4)
+				m_floppy3->get_device()->ss_w(1);
 		}
 		else
 		{
@@ -293,7 +351,13 @@ WRITE8_MEMBER(gimix_state::dma_w)
 				m_floppy0->get_device()->ss_w(0);
 			if(m_selected_drive == 2)
 				m_floppy1->get_device()->ss_w(0);
+			if(m_selected_drive == 3)
+				m_floppy2->get_device()->ss_w(0);
+			if(m_selected_drive == 4)
+				m_floppy3->get_device()->ss_w(0);
 		}
+		if((data & 0x80) == 0)
+			m_irqs->in_w<6>(0);
 		break;
 	case 2:
 		logerror("DMA: DMA start address MSB %02x\n",data);
@@ -325,6 +389,18 @@ READ8_MEMBER(gimix_state::fdc_r)
 		m_floppy1_ready = true;
 		logerror("FDC: Floppy drive 1 motor on\n");
 	}
+	if(m_selected_drive == 3 && m_floppy2_ready == false)
+	{
+		m_floppy2->get_device()->mon_w(0);
+		m_floppy2_ready = true;
+		logerror("FDC: Floppy drive 2 motor on\n");
+	}
+	if(m_selected_drive == 4 && m_floppy3_ready == false)
+	{
+		m_floppy3->get_device()->mon_w(0);
+		m_floppy3_ready = true;
+		logerror("FDC: Floppy drive 3 motor on\n");
+	}
 	return m_fdc->read(offset);
 }
 
@@ -335,6 +411,10 @@ WRITE8_MEMBER(gimix_state::fdc_w)
 		m_floppy0->get_device()->mon_w(0);
 	if(m_selected_drive == 2)
 		m_floppy1->get_device()->mon_w(0);
+	if(m_selected_drive == 3)
+		m_floppy2->get_device()->mon_w(0);
+	if(m_selected_drive == 4)
+		m_floppy3->get_device()->mon_w(0);
 	m_fdc->write(offset,data);
 }
 
@@ -361,17 +441,17 @@ WRITE8_MEMBER(gimix_state::pia_pb_w)
 }
 
 
-WRITE_LINE_MEMBER(gimix_state::irq_w)
-{
-	m_maincpu->set_input_line(M6809_IRQ_LINE,state ? ASSERT_LINE : CLEAR_LINE);
-}
-
 WRITE_LINE_MEMBER(gimix_state::fdc_irq_w)
 {
 	if(state)
 		m_dma_status |= 0x40;
 	else
 		m_dma_status &= ~0x40;
+
+	if (DMA_IRQ_ENABLE)
+		m_irqs->in_w<6>(state);
+	else
+		m_irqs->in_w<6>(0);
 }
 
 WRITE_LINE_MEMBER(gimix_state::fdc_drq_w)
@@ -398,27 +478,22 @@ WRITE_LINE_MEMBER(gimix_state::fdc_drq_w)
 		m_dma_status &= ~0x80;
 }
 
-INPUT_CHANGED_MEMBER(gimix_state::drive_size_cb)
-{
-	// set FDC clock based on DIP Switch S2-9 (5.25"/8" drive select)
-	if(m_dma_dip->read() & 0x00000100)
-		m_fdc->set_unscaled_clock(8_MHz_XTAL / 4); // 8 inch (2MHz)
-	else
-		m_fdc->set_unscaled_clock(8_MHz_XTAL / 8); // 5.25 inch (1MHz)
-}
-
 void gimix_state::machine_reset()
 {
 	m_term_data = 0;
 	m_rombank1->set_entry(0);  // RAM banks are undefined on startup
 	m_rombank2->set_entry(1);
 	m_fixedrombank->set_entry(0);
+	m_fpla_sw_latch = false;
 	m_dma_status = 0x00;
 	m_dma_ctrl = 0x00;
+	m_irqs->in_w<6>(0);
 	m_task = 0x00;
 	m_selected_drive = 0;
 	m_floppy0_ready = false;
 	m_floppy1_ready = false;
+	m_floppy2_ready = false;
+	m_floppy3_ready = false;
 	membank("lower_ram")->set_base(m_ram->pointer());
 	if(m_ram->size() > 65536)
 		membank("upper_ram")->set_base(m_ram->pointer()+0x10000);
@@ -439,6 +514,7 @@ void gimix_state::machine_start()
 	m_rombank1->set_entry(0);  // RAM banks are undefined on startup
 	m_rombank2->set_entry(1);
 	m_fixedrombank->set_entry(0);
+	m_fpla_sw_latch = false;
 	// install any extra RAM
 	if(m_ram->size() > 65536)
 	{
@@ -455,24 +531,10 @@ void gimix_state::driver_start()
 {
 }
 
-
-TIMER_DEVICE_CALLBACK_MEMBER(gimix_state::test_timer_w)
-{
-	static bool prev;
-	if(!prev)
-	{
-		m_maincpu->set_input_line(M6809_IRQ_LINE,ASSERT_LINE);
-		prev = true;
-	}
-	else
-	{
-		m_maincpu->set_input_line(M6809_IRQ_LINE,CLEAR_LINE);
-		prev = false;
-	}
-}
-
 FLOPPY_FORMATS_MEMBER( gimix_state::floppy_formats )
-	FLOPPY_FLEX_FORMAT
+	FLOPPY_MFI_FORMAT,
+	FLOPPY_FLEX_FORMAT,
+	FLOPPY_OS9_FORMAT
 FLOPPY_FORMATS_END
 
 static void gimix_floppies(device_slot_interface &device)
@@ -481,27 +543,222 @@ static void gimix_floppies(device_slot_interface &device)
 	device.option_add("8dd", FLOPPY_8_DSDD);
 }
 
+/***************************************************************************
+  DISASSEMBLY OVERRIDE (OS9 syscalls)
+ ***************************************************************************/
+
+static const char *const os9syscalls[] =
+{
+	"F$Link",          // Link to Module
+	"F$Load",          // Load Module from File
+	"F$UnLink",        // Unlink Module
+	"F$Fork",          // Start New Process
+	"F$Wait",          // Wait for Child Process to Die
+	"F$Chain",         // Chain Process to New Module
+	"F$Exit",          // Terminate Process
+	"F$Mem",           // Set Memory Size
+	"F$Send",          // Send Signal to Process
+	"F$Icpt",          // Set Signal Intercept
+	"F$Sleep",         // Suspend Process
+	"F$SSpd",          // Suspend Process
+	"F$ID",            // Return Process ID
+	"F$SPrior",        // Set Process Priority
+	"F$SSWI",          // Set Software Interrupt
+	"F$PErr",          // Print Error
+	"F$PrsNam",        // Parse Pathlist Name
+	"F$CmpNam",        // Compare Two Names
+	"F$SchBit",        // Search Bit Map
+	"F$AllBit",        // Allocate in Bit Map
+	"F$DelBit",        // Deallocate in Bit Map
+	"F$Time",          // Get Current Time
+	"F$STime",         // Set Current Time
+	"F$CRC",           // Generate CRC
+	"F$GPrDsc",        // get Process Descriptor copy
+	"F$GBlkMp",        // get System Block Map copy
+	"F$GModDr",        // get Module Directory copy
+	"F$CpyMem",        // Copy External Memory
+	"F$SUser",         // Set User ID number
+	"F$UnLoad",        // Unlink Module by name
+	"F$Alarm",         // Color Computer Alarm Call (system wide)
+	nullptr,
+	nullptr,
+	nullptr,
+	nullptr,
+	nullptr,
+	nullptr,
+	"F$TPS",           // Return System's Ticks Per Second
+	nullptr,
+	"F$VIRQ",          // Install/Delete Virtual IRQ
+	"F$SRqMem",        // System Memory Request
+	"F$SRtMem",        // System Memory Return
+	"F$IRQ",           // Enter IRQ Polling Table
+	"F$IOQu",          // Enter I/O Queue
+	"F$AProc",         // Enter Active Process Queue
+	"F$NProc",         // Start Next Process
+	"F$VModul",        // Validate Module
+	"F$Find64",        // Find Process/Path Descriptor
+	"F$All64",         // Allocate Process/Path Descriptor
+	"F$Ret64",         // Return Process/Path Descriptor
+	"F$SSvc",          // Service Request Table Initialization
+	"F$IODel",         // Delete I/O Module
+	"F$SLink",         // System Link
+	"F$Boot",          // Bootstrap System
+	"F$BtMem",         // Bootstrap Memory Request
+	"F$GProcP",        // Get Process ptr
+	"F$Move",          // Move Data (low bound first)
+	"F$AllRAM",        // Allocate RAM blocks
+	"F$AllImg",        // Allocate Image RAM blocks
+	"F$DelImg",        // Deallocate Image RAM blocks
+	"F$SetImg",        // Set Process DAT Image
+	"F$FreeLB",        // Get Free Low Block
+	"F$FreeHB",        // Get Free High Block
+	"F$AllTsk",        // Allocate Process Task number
+	"F$DelTsk",        // Deallocate Process Task number
+	"F$SetTsk",        // Set Process Task DAT registers
+	"F$ResTsk",        // Reserve Task number
+	"F$RelTsk",        // Release Task number
+	"F$DATLog",        // Convert DAT Block/Offset to Logical
+	"F$DATTmp",        // Make temporary DAT image (Obsolete)
+	"F$LDAXY",         // Load A [X,[Y]]
+	"F$LDAXYP",        // Load A [X+,[Y]]
+	"F$LDDDXY",        // Load D [D+X,[Y]]
+	"F$LDABX",         // Load A from 0,X in task B
+	"F$STABX",         // Store A at 0,X in task B
+	"F$AllPrc",        // Allocate Process Descriptor
+	"F$DelPrc",        // Deallocate Process Descriptor
+	"F$ELink",         // Link using Module Directory Entry
+	"F$FModul",        // Find Module Directory Entry
+	"F$MapBlk",        // Map Specific Block
+	"F$ClrBlk",        // Clear Specific Block
+	"F$DelRAM",        // Deallocate RAM blocks
+	"F$GCMDir",        // Pack module directory
+	"F$AlHRam",        // Allocate HIGH RAM Blocks
+	nullptr,
+	nullptr,
+	nullptr,
+	nullptr,
+	nullptr,
+	nullptr,
+	nullptr,
+	nullptr,
+	nullptr,
+	nullptr,
+	nullptr,
+	nullptr,
+	nullptr,
+	nullptr,
+	nullptr,
+	nullptr,
+	nullptr,
+	nullptr,
+	nullptr,
+	nullptr,
+	nullptr,
+	nullptr,
+	nullptr,
+	nullptr,
+	nullptr,
+	nullptr,
+	nullptr,
+	nullptr,
+	"F$RegDmp",        // Ron Lammardo's debugging register dump call
+	"F$NVRAM",         // Non Volatile RAM (RTC battery backed static) read/write
+	nullptr,
+	nullptr,
+	nullptr,
+	nullptr,
+	nullptr,
+	nullptr,
+	nullptr,
+	nullptr,
+	nullptr,
+	nullptr,
+	nullptr,
+	nullptr,
+	nullptr,
+	nullptr,
+	"I$Attach",        // Attach I/O Device
+	"I$Detach",        // Detach I/O Device
+	"I$Dup",           // Duplicate Path
+	"I$Create",        // Create New File
+	"I$Open",          // Open Existing File
+	"I$MakDir",        // Make Directory File
+	"I$ChgDir",        // Change Default Directory
+	"I$Delete",        // Delete File
+	"I$Seek",          // Change Current Position
+	"I$Read",          // Read Data
+	"I$Write",         // Write Data
+	"I$ReadLn",        // Read Line of ASCII Data
+	"I$WritLn",        // Write Line of ASCII Data
+	"I$GetStt",        // Get Path Status
+	"I$SetStt",        // Set Path Status
+	"I$Close",         // Close Path
+	"I$DeletX"         // Delete from current exec dir
+};
+
+
+//-------------------------------------------------
+//  os9_dasm_override
+//-------------------------------------------------
+
+offs_t gimix_state::os9_dasm_override(std::ostream &stream, offs_t pc, const util::disasm_interface::data_buffer &opcodes, const util::disasm_interface::data_buffer &params)
+{
+	unsigned call;
+	offs_t result = 0;
+
+	// Microware OS-9 (on the Gimix) and a number of other 6x09 based
+	// systems used the SWI2 instruction for syscalls.  This checks for a
+	// SWI2 and looks up the syscall as appropriate.
+	//
+	// But only apply this override if the OS9 ROMs are latched on.
+	if (!m_fpla_sw_latch)
+		return 0;
+
+	if ((opcodes.r8(pc) == 0x10) && (opcodes.r8(pc+1) == 0x3F))
+	{
+		call = opcodes.r8(pc+2);
+		if ((call < ARRAY_LENGTH(os9syscalls)) && (os9syscalls[call] != nullptr))
+		{
+			util::stream_format(stream, "OS9   %s", os9syscalls[call]);
+			result = 3;
+		}
+	}
+	return result;
+}
+
+
+offs_t gimix_state::dasm_override(std::ostream &stream, offs_t pc, const util::disasm_interface::data_buffer &opcodes, const util::disasm_interface::data_buffer &params)
+{
+	return os9_dasm_override(stream, pc, opcodes, params);
+}
+
 void gimix_state::gimix(machine_config &config)
 {
 	// basic machine hardware
 	MC6809(config, m_maincpu, 8_MHz_XTAL);
 	m_maincpu->set_addrmap(AS_PROGRAM, &gimix_state::gimix_mem);
+	m_maincpu->set_dasm_override(FUNC(gimix_state::dasm_override));
+
+	INPUT_MERGER_ANY_HIGH(config, m_irqs).output_handler().set_inputline(m_maincpu, M6809_IRQ_LINE);
 
 	/* rtc */
 	mm58167_device &rtc(MM58167(config, "rtc", 32.768_kHz_XTAL));
-	rtc.irq().set(FUNC(gimix_state::irq_w));
+	rtc.irq().set(m_irqs, FUNC(input_merger_device::in_w<0>));
 
 	/* timer */
 	ptm6840_device &ptm(PTM6840(config, "timer", 2'000'000));  // clock is a guess
-	ptm.irq_callback().set(FUNC(gimix_state::irq_w));  // PCB pictures show both the RTC and timer set to generate IRQs (are jumper configurable)
+	// PCB pictures show both the RTC and timer set to generate IRQs (are jumper configurable)
+	ptm.irq_callback().set(m_irqs, FUNC(input_merger_device::in_w<1>));
 
 	/* floppy disks */
 	FD1797(config, m_fdc, 8_MHz_XTAL / 4);
 	m_fdc->intrq_wr_callback().set(FUNC(gimix_state::fdc_irq_w));
 	m_fdc->drq_wr_callback().set(FUNC(gimix_state::fdc_drq_w));
 	m_fdc->set_force_ready(true);
-	FLOPPY_CONNECTOR(config, "fdc:0", gimix_floppies, "525hd", gimix_state::floppy_formats);
-	FLOPPY_CONNECTOR(config, "fdc:1", gimix_floppies, "525hd", gimix_state::floppy_formats);
+	FLOPPY_CONNECTOR(config, "fdc:0", gimix_floppies, "525hd", gimix_state::floppy_formats).enable_sound(true);;
+	FLOPPY_CONNECTOR(config, "fdc:1", gimix_floppies, "525hd", gimix_state::floppy_formats).enable_sound(true);;
+	FLOPPY_CONNECTOR(config, "fdc:2", gimix_floppies, "525hd", gimix_state::floppy_formats).enable_sound(true);;
+	FLOPPY_CONNECTOR(config, "fdc:3", gimix_floppies, "525hd", gimix_state::floppy_formats).enable_sound(true);;
 
 	/* parallel ports */
 	pia6821_device &pia1(PIA6821(config, "pia1", 2'000'000));
@@ -516,18 +773,22 @@ void gimix_state::gimix(machine_config &config)
 	ACIA6850(config, m_acia1, 2'000'000);
 	m_acia1->txd_handler().set("serial1", FUNC(rs232_port_device::write_txd));
 	m_acia1->rts_handler().set("serial1", FUNC(rs232_port_device::write_rts));
+	m_acia1->irq_handler().set(m_irqs, FUNC(input_merger_device::in_w<2>));
 
 	ACIA6850(config, m_acia2, 2'000'000);
 	m_acia2->txd_handler().set("serial2", FUNC(rs232_port_device::write_txd));
 	m_acia2->rts_handler().set("serial2", FUNC(rs232_port_device::write_rts));
+	m_acia2->irq_handler().set(m_irqs, FUNC(input_merger_device::in_w<3>));
 
 	ACIA6850(config, m_acia3, 2'000'000);
 	m_acia3->txd_handler().set("serial3", FUNC(rs232_port_device::write_txd));
 	m_acia3->rts_handler().set("serial3", FUNC(rs232_port_device::write_rts));
+	m_acia3->irq_handler().set(m_irqs, FUNC(input_merger_device::in_w<4>));
 
 	ACIA6850(config, m_acia4, 2'000'000);
 	m_acia4->txd_handler().set("serial4", FUNC(rs232_port_device::write_txd));
 	m_acia4->rts_handler().set("serial4", FUNC(rs232_port_device::write_rts));
+	m_acia4->irq_handler().set(m_irqs, FUNC(input_merger_device::in_w<5>));
 
 	rs232_port_device &serial1(RS232_PORT(config, "serial1", default_rs232_devices, nullptr));
 	serial1.rxd_handler().set(m_acia1, FUNC(acia6850_device::write_rxd));
@@ -545,7 +806,7 @@ void gimix_state::gimix(machine_config &config)
 	serial4.rxd_handler().set(m_acia4, FUNC(acia6850_device::write_rxd));
 	serial4.cts_handler().set(m_acia4, FUNC(acia6850_device::write_cts));
 
-	clock_device &acia_clock(CLOCK(config, "acia_clock", 153600));
+	clock_device &acia_clock(CLOCK(config, "acia_clock", 9600 * 16));
 	acia_clock.signal_handler().set(m_acia1, FUNC(acia6850_device::write_txc));
 	acia_clock.signal_handler().append(m_acia1, FUNC(acia6850_device::write_rxc));
 	acia_clock.signal_handler().append(m_acia2, FUNC(acia6850_device::write_txc));
@@ -561,26 +822,28 @@ void gimix_state::gimix(machine_config &config)
 	RAM(config, RAM_TAG).set_default_size("128K").set_extra_options("56K,256K,512K");
 
 	SOFTWARE_LIST(config, "flop_list").set_original("gimix");
-
-	// uncomment this timer to use a hack that generates a regular IRQ, this will get OS-9 to boot
-	// for some unknown reason, OS-9 does not touch the 6840, and only clears/disables IRQs on the RTC
-	//TIMER(config, "test_timer").configure_periodic(FUNC(gimix_state::test_timer_w), attotime::from_msec(100));
 }
 
 ROM_START( gimix )
 	ROM_REGION( 0x10000, "roms", 0)
 /* CPU board U4: gimixf8.bin  - checksum 68DB - 2716 - GMXBUG09 V2.1 | (c)1981 GIMIX | $F800 I2716 */
-		ROM_LOAD( "gimixf8.u4",  0x000000, 0x000800, CRC(7d60f838) SHA1(eb7546e8bbf50d33e181f3e86c3e4c5c9032cab2) )
+	ROM_LOAD( "gimixf8.u4",  0x000000, 0x000800, CRC(7d60f838) SHA1(eb7546e8bbf50d33e181f3e86c3e4c5c9032cab2) )
 /* CPU board U5: gimixv14.bin - checksum 97E2 - 2716 - GIMIX 6809 | AUTOBOOT | V1.4 I2716 */
-		ROM_LOAD( "gimixv14.u5", 0x000800, 0x000800, CRC(f795b8b9) SHA1(eda2de51cc298d94b36605437d900ce971b3b276) )
-/* CPU board U6: os9l1v11.bin - checksum 2C84 - 2716 - OS-9tmL1 V1 | GIMIX P1 " (c)1982 MSC
-   CPU board U7: os9l1v12.bin - checksum 7694 - 2716 - OS-9tmL1 V1 | GIMIX P2-68 | (c)1982 MSC */
-		ROM_LOAD( "os9l1v11.u6", 0x001000, 0x000800, CRC(0d6527a0) SHA1(1435a22581c6e9e0ae338071a72eed646f429530) )
-		ROM_LOAD( "os9l1v12.u7", 0x001800, 0x000800, CRC(b3c65feb) SHA1(19d1ea1e84473b25c95cbb8449e6b9828567e998) )
+	ROM_LOAD( "gimixv14.u5", 0x000800, 0x000800, CRC(f795b8b9) SHA1(eda2de51cc298d94b36605437d900ce971b3b276) )
+
+	ROM_SYSTEM_BIOS(0, "os9l1v11", "OS9 Level 1 version 1.1")
+/* CPU board U6: os9p1-l1v11.bin - checksum 2C84 - 2716 - OS-9tmL1 V1 | GIMIX P1 " (c)1982 MSC
+   CPU board U7: os9p2-l1v11.bin - checksum 7694 - 2716 - OS-9tmL1 V1 | GIMIX P2-68 | (c)1982 MSC */
+	ROMX_LOAD( "os9p1-l1v11.u6", 0x001000, 0x000800, CRC(0d6527a0) SHA1(1435a22581c6e9e0ae338071a72eed646f429530), ROM_BIOS(0))
+	ROMX_LOAD( "os9p2-l1v11.u7", 0x001800, 0x000800, CRC(b3c65feb) SHA1(19d1ea1e84473b25c95cbb8449e6b9828567e998), ROM_BIOS(0))
+
+	ROM_SYSTEM_BIOS(1, "os9l1v12", "OS9 Level 1 version 1.2")
+	ROMX_LOAD( "os9p1-l1v12.u6", 0x001000, 0x000800, CRC(4de6e313) SHA1(b32cbc07418a147fd33a4404a5c2f68c25616c0d), ROM_BIOS(1))
+	ROMX_LOAD( "os9p2-l1v12.u7", 0x001800, 0x000800, CRC(22f5f128) SHA1(8abf5cd2a52c0b8286f717f9ddf7feca61d1f46d), ROM_BIOS(1))
 
 /* Hard drive controller board 2 (XEBEC board) 11H: gimixhd.bin - checksum 2436 - 2732 - 104521D */
 	ROM_REGION( 0x10000, "xebec", 0)
-		ROM_LOAD( "gimixhd.h11",  0x000000, 0x001000, CRC(35c12201) SHA1(51ac9052f9757d79c7f5bd3aa5d8421e98cfcc37) )
+	ROM_LOAD( "gimixhd.h11",  0x000000, 0x001000, CRC(35c12201) SHA1(51ac9052f9757d79c7f5bd3aa5d8421e98cfcc37) )
 ROM_END
 
-COMP( 1980, gimix, 0, 0, gimix, gimix, gimix_state, empty_init, "Gimix", "Gimix 6809 System", MACHINE_IS_SKELETON )
+COMP( 1980, gimix, 0, 0, gimix, gimix, gimix_state, empty_init, "Gimix", "Gimix 6809 System", MACHINE_NO_SOUND_HW )


### PR DESCRIPTION
The FDC clock changes with the programmed connector selection.

The 5.25 versus 8 inch boot floppy jumper is an input and does
not need and input changed handler.

The FDC supports four floppy drives, up from two.

The IRQ line was not implement. Add an input merge device and
connect up more of the IRQs to this. The timer hack is no longer
necessary and has been removed - it was just missing an IRQ.

Add a DASM override for OS9 system calls, copied largely from the
COCO, enabled only when the OS9 ROMs are switched on.

Add a BIOS option for OS9 Level 1 version 1.2.
Renamed the version 1.1 ROMs for consistency.

The Gimix machine appears to be working well enough to promote it
from a 'skeleton' to working.

Found the OS9 L1 V1.2 ROMs and a boot disk at https://www.roug.org/retrocomputing/os/os9/gmx If anyone knows of more Gimix OS9 software then it might be possible to push this emulator OS9 support further - there are some interesting documented features, hard disk support, a hardware CRC card, intelligent serial ports, 64k user space usable in OS9 Level 2, etc