### PR TITLE
Apple II update to Feb 23rd - additional note included

### DIFF
--- a/hash/apple2_flop_clcracked.xml
+++ b/hash/apple2_flop_clcracked.xml
@@ -36206,19 +36206,6 @@
 		</part>
 	</software>
 
-	<software name="pickpart">
-		<description>Pick The Part (cleanly cracked)</description>
-		<year>1983</year>
-		<publisher>Sunburst Communications</publisher>
-		<info name="release" value="2020-02-17"/>
-
-		<part name="flop1" interface="floppy_5_25">
-			<dataarea name="flop" size="143360">
-				<rom name="pick the part (4am crack).dsk" size="143360" crc="4ef73c91" sha1="b4900ba310892fc33eb8c6b4bff54f224edf2701" />
-			</dataarea>
-		</part>
-	</software>
-
 	<software name="bldpersp">
 		<description>Building Perspective (cleanly cracked)</description>
 		<year>1986</year>
@@ -36241,6 +36228,19 @@
 		<part name="flop1" interface="floppy_5_25">
 			<dataarea name="flop" size="143360">
 				<rom name="world atlas action - geography facts (4am crack).dsk" size="143360" crc="11dfdc5c" sha1="061e654a08f0503a52402dc6207936884903ae52" />
+			</dataarea>
+		</part>
+	</software>
+
+	<software name="pickpart">
+		<description>Pick The Part (cleanly cracked)</description>
+		<year>1983</year>
+		<publisher>Sunburst Communications</publisher>
+		<info name="release" value="2020-02-17"/>
+
+		<part name="flop1" interface="floppy_5_25">
+			<dataarea name="flop" size="143360">
+				<rom name="pick the part (4am crack).dsk" size="143360" crc="4ef73c91" sha1="b4900ba310892fc33eb8c6b4bff54f224edf2701" />
 			</dataarea>
 		</part>
 	</software>

--- a/hash/apple2_flop_orig.xml
+++ b/hash/apple2_flop_orig.xml
@@ -10401,7 +10401,7 @@
 	</software>
 
 	<software name="advprgkt">
-		<description>Adventure Programming Kit (Versoin 10.84)</description>
+		<description>Adventure Programming Kit (Version 10.84)</description>
 		<year>1984</year>
 		<publisher>Salty Software</publisher>
 		<info name="release" value="2020-01-24"/>
@@ -11104,6 +11104,114 @@
 		<part name="flop1" interface="floppy_5_25">
 			<dataarea name="flop" size="234873">
 				<rom name="generic computer games.woz" size="234873" crc="85d333f6" sha1="eebdbaab826298355df82a3859fa9e33af5fa922" />
