### PR TITLE
powerins.cpp: Reduce duplicates related to nmk16.cpp, Move subclass into nmk16.h (Similar hardware design)

### DIFF
--- a/src/mame/drivers/powerins.cpp
+++ b/src/mame/drivers/powerins.cpp
@@ -72,7 +72,7 @@ void powerins_state::powerins_map(address_map &map)
 	map(0x100019, 0x100019).w(FUNC(powerins_state::tilebank_w));
 	map(0x10001f, 0x10001f).w(m_soundlatch, FUNC(generic_latch_8_device::write));
 	map(0x120000, 0x120fff).ram().w(m_palette, FUNC(palette_device::write16)).share("palette");
-	map(0x130000, 0x130007).ram().w(FUNC(nmk16_state::scroll_w<0>)).umask16(0x00ff);
+	map(0x130000, 0x130007).ram().w(FUNC(powerins_state::scroll_w<0>)).umask16(0x00ff);
 	map(0x140000, 0x143fff).ram().w(FUNC(powerins_state::bgvideoram_w<0>)).share("bgvideoram0");
 	map(0x170000, 0x170fff).mirror(0x1000).ram().w(FUNC(powerins_state::txvideoram_w)).share("txvideoram");
 	map(0x180000, 0x18ffff).ram().share("mainram");

--- a/src/mame/drivers/powerins.cpp
+++ b/src/mame/drivers/powerins.cpp
@@ -10,10 +10,10 @@
 Set 1
     CPU:    MC68000, Z80 (for sound)
     Sound:  2x OKI6295 + 1x YM2203
-Set 2
+Bootleg Set 1
     CPU:    MC68000
     Sound:  OKIM6295
-Set 3
+Bootleg Set 2
     CPU:    MC68000, Z80 (for sound)
     Sound:  2x OKI6295 (Sound code supports an additional YM2203, but it's not fitted)
 
@@ -26,7 +26,7 @@ Note:
 
 TODO:
 - sprites flip y (not used by the game)
-- graphic system and PCB design is similar as nmk16.cpp games;
+- graphic system and PCB design is similar as macross2 era hardwares in nmk16.cpp;
   it's mergeable?
 
 ***************************************************************************/
@@ -50,21 +50,14 @@ TODO:
 ***************************************************************************/
 
 
-WRITE8_MEMBER(powerins_state::powerinsa_okibank_w)
+void powerins_state::powerinsa_okibank_w(u8 data)
 {
-	m_okibank->set_entry(data & 7);
+	m_okibank[0]->set_entry(data & 7);
 }
 
-READ8_MEMBER(powerins_state::powerinsb_fake_ym2203_r)
+u8 powerins_state::powerinsb_fake_ym2203_r()
 {
 	return 0x01;
-}
-
-template<int Layer>
-WRITE16_MEMBER(powerins_state::vram_w)
-{
-	COMBINE_DATA(&m_vram[Layer][offset]);
-	m_tilemap[Layer]->mark_tile_dirty(offset);
 }
 
 void powerins_state::powerins_map(address_map &map)
@@ -75,14 +68,14 @@ void powerins_state::powerins_map(address_map &map)
 	map(0x100008, 0x100009).portr("DSW1");
 	map(0x10000a, 0x10000b).portr("DSW2");
 	map(0x100015, 0x100015).w(FUNC(powerins_state::flipscreen_w));
-	map(0x100016, 0x100017).nopw();          // ? always 1
+	map(0x100016, 0x100017).nopw();    /* IRQ enable or z80 sound reset like in Macross 2? */
 	map(0x100019, 0x100019).w(FUNC(powerins_state::tilebank_w));
-	map(0x10001f, 0x10001f).w("soundlatch", FUNC(generic_latch_8_device::write));
+	map(0x10001f, 0x10001f).w(m_soundlatch, FUNC(generic_latch_8_device::write));
 	map(0x120000, 0x120fff).ram().w(m_palette, FUNC(palette_device::write16)).share("palette");
-	map(0x130000, 0x130007).ram().share("vctrl_0");
-	map(0x140000, 0x143fff).ram().w(FUNC(powerins_state::vram_w<0>)).share("vram_0");
-	map(0x170000, 0x170fff).mirror(0x1000).ram().w(FUNC(powerins_state::vram_w<1>)).share("vram_1");
-	map(0x180000, 0x18ffff).ram().share("spriteram");
+	map(0x130000, 0x130007).ram().w(FUNC(nmk16_state::scroll_w<0>)).umask16(0x00ff);
+	map(0x140000, 0x143fff).ram().w(FUNC(powerins_state::bgvideoram_w<0>)).share("bgvideoram0");
+	map(0x170000, 0x170fff).mirror(0x1000).ram().w(FUNC(powerins_state::txvideoram_w)).share("txvideoram");
+	map(0x180000, 0x18ffff).ram().share("mainram");
 }
 
 /* powerinsa: same as the original one but without the sound cpu (and inferior sound HW) */
@@ -90,25 +83,16 @@ void powerins_state::powerinsa_map(address_map &map)
 {
 	powerins_map(map);
 	map(0x100031, 0x100031).w(FUNC(powerins_state::powerinsa_okibank_w));
-	map(0x10003f, 0x10003f).rw("oki1", FUNC(okim6295_device::read), FUNC(okim6295_device::write));
+	map(0x10003f, 0x10003f).rw(m_oki[0], FUNC(okim6295_device::read), FUNC(okim6295_device::write));
 }
 
 void powerins_state::powerins_sound_map(address_map &map)
 {
 	map(0x0000, 0xbfff).rom();
 	map(0xc000, 0xdfff).ram();
-	map(0xe000, 0xe000).r("soundlatch", FUNC(generic_latch_8_device::read));
+	map(0xe000, 0xe000).r(m_soundlatch, FUNC(generic_latch_8_device::read));
 //  map(0xe000, 0xe000).nopw(); // ? written only once ?
 //  map(0xe001, 0xe001).nopw(); // ?
-}
-
-void powerins_state::powerins_sound_io_map(address_map &map)
-{
-	map.global_mask(0xff);
-	map(0x00, 0x01).rw("ym2203", FUNC(ym2203_device::read), FUNC(ym2203_device::write));
-	map(0x80, 0x80).rw("oki1", FUNC(okim6295_device::read), FUNC(okim6295_device::write));
-	map(0x88, 0x88).rw("oki2", FUNC(okim6295_device::read), FUNC(okim6295_device::write));
-	map(0x90, 0x97).w("nmk112", FUNC(nmk112_device::okibank_w));
 }
 
 void powerins_state::powerinsb_sound_io_map(address_map &map)
@@ -116,15 +100,15 @@ void powerins_state::powerinsb_sound_io_map(address_map &map)
 	map.global_mask(0xff);
 	map(0x00, 0x00).r(FUNC(powerins_state::powerinsb_fake_ym2203_r)).nopw();
 	map(0x01, 0x01).noprw();
