### PR TITLE
Finish midqslvr.cpp's documentation (nw)

### DIFF
--- a/src/devices/cpu/mcs51/mcs51.cpp
+++ b/src/devices/cpu/mcs51/mcs51.cpp
@@ -10,6 +10,8 @@
  *   8052 Product Line (8032,8052,8752)
  *   8054 Product Line (8054)
  *   8058 Product Line (8058)
+ *   80552 Product Line (80552, 83552, 87552)
+ *   80562 Product Line (80562, 83562, 87562)
  *
  *   Copyright Steve Ellenoff, all rights reserved.
  *
@@ -87,7 +89,7 @@
  *
  *****************************************************************************/
 
-/* TODO: Varios
+/* TODO: Various
  *  - EA pin - defined by architecture, must implement:
  *    1 means external access, bypassing internal ROM
  *  - T0 output clock ?
@@ -100,6 +102,7 @@
  *      actually use 80CXX, i.e. CMOS versions.
  *      "Normal" 805X will return a 0 if reading from a output port which has
  *      a 0 written to it's latch. At least cardline expects a 1 here.
+ * - ADC support for 80552/80562 (controls analog inputs for Arctic Thunder)
  *
  * Done: (Couriersud)
  * - Merged DS5002FP

--- a/src/mame/drivers/midqslvr.cpp
+++ b/src/mame/drivers/midqslvr.cpp
@@ -45,9 +45,9 @@ Chipsets (VIA Pro133A):
 - VT82C694X Northbridge
 - VT82C686A Southbridge
 
-Note: Not only a beefed up Quicksilver II but acts like a normal PC. You get the normal bios startup, a Windows 2000 startup sequence and
-then the game launcher starts. Another difference is the storage device has a copy protection scheme that "locks" the storage device to the
-motherboard's serial number. If a drive doesn't match the motherboard's serial number, the game launcher will give an error.
+Note: Entirely different motherboard/chipset hardware (most likely needs its own driver). This game's storage device has a 
+copy protection scheme that "locks" the storage device to the motherboard's serial number. If a drive doesn't match the 
+motherboard's serial number, the game launcher will give an error.
 
 I/O boards:
 
@@ -90,9 +90,10 @@ Notes:
     JP10: 9 pin connector for coin meter
     JP11: 2 pin connector for watchdog reset
     JP12: connector for development use, not used
-    JP13-15: connectors, not used
+    JP13-14: connectors, not used
+    JP15: Alternate serial port
     JP16: Power connector
-    P1: DB9 RS-232 port to computer
+    P1: DB9 serial port to computer
     Q2: ULN2064B Darlington Transistor
     S1: Dip Switches (8).
          S1-3: *Off: Game Mode, On: Test Mode
@@ -100,11 +101,11 @@ Notes:
          S1-8: Off: Watchdog Disabled, *On: Watchdog Enabled
     U1: Texas Instruments LS85A Logic Gate
     U2-3: EL244CS Amplifier
-    U4: 109B Instrumentation Amplifier
+    U4: LTC1098 8-bit Serial A/D converter
     U5: PC16550DV UART Interface IC
     U6: Motorola MC74HC273A Octal D Flip-Flop (LS273 based)
     U7: DS14185WM RS-232 Interface IC
-    U8: CY7C63513-PVC 8-bit RISC Microcontroller
+    U8: CY7C63513-PVC 8-bit RISC Microcontroller @12MHz (6MHz OSC)
     U10: Atmel 24C01A Serial EEPROM
     U12: MAX707CSA Supervisory Circuit
     Y2: Crystal/XTAL 6.000 MHz
@@ -157,13 +158,13 @@ Notes:
     JP20: connector for development use, not used
     JP21: 2 pin connector for watchdog reset
     JP22: 9 pin connector for coin meter
-    JP23: Alternate RS232 port
+    JP23: Alternate serial port
     JP24: connector, not used
-    P1: DB9 RS-232 port to computer
+    P1: DB9 serial port to computer
     Q4: ULN2064B Darlington Transistor
     S1: Dip Switches (8)
          S1-7: *Off: UART, On: USB
-         S1-8: Off: Watchdog Disabled, *On: Watchdog Enabled
+         S1-8: *Off: Watchdog Enabled, On: Watchdog Disabled
     S2: Dip Switches (8), all set to "off"
     U1: LS85A Logic Gate
     U2-3: EL244CS Amplifier
@@ -172,14 +173,13 @@ Notes:
     U11: ADC0834 Serial I/O Converter
     U12-15: HC541 Octal Buffer
     U17: Atmel 24C01A Serial EEPROM
-    U18: CY7C63513-PVC 8-bit RISC Microcontroller
+    U18: CY7C63513-PVC 8-bit RISC Microcontroller @12MHz (6MHz OSC)
     U19: DS14185WM RS-232 Interface IC
     U20: PC16550DV UART Interface IC
     U21: Oscilator 3.6864 MHz
     U22: HC04 Hex Inverter
     Y1: Crystal/XTAL 6.000 MHz
 
-(Incomplete)
 MIDWAY GAMES INC.
 SUBSTITUTE MAGICBUS
 5770-16367-02
@@ -223,24 +223,25 @@ Notes:
     JP20: connector for development use, not used
     JP21: 2 pin connector for watchdog reset
     JP22: 9 pin connector for coin meter
-    JP23: Alternate RS232 port
+    JP23: Alternate serial port
     JP24: connector, not used
-    P1: DB9 RS-232 port to computer
+    P1: DB9 serial port to computer
     S1: Dip Switches (8)
     S1: Dip Switches (8)
          S1-7: *Off: UART, On: USB
-         S1-8: Off: Watchdog Disabled, *On: Watchdog Enabled
+         S1-8: *Off: Watchdog Enabled, On: Watchdog Disabled
     S2: Dip Switches (8)
     U4-5: MC74HC273A Octal D Flip-Flop (LS273 based)
-    U6: Not known yet
-    U7/U11: Atmel 24C01A Serial EEPROM
-    U8: MAX707CSA Supervisory Circuit
+    U6: 74HC04D Hex inverter
+    U7: MAX707CSA Supervisory Circuit
+    U8: MAX765CSA Switching Voltage Regulator
+    U11: Atmel 24C01A Serial EEPROM
     U12-19: HC541 Octal Buffer
-    U20: Philips P87C51/2 8-bit Microcontroller
+    U20: 87C552 8-bit Microcontroller (Intel MCS-51 based with a 10-bit A/D converter) @ 16MHz
     U21: DS14185WM RS-232 Interface IC
     U22-24: ULN2064B Darlington Transistor
-    U25: Not known yet
-    Y2: FS14.74 Crystal/Oscilator
+    U25: 74HC367D Hex Buffer/Line Driver
+    Y2: Crystal/XTAL 16.000 MHz
 
 ***************************************************************************/
 