+			</dataarea>
+		</part>
+	</software>
+
+	<software name="crscrwmn">
+		<description>The Curse of Crowley Manor</description>
+		<year>1981</year>
+		<publisher>Adventure International</publisher>
+		<info name="release" value="2020-02-22"/>
+		<sharedfeat name="compatibility" value="A2P,A2E,A2EE,A2C,A2GS" />
+		<!-- It requires a 48K Apple ][+ or later. -->
+
+		<part name="flop1" interface="floppy_5_25">
+			<dataarea name="flop" size="234833">
+				<rom name="the curse of crowley manor.woz" size="234833" crc="347d21ee" sha1="1c8eeebb2b48199e4772efda9d7bab0584fd041c" />
+			</dataarea>
+		</part>
+	</software>
+
+	<software name="elysflds">
+		<description>The Elysian Fields and Other Greek Myths</description>
+		<year>1984</year>
+		<publisher>American Eagle</publisher>
+		<info name="release" value="2020-02-21"/>
+		<sharedfeat name="compatibility" value="A2P,A2E,A2EE,A2C,A2GS" />
+		<!-- It requires a 48K Apple ][+ or later. -->
+
+		<part name="flop1" interface="floppy_5_25">
+			<feature name="part_id" value="Side A"/>
+			<dataarea name="flop" size="234803">
+				<rom name="the elysian fields and other greek myths side a.woz" size="234803" crc="ac522a7e" sha1="1f8c406ef352908816b01c92087a19ee7cb98d64" />
+			</dataarea>
+		</part>
+		<part name="flop2" interface="floppy_5_25">
+			<feature name="part_id" value="Side B"/>
+			<dataarea name="flop" size="234803">
+				<rom name="the elysian fields and other greek myths side b.woz" size="234803" crc="b026c686" sha1="d76f1e326bf16d097db8884d8bbca1e00c302d17" />
+			</dataarea>
+		</part>
+	</software>
+
+	<software name="murdmiss">
+		<description>Murder on the Mississippi</description>
+		<year>1986</year>
+		<publisher>Activision</publisher>
+		<info name="release" value="2020-02-21"/>
+		<sharedfeat name="compatibility" value="A2P,A2E,A2EE,A2C,A2GS" />
+		<!-- It requires a 64K Apple ][+ or later. -->
+	
+			<part name="flop1" interface="floppy_5_25">
+			<feature name="part_id" value="Side A"/>
+			<dataarea name="flop" size="234791">
+				<rom name="murder on the mississippi side a.woz" size="234791" crc="5b615fa1" sha1="c6d9bbff02f896b4bdac6dec1adf9bf52ae92cda" />
+			</dataarea>
+		</part>
+		<part name="flop2" interface="floppy_5_25">
+			<feature name="part_id" value="Side B"/>
+			<dataarea name="flop" size="234791">
+				<rom name="murder on the mississippi side b.woz" size="234791" crc="8d1c2ac2" sha1="42e605a010209eb15c7bc033f961f7aaa8b1ddc1" />
+			</dataarea>
+		</part>
+	</software>
+
+	<software name="pmmandmr">
+		<description>Perry Mason: The Case of the Mandarin Murder</description>
+		<year>1985</year>
+		<publisher>Telarium</publisher>
+		<info name="release" value="2020-02-21"/>
+		<sharedfeat name="compatibility" value="A2P,A2E,A2EE,A2C,A2GS" />
+		<!-- It requires a 64K Apple ][+ or later. -->
+
+		<part name="flop1" interface="floppy_5_25">
+			<feature name="part_id" value="Side A"/>
+			<dataarea name="flop" size="234784">
+				<rom name="perry mason- the case of the mandarin murder - side a.woz" size="234784" crc="38f4ce1e" sha1="9c8f7d53099d99efca66a0c37bf571b62c553210" />
+			</dataarea>
+		</part>
+		<part name="flop2" interface="floppy_5_25">
+			<feature name="part_id" value="Side B"/>
+			<dataarea name="flop" size="234784">
+				<rom name="perry mason- the case of the mandarin murder - side b.woz" size="234784" crc="b3f009d0" sha1="5458b42139db7050924c43cfe738264937053827" />
+			</dataarea>
+		</part>
+		<part name="flop3" interface="floppy_5_25">
+			<feature name="part_id" value="Side C"/>
+			<dataarea name="flop" size="234784">
+				<rom name="perry mason- the case of the mandarin murder - side c.woz" size="234784" crc="75b3c942" sha1="42bc543854a5a40165bca57dfd10b1190ec95d5b" />
+			</dataarea>
+		</part>
+		<part name="flop4" interface="floppy_5_25">
+			<feature name="part_id" value="Side D"/>
+			<dataarea name="flop" size="234784">
+				<rom name="perry mason- the case of the mandarin murder - side d.woz" size="234784" crc="8b384f2a" sha1="fac1b3d0b8e720be9febc68b0454ff7fb67778d3" />
+			</dataarea>
+		</part>
+	</software>
+
+	<software name="typetut3">
+		<description>Typing Tutor III with Letter Invaders</description>
+		<year>1984</year>
+		<publisher>Simon &amp; Schuster</publisher>
+		<info name="release" value="2020-02-21"/>
+		<sharedfeat name="compatibility" value="A2E,A2EE,A2C,A2GS" />
+		<!-- It requires a 48K Apple //e or later. -->
+
+		<part name="flop1" interface="floppy_5_25">
+			<dataarea name="flop" size="241496">
+				<rom name="typing tutor iii with letter invaders.woz" size="241496" crc="28f9acbc" sha1="1b80d0d0d6fe4fda09501799b03cc3486851a3b5" />
 			</dataarea>
 		</part>
 	</software>

--- a/hash/apple2_flop_orig.xml
+++ b/hash/apple2_flop_orig.xml
@@ -10583,84 +10583,47 @@
 		</part>
 	</software>
 
-	<software name="tzoner11">
-		<description>Time Zone (Version 1.1)</description>
-		<year>1982</year>
-		<publisher>On-Line Systems</publisher>
-		<info name="release" value="2020-02-08"/>
-		<sharedfeat name="compatibility" value="A2,A2P,A2E,A2EE,A2C,A2GS" />
-		<!-- It runs on any Apple II with 48K. -->
+	<software name="specprpt">
+		<description>Spectrum: Programs and Patterns</description>
+		<year>1984</year>
+		<publisher>Sunburst Communications</publisher>
+		<info name="release" value="2020-02-06"/>
+		<sharedfeat name="compatibility" value="A2fP,A2E,A2EE,A2C,A2GS" />
+		<!-- It requires a 48K Apple ][+ or later. -->
 
 		<part name="flop1" interface="floppy_5_25">
-			<feature name="part_id" value="Disk A"/>
-			<dataarea name="flop" size="234882">
-				<rom name="time zone v1.1 disk a.woz" size="234882" crc="9dd9bcbb" sha1="18ad98f30f49af2fa9f9cae99ad77b4709f21ac4" />
+			<dataarea name="flop" size="234751">
+				<rom name="spectrum- patterns and programs.woz" size="234751" crc="7b5a279a" sha1="f433ecbcbebd17f6d86925ce8c085d49ac4ab164" />
 			</dataarea>
 		</part>
-		<part name="flop2" interface="floppy_5_25">
-			<feature name="part_id" value="Disk B"/>
-			<dataarea name="flop" size="234882">
-				<rom name="time zone v1.1 disk b.woz" size="234882" crc="b0e640d9" sha1="f568d25a10a624937b5c0a7f5a7d285e9706e214" />
+	</software>
+
+	<software name="garftrv">
+		<description>Garfield Trivia Game</description>
+		<year>1989</year>
+		<publisher>Developmental Learning Materials</publisher>
+		<info name="release" value="2020-02-06"/>
+		<sharedfeat name="compatibility" value="A2P,A2E,A2EE,A2C,A2GS" />
+		<!-- It requires a 64K Apple ][+ or later. -->
+
+		<part name="flop1" interface="floppy_5_25">
+			<dataarea name="flop" size="241463">
+				<rom name="garfield trivia game.woz" size="241463" crc="dfb2a731" sha1="7def8dbddb0149d4c74fc5c6a9c53f6db26d9232" />
 			</dataarea>
 		</part>
-		<part name="flop3" interface="floppy_5_25">
-			<feature name="part_id" value="Disk C"/>
-			<dataarea name="flop" size="234882">
-				<rom name="time zone v1.1 disk c.woz" size="234882" crc="f1bc7998" sha1="875c3c74236477c2aefad415b2906490b6c5b134" />
-			</dataarea>
-		</part>
-		<part name="flop4" interface="floppy_5_25">
-			<feature name="part_id" value="Disk D"/>
-			<dataarea name="flop" size="234882">
-				<rom name="time zone v1.1 disk d.woz" size="234882" crc="fe0c102d" sha1="f7cbca00e759c4395baabbcd3b142d487d4785c1" />
-			</dataarea>
-		</part>
-		<part name="flop5" interface="floppy_5_25">
-			<feature name="part_id" value="Disk E"/>
-			<dataarea name="flop" size="234882">
-				<rom name="time zone v1.1 disk e.woz" size="234882" crc="30bc6bde" sha1="12f1badcaddf514ea2ad8adc91134f8a17996122" />
-			</dataarea>
-		</part>
-		<part name="flop6" interface="floppy_5_25">
-			<feature name="part_id" value="Disk F"/>
-			<dataarea name="flop" size="234882">
-				<rom name="time zone v1.1 disk f.woz" size="234882" crc="93963177" sha1="fb4fabaa5ef5f2d2530682ac4a4ddec64b1b2824" />
-			</dataarea>
-		</part>
-		<part name="flop7" interface="floppy_5_25">
-			<feature name="part_id" value="Disk G"/>
-			<dataarea name="flop" size="234882">
-				<rom name="time zone v1.1 disk g.woz" size="234882" crc="3ee201e6" sha1="97006b422e543c845e46c5e85a1f65758c2c146c" />
-			</dataarea>
-		</part>
-		<part name="flop8" interface="floppy_5_25">
-			<feature name="part_id" value="Disk H"/>
-			<dataarea name="flop" size="234882">
-				<rom name="time zone v1.1 disk h.woz" size="234882" crc="efba5ced" sha1="6399284ba922097e794731a70babbd5d91b864bb" />
-			</dataarea>
-		</part>
-		<part name="flop9" interface="floppy_5_25">
-			<feature name="part_id" value="Disk I"/>
-			<dataarea name="flop" size="234882">
-				<rom name="time zone v1.1 disk i.woz" size="234882" crc="57ca6357" sha1="ca7f12495f0c014a6a8395fb36c82ee9f372c0dc" />
-			</dataarea>
-		</part>
-		<part name="flop10" interface="floppy_5_25">
-			<feature name="part_id" value="Disk J"/>
-			<dataarea name="flop" size="234882">
-				<rom name="time zone v1.1 disk j.woz" size="234882" crc="afb5b9d2" sha1="b5323943e5f04f7e773a26a593fdd5697b58ac29" />
-			</dataarea>
-		</part>
-		<part name="flop11" interface="floppy_5_25">
-			<feature name="part_id" value="Disk K"/>
-			<dataarea name="flop" size="234882">
-				<rom name="time zone v1.1 disk k.woz" size="234882" crc="ae166b20" sha1="2901bb34acd69e8c2bceddaa3141b6d7f09403e7" />
-			</dataarea>
-		</part>
-		<part name="flop12" interface="floppy_5_25">
-			<feature name="part_id" value="Disk L"/>
-			<dataarea name="flop" size="234882">
-				<rom name="time zone v1.1 disk l.woz" size="234882" crc="e5521794" sha1="7eb9d72811f682c06cb087ad195900930197746d" />
+	</software>
+
+	<software name="mstrt21">
+		<description>MasterType (Version 2.1)</description>
+		<year>1984</year>
+		<publisher>Scarborough Systems</publisher>
+		<info name="release" value="2020-02-06"/>
+		<sharedfeat name="compatibility" value="A2E,A2EE,A2C,A2GS" />
+		<!-- Due to its use of double hi-res graphics, it requires a 128K Apple //e or later.-->
+
+		<part name="flop1" interface="floppy_5_25">
+			<dataarea name="flop" size="241632">
+				<rom name="mastertype v2.1.woz" size="241632" crc="2e3f25b3" sha1="944ee9e263ce5cceee795ede0dd5d8829d26cb15" />
 			</dataarea>
 		</part>
 	</software>
@@ -10747,91 +10710,262 @@
 		</part>
 	</software>
 
-	<software name="mstrt21">
-		<description>MasterType (Version 2.1)</description>
-		<year>1984</year>
-		<publisher>Scarborough Systems</publisher>
-		<info name="release" value="2020-02-06"/>
-		<sharedfeat name="compatibility" value="A2E,A2EE,A2C,A2GS" />
-		<!-- Due to its use of double hi-res graphics, it requires a 128K Apple //e or later.-->
+	<software name="tzoner11">
+		<description>Time Zone (Version 1.1)</description>
+		<year>1982</year>
+		<publisher>On-Line Systems</publisher>
+		<info name="release" value="2020-02-08"/>
+		<sharedfeat name="compatibility" value="A2,A2P,A2E,A2EE,A2C,A2GS" />
+		<!-- It runs on any Apple II with 48K. -->
 
 		<part name="flop1" interface="floppy_5_25">
-			<dataarea name="flop" size="241632">
-				<rom name="mastertype v2.1.woz" size="241632" crc="2e3f25b3" sha1="944ee9e263ce5cceee795ede0dd5d8829d26cb15" />
+			<feature name="part_id" value="Disk A"/>
+			<dataarea name="flop" size="234882">
+				<rom name="time zone v1.1 disk a.woz" size="234882" crc="9dd9bcbb" sha1="18ad98f30f49af2fa9f9cae99ad77b4709f21ac4" />
+			</dataarea>
+		</part>
+		<part name="flop2" interface="floppy_5_25">
+			<feature name="part_id" value="Disk B"/>
+			<dataarea name="flop" size="234882">
+				<rom name="time zone v1.1 disk b.woz" size="234882" crc="b0e640d9" sha1="f568d25a10a624937b5c0a7f5a7d285e9706e214" />
+			</dataarea>
+		</part>
+		<part name="flop3" interface="floppy_5_25">
+			<feature name="part_id" value="Disk C"/>
+			<dataarea name="flop" size="234882">
+				<rom name="time zone v1.1 disk c.woz" size="234882" crc="f1bc7998" sha1="875c3c74236477c2aefad415b2906490b6c5b134" />
+			</dataarea>
+		</part>
+		<part name="flop4" interface="floppy_5_25">
+			<feature name="part_id" value="Disk D"/>
+			<dataarea name="flop" size="234882">
+				<rom name="time zone v1.1 disk d.woz" size="234882" crc="fe0c102d" sha1="f7cbca00e759c4395baabbcd3b142d487d4785c1" />
+			</dataarea>
+		</part>
+		<part name="flop5" interface="floppy_5_25">
+			<feature name="part_id" value="Disk E"/>
+			<dataarea name="flop" size="234882">
+				<rom name="time zone v1.1 disk e.woz" size="234882" crc="30bc6bde" sha1="12f1badcaddf514ea2ad8adc91134f8a17996122" />
+			</dataarea>
+		</part>
+		<part name="flop6" interface="floppy_5_25">
+			<feature name="part_id" value="Disk F"/>
+			<dataarea name="flop" size="234882">
+				<rom name="time zone v1.1 disk f.woz" size="234882" crc="93963177" sha1="fb4fabaa5ef5f2d2530682ac4a4ddec64b1b2824" />
+			</dataarea>
+		</part>
+		<part name="flop7" interface="floppy_5_25">
+			<feature name="part_id" value="Disk G"/>
+			<dataarea name="flop" size="234882">
+				<rom name="time zone v1.1 disk g.woz" size="234882" crc="3ee201e6" sha1="97006b422e543c845e46c5e85a1f65758c2c146c" />
+			</dataarea>
+		</part>
+		<part name="flop8" interface="floppy_5_25">
+			<feature name="part_id" value="Disk H"/>
+			<dataarea name="flop" size="234882">
+				<rom name="time zone v1.1 disk h.woz" size="234882" crc="efba5ced" sha1="6399284ba922097e794731a70babbd5d91b864bb" />
+			</dataarea>
+		</part>
+		<part name="flop9" interface="floppy_5_25">
+			<feature name="part_id" value="Disk I"/>
+			<dataarea name="flop" size="234882">
+				<rom name="time zone v1.1 disk i.woz" size="234882" crc="57ca6357" sha1="ca7f12495f0c014a6a8395fb36c82ee9f372c0dc" />
+			</dataarea>
+		</part>
+		<part name="flop10" interface="floppy_5_25">
+			<feature name="part_id" value="Disk J"/>
+			<dataarea name="flop" size="234882">
+				<rom name="time zone v1.1 disk j.woz" size="234882" crc="afb5b9d2" sha1="b5323943e5f04f7e773a26a593fdd5697b58ac29" />
+			</dataarea>
+		</part>
+		<part name="flop11" interface="floppy_5_25">
+			<feature name="part_id" value="Disk K"/>
+			<dataarea name="flop" size="234882">
+				<rom name="time zone v1.1 disk k.woz" size="234882" crc="ae166b20" sha1="2901bb34acd69e8c2bceddaa3141b6d7f09403e7" />
+			</dataarea>
+		</part>
+		<part name="flop12" interface="floppy_5_25">
+			<feature name="part_id" value="Disk L"/>
+			<dataarea name="flop" size="234882">
+				<rom name="time zone v1.1 disk l.woz" size="234882" crc="e5521794" sha1="7eb9d72811f682c06cb087ad195900930197746d" />
 			</dataarea>
 		</part>
 	</software>
 
-	<software name="garftrv">
-		<description>Garfield Trivia Game</description>
-		<year>1989</year>
-		<publisher>Developmental Learning Materials</publisher>
-		<info name="release" value="2020-02-06"/>
+	<software name="gencgame">
+		<description>Generic Computer Games</description>
+		<year>1982</year>
+		<publisher>Huntington Computing</publisher>
+		<info name="release" value="2020-02-08"/>
+		<sharedfeat name="compatibility" value="A2P,A2E,A2EE,A2C,A2GS" />
+		<!-- It requires a 48K Apple ][+ or later. -->
+		<!--"Generic Computer Games" is a 1982 pair of action games developed by Kieth Vilt and distributed by Huntington Computing. It requires a 48K Apple ][+ or later.-->
+		<part name="flop1" interface="floppy_5_25">
+			<dataarea name="flop" size="234873">
+				<rom name="generic computer games.woz" size="234873" crc="85d333f6" sha1="eebdbaab826298355df82a3859fa9e33af5fa922" />
+			</dataarea>
+		</part>
+	</software>
+
+	<software name="trisland">
+		<description>Treasure Island</description>
+		<year>1985</year>
+		<publisher>Windham Classics</publisher>
+		<info name="release" value="2020-02-08"/>
 		<sharedfeat name="compatibility" value="A2P,A2E,A2EE,A2C,A2GS" />
 		<!-- It requires a 64K Apple ][+ or later. -->
-
-		<part name="flop1" interface="floppy_5_25">
-			<dataarea name="flop" size="241463">
-				<rom name="garfield trivia game.woz" size="241463" crc="dfb2a731" sha1="7def8dbddb0149d4c74fc5c6a9c53f6db26d9232" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="specprpt">
-		<description>Spectrum: Programs and Patterns</description>
-		<year>1984</year>
-		<publisher>Sunburst Communications</publisher>
-		<info name="release" value="2020-02-06"/>
-		<sharedfeat name="compatibility" value="A2fP,A2E,A2EE,A2C,A2GS" />
-		<!-- It requires a 48K Apple ][+ or later. -->
-
-		<part name="flop1" interface="floppy_5_25">
-			<dataarea name="flop" size="234751">
-				<rom name="spectrum- patterns and programs.woz" size="234751" crc="7b5a279a" sha1="f433ecbcbebd17f6d86925ce8c085d49ac4ab164" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="expamazn">
-		<description>Expedition Amazon</description>
-		<year>1983</year>
-		<publisher>Penguin Software</publisher>
-		<info name="release" value="2020-02-18"/>
-		<sharedfeat name="compatibility" value="A2P,A2E,A2EE,A2C,A2GS" />
-		<!-- It requires a 48K Apple ][+ or later. -->
 
 		<part name="flop1" interface="floppy_5_25">
 			<feature name="part_id" value="Side A"/>
-			<dataarea name="flop" size="235507">
-				<rom name="expedition amazon side a.woz" size="235507" crc="b318d4dd" sha1="bff9901632fd32337cb0e400a9b79328f74c4414" />
+			<dataarea name="flop" size="234852">
+				<rom name="treasure island side a.woz" size="234852" crc="8990c495" sha1="eed208fe2c6fb17a45ae2f522442969d12112d17" />
 			</dataarea>
 		</part>
 		<part name="flop2" interface="floppy_5_25">
-			<feature name="part_id" value="Side B (Boot)"/>
-			<dataarea name="flop" size="235507">
-				<rom name="expedition amazon side b (boot).woz" size="235507" crc="25f68170" sha1="10601a71523d05c46918983176f96364643b1248" />
+			<feature name="part_id" value="Side B"/>
+			<dataarea name="flop" size="234852">
+				<rom name="treasure island side b.woz" size="234852" crc="84e20cf7" sha1="99aeadaf4b420a4d7b25934ba47c4b44845ef2aa" />
+			</dataarea>
+		</part>
+		<part name="flop3" interface="floppy_5_25">
+			<feature name="part_id" value="Side C"/>
+			<dataarea name="flop" size="234852">
+				<rom name="treasure island side c.woz" size="234852" crc="869e455f" sha1="cb83a938e54f1b262c2e49dfcb107566d8f5e60f" />
+			</dataarea>
+		</part>
+		<part name="flop4" interface="floppy_5_25">
+			<feature name="part_id" value="Side D"/>
+			<dataarea name="flop" size="234852">
+				<rom name="treasure island side d.woz" size="234852" crc="96f345f3" sha1="dd2b097d6a48510dc3c1a0f005c218ca40a5ae28" />
 			</dataarea>
 		</part>
 	</software>
 
-	<software name="221bbv11">
-		<description>221B Baker Street (Version 1.1)</description>
-		<year>1986</year>
-		<publisher>Datasoft</publisher>
-		<info name="release" value="2020-02-18"/>
+	<software name="trans1985">
+		<description>Transylvania (1985 Version)</description>
+		<year>1985</year>
+		<publisher>Penguin Software</publisher>
+		<info name="release" value="2020-02-10"/>
 		<sharedfeat name="compatibility" value="A2P,A2E,A2EE,A2C,A2GS" />
 		<!-- It requires a 64K Apple ][+ or later. -->
 
 		<part name="flop1" interface="floppy_5_25">
-			<feature name="part_id" value="Disk 1 - Program disk"/>
-			<dataarea name="flop" size="234878">
-				<rom name="221b baker st. disk 1 - program disk.woz" size="234878" crc="c7776abc" sha1="340a2728d675c5dccd3210b29e5dce1fc4388c65" />
+			<feature name="part_id" value="Side A"/>
+			<dataarea name="flop" size="241472">
+				<rom name="transylvania 1985 side a.woz" size="241472" crc="2c8f80ae" sha1="0fcb96cced72a4fbfb4aaf383313d5c135eb4665" />
 			</dataarea>
 		</part>
 		<part name="flop2" interface="floppy_5_25">
-			<feature name="part_id" value="Disk 2 - Case disk"/>
-			<dataarea name="flop" size="234875">
-				<rom name="221b baker st. disk 2 - case disk.woz" size="234875" crc="6da11041" sha1="deae0f24fe1c50f034520840e7760dd859682bb4" />
+			<feature name="part_id" value="Side B"/>
+			<dataarea name="flop" size="241472">
+				<rom name="transylvania 1985 side b.woz" size="241472" crc="d6c4136f" sha1="3a04c95791f31cc3d2cc6165ac5d194948cbd898" />
+			</dataarea>
+		</part>
+	</software>
+
+	<software name="tmblbugs">
+		<description>Tumble Bugs</description>
+		<year>1982</year>
+		<publisher>Datasoft</publisher>
+		<info name="release" value="2020-02-10"/>
+		<sharedfeat name="compatibility" value="A2,A2P,A2E,A2EE,A2C,A2GS" />
+		<!-- It runs on any Apple II with 48K. -->
+
+		<part name="flop1" interface="floppy_5_25">
+			<dataarea name="flop" size="234781">
+				<rom name="tumble bugs.woz" size="234781" crc="5d25965a" sha1="471e6bddba99ff85cc4945ca1b7dbc46366490d9" />
+			</dataarea>
+		</part>
+	</software>
+
+	<software name="alterego">
+		<description>Alter Ego (male version)</description>
+		<year>1985</year>
+		<publisher>Activision</publisher>
+		<info name="release" value="2020-02-10"/>
+		<sharedfeat name="compatibility" value="A2P,A2E,A2EE,A2C,A2GS" />
+		<!-- It requires a 64K Apple ][+ or later. -->
+
+		<part name="flop1" interface="floppy_5_25">
+			<feature name="part_id" value="Disk 1 Side A"/>
+			<dataarea name="flop" size="241435">
+				<rom name="alter ego - male version - disk 1a.woz" size="241435" crc="1496257d" sha1="86e1caf423475ef4c98f6ac39d2c2be1d6b3258e" />
+			</dataarea>
+		</part>
+		<part name="flop2" interface="floppy_5_25">
+			<feature name="part_id" value="Disk 1 Side B"/>
+			<dataarea name="flop" size="234779">
+				<rom name="alter ego - male version - disk 1b.woz" size="234779" crc="3e75c9e8" sha1="ed4e0fee9d9b277d50adc65b75ddd993d4ae27f0" />
+			</dataarea>
+		</part>
+		<part name="flop3" interface="floppy_5_25">
+			<feature name="part_id" value="Disk 2 Side A"/>
+			<dataarea name="flop" size="241435">
+				<rom name="alter ego - male version - disk 2a.woz" size="241435" crc="e51ed263" sha1="76ed38677d7477d82b70990936c92cb8cf76b9fd" />
+			</dataarea>
+		</part>
+		<part name="flop4" interface="floppy_5_25">
+			<feature name="part_id" value="Disk 2 Side B"/>
+			<dataarea name="flop" size="234779">
+				<rom name="alter ego - male version - disk 2b.woz" size="234779" crc="f32d44ab" sha1="85f83c606b6d166f145a1555698bc3ccc53f6d1c" />
+			</dataarea>
+		</part>
+		<part name="flop5" interface="floppy_5_25">
+			<feature name="part_id" value="Disk 3 Side A"/>
+			<dataarea name="flop" size="241435">
+				<rom name="alter ego - male version - disk 3a.woz" size="241435" crc="4a5ca9d4" sha1="1acad32473a0b5c78aca09ada2824f111e0ff197" />
+			</dataarea>
+		</part>
+		<part name="flop6" interface="floppy_5_25">
+			<feature name="part_id" value="Disk 3 Side B"/>
+			<dataarea name="flop" size="234779">
+				<rom name="alter ego - male version - disk 3b.woz" size="234779" crc="dee58649" sha1="a59ed9d990d7b9d77ee7b468c509e49749987179" />
+			</dataarea>
+		</part>
+	</software>
+
+	<software name="altregof">
+		<description>Alter Ego (female version)</description>
+		<year>1986</year>
+		<publisher>Activision</publisher>
+		<info name="release" value="2020-02-10"/>
+		<sharedfeat name="compatibility" value="A2P,A2E,A2EE,A2C,A2GS" />
+		<!-- It requires a 64K Apple ][+ or later. -->
+
+		<part name="flop1" interface="floppy_5_25">
+			<feature name="part_id" value="Disk 1 Side A"/>
+			<dataarea name="flop" size="241437">
+				<rom name="alter ego - female version - disk 1a.woz" size="241437" crc="a08e8f56" sha1="c90e6087662186c8aa9daa7ef5cef2b67334357a" />
+			</dataarea>
+		</part>
+		<part name="flop2" interface="floppy_5_25">
+			<feature name="part_id" value="Disk 1 Side B"/>
+			<dataarea name="flop" size="234781">
+				<rom name="alter ego - female version - disk 1b.woz" size="234781" crc="ed3d7039" sha1="2b7db817b4fb2ca8c93c0aafdde150aae50eeb1f" />
+			</dataarea>
+		</part>
+		<part name="flop3" interface="floppy_5_25">
+			<feature name="part_id" value="Disk 2 Side A"/>
+			<dataarea name="flop" size="234781">
+				<rom name="alter ego - female version - disk 2a.woz" size="234781" crc="6569875e" sha1="56b830103a45bc14ec9a02dccb3c4de602e59350" />
+			</dataarea>
+		</part>
+		<part name="flop4" interface="floppy_5_25">
+			<feature name="part_id" value="Disk 2 Side B"/>
+			<dataarea name="flop" size="234781">
+				<rom name="alter ego - female version - disk 2b.woz" size="234781" crc="ee0e46c8" sha1="f44263f95a9c0acc1c0dbb6f11719c880cb9dde7" />
+			</dataarea>
+		</part>
+		<part name="flop5" interface="floppy_5_25">
+			<feature name="part_id" value="Disk 3 Side A"/>
+			<dataarea name="flop" size="234781">
+				<rom name="alter ego - female version - disk 3a.woz" size="234781" crc="aa2bcd8c" sha1="a9de65ca9a0fb64c19ae0de44373c6ac066fb45e" />
+			</dataarea>
+		</part>
+		<part name="flop6" interface="floppy_5_25">
+			<feature name="part_id" value="Disk 3 Side B"/>
+			<dataarea name="flop" size="234781">
+				<rom name="alter ego - female version - disk 3b.woz" size="234781" crc="97d5aee3" sha1="f512e4c84f2086f9ac84b567eaf517d0e5047651" />
 			</dataarea>
 		</part>
 	</software>
@@ -10930,239 +11064,61 @@
 		</part>
 	</software>
 
-	<software name="altregof">
-		<description>Alter Ego (female version)</description>
+	<software name="221bbv11">
+		<description>221B Baker Street (Version 1.1)</description>
 		<year>1986</year>
-		<publisher>Activision</publisher>
-		<info name="release" value="2020-02-10"/>
-		<sharedfeat name="compatibility" value="A2P,A2E,A2EE,A2C,A2GS" />
-		<!-- It requires a 64K Apple ][+ or later. -->
-
-		<part name="flop1" interface="floppy_5_25">
-			<feature name="part_id" value="Disk 1 Side A"/>
-			<dataarea name="flop" size="241437">
-				<rom name="alter ego - female version - disk 1a.woz" size="241437" crc="a08e8f56" sha1="c90e6087662186c8aa9daa7ef5cef2b67334357a" />
-			</dataarea>
-		</part>
-		<part name="flop2" interface="floppy_5_25">
-			<feature name="part_id" value="Disk 1 Side B"/>
-			<dataarea name="flop" size="234781">
-				<rom name="alter ego - female version - disk 1b.woz" size="234781" crc="ed3d7039" sha1="2b7db817b4fb2ca8c93c0aafdde150aae50eeb1f" />
-			</dataarea>
-		</part>
-		<part name="flop3" interface="floppy_5_25">
-			<feature name="part_id" value="Disk 2 Side A"/>
-			<dataarea name="flop" size="234781">
-				<rom name="alter ego - female version - disk 2a.woz" size="234781" crc="6569875e" sha1="56b830103a45bc14ec9a02dccb3c4de602e59350" />
-			</dataarea>
-		</part>
-		<part name="flop4" interface="floppy_5_25">
-			<feature name="part_id" value="Disk 2 Side B"/>
-			<dataarea name="flop" size="234781">
-				<rom name="alter ego - female version - disk 2b.woz" size="234781" crc="ee0e46c8" sha1="f44263f95a9c0acc1c0dbb6f11719c880cb9dde7" />
-			</dataarea>
-		</part>
-		<part name="flop5" interface="floppy_5_25">
-			<feature name="part_id" value="Disk 3 Side A"/>
-			<dataarea name="flop" size="234781">
-				<rom name="alter ego - female version - disk 3a.woz" size="234781" crc="aa2bcd8c" sha1="a9de65ca9a0fb64c19ae0de44373c6ac066fb45e" />
-			</dataarea>
-		</part>
-		<part name="flop6" interface="floppy_5_25">
-			<feature name="part_id" value="Disk 3 Side B"/>
-			<dataarea name="flop" size="234781">
-				<rom name="alter ego - female version - disk 3b.woz" size="234781" crc="97d5aee3" sha1="f512e4c84f2086f9ac84b567eaf517d0e5047651" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="alterego">
-		<description>Alter Ego (male version)</description>
-		<year>1985</year>
-		<publisher>Activision</publisher>
-		<info name="release" value="2020-02-10"/>
-		<sharedfeat name="compatibility" value="A2P,A2E,A2EE,A2C,A2GS" />
-		<!-- It requires a 64K Apple ][+ or later. -->
-
-		<part name="flop1" interface="floppy_5_25">
-			<feature name="part_id" value="Disk 1 Side A"/>
-			<dataarea name="flop" size="241435">
-				<rom name="alter ego - male version - disk 1a.woz" size="241435" crc="1496257d" sha1="86e1caf423475ef4c98f6ac39d2c2be1d6b3258e" />
-			</dataarea>
-		</part>
-		<part name="flop2" interface="floppy_5_25">
-			<feature name="part_id" value="Disk 1 Side B"/>
-			<dataarea name="flop" size="234779">
-				<rom name="alter ego - male version - disk 1b.woz" size="234779" crc="3e75c9e8" sha1="ed4e0fee9d9b277d50adc65b75ddd993d4ae27f0" />
-			</dataarea>
-		</part>
-		<part name="flop3" interface="floppy_5_25">
-			<feature name="part_id" value="Disk 2 Side A"/>
-			<dataarea name="flop" size="241435">
-				<rom name="alter ego - male version - disk 2a.woz" size="241435" crc="e51ed263" sha1="76ed38677d7477d82b70990936c92cb8cf76b9fd" />
-			</dataarea>
-		</part>
-		<part name="flop4" interface="floppy_5_25">
-			<feature name="part_id" value="Disk 2 Side B"/>
-			<dataarea name="flop" size="234779">
-				<rom name="alter ego - male version - disk 2b.woz" size="234779" crc="f32d44ab" sha1="85f83c606b6d166f145a1555698bc3ccc53f6d1c" />
-			</dataarea>
-		</part>
-		<part name="flop5" interface="floppy_5_25">
-			<feature name="part_id" value="Disk 3 Side A"/>
-			<dataarea name="flop" size="241435">
-				<rom name="alter ego - male version - disk 3a.woz" size="241435" crc="4a5ca9d4" sha1="1acad32473a0b5c78aca09ada2824f111e0ff197" />
-			</dataarea>
-		</part>
-		<part name="flop6" interface="floppy_5_25">
-			<feature name="part_id" value="Disk 3 Side B"/>
-			<dataarea name="flop" size="234779">
-				<rom name="alter ego - male version - disk 3b.woz" size="234779" crc="dee58649" sha1="a59ed9d990d7b9d77ee7b468c509e49749987179" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="tmblbugs">
-		<description>Tumble Bugs</description>
-		<year>1982</year>
 		<publisher>Datasoft</publisher>
-		<info name="release" value="2020-02-10"/>
-		<sharedfeat name="compatibility" value="A2,A2P,A2E,A2EE,A2C,A2GS" />
-		<!-- It runs on any Apple II with 48K. -->
+		<info name="release" value="2020-02-18"/>
+		<sharedfeat name="compatibility" value="A2P,A2E,A2EE,A2C,A2GS" />
+		<!-- It requires a 64K Apple ][+ or later. -->
 
 		<part name="flop1" interface="floppy_5_25">
-			<dataarea name="flop" size="234781">
-				<rom name="tumble bugs.woz" size="234781" crc="5d25965a" sha1="471e6bddba99ff85cc4945ca1b7dbc46366490d9" />
+			<feature name="part_id" value="Disk 1 - Program disk"/>
+			<dataarea name="flop" size="234878">
+				<rom name="221b baker st. disk 1 - program disk.woz" size="234878" crc="c7776abc" sha1="340a2728d675c5dccd3210b29e5dce1fc4388c65" />
+			</dataarea>
+		</part>
+		<part name="flop2" interface="floppy_5_25">
+			<feature name="part_id" value="Disk 2 - Case disk"/>
+			<dataarea name="flop" size="234875">
+				<rom name="221b baker st. disk 2 - case disk.woz" size="234875" crc="6da11041" sha1="deae0f24fe1c50f034520840e7760dd859682bb4" />
 			</dataarea>
 		</part>
 	</software>
 
-	<software name="trans1985">
-		<description>Transylvania (1985 Version)</description>
-		<year>1985</year>
+	<software name="expamazn">
+		<description>Expedition Amazon</description>
+		<year>1983</year>
 		<publisher>Penguin Software</publisher>
-		<info name="release" value="2020-02-10"/>
-		<sharedfeat name="compatibility" value="A2P,A2E,A2EE,A2C,A2GS" />
-		<!-- It requires a 64K Apple ][+ or later. -->
-
-		<part name="flop1" interface="floppy_5_25">
-			<feature name="part_id" value="Side A"/>
-			<dataarea name="flop" size="241472">
-				<rom name="transylvania 1985 side a.woz" size="241472" crc="2c8f80ae" sha1="0fcb96cced72a4fbfb4aaf383313d5c135eb4665" />
-			</dataarea>
-		</part>
-		<part name="flop2" interface="floppy_5_25">
-			<feature name="part_id" value="Side B"/>
-			<dataarea name="flop" size="241472">
-				<rom name="transylvania 1985 side b.woz" size="241472" crc="d6c4136f" sha1="3a04c95791f31cc3d2cc6165ac5d194948cbd898" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="trisland">
-		<description>Treasure Island</description>
-		<year>1985</year>
-		<publisher>Windham Classics</publisher>
-		<info name="release" value="2020-02-08"/>
-		<sharedfeat name="compatibility" value="A2P,A2E,A2EE,A2C,A2GS" />
-		<!-- It requires a 64K Apple ][+ or later. -->
-
-		<part name="flop1" interface="floppy_5_25">
-			<feature name="part_id" value="Side A"/>
-			<dataarea name="flop" size="234852">
-				<rom name="treasure island side a.woz" size="234852" crc="8990c495" sha1="eed208fe2c6fb17a45ae2f522442969d12112d17" />
-			</dataarea>
-		</part>
-		<part name="flop2" interface="floppy_5_25">
-			<feature name="part_id" value="Side B"/>
-			<dataarea name="flop" size="234852">
-				<rom name="treasure island side b.woz" size="234852" crc="84e20cf7" sha1="99aeadaf4b420a4d7b25934ba47c4b44845ef2aa" />
-			</dataarea>
-		</part>
-		<part name="flop3" interface="floppy_5_25">
-			<feature name="part_id" value="Side C"/>
-			<dataarea name="flop" size="234852">
-				<rom name="treasure island side c.woz" size="234852" crc="869e455f" sha1="cb83a938e54f1b262c2e49dfcb107566d8f5e60f" />
-			</dataarea>
-		</part>
-		<part name="flop4" interface="floppy_5_25">
-			<feature name="part_id" value="Side D"/>
-			<dataarea name="flop" size="234852">
-				<rom name="treasure island side d.woz" size="234852" crc="96f345f3" sha1="dd2b097d6a48510dc3c1a0f005c218ca40a5ae28" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="gencgame">
-		<description>Generic Computer Games</description>
-		<year>1982</year>
-		<publisher>Huntington Computing</publisher>
-		<info name="release" value="2020-02-08"/>
-		<sharedfeat name="compatibility" value="A2P,A2E,A2EE,A2C,A2GS" />
-		<!-- It requires a 48K Apple ][+ or later. -->
-		<!--"Generic Computer Games" is a 1982 pair of action games developed by Kieth Vilt and distributed by Huntington Computing. It requires a 48K Apple ][+ or later.-->
-		<part name="flop1" interface="floppy_5_25">
-			<dataarea name="flop" size="234873">
-				<rom name="generic computer games.woz" size="234873" crc="85d333f6" sha1="eebdbaab826298355df82a3859fa9e33af5fa922" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="crscrwmn">
-		<description>The Curse of Crowley Manor</description>
-		<year>1981</year>
-		<publisher>Adventure International</publisher>
-		<info name="release" value="2020-02-22"/>
+		<info name="release" value="2020-02-18"/>
 		<sharedfeat name="compatibility" value="A2P,A2E,A2EE,A2C,A2GS" />
 		<!-- It requires a 48K Apple ][+ or later. -->
 
 		<part name="flop1" interface="floppy_5_25">
-			<dataarea name="flop" size="234833">
-				<rom name="the curse of crowley manor.woz" size="234833" crc="347d21ee" sha1="1c8eeebb2b48199e4772efda9d7bab0584fd041c" />
+			<feature name="part_id" value="Side A"/>
+			<dataarea name="flop" size="235507">
+				<rom name="expedition amazon side a.woz" size="235507" crc="b318d4dd" sha1="bff9901632fd32337cb0e400a9b79328f74c4414" />
+			</dataarea>
+		</part>
+		<part name="flop2" interface="floppy_5_25">
+			<feature name="part_id" value="Side B (Boot)"/>
+			<dataarea name="flop" size="235507">
+				<rom name="expedition amazon side b (boot).woz" size="235507" crc="25f68170" sha1="10601a71523d05c46918983176f96364643b1248" />
 			</dataarea>
 		</part>
 	</software>
 
-	<software name="elysflds">
-		<description>The Elysian Fields and Other Greek Myths</description>
+	<software name="typetut3">
+		<description>Typing Tutor III with Letter Invaders</description>
 		<year>1984</year>
-		<publisher>American Eagle</publisher>
+		<publisher>Simon &amp; Schuster</publisher>
 		<info name="release" value="2020-02-21"/>
-		<sharedfeat name="compatibility" value="A2P,A2E,A2EE,A2C,A2GS" />
-		<!-- It requires a 48K Apple ][+ or later. -->
+		<sharedfeat name="compatibility" value="A2E,A2EE,A2C,A2GS" />
+		<!-- It requires a 48K Apple //e or later. -->
 
 		<part name="flop1" interface="floppy_5_25">
-			<feature name="part_id" value="Side A"/>
-			<dataarea name="flop" size="234803">
-				<rom name="the elysian fields and other greek myths side a.woz" size="234803" crc="ac522a7e" sha1="1f8c406ef352908816b01c92087a19ee7cb98d64" />
-			</dataarea>
-		</part>
-		<part name="flop2" interface="floppy_5_25">
-			<feature name="part_id" value="Side B"/>
-			<dataarea name="flop" size="234803">
-				<rom name="the elysian fields and other greek myths side b.woz" size="234803" crc="b026c686" sha1="d76f1e326bf16d097db8884d8bbca1e00c302d17" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="murdmiss">
-		<description>Murder on the Mississippi</description>
-		<year>1986</year>
-		<publisher>Activision</publisher>
-		<info name="release" value="2020-02-21"/>
-		<sharedfeat name="compatibility" value="A2P,A2E,A2EE,A2C,A2GS" />
-		<!-- It requires a 64K Apple ][+ or later. -->
-	
-			<part name="flop1" interface="floppy_5_25">
-			<feature name="part_id" value="Side A"/>
-			<dataarea name="flop" size="234791">
-				<rom name="murder on the mississippi side a.woz" size="234791" crc="5b615fa1" sha1="c6d9bbff02f896b4bdac6dec1adf9bf52ae92cda" />
-			</dataarea>
-		</part>
-		<part name="flop2" interface="floppy_5_25">
-			<feature name="part_id" value="Side B"/>
-			<dataarea name="flop" size="234791">
-				<rom name="murder on the mississippi side b.woz" size="234791" crc="8d1c2ac2" sha1="42e605a010209eb15c7bc033f961f7aaa8b1ddc1" />
+			<dataarea name="flop" size="241496">
+				<rom name="typing tutor iii with letter invaders.woz" size="241496" crc="28f9acbc" sha1="1b80d0d0d6fe4fda09501799b03cc3486851a3b5" />
 			</dataarea>
 		</part>
 	</software>
@@ -11201,17 +11157,76 @@
 		</part>
 	</software>
 
-	<software name="typetut3">
-		<description>Typing Tutor III with Letter Invaders</description>
-		<year>1984</year>
-		<publisher>Simon &amp; Schuster</publisher>
+	<software name="murdmiss">
+		<description>Murder on the Mississippi</description>
+		<year>1986</year>
+		<publisher>Activision</publisher>
 		<info name="release" value="2020-02-21"/>
-		<sharedfeat name="compatibility" value="A2E,A2EE,A2C,A2GS" />
-		<!-- It requires a 48K Apple //e or later. -->
+		<sharedfeat name="compatibility" value="A2P,A2E,A2EE,A2C,A2GS" />
+		<!-- It requires a 64K Apple ][+ or later. -->
+	
+			<part name="flop1" interface="floppy_5_25">
+			<feature name="part_id" value="Side A"/>
+			<dataarea name="flop" size="234791">
+				<rom name="murder on the mississippi side a.woz" size="234791" crc="5b615fa1" sha1="c6d9bbff02f896b4bdac6dec1adf9bf52ae92cda" />
+			</dataarea>
+		</part>
+		<part name="flop2" interface="floppy_5_25">
+			<feature name="part_id" value="Side B"/>
+			<dataarea name="flop" size="234791">
+				<rom name="murder on the mississippi side b.woz" size="234791" crc="8d1c2ac2" sha1="42e605a010209eb15c7bc033f961f7aaa8b1ddc1" />
+			</dataarea>
+		</part>
+	</software>
+
+	<software name="elysflds">
+		<description>The Elysian Fields and Other Greek Myths</description>
+		<year>1984</year>
+		<publisher>American Eagle</publisher>
+		<info name="release" value="2020-02-21"/>
+		<sharedfeat name="compatibility" value="A2P,A2E,A2EE,A2C,A2GS" />
+		<!-- It requires a 48K Apple ][+ or later. -->
 
 		<part name="flop1" interface="floppy_5_25">
-			<dataarea name="flop" size="241496">
-				<rom name="typing tutor iii with letter invaders.woz" size="241496" crc="28f9acbc" sha1="1b80d0d0d6fe4fda09501799b03cc3486851a3b5" />
+			<feature name="part_id" value="Side A"/>
+			<dataarea name="flop" size="234803">
+				<rom name="the elysian fields and other greek myths side a.woz" size="234803" crc="ac522a7e" sha1="1f8c406ef352908816b01c92087a19ee7cb98d64" />
+			</dataarea>
+		</part>
+		<part name="flop2" interface="floppy_5_25">
+			<feature name="part_id" value="Side B"/>
+			<dataarea name="flop" size="234803">
+				<rom name="the elysian fields and other greek myths side b.woz" size="234803" crc="b026c686" sha1="d76f1e326bf16d097db8884d8bbca1e00c302d17" />
+			</dataarea>
+		</part>
+	</software>
+
+	<software name="crscrwmn">
+		<description>The Curse of Crowley Manor</description>
+		<year>1981</year>
+		<publisher>Adventure International</publisher>
+		<info name="release" value="2020-02-22"/>
+		<sharedfeat name="compatibility" value="A2P,A2E,A2EE,A2C,A2GS" />
+		<!-- It requires a 48K Apple ][+ or later. -->
+
+		<part name="flop1" interface="floppy_5_25">
+			<dataarea name="flop" size="234833">
+				<rom name="the curse of crowley manor.woz" size="234833" crc="347d21ee" sha1="1c8eeebb2b48199e4772efda9d7bab0584fd041c" />
+			</dataarea>
+		</part>
+	</software>
+
+<software name="croschck">
+		<description>Crosscheck</description>
+		<year>1986</year>
+		<publisher>Datasoft</publisher>
+		<info name="release" value="2020-02-22"/>
+		<sharedfeat name="compatibility" value="A2,A2P,A2E,A2EE,A2C,A2GS"/>
+		<!-- It runs on any Apple II with 48K. -->
+
+		<part name="flop1" interface="floppy_5_25">
+			<dataarea name="flop" size="234798">
+				<rom name="crosscheck.woz" size="234798" crc="222287cd" sha1="83b72c3b27003f0d171b8caea063460029b319f1"/>
 			</dataarea>
 		</part>
 	</software>


### PR DESCRIPTION
Okay, so there's going to be questions about why there's so much addition and removal from the clcracked and orig softlists.

It basically boils down to the fact I forgot that the scripts on this ancient Linux laptop were much older versions that didn't have the "automatically reorder the entries in the correct release order" update. As such, they were in reverse order for each commit, and I want them to remain in release order.

This has been fixed and it won't be happening again.