### PR TITLE
Adding and tidying some C64 tapes

### DIFF
--- a/hash/c64_cass.xml
+++ b/hash/c64_cass.xml
@@ -7058,6 +7058,26 @@ Some are based on the C64 Tape Archive at https://archive.org/download/c64tapes/
 		</part>
 	</software>
 
+	<software name="summrck">
+		<description>Summer Camp</description>
+		<year>1990</year>
+		<publisher>Kixx</publisher>
+
+		<part name="summrcka" interface="cbm_cass">
+			<feature name="part_id" value="Side A"/>
+			<dataarea name="cass" size="507164">
+				<rom name="summrcka.tap" size="507164" crc="2c8bc3d7" sha1="c2f8468308b202c6b60c2beed1edf38f5a46dbff"/>
+			</dataarea>
+		</part>
+
+		<part name="summrckb" interface="cbm_cass">
+			<feature name="part_id" value="Side B"/>
+			<dataarea name="cass" size="515968">
+				<rom name="summrckb.tap" size="515968" crc="e913833d" sha1="d4ad033192e4788d28574d5c45c2afde81d75121"/>
+			</dataarea>
+		</part>
+	</software>
+
 	<software name="sumgames">
 		<description>Summer Games</description>
 		<year>1984</year>

--- a/hash/c64_cass.xml
+++ b/hash/c64_cass.xml
@@ -1014,8 +1014,9 @@ Some are based on the C64 Tape Archive at https://archive.org/download/c64tapes/
 		<description>Boulder Dash 4</description>
 		<year>1989</year>
 		<publisher>Hi Tec Software</publisher>
+		<!-- Dumped by @c64tapes -->
 
-		<part name="bdashck" interface="cbm_cass">
+		<part name="cass" interface="cbm_cass">
 			<feature name="part_id" value="Boulder Dash Construction Kit"/>
 			<dataarea name="cass" size="250098">
 				<rom name="bdashck.tap" size="250098" crc="a1748639" sha1="6a76ba69fdf0709ce330c2c47ceb7677fdd45bb9"/>
@@ -2901,15 +2902,16 @@ Some are based on the C64 Tape Archive at https://archive.org/download/c64tapes/
 		<description>The Greed Monster</description>
 		<year>1990</year>
 		<publisher>Hi Tec Software</publisher>
+		<!-- Dumped by @c64tapes -->
 
-		<part name="greedmna" interface="cbm_cass">
+		<part name="cass1" interface="cbm_cass">
 			<feature name="part_id" value="Side A"/>
 			<dataarea name="cass" size="827446">
 				<rom name="greedmna.tap" size="827446" crc="d75a92ce" sha1="5178771a761c53d95769edbcc257fe2acf4c9a55"/>
 			</dataarea>
 		</part>
 
-		<part name="greedmnb" interface="cbm_cass">
+		<part name="cass2" interface="cbm_cass">
 			<feature name="part_id" value="Side B"/>
 			<dataarea name="cass" size="830302">
 				<rom name="greedmnb.tap" size="830302" crc="489e9390" sha1="61503e8fbaea297824729cc24023819fba8d77ca"/>
@@ -3019,15 +3021,16 @@ Some are based on the C64 Tape Archive at https://archive.org/download/c64tapes/
 		<description>Hacker II</description>
 		<year>1989</year>
 		<publisher>Mastertronic</publisher>
+		<!-- Dumped by @c64tapes -->
 
-		<part name="hacker2a" interface="cbm_cass">
+		<part name="cass1" interface="cbm_cass">
 			<feature name="part_id" value="Side A"/>
 			<dataarea name="cass" size="384234">
 				<rom name="hacker2a.tap" size="384234" crc="9c9c5aed" sha1="a499a909d48578ad7b0df5b16a97c4f2930dbaad"/>
 			</dataarea>
 		</part>
 
-		<part name="hacker2b" interface="cbm_cass">
+		<part name="cass2" interface="cbm_cass">
 			<feature name="part_id" value="Side B"/>
 			<dataarea name="cass" size="384234">
 				<rom name="hacker2b.tap" size="384234" crc="7c16e324" sha1="80e830dfb92916441ccfbd2c6e01e278bfa37c65"/>
