### PR TITLE
hp80: HP82939 serial I/O module added

### DIFF
--- a/scripts/src/bus.lua
+++ b/scripts/src/bus.lua
@@ -3940,6 +3940,8 @@ if (BUSES["HP80_IO"]~=null) then
 		MAME_DIR .. "src/devices/bus/hp80_io/hp80_io.h",
 		MAME_DIR .. "src/devices/bus/hp80_io/82937.cpp",
 		MAME_DIR .. "src/devices/bus/hp80_io/82937.h",
+		MAME_DIR .. "src/devices/bus/hp80_io/82939.cpp",
+		MAME_DIR .. "src/devices/bus/hp80_io/82939.h",
 	}
 end
 

--- a/src/devices/bus/hp80_io/82939.cpp
+++ b/src/devices/bus/hp80_io/82939.cpp
@@ -1,0 +1,228 @@
+// license:BSD-3-Clause
+// copyright-holders: F. Ulivi
+/*********************************************************************
+
+    82939.cpp
+
+    82939 module (RS232 interface)
+
+    Thanks to Tim Nye & Everett Kaser for dumping the 8049 ROM
+
+    Main reference for this module is:
+    HP 82939-90001, jun 81, HP82939A Serial Interface - Installation
+    and Theory of operation manual
+
+*********************************************************************/
+
+#include "emu.h"
+#include "82939.h"
+#include "coreutil.h"
+
+// Debugging
+#define VERBOSE 0
+#include "logmacro.h"
+
+// Bit manipulation
+namespace {
+	template<typename T> constexpr T BIT_MASK(unsigned n)
+	{
+		return (T)1U << n;
+	}
+
+	template<typename T> void BIT_SET(T& w , unsigned n)
+	{
+		w |= BIT_MASK<T>(n);
+	}
+}
+
+hp82939_io_card_device::hp82939_io_card_device(const machine_config &mconfig, const char *tag, device_t *owner, uint32_t clock)
+	: device_t(mconfig , HP82939_IO_CARD , tag , owner , clock),
+	  device_hp80_io_interface(mconfig, *this),
+	  m_cpu(*this , "cpu"),
+	  m_translator(*this , "xlator"),
+	  m_rs232(*this , "rs232"),
+	  m_uart(*this , "uart"),
+	  m_sw12(*this , "sw12")
+{
+}
+
+hp82939_io_card_device::~hp82939_io_card_device()
+{
+}
+
+void hp82939_io_card_device::install_read_write_handlers(address_space& space , uint16_t base_addr)
+{
+	space.install_readwrite_handler(base_addr, base_addr + 1, read8_delegate(*m_translator, FUNC(hp_1mb5_device::cpu_r)), write8_delegate(*m_translator, FUNC(hp_1mb5_device::cpu_w)));
+}
+
+void hp82939_io_card_device::inten()
+{
+	m_translator->inten();
+}
+
+void hp82939_io_card_device::clear_service()
+{
+	m_translator->clear_service();
+}
+
+static INPUT_PORTS_START(hp82939_port)
+	PORT_HP80_IO_SC(10)
+	PORT_START("sw12")
+	PORT_DIPNAME(0x40 , 0 , "Auto Handshake")
+	PORT_DIPLOCATION("S1:1")
+	PORT_DIPSETTING(0x00 , "Ignore")
+	PORT_DIPSETTING(0x40 , DEF_STR(On))
+	PORT_DIPNAME(0x20 , 0 , "Parity tx")
+	PORT_DIPLOCATION("S2:1")
+	PORT_DIPSETTING(0x00 , DEF_STR(Off))
+	PORT_DIPSETTING(0x20 , DEF_STR(On))
+	PORT_DIPNAME(0x10 , 0 , "Parity")
+	PORT_DIPLOCATION("S2:2")
+	PORT_DIPSETTING(0x00 , "Odd")
+	PORT_DIPSETTING(0x10 , "Even")
+	PORT_DIPNAME(0x08 , 0x08 , "Parity enable")
+	PORT_DIPLOCATION("S2:3")
+	PORT_DIPSETTING(0x00 , DEF_STR(Off))
+	PORT_DIPSETTING(0x08 , DEF_STR(On))
+	PORT_DIPNAME(0x04 , 0 , "Stop bits")
+	PORT_DIPLOCATION("S2:4")
+	PORT_DIPSETTING(0x00 , "1")
+	PORT_DIPSETTING(0x04 , "2")
+	PORT_DIPNAME(0x03 , 0x02 , "Character size")
+	PORT_DIPLOCATION("S2:5,6")
+	PORT_DIPSETTING(0x00 , "5")
+	PORT_DIPSETTING(0x01 , "6")
+	PORT_DIPSETTING(0x02 , "7")
+	PORT_DIPSETTING(0x03 , "8")
+	PORT_DIPNAME(0x780 , 0x300 , "Baud rate")
+	PORT_DIPLOCATION("S2:7,8,9,10")
+	PORT_DIPSETTING(0x000 , "50")
+	PORT_DIPSETTING(0x080 , "75")
+	PORT_DIPSETTING(0x100 , "110")
+	PORT_DIPSETTING(0x180 , "134.5")
+	PORT_DIPSETTING(0x200 , "150")
+	PORT_DIPSETTING(0x280 , "200")
+	PORT_DIPSETTING(0x300 , "300")
+	PORT_DIPSETTING(0x380 , "600")
+	PORT_DIPSETTING(0x400 , "1200")
+	PORT_DIPSETTING(0x480 , "1800")
+	PORT_DIPSETTING(0x500 , "2000")
+	PORT_DIPSETTING(0x580 , "2400")
+	PORT_DIPSETTING(0x600 , "3600")
+	PORT_DIPSETTING(0x680 , "4800")
+	PORT_DIPSETTING(0x700 , "7200")
+	PORT_DIPSETTING(0x780 , "9600")
+INPUT_PORTS_END
+
+ioport_constructor hp82939_io_card_device::device_input_ports() const
+{
+	return INPUT_PORTS_NAME(hp82939_port);
+}
+
+void hp82939_io_card_device::device_start()
+{
+}
+
+ROM_START(hp82939)
+	ROM_REGION(0x800 , "cpu" , 0)
+	ROM_LOAD("1820-2438.bin" , 0 , 0x800 , CRC(3a2f42a2) SHA1(0f6a70eb8981a8a87c7514ce8226ff1af3ac1668))
+ROM_END
+
+READ8_MEMBER(hp82939_io_card_device::p1_r)
+{
+	uint8_t res = uint8_t(m_sw12->read() & 0x7f);
+
+	BIT_SET(res , 7);
+
+	return res;
+}
+
+WRITE8_MEMBER(hp82939_io_card_device::p1_w)
+{
+	if (BIT(data , 7)) {
+		m_uart->reset();
+	}
+}
+
+READ8_MEMBER(hp82939_io_card_device::p2_r)
+{
+	uint8_t res = uint8_t((m_sw12->read() >> 7) & 0xf);
+
+	if (m_rs232->cts_r()) {
+		BIT_SET(res , 4);
+	}
+	if (m_rs232->dsr_r()) {
+		BIT_SET(res , 5);
+	}
+	// RI always reads 1
+	BIT_SET(res , 6);
+	if (m_rs232->dcd_r()) {
+		BIT_SET(res , 7);
+	}
+
+	return res;
+}
+
+READ8_MEMBER(hp82939_io_card_device::cpu_r)
+{
+	if ((offset & 0x82) == 0x00) {
+		return m_translator->uc_r(space , offset & 1 , mem_mask);
+	} else if ((offset & 0x83) == 0x82) {
+		return m_uart->ins8250_r((offset >> 2) & 7);
+	} else {
+		return 0xff;
+	}
+}
+
+WRITE8_MEMBER(hp82939_io_card_device::cpu_w)
+{
+	if ((offset & 0x82) == 0x00) {
+		m_translator->uc_w(space , offset & 1 , data , mem_mask);
+	} else if ((offset & 0x83) == 0x82) {
+		m_uart->ins8250_w((offset >> 2) & 7 , data);
+	}
+}
+
+void hp82939_io_card_device::cpu_io_map(address_map &map)
+{
+	map.unmap_value_high();
+	map(0x00 , 0xff).rw(FUNC(hp82939_io_card_device::cpu_r) , FUNC(hp82939_io_card_device::cpu_w));
+}
+
+const tiny_rom_entry *hp82939_io_card_device::device_rom_region() const
+{
+	return ROM_NAME(hp82939);
+}
+
+void hp82939_io_card_device::device_add_mconfig(machine_config &config)
+{
+	I8049(config, m_cpu, XTAL(5'529'600));
+	m_cpu->set_addrmap(AS_IO, &hp82939_io_card_device::cpu_io_map);
+	m_cpu->t1_in_cb().set("xlator", FUNC(hp_1mb5_device::int_r));
+	m_cpu->set_t0_clk_cb("uart" , FUNC(device_t::set_unscaled_clock_int));
+	m_cpu->p1_in_cb().set(FUNC(hp82939_io_card_device::p1_r));
+	m_cpu->p1_out_cb().set(FUNC(hp82939_io_card_device::p1_w));
+	m_cpu->p2_in_cb().set(FUNC(hp82939_io_card_device::p2_r));
+
+	HP_1MB5(config, m_translator, 0);
+	m_translator->irl_handler().set(FUNC(hp82939_io_card_device::irl_w));
+	m_translator->halt_handler().set(FUNC(hp82939_io_card_device::halt_w));
+	m_translator->reset_handler().set_inputline(m_cpu , INPUT_LINE_RESET);
+
+	RS232_PORT(config, m_rs232, default_rs232_devices, nullptr);
+
+	INS8250(config , m_uart , 0);
+	m_uart->out_int_callback().set_inputline(m_cpu , MCS48_INPUT_IRQ);
+	m_uart->out_tx_callback().set(m_rs232 , FUNC(rs232_port_device::write_txd));
+	m_uart->out_dtr_callback().set(m_rs232 , FUNC(rs232_port_device::write_dtr));
+	m_uart->out_rts_callback().set(m_rs232 , FUNC(rs232_port_device::write_rts));
+	m_uart->out_out1_callback().set(m_rs232 , FUNC(rs232_port_device::write_spds));
+
+	m_rs232->rxd_handler().set(m_uart , FUNC(ins8250_device::rx_w));
+	m_rs232->dcd_handler().set(m_uart , FUNC(ins8250_device::dcd_w));
+	m_rs232->dsr_handler().set(m_uart , FUNC(ins8250_device::dsr_w));
+	m_rs232->cts_handler().set(m_uart , FUNC(ins8250_device::cts_w));
+}
+
+// device type definition
+DEFINE_DEVICE_TYPE(HP82939_IO_CARD, hp82939_io_card_device, "hp82939", "HP82939 card")

