### PR TITLE
Don't clear the input queue on reset.

### DIFF
--- a/src/emu/diexec.cpp
+++ b/src/emu/diexec.cpp
@@ -662,7 +662,6 @@ void device_execute_interface::device_input::start(device_execute_interface &exe
 void device_execute_interface::device_input::reset()
 {
 	m_curvector = m_stored_vector = m_execute->default_irq_vector(m_linenum);
-	m_qindex = 0;
 }
 
 


### PR DESCRIPTION
This fixes problems where devices are input line changes are missed
because a device was reset. One case is at startup, where one device's
output is wire to another's input. During start the first device adds,
eg, a RESET assertion to the second. When that device starts, it resets
itself and clears the pending RESET assertion.

I've testing this a bit on the few games I have, and I haven't seen any issues.