### PR TITLE
st_flop.xml: Add Fantasy World Dizzy

### DIFF
--- a/hash/st_flop.xml
+++ b/hash/st_flop.xml
@@ -1686,6 +1686,18 @@ license:CC0
 		</part>
 	</software>
 
+	<software name="fwdizzy" supported="no">
+		<description>Fantasy World Dizzy (Euro)</description>
+		<year>1991</year>
+		<publisher>Codemasters</publisher>
+		<sharedfeat name="compatibility" value="PAL"/>
+		<part name="flop1" interface="floppy_3_5">
+			<dataarea name="flop" size="2111192">
+				<rom name="fantasy world dizzy.mfm" size="2111192" crc="0e3bc56e" sha1="dd941a52b47a3c078b02c2c9ee8b566a94622a1f" />
+			</dataarea>
+		</part>
+	</software>
+
 	<software name="ferrari" supported="no">
 		<description>Ferrari Formula One (Euro)</description>
 		<year>1989</year>

--- a/hash/st_flop.xml
+++ b/hash/st_flop.xml
@@ -25,8 +25,8 @@ license:CC0
 		<publisher>Kixx</publisher>
 		<sharedfeat name="compatibility" value="PAL"/>
 		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="425024">
-				<rom name="1943.stx" size="425024" crc="0e65cf47" sha1="3e9db2e46b1b3506d79456a7e427b10471b3ceb0" offset="0" />
+			<dataarea name="flop" size="3133369">
+				<rom name="1943.mfm" size="3133369" crc="ff64e5f9" sha1="65a442c6812245e3842fdad5e60c9ccb17b0f80d" />
 			</dataarea>
 		</part>
 	</software>
@@ -1705,14 +1705,14 @@ license:CC0
 		<sharedfeat name="compatibility" value="PAL"/>
 		<part name="flop1" interface="floppy_3_5">
 			<feature name="part_id" value="Boot Disk" />
-			<dataarea name="flop" size="425552">
-				<rom name="e02431xl(1).stx" size="425552" crc="55d733c5" sha1="9c5581f80bc3c89c3bc97b907c80db99919eb4d4"/>
+			<dataarea name="flop" size="2377383">
+				<rom name="e02431xl(1).mfm" size="2377383" crc="97032905" sha1="e7448484dd03f68ccb01e8188e29404953ab28cb"/>
 			</dataarea>
 		</part>
 		<part name="flop2" interface="floppy_3_5">
 			<feature name="part_id" value="Data Disk" />
-			<dataarea name="flop" size="425040">
-				<rom name="e02431xl(2).stx" size="425040" crc="a0c353e9" sha1="f976beb1167ed203293969d8c1b3db35a4dd005d"/>
+			<dataarea name="flop" size="2377453">
+				<rom name="e02431xl(2).mfm" size="2377453" crc="1eeea420" sha1="7234349114f2bb077d4d2ba8da5e6368c6caa475"/>
 			</dataarea>
 		</part>
 	</software>
@@ -2734,8 +2734,8 @@ license:CC0
 		<publisher>English Software</publisher>
 		<sharedfeat name="compatibility" value="PAL"/>
 		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="425024">
-				<rom name="leviathan.stx" size="425024" crc="05e0caa6" sha1="f18afa94caa21cc090ef8234fb3a61c435908c70" offset="0" />
+			<dataarea name="flop" size="3133311">
+				<rom name="leviathan.mfm" size="3133311" crc="8ba6fcfb" sha1="340b866b34bdb99a96d4fe3784d32672c65d1165" />
 			</dataarea>
 		</part>
 	</software>
@@ -3033,8 +3033,8 @@ license:CC0
 		<publisher>Kixx XL</publisher>
 		<sharedfeat name="compatibility" value="PAL"/>
 		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="847952">
-				<rom name="midwinter.stx" size="847952" crc="e5f07ed4" sha1="5f5656ce2f3e25b3ce7eab6e64f77cafb45ad0c9" offset="0" />
+			<dataarea name="flop" size="2150273">
+				<rom name="midwinter.mfm" size="2150273" crc="8486d6b0" sha1="c6500e99a3b2af9dae1cc7681ffc0c1c7f3b8061" />
 			</dataarea>
 		</part>
 	</software>
@@ -4111,8 +4111,8 @@ license:CC0
 		<publisher>Smash 16</publisher>
 		<sharedfeat name="compatibility" value="PAL"/>
 		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="415008">
-				<rom name="spidertronic.stx" size="415008" crc="78214642" sha1="3838054a74b86a5d3b16e4683f50728f9ab20a78" offset="0" />
+			<dataarea name="flop" size="3133401">
+				<rom name="spidertronic.mfm" size="3133401" crc="57607130" sha1="4dc1ee4efacd52e5ba9a5c74c3b82618783b35aa" />
 			</dataarea>
 		</part>
 	</software>
@@ -4328,8 +4328,8 @@ license:CC0
 		<publisher>Gremlin Graphics</publisher>
 		<sharedfeat name="compatibility" value="PAL"/>
 		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="847952">
-				<rom name="striker.stx" size="847952" crc="f9fe0cc2" sha1="d8bb86e94d6ee5df312f6eb80f72d92edb2fb326" offset="0" />
+			<dataarea name="flop" size="2150288">
+				<rom name="striker.mfm" size="2150288" crc="f4145309" sha1="af26fd1b75bedd50f2a58fbb0eb4acf1f37f3d19" />
 			</dataarea>
 		</part>
 	</software>
@@ -4660,8 +4660,8 @@ license:CC0
 		<publisher>Again Again</publisher>
 		<sharedfeat name="compatibility" value="PAL"/>
 		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="424512">
-				<rom name="track suit manager.stx" size="424512" crc="7e48af79" sha1="1b7e015cffaeefb4d0b26d4cb434c6ee95507636" offset="0" />
+			<dataarea name="flop" size="2993999">
+				<rom name="track suit manager.mfm" size="2993999" crc="4ed508ad" sha1="4e2d765b06efa87a80362439566da96f367993e0" />
 			</dataarea>
 		</part>
 	</software>


### PR DESCRIPTION
From Greaseweazle dump by mikerochip.

Speaking with Jeff of HxC it seems stx isn't the best of formats, so replace those with mfm dumps.