--- a/src/devices/bus/hp80_io/82939.h
+++ b/src/devices/bus/hp80_io/82939.h
@@ -1,0 +1,60 @@
+// license:BSD-3-Clause
+// copyright-holders: F. Ulivi
+/*********************************************************************
+
+    82939.h
+
+    82939 module (RS232 interface)
+
+*********************************************************************/
+
+#ifndef MAME_BUS_HP80_IO_82939_H
+#define MAME_BUS_HP80_IO_82939_H
+
+#pragma once
+
+#include "hp80_io.h"
+#include "cpu/mcs48/mcs48.h"
+#include "machine/1mb5.h"
+#include "machine/ins8250.h"
+#include "bus/rs232/rs232.h"
+
+class hp82939_io_card_device : public device_t, public device_hp80_io_interface
+{
+public:
+	// construction/destruction
+	hp82939_io_card_device(const machine_config &mconfig, const char *tag, device_t *owner, uint32_t clock);
+	virtual ~hp82939_io_card_device();
+
+protected:
+	virtual void device_start() override;
+
+	// device-level overrides
+	virtual ioport_constructor device_input_ports() const override;
+	virtual const tiny_rom_entry *device_rom_region() const override;
+	virtual void device_add_mconfig(machine_config &config) override;
+
+	virtual void install_read_write_handlers(address_space& space , uint16_t base_addr) override;
+
+	virtual void inten() override;
+	virtual void clear_service() override;
+
+private:
+	required_device<i8049_device> m_cpu;
+	required_device<hp_1mb5_device> m_translator;
+	required_device<rs232_port_device> m_rs232;
+	required_device<ins8250_device> m_uart;
+	required_ioport m_sw12;
+
+	DECLARE_READ8_MEMBER(p1_r);
+	DECLARE_WRITE8_MEMBER(p1_w);
+	DECLARE_READ8_MEMBER(p2_r);
+	DECLARE_READ8_MEMBER(cpu_r);
+	DECLARE_WRITE8_MEMBER(cpu_w);
+	void cpu_io_map(address_map &map);
+};
+
+// device type definition
+DECLARE_DEVICE_TYPE(HP82939_IO_CARD, hp82939_io_card_device)
+
+#endif // MAME_BUS_HP80_IO_82939_H

