### PR TITLE
deco16ic.cpp Drawing behavior updates

### DIFF
--- a/src/mame/drivers/backfire.cpp
+++ b/src/mame/drivers/backfire.cpp
@@ -401,8 +401,6 @@ void backfire_state::backfire(machine_config &config)
 	m_deco_tilegen[0]->set_screen(m_lscreen);
 	m_deco_tilegen[0]->set_pf1_size(DECO_64x32);
 	m_deco_tilegen[0]->set_pf2_size(DECO_64x32);
-	m_deco_tilegen[0]->set_pf1_trans_mask(0x0f);
-	m_deco_tilegen[0]->set_pf2_trans_mask(0x0f);
 	m_deco_tilegen[0]->set_pf1_col_bank(0x00);
 	m_deco_tilegen[0]->set_pf2_col_bank(0x40);
 	m_deco_tilegen[0]->set_pf1_col_mask(0x0f);
@@ -417,8 +415,6 @@ void backfire_state::backfire(machine_config &config)
 	m_deco_tilegen[1]->set_screen(m_lscreen);
 	m_deco_tilegen[1]->set_pf1_size(DECO_64x32);
 	m_deco_tilegen[1]->set_pf2_size(DECO_64x32);
-	m_deco_tilegen[1]->set_pf1_trans_mask(0x0f);
-	m_deco_tilegen[1]->set_pf2_trans_mask(0x0f);
 	m_deco_tilegen[1]->set_pf1_col_bank(0x10);
 	m_deco_tilegen[1]->set_pf2_col_bank(0x50);
 	m_deco_tilegen[1]->set_pf1_col_mask(0x0f);

--- a/src/mame/drivers/boogwing.cpp
+++ b/src/mame/drivers/boogwing.cpp
@@ -350,8 +350,6 @@ void boogwing_state::boogwing(machine_config &config)
 	DECO16IC(config, m_deco_tilegen[0], 0);
 	m_deco_tilegen[0]->set_pf1_size(DECO_64x32);
 	m_deco_tilegen[0]->set_pf2_size(DECO_64x32);
-	m_deco_tilegen[0]->set_pf1_trans_mask(0x0f);
-	m_deco_tilegen[0]->set_pf2_trans_mask(0x1f);  // pf2 has 5bpp graphics
 	m_deco_tilegen[0]->set_pf1_col_bank(0);
 	m_deco_tilegen[0]->set_pf2_col_bank(0);   // pf2 is non default
 	m_deco_tilegen[0]->set_pf1_col_mask(0x0f);
@@ -365,8 +363,6 @@ void boogwing_state::boogwing(machine_config &config)
 	DECO16IC(config, m_deco_tilegen[1], 0);
 	m_deco_tilegen[1]->set_pf1_size(DECO_64x32);
 	m_deco_tilegen[1]->set_pf2_size(DECO_64x32);
-	m_deco_tilegen[1]->set_pf1_trans_mask(0x0f);
-	m_deco_tilegen[1]->set_pf2_trans_mask(0x0f);
 	m_deco_tilegen[1]->set_pf1_col_bank(0);
 	m_deco_tilegen[1]->set_pf2_col_bank(16);
 	m_deco_tilegen[1]->set_pf1_col_mask(0x0f);

--- a/src/mame/drivers/cbuster.cpp
+++ b/src/mame/drivers/cbuster.cpp
@@ -286,8 +286,6 @@ void cbuster_state::twocrude(machine_config &config)
 	DECO16IC(config, m_deco_tilegen[0], 0);
 	m_deco_tilegen[0]->set_pf1_size(DECO_64x32);
 	m_deco_tilegen[0]->set_pf2_size(DECO_64x32);
-	m_deco_tilegen[0]->set_pf1_trans_mask(0x0f);
-	m_deco_tilegen[0]->set_pf2_trans_mask(0x0f);
 	m_deco_tilegen[0]->set_pf1_col_bank(0x00);
 	m_deco_tilegen[0]->set_pf2_col_bank(0x20);
 	m_deco_tilegen[0]->set_pf1_col_mask(0x0f);
@@ -301,8 +299,6 @@ void cbuster_state::twocrude(machine_config &config)
 	DECO16IC(config, m_deco_tilegen[1], 0);
 	m_deco_tilegen[1]->set_pf1_size(DECO_64x32);
 	m_deco_tilegen[1]->set_pf2_size(DECO_64x32);
-	m_deco_tilegen[1]->set_pf1_trans_mask(0x0f);
-	m_deco_tilegen[1]->set_pf2_trans_mask(0x0f);
 	m_deco_tilegen[1]->set_pf1_col_bank(0x30);
 	m_deco_tilegen[1]->set_pf2_col_bank(0x40);
 	m_deco_tilegen[1]->set_pf1_col_mask(0x0f);

--- a/src/mame/drivers/cninja.cpp
+++ b/src/mame/drivers/cninja.cpp
@@ -736,6 +736,11 @@ DECO16IC_BANK_CB_MEMBER(cninja_state::mutantf_2_bank_callback)
 	return ((bank >> 5) & 0x1) << 14;
 }
 
+// palette bits are not effected
+u16 cninja_state::robocop2_mix_callback(u16 p, u16 p2)
+{
+	return (p & 0x70f) | ((p2 & 0xf) << 4);
+}
 
 DECOSPR_PRIORITY_CB_MEMBER(cninja_state::pri_callback)
 {
@@ -793,8 +798,6 @@ void cninja_state::cninja(machine_config &config)
 	DECO16IC(config, m_deco_tilegen[0], 0);
 	m_deco_tilegen[0]->set_pf1_size(DECO_64x32);
 	m_deco_tilegen[0]->set_pf2_size(DECO_64x32);
-	m_deco_tilegen[0]->set_pf1_trans_mask(0x0f);
-	m_deco_tilegen[0]->set_pf2_trans_mask(0x0f);
 	m_deco_tilegen[0]->set_pf1_col_bank(0x00);
 	m_deco_tilegen[0]->set_pf2_col_bank(0x10);
 	m_deco_tilegen[0]->set_pf1_col_mask(0x0f);
@@ -806,8 +809,6 @@ void cninja_state::cninja(machine_config &config)
 	DECO16IC(config, m_deco_tilegen[1], 0);
 	m_deco_tilegen[1]->set_pf1_size(DECO_64x32);
 	m_deco_tilegen[1]->set_pf2_size(DECO_64x32);
-	m_deco_tilegen[1]->set_pf1_trans_mask(0x0f);
-	m_deco_tilegen[1]->set_pf2_trans_mask(0x0f);
 	m_deco_tilegen[1]->set_pf1_col_bank(0x00);
 	m_deco_tilegen[1]->set_pf2_col_bank(0x30);
 	m_deco_tilegen[1]->set_pf1_col_mask(0x0f);
@@ -880,8 +881,6 @@ void cninja_state::stoneage(machine_config &config)
 	DECO16IC(config, m_deco_tilegen[0], 0);
 	m_deco_tilegen[0]->set_pf1_size(DECO_64x32);
 	m_deco_tilegen[0]->set_pf2_size(DECO_64x32);
-	m_deco_tilegen[0]->set_pf1_trans_mask(0x0f);
-	m_deco_tilegen[0]->set_pf2_trans_mask(0x0f);
 	m_deco_tilegen[0]->set_pf1_col_bank(0x00);
 	m_deco_tilegen[0]->set_pf2_col_bank(0x10);
 	m_deco_tilegen[0]->set_pf1_col_mask(0x0f);
@@ -893,8 +892,6 @@ void cninja_state::stoneage(machine_config &config)
 	DECO16IC(config, m_deco_tilegen[1], 0);
 	m_deco_tilegen[1]->set_pf1_size(DECO_64x32);
 	m_deco_tilegen[1]->set_pf2_size(DECO_64x32);
-	m_deco_tilegen[1]->set_pf1_trans_mask(0x0f);
-	m_deco_tilegen[1]->set_pf2_trans_mask(0x0f);
 	m_deco_tilegen[1]->set_pf1_col_bank(0x00);
 	m_deco_tilegen[1]->set_pf2_col_bank(0x30);
 	m_deco_tilegen[1]->set_pf1_col_mask(0x0f);
@@ -975,8 +972,6 @@ void cninja_state::cninjabl(machine_config &config)
 	DECO16IC(config, m_deco_tilegen[0], 0);
 	m_deco_tilegen[0]->set_pf1_size(DECO_64x32);
 	m_deco_tilegen[0]->set_pf2_size(DECO_64x32);
-	m_deco_tilegen[0]->set_pf1_trans_mask(0x0f);
-	m_deco_tilegen[0]->set_pf2_trans_mask(0x0f);
 	m_deco_tilegen[0]->set_pf1_col_bank(0x00);
 	m_deco_tilegen[0]->set_pf2_col_bank(0x10);
 	m_deco_tilegen[0]->set_pf1_col_mask(0x0f);
@@ -988,8 +983,6 @@ void cninja_state::cninjabl(machine_config &config)
 	DECO16IC(config, m_deco_tilegen[1], 0);
 	m_deco_tilegen[1]->set_pf1_size(DECO_64x32);
 	m_deco_tilegen[1]->set_pf2_size(DECO_64x32);
-	m_deco_tilegen[1]->set_pf1_trans_mask(0x0f);
-	m_deco_tilegen[1]->set_pf2_trans_mask(0x0f);
 	m_deco_tilegen[1]->set_pf1_col_bank(0x00);
 	m_deco_tilegen[1]->set_pf2_col_bank(0x30);
 	m_deco_tilegen[1]->set_pf1_col_mask(0x0f);
@@ -1045,8 +1038,6 @@ void cninja_state::edrandy(machine_config &config)
 	DECO16IC(config, m_deco_tilegen[0], 0);
 	m_deco_tilegen[0]->set_pf1_size(DECO_64x32);
 	m_deco_tilegen[0]->set_pf2_size(DECO_64x32);
-	m_deco_tilegen[0]->set_pf1_trans_mask(0x0f);
-	m_deco_tilegen[0]->set_pf2_trans_mask(0x0f);
 	m_deco_tilegen[0]->set_pf1_col_bank(0x00);
 	m_deco_tilegen[0]->set_pf2_col_bank(0x10);
 	m_deco_tilegen[0]->set_pf1_col_mask(0x0f);
@@ -1058,8 +1049,6 @@ void cninja_state::edrandy(machine_config &config)
 	DECO16IC(config, m_deco_tilegen[1], 0);
 	m_deco_tilegen[1]->set_pf1_size(DECO_64x32);
 	m_deco_tilegen[1]->set_pf2_size(DECO_64x32);
-	m_deco_tilegen[1]->set_pf1_trans_mask(0x0f);
-	m_deco_tilegen[1]->set_pf2_trans_mask(0x0f);
 	m_deco_tilegen[1]->set_pf1_col_bank(0x00);
 	m_deco_tilegen[1]->set_pf2_col_bank(0x30);
 	m_deco_tilegen[1]->set_pf1_col_mask(0x0f);
@@ -1106,8 +1095,7 @@ void cninja_state::robocop2(machine_config &config)
 
 	h6280_device &audiocpu(H6280(config, m_audiocpu, XTAL(32'220'000) / 8));
 	audiocpu.set_addrmap(AS_PROGRAM, &cninja_state::sound_map);
-	audiocpu.add_route(ALL_OUTPUTS, "lspeaker", 0); // internal sound unused
-	audiocpu.add_route(ALL_OUTPUTS, "rspeaker", 0);
+	audiocpu.add_route(ALL_OUTPUTS, "mono", 0); // internal sound unused
 
 	deco_irq_device &irq(DECO_IRQ(config, "irq", 0));
 	irq.set_screen_tag(m_screen);
@@ -1132,8 +1120,6 @@ void cninja_state::robocop2(machine_config &config)
 	DECO16IC(config, m_deco_tilegen[0], 0);
 	m_deco_tilegen[0]->set_pf1_size(DECO_64x32);
 	m_deco_tilegen[0]->set_pf2_size(DECO_64x32);
-	m_deco_tilegen[0]->set_pf1_trans_mask(0x0f);
-	m_deco_tilegen[0]->set_pf2_trans_mask(0x0f);
 	m_deco_tilegen[0]->set_pf1_col_bank(0x00);
 	m_deco_tilegen[0]->set_pf2_col_bank(0x10);
 	m_deco_tilegen[0]->set_pf1_col_mask(0x0f);
@@ -1146,14 +1132,13 @@ void cninja_state::robocop2(machine_config &config)
 	DECO16IC(config, m_deco_tilegen[1], 0);
 	m_deco_tilegen[1]->set_pf1_size(DECO_64x32);
 	m_deco_tilegen[1]->set_pf2_size(DECO_64x32);
-	m_deco_tilegen[1]->set_pf1_trans_mask(0x0f);
-	m_deco_tilegen[1]->set_pf2_trans_mask(0x0f);
 	m_deco_tilegen[1]->set_pf1_col_bank(0x00);
 	m_deco_tilegen[1]->set_pf2_col_bank(0x30);
 	m_deco_tilegen[1]->set_pf1_col_mask(0x0f);
 	m_deco_tilegen[1]->set_pf2_col_mask(0x0f);
 	m_deco_tilegen[1]->set_bank1_callback(FUNC(cninja_state::robocop2_bank_callback));
 	m_deco_tilegen[1]->set_bank2_callback(FUNC(cninja_state::robocop2_bank_callback));
+	m_deco_tilegen[1]->set_mix_callback(FUNC(cninja_state::robocop2_mix_callback));
 	m_deco_tilegen[1]->set_pf12_8x8_bank(0);
 	m_deco_tilegen[1]->set_pf12_16x16_bank(2);
 	m_deco_tilegen[1]->set_gfxdecode_tag(m_gfxdecode);
@@ -1171,26 +1156,19 @@ void cninja_state::robocop2(machine_config &config)
 	m_ioprot->set_use_magic_read_address_xor(true);
 
 	/* sound hardware */
-	SPEAKER(config, "lspeaker").front_left();
-	SPEAKER(config, "rspeaker").front_right();
+	SPEAKER(config, "mono").front_center();
 
-	ym2203_device &ym1(YM2203(config, "ym1", XTAL(32'220'000) / 8));
-	ym1.add_route(ALL_OUTPUTS, "lspeaker", 0.60);
-	ym1.add_route(ALL_OUTPUTS, "rspeaker", 0.60);
+	YM2203(config, "ym1", XTAL(32'220'000) / 8).add_route(ALL_OUTPUTS, "mono", 0.60);
 
 	ym2151_device &ym2(YM2151(config, "ym2", XTAL(32'220'000) / 9));
 	ym2.irq_handler().set_inputline(m_audiocpu, 1); /* IRQ2 */
 	ym2.port_write_handler().set(FUNC(cninja_state::sound_bankswitch_w));
-	ym2.add_route(0, "lspeaker", 0.45);
-	ym2.add_route(1, "rspeaker", 0.45);
+	ym2.add_route(0, "mono", 0.45);
+	ym2.add_route(1, "mono", 0.45);
 
-	okim6295_device &oki1(OKIM6295(config, "oki1", XTAL(32'220'000) / 32, okim6295_device::PIN7_HIGH));
-	oki1.add_route(ALL_OUTPUTS, "lspeaker", 0.75);
-	oki1.add_route(ALL_OUTPUTS, "rspeaker", 0.75);
+	OKIM6295(config, "oki1", XTAL(32'220'000) / 32, okim6295_device::PIN7_HIGH).add_route(ALL_OUTPUTS, "mono", 0.75);
 
-	OKIM6295(config, m_oki2, XTAL(32'220'000) / 16, okim6295_device::PIN7_HIGH);
-	m_oki2->add_route(ALL_OUTPUTS, "lspeaker", 0.60);
-	m_oki2->add_route(ALL_OUTPUTS, "rspeaker", 0.60);
+	OKIM6295(config, m_oki2, XTAL(32'220'000) / 16, okim6295_device::PIN7_HIGH).add_route(ALL_OUTPUTS, "mono", 0.60);
 }
 
 
