### PR TITLE
fmtowns_cd.xml: requirements, 12 replacements and 10 additions

### DIFF
--- a/hash/fmtowns_cd.xml
+++ b/hash/fmtowns_cd.xml
@@ -30,7 +30,6 @@ Ablemax Suugaku                                               Able Serve        
 AD&D Heroes of the Lance                                      Pony Canyon                       1990/6     CD
 Aesop World Dai-1-shuu (Denshi Ehon)                          Fujitsu                           1993/12    CD
 Aesop World Dai-2-shuu (Denshi Ehon)                          Fujitsu                           1993/12    CD
-After Burner (v1.02)                                          CRI                               1989/11    CD
 Airwave Adventure                                             Toshiba EMI                       1989/12    CD
 Aishuu to Netsujou no Chouwa                                  Fujitsu                           1995/4     CD
 Akiko Gold                                                    Fairytale (Red Zone)              1995/1     SET(CD+FD)
@@ -60,7 +59,6 @@ ByHAND V2.1                                                   Fujitsu           
 ByHAND V3.1                                                   Fujitsu                           1994/3     CD
 CAL Towns 3                                                   Birdy Soft                        1993/7     CD
 California X Party: Joshi Daisei Himitsu Club                 HOP                               1994/9     SET(CD+FD)
-Can Can Bunny Premiere                                        Cocktail Soft                     1992/9     CD
 Car Marty Exciting CD                                         Fujitsu Ten                       1994/3     CD×2
 Car Marty Exciting CD                                         Fujitsu Ten                       1994/3     CD×2
 Car Marty Exciting CD                                         Fujitsu Ten                       1994/6     CD×2
@@ -106,7 +104,6 @@ Cyclone Express Alpha Towns                                   Ans               
 Dai-i-ku                                                      Sanshusha                         1990/11    CD
 Daijirin CD-ROM                                               Fujitsu                           1993/2     CD
 Daisenkai CD-ROM                                              Fujitsu                           1993/11    CD
-Debut Shimasu…                                                Ilis Plan                         1994/6     CD
 Debut Shimasu… 3                                              Ilis Plan                         1995/2     CD
 Demon City                                                    Cocktail Soft                     1994/3     CD
 Demonstration CD-ROM '90 Fuyu-gou                             Fujitsu                           1990/11    SET(CD+FD)
@@ -200,7 +197,6 @@ FM Towns Free Ware Collection (EYE COM-ban)                   Fujitsu           
 FM Towns Paso-Rika Ver. 3                                     Maris                             1993/11    CD
 FM Towns Shougaku Ongaku (5-6-nensei You)                     Kyouiku Shuppan                   1991/5     SET(CD+FD)
 FM Towns-ban Dyna-pers                                        Dynaware                          1989/12    CD
-FreeColle Marty 1                                             Fujitsu                           1993/12    CD
 * Fujitsu Air Warrior V1.2                                    Fujitsu                           1993/11    SET(CD+FD)
 * Fujitsu Air Warrior V1.1                                    Fujitsu                           1992/3     SET(CD+FD)
 Fujitsu Air Warrior V2.1                                      Fujitsu                           1995/4     SET(CD+FD)
@@ -275,7 +271,6 @@ Hyper Aquarium Kaisui-hen                                     Inter Limited Logi
 Hyper Aquarium Tansui-hen                                     Inter Limited Logic               1992/1     CD
 Hyper Asobi Meijin                                            Corpus                            1989/11    SET(CD+FD)
 Hyper Asobi Meijin 2                                          Corpus                            1991/11    SET(CD+FD)
-Hyper Channel / Towns-TV                                      Dennou Shoukai                    1990/1     CD
 Hyper Chuugokugo Nyuumon-hen (Ge) Pekingo Gengakuin-hen       SofMedia                          1991/3     CD
 Hyper Chuugokugo Nyuumon-hen (Jou) Pekingo Gengakuin-hen      SofMedia                          1991/3     CD
 Hyper Drill Series Shougakkou Kokugo 3-nen                    Uchida Youkou                     1996/3     CD
@@ -528,7 +523,6 @@ Primary Health Care System                                    Raison            
 Princess Danger                                               Janis                             1996/4     CD
 Private Slave                                                 Raccoon                           1993/8     SET(CD+FD)
 Pro Student G Renkaban                                        Alice Soft                        1995/4     CD
-Pro Yakyuu Family Stadium '90                                 Game Arts                         1990/9     CD
 Psychic Detective Series Vol. 1: Invitation: Kage kara no Shoutaijou (Remake)   Data West                         1993/11    SET(CD+FD)
 Psychic Detective Series Vol. 2: Memories (Remake)            Data West                         1994/4     SET(CD+FD)
 Psychic Detective Series Vol. 3: Aya (Remake)                 Data West                         1994/7     SET(CD+FD)
@@ -584,7 +578,7 @@ Sexy PK 2 World Cup Ban                                       Birdy Soft        
 Sexy PK World Cup Ban                                         Birdy Soft                        1995/6     CD
 Shadow of the Beast: Mashou no Okite (1991-10-11)             Victor Entertainment              1991/10?   CD
 Shakaika Database: Nihon no Bunka / Sangyou / Shizen          Nihon Kyouiku System              1991/12    CD
-Shamhat: The Holy Circlet                                     Data West                         1993/4     SET(CD+FD)
+* Shamhat: The Holy Circlet                                   Data West                         1993/4     SET(CD+FD)
 Shamhat: The Holy Circlet (Marty-ban)                         Data West                         1993/4     SET(CD+FD)
 Shanghai: Banri no Choujou                                    Electronic Arts Victor            1995/9     CD
 Shijou Saikyou no Video Bible                                 System Sacom                      1989/12    CD
@@ -630,7 +624,7 @@ Sunshine 1-nen                                                Uchida Youkou     
 Sunshine 2-nen                                                Uchida Youkou                     1993/7     CD
 Super Kakitaoshi                                              Nikkonren Kikaku                  1993/?     SET(CD+FD)
 Super Zurukamashi                                             Nikkonren Kikaku                  1993/?     SET(CD+FD)
-Suzaku                                                        Wolf Team                         1992/10    SET(CD+FD)
+* Suzaku                                                      Wolf Team                         1992/10    SET(CD+FD)
 Tactical Tank Corps DX                                        GAM                               1995/2     SET(CD+FD)
 Taiken Shiyou! Marty Channel 2                                Fujitsu                           1993/6     CD×02
 Takken Ou                                                     Techno Business                   1994/10    CD
@@ -866,6 +860,7 @@ User/save disks that can be created from the game itself are not included.
 		<description>F-BASIC386 v2.1 L10</description>
 		<year>1992</year>
 		<publisher>富士通 (Fujitsu)</publisher>
+		<info name="usage" value="Requires 2 MB RAM"/>
 		<part name="cdrom" interface="fmt_cdrom">
 			<diskarea name="cdrom">
 				<disk name="[os] f-basic386 v2.1 l10" sha1="e69f917dc978dea9a602adf3864db4543d314c9a" />
@@ -987,16 +982,32 @@ User/save disks that can be created from the game itself are not included.
 
 	<software name="tss1110">
 		<!--
-		 Origin: Neo Kobe Collection
-		 <rom name="[OS] Towns System Software v1.1 L10.bin" size="409732480" crc="441b8037" sha1="ae188a5d94430e0d8820b10e1e265c426124b90d"/>
-		 <rom name="[OS] Towns System Software v1.1 L10.cue" size="1123" crc="9d95bc5c" sha1="0a5ce0ee30ed7bc8f5d0192ee9c5c3ae3d2ea71b"/>
+		Origin: redump.org
+		<rom name="Towns System Software V1.1L10 (Japan) (Track 01).bin" size="67220160" crc="199881c0" sha1="07cae8073ed718fe9412cf8122e47e545734d7bd"/>
+		<rom name="Towns System Software V1.1L10 (Japan) (Track 02).bin" size="2845920" crc="c3a8a67e" sha1="b819792025af57961983c9e3980cb199d8c603ad"/>
+		<rom name="Towns System Software V1.1L10 (Japan) (Track 03).bin" size="8469552" crc="bf055392" sha1="6dfedea95b2c9787ce0853880f1ab9491494173c"/>
+		<rom name="Towns System Software V1.1L10 (Japan) (Track 04).bin" size="4243008" crc="80379ff5" sha1="adf45689e2bb58b03d972cc49f3cdc230df90ee6"/>
+		<rom name="Towns System Software V1.1L10 (Japan) (Track 05).bin" size="2509584" crc="5f95c7b8" sha1="458254012df042a871dc3214c3d0fc4631720f22"/>
+		<rom name="Towns System Software V1.1L10 (Japan) (Track 06).bin" size="2702448" crc="26cfae15" sha1="fdc05da986f4e68d7cfbb079c63d13cb3090c34b"/>
+		<rom name="Towns System Software V1.1L10 (Japan) (Track 07).bin" size="3057600" crc="ebdc6d6e" sha1="8a33441f5e72ed7edf855b8d913495861b810060"/>
+		<rom name="Towns System Software V1.1L10 (Japan) (Track 08).bin" size="2829456" crc="edcf6157" sha1="a01726f6a97c415f54bd930e18a47c37f08a9921"/>
+		<rom name="Towns System Software V1.1L10 (Japan) (Track 09).bin" size="3375120" crc="721cb5fe" sha1="cd0730663bb5583db4d2750f68edc5ab9e0fff71"/>
+		<rom name="Towns System Software V1.1L10 (Japan) (Track 10).bin" size="3560928" crc="e1e342ed" sha1="aa19656f8d537d676dbc3fceb8d7456238541064"/>
+		<rom name="Towns System Software V1.1L10 (Japan) (Track 11).bin" size="2312016" crc="b1255f83" sha1="43b257ffe84309d046e5cceb1f5d73f6c8af415d"/>
+		<rom name="Towns System Software V1.1L10 (Japan) (Track 12).bin" size="127370208" crc="12846823" sha1="175521e0ae772be710855f780eb472f916997678"/>
+		<rom name="Towns System Software V1.1L10 (Japan) (Track 13).bin" size="47644464" crc="816fc82a" sha1="b1311940c386d10a25c70edc3119c3237bfbdd77"/>
+		<rom name="Towns System Software V1.1L10 (Japan) (Track 14).bin" size="31789632" crc="2a353dfd" sha1="7bf3d2369b3c7f1db4779430a678361a819eb6f6"/>
+		<rom name="Towns System Software V1.1L10 (Japan) (Track 15).bin" size="28781424" crc="0a891438" sha1="7841d3ecc289ce2f8a1428b8cc6acbde05776346"/>
+		<rom name="Towns System Software V1.1L10 (Japan) (Track 16).bin" size="33875856" crc="9ccc4919" sha1="06d05217fdec562b18c2072f9d094e72768e4cce"/>
+		<rom name="Towns System Software V1.1L10 (Japan) (Track 17).bin" size="46186224" crc="c2689efd" sha1="86f2c32fa77a60d60d8a6cdc92da1e22c4022bb7"/>
+		<rom name="Towns System Software V1.1L10 (Japan).cue" size="2249" crc="2f73da97" sha1="a0bb770856dd74525e06d4f39b4ad07c6d7409c5"/>
 		 -->
 		<description>Towns System Software v1.1 L10</description>
 		<year>1989</year>
 		<publisher>富士通 (Fujitsu)</publisher>
 		<part name="cdrom" interface="fmt_cdrom">
 			<diskarea name="cdrom">
-				<disk name="[os] towns system software v1.1 l10" sha1="4cc560ebcf22337d4b6ae7143dafc2410c07907a" />
+				<disk name="towns system software v1.1l10 (japan)" sha1="98807c8ff948ed200cbd3199a32ae1edfdfae542" />
 			</diskarea>
 		</part>
 	</software>
@@ -1072,6 +1083,7 @@ User/save disks that can be created from the game itself are not included.
 		<description>Towns System Software v2.1 L10A</description>
 		<year>1991</year>
 		<publisher>富士通 (Fujitsu)</publisher>
+		<info name="usage" value="Requires 2 MB RAM"/>
 		<part name="cdrom" interface="fmt_cdrom">
 			<diskarea name="cdrom">
 				<disk name="[os] towns system software v2.1 l10a" sha1="17c7e8ab678ac7ff258242c1aad75673848e66d6" />
@@ -1096,6 +1108,7 @@ User/save disks that can be created from the game itself are not included.
 		<description>Towns System Software v2.1 L51</description>
 		<year>1995</year>
 		<publisher>富士通 (Fujitsu)</publisher>
+		<info name="usage" value="Requires 4 MB RAM"/>
 		<part name="cdrom" interface="fmt_cdrom">
 			<diskarea name="cdrom">
 				<disk name="towns system software v2.1l51 (japan)" sha1="85d8dcc3bc79858f1beaf2c1b35073060dc6d07d" />
@@ -1192,7 +1205,7 @@ User/save disks that can be created from the game itself are not included.
 		<publisher>富士通 (Fujitsu)</publisher>
 		<info name="alt_title" value="ＴＯＷＮＳ百人一首" />
 		<info name="release" value="198911xx" />
-		<info name="usage" value="Requires HDD installation"/>
+		<info name="usage" value="Requires 2 MB RAM"/>
 		<part name="cdrom" interface="fmt_cdrom">
 			<diskarea name="cdrom">
 				<disk name="towns hyakunin isshu" sha1="ef05fdcfbcdd8e4777638eaa3b8e7bf1d3e13ba8" />
@@ -1211,6 +1224,7 @@ User/save disks that can be created from the game itself are not included.
 		<publisher>日本クリエイト (Nihon Create)</publisher>
 		<info name="alt_title" value="３×３ＥＹＥＳ 三只眼變成" />
 		<info name="release" value="199310xx" />
+		<info name="usage" value="Requires 2 MB RAM"/>
 		<part name="cdrom" interface="fmt_cdrom">
 			<diskarea name="cdrom">
 				<disk name="3x3 eyes - sanjiyan henjou (japan)" sha1="3140e4b7c4a2c5666ed8d7c0e3ae919ed565e5c1" />
@@ -1237,6 +1251,7 @@ User/save disks that can be created from the game itself are not included.
 		<publisher>エレクトロニック・アーツ・ビクター (Electronic Arts Victor)</publisher>
 		<info name="alt_title" value="4D ボクシング" />
 		<info name="release" value="199212xx" />
+		<info name="usage" value="Requires 2 MB RAM"/>
 		<part name="cdrom" interface="fmt_cdrom">
 			<diskarea name="cdrom">
 				<disk name="4d boxing (japan)" sha1="b2705fc93b991ac2b7b45b697f15157085f37b4d" />
@@ -1266,6 +1281,7 @@ User/save disks that can be created from the game itself are not included.
 		<publisher>エレクトロニック・アーツ・ビクター (Electronic Arts Victor)</publisher>
 		<info name="alt_title" value="4D ドライビング" />
 		<info name="release" value="199303xx" />
+		<info name="usage" value="Requires 2 MB RAM"/>
 		<part name="cdrom" interface="fmt_cdrom">
 			<diskarea name="cdrom">
 				<disk name="4d driving (japan)" sha1="68794807a59b1095c2b10bf2e6a4da3eb6371f8f" />
@@ -1286,6 +1302,7 @@ User/save disks that can be created from the game itself are not included.
 		<publisher>エレクトロニック・アーツ・ビクター (Electronic Arts Victor)</publisher>
 		<info name="alt_title" value="4D テニス" />
 		<info name="release" value="199307xx" />
+		<info name="usage" value="Requires 2 MB RAM"/>
 		<part name="cdrom" interface="fmt_cdrom">
 			<diskarea name="cdrom">
 				<disk name="4d tennis" sha1="5ee1a3342469e87bc0f1d613982a92bc8ab5c5bb" />
@@ -1344,6 +1361,7 @@ User/save disks that can be created from the game itself are not included.
 		<year>1989</year>
 		<publisher>データウエスト (Data West)</publisher>
 		<info name="release" value="198912xx" />
+		<info name="usage" value="Requires 2 MB RAM"/>
 		<part name="cdrom" interface="fmt_cdrom">
 			<diskarea name="cdrom">
 				<disk name="the 4th unit 4 - zero" sha1="7b41956851d62962e24329380441a0d7b5778983" />
@@ -1372,6 +1390,7 @@ User/save disks that can be created from the game itself are not included.
 		<year>1990</year>
 		<publisher>データウエスト (Data West)</publisher>
 		<info name="release" value="199004xx" />
+		<info name="usage" value="Requires 2 MB RAM"/>
 		<part name="cdrom" interface="fmt_cdrom">
 			<diskarea name="cdrom">
 				<disk name="4th unit act. 5, the - d-again (japan)" sha1="f6c642be482b76d04936b7fd6d76aeb14e1055a8" />
@@ -1396,6 +1415,7 @@ User/save disks that can be created from the game itself are not included.
 		<year>1990</year>
 		<publisher>データウエスト (Data West)</publisher>
 		<info name="release" value="199012xx" />
+		<info name="usage" value="Requires 2 MB RAM"/>
 		<part name="cdrom" interface="fmt_cdrom">
 			<diskarea name="cdrom">
 				<disk name="4th unit series, the - merrygoround (japan)" sha1="68d99ab70038c78b95d7d229a185ab5eea0d4073" />
@@ -1419,6 +1439,7 @@ User/save disks that can be created from the game itself are not included.
 		<year>1992</year>
 		<publisher>データウエスト (Data West)</publisher>
 		<info name="release" value="199204xx" />
+		<info name="usage" value="Requires 2 MB RAM"/>
 		<part name="flop1" interface="floppy_3_5">
 			<feature name="part_id" value="Boot Disk" />
 			<dataarea name="flop" size="1261568">
@@ -1502,6 +1523,7 @@ User/save disks that can be created from the game itself are not included.
 		<publisher>アートディンク (Artdink)</publisher>
 		<info name="alt_title" value="A列車で行こうIII" />
 		<info name="release" value="199104xx" />
+		<info name="usage" value="Requires 2 MB RAM"/>
 		<part name="cdrom" interface="fmt_cdrom">
 			<diskarea name="cdrom">
 				<disk name="a ressha de ikou iii" sha1="095710f80f004917dce963719cb1c4bae4d5fc49" />
@@ -1522,6 +1544,7 @@ User/save disks that can be created from the game itself are not included.
 		<publisher>アートディンク (Artdink)</publisher>
 		<info name="alt_title" value="A列車で行こうIV" />
 		<info name="release" value="199312xx" />
+		<info name="usage" value="Requires 2 MB RAM"/>
 		<part name="flop1" interface="floppy_3_5">
 			<feature name="part_id" value="System Disk" />
 			<dataarea name="flop" size="1261568">
@@ -1549,6 +1572,7 @@ User/save disks that can be created from the game itself are not included.
 		<publisher>ファミリーソフト (Family Soft)</publisher>
 		<info name="alt_title" value="ＡＢＥＬ 真・黙示録大戦" />
 		<info name="release" value="199511xx" />
+		<info name="usage" value="Requires 2 MB RAM"/>
 		<part name="cdrom" interface="fmt_cdrom">
 			<diskarea name="cdrom">
 				<disk name="abel" sha1="5fb92a84f3d1e7530b6dce9060f9814ec2fa6d2b" />
@@ -1569,6 +1593,7 @@ User/save disks that can be created from the game itself are not included.
 		<publisher>富士通 (Fujitsu)</publisher>
 		<info name="alt_title" value="アドバンテージテニス" />
 		<info name="release" value="199210xx" />
+		<info name="usage" value="Requires 2 MB RAM"/>
 		<part name="cdrom" interface="fmt_cdrom">
 			<diskarea name="cdrom">
 				<disk name="advantage tennis" sha1="4210307af2238e8b0bc546b36f13f2fe651464cd" />
@@ -1590,6 +1615,7 @@ User/save disks that can be created from the game itself are not included.
 		<publisher>富士通 (Fujitsu)</publisher>
 		<info name="alt_title" value="エターナム" />
 		<info name="release" value="199303xx" />
+		<info name="usage" value="Requires 2 MB RAM"/>
 		<part name="cdrom" interface="fmt_cdrom">
 			<diskarea name="cdrom">
 				<disk name="aeternam" sha1="e5c5955e303d9fbc9f1e7b3bb4d601aeace34765" />
@@ -1599,6 +1625,56 @@ User/save disks that can be created from the game itself are not included.
 
 	<!-- Runs too fast -->
 	<software name="aburner" supported="partial">
+		<!--
+		Origin: redump.org
+		<rom name="After Burner (Japan) (Rev 1) (Track 1).bin" size="6985440" crc="e43d4e88" sha1="fcfba206bc0996baae9de2c3781124399824bbf5"/>
+		<rom name="After Burner (Japan) (Rev 1) (Track 2).bin" size="15944208" crc="c81500bd" sha1="ff1f81f752ed310b2cfc5727d06ce5110c1c6036"/>
+		<rom name="After Burner (Japan) (Rev 1) (Track 3).bin" size="36352512" crc="f2841431" sha1="90b89a93a5eeff5c9ec5d2b8dae8d3e16341b5ad"/>
+		<rom name="After Burner (Japan) (Rev 1) (Track 4).bin" size="58778832" crc="79b89034" sha1="6bee455fc707e2c9ea1aa7b9d2da056b5abaa51b"/>
+		<rom name="After Burner (Japan) (Rev 1) (Track 5).bin" size="21570192" crc="3c6ed1ae" sha1="aa8f38a2c2e82184605e5f1629b25f712f7513e8"/>
+		<rom name="After Burner (Japan) (Rev 1) (Track 6).bin" size="52943520" crc="2aac50ae" sha1="95f2da7928518de97d70134f40d33e09fdbea5d5"/>
+		<rom name="After Burner (Japan) (Rev 1) (Track 7).bin" size="35381136" crc="ce0b0df6" sha1="ccd66b6ec1e12791b907501ddaf52229f4e74543"/>
+		<rom name="After Burner (Japan) (Rev 1) (Track 8).bin" size="5244960" crc="cb9a33a8" sha1="c1dcd7c99a2a6f08e4874c20652fec0bb9704edd"/>
+		<rom name="After Burner (Japan) (Rev 1).cue" size="981" crc="8d8b4e65" sha1="42ba0bac8e3c84e1398120584c1fd494c622700f"/>
+		-->
+		<description>After Burner (v1.02)</description>
+		<year>1989</year>
+		<publisher>CRI</publisher>
+		<info name="alt_title" value="アフターバーナー" />
+		<info name="release" value="198911xx" />
+		<part name="cdrom" interface="fmt_cdrom">
+			<diskarea name="cdrom">
+				<disk name="after burner (japan) (rev 1)" sha1="c4b0f4bd4a0135933d6f15c2091c59be98b2c91d" />
+			</diskarea>
+		</part>
+	</software>
+
+	<software name="aburnera" cloneof="aburner" supported="partial">
+		<!--
+		Origin: redump.org
+		<rom name="After Burner (Japan) (Rev 1) (Alt) (Track 1).bin" size="6985440" crc="e43d4e88" sha1="fcfba206bc0996baae9de2c3781124399824bbf5"/>
+		<rom name="After Burner (Japan) (Rev 1) (Alt) (Track 2).bin" size="15939504" crc="2e023c16" sha1="49ac83e3546fe0b7fe8588f887412361e703243c"/>
+		<rom name="After Burner (Japan) (Rev 1) (Alt) (Track 3).bin" size="36357216" crc="8cfb8ad8" sha1="ee306f5a7b9e91607e0fc3149db14d9a87ddc6f7"/>
+		<rom name="After Burner (Japan) (Rev 1) (Alt) (Track 4).bin" size="58776480" crc="75170acb" sha1="59fe3418f50c18f63899d4559c2e080eb7412b9a"/>
+		<rom name="After Burner (Japan) (Rev 1) (Alt) (Track 5).bin" size="21572544" crc="bbc8f798" sha1="4b4df7c24e2d1fbaacf58c88c6cead0e8cfe7a01"/>
+		<rom name="After Burner (Japan) (Rev 1) (Alt) (Track 6).bin" size="53296320" crc="0138aece" sha1="db5b1e9727d25f4270314ef9b65a740cc97ec01d"/>
+		<rom name="After Burner (Japan) (Rev 1) (Alt) (Track 7).bin" size="35028336" crc="5b98a506" sha1="a8278e22714f19e6c6c9eeba3ec7c9af26194a34"/>
+		<rom name="After Burner (Japan) (Rev 1) (Alt) (Track 8).bin" size="5244960" crc="cb9a33a8" sha1="c1dcd7c99a2a6f08e4874c20652fec0bb9704edd"/>
+		<rom name="After Burner (Japan) (Rev 1) (Alt).cue" size="1006" crc="731bb65e" sha1="d4ddfb5cf75cc898c06cb1e05207105b07a16938"/>
+		-->
+		<description>After Burner (v1.02, alt)</description>
+		<year>1989</year>
+		<publisher>CRI</publisher>
+		<info name="alt_title" value="アフターバーナー" />
+		<info name="release" value="198911xx" />
+		<part name="cdrom" interface="fmt_cdrom">
+			<diskarea name="cdrom">
+				<disk name="after burner (japan) (rev 1) (alt)" sha1="a87bca5b66111988de5fd351270f092883516528" />
+			</diskarea>
+		</part>
+	</software>
+
+	<software name="aburnero" cloneof="aburner" supported="partial">
 		<!--
 		Origin: redump.org
 		<rom name="After Burner (Japan) (Track 1).bin" size="7126560" crc="789fc2c6" sha1="0604f645a7777df34006b93baa1c2f68d3379dad"/>
@@ -1645,6 +1721,7 @@ User/save disks that can be created from the game itself are not included.
 		<publisher>CRI</publisher>
 		<info name="alt_title" value="アフターバーナーIII" />
 		<info name="release" value="199206xx" />
+		<info name="usage" value="Requires 2 MB RAM"/>
 		<part name="cdrom" interface="fmt_cdrom">
 			<diskarea name="cdrom">
 				<disk name="after burner iii (japan)" sha1="fe11d382c3efef8ed4a698f6a9832fb6bcd09167" />
@@ -1688,6 +1765,7 @@ User/save disks that can be created from the game itself are not included.
 		<publisher>光栄 (Koei)</publisher>
 		<info name="alt_title" value="エアマネジメント 大空に賭ける" />
 		<info name="release" value="199209xx" />
+		<info name="usage" value="Requires 2 MB RAM"/>
 		<part name="flop1" interface="floppy_3_5">
 			<feature name="part_id" value="User Disk" />
 			<dataarea name="flop" size="1261568">
@@ -1752,6 +1830,7 @@ User/save disks that can be created from the game itself are not included.
 		<publisher>アリスソフト (AliceSoft)</publisher>
 		<info name="alt_title" value="アリスの館CD" />
 		<info name="release" value="199107xx" />
+		<info name="usage" value="Requires 2 MB RAM"/>
 		<part name="cdrom" interface="fmt_cdrom">
 			<diskarea name="cdrom">
 				<disk name="alice no yakata cd" sha1="03ee698cd4801d8e297eb6eade6aae7c87b7f2e8" />
@@ -1772,6 +1851,7 @@ User/save disks that can be created from the game itself are not included.
 		<publisher>アリスソフト (AliceSoft)</publisher>
 		<info name="alt_title" value="アリスの館2" />
 		<info name="release" value="199210xx" />
+		<info name="usage" value="Requires 2 MB RAM"/>
 		<part name="cdrom" interface="fmt_cdrom">
 			<diskarea name="cdrom">
 				<disk name="alice no yakata cd 2" sha1="d375cc44c0e421834f6ec3b2da3568eec7d28192" />
@@ -1803,18 +1883,29 @@ User/save disks that can be created from the game itself are not included.
 
 	<software name="aitd">
 		<!--
-		Origin: Neo Kobe Collection
-		<rom name="Alone in the Dark.bin" size="226057776" crc="74d5b144" sha1="1bc9a0010e5e55c6290f8f7deaee0900ce7fc47e"/>
-		<rom name="Alone in the Dark.cue" size="514" crc="13836533" sha1="65a0ff4f3e0daa29d1581d087e8f47145a0c774f"/>
+		Origin: redump.org
+		<rom name="Alone in the Dark (Japan) (Track 01).bin" size="15076320" crc="201cea10" sha1="60757890a6a6f747423040eace023edd57419b80"/>
+		<rom name="Alone in the Dark (Japan) (Track 02).bin" size="4285344" crc="0678de07" sha1="60e6c5d7dce432de914f4863e7c77a10b51e58ea"/>
+		<rom name="Alone in the Dark (Japan) (Track 03).bin" size="11348400" crc="3c28675b" sha1="4a8158b6ad03294f2ca68e87a25efb5ae40989cc"/>
+		<rom name="Alone in the Dark (Japan) (Track 04).bin" size="21280896" crc="c52f84a1" sha1="ab398d20d20a9fb1915d5880027e5862d9bc3084"/>
+		<rom name="Alone in the Dark (Japan) (Track 05).bin" size="37528512" crc="c3100666" sha1="60ffcc89834428753183f41bb4ea34658ca87efb"/>
+		<rom name="Alone in the Dark (Japan) (Track 06).bin" size="28588560" crc="d73a96e2" sha1="59806ba3b3cc020f6e0b6c5c09a29b0d403e12d2"/>
+		<rom name="Alone in the Dark (Japan) (Track 07).bin" size="18599616" crc="2908fd7b" sha1="55cf5cc85edb93da493daca72a134bf9929d2f5c"/>
+		<rom name="Alone in the Dark (Japan) (Track 08).bin" size="35860944" crc="55f5a98b" sha1="04d42434f6ed0c20348e42616213f0db9f5f5a4a"/>
+		<rom name="Alone in the Dark (Japan) (Track 09).bin" size="26213040" crc="07ac9d9c" sha1="cbea5426b63c1fd2b02addaa3f30a95aeacccf67"/>
+		<rom name="Alone in the Dark (Japan) (Track 10).bin" size="4132464" crc="203018e6" sha1="9805d2b5e15e1fe7b1b1cdb3c5fe670bcaaa5666"/>
+		<rom name="Alone in the Dark (Japan) (Track 11).bin" size="23496480" crc="18579a48" sha1="09b40bff74ed482d59c17b0cbfb05cc24c777c79"/>
+		<rom name="Alone in the Dark (Japan).cue" size="1302" crc="5d1b9ee9" sha1="e36160619f20d63c499de77ee00a9a04bfde3603"/>
 		-->
 		<description>Alone in the Dark</description>
 		<year>1993</year>
 		<publisher>アローマイクロテックス (Arrow Micro-Techs)</publisher>
 		<info name="alt_title" value="アローン・イン・ザ・ダーク" />
 		<info name="release" value="199312xx" />
+		<info name="usage" value="Requires 2 MB RAM"/>
 		<part name="cdrom" interface="fmt_cdrom">
 			<diskarea name="cdrom">
-				<disk name="alone in the dark" sha1="7cd07179e94161d59e0f426b71d87a72aeeae581" />
+				<disk name="alone in the dark (japan)" sha1="82552555c44cb7972a73e8261bc989447b231bce" />
 			</diskarea>
 		</part>
 	</software>
@@ -1832,7 +1923,7 @@ User/save disks that can be created from the game itself are not included.
 		<publisher>アローマイクロテックス (Arrow Micro-Techs)</publisher>
 		<info name="alt_title" value="アローン・イン・ザ・ダーク2" />
 		<info name="release" value="199412xx" />
-		<info name="usage" value="Requires HDD installation"/>
+		<info name="usage" value="Requires HDD installation and 4 MB RAM"/>
 		<part name="cdrom" interface="fmt_cdrom">
 			<diskarea name="cdrom">
 				<disk name="alone in the dark 2" sha1="6ac20d5879eaa4e4e65b0bc2377306e27ecc37a1" />
@@ -1853,6 +1944,7 @@ User/save disks that can be created from the game itself are not included.
 		<publisher>ライトスタッフ (Right Stuff)</publisher>
 		<info name="alt_title" value="アルシャーク" />
 		<info name="release" value="199305xx" />
+		<info name="usage" value="Requires 2 MB RAM"/>
 		<part name="cdrom" interface="fmt_cdrom">
 			<diskarea name="cdrom">
 				<disk name="alshark" sha1="ecbdc6dead64d45836037a341bfd49332c7f8e29" />
@@ -1891,6 +1983,7 @@ User/save disks that can be created from the game itself are not included.
 		<publisher>アリスソフト (AliceSoft)</publisher>
 		<info name="alt_title" value="AmbivalenZ ～二律背反～" />
 		<info name="release" value="199404xx" />
+		<info name="usage" value="Requires 2 MB RAM"/>
 		<part name="flop1" interface="floppy_3_5">
 			<feature name="part_id" value="Boot Disk" />
 			<dataarea name="flop" size="1261568">
@@ -1917,6 +2010,7 @@ User/save disks that can be created from the game itself are not included.
 		<publisher>富士通 (Fujitsu)</publisher>
 		<info name="alt_title" value="アメリカ横断ウルトラクイズ" />
 		<info name="release" value="199411xx" />
+		<info name="usage" value="Requires 2 MB RAM"/>
 		<part name="cdrom" interface="fmt_cdrom">
 			<diskarea name="cdrom">
 				<disk name="america oudan ultra quiz" sha1="08cdcfb5ba9d421da422852be6d29f4544a99e9b" />
@@ -1971,6 +2065,7 @@ User/save disks that can be created from the game itself are not included.
 		<publisher>アクティブ (Active)</publisher>
 		<info name="alt_title" value="エンジェル・ハイロウ" />
 		<info name="release" value="199610xx" />
+		<info name="usage" value="Requires 2 MB RAM"/>
 		<part name="cdrom" interface="fmt_cdrom">
 			<diskarea name="cdrom">
 				<disk name="angel halo" sha1="9d79b87bdfa4a3c3308c15a7e7c2927686f79c68" />
@@ -1987,7 +2082,7 @@ User/save disks that can be created from the game itself are not included.
 		<year>1999?</year>
 		<publisher>&lt;doujin&gt;</publisher>
 		<info name="alt_title" value="AnotherTOWNS あなた～ フリーソフトウェアコレクション" />
-		<info name="usage" value="Requires 32 MB of RAM" />
+		<info name="usage" value="Requires 20 MB RAM" />
 		<part name="cdrom" interface="fmt_cdrom">
 			<diskarea name="cdrom">
 				<disk name="anotowns" sha1="f6b1a56808d9abd79b50a830b409c1b87659ab01" />
@@ -2048,6 +2143,7 @@ User/save disks that can be created from the game itself are not included.
 		<publisher>光栄 (Koei)</publisher>
 		<info name="alt_title" value="蒼き狼と白き牝鹿 元朝秘史" />
 		<info name="release" value="199302xx" />
+		<info name="usage" value="Requires 2 MB RAM"/>
 		<part name="cdrom" interface="fmt_cdrom">
 			<diskarea name="cdrom">
 				<disk name="aoki ookami to shiroki mejika - genchou hishi" sha1="45b8790a77cb77632f067f366cc055e830eddae8" />
@@ -2068,6 +2164,7 @@ User/save disks that can be created from the game itself are not included.
 		<publisher>フェアリーテール (Fairytale)</publisher>
 		<info name="alt_title" value="ア・ラ・ベ・ス・ク ～少女たちの織りなす愛の物語～" />
 		<info name="release" value="199404xx" />
+		<info name="usage" value="Requires 2 MB RAM"/>
 		<part name="cdrom" interface="fmt_cdrom">
 			<diskarea name="cdrom">
 				<disk name="arabesque" sha1="5869c0c1d2eee0f551722a7d08d7feef6be53868" />
@@ -2105,6 +2202,7 @@ User/save disks that can be created from the game itself are not included.
 		<publisher>ファミリーソフト (Family Soft)</publisher>
 		<info name="alt_title" value="あすか 120% BURNING Fest. エクセレント" />
 		<info name="release" value="199412xx" />
+		<info name="usage" value="Requires 2 MB RAM"/>
 		<part name="flop1" interface="floppy_3_5">
 			<feature name="part_id" value="Boot Disk" />
 			<dataarea name="flop" size="1261568">
@@ -2131,6 +2229,7 @@ User/save disks that can be created from the game itself are not included.
 		<publisher>アートディンク (Artdink)</publisher>
 		<info name="alt_title" value="ジ・アトラス" />
 		<info name="release" value="199110xx" />
+		<info name="usage" value="Requires 2 MB RAM"/>
 		<part name="cdrom" interface="fmt_cdrom">
 			<diskarea name="cdrom">
 				<disk name="the atlas" sha1="31378695a7eb7fe953e51463829468f214f2a2f4" />
@@ -2151,6 +2250,7 @@ User/save disks that can be created from the game itself are not included.
 		<publisher>アートディンク (Artdink)</publisher>
 		<info name="alt_title" value="ジ・アトラスII" />
 		<info name="release" value="199305xx" />
+		<info name="usage" value="Requires 2 MB RAM"/>
 		<part name="flop1" interface="floppy_3_5">
 			<feature name="part_id" value="System Disk" />
 			<dataarea name="flop" size="1261568">
@@ -2176,6 +2276,7 @@ User/save disks that can be created from the game itself are not included.
 		<year>1992</year>
 		<publisher>富士通 (Fujitsu)</publisher>
 		<info name="release" value="199203xx" />
+		<info name="usage" value="Requires 2 MB RAM"/>
 		<part name="cdrom" interface="fmt_cdrom">
 			<diskarea name="cdrom">
 				<disk name="awesome" sha1="f758d24ebb1e94dfe1499b1af38c32fd1b9de8ff" />
@@ -2199,6 +2300,7 @@ User/save disks that can be created from the game itself are not included.
 		<publisher>ハード (Hard)</publisher>
 		<info name="alt_title" value="はっちゃけあやよさん 1-2-3" />
 		<info name="release" value="199307xx" />
+		<info name="usage" value="Requires 2 MB RAM"/>
 		<part name="cdrom" interface="fmt_cdrom">
 			<diskarea name="cdrom">
 				<disk name="hatchake ayayo-san 1-2-3" sha1="b9d11ce0cdcb144cbda9f9fdb2c9b7b02b8400a5" />
@@ -2219,6 +2321,7 @@ User/save disks that can be created from the game itself are not included.
 		<publisher>アリスソフト (AliceSoft)</publisher>
 		<info name="alt_title" value="あゆみちゃん物語" />
 		<info name="release" value="199310xx" />
+		<info name="usage" value="Requires 2 MB RAM"/>
 		<part name="flop1" interface="floppy_3_5">
 			<feature name="part_id" value="Boot Disk?" />
 			<dataarea name="flop" size="1261568">
@@ -2245,6 +2348,7 @@ User/save disks that can be created from the game itself are not included.
 		<publisher>Core Magazine</publisher>
 		<info name="alt_title" value="あゆみちゃん物語 実写版" />
 		<info name="release" value="199501xx" />
+		<info name="usage" value="Requires 2 MB RAM"/>
 		<part name="cdrom" interface="fmt_cdrom">
 			<diskarea name="cdrom">
 				<disk name="ayumi-chan monogatari jissha-ban" sha1="5a78396c9acb9c593710e0ce9aad520147b3759d" />
@@ -2255,33 +2359,29 @@ User/save disks that can be created from the game itself are not included.
 	<!-- Runs too fast? -->
 	<software name="azure" supported="partial">
 		<!--