@@ -684,7 +685,7 @@ ROM_START( hydrthnd )
 	ROM_REGION32_LE(0x80000, "bios", 0)
 	ROM_LOAD( "lh28f004sct.u8b1", 0x000000, 0x080000, CRC(ab04a343) SHA1(ba77933400fe470f45ab187bc0d315922caadb12) )
 
-	ROM_REGION( 0x2000, "iocpu", 0 )   /* Diego board CY7C63513-PVC MCU code */
+	ROM_REGION( 0x2000, "iocpu", 0 )   /* Diego board CY7C63513 MCU code */
 	ROM_LOAD( "diego.u8", 0x0000, 0x2000, NO_DUMP ) // 8KB internal EPROM
 
 	DISK_REGION( "ide:0:hdd:image" )
@@ -695,7 +696,7 @@ ROM_START( offrthnd )
 	ROM_REGION32_LE(0x80000, "bios", 0)
 	ROM_LOAD( "lh28f004sct.u8b1", 0x000000, 0x080000, CRC(ab04a343) SHA1(ba77933400fe470f45ab187bc0d315922caadb12) )
 
-	ROM_REGION( 0x2000, "iocpu", 0 )   /* Magicbus board CY7C63513-PVC MCU code */
+	ROM_REGION( 0x2000, "iocpu", 0 )   /* Magicbus board CY7C63513 MCU code */
 	ROM_LOAD( "magicbus.u18", 0x0000, 0x2000, NO_DUMP ) // 8KB internal EPROM
 
 	DISK_REGION( "ide:0:hdd:image" )