@@ -1203,8 +1181,7 @@ void cninja_state::mutantf(machine_config &config)
 
 	h6280_device &audiocpu(H6280(config, m_audiocpu, XTAL(32'220'000) / 8));
 	audiocpu.set_addrmap(AS_PROGRAM, &cninja_state::sound_map_mutantf);
-	audiocpu.add_route(ALL_OUTPUTS, "lspeaker", 0); // internal sound unused
-	audiocpu.add_route(ALL_OUTPUTS, "rspeaker", 0);
+	audiocpu.add_route(ALL_OUTPUTS, "mono", 0); // internal sound unused
 
 	/* video hardware */
 	SCREEN(config, m_screen, SCREEN_TYPE_RASTER);
@@ -1224,8 +1201,6 @@ void cninja_state::mutantf(machine_config &config)
 	DECO16IC(config, m_deco_tilegen[0], 0);
 	m_deco_tilegen[0]->set_pf1_size(DECO_64x32);
 	m_deco_tilegen[0]->set_pf2_size(DECO_64x32);
-	m_deco_tilegen[0]->set_pf1_trans_mask(0x0f);
-	m_deco_tilegen[0]->set_pf2_trans_mask(0x0f);
 	m_deco_tilegen[0]->set_pf1_col_bank(0x00);
 	m_deco_tilegen[0]->set_pf2_col_bank(0x30);
 	m_deco_tilegen[0]->set_pf1_col_mask(0x0f);
@@ -1239,8 +1214,6 @@ void cninja_state::mutantf(machine_config &config)
 	DECO16IC(config, m_deco_tilegen[1], 0);
 	m_deco_tilegen[1]->set_pf1_size(DECO_64x32);
 	m_deco_tilegen[1]->set_pf2_size(DECO_64x32);
-	m_deco_tilegen[1]->set_pf1_trans_mask(0x0f);
-	m_deco_tilegen[1]->set_pf2_trans_mask(0x0f);
 	m_deco_tilegen[1]->set_pf1_col_bank(0x20);
 	m_deco_tilegen[1]->set_pf2_col_bank(0x40);
 	m_deco_tilegen[1]->set_pf1_col_mask(0x0f);
@@ -1266,22 +1239,17 @@ void cninja_state::mutantf(machine_config &config)
 	m_ioprot->soundlatch_irq_cb().set_inputline(m_audiocpu, 0);
 
 	/* sound hardware */
-	SPEAKER(config, "lspeaker").front_left();
-	SPEAKER(config, "rspeaker").front_right();
+	SPEAKER(config, "mono").front_center();
 
 	ym2151_device &ymsnd(YM2151(config, "ymsnd", XTAL(32'220'000) / 9));
 	ymsnd.irq_handler().set_inputline(m_audiocpu, 1); /* IRQ2 */
 	ymsnd.port_write_handler().set(FUNC(cninja_state::sound_bankswitch_w));
-	ymsnd.add_route(0, "lspeaker", 0.45);
-	ymsnd.add_route(1, "rspeaker", 0.45);
+	ymsnd.add_route(0, "mono", 0.45);
+	ymsnd.add_route(1, "mono", 0.45);
 
-	okim6295_device &oki1(OKIM6295(config, "oki1", XTAL(32'220'000) / 32, okim6295_device::PIN7_HIGH));
-	oki1.add_route(ALL_OUTPUTS, "lspeaker", 0.75);
-	oki1.add_route(ALL_OUTPUTS, "rspeaker", 0.75);
+	OKIM6295(config, "oki1", XTAL(32'220'000) / 32, okim6295_device::PIN7_HIGH).add_route(ALL_OUTPUTS, "mono", 0.75);
 
-	OKIM6295(config, m_oki2, XTAL(32'220'000) / 16, okim6295_device::PIN7_HIGH);
-	m_oki2->add_route(ALL_OUTPUTS, "lspeaker", 0.60);
-	m_oki2->add_route(ALL_OUTPUTS, "rspeaker", 0.60);
+	OKIM6295(config, m_oki2, XTAL(32'220'000) / 16, okim6295_device::PIN7_HIGH).add_route(ALL_OUTPUTS, "mono", 0.60);
 }
 
 /**********************************************************************************/

--- a/src/mame/drivers/cninja.cpp
+++ b/src/mame/drivers/cninja.cpp
@@ -665,30 +665,11 @@ static const gfx_layout tilelayout =
 	64*8
 };
 
-static const gfx_layout tilelayout_8bpp =
-{
-	16,16,
-	4096,
-	8,
-	{ 0x100000*8+8, 0x100000*8, 0x40000*8+8, 0x40000*8, 0xc0000*8+8, 0xc0000*8, 8, 0 },
-	{ STEP8(16*8*2,1), STEP8(0,1) },
-	{ STEP16(0,8*2) },
-	64*8
-};
-
 static GFXDECODE_START( gfx_cninja )
 	GFXDECODE_ENTRY( "chars",    0, charlayout,   0, 32 )  /* Characters 8x8 */
 	GFXDECODE_ENTRY( "tiles1",   0, tilelayout,   0, 32 )  /* Tiles 16x16 */
 	GFXDECODE_ENTRY( "tiles2",   0, tilelayout, 512, 64 )  /* Tiles 16x16 */
 	GFXDECODE_ENTRY( "sprites1", 0, tilelayout, 768, 32 )  /* Sprites 16x16 */
-GFXDECODE_END
-
-static GFXDECODE_START( gfx_robocop2 )
-	GFXDECODE_ENTRY( "chars",    0, charlayout,        0, 32 )  /* Characters 8x8 */
-	GFXDECODE_ENTRY( "tiles1",   0, tilelayout,        0, 32 )  /* Tiles 16x16 */
-	GFXDECODE_ENTRY( "tiles2",   0, tilelayout,      512, 64 )  /* Tiles 16x16 */
-	GFXDECODE_ENTRY( "sprites1", 0, tilelayout,      768, 32 )  /* Sprites 16x16 */
-	GFXDECODE_ENTRY( "tiles2",   0, tilelayout_8bpp, 512,  1 )  /* Tiles 16x16 */
 GFXDECODE_END
 
 static GFXDECODE_START( gfx_mutantf )
@@ -1112,7 +1093,7 @@ void cninja_state::robocop2(machine_config &config)
 	MCFG_MACHINE_START_OVERRIDE(cninja_state,robocop2)
 	MCFG_MACHINE_RESET_OVERRIDE(cninja_state,robocop2)
 
-	GFXDECODE(config, m_gfxdecode, m_palette, gfx_robocop2);
+	GFXDECODE(config, m_gfxdecode, m_palette, gfx_cninja);
 	PALETTE(config, m_palette).set_format(palette_device::xBGR_888, 2048);
 
 	BUFFERED_SPRITERAM16(config, m_spriteram[0]);