-	map(0x80, 0x80).rw("oki1", FUNC(okim6295_device::read), FUNC(okim6295_device::write));
-	map(0x88, 0x88).rw("oki2", FUNC(okim6295_device::read), FUNC(okim6295_device::write));
+	map(0x80, 0x80).rw(m_oki[0], FUNC(okim6295_device::read), FUNC(okim6295_device::write));
+	map(0x88, 0x88).rw(m_oki[1], FUNC(okim6295_device::read), FUNC(okim6295_device::write));
 	map(0x90, 0x97).w("nmk112", FUNC(nmk112_device::okibank_w));
 }
 
 void powerins_state::powerinsa_oki_map(address_map &map)
 {
-	map(0x00000, 0x2ffff).rom();
-	map(0x30000, 0x3ffff).bankr("okibank");
+	map(0x00000, 0x2ffff).rom().region("oki1", 0);
+	map(0x30000, 0x3ffff).bankr("okibank1");
 }
 
 
@@ -244,15 +228,15 @@ INPUT_PORTS_END
 ***************************************************************************/
 
 static GFXDECODE_START( gfx_powerins )
-	GFXDECODE_ENTRY( "gfx1", 0, gfx_8x8x4_col_2x2_group_packed_msb, 0x000, 0x20 ) // [0] Tiles
-	GFXDECODE_ENTRY( "gfx2", 0, gfx_8x8x4_packed_msb,               0x200, 0x10 ) // [1] Tiles
-	GFXDECODE_ENTRY( "gfx3", 0, gfx_8x8x4_col_2x2_group_packed_msb, 0x400, 0x40 ) // [2] Sprites
+	GFXDECODE_ENTRY( "fgtile",  0, gfx_8x8x4_packed_msb,               0x200, 0x10 ) // [1] Tiles
+	GFXDECODE_ENTRY( "bgtile",  0, gfx_8x8x4_col_2x2_group_packed_msb, 0x000, 0x20 ) // [0] Tiles
+	GFXDECODE_ENTRY( "sprites", 0, gfx_8x8x4_col_2x2_group_packed_msb, 0x400, 0x40 ) // [2] Sprites
 GFXDECODE_END
 
 static GFXDECODE_START( gfx_powerinsc )
-	GFXDECODE_ENTRY( "gfx1", 0,        gfx_8x8x4_col_2x2_group_packed_msb, 0x000, 0x20 ) // [0] Tiles
-	GFXDECODE_ENTRY( "gfx1", 0x280000, gfx_8x8x4_packed_msb,               0x200, 0x10 ) // [1] Tiles
-	GFXDECODE_ENTRY( "gfx3", 0,        gfx_8x8x4_col_2x2_group_packed_msb, 0x400, 0x40 ) // [2] Sprites
+	GFXDECODE_ENTRY( "bgtile",  0x280000, gfx_8x8x4_packed_msb,               0x200, 0x10 ) // [1] Tiles
+	GFXDECODE_ENTRY( "bgtile",  0,        gfx_8x8x4_col_2x2_group_packed_msb, 0x000, 0x20 ) // [0] Tiles
+	GFXDECODE_ENTRY( "sprites", 0,        gfx_8x8x4_col_2x2_group_packed_msb, 0x400, 0x40 ) // [2] Sprites
 GFXDECODE_END
 
 /***************************************************************************
@@ -263,17 +247,17 @@ GFXDECODE_END
 
 MACHINE_START_MEMBER(powerins_state, powerinsa)
 {
-	m_okibank->configure_entries(0, 5, memregion("oki1")->base() + 0x30000, 0x10000);
+	m_okibank[0]->configure_entries(0, 5, memregion("oki1")->base() + 0x30000, 0x10000);
 }
 
 void powerins_state::init_powerinsc()
 {
-	uint8_t *gfx1 = memregion("gfx1")->base();
+	u8 *bgtile = memregion("bgtile")->base();
 
 	for (int i = 0; i < 0x300000; i++)
 	{
-		uint8_t x = gfx1[i];
-		gfx1[i] = bitswap(x, 3, 2, 1, 0, 7, 6, 5, 4);
+		u8 x = bgtile[i];
+		bgtile[i] = bitswap(x, 3, 2, 1, 0, 7, 6, 5, 4);
 	}
 }
 
@@ -283,9 +267,9 @@ void powerins_state::powerins(machine_config &config)
 	M68000(config, m_maincpu, XTAL(12'000'000));   /* 12MHz */
 	m_maincpu->set_addrmap(AS_PROGRAM, &powerins_state::powerins_map);
 
-	Z80(config, m_soundcpu, XTAL(12'000'000) / 2); /* 6 MHz */
-	m_soundcpu->set_addrmap(AS_PROGRAM, &powerins_state::powerins_sound_map);
-	m_soundcpu->set_addrmap(AS_IO, &powerins_state::powerins_sound_io_map);
+	Z80(config, m_audiocpu, XTAL(12'000'000) / 2); /* 6 MHz */
+	m_audiocpu->set_addrmap(AS_PROGRAM, &powerins_state::powerins_sound_map);
+	m_audiocpu->set_addrmap(AS_IO, &powerins_state::macross2_sound_io_map);
 
 	/* video hardware */
 	SCREEN(config, m_screen, SCREEN_TYPE_RASTER);
@@ -308,17 +292,15 @@ void powerins_state::powerins(machine_config &config)
 	/* sound hardware */
 	SPEAKER(config, "mono").front_center();
 
-	GENERIC_LATCH_8(config, "soundlatch");
+	GENERIC_LATCH_8(config, m_soundlatch);
 
-	ym2203_device &ym2203(YM2203(config, "ym2203", XTAL(12'000'000) / 8));
-	ym2203.irq_handler().set_inputline(m_soundcpu, 0);
-	ym2203.add_route(ALL_OUTPUTS, "mono", 2.0);
+	ym2203_device &ymsnd(YM2203(config, "ymsnd", XTAL(12'000'000) / 8));
+	ymsnd.irq_handler().set_inputline(m_audiocpu, 0);
+	ymsnd.add_route(ALL_OUTPUTS, "mono", 2.0);
 
-	okim6295_device &oki1(OKIM6295(config, "oki1", XTAL(16'000'000) / 4, okim6295_device::PIN7_LOW));
-	oki1.add_route(ALL_OUTPUTS, "mono", 0.15);
+	OKIM6295(config, m_oki[0], XTAL(16'000'000) / 4, okim6295_device::PIN7_LOW).add_route(ALL_OUTPUTS, "mono", 0.15);
 
-	okim6295_device &oki2(OKIM6295(config, "oki2", XTAL(16'000'000) / 4, okim6295_device::PIN7_LOW));
-	oki2.add_route(ALL_OUTPUTS, "mono", 0.15);
+	OKIM6295(config, m_oki[1], XTAL(16'000'000) / 4, okim6295_device::PIN7_LOW).add_route(ALL_OUTPUTS, "mono", 0.15);
 
 	nmk112_device &nmk112(NMK112(config, "nmk112", 0));
 	nmk112.set_rom0_tag("oki1");
