### PR TITLE
meritsdx.cpp: Marked Flash ROMs with user data as BAD_DUMP (nw)

### DIFF
--- a/src/mame/drivers/meritsdx.cpp
+++ b/src/mame/drivers/meritsdx.cpp
@@ -5,7 +5,7 @@
     Skeleton driver for Merit Scorpion DX darts machines
 
     Hardware overview:
-    Main CPU: AMD Elan SC300-33KC (Am386SXLV CPU core)
+    Main CPU: AMD Elan SC300-33KC (Am386SXLV CPU core + 6845 CGA)
     Others: Dallas 1232, M48T08-150PC1, F82C735A, PCMCIA slot (for a modem),
             LCD CGA screen and magnetic stripe card reader
     OSC: 24.000 MHz
@@ -13,7 +13,10 @@
     Notes:
     Uses a ROM-DOS as its operating system.
     The card reader emulates a PS2 keyboard. The keyboard BIOS is undumped
-    (it's a Phoenix BIOS on a protected Intel MCU)
+    (it's a Phoenix BIOS on a protected Intel 8242 MCU).
+    The Flash ROMs contain user data (from a championship on Spain). Once emulated,
+    they must be reflashed with a factory reset (can be done on the emulated
+    system) and updated on the driver.
 
 *******************************************************************************/
 
@@ -65,11 +68,12 @@ ROM_START(scrpndx)
 	ROM_REGION(0x80000, "romdos", 0)
 	ROM_LOAD( "4999-01-00_u20-r1_c1997_mii.u20", 0x00000, 0x80000, CRC(3c32355e) SHA1(56f846e655184b66db19cd01481e0016c463cf7d) )
 
+	// The Flash ROMs contain user data
 	ROM_REGION(0x400000, "flashroms", 0)
-	ROM_LOAD( "am29f800bb.u22", 0x000000, 0x100000, CRC(9b7510a5) SHA1(76ed78da976f8898a7a084fa5a37ea66aba886ff) )
-	ROM_LOAD( "am29f800bb.u23", 0x100000, 0x100000, CRC(8dc09838) SHA1(01e150daecac5f148a8cc6fb23715cf8b2cbd48a) )
-	ROM_LOAD( "am29f800bb.u24", 0x200000, 0x100000, CRC(c5d5a5ee) SHA1(66bfb9a1eccd43c3d5ede0c4f17c231593729926) )
-	ROM_LOAD( "am29f800bb.u25", 0x300000, 0x100000, CRC(1b26141d) SHA1(bf60c1f8ff9119aebc172fbacec3de89e2513c1c) )
+	ROM_LOAD( "am29f800bb.u22", 0x000000, 0x100000, BAD_DUMP CRC(9b7510a5) SHA1(76ed78da976f8898a7a084fa5a37ea66aba886ff) )
+	ROM_LOAD( "am29f800bb.u23", 0x100000, 0x100000, BAD_DUMP CRC(8dc09838) SHA1(01e150daecac5f148a8cc6fb23715cf8b2cbd48a) )
+	ROM_LOAD( "am29f800bb.u24", 0x200000, 0x100000, BAD_DUMP CRC(c5d5a5ee) SHA1(66bfb9a1eccd43c3d5ede0c4f17c231593729926) )
+	ROM_LOAD( "am29f800bb.u25", 0x300000, 0x100000, BAD_DUMP CRC(1b26141d) SHA1(bf60c1f8ff9119aebc172fbacec3de89e2513c1c) )
 
 	ROM_REGION(0x5ba, "plds", 0)
 	ROM_LOAD( "sc_3986_intr_palce22v10q-25.u81",  0x000, 0x2dd, CRC(2a33bc54) SHA1(ed40828154f6c75f2c0109f6df6bbaef0773f841) )
@@ -77,4 +81,4 @@ ROM_START(scrpndx)
 ROM_END
 
 
-GAME(1996, scrpndx,         0,  scrpndx, scrpndx, meritsdx_state, empty_init, ROT0, "Merit", "Scorpion DX", MACHINE_IS_SKELETON_MECHANICAL) // OCT 15 1996 -- ASM 15:30
+GAME(1996, scrpndx, 0, scrpndx, scrpndx, meritsdx_state, empty_init, ROT0, "Merit", "Scorpion DX", MACHINE_IS_SKELETON_MECHANICAL) // OCT 15 1996 -- ASM 15:30


### PR DESCRIPTION
(nw) The flash ROMs contains user data (from a championship). Once emulated, they must be reflashed with a factory reset (can be done on the emulated system) and then update the driver.