### PR TITLE
Euro XT: BIOS revision, several: XTA harddisk info

### DIFF
--- a/src/mame/drivers/at.cpp
+++ b/src/mame/drivers/at.cpp
@@ -1065,6 +1065,10 @@ ROM_START( ibm5162 ) //MB p/n 62x1168 - IBM 5162, 6 Mhz, zero wait state RAM
 	ROM_LOAD( "59x7594.82s147an.u90", 0x0020, 0x0200, NO_DUMP) /* S N82S147AN 8629 // VCT 59X7594 */
 ROM_END
 
+
+// According to http://nerdlypleasures.blogspot.com/2014/04/the-original-8-bit-ide-interface.html
+// the IBM PS/1 Model 2011 use a customised version of the XTA (8-bit IDE) harddisk interface
+
 ROM_START( ibmps1es )
 	ROM_REGION16_LE(0x40000, "bios", 0)
 	ROM_LOAD16_BYTE( "ibm_1057757_24-05-90.bin", 0x00000, 0x20000, CRC(c8f81ea4) SHA1(925ed0e98f9f2997cb86554ef384bcfaf2a4ecbe))

--- a/src/mame/drivers/compc.cpp
+++ b/src/mame/drivers/compc.cpp
@@ -25,7 +25,7 @@ RAM: 640K
 Bus: 3x ISA
 Video: On board: MDA/CGA/Hercules/Plantronics
 Mass storage: 1x Floppy 5.25" 360K and (PC10) another 360K or (PC20) 3.5" harddisk
-On board ports: Floppy, XT-IDE Harddisk, Mouse, serial, parallel, RTC, Speaker
+On board ports: Floppy, XTA(8-bit IDE) Harddisk, Mouse, serial, parallel, RTC, Speaker
 Options: 8087 FPU
 ***************************************************************************/
 

--- a/src/mame/drivers/europc.cpp
+++ b/src/mame/drivers/europc.cpp
@@ -5,26 +5,26 @@
 *
 * Schneider Rundfunkwerke AG Euro PC and Euro PC II driver
 *
-* Manuals and BIOS files: ftp://ftp.cpcszene.de/pub/Computer/Schneider_PC/EuroPC_XT/
+* Manuals and BIOS files: ftp://ftp.cpcszene.de/pub/Computer/Schneider_PC/EuroPC_XT/ (down), mirror at https://lanowski.de/mirrors/
 *
 * Euro PC: Computer and floppy drive integrated into the keyboard, 8088, 512K RAM, there was an upgrade card for the ISA slot that took it to 640K, single ISA slot
            FD360 external 360K 5.25" DS DD floppy, FD720 external 720K 3,5" DS DD floppy, HD-20 external harddisk, internal graphics card is CGA or Hercules, 64KB VRAM
 * Euro PC II: like Euro PC, socket for 8087, 768K RAM on board, driver on Schneider DOS disk allowed the portion over 640K to be used as extended memory or ramdisk.
-* Euro XT: conventional desktop, specs like Euro PC II, two ISA slots on a riser card, 102 key seperate keyboard, internal XT-IDE 20MB harddisk, connector for FD360 and FD720 was retained
+* Euro XT: conventional desktop, specs like Euro PC II, two ISA slots on a riser card, 102 key seperate keyboard, internal XTA (XT-IDE) 20MB harddisk, connector for FD360 and FD720 was retained
 *
-* Only BIOS versions >2.06 are supported so far because of changes in the memory management, according to https://www.forum64.de/index.php?thread/43066-schneider-euro-pc-i-ii-xt-welche-bios-version-habt-ihr/
-* Versions 2.04 and 2.05 only show a single dash on the top left of the screen.
+* https://www.forum64.de/index.php?thread/43066-schneider-euro-pc-i-ii-xt-welche-bios-version-habt-ihr/ claims Versions BIOS >=2.06 have a change in memory management.
+* Versions 2.04 and 2.05 only show a single dash on the top left of the screen, set slot 1 to from AGA to CGA or Hercules to get them to display.
 *
 * To get rid of the BIOS error messages when you first start the system, enter the BIOS with Ctrl-Alt-Esc, match the RAM size to your settings in MAME, set the CPU speed to 9.54MHz
-* and the graphics adapter to Color/Graphics 80, internal graphics off
+* and the graphics adapter to Color/Graphics 80 or Special Adapter, internal graphics off
 *