@@ -333,18 +315,18 @@ void powerins_state::powerinsa(machine_config &config)
 
 	m_maincpu->set_addrmap(AS_PROGRAM, &powerins_state::powerinsa_map);
 
-	m_screen->set_refresh_hz(60);
+	m_screen->set_raw(XTAL(14'318'181) / 2, 456, 0, 320, 262, 16, 240); // ~60hz, XTAL verified, correct params?
+	m_screen->screen_vblank().set(FUNC(powerins_state::screen_vblank_powerinsa));
 
-	config.device_remove("soundcpu");
+	config.device_remove("audiocpu");
 
 	MCFG_MACHINE_START_OVERRIDE(powerins_state, powerinsa)
 
-	okim6295_device &oki1(OKIM6295(config.replace(), "oki1", 990000, okim6295_device::PIN7_LOW)); // pin7 not verified
-	oki1.set_addrmap(0, &powerins_state::powerinsa_oki_map);
-	oki1.add_route(ALL_OUTPUTS, "mono", 1.0);
+	m_oki[0]->set_clock(990000); // pin7 not verified
+	m_oki[0]->set_addrmap(0, &powerins_state::powerinsa_oki_map);
 
 	config.device_remove("oki2");
-	config.device_remove("ym2203");
+	config.device_remove("ymsnd");
 	config.device_remove("nmk112");
 }
 
@@ -354,12 +336,13 @@ void powerins_state::powerinsb(machine_config &config)
 
 	/* basic machine hardware */
 
-	m_screen->set_refresh_hz(60);
+	m_screen->set_raw(XTAL(14'318'181) / 2, 456, 0, 320, 262, 16, 240); // ~60hz, XTAL verified, correct params?
+	m_screen->screen_vblank().set(FUNC(powerins_state::screen_vblank_powerinsa));
 
-	m_soundcpu->set_addrmap(AS_IO, &powerins_state::powerinsb_sound_io_map);
-	m_soundcpu->set_periodic_int(FUNC(powerins_state::irq0_line_hold), attotime::from_hz(120));  // YM2203 rate is at 150??
+	m_audiocpu->set_addrmap(AS_IO, &powerins_state::powerinsb_sound_io_map);
+	m_audiocpu->set_periodic_int(FUNC(powerins_state::irq0_line_hold), attotime::from_hz(120));  // YM2203 rate is at 150??
 
-	config.device_remove("ym2203");    // Sound code talks to one, but it's not fitted on the board
+	config.device_remove("ymsnd");    // Sound code talks to one, but it's not fitted on the board
 }
 
 void powerins_state::powerinsc(machine_config &config)
@@ -436,18 +419,18 @@ ROM_START( powerins )
 	ROM_LOAD16_WORD_SWAP( "93095-3a.u108", 0x00000, 0x80000, CRC(9825ea3d) SHA1(567fd8e3d866a58a68608ea20c5d3fc16cf9f444) )
 	ROM_LOAD16_WORD_SWAP( "93095-4.u109",  0x80000, 0x80000, CRC(d3d7a782) SHA1(7846de0ebb09bd9b2534cd451ff9aa5175e60647) )
 
-	ROM_REGION( 0x20000, "soundcpu", 0 )        /* Z80 Code */
+	ROM_REGION( 0x20000, "audiocpu", 0 )        /* Z80 Code */
 	ROM_LOAD( "93095-2.u90",  0x00000, 0x20000, CRC(4b123cc6) SHA1(ed61d3a2ab20c86b91fd7bafa717be3ce26159be) )
 
-	ROM_REGION( 0x280000, "gfx1", 0 )   /* Layer 0 */
+	ROM_REGION( 0x280000, "bgtile", 0 )   /* Layer 0 */
 	ROM_LOAD( "93095-5.u16",  0x000000, 0x100000, CRC(b1371808) SHA1(15fca313314ff2e0caff35841a2fdda97f6235a8) )
 	ROM_LOAD( "93095-6.u17",  0x100000, 0x100000, CRC(29c85d80) SHA1(abd54f9c8bade21ea918a426627199da04193165) )
 	ROM_LOAD( "93095-7.u18",  0x200000, 0x080000, CRC(2dd76149) SHA1(975e4d371fdfbbd9a568da4d4c91ffd3f0ae636e) )
 
-	ROM_REGION( 0x100000, "gfx2", 0 )   /* Layer 1 */
+	ROM_REGION( 0x100000, "fgtile", 0 )   /* Layer 1 */
 	ROM_LOAD( "93095-1.u15",  0x000000, 0x020000, CRC(6a579ee0) SHA1(438e87b930e068e0cf7352e614a14049ebde6b8a) )
 
-	ROM_REGION( 0x800000, "gfx3", 0 )   /* Sprites */
+	ROM_REGION( 0x800000, "sprites", 0 )   /* Sprites */
 	ROM_LOAD16_WORD_SWAP( "93095-12.u116", 0x000000, 0x100000, CRC(35f3c2a3) SHA1(70efebfe248401ba3d766dc0e4bcc2846cd0d9a0) )
 	ROM_LOAD16_WORD_SWAP( "93095-13.u117", 0x100000, 0x100000, CRC(1ebd45da) SHA1(99b0ac734890673064b2a4b4b57ff2694e338dea) )
 	ROM_LOAD16_WORD_SWAP( "93095-14.u118", 0x200000, 0x100000, CRC(760d871b) SHA1(4887122ad0518c90f08c11a7a6b694f3fd218498) )
@@ -476,18 +459,18 @@ ROM_START( powerinsj )
 	ROM_LOAD16_WORD_SWAP( "93095-3j.u108", 0x00000, 0x80000, CRC(3050a3fb) SHA1(e7e729bf62266e2e78ccd84cf937abb99de18ad5) )
 	ROM_LOAD16_WORD_SWAP( "93095-4.u109",  0x80000, 0x80000, CRC(d3d7a782) SHA1(7846de0ebb09bd9b2534cd451ff9aa5175e60647) )
 
-	ROM_REGION( 0x20000, "soundcpu", 0 )        /* Z80 Code */
+	ROM_REGION( 0x20000, "audiocpu", 0 )        /* Z80 Code */
 	ROM_LOAD( "93095-2.u90",  0x00000, 0x20000, CRC(4b123cc6) SHA1(ed61d3a2ab20c86b91fd7bafa717be3ce26159be) )
 
-	ROM_REGION( 0x280000, "gfx1", 0 )   /* Layer 0 */
+	ROM_REGION( 0x280000, "bgtile", 0 )   /* Layer 0 */
 	ROM_LOAD( "93095-5.u16",  0x000000, 0x100000, CRC(b1371808) SHA1(15fca313314ff2e0caff35841a2fdda97f6235a8) )
 	ROM_LOAD( "93095-6.u17",  0x100000, 0x100000, CRC(29c85d80) SHA1(abd54f9c8bade21ea918a426627199da04193165) )
 	ROM_LOAD( "93095-7.u18",  0x200000, 0x080000, CRC(2dd76149) SHA1(975e4d371fdfbbd9a568da4d4c91ffd3f0ae636e) )
 
