### PR TITLE
swtpc09: the OS9 DC5 variant needs a unique id.

### DIFF
--- a/src/mame/machine/swtpc09.cpp
+++ b/src/mame/machine/swtpc09.cpp
@@ -20,7 +20,7 @@
 #define UNIFLEX_DMAF2 2
 #define UNIFLEX_DMAF3 3
 #define FLEX_DC5_PIAIDE 4
-#define OS9_DC5 4
+#define OS9_DC5 5
 
 
 READ8_MEMBER(swtpc09_state::unmapped_r)


### PR DESCRIPTION
Fixes swtpc09i issue noted in https://github.com/mamedev/mame/pull/6282 thanks.