@@ -4026,8 +4029,9 @@ Some are based on the C64 Tape Archive at https://archive.org/download/c64tapes/
 		<description>Kettle</description>
 		<year>1986</year>
 		<publisher>Alligata</publisher>
+		<!-- Dumped by @c64tapes -->
 
-		<part name="kettlea" interface="cbm_cass">
+		<part name="cass" interface="cbm_cass">
 			<feature name="part_id" value="Side A"/>
 			<dataarea name="cass" size="329346">
 				<rom name="kettlea.tap" size="329346" crc="1ac910df" sha1="6f99c98d6c67ab1fd0678db4d26cb30bb4db7b55"/>
@@ -5986,12 +5990,13 @@ Some are based on the C64 Tape Archive at https://archive.org/download/c64tapes/
 		</part>
 	</software>
 
-	<software name="robocod">
+	<software name="robocodk">
 		<description>James Pond 2: RoboCod</description>
 		<year>1992</year>
 		<publisher>Kixx</publisher>
+		<!-- Dumped by @c64tapes -->
 
-		<part name="robocoda" interface="cbm_cass">
+		<part name="cass" interface="cbm_cass">
 			<feature name="part_id" value="Side A"/>
 			<dataarea name="cass" size="763681">
 				<rom name="robocoda.tap" size="763681" crc="9c3a5a87" sha1="1f47600332f3140c3956f7907e0707e38d3f617c"/>
@@ -7082,15 +7087,16 @@ Some are based on the C64 Tape Archive at https://archive.org/download/c64tapes/
 		<description>Summer Camp</description>
 		<year>1990</year>
 		<publisher>Kixx</publisher>
+		<!-- Dumped by @c64tapes -->
 
-		<part name="summrcka" interface="cbm_cass">
+		<part name="cass1" interface="cbm_cass">
 			<feature name="part_id" value="Side A"/>
 			<dataarea name="cass" size="507164">
 				<rom name="summrcka.tap" size="507164" crc="2c8bc3d7" sha1="c2f8468308b202c6b60c2beed1edf38f5a46dbff"/>
 			</dataarea>
 		</part>
 
-		<part name="summrckb" interface="cbm_cass">
+		<part name="cass2" interface="cbm_cass">
 			<feature name="part_id" value="Side B"/>
 			<dataarea name="cass" size="515968">
 				<rom name="summrckb.tap" size="515968" crc="e913833d" sha1="d4ad033192e4788d28574d5c45c2afde81d75121"/>
@@ -7366,15 +7372,16 @@ Some are based on the C64 Tape Archive at https://archive.org/download/c64tapes/
 		<description>Tetris</description>
 		<year>1989</year>
 		<publisher>Mastertronic Plus</publisher>
+		<!-- Dumped by @c64tapes -->
 
-		<part name="tetrisa" interface="cbm_cass">
+		<part name="cass1" interface="cbm_cass">
 			<feature name="part_id" value="Side A"/>
 			<dataarea name="cass" size="444689">
 				<rom name="tetrisa.tap" size="444689" crc="13bc6c8d" sha1="7c1fac70c035aa6d782a690f779302243aabd03a"/>
 			</dataarea>
 		</part>
 
-		<part name="tetrisb" interface="cbm_cass">
+		<part name="cass2" interface="cbm_cass">
 			<feature name="part_id" value="Side B"/>
 			<dataarea name="cass" size="444689">
 				<rom name="tetrisb.tap" size="444689" crc="79de6451" sha1="abf51ce18a4cf38e4248952580c4385f8b3bd2a6"/>

--- a/hash/c64_cass.xml
+++ b/hash/c64_cass.xml
@@ -6650,7 +6650,7 @@ Some are based on the C64 Tape Archive at https://archive.org/download/c64tapes/
 
 	<software name="spyvspy">
 		<description>Spy vs Spy</description>
-		<year>19??</year>
+		<year>1989</year>
 		<publisher>HiTEC Software</publisher>
 
 		<part name="cass1" interface="cbm_cass">
@@ -6662,7 +6662,7 @@ Some are based on the C64 Tape Archive at https://archive.org/download/c64tapes/
 
 	<software name="spyvspy2">
 		<description>Spy vs Spy II: The Island Caper</description>