-	ROM_REGION( 0x100000, "gfx2", 0 )   /* Layer 1 */
+	ROM_REGION( 0x100000, "fgtile", 0 )   /* Layer 1 */
 	ROM_LOAD( "93095-1.u15",  0x000000, 0x020000, CRC(6a579ee0) SHA1(438e87b930e068e0cf7352e614a14049ebde6b8a) )
 
-	ROM_REGION( 0x800000, "gfx3", 0 )   /* Sprites */
+	ROM_REGION( 0x800000, "sprites", 0 )   /* Sprites */
 	ROM_LOAD16_WORD_SWAP( "93095-12.u116", 0x000000, 0x100000, CRC(35f3c2a3) SHA1(70efebfe248401ba3d766dc0e4bcc2846cd0d9a0) )
 	ROM_LOAD16_WORD_SWAP( "93095-13.u117", 0x100000, 0x100000, CRC(1ebd45da) SHA1(99b0ac734890673064b2a4b4b57ff2694e338dea) )
 	ROM_LOAD16_WORD_SWAP( "93095-14.u118", 0x200000, 0x100000, CRC(760d871b) SHA1(4887122ad0518c90f08c11a7a6b694f3fd218498) )
@@ -516,20 +499,20 @@ ROM_START( powerinspu )
 	ROM_LOAD16_WORD_SWAP( "3.p000.v4.0a.u116.27c240", 0x000000, 0x80000, CRC(d1dd5a3f) SHA1(b2a52a2bbdf63eddc04bae2b4322d6d320f35e89) )
 	ROM_LOAD16_WORD_SWAP( "4.p000.v3.8.u117.27c4096", 0x080000, 0x80000, CRC(9c0f23cf) SHA1(9ac78939a743c340aa51ff1b05817866124acd34) )
 
-	ROM_REGION( 0x20000, "soundcpu", 0 )        /* Z80 Code */
+	ROM_REGION( 0x20000, "audiocpu", 0 )        /* Z80 Code */
 	ROM_LOAD( "2.sound 9.20.u74.27c1001",  0x000000, 0x20000, CRC(4b123cc6) SHA1(ed61d3a2ab20c86b91fd7bafa717be3ce26159be) )
 
-	ROM_REGION( 0x280000, "gfx1", 0 )   /* Layer 0 */
+	ROM_REGION( 0x280000, "bgtile", 0 )   /* Layer 0 */
 	ROM_LOAD( "ba0.s0.27c040", 0x000000, 0x80000, CRC(1975b4b8) SHA1(cb400967744fa602df1bd2d88950dfdbdc77073f) ) /* located on OS93089 SUB daughterboard */
 	ROM_LOAD( "ba1.s1.27c040", 0x080000, 0x80000, CRC(376e4919) SHA1(12baa17382c176838df1b5ef86f1fa6dbcb978dd) )
 	ROM_LOAD( "ba2.s2.27c040", 0x100000, 0x80000, CRC(0d5ff532) SHA1(4febdb9cdacd85903a4a28e8df945dee0ce85558) )
 	ROM_LOAD( "ba3.s3.27c040", 0x180000, 0x80000, CRC(99b25791) SHA1(82f4bb5780826773d2e5f7143afb3ba209f57652) )
 	ROM_LOAD( "ba4.s4.27c040", 0x200000, 0x80000, CRC(2dd76149) SHA1(975e4d371fdfbbd9a568da4d4c91ffd3f0ae636e) )
 
-	ROM_REGION( 0x100000, "gfx2", 0 )   /* Layer 1 */
+	ROM_REGION( 0x100000, "fgtile", 0 )   /* Layer 1 */
 	ROM_LOAD( "1.text 1080.u16.27c010", 0x000000, 0x20000, CRC(6a579ee0) SHA1(438e87b930e068e0cf7352e614a14049ebde6b8a) )
 
-	ROM_REGION( 0x800000, "gfx3", 0 )   /* Sprites */
+	ROM_REGION( 0x800000, "sprites", 0 )   /* Sprites */
 	ROM_LOAD16_BYTE( "fo0.mo0.27c040", 0x000001, 0x80000, CRC(8b9b89c9) SHA1(f1d39d1a62e40a14642d8f22fc38b764465a8daa) ) /* located on OS93089 SUB daughterboard */
 	ROM_LOAD16_BYTE( "fe0.me0.27c040", 0x000000, 0x80000, CRC(4d127bdf) SHA1(26a7c277e7660a7c7c0c11cacadf815d2487ba8a) )
 	ROM_LOAD16_BYTE( "fo1.mo1.27c040", 0x100001, 0x80000, CRC(298eb50e) SHA1(2b922c1473bb559a1e8bd6221619141658179bb9) )
@@ -570,20 +553,20 @@ ROM_START( powerinspj )
 	ROM_LOAD16_WORD_SWAP( "3.p000.pc_j_12-1_155e.u116", 0x000000, 0x80000, CRC(4ea18490) SHA1(6b933b7ee11c65adf15430c8b185feaddb1c0bb0) ) /* labeled:  PC J 12/1 155E */
 	ROM_LOAD16_WORD_SWAP( "4.p000.f_p4.u117",           0x080000, 0x80000, CRC(9c0f23cf) SHA1(9ac78939a743c340aa51ff1b05817866124acd34) ) /* labeled:  F P4 */
 
-	ROM_REGION( 0x20000, "soundcpu", 0 )        /* Z80 Code */
+	ROM_REGION( 0x20000, "audiocpu", 0 )        /* Z80 Code */
 	ROM_LOAD( "2.sound 9.20.u74.27c1001",  0x000000, 0x20000, CRC(4b123cc6) SHA1(ed61d3a2ab20c86b91fd7bafa717be3ce26159be) )
 
-	ROM_REGION( 0x280000, "gfx1", 0 )   /* Layer 0 */
+	ROM_REGION( 0x280000, "bgtile", 0 )   /* Layer 0 */
 	ROM_LOAD( "ba0.s0.27c040", 0x000000, 0x80000, CRC(1975b4b8) SHA1(cb400967744fa602df1bd2d88950dfdbdc77073f) ) /* located on OS93089 SUB daughterboard */
 	ROM_LOAD( "ba1.s1.27c040", 0x080000, 0x80000, CRC(376e4919) SHA1(12baa17382c176838df1b5ef86f1fa6dbcb978dd) )
 	ROM_LOAD( "ba2.s2.27c040", 0x100000, 0x80000, CRC(0d5ff532) SHA1(4febdb9cdacd85903a4a28e8df945dee0ce85558) )
 	ROM_LOAD( "ba3.s3.27c040", 0x180000, 0x80000, CRC(99b25791) SHA1(82f4bb5780826773d2e5f7143afb3ba209f57652) )
 	ROM_LOAD( "ba4.s4.27c040", 0x200000, 0x80000, CRC(2dd76149) SHA1(975e4d371fdfbbd9a568da4d4c91ffd3f0ae636e) )
 
