### PR TITLE
Fixed software list declaration for apple2gs with the actual content of the related software lists

### DIFF
--- a/src/mame/drivers/apple2gs.cpp
+++ b/src/mame/drivers/apple2gs.cpp
@@ -4738,7 +4738,7 @@ void apple2gs_state::apple2gs(machine_config &config)
 	SOFTWARE_LIST(config, "flop525_clean").set_compatible("apple2_flop_clcracked"); // No filter on clean cracks yet.
 	// As WOZ images won't load in the 2GS driver yet, comment out the softlist entry.
 	//SOFTWARE_LIST(config, "flop525_orig").set_compatible("apple2_flop_orig").set_filter("A2GS");  // Filter list to compatible disks for this machine.
-	SOFTWARE_LIST(config, "flop525_misc").set_compatible("apple2_misc");
+	SOFTWARE_LIST(config, "flop525_misc").set_compatible("apple2_flop_misc");
 }
 
 void apple2gs_state::apple2gsr1(machine_config &config)


### PR DESCRIPTION
This is making my F/E stalled although it should happily display the content of all apple2gs related software lists.