--- a/src/mame/drivers/darkseal.cpp
+++ b/src/mame/drivers/darkseal.cpp
@@ -162,31 +162,20 @@ INPUT_PORTS_END
 static const gfx_layout charlayout =
 {
 	8,8,    /* 8*8 chars */
-	4096,
+	RGN_FRAC(1,2),
 	4,      /* 4 bits per pixel  */
-	{ 0x00000*8, 0x10000*8, 0x8000*8, 0x18000*8 },
+	{ 8, 0, RGN_FRAC(1,2)+8, RGN_FRAC(1,2) },
 	{ STEP8(0,1) },
-	{ STEP8(0,8) },
-	8*8 /* every char takes 8 consecutive bytes */
+	{ STEP8(0,8*2) },
+	8*8*2 /* every char takes 8 consecutive bytes */
 };
 
 static const gfx_layout seallayout =
 {
 	16,16,
-	4096,
+	RGN_FRAC(1,2),
 	4,
-	{ 8, 0,  0x40000*8+8, 0x40000*8 },
-	{ STEP8(16*8*2,1), STEP8(0,1) },
-	{ STEP16(0,8*2) },
-	64*8
-};
-
-static const gfx_layout seallayout2 =
-{
-	16,16,
-	4096*2,
-	4,
-	{ 8, 0, 0x80000*8+8, 0x80000*8 },
+	{ 8, 0, RGN_FRAC(1,2)+8, RGN_FRAC(1,2) },
 	{ STEP8(16*8*2,1), STEP8(0,1) },
 	{ STEP16(0,8*2) },
 	64*8
@@ -196,7 +185,7 @@ static GFXDECODE_START( gfx_darkseal )
 	GFXDECODE_ENTRY( "gfx1", 0, charlayout,    0, 16 )  /* Characters 8x8 */
 	GFXDECODE_ENTRY( "gfx2", 0, seallayout,  768, 16 )  /* Tiles 16x16 */
 	GFXDECODE_ENTRY( "gfx3", 0, seallayout, 1024, 16 )  /* Tiles 16x16 */
-	GFXDECODE_ENTRY( "gfx4", 0, seallayout2, 256, 32 )  /* Sprites 16x16 */
+	GFXDECODE_ENTRY( "gfx4", 0, seallayout,  256, 32 )  /* Sprites 16x16 */
 GFXDECODE_END
 
 /******************************************************************************/
@@ -230,8 +219,6 @@ void darkseal_state::darkseal(machine_config &config)
 	DECO16IC(config, m_deco_tilegen[0], 0);
 	m_deco_tilegen[0]->set_pf1_size(DECO_64x64);
 	m_deco_tilegen[0]->set_pf2_size(DECO_64x64);     // both these tilemaps need to be twice the y size of usual!
-	m_deco_tilegen[0]->set_pf1_trans_mask(0x0f);
-	m_deco_tilegen[0]->set_pf2_trans_mask(0x0f);
 	m_deco_tilegen[0]->set_pf1_col_bank(0x00);
 	m_deco_tilegen[0]->set_pf2_col_bank(0x00);
 	m_deco_tilegen[0]->set_pf1_col_mask(0x0f);
@@ -243,8 +230,6 @@ void darkseal_state::darkseal(machine_config &config)
 	DECO16IC(config, m_deco_tilegen[1], 0);
 	m_deco_tilegen[1]->set_pf1_size(DECO_64x32);
 	m_deco_tilegen[1]->set_pf2_size(DECO_64x32);
-	m_deco_tilegen[1]->set_pf1_trans_mask(0x0f);
-	m_deco_tilegen[1]->set_pf2_trans_mask(0x0f);
 	m_deco_tilegen[1]->set_pf1_col_bank(0x00);
 	m_deco_tilegen[1]->set_pf2_col_bank(0x00);
 	m_deco_tilegen[1]->set_pf1_col_mask(0x0f);
@@ -288,8 +273,8 @@ ROM_START( darkseal )
 	ROM_LOAD( "fz_06-1.j15", 0x00000, 0x10000, CRC(c4828a6d) SHA1(fbfd0c85730bbe18401879cd68c19aaec9d482d8) )
 
 	ROM_REGION( 0x020000, "gfx1", 0 )
-	ROM_LOAD( "fz_02.j1", 0x000000, 0x10000, CRC(3c9c3012) SHA1(086c2123725d4aa32838c0b6c82317d9c789c465) ) /* chars */
-	ROM_LOAD( "fz_03.j2", 0x010000, 0x10000, CRC(264b90ed) SHA1(0bb1557673107c2d732a9374d5601a6eaf229473) )
+	ROM_LOAD16_BYTE( "fz_02.j1", 0x000001, 0x10000, CRC(3c9c3012) SHA1(086c2123725d4aa32838c0b6c82317d9c789c465) ) /* chars */
+	ROM_LOAD16_BYTE( "fz_03.j2", 0x000000, 0x10000, CRC(264b90ed) SHA1(0bb1557673107c2d732a9374d5601a6eaf229473) )
 
 	ROM_REGION( 0x080000, "gfx2", 0 )
 	ROM_LOAD( "mac-03.h3", 0x000000, 0x80000, CRC(9996f3dc) SHA1(fffd9ecfe142a0c7c3c9c521778ff9c55ea8b225) ) /* tiles 1 */
@@ -319,8 +304,8 @@ ROM_START( darkseal1 )
 	ROM_LOAD( "fz_06-1.j15", 0x00000, 0x10000, CRC(c4828a6d) SHA1(fbfd0c85730bbe18401879cd68c19aaec9d482d8) )
 
 	ROM_REGION( 0x020000, "gfx1", 0 )
-	ROM_LOAD( "fz_02-1.j1", 0x000000, 0x10000, CRC(3c9c3012) SHA1(086c2123725d4aa32838c0b6c82317d9c789c465) ) /* chars */
-	ROM_LOAD( "fz_03-1.j2", 0x010000, 0x10000, CRC(264b90ed) SHA1(0bb1557673107c2d732a9374d5601a6eaf229473) )
+	ROM_LOAD16_BYTE( "fz_02-1.j1", 0x000001, 0x10000, CRC(3c9c3012) SHA1(086c2123725d4aa32838c0b6c82317d9c789c465) ) /* chars */
+	ROM_LOAD16_BYTE( "fz_03-1.j2", 0x000000, 0x10000, CRC(264b90ed) SHA1(0bb1557673107c2d732a9374d5601a6eaf229473) )
 
 	ROM_REGION( 0x080000, "gfx2", 0 )
 	ROM_LOAD( "mac-03.h3", 0x000000, 0x80000, CRC(9996f3dc) SHA1(fffd9ecfe142a0c7c3c9c521778ff9c55ea8b225) ) /* tiles 1 */
@@ -350,8 +335,8 @@ ROM_START( darksealj )
 	ROM_LOAD( "fz_06-1.j15", 0x00000, 0x10000, CRC(c4828a6d) SHA1(fbfd0c85730bbe18401879cd68c19aaec9d482d8) )
 
 	ROM_REGION( 0x020000, "gfx1", 0 )
-	ROM_LOAD( "fz_02.j1", 0x000000, 0x10000, CRC(3c9c3012) SHA1(086c2123725d4aa32838c0b6c82317d9c789c465) ) /* chars */
-	ROM_LOAD( "fz_03.j2", 0x010000, 0x10000, CRC(264b90ed) SHA1(0bb1557673107c2d732a9374d5601a6eaf229473) )
+	ROM_LOAD16_BYTE( "fz_02.j1", 0x000001, 0x10000, CRC(3c9c3012) SHA1(086c2123725d4aa32838c0b6c82317d9c789c465) ) /* chars */
+	ROM_LOAD16_BYTE( "fz_03.j2", 0x000000, 0x10000, CRC(264b90ed) SHA1(0bb1557673107c2d732a9374d5601a6eaf229473) )
 
 	ROM_REGION( 0x080000, "gfx2", 0 )
 	ROM_LOAD( "mac-03.h3", 0x000000, 0x80000, CRC(9996f3dc) SHA1(fffd9ecfe142a0c7c3c9c521778ff9c55ea8b225) ) /* tiles 1 */
@@ -381,8 +366,8 @@ ROM_START( gatedoom )
 	ROM_LOAD( "fz_06-1.j15", 0x00000, 0x10000, CRC(c4828a6d) SHA1(fbfd0c85730bbe18401879cd68c19aaec9d482d8) )
 
 	ROM_REGION( 0x020000, "gfx1", 0 )
-	ROM_LOAD( "fz_02.j1", 0x000000, 0x10000, CRC(3c9c3012) SHA1(086c2123725d4aa32838c0b6c82317d9c789c465) ) /* chars */
-	ROM_LOAD( "fz_03.j2", 0x010000, 0x10000, CRC(264b90ed) SHA1(0bb1557673107c2d732a9374d5601a6eaf229473) )
+	ROM_LOAD16_BYTE( "fz_02.j1", 0x000001, 0x10000, CRC(3c9c3012) SHA1(086c2123725d4aa32838c0b6c82317d9c789c465) ) /* chars */
+	ROM_LOAD16_BYTE( "fz_03.j2", 0x000000, 0x10000, CRC(264b90ed) SHA1(0bb1557673107c2d732a9374d5601a6eaf229473) )
 
 	ROM_REGION( 0x080000, "gfx2", 0 )
 	ROM_LOAD( "mac-03.h3", 0x000000, 0x80000, CRC(9996f3dc) SHA1(fffd9ecfe142a0c7c3c9c521778ff9c55ea8b225) ) /* tiles 1 */
@@ -412,8 +397,8 @@ ROM_START( gatedoom1 )
 	ROM_LOAD( "fz_06-1.j15", 0x00000, 0x10000, CRC(c4828a6d) SHA1(fbfd0c85730bbe18401879cd68c19aaec9d482d8) )
 
 	ROM_REGION( 0x020000, "gfx1", 0 )
-	ROM_LOAD( "fz_02.j1", 0x000000, 0x10000, CRC(3c9c3012) SHA1(086c2123725d4aa32838c0b6c82317d9c789c465) ) /* chars */
-	ROM_LOAD( "fz_03.j2", 0x010000, 0x10000, CRC(264b90ed) SHA1(0bb1557673107c2d732a9374d5601a6eaf229473) )
+	ROM_LOAD16_BYTE( "fz_02.j1", 0x000001, 0x10000, CRC(3c9c3012) SHA1(086c2123725d4aa32838c0b6c82317d9c789c465) ) /* chars */
+	ROM_LOAD16_BYTE( "fz_03.j2", 0x000000, 0x10000, CRC(264b90ed) SHA1(0bb1557673107c2d732a9374d5601a6eaf229473) )
 
 	ROM_REGION( 0x080000, "gfx2", 0 )
 	ROM_LOAD( "mac-03.h3", 0x000000, 0x80000, CRC(9996f3dc) SHA1(fffd9ecfe142a0c7c3c9c521778ff9c55ea8b225) ) /* tiles 1 */

--- a/src/mame/drivers/dassault.cpp
+++ b/src/mame/drivers/dassault.cpp
@@ -559,8 +559,6 @@ void dassault_state::dassault(machine_config &config)
 	DECO16IC(config, m_deco_tilegen[0], 0);
 	m_deco_tilegen[0]->set_pf1_size(DECO_64x32);
 	m_deco_tilegen[0]->set_pf2_size(DECO_64x32);
-	m_deco_tilegen[0]->set_pf1_trans_mask(0x0f);
-	m_deco_tilegen[0]->set_pf2_trans_mask(0x0f);
 	m_deco_tilegen[0]->set_pf1_col_bank(0);
 	m_deco_tilegen[0]->set_pf2_col_bank(16);
 	m_deco_tilegen[0]->set_pf1_col_mask(0x0f);
@@ -574,8 +572,6 @@ void dassault_state::dassault(machine_config &config)
 	DECO16IC(config, m_deco_tilegen[1], 0);
 	m_deco_tilegen[1]->set_pf1_size(DECO_64x32);
 	m_deco_tilegen[1]->set_pf2_size(DECO_64x32);
-	m_deco_tilegen[1]->set_pf1_trans_mask(0x0f);
-	m_deco_tilegen[1]->set_pf2_trans_mask(0x0f);
 	m_deco_tilegen[1]->set_pf1_col_bank(0);
 	m_deco_tilegen[1]->set_pf2_col_bank(16);
 	m_deco_tilegen[1]->set_pf1_col_mask(0x0f);

--- a/src/mame/drivers/dblewing.cpp
+++ b/src/mame/drivers/dblewing.cpp
@@ -370,8 +370,6 @@ void dblewing_state::dblewing(machine_config &config)
 	DECO16IC(config, m_deco_tilegen, 0);
 	m_deco_tilegen->set_pf1_size(DECO_64x32);
 	m_deco_tilegen->set_pf2_size(DECO_64x32);
-	m_deco_tilegen->set_pf1_trans_mask(0x0f);
-	m_deco_tilegen->set_pf2_trans_mask(0x0f);
 	m_deco_tilegen->set_pf1_col_bank(0x00);
 	m_deco_tilegen->set_pf2_col_bank(0x10);
 	m_deco_tilegen->set_pf1_col_mask(0x0f);

--- a/src/mame/drivers/deco156.cpp
+++ b/src/mame/drivers/deco156.cpp
@@ -336,8 +336,6 @@ void deco156_state::hvysmsh(machine_config &config)
 	DECO16IC(config, m_deco_tilegen, 0);
 	m_deco_tilegen->set_pf1_size(DECO_64x32);
 	m_deco_tilegen->set_pf2_size(DECO_64x32);
-	m_deco_tilegen->set_pf1_trans_mask(0x0f);
-	m_deco_tilegen->set_pf2_trans_mask(0x0f);
 	m_deco_tilegen->set_pf1_col_bank(0x00);
 	m_deco_tilegen->set_pf2_col_bank(0x10);
 	m_deco_tilegen->set_pf1_col_mask(0x0f);
@@ -388,8 +386,6 @@ void deco156_state::wcvol95(machine_config &config)
 	DECO16IC(config, m_deco_tilegen, 0);
 	m_deco_tilegen->set_pf1_size(DECO_64x32);
 	m_deco_tilegen->set_pf2_size(DECO_64x32);
-	m_deco_tilegen->set_pf1_trans_mask(0x0f);
-	m_deco_tilegen->set_pf2_trans_mask(0x0f);
 	m_deco_tilegen->set_pf1_col_bank(0x00);
 	m_deco_tilegen->set_pf2_col_bank(0x10);
 	m_deco_tilegen->set_pf1_col_mask(0x0f);

--- a/src/mame/drivers/deco32.cpp
+++ b/src/mame/drivers/deco32.cpp
@@ -883,6 +883,18 @@ DECOSPR_PRIORITY_CB_MEMBER( fghthist_state::fghthist_pri_callback )
 	return mask;
 }
 