-	ROM_REGION( 0x100000, "gfx2", 0 )   /* Layer 1 */
+	ROM_REGION( 0x100000, "fgtile", 0 )   /* Layer 1 */
 	ROM_LOAD( "1.text 1080.u16.27c010", 0x000000, 0x20000, CRC(6a579ee0) SHA1(438e87b930e068e0cf7352e614a14049ebde6b8a) )
 
-	ROM_REGION( 0x800000, "gfx3", 0 )   /* Sprites */
+	ROM_REGION( 0x800000, "sprites", 0 )   /* Sprites */
 	ROM_LOAD16_BYTE( "fo0.mo0.27c040", 0x000001, 0x80000, CRC(8b9b89c9) SHA1(f1d39d1a62e40a14642d8f22fc38b764465a8daa) ) /* located on OS93089 SUB daughterboard */
 	ROM_LOAD16_BYTE( "fe0.me0.27c040", 0x000000, 0x80000, CRC(4d127bdf) SHA1(26a7c277e7660a7c7c0c11cacadf815d2487ba8a) )
 	ROM_LOAD16_BYTE( "fo1.mo1.27c040", 0x100001, 0x80000, CRC(298eb50e) SHA1(2b922c1473bb559a1e8bd6221619141658179bb9) )
@@ -654,14 +637,14 @@ ROM_START( powerinsa )
 	ROM_LOAD16_WORD_SWAP( "rom1", 0x000000, 0x080000, CRC(b86c84d6) SHA1(2ec0933130925dfae859ea6abe62a8c92385aee8) )
 	ROM_LOAD16_WORD_SWAP( "rom2", 0x080000, 0x080000, CRC(d3d7a782) SHA1(7846de0ebb09bd9b2534cd451ff9aa5175e60647) )
 
-	ROM_REGION( 0x280000, "gfx1", 0 )   /* Layer 0 */
+	ROM_REGION( 0x280000, "bgtile", 0 )   /* Layer 0 */
 	ROM_LOAD( "rom6",  0x000000, 0x200000, CRC(b6c10f80) SHA1(feece0aeaa01a455d0c4885a3699f8bda14fe00f) )
 	ROM_LOAD( "rom4",  0x200000, 0x080000, CRC(2dd76149) SHA1(975e4d371fdfbbd9a568da4d4c91ffd3f0ae636e) )
 
-	ROM_REGION( 0x100000, "gfx2", 0 )   /* Layer 1 */
+	ROM_REGION( 0x100000, "fgtile", 0 )   /* Layer 1 */
 	ROM_LOAD( "rom3",  0x000000, 0x020000, CRC(6a579ee0) SHA1(438e87b930e068e0cf7352e614a14049ebde6b8a) )
 
-	ROM_REGION( 0x800000, "gfx3", 0 )   /* Sprites */
+	ROM_REGION( 0x800000, "sprites", 0 )   /* Sprites */
 	ROM_LOAD16_WORD_SWAP( "rom10", 0x000000, 0x200000, CRC(efad50e8) SHA1(89e8c307b927e987a32d22ab4ab7f3be037cca03) )
 	ROM_LOAD16_WORD_SWAP( "rom9",  0x200000, 0x200000, CRC(08229592) SHA1(759679e89832b475adfdc783630d9ee2c105b0f3) )
 	ROM_LOAD16_WORD_SWAP( "rom8",  0x400000, 0x200000, CRC(b02fdd6d) SHA1(1e2c52b4e9999f0b564fcf13ff41b097ad7d0c39) )
@@ -727,20 +710,20 @@ ROM_START( powerinsb )
 	ROM_LOAD16_BYTE( "2q.bin", 0x000000, 0x80000, CRC(11bf3f2a) SHA1(c840add78da9b19839c667f9bbd77e0a7c560ed7) )
 	ROM_LOAD16_BYTE( "2r.bin", 0x000001, 0x80000, CRC(d8d621be) SHA1(91d501ac661c1ff52c85eee96c455c008a7dad1c) )
 
-	ROM_REGION( 0x20000, "soundcpu", 0 )        /* Z80 Code */
+	ROM_REGION( 0x20000, "audiocpu", 0 )        /* Z80 Code */
 	ROM_LOAD( "1f.bin",  0x000000, 0x20000, CRC(4b123cc6) SHA1(ed61d3a2ab20c86b91fd7bafa717be3ce26159be) )
 
-	ROM_REGION( 0x280000, "gfx1", 0 )   /* Layer 0 */
+	ROM_REGION( 0x280000, "bgtile", 0 )   /* Layer 0 */
 	ROM_LOAD( "13k.bin", 0x000000, 0x80000, CRC(1975b4b8) SHA1(cb400967744fa602df1bd2d88950dfdbdc77073f) )
 	ROM_LOAD( "13l.bin", 0x080000, 0x80000, CRC(376e4919) SHA1(12baa17382c176838df1b5ef86f1fa6dbcb978dd) )
 	ROM_LOAD( "13o.bin", 0x100000, 0x80000, CRC(0d5ff532) SHA1(4febdb9cdacd85903a4a28e8df945dee0ce85558) )
 	ROM_LOAD( "13q.bin", 0x180000, 0x80000, CRC(99b25791) SHA1(82f4bb5780826773d2e5f7143afb3ba209f57652) )
 	ROM_LOAD( "13r.bin", 0x200000, 0x80000, CRC(2dd76149) SHA1(975e4d371fdfbbd9a568da4d4c91ffd3f0ae636e) )
 
-	ROM_REGION( 0x100000, "gfx2", 0 )   /* Layer 1 */
+	ROM_REGION( 0x100000, "fgtile", 0 )   /* Layer 1 */
 	ROM_LOAD( "6n.bin", 0x000000, 0x20000, CRC(6a579ee0) SHA1(438e87b930e068e0cf7352e614a14049ebde6b8a) )
 
-	ROM_REGION( 0x800000, "gfx3", 0 )   /* Sprites */
+	ROM_REGION( 0x800000, "sprites", 0 )   /* Sprites */
 	ROM_LOAD16_BYTE( "14g.bin", 0x000001, 0x80000, CRC(8b9b89c9) SHA1(f1d39d1a62e40a14642d8f22fc38b764465a8daa) )
 	ROM_LOAD16_BYTE( "11g.bin", 0x000000, 0x80000, CRC(4d127bdf) SHA1(26a7c277e7660a7c7c0c11cacadf815d2487ba8a) )
 	ROM_LOAD16_BYTE( "13g.bin", 0x100001, 0x80000, CRC(298eb50e) SHA1(2b922c1473bb559a1e8bd6221619141658179bb9) )
@@ -780,10 +763,10 @@ ROM_START( powerinsc )
 	ROM_LOAD16_BYTE( "10.040.u41", 0x000000, 0x80000, CRC(88e1244b) SHA1(595a560b807eab9576ed057a7e532c83860e9c40) )
 	ROM_LOAD16_BYTE( "11.040.u39", 0x000001, 0x80000, CRC(46cd506f) SHA1(4585824f65e2b7da9f815fee92bb5f6d250a286d) )
 
