### PR TITLE
wd_fdc: Condition command completion interrupt on busy flag having be…

### DIFF
--- a/src/devices/machine/wd_fdc.cpp
+++ b/src/devices/machine/wd_fdc.cpp
@@ -275,7 +275,7 @@ void wd_fdc_device_base::command_end()
 	main_state = sub_state = IDLE;
 	motor_timeout = 0;
 
-	if (!drq) {
+	if(!drq && (status & S_BUSY)) {
 		status &= ~S_BUSY;
 		intrq = true;
 		if(!intrq_cb.isnull())
@@ -2194,7 +2194,7 @@ void wd_fdc_device_base::drop_drq()
 		drq = false;
 		if(!drq_cb.isnull())
 			drq_cb(false);
-		if (main_state == IDLE) {
+		if(main_state == IDLE && (status & S_BUSY)) {
 			status &= ~S_BUSY;
 			intrq = true;
 			if(!intrq_cb.isnull())


### PR DESCRIPTION
…en set

(nw) The logic for dropping the busy flag and raising INTRQ still seems a bit questionable, but at least the Pied Piper does not like spurious interrupts to occur from these conditions when 0xd0 is in the command register (and the busy flag that indicates that a command is in progress is therefore not set).