--- a/src/devices/bus/hp80_io/hp80_io.cpp
+++ b/src/devices/bus/hp80_io/hp80_io.cpp
@@ -143,8 +143,10 @@ WRITE_LINE_MEMBER(device_hp80_io_interface::halt_w)
 }
 
 #include "82937.h"
+#include "82939.h"
 
 void hp80_io_slot_devices(device_slot_interface &device)
 {
 	device.option_add("82937_hpib" , HP82937_IO_CARD);
+	device.option_add("82939_serial" , HP82939_IO_CARD);
 }

--- a/src/devices/machine/1mb5.cpp
+++ b/src/devices/machine/1mb5.cpp
@@ -77,8 +77,6 @@ READ8_MEMBER(hp_1mb5_device::cpu_r)
 		// Read IB
 		res = m_ib;
 		if (m_ibf) {
-			machine().scheduler().boost_interleave(attotime::from_usec(50) , attotime::from_usec(100));
-			space.device().execute().spin();
 			m_ibf = false;
 			update_halt();
 		}
@@ -92,14 +90,13 @@ READ8_MEMBER(hp_1mb5_device::cpu_r)
 WRITE8_MEMBER(hp_1mb5_device::cpu_w)
 {
 	LOG("WR %u=%02x\n" , offset , data);
-	bool need_resched = false;
 
 	switch (offset) {
 	case 0:
 		// Write CR
 		m_cr = data;
-		need_resched |= set_reset(BIT(m_cr , 7));
-		need_resched |= set_int(!BIT(m_cr , 0));
+		set_reset(BIT(m_cr , 7));
+		set_int(!BIT(m_cr , 0));
 		break;
 
 	case 1:
@@ -109,17 +106,11 @@ WRITE8_MEMBER(hp_1mb5_device::cpu_w)
 		update_halt();
 		break;
 	}
-	if (need_resched) {
-		LOG("resched %s\n" , space.device().tag());
-		machine().scheduler().boost_interleave(attotime::from_usec(5) , attotime::from_usec(100));
-		space.device().execute().spin();
-	}
 }
 
 READ8_MEMBER(hp_1mb5_device::uc_r)
 {
 	uint8_t res = 0;
-	bool need_resched = false;
 
 	switch (offset) {
 	case 0:
@@ -137,14 +128,10 @@ READ8_MEMBER(hp_1mb5_device::uc_r)
 		// Read OB
 		res = m_ob;
 		m_obf = false;
-		need_resched |= update_halt();
+		update_halt();
 		break;
 	}
 
-	if (need_resched) {
-		LOG("resched %s\n" , space.device().tag());
-		space.device().execute().spin();
-	}
 	//LOG("RDU %u=%02x\n" , offset , res);
 	return res;
 }