-	ROM_REGION( 0x20000, "soundcpu", 0 )        /* Z80 Code */
+	ROM_REGION( 0x20000, "audiocpu", 0 )        /* Z80 Code */
 	ROM_LOAD( "1.010.u2",  0x000000, 0x20000, CRC(4b123cc6) SHA1(ed61d3a2ab20c86b91fd7bafa717be3ce26159be) )
 
-	ROM_REGION( 0x300000, "gfx1", 0 )   /* Layer 0 */
+	ROM_REGION( 0x300000, "bgtile", 0 )   /* Layer 0 */
 	ROM_LOAD16_BYTE( "33.040.u99",  0x000000, 0x80000, CRC(9b56a394) SHA1(f9451d8d5a911f4daa0f57af496dae08d320b3b2) )
 	ROM_LOAD16_BYTE( "22.040.u97",  0x000001, 0x80000, CRC(1e693f05) SHA1(049eeabd9b4f55f2f314f4f6871b1a0e1ec39517) )
 	ROM_LOAD16_BYTE( "32.040.u100", 0x100000, 0x80000, CRC(7749bc80) SHA1(ceee996e694865dfbc48b5365731f4903ca674f1) )
@@ -792,7 +775,7 @@ ROM_START( powerinsc )
 	ROM_LOAD16_BYTE( "20.040.u101", 0x200001, 0x80000, CRC(e4b2823c) SHA1(1ef41ff625ad82dcc85994f87e1d82fc11e26dd8) )
 
 	// TODO: check sprites' ROM loading
-	ROM_REGION( 0x800000, "gfx3", 0 )   /* Sprites */
+	ROM_REGION( 0x800000, "sprites", 0 )   /* Sprites */
 	ROM_LOAD16_BYTE( "30.040.u82", 0x000000, 0x80000,  CRC(6668d29d) SHA1(41b7ab49b72a1ffc7618c3fc45a1c1bbe1d84d21) )
 	ROM_LOAD16_BYTE( "19.040.u91", 0x000001, 0x80000,  CRC(17659d0c) SHA1(394b5dbb4461d0c05599d1ecd9fe92de999970fa) )
 	ROM_LOAD16_BYTE( "29.040.u85", 0x100000, 0x80000,  CRC(c349e556) SHA1(a89d4292a6f3b3cfd5b85f8db6de207831e779e6) )

--- a/src/mame/includes/nmk16.h
+++ b/src/mame/includes/nmk16.h
@@ -84,7 +84,6 @@ public:
 	void init_bjtwin();
 
 protected:
-	DECLARE_VIDEO_START(gunnail);
 	TIMER_DEVICE_CALLBACK_MEMBER(nmk16_scanline);
 	u32 screen_update_macross(screen_device &screen, bitmap_ind16 &bitmap, const rectangle &cliprect);
 
@@ -118,6 +117,7 @@ protected:
 	optional_ioport_array<2> m_dsw_io;
 	optional_ioport_array<3> m_in_io;
 
+	emu_timer *m_dma_timer;
 	int m_tilerambank;
 	int m_sprdma_base;
 	int mask[4*2];
@@ -173,6 +173,7 @@ protected:
 	DECLARE_VIDEO_START(bioship);
 	DECLARE_VIDEO_START(strahl);
 	DECLARE_VIDEO_START(macross2);
+	DECLARE_VIDEO_START(gunnail);
 	DECLARE_VIDEO_START(bjtwin);
 	void get_colour_4bit(u32 &colour, u32 &pri_mask);
 	void get_colour_5bit(u32 &colour, u32 &pri_mask);
@@ -180,11 +181,12 @@ protected:
 	u32 screen_update_tharrier(screen_device &screen, bitmap_ind16 &bitmap, const rectangle &cliprect);
 	u32 screen_update_strahl(screen_device &screen, bitmap_ind16 &bitmap, const rectangle &cliprect);
 	u32 screen_update_bjtwin(screen_device &screen, bitmap_ind16 &bitmap, const rectangle &cliprect);
+	TIMER_CALLBACK_MEMBER(dma_callback);
 	TIMER_DEVICE_CALLBACK_MEMBER(tdragon_mcu_sim);
 	TIMER_DEVICE_CALLBACK_MEMBER(hachamf_mcu_sim);
 	TIMER_DEVICE_CALLBACK_MEMBER(manybloc_scanline);
 	void video_init();
-	void draw_sprites(screen_device &screen, bitmap_ind16 &bitmap, const rectangle &cliprect);
+	void draw_sprites(screen_device &screen, bitmap_ind16 &bitmap, const rectangle &cliprect, u16 *src);
 	void bg_update(screen_device &screen, bitmap_ind16 &bitmap, const rectangle &cliprect, int layer = 0);
 	void tx_update(screen_device &screen, bitmap_ind16 &bitmap, const rectangle &cliprect);
 	void mcu_run(u8 dsw_setting);

--- a/src/mame/includes/powerins.h
+++ b/src/mame/includes/powerins.h
@@ -3,26 +3,17 @@
 #ifndef MAME_INCLUDES_POWERINS_H
 #define MAME_INCLUDES_POWERINS_H
 
+#include "includes/nmk16.h"
 #include "video/nmk16spr.h"
 #include "emupal.h"
 #include "screen.h"
 #include "tilemap.h"
 