+void captaven_state::tile_callback(u32 &tile, u32 &colour, int layer, bool is_8x8)
+{
+	// Captain America operates this chip in 8bpp mode.
+	// In 8bpp mode you appear to only get 1 layer, not 2, but you also
+	// have an extra 2 tile bits, and 2 less colour bits.
+	if (layer == 0)
+	{
+		tile |= ((colour & 0x3) << 12);
+		colour >>= 2;
+	}
+}
+
 DECO16IC_BANK_CB_MEMBER( captaven_state::bank_callback )
 {
 	return (bank & 0x20) << 9;
@@ -908,6 +920,11 @@ DECO16IC_BANK_CB_MEMBER( dragngun_state::bank_2_callback )
 DECO16IC_BANK_CB_MEMBER( nslasher_state::bank_callback )
 {
 	return (bank & ~0xf) << 8;
+}
+
+u16 nslasher_state::mix_callback(u16 p, u16 p2)
+{
+	return ((p & 0x70f) + (((p & 0x30) | (p2 & 0x0f)) << 4)) & 0x7ff;
 }
 
 
@@ -1867,8 +1884,6 @@ void captaven_state::captaven(machine_config &config)
 	DECO16IC(config, m_deco_tilegen[0], 0);
 	m_deco_tilegen[0]->set_pf1_size(DECO_64x32);
 	m_deco_tilegen[0]->set_pf2_size(DECO_64x32);
-	m_deco_tilegen[0]->set_pf1_trans_mask(0x0f);
-	m_deco_tilegen[0]->set_pf2_trans_mask(0x0f);
 	m_deco_tilegen[0]->set_pf1_col_bank(0x20);
 	m_deco_tilegen[0]->set_pf2_col_bank(0x30);
 	m_deco_tilegen[0]->set_pf1_col_mask(0x0f);
@@ -1880,12 +1895,11 @@ void captaven_state::captaven(machine_config &config)
 	DECO16IC(config, m_deco_tilegen[1], 0);    // pf3 is in 8bpp mode, pf4 is not used
 	m_deco_tilegen[1]->set_pf1_size(DECO_32x32);
 	m_deco_tilegen[1]->set_pf2_size(DECO_32x32);
-	m_deco_tilegen[1]->set_pf1_trans_mask(0xff);
-	m_deco_tilegen[1]->set_pf2_trans_mask(0x00);
-	m_deco_tilegen[1]->set_pf1_col_bank(0x10);
+	m_deco_tilegen[1]->set_pf1_col_bank(0x04);
 	m_deco_tilegen[1]->set_pf2_col_bank(0x00);
-	m_deco_tilegen[1]->set_pf1_col_mask(0x0f);
+	m_deco_tilegen[1]->set_pf1_col_mask(0x03);
 	m_deco_tilegen[1]->set_pf2_col_mask(0x00);
+	m_deco_tilegen[1]->set_tile_callback(FUNC(captaven_state::tile_callback));
 	m_deco_tilegen[1]->set_bank1_callback(FUNC(captaven_state::bank_callback));
 	// no bank2 callback
 	m_deco_tilegen[1]->set_pf12_8x8_bank(0);
@@ -1946,8 +1960,6 @@ void fghthist_state::fghthist(machine_config &config)
 	DECO16IC(config, m_deco_tilegen[0], 0);
 	m_deco_tilegen[0]->set_pf1_size(DECO_64x32);
 	m_deco_tilegen[0]->set_pf2_size(DECO_64x32);
-	m_deco_tilegen[0]->set_pf1_trans_mask(0x0f);
-	m_deco_tilegen[0]->set_pf2_trans_mask(0x0f);
 	m_deco_tilegen[0]->set_pf1_col_bank(0x00);
 	m_deco_tilegen[0]->set_pf2_col_bank(0x10);
 	m_deco_tilegen[0]->set_pf1_col_mask(0x0f);
@@ -1961,8 +1973,6 @@ void fghthist_state::fghthist(machine_config &config)
 	DECO16IC(config, m_deco_tilegen[1], 0);
 	m_deco_tilegen[1]->set_pf1_size(DECO_64x32);
 	m_deco_tilegen[1]->set_pf2_size(DECO_64x32);
-	m_deco_tilegen[1]->set_pf1_trans_mask(0x0f);
-	m_deco_tilegen[1]->set_pf2_trans_mask(0x0f);
 	m_deco_tilegen[1]->set_pf1_col_bank(0x20);
 	m_deco_tilegen[1]->set_pf2_col_bank(0x30);
 	m_deco_tilegen[1]->set_pf1_col_mask(0x0f);
@@ -2070,8 +2080,6 @@ void dragngun_state::dragngun(machine_config &config)
 	DECO16IC(config, m_deco_tilegen[0], 0);
 	m_deco_tilegen[0]->set_pf1_size(DECO_64x32);
 	m_deco_tilegen[0]->set_pf2_size(DECO_64x32);
-	m_deco_tilegen[0]->set_pf1_trans_mask(0x0f);
-	m_deco_tilegen[0]->set_pf2_trans_mask(0x0f);
 	m_deco_tilegen[0]->set_pf1_col_bank(0x20);
 	m_deco_tilegen[0]->set_pf2_col_bank(0x30);
 	m_deco_tilegen[0]->set_pf1_col_mask(0x0f);
@@ -2085,8 +2093,6 @@ void dragngun_state::dragngun(machine_config &config)
 	DECO16IC(config, m_deco_tilegen[1], 0);
 	m_deco_tilegen[1]->set_pf1_size(DECO_64x32);
 	m_deco_tilegen[1]->set_pf2_size(DECO_64x32);
-	m_deco_tilegen[1]->set_pf1_trans_mask(0xff);
-	m_deco_tilegen[1]->set_pf2_trans_mask(0xff);
 	m_deco_tilegen[1]->set_pf1_col_bank(0x04);
 	m_deco_tilegen[1]->set_pf2_col_bank(0x04);
 	m_deco_tilegen[1]->set_pf1_col_mask(0x03);
@@ -2196,8 +2202,6 @@ void dragngun_state::lockload(machine_config &config)
 	DECO16IC(config, m_deco_tilegen[0], 0);
 	m_deco_tilegen[0]->set_pf1_size(DECO_64x32);
 	m_deco_tilegen[0]->set_pf2_size(DECO_64x32);
-	m_deco_tilegen[0]->set_pf1_trans_mask(0x0f);
-	m_deco_tilegen[0]->set_pf2_trans_mask(0x0f);
 	m_deco_tilegen[0]->set_pf1_col_bank(0x20);
 	m_deco_tilegen[0]->set_pf2_col_bank(0x30);
 	m_deco_tilegen[0]->set_pf1_col_mask(0x0f);
@@ -2211,8 +2215,6 @@ void dragngun_state::lockload(machine_config &config)
 	DECO16IC(config, m_deco_tilegen[1], 0);
 	m_deco_tilegen[1]->set_pf1_size(DECO_32x32);
 	m_deco_tilegen[1]->set_pf2_size(DECO_32x32);    // lockload definitely wants pf34 half width..
-	m_deco_tilegen[1]->set_pf1_trans_mask(0xff);
-	m_deco_tilegen[1]->set_pf2_trans_mask(0xff);
 	m_deco_tilegen[1]->set_pf1_col_bank(0x04);
 	m_deco_tilegen[1]->set_pf2_col_bank(0x04);
 	m_deco_tilegen[1]->set_pf1_col_mask(0x03);
@@ -2274,8 +2276,6 @@ void nslasher_state::tattass(machine_config &config)
 	DECO16IC(config, m_deco_tilegen[0], 0);
 	m_deco_tilegen[0]->set_pf1_size(DECO_64x32);
 	m_deco_tilegen[0]->set_pf2_size(DECO_64x32);
-	m_deco_tilegen[0]->set_pf1_trans_mask(0x0f);
-	m_deco_tilegen[0]->set_pf2_trans_mask(0x0f);
 	m_deco_tilegen[0]->set_pf1_col_bank(0x00);
 	m_deco_tilegen[0]->set_pf2_col_bank(0x10);
 	m_deco_tilegen[0]->set_pf1_col_mask(0x0f);
@@ -2289,14 +2289,13 @@ void nslasher_state::tattass(machine_config &config)
 	DECO16IC(config, m_deco_tilegen[1], 0);
 	m_deco_tilegen[1]->set_pf1_size(DECO_64x32);
 	m_deco_tilegen[1]->set_pf2_size(DECO_64x32);
-	m_deco_tilegen[1]->set_pf1_trans_mask(0x0f);
-	m_deco_tilegen[1]->set_pf2_trans_mask(0x0f);
 	m_deco_tilegen[1]->set_pf1_col_bank(0x20);
 	m_deco_tilegen[1]->set_pf2_col_bank(0x30);
 	m_deco_tilegen[1]->set_pf1_col_mask(0x0f);
 	m_deco_tilegen[1]->set_pf2_col_mask(0x0f);
 	m_deco_tilegen[1]->set_bank1_callback(FUNC(nslasher_state::bank_callback));
 	m_deco_tilegen[1]->set_bank2_callback(FUNC(nslasher_state::bank_callback));
+	m_deco_tilegen[1]->set_mix_callback(FUNC(nslasher_state::mix_callback));
 	m_deco_tilegen[1]->set_pf12_8x8_bank(0);
 	m_deco_tilegen[1]->set_pf12_16x16_bank(2);
 	m_deco_tilegen[1]->set_gfxdecode_tag(m_gfxdecode);
@@ -2348,8 +2347,6 @@ void nslasher_state::nslasher(machine_config &config)
 	DECO16IC(config, m_deco_tilegen[0], 0);
 	m_deco_tilegen[0]->set_pf1_size(DECO_64x32);
 	m_deco_tilegen[0]->set_pf2_size(DECO_64x32);
-	m_deco_tilegen[0]->set_pf1_trans_mask(0x0f);
-	m_deco_tilegen[0]->set_pf2_trans_mask(0x0f);
 	m_deco_tilegen[0]->set_pf1_col_bank(0x00);
 	m_deco_tilegen[0]->set_pf2_col_bank(0x10);
 	m_deco_tilegen[0]->set_pf1_col_mask(0x0f);
@@ -2363,14 +2360,13 @@ void nslasher_state::nslasher(machine_config &config)
 	DECO16IC(config, m_deco_tilegen[1], 0);
 	m_deco_tilegen[1]->set_pf1_size(DECO_64x32);
 	m_deco_tilegen[1]->set_pf2_size(DECO_64x32);
-	m_deco_tilegen[1]->set_pf1_trans_mask(0x0f);
-	m_deco_tilegen[1]->set_pf2_trans_mask(0x0f);
 	m_deco_tilegen[1]->set_pf1_col_bank(0x20);
 	m_deco_tilegen[1]->set_pf2_col_bank(0x30);
 	m_deco_tilegen[1]->set_pf1_col_mask(0x0f);
 	m_deco_tilegen[1]->set_pf2_col_mask(0x0f);
 	m_deco_tilegen[1]->set_bank1_callback(FUNC(nslasher_state::bank_callback));
 	m_deco_tilegen[1]->set_bank2_callback(FUNC(nslasher_state::bank_callback));
+	m_deco_tilegen[1]->set_mix_callback(FUNC(nslasher_state::mix_callback));
 	m_deco_tilegen[1]->set_pf12_8x8_bank(0);
 	m_deco_tilegen[1]->set_pf12_16x16_bank(2);
 	m_deco_tilegen[1]->set_gfxdecode_tag(m_gfxdecode);

--- a/src/mame/drivers/dietgo.cpp
+++ b/src/mame/drivers/dietgo.cpp
@@ -222,8 +222,6 @@ void dietgo_state::dietgo(machine_config &config)
 	DECO16IC(config, m_deco_tilegen, 0);
 	m_deco_tilegen->set_pf1_size(DECO_64x32);
 	m_deco_tilegen->set_pf2_size(DECO_64x32);
-	m_deco_tilegen->set_pf1_trans_mask(0x0f);
-	m_deco_tilegen->set_pf2_trans_mask(0x0f);
 	m_deco_tilegen->set_pf1_col_bank(0x00);
 	m_deco_tilegen->set_pf2_col_bank(0x10);
 	m_deco_tilegen->set_pf1_col_mask(0x0f);

--- a/src/mame/drivers/dreambal.cpp
+++ b/src/mame/drivers/dreambal.cpp
@@ -339,8 +339,6 @@ void dreambal_state::dreambal(machine_config &config)
 	DECO16IC(config, m_deco_tilegen, 0);
 	m_deco_tilegen->set_pf1_size(DECO_64x32);
 	m_deco_tilegen->set_pf2_size(DECO_64x32);
-	m_deco_tilegen->set_pf1_trans_mask(0x0f);
-	m_deco_tilegen->set_pf2_trans_mask(0x0f);
 	m_deco_tilegen->set_pf1_col_bank(0x00);
 	m_deco_tilegen->set_pf2_col_bank(0x10);
 	m_deco_tilegen->set_pf1_col_mask(0x0f);

--- a/src/mame/drivers/funkyjet.cpp
+++ b/src/mame/drivers/funkyjet.cpp
@@ -336,8 +336,6 @@ void funkyjet_state::funkyjet(machine_config &config)
 	DECO16IC(config, m_deco_tilegen, 0);
 	m_deco_tilegen->set_pf1_size(DECO_64x32);
 	m_deco_tilegen->set_pf2_size(DECO_64x32);
-	m_deco_tilegen->set_pf1_trans_mask(0x0f);
-	m_deco_tilegen->set_pf2_trans_mask(0x0f);
 	m_deco_tilegen->set_pf1_col_bank(0x00);
 	m_deco_tilegen->set_pf2_col_bank(0x10);
 	m_deco_tilegen->set_pf1_col_mask(0x0f);

--- a/src/mame/drivers/pktgaldx.cpp
+++ b/src/mame/drivers/pktgaldx.cpp
@@ -362,8 +362,6 @@ void pktgaldx_state::pktgaldx(machine_config &config)
 	DECO16IC(config, m_deco_tilegen, 0);
 	m_deco_tilegen->set_pf1_size(DECO_64x32);
 	m_deco_tilegen->set_pf2_size(DECO_64x32);
-	m_deco_tilegen->set_pf1_trans_mask(0x0f);
-	m_deco_tilegen->set_pf2_trans_mask(0x0f);
 	m_deco_tilegen->set_pf1_col_bank(0x00);
 	m_deco_tilegen->set_pf2_col_bank(0x10);
 	m_deco_tilegen->set_pf1_col_mask(0x0f);

--- a/src/mame/drivers/rohga.cpp
+++ b/src/mame/drivers/rohga.cpp
@@ -893,8 +893,6 @@ void rohga_state::rohga(machine_config &config)
 	DECO16IC(config, m_deco_tilegen[0], 0);
 	m_deco_tilegen[0]->set_pf1_size(DECO_64x64);
 	m_deco_tilegen[0]->set_pf2_size(DECO_64x32);
-	m_deco_tilegen[0]->set_pf1_trans_mask(0x0f);
-	m_deco_tilegen[0]->set_pf2_trans_mask(0x0f);
 	m_deco_tilegen[0]->set_pf1_col_bank(0x00);
 	m_deco_tilegen[0]->set_pf2_col_bank(0x10);
 	m_deco_tilegen[0]->set_pf1_col_mask(0x0f);
@@ -908,8 +906,6 @@ void rohga_state::rohga(machine_config &config)
 	DECO16IC(config, m_deco_tilegen[1], 0);
 	m_deco_tilegen[1]->set_pf1_size(DECO_64x32);
 	m_deco_tilegen[1]->set_pf2_size(DECO_64x32);
-	m_deco_tilegen[1]->set_pf1_trans_mask(0x0f);
-	m_deco_tilegen[1]->set_pf2_trans_mask(0x0f);
 	m_deco_tilegen[1]->set_pf1_col_bank(0x00);
 	m_deco_tilegen[1]->set_pf2_col_bank(0x10);
 	m_deco_tilegen[1]->set_pf1_col_mask(0x0f);
@@ -983,8 +979,6 @@ void rohga_state::wizdfire(machine_config &config)
 	DECO16IC(config, m_deco_tilegen[0], 0);
 	m_deco_tilegen[0]->set_pf1_size(DECO_64x32);
 	m_deco_tilegen[0]->set_pf2_size(DECO_64x32);
-	m_deco_tilegen[0]->set_pf1_trans_mask(0x0f);
-	m_deco_tilegen[0]->set_pf2_trans_mask(0x0f);
 	m_deco_tilegen[0]->set_pf1_col_bank(0x00);
 	m_deco_tilegen[0]->set_pf2_col_bank(0x10);
 	m_deco_tilegen[0]->set_pf1_col_mask(0x0f);
@@ -998,8 +992,6 @@ void rohga_state::wizdfire(machine_config &config)
 	DECO16IC(config, m_deco_tilegen[1], 0);
 	m_deco_tilegen[1]->set_pf1_size(DECO_64x32);
 	m_deco_tilegen[1]->set_pf2_size(DECO_64x32);
-	m_deco_tilegen[1]->set_pf1_trans_mask(0x0f);
-	m_deco_tilegen[1]->set_pf2_trans_mask(0x0f);
 	m_deco_tilegen[1]->set_pf1_col_bank(0x00);
 	m_deco_tilegen[1]->set_pf2_col_bank(0x10);
 	m_deco_tilegen[1]->set_pf1_col_mask(0x0f);
@@ -1078,8 +1070,6 @@ void rohga_state::nitrobal(machine_config &config)
 	DECO16IC(config, m_deco_tilegen[0], 0);
 	m_deco_tilegen[0]->set_pf1_size(DECO_64x32);
 	m_deco_tilegen[0]->set_pf2_size(DECO_32x32);
-	m_deco_tilegen[0]->set_pf1_trans_mask(0x0f);
-	m_deco_tilegen[0]->set_pf2_trans_mask(0x0f);
 	m_deco_tilegen[0]->set_pf1_col_bank(0x00);
 	m_deco_tilegen[0]->set_pf2_col_bank(0x10);
 	m_deco_tilegen[0]->set_pf1_col_mask(0x0f);
@@ -1093,8 +1083,6 @@ void rohga_state::nitrobal(machine_config &config)
 	DECO16IC(config, m_deco_tilegen[1], 0);
 	m_deco_tilegen[1]->set_pf1_size(DECO_32x32);
 	m_deco_tilegen[1]->set_pf2_size(DECO_32x32);
-	m_deco_tilegen[1]->set_pf1_trans_mask(0x0f);
-	m_deco_tilegen[1]->set_pf2_trans_mask(0x0f);
 	m_deco_tilegen[1]->set_pf1_col_bank(0);
 	m_deco_tilegen[1]->set_pf2_col_bank(0);
 	m_deco_tilegen[1]->set_pf1_col_mask(0);
@@ -1174,8 +1162,6 @@ void rohga_state::schmeisr(machine_config &config)
 	DECO16IC(config, m_deco_tilegen[0], 0);
 	m_deco_tilegen[0]->set_pf1_size(DECO_64x64);
 	m_deco_tilegen[0]->set_pf2_size(DECO_64x32);
-	m_deco_tilegen[0]->set_pf1_trans_mask(0x0f);
-	m_deco_tilegen[0]->set_pf2_trans_mask(0x0f);
 	m_deco_tilegen[0]->set_pf1_col_bank(0x00);
 	m_deco_tilegen[0]->set_pf2_col_bank(0x10);
 	m_deco_tilegen[0]->set_pf1_col_mask(0x0f);
@@ -1189,8 +1175,6 @@ void rohga_state::schmeisr(machine_config &config)
 	DECO16IC(config, m_deco_tilegen[1], 0);
 	m_deco_tilegen[1]->set_pf1_size(DECO_64x32);
 	m_deco_tilegen[1]->set_pf2_size(DECO_64x32);
-	m_deco_tilegen[1]->set_pf1_trans_mask(0x0f);
-	m_deco_tilegen[1]->set_pf2_trans_mask(0x0f);
 	m_deco_tilegen[1]->set_pf1_col_bank(0x00);
 	m_deco_tilegen[1]->set_pf2_col_bank(0x10);
 	m_deco_tilegen[1]->set_pf1_col_mask(0x0f);

--- a/src/mame/drivers/simpl156.cpp
+++ b/src/mame/drivers/simpl156.cpp
@@ -406,8 +406,6 @@ void simpl156_state::chainrec(machine_config &config)
 	DECO16IC(config, m_deco_tilegen, 0);
 	m_deco_tilegen->set_pf1_size(DECO_64x32);
 	m_deco_tilegen->set_pf2_size(DECO_64x32);
-	m_deco_tilegen->set_pf1_trans_mask(0x0f);
-	m_deco_tilegen->set_pf2_trans_mask(0x0f);
 	m_deco_tilegen->set_pf1_col_bank(0x00);
 	m_deco_tilegen->set_pf2_col_bank(0x10);
 	m_deco_tilegen->set_pf1_col_mask(0x0f);

--- a/src/mame/drivers/supbtime.cpp
+++ b/src/mame/drivers/supbtime.cpp
@@ -347,8 +347,6 @@ void supbtime_state::supbtime(machine_config &config)
 	DECO16IC(config, m_deco_tilegen, 0);
 	m_deco_tilegen->set_pf1_size(DECO_64x32);
 	m_deco_tilegen->set_pf2_size(DECO_64x32);
-	m_deco_tilegen->set_pf1_trans_mask(0x0f);
-	m_deco_tilegen->set_pf2_trans_mask(0x0f);
 	m_deco_tilegen->set_pf1_col_bank(0x00);
 	m_deco_tilegen->set_pf2_col_bank(0x10);
 	m_deco_tilegen->set_pf1_col_mask(0x0f);

--- a/src/mame/drivers/vaportra.cpp
+++ b/src/mame/drivers/vaportra.cpp
@@ -236,8 +236,6 @@ void vaportra_state::vaportra(machine_config &config)
 	DECO16IC(config, m_deco_tilegen[0], 0);
 	m_deco_tilegen[0]->set_pf1_size(DECO_64x32);
 	m_deco_tilegen[0]->set_pf2_size(DECO_64x32);
-	m_deco_tilegen[0]->set_pf1_trans_mask(0x0f);
-	m_deco_tilegen[0]->set_pf2_trans_mask(0x0f);
 	m_deco_tilegen[0]->set_pf1_col_bank(0x00);
 	m_deco_tilegen[0]->set_pf2_col_bank(0x20);
 	m_deco_tilegen[0]->set_pf1_col_mask(0x0f);
@@ -251,8 +249,6 @@ void vaportra_state::vaportra(machine_config &config)
 	DECO16IC(config, m_deco_tilegen[1], 0);
 	m_deco_tilegen[1]->set_pf1_size(DECO_64x32);
 	m_deco_tilegen[1]->set_pf2_size(DECO_64x32);
-	m_deco_tilegen[1]->set_pf1_trans_mask(0x0f);
-	m_deco_tilegen[1]->set_pf2_trans_mask(0x0f);
 	m_deco_tilegen[1]->set_pf1_col_bank(0x30);
 	m_deco_tilegen[1]->set_pf2_col_bank(0x40);
 	m_deco_tilegen[1]->set_pf1_col_mask(0x0f);

--- a/src/mame/includes/cninja.h
+++ b/src/mame/includes/cninja.h
@@ -81,6 +81,7 @@ public:
 	DECO16IC_BANK_CB_MEMBER(mutantf_2_bank_callback);
 
 	DECOSPR_PRIORITY_CB_MEMBER(pri_callback);
+	u16 robocop2_mix_callback(u16 p, u16 p2);
 
 	DECLARE_READ16_MEMBER( edrandy_protection_region_6_146_r );
 	DECLARE_WRITE16_MEMBER( edrandy_protection_region_6_146_w );

--- a/src/mame/includes/deco32.h
+++ b/src/mame/includes/deco32.h
@@ -123,6 +123,7 @@ private:
 
 	u32 screen_update(screen_device &screen, bitmap_ind16 &bitmap, const rectangle &cliprect);
 
+	void tile_callback(u32 &tile, u32 &colour, int layer, bool is_8x8);
 	DECO16IC_BANK_CB_MEMBER(bank_callback);
 	DECOSPR_PRIORITY_CB_MEMBER(captaven_pri_callback);
 
@@ -193,6 +194,7 @@ private:
 
 	u16 port_b_tattass();
 	DECO16IC_BANK_CB_MEMBER(bank_callback);
+	u16 mix_callback(u16 p, u16 p2);
 
 	void nslasher_map(address_map &map);
 	void tattass_map(address_map &map);

--- a/src/mame/includes/sshangha.h
+++ b/src/mame/includes/sshangha.h
@@ -53,6 +53,7 @@ private:
 
 	int m_video_control;
 	DECO16IC_BANK_CB_MEMBER(bank_callback);
+	u16 mix_callback(u16 p, u16 p2);
 
 	DECLARE_READ16_MEMBER(sshangha_protection_region_8_146_r);
 	DECLARE_WRITE16_MEMBER(sshangha_protection_region_8_146_w);
@@ -60,9 +61,6 @@ private:
 	DECLARE_WRITE16_MEMBER(sshangha_protection_region_d_146_w);
 	DECLARE_READ16_MEMBER(deco_71_r);
 	DECLARE_READ16_MEMBER(sshanghab_protection16_r);
-
-	DECLARE_READ16_MEMBER(palette_r);
-	DECLARE_WRITE16_MEMBER(palette_w);
 
 	DECLARE_READ8_MEMBER(sound_shared_r);
 	DECLARE_WRITE8_MEMBER(sound_shared_w);

--- a/src/mame/video/cninja.cpp
+++ b/src/mame/video/cninja.cpp
@@ -206,20 +206,6 @@ uint32_t cninja_state::screen_update_robocop2(screen_device &screen, bitmap_ind1
 	uint16_t flip = m_deco_tilegen[0]->pf_control_r(0);
 	uint16_t priority = m_priority;
 
-	/* One of the tilemap chips can switch between 2 tilemaps at 4bpp, or 1 at 8bpp */
-	if (priority & 4)
-	{
-		m_deco_tilegen[1]->set_tilemap_colour_mask(0, 0);
-		m_deco_tilegen[1]->set_tilemap_colour_mask(1, 0);
-		m_deco_tilegen[1]->pf12_set_gfxbank(0, 4);
-	}
-	else
-	{
-		m_deco_tilegen[1]->set_tilemap_colour_mask(0, 0xf);
-		m_deco_tilegen[1]->set_tilemap_colour_mask(1, 0xf);
-		m_deco_tilegen[1]->pf12_set_gfxbank(0, 2);
-	}
-
 	/* Update playfields */
 	flip_screen_set(BIT(flip, 7));
 	m_sprgen[0]->set_flip_screen(BIT(flip, 7));
@@ -238,11 +224,18 @@ uint32_t cninja_state::screen_update_robocop2(screen_device &screen, bitmap_ind1
 	{
 		case 8:
 			m_deco_tilegen[0]->tilemap_2_draw(screen, bitmap, cliprect, 0, 2);
-			m_deco_tilegen[1]->tilemap_1_draw(screen, bitmap, cliprect, 0, 4);
+			if (priority & 4)
+				m_deco_tilegen[1]->tilemap_12_combine_draw(screen, bitmap, cliprect, 0, 4);
+			else
+				m_deco_tilegen[1]->tilemap_1_draw(screen, bitmap, cliprect, 0, 4);
 			break;
 		default:
 		case 0:
-			m_deco_tilegen[1]->tilemap_1_draw(screen, bitmap, cliprect, 0, 2);
+			if (priority & 4)
+				m_deco_tilegen[1]->tilemap_12_combine_draw(screen, bitmap, cliprect, 0, 2);
+			else
+				m_deco_tilegen[1]->tilemap_1_draw(screen, bitmap, cliprect, 0, 2);
+
 			m_deco_tilegen[0]->tilemap_2_draw(screen, bitmap, cliprect, 0, 4);
 			break;
 	}

--- a/src/mame/video/deco16ic.cpp
+++ b/src/mame/video/deco16ic.cpp
@@ -186,19 +186,18 @@ deco16ic_device::deco16ic_device(const machine_config &mconfig, const char *tag,
 	, m_pf12_control(nullptr)
 	, m_pf1_rowscroll_ptr(nullptr)
 	, m_pf2_rowscroll_ptr(nullptr)
+	, m_tile_cb(*this)
 	, m_bank1_cb(*this)
 	, m_bank2_cb(*this)
+	, m_mix_cb(*this)
 	, m_use_custom_pf1(0)
 	, m_use_custom_pf2(0)
 	, m_pf1_bank(0)
 	, m_pf2_bank(0)
 	, m_pf12_last_small(0)
 	, m_pf12_last_big(0)
-	, m_pf1_8bpp_mode(0)
 	, m_pf1_size(0)
 	, m_pf2_size(0)
-	, m_pf1_trans_mask(0xf)
-	, m_pf2_trans_mask(0xf)
 	, m_pf1_colour_bank(0)
 	, m_pf2_colour_bank(0)
 	, m_pf1_colourmask(0xf)
@@ -218,8 +217,10 @@ void deco16ic_device::device_start()
 	if(!m_gfxdecode->started())
 		throw device_missing_dependencies();
 
+	m_tile_cb.resolve();
 	m_bank1_cb.resolve();
 	m_bank2_cb.resolve();
+	m_mix_cb.resolve();
 
 	int fullheight1 = 0;
 	int fullwidth1 = 0;
@@ -251,8 +252,6 @@ void deco16ic_device::device_start()
 	m_pf1_tilemap_16x16->set_transparent_pen(0);
 	m_pf2_tilemap_16x16->set_transparent_pen(0);
 
-	m_pf1_8bpp_mode = 0;
-
 	m_pf1_data = make_unique_clear<u16[]>(0x2000 / 2);
 	m_pf2_data = make_unique_clear<u16[]>(0x2000 / 2);
 	m_pf12_control = make_unique_clear<u16[]>(0x10 / 2);
@@ -265,8 +264,6 @@ void deco16ic_device::device_start()
 	save_item(NAME(m_pf12_16x16_gfx_bank));
 	save_item(NAME(m_pf12_last_small));
 	save_item(NAME(m_pf12_last_big));
-
-	save_item(NAME(m_pf1_8bpp_mode));
 
 	save_pointer(NAME(m_pf1_data), 0x2000 / 2);
 	save_pointer(NAME(m_pf2_data), 0x2000 / 2);
@@ -296,8 +293,8 @@ TILEMAP_MAPPER_MEMBER(deco16ic_device::deco16_scan_rows)
 
 TILE_GET_INFO_MEMBER(deco16ic_device::get_pf2_tile_info)
 {
-	const u16 tile = m_pf2_data[tile_index];
-	u8 colour = (tile >> 12) & 0xf;
+	u32 tile = m_pf2_data[tile_index];
+	u32 colour = (tile >> 12) & 0xf;
 	u8 flags = 0;
 
 	if (tile & 0x8000)
@@ -314,16 +311,20 @@ TILE_GET_INFO_MEMBER(deco16ic_device::get_pf2_tile_info)
 		}
 	}
 
+	tile &= 0xfff;
+	if (!m_tile_cb.isnull())
+		m_tile_cb(tile, colour, 1, false);
+
 	tileinfo.set(m_pf12_16x16_gfx_bank,
-			(tile & 0xfff) | m_pf2_bank,
+			tile + m_pf2_bank,
 			(colour & m_pf2_colourmask) + m_pf2_colour_bank,
 			flags);
 }
 
 TILE_GET_INFO_MEMBER(deco16ic_device::get_pf1_tile_info)
 {
-	const u16 tile = m_pf1_data[tile_index];
-	u8 colour = (tile >> 12) & 0xf;
+	u32 tile = m_pf1_data[tile_index];
+	u32 colour = (tile >> 12) & 0xf;
 	u8 flags = 0;
 
 	if (tile & 0x8000)
@@ -340,29 +341,20 @@ TILE_GET_INFO_MEMBER(deco16ic_device::get_pf1_tile_info)
 		}
 	}
 
-	if (m_pf1_8bpp_mode)
-	{
-		// Captain America operates this chip in 8bpp mode.
-		// In 8bpp mode you appear to only get 1 layer, not 2, but you also
-		// have an extra 2 tile bits, and 2 less colour bits.
-		tileinfo.set(m_pf12_16x16_gfx_bank,
-				(tile & 0x3fff) | m_pf1_bank,
-				((colour & m_pf1_colourmask) + m_pf1_colour_bank)>>2,
-				flags);
-	}
-	else
-	{
-		tileinfo.set(m_pf12_16x16_gfx_bank,
-				(tile & 0xfff) | m_pf1_bank,
-				(colour & m_pf1_colourmask) + m_pf1_colour_bank,
-				flags);
-	}
+	tile &= 0xfff;
+	if (!m_tile_cb.isnull())
+		m_tile_cb(tile, colour, 0, false);
+
+	tileinfo.set(m_pf12_16x16_gfx_bank,
+			tile + m_pf1_bank,
+			(colour & m_pf1_colourmask) + m_pf1_colour_bank,
+			flags);
 }
 
 TILE_GET_INFO_MEMBER(deco16ic_device::get_pf2_tile_info_b)
 {
-	const u16 tile = m_pf2_data[tile_index];
-	u8 colour = (tile >> 12) & 0xf;
+	u32 tile = m_pf2_data[tile_index];
+	u32 colour = (tile >> 12) & 0xf;
 	u8 flags = 0;
 
 	if (tile & 0x8000)
@@ -379,16 +371,20 @@ TILE_GET_INFO_MEMBER(deco16ic_device::get_pf2_tile_info_b)
 		}
 	}
 