@@ -152,31 +139,24 @@ READ8_MEMBER(hp_1mb5_device::uc_r)
 WRITE8_MEMBER(hp_1mb5_device::uc_w)
 {
 	//LOG("WRU %u=%02x SR=%02x\n" , offset , data , m_sr);
-	bool need_resched = false;
 
 	switch (offset) {
 	case 0:
 		// Write SR
 		if (!BIT(m_sr , 0) && BIT(data , 0)) {
-			need_resched |= set_service(true);
+			set_service(true);
 		}
 		m_sr = data;
 		m_hlten = BIT(m_sr , 7);
-		if (update_halt() && !m_halt) {
-			need_resched = true;
-		}
+		update_halt();
 		break;
 
 	case 1:
 		// Write IB
 		m_ib = data;
 		m_ibf = true;
-		need_resched |= update_halt();
+		update_halt();
 		break;
-	}
-	if (need_resched) {
-		LOG("resched %s\n" , space.device().tag());
-		space.device().execute().spin();
 	}
 }
 
@@ -251,50 +231,38 @@ void hp_1mb5_device::device_reset()
 	m_int_handler(true);
 }
 
-bool hp_1mb5_device::set_service(bool new_service)
+void hp_1mb5_device::set_service(bool new_service)
 {
 	if (new_service != m_service) {
 		m_service = new_service;
 		LOG("irl=%d\n" , m_service);
 		m_irl_handler(m_service);
-		return true;
-	} else {
-		return false;
 	}
 }
 