-class powerins_state : public driver_device
+class powerins_state : public nmk16_state
 {
 public:
 	powerins_state(const machine_config &mconfig, device_type type, const char *tag) :
-		driver_device(mconfig, type, tag),
-		m_maincpu(*this, "maincpu"),
-		m_soundcpu(*this, "soundcpu"),
-		m_gfxdecode(*this, "gfxdecode"),
-		m_screen(*this, "screen"),
-		m_palette(*this, "palette"),
-		m_spritegen(*this, "spritegen"),
-		m_vctrl_0(*this, "vctrl_0"),
-		m_vram(*this, "vram_%u", 0U),
-		m_spriteram(*this, "spriteram"),
-		m_okibank(*this, "okibank")
+		nmk16_state(mconfig, type, tag)
 	{ }
 
 	void powerins(machine_config &config);
@@ -33,45 +24,22 @@ public:
 	void init_powerinsc();
 
 private:
-	required_device<cpu_device> m_maincpu;
-	optional_device<cpu_device> m_soundcpu;
-	required_device<gfxdecode_device> m_gfxdecode;
-	required_device<screen_device> m_screen;
-	required_device<palette_device> m_palette;
-	required_device<nmk_16bit_sprite_device> m_spritegen;
-
-	required_shared_ptr<uint16_t> m_vctrl_0;
-	required_shared_ptr_array<uint16_t, 2> m_vram;
-	required_shared_ptr<uint16_t> m_spriteram;
-
-	optional_memory_bank m_okibank;
-
-	std::unique_ptr<uint16_t[]> m_spritebuffer[2];
-
-	tilemap_t *m_tilemap[2];
-	int m_tile_bank;
-
-	DECLARE_WRITE8_MEMBER(powerinsa_okibank_w);
-	DECLARE_WRITE8_MEMBER(flipscreen_w);
-	DECLARE_WRITE8_MEMBER(tilebank_w);
-	template<int Layer> DECLARE_WRITE16_MEMBER(vram_w);
-	DECLARE_READ8_MEMBER(powerinsb_fake_ym2203_r);
+	void powerinsa_okibank_w(u8 data);
+	u8 powerinsb_fake_ym2203_r();
 
 	DECLARE_MACHINE_START(powerinsa);
 
-	TILE_GET_INFO_MEMBER(get_tile_info_0);
-	TILE_GET_INFO_MEMBER(get_tile_info_1);
-	TILEMAP_MAPPER_MEMBER(get_memory_offset_0);
+	TILE_GET_INFO_MEMBER(powerins_get_bg_tile_info);
 
 	DECLARE_WRITE_LINE_MEMBER(screen_vblank);
+	DECLARE_WRITE_LINE_MEMBER(screen_vblank_powerinsa);
 
 	virtual void video_start() override;
 
 	void get_colour_6bit(u32 &colour, u32 &pri_mask);
 	void get_flip_extcode(u16 attr, int &flipx, int &flipy, int &code);
-	uint32_t screen_update(screen_device &screen, bitmap_ind16 &bitmap, const rectangle &cliprect);
+	u32 screen_update(screen_device &screen, bitmap_ind16 &bitmap, const rectangle &cliprect);
 	void powerins_map(address_map &map);
-	void powerins_sound_io_map(address_map &map);
 	void powerins_sound_map(address_map &map);
 	void powerinsa_map(address_map &map);
 	void powerinsa_oki_map(address_map &map);

--- a/src/mame/video/nmk16.cpp
+++ b/src/mame/video/nmk16.cpp
@@ -79,6 +79,7 @@ void nmk16_state::video_init()
 
 	m_tilerambank = 0;
 
+	m_dma_timer = machine().scheduler().timer_alloc(timer_expired_delegate(FUNC(nmk16_state::dma_callback),this));
 	save_pointer(NAME(m_spriteram_old), 0x1000/2);
 	save_pointer(NAME(m_spriteram_old2), 0x1000/2);
 	save_item(NAME(m_bgbank));
@@ -285,9 +286,9 @@ void nmk16_state::get_sprite_flip(u16 attr, int &flipx, int &flipy, int &code)
 	flipx = (attr & 0x100) >> 8;
 }
 
-void nmk16_state::draw_sprites(screen_device &screen, bitmap_ind16 &bitmap, const rectangle &cliprect)
+void nmk16_state::draw_sprites(screen_device &screen, bitmap_ind16 &bitmap, const rectangle &cliprect, u16 *src)
 {
-	m_spritegen->draw_sprites(screen, bitmap, cliprect, m_gfxdecode->gfx(2), m_spriteram_old2.get(), 0x1000 / 2);
+	m_spritegen->draw_sprites(screen, bitmap, cliprect, m_gfxdecode->gfx(2), src, 0x1000 / 2);
 }
 
 /***************************************************************************
@@ -349,7 +350,7 @@ u32 nmk16_state::screen_update_macross(screen_device &screen, bitmap_ind16 &bitm
 	screen.priority().fill(0, cliprect);
 	bg_update(screen, bitmap, cliprect, 0);
 	tx_update(screen, bitmap, cliprect);
-	draw_sprites(screen, bitmap, cliprect);
+	draw_sprites(screen, bitmap, cliprect, m_spriteram_old2.get());
 	return 0;
 }
 
@@ -363,7 +364,7 @@ u32 nmk16_state::screen_update_tharrier(screen_device &screen, bitmap_ind16 &bit
 
 	bg_update(screen, bitmap, cliprect, 0);
 	tx_update(screen, bitmap, cliprect);
-	draw_sprites(screen, bitmap, cliprect);
+	draw_sprites(screen, bitmap, cliprect, m_spriteram_old2.get());
 	return 0;
 }
 
@@ -373,7 +374,7 @@ u32 nmk16_state::screen_update_strahl(screen_device &screen, bitmap_ind16 &bitma
 	bg_update(screen, bitmap, cliprect, 0);
 	bg_update(screen, bitmap, cliprect, 1);
 	tx_update(screen, bitmap, cliprect);
-	draw_sprites(screen, bitmap, cliprect);
+	draw_sprites(screen, bitmap, cliprect, m_spriteram_old2.get());
 	return 0;
 }
 
@@ -381,7 +382,7 @@ u32 nmk16_state::screen_update_bjtwin(screen_device &screen, bitmap_ind16 &bitma
 {
 	screen.priority().fill(0, cliprect);
 	bg_update(screen, bitmap, cliprect, 0);
-	draw_sprites(screen, bitmap, cliprect);
+	draw_sprites(screen, bitmap, cliprect, m_spriteram_old.get()); // only a single buffer, verified
 	return 0;
 }
 
@@ -443,7 +444,7 @@ void afega_state::video_update(screen_device &screen, bitmap_ind16 &bitmap, cons
 
 	m_tx_tilemap->draw(screen, bitmap, cliprect, 0, 2);
 
-	draw_sprites(screen, bitmap, cliprect);
+	draw_sprites(screen, bitmap, cliprect, m_spriteram_old2.get());
 }
 
 void afega_state::redhawki_video_update(screen_device &screen, bitmap_ind16 &bitmap, const rectangle &cliprect)
@@ -454,7 +455,7 @@ void afega_state::redhawki_video_update(screen_device &screen, bitmap_ind16 &bit
 
 	m_bg_tilemap[0]->draw(screen, bitmap, cliprect, 0, 1);
 
-	draw_sprites(screen, bitmap, cliprect);
+	draw_sprites(screen, bitmap, cliprect, m_spriteram_old2.get());
 }
 
 u32 afega_state::screen_update_afega(screen_device &screen, bitmap_ind16 &bitmap, const rectangle &cliprect)   { video_update(screen, bitmap, cliprect, 1, -0x100, +0x000, 0x0001);  return 0; }
@@ -472,6 +473,6 @@ u32 afega_state::screen_update_firehawk(screen_device &screen, bitmap_ind16 &bit
 
 	m_tx_tilemap->draw(screen, bitmap, cliprect, 0, 2);
 
-	draw_sprites(screen, bitmap, cliprect);
+	draw_sprites(screen, bitmap, cliprect, m_spriteram_old2.get());
 	return 0;
 }

--- a/src/mame/video/powerins.cpp
+++ b/src/mame/video/powerins.cpp
@@ -46,29 +46,6 @@ Note:   if MAME_DEBUG is defined, pressing Z with:
 
 /***************************************************************************
 
-                        Hardware registers access
-
-***************************************************************************/
-
-
-WRITE8_MEMBER(powerins_state::flipscreen_w)
-{
-	flip_screen_set(data & 1);
-	m_spritegen->set_flip_screen(flip_screen());
-}
-
-WRITE8_MEMBER(powerins_state::tilebank_w)
-{
-	if (data != m_tile_bank)
-	{
-		m_tile_bank = data;     // Tiles Bank (VRAM 0)
-		m_tilemap[0]->mark_all_dirty();
-	}
-}
-
-
-/***************************************************************************
-
                         Callbacks for the TileMap code
 
 ***************************************************************************/