-		Origin: Neo Kobe Collection
-		<rom name="Azure.ccd" size="2720" crc="abba1a9c" sha1="dfc2b8b4e7f907b7f03314df3ce7e5b8e4fb5d79"/>
-		<rom name="Azure.img" size="297763200" crc="e6eed565" sha1="df5983c6eb3069ce0f3126408fd6a3076cb16973"/>
-		<rom name="Azure.sub" size="12153600" crc="997bde0c" sha1="89446f9070f38b87408947cc5b19257b937aa03b"/>
-
-		*after conversion with IsoBuster+EAC *
-		<rom name="azure.cue" size="1468" crc="0e93296f" sha1="267e19bc59995b0ceeb93a914cd9fda8c49e3976"/>
-		<rom name="track01.bin" size="10231200" crc="02f834d3" sha1="f04f79a667bfd7e7eb519168ea12b569c61194b6"/>
-		<rom name="track02.bin" size="10760400" crc="8c3a5f07" sha1="c50dea9e12b898a3bbecf92e74b58e4d099478ea"/>
-		<rom name="track03.bin" size="25401600" crc="51660b91" sha1="494c095ccb79f48624ab7c1d0cf63691703ade7a"/>
-		<rom name="track04.bin" size="19933200" crc="795bfffe" sha1="5e69390f6c7f14d4895be583e56c65eaf83f47cc"/>
-		<rom name="track05.bin" size="25930800" crc="2424296c" sha1="f64663460c6751ae716f82eac10bb3cdd7eb95dd"/>
-		<rom name="track06.bin" size="26283600" crc="f65c8d90" sha1="491de4ee4ea7790e75e2308b8a944354c662d48f"/>
-		<rom name="track07.bin" size="30870000" crc="e8d99d4d" sha1="3cf070afcba6922d853b2ad4a56e9e79457920d2"/>
-		<rom name="track08.bin" size="33692400" crc="2e35719a" sha1="a30ef11f51c25dd120ea952eef9a36b6ec4399e0"/>
-		<rom name="track09.bin" size="46922400" crc="30db1227" sha1="d1c7a4a56c1c5b50df9be2f7a8b23eaf507d9e99"/>
-		<rom name="track10.bin" size="34045200" crc="31d37be9" sha1="094d5644cc9bcce8c7a16cd1e222bd3e426de65f"/>
-		<rom name="track11.bin" size="33692400" crc="76b54b81" sha1="24227e6bfa698dd686f68f07530ee4b1901d40d3"/>
+		Origin: redump.org
+		<rom name="Azure (Japan) (Track 01).bin" size="10231200" crc="02f834d3" sha1="f04f79a667bfd7e7eb519168ea12b569c61194b6"/>
+		<rom name="Azure (Japan) (Track 02).bin" size="10407600" crc="c611a050" sha1="69df6ebc69fb98f51cf1e461983ca47801f221e6"/>
+		<rom name="Azure (Japan) (Track 03).bin" size="25401600" crc="9addc458" sha1="efd13d9458bfa5fd58f4b01a01b349f03f5d75f1"/>
+		<rom name="Azure (Japan) (Track 04).bin" size="19933200" crc="3fb663f5" sha1="c35af4ff82bdaec1c60d206ea8c8b9172a84fb39"/>
+		<rom name="Azure (Japan) (Track 05).bin" size="25930800" crc="196cce7b" sha1="2bf185fcea4ac33ae698796cf43cd1fcb54e55ea"/>
+		<rom name="Azure (Japan) (Track 06).bin" size="26283600" crc="0dcac824" sha1="eda9abb275e238d7b3be1f9afd34ecd9d481a7c9"/>
+		<rom name="Azure (Japan) (Track 07).bin" size="30870000" crc="100c8c32" sha1="dbb2461028bd4e66fc7070672b806374ecedc6c2"/>
+		<rom name="Azure (Japan) (Track 08).bin" size="33692400" crc="cc910c5f" sha1="0366b87d25bfff15621735debfd1fadfc34a3f4b"/>
+		<rom name="Azure (Japan) (Track 09).bin" size="46922400" crc="4d73ea00" sha1="0cd84a368e74a1d9a72db39b2d9b676e570e93d7"/>
+		<rom name="Azure (Japan) (Track 10).bin" size="34045200" crc="dbaa8279" sha1="8666cf091ce3aef33c472b1a133d37b485f5ec41"/>
+		<rom name="Azure (Japan) (Track 11).bin" size="34045200" crc="b1a1298c" sha1="17ccf53d9fc774b67b07fcda249543fd17de2e49"/>
+		<rom name="Azure (Japan).cue" size="1193" crc="0062b4ab" sha1="eafda530ae1aa348e6e31f1df02c29279674b13d"/>
 		-->
 		<description>Azure</description>
 		<year>1993</year>
 		<publisher>ファミリーソフト (Family Soft)</publisher>
 		<info name="alt_title" value="アジャ" />
 		<info name="release" value="199302xx" />
+		<info name="usage" value="Requires 2 MB RAM"/>
 		<part name="cdrom" interface="fmt_cdrom">
 			<diskarea name="cdrom">
-				<disk name="azure" sha1="cc85c3223336a3f237ff2e5030fefae78e6d0d01" />
+				<disk name="azure (japan)" sha1="345f2e09eedc5bad3ec72e2df7eab21fc49d12c6" />
 			</diskarea>
 		</part>
 	</software>
@@ -2298,6 +2398,7 @@ User/save disks that can be created from the game itself are not included.
 		<year>1996</year>
 		<publisher>姫屋ソフト (Himeya Soft)</publisher>
 		<info name="release" value="199601xx" />
+		<info name="usage" value="Requires 2 MB RAM"/>
 		<part name="cdrom" interface="fmt_cdrom">
 			<diskarea name="cdrom">
 				<disk name="bacta 1 &amp; 2 + voice" sha1="86c2d8dcb4e40b108e7e8fab5c1f9f3609f65ed7" />
@@ -2318,6 +2419,7 @@ User/save disks that can be created from the game itself are not included.
 		<publisher>フェアリーテール (Fairytale)</publisher>
 		<info name="alt_title" value="マリアに捧げるバラード" />
 		<info name="release" value="199506xx" />
+		<info name="usage" value="Requires 2 MB RAM"/>
 		<part name="flop1" interface="floppy_3_5">
 			<feature name="part_id" value="User Disk" />
 			<dataarea name="flop" size="1261568">
@@ -2363,6 +2465,7 @@ User/save disks that can be created from the game itself are not included.
 		<publisher>富士通 (Fujitsu)</publisher>
 		<info name="alt_title" value="バトル・チェス" />
 		<info name="release" value="199109xx" />
+		<info name="usage" value="Requires 2 MB RAM"/>
 		<part name="cdrom" interface="fmt_cdrom">
 			<diskarea name="cdrom">
 				<disk name="battle chess (japan) (en,ja)" sha1="0697976fd0d3c5a8a1282d3bf3a319d50d525036" />
@@ -2383,6 +2486,7 @@ User/save disks that can be created from the game itself are not included.
 		<publisher>バーディーソフト (Birdy Soft)</publisher>
 		<info name="alt_title" value="ビースト3" />
 		<info name="release" value="199403xx" />
+		<info name="usage" value="Requires 2 MB RAM"/>
 		<part name="cdrom" interface="fmt_cdrom">
 			<diskarea name="cdrom">
 				<disk name="beast 3" sha1="5505a0105fa9abe32b3240bac1144555b22740ee" />
@@ -2402,6 +2506,7 @@ User/save disks that can be created from the game itself are not included.
 		<year>1994?</year>
 		<publisher>シグナワークス (Signa Works)</publisher>
 		<info name="alt_title" value="ベルズ・アベニュー Vol.1" />
+		<info name="usage" value="Requires 2 MB RAM"/>
 		<part name="cdrom" interface="fmt_cdrom">
 			<diskarea name="cdrom">
 				<disk name="bellsav1" sha1="e085475aa75a2d2f274700f93484bcb6bbcc42ea" />
@@ -2421,6 +2526,7 @@ User/save disks that can be created from the game itself are not included.
 		<year>1994?</year>
 		<publisher>シグナワークス (Signa Works)</publisher>
 		<info name="alt_title" value="ベルズ・アベニュー Vol.2" />
+		<info name="usage" value="Requires 2 MB RAM"/>
 		<part name="cdrom" interface="fmt_cdrom">
 			<diskarea name="cdrom">
 				<disk name="bellsav2" sha1="c910ef48ea6677c77d40518f75af2160e58ae763" />
@@ -2430,17 +2536,22 @@ User/save disks that can be created from the game itself are not included.
 
 	<software name="biblemas">
 		<!--
-		Origin: Neo Kobe Collection
-		<rom name="Bible Master.ccd" size="1902" crc="5fe16167" sha1="7c3db9b391ff419950c34583a3cd10ba51458635"/>
-		<rom name="Bible Master.cue" size="310" crc="e99968b4" sha1="ff897f592e6e079194bfc44350d89e8ac0097285"/>
-		<rom name="Bible Master.img" size="241903200" crc="c50d6fe0" sha1="be14564d9cc9a868a8dc83add97aafdabc1f5aef"/>
-		<rom name="Bible Master.sub" size="9873600" crc="dc397949" sha1="adba917e897c0c493207cb5ecba44969303afbc7"/>
+		Origin: redump.org
+		<rom name="Bible Master - Crash of the BlleotRutz (Japan) (Track 1).bin" size="6138720" crc="8e6dc685" sha1="693cbebcc53e11d04d2f8875b00924bd681f906a"/>
+		<rom name="Bible Master - Crash of the BlleotRutz (Japan) (Track 2).bin" size="66919104" crc="874fea90" sha1="f3bdb9dd10fb083c6bcd9c5cd0c40321018886d2"/>
+		<rom name="Bible Master - Crash of the BlleotRutz (Japan) (Track 3).bin" size="3229296" crc="2431323a" sha1="d5f451dddd0430333383a63dc477c65572e082f3"/>
+		<rom name="Bible Master - Crash of the BlleotRutz (Japan) (Track 4).bin" size="45221904" crc="874443e0" sha1="1f11676a55b7cdf02622d8054c9ec4552aa2e769"/>
+		<rom name="Bible Master - Crash of the BlleotRutz (Japan) (Track 5).bin" size="24430224" crc="6722b399" sha1="b74051d0036b3630380ce5cd3f376a176c213d41"/>
+		<rom name="Bible Master - Crash of the BlleotRutz (Japan) (Track 6).bin" size="61702368" crc="71e31506" sha1="32a88bfeec66e222bc6e34138345edb9ba8158a0"/>
+		<rom name="Bible Master - Crash of the BlleotRutz (Japan) (Track 7).bin" size="34261584" crc="cd0d142e" sha1="7af7d44e3e020c4e6af38f812790726af8cf3f9b"/>
+		<rom name="Bible Master - Crash of the BlleotRutz (Japan).cue" size="870" crc="3b28e0e1" sha1="453f0330938bb14d1227c1f2f30bf0145e3066b1"/>
 		-->
-		<description>Bible Master</description>
+		<description>Bible Master - Crash of the BlleotRutz</description>
 		<year>1993</year>
 		<publisher>グローディア (Glodia)</publisher>
 		<info name="alt_title" value="バイブル マスター" />
 		<info name="release" value="199312xx" />
+		<info name="usage" value="Requires 2 MB RAM"/>
 		<part name="flop1" interface="floppy_3_5">
 			<feature name="part_id" value="System Disk" />
 			<dataarea name="flop" size="1261568">
@@ -2449,7 +2560,7 @@ User/save disks that can be created from the game itself are not included.
 		</part>
 		<part name="cdrom" interface="fmt_cdrom">
 			<diskarea name="cdrom">
-				<disk name="bible master" sha1="cddc6fc109ed6de40a59dce4918b9b0f1c928992" />
+				<disk name="bible master - crash of the blleotrutz (japan)" sha1="014f0c293bc0c1ae62c42af8cbf6ed53c4ec3a9e" />
 			</diskarea>
 		</part>
 	</software>
@@ -2529,6 +2640,7 @@ User/save disks that can be created from the game itself are not included.
 		<publisher>ビング (Ving)</publisher>
 		<info name="alt_title" value="ブランディア" />
 		<info name="release" value="199409xx" />
+		<info name="usage" value="Requires 2 MB RAM"/>
 		<part name="cdrom" interface="fmt_cdrom">
 			<diskarea name="cdrom">
 				<disk name="blandia (japan)" sha1="dc189eaa29a134e350dc0dd14f309ae15a756229" />
@@ -2548,6 +2660,7 @@ User/save disks that can be created from the game itself are not included.
 		<year>1992</year>
 		<publisher>Sofcom</publisher>
 		<info name="release" value="199204xx" />
+		<info name="usage" value="Requires 2 MB RAM"/>
 		<part name="cdrom" interface="fmt_cdrom">
 			<diskarea name="cdrom">
 				<disk name="blue - will to power" sha1="6ef80af0ccf21be12d68cd4ea2baf0988762f004" />
@@ -2557,18 +2670,32 @@ User/save disks that can be created from the game itself are not included.
 
 	<software name="panicbom">
 		<!--
-		Origin: Neo Kobe Collection
-		<rom name="Bomberman - Panic Bomber.bin" size="189806400" crc="7ed8cc7a" sha1="65dd63bd618dfbdccd82bb7b5b7d6a024025a681"/>
-		<rom name="Bomberman - Panic Bomber.cue" size="614" crc="f6601687" sha1="a926cc21f244c8558787735559cd6a86161344c3"/>
+		Origin: redump.org
+		<rom name="Bomberman - Panic Bomber (Japan) (Track 01).bin" size="10233552" crc="248b3802" sha1="0bf6ffbc0a6a104f02f25c093f22b57c6fe21781"/>
+		<rom name="Bomberman - Panic Bomber (Japan) (Track 02).bin" size="4584048" crc="f07c5f5b" sha1="dbf6d36b460aaf338e8584f2e9a559acbc677433"/>
+		<rom name="Bomberman - Panic Bomber (Japan) (Track 03).bin" size="32634000" crc="25629ed9" sha1="1f62caf64a978bdfa64ee1f40c6562d25fa05513"/>
+		<rom name="Bomberman - Panic Bomber (Japan) (Track 04).bin" size="31399200" crc="14b48920" sha1="3e84b9b39103a8e1e2652c224e1dd4cd7f01ff12"/>
+		<rom name="Bomberman - Panic Bomber (Japan) (Track 05).bin" size="28224000" crc="557ae772" sha1="6b888da0c5b677994aa28a247c842ed29ca24dff"/>
+		<rom name="Bomberman - Panic Bomber (Japan) (Track 06).bin" size="1058400" crc="5aaaa593" sha1="1d51838636ad65ab6cec6fc2782b787735bb06db"/>
+		<rom name="Bomberman - Panic Bomber (Japan) (Track 07).bin" size="1234800" crc="efe6e9a5" sha1="7296630251572cf732be49234990edd4ffb5fc72"/>
+		<rom name="Bomberman - Panic Bomber (Japan) (Track 08).bin" size="1234800" crc="7bf36972" sha1="24efaa7e0433e357d778d0d26885b6598fc46915"/>
+		<rom name="Bomberman - Panic Bomber (Japan) (Track 09).bin" size="1058400" crc="d8efcc3b" sha1="867e42a7eed1ed8cb36a9b6df6f20987aa16819b"/>
+		<rom name="Bomberman - Panic Bomber (Japan) (Track 10).bin" size="1940400" crc="74817d55" sha1="5450e22251c8dac2f53a4fb49b3f1db25f0218fe"/>
+		<rom name="Bomberman - Panic Bomber (Japan) (Track 11).bin" size="25754400" crc="3c90aaa9" sha1="d84c9533aa3a3f8153781955aad6dc7e08551621"/>
+		<rom name="Bomberman - Panic Bomber (Japan) (Track 12).bin" size="28047600" crc="5eff6ffb" sha1="a69f16e76d261bce4085f11d877c7fd4655c7abb"/>
+		<rom name="Bomberman - Panic Bomber (Japan) (Track 13).bin" size="21697200" crc="7115797b" sha1="2b4e80b2e551f0956a37672c8ec0365c289254ab"/>
+		<rom name="Bomberman - Panic Bomber (Japan) (Track 14).bin" size="1058400" crc="648c227c" sha1="729c8d0d2eb161d068c48a84826268f9ec790222"/>
+		<rom name="Bomberman - Panic Bomber (Japan).cue" size="1783" crc="8ee2eca5" sha1="5c87b6af7f43e13e01299dbcb829948ffd0a3f16"/>
 		-->
 		<description>Bomberman - Panic Bomber</description>
 		<year>1995</year>
 		<publisher>アスキー (ASCII)</publisher>
 		<info name="alt_title" value="ボンバーマンぱにっくボンバー" />
 		<info name="release" value="199504xx" />
+		<info name="usage" value="Requires 2 MB RAM"/>
 		<part name="cdrom" interface="fmt_cdrom">
 			<diskarea name="cdrom">
-				<disk name="bomberman - panic bomber" sha1="1fc5adf361f2a4ec5ddf1d55bacda3284f43f00d" />
+				<disk name="bomberman - panic bomber (japan)" sha1="019a1d0b207d6f3492fcbe230638740857a00c12" />
 			</diskarea>
 		</part>
 	</software>
@@ -2603,6 +2730,7 @@ User/save disks that can be created from the game itself are not included.
 		<publisher>アートディンク (Artdink)</publisher>
 		<info name="alt_title" value="ビッグオナー" />
 		<info name="release" value="199209xx" />
+		<info name="usage" value="Requires 2 MB RAM"/>
 		<part name="cdrom" interface="fmt_cdrom">
 			<diskarea name="cdrom">
 				<disk name="big honour (japan)" sha1="e810dcd4ee51a464abcf5274ff708bd0b9e53f2e" />
@@ -2623,6 +2751,7 @@ User/save disks that can be created from the game itself are not included.
 		<publisher>アスキー (ASCII)</publisher>
 		<info name="alt_title" value="ベストプレーベースボール" />
 		<info name="release" value="199204xx" />
+		<info name="usage" value="Requires 2 MB RAM"/>
 		<part name="cdrom" interface="fmt_cdrom">
 			<diskarea name="cdrom">
 				<disk name="the best play baseball" sha1="11bdce513c48010b272988525ae458ec60c743f6" />
@@ -2641,6 +2770,7 @@ User/save disks that can be created from the game itself are not included.
 		<publisher>ディー・オー (D.O.)</publisher>
 		<info name="alt_title" value="ブランマーカー" />
 		<info name="release" value="199311xx" />
+		<info name="usage" value="Requires 2 MB RAM"/>
 		<part name="cdrom" interface="fmt_cdrom">
 			<diskarea name="cdrom">
 				<disk name="branmarker (japan)" sha1="064cb20e663b2c8f76e7c8597470035c5cbe30cd" />
@@ -2662,6 +2792,8 @@ User/save disks that can be created from the game itself are not included.
 		<year>1995</year>
 		<publisher>ディー・オー (D.O.)</publisher>
 		<info name="alt_title" value="ブランマーカー２" />
+		<info name="release" value="199510xx" />
+		<info name="usage" value="Requires 2 MB RAM"/>
 		<part name="cdrom1" interface="fmt_cdrom">
 			<feature name="part_id" value="Game Disc" />
 			<diskarea name="cdrom">
@@ -2689,6 +2821,7 @@ User/save disks that can be created from the game itself are not included.
 		<publisher>ビング (Ving)</publisher>
 		<info name="alt_title" value="バブルボブル" />
 		<info name="release" value="199010xx" />
+		<info name="usage" value="Requires 2 MB RAM"/>
 		<part name="cdrom" interface="fmt_cdrom">
 			<diskarea name="cdrom">
 				<disk name="bubble bobble" sha1="6832299e67d17aca22d0ec2265b78d6e42336e30" />
@@ -2729,6 +2862,7 @@ User/save disks that can be created from the game itself are not included.
 		<publisher>リバーヒルソフト (Riverhill Soft)</publisher>
 		<info name="alt_title" value="ブライ -完結編-" />
 		<info name="release" value="199105xx" />
+		<info name="usage" value="Requires 2 MB RAM"/>
 		<part name="cdrom" interface="fmt_cdrom">
 			<diskarea name="cdrom">
 				<disk name="burai kanketsu-hen" sha1="acf9f3c856ef1398805509352b4e6e2f53f61b47" />
@@ -2748,6 +2882,7 @@ User/save disks that can be created from the game itself are not included.
 		<year>1992</year>
 		<publisher>バーディーソフト (Birdy Soft)</publisher>
 		<info name="release" value="199211xx" />
+		<info name="usage" value="Requires 2 MB RAM"/>
 		<part name="cdrom" interface="fmt_cdrom">
 			<diskarea name="cdrom">
 				<disk name="cal towns" sha1="ab905889b8a3edfd7cdfe51c728d017f257e34f7" />
@@ -2775,7 +2910,41 @@ User/save disks that can be created from the game itself are not included.
 		</part>
 	</software>
 
-	<software name="cancanb">
+	<software name="cancanbp">
+		<!--
+		Origin: redump.org
+		<rom name="Can Can Bunny Premiere (Japan) (Track 01).bin" size="20815200" crc="f1d04cfd" sha1="ced7d3c199770a3434819a5189a0ce64a96ee1df"/>
+		<rom name="Can Can Bunny Premiere (Japan) (Track 02).bin" size="44452800" crc="637e717b" sha1="abd900743947fe3895edc95a61654605eb4ae64f"/>
+		<rom name="Can Can Bunny Premiere (Japan) (Track 03).bin" size="32810400" crc="f78bc810" sha1="f4d2f97a80b75fae47c1e6ab5181f5af657f8c36"/>
+		<rom name="Can Can Bunny Premiere (Japan) (Track 04).bin" size="41101200" crc="06635159" sha1="cd7d50bf6bd428989e60f84249a063ab31fe1402"/>
+		<rom name="Can Can Bunny Premiere (Japan) (Track 05).bin" size="35456400" crc="a6fc879d" sha1="6718e1aa9d79f550bc79b42573f241e7d6f964f0"/>
+		<rom name="Can Can Bunny Premiere (Japan) (Track 06).bin" size="34750800" crc="e97a3750" sha1="c00cef4b62a638d595648cc3de14a320b99f84cd"/>
+		<rom name="Can Can Bunny Premiere (Japan) (Track 07).bin" size="39513600" crc="3fe36b0d" sha1="44c9a4288e7892a15886a2e63077a45351556922"/>
+		<rom name="Can Can Bunny Premiere (Japan) (Track 08).bin" size="28224000" crc="a65ab975" sha1="34980137b158b34c895ed2ef9bdd67d6e18b730e"/>
+		<rom name="Can Can Bunny Premiere (Japan) (Track 09).bin" size="29988000" crc="64536ae0" sha1="16ee4671f4d1c7eff8ab6d4f12be2c6327c7e445"/>
+		<rom name="Can Can Bunny Premiere (Japan) (Track 10).bin" size="12877200" crc="98c1d9dc" sha1="574bc9e1fe57c80b6aa15b33fa4062d99a074ea0"/>
+		<rom name="Can Can Bunny Premiere (Japan) (Track 11).bin" size="23284800" crc="0d5dda5b" sha1="c6c903e8dd1661b90d4fe9a6d34fcb5b049d7503"/>
+		<rom name="Can Can Bunny Premiere (Japan) (Track 12).bin" size="30693600" crc="7d92b7d1" sha1="9a9df05a4d7e81bea88ff2eed164bb6c04cc324e"/>
+		<rom name="Can Can Bunny Premiere (Japan) (Track 13).bin" size="36162000" crc="d671adc9" sha1="ac5b497c6f880fc9e2dd71650a7ba4e717ca857b"/>
+		<rom name="Can Can Bunny Premiere (Japan) (Track 14).bin" size="30340800" crc="28439f0b" sha1="b7a9877c2ff7e2f69532bd39cde1aa3588c6fbf7"/>
+		<rom name="Can Can Bunny Premiere (Japan) (Track 15).bin" size="39866400" crc="8f60e590" sha1="9a117e9d7bc3fd26cb02b1614cd72ecc8ef528cf"/>
+		<rom name="Can Can Bunny Premiere (Japan) (Track 16).bin" size="46569600" crc="78bd6b21" sha1="ded8847b325ce77a79cad00dc01e5dec70099dce"/>
+		<rom name="Can Can Bunny Premiere (Japan).cue" size="1982" crc="82668808" sha1="0607f3e15df4a325d8e20d6b720eeee7cf5025c7"/>
+		-->
+		<description>Can Can Bunny Premiere</description>
+		<year>1992</year>
+		<publisher>カクテル・ソフト (Cocktail Soft)</publisher>
+		<info name="alt_title" value="きゃんきゃんバニー・プルミエール" />
+		<info name="release" value="199209xx" />
+		<info name="usage" value="Requires 2 MB RAM"/>
+		<part name="cdrom" interface="fmt_cdrom">
+			<diskarea name="cdrom">
+				<disk name="can can bunny premiere (japan)" sha1="7dc902c238777e4102d0b9ed2d1ae59f3caac422" />
+			</diskarea>
+		</part>
+	</software>
+
+	<software name="cancanbx">
 		<!--
 		Origin: Neo Kobe Collection
 		<rom name="Can Can Bunny Extra.ccd" size="3046" crc="08ed0643" sha1="295218b17312f25e68cdf39ea4f3fd6a1df2e934"/>
@@ -2788,6 +2957,7 @@ User/save disks that can be created from the game itself are not included.
 		<publisher>カクテル・ソフト (Cocktail Soft)</publisher>
 		<info name="alt_title" value="きゃんきゃんバニー・エクストラ" />
 		<info name="release" value="199309xx" />
+		<info name="usage" value="Requires 2 MB RAM"/>
 		<part name="cdrom" interface="fmt_cdrom">
 			<diskarea name="cdrom">
 				<disk name="can can bunny extra" sha1="385d444f67398de5b1acc65dd19e6aecafab0de1" />
@@ -2808,6 +2978,7 @@ User/save disks that can be created from the game itself are not included.
 		<publisher>ビクター音楽産業 (Victor Musical Industries)</publisher>
 		<info name="alt_title" value="キャッスルズ" />
 		<info name="release" value="199210xx" />
+		<info name="usage" value="Requires 2 MB RAM"/>
 		<part name="cdrom" interface="fmt_cdrom">
 			<diskarea name="cdrom">
 				<disk name="castles" sha1="411c2753dbbef40b91bc6cd922f82eda27820280" />
@@ -2835,6 +3006,7 @@ User/save disks that can be created from the game itself are not included.
 		<publisher>Cat's Pro.</publisher>
 		<info name="alt_title" value="キャッツ・パート１" />
 		<info name="release" value="199304xx" />
+		<info name="usage" value="Requires 2 MB RAM"/>
 		<part name="cdrom" interface="fmt_cdrom">
 			<diskarea name="cdrom">
 				<disk name="cat's part-1 (japan)" sha1="8985f14c6c8647ee8457e01c02f6b5d9672b0061" />
@@ -2855,6 +3027,7 @@ User/save disks that can be created from the game itself are not included.
 		<publisher>エレクトロニック・アーツ・ビクター (Electronic Arts Victor)</publisher>
 		<info name="alt_title" value="センチュリオン" />
 		<info name="release" value="199311xx" />
+		<info name="usage" value="Requires 2 MB RAM"/>
 		<part name="cdrom" interface="fmt_cdrom">
 			<diskarea name="cdrom">
 				<disk name="centurion" sha1="7df6066270855bd7ae85286ce502e1663610760c" />
@@ -2873,6 +3046,7 @@ User/save disks that can be created from the game itself are not included.
 		<publisher>R-Key</publisher>
 		<info name="alt_title" value="CGシンジケート Vol.1 リサ・ノースポイント" />
 		<info name="release" value="199112xx" />
+		<info name="usage" value="Requires 2 MB RAM"/>
 		<part name="cdrom" interface="fmt_cdrom">
 			<diskarea name="cdrom">
 				<disk name="cg syndicate vol. 1 - lisa northpoint (japan)" sha1="eaf4be8306fa7f14699bc4a678366d687ab85da6" />
@@ -2909,6 +3083,7 @@ User/save disks that can be created from the game itself are not included.
 		<publisher>ビング (Ving)</publisher>
 		<info name="alt_title" value="TAITO チェイスＨＱ" />
 		<info name="release" value="199108xx" />
+		<info name="usage" value="Requires 2 MB RAM"/>
 		<part name="cdrom" interface="fmt_cdrom">
 			<diskarea name="cdrom">
 				<disk name="taito chase h.q. (japan)" sha1="8ec3b12763866865ace239e717297b2defcaba43" />
@@ -2946,6 +3121,7 @@ User/save disks that can be created from the game itself are not included.
 		<publisher>ビング (Ving)</publisher>
 		<info name="alt_title" value="TAITO チェイスＨＱ" />
 		<info name="release" value="1991xxxx" />
+		<info name="usage" value="Requires 2 MB RAM"/>
 		<part name="cdrom" interface="fmt_cdrom">
 			<diskarea name="cdrom">
 				<disk name="taito chase h.q. (japan) (demo)" sha1="531f1102be4e13ac9e8a90a040bb706ae9a2d12f" />
@@ -2966,6 +3142,7 @@ User/save disks that can be created from the game itself are not included.
 		<publisher>トップビジネスシステム (Top Business System)</publisher>
 		<info name="alt_title" value="注文の多い料理店" />
 		<info name="release" value="199108xx" />
+		<info name="usage" value="Requires 2 MB RAM"/>
 		<part name="cdrom" interface="fmt_cdrom">
 			<diskarea name="cdrom">
 				<disk name="chuumon" sha1="ac7a8e5b18cc5ad213a0e5191a115683b309f883" />
@@ -2986,6 +3163,7 @@ User/save disks that can be created from the game itself are not included.
 		<publisher>ビクター音楽産業 (Victor Musical Industries)</publisher>
 		<info name="alt_title" value="クラシック・ロード" />
 		<info name="release" value="199402xx" />
+		<info name="usage" value="Requires 2 MB RAM"/>
 		<part name="cdrom" interface="fmt_cdrom">
 			<diskarea name="cdrom">
 				<disk name="classic road" sha1="a4debada6767e53ec0edb0ee9128f8fe96a99a6c" />
@@ -3005,6 +3183,7 @@ User/save disks that can be created from the game itself are not included.
 		<year>1989</year>
 		<publisher>東芝EMI (Toshiba EMI)</publisher>
 		<info name="release" value="198911xx" />
+		<info name="usage" value="Requires 2 MB RAM"/>
 		<part name="cdrom" interface="fmt_cdrom">
 			<diskarea name="cdrom">
 				<disk name="the case of the cautious condor" sha1="b922563e2617dc46b3aac534c3ee81039a3953c7" />
@@ -3025,6 +3204,7 @@ User/save disks that can be created from the game itself are not included.
 		<publisher>ディー・オー (D.O.)</publisher>
 		<info name="alt_title" value="クリスタルリナール －逢魔の迷宮－" />
 		<info name="release" value="199408xx" />
+		<info name="usage" value="Requires 2 MB RAM"/>
 		<part name="cdrom" interface="fmt_cdrom">
 			<diskarea name="cdrom">
 				<disk name="crystal rinal" sha1="96bce4606ee6775e966328143a6051fe312d9a8d" />
@@ -3041,7 +3221,7 @@ User/save disks that can be created from the game itself are not included.
 		<description>CubicSketch V1.1 L10</description>
 		<year>1994</year>
 		<publisher>富士通 (Fujitsu)</publisher>
-		<info name="usage" value="Requires 4 MB of RAM" />
+		<info name="usage" value="Requires 4 MB RAM" />
 		<info name="release" value="199405xx" />
 		<part name="cdrom" interface="fmt_cdrom">
 			<diskarea name="cdrom">
@@ -3063,6 +3243,7 @@ User/save disks that can be created from the game itself are not included.
 		<publisher>カクテル・ソフト (Cocktail Soft)</publisher>
 		<info name="alt_title" value="カスタムメイト２＆いつかどこかで" />
 		<info name="release" value="199508xx" />
+		<info name="usage" value="Requires 2 MB RAM"/>
 		<part name="flop1" interface="floppy_3_5">
 			<feature name="part_id" value="Save Disk" />
 			<dataarea name="flop" size="1261568">
@@ -3114,7 +3295,7 @@ User/save disks that can be created from the game itself are not included.
 		<publisher>富士通 (Fujitsu)</publisher>
 		<info name="alt_title" value="サイベリア" />
 		<info name="release" value="199505xx" />
-		<info name="usage" value="Requires HDD installation"/>
+		<info name="usage" value="Requires HDD installation and 4 MB RAM"/>
 		<part name="cdrom" interface="fmt_cdrom">
 			<diskarea name="cdrom">
 				<disk name="cyberia" sha1="9b6100154ebe61fe19e17b01a2f037310448a72a" />
@@ -3129,10 +3310,11 @@ User/save disks that can be created from the game itself are not included.
 		<rom name="Cyber Sculpt (Japan) (Rev A).cue" size="117" crc="220735d1" sha1="db75ec48bb8656146aaeaaa3c94a228f9efb78bc"/>
 		-->
 		<description>Cyber Sculpt V1.0 (HMC-140A)</description>
-		<year>1995</year>
+		<year>1991</year>
 		<publisher>富士通 (Fujitsu)</publisher>
 		<info name="alt_title" value="サイバー・スカルプト" />
 		<info name="release" value="199111xx" />
+		<info name="usage" value="Requires 2 MB RAM"/>
 		<part name="cdrom" interface="fmt_cdrom">
 			<diskarea name="cdrom">
 				<disk name="cyber sculpt (japan) (rev a)" sha1="04983debbc720a3b897cc53c7f70e16a3f932329" />
@@ -3150,6 +3332,7 @@ User/save disks that can be created from the game itself are not included.
 		<year>1995</year>
 		<publisher>ディー・オー (D.O.)</publisher>
 		<info name="release" value="199505xx" />
+		<info name="usage" value="Requires 2 MB RAM"/>
 		<part name="cdrom" interface="fmt_cdrom">
 			<diskarea name="cdrom">
 				<disk name="d.o. kanshuu premium box - touch my heart" sha1="b3b4fdd6a780911b432d925dbb5eeb5844f0485c" />
@@ -3169,6 +3352,7 @@ User/save disks that can be created from the game itself are not included.
 		<year>1995</year>
 		<publisher>アリスソフト (AliceSoft)</publisher>
 		<info name="alt_title" value="DPS全部" />
+		<info name="usage" value="Requires 2 MB RAM"/>
 		<part name="cdrom" interface="fmt_cdrom">
 			<diskarea name="cdrom">
 				<disk name="d.p.s. zenbu" sha1="0dfb4343e175a124795974183c17356530231b85" />
@@ -3189,6 +3373,7 @@ User/save disks that can be created from the game itself are not included.
 		<publisher>光栄 (Koei)</publisher>
 		<info name="alt_title" value="大航海時代" />
 		<info name="release" value="199011xx" />
+		<info name="usage" value="Requires 2 MB RAM"/>
 		<part name="flop1" interface="floppy_3_5">
 			<feature name="part_id" value="Save Disk" />
 			<dataarea name="flop" size="1261568">
@@ -3215,6 +3400,7 @@ User/save disks that can be created from the game itself are not included.
 		<publisher>光栄 (Koei)</publisher>
 		<info name="alt_title" value="大航海時代II" />
 		<info name="release" value="199304xx" />
+		<info name="usage" value="Requires 2 MB RAM"/>
 		<part name="flop1" interface="floppy_3_5">
 			<feature name="part_id" value="Save Disk" />
 			<dataarea name="flop" size="1261568">
@@ -3242,6 +3428,7 @@ User/save disks that can be created from the game itself are not included.
 		<publisher>ペガサスジャパン (Pegasus Japan)</publisher>
 		<info name="alt_title" value="大戦略III'90" />
 		<info name="release" value="199112xx" />
+		<info name="usage" value="Requires 2 MB RAM"/>
 		<part name="flop1" interface="floppy_3_5">
 			<feature name="part_id" value="Game Disk" />
 			<dataarea name="flop" size="1261568">
@@ -3303,6 +3490,7 @@ User/save disks that can be created from the game itself are not included.
 		<year>1996</year>
 		<publisher>ミンク (Mink)</publisher>
 		<info name="release" value="199606xx" />
+		<info name="usage" value="Requires 2 MB RAM"/>
 		<part name="cdrom" interface="fmt_cdrom">
 			<diskarea name="cdrom">
 				<disk name="dangel" sha1="5b748eb84966710bf125a84dac3e878f62872ba6" />
@@ -3323,6 +3511,7 @@ User/save disks that can be created from the game itself are not included.
 		<publisher>姫屋ソフト (Himeya Soft)</publisher>
 		<info name="alt_title" value="デ・ファーナ" />
 		<info name="release" value="199511xx" />
+		<info name="usage" value="Requires 2 MB RAM"/>
 		<part name="cdrom" interface="fmt_cdrom">
 			<diskarea name="cdrom">
 				<disk name="de.fana" sha1="935c63b0c38c56e7f19957cf6fe7cc2472728964" />
@@ -3330,7 +3519,27 @@ User/save disks that can be created from the game itself are not included.
 		</part>
 	</software>
 
-	<software name="debut2">
+	<software name="debuts1">
+		<!--
+		Origin: redump.org
+		<rom name="Debut Shimasu... Vol. 1 - Nakagawa Yuuko (Japan) (Track 1).bin" size="34807248" crc="2c96079f" sha1="148683cc738e23fb639da45337f6046e2fe09563"/>
+		<rom name="Debut Shimasu... Vol. 1 - Nakagawa Yuuko (Japan) (Track 2).bin" size="215734848" crc="a03ff180" sha1="17815b524039a87f00e5f8048e91aee4ab55a56f"/>
+		<rom name="Debut Shimasu... Vol. 1 - Nakagawa Yuuko (Japan).cue" size="289" crc="dccaf7d0" sha1="51b2d4f95810ea7783142e3b7fe737485f10ef8c"/>
+		-->
+		<description>Debut Shimasu... - Nakagawa Yuuko</description>
+		<year>1994</year>
+		<publisher>アイリスプラン (Ilis Plan)</publisher>
+		<info name="alt_title" value="デビューします･･･ 中川裕子" />
+		<info name="release" value="199406xx" />
+		<info name="usage" value="Requires 2 MB RAM"/>
+		<part name="cdrom" interface="fmt_cdrom">
+			<diskarea name="cdrom">
+				<disk name="debut shimasu... vol. 1 - nakagawa yuuko (japan)" sha1="88ac13e766313d6cce34e50b9c62ca9cccb6aa00" />
+			</diskarea>
+		</part>
+	</software>
+
+	<software name="debuts2">
 		<!--
 		Origin: P2P
 		<rom name="Image.cdm" size="1075" crc="864a0aef" sha1="11b84a227e6791d8e834bbf76946d374abe122c2"/>
@@ -3339,10 +3548,11 @@ User/save disks that can be created from the game itself are not included.
 		<rom name="Image.sub" size="15851040" crc="f76f8c39" sha1="8a46276e7a01f33b7b4eb99210be6c8826b6760d"/>
 		-->
 		<description>Debut Shimasu... 2 - Nogami Aki</description>
-		<year>1994?</year>
+		<year>1994</year>
 		<publisher>アイリスプラン (Ilis Plan)</publisher>
 		<info name="alt_title" value="デビューします･･･２ 野上アキ" />
 		<info name="release" value="199407xx" />
+		<info name="usage" value="Requires 2 MB RAM"/>
 		<part name="cdrom" interface="fmt_cdrom">
 			<diskarea name="cdrom">
 				<disk name="debut2" sha1="8490214513d8533565d50fb9b5e0aaf0cf344d21" />
