### PR TITLE
flex_dsk: include an identify() method.

### DIFF
--- a/src/lib/formats/flex_dsk.cpp
+++ b/src/lib/formats/flex_dsk.cpp
@@ -71,6 +71,15 @@ const char *flex_format::extensions() const
 	return "dsk";
 }
 
+int flex_format::identify(io_generic *io, uint32_t form_factor)
+{
+	int type = find_size(io, form_factor);
+
+	if (type != -1)
+		return 75;
+	return 0;
+}
+
 int flex_format::find_size(io_generic *io, uint32_t form_factor)
 {
 	uint64_t size = io_generic_size(io);

--- a/src/lib/formats/flex_dsk.h
+++ b/src/lib/formats/flex_dsk.h
@@ -21,6 +21,7 @@ public:
 	virtual const char *name() const override;
 	virtual const char *description() const override;
 	virtual const char *extensions() const override;
+	virtual int identify(io_generic *io, uint32_t form_factor) override;
 	virtual int find_size(io_generic *io, uint32_t form_factor) override;
 	virtual const wd177x_format::format &get_track_format(const format &f, int head, int track) override;
 


### PR DESCRIPTION
It is necessary to return a higher score on success, higher than
returned by the default method, in order for a general 'identify' to
succeed over competitive matches.