### PR TITLE
Fix smartquotes by disabling them

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -145,7 +145,11 @@ html_theme_path = ["../themes/"]
 
 # If true, SmartyPants will be used to convert quotes and dashes to
 # typographically correct entities.
+# This was depreciated in Sphinx 1.6.6
 #html_use_smartypants = True
+
+# We don't want smartquotes in general.
+smartquotes = False
 
 # Custom sidebar templates, maps document names to template names.
 #html_sidebars = {}


### PR DESCRIPTION
While smartquotes are somewhat configurable, it's better if we don't use them at all. Makes sure there are no hidden pit traps for the users.