@@ -706,8 +707,8 @@ ROM_START( arctthnd )
 	ROM_REGION32_LE(0x80000, "bios", ROMREGION_ERASEFF)
 	ROM_LOAD( "m29f002bt.u6", 0x040000, 0x040000, CRC(012c9290) SHA1(cdee6f19d5e5ea5bb1dd6a5ec397ac70b3452790) )
 
-	ROM_REGION( 0x2000, "iocpu", 0 )   /* Substitute board P87C51/2 MCU code */
-	ROM_LOAD( "substitute.u20", 0x0000, 0x2000, NO_DUMP ) // 8KB internal EPROM
+	ROM_REGION( 0x2000, "iocpu", 0 )   /* Substitute board 87C552 MCU code */
+	ROM_LOAD( "87c552.bin", 0x0000, 0x2000, NO_DUMP ) // 8KB internal EPROM
 
 	DISK_REGION( "ide:0:hdd:image" )
 	DISK_IMAGE( "arctthnd", 0,  SHA1(f4373e57c3f453ac09c735b5d8d99ff811416a23) )
@@ -717,8 +718,8 @@ ROM_START( ultarctc )
 	ROM_REGION32_LE(0x80000, "bios", ROMREGION_ERASEFF)
 	ROM_LOAD( "m29f002bt.u6", 0x040000, 0x040000, CRC(012c9290) SHA1(cdee6f19d5e5ea5bb1dd6a5ec397ac70b3452790) )
 
-	ROM_REGION( 0x2000, "iocpu", 0 )   /* Substitute board P87C51/2 MCU code */
-	ROM_LOAD( "substitute.u20", 0x0000, 0x2000, NO_DUMP ) // 8KB internal EPROM
+	ROM_REGION( 0x2000, "iocpu", 0 )   /* Substitute board 87C552 MCU code */
+	ROM_LOAD( "87c552.bin", 0x0000, 0x2000, NO_DUMP ) // 8KB internal EPROM
 
 	DISK_REGION( "ide:0:hdd:image" )
 	DISK_IMAGE( "uarctict", 0, SHA1(8557a1d7ae8dc41c879350cb1c228f4c27a0dd09) )
@@ -731,8 +732,8 @@ ROM_START( ultarctcup )
 	ROM_REGION32_LE(0x80000, "bios", ROMREGION_ERASEFF)
 	ROM_LOAD( "m29f002bt.u6", 0x040000, 0x040000, CRC(012c9290) SHA1(cdee6f19d5e5ea5bb1dd6a5ec397ac70b3452790) )
 
-	ROM_REGION( 0x2000, "iocpu", 0 )   /* Substitute board P87C51/2 MCU code */
-	ROM_LOAD( "substitute.u20", 0x0000, 0x2000, NO_DUMP ) // 8KB internal EPROM
+	ROM_REGION( 0x2000, "iocpu", 0 )   /* Substitute board 87C552 MCU code */
+	ROM_LOAD( "87c552.bin", 0x0000, 0x2000, NO_DUMP ) // 8KB internal EPROM
 
 	DISK_REGION( "ide:0:hdd:image" )
 	DISK_IMAGE( "uarctict", 0, SHA1(8557a1d7ae8dc41c879350cb1c228f4c27a0dd09) )


### PR DESCRIPTION
U4 component on the Diego board was initially incorrect as "109B" instead of "1098" (A/D converter that obviously controls steering and throttle). Arctic Thunder's I/O cpu turned out to be a 87C552 MCU which uses the same architecture as the predicted 87C51/2; both Intel MCS-51 based. If anyone wants this decapped, I will (most likely) be happy to donate my substitute I/O board though I would hate to waste a fully working pcb.

Just to be sure: http://www.keil.com/dd/docs/datashts/philips/8xc5x2_ov.pdf