@@ -3383,6 +3593,7 @@ User/save disks that can be created from the game itself are not included.
 		<publisher>フェアリーテール (Fairytale)</publisher>
 		<info name="alt_title" value="デッド・オブ・ザ・ブレイン" />
 		<info name="release" value="199302xx" />
+		<info name="usage" value="Requires 2 MB RAM"/>
 		<part name="cdrom" interface="fmt_cdrom">
 			<diskarea name="cdrom">
 				<disk name="dead of the brain" sha1="c8493803f60156504f69d8003624f4caf98831b6" />
@@ -3412,6 +3623,7 @@ User/save disks that can be created from the game itself are not included.
 		<publisher>KID</publisher>
 		<info name="alt_title" value="デスブレイド" />
 		<info name="release" value="199211xx" />
+		<info name="usage" value="Requires 2 MB RAM"/>
 		<part name="cdrom" interface="fmt_cdrom">
 			<diskarea name="cdrom">
 				<disk name="death brade (japan)" sha1="d5a64749f2908093d5d5a84d774f08a995f3280a" />
@@ -3432,6 +3644,7 @@ User/save disks that can be created from the game itself are not included.
 		<publisher>ジャスト (Jast)</publisher>
 		<info name="alt_title" value="ディープ" />
 		<info name="release" value="199503xx" />
+		<info name="usage" value="Requires 2 MB RAM"/>
 		<part name="flop1" interface="floppy_3_5">
 			<feature name="part_id" value="Boot Disk" />
 			<dataarea name="flop" size="1261568">
@@ -3475,6 +3688,7 @@ User/save disks that can be created from the game itself are not included.
 		<publisher>カクテル・ソフト (Cocktail Soft)</publisher>
 		<info name="alt_title" value="電撃ナース" />
 		<info name="release" value="199212xx" />
+		<info name="usage" value="Requires 2 MB RAM"/>
 		<part name="cdrom" interface="fmt_cdrom">
 			<diskarea name="cdrom">
 				<disk name="dengeki nurse" sha1="b2e82a8dea0c827f49abff6a346150df3ca16ec1" />
@@ -3522,6 +3736,7 @@ User/save disks that can be created from the game itself are not included.
 		<publisher>アスキー (ASCII)</publisher>
 		<info name="alt_title" value="ダービースタリオン" />
 		<info name="release" value="199402xx" />
+		<info name="usage" value="Requires 2 MB RAM"/>
 		<part name="cdrom" interface="fmt_cdrom">
 			<diskarea name="cdrom">
 				<disk name="derby stallion (japan)" sha1="e8f00f5d75abe71b3795cb2a68592e158056f5ed" />
