### PR TITLE
luaengine: save state to/from binary string buffer

### DIFF
--- a/src/emu/save.h
+++ b/src/emu/save.h
@@ -232,6 +232,9 @@ public:
 	static save_error check_file(running_machine &machine, emu_file &file, const char *gamename, void (CLIB_DECL *errormsg)(const char *fmt, ...));
 	save_error write_file(emu_file &file);
 	save_error read_file(emu_file &file);
+	
+	save_error write_buffer(u8 *data, size_t size);
+	save_error read_buffer(u8 *data, size_t size);
 
 private:
 	// internal helpers

--- a/src/frontend/mame/luaengine.cpp
+++ b/src/frontend/mame/luaengine.cpp
@@ -1280,7 +1280,7 @@ void lua_engine::initialize()
  * machine:save(filename) - save state to filename
  * machine:load(filename) - load state from filename
  * machine:buffer_save() - return save state buffer as binary string
- * machine:buffer_load(str) - load state from binary string buffer. returns true on success
+ * machine:buffer_load(str) - load state from binary string buffer. returns true on success, otherwise nil
  * machine:popmessage(str) - print str as popup
  * machine:popmessage() - clear displayed popup message
  * machine:logerror(str) - print str to log


### PR DESCRIPTION
Dumping all save items in one go is a major pain since they are separated by device and their manipulation is based on name and index, which is unconvenient and slow if I want them all. RAM states use internally kept buffer, so transferring them via lua is also not convenient: it'd take twice the space and twice the time to save them internally and then to copy over to/from lua.

So I made luaengine return savestate buffer as a binary string, with the same contents the file based savestate has, just without compression (like in ram states). I also made it load the savestate from such a string: it's not void pointer, and all the usual checks are there, so it should be safe to manage savestates like that.

This is another step forward for https://github.com/mamedev/mame/issues/2398 (see "Application examples") and if this PR is merged that issue can be closed. @rb6502 wanted this [2 years ago](https://github.com/mamedev/mame/pull/2897#issuecomment-349725144) btw.