-bool hp_1mb5_device::update_halt()
+void hp_1mb5_device::update_halt()
 {
 	bool new_halt = m_hlten && m_obf && !m_ibf;
 	if (new_halt != m_halt) {
 		LOG("HALT=%d\n" , new_halt);
 		m_halt = new_halt;
 		m_halt_handler(m_halt);
-		return true;
-	} else {
-		return false;
 	}
 }
 
-bool hp_1mb5_device::set_reset(bool new_reset)
+void hp_1mb5_device::set_reset(bool new_reset)
 {
 	if (new_reset != m_reset) {
 		m_reset = new_reset;
 		m_reset_handler(m_reset);
-		return true;
-	} else {
-		return false;
 	}
 }
 
-bool hp_1mb5_device::set_int(bool new_int)
+void hp_1mb5_device::set_int(bool new_int)
 {
 	if (new_int != m_cint) {
 		m_cint = new_int;
 		LOG("cint=%d\n" , m_cint);
 		m_int_handler(m_cint);
-		return true;
-	} else {
-		return false;
 	}
 }

--- a/src/devices/machine/1mb5.h
+++ b/src/devices/machine/1mb5.h
@@ -71,10 +71,10 @@ private:
 	bool m_reset;
 	bool m_halt;
 
-	bool set_service(bool new_service);
-	bool update_halt();
-	bool set_reset(bool new_reset);
-	bool set_int(bool new_int);
+	void set_service(bool new_service);
+	void update_halt();
+	void set_reset(bool new_reset);
+	void set_int(bool new_int);
 };
 
 // device type definition

--- a/src/mame/drivers/hp80.cpp
+++ b/src/mame/drivers/hp80.cpp
@@ -125,6 +125,7 @@ protected:
 	virtual void rombank_mem_map(address_map &map);
 	virtual void unmap_optroms(address_space &space);
 
+	virtual void machine_start() override;
 	virtual void machine_reset() override;
 
 	IRQ_CALLBACK_MEMBER(irq_callback);
@@ -164,8 +165,9 @@ protected:
 
 	bool m_global_int_en;
 	uint16_t m_int_serv;
-	unsigned m_top_pending;
 	uint16_t m_int_acked;
+	unsigned m_top_acked;
+	unsigned m_top_pending;
 	uint16_t m_int_en;
 	uint8_t m_halt_lines;
 
@@ -192,6 +194,8 @@ protected:
 
 	void irq_w(unsigned n_irq , bool state);
 	void irq_en_w(unsigned n_irq , bool state);
+	void release_irq(unsigned n_irq);
+	static unsigned get_top_irq(uint16_t irqs);
 	void update_int_bits();
 	void update_irl();
 };
@@ -274,11 +278,28 @@ void hp80_base_state::unmap_optroms(address_space &space)
 {
 }
 
