### PR TITLE
BIOS selection: only populate the menu with system BIOSes

### DIFF
--- a/src/frontend/mame/ui/miscmenu.cpp
+++ b/src/frontend/mame/ui/miscmenu.cpp
@@ -94,12 +94,18 @@ void menu_bios_selection::populate(float &customtop, float &custombottom)
 		if (rom && !ROMENTRY_ISEND(rom))
 		{
 			const char *val = "default";
+			bool issystem_bios = false;
 			for ( ; !ROMENTRY_ISEND(rom); rom++)
 			{
-				if (ROMENTRY_ISSYSTEM_BIOS(rom) && ROM_GETBIOSFLAGS(rom) == device.system_bios())
-					val = rom->hashdata;
+				if (ROMENTRY_ISSYSTEM_BIOS(rom))
+				{
+					issystem_bios = true;
+					if (ROM_GETBIOSFLAGS(rom) == device.system_bios())
+						val = rom->hashdata;
+				}
 			}
-			item_append(!device.owner() ? "driver" : (device.tag() + 1), val, FLAG_LEFT_ARROW | FLAG_RIGHT_ARROW, (void *)&device);
+			if (issystem_bios)
+				item_append(!device.owner() ? "driver" : (device.tag() + 1), val, FLAG_LEFT_ARROW | FLAG_RIGHT_ARROW, (void *)&device);
 		}
 	}
 


### PR DESCRIPTION
If there are multiple devices in a machine with ROMs and some have BIOSes and
some not then ROMs that are not system BIOSes were being populated in the BIOS
selection menu and this broke the BIOS selection handler.

Perhaps someone should take a look at this suggestion. The bug is real, ROMs without a BIOS selection can be populated in the menu and if selected in the menu it crashes a debug build, but is this the the right fix wrt the selection handler.