-* To-Do: * An external 20MB harddisk (Schneider HD20) can be added to the PC and PC II. This is a XT IDE drive. The BIOSs contain their own copy of the WD XT IDE BIOS that can be activated from the BIOS setup menu.
+* To-Do: * An external 20MB harddisk (Schneider HD20) can be added to the PC and PC II. This is a XTA (8-bit IDE) drive. The BIOSs contain their own copy of the WD XT IDE BIOS that can be activated from the BIOS setup menu.
 *          (load debug, then g=f000:a000 to enter formatter routine)
 *        * emulate internal graphics, but AGA is not quite the correct choice for the standard graphics adapter (it's a Commodore standard), as the Schneiders are only capable of switching between Hercules and CGA modes.
 *        * The PC 2 and XT have 768K of memory that can be configured from the BIOS setup as 640K, 640K+128K EMS and 512K+256K EMS. The EMS options are not visible in our emulation and loading the EMS driver fails.
 *          See http://forum.classic-computing.de/index.php?page=Thread&threadID=8380 for screenshots.
 *        * use correct AT style keyboard for XT
-*        * make BIOS versions v2.04 and v2.05 work
+*
 *
 *****************************************************************************************************/
 

--- a/src/mame/drivers/europc.cpp
+++ b/src/mame/drivers/europc.cpp
@@ -663,6 +663,10 @@ ROM_START( euroxt )
 	ROMX_LOAD("euroxt_bios_v1.01.bin", 0x8000, 0x8000, CRC(1e1fe931) SHA1(bb7cae224d66ae48045f323ecb9ad59bf49ed0a2), ROM_BIOS(0))
 	ROM_SYSTEM_BIOS( 1, "v1.02", "EuroXT v1.02" )
 	ROMX_LOAD("euro_xt_bios_id.nr.51463_v1.02.bin", 0x8000, 0x8000, CRC(c36de60e) SHA1(c668cc9c5f3325233f30eac654678e1b8b7a7847), ROM_BIOS(1))
+	ROM_SYSTEM_BIOS( 2, "v1.04", "EuroXT v1.04" )
+	ROMX_LOAD("euro_xt_bios_v1.04_cs8b00_5.12.89_21_25.bin", 0x8000, 0x8000, CRC(24033a62) SHA1(9d1d89cb8b99569b6c0aaa7c6aceb355dc20b2fd), ROM_BIOS(2))
+	
+	// BIOS ROM versions 1.02 and 1.04 were accompanied by identical char ROM versions 50146, which in turn match the one used in /bus/isa/aga.cpp
 ROM_END
 
 //    YEAR  NAME     PARENT   COMPAT  MACHINE  INPUT   CLASS            INIT         COMPANY              FULLNAME      FLAGS

--- a/src/mame/drivers/ps2.cpp
+++ b/src/mame/drivers/ps2.cpp
@@ -10,6 +10,9 @@
 #include "bus/pc_kbd/keyboards.h"
 #include "softlist_dev.h"
 
+// According to http://nerdlypleasures.blogspot.com/2014/04/the-original-8-bit-ide-interface.html
+// the IBM PS/2 Model 25-286 and Model 30-286 use a customised version of the XTA (8-bit IDE) harddisk interface
+
 class ps2_state : public driver_device
 {
 public:

--- a/src/mame/drivers/tandy1t.cpp
+++ b/src/mame/drivers/tandy1t.cpp
@@ -34,7 +34,12 @@ Tandy 1000 (80286) variations:
 1000RLX-HD          1024MB RAM          10.0/5.0 MHz    v02.00.00
 
 Tandy 1000 (80386) variations:
-1000RSX/1000RSX-HD  1M-9M RAM           25.0/8.0 MHz    v01.10.00 */
+1000RSX/1000RSX-HD  1M-9M RAM           25.0/8.0 MHz    v01.10.00 
+
+According to http://nerdlypleasures.blogspot.com/2014/04/the-original-8-bit-ide-interface.html 
+the 286 based Tandy 1000 TL/2, TL/3, RLX, RLX-B and the 8086 based Tandy 1000RL & RL-HD
+used XTA (8-bit IDE) harddisks.
+*/
 
 #include "emu.h"
 #include "machine/genpc.h"


### PR DESCRIPTION
Added comments to several drivers about the XTA (8-bit IDE) harddisks used in those machines. The term XT-IDE is now firmly established for the open source hardware project, this is possibly confusing.