+void hp80_base_state::machine_start()
+{
+	save_item(NAME(m_global_int_en));
+	save_item(NAME(m_int_serv));
+	save_item(NAME(m_int_acked));
+	save_item(NAME(m_top_acked));
+	save_item(NAME(m_top_pending));
+	save_item(NAME(m_int_en));
+	save_item(NAME(m_halt_lines));
+	save_pointer(NAME(m_kb_state) , 3);
+	save_item(NAME(m_kb_enable));
+	save_item(NAME(m_kb_pressed));
+	save_item(NAME(m_kb_flipped));
+	save_item(NAME(m_kb_keycode));
+}
+
 void hp80_base_state::machine_reset()
 {
 	m_int_serv = 0;
-	m_top_pending = NO_IRQ;
 	m_int_acked = 0;
+	m_top_acked = NO_IRQ;
+	m_top_pending = NO_IRQ;
 	m_int_en = 0;
 	m_global_int_en = false;
 	m_kb_state[ 0 ] = 0;
@@ -336,8 +357,9 @@ static const uint8_t vector_table[] = {
 
 IRQ_CALLBACK_MEMBER(hp80_base_state::irq_callback)
 {
-	LOG_IRQ("IRQ ACK %u\n" , m_top_pending);
+	LOG_IRQ("IRQ ACK %u %u\n" , m_top_pending , m_top_acked);
 	BIT_SET(m_int_acked , m_top_pending);
+	m_top_acked = m_top_pending;
 	if (m_top_pending > IRQ_IOP0_BIT && m_top_pending < IRQ_BIT_COUNT) {
 		// Interrupts are disabled in all I/O translators of higher priority than
 		// the one being serviced
@@ -351,12 +373,14 @@ IRQ_CALLBACK_MEMBER(hp80_base_state::irq_callback)
 
 WRITE8_MEMBER(hp80_base_state::ginten_w)
 {
+	LOG_IRQ("GINTEN\n");
 	m_global_int_en = true;
 	update_irl();
 }
 
 WRITE8_MEMBER(hp80_base_state::gintdis_w)
 {
+	LOG_IRQ("GINTDIS\n");
 	m_global_int_en = false;
 	update_irl();
 }
@@ -406,6 +430,7 @@ WRITE8_MEMBER(hp80_base_state::keycod_w)
 	if (data == 1) {
 		irq_w(IRQ_KEYBOARD_BIT , false);
 		m_kb_enable = true;
+		release_irq(IRQ_KEYBOARD_BIT);
 	} else {
 		LOG("Funny write to keycod=%02x\n" , data);
 	}
@@ -461,9 +486,10 @@ WRITE8_MEMBER(hp80_base_state::clksts_w)
 		}
 		if (BIT(data , 5)) {
 			// Clear timer irq
-			irq_w(IRQ_TIMER0_BIT + m_timer_idx , false);
+			unsigned irq_n = IRQ_TIMER0_BIT + m_timer_idx;
+			irq_w(irq_n , false);
+			release_irq(irq_n);
 		}
-		update_int_bits();
 	}
 }
 
@@ -499,8 +525,11 @@ WRITE8_MEMBER(hp80_base_state::rselec_w)
 
 READ8_MEMBER(hp80_base_state::intrsc_r)
 {
-	if (m_top_pending >= IRQ_IOP0_BIT && m_top_pending < IRQ_BIT_COUNT && BIT(m_int_acked , m_top_pending)) {
-		return (uint8_t)m_io_slots[ m_top_pending - IRQ_IOP0_BIT ]->get_base_addr();
+	if (m_top_acked >= IRQ_IOP0_BIT && m_top_acked < IRQ_BIT_COUNT) {
+		LOG_IRQ("INTRSC %u\n" , m_top_acked);
+		// Clear interrupt request in the slot being serviced
+		m_io_slots[ m_top_acked - IRQ_IOP0_BIT ]->clear_service();
+		return (uint8_t)m_io_slots[ m_top_acked - IRQ_IOP0_BIT ]->get_base_addr();
 	} else {
 		// Probably..
 		return 0xff;
@@ -509,16 +538,15 @@ READ8_MEMBER(hp80_base_state::intrsc_r)
 
 WRITE8_MEMBER(hp80_base_state::intrsc_w)
 {
-	if (m_top_pending >= IRQ_IOP0_BIT && m_top_pending < IRQ_BIT_COUNT && BIT(m_int_acked , m_top_pending)) {
-		// Clear interrupt request in the slot being serviced
-		m_io_slots[ m_top_pending - IRQ_IOP0_BIT ]->clear_service();
-	}
+	LOG_IRQ("INTRSC W %u %03x %03x %03x\n" , m_top_acked , m_int_serv , m_int_en , m_int_acked);
 	for (auto& iop: m_io_slots) {
 		iop->inten();
 	}
 	for (unsigned i = IRQ_IOP0_BIT; i < (IRQ_IOP0_BIT + IOP_COUNT); i++) {
 		irq_en_w(i , true);
 	}
+	m_int_acked &= ~(((1U << IOP_COUNT) - 1) << IRQ_IOP0_BIT);
+	update_int_bits();
 }
 
 // Outer index: key position [0..79] = r * 8 + c
@@ -780,35 +808,44 @@ WRITE8_MEMBER(hp80_base_state::halt_w)
 
 void hp80_base_state::irq_w(unsigned n_irq , bool state)
 {
-	if (state && !BIT(m_int_serv , n_irq)) {
-		// Set service request
-		BIT_SET(m_int_serv , n_irq);
-		BIT_CLR(m_int_acked , n_irq);
-	} else if (!state && BIT(m_int_serv , n_irq)) {
-		// Clear service request
-		BIT_CLR(m_int_serv , n_irq);
-		BIT_CLR(m_int_acked , n_irq);
-	}
+	LOG_IRQ("IRQ_W %u %d\n" , n_irq , state);
+	COPY_BIT(state , m_int_serv , n_irq);
 	update_int_bits();
 }
 
 void hp80_base_state::irq_en_w(unsigned n_irq , bool state)
 {
+	LOG_IRQ("IRQ_EN_W %u %d\n" , n_irq , state);
 	COPY_BIT(state , m_int_en , n_irq);
 	update_int_bits();
 }
 
+void hp80_base_state::release_irq(unsigned n_irq)
+{
+	if (BIT(m_int_acked , n_irq)) {
+		BIT_CLR(m_int_acked , n_irq);
+		update_int_bits();
+	}
+}
+
+unsigned hp80_base_state::get_top_irq(uint16_t irqs)
+{
+	unsigned top;
+	for (top = 0; top < IRQ_BIT_COUNT && !BIT(irqs , 0); top++ , irqs >>= 1) {
+	}
+	return top;
+}
+
 void hp80_base_state::update_int_bits()
 {
-	uint16_t irqs = m_int_en & m_int_serv;
-	for (m_top_pending = 0; m_top_pending < IRQ_BIT_COUNT && !BIT(irqs , m_top_pending); m_top_pending++) {
-	}
+	m_top_pending = get_top_irq(m_int_en & m_int_serv);
+	m_top_acked = get_top_irq(m_int_acked);
 	update_irl();
 }
 
 void hp80_base_state::update_irl()
 {
-	m_cpu->set_input_line(0 , m_global_int_en && m_top_pending < IRQ_BIT_COUNT && !BIT(m_int_acked , m_top_pending));
+	m_cpu->set_input_line(0 , m_global_int_en && m_top_pending < m_top_acked);
 }
 
 // ************
@@ -955,6 +992,7 @@ hp85_state::hp85_state(const machine_config &mconfig, device_type type, const ch
 
 void hp85_state::machine_start()
 {
+	hp80_base_state::machine_start();
 	m_screen->register_screen_bitmap(m_bitmap);
 	m_video_mem.resize(VIDEO_MEM_SIZE);
 }
@@ -1654,6 +1692,8 @@ void hp86_state::hp86(machine_config &config)
 
 void hp86_state::machine_start()
 {
+	hp80_base_state::machine_start();
+
 	m_run_light.resolve();
 
 	m_screen->register_screen_bitmap(m_bitmap);

--- a/src/mame/drivers/hp80.cpp
+++ b/src/mame/drivers/hp80.cpp
@@ -221,6 +221,7 @@ void hp80_base_state::hp80_base(machine_config &config)
 	HP_CAPRICORN(config, m_cpu, CPU_CLOCK);
 	m_cpu->set_addrmap(AS_PROGRAM, &hp80_base_state::cpu_mem_map);
 	m_cpu->set_irq_acknowledge_callback(FUNC(hp80_base_state::irq_callback));
+	config.set_perfect_quantum(m_cpu);
 
 	ADDRESS_MAP_BANK(config, "rombank").set_map(&hp80_base_state::rombank_mem_map).set_options(ENDIANNESS_LITTLE, 8, 21, HP80_OPTROM_SIZE);
 


### PR DESCRIPTION
Hi,

I've just added the emulation of HP82939 serial I/O module for HP80 systems.
I needed to fix a small bug in INS8250 emulation because the module self-test was failing. Hopefully I didn't break anything in other systems with 8250.
ROM image for the module microcontroller will be emailed shortly to "code" address.
Thank you.
--F.Ulivi