@@ -3542,6 +3757,7 @@ User/save disks that can be created from the game itself are not included.
 		<publisher>シーズウェア (C's Ware)</publisher>
 		<info name="alt_title" value="デザイア 背徳の螺旋" />
 		<info name="release" value="199411xx" />
+		<info name="usage" value="Requires 2 MB RAM"/>
 		<part name="cdrom" interface="fmt_cdrom">
 			<diskarea name="cdrom">
 				<disk name="desire" sha1="a7ba23ec748ba4a58d0baab8172ee8ba17c450c5" />
@@ -3579,6 +3795,7 @@ User/save disks that can be created from the game itself are not included.
 		<publisher>日本アプリケーション (Nihon Application)</publisher>
 		<info name="alt_title" value="大逆鱗" />
 		<info name="release" value="199511xx" />
+		<info name="usage" value="Requires 2 MB RAM"/>
 		<part name="cdrom" interface="fmt_cdrom">
 			<diskarea name="cdrom">
 				<disk name="die gekirin" sha1="2c8e76eebd8b8578cbe7fc3b7b69298de39a9bfd" />
@@ -3597,6 +3814,7 @@ User/save disks that can be created from the game itself are not included.
 		<description>Digital Pinup Girls Vol. 1</description>
 		<year>1993</year>
 		<publisher>Transpegasus</publisher>
+		<info name="usage" value="Requires 2 MB RAM"/>
 		<part name="cdrom" interface="fmt_cdrom">
 			<diskarea name="cdrom">
 				<disk name="digital pinup girls vol. 1" sha1="8d411ad637a7aabd6d752a49c4db8568d508ef34" />
@@ -3616,6 +3834,7 @@ User/save disks that can be created from the game itself are not included.
 		<year>1989</year>
 		<publisher>FNC</publisher>
 		<info name="release" value="198911xx" />
+		<info name="usage" value="Requires 2 MB RAM"/>
 		<part name="cdrom" interface="fmt_cdrom">
 			<diskarea name="cdrom">
 				<disk name="dodamega" sha1="876ebe9db24ad2206e2bb4795284d828fa264442" />
@@ -3635,6 +3854,7 @@ User/save disks that can be created from the game itself are not included.
 		<year>1994</year>
 		<publisher>ディー・オー (D.O.)</publisher>
 		<info name="alt_title" value="どきどきディスクＣＤ版　第１巻　クラブＤ．Ｏ．事務局" />
+		<info name="usage" value="Requires 2 MB RAM"/>
 		<part name="cdrom" interface="fmt_cdrom">
 			<diskarea name="cdrom">
 				<disk name="doki doki disk cd vol.1" sha1="b11bdae6dccb9799535baee0d0e257507037b614" />
@@ -3693,6 +3913,7 @@ User/save disks that can be created from the game itself are not included.
 		<publisher>ディー・オー (D.O.)</publisher>
 		<info name="alt_title" value="ＤＯＲ ～ ベストセレクション ～ 下巻" />
 		<info name="release" value="199305xx" />
+		<info name="usage" value="Requires 2 MB RAM"/>
 		<part name="cdrom1" interface="fmt_cdrom">
 			<diskarea name="cdrom">
 				<disk name="dor - best selection - gekan (japan) (disc 1)" sha1="b5589543eb983def1db44c123f8c9b145adf527b" />
@@ -3723,6 +3944,7 @@ User/save disks that can be created from the game itself are not included.
 		<publisher>ディー・オー (D.O.)</publisher>
 		<info name="alt_title" value="ＤＯＲ ～ ベストセレクション ～ 上巻" />
 		<info name="release" value="199304xx" />
+		<info name="usage" value="Requires 2 MB RAM"/>
 		<part name="cdrom1" interface="fmt_cdrom">
 			<diskarea name="cdrom">
 				<disk name="dor best selection joukan (disc 1)" sha1="4384e5214835b93d4cb60762913dc01a29294bb6" />
@@ -3747,6 +3969,7 @@ User/save disks that can be created from the game itself are not included.
 		<year>1993</year>
 		<publisher>ディー・オー (D.O.)</publisher>
 		<info name="release" value="199312xx" />
+		<info name="usage" value="Requires 2 MB RAM"/>
 		<part name="cdrom" interface="fmt_cdrom">
 			<diskarea name="cdrom">
 				<disk name="dor special edition '93" sha1="3c37b0b2890920249c06a354d8d31ce608352fee" />
@@ -3766,6 +3989,7 @@ User/save disks that can be created from the game itself are not included.
 		<year>1993</year>
 		<publisher>ディー・オー (D.O.)</publisher>
 		<info name="release" value="199312xx" />
+		<info name="usage" value="Requires 2 MB RAM"/>
 		<part name="cdrom" interface="fmt_cdrom">
 			<diskarea name="cdrom">
 				<disk name="dor special edition '93 (alt)" sha1="7c8ed53fc332b99eebdeb81933184b85b424a1ac" />
@@ -3786,6 +4010,7 @@ User/save disks that can be created from the game itself are not included.
 		<publisher>ディー・オー (D.O.)</publisher>
 		<info name="alt_title" value="DOR SPECIAL EDITION 魁" />
 		<info name="release" value="199306xx" />
+		<info name="usage" value="Requires 2 MB RAM"/>
 		<part name="cdrom" interface="fmt_cdrom">
 			<diskarea name="cdrom">
 				<disk name="dor special edition sakigake" sha1="134465d1bba5c1f2f1b35cb9e7dad90f9be11be7" />
@@ -3826,6 +4051,7 @@ User/save disks that can be created from the game itself are not included.
 		<publisher>エルフ (Elf)</publisher>
 		<info name="alt_title" value="同級生2" />
 		<info name="release" value="199502xx" />
+		<info name="usage" value="Requires 2 MB RAM"/>
 		<part name="cdrom" interface="fmt_cdrom">
 			<diskarea name="cdrom">
 				<disk name="doukyuusei 2" sha1="ec43759d5482a5a29323ad7274bb6dc14e1cbc8d" />
@@ -3846,6 +4072,7 @@ User/save disks that can be created from the game itself are not included.
 		<publisher>マイクロキャビン (Micro Cabin)</publisher>
 		<info name="alt_title" value="ドラゴンハーフ" />
 		<info name="release" value="199404xx" />
+		<info name="usage" value="Requires 2 MB RAM"/>
 		<part name="cdrom" interface="fmt_cdrom">
 			<diskarea name="cdrom">
 				<disk name="dragon half" sha1="390d5edd522faaeeda42237ced0856adbb0387ed" />
@@ -3864,6 +4091,7 @@ User/save disks that can be created from the game itself are not included.
 		<publisher>エルフ (Elf)</publisher>
 		<info name="alt_title" value="ドラゴンナイトIII" />
 		<info name="release" value="199202xx" />
+		<info name="usage" value="Requires 2 MB RAM"/>
 		<part name="cdrom" interface="fmt_cdrom">
 			<diskarea name="cdrom">
 				<disk name="dragon knight iii" sha1="7f1d23ee707023d5058fda1c958c80fb45677489" />
@@ -3884,6 +4112,7 @@ User/save disks that can be created from the game itself are not included.
 		<publisher>エルフ (Elf)</publisher>
 		<info name="alt_title" value="ドラゴンナイト4" />
 		<info name="release" value="199404xx" />
+		<info name="usage" value="Requires 2 MB RAM"/>
 		<part name="cdrom" interface="fmt_cdrom">
 			<diskarea name="cdrom">
 				<disk name="dragon knight 4" sha1="a8ed04efe5e90c18de6c1a76fc73d730670857dc" />
@@ -3904,6 +4133,7 @@ User/save disks that can be created from the game itself are not included.
 		<publisher>ポニーキャニオン (Pony Canyon)</publisher>
 		<info name="alt_title" value="ドラゴン・オブ・フレイム" />
 		<info name="release" value="199201xx" />
+		<info name="usage" value="Requires 2 MB RAM"/>
 		<part name="cdrom" interface="fmt_cdrom">
 			<diskarea name="cdrom">
 				<disk name="ad&amp;d dragons of flame" sha1="0e0fed376b4882c338e9d4510b377c8f9318df67" />
@@ -3983,6 +4213,7 @@ User/save disks that can be created from the game itself are not included.
 		<publisher>富士通 (Fujitsu)</publisher>
 		<info name="alt_title" value="ドラッケン" />
 		<info name="release" value="199011xx" />
+		<info name="usage" value="Requires 2 MB RAM"/>
 		<part name="cdrom" interface="fmt_cdrom">
 			<diskarea name="cdrom">
 				<disk name="drakkhen (japan)" sha1="a109ee34ec4411e873cbcd6c1a3c3ba9bfec55b0" />
@@ -4001,6 +4232,7 @@ User/save disks that can be created from the game itself are not included.
 		<publisher>富士通 (Fujitsu)</publisher>
 		<info name="alt_title" value="ダンジョンマスター" />
 		<info name="release" value="198911xx" />
+		<info name="usage" value="Requires 2 MB RAM"/>
 		<part name="cdrom" interface="fmt_cdrom">
 			<diskarea name="cdrom">
 				<disk name="dungeon master" sha1="e4b7b106c1d303af3d41ce33c2979df830739df1" />
@@ -4021,6 +4253,7 @@ User/save disks that can be created from the game itself are not included.
 		<publisher>ビクター音楽産業 (Victor Musical Industries)</publisher>
 		<info name="alt_title" value="ダンジョンマスターII スカルキープ" />
 		<info name="release" value="199401xx" />
+		<info name="usage" value="Requires 2 MB RAM"/>
 		<part name="cdrom" interface="fmt_cdrom">
 			<diskarea name="cdrom">
 				<disk name="dungeon master ii - skullkeep" sha1="d94dcd021aeb4e020c202d31c9fe1c42b57f35e8" />
@@ -4038,6 +4271,7 @@ User/save disks that can be created from the game itself are not included.
 		<year>1995</year>
 		<publisher>富士通 (Fujitsu)</publisher>
 		<info name="alt_title" value="えほんらいたー SCHOOL" />
+		<info name="usage" value="Requires 2 MB RAM"/>
 		<part name="cdrom" interface="fmt_cdrom">
 			<diskarea name="cdrom">
 				<disk name="ehonwrit" sha1="093d955515b1f06cbb67ccc5aeccf45402ec0587" />
@@ -4058,6 +4292,7 @@ User/save disks that can be created from the game itself are not included.
 		<publisher>シーズウェア (C's Ware)</publisher>
 		<info name="alt_title" value="エイミーと呼ばないでっ" />
 		<info name="release" value="199508xx" />
+		<info name="usage" value="Requires 2 MB RAM"/>
 		<part name="cdrom" interface="fmt_cdrom">
 			<diskarea name="cdrom">
 				<disk name="eimmy to yobanaide" sha1="4c321b593322b94cf84a68ad1021d0cf3b24b1c4" />
@@ -4067,21 +4302,19 @@ User/save disks that can be created from the game itself are not included.
 
 	<software name="elfish">
 		<!--
-		Origin: Neo Kobe Collection
-		<rom name="Elfish.ccd" size="769" crc="3990aa0a" sha1="a34bc28fd4c9074206e28db7b1226f645afc4602"/>
-		<rom name="Elfish.cue" size="70" crc="01a388af" sha1="b681395c929a9714e0892f9212e917f97abf75e9"/>
-		<rom name="Elfish.img" size="221911200" crc="54942929" sha1="28ef2c15b0f4b3ce7a347f357b1ab038f6912049"/>
-		<rom name="Elfish.sub" size="9057600" crc="160a0c25" sha1="669635dce8b54482df7deae714ec6075ab6e622c"/>
+		Origin: redump.org
+		<rom name="ElFish (Japan).bin" size="221911200" crc="54942929" sha1="28ef2c15b0f4b3ce7a347f357b1ab038f6912049"/>
+		<rom name="ElFish (Japan).cue" size="80" crc="c09d7cad" sha1="f3769f1c163fdb81c4ee716937d5b3a61f0c40cb"/>
 		-->
-		<description>Elfish</description>
+		<description>ElFish</description>
 		<year>1994</year>
 		<publisher>富士通 (Fujitsu)</publisher>
 		<info name="alt_title" value="エル・フィッシュ" />
 		<info name="release" value="199407xx" />
-		<info name="usage" value="Requires HDD installation and an FPU"/>
+		<info name="usage" value="Requires HDD installation, 4 MB RAM and a 486 CPU"/>
 		<part name="cdrom" interface="fmt_cdrom">
 			<diskarea name="cdrom">
-				<disk name="elfish" sha1="c0dd2d0c0caaea9098de8a550aac7b5005030f8f" />
+				<disk name="elfish (japan)" sha1="8711c6e0bbf4b38923ce9ae93c1bf842b0ee6be0" />
 			</diskarea>
 		</part>
 	</software>
@@ -4094,11 +4327,12 @@ User/save disks that can be created from the game itself are not included.
 		<rom name="Elfish Lite.img" size="126655200" crc="8515a508" sha1="2440ea0d2ff9a7dd587987726e38c9de265468c1"/>
 		<rom name="Elfish Lite.sub" size="5169600" crc="c7a5fcd9" sha1="7996e1b60962de0b4ca65371e87889e3fcde1195"/>
 		-->
-		<description>Elfish Lite</description>
+		<description>ElFish Lite</description>
 		<year>1993</year>
 		<publisher>富士通 (Fujitsu)</publisher>
 		<info name="alt_title" value="エル・フィッシュ LITE" />
 		<info name="release" value="199311xx" />
+		<info name="usage" value="Requires 2 MB RAM"/>
 		<part name="cdrom" interface="fmt_cdrom">
 			<diskarea name="cdrom">
 				<disk name="elfish lite" sha1="1667eb91450e756ae37910aa9291957430fc588b" />
@@ -4119,6 +4353,7 @@ User/save disks that can be created from the game itself are not included.
 		<publisher>マイクロキャビン (Micro Cabin)</publisher>
 		<info name="alt_title" value="エルムナイト" />
 		<info name="release" value="199211xx" />
+		<info name="usage" value="Requires 2 MB RAM"/>
 		<part name="cdrom" interface="fmt_cdrom">
 			<diskarea name="cdrom">
 				<disk name="elm knight" sha1="98ff3cc7c954c1aa98b3c966d420bc72cb7fb423" />
@@ -4139,6 +4374,7 @@ User/save disks that can be created from the game itself are not included.
 		<publisher>グローディア (Glodia)</publisher>
 		<info name="alt_title" value="エメラルド・ドラゴン" />
 		<info name="release" value="199205xx" />
+		<info name="usage" value="Requires 2 MB RAM"/>
 		<part name="flop1" interface="floppy_3_5">
 			<feature name="part_id" value="System Disk" />
 			<dataarea name="flop" size="1261568">
@@ -4170,6 +4406,7 @@ User/save disks that can be created from the game itself are not included.
 		<publisher>光栄 (Koei)</publisher>
 		<info name="release" value="199403xx" />
 		<info name="alt_title" value="エミット Vol. 1 時の迷子" />
+		<info name="usage" value="Requires 2 MB RAM"/>
 		<part name="flop1" interface="floppy_3_5">
 			<dataarea name="flop" size="1261568">
 				<rom name="emit1.hdm" size="1261568" crc="660198bd" sha1="f84e0ede2de479d61de72c59e64a5c6829ae9cb7" offset="000000" />
@@ -4201,6 +4438,7 @@ User/save disks that can be created from the game itself are not included.
 		<publisher>光栄 (Koei)</publisher>
 		<info name="release" value="199407xx" />
 		<info name="alt_title" value="エミット Vol. 2 命がけの旅" />
+		<info name="usage" value="Requires 2 MB RAM"/>
 		<part name="flop1" interface="floppy_3_5">
 			<dataarea name="flop" size="1261568">
 				<rom name="emit2.hdm" size="1261568" crc="b0e599e6" sha1="a7ba288dd17aa136e3fad5d5d070d5c87c61d5b6" offset="000000" />
@@ -4231,6 +4469,7 @@ User/save disks that can be created from the game itself are not included.
 		<publisher>光栄 (Koei)</publisher>
 		<info name="release" value="199409xx" />
 		<info name="alt_title" value="エミット Vol. 3 私にさよならを" />
+		<info name="usage" value="Requires 2 MB RAM"/>
 		<part name="flop1" interface="floppy_3_5">
 			<dataarea name="flop" size="1261568">
 				<rom name="emit3.hdm" size="1261568" crc="4e00e431" sha1="8feb87e951bb4030c085a3a37add7091533c7272" />
@@ -4363,6 +4602,7 @@ User/save disks that can be created from the game itself are not included.
 		<publisher>電脳商会 (Dennou Shoukai)</publisher>
 		<info name="alt_title" value="宴会王の逆襲" />
 		<info name="release" value="199108xx" />
+		<info name="usage" value="Requires 2 MB RAM"/>
 		<part name="cdrom" interface="fmt_cdrom">
 			<diskarea name="cdrom">
 				<disk name="enkaio2" sha1="ae073ccdac82eae6da15ee3d9fbcb7046f542721" />
@@ -4383,6 +4623,7 @@ User/save disks that can be created from the game itself are not included.
 		<publisher>シーズウェア (C's Ware)</publisher>
 		<info name="alt_title" value="悦楽の学園" />
 		<info name="release" value="199408xx" />
+		<info name="usage" value="Requires 2 MB RAM"/>
 		<part name="cdrom" interface="fmt_cdrom">
 			<diskarea name="cdrom">
 				<disk name="etsuraku no gakuen" sha1="0c8f0badf5a5dbd86ad56c5302d5db519d828fd5" />
@@ -4403,6 +4644,7 @@ User/save disks that can be created from the game itself are not included.
 		<publisher>光栄 (Koei)</publisher>
 		<info name="alt_title" value="ヨーロッパ戦線" />
 		<info name="release" value="199207xx" />
+		<info name="usage" value="Requires 2 MB RAM"/>
 		<part name="flop1" interface="floppy_3_5">
 			<feature name="part_id" value="User Disk" />
 			<dataarea name="flop" size="1261568">
@@ -4448,6 +4690,7 @@ User/save disks that can be created from the game itself are not included.
 		<publisher>アモルファス (Amorphous)</publisher>
 		<info name="alt_title" value="エクセレント10" />
 		<info name="release" value="199010xx" />
+		<info name="usage" value="Requires 2 MB RAM"/>
 		<part name="cdrom" interface="fmt_cdrom">
 			<diskarea name="cdrom">
 				<disk name="excellent 10" sha1="ddaf24560a029527fcd02d0cd1fd1d09e2913b3f" />
@@ -4471,6 +4714,7 @@ User/save disks that can be created from the game itself are not included.
 		<description>Exciting CD</description>
 		<year>1994</year>
 		<publisher>富士通 (Fujitsu)</publisher>
+		<info name="usage" value="Requires 2 MB RAM"/>
 		<part name="cdrom1" interface="fmt_cdrom">
 			<diskarea name="cdrom">
 				<disk name="exciting cd (disc 1)" sha1="f8840ecca419df7da393dccb844471d5324cab23" />
@@ -4499,6 +4743,7 @@ User/save disks that can be created from the game itself are not included.
 		<description>Exciting CD '94 Summer</description>
 		<year>1994</year>
 		<publisher>富士通 (Fujitsu)</publisher>
+		<info name="usage" value="Requires 2 MB RAM"/>
 		<part name="cdrom1" interface="fmt_cdrom">
 			<diskarea name="cdrom">
 				<disk name="exciting cd '94 summer (disc 1)" sha1="267497e6ea4ee286e702d5525f141585bdef0f7f" />
@@ -4524,6 +4769,7 @@ User/save disks that can be created from the game itself are not included.
 		<publisher>サイベル (Cybelle)</publisher>
 		<info name="alt_title" value="アイ・オブ・ザ・ビホルダー2 ザ・レジェンド・オブ・ダークムーン" />
 		<info name="release" value="199311xx" />
+		<info name="usage" value="Requires 2 MB RAM"/>
 		<part name="cdrom" interface="fmt_cdrom">
 			<diskarea name="cdrom">
 				<disk name="eye of the beholder ii" sha1="50657bf7d7fc751c16975680410ea390f720084e" />
@@ -4543,9 +4789,38 @@ User/save disks that can be created from the game itself are not included.
 		<year>1993</year>
 		<publisher>イマジニア (Imagineer)</publisher>
 		<info name="release" value="199303xx" />
+		<info name="usage" value="Requires 2 MB RAM"/>
 		<part name="cdrom" interface="fmt_cdrom">
 			<diskarea name="cdrom">
 				<disk name="f29 retaliator" sha1="6da6228541bd192aac9c56db97d5b260c6edc6ca" />
+			</diskarea>
+		</part>
+	</software>
+
+	<!-- Hangs after getting a strike -->
+	<software name="famist90" supported="no">
+		<!--
+		Origin: redump.org
+		<rom name="Pro Yakyuu Family Stadium - 90-nendo Pennant Race-ban (Japan) (Track 01).bin" size="9532656" crc="195eda5e" sha1="104ec7347d3e9aac9dd4a0700025dfe4f54edf39"/>
+		<rom name="Pro Yakyuu Family Stadium - 90-nendo Pennant Race-ban (Japan) (Track 02).bin" size="1439424" crc="bd6fbf1f" sha1="1a29fcce39db439b006f02c793c9addf7aab8930"/>
+		<rom name="Pro Yakyuu Family Stadium - 90-nendo Pennant Race-ban (Japan) (Track 03).bin" size="1041936" crc="3ba98a76" sha1="9cd860ccbfab844809d8c45d88e8b220c3846b10"/>
+		<rom name="Pro Yakyuu Family Stadium - 90-nendo Pennant Race-ban (Japan) (Track 04).bin" size="1070160" crc="be3d15a6" sha1="02dcf0743bdfd09f2a9dfeb9de4325bcd7593099"/>
+		<rom name="Pro Yakyuu Family Stadium - 90-nendo Pennant Race-ban (Japan) (Track 05).bin" size="1110144" crc="f96e6334" sha1="cde6801ddab0c857860a9b42329124380f160dd2"/>
+		<rom name="Pro Yakyuu Family Stadium - 90-nendo Pennant Race-ban (Japan) (Track 06).bin" size="1053696" crc="39ce492e" sha1="08e890e26b0d8de5d058105e1d8ec10d81ad5d50"/>
+		<rom name="Pro Yakyuu Family Stadium - 90-nendo Pennant Race-ban (Japan) (Track 07).bin" size="1305360" crc="4c7a574b" sha1="b56eea3e4bbc48b943236922917e349058430d0e"/>
+		<rom name="Pro Yakyuu Family Stadium - 90-nendo Pennant Race-ban (Japan) (Track 08).bin" size="1091328" crc="1efdb8fe" sha1="7c418eefe4c6879d782c49174e37dc123d708c51"/>
+		<rom name="Pro Yakyuu Family Stadium - 90-nendo Pennant Race-ban (Japan) (Track 09).bin" size="1105440" crc="e76fa141" sha1="3807d895846e23c4a691505aa22ca5b5b238bced"/>
+		<rom name="Pro Yakyuu Family Stadium - 90-nendo Pennant Race-ban (Japan) (Track 10).bin" size="1159536" crc="c8c61b2f" sha1="4079226c26ae3482ceaf3ce2162dbfacda112a40"/>
+		<rom name="Pro Yakyuu Family Stadium - 90-nendo Pennant Race-ban (Japan).cue" size="1542" crc="7029a486" sha1="f7074a2e602c1d835eddc87bc650f98e321c7b72"/>
+		-->
+		<description>Pro Yakyuu Family Stadium - 90-nendo Pennant Race-ban</description>
+		<year>1990</year>
+		<publisher>ゲームアーツ (Game Arts)</publisher>
+		<info name="alt_title" value="プロ野球ファミリー・スタジアム　９０年度　ペナント・レース版" />
+		<info name="release" value="199009xx" />
+		<part name="cdrom" interface="fmt_cdrom">
+			<diskarea name="cdrom">
+				<disk name="pro yakyuu family stadium - 90-nendo pennant race-ban (japan)" sha1="da59ba87b6ebd5ded5dbad2576466ef2d377e370" />
 			</diskarea>
 		</part>
 	</software>
@@ -4565,6 +4840,7 @@ User/save disks that can be created from the game itself are not included.
 		<publisher>ビング (Ving)</publisher>
 		<info name="alt_title" value="ファイナル・ブロー" />
 		<info name="release" value="199003xx" />
+		<info name="usage" value="Requires 2 MB RAM"/>
 		<part name="cdrom" interface="fmt_cdrom">
 			<diskarea name="cdrom">
 				<disk name="final blow (japan)" sha1="8884cd2ba7b9d32bea083a15f222d79b06366874" />
@@ -4585,6 +4861,7 @@ User/save disks that can be created from the game itself are not included.
 		<publisher>ビクター音楽産業 (Victor Musical Industries)</publisher>
 		<info name="alt_title" value="フラッシュバック" />
 		<info name="release" value="199404xx" />
+		<info name="usage" value="Requires 2 MB RAM"/>
 		<part name="cdrom" interface="fmt_cdrom">
 			<diskarea name="cdrom">
 				<disk name="flashback" sha1="af8329500f8ac14f4a504ad2d56b7eb85f890f72" />
@@ -4623,6 +4900,7 @@ User/save disks that can be created from the game itself are not included.
 		<year>1993</year>
 		<publisher>富士通 (Fujitsu)</publisher>
 		<info name="release" value="199311xx" />
+		<info name="usage" value="Requires 2 MB RAM"/>
 		<part name="cdrom" interface="fmt_cdrom">
 			<diskarea name="cdrom">
 				<disk name="fm towns super technology demo 1993" sha1="4a685d1a33f7d75956ec0da7429c8d24b98fd014" />
@@ -4699,6 +4977,7 @@ User/save disks that can be created from the game itself are not included.
 		<year>1992</year>
 		<publisher>富士通 (Fujitsu)</publisher>
 		<info name="release" value="199202xx" />
+		<info name="usage" value="Requires 2 MB RAM"/>
 		<part name="cdrom" interface="fmt_cdrom">
 			<diskarea name="cdrom">
 				<disk name="fractal engine demo" sha1="97c2b8955b99b309a1f7bb6333eef3da0577d195" />
@@ -4718,6 +4997,7 @@ User/save disks that can be created from the game itself are not included.
 		<year>1992</year>
 		<publisher>Sofcom</publisher>
 		<info name="release" value="199211xx" />
+		<info name="usage" value="Requires 2 MB RAM"/>
 		<part name="cdrom" interface="fmt_cdrom">
 			<diskarea name="cdrom">
 				<disk name="free will - knight of argent" sha1="ad5646cf46d8b0243220dd783e96f556e9a85467" />
@@ -4763,6 +5043,7 @@ User/save disks that can be created from the game itself are not included.
 		<year>1991</year>
 		<publisher>富士通 (Fujitsu)</publisher>
 		<info name="release" value="199111xx" />
+		<info name="usage" value="Requires 2 MB RAM"/>
 		<part name="cdrom1" interface="fmt_cdrom">
 			<feature name="part_id" value="Program Disk"/>
 			<diskarea name="cdrom">
@@ -4794,6 +5075,7 @@ User/save disks that can be created from the game itself are not included.
 		<year>1992</year>
 		<publisher>富士通 (Fujitsu)</publisher>
 		<info name="release" value="199205xx" />
+		<info name="usage" value="Requires 2 MB RAM"/>
 		<part name="cdrom" interface="fmt_cdrom">
 			<diskarea name="cdrom">
 				<disk name="free software collection 5 (japan)" sha1="b429e65d9aaba3a54ea281c7fd70bee8eb0ddeea" />
@@ -4813,6 +5095,7 @@ User/save disks that can be created from the game itself are not included.
 		<year>1993</year>
 		<publisher>富士通 (Fujitsu)</publisher>
 		<info name="release" value="199306xx" />
+		<info name="usage" value="Requires 2 MB RAM"/>
 		<part name="cdrom" interface="fmt_cdrom">
 			<diskarea name="cdrom">
 				<disk name="free software collection 6" sha1="02f5d485d0be0cce79c6c535e2e14e22769d6110" />
@@ -4832,6 +5115,7 @@ User/save disks that can be created from the game itself are not included.
 		<year>1993</year>
 		<publisher>富士通 (Fujitsu)</publisher>
 		<info name="release" value="199312xx" />
+		<info name="usage" value="Requires 2 MB RAM"/>
 		<part name="cdrom" interface="fmt_cdrom">
 			<diskarea name="cdrom">
 				<disk name="free software collection 7" sha1="89886e68a793ebd0295c437e9272ca2b285f6ddb" />
@@ -4851,6 +5135,7 @@ User/save disks that can be created from the game itself are not included.
 		<year>1994</year>
 		<publisher>富士通 (Fujitsu)</publisher>
 		<info name="release" value="199406xx" />
+		<info name="usage" value="Requires 2 MB RAM"/>
 		<part name="cdrom" interface="fmt_cdrom">
 			<diskarea name="cdrom">
 				<disk name="free software collection 8" sha1="bdae35dab6691274f66654c85cc6fbe9db22a16a" />
@@ -4870,6 +5155,7 @@ User/save disks that can be created from the game itself are not included.
 		<year>1994</year>
 		<publisher>富士通 (Fujitsu)</publisher>
 		<info name="release" value="199412xx" />
+		<info name="usage" value="Requires 2 MB RAM"/>
 		<part name="cdrom" interface="fmt_cdrom">
 			<diskarea name="cdrom">
 				<disk name="free software collection 9" sha1="13a1990a9aa59e3b186eeffa8162ee1ecd487c0b" />
@@ -4889,6 +5175,7 @@ User/save disks that can be created from the game itself are not included.
 		<year>1995</year>
 		<publisher>富士通 (Fujitsu)</publisher>
 		<info name="release" value="199506xx" />
+		<info name="usage" value="Requires 2 MB RAM"/>
 		<part name="cdrom" interface="fmt_cdrom">
 			<diskarea name="cdrom">
 				<disk name="free software collection 10" sha1="d0624c4b4c2a02b2a808e905f10d827efbedb4d2" />
@@ -4908,9 +5195,28 @@ User/save disks that can be created from the game itself are not included.
 		<year>1995</year>
 		<publisher>富士通 (Fujitsu)</publisher>
 		<info name="release" value="199506xx" />
+		<info name="usage" value="Requires 2 MB RAM"/>
 		<part name="cdrom" interface="fmt_cdrom">
 			<diskarea name="cdrom">
 				<disk name="free software collection 11" sha1="81a0100b41153fbaac04a37a21407b40a57bf568" />
+			</diskarea>
+		</part>
+	</software>
+
+	<software name="fscmarty">
+		<!--
+		Origin: redump.org
+		<rom name="Free Software Collection MaRTy.1 (Japan).bin" size="158407200" crc="27d18712" sha1="4292643928136a6113f7e5b146ca1a9567023f8b"/>
+		<rom name="Free Software Collection MaRTy.1 (Japan).cue" size="106" crc="fa39270f" sha1="71418990c5fa33fca2976d0c521338a0e66ec659"/>
+		-->
+		<description>Free Software Collection Marty 1</description>
+		<year>1992</year>
+		<publisher>富士通 (Fujitsu)</publisher>
+		<info name="release" value="199211xx" />
+		<info name="usage" value="Requires 2 MB RAM"/>
+		<part name="cdrom" interface="fmt_cdrom">
+			<diskarea name="cdrom">
+				<disk name="free software collection marty.1 (japan)" sha1="25b54e516972dcd33eba8bb21c3d3f9f8c50d576" />
 			</diskarea>
 		</part>
 	</software>
@@ -4928,6 +5234,7 @@ User/save disks that can be created from the game itself are not included.
 		<publisher>ビング (Ving)</publisher>
 		<info name="alt_title" value="飛翔鮫" />
 		<info name="release" value="199309xx" />
+		<info name="usage" value="Requires 2 MB RAM"/>
 		<part name="cdrom" interface="fmt_cdrom">
 			<diskarea name="cdrom">
 				<disk name="hishouzame" sha1="4704726801f67e1cd09ba1f7475985036edff19c" />
@@ -4935,6 +5242,7 @@ User/save disks that can be created from the game itself are not included.
 		</part>
 	</software>
 
+	<!-- Works only on the 386SX-based models (Marty & UX). Probably an emulation bug, but it needs to be confirmed on real hardware. -->
 	<software name="funnybee">
 		<!--
 		Origin: Neo Kobe Collection
@@ -5023,6 +5331,7 @@ User/save disks that can be created from the game itself are not included.
 		<year>1991</year>
 		<publisher>富士通 (Fujitsu)</publisher>
 		<info name="release" value="199103xx" />
+		<info name="usage" value="Requires 2 MB RAM"/>
 		<part name="cdrom" interface="fmt_cdrom">
 			<diskarea name="cdrom">
 				<disk name="freeware collection 3" sha1="60a1f6791c4304172f9b935fe61c736da6d6b3f6" />
@@ -5049,6 +5358,7 @@ User/save disks that can be created from the game itself are not included.
 		<publisher>富士通 (Fujitsu)</publisher>
 		<info name="alt_title" value="富士通 Habitat V2.1L10" />
 		<info name="release" value="199405xx" />
+		<info name="usage" value="Requires 2 MB RAM"/>
 		<part name="flop1" interface="floppy_3_5">
 			<dataarea name="flop" size="1261568">
 				<rom name="habitatv2.1l10.hdm" size="1261568" crc="4dc2691b" sha1="a99ada487e1970240a284eb67f7420b13c45f265" />
@@ -5079,6 +5389,7 @@ User/save disks that can be created from the game itself are not included.
 		<publisher>エー・エム・アール (AMR)</publisher>
 		<info name="alt_title" value="ジーファイヴ" />
 		<info name="release" value="198907xx" />
+		<info name="usage" value="Requires 2 MB RAM"/>
 		<part name="cdrom" interface="fmt_cdrom">
 			<diskarea name="cdrom">
 				<disk name="g5 (japan)" sha1="3038fd11e7c7f58b17ef96fb9c872f4c7924915a" />
@@ -5099,7 +5410,7 @@ User/save disks that can be created from the game itself are not included.
 		<publisher>アリスソフト (AliceSoft)</publisher>
 		<info name="alt_title" value="学園KING -日出彦学校を作る-" />
 		<info name="release" value="199606xx" />
-		<info name="usage" value="Requires HDD installation"/>
+		<info name="usage" value="Requires HDD installation and 2 MB RAM"/>
 		<part name="cdrom" interface="fmt_cdrom">
 			<diskarea name="cdrom">
 				<disk name="gakuen king" sha1="c02be1aa661a23f536e8ccb2413e0cc528226757" />
@@ -5127,6 +5438,7 @@ User/save disks that can be created from the game itself are not included.
 		<publisher>CRI</publisher>
 		<info name="alt_title" value="ギャラクシーフォースII" />
 		<info name="release" value="199103xx" />
+		<info name="usage" value="Requires 2 MB RAM"/>
 		<part name="cdrom" interface="fmt_cdrom">
 			<diskarea name="cdrom">
 				<disk name="galaxy force ii" sha1="7b012179cd21c6ac3f58d6b2cb5bde0782007d28" />
@@ -5146,6 +5458,7 @@ User/save disks that can be created from the game itself are not included.
 		<year>1992</year>
 		<publisher>徳間書店インターメディア (Tokuma Shoten Intermedia)</publisher>
 		<info name="alt_title" value="GAMEテクノポリス スーパーコレクション1" />
+		<info name="usage" value="Requires 2 MB RAM"/>
 		<part name="cdrom" interface="fmt_cdrom">
 			<diskarea name="cdrom">
 				<disk name="game technopolis super collection 1" sha1="c35229967fd790450d36c9ec1e4c70b9d3d7d336" />
@@ -5163,6 +5476,7 @@ User/save disks that can be created from the game itself are not included.
 		<year>1993</year>
 		<publisher>徳間書店インターメディア (Tokuma Shoten Intermedia)</publisher>
 		<info name="alt_title" value="GAMEテクノポリス スーパーコレクション2" />
+		<info name="usage" value="Requires 2 MB RAM"/>
 		<part name="cdrom" interface="fmt_cdrom">
 			<diskarea name="cdrom">
 				<disk name="game technopolis super collection 2" sha1="71e1cb211ed1055086162de74fd265498a986546" />
@@ -5192,6 +5506,7 @@ User/save disks that can be created from the game itself are not included.
 		<publisher>日本アプリケーション (Nihon Application)</publisher>
 		<info name="alt_title" value="ＧＥＫＩＲＩＮ 失なわれし宝剣" />
 		<info name="release" value="199412xx" />
+		<info name="usage" value="Requires 2 MB RAM"/>
 		<part name="cdrom" interface="fmt_cdrom">
 			<diskarea name="cdrom">
 				<disk name="gekirin" sha1="9fb33975654240e0916d76494443c3879c971ae3" />
@@ -5233,6 +5548,7 @@ User/save disks that can be created from the game itself are not included.
 		<publisher>ビング (Ving)</publisher>
 		<info name="alt_title" value="現代大戦略ＥＸスペシャル" />
 		<info name="release" value="199409xx" />
+		<info name="usage" value="Requires 2 MB RAM"/>
 		<part name="cdrom" interface="fmt_cdrom">
 			<diskarea name="cdrom">
 				<disk name="gendai daisenryaku ex special" sha1="28d5b423ebb87c784a117aad28308522dc54dd56" />
@@ -5251,6 +5567,7 @@ User/save disks that can be created from the game itself are not included.
 		<publisher>Zoom</publisher>
 		<info name="alt_title" value="ジェノサイド・スクウエア" />
 		<info name="release" value="199304xx" />
+		<info name="usage" value="Requires 2 MB RAM"/>
 		<part name="cdrom" interface="fmt_cdrom">
 			<diskarea name="cdrom">
 				<disk name="genocide^2 - genocide square (japan)" sha1="0bb72510a65ed2110efdd913889506776120b7ef" />
@@ -5271,6 +5588,7 @@ User/save disks that can be created from the game itself are not included.
 		<publisher>インターハート (Interheart)</publisher>
 		<info name="alt_title" value="戯画もーしょん" />
 		<info name="release" value="199503xx" />
+		<info name="usage" value="Requires 2 MB RAM"/>
 		<part name="cdrom" interface="fmt_cdrom">
 			<diskarea name="cdrom">
 				<disk name="giga motion" sha1="db0c83a91eba1a3f840f1d244716e0477e3b1ee6" />
@@ -5289,6 +5607,7 @@ User/save disks that can be created from the game itself are not included.
 		<publisher>ボーステック (Bothtec)</publisher>
 		<info name="alt_title" value="銀河英雄伝説III SP" />
 		<info name="release" value="199312xx" />
+		<info name="usage" value="Requires 2 MB RAM"/>
 		<part name="flop1" interface="floppy_3_5">
 			<feature name="part_id" value="Game Disk" />
 			<dataarea name="flop" size="1261568">
@@ -5315,6 +5634,7 @@ User/save disks that can be created from the game itself are not included.
 		<publisher>ウルフチーム (WolfTeam)</publisher>
 		<info name="alt_title" value="轟2タウンズスペシャル" />
 		<info name="release" value="198909xx" />
+		<info name="usage" value="Requires 2 MB RAM"/>
 		<part name="flop1" interface="floppy_3_5">
 			<feature name="part_id" value="System Disk" />
 			<dataarea name="flop" size="1261568">
@@ -5338,6 +5658,7 @@ User/save disks that can be created from the game itself are not included.
 		<year>1994</year>
 		<publisher>ミンク (Mink)</publisher>
 		<info name="release" value="199411xx" />
+		<info name="usage" value="Requires 2 MB RAM"/>
 		<part name="cdrom" interface="fmt_cdrom">
 			<diskarea name="cdrom">
 				<disk name="gokko vol. 01 - doctor (japan)" sha1="aef878a0937ec2e9350467de8f94cc3118cd7420" />
@@ -5355,6 +5676,7 @@ User/save disks that can be created from the game itself are not included.
 		<year>1994</year>
 		<publisher>ミンク (Mink)</publisher>
 		<info name="release" value="199412xx" />
+		<info name="usage" value="Requires 2 MB RAM"/>
 		<part name="cdrom" interface="fmt_cdrom">
 			<diskarea name="cdrom">
 				<disk name="gokko vol. 02 - school gal's (japan)" sha1="88ff6c151f5cfa8efb54b90ba641e58d359aba42" />
@@ -5372,6 +5694,7 @@ User/save disks that can be created from the game itself are not included.
 		<year>1994</year>
 		<publisher>ミンク (Mink)</publisher>
 		<info name="release" value="199412xx" />
+		<info name="usage" value="Requires 2 MB RAM"/>
 		<part name="cdrom" interface="fmt_cdrom">
 			<diskarea name="cdrom">
 				<disk name="gokko vol. 03 - etcetera (japan)" sha1="52dfd5efdfb673a4bb882f13e7394844b0ecd4bb" />
@@ -5392,6 +5715,7 @@ User/save disks that can be created from the game itself are not included.
 		<publisher>ぎょうせい (Gyousei)</publisher>
 		<info name="alt_title" value="メルヘン図書館　グリム童話　赤ずきん" />
 		<info name="release" value="198912xx" />
+		<info name="usage" value="Requires 2 MB RAM"/>
 		<part name="cdrom" interface="fmt_cdrom">
 			<diskarea name="cdrom">
 				<disk name="grimm" sha1="78e0cbc80ad750219b9cf247052e1018a57c4f78" />
@@ -5410,6 +5734,7 @@ User/save disks that can be created from the game itself are not included.
 		<publisher>ウルフチーム (WolfTeam)</publisher>
 		<info name="alt_title" value="ＧＵＬＦ ＷＡＲ 蒼鋼伝" />
 		<info name="release" value="199312xx" />
+		<info name="usage" value="Requires 2 MB RAM"/>
 		<part name="flop1" interface="floppy_3_5">
 			<feature name="part_id" value="System Disk" />
 			<dataarea name="flop" size="1261568">
@@ -5436,6 +5761,7 @@ User/save disks that can be created from the game itself are not included.
 		<publisher>アクティブ (Active)</publisher>
 		<info name="alt_title" value="ガンブレイズ" />
 		<info name="release" value="199412xx" />
+		<info name="usage" value="Requires 2 MB RAM"/>
 		<part name="cdrom" interface="fmt_cdrom">
 			<diskarea name="cdrom">
 				<disk name="gunblaze" sha1="2ef094206014ebbe9606e2eca117779e833bd1eb" />
@@ -5445,20 +5771,38 @@ User/save disks that can be created from the game itself are not included.
 
 	<software name="gundamhc">
 		<!--
-		Origin: Neo Kobe Collection
-		<rom name="Mobile Suit Gundam Hyper Classic Operation.ccd" size="4391" crc="0abaaa64" sha1="cdc24486041c41ad3ff10c21cddec6d35b62b162"/>
-		<rom name="Mobile Suit Gundam Hyper Classic Operation.cue" size="858" crc="c46ffb12" sha1="cb4d797e05e7157c979442fee8453d2daadc4049"/>
-		<rom name="Mobile Suit Gundam Hyper Classic Operation.img" size="266745024" crc="d99bd13a" sha1="139c1c8c34b443c9888a6ce3d8584599a4e39fec"/>
-		<rom name="Mobile Suit Gundam Hyper Classic Operation.sub" size="10887552" crc="46761a4e" sha1="c960498b2bd3161662f5f650a81c96f60d6fa5a6"/>
+		Origin: redump.org
+		<rom name="Mobile Suit Gundam - Hyper Classic Operation (Japan) (Track 01).bin" size="105840000" crc="9c83fc85" sha1="7ff4a2c8e284b55d0223c4e6d03a095388f7ca0b"/>
+		<rom name="Mobile Suit Gundam - Hyper Classic Operation (Japan) (Track 02).bin" size="10282944" crc="985372c6" sha1="1e9414b2b417210951f4a850aea7fedcf939dc50"/>
+		<rom name="Mobile Suit Gundam - Hyper Classic Operation (Japan) (Track 03).bin" size="8925840" crc="e0ac493b" sha1="32bfef351e3f360512b1194cf8fdd3dd3f9993cb"/>
+		<rom name="Mobile Suit Gundam - Hyper Classic Operation (Japan) (Track 04).bin" size="7726320" crc="1ba8ac34" sha1="1c4f7da1df9971327fb815cc4c8e8f44ddf8dfeb"/>
+		<rom name="Mobile Suit Gundam - Hyper Classic Operation (Japan) (Track 05).bin" size="9784320" crc="49e4646e" sha1="d5b272e3c3291952a29d3f96abffdbb996a2c630"/>
+		<rom name="Mobile Suit Gundam - Hyper Classic Operation (Japan) (Track 06).bin" size="8772960" crc="0b255eef" sha1="26432fbf3c5911738d499fb3a4c4805d6dabeb08"/>
+		<rom name="Mobile Suit Gundam - Hyper Classic Operation (Japan) (Track 07).bin" size="7745136" crc="c29d35a8" sha1="ed4b54632727e4a09e907317a3052c8b7268eddb"/>
+		<rom name="Mobile Suit Gundam - Hyper Classic Operation (Japan) (Track 08).bin" size="8972880" crc="50ecdc37" sha1="8b3ed349bec078c775e37050c76a5c651cc22c59"/>
+		<rom name="Mobile Suit Gundam - Hyper Classic Operation (Japan) (Track 09).bin" size="7267680" crc="fe46bb82" sha1="1c0705457a762fa80f2b58155a71aca7f22e21e4"/>
+		<rom name="Mobile Suit Gundam - Hyper Classic Operation (Japan) (Track 10).bin" size="10000704" crc="b2bac9d3" sha1="4934a81051db17e5b4f8369fd8f8a8cb494ec44b"/>
+		<rom name="Mobile Suit Gundam - Hyper Classic Operation (Japan) (Track 11).bin" size="15652560" crc="160c61da" sha1="07cd68b6991e66497841e8dd6c74a512f27b78f8"/>
+		<rom name="Mobile Suit Gundam - Hyper Classic Operation (Japan) (Track 12).bin" size="9062256" crc="45f9ad44" sha1="92f77bf277aaeeb59a7625de1e7f1b374506bbdf"/>
+		<rom name="Mobile Suit Gundam - Hyper Classic Operation (Japan) (Track 13).bin" size="9389184" crc="8aef3dd3" sha1="d98aafeac2e644faa9a21758dc3e1f2d9d97f2a6"/>
+		<rom name="Mobile Suit Gundam - Hyper Classic Operation (Japan) (Track 14).bin" size="5127360" crc="33d2e3c1" sha1="961026fed20034e5b9b963f2375561cdc9fa08c5"/>
+		<rom name="Mobile Suit Gundam - Hyper Classic Operation (Japan) (Track 15).bin" size="8709456" crc="798de889" sha1="b2329c90e4c2dcf7ab6ca7e5c1a680913d203639"/>
+		<rom name="Mobile Suit Gundam - Hyper Classic Operation (Japan) (Track 16).bin" size="5962320" crc="f0965b70" sha1="0f00cdbef3782e43d2ce3e60dc4a35b74a93752b"/>
+		<rom name="Mobile Suit Gundam - Hyper Classic Operation (Japan) (Track 17).bin" size="7460544" crc="18c7e002" sha1="5c309079046b646cc39f23e7c6a43b334f46d370"/>
+		<rom name="Mobile Suit Gundam - Hyper Classic Operation (Japan) (Track 18).bin" size="7427616" crc="b1d82b7d" sha1="fcb2f8831c7ac0b6a39a8f2d325c95c8933c1437"/>
+		<rom name="Mobile Suit Gundam - Hyper Classic Operation (Japan) (Track 19).bin" size="7801584" crc="e06c62cc" sha1="64cc97ecf624c34cbf4f8cf719d1471eba56bb14"/>
+		<rom name="Mobile Suit Gundam - Hyper Classic Operation (Japan) (Track 20).bin" size="4833360" crc="5783247d" sha1="4d361a138207ed00a8e88cb89363b4d3822ccf43"/>
+		<rom name="Mobile Suit Gundam - Hyper Classic Operation (Japan).cue" size="2945" crc="7a37b259" sha1="1ed53837e6fd6c9cfeab4699101156671e14267f"/>
 		-->
 		<description>Mobile Suit Gundam - Hyper Classic Operation</description>
 		<year>1992</year>
 		<publisher>ファミリーソフト (Family Soft)</publisher>
 		<info name="alt_title" value="機動戦士ガンダム ハイパー クラシック オペレーション" />
 		<info name="release" value="199208xx" />
+		<info name="usage" value="Requires 2 MB RAM"/>
 		<part name="cdrom" interface="fmt_cdrom">
 			<diskarea name="cdrom">
-				<disk name="mobile suit gundam hyper classic operation" sha1="6c4a876c7973e4652d06c8ad1a9b3b3769e3f90e" />
+				<disk name="mobile suit gundam - hyper classic operation (japan)" sha1="b2880252a789e03118cce630d3a3ed410f22cc60" />
 			</diskarea>
 		</part>
 	</software>
@@ -5476,6 +5820,7 @@ User/save disks that can be created from the game itself are not included.
 		<publisher>ファミリーソフト (Family Soft)</publisher>
 		<info name="alt_title" value="機動戦士ガンダム ハイパー デザート オペレーション" />
 		<info name="release" value="199209xx" />
+		<info name="usage" value="Requires 2 MB RAM"/>
 		<part name="cdrom" interface="fmt_cdrom">
 			<diskarea name="cdrom">
 				<disk name="mobile suit gundam hyper desert operation" sha1="05410dc1fe303c5613650f2a697d76ad769644ea" />
@@ -5500,6 +5845,7 @@ User/save disks that can be created from the game itself are not included.
 		<year>1990</year>
 		<publisher>マイクロプローズジャパン (MicroProse Japan)</publisher>
 		<info name="release" value="199010xx" />
+		<info name="usage" value="Requires 2 MB RAM"/>
 		<part name="cdrom" interface="fmt_cdrom">
 			<diskarea name="cdrom">
 				<disk name="gunship - the helicopter simulation (japan)" sha1="d60b20686c1e4ed6f791d890f397fabcc3950e32" />
@@ -5520,6 +5866,7 @@ User/save disks that can be created from the game itself are not included.
 		<publisher>フォスター (Foster)</publisher>
 		<info name="alt_title" value="花の記憶" />
 		<info name="release" value="199512xx" />
+		<info name="usage" value="Requires 2 MB RAM"/>
 		<part name="cdrom" interface="fmt_cdrom">
 			<diskarea name="cdrom">
 				<disk name="hana no kioku" sha1="d0ade7a3f7f36fa8a5f8bd6016643823a913b866" />
@@ -5540,6 +5887,7 @@ User/save disks that can be created from the game itself are not included.
 		<publisher>アクティブ (Active)</publisher>
 		<info name="alt_title" value="花札でPON！" />
 		<info name="release" value="199607xx" />
+		<info name="usage" value="Requires 2 MB RAM"/>
 		<part name="flop1" interface="floppy_3_5">
 			<feature name="part_id" value="Boot Disk" />
 			<dataarea name="flop" size="1261568">
@@ -5564,6 +5912,7 @@ User/save disks that can be created from the game itself are not included.
 		<publisher>アクティブ (Active)</publisher>
 		<info name="alt_title" value="花よりダンゴ２" />
 		<info name="release" value="19930417" />
+		<info name="usage" value="Requires 2 MB RAM"/>
 		<part name="cdrom" interface="fmt_cdrom">
 			<diskarea name="cdrom">
 				<disk name="hana yori dango 2 (japan)" sha1="15129ffdf02c307db6a8174b6c953a820497cb2f" />
@@ -5584,6 +5933,7 @@ User/save disks that can be created from the game itself are not included.
 		<publisher>ディー・オー (D.O.)</publisher>
 		<info name="alt_title" value="全日本美少女麻雀選手権大会 ハートでロン！！" />
 		<info name="release" value="199503xx" />
+		<info name="usage" value="Requires 2 MB RAM"/>
 		<part name="cdrom" interface="fmt_cdrom">
 			<diskarea name="cdrom">
 				<disk name="heart de ron!!" sha1="1c95cf153e055068b71f8fd6fffe760d1ddd2ac0" />
@@ -5603,6 +5953,7 @@ User/save disks that can be created from the game itself are not included.
 		<year>1995</year>
 		<publisher>富士通 (Fujitsu)</publisher>
 		<info name="release" value="199503xx" />
+		<info name="usage" value="Requires 4 MB RAM"/>
 		<part name="cdrom" interface="fmt_cdrom">
 			<diskarea name="cdrom">
 				<disk name="high c compiler multimedia development kit v1.7 l13" sha1="1755383d812fe07b4ad2cd0b44c111cb14b25ae7" />
@@ -5619,6 +5970,7 @@ User/save disks that can be created from the game itself are not included.
 		<description>High C Compiler Multimedia Kit v1.7 L12</description>
 		<year>1994</year>
 		<publisher>富士通 (Fujitsu)</publisher>
+		<info name="usage" value="Requires 2 MB RAM"/>
 		<part name="cdrom" interface="fmt_cdrom">
 			<diskarea name="cdrom">
 				<disk name="high c compiler multimedia kit v1.7l12 (japan)" sha1="e2a0029805fe11e0b3d312861de1d7f51950d93a" />
@@ -5626,6 +5978,7 @@ User/save disks that can be created from the game itself are not included.
 		</part>
 	</software>
 
+	<!-- These CDs are probably supposed to be self-bootable but they are missing the IPL sector. Marked as bad dumps until they are redumped. -->
 	<software name="highlt20">
 		<!--
 		Origin: Neo Kobe Collection
@@ -5642,14 +5995,15 @@ User/save disks that can be created from the game itself are not included.
 		<description>Highlight CD 20</description>
 		<year>1993</year>
 		<publisher>富士通 (Fujitsu)</publisher>
+		<info name="usage" value="Requires 2 MB RAM"/>
 		<part name="cdrom1" interface="fmt_cdrom">
 			<diskarea name="cdrom">
-				<disk name="highlight cd 20 (disc 1)" sha1="50be2720db6e121f744d12641a09168a80e330b5" />
+				<disk name="highlight cd 20 (disc 1)" sha1="50be2720db6e121f744d12641a09168a80e330b5" status="baddump" />
 			</diskarea>
 		</part>
 		<part name="cdrom2" interface="fmt_cdrom">
 			<diskarea name="cdrom">
-				<disk name="highlight cd 20 (disc 2)" sha1="b7251d8531bf3a18e32beec3e9d836de203052ac" />
+				<disk name="highlight cd 20 (disc 2)" sha1="b7251d8531bf3a18e32beec3e9d836de203052ac" status="baddump" />
 			</diskarea>
 		</part>
 	</software>
@@ -5665,6 +6019,7 @@ User/save disks that can be created from the game itself are not included.
 		<publisher>ウルフチーム (WolfTeam)</publisher>
 		<info name="alt_title" value="緋王伝II" />
 		<info name="release" value="199403xx" />
+		<info name="usage" value="Requires 2 MB RAM"/>
 		<!--
 		Note from the dumper:
 
@@ -5699,6 +6054,7 @@ User/save disks that can be created from the game itself are not included.
 		<publisher>ディー・オー (D.O.)</publisher>
 		<info name="alt_title" value="星の砂物語" />
 		<info name="release" value="199209xx" />
+		<info name="usage" value="Requires 2 MB RAM"/>
 		<part name="cdrom" interface="fmt_cdrom">
 			<diskarea name="cdrom">
 				<disk name="hoshi no suna monogatari" sha1="3484f993ecabe99049522ca7cb67334609982269" />
@@ -5719,6 +6075,7 @@ User/save disks that can be created from the game itself are not included.
 		<publisher>ディー・オー (D.O.)</publisher>
 		<info name="alt_title" value="星の砂物語2" />
 		<info name="release" value="199210xx" />
+		<info name="usage" value="Requires 2 MB RAM"/>
 		<part name="cdrom" interface="fmt_cdrom">
 			<diskarea name="cdrom">
 				<disk name="hoshi no suna monogatari 2" sha1="6fba473c7964bdd99b932d570af86a0115bcc798" />
@@ -5739,6 +6096,7 @@ User/save disks that can be created from the game itself are not included.
 		<publisher>ディー・オー (D.O.)</publisher>
 		<info name="alt_title" value="星の砂物語3" />
 		<info name="release" value="199508xx" />
+		<info name="usage" value="Requires 2 MB RAM"/>
 		<part name="cdrom" interface="fmt_cdrom">
 			<diskarea name="cdrom">
 				<disk name="hoshi no suna monogatari 3" sha1="6526c4192fcfb73dbf32f4d2a2575ae6a554d376" />
@@ -5767,6 +6125,67 @@ User/save disks that can be created from the game itself are not included.
 		<part name="cdrom" interface="fmt_cdrom">
 			<diskarea name="cdrom">
 				<disk name="hyper address" sha1="0b71c0bea2d66cf60f6c37cabc9284be794ff5cb" />
+			</diskarea>
+		</part>
+	</software>
+
+	<software name="hypchttv">
+		<!--
+		Origin: redump.org
+		<rom name="Hyper Channel - Towns TV (Japan) (Track 01).bin" size="116071200" crc="7c76a67b" sha1="2aa1212ea0e37b47d003f6ef48d324f0ec6ed23a"/>
+		<rom name="Hyper Channel - Towns TV (Japan) (Track 02).bin" size="3328080" crc="ba11e056" sha1="55baff9351caa5470efd6a8452695466e73e4389"/>
+		<rom name="Hyper Channel - Towns TV (Japan) (Track 03).bin" size="16064160" crc="432f7fbb" sha1="7f5f9f3645295934a514a7b2d2ea71bec6b310ea"/>
+		<rom name="Hyper Channel - Towns TV (Japan) (Track 04).bin" size="15946560" crc="b2c42292" sha1="94988986f6a2b541599ad579f9c8faa254998fa2"/>
+		<rom name="Hyper Channel - Towns TV (Japan) (Track 05).bin" size="10078320" crc="772aedea" sha1="f4370d4ab53f79f5a4c0aeb277924959f9a4db6c"/>
+		<rom name="Hyper Channel - Towns TV (Japan) (Track 06).bin" size="4492320" crc="0871bf77" sha1="33a932537761017ed42368e186f5de010f554a7d"/>
+		<rom name="Hyper Channel - Towns TV (Japan) (Track 07).bin" size="2081520" crc="497b2016" sha1="05724f108bc2837dba4f2bc0de6655108ae13651"/>
+		<rom name="Hyper Channel - Towns TV (Japan) (Track 08).bin" size="3586800" crc="de788d27" sha1="264ebf078af68a8ae097c51d13bc8a1822c484e4"/>
+		<rom name="Hyper Channel - Towns TV (Japan) (Track 09).bin" size="2940000" crc="1e0d79ca" sha1="4739a4b4fcfd5871090dd55853a080eb538a1c1f"/>
+		<rom name="Hyper Channel - Towns TV (Japan) (Track 10).bin" size="4421760" crc="f576e936" sha1="de0c3164b72539ebd457bfe7a9ae18cd28582fb4"/>
+		<rom name="Hyper Channel - Towns TV (Japan) (Track 11).bin" size="3857280" crc="3e8a9c8b" sha1="68f04a615581538706300d4d60ba9d0d19975a07"/>
+		<rom name="Hyper Channel - Towns TV (Japan) (Track 12).bin" size="1470000" crc="d444359b" sha1="2bad7cd29d4db5d9a8c0a1d13b1e42d57394294d"/>
+		<rom name="Hyper Channel - Towns TV (Japan) (Track 13).bin" size="2328480" crc="62b9503f" sha1="7ea5f44be38d9d0d8ca4c078dcd71333f76e1eec"/>
+		<rom name="Hyper Channel - Towns TV (Japan) (Track 14).bin" size="3057600" crc="5e0e0d13" sha1="fc52908a585d502db88c9d5950c4c75cb537ba53"/>
+		<rom name="Hyper Channel - Towns TV (Japan) (Track 15).bin" size="2822400" crc="aa3d423d" sha1="36a3aa59bb6cb77eb10dea754a4ffe2207889dcb"/>
+		<rom name="Hyper Channel - Towns TV (Japan) (Track 16).bin" size="3610320" crc="b9e41c7f" sha1="bc59bbc18c21efab294b73590e9330f574e33af4"/>
+		<rom name="Hyper Channel - Towns TV (Japan) (Track 17).bin" size="4915680" crc="078b5423" sha1="d1ac0123100f6aeb2d42e547c6ca74cc86714539"/>
+		<rom name="Hyper Channel - Towns TV (Japan) (Track 18).bin" size="5550720" crc="7bcc528d" sha1="9ef04ce718e3d6ad3e42298a75272ab7756da5b0"/>
+		<rom name="Hyper Channel - Towns TV (Japan) (Track 19).bin" size="2916480" crc="95e560c4" sha1="000ba9d90887007757ee1d1047bc00d7af5d014a"/>
+		<rom name="Hyper Channel - Towns TV (Japan) (Track 20).bin" size="13218240" crc="3f8535a5" sha1="362317ea0b421f90b5d121edbae9746cbb5d00dd"/>
+		<rom name="Hyper Channel - Towns TV (Japan) (Track 21).bin" size="11771760" crc="760a3c3f" sha1="67d95edd441471b660bb390e6d5cdc7074005195"/>
+		<rom name="Hyper Channel - Towns TV (Japan) (Track 22).bin" size="17992800" crc="9c5d4cdf" sha1="05a71792e374d7a0147af6c495afd0a3cbdbd9b5"/>
+		<rom name="Hyper Channel - Towns TV (Japan) (Track 23).bin" size="20991600" crc="c15ed924" sha1="0a2832f95fa3e0521e76142efaf4e52f0417e157"/>
+		<rom name="Hyper Channel - Towns TV (Japan) (Track 24).bin" size="10337040" crc="0df88671" sha1="db41ce531edd359a8fea98fe9a6b5fe14f470ffb"/>
+		<rom name="Hyper Channel - Towns TV (Japan) (Track 25).bin" size="2787120" crc="f8d02576" sha1="e0ce950510ceb0486928270348a47245fe8b226f"/>
+		<rom name="Hyper Channel - Towns TV (Japan) (Track 26).bin" size="15193920" crc="f9ed92f7" sha1="d66ec67d844c1135792c18f8526d664227ac9a07"/>
+		<rom name="Hyper Channel - Towns TV (Japan) (Track 27).bin" size="1140720" crc="83038b34" sha1="20744c67230ac8d5cecdf48e4b802ff11b3440bb"/>
+		<rom name="Hyper Channel - Towns TV (Japan) (Track 28).bin" size="9149280" crc="aeef02ea" sha1="c13f9395da8c9a4b2285868db3a671c4c270f733"/>
+		<rom name="Hyper Channel - Towns TV (Japan) (Track 29).bin" size="34856640" crc="44bc285e" sha1="990c8bafa607084fc48aff7537ef629f3fc27f40"/>
+		<rom name="Hyper Channel - Towns TV (Japan) (Track 30).bin" size="3386880" crc="d5388f77" sha1="4484f66ed6b1ef364d01682cceac691e53084bfa"/>
+		<rom name="Hyper Channel - Towns TV (Japan) (Track 31).bin" size="54060720" crc="e25d9f7e" sha1="d0dcd87a3efaa1ed3a3fa02c2a2c9e362f618cf0"/>
+		<rom name="Hyper Channel - Towns TV (Japan) (Track 32).bin" size="1152480" crc="de77287d" sha1="31a9914fd7260f81938714407b10b2259493a205"/>
+		<rom name="Hyper Channel - Towns TV (Japan) (Track 33).bin" size="11889360" crc="d3fefcdf" sha1="ee4ff5227fb66a087fe08f33150a548444267a89"/>
+		<rom name="Hyper Channel - Towns TV (Japan) (Track 34).bin" size="13088880" crc="4b8e4057" sha1="6f2846e8fac42e3d6113834a2e033f69522e222c"/>
+		<rom name="Hyper Channel - Towns TV (Japan) (Track 35).bin" size="16334640" crc="3cf71812" sha1="71ab7dd592a82c65b6e19bcc1c74e7b864019787"/>
+		<rom name="Hyper Channel - Towns TV (Japan) (Track 36).bin" size="17028480" crc="0db95997" sha1="eaa361e424ad931d62fc3a1ef57673bf887185e6"/>
+		<rom name="Hyper Channel - Towns TV (Japan) (Track 37).bin" size="18898320" crc="f80fc17d" sha1="343715e94c3ad4c025391991830284bef07262a6"/>
+		<rom name="Hyper Channel - Towns TV (Japan) (Track 38).bin" size="21661920" crc="245a322e" sha1="ecea325a8ffd8e7d7764205ab41903c74a5bdab0"/>
+		<rom name="Hyper Channel - Towns TV (Japan) (Track 39).bin" size="12065760" crc="511251ef" sha1="c0877fb5b0a46945bb5078dbb4d242fea17dd190"/>
+		<rom name="Hyper Channel - Towns TV (Japan) (Track 40).bin" size="15981840" crc="810c536d" sha1="4881112afee6f03db8718a05cfa3b983f5f6a498"/>
+		<rom name="Hyper Channel - Towns TV (Japan) (Track 41).bin" size="25460400" crc="95817ec3" sha1="f3cba4a653032374f74b9e18c33e3de8538fba8f"/>
+		<rom name="Hyper Channel - Towns TV (Japan) (Track 42).bin" size="25495680" crc="5a90b433" sha1="59708da0bf32fa82ddf867b5188dae46c7d7c5fc"/>
+		<rom name="Hyper Channel - Towns TV (Japan) (Track 43).bin" size="2507232" crc="9e60f96f" sha1="b91782170ed93eb405c75bda28e520349ad2eaf8"/>
+		<rom name="Hyper Channel - Towns TV (Japan).cue" size="5466" crc="a1b60a41" sha1="c9f0a268b8437cd26e84f18e786e46118b404ca1"/>
+		-->
+		<description>Hyper Channel - Towns TV</description>
+		<year>1990</year>
+		<publisher>電脳商会 (Dennou Shoukai)</publisher>
+		<info name="alt_title" value="ハイパー・チャンネル　ＴＯＷＮＳ　ＴＶ" />
+		<info name="release" value="199001xx" />
+		<info name="usage" value="Requires 2 MB RAM"/>
+		<part name="cdrom" interface="fmt_cdrom">
+			<diskarea name="cdrom">
+				<disk name="hyper channel - towns tv (japan)" sha1="acd1ed9b0b39e45360528b4678f6f318733b054b" />
 			</diskarea>
 		</part>
 	</software>
@@ -5858,6 +6277,7 @@ User/save disks that can be created from the game itself are not included.
 		<year>1993</year>
 		<publisher>ダットジャパン (Datt Japan)</publisher>
 		<info name="release" value="199304xx" />
+		<info name="usage" value="Requires 2 MB RAM"/>
 		<part name="cdrom" interface="fmt_cdrom">
 			<diskarea name="cdrom">
 				<disk name="hyper ocean" sha1="4aeb8ac2f4432832d46668e2a5572260a946724c" />
@@ -5878,6 +6298,7 @@ User/save disks that can be created from the game itself are not included.
 		<publisher>ケイエスエス (KSS)</publisher>
 		<info name="alt_title" value="アイドル プロジェクト" />
 		<info name="release" value="199507xx" />
+		<info name="usage" value="Requires 2 MB RAM"/>
 		<part name="flop1" interface="floppy_3_5">
 			<feature name="part_id" value="System Disk" />
 			<dataarea name="flop" size="1261568">
@@ -5893,20 +6314,19 @@ User/save disks that can be created from the game itself are not included.
 
 	<software name="if2">
 		<!--
-		Origin: P2P
-		<rom name="Image.cdm" size="866" crc="8a41e3f9" sha1="4cd23a08dac86d5cd9538f5676ea3b8ff5f077fd"/>
-		<rom name="Image.cue" size="71" crc="b496048a" sha1="8590392ca153b7559d50bef2f83defc45e315624"/>
-		<rom name="Image.img" size="20815200" crc="2b674736" sha1="cfc887aa25a66dc5bccd35153989d0a7590a9755"/>
-		<rom name="Image.sub" size="849600" crc="02771f97" sha1="5d0f77b63936392b2cc9db8a21f8e90d78ca0f5a"/>
+		Origin: redump.org
+		<rom name="if 2 - Invitations from Fantastic Stories (Japan).bin" size="20815200" crc="2b674736" sha1="cfc887aa25a66dc5bccd35153989d0a7590a9755"/>
+		<rom name="if 2 - Invitations from Fantastic Stories (Japan).cue" size="138" crc="5a455327" sha1="92f01383275dd88e6aff59373b52b6aa87dc3ca5"/>
 		-->
-		<description>If 2</description>
+		<description>if 2 - Invitations from Fantastic Stories</description>
 		<year>1993</year>
 		<publisher>アクティブ (Active)</publisher>
 		<info name="alt_title" value="イフ2" />
 		<info name="release" value="19931119" />
+		<info name="usage" value="Requires 2 MB RAM"/>
 		<part name="cdrom" interface="fmt_cdrom">
 			<diskarea name="cdrom">
-				<disk name="if2" sha1="5c3e29a04bc8cb173f06be5476a22d609410613a" />
+				<disk name="if 2 - invitations from fantastic stories (japan)" sha1="aab5838de5a0e92d8a887e075f913aed0acdf18d" />
 			</diskarea>
 		</part>
 	</software>
@@ -5933,14 +6353,14 @@ User/save disks that can be created from the game itself are not included.
 	<!--
 	This is named "Go Dojo Yaburi" in the Neo Kobe Collection. That name actually
 	corresponds to a different Go game, also published by Fujitsu.
-	    <rom name="Go Dojo Yaburi.ccd" size="1061" crc="833c729d" sha1="11365f1eae3e7dafdde4f38373af323986a5f4b3"/>
-	    <rom name="Go Dojo Yaburi.cue" size="224" crc="fe242e98" sha1="9ff91b652a3f2168a6a670bc646cd95f10f2735d"/>
-	    <rom name="Go Dojo Yaburi.img" size="105487200" crc="b9af10b1" sha1="3d0b1a638a3c3fa12fd1c4e76996cc75d618b5e8"/>
-	    <rom name="Go Dojo Yaburi.sub" size="4305600" crc="04ee81d0" sha1="06e02a0a1c453188324dd19e801b424175149a4b"/>
 	-->
 	<software name="igohonka">
 		<!--
 		Origin: Neo Kobe Collection
+		<rom name="Go Dojo Yaburi.ccd" size="1061" crc="833c729d" sha1="11365f1eae3e7dafdde4f38373af323986a5f4b3"/>
+		<rom name="Go Dojo Yaburi.cue" size="224" crc="fe242e98" sha1="9ff91b652a3f2168a6a670bc646cd95f10f2735d"/>
+		<rom name="Go Dojo Yaburi.img" size="105487200" crc="b9af10b1" sha1="3d0b1a638a3c3fa12fd1c4e76996cc75d618b5e8"/>
+		<rom name="Go Dojo Yaburi.sub" size="4305600" crc="04ee81d0" sha1="06e02a0a1c453188324dd19e801b424175149a4b"/>
 		-->
 		<description>Igo Doujou - Honkakuha Yose Tsumego Shinan</description>
 		<year>1989</year>
@@ -5965,6 +6385,7 @@ User/save disks that can be created from the game itself are not included.
 		<publisher>ビング (Ving)</publisher>
 		<info name="alt_title" value="イメージファイト" />
 		<info name="release" value="199011xx" />
+		<info name="usage" value="Requires 2 MB RAM"/>
 		<part name="cdrom" interface="fmt_cdrom">
 			<diskarea name="cdrom">
 				<disk name="image fight" sha1="a7f3b33eea6197eed14967902d1355c345244db0" />
@@ -5999,6 +6420,7 @@ User/save disks that can be created from the game itself are not included.
 		<publisher>サイベル (Cybelle)</publisher>
 		<info name="alt_title" value="インクレディブル・マシーン" />
 		<info name="release" value="199404xx" />
+		<info name="usage" value="Requires 2 MB RAM"/>
 		<part name="cdrom" interface="fmt_cdrom">
 			<diskarea name="cdrom">
 				<disk name="incredible machine, the (japan)" sha1="cf66d0ff684711a0bf6bb6ce4c77c867cebe32a1" />
@@ -6032,6 +6454,7 @@ User/save disks that can be created from the game itself are not included.
 		<year>1990</year>
 		<publisher>富士通 (Fujitsu)</publisher>
 		<info name="release" value="199007xx" />
+		<info name="usage" value="Requires 2 MB RAM"/>
 		<part name="cdrom" interface="fmt_cdrom">
 			<diskarea name="cdrom">
 				<disk name="indiana jones and the last crusade (japan) (en,ja)" sha1="9ac388d3e0640d45cf2469a6fe4a872a45dcd8f2" />
@@ -6053,6 +6476,7 @@ User/save disks that can be created from the game itself are not included.
 		<year>1993</year>
 		<publisher>ビクター音楽産業 (Victor Musical Industries)</publisher>
 		<info name="release" value="199308xx" />
+		<info name="usage" value="Requires 2 MB RAM"/>
 		<part name="cdrom" interface="fmt_cdrom">
 			<diskarea name="cdrom">
 				<disk name="indiana jones and the fate of atlantis" sha1="e60dff85f2932966f28732c91165dc4e483756de" />
@@ -6071,6 +6495,7 @@ User/save disks that can be created from the game itself are not included.
 		<publisher>ビクター音楽産業 (Victor Musical Industries)</publisher>
 		<info name="alt_title" value="インフェステーション 沈黙の惑星" />
 		<info name="release" value="199203xx" />
+		<info name="usage" value="Requires 2 MB RAM"/>
 		<part name="cdrom" interface="fmt_cdrom">
 			<diskarea name="cdrom">
 				<disk name="infestation" sha1="08cb569b0227db10f938adc42c92987634714787" />
@@ -6091,6 +6516,7 @@ User/save disks that can be created from the game itself are not included.
 		<publisher>光栄 (Koei)</publisher>
 		<info name="alt_title" value="伊忍道・打倒信長" />
 		<info name="release" value="199202xx" />
+		<info name="usage" value="Requires 2 MB RAM"/>
 		<part name="flop1" interface="floppy_3_5">
 			<feature name="part_id" value="User Disk" />
 			<dataarea name="flop" size="1261568">
@@ -6117,6 +6543,7 @@ User/save disks that can be created from the game itself are not included.
 		<publisher>DEZ</publisher>
 		<info name="alt_title" value="淫獣学園 Laブルーガール" />
 		<info name="release" value="199407xx" />
+		<info name="usage" value="Requires 2 MB RAM"/>
 		<part name="cdrom" interface="fmt_cdrom">
 			<diskarea name="cdrom">
 				<disk name="injuu gakuen - la blue girl" sha1="5e9d0e7657f8834277ec7f2833fe3d3cc889b6e2" />
@@ -6137,6 +6564,7 @@ User/save disks that can be created from the game itself are not included.
 		<publisher>富士通 (Fujitsu)</publisher>
 		<info name="alt_title" value="石道" />
 		<info name="release" value="199006xx" />
+		<info name="usage" value="Requires 2 MB RAM"/>
 		<part name="cdrom" interface="fmt_cdrom">
 			<diskarea name="cdrom">
 				<disk name="ishidou" sha1="141cb39d019581436a7ea6e99dd0411b4f7ef30a" />
@@ -6202,8 +6630,7 @@ User/save disks that can be created from the game itself are not included.
 		</part>
 	</software>
 
-	<!-- Hangs during the intro -->
-	<software name="jangou4" supported="no">
+	<software name="jangou4">
 		<!--
 		Origin: Neo Kobe Collection
 		<rom name="Jango 4.ccd" size="4391" crc="b3b19065" sha1="979d0ce4e7efbf691433a7b275ba60710d339793"/>
@@ -6216,6 +6643,7 @@ User/save disks that can be created from the game itself are not included.
 		<publisher>ビクター音楽産業 (Victor Musical Industries)</publisher>
 		<info name="alt_title" value="雀豪４" />
 		<info name="release" value="199411xx" />
+		<info name="usage" value="Requires 2 MB RAM. Insert a floppy disk in drive 1 before booting the game."/>
 		<part name="cdrom" interface="fmt_cdrom">
 			<diskarea name="cdrom">
 				<disk name="jango 4" sha1="c3c47c867fff8869f53bc7afb5f3dd944146c27e" />
@@ -6236,6 +6664,7 @@ User/save disks that can be created from the game itself are not included.
 		<publisher>フェアリーテール (Fairytale)</publisher>
 		<info name="alt_title" value="雀妃楼" />
 		<info name="release" value="199406xx" />
+		<info name="usage" value="Requires 2 MB RAM"/>
 		<part name="cdrom" interface="fmt_cdrom">
 			<diskarea name="cdrom">
 				<disk name="jankirou" sha1="b299d72db8a36c196f6795d450c9541244b1b208" />
@@ -6256,6 +6685,7 @@ User/save disks that can be created from the game itself are not included.
 		<publisher>インターハート (Interheart)</publisher>
 		<info name="alt_title" value="ジェラシー" />
 		<info name="release" value="199507xx" />
+		<info name="usage" value="Requires 2 MB RAM"/>
 		<part name="cdrom" interface="fmt_cdrom">
 			<diskarea name="cdrom">
 				<disk name="jealousy" sha1="49244a1e50fc4300f4ead328d4b43c8449042d53" />
@@ -6273,6 +6703,7 @@ User/save disks that can be created from the game itself are not included.
 		<year>1992</year>
 		<publisher>バーディーソフト (Birdy Soft)</publisher>
 		<info name="release" value="199207xx" />
+		<info name="usage" value="Requires 2 MB RAM"/>
 		<part name="cdrom" interface="fmt_cdrom">
 			<diskarea name="cdrom">
 				<disk name="joker towns (Japan)" sha1="bc09ad20f315dcd4804452b5885c06eca281b48d" />
@@ -6293,6 +6724,7 @@ User/save disks that can be created from the game itself are not included.
 		<publisher>Byakuya-Shobo</publisher>
 		<info name="alt_title" value="女子高生少女発熱" />
 		<info name="release" value="199312xx" />
+		<info name="usage" value="Requires 2 MB RAM"/>
 		<part name="cdrom" interface="fmt_cdrom">
 			<diskarea name="cdrom">
 				<disk name="joshikousei shoujo hakunetsu" sha1="e8d9cb254a16d113544a2e3dba6b73a93003b915" />
@@ -6311,6 +6743,7 @@ User/save disks that can be created from the game itself are not included.
 		<publisher>ケイエスエス (KSS)</publisher>
 		<info name="alt_title" value="女子校制服物語" />
 		<info name="release" value="199504xx" />
+		<info name="usage" value="Requires 2 MB RAM"/>
 		<part name="flop1" interface="floppy_3_5">
 			<dataarea name="flop" size="1261568">
 				<rom name="joshikou_seifuku_monogatari.hdm" size="1261568" crc="3fdba734" sha1="8e8aed41e329bd02479e6b55675110ddc29b33f2" offset="000000" />
@@ -6336,6 +6769,7 @@ User/save disks that can be created from the game itself are not included.
 		<publisher>パンサーソフトウェア (Panther Software)</publisher>
 		<info name="alt_title" value="ジョシュア" />
 		<info name="release" value="199211xx" />
+		<info name="usage" value="Requires 2 MB RAM"/>
 		<part name="cdrom" interface="fmt_cdrom">
 			<diskarea name="cdrom">
 				<disk name="joshua" sha1="038de795c9f4bd6eef3758d94187c9c0855a1a44" />
@@ -6354,6 +6788,7 @@ User/save disks that can be created from the game itself are not included.
 		<year>1994</year>
 		<publisher>富士通 (Fujitsu)</publisher>
 		<info name="alt_title" value="奏　Ｖ１．１Ｌ１０" />
+		<info name="usage" value="Requires 2 MB RAM"/>
 		<part name="cdrom" interface="fmt_cdrom">
 			<diskarea name="cdrom">
 				<disk name="kanade v1.1l10 (japan) (rev a)" sha1="9a4cad8e1bc964f3550f8cd75c71553163bfa181" />
@@ -6375,6 +6810,7 @@ User/save disks that can be created from the game itself are not included.
 		<publisher>富士通大分ソフトウェアラボラトリ (Fujitsu Ooita Software Laboratory)</publisher>
 		<info name="alt_title" value="カタカナのえほん" />
 		<info name="release" value="199504xx" />
+		<info name="usage" value="Requires 2 MB RAM"/>
 		<part name="cdrom" interface="fmt_cdrom">
 			<diskarea name="cdrom">
 				<disk name="katakana no ehon (japan)" sha1="ed55e7e0c38637008afadc83f8ea6f1168976f74" />
@@ -6394,6 +6830,7 @@ User/save disks that can be created from the game itself are not included.
 		<publisher>富士通大分ソフトウェアラボラトリ (Fujitsu Ooita Software Laboratory)</publisher>
 		<info name="alt_title" value="かんじのえほん" />
 		<info name="release" value="199207xx" />
+		<info name="usage" value="Requires 2 MB RAM"/>
 		<part name="cdrom" interface="fmt_cdrom">
 			<diskarea name="cdrom">
 				<disk name="kanji no ehon (japan)" sha1="d7ca0ee65ad99a17d090b0a6d8f6ca84284ee6e9" />
@@ -6413,6 +6850,7 @@ User/save disks that can be created from the game itself are not included.
 		<year>1992</year>
 		<publisher>富士通 (Fujitsu)</publisher>
 		<info name="release" value="199208xx" />
+		<info name="usage" value="Requires 2 MB RAM"/>
 		<part name="cdrom" interface="fmt_cdrom">
 			<diskarea name="cdrom">
 				<disk name="kid pix" sha1="090939e80a209292d6b606e3e7b2b44bbd3585be" />
@@ -6431,6 +6869,7 @@ User/save disks that can be created from the game itself are not included.
 		<publisher>リバーヒルソフト (Riverhill Soft)</publisher>
 		<info name="alt_title" value="ＫＩＧＥＮ 輝きの覇者" />
 		<info name="release" value="199205xx" />
+		<info name="usage" value="Requires 2 MB RAM"/>
 		<part name="cdrom" interface="fmt_cdrom">
 			<diskarea name="cdrom">
 				<disk name="kigen" sha1="3df8b6bb0c3ee6797f784c349a1ca40efb13dac8" />
@@ -6451,6 +6890,7 @@ User/save disks that can be created from the game itself are not included.
 		<publisher>シーズウェア (C's Ware)</publisher>
 		<info name="alt_title" value="禁断の血族" />
 		<info name="release" value="199407xx" />
+		<info name="usage" value="Requires 2 MB RAM"/>
 		<part name="cdrom" interface="fmt_cdrom">
 			<diskarea name="cdrom">
 				<disk name="kindan no ketsuzoku" sha1="589dfff7b733335530a19f3a88a7cdda91826187" />
@@ -6471,6 +6911,7 @@ User/save disks that can be created from the game itself are not included.
 		<publisher>スタークラフト (Starcraft)</publisher>
 		<info name="alt_title" value="キングス バウンティ 盗まれた秩序" />
 		<info name="release" value="199407xx" />
+		<info name="usage" value="Requires 2 MB RAM"/>
 		<part name="cdrom" interface="fmt_cdrom">
 			<diskarea name="cdrom">
 				<disk name="king's bounty" sha1="3bf83f353aee51986e0e73b581feb4a7cc0ad850" />
@@ -6492,6 +6933,7 @@ User/save disks that can be created from the game itself are not included.
 		<year>1991</year>
 		<publisher>シエラオンラインジャパン (Sierra On-Line Japan)</publisher>
 		<info name="release" value="199108xx" />
+		<info name="usage" value="Requires 2 MB RAM"/>
 		<part name="cdrom" interface="fmt_cdrom">
 			<diskarea name="cdrom">
 				<disk name="king's quest v" sha1="fa5aaa4c63ca1c3d5f162d0110840bcfdd06d891" />
@@ -6512,6 +6954,7 @@ User/save disks that can be created from the game itself are not included.
 		<publisher>ログ (Log)</publisher>
 		<info name="alt_title" value="極" />
 		<info name="release" value="199210xx" />
+		<info name="usage" value="Requires 2 MB RAM"/>
 		<part name="cdrom" interface="fmt_cdrom">
 			<diskarea name="cdrom">
 				<disk name="kiwame" sha1="9a906bb69fb7eca6bc1b5da7164fcb869660fb2b" />
@@ -6532,6 +6975,7 @@ User/save disks that can be created from the game itself are not included.
 		<publisher>ログ (Log)</publisher>
 		<info name="alt_title" value="極II" />
 		<info name="release" value="199406xx" />
+		<info name="usage" value="Requires 2 MB RAM"/>
 		<part name="cdrom" interface="fmt_cdrom">
 			<diskarea name="cdrom">
 				<disk name="kiwame ii" sha1="b3bcb4e8f1de660e8669b5d34b3802d238e7bc9f" />
@@ -6552,6 +6996,7 @@ User/save disks that can be created from the game itself are not included.
 		<publisher>フォスター (Foster)</publisher>
 		<info name="alt_title" value="ここは楽園荘" />
 		<info name="release" value="199603xx" />
+		<info name="usage" value="Requires 2 MB RAM"/>
 		<part name="cdrom" interface="fmt_cdrom">
 			<diskarea name="cdrom">
 				<disk name="koko wa rakuensou" sha1="711d590b172c5c496d1f14f825dbc7b8a10e71fb" />
@@ -6570,6 +7015,7 @@ User/save disks that can be created from the game itself are not included.
 		<publisher>フォスター (Foster)</publisher>
 		<info name="alt_title" value="ここは楽園荘2" />
 		<info name="release" value="199604xx" />
+		<info name="usage" value="Requires 2 MB RAM"/>
 		<part name="cdrom" interface="fmt_cdrom">
 			<diskarea name="cdrom">
 				<disk name="koko wa rakuensou 2" sha1="d7879482b9f644f09c6324688fe4d3a2898ed137" />
@@ -6609,6 +7055,7 @@ User/save disks that can be created from the game itself are not included.
 		<publisher>電脳商会 (Dennou Shoukai)</publisher>
 		<info name="alt_title" value="電脳絵本 恐竜の世界" />
 		<info name="release" value="199004xx" />
+		<info name="usage" value="Requires 2 MB RAM"/>
 		<part name="cdrom" interface="fmt_cdrom">
 			<diskarea name="cdrom">
 				<disk name="kyosekai" sha1="05ae0457c1dc8da8d265831cad64e40a41a7adaf" />
@@ -6657,6 +7104,7 @@ User/save disks that can be created from the game itself are not included.
 		<year>1992?</year>
 		<publisher>電脳商会 (Dennou Shoukai)</publisher>
 		<info name="alt_title" value="教育＆ＦＭ　ＴＯＷＮＳ　ＶＯＬ．３" />
+		<info name="usage" value="Requires 2 MB RAM"/>
 		<part name="cdrom" interface="fmt_cdrom">
 			<diskarea name="cdrom">
 				<disk name="kyouiku &amp; fm towns vol. 3 (japan)" sha1="1eec5db2f2e844b59d1f0bf824ffae7b5e1821d2" />
@@ -6696,6 +7144,7 @@ User/save disks that can be created from the game itself are not included.
 		<publisher>スタークラフト (Starcraft)</publisher>
 		<info name="alt_title" value="レジェンド・オブ・キランディア" />
 		<info name="release" value="199310xx" />
+		<info name="usage" value="Requires 2 MB RAM"/>
 		<part name="flop1" interface="floppy_3_5">
 			<feature name="part_id" value="User Disk" />
 			<dataarea name="flop" size="1261568">
@@ -6804,6 +7253,7 @@ User/save disks that can be created from the game itself are not included.
 		<publisher>スタークラフト (Starcraft)</publisher>
 		<info name="alt_title" value="キランディア2 運命の手" />
 		<info name="release" value="199510xx" />
+		<info name="usage" value="Requires 2 MB RAM"/>
 		<part name="cdrom" interface="fmt_cdrom">
 			<diskarea name="cdrom">
 				<disk name="kyrandia ii - the hand of fate (japan) (en,ja)" sha1="adef11bcdd2398cb14c509f572a65fb4f849cf17" />
@@ -6823,6 +7273,7 @@ User/save disks that can be created from the game itself are not included.
 		<publisher>ビング (Ving)</publisher>
 		<info name="alt_title" value="究極タイガー" />
 		<info name="release" value="199402xx" />
+		<info name="usage" value="Requires 2 MB RAM"/>
 		<part name="cdrom" interface="fmt_cdrom">
 			<diskarea name="cdrom">
 				<disk name="kyuukyoku tiger" sha1="7c0f1c42dba49fe71114d21ad2f604dabe729196" />
@@ -6842,6 +7293,7 @@ User/save disks that can be created from the game itself are not included.
 		<year>1993</year>
 		<publisher>パンサーソフトウェア (Panther Software)</publisher>
 		<info name="release" value="199311xx" />
+		<info name="usage" value="Requires 2 MB RAM"/>
 		<part name="cdrom" interface="fmt_cdrom">
 			<diskarea name="cdrom">
 				<disk name="ku2++" sha1="89f36240314f15dcb45526b03beb84e417296a97" />
@@ -6864,6 +7316,7 @@ User/save disks that can be created from the game itself are not included.
 		<publisher>スタークラフト (Starcraft)</publisher>
 		<info name="alt_title" value="ランズ オブ ロア" />
 		<info name="release" value="199501xx" />
+		<info name="usage" value="Requires 2 MB RAM"/>
 		<part name="cdrom" interface="fmt_cdrom">
 			<diskarea name="cdrom">
 				<disk name="lands of lore" sha1="849e7ec5c5844ec8b774328513b6c6b5d52106e0" />
@@ -7089,6 +7542,7 @@ User/save disks that can be created from the game itself are not included.
 		<publisher>CRI</publisher>
 		<info name="alt_title" value="ラストサバイバー" />
 		<info name="release" value="199011xx" />
+		<info name="usage" value="Requires 2 MB RAM"/>
 		<part name="cdrom" interface="fmt_cdrom">
 			<diskarea name="cdrom">
 				<disk name="last survivor (japan)" sha1="2daa0d86cda7f88037065f1a70924261fecc3afd" />
@@ -7109,6 +7563,7 @@ User/save disks that can be created from the game itself are not included.
 		<publisher>アートディンク (Artdink)</publisher>
 		<info name="alt_title" value="ルナティックドーンII" />
 		<info name="release" value="199411xx" />
+		<info name="usage" value="Requires 4 MB RAM"/>
 		<part name="flop1" interface="floppy_3_5">
 			<feature name="part_id" value="User Disk" />
 			<dataarea name="flop" size="1261568">
@@ -7145,6 +7600,7 @@ User/save disks that can be created from the game itself are not included.
 		<publisher>光栄 (Koei)</publisher>
 		<info name="alt_title" value="リーディングカンパニー" />
 		<info name="release" value="199204xx" />
+		<info name="usage" value="Requires 2 MB RAM"/>
 		<part name="flop1" interface="floppy_3_5">
 			<dataarea name="flop" size="1261568">
 				<rom name="leading company.hdm" size="1261568" crc="c4ab1147" sha1="8a3e197458a190daa505868338cac65129515d4b" offset="000000" />
@@ -7192,6 +7648,7 @@ User/save disks that can be created from the game itself are not included.
 		<publisher>富士通 (Fujitsu)</publisher>
 		<info name="alt_title" value="レミングス2 ザ・トライブス" />
 		<info name="release" value="199406xx" />
+		<info name="usage" value="Requires 2 MB RAM"/>
 		<part name="cdrom" interface="fmt_cdrom">
 			<diskarea name="cdrom">
 				<disk name="lemmings 2 - the tribes" sha1="cf5e532b00f9f94ccf9d7f71f949f018714c5b2c" />
@@ -7212,6 +7669,7 @@ User/save disks that can be created from the game itself are not included.
 		<publisher>パンサーソフトウェア (Panther Software)</publisher>
 		<info name="alt_title" value="レッサーメルン" />
 		<info name="release" value="199210xx" />
+		<info name="usage" value="Requires 2 MB RAM"/>
 		<part name="cdrom" interface="fmt_cdrom">
 			<diskarea name="cdrom">
 				<disk name="lesser mern" sha1="e9e9e42e26db1afbeb6f111d9ee4068fd09c3c3d" />
@@ -7255,6 +7713,7 @@ User/save disks that can be created from the game itself are not included.
 		<publisher>リビドー (Libido)</publisher>
 		<info name="alt_title" value="リビドー７" />
 		<info name="release" value="199407xx" />
+		<info name="usage" value="Requires 2 MB RAM"/>
 		<part name="cdrom" interface="fmt_cdrom">
 			<diskarea name="cdrom">
 				<disk name="libido7 (japan)" sha1="0923dcfda7ff9f1992e36311b88b41df73329513" />
@@ -7277,6 +7736,7 @@ User/save disks that can be created from the game itself are not included.
 		<publisher>ビング (Ving)</publisher>
 		<info name="alt_title" value="ライフ＆デス" />
 		<info name="release" value="199201xx" />
+		<info name="usage" value="Requires 2 MB RAM. Insert a floppy disk in drive 1 before booting the game."/>
 		<part name="cdrom" interface="fmt_cdrom">
 			<diskarea name="cdrom">
 				<disk name="life &amp; death (japan)" sha1="f0afbcbc3194c845ec5fdade21c13f095a53235b" />
@@ -7315,7 +7775,7 @@ User/save disks that can be created from the game itself are not included.
 		<publisher>サイベル (Cybelle)</publisher>
 		<info name="alt_title" value="ゴルフ・リンクス３８６プロ" />
 		<info name="release" value="199502xx" />
-		<info name="usage" value="Requires HDD installation"/>
+		<info name="usage" value="Requires HDD installation and 4 MB RAM"/>
 		<part name="cdrom" interface="fmt_cdrom">
 			<diskarea name="cdrom">
 				<disk name="golf links 386 pro" sha1="c0eb847d7168e6209482b19a270bd81d40383137" />
@@ -7336,6 +7796,7 @@ User/save disks that can be created from the game itself are not included.
 		<publisher>ハミングバード (HummingBird)</publisher>
 		<info name="alt_title" value="ロードス島戦記 灰色の魔女" />
 		<info name="release" value="199404xx" />
+		<info name="usage" value="Requires 2 MB RAM"/>
 		<part name="flop1" interface="floppy_3_5">
 			<feature name="part_id" value="System Disk" />
 			<dataarea name="flop" size="1261568">
@@ -7389,6 +7850,7 @@ User/save disks that can be created from the game itself are not included.
 		<year>1991</year>
 		<publisher>富士通 (Fujitsu)</publisher>
 		<info name="release" value="199104xx" />
+		<info name="usage" value="Requires 2 MB RAM"/>
 		<part name="cdrom1" interface="fmt_cdrom">
 			<diskarea name="cdrom">
 				<disk name="loom (japan)" sha1="64e79a35ad8b52fcb7cfec6fce2bef1bdc0ffe8e" />
@@ -7415,6 +7877,7 @@ User/save disks that can be created from the game itself are not included.
 		<publisher>電波新聞社 (Dempa Shinbunsha)</publisher>
 		<info name="alt_title" value="リブルラブル" />
 		<info name="release" value="199403xx" />
+		<info name="usage" value="Requires 2 MB RAM"/>
 		<part name="cdrom" interface="fmt_cdrom">
 			<diskarea name="cdrom">
 				<disk name="libble rabble" sha1="5f3fef308eb0f59e7b6d8b4f6e87a9653ccfaa7b" />
@@ -7435,6 +7898,7 @@ User/save disks that can be created from the game itself are not included.
 		<publisher>スタークラフト (Starcraft)</publisher>
 		<info name="alt_title" value="指輪物語 第二巻 二つの塔" />
 		<info name="release" value="199304xx" />
+		<info name="usage" value="Requires 2 MB RAM"/>
 		<part name="flop1" interface="floppy_3_5">
 			<feature name="part_id" value="User Disk" />
 			<dataarea name="flop" size="1261568">
@@ -7461,6 +7925,7 @@ User/save disks that can be created from the game itself are not included.
 		<publisher>CRI</publisher>
 		<info name="alt_title" value="ルパン三世-香港の魔手 「復讐は迷宮の果てに」" />
 		<info name="release" value="199006xx" />
+		<info name="usage" value="Requires 2 MB RAM"/>
 		<part name="cdrom" interface="fmt_cdrom">
 			<diskarea name="cdrom">
 				<disk name="lupin iii - hong kong no mashu" sha1="c42ff4f7d772bf8a7d5b33ae64e5b8d0dfa7e956" />
@@ -7506,6 +7971,7 @@ User/save disks that can be created from the game itself are not included.
 		<publisher>クィーンソフト (Queensoft)</publisher>
 		<info name="alt_title" value="マッドパラドックス" />
 		<info name="release" value="199402xx" />
+		<info name="usage" value="Requires 2 MB RAM"/>
 		<part name="cdrom" interface="fmt_cdrom">
 			<diskarea name="cdrom">
 				<disk name="mad paradox" sha1="da8146ef3fcffb9e8679b3f64bb80efc48785e80" />
@@ -7580,6 +8046,7 @@ User/save disks that can be created from the game itself are not included.
 		<publisher>アクティブ (Active)</publisher>
 		<info name="alt_title" value="麻雀でPON！" />
 		<info name="release" value="199404xx" />
+		<info name="usage" value="Requires 2 MB RAM"/>
 		<part name="cdrom" interface="fmt_cdrom">
 			<diskarea name="cdrom">
 				<disk name="mahjong de pon! (japan)" sha1="a6332b3d1f893621f25f035b538cb14a6e5d946e" />
@@ -7618,6 +8085,7 @@ User/save disks that can be created from the game itself are not included.
 		<publisher>フォーサイト (Foresight)</publisher>
 		<info name="alt_title" value="麻雀美少女伝リップル" />
 		<info name="release" value="199502xx" />
+		<info name="usage" value="Requires 2 MB RAM"/>
 		<part name="cdrom" interface="fmt_cdrom">
 			<diskarea name="cdrom">
 				<disk name="mahjong bishoujoden ripple (japan)" sha1="a235882ed0a34c655c95186d377146322542bbaf" />
@@ -7636,6 +8104,7 @@ User/save disks that can be created from the game itself are not included.
 		<publisher>エレクトロニック・アーツ・ビクター (Electronic Arts Victor)</publisher>
 		<info name="alt_title" value="魔法大作戦" />
 		<info name="release" value="199502xx" />
+		<info name="usage" value="Requires 3 MB RAM"/>
 		<part name="cdrom" interface="fmt_cdrom">
 			<diskarea name="cdrom">
 				<disk name="mahou daisakusen" sha1="534e04e71d29907098b0c0151b69de70ba37570e" />
@@ -7656,6 +8125,7 @@ User/save disks that can be created from the game itself are not included.
 		<publisher>フォーサイト (Foresight)</publisher>
 		<info name="alt_title" value="曼陀羅家一族" />
 		<info name="release" value="199503xx" />
+		<info name="usage" value="Requires 2 MB RAM"/>
 		<part name="cdrom" interface="fmt_cdrom">
 			<diskarea name="cdrom">
 				<disk name="mandarake ichizoku" sha1="5a991b6ca46127232a270e6f422c9a17f7ede537" />
@@ -7675,6 +8145,7 @@ User/save disks that can be created from the game itself are not included.
 		<year>1993</year>
 		<publisher>アモルファス (Amorphous)</publisher>
 		<info name="release" value="199302xx" />
+		<info name="usage" value="Requires 2 MB RAM"/>
 		<part name="cdrom" interface="fmt_cdrom">
 			<diskarea name="cdrom">
 				<disk name="many colors" sha1="392e9a0faebb7ec2bc56fc0cfdc6ca800f610dd0" />
@@ -7717,6 +8188,7 @@ User/save disks that can be created from the game itself are not included.
 		<publisher>ホームデータ (Home Data)</publisher>
 		<info name="alt_title" value="マーブルマッドネス" />
 		<info name="release" value="199106xx" />
+		<info name="usage" value="Requires 2 MB RAM"/>
 		<part name="cdrom" interface="fmt_cdrom">
 			<diskarea name="cdrom">
 				<disk name="marble madness (japan)" sha1="a32d2ab9fba3df6ff76b8deaa8d40ce169850ced" />
@@ -7735,6 +8207,7 @@ User/save disks that can be created from the game itself are not included.
 		<publisher>フェアリーテール (Fairytale)</publisher>
 		<info name="alt_title" value="マリンフィルト" />
 		<info name="release" value="199304xx" />
+		<info name="usage" value="Requires 2 MB RAM"/>
 		<part name="cdrom" interface="fmt_cdrom">
 			<diskarea name="cdrom">
 				<disk name="marine philt" sha1="09b14f591f1c78ab0b125c1cad9b041670931695" />
@@ -7773,6 +8246,7 @@ User/save disks that can be created from the game itself are not included.
 		<publisher>カプコン (Capcom)</publisher>
 		<info name="alt_title" value="マッスルボマー" />
 		<info name="release" value="199311xx" />
+		<info name="usage" value="Requires 2 MB RAM"/>
 		<part name="cdrom" interface="fmt_cdrom">
 			<diskarea name="cdrom">
 				<disk name="muscle bomber" sha1="c10e04ed66acd02d9e383e948625091bb8c37cd9" />
@@ -7799,6 +8273,7 @@ User/save disks that can be created from the game itself are not included.
 		<publisher>富士通 (Fujitsu)</publisher>
 		<info name="alt_title" value="マイクロコズム" />
 		<info name="release" value="199304xx" />
+		<info name="usage" value="Requires 2 MB RAM"/>
 		<part name="cdrom" interface="fmt_cdrom">
 			<diskarea name="cdrom">
 				<disk name="microcosm (japan) (rev a)" sha1="f52390e5e2148ae0735e6f016afa630d9182809d" />
@@ -7825,6 +8300,7 @@ User/save disks that can be created from the game itself are not included.
 		<publisher>富士通 (Fujitsu)</publisher>
 		<info name="alt_title" value="マイクロコズム" />
 		<info name="release" value="199303xx" />
+		<info name="usage" value="Requires 2 MB RAM"/>
 		<part name="cdrom" interface="fmt_cdrom">
 			<diskarea name="cdrom">
 				<disk name="microcosm (japan)" sha1="4dbbbd66b018fc9145e990e00adc611c98a58d7a" />
@@ -7845,6 +8321,7 @@ User/save disks that can be created from the game itself are not included.
 		<publisher>イマジニア (Imagineer)</publisher>
 		<info name="alt_title" value="メガロマニア" />
 		<info name="release" value="199303xx" />
+		<info name="usage" value="Requires 2 MB RAM"/>
 		<part name="cdrom" interface="fmt_cdrom">
 			<diskarea name="cdrom">
 				<disk name="mega lo mania" sha1="f5d7373adb8f6f66a6037cd8c7a7e71f3e964b26" />
@@ -7867,7 +8344,7 @@ User/save disks that can be created from the game itself are not included.
 		<publisher>ケイエスエス (KSS)</publisher>
 		<info name="alt_title" value="メンゾベランザン 闇の紋章" />
 		<info name="release" value="199601xx" />
-		<info name="usage" value="Requires HDD installation"/>
+		<info name="usage" value="Requires HDD installation and 4 MB RAM. Run INSTFMT.EXE from the command line to install."/>
 		<part name="cdrom" interface="fmt_cdrom">
 			<diskarea name="cdrom">
 				<disk name="menzoberranzan" sha1="ff975cf59dc3c8c884a588245311a3319fb7506e" />
@@ -7888,6 +8365,7 @@ User/save disks that can be created from the game itself are not included.
 		<publisher>エルフ (Elf)</publisher>
 		<info name="alt_title" value="メタルアイ" />
 		<info name="release" value="199307xx" />
+		<info name="usage" value="Requires 2 MB RAM"/>
 		<part name="cdrom" interface="fmt_cdrom">
 			<diskarea name="cdrom">
 				<disk name="metal eye" sha1="01c44ebc9e9ec32a37f9153b890adb22801928d3" />
@@ -7908,6 +8386,7 @@ User/save disks that can be created from the game itself are not included.
 		<publisher>エルフ (Elf)</publisher>
 		<info name="alt_title" value="メタルアイ2" />
 		<info name="release" value="199409xx" />
+		<info name="usage" value="Requires 2 MB RAM"/>
 		<part name="cdrom" interface="fmt_cdrom">
 			<diskarea name="cdrom">
 				<disk name="metal eye 2" sha1="a657dea0277866d0dee8af92f987985464e5f83d" />
@@ -7927,6 +8406,7 @@ User/save disks that can be created from the game itself are not included.
 		<year>1990</year>
 		<publisher>CRI</publisher>
 		<info name="release" value="199009xx" />
+		<info name="usage" value="Requires 2 MB RAM"/>
 		<part name="cdrom" interface="fmt_cdrom">
 			<diskarea name="cdrom">
 				<disk name="my fair lady can ii - elementary" sha1="49e0d2a348b405d01b9790267f70a108b69cac8b" />
@@ -7946,7 +8426,7 @@ User/save disks that can be created from the game itself are not included.
 		<year>1995</year>
 		<publisher>アリスソフト (AliceSoft)</publisher>
 		<info name="alt_title" value="夢幻泡影" />
-		<info name="usage" value="Requires HDD installation"/>
+		<info name="usage" value="Requires HDD installation and 2 MB RAM"/>
 		<part name="cdrom" interface="fmt_cdrom">
 			<diskarea name="cdrom">
 				<disk name="mugen houyou" sha1="19d89c9f5c41fc1c77bc3a27220aeb9da39f484a" />
@@ -7967,6 +8447,7 @@ User/save disks that can be created from the game itself are not included.
 		<publisher>ディスカバリー (Discovery)</publisher>
 		<info name="alt_title" value="ミラージュ" />
 		<info name="release" value="199201xx" />
+		<info name="usage" value="Requires 2 MB RAM"/>
 		<part name="cdrom" interface="fmt_cdrom">
 			<diskarea name="cdrom">
 				<disk name="mirage" sha1="b1536b6de52c10315b54a665a82cf83906c32f4a" />
@@ -7987,6 +8468,7 @@ User/save disks that can be created from the game itself are not included.
 		<publisher>Apros</publisher>
 		<info name="alt_title" value="ミラーズ" />
 		<info name="release" value="199206xx" />
+		<info name="usage" value="Requires 2 MB RAM"/>
 		<part name="cdrom" interface="fmt_cdrom">
 			<diskarea name="cdrom">
 				<disk name="mirrors" sha1="cecb05ffd74a82b4f7664fae139172f8493a32af" />
@@ -8034,21 +8516,19 @@ User/save disks that can be created from the game itself are not included.
 
 	<software name="mightmg3">
 		<!--
-		Origin: Tokugawa Corporate Forums (yukin)
-		<rom name="MM3.mdf" size="15523200" crc="926d169b" sha1="107090bdd34e831f27ea979e3fd6a24c86aa418a"/>
-		<rom name="MM3.mds" size="500" crc="99adcc2f" sha1="1d6b9f2257f821d06d0f85a021e5be5a2f448f03"/>
-
-		CUE file used for CHD conversion:
-		<rom name="MM3.cue" size="64" crc="5c30fa2b" sha1="7b53d089cbc4fb4fa0d517adafd8f74f8c94a652"/>
+		Origin: redump.org
+		<rom name="Might and Magic III - Isles of Terra (Japan).bin" size="15523200" crc="f137d0e0" sha1="8bd148481bf34f301f67587a77ced6c059c240cc"/>
+		<rom name="Might and Magic III - Isles of Terra (Japan).cue" size="110" crc="c6f3105b" sha1="ec1a239c028ec0a0c7dc4447f144c62d9b51bc17"/>
 		-->
 		<description>Might and Magic III - Isles of Terra</description>
 		<year>1992</year>
 		<publisher>スタークラフト (Starcraft)</publisher>
 		<info name="alt_title" value="マイト＆マジックIII" />
 		<info name="release" value="199210xx" />
+		<info name="usage" value="Requires 2 MB RAM"/>
 		<part name="cdrom" interface="fmt_cdrom">
 			<diskarea name="cdrom">
-				<disk name="mm3" sha1="fcab3ac89b001b394071798511ccb8692926818f" />
+				<disk name="might and magic iii - isles of terra (japan)" sha1="745fb7948515c87a6819846dbb305839580b53af" />
 			</diskarea>
 		</part>
 	</software>
@@ -8064,6 +8544,7 @@ User/save disks that can be created from the game itself are not included.
 		<publisher>スタークラフト (Starcraft)</publisher>
 		<info name="alt_title" value="クラウズ・オブ・ジーン" />
 		<info name="release" value="199309xx" />
+		<info name="usage" value="Requires 2 MB RAM"/>
 		<part name="cdrom" interface="fmt_cdrom">
 			<diskarea name="cdrom">
 				<disk name="might and magic iv - clouds of xeen" sha1="11a65c5cab772e3315b4c09e22caaf47eced0a2b" />
@@ -8082,6 +8563,7 @@ User/save disks that can be created from the game itself are not included.
 		<publisher>スタークラフト (Starcraft)</publisher>
 		<info name="alt_title" value="ダークサイド・オブ・ジーン" />
 		<info name="release" value="199405xx" />
+		<info name="usage" value="Requires 3 MB RAM"/>
 		<part name="cdrom" interface="fmt_cdrom">
 			<diskarea name="cdrom">
 				<disk name="might and magic v - darkside of xeen" sha1="5c1ad8661f637e57af130b23a9427ee855daf63f" />
@@ -8102,6 +8584,7 @@ User/save disks that can be created from the game itself are not included.
 		<year>1994</year>
 		<publisher>富士通 (Fujitsu)</publisher>
 		<info name="release" value="199412xx" />
+		<info name="usage" value="Requires 2 MB RAM"/>
 		<part name="cdrom" interface="fmt_cdrom">
 			<diskarea name="cdrom">
 				<disk name="megamorph" sha1="59e30f6ce0c8cb62b22afe383ffcf7450910a612" />
@@ -8164,6 +8647,7 @@ User/save disks that can be created from the game itself are not included.
 		<publisher>ビクター音楽産業 (Victor Musical Industries)</publisher>
 		<info name="alt_title" value="モンキーアイランド" />
 		<info name="release" value="199209xx" />
+		<info name="usage" value="Requires 2 MB RAM"/>
 		<part name="cdrom" interface="fmt_cdrom">
 			<diskarea name="cdrom">
 				<disk name="the secret of monkey island" sha1="06ed4efdb149fbee70474bc9a4fd0002b9a6a31e" />
@@ -8186,6 +8670,7 @@ User/save disks that can be created from the game itself are not included.
 		<publisher>ビクター音楽産業 (Victor Musical Industries)</publisher>
 		<info name="alt_title" value="モンキーアイランド２ ～ル・チャックの逆襲～" />
 		<info name="release" value="199402xx" />
+		<info name="usage" value="Requires 2 MB RAM"/>
 		<part name="cdrom" interface="fmt_cdrom">
 			<diskarea name="cdrom">
 				<disk name="monkey island 2 - lechuck's revenge" sha1="4e3575059ee57961ad2a96c9cf4e7cbedbd3d2a5" />
@@ -8206,6 +8691,7 @@ User/save disks that can be created from the game itself are not included.
 		<publisher>ディー・オー (D.O.)</publisher>
 		<info name="alt_title" value="Ｍゥーンライトちゃんリンしゃん" />
 		<info name="release" value="199303xx" />
+		<info name="usage" value="Requires 2 MB RAM"/>
 		<part name="cdrom" interface="fmt_cdrom">
 			<diskarea name="cdrom">
 				<disk name="moonlight chan rin shan" sha1="55e927efd17e1b7dd5f08745a68219da488d6c82" />
@@ -8250,6 +8736,7 @@ User/save disks that can be created from the game itself are not included.
 		<publisher>データウエスト (Data West)</publisher>
 		<info name="alt_title" value="Ms.DETECTIVE ファイル#1 「石見銀山殺人事件」" />
 		<info name="release" value="199209xx" />
+		<info name="usage" value="Requires 2 MB RAM"/>
 		<part name="cdrom1" interface="fmt_cdrom">
 			<diskarea name="cdrom">
 				<disk name="ms. detective file 1 - iwami ginzan satsujin jiken (japan) (disc 1)" sha1="03832ac67feccbffbcbff33728aa654065fbb549" />
@@ -8276,6 +8763,7 @@ User/save disks that can be created from the game itself are not included.
 		<publisher>データウエスト (Data West)</publisher>
 		<info name="alt_title" value="Ms.DETECTIVE ファイル#2 「姿なき依頼人」" />
 		<info name="release" value="199310xx" />
+		<info name="usage" value="Requires 2 MB RAM"/>
 		<part name="cdrom" interface="fmt_cdrom">
 			<diskarea name="cdrom">
 				<disk name="ms. detective file 2 - sugata-naki irainin (japan)" sha1="bf2ddf1db97c1e9303f56f98e0714f1da201dc0d" />
@@ -8319,6 +8807,7 @@ User/save disks that can be created from the game itself are not included.
 		<publisher>ケイエスエス (KSS)</publisher>
 		<info name="alt_title" value="無人島物語" />
 		<info name="release" value="199509xx" />
+		<info name="usage" value="Requires 2 MB RAM"/>
 		<part name="cdrom" interface="fmt_cdrom">
 			<diskarea name="cdrom">
 				<disk name="mujintou monogatari" sha1="7cfe7c2b9d4bef30c1db4dbeae0a99799a90dea0" />
@@ -8340,6 +8829,7 @@ User/save disks that can be created from the game itself are not included.
 		<publisher>リバーヒルソフト (Riverhill Soft)</publisher>
 		<info name="alt_title" value="マーダークラブＤＸ" />
 		<info name="release" value="199205xx" />
+		<info name="usage" value="Requires 2 MB RAM"/>
 		<part name="cdrom" interface="fmt_cdrom">
 			<diskarea name="cdrom">
 				<disk name="murder club dx" sha1="eddbdc4e5f8b5d2ffa35aab5f6c136129ce29653" />
@@ -8379,6 +8869,7 @@ User/save disks that can be created from the game itself are not included.
 		<year>1993</year>
 		<publisher>富士通 (Fujitsu)</publisher>
 		<info name="release" value="19931126" />
+		<info name="usage" value="Requires 2 MB RAM"/>
 		<part name="cdrom" interface="fmt_cdrom">
 			<diskarea name="cdrom">
 				<disk name="musicmac" sha1="fd43146d8d7bcdb233b7ca06f164ae52550c5476" />
@@ -8398,6 +8889,7 @@ User/save disks that can be created from the game itself are not included.
 		<year>1993</year>
 		<publisher>ビクター音楽産業 (Victor Musical Industries)</publisher>
 		<info name="release" value="199309xx" />
+		<info name="usage" value="Requires 2 MB RAM"/>
 		<part name="cdrom" interface="fmt_cdrom">
 			<diskarea name="cdrom">
 				<disk name="musium towns" sha1="350c5c1f5e36ef48875fc9abbdecf3fc82c50dbf" />
@@ -8417,6 +8909,7 @@ User/save disks that can be created from the game itself are not included.
 		<year>1992</year>
 		<publisher>バーディーソフト (Birdy Soft)</publisher>
 		<info name="release" value="199211xx" />
+		<info name="usage" value="Requires 2 MB RAM"/>
 		<part name="cdrom" interface="fmt_cdrom">
 			<diskarea name="cdrom">
 				<disk name="my eyes!" sha1="a1093fcd4bbddcd90b3faa0617d5a895c214e3c4" />
@@ -8475,6 +8968,7 @@ User/save disks that can be created from the game itself are not included.
 		<publisher>ガイナックス (Gainax)</publisher>
 		<info name="alt_title" value="ふしぎの海のナディア" />
 		<info name="release" value="199302xx" />
+		<info name="usage" value="Requires 2 MB RAM"/>
 		<part name="cdrom1" interface="fmt_cdrom">
 			<feature name="part_id" value="Disk A - Unidentified Noise"/>
 			<diskarea name="cdrom">
@@ -8508,6 +9002,7 @@ User/save disks that can be created from the game itself are not included.
 		<publisher>フェアリーテール (Fairytale)</publisher>
 		<info name="alt_title" value="ネクロノミコン" />
 		<info name="release" value="199408xx" />
+		<info name="usage" value="Requires 2 MB RAM"/>
 		<part name="cdrom" interface="fmt_cdrom">
 			<diskarea name="cdrom">
 				<disk name="necronomicon" sha1="82672ceafa32c0e9975aeda8f3f578c1c204ff52" />
@@ -8532,6 +9027,7 @@ User/save disks that can be created from the game itself are not included.
 		<publisher>ティーアンドイーソフト (T&amp;E Soft)</publisher>
 		<info name="alt_title" value="遙かなるオーガスタ" />
 		<info name="release" value="199001xx" />
+		<info name="usage" value="Requires 2 MB RAM"/>
 		<part name="flop1" interface="floppy_3_5">
 			<feature name="part_id" value="System Disk" />
 			<dataarea name="flop" size="3577399">
@@ -8625,6 +9121,7 @@ User/save disks that can be created from the game itself are not included.
 		<publisher>富士通 (Fujitsu)</publisher>
 		<info name="alt_title" value="ＮＨＫ英語であそぼ 1" />
 		<info name="release" value="199307xx" />
+		<info name="usage" value="Requires 2 MB RAM"/>
 		<part name="cdrom" interface="fmt_cdrom">
 			<diskarea name="cdrom">
 				<disk name="nhk eigo de asobo vol. 1 (japan)" sha1="ee7667cbdfbd8e1ee0586861745b7e9ea5182164" />
@@ -8706,6 +9203,7 @@ User/save disks that can be created from the game itself are not included.
 		<publisher>富士通 (Fujitsu)</publisher>
 		<info name="alt_title" value="ＮＨＫ英語であそぼ 2" />
 		<info name="release" value="199312xx" />
+		<info name="usage" value="Requires 2 MB RAM"/>
 		<part name="cdrom" interface="fmt_cdrom">
 			<diskarea name="cdrom">
 				<disk name="nhk eigo de asobo vol. 2 (japan)" sha1="7a0772ba3044392a6df13eeeedb14ea6b1005f21" />
@@ -8724,6 +9222,7 @@ User/save disks that can be created from the game itself are not included.
 		<publisher>CRC総合研究所 (CRC Sougou Kenkyuusho)</publisher>
 		<info name="alt_title" value="ＮＨＫ実践英会話" />
 		<info name="release" value="199108xx" />
+		<info name="usage" value="Requires 2 MB RAM"/>
 		<part name="cdrom" interface="fmt_cdrom">
 			<diskarea name="cdrom">
 				<disk name="nhkeikai" sha1="aa3f3c0a48bde7032fb8357f446ce4f2736dee53" />
@@ -8788,6 +9287,7 @@ User/save disks that can be created from the game itself are not included.
 		<publisher>東京書籍 (Tokyo Shoseki)</publisher>
 		<info name="alt_title" value="NEW HORIZON CD ラーニングシステム II 1年" />
 		<info name="release" value="199305xx" />
+		<info name="usage" value="Requires 2 MB RAM"/>
 		<part name="cdrom" interface="fmt_cdrom">
 			<diskarea name="cdrom">
 				<disk name="new horizon cd learning system ii - english course 1 (japan)" sha1="b75d8ca2fcbe6cf85059c608a117af5ad6316c39" />
@@ -8806,6 +9306,7 @@ User/save disks that can be created from the game itself are not included.
 		<publisher>ぎょうせい (Gyousei)</publisher>
 		<info name="alt_title" value="日本昔ばなし" />
 		<info name="release" value="199011xx" />
+		<info name="usage" value="Requires 2 MB RAM"/>
 		<part name="cdrom" interface="fmt_cdrom">
 			<diskarea name="cdrom">
 				<disk name="nihonmb" sha1="cc65573ed38e0f142fcf8e32b9f13f37dcc64566" />
@@ -8826,6 +9327,7 @@ User/save disks that can be created from the game itself are not included.
 		<publisher>CRI</publisher>
 		<info name="alt_title" value="日本の歴史 貴族編" />
 		<info name="release" value="199009xx" />
+		<info name="usage" value="Requires 2 MB RAM"/>
 		<part name="cdrom" interface="fmt_cdrom">
 			<diskarea name="cdrom">
 				<disk name="nihon no rekishi - kizoku-hen" sha1="1bf433fc57cba5d452088b69c3b63d1be8ff9e1c" />
@@ -8846,6 +9348,7 @@ User/save disks that can be created from the game itself are not included.
 		<publisher>CRI</publisher>
 		<info name="alt_title" value="日本の歴史 古代編" />
 		<info name="release" value="199007xx" />
+		<info name="usage" value="Requires 2 MB RAM"/>
 		<part name="cdrom" interface="fmt_cdrom">
 			<diskarea name="cdrom">
 				<disk name="nihon no rekishi - kodai-hen" sha1="994b5f62b4c1ff2cd439948f12c52fa6d63cb8dc" />
@@ -8888,6 +9391,7 @@ User/save disks that can be created from the game itself are not included.
 		<publisher>フォレスト (Forest)</publisher>
 		<info name="alt_title" value="人形使い" />
 		<info name="release" value="199310xx" />
+		<info name="usage" value="Requires 2 MB RAM"/>
 		<part name="cdrom" interface="fmt_cdrom">
 			<diskarea name="cdrom">
 				<disk name="ningyou tsukai" sha1="d2e93204d3cc2557f26ee72c07d0ab1109bf5846" />
@@ -8908,6 +9412,7 @@ User/save disks that can be created from the game itself are not included.
 		<publisher>光栄 (Koei)</publisher>
 		<info name="alt_title" value="信長の野望 武将風雲録" />
 		<info name="release" value="199107xx" />
+		<info name="usage" value="Requires 2 MB RAM"/>
 		<part name="flop1" interface="floppy_3_5">
 			<feature name="part_id" value="User Disk" />
 			<dataarea name="flop" size="1261568">
@@ -8934,6 +9439,7 @@ User/save disks that can be created from the game itself are not included.
 		<publisher>光栄 (Koei)</publisher>
 		<info name="alt_title" value="信長の野望 覇王伝" />
 		<info name="release" value="199304xx" />
+		<info name="usage" value="Requires 2 MB RAM"/>
 		<part name="flop1" interface="floppy_3_5">
 			<dataarea name="flop" size="1261568">
 				<rom name="nobunaga no yabou - haou-den.hdm" size="1261568" crc="d426a880" sha1="4194c61909c37fdf83daae77dcd84ad996237b0c" offset="000000" />
@@ -8985,6 +9491,7 @@ User/save disks that can be created from the game itself are not included.
 		<publisher>光栄 (Koei)</publisher>
 		<info name="alt_title" value="信長の野望 天翔記" />
 		<info name="release" value="199503xx" />
+		<info name="usage" value="Requires 2 MB RAM"/>
 		<part name="cdrom" interface="fmt_cdrom">
 			<diskarea name="cdrom">
 				<disk name="nobunaga no yabou - tenshouki" sha1="fe1ca3991c5a1399cd720ae177644ca314b5d004" status="baddump" />
@@ -9024,6 +9531,7 @@ User/save disks that can be created from the game itself are not included.
 		<publisher>Cat's Pro.</publisher>
 		<info name="alt_title" value="ノ・ヴァ～魅入られた肢体" />
 		<info name="release" value="199307xx" />
+		<info name="usage" value="Requires 2 MB RAM"/>
 		<part name="cdrom" interface="fmt_cdrom">
 			<diskarea name="cdrom">
 				<disk name="nova - miirareta shitai (japan)" sha1="e6baab348384bc6e29b9240ed094cf572ab885e6" />
@@ -9043,6 +9551,7 @@ User/save disks that can be created from the game itself are not included.
 		<year>1994</year>
 		<publisher>Softbank</publisher>
 		<info name="alt_title" value="お気楽 TownsGEAR" />
+		<info name="usage" value="Requires 2 MB RAM"/>
 		<part name="cdrom" interface="fmt_cdrom">
 			<diskarea name="cdrom">
 				<disk name="okiraku towns gear" sha1="a614a4471c91a19fe33bf903a5f699907bad813e" />
@@ -9064,6 +9573,7 @@ User/save disks that can be created from the game itself are not included.
 		<publisher>CRI</publisher>
 		<info name="alt_title" value="ハイパー奥の細道" />
 		<info name="release" value="199103xx" />
+		<info name="usage" value="Requires 2 MB RAM"/>
 		<part name="cdrom" interface="fmt_cdrom">
 			<diskarea name="cdrom">
 				<disk name="okuhoso" sha1="7d30d096899dc10b2a88cf132e9a478464b0fa3a" />
@@ -9082,6 +9592,7 @@ User/save disks that can be created from the game itself are not included.
 		<publisher>コスモス・コンピュータ (Cosmos Computer)</publisher>
 		<info name="alt_title" value="億万長者II" />
 		<info name="release" value="199107xx" />
+		<info name="usage" value="Requires 2 MB RAM"/>
 		<part name="cdrom" interface="fmt_cdrom">
 			<diskarea name="cdrom">
 				<disk name="okuman2" sha1="0b646c69dc9a4e8c0e9343885c188d6b9456f513" />
@@ -9107,6 +9618,7 @@ User/save disks that can be created from the game itself are not included.
 		<publisher>ビング (Ving)</publisher>
 		<info name="alt_title" value="オペレーション・ウルフ" />
 		<info name="release" value="199004xx" />
+		<info name="usage" value="Requires 2 MB RAM"/>
 		<part name="cdrom" interface="fmt_cdrom">
 			<diskarea name="cdrom">
 				<disk name="operation wolf (japan)" sha1="1089ca12c9c4b4a82ccd760a68f0b106d8268dc0" />
@@ -9128,6 +9640,7 @@ User/save disks that can be created from the game itself are not included.
 		<publisher>ミサワホーム総合研究所 (Misawa Home Sougou Kenkyuusho)</publisher>
 		<info name="alt_title" value="おしゃれ倶楽部" />
 		<info name="release" value="199103xx" />
+		<info name="usage" value="Requires 2 MB RAM"/>
 		<part name="cdrom" interface="fmt_cdrom">
 			<diskarea name="cdrom">
 				<disk name="oshaclub" sha1="16bff0197bb8fbb97667004205bb02b093376cb2" />
@@ -9148,6 +9661,7 @@ User/save disks that can be created from the game itself are not included.
 		<publisher>ミサワホーム総合研究所 (Misawa Home Sougou Kenkyuusho)</publisher>
 		<info name="alt_title" value="おしゃれクッキング" />
 		<info name="release" value="198912xx" />
+		<info name="usage" value="Requires 2 MB RAM"/>
 		<part name="cdrom" interface="fmt_cdrom">
 			<diskarea name="cdrom">
 				<disk name="oshare cooking" sha1="d6175d9a81760fbd9e497e6a396dbaf2aad6d57c" />
@@ -9166,6 +9680,7 @@ User/save disks that can be created from the game itself are not included.
 		<publisher>ミサワホーム総合研究所 (Misawa Home Sougou Kenkyuusho)</publisher>
 		<info name="alt_title" value="おしゃれクッキングII" />
 		<info name="release" value="199011xx" />
+		<info name="usage" value="Requires 2 MB RAM"/>
 		<part name="cdrom" interface="fmt_cdrom">
 			<diskarea name="cdrom">
 				<disk name="oshacoo2" sha1="dfcd058c69ec2a8cd1a29978b0f1cc772a1fe51c" />
@@ -9185,6 +9700,7 @@ User/save disks that can be created from the game itself are not included.
 		<publisher>リバーヒルソフト (Riverhill Soft)</publisher>
 		<info name="alt_title" value="黄金の羅針盤 翔洋丸桑港航路殺人事件" />
 		<info name="release" value="199104xx" />
+		<info name="usage" value="Requires 2 MB RAM"/>
 		<part name="cdrom" interface="fmt_cdrom">
 			<diskarea name="cdrom">
 				<disk name="ougon no rashimban" sha1="192ab79d6cd44db18a8410d35891fe4bc1f74528" />
@@ -9311,6 +9827,7 @@ User/save disks that can be created from the game itself are not included.
 		<publisher>アートディンク (Artdink)</publisher>
 		<info name="alt_title" value="機甲師団" />
 		<info name="release" value="199012xx" />
+		<info name="usage" value="Requires 2 MB RAM"/>
 		<part name="cdrom" interface="fmt_cdrom">
 			<diskarea name="cdrom">
 				<disk name="panzer division [kikou shidan]" sha1="fae75398775e7f01d760e0e7c87c2e937a14ad87" />
@@ -9327,6 +9844,7 @@ User/save disks that can be created from the game itself are not included.
 		<description>Pegasus (Rev C)</description>
 		<year>1995</year>
 		<publisher>富士通 (Fujitsu)</publisher>
+		<info name="usage" value="Requires 4 MB RAM"/>
 		<part name="cdrom" interface="fmt_cdrom">
 			<diskarea name="cdrom">
 				<disk name="pegasus v1.1l10 (japan) (rev c)" sha1="92bd7e0a25d50152c836a6e1015c4c2f3819b1a9" />
@@ -9343,6 +9861,7 @@ User/save disks that can be created from the game itself are not included.
 		<description>Pegasus (Rev A)</description>
 		<year>1995</year>
 		<publisher>富士通 (Fujitsu)</publisher>
+		<info name="usage" value="Requires 4 MB RAM"/>
 		<part name="cdrom" interface="fmt_cdrom">
 			<diskarea name="cdrom">
 				<disk name="pegasus v1.1l10 (japan) (rev a)" sha1="bce3ddc34dc70ce966f972cdec8d81fbd66d5173" />
@@ -9362,6 +9881,7 @@ User/save disks that can be created from the game itself are not included.
 		<year>1994</year>
 		<publisher>ジャニス (Janis)</publisher>
 		<info name="release" value="199402xx" />
+		<info name="usage" value="Requires 2 MB RAM"/>
 		<part name="cdrom" interface="fmt_cdrom">
 			<diskarea name="cdrom">
 				<disk name="yuka watanabe &amp; tomo kawai - pleasure (japan)" sha1="8e0bc95a85c2189698b2a1bcc181f9fe8a80431c" />
@@ -9410,6 +9930,7 @@ User/save disks that can be created from the game itself are not included.
 		<publisher>ビング (Ving)</publisher>
 		<info name="alt_title" value="プラネッツ・エッジ" />
 		<info name="release" value="199309xx" />
+		<info name="usage" value="Requires 2 MB RAM"/>
 		<part name="cdrom" interface="fmt_cdrom">
 			<diskarea name="cdrom">
 				<disk name="planet's edge" sha1="41c000e9a1f73d76437ab56bee363d481f56b58f" />
@@ -9430,6 +9951,7 @@ User/save disks that can be created from the game itself are not included.
 		<publisher>ガイナックス (Gainax)</publisher>
 		<info name="alt_title" value="プリンセスメーカー２" />
 		<info name="release" value="199409xx" />
+		<info name="usage" value="Requires 2 MB RAM"/>
 		<part name="cdrom" interface="fmt_cdrom">
 			<diskarea name="cdrom">
 				<disk name="princess maker 2" sha1="a0ed8d1a394ccfc109c3afdc6fdc6fd6a095643d" />
@@ -9450,6 +9972,7 @@ User/save disks that can be created from the game itself are not included.
 		<publisher>ポニーテールソフト (Ponytail Soft)</publisher>
 		<info name="alt_title" value="ポンカン" />
 		<info name="release" value="199407xx" />
+		<info name="usage" value="Requires 2 MB RAM"/>
 		<part name="cdrom" interface="fmt_cdrom">
 			<diskarea name="cdrom">
 				<disk name="ponkan" sha1="2e02fbd3cafbfc385d21c97c8b91d771fdd22cc2" />
@@ -9497,6 +10020,7 @@ User/save disks that can be created from the game itself are not included.
 		<publisher>工画堂 (Kogado)</publisher>
 		<info name="alt_title" value="パワードール" />
 		<info name="release" value="199407xx" />
+		<info name="usage" value="Requires 2 MB RAM"/>
 		<part name="flop1" interface="floppy_3_5">
 			<feature name="part_id" value="User Disk" />
 			<dataarea name="flop" size="1261568">
@@ -9529,6 +10053,7 @@ User/save disks that can be created from the game itself are not included.
 		<publisher>工画堂 (Kogado)</publisher>
 		<info name="alt_title" value="パワードール2" />
 		<info name="release" value="199511xx" />
+		<info name="usage" value="Requires 2 MB RAM"/>
 		<part name="cdrom" interface="fmt_cdrom">
 			<diskarea name="cdrom">
 				<disk name="power dolls 2" sha1="248ec3f239e8d069490867d437ac0465dbf878b4" />
@@ -9549,6 +10074,7 @@ User/save disks that can be created from the game itself are not included.
 		<publisher>イマジニア (Imagineer)</publisher>
 		<info name="alt_title" value="パワーモンガー" />
 		<info name="release" value="199205xx" />
+		<info name="usage" value="Requires 2 MB RAM"/>
 		<part name="flop1" interface="floppy_3_5">
 			<feature name="part_id" value="Boot Disk (En)" />
 			<dataarea name="flop" size="1261568">
@@ -9599,6 +10125,7 @@ User/save disks that can be created from the game itself are not included.
 		<publisher>インタープログ (Interprog)</publisher>
 		<info name="alt_title" value="プリンス・オブ・ペルシャ2 ザ・シャドウ アンド ザ・フレーム" />
 		<info name="release" value="199407xx" />
+		<info name="usage" value="Requires 2 MB RAM"/>
 		<part name="cdrom" interface="fmt_cdrom">
 			<diskarea name="cdrom">
 				<disk name="prince of persia 2" sha1="7e46f99eb028afc8f955e5d4d7d3e38b6fefbc73" />
@@ -9664,6 +10191,7 @@ User/save disks that can be created from the game itself are not included.
 		<publisher>Sofcom</publisher>
 		<info name="alt_title" value="プロビデンツァ Legenda la Spada di Alfa" />
 		<info name="release" value="199109xx" />
+		<info name="usage" value="Requires 2 MB RAM"/>
 		<part name="cdrom" interface="fmt_cdrom">
 			<diskarea name="cdrom">
 				<disk name="provvidenza" sha1="a104b48ade5fbe34b324f0c7f3a3fa0de7b482fc" />
@@ -9720,6 +10248,7 @@ User/save disks that can be created from the game itself are not included.
 		<publisher>データウエスト (Data West)</publisher>
 		<info name="alt_title" value="サイキック・ディテクティヴ・シリーズ　Vol.2　メモリーズ" />
 		<info name="release" value="198910xx" />
+		<info name="usage" value="Requires 2 MB RAM"/>
 		<part name="cdrom" interface="fmt_cdrom">
 			<diskarea name="cdrom">
 				<disk name="psychic detective series vol. 2 - memories" sha1="dc3d92414e77cf0220e10f46a92e2c24d07daa82" />
@@ -9745,6 +10274,7 @@ User/save disks that can be created from the game itself are not included.
 		<publisher>データウエスト (Data West)</publisher>
 		<info name="alt_title" value="サイキック・ディテクティヴ・シリーズ　Vol.3　アヤ" />
 		<info name="release" value="199006xx" />
+		<info name="usage" value="Requires 2 MB RAM"/>
 		<part name="cdrom" interface="fmt_cdrom">
 			<diskarea name="cdrom">
 				<disk name="psychic detective series vol. 3 - aya" sha1="2ee820e859d4a6120ed6940a318d45c1101b4140" />
@@ -9770,6 +10300,7 @@ User/save disks that can be created from the game itself are not included.
 		<publisher>データウエスト (Data West)</publisher>
 		<info name="alt_title" value="サイキック・ディテクティヴ・シリーズ　Vol.4　オルゴール" />
 		<info name="release" value="199104xx" />
+		<info name="usage" value="Requires 2 MB RAM"/>
 		<part name="flop1" interface="floppy_3_5">
 			<dataarea name="flop" size="1261568">
 				<rom name="psychic detective series vol. 4 - orgel.hdm" size="1261568" crc="81a557bf" sha1="e32d7a6b60a2265a7035a05f8272ac7938cf82bf" offset="000000" />
@@ -9795,6 +10326,7 @@ User/save disks that can be created from the game itself are not included.
 		<publisher>データウエスト (Data West)</publisher>
 		<info name="alt_title" value="サイキック・ディテクティヴ・シリーズ　Vol.5　ナイトメア" />
 		<info name="release" value="199111xx" />
+		<info name="usage" value="Requires 2 MB RAM"/>
 		<part name="flop1" interface="floppy_3_5">
 			<feature name="part_id" value="System Disk" />
 			<dataarea name="flop" size="1261568">
@@ -9825,6 +10357,7 @@ User/save disks that can be created from the game itself are not included.
 		<publisher>データウエスト (Data West)</publisher>
 		<info name="alt_title" value="サイキック・ディテクティヴ・シリーズ・ファイナル　「ソリチュード（上巻）」" />
 		<info name="release" value="199212xx" />
+		<info name="usage" value="Requires 2 MB RAM"/>
 		<part name="flop1" interface="floppy_3_5">
 			<dataarea name="flop" size="1261568">
 				<rom name="psychic detective series final - solitude joukan.hdm" size="1261568" crc="9dd1bf09" sha1="36f9557b45a606f54cebb180f88e37207a854e37" offset="000000" />
@@ -9852,6 +10385,7 @@ User/save disks that can be created from the game itself are not included.
 		<publisher>データウエスト (Data West)</publisher>
 		<info name="alt_title" value="サイキック・ディテクティヴシリーズ・ファイナル　「ソリチュード（下巻）」" />
 		<info name="release" value="199303xx" />
+		<info name="usage" value="Requires 2 MB RAM"/>
 		<part name="flop1" interface="floppy_3_5">
 			<dataarea name="flop" size="1261568">
 				<rom name="psychic detective series final - solitude gekan.hdm" size="1261568" crc="1e6f92b3" sha1="a0c3e96599e546c0c212091f52d42adbb2dbbb5b" offset="000000" />
@@ -9902,6 +10436,7 @@ User/save disks that can be created from the game itself are not included.
 		<publisher>ビング (Ving)</publisher>
 		<info name="alt_title" value="プリルラ" />
 		<info name="release" value="199411xx" />
+		<info name="usage" value="Requires 2 MB RAM"/>
 		<part name="cdrom" interface="fmt_cdrom">
 			<diskarea name="cdrom">
 				<disk name="pu-li-ru-la" sha1="eb21c2d89c6a01570af580985b1b3771d0f151d0" />
@@ -9920,6 +10455,7 @@ User/save disks that can be created from the game itself are not included.
 		<publisher>富士通 (Fujitsu)</publisher>
 		<info name="alt_title" value="Tom Snyder's パピーラブ２" />
 		<info name="release" value="199303xx" />
+		<info name="usage" value="Requires 2 MB RAM"/>
 		<part name="cdrom" interface="fmt_cdrom">
 			<diskarea name="cdrom">
 				<disk name="puplove2" sha1="35c86cc71dfbdc0d4351892f1270b6b8772e1b67" />
@@ -9955,6 +10491,7 @@ User/save disks that can be created from the game itself are not included.
 		<publisher>CRI</publisher>
 		<info name="alt_title" value="ぷよぷよ" />
 		<info name="release" value="199403xx" />
+		<info name="usage" value="Requires 2 MB RAM"/>
 		<part name="cdrom" interface="fmt_cdrom">
 			<diskarea name="cdrom">
 				<disk name="puyo puyo (japan)" sha1="1916f4a364a42c9ea81e0deaa971bcebc1d8f49d" />
@@ -9991,6 +10528,7 @@ User/save disks that can be created from the game itself are not included.
 		<year>1995</year>
 		<publisher>ビクター音楽産業 (Victor Musical Industries)</publisher>
 		<info name="release" value="199501xx" />
+		<info name="usage" value="Requires 2 MB RAM"/>
 		<part name="cdrom" interface="fmt_cdrom">
 			<diskarea name="cdrom">
 				<disk name="rac rally" sha1="7298bfc4a5bc0c4eb7744337619f9321300a13b6" />
@@ -10017,6 +10555,7 @@ User/save disks that can be created from the game itself are not included.
 		<publisher>KID</publisher>
 		<info name="alt_title" value="雷電伝説" />
 		<info name="release" value="199111xx" />
+		<info name="usage" value="Requires 2 MB RAM"/>
 		<part name="cdrom" interface="fmt_cdrom">
 			<diskarea name="cdrom">
 				<disk name="raiden densetsu - raiden trad (japan)" sha1="9922c6246184d0b25b066f8d0d80676fbbe70c47" />
@@ -10036,6 +10575,7 @@ User/save disks that can be created from the game itself are not included.
 		<year>1994</year>
 		<publisher>ジックス (ZyX)</publisher>
 		<info name="alt_title" value="雷の戦士ライディ" />
+		<info name="usage" value="Requires 2 MB RAM"/>
 		<part name="cdrom" interface="fmt_cdrom">
 			<diskarea name="cdrom">
 				<disk name="ikazuchi no senshi raidy" sha1="da27ad369e6a084c2b9b17401c9ccd7b7f5370cf" />
@@ -10065,6 +10605,7 @@ User/save disks that can be created from the game itself are not included.
 		<publisher>ジックス (ZyX)</publisher>
 		<info name="alt_title" value="雷の戦士ライディ2" />
 		<info name="release" value="199603xx" />
+		<info name="usage" value="Requires 2 MB RAM"/>
 		<part name="cdrom" interface="fmt_cdrom">
 			<diskarea name="cdrom">
 				<disk name="ikazuchi no senshi raidy ii" sha1="798073ac9329aaf2a956ca30490914d46424a28d" />
@@ -10116,6 +10657,7 @@ User/save disks that can be created from the game itself are not included.
 		<publisher>アリスソフト (AliceSoft)</publisher>
 		<info name="alt_title" value="Rance3 リーザス陥落" />
 		<info name="release" value="199205xx" />
+		<info name="usage" value="Requires 2 MB RAM"/>
 		<part name="cdrom" interface="fmt_cdrom">
 			<diskarea name="cdrom">
 				<disk name="rance iii - leazas kanraku (japan)" sha1="4442afdf642a95a6b6279f7b483dad893d0668c8" />
@@ -10160,6 +10702,7 @@ User/save disks that can be created from the game itself are not included.
 		<publisher>アリスソフト (AliceSoft)</publisher>
 		<info name="alt_title" value="Rance4 ～教団の遺産～" />
 		<info name="release" value="199403xx" />
+		<info name="usage" value="Requires 2 MB RAM"/>
 		<part name="flop1" interface="floppy_3_5">
 			<feature name="part_id" value="Boot Disk" />
 			<dataarea name="flop" size="1261568">
@@ -10186,7 +10729,7 @@ User/save disks that can be created from the game itself are not included.
 		<publisher>アリスソフト (AliceSoft)</publisher>
 		<info name="alt_title" value="ランス4.1～お薬工場を救え！～" />
 		<info name="release" value="199512xx" />
-		<info name="usage" value="Requires HDD installation"/>
+		<info name="usage" value="Requires HDD installation and 2 MB RAM"/>
 		<part name="cdrom" interface="fmt_cdrom">
 			<diskarea name="cdrom">
 				<disk name="rance 4.1" sha1="5eb36774483fe9c3e7ba5745aaa336540b07f402" />
@@ -10207,7 +10750,7 @@ User/save disks that can be created from the game itself are not included.
 		<publisher>アリスソフト (AliceSoft)</publisher>
 		<info name="alt_title" value="ランス4.2～エンジェル組～" />
 		<info name="release" value="199512xx" />
-		<info name="usage" value="Requires HDD installation"/>
+		<info name="usage" value="Requires HDD installation and 2 MB RAM"/>
 		<part name="cdrom" interface="fmt_cdrom">
 			<diskarea name="cdrom">
 				<disk name="rance 4.2" sha1="e61f331f1a8f026f1a88325a4497eeb4d4c06446" />
@@ -10228,6 +10771,7 @@ User/save disks that can be created from the game itself are not included.
 		<publisher>ビング (Ving)</publisher>
 		<info name="alt_title" value="Ｒａｖｅｎｌｏｆｔ ～悪の化身～" />
 		<info name="release" value="199504xx" />
+		<info name="usage" value="Requires 2 MB RAM"/>
 		<part name="cdrom" interface="fmt_cdrom">
 			<diskarea name="cdrom">
 				<disk name="ravenloft" sha1="30ddd15c78dd03abbd91799256ba884548b54abb" />
@@ -10248,6 +10792,7 @@ User/save disks that can be created from the game itself are not included.
 		<publisher>データウエスト (Data West)</publisher>
 		<info name="alt_title" value="ライザンバー" />
 		<info name="release" value="199004xx" />
+		<info name="usage" value="Requires 2 MB RAM"/>
 		<part name="cdrom" interface="fmt_cdrom">
 			<diskarea name="cdrom">
 				<disk name="rayxanber" sha1="5e7c36227d61be81f8a4cf4ef79889d12a72549c" />
@@ -10272,6 +10817,7 @@ User/save disks that can be created from the game itself are not included.
 		<publisher>ビング (Ving)</publisher>
 		<info name="alt_title" value="レインボーアイランド EXTRA" />
 		<info name="release" value="199204xx" />
+		<info name="usage" value="Requires 2 MB RAM"/>
 		<part name="cdrom" interface="fmt_cdrom">
 			<diskarea name="cdrom">
 				<disk name="rainbow islands extra" sha1="5dc2afbffca0ccdeba87d036ddcf5e53ad9df8f2" status="baddump" />
@@ -10292,6 +10838,7 @@ User/save disks that can be created from the game itself are not included.
 		<publisher>コスモス・コンピュータ (Cosmos Computer)</publisher>
 		<info name="alt_title" value="レジオナルパワー2" />
 		<info name="release" value="199209xx" />
+		<info name="usage" value="Requires 2 MB RAM"/>
 		<part name="cdrom" interface="fmt_cdrom">
 			<diskarea name="cdrom">
 				<disk name="regional power ii" sha1="18e1100519fbfdfec7a9abc495b1a3719a5529d0" />
@@ -10316,6 +10863,7 @@ User/save disks that can be created from the game itself are not included.
 		<publisher>シュールド・ウェーブ (Sur De Wave)</publisher>
 		<info name="alt_title" value="電脳少女" />
 		<info name="release" value="199212xx" />
+		<info name="usage" value="Requires 2 MB RAM"/>
 		<part name="cdrom" interface="fmt_cdrom">
 			<diskarea name="cdrom">
 				<disk name="rejection - denno senshi" sha1="ed27051ac0deb746e97165008b9d19e4274af45e" />
@@ -10336,7 +10884,7 @@ User/save disks that can be created from the game itself are not included.
 		<publisher>データウエスト (Data West)</publisher>
 		<info name="alt_title" value="リターントゥゾーク" />
 		<info name="release" value="199410xx" />
-		<info name="usage" value="Requires HDD installation"/>
+		<info name="usage" value="Requires HDD installation and 6 MB RAM"/>
 		<part name="cdrom" interface="fmt_cdrom">
 			<diskarea name="cdrom">
 				<disk name="return to zork" sha1="ec6c343f5016d60df7650b636298945372471550" />
@@ -10357,6 +10905,7 @@ User/save disks that can be created from the game itself are not included.
 		<publisher>ジックス (ZyX)</publisher>
 		<info name="alt_title" value="リングアウト" />
 		<info name="release" value="199506xx" />
+		<info name="usage" value="Requires 2 MB RAM"/>
 		<part name="cdrom" interface="fmt_cdrom">
 			<diskarea name="cdrom">
 				<disk name="ring out!!" sha1="2b50d05b278824e36a1b2fdf500a5ec4c9daeb3b" />
@@ -10377,6 +10926,7 @@ User/save disks that can be created from the game itself are not included.
 		<publisher>フォスター (Foster)</publisher>
 		<info name="alt_title" value="林間学校" />
 		<info name="release" value="199602xx" />
+		<info name="usage" value="Requires 2 MB RAM"/>
 		<part name="cdrom" interface="fmt_cdrom">
 			<diskarea name="cdrom">
 				<disk name="rinkan" sha1="2574f07d8495ea197b5a04136f860b5466fa1ad5" />
@@ -10394,6 +10944,7 @@ User/save disks that can be created from the game itself are not included.
 		<year>1990</year>
 		<publisher>ポニーキャニオン (Pony Canyon)</publisher>
 		<info name="release" value="199005xx" />
+		<info name="usage" value="Requires 2 MB RAM"/>
 		<part name="cdrom" interface="fmt_cdrom">
 			<diskarea name="cdrom">
 				<disk name="rocket ranger" sha1="faee63cd159d68240360149887702560dedff780" />
@@ -10414,6 +10965,7 @@ User/save disks that can be created from the game itself are not included.
 		<publisher>富士通 (Fujitsu)</publisher>
 		<info name="alt_title" value="龍闘伝" />
 		<info name="release" value="199005xx" />
+		<info name="usage" value="Requires 2 MB RAM"/>
 		<part name="cdrom" interface="fmt_cdrom">
 			<diskarea name="cdrom">
 				<disk name="ryuutouden" sha1="b3468afda6c697b270d49ccc89545dc57b0c6c80" />
@@ -10434,6 +10986,7 @@ User/save disks that can be created from the game itself are not included.
 		<publisher>アクティブ (Active)</publisher>
 		<info name="alt_title" value="櫻の杜" />
 		<info name="release" value="19951027" />
+		<info name="usage" value="Requires 2 MB RAM"/>
 		<part name="cdrom" interface="fmt_cdrom">
 			<diskarea name="cdrom">
 				<disk name="sakumori" sha1="36bfe8686bb2eadb962852e5e1e44de94e654c23" />
@@ -10454,6 +11007,7 @@ User/save disks that can be created from the game itself are not included.
 		<publisher>光栄 (Koei)</publisher>
 		<info name="alt_title" value="三国志II" />
 		<info name="release" value="199006xx" />
+		<info name="usage" value="Requires 2 MB RAM"/>
 		<part name="flop1" interface="floppy_3_5">
 			<dataarea name="flop" size="1281968">
 				<rom name="sango2.d88" size="1281968" crc="40a7015d" sha1="79ae6709d7ee2c7f35c07f967e032f790565278b" offset="000000" />
@@ -10517,6 +11071,7 @@ User/save disks that can be created from the game itself are not included.
 		<publisher>フェアリーテール (Fairytale)</publisher>
 		<info name="alt_title" value="沙也香＆美穂" />
 		<info name="release" value="199409xx" />
+		<info name="usage" value="Requires 2 MB RAM"/>
 		<part name="cdrom" interface="fmt_cdrom">
 			<diskarea name="cdrom">
 				<disk name="sayaka &amp; miho" sha1="c1a31725589c0256e6e93c71033db07772fa550c" />
@@ -10534,6 +11089,7 @@ User/save disks that can be created from the game itself are not included.
 		<description>Scavenger 4 Demo Disc</description>
 		<year>1993</year>
 		<publisher>富士通 (Fujitsu)</publisher>
+		<info name="usage" value="Requires 2 MB RAM"/>
 		<part name="cdrom" interface="fmt_cdrom">
 			<diskarea name="cdrom">
 				<disk name="scavenger 4 (demo disc)" sha1="d94ff9ddc64c3acc20814f8290e5c5a0e6fe2217" />
@@ -10555,6 +11111,7 @@ User/save disks that can be created from the game itself are not included.
 		<publisher>富士通 (Fujitsu)</publisher>
 		<info name="alt_title" value="スカベンジャー４" />
 		<info name="release" value="199312xx" />
+		<info name="usage" value="Requires 2 MB RAM"/>
 		<part name="cdrom" interface="fmt_cdrom">
 			<diskarea name="cdrom">
 				<disk name="scavenger 4" sha1="a78fff2a22e995afb7cbadcec026caf65ac3490e" />
@@ -10573,6 +11130,7 @@ User/save disks that can be created from the game itself are not included.
 		<publisher>富士通 (Fujitsu)</publisher>
 		<info name="alt_title" value="スカベンジャー４" />
 		<info name="release" value="199311xx" />
+		<info name="usage" value="Requires 2 MB RAM"/>
 		<part name="cdrom" interface="fmt_cdrom">
 			<diskarea name="cdrom">
 				<disk name="scavenger 4 (japan)" sha1="cd3018dc93541f3fd6489d51e5b3ad88c1cdd4a4" />
@@ -10593,6 +11151,7 @@ User/save disks that can be created from the game itself are not included.
 		<publisher>King Records</publisher>
 		<info name="alt_title" value="スコラ MOVIE MAGAZINE" />
 		<info name="release" value="199403xx" />
+		<info name="usage" value="Requires 2 MB RAM"/>
 		<part name="flop1" interface="floppy_3_5">
 			<feature name="part_id" value="Boot Disk" />
 			<dataarea name="flop" size="1261568">
@@ -10619,6 +11178,7 @@ User/save disks that can be created from the game itself are not included.
 		<publisher>工画堂 (Kogado)</publisher>
 		<info name="alt_title" value="シュヴァルツシルト" />
 		<info name="release" value="199111xx" />
+		<info name="usage" value="Requires 2 MB RAM"/>
 		<part name="flop1" interface="floppy_3_5">
 			<feature name="part_id" value="Game Disk" />
 			<dataarea name="flop" size="1261568">
@@ -10653,6 +11213,7 @@ User/save disks that can be created from the game itself are not included.
 		<publisher>工画堂 (Kogado)</publisher>
 		<info name="alt_title" value="シュヴァルツシルト4 THE CRADLE END" />
 		<info name="release" value="199312xx" />
+		<info name="usage" value="Requires 2 MB RAM"/>
 		<part name="cdrom" interface="fmt_cdrom">
 			<diskarea name="cdrom">
 				<disk name="schwarzschild iv - the cradle end (japan)" sha1="6c7e0fba4eaa4d68f375976ff25eaa62bad2bce5" />
@@ -10671,6 +11232,7 @@ User/save disks that can be created from the game itself are not included.
 		<publisher>グラムス (Glams)</publisher>
 		<info name="alt_title" value="Secre VOLUME I 飯島直子" />
 		<info name="release" value="199308xx" />
+		<info name="usage" value="Requires 2 MB RAM"/>
 		<part name="cdrom" interface="fmt_cdrom">
 			<diskarea name="cdrom">
 				<disk name="secre volume i - naoko iijima (japan)" sha1="33d5da58a5b7d4a5abd48f2a6335c71e007d25a6" />
@@ -10691,6 +11253,7 @@ User/save disks that can be created from the game itself are not included.
 		<publisher>グラムス (Glams)</publisher>
 		<info name="alt_title" value="Secre VOLUME 2 及川麻衣" />
 		<info name="release" value="19930819" />
+		<info name="usage" value="Requires 2 MB RAM"/>
 		<part name="cdrom" interface="fmt_cdrom">
 			<diskarea name="cdrom">
 				<disk name="secre2" sha1="ccd2a47f886e0ef66b5477aabbf128bb8118b684" />
@@ -10717,9 +11280,31 @@ User/save disks that can be created from the game itself are not included.
 		<publisher>アートディンク (Artdink)</publisher>
 		<info name="alt_title" value="関ヶ原" />
 		<info name="release" value="199204xx" />
+		<info name="usage" value="Requires 2 MB RAM"/>
 		<part name="cdrom" interface="fmt_cdrom">
 			<diskarea name="cdrom">
 				<disk name="sekigahara (japan)" sha1="04f0bda6d14765dacaa339145c3920cf0ae8332b" />
+			</diskarea>
+		</part>
+	</software>
+
+	<!-- Missing a floppy disk -->
+	<software name="shamhat" supported="no">
+		<!--
+		Origin: redump.org
+		<rom name="Shamhat - The Holy Circlet (Japan) (Track 1).bin" size="260484000" crc="5c856e63" sha1="2751566dd6bb590dfb4c67e5e54d5c9535233d80"/>
+		<rom name="Shamhat - The Holy Circlet (Japan) (Track 2).bin" size="5997600" crc="97dfe1ae" sha1="1d9d1ff4e3ee96c9b14caa867d58fe7f58a693d4"/>
+		<rom name="Shamhat - The Holy Circlet (Japan) (Track 3).bin" size="54695760" crc="95e66371" sha1="ae10a3f5ce8fdc8a841aaaea5936dff6e576a2b1"/>
+		<rom name="Shamhat - The Holy Circlet (Japan).cue" size="366" crc="65b04438" sha1="a7bd44db41f64066975a485c166dada00468867c"/>
+		-->
+		<description>Shamhat - The Holy Circlet</description>
+		<year>1993</year>
+		<publisher>データウエスト (Data West)</publisher>
+		<info name="alt_title" value="シャムハト　－Ｔｈｅ　Ｈｏｌｙ　Ｃｉｒｃｌｅｔ－" />
+		<info name="release" value="199304xx" />
+		<part name="cdrom" interface="fmt_cdrom">
+			<diskarea name="cdrom">
+				<disk name="shamhat - the holy circlet (japan)" sha1="538a5f793c970a3ad9732c9e30f75b5b68b7b8f0" />
 			</diskarea>
 		</part>
 	</software>
@@ -10742,6 +11327,7 @@ User/save disks that can be created from the game itself are not included.
 		<publisher>アスキー (ASCII)</publisher>
 		<info name="alt_title" value="上海" />
 		<info name="release" value="199012xx" />
+		<info name="usage" value="Requires 2 MB RAM"/>
 		<part name="cdrom" interface="fmt_cdrom">
 			<diskarea name="cdrom">
 				<disk name="shanghai (japan)" sha1="4c1bba4f7521d3fc5e89a8bb7a33a4923d0dc2db" />
@@ -10760,6 +11346,7 @@ User/save disks that can be created from the game itself are not included.
 		<publisher>エルフ (Elf)</publisher>
 		<info name="alt_title" value="シャングリラ2" />
 		<info name="release" value="199410xx" />
+		<info name="usage" value="Requires 2 MB RAM"/>
 		<part name="cdrom" interface="fmt_cdrom">
 			<diskarea name="cdrom">
 				<disk name="shangrlia 2 (japan)" sha1="4bcb9e21bcec7d61e741791d15558e712a16139c" />
@@ -10778,6 +11365,7 @@ User/save disks that can be created from the game itself are not included.
 		<publisher>富士通 (Fujitsu)</publisher>
 		<info name="alt_title" value="シャーロックホームズの探偵講座" />
 		<info name="release" value="199106xx" />
+		<info name="usage" value="Requires 2 MB RAM"/>
 		<part name="cdrom" interface="fmt_cdrom">
 			<diskarea name="cdrom">
 				<disk name="sherlock holmes - consulting detective (japan)" sha1="e0e0767fbde8bb455641666f7f2fe48c45e0048a" />
@@ -10798,6 +11386,7 @@ User/save disks that can be created from the game itself are not included.
 		<publisher>リビドー (Libido)</publisher>
 		<info name="alt_title" value="シンク" />
 		<info name="release" value="199304xx" />
+		<info name="usage" value="Requires 2 MB RAM"/>
 		<part name="cdrom" interface="fmt_cdrom">
 			<diskarea name="cdrom">
 				<disk name="shinc" sha1="5cb5158e300c504e987d0ab9564ddffa902c28ed" />
@@ -10841,6 +11430,7 @@ User/save disks that can be created from the game itself are not included.
 		<publisher>徳間書店インターメディア (Tokuma Shoten Intermedia)</publisher>
 		<info name="alt_title" value="新宿ラビリンス" />
 		<info name="release" value="199412xx" />
+		<info name="usage" value="Requires 2 MB RAM"/>
 		<part name="flop1" interface="floppy_3_5">
 			<feature name="part_id" value="Master Disk" />
 			<dataarea name="flop" size="1261568">
@@ -10890,6 +11480,7 @@ User/save disks that can be created from the game itself are not included.
 		<publisher>ダットジャパン (Datt Japan)</publisher>
 		<info name="alt_title" value="少年マガジンヒストリー" />
 		<info name="release" value="199211xx" />
+		<info name="usage" value="Requires 2 MB RAM"/>
 		<part name="cdrom" interface="fmt_cdrom">
 			<diskarea name="cdrom">
 				<disk name="shounen magazine history" sha1="f453ee25f0f0da3ca23bbbd09632aa63f7a7d2fb" />
@@ -10908,6 +11499,7 @@ User/save disks that can be created from the game itself are not included.
 		<publisher>イマジニア (Imagineer)</publisher>
 		<info name="alt_title" value="シムアント" />
 		<info name="release" value="199302xx" />
+		<info name="usage" value="Requires 2 MB RAM"/>
 		<part name="cdrom" interface="fmt_cdrom">
 			<diskarea name="cdrom">
 				<disk name="simant" sha1="56d7d642dd93073a76f19db4dde3418eb0f5ab17" />
@@ -10927,6 +11519,7 @@ User/save disks that can be created from the game itself are not included.
 		<year>1992</year>
 		<publisher>富士通 (Fujitsu)</publisher>
 		<info name="alt_title" value="シムシティ" />
+		<info name="usage" value="Requires 2 MB RAM"/>
 		<part name="cdrom" interface="fmt_cdrom">
 			<diskarea name="cdrom">
 				<disk name="simcity" sha1="4f161a7cd9d5fb27f2ebd6d544310e2c42d26da6" />
@@ -10960,6 +11553,7 @@ User/save disks that can be created from the game itself are not included.
 		<publisher>富士通 (Fujitsu)</publisher>
 		<info name="alt_title" value="シムシティ" />
 		<info name="release" value="199003xx" />
+		<info name="usage" value="Requires 2 MB RAM"/>
 		<part name="cdrom" interface="fmt_cdrom">
 			<diskarea name="cdrom">
 				<disk name="simcity (japan)" sha1="386efdf2dbacb0da8b81e294ad3b1b99ca33d4bc" />
@@ -10982,6 +11576,7 @@ User/save disks that can be created from the game itself are not included.
 		<publisher>富士通 (Fujitsu)</publisher>
 		<info name="alt_title" value="シムシティ2000" />
 		<info name="release" value="199412xx" />
+		<info name="usage" value="Requires 3 MB RAM"/>
 		<part name="cdrom" interface="fmt_cdrom">
 			<diskarea name="cdrom">
 				<disk name="simcity 2000" sha1="b0a731372cc12dbdb5dd7140daa75cb99952cc77" />
@@ -11002,6 +11597,7 @@ User/save disks that can be created from the game itself are not included.
 		<publisher>イマジニア (Imagineer)</publisher>
 		<info name="alt_title" value="シムアース" />
 		<info name="release" value="199109xx" />
+		<info name="usage" value="Requires 2 MB RAM"/>
 		<part name="cdrom" interface="fmt_cdrom">
 			<diskarea name="cdrom">
 				<disk name="simearth" sha1="e14823bae0e649313d2dec35d889e06d2a42986a" />
@@ -11022,6 +11618,7 @@ User/save disks that can be created from the game itself are not included.
 		<publisher>富士通 (Fujitsu)</publisher>
 		<info name="alt_title" value="シムファーム" />
 		<info name="release" value="199409xx" />
+		<info name="usage" value="Requires 2 MB RAM"/>
 		<part name="cdrom" interface="fmt_cdrom">
 			<diskarea name="cdrom">
 				<disk name="simfarm" sha1="4c87c0002006a539e04fd2bdb1b4a1c7435aa452" />
@@ -11100,6 +11697,7 @@ User/save disks that can be created from the game itself are not included.
 		<publisher>ガイナックス (Gainax)</publisher>
 		<info name="alt_title" value="サイレントメビウス" />
 		<info name="release" value="199109xx" />
+		<info name="usage" value="Requires 2 MB RAM"/>
 		<part name="cdrom" interface="fmt_cdrom">
 			<diskarea name="cdrom">
 				<disk name="silent moebius - case - titanic (japan)" sha1="a9e5cb2f1968e381d704b6e37b5c1a55cc50375f" />
@@ -11120,6 +11718,7 @@ User/save disks that can be created from the game itself are not included.
 		<publisher>JHV</publisher>
 		<info name="alt_title" value="卒業 '９３" />
 		<info name="release" value="199310xx" />
+		<info name="usage" value="Requires 2 MB RAM"/>
 		<part name="flop1" interface="floppy_3_5">
 			<feature name="part_id" value="Play Disk" />
 			<dataarea name="flop" size="1261568">
@@ -11173,6 +11772,7 @@ User/save disks that can be created from the game itself are not included.
 		<publisher>富士通 (Fujitsu)</publisher>
 		<info name="alt_title" value="スペースミュージアム" />
 		<info name="release" value="199311xx" />
+		<info name="usage" value="Requires 2 MB RAM"/>
 		<part name="cdrom" interface="fmt_cdrom">
 			<diskarea name="cdrom">
 				<disk name="space museum (japan)" sha1="06b8623523615234bbf9d0161fb88576dda70e21" />
@@ -11232,6 +11832,7 @@ User/save disks that can be created from the game itself are not included.
 		<publisher>ビング (Ving)</publisher>
 		<info name="alt_title" value="スプラッターハウス" />
 		<info name="release" value="199206xx" />
+		<info name="usage" value="Requires 2 MB RAM"/>
 		<part name="cdrom" interface="fmt_cdrom">
 			<diskarea name="cdrom">
 				<disk name="splatterhouse (japan)" sha1="77c982a3fa1417cba7ce705a455e212e7c342dcd" />
@@ -11268,6 +11869,7 @@ User/save disks that can be created from the game itself are not included.
 		<publisher>ウェーブトレイン (Wave Train)</publisher>
 		<info name="alt_title" value="スーパー・オデッセイ＆電脳プラネタリウム" />
 		<info name="release" value="198912xx" />
+		<info name="usage" value="Requires 2 MB RAM"/>
 		<part name="cdrom" interface="fmt_cdrom">
 			<diskarea name="cdrom">
 				<disk name="super odyssey &amp; dennou planetarium (japan)" sha1="900823d5bb33f4bb59e35104e6b37523afe3b47b" />
@@ -11288,6 +11890,7 @@ User/save disks that can be created from the game itself are not included.
 		<publisher>富士通 (Fujitsu)</publisher>
 		<info name="alt_title" value="ソフトウェアコンテスト入選作品集 Vol.2" />
 		<info name="release" value="199301xx" />
+		<info name="usage" value="Requires 2 MB RAM"/>
 		<part name="cdrom" interface="fmt_cdrom">
 			<diskarea name="cdrom">
 				<disk name="softcon2" sha1="204589dd46a5e2db1a65c9252e17844868650583" />
@@ -11306,6 +11909,7 @@ User/save disks that can be created from the game itself are not included.
 		<publisher>シンキングラビット (Thinking Rabbit)</publisher>
 		<info name="alt_title" value="倉庫番パーフェクト" />
 		<info name="release" value="199007xx" />
+		<info name="usage" value="Requires 2 MB RAM"/>
 		<part name="cdrom" interface="fmt_cdrom">
 			<diskarea name="cdrom">
 				<disk name="sbpt_u_100" sha1="50a4dc0e4fa24d7d6663da79a3d917480aa19468" />
@@ -11332,6 +11936,7 @@ User/save disks that can be created from the game itself are not included.
 		<publisher>ビクター音楽産業 (Victor Musical Industries)</publisher>
 		<info name="alt_title" value="シャドー・オブ・ザ・ビースト 魔性の掟" />
 		<info name="release" value="199109xx" />
+		<info name="usage" value="Requires 2 MB RAM"/>
 		<part name="cdrom" interface="fmt_cdrom">
 			<diskarea name="cdrom">
 				<disk name="shadow of the beast - mashou no okite (japan)" sha1="419a46ecb95b0739b69ccb3133400365fca25f53" />
@@ -11364,6 +11969,7 @@ User/save disks that can be created from the game itself are not included.
 		<publisher>ビクター音楽産業 (Victor Musical Industries)</publisher>
 		<info name="alt_title" value="シャドー・オブ・ザ・ビースト2 獣神の呪縛" />
 		<info name="release" value="199306xx" />
+		<info name="usage" value="Requires 2 MB RAM"/>
 		<part name="cdrom" interface="fmt_cdrom">
 			<diskarea name="cdrom">
 				<disk name="shadow of the beast ii - juushin no jubaku (japan)" sha1="39c34e8c2bc89404431c1be99144a3cd32998664" />
@@ -11408,6 +12014,7 @@ User/save disks that can be created from the game itself are not included.
 		<publisher>ビング (Ving)</publisher>
 		<info name="alt_title" value="スーパーリアル麻雀PII＆PIII" />
 		<info name="release" value="199204xx" />
+		<info name="usage" value="Requires 2 MB RAM"/>
 		<part name="cdrom" interface="fmt_cdrom">
 			<diskarea name="cdrom">
 				<disk name="super real mahjong pii&amp;piii (japan)" sha1="414acdba619462b6f23f37c64588a6f51050569f" />
@@ -11426,6 +12033,7 @@ User/save disks that can be created from the game itself are not included.
 		<publisher>ビング (Ving)</publisher>
 		<info name="alt_title" value="スーパーリアル麻雀PII＆PIII＋" />
 		<info name="release" value="199303xx" />
+		<info name="usage" value="Requires 2 MB RAM"/>
 		<part name="cdrom" interface="fmt_cdrom">
 			<diskarea name="cdrom">
 				<disk name="super real mahjong pii &amp; piii +" sha1="771be8adecbb5798bb1cd79942854937c337c262" />
@@ -11456,6 +12064,7 @@ User/save disks that can be created from the game itself are not included.
 		<publisher>ビング (Ving)</publisher>
 		<info name="alt_title" value="スーパーリアル麻雀PIV" />
 		<info name="release" value="199405xx" />
+		<info name="usage" value="Requires 2 MB RAM"/>
 		<part name="cdrom" interface="fmt_cdrom">
 			<diskarea name="cdrom">
 				<disk name="super real mahjong piv (japan)" sha1="aa9cb9548a18538503395803e04156776c60ee31" />
@@ -11474,6 +12083,7 @@ User/save disks that can be created from the game itself are not included.
 		<publisher>ウェーブトレイン (Wave Train)</publisher>
 		<info name="alt_title" value="スペースローグ" />
 		<info name="release" value="199007xx" />
+		<info name="usage" value="Requires 2 MB RAM"/>
 		<part name="cdrom" interface="fmt_cdrom">
 			<diskarea name="cdrom">
 				<disk name="space rogue" sha1="f409d07391dfdff739241710df792ddd84531a85" />
@@ -11496,6 +12106,7 @@ User/save disks that can be created from the game itself are not included.
 		<publisher>ウェーブトレイン (Wave Train)</publisher>
 		<info name="alt_title" value="スペースローグ" />
 		<info name="release" value="199007xx" />
+		<info name="usage" value="Requires 2 MB RAM"/>
 		<part name="cdrom" interface="fmt_cdrom">
 			<diskarea name="cdrom">
 				<disk name="space rogue (no disk check)" sha1="29b752371f08eb772eb91b4f8c268ea7efd8102f" />
@@ -11561,6 +12172,7 @@ User/save disks that can be created from the game itself are not included.
 		<publisher>カプコン (Capcom)</publisher>
 		<info name="alt_title" value="スーパーストリートファイターII" />
 		<info name="release" value="199410xx" />
+		<info name="usage" value="Requires 4 MB RAM"/>
 		<part name="cdrom" interface="fmt_cdrom">
 			<diskarea name="cdrom">
 				<disk name="super street fighter ii - the new challengers (japan)" sha1="7b4a58d823a079753916a2474fcb493eca923605" />
@@ -11577,6 +12189,7 @@ User/save disks that can be created from the game itself are not included.
 		<description>Super Street Fighter II - The New Challengers (Sample Disc)</description>
 		<year>1994</year>
 		<publisher>カプコン (Capcom)</publisher>
+		<info name="usage" value="Requires 4 MB RAM"/>
 		<part name="cdrom" interface="fmt_cdrom">
 			<diskarea name="cdrom">
 				<disk name="super street fighter ii (sample disc)" sha1="6eae776377e80ae43950f47c4f930df36b63c6d6" />
@@ -11597,6 +12210,7 @@ User/save disks that can be created from the game itself are not included.
 		<publisher>HOT・B</publisher>
 		<info name="alt_title" value="スーパー上海ドラゴンズアイ" />
 		<info name="release" value="199111xx" />
+		<info name="usage" value="Requires 2 MB RAM"/>
 		<part name="cdrom" interface="fmt_cdrom">
 			<diskarea name="cdrom">
 				<disk name="super shanghai - dragon's eye" sha1="3e8abecc76e6cb5f98c3d40398e71a0f3600e45a" />
@@ -11618,6 +12232,7 @@ User/save disks that can be created from the game itself are not included.
 		<publisher>JHV</publisher>
 		<info name="alt_title" value="サムライスピリッツ" />
 		<info name="release" value="199509xx" />
+		<info name="usage" value="Requires 4 MB RAM"/>
 		<part name="flop1" interface="floppy_3_5">
 			<feature name="part_id" value="Boot Disk" />
 			<dataarea name="flop" size="1261568">
@@ -11644,6 +12259,7 @@ User/save disks that can be created from the game itself are not included.
 		<publisher>アモルファス (Amorphous)</publisher>
 		<info name="alt_title" value="スーパーシューティングTOWNS" />
 		<info name="release" value="199112xx" />
+		<info name="usage" value="Requires 2 MB RAM"/>
 		<part name="cdrom" interface="fmt_cdrom">
 			<diskarea name="cdrom">
 				<disk name="super shooting towns" sha1="64dd74baedfc4ef6c2bcdd96b8dd449c8beb36a2" />
@@ -11664,6 +12280,7 @@ User/save disks that can be created from the game itself are not included.
 		<publisher>JHV</publisher>
 		<info name="alt_title" value="スタークルーザーII" />
 		<info name="release" value="199404xx" />
+		<info name="usage" value="Requires 2 MB RAM"/>
 		<part name="flop1" interface="floppy_3_5">
 			<feature name="part_id" value="User Disk" />
 			<dataarea name="flop" size="1261568">
@@ -11690,6 +12307,7 @@ User/save disks that can be created from the game itself are not included.
 		<publisher>エレクトロニック・アーツ・ビクター (Electronic Arts Victor)</publisher>
 		<info name="alt_title" value="ストライク・コマンダー" />
 		<info name="release" value="199408xx" />
+		<info name="usage" value="Requires HDD installation and 4 MB RAM"/>
 		<part name="cdrom" interface="fmt_cdrom">
 			<diskarea name="cdrom">
 				<disk name="strike commander" sha1="4ce5635dfe368cedfe0d61fb46a11d8f7fb2c083" />
@@ -11710,6 +12328,7 @@ User/save disks that can be created from the game itself are not included.
 		<publisher>エレクトロニック・アーツ・ビクター (Electronic Arts Victor)</publisher>
 		<info name="alt_title" value="ストライク・コマンダーPLUS" />
 		<info name="release" value="199504xx" />
+		<info name="usage" value="Requires HDD installation and 4 MB RAM"/>
 		<part name="cdrom" interface="fmt_cdrom">
 			<diskarea name="cdrom">
 				<disk name="strike commander plus" sha1="c926c123e3c0c8e439b16c27ecca3b420e1964bb" />
@@ -11730,6 +12349,7 @@ User/save disks that can be created from the game itself are not included.
 		<publisher>ビング (Ving)</publisher>
 		<info name="alt_title" value="ストロングホールド ～皇帝の要塞～" />
 		<info name="release" value="199406xx" />
+		<info name="usage" value="Requires 2 MB RAM"/>
 		<part name="cdrom" interface="fmt_cdrom">
 			<diskarea name="cdrom">
 				<disk name="stronghold" sha1="dfebcbaaa112dfd262945e20bb881fc6f54e7f07" />
@@ -11756,6 +12376,25 @@ User/save disks that can be created from the game itself are not included.
 		</part>
 	</software>
 
+	<!-- Missing a floppy disk -->
+	<software name="suzaku" supported="no">
+		<!--
+		Origin: redump.org
+		<rom name="Suzaku (Japan).bin" size="26107200" crc="fe233985" sha1="445fad31af6443b66287fda2d384270252fe33cc"/>
+		<rom name="Suzaku (Japan).cue" size="103" crc="f4620f82" sha1="9da9198602bbbdc8d514e1cee5ca314ff1d14f09"/>
+		-->
+		<description>Suzaku</description>
+		<year>1992</year>
+		<publisher>ウルフチーム (WolfTeam)</publisher>
+		<info name="alt_title" value="スザク" />
+		<info name="release" value="199210xx" />
+		<part name="cdrom" interface="fmt_cdrom">
+			<diskarea name="cdrom">
+				<disk name="suzaku (japan)" sha1="e3cdfc33799bb743fe6c92e93e6207bc2e654179" />
+			</diskarea>
+		</part>
+	</software>
+
 	<software name="syndicat">
 		<!--
 		Origin: Neo Kobe Collection
@@ -11771,6 +12410,7 @@ User/save disks that can be created from the game itself are not included.
 		<publisher>エレクトロニック・アーツ・ビクター (Electronic Arts Victor)</publisher>
 		<info name="alt_title" value="シンジケート" />
 		<info name="release" value="199407xx" />
+		<info name="usage" value="Requires 2 MB RAM"/>
 		<part name="cdrom" interface="fmt_cdrom">
 			<diskarea name="cdrom">
 				<disk name="syndicate" sha1="d676fb5d4345ec464740c1b9c53327df0925a46a" />
@@ -11789,6 +12429,7 @@ User/save disks that can be created from the game itself are not included.
 		<description>Towns Taikenban CD '93</description>
 		<year>1993</year>
 		<publisher>富士通 (Fujitsu)</publisher>
+		<info name="usage" value="Requires 2 MB RAM to boot, some demos require more"/>
 		<part name="cdrom" interface="fmt_cdrom">
 			<diskarea name="cdrom">
 				<disk name="taikenban cd" sha1="4bfe5252ef91a95b06a2ece9b60f110cf913d980" />
@@ -11818,6 +12459,7 @@ User/save disks that can be created from the game itself are not included.
 		<publisher>富士通 (Fujitsu)</publisher>
 		<info name="alt_title" value="体験しよう！マーティチャンネル" />
 		<info name="release" value="199302xx" />
+		<info name="usage" value="Requires 2 MB RAM"/>
 		<part name="cdrom" interface="fmt_cdrom">
 			<diskarea name="cdrom">
 				<disk name="taiken shiyou! marty channel (japan)" sha1="d1577643f6bdf903c22877f7de6c450c5bed8730" />
@@ -11838,6 +12480,7 @@ User/save disks that can be created from the game itself are not included.
 		<publisher>光栄 (Koei)</publisher>
 		<info name="alt_title" value="太閤立志伝" />
 		<info name="release" value="199205xx" />
+		<info name="usage" value="Requires 2 MB RAM"/>
 		<part name="cdrom" interface="fmt_cdrom">
 			<diskarea name="cdrom">
 				<disk name="taikou risshinden" sha1="b66a2e514c893103f7fdc8b0c5850529d96f51ea" />
@@ -11858,6 +12501,7 @@ User/save disks that can be created from the game itself are not included.
 		<publisher>ジックス (ZyX)</publisher>
 		<info name="alt_title" value="高見沢恭介 熱血！！教育研修" />
 		<info name="release" value="199501xx" />
+		<info name="usage" value="Requires 2 MB RAM"/>
 		<part name="cdrom" interface="fmt_cdrom">
 			<diskarea name="cdrom">
 				<disk name="takamizawa kyosuke - nekketsu!! kyouiku kenshuu" sha1="ce13831f3094f9ab53c392480ece497c9b3c7997" />
@@ -11878,6 +12522,7 @@ User/save disks that can be created from the game itself are not included.
 		<publisher>データウエスト (Data West)</publisher>
 		<info name="alt_title" value="誕生 ～Ｄｅｂｕｔ～" />
 		<info name="release" value="199404xx" />
+		<info name="usage" value="Requires 2 MB RAM"/>
 		<part name="flop1" interface="floppy_3_5">
 			<feature name="part_id" value="Key Disk" />
 			<dataarea name="flop" size="1261568">
@@ -11893,20 +12538,29 @@ User/save disks that can be created from the game itself are not included.
 
 	<software name="tatsuou">
 		<!--
-		Origin: Neo Kobe Collection
-		<rom name="Tatsujin Oh.ccd" size="2677" crc="5385c746" sha1="cdd05fe21013bef94dccf38481b7bc1e6790ac6b"/>
-		<rom name="Tatsujin Oh.cue" size="488" crc="851f0921" sha1="fa6fc02d54cb17582255e64780b948aa346f8a73"/>
-		<rom name="Tatsujin Oh.img" size="344325744" crc="b6298ebe" sha1="175e8b6e1a7fec115785f288e22db374d959c364"/>
-		<rom name="Tatsujin Oh.sub" size="14054112" crc="6cd82894" sha1="84b64a44c9ade15319205bd62cbd69e29b5e8489"/>
+		Origin: redump.org
+		<rom name="Tatsujin-ou (Japan) (Track 01).bin" size="20815200" crc="1decb00f" sha1="7d8ec09c8be535eeb47d457e3b20fdc282b6d4e3"/>
+		<rom name="Tatsujin-ou (Japan) (Track 02).bin" size="3081120" crc="cd4b68ec" sha1="9655b18161ef863770e72ba03f5cde74465db9c3"/>
+		<rom name="Tatsujin-ou (Japan) (Track 03).bin" size="4896864" crc="3a9d92a1" sha1="a5c4ad0fb56f8ee8283400d13caaab6bae4a44b2"/>
+		<rom name="Tatsujin-ou (Japan) (Track 04).bin" size="1552320" crc="fe65984b" sha1="b4ee49b73957e280b8913c5aa33b5c56f0fdcd78"/>
+		<rom name="Tatsujin-ou (Japan) (Track 05).bin" size="44871456" crc="f2906521" sha1="8b42a8410faa89e0993d5ae19fca662f874173d2"/>
+		<rom name="Tatsujin-ou (Japan) (Track 06).bin" size="44727984" crc="b0d21efd" sha1="4b009ab919f05b882cb102442cf6fe7933ac9424"/>
+		<rom name="Tatsujin-ou (Japan) (Track 07).bin" size="44429280" crc="63d35e88" sha1="7f6aa3ddbe34053efef2060421158a5d0fffd3e8"/>
+		<rom name="Tatsujin-ou (Japan) (Track 08).bin" size="44965536" crc="86c3d543" sha1="df156fa5a1d2207835886bf2e52fe0f00dd17c7f"/>
+		<rom name="Tatsujin-ou (Japan) (Track 09).bin" size="44939664" crc="2fd96812" sha1="fa3581d1ab6a003e6a86653796a6694c740a1ad1"/>
+		<rom name="Tatsujin-ou (Japan) (Track 10).bin" size="44593920" crc="e6277c4d" sha1="f0a8c1693af4df4064e53cc580a03dc3cc1af0d7"/>
+		<rom name="Tatsujin-ou (Japan) (Track 11).bin" size="45452400" crc="8b50c64b" sha1="43d35589ab0e3e49db7b91ae6ba53154c9dfed64"/>
+		<rom name="Tatsujin-ou (Japan).cue" size="1029" crc="cab56943" sha1="4d6395e8151f11d4a1eaa7f97aa18ffa540d0274"/>
 		-->
 		<description>Tatsujin Ou</description>
 		<year>1993</year>
 		<publisher>ビング (Ving)</publisher>
 		<info name="alt_title" value="達人王" />
 		<info name="release" value="199304xx" />
+		<info name="usage" value="Requires 2 MB RAM"/>
 		<part name="cdrom" interface="fmt_cdrom">
 			<diskarea name="cdrom">
-				<disk name="tatsujin oh" sha1="ee1b312958a139fc3a5329f4a9dae662286d3705" />
+				<disk name="tatsujin-ou (japan)" sha1="b57c4afce992e612695f6f6516d464aa48272215" />
 			</diskarea>
 		</part>
 	</software>
@@ -11923,6 +12577,7 @@ User/save disks that can be created from the game itself are not included.
 		<year>1990</year>
 		<publisher>データウエスト (Data West)</publisher>
 		<info name="release" value="199009xx" />
+		<info name="usage" value="Requires 2 MB RAM"/>
 		<part name="cdrom" interface="fmt_cdrom">
 			<diskarea name="cdrom">
 				<disk name="tdf - terrestrial defense force" sha1="584ac4f25e5cc1f38857d26b5dc988219ae5646b" />
@@ -11955,6 +12610,7 @@ User/save disks that can be created from the game itself are not included.
 		<publisher>光栄 (Koei)</publisher>
 		<info name="alt_title" value="提督の決断II" />
 		<info name="release" value="199406xx" />
+		<info name="usage" value="Requires 2 MB RAM"/>
 		<part name="flop1" interface="floppy_3_5">
 			<dataarea name="flop" size="1261568">
 				<rom name="teitoku no ketsudan ii.hdm" size="1261568" crc="aabcd4f9" sha1="5079e129b96836f6d19503528633ee66e29cfebc" offset="000000" />
@@ -11978,6 +12634,7 @@ User/save disks that can be created from the game itself are not included.
 		<publisher>超音速 (Super Sonic)</publisher>
 		<info name="alt_title" value="帝都大戦" />
 		<info name="release" value="198912xx" />
+		<info name="usage" value="Requires 2 MB RAM"/>
 		<part name="cdrom" interface="fmt_cdrom">
 			<diskarea name="cdrom">
 				<disk name="teito taisen (japan)" sha1="324eb4c855cf9b27ead9dc2f8706f8c0f23f06f4" />
@@ -11998,6 +12655,7 @@ User/save disks that can be created from the game itself are not included.
 		<publisher>アートディンク (Artdink)</publisher>
 		<info name="alt_title" value="天下御免" />
 		<info name="release" value="199406xx" />
+		<info name="usage" value="Requires 2 MB RAM"/>
 		<part name="flop1" interface="floppy_3_5">
 			<feature name="part_id" value="System Disk" />
 			<dataarea name="flop" size="1261568">
@@ -12045,7 +12703,7 @@ User/save disks that can be created from the game itself are not included.
 		<publisher>アローマイクロテックス (Arrow Micro-Techs)</publisher>
 		<info name="alt_title" value="ザ・ホード" />
 		<info name="release" value="199504xx" />
-		<info name="usage" value="Requires HDD installation"/>
+		<info name="usage" value="Requires HDD installation, 4 MB RAM and a 486 CPU"/>
 		<part name="cdrom" interface="fmt_cdrom">
 			<diskarea name="cdrom">
 				<disk name="the horde" sha1="53b6f886fafc5e532583c7ccd85774d73608c4ca" />
@@ -12056,20 +12714,16 @@ User/save disks that can be created from the game itself are not included.
 	<!-- Hangs after the title screen -->
 	<software name="titan" supported="no">
 		<!--
-		Origin: Neo Kobe Collection
-		<rom name="Titan.mdf" size="219824976" crc="2ade491f" sha1="cd0bf80ccaa1ba8956b4da84266c6769a2abeeb7"/>
-		<rom name="Titan.mds" size="1722" crc="5ed8ebc9" sha1="1c94068577cad32df2b3766dcfb1772bfebb3036"/>
-
-		*after conversion with IsoBuster+EAC *
-		<rom name="titan.cue" size="1105" crc="ac985fdd" sha1="97fe25cc4460a9c6af9559b0ae0a4b963fde198b"/>
-		<rom name="track01.bin" size="3880800" crc="38fc974e" sha1="95e6d3c8494d2c5879e9f201904f81aab3207601"/>
-		<rom name="track02.bin" size="33715920" crc="e6246e57" sha1="e3d55438231ff139e460a4ac360269842cc891b8"/>
-		<rom name="track03.bin" size="30658320" crc="dda98071" sha1="b50165fffc55b87f53104246546cca09919ff3dc"/>
-		<rom name="track04.bin" size="24841824" crc="e74a2642" sha1="634c16f383621b5ab9a3f09f5c8eceae6eac6e17"/>
-		<rom name="track05.bin" size="39226656" crc="6335cfa0" sha1="b05c5a772c5961ae74e62b0b7ab6fdf8ee423aa6"/>
-		<rom name="track06.bin" size="25025280" crc="68cca47d" sha1="b6cc1687108b0a955143fe2ba3673b84f2573400"/>
-		<rom name="track07.bin" size="35378784" crc="2519e64a" sha1="c9248610aba38747f7909d1d908422dc7e706180"/>
-		<rom name="track08.bin" size="27450192" crc="f152951e" sha1="160e46559b32606dbe889195ae50c629cbd390f4"/>
+		Origin: redump.org
+		<rom name="Titan (Japan) (Track 1).bin" size="3528000" crc="d6e6fed9" sha1="c0a402e885ccb04b1f656a0ad8df4f2b17894043"/>
+		<rom name="Titan (Japan) (Track 2).bin" size="33504240" crc="0c85b9f1" sha1="ae3cf1d9793b78ce77095a095c8ddcc87228313d"/>
+		<rom name="Titan (Japan) (Track 3).bin" size="30681840" crc="4f6b6220" sha1="dc7e9627c86ec117eeeff8b12380acecc14ebf72"/>
+		<rom name="Titan (Japan) (Track 4).bin" size="24801840" crc="7ac401e7" sha1="d943b454cec6663feb7f445061d6b36909ab33f3"/>
+		<rom name="Titan (Japan) (Track 5).bin" size="39149040" crc="8a84e317" sha1="e3a4dd9edfb576fd120aa61864c677ed53eebcef"/>
+		<rom name="Titan (Japan) (Track 6).bin" size="25001760" crc="9b749b1c" sha1="7e48a7828198737856530048cae9f2ed528caa6f"/>
+		<rom name="Titan (Japan) (Track 7).bin" size="35468160" crc="30dd0610" sha1="b78df38dadad35e4a5e2408e9bf472b8982910ef"/>
+		<rom name="Titan (Japan) (Track 8).bin" size="28042896" crc="db4ff0c3" sha1="efb2096cb63a480ac4cd61427c486ec3df8fbc92"/>
+		<rom name="Titan (Japan).cue" size="861" crc="b6078ba9" sha1="7dfed36399c5a2666f75b0b287c78b441e26fcc0"/>
 		-->
 		<description>Titan</description>
 		<year>1989</year>
@@ -12078,7 +12732,7 @@ User/save disks that can be created from the game itself are not included.
 		<info name="release" value="198911xx" />
 		<part name="cdrom" interface="fmt_cdrom">
 			<diskarea name="cdrom">
-				<disk name="titan" sha1="bb35134376680af0908f7a85501fbd9e50e81168" />
+				<disk name="titan (japan)" sha1="88b009736f2afe33618faba388c6e234f4f165a9" />
 			</diskarea>
 		</part>
 	</software>
@@ -12133,6 +12787,7 @@ User/save disks that can be created from the game itself are not included.
 		<publisher>アートディンク (Artdink)</publisher>
 		<info name="alt_title" value="トキオ 東京都第24区" />
 		<info name="release" value="199212xx" />
+		<info name="usage" value="Requires 2 MB RAM"/>
 		<part name="flop1" interface="floppy_3_5">
 			<feature name="part_id" value="System Disk" />
 			<dataarea name="flop" size="1261568">
@@ -12181,10 +12836,10 @@ User/save disks that can be created from the game itself are not included.
 		<publisher>アリスソフト (AliceSoft)</publisher>
 		<info name="alt_title" value="闘神都市II そして、それから…" />
 		<info name="release" value="199512xx" />
-		<info name="usage" value="Requires HDD installation"/>
+		<info name="usage" value="Requires HDD installation and 2 MB RAM"/>
 		<part name="cdrom" interface="fmt_cdrom">
 			<diskarea name="cdrom">
-				<disk name="toushin toshi ii - soshite sorekara..." sha1="e3361f4395e93e9fe10edba31a77240e9f49b43d" />
+				<disk name="toushin toshi ii - soshite sorekara" sha1="e3361f4395e93e9fe10edba31a77240e9f49b43d" />
 			</diskarea>
 		</part>
 	</software>
@@ -12201,6 +12856,7 @@ User/save disks that can be created from the game itself are not included.
 		<publisher>アグミックス (Agumix)</publisher>
 		<info name="alt_title" value="クイーン・オブ・デュエリスト" />
 		<info name="release" value="199306xx" />
+		<info name="usage" value="Requires 2 MB RAM"/>
 		<part name="flop1" interface="floppy_3_5">
 			<feature name="part_id" value="User Disk" />
 			<dataarea name="flop" size="1261568">
@@ -12225,6 +12881,7 @@ User/save disks that can be created from the game itself are not included.
 		<publisher>アグミックス (Agumix)</publisher>
 		<info name="alt_title" value="クイーン・オブ・デュエリスト外伝＋外伝αLIGHT" />
 		<info name="release" value="199404xx" />
+		<info name="usage" value="Requires 2 MB RAM"/>
 		<part name="flop1" interface="floppy_3_5">
 			<feature name="part_id" value="User Disk" />
 			<dataarea name="flop" size="1261568">
@@ -12250,6 +12907,7 @@ User/save disks that can be created from the game itself are not included.
 		<year>1994?</year>
 		<publisher>バーディーソフト (Birdy Soft)</publisher>
 		<info name="alt_title" value="THAT'S 投稿 PART2" />
+		<info name="usage" value="Requires 2 MB RAM"/>
 		<part name="cdrom" interface="fmt_cdrom">
 			<diskarea name="cdrom">
 				<disk name="toukou2" sha1="e3d9e3cf9695ab63064de8e02b014e29664a5422" />
@@ -12270,6 +12928,7 @@ User/save disks that can be created from the game itself are not included.
 		<publisher>バーディーソフト (Birdy Soft)</publisher>
 		<info name="alt_title" value="THAT'S 投稿 夏の大特集" />
 		<info name="release" value="199409xx" />
+		<info name="usage" value="Requires 2 MB RAM"/>
 		<part name="cdrom" interface="fmt_cdrom">
 			<diskarea name="cdrom">
 				<disk name="toukoun" sha1="d5f81c0d5fc7dd61573ea09233ef83aa98d6c6b6" />
@@ -12296,6 +12955,7 @@ User/save disks that can be created from the game itself are not included.
 		<publisher>CRI</publisher>
 		<info name="alt_title" value="ターボアウトラン" />
 		<info name="release" value="198912xx" />
+		<info name="usage" value="Requires 2 MB RAM"/>
 		<part name="cdrom" interface="fmt_cdrom">
 			<diskarea name="cdrom">
 				<disk name="turbo outrun (japan)" sha1="0085118e87c8b3bbdd7ab3dfa5233df3164f1511" />
@@ -12312,6 +12972,7 @@ User/save disks that can be created from the game itself are not included.
 		<description>Towns Magazine Vol. 1</description>
 		<year>1994</year>
 		<publisher>富士通 (Fujitsu)</publisher>
+		<info name="usage" value="Requires 2 MB RAM"/>
 		<part name="cdrom" interface="fmt_cdrom">
 			<diskarea name="cdrom">
 				<disk name="towns magazine vol. 1" sha1="eab53db6a65d7d7030da1b9e7c5a93a19bd2f279" />
@@ -12336,6 +12997,7 @@ User/save disks that can be created from the game itself are not included.
 		<year>1994</year>
 		<publisher>富士通 (Fujitsu)</publisher>
 		<info name="release" value="199411xx" />
+		<info name="usage" value="Requires 2 MB RAM to boot, some demos require more"/>
 		<part name="cdrom1" interface="fmt_cdrom">
 			<diskarea name="cdrom">
 				<disk name="towns magazine vol. 2 (disc 1)" sha1="65d208a41d0089eb11f7607e0a78fba60fbdbaa4" />
@@ -12358,6 +13020,7 @@ User/save disks that can be created from the game itself are not included.
 		<description>TownsFullcolor V2.1 L10</description>
 		<year>1994</year>
 		<publisher>富士通 (Fujitsu)</publisher>
+		<info name="usage" value="Requires 4 MB RAM"/>
 		<info name="release" value="199412xx" />
 		<part name="cdrom" interface="fmt_cdrom">
 			<diskarea name="cdrom">
@@ -12366,7 +13029,24 @@ User/save disks that can be created from the game itself are not included.
 		</part>
 	</software>
 
-	<software name="townspnt">
+	<software name="tpaint10">
+		<!--
+		Origin: redump.org
+		<rom name="Towns Paint V1.1L10 (Japan).bin" size="20286000" crc="f0e255e0" sha1="832f5ccd13e0c7f79410089564f799b05f828091"/>
+		<rom name="Towns Paint V1.1L10 (Japan).cue" size="116" crc="7b80b759" sha1="5bdc59db0fbdb4373025be58d3a4903bdb3cf33e"/>
+		-->
+		<description>TownsPAINT V1.1 L10</description>
+		<year>1989</year>
+		<publisher>富士通 (Fujitsu)</publisher>
+		<info name="release" value="198903xx" />
+		<part name="cdrom" interface="fmt_cdrom">
+			<diskarea name="cdrom">
+				<disk name="towns paint v1.1l10 (japan)" sha1="9dd1f623dacb154bdef15409dff4145549b7b647" />
+			</diskarea>
+		</part>
+	</software>
+
+	<software name="tpaint20">
 		<!--
 		Origin: Private dump (r09)
 		<rom name="townspaint.bin" size="39337200" crc="a384a685" sha1="d1ba91cffb50916c04d2cce54b5622a0181df451"/>
@@ -12430,6 +13110,7 @@ User/save disks that can be created from the game itself are not included.
 		<publisher>ジックス (ZyX)</publisher>
 		<info name="alt_title" value="トリガー" />
 		<info name="release" value="199406xx" />
+		<info name="usage" value="Requires 2 MB RAM"/>
 		<part name="cdrom" interface="fmt_cdrom">
 			<diskarea name="cdrom">
 				<disk name="trigger" sha1="4e6040576d084861e6fd478a8fbfb6b6723c7596" />
@@ -12464,6 +13145,7 @@ User/save disks that can be created from the game itself are not included.
 		<publisher>スタークラフト (Starcraft)</publisher>
 		<info name="alt_title" value="トンネルズ・アンド・トロールズ カザンの戦士たち" />
 		<info name="release" value="199011xx" />
+		<info name="usage" value="Requires 2 MB RAM"/>
 		<part name="cdrom" interface="fmt_cdrom">
 			<diskarea name="cdrom">
 				<disk name="tunnels and trolls" sha1="098e7889db2229e69fe4ebbb9af0728154c94658" />
@@ -12482,6 +13164,7 @@ User/save disks that can be created from the game itself are not included.
 		<publisher>富士通 (Fujitsu)</publisher>
 		<info name="alt_title" value="ウルティマIV Quest of the Avatar" />
 		<info name="release" value="199204xx" />
+		<info name="usage" value="Requires 2 MB RAM"/>
 		<part name="cdrom" interface="fmt_cdrom">
 			<diskarea name="cdrom">
 				<disk name="ultima iv - quest of the avatar" sha1="b848a6330b0aa8c197079708ca6533d780cf067d" />
@@ -12502,6 +13185,7 @@ User/save disks that can be created from the game itself are not included.
 		<publisher>富士通 (Fujitsu)</publisher>
 		<info name="alt_title" value="ウルティマV Warriors of Destiny" />
 		<info name="release" value="199208xx" />
+		<info name="usage" value="Requires 2 MB RAM"/>
 		<part name="cdrom" interface="fmt_cdrom">
 			<diskarea name="cdrom">
 				<disk name="ultima v - warriors of destiny" sha1="70aa1bf29817f583317426fde3a7ceb5a22703fa" />
@@ -12522,6 +13206,7 @@ User/save disks that can be created from the game itself are not included.
 		<publisher>富士通 (Fujitsu)</publisher>
 		<info name="alt_title" value="ウルティマVI 偽りの予言者" />
 		<info name="release" value="199112xx" />
+		<info name="usage" value="Requires 2 MB RAM"/>
 		<part name="cdrom" interface="fmt_cdrom">
 			<diskarea name="cdrom">
 				<disk name="ultima vi - the false prophet" sha1="1add2897492af4ff236743e712ae2244dda80319" />
@@ -12542,6 +13227,7 @@ User/save disks that can be created from the game itself are not included.
 		<publisher>富士通 (Fujitsu)</publisher>
 		<info name="alt_title" value="ウルティマトリロジー Ⅰ・Ⅱ・Ⅲ" />
 		<info name="release" value="199010xx" />
+		<info name="usage" value="Requires 2 MB RAM"/>
 		<part name="cdrom" interface="fmt_cdrom">
 			<diskarea name="cdrom">
 				<disk name="ultima trilogy i-ii-iii" sha1="75b22d990d1b70b32b3e542778b1621aa6db420c" />
@@ -12562,6 +13248,7 @@ User/save disks that can be created from the game itself are not included.
 		<publisher>エレクトロニック・アーツ・ビクター (Electronic Arts Victor)</publisher>
 		<info name="alt_title" value="ウルティマアンダーワールド" />
 		<info name="release" value="199312xx" />
+		<info name="usage" value="Requires 2 MB RAM. Insert a floppy disk in drive 1 before booting the game."/>
 		<part name="cdrom" interface="fmt_cdrom">
 			<diskarea name="cdrom">
 				<disk name="ultima underworld" sha1="048ed1c5cfc5b8c7ea1d8f9cc3ea6aa7cf39390c" />
@@ -12580,6 +13267,7 @@ User/save disks that can be created from the game itself are not included.
 		<publisher>エレクトロニック・アーツ・ビクター (Electronic Arts Victor)</publisher>
 		<info name="alt_title" value="ウルティマアンダーワールド2" />
 		<info name="release" value="199502xx" />
+		<info name="usage" value="Requires HDD installation and 2 MB RAM"/>
 		<part name="cdrom" interface="fmt_cdrom">
 			<diskarea name="cdrom">
 				<disk name="ultima underworld ii - labyrinth of worlds (japan)" sha1="fd21d3240408860955089b1ccd5b2f3a15c498cc" />
@@ -12600,6 +13288,7 @@ User/save disks that can be created from the game itself are not included.
 		<publisher>HOP</publisher>
 		<info name="alt_title" value="浮気なあ・な・たスイッチをい・れ・て" />
 		<info name="release" value="199406xx" />
+		<info name="usage" value="Requires 4 MB RAM"/>
 		<part name="flop1" interface="floppy_3_5">
 			<feature name="part_id" value="Boot Disk" />
 			<dataarea name="flop" size="1261568">
@@ -12649,6 +13338,7 @@ User/save disks that can be created from the game itself are not included.
 		<publisher>グローディア (Glodia)</publisher>
 		<info name="alt_title" value="ヴェインドリーム" />
 		<info name="release" value="199304xx" />
+		<info name="usage" value="Requires 2 MB RAM"/>
 		<part name="flop1" interface="floppy_3_5">
 			<feature name="part_id" value="System Disk" />
 			<dataarea name="flop" size="1261568">
@@ -12689,6 +13379,7 @@ User/save disks that can be created from the game itself are not included.
 		<publisher>グローディア (Glodia)</publisher>
 		<info name="alt_title" value="ヴェインドリームII" />
 		<info name="release" value="199309xx" />
+		<info name="usage" value="Requires 2 MB RAM"/>
 		<part name="flop1" interface="floppy_3_5">
 			<feature name="part_id" value="System Disk" />
 			<dataarea name="flop" size="1261568">
@@ -12715,6 +13406,7 @@ User/save disks that can be created from the game itself are not included.
 		<publisher>CD Bros.</publisher>
 		<info name="alt_title" value="ヴアーストニス 空虚の生贄達" />
 		<info name="release" value="199309xx" />
+		<info name="usage" value="Requires 2 MB RAM"/>
 		<part name="cdrom" interface="fmt_cdrom">
 			<diskarea name="cdrom">
 				<disk name="vastness" sha1="12d1fbe66e92cd580616814077eebb402d4e0332" />
@@ -12737,6 +13429,7 @@ User/save disks that can be created from the game itself are not included.
 		<publisher>ビング (Ving)</publisher>
 		<info name="alt_title" value="ヴェイル オブ ダークネス ～呪われた予言～" />
 		<info name="release" value="199408xx" />
+		<info name="usage" value="Requires 2 MB RAM"/>
 		<part name="cdrom" interface="fmt_cdrom">
 			<diskarea name="cdrom">
 				<disk name="veil of darkness" sha1="bf61510fbd3893f086297ad0c3e27655a08bde1c" />
@@ -12808,6 +13501,7 @@ User/save disks that can be created from the game itself are not included.
 		<publisher>ビング (Ving)</publisher>
 		<info name="alt_title" value="ビューポイント" />
 		<info name="release" value="199311xx" />
+		<info name="usage" value="Requires 2 MB RAM"/>
 		<part name="cdrom" interface="fmt_cdrom">
 			<diskarea name="cdrom">
 				<disk name="viewpoint" sha1="c977abc3e3ab7d675b6be7aacac69a57bc6e52be" />
@@ -12827,6 +13521,7 @@ User/save disks that can be created from the game itself are not included.
 		<year>1995</year>
 		<publisher>ソニア (Sogna)</publisher>
 		<info name="release" value="199504xx" />
+		<info name="usage" value="Requires 2 MB RAM"/>
 		<part name="cdrom" interface="fmt_cdrom">
 			<diskarea name="cdrom">
 				<disk name="viper v6 turbo rs" sha1="3ba0afc8b3cfbdae0e37c0e049d8ed6d9dd4e4ff" />
@@ -12846,6 +13541,7 @@ User/save disks that can be created from the game itself are not included.
 		<year>1995</year>
 		<publisher>ソニア (Sogna)</publisher>
 		<info name="release" value="199507xx" />
+		<info name="usage" value="Requires 2 MB RAM"/>
 		<part name="cdrom" interface="fmt_cdrom">
 			<diskarea name="cdrom">
 				<disk name="viper v10 turbo rs" sha1="0afcc96abbe300b9b0499948fede525dcf084ba0" />
@@ -12872,6 +13568,7 @@ User/save disks that can be created from the game itself are not included.
 		<publisher>フェアリーテール (Fairytale)</publisher>
 		<info name="alt_title" value="バーチャコール" />
 		<info name="release" value="199503xx" />
+		<info name="usage" value="Requires 2 MB RAM"/>
 		<part name="flop1" interface="floppy_3_5">
 			<feature name="part_id" value="Save Disk" />
 			<dataarea name="flop" size="1261568">
@@ -12929,6 +13626,7 @@ User/save disks that can be created from the game itself are not included.
 		<publisher>ビング (Ving)</publisher>
 		<info name="alt_title" value="ヴォルフィード" />
 		<info name="release" value="199112xx" />
+		<info name="usage" value="Requires 2 MB RAM"/>
 		<part name="cdrom" interface="fmt_cdrom">
 			<diskarea name="cdrom">
 				<disk name="volfied" sha1="353db36abf89433dfc2f63659f471fd9edfbaf8d" />
@@ -12949,6 +13647,7 @@ User/save disks that can be created from the game itself are not included.
 		<publisher>Mic</publisher>
 		<info name="alt_title" value="倭国制覇伝" />
 		<info name="release" value="199404xx" />
+		<info name="usage" value="Requires 2 MB RAM"/>
 		<part name="cdrom" interface="fmt_cdrom">
 			<diskarea name="cdrom">
 				<disk name="wakoku seiha den" sha1="c678cf3231d465243e898f81259032635bc7aaf5" />
@@ -12967,6 +13666,7 @@ User/save disks that can be created from the game itself are not included.
 		<description>Welcome to FM Towns</description>
 		<year>1994</year>
 		<publisher>富士通 (Fujitsu)</publisher>
+		<info name="usage" value="Requires 3 MB RAM"/>
 		<part name="cdrom" interface="fmt_cdrom">
 			<diskarea name="cdrom">
 				<disk name="weltowns" sha1="81318dcbf6689d005e400fefae51cd775ddea0fe" />
@@ -13047,6 +13747,7 @@ User/save disks that can be created from the game itself are not included.
 		<publisher>富士通 (Fujitsu)</publisher>
 		<info name="alt_title" value="ウイングコマンダー" />
 		<info name="release" value="199212xx" />
+		<info name="usage" value="Requires 2 MB RAM"/>
 		<part name="cdrom" interface="fmt_cdrom">
 			<diskarea name="cdrom">
 				<disk name="wing commander (japan)" sha1="bc66292d4304cba0d4915e573769ea525fe4d662" />
@@ -13086,6 +13787,7 @@ User/save disks that can be created from the game itself are not included.
 		<publisher>エレクトロニック・アーツ・ビクター (Electronic Arts Victor)</publisher>
 		<info name="alt_title" value="ウィング・コマンダーII" />
 		<info name="release" value="199507xx" />
+		<info name="usage" value="Requires HDD installation and 4 MB RAM"/>
 		<part name="cdrom" interface="fmt_cdrom">
 			<diskarea name="cdrom">
 				<disk name="wing commander ii and special operations" sha1="936038a14140fc7901a6642e1e43f38376703ddd" />
@@ -13120,6 +13822,7 @@ User/save disks that can be created from the game itself are not included.
 		<year>1990</year>
 		<publisher>アスキー (ASCII)</publisher>
 		<info name="release" value="199012xx" />
+		<info name="usage" value="Requires 2 MB RAM"/>
 		<part name="flop1" interface="floppy_3_5">
 			<feature name="part_id" value="User Disk" />
 			<dataarea name="flop" size="1089776">
@@ -13145,6 +13848,7 @@ User/save disks that can be created from the game itself are not included.
 		<year>1991</year>
 		<publisher>アスキー (ASCII)</publisher>
 		<info name="release" value="199112xx" />
+		<info name="usage" value="Requires 2 MB RAM"/>
 		<part name="flop1" interface="floppy_3_5">
 			<feature name="part_id" value="User Disk" />
 			<dataarea name="flop" size="1261568">
@@ -13194,6 +13898,7 @@ User/save disks that can be created from the game itself are not included.
 		<publisher>グレイト (Great)</publisher>
 		<info name="alt_title" value="レッスル エンジェルス 3 目指すは最強団体！" />
 		<info name="release" value="199408xx" />
+		<info name="usage" value="Requires 2 MB RAM"/>
 		<part name="flop1" interface="floppy_3_5">
 			<feature name="part_id" value="Save Disk" />
 			<dataarea name="flop" size="1261568">
@@ -13220,6 +13925,7 @@ User/save disks that can be created from the game itself are not included.
 		<publisher>グレイト (Great)</publisher>
 		<info name="alt_title" value="レッスル エンジェルス スペシャル" />
 		<info name="release" value="199410xx" />
+		<info name="usage" value="Requires 2 MB RAM"/>
 		<part name="flop1" interface="floppy_3_5">
 			<feature name="part_id" value="User Disk" />
 			<dataarea name="flop" size="1261568">
@@ -13246,6 +13952,7 @@ User/save disks that can be created from the game itself are not included.
 		<publisher>富士通 (Fujitsu)</publisher>
 		<info name="alt_title" value="カルメン・サンディエゴを探せ! -世界編-" />
 		<info name="release" value="199304xx" />
+		<info name="usage" value="Requires 2 MB RAM"/>
 		<part name="cdrom" interface="fmt_cdrom">
 			<diskarea name="cdrom">
 				<disk name="where in the world is carmen sandiego" sha1="cc3fe8d265784809b893a8e8375153060b162a1d" />
@@ -13266,6 +13973,7 @@ User/save disks that can be created from the game itself are not included.
 		<publisher>エルフ (Elf)</publisher>
 		<info name="alt_title" value="ワーズ・ワース" />
 		<info name="release" value="199309xx" />
+		<info name="usage" value="Requires 2 MB RAM"/>
 		<part name="cdrom" interface="fmt_cdrom">
 			<diskarea name="cdrom">
 				<disk name="words worth" sha1="63c9e54e3cc6db4e716377ac15a08c5941327fef" />
@@ -13286,6 +13994,7 @@ User/save disks that can be created from the game itself are not included.
 		<publisher>マイクロキャビン (Micro Cabin)</publisher>
 		<info name="alt_title" value="サークII ライジング・オブ・ザ・レッドムーン" />
 		<info name="release" value="199107xx" />
+		<info name="usage" value="Requires 2 MB RAM"/>
 		<part name="cdrom" interface="fmt_cdrom">
 			<diskarea name="cdrom">
 				<disk name="xak ii - rising of the redmoon" sha1="b5383012b7d6e39b42edda4d13af7d5cc62b9191" />
@@ -13306,6 +14015,7 @@ User/save disks that can be created from the game itself are not included.
 		<publisher>マイクロキャビン (Micro Cabin)</publisher>
 		<info name="alt_title" value="サークIII ジ・エターナル・リカーレンス" />
 		<info name="release" value="199309xx" />
+		<info name="usage" value="Requires 2 MB RAM"/>
 		<part name="cdrom" interface="fmt_cdrom">
 			<diskarea name="cdrom">
 				<disk name="xak iii - the eternal recurrence" sha1="71f9b0dd3906a1c6d6e2b1ccb646e25530a66df3" />
@@ -13326,6 +14036,7 @@ User/save disks that can be created from the game itself are not included.
 		<publisher>シーズウェア (C's Ware)</publisher>
 		<info name="alt_title" value="XENON ～無限の肢体～" />
 		<info name="release" value="199503xx" />
+		<info name="usage" value="Requires 2 MB RAM"/>
 		<part name="cdrom" interface="fmt_cdrom">
 			<diskarea name="cdrom">
 				<disk name="xenon" sha1="d6544b946ece77ce93fb6cf1db3ffb231b464ac0" />
@@ -13356,26 +14067,73 @@ User/save disks that can be created from the game itself are not included.
 
 	<software name="yamikets">
 		<!--
-		Origin: Neo Kobe Collection
-		<rom name="Yami no Ketsuzoku Special.ccd" size="8295" crc="3278257f" sha1="be9eb079667a5591b361d3bd6452f22233c2e4bf"/>
-		<rom name="Yami no Ketsuzoku Special.cue" size="3179" crc="c39054c2" sha1="fcba6129871554abeee099a3bae405292ce38272"/>
-		<rom name="Yami no Ketsuzoku Special.img" size="688312800" crc="a6819d7e" sha1="774a42f852819af28434f06984247a631e4ea124"/>
-		<rom name="Yami no Ketsuzoku Special.sub" size="28094400" crc="12c99335" sha1="2983c0025adffa7e21636cc23335de37a499cbaf"/>
+		Origin: redump.org
+		<rom name="Yami no Ketsuzoku Special - The Predestined Homicides (Japan) (Track 01).bin" size="9878400" crc="f5114dd5" sha1="a657cfe87565e08f147f3ff58e603a4ee081ef97"/>
+		<rom name="Yami no Ketsuzoku Special - The Predestined Homicides (Japan) (Track 02).bin" size="5997600" crc="36210011" sha1="f30cf37ecd45f036a92359d6bf51b2443ad4097b"/>
+		<rom name="Yami no Ketsuzoku Special - The Predestined Homicides (Japan) (Track 03).bin" size="14288400" crc="741146ad" sha1="403daf43f0be2e9c55147941d6567dd94ba0a7b6"/>
+		<rom name="Yami no Ketsuzoku Special - The Predestined Homicides (Japan) (Track 04).bin" size="15876000" crc="c925c248" sha1="86e23e5ac5733f782ea1744ee8e31c5150ebd3f0"/>
+		<rom name="Yami no Ketsuzoku Special - The Predestined Homicides (Japan) (Track 05).bin" size="13053600" crc="d54fa56a" sha1="f69d3ebcf63d7c3fd82f071172d8a028d53ee8cd"/>
+		<rom name="Yami no Ketsuzoku Special - The Predestined Homicides (Japan) (Track 06).bin" size="9702000" crc="17b7a969" sha1="0f2f7e06d75cce44e08a7c01f8b17050b5931c25"/>
+		<rom name="Yami no Ketsuzoku Special - The Predestined Homicides (Japan) (Track 07).bin" size="9878400" crc="ac082418" sha1="4e663cd608647a43198a85ec89919a0f423963e5"/>
+		<rom name="Yami no Ketsuzoku Special - The Predestined Homicides (Japan) (Track 08).bin" size="15523200" crc="651dc6e8" sha1="2ba64db77e52b3fbc46f308e5a49b67c69f89f37"/>
+		<rom name="Yami no Ketsuzoku Special - The Predestined Homicides (Japan) (Track 09).bin" size="5292000" crc="ce932362" sha1="355fe5b48d17e383e7049c0f71e8ea206af29bb3"/>
+		<rom name="Yami no Ketsuzoku Special - The Predestined Homicides (Japan) (Track 10).bin" size="8467200" crc="7e69c6b7" sha1="eda27dac448a3e5068776b30f1e398f83f079fa9"/>
+		<rom name="Yami no Ketsuzoku Special - The Predestined Homicides (Japan) (Track 11).bin" size="7585200" crc="60cd49c9" sha1="f1b3d2f8c0a91d7fa7c21758c92230b2e23c6c00"/>
+		<rom name="Yami no Ketsuzoku Special - The Predestined Homicides (Japan) (Track 12).bin" size="13406400" crc="b258e75a" sha1="0be92cc0713428e3027443a918d83d5d2974c0bb"/>
+		<rom name="Yami no Ketsuzoku Special - The Predestined Homicides (Japan) (Track 13).bin" size="8290800" crc="e59e2af1" sha1="88923b50fc610888f40f4f46c401fe56316bf717"/>
+		<rom name="Yami no Ketsuzoku Special - The Predestined Homicides (Japan) (Track 14).bin" size="14641200" crc="9a25226e" sha1="1f1249f02a3fb5d7b84ea643593e03e432e6574d"/>
+		<rom name="Yami no Ketsuzoku Special - The Predestined Homicides (Japan) (Track 15).bin" size="18698400" crc="d3b8cbbb" sha1="b70111a79b64a43129991f72ec2f259ea2053609"/>
+		<rom name="Yami no Ketsuzoku Special - The Predestined Homicides (Japan) (Track 16).bin" size="22579200" crc="e5381e0a" sha1="982a9fb18a55ee57d4663e434ac1f7ec4ad44d38"/>
+		<rom name="Yami no Ketsuzoku Special - The Predestined Homicides (Japan) (Track 17).bin" size="10407600" crc="15b71a20" sha1="02741d6ba6cbe11e53b86cec96bf38b2d6b22cce"/>
+		<rom name="Yami no Ketsuzoku Special - The Predestined Homicides (Japan) (Track 18).bin" size="6879600" crc="9658be4c" sha1="5deba7e2a06f0533eb4b13ce64b43378fc8ff8c1"/>
+		<rom name="Yami no Ketsuzoku Special - The Predestined Homicides (Japan) (Track 19).bin" size="21344400" crc="8827fcd1" sha1="c60e19d1cef11da173510c60a3fdba7e3f250791"/>
+		<rom name="Yami no Ketsuzoku Special - The Predestined Homicides (Japan) (Track 20).bin" size="11995200" crc="fc337ed0" sha1="ac96cb03416954c78c8a87b0399294462000b255"/>
+		<rom name="Yami no Ketsuzoku Special - The Predestined Homicides (Japan) (Track 21).bin" size="32634000" crc="e6af1730" sha1="efd9a75e0ce2c7f1b182ab6ba95fff0f402f9e5f"/>
+		<rom name="Yami no Ketsuzoku Special - The Predestined Homicides (Japan) (Track 22).bin" size="41454000" crc="3726efb0" sha1="bddd6a4d62268b331d94f86d5f407cb1d7df7773"/>
+		<rom name="Yami no Ketsuzoku Special - The Predestined Homicides (Japan) (Track 23).bin" size="11113200" crc="4a91105d" sha1="3718732e14f6aa679442e0b96583499bdbdd7497"/>
+		<rom name="Yami no Ketsuzoku Special - The Predestined Homicides (Japan) (Track 24).bin" size="7056000" crc="5d67430c" sha1="518fcb65510f0a6a31cc978f7f1f4bdfb0e1ccdd"/>
+		<rom name="Yami no Ketsuzoku Special - The Predestined Homicides (Japan) (Track 25).bin" size="5644800" crc="28de4fb3" sha1="fed5dc0a849a0ade5461611e96efd006966a1539"/>
+		<rom name="Yami no Ketsuzoku Special - The Predestined Homicides (Japan) (Track 26).bin" size="10054800" crc="79d843ef" sha1="04aa14b9a718a890a8af11f64a99547eab8bc6cc"/>
+		<rom name="Yami no Ketsuzoku Special - The Predestined Homicides (Japan) (Track 27).bin" size="14464800" crc="ec974e14" sha1="923f8200bfe7b8ee8a0d1cb2bf54848d48fb0d8a"/>
+		<rom name="Yami no Ketsuzoku Special - The Predestined Homicides (Japan) (Track 28).bin" size="25225200" crc="063e6e21" sha1="a80d991ac33efec984e50242f0acee4f0c6f98b1"/>
+		<rom name="Yami no Ketsuzoku Special - The Predestined Homicides (Japan) (Track 29).bin" size="6703200" crc="b5007c68" sha1="97ece1c697684d67899d4922e17b44e9cf26a536"/>
+		<rom name="Yami no Ketsuzoku Special - The Predestined Homicides (Japan) (Track 30).bin" size="10760400" crc="90c82327" sha1="82f0f9457bae4a977ed21c43883425f5c73c98d5"/>
+		<rom name="Yami no Ketsuzoku Special - The Predestined Homicides (Japan) (Track 31).bin" size="19580400" crc="e65a8a7d" sha1="e72cd71359046ffad3a16d1c5bdf4ea81aa5015a"/>
+		<rom name="Yami no Ketsuzoku Special - The Predestined Homicides (Japan) (Track 32).bin" size="19580400" crc="89845d68" sha1="9f699c06977378d435d3d955e794b83cdd7f4e11"/>
+		<rom name="Yami no Ketsuzoku Special - The Predestined Homicides (Japan) (Track 33).bin" size="10936800" crc="f59b5e8d" sha1="3a7e104df98c2665495fb61684ef23dfd0e3f2e5"/>
+		<rom name="Yami no Ketsuzoku Special - The Predestined Homicides (Japan) (Track 34).bin" size="8996400" crc="86ef3055" sha1="cb98d32d844a358104c081b2588fb64fb97cd484"/>
+		<rom name="Yami no Ketsuzoku Special - The Predestined Homicides (Japan) (Track 35).bin" size="9878400" crc="1b757222" sha1="3ccf274e4a7e078100cf62f477c92cb06d2f705e"/>
+		<rom name="Yami no Ketsuzoku Special - The Predestined Homicides (Japan) (Track 36).bin" size="6174000" crc="f287de09" sha1="ebfee61cc62e3decdbf08ec5f4b26fe9ac25effc"/>
+		<rom name="Yami no Ketsuzoku Special - The Predestined Homicides (Japan) (Track 37).bin" size="8290800" crc="509219db" sha1="ee9bd6c58f61f37013dca17f9e8a03a7817edfd6"/>
+		<rom name="Yami no Ketsuzoku Special - The Predestined Homicides (Japan) (Track 38).bin" size="7408800" crc="9fd8acbd" sha1="4daffd0151723271b6cf006f4717f19e76f40588"/>
+		<rom name="Yami no Ketsuzoku Special - The Predestined Homicides (Japan) (Track 39).bin" size="4762800" crc="d763182c" sha1="d45a230847a04746bead50952d5403aed55b769e"/>
+		<rom name="Yami no Ketsuzoku Special - The Predestined Homicides (Japan) (Track 40).bin" size="18874800" crc="1bce525f" sha1="1a7ec6dc38e93af8eddd9ed37b4f77be7a2e99a6"/>
+		<rom name="Yami no Ketsuzoku Special - The Predestined Homicides (Japan) (Track 41).bin" size="13053600" crc="18a3dfac" sha1="73625624b7532e9b6451891132f722a4ad6e1b7f"/>
+		<rom name="Yami no Ketsuzoku Special - The Predestined Homicides (Japan) (Track 42).bin" size="15699600" crc="aad0696a" sha1="41baaefc5cb750e5f1e563d855ce224d301961c9"/>
+		<rom name="Yami no Ketsuzoku Special - The Predestined Homicides (Japan) (Track 43).bin" size="22402800" crc="6893103d" sha1="f37470785292e21763d4e4f8bb3aca7365266bf8"/>
+		<rom name="Yami no Ketsuzoku Special - The Predestined Homicides (Japan) (Track 44).bin" size="14288400" crc="1e927ba3" sha1="5b4b73ce4df12b7d78add87b9ec94d5f8b37a8fe"/>
+		<rom name="Yami no Ketsuzoku Special - The Predestined Homicides (Japan) (Track 45).bin" size="26460000" crc="e1dc1213" sha1="71b184f454cbf7608f170f168197e10367ff0979"/>
+		<rom name="Yami no Ketsuzoku Special - The Predestined Homicides (Japan) (Track 46).bin" size="19404000" crc="0605785a" sha1="2a0892a30850785730c6d0086148b0f9e122f133"/>
+		<rom name="Yami no Ketsuzoku Special - The Predestined Homicides (Japan) (Track 47).bin" size="9172800" crc="bd3f88ad" sha1="3fd0e12499d1282c0bf3f7883cbf71b57c7ef3cd"/>
+		<rom name="Yami no Ketsuzoku Special - The Predestined Homicides (Japan) (Track 48).bin" size="29635200" crc="4a3f05e0" sha1="58dc1b296a574085c3e1f0d781c0ee5f2323ad87"/>
+		<rom name="Yami no Ketsuzoku Special - The Predestined Homicides (Japan) (Track 49).bin" size="14817600" crc="1d1dad1f" sha1="a85c2f3210e0c0ecf4f9db18bda4b210f3b4ed39"/>
+		<rom name="Yami no Ketsuzoku Special - The Predestined Homicides (Japan).cue" size="7626" crc="05601944" sha1="881951aa732d6be722b63458cd7dc8029eb3076b"/>
 		-->
-		<description>Yami no Ketsuzoku Special</description>
+		<description>Yami no Ketsuzoku Special - The Predestined Homicides</description>
 		<year>1991</year>
 		<publisher>システムサコム (System Sacom)</publisher>
 		<info name="alt_title" value="闇の血族 スペシャル" />
 		<info name="release" value="199106xx" />
+		<info name="usage" value="Requires 2 MB RAM"/>
 		<part name="flop1" interface="floppy_3_5">
-			<feature name="part_id" value="User Disk" />
+			<feature name="part_id" value="Utility Disk" />
 			<dataarea name="flop" size="1261568">
-				<rom name="yami no ketsuzoku special (user disk).hdm" size="1261568" crc="62e6f35a" sha1="ee1e86547bac53e5e9dc7a010bc60f3b511965b6" offset="000000" />
+				<rom name="yami no ketsuzoku special (utility disk).hdm" size="1261568" crc="62e6f35a" sha1="ee1e86547bac53e5e9dc7a010bc60f3b511965b6" offset="000000" />
 			</dataarea>
 		</part>
 		<part name="cdrom" interface="fmt_cdrom">
 			<diskarea name="cdrom">
-				<disk name="yami no ketsuzoku special" sha1="17fb4fcf02935c509a87f6d8c5b7809b633f64a8" />
+				<disk name="yami no ketsuzoku special - the predestined homicides (japan)" sha1="04a091f1fbb3c1bc458bbbe3a4e000b6456bb93c" />
 			</diskarea>
 		</part>
 	</software>
@@ -13391,6 +14149,7 @@ User/save disks that can be created from the game itself are not included.
 		<publisher>ディー・オー (D.O.)</publisher>
 		<info name="alt_title" value="妖獣戦記 -A.D.2048-" />
 		<info name="release" value="199311xx" />
+		<info name="usage" value="Requires 2 MB RAM"/>
 		<part name="cdrom" interface="fmt_cdrom">
 			<diskarea name="cdrom">
 				<disk name="youjuu senki - a. d. 2048 (japan)" sha1="109b8fbeed54bf49ec89a969da675b7c9a8ed555" />
@@ -13412,6 +14171,7 @@ User/save disks that can be created from the game itself are not included.
 		<publisher>ディー・オー (D.O.)</publisher>
 		<info name="alt_title" value="妖獣戦記2 黎明の戦士たち" />
 		<info name="release" value="199402xx" />
+		<info name="usage" value="Requires 2 MB RAM"/>
 		<part name="cdrom" interface="fmt_cdrom">
 			<diskarea name="cdrom">
 				<disk name="yojusen2" sha1="219f6731e9960291832df99d43ee52ab5d62bc52" />
@@ -13433,6 +14193,7 @@ User/save disks that can be created from the game itself are not included.
 		<publisher>CRI</publisher>
 		<info name="alt_title" value="ゆみみみっくす" />
 		<info name="release" value="199312xx" />
+		<info name="usage" value="Requires 2 MB RAM"/>
 		<part name="cdrom" interface="fmt_cdrom">
 			<diskarea name="cdrom">
 				<disk name="yumimi mix (japan)" sha1="4e2476bf1b9ad6a88972371fc110916960130b0c" />
@@ -13476,6 +14237,7 @@ User/save disks that can be created from the game itself are not included.
 		<year>1990</year>
 		<publisher>ツァイト (Zeit)</publisher>
 		<info name="release" value="199012xx" />
+		<info name="usage" value="Requires 2 MB RAM"/>
 		<part name="cdrom" interface="fmt_cdrom">
 			<diskarea name="cdrom">
 				<disk name="z's triphony digitalcraft towns (japan) (rev a)" sha1="1467a31fbc79e0eb4316773055468f03d28c2894" />
@@ -13493,6 +14255,7 @@ User/save disks that can be created from the game itself are not included.
 		<year>1990</year>
 		<publisher>富士通 (Fujitsu)</publisher>
 		<info name="release" value="199102xx" />
+		<info name="usage" value="Requires 2 MB RAM"/>
 		<part name="cdrom" interface="fmt_cdrom">
 			<diskarea name="cdrom">
 				<disk name="zak mckracken" sha1="0a06dcd3aaebcd79ec3c03dd0b179b9047e2bccd" />
@@ -13518,6 +14281,7 @@ User/save disks that can be created from the game itself are not included.
 		<publisher>ウルフチーム (WolfTeam)</publisher>
 		<info name="alt_title" value="斬2タウンズスペシャル" />
 		<info name="release" value="199204xx" />
+		<info name="usage" value="Requires 2 MB RAM"/>
 		<part name="flop1" interface="floppy_3_5">
 			<feature name="part_id" value="User Disk" />
 			<dataarea name="flop" size="1261568">
@@ -13545,6 +14309,7 @@ User/save disks that can be created from the game itself are not included.
 		<publisher>日本テレネット (Nihon Telenet)</publisher>
 		<info name="alt_title" value="斬III　～天運我にあり～" />
 		<info name="release" value="199404xx" />
+		<info name="usage" value="Requires 2 MB RAM"/>
 		<part name="flop1" interface="floppy_3_5">
 			<feature name="part_id" value="System Disk" />
 			<dataarea name="flop" size="1281968">
@@ -13571,6 +14336,7 @@ User/save disks that can be created from the game itself are not included.
 		<publisher>ディー・オー (D.O.)</publisher>
 		<info name="alt_title" value="雑音領域" />
 		<info name="release" value="199502xx" />
+		<info name="usage" value="Requires 2 MB RAM"/>
 		<part name="cdrom" interface="fmt_cdrom">
 			<diskarea name="cdrom">
 				<disk name="zatsuon ryouiki" sha1="f61c4277ef4a2ec49f127d6b798e30d9b7b0b3af" />
@@ -13591,6 +14357,7 @@ User/save disks that can be created from the game itself are not included.
 		<publisher>姫屋ソフト (Himeya Soft)</publisher>
 		<info name="alt_title" value="ゼニス" />
 		<info name="release" value="199502xx" />
+		<info name="usage" value="Requires 2 MB RAM"/>
 		<part name="cdrom" interface="fmt_cdrom">
 			<diskarea name="cdrom">
 				<disk name="zenith" sha1="3709c5434e21c060895b0ee0d7921e7f2d0c4ca0" />
@@ -13639,6 +14406,7 @@ User/save disks that can be created from the game itself are not included.
 		<publisher>ビクター音楽産業 (Victor Musical Industries)</publisher>
 		<info name="alt_title" value="続ダンジョン・マスター カオスの逆襲" />
 		<info name="release" value="199012xx" />
+		<info name="usage" value="Requires 2 MB RAM"/>
 		<part name="cdrom" interface="fmt_cdrom">
 			<diskarea name="cdrom">
 				<disk name="dungeon master - chaos strikes back (japan)" sha1="a7ebf93b4f501d14fcc2515112fbdda616129114" />
@@ -13657,6 +14425,7 @@ User/save disks that can be created from the game itself are not included.
 		<publisher>ディー・オー (D.O.)</publisher>
 		<info name="alt_title" value="続妖獣戦記 ―砂塵の黙示録―" />
 		<info name="release" value="199402xx" />
+		<info name="usage" value="Requires 2 MB RAM"/>
 		<part name="cdrom" interface="fmt_cdrom">
 			<diskarea name="cdrom">
 				<disk name="zoku youjuu senki - suna no mokushiroku (japan)" sha1="91e09f83c7c0439131290d9d7783566b5e085d85" />


### PR DESCRIPTION
- Added requirements for software items that need more hardware than what an unexpanded Model 1 would provide (386 CPU, 1 MB RAM, no HDD).

- Replaced entries with dumps from the redump.org database, with proper track indexes and offset correction:

Alone in the Dark
Azure
Bible Master - Crash of the BlleotRutz
Bomberman - Panic Bomber
ElFish
if 2 - Invitations from Fantastic Stories
Might and Magic III - Isles of Terra
Mobile Suit Gundam - Hyper Classic Operation
Tatsujin Ou
Titan
Towns System Software v1.1 L10
Yami no Ketsuzoku Special - The Predestined Homicides

- Added new working dumps from the redump.org database:

After Burner (v1.02)
After Burner (v1.02, alt)
Can Can Bunny Premiere
Debut Shimasu... - Nakagawa Yuuko
Free Software Collection Marty 1
Hyper Channel - Towns TV
TownsPAINT V1.1 L10

- Added new NOT working dumps from the redump.org database:

Pro Yakyuu Family Stadium - 90-nendo Pennant Race-ban
Shamhat - The Holy Circlet
Suzaku

- Re-tested and promoted to working status:

Jangou 4

- Various metadata fixes