+	tile &= 0xfff;
+	if (!m_tile_cb.isnull())
+		m_tile_cb(tile, colour, 1, true);
+
 	tileinfo.set(m_pf12_8x8_gfx_bank,
-			(tile & 0xfff) | m_pf2_bank,
+			tile + m_pf2_bank,
 			(colour & m_pf2_colourmask) + m_pf2_colour_bank,
 			flags);
 }
 
 TILE_GET_INFO_MEMBER(deco16ic_device::get_pf1_tile_info_b)
 {
-	const u16 tile = m_pf1_data[tile_index];
-	u8 colour = (tile >> 12) & 0xf;
+	u32 tile = m_pf1_data[tile_index];
+	u32 colour = (tile >> 12) & 0xf;
 	u8 flags = 0;
 
 	if (tile & 0x8000)
@@ -405,8 +401,12 @@ TILE_GET_INFO_MEMBER(deco16ic_device::get_pf1_tile_info_b)
 		}
 	}
 
+	tile &= 0xfff;
+	if (!m_tile_cb.isnull())
+		m_tile_cb(tile, colour, 0, true);
+
 	tileinfo.set(m_pf12_8x8_gfx_bank,
-			(tile & 0xfff) | m_pf1_bank,
+			tile + m_pf1_bank,
 			(colour & m_pf1_colourmask) + m_pf1_colour_bank,
 			flags);
 }
