### PR TITLE
Roll back no longer needed /ZI workaround

### DIFF
--- a/scripts/src/tools.lua
+++ b/scripts/src/tools.lua
@@ -133,15 +133,6 @@ files {
 configuration { "mingw*" or "vs*" }
 	targetextension ".exe"
 
--- workaround for https://developercommunity.visualstudio.com/content/problem/752372/vs2019-v1631-c-internal-compiler-error-when-zi-opt.html
--- should be fixed in 16.5
-configuration { "Debug", "vs2019" }
-	if _OPTIONS["vs"]==nil then
-		flags {
-			"NoEditAndContinue",
-		}
-	end
-
 configuration { }
 
 strip()
@@ -717,15 +708,6 @@ files {
 
 configuration { "mingw*" or "vs*" }
 	targetextension ".exe"
-
--- workaround for https://developercommunity.visualstudio.com/content/problem/752372/vs2019-v1631-c-internal-compiler-error-when-zi-opt.html
--- should be fixed in 16.5
-configuration { "Debug", "vs2019" }
-	if _OPTIONS["vs"]==nil then
-		flags {
-			"NoEditAndContinue",
-		}
-	end
 
 configuration { }
 


### PR DESCRIPTION
The issue has been fixed as of Visual Studio 2019 16.5
I have tested it locally but merging should wait until appveyor is updated too, otherwise CI will break.