### PR TITLE
Confirm Zeus 2's cab linking is firewire/IEEE 1394

### DIFF
--- a/src/mame/drivers/midzeus.cpp
+++ b/src/mame/drivers/midzeus.cpp
@@ -453,12 +453,16 @@ WRITE32_MEMBER(midzeus2_state::crusnexo_leds_w)
 }
 
 
+
 /*************************************
  *
  *  Firewire/IEEE 1394 access (Zeus 2 only)
  *
+ *  Hardware: TSB12LV01A link layer controller and IBM IBM21S851 physical layer (PHY) transceiver.
+ *
  *************************************/
-READ32_MEMBER(midzeus_state::firewire_r) //Hardware: TSB12LV01A link layer controller and IBM IBM21S851 physical layer (PHY) transceiver.
+
+READ32_MEMBER(midzeus_state::firewire_r)
 {
 	uint32_t retVal = 0;
 	if (offset < 0x40)

--- a/src/mame/drivers/midzeus.cpp
+++ b/src/mame/drivers/midzeus.cpp
@@ -455,10 +455,10 @@ WRITE32_MEMBER(midzeus2_state::crusnexo_leds_w)
 
 /*************************************
  *
- *  Firewwire access (Zeus 2 only)
+ *  Firewire/IEEE 1394 access (Zeus 2 only)
  *
  *************************************/
-READ32_MEMBER(midzeus_state::firewire_r)
+READ32_MEMBER(midzeus_state::firewire_r) //Hardware: TSB12LV01A link layer controller and IBM IBM21S851 physical layer (PHY) transceiver.
 {
 	uint32_t retVal = 0;
 	if (offset < 0x40)


### PR DESCRIPTION
Zeus 2 pcbs use dedicated firewire/IEEE 1394 hardware to link other pcbs (verified on hardware).

Link layer controller: https://www.digchip.com/datasheets/download_datasheet.php?id=1001640&part-number=TSB12LV01A

 Physical layer interface (PHY): https://datasheet.datasheetarchive.com/originals/library/Datasheets-IS15/DSA00292238.pdf