-		<year>19??</year>
+		<year>1989</year>
 		<publisher>HiTEC Software</publisher>
 
 		<part name="cass1" interface="cbm_cass">
@@ -6674,7 +6674,7 @@ Some are based on the C64 Tape Archive at https://archive.org/download/c64tapes/
 
 	<software name="spyvspy3">
 		<description>Spy vs Spy III: Arctic Antics</description>
-		<year>19??</year>
+		<year>1989</year>
 		<publisher>HiTEC Software</publisher>
 
 		<part name="cass1" interface="cbm_cass">

--- a/hash/c64_cass.xml
+++ b/hash/c64_cass.xml
@@ -5953,6 +5953,19 @@ Some are based on the C64 Tape Archive at https://archive.org/download/c64tapes/
 		</part>
 	</software>
 
+	<software name="robocod">
+		<description>James Pond 2: RoboCod</description>
+		<year>1992</year>
+		<publisher>Kixx</publisher>
+
+		<part name="robocoda" interface="cbm_cass">
+			<feature name="part_id" value="Side A"/>
+			<dataarea name="cass" size="763681">
+				<rom name="robocoda.tap" size="763681" crc="9c3a5a87" sha1="1f47600332f3140c3956f7907e0707e38d3f617c"/>
+			</dataarea>
+		</part>
+	</software>
+
 	<software name="robocop">
 		<description>Robocop</description>
 		<year>1988</year>

--- a/hash/c64_cass.xml
+++ b/hash/c64_cass.xml
@@ -1010,6 +1010,19 @@ Some are based on the C64 Tape Archive at https://archive.org/download/c64tapes/
 		</part>
 	</software>
 
+	<software name="bdash4h">
+		<description>Boulder Dash 4</description>
+		<year>1989</year>
+		<publisher>Hi Tec Software</publisher>
+
+		<part name="bdashck" interface="cbm_cass">
+			<feature name="part_id" value="Boulder Dash Construction Kit"/>
+			<dataarea name="cass" size="250098">
+				<rom name="bdashck.tap" size="250098" crc="a1748639" sha1="6a76ba69fdf0709ce330c2c47ceb7677fdd45bb9"/>
+			</dataarea>
+		</part>
+	</software>
+
 	<software name="bombjack">
 		<description>Bomb Jack</description>
 		<year>1988</year>

--- a/hash/c64_cass.xml
+++ b/hash/c64_cass.xml
@@ -2897,6 +2897,26 @@ Some are based on the C64 Tape Archive at https://archive.org/download/c64tapes/
 		</part>
 	</software>
 
+	<software name="greedmn">
+		<description>The Greed Monster</description>
+		<year>1990</year>
+		<publisher>Hi Tec Software</publisher>
+
+		<part name="greedmna" interface="cbm_cass">
+			<feature name="part_id" value="Side A"/>
+			<dataarea name="cass" size="827446">
+				<rom name="greedmna.tap" size="827446" crc="d75a92ce" sha1="5178771a761c53d95769edbcc257fe2acf4c9a55"/>
+			</dataarea>
+		</part>
+
+		<part name="greedmnb" interface="cbm_cass">
+			<feature name="part_id" value="Side B"/>
+			<dataarea name="cass" size="830302">
+				<rom name="greedmnb.tap" size="830302" crc="489e9390" sha1="61503e8fbaea297824729cc24023819fba8d77ca"/>
+			</dataarea>
+		</part>
+	</software>
+
 	<software name="gribblys">
 		<description>Gribbly's Day Out</description>
 		<year>1985</year>

--- a/hash/c64_cass.xml
+++ b/hash/c64_cass.xml
@@ -2995,6 +2995,26 @@ Some are based on the C64 Tape Archive at https://archive.org/download/c64tapes/
 		</part>
 	</software>
 