@@ -96,18 +73,13 @@ Offset:
 #define DIM_NY_0            (0x20)
 */
 
-TILE_GET_INFO_MEMBER(powerins_state::get_tile_info_0)
+TILE_GET_INFO_MEMBER(powerins_state::powerins_get_bg_tile_info)
 {
-	uint16_t code = m_vram[0][tile_index];
-	tileinfo.set(0,
-			(code & 0x07ff) | (m_tile_bank << 11),
+	uint16_t code = m_bgvideoram[0][tile_index];
+	tileinfo.set(1,
+			(code & 0x07ff) | (m_bgbank << 11),
 			((code & 0xf000) >> 12) | ((code & 0x0800) >> 7),
 			0);
-}
-
-TILEMAP_MAPPER_MEMBER(powerins_state::get_memory_offset_0)
-{
-	return  (row & 0xf) | ((col & 0xff) << 4) | ((row & 0x10) << 8);
 }
 
 
@@ -127,15 +99,6 @@ Offset:
 #define DIM_NY_1    (0x20)
 */
 
-TILE_GET_INFO_MEMBER(powerins_state::get_tile_info_1)
-{
-	uint16_t code = m_vram[1][tile_index];
-	tileinfo.set(1,
-			code & 0x0fff,
-			(code & 0xf000) >> 12,
-			0);
-}
-
 /***************************************************************************
 
 
@@ -146,20 +109,15 @@ TILE_GET_INFO_MEMBER(powerins_state::get_tile_info_1)
 
 void powerins_state::video_start()
 {
-	m_spritebuffer[0] = make_unique_clear<uint16_t[]>(0x1000/2);
-	m_spritebuffer[1] = make_unique_clear<uint16_t[]>(0x1000/2);
+	m_bg_tilemap[0] = &machine().tilemap().create(*m_gfxdecode, tilemap_get_info_delegate(*this, FUNC(powerins_state::powerins_get_bg_tile_info)), tilemap_mapper_delegate(*this, FUNC(powerins_state::tilemap_scan_pages)), 16, 16, 256, 32);
+	m_tx_tilemap = &machine().tilemap().create(*m_gfxdecode, tilemap_get_info_delegate(*this, FUNC(powerins_state::common_get_tx_tile_info)), TILEMAP_SCAN_COLS, 8, 8, 64, 32);
 
-	m_tilemap[0] = &machine().tilemap().create(*m_gfxdecode, tilemap_get_info_delegate(*this, FUNC(powerins_state::get_tile_info_0)), tilemap_mapper_delegate(*this, FUNC(powerins_state::get_memory_offset_0)), 16, 16, 256, 32);
-	m_tilemap[1] = &machine().tilemap().create(*m_gfxdecode, tilemap_get_info_delegate(*this, FUNC(powerins_state::get_tile_info_1)), TILEMAP_SCAN_COLS, 8, 8, 64, 32);
+	m_tx_tilemap->set_transparent_pen(15);
 
-	m_tilemap[1]->set_transparent_pen(15);
-
-	save_item(NAME(m_tile_bank));
-	save_pointer(NAME(m_spritebuffer[0]), 0x1000/2);
-	save_pointer(NAME(m_spritebuffer[1]), 0x1000/2);
+	video_init();
 	 // fixed offset
-	m_tilemap[0]->set_scrolldx(32,32);
-	m_tilemap[1]->set_scrolldx(32,32);
+	m_bg_tilemap[0]->set_scrolldx(32,32);
+	m_tx_tilemap->set_scrolldx(32,32);
 }
 
 
@@ -227,15 +185,9 @@ void powerins_state::get_flip_extcode(u16 attr, int &flipx, int &flipy, int &cod
 ***************************************************************************/
 
 
-uint32_t powerins_state::screen_update(screen_device &screen, bitmap_ind16 &bitmap, const rectangle &cliprect)
+u32 powerins_state::screen_update(screen_device &screen, bitmap_ind16 &bitmap, const rectangle &cliprect)
 {
 	int layers_ctrl = -1;
-
-	int scrollx = (m_vctrl_0[2/2]&0xff) | ((m_vctrl_0[0/2]&0xff)<<8);
-	int scrolly = (m_vctrl_0[6/2]&0xff) | ((m_vctrl_0[4/2]&0xff)<<8);
-
-	m_tilemap[0]->set_scrollx(0, scrollx);
-	m_tilemap[0]->set_scrolly(0, scrolly);
 
 #ifdef MAME_DEBUG
 if (machine().input().code_pressed(KEYCODE_Z))
@@ -251,10 +203,10 @@ if (machine().input().code_pressed(KEYCODE_Z))
 #endif
 
 	screen.priority().fill(0, cliprect);
-	if (layers_ctrl&1)      m_tilemap[0]->draw(screen, bitmap, cliprect, 0, 1);
+	if (layers_ctrl&1)      bg_update(screen, bitmap, cliprect, 0);
 	else                    bitmap.fill(0, cliprect);
-	if (layers_ctrl&2)      m_tilemap[1]->draw(screen, bitmap, cliprect, 0, 2);
-	if (layers_ctrl&8)      m_spritegen->draw_sprites(screen, bitmap, cliprect, m_gfxdecode->gfx(2), m_spritebuffer[1].get(), 0x1000/2);
+	if (layers_ctrl&2)      tx_update(screen, bitmap, cliprect);
+	if (layers_ctrl&8)      draw_sprites(screen, bitmap, cliprect, m_spriteram_old2.get());
 	return 0;
 }
 
@@ -262,8 +214,18 @@ WRITE_LINE_MEMBER(powerins_state::screen_vblank)
 {
 	if (state)
 	{
-		std::copy_n(&m_spritebuffer[0][0], 0x1000/2, &m_spritebuffer[1][0]);
-		std::copy_n(&m_spriteram[0x8000/2], 0x1000/2, &m_spritebuffer[0][0]);
 		m_maincpu->set_input_line(4, HOLD_LINE);
+		m_dma_timer->adjust(attotime::from_usec(256)); // 256 USEC after VBOUT, same as nmk16.cpp?
+	}
+}
+
+WRITE_LINE_MEMBER(powerins_state::screen_vblank_powerinsa)
+{
+	if (state)
+	{
+		m_maincpu->set_input_line(4, HOLD_LINE);
+		// bootlegs aren't has DMA?
+		memcpy(m_spriteram_old2.get(),m_spriteram_old.get(), 0x1000);
+		memcpy(m_spriteram_old.get(), m_mainram + m_sprdma_base / 2, 0x1000);
 	}
 }


### PR DESCRIPTION
Add notes, Simplify handlers, Use screen raw params for bootlegs
nmk16.cpp: Use timer for sprite DMA behavior, Reduce duplicates, Fix sabotenb sprite delay, Add notes