@@ -438,10 +438,8 @@ void deco16ic_device::custom_tilemap_draw(
 	const u16 control1,
 	int combine_mask,
 	int combine_shift,
-	int trans_mask,
 	int flags,
 	u8 priority,
-	int is_tattoo,
 	u8 pmask
 	)
 {
@@ -450,11 +448,12 @@ void deco16ic_device::custom_tilemap_draw(
 	if (sizeof(*dest) == 2) rgb = 0;
 	else rgb = 1;
 
-	gfx_element *gfx = m_gfxdecode->gfx(BIT(control1, 7) ? m_pf12_8x8_gfx_bank : m_pf12_16x16_gfx_bank);
 	tilemap_t *tilemap0 = BIT(control1, 7) ? tilemap0_8x8 : tilemap0_16x16;
 	tilemap_t *tilemap1 = BIT(control1, 7) ? tilemap1_8x8 : tilemap1_16x16;
 	const bitmap_ind16 *src_bitmap0 = tilemap0 ? &tilemap0->pixmap() : nullptr;
 	const bitmap_ind16 *src_bitmap1 = tilemap1 ? &tilemap1->pixmap() : nullptr;
+	const bitmap_ind8 *src_flagsmap0 = tilemap0 ? &tilemap0->flagsmap() : nullptr;
+	const bitmap_ind8 *src_flagsmap1 = tilemap1 ? &tilemap1->flagsmap() : nullptr;
 	int column_offset, src_x = 0;
 	const int row_type = 1 << ((control0 >> 3) & 0xf);
 	const int col_type = 8 << (control0 & 7);
@@ -465,6 +464,10 @@ void deco16ic_device::custom_tilemap_draw(
 	// Playfield disable
 	if (!BIT(control0, 7))
 		return;
+
+	// initialize draw layer flags
+	if ((flags & (TILEMAP_DRAW_LAYER0 | TILEMAP_DRAW_LAYER1 | TILEMAP_DRAW_LAYER2)) == 0)
+		flags |= TILEMAP_DRAW_LAYER0;
 
 	const int starty = cliprect.top();
 	const int endy = cliprect.bottom() + 1;
@@ -492,23 +495,30 @@ void deco16ic_device::custom_tilemap_draw(
 				column_offset = 0;
 
 			u16 p = src_bitmap0->pix16((src_y + column_offset) & height_mask, src_x);
+			u8 f = src_flagsmap0->pix8((src_y + column_offset) & height_mask, src_x);
 
 			if (src_bitmap1)
 			{
-				if (!is_tattoo)
+				f |= src_flagsmap1->pix8((src_y + column_offset) & height_mask, src_x) & ~TILEMAP_DRAW_CATEGORY_MASK;
+				if (!m_mix_cb.isnull())
+				{
+					const u16 p2 = src_bitmap1->pix16((src_y + column_offset) & height_mask, src_x);
+					p = m_mix_cb(p, p2);
+				}
+				else
 				{
 					// does boogie wings actually use this, or is the tattoo assassin code correct in this mode?
 					p |= (src_bitmap1->pix16((src_y + column_offset) & height_mask, src_x) & combine_mask) << combine_shift;
 				}
-				else
-				{
-					const u16 p2 = src_bitmap1->pix16((src_y + column_offset) & height_mask, src_x);
-					p = gfx->colorbase() + (m_pf1_colour_bank * gfx->granularity()) + (((p & 0x30) << 4) | (p & 0x0f) | ((p2 & 0x0f) << 4));
-				}
 			}
 			src_x = (src_x + 1) & width_mask;
 
-			if ((flags & TILEMAP_DRAW_OPAQUE) || (p & trans_mask))
+			const bool is_drawn = ((flags & TILEMAP_DRAW_OPAQUE) ||
+					((f & TILEMAP_PIXEL_LAYER0) && (flags & TILEMAP_DRAW_LAYER0)) ||
+					((f & TILEMAP_PIXEL_LAYER1) && (flags & TILEMAP_DRAW_LAYER1)) ||
+					((f & TILEMAP_PIXEL_LAYER2) && (flags & TILEMAP_DRAW_LAYER2)));
+
+			if (is_drawn)
 			{
 				dest = &bitmap.pix(y);
 				if (!rgb) dest[x] = p;
@@ -540,12 +550,6 @@ void deco16ic_device::set_transmask(int tmap, int group, u32 fgmask, u32 bgmask)
 		m_pf2_tilemap_8x8->set_transmask(group, fgmask, bgmask);
 		break;
 	}
-}
-
-/* captain america seems to have a similar 8bpp feature to robocop2, investigate merging */
-void deco16ic_device::set_pf1_8bpp_mode(int mode)
-{
-	m_pf1_8bpp_mode = mode;
 }
 
 /* robocop 2 can switch between 2 tilemaps at 4bpp, or 1 at 8bpp */
@@ -954,7 +958,7 @@ void deco16ic_device::tilemap_1_draw_common(screen_device &screen, _BitmapClass 
 {
 	if (m_use_custom_pf1)
 	{
-		custom_tilemap_draw(screen, bitmap, cliprect, m_pf1_tilemap_8x8, m_pf1_tilemap_16x16, nullptr, nullptr, m_pf1_rowscroll_ptr, m_pf12_control[1], m_pf12_control[2], m_pf12_control[5] & 0xff, m_pf12_control[6] & 0xff, 0, 0, m_pf1_trans_mask, flags, priority, 0, pmask);
+		custom_tilemap_draw(screen, bitmap, cliprect, m_pf1_tilemap_8x8, m_pf1_tilemap_16x16, nullptr, nullptr, m_pf1_rowscroll_ptr, m_pf12_control[1], m_pf12_control[2], m_pf12_control[5] & 0xff, m_pf12_control[6] & 0xff, 0, 0, flags, priority, pmask);
 	}
 	else
 	{
@@ -977,7 +981,7 @@ void deco16ic_device::tilemap_2_draw_common(screen_device &screen, _BitmapClass 
 {
 	if (m_use_custom_pf2)
 	{
-		custom_tilemap_draw(screen, bitmap, cliprect, m_pf2_tilemap_8x8, m_pf2_tilemap_16x16, nullptr, nullptr, m_pf2_rowscroll_ptr, m_pf12_control[3], m_pf12_control[4], m_pf12_control[5] >> 8, m_pf12_control[6] >> 8, 0, 0, m_pf2_trans_mask, flags, priority, 0, pmask);
+		custom_tilemap_draw(screen, bitmap, cliprect, m_pf2_tilemap_8x8, m_pf2_tilemap_16x16, nullptr, nullptr, m_pf2_rowscroll_ptr, m_pf12_control[3], m_pf12_control[4], m_pf12_control[5] >> 8, m_pf12_control[6] >> 8, 0, 0, flags, priority, pmask);
 	}
 	else
 	{
@@ -998,12 +1002,12 @@ void deco16ic_device::tilemap_2_draw(screen_device &screen, bitmap_rgb32 &bitmap
 /*****************************************************************************************/
 
 // Combines the output of two 4BPP tilemaps into an 8BPP tilemap
-void deco16ic_device::tilemap_12_combine_draw(screen_device &screen, bitmap_ind16 &bitmap, const rectangle &cliprect, int flags, u8 priority, int is_tattoo, u8 pmask)
+void deco16ic_device::tilemap_12_combine_draw(screen_device &screen, bitmap_ind16 &bitmap, const rectangle &cliprect, int flags, u8 priority, u8 pmask)
 {
-	custom_tilemap_draw(screen, bitmap, cliprect, nullptr, m_pf1_tilemap_16x16, nullptr, m_pf2_tilemap_16x16, m_pf1_rowscroll_ptr, m_pf12_control[1], m_pf12_control[2], m_pf12_control[5] & 0xff, m_pf12_control[6] & 0xff, 0xf, 4, 0xff, flags, priority, is_tattoo, pmask);
+	custom_tilemap_draw(screen, bitmap, cliprect, nullptr, m_pf1_tilemap_16x16, nullptr, m_pf2_tilemap_16x16, m_pf1_rowscroll_ptr, m_pf12_control[1], m_pf12_control[2], m_pf12_control[5] & 0xff, m_pf12_control[6] & 0xff, 0xf, 4, flags, priority, pmask);
 }
 
-void deco16ic_device::tilemap_12_combine_draw(screen_device &screen, bitmap_rgb32 &bitmap, const rectangle &cliprect, int flags, u8 priority, int is_tattoo, u8 pmask)
+void deco16ic_device::tilemap_12_combine_draw(screen_device &screen, bitmap_rgb32 &bitmap, const rectangle &cliprect, int flags, u8 priority, u8 pmask)
 {
-	custom_tilemap_draw(screen, bitmap, cliprect, nullptr, m_pf1_tilemap_16x16, nullptr, m_pf2_tilemap_16x16, m_pf1_rowscroll_ptr, m_pf12_control[1], m_pf12_control[2], m_pf12_control[5] & 0xff, m_pf12_control[6] & 0xff, 0xf, 4, 0xff, flags, priority, is_tattoo, pmask);
+	custom_tilemap_draw(screen, bitmap, cliprect, nullptr, m_pf1_tilemap_16x16, nullptr, m_pf2_tilemap_16x16, m_pf1_rowscroll_ptr, m_pf12_control[1], m_pf12_control[2], m_pf12_control[5] & 0xff, m_pf12_control[6] & 0xff, 0xf, 4, flags, priority, pmask);
 }

--- a/src/mame/video/deco16ic.h
+++ b/src/mame/video/deco16ic.h
@@ -25,7 +25,9 @@
     TYPE DEFINITIONS
 ***************************************************************************/
 
+typedef device_delegate<void (u32 &tile, u32 &colour, int layer, bool is_8x8)> deco16_tile_cb_delegate;
 typedef device_delegate<int (int bank)> deco16_bank_cb_delegate;
+typedef device_delegate<u16 (u16 p, u16 p2)> deco16_mix_cb_delegate;
 
 class deco16ic_device : public device_t, public device_video_interface
 {
@@ -35,19 +37,18 @@ public:
 	// configuration
 	template <typename T> void set_gfxdecode_tag(T &&tag) { m_gfxdecode.set_tag(std::forward<T>(tag)); }
 //  void set_palette_tag(const char *tag);
+	template <typename... T> void set_tile_callback(T &&... args) { m_tile_cb.set(std::forward<T>(args)...); }
 	template <typename... T> void set_bank1_callback(T &&... args) { m_bank1_cb.set(std::forward<T>(args)...); }
 	template <typename... T> void set_bank2_callback(T &&... args) { m_bank2_cb.set(std::forward<T>(args)...); }
+	template <typename... T> void set_mix_callback(T &&... args) { m_mix_cb.set(std::forward<T>(args)...); }
 	void set_pf1_size(int size) { m_pf1_size = size; }
 	void set_pf2_size(int size) { m_pf2_size = size; }
-	void set_pf1_trans_mask(int mask) { m_pf1_trans_mask = mask; }
-	void set_pf2_trans_mask(int mask) { m_pf2_trans_mask = mask; }
 	void set_pf1_col_mask(int mask) { m_pf1_colourmask = mask; }
 	void set_pf2_col_mask(int mask) { m_pf2_colourmask = mask; }
 	void set_pf1_col_bank(int bank) { m_pf1_colour_bank = bank; }
 	void set_pf2_col_bank(int bank) { m_pf2_colour_bank = bank; }
 	void set_pf12_8x8_bank(int bank) { m_pf12_8x8_gfx_bank = bank; }
 	void set_pf12_16x16_bank(int bank) { m_pf12_16x16_gfx_bank = bank; }
-
 
 	void pf1_data_w(offs_t offset, u16 data, u16 mem_mask = ~0);
 	void pf2_data_w(offs_t offset, u16 data, u16 mem_mask = ~0);
@@ -81,15 +82,12 @@ public:
 	void tilemap_2_draw(screen_device &screen, bitmap_rgb32 &bitmap, const rectangle &cliprect, int flags, u8 priority, u8 pmask = 0xff);
 
 	/* used by boogwing, nitrobal */
-	void tilemap_12_combine_draw(screen_device &screen, bitmap_ind16 &bitmap, const rectangle &cliprect, int flags, u8 priority, int is_tattoo = false, u8 pmask = 0xff);
-	void tilemap_12_combine_draw(screen_device &screen, bitmap_rgb32 &bitmap, const rectangle &cliprect, int flags, u8 priority, int is_tattoo = false, u8 pmask = 0xff);
+	void tilemap_12_combine_draw(screen_device &screen, bitmap_ind16 &bitmap, const rectangle &cliprect, int flags, u8 priority, u8 pmask = 0xff);
+	void tilemap_12_combine_draw(screen_device &screen, bitmap_rgb32 &bitmap, const rectangle &cliprect, int flags, u8 priority, u8 pmask = 0xff);
 
 	/* used by robocop2 */
 	void set_tilemap_colour_mask(int tmap, int mask);
 	void pf12_set_gfxbank(int small, int big);
-
-	/* used by captaven */
-	void set_pf1_8bpp_mode(int mode);
 
 	/* used by cninja */
 	void set_transmask(int tmap, int group, u32 fgmask, u32 bgmask);
@@ -119,10 +117,8 @@ public:
 			const u16 control1,
 			int combine_mask,
 			int combine_shift,
-			int trans_mask,
 			int flags,
 			u8 priority,
-			int is_tattoo,
 			u8 pmask = 0xff);
 
 protected:
@@ -141,17 +137,19 @@ private:
 	tilemap_t *m_pf1_tilemap_16x16, *m_pf2_tilemap_16x16;
 	tilemap_t *m_pf1_tilemap_8x8, *m_pf2_tilemap_8x8;
 
+	deco16_tile_cb_delegate m_tile_cb;
+
 	deco16_bank_cb_delegate m_bank1_cb;
 	deco16_bank_cb_delegate m_bank2_cb;
+
+	deco16_mix_cb_delegate m_mix_cb;
 
 	int m_use_custom_pf1, m_use_custom_pf2;
 	int m_pf1_bank, m_pf2_bank;
 	int m_pf12_last_small, m_pf12_last_big;
-	int m_pf1_8bpp_mode;
 
 	int m_pf1_size;
 	int m_pf2_size;
-	int m_pf1_trans_mask, m_pf2_trans_mask;
 	int m_pf1_colour_bank, m_pf2_colour_bank;
 	int m_pf1_colourmask, m_pf2_colourmask;
 	int m_pf12_8x8_gfx_bank, m_pf12_16x16_gfx_bank;

--- a/src/mame/video/deco32.cpp
+++ b/src/mame/video/deco32.cpp
@@ -104,7 +104,6 @@ void deco32_state::allocate_rowscroll(int size1, int size2, int size3, int size4
 
 void captaven_state::video_start()
 {
-	m_deco_tilegen[1]->set_pf1_8bpp_mode(1);
 	deco32_state::allocate_spriteram(0);
 	deco32_state::allocate_rowscroll(0x4000/4, 0x2000/4, 0x4000/4, 0x2000/4);
 	deco32_state::video_start();
@@ -134,7 +133,6 @@ void nslasher_state::video_start()
 
 void dragngun_state::video_start()
 {
-	//m_deco_tilegen[0]->set_pf1_8bpp_mode(1); // despite being 8bpp this doesn't require the same shifting as captaven, why not?
 	m_screen->register_screen_bitmap(m_temp_render_bitmap);
 	deco32_state::allocate_rowscroll(0x4000/4, 0x2000/4, 0x4000/4, 0x2000/4);
 	deco32_state::allocate_buffered_palette();
@@ -423,7 +421,7 @@ u32 nslasher_state::screen_update_nslasher(screen_device &screen, bitmap_rgb32 &
 	/* Draw playfields & sprites */
 	if (m_pri & 2)
 	{
-		m_deco_tilegen[1]->tilemap_12_combine_draw(screen, bitmap, cliprect, 0, 1, 1);
+		m_deco_tilegen[1]->tilemap_12_combine_draw(screen, bitmap, cliprect, 0, 1);
 		m_deco_tilegen[0]->tilemap_2_draw(screen, bitmap, cliprect, 0, 4);
 	}
 	else
@@ -625,7 +623,7 @@ u32 nslasher_state::screen_update_tattass(screen_device &screen, bitmap_rgb32 &b
 	/* Draw playfields & sprites */
 	if (m_pri & 2)
 	{
-		m_deco_tilegen[1]->tilemap_12_combine_draw(screen, bitmap, cliprect, 0, 1, 1);
+		m_deco_tilegen[1]->tilemap_12_combine_draw(screen, bitmap, cliprect, 0, 1);
 		m_deco_tilegen[0]->tilemap_2_draw(screen, bitmap, cliprect, 0, 4);
 	}
 	else

--- a/src/mame/video/sshangha.cpp
+++ b/src/mame/video/sshangha.cpp
@@ -54,21 +54,20 @@ uint32_t sshangha_state::screen_update(screen_device &screen, bitmap_rgb32 &bitm
 	// TODO: fully verify draw order / priorities
 
 	/* the tilemap 4bpp + 4bpp = 8bpp mixing actually seems external to the tilemap, note video_control is not part of the tilemap chip */
-	if (combine_tilemaps) {
-		m_tilegen->tilemap_12_combine_draw(screen, bitmap, cliprect, 0, 0, 1);
-	}
-	else {
+	if (combine_tilemaps)
+		m_tilegen->tilemap_12_combine_draw(screen, bitmap, cliprect, 0, 0);
+	else
 		m_tilegen->tilemap_2_draw(screen, bitmap, cliprect, 0, 0);
-	}
+
 	//                                                          pri,   primask,palbase,palmask
-	m_sprgen1->inefficient_copy_sprite_bitmap(bitmap, cliprect, 0x000, 0x000,  0x000,  0x0ff); // low+high pri spr1 (definitely needs to be below low pri spr2 - game tiles & definitely needs to be below tilemap1 - lightning on win screen in traditional mode)
-	m_sprgen2->inefficient_copy_sprite_bitmap(bitmap, cliprect, 0x200, 0x200,  0x100,  0x0ff); // low pri spr2  (definitely needs to be below tilemap1 - 2nd level failure screen etc.)
+	m_sprgen1->inefficient_copy_sprite_bitmap(bitmap, cliprect, 0x000, 0x000,  0x200,  0x0ff); // low+high pri spr1 (definitely needs to be below low pri spr2 - game tiles & definitely needs to be below tilemap1 - lightning on win screen in traditional mode)
+	m_sprgen2->inefficient_copy_sprite_bitmap(bitmap, cliprect, 0x200, 0x200,  0x000,  0x0ff); // low pri spr2  (definitely needs to be below tilemap1 - 2nd level failure screen etc.)
 
 	if (!combine_tilemaps)
 		m_tilegen->tilemap_1_draw(screen, bitmap, cliprect, 0, 0);
 
 	//                                                          pri,   primask,palbase,palmask
-	m_sprgen2->inefficient_copy_sprite_bitmap(bitmap, cliprect, 0x000, 0x200,  0x100,  0x0ff); // high pri spr2 (definitely needs to be above tilemap1 - title logo)
+	m_sprgen2->inefficient_copy_sprite_bitmap(bitmap, cliprect, 0x000, 0x200,  0x000,  0x0ff); // high pri spr2 (definitely needs to be above tilemap1 - title logo)
 
 	return 0;
 }


### PR DESCRIPTION
deco16ic.cpp: Fix transparency/transmask handling in custom draw case
Use callback for tile info and 8bpp mixing, Fix sshangha regression, Reduce unnecessary values

cninja.cpp: Correct 8bpp tilemap drawing behavior in robocop2 (in 8bpp tilemap, Same data in both tilemap RAM for tilegen[1], only tile bank is different), Correct sound routes for PCBs without stereo sound output

darkseal.cpp, sshangha.cpp: Cleanup gfxdecode layout

sshangha.cpp: Correct palette entries, Both chip and PCB hasn't any stereo sound output, Correct sound output routes

mirage.cpp: Use pri_callback for sprite priority