+	<software name="hacker2">
+		<description>Hacker II</description>
+		<year>1989</year>
+		<publisher>Mastertronic</publisher>
+
+		<part name="hacker2a" interface="cbm_cass">
+			<feature name="part_id" value="Side A"/>
+			<dataarea name="cass" size="384234">
+				<rom name="hacker2a.tap" size="384234" crc="9c9c5aed" sha1="a499a909d48578ad7b0df5b16a97c4f2930dbaad"/>
+			</dataarea>
+		</part>
+
+		<part name="hacker2b" interface="cbm_cass">
+			<feature name="part_id" value="Side B"/>
+			<dataarea name="cass" size="384234">
+				<rom name="hacker2b.tap" size="384234" crc="7c16e324" sha1="80e830dfb92916441ccfbd2c6e01e278bfa37c65"/>
+			</dataarea>
+		</part>
+	</software>
+
 	<software name="hate">
 		<description>H.A.T.E: Hostile All Terrain Encounter</description>
 		<year>1989</year>

--- a/hash/c64_cass.xml
+++ b/hash/c64_cass.xml
@@ -4002,6 +4002,19 @@ Some are based on the C64 Tape Archive at https://archive.org/download/c64tapes/
 		</part>
 	</software>
 
+	<software name="kettle">
+		<description>Kettle</description>
+		<year>1986</year>
+		<publisher>Alligata</publisher>
+
+		<part name="kettlea" interface="cbm_cass">
+			<feature name="part_id" value="Side A"/>
+			<dataarea name="cass" size="329346">
+				<rom name="kettlea.tap" size="329346" crc="1ac910df" sha1="6f99c98d6c67ab1fd0678db4d26cb30bb4db7b55"/>
+			</dataarea>
+		</part>
+	</software>
+
 	<software name="kgbsspy">
 		<description>KGB Superspy</description>
 		<year>19??</year>

--- a/hash/c64_cass.xml
+++ b/hash/c64_cass.xml
@@ -7342,6 +7342,26 @@ Some are based on the C64 Tape Archive at https://archive.org/download/c64tapes/
 		</part>
 	</software>
 
+	<software name="tetris">
+		<description>Tetris</description>
+		<year>1989</year>
+		<publisher>Mastertronic Plus</publisher>
+
+		<part name="tetrisa" interface="cbm_cass">
+			<feature name="part_id" value="Side A"/>
+			<dataarea name="cass" size="444689">
+				<rom name="tetrisa.tap" size="444689" crc="13bc6c8d" sha1="7c1fac70c035aa6d782a690f779302243aabd03a"/>
+			</dataarea>
+		</part>
+
+		<part name="tetrisb" interface="cbm_cass">
+			<feature name="part_id" value="Side B"/>
+			<dataarea name="cass" size="444689">
+				<rom name="tetrisb.tap" size="444689" crc="79de6451" sha1="abf51ce18a4cf38e4248952580c4385f8b3bd2a6"/>
+			</dataarea>
+		</part>
+	</software>
+
 	<software name="thomas">
 		<description>Thomas the Tank Engine &amp; Friends</description>
 		<year>1990</year>


### PR DESCRIPTION
Hi!

So I'm [dumping](https://archive.org/details/c64tapes) a bunch of C64 tapes, and also [collating](http://c64tapes.com) some C64 tapes dumped by myself as well as others, as two separate projects.  I'm also working on a handy export feature that generates c64_cass.xml based on these.  There's a few things to note:

- Some of these dumps are only one side, if only one side dumped successfully.  I'll add to, or replace, those if and when I can get the other side to dump successfully.
- I'm sticking to the 8.3 filename convention for both the software name and ROM name.  I'm also trying to keep re-releases of titles separate, assuming you'll want _all_ known releases and re-releases of any given title.  So e.g. `bdash4h`, for Hi Tec Software's re-release of Boulder Dash 4, isn't going to conflict with the original release at `bdash4`, whenever that's added.  I'd be happy to rename the existing software and ROM names if you'd like, to stick to this convention..?  It would avoid conflicts in the future, allowing you to theoretically preserve all reissues.
- Tapes are a bit arbitrary, alas.  The dumping program `tapclean` can optimise them, which somewhat helps.  Would you like me to replace the existing .tap files with their optimised equivalents?  This would change their overall CRCs while keeping their payloads (depicted by their magic CRCs) identical.

Anyway, I was hoping to revamp this section quite a bit, but I don't want to tread on anyone else's toes or anything.

Cheers!